### PR TITLE
fix(#2807): accept keyspace-qualified UDT type names — parse + decode both read paths

### DIFF
--- a/cqlite-core/src/schema/cql_parser.rs
+++ b/cqlite-core/src/schema/cql_parser.rs
@@ -3,6 +3,12 @@
 //! This module provides parsing capabilities for CQL CREATE TABLE statements
 //! to extract table schema information including table names, column definitions,
 //! partition keys, clustering keys, and type information.
+//!
+//! NOTE (file-size ratchet, epic #1116): this file is over the campsite
+//! source-line threshold and a split-by-responsibility is pending under #1116.
+//! Issue #2807 grew it by a small grammar fix (keyspace-qualified UDT names) and
+//! ran the gate with `CQLITE_ALLOW_FILE_GROWTH=1`; splitting the parser is out of
+//! scope for that bug fix.
 
 use crate::cql::{CqlCreateTable, CqlDataType};
 use crate::error::{Error, Result};
@@ -63,10 +69,19 @@ fn qualified_table_name(input: &str) -> IResult<&str, (Option<String>, String)> 
 /// `describe` output ALWAYS emits UDT column types keyspace-qualified
 /// (e.g. `cassandra_easy_stress.addr`), so the grammar must accept the optional
 /// `keyspace.` prefix (issue #2807). The qualified name is RETAINED verbatim in
-/// the returned string: the downstream resolver
-/// ([`crate::schema::TableSchema::validate_udt_references`] /
-/// [`crate::schema::CqlType::parse`]) already splits `keyspace.udt`, so the
-/// keyspace is information it needs — it must not be dropped here.
+/// the returned `data_type` string — the keyspace is information downstream
+/// lookups need and MUST NOT be dropped here.
+///
+/// IMPORTANT for any NEW consumer of a `data_type` string: the registry is keyed
+/// by BARE UDT name, and `CqlType::parse` does NOT split the qualifier (it yields
+/// `Custom("udt:ks.addr")` intact). Only two places split `keyspace.udt`, both via
+/// the single shared [`crate::schema::split_qualified_udt`]:
+/// [`crate::schema::UdtRegistry::resolve_udt_reference`] (type resolution) and
+/// [`crate::schema::TableSchema::validate_udt_references`] (`ensure_udt_exists`);
+/// registry-backed *decode* lookups go through
+/// [`crate::schema::UdtRegistry::get_udt_qualified`]. A new consumer that calls
+/// `registry.get_udt(keyspace, name)` on a raw `data_type` WILL miss a qualified
+/// reference and silently degrade the value to `Blob` — split first.
 fn qualified_type_name(input: &str) -> IResult<&str, String> {
     let (input, first) = identifier(input)?;
     let (input, second) = opt(preceded(char('.'), identifier))(input)?;
@@ -155,8 +170,11 @@ fn cql_type(input: &str) -> IResult<&str, String> {
             ),
             // Simple types and UDTs. UDT type names may be keyspace-qualified
             // (`keyspace.type_name`), which Cassandra always emits (issue #2807);
-            // `qualified_type_name` accepts the optional prefix and retains it.
-            map(qualified_type_name, |name| name),
+            // `qualified_type_name` accepts the optional prefix and retains it. The
+            // retained qualifier is later split on a single `.` by
+            // `UdtRegistry::get_udt_qualified`, which assumes an unquoted, dot-free
+            // keyspace name (the only form the grammar / `describe` produce).
+            qualified_type_name,
         ))(input)?;
 
         Ok((input, base))

--- a/cqlite-core/src/schema/cql_parser.rs
+++ b/cqlite-core/src/schema/cql_parser.rs
@@ -58,6 +58,25 @@ fn qualified_table_name(input: &str) -> IResult<&str, (Option<String>, String)> 
     }
 }
 
+/// Parse a UDT type reference, which may be keyspace-qualified
+/// (`keyspace.type_name`) or bare (`type_name`). Cassandra's `CREATE TABLE` /
+/// `describe` output ALWAYS emits UDT column types keyspace-qualified
+/// (e.g. `cassandra_easy_stress.addr`), so the grammar must accept the optional
+/// `keyspace.` prefix (issue #2807). The qualified name is RETAINED verbatim in
+/// the returned string: the downstream resolver
+/// ([`crate::schema::TableSchema::validate_udt_references`] /
+/// [`crate::schema::CqlType::parse`]) already splits `keyspace.udt`, so the
+/// keyspace is information it needs — it must not be dropped here.
+fn qualified_type_name(input: &str) -> IResult<&str, String> {
+    let (input, first) = identifier(input)?;
+    let (input, second) = opt(preceded(char('.'), identifier))(input)?;
+
+    match second {
+        Some(type_name) => Ok((input, format!("{}.{}", first, type_name))),
+        None => Ok((input, first)),
+    }
+}
+
 /// Maximum allowed CQL type nesting depth for the nom schema parser. Mirrors
 /// [`crate::parser::complex_types::ComplexTypeParser`] (`max_depth = 32`) and the
 /// [`crate::schema::CqlType`] string parser guard.
@@ -134,8 +153,10 @@ fn cql_type(input: &str) -> IResult<&str, String> {
                 )),
                 |(_, _, inner, _)| format!("frozen<{}>", inner),
             ),
-            // Simple types and UDTs
-            map(identifier, |name| name),
+            // Simple types and UDTs. UDT type names may be keyspace-qualified
+            // (`keyspace.type_name`), which Cassandra always emits (issue #2807);
+            // `qualified_type_name` accepts the optional prefix and retains it.
+            map(qualified_type_name, |name| name),
         ))(input)?;
 
         Ok((input, base))

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -21,7 +21,7 @@ mod key_ordering;
 mod schema_comparator;
 mod udt_registry;
 
-pub use udt_registry::{udt_registry_from_cql, UdtRegistry};
+pub use udt_registry::{split_qualified_udt, udt_registry_from_cql, UdtRegistry};
 
 /// Test-only work counters for the derived-comparator caching path (issue #1709).
 ///
