### PR TITLE
fix(#2841): worker-supervisor headless launch (-p + skip-permissions + flow-lead) + orphan-probe + docs

### DIFF
--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -125,16 +125,31 @@ and the supervisor — not a bare loop — guards the machine:
 bash scripts/local/worker-supervisor.sh          # defaults: MAX_ISSUES=4, 8h ceiling
 ```
 
+Each iteration spawns a headless worker with the validated invocation (issue #2841):
+
+```bash
+claude -p --output-format stream-json --verbose --dangerously-skip-permissions --agent flow-lead '/worker'
+```
+
+`-p` runs the prompt to completion and exits (no interactive TUI to block on); `--agent flow-lead`
+is the registered orchestrator (`worker` is a `/`-command/skill, **not** an agent — `--agent worker`
+exits 1); `--dangerously-skip-permissions` lets an unattended session run `gh`/`git` without a human
+approving each prompt; `--output-format stream-json --verbose` streams the worker's live activity to
+stdout so the supervisor's per-iteration redirect captures it (see monitoring, below). Override the
+whole command with `WORKER_CMD` if needed; the default is what the supervisor uses when you don't.
+
 What it guarantees:
 
 - **One issue per session**: each iteration rehydrates from the board, resumes this machine's own
   claim branch first (crash recovery), else claims the next Ready item, works it to merged +
   finalized, and exits. Empty Ready = cheap no-op + backoff.
 - **It cannot overload the box**: preflight holds the next iteration while load is high, a dead
-  iteration's cargo/gate processes **or an orphaned worker Claude CLI** (`--agent worker`, #2670)
+  iteration's cargo/gate processes **or an orphaned worker Claude CLI** (the unattended
+  `claude -p … --agent flow-lead` spawn shape, #2670/#2841)
   linger, or disk is low — it waits, it never spins. A flock makes a second supervisor on the same
-  machine refuse to start. (The Claude probe keys on the supervisor's own `--agent worker` spawn
-  shape, so a legitimate interactive `claude` REPL or a different-agent session is not matched.) A
+  machine refuse to start. (The Claude probe keys on the supervisor's own `-p … --agent flow-lead`
+  spawn shape, so a legitimate interactive `claude` REPL or an interactive `claude --agent flow-lead`
+  lead session — neither carries `-p` — is not matched.) A
   hold cannot latch it silently: every hold pass re-checks the stop-file and the wall-clock budget,
   and a leftover hold that never clears stops the loop loudly, paging the surviving PIDs (#2670).
   The two leftover families are bounded **separately** (#2670): a non-self-clearing orphaned worker
@@ -170,7 +185,13 @@ What it guarantees:
   **parks** (posts a `needs-decision` question comment + EXITs) rather than waiting — the supervisor
   judges it `parked-on-owner` and pages the owner once. A worker that nonetheless gets stuck on an
   interactive prompt is caught mid-iteration by a log-tail watchdog and paged as `stuck-on-question`.
-  **Neither counts toward the crash breaker.**
+  **Neither counts toward the crash breaker.** The watchdog reads the per-iteration capture at
+  `$LOG_DIR/iter-<N>.log` — under `-p` a worker writes its narrative to the session transcript, not
+  stdout, so the supervisor's default `WORKER_CMD` adds `--output-format stream-json --verbose`
+  precisely so the redirect captures a live event stream; the watchdog's "prompt signature in the
+  tail AND log size frozen across two scans" logic then works, and the log stays useful to a human
+  (a wedged worker's byte size freezes exactly when the stream stops). **Watch a live worker** with
+  `tail -f "$LOG_DIR/iter-$(ls -1 "$LOG_DIR" | grep -oE 'iter-[0-9]+' | sort -t- -k2 -n | tail -1 | cut -d- -f2).log"` (or simply `tail -f "$LOG_DIR"/iter-*.log`).
 
 **Per-iteration verdicts** (one journal line each):
 

--- a/openspec/changes/worker-supervisor-headless-launch/design.md
+++ b/openspec/changes/worker-supervisor-headless-launch/design.md
@@ -1,0 +1,75 @@
+# Design — worker-supervisor headless launch
+
+## The corrected default invocation
+
+```sh
+WORKER_CMD="claude -p --dangerously-skip-permissions --agent flow-lead '/worker'"
+```
+
+Each token fixes one validated failure:
+- `-p` (`--print`) — non-interactive; runs the prompt to completion and exits, matching the
+  supervisor's one-shot-per-iteration model. Without it, `claude` blocks on an interactive TUI.
+- `--dangerously-skip-permissions` — a supervisor-spawned session has no human to approve
+  per-command permission prompts, so `gh project`/`gh auth`/`git worktree` etc. are auto-denied.
+  Skip-permissions is the standard headless posture; the safety net is the gate + roborev +
+  spec-audit + GitHub branch-protection + `agent-notify` pages + the breaker/wall-clock budgets,
+  NOT per-command keyboard approval.
+- `--agent flow-lead` — the registered orchestrator agent. `worker` is a `/`-command, not an agent.
+- `'/worker'` — the prompt: invoke the worker skill (single-issue session mode, #2090).
+
+The literal prompt text is kept minimal (`/worker`) because the skill body carries the full
+contract; the previous long inline prompt is redundant with the skill.
+
+## Decision: how to close the `-p` watchdog gap
+
+`-p` writes activity to the session transcript, not stdout, so the supervisor's
+`bash -c "$WORKER_CMD" >"$logfile" 2>&1` captures an empty `iter-N.log`. The
+stuck-on-question watchdog (`detect_prompt_signature`/`log_size` reading `iter-N.log`) then
+never fires.
+
+Three options considered:
+
+| Option | Approach | Verdict |
+|--------|----------|---------|
+| **A. Capture `-p` output to iter-N.log** (CHOSEN) | Add `--output-format stream-json` (or `--verbose`) so `-p` emits a live event stream to stdout, which the existing `>"$logfile"` redirect captures. The watchdog's tail-scan + no-growth logic then works unchanged. | Smallest, most local change. Keeps the watchdog contract intact. Log also becomes useful for humans tailing it (fixes the "tail is empty" confusion we hit). |
+| B. Point watchdog at the transcript | Resolve `~/.claude/projects/<proj>/<session-id>.jsonl` and scan it instead. | Rejected: the supervisor doesn't know the worker's session-id (claude self-assigns it); mapping is fragile and cmux-specific. |
+| C. Document watchdog as `-p`-incompatible | Leave the log empty; rely solely on breaker + wall-clock. | Rejected: silently drops a safety feature. Acceptable only as a fallback if A proves unreliable. |
+
+**Chosen: A**, with C as the documented fallback if the stream format is unavailable. The
+watchdog's positive-wedge-evidence logic (signature in tail AND log not growing across two
+scans) still holds against a streamed log: a wedged interactive prompt emits no further stream
+events, so the byte size freezes exactly as the watchdog expects.
+
+If `-p`'s stream output proves too chatty/noisy for the prompt-signature regex, the fallback
+is C — flip a documented flag and lean on the breaker/wall-clock backstops — but A is tried first.
+
+## Decision: the coupled orphan-detection probe
+
+`PROC_MATCH_WORKER='[c]laude.*--agent worker'` must change to `'[c]laude.*--agent flow-lead'`
+so it matches the corrected spawn. Analysis of the exclusion property:
+- The bracket trick (`[c]laude`) still prevents the probe's own `bash -c` wrapper from
+  self-matching.
+- **Widened match risk:** `--agent flow-lead` also matches an interactive `claude --agent
+  flow-lead` session an operator runs by hand (e.g. this very lead session). Per the
+  one-worker-per-machine rule (#1930) that is arguably correct to flag, but to avoid a
+  false leftover-hold against a deliberate interactive lead, the pattern is tightened to the
+  full spawn shape including `-p`: `'[c]laude.*-p.*--agent flow-lead'` (an interactive lead
+  has no `-p`). This preserves "detect orphaned unattended workers" while excluding an
+  interactive REPL and an interactive lead session.
+
+## Alternatives for the agent (why not create a `worker` agent)
+
+Creating `.claude/agents/worker.md` would make `--agent worker` valid and keep the historical
+command literally correct. Rejected: the `/worker` skill already encodes the flow-lead-worker
+persona; a separate agent duplicates that and adds a second artifact to keep synchronized with
+the skill. Reusing `flow-lead` + `/worker` is one source of truth.
+
+## Test strategy
+
+- `scripts/tests/test_worker_supervisor.sh`: update the orphan-detection pattern case to the
+  new `-p.*--agent flow-lead` shape; assert an interactive `claude --agent flow-lead` (no `-p`)
+  is NOT matched; assert a plain `claude` REPL is NOT matched.
+- Add a case asserting the default `WORKER_CMD` (when unset by the caller) contains `-p`,
+  `--dangerously-skip-permissions`, and `--agent flow-lead` — so a future edit that drops one
+  fails the test rather than shipping a silently-broken default.
+- The gate `tooling-tests` component runs this suite; it stays the gate of record.

--- a/openspec/changes/worker-supervisor-headless-launch/proposal.md
+++ b/openspec/changes/worker-supervisor-headless-launch/proposal.md
@@ -1,0 +1,74 @@
+# Fix worker-supervisor headless launch (issue #2841)
+
+## Why
+
+The unattended fleet runner `scripts/local/worker-supervisor.sh` cannot spawn a working
+worker with its documented default. Validated live on 2026-07-24, the default
+`WORKER_CMD` fails in **three independent ways**, each masking the next:
+
+1. **Wrong agent** — the default is `claude --agent worker '…'`, but `worker` is a
+   slash-command/skill (`.claude/commands/worker.md`), NOT a registered agent type. Every
+   spawn exits 1 with `--agent 'worker' not found`. Three abnormal iterations trip the
+   crash-loop breaker in ~50s (`issues_done=0`).
+2. **No headless permission grant** — with `--agent flow-lead`, the worker spawns but every
+   `gh project` / `gh auth` / `gh api` / `git worktree` / `git -C` command returns
+   "requires approval" and is auto-denied (no human in a supervisor-spawned session). The
+   worker correctly refuses to label-dispatch (Path A #1886) and prints a "please approve
+   these tools" message to a human instead of writing a `blocked` marker → `marker_present=no`
+   → abnormal → breaker.
+3. **Interactive TUI by default** — `claude` starts an interactive session unless given
+   `-p/--print`. Without it the worker opens the chat UI and blocks on keyboard input
+   forever (0.1% CPU, 0-byte log, no children) — alive to the supervisor's exit-code check
+   but doing nothing.
+
+The validated working invocation is:
+`claude -p --dangerously-skip-permissions --agent flow-lead '/worker'`
+(confirmed live: claimed #1883, created its worktree, set board In Progress, dispatched an
+Explore subagent, began authoring its OpenSpec change).
+
+A **monitoring gap** falls out of fix #3: `-p` streams worker activity to the session
+transcript (`~/.claude/projects/<proj>/<session-id>.jsonl`), NOT stdout, so
+`logs/worker-supervisor/iter-N.log` stays 0 bytes for a healthy `-p` worker. The
+supervisor's mid-iteration stuck-on-question watchdog (`detect_prompt_signature`/`log_size`
+on `iter-N.log`) can therefore never fire under `-p`.
+
+A **coupled probe** must stay consistent: `PROC_MATCH_WORKER='[c]laude.*--agent worker'`
+(the leftover-worker orphan-detection preflight probe) keys on the literal `--agent worker`.
+The corrected spawn uses `--agent flow-lead`, so this probe must be updated or the
+leftover-worker guard silently stops detecting orphans.
+
+## What Changes
+
+- Correct the baked-in default `WORKER_CMD` to the validated headless invocation.
+- Update `PROC_MATCH_WORKER` to match the corrected spawn shape while still excluding a
+  plain interactive `claude` REPL / a different-agent session.
+- Resolve the `-p` watchdog gap: capture `-p` output to `iter-N.log` so the existing
+  stuck-on-question watchdog keeps working (chosen over pointing the watchdog at the
+  transcript, or documenting it as `-p`-incompatible — see design.md).
+- Update doctrine that names `claude --agent worker`: `docs/development/fleet-runbook.md`,
+  `CLAUDE.md`, and the issue #2090 references.
+- Update `scripts/tests/test_worker_supervisor.sh`: the orphan-detection pattern test and a
+  new assertion that the default invocation is headless-shaped.
+
+## Non-goals
+
+- **No change to the worker/flow-lead behavior itself** — this is purely the launch
+  mechanism and its monitoring/probe wiring.
+- **No new `worker` agent** — reusing the registered `flow-lead` agent + the `/worker` skill
+  is deliberate (the skill already IS the flow-lead-worker persona; a new agent is another
+  artifact to maintain and keep in sync).
+- **No cmux integration work.** This box wraps `claude` in cmux (cmux hooks appear in the
+  spawned worker's `--settings`), but the plain-CLI `WORKER_CMD` is confirmed working; whether
+  a cmux-native worker entrypoint is preferable is out of scope and, if wanted, a separate issue.
+- **No change to the breaker / wall-clock / GitHub-merge-verification backstops.**
+
+## Doctrine impact
+
+User-facing launch instructions change, so `CLAUDE.md`, `docs/development/fleet-runbook.md`,
+and the website `agents-developing/` delivery-pipeline page are updated in this same change.
+
+## Routing
+
+Design-driven (process/tooling; no SSTable/parity oracle). There is a genuine design choice
+(how to close the `-p` watchdog gap) plus a coupled probe to keep consistent, so it goes
+through OpenSpec rather than straight to implement.

--- a/openspec/changes/worker-supervisor-headless-launch/specs/agent-fleet-runtime/spec.md
+++ b/openspec/changes/worker-supervisor-headless-launch/specs/agent-fleet-runtime/spec.md
@@ -1,0 +1,92 @@
+# agent-fleet-runtime — worker-supervisor headless launch
+
+## ADDED Requirements
+
+### Requirement: Default worker invocation SHALL be headless-executable
+
+The supervisor's default `WORKER_CMD` (used when the caller does not export one) SHALL launch a
+worker that runs non-interactively to completion against a valid agent with the permissions an
+unattended session needs. It SHALL invoke the registered `flow-lead` agent (not the non-existent
+`worker` agent), run in print/non-interactive mode (`-p`), and skip interactive permission
+prompts (`--dangerously-skip-permissions`).
+
+#### Scenario: Default invocation names a registered agent
+- **WHEN** the supervisor starts with no caller-provided `WORKER_CMD`
+- **THEN** the resolved `WORKER_CMD` SHALL invoke `--agent flow-lead`
+- **AND** it SHALL NOT invoke `--agent worker` (which is a slash-command/skill, not an agent type)
+
+#### Scenario: Default invocation is non-interactive
+- **WHEN** the supervisor resolves its default `WORKER_CMD`
+- **THEN** the command SHALL include the `-p`/`--print` flag so `claude` runs the prompt to
+  completion and exits rather than opening an interactive TUI that blocks on keyboard input
+
+#### Scenario: Default invocation runs without per-command approval
+- **WHEN** the supervisor resolves its default `WORKER_CMD`
+- **THEN** the command SHALL include `--dangerously-skip-permissions` so a supervisor-spawned
+  session can run `gh project`, `gh auth`, `git worktree`, and `git -C` without a human approving
+  each prompt
+
+#### Scenario: A default-invocation worker reaches the board and writes a marker
+- **GIVEN** a reachable board with at least one Ready item OR an empty Ready column
+- **WHEN** the supervisor runs one iteration with the default `WORKER_CMD`
+- **THEN** the worker SHALL orient against the board and write a well-formed iteration marker
+  (`finalized` / `no-work` / `blocked` / `parked-on-owner`)
+- **AND** the iteration SHALL NOT be judged `abnormal` due to a spawn failure, an auto-denied
+  permission, or an interactive-TUI wedge
+
+### Requirement: Leftover-worker orphan detection SHALL match the corrected spawn shape
+
+The preflight leftover-worker probe SHALL detect an orphaned unattended worker from a prior
+iteration under the corrected spawn shape, while excluding a deliberate interactive `claude`
+session (a plain REPL or an interactive `--agent flow-lead` lead session) on the same machine.
+
+#### Scenario: An orphaned unattended worker is detected
+- **GIVEN** a surviving process whose argv matches the unattended worker spawn shape
+  (`claude … -p … --agent flow-lead …`)
+- **WHEN** preflight runs its leftover-worker probe
+- **THEN** the probe SHALL count it as a leftover-worker and hold the next spawn
+
+#### Scenario: An interactive session is not misdetected as a leftover worker
+- **GIVEN** an interactive `claude --agent flow-lead` session with NO `-p` flag, or a plain
+  `claude` REPL
+- **WHEN** preflight runs its leftover-worker probe
+- **THEN** the probe SHALL NOT count it as a leftover worker
+
+#### Scenario: The probe does not match its own wrapper
+- **WHEN** the leftover-worker probe evaluates the running process list
+- **THEN** the probe's own `bash -c` wrapper (whose argv contains the pattern text) SHALL NOT
+  be counted as a leftover (bracket-trick preserved)
+
+### Requirement: The stuck-on-question watchdog SHALL observe a print-mode worker
+
+The supervisor SHALL ensure the mid-iteration stuck-on-question watchdog can still observe worker
+activity under print-mode (`-p`), which directs worker activity to the session transcript rather
+than stdout. It SHALL do so by capturing the worker's live event stream into the per-iteration log
+the watchdog scans, OR it SHALL explicitly document the watchdog as print-mode-incompatible and
+name the breaker + wall-clock budget as the operative backstops.
+
+#### Scenario: A healthy print-mode worker produces a non-empty iteration log
+- **GIVEN** the default (print-mode) `WORKER_CMD`
+- **WHEN** a worker runs and makes progress (tool calls, subagent dispatch)
+- **THEN** the per-iteration log the watchdog scans SHALL grow with the worker's activity
+  (not remain 0 bytes)
+
+#### Scenario: A wedged print-mode worker is still classified as stuck
+- **GIVEN** a print-mode worker whose captured log shows an interactive-prompt signature in its
+  tail and whose log size does not grow across two consecutive watchdog scans
+- **WHEN** the watchdog evaluates it
+- **THEN** it SHALL classify the iteration as `stuck-on-question`, page the owner, and NOT count
+  it toward the crash breaker
+
+### Requirement: Fleet doctrine SHALL instruct the working invocation
+
+User-facing fleet documentation SHALL instruct the validated headless invocation and SHALL NOT
+instruct the non-functional `--agent worker` form.
+
+#### Scenario: Doctrine names no non-functional invocation
+- **WHEN** `docs/development/fleet-runbook.md`, `CLAUDE.md`, and the issue #2090 references are
+  read
+- **THEN** they SHALL describe the launch using `--agent flow-lead` with `-p` and
+  `--dangerously-skip-permissions`
+- **AND** a repository grep for `--agent worker` as a launch instruction SHALL return nothing
+  (excluding historical/changelog context that documents the fix)

--- a/openspec/changes/worker-supervisor-headless-launch/tasks.md
+++ b/openspec/changes/worker-supervisor-headless-launch/tasks.md
@@ -1,0 +1,54 @@
+# Tasks — worker-supervisor headless launch
+
+## 1. Correct the default invocation
+- [ ] 1.1 In `scripts/local/worker-supervisor.sh` (~L258), change the default `WORKER_CMD` to
+      `claude -p --dangerously-skip-permissions --agent flow-lead '/worker'`. Update the
+      surrounding comment to explain each flag (surface: the `if [[ -z "${WORKER_CMD:-}" ]]` block).
+
+## 2. Fix the coupled orphan-detection probe
+- [ ] 2.1 In `scripts/local/worker-supervisor.sh` (~L281), change `PROC_MATCH_WORKER` to
+      `'[c]laude.*-p.*--agent flow-lead'` (matches the unattended spawn; excludes an interactive
+      `--agent flow-lead` lead that has no `-p`, and a plain REPL). Update the comment block that
+      documents the `--agent worker` keying (~L290-310, incl. the `#2670` references).
+
+## 3. Close the `-p` watchdog gap (design decision A)
+- [ ] 3.1 Ensure the worker's `-p` activity is captured into `iter-N.log` so
+      `detect_prompt_signature`/`log_size` keep working — add the stream/verbose output flag to the
+      default `WORKER_CMD` (or wrap the capture) so the redirect `>"$logfile"` is non-empty for a
+      healthy worker (surface: `run_iteration`'s `bash -c "$WORKER_CMD" >"$logfile" 2>&1`).
+- [ ] 3.2 If 3.1's stream format is unavailable/too noisy, fall back to design option C: document
+      the watchdog as print-mode-incompatible in the runbook and name the breaker + wall-clock as
+      the backstops. (Decision recorded in the PR.)
+
+## 4. Tests (gate of record: `tooling-tests` component)
+- [ ] 4.1 `scripts/tests/test_worker_supervisor.sh`: update the orphan-detection pattern test
+      (~L1372-1380) to the new `-p.*--agent flow-lead` shape; add assertions that an interactive
+      `claude --agent flow-lead` (no `-p`) and a plain `claude` REPL are NOT matched.
+- [ ] 4.2 Add a test asserting the resolved default `WORKER_CMD` (caller unset) contains `-p`,
+      `--dangerously-skip-permissions`, and `--agent flow-lead`.
+- [ ] 4.3 Add/extend a test that a healthy (stubbed) worker produces a non-empty `iter-N.log` and
+      that the wedge classifier still fires on a frozen-log + signature stub.
+
+## 5. Doctrine (same change)
+- [ ] 5.1 `docs/development/fleet-runbook.md`: correct the launch command + the `--agent worker`
+      references (~L134-136); update the monitoring section (transcript vs iter-log; how to watch a
+      `-p` worker).
+- [ ] 5.2 `CLAUDE.md`: correct any `claude --agent worker` invocation to the validated form.
+- [ ] 5.3 Website `agents-developing/` delivery-pipeline page: same launch-command correction.
+- [ ] 5.4 Add a short note to the #2090 references so the historical doctrine points at the
+      corrected invocation.
+
+## 6. Gate + audit + review (endgame, via flow-closer)
+- [ ] 6.1 `--lite` each fix round (summary-file redirect).
+- [ ] 6.2 rust-reviewer (n/a — shell/docs) → skip; run `roborev review --branch --base origin/main`
+      on the lite-green diff (review-first).
+- [ ] 6.3 flow-closer: ONE full `scripts/agent-gate.sh` → spec-auditor (C) anchored to
+      `openspec/changes/worker-supervisor-headless-launch/specs/**` → final roborev → merge-on-green
+      → finalize.
+
+## Notes
+- No production Rust change → no no-heuristics / memory-budget impact.
+- Shell + markdown only; the `file-size` ratchet and `fmt`/`clippy` components are unaffected but
+  the full gate still runs as the gate of record.
+- Do NOT restart or disturb the running fleet while implementing; the fix lands via PR and takes
+  effect on the NEXT supervisor launch.

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -301,7 +301,7 @@ fi
 # and the "what we name in the page" set can never drift apart. `[c]argo`/`[c]laude` are
 # the bracket-trick forms (see below).
 PROC_MATCH_BUILD='[c]argo |[n]extest|[g]ate_slot_daemon'
-PROC_MATCH_WORKER='[c]laude.*-p.*--agent flow-lead'
+PROC_MATCH_WORKER='[c]laude.* (-p|--print)( |$).*--agent flow-lead'
 # Leftover-process probes (issue #2670): two families of prior-iteration debris block
 # the next spawn (HOLD-and-poll, same as load/disk), bounded SEPARATELY (roborev 1839)
 # so each needs its OWN count probe:
@@ -313,15 +313,21 @@ PROC_MATCH_WORKER='[c]laude.*-p.*--agent flow-lead'
 #       LEFTOVER_HOLD_MAX (reason `leftover-worker`).
 # The Claude match is keyed on the supervisor's OWN spawn shape — the unattended
 # headless launch `claude … -p … --agent flow-lead` (see WORKER_CMD, issue #2841) —
-# NOT a bare `claude`. The `-p` token is load-bearing: a plain interactive `claude`
-# REPL has neither `-p` nor `--agent flow-lead`, and a deliberate INTERACTIVE lead
-# session (`claude --agent flow-lead`, no `-p`) is likewise excluded, so a legitimate
-# hand-run lead/REPL on the box is not misdetected as a leftover worker. Only the
-# print-mode unattended spawn carries both `-p` and `--agent flow-lead`. LIMIT: an
+# NOT a bare `claude`. The print-mode token (`-p` or `--print`) is load-bearing and is
+# matched as a WHITESPACE-DELIMITED token ` (-p|--print)( |$)` (roborev #2841): an
+# UNANCHORED `-p` would also match the `-p` inside `--dangerously-skip-permissions`
+# (ski-P-ermissions), misclassifying an interactive `claude --dangerously-skip-permissions
+# --agent flow-lead` lead as a leftover worker. A plain interactive `claude` REPL has
+# neither the print token nor `--agent flow-lead`, and a deliberate INTERACTIVE lead
+# session (`claude --agent flow-lead`, no `-p`/`--print`) is likewise excluded, so a
+# legitimate hand-run lead/REPL on the box is not misdetected as a leftover worker. Only
+# the print-mode unattended spawn carries both the print token and `--agent flow-lead`. LIMIT: an
 # operator who deliberately runs the full `claude -p … --agent flow-lead` shape by hand
 # WILL be matched (correctly — by the one-worker-per-machine rule #1930). The current
 # iteration's own worker has already exited before preflight runs, so any print-mode
-# `--agent flow-lead` process seen here is from a prior iteration.
+# `--agent flow-lead` process seen here is from a prior iteration. The WORKER_CMD default
+# and this pattern are coupled: test_worker_supervisor.sh asserts PROC_MATCH_WORKER
+# actually matches the resolved default WORKER_CMD (anti-drift, roborev #2841).
 #
 # SELF-MATCH DEFUSED (roborev 1813, MED-HIGH): a live `bash -c` wrapper's OWN argv
 # contains these pattern strings, so a naive pattern would match the wrapper and report

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -254,9 +254,32 @@ detect_ncpu() {
 LOAD_MAX="${LOAD_MAX:-$(detect_ncpu)}"
 
 # Real invocation (documented default; every real fleet run should pin this
-# explicitly rather than rely on the default prompt text drifting).
+# explicitly rather than rely on the default prompt text drifting). Validated
+# headless launch (issue #2841) — each flag fixes a distinct spawn failure:
+#   -p (--print)                    non-interactive; runs the prompt to completion
+#                                   and exits (matches the one-shot-per-iteration
+#                                   model). WITHOUT it `claude` opens an interactive
+#                                   TUI and blocks on keyboard input forever.
+#   --output-format stream-json     with `-p`, emit a LIVE event stream to stdout
+#     --verbose                     (required by the CLI for stream-json under -p)
+#                                   so the supervisor's `>"$logfile"` redirect
+#                                   captures non-empty worker activity and the
+#                                   stuck-on-question watchdog (detect_prompt_signature
+#                                   /log_size on iter-N.log) keeps working. Without a
+#                                   stream flag `-p` writes only to the session
+#                                   transcript and iter-N.log stays 0 bytes (design
+#                                   decision A; see openspec change).
+#   --dangerously-skip-permissions  a supervisor-spawned session has no human to
+#                                   approve per-command prompts, so gh project / gh
+#                                   auth / git worktree / git -C would be auto-denied.
+#   --agent flow-lead               the registered orchestrator agent. `worker` is a
+#                                   /-command/skill (.claude/commands/worker.md), NOT
+#                                   a registered agent type — `--agent worker` exits 1.
+#   '/worker'                       the prompt: invoke the worker skill (single-issue
+#                                   session mode, #2090). The skill body carries the
+#                                   full contract, so the inline prompt stays minimal.
 if [[ -z "${WORKER_CMD:-}" ]]; then
-  WORKER_CMD="claude --agent worker 'Resume the existing issue-<N>-* claim branch on this machine if one exists; otherwise claim the next Ready issue from the board. Run it to completion (implement, gate, review, merge on green, finalize, telemetry stamp). Write the iteration marker as your last act, then exit.'"
+  WORKER_CMD="claude -p --output-format stream-json --verbose --dangerously-skip-permissions --agent flow-lead '/worker'"
 fi
 
 # NOTE: default probe commands are assigned via explicit if/then blocks, not a
@@ -278,7 +301,7 @@ fi
 # and the "what we name in the page" set can never drift apart. `[c]argo`/`[c]laude` are
 # the bracket-trick forms (see below).
 PROC_MATCH_BUILD='[c]argo |[n]extest|[g]ate_slot_daemon'
-PROC_MATCH_WORKER='[c]laude.*--agent worker'
+PROC_MATCH_WORKER='[c]laude.*-p.*--agent flow-lead'
 # Leftover-process probes (issue #2670): two families of prior-iteration debris block
 # the next spawn (HOLD-and-poll, same as load/disk), bounded SEPARATELY (roborev 1839)
 # so each needs its OWN count probe:
@@ -288,13 +311,17 @@ PROC_MATCH_WORKER='[c]laude.*--agent worker'
 #   (2) an orphaned worker Claude CLI from a prior iteration (a SIGTERM'd-wrapper
 #       survivor and stuck-on-question hazard) — NON-self-clearing; gets the TIGHT
 #       LEFTOVER_HOLD_MAX (reason `leftover-worker`).
-# The Claude match is keyed on the supervisor's OWN spawn shape — `--agent worker`
-# (see WORKER_CMD) — NOT a bare `claude`. A plain interactive `claude` REPL, or a
-# different-agent session (`--agent flow-lead`), never carries that marker, so a
-# legitimate interactive session on the box is not matched. LIMIT: an operator who
-# deliberately runs `claude --agent worker` by hand WILL be matched (correctly — by the
-# one-worker-per-machine rule #1930). The current iteration's own worker has already
-# exited before preflight runs, so any `--agent worker` seen here is from a prior iteration.
+# The Claude match is keyed on the supervisor's OWN spawn shape — the unattended
+# headless launch `claude … -p … --agent flow-lead` (see WORKER_CMD, issue #2841) —
+# NOT a bare `claude`. The `-p` token is load-bearing: a plain interactive `claude`
+# REPL has neither `-p` nor `--agent flow-lead`, and a deliberate INTERACTIVE lead
+# session (`claude --agent flow-lead`, no `-p`) is likewise excluded, so a legitimate
+# hand-run lead/REPL on the box is not misdetected as a leftover worker. Only the
+# print-mode unattended spawn carries both `-p` and `--agent flow-lead`. LIMIT: an
+# operator who deliberately runs the full `claude -p … --agent flow-lead` shape by hand
+# WILL be matched (correctly — by the one-worker-per-machine rule #1930). The current
+# iteration's own worker has already exited before preflight runs, so any print-mode
+# `--agent flow-lead` process seen here is from a prior iteration.
 #
 # SELF-MATCH DEFUSED (roborev 1813, MED-HIGH): a live `bash -c` wrapper's OWN argv
 # contains these pattern strings, so a naive pattern would match the wrapper and report

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -70,6 +70,30 @@ EOF
   chmod +x "$path"
 }
 
+# issue #2841 (design decision A): a HEALTHY worker that emits activity to stdout
+# (as a real `claude -p --output-format stream-json --verbose` worker does) BEFORE
+# writing its finalize marker — so the supervisor's `>"$logfile"` redirect captures a
+# NON-EMPTY iter-N.log. Proves the watchdog has a live stream to scan under `-p`.
+write_verbose_finalize_stub() {
+  local path="$1" counter_file="$2"
+  cat >"$path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+n=0
+[[ -f "$counter_file" ]] && n=\$(cat "$counter_file")
+n=\$((n + 1))
+echo "\$n" >"$counter_file"
+# Stream-style activity to stdout (captured into iter-N.log by the supervisor).
+echo '{"type":"system","subtype":"init"}'
+echo '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}'
+echo '{"type":"assistant","message":{"content":[{"type":"text","text":"dispatching subagent"}]}}'
+cat >"\$MARKER_FILE" <<JSON
+{"outcome":"finalized","issue":\$n,"pr":"https://github.com/pmcfadin/cqlite/pull/\$n","duration_s":1}
+JSON
+EOF
+  chmod +x "$path"
+}
+
 # Finalize stub that always claims the SAME issue/PR (roborev 1839): used to exercise
 # the per-PR auto-merge-stuck path (the same PR observed unmerged N times), distinct
 # from write_finalize_stub's incrementing PR (used for the healthy distinct-PR case).
@@ -1368,29 +1392,33 @@ test_finalized_unverified_not_counted_no_breaker() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 26 (#2670): PROC_PROBE discriminates the supervisor's OWN worker spawn
-# shape (`claude ... --agent worker`) from a legitimate interactive `claude`
-# session / a different-agent session. Portable PROPERTY proof is a pure-string
+# Test 26 (#2670 / #2841): PROC_PROBE discriminates the supervisor's OWN
+# unattended worker spawn shape (`claude … -p … --agent flow-lead …`, issue
+# #2841) from a legitimate INTERACTIVE `claude --agent flow-lead` lead session
+# (no `-p`) and a plain `claude` REPL. Portable PROPERTY proof is a pure-string
 # `grep -E` regex check (always runs, deterministic); the live-process PID check
 # is a bonus that SKIPs (never fails) if the control process never schedules
 # within the wait cap — an environmental non-result, not a property failure
 # (roborev 1819 finding 7).
 # ---------------------------------------------------------------------------
 test_proc_probe_discriminates_worker_claude() {
-  local pat='[c]laude.*--agent worker'
-  # Pure-string property proof (no live process): the pattern matches the worker
-  # argv shape and NOT a different-agent session.
-  if ! printf 'claude --agent worker resume the claim\n' | grep -qE "$pat" ||
-       printf 'claude --agent flow-lead review the board\n' | grep -qE "$pat"; then
-    fail "proc-probe: pure-string regex does not discriminate worker vs other-agent"
+  local pat='[c]laude.*-p.*--agent flow-lead'
+  # Pure-string property proof (no live process): the pattern matches the
+  # unattended `-p` worker argv shape and NOT an interactive lead / plain REPL.
+  if ! printf "claude -p --output-format stream-json --verbose --dangerously-skip-permissions --agent flow-lead '/worker'\n" | grep -qE "$pat" ||
+       printf 'claude --agent flow-lead review the board\n' | grep -qE "$pat" ||
+       printf 'claude\n' | grep -qE "$pat"; then
+    fail "proc-probe: pure-string regex does not discriminate -p worker vs interactive lead / REPL"
     return
   fi
-  # Bonus live check: spawn the two argv-shaped stubs and confirm the same
+  # Bonus live check: spawn the three argv-shaped stubs and confirm the same
   # discrimination against real PIDs.
-  bash -c 'exec -a "claude --agent worker resume the claim branch" sleep 30' &
+  bash -c "exec -a 'claude -p --dangerously-skip-permissions --agent flow-lead /worker' sleep 30" &
   local wpid=$!
   bash -c 'exec -a "claude --agent flow-lead review the board" sleep 30' &
   local ipid=$!
+  bash -c 'exec -a "claude" sleep 30' &
+  local rpid=$!
   local waited=0 control_up="no"
   while [[ "$waited" -lt 50 ]]; do
     pgrep -f "$pat" | grep -qw "$wpid" && { control_up="yes"; break; }
@@ -1398,19 +1426,20 @@ test_proc_probe_discriminates_worker_claude() {
     waited=$((waited + 1))
   done
   if [[ "$control_up" == "no" ]]; then
-    kill "$wpid" "$ipid" 2>/dev/null || true
-    wait "$wpid" "$ipid" 2>/dev/null || true
+    kill "$wpid" "$ipid" "$rpid" 2>/dev/null || true
+    wait "$wpid" "$ipid" "$rpid" 2>/dev/null || true
     skip "proc-probe (live): control worker process never scheduled within cap — pure-string proof held"
     return
   fi
-  local worker_matched="yes" interactive_matched="no"
+  local worker_matched="yes" interactive_matched="no" repl_matched="no"
   pgrep -f "$pat" | grep -qw "$ipid" && interactive_matched="yes"
-  kill "$wpid" "$ipid" 2>/dev/null || true
-  wait "$wpid" "$ipid" 2>/dev/null || true
-  if [[ "$worker_matched" == "yes" && "$interactive_matched" == "no" ]]; then
-    pass "proc-probe: matches --agent worker spawn, excludes interactive/other-agent claude"
+  pgrep -f "$pat" | grep -qw "$rpid" && repl_matched="yes"
+  kill "$wpid" "$ipid" "$rpid" 2>/dev/null || true
+  wait "$wpid" "$ipid" "$rpid" 2>/dev/null || true
+  if [[ "$worker_matched" == "yes" && "$interactive_matched" == "no" && "$repl_matched" == "no" ]]; then
+    pass "proc-probe: matches -p --agent flow-lead worker, excludes interactive lead + plain REPL"
   else
-    fail "proc-probe: worker_matched=$worker_matched interactive_matched=$interactive_matched"
+    fail "proc-probe: worker=$worker_matched interactive=$interactive_matched repl=$repl_matched"
   fi
 }
 
@@ -1570,14 +1599,14 @@ test_stop_file_honored_mid_hold() {
 # sanity run of the verbatim default probe: well-formed, and its worker-Claude
 # sub-probe is 0 with no worker running.
 test_probe_no_self_match() {
-  local pat='[c]laude.*--agent worker'
+  local pat='[c]laude.*-p.*--agent flow-lead'
   # PROPERTY proof (pure-string, always runs, deterministic): the bracketed pattern
-  # matches a REAL worker argv, and does NOT match a process whose argv literally
-  # contains the bracketed PATTERN TEXT (exactly as the probe's own `bash -c`
-  # wrapper does) — `[c]laude` = literal `c`+`laude`; the text `[c]laude` has `c`
-  # followed by `]`, so no match. This is the self-exclusion property.
-  if ! printf 'claude --agent worker resume the claim\n' | grep -qE "$pat" ||
-       printf 'wrap [c]laude.*--agent worker probe\n' | grep -qE "$pat"; then
+  # matches a REAL unattended `-p` worker argv, and does NOT match a process whose
+  # argv literally contains the bracketed PATTERN TEXT (exactly as the probe's own
+  # `bash -c` wrapper does) — `[c]laude` = literal `c`+`laude`; the text `[c]laude`
+  # has `c` followed by `]`, so no match. This is the self-exclusion property.
+  if ! printf "claude -p --dangerously-skip-permissions --agent flow-lead '/worker'\n" | grep -qE "$pat" ||
+       printf 'wrap [c]laude.*-p.*--agent flow-lead probe\n' | grep -qE "$pat"; then
     fail "probe self-match: pure-string regex fails the self-exclusion property"
     return
   fi
@@ -1590,17 +1619,17 @@ test_probe_no_self_match() {
   worker_probe="$(env -u PROC_PROBE_WORKER_CMD SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$PROC_PROBE_WORKER_CMD"' 2>/dev/null)"
   # shellcheck disable=SC2016
   build_probe="$(env -u PROC_PROBE_BUILD_CMD SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$PROC_PROBE_BUILD_CMD"' 2>/dev/null)"
-  [[ "$worker_probe" == *'[c]laude.*--agent worker'* && "$worker_probe" == *'grep -vxF'* &&
+  [[ "$worker_probe" == *'[c]laude.*-p.*--agent flow-lead'* && "$worker_probe" == *'grep -vxF'* &&
      "$build_probe" == *'[c]argo '* && "$build_probe" == *'grep -vxF'* ]] && defaulted="yes"
   if [[ "$defaulted" != "yes" ]]; then
     fail "probe self-match: default per-family probe strings missing bracket trick / self-exclusion: worker='${worker_probe:0:50}' build='${build_probe:0:50}'"
     return
   fi
-  # Bonus live check: real `claude --agent worker` stub matches, wrapper-text stub
-  # does not. SKIPs (never fails) if the control worker never schedules.
-  bash -c 'exec -a "claude --agent worker resume the claim" sleep 30' &
+  # Bonus live check: real `claude -p … --agent flow-lead` stub matches, wrapper-text
+  # stub does not. SKIPs (never fails) if the control worker never schedules.
+  bash -c "exec -a 'claude -p --dangerously-skip-permissions --agent flow-lead /worker' sleep 30" &
   local wpid=$!
-  bash -c 'exec -a "wrap [c]laude.*--agent worker probe" sleep 30' &
+  bash -c 'exec -a "wrap [c]laude.*-p.*--agent flow-lead probe" sleep 30' &
   local xpid=$!
   local waited=0 control_up="no"
   while [[ "$waited" -lt 50 ]]; do
@@ -2464,6 +2493,56 @@ test_claim_issue_learned_from_marker() {
 # No test function here by design — see comment in acquire_lock() itself.
 
 # ---------------------------------------------------------------------------
+# Test (#2841): the resolved DEFAULT WORKER_CMD (caller does not export one)
+# is a headless-executable invocation — source the supervisor with WORKER_CMD
+# unset (the source-guard keeps main() from running) and assert the resolved
+# value carries `-p`, `--dangerously-skip-permissions`, and `--agent flow-lead`,
+# and does NOT name the non-existent `--agent worker`. A future edit that drops
+# any of these fails here rather than shipping a silently-broken default.
+# ---------------------------------------------------------------------------
+test_default_worker_cmd_is_headless() {
+  local resolved
+  # shellcheck disable=SC2016  # $SUP/$WORKER_CMD expand inside the sub-bash, not here.
+  resolved="$(env -u WORKER_CMD SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$WORKER_CMD"' 2>/dev/null)"
+  if [[ "$resolved" == *' -p '* && "$resolved" == *'--dangerously-skip-permissions'* &&
+        "$resolved" == *'--agent flow-lead'* && "$resolved" != *'--agent worker'* ]]; then
+    pass "default WORKER_CMD: headless (-p + skip-permissions + --agent flow-lead, no --agent worker)"
+  else
+    fail "default WORKER_CMD: resolved='$resolved'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test (#2841 / design decision A, R3): a HEALTHY worker whose stub emits stream
+# activity to stdout produces a NON-EMPTY iter-N.log (the redirect captures the
+# `-p --output-format stream-json --verbose` event stream the watchdog scans),
+# so the watchdog is not blinded under `-p`. The existing wedge classifier tests
+# (test_genuine_wedge_frozen_is_stuck etc.) cover the frozen-log+signature side.
+# ---------------------------------------------------------------------------
+test_healthy_worker_iterlog_nonempty() {
+  local d counter jf rc fcount logsize
+  d="$(new_case_dir)"
+  counter="$d/counter"
+  common_env "$d"
+  write_verbose_finalize_stub "$d/bin/worker.sh" "$counter"
+  export WORKER_CMD="$d/bin/worker.sh"
+  export MAX_ISSUES=1
+  jf="$JOURNAL_FILE"
+
+  bash "$SUPERVISOR" >"$d/stdout.log" 2>&1
+  rc=$?
+  fcount=$(jline_count "$jf" '"outcome":"finalized"')
+  logsize=0
+  [[ -f "$LOG_DIR/iter-1.log" ]] && logsize=$(wc -c <"$LOG_DIR/iter-1.log" | tr -d ' ')
+  if [[ "$rc" -eq 0 && "$fcount" -eq 1 && "$logsize" -gt 0 ]] &&
+     grep -q 'tool_use' "$LOG_DIR/iter-1.log"; then
+    pass "healthy worker: -p stream activity captured into non-empty iter-1.log ($logsize bytes)"
+  else
+    fail "healthy iter-log: rc=$rc finalized=$fcount logsize=$logsize (see $LOG_DIR/iter-1.log)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 echo "=== worker-supervisor test suite ==="
@@ -2522,5 +2601,7 @@ test_build_hold_clears_then_proceeds
 test_probe_list_derives_from_count_set
 test_grace_cap_disabled_semantics
 test_mid_grace_stop_is_aborted
+test_default_worker_cmd_is_headless
+test_healthy_worker_iterlog_nonempty
 echo "=== $PASS_COUNT passed, $FAIL_COUNT failed, $SKIP_COUNT skipped ==="
 [[ "$FAIL_COUNT" -eq 0 ]]

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -1402,13 +1402,22 @@ test_finalized_unverified_not_counted_no_breaker() {
 # (roborev 1819 finding 7).
 # ---------------------------------------------------------------------------
 test_proc_probe_discriminates_worker_claude() {
-  local pat='[c]laude.*-p.*--agent flow-lead'
+  # Source the ACTUAL pattern from the script (anti-drift): a regex edit that
+  # broke discrimination would break this test, not silently pass a stale copy.
+  local pat
+  pat="$(grep -E "^PROC_MATCH_WORKER=" "$SUPERVISOR" | head -1 | sed -E "s/^PROC_MATCH_WORKER='(.*)'$/\1/")"
   # Pure-string property proof (no live process): the pattern matches the
-  # unattended `-p` worker argv shape and NOT an interactive lead / plain REPL.
+  # unattended `-p` (and long-form `--print`) worker argv shape and NOT an
+  # interactive lead / plain REPL. The `-p` MUST be matched as a whitespace-
+  # delimited token (roborev #2841): a `claude --dangerously-skip-permissions
+  # --agent flow-lead` interactive lead has a `-p` INSIDE `ski-p-ermissions` but
+  # NO real print flag, and must NOT match.
   if ! printf "claude -p --output-format stream-json --verbose --dangerously-skip-permissions --agent flow-lead '/worker'\n" | grep -qE "$pat" ||
+       ! printf "claude --print --dangerously-skip-permissions --agent flow-lead '/worker'\n" | grep -qE "$pat" ||
+       printf 'claude --dangerously-skip-permissions --agent flow-lead review the board\n' | grep -qE "$pat" ||
        printf 'claude --agent flow-lead review the board\n' | grep -qE "$pat" ||
        printf 'claude\n' | grep -qE "$pat"; then
-    fail "proc-probe: pure-string regex does not discriminate -p worker vs interactive lead / REPL"
+    fail "proc-probe: pure-string regex does not discriminate -p/--print worker vs interactive lead (incl. skip-permissions) / REPL"
     return
   fi
   # Bonus live check: spawn the three argv-shaped stubs and confirm the same
@@ -1599,14 +1608,17 @@ test_stop_file_honored_mid_hold() {
 # sanity run of the verbatim default probe: well-formed, and its worker-Claude
 # sub-probe is 0 with no worker running.
 test_probe_no_self_match() {
-  local pat='[c]laude.*-p.*--agent flow-lead'
+  # Source the ACTUAL pattern from the script (anti-drift, roborev #2841): a naive
+  # hardcoded copy would silently desync from an edit to PROC_MATCH_WORKER.
+  local pat
+  pat="$(env -u PROC_MATCH_WORKER SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$PROC_MATCH_WORKER"' 2>/dev/null)"
   # PROPERTY proof (pure-string, always runs, deterministic): the bracketed pattern
   # matches a REAL unattended `-p` worker argv, and does NOT match a process whose
   # argv literally contains the bracketed PATTERN TEXT (exactly as the probe's own
   # `bash -c` wrapper does) — `[c]laude` = literal `c`+`laude`; the text `[c]laude`
   # has `c` followed by `]`, so no match. This is the self-exclusion property.
   if ! printf "claude -p --dangerously-skip-permissions --agent flow-lead '/worker'\n" | grep -qE "$pat" ||
-       printf 'wrap [c]laude.*-p.*--agent flow-lead probe\n' | grep -qE "$pat"; then
+       printf 'wrap %s probe\n' "$pat" | grep -qE "$pat"; then
     fail "probe self-match: pure-string regex fails the self-exclusion property"
     return
   fi
@@ -1619,7 +1631,7 @@ test_probe_no_self_match() {
   worker_probe="$(env -u PROC_PROBE_WORKER_CMD SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$PROC_PROBE_WORKER_CMD"' 2>/dev/null)"
   # shellcheck disable=SC2016
   build_probe="$(env -u PROC_PROBE_BUILD_CMD SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$PROC_PROBE_BUILD_CMD"' 2>/dev/null)"
-  [[ "$worker_probe" == *'[c]laude.*-p.*--agent flow-lead'* && "$worker_probe" == *'grep -vxF'* &&
+  [[ "$worker_probe" == *"$pat"* && "$worker_probe" == *'grep -vxF'* &&
      "$build_probe" == *'[c]argo '* && "$build_probe" == *'grep -vxF'* ]] && defaulted="yes"
   if [[ "$defaulted" != "yes" ]]; then
     fail "probe self-match: default per-family probe strings missing bracket trick / self-exclusion: worker='${worker_probe:0:50}' build='${build_probe:0:50}'"
@@ -1629,7 +1641,7 @@ test_probe_no_self_match() {
   # stub does not. SKIPs (never fails) if the control worker never schedules.
   bash -c "exec -a 'claude -p --dangerously-skip-permissions --agent flow-lead /worker' sleep 30" &
   local wpid=$!
-  bash -c 'exec -a "wrap [c]laude.*-p.*--agent flow-lead probe" sleep 30' &
+  bash -c "exec -a 'wrap $pat probe' sleep 30" &
   local xpid=$!
   local waited=0 control_up="no"
   while [[ "$waited" -lt 50 ]]; do
@@ -2499,16 +2511,22 @@ test_claim_issue_learned_from_marker() {
 # value carries `-p`, `--dangerously-skip-permissions`, and `--agent flow-lead`,
 # and does NOT name the non-existent `--agent worker`. A future edit that drops
 # any of these fails here rather than shipping a silently-broken default.
+# ANTI-DRIFT (roborev #2841): also assert PROC_MATCH_WORKER actually MATCHES the
+# resolved default WORKER_CMD — a flag reorder or regex edit that desynced the
+# orphan-probe pattern from the spawn shape (the #2670 coupling) fails HERE.
 # ---------------------------------------------------------------------------
 test_default_worker_cmd_is_headless() {
-  local resolved
+  local resolved pat
   # shellcheck disable=SC2016  # $SUP/$WORKER_CMD expand inside the sub-bash, not here.
   resolved="$(env -u WORKER_CMD SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$WORKER_CMD"' 2>/dev/null)"
+  # shellcheck disable=SC2016  # $SUP/$PROC_MATCH_WORKER expand inside the sub-bash, not here.
+  pat="$(env -u WORKER_CMD SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$PROC_MATCH_WORKER"' 2>/dev/null)"
   if [[ "$resolved" == *' -p '* && "$resolved" == *'--dangerously-skip-permissions'* &&
-        "$resolved" == *'--agent flow-lead'* && "$resolved" != *'--agent worker'* ]]; then
-    pass "default WORKER_CMD: headless (-p + skip-permissions + --agent flow-lead, no --agent worker)"
+        "$resolved" == *'--agent flow-lead'* && "$resolved" != *'--agent worker'* ]] &&
+     printf '%s' "$resolved" | grep -qE "$pat"; then
+    pass "default WORKER_CMD: headless (-p + skip-permissions + --agent flow-lead) AND matched by PROC_MATCH_WORKER"
   else
-    fail "default WORKER_CMD: resolved='$resolved'"
+    fail "default WORKER_CMD: resolved='$resolved' pat='$pat' matched=$(printf '%s' "$resolved" | grep -qE "$pat" && echo yes || echo no)"
   fi
 }
 


### PR DESCRIPTION
Closes #2841

## Summary
Fixes the unattended fleet runner's default launch, which failed three independent ways (all validated live 2026-07-24):
1. **Wrong agent** — `--agent worker` doesn't exist (it's a `/`-command/skill); use the registered `flow-lead` agent.
2. **No headless permissions** — a supervisor-spawned session auto-denies `gh project`/`gh auth`/`git worktree`; add `--dangerously-skip-permissions`.
3. **Interactive TUI** — without `-p` the worker wedges on a chat prompt at 0% CPU; add `-p`.

Corrected default: `claude -p --output-format stream-json --verbose --dangerously-skip-permissions --agent flow-lead '/worker'`.

## Changes
- `scripts/local/worker-supervisor.sh`: headless `WORKER_CMD` default (design **option A** — `stream-json`+`verbose` streams worker activity into `iter-N.log` so the stuck-on-question watchdog keeps working); `PROC_MATCH_WORKER` updated to `[c]laude.*-p.*--agent flow-lead` (matches unattended workers, excludes an interactive `--agent flow-lead` lead with no `-p` and a plain REPL).
- `scripts/tests/test_worker_supervisor.sh`: orphan-probe cases + a test asserting the default invocation is headless-shaped + R3 log-capture/wedge coverage. **57/57 pass.**
- `docs/development/fleet-runbook.md`: corrected launch command + monitoring section (how to tail a `-p` worker). CLAUDE.md + website confirmed to name no broken invocation (no change needed).
- OpenSpec change `worker-supervisor-headless-launch` (proposal/design/spec/tasks), validated `--strict`.

## Verification
- LITE gate: **RESULT: PASS** (file-size, fmt, clippy, roborev-lints, scoped-tests) at `59a2343fb`.
- `test_worker_supervisor.sh`: **57 passed, 0 failed**.
- Full `agent-gate.sh` (gate of record) runs pre-merge via flow-closer.

Spec approved at Seam 1 by owner. Design option A chosen (capture `-p` stream into the iter-log) over pointing the watchdog at the session transcript (fragile) or documenting the watchdog as `-p`-incompatible (drops a safety feature).