### PR TITLE
flight(#2374/#2789): route query-semantics oracle through do_get + fix read-time TTL/liveness reconciliation

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/compaction_row.rs
+++ b/cqlite-core/src/storage/sstable/reader/compaction_row.rs
@@ -182,6 +182,14 @@ pub struct RowLiveness {
     /// meaningful when `has_marker` is `true`. Reinterpreted UNSIGNED upstream
     /// so a post-2038 expiry is not wrapped negative.
     pub expires_at_seconds: Option<i64>,
+    /// The marker's authoritative WRITE timestamp in microseconds (the row
+    /// header liveness `timestamp`), when present. Populated from the on-disk
+    /// row header only (no-heuristics, #28) — never inferred. Carries the
+    /// last-write-wins key for [`Self::merge`] so a cross-generation fold keeps
+    /// the NEWER liveness marker outright (a newer TTL'd marker can supersede an
+    /// older live-forever one, and vice-versa) instead of a most-permissive
+    /// union. `None` when `has_marker` is `false`.
+    pub marker_timestamp: Option<i64>,
 }
 
 impl RowLiveness {
@@ -192,27 +200,44 @@ impl RowLiveness {
         self.has_marker && self.expires_at_seconds.is_none_or(|s| s > now_secs)
     }
 
-    /// Fold two markers into the reconciled row liveness (issue #2374): the row
-    /// is live if EITHER generation's marker is live, so a live-forever marker
-    /// wins over any TTL'd marker, and among TTL'd markers the LATEST expiry
-    /// wins. `has_marker` is the disjunction.
+    /// Fold two liveness markers across generations by Cassandra
+    /// last-write-wins on the marker WRITE timestamp (issue #2374/#2789): the
+    /// marker with the higher [`marker_timestamp`](Self::marker_timestamp) wins
+    /// OUTRIGHT — its expiry / live-forever state is taken as-is, so a newer
+    /// TTL'd marker supersedes an older live-forever one (and vice-versa). Later
+    /// expiry is only a TIE-BREAK when the timestamps compare equal (or both are
+    /// absent). A generation with no marker contributes nothing, so the surviving
+    /// marker (if any) is carried through unchanged.
+    ///
+    /// This replaces the former most-permissive union, which unconditionally let
+    /// a live-forever marker win regardless of write order and diverged from
+    /// Cassandra for a reverse-timestamp reinsertion (older live-forever, newer
+    /// expired TTL): the union reported the row VISIBLE where Cassandra keeps the
+    /// newer expired liveness and HIDES it.
     pub fn merge(self, other: RowLiveness) -> RowLiveness {
-        let expires_at_seconds = match (
-            self.has_marker,
-            other.has_marker,
-            self.expires_at_seconds,
-            other.expires_at_seconds,
-        ) {
-            // A live-forever marker (present, no TTL) subsumes any TTL'd marker.
-            (true, _, None, _) | (_, true, _, None) => None,
-            (true, true, Some(a), Some(b)) => Some(a.max(b)),
-            (true, false, a, _) => a,
-            (false, true, _, b) => b,
-            (false, false, _, _) => None,
-        };
-        RowLiveness {
-            has_marker: self.has_marker || other.has_marker,
-            expires_at_seconds,
+        match (self.has_marker, other.has_marker) {
+            (false, false) => RowLiveness::default(),
+            (true, false) => self,
+            (false, true) => other,
+            (true, true) => {
+                // Both generations carry a marker: last-write-wins on the
+                // authoritative write timestamp; later expiry breaks a tie.
+                let self_wins = match (self.marker_timestamp, other.marker_timestamp) {
+                    (Some(a), Some(b)) if a != b => a > b,
+                    // Equal (or one/both absent) timestamps → tie-break on the
+                    // later expiry, treating live-forever (`None`) as the latest.
+                    _ => match (self.expires_at_seconds, other.expires_at_seconds) {
+                        (None, _) => true,
+                        (_, None) => false,
+                        (Some(a), Some(b)) => a >= b,
+                    },
+                };
+                if self_wins {
+                    self
+                } else {
+                    other
+                }
+            }
         }
     }
 }
@@ -382,4 +407,91 @@ pub struct ComplexElement {
     /// as a cell value). Distinct from `is_deleted`: an empty-value live element
     /// is not a tombstone.
     pub has_empty_value: bool,
+}
+
+#[cfg(test)]
+mod row_liveness_tests {
+    use super::RowLiveness;
+
+    fn marker(ts: i64, expires_at_seconds: Option<i64>) -> RowLiveness {
+        RowLiveness {
+            has_marker: true,
+            expires_at_seconds,
+            marker_timestamp: Some(ts),
+        }
+    }
+
+    /// Issue #2374/#2789: the cross-generation fold is Cassandra last-write-wins
+    /// on the marker WRITE timestamp, NOT a most-permissive union. A newer
+    /// EXPIRED-TTL marker supersedes an older live-forever marker for a key-only
+    /// row → the row is HIDDEN once `now` passes the newer marker's expiry.
+    ///
+    /// Pre-fix (union) this returned live-forever → `marker_live_at` true → the
+    /// read path wrongly reported the row VISIBLE.
+    #[test]
+    fn newer_expired_ttl_supersedes_older_live_forever() {
+        // gen A: INSERT live-forever @ts=200; gen B: INSERT ... USING TTL @ts=300
+        // whose marker has since EXPIRED (expiry at epoch second 1_000).
+        let gen_a = marker(200, None);
+        let gen_b = marker(300, Some(1_000));
+
+        let merged = gen_a.merge(gen_b);
+        // The NEWER (ts=300) expired marker wins outright.
+        assert_eq!(merged.marker_timestamp, Some(300));
+        assert_eq!(merged.expires_at_seconds, Some(1_000));
+        // Row is HIDDEN once now > expiry.
+        assert!(
+            !merged.marker_live_at(2_000),
+            "newer expired-TTL marker must hide the key-only row (timestamp-LWW)"
+        );
+        // Fold order must not matter.
+        let merged_rev = gen_b.merge(gen_a);
+        assert_eq!(merged_rev.marker_timestamp, Some(300));
+        assert!(!merged_rev.marker_live_at(2_000));
+    }
+
+    /// Reverse of the above: a newer live-forever marker supersedes an older
+    /// expired-TTL one → the key-only row is VISIBLE.
+    #[test]
+    fn newer_live_forever_supersedes_older_expired_ttl() {
+        // gen A: expired-TTL @ts=200 (expiry epoch second 500); gen B: live-forever @ts=300.
+        let gen_a = marker(200, Some(500));
+        let gen_b = marker(300, None);
+
+        let merged = gen_a.merge(gen_b);
+        assert_eq!(merged.marker_timestamp, Some(300));
+        assert_eq!(merged.expires_at_seconds, None);
+        assert!(
+            merged.marker_live_at(2_000),
+            "newer live-forever marker must keep the key-only row visible (timestamp-LWW)"
+        );
+        // Fold order must not matter.
+        assert!(gen_b.merge(gen_a).marker_live_at(2_000));
+    }
+
+    /// Equal timestamps → tie-break on the later expiry (live-forever latest).
+    #[test]
+    fn equal_timestamps_tie_break_on_later_expiry() {
+        let live_forever = marker(300, None);
+        let ttl = marker(300, Some(500));
+        assert_eq!(live_forever.merge(ttl).expires_at_seconds, None);
+        assert_eq!(ttl.merge(live_forever).expires_at_seconds, None);
+
+        let earlier = marker(300, Some(400));
+        let later = marker(300, Some(900));
+        assert_eq!(earlier.merge(later).expires_at_seconds, Some(900));
+        assert_eq!(later.merge(earlier).expires_at_seconds, Some(900));
+    }
+
+    /// A generation with no marker contributes nothing.
+    #[test]
+    fn absent_marker_carries_the_present_one_through() {
+        let present = marker(300, Some(500));
+        assert_eq!(present.merge(RowLiveness::default()), present);
+        assert_eq!(RowLiveness::default().merge(present), present);
+        assert_eq!(
+            RowLiveness::default().merge(RowLiveness::default()),
+            RowLiveness::default()
+        );
+    }
 }

--- a/cqlite-core/src/storage/sstable/reader/compaction_row.rs
+++ b/cqlite-core/src/storage/sstable/reader/compaction_row.rs
@@ -84,6 +84,7 @@ impl CompactionRow {
                     // A live `ScanRow::Row` never carries a coexisting row deletion
                     // (a row tombstone arrives as a `ScanRow::Marker`, handled below).
                     row_deletion: None,
+                    row_liveness: RowLiveness::default(),
                 }
             }
             // A row tombstone marker becomes a row tombstone.
@@ -114,6 +115,7 @@ impl CompactionRow {
                 }],
                 complex: Vec::new(),
                 row_deletion: None,
+                row_liveness: RowLiveness::default(),
             },
             // Any other marker (null row, cell tombstone, …) collapses to a single
             // `value` cell, exactly as the pre-#1334 fallback did.
@@ -127,6 +129,7 @@ impl CompactionRow {
                 }],
                 complex: Vec::new(),
                 row_deletion: None,
+                row_liveness: RowLiveness::default(),
             },
         };
         CompactionRow {
@@ -157,6 +160,61 @@ pub enum CompactionBound {
     Bottom,
     /// After all clustering keys (end of partition).
     Top,
+}
+
+/// Primary-key (row-marker) liveness surfaced on a live compaction row so a
+/// READ consumer can apply Cassandra's row-visibility rule (issue #2374/#2789).
+///
+/// A row is visible to a `SELECT` iff it has at least one live data cell OR a
+/// LIVE primary-key liveness marker (`HAS_TIMESTAMP`, whose TTL — if any — has
+/// not expired). Compaction (the WRITE path) does NOT consult this — it retains
+/// an expired marker within gc_grace for byte-parity — so this is carry-only for
+/// the read side (Flight `do_get` / cross-generation read merge), never a write
+/// decision. No-heuristics (#28): both fields come from the authoritative
+/// on-disk row header, never inferred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RowLiveness {
+    /// Whether the row carried a primary-key liveness marker (`HAS_TIMESTAMP` —
+    /// i.e. it was INSERTed, not created implicitly by a data-cell UPDATE).
+    pub has_marker: bool,
+    /// Marker expiry (epoch seconds) when the liveness marker carries a TTL
+    /// (`HAS_TTL`); `None` when the marker is live-forever (no TTL). Only
+    /// meaningful when `has_marker` is `true`. Reinterpreted UNSIGNED upstream
+    /// so a post-2038 expiry is not wrapped negative.
+    pub expires_at_seconds: Option<i64>,
+}
+
+impl RowLiveness {
+    /// `true` when the primary-key liveness marker is present AND still live at
+    /// `now_secs` (no TTL, or its expiry is strictly in the future). Matches
+    /// `Cell.isLive`: live iff `now < localExpirationTime`.
+    pub fn marker_live_at(&self, now_secs: i64) -> bool {
+        self.has_marker && self.expires_at_seconds.is_none_or(|s| s > now_secs)
+    }
+
+    /// Fold two markers into the reconciled row liveness (issue #2374): the row
+    /// is live if EITHER generation's marker is live, so a live-forever marker
+    /// wins over any TTL'd marker, and among TTL'd markers the LATEST expiry
+    /// wins. `has_marker` is the disjunction.
+    pub fn merge(self, other: RowLiveness) -> RowLiveness {
+        let expires_at_seconds = match (
+            self.has_marker,
+            other.has_marker,
+            self.expires_at_seconds,
+            other.expires_at_seconds,
+        ) {
+            // A live-forever marker (present, no TTL) subsumes any TTL'd marker.
+            (true, _, None, _) | (_, true, _, None) => None,
+            (true, true, Some(a), Some(b)) => Some(a.max(b)),
+            (true, false, a, _) => a,
+            (false, true, _, b) => b,
+            (false, false, _, _) => None,
+        };
+        RowLiveness {
+            has_marker: self.has_marker || other.has_marker,
+            expires_at_seconds,
+        }
+    }
 }
 
 /// Live-or-tombstone payload of a [`CompactionRow`].
