### PR TITLE
feat(#2165): complete the G2 single decode plane — route sequential-scan block decompress through ChunkSource

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/chunk_source.rs
+++ b/cqlite-core/src/storage/sstable/reader/chunk_source.rs
@@ -184,22 +184,28 @@ impl<'a> ChunkSource<'a> {
         Ok(self.cache.insert(key, decompressed))
     }
 
-    /// Decompress-only helper for the BIG reverse path: decompress without caching.
+    /// Decompress-only helper for already-CRC-validated compressed buffers: decompress
+    /// without caching.
     ///
-    /// Preserves the uncached behavior of the BIG reverse/seek window path
-    /// (`decompress_partition_window` via `block_io::read_compressed_chunk_at`) — no B1
-    /// cache insertion, no DECOMPRESS_CALLS counter (separate work_counters::add_chunk_decompressed).
-    /// This exists ONLY to consolidate the `Compression::decompress` call site into this
-    /// module while changing zero runtime behavior on the reverse path.
+    /// Consumers (all uncached — no B1 cache insertion, no DECOMPRESS_CALLS counter;
+    /// their own counters, e.g. work_counters::add_chunk_decompressed, apply):
+    /// - the BIG reverse/seek window path (`decompress_partition_window` via
+    ///   `block_io::read_compressed_chunk_at`),
+    /// - the stitch path (`stitch_all_chunks`, `data_access/mod.rs`),
+    /// - the sequential-scan block decode (`parse_block_entries`, issue #2165).
+    ///
+    /// This exists to consolidate the `Compression::decompress` call site into this
+    /// module while changing zero runtime behavior on those paths.
     pub(crate) fn decompress_only(
         compression: Option<&Compression>,
         compressed: Vec<u8>,
     ) -> Result<Vec<u8>> {
         if let Some(c) = compression {
+            let compressed_len = compressed.len();
             c.decompress(&compressed).map_err(|e| {
                 Error::corruption(format!(
-                    "ChunkSource: reverse-path decompress failed: {}",
-                    e
+                    "ChunkSource: decompress failed ({} compressed bytes): {}",
+                    compressed_len, e
                 ))
             })
         } else {

--- a/cqlite-core/src/storage/sstable/reader/chunk_source.rs
+++ b/cqlite-core/src/storage/sstable/reader/chunk_source.rs
@@ -2,11 +2,12 @@
 //!
 //! The point-read (BTI get, BIG point), windowed-scan, and BIG-reverse decode paths all
 //! resolve their `Compression::decompress` here. The `iterate_all_partitions` and
-//! `sequential_scan` decode sites (`parse_partition_at_offset` in `parsing/mod.rs`,
-//! `parse_block_entries` in `parsing/block_entries.rs`) remain on the legacy
-//! `self.file` + `compression_reader` model (not `ReadAt` + `CompressionInfo` + chunk-index)
-//! and are a scoped follow-up (#2165) to route through ChunkSource. Architecture test:
-//! `tests/chunk_decode_single_plane.rs`.
+//! `sequential_scan` decode site (`parse_block_entries` in `parsing/block_entries.rs`)
+//! also routes its block decompress through `ChunkSource::decompress_only` (issue #2165),
+//! so `parsing/` no longer calls `Compression::decompress` inline. `parsing/` retains the
+//! legacy `self.file` + `compression_reader` block-read/CRC model (not `ReadAt` +
+//! `CompressionInfo` + chunk-index); only the decompress step is consolidated here.
+//! Architecture test: `tests/chunk_decode_single_plane.rs`.
 
 use crate::storage::cache::{ChunkKey, DecompressedChunkCache};
 use crate::storage::sstable::compression::Compression;

--- a/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
@@ -101,6 +101,14 @@ impl SSTableReader {
 
         let mut entries = Vec::new();
 
+        // An empty block is a no-op regardless of compression: `read_next_block`
+        // can yield `Ok(Some(Vec::new()))` for a zero-length block, and an empty
+        // buffer is not valid compressed input. Short-circuit BEFORE any decompress
+        // so the enclosing scan continues instead of failing closed on empty bytes.
+        if block_data.is_empty() {
+            return Ok(entries);
+        }
+
         // Decompress block data if compression is enabled.
         //
         // Route the decompress through the single chunk decode plane
@@ -108,6 +116,20 @@ impl SSTableReader {
         // stitch path uses (`data_access/mod.rs`), so `parsing/` no longer calls
         // `Compression::decompress` inline. A failed decompress FAILS CLOSED with a
         // corruption error; it is never a silent raw-bytes parse (no-heuristics, #28).
+        //
+        // Reachability invariant (issue #2165): this compressed branch is effectively
+        // unreached on real files today — BTI-with-CompressionInfo routes to
+        // `bti_scan_with_metadata`, nb multi-chunk routes through
+        // `requires_chunk_stitching` → the stitch path, and uncompressed files take
+        // the `compression_reader == None` branch below. The fail-closed assumption
+        // (a decompress failure HERE == corruption) is therefore currently safe. It
+        // would NOT hold for Cassandra's incompressible-stored-raw chunk format
+        // (a chunk whose `len >= max_compressed_length` is stored uncompressed) if a
+        // future refactor ever re-wired a real compressed chunk through this branch:
+        // such a chunk would need the stitch path's `>= max_compressed_length` raw
+        // passthrough (see `stitch_all_chunks`), which is deliberately NOT duplicated
+        // here (dead code today). A future re-wirer MUST add it before relying on this
+        // branch for real compressed chunks.
         let data = if let Some(compression_reader) = &self.compression_reader {
             tracing::debug!(
                 "parse_block_entries: Attempting block decompression with algorithm: {:?}",
@@ -1287,8 +1309,22 @@ mod tests {
         block_data.extend_from_slice(&[0, 0, 0, 0]); // deletion_time
         block_data.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0]); // unknown 8-byte field
 
+        // Compress the synthetic block with the reader's declared algorithm so the
+        // fail-closed decompress (issue #2165) succeeds and the format dispatch this
+        // test asserts on is actually reached. A raw/uncompressed buffer would now
+        // error on decompress BEFORE any dispatch, silently voiding this coverage.
+        let compression_reader = reader
+            .compression_reader
+            .as_ref()
+            .expect("simple_table should be compressed");
+        let compression = Compression::new(*compression_reader.algorithm())
+            .expect("valid compression algorithm");
+        let compressed = compression
+            .compress(&block_data)
+            .expect("compress synthetic block");
+
         // Try parsing - should route to V5CompressedLegacyParser
-        let result = reader.parse_block_entries(&block_data, None, false);
+        let result = reader.parse_block_entries(&compressed, None, false);
 
         // We expect either success or a specific parsing error (not a dispatch error)
         match result {
@@ -1297,6 +1333,14 @@ mod tests {
             }
             Err(e) => {
                 let err_msg = e.to_string();
+                // Decompress must have SUCCEEDED — otherwise dispatch was never reached
+                // and this test would pass vacuously (issue #2165: fail-closed decompress
+                // errors before dispatch on a raw buffer).
+                assert!(
+                    !err_msg.contains("decompress"),
+                    "block must decompress so dispatch is reached, got decompress error: {}",
+                    err_msg
+                );
                 // Should not be a format dispatch error
                 assert!(
                     !err_msg.contains("Unknown format") && !err_msg.contains("Not implemented"),
@@ -1362,20 +1406,60 @@ mod tests {
 
         let result = reader.parse_block_entries(&invalid_compressed_data, None, false);
 
-        // FAIL CLOSED: an Err propagates, and no rows are produced from the raw bytes.
+        // FAIL CLOSED: the DECOMPRESS path must return a corruption error (not just
+        // any error), and no rows may be produced from the raw bytes.
         match result {
             Ok(rows) => panic!(
                 "decompress failure must fail closed with an error, got {} rows",
                 rows.len()
             ),
             Err(e) => {
+                assert!(
+                    matches!(e, Error::Corruption(_)),
+                    "decompress failure must surface as Error::Corruption, got: {:?}",
+                    e
+                );
                 let err_msg = e.to_string();
                 assert!(
-                    !err_msg.is_empty(),
-                    "Should produce a meaningful corruption error message"
+                    err_msg.contains("decompress"),
+                    "corruption error should name the decompress failure, got: {}",
+                    err_msg
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_empty_block_on_compressed_reader_is_noop() {
+        // Issue #2165: `read_next_block` can yield an empty block; on a COMPRESSED
+        // reader the empty buffer must NOT reach decompress (which would fail closed
+        // and abort the whole scan). It must short-circuit to Ok(empty entries) so
+        // the enclosing scan continues.
+        let reader = match create_test_reader("test_basic", "compression_test_table").await {
+            Some(r) => r,
+            None => {
+                eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set or test data unavailable");
+                return;
+            }
+        };
+        assert!(
+            reader.compression_reader.is_some(),
+            "Expected compression_test_table to have compression"
+        );
+
+        let empty: Vec<u8> = Vec::new();
+        let result = reader.parse_block_entries(&empty, None, false);
+
+        assert!(
+            result.is_ok(),
+            "empty block on a compressed reader must be a no-op, got: {:?}",
+            result
+        );
+        assert_eq!(
+            result.unwrap().len(),
+            0,
+            "empty block must yield zero entries"
+        );
     }
 
     // ========================================================================

--- a/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
@@ -109,27 +109,19 @@ impl SSTableReader {
             return Ok(entries);
         }
 
-        // Decompress block data if compression is enabled.
-        //
-        // Route the decompress through the single chunk decode plane
-        // (`ChunkSource::decompress_only`, issue #2165 / G2) — the same shape the
-        // stitch path uses (`data_access/mod.rs`), so `parsing/` no longer calls
+        // Decompress block data if compression is enabled. Route through the single
+        // chunk decode plane (`ChunkSource::decompress_only`, issue #2165 / G2) — the
+        // stitch-path shape (`data_access/mod.rs`) — so `parsing/` no longer calls
         // `Compression::decompress` inline. A failed decompress FAILS CLOSED with a
-        // corruption error; it is never a silent raw-bytes parse (no-heuristics, #28).
+        // corruption error; never a silent raw-bytes parse (no-heuristics, #28).
         //
-        // Reachability invariant (issue #2165): this compressed branch is effectively
-        // unreached on real files today — BTI-with-CompressionInfo routes to
-        // `bti_scan_with_metadata`, nb multi-chunk routes through
-        // `requires_chunk_stitching` → the stitch path, and uncompressed files take
-        // the `compression_reader == None` branch below. The fail-closed assumption
-        // (a decompress failure HERE == corruption) is therefore currently safe. It
-        // would NOT hold for Cassandra's incompressible-stored-raw chunk format
-        // (a chunk whose `len >= max_compressed_length` is stored uncompressed) if a
-        // future refactor ever re-wired a real compressed chunk through this branch:
-        // such a chunk would need the stitch path's `>= max_compressed_length` raw
-        // passthrough (see `stitch_all_chunks`), which is deliberately NOT duplicated
-        // here (dead code today). A future re-wirer MUST add it before relying on this
-        // branch for real compressed chunks.
+        // Reachability invariant (#2165): this compressed branch is effectively
+        // unreached on real files today (BTI+CompressionInfo → `bti_scan_with_metadata`;
+        // nb multi-chunk → `requires_chunk_stitching` stitch path; uncompressed →
+        // the `None` branch below), so fail-closed == corruption is currently safe.
+        // A future re-wirer sending real compressed chunks here MUST first add the
+        // stitch path's `len >= max_compressed_length` raw-passthrough (incompressible
+        // chunks are stored uncompressed) — deliberately NOT duplicated here (dead today).
         let data = if let Some(compression_reader) = &self.compression_reader {
             tracing::debug!(
                 "parse_block_entries: Attempting block decompression with algorithm: {:?}",
@@ -1317,8 +1309,8 @@ mod tests {
             .compression_reader
             .as_ref()
             .expect("simple_table should be compressed");
-        let compression = Compression::new(*compression_reader.algorithm())
-            .expect("valid compression algorithm");
+        let compression =
+            Compression::new(*compression_reader.algorithm()).expect("valid compression algorithm");
         let compressed = compression
             .compress(&block_data)
             .expect("compress synthetic block");

--- a/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
@@ -101,29 +101,23 @@ impl SSTableReader {
 
         let mut entries = Vec::new();
 
-        // Decompress block data if compression is enabled
+        // Decompress block data if compression is enabled.
+        //
+        // Route the decompress through the single chunk decode plane
+        // (`ChunkSource::decompress_only`, issue #2165 / G2) — the same shape the
+        // stitch path uses (`data_access/mod.rs`), so `parsing/` no longer calls
+        // `Compression::decompress` inline. A failed decompress FAILS CLOSED with a
+        // corruption error; it is never a silent raw-bytes parse (no-heuristics, #28).
         let data = if let Some(compression_reader) = &self.compression_reader {
             tracing::debug!(
                 "parse_block_entries: Attempting block decompression with algorithm: {:?}",
                 compression_reader.algorithm()
             );
             let compression = Compression::new(*compression_reader.algorithm())?;
-            match compression.decompress(block_data) {
-                Ok(decompressed) => {
-                    tracing::debug!(
-                        "parse_block_entries: Block decompressed {} bytes to {} bytes",
-                        block_data.len(),
-                        decompressed.len()
-                    );
-                    decompressed
-                }
-                Err(e) => {
-                    tracing::debug!("parse_block_entries: Block decompression failed ({}), parsing raw data instead. First 32 bytes: {:02x?}",
-                        e, &block_data[..std::cmp::min(32, block_data.len())]);
-                    // Fall back to raw data
-                    block_data.to_vec()
-                }
-            }
+            super::super::chunk_source::ChunkSource::decompress_only(
+                Some(&compression),
+                block_data.to_vec(),
+            )?
         } else {
             tracing::debug!("parse_block_entries: No compression, using raw block data");
             block_data.to_vec()
@@ -1344,7 +1338,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_decompression_fallback_on_failure() {
+    async fn test_decompression_failure_is_fail_closed() {
+        // Issue #2165 / G2: a compressed block that fails to decompress must FAIL
+        // CLOSED (corruption error) — it must NOT silently fall back to parsing the
+        // raw compressed bytes as row data (no-heuristics, #28). This flips the former
+        // `test_decompression_fallback_on_failure`, which asserted the silent fallback.
         let reader = match create_test_reader("test_basic", "compression_test_table").await {
             Some(r) => r,
             None => {
@@ -1353,30 +1351,28 @@ mod tests {
             }
         };
 
-        // Verify this table has compression
+        // Verify this table has compression (drives the decompress branch)
         assert!(
             reader.compression_reader.is_some(),
             "Expected compression_test_table to have compression"
         );
 
-        // Pass invalid compressed data (should fall back to raw parsing)
+        // Bytes that cannot be decompressed by the declared algorithm.
         let invalid_compressed_data = vec![0xFF; 100];
 
         let result = reader.parse_block_entries(&invalid_compressed_data, None, false);
 
-        // Should attempt decompression, fail, then fall back to raw parsing
-        // The raw parsing will likely fail too (invalid data), but we verify
-        // the decompression fallback path is exercised
+        // FAIL CLOSED: an Err propagates, and no rows are produced from the raw bytes.
         match result {
-            Ok(_) => {
-                // If it somehow succeeds, that's fine
-            }
+            Ok(rows) => panic!(
+                "decompress failure must fail closed with an error, got {} rows",
+                rows.len()
+            ),
             Err(e) => {
                 let err_msg = e.to_string();
-                // Should not panic or crash, just return an error
                 assert!(
                     !err_msg.is_empty(),
-                    "Should produce a meaningful error message"
+                    "Should produce a meaningful corruption error message"
                 );
             }
         }

--- a/cqlite-core/tests/chunk_decode_single_plane.rs
+++ b/cqlite-core/tests/chunk_decode_single_plane.rs
@@ -39,12 +39,8 @@ fn scan_file(path: &Path, sites: &mut Vec<(String, usize)>, root: &Path) {
     if rel_str.contains("chunk_decompressor.rs")
         || rel_str.contains("bulletproof_reader.rs")
         || rel_str.contains("benchmarks/") // benchmarks are not query-path
-        || rel_str.contains("compaction.rs") // compaction read: out of scope (design.md)
-        // parsing/mod.rs and parsing/block_entries.rs: iterate_all_partitions / sequential_scan
-        // decode path (self.file + compression_reader model, not ReadAt+CompressionInfo+chunk-index).
-        // Migrating them to ChunkSource is a scoped follow-up (see design.md "Deferred / follow-up").
-        || rel_str.contains("parsing/mod.rs")
-        || rel_str.contains("parsing/block_entries.rs")
+        || rel_str.contains("compaction.rs")
+    // compaction read: out of scope (design.md)
     {
         return;
     }
@@ -264,11 +260,11 @@ async fn warm_cache_skips_decompress() {
 ///
 /// Drives the WINDOWED scan plane (`scan_stream` → `run_scan_stream_windowed` →
 /// `ChunkSource::new`), NOT `SSTableReader::scan()`: `scan()` on an nb/BIG SSTable
-/// takes the legacy `self.file` + `compression_reader` sequential path
-/// (`sequential_scan`) that is the scoped #2165 follow-up and never bumps
-/// `DECOMPRESS_CALLS`. `simple_table` is nb + Snappy multi-chunk, so
-/// `requires_chunk_stitching()` holds and `scan_stream` routes through the
-/// ChunkSource windowed decode plane this change consolidates.
+/// takes the sequential path (`sequential_scan` → `parse_block_entries`), which now
+/// routes its block decompress through `ChunkSource::decompress_only` (issue #2165)
+/// — an uncached decompress that never bumps `DECOMPRESS_CALLS`. `simple_table` is
+/// nb + Snappy multi-chunk, so `requires_chunk_stitching()` holds and `scan_stream`
+/// routes through the ChunkSource windowed decode plane this test asserts.
 #[tokio::test]
 #[serial_test::serial]
 async fn warm_windowed_scan_skips_decompress() {

--- a/openspec/changes/chunk-source-scan-decode/design.md
+++ b/openspec/changes/chunk-source-scan-decode/design.md
@@ -1,0 +1,77 @@
+# Design: chunk-source-scan-decode (issue #2165)
+
+## Context
+
+Current state of the two sites named by the issue:
+
+| Site named in #2165 | Current reality |
+|---|---|
+| `parse_partition_at_offset` (`parsing/mod.rs:685`) | **Gone.** Removed by the #112 file splits + #2302 full-index enumeration. `parsing/mod.rs` has zero `.decompress(` calls. Allowlist entry is dead. |
+| `parse_block_entries` (`parsing/block_entries.rs:111`) | **Live, narrowly reached.** Decompresses an already-read, CRC-validated compressed block (`read_next_block` → `read_nb_format_chunk_data`) inline via `Compression::new(*compression_reader.algorithm())`, with a silent parse-raw-bytes fallback on failure (lines 120–125). Callers: `data_access/sequential.rs:273` (`get_all_entries`) and `:768` (`sequential_scan`), non-stitching branch only. Public surfaces: `SSTableReader::scan` (three index-fallback sites) and `iterate_all_partitions` → `sequential_scan`, plus `full_index_stream.rs:423` bail-to-sequential. |
+
+Reachability note: `requires_chunk_stitching()` routes `V5CompressedLegacy` + nb through the stitch
+path (already on `ChunkSource::decompress_only`), and BTI-compressed scans early-return via
+`bti_scan_with_metadata`; uncompressed formats have `compression_reader == None`. So the `:111`
+decompress fires on a narrow residue of real-world inputs; the deliberate driver is the synthetic
+test `test_decompression_fallback_on_failure` (`block_entries.rs:1347`). The change is therefore
+primarily an **architecture-invariant completion** (close the G2 plane, delete the allowlist) plus
+one **fail-closed semantic fix**, with the full parity suite guarding no-regression.
+
+## Decision 1 — migration shape: `decompress_only`, not `chunk(index)`
+
+**Chosen: (a) mechanical swap to `ChunkSource::decompress_only(self.compression.as_ref(), block_data)`**
+(static, uncached, no counter) — exactly the pattern the stitch path uses at `data_access/mod.rs:474`
+for the same input shape: a buffer already read + CRC-validated by the unified C2 primitive
+(`block_io.rs::read_compressed_chunk_at`).
+
+**Beat: (b) restructuring the non-stitching loop onto `ChunkSource::new(...)` + `chunk(index)`.**
+That would require threading a `ReadAt` source, `CompressionInfo`, cache namespace + `cache_id`
+through `ScanCursor`/`read_next_block`, duplicate the CRC step already performed upstream, and put
+full-scan blocks into the B1 `DecompressedChunkCache` — churning the cache point reads depend on,
+for zero correctness gain. The archived G2 design's "adaptation layer" anticipated this heavier
+shape before `parse_partition_at_offset` was removed; it is no longer warranted.
+
+## Decision 2 — decompress failure fails closed (behavioral change, corrupt files only)
+
+**Chosen:** a failed block decompress returns a corruption error (via `decompress_only`'s `Err`),
+never a silent raw-bytes parse attempt.
+
+**Beat:** preserving the legacy fallback (wrap `decompress_only` in `or_else(raw)`). Rejected as a
+no-heuristics violation (#28): "maybe these compressed bytes were actually uncompressed" is
+byte-pattern guessing; on a genuinely corrupt file it can fabricate garbage rows instead of an
+error. `ChunkSource` (the plane of record) already fails closed on every other path; keeping a
+divergent semantic in the one migrated site would defeat the point of consolidation.
+
+`test_decompression_fallback_on_failure` (`block_entries.rs:1347`) — today the only deliberate
+driver of the fallback — flips to assert the error. Healthy-file behavior is unchanged
+(`compression: None` ⇒ raw passthrough is identical on both models).
+
+## Architecture-test delta
+
+`chunk_decode_single_plane.rs`: delete the two exclusion lines (46–47) + their comment (43–45);
+update the `warm_windowed_scan_skips_decompress` doc-comment (267–271) which currently documents the
+legacy path as "the scoped #2165 follow-up"; update the `chunk_source.rs:4-9` module doc naming the
+deferred sites. The scan then asserts `parsing/` is fully consolidated — the issue's acceptance
+criterion verbatim.
+
+## Test plan (wiring evidence)
+
+- **Architecture:** `chunk_decode_single_plane.rs` green with the allowlist entries removed —
+  `.decompress(` resolves in exactly one module (`chunk_source`).
+- **Fail-closed:** flipped `test_decompression_fallback_on_failure` asserts a corruption error
+  through the `parse_block_entries` surface.
+- **No-regression (public surfaces, real fixtures):** `v5_compressed_legacy_parity_test.rs`,
+  `v5_compressed_legacy_row_count_parity.rs`, `issue_1085_tombstones_full_scan_parity.rs`
+  (full-scan reconciliation), `index_size_zero_integration_test.rs` (drives the size=0 →
+  `sequential_scan` fallback that reaches `parse_block_entries`), `point_vs_full_differential.rs`
+  + `query_semantics_oracle_parity.rs` (read-path equivalence), 33-table smoke.
+- **Alloc/perf guards untouched but relevant:** `test_issue_1046_scan_alloc_scaling.rs`,
+  `issue_1333_scan_scratch_reuse.rs` (per-block buffer handling unchanged: same
+  input buffer, same output `Vec<u8>`).
+
+## Risks
+
+- **Low.** One call-site swap with an in-repo precedent; the narrow reachability means the parity
+  blast radius is small, and the full suite covers the scan/iterate surfaces that could regress.
+- The fail-closed flip could, in theory, surface errors on previously-"working" corrupt files —
+  that is the intended behavior change and is confined to files whose blocks fail decompression.

--- a/openspec/changes/chunk-source-scan-decode/proposal.md
+++ b/openspec/changes/chunk-source-scan-decode/proposal.md
@@ -1,0 +1,59 @@
+# Proposal: Complete the G2 single decode plane — migrate the last `parsing/` decompress site onto `ChunkSource` (issue #2165)
+
+**Milestone:** 0.17 · **Priority:** P3 · **Routing:** design-driven (I/O-model consolidation with a
+behavioral decision) · **Issue:** #2165 (G2 follow-up from #1598)
+
+## Why
+
+Issue #1598 (G2) consolidated the query-path chunk decode (read → CRC → decompress → B1-cache) into
+one module, `reader/chunk_source.rs`, and locked the invariant with the architecture test
+`cqlite-core/tests/chunk_decode_single_plane.rs`. Two `parsing/` sites were deferred with allowlist
+exclusions. Investigation of the current tree (2026-07-23) corrects the issue premise:
+
+- **`parse_partition_at_offset` no longer exists.** `parsing/mod.rs` (now 355 lines, post-#112
+  splits and #2302 full-index enumeration) contains zero `.decompress(` calls. Its allowlist
+  exclusion (`chunk_decode_single_plane.rs:46`) is vacuous dead config.
+- **Exactly ONE query-reachable legacy site remains:** `parse_block_entries`
+  (`parsing/block_entries.rs:111`) — inline `Compression::new(...)` + `decompress(block_data)`
+  driven by the legacy `self.compression_reader` field, reached from the non-stitching branches of
+  `sequential_scan` and `get_all_entries` (public surfaces: `SSTableReader::scan` index-fallback
+  paths and `iterate_all_partitions` → `sequential_scan`).
+- That site also carries a **silent decompress-failure → parse-raw-bytes fallback**
+  (`block_entries.rs:120-125`) — a no-heuristics smell (#28): on corruption it guesses the bytes
+  were uncompressed instead of surfacing an error. `ChunkSource` fails closed
+  (`Error::corruption`); the legacy site must not keep a divergent semantic.
+
+The archived G2 design's "adaptation layer" framing is heavier than current reality: the in-repo
+precedent for exactly this shape — an already-read, already-CRC-validated compressed buffer — is the
+stitch path (`data_access/mod.rs:474`), which calls `ChunkSource::decompress_only(...)`.
+
+## What Changes
+
+1. **Migrate `parsing/block_entries.rs:111`** to `ChunkSource::decompress_only(...)` — the same
+   pattern as the stitch path. The `compression_reader == None` (uncompressed / no
+   `CompressionInfo`) raw passthrough is preserved unchanged.
+2. **Drop the silent raw-bytes fallback** on decompress failure — fail closed with a corruption
+   error, matching `ChunkSource` semantics and the no-heuristics mandate. The synthetic test
+   `test_decompression_fallback_on_failure` flips to assert the fail-closed behavior.
+3. **Remove the two allowlist exclusions** (`parsing/mod.rs`, `parsing/block_entries.rs`) from
+   `chunk_decode_single_plane.rs` so the architecture test asserts full consolidation of `parsing/`,
+   and update its stale doc-comments (the `warm_windowed_scan_skips_decompress` note naming #2165 as
+   pending, and the `chunk_source.rs:4-9` module doc naming the deferred sites).
+4. **Record the premise correction** on issue #2165 (comment; no scope/title change).
+
+## Non-goals
+
+- No restructuring of the sequential-scan I/O model (`ScanCursor` / `read_next_block` / `block_io`)
+  onto `ChunkSource::chunk(index)` — the block read + CRC already happens upstream in the unified C2
+  primitive; only the decompress step moves.
+- No B1-caching of sequential-scan blocks (a full scan would churn the point-read chunk cache).
+- No change to the stitching (`V5CompressedLegacy`/nb) path, BTI scan path, public APIs, or decoded
+  bytes on any healthy file.
+- No deletion of `parse_block_entries` itself or its callers.
+
+## Doctrine impact
+
+None (no CLAUDE.md / website change). The architecture test and module docs updated in-change are
+the record. Behavioral delta on **corrupt** compressed files only: previously a failed block
+decompress silently attempted a raw parse; now it errors — the fail-closed direction doctrine
+already mandates.

--- a/openspec/changes/chunk-source-scan-decode/specs/chunk-decode-plane/spec.md
+++ b/openspec/changes/chunk-source-scan-decode/specs/chunk-decode-plane/spec.md
@@ -1,0 +1,53 @@
+# chunk-decode-plane — delta for chunk-source-scan-decode (issue #2165)
+
+## MODIFIED Requirements
+
+### Requirement: A single chunk decode plane
+Chunk read → CRC → decompress → B1-cache SHALL be performed in exactly one module
+(`reader/chunk_source.rs`) reached by every query/CLI-query read path — including the sequential
+scan and full-partition iteration paths (`sequential_scan`, `iterate_all_partitions`,
+`parse_block_entries`). No other non-test module in the query decode path SHALL call a compression
+`decompress` primitive or an inline chunk CRC verification directly, and the architecture test
+SHALL NOT carry allowlist exclusions for `parsing/` modules.
+
+#### Scenario: Decompress is invoked from exactly one module on the query path
+- **WHEN** the workspace source is scanned for calls to `Compression::decompress` (or an inline per-chunk `crc32fast` verify-then-decompress sequence) reachable from `get`, the windowed scan, the sequential scan / full-partition iteration, or the CLI query path
+- **THEN** every such call resolves inside `reader/chunk_source.rs`, and the architecture test that counts these call sites reports exactly one module
+
+#### Scenario: The parsing module carries no decompress call sites and no allowlist exclusion
+- **WHEN** `cqlite-core/tests/chunk_decode_single_plane.rs` runs after the migration
+- **THEN** its source scan covers `parsing/mod.rs` and `parsing/block_entries.rs` (the exclusion entries for both are deleted), and the test passes with `parsing/` fully consolidated
+
+#### Scenario: A repeat read of a resident chunk decompresses zero times
+- **WHEN** the same chunk index is read twice through `ChunkSource::chunk` with a warm `DecompressedChunkCache`
+- **THEN** the second call returns an `Arc` clone of the cached bytes, the process-global `DECOMPRESS_CALLS` counter is unchanged across the second call, and no file read is issued
+
+#### Scenario: CRC is verified before decompression
+- **WHEN** `ChunkSource::chunk` reads a chunk whose stored inline CRC32 does not match the computed CRC over its compressed bytes
+- **THEN** it returns a corruption error and never invokes the decompressor for that chunk
+
+## ADDED Requirements
+
+### Requirement: Sequential block decompression fails closed
+The reader SHALL surface a corruption error when a compressed block reached via the sequential
+scan / full-partition iteration path (`parse_block_entries`) fails decompression, and SHALL NOT
+fall back to parsing the raw compressed bytes as row data.
+
+#### Scenario: Decompress failure surfaces an error instead of a raw-bytes parse
+- **GIVEN** a reader whose `CompressionInfo` declares a compression algorithm and a block whose bytes fail decompression
+- **WHEN** `parse_block_entries` processes that block
+- **THEN** it returns a corruption error, no rows are produced from the raw bytes, and the former silent-fallback test (`test_decompression_fallback_on_failure`) asserts this fail-closed behavior
+
+#### Scenario: Uncompressed readers are unaffected
+- **GIVEN** a reader with no `CompressionInfo` (`compression_reader == None`), e.g. an uncompressed or BTI no-CompressionInfo SSTable
+- **WHEN** the sequential scan parses its blocks
+- **THEN** blocks are parsed as raw bytes exactly as before the migration, with no decompression attempted and no error
+
+### Requirement: Scan and iteration parity is unchanged by the migration
+Routing the sequential-scan block decompress through `ChunkSource` SHALL NOT change any decoded
+bytes or row set on healthy files; the existing parity suites over the public scan/iteration
+surfaces SHALL remain green.
+
+#### Scenario: Sequential-scan and full-iteration parity suites stay green on real fixtures
+- **WHEN** the compressed-legacy parity tests (`v5_compressed_legacy_parity_test`, `v5_compressed_legacy_row_count_parity`), the tombstone full-scan parity test (`issue_1085`), the index-size-zero sequential-fallback integration test, the point-vs-full differential lane, and the query-semantics oracle run against the real datasets after the migration
+- **THEN** every previously passing test passes with identical rows, values, and order

--- a/openspec/changes/chunk-source-scan-decode/tasks.md
+++ b/openspec/changes/chunk-source-scan-decode/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: chunk-source-scan-decode (issue #2165)
+
+## 1. Migrate the decompress site (surface: `parse_block_entries` → `SSTableReader::scan` / `iterate_all_partitions`)
+- [ ] 1.1 Replace the inline `Compression::new(...)` + `decompress(block_data)` at
+      `parsing/block_entries.rs:111` with `ChunkSource::decompress_only(...)` (stitch-path
+      precedent, `data_access/mod.rs:474`); preserve the `compression_reader == None` raw
+      passthrough unchanged.
+- [ ] 1.2 Remove the silent decompress-failure → raw-bytes fallback (lines 120–125); propagate the
+      corruption error.
+- [ ] 1.3 Flip `test_decompression_fallback_on_failure` (`block_entries.rs:1347`) to assert the
+      fail-closed error through the `parse_block_entries` surface.
+
+## 2. Architecture test + docs (surface: `chunk_decode_single_plane.rs`)
+- [ ] 2.1 Delete the `parsing/mod.rs` + `parsing/block_entries.rs` exclusions (lines 43–47) so the
+      scan covers `parsing/` fully; test must pass.
+- [ ] 2.2 Update stale doc-comments naming #2165 as pending: `warm_windowed_scan_skips_decompress`
+      (chunk_decode_single_plane.rs:267–271) and the `chunk_source.rs:4–9` module doc.
+- [ ] 2.3 Comment the premise correction on issue #2165 (`parse_partition_at_offset` already gone;
+      scope reduced to one site). No scope/title change.
+
+## 3. Verify (public surfaces, real fixtures; `CQLITE_DATASETS_ROOT` → main repo datasets)
+- [ ] 3.1 Diff-scoped: `chunk_decode_single_plane`, flipped fallback test, `cqlite-core --lib`.
+- [ ] 3.2 Parity/no-regression targets: `v5_compressed_legacy_parity_test`,
+      `v5_compressed_legacy_row_count_parity`, `issue_1085_tombstones_full_scan_parity`,
+      `index_size_zero_integration_test`, `point_vs_full_differential`,
+      `query_semantics_oracle_parity`; 33-table smoke.
+- [ ] 3.3 `scripts/agent-gate.sh --lite` green each fix round (summary-file redirect).
+
+## 4. Review + endgame (per the implement loop)
+- [ ] 4.1 `rust-reviewer` + roborev on the lite-green diff (review-first).
+- [ ] 4.2 Open PR (1:1:1:1; branch `issue-2165-chunk-source-scan-decode`).
+- [ ] 4.3 `flow-closer`: ONE full gate → C (`spec-auditor` on this change's `specs/**`) → final
+      roborev → premerge-assert + `--auto` merge → finalize (telemetry stamp + archive + close).


### PR DESCRIPTION
Closes #2165.

Completes the G2 single-chunk-decode-plane (#1598): migrates the last query-reachable inline `Compression::decompress` in `parsing/` onto `ChunkSource::decompress_only`, and removes the silent decompress-failure → raw-bytes fallback so the sequential scan **fails closed** (no-heuristics #28). The arch test `chunk_decode_single_plane.rs` now asserts `parsing/` is fully consolidated (both allowlist exclusions deleted).

**Premise correction (from tree investigation):** `parse_partition_at_offset` (parsing/mod.rs:685) named in the issue no longer exists (removed by #112 splits + #2302 full-index enumeration). Exactly ONE site remained — `parse_block_entries` (block_entries.rs).

### Changes
- `parse_block_entries`: `ChunkSource::decompress_only(...)` swap (stitch-path precedent at data_access/mod.rs:474); `compression_reader == None` raw passthrough preserved exactly.
- Fail-closed on decompress failure (silent raw-bytes fallback removed).
- **Empty-block short-circuit** before decompress — a zero-length block stays a no-op instead of failing closed and aborting the whole scan (roborev catch).
- Restored `test_format_dispatch_row_decoder` coverage (compresses its synthetic block so format dispatch is actually reached; was silently vacuous under fail-closed).
- `decompress_only` doc/error generalized across its 3 consumers (incl. compressed-len for triage).
- Reachability-invariant comment documenting why a real (incl. incompressible-stored-raw) compressed chunk can't reach this fail-closed branch today.

### Review
- rust-reviewer (2 passes): no blockers. roborev: 4 findings (1 med + 3 low) all addressed; 1 nit deferred (`to_vec` on a dead branch).
- New tests: `test_empty_block_on_compressed_reader_is_noop`, strengthened `test_decompression_failure_is_fail_closed` (asserts `Error::Corruption` + "decompress").
- Parity/no-regression: v5_compressed_legacy_parity, v5_compressed_legacy_row_count_parity, issue_1085_tombstones_full_scan_parity, index_size_zero_integration_test, point_vs_full_differential, query_semantics_oracle_parity — all green. Lite PASS @ dff2935bb.

### Note for the gate of record
`block_entries.rs` is a known epic-#1116/#1135 over-threshold file (1487→1559 from the review-mandated inline tests; splitting is out of scope here) — the full gate needs `CQLITE_ALLOW_FILE_GROWTH=1`.

OpenSpec change: `chunk-source-scan-decode`.