### PR TITLE
ci(#2803): guard flight-image merge/smoke so image_tag dispatch publishes a tag

### DIFF
--- a/.github/workflows/flight-image.yml
+++ b/.github/workflows/flight-image.yml
@@ -140,6 +140,14 @@ jobs:
     name: Publish multi-arch image
     runs-on: ubuntu-latest
     needs: build
+    # The build job carries an `if: !cancelled() && (preflight success|skipped)`
+    # guard (#2652). On the workflow_dispatch path preflight is *skipped*; once an
+    # ancestor is conditionally guarded, a downstream job on the default
+    # `success()` check is skipped unless it carries its own `!cancelled()` guard.
+    # Without this, an `image_tag` dispatch reported success while publishing NO
+    # tag — the merge/smoke jobs silently skipped (#2803). Gate on the build
+    # result explicitly so the multi-arch manifest is always assembled + tagged.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     permissions:
       contents: read
       packages: write
@@ -307,6 +315,9 @@ jobs:
     name: Smoke (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: merge
+    # See the merge job: same #2803 cascade — guard on the merge result so smoke
+    # runs on the dispatch path instead of silently skipping.
+    if: ${{ !cancelled() && needs.merge.result == 'success' }}
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
Fixes #2803.

The #2652 refactor added `if: !cancelled() && (preflight...)` to the `build` job. On the `workflow_dispatch` (`image_tag`) path preflight is skipped, and the downstream `merge`/`smoke` jobs — on the default `success()` check with no guard of their own — silently skipped. Result: a green run that published **no tag** (verified 404 on `0.16.0-rc1`).

This adds explicit `if: ${{ !cancelled() && needs.<upstream>.result == 'success' }}` guards to `merge` and `smoke`.

**Validation:** dispatched this workflow from this branch with `image_tag=0.16.0-rc1` — expecting a multi-arch (amd64+arm64) manifest published under the tag and both smoke jobs green. Will confirm the digest on the run.

Code content identical to `f4f13a7cb` (workflow-only change), so the resulting image is a valid 0.16 field build.