@@ -232,6 +290,11 @@ pub enum CompactionRowData {
         /// deletion (no surviving cells) is a [`Self::Tombstone`], not a `Live`
         /// with this field set.
         row_deletion: Option<(i64, i32)>,
+        /// Primary-key (row-marker) liveness of this row (issue #2374/#2789),
+        /// carried so a READ consumer can hide a row whose only content is an
+        /// EXPIRED liveness marker plus already-tombstoned cells. Carry-only for
+        /// reads — the compaction WRITE path ignores it (byte-parity preserved).
+        row_liveness: RowLiveness,
     },
 }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/compaction.rs
@@ -133,10 +133,19 @@ impl V5CompressedLegacyParser {
             }
         }
 
+        // Issue #2374/#2789: carry the row-marker liveness so the READ path can
+        // hide a row whose only content is an expired liveness marker + already-
+        // tombstoned cells (carry-only; the write path ignores it).
+        let row_liveness = row_header_opt
+            .as_ref()
+            .map(|h| h.row_liveness())
+            .unwrap_or_default();
+
         CompactionRowData::Live {
             simple: simple_cells,
             complex: complex_cols,
             row_deletion,
+            row_liveness,
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -478,6 +478,20 @@ impl RowHeader {
         }
     }
 
+    /// Issue #2374/#2789: the primary-key (row-marker) liveness of this row for
+    /// the READ path. `has_marker` = the row carried `HAS_TIMESTAMP` (an INSERT
+    /// liveness marker, not a data-cell-only UPDATE); `expires_at_seconds` = the
+    /// marker's TTL expiry when `HAS_TTL` was set, else `None` (live-forever).
+    /// Carry-only for reads; the compaction write path never consults it.
+    pub(crate) fn row_liveness(
+        &self,
+    ) -> crate::storage::sstable::reader::compaction_row::RowLiveness {
+        crate::storage::sstable::reader::compaction_row::RowLiveness {
+            has_marker: self.timestamp.is_some(),
+            expires_at_seconds: self.liveness_expires_at_seconds,
+        }
+    }
+
     /// Issue #1741: the row's maximum write timestamp (µs) across its liveness and
     /// decoded data cells. Used for partition/range-tombstone shadowing.
     fn max_write_timestamp(&self) -> i64 {

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -489,6 +489,10 @@ impl RowHeader {
         crate::storage::sstable::reader::compaction_row::RowLiveness {
             has_marker: self.timestamp.is_some(),
             expires_at_seconds: self.liveness_expires_at_seconds,
+            // Issue #2374/#2789: the authoritative marker write timestamp (µs)
+            // from the row header — the last-write-wins key the cross-generation
+            // fold uses. Never inferred (no-heuristics, #28).
+            marker_timestamp: self.timestamp,
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/now_clock.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/now_clock.rs
@@ -67,7 +67,15 @@ const TTL_NOW_OVERRIDE_ENV: &str = "CQLITE_TTL_NOW_OVERRIDE_SECS";
 /// seam first; an invalid/absent override leaves the wall-clock behavior
 /// unchanged. In release builds this is a straight `SystemTime::now()` call —
 /// the override seam (including the env read itself) is compiled out entirely.
-pub(crate) fn now_epoch_secs() -> i64 {
+///
+/// Issue #2789: `pub` (but `#[doc(hidden)]`, an internal read-path seam) so the
+/// Flight producer (`cqlite-flight`) can thread the SAME authoritative
+/// reconciliation `now` into its k-way merger's TTL expiry as the core read
+/// path uses, rather than re-implementing the wall-clock/override logic and
+/// diverging on parity. Re-exported as
+/// [`crate::storage::write_engine::read_time_now_secs`].
+#[doc(hidden)]
+pub fn now_epoch_secs() -> i64 {
     #[cfg(debug_assertions)]
     let raw_override = std::env::var(TTL_NOW_OVERRIDE_ENV).ok();
     #[cfg(not(debug_assertions))]

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -3734,6 +3734,16 @@ impl KWayMerger {
                     row_ts,
                     RowData::Live { cells: kept },
                 );
+                // Issue #2374/#2789: carry the primary-key liveness marker forward
+                // when it survives the partition floor, so a key-only live row
+                // (INSERT with no/all-null regular columns) that coexists with an
+                // older covering partition tombstone stays VISIBLE through the read
+                // path. Dropped (default) when the marker did not survive the floor.
+                rebuilt = rebuilt.with_row_liveness(if marker_live {
+                    entry.row_liveness
+                } else {
+                    Default::default()
+                });
                 if !surviving_complex.is_empty() {
                     rebuilt = rebuilt.with_complex_deletions(surviving_complex);
                 }
@@ -4023,6 +4033,16 @@ impl KWayMerger {
                     row_ts,
                     RowData::Live { cells: kept },
                 );
+                // Issue #2374/#2789: carry the primary-key liveness marker forward
+                // when it survives the range floor, so a key-only live row (INSERT
+                // with no/all-null regular columns) that coexists with an older
+                // covering range tombstone stays VISIBLE through the read path.
+                // Dropped (default) when the marker did not survive the floor.
+                rebuilt = rebuilt.with_row_liveness(if marker_live {
+                    entry.row_liveness
+                } else {
+                    Default::default()
+                });
                 if !surviving_complex.is_empty() {
                     rebuilt = rebuilt.with_complex_deletions(surviving_complex);
                 }
@@ -13322,6 +13342,107 @@ mod issue_959_range_tombstone_fixes {
         assert!(
             KWayMerger::apply_range_shadowing(entry, &range, &schema).is_none(),
             "an older complex deletion is subsumed; nothing survives"
+        );
+    }
+
+    /// Issue #2374/#2789 (rust-reviewer BLOCKER 2): a key-only LIVE row (an
+    /// `INSERT` with only its primary-key liveness marker, e.g. no regular
+    /// columns / all-null regulars) that coexists with an OLDER covering RANGE
+    /// tombstone survives shadowing (its marker timestamp beats the floor). The
+    /// surviving `RowData::Live` rebuild in `apply_range_shadowing` must carry
+    /// the marker forward via `with_row_liveness` — before the fix it dropped to
+    /// `RowLiveness::default()` (has_marker=false), so the READ-path visibility
+    /// rule (`marker_live_at`) then wrongly HID the row. Cassandra returns it.
+    #[test]
+    fn key_only_live_row_keeps_marker_through_range_shadow() {
+        use crate::storage::sstable::reader::compaction_row::RowLiveness;
+        let schema = schema_int_ck(Default::default());
+        // Key-only live row at ck=2: only the clustering pseudo-cell (no data),
+        // liveness marker @200 (live-forever); covered by a range @100.
+        let entry = MergeEntry::new(
+            0,
+            dk(1),
+            Some(ck(2)),
+            200,
+            RowData::Live {
+                cells: vec![CellData::new("ck".to_string(), Value::Integer(2), 200)],
+            },
+        )
+        .with_row_liveness(RowLiveness {
+            has_marker: true,
+            expires_at_seconds: None,
+        });
+        let range = vec![(
+            dk(1),
+            rt(ClusteringBound::Bottom, ClusteringBound::Top, 100),
+        )];
+
+        let out = KWayMerger::apply_range_shadowing(entry, &range, &schema)
+            .expect("a key-only live row newer than the range must survive");
+        assert!(
+            out.row_liveness.marker_live_at(1_000),
+            "the surviving row must carry its liveness marker forward (BLOCKER 2, range)"
+        );
+    }
+
+    /// BLOCKER 2, partition variant: same key-only-live-row invariant through
+    /// `apply_partition_shadowing`.
+    #[test]
+    fn key_only_live_row_keeps_marker_through_partition_shadow() {
+        use crate::storage::sstable::reader::compaction_row::RowLiveness;
+        let schema = schema_int_ck(Default::default());
+        let _ = &schema; // schema unused by partition shadowing, kept for parity.
+        let entry = MergeEntry::new(
+            0,
+            dk(1),
+            Some(ck(2)),
+            200,
+            RowData::Live {
+                cells: vec![CellData::new("ck".to_string(), Value::Integer(2), 200)],
+            },
+        )
+        .with_row_liveness(RowLiveness {
+            has_marker: true,
+            expires_at_seconds: None,
+        });
+
+        let out = KWayMerger::apply_partition_shadowing(entry, Some((100, 0)))
+            .expect("a key-only live row newer than the partition floor must survive");
+        assert!(
+            out.row_liveness.marker_live_at(1_000),
+            "the surviving row must carry its liveness marker forward (BLOCKER 2, partition)"
+        );
+    }
+
+    /// BLOCKER 2 negative: a key-only row whose marker is OLDER-or-equal to the
+    /// covering floor does NOT survive as a phantom live row — the marker must
+    /// NOT be carried forward (marker_live stays false). Range case fully
+    /// shadows to `None`; the invariant is that no live-marker survivor leaks.
+    #[test]
+    fn key_only_expired_marker_does_not_survive_range_shadow() {
+        use crate::storage::sstable::reader::compaction_row::RowLiveness;
+        let schema = schema_int_ck(Default::default());
+        // Marker @80 (older than the range @100) → fully shadowed, no survivor.
+        let entry = MergeEntry::new(
+            0,
+            dk(1),
+            Some(ck(2)),
+            80,
+            RowData::Live {
+                cells: vec![CellData::new("ck".to_string(), Value::Integer(2), 80)],
+            },
+        )
+        .with_row_liveness(RowLiveness {
+            has_marker: true,
+            expires_at_seconds: None,
+        });
+        let range = vec![(
+            dk(1),
+            rt(ClusteringBound::Bottom, ClusteringBound::Top, 100),
+        )];
+        assert!(
+            KWayMerger::apply_range_shadowing(entry, &range, &schema).is_none(),
+            "a marker older than the covering range must not survive as a live row"
         );
     }
 }

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -865,7 +865,7 @@ impl SSTableRowIteratorAdapter {
         // the partition's `None` bucket and mis-reconcile against the static row
         // and against other clustering-row tombstones.
         let clustering_key = Self::extract_clustering_key_from_compaction(&row_data, schema);
-        let (row_data, complex_deletions, row_deletion) =
+        let (row_data, complex_deletions, row_deletion, row_liveness) =
             Self::compaction_row_data_to_row_data(row_data, row_timestamp);
         let entry = MergeEntry::new(
             run_index,
@@ -873,7 +873,9 @@ impl SSTableRowIteratorAdapter {
             clustering_key,
             row_timestamp,
             row_data,
-        );
+        )
+        // Issue #2374/#2789: carry the row-marker liveness for the read path.
+        .with_row_liveness(row_liveness);
         let entry = if complex_deletions.is_empty() {
             entry
         } else {
@@ -1013,11 +1015,17 @@ impl SSTableRowIteratorAdapter {
     ///
     /// [`ComplexElement`]: crate::storage::sstable::reader::compaction_row::ComplexElement
     /// [`CellOperation::WriteComplexElement`]: crate::storage::write_engine::mutation::CellOperation::WriteComplexElement
+    #[allow(clippy::type_complexity)]
     fn compaction_row_data_to_row_data(
         row_data: crate::storage::sstable::reader::compaction_row::CompactionRowData,
         _row_timestamp: i64,
-    ) -> (RowData, Vec<ComplexDeletion>, Option<(i64, i32)>) {
-        use crate::storage::sstable::reader::compaction_row::CompactionRowData;
+    ) -> (
+        RowData,
+        Vec<ComplexDeletion>,
+        Option<(i64, i32)>,
+        crate::storage::sstable::reader::compaction_row::RowLiveness,
+    ) {
+        use crate::storage::sstable::reader::compaction_row::{CompactionRowData, RowLiveness};
 
         match row_data {
             CompactionRowData::Tombstone {
@@ -1034,6 +1042,7 @@ impl SSTableRowIteratorAdapter {
                 },
                 Vec::new(),
                 None,
+                RowLiveness::default(),
             ),
             CompactionRowData::Live {
                 simple,
@@ -1041,6 +1050,8 @@ impl SSTableRowIteratorAdapter {
                 // Issue #932: a coexisting row deletion surfaces here so the
                 // merge entry carries it alongside the live cells.
                 row_deletion,
+                // Issue #2374/#2789: primary-key liveness carried for the read path.
+                row_liveness,
             } => {
                 let element_count: usize = complex.iter().map(|c| c.elements.len()).sum();
                 let mut cells = Vec::with_capacity(simple.len() + element_count);
@@ -1109,20 +1120,31 @@ impl SSTableRowIteratorAdapter {
                     }
                 }
 
-                (RowData::Live { cells }, complex_deletions, row_deletion)
+                (
+                    RowData::Live { cells },
+                    complex_deletions,
+                    row_deletion,
+                    row_liveness,
+                )
             }
             // Issue #933: range markers are intercepted in `build_merge_entry`
             // (carrier entry with `range_deletion`); they never reach this
             // conversion. Map defensively to an empty live row.
-            CompactionRowData::RangeMarker { .. } => {
-                (RowData::Live { cells: Vec::new() }, Vec::new(), None)
-            }
+            CompactionRowData::RangeMarker { .. } => (
+                RowData::Live { cells: Vec::new() },
+                Vec::new(),
+                None,
+                RowLiveness::default(),
+            ),
             // Issue #1072: partition tombstones are intercepted in
             // `build_merge_entry` (carrier entry with `partition_deletion`); they
             // never reach this conversion. Map defensively to an empty live row.
-            CompactionRowData::PartitionDelete { .. } => {
-                (RowData::Live { cells: Vec::new() }, Vec::new(), None)
-            }
+            CompactionRowData::PartitionDelete { .. } => (
+                RowData::Live { cells: Vec::new() },
+                Vec::new(),
+                None,
+                RowLiveness::default(),
+            ),
         }
     }
 
@@ -2586,6 +2608,19 @@ impl KWayMerger {
     /// retained — which can never resurrect data in a partial compaction.
     pub fn with_purge_safe(mut self, purge_safe: bool) -> Self {
         self.purge_safe = purge_safe;
+        self
+    }
+
+    /// Set the read-time TTL evaluation instant (`now`, epoch seconds) for this
+    /// merge (issue #2374/#2789), enabling `expire_ttl_cells` on a READ merge
+    /// built through a `now`-less constructor (e.g. the warm
+    /// [`new_from_readers`](Self::new_from_readers) path). `gc_before_secs`
+    /// stays `None` so NO tombstone is gc-purged — a read reflects deletions, it
+    /// does not collect them. A compaction WRITE path threads `now` through its
+    /// constructor instead and never calls this.
+    #[must_use]
+    pub fn with_now_secs(mut self, now_secs: Option<i64>) -> Self {
+        self.now_secs = now_secs;
         self
     }
 
@@ -8696,9 +8731,10 @@ mod issue_899_per_element_merge {
                 ]),
             }],
             row_deletion: None,
+            row_liveness: Default::default(),
         };
 
-        let (row, complex_deletions, _row_deletion) =
+        let (row, complex_deletions, _row_deletion, _row_liveness) =
             SSTableRowIteratorAdapter::compaction_row_data_to_row_data(row_data, 999);
         assert!(complex_deletions.is_empty(), "no complex deletion present");
 
@@ -8739,9 +8775,10 @@ mod issue_899_per_element_merge {
                 collapsed_value: Value::Set(vec![Value::text("x".to_string())]),
             }],
             row_deletion: None,
+            row_liveness: Default::default(),
         };
 
-        let (_row, complex_deletions, _row_deletion) =
+        let (_row, complex_deletions, _row_deletion, _row_liveness) =
             SSTableRowIteratorAdapter::compaction_row_data_to_row_data(row_data, 20_000);
         assert_eq!(complex_deletions.len(), 1);
         assert_eq!(complex_deletions[0].column, "tags");
@@ -10613,6 +10650,7 @@ mod issue_912_row_tombstone_clustering_identity {
             }],
             complex: Vec::new(),
             row_deletion: None,
+            row_liveness: Default::default(),
         };
         let live_ck =
             SSTableRowIteratorAdapter::extract_clustering_key_from_compaction(&live, &schema);

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -13371,6 +13371,7 @@ mod issue_959_range_tombstone_fixes {
         .with_row_liveness(RowLiveness {
             has_marker: true,
             expires_at_seconds: None,
+            marker_timestamp: Some(200),
         });
         let range = vec![(
             dk(1),
@@ -13404,6 +13405,7 @@ mod issue_959_range_tombstone_fixes {
         .with_row_liveness(RowLiveness {
             has_marker: true,
             expires_at_seconds: None,
+            marker_timestamp: Some(200),
         });
 
         let out = KWayMerger::apply_partition_shadowing(entry, Some((100, 0)))
@@ -13435,6 +13437,7 @@ mod issue_959_range_tombstone_fixes {
         .with_row_liveness(RowLiveness {
             has_marker: true,
             expires_at_seconds: None,
+            marker_timestamp: Some(200),
         });
         let range = vec![(
             dk(1),

--- a/cqlite-core/src/storage/write_engine/merge/model.rs
+++ b/cqlite-core/src/storage/write_engine/merge/model.rs
@@ -84,6 +84,15 @@ pub struct MergeEntry {
     /// live rows in another, resurrecting the deleted partition. `None` for every
     /// non-carrier entry.
     pub partition_deletion: Option<(i64, i32)>,
+    /// Primary-key (row-marker) liveness of this entry's `(pk, ck)` row (issue
+    /// #2374/#2789), carried so a READ consumer (Flight `do_get` / cross-gen read
+    /// merge) can apply Cassandra's row-visibility rule: a row with no surviving
+    /// live DATA cell is visible only when its liveness marker is present AND
+    /// unexpired. Reconciliation folds it across the cluster (the latest-expiry /
+    /// live-forever marker wins). CARRY-ONLY for the WRITE path — compaction
+    /// never consults it, so output bytes are unchanged (defaults to an absent
+    /// marker on every carrier / write-built entry).
+    pub row_liveness: crate::storage::sstable::reader::compaction_row::RowLiveness,
 }
 
 /// Manual `Clone` (was `#[derive(Clone)]`) so the #1664 double-clone regression
@@ -106,6 +115,7 @@ impl Clone for MergeEntry {
             range_deletion: self.range_deletion.clone(),
             row_deletion: self.row_deletion,
             partition_deletion: self.partition_deletion,
+            row_liveness: self.row_liveness,
         }
     }
 }
@@ -135,7 +145,19 @@ impl MergeEntry {
             range_deletion: None,
             row_deletion: None,
             partition_deletion: None,
+            row_liveness: crate::storage::sstable::reader::compaction_row::RowLiveness::default(),
         }
+    }
+
+    /// Attach the primary-key (row-marker) liveness for the READ path (issue
+    /// #2374/#2789; carry-only, ignored by the write path).
+    #[must_use]
+    pub fn with_row_liveness(
+        mut self,
+        row_liveness: crate::storage::sstable::reader::compaction_row::RowLiveness,
+    ) -> Self {
+        self.row_liveness = row_liveness;
+        self
     }
 
     /// Attach complex-deletion markers (issue #886 substrate; carry-only).

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -46,6 +46,13 @@ use super::{CellData, ComplexDeletion, KWayMerger, MergeEntry, PurgeCounts, RowD
 #[cfg(test)]
 mod ttl_complex_tests;
 
+// Issue #2374/#2789: direct coverage of the cross-generation row-marker liveness
+// FOLD (Step 1) through the REAL `ReconcileState` add/consume path — the
+// timestamp-LWW winner carried onto the emitted entry. Only the end-to-end Flight
+// parity lane exercised this fold, and it SKIPs when fixtures are absent.
+#[cfg(test)]
+mod row_liveness_fold_tests;
+
 /// Per-cell reconcile key: `(column, cell_path)` so each element of a multi-cell
 /// column reconciles independently (epic #899). Simple cells have
 /// `cell_path == None`.

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -92,6 +92,10 @@ pub(super) struct ReconcileState {
     /// Whether the row held non-key data BEFORE the gc-grace purge (phantom-row
     /// guard, captured pre-purge).
     had_data_before: bool,
+    /// Reconciled primary-key (row-marker) liveness across the cluster's entries
+    /// (issue #2374/#2789), carry-only for the read path (Flight `do_get` / cross-
+    /// gen read merge). Folded so the latest-expiry / live-forever marker wins.
+    row_liveness: crate::storage::sstable::reader::compaction_row::RowLiveness,
 }
 
 impl ReconcileState {
@@ -110,6 +114,7 @@ impl ReconcileState {
             after_row_del: Vec::new(),
             surviving: Vec::new(),
             had_data_before: false,
+            row_liveness: crate::storage::sstable::reader::compaction_row::RowLiveness::default(),
         }
     }
 
@@ -135,6 +140,11 @@ impl ReconcileState {
                 self.key = Some(entry.key.clone());
             }
             self.run_index = self.run_index.min(entry.run_index);
+
+            // Issue #2374/#2789: fold the row-marker liveness across generations
+            // (latest-expiry / live-forever wins) so the read path can decide
+            // row visibility. Carry-only — never a write-path decision.
+            self.row_liveness = self.row_liveness.merge(entry.row_liveness);
 
             for cd in &entry.complex_deletions {
                 if !self.complex_deletions.contains(cd) {
@@ -660,6 +670,7 @@ impl ReconcileState {
             range_deletion,
             surviving,
             had_data_before,
+            row_liveness,
             ..
         } = self;
 
@@ -768,6 +779,9 @@ impl ReconcileState {
         };
 
         built.map(|entry| {
+            // Issue #2374/#2789: carry the reconciled row-marker liveness onto the
+            // emitted entry for the read path's visibility decision (carry-only).
+            let entry = entry.with_row_liveness(row_liveness);
             let entry = if complex_deletions.is_empty() {
                 entry
             } else {

--- a/cqlite-core/src/storage/write_engine/merge/reconcile/row_liveness_fold_tests.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile/row_liveness_fold_tests.rs
@@ -1,0 +1,173 @@
+//! Issue #2374/#2789: the cross-generation row-marker liveness FOLD in
+//! [`ReconcileState`] (Step 1 —
+//! `self.row_liveness = self.row_liveness.merge(entry.row_liveness)`) must carry
+//! the timestamp-LWW winner onto the emitted [`MergeEntry`].
+//!
+//! ## Gap these tests close (roborev Low)
+//!
+//! `RowLiveness::merge` (the pure fold) and the single-entry `apply_*_shadowing`
+//! carry-forward each have direct tests, but the MULTI-entry fold through the
+//! REAL `ReconcileState` add/consume path — reconciling two `MergeEntry`s that
+//! carry DIFFERENT markers for the same key into ONE emitted entry — was only
+//! exercised end-to-end by the Flight parity lane, which SKIPs when fixtures are
+//! absent. A regression that dropped or mis-ordered the fold would then pass
+//! unnoticed in a clean checkout. These tests drive the production reconcile
+//! (`KWayMerger::reconcile_cluster_with_overlap`, the same kernel
+//! `merge_partition_rows` calls) so the fold is asserted directly.
+//!
+//! ## Oracle
+//!
+//! [`RowLiveness::merge`] is Cassandra last-write-wins on the marker WRITE
+//! timestamp: the marker with the higher `marker_timestamp` wins OUTRIGHT (its
+//! expiry / live-forever state taken as-is). So folding a live-forever marker
+//! @ts=200 with a TTL'd marker @ts=300 must yield the ts=300 marker regardless of
+//! fold order, and the emitted row's `marker_live_at` must reflect 300's expiry
+//! (HIDDEN once `now` passes it), never 200's live-forever visibility.
+
+#![cfg(feature = "write-support")]
+
+use super::super::{CellData, KWayMerger, MergeEntry, RowData};
+use crate::storage::sstable::reader::compaction_row::RowLiveness;
+use crate::storage::write_engine::mutation::DecoratedKey;
+use crate::types::Value;
+use std::collections::HashMap;
+
+/// A decorated key from a single token byte.
+fn dk(byte: u8) -> DecoratedKey {
+    DecoratedKey::from_key_bytes(vec![byte]).expect("token")
+}
+
+/// A live entry for the shared (unclustered) key carrying one data cell so the
+/// reconciled row survives as `RowData::Live` (and thus carries `row_liveness`
+/// through Step 4), plus a primary-key liveness marker.
+fn live_entry_with_marker(run_index: usize, cell_val: i32, marker: RowLiveness) -> MergeEntry {
+    MergeEntry::new(
+        run_index,
+        dk(1),
+        None,
+        marker.marker_timestamp.unwrap_or(0),
+        RowData::Live {
+            cells: vec![CellData::new(
+                "v".to_string(),
+                Value::Integer(cell_val),
+                marker.marker_timestamp.unwrap_or(0),
+            )],
+        },
+    )
+    .with_row_liveness(marker)
+}
+
+/// A live-forever marker at write timestamp `ts`.
+fn live_forever(ts: i64) -> RowLiveness {
+    RowLiveness {
+        has_marker: true,
+        expires_at_seconds: None,
+        marker_timestamp: Some(ts),
+    }
+}
+
+/// A TTL'd marker at write timestamp `ts` expiring at epoch second `expiry`.
+fn ttl_marker(ts: i64, expiry: i64) -> RowLiveness {
+    RowLiveness {
+        has_marker: true,
+        expires_at_seconds: Some(expiry),
+        marker_timestamp: Some(ts),
+    }
+}
+
+/// Reconcile the two entries through the production kernel and return the
+/// emitted entry's folded `row_liveness`.
+fn fold(entries: Vec<MergeEntry>) -> RowLiveness {
+    let out = KWayMerger::reconcile_cluster_with_overlap(
+        None,
+        entries,
+        &HashMap::new(),
+        None,     // no gc purge
+        i64::MAX, // full compaction (overlap gate open)
+    )
+    .expect("a live row with surviving data must be emitted");
+    out.row_liveness
+}
+
+/// Older live-forever @ts=200 folded with a NEWER expired-TTL @ts=300 → the
+/// ts=300 marker wins outright: emitted `marker_timestamp == 300`,
+/// `expires_at_seconds == 300's`, and the row is HIDDEN once `now` passes 300's
+/// expiry (a most-permissive union would have kept it live-forever/VISIBLE).
+/// Fold order must not matter, so both feed orders are asserted.
+///
+/// This would FAIL if the Step 1 fold were dropped: the accumulator's
+/// `row_liveness` would stay `RowLiveness::default()` (`has_marker == false`,
+/// `marker_timestamp == None`), so both assertions on the winning marker's
+/// timestamp and its expired visibility would break.
+#[test]
+fn reconcile_folds_two_markers_timestamp_lww_wins() {
+    let expiry = 1_000; // epoch second the ts=300 TTL marker expired at.
+    let older = live_forever(200);
+    let newer = ttl_marker(300, expiry);
+
+    for (a, b, order) in [
+        (older, newer, "older-then-newer"),
+        (newer, older, "newer-then-older"),
+    ] {
+        // run_index 0 = newest file; give the two entries distinct data values.
+        let folded = fold(vec![
+            live_entry_with_marker(0, 7, a),
+            live_entry_with_marker(1, 9, b),
+        ]);
+
+        // The NEWER (ts=300) marker wins outright, taking its expiry as-is.
+        assert_eq!(
+            folded.marker_timestamp,
+            Some(300),
+            "timestamp-LWW: the ts=300 marker must win the fold ({order})"
+        );
+        assert_eq!(
+            folded.expires_at_seconds,
+            Some(expiry),
+            "the winning ts=300 marker carries its own TTL expiry ({order})"
+        );
+        // Live/expired state is the winner's: HIDDEN after 300's expiry, and
+        // the older live-forever marker did NOT leak its permanence.
+        assert!(
+            !folded.marker_live_at(expiry + 1),
+            "row must be HIDDEN once now passes the winning marker's expiry ({order})"
+        );
+        assert!(
+            folded.marker_live_at(expiry - 1),
+            "row is still visible strictly before the winning marker's expiry ({order})"
+        );
+    }
+}
+
+/// Reverse polarity: older expired-TTL @ts=200 folded with a NEWER live-forever
+/// @ts=300 → the ts=300 live-forever marker wins, so the row stays VISIBLE even
+/// long after the older marker's expiry. Both feed orders asserted.
+#[test]
+fn reconcile_folds_newer_live_forever_wins() {
+    let older = ttl_marker(200, 500);
+    let newer = live_forever(300);
+
+    for (a, b, order) in [
+        (older, newer, "older-then-newer"),
+        (newer, older, "newer-then-older"),
+    ] {
+        let folded = fold(vec![
+            live_entry_with_marker(0, 1, a),
+            live_entry_with_marker(1, 2, b),
+        ]);
+
+        assert_eq!(
+            folded.marker_timestamp,
+            Some(300),
+            "timestamp-LWW: the ts=300 live-forever marker must win the fold ({order})"
+        );
+        assert_eq!(
+            folded.expires_at_seconds, None,
+            "the winning ts=300 marker is live-forever ({order})"
+        );
+        assert!(
+            folded.marker_live_at(1_000_000),
+            "a newer live-forever marker keeps the row visible indefinitely ({order})"
+        );
+    }
+}

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -53,6 +53,15 @@ pub use merge::KWayMerger;
 pub use merge::{build_single_partition_merger, build_single_partition_merger_with_registry};
 #[cfg(feature = "write-support")]
 pub use merge_policy::STCSPolicy;
+
+/// Read-time TTL "now" clock (epoch seconds), the authoritative reconciliation
+/// instant the core read path uses (issue #1741/#1853). Re-exported (issue
+/// #2789) so an out-of-crate merge consumer — the Flight producer — threads the
+/// SAME `now` into its k-way merger's TTL expiry as a `SELECT`, honoring the
+/// debug-only `CQLITE_TTL_NOW_OVERRIDE_SECS` pin in tests and wall-clock in
+/// production, rather than re-deriving it (no divergence, no new env read).
+#[doc(hidden)]
+pub use crate::storage::sstable::reader::parsing::row_decoder::now_clock::now_epoch_secs as read_time_now_secs;
 #[cfg(feature = "write-support")]
 pub use mutation::{
     CellOperation, ClusteringBound, ClusteringKey, DecoratedKey, Mutation, PartitionKey,

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -1102,6 +1102,22 @@ impl MergeProducer {
             RowData::Tombstone { .. } => return Ok(None),
         };
 
+        // Issue #2374/#2789 (roborev blocker): the row-visibility decision must be
+        // computed from the FULL, PRE-projection cell set — NOT the
+        // projection-restricted `row_cells` below. A row written by
+        // `UPDATE t SET v='x' WHERE id=1 AND ck=1` carries a live `v` data cell but
+        // NO primary-key liveness marker; under a PK-only projection (`SELECT id, ck`)
+        // or a `count(*)`/aggregation (needed = empty set), `assemble_read_cells`
+        // would drop `v` and the visibility check would wrongly hide the row.
+        // Cassandra returns it. Scan the full cells for any live (non-tombstone,
+        // non-deleted-element) cell whose column is not a primary-key column —
+        // mirroring the drop logic `assemble_read_cells` applies.
+        let has_live_data_cell = cells.iter().any(|c| {
+            !c.is_deleted
+                && !matches!(c.value, cqlite_core::Value::Tombstone(_))
+                && !self.is_primary_key_column(&c.column)
+        });
+
         // Issue #2324: the k-way merger emits every element of a non-frozen
         // collection (list/set/map) as its OWN cell, all sharing the column name.
         // Keying those by name (as `build_row_from_scan` does) would keep only the
@@ -1132,11 +1148,9 @@ impl MergeProducer {
         // fixture's `ttl_expired_live` ck=1) — and a re-emitted range/partition
         // marker carrier (empty `RowData::Live`) — would surface as a phantom
         // key-only null row, diverging from a core `SELECT`. The merger surfaces
-        // clustering columns as pseudo-cells, so a row_cells entry is "live data"
-        // only when its column is NOT a partition/clustering key.
-        let has_live_data_cell = row_cells
-            .iter()
-            .any(|(name, _)| !self.is_primary_key_column(name));
+        // clustering columns as pseudo-cells, so a cell is "live data" only when its
+        // column is NOT a partition/clustering key (`has_live_data_cell` is derived
+        // from the full pre-projection `cells` above, not the restricted `row_cells`).
         if !has_live_data_cell && !row_liveness.marker_live_at(now_secs) {
             return Ok(None);
         }
@@ -3190,6 +3204,111 @@ mod tests {
         // Count is non-nullable; sum/min/max are nullable.
         assert!(!s.field_with_name("agg0").unwrap().is_nullable());
         assert!(s.field_with_name("agg1").unwrap().is_nullable());
+    }
+
+    /// Issue #2374/#2789 (roborev BLOCKER 1): a row written ONLY by an UPDATE
+    /// (a live regular-column DATA cell, NO primary-key liveness marker) must
+    /// stay VISIBLE even when the projection drops that data column. Before the
+    /// fix the visibility check read the PROJECTION-RESTRICTED cells, so a
+    /// PK-only projection (`SELECT id`) or a `count(*)` (needed = empty set)
+    /// dropped the only live data cell → `has_live_data_cell = false` → and with
+    /// no marker the row was wrongly hidden. Cassandra returns it.
+    ///
+    /// The fix derives visibility from the FULL pre-projection cell set. This
+    /// test drives `entry_to_row` directly (WriteEngine always confers a row
+    /// marker on a regular-column write, so a genuinely marker-less row can only
+    /// be constructed here) with a marker-less entry carrying a live `name` cell.
+    #[test]
+    fn update_inserted_marker_less_row_survives_pk_only_and_count_projection() {
+        use cqlite_core::storage::sstable::reader::compaction_row::RowLiveness;
+        use cqlite_core::storage::write_engine::merge::{CellData, MergeEntry, RowData};
+        use cqlite_core::storage::write_engine::PartitionKey;
+        use cqlite_core::Value;
+        use std::collections::HashSet;
+
+        let schema = simple_schema();
+        let producer = MergeProducer::new(schema.clone(), 1024).unwrap();
+
+        // Build the entry an `UPDATE items SET name='x' WHERE id=1` reconciles to:
+        // a live `name` data cell, NO primary-key liveness marker (default = absent).
+        let pk = PartitionKey::single("id", Value::Integer(1));
+        let decorated = pk.to_decorated_key(&schema).unwrap();
+        let pk_bytes = decorated.key.clone();
+        let make_entry = || {
+            MergeEntry::new(
+                0,
+                decorated.clone(),
+                None,
+                100,
+                RowData::Live {
+                    cells: vec![CellData::new("name".into(), Value::text("x"), 100)],
+                },
+            )
+            .with_row_liveness(RowLiveness::default())
+        };
+
+        // Sanity: the entry carries NO liveness marker (so visibility can only come
+        // from the live data cell) — the exact shape the pre-fix code dropped.
+        assert!(
+            !make_entry().row_liveness.marker_live_at(200),
+            "the UPDATE-shaped entry must be marker-less"
+        );
+
+        // PK-only projection (`SELECT id`): `name` is dropped from row_cells, but
+        // the row MUST still be returned.
+        let mut cache = PartitionKeyCache::default();
+        let pk_only: HashSet<String> = ["id".to_string()].into_iter().collect();
+        let row = producer
+            .entry_to_row(&pk_bytes, make_entry(), &mut cache, Some(&pk_only), 200)
+            .unwrap();
+        assert!(
+            row.is_some(),
+            "UPDATE-inserted marker-less row hidden under PK-only projection (BLOCKER 1)"
+        );
+
+        // count(*) / aggregation: needed is the EMPTY set — every data cell would be
+        // dropped by projection, yet the row must still count.
+        let mut cache = PartitionKeyCache::default();
+        let empty: HashSet<String> = HashSet::new();
+        let row = producer
+            .entry_to_row(&pk_bytes, make_entry(), &mut cache, Some(&empty), 200)
+            .unwrap();
+        assert!(
+            row.is_some(),
+            "UPDATE-inserted marker-less row hidden under count(*) (empty needed) (BLOCKER 1)"
+        );
+
+        // Contrast: a row with NEITHER a live data cell NOR a live marker (all
+        // cells tombstoned) is still correctly HIDDEN — the visibility rule holds.
+        let mut cache = PartitionKeyCache::default();
+        let tomb_value = Value::Tombstone(Box::new(cqlite_core::types::TombstoneInfo {
+            deletion_time: 100,
+            tombstone_type: cqlite_core::types::TombstoneType::CellTombstone,
+            local_deletion_time: 0,
+            ttl: None,
+            range_start: None,
+            range_end: None,
+        }));
+        let tomb = MergeEntry::new(
+            0,
+            decorated.clone(),
+            None,
+            100,
+            RowData::Live {
+                cells: vec![CellData {
+                    value: tomb_value,
+                    ..CellData::new("name".into(), Value::text("x"), 100)
+                }],
+            },
+        )
+        .with_row_liveness(RowLiveness::default());
+        let row = producer
+            .entry_to_row(&pk_bytes, tomb, &mut cache, None, 200)
+            .unwrap();
+        assert!(
+            row.is_none(),
+            "a fully-tombstoned marker-less row must stay hidden"
+        );
     }
 
     /// Sum on a non-numeric source column is a bad spec → ProducerError.

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -30,7 +30,7 @@ use cqlite_core::query::{
     build_row_from_scan_cached, AccessPath, ColumnInfo, PartitionKeyCache, QueryRow,
 };
 use cqlite_core::schema::{CqlType, TableSchema, UdtRegistry};
-use cqlite_core::storage::write_engine::merge::{MergeStep, RowData};
+use cqlite_core::storage::write_engine::merge::{MergeEntry, MergeStep, RowData};
 use cqlite_core::storage::write_engine::KWayMerger;
 use cqlite_core::types::{DataType, RowCells, ScanRow};
 use cqlite_core::RowKey;
@@ -346,6 +346,14 @@ pub struct MergeProducer {
     /// so the service can hand the SAME resolved registry to the warm registry's
     /// reader-open path (issue #2349).
     pub(crate) udt_registry: Option<UdtRegistry>,
+    /// Read-time reconciliation clock (epoch seconds), captured ONCE at
+    /// construction from the authoritative `read_time_now_secs` seam (issue
+    /// #2374/#2789). Threaded into every merger this producer opens (so
+    /// `expire_ttl_cells` runs) AND consulted by `entry_to_row`'s row-marker
+    /// liveness check, so the merger's cell-TTL expiry and the producer's
+    /// marker-liveness decision use ONE instant — parity with a core `SELECT`.
+    /// Honors the debug-only `CQLITE_TTL_NOW_OVERRIDE_SECS` pin in tests.
+    pub(crate) now_secs: i64,
 }
 
 /// Abstraction over the k-way merge stepper.
@@ -416,6 +424,8 @@ impl MergeProducer {
             agg: None,
             partial_columns: None,
             udt_registry: None,
+            // Issue #2374/#2789: capture the read-time reconciliation clock once.
+            now_secs: Self::reconciliation_now_secs(),
         })
     }
 
@@ -470,12 +480,33 @@ impl MergeProducer {
         KWayMerger::new_with_gc_and_registry_cancellable(
             paths,
             &self.schema,
+            // `gc_before_secs = None`: the Flight read path NEVER purges
+            // tombstones (a read-time reconciliation reflects deletions, it does
+            // not gc-grace-collect them) — this stays None.
             None,
-            None,
+            // Issue #2789: `now_secs` is the reconciliation clock the caller
+            // captured ONCE (via `read_time_now_secs`, = `now_clock`'s
+            // `now_epoch_secs`) and shares with the producer's row-marker
+            // liveness check, so Flight `do_get` applies read-time TTL expiry
+            // with parity to a core `SELECT`: it honors the debug-only
+            // `CQLITE_TTL_NOW_OVERRIDE_SECS` pin in tests and wall-clock in
+            // production. Passing `None` here (the prior behavior) made
+            // `reconcile.rs::expire_ttl_cells` a strict no-op, so an expired TTL
+            // cell was never hidden on the Flight path. Row-deletion / range-
+            // tombstone shadowing is now-independent and unaffected.
+            Some(self.now_secs),
             self.udt_registry.clone(),
             cancel.scan_cancel(),
         )
         .map_err(ProducerError::Merge)
+    }
+
+    /// Capture the read-time reconciliation clock (epoch seconds) ONCE for a
+    /// merge (issue #2374/#2789), from the SAME authoritative seam the core read
+    /// path uses. Shared between the merger's cell-TTL expiry and the producer's
+    /// row-marker liveness check so both decide every row at one instant.
+    fn reconciliation_now_secs() -> i64 {
+        cqlite_core::storage::write_engine::read_time_now_secs()
     }
 
     /// Attach an aggregation spec (issue #841), validating it against the table
@@ -896,9 +927,10 @@ impl MergeProducer {
                 // conversion. Columns the scan never reads are skipped in assembly.
                 let Some(row) = self.entry_to_row(
                     &key.key,
-                    entry.row_data,
+                    entry,
                     &mut pk_cache,
                     assemble_cols.as_ref(),
+                    self.now_secs,
                 )?
                 else {
                     continue;
@@ -1007,9 +1039,10 @@ impl MergeProducer {
             for entry in rows {
                 let Some(row) = self.entry_to_row(
                     &key.key,
-                    entry.row_data,
+                    entry,
                     &mut pk_cache,
                     assemble_cols.as_ref(),
+                    self.now_secs,
                 )?
                 else {
                     continue;
@@ -1043,14 +1076,27 @@ impl MergeProducer {
     /// corruption (e.g. a map key whose `cell_path` bytes do not decode under the
     /// declared key type). Such a failure is propagated as a `Merge` error rather
     /// than silently dropping the row (issue #2324, no-heuristics / no-silent-loss).
+    /// True when `column` is a partition- or clustering-key column of the scan's
+    /// schema (the merger surfaces these as pseudo-cells). Used by the
+    /// read-visibility rule (issue #2374/#2789) so a key-only reconciled row is
+    /// not mistaken for one carrying live data.
+    fn is_primary_key_column(&self, column: &str) -> bool {
+        self.schema.partition_keys.iter().any(|k| k.name == column)
+            || self.schema.clustering_keys.iter().any(|c| c.name == column)
+    }
+
     pub(crate) fn entry_to_row(
         &self,
         partition_key: &[u8],
-        row_data: RowData,
+        entry: MergeEntry,
         pk_cache: &mut PartitionKeyCache,
         needed: Option<&std::collections::HashSet<String>>,
+        now_secs: i64,
     ) -> Result<Option<QueryRow>, ProducerError> {
-        let cells = match row_data {
+        // Issue #2374/#2789: the read-visibility marker liveness carried on the
+        // reconciled entry, checked below AFTER cell reassembly.
+        let row_liveness = entry.row_liveness;
+        let cells = match entry.row_data {
             RowData::Live { cells } => cells,
             // Whole-row deletion: suppress from output.
             RowData::Tombstone { .. } => return Ok(None),
@@ -1075,6 +1121,25 @@ impl MergeProducer {
             needed,
         )
         .map_err(ProducerError::Merge)?;
+
+        // Issue #2374/#2789: Cassandra row-visibility rule for the READ path. A
+        // reconciled row is visible to a `SELECT` iff it has at least one
+        // surviving live DATA cell (a non-primary-key column that survived
+        // cell-tombstone drop + read-time TTL expiry) OR a LIVE primary-key
+        // liveness marker (an INSERT whose row-marker TTL, if any, has not
+        // expired at `now_secs`). Without this, a row whose only content is an
+        // EXPIRED liveness marker plus already-tombstoned cells (the compaction
+        // fixture's `ttl_expired_live` ck=1) — and a re-emitted range/partition
+        // marker carrier (empty `RowData::Live`) — would surface as a phantom
+        // key-only null row, diverging from a core `SELECT`. The merger surfaces
+        // clustering columns as pseudo-cells, so a row_cells entry is "live data"
+        // only when its column is NOT a partition/clustering key.
+        let has_live_data_cell = row_cells
+            .iter()
+            .any(|(name, _)| !self.is_primary_key_column(name));
+        if !has_live_data_cell && !row_liveness.marker_live_at(now_secs) {
+            return Ok(None);
+        }
 
         let key = RowKey::new(partition_key.to_vec());
         // Issue #1817: reuse the caller's per-merge partition-key decode cache so a

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -1058,6 +1058,15 @@ impl MergeProducer {
         Ok(())
     }
 
+    /// True when `column` is a partition- or clustering-key column of the scan's
+    /// schema (the merger surfaces these as pseudo-cells). Used by the
+    /// read-visibility rule (issue #2374/#2789) so a key-only reconciled row is
+    /// not mistaken for one carrying live data.
+    fn is_primary_key_column(&self, column: &str) -> bool {
+        self.schema.partition_keys.iter().any(|k| k.name == column)
+            || self.schema.clustering_keys.iter().any(|c| c.name == column)
+    }
+
     /// Reconstruct one logical row from a merged entry, or `None` for a row
     /// tombstone. Cell tombstones are dropped so the column reads as null.
     ///
@@ -1076,15 +1085,6 @@ impl MergeProducer {
     /// corruption (e.g. a map key whose `cell_path` bytes do not decode under the
     /// declared key type). Such a failure is propagated as a `Merge` error rather
     /// than silently dropping the row (issue #2324, no-heuristics / no-silent-loss).
-    /// True when `column` is a partition- or clustering-key column of the scan's
-    /// schema (the merger surfaces these as pseudo-cells). Used by the
-    /// read-visibility rule (issue #2374/#2789) so a key-only reconciled row is
-    /// not mistaken for one carrying live data.
-    fn is_primary_key_column(&self, column: &str) -> bool {
-        self.schema.partition_keys.iter().any(|k| k.name == column)
-            || self.schema.clustering_keys.iter().any(|c| c.name == column)
-    }
-
     pub(crate) fn entry_to_row(
         &self,
         partition_key: &[u8],

--- a/cqlite-flight/src/producer_point.rs
+++ b/cqlite-flight/src/producer_point.rs
@@ -203,7 +203,12 @@ impl MergeProducer {
             // a cancel takes effect mid-partition — not after buffering the whole
             // partition. Output stays byte-identical (same reconciliation, same
             // order, same batching) to the buffered `drive_merge`.
-            Some(mut merger) => self.drive_merge_over(&mut merger, cancel, sink, progress, label),
+            Some(merger) => {
+                // Issue #2374/#2789: thread the read-time reconciliation clock so
+                // the point-read merge expires TTL cells with parity to core.
+                let mut merger = merger.with_now_secs(Some(self.now_secs));
+                self.drive_merge_over(&mut merger, cancel, sink, progress, label)
+            }
         }
     }
 }

--- a/cqlite-flight/src/producer_stream.rs
+++ b/cqlite-flight/src/producer_stream.rs
@@ -184,9 +184,10 @@ impl MergeProducer {
             // (`entry_to_row` → None) are skipped without counting a row.
             let Some(row) = self.entry_to_row(
                 &key.key,
-                entry.row_data,
+                *entry,
                 &mut pk_cache,
                 assemble_cols.as_ref(),
+                self.now_secs,
             )?
             else {
                 continue;

--- a/cqlite-flight/src/producer_warm.rs
+++ b/cqlite-flight/src/producer_warm.rs
@@ -94,7 +94,10 @@ impl MergeProducer {
                 // Issue #2423: row-granular streaming drive (see `produce_point`) —
                 // bounds a warm wide-partition point read to one clustering group +
                 // batch and makes cancellation mid-partition, byte-identically.
-                Some(mut merger) => {
+                Some(merger) => {
+                    // Issue #2374/#2789: thread the read-time reconciliation clock
+                    // so the warm point-read merge expires TTL cells with parity.
+                    let mut merger = merger.with_now_secs(Some(self.now_secs));
                     self.drive_merge_over(&mut merger, cancel, sink, progress, label)
                 }
             };
@@ -107,7 +110,10 @@ impl MergeProducer {
         let token_bound = self.spec.token.as_ref().map(|t| t.to_scan_bound());
         let mut merger =
             KWayMerger::new_from_readers(readers, &self.schema, cancel.scan_cancel(), token_bound)
-                .map_err(ProducerError::Merge)?;
+                .map_err(ProducerError::Merge)?
+                // Issue #2374/#2789: thread the read-time reconciliation clock so
+                // the warm full-scan merge expires TTL cells with parity to core.
+                .with_now_secs(Some(self.now_secs));
         on_merger_built();
         // Issue #2423: the warm full-scan branch streams row-granularly too, matching
         // the cold full-scan path (#2230) — bounded memory + mid-partition cancel.

--- a/cqlite-flight/tests/query_semantics_flight_parity.rs
+++ b/cqlite-flight/tests/query_semantics_flight_parity.rs
@@ -1,0 +1,507 @@
+//! Issue #2374 — the QUERY-SEMANTICS parity oracle, over the FLIGHT `do_get`
+//! path (the Trino/Flight read surface), mirroring the in-core lane
+//! `cqlite-core/tests/query_semantics_oracle_parity.rs`.
+//!
+//! The physical sstabledump JSONL goldens (`*-Data.db.jsonl`) enumerate every
+//! on-disk cell — including tombstones, deleted rows, and expired-but-
+//! uncompacted TTL cells — so a row-count/value comparison against them
+//! structurally CANNOT catch a read-time-reconciliation bug: when the Flight
+//! producer fails to reconcile, both sides still contain the shadowed/expired
+//! rows and parity passes while a real Cassandra `SELECT` diverges. This lane
+//! guards the Flight path against exactly that (the #2789 read-time TTL bug this
+//! test was written to expose, before the fix threaded a reconciliation `now`
+//! into the Flight k-way merger).
+//!
+//! This test compares Flight `do_get` output to the POST-RECONCILIATION result
+//! set a real Cassandra returns, recorded per-fixture in
+//! `test-data/query-semantics-oracle.json`. TTL expiry is evaluated at a PINNED
+//! `now` (per case) via the debug-only `CQLITE_TTL_NOW_OVERRIDE_SECS` reader
+//! seam, so it is deterministic and never wall-clock-flaky.
+//!
+//! DEBUG-ONLY PIN: the `CQLITE_TTL_NOW_OVERRIDE_SECS` seam is
+//! `#[cfg(debug_assertions)]`, so the pin only takes effect in a debug build.
+//! The agent gate runs debug, so the lane always exercises the pinned path
+//! there. The anti-empty-pass contract below guarantees the test can never
+//! green-pass vacuously.
+//!
+//! Anti-empty-pass / SKIP contract (IDENTICAL to the in-core lane):
+//!   * Each case carries a non-empty `expected_rows`; a `0-rows-when-rows-
+//!     expected` result is a HARD mismatch failure, never a vacuous pass.
+//!   * `physical_row_count` is re-derived from the committed golden JSONL and
+//!     asserted, proving the fixture's rows are physically present on disk.
+//!   * When the committed fixture (or its `*.db` binaries) is absent, the case
+//!     SKIPs cleanly — UNLESS `CQLITE_REQUIRE_FIXTURES=1` (the agent-gate
+//!     `flight-query-semantics-oracle` component sets it), in which case an
+//!     absent/empty fixture is a hard FAIL (fail-closed).
+//!
+//! Cases run SEQUENTIALLY inside ONE test so the process-global TTL-now env seam
+//! is never mutated concurrently.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use arrow::array::{Array, Int32Array, Int64Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use serde::Deserialize;
+use tonic::Request;
+
+use cqlite_flight::service::CqliteFlightService;
+
+/// Debug-only reader seam (see `now_clock.rs`): pins the read-time TTL "now"
+/// clock (epoch seconds) so a long-expired fixture is read deterministically
+/// "as of" the oracle's pinned evaluation time.
+const TTL_NOW_OVERRIDE_ENV: &str = "CQLITE_TTL_NOW_OVERRIDE_SECS";
+
+/// Fail-closed switch: when set, an absent/empty committed fixture is a hard
+/// failure instead of a clean skip (the agent-gate `flight-query-semantics-
+/// oracle` component sets it, matching the in-core `query-semantics-oracle`).
+fn require_fixtures() -> bool {
+    std::env::var("CQLITE_REQUIRE_FIXTURES")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Oracle model (test-data/query-semantics-oracle.json)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct Oracle {
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    id: String,
+    keyspace: String,
+    table: String,
+    fixture_dir_prefix: String,
+    sstable_prefix: String,
+    schema: String,
+    #[allow(dead_code)]
+    query: String,
+    pinned_now_secs: i64,
+    physical_row_count: usize,
+    /// Ordered map per row so JSON author-order is preserved for readable diffs.
+    expected_rows: Vec<serde_json::Map<String, serde_json::Value>>,
+    /// Explicit opt-in for a case whose correct semantic result is ZERO rows.
+    /// Required whenever `expected_rows` is empty — see the module doc's anti-
+    /// empty-pass contract. Defaults to `false`.
+    #[serde(default)]
+    expect_empty: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution (mirrors the in-core lane)
+// ---------------------------------------------------------------------------
+
+/// Repo root = the parent of this crate's manifest dir (`<repo>/cqlite-flight`).
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cqlite-flight has a parent repo dir")
+        .to_path_buf()
+}
+
+/// The `sstables/` root. Prefer `CQLITE_DATASETS_ROOT` when it actually holds the
+/// committed keyspace; otherwise fall back to the in-repo committed corpus.
+fn sstables_root(keyspace: &str) -> Option<PathBuf> {
+    let candidates = [
+        std::env::var("CQLITE_DATASETS_ROOT")
+            .ok()
+            .map(|r| PathBuf::from(r).join("sstables")),
+        Some(
+            repo_root()
+                .join("test-data")
+                .join("datasets")
+                .join("sstables"),
+        ),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|root| root.join(keyspace).is_dir())
+}
+
+fn schema_path(file: &str) -> Option<PathBuf> {
+    let candidates = [
+        std::env::var("CQLITE_DATASETS_ROOT").ok().and_then(|r| {
+            PathBuf::from(r)
+                .parent()
+                .map(|p| p.join("schemas").join(file))
+        }),
+        Some(repo_root().join("test-data").join("schemas").join(file)),
+    ];
+    candidates.into_iter().flatten().find(|p| p.exists())
+}
+
+fn fixture_dir(sstables_root: &Path, keyspace: &str, prefix: &str) -> Option<PathBuf> {
+    let ks_dir = sstables_root.join(keyspace);
+    std::fs::read_dir(&ks_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(prefix))
+                    .unwrap_or(false)
+        })
+}
+
+/// Count `type == "row"` entries in the committed sstabledump JSONL golden
+/// (anti-empty-pass: proves the physical rows are really on disk).
+fn golden_row_count(dir: &Path, sstable_prefix: &str) -> Option<usize> {
+    let jsonl = dir.join(format!("{sstable_prefix}-Data.db.jsonl"));
+    let text = std::fs::read_to_string(&jsonl).ok()?;
+    let mut total = 0usize;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line).ok()?;
+        if let Some(rows) = v.get("rows").and_then(|r| r.as_array()) {
+            total += rows
+                .iter()
+                .filter(|r| r.get("type").and_then(|t| t.as_str()) == Some("row"))
+                .count();
+        }
+    }
+    Some(total)
+}
+
+// ---------------------------------------------------------------------------
+// DDL derivation (the schema file holds ALL tables; the Flight ticket carries
+// ONE `CREATE TABLE`, so build the per-table DDL matching the fixture)
+// ---------------------------------------------------------------------------
+
+/// Extract the single `CREATE TABLE ... <table> (...)` statement for `table`
+/// from the multi-table `.cql` schema file, and rewrite it as a keyspace-
+/// qualified DDL string the Flight ticket needs. Every table in
+/// `compaction-tombstone-ttl-parity.cql` has the identical
+/// `(id INT, ck INT, v TEXT, PRIMARY KEY (id, ck))` shape, so the DDL is derived
+/// authoritatively from the schema's declared column set rather than guessed.
+fn ddl_for(schema_file: &Path, keyspace: &str, table: &str) -> Result<String, String> {
+    // The parity schema declares every table with the SAME column set; assert
+    // the target table is actually declared in the file so a typo can never
+    // silently synthesize a DDL for a non-existent table.
+    let text = std::fs::read_to_string(schema_file)
+        .map_err(|e| format!("read schema {}: {e}", schema_file.display()))?;
+    let declared = text.contains(&format!("TABLE IF NOT EXISTS {table} "))
+        || text.contains(&format!("TABLE {table} "));
+    if !declared {
+        return Err(format!(
+            "table {table} is not declared in {}",
+            schema_file.display()
+        ));
+    }
+    Ok(format!(
+        "CREATE TABLE {keyspace}.{table} \
+         (id int, ck int, v text, PRIMARY KEY (id, ck))"
+    ))
+}
+
+/// Build the on-the-wire Flight ticket JSON: keyspace + table + per-table DDL +
+/// the oracle's `SELECT id, ck, v` projection.
+fn ticket_bytes(keyspace: &str, table: &str, ddl: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": keyspace,
+        "table": table,
+        "ddl": ddl,
+        "columns": ["id", "ck", "v"],
+    }))
+    .expect("serialize flight ticket")
+}
+
+// ---------------------------------------------------------------------------
+// Arrow batch → comparable rows
+// ---------------------------------------------------------------------------
+
+/// Decode an `id`/`ck`/`v` cell out of a batch column at row `i` into plain
+/// JSON, comparing directly against the oracle's authored scalars. `id`/`ck`
+/// are CQL `int` (Arrow Int32), `v` is `text` (Arrow Utf8). An `int` may also
+/// surface as Int64 depending on the converter; both are accepted. Any other
+/// shape is a hard error, never a silent mis-compare.
+fn cell_to_json(batch: &RecordBatch, col: &str, i: usize) -> Result<serde_json::Value, String> {
+    use serde_json::json;
+    let array = batch
+        .column_by_name(col)
+        .ok_or_else(|| format!("batch missing projected column {col}"))?;
+    if array.is_null(i) {
+        return Ok(serde_json::Value::Null);
+    }
+    if let Some(a) = array.as_any().downcast_ref::<Int32Array>() {
+        return Ok(json!(a.value(i)));
+    }
+    if let Some(a) = array.as_any().downcast_ref::<Int64Array>() {
+        return Ok(json!(a.value(i)));
+    }
+    if let Some(a) = array.as_any().downcast_ref::<StringArray>() {
+        return Ok(json!(a.value(i)));
+    }
+    Err(format!(
+        "column {col} has unsupported Arrow type {:?}",
+        array.data_type()
+    ))
+}
+
+/// Drive one `do_get` in-process and decode every returned batch into rows of
+/// the oracle's `id`/`ck`/`v` projection.
+async fn do_get_rows(
+    svc: &CqliteFlightService,
+    ticket: Vec<u8>,
+) -> Result<Vec<serde_json::Map<String, serde_json::Value>>, String> {
+    let resp = svc
+        .do_get(Request::new(Ticket::new(ticket)))
+        .await
+        .map_err(|s| format!("do_get status: {s}"))?;
+    let stream = resp
+        .into_inner()
+        .map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
+    let mut rb = FlightRecordBatchStream::new_from_flight_data(stream);
+    let cols = ["id", "ck", "v"];
+    let mut out = Vec::new();
+    while let Some(batch) = rb.next().await {
+        let batch: RecordBatch = batch.map_err(|e| format!("decode flight batch: {e}"))?;
+        for i in 0..batch.num_rows() {
+            let mut m = serde_json::Map::new();
+            for col in cols {
+                m.insert(col.to_string(), cell_to_json(&batch, col, i)?);
+            }
+            out.push(m);
+        }
+    }
+    Ok(out)
+}
+
+/// Normalize a result set into a sorted, comparable multiset (row order is not
+/// asserted; the oracle compares as a multiset keyed by the projected columns).
+fn normalize(rows: Vec<serde_json::Map<String, serde_json::Value>>) -> Vec<String> {
+    let mut out: Vec<String> = rows
+        .into_iter()
+        .map(|m| {
+            let sorted: BTreeMap<_, _> = m.into_iter().collect();
+            serde_json::to_string(&sorted).unwrap_or_default()
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// One case: returns Ok(true) if it ran a comparison, Ok(false) if it SKIPped.
+async fn run_case(case: &Case) -> Result<bool, String> {
+    // Anti-empty-pass config validation (independent of fixture presence): an
+    // empty `expected_rows` must be an explicit, provable opt-in — never an
+    // accident that silently collapses the compared column set to `[]`.
+    if case.expected_rows.is_empty() {
+        if !case.expect_empty {
+            return Err(format!(
+                "case {}: expected_rows is empty but expect_empty is not set — a \
+                 case expecting zero semantic rows must opt in explicitly",
+                case.id
+            ));
+        }
+        if case.physical_row_count == 0 {
+            return Err(format!(
+                "case {}: expect_empty is set but physical_row_count is 0 — \
+                 expect_empty must prove rows existed on disk and were reconciled away",
+                case.id
+            ));
+        }
+    }
+
+    let Some(root) = sstables_root(&case.keyspace) else {
+        let msg = format!("case {}: keyspace {} absent", case.id, case.keyspace);
+        if require_fixtures() {
+            return Err(format!("REQUIRE_FIXTURES: {msg}"));
+        }
+        eprintln!("SKIP {msg}");
+        return Ok(false);
+    };
+    let Some(dir) = fixture_dir(&root, &case.keyspace, &case.fixture_dir_prefix) else {
+        let msg = format!(
+            "case {}: fixture dir {}* absent",
+            case.id, case.fixture_dir_prefix
+        );
+        if require_fixtures() {
+            return Err(format!("REQUIRE_FIXTURES: {msg}"));
+        }
+        eprintln!("SKIP {msg}");
+        return Ok(false);
+    };
+    let data_db = dir.join(format!("{}-Data.db", case.sstable_prefix));
+    if !data_db.exists() {
+        let msg = format!("case {}: {} not fetched", case.id, data_db.display());
+        if require_fixtures() {
+            return Err(format!("REQUIRE_FIXTURES: {msg}"));
+        }
+        eprintln!("SKIP {msg}");
+        return Ok(false);
+    }
+    let Some(schema) = schema_path(&case.schema) else {
+        let msg = format!("case {}: schema {} absent", case.id, case.schema);
+        if require_fixtures() {
+            return Err(format!("REQUIRE_FIXTURES: {msg}"));
+        }
+        eprintln!("SKIP {msg}");
+        return Ok(false);
+    };
+
+    // Anti-empty-pass: the physical rows really exist on disk, and the oracle's
+    // declared physical count matches the committed golden.
+    let golden = golden_row_count(&dir, &case.sstable_prefix)
+        .ok_or_else(|| format!("case {}: golden JSONL missing/unreadable", case.id))?;
+    if golden != case.physical_row_count {
+        return Err(format!(
+            "case {}: golden physical row count {golden} != oracle physical_row_count {}",
+            case.id, case.physical_row_count
+        ));
+    }
+    // A shadowing/expiry oracle only ever HIDES rows a physical dump shows.
+    if golden < case.expected_rows.len() {
+        return Err(format!(
+            "case {}: physical rows {golden} < expected semantic rows {}",
+            case.id,
+            case.expected_rows.len()
+        ));
+    }
+
+    let ddl = ddl_for(&schema, &case.keyspace, &case.table)
+        .map_err(|e| format!("case {}: {e}", case.id))?;
+
+    // Pin the read-time TTL clock for this case (removed after do_get, before
+    // the next case). The Flight producer threads this SAME `now` (via
+    // `read_time_now_secs`, issue #2789) into its k-way merger's TTL expiry.
+    // The service resolves `<data_dir>/<keyspace>/<table>-<uuid>/`, so point it
+    // at the sstables root.
+    std::env::set_var(TTL_NOW_OVERRIDE_ENV, case.pinned_now_secs.to_string());
+    let svc = CqliteFlightService::new(root.clone(), 8192);
+    let ticket = ticket_bytes(&case.keyspace, &case.table, &ddl);
+    let got_rows = do_get_rows(&svc, ticket).await;
+    std::env::remove_var(TTL_NOW_OVERRIDE_ENV);
+    let actual = got_rows.map_err(|e| format!("case {}: {e}", case.id))?;
+
+    let expected = normalize(case.expected_rows.clone());
+    let got = normalize(actual);
+    if expected != got {
+        return Err(format!(
+            "case {} ({}.{}): FLIGHT query-semantics MISMATCH\n  pinned_now_secs: {}\n  physical rows on disk: {golden}\n  expected ({} rows): {:#?}\n  got      ({} rows): {:#?}",
+            case.id,
+            case.keyspace,
+            case.table,
+            case.pinned_now_secs,
+            expected.len(),
+            expected,
+            got.len(),
+            got,
+        ));
+    }
+    eprintln!(
+        "PASS case {} (flight) — semantic {} rows (physical dump had {golden}); reconciliation applied",
+        case.id,
+        got.len()
+    );
+    Ok(true)
+}
+
+/// A synthetic `Case` for the guard-enforcement tests below.
+fn synthetic_case(
+    id: &str,
+    expected_rows_len_zero: bool,
+    expect_empty: bool,
+    physical_row_count: usize,
+) -> Case {
+    Case {
+        id: id.to_string(),
+        keyspace: "does_not_matter".to_string(),
+        table: "does_not_matter".to_string(),
+        fixture_dir_prefix: "does_not_matter".to_string(),
+        sstable_prefix: "does_not_matter".to_string(),
+        schema: "does_not_matter.cql".to_string(),
+        query: "SELECT 1".to_string(),
+        pinned_now_secs: 0,
+        physical_row_count,
+        expected_rows: if expected_rows_len_zero {
+            Vec::new()
+        } else {
+            vec![serde_json::Map::new()]
+        },
+        expect_empty,
+    }
+}
+
+/// An empty `expected_rows` without the explicit `expect_empty` opt-in must FAIL
+/// LOUDLY, never silently collapse to `[]` and pass vacuously.
+#[tokio::test]
+async fn empty_expected_rows_without_opt_in_fails_loudly() {
+    let case = synthetic_case("synthetic_empty_no_optin", true, false, 5);
+    let err = run_case(&case).await.expect_err(
+        "an empty expected_rows without expect_empty must fail loudly, not vacuously pass",
+    );
+    assert!(
+        err.contains("expect_empty"),
+        "error must name the missing opt-in, got: {err}"
+    );
+}
+
+/// `expect_empty: true` still requires proof that physical rows existed and were
+/// reconciled away — `physical_row_count == 0` is an empty/misconfigured fixture.
+#[tokio::test]
+async fn expect_empty_requires_nonzero_physical_row_count() {
+    let case = synthetic_case("synthetic_empty_zero_physical", true, true, 0);
+    let err = run_case(&case)
+        .await
+        .expect_err("expect_empty with physical_row_count == 0 must fail loudly");
+    assert!(
+        err.contains("physical_row_count"),
+        "error must name the missing proof, got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_semantics_oracle_matches_flight_do_get() {
+    let oracle_path = repo_root()
+        .join("test-data")
+        .join("query-semantics-oracle.json");
+    let text = std::fs::read_to_string(&oracle_path)
+        .unwrap_or_else(|e| panic!("read oracle {}: {e}", oracle_path.display()));
+    let oracle: Oracle = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("parse oracle {}: {e}", oracle_path.display()));
+    assert!(
+        !oracle.cases.is_empty(),
+        "oracle must define at least one case"
+    );
+
+    // Sequential: the TTL-now env seam is process-global.
+    let mut ran = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    for case in &oracle.cases {
+        match run_case(case).await {
+            Ok(true) => ran += 1,
+            Ok(false) => {}
+            Err(e) => failures.push(e),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "flight query-semantics oracle failures:\n{}",
+        failures.join("\n\n")
+    );
+
+    if require_fixtures() {
+        assert!(
+            ran > 0,
+            "CQLITE_REQUIRE_FIXTURES=1 but no oracle case ran (fixtures absent) — fail-closed"
+        );
+    } else if ran == 0 {
+        eprintln!("SKIP flight query_semantics_oracle: no fixtures present (set CQLITE_REQUIRE_FIXTURES=1 to fail-close)");
+    }
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1331,7 +1331,7 @@ _python_build_verify_venv() {
   return 3
 }
 
-COMPONENTS=(file-size fmt clippy roborev-lints core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle python-bindings node-bindings delivery-telemetry oom-audit parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy roborev-lints core-tests tombstones-scan scan-offload-guard work-counters-guard byte-budget-guard arrow-parity-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity query-semantics-oracle flight-query-semantics-oracle python-bindings node-bindings delivery-telemetry oom-audit parity-report operator-metrics-doc kit-dashboard-drift binding-unwind-profile tooling-tests minimal-build smoke)
 
 # _component_lane <name> (issues #1737, #2657): SINGLE SOURCE OF TRUTH for the
 # MAIN-vs-SIDE lane split. Defined early (before the arg-parse dispatch) so the
@@ -2215,6 +2215,48 @@ run_query_semantics_oracle() {
   if env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
       cargo test -p cqlite-core --features "state_machine cli-helpers" \
         --test query_semantics_oracle_parity >"$log" 2>&1; then
+    status=PASS
+  else
+    status=FAIL
+    echo "--- [$name] FAILED; last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+  fi
+  end=$(date +%s)
+  record_result "$name" "$status" "$((end - start))"
+  echo ">>> [$name] $status ($((end - start))s)"
+}
+
+# flight-query-semantics-oracle: the QUERY-SEMANTICS parity lane routed through the
+# FLIGHT do_get path (issue #2374), the sibling of query-semantics-oracle above. The
+# in-core lane never exercises the Flight producer/merge path (it drives
+# cqlite_core::Database directly), so a read-time reconciliation regression in the
+# Flight producer would pass the in-core oracle. This lane replays the SAME oracle
+# cases through a REAL in-process do_get at a PINNED `now` and asserts the post-
+# reconciliation result set matches — including read-time TTL expiry (issue #2789).
+# Same fixture policy + SKIP/fail-closed contract as its sibling: fail-closed
+# (CQLITE_REQUIRE_FIXTURES=1) when the committed test_compaction_tombstone_ttl
+# fixtures are present, loud SKIP (never silent PASS) when CQLITE_DATASETS_ROOT is
+# unset or the committed keyspace is absent. NOT in DATASET_COMPONENTS: self-guarding.
+run_flight_query_semantics_oracle() {
+  local name=flight-query-semantics-oracle
+  if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
+    return 0
+  fi
+  local log="$LOG_DIR/$name.log"
+  local start end status
+  start=$(date +%s)
+  local committed_ks="${CQLITE_DATASETS_ROOT:-}/sstables/test_compaction_tombstone_ttl"
+  if [ -z "${CQLITE_DATASETS_ROOT:-}" ] || [ ! -d "$committed_ks" ]; then
+    status=SKIP
+    echo ">>> [$name] SKIP (CQLITE_DATASETS_ROOT unset or committed test_compaction_tombstone_ttl fixtures absent)"
+    record_result "$name" "$status" 0
+    return 0
+  fi
+  echo ">>> [$name] query-semantics parity oracle vs Flight do_get (#2374/#2789)"
+  if env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+      cargo test -p cqlite-flight \
+        --test query_semantics_flight_parity >"$log" 2>&1; then
     status=PASS
   else
     status=FAIL
@@ -4136,6 +4178,7 @@ dispatch_component() {
   check_no_unexpected_zero_tests "Pass 2 (write-support)" "$log2"' ;;
     compaction-byte-parity) run_compaction_byte_parity ;;
     query-semantics-oracle) run_query_semantics_oracle ;;
+    flight-query-semantics-oracle) run_flight_query_semantics_oracle ;;
     python-bindings) run_python_bindings ;;
     node-bindings) run_node_bindings ;;
     delivery-telemetry) run_delivery_telemetry ;;


### PR DESCRIPTION
Closes #2374
Closes #2789

## Summary
Adds a Flight query-semantics parity lane replaying the query-semantics oracle's canonical SELECTs through **real do_get** at a pinned `now`, and — as the prerequisite the lane exposed — fixes read-time TTL/liveness reconciliation on the Flight read path.

### #2789 fix — Flight do_get now applies read-time TTL/liveness reconciliation
- The producer previously passed `now_secs = None` to the k-way merger → `expire_ttl_cells` was a strict no-op → Flight do_get never expired TTL rows. Now threads a single authoritative reconciliation `now` (from the same `now_epoch_secs()` seam the core read path uses — honors `CQLITE_TTL_NOW_OVERRIDE_SECS` under debug, wall-clock in prod; **no-heuristics**) into **every** Flight merger (cold/warm/point/stream).
- Surfaces carry-only primary-key **`RowLiveness`** (with an authoritative `marker_timestamp` from the row header) through reconcile/shadowing, and applies Cassandra's row-visibility rule in `entry_to_row`: hide a row with no live data cell unless its PK liveness marker is live. Visibility is computed from the **full pre-projection** cell set (so PK-only projections / `count(*)` don't wrongly hide UPDATE-inserted rows).
- The cross-generation liveness fold is **timestamp-LWW** (newer marker wins; later-expiry only a tie-break) — matching Cassandra, not a permissive union.

### #2374 — the parity lane
`cqlite-flight/tests/query_semantics_flight_parity.rs`: replays all 3 oracle cases (ttl_expired_live, shadow_row_delete, rt_cross_gen) through in-process do_get at the oracle's pinned `now`, comparing the post-reconciliation result set as a multiset. SKIP-aware dataset gating identical to the in-core lane; anti-empty-pass (0-rows-when-expected is a hard fail). New gate component `flight-query-semantics-oracle` in `scripts/agent-gate.sh` (self-guarding).

## Byte-parity preserved
`RowLiveness` is carry-only on the READ path; the compaction WRITE path never consults it. `issue_1387_tombstone_ttl_compaction_byte_parity` stays green (4 passed, 1 ignored).

## Review (review-first; 3 rounds — merge-core change)
- rust-reviewer + roborev, each round. **Blockers found + fixed:** (1) projection-restricted visibility hiding UPDATE-inserted rows; (2) `row_liveness` dropped during range/partition shadowing; (3) permissive-union liveness fold vs timestamp-LWW. All fixed with regression tests (verified fail-pre-fix/pass-post-fix). rust-reviewer confirmed all fixes correct; roborev r4 = no blockers, 2 non-blocking nits (one folded in as a `ReconcileState` fold unit test, one filed as pre-existing follow-up #2799).

## Note for reviewer
Several touched core files (`merge/mod.rs`, `producer.rs`, etc.) were already over the #1116 800-line threshold; the diff grows them minimally → acked with `CQLITE_ALLOW_FILE_GROWTH=1` per doctrine (split out of scope here).

Cross-refs: #1742 (two-oracle doctrine), #972 (tombstone/TTL parity), #2799 (pre-existing partition-key-only row-DELETE-vs-marker gap, follow-up).