@@ -693,11 +693,10 @@ impl TableSchema {
         registry: &UdtRegistry,
     ) -> Result<()> {
         // A reference may be qualified as `keyspace.udt`; honor an explicit
-        // keyspace, otherwise resolve against the table's keyspace.
-        let (lookup_keyspace, bare_name) = match udt_name.split_once('.') {
-            Some((ks, name)) => (ks, name),
-            None => (self.keyspace.as_str(), udt_name),
-        };
+        // keyspace, otherwise resolve against the table's keyspace. Routes through
+        // the single shared splitter (issue #2807).
+        let (lookup_keyspace, bare_name) =
+            crate::schema::split_qualified_udt(udt_name, self.keyspace.as_str());
 
         if registry.contains_udt(lookup_keyspace, bare_name)
             || registry.contains_udt("system", bare_name)

--- a/cqlite-core/src/schema/udt_registry.rs
+++ b/cqlite-core/src/schema/udt_registry.rs
@@ -10,6 +10,32 @@ use crate::types::UdtTypeDef;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Split a possibly KEYSPACE-QUALIFIED UDT reference into `(lookup_keyspace,
+/// bare_name)`. This is the SINGLE authoritative split rule shared by every UDT
+/// lookup — the resolver ([`UdtRegistry::resolve_udt_reference`]), the read-path
+/// decode fallbacks ([`UdtRegistry::get_udt_qualified`]), and the writer's
+/// `resolve_registered_udt` (promoted here from the write path, roborev #1020).
+///
+/// Cassandra always emits UDT column types keyspace-qualified (`frozen<ks.addr>`,
+/// issue #2807) and the CQL parser now RETAINS that qualifier in `data_type`, but
+/// the registry is keyed by `(keyspace, bare_name)` (see [`UdtRegistry::get_udt`]).
+/// So any consumer of a `data_type` string that references a UDT MUST route its
+/// registry lookup through this split first — otherwise `ks.addr` never matches
+/// the bare-`addr` key and the value silently degrades to `BytesType`/`Blob`.
+///
+/// The split assumes an unquoted, dot-free keyspace name — the only form the CQL
+/// grammar and `describe` produce (a quoted case-sensitive UDT name is normalized
+/// to its bare, dot-free form by the quote-stripping `identifier` parser first).
+pub fn split_qualified_udt<'a>(
+    reference: &'a str,
+    default_keyspace: &'a str,
+) -> (&'a str, &'a str) {
+    match reference.split_once('.') {
+        Some((keyspace, bare_name)) => (keyspace, bare_name),
+        None => (default_keyspace, reference),
+    }
+}
+
 /// Build a [`UdtRegistry`] from every `CREATE TYPE` statement in a CQL DDL string
 /// (issue #2349).
 ///
