### PR TITLE
fix(#2806): split pruning reads handle-borne bound-key tokens — prunes through the real pushdown path

### DIFF
--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -16,6 +16,7 @@ import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.expression.Call;
@@ -219,12 +220,22 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             return Optional.empty();
         }
 
+        // Precompute the fully-bound partition key's covering token(s) NOW (issue #2806),
+        // while the TYPED partition-key domain is still in hand. applyFilter pushes the PK
+        // predicate into filterJson and returns the summary UNENFORCED, so the enforced
+        // Constraint later handed to getSplits binds no columns — the bound key must ride on
+        // the handle for the split manager to prune (issue #2679). When this call does not
+        // fully bind the PK we INHERIT any tokens a prior applyFilter call attached: the PK,
+        // once equality-bound, stays bound across the iterative applyFilter calls, and a
+        // superset of covering ranges is always correct (never drops rows).
+        List<Long> boundKeyTokens = boundKeyTokensFor(table, constraint.getSummary());
+
         // Preserve any pushed-down LIMIT (#2129): this branch only runs for a
         // non-aggregated handle, so aggregation/finalize stay empty, but a prior
         // applyLimit's cap must NOT be dropped when the handle is rebuilt.
         CqliteFlightTableHandle newHandle = new CqliteFlightTableHandle(
                 table.keyspace(), table.table(), table.ddl(),
-                Optional.of(filterJson), Optional.empty(), Optional.empty(), table.limit());
+                Optional.of(filterJson), Optional.empty(), Optional.empty(), table.limit(), boundKeyTokens);
 
         // The residual expression Trino must still evaluate (the untranslatable
         // conjuncts, ANDed). Empty residual => TRUE (fully pushed).
@@ -239,6 +250,28 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
                 constraint.getSummary(),
                 remainingExpression,
                 false));
