### PR TITLE
release: bump versions to 0.16.1 + release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 # belongs to an unrelated project; the CLI publishes as `cqlite-cli` (binary
 # `cqlite`). See issue #782.
 name = "cqlite"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 publish = false
 
@@ -52,7 +52,7 @@ crc32fast = { workspace = true }
 cqlite-integration-tests = { path = "tests" }
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "Apache-2.0"

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.16.0"
+version = "0.16.1"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # version is required (alongside path) so the dep resolves when published to
 # crates.io. Keep this literal in sync with [workspace.package].version on every
 # release (see release checklist).
-cqlite-core = { path = "../cqlite-core", version = "0.16.0" }
+cqlite-core = { path = "../cqlite-core", version = "0.16.1" }
 
 # CLI framework
 clap = { workspace = true }

--- a/docs/releases/RELEASE_NOTES_v0.16.1.md
+++ b/docs/releases/RELEASE_NOTES_v0.16.1.md
@@ -1,0 +1,48 @@
+# CQLite v0.16.1
+
+Patch release on v0.16.0. One headline feature: CQLite now reads a **second
+Cassandra on-disk format** — CommitLog segment files — alongside SSTables.
+
+## New: Cassandra 5.0 CommitLog reader (#2389, PR #2797)
+
+A `CommitLogReader` that parses Cassandra 5.0 CommitLog segment files (the raw
+files Cassandra writes via `CommitLogSegment`/`CommitLogDescriptor`) into a
+stream of decoded mutations. Contributed by @rustyrazorblade.
+
+- **Library API**: `cqlite_core::storage::commitlog` — `CommitLogReader::open`
+  / `open_with_schemas`, lazy `MutationIter` (streaming decode, one record at a
+  time; 128 MB segment cap).
+- **CLI**: new `read-commitlog` subcommand (JSON and text output) alongside the
+  existing SSTable commands.
+- **What it decodes**: descriptor header (version-gated, Cassandra 5.0-era
+  commitlog version 7), CRC-framed sync sections with torn-tail tolerance
+  (mirrors `tolerateTruncation`), and schema-aware mutation/cell decode for the
+  common insert path.
+- **Honest bail, never a guess**: unmodeled constructs (clustering columns,
+  static rows, collection/complex columns, deletions, range tombstones) are
+  reported structurally rather than misdecoded; compressed and encrypted
+  segments fail closed with a typed error. No-heuristics throughout — format
+  facts come from the descriptor header and supplied schema only.
+- **Verified against Cassandra source and real fixtures**: field-for-field
+  adjudication against `cassandra-5.0.2` (descriptor layout, sync-marker CRC
+  feed, mutation/PartitionUpdate serialization, `VIntCoding`,
+  `CounterContext`), plus parity fixtures produced by a real Cassandra 5.0.2
+  node with an insert-set-vs-decoded-set oracle. Format documentation shipped
+  as Appendix H of the SSTable definitive guide.
+- **Scope line**: reader only. The CommitLog **writer** is #2388 (explicit
+  follow-on); CDC tailing, encryption support, and query/Flight-surface
+  integration are out of scope for this pass. Segments written under
+  `storage_compatibility_mode: NONE/UPGRADING` (commitlog version 8) are
+  rejected with a typed error — version-8 support is tracked as a follow-up.
+- Known hardening follow-ups (hostile-file edge cases, none reachable from
+  authentic Cassandra output): #2838.
+
+## Also in this release
+
+- Delivery/CI housekeeping riding main since v0.16.0 (0.16.0 GA field-validation
+  report, telemetry records).
+
+## Upgrade notes
+
+No breaking changes. All 0.16.0 APIs are unchanged; the commitlog module and
+CLI subcommand are purely additive.


### PR DESCRIPTION
Version bump 0.16.0 → 0.16.1 across all publish manifests (scripts/bump-version.sh set 0.16.1 + cli dep pin + package-lock) and v0.16.1 release notes.

Headline: Cassandra 5.0 CommitLog reader (#2389, PR #2797, contributed by @rustyrazorblade).

After this merges: tag v0.16.1 on the merge commit → tag push auto-triggers the release train; then cut release/0.16 at the tag (convention #2410).