@@ -74,6 +100,28 @@ impl UdtRegistry {
     /// Get a UDT definition by keyspace and name
     pub fn get_udt(&self, keyspace: &str, name: &str) -> Option<&UdtTypeDef> {
         self.udts.get(keyspace)?.get(name)
+    }
+
+    /// Look up a UDT by a reference that MAY be keyspace-qualified
+    /// (`keyspace.type_name`) and/or carry the schema-parse `udt:` prefix, routing
+    /// through the SINGLE shared splitter [`split_qualified_udt`] (also used by the
+    /// resolver and the writer): an explicit `keyspace.` prefix selects that
+    /// keyspace, otherwise `default_keyspace`. The registry is keyed by BARE name,
+    /// so the qualifier MUST be stripped before the HashMap lookup (issue #2807).
+    ///
+    /// This is the qualifier-aware entry point every registry-backed *decode*
+    /// fallback must use: Cassandra emits UDT column types keyspace-qualified
+    /// (`frozen<ks.addr>`), which the CQL parser now retains, so a plain
+    /// `get_udt(&self.keyspace, "ks.addr")` would MISS a bare-`addr`-keyed
+    /// registry and silently degrade the cell to `Blob`.
+    pub fn get_udt_qualified(
+        &self,
+        default_keyspace: &str,
+        reference: &str,
+    ) -> Option<&UdtTypeDef> {
+        let reference = reference.strip_prefix("udt:").unwrap_or(reference);
+        let (keyspace, bare_name) = split_qualified_udt(reference, default_keyspace);
+        self.get_udt(keyspace, bare_name)
     }
 
     /// Get all UDTs in a keyspace
@@ -273,10 +321,7 @@ impl UdtRegistry {
         keyspace: &str,
         depth: usize,
     ) -> Option<CqlType> {
-        let (lookup_keyspace, bare_name) = match udt_name.split_once('.') {
-            Some((ks, n)) => (ks, n),
-            None => (keyspace, udt_name),
-        };
+        let (lookup_keyspace, bare_name) = split_qualified_udt(udt_name, keyspace);
         let def = self
             .get_udt(lookup_keyspace, bare_name)
             .or_else(|| self.get_udt("system", bare_name))?;

--- a/cqlite-core/src/schema/udt_registry.rs
+++ b/cqlite-core/src/schema/udt_registry.rs
@@ -114,6 +114,24 @@ impl UdtRegistry {
     /// (`frozen<ks.addr>`), which the CQL parser now retains, so a plain
     /// `get_udt(&self.keyspace, "ks.addr")` would MISS a bare-`addr`-keyed
     /// registry and silently degrade the cell to `Blob`.
+    ///
+    /// STRICTLY NON-REGRESSIVE: if the split lookup misses, it retries the ORIGINAL
+    /// (unsplit, `udt:`-stripped) reference against `default_keyspace`. This
+    /// preserves the exotic case of a registry entry whose BARE name legitimately
+    /// contains a dot (a quoted `"my.type"`) and the catch-all decode arms that may
+    /// hand this method a non-grammar-sourced string — neither must be broken by the
+    /// qualifier split.
+    ///
+    /// Two deliberate asymmetries vs the write path / resolver:
+    /// - Read-path resolution here is CASE-SENSITIVE, whereas the writer's
+    ///   `resolve_registered_udt` also does an unambiguous case-insensitive name
+    ///   fallback. This asymmetry is known and tracked as a follow-up; decode input
+    ///   is the authoritative on-disk/DDL casing, so exact match is correct today.
+    /// - There is intentionally NO `system`-keyspace fallback (unlike
+    ///   [`Self::resolve_udt_reference`] / [`super::TableSchema::ensure_udt_exists`]):
+    ///   the decode fallbacks never had one, and adding it here would change pre-fix
+    ///   decode semantics (a missing UDT must fall through unchanged, not silently
+    ///   bind to a same-named `system` type).
     pub fn get_udt_qualified(
         &self,
         default_keyspace: &str,
@@ -122,6 +140,9 @@ impl UdtRegistry {
         let reference = reference.strip_prefix("udt:").unwrap_or(reference);
         let (keyspace, bare_name) = split_qualified_udt(reference, default_keyspace);
         self.get_udt(keyspace, bare_name)
+            // Non-regressive fallback: a bare name that itself contains a dot
+            // (quoted `"my.type"`) must still resolve against the default keyspace.
+            .or_else(|| self.get_udt(default_keyspace, reference))
     }
 
     /// Get all UDTs in a keyspace
@@ -559,6 +580,41 @@ mod resolve_tests {
     const DDL: &str = "\
 CREATE TYPE ks.address_type (street text, city text); \
 CREATE TYPE ks.contact_info (email text, address frozen<address_type>);";
+
+    #[test]
+    fn get_udt_qualified_splits_keyspace_and_strips_udt_prefix() {
+        let reg = udt_registry_from_cql(DDL, "ks");
+        // Qualified reference resolves via the explicit keyspace.
+        assert!(reg.get_udt_qualified("other", "ks.address_type").is_some());
+        // `udt:` prefix is normalized away.
+        assert!(reg.get_udt_qualified("ks", "udt:address_type").is_some());
+        // Bare reference resolves via the default keyspace.
+        assert!(reg.get_udt_qualified("ks", "address_type").is_some());
+        // Wrong explicit keyspace does not resolve.
+        assert!(reg.get_udt_qualified("ks", "nope.address_type").is_none());
+    }
+
+    /// Issue #2807 (addendum item 1): a registry entry whose BARE name legitimately
+    /// contains a dot (a quoted `"my.type"`) must STILL resolve — the unconditional
+    /// first-dot split would otherwise regress it, so `get_udt_qualified` retries
+    /// the original unsplit reference against the default keyspace.
+    #[test]
+    fn get_udt_qualified_non_regressive_for_dotted_bare_name() {
+        let mut reg = UdtRegistry::new();
+        reg.register_udt(
+            UdtTypeDef::new("ks".to_string(), "my.type".to_string()).with_field(
+                "v".to_string(),
+                CqlType::Text,
+                true,
+            ),
+        );
+        // Split would look up keyspace `my`/name `type` (miss); the fallback recovers
+        // the real bare-dotted entry in the default keyspace.
+        let got = reg
+            .get_udt_qualified("ks", "my.type")
+            .expect("dotted bare name resolves");
+        assert_eq!(got.name, "my.type");
+    }
 
     #[test]
     fn from_cql_registers_every_create_type() {

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_complex.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_complex.rs
@@ -121,7 +121,7 @@ impl V5CompressedLegacyParser {
             } else if let Some(udt_def) = self
                 .udt_registry
                 .as_ref()
-                .and_then(|reg| reg.get_udt(&self.keyspace, &inner_type).cloned())
+                .and_then(|reg| reg.get_udt_qualified(&self.keyspace, &inner_type).cloned())
             {
                 // frozen<short_udt_name>: look up the concrete UDT definition in the
                 // registry (Issue #502).  This handles type strings like

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs
@@ -942,6 +942,12 @@ mod regression_1641_boundary_peek_tests;
 #[cfg(test)]
 mod regression_1795_overflow_tests;
 
+// Issue #2807: the DECODE surface for keyspace-qualified UDT type names — the
+// registry-backed fallback must split `ks.udt` before the bare-keyed lookup, or
+// the value silently degrades to `Blob`.
+#[cfg(test)]
+mod regression_2807_qualified_udt_decode_tests;
+
 impl V5CompressedLegacyParser {
     /// Create a new V5CompressedLegacy parser
     ///

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_type_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_type_value.rs
@@ -774,7 +774,7 @@ impl V5CompressedLegacyParser {
                                         .strip_prefix("udt:")
                                         .unwrap_or(nested_type_name);
                                     if let Some(nested_udt) =
-                                        registry.get_udt(&self.keyspace, lookup_name)
+                                        registry.get_udt_qualified(&self.keyspace, lookup_name)
                                     {
                                         self.parse_nested_udt_from_registry(
                                             field_data, nested_udt, registry,
@@ -789,7 +789,7 @@ impl V5CompressedLegacyParser {
                                 CqlType::Udt(udt_name, inline_fields) => {
                                     // Prefer registry, fall back to inline fields (Issue #239)
                                     if let Some(nested_udt) =
-                                        registry.get_udt(&self.keyspace, udt_name)
+                                        registry.get_udt_qualified(&self.keyspace, udt_name)
                                     {
                                         self.parse_nested_udt_from_registry(
                                             field_data, nested_udt, registry,
@@ -815,7 +815,7 @@ impl V5CompressedLegacyParser {
                                             .strip_prefix("udt:")
                                             .unwrap_or(nested_type_name);
                                         if let Some(nested_udt) =
-                                            registry.get_udt(&self.keyspace, lookup_name)
+                                            registry.get_udt_qualified(&self.keyspace, lookup_name)
                                         {
                                             let inner_value = self.parse_nested_udt_from_registry(
                                                 field_data, nested_udt, registry,
@@ -831,7 +831,7 @@ impl V5CompressedLegacyParser {
                                     CqlType::Udt(udt_name, inline_fields) => {
                                         // Prefer registry, fall back to inline fields (Issue #239)
                                         if let Some(nested_udt) =
-                                            registry.get_udt(&self.keyspace, udt_name)
+                                            registry.get_udt_qualified(&self.keyspace, udt_name)
                                         {
                                             let inner_value = self.parse_nested_udt_from_registry(
                                                 field_data, nested_udt, registry,
@@ -924,7 +924,7 @@ impl V5CompressedLegacyParser {
                 // Try to look up as UDT in registry by short name (Issue #238)
                 // This handles cases like "address_type" which aren't in full marshal format
                 if let Some(ref registry) = self.udt_registry {
-                    if let Some(udt_def) = registry.get_udt(&self.keyspace, type_str) {
+                    if let Some(udt_def) = registry.get_udt_qualified(&self.keyspace, type_str) {
                         tracing::debug!(
                             "Frozen element '{}': found UDT '{}' in registry, parsing {} fields",
                             column_name,
@@ -998,7 +998,7 @@ impl V5CompressedLegacyParser {
                                             .unwrap_or(nested_type_name);
                                         // Check if this is a nested UDT
                                         if let Some(nested_udt) =
-                                            registry.get_udt(&self.keyspace, lookup_name)
+                                            registry.get_udt_qualified(&self.keyspace, lookup_name)
                                         {
                                             // Recursively parse nested UDT
                                             self.parse_nested_udt_from_registry(
@@ -1012,7 +1012,7 @@ impl V5CompressedLegacyParser {
                                     CqlType::Udt(udt_name, inline_fields) => {
                                         // Prefer registry, fall back to inline fields (Issue #239)
                                         if let Some(nested_udt) =
-                                            registry.get_udt(&self.keyspace, udt_name)
+                                            registry.get_udt_qualified(&self.keyspace, udt_name)
                                         {
                                             self.parse_nested_udt_from_registry(
                                                 field_data, nested_udt, registry,
@@ -1036,8 +1036,8 @@ impl V5CompressedLegacyParser {
                                                 let lookup_name = nested_type_name
                                                     .strip_prefix("udt:")
                                                     .unwrap_or(nested_type_name);
-                                                if let Some(nested_udt) =
-                                                    registry.get_udt(&self.keyspace, lookup_name)
+                                                if let Some(nested_udt) = registry
+                                                    .get_udt_qualified(&self.keyspace, lookup_name)
                                                 {
                                                     let inner_value = self
                                                         .parse_nested_udt_from_registry(
@@ -1050,8 +1050,8 @@ impl V5CompressedLegacyParser {
                                             }
                                             CqlType::Udt(udt_name, inline_fields) => {
                                                 // Prefer registry, fall back to inline fields (Issue #239)
-                                                if let Some(nested_udt) =
-                                                    registry.get_udt(&self.keyspace, udt_name)
+                                                if let Some(nested_udt) = registry
+                                                    .get_udt_qualified(&self.keyspace, udt_name)
                                                 {
                                                     let inner_value = self
                                                         .parse_nested_udt_from_registry(

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_type_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_type_value.rs
@@ -769,12 +769,10 @@ impl V5CompressedLegacyParser {
                         let value = if let Some(ref registry) = self.udt_registry {
                             match &field_def.field_type {
                                 CqlType::Custom(nested_type_name) => {
-                                    // Issue #239: Handle "udt:" prefix from schema parsing
-                                    let lookup_name = nested_type_name
-                                        .strip_prefix("udt:")
-                                        .unwrap_or(nested_type_name);
+                                    // `get_udt_qualified` owns "udt:" + keyspace-
+                                    // qualifier normalization (Issue #239 / #2807).
                                     if let Some(nested_udt) =
-                                        registry.get_udt_qualified(&self.keyspace, lookup_name)
+                                        registry.get_udt_qualified(&self.keyspace, nested_type_name)
                                     {
                                         self.parse_nested_udt_from_registry(
                                             field_data, nested_udt, registry,
@@ -810,12 +808,10 @@ impl V5CompressedLegacyParser {
                                 }
                                 CqlType::Frozen(inner) => match inner.as_ref() {
                                     CqlType::Custom(nested_type_name) => {
-                                        // Issue #239: Handle "udt:" prefix from schema parsing
-                                        let lookup_name = nested_type_name
-                                            .strip_prefix("udt:")
-                                            .unwrap_or(nested_type_name);
-                                        if let Some(nested_udt) =
-                                            registry.get_udt_qualified(&self.keyspace, lookup_name)
+                                        // `get_udt_qualified` owns "udt:" + keyspace-
+                                        // qualifier normalization (Issue #239 / #2807).
+                                        if let Some(nested_udt) = registry
+                                            .get_udt_qualified(&self.keyspace, nested_type_name)
                                         {
                                             let inner_value = self.parse_nested_udt_from_registry(
                                                 field_data, nested_udt, registry,
@@ -992,13 +988,10 @@ impl V5CompressedLegacyParser {
                                 // Parse field value - handle nested UDTs specially (including FROZEN<udt>)
                                 let value = match &field_def.field_type {
                                     CqlType::Custom(nested_type_name) => {
-                                        // Issue #239: Handle "udt:" prefix from schema parsing
-                                        let lookup_name = nested_type_name
-                                            .strip_prefix("udt:")
-                                            .unwrap_or(nested_type_name);
-                                        // Check if this is a nested UDT
-                                        if let Some(nested_udt) =
-                                            registry.get_udt_qualified(&self.keyspace, lookup_name)
+                                        // `get_udt_qualified` owns "udt:" + keyspace-
+                                        // qualifier normalization (Issue #239 / #2807).
+                                        if let Some(nested_udt) = registry
+                                            .get_udt_qualified(&self.keyspace, nested_type_name)
                                         {
                                             // Recursively parse nested UDT
                                             self.parse_nested_udt_from_registry(

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/raw_value.rs
@@ -468,7 +468,7 @@ impl V5CompressedLegacyParser {
                 // correct for already-extracted cell value bytes.
                 // See Issue #481 regression fix.
                 if let Some(ref registry) = self.udt_registry {
-                    if registry.get_udt(&self.keyspace, other).is_some() {
+                    if registry.get_udt_qualified(&self.keyspace, other).is_some() {
                         tracing::debug!(
                             "parse_value_from_raw_bytes: type '{}' for '{}' resolved as UDT via registry, delegating to parse_raw_type_value",
                             other,

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/regression_2807_qualified_udt_decode_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/regression_2807_qualified_udt_decode_tests.rs
@@ -94,20 +94,89 @@ fn unqualified_udt_type_name_still_decodes_to_struct() {
 }
 
 /// A genuinely-unregistered qualified reference must NOT falsely resolve: the
-/// split keyspace has no such UDT, so decode does not produce a populated struct
-/// (fail-open, never a fabricated type).
+/// split keyspace has no such UDT, so decode must not produce the registered UDT
+/// struct (fail-open, never a fabricated type). Fed the SAME 2-field payload the
+/// positive test uses, so the ONLY variable is the keyspace qualifier.
 #[test]
 fn qualified_reference_to_unknown_udt_does_not_resolve() {
     let parser = parser_with_registry();
-    let data = encode_udt(&["x"]);
+    let data = encode_udt(&["main st", "nyc"]);
 
-    // `other_ks.addr` splits to keyspace `other_ks`, which holds no `addr`.
+    // `other_ks.addr` splits to keyspace `other_ks`, which holds no `addr`; the
+    // non-regressive fallback (bare `other_ks.addr` in the default keyspace) also
+    // misses, so this must NOT decode to the registered `addr` struct.
     let result = parser.parse_raw_type_value(&data, 0, "other_ks.addr", "col", 0);
-    if let Ok((Value::Udt(udt), _)) = result {
-        assert_ne!(
-            udt.fields.len(),
-            2,
-            "an unknown-keyspace reference must not resolve to the registered addr struct"
-        );
+    assert!(
+        !matches!(result, Ok((Value::Udt(_), _))),
+        "unknown-keyspace qualified reference must not resolve to a UDT, got {result:?}"
+    );
+}
+
+/// Issue #2807 (addendum item 4): drive the SECOND silent-degradation site — the
+/// nested-field registry fallback in `parse_nested_udt_from_registry` (udt.rs) —
+/// through the decode surface. A three-level qualified nest
+/// (`outer{ m: mid }`, `mid{ leaf }`, `leaf{ v: text }`) forces a qualified
+/// `get_udt_qualified` lookup INSIDE the nested decoder, asserting the deepest
+/// field materializes as structured text, never a `Blob`.
+#[test]
+fn nested_qualified_udt_field_decodes_via_nested_registry_fallback() {
+    // A nested-UDT field typed as `Custom("udt:<qualified>")` — the exact shape
+    // `CqlType::parse` yields for a qualified UDT reference.
+    fn qualified_udt_field(qualified: &str) -> CqlType {
+        CqlType::Custom(format!("udt:{qualified}"))
     }
+
+    let mut reg = UdtRegistry::new();
+    reg.register_udt(
+        UdtTypeDef::new(KEYSPACE.to_string(), "leaf".to_string()).with_field(
+            "v".to_string(),
+            CqlType::Text,
+            true,
+        ),
+    );
+    reg.register_udt(
+        UdtTypeDef::new(KEYSPACE.to_string(), "mid".to_string()).with_field(
+            "leaf".to_string(),
+            qualified_udt_field("cassandra_easy_stress.leaf"),
+            true,
+        ),
+    );
+    reg.register_udt(
+        UdtTypeDef::new(KEYSPACE.to_string(), "outer".to_string()).with_field(
+            "m".to_string(),
+            qualified_udt_field("cassandra_easy_stress.mid"),
+            true,
+        ),
+    );
+    let parser = V5CompressedLegacyParser::new(KEYSPACE.to_string(), "t".to_string(), 0, 0, None)
+        .with_udt_registry(reg);
+
+    // Frame each level: one 4-byte-BE-prefixed field per UDT.
+    let leaf_bytes = encode_udt(&["deep"]); // leaf{ v = "deep" }
+    let mut mid_bytes = Vec::new();
+    mid_bytes.extend_from_slice(&(leaf_bytes.len() as i32).to_be_bytes());
+    mid_bytes.extend_from_slice(&leaf_bytes);
+    let mut outer_bytes = Vec::new();
+    outer_bytes.extend_from_slice(&(mid_bytes.len() as i32).to_be_bytes());
+    outer_bytes.extend_from_slice(&mid_bytes);
+
+    let (value, _off) = parser
+        .parse_raw_type_value(&outer_bytes, 0, "cassandra_easy_stress.outer", "col", 0)
+        .expect("qualified 3-level nested UDT must decode");
+
+    // outer.m → mid.leaf → leaf.v == "deep", all resolved via qualified lookups.
+    let outer = match value {
+        Value::Udt(u) => u,
+        other => panic!("outer must be Udt, got {other:?}"),
+    };
+    let mid = match outer.fields[0].value.as_ref() {
+        Some(Value::Udt(u)) => u,
+        other => panic!("outer.m must decode to a nested Udt, got {other:?} (Blob = the bug)"),
+    };
+    let leaf = match mid.fields[0].value.as_ref() {
+        Some(Value::Udt(u)) => u,
+        other => panic!("mid.leaf must decode to a nested Udt, got {other:?} (Blob = the bug)"),
+    };
+    assert_eq!(leaf.type_name, "leaf");
+    assert_eq!(leaf.fields[0].value, Some(Value::Text("deep".into())));
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/regression_2807_qualified_udt_decode_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/regression_2807_qualified_udt_decode_tests.rs
@@ -1,0 +1,113 @@
+//! Regression tests for issue #2807 — the DECODE surface for keyspace-qualified
+//! UDT type names.
+//!
+//! Cassandra emits UDT column types keyspace-qualified (`frozen<ks.addr>`), which
+//! the CQL parser now RETAINS in `column.data_type`. The registry is keyed by BARE
+//! name, so a plain `get_udt(&self.keyspace, "ks.addr")` MISSES and the value
+//! silently degrades to `Blob` (worse than the pre-fix hard parse failure). These
+//! tests drive the reader's registry-backed decode fallback
+//! ([`V5CompressedLegacyParser::parse_raw_type_value`], `pub(super)`, reachable
+//! from this child module) with a QUALIFIED type name and assert the UDT
+//! materializes as a STRUCTURED [`crate::Value::Udt`], never a `Blob` — proving the
+//! lookups route through the qualifier-aware
+//! [`crate::schema::UdtRegistry::get_udt_qualified`].
+//!
+//! These carry NO dataset/reader/feature-flag dependency: `parse_raw_type_value`
+//! is a `pub(super)` method on a plainly-constructed parser, so they run in every
+//! build/lane (never a vacuous 0-row skip).
+
+use super::V5CompressedLegacyParser;
+use crate::schema::{CqlType, UdtRegistry};
+use crate::types::UdtTypeDef;
+use crate::Value;
+
+const KEYSPACE: &str = "cassandra_easy_stress";
+
+/// Registry holding a bare-keyed `addr` UDT (street text, city text) in
+/// `cassandra_easy_stress` — exactly how `udt_registry_from_cql` keys a
+/// `CREATE TYPE cassandra_easy_stress.addr (...)`.
+fn registry_with_addr() -> UdtRegistry {
+    let mut reg = UdtRegistry::new();
+    reg.register_udt(
+        UdtTypeDef::new(KEYSPACE.to_string(), "addr".to_string())
+            .with_field("street".to_string(), CqlType::Text, true)
+            .with_field("city".to_string(), CqlType::Text, true),
+    );
+    reg
+}
+
+/// Encode a frozen-context UDT body: each field is a 4-byte big-endian i32 length
+/// prefix followed by the raw field bytes (text = raw UTF-8).
+fn encode_udt(fields: &[&str]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for f in fields {
+        out.extend_from_slice(&(f.len() as i32).to_be_bytes());
+        out.extend_from_slice(f.as_bytes());
+    }
+    out
+}
+
+fn parser_with_registry() -> V5CompressedLegacyParser {
+    V5CompressedLegacyParser::new(KEYSPACE.to_string(), "t".to_string(), 0, 0, None)
+        .with_udt_registry(registry_with_addr())
+}
+
+/// The core #2807 decode assertion: a KEYSPACE-QUALIFIED type name
+/// (`cassandra_easy_stress.addr`) resolves the bare-keyed registry entry and
+/// decodes to a structured `Value::Udt` — NOT a `Blob`.
+#[test]
+fn qualified_udt_type_name_decodes_to_struct_not_blob() {
+    let parser = parser_with_registry();
+    let data = encode_udt(&["main st", "nyc"]);
+
+    let (value, _off) = parser
+        .parse_raw_type_value(&data, 0, "cassandra_easy_stress.addr", "col", 0)
+        .expect("qualified UDT type name must decode via the registry");
+
+    match value {
+        Value::Udt(udt) => {
+            assert_eq!(udt.type_name, "addr", "resolved to the bare-keyed UDT");
+            assert_eq!(udt.fields.len(), 2, "street + city materialized");
+            assert_eq!(udt.fields[0].name, "street");
+            assert_eq!(udt.fields[0].value, Some(Value::Text("main st".into())));
+        }
+        other => {
+            panic!("qualified UDT must decode to Value::Udt, got {other:?} (Blob = the #2807 bug)")
+        }
+    }
+}
+
+/// The unqualified form must still decode identically (regression guard).
+#[test]
+fn unqualified_udt_type_name_still_decodes_to_struct() {
+    let parser = parser_with_registry();
+    let data = encode_udt(&["main st", "nyc"]);
+
+    let (value, _off) = parser
+        .parse_raw_type_value(&data, 0, "addr", "col", 0)
+        .expect("bare UDT type name must still decode");
+
+    assert!(
+        matches!(value, Value::Udt(ref udt) if udt.type_name == "addr" && udt.fields.len() == 2),
+        "unqualified `addr` must still resolve to the struct, got {value:?}"
+    );
+}
+
+/// A genuinely-unregistered qualified reference must NOT falsely resolve: the
+/// split keyspace has no such UDT, so decode does not produce a populated struct
+/// (fail-open, never a fabricated type).
+#[test]
+fn qualified_reference_to_unknown_udt_does_not_resolve() {
+    let parser = parser_with_registry();
+    let data = encode_udt(&["x"]);
+
+    // `other_ks.addr` splits to keyspace `other_ks`, which holds no `addr`.
+    let result = parser.parse_raw_type_value(&data, 0, "other_ks.addr", "col", 0);
+    if let Ok((Value::Udt(udt), _)) = result {
+        assert_ne!(
+            udt.fields.len(),
+            2,
+            "an unknown-keyspace reference must not resolve to the registered addr struct"
+        );
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/udt.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/udt.rs
@@ -993,12 +993,10 @@ impl V5CompressedLegacyParser {
                 // Handle deeply nested UDTs (including FROZEN<udt> types)
                 let value = match &field_def.field_type {
                     CqlType::Custom(nested_type_name) => {
-                        // Issue #239: Handle "udt:" prefix from schema parsing
-                        let lookup_name = nested_type_name
-                            .strip_prefix("udt:")
-                            .unwrap_or(nested_type_name);
+                        // `get_udt_qualified` owns "udt:" + keyspace-qualifier
+                        // normalization (Issue #239 / #2807).
                         if let Some(nested_udt) =
-                            registry.get_udt_qualified(&self.keyspace, lookup_name)
+                            registry.get_udt_qualified(&self.keyspace, nested_type_name)
                         {
                             self.parse_nested_udt_from_registry(field_data, nested_udt, registry)?
                         } else {
@@ -1030,12 +1028,10 @@ impl V5CompressedLegacyParser {
                         // Handle FROZEN<udt_type> - the inner type may be a UDT
                         match inner.as_ref() {
                             CqlType::Custom(nested_type_name) => {
-                                // Issue #239: Handle "udt:" prefix from schema parsing
-                                let lookup_name = nested_type_name
-                                    .strip_prefix("udt:")
-                                    .unwrap_or(nested_type_name);
+                                // `get_udt_qualified` owns "udt:" + keyspace-qualifier
+                                // normalization (Issue #239 / #2807).
                                 if let Some(nested_udt) =
-                                    registry.get_udt_qualified(&self.keyspace, lookup_name)
+                                    registry.get_udt_qualified(&self.keyspace, nested_type_name)
                                 {
                                     let inner_value = self.parse_nested_udt_from_registry(
                                         field_data, nested_udt, registry,

--- a/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/udt.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/udt.rs
@@ -997,7 +997,9 @@ impl V5CompressedLegacyParser {
                         let lookup_name = nested_type_name
                             .strip_prefix("udt:")
                             .unwrap_or(nested_type_name);
-                        if let Some(nested_udt) = registry.get_udt(&self.keyspace, lookup_name) {
+                        if let Some(nested_udt) =
+                            registry.get_udt_qualified(&self.keyspace, lookup_name)
+                        {
                             self.parse_nested_udt_from_registry(field_data, nested_udt, registry)?
                         } else {
                             Value::Blob(
@@ -1009,7 +1011,9 @@ impl V5CompressedLegacyParser {
                     }
                     CqlType::Udt(udt_name, inline_fields) => {
                         // Inline UDT type - prefer registry, fall back to inline fields (Issue #239)
-                        if let Some(nested_udt) = registry.get_udt(&self.keyspace, udt_name) {
+                        if let Some(nested_udt) =
+                            registry.get_udt_qualified(&self.keyspace, udt_name)
+                        {
                             self.parse_nested_udt_from_registry(field_data, nested_udt, registry)?
                         } else if !inline_fields.is_empty() {
                             // Issue #239: Use inline field definitions for nested UDTs
@@ -1031,7 +1035,7 @@ impl V5CompressedLegacyParser {
                                     .strip_prefix("udt:")
                                     .unwrap_or(nested_type_name);
                                 if let Some(nested_udt) =
-                                    registry.get_udt(&self.keyspace, lookup_name)
+                                    registry.get_udt_qualified(&self.keyspace, lookup_name)
                                 {
                                     let inner_value = self.parse_nested_udt_from_registry(
                                         field_data, nested_udt, registry,
@@ -1043,7 +1047,8 @@ impl V5CompressedLegacyParser {
                             }
                             CqlType::Udt(udt_name, inline_fields) => {
                                 // Prefer registry, fall back to inline fields (Issue #239)
-                                if let Some(nested_udt) = registry.get_udt(&self.keyspace, udt_name)
+                                if let Some(nested_udt) =
+                                    registry.get_udt_qualified(&self.keyspace, udt_name)
                                 {
                                     let inner_value = self.parse_nested_udt_from_registry(
                                         field_data, nested_udt, registry,

--- a/cqlite-core/src/storage/sstable/writer/data_writer/schema_helpers.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/schema_helpers.rs
@@ -428,7 +428,7 @@ fn render_udt_reference(
     // `keyspace.udt` reference contributes its explicit keyspace + bare name to
     // the marshal (the `UserType(...)` carries an unqualified hex name —
     // roborev #1020 Finding 1).
-    let (ref_keyspace, bare_name) = split_qualified_udt(name, keyspace);
+    let (ref_keyspace, bare_name) = crate::schema::split_qualified_udt(name, keyspace);
     let mut out = String::from("org.apache.cassandra.db.marshal.UserType(");
     out.push_str(ref_keyspace);
     out.push(',');
@@ -443,35 +443,20 @@ fn render_udt_reference(
     out
 }
 
-/// Split a possibly KEYSPACE-QUALIFIED UDT reference `name` into its
-/// `(lookup_keyspace, bare_name)` (roborev #1020 Finding 1). A reference may be
-/// written `keyspace.udt` (the schema parser + validation honor this form — see
-/// `TableSchema::ensure_udt_exists`); when qualified, the explicit keyspace is
-/// used, otherwise the table's `default_keyspace`. The registry keys UDTs by
-/// `(keyspace, bare_name)` (see `UdtRegistry::get_udt`), so resolution everywhere
-/// MUST go through this split — otherwise `frozen<test_ks.person>` never matches
-/// the registry and silently falls back to `BytesType` (the exact #1020 bug, for
-/// qualified names).
-fn split_qualified_udt<'a>(name: &'a str, default_keyspace: &'a str) -> (&'a str, &'a str) {
-    match name.split_once('.') {
-        Some((ks, bare)) => (ks, bare),
-        None => (default_keyspace, name),
-    }
-}
-
 /// Resolve a UDT name in `registry` for `keyspace`: exact match first, then an
 /// unambiguous case-insensitive match (unquoted CQL identifiers are
 /// case-insensitive). Ambiguous case-insensitive matches resolve to `None`.
 ///
 /// `name` may be KEYSPACE-QUALIFIED (`keyspace.udt`); the explicit keyspace wins
-/// over `keyspace` when present (roborev #1020 Finding 1, via
-/// [`split_qualified_udt`]).
+/// over `keyspace` when present (roborev #1020 Finding 1, via the shared
+/// [`crate::schema::split_qualified_udt`], promoted here to the schema module in
+/// issue #2807 so the read path shares it).
 fn resolve_registered_udt<'a>(
     name: &str,
     keyspace: &str,
     registry: &'a UdtRegistry,
 ) -> Option<&'a UdtTypeDef> {
-    let (lookup_keyspace, bare_name) = split_qualified_udt(name, keyspace);
+    let (lookup_keyspace, bare_name) = crate::schema::split_qualified_udt(name, keyspace);
     if let Some(udt) = registry.get_udt(lookup_keyspace, bare_name) {
         return Some(udt);
     }
@@ -736,7 +721,7 @@ pub(crate) fn cql_type_references_udt(
             // `clean` may be KEYSPACE-QUALIFIED (`keyspace.udt`); resolve the
             // registry under the explicit keyspace when present, else `keyspace`
             // (roborev #1020 Finding 1, via `split_qualified_udt`).
-            let (lookup_keyspace, bare_name) = split_qualified_udt(clean, keyspace);
+            let (lookup_keyspace, bare_name) = crate::schema::split_qualified_udt(clean, keyspace);
             name.starts_with("udt:")
                 || registry.get_udt(lookup_keyspace, bare_name).is_some()
                 || registry

--- a/cqlite-core/tests/qualified_udt_schema_parse.rs
+++ b/cqlite-core/tests/qualified_udt_schema_parse.rs
@@ -161,6 +161,83 @@ fn quoted_case_sensitive_qualified_udt_resolves_against_registry() {
     }
 }
 
+/// Newly reachable via the grammar fix (#2807 addendum case a): a `CREATE TYPE`
+/// whose FIELD type is itself keyspace-qualified previously FAILED to parse (so it
+/// never registered); now it registers with a qualified field type that the NESTED
+/// registry lookups must resolve through the shared splitter. This drives the
+/// authoritative DDL→registry resolver over a two-level qualified UDT and asserts
+/// the inner UDT fully materializes.
+#[test]
+fn nested_qualified_udt_field_type_resolves() {
+    let ks = "cassandra_easy_stress";
+    let ddl = "CREATE TYPE cassandra_easy_stress.inner (v text); \
+        CREATE TYPE cassandra_easy_stress.outer (n frozen<cassandra_easy_stress.inner>);";
+    let registry = udt_registry_from_cql(ddl, ks);
+    assert!(registry.contains_udt(ks, "inner"));
+    assert!(registry.contains_udt(ks, "outer"));
+
+    let outer = CqlType::parse("frozen<cassandra_easy_stress.outer>").expect("outer type parses");
+    let resolved = registry.resolve_type(&outer, ks);
+    // frozen<outer> → outer{ n: frozen<inner> } → inner{ v: text }
+    let outer_fields = match &resolved {
+        CqlType::Frozen(i) => match i.as_ref() {
+            CqlType::Udt(name, fields) => {
+                assert_eq!(name, "outer");
+                fields
+            }
+            other => panic!("expected outer Udt, got {other:?}"),
+        },
+        other => panic!("expected Frozen, got {other:?}"),
+    };
+    let (_, n_type) = outer_fields
+        .iter()
+        .find(|(n, _)| n == "n")
+        .expect("field n");
+    // The nested qualified field type must have resolved to the full inner struct.
+    let inner_fields = match n_type {
+        CqlType::Frozen(i) => match i.as_ref() {
+            CqlType::Udt(name, fields) => {
+                assert_eq!(name, "inner");
+                fields
+            }
+            other => panic!("nested field must resolve to inner Udt, got {other:?}"),
+        },
+        CqlType::Udt(name, fields) => {
+            assert_eq!(name, "inner");
+            fields
+        }
+        other => panic!("nested field must resolve to inner Udt, got {other:?}"),
+    };
+    assert_eq!(inner_fields.len(), 1);
+    assert_eq!(inner_fields[0].0, "v");
+}
+
+/// Newly reachable (#2807 addendum case b): a qualified frozen UDT in a
+/// partition-KEY position. `parse_create_table` copies the column `data_type` into
+/// the `KeyColumn`, so the qualifier must survive there too and resolve.
+#[test]
+fn qualified_udt_in_partition_key_position_parses_and_resolves() {
+    let ks = "cassandra_easy_stress";
+    let schema = parse_cql_schema(
+        "CREATE TABLE cassandra_easy_stress.t (\
+            id frozen<cassandra_easy_stress.addr>, v text, PRIMARY KEY (id));",
+    )
+    .expect("qualified UDT in key position must parse (#2807)");
+
+    let pk = &schema.partition_keys[0];
+    assert_eq!(pk.name, "id");
+    assert_eq!(pk.data_type, "frozen<cassandra_easy_stress.addr>");
+
+    let registry =
+        udt_registry_from_cql("CREATE TYPE cassandra_easy_stress.addr (street text);", ks);
+    let resolved =
+        registry.resolve_type(&CqlType::parse(&pk.data_type).expect("key type parses"), ks);
+    assert!(
+        find_resolved_addr(&resolved).is_some(),
+        "partition-key UDT must resolve to a struct, got {resolved:?}"
+    );
+}
+
 /// Walk a (possibly collection-wrapped) resolved type and return the `addr` UDT's
 /// populated fields, or `None` if it never resolved to a struct.
 fn find_resolved_addr(ty: &CqlType) -> Option<&Vec<(String, CqlType)>> {

--- a/cqlite-core/tests/qualified_udt_schema_parse.rs
+++ b/cqlite-core/tests/qualified_udt_schema_parse.rs
@@ -1,0 +1,174 @@
+//! Issue #2807: keyspace-qualified UDT type names in CQL schemas.
+//!
+//! Cassandra's `CREATE TABLE` / `describe` output ALWAYS emits UDT column types
+//! keyspace-qualified (e.g. `list<frozen<cassandra_easy_stress.addr>>`). Before
+//! this fix the nom schema parser rejected the `.` in the qualified type name
+//! (`identifier` stops at `.`), so every table with a UDT column failed to parse
+//! and was unreadable via Flight `do_get`.
+//!
+//! These tests exercise the SAME public schema-parse surface the Flight
+//! `get_schema` path uses — [`cqlite_core::schema::parse_cql_schema`] — plus the
+//! authoritative DDL→registry resolver
+//! [`cqlite_core::schema::udt_registry_from_cql`] / [`UdtRegistry::resolve_type`],
+//! proving both the grammar fix AND that the parser and registry key qualified
+//! UDT references IDENTICALLY (bare name + separate keyspace) so the column
+//! actually resolves rather than silently missing (the #2349 degradation class).
+
+use cqlite_core::schema::{parse_cql_schema, udt_registry_from_cql, CqlType};
+
+fn data_type_of<'a>(schema: &'a cqlite_core::schema::TableSchema, col: &str) -> &'a str {
+    schema
+        .columns
+        .iter()
+        .find(|c| c.name == col)
+        .unwrap_or_else(|| panic!("column {col} missing from parsed schema"))
+        .data_type
+        .as_str()
+}
+
+#[test]
+fn qualified_udt_in_frozen_collection_parses() {
+    let cql = "CREATE TABLE t (key text PRIMARY KEY, \
+        u1 list<frozen<cassandra_easy_stress.addr>>)";
+    let schema = parse_cql_schema(cql).expect("qualified-UDT DDL must parse (#2807)");
+    assert_eq!(
+        data_type_of(&schema, "u1"),
+        "list<frozen<cassandra_easy_stress.addr>>"
+    );
+}
+
+#[test]
+fn qualified_scalar_udt_column_parses() {
+    let cql = "CREATE TABLE t (key text PRIMARY KEY, a frozen<cassandra_easy_stress.addr>)";
+    let schema = parse_cql_schema(cql).expect("qualified-UDT DDL must parse (#2807)");
+    assert_eq!(
+        data_type_of(&schema, "a"),
+        "frozen<cassandra_easy_stress.addr>"
+    );
+}
+
+/// The exact field-failure shape: a realistic `CREATE TABLE` as Cassandra's
+/// `describe` emits it, with qualified UDTs in every collection position.
+#[test]
+fn full_create_table_with_qualified_udts_parses() {
+    let cql = "CREATE TABLE cassandra_easy_stress.t (\
+        key text, \
+        u1 list<frozen<cassandra_easy_stress.addr>>, \
+        u2 frozen<cassandra_easy_stress.addr>, \
+        m map<text, frozen<cassandra_easy_stress.addr>>, \
+        s set<frozen<cassandra_easy_stress.addr>>, \
+        PRIMARY KEY (key));";
+    let schema = parse_cql_schema(cql).expect("qualified-UDT DDL must parse (#2807)");
+    assert_eq!(
+        data_type_of(&schema, "u1"),
+        "list<frozen<cassandra_easy_stress.addr>>"
+    );
+    assert_eq!(
+        data_type_of(&schema, "u2"),
+        "frozen<cassandra_easy_stress.addr>"
+    );
+    assert_eq!(
+        data_type_of(&schema, "m"),
+        "map<text, frozen<cassandra_easy_stress.addr>>"
+    );
+    assert_eq!(
+        data_type_of(&schema, "s"),
+        "set<frozen<cassandra_easy_stress.addr>>"
+    );
+}
+
+/// Regression: the UNqualified UDT form must still parse unchanged.
+#[test]
+fn unqualified_udt_still_parses() {
+    let cql = "CREATE TABLE t (key text PRIMARY KEY, a frozen<addr>, b addr)";
+    let schema = parse_cql_schema(cql).expect("unqualified UDT must still parse");
+    assert_eq!(data_type_of(&schema, "a"), "frozen<addr>");
+    assert_eq!(data_type_of(&schema, "b"), "addr");
+}
+
+/// CONNECTION test: BOTH a keyspace-qualified `CREATE TYPE` AND a table whose UDT
+/// columns reference it keyspace-qualified in every collection position — proving
+/// the parser fix (which RETAINS the `keyspace.` prefix) and the registry (keyed
+/// by bare name + separate keyspace) key types IDENTICALLY, so the column
+/// actually resolves against the registry entry rather than silently missing.
+#[test]
+fn qualified_udt_column_resolves_against_registry_from_field_ddl() {
+    let ks = "cassandra_easy_stress";
+    let create_type = "CREATE TYPE cassandra_easy_stress.addr (street text, city text, zip int);";
+    let create_table = "CREATE TABLE cassandra_easy_stress.t (\
+        key text, \
+        u1 list<frozen<cassandra_easy_stress.addr>>, \
+        u2 frozen<cassandra_easy_stress.addr>, \
+        m map<text, frozen<cassandra_easy_stress.addr>>, \
+        s set<frozen<cassandra_easy_stress.addr>>, \
+        PRIMARY KEY (key));";
+
+    // Registry built from the CREATE TYPE (the Flight read path resolves a
+    // ticket's DDL through this exact function).
+    let registry = udt_registry_from_cql(create_type, ks);
+    assert!(
+        registry.contains_udt(ks, "addr"),
+        "registry keyed by bare `addr` in keyspace `{ks}`"
+    );
+
+    // Table parsed through the PUBLIC schema-parse surface Flight uses.
+    let schema = parse_cql_schema(create_table).expect("qualified-UDT DDL must parse (#2807)");
+
+    // Every UDT column's declared type must resolve to a full struct (street,
+    // city, zip) via the registry — not stay an opaque unresolved reference.
+    for col_name in ["u1", "u2", "m", "s"] {
+        let parsed = CqlType::parse(data_type_of(&schema, col_name))
+            .unwrap_or_else(|e| panic!("column {col_name} type must parse: {e:?}"));
+        let resolved = registry.resolve_type(&parsed, ks);
+        let fields = find_resolved_addr(&resolved).unwrap_or_else(|| {
+            panic!("{col_name}: `addr` did not resolve to a populated struct: {resolved:?}")
+        });
+        assert_eq!(fields.len(), 3, "{col_name}: addr has street+city+zip");
+        assert_eq!(fields[0].0, "street", "{col_name}");
+    }
+}
+
+/// Cassandra emits case-sensitive UDT names quoted (`frozen<ks."MyType">`). The
+/// grammar supports quoted identifiers in the UDT type position; CREATE TYPE and
+/// the column reference both normalize through the same quote-stripping
+/// identifier, so they key identically and the column resolves.
+#[test]
+fn quoted_case_sensitive_qualified_udt_resolves_against_registry() {
+    let ks = "ks";
+    let registry = udt_registry_from_cql(r#"CREATE TYPE ks."MyAddr" (street text);"#, ks);
+    assert!(
+        registry.contains_udt(ks, "MyAddr"),
+        "quoted CREATE TYPE keys the bare, case-preserved `MyAddr`"
+    );
+
+    let schema = parse_cql_schema(
+        r#"CREATE TABLE ks.t (key text, a frozen<ks."MyAddr">, PRIMARY KEY (key));"#,
+    )
+    .expect("quoted qualified-UDT DDL must parse (#2807)");
+    let resolved = registry.resolve_type(
+        &CqlType::parse(data_type_of(&schema, "a")).expect("type must parse"),
+        ks,
+    );
+    match &resolved {
+        CqlType::Frozen(inner) => match inner.as_ref() {
+            CqlType::Udt(name, fields) => {
+                assert_eq!(name, "MyAddr", "case-preserved bare node name");
+                assert_eq!(fields.len(), 1);
+            }
+            other => panic!("expected resolved Udt, got {other:?}"),
+        },
+        other => panic!("expected Frozen, got {other:?}"),
+    }
+}
+
+/// Walk a (possibly collection-wrapped) resolved type and return the `addr` UDT's
+/// populated fields, or `None` if it never resolved to a struct.
+fn find_resolved_addr(ty: &CqlType) -> Option<&Vec<(String, CqlType)>> {
+    match ty {
+        CqlType::Udt(name, fields) if name == "addr" && !fields.is_empty() => Some(fields),
+        CqlType::List(i) | CqlType::Set(i) | CqlType::Frozen(i) => find_resolved_addr(i),
+        CqlType::Map(k, v) => find_resolved_addr(k).or_else(|| find_resolved_addr(v)),
+        CqlType::Tuple(ts) => ts.iter().find_map(find_resolved_addr),
+        _ => None,
+    }
+}


### PR DESCRIPTION
Closes #2807. Field-verified on 0.16.0-rc1 (AWS easy-db-lab round #2805, Probe B): every Cassandra table with a UDT column was unreadable via Flight — the CQL schema parser rejected keyspace-qualified UDT type names (`frozen<cassandra_easy_stress.addr>`, the form Cassandra always emits) with a nom `Char` error.

## What

- **Parser**: new `qualified_type_name` (mirrors `qualified_table_name`); `parse_type_inner`'s UDT branch accepts an optional `keyspace.` prefix, retained verbatim.
- **Decode path** (review-first blocker, caught by rust-reviewer + roborev independently): the reader's 15 registry-fallback lookups called `get_udt()` with the unsplit qualified string against a bare-keyed registry → silent `Value::Blob` degradation. Promoted the write path's `split_qualified_udt` to `crate::schema` (single shared splitter), added `UdtRegistry::get_udt_qualified` (split lookup, DDL qualifier wins; unsplit-reference fallback on miss so the change is strictly non-regressive), converted all 15 sites.
- **Tests** (public surfaces): `cqlite-core/tests/qualified_udt_schema_parse.rs` — all collection positions, scalar, key-position, nested qualified field types, quoted case-sensitive form, registry-connection assertions, unqualified regression; `row_decoder/regression_2807_qualified_udt_decode_tests.rs` — decode-surface proof that qualified UDT cells materialize as structured `Value::Udt` (not Blob) through the exact previously-broken fallback branch, incl. a 3-level qualified nest and a non-vacuous negative case.

## Review trail
Review-first per #2086: rust-reviewer + roborev on the lite-green diff; 1 blocker + 2 Medium fixed across two rounds; focused re-review confirmed every reader lookup site is qualified-aware (grep-verified zero raw `get_udt` in the row decoder). Residual nits batched to a follow-up issue (linked after filing).

Field re-validation: the AWS team's Probe B (cold + warm vs sstabledump, field-for-field) re-runs against the next 0.16 build — tracked on #2805.