+    }
+
+    /**
+     * The covering Murmur3 token(s) to attach to the rebuilt handle for plan-time split
+     * pruning (issues #2806, #2679). Derives them from the TYPED summary via the single
+     * {@link CqliteFlightSplitManager#computeBoundTokens} authority (partitioner check +
+     * composite-PK arity guard + serialization, all fail-safe). When this call does not
+     * fully bind the partition key it INHERITS whatever tokens {@code table} already
+     * carries — a later mixed-predicate applyFilter call must not drop a PK bound by an
+     * earlier one.
+     */
+    private List<Long> boundKeyTokensFor(CqliteFlightTableHandle table, TupleDomain<ColumnHandle> summary) {
+        Optional<long[]> tokens =
+                CqliteFlightSplitManager.computeBoundTokens(table, summary, Partitioner.resolve());
+        if (tokens.isEmpty()) {
+            return table.boundKeyTokens();
+        }
+        List<Long> out = new ArrayList<>(tokens.get().length);
+        for (long token : tokens.get()) {
+            out.add(token);
+        }
+        return out;
     }
 
     /**
@@ -292,10 +325,13 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             return Optional.empty();
         }
 
+        // Preserve any precomputed bound-key tokens (issue #2806): a point read with a LIMIT
+        // (WHERE key = ? LIMIT n) has both applyFilter and applyLimit rebuild the handle; the
+        // pruning tokens attached by applyFilter must survive this rebuild.
         CqliteFlightTableHandle newHandle = new CqliteFlightTableHandle(
                 table.keyspace(), table.table(), table.ddl(),
                 table.filterJson(), table.aggregationJson(), table.finalizePlanJson(),
-                OptionalLong.of(limit));
+                OptionalLong.of(limit), table.boundKeyTokens());
 
         return Optional.of(new LimitApplicationResult<>(newHandle, false, false));
     }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -229,6 +229,16 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
         // once equality-bound, stays bound across the iterative applyFilter calls, and a
         // superset of covering ranges is always correct (never drops rows).
         List<Long> boundKeyTokens = boundKeyTokensFor(table, constraint.getSummary());
+        if (boundKeyTokens.isEmpty()) {
+            // A filter WAS pushed but the partition key was not fully bound in the summary
+            // (the inert case this issue exists for, #2806) — e.g. a partial PK, a range, or a
+            // PK predicate that arrived via the expression channel with an ALL summary. Pruning
+            // stays correctly inert (full fan-out); logged at DEBUG so the field probe can see it.
+            LOG.log(System.Logger.Level.DEBUG,
+                    () -> "Split pruning inert for " + table.keyspace() + "." + table.table()
+                            + ": a filter was pushed but the constraint summary did not fully bind "
+                            + "the partition key; using full fan-out (always correct)");
+        }
 
         // Preserve any pushed-down LIMIT (#2129): this branch only runs for a
         // non-aggregated handle, so aggregation/finalize stay empty, but a prior
@@ -262,8 +272,18 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * earlier one.
      */
     private List<Long> boundKeyTokensFor(CqliteFlightTableHandle table, TupleDomain<ColumnHandle> summary) {
-        Optional<long[]> tokens =
-                CqliteFlightSplitManager.computeBoundTokens(table, summary, Partitioner.resolve());
+        Optional<long[]> tokens;
+        try {
+            tokens = CqliteFlightSplitManager.computeBoundTokens(table, summary, Partitioner.resolve());
+        } catch (RuntimeException e) {
+            // Pruning is a best-effort optimization (fail-safe by contract): a plan-time
+            // RuntimeException while deriving covering tokens must never fail the query. Fall
+            // back to whatever tokens the handle already carries (full fan-out if none).
+            LOG.log(System.Logger.Level.DEBUG,
+                    "Bound-key token precompute failed for " + table.keyspace() + "." + table.table()
+                            + "; leaving split pruning to the split-time fallback (full fan-out)", e);
+            return table.boundKeyTokens();
+        }
         if (tokens.isEmpty()) {
             return table.boundKeyTokens();
         }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -2,6 +2,7 @@ package in.mcfad.cqlite.flight;
 
 import io.trino.spi.StandardErrorCode;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorSession;
@@ -10,6 +11,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedSplitSource;
+import io.trino.spi.predicate.TupleDomain;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -139,49 +141,27 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
             if (!pruningEnabled) {
                 return ranges;
             }
-            if (constraint == null) {
-                return ranges;
+            // Authoritative bound-key source (issue #2806): applyFilter pushes the point-read PK
+            // predicate into filterJson and returns the summary UNENFORCED (honesty contract,
+            // #2164), so the enforced Constraint here binds NO columns — the bound key rides on
+            // the handle, precomputed where the TYPED partition-key domain was available. Prefer
+            // it; only when the handle carries none do we fall back to deriving from the
+            // split-time constraint (the enforced-constraint path and the direct unit tests).
+            long[] tokens;
+            if (!handle.boundKeyTokens().isEmpty()) {
+                List<Long> stored = handle.boundKeyTokens();
+                tokens = new long[stored.size()];
+                for (int i = 0; i < tokens.length; i++) {
+                    tokens[i] = stored.get(i);
+                }
+            } else {
+                TupleDomain<ColumnHandle> summary = constraint == null ? null : constraint.getSummary();
+                Optional<long[]> derived = computeBoundTokens(handle, summary, partitioner);
+                if (derived.isEmpty()) {
+                    return ranges;
+                }
+                tokens = derived.get();
             }
-            if (partitioner != Partitioner.MURMUR3) {
-                LOG.log(System.Logger.Level.DEBUG,
-                        () -> "Split pruning disabled: partitioner " + partitioner
-                                + " is not Murmur3Partitioner; using full fan-out for "
-                                + handle.keyspace() + "." + handle.table());
-                return ranges;
-            }
-            List<KeyColumn> partitionKey = PrimaryKeyExtractor.extract(handle.ddl()).partitionKey();
-            // Fail-safe composite-PK consistency guard (issue #2679 roborev): the pruning path
-            // builds a composite partition-key byte layout whose Murmur3 token is correct ONLY
-            // when EVERY partition-key component is present, in order. PrimaryKeyExtractor was
-            // built for estimateGroupRatio (#944) where a parse MISS is fail-safe — but here an
-            // UNDER-count on a composite PK (e.g. a quoted identifier containing ')' closes the
-            // composite group early, so PRIMARY KEY ((a,b)) resolves to [a]) is CATASTROPHIC:
-            // it builds a single-component raw-byte key, computes the WRONG token, maps to the
-            // wrong range, and SILENTLY DROPS the partition's rows. Cross-check the extracted
-            // partition-key column count against an INDEPENDENT, quote-aware arity scan of the
-            // same DDL; prune only when they agree. Any disagreement — or an indeterminate
-            // arity — means we cannot be certain we have all components in the right order, so
-            // we fall back to the full fan-out (always correct). This subsumes the
-            // single-component case (1 == 1) unchanged.
-            java.util.OptionalInt arity = PrimaryKeyExtractor.partitionKeyArity(handle.ddl());
-            if (arity.isEmpty() || arity.getAsInt() != partitionKey.size()) {
-                LOG.log(System.Logger.Level.DEBUG,
-                        () -> "Split pruning skipped for " + handle.keyspace() + "." + handle.table()
-                                + " (full fan-out): partition-key parse is not provably complete — "
-                                + "extractor resolved " + partitionKey.size() + " component(s) but the "
-                                + "independent quote-aware arity scan found "
-                                + (arity.isEmpty() ? "an indeterminate count" : arity.getAsInt())
-                                + "; refusing to prune on a possibly under-counted composite key");
-                return ranges;
-            }
-            BoundPartitionKeys bound = BoundPartitionKeys.compute(constraint.getSummary(), partitionKey);
-            if (!bound.isBound()) {
-                LOG.log(System.Logger.Level.DEBUG,
-                        () -> "Split pruning skipped for " + handle.keyspace() + "." + handle.table()
-                                + " (full fan-out): " + bound.skipReason());
-                return ranges;
-            }
-            long[] tokens = bound.tokens().orElseThrow();
             List<CqliteFlightSplit> pruned = new ArrayList<>();
             for (CqliteFlightSplit split : ranges) {
                 if (rangeCoversAnyToken(split, tokens)) {
@@ -211,6 +191,62 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
                             + handle.keyspace() + "." + handle.table(), e);
             return ranges;
         }
+    }
+
+    /**
+     * Derive the Murmur3 covering token(s) for a fully-bound partition key from a TYPED
+     * {@link TupleDomain} summary, or {@link Optional#empty()} on ANY doubt (issue #2806).
+     *
+     * <p>This is the single authority for the fail-safe partitioner check, the composite-PK
+     * arity cross-check, and the {@link BoundPartitionKeys} serialization, shared by two
+     * callers: {@link CqliteFlightMetadata#applyFilter} precomputes the tokens here (where the
+     * typed partition-key domain is still in hand) and stores them on the handle, and
+     * {@link #pruneToBoundPartitionKey} calls it as the split-time fallback when the handle
+     * carries none. Empty means "do not prune" — the caller emits the always-correct full
+     * fan-out — and the reason is logged at DEBUG.
+     */
+    static Optional<long[]> computeBoundTokens(
+            CqliteFlightTableHandle handle, TupleDomain<ColumnHandle> summary, Partitioner partitioner) {
+        if (partitioner != Partitioner.MURMUR3) {
+            LOG.log(System.Logger.Level.DEBUG,
+                    () -> "Split pruning disabled: partitioner " + partitioner
+                            + " is not Murmur3Partitioner; using full fan-out for "
+                            + handle.keyspace() + "." + handle.table());
+            return Optional.empty();
+        }
+        List<KeyColumn> partitionKey = PrimaryKeyExtractor.extract(handle.ddl()).partitionKey();
+        // Fail-safe composite-PK consistency guard (issue #2679 roborev): the pruning path
+        // builds a composite partition-key byte layout whose Murmur3 token is correct ONLY
+        // when EVERY partition-key component is present, in order. PrimaryKeyExtractor was
+        // built for estimateGroupRatio (#944) where a parse MISS is fail-safe — but here an
+        // UNDER-count on a composite PK (e.g. a quoted identifier containing ')' closes the
+        // composite group early, so PRIMARY KEY ((a,b)) resolves to [a]) is CATASTROPHIC:
+        // it builds a single-component raw-byte key, computes the WRONG token, maps to the
+        // wrong range, and SILENTLY DROPS the partition's rows. Cross-check the extracted
+        // partition-key column count against an INDEPENDENT, quote-aware arity scan of the
+        // same DDL; prune only when they agree. Any disagreement — or an indeterminate
+        // arity — means we cannot be certain we have all components in the right order, so
+        // we fall back to the full fan-out (always correct). This subsumes the
+        // single-component case (1 == 1) unchanged.
+        java.util.OptionalInt arity = PrimaryKeyExtractor.partitionKeyArity(handle.ddl());
+        if (arity.isEmpty() || arity.getAsInt() != partitionKey.size()) {
+            LOG.log(System.Logger.Level.DEBUG,
+                    () -> "Split pruning skipped for " + handle.keyspace() + "." + handle.table()
+                            + " (full fan-out): partition-key parse is not provably complete — "
+                            + "extractor resolved " + partitionKey.size() + " component(s) but the "
+                            + "independent quote-aware arity scan found "
+                            + (arity.isEmpty() ? "an indeterminate count" : arity.getAsInt())
+                            + "; refusing to prune on a possibly under-counted composite key");
+            return Optional.empty();
+        }
+        BoundPartitionKeys bound = BoundPartitionKeys.compute(summary, partitionKey);
+        if (!bound.isBound()) {
+            LOG.log(System.Logger.Level.DEBUG,
+                    () -> "Split pruning skipped for " + handle.keyspace() + "." + handle.table()
+                            + " (full fan-out): " + bound.skipReason());
+            return Optional.empty();
+        }
+        return bound.tokens();
     }
 
     /** Does this split's {@code (start, end]} range (with wraparound) contain any of {@code tokens}? */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightSplitManager.java
@@ -148,7 +148,11 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
             // it; only when the handle carries none do we fall back to deriving from the
             // split-time constraint (the enforced-constraint path and the direct unit tests).
             long[] tokens;
-            if (!handle.boundKeyTokens().isEmpty()) {
+            // The handle-borne tokens are only ever attached under Murmur3 (applyFilter derives
+            // them via computeBoundTokens, which returns none for any other partitioner), so this
+            // fast path is Murmur3-only by construction. Gate on `partitioner` anyway so a
+            // non-Murmur3 split-time resolution can never consume Murmur3 tokens (fail-safe).
+            if (partitioner == Partitioner.MURMUR3 && !handle.boundKeyTokens().isEmpty()) {
                 List<Long> stored = handle.boundKeyTokens();
                 tokens = new long[stored.size()];
                 for (int i = 0; i < tokens.length; i++) {
@@ -207,6 +211,12 @@ public class CqliteFlightSplitManager implements ConnectorSplitManager {
      */
     static Optional<long[]> computeBoundTokens(
             CqliteFlightTableHandle handle, TupleDomain<ColumnHandle> summary, Partitioner partitioner) {
+        // Cheap short-circuit BEFORE any DDL regex work: an absent/ALL/NONE summary binds no
+        // partition key, so it can never fully bind. This runs on every optimizer iteration for
+        // every table, so skip the extract/arity parse when there is provably nothing to bind.
+        if (summary == null || summary.isAll() || summary.isNone()) {
+            return Optional.empty();
+        }
         if (partitioner != Partitioner.MURMUR3) {
             LOG.log(System.Logger.Level.DEBUG,
                     () -> "Split pruning disabled: partitioner " + partitioner

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightTableHandle.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightTableHandle.java
@@ -66,7 +66,7 @@ public record CqliteFlightTableHandle(
         boundKeyTokens = boundKeyTokens == null ? List.of() : List.copyOf(boundKeyTokens);
     }
 
-    /** Canonical-arity constructor without precomputed bound-key tokens (defaults to none). */
+    /** Legacy 7-arg constructor (pre-#2806); defaults {@code boundKeyTokens} to none. */
     public CqliteFlightTableHandle(
             String keyspace,
             String table,

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightTableHandle.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightTableHandle.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.trino.spi.connector.ConnectorTableHandle;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 
@@ -33,6 +34,18 @@ import java.util.OptionalLong;
  * connector returns {@code limitGuaranteed = false} and Trino keeps a global
  * {@code Limit} above the scan. It is never set on an aggregated handle (the
  * aggregate already collapses the row set).
+ *
+ * <p>{@code boundKeyTokens} holds the Murmur3 token(s) of the fully-bound partition
+ * key, precomputed at {@link CqliteFlightMetadata#applyFilter} time (issue #2806) —
+ * where the TYPED partition-key domain is still available — and consumed by
+ * {@link CqliteFlightSplitManager#getSplits} for plan-time split pruning (issue
+ * #2679). This is REQUIRED because {@code applyFilter} pushes the point-read PK
+ * predicate into {@code filterJson} and returns the summary unenforced (the honesty
+ * contract, #2164), so the enforced {@code Constraint} handed to {@code getSplits}
+ * binds NO columns — the bound key must therefore ride on the handle, not the
+ * split-time constraint. Empty when the partition key is not fully bound (or pruning
+ * cannot be grounded); the split manager then falls back to the split-time
+ * constraint and, absent both, to the always-correct full fan-out.
  */
 public record CqliteFlightTableHandle(
         String keyspace,
@@ -41,8 +54,29 @@ public record CqliteFlightTableHandle(
         Optional<String> filterJson,
         Optional<String> aggregationJson,
         Optional<String> finalizePlanJson,
-        OptionalLong limit)
+        OptionalLong limit,
+        List<Long> boundKeyTokens)
         implements ConnectorTableHandle {
+
+    /**
+     * Compact constructor: keep {@code boundKeyTokens} an immutable list (records are
+     * shared across planning threads), tolerating {@code null} as an empty list.
+     */
+    public CqliteFlightTableHandle {
+        boundKeyTokens = boundKeyTokens == null ? List.of() : List.copyOf(boundKeyTokens);
+    }
+
+    /** Canonical-arity constructor without precomputed bound-key tokens (defaults to none). */
+    public CqliteFlightTableHandle(
+            String keyspace,
+            String table,
+            String ddl,
+            Optional<String> filterJson,
+            Optional<String> aggregationJson,
+            Optional<String> finalizePlanJson,
+            OptionalLong limit) {
+        this(keyspace, table, ddl, filterJson, aggregationJson, finalizePlanJson, limit, List.of());
+    }
 
     /** Convenience constructor for a handle with no pushed-down filter or aggregation. */
     public CqliteFlightTableHandle(String keyspace, String table, String ddl) {

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningPushdownTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningPushdownTest.java
@@ -1,0 +1,172 @@
+package in.mcfad.cqlite.flight;
+
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
+import io.airlift.slice.Slices;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Split pruning through the REAL pushdown path (issue #2806). #2679's plan-time split
+ * pruning was inert in the field: {@code applyFilter} pushes the fully-bound point-read
+ * PK predicate into the handle's {@code filterJson} and returns the summary UNENFORCED
+ * (the honesty contract, #2164), so the {@code Constraint} Trino hands {@code getSplits}
+ * binds NO columns ({@code TupleDomain.ALL}). Reading the bound key only from that
+ * split-time constraint therefore always fell through to the full fan-out.
+ *
+ * <p>These tests reproduce that exact path — {@link CqliteFlightMetadata#applyFilter}
+ * (the true pushdown) to build the handle, then {@link CqliteFlightSplitManager
+ * #pruneToBoundPartitionKey} with an {@code ALL} split-time constraint (what getSplits
+ * actually receives) — so a unit test that fed a populated {@code Constraint.getSummary()}
+ * (as {@link CqliteFlightSplitPruningTest} does) can no longer pass while the field fails.
+ */
+class CqliteFlightSplitPruningPushdownTest {
+
+    private final CqliteFlightMetadata metadata = new CqliteFlightMetadata(null, null, null);
+
+    private static final String INT_PK_DDL = "CREATE TABLE ks.t (id int PRIMARY KEY, v text)";
+    private static final CqliteFlightColumnHandle ID_INT =
+            new CqliteFlightColumnHandle("id", INTEGER, PushdownCapability.FULL);
+
+    private static final String COMPOSITE_PK_DDL =
+            "CREATE TABLE ks.t (a text, b int, v text, PRIMARY KEY ((a, b)))";
+    private static final CqliteFlightColumnHandle A_TEXT =
+            new CqliteFlightColumnHandle("a", VARCHAR, PushdownCapability.FULL);
+
+    private static ReplicaInfo range(long start, long end) {
+        return new ReplicaInfo(Long.toString(start), Long.toString(end),
+                Map.of("dc1", List.of("10.0.0.1:7000")));
+    }
+
+    /** A full unwrapped (MIN, .., MAX] tiling with a range per interior boundary. */
+    private static TokenRangeReplicasResponse ringCovering(long... interiorBoundaries) {
+        long[] sorted = interiorBoundaries.clone();
+        java.util.Arrays.sort(sorted);
+        List<ReplicaInfo> ranges = new ArrayList<>();
+        long prev = Long.MIN_VALUE;
+        for (long b : sorted) {
+            ranges.add(range(prev, b));
+            prev = b;
+        }
+        ranges.add(range(prev, Long.MAX_VALUE));
+        return new TokenRangeReplicasResponse(List.of(), ranges);
+    }
+
+    /** The split-time constraint getSplits actually receives after full PK pushdown: binds nothing. */
+    private static Constraint enforcedAll() {
+        return new Constraint(TupleDomain.all(), Constant.TRUE, Map.of());
+    }
+
+    /**
+     * Drive the REAL pushdown: apply a summary-delivered predicate through
+     * {@link CqliteFlightMetadata#applyFilter}, returning the rebuilt handle (predicate
+     * now in filterJson; bound-key tokens precomputed onto the handle).
+     */
+    private CqliteFlightTableHandle pushdown(String ddl, TupleDomain<ColumnHandle> summary) {
+        ConnectorTableHandle base = new CqliteFlightTableHandle("ks", "t", ddl);
+        var applied = metadata.applyFilter(null, base, new Constraint(summary, Constant.TRUE, Map.of()))
+                .orElseThrow(() -> new AssertionError("applyFilter should push the PK predicate"));
+        // Sanity: the predicate really did land in filterJson (the field pushdown), AND the
+        // remaining summary is returned unenforced (why the split-time constraint is empty).
+        CqliteFlightTableHandle handle = (CqliteFlightTableHandle) applied.getHandle();
+        assertTrue(handle.filterJson().isPresent(), "PK predicate must be pushed into filterJson");
+        assertEquals(summary, applied.getRemainingFilter(),
+                "summary is returned unenforced (#2164) — so the split-time constraint binds nothing");
+        return handle;
+    }
+
+    @Test
+    void fullyBoundPkPushedIntoFilterJsonStillPrunesToOneSplit() {
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A}); // int 42
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+
+        CqliteFlightTableHandle handle = pushdown(INT_PK_DDL,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        ID_INT, Domain.singleValue(INTEGER, 42L))));
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(handle, resp, "dc1", 8815);
+        assertTrue(full.size() > 1, "fixture must fan out to many ranges");
+
+        // The enforced split-time constraint binds NO columns — the pre-#2806 read source.
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                handle, full, enforcedAll(), true, Partitioner.MURMUR3);
+
+        assertEquals(1, pruned.size(),
+                "the bound PK lives in filterJson/on the handle, not the split-time constraint — "
+                        + "pruning must still reach exactly one covering split");
+        CqliteFlightSplit s = pruned.get(0);
+        assertTrue(Murmur3Token.tokenInRange(token, s.tokenStart(), s.tokenEnd(), s.wraparound()));
+    }
+
+    @Test
+    void inListPushedIntoFilterJsonPrunesToTwoRangeUnion() {
+        long t1 = Murmur3Token.token(new byte[] {0, 0, 0, 0x01}); // int 1
+        long t2 = Murmur3Token.token(new byte[] {0, 0, 0, 0x02}); // int 2
+        long lo = Math.min(t1, t2);
+        long hi = Math.max(t1, t2);
+        TokenRangeReplicasResponse resp = ringCovering(lo - 1, lo, hi - 1, hi);
+
+        CqliteFlightTableHandle handle = pushdown(INT_PK_DDL,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        ID_INT, Domain.multipleValues(INTEGER, List.of(1L, 2L)))));
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(handle, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                handle, full, enforcedAll(), true, Partitioner.MURMUR3);
+
+        assertEquals(2, pruned.size(), "IN over two keys in two ranges → the two-range union");
+        assertTrue(pruned.stream().anyMatch(
+                s -> Murmur3Token.tokenInRange(t1, s.tokenStart(), s.tokenEnd(), s.wraparound())));
+        assertTrue(pruned.stream().anyMatch(
+                s -> Murmur3Token.tokenInRange(t2, s.tokenStart(), s.tokenEnd(), s.wraparound())));
+    }
+
+    @Test
+    void notFullyBoundCompositePkKeepsFullFanOut() {
+        // Only the first component of a composite PK is bound → the PK is NOT fully bound,
+        // so no tokens are attached and the fail-safe full fan-out is preserved even though
+        // 'a = hello' was pushed into filterJson.
+        TokenRangeReplicasResponse resp = ringCovering(-100L, 0L, 100L);
+        CqliteFlightTableHandle handle = pushdown(COMPOSITE_PK_DDL,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        A_TEXT, Domain.singleValue(VARCHAR, Slices.utf8Slice("hello")))));
+
+        assertTrue(handle.boundKeyTokens().isEmpty(), "a partial composite PK attaches no tokens");
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(handle, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                handle, full, enforcedAll(), true, Partitioner.MURMUR3);
+
+        assertEquals(full.size(), pruned.size(), "partial PK binding → full fan-out (never drop rows)");
+    }
+
+    @Test
+    void toggleOffKeepsFullFanOutEvenWithBoundKeyTokens() {
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        CqliteFlightTableHandle handle = pushdown(INT_PK_DDL,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        ID_INT, Domain.singleValue(INTEGER, 42L))));
+
+        assertFalse(handle.boundKeyTokens().isEmpty(), "a fully-bound PK attaches tokens");
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(handle, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                handle, full, enforcedAll(), false, Partitioner.MURMUR3);
+
+        assertEquals(full.size(), pruned.size(), "the kill switch forces the unpruned baseline");
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningPushdownTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightSplitPruningPushdownTest.java
@@ -1,5 +1,10 @@
 package in.mcfad.cqlite.flight;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
 import io.airlift.slice.Slices;
@@ -43,10 +48,21 @@ class CqliteFlightSplitPruningPushdownTest {
     private static final CqliteFlightColumnHandle ID_INT =
             new CqliteFlightColumnHandle("id", INTEGER, PushdownCapability.FULL);
 
+    private static final CqliteFlightColumnHandle V_TEXT =
+            new CqliteFlightColumnHandle("v", VARCHAR, PushdownCapability.FULL);
+
     private static final String COMPOSITE_PK_DDL =
             "CREATE TABLE ks.t (a text, b int, v text, PRIMARY KEY ((a, b)))";
     private static final CqliteFlightColumnHandle A_TEXT =
             new CqliteFlightColumnHandle("a", VARCHAR, PushdownCapability.FULL);
+
+    // Mirror Trino's handle codec (airlift ObjectMapperProvider): serialize by FIELDS, Optional-
+    // aware via the jdk8 module — the handle round-trips coordinator->worker like a split does.
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new Jdk8Module())
+            .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+            .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     private static ReplicaInfo range(long start, long end) {
         return new ReplicaInfo(Long.toString(start), Long.toString(end),
@@ -79,15 +95,19 @@ class CqliteFlightSplitPruningPushdownTest {
      */
     private CqliteFlightTableHandle pushdown(String ddl, TupleDomain<ColumnHandle> summary) {
         ConnectorTableHandle base = new CqliteFlightTableHandle("ks", "t", ddl);
-        var applied = metadata.applyFilter(null, base, new Constraint(summary, Constant.TRUE, Map.of()))
-                .orElseThrow(() -> new AssertionError("applyFilter should push the PK predicate"));
-        // Sanity: the predicate really did land in filterJson (the field pushdown), AND the
-        // remaining summary is returned unenforced (why the split-time constraint is empty).
-        CqliteFlightTableHandle handle = (CqliteFlightTableHandle) applied.getHandle();
+        CqliteFlightTableHandle handle = applyFilterOn(base, summary);
+        // Sanity: the predicate really did land in filterJson (the field pushdown).
         assertTrue(handle.filterJson().isPresent(), "PK predicate must be pushed into filterJson");
+        return handle;
+    }
+
+    /** Apply one more predicate to an existing handle through the real applyFilter (iterative pushdown). */
+    private CqliteFlightTableHandle applyFilterOn(ConnectorTableHandle base, TupleDomain<ColumnHandle> summary) {
+        var applied = metadata.applyFilter(null, base, new Constraint(summary, Constant.TRUE, Map.of()))
+                .orElseThrow(() -> new AssertionError("applyFilter should push the predicate"));
         assertEquals(summary, applied.getRemainingFilter(),
                 "summary is returned unenforced (#2164) — so the split-time constraint binds nothing");
-        return handle;
+        return (CqliteFlightTableHandle) applied.getHandle();
     }
 
     @Test
@@ -168,5 +188,91 @@ class CqliteFlightSplitPruningPushdownTest {
                 handle, full, enforcedAll(), false, Partitioner.MURMUR3);
 
         assertEquals(full.size(), pruned.size(), "the kill switch forces the unpruned baseline");
+    }
+
+    @Test
+    void unsupportedPartitionerAtSplitTimeIgnoresHandleTokens() {
+        // Defensive fail-safe (roborev): even a handle carrying Murmur3 tokens must NOT be
+        // consumed when the split-time partitioner resolves to non-Murmur3 — the token fast
+        // path is gated on the partitioner, mirroring the constraint path's guard.
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+        CqliteFlightTableHandle handle = pushdown(INT_PK_DDL,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        ID_INT, Domain.singleValue(INTEGER, 42L))));
+        assertFalse(handle.boundKeyTokens().isEmpty(), "a fully-bound PK attaches tokens");
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(handle, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                handle, full, enforcedAll(), true, Partitioner.UNSUPPORTED);
+
+        assertEquals(full.size(), pruned.size(),
+                "a non-Murmur3 split-time partitioner must not consume the handle's Murmur3 tokens");
+    }
+
+    @Test
+    void tokensSurviveASecondNonPkBindingApplyFilterAndStillPrune() {
+        // Iterative pushdown (#2164 accumulation): call 1 binds the PK, call 2 binds only a
+        // non-PK column. The PK tokens attached by call 1 must be INHERITED by call 2's handle
+        // (deleting the inherit branch drops them → this test fails), and pruning still fires.
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A}); // int 42
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+
+        CqliteFlightTableHandle afterPk = pushdown(INT_PK_DDL,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        ID_INT, Domain.singleValue(INTEGER, 42L))));
+        assertFalse(afterPk.boundKeyTokens().isEmpty(), "call 1 (PK-binding) attaches tokens");
+
+        // Call 2 binds only 'v' (a non-PK column) — no PK tokens derivable from this summary.
+        CqliteFlightTableHandle afterBoth = applyFilterOn(afterPk,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        V_TEXT, Domain.singleValue(VARCHAR, Slices.utf8Slice("x")))));
+        assertEquals(afterPk.boundKeyTokens(), afterBoth.boundKeyTokens(),
+                "the PK tokens from call 1 must survive a later non-PK-binding applyFilter call");
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(afterBoth, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                afterBoth, full, enforcedAll(), true, Partitioner.MURMUR3);
+        assertEquals(1, pruned.size(), "inherited PK tokens still prune to the covering split");
+    }
+
+    @Test
+    void tokensSurviveApplyLimitRebuildAndStillPrune() {
+        // The canonical field query WHERE key = ? LIMIT n: applyFilter then applyLimit both
+        // rebuild the handle (#2129 rebuild-drops-state class). The pruning tokens must survive.
+        long token = Murmur3Token.token(new byte[] {0, 0, 0, 0x2A});
+        TokenRangeReplicasResponse resp = ringCovering(token - 1, token, token + 1000);
+
+        CqliteFlightTableHandle afterFilter = pushdown(INT_PK_DDL,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        ID_INT, Domain.singleValue(INTEGER, 42L))));
+
+        var limited = metadata.applyLimit(null, afterFilter, 5L)
+                .orElseThrow(() -> new AssertionError("applyLimit should push the cap"));
+        CqliteFlightTableHandle afterLimit = (CqliteFlightTableHandle) limited.getHandle();
+        assertEquals(5L, afterLimit.limit().orElseThrow(), "the limit is pushed");
+        assertEquals(afterFilter.boundKeyTokens(), afterLimit.boundKeyTokens(),
+                "applyLimit's rebuild must preserve the precomputed bound-key tokens");
+
+        List<CqliteFlightSplit> full = CqliteFlightSplitManager.buildSplits(afterLimit, resp, "dc1", 8815);
+        List<CqliteFlightSplit> pruned = CqliteFlightSplitManager.pruneToBoundPartitionKey(
+                afterLimit, full, enforcedAll(), true, Partitioner.MURMUR3);
+        assertEquals(1, pruned.size(), "tokens preserved across applyLimit still prune to one split");
+    }
+
+    @Test
+    void handleWithBoundKeyTokensSurvivesJsonRoundTrip() throws Exception {
+        // The handle serializes coordinator->worker like a split; a serde break on the new
+        // boundKeyTokens component would fail every query. Round-trip a fully-populated handle.
+        CqliteFlightTableHandle original = pushdown(INT_PK_DDL,
+                TupleDomain.<ColumnHandle>withColumnDomains(Map.of(
+                        ID_INT, Domain.singleValue(INTEGER, 42L))));
+        assertFalse(original.boundKeyTokens().isEmpty(), "precondition: tokens are attached");
+
+        byte[] json = MAPPER.writeValueAsBytes(original);
+        CqliteFlightTableHandle restored = MAPPER.readValue(json, CqliteFlightTableHandle.class);
+
+        assertEquals(original, restored, "the whole 8-component handle round-trips");
+        assertEquals(original.boundKeyTokens(), restored.boundKeyTokens(), "bound-key tokens survive serde");
     }
 }


