### PR TITLE
docs(#2817): 0.17 throughput program — research, verdicts, backlog manifest

### DIFF
--- a/docs/architecture/throughput-program-2026-07.md
+++ b/docs/architecture/throughput-program-2026-07.md
@@ -1,0 +1,431 @@
+# CQLite throughput program — Phase 3 synthesis (2026-07)
+
+**Date:** 2026-07-21 · **Status:** filed as **epic #2817** (0.17 scan-path throughput program); manifest
+items M0–M17 filed as GitHub issues (numbers inline in §7) · **Author:** Phase-3 synthesizer
+
+This document folds the throughput research program into one actionable plan: the ground truth
+(Phase 0), the eight lever memos (Phase 1-1…1-8), and the seven adversarial adjudications
+(Phase 2-verify-*). **Precedence rule applied throughout: where a Phase-2 doc overrules a Phase-1
+doc, the Phase-2 ruling is final.** Every rows/s figure carries its shape qualifier
+(narrow/wide, warm/cold, RF). No optimism theater — the graveyard (§4) is a first-class deliverable.
+
+Source files (cite by section): `docs/research/phase0-scan-cost-breakdown-2026-07.md` (P0),
+`phase1-{1..8}-*.md` (P1.n), `phase2-verify-{row-engine,stage2,field-gap,transport,parallelism,caching,io}.md`
+(P2:name).
+
+---
+
+## 1. Executive summary + verdict table
+
+The through-Trino field baseline is **~10.6k rows/s/pod** (R12/#2367: 1.94M rows / 61.1s / 3 pods,
+RF=3, LZ4, ~1.9M partitions/node, 4-vCPU pods). Server-direct field is **~29k rows/s/ring** (R11b).
+The local single-stream ceiling is **~500k rows/s/core** (P0: M1, RF=1, narrow `keyvalue`, warm,
+**uncompressed**, loopback) — a server-direct ceiling for that shape, **not** a field prediction.
+
+The program's central finding: **the gap is almost entirely server-side and Trino-independent.**
+P1.7's pivot — through-Trino aggregate (~32k) ≈ server-direct ring (~29k) — proves the connector,
+HTTP/2 window, and split distribution add ≈0 on aggregate (P2:field-gap §1). The row *feed* is the
+throughput ceiling; Trino is a *latency floor* (0.2–2s), not a throughput tax.
+
+**Verdict table** (substance verbatim from P2:stage2 §0 for the A4/B3 rungs):
+
+| Target | Verdict | Limiting factor (named) |
+|---|---|---|
+| **A4 Stage-1** — 100k rows/s/pod (server-direct) | **REACHABLE** | none binding; L1 batch-channel + fan-out-to-cores clears it comfortably (P2:stage2 §0) |
+| **A4 Stage-2** — 600k rows/s/pod = 150k/core | **NOT reliably reachable** on the pure row engine (optimistic-corner only; central **~400–450k/pod**) | **C(N) < 4**: a 4-vCPU pod is **2 physical cores + hyperthreads, not 4× parallelism** + reconcile machinery (~2µs/row measured, P2:stage2 §3/§4) |
+| **B3 Stage-1** — ≤10s (≈65k rows/s/pod) | **REACHABLE, at the edge** | needs full-core parallelism (~4×) **and** constants (~1.5×) to both land (P1.7 §4) |
+| **B3 Stage-2** — ≤3s (216–323k rows/s/pod) | **REACHABLE-AT-COST on a row feed** (overrules P1.7's "not credible") | **NOT the row engine** — the **Trino coordinator floor** eating the 3s budget + **cold-start IO latency**; needs floor ≤~1.2s AND warm/prefetched IO AND L1/L3 landed (P2:stage2 §2) |
+| **B2** — ≥100 qps @32thr warm | **REACHABLE** (reachable-at-cost, stack: #2680 pod-skew balance + #2600/#2765 egress relief + warm p50 ≤~0.3s) | pod-skew (count-balanced floorMod) — the #2680 lever (P1.7 §4) |
+| **A2** — ≥1000 qps/pod warm | **REACHABLE-AT-COST, gated on measurement** | **unknown keyed access skew** — the decoded-partition cache's ~1.5–3× rests on an **unmeasured** hot-set hit rate (field keyed loadtest on record is ~0.9 qps, no skew captured); must measure the access distribution first (P2:caching §4) |
+| **Worker ingest** — ≥250–350 MB/s/worker | **REACHABLE-AT-COST (wide rows only), via the Arrow path** | **row width**: at 180B/narrow rows this needs ~1.4M rows/s/worker = not credible on the row engine; credible only for **wide rows (≥1KB)** or via columnar. **Not via JDBC** (~32 MB/s/conn — moot, the path is Arrow) (P1.8 §3c, P1.5 §8) |
+| **B4** — cold ≤3s / peak ≤512Mi / ≤16Mi per-query working set | **MET / holdable** | ≤16Mi is the **per-query working-set** target (NOT idle), and a single stream ≈15MB already ≈ the whole ≤16Mi (satisfiable at concurrency 1 or smaller batch_size); cold ≤3s met post-#2412; peak held with admission-resize + chunk-cache retune (P2:caching §1, P2:parallelism §6) |
+| **A5** — 0 restarts @80thr | **MET today** | field 0 OOMKills, peak 270–391Mi @80thr; the memory-derived admission resize is a **forward guard** bundled with #2680, not a live-OOM fix (P2:parallelism §1) |
+
+**Honest A4 Stage-2 finding (verbatim substance, P2:stage2):** central ~420k/pod, 600k is the
+optimistic corner; C(N) = 2.5–3.5× (central 3×) on 2 physical cores, not the flat 4× both P1.2 and
+P1.7 assumed. **Ingest caveat:** 250–350 MB/s is **not credible on narrow rows via the row engine**;
+the target implicitly assumes a wider row shape than the `keyvalue` benchmark — state the assumed
+width on record.
+
+---
+
+## 2. Ground truth (Phase 0 + the canonical field-gap decomposition)
+
+**Method (P0 §1):** CPU-sampling profile (`samply`, 1000 Hz, CPU-weighted by `threadCPUDelta`) of
+the real `cqlite-flight` server under sustained single-stream `--shape full` load; 3M rows / 4
+uncompressed SSTables / narrow `keyvalue`; two orthogonal attributions (self-by-library and
+by-operation) that **agree**.
+
+**Where the single-stream CPU goes (P0 §3):**
+
+| Stage | % CPU | What it is |
+|---|--:|---|
+| 4b — merge fan-in channel park/wake | **49.9%** | one `sync_channel` `send` **per row** (cap 256), ~94% kernel park/wake — overhead of thread-per-input decode, not merge math |
+| 4a — k-way merge / reconcile compute | **32.5%** | `reconcile_cluster_with_overlap_counted`, heap refill — the true ceiling once 4b is removed (~2µs/row, machinery-dominated on singletons) |
+| malloc (by-library) | 17.6% | per-row `RowKey::new(pk.to_vec())`, `MergeEntry`, `QueryRow` allocs + SipHash key hash |
+| 2 — parse/decode | 9.7% | cell/vint decode |
+| 3 — row materialize | 4.5% | `entry_to_row` → `QueryRow` |
+| 5 — Arrow encode | 1.0% | cheap for 2 columns |
+| 1 / 6 — IO+decompress / transport | 0.0% / 0.2% | **warm + uncompressed + loopback artifacts — real in the field** (P0 §5 caveats 1–3) |
+
+Blunt truth: **~55% of single-stream CPU is kernel syscalls, ~18% allocator, only ~22% CQLite's own
+logic.** IO (0%) and transport (0.2%) are rig artifacts.
+
+**The canonical field-gap decomposition (P2:field-gap §4)** — shares of the **~47–50× per-node**
+gap (~500k single warm M1 stream → ~10k rows/s/node), each with a falsifying measurement:
+
+| # | Bucket | Share | Grade | Falsifying measurement |
+|---|---|--:|:--:|---|
+| 1 | **Hardware + core-contention** (i4i vCPU vs M1 P-core; 55% kernel tax *contends* on 4 shared cores, C(N)<1) | **25–35%** | MED | warm server-direct on i4i at conc 1 and pod-native, vs the 500k M1 anchor |
+| 2 | **Field data-plane heaviness** (many SSTables → more reader threads → worse 4b; real tombstone/TTL/LWW reconcile overlap → heavier 4a) | **18–28%** | MED | SSTable-count/node + reconcile-overlap ratio; re-profile 4a/4b in-`stream` on field data |
+| 3 | **Cold-IO *latency*** (synchronous mmap faults, `Auto`→mmap, **no `madvise`**, 128KiB readahead, multi-SSTable LBA interleave) — **NOT bandwidth, NOT decompress-CPU** | **10–22%** | **LOW** | cold-vs-warm A/B of the same full-ring scan; the cold−warm delta *is* this bucket |
+| 4 | Distribution / concurrency shortfall | 6–14% | MED | B3 per-pod concurrency during the 61s scan (currently unrecorded) |
+| 5 | Transport — network + HTTP/2 window | 5–10% | MED→LOW | server-direct over the real app-node network vs loopback |
+| 6 | Connector page-build (`ArrowToTrino` row-at-a-time) | 3–8% | MED | through-Trino minus server-direct at equal concurrency (≈0 per P1.7) |
+| 7 | LZ4 decompression CPU | **1–2%** | **HIGH** | i4i cold-compressed decode bench |
+
+Buckets **1+2+3 ≈ 55–75%** (server-side per-node) dominate; **4+5+6 ≈ 15–30%** (Trino/transport)
+is the axis P1.5 over-weighted at 45–80%; decompress (7) ≈ 1%. **The field's standing telemetry
+cannot adjudicate this**: the 5-phase RPC metric (`validate→admission→resolve→merge_setup→stream`,
+`obs.rs:210`) **folds the entire data plane into `stream`** — cold faults, LZ4, decode, merge,
+reconcile, materialize, Arrow encode, and gRPC write are all one histogram. Only an in-`stream`
+profile can settle it. This is why the i4i cold-vs-warm profile is the program's #1 item (§5).
+
+---
+
+## 3. The multiplier stacks (post-skeptic only, obeying the composition rules)
+
+**Composition rules (authoritative — P2:parallelism §5):**
+1. **ONE utilization credit for the whole width stack.** Sub-splits (#2680), transport fan-out
+   (T6), and producer-side parallelism are **substitutes competing for one per-pod width budget**,
+   all bounded by `min(N_admitted, N_drain_sat_postfix, N_mem) × C(N)<1`. **Do NOT** multiply
+   #2680 × fan-out × producer-parallel; the first lever to reach the ceiling caps the rest.
+2. **`width_postfix ≤ 4` (vCPU) for narrow CPU-bound rows**, `≤ N_mem ~16–24` for wide/network-bound.
+   Today's realized width is **drain-bound ~4–8** (N_drain_sat), *below* cores, and rises toward the
+   vCPU wall only **post-L1**.
+3. **Per-stream ceiling levers compound on the Amdahl residual** — L1/L3/ArrowToTrino/window raise
+   `per_stream_rows_s` AND raise the width ceiling (they are the multiplicand; width is the multiplier).
+   Field-shape numbers, not rig-narrow.
+4. **No L1 × #2680 product** — on one pod #2680 = 1.0× (skew fix only); their gains overlap in
+   aggregate qps (P2:row-engine §7).
+5. **L1 = the #2765-adjacent same-channel co-design** — L1 (batch, syscall axis) and #2765 (adaptive
+   depth, memory axis) hit the **same** fan-in `sync_channel` (P2:row-engine §3.1 overrules P1.1's
+   "different channel/orthogonal"). No throughput double-count, but a **mandatory** co-design on the
+   256-cap constant.
+
+**The surviving bottom-up stack (P2:stage2 §0, the honest band):**
+
+```
+Fixed single-thread pipeline (per-row channel deleted, L1/L2)   285k rows/s/core  (narrow rig)
+  ÷ field derate  1.5–3×  (central 2×)                        → 95–190k /core  (central 143k)
+  × C(N) on 4 vCPU  2.5–3.5×  (central 3×)                    → 238–670k /pod   (central ~420k)
+       ├─ A4 Stage-1 (100k):  cleared with wide margin  → REACHABLE
+       ├─ B3 Stage-2 (216–323k/pod = 54–81k/core):  fixed pipeline does 95–190k/core → cleared at central
+       └─ A4 Stage-2 (600k):  only the optimistic corner (derate ~1.5×, C(N) ~3.5×)  → NOT reliable
+```
+
+The derate is **1.5–3×, not P1.2's 3–5×** (RF=3 is NOT a per-node reconcile multiplier — it is
+compaction generation-overlap ~1.1–1.5×, deduped by the connector's one-replica pin; LZ4 is
+~1.01–1.05×, not 1.3–2×; cold cache is a **latency** term, not a throughput derate — P2:stage2 §1).
+C(N) is **2.5–3.5×, not 4×** (P2:stage2 §3).
+
+**Which stack reaches what:**
+- **A4 Stage-1 / B3 Stage-1 / B3 Stage-2 / B2:** the width credit (up to ~4 vCPU × C(N)) × the L1/L3
+  per-stream residual clears all of these at the central band.
+- **A4 Stage-2 (600k):** falls short at the center (~420k). The gap is **C(N)** (2 physical cores)
+  + reconcile machinery — **not** Arrow encode (1%), **not** the container format, **not** the
+  columnar option. No single lever closes it on the narrow corpus; the honest closers are wider pods
+  (more physical cores) or the columnar increment **on wide rows** — accept that (P2:stage2 §8).
+- **Worker ingest 250–350 MB/s:** narrow via row engine = NOT credible (~1.4M rows/s needed); wide
+  (≥1KB) at ~100k rows/s = ~100 MB/s, 2–3KB = 200–300 MB/s → reachable **for wide rows**, via Arrow
+  batches (the CQLite producer, not the JVM page builder, is the limiter — P1.8 §3c).
+
+---
+
+## 4. Surviving lever table + the graveyard
+
+**Surviving levers** (post-skeptic multiplier = field shape; cost S/M/L):
+
+| Lever | Post-skeptic multiplier (field) | Cost | Risk | Verdict provenance |
+|---|---|:--:|---|---|
+| **L1** batch fan-in `sync_channel` | util **1.5–1.9× rig-narrow ceiling**; single-stream ~1.05–1.15× field; **raises C(N) + N_drain_sat** | M | Med (co-design #2765 same channel; cut msg-capacity for B4; keep #2419 gauge/#2361 cancel-recv) | P2:row-engine (SURVIVES-weakened) — **#1 lever, prerequisite for C(N) and fan-out** |
+| **L3** reconcile singleton fast-path | disjoint-narrow **~1.20× upper**; **field-w/-TTL/overlap ~1.03–1.08×** | M–L | High (byte-parity; query-semantics + point-vs-full oracles load-bearing) | **Disposition unresolved — see §4 tension flag** (P2:stage2 ranks #2 / P2:row-engine WEAKENED) |
+| **L4** `RowKey` Arc hoist (#1883) | **1.05–1.09× multi-row-partition only; 1.0× single-row of any width** | S–M | Low | P2:row-engine (SURVIVES re-scoped) — win governed by clustering fan-out, unknown from profile |
+| **L5** FxHash `row_values` map | ~1.04× narrow & wide | S | Low | P2:row-engine (SURVIVES) — target confirmed still SipHash |
+| **L2** inline/thread-less merge | ~1.4–1.8× narrow single-stream; **≤1.0× wide/field → not credited in field stack** | L | High (shape-fragile; A/B-gated) | P2:row-engine (SURVIVES narrow-only) |
+| **#2680** weight-balanced sub-splits | util (skew fix) up to 2–4× on *lagging* pods; **0× on one pod** | M | Med (P0 #2782 hang; needs early-close drain fix) | P2:parallelism P-A (SOUND) — K=2 rotation carries flight-pod balance, NOT SplitWeight |
+| **#2765** adaptive egress budget (+ fan-out T6) | stability enabler; bounds fan-in growth; unlocks higher useful concurrency | M | Med (bounds fan-in only, not the 57k-row Arrow egress) | P2:parallelism L4/L3 |
+| **T4** byte-bounded batch | ~1.0–1.1× (robustness/B4, not throughput) | S | Low | P2:transport (SURVIVES minor) |
+| **T1+T2** bulk per-column `ArrowToTrino` + async prefetch | **~1.0× today; ~1.1–1.3× combined only AFTER server ceiling raised** | M | Med (off-heap lifetime vs Trino page graph) | P2:transport (WEAKENED — reframed bulk copy, not zero-copy) |
+| **madvise(WILLNEED)** under Auto-mmap | ~1.0× warm; marginal cold-p99 hedge (B4 justification **stale** post-#2412) | S | Low | P2:io (RESPEC — policy flip on built machinery) |
+| **Chunk-cache retune** (256MiB→smaller) | 0× throughput; closes a B4 **peak** hazard | S (config) | Low | P2:caching §1 |
+| **Decoded-partition cache** (K-A/K-D) | **~1.5–3× keyed IF the skew is real — UNMEASURED** | L | High (3.5× decoded size, B4; #2037 overlap) | P2:caching §4 — gate on measured access distribution |
+
+**Sequence (P2:stage2 §8):** **L1 → L3 → fan-out-past-drain (gated #2765)**. L1 is both the biggest
+single-stream lever and the enabler of C(N); nothing scales without it. L5+L4 are a near-free warm-up
+bundle. #2680 re-land runs in parallel on the connector tier.
+
+**§4 tension flag (phase2-vs-phase2, L3 disposition — UNRESOLVED):** P2:stage2 §6 ranks L3 the **#2
+highest-value ceiling lever** (it attacks the measured ~2µs/row singleton machinery = the true ceiling
+once L1 lands; ~1.20× disjoint-narrow). P2:row-engine §4 rules it **WEAKENED** (field data with
+TTL/overlap **never hits** the fast-path; ~1.03–1.08×, and pushed toward the low end). The disagreement
+is entirely about **field cluster shape** (singleton vs multi-generation overlap) — which is exactly
+what the reconcile-overlap multiplier (#2043 repoint, §7) and the i4i in-`stream` re-profile would
+measure. **Resolution: L3's slot is gated on that overlap data; do not commit it as a headline lever
+until the field cluster shape is measured.**
+
+**Other phase2-vs-phase2 tensions flagged:**
+- **C(N) magnitude.** P2:stage2 defends central **C(N) 3×** (pod-vs-core). P2:parallelism is more
+  conservative — width `≤4` vCPU for CPU-bound rows, drain-bound **~4–6 today**, × C(N)<1, ⇒ realistic
+  post-fix ~2.8×. They agree 600k needs the optimistic corner; stage2's 3× sits at the **top** of
+  parallelism's realistic post-L1 band. Flagged, not silently picked.
+- **Cold-IO denominator.** P2:field-gap sizes cold-IO **latency** at 10–22% of the *wall-clock*
+  ~47× field-vs-local gap; P2:stage2 §1e **removes** cold cache from the *throughput* derate entirely
+  (reclassed to a latency term against the B3 3s budget). Complementary (different denominators), not
+  contradictory — but the two must not be summed.
+
+**The graveyard (killed / demoted — honesty deliverable):**
+
+| Item | Disposition | One-line reason |
+|---|---|---|
+| **T3** HTTP/2 window sizing | **KILLED** | client window is already **1MiB with BDP auto-tuning** (grpc-java 1.79.0), not 64KB; the tonic-server knob is the wrong flow-control direction for `do_get` egress (P2:transport §2). Close as "not applicable in this stack." |
+| **Columnar scan producer** (P1.2 option a) | **DEFERRED past 0.17** | ~1.05× narrow / 1.5× wide; touches neither the 49.9% channel nor the ~2µs/row reconcile; Stage-3 prep. Revisit only on sharpened #2605 data >1.3× on wide/overlap corpus (P2:stage2 §6). |
+| **`io_uring` / forced `O_DIRECT` scan** | **NOT filed** | IO is not throughput-binding below multi-GB/s row rates (cold bandwidth need 10–120 MB/s vs ≥1GB/s NVMe, ~8–30× headroom); gated behind the i4i measurement (P2:io §4, P1.3 §2b). |
+| **Idle-drain sweeper (S-D)** | **DEMOTED to P3** | B4 has **no idle clause**; caches are lazy LRUs sitting near-zero at idle (a scan populates ~0 of the chunk cache); the field meets the ≤512Mi peak (0 OOMKills). Preventive hardening, gates nothing (P2:caching §1). |
+| **#2561** BTI chunk-straddle | **already FIXED on main** (PR #2554) | only a BIG-path verify test remains; P3 traceability-close, ride #2565 nit batch (P2:caching §2). |
+| **T5** Flight-body compression | **demoted → latent** | net-**negative** for narrow rows (steals server CPU from the bottleneck coordinator); no network-bound case today (T3 headroom analysis); latent WAN lever only (P2:transport). |
+| **L5-intra-query parallel merge** (P1.6 L5) | **DO NOT pursue** | it is #2680 rebuilt inside the server at higher cost — same C(N) tax, new scheduler + cancellation + concat (P1.6 §2). |
+| **T1 "near-zero-copy" naming** | **reframed** | it is a **bulk per-column on-heap copy** (Arrow buffer freed on stream advance), not zero-copy; win = alloc-count + dispatch elimination, not copy-bandwidth (P2:transport §3). |
+| **RF=3 as a reconcile multiplier** | **killed misattribution** | reconcile is per-node-per-cell; the connector pins one replica; real term is compaction generation-overlap ~1.1–1.5× (P2:stage2 §1a). |
+| **#2165 as a decode-speed lever** | **worthless** (keep for maintainability) | Stage 2 is 9.7% and it is decode-plane *consolidation*, perf-neutral; cache value is keyed/repeated-range only (P2:caching §3, P1.1). |
+| **AE Arrow-encode series** (#1497/#1498/#1500) | **demoted for scan** | Stage 5 = 1.0% → ≤1.01× on narrow scan; remain valid for the export/wide-collection path they were filed under (P1.1 §3). |
+| **#941 full DataFusion program** | **NOT a 0.17 throughput pull** | owner-gated MPP surface; DataFusion does not speed the reconcile; its A3/#1907 bounded-stream blocker overlaps the deferred columnar producer (P1.2 §3.1, P1.7 Option 2). |
+
+---
+
+## 5. Measurement first
+
+**#1 — i4i cold-vs-warm server-direct profile (P1 — the program's first item).** Replay P0's exact
+`samply`/`perf` methodology on the field i4i.xlarge pod, server-direct (`flight-loadgen` →
+`cqlite-flight`, `--shape full`), **cold then warm**, capturing **both on-CPU and off-CPU (blocked)
+time**, recording SSTable-count/node and the resolved `DiskAccessMode`. It **adjudicates the 55–75%
+server-side bucket** in one run: cold−warm delta = bucket 3 (cold-IO latency); warm-i4i vs the 500k
+M1 anchor = bucket 1 (hardware+C(N)); it is the first-ever measurement of Stage-1 (IO+decompress)
+and Stage-6 (transport); server-direct removes Trino/connector as confounders (P2:field-gap §6).
+**Everything IO-heavy is gated behind this** — do NOT lead with io_uring/O_DIRECT/DataFusion.
+
+**#2 — the phase-metric data-plane split.** The field's 5-phase RPC metric folds the whole data plane
+into `stream`, so no dashboard can express the P1.3↔P1.5 disagreement (P2:field-gap §2). Split
+`stream` into sub-phases (cold-fault / decompress / merge / encode / gRPC-write) so the field can
+attribute in-`stream` cost without a profiler on every run.
+
+**#3 — the keyed access-distribution probe (gates A2 work).** The decoded-partition cache's ~1.5–3×
+rests on an **unmeasured** hot-set skew; the only field keyed loadtest on record is ~0.9 qps with no
+captured concentration (P2:caching §4). Instrument the field keyed partition access distribution
+(Zipf/skew over `cqlite.read.partition_lookup.*`). This is the **gate** that decides whether the A2
+decoded-cache lever is worth building.
+
+**#4 — B3 per-pod concurrency capture.** The "12/64 → ~4 streams" divisor is borrowed from the R12
+B2 saturation probe, not the B3 scan; the scan's actual per-pod concurrency during the 61s is
+unrecorded (P2:field-gap §1). Capture it — it retires a load-bearing guessed divisor and confirms
+bucket 4 is small.
+
+---
+
+## 6. NEEDS-OWNER list
+
+1. **A4 Stage-2 rung** — revise the ~600k/pod goal to **~400–450k/pod** on the pure row engine, or
+   hold it aspirational pending the i4i measurement? Central is ~420k; 600k is the optimistic corner
+   (2 physical cores). (P2:stage2 §8.)
+2. **Ingest target's implicit row-width assumption** — 250–350 MB/s is not credible on narrow rows
+   via the row engine; state the assumed row width on record (it presumes ≥1KB rows or columnar).
+   (P1.5 §8, P1.8 §3c.)
+3. **Snapshot-reuse-window default** (freshness) — the 3s window (`CqliteFlightConfig.java:84`) sets
+   max data staleness; lengthening it is the cheapest keyed lever in the program but is a
+   product/data-semantics call (mirrors #2305). Knob exists; the *value* is the owner's. (P2:caching §5.)
+4. **Decoded-cache (K-A) vs #2037 sequencing** — the measurement precursor (#3 above) proceeds
+   standalone; the *cache build* overlaps the owner-gated #2037 WS6 per-generation Arrow cache.
+   Unblock the measurement; keep the build reconciled with #2037 so it isn't built twice. (P2:caching §4.)
+5. **B4 "≤16Mi" semantics, on record** — confirm the ratified reading is **per-query working set**,
+   not idle-pod memory, so no future agent re-derives a phantom idle gate. (P2:caching §1/§6.)
+6. **The Flight bulk-path API** (new public surface) — P1.7 Option 4 (Hybrid): add a ticket-level
+   Flight-native bulk-export path so A4/A-lane consumers (pandas/Spark/ADBC) get server-direct rates
+   and skip the coordinator floor. A4 is a server-direct goal already; this is *how* it reaches real
+   consumers. New public surface → a product call on whether to pursue.
+7. **B3 Stage-2 strategy** — the coordinator floor (0.2–2s) inside the 3s budget is the swing factor.
+   Accept the floor (measure it ≤~1.2s for this scan shape), route the bulk-path around it, or defer
+   Stage-2? This is a Trino/IO measurement + product call, not a row-vs-columnar decision. (P2:stage2 §2.)
+
+---
+
+## 7. The 0.17 backlog manifest
+
+Derived from the surviving levers, deduped against `throughput-backlog-inventory-2026-07.md`.
+**Sequenced by dependency;** items gated on the i4i measurement (M0) are marked. Acceptance criteria
+are in flight-loadgen/perf terms with the number each must demonstrate.
+
+**Compact index** (action | title | P | gated-on):
+
+| # | Action | Title | P | Gated-on |
+|---|---|---|:--:|---|
+| M0 → #2818 | NEW | i4i cold-vs-warm server-direct `samply` profile | P1 | — (first) |
+| M1 → #2819 | NEW / EXTEND #1686 | Split `stream` RPC phase into data-plane sub-phases | P2 | — |
+| M2 → #2820 | NEW | L1 batch fan-in `sync_channel`, co-designed with #2765 | P1 | M0 (informs), #2765 co-design |
+| M3 → #2765 | EXTEND #2765 | Productionize adaptive egress budget + fan-out-past-drain + L1 256-cap co-design | P2 | M2 |
+| M4 → #1883 | EXTEND #1883 | L5 FxHash + L4 RowKey Arc hoist cheap bundle | P2 | — |
+| M5 → #2680 | EXTEND #2680 | Re-land: K=2 opt-in rotation + early-close cancel fix + admission-resize + #2792 required | P1 | #2782, #2792 |
+| M6 → #2821 | NEW | Streaming `do_get` result-budget wiring gap | P2 | — |
+| M7 → #2822 | NEW (investigate) | L3 reconcile singleton fast-path | P3 | M0 + M9 (overlap data) |
+| M8 → #2823 | NEW | L2 inline/thread-less merge (A/B-gated, narrow-only) | P3 | M2 |
+| M9 → #2043 | EXTEND #2043 | Repoint WS7 to pin the reconcile **overlap** multiplier | P3 | — |
+| M10 → #2824 | RESPEC #1518-adjacent (NEW) | `madvise(WILLNEED)` under Auto-mmap + `MADV_DONTNEED` post-scan | P3 | M0 (re-measure) |
+| M11 → #2825 | NEW | T4 byte-bounded batch sizing | P2 | — |
+| M12 → #2826 | NEW | T1+T2 bulk `ArrowToTrino` per-column copy + async prefetch | P3 | M2/M3 (post-server) |
+| M13 → #2827 | NEW | Keyed access-distribution probe | P2 | — |
+| M14 → #2828 | NEW (config) | Chunk-cache `block_cache.max_size` retune for 512Mi pod | P2 | — |
+| M15 → #2605 | EXTEND #2605 | Sharpen the DataFusion PoC measurement | P2 | — |
+| M16 → #2165 | RE-SCOPE #2165 | Decode-plane consolidation only (not a throughput lever) | P3 | — |
+| M17 → #2561 | CLOSE-WITH-VERIFY #2561 | BIG-path present-key no-scan verify test, then close (CLOSED) | P3 | — |
+
+**Body drafts + acceptance:**
+
+- **M0 (#2818) — i4i cold-vs-warm profile (NEW, P1).** Replay P0's `samply` method on the field i4i.xlarge
+  pod server-direct, cold then warm, on-CPU + off-CPU, recording SSTable-count/node + `DiskAccessMode`.
+  *Accept:* produces the first in-`stream` CPU decomposition on field hardware; reports cold−warm delta
+  (bucket 3), warm-i4i-vs-500k-M1-anchor ratio (bucket 1), and Stage-1/Stage-6 shares; confirms or
+  refutes buckets 1+2+3 ≈ 55–75%. **Dep:** none — first. **Dedup:** new; the field 5-phase metric
+  cannot express this.
+
+- **M1 (#2819) — phase-metric data-plane split (NEW / EXTEND epic AI #1686, P2).** Split the `stream` RPC
+  phase into sub-phase timers (cold-fault / decompress / merge / encode / gRPC-write). *Accept:* a
+  field dashboard attributes in-`stream` cost across ≥4 sub-phases; the cold-fault sub-phase is
+  isolable from `send` park/wake. **Dep:** none. **Dedup:** extends observability epic AI #1686
+  (#1701/#1705/#1707 why-slow phase timings) rather than a new metrics stack.
+
+- **M2 (#2820) — L1 batch fan-in `sync_channel` (NEW, P1).** Accumulate `Vec<MergeEntry>` in `forward_row`,
+  `send` one message per `BATCH_EMIT_ROWS` rows; consumer drains a held batch. Reuse F2/#1592's
+  `BATCH_EMIT_ROWS` + send-count/parity-oracle pattern. **Co-design with #2765 on the SAME channel**
+  (256-cap constant becomes batch-unit); **cut message-capacity** so resident rows stay bounded for
+  B4; preserve the #2419 `egress_channel_depth` gauge accounting and the #2361 cancel-aware
+  `recv_timeout`. *Accept:* per-row `send` count drops ~256× (send-count oracle); util throughput on
+  the server-direct `flight-loadgen --shape full` narrow rig rises measurably toward the 1.5–1.9×
+  ceiling; query-semantics + point-vs-full oracles green; peak RSS/stream unchanged. **Dep:** M0
+  informs but does not block (49.9% is already measured). **Dedup:** NEW — #2765/#2600 bound the
+  *outer* egress; F2/#1592 batched a *different* (public `scan_stream`) channel; the inner fan-in
+  `sync_channel` has zero coverage.
+
+- **M3 (#2765) — #2765 productionize + fan-out-past-drain + L1 co-design (EXTEND #2765, P2).** Land the
+  `clamp(BUDGET/active_merges, MIN, 256)` impl; reconcile the budget's message-unit with L1's batch
+  (else `clamp(…,256)` budgets 256 *batches* = 65k rows); then raise effective fan-out toward the
+  memory-safe admission ceiling. *Accept:* egress depth stays bounded under 80-thread overload
+  (no depth-8080 blowup) at <10% qps cost; fan-out raises realized per-pod concurrency only after L1
+  lands (no #2600 re-fire). **Dep:** M2. **Dedup:** extends #2765 (inventory: "extend #2765, don't
+  refile").
+
+- **M4 (#1883) — L5 FxHash + L4 RowKey Arc hoist bundle (EXTEND #1883, P2).** Swap the per-row
+  `HashMap<Arc<str>,Value>` (`row_build.rs:246`) to `FxHashMap`; hoist `RowKey(Arc<[u8]>)` build
+  outside `for entry in rows`. *Accept:* SipHash disappears from the row hot path (profile); alloc
+  count/row drops by one on multi-row-partition tables (#1883 dhat ratchet); ~1.04×+1.05–1.09× on the
+  multi-row-partition fixture, **1.0× credited on single-row-partition** (do not claim a field win the
+  profile can't support). **Dep:** none. **Dedup:** L4 lives under #1883 (already 0.17); L5 folds in.
+
+- **M5 (#2680) — #2680 re-land (EXTEND #2680, P1).** Default **K=1** (byte-identical pre-#2680), **opt-in
+  K=2** (the sub-split *rotation* carries flight-pod balance — NOT `getSplitWeight()`, which is
+  Trino-worker accounting), **never K=4 default**. Fix the early-close drain (a
+  `producer_thread_from_reader` blocked in `send` on a full fan-in channel must wake on `ScanCancel`).
+  Bundle the **memory-derived admission resize** (`--max-concurrent-scans` 64 → ~16–24 from
+  512Mi/per-stream-MB) as a forward guard. Require #2792 (Flight↔Trino E2E as a `required` check).
+  *Accept:* `SELECT id … LIMIT 2` under K≥2 returns 2 rows in **<5s** (not the 180s #2782 hang) in the
+  now-`required` E2E lane; server-side early-close drain unit test (no producer left blocked); busiest
+  pod CPU ≤~1.3× median @32thr (report-only next round); #2679 point read = 1 DoGet at any K; K=1
+  identity byte-for-byte. **Dep:** #2782 resolved, #2792. **Dedup:** re-land of reverted #2779; extends
+  #2680. **Owner note:** #2782 has no milestone — flag to owner (likely 0.16).
+
+- **M6 (#2821) — streaming result-budget wiring gap (NEW, P2).** The 64MiB `QueryConfig::n` result budget is
+  enforced only on the materializing `CollectSink` path; `rg result_budget cqlite-flight/src` returns
+  nothing — the streaming `do_get` path is bounded **only** structurally by the 4-deep batch channel
+  + admission K (P2:parallelism §2). *Accept:* either a byte budget is enforced on the streaming egress
+  (bounded per-stream residency independent of row width), or the gap is documented + admission is the
+  sole documented governor with a test pinning the per-stream ceiling. **Dep:** none. **Dedup:** NEW —
+  not covered by #2230/#2423 (which bound intra-partition materialization).
+
+- **M7 (#2822) — L3 reconcile singleton fast-path (NEW, investigate, P3).** In
+  `reconcile_cluster_with_overlap_counted`, when a cluster is a lone Live entry with no
+  row/complex/range deletion, no TTL/expiring cell, no dropped columns, emit directly and skip
+  `ReconcileState` construction + the winner map. *Accept:* the same PR extends
+  `query_semantics_oracle_parity.rs` AND `point_vs_full_differential.rs` with a
+  singleton/TTL-collision/tombstone case (so `--lite` exercises the fast-path vs the full path at a
+  pinned `now`); demonstrates ~1.20× on the disjoint-narrow-no-TTL fixture. **Dep:** M0 + M9 (the
+  field cluster-shape / overlap data — **its disposition is unresolved, §4**). **Dedup:** NEW; #2213
+  (Murmur3 per-comparison) is a minor complement.
+
+- **M8 (#2823) — L2 inline/thread-less merge (NEW, A/B-gated, P3).** For `k` inputs ≤ threshold + single
+  stream, pull each `RunReader` on the coordinator thread — no producer threads, no `sync_channel`.
+  *Accept:* ships behind a `k`+stream-count A/B gate that fires **only** where it wins; ~1.4–1.8× on
+  the narrow few-SSTable fixture; **≤1.0× wide → not credited in the field stack**; byte-parity
+  oracles green. **Dep:** M2. **Dedup:** NEW — no prior inline-merge bypass in `git log`.
+
+- **M9 (#2043) — #2043 repoint (EXTEND #2043, P3).** Repoint WS7 to pin the reconcile **overlap multiplier**
+  at field compaction state (the base is already ~2µs/row measured, machinery-dominated — NOT the
+  `[ASSUMED]` 10–500ns/row). *Accept:* reports reconcile ns/row for clusters spanning k generations
+  with real LWW/tombstone/TTL collisions; tightens the §3 derate's 1.1–1.5× gen-overlap term and
+  resolves the L3 disposition (§4). **Dep:** none. **Dedup:** re-scopes the existing #2043 spike.
+
+- **M10 (#2824) — madvise(WILLNEED) respec (NEW, P3).** Flip `Auto` to issue the already-built
+  `madvise(MADV_WILLNEED)` at open (`reader/mod.rs:1052`, currently gated off by `PrefetchMode::Auto →
+  None`) + `MADV_DONTNEED` post-scan-once; keep `posix_fadvise` only behind an explicit
+  buffered/direct backend. **Do NOT reach for `MADV_SEQUENTIAL`** (the #1143 ~2× p99 drop-behind
+  regression; re-run `issue_1143_mmap_prefetch_tail_guard.rs` if touched). *Accept:* cold-p99 on a
+  cold i4i scan improves marginally with no warm regression and no #1143 tail reintroduction. **Dep:**
+  M0 (the B4 justification is **stale** post-#2412 — reprice as a cold-p99 hedge, defer behind the
+  i4i re-measurement). **Dedup:** NEW; respec of P1.3's fadvise lever (dead code on the Auto-mmap path).
+
+- **M11 (#2825) — T4 byte-bounded batch (NEW, P2).** Cap MB/batch (finish on whichever of row-cap 8192 /
+  byte-cap trips first). *Accept:* wide-row batches stay under a configured byte ceiling; the
+  57,344-row Arrow egress buffer stops scaling to ~8MB/batch on wide rows (helps B4). ~1.0–1.1×
+  throughput — filed as a **robustness/correctness** lever, not throughput. **Dep:** none. **Dedup:**
+  NEW connector/server surface; #1476/#2230 are the read-path analogue.
+
+- **M12 (#2826) — T1+T2 connector follow-on (NEW, P3, post-server).** Bulk per-column `ArrowToTrino` copy
+  (varchar via `VariableWidthBlock(Slice, offsets, nulls)`, one `Slice.copyOf`/column; kill the 3.9M
+  per-scan `byte[]` allocs) + async batch prefetch (double-buffer `FlightStream.next()`). *Accept:*
+  page-build CPU drops ~10–20× isolated; combined pod effect ~1.1–1.3× **measured only after the
+  server ceiling is raised** (M2/M3) — at field per-stream rates today it is ~1.0× (page-build is
+  ~0.05% of the per-batch cycle). **Dep:** M2/M3 — sequenced LAST. **Dedup:** NEW connector surface
+  (AE #1470 is the server-side sibling); it is a **bulk copy**, not zero-copy.
+
+- **M13 (#2827) — keyed access-distribution probe (NEW, P2).** Instrument the field keyed partition access
+  distribution (skew/Zipf over existing `cqlite.read.partition_lookup.*`). *Accept:* reports the
+  hot-set concentration for the field keyed workload at A2-scale qps; **decides** whether a
+  64–128MiB decoded-partition cache clears a useful hit ratio. **Dep:** none — standalone, decoupled
+  from #2037. **Dedup:** NEW; it is the **gate** for the K-A decoded-cache build (which stays
+  reconciled with #2037 WS6, not filed standalone).
+
+- **M14 (#2828) — chunk-cache retune (NEW config, P2).** Retune `block_cache.max_size` (256MiB default =
+  `max_memory/4`) down for the 512Mi Flight/Trino pod; confirm cqlite-flight currently inherits the
+  library default (no override found). *Accept:* a filled chunk cache + concurrent stream working sets
+  stay under ≤512Mi peak under sustained point-read load; no throughput regression. **Dep:** none.
+  **Dedup:** config retune, not a refile; the real (peak) B4 item (idle-drain is demoted, §4).
+
+- **M15 (#2605) — #2605 sharpen (EXTEND #2605, P2).** The DataFusion PoC must (1) isolate the
+  **decode-to-column** delta from the **vectorized-exec** delta; (2) measure on **wide + RF=3/overlap**
+  shape, not RF=1 narrow; (3) record peak memory under B4 512Mi; (4) confirm both arms consume
+  **post-reconciliation** batches. *Accept:* reports the isolated decode-to-column delta on a
+  wide/overlap corpus; feeds the columnar-producer slot trigger (>1.3× → revisit; else Stage-3 prep)
+  and the #941 promotion decision. **Dep:** none. **Dedup:** sharpens existing 0.16 #2605.
+
+- **M16 (#2165) — #2165 re-scope (RE-SCOPE #2165, P3).** Keep as **decode-plane consolidation**
+  (`chunk_decode_single_plane.rs`), **not** a scan throughput lever. If wired-and-populated from
+  scans, it MUST ship with scan-resistant admission (K-G) or a scan evicts the keyed hot set.
+  *Accept:* the two query-reachable legacy-IO decode sites route through ChunkSource with no perf
+  regression; no scan-throughput multiplier claimed. **Dep:** none. **Dedup:** re-scope existing #2165.
+
+- **M17 (#2561) — #2561 close-with-verify (CLOSE-WITH-VERIFY #2561, P3).** The BTI bug is already fixed on
+  main (PR #2554); add a one-shot BIG-path assertion (present-key `get()` across a straddling BIG
+  partition asserts `SCAN_FOR_KEY_CALLS` delta == 0), then close. *Accept:* the verify test passes;
+  #2561 closes. **Dep:** none — ride the #2565 nit batch. **Dedup:** close, not refile.
+
+---
+
+*Committed under epic #2817 (0.17 scan-path throughput program); manifest items M0–M17 filed as
+issues #2818–#2828 (new) + #2765/#1883/#2680/#2043/#2605/#2165/#2561 (extended/closed) — see §7.*

--- a/docs/research/phase0-scan-cost-breakdown-2026-07.md
+++ b/docs/research/phase0-scan-cost-breakdown-2026-07.md
@@ -1,0 +1,276 @@
+# Phase 0 — Ground-truth CPU cost breakdown of a sustained single-stream Flight `do_get` full scan
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Author:** Phase-0 profiling agent
+
+This is the anchor measurement for the throughput research program. Every downstream
+multiplier claim should trace back to the numbers here. The headline is deliberately
+uncomfortable: **for a single-stream full scan, most of the CPU is NOT in SSTable parsing,
+merge compute, Arrow encoding, or gRPC. It is in the merge's per-row cross-thread channel
+handoff (kernel park/wake syscalls) and the allocator.** Read the CAVEATS section before
+quoting any figure — the local rig cannot see several field costs, and it exaggerates one.
+
+---
+
+## 1. Method
+
+**Primary method: sampling CPU profile of the real Flight server under sustained
+single-stream load** (method 1 from the brief). No derivation/arithmetic fallback was
+needed.
+
+- **Server:** the real `cqlite-flight` Arrow Flight server binary (`target/release/cqlite-flight`),
+  driving the real `FlightService::do_get` warm-reader row path
+  (`produce_streaming_from_readers` → `from_readers::drive_query_stream`, the thread-per-input
+  k-way merge). Batch size 8192, `--max-concurrent-scans 64` (never shed; single stream).
+- **Load driver:** the real `tools/flight-loadgen` binary, `--shape full` (full ring, no limit,
+  no token bounds → true full scan), `--ramp 1` (single concurrent stream), `--step-duration 62s`.
+  Talks plain gRPC to the server; drains and drops every batch.
+- **Profiler:** `samply record` (macOS, sampling at 1000 Hz, all threads). `samply` was made to
+  **launch** the server as its child (macOS `task_for_pid` attach needs entitlements; child-launch
+  gets the task port for free). ~50 s of the record window overlaps active scanning.
+- **CPU attribution is weighted by `threadCPUDelta` (µs of on-CPU time per sample), NOT by sample
+  count.** This was validated: idle threads show 0.0 s CPU against 115 s of wall time, so the CPU
+  delta is genuine on-CPU time, not wall time. This is what lets us separate real work from
+  backpressure parking.
+- **Symbolication:** the release profile is stripped (`[profile.release] strip = true`), so the
+  server was rebuilt unstripped (`CARGO_PROFILE_RELEASE_DEBUG=true CARGO_PROFILE_RELEASE_STRIP=false`)
+  and its 4,221 sampled frame addresses were resolved with `atos` against the debug-map binary.
+  System-dylib frames (kernel/malloc/platform) resolve only to their library, which is sufficient —
+  their stage owner is read from the nearest named CQLite ancestor frame.
+
+Two orthogonal attributions were computed and **they agree**:
+1. **By operation** — each sample's CPU charged to the leaf-most *non-generic* owning operation
+   (so a `malloc`/syscall is charged to the CQLite function that caused it).
+2. **By where cycles retire** — self-CPU by library (kernel vs own-code vs allocator vs memcpy).
+
+### Environment
+
+| | |
+|---|---|
+| Machine | Apple M1 Pro, 10 cores, 32 GB RAM, macOS (Darwin 25.5) |
+| Build | `release` + `debug=true`, `strip=false`, `panic=abort`, LTO on |
+| Data | **synthesized** `cassandra_easy_stress.keyvalue` (`key text PRIMARY KEY, value text`) — the real easy_stress field table shape |
+| Dataset size | 3,000,000 rows across **4 uncompressed SSTables** (`nb-*-big`, ~62 MB Data.db each, ~248 MB total), disjoint key ranges → genuine 4-way merge |
+| Cache | page-cache-warm (data read repeatedly across looped scans) |
+
+The largest *real* local table is 632 KB — a single scan finishes in milliseconds and cannot
+sustain a steady-state profile. A ~3 M-row single table was synthesized with the write engine
+(`WriteEngine`, durability disabled, auto-compaction off, one flush per SSTable) so a single scan
+runs ~6 s and a 62 s loop gives a clean steady state. **These SSTables are uncompressed** — the
+CQLite write path never emits `CompressionInfo.db` (claim boundary #1406) — which is the single
+most important caveat (see §5).
+
+---
+
+## 2. Throughput anchors (single-stream, warm, release)
+
+Measured at the Flight **client** (loadgen), concurrency 1, full scan:
+
+| Run | rows/s | MB/s (Arrow wire) | p50 latency / 3 M-row scan |
+|-----|-------:|------------------:|---------------------------:|
+| warm probe (stripped bin) | **537 k** | 157 | 5.54 s |
+| profile load A (stripped) | 506 k | 148 | 5.99 s |
+| profile load B (unstripped, the profiled run) | 501 k | 147 | 6.01 s |
+
+**Single-stream local anchor: ~500–540 k rows/s, ~150 MB/s of Arrow-IPC wire bytes** (≈ 880 MB
+per 3 M-row scan; the Arrow/gRPC wire form is ~3.5× the packed 248 MB on disk). Server-side
+processing rate matches (~500 k rows/s/stream).
+
+**Relation to the field's "~10 k rows/s/pod".** The local number is ~50× higher, for expected
+reasons, and the two are **not** comparable as-is:
+- Local is **RF=1, one SSTable set, no replica fan-out, no Trino**, page-cache-warm, **uncompressed**,
+  server-direct over loopback. The field number is **through Trino** (split planning + JDBC connector
+  + replica dedup + network) at **RF=3** over compressed SSTables with cold-ish cache and 1.93 M
+  partitions/node.
+- Narrow 2-column rows here maximize rows/s (little per-row data) while *also* maximizing the
+  per-row coordination overhead this report indicts. Wider field rows move MB/s up and rows/s down.
+
+Treat the local figure as the **server-direct single-stream ceiling for this row shape**, not a
+field prediction.
+
+---
+
+## 3. The CPU breakdown
+
+Total sampled on-CPU budget over the window: **154.1 CPU-seconds** (the scan is multi-threaded, so
+CPU-seconds exceed wall-seconds).
+
+### 3a. Where cycles actually retire (self-CPU by library) — the blunt truth
+
+| Where | CPU-s | % | What it is |
+|-------|------:|--:|------------|
+| **libsystem_kernel** | 84.4 | **54.7 %** | syscalls — overwhelmingly `sync_channel` park/wake between the per-SSTable reader threads and the merge coordinator |
+| **cqlite-flight (own code)** | 34.5 | **22.4 %** | the actual parse / merge / reconcile / materialize / Arrow-build logic |
+| **libsystem_malloc** | 27.2 | **17.6 %** | allocator — per-row allocations (MergeEntry, partition-key `Vec` copies, `QueryRow`, Arrow builders) |
+| libsystem_platform | 5.0 | 3.3 % | `memcpy`/`memmove`/`memset` |
+| dyld / pthread / other | 3.0 | 2.0 % | stubs, misc |
+
+> **Only ~22 % of single-stream CPU is CQLite's own logic. ~55 % is kernel syscalls for per-row
+> cross-thread channel coordination, and ~18 % is the allocator.** The data-plane compute is
+> dwarfed by coordination + allocation overhead for this workload.
+
+### 3b. By pipeline stage (CPU charged to the causing operation)
+
+Mapped onto the seven requested stages. The merge subsystem is split into its *compute* and its
+*cross-thread fan-in coordination* so the seven stages still sum to 100 %.
+
+| # | Stage | CPU-s | % | Notes |
+|---|-------|------:|--:|-------|
+| 1 | **SSTable IO + decompression** | 0.02 | **0.0 %** | page-cache-warm **and uncompressed** — near-zero. **Field will be materially higher** (see §5). |
+| 2 | **Binary parse / decode** (Data.db cell → Value) | 14.9 | **9.7 %** | `row_decoder`, `data_access`, cell/vint decode on the reader threads |
+| 3 | **Row materialization / per-cell conversion** | 6.9 | **4.5 %** | `entry_to_row` → `assemble_read_cells` → `build_row_from_scan`, `RowKey::new(pk.to_vec())` |
+| 4a | **K-way merge / reconcile compute** | 50.0 | **32.5 %** | `reconcile_cluster_with_overlap_counted`, `refill_heap` (BinaryHeap), `finalize_current_cluster`, `build_merge_entry` |
+| 4b | **Merge fan-in channel coordination** (park/wake) | 76.9 | **49.9 %** | `from_readers::forward_row` → `SyncSender::send`, one send **per row** into a cap-256 channel; ~94 % of it is kernel park/wake |
+| 5 | **Arrow encode** (RecordBatch build) | 1.6 | **1.0 %** | `rows_to_record_batch` / column builders — cheap for 2 narrow columns |
+| 6 | **gRPC / Flight write** (IPC serialize + h2 + socket) | 0.3 | **0.2 %** | near-zero on-CPU on loopback (see §5) |
+| 7 | **Everything else** (uncharged kernel/alloc) | 3.5 | **2.2 %** | plus SipHash partition-key hashing ≈ 4.5 %, distributed into stages 3/4a above |
+
+> Stage **4b** is not "merge math" — it is the **overhead of the thread-per-input parallel-decode
+> design**: every decoded row crosses a bounded `sync_channel` (capacity 256) to a single
+> CPU-bound coordinator, and because the coordinator cannot drain fast enough, the reader threads
+> spend ~72 s parked in `send` (kernel futex/semaphore). This overhead would not exist in a
+> single-threaded merge of the same data.
+
+**Error bars.** Stage boundaries are drawn by symbol name; a few percent can shift between adjacent
+stages (e.g. decode↔materialize, or SipHash between 3 and 4a). The *coarse* split — coordination +
+alloc ≫ own-compute, transport ≈ 0, IO ≈ 0 — is robust to ±3–4 pp reclassification. The two
+independent attributions (§3a self-by-library vs §3b by-operation) corroborate each other:
+kernel-55 % ↔ channel-50 %, malloc-18 % ↔ (charged into stages 3/4), own-code-22 % ↔ decode+materialize+reconcile-compute.
+
+### Thread architecture (why the split looks the way it does)
+
+Per `do_get`, the warm-reader path spawns **one reader thread per input SSTable**
+(`from_readers::drive_query_stream`), each decoding its SSTable and pushing rows over a bounded
+`sync_channel(256)` to **one k-way merge coordinator** (`produce_streaming` /
+`KWayMerger`) that reconciles, materializes, builds RecordBatches, and hands them to the tonic
+response via a separate `tokio::mpsc`. In the profile:
+- The coordinator thread carries ~62 CPU-s of real reconcile/materialize/hash/heap work — it is the
+  throughput limiter.
+- The ~44 reader threads carry ~72 CPU-s **almost entirely blocked in `send`** (~74 % of each
+  reader's time is park/wake, ~13 % actual decode) — they are starved by the coordinator.
+
+---
+
+## 4. Top-3 single-stream bottlenecks (with code paths)
+
+### #1 — Merge fan-in channel handoff: one `send` per row into a cap-256 `sync_channel` (~47–50 % of CPU)
+The dominant cost, and almost pure overhead.
+- `cqlite-core/src/storage/write_engine/merge/from_readers.rs:137` — `forward_row` → `sender.send(msg)`,
+  called **once per row** (33 M sends per scan).
+- `cqlite-core/src/storage/write_engine/merge/from_readers.rs:186` — `std::sync::mpsc::sync_channel(STREAMING_CHANNEL_CAPACITY)`.
+- `cqlite-core/src/storage/write_engine/merge/mod.rs:537` — `STREAMING_CHANNEL_CAPACITY = 256`.
+- Retire site: `libsystem_kernel` park/wake (Rust's `mpsc` is implemented over `mpmc`;
+  `mpmc::array::Channel::send::{{closure}}` was the caller of ~72 CPU-s of kernel time).
+
+**Why it dominates:** the payload is one `MergeEntry` per row, the channel is small (256), and the
+single consumer is CPU-bound, so producers constantly hit a full channel and park; each row costs a
+context-switch pair. For narrow rows the fixed per-row handoff cost swamps the actual data.
+**Lever directions (for downstream design, not measured here):** batch multiple rows per channel
+message; widen the channel; or bypass the per-input thread/channel entirely for the
+single-stream / few-SSTable case and merge inline.
+
+### #2 — K-way merge / reconcile compute on the coordinator (~32 % of CPU)
+The real merge math, and the true throughput limiter once #1's overhead is removed.
+- `cqlite-core/src/storage/write_engine/merge/mod.rs:4117` — `KWayMerger::reconcile_cluster_with_overlap_counted` (~9 CPU-s on the coordinator alone).
+- `cqlite-core/src/storage/write_engine/merge/mod.rs:2941` — `KWayMerger::refill_heap` (BinaryHeap pop/push).
+- `cqlite-core/src/storage/write_engine/merge/streaming.rs:567` — `StreamingMerger::finalize_current_cluster`.
+- `cqlite-core/src/storage/write_engine/merge/mod.rs:784` — `SSTableRowIteratorAdapter::build_merge_entry`.
+
+### #3 — Per-row allocation + partition-key hashing (~18 % malloc + ~4.5 % SipHash)
+- Allocator churn (17.6 % of CPU, `libsystem_malloc`) is driven by per-row allocations:
+  `RowKey::new(partition_key.to_vec())` at `cqlite-flight/src/producer.rs:1000` (copies the PK bytes
+  every row), `MergeEntry` construction, `QueryRow`/`RowCells` assembly in
+  `entry_to_row` (`cqlite-flight/src/producer.rs:967`), and Arrow builder growth.
+- SipHash partition-key hashing: 6.9 CPU-s / 4.5 % at `core::hash::sip` (`sip.rs:257`) via
+  `BuildHasher::hash_one` — the default `HashMap` hasher used for per-row partition-key lookups
+  (`PartitionKeyCache`). A faster hasher and/or fewer per-row key copies would cut into both this
+  and the malloc line.
+
+*(Allocation pressure was not counted with dhat — time-boxed. The 17.6 % malloc-CPU is the anchor;
+a dhat run on the producer path would give exact allocs/row and is the recommended follow-up.)*
+
+---
+
+## 5. CAVEATS — what this local rig cannot tell us about the field
+
+Ordered by how much they distort the numbers.
+
+1. **Uncompressed data → Stage 1 (IO+decompress) is ~0 % here; the field is NOT.** The CQLite write
+   path emits uncompressed SSTables (no `CompressionInfo.db`; the server logged *"Assuming no
+   compression"* for every file). Field Cassandra SSTables are **LZ4-compressed by default**, so the
+   field adds a whole decompression-CPU stage this profile is structurally blind to. On a
+   compressed corpus, expect Stage 1 to become a real single-digit-to-low-double-digit %, partly
+   drawn from the relative share of the other stages.
+2. **Page-cache-warm → IO-wait is invisible.** Data was reread every loop, so there is essentially
+   no disk `read()` wait. The field's 1.93 M partitions/node will not be fully resident; cold/partly-cold
+   scans add real IO-wait (wall time, not CPU) that this CPU profile does not capture. This profile
+   measures **CPU cost**, not IO-bound wall time.
+3. **Transport (Stage 6) ≈ 0 % is a loopback artifact.** Over loopback, the socket write is a cheap
+   kernel copy and the client drains-and-drops; arrow-flight IPC encode of already-columnar batches
+   is mostly `memcpy`. Over a real network (field), TLS, congestion control, and genuine
+   `send`/`recv` syscalls make Stage 6 materially larger. Do **not** conclude "gRPC is free."
+4. **Narrow 2-column `keyvalue` rows, one row per partition.** This is a real field table shape
+   (`cassandra_easy_stress.keyvalue`), but it is the *extreme* that **maximizes per-row coordination
+   and allocation overhead** (Stages 4b/7) and **minimizes** decode/materialize/Arrow-build per row
+   (Stages 2/3/5). Wide rows, clustering keys, and collections would shift weight toward Stages
+   2/3/5 and dilute the channel/alloc overhead. The #1 finding (per-row channel handoff) is
+   *worst* for this shape; treat 47–50 % as an upper bound for it, not a universal constant.
+5. **4 SSTables, disjoint keys, no tombstones/overlap.** Real nodes have more SSTables and genuine
+   reconciliation overlap (LWW collisions, tombstones, TTL). More inputs → more reader threads → the
+   Stage-4b channel cost gets *worse*; real reconciliation collisions make Stage-4a heavier. Both
+   push in the same direction (data plane up), but the exact split will move.
+6. **Apple M1 Pro, not i4i.xlarge.** Different core counts, memory bandwidth, syscall/context-switch
+   costs, and allocator (macOS `libsystem_malloc` vs glibc/jemalloc). The *shape* (coordination +
+   alloc dominate for narrow rows) should carry; the exact percentages will not. In particular the
+   macOS park/wake syscall cost may differ from Linux futex cost — the 55 % kernel share is the
+   figure most sensitive to OS.
+7. **RF=1, server-direct, no Trino.** No split planning, connector, replica dedup, or Trino
+   worker-side merge — all of which the field "10 k rows/s/pod" number folds in. This profile is the
+   layer *underneath* that number.
+
+---
+
+## 6. Reproduction
+
+```bash
+# 1. Build server unstripped with debug (dep tree already at debug=true):
+CARGO_PROFILE_RELEASE_DEBUG=true CARGO_PROFILE_RELEASE_STRIP=false \
+  cargo build --release -p cqlite-flight --bin cqlite-flight
+
+# 2. Synthesize a 3M-row / 4-SSTable keyvalue table (throwaway example, see note):
+cargo build --release -p cqlite-flight --example gen_bigtable   # uncommitted helper
+./target/release/examples/gen_bigtable <data_dir> 750000 4
+
+# 3. Profile the server under single-stream full-scan load:
+samply record --save-only --no-open -o profile.json.gz -r 1000 -- \
+  ./target/release/cqlite-flight --data-dir <data_dir> --listen 127.0.0.1:8815 \
+  --batch-size 8192 --max-concurrent-scans 64
+# in parallel:
+./target/release/flight-loadgen --endpoint http://127.0.0.1:8815 \
+  --ticket-template keyvalue-template.json --ramp 1 --step-duration 62s --shape full
+# then SIGTERM the server (by exact comm 'cqlite-flight') so samply finalizes.
+
+# 4. Symbolicate frame addresses with atos (-l 0x100000000) against the unstripped binary
+#    and CPU-weight samples by threadCPUDelta. (analysis scripts were ad-hoc Python.)
+```
+
+**Note on the generator:** `gen_bigtable.rs` is a throwaway generator (write engine + the
+`keyvalue` test fixture, durability disabled, auto-compaction off, one flush per SSTable). It was
+NOT committed and is removed after this run; the ticket template is a full-ring `FlightTicket` with
+no limit/token bounds.
+
+---
+
+## 7. One-paragraph summary for the program
+
+For a single-stream, warm, uncompressed full scan of a narrow `keyvalue` table, CQLite's Flight
+server spends **~55 % of CPU in the kernel** (per-row `sync_channel` park/wake between the
+thread-per-input decoders and the single k-way merge coordinator), **~18 % in the allocator**
+(per-row `Vec`/row/entry allocations + default-hasher key lookups), and only **~22 % in its own
+parse/merge/materialize/Arrow logic** — of which the real merge/reconcile compute is the largest
+piece. Actual SSTable IO+decompression (≈0 %, artifact of warm+uncompressed local data) and
+gRPC/Flight transport (≈0 %, loopback artifact) are invisible here and **will be real in the
+field**. The #1 addressable single-stream inefficiency is the **per-row cross-thread channel
+handoff** (`from_readers::forward_row`, cap-256 `sync_channel`); #2 is the k-way reconcile compute
+on the coordinator; #3 is per-row allocation + SipHash key hashing. Local single-stream throughput
+is ~500 k rows/s (~150 MB/s wire) — a server-direct RF=1 ceiling, ~50× the field's through-Trino
+RF=3 number, and not a field prediction.

--- a/docs/research/phase1-1-row-engine.md
+++ b/docs/research/phase1-1-row-engine.md
@@ -1,0 +1,163 @@
+# Phase 1-1 — Row-engine cost levers (keep the row pipeline, make it faster)
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · Agent 1/8 of the throughput program
+
+Anchored entirely to `docs/research/phase0-scan-cost-breakdown-2026-07.md` (the single-stream,
+warm, uncompressed, narrow-`keyvalue`, 4-way-merge CPU profile: 154.1 CPU-s total) and deduped
+against `docs/research/throughput-backlog-inventory-2026-07.md`. Every multiplier below shows its
+Amdahl arithmetic against the Phase-0 stage %s. **Read §0 (framing) before quoting any number.**
+
+---
+
+## 0. Framing — three things that make or break every number here
+
+1. **Amdahl ceiling.** Fixing a stage that is `X` of total CPU buys **at most `1/(1-X)` alone**;
+   combined levers multiply on the **residual** (`1/(1-X₁) · 1/(1-X₂')` where `X₂'` is stage 2's
+   share of what's *left*). None of these levers touch IO (0%) or transport (0.2%) — both are ~0 in
+   this rig and real in the field (Phase-0 §5 caveats 1–3), so a field re-profile can only *shrink*
+   these shares.
+
+2. **Per-stream-ceiling vs utilization — they are NOT the same win.** The 154 CPU-s is spread across
+   ~45 threads: one CPU-bound **coordinator** (~62 CPU-s of real reconcile/materialize/hash/heap
+   work = the single-stream throughput limiter) and ~44 **reader threads** carrying ~72 CPU-s that
+   is *almost entirely `send`-park* (blocked, not throughput-limiting).
+   - A **utilization lever** removes total CPU so more concurrent streams fit on the box (raises
+     aggregate rows/s under load; lifts B2/A2 qps). It may not move a single stream at all.
+   - A **per-stream-ceiling lever** shortens the *coordinator's* critical path or the pipeline
+     wall-time, raising the ~500 k rows/s single-stream number the brief asks to lift.
+   - The channel park/wake (Stage 4b, 49.9%) is *mostly* utilization (producer-side park, off the
+     critical path) with a *smaller* per-stream slice (the futex **wake** the coordinator's `recv`
+     fires to unpark a producer, once per row, **is** on the critical path). Both are labelled per
+     lever below.
+
+3. **Shape bound (Phase-0 §5 caveat 4).** The profiled narrow 2-column, one-row-per-partition
+   `keyvalue` shape is the *extreme* that **maximizes** the channel + alloc + hash shares (Stages
+   4b/3/7) and **minimizes** decode/materialize/Arrow (Stages 2/3/5). So the channel/alloc levers
+   are quoted at their **upper bound**; wide rows (clustering keys, collections) dilute them and
+   shift weight to decode/reconcile. Every multiplier below is bounded for **narrow AND wide**.
+
+**Constraints honored by all levers:** B4 peak ≤512 Mi (batching adds only bounded buffers;
+inline-merge *reduces* memory), A5 stability, byte-for-byte reconcile parity, no-heuristics (#28)
+untouched (no lever infers type/behavior from bytes).
+
+---
+
+## 1. Lever table
+
+| # | Lever | Mechanism | Anchored multiplier (arithmetic) | Kind | Cost | Risk | Issue | Evidence (file:line) |
+|---|-------|-----------|----------------------------------|------|------|------|-------|----------------------|
+| L1 | **Batch the k-way merge fan-in `sync_channel`** | Accumulate `Vec<MergeEntry>` in `forward_row` and `send` one message per `BATCH_EMIT_ROWS`(256) rows instead of one `send`/row; consumer `next()` drains a locally-held batch, one `recv` per batch. Drops sends/wakes **256×**. | Stage 4b = 49.9%, ~94% of it (≈47% of total) is kernel park/wake removable by batching. **Utilization:** `1/(1-0.47) ≈ 1.9×` aggregate CPU headroom. **Single-stream:** only the coordinator-side wake-per-`recv` is on the critical path (a fraction of 4b) → bounded **~1.15–1.35×**. Wide rows: park/wake share shrinks, so utilization ~1.4–1.6×, single-stream ~1.1×. | Mostly utilization + modest per-stream | **M** | Med (must preserve #2419 egress-depth gauge accounting + #2361 cancel-aware recv; batch becomes the gauge unit) | **NEW** (biggest gap — see §3) | send: `from_readers.rs:137,150`; cap: `mod.rs:537` (`=256`); recv: `mod.rs:1235`; batch-size precedent: `scan_stream_windowed.rs` `BATCH_EMIT_ROWS=256` |
+| L2 | **Inline (thread-less) merge for the few-SSTable single-stream case** | When `k` inputs ≤ small threshold and single stream, pull each `RunReader` iterator directly on the coordinator thread — no producer threads, no `sync_channel`. Eliminates **all** of Stage 4b. | Removes 49.9% entirely. **Utilization:** `1/(1-0.499) ≈ 2.0×`. **Single-stream narrow:** removes ~47% critical-path wake but *re-serializes* decode (Stage 2, 9.7%, was overlapped across ~4 threads) → adds back ~2–3×·0.097 ≈ +0.15–0.20 of critical path → net **~1.4–1.8×**. **Single-stream WIDE: NEUTRAL-to-NEGATIVE** (decode is large and its overlap is lost). | Highest single-stream ceiling (narrow only) | **L** | High (reconcile parity heart; shape-fragile; needs an A/B gate to prove it only fires where it wins) | **NEW** | architecture: `from_readers.rs:176` (`open_from_reader` spawns the thread); Phase-0 §4 "bypass the per-input thread/channel entirely for the single-stream / few-SSTable case and merge inline" |
+| L3 | **Reconcile singleton/no-overlap fast-path** | In `reconcile_cluster_with_overlap_counted`, when a clustering group has exactly one `Live` entry with no row/complex/range deletion and no gc/TTL work pending, emit it directly, skipping `ReconcileState` construction + per-`(column,cell_path)` winner resolution. | Stage 4a = 32.5%. Fast-path skips most per-cluster machinery for **singleton clusters** (every cluster in the disjoint-key profile). Cutting 4a to ~15% saves ~17.5 pp → `1/(1-0.175) ≈ 1.20×` single-stream. **Overlapping/wide field data: far less** (real reconciliation collisions keep the full path) — bound ~1.03–1.08×. | Per-stream ceiling (the true limiter once L1/L2 land) | **M–L** | Med-High (must be byte-identical to full reconcile; parity oracle load-bearing) | **NEW** | `mod.rs:4117` (`reconcile_cluster_with_overlap_counted`), `mod.rs:4156–4180` (ReconcileState steps); heap refill `mod.rs:2941` |
+| L4 | **`RowKey` Arc-per-partition hoist** | Build one `RowKey(Arc<[u8]>)` per partition (outside `for entry in rows`) and clone the `Arc` per row, instead of `RowKey::new(partition_key.to_vec())` (fresh alloc+memcpy) every row. | Part of malloc 17.6% + Stage 3 (4.5%). **WIDE rows** (many rows/partition): removes ~1 alloc+copy/row → bound `1/(1-0.05..0.08) ≈ 1.05–1.09×`. **NARROW (1 row/partition): NEUTRAL** — one Arc/partition == one Arc/row, only the `.to_vec()` copy saved. | Utilization + wide per-stream | **S–M** | Low | under **#1883** (0.17 per-row alloc budget — this is a concrete fix; #1883 is the ratchet) | alloc site: `producer.rs:1000` (`RowKey::new(partition_key.to_vec())`); loop: `producer.rs:812,817` (`key.key` constant across `rows`); `RowKey(Arc<[u8]>)` at `types.rs` |
+| L5 | **FxHash the per-row `row_values` map** | Swap the default-`RandomState` (SipHash) `HashMap<Arc<str>,Value>` built once per row to `rustc_hash::FxHashMap`. Keys are **internal** interned column names — no HashDoS surface. | SipHash ≈ 4.5% of CPU. FxHash removes ~0.038 → `1/(1-0.038) ≈ 1.04×`. Nearly free; same on narrow & wide (per-row map is per-row regardless). | Utilization | **S** | Low (FxHash already adopted in read path #1590/#1817 — no revert) | **NEW** (trivial; fold under E-hygiene / #1883) | `row_build.rs:246` (`HashMap::with_capacity`, default hasher); precedent `#1817` FxHashMap row map, `#1590` E8 FxHash |
+
+*Note:* Phase-0 attributes SipHash to "`PartitionKeyCache`", but that struct is a **single-entry
+decode cache** (`row_build.rs:125`, no hashing). The real per-row SipHash is the `row_values`
+`HashMap` at `row_build.rs:246`. L5 targets the actual site. (For a 2-column row a `SmallVec`
+beats any HashMap; FxHash is the S-cost version, a Vec swap is the M-cost follow-on.)
+
+---
+
+## 2. Combined-lever arithmetic (multiply on the residual)
+
+Cheap bundle then headline then limiter, aggregate-CPU / utilization view:
+
+```
+L5 (FxHash)          1.04×
+L1 (batch channel)   1.89×   (park/wake removal, utilization)
+L3 (reconcile fast)  1.20×   (residual, disjoint/narrow)
+                     ------
+aggregate util ≈ 1.04 × 1.89 × 1.20 ≈ 2.36×   (NARROW, disjoint — upper bound)
+```
+
+Single-stream (~500 k rows/s) view — only per-stream-ceiling slices count:
+
+```
+L5  1.04×  ·  L1 ~1.25×  ·  L3 ~1.20×  ≈ 1.56×  → ~780 k rows/s   (NARROW)
+   + L2 instead of L1 (narrow, few-SSTable): L1's ~1.25 → L2's ~1.6 → ~1.9× total → ~950 k rows/s
+```
+
+**Wide-row single-stream** collapses toward ~1.05–1.15× total (L1 park/wake share shrinks, L3
+singletons vanish, L4 replaces L5 as the live lever). This is expected and correct: the narrow shape
+is where the row engine's *coordination/alloc tax* is worst, so it is where these levers pay most.
+
+---
+
+## 3. Existing-issue → Phase-0-stage map (what buys which slice)
+
+| Phase-0 stage | % CPU | Existing groomed issue(s) | Verdict |
+|---|---|---|---|
+| **4b — fan-in channel park/wake** | **49.9%** | **NONE.** #2765 (adaptive egress budget) and #2600 (shipped) bound the **OUTER** merge→tonic `tokio::mpsc` egress depth (stability/B4/A5) — a *different channel*. F2 #1592/PR #2100 batched the **single-generation public `scan_stream`** forwarder — also a different channel. Neither touches the **inner per-SSTable→coordinator `sync_channel`** Phase-0 indicts. | **NEW filing required (L1/L2).** The single largest cost has zero existing coverage. Do NOT credit #2765 with this multiplier — it is orthogonal (depth cap, not per-row CPU). |
+| **4a — reconcile/heap compute** | **32.5%** | NONE targets a reconcile fast-path. Epic Q #1610 (write/compaction alloc discipline) is adjacent but unstarted/off-target. #2213 (Murmur3 recomputed per heap comparison) is a real *small* 4a sub-cut, already filed. | **NEW filing (L3).** #2213 is a legit minor complement (heap comparator). |
+| **3 + malloc — materialize/alloc** | 4.5% + 17.6% | **#1883** (0.17, per-row alloc budget/ratchet) — the *measurement*; L4 (`RowKey` hoist) is the concrete fix under it. #1817 (partition-key decode hoist) is precedent. | **#1883 keeps** (relevant). L4 is a new concrete fix beneath it. |
+| **2 — parse/decode** | 9.7% | Epics I–M (#1602–#1606) **all CLOSED** — already optimized. #2165 (route sequential_scan decode through ChunkSource) is *consolidation*, not a speedup. | Stage largely mined out. See demotions. |
+| **5 — Arrow encode** | 1.0% | AE-series #1497/#1498/#1500 (delta emit / Node parquet). | Buys ≤ `1/(1-0.01)=1.01×` on THIS shape. Real for wide/collection & export paths, **not scan throughput on narrow rows.** |
+| **1 / 6 — IO / transport** | 0% / 0.2% | — | Invisible in-rig; field-real (Phase-0 §5). Out of this agent's row-engine scope. |
+
+### Issues Phase-0 proves near-worthless *as single-stream throughput levers* (say it bluntly)
+
+- **#2177** (stale `range()` comment nit) — a **comment fix**, 0% CPU. Not a perf lever.
+- **#1655** (M2 campsite file-split tracking) — hygiene, 0% CPU.
+- **#2165** (route `iterate_all_partitions`/`sequential_scan` through ChunkSource) — Stage 2 is only
+  9.7% *and* this is decode-plane *consolidation*, not an optimization; expected perf-neutral.
+  Worthless as a throughput lever (keep only for maintainability).
+- **#2349** (UDT registry into flight reads, CLOSED) — a **correctness/decode** fix; the narrow
+  `keyvalue` shape has no UDTs, so zero throughput bearing. Not a lever.
+- **AE Arrow-encode series (#1497/#1498/#1500)** — Stage 5 = 1.0%; ≤1.01× on narrow scan. Demoted
+  for *this* program (they remain valid for the export/wide-collection path they were filed under).
+- **#2765** (adaptive egress budget) — **not demoted, but re-scoped:** it is a **stability/B4/A5**
+  lever on the outer egress channel, NOT the Stage-4b per-row CPU lever. It must not be conflated
+  with L1.
+
+### Phase-0 levers with NO existing issue → new filings
+
+1. **L1 — batch the k-way merge fan-in `sync_channel`** (headline; ~1.9× utilization). NEW.
+2. **L2 — inline/thread-less merge for few-SSTable single-stream** (highest narrow single-stream
+   ceiling; shape-fragile). NEW. Can be an A/B experiment gated on `k` and stream count.
+3. **L3 — reconcile singleton/no-overlap fast-path** (true per-stream limiter once L1/L2 land). NEW.
+4. **L5 — FxHash the per-row `row_values` map** (freebie). NEW/trivial (fold under E-hygiene/#1883).
+   (**L4** already has a home under **#1883**.)
+
+---
+
+## 4. Prior-attempt check (don't re-propose reverted work)
+
+- **F2 #1592 / PR #2100** "batch the public streaming channel (stop one async wake per row)":
+  batched the **single-generation `scan_stream`** forwarder (the outer `Vec<Row>` surface into the
+  query-engine consumers), reusing `BATCH_EMIT_ROWS`. **Did NOT touch the inner k-way-merge fan-in
+  `sync_channel`** (that path re-batches via a per-run `RunReader` peek-buffer `refill_buffer`, but
+  the channel itself is still one message/row — `from_readers.rs:150`). **Not merged, not reverted —
+  simply a different channel.** L1 is the un-taken sibling and F2 is the *precedent* (technique,
+  `BATCH_EMIT_ROWS` constant, parity/send-count oracle test pattern in
+  `issue_1592_stream_channel_batch.rs`) — reuse it.
+- **#1143 / PR #1265** "batched row emission" (windowed-scan p99) — another batching precedent, also
+  a different (windowed-scan) path. Not reverted.
+- **#1817 / PR #2221** "partition-key hoist + internal FxHashMap row map" and **#1590 / PR #1877**
+  "E8 FxHash bundle" — FxHash **already adopted** in the read path and **not reverted**. L5 extends
+  the same accepted pattern to the still-default-hashed `row_values` map. No re-litigation risk.
+- **#1668 / PR #2304** within-partition streaming merge (Q5) — established `streaming.rs`
+  `finalize_current_cluster`; L3 must slot its fast-path *inside* that reconcile call to stay parity-safe.
+- No prior attempt at an inline/thread-less merge bypass (L2) or a reconcile singleton fast-path (L3)
+  was found in `git log`.
+
+---
+
+## 5. Recommended sequence (multiplier-per-effort)
+
+1. **L5 FxHash `row_values`** — S, low-risk, ~1.04×, accepted precedent. Bundle as the warm-up.
+2. **L4 `RowKey` Arc hoist** — S–M, low-risk; wide-row alloc win, neutral on narrow. Land under #1883.
+   *(1+2 are a cheap "free multiplier" bundle, ~1 PR.)*
+3. **L1 batch the fan-in `sync_channel`** — M, the headline. Best multiplier-per-effort: ~1.9×
+   utilization + ~1.15–1.35× single-stream, reusing the F2 batch machinery & oracle pattern. **NEW.**
+4. **L3 reconcile singleton fast-path** — M–L; the true per-stream ceiling lever once L1 exposes the
+   coordinator as the limiter. Parity-oracle-gated. **NEW.**
+5. **L2 inline-merge bypass** — L, highest narrow single-stream ceiling (~1.6–1.8×) but shape-fragile
+   (loses decode overlap → wide-neutral/negative). Ship **only** behind an A/B gate on `k`+stream
+   count; it is the experiment, not the default. **NEW.**
+
+**One-line for the program:** the single biggest single-stream lever the backlog does not cover is
+**L1 — batching the inner k-way-merge fan-in channel** (Stage 4b, 49.9%); it needs a new filing,
+reuses F2's proven batch machinery, and #2765 is NOT it (that's the outer egress-depth stability
+cap). L5+L4 are near-free companions; L3 then L2 are the successive single-stream-ceiling pushes,
+both parity-risky and both un-filed.

--- a/docs/research/phase1-2-columnar.md
+++ b/docs/research/phase1-2-columnar.md
@@ -1,0 +1,366 @@
+# Phase 1 — Agent 2/8: Columnar / vectorized scan path
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Scope:** READ-ONLY analysis
+**Anchor:** `docs/research/phase0-scan-cost-breakdown-2026-07.md` (the ground-truth CPU profile)
+**Dedup base:** `docs/research/throughput-backlog-inventory-2026-07.md`
+
+> **Headline (uncomfortable, on purpose).** For the Flight `do_get` full-scan throughput number,
+> **columnar / DataFusion is oversold.** Phase-0 proves Arrow encode is **1.0 %** of CPU and the
+> real cost is the k-way **reconcile (32.5 %)** plus per-row **channel coordination (49.9 %)** and
+> **allocation (17.6 %)**. Columnar decode-to-Arrow-columns can delete **row materialization
+> (4.5 %)** + the redundant transpose + per-row alloc — a **~1.2–1.5× multiplier that scales with
+> row width** — but it **cannot touch the reconcile**, which is inherently row/cell-ordered and is
+> the field's dominant per-row derate under RF=3. The Stage-2 levers are, in order: (1) delete the
+> per-row channel handoff [threading fix, not columnar], (2) parallelize splits across the pod's 4
+> vCPUs [#2680, not columnar], (3) control alloc [not columnar], (4) columnar decode [this memo] as
+> a secondary multiplier that earns its keep on **wide rows and analytical (aggregate/filter) query
+> shapes**. Recommend a **scoped columnar scan producer for 0.17 (M, low-risk)** — NOT the full
+> #941 DataFusion program.
+
+---
+
+## 1. What Stage 2 actually requires — the arithmetic
+
+### 1.1 The ladder and the two anchors
+
+Ratified A4 ladder (`941-datafusion-decision-brief-2026-07.md` §"ladder math",
+`performance-goals-2026-07.md`):
+
+```
+baseline 10k  →  Stage 1: 100k  →  Stage 2: 600k  →  Stage 3: millions   (rows/s/pod)
+   R12 field       row-engine        "not row-at-a-time"     "columnar"
+   (~10.6k)        territory         per the brief           per the ladder
+```
+
+- **Field baseline (R12, #2367):** ~10.6k rows/s/pod (1.94M rows / 61.1s / 3 pods), through Trino,
+  RF=3, LZ4, ~1.9M partitions/node, 4-vCPU pods.
+- **Local ceiling (Phase-0):** ~500k rows/s **single stream**, M1 core, RF=1, narrow 2-col rows,
+  warm, **uncompressed**, server-direct. This is **≈2.0 µs/row of real coordinator work** (see
+  below) — NOT a field prediction, ~50× the field number for known reasons.
+
+The brief reads Stage 2 as "600k rows/s/pod = ~1.6 µs/row end-to-end … vectorized-execution
+territory." **That reading conflates rows/s/pod with single-thread µs/row.** A pod has **4 vCPUs**.
+600k rows/s/pod is only 1.6 µs/row *if the merge runs on one core*. With parallel splits across 4
+vCPUs it is **6.4 µs/row/core** — squarely reachable by a row engine. So the real question is not
+"can one coordinator hit 1.6 µs/row" but "can 4 parallel per-split merges hit 600k/pod aggregate,
+on wide/RF=3/LZ4 data."
+
+### 1.2 Where the single-stream ceiling really comes from (Phase-0 re-read)
+
+Phase-0's critical finding, restated precisely: **single-stream throughput is limited by the one
+k-way merge coordinator doing real reconcile+materialize+arrow work; the 49.9 % channel park/wake
+is the reader threads idling *because the coordinator cannot drain them*** (report §3, thread
+architecture: "coordinator carries ~62 CPU-s of real work — it is the throughput limiter"; "reader
+threads … almost entirely blocked in `send` … starved by the coordinator"). So:
+
+- **Coordinator real work ≈ 2.0–2.5 µs/row** (≈500k rows/s, one core). Composition (by-stage §3b,
+  charged to the coordinator): reconcile **4a 32.5 %** + materialize **3 4.5 %** + arrow **5 1.0 %**
+  + its slice of alloc (part of malloc **17.6 %**) + SipHash key-hash (**4.5 %**).
+- **Channel 4b (49.9 %)** and most of **malloc (17.6 %)** are *overhead / symptom* of the
+  thread-per-input design and per-row `QueryRow`/`RowKey`/`MergeEntry` churn — deletable, but
+  deleting them frees CPU (helps multi-stream throughput/pod and total CPU-s), it does not by itself
+  raise the coordinator's serial ceiling much.
+
+### 1.3 Model: real single-threaded compute per row
+
+Sum the genuine data-plane stages (by-stage §3b, which sums to 100 % over 154.1 CPU-s):
+
+| Stage | % | Deletable by… |
+|---|---|---|
+| 2 decode | 9.7 | irreducible (needed to feed reconcile) |
+| 3 row materialize (`entry_to_row`→`QueryRow`) | 4.5 | **columnar** (this memo) |
+| 4a reconcile / LWW / tombstone | **32.5** | **irreducible** — not columnar, not threading |
+| 5 arrow build | 1.0 | already cheap |
+| 4b channel park/wake | 49.9 | **threading** (batch handoff / inline merge) |
+| malloc (by-library, distributed into 3/4a/4b) | 17.6 | ~half **alloc discipline + columnar**, ~half irreducible output |
+| SipHash key hash | 4.5 | faster hasher / fewer key copies |
+
+**Real compute** = decode 9.7 + materialize 4.5 + reconcile 32.5 + arrow 1.0 ≈ **47.7 %**, plus
+~half the malloc (~9 %) that is genuine output/Arrow ≈ **~57 % of 154.1 CPU-s ≈ 88 CPU-s**. Over
+the profiled ~25M rows (≈500k/s × ~50s active), that is **≈3.5 µs/row of real single-threaded
+compute** on an M1 core, RF=1, narrow, warm, uncompressed.
+
+- One inline-merge core (channel deleted): **~3.5 µs/row → ~285k rows/s/core**.
+- 4 parallel per-split merges on a pod (perfect parallelism, M1-class cores, RF=1 narrow warm):
+  **~1.14M rows/s/pod** — *above* Stage 2.
+
+### 1.4 The field derate — why the row pipeline lands *near but likely short of* 600k
+
+The M1/RF=1/narrow/warm/uncompressed number must be derated to field (4-vCPU, RF=3, wide, LZ4):
+
+| Factor | Effect on µs/row | Which stage |
+|---|---|---|
+| RF=3 fan-in | reconcile ~2–3× more input cells to compare/shadow across replicas×gens | **4a (the big one)** |
+| LZ4 decompress | Stage 1 goes 0 %→ real single-digit-to-low-double-digit % | 1 (invisible in Phase-0) |
+| Wide-ish rows (many cells/row) | decode + materialize + arrow + alloc scale with cell count | 2, **3**, 5, malloc |
+| Slower cores (i4i.xlarge vCPU < M1) | ~1.3–2× | all |
+| Cold-ish cache (1.9M part/node) | IO-wait (wall, not CPU) | 1 |
+
+Net per-row derate ≈ **3–5×** → single-core field **~10–17 µs/row** → **4 vCPUs ≈ 240k–400k
+rows/s/pod** on a *fixed row pipeline* (channel deleted, alloc controlled, splits parallelized).
+
+**Conclusion (arithmetic):**
+
+- A fixed row pipeline + agent-1 fixes credibly reaches **~250k–500k rows/s/pod** — a **25–50×**
+  jump over R12's ~10.6k, i.e. **Stage 1 (100k) comfortably, and into the lower half of the gap to
+  Stage 2**, but **likely short of the 600k bar** on wide/RF=3/LZ4 data.
+- The residual gap to 600k is dominated by **RF=3 reconcile (4a)** and **wide-row per-cell
+  decode/materialize** — NOT by Arrow encode and NOT by the container format.
+- **Columnar decode is NOT structurally required to reach Stage 2, and it does not remove the
+  dominant field cost (reconcile).** It removes the *materialize + transpose + alloc* slice, which
+  grows with row width — a real but secondary multiplier. The ladder itself places full columnar at
+  **Stage 3 (millions)**, above Stage 2 — consistent with this finding.
+
+---
+
+## 2. Decode-directly-to-Arrow-columns — where it attaches, and the correctness problem
+
+### 2.1 The current path (two row materializations, then a transpose)
+
+```
+KWayMerger.step()  → MergeStep::Partition{ key, rows:[MergeEntry] }        (merge/mod.rs, streaming.rs)
+  producer.drive_merge (producer.rs:785)  per entry:
+    entry_to_row (producer.rs:967)
+      assemble_read_cells (merge::assemble_read_cells)   → RowCells         [reassemble collections]
+      RowKey::new(partition_key.to_vec())  (producer.rs:1000)               [per-row PK Vec COPY = malloc]
+      build_row_from_scan_cached → QueryRow                                 [row-oriented carrier alloc]
+    buffer.push(row)                        → Vec<QueryRow>                  [MATERIALIZATION #1]
+    at batch_size: flush_buffer → rows_to_record_batch (arrow_convert.rs:197)
+      convert_to_arrays (arrow_convert.rs:1296)
+        transpose_columns(columns, rows)    → Cells per column              [MATERIALIZATION #2 / transpose]
+        convert_column_to_array per column  → ArrayRef                      [typed builder append]
+```
+
+There are **two** materializations: the `Vec<QueryRow>` buffer, then `transpose_columns` re-scatters
+those rows back into per-column slices (`arrow_convert.rs:1300`) before the typed builders run. The
+typed column builders already exist and are CQL-type-driven (`convert_column_to_array`,
+`arrow_convert.rs:1322` — no heuristics, authoritative `cql_type`).
+
+### 2.2 The columnar attach point
+
+A columnar scan producer **replaces the `Vec<QueryRow>` buffer with a set of per-column Arrow
+builders** and makes `entry_to_row` append each surviving cell straight into its column's builder:
+
+```
+drive_merge per surviving entry:
+  reconcile stays IDENTICAL (row-wise, in KWayMerger)                       [UNCHANGED]
+  assemble_read_cells → RowCells                                           [UNCHANGED]
+  → for each needed column: builder[col].append(cell_value_or_null)         [NEW: direct scatter]
+  cell tombstone → append null;  row tombstone → skip row (append nothing)  [reconcile result]
+  at byte/row cap: finish() all builders → RecordBatch                      [replaces flush_buffer]
+```
+
+Attach sites: **`producer.rs` `drive_merge`/`flush_buffer`** (buffer → builder set) and the
+**`entry_to_row`→builder append** edge. Deletes: materialization #1 (`QueryRow` + `RowKey::new`
+PK-copy), materialization #2 (`transpose_columns`), and the per-row row-carrier allocs. Reuses:
+every typed builder in `arrow_convert.rs`.
+
+### 2.3 The correctness problem — three options, only one is 0.17-shaped
+
+The k-way merge/reconciliation is **inherently row/cell-ordered**: LWW is per-cell by writetime, and
+tombstones **shadow across SSTables/generations** (a value in gen-47 can be killed by a tombstone or
+a newer-timestamp cell in a *different* generation or the tail). #2037 §7b makes this explicit: a
+per-SSTable columnar file is *wrong as a standalone answer*.
+
+| Option | Description | Tombstone reconciliation | Query-semantics oracle | Verdict |
+|---|---|---|---|---|
+| **(a) merge keys row-wise, scatter values into column builders** | Reconcile exactly as today; a surviving row's cells append to column builders (cell tombstone→null, row tombstone→skip) | **Compatible** — reconcile is byte-for-byte unchanged; only the output *container* changes | **Unchanged by construction** — identical row set, values, order at pinned `now` | **RECOMMEND** |
+| (b) merge-then-gather | Materialize `Vec<QueryRow>`, then transpose to columns | Compatible (this is essentially TODAY's path) | Unchanged | No net win — it *is* the redundant double-pass we want to delete |
+| (c) per-SSTable columnar decode + merge-on-sorted-runs | Decode each SSTable to columns independently, merge columnar runs | **Broken cheaply** — cross-gen tombstone shadowing means a per-SSTable column is not a final answer; you must carry the full LWW envelope (writetime/TTL/deletion per cell) columnar and merge columnar | Would need the #2037 per-generation-cache design to stay correct | **Reject for 0.17** (this IS #2037, a large exploration) |
+
+**Only option (a) is compatible with the parity oracles at low cost**, because reconciliation is
+untouched and only the output container changes:
+
+- **Physical-dump parity** (`*-Data.db.jsonl`): enumerates on-disk cells incl. tombstones — unaffected,
+  it operates below the producer.
+- **Query-semantics oracle** (`query-semantics-oracle.json`, gate component `query-semantics-oracle`):
+  post-reconciliation `SELECT` result set at a pinned `now` — **identical by construction** under (a).
+- **Point-vs-full differential** (`point_vs_full_differential.rs`): unaffected (routing knob, both
+  paths reconcile identically).
+- **No-heuristics**: builders are driven by authoritative `cql_type` (existing
+  `convert_column_to_array` dispatch) — no byte-pattern inference introduced.
+
+Wiring-evidence for done: route the **query-semantics oracle lane and the physical-dump smoke
+through the columnar producer** (extend #2374's Flight-do_get oracle lane) so the surface is
+exercised end-to-end, not just a helper unit test.
+
+### 2.4 The B4 memory trap (≤512Mi peak)
+
+Columnar builders hold a **whole batch in flight** (row cap 8192 × all columns × per-cell backing).
+For wide rows this is exactly the hazard the #941 council flagged (`issue-941-design-a` §memory:
+"byte_cap is the primary governor … 8 MiB/batch × 4-batch channel = 32 MiB/scan … the target is
+plausibly blown under fan-out"). Under **B4 ≤512Mi peak** with the pod running ~4 concurrent
+split-merges plus egress channels, the columnar batch **must be bounded by BYTES, not rows** — carry
+the #1907 lesson forward: byte_cap primary (start ~4–8 MiB, drop to 2–4 MiB for wide tables), finish
+the batch on whichever of row-cap / byte-cap trips first. A naive `8192-row` builder on wide rows can
+blow the budget. **A5 stability** actually *improves*: deleting per-row `QueryRow`/`RowKey` malloc
+removes allocator jitter that shows up in p99 (Phase-0 stage-3/malloc), provided batch memory is
+byte-bounded so peak doesn't spike.
+
+---
+
+## 3. Disposition of existing work — #941 / #2605 / #2037
+
+Treating **#941 and #2605 as ONE lineage** (the brief scopes #2605 as the de-risking spike for the
+#941 promotion decision) and #2037 as a separate owner-gated exploration:
+
+### 3.1 #941 Design-A epic (#1905–#1914) — keep Backlog, owner-gated; NOT a 0.17 throughput pull
+
+The Design-A packet is an **MPP / analytical-execution surface** (a DataFusion `TableProvider` so
+DataFusion can run leaf scans while Trino stays the MPP scheduler), gated behind Sidecar snapshot
+manifests/leases, split planning, ring-coverage correctness, and 8 non-negotiable invariants. It is
+**not a throughput fix for the existing do_get path**:
+
+- Its value is **vectorized filter / project / aggregate / join over already-reconciled batches** —
+  which helps *analytical query shapes*, not the full-scan `do_get` rows/s number Phase-0 measured
+  (where Arrow encode is 1.0 % and the cost is the reconcile that happens *before* DataFusion sees a
+  batch). DataFusion vectorization **does not speed up the k-way reconcile**.
+- It is **L** (10 children, MPP integration, Sidecar leases, signed manifest, Java+Rust type
+  contract, E2E-vs-Trino capstone #1912). The hard blocker #1907 (`Vec<RecordBatch>` → bounded
+  cancellable stream) is real work the row path also wants.
+- **Disposition:** leave at Backlog/P3 owner-gated. Its A3 streaming-producer blocker (#1907)
+  partially overlaps the columnar scan producer below — sequence so the columnar producer lands the
+  bounded-stream + byte-cap plumbing that #1907 needs, de-risking #941 as a side effect.
+
+### 3.2 #2605 TableProvider PoC (0.16, P2) — keep, but SHARPEN what it must measure
+
+As filed, #2605 benches DataFusion vs the row engine on three shapes (count(\*), projected scan,
+filtered scan) on the R12 corpus, feature-gated, zero wiring. **The risk is it measures the wrong
+delta** and over- or under-sells columnar. To de-risk the 0.17 call it must isolate:
+
+1. **Decode-to-column delta vs vectorized-exec delta, separately.** How much of any DataFusion win
+   comes from (i) not materializing `QueryRow`+transpose (which cqlite can capture *without*
+   DataFusion, via §2 option (a)) vs (ii) vectorized filter/aggregate over batches (which *needs*
+   DataFusion)? These are different levers with different costs — the PoC must attribute the delta,
+   not just report a single ratio.
+2. **On the field regime, not RF=1 narrow warm.** Measure on **wide-ish rows + a multi-generation /
+   RF=3-shaped merge fan-in**, else it measures the regime where columnar helps *least* (narrow) or
+   *most* (misleadingly) and mispredicts the field.
+3. **Peak memory under B4 (≤512Mi).** Record builder/batch peak at the chosen byte_cap — a
+   throughput win that blows 512Mi is not a win.
+4. **The reconcile is unchanged in both arms.** Confirm the PoC feeds *post-reconciliation* batches
+   to DataFusion (it must — reconcile can't move into DataFusion without breaking Cassandra
+   semantics), so the measured delta is honestly "post-merge vectorization," not "faster merge."
+
+Its result then feeds the brief's trigger rule (Stage-1 <~30k/pod → promote #941 for 0.16; else
+#941→0.17 with the spike banked).
+
+### 3.3 #2037 ArrowMemtable (#2043 WS7 only) — keep owner-gated; harvest #2043's constant
+
+- The epic's **post-merge-columnarization principle** ("row format until data stops mutating; Arrow
+  from the first immutable moment; the columnar copy never has to be independently query-answerable
+  because the tombstone-aware merger runs first") is **exactly the design law that validates §2
+  option (a)** — columnarize *after* reconcile, never per-SSTable. Good corroboration, but the epic
+  itself is a **Cassandra-coordinator CEP-11 play** (in-JVM memtable plugin, freshness protocol),
+  **out of scope** for the do_get throughput lever.
+- **#2043 (WS7 bench spike) is directly useful and should be harvested regardless of #2037's fate:**
+  it produces the **k-way merge ns/row** and **nb decode throughput** constants that the entire
+  Stage-2 arithmetic hinges on. Today those are a `[ASSUMED]` **10–500 ns/row** blind spot (a
+  25–50× unreconciled spread, per #2037 §12.1). Until #2043 pins the real reconcile ns/row, §1.4's
+  derate is an estimate. **Recommend feeding #2043's measurement into the #2605 report.**
+- **Disposition:** #2037 stays owner-gated exploration ("do not promote WS1–9 without owner");
+  pull *only* #2043's constant into the throughput program.
+
+---
+
+## 4. Estimate — multiplier / cost / risk for a scoped columnar scan path
+
+**Recommended 0.17 increment:** a **columnar scan producer** — §2 option (a): replace the
+`Vec<QueryRow>` buffer + `transpose_columns` with direct decode-into-Arrow-column-builders inside the
+existing flight producer, keeping the row-wise reconcile untouched, byte-cap bounded. This is the
+scoped increment; it is **not** the #941 DataFusion program and does not need DataFusion at all.
+
+### 4.1 Multiplier (arithmetic anchored to Phase-0 %s)
+
+Applied **on top of** the fixed row pipeline (channel deleted, alloc controlled, splits
+parallelized):
+
+- Columnar deletes: **materialize (stage 3, 4.5 %)** + the redundant `transpose_columns` pass
+  (part of the second `convert_to_arrays` traversal) + the per-row `QueryRow`/`RowKey::new` PK-copy
+  alloc (a chunk of the 17.6 % malloc — call it ~8–10 pp on wide rows, less on narrow).
+- On the **remaining coordinator cost** after row fixes (reconcile 32.5 % + decode 9.7 % + arrow
+  1.0 % + necessary alloc), removing ~4.5 % + ~8–10 pp of alloc + the transpose is a **~20–40 %
+  reduction of the remaining per-row cost → ~1.2–1.5×**.
+- **Width-dependent:** materialize + transpose + alloc scale with **cells/row**, so the multiplier
+  sits near **1.5×** on wide rows (many cells) and near **1.0–1.1×** on narrow 2-col rows. This is
+  the opposite width-sensitivity from the channel overhead (worst on narrow rows), so columnar and
+  the threading fix are complementary, not redundant.
+
+**Net:** columnar is a **~1.2–1.5× multiplier**, best on wide rows — a real Stage-2 *contributor*,
+not a Stage-2 *unlock*. It does **not** move reconcile (32.5 %, the field's dominant derate). Do not
+sell it as "the 600k lever."
+
+### 4.2 Engineering cost — **M (medium)**, ~3–5 issues
+
+| # | Issue | Size |
+|---|---|---|
+| 1 | Column-builder sink replacing the `Vec<QueryRow>` buffer in `producer.rs` (`drive_merge`/`flush_buffer`) | S–M |
+| 2 | `entry_to_row`→builder append edge; cell-tombstone→null, row-tombstone→skip; reuse `convert_column_to_array` builders | M |
+| 3 | Collection / UDT / frozen columnar append (the `assemble_read_cells` reassembly must feed list/map/UDT builders — the fiddly part) | M |
+| 4 | Byte-cap batch bound under B4 (≤512Mi); finish-on-first-of row/byte cap | S |
+| 5 | Parity wiring-evidence: route query-semantics oracle + physical-dump smoke through the columnar producer (extend #2374) | S |
+
+Full #941 DataFusion program by contrast = **L** (10 children + Sidecar + MPP + manifest + capstone).
+The columnar scan producer also lands the bounded-stream/byte-cap plumbing #1907 (#941 A3) needs.
+
+### 4.3 Risk — **LOW–MEDIUM (correctness), MEDIUM (memory)**
+
+- **Correctness: LOW under option (a).** Reconcile is byte-for-byte unchanged; only the output
+  container changes → physical-dump + query-semantics + point-vs-full oracles are **unchanged by
+  construction**. No-heuristics preserved (type-driven builders). Risk rises to HIGH only if someone
+  drifts toward option (c) per-SSTable columnar — which breaks cross-gen tombstone shadowing; the
+  design must state option (a) as a hard boundary.
+- **Memory: MEDIUM.** Columnar builders hold a whole batch; wide rows × 8192-row cap can blow B4
+  512Mi under 4-way split fan-out. Mitigation is mandatory byte-cap governance (#1907/#941-council
+  lesson). Manageable, but it is the real risk and must be a first-class acceptance criterion.
+- **A5 stability:** net positive — deleting per-row alloc reduces p99 allocator jitter, provided
+  peak is byte-bounded.
+- **Collections/UDT:** the one genuinely fiddly area (issue #3) — the multi-cell collection
+  reassembly (`assemble_read_cells`, #2324) must land in list/map/UDT builders without regressing
+  the composite-keyed-collection fail-closed contract. Scope carefully; it is where a parity
+  regression would hide.
+
+---
+
+## 5. Final packet
+
+**Stage-2 requirement arithmetic.** 600k rows/s/pod on a 4-vCPU pod = **6.4 µs/row/core** with
+parallel splits (not the brief's 1.6 µs/row single-thread reading). Phase-0's ~500k/s single stream
+= **~2.0–2.5 µs/row real coordinator work** (M1, RF=1, narrow, warm, uncompressed); genuine
+single-threaded compute ≈ **3.5 µs/row**. Field-derated **3–5×** (RF=3 reconcile, LZ4, wide rows,
+slower cores) → single-core **~10–17 µs/row** → **4 vCPUs ≈ 240k–400k rows/s/pod** on a fixed row
+pipeline: **Stage 1 (100k) comfortably, into the lower gap toward Stage 2, likely short of 600k.**
+The residual gap is **RF=3 reconcile (32.5 %) + wide-row per-cell decode/materialize**, NOT Arrow
+encode (1.0 %) and NOT the container format. **Columnar is not structurally required for Stage 2 and
+does not remove the dominant cost; the ladder itself puts full columnar at Stage 3.**
+
+**Recommended 0.17 columnar increment.** A **scoped columnar scan producer** (§2 option (a)):
+reconcile row-wise exactly as today, scatter surviving cells straight into byte-cap-bounded Arrow
+column builders in the flight producer, deleting the `Vec<QueryRow>` buffer + `transpose_columns` +
+per-row PK-copy alloc. This is the **only** merge/columnar option compatible with tombstone
+reconciliation and the query-semantics oracle at low cost (options (b) = today's redundant
+double-pass, (c) per-SSTable columnar = breaks cross-gen shadowing = the large #2037 exploration).
+**Not the full #941 DataFusion program.**
+
+**Multiplier / cost / risk.** Multiplier **~1.2–1.5×** on top of the fixed row pipeline
+(width-dependent: ~1.5× wide, ~1.0–1.1× narrow; deletes materialize 4.5 % + transpose + ~8–10 pp
+alloc; **cannot** touch reconcile 32.5 %). Cost **M** (~3–5 issues, reuses existing typed builders;
+the #941 program is **L**). Risk **LOW** correctness (oracles unchanged by construction under option
+(a)), **MEDIUM** memory (B4 512Mi — builders must be byte-bounded, not row-bounded), with
+collections/UDT the one fiddly area.
+
+**#941 / #2605 / #2037 disposition.**
+- **#941 (#1905–#1914):** keep Backlog/owner-gated — it is an MPP/analytical-execution surface, not
+  a do_get throughput fix; DataFusion does not speed up the reconcile. Its A3 bounded-stream blocker
+  (#1907) overlaps the columnar producer; sequence so the producer banks that plumbing.
+- **#2605 (0.16 PoC):** keep, but **sharpen the measurement** — attribute decode-to-column vs
+  vectorized-exec delta separately, measure on wide/RF=3 shape (not RF=1 narrow), record peak memory
+  under 512Mi, and confirm both arms consume *post-reconciliation* batches. Feed the result to the
+  #941 promotion trigger.
+- **#2037 (+#2043):** keep owner-gated exploration; its post-merge-columnarization law **validates
+  option (a)**. **Harvest #2043 (WS7)** — it pins the k-way-merge **ns/row** constant (today a
+  `[ASSUMED]` 10–500 ns/row, 25–50× blind spot) that the whole Stage-2 arithmetic hinges on; route
+  it into the #2605 report.
+
+**File left uncommitted per instructions:**
+`/Users/patrickmcfadin/local_projects/cqlite/docs/research/phase1-2-columnar.md`

--- a/docs/research/phase1-3-linux-io.md
+++ b/docs/research/phase1-3-linux-io.md
@@ -1,0 +1,250 @@
+# Phase 1, Agent 3/8 — Linux IO + LZ4 decompress: modeling the field cost Phase 0 could not see
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Scope:** READ-ONLY
+
+Phase 0 measured a **warm-cache, uncompressed, macOS-loopback** single-stream scan and found
+Stage 1 (IO + decompress) = **0.0 %** of CPU and Stage 6 (transport) = **0.2 %**. Both are
+artifacts of the rig, not the field. This agent owns that blind spot: model what LZ4 decompression
+and cold NVMe IO actually cost on the field profile (i4i.xlarge NVMe, 1.93 M partitions/node, LZ4
+SSTables, cold scans, B4 cold-start ≤ 3 s), enumerate the Linux IO levers, and — the load-bearing
+part — state honestly **when IO becomes the binding constraint** relative to the agent-1/2 CPU work.
+
+**Headline (three claims, derived below):**
+
+1. **The read path is already a mature multi-backend IO engine** (Epic F, closed): buffered / mmap /
+   `O_DIRECT`+`F_NOCACHE` direct, an `Auto` RAM-sizing heuristic, `madvise` (SEQUENTIAL / WILLNEED /
+   RANDOM), a clamped direct-IO prefetch window, lock-free positional `pread`, and a decompressed-chunk
+   cache. Most textbook IO levers are **already built**. `io_uring` and `posix_fadvise` are the only
+   two absent from the codebase.
+2. **At the 100 k–600 k rows/s targets, neither cold NVMe bandwidth nor LZ4 decompress is the binding
+   constraint.** LZ4 decode adds **~0.1 %–1 %** CPU over the Phase-0 budget; cold sequential bandwidth
+   needed is **~10–350 MB/s**, an order of magnitude under what an i4i.xlarge NVMe delivers. The engine
+   stays **CPU-bound on the Phase-0 per-row coordination** (channel handoff 50 %, reconcile 32 %,
+   alloc 18 %).
+3. **IO owns exactly one thing on the critical path today: cold-start *latency* (B4 ≤ 3 s), not
+   throughput.** The one genuinely-additive code lever is **`posix_fadvise(SEQUENTIAL)` + `WILLNEED`
+   on the cold buffered scan / open** — cheap, portable, no downside. Everything heavier (`io_uring`,
+   a decompress-ahead thread) should wait behind agent-1/2 and behind a *measurement* that IO is
+   binding, which the arithmetic says will not happen until row rates far above 600 k.
+
+---
+
+## 1. The read path, from first principles (what actually touches the disk)
+
+### 1a. Backends (all present; `cqlite-core/src/storage/sstable/reader/`)
+
+The reader resolves a per-SSTable **`DiskAccessMode`** at open (`resolve_disk_access_mode`,
+`reader/mod.rs:245`). Default config is `Auto` (`config.rs:124`); the Flight server and CLI do **not**
+override it, so the field scan path runs `Auto`:
+
+| Backend | Mechanism | Where |
+|---|---|---|
+| **Buffered** | `BufReader<tokio::fs::File>`, page cache, per-chunk `seek`+`read_exact` | `source.rs` `BlockSource::Buffered` |
+| **Mmap** | `memmap2` map, served from page cache, zero read syscalls | `source.rs` `BlockSource::Mapped`; `reader/mod.rs:1141` |
+| **Direct** (unix) | `O_DIRECT` (Linux) / `F_NOCACHE` (macOS), aligned `pread` into a 4 K-aligned bounce buffer, clamped read-ahead window | `source.rs:357` `open_direct_file`, `DirectCursor`; `prefetch_window.rs` |
+| **Point-read (positional)** | lock-free `FileExt::read_at` (`pread`) / `MmapReadAt` slice / `DirectReadAt` | `read_at.rs` |
+
+**`Auto` heuristic** (`reader/mod.rs:262`): file `< mmap_min_size` → Buffered; file `> memory_fraction
+× RAM` (default 0.5) → Direct; else → **Mmap**. On an i4i.xlarge (32 GiB RAM) the Direct threshold is
+**16 GiB** — no single field SSTable approaches that, so **`Auto` resolves to Mmap for essentially
+every field Data.db**, i.e. page-cache reads with **kernel-default read-ahead and no explicit hint**
+(see §1c).
+
+### 1b. Chunk decompression path (LZ4)
+
+- Cassandra 5.0 LZ4 SSTables store Data.db as a stream of **64 KiB-uncompressed chunks**
+  (`CompressionInfo.chunk_length`, `compression_info.rs:14`), each compressed + a trailing 4-byte
+  BE CRC32. Chunk offsets live in `CompressionInfo.db`.
+- Read → CRC → decompress → cache funnels through **one plane**: `ChunkSource`
+  (`reader/chunk_source.rs`). `read_compressed_chunk_at` (`block_io.rs:580`) does one positional read
+  of payload+CRC, verifies CRC **before** decompress (guardrail #1411), then
+  `Compression::decompress` (`compression.rs:249`) runs the decoder. Decompressed chunks land in the
+  **B1 `DecompressedChunkCache`** as `Bytes` (zero-copy into cache; `chunk_source.rs:149`).
+- The decoder is **`lz4_flex` with `safe-decode`** (`Cargo.toml:39/145`; `compression.rs:259`
+  `decompress_size_prepended`). Safe-decode is the deliberate choice (no `unsafe`), and it is the
+  slower of lz4_flex's two modes.
+- **Decompress is *inline on the per-input reader thread*** in the thread-per-input merge
+  (`from_readers`), so it already overlaps with the coordinator's consumption — the reader threads
+  are ~74 % *parked in `send`* (Phase-0 §3), i.e. decompress runs in CPU the reader thread would
+  otherwise waste blocked. This matters for the "decompress-ahead thread" lever (§2, low value).
+
+### 1c. The one real gap: no explicit read-ahead on the cold sequential scan
+
+`Auto` deliberately issues **no `madvise`** (`mmap_advice_for`, `reader/mod.rs:316`; issue #1143):
+`MADV_SEQUENTIAL` couples aggressive read-ahead with **drop-behind**, which evicts hot pages under
+concurrent write load and blew up the read p99 tail (~2×). So the cold mmap scan relies entirely on
+the **kernel default read-ahead window (typically 128 KiB)**. There is **no `posix_fadvise` anywhere
+in the tree** (confirmed: `rg fadvise` → nothing). This is the actionable IO lever — see §2.
+
+---
+
+## 2. Modeling the field IO + decompress cost (the arithmetic)
+
+### 2a. Data volume per node
+
+Phase-0 anchor: **3 M narrow rows (`key text, value text`) = 248 MB uncompressed** across 4 SSTables
+→ **~82 B/row uncompressed on disk**. Field rows are **wider** (brief). The exact
+`easy_cass_stress.keyvalue` value width is not pinned in the repo, so model a 3-point range for the
+field's **~1.94 M rows/node**:
+
+| Field row width (uncompressed) | Uncompressed Data.db/node | LZ4 on-disk (÷2.5 typ. text) | # 64 KiB chunks |
+|---|---:|---:|---:|
+| ~82 B (narrow, Phase-0 shape) | 159 MB | ~64 MB | ~2,400 |
+| ~250 B (moderate) | 485 MB | ~195 MB | ~7,400 |
+| ~500 B (wide) | 970 MB | ~390 MB | ~14,800 |
+
+(LZ4 on text/keyvalue typically 2–4×; 2.5× used as a mid estimate. Chunk count = uncompressed ÷ 64 KiB.)
+
+### 2b. Is cold NVMe bandwidth ever binding at 100 k–600 k rows/s?
+
+A full scan reads the **compressed** bytes off disk. Bytes/s off disk needed to sustain a row rate:
+
+```
+compressed_bytes_per_row = uncompressed_bytes_per_row / compression_ratio
+disk_MBps = rows_per_s × compressed_bytes_per_row
+```
+
+| Row rate | 82 B/row (÷2.5 → 33 B) | 250 B/row (→100 B) | 500 B/row (→200 B) |
+|---|---:|---:|---:|
+| 100 k rows/s | **3.3 MB/s** | 10 MB/s | 20 MB/s |
+| 600 k rows/s | **20 MB/s** | 60 MB/s | **120 MB/s** |
+
+**i4i.xlarge NVMe (AWS Nitro SSD) delivers ≥ ~1 GB/s sequential read and ~100 µs-class latency.**
+The worst cell above (600 k rows/s, wide) needs **120 MB/s** — **~8× under** the drive's sequential
+bandwidth. **Cold IO *bandwidth* is never the binding constraint in the target envelope.** It would
+only bind at multi-GB/s row rates (millions of wide rows/s), far above 600 k.
+
+The real cold-IO risks are **latency-shaped, not bandwidth-shaped**:
+- **B4 cold-start ≤ 3 s**: first-touch faulting a cold file's Summary/Index/first chunks (see §4).
+- **Read-ahead starvation**: with the default 128 KiB window and *synchronous* mmap page faults on
+  one thread, a cold sequential scan can stall on fault latency well below the drive's bandwidth —
+  this is what `fadvise(SEQUENTIAL)` on a **buffered** fd fixes without the mmap drop-behind hazard.
+- **Multi-SSTable interleave**: N reader threads reading N SSTables interleave the device's LBA
+  stream, degrading each toward random. NVMe tolerates this far better than spinning disks, and 60 MB/s
+  aggregate is trivial, so this is a minor concern until SSTable counts are high.
+
+### 2c. LZ4 decompress CPU, as a % on the Phase-0 breakdown
+
+Prior art: reference LZ4 (C, unsafe) decompresses **~4–5 GB/s/core** (lz4.org: ~4970 MB/s single
+core). **`lz4_flex` safe-decode is ~40–60 % of that — model ~1.5 GB/s/core** (its README benches it
+against C lz4; safe mode pays bounds checks). Decompress is **per-byte of uncompressed output**:
+
+```
+decompress_CPU_s = uncompressed_bytes / 1.5e9
+```
+
+Anchoring to the **Phase-0 CPU budget** (154 CPU-s for a 3 M-row / 248 MB scan, at 500 k rows/s):
+
+| Field shape | Uncompressed/scan | Decompress CPU-s @1.5 GB/s | As % of a ~154 CPU-s Phase-0-shaped budget |
+|---|---:|---:|---:|
+| 82 B/row (matches Phase-0 volume) | 248 MB | 0.17 CPU-s | **~0.11 %** |
+| 250 B/row | 485 MB | 0.32 CPU-s | ~0.21 % |
+| 500 B/row | 970 MB | 0.65 CPU-s | ~0.42 % |
+
+Even halving the decoder to a pessimistic **0.75 GB/s** only doubles these to **~0.2 %–0.8 %**.
+
+**Why so small:** Phase-0's budget is **per-row-coordination-dominated** (channel handoff + alloc +
+reconcile = ~98 %), and those costs scale with **row count**, not bytes. Decompress scales with
+**bytes**. For narrow rows the per-row overhead swamps decompress entirely; for wide rows the byte
+volume grows but so does per-row parse/materialize, keeping decompress a low-single-digit-percent
+tail at most.
+
+**Honest caveat on the denominator:** the Phase-0 154 CPU-s is *inflated* by the channel-handoff
+overhead agent-1 targets (~50 %). Once that is removed the budget roughly halves, so decompress's
+**relative** share roughly **doubles** — to ~0.2 %–1.6 %. Still small in absolute terms, but this is
+the mechanism by which "IO/decompress starts to matter" — it becomes visible *only after* the CPU
+coordination cost is gone (§3).
+
+**Corrected Phase-0 Stage 1 for the field:** replace the `0.0 %` warm+uncompressed cell with
+**~0.2 %–1 % CPU (LZ4 decode) + a cold-start latency term (wall-time, not CPU)**. Stage 6 (transport)
+similarly moves off `~0 %` over a real network, but that is agent-4/5/6 territory, not IO.
+
+---
+
+## 3. When does IO become binding? (the honest ordering claim)
+
+Phase-0 is unambiguous: at 500 k rows/s **warm**, the engine is **CPU-bound on merge plumbing** —
+50 % channel park/wake, 32 % reconcile, 18 % alloc; IO and decompress are ~0 %. The field adds a
+**cold-latency** term and a **~1 %** decompress-CPU term. Therefore:
+
+> **IO throughput is NOT the binding constraint, and does not become one within the 100 k–600 k rows/s
+> target envelope, until the agent-1 (per-row channel handoff) and agent-2 (reconcile/alloc) CPU
+> levers land.** Even after they land, cold **bandwidth** still won't bind (§2b arithmetic); what
+> surfaces next is cold **read-ahead latency** and the now-relatively-larger **decompress CPU** — both
+> addressed by the cheap fadvise lever, not by `io_uring`/`O_DIRECT` batching.
+
+**Dependency order for the program:**
+
+1. **Now, unconditionally — `fadvise(SEQUENTIAL)` + `WILLNEED` (S, portable).** It has no downside,
+   directly serves B4 cold-start (§4), and pre-empts the read-ahead-starvation risk. Do it early even
+   though IO isn't yet binding — it is a pure win and removes IO as a *variable* before agent-1/2 change
+   the CPU picture.
+2. **agent-1 + agent-2 land** (remove ~50 % channel + ~18 % alloc + shrink reconcile). Throughput
+   roughly doubles; the CPU budget halves; decompress's relative share doubles but stays ~1 %.
+3. **Re-measure cold, compressed, on i4i.** Only if that measurement shows a cold scan **bandwidth- or
+   IOPS-bound** (the arithmetic says it won't below multi-GB/s row rates) do the heavy levers
+   (`io_uring` batching, forced `O_DIRECT` scan) earn their portability cost. Until then they are
+   speculative.
+
+---
+
+## 4. Lever table
+
+Multiplier = effect on scan throughput / cold-start unless noted. "Already built" levers are marked;
+their entry is *tuning*, not new implementation. Portability cost is against the **macOS dev/gate
+parity** rule: Linux-only code must be `cfg`-gated with a portable fallback.
+
+| Lever | Mechanism | Anchored multiplier arithmetic | Cost | Risk | Portability / dev-parity |
+|---|---|---|---|---|---|
+| **`posix_fadvise(POSIX_FADV_SEQUENTIAL)` on the buffered cold scan** ← **the gap** | Doubles/extends kernel read-ahead on the buffered fd **without** mmap drop-behind (#1143). Frees the cold sequential scan from the 128 KiB default window. | Cold bandwidth need is 20–120 MB/s (§2b); default 128 KiB read-ahead at ~100 µs NVMe fault latency pipelines to ~1.3 GB/s only if perfectly overlapped — a single faulting thread stalls well below that. `SEQUENTIAL` lifts the window ~2–8× → removes cold-scan fault stalls; **~1.0× warm, meaningful on cold p99**. | **S** | Low — advisory hint, kernel may ignore; no correctness effect. | Linux `libc::posix_fadvise`; macOS has no `POSIX_FADV_SEQUENTIAL` → map to `F_RDAHEAD`/`F_RDADVISE` or **no-op fallback**. `cfg`-gate; gate stays green on macOS (no-op path). |
+| **`posix_fadvise(WILLNEED)` on Summary/Index/first data chunks at open** | Kick off async read-ahead of the components the first `do_get` touches, so cold-start faults are already in flight. | Directly serves **B4 ≤ 3 s**: overlaps index/summary/first-chunk faults with query setup instead of serializing them. Turns a cold-start's serial fault chain into one async prefetch. | **S** | Low — advisory; wasted read if the file is never scanned. | Same `cfg` story as above; macOS `F_RDADVISE` (range read-ahead) is the near-equivalent; else no-op. |
+| **`fadvise(DONTNEED)` after a scan-once full scan** | Evict the just-scanned pages so a one-shot analytic scan doesn't pollute the page cache and evict the working set (the *good* half of drop-behind, without the concurrent-write eviction that hurt #1143 — because it's issued *after* the scan, not as ongoing drop-behind). | No throughput multiplier; protects **other** queries' warm cache under memory pressure (1.93 M partitions/node won't all fit). Guards the hot-set hit rate that keeps warm p50 low. | **S** | Medium — must only fire on genuine scan-once (not on a table being re-scanned); mis-targeting cold-evicts a hot file. Gate behind the ticket's scan-once signal. | `cfg`-gate; macOS `F_NOCACHE`-after-the-fact is not equivalent → no-op fallback. |
+| **Read-ahead / prefetch-window tuning** (already built: `direct_io_prefetch_bytes`, clamp) | The direct backend already floors the window at `2×(chunk+4)` and 4 K-aligns it (`prefetch_window.rs`). Tuning = raise the 1 MiB default for cold sequential direct scans. | Direct backend only engages for files > 16 GiB (Auto) — **never** for field SSTables. Value is near-zero **unless** we force Direct for scan-once (below). | **S** | Low. | Already portable (value computed on all platforms; backend degrades to buffered off-unix). |
+| **mmap vs `pread` on NVMe for the scan pattern** (already built; a *policy* choice) | Point reads: dedicated `MADV_RANDOM` map (#2210, done). Full scans: mmap faults synchronously on the tokio worker (SIGBUS risk on truncation; #1143 tail). Buffered `pread` + `fadvise(SEQUENTIAL)` pipelines better and is SIGBUS-safe. | For a **cold sequential** NVMe scan, buffered-pread+`fadvise` ≳ mmap-default-readahead (no synchronous per-page fault on the worker thread, no drop-behind). Reinforces lever #1; argues **keep buffered as the scan default** (it already is — mmap is opt-in). | **S** (policy) | Low — buffered is already the safe default. | Fully portable. |
+| **Decompress-ahead / pipeline decompress with decode** | Overlap chunk decompress with the merge coordinator's row consumption. | **Already effectively overlapped**: decompress runs on the per-input reader thread, which is ~74 % *parked in `send`* (Phase-0 §3) — decompress consumes otherwise-wasted CPU. A dedicated decompress-ahead thread adds a queue hop for ~1 % of CPU. **~1.0×.** | **M** | Medium — another cross-thread handoff, the exact cost agent-1 is removing. Net-negative until the merge is single-threaded. | Portable (std threads), but low value. |
+| **Compression-block prefetch / read-ahead of next chunk's compressed bytes** | Issue the next chunk's positional read before the current chunk finishes decompressing. | Bounded by the same 20–120 MB/s need; the B1 cache + `Auto`→mmap page cache already serve most re-reads. Marginal on cold, nil on warm. **~1.0×.** | **M** | Low. | Portable. Low value given §2b. |
+| **`io_uring` batched reads** | Submit many chunk reads via one `io_uring` submission queue; overlap IO with CPU without a thread per input. | Only helps when **IO-bound**, which §2b shows the workload is **not** below multi-GB/s row rates. At 60 MB/s of compressed reads, submission-batching saves ~0 wall-time. **~1.0× until IO binds.** | **L** | High — new unsafe dependency (`tokio-uring`/`io-uring`), runtime integration, kernel ≥ 5.x, and it duplicates the read path. | **Linux-only.** Needs full `cfg`-gate + a buffered/pread fallback the macOS gate exercises; doubles the read-path surface to test. **Highest dev-parity cost.** Defer until a cold measurement proves IO binding. |
+| **Forced `O_DIRECT` for scan-once full scans** (backend built; policy new) | Bypass the page cache on a one-shot analytic scan so it doesn't evict the OLTP working set (HTAP isolation). | No throughput multiplier vs warm; protects co-located point-read latency under a big scan. Overlaps with `fadvise(DONTNEED)` (cheaper). At 120 MB/s the aligned-read overhead is affordable. | **M** (policy on built backend) | Medium — `O_DIRECT` alignment + the #2319 bounce-buffer-reuse fragility (regressed once); refused on tmpfs/overlay (already falls back). | Backend already `cfg(unix)` with buffered fallback; macOS `F_NOCACHE` path exists. Moderate. |
+
+**S/M/L** = implementation size. The only **S + portable + no-downside + on-the-critical-path** lever
+is the fadvise family (rows 1–2). Everything L is IO-bound-only and gated behind a measurement.
+
+---
+
+## 5. Prior work in the repo + backlog (dedup — no new duplicate filings)
+
+Epic **F #1518 (closed)** already delivered the IO substrate: F1 reader-map `RwLock`, F3 blocking IO
+off async, **F6 direct-IO + read-ahead window** (#1596, `prefetch_window.rs`), **F6.1 `MADV_RANDOM`
+point map** (#2210, closed), plus the point-read positional `pread` refactor (**C2 #1573**), the
+`Auto` disk-access heuristic, and the B1 decompressed-chunk cache (**Epic B #1514**). The direct-IO
+bounce-buffer reuse regression (**#2319**) is closed but flagged fragile.
+
+**What is genuinely un-filed and additive** (candidates, do not duplicate F6):
+- `posix_fadvise(SEQUENTIAL/WILLNEED/DONTNEED)` on the **buffered** cold-scan + open path — **absent
+  from the tree**, distinct from the mmap `madvise` that #1143 disabled. This is the cleanest new
+  filing.
+- A **Stage-0 cold-compressed decode bench on i4i** to convert this model's §2b/§2c estimates into
+  measured numbers (extends the existing `benches/decode_policy_bench.rs` F6.4 decompress-throughput
+  arm, which already measures lz4_flex decode-only vs full-scan but on the local warm rig).
+
+`io_uring` and forced-`O_DIRECT`-scan are **not** recommended as filings yet — they are IO-bound-only
+levers and the arithmetic says IO does not bind in the target envelope.
+
+---
+
+## 6. One-paragraph summary for the program
+
+CQLite's read path is **already** a mature multi-backend IO engine (buffered / mmap / `O_DIRECT`,
+`Auto` RAM-sizing, `madvise`, clamped prefetch window, lock-free `pread`, decompressed-chunk cache —
+Epic F, closed); the only textbook levers **absent** are `io_uring` and `posix_fadvise`. Modeling the
+field profile Phase-0 could not see: **LZ4 decode via `lz4_flex` safe-decode (~1.5 GB/s/core) adds
+only ~0.1 %–1 % CPU** over the Phase-0 budget (decompress scales with bytes; Phase-0's cost is
+per-row-coordination-dominated), and **cold NVMe *bandwidth* is never binding** — the target
+100 k–600 k rows/s needs just **~10–120 MB/s** of compressed reads against an i4i.xlarge NVMe's ≥ 1 GB/s.
+The engine stays **CPU-bound on the Phase-0 merge plumbing**. IO owns exactly one thing on the
+critical path today — **cold-start *latency* (B4 ≤ 3 s)** — and the single cheap, portable, no-downside
+lever is **`posix_fadvise(SEQUENTIAL)` + `WILLNEED`** on the cold buffered scan/open (map to
+`F_RDADVISE`/no-op on macOS to keep the gate green). Do that now; defer `io_uring` and
+forced-`O_DIRECT`-scan behind **both** the agent-1/2 CPU levers landing **and** a cold-compressed i4i
+measurement proving IO binding — which, by the arithmetic here, will not happen below multi-GB/s row
+rates.

--- a/docs/research/phase1-4-caching.md
+++ b/docs/research/phase1-4-caching.md
@@ -1,0 +1,193 @@
+# Phase 1 — Caching levers for the CQLite throughput program
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Agent:** Phase-1 4/8 (CACHING) ·
+**Method:** READ-ONLY code + issue survey. No builds, no commits, no GitHub writes.
+
+Anchored to `docs/research/phase0-scan-cost-breakdown-2026-07.md` (the CPU breakdown) and
+`docs/research/throughput-backlog-inventory-2026-07.md` (the dedup map). Every multiplier here
+traces back to Phase-0's stage shares; every collision traces to the inventory's cache watchlist.
+
+---
+
+## 0. TL;DR — the one thing to internalize
+
+**Caching is a keyed-read / repeated-query lever, NOT a scan lever.** Phase-0 proved a single-stream
+full scan spends **~82 % of CPU in merge plumbing** (49.9 % per-row channel park/wake + 32.5 % k-way
+reconcile) that **no data cache can touch**, and only **~14 % in the stages a cache buys back**
+(9.7 % parse + 4.5 % materialize; IO+decompress ≈0 % locally because the rig is warm+uncompressed).
+So:
+
+- **For a true one-off full scan, every decoded/chunk/key/row cache has hit-rate ≈ 0 — useless.** No
+  optimism theater: a scan reads each partition exactly once, evicts its own working set, and the
+  merge cost it is bottlenecked on is uncacheable. The only scan-relevant cache is the **warm-reader
+  cache (already shipped, #2310)** which amortizes *open* cost, and — for the field's LZ4+cold reality
+  Phase-0 is blind to — a chunk cache buys back decompress+IO **only on repeated scans of the same
+  token range within a freshness window**.
+- **For keyed reads (A2 ≥1,000 qps/pod) and repeated concurrent queries (B2), caches are
+  transformative** — high temporal locality, the per-read cost is index+IO+decompress+parse+materialize
+  with little/no merge, and a hot-hit removes nearly all of it. This is the workload to optimize.
+
+**B4 is already in tension before we add anything.** The three shipped resident caches declare
+**256 MiB (chunk) + 64 MiB (global key) + 64 MiB (warm readers) = 384 MiB** of budget against a
+**512 Mi peak** ceiling — and **none of them drain at idle** (verified: no TTL/decay/idle-sweep on any
+of the three; the warm registry's `last_access` drives *budget-LRU only*, not a time-based drain). A
+pod that serves one scan and goes quiet holds its last cache contents indefinitely. **The idle-≤16 Mi
+half of B4 is therefore not met by construction today**, and every new cache worsens it. Any lever
+below that adds resident bytes MUST ship an idle-drain or it is a B4 regression — this is the gating
+constraint, restated per lever.
+
+---
+
+## 1. Inventory — what is and isn't cached today
+
+### 1a. Shipped caches (read the code)
+
+| # | Cache | Issue | What it caches | Scope / budget | Wired sites | Idle-drain? |
+|---|-------|-------|----------------|----------------|-------------|-------------|
+| 1 | **`DecompressedChunkCache`** (B1) | #1567 / Epic B1 | **post-decompress** SSTable chunk bytes (`Bytes`, refcount-bump hit) keyed by `(sstable_id ^ site_salt, chunk_index, aux=size)` | **per-manager**, byte-bounded, sharded ×16 `Mutex<LruCache>`; default **256 MiB** (`block_cache.max_size = max_memory/4`), configurable; `disabled()` = genuine no-op | BTI target-chunk (`ChunkSource::chunk`), windowed scan (`decode_borrowed`), BIG point-read (`get_cached_data`, aux=size). **NOT** wired on `iterate_all_partitions`/`sequential_scan` legacy decode → follow-up **#2165** | **No** |
+| 2 | **`GlobalKeyOffsetCache`** | #2059 / Epic B | partition **key → `PartitionLoc{offset,size}`** (skips the `Index.db` interval read on hit; BIG resolves offset+size, BTI offset-only) | **process-global singleton**, byte-bounded, sharded ×128; **FIXED 64 MiB** (ignores `max_size` by design §B); invalidate-by-generation-identity (inode-stable, #2345/#2383) | every `SSTableReader` open with block-cache enabled; consulted before index descent | **No** |
+| 3 | **`ChunkDecompressor.chunk_cache`** (B3) | #1569 / Epic B3 | post-decompress chunks (`Arc<[u8]>`) keyed by chunk index | **per-reader**, single-threaded, **16 entries ≈ 256 KB** fixed `LruCache`; legacy `BulletproofReader` stack (being consolidated onto ChunkSource, G-series #1598/#2165) | legacy `read_data` decode path | n/a (tiny, per-reader; dies with reader) |
+| 4 | **`WarmTableRegistry`** | #2310 | **`Arc<SSTableReader>`** (open FDs + parsed Summary/lazy-BIG-index #2412 + BTI trie) per `(keyspace,table)` generation set | **per Flight process**, byte-bounded LRU, **64 MiB**; generation-keyed; rebind-by-inode (#2383); refreshed by probe/manifest | Flight `do_get` warm path — a warm hit amortizes **O(summary) open (#2412) to ~0** | **No** (LRU under budget only) |
+| 5 | **`SnapshotManager` reuse** (connector) | #2356/#2306 | the **snapshot directory identity** per `(keyspace,table)` within a freshness window (NOT data) | Trino JVM; **3 s window** (`DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS=3000`), retire-grace **10 min**, TTL **6 h** backstop | Trino split planning → N queries/window pay ONE create fan-out (one flush/host) | window-scoped |
+
+### 1b. Supporting / non-data caches (for completeness — not throughput levers)
+
+- **Query plan cache** (`engine.rs` `plan_cache: DashMap`, `prepared.rs` `plan_cache`) — caches
+  *parsed+optimized query plans* by query text. Saves re-parse/re-optimize, not data. Irrelevant to
+  scan/keyed data throughput.
+- **`PartitionKeyCache`** (`row_build.rs`) — a **per-stream single-entry memo** of the last decoded
+  partition key's columns, making a partition-grouped scan decode PK columns O(partitions) not
+  O(rows). NOT a cross-query cache; a working-set optimization inside one scan. (It is also the
+  SipHash-per-row site Phase-0 flagged at ~4.5 %.)
+- **`type_cache`** (write path, parsed `CqlType`) — write-only, irrelevant to reads.
+- **Connector `HostSnapshotApis`** — per-host HTTP `SnapshotApi` client reuse (connection pooling).
+- **Connector `CqliteFlightMetadata` nonAggregatedStats** — memoized `TableStatistics` (incl. negative
+  `empty()`) per `SchemaTableName`; plan-time, not data.
+
+### 1c. What is NOT cached anywhere today (the real gaps)
+
+- **No decoded-row / decoded-partition cache across queries.** The only decoded-form memo is the
+  per-stream single-entry `PartitionKeyCache`. A repeated point read re-parses and re-materializes the
+  partition body every time even when its chunk is resident in B1. **This is the biggest keyed-read
+  gap.**
+- **No Arrow `RecordBatch` / page cache** — server-side or connector-side. Every `do_get` rebuilds
+  batches from rows.
+- **No Trino-worker split/page result cache** — repeated identical splits within the 3 s snapshot
+  window re-fetch and re-decode end to end.
+- **No separate "uncompressed-chunk (post-LZ4, pre-decode)" tier** — and there shouldn't be: LZ4
+  decompress *is* the decode, and **B1 already caches the decompressed (uncompressed) chunk buffer**,
+  which is exactly Cassandra's own `ChunkCache` model (Cassandra caches decompressed chunk buffers,
+  not compressed ones). The "pre-decode" framing has no distinct artifact to cache here.
+
+### 1d. Tried-and-reverted / cautionary history (`git log --grep`, inventory watchlist)
+
+- **Epic B (#1514) already shipped the whole read-cache family** (B1 chunk, B3 decompressor,
+  B4 key→offset, B5 observability) — a new "add a cache" filing re-treads closed ground. Confirmed via
+  `git log`: #2170 (one ChunkSource decode plane), #2513 (pin BIG point-read served from B1 cache),
+  #2554 (#2059 global key cache), #2320/#1940 (window-as-`Bytes` zero-copy substrate).
+- **No cache was tried-and-reverted**, but there are **live gaps in the shipped caches**:
+  - **#2561** (P2, bug) — BTI point-read chunk-straddling decode trusts a closure-fired-as-complete
+    signal → whole-file fallback; found *via #2059's own gate*. A correctness gap in the cached path.
+  - **#2565** — #2059 doc/test-hygiene nits (open).
+  - **#2165** — `iterate_all_partitions`/`sequential_scan` decode still bypasses B1 (the scan path
+    most relevant to full scans is the one NOT wired to the chunk cache).
+- **#302f1927 lesson:** #2059's global cache *broke a per-reader cold-start test assumption* (serial-order
+  coin flip) — a process-global cache leaks state across "independent" reads/tests. Any new
+  process-global decoded cache inherits this hazard: tests need explicit `invalidate_all()` cold-start.
+- **#2316/#2321 lesson:** merge producer-thread cost is already the throughput limiter — caches that
+  add per-read background threads/timers (an idle-drain sweeper) must stay off the hot path.
+
+---
+
+## 2. Workload split — why the two targets behave oppositely
+
+| | **Scan (A4 / B3 full-ring, one-off)** | **Keyed read (A2 ≥1k qps/pod) + repeated concurrent (B2)** |
+|---|---|---|
+| Access pattern | each partition read **once**; working set = whole table (248 MB local, **GB-scale field**) | small hot set of partitions/dashboards read **repeatedly** within the snapshot window |
+| Temporal locality | ~0 (except **Trino re-scanning the same token range** across splits / repeated dashboards) | **high** |
+| Phase-0 cost profile | 82 % merge plumbing (uncacheable) + ~14 % parse/materialize + field-only decompress/IO | index lookup + IO + decompress + parse + materialize; **little/no merge** for point reads |
+| Cache hit rate | **≈0 one-off**; only repeated-range scans within a window hit | **high** — this is where caches pay |
+| Multiplier ceiling from caching | **~1.16× local** (1/(1−0.14)); **~1.3–1.5× field** if LZ4 decompress is 20–30 % of a cold scan — but only realized on *repeated* scans | **2–10×** on the hot set (a hot hit removes nearly the entire per-read cost) |
+| Memory pressure vs B4 | catastrophic if you try to cache scan output (decoded rows are ~3.5× on-disk per Phase-0 wire ratio) → **thrash under 512 Mi** | modest — hot set is small; fits a bounded cache |
+
+**Rule:** size and invalidate every cache for the **keyed/repeated** workload; treat scans as
+**cache-transparent** (bypass or single-touch, never let a scan evict the hot keyed set — a
+scan-resistant admission policy, see §4 Lever G).
+
+---
+
+## 3. Lever table — SCAN workload (A4 / B3)
+
+Peak-memory math is **per Flight pod** against **B4: ≤512 Mi peak, ≤16 Mi idle**. "Multiplier" is the
+*realized* scan speedup, not the theoretical ceiling.
+
+| Lever | What it caches | Hit-rate model (field: 1.93 M part/node, GB-scale) | Peak-mem math vs 512 Mi | Idle-≤16 Mi story | Multiplier (scan) | Cost | Risk | Collisions |
+|-------|----------------|-----------------------------------------------------|--------------------------|-------------------|-------------------|------|------|------------|
+| **S-A. Wire B1 chunk cache into `sequential_scan`/`iterate_all_partitions`** (#2165) | post-decompress chunks on the full-scan decode path (today it bypasses B1) | **~0 for one-off** full ring; **useful only when Trino re-scans the same token range** within a window (repeated dashboards, multi-split overlap). Field LZ4 decompress is real (Phase-0 §5.1), so a repeated-range hit buys back real decompress+IO | reuses the existing 256 MiB B1 budget — **no new bytes** IF sized down (see S-D) | inherits B1 (no drain today — **must add S-D**) | **1.0× one-off; ~1.3–1.5× on repeated-range scans** (field, decompress-bound) | **M** | scan blows a bounded cache → churns the keyed hot set unless scan-resistant (Lever G). Correctness parity on the legacy path | **#2165** (exact issue). Extends Epic B, does not refile |
+| **S-B. Longer snapshot-reuse window** (connector tuning) | raises reuse of the *whole downstream stack* (warm readers + B1 + key cache stay hot for the same generation longer) | monotonic in window length: a 3 s→30 s window turns N-queries-per-3 s into N-per-30 s → fewer create fan-outs (fewer flushes) AND higher warm/B1/key hit rates | **0 new bytes in the Flight pod**; more *retained superseded snapshot dirs* on disk (≈ grace/window, disk not RAM) | unaffected (disk, not the 16 Mi RAM ceiling) | indirect — lifts keyed multipliers more than scan; modest scan lift on repeated ranges | **S** (config knob `cqlite.snapshot-reuse-window-ms` already exists) | **freshness contract** — data up to window-old; owner call (mirrors #2305 flush-on-snapshot decision) | Tuning, not code. No issue collision; owner-gated freshness decision |
+| **S-C. Expanded warm-reader/summary caching** | more generations' `Arc<SSTableReader>` (open FDs + lazy summary #2412) resident | warm-open already ≈0 cost on hit (#2412 made open O(summary)); expansion only helps when the working set of *generations* exceeds the 64 MiB reader budget | raising the 64 MiB warm budget adds directly to peak; readers hold FDs + parsed summary (tens of KB–MB each) | **No drain today** — readers persist idle (FD leak risk, see #2013 soak) | **~1.0–1.05×** (open is already amortized) — low value | **S–M** | FD exhaustion under many generations; #2013 resource-leak class | Extends #2310; low priority |
+| **S-D. Idle-drain / TTL decay on all resident caches** (B4 enabler) | nothing new — *drains* B1 + key cache + warm readers after an idle interval | n/a (memory lever, not a hit-rate lever) | **the lever that MAKES the 384 MiB of existing budget B4-legal** — drains toward ≤16 Mi when a pod goes quiet | **this IS the idle story** for every other lever | 0× throughput; **unblocks** every resident-cache lever under B4 | **M** | drain sweeper must stay off the hot path (#2316 lesson); a too-eager drain re-cold-starts a briefly-idle pod (thrash under bursty B2) | **New** — no existing issue owns "cache idle-drain"; prerequisite for any resident-cache growth. Pairs with #2013 |
+
+**Scan verdict:** the only genuinely useful *new* scan work is **S-A (#2165)** — and it pays only in
+the field (LZ4) on repeated ranges, capped at ~1.3–1.5×. **S-B (window tuning)** is the cheapest lever
+in the whole program and lifts keyed reads more than scans. **S-D is not optional** — it is the B4
+gate. Do not build a scan-output/row cache: it cannot beat the 82 % merge wall and it detonates B4.
+
+---
+
+## 4. Lever table — KEYED / CONCURRENT workload (A2 ≥1k qps/pod, B2)
+
+This is where caching earns its multiplier. Hit rate assumes a **hot set that fits the budget** (the
+field's dashboards hit a small partition subset repeatedly — the classic keyed workload).
+
+| Lever | What it caches | Hit-rate model | Peak-mem math vs 512 Mi | Idle-≤16 Mi story | Multiplier (keyed) | Cost | Risk | Collisions |
+|-------|----------------|----------------|--------------------------|-------------------|--------------------|------|------|------------|
+| **K-A. Decoded-partition cache** (NEW, the biggest gap) | post-parse, post-materialize partition columns/rows keyed by `(GenerationIdentity, partition key)` — reuses the #2059 inode-stable identity for **safe invalidation** | **high on the hot set** — a repeated point read that today re-parses+re-materializes (Phase-0 stages 2+3 = ~14 % CPU, plus the alloc + SipHash it drives) becomes a clone | **decoded rows are ~3.5× on-disk size** (Phase-0 wire ratio) → budget must be **small (e.g. 32–64 MiB) and hot-set-only**, NOT scan-populated (needs Lever G scan-resistance) | **No drain unless S-D** — decoded bytes are the most expensive to hold idle → S-D mandatory | **removes parse+materialize+alloc+SipHash on a hit** → on top of an already-warm chunk/key hit, a point read collapses to a cache clone. **~1.5–3× on the hot keyed set** (larger when parse/materialize dominate wide rows) | **L** | invalidation on generation turnover (identity handles it, fail-closed like #2059); **memory blowup** (3.5× factor); process-global cold-start test hazard (#302f1927 lesson) | **HIGH collision with #2037 ArrowMemtable** (coordinator-native decoded/Arrow cache — the *same idea*, owner-gated exploration). A 0.17 filing here MUST reconcile with #2037 WS6 (per-generation Arrow cache) or it triples surface. Also overlaps #2605 DataFusion PoC |
+| **K-B. Global key cache — already shipped** (#2059) | key→offset; skips `Index.db` interval read on hit | **high** on repeated keyed reads; fixed 64 MiB holds >1 M hot locations | 64 MiB fixed (already counted) | **No drain** (needs S-D) | **already realized** — skips the index descent (a real per-point-read cost). Baseline, not a new lever | shipped | **#2561 (chunk-straddling whole-file fallback bug)** undermines the win on straddling partitions; **fix #2561 first** | Fix #2561/#2565; don't refile |
+| **K-C. B1 chunk cache — already shipped** (#1567) | post-decompress chunk holding the partition body | **high** on repeated keyed reads (partition body chunk resident → refcount-bump, skips IO+decompress) | 256 MiB default — **oversized for a 512 Mi pod**; size to the hot set (S-D + a smaller `block_cache.max_size`) | **No drain** (needs S-D) | **already realized** for point reads; buys back the field's LZ4 decompress | shipped | 256 MiB default vs 512 Mi peak is the single biggest B4 hazard — **retune the default down for the Flight/Trino deployment** | Config retune, not refile; pairs with S-D |
+| **K-D. Snapshot-scoped decode cache** (the safe-invalidation design for K-A) | K-A's decoded entries keyed/bucketed by **snapshot identity** so invalidation = "snapshot rolled → drop the bucket" (immutable snapshot ⇒ no per-entry invalidation) | same hit-rate model as K-A; **cleaner invalidation** — a snapshot is a Cassandra point-in-time hardlink set, immutable, so a bucket is valid until the generation set changes | same as K-A | drop-on-roll gives a **natural idle-drain** if paired with the 3 s window / warm-registry generation identity | same as K-A, with **lower invalidation risk** | **L** (do K-A this way if at all) | ties cache lifetime to snapshot lifecycle — correct-by-construction but couples core to the connector's snapshot notion | Same #2037 collision as K-A; aligns with #2356 snapshot model |
+| **K-E. Trino-connector-side page/split cache** | Arrow pages / split results on the **Trino worker** (JVM), keyed by `(split, snapshot epoch)` | **high** on repeated identical splits within the 3 s window (dashboard refresh) | **lives in the Trino JVM, OUTSIDE the 512 Mi Flight-pod B4 ceiling** — Trino's own memory management, not the pod idle-16 Mi budget | n/a to the Flight pod; Trino manages its own eviction | avoids the whole Flight round-trip (network + decode + merge) on a repeat split → **large for repeated dashboards**, but Trino may already cache upstream | **M** (Java connector work) | correctness on snapshot roll (epoch key handles it); may duplicate Trino's built-in caching layers | No cqlite issue; separate connector track. Don't conflate with Spark #1947–1950 |
+| **K-F. Longer snapshot-reuse window** (= S-B, keyed view) | keeps the whole warm+B1+key stack hot for the same generation longer | **directly multiplies keyed hit rates** — the hot set stays resident across more queries | 0 new pod bytes | window-scoped | biggest cheap lift for A2/B2 | **S** | freshness contract (owner call) | Existing knob; owner-gated |
+| **K-G. Scan-resistant admission (SLRU / scan-bypass)** | not a new cache — an **admission policy** so a full scan does not evict the keyed hot set from B1/K-A | n/a — protects the *other* caches' hit rates under mixed scan+keyed load (A5: eviction under 80-thread overload must not thrash) | 0 new bytes | improves idle behavior (scan bytes never pinned) | protects the 2–10× keyed multiplier from collapsing to ~1× when a scan runs concurrently | **M** | mis-tuned admission starves legitimately-hot scanned ranges | Cassandra prior art (ChunkCache is scan-aware); no cqlite issue. Pairs with #2600/#2765 egress work |
+
+**Keyed verdict:** the shipped **K-B + K-C** already deliver the index+IO+decompress skip — **first fix
+#2561 (they're partially broken on straddling partitions) and retune the 256 MiB chunk default down**
+before anything new. The one high-value *new* lever is **K-A/K-D (decoded-partition cache, snapshot-scoped)**,
+but it is **L-cost, B4-dangerous (3.5× decoded size), and collides hard with the #2037 ArrowMemtable
+exploration** — it should be reconciled with #2037/#2605, not filed independently. **K-F/S-B (window
+tuning) is the cheapest keyed win in the program.** **K-G (scan-resistance) is the A5 safety belt** that
+keeps mixed workloads from thrashing.
+
+---
+
+## 5. Recommended sequencing (cheapest, highest-leverage first)
+
+1. **Fix the shipped caches before adding any** — **#2561** (BTI chunk-straddling whole-file fallback,
+   a real correctness+perf hole in K-C found via #2059's gate) and retune **`block_cache.max_size`**
+   down from 256 MiB for the 512 Mi Flight/Trino deployment. **No new code, closes a B4 hazard.**
+2. **S-B / K-F: tune the snapshot-reuse window** (owner freshness call). Config-only; lifts keyed hit
+   rates and cuts create fan-outs. Highest ROI in the program.
+3. **S-D: cache idle-drain / TTL decay.** The B4 gate — without it the existing 384 MiB of budget
+   already misses idle-≤16 Mi and no resident-cache lever is legal. Off the hot path (#2316).
+4. **S-A / #2165: wire B1 into the sequential-scan path.** Field-only (LZ4) repeated-range payoff;
+   pair with **K-G scan-resistance** so it doesn't evict the keyed hot set.
+5. **K-A / K-D: decoded-partition cache (snapshot-scoped)** — only after reconciling with **#2037
+   ArrowMemtable** and **#2605 DataFusion PoC**. Highest keyed multiplier, highest cost/risk. Do not
+   file standalone.
+6. **K-E: Trino-side page/split cache** — separate connector track; evaluate against Trino's own
+   caching first.
+
+## 6. Hard constraints restated (do not violate)
+
+- **B4 (512 Mi peak / 16 Mi idle) is a ceiling, not a trade chip.** Current declared budget 384 MiB with
+  no idle-drain ⇒ idle-16 Mi is unmet today. Every resident-cache lever must state peak-mem math and
+  ship an idle-drain (S-D) or it is a regression.
+- **A5 (no thrash under 80-thread overload):** eviction must be scan-resistant (K-G) and lock-sharded
+  (both shipped caches already shard ×16/×128) so the hit path never serializes.
+- **No-heuristics (#28):** every proposed key (`GenerationIdentity`, chunk index, snapshot epoch) is
+  authoritative — never inferred from decoded byte content. K-A/K-D reuse #2059's inode-stable identity.
+- **Scans cannot beat the 82 % merge wall** (Phase-0). Caching's scan ceiling is ~1.16× local /
+  ~1.3–1.5× field, realized only on repeated ranges. Do not sell caching as a scan fix.
+
+**File path:** `/Users/patrickmcfadin/local_projects/cqlite/docs/research/phase1-4-caching.md`
+(uncommitted per instructions).

--- a/docs/research/phase1-5-transport-ingest.md
+++ b/docs/research/phase1-5-transport-ingest.md
@@ -1,0 +1,381 @@
+# Phase 1.5 — Transport & worker ingest: decomposing the through-Trino throughput gap
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Agent:** Phase-1 agent 5/8 (transport & worker ingest)
+**Anchors:** `docs/research/phase0-scan-cost-breakdown-2026-07.md` (server-side CPU),
+`docs/research/throughput-backlog-inventory-2026-07.md` (dedup), R12 field round (#2367).
+
+READ-ONLY survey. Every claim below is `file:line`, a field measurement, or cited prior art, and is
+marked **[CODE]**, **[FIELD]**, **[DERIVED]** (arithmetic from the other two), or **[PRIOR-ART]**.
+No workspace build was run (the one-microbench allowance needs a full cqlite-flight/Java build —
+declined per the constraint); the connector costs are read off the source and the Arrow-Java API
+contract, not measured, and are flagged **[DERIVED]** wherever a multiplier is quoted.
+
+---
+
+## 0. The two numbers, reconciled
+
+| | rows/s | MB/s | source |
+|---|---:|---:|---|
+| **Local server-direct, single stream** | ~500 k / stream | ~150 (Arrow wire) | Phase 0 §2 **[FIELD]** — warm, uncompressed, RF=1, loopback, narrow `keyvalue` |
+| **Field, through Trino (B3 / R12)** | **~10.6 k / pod** | **~1.9 / worker** | 941 brief: 1.94 M rows, 61.1 s, 3 pods **[FIELD]**; worker MB/s = rows/s × row-width **[DERIVED]** |
+
+**The "1–2 MB/s/worker" is not an independent floor — it is the arithmetic image of 10.6 k
+rows/s/pod.** 10.6 k rows/s × ~180 B/row Arrow-wire ≈ **1.9 MB/s** **[DERIVED]** (row width assumed
+from the `cassandra_easy_stress.keyvalue` shape Phase 0 used: `key text` + `value text`, ~100–200 B
+on the wire; if the R12 corpus is wider, MB/s rises and rows/s falls proportionally). So there is
+**one gap to explain, expressed two ways**, and both the rows/s and the MB/s levers below move the
+same underlying quantity. Do not treat page-building, the network, and rows/s as three separate
+throughput problems — they are one drain chain.
+
+**The drain chain (the unit of analysis):**
+
+```
+SSTable → decode → k-way merge → egress channel(#2600) → Arrow encode → gRPC/HTTP2 write
+   → [network + HTTP/2 flow control] → Java FlightStream.next() → ArrowToTrino row-by-row page build → Trino Page
+```
+
+The slowest link in this chain, times the number of concurrent chains (streams) per pod, sets
+10.6 k rows/s/pod. Phase 0 profiled the **first four links** (server CPU); this report owns the
+**last five** (encode → wire → Java ingest) plus **how many chains run at once**.
+
+---
+
+## 1. The gap decomposition — where the ~47× goes
+
+500 k rows/s (single local stream) ÷ 10.6 k rows/s/pod = **~47×**. It splits cleanly into a
+**distribution** deficit (the pod runs too few effective streams) and a **per-stream ceiling**
+deficit (each field stream is far slower than the local one). The R12 saturation telemetry is the
+key that separates them.
+
+> **R12 saturation snapshot [FIELD]** (941 brief, quoting #2367 / #2600): **admission 12/64**,
+> **blocking pool 8/~512**, **egress queued 3,505 rows**. Read this precisely: the server was
+> **≈5× under its admission ceiling and ≈64× under its blocking-pool ceiling** — it was **not**
+> parallelism-bound — yet **rows were piling up at the egress channel**. The pipeline was
+> **drain-limited, not produce-limited.**
+
+### 1a. Distribution deficit — the pod runs too few, and stalling, streams (≈4–16×)
+
+- **Fan-out model [CODE]:** the full-scan path emits **one split per token range**, each pinned to
+  one replica (`CqliteFlightSplitManager.buildSplits`, `CqliteFlightSplitManager.java:288–337`).
+  Trino's driver scheduler runs those splits concurrently up to `task.concurrency` per worker. Each
+  split is **one** `CqliteFlightPageSource` → **one** `ReplicaFailoverStream` → **one** `do_get`.
+- **admission 12/64 across 3 pods ⇒ ~4 concurrent `do_get` per pod [DERIVED].** Against a 64-permit
+  ceiling and a ~512 blocking pool, the server has **5–16× idle parallelism headroom**. The pod is
+  aggregating ~4 streams × ~2.6 k rows/s/stream ([DERIVED] 10.6 k ÷ 4), not 64 × anything.
+- **No Java-side prefetch — each stream is internally serial [CODE].**
+  `CqliteFlightPageSource.getNextSourcePage` (`CqliteFlightPageSource.java:45–64`) is a **synchronous
+  pull**: it calls `stream.next()` (blocks for the next Arrow batch), then runs `ArrowToTrino.toPage`,
+  then returns. While the page is being built the FlightStream is **not being pulled**, so the
+  server's next batch has nowhere to go → the per-stream pipeline is `[wait batch] → [build page] →
+  [Trino consumes] → [wait batch]` with **no double-buffering**. Page-build latency is injected
+  directly into stream idle time. `ReplicaFailoverStream` (`ReplicaFailoverStream.java:67–121`) is
+  the same synchronous `next()/getRoot()` with no async/prefetch/executor.
+- **The aggregate path is worse but off the B3 critical path [CODE]:**
+  `CqliteFlightAggregatePageSource` (`:83–92`) fans out **serially** — a `for` loop over ranges,
+  one `do_get` at a time inside a single page source. B3 is a non-aggregate full scan, so the
+  scalar path above governs; but any GROUP-BY/agg query is single-stream-serial today.
+
+**Distribution verdict:** the pod is leaving **~4–16×** on the table purely to under-fan-out and
+per-stream serialization, and #2600's egress queue (3,505) proves the few streams that *do* run
+can't drain — so simply raising `task.concurrency`/split count without fixing the ceiling just moves
+the queue.
+
+### 1b. Per-stream ceiling deficit — each field stream is ~189× the local one (≈3–12× beyond what RF/network trivially explain)
+
+500 k ÷ 2.6 k ≈ **189× per stream [DERIVED]**. Local is warm/uncompressed/RF1/loopback; field is
+none of those. Multiplicative factors, **wide bands, honest confidence**:
+
+| Factor | Est. multiplier | Confidence | Basis |
+|---|---:|---|---|
+| **Cold / partly-cold IO** (1.93 M partitions/node not resident; Phase 0 was page-cache-warm) | **2–8×** | **LOW** | Phase 0 §5.2 flags this as invisible on the warm rig; pure unknown, and likely the single biggest term |
+| **LZ4 decompression** (field SSTables compressed; local was uncompressed → Phase 0 Stage-1 ≈0%) | **1.3–2×** | MED | Phase 0 §5.1 — "a whole decompression-CPU stage this profile is structurally blind to" |
+| **Network transport + HTTP/2 flow control** (real send/recv + window stalls vs loopback ≈0%) | **1.5–3×** | MED | Phase 0 §5.3; §5 below (gRPC window is unconfigured) |
+| **Connector page building + no Java prefetch** (row-by-row `toPage`, serial pull) | **1.5–5×** | MED | §2 below; `ArrowToTrino.java:107–141`, `CqliteFlightPageSource.java:45–64` |
+| **Trino overhead** (split planning, exchange, driver sched, page processing) | **1.2–2×** | LOW | not in CQLite's code; generic MPP overhead |
+| **RF=3** | **~1.0–1.2×** | MED | connector reads each range from **one** pinned replica (`buildSplits`), so RF3 does **not** 3× the row work; cost is fan-out/coordination only |
+
+Product of the bands: ~9× (low) to ~360× (high), straddling the observed 189× — i.e. the factors are
+individually plausible but **cannot be pinned without field profiling of the through-Trino path**
+(no such profile exists; Phase 0 is server-direct only). The **narrow-row per-row coordination
+ceiling** Phase 0 indicts (the cap-256 `sync_channel` handoff, 47–50% of server CPU) is *already
+inside* the 500 k local number — it is the same on both sides and does not itself widen the gap; it
+just means the per-stream ceiling starts low.
+
+**Confidence-weighted attribution of the ~47× pod gap:**
+
+| Bucket | Share of the 47× | Confidence | Actionable via |
+|---|---|---|---|
+| Distribution (under-fan-out + per-stream serialization + undrained egress) | **~30–50%** | MED | more streams (§2b), async prefetch (§2b), #2600/#2765 egress budget (§6) |
+| Cold-IO + decompression (field-only, data-plane) | **~30–45%** | LOW | out of transport scope — read-path/caching epics (B/F, closed) + warm-reader residency |
+| Transport + connector ingest (encode/wire/page-build) | **~15–30%** | MED | §2, §3, §4, §5 below — **this report's owned levers** |
+
+---
+
+## 2. Lever #1 — Connector page building (`ArrowToTrino`)
+
+### 2a. What it does today, per cell [CODE]
+
+`ArrowToTrino.toPage` (`ArrowToTrino.java:55–65`) → `toBlock` (`:107–120`) → `writeValue` (`:122–141`)
+is a **row-at-a-time, per-cell dispatch** loop:
+
+```java
+for (int i = 0; i < rowCount; i++) {            // per row
+    if (vector.isNull(i)) { builder.appendNull(); continue; }   // validity check
+    writeValue(type, vector, i, builder);        // switch(type) → checkcast → get(i) → builder.write*
+}
+```
+
+Per cell the JVM does, every row: (1) `vector.isNull(i)` bitmap probe; (2) a `switch (type)` Java-21
+pattern match (`:123–140`) — a chain of type tests; (3) a `checkcast` to the concrete vector
+(`(BigIntVector) vector`); (4) `vector.get(i)` — a bounds-checked buffer read; (5) an interface
+dispatch `t.writeLong/writeSlice(builder, …)` into a `BlockBuilder` (capacity check + append). That
+is **~5–10 ops + 1–2 virtual/interface dispatches per cell**, none of it hoisted out of the loop —
+the type is re-decided for **every cell** even though it is constant for the whole column.
+
+**The varchar/varbinary path additionally allocates and copies per cell [CODE]/[PRIOR-ART].**
+`varcharSlice`/`binarySlice` (`:307–334`) call `VarCharVector.get(i)` / `VarBinaryVector.get(i)`,
+and Arrow-Java's `BaseVariableWidthVector.get(int)` **allocates a fresh `byte[]` and copies the cell
+out of the off-heap buffer** ([PRIOR-ART] — Arrow-Java API contract; the zero-copy accessor is
+`get(NullableVarCharHolder)` / direct `ArrowBuf` slicing, not used here). For the 2-varchar
+`keyvalue` row that is **2 heap `byte[]` allocations + 2 copies per row** → **~3.9 M short-lived
+`byte[]`/scan** on the worker, straight into the young-gen allocator and the exact per-cell-alloc
+anti-pattern Phase 0 flags on the *server* side.
+
+The FixedSizeBinary→UUID path (`formatUuid`, `:337–344`, `varcharSlice` `:326`) is worse still —
+`HexFormat` + 4 `String` concatenations per uuid cell — but `keyvalue` doesn't hit it.
+
+### 2b. Near-zero-copy mapping to Trino blocks [PRIOR-ART]/[DERIVED]
+
+Arrow's in-memory layout and Trino's `io.trino.spi.block` layout are close cousins; a **bulk,
+per-column** conversion replaces the per-cell loop:
+
+- **Fixed-width (int/bigint/double/real/date/timestamp):** Arrow's fixed-width vector data buffer is
+  a contiguous little-endian array. Trino `IntArrayBlock`/`LongArrayBlock` wrap an on-heap
+  `int[]`/`long[]`. Conversion collapses to **one bulk copy of the whole column buffer** into the
+  primitive array + **one bulk copy of the validity bitmap** — ~memcpy bandwidth (GB/s), **one type
+  dispatch per column per batch** instead of per cell. On little-endian hosts (all field pods) no
+  byte-swap is needed. [PRIOR-ART] the Trino BigQuery Storage-API and Snowflake Arrow readers both
+  convert Arrow batches **column-at-a-time** into Trino blocks; DuckDB and Velox import Arrow
+  fixed-width buffers **zero-copy** (wrap, no copy) via the Arrow C-Data interface.
+- **Variable-width (varchar/varbinary):** Trino's `VariableWidthBlock` is *literally* `(Slice
+  values, int[] offsets, boolean[] valueIsNull)` — the **same three-buffer shape** as an Arrow
+  `VarCharVector` (data buffer, offset buffer, validity). Build the block from **one `Slice`
+  wrapping the Arrow data buffer** + **one offset-array copy** (int32→int32, or a widen for
+  `LargeVarChar`), eliminating the ~3.9 M per-cell `byte[]` allocations entirely. This is the single
+  biggest connector win for the narrow text shape.
+- **Memory-lifetime caveat [CODE]/constraint A5/B4:** the Arrow data buffer is off-heap and owned by
+  the Flight `VectorSchemaRoot`, freed when the stream advances/closes. A `Slice` *wrapping* it
+  (true zero-copy) would dangle unless the block's lifetime is bounded to the batch — Trino pages can
+  outlive a `getNextSourcePage` call. So the safe first step is **one bulk on-heap copy per column**
+  (a `Slice.copyOf` of the whole data buffer), not a raw wrap: still ~memcpy-cheap, drops per-cell
+  dispatch + per-cell alloc, and keeps the off-heap buffer's lifetime out of Trino's page graph
+  (protects the worker heap budget, B4). Raw zero-copy wrap is a later, riskier step needing explicit
+  retain/release plumbing.
+
+**Estimated multiplier on the page-build step [DERIVED]:** row-by-row costs ~20–50 ns/cell
+(fixed-width) and ~80–150 ns/cell (varchar, dominated by the `byte[]` alloc + young-gen pressure);
+bulk column copy is ~1–3 ns/cell (memcpy-bound) + one dispatch/column/batch amortized to ~0. That is
+**~10–20× on the page-build CPU** and **eliminates the 3.9 M allocs/scan**. Because page-build sits
+on the serial pull chain (§1a), the *effective* stream multiplier is smaller than 10–20× (page-build
+is one link of several) — call it **~1.5–3× on stream throughput [DERIVED]**, larger once prefetch
+(below) also lands.
+
+**Pair it with async prefetch [CODE] (distribution, not ceiling):** double-buffer the FlightStream —
+pull batch *n+1* while converting batch *n* — so page-build CPU overlaps network/produce latency
+instead of serializing behind it. Small change to `CqliteFlightPageSource`/`ReplicaFailoverStream`
+(a one-slot read-ahead), directly attacks the §1a serialization.
+
+---
+
+## 3. Lever #3 — Arrow batch sizing (`--batch-size 8192`)
+
+- **Current [CODE]:** server default `batch_size = 8192` rows (`main.rs:35–36`,
+  `service.rs:238–243`, `producer.rs:401`). Batches are buffered to `batch_size` then emitted
+  (`producer.rs:777,839`).
+- **Bytes/batch on field rows [DERIVED]:** 8192 × ~180 B ≈ **1.47 MB/batch** (narrow keyvalue);
+  a 1 KB wide row ⇒ ~8 MB/batch.
+- **gRPC message ceiling:** 1.47 MB < gRPC's 4 MB default inbound cap, fine for narrow rows; but an
+  **8 MB wide-row batch exceeds it** and would need a raised `maxInboundMessageSize` on the Java
+  client (**not set today** — `FlightClient.builder(allocator, location).build()`,
+  `CqliteFlightClient.java:101–103`, no options). Arrow-Flight-Java defaults the inbound limit high,
+  so this is latent, not active, but it caps how far batch-size can grow for wide tables.
+- **HTTP/2 flow-control interaction (the real issue) [DERIVED]:** a 1.47 MB batch is **~22× the
+  default 64 KB HTTP/2 stream window** (§5). With an unconfigured window, the server can push only
+  ~64 KB before blocking on a `WINDOW_UPDATE` round-trip → a large batch is drip-fed a window at a
+  time. **Bigger batches don't help, and can hurt, until the window is opened** — batch-size and the
+  window are coupled and must move together.
+- **Verdict:** batch-size 8192 is reasonable for narrow rows; the lever here is **not** raising it in
+  isolation but (a) making it **byte-bounded** for wide rows (cap MB/batch so one config works across
+  shapes) and (b) opening the window (§5) so the batch can actually stream. Low standalone value;
+  medium as a co-lever.
+
+---
+
+## 4. Lever #4 — IPC / Flight-body compression
+
+- **Current [CODE]: OFF.** `encode_do_get` builds `FlightDataEncoderBuilder::new()` with **no
+  `.with_options(...)`** (`streaming.rs:439–448`), so the Arrow-IPC body uses default
+  `IpcWriteOptions` → **`batch_compression_type: None`**. Flight data bodies cross the app-node
+  network **uncompressed**. (The `IpcWriteOptions::default()` at `service.rs:558` is GetSchema-only,
+  also uncompressed, and schema is tiny — irrelevant.)
+- **Wire savings [DERIVED]/[PRIOR-ART]:** Arrow LZ4_FRAME/ZSTD on columnar batches typically yields
+  **~2–4×** on text/int columns (columnar data compresses well; the local Arrow wire form is already
+  ~3.5× the packed on-disk size per Phase 0 §2, so there is fat to squeeze). ZSTD compresses harder,
+  LZ4 is cheaper CPU.
+- **CPU cost vs when it helps:** compression trades server CPU for wire bytes. It **helps when the
+  link is the bottleneck** (cross-node network, or a window-throttled stream — §5) and **hurts when
+  CPU is the bottleneck** (Phase 0: server is already ~55% kernel + 18% alloc for narrow rows —
+  adding LZ4 there steals cycles from the merge). **At a genuine 250 MB/s app-node link, LZ4 (~500
+  MB/s–1 GB/s/core encode) roughly breaks even to net-positive; ZSTD only pays if the network is the
+  hard limit.** Decision rule: enable **LZ4 when the drain chain is network/window-bound** (wide
+  rows, saturated NIC), leave **off when CPU-bound** (narrow rows on a fast intra-rack link).
+  Make it a server flag, default off, opt-in per deployment. Confidence MED; needs a field A/B.
+- **Constraint tie-in (B4 memory):** compression **reduces** peak wire buffering both sides — a mild
+  win for the worker heap budget, independent of throughput.
+
+---
+
+## 5. Lever #5 — gRPC / HTTP-2 tuning
+
+- **Server config today is one line [CODE]:** `main.rs:128–131` — `Server::builder()
+  .max_concurrent_streams(max_concurrent_streams)` only, where `max_concurrent_streams = max(K×4,
+  1024)` (`:101–104`). **No** `.initial_stream_window_size(...)`, **no**
+  `.initial_connection_window_size(...)`, **no** `.max_frame_size(...)`. So the **HTTP/2 flow-control
+  windows fall to tonic/h2 defaults (~64 KB stream, ~64 KB connection)** [PRIOR-ART: h2 crate
+  defaults].
+- **Client config today [CODE]:** `CqliteFlightClient.java:101–103` builds the FlightClient with
+  **no** window / message / compression options — pure Arrow-Flight-Java defaults.
+- **Why it bites [DERIVED]:** a 64 KB stream window against a 1.47 MB batch (§3) means a batch is
+  released **~22 windows at a time**, each gated on a client `WINDOW_UPDATE`. On loopback (Phase 0)
+  the round-trip is ~free, which is exactly why Phase 0 saw transport ≈0% and **could not see this**.
+  On a real app-node link with RTT `r`, a single 64 KB-windowed stream tops out near `64 KB / r`
+  (e.g. 0.5 ms ⇒ ~128 MB/s ceiling **per stream** regardless of NIC), and the *connection* window
+  (also 64 KB, shared across all streams to a host) can throttle the aggregate even harder. This is a
+  classic bandwidth-delay-product stall and a prime suspect for why per-stream field rates sit so far
+  under the local ceiling.
+- **Lever:** raise `initial_stream_window_size` and `initial_connection_window_size` to a BDP-sized
+  value (e.g. 4–16 MB) on the tonic server, and match `maxInboundMessageSize` + window on the Java
+  client. **Low code cost, potentially high payoff on the network-bound term**, and it is the
+  *enabler* for larger/byte-bounded batches (§3) and for compression (§4) to matter. Confidence MED
+  (the window default is real and unset in code; the field magnitude is unmeasured through Trino).
+- **Constraint (B4/A5):** bigger windows raise per-connection buffered bytes on **both** heaps
+  (server flight buffers + worker off-heap Arrow). Size the window against the worker's
+  `≤512 Mi`/`≤16 Mi` B4 envelope and admission `K`, not blindly — a 16 MB window × many streams is a
+  memory footgun. This is the load-bearing tension in the whole report: **every ceiling lever that
+  raises in-flight bytes trades against B4.**
+
+---
+
+## 6. Lever #6 — Multiple streams per worker × egress-budget coupling (#2600/#2765)
+
+- **The coupling the brief flags is real and bidirectional [FIELD]/[CODE].** #2600 (shipped, PR #2766)
+  attributed R12's dominant saturation — **3,505 rows queued at merge-egress while blocking pool sat
+  at 8/512** — to **consumer-side drain latency**: the Arrow-encode + gRPC-write stage (the egress
+  channel's consumer) starved under CPU contention, so the merge's producer filled the channel. The
+  lever shipped was a **process-global adaptive egress budget** `clamp(EGRESS_ROW_BUDGET /
+  active_merges, MIN, 256)` (#2765 tracks the productionized impl), CAP=32 cutting depth 5–8× at <10%
+  qps cost (MEMORY.md).
+- **Why a worker-ingest fix feeds back into it [DERIVED]:** the egress channel's consumer chain is
+  `encode → gRPC-write → [HTTP/2 window] → Java recv → page-build`. **Anything that speeds the Java
+  drain (near-zero-copy page build §2, prefetch §2b, opened window §5) raises the real drain rate,
+  which *empties* the egress channel** — reducing backpressure, letting more concurrent merges share
+  the global budget, and letting `active_merges` climb toward the 64 admission ceiling. So the §2/§5
+  levers and #2765 are **complements, not substitutes**: fix the drain and #2765's `clamp` stops
+  binding as often; leave the drain slow and adding streams (§1a) just deepens the queue.
+- **Distribution vs ceiling, stated cleanly:** *more streams* (raise `task.concurrency`/split count,
+  async prefetch) is a **utilization** lever — it only helps once the **ceiling** (drain rate per
+  stream) is high enough that the added streams don't just re-fill the egress queue. **Order matters:
+  raise the ceiling (§2 page-build, §5 window, §4 compression-if-network-bound) first, then widen
+  distribution (§1a, #2765 budget).** Doing distribution first re-creates the #2600 fire.
+
+---
+
+## 7. Lever table
+
+Multiplier = expected effect on **pod rows/s** (≈ MB/s), not on the isolated sub-step. S/M/L = code cost.
+
+| # | Lever | Multiplier (pod) | Cost | Risk | Type | Collisions / dependencies |
+|---|---|---:|---|---|---|---|
+| 1 | **Near-zero-copy `ArrowToTrino`** — bulk per-column copy; varchar via `VariableWidthBlock(Slice,offsets,nulls)`; kill 3.9 M/scan `byte[]` allocs | **1.5–3×** | **M** | MED — off-heap buffer lifetime vs Trino page graph (B4); use bulk on-heap copy first, raw wrap later | Ceiling | Epic AE #1470 (per-cell conversion, server-side sibling); Epic K #1604 (closed). **New surface — no existing connector issue owns it.** |
+| 2 | **Async batch prefetch** in the page source (double-buffer `next()`/convert) | **1.3–2×** | **S** | LOW | Distribution | Pairs with #1; touches `CqliteFlightPageSource`/`ReplicaFailoverStream` |
+| 3 | **HTTP/2 window sizing** (server `initial_stream/connection_window_size`, client match) | **1.5–3× (network-bound)** | **S** | MED — raises in-flight bytes both heaps (B4/A5) | Ceiling (enabler) | Enables #4/#5-batch; size vs B4 envelope + admission K |
+| 4 | **Byte-bounded batch size** (cap MB/batch; raise client `maxInboundMessageSize`) | **1.0–1.3×** | **S** | LOW | Ceiling (co-lever) | Only pays **after** lever 3; #1476/#2230 (byte-budget, closed) are the read-path analogue |
+| 5 | **Flight-body LZ4 compression, opt-in** (`FlightDataEncoderBuilder::with_options`) | **1.3–2× (network-bound); ≤1× (CPU-bound)** | **S** | MED — steals server CPU on narrow rows | Ceiling (conditional) | Default OFF; A/B in field; Phase 0 says server is CPU-bound for narrow rows |
+| 6 | **Raise effective fan-out** — `task.concurrency`/split count toward admission 64 | **2–5× (only post-ceiling)** | **S** | HIGH if done first — re-creates #2600 egress fire | Distribution | **Gated on #2765** adaptive egress budget; ordering-critical (§6) |
+| — | **Vectorized execution (DataFusion #941 / #2605)** | **≫ (Stage 2: 600 k rows/s)** | **L** | — | Ceiling (structural) | The only path past the row-engine ~1.6 µs/row wall (941 brief); out of this report's transport scope but the real Stage-2 answer |
+
+**No duplicate filings:** per the inventory, levers 1–5 are **unclaimed transport/connector surface**
+(the closest, AE #1470, is server-side per-cell cost, not connector page-build). Lever 6 must
+**extend #2765**, not refile (inventory §Collision-watchlist: "extend #2765, don't refile"). Lever 3
+must not be conflated with #2680/#2782 (an active split-scheduling P0 fire — a *different* connector
+concern).
+
+---
+
+## 8. Is 250–350 MB/s/worker credible, and via what stack?
+
+**Today: ~1.9 MB/s/worker [DERIVED].** The target is **~130–180× today** — far beyond the local
+server-direct single-stream ceiling itself (~150 MB/s). **The answer is emphatically shape- and
+stack-dependent:**
+
+1. **Narrow rows (keyvalue, ~180 B) via the row engine + transport levers 1–6: NOT credible.**
+   MB/s = rows/s × 180 B. To hit 250 MB/s you need **~1.4 M rows/s/worker** — *3× the entire local
+   RF1/warm/uncompressed single-stream ceiling*, in the field, under RF3 + compression + network.
+   The row engine's ~1.6 µs/row wall (941 brief) caps a single stream near ~600 k rows/s even
+   perfectly tuned; you would need several such streams each at an unattainable field rate. The
+   transport levers (1–6) realistically get narrow-row rows/s from ~10.6 k to **~40–120 k/pod**
+   (compounding lever 1×2×3 ceiling gains ~3–6× and fan-out 2–5× once drain is fixed) — i.e.
+   **~7–22 MB/s/worker**. Good (approaching the A4 Stage-1 100 k rung), but an order of magnitude
+   short of 250 MB/s.
+
+2. **Wide rows (≥1 KB) via row engine + levers 1–6: plausibly credible at the low end.**
+   MB/s scales with row width at fixed rows/s. At ~100 k rows/s/pod (Stage-1-plausible post-levers)
+   × 1 KB = **~100 MB/s/worker**; a 2–3 KB row at that rate reaches **200–300 MB/s** — so **250 MB/s
+   is reachable for wide rows** on the row engine *if* fan-out and drain are fixed, because the
+   per-row coordination overhead (Phase 0's dominant cost) amortizes over more bytes. Wide rows are
+   the regime where levers 1 (bulk column copy) and 4 (compression) pay most.
+
+3. **Narrow rows at 250–350 MB/s: only via vectorized/columnar execution (Stage 2/3, DataFusion
+   #941).** 250 MB/s at 180 B/row = ~1.4 M rows/s — Stage-2/3 territory the 941 brief already
+   concluded the row engine cannot reach. Transport levers are **necessary but not sufficient**; they
+   remove the drain-chain ceilings so the columnar engine's output can actually leave the pod.
+
+**Bottom line for the program:**
+
+- **250–350 MB/s/worker is credible for wide rows on the tuned row engine**, and **not credible for
+  narrow rows without vectorized execution.** The MB/s target implicitly assumes a wider row shape
+  than the keyvalue benchmark; state the target's assumed row width explicitly.
+- **The transport stack that gets there:** near-zero-copy `ArrowToTrino` (lever 1) + async prefetch
+  (2) + opened HTTP/2 window (3) + byte-bounded batches (4) + fan-out-past-drain gated on #2765 (6),
+  with LZ4 (5) toggled by whether the app-node link is the bottleneck. These are the **enabling
+  layer**; DataFusion (#941/#2605) is the **rows/s engine** for the narrow-row Stage-2 target.
+- **The binding constraint on every ceiling lever is B4 memory** (worker heap ≤512 Mi / ≤16 Mi
+  per-page, plus server flight buffers): windows, batch bytes, and prefetch depth all raise in-flight
+  bytes and must be co-sized against admission `K` and the B4 envelope. Size them together, not
+  independently.
+- **Ordering is load-bearing (§6):** raise the per-stream ceiling (1,2,3,4) *before* widening
+  distribution (6), or you just rebuild the #2600 egress fire at a deeper queue.
+
+---
+
+## 9. Evidence index
+
+| Claim | Location |
+|---|---|
+| Connector page build is row-by-row, per-cell `switch` dispatch | `trino-connector/.../ArrowToTrino.java:55–65,107–141` |
+| Varchar path allocates+copies `byte[]` per cell (`VarCharVector.get(i)`) | `ArrowToTrino.java:307–334` + Arrow-Java `BaseVariableWidthVector.get` contract |
+| Page source is synchronous pull, no prefetch/double-buffer | `CqliteFlightPageSource.java:45–64`; `ReplicaFailoverStream.java:67–121` |
+| One split per token range, one replica pinned | `CqliteFlightSplitManager.java:288–337` |
+| Aggregate path fans out serially (one do_get at a time) | `CqliteFlightAggregatePageSource.java:83–92` |
+| Flight body compression OFF (default `IpcWriteOptions`) | `cqlite-flight/src/streaming.rs:439–448` |
+| gRPC server sets only `max_concurrent_streams`; no window/frame tuning | `cqlite-flight/src/main.rs:101–104,128–131` |
+| Client builds FlightClient with no window/message/compression options | `CqliteFlightClient.java:101–103` |
+| batch_size default 8192 | `cqlite-flight/src/main.rs:35–36`; `service.rs:238–243`; `producer.rs:401` |
+| admission K=64, blocking pool ~512 | `cqlite-flight/src/admission.rs:43`; `main.rs:42–44` |
+| Server CPU: 55% kernel channel handoff, 18% alloc, transport ≈0% (loopback), decompression invisible | Phase 0 §3a, §3b, §5.1–5.3 |
+| Field B3/R12: 1.94 M rows, 61.1 s, 3 pods = 10.6 k rows/s/pod; saturation admission 12/64, blocking 8/512, egress 3,505 | 941 decision brief (quoting #2367/#2600) |
+| Row engine ~1.6 µs/row wall ⇒ Stage-2 needs vectorization | 941 decision brief |
+| Adaptive egress budget (#2600 shipped / #2765 impl) | inventory §5; MEMORY.md #2600 |
+
+**File:** `/Users/patrickmcfadin/local_projects/cqlite/docs/research/phase1-5-transport-ingest.md`
+(uncommitted per instructions).

--- a/docs/research/phase1-6-parallelism.md
+++ b/docs/research/phase1-6-parallelism.md
@@ -1,0 +1,327 @@
+# Phase 1 — Dimension 6: Parallelism & Scheduling
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Agent:** Phase-1 6/8 (parallelism & scheduling)
+**Inputs:** `docs/research/phase0-scan-cost-breakdown-2026-07.md`, `docs/research/throughput-backlog-inventory-2026-07.md`
+
+---
+
+## 0. The hard discipline for this dimension (read first)
+
+Every lever in this document is a **UTILIZATION multiplier**: it spreads work over idle cores or
+idle pods. **None of them raises the per-stream ceiling** — the rate at which one `do_get` coordinator
+turns SSTable bytes into Arrow rows. That ceiling is owned by Phase-0's #1/#2/#3 findings (per-row
+channel handoff, k-way reconcile compute, per-row alloc/hash) and by the other Phase-1 dimensions.
+If the per-stream coordinator does *X* rows/s, four parallel streams do **at most** `4·X` and in
+practice **less**, because Phase-0 measured that a single stream already burns **~55 % of its CPU in
+kernel `sync_channel` park/wake** — and that syscall/context-switch tax *contends* when you stack
+streams onto the same cores.
+
+**Honest per-pod formula (used throughout):**
+
+```
+per_pod_rows_s  =  min( N_admitted , N_drain_sat , N_mem )  ×  per_stream_rows_s  ×  C(N)
+                   \_______________  utilization width  ______________/           \_ contention _/
+
+  N_admitted     = admission ceiling (--max-concurrent-scans, default 64)
+  N_drain_sat    = concurrent streams past which the drain-bound consumer stops
+                   scaling  (measured ≈ 8 on the local rig, see §4)
+  N_mem          = concurrent streams that fit the pod memory budget (B4 → §6)
+  per_stream_rows_s = the per-stream ceiling — NOT movable by anything here
+  C(N)  ≤ 1      = contention factor, FALLS as N grows (kernel park/wake tax, Phase-0 §3a)
+```
+
+The width term `min(...)` is what parallelism levers move. The two right-hand terms are the honest
+tax that stops `4 vCPU → 4× throughput` from being true. On a 4-vCPU pod the effective width is **not
+4** — it is whichever of the three ceilings bites first, and on today's code the **drain-bound
+saturation (~8 concurrent streams) and the single-threaded merge coordinator** dominate, not core
+count.
+
+---
+
+## 1. Lever table (every lever labeled UTILIZATION)
+
+| # | Lever | Layer | Class | What it buys (honest per-pod math) | Cost / hazard | Status |
+|---|-------|-------|-------|-----|------|--------|
+| L1 | **#2680 re-land — K-way token sub-splitting + `SplitWeight`** | Trino connector (plan-time) | UTILIZATION (pod-skew fix) | Field: busiest pod does 2–4× the CPU of the median (count-balanced floorMod). Weight-balancing flattens the skew so aggregate qps rises off the ~39 qps floor toward the pod-count limit. **Multiplier ≈ (skew ratio) → up to ~2–4× on the *lagging* pods, i.e. it recovers stranded utilization; it does NOT raise any single pod's ceiling.** | Caused P0 #2782 (LIMIT hang) via `K=4` default + Trino early-termination not draining sub-split DoGet streams. See §3. | Reverted (`0bd63148b`); re-land is the headline 0.17 lever |
+| L2 | **Lower default `sub-splits-per-range` (K=1 or 2), let `SplitWeight` carry balance** | Trino connector | UTILIZATION | Same skew fix as L1 with far less split inflation. At ~48 ring ranges, K=2 → ~96 splits (~32/pod) already fills a 32-thread Trino worker; K=4 → ~192 is past the sweet spot (§5) and is what armed #2782. | None beyond L1; strictly safer | Part of L1 re-land spec |
+| L3 | **Admission ceiling `--max-concurrent-scans` (currently 64)** | Flight server | UTILIZATION *cap* (also a stability guard) | Sets `N_admitted`. Today sized from blocking-pool/fd ceilings, **not memory or drain**. At 64 it is far above both the drain-saturation width (~8) and the memory-safe width (§6) → it does not add throughput, only admits streams that pile into buffers. | **Too high for a 512Mi/4-vCPU pod** — see §6, A5 restart risk | Shipped #2420; **re-sizing is a lever** |
+| L4 | **#2765 process-global adaptive egress budget** (`cap_per_merge = clamp(BUDGET/active_merges, MIN, 256)`) | Flight/core merge | UTILIZATION-enabling (stability) | Bounds the **merge fan-in** working set (`STREAMING_CHANNEL_CAPACITY × active_merges`) to a fixed budget instead of growing with concurrency. Lets you raise concurrency without the depth-8080 blowup. Measured: CAP=32 cut egress depth 5–8× at <10 % qps cost. | Bounds only the fan-in channel, **not** the Arrow egress channel (the memory-dominant one — §6). | #2600 shipped (characterization); **#2765 impl open, unmilestoned** |
+| L5 | **Intra-query parallel merge (range-shard one `do_get` over R coordinators)** | Flight server | UTILIZATION | Would let ONE stream use >1 core by running R independent coordinators over R token sub-ranges of the same M SSTables. **But this is L1 done inside the server** — same effect, more machinery. | New intra-server merge-sharding + concat + cancellation; duplicates Trino's scheduler. **Strictly more expensive than L1 for the same utilization** (§2). | Not filed — recommend NOT pursuing; prefer L1 |
+| L6 | **Batch rows per fan-in channel message** (Phase-0 #1 mitigation) | core merge | *per-stream* (NOT utilization) | Cuts the per-row `send` count → attacks the 55 % kernel tax → raises `C(N)` and `per_stream_rows_s`. Listed here because it is the thing that makes L1/L3 *scale better*, but it is a **per-stream ceiling lever**, owned by another dimension. | Design work in the merge fan-in | Phase-0 finding #1; not this dimension's to spec |
+
+**Reading the table:** L1/L2/L3 are the parallelism/scheduling levers proper. L4 is a stability
+enabler that *unlocks* higher useful concurrency. L5 is the tempting-but-wrong intra-server variant of
+L1. L6 is flagged only because the honest math above shows that **the contention term `C(N)` — a
+per-stream property — is what caps how much any utilization lever can deliver**; without L6-class work
+the per-pod curve flattens early (§4).
+
+---
+
+## 2. Intra-query parallelism vs more `do_get`s per pod — which is cheaper?
+
+**Where parallelism already exists.** Per `do_get`, the warm path spawns **one reader thread per
+input SSTable** (`from_readers.rs::open_from_reader` → `producer_thread_from_reader`), each decoding
+its SSTable and pushing rows over a bounded `sync_channel(256)` to **one** k-way merge coordinator
+(`KWayMerger::step` / `reconcile_cluster_with_overlap_counted`). So decode is already parallel across
+SSTables; **the merge/reconcile coordinator is single-threaded and is the per-stream throughput
+limiter** (Phase-0 §3b stage 4a = 32.5 % of CPU, all on the one coordinator thread).
+
+**Option A — intra-query parallel merge (L5).** Shard the `do_get`'s token range into R sub-ranges,
+run R coordinators (each merging the same M readers, scoped by `ScanTokenBound` — the machinery
+already exists via #2413's `token_bound` on `new_from_readers`), concatenate. This makes one stream
+use R cores.
+
+**Option B — more `do_get`s per pod (L1/#2680).** Trino already emits one split per token range and
+schedules them concurrently; sub-splitting a range into K slices emits K `do_get`s that the Trino
+scheduler + the Flight admission semaphore already spread across the pod's cores. Each sub-split is a
+token-bounded Summary-guided walk (#2412/#2413) — the *same* per-coordinator work Option A's shards
+would do.
+
+**Verdict: Option B (more `do_get`s via sub-splits) is cheaper for the same utilization.** Both
+options spin up N independent single-threaded coordinators over token sub-ranges; the only difference
+is *who schedules them*. Option B reuses three things already in production — Trino's split scheduler,
+the #2420 admission semaphore, and the #2413 token pushdown — and needs **zero new server code**.
+Option A rebuilds a scheduler inside the server, adds cross-shard cancellation and output
+concatenation, and still hits the same `C(N)` contention tax. **#2680 *is* intra-pod parallelism,
+expressed at the split layer.** Recommend not filing L5.
+
+**What limits concurrent streams per pod** (the `min(...)` width): (1) **admission** `N_admitted`=64
+(L3); (2) **drain saturation** `N_drain_sat`≈8 — the consumer (Arrow-encode + gRPC-write +
+coordinator) is drain-bound, so past ~8 streams throughput is flat and only latency/buffers grow
+(§4, and #2765's own baseline table); (3) **memory** `N_mem` (§6). Today `N_drain_sat` bites first for
+throughput and `N_mem` bites first for stability — **admission at 64 is above both**, which is the
+core mis-sizing.
+
+---
+
+## 3. #2680 re-land spec sketch + acceptance criteria
+
+### 3.1 What shipped and was reverted
+
+Reverted commit `f5dd215a7` (PR #2779), backed out by `0bd63148b`/`7fa3f2050`. It added:
+- `TokenRangeSlicer` — overflow-safe BigInteger ring arithmetic expanding `(start,end]` into K equal
+  token-span slices (wraparound-safe, exact coverage, never an empty `(x,x]` slice, K=1 = identity).
+- `cqlite.sub-splits-per-range` config — **default 4**, min 1, max 64.
+- `getSplitWeight()` on `CqliteFlightSplit` (proportional to slice token span, mean-span = `standard()`,
+  clamped to Trino's valid proportion range) and `CqliteFlightAggregateSplit` (clamped sum over slices).
+- Slicing at the single `sliceRanges` seam before every consumer: scan `buildSplits`, the snapshot host
+  chooser (`distinctReplicaHosts`), and #2679 pruning. Slice *i*'s primary = `rotated(parent)[i % n]` so
+  per-owner span converges to ~1/N; full owner set retained per slice (#2241); snapshot chooser covers
+  every slice primary (#2227). Aggregate path exempted from sub-splitting.
+
+### 3.2 The #2782 hazard class (what the re-land MUST fix)
+
+**Symptom:** with `K=4`, `SELECT ... LIMIT 2` (and partial-predicate + LIMIT) **hang 180 s** through
+Trino; `LIMIT 100` (> 5-row table, drains every split) and unbounded scans **pass**.
+
+**Root-cause class — early-termination stream drain, not ring math:** Trino satisfies a small `LIMIT`
+from the first split(s) and then **cancels / never schedules the remaining sub-splits**. K=4 quadruples
+the in-flight split count, so far more sub-split `DoGet` streams exist that Trino closes early. The
+hang points at a **sub-split's Flight `DoGet` stream not being closed/drained on early close** — the
+server-side producer thread (`producer_thread_from_reader`) blocks in `send` on a full `sync_channel`
+forever if the consumer disappears without the cancel propagating. (CQLite has cooperative cancel via
+`ScanCancel` polled before each `step` — #1473/#2361 — so the fix is ensuring Trino's early close
+*fires* that cancel on every not-yet-drained sub-split, and that a blocked producer observes it.)
+
+This is a **utilization-lever safety bug**: sub-splitting multiplies the number of cancellable streams,
+so any latent early-close/drain gap that a single split per range hid becomes a hang.
+
+### 3.3 Re-land design sketch
+
+1. **Default `K=1`, not 4.** Ship the mechanism inert-by-default (K=1 = byte-identical pre-#2680
+   behavior, already proven). Let `getSplitWeight()` + a **conservative default K=2** (opt-in bump)
+   carry the balance. The field skew fix does not need K=4; §5 shows K=4 overshoots the split-count
+   sweet spot and is exactly what armed #2782.
+2. **Fix the early-close drain** as a hard prerequisite, gated by the `Flight ↔ Trino E2E` lane as the
+   oracle (#2792 makes that lane `required` for `trino-connector/**`). The cancel must reach every
+   sub-split's producer thread; a producer blocked in `send` on a full fan-in channel must wake and
+   exit on cancel (verify the `SyncSender::send` blocked path is cancel-observing, or bound the block).
+3. **Keep `SplitWeight` as the balancing mechanism**, K as the *granularity* knob. Balance should come
+   from weight-proportional scheduling, not from raw split multiplication.
+4. **Compose with #2679 pruning safely:** a fully-bound point read must prune to the **single covering
+   sub-slice → 1 DoGet** (the reverted commit's "K=4 pruning to one narrower slice" test), never
+   re-fan-out. Preserve this — sub-splitting must not re-inflate what #2679 collapsed.
+
+### 3.4 Acceptance criteria — proving the hang is dead
+
+- [ ] **LIMIT-under-sub-splits, the direct #2782 oracle:** with `K≥2`, `SELECT id FROM t LIMIT 2`
+      (small LIMIT, forcing Trino early termination while sub-splits remain in flight) returns exactly
+      2 rows in **< 5 s**, not a 180 s hang — asserted in the `Flight ↔ Trino E2E` lane. Repeat for the
+      partial-predicate + LIMIT shape (`WHERE score>15 AND ... LIMIT 2`).
+- [ ] **Early-close drain unit test (server-side):** a `do_get` whose consumer drops mid-stream while
+      the fan-in `sync_channel` is full must have every producer thread observe cancel and exit within
+      a bounded time (no thread left blocked in `send`) — a `producer_thread_from_reader`-level test,
+      since that is the thread that hangs.
+- [ ] **`Flight ↔ Trino E2E` is a `required` check** for `trino-connector/**` and Flight changes
+      (#2792) — the process gap that let #2779 auto-merge red must be closed before re-land.
+- [ ] **Weight balance (carried over from #2680):** per-owner assigned weight (Σ partitions or Σ bytes)
+      within ≤1.25× of the mean under an RF==N fixture with 8×-unequal-span ranges; `getSplitWeight()`
+      span-proportional + clamped; determinism preserved (`selectionIsDeterministicAcrossInvocations`);
+      full owner set retained (#2241); snapshot chooser covers every slice primary (#2227).
+- [ ] **#2679 compose:** a fully-bound PK point read emits exactly **1 DoGet** at any K (prune to the
+      single covering sub-slice), asserted on the public split-count / do_get counter surface.
+- [ ] **K=1 identity:** ranges/hosts/owner-sets/count byte-identical to pre-#2680 at the default.
+- [ ] **Field (report-only, next round):** busiest pod CPU ≤ ~1.3× median at 32 threads; aggregate qps
+      ceiling rises off ~39.
+
+---
+
+## 4. Utilization saturates early — the drain-bound ceiling (`N_drain_sat`)
+
+The single most important honest number for this dimension comes from #2765's measured baseline
+(server-direct `flight-loadgen` vs `cqlite-flight`, `--max-concurrent-scans 128`, full scan; Apple
+Silicon, trends machine-independent):
+
+| threads | peak egress depth | qps | p50 ms |
+|--------:|------------------:|----:|-------:|
+| 1  | 3    | 38  | 26  |
+| 8  | 1473 | 195 | 36  |
+| 32 | 5397 | 187 | 178 |
+| 80 | 8080 | 190 | 417 |
+
+**Throughput saturates at ~8 concurrent streams (195 qps) and is flat to 80 (190 qps).** Beyond ~8,
+extra concurrency buys only latency (36→417 ms) and buffer depth (1473→8080). The consumer — the
+single-threaded coordinator + Arrow-encode + gRPC-write — is **drain-bound**, exactly Phase-0's
+finding that ~55 % of a stream's CPU is kernel park/wake and the coordinator is the limiter. This is
+the empirical value of `N_drain_sat ≈ 8` and the reason `C(N)` collapses past it.
+
+**Consequence for the per-pod math:** on this rig one pod's useful width is ~8 streams, *not* the 64
+admission slots and *not* the 4 vCPUs× anything. A 4-vCPU field pod will have a *lower* `N_drain_sat`
+(fewer cores to absorb the park/wake tax) — plausibly ~4–6. **Adding splits/streams past that point is
+pure loss** (latency + memory), which is *also* the mechanism behind #2782 (more early-cancelled
+sub-splits) and the depth-8080 saturation (#2600/#2765). The lever that raises `N_drain_sat` is L6
+(cut the per-row channel tax) — a **per-stream** lever, not a scheduling one.
+
+---
+
+## 5. Split sizing for a 4-vCPU pod / 32-thread Trino
+
+**Today's split count.** One split per read-replica token range. Standing rig = 3 nodes × `num_tokens`
+16 → ~48 ranges (RF=3 read-replica intervals). A full scan = ~48 splits, ~16 per pod across 3 pods. A
+point read *without* #2679 = still ~48 DoGets to fetch 1 partition (the #2679 motivation).
+
+**Per-split fixed cost is now LOW — this is why sub-splitting is finally viable.** The three big
+per-split fixed costs were retired in 0.15:
+- **Snapshot open** — amortized by #2356 snapshot reuse per `(keyspace,table)` (~0 after the first split
+  of a query).
+- **Index open** — #2412 lazy Summary-guided BIG index: O(summary) open, ~0 resident, no full Index.db
+  slurp.
+- **Full-ring body walk** — #2413 pushes the split's token range into the per-SSTable walk, so a split
+  reads only in-range partition bodies (not from ring start).
+
+So a split is now ≈ a token-bounded Summary-guided walk with negligible open cost. **That is the
+precondition that makes K-way sub-splitting cheap** (the #941 council's "one split per vnode is
+pathological until token seeks exist" caveat is now largely resolved by #2413).
+
+**Optimal split count.** Two competing pressures:
+- **Floor:** enough splits to (a) fill Trino's 32 worker threads and (b) give weight-balancing enough
+  granularity to flatten the 2–4× pod skew — needs *several×* the pod count, so ≥ ~4× pods.
+- **Ceiling:** past `N_drain_sat` (~8/pod, §4) more concurrent splits per pod add no throughput, and
+  each extra split adds an early-cancellable DoGet stream (#2782 blast radius) + a fan-in channel
+  working set.
+
+For 3 pods × 4 vCPU and a 32-thread Trino: target **total splits ≈ 4–8× the pod count ≈ 48–96**. The
+~48-range ring already sits at the low end; **K=2 → ~96 splits (~32/pod)** fills the Trino worker and
+gives balancing granularity without overshoot. **K=4 → ~192 (~64/pod)** is well past `N_drain_sat` and
+past the split-count sweet spot — it bought skew-balancing granularity at the cost of 4× the
+early-termination surface, which is the #2782 trade that blew up. **Recommend default K=1, opt-in K=2,
+never K=4 as a default.**
+
+**#2679 interaction.** Split pruning collapses a fully-bound point read from ~48 DoGets to 1. Sub-
+splitting must prune to the single covering sub-slice (1 DoGet) — the two compose, but only if the
+re-land preserves that path (§3.4). For scans, #2679 does nothing (no bound PK) and sub-splitting is
+the relevant lever.
+
+---
+
+## 6. Memory / stability coupling — the B4-implied concurrency ceiling
+
+### 6.1 Per-stream buffered working set (from code)
+
+Two distinct bounded buffers per `do_get` (do not conflate — #2765 touches only the first):
+
+| Buffer | Constant | Rows resident / stream | Source |
+|--------|----------|-----:|--------|
+| **Merge fan-in** (per input SSTable) | `STREAMING_CHANNEL_CAPACITY = 256` × M SSTables | 256·M `MergeEntry` | `merge/mod.rs:537`, `from_readers.rs:186` |
+| **Arrow egress** (do_get → gRPC) | `(DO_GET_CHANNEL_CAPACITY 4 + IN_FLIGHT 3) × batch_size 8192` | **57,344 Arrow rows** | `streaming.rs:65/86`, batch 8192 |
+| Coordinator build buffer | 1 × `batch_size` | 8,192 rows | producer build |
+
+The **Arrow egress buffer dominates**: 57,344 rows/stream vs 256·M (≈2,048 at M=8) fan-in +8,192
+build. **#2765's adaptive budget bounds the fan-in term only** (the 256·M side, which is the
+concurrency-*growing* one and the depth-8080 signal) — it does **not** bound the 57,344-row Arrow
+egress buffer, which is per-stream fixed and is the memory-dominant term. **Flag:** to bound pod
+memory under concurrency you also need either a memory-derived admission ceiling (below) or an
+adaptive `DO_GET_CHANNEL_CAPACITY`/`batch_size`.
+
+### 6.2 Bytes and the ceiling
+
+B4 = ≤3 s / **≤512Mi pod** / ≤16Mi (per-query working set target). Per-stream Arrow-egress bytes at a
+field-representative row width:
+
+- Narrow (`keyvalue`, ~300 B/Arrow-row, Phase-0's 150 MB/s ÷ 500k rows/s): 57,344 × 300 B ≈ **17 MB/stream**.
+- Moderate (~256 B/row): ≈ **14.7 MB/stream**.
+- Add transient encode doubling + reader mmaps/decompress buffers/snapshot handles: budget **~20–30
+  MB/stream** all-in.
+
+**`N_mem` = 512Mi / per-stream-MB:**
+
+| per-stream all-in | `N_mem` (streams in 512Mi) |
+|------:|------:|
+| 15 MB | ~34 |
+| 20 MB | ~26 |
+| 30 MB | ~17 |
+
+**B4-implied concurrency ceiling: ~14–34 concurrent streams per 512Mi pod, ~20 as a working
+midpoint**, with the `batch_size × channel-depth` Arrow-egress product as the dominant term (a single
+stream already consumes ~15 MB, essentially the whole ≤16Mi per-query target on its own — the ≤16Mi
+number is only satisfiable at concurrency 1 or with a smaller `batch_size`/channel depth).
+
+### 6.3 The A5 (0-restart under 80-thread overload) finding
+
+**Admission default 64 is memory-unsafe for a 512Mi/4-vCPU pod.** It was "sized from blocking-pool
+(~256) / fd (~1024÷SSTables) ceilings, **not** core count" — and **not memory**. At the memory
+midpoint, 64 admitted × ~20 MB ≈ **1.28 GB ≫ 512Mi → OOMKill**, exactly the A5 failure mode when 80
+threads pile onto a pod. Three coupled conclusions:
+
+1. **`N_drain_sat` (~8) < `N_mem` (~20) < `N_admitted` (64).** Throughput is capped by drain at ~8;
+   memory is safe up to ~20; admission lets in 64. The **64 ceiling protects neither throughput nor
+   memory** — it admits streams that only deepen buffers and threaten OOM.
+2. **Re-size admission from memory:** on a 512Mi pod cap `--max-concurrent-scans ≈ 512Mi / per-stream-MB
+   ≈ 16–24` (round to ~16 for headroom). This keeps A5 at 0 restarts by construction and costs no
+   throughput (it is still ≥ `N_drain_sat`).
+3. **#2765 is necessary but not sufficient for A5:** it bounds the fan-in growth (256·M·active_merges),
+   removing the depth-8080 blowup, but the per-stream 57k-row Arrow egress buffer × concurrency is the
+   larger memory term and is bounded only by admission. **A5 safety = memory-derived admission (L3) +
+   #2765 (L4) together**, not either alone.
+
+---
+
+## 7. Summary packet
+
+**Lever set (all UTILIZATION, none raise the per-stream ceiling):**
+- **L1 #2680 re-land** — weight-balanced sub-splits; recovers 2–4× stranded utilization on lagging
+  pods; **default K=1/opt-in K=2, never K=4**; gated on the early-close drain fix + `Flight↔Trino E2E`
+  as `required` (#2792).
+- **L3 admission re-sizing** — the current 64 is above both the useful (~8) and the memory-safe (~16–24)
+  width; re-derive from pod memory.
+- **L4 #2765 adaptive egress budget** — bounds fan-in growth; stability enabler; open/unmilestoned.
+- **L5 intra-query parallel merge — DO NOT pursue**: it is L1 rebuilt inside the server at higher cost.
+- **L6 per-row channel batching** — the only thing that raises the contention factor `C(N)`, but it is a
+  *per-stream* lever, out of this dimension.
+
+**Honest per-pod math:** `per_pod = min(N_admitted 64, N_drain_sat ≈8, N_mem ≈20) × per_stream × C(N)`.
+On today's code the width is **~8 (drain-bound)**, *not* 4 vCPU × anything and *not* 64 admission slots.
+4 streams ≠ 4× because Phase-0's 55 % kernel park/wake tax contends (`C(N)<1`, falling). Utilization
+levers move the `min(...)`; they cannot move `per_stream_rows_s`.
+
+**#2680 re-land acceptance (hang-is-dead):** small-`LIMIT`-under-sub-splits returns in <5 s (not 180 s)
+in a now-`required` E2E lane; server-side early-close drain unit test (no producer left blocked in
+`send`); weight ≤1.25× mean; #2679 point read = 1 DoGet at any K; K=1 identity.
+
+**B4-implied concurrency ceiling:** **~14–34 concurrent streams per 512Mi pod (~20 midpoint)**,
+Arrow-egress `batch_size×channel-depth` = 57,344 rows ≈ 15–20 MB/stream is the dominant term. A single
+stream ≈ the whole ≤16Mi per-query target. **Admission at 64 → ~1.3 GB at ~20 MB/stream ≫ 512Mi → A5
+OOM risk; re-size admission to ~16–24 from memory. #2765 bounds only the fan-in term, so A5 safety
+needs memory-derived admission AND #2765.**
+
+**File:** `docs/research/phase1-6-parallelism.md` (uncommitted per instructions).

--- a/docs/research/phase1-7-trino-question.md
+++ b/docs/research/phase1-7-trino-question.md
@@ -1,0 +1,276 @@
+# Phase 1-7 — Alternative engines: the Trino question
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Author:** Phase-1 agent 7/8 (strategic engine comparison)
+
+Read-only strategic analysis. Companion to agent 5's connector-mechanics decomposition (same code,
+different altitude: agent 5 owns *how* to fix the connector; this owns *whether fixing it is the
+right bet* vs switching engines). Anchored to Phase 0 (`phase0-scan-cost-breakdown-2026-07.md`), the
+throughput backlog inventory (`throughput-backlog-inventory-2026-07.md`), the ratified performance
+goals (`performance-goals-2026-07.md`, branch `research-parquet-comparison`), the class-marks memo
+(`perf-class-marks-2026-07.md`, same branch), and the #941 Design-A packet + decision brief
+(`docs/architecture/`).
+
+---
+
+## 0. The one number that reframes the whole question
+
+**Trino is not a 30× tax on scan throughput. The row-at-a-time feed is.**
+
+- Field **server-direct** full-ring scan (round-11b, #2367): **~29 k rows/s/ring**.
+- Field **through-Trino** full-ring scan (B3, round-12): **1.94 M rows / 61 s over 3 pods ≈ 31.8 k
+  rows/s aggregate ≈ 10.6 k rows/s/pod.**
+
+Through-Trino aggregate throughput (~32 k rows/s) is *roughly the same as* server-direct ring
+throughput (~29 k rows/s). Trino is **not** eating an order of magnitude off the scan rate — it is
+handing the same row-engine feed to more cores and getting back approximately what the feed can
+produce. The Iceberg/Hive connectors reach **GB/s per worker** through the *same Trino* because they
+feed it **vectorized columnar Parquet/ORC pages** with predicate + partition + row-group pruning
+([LakeOps], [Trino docs]). Our connector diverges by feeding Trino **one row at a time, materialized
+then re-encoded into Arrow builders** — Trino per se is fast; our feed is slow.
+
+Two distinct Trino costs must be separated, because they have opposite fixability:
+
+1. **Per-query latency floor ≈ 0.2–2 s wall** (planning 20–50 ms + split sourcing + scheduling +
+   a collection stage), paid by *every* connector, Iceberg included ([class-marks], [Trino #10971],
+   [Trino #15252]). **Structural. Not fixable in our connector.** It gates point-read / interactive
+   latency (B1) and makes Pinot-class 70–100 ms p99 *unreachable through Trino by construction*.
+2. **Scan throughput tax ≈ small.** The 61 s is dominated by the row-engine feed ceiling
+   (~10 k rows/s/pod), **not** by Trino overhead. **Fixable** — in the server (constant factors,
+   parallelism) and the connector (split granularity, pod balance, backpressure relief).
+
+Everything below follows from that split.
+
+---
+
+## 1. Where the 61 s actually goes (B3 decomposition)
+
+| Contributor | ~share of the 61 s | Fixable where | Evidence |
+|---|---|---|---|
+| Trino coordinator floor (plan+schedule+collect) | ~0.2–2 s (≤3 %) | **Trino-structural** — not ours | [class-marks], [Trino #10971] |
+| Split scheduling of many 1-per-vnode splits | small but real | connector (#2680 balance, sub-splitting) | `CqliteFlightSplitManager.java:28` "one split per token range" |
+| **Row-engine scan feed (decode → merge → materialize → Arrow)** | **the bulk (~90 %+)** | **server + connector parallelism** | Phase 0 §3; ~10 k rows/s/pod |
+| Egress channel backpressure (consumer drain vs producer) | material under load | server (#2600 shipped / #2765) | R12: 3,505 rows queued at merge-egress |
+| Arrow-flight transport | ~0 % | n/a (µs-class, ~1 GB/s) | [class-marks] #2/#5 |
+
+The scan feed is limited by two things Phase 0 named for the *single stream* (per-row cross-thread
+channel handoff = 55 % kernel, allocator = 18 %, own compute = 22 %) **and** by the field pods not
+using their cores: **1 split per vnode range, pinned to 1 replica, scanned single-threaded**
+(`CqliteFlightSplitManager` produces one split per read-replica range). An i4i.xlarge is 4 vCPU; a
+per-pod feed of ~10 k rows/s while the pod has 4 cores is the tell that the scan is running on ~1 of
+them and stalling on egress. **The dominant lever is parallelism-to-all-cores, then constant
+factors.**
+
+---
+
+## 2. Target arithmetic — what each B-goal actually demands
+
+Baseline: 1.94 M rows / 61 s / 3 pods; B2 34–39 qps; B1 p50 227 / p99 366 ms.
+
+| Goal | Baseline | Target | Speedup needed | Per-pod feed implied (3 pods) |
+|---|---|---|---|---|
+| B1 warm interactive | 227 / 366 ms | ≤300 / ≤500 ms | already at floor | — (gateway-bound) |
+| B2 concurrency | 34–39 qps @≤32thr | **≥100 qps @32thr** | ~2.6–3× | needs balanced pods + warm p50 ≤~0.3 s |
+| **B3 Stage 1** | 61 s | **≤10 s** | **~6.1×** | ~10 k → **~65 k rows/s/pod** |
+| **B3 Stage 2** | 61 s | **≤3 s** | **~20×** | ~10 k → **~215 k rows/s/pod ≈ 54 k rows/s/core** |
+
+The two B3 rungs land in different worlds:
+
+- **65 k rows/s/pod** (Stage 1) is reachable by using all 4 cores (4× from parallelism) plus a modest
+  constant-factor win (~1.5×) from Stage-1 levers (egress #2600, zero-copy #1644). The #941 decision
+  brief's own independent estimate — Stage-1 levers alone → **66 s → 15–25 s** — corroborates that
+  parallelism is the missing multiplier: constant factors get ~2.5–4×, cores supply the rest.
+- **54 k rows/s/core** (Stage 2) at 4 vCPU means **~1.6 µs/row end-to-end including decode, merge,
+  reconcile, and Arrow encode.** Phase 0 puts single-stream own-compute at ~22 % of a ~500 k-rows/s
+  ceiling on an *unloaded warm M1* with *2 narrow columns* — real field rows (compressed, wider,
+  reconciliation overlap) are far heavier per row. **1.6 µs/row is vectorized-execution territory, not
+  row-at-a-time territory.** This is the same conclusion the Design-A packet and the ladder math
+  reached ("Stage 2 is not row-engine territory").
+
+---
+
+## 3. The four options, modeled honestly
+
+For each: projected B3/B2, what we lose, engineering cost (S/M/L in issue-count terms), migration risk.
+
+### Option 1 — Fix the connector + server, keep Trino (baseline)
+
+Assume the agent-5-class fixes land: weight-balanced sub-splits so every pod core scans (#2680, but
+see risk), adaptive egress budget (#2600 shipped / #2765 impl), zero-copy value extraction (#1644),
+partition-materialization bounds (#2230/#2423 shipped). None of these touch Trino; they change what
+the connector feeds it and how many streams feed it.
+
+- **Floor Trino imposes:** the **0.2–2 s per-query coordinator floor** (hurts B1/point reads, not
+  scans) and **coordinator scaling to ~tens of concurrent queries** ([class-marks]). Neither bounds a
+  3-pod full scan.
+- **Prior art that our feed diverges from:** Iceberg/Hive connectors hit GB/s per worker via
+  vectorized columnar readers + pushdown pruning ([LakeOps], [Trino episode 40]). Our divergence is
+  the row-at-a-time Arrow feed (Phase 0 §3: per-row channel handoff + per-row alloc) and single-stream
+  per-split scan — **both in our code, both addressable.**
+- **Projected B3:** ~61 s → **~10–20 s** (parallelism 4× + constants ~1.5–2×). Stage 1 **≤10 s
+  reachable but at the edge** — it needs full-core parallelism *and* the constant-factor wins to both
+  land, not one or the other.
+- **Projected B2:** ~39 → **~80–110 qps** once pod skew is removed (#2680 targets 2–4× skew) and warm
+  p50 sits near the B1 floor (~0.3 s → 32 threads / 0.3 s ≈ 100 qps ceiling per the floor arithmetic).
+  **≥100 qps reachable.**
+- **What we lose:** nothing. Keeps JDBC/BI (Tableau/PowerBI), federation, MPP scheduling, fault
+  tolerance, all easy-db-lab tooling.
+- **Cost:** **M** — mostly already-filed 0.16 issues (#2680, #2765, #1644, #2371–#2377 coverage). No
+  new architecture.
+- **Risk:** **medium** — #2680's `sub-splits-per-range=4` default already caused a **live P0 (#2782,
+  LIMIT hang)**: sub-split + LIMIT + Trino early-termination ⇒ a DoGet stream not drained. The
+  parallelism lever is real *and* the exact one currently on fire. Flight↔Trino E2E is not yet a
+  `required` check (#2792).
+
+### Option 2 — DataFusion as the SQL layer (#941 + #2037)
+
+DataFusion is the **fastest single-node Parquet engine** (ClickBench, ahead of DuckDB/ClickHouse,
+[InfluxData]/[DataFusion blog]) and vectorized. But it is **single-node, embeddable — no distributed
+MPP** ([Slashdot compare]). The Design-A packet reflects this honestly: DataFusion is a co-located
+`TableProvider` that **still pulls Arrow from `cqlite-flight` per partition**; **Trino stays the MPP
+owner**. So Option 2 is *not* "replace Trino" — it is "add a second, vectorized SQL surface."
+
+- **The trap:** DataFusion-over-Flight **does not fix B3 by itself.** If the feed is still the row
+  engine, DataFusion just consumes the same ~10 k rows/s/pod. The vectorization win only materializes
+  when the **feed becomes columnar** — i.e. #2037 (ArrowMemtable / vectorized decode). **Swapping the
+  SQL engine on top of a row feed is a no-op for scan throughput.** This is the single most important
+  finding for this option: the bottleneck is the feed, not the SQL tier.
+- **Projected B3:** with a columnar feed (#2037) + vectorized exec, **≤3 s is the only credible path
+  to Stage 2.** Without the columnar feed, no better than Option 1.
+- **Projected B2:** DataFusion doesn't change the Trino path's concurrency; if used as a *replacement*
+  coordinator it loses distribution entirely (single-node). Neutral-to-worse for B2.
+- **What we lose if DataFusion *replaces* Trino as the gateway:** MPP scheduling, fault tolerance,
+  cross-catalog **federation** (joins to other sources), the mature **JDBC/BI ecosystem** Trino gives
+  us (Tableau/PowerBI), and the existing easy-db-lab + trino-connector tooling. As an *additive*
+  embedded/programmatic surface (Design-A's actual proposal), we lose none of that but take on a heavy
+  dependency.
+- **Cost:** **L** — #941 epic children #1905–#1914 (10 issues, all unstarted P3) **plus** #2037
+  ArrowMemtable (exploration epic, WS1–9 mostly unfiled) for the feed. Arrow-version skew (DataFusion
+  ahead of repo's Arrow 53) is a standing integration tax.
+- **Risk:** **high** — heavy dep landing while the row path churns under it; moving baseline (the
+  #941 brief's explicit reason for Option-C-spike-first); the columnar-feed half (#2037) is itself an
+  owner-gated multi-release exploration, not a scheduled build.
+
+### Option 3 — Flight SQL direct (no SQL middle tier for programmatic consumers)
+
+Expose Flight SQL (or the existing Flight `do_get` ticket surface) directly to **programmatic
+consumers** (pandas/ADBC, Spark, Python, Rust) that don't need Trino's SQL gateway.
+
+- **Which workloads bypass SQL:** bulk export, ETL feeds, notebook/dataframe pulls, ML feature
+  extraction — anything that wants *rows fast* and can express its predicate as a ticket. These hit
+  the **server-direct ceiling** (A-lane: ~500 k rows/s/stream local, ~29 k rows/s/ring field today,
+  tens-of-ms warm point reads once cold-parse #2385/#2412 is fully paid down) and **escape the
+  0.2–2 s coordinator floor entirely** ([class-marks] engine-vs-gateway separation).
+- **Which cannot:** BI tools. Flight SQL JDBC exists as a universal driver ([Dremio]) but **Tableau
+  does not support it** and recommends vendor drivers ([Dremio Tableau note]); Power BI/DBeaver
+  support is uneven. So Flight SQL does not retire Trino for the BI seat.
+- **Cost of a second query surface:** Flight **SQL** (prepared statements, catalog metadata, SQL
+  parse/plan) is more than the current ticket API — a SQL front end is, effectively, DataFusion again
+  or a hand-rolled CQL-subset planner. The *ticket-level* bulk API (no SQL) is much cheaper and already
+  ~exists.
+- **Projected B3/B2:** **does not move them** — B3/B2 are through-Trino by definition. It makes them
+  *partly moot* for the export/programmatic slice by giving those users the A-lane numbers instead.
+- **Cost:** **M** (ticket-level bulk path, mostly present) to **L** (full Flight SQL surface + planner).
+- **Risk:** low if additive; the standing cost is maintaining a second surface's semantics/parity.
+
+### Option 4 — Hybrid: Trino for SQL + a Flight-native bulk-path API
+
+Keep Trino + connector fixes (Option 1) for ad-hoc SQL/BI; **add a Flight-native bulk-export path**
+(the cheap end of Option 3) feeding pandas/Spark/Arrow consumers directly at server-direct rates.
+
+- This is the honest reading of the *ratified goal tables themselves*: **A4 (scan rows/s/pod) is a
+  server-direct goal already**; **B3 (through-Trino full scan) stays Trino-bound.** The bulk path
+  *is* how A4 gets delivered to real consumers.
+- **Does it satisfy A4 while B3 stays Trino-bound?** Yes — A4 is server-direct-bound regardless of
+  Trino, so the bulk path delivers it directly; B3 remains a separate through-SQL number governed by
+  Option 1.
+- **Is B3 ≤10 s achievable with connector fixes alone?** **Yes for Stage 1** (Option 1 arithmetic).
+  **No for Stage 2 ≤3 s** — that needs Option 2's columnar feed.
+- **What we lose:** nothing; this is strictly additive and matches the ladder's own sequencing.
+- **Cost:** **M** (Option 1 issues, already filed) **+ S–M** (ticket-level bulk path).
+- **Risk:** low-medium (inherits Option 1's #2782 fire; the bulk path itself is low-risk).
+
+### Option summary table
+
+| Option | Projected B3 | Projected B2 | What we lose | Cost | Migration risk |
+|---|---|---|---|---|---|
+| **1. Fix connector, keep Trino** | ~10–20 s (Stage 1 ≤10 s at the edge) | ~80–110 qps (**≥100 reachable**) | nothing | **M** | medium (#2782 live P0 on the exact parallelism lever) |
+| **2. DataFusion SQL layer** | ≤3 s **only with columnar feed #2037**; else = Option 1 | neutral / worse if it replaces Trino (single-node) | federation, JDBC/BI, MPP, tooling (if replacing) | **L** | high (heavy dep, moving baseline, Arrow skew) |
+| **3. Flight SQL direct** | unchanged (bypasses, doesn't fix) | unchanged | nothing (additive) | **M–L** | low (2nd-surface maintenance) |
+| **4. Hybrid (Trino SQL + Flight bulk)** | Stage 1 ≤10 s via Opt 1; A4 delivered directly | ≥100 via Opt 1 | nothing | **M (+S)** | low-medium |
+
+---
+
+## 4. Per-target verdict — required vs nice-to-have
+
+| Target | Verdict | Required option | Why |
+|---|---|---|---|
+| **B1 warm ≤300/≤500 ms** | met at baseline (227/366) | Option 1 (hold the floor) | gateway-bound; already at Trino's coordinator floor. Below ~200 ms is unreachable *through Trino* — go server-direct (Opt 3/4) for tens-of-ms. |
+| **B2 ≥100 qps @32thr** | **reachable** | **Option 1 REQUIRED** | pod-skew balance (#2680) + egress relief (#2600/#2765) + warm p50 ≤~0.3 s. Trino coordinator handles tens of concurrent queries — not structurally blocking at this scale. |
+| **B3 Stage 1 ≤10 s** | **reachable, at the edge** | **Option 1 REQUIRED & SUFFICIENT** | needs full-core parallelism (~4×) **and** constant-factor wins (~1.5–2×) to *both* land. Trino is not the limiter; the row feed and split granularity are. Option 4's bulk path makes it moot for export consumers. |
+| **B3 Stage 2 ≤3 s** | **NOT credible through Trino with a row feed** | **Option 2 (#941 vectorized) + columnar feed (#2037)** | ~20× / ~1.6 µs/row = vectorized territory. **Limiting factor named:** per-row materialization + per-row Arrow-builder + single-threaded merge-coordinator reconcile. A row-at-a-time engine cannot hit 54 k rows/s/core; no connector fix closes this. |
+| **A1–A4 (server-direct)** | server-direct-bound | Option 3/4 (Flight bulk path) | already independent of Trino; the coordinator floor is the reason to offer a non-SQL path at all. |
+
+---
+
+## 5. No-optimism-theater statement
+
+**Stage-2 B3 ≤3 s through Trino is not credible with the current architecture, and it is not credible
+with a connector fix.** The limiting factor is not Trino and not the wire — it is that a
+**row-at-a-time feed (decode → reconcile → per-row materialize → per-row Arrow builder → per-row
+cross-thread channel handoff)** cannot sustain the ~1.6 µs/row the target implies. Phase 0 measured
+that even a warm, uncompressed, 2-column single stream spends 55 % of CPU in per-row channel park/wake
+and 18 % in the allocator; real field rows are heavier. Reaching ≤3 s requires **columnar execution
+(#941 DataFusion) fed by a columnar source (#2037 ArrowMemtable / vectorized decode)** — two
+owner-gated exploration tracks, a **multi-release bet**, not a 0.16/0.17 connector fix. Anyone
+promising ≤3 s through-Trino from connector work alone is mis-reading the feed as the SQL tier.
+
+---
+
+## 6. Recommendation
+
+**Adopt Option 4 (Hybrid) now; bank the #941 spike; do not promote Option 2 yet.**
+
+1. **Now (0.16/0.17), Option 1 + the bulk path (Option 4):** land the already-filed connector+server
+   fixes (#2680 weight-balanced splits — *after* #2782 is resolved and #2792 makes the E2E lane
+   `required`), #2600/#2765 egress budget, #1644 zero-copy). This delivers **B2 ≥100 qps** and
+   **B3 Stage 1 ≤10 s** (at the edge — measure, don't assume). Add the **ticket-level Flight bulk
+   path** so A4/A-lane consumers (pandas/Spark/ADBC) get server-direct rates and skip the coordinator
+   floor. Least regret, matches the ladder's own sequencing, loses nothing.
+
+2. **Keep the #941 spike (#2605) banked, decide on data.** The decision brief's trigger stands: if a
+   field round shows Stage-1 landing short of **~30 k rows/s/pod**, promote #941; if it clears that,
+   #941 targets 0.17. **But correct the brief's framing in one respect:** promoting #941 *without*
+   the columnar feed (#2037) will not move B3 — sequence #2037's vectorized-decode spike (WS7 #2043)
+   *ahead of or with* any #941 promotion, or the DataFusion bet buys nothing on scan throughput.
+
+3. **Do not treat DataFusion as a Trino replacement.** It is single-node; replacing Trino forfeits
+   federation, the JDBC/BI seat (Tableau has no Flight SQL support), MPP, and all existing tooling.
+   Its role is *additive* vectorized execution over a *columnar feed* — valuable only for Stage 2, and
+   only in tandem with #2037.
+
+**Bottom line for the program:** the through-Trino tax is a *latency floor* (structural, ~0.2–2 s,
+matters for point/interactive → answer is go server-direct) plus a *throughput ceiling* that is **our
+row feed, not Trino** (fixable → Option 1 gets Stage 1 + B2). Trino stays. The genuine engine question
+is **not** Trino-vs-DataFusion; it is **row-feed-vs-columnar-feed** — and that question is forced only
+at Stage 2, on data, when Stage 1 saturates.
+
+---
+
+### Sources
+- Internal: `phase0-scan-cost-breakdown-2026-07.md`, `throughput-backlog-inventory-2026-07.md`,
+  `performance-goals-2026-07.md` + `perf-class-marks-2026-07.md` (branch `research-parquet-comparison`),
+  `docs/architecture/issue-941-design-a-colocated-flight-provider.md`,
+  `docs/architecture/941-datafusion-decision-brief-2026-07.md`,
+  `docs/architecture/trino-flight-read-path-audit-2026-07-08.md`,
+  `trino-connector/.../CqliteFlightSplitManager.java`.
+- Trino connector scan prior art: [LakeOps Trino-Iceberg optimization](https://lakeops.dev/blog/trino-iceberg-optimization),
+  [Trino episode 40 (Iceberg)](https://trino.io/episodes/40.html),
+  [Iceberg connector docs](https://trino.io/docs/current/connector/iceberg.html).
+- Trino coordinator floor / scheduling: [Trino #10971 split-sourcing metrics](https://github.com/trinodb/trino/issues/10971),
+  [Trino #15252 scheduling time](https://github.com/trinodb/trino/discussions/15252),
+  [Shopify faster Trino](https://shopify.engineering/faster-trino-query-execution-infrastructure).
+- DataFusion: [DataFusion fastest single-node Parquet (ClickBench)](https://datafusion.apache.org/blog/2024/11/18/datafusion-fastest-single-node-parquet-clickbench/),
+  [InfluxData writeup](https://www.influxdata.com/blog/apache-datafusion-fastest-single-node-querying-engine/),
+  [DataFusion vs Trino compare](https://slashdot.org/software/comparison/Apache-DataFusion-vs-Trino/).
+- Flight SQL / BI: [Dremio Arrow Flight SQL universal JDBC](https://www.dremio.com/blog/arrow-flight-sql-a-universal-jdbc-driver/),
+  [Dremio: will Flight SQL replace ODBC/JDBC (Tableau limitation)](https://www.dremio.com/blog/will-apache-arrow-flight-sql-replace-odbc-and-jdbc-for-analytics-bi-workloads/).

--- a/docs/research/phase1-8-prior-art.md
+++ b/docs/research/phase1-8-prior-art.md
@@ -1,0 +1,166 @@
+# Phase 1-8 — Prior-art calibration of the achievable per-core scan envelope
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Author:** Phase-1 prior-art calibration agent
+
+Purpose: give Phase 2 a defensible envelope so it can kill inflated multiplier claims. The anchor is
+Phase 0 (`docs/research/phase0-scan-cost-breakdown-2026-07.md`): CQLite today does **~500-540 k rows/s
+single-stream, warm, narrow-row** on an M1 Pro, and the CPU splits **merge channel coordination 49.9 %,
+merge compute 32.5 %, parse/decode 9.7 %, row materialization 4.5 %, Arrow encode 1.0 %, malloc 17.6 %**.
+
+**The single most important normalization rule in this document:** the headline "millions of rows/s/core"
+numbers from ClickHouse/DuckDB/Velox are **columnar single-column SIMD aggregation** — they scan a few
+bytes per row and reduce in place. CQLite's Flight pipeline **materializes every cell, reconciles a k-way
+LSM merge with tombstones, and ships every row over the wire.** These are different workloads by 1-3
+orders of magnitude. The only true structural analog is **ScyllaDB** (SSTable k-way merge with
+tombstones), and even Scylla's billion-row number is *aggregation pushdown*, not row export. Always
+normalize to **rows/s/core AND MB/s/core, with row width stated**, or the comparison is meaningless.
+
+---
+
+## 1. Calibration table (per-core prior art, with sources + hardware)
+
+| System | Figure (normalized) | Workload / row width | Hardware | Columnar or row? Pushdown? | Source | Verified? |
+|---|---|---|---|---|---|---|
+| **ClickHouse** | **2-10 GB/s per core** | aggregation-heavy, compressed columns, few bytes/row touched | AMD EPYC Milan (c6a.4xlarge, 16 vCPU), AVX2 | Columnar SIMD, in-place aggregation | [pulse.support ClickBench KB](https://pulse.support/kb/clickhouse-benchmark) | Secondary (vendor-adjacent KB); order-of-magnitude only |
+| **ClickHouse** | ~703 M rows/s single node ⇒ **~44 M rows/s/core** | 10 B-row aggregation, wide analytics table | 16-core node | Columnar SIMD aggregation | [clickhouse.com parallel-replicas blog](https://clickhouse.com/blog/clickhouse-parallel-replicas) | Vendor benchmark |
+| **ClickHouse (cluster)** | 10.2 B rows/s / 192 GB/s over 9 nodes | 10 B-row aggregation | 9 ClickHouse Cloud nodes | Columnar, aggregation | same as above | Vendor benchmark |
+| **DuckDB** | 200 M-row single-col aggregate in ~40 ms ⇒ order **~10²-10³ M rows/s/core** | one column read, single aggregate, ~4-8 B/row | MacBook Pro M1 (~8-10 cores) | Columnar vectorized (1024-2048 vector), SIMD | [duckdb.org benchmarks-over-time](https://duckdb.org/2024/06/26/benchmarks-over-time); [medium/ThinkingLoop](https://medium.com/@ThinkingLoop/parallel-query-processing-in-duckdb-85ecd1446176) | Interactive-chart figures not text-extractable → **UNVERIFIED exact ms**; magnitude corroborated by multiple secondary posts |
+| **DuckDB (scaling)** | 7-8× on 8 cores vs 1 thread | Q1 aggregation, 120 M rows in <500 ms | 8-core laptop | Columnar, multi-threaded | [duckdb-in-depth/endjin](https://endjin.com/blog/2025/04/duckdb-in-depth-how-it-works-what-makes-it-fast) | Secondary |
+| **Velox** | ~order-of-magnitude on CPU-bound TPC-H; 6-7× avg on Meta production | mixed OLAP | not stated in abstract | Columnar vectorized + adaptive | [Velox VLDB p3372](https://www.vldb.org/pvldb/vol15/p3372-pedreira.pdf); [fb eng blog](https://engineering.fb.com/2023/03/09/open-source/velox-open-source-execution-engine/) | Paper PDF body not extractable → **absolute per-core UNVERIFIED**; speedups verified from abstract/blog |
+| **ScyllaDB** ⭐ | 1 B rows/s cluster ⇒ **~428 k rows/s/core**; full-year cold **~417 k/core**; cached **~658 k/core** | aggregation scan (`count/sum/min/max`) over **narrow** temperature rows | ~83× n2.xlarge, 28 Xeon Gold 5120 @2.2 GHz/node, NVMe (≈2324 cores) | **Row/LSM SSTable k-way merge**, but **aggregation pushdown on-shard, no row transfer** | [scylladb.com 1B-rows blog](https://www.scylladb.com/2019/12/12/how-scylla-scaled-to-one-billion-rows-a-second/); [press release](https://www.scylladb.com/press-release/scylladb-smashes-performance-record/) | Vendor; node count 83 per fetch (some coverage says 40) → per-core **~400-450 k** is the defensible band |
+| **ScyllaDB** | **~12,500 ops/s/core** | point reads/writes post-replication | shard-per-core (Seastar) | Row, point-op | [scylladb.com shard-per-core](https://www.scylladb.com/product/technology/shard-per-core-architecture/); [why-shard-per-core](https://www.scylladb.com/2024/10/21/why-scylladbs-shard-per-core-architecture-matters/) | Vendor rule-of-thumb |
+| **Cassandra 5.0** | No clean per-core scan number; trie memtable = "30 % more data / same memory", faster reads | qualitative | — | Row/LSM, trie-indexed BTI | [Trie Memtables VLDB p3359](https://www.vldb.org/pvldb/vol15/p3359-lambov.pdf); [C* 5.0 features blog](https://cassandra.apache.org/_/blog/Apache-Cassandra-5.0-Features-Trie-Memtables-and-Trie-Indexed-SSTables.html) | **No per-core rows/s figure found — UNVERIFIED** |
+| **DataFusion** | **~950 k rows/s single core** (SSD-bound, historical floor) | scan, TPC-H era | single core, SSD-limited | Columnar (Arrow), but IO-bound | [andygrove.io 0.2.1 bench (2018)](https://andygrove.io/2018/03/datafusion-0.2.1-benchmark/) | Old (2018); treat as **floor**, not ceiling |
+| **DataFusion** | fastest single-node ClickBench parquet; 14 GB / 100 M-ish rows | 43 aggregation/filter queries | c6a.4xlarge (16 core) | Columnar vectorized | [datafusion.apache.org fastest-parquet-clickbench](https://datafusion.apache.org/blog/2024/11/18/datafusion-fastest-single-node-parquet-clickbench/) | Blog gives only relative "1.x" → **absolute rate UNVERIFIED** |
+| **Arrow Flight** | **DoGet up to 6000 MB/s** multi-stream; **~2000 MB/s @16 streams remote (~125 MB/s/stream)**; **localhost single stream 2-3 GB/s (C++, no TLS)**; up to 10 GB/s localhost | Arrow RecordBatch transfer | Mellanox ConnectX-3/IB nodes; uses "up to half of system cores" | Columnar wire | [arxiv 2204.03032](https://arxiv.org/abs/2204.03032); [ACM 10.1145/3527199.3527264](https://dl.acm.org/doi/fullHtml/10.1145/3527199.3527264); [introducing-arrow-flight](https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/) | Paper; per-stream single-thread ceiling inferred, not stated → **per-stream UNVERIFIED beyond 2-3 GB/s localhost C++** |
+| **Trino JDBC ingest** | **single JDBC conn ~32 MB/s / ~0.73 M rows/s**; 7× parallel ⇒ **~224 MB/s**; columnar HDFS scan ~10,300 MB/s | row-by-row JDBC deserialization into Pages | 4-node Trino, Oracle single-box source | **Row ingest = the bottleneck**; columnar = not | [starburst benchmarking-jdbc-bottleneck](https://www.starburst.io/blog/benchmarking-the-jdbc-bottleneck-in-trino/); [dangers-of-jdbc-bottleneck](https://www.starburst.io/blog/jdbc-trino-starburst/) | Vendor lab; figures explicit |
+
+**Row-width warning (load-bearing):** the ClickHouse/DuckDB "10²-10³ M rows/s/core" figures touch
+**4-8 bytes/row** (one column). CQLite Phase-0 rows are ~2 text columns, **~50 B packed on disk / ~300 B
+on the Arrow wire** (150 MB/s ÷ 500 k rows/s). Scylla's temperature rows are narrow too but it never
+serializes them out. A rows/s number without a width is not comparable; convert to MB/s/core before
+trusting any cross-system multiplier.
+
+---
+
+## 2. Technique-transfer matrix (does it survive CQLite's constraints?)
+
+Constraints CQLite must honor: Rust library; **k-way LSM merge with tombstone reconciliation** (read-time
+reconciliation, not just physical dump); **parity oracles** (byte + query-semantic) that pin exact row
+sets/order at a fixed `now`; **512 Mi memory ceiling**; embedded inside a Flight server, not a
+thread-per-core process it owns end-to-end.
+
+| Technique | Behind whose numbers | Transfers to CQLite? | Phase-0 stage it attacks | Constraint / caveat |
+|---|---|---|---|---|
+| **Run-length / no-overlap fast-path merge** (emit a whole SSTable run untouched when its key range doesn't overlap other inputs) | ScyllaDB LSM merge | **YES — highest structural fit** (same problem shape) | 4a merge compute (32.5 %) **and** 4b channel (49.9 %) | Legal only where key ranges are provably disjoint over the interval; tombstone/overlap regions still need per-row reconcile. Parity-safe: output set unchanged, just fewer heap/channel ops. |
+| **Inline / single-thread merge for the few-SSTable case** (bypass thread-per-input + per-row `sync_channel`) | (Phase-0's own #1 lever; classic single-threaded LSM iterators) | **YES** | 4b channel coordination (**49.9 %**, the biggest single line) | The per-row cross-thread `send` IS the 50 %. For 4 SSTables the parallel-decode design loses. Parity-safe. |
+| **Vectorized / batch-at-a-time through every operator** (1k+ row batches, not per-row) | ClickHouse, DuckDB, Velox | **PARTIAL** | 4b (batch the channel handoff), 4a (batch heap refill), 3 (batch materialize) | The merge is inherently row-ordered at cluster boundaries, but you can batch **within** a run and batch the channel message (N rows/send instead of 1). CQLite already batches only at the Arrow-encode tail (8192); the merge core is per-row. |
+| **Arena / bump allocation** (per-batch arena for MergeEntry/RowKey/QueryRow) | Velox memory pools; ClickHouse arenas | **YES** | malloc (**17.6 %**) + materialization (4.5 %) | Rust `bumpalo`/reset-per-batch. Pure allocation strategy → parity-invariant. Watch the 512 Mi ceiling: bound arena to batch size. |
+| **Late materialization** (defer PK `Vec` copy + full row assembly until survivors are chosen) | Velox, DuckDB, ClickHouse | **PARTIAL** | 3 materialization (4.5 %) + malloc + SipHash key-hash (4.5 %) | Reconciliation needs keys early but not full values; defer value assembly + `RowKey::new(pk.to_vec())` copies past the merge. Parity-safe if survivor selection is unchanged. |
+| **Dictionary-preserving decode** (keep low-cardinality columns dict-encoded through to Arrow dictionary arrays) | ClickHouse, DuckDB, Velox, Arrow | **WEAK for this shape** | 2 decode (9.7 %), 5 Arrow encode (1.0 %) | Helps low-cardinality columns; the narrow text-PK `keyvalue` shape has high-cardinality keys → little benefit. Data-dependent; not a general lever. |
+| **Thread-per-core / sharded (Seastar model)** | ScyllaDB, Seastar | **PARTIAL — big architecture change** | 4b (50 %) by removing cross-thread handoff entirely | CQLite is a lib inside a Flight/tokio server; it can't own the whole box the way Seastar does. A shard-per-core merge with inline (no channel) reconciliation captures most of the 4b win without a full runtime rewrite. High effort. |
+| **SIMD decode** (vectorized vint/cell decode) | ClickHouse, Velox, DataFusion | **WEAK** | 2 decode (9.7 %) | vint/cell decode is branchy and serial; SIMD wins on bulk fixed-width columns, not variable-length Cassandra cells. Parse isn't the bottleneck anyway. Low priority. |
+
+---
+
+## 3. The sanity envelope (what Phase 2 can defend)
+
+### 3a. Credible per-core ceiling for **row-pipeline** CQLite-shaped work (LSM merge + materialize + Arrow encode + ship)
+
+**~150-600 k rows/s/core for narrow rows, with the current ~500 k single-stream number sitting mid-band —
+but only the low end is safe under contention today.**
+
+- The only structural analog, **ScyllaDB, sustains ~400-450 k rows/s/core** on an LSM SSTable k-way merge
+  of narrow rows — **and that is with aggregation pushdown (no row materialization or transfer)**. Row
+  export is strictly heavier than Scylla's on-shard reduce, so Scylla's per-core rate is a **generous
+  upper bound**, not a floor, for a row-export pipeline.
+- CQLite's own Phase-0 single-stream ~500 k rows/s/core looks competitive with Scylla — **but ~68 % of
+  that core's budget is waste** (49.9 % channel coordination + ~18 % malloc). The *useful* compute
+  (decode + reconcile + materialize + encode ≈ 32 %) is doing ~500 k rows/s on a third of a core, which
+  is why the levers in §2 have real headroom. Removing the per-row channel and the per-row allocations is
+  what converts single-stream throughput into **linear multi-core scaling**.
+
+### 3b. Does prior art support **600 k rows/s/pod on 4 vCPU (~150 k rows/s/core) on a ROW pipeline?**
+
+**YES — credible, and conservative — but it is a post-fix target, not a current-architecture given.**
+
+- 150 k rows/s/core is **~⅓ of Scylla's per-core LSM rate** and **~⅓ of CQLite's own measured single-stream
+  rate**. There is nothing exotic about it *per core*.
+- The risk is **not** the per-core ceiling; it is **scaling to 4 concurrent cores**. Today's thread-per-input
+  design already spends ~50 % of a single stream's CPU parking on a cap-256 channel; four concurrent scans
+  contend harder, so naive 4× fan-out will **not** reach 600 k without first landing the §2 levers
+  (no-overlap fast-path, inline/batched merge, arena alloc). Claim it as an **engineering target gated on
+  the merge-coordination fix**, not a property of the shipped code.
+
+### 3c. Does prior art support **≥250-350 MB/s/worker ingest into a JVM (Trino page building)?**
+
+**YES via a columnar/Arrow path; NO via row-oriented JDBC ingest — and this is a load-bearing distinction.**
+
+- **JDBC row ingest ceiling is ~32 MB/s / ~0.73 M rows/s per connection** (Starburst lab). Parallel physical
+  partitions reach only **~224 MB/s** and plateau (source-side limited). A per-worker 250-350 MB/s target
+  **cannot** be hit through a row-by-row JDBC deserialize-into-Pages path — that is the documented Trino
+  bottleneck the whole exercise exists to escape.
+- The **columnar/Arrow path clears it with room to spare**: Trino columnar (HDFS) scans hit ~10,000 MB/s;
+  **Arrow Flight single-stream localhost is 2-3 GB/s (C++, no TLS)** and multi-stream up to 6 GB/s. 250-350
+  MB/s/worker is **~10-15 %** of the single-stream Arrow ceiling — comfortably credible **provided ingest is
+  Arrow batches, not JDBC rows**, and provided the Flight producer can actually *fill* the wire (Phase-0
+  shows CQLite's producer is merge/alloc-bound long before it saturates a 2-3 GB/s wire, so the worker-side
+  JVM page building is **not** the binding constraint — the CQLite producer is).
+
+### 3d. Columnar CQLite-shaped work
+
+Prior art supports **millions of rows/s/core** — **but only for pushdown aggregation / single-column scans**,
+never for full-row materialization and transfer. A CQLite Flight `do_get` that returns whole rows **cannot
+inherit those numbers**. Columnar-grade rates apply only to a hypothetical CQLite path that pushes
+aggregation/projection down and never materializes full rows (that path does not exist today).
+
+---
+
+## Final packet
+
+**Envelope (defensible bands):**
+- **Row-pipeline CQLite-shaped work (LSM merge + materialize + Arrow encode + ship), narrow rows:**
+  credible **150-450 k rows/s/core**; Scylla's ~400-450 k/core LSM rate is a generous *upper* bound (it
+  aggregates on-shard, never ships rows). CQLite's measured ~500 k single-stream is real but ~⅔ waste.
+- **600 k rows/s/pod on 4 vCPU (150 k rows/s/core):** credible and conservative **per core**; the binding
+  risk is 4-way concurrent scaling, which requires the merge-coordination fix first. A post-fix target.
+- **Columnar CQLite-shaped work:** millions of rows/s/core **only** with aggregation/projection pushdown
+  (no full-row export). Not applicable to today's row-returning `do_get`.
+- **Ingest MB/s/worker into the JVM:** **250-350 MB/s/worker is credible via Arrow batches** (Arrow Flight
+  single-stream localhost 2-3 GB/s; the CQLite producer, not the JVM page builder, is the real limiter).
+  **Not achievable via JDBC row ingest** (~32 MB/s/conn, ~224 MB/s parallel plateau).
+
+**5 most transferable techniques (ranked by impact × fit):**
+1. **Inline / batched merge that eliminates the per-row cross-thread `sync_channel`** — attacks stage 4b
+   (**49.9 %** of single-stream CPU), the biggest single line. Parity-safe. (Phase-0's own #1 lever.)
+2. **Run-length / no-overlap fast-path merge (Scylla model)** — emit disjoint SSTable runs without per-row
+   heap/reconcile ops; attacks 4a (32.5 %) + 4b. Highest *structural* fit — same LSM-merge problem shape.
+3. **Vectorized batch-at-a-time through the merge core** (N rows/channel-message, batched heap refill) —
+   attacks 4b/4a/3; CQLite currently batches only at the Arrow tail, not the merge.
+4. **Arena / bump allocation per batch** — attacks the **17.6 % malloc** + per-row `RowKey`/`QueryRow`
+   copies; parity-invariant; bound to batch size for the 512 Mi ceiling.
+5. **Late materialization + cheaper PK hashing** (defer `pk.to_vec()` copy + value assembly past survivor
+   selection; drop the default SipHash `HashMap` hasher) — attacks stage 3 (4.5 %) + SipHash (4.5 %) + malloc.
+
+**Red flags for common multiplier claims:**
+- **"Columnar engines do 100 M-1 B rows/s/core, so we can multiply by 10-100×."** Category error: those are
+  single-column SIMD *aggregation* numbers (4-8 B/row, no materialization, no transfer). CQLite ships every
+  cell. Do not import them into a row-export pipeline.
+- **"Scylla does 1 B rows/s, LSM is LSM."** Scylla's number is **aggregation pushdown across ~2324 cores
+  (~428 k/core) with zero row materialization or cross-node row transfer.** It is an *upper bound* for a
+  heavier row-export workload, not a matchable target.
+- **"600 k rows/s/pod is a given."** Credible *per core*, but gated on removing the per-row channel
+  coordination that today eats ~50 % of a single stream; naive 4× fan-out on the current design will not
+  reach it. Present as a post-fix target.
+- **"250-350 MB/s/worker ingest is fine."** True for **Arrow** ingest only. Over **JDBC row ingest it is
+  physically off the table** (~32 MB/s/conn). Any claim that doesn't name the transport is unfalsifiable.
+- **Row-width laundering:** comparing CQLite's narrow-row rows/s to a competitor's different row width (or
+  citing rows/s with no width). Always co-report MB/s/core.
+- **Local-to-field extrapolation:** never multiply Phase-0's warm + uncompressed + RF=1 + loopback
+  single-stream figure by pod count to predict a compressed, RF=3, through-Trino field number.
+
+**Verification flags:** DuckDB exact-ms (interactive charts, not text), Velox absolute per-core (paper body
+not extractable), DataFusion ClickBench absolute rate (blog gives only relative "1.x"), Cassandra per-core
+scan rate (no figure found), Arrow Flight per-stream single-thread ceiling beyond the 2-3 GB/s localhost C++
+point, and Scylla's exact node count (83 per the blog fetch vs 40 in some coverage) are all flagged
+UNVERIFIED / order-of-magnitude in §1. ClickHouse "2-10 GB/s/core" is a vendor-adjacent rule of thumb.

--- a/docs/research/phase2-verify-caching.md
+++ b/docs/research/phase2-verify-caching.md
@@ -1,0 +1,313 @@
+# Phase 2 — Adversarial verification of the caching packet (`phase1-4-caching.md`)
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Agent:** Phase-2 adversarial verifier ·
+**Method:** READ-ONLY — code inspection (`cqlite-core/src`, `cqlite-flight/src`,
+`trino-connector/src`), issue reads (`gh`), and cross-check against the sibling Phase-1 packets
+(`phase1-1`, `phase1-2`, `phase1-3`, `phase1-5`, `phase1-6`) and MEMORY field rounds. No builds, no
+writes, no GitHub writes.
+
+Target under attack: `docs/research/phase1-4-caching.md`. Anchor: `phase0-scan-cost-breakdown-2026-07.md`.
+
+---
+
+## 0. Verdict summary
+
+| # | Packet claim | Verdict | Severity ruling |
+|---|--------------|---------|-----------------|
+| 1 | **B4 idle-≤16 Mi "unmet by construction" (384 MiB of undrainable cache)** | **WRONG as stated — two independent errors** | S-D idle-drain is **P3 hardening**, NOT a P1 B4 gate. The real (peak) hazard is the 256 MiB chunk-cache default, a config retune. |
+| 2 | **#2561 (BTI chunk-straddle whole-file fallback) — "fix #2561 first, K-B/K-C partially broken"** | **STALE — the BTI bug is already fixed on `main`** (landed in #2059's PR #2554). | **NOT a 0.17 slot.** P3 traceability-close; BIG-path follow-up is a verify task, not a live landmine. |
+| 3 | **#2165 (wire scan decode through ChunkSource) — caching wants it wired, row-engine demoted it** | **Both right for different workloads** — no real conflict. | **Re-scope, don't close.** Keep for decode-plane maintainability; do NOT credit it a scan multiplier; the *cache* value is keyed/repeated-range only. |
+| 4 | **K-A/K-D decoded-partition cache — "biggest keyed lever, ~1.5–3×"; don't file standalone (reconcile with #2037)** | **Lever direction is sound; the hit-rate model is UNSUPPORTED by field data.** #2037 coupling is **half-right**. | Real A2 lever, but **gate it on a measured keyed access distribution first**. Decouple the *measurement* from #2037; keep the *build* reconciled. |
+| 5 | **Snapshot-reuse-window tuning is an owner freshness call** | **CONFIRMED correct.** | Lands on NEEDS-OWNER, not an autonomous filing. |
+
+---
+
+## 1. THE B4 IDLE-DRAIN CLAIM — the headline is wrong twice over
+
+The packet's gating claim (lines 30–37, 182–184):
+
+> "three shipped resident caches declare 256 MiB + 64 MiB + 64 MiB = 384 MiB … none drain at idle …
+> **The idle-≤16 Mi half of B4 is therefore not met by construction today**, and every new cache
+> worsens it."
+
+**This is wrong on two independent grounds. It should not gate any lever.**
+
+### Error 1 — B4 has no "idle" clause. "≤16 Mi" is the per-query working-set target.
+
+I checked the ratified B4 definition against every place it is stated. **The caching packet is the
+only one of the eight Phase-1 documents that reads "≤16 Mi" as an idle-pod ceiling.** Every sibling
+reads it as a *per-query working-set* target:
+
+- `phase1-6-parallelism.md:258` — "**B4 = ≤3 s / ≤512Mi pod / ≤16Mi (per-query working set target)**."
+- `phase1-6-parallelism.md:276` — "a single stream already consumes ~15 MB, essentially the whole
+  ≤16Mi **per-query** target on its own — the ≤16Mi number is only satisfiable at concurrency 1 or
+  with a smaller batch_size."
+- `phase1-5-transport-ingest.md:263,352` — "the `≤512 Mi`/`≤16 Mi` B4 envelope"; "worker heap ≤512 Mi
+  / ≤16 Mi **[per-query]**."
+- `phase1-3-linux-io.md:24,118` — the *third* B4 number the IO agent tracks is "**cold-start latency
+  B4 ≤ 3 s**", not an idle byte count.
+- MEMORY (ratified 2026-07-15): "**B4 ≤3s/≤512Mi/≤16Mi**" — three numbers: latency, pod peak,
+  per-query working set. No "idle".
+
+A full-tree grep for an idle memory target (`idle` + `mem/16/rss/drain/pod`, outside `phase1-4`)
+returns **zero** hits in `docs/architecture` or `docs/reports`. The only other "idle" usages are the
+#2037 research ("no background CPU when idle" — a *CPU* property) and the telemetry schema. **There is
+no idle-memory clause in B4 to violate.** The packet reified a target that does not exist and then
+declared it "unmet by construction."
+
+The three shipped caches (256 + 64 + 64) are **shared amortized infrastructure counted against the
+≤512 Mi PEAK**, not against the ≤16 Mi per-query number. The per-query number governs Arrow-egress
+buffers per stream (`batch_size × channel-depth`), which is exactly what `phase1-6` sizes admission
+against — nothing to do with resident caches.
+
+### Error 2 — 384 MiB is a DECLARED CAP, not resident memory. Lazy caches sit near-zero.
+
+Even under a (nonexistent) idle-memory clause, the "holds 384 MiB indefinitely" premise is false. All
+three caches are **lazily populated, byte-bounded LRUs** — resident bytes = *touched* working set,
+capped at the budget, never the budget itself:
+
+- **Chunk cache** (`chunk_source.rs:80-149`): `chunk()` = `cache.get` → on miss decompress →
+  `cache.insert`. Only chunks actually read are ever inserted.
+- **Critically, the scan path inserts NOTHING.** Per #2165 itself, `iterate_all_partitions` /
+  `sequential_scan` decode **bypasses `ChunkSource` entirely** (they still use the legacy `self.file`
+  + `compression_reader` model). So the packet's own worked example — "a pod that serves **one scan**
+  and goes quiet" — populates **~0 bytes** of the 256 MiB chunk cache, because a scan never touches
+  B1. The scenario the packet uses to motivate the crisis is the one scenario where the chunk cache
+  stays empty.
+- **Global key cache** (64 MiB): populated only by *point-read* index resolution; a scan-only pod
+  holds ~0 here too.
+- **Warm registry** (64 MiB): holds `Arc<SSTableReader>` = open FDs + parsed Summary/lazy-BIG-index —
+  tens of KB to low-MB per generation, a handful of generations. Nowhere near 64 MiB resident for the
+  R12 2-generation corpus.
+
+So a genuinely idle pod after a scan holds a few MB (warm readers), not 384 MiB. The "no drain" code
+observation is **factually true** (I confirmed: no TTL/decay/idle-sweep on `DecompressedChunkCache`
+or `GlobalKeyOffsetCache`; the `cache_ttl` hits in the tree are unrelated legacy caches —
+`cql/config.rs`, `schema_discovery.rs`, `sstable_data_manager.rs`), but "no drain" ≠ "384 MiB
+resident at idle."
+
+### Field evidence — the pod PEAK is met in practice, and idle was never measured because it isn't a target
+
+- **R11b field (MEMORY, `#2367`): "0 OOMKills @80thr."** Pods run at the 512 Mi limit and did not
+  OOMKill under 80-thread overload → the ≤512 Mi PEAK is satisfied in the field *with all three
+  caches live*. This is the constraint that actually exists, and it passes.
+- `round-validation-metrics.md` B7/B8 measure **cancellation reclaim** and **CPU/memory trajectory
+  under load** — not idle. R7's "leaked to 5.5 GB" was a genuine *leak bug* (since fixed), unrelated
+  to cache retention policy. There is no idle-memory measurement in any round because **idle memory is
+  not a round criterion.**
+- The `cqlite.proc.rss_bytes` gauge (`flight-metrics-reference.md:52`) exists precisely to watch peak
+  ("a level nearing the memory limit is the OOMKill risk") — a *peak* watch, not an idle watch.
+
+### The one real, correctly-stated hazard hiding inside the wrong claim
+
+The packet is right about **one** thing, but it is a **peak** problem, not an idle one: the library
+default `block_cache.max_size = max_memory / 4 = 256 MiB` (`config.rs:299`, from a 1 GB default
+`max_memory`). Under B4's real binding constraint — `phase1-6`'s "~20 concurrent streams ×
+15–20 MB/stream ≈ 300–680 MB" — a **filled** 256 MiB chunk cache **plus** concurrent stream
+working sets can breach ≤512 Mi. That is the K-C "retune the 256 MiB default down for the 512 Mi
+Flight/Trino deployment" recommendation, and it is **legitimate** — but note (a) it only bites when the
+chunk cache is actually *full* (sustained point-read load, not idle, and never on the scan path that
+doesn't populate it), and (b) I could not find an explicit `block_cache` override in `cqlite-flight/src`,
+so the deployment likely does inherit the 256 MiB library default — worth confirming before the retune.
+
+### Severity ruling: S-D idle-drain is **P3 hardening**, not a P1 B4 gate
+
+- The packet's "S-D is not optional — it is the B4 gate" (line 134, 170–171, 183–184) is **downgraded
+  to P3**. There is no idle clause to gate, the caches don't hold 384 MiB idle, and the field meets
+  the real (peak) ceiling today. An idle-drain sweeper is *preventive hardening* (bound worst-case
+  resident bytes on a long-lived multi-tenant pod, reduce FD retention per #2013) — nice to have, and
+  it must stay off the hot path (#2316), but it **unblocks nothing** and gates no other lever.
+- The **peak retune (K-C: smaller `block_cache.max_size` for the pod)** is the item with real B4
+  standing, and it is a **config change, P2 at most**, not new code.
+- **Correction for the packet:** strike "idle-≤16 Mi unmet by construction" and "S-D is the B4 gate."
+  Replace with: "The 256 MiB chunk-cache default is oversized for a 512 Mi pod under concurrency
+  (peak, not idle); retune it. Idle-drain is optional P3 hardening."
+
+---
+
+## 2. #2561 — the bug is REAL but already FIXED on `main`; not a 0.17 slot
+
+**Is it real?** Yes. The root cause is genuine: the BTI point-read decode of a partition straddling a
+chunk boundary trusted "emit closure fired = complete partition," emitted a garbage entry off the
+truncated tail, returned `found=None`, and fell through to a whole-file `scan_for_key` — violating the
+#1572 "present-key `get()` never sequential-scans" invariant. It is a correctness-adjacent **perf**
+hole (wrong path, but the offset was correct; it degraded a point read to a full scan on ~7 straddling
+partitions).
+
+**Is it open?** The issue is OPEN, but the **fix already landed on `main`.** Per the issue body and
+confirmed in code: commit `0ebb43381` merged via PR #2554 (#2059). `bti_point.rs:186` now documents
+and enforces the `emitted_our_key` gate ("parse returns Ok AND the emit closure fired for the QUERIED
+key"), and the regression test `present_key_get_does_not_sequential_scan` was strengthened to check
+every key (0/80 fail post-fix, was deterministic-fail pre-fix). **The BTI path — K-C/K-B's cached
+point-read path — is not broken on `main`.**
+
+**The only open remainder** is the issue's own follow-up: "confirm the BIG-format equivalent
+(`big_point.rs`) doesn't have the same closure-fired-trusted-as-complete pattern." I inspected
+`big_point.rs`: it does **not** share the pattern. The BIG point path reasons about **block-map
+completeness** and falls to `scan_for_key` only for a genuinely-ambiguous partial map (`big_point.rs:
+46,103-171`) — a *bounded, by-design, #1572-sanctioned* fallback ("rare and acceptable"
+false-positive with `SCAN_FOR_KEY_CALLS` observable), not a truncated-tail decode bug. So the BIG
+follow-up looks like a **no-op verify**, not a live gap.
+
+**Disposition ruling:**
+- **NOT worth a 0.17 correctness/perf slot** — the landmine (BTI present-key full-scan) is already
+  disarmed on `main`.
+- Re-scope #2561 to a **P3 traceability-close**: add a one-shot BIG-path assertion test (present-key
+  `get()` across a straddling BIG partition asserts `SCAN_FOR_KEY_CALLS` delta == 0 for a truly-present
+  key) to nail down the follow-up, then close. This can ride the #2565 nit batch, not a standalone slot.
+- **Correction for the packet:** "fix #2561 first, K-B/K-C are partially broken on straddling
+  partitions" is **stale** — strike it. The caches are correct on `main`; only a verify test remains.
+
+---
+
+## 3. #2165 — both packets are right; it is a maintainability item, not a lever either way
+
+The apparent conflict: `phase1-1` (row-engine) demotes #2165 — "Stage 2 is only 9.7% *and* this is
+decode-plane *consolidation*, not an optimization; expected perf-neutral; worthless as a throughput
+lever (keep only for maintainability)." `phase1-4` (caching) wants it wired — "S-A: wire B1 into the
+sequential-scan path … ~1.3–1.5× on repeated-range scans."
+
+**There is no real contradiction — they are measuring different things:**
+
+- `phase1-1` is correct that **routing decode through ChunkSource buys ~0 as a decode/parse speedup**
+  (Stage 2 is 9.7%, and consolidation doesn't make decode faster).
+- `phase1-4` is correct that the **side effect** of routing through ChunkSource is that the scan path
+  gains **access to the B1 chunk cache**, which today it entirely bypasses — and *that* pays back
+  decompress+IO **only when the same token range is re-scanned within a freshness window** (repeated
+  dashboards, multi-split overlap), which is a real field pattern through Trino. It is **worthless for
+  a one-off scan** (hit rate ≈ 0) and pays only on repeated ranges — exactly what `phase1-4`'s own
+  table says (line 126: "1.0× one-off; ~1.3–1.5× on repeated-range scans").
+
+So: **#2165 as a decode-speed lever = worthless (phase1-1 right). #2165 as a cache-enablement for
+repeated-range scans = modest field-only win (phase1-4 right).** Both correct; the packets just
+attach it to different mechanisms.
+
+**Ruling on #2165's 0.17 disposition — re-scope, do NOT close:**
+- **Keep it** — it has independent standing as **decode-plane consolidation** (its stated acceptance:
+  `chunk_decode_single_plane.rs` excludes only non-query paths; today two query-reachable sites still
+  use the legacy IO model). That maintainability value is real and outlives this program.
+- **Do NOT credit it a scan throughput multiplier.** In the 0.17 program it is neither a per-stream nor
+  a utilization lever for a one-off scan.
+- **If wired, the payoff is a keyed/repeated-range cache win, and it MUST ship with scan-resistant
+  admission (Lever K-G)** or a full scan will evict the keyed hot set from B1 — turning a keyed win
+  into a keyed regression. Wire-for-consolidation is safe; wire-and-populate-B1-from-scans is only safe
+  behind scan-resistance.
+- Net: **keep as-is (maintainability), P3; not a throughput lever; its cache value is contingent on
+  K-G.** The two packets should cross-reference rather than appear to disagree.
+
+---
+
+## 4. Decoded-partition cache (K-A/K-D) — right direction, unsupported hit-rate model, half-right #2037 coupling
+
+**The lever direction is sound.** A repeated point read today re-parses + re-materializes the
+partition body even when its chunk is resident in B1 (Phase-0 stages 2+3 ≈ 14% CPU, plus the alloc +
+SipHash they drive). A decoded cache collapses a hot-set point read to a clone. This is the one
+genuinely *new* keyed lever, and the packet is right that it is the biggest keyed gap.
+
+**But the A2 hit-rate model is asserted, not measured — this is the weak point.** The packet's
+`~1.5–3× on the hot keyed set` rests entirely on "the field's dashboards hit a small partition subset
+repeatedly (the classic keyed workload)" (line 140). I searched for any field evidence of the keyed
+**access distribution** and found **none**:
+
+- There is **no Zipf/skew measurement** of the field keyed workload anywhere in `docs/`. "1.93 M
+  partitions/node" is the *corpus size*, not an access distribution.
+- The only field keyed loadtest on record (`round-validation-metrics.md` C9) is **~0.9 qps aggregate,
+  ~30 rows/s, warm point-read + LIMIT 5/100** — three orders of magnitude below the **A2 ≥1,000
+  qps/pod** target the cache is being justified against, and with no reported hot-set concentration.
+- The cache-effectiveness gauges exist (`cqlite.cache.key.*`, `cqlite.warm.cache.*`) but I found no
+  captured field values establishing a hot-set hit ratio.
+
+**So the working-set question the attack asks — "does a 64–128 MiB decoded cache hold enough to
+matter?" — cannot be answered from current data.** With decoded rows at ~3.5× on-disk size (Phase-0
+wire ratio), a 64 MiB decoded budget holds ~18 MiB-on-disk-equivalent of hot partitions. Whether that
+covers the field hot set is **entirely dependent on a skew we have not measured.** If the keyed access
+is near-uniform over 1.93 M partitions (no evidence either way), the hit rate is ~0 and the cache is
+dead weight under B4 peak. If it is strongly Zipf (plausible for dashboards, but *unproven*), 64 MiB
+could carry a high hit ratio. **The multiplier is real IF the skew is real, and we don't know the skew.**
+
+**Invalidation vs the 3 s reuse window — this part actually works.** K-D's snapshot-scoped design is
+correct-by-construction: a Cassandra snapshot is an immutable point-in-time hardlink set, so a bucket
+keyed by generation identity (the #2059 inode-stable identity, `#2345/#2383`) is valid until the
+generation set changes; "snapshot rolled → drop the bucket" is a clean invalidation and gives a
+natural drain. The 3 s connector reuse window (`DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS = 3_000`,
+confirmed in `CqliteFlightConfig.java:84`) bounds staleness; within a window the generation identity
+is stable, so decoded entries stay valid. Invalidation is **not** the risk here — the **hit rate** is.
+
+**The #2037 coupling is half-right.** The packet says "reconcile with #2037 WS6 (per-generation Arrow
+cache) or it triples surface; do not file standalone" (lines 145, 174–176). Assessment:
+- **Right** that the *build artifact* overlaps: #2037's disposable per-generation Arrow segment cache
+  ("columnar per-generation Arrow segments exist only as a cache, invalidated exactly at generation
+  death") is structurally the same idea as K-A/K-D at a different serialization (Arrow vs decoded
+  rows). Building both independently *would* triple surface. The `issue-2037-arrow-olap-research.md`
+  postures (S3/S4A disposable-per-generation cache) are literally this mechanism.
+- **Wrong to let it hostage the A2 lever indefinitely.** #2037 is an **owner-gated exploration epic**
+  (P2, children Backlog by design, no schedule). Coupling K-A's *delivery* to #2037's *promotion*
+  means a real, cheap-to-prototype A2 lever waits on a large architectural decision that may never
+  land. **Decouple the measurement from the build:**
+  1. **File the cheap, decoupled precursor now (P2, 0.17-eligible, standalone):** *instrument the
+     field keyed workload's partition access distribution* (a hot-set-concentration probe over the
+     existing `cqlite.read.partition_lookup.*` counters, or a one-shot key-frequency capture during a
+     field round). This is a few counters, no #2037 dependency, and it is the **gate** that decides
+     whether K-A is worth anything. It answers the unmeasured-skew question the whole lever rests on.
+  2. **Keep the decoded/Arrow *cache implementation* reconciled with #2037 WS6** — do not build two
+     per-generation decoded caches. When the skew data justifies it, build it once, as the shared
+     substrate #2037 also consumes.
+- Net **decoded-cache verdict:** sound lever, **do not build blind.** Gate on a measured keyed access
+  distribution (standalone P2 probe, decoupled from #2037). Keep the cache *implementation* reconciled
+  with #2037 so it isn't built twice. Do not let the owner-gated exploration indefinitely hostage the
+  measurement.
+
+---
+
+## 5. Snapshot-reuse-window tuning — CONFIRMED an owner freshness call → NEEDS-OWNER
+
+The packet routes S-B/K-F (lengthen the 3 s snapshot-reuse window) as "freshness contract — data up to
+window-old; owner call (mirrors #2305 flush-on-snapshot decision)." **Confirmed correct:**
+
+- The window (`DEFAULT_SNAPSHOT_REUSE_WINDOW_MILLIS = 3_000`, `CqliteFlightConfig.java:84`) directly
+  sets **maximum data staleness** — lengthening it trades freshness for fewer snapshot-create
+  fan-outs and higher warm/B1/key hit rates. That is a **product/data-semantics tradeoff**, not an
+  engineering optimization.
+- It mirrors the standing **#2305 owner decision** (flush-on-snapshot semantics, "snapshot-mode
+  semantics unchanged … about parse-cost, not read semantics") — the freshness contract is
+  explicitly owner-owned per MEMORY.
+- The knob **already exists** (`cqlite.snapshot-reuse-window-ms`), so this is a *default-value* /
+  *recommended-setting* decision, not code.
+
+→ **Lands on NEEDS-OWNER. Not an autonomous filing.** An agent must not change the default staleness
+window; it surfaces the tradeoff (cheapest keyed lift in the program vs freshness cost) and lets the
+owner set the number.
+
+---
+
+## 6. NEEDS-OWNER list (product / freshness / scope decisions this verification surfaces)
+
+1. **Snapshot-reuse-window default** (§5) — freshness vs hit-rate/fan-out tradeoff. The knob exists
+   (`cqlite.snapshot-reuse-window-ms`, default 3 s); the *value* is a data-staleness product call.
+   Mirrors #2305. Cheapest keyed lever in the program, but owner-gated.
+2. **Decoded-cache (K-A) vs #2037 sequencing** (§4) — the *measurement precursor* (keyed
+   access-distribution probe) can proceed standalone P2, but the **cache build** overlaps the
+   owner-gated #2037 ArrowMemtable WS6 per-generation cache. Owner decides whether K-A ships as its own
+   thing (reconciled implementation) or waits for #2037 promotion. Recommendation: unblock the
+   measurement now; keep the build reconciled.
+3. **B4 "≤16 Mi" definition, on record** (§1) — worth an owner one-liner confirming the ratified
+   reading is **per-query working set**, not idle-pod memory, so no future agent re-derives the
+   phantom idle gate. (Every sibling packet already reads it this way; this just pins it.)
+
+## 7. Corrections the caching packet (`phase1-4`) should absorb
+
+- **Strike** "idle-≤16 Mi unmet by construction" and "S-D is the B4 gate." B4 has no idle clause;
+  384 MiB is a cap not a resident figure; the field meets the ≤512 Mi peak (R11b 0 OOMKills @80thr).
+  **Downgrade S-D to P3 preventive hardening.** Keep the **peak retune (K-C, smaller
+  `block_cache.max_size`)** as the item with real (peak) B4 standing — a config change, P2.
+- **Strike** "fix #2561 first, K-B/K-C partially broken." The BTI bug is fixed on `main` (PR #2554);
+  only a BIG-path verify test remains. #2561 → P3 traceability-close, ride the #2565 nit batch.
+- **Reconcile #2165 wording with `phase1-1`:** it is a maintainability/consolidation item (P3), not a
+  scan throughput lever; its cache value is keyed/repeated-range only and contingent on K-G
+  scan-resistance. No disagreement between the packets once framed this way.
+- **Gate K-A on a measured keyed access distribution** before claiming its ~1.5–3× — the hot-set
+  assumption is currently unmeasured (field keyed loadtest on record is ~0.9 qps with no captured
+  skew). File the access-distribution probe standalone; decouple it from #2037.
+
+**File path:** `/Users/patrickmcfadin/local_projects/cqlite/docs/research/phase2-verify-caching.md`
+(uncommitted per instructions).

--- a/docs/research/phase2-verify-field-gap.md
+++ b/docs/research/phase2-verify-field-gap.md
@@ -1,0 +1,253 @@
+# Phase 2 — Adversarial reconciliation of the field-gap decomposition
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Author:** Phase-2 adversarial reconciler
+**Adjudicates:** `phase1-3-linux-io.md` (IO/decompress) vs `phase1-5-transport-ingest.md` (transport/ingest),
+using `phase0-scan-cost-breakdown-2026-07.md` (server CPU), `phase1-6-parallelism.md` (concurrency
+math), `phase1-7-trino-question.md` (the server-direct pivot), and primary code evidence.
+
+This document exists to settle **one contradiction** and hand the program a single canonical gap
+table plus the one field measurement that must come first in 0.17.
+
+---
+
+## 0. The contradiction, stated precisely
+
+- **P1.5 §1 (transport):** attributes **30–45 % of the ~47× local-vs-field gap** to a single
+  **"cold-IO + LZ4 decompression"** bucket, graded **LOW**, and separately **30–50 %** to
+  "distribution" and **15–30 %** to "transport + connector ingest".
+- **P1.3 (IO):** by arithmetic, **LZ4 decode ≈ 0.1–1 % of CPU** and **cold NVMe bandwidth has ~8×
+  headroom** (needs 10–120 MB/s against ≥ 1 GB/s), so **"cold IO never binds"** in the 100 k–600 k
+  rows/s envelope.
+
+Both cannot hold at that magnitude. A 30–45 % bucket built from two sub-terms that a sound
+arithmetic says are ~1 % (decompress-CPU) and non-binding (cold bandwidth) is over-sized **as
+labeled**. The reconciliation below shows the honest resolution is **not** "one doc is simply right"
+— it is that **P1.5 mislabeled and over-sized the bucket, P1.3 is arithmetically right but let a real
+sub-term fall off its headline, and BOTH docs over-weighted the Trino/connector axis** because
+neither fully used the one field number that reframes everything (P1.7 §0).
+
+---
+
+## 1. The pivot both P1.3 and P1.5 under-used (primary evidence)
+
+**P1.7 §0/§1 [FIELD]:** field **server-direct** full-ring scan (R11b, #2367) ≈ **29 k rows/s/ring**;
+field **through-Trino** full-ring scan (B3, R12) = 1.94 M rows / 61.1 s / 3 pods ≈ **31.8 k rows/s
+aggregate** (~10.6 k/pod). **These two aggregates are equal within noise (29 k ≈ 32 k).**
+
+> **Consequence that neither P1.3 nor P1.5 propagated:** *Trino, the connector page-build, the
+> HTTP/2 window, and split distribution add ≈ 0 to the aggregate.* If they cost a large multiple,
+> through-Trino would be far **below** server-direct; it is not — it is marginally **above**. So the
+> ~47× gap is almost entirely a **server-side, per-node scan-feed** deficit measured **with Trino
+> removed**. P1.5 built its whole decomposition on `500 k (1 local stream) ÷ 10.6 k (field pod)` and
+> then attributed 45–80 % of it (across the distribution + transport + connector buckets) to the
+> layer P1.7 proves is nearly free on aggregate.
+
+**Corollary — the per-stream "189×" is not a derivable quantity.** P1.5 §1b divides 10.6 k/pod by
+"~4 streams/pod" (from **admission 12/64**) to get ~2.6 k/stream, then 500 k ÷ 2.6 k = 189×. But
+**admission 12/64 is the R12 *B2 saturation-probe* snapshot, not the B3 scan** — B3's actual per-pod
+concurrency during the 61 s full scan is unrecorded. The 189× therefore rests on a concurrency number
+borrowed from a different workload. **We do not know the field per-stream rate.** This is itself a
+top-tier measurement gap (§5), and it means the honest decomposition must be anchored at the
+**aggregate/per-node** level (~500 k single warm M1 stream → ~10 k/node = **~47–50×/node**), where
+P1.7 gives solid ground, not at the per-stream level where the divisor is a guess.
+
+---
+
+## 2. Ground truth the field actually measures (why neither doc could settle this from telemetry)
+
+The task's key pointer: read the in-code phase metric. The closed phase set
+(`cqlite-flight/src/obs.rs:210–227`, `RPC_PHASES`) is exactly **five**:
+
+`validate` → `admission` → `resolve` → `merge_setup` → `stream`
+
+- `admission` = time parked on the `--max-concurrent-scans` semaphore (this is where **12/64** comes
+  from).
+- `resolve` = snapshot + reader open, Summary/Index load — **the only isolatable cold-open signal.**
+- **`stream` = the ENTIRE data plane**: cold body-chunk faults, LZ4 decompress, decode, k-way merge,
+  reconcile, per-row materialize, Arrow encode, **and** gRPC write, all folded into one histogram
+  (`cqlite.rpc.phase.duration`, `PhaseTimer`, `obs.rs:270–290`; the scan loop runs entirely inside
+  `PHASE_STREAM`, `streaming.rs:757`).
+
+> **The field's standing instrumentation is structurally blind to the P1.3↔P1.5 split.** Cold-IO
+> latency, decompress-CPU, channel park/wake, and reconcile are all inside `stream` and cannot be
+> separated by any dashboard query. The ONLY cold signal the field can currently see is an elevated
+> **`resolve`** phase (open/index faults) — not the in-`stream` body-scan faults where the disputed
+> cost would actually live. **Neither P1.3 nor P1.5 could have settled the contradiction from field
+> data because the field data cannot express it.** This is why the first 0.17 measurement must be an
+> *in-`stream` profile*, not another dashboard read (§5).
+
+**Two more primary confirmations that ground the mechanism:**
+
+- **Field path = the profiled path.** The field `do_get` drives
+  `produce_streaming_from_readers` (`streaming.rs:349`, `producer.rs`) — the **same** warm-reader
+  thread-per-input k-way merge Phase 0 profiled. So Phase 0's CPU shape (55 % kernel `sync_channel`
+  park/wake, 18 % alloc, 22 % own compute) is the field server's shape too, *plus* the field-only
+  terms.
+- **`Auto` → mmap, no `madvise`.** `resolve_disk_access_mode` (`reader/mod.rs:245–268`) returns
+  **Buffered** below `mmap_min_size`, **Direct** only above `memory_fraction × RAM` (16 GiB on a
+  32 GiB box) — so every field Data.db (≪ 16 GiB) resolves to **Mmap**. `mmap_advice_for`
+  (`reader/mod.rs:316`) returns **`None`** for the scan (deliberately, to avoid the #1143
+  `MADV_SEQUENTIAL` drop-behind tail). **Result: cold field scans fault synchronously on the reader
+  thread with only the kernel-default ~128 KiB readahead and no hint.** This is the exact mechanism
+  the cold-IO-latency bucket rides on — real, but latency-shaped, not bandwidth- or CPU-shaped.
+
+---
+
+## 3. Stress-testing each doc's magnitude claim
+
+### 3a. P1.3's "IO never binds" — does cold *latency* (not bandwidth) survive?
+
+P1.3's bandwidth arithmetic is **sound and survives** (100 k–600 k rows/s needs 10–120 MB/s vs
+≥ 1 GB/s NVMe; LZ4 decode ~0.2–1 % CPU). But its headline collapses two different questions. On the
+**synchronous-mmap-fault** path (§2), the binding question is not "is there enough bandwidth?" but
+"does the faulting reader thread stall?" Mechanism check:
+
+- **Sequential case (readahead effective):** Cassandra Data.db is stored in **partition-token order**;
+  a #2412/#2413 Summary-guided, token-bounded split walks a **contiguous** token range → **sequential
+  on disk**. A 64 KiB uncompressed chunk (~26 KiB compressed) covers ~800 narrow rows; a 128 KiB
+  readahead window covers ~2 chunks. A cold fault every ~1,600 rows at ~100 µs NVMe latency ≈
+  **0.06 µs/row** — negligible against the field's ~34 µs/row aggregate. **P1.3 wins here.**
+- **Defeated-readahead case:** the warm path spawns **one reader thread per input SSTable**
+  (`from_readers`). A real node carries **many** SSTables (not the local rig's 4) from ongoing
+  flush/compaction; N threads faulting N files **interleave the device LBA stream**, degrading each
+  toward random and stalling the 128 KiB window (P1.3 §2b flags this, then drops it). This is the
+  ONLY regime where cold-IO latency climbs toward a double-digit share — and it is **testable** and
+  **currently unmeasured**.
+
+**Verdict on P1.3:** right on bandwidth and decompress-CPU (grade HIGH); **overreaches** only in
+letting the cold-**latency**/readahead-starvation term — which it correctly identifies in §2b —
+fall out of its "IO never binds" headline. On a thread blocked in a synchronous page fault, latency
+*is* throughput for that stream.
+
+### 3b. P1.5's buckets — decomposing the mislabel
+
+- **"Cold-IO + decompression 30–45 % (LOW)":** the **decompression** half is ~1 % (P1.3, HIGH), and
+  the **bandwidth** half is non-binding (P1.3, HIGH). What remains is the cold-IO **latency** term of
+  §3a — real, but (i) latency-shaped, (ii) amortized over a 61 s sustained scan so cold-start is a
+  small fraction, and (iii) only large in the defeated-readahead regime. **Reconciled magnitude:
+  ~10–25 %, not 30–45 %**, grade LOW. P1.5's *instinct* ("likely the single biggest term, and
+  invisible on the warm rig") was directionally right; its *label* (bundling ~0 % decompress) and its
+  *ceiling* (45 %) were wrong.
+- **"Distribution 30–50 % (MED)":** capped hard by P1.7 — through-Trino aggregate ≈ server-direct
+  aggregate, so the connector/Trino distribution layer is **not** leaving a large multiple on the
+  table. And P1.6 §4 shows the server's own consumer **drain-saturates at `N_drain_sat` ≈ 4–8
+  streams**, at/below where admission already sits — so "run more streams" cannot be a big share of a
+  server-direct gap. **Reconciled: ~5–15 %.**
+- **"Transport + connector 15–30 % (MED)":** same P1.7 cap. Real for **point-read latency** (the
+  0.2–2 s Trino floor, P1.7 §0) but small for **scan throughput** on aggregate. **Reconciled:
+  ~7–18 % combined.**
+
+### 3c. Reconciling P1.5's "~4 do_gets" with P1.6
+
+P1.5 reads admission 12/64 → ~4 streams/pod as **under-fan-out** (idle parallelism). P1.6 §4 reads
+the **same regime** as **drain-saturation**: throughput is flat from 8 to 80 concurrent streams
+(195 → 190 qps); past ~8 streams you buy only latency and buffer depth. **These are the same fact seen
+from two sides:** the pod runs ~4–8 useful streams **because that is where the single-threaded
+coordinator + Arrow-encode + gRPC-write consumer saturates**, not because Trino forgot to schedule
+more. So the "distribution deficit" is mostly a **per-stream drain ceiling**, i.e. a **server**
+property (Phase 0's 55 % kernel tax + single-threaded merge), **not** a scheduling shortfall. This is
+the second reason to move weight OUT of P1.5's distribution/transport axis and INTO the server-side
+per-stream/per-core buckets.
+
+---
+
+## 4. The reconciled gap table (canonical)
+
+Shares are of the **~47–50× per-node** multiplicative gap (`~500 k single warm M1 stream → ~10 k
+rows/s/node`), stated as confidence-weighted shares of the log-magnitude summing to 100 %. Each row
+names the **falsifying measurement** that would settle it.
+
+| # | Bucket | Share | Grade | Mechanism / primary evidence | Falsifying measurement |
+|---|--------|------:|:-----:|------------------------------|------------------------|
+| 1 | **Hardware + core-contention** — i4i.xlarge vCPU (4 cores, all shared) vs M1 Pro P-core (1 of 10 busy, 9 idle absorbing park/wake); Phase 0's 55 % kernel `sync_channel` tax *contends* when streams stack on 4 cores (`C(N) < 1`, P1.6 §0) | **~25–35 %** | MED | Phase 0 §3a (kernel tax); P1.6 §4 saturation table (flat 8→80 streams); field path = profiled path (§2) | Warm server-direct scan **on the i4i pod** at concurrency 1 and at pod-native concurrency; compare to the 500 k M1 warm anchor → isolates hardware + `C(N)` |
+| 2 | **Field data-plane heaviness** — many SSTables (not 4) → more reader threads → worse Stage-4b channel tax; genuine tombstone/TTL/LWW **reconciliation overlap** → heavier Stage-4a | **~18–28 %** | MED | Phase 0 §5.5 caveat (owned by neither P1.3 nor P1.5); `from_readers` one thread/SSTable | Record **SSTable-count/node** + reconcile-overlap ratio; re-profile Stage-4a/4b share in-`stream` on field data |
+| 3 | **Cold-IO *latency*** — synchronous mmap faults on the reader thread, `Auto`→mmap, **no `madvise`**, 128 KiB readahead, multi-SSTable LBA interleave. **NOT bandwidth, NOT decompress-CPU.** (This is the *reclassified, halved* remnant of P1.5's 30–45 % bucket.) | **~10–22 %** | **LOW** | §2/§3a; `reader/mod.rs:245–268,316`; P1.3 §2b (names it, then drops it) | **Cold-vs-warm A/B of the same full-ring scan**; the cold−warm delta *is* this bucket. On-CPU vs off-CPU-in-fault split isolates fault-wait from `send` park/wake |
+| 4 | **Distribution / concurrency shortfall** — fewer effective streams than cores, per-stream serial pull, under-fan-out | **~6–14 %** | MED | P1.5 §1a; **capped by P1.7** (through-Trino ≈ server-direct) and P1.6 §4 (`N_drain_sat`≈4–8) | B3 per-pod concurrency actually observed during the 61 s scan (currently unrecorded — §5) |
+| 5 | **Transport — network + HTTP/2 flow-control window** (64 KiB default, unset in code) | **~5–10 %** | MED→LOW | P1.5 §5; **capped by P1.7** (aggregate parity) | Server-direct **over the real app-node network** vs loopback, same scan |
+| 6 | **Connector page-build** — `ArrowToTrino` row-at-a-time, 3.9 M `byte[]`/scan | **~3–8 %** | MED | P1.5 §2; **capped by P1.7** | through-Trino **minus** server-direct at equal concurrency (P1.7 says this delta is ~0) |
+| 7 | **LZ4 decompression CPU** | **~1–2 %** | **HIGH** | P1.3 §2c (~0.2–1 % @ 1.5 GB/s/core) | i4i cold-compressed decode bench (extends `decode_policy_bench.rs`) |
+
+Buckets **1 + 2 + 3 ≈ 55–75 %** — the server-side per-node terms — and **4 + 5 + 6 ≈ 15–30 %** — the
+Trino/connector/transport axis that P1.5 owned and over-weighted. **Decompress (7) is ~1 %.** The
+reallocation vs P1.5 is the whole story: weight moves *out* of "cold-IO+decompression" (30–45 % → 3
+reclassified to ~10–22 % + 7 at ~1 %) and *out* of distribution+transport+connector (45–80 % → 4+5+6
+at ~15–30 %), and *into* hardware+contention (1) and field data-plane heaviness (2), which neither
+transport-focused doc owned.
+
+---
+
+## 5. Who was wrong, and why
+
+- **P1.3 was substantially RIGHT.** Its bandwidth and decompress-CPU arithmetic (grade HIGH) survives
+  adversarial checking: cold NVMe bandwidth has ~8× headroom; LZ4 decode is ~1 % CPU. Its **only**
+  overreach is the headline "IO never binds," which quietly drops the cold-**latency**/readahead-
+  starvation term it itself raised in §2b — a term that, on a synchronous-mmap-fault reader thread
+  with no `madvise`, is throughput-limiting for the blocked stream. Fix: keep P1.3's numbers, promote
+  its own §2b latency caveat into a first-class (LOW-confidence) bucket (row 3).
+- **P1.5 was WRONG in two specific, asymmetric ways.** (1) It **bundled** a ~1 % term (decompress-CPU)
+  with a real-but-different, latency-shaped term (cold-IO fault serialization) into one oversized
+  30–45 % LOW bucket — a category error P1.3's arithmetic exposes; the two halves have opposite
+  magnitudes. (2) It **over-weighted its own owned axis** (distribution + transport + connector,
+  45–80 % combined) because it never reconciled against **P1.7's pivot** — through-Trino aggregate ≈
+  server-direct aggregate — which caps that entire axis, nor against **P1.6 §4** (drain-saturation),
+  which reframes "under-fan-out" as a server drain ceiling. P1.5's *instinct* that a large, warm-rig-
+  invisible data-plane term dominates was **right**; its label, magnitude, and layer were wrong.
+- **Root cause of the contradiction:** neither doc could falsify itself from field telemetry, because
+  the field's 5-phase metric **folds the entire data plane into `stream`** (§2). The disagreement was
+  never resolvable by argument — it needs the one measurement below.
+
+---
+
+## 6. The single highest-value first 0.17 field measurement
+
+**File it as a 0.17 issue (proposed):** *"Field cold-vs-warm server-direct full-ring scan profile on
+i4i — first real measurement of Stage-1 (IO+decompress) and Stage-6 (transport), and an in-`stream`
+decomposition."*
+
+**What it is:** replay **Phase 0's exact `samply`/`perf` methodology on the field i4i.xlarge pod**,
+server-direct (`flight-loadgen` → `cqlite-flight`, `--shape full`), **cold then warm**, capturing
+**both on-CPU and off-CPU (blocked) time**, and **recording SSTable-count/node** and the resolved
+`DiskAccessMode`.
+
+**Why it is THE measurement — it settles every disputed row at once:**
+
+1. **Cold − warm delta = bucket 3** (cold-IO latency) directly. Off-CPU-in-fault vs off-CPU-in-`send`
+   separates IO fault-wait from channel park/wake — the exact P1.3↔P1.5 split.
+2. **Warm i4i run vs the 500 k M1 warm anchor = bucket 1** (hardware + `C(N)` contention), the term
+   both docs under-weighted.
+3. **First-ever measurement of Stage 1 and Stage 6** — the two stages the local rig is *structurally*
+   blind to (Phase 0 §5) and the two the whole contradiction lives in.
+4. **Server-direct removes Trino/connector as confounders** — and if server-direct field ≈ 29 k while
+   through-Trino ≈ 32 k both re-confirm, buckets 4–6 are confirmed small (validates P1.7's pivot on
+   fresh data).
+5. **It uses instrumentation the field lacks** — the standing 5-phase metric cannot resolve inside
+   `stream`; only a profile can. So this is not a dashboard read, it is the missing instrument.
+
+**Secondary (cheap, same trip):** record B3's **actual per-pod concurrency** during the 61 s scan (to
+retire the borrowed "12/64 → ~4 streams" divisor, §1) and the SSTable-count/node (bucket 2 mechanism).
+
+**Do NOT lead with:** an `io_uring`/`O_DIRECT` build, a DataFusion spike, or a connector rewrite —
+every one of those is gated behind this measurement telling us which bucket is real. The arithmetic
+says buckets 1+2+3 (server-side) dominate and 4–7 (Trino/transport/decompress) are small; **this A/B
+is what converts that from a reconciled estimate into a measured fact.**
+
+---
+
+## 7. One-paragraph summary for the program
+
+The ~47× local-vs-field gap is **almost entirely server-side and Trino-independent**: P1.7's pivot —
+through-Trino aggregate (~32 k rows/s) ≈ server-direct ring (~29 k) — proves the connector, HTTP/2
+window, and split distribution add ≈ 0 on aggregate, so the gap cannot be the transport axis P1.5
+weighted at 45–80 %. Reconciling the headline contradiction: **P1.3 is right** (LZ4 ≈ 1 % CPU, cold
+bandwidth has 8× headroom) and **P1.5's "cold-IO + decompression 30–45 %" is mislabeled and
+oversized** — decompression is ~1 %, cold *bandwidth* is non-binding, and only a **latency-shaped**
+cold-mmap-fault term (synchronous faults, `Auto`→mmap, no `madvise`, 128 KiB readahead) survives, at
+a reclassified **~10–22 %, LOW confidence**. The gap reallocates to two buckets neither transport doc
+owned: **hardware + core-contention (~25–35 %)** and **field data-plane heaviness — more SSTables +
+real reconciliation overlap (~18–28 %)**. Crucially, the field's own 5-phase metric folds the entire
+data plane into `stream`, so **no existing telemetry can adjudicate this** — the first 0.17 field
+measurement must be a **cold-vs-warm server-direct `samply` profile on the i4i pod** (Phase 0's method,
+field hardware), which isolates every disputed bucket in one run and makes the first-ever real
+measurement of Stage-1 (IO+decompress) and Stage-6 (transport).
+
+**File:** `docs/research/phase2-verify-field-gap.md` (uncommitted per instructions).

--- a/docs/research/phase2-verify-io.md
+++ b/docs/research/phase2-verify-io.md
@@ -1,0 +1,156 @@
+# Phase 2 — Adversarial verification of the Phase-1 IO packet (`phase1-3-linux-io.md`)
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Scope:** READ-ONLY (code + git verify)
+
+The IO packet's one surviving code lever is the **fadvise family** (`SEQUENTIAL` + `WILLNEED` at
+open, `DONTNEED` post-scan): S-cost, portable `cfg`-gate, sold as serving **B4 cold-start**. This
+packet attacks that lever at file:line. **Verdict up front: the lever as written is DEAD CODE on the
+field path and must be RESPEC'd to `madvise(WILLNEED)` under Auto-mmap. Its B4 justification is
+largely stale. The LZ4/NVMe arithmetic is sound (if anything conservative).**
+
+---
+
+## Ruling 1 — fadvise vs madvise: **RESPEC (the lever as specified is dead code on the field path)**
+
+The Phase-1 packet flags its own contradiction and then resolves it the wrong way. Verified chain:
+
+**a) The field path runs `Auto`.** No override anywhere in the Flight server or CLI:
+`rg disk_access_mode|DiskAccessMode|prefetch|CQLITE_USE_MMAP|CQLITE_DISK_ACCESS` over
+`cqlite-flight/src` + `cqlite-cli/src` returns **nothing** (the only hit is an unrelated `prefetch`
+comment in `streaming.rs`). The easy-db-lab kits set no disk-access/mmap/prefetch config either.
+`disk_access_mode` and `prefetch` both default to `Auto` — confirmed by the round-trip test at
+`cqlite-core/src/config.rs:997-998` (`assert_eq!(config.disk_access_mode, DiskAccessMode::Auto)`,
+`PrefetchMode::Auto`).
+
+**b) `Auto` resolves to `Mmap` for every field SSTable.** `resolve_disk_access_mode`
+(`cqlite-core/src/storage/sstable/reader/mod.rs:245-282`): a file `< mmap_min_size_bytes` → Buffered;
+`> memory_fraction × RAM` → Direct; else **Mmap**. The lower bound is
+**`default_mmap_min_size_bytes()` = one page = 4096 bytes** (`config.rs:207-209`), and the Direct
+threshold on a 32 GiB i4i.xlarge is **16 GiB**. So **any real Data.db (≥ 4 KiB, < 16 GiB) → Mmap.**
+The buffered backend is essentially *never* selected on the field scan path.
+
+> This falsifies the Phase-1 packet's own lever-table row (`phase1-3-linux-io.md:203`): *"keep
+> buffered as the scan default (it already is — mmap is opt-in)."* **Backwards.** Under `Auto` the
+> scan default **is mmap** for any file ≥ 4 KiB; buffered is the sub-page exception. This single
+> factual error is the root of the mis-specified lever.
+
+**c) Mmap reads never touch a file descriptor.** `BlockSource::Mapped(MmapCursor)`
+(`reader/source.rs:51,91,98,265`) serves every read from the `Arc<Mmap>` memory slice via
+`poll_read` on the cursor; the positional path uses `MmapReadAt` (a slice), not `read_at.rs`'s
+`FileExt::read_at`. There are **zero `read()`/`pread()` syscalls** on the mmap scan path.
+
+**d) `posix_fadvise` acts on a file-descriptor's page cache for `read()`/`pread()` — it has *no
+effect* on mmap'd region access.** The mmap analogue is `madvise`. Therefore **the fadvise
+SEQUENTIAL/WILLNEED/DONTNEED lever as specified would never fire on the field path** — it is only
+reachable when a Buffered or Direct backend is explicitly selected, which the default `Auto` never
+does for a field SSTable.
+
+**The respec (precise):**
+
+- **The correct S-lever for the field is `madvise(MADV_WILLNEED)` at open on the Auto-mmap scan
+  mapping — not `posix_fadvise`.** The machinery is **already built and wired**:
+  `mmap.advise(Advice::WillNeed)` at `reader/mod.rs:1052-1053`, driven by `PrefetchMode::WillNeed`
+  in `mmap_advice_for` (`reader/mod.rs:316-328`). It is simply **not selected by `Auto`** —
+  `mmap_advice_for` returns `None` for `Auto`/`Off`. The lever is a *policy flip* (teach `Auto` to
+  issue `WILLNEED` at open, or add a distinct open-time WILLNEED pass), not new IO code. (`#2210`
+  already proved the pattern: a dedicated `MADV_RANDOM` mapping for point reads at
+  `reader/mod.rs:1167`.)
+- **`posix_fadvise` is correct *only if* a buffered/direct backend is explicitly configured**
+  (non-default; e.g. an operator sets `disk_access_mode=buffered` or a >16 GiB file forces Direct).
+  Keep it as a `cfg`-gated hint **behind a backend check**, not on the default scan path. As the
+  primary field lever it is dead code — **do not ship it as "the gap."**
+- **`DONTNEED` post-scan** has the same split: mmap → `madvise(MADV_DONTNEED)`; buffered →
+  `fadvise(DONTNEED)`. Spec it against the *actual* backend, not unconditionally as fadvise.
+
+Net: the lever **survives, but respec'd** — "issue the already-built `madvise(WILLNEED)` under
+Auto-mmap at open (+ `MADV_DONTNEED` post-scan-once); `posix_fadvise` only under an explicit
+buffered/direct backend." The Phase-1 framing ("`posix_fadvise` is the one absent, additive lever")
+is wrong for the default backend.
+
+---
+
+## Ruling 2 — the #1143 story: **MEASURED REGRESSION, and it constrains the respec**
+
+`git show 5495dd649` (`perf(#1143): … drop MADV_SEQUENTIAL drop-behind on Auto prefetch`, PR #1347)
++ the doc comment at `reader/mod.rs:303-314`:
+
+- **It was a measured regression, not unfinished work.** `MADV_SEQUENTIAL` couples aggressive
+  read-ahead with **drop-behind** (pages evicted as the scan passes). Under **concurrent write
+  load** the eviction meant overlapping scans re-faulted just-dropped pages as **synchronous major
+  page faults on the tokio worker thread**, and the read-side **p99 tail regressed ~2×**. There is a
+  dedicated 313-line guard: `cqlite-core/tests/issue_1143_mmap_prefetch_tail_guard.rs`.
+
+- **Why this does NOT block the respec — the hazard is specific to `SEQUENTIAL`.** `MADV_WILLNEED`
+  does **async read-ahead of the range with no drop-behind** — it never evicts. So issuing
+  `WILLNEED` under `Auto` (the respec in Ruling 1) does **not** reintroduce the #1143 tail; only
+  re-enabling `SEQUENTIAL` would. Any respec that reaches for `SEQUENTIAL` (or an
+  eviction-on-advance `DONTNEED` *during* a scan) must re-answer the concurrent-write drop-behind
+  question and re-run the #1143 tail guard. A one-shot `MADV_DONTNEED` issued *after* a genuine
+  scan-once (not during) is the safe half, exactly as the Phase-1 packet's DONTNEED row argues —
+  that reasoning holds, it just has to be spelled `madvise`, not `fadvise`.
+
+---
+
+## Ruling 3 — B4 cold-start justification: **WEAK / LARGELY STALE**
+
+B4 (cold ≤ 3 s) is open-time latency — faulting Summary / Statistics / Index + the first data chunk.
+The Phase-1 lever sells WILLNEED-at-open as turning "a cold-start's serial fault chain into one async
+prefetch." That serial fault chain **has already been engineered away**:
+
+- **`#2385/#2395` (commit `02984d3ab`)**: *"retire redundant SSTableIndex from BIG open — parse-once,
+  kill O(N²) cold-start."*
+- **`#2412` (commit `5a0ef023f`)**: *"lazy Summary-guided BIG index — O(summary) open."* Confirmed in
+  `index_reader/lazy.rs` + `reader/component_loading.rs`: open now reads only the **small Summary.db**,
+  not the full Index.db.
+- **Field evidence (R11b, MEMORY):** cold-start field PASS with **"cold parses ZERO"**, 0 OOMKills at
+  80 threads. Cold-start is already meeting the bar in the field.
+
+So the "Summary/Index/first-chunk serial fault chain" the lever claims to shorten is already
+**O(summary)-short and empirically not the bottleneck**. WILLNEED-at-open could still *marginally*
+overlap the small summary + first-chunk faults with query setup, but it is **not the B4 saver the
+Phase-1 packet frames it as** — that headline rationale is superseded by #2385 + #2412 and by the
+field measurement. **Downgrade** the B4 line from "directly serves B4 ≤ 3 s" to "B4 already met in
+field post-#2412; WILLNEED-at-open is a marginal, speculative cold-p99 hedge, not a B4 fix." This
+removes the lever's main urgency claim; it stands only as a cheap page-cache hint, priced S but
+low-value, and should sit **behind a re-measurement** the same way `io_uring` does.
+
+---
+
+## Ruling 4 — LZ4 ~1.5 GB/s/core + 8× NVMe headroom: **SOUND, mildly conservative**
+
+- **`lz4_flex` safe-decode ~1.5 GB/s/core.** Reasonable-to-conservative. Reference C LZ4 decompresses
+  ~4.5–5 GB/s/core; `lz4_flex` safe-decode (bounds-checked, the codebase's deliberate no-`unsafe`
+  choice — `compression.rs:259`, `Cargo.toml` `safe-decode`) benches competitively but pays the
+  checks, so ~1.5 GB/s is a fair pessimistic anchor. The doc's own halving to 0.75 GB/s only doubles
+  the result to ~0.2–0.8 % CPU. No correction — the decompress-is-a-low-single-digit-% conclusion is
+  robust, and the honest §2c caveat (relative share ~doubles to ~1–1.6 % once the CPU coordination
+  cost is removed) is correct.
+- **8× NVMe headroom arithmetic checks out and is conservative.** 600 k rows/s × (500 B ÷ 2.5) =
+  120 MB/s vs an i4i.xlarge Nitro SSD's ≥ 1 GB/s sequential read → ~8×. The floor is understated:
+  i4i.xlarge NVMe sequential read is typically **2–4+ GB/s**, so true headroom is ~16–30×. The
+  conclusion — **cold IO bandwidth never binds in the 100 k–600 k rows/s envelope** — is if anything
+  stronger than stated.
+- **Minor:** the 2.5× text compression ratio is a fair mid-point; better field ratios (3–4×) only
+  shrink disk bytes and widen headroom. No change needed. Row-width band (82/250/500 B) is a modeled
+  guess (the packet admits `easy_cass_stress.keyvalue` width isn't pinned) but does not affect the
+  binding-constraint conclusion.
+
+---
+
+## Bottom line for the program
+
+1. **The IO packet's surviving lever is mis-targeted.** As written (`posix_fadvise` on "the buffered
+   cold scan") it is **dead code** — the field runs `Auto` → **Mmap** (mmap_min_size = 4 KiB, no fd
+   reads), and fadvise cannot touch mmap'd pages. **RESPEC to: flip `Auto` to issue the already-built
+   `madvise(MADV_WILLNEED)` at open** (`reader/mod.rs:1052`, currently gated off by
+   `PrefetchMode::Auto → None`); add `MADV_DONTNEED` post-scan-once; keep `posix_fadvise` only as a
+   backend-gated hint for an explicitly-configured buffered/direct mode. This is a **policy flip on
+   built machinery**, not new IO code, which further lowers its cost — but also its novelty.
+2. **#1143 was a measured ~2× p99 regression** from `MADV_SEQUENTIAL` drop-behind under concurrent
+   writes; **`WILLNEED` sidesteps it** (no drop-behind), so the respec is safe — but any reach for
+   `SEQUENTIAL`/in-scan `DONTNEED` must re-run `issue_1143_mmap_prefetch_tail_guard.rs`.
+3. **The B4 justification is largely stale** — #2385 + #2412 made open O(summary) and R11b field
+   cold-start already passes ("cold parses zero"). Reprice the lever from "B4 saver" to "cheap,
+   low-value cold-p99 hedge, defer behind a re-measurement."
+4. **The LZ4/NVMe arithmetic is sound and conservative** — no corrections; IO bandwidth does not bind
+   in-envelope, arguably by a wider margin than the packet claims.

--- a/docs/research/phase2-verify-parallelism.md
+++ b/docs/research/phase2-verify-parallelism.md
@@ -1,0 +1,308 @@
+# Phase 2 — Adversarial verification of the parallelism / scheduling claims
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Agent:** Phase-2 adversarial verifier
+**Verified against:** `docs/research/phase1-6-parallelism.md` (target), `phase1-5-transport-ingest.md`,
+`phase1-1-row-engine.md`, `phase0-scan-cost-breakdown-2026-07.md`
+**Method:** READ-ONLY. Every ruling below is anchored to a `file:line`, an issue/PR body, a git
+revert SHA, or a field round note. No builds.
+
+---
+
+## 0. Verdict table (per target)
+
+| Target | Claim | Verdict | One-line |
+|---|---|---|---|
+| **P-A** | #2680 re-land: default K=1, opt-in K=2, never K=4; early-close cancel fix; #2792 E2E required | **SOUND, one rationale correction** | Root-cause reading matches #2782 exactly; shape is safe; but "SplitWeight carries the balance" is wrong — the **sub-split rotation** carries flight-pod balance, SplitWeight is Trino-worker accounting. |
+| **P-B** | Resize admission 64→16–24 because 64×15–20MB ≈ 1.3GB ≫ 512Mi → OOMKill | **DIRECTION right, JUSTIFICATION overstated** | The 1.3GB→OOM did **not** happen in the field (R11b 80-thread overload = 0 OOMKills, peak 270–391Mi). Real-but-**unexercised**. Resize is a prudent P2 companion to #2680, not a live-OOM P1. |
+| **P-C** | Per-stream buffer = (4+3)×8192 = 57,344 rows ≈ 15–20MB; B4 ceiling ~14–34 streams | **VERIFIED, two corrections** | Channel counts **batches** (cap 4), each ≤ `batch_size` 8192 **rows** — math is structurally right. But `IN_FLIGHT_ALLOWANCE=3` is `#[cfg(test)]` (prod peak ≈ 4–6 batches, ~33–49k rows), and the byte figure is row-width-dependent. The 64MiB result budget does **not** cap the streaming path. |
+| **P-D** | Drain saturates at ~8 concurrent streams = the pod's useful width | **CORRECT and honestly bounded** | ~8 is a real measured number (local 10-core rig); the packet already says L6 raises it and a 4-vCPU pod is lower. It does **not** treat 8 as a constant. Recommend an explicit "(pre-L6, local rig)" tag. |
+
+---
+
+## 1. THE A5 CONTRADICTION — ruling: **REAL-BUT-UNEXERCISED (mechanism), OVERSTATED (as written)**
+
+### The deciding field evidence (falsifies the "1.3GB → OOM" claim as stated)
+
+#2367 R11b field round, **80-thread scan-heavy overload** (`count(*)` + `LIMIT 50000`):
+
+- **"0 pod restarts, 0 OOMKills, pods stayed 1/1 Running, no hangs"** (#2367 comment, the R11b
+  admission-control section).
+- **Memory trajectory: idle 3–4Mi, peak 270–391Mi, 0 OOMKills, no growth trend** (#2367 R11b memory
+  4-point + the round-11b-vs-expectation table: `memory | idle 3–4Mi, peak 270–391Mi, 0 OOMKills`;
+  `80-thread overload | 0 restarts`).
+- do_get whole-round **30,414 ok / 708 error (2.3% aborted/superseded splits)** — the server was
+  processing tens of thousands of streams and still peaked at **391Mi**, well under the 512Mi B4 pod.
+
+If P-B's arithmetic (64 admitted × ~20MB ≈ 1.28GB) described the realized state, the pod would have
+OOMKilled under an 80-thread flood. It did not — it peaked at **~0.3× the 512Mi budget**. So the
+literal claim *"admission 64 → 1.3GB → A5 OOMKill under overload"* is **not what the field shows.**
+
+### Why it didn't OOM — the mechanism (this is the "real-but-unexercised" part)
+
+Realized concurrent streams per pod **never approached 64**:
+
+1. **Drain saturation caps useful concurrency at ~8** (#2765 baseline table, reproduced in
+   phase1-6 §4): throughput is flat 8→80 threads; extra offered concurrency piles into buffers/latency,
+   it does not create 64 simultaneously-producing streams.
+2. **Fan-out skew pinned most load onto one pod** (#2367 R9/R11: *"only 1 of 3 flight pods did any
+   work"*, *"Every concurrent do_get lands on one pod"* — the `pickReplica` first-replica bug, later
+   the floorMod rotation). Even the busy pod stayed at 391Mi.
+3. **Admission telemetry corroborates:** R12 saturation snapshot **admission 12/64** (phase1-5 §1);
+   R11b `admission_in_use` read **0** at 20–80 threads (scrape-resolution caveat, #2367). Nothing in
+   the field record shows the pod ever holding anywhere near 64 concurrent Arrow-egress buffers.
+
+The per-stream buffer math (P-C) is correct; the OOM never fired because the **width term** (realized
+concurrent streams) sat at ~8–12, not 64. The 1.3GB is the number for a *hypothetical* 64-wide pod
+that the current code's drain-saturation + skew prevent from ever existing.
+
+### The sharp coupling the packet under-states — and the corrected ruling
+
+The reason 64 is unexercised (drain saturation + **fan-out skew**) is *itself* the thing #2680 sets
+out to fix. **A successful #2680 re-land spreads load evenly AND multiplies split count → it pushes a
+pod's realized concurrent-stream count UP, toward the admission ceiling.** So:
+
+- **Today:** the A5 memory hazard is **real in principle, unexercised in practice** — P-B's OOM is a
+  hazard of a state the current code does not reach.
+- **After #2680 K=2 + drain-fix:** realized per-pod concurrency rises, so the 57k-row Arrow buffer ×
+  concurrency starts to matter for the first time.
+
+**Ruling:** the memory-derived admission resize is **a sensible companion to the #2680 re-land**, not
+noise — but its correct justification is *"the re-land will raise realized concurrency, so cap it from
+memory before it bites,"* **not** *"we are OOMing at 64 today"* (the field falsifies that). It is a
+**P2 forward-looking stability guard bundled with #2680**, not a standalone P1 stability fix. The
+packet's §6.3 should be reworded to lead with the field's 0-OOMKill/391Mi result and frame the resize
+as a pre-emptive cap that becomes load-bearing only once #2680 unlocks higher concurrency.
+
+---
+
+## 2. P-C BUFFER MATH — verified at file:line, two corrections
+
+### What the channel actually counts (verified)
+
+- `cqlite-flight/src/streaming.rs:65` — `DO_GET_CHANNEL_CAPACITY: usize = 4`, documented (`:58`) as
+  **"do_get channel capacity, in batches."** The channel payload is `RecordBatch`
+  (`streaming.rs:140` `mpsc::Sender<Result<RecordBatch, ProducerError>>`, `:299`
+  `mpsc::channel::<Result<RecordBatch, ProducerError>>(capacity.max(1))`).
+- `cqlite-flight/src/producer.rs:401` — batches are built to `batch_size` **rows** (default 8192,
+  `main.rs:35–36`) then emitted. So `8192` counts **rows per batch**, and the channel holds **4
+  batches**. P-C's "channel = batches, 8192 = rows/batch" reading is **correct** — this directly
+  answers attack-line-1's "is it rows or batches?": it is a **4-deep batch channel**, each batch a row
+  vector of ≤8192.
+- Peak resident rows/stream = (channel depth + in-flight slack) × batch_size. The doc comment
+  (`streaming.rs:61`) states the bound as `(DO_GET_CHANNEL_CAPACITY + IN_FLIGHT_ALLOWANCE) · batch_size`.
+
+**Correction 1 — the `+3` is a test bound, not a production one.** `IN_FLIGHT_ALLOWANCE = 3` is
+`#[cfg(test)]` (`streaming.rs:85`); its own doc says it is a *"test-observation bound, not a value any
+production code branches on."* Its three components are +1 send-in-flight, +1 encoder prefetch, +1
+Tokio scheduling slack — of which only the first two are real production residency. So the **production**
+peak is ≈ `(4 + ~2) × 8192 ≈ 49,152 rows`, not 57,344. P-C's 57,344 is a ~15% over-count (uses the
+test bound). Order of magnitude and every downstream conclusion are unaffected, but the packet should
+cite the production figure and not the `#[cfg(test)]` constant as if it were a runtime property.
+
+**Correction 2 — the 15–20MB is row-width-dependent, state it as such.** 49k–57k rows × row-width.
+At the narrow `keyvalue` ~300B/Arrow-row that is ~15–17MB; wider field rows raise it, narrower lower
+it. The packet's §6.2 does band this (15/20/30MB), which is fine — just anchor the row count to the
+production 49k, not 57k.
+
+### Does the byte-bounded result budget already cap this? **No — not on the streaming path.**
+
+- The result budget (`cqlite-core/src/query/result_budget.rs`, `QueryConfig::n` default **64MiB**,
+  `config.rs`) is enforced by `enforce_result_budget` on the **materializing / collect-into-`Vec`**
+  path (the byte-identity parity path, `producer.rs:369–375` `CollectSink`).
+- **The streaming `do_get` path does not enforce it** — `rg result_budget cqlite-flight/src` returns
+  **nothing**. The streaming path (`streaming.rs`) emits each batch as produced and is bounded
+  **structurally** by the 4-deep batch channel, not by a byte budget.
+
+So P-C's fear is **not** already handled by `--max-result-bytes`/`QueryConfig::n`. Per-stream residency
+is capped *only* by the channel depth (structural, ~49k rows) and cross-stream residency is capped
+*only* by admission `K`. This is exactly why a memory-derived admission ceiling (P-B) is the right knob
+— there is no byte budget on the streaming egress to lean on. The B4-implied ~14–34 streams/512Mi
+(§6.2) is arithmetically sound given the per-stream figure.
+
+---
+
+## 3. P-A #2680 RE-LAND — root cause verified; re-land shape ruled; **SplitWeight rationale corrected**
+
+### 3.1 The #2782 root-cause reading is CORRECT and evidenced
+
+#2782 body confirms the packet's reading verbatim:
+- **Symptom:** `SELECT id ... LIMIT 2` (and partial-predicate + LIMIT) **hang 180s**; `LIMIT 100`
+  (> 5-row table, full-drains every split) and unbounded scans **PASS**.
+- **Discriminating evidence** (quoted in #2782): *"LIMIT 2 (small — Trino stops early) hangs; LIMIT 100
+  … consumes every split to completion PASSES."* → early-termination-with-more-splits-in-flight, **not**
+  ring/slice math.
+- **Trigger:** `DEFAULT_SUB_SPLITS_PER_RANGE = 4` shipped as **production default** (K=4), quadrupling
+  the in-flight cancellable split count.
+- **Mechanism:** a sub-split's Flight `DoGet` producer blocks in `send` on a full fan-in channel and
+  never observes the early close. The packet's §3.2 identification (`producer_thread_from_reader` blocked
+  in `send` on the cap-256 `sync_channel`, `from_readers.rs:96/123` `forward_row` →
+  `mod.rs:537` `STREAMING_CHANNEL_CAPACITY=256`) is the correct thread. **CQLite's cancel is cooperative
+  (`ScanCancel` polled before each `step`)**, so the fix is ensuring early close *fires* that cancel on
+  every not-yet-drained sub-split AND that a producer already blocked in `send` wakes on it — precisely
+  the packet's §3.4 "early-close drain unit test." Verified sound.
+
+Revert history confirms the timeline: `f5dd215a7` (PR #2779 feat) → `0bd63148b`/`7fa3f2050` reverts
+(PR #2791). The re-land is greenfield off a known-good base.
+
+### 3.2 #2792 is real and correctly scoped
+
+#2792 body: promote `Flight ↔ Trino E2E` to a `required` check via the standard **path-conditional**
+workaround (success-by-skip on non-connector paths, real run on `trino-connector/**`/`cqlite-flight/**`),
+with `enforce_admins` preserved (#2433). AC includes the exact #2782 reproducer. This closes the
+process gap that let #2779 auto-merge red. The packet's dependency on #2792 is correct.
+
+### 3.3 RE-LAND SHAPE RULING — K=2 opt-in is right; **SplitWeight-only is NOT a substitute**
+
+Attack-line-3 asks: is "default K=1, opt-in K=2" the right re-land, or does **SplitWeight-only (no
+sub-splits, zero hang risk)** capture most of the 2–4× skew win?
+
+**Ruling: SplitWeight-only does NOT capture the win. The flight-pod skew is fixed by the sub-split
+rotation, not by SplitWeight.** Evidence:
+
+- **Which flight pod does the CPU work is determined by `split.host()`**, surfaced as Trino soft-affinity
+  locality hints in `CqliteFlightSplit.getAddresses()` (`CqliteFlightSplit.java:72–80`), and the primary
+  is the deterministic per-range rotation `sorted[floorMod(rotationKey, size)]`
+  (`CqliteFlightSplitManager.java:348–349,396–409`). This is confirmed causally by the field: the R9
+  skew was *"pickReplica deterministic first-replica"* pinning **one pod** (#2367); the #2409 rotation
+  fix spread *participation* but, per #2680's own triage, **count-balanced ≠ weight-balanced** — heavy
+  ranges still cluster onto whichever pod floorMod hands them.
+- **`SplitWeight` (the reverted `getSplitWeight()`) is Trino's scheduler cost accounting** — it bounds
+  the summed weight of outstanding splits **per Trino worker**, i.e. it governs Trino-worker-side split
+  concurrency, **not which flight pod a split's `do_get` connects to.** Trino workers and cqlite-flight
+  pods are distinct tiers; the connector opens a `FlightStream` to `split.host()` regardless of which
+  Trino worker runs the split. So overriding `getSplitWeight()` at **K=1** leaves every heavy range still
+  wholly assigned to its single floorMod pod — **it cannot move flight-pod CPU load at all.**
+- **To rebalance flight-pod load you must change the assignment granularity or the assignment rule:**
+  (a) **sub-split each range into K slices and rotate the primary per slice**
+  (`slice i primary = rotated(parent)[i % n]`, the reverted design) — refines granularity so heavy
+  ranges' sub-slices spread across owners; or (b) **weight-aware bin-packing at K=1** (#2680 candidate
+  direction 1) — assigns whole ranges to owners by size, zero split inflation, zero hang risk, **but
+  requires a per-range size feed that does not exist.** The shipped/reverted implementation chose (a).
+
+**Therefore:** the honest re-land is **default K=1 (byte-identical pre-#2680), opt-in K=2 (the minimum
+granularity that delivers the rotation-based flight-pod balance), never K=4 default (the #2782 trigger),
+gated on the early-close drain fix + #2792 required.** The packet lands on exactly this — but its §3.3/§7
+wording *"let getSplitWeight() + a conservative default K=2 carry the balance"* is **imprecise and should
+be corrected**: at K=2 it is the **sub-split ROTATION** that carries flight-pod balance; `getSplitWeight()`
+only refines Trino-worker scheduling order and adds nothing to flight-pod CPU distribution. "SplitWeight-only,
+no sub-splits" is a **rejected** option (captures ~0 of the flight-pod skew win), not the safe shortcut the
+question probes for. The only zero-inflation alternative is weight-aware bin-packing (K=1), which is blocked
+on a size feed and was not built — so K=2 sub-split rotation is the pragmatic re-land.
+
+---
+
+## 4. P-D DRAIN-SATURATION-AT-8 — correct, and NOT treated as a constant
+
+Attack-line-4 asks whether the packet wrongly treats ~8 as a fixed pod width when row-engine L1 +
+transport T-levers would raise the drain rate and move saturation.
+
+**Ruling: the packet does NOT double-count; it already treats 8 as movable.** Evidence in the target:
+- §4: *"The lever that raises `N_drain_sat` is L6 (cut the per-row channel tax) — a per-stream lever,
+  not a scheduling one."*
+- §4: *"A 4-vCPU field pod will have a lower `N_drain_sat` … plausibly ~4–6"* — it explicitly does not
+  export the local 10-core `~8` as a field constant.
+- §6.3 point 1: orders `N_drain_sat (~8) < N_mem (~20) < N_admitted (64)` as *current-code* values.
+- phase1-5 §6 (the sibling packet) states the coupling directly: *"anything that speeds the Java drain …
+  raises the real drain rate, which empties the egress channel … letting `active_merges` climb toward
+  the 64 admission ceiling."*
+
+So the "8" is honestly scoped as **today's drain-bound width on the local rig**, and both packets say
+the row-engine (L6) and transport (ArrowToTrino/prefetch/window) levers **raise** it. The one gap: the
+§7 summary formula pins `N_drain_sat ≈8` inline **without** a "(pre-L6, local 10-core)" tag, so a Phase-3
+reader skimming only the summary could inherit 8 as a field constant. **Recommendation:** label it
+`N_drain_sat ≈ 8 (pre-L6, local 10-core; ~4–6 on a 4-vCPU field pod, rising with L6/transport)` wherever
+it appears standalone.
+
+**Honest post-fix width model** (the "8 is not a constant" answer, stated for Phase 3):
+
+```
+width_postfix = min( N_admitted , N_drain_sat_postfix , N_mem )
+  N_drain_sat_postfix  rises as L6 (channel batching) + ArrowToTrino zero-copy + prefetch + HTTP/2
+                       window speed the drain — but is HARD-CAPPED at the vCPU count (4) for
+                       CPU-bound narrow rows: you cannot run more truly-concurrent CPU-bound
+                       streams than cores.
+  N_mem  ≈ 512Mi / per-stream-MB ≈ 16–24 (memory-bound wide rows / slow link regime).
+```
+
+For narrow CPU-bound rows, `width_postfix → ~4` (vCPU-bound). For wide/compressed/network-bound rows,
+`width_postfix → N_mem ~16–24` (memory/link-bound). Saturation "moves" from ~8 (today, drain-bound below
+cores) toward the 4-vCPU wall — it does not grow without limit.
+
+---
+
+## 5. UTILIZATION STACKING — the credit cap for Phase 3
+
+Attack-line-5: sub-splits (#2680/L1), row-engine producer-side utilization (phase1-1 L1/L6), and
+transport fan-out (phase1-5 lever 6) all widen effective streams. How much **total** utilization credit
+may the stack take against 4 vCPUs and the post-fix drain?
+
+**Ruling — ONE width multiplier for the entire utilization stack, not three multiplied:**
+
+1. **Sub-splits (#2680), transport fan-out (phase1-5 #6), and producer-side parallel decode all buy the
+   SAME quantity — realized concurrent streams per pod — and all cash out against the SAME ceiling**
+   `min(N_admitted, N_drain_sat_postfix, N_mem)`. They are **substitutes competing for one width budget,
+   not independent multipliers.** #2680 spreads streams *across pods* (fixes skew); fan-out raises streams
+   *per pod*; both are throttled by the same per-pod drain/vCPU/memory `min(...)`. Phase 3 must **NOT**
+   multiply their separately-quoted "2–4× (skew)" × "2–5× (fan-out)" — the first lever to reach the
+   ceiling caps the rest.
+
+2. **The utilization ceiling on a 4-vCPU pod is ≈ the vCPU count for CPU-bound rows** (`width_postfix → 4`,
+   §4). Today's effective width is already ~8 on a 10-core local rig and drain-bound *below* cores; on a
+   4-vCPU field pod the realized width is smaller. So the utilization stack's total credit over a single
+   stream is **bounded at ~4× (the vCPU envelope), × `C(N) < 1`** (Phase-0's 55% kernel park/wake tax that
+   contends as streams stack) — **not** the ~2-to-many× product the three packets separately imply.
+
+3. **Per-stream ceiling levers are a DIFFERENT axis and DO compound — on the Amdahl residual.** L6 (batch
+   the fan-in channel, ~1.9× util / ~1.15–1.35× single-stream), L3 (reconcile fast-path), ArrowToTrino
+   zero-copy, HTTP/2 window: these raise `per_stream_rows_s`, and by speeding the drain they **raise the
+   width ceiling** (`N_drain_sat_postfix`). They are the **multiplicand**; width is the **multiplier**.
+
+**The cap rule for Phase 3, stated as an equation:**
+
+```
+per_pod_gain  ≤  (width_postfix / width_now)  ×  (Π per-stream ceiling levers, Amdahl residual)  ×  C(N)
+                 \___ ONE utilization factor ___/     \___ compounds on the residual ___/         \_<1_/
+
+  width_postfix ≤ 4 (vCPU) for narrow CPU-bound rows; ≤ N_mem ~16–24 for wide/network-bound rows
+  Take the utilization credit ONCE (the min-width move). Do NOT stack #2680 × fan-out × producer-parallel.
+  Per-stream levers (L6/L3/ArrowToTrino/window) are the residual product AND the thing that raises width.
+```
+
+Concretely: Phase 3 may claim **one** width improvement (from the utilization stack collectively, bounded
+by the 4-vCPU / `N_mem` envelope) **times** the Amdahl product of the per-stream ceiling levers **times**
+`C(N)<1`. It may not present sub-splitting, transport fan-out, and producer-side parallelism as three
+independent 2–5× factors — they are one lever expressed three ways, all bounded by the same per-pod
+`min(...)`.
+
+---
+
+## 6. Summary packet
+
+**Per-target verdicts:** P-A **sound** (root cause matches #2782; K=1/opt-in-K=2 shape correct; #2792
+real) with the **SplitWeight rationale corrected**; P-B **direction right, OOM justification overstated**
+(field 0-OOMKill / 391Mi peak falsifies the 1.3GB-today claim); P-C **verified** with the `#[cfg(test)]`
++3 over-count and the row-width caveat noted, and the confirmation that the 64MiB result budget does
+**not** cap the streaming path; P-D **correct and honestly non-constant**.
+
+**The A5 ruling — REAL-BUT-UNEXERCISED (mechanism) / OVERSTATED (as written).** Deciding evidence:
+#2367 R11b **80-thread overload = 0 OOMKills, peak RSS 270–391Mi** against a 512Mi pod, with realized
+concurrency ~≤12 (admission 12/64, `in_use` scrape-0, fan-out pinned to one pod, drain saturates ~8).
+The 1.3GB is the number for a 64-wide pod the current code never reaches. The memory-derived admission
+resize (64→16–24) is a **P2 forward guard to bundle with the #2680 re-land** — justified by *"the re-land
+raises realized concurrency toward the ceiling,"* **not** by a live OOM. Downgrade its stated severity.
+
+**The re-land shape ruling — K=2 opt-in, SplitWeight-only REJECTED.** Flight-pod CPU load is set by
+`split.host()` rotation (`CqliteFlightSplit.getAddresses` + floorMod primary), not by `getSplitWeight()`
+(Trino-worker split-cost accounting). SplitWeight-only at K=1 moves **zero** flight-pod load; the skew fix
+requires the **sub-split rotation** (K≥2) or weight-aware bin-packing at K=1 (blocked on a nonexistent
+size feed). So: **default K=1, opt-in K=2, never K=4 default**, gated on the early-close drain fix
+(`producer_thread_from_reader` blocked-in-`send` must wake on cancel) + #2792 `required`. Correct the
+packet's "SplitWeight carries the balance" to "the K=2 sub-split rotation carries flight-pod balance."
+
+**The total utilization credit cap.** ONE width multiplier for the whole utilization stack (#2680 +
+transport fan-out + producer-side parallelism — substitutes competing for one per-pod width budget),
+bounded by `min(N_admitted, N_drain_sat_postfix ≈ 4-vCPU envelope, N_mem ~16–24) × C(N)<1`. Per-stream
+ceiling levers (L6/L3/ArrowToTrino/window) compound on the Amdahl residual and are what raise the width
+ceiling. Phase 3 must not multiply the three utilization quotes as independent factors.
+
+**File:** `docs/research/phase2-verify-parallelism.md` (uncommitted per instructions).

--- a/docs/research/phase2-verify-row-engine.md
+++ b/docs/research/phase2-verify-row-engine.md
@@ -1,0 +1,300 @@
+# Phase 2 — Adversarial verification of the row-engine levers (L1–L5)
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Role:** Phase-2 adversarial verifier
+**Target:** `docs/research/phase1-1-row-engine.md`
+**Cross-checks:** `docs/research/phase0-scan-cost-breakdown-2026-07.md`,
+`docs/research/phase1-6-parallelism.md`, `docs/research/phase1-8-prior-art.md`
+**Method:** read the cited source at each line, ran `git log` for prior/reverted attempts, default
+skeptical — a lever survives only if the best attack fails. READ-ONLY (no builds/commits).
+
+---
+
+## 0. Bottom line (verdicts first)
+
+| Lever | Verdict | Revised multiplier | The attack that landed |
+|---|---|---|---|
+| **L1** batch fan-in `sync_channel` | **SURVIVES (weakened)** | util **1.5–1.9× rig-narrow upper bound**; single-stream **~1.1–1.25× narrow / ~1.05–1.1× wide** (was 1.15–1.35×) | P1.1's "#2765 is a different channel, orthogonal" is **factually wrong** — same channel, must co-design; single-stream slice is unmeasured and over-quoted |
+| **L2** inline/thread-less merge | **SURVIVES (narrow-only, A/B-gated)** | ~1.4–1.8× narrow single-stream (unmeasured); **≤1.0× wide/field → do not credit in the field stack** | decode-overlap-loss logic holds; field-shape kills it, as the doc concedes |
+| **L3** reconcile singleton fast-path | **WEAKENED** | disjoint-narrow-no-TTL **~1.20× upper bound**; **field-with-TTL/overlap ~1.03–1.08× or lower** | precondition (singleton + no del + no TTL + no dropped-cols) is narrow; checking it ≈ doing the work; field TTL/overlap rows never hit it |
+| **L4** `RowKey` Arc hoist (#1883) | **SURVIVES (re-scoped)** | **1.05–1.09× ONLY for multi-row-partition tables; 1.0× for single-row-partition of ANY width** | doc conflates "wide (bytes)" with "many rows/partition"; the win is governed by clustering fan-out, unknown from the profile |
+| **L5** FxHash `row_values` map | **SURVIVES** | ~1.04× narrow & wide | none — target confirmed still SipHash; #1817's "FxHashMap row map" was a *different* map (per-partition LIMIT counter) |
+
+**Double-count ruling and field governing multiplier are in §7 and §8.**
+
+---
+
+## 1. Attack line 1 — do the code claims hold at the cited lines?
+
+All four mechanical claims **verified true**:
+
+- **`from_readers.rs:137` / `:150` — one `send` per row.** `forward_row` (fn opens at :137) calls
+  `sender.send(msg)` at :150 exactly once per streamed row, inside the
+  `stream_all_partitions_for_query` per-row callback. Confirmed one `MergeEntry` per `send`.
+- **`mod.rs:537` — `STREAMING_CHANNEL_CAPACITY = 256`** (`#[cfg(feature = "write-support")] const … = 256`). Confirmed.
+- **`mod.rs:1235` — recv site.** The consumer's `recv` is `receiver.recv_timeout(RECV_CANCEL_POLL)`
+  in a cancel-polling loop (issue #2361), one recv per entry, with `channel_depth::received()`
+  decrementing the #2419 gauge per DATA entry. Confirmed — and note it is a **cancel-aware timed
+  recv**, not a plain `recv()`; L1 must preserve that.
+- **`producer.rs:1000` — `RowKey::new(partition_key.to_vec())`.** Inside `entry_to_row`, called once
+  per `entry in rows` (loop at `producer.rs:812`). `RowKey(pub Arc<[u8]>)` (`types.rs:1687`),
+  `RowKey::new(bytes: Vec<u8>)` (`types.rs:1691`). Confirmed: `.to_vec()` (Vec alloc + memcpy) then
+  `Arc::<[u8]>::from(vec)` (second alloc + copy) — **two allocations per row**.
+
+**The P1.1 SipHash re-attribution is CORRECT.** Phase-0 §4 #3 charged the 6.9 CPU-s / 4.5 % SipHash to
+"per-row partition-key lookups (`PartitionKeyCache`)". I read `PartitionKeyCache::columns_for`
+(`row_build.rs:138`): it does **no hashing at all** — a raw-byte compare
+(`cached.as_ref() == key_bytes.as_ref()`) plus a fingerprint equality check. There is **no
+`hash_one`** anywhere on the row path (the only `hash_one_value` is in `aggregation/group_key_cmp.rs`,
+off the scan path). The real per-row SipHash is the `HashMap<Arc<str>, Value>` at **`row_build.rs:246`**
+(default `RandomState` hasher, `cells.len() + pk_hint` inserts per row). Phase-0 measured a real
+`core::hash::sip` cost; it just named the wrong owning function. P1.1 fixes the attribution correctly.
+**L5 targets the actual site.**
+
+---
+
+## 2. Attack line 3 — history: is F2/#1592 a different channel, any reverted precedent?
+
+- **F2 #1592 / PR #2100 (`cb8241e92`)** = *"batch the public streaming channel (stop one async wake
+  per row)"*. Verified it batched the **outer async `scan_stream` forwarder** (the `Vec<Row>` surface
+  into query-engine consumers) — a **`tokio` async wake**, a different channel from the inner
+  `std::sync::mpsc::sync_channel` L1 targets. Not reverted; archived (`0ae161bd4`). **Precedent
+  transfers** (technique + `BATCH_EMIT_ROWS` + the send-count/parity oracle pattern), the channel does
+  not. P1.1 is right here.
+- **No reverted inner-channel batching or hasher swap exists.** `git log --grep` for revert×(batch|
+  channel|merge|inline|hash) returns only unrelated reverts (`#844` multicell, `#441/#442` wide-row).
+  FxHash was **adopted and kept** — `#1590` (E8, `59e3ec9ec`), `#1817` (`815690fec`). No re-litigation
+  risk for L5.
+- **`#1817` caveat that matters for L5 (see §6).** Its commit says "internal FxHashMap row map", which
+  could read as "the per-row map is already FxHashed → L5 is dead." It is not — that FxHashMap is a
+  *different* map. Reconciled in §6.
+
+---
+
+## 3. Attack line 2 / 4 / 6 findings that change the levers
+
+### 3.1 The #2765 "different channel" claim is FALSE — L1 and #2765 are the SAME channel (attack line 2)
+
+This is the single biggest error in P1.1. P1.1 §3 asserts: *"#2765 … bound the OUTER merge→tonic
+`tokio::mpsc` egress depth — a different channel … Do NOT credit #2765 with this multiplier — it is
+orthogonal."*
+
+**Verified against code — the opposite is true.** There are exactly two channels:
+
+| Channel | Type | Constant | What #2600/#2765 & L1 do |
+|---|---|---|---|
+| **Fan-in** producer→coordinator | `std::sync::mpsc::sync_channel` | `STREAMING_CHANNEL_CAPACITY = 256` (`mod.rs:537`, `from_readers.rs:186`) | **L1 batches it; #2765 adaptively sizes it** |
+| **Outer Arrow egress** coordinator→tonic | `tokio::sync::mpsc::channel` | `DO_GET_CHANNEL_CAPACITY=4` + `IN_FLIGHT_ALLOWANCE=3`, ×8192 = 57,344 rows (`streaming.rs:65/86/299`) | neither touches it |
+
+The #2419 gauge that #2600 characterizes is literally named `cqlite.merge.egress_channel_depth`
+(`channel_depth.rs` header: *"live count of merged DATA entries … buffered in the bounded
+producer→consumer `sync_channel` (capacity `STREAMING_CHANNEL_CAPACITY` = 256)"*). #2765's
+`clamp(BUDGET/active_merges, MIN, **256**)` clamps to that 256 fan-in cap. So **#2765 and L1 attack the
+SAME fan-in `sync_channel`** — #2765 on the **memory-depth axis** (adaptive capacity), L1 on the
+**per-message syscall axis** (batching). The genuinely-different channel neither touches is the outer
+57,344-row Arrow egress. **P1.6 §6.1 has this right; P1.1 §3 has it backwards.**
+
+Consequence: P1.1 reaches the correct conclusion ("don't double-credit #2765 with L1's multiplier") for
+the wrong reason. The right statement is: *they share a channel and must be **co-designed**, not that
+they are orthogonal.* See the co-design requirement in §3.3.
+
+### 3.2 L1's single-stream slice is over-quoted and unmeasured (attack line 2)
+
+Phase-0 is explicit that Stage 4b's 49.9 % is *mostly producer-side park* (reader threads blocked in
+`send`, off the critical path) with only a *smaller coordinator-side wake-per-`recv`* on the critical
+path. P1.1 turns that into single-stream **1.15–1.35×**. But the coordinator is CPU-bound on ~62 CPU-s
+of real reconcile/materialize/hash/heap work; the per-row `recv_timeout` syscall is *on top of* that
+real work, not 15–25 % of it in any measured sense. The 1.15–1.35× is an **estimate with no
+measurement behind it**, sitting at/above the plausible band. **Revised: ~1.1–1.25× narrow
+single-stream, ~1.05–1.1× wide** — and flagged unmeasured; a `perf`/`dtrace` of the coordinator's recv
+share is the honest way to firm it up.
+
+The **utilization** ~1.9× is more defensible, but *only* as the mechanism P1.6 already names: cutting
+the park/wake syscall tax raises `C(N)` and pushes `N_drain_sat` past the measured ~8-stream ceiling
+(195 qps flat to 80 threads). It is an **aggregate-CPU-headroom upper bound** realized as throughput
+**only** because that tax is what collapses `C(N)` — i.e. **L1 (P1.1) and L6 (P1.6) are the same
+lever described twice.** Keep 1.5–1.9× as a **rig-narrow ceiling**, not a field figure (§8).
+
+### 3.3 Memory / B4 / A5 (attack line 6) — real, conditional, not a kill
+
+Current fan-in resident set = 256 msgs × 1 `MergeEntry` × M sources (≈1 K entries at M=4, 2 K at M=8).
+A naive L1 with `BATCH_EMIT_ROWS=256` and **unchanged** 256-msg capacity would hold
+256×256×M = **65 K×M `MergeEntry` per stream — a 256× blowup**, straight through B4. A sane L1 must
+**cut the message-capacity** so resident rows stay bounded (e.g. 4 msgs × 256 rows = 4× current). At a
+"few hundred bytes"/`MergeEntry` (the `mod.rs:531` comment) that is low single-digit MB/stream — well
+under the 57,344-row / ~15–17 MB/stream Arrow egress term that P1.6 shows dominates. **So B4-safe iff
+capacity is cut proportionally.**
+
+Because #2765 sizes that **same** capacity, the two **must be co-designed**: #2765's budget is in
+message/entry units; once a message is a 256-row batch, its `clamp(…, MIN, 256)` would budget 256
+*batches* = 65 K rows unless reconciled. P1.1 misses this entirely because it believes they are
+different channels. **This is a hard prerequisite, not a nicety.** Not a memory *kill* for L1, but the
+"batching adds only bounded buffers" line in P1.1 §0 is under-specified and must carry the
+capacity-reduction + #2765-reconciliation math.
+
+### 3.4 Parity oracles for L2/L3 (attack line 4)
+
+L2 and L3 alter merge structure/order, so the **physical-dump `*-Data.db.jsonl` goldens cannot catch a
+regression** — they enumerate every on-disk cell incl. tombstones, so a read-time-reconciliation
+divergence stays green on both sides (CLAUDE.md "two parity oracles"). The load-bearing gates are:
+- **`query-semantics-oracle`** (`test-data/query-semantics-oracle.json`,
+  `query_semantics_oracle_parity.rs`) — post-reconciliation result set at a **pinned `now`**.
+- **point-vs-full differential** (`point_vs_full_differential.rs`, #1918) — for L3 especially, since a
+  singleton fast-path could diverge point vs full read paths.
+
+**`--lite`-provable acceptance is possible but requires deliberate wiring.** `--lite` runs the touched
+package `--lib` **plus the diff's new `--test` targets**. The oracle parity files live in
+`cqlite-core/tests/`, so they only enter the blast radius if the L2/L3 diff **adds cases to those exact
+test files** (making them diff-touched). Acceptance criterion: *the same PR extends
+`query_semantics_oracle_parity.rs` (and `point_vs_full_differential.rs` for L3) with a
+singleton/no-overlap-and-a-TTL/tombstone-collision case, so `--lite` exercises the fast-path against
+the full path.* Without that, only the once-per-issue full gate covers it.
+
+---
+
+## 4. Per-lever detail
+
+### L1 — batch fan-in `sync_channel` → **SURVIVES (weakened)**
+Mechanics verified (§1). Revised multipliers (§3.2): util **1.5–1.9× rig-narrow ceiling**,
+single-stream **~1.1–1.25× narrow / ~1.05–1.1× wide (unmeasured)**. Costs/risks **larger than P1.1
+states**: (a) co-design with **#2765 on the same channel** (§3.1); (b) cut message-capacity for B4
+(§3.3); (c) preserve the #2419 `egress_channel_depth` gauge — the batch becomes the accounting unit;
+(d) preserve #2361 cancel-aware `recv_timeout`. NEW filing still warranted; F2 machinery transfers.
+
+### L2 — inline/thread-less merge → **SURVIVES (narrow-only, A/B-gated)**
+The decode-re-serialization argument holds: Stage 2 decode (9.7 %, ~14.9 CPU-s) is currently overlapped
+across ~4 reader threads; inlining serializes it onto the coordinator, adding it to the critical path
+while removing the ~47 % producer park/wake. Net **~1.4–1.8× narrow** (unmeasured), **≤1.0× wide** as
+decode grows. Correctly scoped as an experiment behind a `k`+stream-count A/B gate. **Do not credit L2
+in the field stack** (§8). Parity-safe *if* survivor selection is byte-identical — same oracle burden
+as L3 (§3.4).
+
+### L3 — reconcile singleton fast-path → **WEAKENED**
+Confirmed genuinely absent: `reconcile_cluster_with_overlap_counted` (`mod.rs:4117`) builds a full
+`ReconcileState` and runs **eight** steps (`fold_row_deletions`, `resolve_cell_winners`,
+`apply_complex_deletions`, `shadow_by_row_deletion`, `filter_dropped_columns`, `expire_ttl_cells`,
+`purge_gc_grace`, `build`) for **every** cluster, including a lone Live row. So there is real machinery
+to skip. **But the fast-path precondition is narrow and self-defeating:** to fire safely it must prove
+*singleton Live AND no row/complex/range deletion AND no expiring/TTL cell (else `expire_ttl_cells`
+must run) AND no dropped columns (else `filter_dropped_columns` must run) AND correct #2163/#1037
+tallies*. Checking all of that **approaches doing the work**; the real saving is skipping
+`ReconcileState` construction + the per-`(column,cell_path)` winner map. On field data the fixtures
+**deliberately keep TTL seams** (`test_basic.ttl_test_table`, `test_da.ttl_table`, MEMORY #1935), and
+real nodes have genuine overlap/tombstones — those clusters **never hit the fast-path**. Revised:
+**~1.20× disjoint-narrow-no-TTL upper bound; ~1.03–1.08× or lower on field-shaped data** (the doc's own
+concession, and I'd push it toward the low end). Parity risk **HIGH**; `--lite`-provable only via §3.4.
+
+### L4 — `RowKey` Arc hoist (#1883) → **SURVIVES (re-scoped)**
+Mechanics verified (§1). **The multiplier is governed by rows-per-partition (clustering fan-out), NOT
+row byte-width** — P1.1 conflates the two. In the narrow keyvalue shape (1 row/partition) hoisting the
+Arc build outside `for entry in rows` saves nothing on alloc *count* (one Arc/partition == one
+Arc/row) — **NEUTRAL**, as P1.1 says. But the same is true of **any single-row-partition table
+regardless of width**: a 180 B wide row that is the *only* row in its partition gets **1.0× from L4**.
+L4 pays **only** when partitions carry many clustering rows (amortize the PK Arc over N rows).
+**~1.05–1.09× for multi-row-partition tables only.** Whether the field is multi-row-per-partition is
+**unknown from the Phase-0 profile** — do not assume it. Cheap, low-risk; keep under #1883, but do not
+credit it in the narrow stack and do not assume a field win.
+
+### L5 — FxHash `row_values` map → **SURVIVES**
+Target confirmed genuinely still SipHash (§1, §6). ~1.04× narrow & wide, near-free, accepted precedent
+(#1590/#1817). Note stands that a `SmallVec` beats any HashMap for a 2–3-column row (M-cost follow-on).
+
+---
+
+## 5. (folded into §4)
+
+---
+
+## 6. The #1817 "FxHashMap row map" reconciliation (why L5 is not already done)
+
+`#1817`'s commit subject reads *"internal FxHashMap row map"*, which would kill L5 if it meant
+`row_build.rs:246`. It does not. Reading the diff and the current tree: the FxHashMap `#1817` added is
+the **per-partition LIMIT counter** — `type PartitionCounts = rustc_hash::FxHashMap<u128, …>`
+(`select_executor/mod.rs:167-173`, *"FxHashMap on the hot PER PARTITION LIMIT counter map"*), keyed on
+a `u128` partition token. The per-**row** `HashMap<Arc<str>, Value>` at `row_build.rs:246` is still
+`std::collections::HashMap` (default SipHash), and `build_row_from_scan_cached` (`row_build.rs:227`,
+containing :246) **is** the function `cqlite-flight/producer.rs:entry_to_row` calls on the hot scan
+path. So L5's target is real and un-optimized; the precedent it cites is genuine; there is no overlap.
+
+---
+
+## 7. The double-count ruling (L1 vs parallelism/#2680 vs #2765)
+
+**Ruling: no naive double-count, but three specific compositions are illegitimate.**
+
+1. **L1 × #2680 as independent aggregate throughput multipliers — ILLEGITIMATE.** They move different
+   terms of P1.6's `per_pod = min(N_admitted, N_drain_sat, N_mem) × per_stream × C(N)`:
+   L1 raises `C(N)`/`N_drain_sat`/`per_stream`; **#2680 only rebalances the cross-pod width and
+   contributes ZERO throughput on a single pod** (its 2–4× is *stranded-utilization recovery on lagging
+   pods*, a skew fix, not a ceiling lift). So `1.9× (L1) × 3× (#2680) ≈ 5.7×` is wrong on two counts:
+   on one pod #2680 = 1.0×, and across pods L1's ceiling-lift and #2680's laggard-recovery **overlap in
+   the same aggregate qps** (once L1 lifts every pod's ceiling, there is less stranded work for #2680 to
+   recover). Credit them as: `aggregate ≈ Σ_pods [ per_stream(with L1) × min(width, N_drain_sat↑L1) ]`,
+   with #2680 flattening the per-pod `min(...)` spread — **not** a scalar product.
+
+2. **L1's "1.9× utilization" AND "raise N_drain_sat" as two wins — ILLEGITIMATE.** They are the same
+   lever (P1.1 L1 ≡ P1.6 L6). Count once.
+
+3. **L1 vs #2765 — same channel, so NOT a throughput double-count but a mandatory co-design.** They hit
+   the same fan-in `sync_channel` on orthogonal axes (syscall-count vs memory-depth); their *throughput*
+   contributions don't overlap, but their *implementations collide* on the capacity constant (§3.3).
+   P1.1's "orthogonal, different channel, don't conflate" is the right no-double-credit verdict via a
+   wrong mechanism — restate it as "same channel, co-design required."
+
+The **outer Arrow egress channel** (`DO_GET_CHANNEL_CAPACITY`, 57,344 rows) is the only genuinely
+independent one, and it is the memory-dominant term P1.6 flags for admission re-sizing — untouched by
+any L1–L5 lever.
+
+---
+
+## 8. The field-shape (wide-row) governing multiplier for the stack
+
+**The field multiplier is the WIDE-ROW single-stream number ~1.05–1.15×, and honestly a touch below
+it.** Reasoning, brutally:
+
+- Phase-0's 49.9 % Stage-4b share is the **narrow + uncompressed + loopback + 1-row/partition extreme**
+  (Phase-0 §5 caveats 1/3/4). Every field departure **shrinks the share L1/L2/L3 attack**:
+  compression adds a real Stage-1 decompress-CPU stage (caveat 1), wider rows add Stage 2/3/5 (caveat
+  4), real network adds Stage-6 transport CPU (caveat 3). All three dilute 4b/4a.
+- **L3 singletons vanish** with clustering keys + real TTL/overlap; **L2 goes ≤1.0×** as decode grows;
+  **L1's park/wake share shrinks** as the coordinator does more real per-row work. **L4 becomes the one
+  lever that can *gain* on the field** — but only if partitions are multi-row (§4), which the profile
+  cannot tell us. **L5 holds at ~1.04×** (per-row map is per-row regardless of shape).
+- So the narrow-shape headline numbers — **2.36× aggregate / 1.56× (or 1.9× w/ L2) single-stream** —
+  are **rig-shape upper bounds, not field predictions**, exactly consistent with phase1-8's envelope
+  (row-pipeline 150–450 k rows/s/core; "600 k/pod is a post-fix target, gated on the merge-coordination
+  fix, not a property of shipped code") and P1.6's "utilization levers cannot move `per_stream`."
+
+**Governing field multiplier for the L-stack on the per-stream ceiling: ~1.05–1.15×**, with L1's
+`C(N)`/`N_drain_sat` utilization win as the component that best survives to the field (park/wake
+contention is genuinely worse under concurrent field load) — but that is a **per-pod utilization**
+recovery, not a per-stream-ceiling gain, and it too is diluted by compression/transport CPU the rig
+cannot see. Anyone quoting a field number north of ~1.15× on the per-stream ceiling from these five
+levers is laundering the rig's narrow shape.
+
+---
+
+## 9. Summary packet
+
+**Per-lever:** L1 **SURVIVES-weakened** (util 1.5–1.9× rig-narrow ceiling; single-stream ~1.1–1.25×
+narrow / ~1.05–1.1× wide, unmeasured; cost = co-design with #2765 on the *same* fan-in channel + cut
+message-capacity for B4 + keep #2419 gauge/#2361 cancel-recv). L2 **SURVIVES narrow-only, A/B-gated**
+(~1.4–1.8× narrow, ≤1.0× wide — not credited in the field stack). L3 **WEAKENED** (~1.20× disjoint-
+narrow-no-TTL upper bound, ~1.03–1.08× field; HIGH parity risk; query-semantics + point-vs-full oracles
+load-bearing; `--lite`-provable only if the diff extends those test files). L4 **SURVIVES re-scoped**
+(1.05–1.09× *only* for multi-row-partition tables; 1.0× for single-row-partition of any width; win
+governed by clustering fan-out, unknown from the profile). L5 **SURVIVES** (~1.04×; target confirmed
+still SipHash; #1817's FxHashMap was a different, per-partition map).
+
+**Code-claim audit:** all four line-level claims true; the P1.1 SipHash re-attribution
+(PartitionKeyCache does no hashing → `row_build.rs:246` is the real site) is **correct**.
+
+**Double-count ruling:** L1 and #2680 attack different formula terms and are NOT a naive product — but
+you may **not** multiply L1's 1.9× by #2680's 2–4× (on one pod #2680 = 1.0×; across pods their gains
+overlap in aggregate qps), and L1's "1.9× util" is the same lever as P1.6's L6 (count once). L1 and
+**#2765 hit the SAME fan-in channel** (P1.1's "different channel/orthogonal" is factually wrong) — no
+throughput double-count but a mandatory co-design on the shared capacity constant. The outer 57,344-row
+Arrow egress channel is the only independent one and is untouched by L1–L5.
+
+**Field governing multiplier for the stack: ~1.05–1.15× on the per-stream ceiling** (wide-row number
+governs, further diluted by compression + transport CPU the rig can't see). The narrow 1.56–2.36×
+figures are rig-shape upper bounds, not field predictions.

--- a/docs/research/phase2-verify-stage2.md
+++ b/docs/research/phase2-verify-stage2.md
@@ -1,0 +1,336 @@
+# Phase 2 — Adversarial adjudication of the Stage-2 question (≥600k rows/s/pod)
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Author:** Phase-2 adversarial adjudicator
+**Scope:** READ-ONLY. Anchored to Phase 0 (`phase0-scan-cost-breakdown-2026-07.md`) and the Phase-1
+memos (`phase1-1`…`phase1-8`). The reconcile cost claims are read off the code
+(`cqlite-core/src/storage/write_engine/merge/reconcile.rs`, `.../merge/mod.rs`).
+
+> **The one-line verdict.** On a **fixed row pipeline** (the per-row channel deleted, alloc
+> controlled, splits parallelized), a 4-vCPU pod lands **~360–500k rows/s/pod central, ~240–670k
+> across the honest band**. That makes **B3 Stage 2 (≤3 s through Trino ≈ 216–323k rows/s/pod)
+> REACHABLE-AT-COST on a row feed** — overruling Phase 1-7 — with the limiting factor moved off the
+> row engine onto **the Trino coordinator floor + cold-start latency inside the 3 s budget**. It
+> makes **A4 Stage 2 (600k rows/s/pod server-direct) NOT reliably reachable** on the pure row engine
+> — reachable only at the optimistic corner — with the limiting factor being **C(N): a 4-vCPU pod is
+> 2 physical cores + hyperthreads, not 4× parallelism**, plus reconcile machinery. **Columnar option
+> (a) does NOT earn a 0.17 slot on throughput grounds** — it is Stage-3 prep behind the row levers.
+
+---
+
+## 0. Packet (read this, then the audit backs every number)
+
+| Target | Per-pod requirement | Verdict | Limiting factor |
+|---|---|---|---|
+| **Stage 1** (A4 100k / B3 ≤10 s ≈ 65k) | 65–100k rows/s/pod | **REACHABLE** | none binding; L1 batch-channel + fan-out clears it comfortably |
+| **B3 Stage 2** (≤3 s through Trino) | **216k** (no floor) → **323k** (1 s floor) → 647k (2 s floor) | **REACHABLE-AT-COST** (row feed) | **NOT the row engine** — the Trino coordinator floor eating the 3 s budget + cold-start IO latency; needs floor ≤ ~1.2 s AND warm/prefetched IO AND L1/L3 landed |
+| **A4 Stage 2** (server-direct) | **600k rows/s/pod = 150k/core** | **NOT reliably reachable** on the pure row engine (optimistic-corner only) | **C(N) < 4** (4 vCPU = 2 physical + HT → ~2.5–3.5× effective) + reconcile machinery (measured ~2 µs/row) |
+
+**Surviving multiplier stack (bottom-up from the fixed single-thread pipeline; the honest band):**
+
+```
+Fixed M1 single-thread pipeline (channel deleted)      285k rows/s/core   (P1.2, 3.5 µs/row)
+  ÷ field derate  1.5–3×  (central 2×)                → 95–190k /core  (central 143k)
+  × C(N) on 4 vCPU  2.5–3.5×  (central 3×)            → 238–670k /pod   (central ~420k)
+                                                         ├─ A4 Stage 2 600k: only the optimistic corner
+                                                         └─ B3 Stage 2 216–323k: cleared at central
+```
+
+**The derate I will defend: ~1.5–3× (central 2×)** — **NOT** Phase 1-2's 3–5×. Decomposed in §1.
+**The C(N) I will defend: 2.5–3.5× (central 3×)** — **NOT** the flat 4× both Phase 1-2 and Phase 1-7
+assumed. Decomposed in §3.
+
+---
+
+## 1. Audit of the field derate — is 3–5× evidenced or hand-waved?
+
+Phase 1-2 §1.4 lists five derate factors and multiplies to **3–5×**. Auditing each against the code
+and the dedicated Phase-1 IO/parallelism agents, **the two largest stated components are overstated,
+and one is misattributed.** The defensible derate is **~1.5–3×.**
+
+### 1a. RF=3 reconcile "2–3× more input cells" — **OVERRULED (misattribution).**
+
+Phase 1-2 makes RF=3 the big term: *"reconcile ~2–3× more input cells to compare/shadow across
+replicas×gens."* **This conflates a cross-node/connector concern with a per-node one.**
+
+- **What the reconcile actually costs, from the code.** `resolve_cell_winners`
+  (`reconcile.rs:191`) iterates **every `MergeEntry` in a clustering group and every cell in each**,
+  doing one `HashMap::entry()` + one `cell_wins()` compare per cell. Cost is **O(total input cells
+  across the entries that share a clustering key)** — i.e. it scales with **how many SSTable
+  generations on this node contain the same partition/row**, not with RF.
+- **RF=3 does not multiply per-node reconcile input.** A partition replicated to 3 nodes appears
+  **once per generation on each node's disk**, not three times on one node. The k-way merge inputs
+  are **this pod's SSTable readers** (`from_readers::drive_query_stream`), i.e. the local generations
+  for the ranges this pod owns. RF governs *how many nodes hold a copy*, and the connector already
+  **pins each token range to one replica** (`CqliteFlightSplitManager.buildSplits`), so RF=3 is
+  deduplicated at plan time. Phase 1-5's factor table agrees: **RF=3 ≈ 1.0–1.2× (fan-out/coordination
+  only, not row work).** Phase 1-2's own memo even writes "replicas×gens" — the **×gens** is the real
+  term; the **replicas×** is the error.
+- **The real 4a derate is generation-overlap, and it is compaction-state-driven, single-digit,
+  bounded.** Phase 0 ran **4 SSTables with disjoint keys → every cluster is a singleton** (1 entry),
+  so it measured the *floor* of reconcile. Field data has genuine overlap (updates, tombstones,
+  TTL), so a hot partition may sit in `k` generations. But `k` is **bounded by the compaction
+  strategy**, not RF: LCS ≈ 1 overlapping SSTable per level; STCS ≈ a handful of size tiers.
+  Append-only/time-series (the R12 `easy_stress` shape) ≈ 1 (no overlap). So the 4a derate is
+  **~1× (append-only) to ~1.5–2.5× (update-heavy) on the 32.5% reconcile slice ⇒ ~1.1–1.5× overall**,
+  not a blanket 2–3×.
+
+**Verdict:** RF=3 is **not** a reconcile multiplier. Replace Phase 1-2's "RF=3 → 2–3×" with
+"generation-overlap → 1.1–1.5× overall, corpus-dependent, ~1× on the append-only R12 corpus."
+
+### 1b. LZ4 decompress — **OVERRULED (overstated by both P1.2 and P1.5).**
+
+- Phase 1-2: *"single-digit-to-low-double-digit %."* Phase 1-5: **"1.3–2×."** Both are wrong high.
+- **Phase 1-3 — the agent who actually modeled it — says LZ4 decode adds `~0.1%–1%` CPU** and the
+  engine "stays CPU-bound on the Phase-0 per-row coordination." Independent per-row check: ~40–50 B
+  packed/row ÷ LZ4 decompress ~2–3 GB/s ≈ **16–25 ns/row** against a ~3.5 µs/row pipeline ≈ **~0.5–1%
+  ⇒ ~1.01×.** Even a pessimistic 1 GB/s LZ4 is ~1.4%.
+- **Verdict:** LZ4 derate ≈ **1.01–1.05×**, negligible. Phase 1-5's 1.3–2× must not enter the stack.
+
+### 1c. Wide-row per-cell decode/materialize — **UPHELD, but do not double-count it.**
+
+decode (9.7%) + materialize (4.5%) + arrow (1.0%) + per-cell alloc scale with **cells/row**, and so
+does reconcile (`resolve_cell_winners` is per-cell). A field row with 4–8 cells vs the profiled 2
+cells is genuinely ~1.5–2.5× heavier per row. **BUT:** the R12 field baseline (10.6k rows/s/pod) was
+measured on the **narrow 2-column `easy_stress.keyvalue` corpus** — the *same shape* as Phase 0. So
+for the corpus that actually anchors the goal, the wide-row derate is **~1×**. Wide-row derate only
+bites if the target corpus is wider than R12; if you invoke it, you must also lower the rows/s target
+proportionally (wide rows are fewer rows at the same MB/s). **In the bottom-up stack it is ~1× for
+the R12 shape; carry it only as an explicit, corpus-named factor, never as a silent 2×.**
+
+### 1d. Slower cores (M1 → i4i.xlarge vCPU) — **UPHELD (~1.3–1.5×), and it hides a bigger issue (see §3).**
+
+An i4i.xlarge vCPU is **one hyperthread of an Ice Lake core**; M1 Pro is a wide ~3.2 GHz core. Single-
+thread M1-vs-one-Ice-Lake-vCPU ≈ **1.3–1.5×**. Defensible as stated. The trap is not the per-core
+speed — it is that "4 vCPU" is **2 physical cores** (§3).
+
+### 1e. Cold cache — **RECLASSIFIED: a latency term, not a throughput derate.**
+
+Phase 1-2 lists cold cache as "IO-wait (wall, not CPU)." Phase 1-3 (dedicated) is sharper: **cold
+sequential bandwidth needed is ~10–350 MB/s, an order of magnitude under i4i NVMe; IO never becomes
+the throughput binding constraint below row rates far above 600k.** Cold IO owns exactly **cold-start
+*latency* (the B4 ≤3 s goal)**, which matters for the ≤3 s B3 Stage-2 budget (§2) but is **not a
+sustained-throughput multiplier**. Remove it from the throughput derate; carry it as a latency risk
+against the B3 3 s budget.
+
+### 1f. Reconstructed derate
+
+| Factor (P1.2) | P1.2 stated | Adjudicated | Basis |
+|---|---|---|---|
+| RF=3 reconcile | 2–3× | **1.1–1.5× (gen-overlap, not RF)** | reconcile.rs:191 is per-node-per-cell; connector pins 1 replica (P1.5) |
+| LZ4 | single→low-double-digit % | **1.01–1.05×** | P1.3 (0.1–1%); per-row math |
+| Wide rows | included | **~1× on R12 corpus** (else explicit) | R12 = narrow keyvalue = Phase-0 shape |
+| Slower cores | 1.3–2× | **1.3–1.5×** | M1 vs 1 Ice-Lake HT |
+| Cold cache | in derate | **removed** (→ latency term) | P1.3: IO not throughput-binding < ~600k |
+| **Product** | **3–5×** | **~1.5–3× (central 2×)** | |
+
+Phase 1-2 reached roughly the right *answer* (240–400k/pod) partly by canceling two errors: an
+**inflated derate (3–5×)** against an **inflated C(N) (perfect 4×)**. Correcting both — derate down
+to 1.5–3×, C(N) down to 2.5–3.5× — lands in the **same band (central ~420k)** with defensible parts.
+
+---
+
+## 2. B3 Stage-2 arithmetic — and why Phase 1-7's central verdict is OVERRULED
+
+Phase 1-7 declared **"B3 Stage 2 ≤3 s NOT credible on a row feed."** Its reasoning was
+"215k/pod = 54k rows/s/core = ~1.6 µs/row = vectorized territory." **Phase 1-2 already caught the
+first half of the error** (1.6 µs/row conflates pod and core). Re-deriving with the correct per-core
+framing **inverts the conclusion.**
+
+- **B3 Stage 2's per-pod bar is LOWER than A4 Stage 2's.** ≤3 s for the R12 scan (1.94M rows, 3 pods)
+  = **216k/pod** (no Trino floor) → **323k/pod** (1 s floor) → 647k/pod (2 s floor). Per core (÷4):
+  **54–81k/core = 12.4–18.6 µs/row/core** at floors ≤1 s. That is **more generous** than A4 Stage 2's
+  6.67 µs/row/core.
+- **The fixed field-derated row pipeline does 95–190k rows/s/core (5.3–10.5 µs/row/core).** That
+  **exceeds** B3 Stage 2's 54–81k/core requirement at floors ≤1 s. **The row engine per-core rate is
+  not the binding constraint** — Phase 1-7 named the wrong limiter.
+- **What actually gates B3 Stage 2 ≤3 s:**
+  1. **The Trino coordinator floor (0.2–2 s) eating the 3 s budget.** At a ~2 s floor only 1 s of
+     scan remains → 647k/pod needed → A4-Stage-2-hard. At ~0.5–1 s floor → 260–323k/pod → cleared by
+     the central pipeline. **This is the swing factor, it is measurable, and it is a Trino/plan-shape
+     property, not a row-engine property.**
+  2. **Cold-start IO latency inside the 3 s budget** (§1e / P1.3: cold start is the one thing IO owns;
+     the B4 ≤3 s cold-start goal exists for exactly this). A cold first scan can spend seconds before
+     rows flow; that competes with the Trino floor for the budget. Sustained bandwidth is fine.
+  3. **Achieving C(N) parallelism + fixed drain** (L1/L6 batch channel; §3).
+
+**Adjudicated B3 Stage 2 verdict: REACHABLE-AT-COST on the row feed**, gated on (a) Trino floor
+≤ ~1.2 s for this scan shape, (b) warm/prefetched IO so cold-start latency does not consume the
+budget, (c) L1 batch-channel + fan-out-past-drain landed. **The limiting factor is the Trino floor +
+cold-start latency, NOT "the row engine can't do 54k/core."** Phase 1-7's structural framing (Trino
+is a *latency floor*, the row *feed* is the throughput ceiling — not Trino-the-tax) is **upheld and
+is the best framing in the set**; only its Stage-2 feasibility call is overruled.
+
+*(Stage-1 B3 ≤10 s ≈ 65k/pod is reachable with margin — uncontested across all agents.)*
+
+---
+
+## 3. C(N) on a 4-vCPU pod — the factor both P1.2 and P1.7 got wrong
+
+Both memos wrote "4 vCPU → 4×." **Two independent reasons it is not 4×:**
+
+1. **An i4i.xlarge is 2 physical cores.** AWS vCPU = one hyperthread; 4 vCPU = 2 Ice-Lake cores with
+   SMT. Two physical cores give ~2×; the two extra hyperthreads add ~0.5–0.75× **only** because the
+   reconcile is pointer-chasing (HashMap `winners`, BinaryHeap `refill_heap`) and thus
+   latency-bound/SMT-friendly. Net **~2.5–3.5× effective, central ~3×** — never 4×.
+2. **Phase 1-6's measured saturation.** P1.6's model is
+   `per_pod = min(N_admitted, N_drain_sat≈8, N_mem≈20) × per_stream × C(N)`, with **C(N) ≤ 1 and
+   falling**, and it states outright: *"the width is ~8 (drain-bound), not 4 vCPU × anything… 4
+   streams ≠ 4× because Phase-0's 55% kernel park/wake tax contends."* On **today's** code the pod
+   is **drain-capped well below core count** (and a 4-vCPU pod's `N_drain_sat` is *lower* than the
+   10-core local rig's 8). The **only lever that raises both `N_drain_sat` and `C(N)` is L6/L1 —
+   batching the per-row fan-in `sync_channel`** (Phase 0 finding #1). So the entire "fixed row
+   pipeline parallelizes" premise **depends on L1 landing**; without it, naive 4× fan-out just
+   deepens the #2600 egress queue.
+
+**Reconciling Phase-0's 55% kernel with C(N):** the 55% kernel park/wake is a *single-stream artifact
+of thread-per-input*. Delete the per-row channel (inline/batched merge, L1/L2) and it collapses, so
+C(N) is **not** bounded by that 55% *once fixed* — it is then bounded by the 2 physical cores + SMT.
+This is why the fix and the scaling are the same work: **L1 batch-channel is simultaneously the
+biggest single-stream lever (49.9% stage 4b) and the thing that makes C(N) approach ~3× instead of
+<1.**
+
+**Defended C(N): 2.5–3.5×, central 3×, and only post-L1.** Pre-L1 the pod is drain-capped and worse.
+
+---
+
+## 4. Audit of Phase 1-8's "150k/core is ⅓-of-Scylla, credible" — UPHELD per-core, OVERRULED as a pod given
+
+- **Per core, 150k/core is defensible and conservative.** It is ~⅓ of Scylla's ~428k/core LSM rate
+  and ~⅓ of CQLite's own measured 500k single-stream. The fixed field-derated pipeline (§0) brackets
+  it (95–190k/core). Phase 1-8's per-core *envelope* (150–450k/core narrow) is **upheld**.
+- **But ⅓-of-Scylla is a *generous* comparison, and Phase 1-8 says so itself.** Scylla's 428k/core is
+  **aggregation pushdown — it never materializes or ships a row.** CQLite materializes every cell,
+  reconciles k-way with tombstones, Arrow-encodes, and ships every row. So Scylla is an **upper
+  bound**, not a peer rate; "⅓ of an upper bound" is not the same as "⅓ of a comparable workload."
+  The per-core number survives on CQLite's *own* Phase-0 evidence (500k measured, ~⅔ of it deletable
+  waste), not on the Scylla analogy — the Scylla line is corroboration, not proof.
+- **What Phase 1-8 under-weights: the pod product.** It flags "the risk is scaling to 4 concurrent
+  cores" but does not quantify it. Quantified (§3): **150k/core × C(N) 2.5–3.5 = 375–525k/pod
+  central**, i.e. **short of 600k at the center**, reaching it only at the optimistic corner. So
+  Phase 1-8's "**600k/pod credible and conservative**" is downgraded to "**150k/core credible; 600k/pod
+  is the optimistic corner, ~400–450k/pod central, because 4 vCPU is 2 physical cores.**"
+
+**A4 Stage 2 verdict: NOT reliably reachable on the pure row engine.** Central ~420k/pod; 600k needs
+the optimistic corner (derate ~1.5×: narrow + append-only + warm; C(N) ~3.5×: good SMT scaling; all
+row levers landed). Limiting factors, in order: **C(N) < 4** (structural, 2 physical cores) and
+**reconcile machinery** (§5). Columnar helps least here (§6).
+
+---
+
+## 5. The reconcile constant and the #2043 (WS7) harvest claim — PARTIALLY OVERRULED
+
+Phase 1-2 §3.3 says the whole Stage-2 arithmetic hinges on #2043 pinning the k-way-merge ns/row,
+today an **`[ASSUMED]` 10–500 ns/row** (25–50× blind spot). **Phase 0 already pins the base
+constant** — and it is *higher* than the assumed range:
+
+- reconcile 4a = **50.0 CPU-s / ~25M rows ≈ 2.0 µs/row**, on **narrow disjoint singleton clusters**
+  (Phase 0's data has no overlap). The coordinator's whole critical path is ~2.0–2.5 µs/row (= the
+  500k ceiling). For singletons, that 2 µs/row is **`ReconcileState` machinery**
+  (`ReconcileState::new` per cluster, the `winners` HashMap, the `order` Vec — `reconcile.rs:156–180`)
+  **not comparison work** — which is exactly what Phase 1-1's L3 singleton fast-path targets. The
+  `[ASSUMED]` 10–500 ns/row was the *merge-algorithm* cost; the real per-row cost is
+  machinery-dominated and an order of magnitude larger.
+- **So #2043 does NOT gate the base arithmetic** — Phase 0 measured it. **What #2043 *does* pin, and
+  what is genuinely unmeasured, is the OVERLAP multiplier on 4a** — reconcile ns/row when clusters
+  span multiple generations with real LWW/tombstone collisions (Phase 0 §5 caveat 5 is explicitly
+  blind to this). That overlap multiplier **is** §1a's residual uncertainty (the 1.1–1.5× I could
+  only bound, not measure).
+
+**Ruling:** #2043 is worth harvesting, but **reframe its deliverable**: it must pin **the overlap
+multiplier on reconcile at field compaction state**, not "the 10–500 ns/row base" (already ~2 µs/row
+measured, machinery-dominated). That single number would tighten §1a's 1.1–1.5× — the last soft spot
+in the derate — and would tell you whether L3 (singleton fast-path) or an overlap-path optimization
+is the higher-value reconcile lever. Route it into the #2605 report as Phase 1-2 recommends.
+
+---
+
+## 6. Ruling on the 0.17 columnar-producer increment (P1.2 option (a)) — DOES NOT earn the slot
+
+**Ruling: the scoped columnar scan producer is NOT a 0.17 throughput lever. It is Stage-3 prep and
+should wait behind the row-engine levers and behind sharpened #2605 data.**
+
+Multiplier-per-effort, on the R12 (narrow) regime that anchors the goal:
+
+| Lever | Multiplier | Cost | Attacks | Verdict |
+|---|---|---|---|---|
+| **L1 batch fan-in channel** (P1.1) | **1.9× util / 1.15–1.35× single**, and raises C(N) | **M** | 49.9% stage 4b — the biggest line | **#1 — do first**; it is the prerequisite for C(N) and for any fan-out |
+| **L3 reconcile singleton fast-path** (P1.1) | 1.20× single | M–L | the **measured ~2 µs/row machinery** (§5) — the true ceiling once L1 lands | **#2** — highest-value ceiling lever |
+| **L5 FxHash + L4 RowKey hoist** (P1.1) | ~1.1× bundle | S | SipHash 4.5% + alloc | near-free warm-up bundle |
+| **Columnar option (a)** (P1.2) | **1.0–1.1× narrow / 1.5× wide** | **M** | materialize 4.5% + transpose + PK-copy alloc | **defer** — see below |
+
+- **On the narrow R12 corpus columnar is ~1.05×** — worse multiplier-per-effort than L1 (1.9×/M) and
+  than L3 (1.2×/M–L), for the same M cost. It reaches 1.5× only on **wide** rows, which are precisely
+  the rows with a *lower* rows/s baseline — so it does not reliably close the **rows/s** A4 Stage-2
+  gap.
+- **It touches neither of the two dominant costs** — the 49.9% channel (L1's) nor the ~2 µs/row
+  reconcile machinery (L3's/§5). It deletes materialize (4.5%) + transpose + one alloc. That is real
+  but secondary, exactly as the ladder places full columnar at **Stage 3**, above Stage 2.
+- **The one honest argument *for* pulling it early is architectural, not throughput:** it banks the
+  bounded-stream + byte-cap plumbing (#1907) that #941-A3 needs. That is a #941-de-risking rationale,
+  not a Stage-2 rationale, and should be scheduled as such if at all.
+
+**Sharpened trigger (supersedes "just build it"):** give the increment a 0.17 slot **only if** the
+sharpened #2605 PoC shows the **decode-to-column delta, isolated from the vectorized-exec delta, on a
+wide-and-overlap-shaped corpus (not RF=1 narrow), exceeds ~1.3×** while staying under B4 512Mi
+byte-bounded. Absent that data it is Stage-3 prep. This matches Phase 1-2's own §3.2 sharpening asks;
+I am making the *slot* conditional on them, not just the measurement.
+
+---
+
+## 7. What I overruled in each of the three positions
+
+**Phase 1-8 (prior art — "600k/pod credible, 150k/core ≈ ⅓ Scylla").**
+- **Upheld:** the per-core envelope (150–450k/core narrow); that 150k/core is unexotic per core.
+- **Overruled:** "600k/pod credible and conservative." Quantifying the 4-concurrent-core risk it only
+  gestured at gives **~400–450k/pod central** (4 vCPU = 2 physical cores + SMT, C(N) ~3, not 4).
+  600k/pod is the optimistic corner.
+- **Tempered:** the ⅓-of-Scylla defense — Scylla is an *upper bound* (aggregation pushdown, no row
+  ship), so it corroborates but cannot *prove* the per-core rate; CQLite's own 500k-with-⅔-waste is
+  the real evidence.
+
+**Phase 1-2 (columnar — "240–400k, likely short; columnar 1.2–1.5×").**
+- **Upheld & credited:** the headline (Stage 1 easy, Stage 2 likely short; columnar is not the unlock;
+  reconcile is the dominant field cost), and the catch that Phase 1-7 conflated pod and core.
+- **Overruled — derate decomposition:** "RF=3 → reconcile 2–3× input cells" is a **misattribution**
+  (reconcile.rs is per-node-per-cell; RF is deduped by the connector's one-replica pin; the real term
+  is compaction generation-overlap, ~1.1–1.5×). "LZ4 single-to-low-double-digit %" is **overstated**
+  (P1.3: 0.1–1% ≈ 1.01×). Net derate **1.5–3×, not 3–5×**.
+- **Net:** same answer band (~240–400k → I get ~240–670k, central ~420k) via corrected parts — its
+  3–5× derate was canceling its optimistic 4× C(N).
+
+**Phase 1-7 (Trino — "B3 Stage 2 ≤3 s NOT credible on a row feed").**
+- **Upheld:** the structural reframing (Trino = latency floor; the row *feed*, not Trino, is the
+  throughput ceiling) — the best framing in the set — and B3 Stage 1 ≤10 s reachable.
+- **Overruled — the B3 Stage-2 feasibility call and its named limiter.** 215–323k/pod is
+  **54–81k rows/s/core = 12–19 µs/row/core**, which the fixed field-derated pipeline (95–190k/core,
+  5–10 µs/row/core) **exceeds**. The row engine per-core rate is **not** the binding constraint; the
+  real gates are the **Trino coordinator floor + cold-start latency inside the 3 s budget** + landing
+  L1/parallelism. B3 Stage 2 is **reachable-at-cost on a row feed**, not "not credible."
+- **Also overruled (shared with P1.2's catch):** the "1.6 µs/row = vectorized territory" framing —
+  it silently assumed a single-thread pod.
+
+---
+
+## 8. Bottom line for the program
+
+1. **A4 Stage 2 (600k rows/s/pod server-direct): plan for ~400–450k/pod on the pure row engine, not
+   600k.** The gap is **C(N)** (2 physical cores) + reconcile, not Arrow encode and not the container.
+   If 600k/pod is a hard requirement, the honest levers are (a) the row levers to the optimistic
+   corner *and* (b) either wider pods (more physical cores) or the columnar increment **on wide rows**
+   — accept that no single lever closes it on the narrow corpus.
+2. **B3 Stage 2 (≤3 s through Trino): pursuable on the row feed** — but the deliverable is **measure
+   the Trino coordinator floor and the cold-start latency for this scan shape first.** If the floor is
+   ≤ ~1.2 s and IO is warm, the central pipeline (L1 + L3 + fan-out) clears 216–323k/pod. If the floor
+   is ~2 s, only the optimistic corner clears it. **This is a Trino/IO measurement, not a
+   row-vs-columnar decision.**
+3. **Sequence: L1 (batch fan-in channel) → L3 (reconcile singleton fast-path) → fan-out-past-drain
+   (gated on #2765).** L1 is both the biggest single-stream lever and the enabler of C(N); nothing
+   scales without it.
+4. **#2043/WS7: harvest, but repoint it** at the reconcile **overlap multiplier** (the base is already
+   measured at ~2 µs/row, machinery-dominated).
+5. **Columnar option (a): defer past 0.17 as a throughput lever**; revisit only as #941/#1907 plumbing
+   or on sharpened #2605 data showing an isolated decode-to-column delta >1.3× on a wide/overlap
+   corpus.
+
+**File left uncommitted per instructions:**
+`/Users/patrickmcfadin/local_projects/cqlite/docs/research/phase2-verify-stage2.md`

--- a/docs/research/phase2-verify-transport.md
+++ b/docs/research/phase2-verify-transport.md
@@ -1,0 +1,256 @@
+# Phase 2 — Adversarial verification of the transport/connector levers (T1–T6)
+
+**Date:** 2026-07-21 · **Status:** research (uncommitted) · **Agent:** Phase-2 adversarial verifier (transport/connector)
+**Target:** `docs/research/phase1-5-transport-ingest.md` (levers T1–T6)
+**Calibration:** `docs/research/phase1-8-prior-art.md`, `docs/research/phase1-6-parallelism.md`, `docs/research/phase0-scan-cost-breakdown-2026-07.md`
+**Mode:** READ-ONLY. No build was run. Every code claim below was re-checked at `file:line`; every version claim is read
+off `Cargo.lock` / `trino-connector/build.gradle.kts`. API-contract claims (h2, grpc-java, Trino SPI, Arrow-Java) are
+labelled **[API-CONTRACT]** and pinned to the resolved dependency versions.
+
+---
+
+## 0. Verdict summary
+
+| # | Lever | Phase-1.5 claim | **Verdict** | Revised pod multiplier |
+|---|-------|-----------------|-------------|------------------------|
+| **T1** | Near-zero-copy `ArrowToTrino` page build | 10–20× page-build CPU; **1.5–3× stream throughput** | **WEAKENED (hard)** | **~1.0× today; ~1.1–1.2× only after the server per-stream ceiling is fixed.** Isolated-step 10–20× survives; the label "zero-copy" is wrong (a per-column copy is required) but the per-CELL→per-COLUMN distinction holds. |
+| **T2** | Async Java-side prefetch (double-buffer) | 1.3–2× | **WEAKENED (hard)** | **~1.0× today.** Fills stream idle time that is ~99.9% server-produce wait at field rates. Compounds with T1 post-fix; combined T1+T2 ≤ ~1.1–1.3×, not the doc's 2–6× product. |
+| **T3** | HTTP/2 window sizing ("1.47 MB batch = 22× the 64 KB window → BDP stall") | 1.5–3× (network-bound) | **KILLED** | **~1.0×.** Double kill: (a) the binding receive window is the **grpc-java client's, defaulting to 1 MiB with BDP auto-tuning**, not 64 KB; the tonic *server* window knob the doc names is the wrong flow-control direction for `do_get` egress. (b) Even a 64 KB window has ~8× headroom over the actual 0.78 MB/s per-stream field byte rate. |
+| **T4** | Byte-bounded batch sizing | 1.0–1.3× | **SURVIVES (minor)** | **~1.0–1.1×.** Real robustness win for wide rows; but the gRPC message-ceiling motivation is moot (Flight defaults `maxInboundMessageSize` high). Keep as a correctness/robustness lever, not a throughput one. |
+| **T5** | Opt-in Flight LZ4/ZSTD body compression | 1.3–2× (net-bound); ≤1× (CPU-bound) | **WEAKENED → conditional** | **~1.0× today; net-NEGATIVE for narrow rows.** Since T3 shows the link is *not* binding at current per-stream rates, compression's throughput case is empty today. Survives only as a latent WAN lever + a mild egress-buffer (B4) reducer. |
+| **T6** | Fan-out past drain (gated on #2765) | 2–5× (post-ceiling only) | **SURVIVES (as stated)** | Correctly gated and correctly ordered *last*. This verification reinforces: it must not precede the server-side ceiling fix. |
+
+**One-line program consequence:** the Phase-1.5 transport levers are aimed at the **last two links of the drain chain
+(network + Java page build), which are idle ~99.9% of the per-batch cycle at field rates.** The binding constraint is
+**server-side produce/drain** (cold IO + LZ4 decompress + the single-threaded merge coordinator + the per-row
+`sync_channel`, and the N_drain_sat≈8 egress saturation) — none of which any of T1–T5 touch. Ordering is not a nuance
+here; it is the whole finding.
+
+---
+
+## 1. Code + version claims re-verified (all TRUE)
+
+| Claim | Location | Status |
+|---|---|---|
+| `toPage`→`toBlock`→`writeValue` is a row-at-a-time per-cell `switch` dispatch | `ArrowToTrino.java:107–141` | **CONFIRMED** — `for (i<rowCount) { isNull(i); writeValue(...) }`; `switch(type)` re-decided every cell (`:123–140`). |
+| Varchar path calls `VarCharVector.get(i)` (per-cell `byte[]` alloc+copy), then `Slices.wrappedBuffer` | `ArrowToTrino.java:319–334` | **CONFIRMED, with a correction** — `Slices.wrappedBuffer(v.get(i))`: `v.get(i)` allocates+copies one `byte[]`; `wrappedBuffer` then **wraps (no second copy)**. So it is **1 alloc + 1 copy per varchar cell**, not "2 copies." The doc's "3.9 M `byte[]` allocs/scan" (allocations) is right; do not restate it as copy-bandwidth. |
+| Page source is a synchronous pull, no prefetch/double-buffer | `CqliteFlightPageSource.java:45–64`; `ReplicaFailoverStream.java:67–121` | **CONFIRMED** — `stream.next()` (blocks) → `toPage` → return, on the calling thread; the only `ExecutorService`/`CompletableFuture` in the connector is `SnapshotManager` (planning-time), not the drain path. |
+| Aggregate path fans out serially | `CqliteFlightAggregatePageSource.java:83–92` | CONFIRMED (off the B3 critical path; scalar scan governs). |
+| Flight body compression OFF | `streaming.rs:439–448` — `FlightDataEncoderBuilder::new().with_schema(...).build(...)`, no `.with_options(...)` | **CONFIRMED** → default `IpcWriteOptions` → `batch_compression_type: None`. The other `IpcWriteOptions::default()` (`service.rs:558`) is GetSchema-only. |
+| gRPC server sets only `max_concurrent_streams`; no window/frame tuning | `main.rs:101–104,128–131` | **CONFIRMED** — `Server::builder().max_concurrent_streams(...)` only; no `initial_stream_window_size`/`initial_connection_window_size`/`max_frame_size`. |
+| Java client builds FlightClient with no window/message/compression options | `CqliteFlightClient.java:101–103` | **CONFIRMED** — `FlightClient.builder(allocator, Location.forGrpcInsecure(...)).build()`; inherits Flight/grpc-java defaults. |
+| batch_size default 8192 | `main.rs:35–36` | CONFIRMED. |
+
+**Resolved versions (load-bearing for the API-contract rulings):**
+- **Rust server transport:** `cqlite-flight` → `arrow-flight 53.4.1` → **`tonic 0.12.3`** → **`h2 0.4.15`**, `hyper 1.10.0` (from `Cargo.lock`).
+- **Java connector transport:** `trino-connector/build.gradle.kts` → **Trino 481**, **arrow-java 19.0.0** (`flight-core:19.0.0`) → **`grpc-netty:1.79.0`**, **netty 4.1.130.Final**.
+
+---
+
+## 2. THE T3 AUTO-TUNE RULING (KILLED)
+
+The T3 claim rests on one premise: *the binding HTTP/2 window is 64 KB, so a 1.47 MB batch stalls at ~22 windows/batch,
+BDP-throttling each stream.* Two independent facts falsify it.
+
+### 2a. Flow-control direction: the tonic-server window knob is the wrong direction for `do_get`
+HTTP/2 flow control is **receiver-advertised and per-direction**. In a `do_get`, bulk data flows **server → client**. The
+window that limits how fast the tonic server may *send* is the window the **Java client advertises for receiving** — plus
+the client's `WINDOW_UPDATE`s. The tonic server's `initial_stream_window_size` / `initial_connection_window_size`
+(the knobs Phase 1.5 §5 says to raise) govern data the **server receives** (client → server), which for `do_get` is only
+the tiny Ticket. **[API-CONTRACT, h2 0.4.15]** `h2::server::Builder::initial_window_size` is documented as the window "for
+**received** data." **Raising it does nothing for `do_get` egress.** h2 on the send side needs no configuration — it emits
+DATA up to whatever the peer's window allows and honors incoming `WINDOW_UPDATE`s automatically.
+
+### 2b. The client window is not 64 KB — it is 1 MiB with BDP auto-tuning
+**[API-CONTRACT, grpc-java 1.79.0]** grpc-netty's `DEFAULT_FLOW_CONTROL_WINDOW = 1048576` (**1 MiB, 16× the assumed
+64 KB**), and grpc-java performs **BDP-based flow-control auto-tuning** (the `FlowControlPinger` / BDP-ping path) that grows
+the connection window from that floor toward the measured bandwidth-delay product. Auto-tuning is **on by default** and is
+disabled only when the application *pins* `flowControlWindow(int)`. Arrow Flight's `FlightClient.builder(...).build()`
+(`CqliteFlightClient.java:101–103`) does **not** pin it, so the connector's client runs at the **1 MiB floor with
+auto-tuning enabled**. So the receive window that actually governs `do_get` is ≥ 1 MiB and adaptive — the "64 KB → 22×"
+arithmetic is against a window that does not exist in this stack.
+
+The Rust `h2` side, for completeness, does **not** auto-tune (fixed 64 KB default, `initial_window_size` unset) — but per
+2a that default is on the irrelevant direction, so its non-auto-tuning is moot.
+
+### 2c. Even the strawman 64 KB would not bind at field per-stream rates
+Field per-stream throughput (Phase 1.5 §1a): 2.6 k rows/s × ~300 B/Arrow-row (Phase 1.8: 150 MB/s ÷ 500 k) ≈ **0.78 MB/s
+per stream**. A single 64 KB window tops a stream out near `64 KB / RTT`: **6.4 MB/s at a WAN-ish 10 ms**, 64–320 MB/s
+intra-rack. Actual demand 0.78 MB/s has **~8× headroom even against the pessimistic 64 KB / 10 ms ceiling.** The window is
+not the limiter; the **server produce rate** is. The window only becomes binding after the per-stream produce rate rises
+~10× **and** the deployment is high-RTT — both false today.
+
+**T3 ruling: KILLED as a near-term lever.** Reclassify as *latent, client-side, WAN-contingent*: if a future high-RTT
+deployment appears **and** the per-stream produce ceiling has already risen ~10×, the fix is to raise/confirm the
+**grpc-java client** window (or leave auto-tuning to do it) — **not** to set `initial_stream_window_size` on the tonic
+server. Revised multiplier **~1.0×** in every current field scenario.
+
+---
+
+## 3. THE T1 SPI-COPY RULING (WEAKENED; distinction holds, label is wrong)
+
+Two sub-questions from the attack brief.
+
+### 3a. Does `VarCharVector → VariableWidthBlock` force a copy? Yes — for *lifetime*, not for SPI/arena reasons.
+**[API-CONTRACT, Trino 481 SPI]** `io.trino.spi.block.VariableWidthBlock` has a public constructor
+`VariableWidthBlock(int positionCount, Slice slice, int[] offsets, Optional<boolean[]> valueIsNull)` that **retains the
+Slice by reference — it does not copy into a Trino arena.** There is **no** `AggregatedMemoryContext` reservation required
+to *construct* a Block: a scan `ConnectorPageSource` returns Pages and Trino accounts their `getRetainedSizeInBytes()`
+downstream; it is not obliged to pre-reserve from a memory pool the way a hash-build operator is. So **Trino's SPI does not
+forbid building a block from a foreign Slice**, and the current `getMemoryUsage()` returning 0 (`CqliteFlightPageSource.java:82`)
+is consistent with that.
+
+The forcing function is **buffer lifetime**, not accounting. The Arrow data buffer is off-heap, owned by the Flight
+`VectorSchemaRoot`, and **freed when `FlightStream.next()` advances or the stream closes.** A Trino Page/Block can be
+retained by operators (exchange buffers, hash tables) **long after** the `getNextSourcePage()` that produced it. A Slice
+*wrapping* the Arrow off-heap buffer would therefore be a **use-after-free**; a true zero-copy wrap needs explicit
+Arrow refcount retain/release plumbing tied to Block lifetime, for which Trino's Block lifecycle exposes no hook.
+
+### 3b. Does the per-CELL → per-COLUMN distinction survive the forced copy? YES.
+The safe implementation is a **bulk on-heap copy per column**:
+- **varchar:** `Slice.copyOf` the entire Arrow data buffer once (one memcpy/column/batch); the Arrow int32 offset buffer is
+  **directly reusable** — Arrow's cumulative-byte-offset semantics equal Trino `VariableWidthBlock`'s `int[] offsets`; copy
+  the validity into a `boolean[]`. This collapses **N per-cell `byte[]` allocations → 1 bulk copy** and **N per-cell
+  `switch` dispatches → 1**.
+- **fixed-width:** one bulk copy of the data buffer into the `int[]`/`long[]` backing an `IntArrayBlock`/`LongArrayBlock`
+  + one validity copy; little-endian on all field pods, no byte-swap.
+
+**So T1's load-bearing claim (per-cell → per-column) HOLDS.** What does **not** hold is the *name*: this is **not**
+"near-zero-copy," it is a **bulk per-column copy**. The same string bytes are still copied off-heap→heap; the win is
+**allocation count + dispatch elimination**, not copy-bandwidth reduction. Phase 1.5's own §2b memory-lifetime caveat and
+its lever-table risk note already say exactly this (bulk on-heap copy first, raw wrap "a later, riskier step") — the doc is
+internally honest; only the lever headline oversells. **The isolated page-build 10–20× is defensible** for the
+alloc-dominated narrow-text shape.
+
+### 3c. But the POD multiplier (1.5–3×) does NOT survive the ordering math.
+At field rates a stream delivers 2.6 k rows/s = one 8192-row batch **every ~3.15 s**. A pessimistic page-build (100 ns/cell
+× 8192 × 2 cols) ≈ **1.6 ms**, i.e. **~0.05 % of the per-batch cycle**; the other ~99.95 % is the Java thread **blocked in
+`stream.next()` waiting on the server** (cold IO + LZ4 decompress + single-threaded coordinator). Eliminating page-build
+entirely buys ~0.05 % at the pod. Phase 1.8 §3c states this outright: *"the CQLite producer, not the JVM page builder, is
+the real limiter."* **T1's 1.5–3× pod multiplier is not defensible at current field per-stream rates.** It materializes
+only *after* the server per-stream ceiling is raised ~100× (toward the ~500 k local ceiling), at which point a batch
+arrives every ~16 ms and page-build's ~1.6 ms is ~10 % of the cycle → T1 (+ prefetch) is worth **~1.1–1.2×**. Revised:
+**~1.0× today, ~1.1–1.2× post-server-fix.**
+
+---
+
+## 4. THE ORDERING RULING (worker-side vs server-drain) — the headline
+
+**Server-side first, decisively. Worker-side T1/T2 buy ≈0 until the server produce/drain ceiling is raised ~100×.**
+
+The drain chain (Phase 1.5 §0):
+```
+SSTable → decode → k-way merge → egress channel(#2600) → Arrow encode → gRPC write
+  → [network + HTTP/2] → FlightStream.next() → ArrowToTrino page build → Trino Page
+```
+Three independent Phase-0/1 measurements converge on **where the time is, and it is not the last two links**:
+1. **Phase 0:** server single-stream CPU is 55 % kernel `sync_channel` park/wake + 18 % alloc + 32 % coordinator merge
+   compute; Arrow encode 1 %, transport ≈0 %. The **single-threaded coordinator + per-row channel** is the per-stream
+   ceiling.
+2. **Phase 1.6 §4:** throughput saturates at **N_drain_sat ≈ 8 concurrent streams** — a **server-side** drain limit
+   (Arrow-encode + gRPC-write + coordinator starving under contention), the #2600/#2765 egress phenomenon. Past 8, only
+   latency and buffer depth grow.
+3. **Phase 1.8 §3c:** the JVM page builder is explicitly **not** the binding constraint.
+
+**Attack-line-3 (double-counting) resolved:** T1 (labelled "ceiling") and T2 (labelled "distribution") both attack the
+worker-side drain, and in the current synchronous-pull design page-build *is* serialized into stream idle time — but that
+idle time is ~99.9% **server-produce wait**, so filling it (T2) and cheapening it (T1) both fish in a ~0.05 % pool.
+Multiplying their separate multipliers (1.5–3× × 1.3–2× = 2–6×) **double-counts the same idle-fill headroom**. Their
+honest **combined** pod ceiling is bounded by page-build's fraction of the per-batch cycle: **≤ ~1.1–1.3×, and only after
+the server ceiling is fixed.**
+
+**Correct order of operations:**
+1. **Server merge/produce ceiling** — Phase-0 #1 (batch the per-row `sync_channel` handoff / inline merge for the
+   few-SSTable case) + #2 (reconcile compute). **Out of transport scope**, but it is the gate everything else waits behind.
+2. **Server-side data-plane** — cold-IO residency + LZ4 decompression (read-path epics). Out of transport scope; likely the
+   single biggest field term (Phase 1.5 §1b, LOW confidence, 2–8×).
+3. **Server-side drain** — #2600/#2765 adaptive egress budget (raises N_drain_sat).
+4. **THEN worker-side T1 + T2 together (~1.1–1.3×)** become visible, because only then is page-build a non-trivial fraction
+   of the cycle.
+5. **T6 fan-out** last, gated on #2765 — Phase 1.5/1.6 already order this correctly; doing it before step 1/3 rebuilds the
+   #2600 egress fire at a deeper queue.
+
+Transport levers are **enabling, not driving**: they remove ceilings so a *future* fast producer's output can leave the
+pod. On today's slow producer they are premature.
+
+---
+
+## 5. Attack-line 4 — the JDBC 32 MB/s figure (no miscitation to kill)
+Phase 1.5 does **not** lean on the JDBC 32 MB/s figure for any lever, and Phase 1.8 §3c handles it correctly: the CQLite
+connector consumes **Arrow record batches** (`ArrowToTrino.toPage` builds Trino Pages from Arrow vectors), **not** JDBC
+`ResultSet` rows. The Starburst ~32 MB/s/conn ceiling is a **row-by-row JDBC deserialization** number and is
+**categorically inapplicable** to this path — the relevant envelope is the Arrow-batch class (GB/s localhost; Phase 1.8
+§1). Any future claim that cites 32 MB/s as a CQLite *worker-ingest* limit would be a category error; neither target doc
+commits it. **Ruling: correctly excluded; nothing to kill, but flag the category boundary so it is not reintroduced.**
+
+---
+
+## 6. Attack-line 5 — B4 memory co-sizing (closes, but only at the correct operating point)
+Per-stream buffered bytes, both heaps:
+
+| Buffer | Owner | Bytes/stream | Source |
+|---|---|---|---|
+| Arrow egress (`(DO_GET 4 + IN_FLIGHT 3) × 8192` = 57,344 rows) | server | **~15–20 MB** (narrow ~300 B/row) | Phase 1.6 §6.1 (`streaming.rs:65/86`) |
+| Merge fan-in (`256 × M` MergeEntry) | server | ~0.5–2 MB (M≤8) | Phase 1.6 §6.1 |
+| grpc-netty flow-control receive buffer | worker (off-heap, netty direct) | **1 MiB floor, auto-tuning toward BDP** | grpc-java 1.79.0 default |
+| Trino Blocks for one batch | worker (on-heap) | ~batch × row-width, bounded to one batch | `ArrowToTrino` |
+
+- **The transport levers' memory impact is modest at the correct width (N_drain_sat ≈ 8, admission re-sized to ~16 per
+  Phase 1.6 §6.3):** server ≈ 8 × ~20 MB ≈ 160 MB flight buffers (comfortable under 512 Mi); worker ≈ 8 × (1–8 MiB netty +
+  one on-heap batch) — tens of MB. **The story closes.**
+- **It does NOT close if T3's window is blindly raised to 4–16 MB × a fanned-out K.** But T3 is killed anyway (the client
+  window is already 1 MiB auto-tuning; the tonic-server knob is the wrong direction), so this footgun never needs to be
+  loaded. The one live memory caveat is that grpc-java **auto-tuning can grow the worker's netty direct-memory window**
+  (toward ~8 MiB × K) independent of any code change — worth watching in the worker's off-heap budget, but it is
+  netty/grpc-managed direct memory, **separate from Trino's 512 Mi heap accounting**, and bounded by BDP (small at low
+  per-stream rates).
+- **T1's bulk-copy** adds one transient per-column on-heap copy (one batch's worth), bounded — no B4 hazard.
+- **T4 (byte-bounded batch)** is the one transport lever that *helps* B4: it caps MB/batch for wide rows, which otherwise
+  scales the 57,344-row egress buffer to ~8 MB/batch × depth.
+
+**Ruling: the co-sizing closes under the correct operating point (K≈8, admission ≈16, no blind window inflation).** It does
+not close under the naive "raise everything" reading — but the only lever that would have forced that (T3 server window) is
+killed.
+
+---
+
+## 7. Revised program guidance
+
+1. **Do not schedule T1/T2/T3/T5 as throughput work now.** At field per-stream rates the network and Java page-build are
+   idle-adjacent (≥99.9 % of the cycle is server-produce wait). Their measured field payoff today is ~1.0×.
+2. **The transport lever with a real, immediate, non-throughput case is T4** (byte-bounded batch, wide-row robustness +
+   B4) — cheap, safe, worth doing on its own merits, **~1.0–1.1×**.
+3. **T1 keeps its engineering value but must be reframed:** it is a **bulk per-column copy** (not zero-copy), worth
+   **~1.1–1.2× at the pod only after** the server produce ceiling is raised, and it **must ship with T2** (prefetch) so its
+   cheaper page-build can overlap the network — the two are complements whose *combined* ceiling is ≤ ~1.3×, not a product.
+4. **T3 should be closed as "not applicable in this stack"** with the flow-control-direction + grpc-java-auto-tuning
+   findings recorded, so it is not refiled. If a WAN deployment ever appears, the knob is the **grpc-java client** window,
+   not `initial_stream_window_size` on tonic.
+5. **T5 stays opt-in/off and explicitly net-negative for narrow rows** (steals server CPU from the coordinator that is the
+   bottleneck); revisit only if a field A/B ever shows a genuinely network-bound link — which T3's headroom analysis says
+   does not exist today.
+6. **T6 ordering is correct as written** and this verification hardens it: fan-out is last, after the server ceiling and
+   #2765.
+7. **The real levers live upstream of this report:** Phase-0 #1 (per-row channel batching / inline merge), the read-path
+   cold-IO/decompression epics, and #2600/#2765 egress. Transport is the enabling layer for a fast producer that does not
+   yet exist.
+
+---
+
+## 8. Evidence index (this report)
+
+| Ruling | Basis |
+|---|---|
+| T3 wrong-direction | `h2 0.4.15` `server::Builder::initial_window_size` = received-data window; `do_get` data is server→client (`main.rs:128–131`, `streaming.rs:439–448`) |
+| T3 client window 1 MiB + auto-tune | grpc-java 1.79.0 `DEFAULT_FLOW_CONTROL_WINDOW=1048576` + BDP `FlowControlPinger`; not pinned by Flight (`CqliteFlightClient.java:101–103`); resolved via `build.gradle.kts` (arrow-java 19.0.0 → grpc-netty:1.79.0) |
+| T3 headroom | 2.6 k rows/s × 300 B = 0.78 MB/s vs 64 KB/10 ms = 6.4 MB/s (Phase 1.5 §1a, Phase 1.8 §1) |
+| T1 SPI accepts foreign Slice | Trino 481 `VariableWidthBlock(int, Slice, int[], Optional<boolean[]>)`; no arena reservation for scan Pages; `getMemoryUsage()=0` (`CqliteFlightPageSource.java:82`) |
+| T1 copy forced by lifetime | Arrow off-heap buffer freed on `FlightStream.next()` advance; Trino Blocks outlive `getNextSourcePage` |
+| T1 per-column distinction | Arrow int32 offsets == Trino `VariableWidthBlock` offsets; one `Slice.copyOf`/column (`ArrowToTrino.java:319–334`) |
+| T1 pod multiplier ≈0 today | 8192 rows / 2.6 k rows/s = 3.15 s/batch; page-build ~1.6 ms = 0.05 % (Phase 1.8 §3c) |
+| Ordering: server is limiter | Phase 0 §3a/§3b; Phase 1.6 §4 (N_drain_sat≈8, server-side); Phase 1.8 §3c |
+| Sync pull confirmed | `CqliteFlightPageSource.java:45–64`; `ReplicaFailoverStream.java:67–121` |
+| Compression OFF confirmed | `streaming.rs:439–448` (no `.with_options`) |
+| Versions | `Cargo.lock` (tonic 0.12.3 / h2 0.4.15); `build.gradle.kts` (Trino 481, arrow-java 19.0.0, grpc-netty 1.79.0, netty 4.1.130.Final) |
+
+**File:** `/Users/patrickmcfadin/local_projects/cqlite/docs/research/phase2-verify-transport.md` (uncommitted per instructions).

--- a/docs/research/throughput-backlog-inventory-2026-07.md
+++ b/docs/research/throughput-backlog-inventory-2026-07.md
@@ -1,0 +1,257 @@
+# Throughput backlog inventory — 2026-07-21
+
+Purpose: a complete dedup map of existing GitHub issues touching scan-path / Flight / connector
+performance, so 0.17 throughput-program filings extend or re-milestone existing work instead of
+duplicating it. Read-only survey — no GitHub writes were made compiling this.
+
+Scope note: epics **A–M** (read-path perf audit + parser perf audit, filed 2026-07) are **entirely
+CLOSED** — every epic issue and the overwhelming majority of children shipped. They are listed here
+for dedup completeness (a 0.17 filer must know this ground was already covered) and because a
+handful of children are still open. Epics **AA/AB/AD/AE/AF** (export-path perf audit) are **mixed**:
+epics open, several children open, several closed, milestone 0.16.
+
+---
+
+## 1. Epic AB #1467 (streaming egress) + children
+
+| # | Title | State | Milestone | Priority | Claims / notes |
+|---|---|---|---|---|---|
+| 1467 | Epic AB — Streaming egress: eliminate materialize-then-emit | OPEN | 0.16 | P1, epic | Umbrella: make every egress path look like `cqlite-cli/src/commands/export.rs` (true streaming). Source: `docs/reports/export-path-performance-audit-2026-07-01.md` (AB1–AB9). |
+| 1476 | AB1 — Flight `do_get`: stream batches instead of materializing whole table | CLOSED | 0.16 | P1 | Full Flight streaming rewrite; AA3 rides it. Shipped. |
+| 1477 | AB2 — Flight: LIMIT pushdown on the ticket | CLOSED | 0.16 | P1 | Interim memory bound; no longer a prerequisite for AB1. |
+| 1478 | AB3 — CLI one-shot `-e SELECT`: stream json/csv/parquet instead of materializing | OPEN | 0.16 | P1 | Still open — one-shot CLI path still slurps. |
+| 1479 | AB4 — `read-sstable`/`export-sstable`/`read`: stop slurping via `get_all_entries()` | OPEN | 0.16 | P2 | |
+| 1480 | AB5 — `import`: stream JSON, single-pass CSV, skip-with-count malformed rows | OPEN | 0.16 | P2 | |
+| 1481 | AB6 — `--out table`: bound + document buffering-by-design path | OPEN | 0.16 | P3 | |
+| 1482 | AB7 — batch `ParquetWriter::write`: cap row-group size | OPEN | 0.16 | P2 | Stop one-group/whole-file. |
+| 1483 | AB8 — CLI: move decorative chatter off stdout | CLOSED | 0.14 | P0, bug | Piped-output corruption fix. Shipped. |
+| 1484 | AB9 — delta-scan: use the #1143 windowed driver instead of stitching whole Data.db | OPEN | 0.16 | P2 | Cross-links read-path epics A–G. |
+
+## Epic AE #1470 (per-cell conversion cost) + children
+
+| # | Title | State | Milestone | Priority | Claims / notes |
+|---|---|---|---|---|---|
+| 1470 | Epic AE — Per-cell conversion cost (export-side parser J1 instance) | OPEN | 0.16 | P2, epic | Resolve per-column accessor once instead of per-cell string-hash dispatch. Source: same audit doc (AE1–AE6). |
+| 1495 | AE1 — arrow_convert: resolve per-column accessor once | CLOSED | 0.14 | P2 | Kills per-cell HashMap lookup. Shipped. |
+| 1496 | AE2 — capacity-hinted builders, drop per-value clones + double-Vec blob | CLOSED | 0.14 | P2 | Shipped. |
+| 1497 | AE3 — delta emit: hoist schema-constant sets + index cell dispatch | OPEN | 0.16 | P2 | Stop O(R·V·cells). |
+| 1498 | AE4 — delta emit: intern column names | OPEN | 0.16 | P3 | Stop per-cell `ColumnId` String clone. |
+| 1499 | AE5 — CLI json/csv: borrow keys, fix `== "null"` sentinel bug | CLOSED | 0.14 | P0, bug | Shipped. |
+| 1500 | AE6 — Node `exportParquet`: `spawn_blocking` | OPEN | 0.16 | P2 | Unblock event loop; ~5-word from memory list. |
+
+**Sibling export-audit epics (same source doc, found during traversal — not separately requested but load-bearing context):**
+
+| # | Title | State | Milestone | Priority |
+|---|---|---|---|---|
+| 1466 | Epic AA — Flight connector hardening (ticket safety, cancellation, lifecycle, tests) | OPEN | none | P0, epic |
+| 1472 | AA2 — Flight: cap ticket size in-crate (defense-in-depth) | OPEN | 0.16 | P3 |
+| 1469 | Epic AD — Round-trip parity + determinism + perf gate | OPEN | none | P1, epic |
+| 1490–1494 | AD1–AD5 (parity/determinism/bench fixtures) | CLOSED | — | — |
+| 1471 | Epic AF — Dead code, feature hygiene, campsite | OPEN | none | P2, epic |
+| 1502–1505 | AF1–AF4 (dead-code delete, feature split, file splits) | OPEN | 0.16 | P2–P3 |
+(AA1/AA3/AA4/AA5 = #1430/#1473/#1474/#1475, all CLOSED.)
+
+---
+
+## 2. Read-path perf audit (Epics A–G) and parser perf audit (Epics H–M)
+
+**All 13 epics (A,B,C,D,F,G,H,I,J,K,L,M — note: no separate "E" epic number gap, E = #1517 "Hot-path mechanics") are CLOSED.** Nearly every child is CLOSED. This entire audit program (2026-07) shipped.
+
+| Epic | # | State | Title |
+|---|---|---|---|
+| A | 1513 | CLOSED | Measurement first: read-path benchmark + regression-gate suite |
+| B | 1514 | CLOSED | Ship the read cache (B1–B5: shared chunk cache, dead-cache delete, decompressor cache, key→offset cache, observability) |
+| C | 1515 | CLOSED | Point-lookup fast path (C1–C5: digest-first index lookup, ReadAt positional reads, zero-copy BTI walk, hoisted rehash, range short-circuit) |
+| D | 1516 | CLOSED | Streaming by default: pushdown + bounded memory (D1–D6: LIMIT/OFFSET pushdown, streaming aggregates, streaming merge, oracle-ordered merge, BulletproofReader retirement, byte-bounded result budget) |
+| E | 1517 | CLOSED | Hot-path mechanics: allocations, copies, syscalls |
+| F | 1518 | CLOSED | Concurrency & scheduling: even latency under load (F1–F6: reader-map RwLock, streaming-channel batching, blocking I/O off async, admission control, lock hygiene, hardware sympathy) |
+| G | 1519 | CLOSED | Reader consolidation (G1–G4: delete dead reader stacks, one ChunkSource decode plane, one PartitionLocator, confine TombstoneMerger) |
+| H | 1601 | CLOSED | Parser measurement + adversarial safety net (fuzz, benches, work-counters) |
+| I | 1602 | CLOSED | Parser correctness landmines (VInt signedness, swallowed stats, Blob fallback, BTI cap) |
+| J | 1603 | CLOSED | One decoder: per-column dispatch + parser stack consolidation |
+| K | 1604 | CLOSED | Row/cell hot-loop mechanics (per-row constant factors; K1 PartitionDriver, K4 Arc-identity clone kill, K5 zero-copy Value, K6 hardware-sympathy bundle) |
+| L | 1605 | CLOSED | BTI parser: floor-walks and zero-alloc descent |
+| M | 1606 | CLOSED | Parser metadata honesty + structural hygiene |
+
+**Open stragglers from these epics (dedup-relevant, still live):**
+
+| # | Title | State | Milestone |
+|---|---|---|---|
+| 2177 | Nit follow-up (#1598 G2): stale `range()` reference in scan_stream_windowed.rs comment | OPEN | none |
+| 2165 | G2 follow-up: route iterate_all_partitions/sequential_scan decode through ChunkSource | OPEN | none |
+| 1655 | M2 — Campsite splits on parser files epics I–L touch (tracking) | OPEN | none |
+| 1883 | Rust-side per-row alloc budget (dhat/allocator hook), ratchets #1447/#1445/#1446 | OPEN | 0.17 (already there) |
+| 1818 | B-series follow-up: BIG point-read cache site dead on public path | CLOSED | — |
+| 2059 | Global bounded key→partition-offset cache (Cassandra key-cache model) | CLOSED | — shipped, gated 2565 nits open |
+| 2565 | Nits follow-up: global bounded key cache (#2059/PR #2554) — doc & test-hygiene | OPEN | none |
+| 2561 | BTI point-read: chunk-straddling partition decode trusts closure-fired-as-complete → whole-file fallback | OPEN | P2, bug — found via #2059 gate |
+
+---
+
+## 3. #941 DataFusion Design-A epic + children #1905–1914
+
+| # | Title | State | Milestone | Priority |
+|---|---|---|---|---|
+| 941 | [EPIC] DataFusion table provider — Design A: co-located Flight-backed provider (Trino stays MPP owner) | OPEN | none | P3, epic |
+| 1905 | A1: SnapshotScanManifest — versioned/signed schema | OPEN | none | P3 |
+| 1906 | A2: Snapshot lease lifecycle; Trino stops production live-dir reads | OPEN | none | P3 |
+| 1907 | A3: Streaming Flight producer — bounded RecordBatchStream, real cancellation, byte-cap budget | OPEN | none | P3 — "the hard blocker" |
+| 1908 | A4: `cqlite-datafusion` crate (provider + exec) | OPEN | none | P3 |
+| 1909 | A5: split planning + ring-coverage correctness | OPEN | none | P3 |
+| 1910 | A6: Trino split model / affinity / dynamic filtering | OPEN | none | P3 |
+| 1911 | A7: consistency-contract invariants (docs + fail-closed enforcement) | OPEN | none | P3 |
+| 1912 | A8: E2E validation — DataFusion vs Trino over same epoch (capstone) | OPEN | none | P3 |
+| 1913 | spike: Sidecar HTTP-Range go/no-go (gates Design B) | OPEN | none | P3 |
+| 1914 | Design C future-epic placeholder (materialized epoch/Iceberg) | OPEN | none | P3, epic-candidate |
+
+Claim: none of 1905–1914 have shipped anything — all still Backlog-shaped (P3, no milestone), dependency-ordered under 1905 first. #2605 (below) is a lighter-weight PoC spike layered on top of this same idea, scoped to 0.16.
+
+---
+
+## 4. #2037 ArrowMemtable epic + WS1–WS9
+
+| # | Title | State | Milestone |
+|---|---|---|---|
+| 2037 | Exploration epic: ArrowMemtable — coordinator-native OLAP path | OPEN | none |
+| 2043 | WS7 bench spike: measure #2037 flip-risk constants (nb decode, k-way merge ns/row, cache-format candidates) | OPEN | none |
+
+**WS1–WS6, WS8, WS9 are NOT filed as separate issues.** The epic body explicitly marks them
+"DO NOT promote without owner" — they exist only as workstream descriptions inside #2037's body
+(WS1 precedent survey, WS2 tail live-stream protocol, WS3 generation pinning, WS4 process-boundary
+decision, WS5 coordinator query surface, WS6 per-generation Arrow cache design, WS8 OLTP-safety
+re-bench, WS9 CEP pitch draft). Only WS7 was groomed into a real issue (#2043). A 0.17 filer touching
+this territory should re-groom from the epic body, not assume WS2–WS9 issue numbers exist.
+
+Non-goals stated in the epic (binding): no CDC, no second on-disk storage format, no `nb` replacement,
+no raw JVM-external trie memory reads. Exit criterion = owner-approved decision packet, not an
+implementation epic yet.
+
+---
+
+## 5. Named individual issues
+
+| # | Title | State | Milestone | Priority | Claims / measured numbers |
+|---|---|---|---|---|---|
+| 2605 | spike(0.16): DataFusion TableProvider PoC over the flight scan path | OPEN | 0.16 | P2 | Bench vs row engine on R12 corpus, feature-gated, zero production wiring. Lightweight sibling to #941's Design-A track. |
+| 2765 | flight/merge: process-global adaptive egress budget | OPEN | none | enhancement | Follow-up to #2600. `cap_per_merge = clamp(EGRESS_ROW_BUDGET/active_merges, MIN, 256)`. Baseline table in body: 80 threads → peak egress depth 8080, qps 190, p50 417ms (local Apple Silicon repro, trend not absolute). |
+| 2600 | flight: characterize + relieve merge-egress channel backpressure | **CLOSED (shipped)** | 0.16 | P1 | R12's dominant saturation signal (3,505 queued @ 80-thread in field). Shipped: attributed backpressure to consumer-side drain latency; lever = adaptive egress budget, CAP=32 cut depth 5-8x at <10% qps cost (per MEMORY.md). PR #2766. Follow-ups #2765 (impl), #2771 (nits), telemetry #2772. |
+| 2679 | trino-connector: plan-time split pruning for fully-bound partition keys | **CLOSED (shipped)** | 0.16 | P1 | Point reads previously fanned out ~48 DoGets across all pods; fix PR #2810 per MEMORY.md #2806 field round. |
+| 2680 | trino-connector: weight-balanced split→pod assignment | OPEN | 0.16 | P1 | floorMod rotation was count-balanced only → 2–4× pod CPU skew, B2 goal blocker. **CAUSED a live P0 regression (#2782, LIMIT hang) via its `sub-splits-per-range=4` default** — see below. Treat as NOT safely closed until #2782 resolved. |
+| 2681 | flight: attribute do_get server-side 'other' errors (0.89% in soak) | **CLOSED (shipped)** | 0.16 | P2 | Fine-grained abort categories + abort-path trace. Follow-up nits #2787 (2 low-severity, open). |
+| 2349 | Wire UDT registry into BOTH flight read paths | **CLOSED (shipped)** | 0.16 | P2, bug | UDT-in-collection decode previously went through non-registry branch. |
+| 2371 | Flight: shadowed data never crosses real do_get transport; no TTL/range-tombstone seam | OPEN | none | P2 | Part of the "2371–2377 cluster" — E2E coverage-gap findings. |
+| 2372 | BTI (`da`) has zero E2E coverage through Flight do_get and Trino testbed | **CLOSED** | 0.16 | P2 | Nit follow-up #2767 (open). |
+| 2373 | Flight: compressed (chunk-stitching) BIG-`nb` never reaches do_get | **CLOSED** | 0.16 | P2 | Nit follow-up #2795 (open). |
+| 2374 | Route the query-semantics oracle through Flight do_get as a parity lane | **CLOSED** | 0.16 | P2 | |
+| 2375 | Flight: `DoGetInput::Aggregate` branch never exercised through real do_get | OPEN | none | P2 | |
+| 2376 | Flight transport E2E for #2352 clearSnapshot regression + generation turnover mid-scan | OPEN | none | P2 | |
+| 2377 | Testbed/loadtest E2E gaps: no shadowed data, no point-lookup/sparse-predicate shapes | OPEN | none | P2 | |
+| 1536 | CLI `cqlite compact` without `--now-sec` silently skips TTL expiry | OPEN | none | P2, enhancement | Not really scan-path throughput — correctness/CLI contract issue, tangential to this program. |
+| 2059 | Global bounded key→partition-offset cache | **CLOSED (shipped)** | — | — | Cassandra key-cache model; bounds aggregate across all open readers. Nits #2565 open. |
+| 1644 | K5 — Zero-copy value extraction (Bytes-backed Value) | **CLOSED** | 0.15 | P1 | Joint Value-v2 train with E1/E3. Residual: #2597 (Tier-2 large-payload retention imperfect, open bug). |
+| 1818 | B-series follow-up: BIG point-read cache dead on public query path | **CLOSED** | 0.15 | P3 | |
+| 2210 | F6.1: MADV_RANDOM dedicated point-read mmap + cold-cache A/B harness | **CLOSED** | 0.15 | P3 | |
+| 2319 | Direct I/O windowed scan allocates bounce buffer per chunk | **CLOSED** | 0.15 | P3, performance | Regressed reused-window from #1940 substrate rework. |
+| 2096 | read-path: partition-seeking merge run reader for multi-candidate point reads | **CLOSED** | 0.15 | P2, performance | D3 follow-up. |
+| 2230 | KWayMerger::step materializes entire partition | **CLOSED** | 0.15 | P2, bug/performance | LIMIT/batch_size didn't bound intra-partition memory; cancellation partition-granular. |
+| 2423 | point-read (WHERE pk=?) and cache-warm merges still materialize whole partition | **CLOSED** | 0.15 | P1, bug/performance | Same defect class as #2230, more common wide-partition shape. |
+| 2412 | Lazy Summary-guided partition index for BIG open | **CLOSED (shipped)** | 0.15 | P1 | O(summary) open, O(log n + interval) lookup, ~0 resident index — "the #2385 real fix." Headline 0.15 ship. |
+| 2413 | flight scans: push split's token range into per-SSTable partition walk | **CLOSED (shipped)** | 0.15 | P1, performance | Every scan previously decoded ALL partition bodies from ring start (#2398 fix). |
+| 2420 | WS4 (epic #2313): admission control / backpressure — bounded concurrent do_get | **CLOSED (shipped)** | 0.15 | P2, performance | tonic concurrency_limit + Semaphore, `--max-concurrent-scans 64`. Nits #2432 open. |
+| 2782 | **P0: LIMIT queries hang (180s timeout) through cqlite_flight after #2680** | **OPEN** | none | P0 | Live regression on main (f5dd215a7). `DEFAULT_SUB_SPLITS_PER_RANGE=4` (#2680's default) + LIMIT + Trino early-termination = hang; evidence points at early-close path not draining a sub-split's DoGet stream. 3 remediation options on the table (revert / K=1 default / fix-forward); process-gap note: Flight↔Trino E2E is not a `required` check, so it didn't block auto-merge. Directly referenced by the program as a release-readiness hazard. Follow-up #2792 (make the E2E lane required, P1, open). |
+
+---
+
+## 6. Sweep — additional open issues matching perf|throughput|scan|flight|arrow|latency|egress|cache|io|memory|split|merge|scheduling|connector
+
+Full keyword sweep of all open issues found **111 matches**; most are nit-batches/follow-ups on
+already-closed parents (already folded into the sections above). Straggler items not yet covered
+above, grouped by theme:
+
+**Flight/connector coverage gaps & hardening (open, unmilestoned — same cluster as 2371–2377):**
+- #2792 P1 — make Flight↔Trino E2E a required check (direct #2782 escape-hatch fix)
+- #2378 P3 — no test of page-source close/cancel tearing down the Flight stream
+- #2333 P3 — flight point-read follow-ups (#2207 nits): OR-of-IN flattening, tombstone-through-transport
+- #2339 P2 — decode composite (frozen tuple/UDT) collection keys in merged-read assembly
+- #2325 P2, bug — empty-string partition key writes OK, reads back corrupted via both scan paths
+- #2322 P2, bug — sequential_scan byte-pattern header-resync silently loses rows on corrupt partition body
+- #2368 P3, bug — SSTableWriter doesn't enforce canonical (token,key) order for equal-token collisions
+
+**Cache/allocation nits (parents closed, hygiene open):**
+- #2565, #2561 (key-cache, #2059 family — see §2)
+- #2311 P3 — arrow_convert #1495 follow-up: transpose peak-memory + reorder-test nits
+- #2213 — Murmur3 recomputed per-comparison on same-partition no-op path (#1917 follow-up)
+- #2617 P3 — R3 follow-up: allocation-free complex-cell path
+
+**Write/merge/compaction (adjacent, not scan-path but same "throughput" umbrella):**
+- Epic Q #1610, Epic R #1611, Epic S #1612, Epic T #1613 (all OPEN, P1/P2 epics — write-path allocation
+  discipline, streaming metadata writers, campsite split; NOT yet started, unmilestoned)
+- #1956 P3 — mutation size estimated twice on accepted write path
+- #1989 P3 — offline compactor hardening: throughput throttle
+
+**Bindings/runtime perf (Node/Python, tangential to scan-path but same throughput theme):**
+- #1901 P1 — move Node streaming off libuv threadpool onto tokio runtime
+- #1883 P2, 0.17 (already milestoned) — Rust-side per-row alloc budget
+- #1845 P1 — dev/test debuginfo diet (build perf, not runtime)
+- #1851 P1 — compress Python/Node parity suites (build/test perf)
+
+**Spark connector track (separate connector, same "connector throughput" family):**
+- #1947–#1950 (S1–S4, all P3, unmilestoned) — connector-commons extraction, DataSourceV2 read connector,
+  pushdown phase 1, E2E rig. None started.
+
+**Observability (adjacent — "why is this slow", not itself a throughput fix):**
+- Epic AI #1686 + children #1701/#1705/#1707 (dead read metrics, catalog drift, why-slow phase timings) — OPEN, unmilestoned/0.17
+
+**CI/gate infra affecting this program's velocity (not product perf, flag for awareness only):**
+- #2662 P1 — gate.yml nightly deep-check dead all July (75m timeout kills every run)
+- #1894 P2 — define explicit CI merge lane-set + rate-limit-aware polling
+
+**Research/exploration epics (large, unmilestoned, owner-gated — do not re-file):**
+- #1934 P2, epic — CQLite two-project split exploration
+- #1951 P3 — cross-replica quorum-merge for Flight connectors (CL.ONE → blockFor-replica) decision packet
+
+---
+
+## 7. 0.16 milestone perf-relevant open items (already scheduled — NOT 0.17 candidates)
+
+These are open, in the 0.16 milestone, and directly perf/throughput-relevant. A 0.17 filing must
+NOT duplicate these; they are already scheduled work for the current milestone.
+
+| # | Title | Priority |
+|---|---|---|
+| 2680 | trino-connector: weight-balanced split→pod assignment (2–4× pod CPU skew, B2 blocker) — **regression-source of live P0 #2782** | P1 |
+| 2605 | spike(0.16): DataFusion TableProvider PoC over the flight scan path | P2 |
+| 1478 | AB3 — CLI one-shot `-e SELECT` streaming | P1 |
+| 1479 | AB4 — read-sstable/export-sstable/read slurp | P2 |
+| 1480 | AB5 — import streaming | P2 |
+| 1481 | AB6 — `--out table` bound | P3 |
+| 1482 | AB7 — batch ParquetWriter row-group cap | P2 |
+| 1484 | AB9 — delta-scan windowed driver | P2 |
+| 1497 | AE3 — delta emit hoist sets + index cell dispatch | P2 |
+| 1498 | AE4 — delta emit intern column names | P3 |
+| 1500 | AE6 — Node exportParquet spawn_blocking | P2 |
+| 1472 | AA2 — Flight ticket size cap | P3 |
+| 1490–1494 (open remainder) | AD parity/determinism (most closed; check live state before filing) | P1–P2 |
+| 1502–1505 | AF1–AF4 dead-code/feature-hygiene/campsite (perf-adjacent, not perf-primary) | P2–P3 |
+
+**#2782 (P0, LIMIT hang via #2680) has no milestone set** despite being a live regression referenced
+by this program as a release-readiness hazard — worth flagging to the owner/lead; it should probably
+be 0.16 given it's blocking on a 0.16 change already on main.
+
+---
+
+## Collision watchlist — where a new 0.17 filing is most likely to duplicate existing work
+
+| Topic | Existing coverage a 0.17 filer MUST check first | Risk |
+|---|---|---|
+| **Caching** (block/chunk/key/result caches) | Epic B #1514 (B1–B5, all closed) — shared bytes-bounded chunk cache, key→offset cache (#2059, closed), decompressor cache. Nits open: #2565, #2561 (BTI chunk-straddling gap found via #2059's own gate). | HIGH — any "add a cache" filing likely re-treads B1–B5; check #2561 first, it's a real live gap in the shipped cache. |
+| **Arrow encode / conversion cost** | Epic AE #1470 (AE1–AE6, 3 open: #1497/#1498/#1500), Epic K #1604 (closed), arrow_convert nits #2311. Epic AK/AJ campsite tracking (#1655, #1711). | MEDIUM — AE3/AE4/AE6 are the actual open remainder; a new filing should extend these, not restart. |
+| **I/O (mmap, direct I/O, syscalls)** | Epic F #1518 (F1–F6, closed) incl. F6.1 MADV_RANDOM (#2210, closed), direct I/O bounce-buffer regression #2319 (closed but flags this is fragile — regressed once already from #1940). | MEDIUM — regression-prone area; check #2319's fix is still intact before assuming it's solved. |
+| **Merge (k-way merge, partition materialization)** | #2230 + #2423 (closed, same defect class — partition-granular materialization/cancellation), #2096 partition-seeking reader (closed), Epic Q #1610 (compaction allocation discipline, open/unstarted). | HIGH — #2765 (adaptive egress budget) is the CURRENT open front here; a 0.17 filer on "merge memory bound" should extend #2765, not refile. |
+| **Connector (Trino split planning/scheduling)** | #2679 (closed — split pruning), #2680 (open — weight-balanced splits, **currently regressing prod via #2782**), df-provider #1905–1914 (all open, unstarted, P3), #2605 (0.16 DataFusion PoC spike). | HIGH — #2680/#2782 is an active fire; do not file a new "connector scheduling" issue without reading #2782 first. Spark connector #1947–1950 is a parallel, separate connector — don't conflate. |
+| **Scheduling / admission / backpressure** | Epic F4 admission control (closed), #2420 flight admission control (closed, nits #2432 open), #2600/#2765 egress backpressure (shipped char. + open impl follow-up). | HIGH — #2765 is the single open front; extend it. |
+| **Flight transport E2E coverage** | The #2371–2377 cluster (3 closed, 4 open: 2371/2375/2376/2377) + #2792 (make E2E required, direct #2782 fallout). | MEDIUM — a "let's test Flight E2E better" filing should map onto whichever of 2371/2375/2376/2377 it actually is, not restart the cluster. |
+| **DataFusion / TableProvider** | #941 + #1905–1914 (full design epic, unstarted) AND #2605 (lighter 0.16 spike PoC) are TWO overlapping tracks already. | HIGH — a 0.17 filing here needs to explicitly reconcile against BOTH #941's Design-A dependency chain and #2605's spike results, or it triples the surface. |
+| **ArrowMemtable / coordinator-native OLAP** | #2037 (exploration epic, WS1–9 mostly unfiled) + #2043 (WS7 spike, open). | LOW for 0.17 (owner-gated exploration, "do not promote without owner") but HIGH for accidental scope creep if a 0.17 perf issue reads like it's proposing WS2–WS6. |
+
+**File path:** `/Users/patrickmcfadin/local_projects/cqlite/docs/research/throughput-backlog-inventory-2026-07.md` (left uncommitted per instructions).


### PR DESCRIPTION
Commits the Phase-3 throughput research program (Phase 0 ground truth, eight Phase-1 lever memos,
seven Phase-2 adversarial adjudications) plus the synthesis + 0.17 backlog manifest. Docs-only diff
(18 files under `docs/architecture/` + `docs/research/`). Backing artifact for **epic #2817**
(0.17 scan-path throughput program).

## Executive summary

The through-Trino field baseline is **~10.6k rows/s/pod** (R12/#2367); the local single-stream
ceiling is **~500k rows/s/core**. The program's central finding: **the gap is almost entirely
server-side and Trino-independent** — ~55–75% of the per-node gap is hardware+C(N), field
data-plane heaviness, and cold-IO latency. Trino is a **latency floor**, not a throughput tax.
**Measurement leads**: the i4i cold-vs-warm profile (M0) adjudicates the server-side buckets before
any IO-heavy lever is committed. The honesty deliverable (the graveyard: killed T3/columnar/io_uring/
idle-drain items) ships as a first-class §4.

## Verdict table

| Target | Verdict | Limiting factor |
|---|---|---|
| A4 Stage-1 (100k rows/s/pod) | **REACHABLE** | none binding; L1 batch-channel + fan-out |
| A4 Stage-2 (600k rows/s/pod) | **NOT reliably reachable** (central ~400–450k) | C(N) < 4 (2 physical cores) + reconcile machinery |
| B3 Stage-1 (≤10s) | **REACHABLE, at the edge** | full-core parallelism ×~4 + constants ×~1.5 |
| B3 Stage-2 (≤3s) | **REACHABLE-AT-COST on a row feed** | Trino coordinator floor + cold-start IO latency |
| B2 (≥100 qps @32thr) | **REACHABLE** | pod-skew (#2680) + egress relief (#2600/#2765) |
| A2 (≥1000 qps/pod) | **REACHABLE-AT-COST, gated on measurement** | unmeasured keyed access skew |
| Worker ingest (≥250–350 MB/s) | **REACHABLE (wide rows only), via Arrow** | row width — not credible narrow via row engine |
| B4 (cold ≤3s / ≤512Mi / ≤16Mi) | **MET / holdable** | ≤16Mi = per-query working set; peak held w/ admission-resize + chunk-cache retune |
| A5 (0 restarts @80thr) | **MET today** | field 0 OOMKills; admission resize is a forward guard |

## Filed issues (manifest M0–M17)

- **NEW:** M0 #2818 (i4i cold-vs-warm profile, P1) · M1 #2819 (phase-metric split, P2) · M2 #2820
  (L1 batch fan-in channel, P1) · M6 #2821 (streaming result-budget gap, P2) · M7 #2822 (L3 singleton
  fast-path, P3) · M8 #2823 (L2 inline merge, P3) · M10 #2824 (madvise WILLNEED, P3) · M11 #2825
  (T4 byte-bounded batch, P2) · M12 #2826 (T1+T2 bulk ArrowToTrino, P3) · M13 #2827 (keyed
  access-distribution probe, P2) · M14 #2828 (chunk-cache retune, P2)
- **EXTEND (comment):** M3 #2765 (adaptive egress budget) · M4 #1883 (FxHash + RowKey Arc hoist) ·
  M5 #2680 (weight-balanced splits re-land) · M9 #2043 (WS7 reconcile-overlap repoint) · M15 #2605
  (DataFusion PoC sharpen)
- **RE-SCOPE:** M16 #2165 (decode-plane consolidation only, P3)
- **CLOSE-WITH-VERIFY:** M17 #2561 (BTI straddle fixed by PR #2554; closed)
- **Epic:** #2817

## NEEDS-OWNER

1. A4 Stage-2 rung — revise ~600k/pod → ~400–450k on the pure row engine, or hold aspirational pending
   the i4i measurement?
2. Ingest target's implicit row-width assumption — state the assumed width (presumes ≥1KB rows or columnar).
3. Snapshot-reuse-window default (freshness) — the cheapest keyed lever, but a product/data-semantics call.
4. Decoded-cache (K-A) vs #2037 sequencing — unblock the measurement; keep the build reconciled with #2037.
5. B4 "≤16Mi" semantics — confirm the ratified reading is per-query working set, not idle-pod memory.
6. The Flight bulk-path API (new public surface) — a product call on whether to pursue.
7. B3 Stage-2 strategy — accept the coordinator floor, route the bulk-path around it, or defer Stage-2?
8. **CPU/concurrency scaling curve (owner directive, folded into M0 #2818)** — measure C(N) at
   N=1,2,4,8,16 streams on i4i.xlarge (+ optional i4i.2xlarge point) to replace the assumed 2.5–3.5×
   band and answer whether CPU count scales linearly.
