### PR TITLE
docs(#2844): backfill release section — website pages + index + CHANGELOG for v0.14.0–v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,245 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes. The next version's entries will collect here._
+
+## [v0.16.1] - 2026-07-23
+
+_The CommitLog release._ A patch on v0.16.0 that adds a second Cassandra on-disk
+format — CommitLog segment files — alongside SSTables. No breaking changes; the new
+module and CLI subcommand are purely additive.
+
+### Added
+
+- Cassandra 5.0 CommitLog reader: `cqlite_core::storage::commitlog` with
+  `CommitLogReader::open` / `open_with_schemas` and a lazy streaming `MutationIter`
+  (one record at a time, 128 MB segment cap) (#2389, PR #2797). Contributed by
+  @rustyrazorblade.
+- `read-commitlog` CLI subcommand (JSON and text output) alongside the SSTable
+  commands (#2389, PR #2797).
+- Appendix H of the SSTable definitive guide: CommitLog on-disk format documentation
+  (#2389, PR #2797).
+
+### Notes
+
+- The reader decodes the version-gated descriptor header (Cassandra 5.0 commitlog
+  version 7), CRC-framed sync sections with torn-tail tolerance, and schema-aware
+  mutation/cell decode for the common insert path. Unmodeled constructs (clustering
+  columns, static rows, collection/complex columns, deletions, range tombstones) are
+  reported structurally rather than misdecoded; compressed and encrypted segments and
+  version-8 segments (`storage_compatibility_mode: NONE/UPGRADING`) fail closed with a
+  typed error. No-heuristics throughout.
+- Scope is reader-only. The CommitLog writer (#2388), CDC tailing, encryption support,
+  and query/Flight integration are out of scope for this pass. Hostile-file hardening
+  follow-ups are tracked in #2838.
+
+## [v0.16.0] - 2026-07-22
+
+_Trino connector completeness & cancellation._ Closes two field-surfaced connector
+gaps on the v0.15.0 latency/throughput base: collection columns now project through
+Trino, and weight-balanced split fan-out ships with a root fix for a
+`LIMIT`-cancellation hang.
+
+### Added
+
+- Typed collection columns through Trino: `list`/`set`/`map` (including
+  `list<frozen<udt>>`) project as Trino `array`/`row`/`map` instead of being silently
+  dropped; unmappable columns are surfaced loudly. Primitive element types decode
+  fully; UDT element-value decode inside a collection remains tracked to #2349 (#2815,
+  PR #2816).
+- Weight-balanced split→pod assignment via K-way token-range sub-splitting
+  (`cqlite.sub-splits-per-range`, default 4) with span-proportional `SplitWeight`,
+  evening out the 2–4× per-pod CPU skew. Aggregate, pushed-`LIMIT`, and fully-bound
+  point reads are exempted to K=1 (#2680, PR #2833).
+- Plan-time split pruning for fully-bound partition keys — a point read prunes to the
+  covering split instead of fanning out (#2679, PR #2774; #2806, PR #2810).
+- UDT registry wired into both Flight read paths, cold and warm (#2349, PR #2761).
+- Keyspace-qualified UDT type names accepted on both read paths (#2807, PR #2808).
+- BTI (`da`) and compressed-chunk-stitching end-to-end Flight `do_get` coverage (#2372,
+  PR #2768; #2373, PR #2780); fine-grained `do_get` abort taxonomy and abort-path trace
+  (#2681, PR #2784); `tables_discovered` / `warm_tables` gauges (#2684, PR #2786).
+
+### Fixed
+
+- **P0 `LIMIT`-cancellation hang fixed at root**: a partial-predicate `LIMIT` under
+  sub-splitting could hang because the blocking Flight `DoGet` read ran on the Trino
+  driver thread, so operator close could never cancel it. The read now runs off the
+  driver thread (`isBlocked()`), letting close cross-cancel the stream; the server
+  egress path also races a cancel flag. Guarded by a docker-compose E2E `LIMIT`
+  regression test (#2782, PR #2833).
+- Read-time TTL/liveness reconciliation routed through `do_get` and validated by the
+  query-semantics oracle (#2374, #2789, PR #2800).
+
+### Changed
+
+- Recurring roborev blocker classes mechanized as `--lite` gate lints (#2656, PR
+  #2741).
+
+## [v0.15.0] - 2026-07-17
+
+_Trino latency, throughput & operations_ (epic #2403). Turns the field-validated read
+path into a fast, observable, overload-resilient one: warm throughput through Trino is
+up roughly **15×** versus the v0.14 field baseline (round-11b measured ~34 qps warm,
+p50 227ms / p99 366ms, server-side ~2ms, zero cold parses, at 80 threads with no
+OOMKills).
+
+### Added
+
+- Flight `do_get` admission control: bounded scan concurrency
+  (`--max-concurrent-scans`), `UNAVAILABLE` load-shedding, and phase-visible queueing;
+  the eager multi-generation merge is admitted through the same semaphore (#2420, PR
+  #2431; #2063, PR #2568).
+- Five in-process saturation gauges — blocking-task guard, merge egress depth, and an
+  fd/thread/RSS sampler on a 2s tick (#2419, PR #2547).
+- Operator-facing flight-metrics reference and a refreshed cqlite-flight Grafana
+  dashboard with a catalog-drift guard; `cqlite.errors.total` eagerly registered at 0
+  on startup (#2426, #2427, #2288).
+- Multi-node read fan-out: split primaries rotate across replica owners, so reads under
+  RF=N are no longer pinned to a single pod (#2397, PR #2409).
+- `tools/flight-loadgen` throughput harness (#2313, PR #2575); a `CQLITE_READ_PATH`
+  forcing knob plus point-vs-full differential lane (#1918); a public Performance page
+  with measured round-11b results (#2473, PR #2475).
+
+### Fixed
+
+- **P0 — silent row loss on large single-cell values**: rows with a single ≥~1MB cell
+  were silently dropped because a 1MB `row_size` heuristic rejected them as corrupt. It
+  is replaced with an authoritative remaining-bytes bound, per the no-heuristics mandate
+  (#2436, PR #2482).
+- v5 cell parsing hardening: overflow-safe cell bounds, `Float32`/varint parity, and a
+  varint arm that decodes a CQL varint as `Value::Varint` rather than a blob (#1795,
+  #1884, #1885, PR #2467, PR #2466).
+- `GROUP BY` float/double groups by the Cassandra comparator: NaN → one group, `±0.0`
+  distinct (#2074, PR #2488).
+- `CompressionInfo` fail-closed: `max_compressed_length == 0` is rejected at parse and
+  in the compressed-offset-window read instead of producing garbage (#2529, #2524);
+  compressed `CHUNK_READ_CALLS` accounting restored (#2167).
+- Complex-cell element TTL clamped to `i32::MAX`, matching the scalar reader (#2173);
+  snapshot-aware SSTable identity parsing handles ID-ful snapshots (#2384).
+
+### Changed / Performance
+
+- Connector snapshot-lifecycle closure — per-`(keyspace, table)` reader reuse plus warm
+  rebind (#2356, #2306, PR #2425); snapshot-retirement hardening with a background
+  grace-sweep (#2452, PR #2579). Trino connector advanced to `0.14.3` / `0.14.4`.
+- Lazy Summary-guided BIG index — `O(summary)` open, bounded point-lookup intervals,
+  and token-pushdown scans (#2412, #2413, PR #2440).
+- Row-granular point-read streaming — point reads and cache-warm merges drive the merge
+  row by row instead of materializing (#2423, PR #2434); the read-path merge streams
+  per-row via `StreamingMerger` (#2230).
+- Zero-copy `Bytes`-backed `Value` on the read path (#1644, PR #2598); binary-search
+  range shadowing in the merge core (#1669); a `MADV_RANDOM` point-read mmap (#2210) and
+  a global bounded key→partition-offset cache (#2059).
+- Uncompressed-SSTable compaction peak heap bounded from **410 → 54 MiB** via
+  row-granular streaming (#2299, PR #2421).
+
+## [v0.14.1] - 2026-07-13
+
+_Cold-start parse fix._ A patch on v0.14.0 that fixes the cold first-query-per-table
+parse cost v0.14.0 called out as a known limitation. No API or behavior changes — a
+pure performance fix.
+
+### Performance
+
+- Retired the redundant `SSTableIndex` from BIG reader open: `SSTableReader::open` no
+  longer builds a second in-memory index, so `Index.db` is parsed exactly once per open
+  (2 → 1), and the surviving build uses capacity hints (linearithmic, not quadratic)
+  (#2385, #2395, PR #2402).
+  - 200k-entry index build: 6.17s → 0.061s (~100×).
+  - Growth ratio (build time vs entry count): 15.5 → 4.96.
+  - Resident index memory: roughly halved per generation.
+
+## [v0.14.0] - 2026-07-13
+
+_Flight field-readiness._ The Arrow Flight server and Trino connector read path are now
+field-validated against a live, at-scale Cassandra deployment (round-9 field build;
+validation tracker #2367).
+
+### Added
+
+- Streaming `do_get` scan: the non-stitching scan path no longer materializes the whole
+  SSTable before the first emit — it walks the index lazily, applies `LIMIT`
+  effectively, and tears producers down on cancel via a Drop-join (#2361).
+- Resolve-phase parse-once warm registry: single-flight parse, rebind-by-inode, and
+  cancel-aware parse remove the CPU spin that hung `LIMIT`, `count(*)`, and point reads
+  at multi-million-partition scale (#2383).
+- `do_get` pushes PK-equality predicates toward partition point-read / prune instead of
+  a full merge scan (#2207).
+- Published Arrow Flight server + Trino connector user-docs page (#2115).
+
+### Changed
+
+- **BREAKING (config schema):** `MemoryConfig` collapsed to a single real caching knob —
+  `block_cache.max_size`, wired as the shared decompressed-chunk cache's byte budget
+  (Epic B / B2, #1568). The decorative `MemoryConfig.row_cache`, `MemoryConfig.query_cache`,
+  and `MemoryConfig.allocator` fields and the never-selected `CachePolicy::Lfu` /
+  `CachePolicy::Arc` variants (all wired to nothing at runtime) were removed. A config
+  that still names any removed field or variant now **fails closed** on deserialization
+  (`deny_unknown_fields` / unknown enum variant) rather than being silently ignored.
+  `Database::stats().memory_stats` keeps its shape but its block-cache numbers are now
+  the real cache's hits/misses/occupancy (a repeated cached read yields a non-zero
+  `block_cache_hit_rate()` instead of a structural `0.0`).
+- **Reader open path (perf):** `CompressionInfo.db` is now parsed **exactly once** per
+  reader open (was twice — a legacy `parse_binary` plus the modern `parse`), and the
+  compression algorithm is derived from that single authoritative parse. The legacy
+  `detect_and_initialize_compression` path — which also issued ~25 speculative
+  `exists()` generation-probe stats per open — is deleted; the component name is derived
+  deterministically from `SsTableDescriptor` (Epic G / G1, #1597). No read result
+  changes (byte-for-byte parity preserved).
+
 ### Removed
 
 - **BREAKING (public API):** deleted the dead SSTable reader stacks flagged by the
   read-path audit (Epic G / G1, #1597). Removed public items:
-  `cqlite_core::storage::sstable::SchemaAwareReader` (and the
-  `schema_aware_reader` module); the `chunked_data_reader` module and
-  `ChunkedDataReader`; `compression::StreamingDecompressor`,
-  `ChunkedDecompressionConfig`, and the duplicate legacy
-  `compression::CompressionInfo` / `ChunkInfo` parser (`parse` / `parse_binary`);
+  `cqlite_core::storage::sstable::SchemaAwareReader` (and the `schema_aware_reader`
+  module); the `chunked_data_reader` module and `ChunkedDataReader`;
+  `compression::StreamingDecompressor`, `ChunkedDecompressionConfig`, and the duplicate
+  legacy `compression::CompressionInfo` / `ChunkInfo` parser (`parse` / `parse_binary`);
   and the streaming half of `CompressionReader` (`read`, `read_streaming`,
-  `with_block_size`, `block_size`) — `CompressionReader` is now a plain
-  `{ algorithm }` field with `new()` + `algorithm()`. All were constructed only in
-  tests or had zero production consumers.
+  `with_block_size`, `block_size`) — `CompressionReader` is now a plain `{ algorithm }`
+  field with `new()` + `algorithm()`. All were constructed only in tests or had zero
+  production consumers.
 
-### Changed
+### Fixed
 
-- **Reader open path (perf):** `CompressionInfo.db` is now parsed **exactly once**
-  per reader open (was twice — a legacy `parse_binary` plus the modern `parse`),
-  and the compression algorithm is derived from that single authoritative parse.
-  The legacy `detect_and_initialize_compression` path — which also issued ~25
-  speculative `exists()` generation-probe stats per open — is deleted; the
-  component name is derived deterministically from `SsTableDescriptor` (Epic G /
-  G1, #1597). No read result changes (byte-for-byte parity preserved).
-- **BREAKING (config schema):** `MemoryConfig` collapsed to a single real caching
-  knob — `block_cache.max_size`, wired as the shared decompressed-chunk cache's
-  byte budget (Epic B / B2, #1568). The decorative `MemoryConfig.row_cache`,
-  `MemoryConfig.query_cache`, and `MemoryConfig.allocator` fields and the
-  never-selected `CachePolicy::Lfu` / `CachePolicy::Arc` variants (all wired to
-  nothing at runtime) were removed. A config that still names any removed field
-  or variant now **fails closed** on deserialization (`deny_unknown_fields` /
-  unknown enum variant) rather than being silently ignored. `Database::stats()
-  .memory_stats` keeps its shape but its block-cache numbers are now the real
-  cache's hits/misses/occupancy (a repeated cached read yields a non-zero
-  `block_cache_hit_rate()` instead of a structural `0.0`).
+- Warm-handles `ENOENT`: streaming merge producers no longer fail when a snapshot path
+  goes stale after `clearSnapshot` — a path-liveness gate re-opens by live path (#2352).
+- `do_get` snapshot-index reload/glob loop honors cancellation, so `LIMIT` queries no
+  longer hang and the in-flight gauge no longer sticks (#2264, #2157).
+- Flight producer `entry_to_row` no longer collapses multi-cell / collection columns via
+  HashMap overwrite (#2324).
+- Read-time reconciliation: a multi-generation `SELECT` applies read-time TTL /
+  partition / range-tombstone visibility (#1849); `scan_stream` single-generation path
+  returns rows on CQLite-written SSTables (#1897).
+- Write path honors `USING TTL` and per-cell expiration; surviving live TTL cells stay
+  byte-identical after compaction, including complex / collection / UDT elements (#1743,
+  #2038, #1538, #1537); non-frozen collection round-trip fixed (#2035).
+- Float/double ordering matches Cassandra (NaN last, `-0.0 < +0.0`) across `Value`
+  comparison, `ORDER BY`, `MIN`/`MAX` (#2010, #1870).
+- Point-lookup `WHERE pk = ?` returns typed columns and routes to the fast path instead
+  of the legacy column-less heuristic fork (#2066, #1802, #1750).
+- No-heuristics + parser hardening: blob decode no longer guesses on a hardcoded byte
+  pattern; recursion-depth guards, `duration` `try_from`, clamped capacities; typed
+  Zstd-dictionary rejection; checked Arrow collection offsets (#1630, #1414, #1723,
+  #1488, #1486).
+- Query-semantics oracle added so read-reconciliation bugs no longer pass physical-dump
+  parity green (#1742); compaction finalize path fsyncs directories (#1959).
+
+### Performance
+
+- Read/parse/export hot paths from the audit epics (B–G, J–M, AC–AE): boxed `Value`
+  variants (88B → ≤40B), byte-bounded result budgets replacing the 1M row-count cliff,
+  `LIMIT`/`OFFSET` pushed into the scan, streaming multi-generation merge + streaming
+  O(1) aggregates, a key→partition-offset cache, one-walk zero-copy BTI trie descent, a
+  single read-side VInt decoder, and capacity-hinted Arrow builders (#1583, #1582,
+  #1577, #1585, #1495, #1817).
+
+### CI / testing
+
+- Metadata-driven, feature-aware CI lanes replace the hand-maintained hardcoded test
+  lists; first green `main` since 2026-07-06 (#2359, #2039). Dataset skip-guard checks
+  `Data.db` so dataset-dependent tests skip rather than panic (#2065). De-flaked
+  wall-clock / global-counter / RSS-monotonic tests (#1776, #1774, #1539).
 
 ## [v0.13.0] - 2026-07-05
 

--- a/website/src/content/docs/releases/index.md
+++ b/website/src/content/docs/releases/index.md
@@ -14,6 +14,11 @@ For the complete, granular change list, see the
 
 | Version | Date | Highlights |
 |---------|------|-----------|
+| [v0.16.1](/cqlite/releases/v0-16-1/) | 2026-07-23 | Reads a second Cassandra on-disk format — CommitLog segment files — via a library API and a `read-commitlog` CLI |
+| [v0.16.0](/cqlite/releases/v0-16-0/) | 2026-07-22 | Trino connector completeness — typed collection columns (array/row/map) · weight-balanced split fan-out · `LIMIT`-cancellation hang fixed |
+| [v0.15.0](/cqlite/releases/v0-15-0/) | 2026-07-17 | Trino latency/throughput/ops — ~15× warm throughput · admission control · saturation gauges · P0 silent-row-loss fix |
+| [v0.14.1](/cqlite/releases/v0-14-1/) | 2026-07-13 | Cold-start parse fix — `Index.db` parsed once per open · 200k-entry index build ~100× faster |
+| [v0.14.0](/cqlite/releases/v0-14-0/) | 2026-07-13 | Flight field-readiness — Arrow Flight + Trino read path validated against a live at-scale Cassandra deployment · 2 breaking changes |
 | [v0.13.0](/cqlite/releases/v0-13-0/) | 2026-07-05 | Performance release — read-path + point-read + compressed-chunk wins · byte-bounded results · `Database.refresh()` · 3 breaking changes |
 | [v0.12.0](/cqlite/releases/v0-12-0/) | 2026-06-22 | Arrow Flight + Trino connector · CDC delta-export to Parquet · byte-for-byte compaction parity |
 

--- a/website/src/content/docs/releases/v0-12-0.md
+++ b/website/src/content/docs/releases/v0-12-0.md
@@ -3,7 +3,7 @@ title: CQLite v0.12.0
 description: Arrow Flight + Trino connector, CDC delta-export to Parquet, and byte-for-byte compaction parity with Apache Cassandra.
 sidebar:
   label: v0.12.0
-  order: 2
+  order: 7
 ---
 
 # CQLite v0.12.0 — the compaction release

--- a/website/src/content/docs/releases/v0-13-0.md
+++ b/website/src/content/docs/releases/v0-13-0.md
@@ -3,7 +3,7 @@ title: CQLite v0.13.0
 description: The performance release — a read-path constant-factor bundle, positional point-reads, one payload+CRC read per compressed chunk, faster Node bindings, byte-bounded results, and Database.refresh().
 sidebar:
   label: v0.13.0
-  order: 1
+  order: 6
 ---
 
 # CQLite v0.13.0 — the performance release

--- a/website/src/content/docs/releases/v0-14-0.md
+++ b/website/src/content/docs/releases/v0-14-0.md
@@ -1,0 +1,83 @@
+---
+title: CQLite v0.14.0
+description: Flight field-readiness — the Arrow Flight server and Trino connector read path, validated against a live at-scale Cassandra deployment.
+sidebar:
+  label: v0.14.0
+  order: 5
+---
+
+# CQLite v0.14.0 — Flight field-readiness
+
+Read and query Apache Cassandra 5.0 SSTables through Arrow Flight and Trino — no
+cluster required. This release takes the Flight read path from working to
+**field-validated**: the round-9 field build ran against a live, at-scale Cassandra
+deployment (validation tracker
+[#2367](https://github.com/pmcfadin/cqlite/issues/2367)).
+
+## ✈️ Field-validated Flight read path
+
+- **Streaming `do_get` scan** — the scan path no longer materializes the whole
+  SSTable before the first row. It walks the index lazily, applies `LIMIT`
+  effectively, and tears producers down on cancel, so memory stays bounded (#2361).
+- **Parse-once warm registry** — the resolve phase stopped re-parsing per request at
+  multi-million-partition scale. Single-flight parse plus rebind-by-inode removes the
+  CPU spin that hung `LIMIT`, `count(*)`, and point reads (#2383).
+- **Predicate pushdown** — `do_get` pushes `WHERE pk = ?` toward a partition
+  point-read or prune instead of a full merge scan (#2207).
+- **Cancellation that works** — the snapshot-index reload loop honors cancellation,
+  so `LIMIT` queries no longer hang and the in-flight gauge no longer sticks
+  (#2264, #2157).
+
+## ✅ Correctness & parity
+
+- **No silent multi-cell collapse** — the Flight producer no longer overwrites
+  multi-cell and collection columns through a HashMap (#2324).
+- **Read-time reconciliation** — a multi-generation `SELECT` applies read-time TTL,
+  partition, and range-tombstone visibility (#1849).
+- **TTL round-trips through compaction** — the write path honors `USING TTL` and
+  per-cell expiration; surviving live TTL cells stay byte-identical after compaction,
+  including complex, collection, and UDT elements (#1743, #2038).
+- **Float ordering matches Cassandra** — `Value` comparison, `ORDER BY`, and
+  `MIN`/`MAX` order floats as Cassandra does: NaN last, `-0.0 < +0.0` (#2010, #1870).
+- **No-heuristics hardening** — blob decode no longer guesses from a byte pattern;
+  recursion-depth guards and clamped capacities protect the parser (#1630, #1414).
+
+## 🚀 Performance
+
+The read, parse, and export hot paths from the audit epics landed: boxed `Value`
+variants (88B → ≤40B), byte-bounded result budgets in place of the 1M-row cliff,
+`LIMIT`/`OFFSET` pushed into the scan, streaming multi-generation merge and O(1)
+aggregates, a key→partition-offset cache, and one-walk zero-copy BTI trie descent
+(#1583, #1582, #1577, #1585).
+
+## ⚠️ Breaking changes
+
+- **Config schema** — `MemoryConfig` collapsed to one real caching knob,
+  `block_cache.max_size`. The decorative `row_cache`, `query_cache`, and `allocator`
+  fields and the unused `CachePolicy::Lfu`/`Arc` variants were removed; a config that
+  still names them now fails closed on deserialization (#1568).
+- **Public API** — the dead SSTable reader stacks flagged by the read-path audit were
+  deleted: `SchemaAwareReader`, `ChunkedDataReader`, `StreamingDecompressor`, the
+  duplicate legacy `CompressionInfo`/`ChunkInfo` parser, and the streaming half of
+  `CompressionReader`. All had zero production consumers (#1597).
+
+## Known limitations
+
+- **Cold first-query-per-table parse cost** — `SSTableReader::open` parses `Index.db`
+  super-linearly (and twice per open), so the first query against a large table pays a
+  cold parse cost at field scale. Fixed in **v0.14.1** (#2385, #2395).
+- **Reads are single-node-bound under RF=N** — under concurrency one pod does the
+  work; throughput caps at one node (#2397).
+
+## Get it
+
+```bash
+brew install pmcfadin/cqlite/cqlite      # CLI (macOS + Linux)
+cargo add cqlite-core                     # Rust library
+pip install cqlite-py                     # Python
+npm install @cqlite/node                  # Node.js
+```
+
+Rust crates and the Python and Node bindings move `0.13.0 → 0.14.0` in lockstep. The
+Trino connector (`in.mcfad:cqlite-trino`) is versioned separately. Full detail in the
+[CHANGELOG](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md).

--- a/website/src/content/docs/releases/v0-14-1.md
+++ b/website/src/content/docs/releases/v0-14-1.md
@@ -1,0 +1,51 @@
+---
+title: CQLite v0.14.1
+description: Cold-start parse fix — Index.db is parsed once per reader open, collapsing a quadratic index build to linearithmic.
+sidebar:
+  label: v0.14.1
+  order: 4
+---
+
+# CQLite v0.14.1 — cold-start parse fix
+
+A patch release on [v0.14.0](/cqlite/releases/v0-14-0/). It fixes the cold
+first-query-per-table parse cost that v0.14.0 called out as a known limitation. No
+API or behavior changes — a pure performance fix.
+
+## 🚀 Cold-start parse fix
+
+`SSTableReader::open` no longer builds a second, redundant in-memory index. `Index.db`
+is now parsed exactly once per open (down from twice), and the surviving index build
+uses capacity hints so it grows linearithmically instead of quadratically (#2385,
+#2395).
+
+- 200k-entry index build: **6.17s → 0.061s** (~100×).
+- Growth ratio (build time vs entry count): **15.5 → 4.96** — quadratic collapses to
+  linearithmic.
+- Parses of `Index.db` per open: **2 → 1**.
+- Resident index memory: roughly halved per generation.
+
+At round-9 field validation, a cold `LIMIT` query took 4m17s at 1.42M partitions. With
+this fix the cold cost drops to seconds per generation.
+
+## Known limitations
+
+Unchanged from v0.14.0, minus the cold-start item fixed above:
+
+- **Reads are single-node-bound under RF=N** — under concurrency one pod does the
+  work; throughput caps at one node (#2397).
+- **Warm scan setup overhead** — warm scans carry a fixed ~4–5s per-query
+  resolve/merge-setup cost, so a `LIMIT 5` scan runs comparably to `LIMIT 100` (#2398).
+
+## Get it
+
+```bash
+brew install pmcfadin/cqlite/cqlite      # CLI (macOS + Linux)
+cargo add cqlite-core                     # Rust library
+pip install cqlite-py                     # Python
+npm install @cqlite/node                  # Node.js
+```
+
+Rust crates and the Python and Node bindings move `0.14.0 → 0.14.1` in lockstep. Full
+detail in the
+[CHANGELOG](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md).

--- a/website/src/content/docs/releases/v0-15-0.md
+++ b/website/src/content/docs/releases/v0-15-0.md
@@ -1,0 +1,83 @@
+---
+title: CQLite v0.15.0
+description: Trino latency, throughput, and operations — roughly 15× warm throughput, admission control, in-process saturation gauges, and a P0 silent-row-loss fix.
+sidebar:
+  label: v0.15.0
+  order: 3
+---
+
+# CQLite v0.15.0 — Trino latency, throughput & operations
+
+This release turns the field-validated read path from v0.14 into a fast, observable,
+overload-resilient one (epic [#2403](https://github.com/pmcfadin/cqlite/issues/2403)).
+Warm throughput through Trino is up roughly **15×** versus the v0.14 field baseline,
+the read hot paths were re-cut end to end, saturation is now legible in-process, and a
+P0 silent-row-loss class is gone.
+
+## 🚀 Warm Trino throughput up ~15×
+
+Round-11b field validation measured **~34 qps warm, p50 227ms / p99 366ms through
+Trino**, with server-side work at ~2ms and zero cold parses on the warm path — at 80
+concurrent threads with no OOMKills. The levers:
+
+- **Connector snapshot-lifecycle closure** — per-`(keyspace, table)` reader reuse plus
+  warm rebind, so repeat queries no longer re-open from cold (#2356, #2306).
+- **Lazy Summary-guided BIG index** — `O(summary)` open, bounded point-lookup
+  intervals, and token-pushdown scans, so a scan no longer decodes every partition
+  body (#2412, #2413).
+- **Row-granular point-read streaming** — point reads and cache-warm merges drive the
+  merge row by row instead of materializing (#2423).
+- **Multi-node read fan-out** — split primaries rotate across replica owners, so reads
+  under RF=N are no longer pinned to a single pod (#2397).
+
+## 🛠️ Operations — admission control & saturation observability
+
+- **Flight `do_get` admission control** — bounded scan concurrency
+  (`--max-concurrent-scans`), `UNAVAILABLE` load-shedding, and phase-visible queueing
+  keep an overloaded server responsive instead of thrashing (#2420, #2063).
+- **Saturation gauges** — five in-process gauges (blocking-task guard, merge egress
+  depth, and an fd/thread/RSS sampler on a 2s tick) make saturation legible during
+  overload (#2419).
+- **Metrics surface** — `cqlite.errors.total` registers at 0 on startup; an
+  operator-facing flight-metrics reference and a refreshed Grafana dashboard ship from
+  the observability catalog (#2288, #2426, #2427).
+
+## ✅ Correctness & parity
+
+- **P0 — silent row loss on large single-cell values** — rows with a single ≥~1MB cell
+  were silently dropped because a 1MB `row_size` heuristic rejected them as corrupt. It
+  is replaced with an authoritative remaining-bytes bound, per the no-heuristics
+  mandate (#2436).
+- **v5 cell parsing hardening** — overflow-safe cell bounds, `Float32`/varint parity,
+  and a varint arm that decodes a CQL varint as `Value::Varint` rather than a blob
+  (#1795, #1884, #1885).
+- **`GROUP BY` float/double** groups by the Cassandra comparator: NaN → one group,
+  `±0.0` distinct (#2074).
+- **`CompressionInfo` fail-closed** — `max_compressed_length == 0` is rejected at parse
+  and read instead of producing garbage (#2529, #2524).
+
+## 🚀 Read/write hot-path train
+
+Zero-copy `Bytes`-backed `Value` on the read path (#1644); binary-search range
+shadowing in the merge core (#1669); a `MADV_RANDOM` point-read mmap and a global
+bounded key→partition-offset cache (#2210, #2059); and a compaction peak-heap drop from
+**410 → 54 MiB** via row-granular streaming (#2299).
+
+## Known limitations
+
+- **Windows Node CI** remains deferred debt; Linux and macOS Node bindings are
+  unaffected (#1979).
+
+## Get it
+
+```bash
+brew install pmcfadin/cqlite/cqlite      # CLI (macOS + Linux)
+cargo add cqlite-core                     # Rust library
+pip install cqlite-py                     # Python
+npm install @cqlite/node                  # Node.js
+```
+
+Rust crates and the Python and Node bindings move `0.14.1 → 0.15.0` in lockstep. The
+Trino connector (`in.mcfad:cqlite-trino`, `0.14.4`) is versioned separately. Full
+detail in the
+[CHANGELOG](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md).

--- a/website/src/content/docs/releases/v0-16-0.md
+++ b/website/src/content/docs/releases/v0-16-0.md
@@ -1,0 +1,55 @@
+---
+title: CQLite v0.16.0
+description: Trino connector completeness — typed collection columns projected as array/row/map, weight-balanced split fan-out, and a fixed LIMIT-cancellation hang.
+sidebar:
+  label: v0.16.0
+  order: 2
+---
+
+# CQLite v0.16.0 — Trino connector completeness & cancellation
+
+This release closes two field-surfaced connector gaps on top of the v0.15.0
+latency/throughput base: Cassandra collection columns now project through Trino, and
+weight-balanced split fan-out ships with a root fix for a `LIMIT`-cancellation hang.
+
+## 🧩 Typed collection columns through Trino
+
+`list`, `set`, and `map` columns — including `list<frozen<udt>>` — now project as Trino
+`array`, `row`, and `map` instead of being silently dropped from the schema. Unmappable
+columns are surfaced loudly rather than hidden. Primitive element types decode fully;
+UDT element-value decode inside a collection remains tracked to
+[#2349](https://github.com/pmcfadin/cqlite/issues/2349) (#2815).
+
+## ⚖️ Weight-balanced, hang-free sub-splitting
+
+- **Weight-balanced split→pod assignment** — K-way token-range sub-splitting
+  (`cqlite.sub-splits-per-range`, default 4) with span-proportional `SplitWeight`,
+  evening out the 2–4× per-pod CPU skew that capped aggregate throughput. Aggregate,
+  pushed-`LIMIT`, and fully-bound point reads are exempted to K=1 (#2680).
+- **P0 `LIMIT`-cancellation hang fixed at root** — a partial-predicate `LIMIT` under
+  sub-splitting could hang because the blocking Flight `DoGet` read ran on the Trino
+  driver thread, so operator close could never cancel it. The read now runs off the
+  driver thread, letting close cross-cancel the stream; a docker-compose E2E `LIMIT`
+  test guards it (#2782).
+
+## Also in this release
+
+- **UDT registry wired into both Flight read paths** (cold + warm) (#2349).
+- **Plan-time split pruning** for fully-bound partition keys — a point read prunes to
+  the covering split instead of fanning out (#2679, #2806).
+- **Keyspace-qualified UDT type names** accepted on both read paths (#2807).
+- **Read-time TTL/liveness reconciliation** routed through `do_get` and validated by
+  the query-semantics oracle (#2374, #2789).
+
+## Get it
+
+```bash
+brew install pmcfadin/cqlite/cqlite      # CLI (macOS + Linux)
+cargo add cqlite-core                     # Rust library
+pip install cqlite-py                     # Python
+npm install @cqlite/node                  # Node.js
+```
+
+Rust crates and the Python and Node bindings move `0.15.0 → 0.16.0` in lockstep. Full
+detail in the
+[CHANGELOG](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md).

--- a/website/src/content/docs/releases/v0-16-1.md
+++ b/website/src/content/docs/releases/v0-16-1.md
@@ -1,0 +1,54 @@
+---
+title: CQLite v0.16.1
+description: A second Cassandra on-disk format — CQLite now reads CommitLog segment files via a library API and a read-commitlog CLI subcommand.
+sidebar:
+  label: v0.16.1
+  order: 1
+---
+
+# CQLite v0.16.1 — CommitLog reader
+
+A patch release on [v0.16.0](/cqlite/releases/v0-16-0/). CQLite now reads a **second
+Cassandra on-disk format** — CommitLog segment files — alongside SSTables. No breaking
+changes; the new module and CLI subcommand are purely additive.
+
+## 📖 Cassandra 5.0 CommitLog reader
+
+A `CommitLogReader` parses Cassandra 5.0 CommitLog segment files — the raw files
+Cassandra writes via `CommitLogSegment` — into a stream of decoded mutations.
+Contributed by @rustyrazorblade (#2389).
+
+- **Library API** — `cqlite_core::storage::commitlog`, with `CommitLogReader::open` /
+  `open_with_schemas` and a lazy `MutationIter` that decodes one record at a time (128
+  MB segment cap).
+- **CLI** — a new `read-commitlog` subcommand with JSON and text output, alongside the
+  existing SSTable commands.
+- **What it decodes** — the version-gated descriptor header (Cassandra 5.0 commitlog
+  version 7), CRC-framed sync sections with torn-tail tolerance, and schema-aware
+  mutation and cell decode for the common insert path.
+- **Honest bail, never a guess** — unmodeled constructs (clustering columns, static
+  rows, collection and complex columns, deletions, range tombstones) are reported
+  structurally rather than misdecoded; compressed and encrypted segments fail closed
+  with a typed error. Format facts come from the descriptor header and supplied schema
+  only.
+- **Verified against Cassandra source and real fixtures** — field-for-field
+  adjudication against `cassandra-5.0.2` plus parity fixtures from a real Cassandra
+  5.0.2 node. Format documentation ships as Appendix H of the SSTable definitive guide.
+
+**Scope** — reader only. The CommitLog writer is a separate follow-on (#2388); CDC
+tailing, encryption, and query/Flight integration are out of scope for this pass.
+Version-8 segments (`storage_compatibility_mode: NONE/UPGRADING`) are rejected with a
+typed error, tracked as a follow-up.
+
+## Get it
+
+```bash
+brew install pmcfadin/cqlite/cqlite      # CLI (macOS + Linux)
+cargo add cqlite-core                     # Rust library
+pip install cqlite-py                     # Python
+npm install @cqlite/node                  # Node.js
+```
+
+Rust crates and the Python and Node bindings move `0.16.0 → 0.16.1` in lockstep. Full
+detail in the
+[CHANGELOG](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md).


### PR DESCRIPTION
Closes #2844.

The published release section stopped at v0.13.0. This backfills the two stale surfaces (the `docs/releases/` notes for all five already existed on main):

- **Website:** new release pages `v0-14-0` … `v0-16-1` (newest-first `sidebar.order`), plus five rows in `releases/index.md`. Each new page is cross-linked from the index table body (satisfies the #2473 agent-plumbing cross-link rule).
- **CHANGELOG:** dated versioned sections `[v0.14.0]`…`[v0.16.1]` cut from `[Unreleased]` (which held only 2 items, both confirmed shipped in v0.14.0 via `git tag --contains`). `[Unreleased]` retained (empty).

Highlights narrative owner-approved 2026-07-24; local dates retained (v0.16.1 = 2026-07-23, matching existing notes convention). Docs-only — no code, no OpenSpec change.

Process fix to stop this recurring: #2845.