### PR DESCRIPTION
Closes #2806. Field-verified on 0.16.0-rc1 (AWS round #2805, Probe A): #2679's plan-time split pruning never fired — `applyFilter` pushdown moves the fully-bound PK predicate into the handle's `filterJson`, so `getSplits` receives `Constraint.getSummary() == TupleDomain.ALL` and the guard fail-safes to full fan-out on every query (13 splits / all 3 pods, identical with pruning on/off).

## What

- **Precompute at `applyFilter` time** — the only point where the typed PK domain still exists: derive the bound key's Murmur3 covering token(s) via the existing `BoundPartitionKeys`/`PartitionKeyBytes` (no new type mapping — rejecting the parse-`filterJson` route which would need a shadow CQL→Trino mapper that could drift, a no-heuristics hazard) and retain `boundKeyTokens: List<Long>` on `CqliteFlightTableHandle`. `pruneToBoundPartitionKey` prefers handle tokens, falls back to the split-time constraint.
- **Fail-safes preserved and extended**: plan-time token computation is exception-contained (a RuntimeException in the optimization path can never fail the query); the handle-token fast path is gated on `partitioner == MURMUR3` (the latent silent-row-loss trap if `Partitioner.resolve()` ever reads Sidecar metadata); partial-PK/arity/serialization guards unchanged; `cqlite.split-pruning-enabled` kill switch gates both token sources; tokens inherit across iterative `applyFilter` calls (superset-safe) and survive `applyLimit` handle rebuilds. No `TokenRangeSlicer`/sub-splits (consistent with the #2680 revert).
- **Tests (393 green, 8 pruning-specific)** drive the REAL pushdown path — `applyFilter` first, then prune with an `ALL` split-time constraint (what `getSplits` actually receives), structurally preventing the #2679 failure mode (its tests fed a populated summary that the real path empties). Positive cases mutation-verified (fail when the fix is neutralized); iterative-inherit and applyLimit-preservation tests fail if their branch is deleted; handle JSON serde round-trip; token-handle + unsupported-partitioner → full fan-out; kill-switch differential.

## Known limitation (documented, observable, intentionally out of scope)
A PK predicate arriving ONLY via the translated-expression channel (summary stays `ALL`) leaves pruning inert — correctly fail-safe, and now visible via a DEBUG log when `filterJson` was pushed but no tokens derived. Follow-up if the field ever observes it.

## Field re-validation
The `EXPLAIN ANALYZE` split-count differential (Probe A, #2805) re-runs against the next 0.16 build: expect 1 source-stage split for `WHERE key = ?`, 2-range union for `IN (k1,k2)`, full fan-out with the kill switch off — with identical row sets throughout.
