### PR TITLE
docs: 0.16.0 GA field-validation report + RC1→GA comparison

### DIFF
--- a/website/public/field-reports/0.16.0/comparison.html
+++ b/website/public/field-reports/0.16.0/comparison.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>cqlite 0.16.0 GA — RC1 → GA comparison</title><style>
+  :root { --bg:#0d1117; --card:#161b22; --border:#30363d; --fg:#e6edf3; --muted:#8b949e;
+          --green:#3fb950; --amber:#d29922; --red:#f85149; --accent:#58a6ff; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg); font:15px/1.6 -apple-system,Segoe UI,Roboto,sans-serif; }
+  .wrap { max-width:1100px; margin:0 auto; padding:32px 24px 80px; }
+  h1 { font-size:28px; margin:0 0 4px; }
+  h2 { font-size:20px; margin:40px 0 12px; padding-bottom:6px; border-bottom:1px solid var(--border); }
+  h3 { font-size:16px; margin:28px 0 8px; }
+  .sub { color:var(--muted); margin:0 0 24px; }
+  nav { margin:0 0 24px; font-size:14px; }
+  nav a { color:var(--accent); text-decoration:none; margin-right:16px; }
+  .pill { display:inline-block; padding:2px 10px; border-radius:999px; font-size:12px; font-weight:600; }
+  .pass { background:rgba(63,185,80,.15); color:var(--green); }
+  .watch { background:rgba(210,153,34,.15); color:var(--amber); }
+  .fail { background:rgba(248,81,73,.15); color:var(--red); }
+  table { width:100%; border-collapse:collapse; margin:12px 0; background:var(--card); border:1px solid var(--border); border-radius:8px; overflow:hidden; }
+  th,td { text-align:left; padding:9px 12px; border-bottom:1px solid var(--border); font-variant-numeric:tabular-nums; vertical-align:top; }
+  th { background:#1c2128; color:var(--muted); font-weight:600; font-size:13px; text-transform:uppercase; letter-spacing:.03em; }
+  tr:last-child td { border-bottom:none; }
+  .good { color:var(--green); font-weight:600; }
+  .warnc { color:var(--amber); font-weight:600; }
+  .badc { color:var(--red); font-weight:600; }
+  code { background:#1c2128; padding:1px 6px; border-radius:4px; font-size:13px; }
+  .callout { background:var(--card); border-left:3px solid var(--accent); padding:12px 16px; border-radius:0 8px 8px 0; margin:16px 0; }
+  .callout.green { border-left-color:var(--green); }
+  .callout.amber { border-left-color:var(--amber); }
+  .callout.red { border-left-color:var(--red); }
+  pre { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:14px; white-space:pre-wrap; font-size:13px; overflow-x:auto; }
+  footer { margin-top:48px; color:var(--muted); font-size:13px; border-top:1px solid var(--border); padding-top:16px; }
+</style></head><body><div class="wrap"><nav><a href="report.html">Verdict</a><a href="comparison.html">RC1 → GA comparison</a></nav>
+<h1>0.16.0-rc1 → 0.16.0 GA</h1>
+<p class="sub">What changed between the first release candidate and the shipped release. RC1 was a per-fix probe round + 3.5h soak (2026-07-21); GA was a targeted perf + fix re-verification (2026-07-23). Same test bed: 3× i4i.xlarge db (RF=3, 13 read-replica token ranges) + m5.xlarge app, Cassandra 5.0.8.</p>
+
+<div class="callout amber"><b>Read the methods before the numbers.</b> The two rounds were not run identically. RC1's split-pruning probe measured <code>do_get</code> counter deltas + <code>EXPLAIN</code> split counts (not per-query latency); GA measured 60-sample server-side <code>elapsedTimeMillis</code>. RC1's throughput came from a <b>3.5h soak</b>; GA's from a <b>180s loadtest</b>. Where a row isn't apples-to-apples it says so.</p></div>
+
+<h2>The three fixes that moved</h2>
+<table><thead><tr><th>Fix</th><th>0.16.0-rc1</th><th>0.16.0 GA</th><th>Change</th></tr></thead><tbody>
+<tr><td><b>#2806</b> / #2679 split pruning</td><td class="badc">REGRESSED / inert</td><td class="good">FIXED</td><td>13 splits (on==off) → <b>1 split</b>; the connector now reads the bound key from the pushed-down <code>filterJson</code> on the table handle instead of the empty <code>constraint.getSummary()</code></td></tr>
+<tr><td><b>#2807</b> UDT keyspace-qual parse</td><td class="badc">BLOCKED (parse crash)</td><td class="good">FIXED</td><td>rc1 <code>code: Char</code> crash at <code>frozen&lt;ks.udt&gt;</code> → all UDT tables now parse &amp; are queryable</td></tr>
+<tr><td><b>#2349</b> scalar <code>frozen&lt;udt&gt;</code></td><td class="badc">unreachable (behind #2807)</td><td class="good">VERIFIED</td><td>decodes to <code>{street: 2 Oak, zip: 10001}</code>, matches sstabledump</td></tr>
+<tr><td><b>#2815</b> <code>list&lt;frozen&lt;udt&gt;&gt;</code></td><td class="badc">column silently dropped (rc2)</td><td class="warnc">symptom fixed</td><td>column now present in schema + <code>SELECT *</code>; elements are raw serialized UDT bytes (correct data, not yet structured — 0.17 candidate)</td></tr>
+</tbody></table>
+
+<h2>Split pruning — from inert to a real win</h2>
+<p>The headline of the whole 0.16 cycle. In RC1 the optimization existed but never fired for the exact query class it targets:</p>
+<table><thead><tr><th><code>WHERE key = ?</code></th><th>0.16.0-rc1</th><th>0.16.0 GA</th></tr></thead><tbody>
+<tr><td>splits, pruning ON</td><td class="badc">13 (inert)</td><td class="good">1</td></tr>
+<tr><td>splits, pruning OFF</td><td>13</td><td>13</td></tr>
+<tr><td>ON vs OFF differential</td><td class="badc">none (identical)</td><td class="good">13 → 1</td></tr>
+<tr><td>per-query latency effect</td><td>not measurable (no fan-out change)</td><td class="good">p50 −18% (185 → 152 ms)</td></tr>
+<tr><td>coordinator CPU / query</td><td>—</td><td class="good">−4× (8 → 2 ms)</td></tr>
+</tbody></table>
+<p>RC1's verdict was <span class="pill fail">regressed → #2806</span>: the pruning logic was correct in isolation but read the wrong source, so keyed reads always fanned out to all 13 read-replica ranges. GA reads the bound key where <code>applyFilter</code> actually put it, and the point read collapses to the single owning split.</p>
+
+<h2>Throughput / latency, round over round</h2>
+<table><thead><tr><th>Round</th><th>Threads</th><th>qps</th><th>p50</th><th>p99</th><th>errors</th><th>Notes</th></tr></thead><tbody>
+<tr><td>soak-0.15</td><td>32</td><td>~39</td><td>798 ms</td><td>1366 ms</td><td>0</td><td>90-min steady block</td></tr>
+<tr><td>0.16.0-rc1</td><td>32</td><td>~32</td><td>990 ms</td><td>1255 ms</td><td>0</td><td>3.5h main soak (flat, 0 err)</td></tr>
+<tr><td><b>0.16.0 GA</b></td><td>32</td><td>~33</td><td>967 ms</td><td>1195 ms</td><td>0</td><td>180s loadtest, pruning ON</td></tr>
+</tbody></table>
+<p>Throughput and latency are statistically unchanged rc1 → GA (~32 → ~33 qps, p99 ~1255 → ~1195 ms). The ~32–39 qps ceiling persists across both because it is owned by the fan-out skew (<code>#2680</code>) and snapshot-resolve floor, not by split pruning. What pruning <i>does</i> change under load is the <b>cold ramp and tail</b>: GA pruning-ON reaches steady state faster (15.7 vs 9.9 qps at 30 s with pruning off) and holds a tighter p99.</p>
+
+<h2>What GA did not re-measure</h2>
+<p>GA was a targeted perf + fix re-verify, so a few dimensions RC1 covered were not repeated. These are gaps in the comparison, not regressions:</p>
+<table><thead><tr><th>Dimension</th><th>0.16.0-rc1</th><th>0.16.0 GA</th></tr></thead><tbody>
+<tr><td>Multi-hour drift soak</td><td class="pill pass">3.5h, flat, 0 err</td><td class="pill watch">not re-run (180s loadtest only)</td></tr>
+<tr><td>Integrity (start == end)</td><td class="pill pass">1,703,038 == 1,703,038</td><td class="pill watch">not re-run</td></tr>
+<tr><td>Memory / fd / thread stability</td><td class="pill pass">RSS flat, 0 OOM/restart</td><td class="pill watch">not captured (no Grafana)</td></tr>
+<tr><td>#2681 abort taxonomy</td><td class="pill pass">0.026% genuine-error SLI</td><td class="pill watch">not re-measured</td></tr>
+<tr><td>Snapshot grace-sweep</td><td class="pill pass">background 312→172, no query</td><td class="pill watch">not re-run</td></tr>
+</tbody></table>
+<p>The read-path stability characteristics were established sound in RC1's soak and there is no code path in the GA delta expected to change them; a full milestone soak on GA would confirm that if desired.</p>
+
+<footer>Generated from <code>clusters/cqlite-rc1-artifacts/</code> (RC1) and <code>clusters/cqlite-016final-perf-20260723-082527/</code> (GA). RC1 detail: <a href="../0.16.0-rc1/report.html">0.16.0-rc1 report</a>. Field round pmcfadin/cqlite#2805.</footer></div></body></html>

--- a/website/public/field-reports/0.16.0/report.html
+++ b/website/public/field-reports/0.16.0/report.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>cqlite 0.16.0 GA — verdict</title><style>
+  :root { --bg:#0d1117; --card:#161b22; --border:#30363d; --fg:#e6edf3; --muted:#8b949e;
+          --green:#3fb950; --amber:#d29922; --red:#f85149; --accent:#58a6ff; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg); font:15px/1.6 -apple-system,Segoe UI,Roboto,sans-serif; }
+  .wrap { max-width:1100px; margin:0 auto; padding:32px 24px 80px; }
+  h1 { font-size:28px; margin:0 0 4px; }
+  h2 { font-size:20px; margin:40px 0 12px; padding-bottom:6px; border-bottom:1px solid var(--border); }
+  h3 { font-size:16px; margin:28px 0 8px; }
+  .sub { color:var(--muted); margin:0 0 24px; }
+  nav { margin:0 0 24px; font-size:14px; }
+  nav a { color:var(--accent); text-decoration:none; margin-right:16px; }
+  .pill { display:inline-block; padding:2px 10px; border-radius:999px; font-size:12px; font-weight:600; }
+  .pass { background:rgba(63,185,80,.15); color:var(--green); }
+  .watch { background:rgba(210,153,34,.15); color:var(--amber); }
+  .fail { background:rgba(248,81,73,.15); color:var(--red); }
+  table { width:100%; border-collapse:collapse; margin:12px 0; background:var(--card); border:1px solid var(--border); border-radius:8px; overflow:hidden; }
+  th,td { text-align:left; padding:9px 12px; border-bottom:1px solid var(--border); font-variant-numeric:tabular-nums; vertical-align:top; }
+  th { background:#1c2128; color:var(--muted); font-weight:600; font-size:13px; text-transform:uppercase; letter-spacing:.03em; }
+  tr:last-child td { border-bottom:none; }
+  .good { color:var(--green); font-weight:600; }
+  .warnc { color:var(--amber); font-weight:600; }
+  .badc { color:var(--red); font-weight:600; }
+  code { background:#1c2128; padding:1px 6px; border-radius:4px; font-size:13px; }
+  .callout { background:var(--card); border-left:3px solid var(--accent); padding:12px 16px; border-radius:0 8px 8px 0; margin:16px 0; }
+  .callout.green { border-left-color:var(--green); }
+  .callout.amber { border-left-color:var(--amber); }
+  .callout.red { border-left-color:var(--red); }
+  pre { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:14px; white-space:pre-wrap; font-size:13px; overflow-x:auto; }
+  footer { margin-top:48px; color:var(--muted); font-size:13px; border-top:1px solid var(--border); padding-top:16px; }
+</style></head><body><div class="wrap"><nav><a href="report.html">Verdict</a><a href="comparison.html">RC1 → GA comparison</a></nav>
+<h1>cqlite 0.16.0 GA — verdict</h1>
+<p class="sub">GA verification round before 0.17 · flight <code>v0.16.0@sha256:74b12ccd</code> (multi-arch INDEX; amd64 <code>a45cac03</code> / arm64 <code>f2f78d0b</code>; also <code>latest</code>) · connector <code>0.16.0</code> (Maven Central) · Trino 481 · Cassandra 5.0.8 RF=3 · 3× i4i.xlarge · ~2.5M partitions/node · 2026-07-23</p>
+
+<div class="callout green"><b>Verdict: 0.16.0 GA is sound — clear to move to 0.17.</b> All three tracked fixes that failed or were partial in the pre-release rounds now hold in the final release: <code>#2806</code> split pruning, <code>#2807</code> UDT parse, and <code>#2815</code> collection-column exposure. Split pruning delivers a measured <b>−18% p50 / −4× coordinator CPU</b> on isolated keyed reads. One residual (structured in-collection UDT decode) is a natural 0.17 follow-up, not a GA regression.</div>
+
+<h2>Fix scorecard — RC1 → GA</h2>
+<table><thead><tr><th>Fix</th><th>RC1 (pre-release)</th><th>0.16.0 GA</th><th>Verdict</th></tr></thead><tbody>
+<tr><td><b>#2806</b> / #2679 split pruning</td><td>Inert — 13 splits on/off, no benefit</td><td>1 split, −18% p50, −4× CPU</td><td class="pill pass">fixed</td></tr>
+<tr><td><b>#2807</b> UDT keyspace-qualified parse</td><td>Parse crash (<code>code: Char</code>), every UDT table unreadable</td><td>All UDT tables parse &amp; query</td><td class="pill pass">fixed</td></tr>
+<tr><td><b>#2349</b> scalar <code>frozen&lt;udt&gt;</code> decode</td><td>Blocked behind the parse crash</td><td><code>{street: 2 Oak, zip: 10001}</code> readable</td><td class="pill pass">verified</td></tr>
+<tr><td><b>#2815</b> <code>list&lt;frozen&lt;udt&gt;&gt;</code> silent drop</td><td>Column absent from schema (data-loss-class, found rc2)</td><td>Column present; <code>SELECT *</code> returns it</td><td class="pill pass">symptom fixed</td></tr>
+<tr><td>#2372 BTI (<code>da</code>) over Flight</td><td>Could-not-observe (no da corpus)</td><td>Not tested (no da corpus)</td><td class="pill watch">could-not-observe</td></tr>
+</tbody></table>
+
+<h2>Split-pruning perf (#2806) — the headline</h2>
+<p>Method: Trino server-side <code>elapsedTimeMillis</code> + <code>totalSplits</code> via the REST API, driven from the control node against the Trino service clusterIP (no port-forward, no wall-clock noise). 60 samples/mode = 3 warmed passes over 20 distinct keys. Kill-switch = <code>cqlite.split-pruning-enabled</code>, pods restarted between modes.</p>
+<table><thead><tr><th>Isolated <code>WHERE key = ?</code></th><th>splits</th><th>p50</th><th>p90</th><th>p99</th><th>coordinator CPU p50</th></tr></thead><tbody>
+<tr><td><b>pruning ON</b></td><td class="good">1</td><td class="good">152 ms</td><td>195 ms</td><td>257 ms</td><td class="good">2 ms</td></tr>
+<tr><td>pruning OFF</td><td>13</td><td>185 ms</td><td>208 ms</td><td>241 ms</td><td>8 ms</td></tr>
+</tbody></table>
+<p>Collapsing the 13-way fan-out to the single owning split cuts p50 latency <b>−18%</b> and coordinator CPU <b>−4×</b>. Smoke checks: <code>IN(2 keys)</code> ON=1 / OFF=13 splits; <code>WHERE key=? LIMIT 1</code> ON prunes / OFF full fan-out — all correct, identical rows, 0 errors either mode.</p>
+
+<h2>Sustained throughput — 32 threads, 180s</h2>
+<table><thead><tr><th>Mode</th><th>steady qps</th><th>p50</th><th>p99</th><th>cold ramp (30s: qps / p99)</th><th>errors</th></tr></thead><tbody>
+<tr><td>pruning ON</td><td>~33.0</td><td>~967 ms</td><td>~1195 ms</td><td>15.7 qps / 6384 ms</td><td>0</td></tr>
+<tr><td>pruning OFF</td><td>~33.9</td><td>~937 ms</td><td>~1462 ms</td><td>9.9 qps / 8492 ms</td><td>0</td></tr>
+</tbody></table>
+<p>Steady-state throughput is <b>equal</b> (~33 qps both) — pruning does not raise the throughput ceiling, which is owned by the known fan-out skew (<code>#2680</code>) and snapshot-resolve floor, not split count. But pruning ON has a markedly <b>faster cold ramp</b> and <b>better tail</b> (p99 −18% steady; 6384 vs 8492 ms cold) because 13× fan-out is expensive to warm.</p>
+
+<h2>UDT collections — #2815 fix, with a residual</h2>
+<div class="callout amber"><b>Symptom fixed, structured decode is the 0.17 follow-up.</b> In rc2 the <code>list&lt;frozen&lt;udt&gt;&gt;</code> column was <i>silently dropped</i> from the projected schema — a data-loss-class omission. In GA the column is back: <code>DESCRIBE udt_simple</code> lists <code>addrs</code> and <code>SELECT *</code> returns it. The residual: elements come back as <code>array(varchar)</code> of <b>raw serialized UDT bytes</b> (e.g. <code>0x000000053120456c6d0000000400002b67</code> = <code>"1 Elm"/11111</code>, decoded by hand and matched field-for-field against <code>sstabledump</code>), not a structured <code>array(row(street,zip))</code>. Data is correct and complete and reachable — it is simply not typed yet. Strictly better than rc2 (where the column vanished entirely); the deeper in-collection structured decode (<code>#2349</code>'s further target) is a clean 0.17 candidate, not a GA blocker.</div>
+
+<footer>Generated from <code>clusters/cqlite-016final-perf-20260723-082527/</code> (raw: <code>perf-out/*.tsv</code>, <code>loadtest-{ON,OFF}.log</code>, <code>final-verdict-summary.txt</code>). No Grafana panels this round — the cluster was torn down after the perf+correctness capture; numbers are Trino server-side stats and <code>sstabledump</code> ground truth. Field round pmcfadin/cqlite#2805.</footer></div></body></html>

--- a/website/src/content/docs/field-validation/0-16-0-ga.md
+++ b/website/src/content/docs/field-validation/0-16-0-ga.md
@@ -1,0 +1,65 @@
+---
+title: 0.16.0 GA Verification
+description: A GA verification round before 0.17 — all three tracked 0.16 fixes (split pruning, UDT parse, collection-column exposure) now hold in the shipped release, with split pruning delivering a measured −18% p50 / −4× coordinator-CPU win on keyed reads.
+sidebar:
+  label: 0.16.0 GA (2026-07-23)
+  order: -2
+---
+
+# 0.16.0 GA verification
+
+A focused round on the **shipped 0.16.0 release** before moving to 0.17 — re-verifying the
+specific fixes that failed or were partial across the release candidates, and quantifying the
+split-pruning win that RC1 could only show as a plan shape.
+
+**Verdict: 0.16.0 GA is sound — clear to move to 0.17.** All three tracked fixes hold:
+[#2806](https://github.com/pmcfadin/cqlite/issues/2806) split pruning,
+[#2807](https://github.com/pmcfadin/cqlite/issues/2807) UDT parse, and
+[#2815](https://github.com/pmcfadin/cqlite/issues/2815) collection-column exposure. Split pruning
+delivers a measured **−18% p50 latency and −4× coordinator CPU** on isolated keyed reads. One
+residual — structured decode of UDT values *inside* collections — is a natural 0.17 follow-up, not
+a GA regression.
+
+<a href="/cqlite/field-reports/0.16.0/report.html" class="not-content" target="_blank" rel="noopener">**Open the full report →**</a>
+
+The report is a self-contained two-view dashboard:
+
+- **[Verdict](/cqlite/field-reports/0.16.0/report.html)** — the fix scorecard, split-pruning latency differential, and the UDT-collection residual.
+- **[RC1 → GA comparison](/cqlite/field-reports/0.16.0/comparison.html)** — what moved between the first release candidate and the shipped release, round-over-round throughput, and the dimensions GA did not re-run.
+
+## Fix re-verification — RC1 → GA
+
+| Fix | 0.16.0-rc1 | 0.16.0 GA |
+|-----|-----------|-----------|
+| **#2806** / #2679 split pruning | Inert — 13 splits on/off, no benefit | **Fixed** — 1 split, −18% p50, −4× CPU |
+| **#2807** UDT keyspace-qualified parse | Parse crash (`code: Char`), tables unreadable | **Fixed** — all UDT tables query |
+| **#2349** scalar `frozen<udt>` decode | Blocked behind the parse crash | **Verified** — `{street, zip}` readable |
+| **#2815** `list<frozen<udt>>` silent drop | Column absent (data-loss-class, rc2) | **Symptom fixed** — column present; raw bytes, not yet structured |
+
+## Split-pruning perf (the headline)
+
+RC1 could only show that pruning *didn't* fire (13 splits on and off). GA both fires it and
+quantifies the win, measured from Trino's own server-side stats over 60 samples per mode:
+
+| Isolated `WHERE key = ?` | splits | p50 | coordinator CPU p50 |
+|--------------------------|--------|-----|---------------------|
+| pruning ON | **1** | **152 ms** | **2 ms** |
+| pruning OFF | 13 | 185 ms | 8 ms |
+
+Under a 32-thread loadtest, steady-state throughput is unchanged (~33 qps both modes — the ceiling
+is the known fan-out skew #2680, not split count), but pruning ON has a much faster cold ramp and a
+tighter p99 tail because 13× fan-out is expensive to warm.
+
+## The one residual (0.17 candidate)
+
+`list<frozen<udt>>` columns are no longer silently dropped — the data-loss symptom that #2815
+tracked is fixed. But the elements come back as `array(varchar)` of **raw serialized UDT bytes**
+(verified correct and complete field-for-field against `sstabledump`), not a structured
+`array(row(...))`. So the data is reachable; the deeper in-collection **structured decode**
+(#2349's further target) is the natural next step for 0.17 — not a GA blocker, and strictly better
+than rc2 where the column vanished entirely.
+
+> Run metadata: flight `v0.16.0@sha256:74b12ccd` (multi-arch INDEX; amd64 `a45cac03` / arm64
+> `f2f78d0b`; also `latest`) · connector 0.16.0 (Maven Central) · Trino 481 · Cassandra 5.0.8 RF=3 ·
+> 3× i4i.xlarge · ~2.5M partitions/node · 2026-07-23. GA was a targeted perf + fix re-verify; the
+> multi-hour soak / integrity / abort-taxonomy dimensions from the RC1 round were not re-run.

--- a/website/src/content/docs/field-validation/index.md
+++ b/website/src/content/docs/field-validation/index.md
@@ -24,6 +24,7 @@ report for that round.
 
 | Round | Date | Stack | Verdict | Report |
 |-------|------|-------|---------|--------|
+| **0.16.0 GA verification** | 2026-07-23 | flight 0.16.0 · connector 0.16.0 | **GA sound — all 3 tracked fixes hold** — #2806 split pruning fixed (−18% p50 / −4× CPU on keyed reads), #2807 UDT parse fixed, #2815 collection-column drop fixed (raw bytes; structured decode is a 0.17 follow-up) | [Full report →](/cqlite/field-validation/0-16-0-ga/) |
 | **0.16.0-rc1 fix validation** | 2026-07-21 | flight 0.16.0-rc1 · connector 0.16.0-rc1 | **Soak ship-grade (0 errors, integrity holds); 2 of 3 testable fixes fail in the field** — #2679 split pruning inert (#2806), #2349 UDT blocked by a parser bug (#2807), #2681 abort taxonomy verified | [Full report →](/cqlite/field-validation/0-16-0-rc1/) |
 | **v0.15.0 milestone soak** | 2026-07-17 | flight 0.15.0 · connector 0.15.0 | **7 / 8 VERIFIED** — the one open flag (background snapshot grace-sweep, #2452) confirmed fixed in the field | [Full report →](/cqlite/field-validation/soak-0-15/) |
 | **Round 12** | 2026-07-15 | flight round12 · connector 0.14.3 | **ALL GREEN** — every R11b baseline held or improved; #2419 saturation gauges now visible under overload; #2436 large-cell fix confirmed | [Full report →](/cqlite/field-validation/round-12/) |
@@ -34,16 +35,15 @@ The stack keeps getting faster and cleaner. Latency numbers are **not** directly
 across rounds — R11b/R12 measured 8-thread load, the 0.15 snapshot ran at 32 threads — but
 throughput, error rate, and resource behavior show the trend.
 
-| Metric | R11b | Round 12 | v0.15.0 | 0.16.0-rc1 | Trend |
-|--------|------|----------|---------|------------|-------|
-| Warm throughput | ~34 qps @8-thr | ~33 qps @8-thr | ~39 qps @32-thr | ~35 qps @8-thr · ~32 qps @32-thr | parity |
-| `count(*)` wall time | 66.2 s | 61.1 s | ~60 s | ~60 s | parity |
-| `do_get` error rate | 2.3% | 1.2% | 0.89% | **0.026%** (genuine `internal`; taxonomy now decomposes it) | improving |
-| Peak RSS under load | 270–391 Mi | ~603 MB @80-thr | ~310 Mi @80-thr | ~1.1 Gi @32-thr (busy pod, flat) | — |
-| Idle RSS | 3–4 Mi | 3 Mi | 4–5 Mi | — | — |
-| Snapshot grace-sweep | — | query-triggered (738 held) | background (660→6, no query) | **background (312→172, no query)** | HELD |
-| OOMKills / restarts | 0 / 0 | 0 / 0 | 0 / 0 | **0 / 0** | clean |
-| Integrity (start == end) | — | — | 1,927,467 | **1,703,038** (new anchor, #2789 TTL) | holds |
+| Metric | Round 12 | v0.15.0 | 0.16.0-rc1 | 0.16.0 GA | Trend |
+|--------|----------|---------|------------|-----------|-------|
+| Warm throughput | ~33 qps @8-thr | ~39 qps @32-thr | ~35 qps @8-thr · ~32 qps @32-thr | ~33 qps @32-thr | parity |
+| Keyed-read splits (point read) | — | — | 13 (pruning inert, #2806) | **1** (pruning fixed) | fixed |
+| Keyed-read p50 (pruning on) | — | — | n/a (inert) | **152 ms** (−18% vs off) | new |
+| `do_get` error rate | 1.2% | 0.89% | **0.026%** (genuine `internal`) | not re-measured | improving |
+| Snapshot grace-sweep | query-triggered (738 held) | background (660→6, no query) | background (312→172, no query) | not re-run | HELD |
+| OOMKills / restarts | 0 / 0 | 0 / 0 | 0 / 0 | 0 / 0 | clean |
+| Integrity (start == end) | — | 1,927,467 | **1,703,038** (new anchor, #2789 TTL) | not re-run | holds |
 
 **What the trend shows:** the read path holds its ~JDBC-floor warm latency while the
 server-side error rate falls every round, peak memory under overload dropped by roughly


### PR DESCRIPTION
## 0.16.0 GA verification report

A focused field round on the **shipped 0.16.0 release** before moving to 0.17, re-verifying the fixes that failed or were partial across the release candidates and quantifying the split-pruning win.

**Verdict: 0.16.0 GA is sound — clear to move to 0.17.** All three tracked fixes hold:

| Fix | RC1 | GA |
|-----|-----|-----|
| #2806 / #2679 split pruning | inert (13 splits on/off) | **fixed** — 1 split, −18% p50, −4× coordinator CPU |
| #2807 UDT keyspace-qualified parse | parse crash, tables unreadable | **fixed** — all UDT tables query |
| #2349 scalar `frozen<udt>` decode | blocked behind #2807 | **verified** — `{street, zip}` readable |
| #2815 `list<frozen<udt>>` silent drop | column absent (data-loss, rc2) | **symptom fixed** — column present; raw bytes, structured decode is a 0.17 follow-up |

### What's in this PR
- `website/public/field-reports/0.16.0/{report,comparison}.html` — self-contained two-view report (verdict + RC1→GA comparison)
- `website/src/content/docs/field-validation/0-16-0-ga.md` — sidebar page (order -2, sorts above rc1)
- `website/src/content/docs/field-validation/index.md` — new report row + refreshed headline-metrics table

### Notes
- Perf numbers are Trino server-side stats (`elapsedTimeMillis`/`totalSplits`), 60 samples/mode. UDT correctness verified field-for-field against `sstabledump`.
- No Grafana panels this round — the cluster was torn down after the perf+correctness capture. The comparison page is explicit about which RC1 dimensions (soak/integrity/abort-taxonomy) GA did not re-run.
- `npm run build` passes; all internal links valid (93 pages).

Field round pmcfadin/cqlite#2805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)