### PR TITLE
feat(#2855): enforced board→label mirror — status:* becomes a machine-written projection of board Status

### DIFF
--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -48,7 +48,8 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
    gh issue edit <N> --add-assignee @me
    # have_project=1: gh project item-edit ... --field Status --single-select-option-id <In Progress>
    # (have_project=0 cannot occur here — Path A eligibility in step 2 already required a reachable board.
-   #  A status:in-progress label write is a decorative mirror for humans only, never a dispatch source.)
+   #  Do NOT write a status:in-progress label — the board→label mirror (#2855) derives it from the
+   #  board Status you just set; a hand-written board-derived label is reverted on the next mirror pass.)
    scripts/flow/claim-heartbeat.sh beat <N>   # FIRST beat — establishes refs/heartbeats/<machine> (#2089)
    ```
    If `claim.sh claim` reports `CLAIM LOST`, you did NOT win — do not create the worktree; take the next
@@ -64,9 +65,12 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
    - the proposal summary + Non-goals,
    - the spec requirements + `#### Scenario:` blocks **verbatim**,
    - the recommended design (chosen + what it beat),
-   then flip the label and wait:
+   then set the transient spec-review sub-marker and wait:
    ```bash
-   gh issue edit <N> --remove-label status:ready --add-label status:spec-review
+   # spec-review is a transient skill-managed sub-marker (NOT a board Status option) — the
+   # board→label mirror (#2855) does not touch it. Do NOT write status:ready/in-progress/in-review;
+   # those labels are the mirror's now, derived from the board Status you set.
+   gh issue edit <N> --add-label status:spec-review
    ```
    Do not start `flow-implement`. Approval is the owner's seam.
 7. **Drop the spec render after approval (issue #2085).** The inline render exists only to get the owner's

--- a/.claude/skills/flow-address/SKILL.md
+++ b/.claude/skills/flow-address/SKILL.md
@@ -22,18 +22,20 @@ Resolve them in the worktree and reply per thread.
    fix is yours to make; a **genuine design/scope** question goes to the owner via `AskUserQuestion`
    (one at a time). Push back with a reason where a suggestion is wrong, rather than complying blindly.
 4. **Fix in the worktree** (`.claude/worktrees/issue-<N>-<slug>`), spawning `sstable-developer` for
-   non-trivial code changes. Set exactly one lifecycle label (clear the others first):
+   non-trivial code changes. Set the transient `addressing` sub-marker (a skill-managed marker the
+   board→label mirror #2855 does not own); clear the sibling transient `spec-review` marker. Do NOT
+   write status:ready/in-progress/in-review — those are the mirror's, derived from the board Status:
    ```bash
-   gh issue edit <N> --remove-label status:in-review --remove-label status:in-progress \
-     --remove-label status:spec-review --remove-label status:ready --add-label status:addressing
+   gh issue edit <N> --remove-label status:spec-review --add-label status:addressing
    ```
 5. **Re-verify** what the change touched: re-run `scripts/agent-gate.sh` (with `CQLITE_DATASETS_ROOT` at
    the main repo) and re-run C (`spec-auditor`) if requirements/tests changed; roborev again if code
    changed materially.
 6. **Push + reply.** `git -C <worktree> push`, then reply on each `$PR` thread with what changed (commit
-   ref), and flip back to exactly one lifecycle label:
+   ref), and clear the transient `addressing` sub-marker. The board stays `In Review` (PR still open),
+   so the mirror keeps `status:in-review` — do NOT hand-write it:
    ```bash
-   gh issue edit <N> --remove-label status:addressing --add-label status:in-review
+   gh issue edit <N> --remove-label status:addressing
    ```
 7. **Re-certify and re-arm merge-on-green (#2667).** The owner's comments are input, NOT a merge
    gate — unless a comment is an explicit `HOLD:` or raises a product/scope question. After addressing

--- a/.claude/skills/flow-board/SKILL.md
+++ b/.claude/skills/flow-board/SKILL.md
@@ -57,25 +57,34 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
 
 ## Steps
 
-1. **Render the board.** If `have_project=1`, render from the Project:
+1. **Cheap candidate discovery (#2855).** `status:*` is now an ENFORCED read-mirror of board Status
+   (written only by `project-board-sync.yml`), so it is server-side filterable and cheap for
+   *narrowing* the candidate set without pulling issue bodies or paginating every board item:
+   ```bash
+   gh issue list --state open --label status:ready --json number,title
+   ```
+   This is discovery only — it narrows candidates. It is **eventually consistent** (≤30-min mirror lag)
+   and is **NEVER the dispatch/claim authority**: you MUST still confirm each candidate against the
+   live board `Status` in step 6 and acquire the claim ref before working it.
+2. **Render the board.** If `have_project=1`, render from the Project (the authoritative view):
    ```bash
    gh project item-list "$project_number" --owner "$project_owner" --format json --limit 200
    ```
    Show, per item: `#N (slug)  P?  Status  assignee  PR/CI  worktree`. Group by `Status`
    (`Backlog → Ready → In Progress → In Review → Done`); each `In Progress` item MUST show its assignee
    (the claiming session/owner). If `have_project=0`, you may render a **read-only** status view from
-   labels (NOT a dispatch source — see Path A note above):
+   the mirrored labels (NOT a dispatch source — see Path A note above):
    ```bash
    gh issue list --state open --json number,title,labels,assignees,url --limit 100
    ```
    Bucket by `status:*`; read the `P?` label as priority; show assignee from `assignees`. This view is
    informational only — no claim/selection happens without the board.
-2. **PRs + CI:**
+3. **PRs + CI:**
    ```bash
    gh pr list --state open --json number,headRefName,title,reviewDecision,url --limit 100
    ```
    For each `issue-*` PR, check required CI; an `In Review` PR is only owner-actionable once CI is green.
-3. **Worktrees + claim refs:** `git worktree list` — confirm each in-flight issue maps 1:1:1:1
+4. **Worktrees + claim refs:** `git worktree list` — confirm each in-flight issue maps 1:1:1:1
    (issue ↔ worktree ↔ change ↔ PR); flag orphans. List the claim locks on origin — the slugless
    fixed-name **claim refs** are now THE lock (#2665); the `issue-<N>-<slug>` branch is only PR plumbing:
    ```bash
@@ -97,7 +106,7 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
    the only evidence until a beat appears. Ref layout + age-bucket semantics are documented in
    `scripts/flow/claim-heartbeat.sh`'s header — this skill only consumes `list`, never reimplements the
    parsing.
-4. **Reconcile + reap.** Cross-check the board against GitHub-side state:
+5. **Reconcile + reap.** Cross-check the board against GitHub-side state:
    - **Drift:** a PR that is **merged** (or its issue closed) while the item is still `In Progress`
      (or `In Review`) → flag for transition to `Done` (the server-side automation should do this; if it
      hasn't, set it: `gh project item-edit ... --field Status --single-select-option-id <Done>` or flip
@@ -106,7 +115,7 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
      commits" guesswork, which false-positived on long no-commit implementation phases and
      false-negatived on a push-then-idle machine. The rule now has two conditions, both required:
      ```bash
-     # 1. heartbeat age for the claiming machine, from the fleet view (step 3a):
+     # 1. heartbeat age for the claiming machine, from the fleet view (step 4a):
      scripts/flow/claim-heartbeat.sh list   # age column for the issue's machine
      # 2. no open PR for the issue:
      gh pr list --state open --search "issue-<N>" --json number --jq 'length'
@@ -163,10 +172,10 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
    - An item with a fresh heartbeat (age ≤ 4h) is **not** touched by either rule. An item with an open PR
      that is **still moving** (head advanced or review activity within 4h) is a live review-wait — surface
      it as in-review as normal. Do not silently steal a live claim.
-5. **Surface ONE next thing.** Pick the furthest-along item waiting on the owner — in order: a
+6. **Surface ONE next thing.** Pick the furthest-along item waiting on the owner — in order: a
    green-CI PR to merge (Seam 2), a committed spec to approve (Seam 1), an addressing PR with replies,
-   an **orphaned endgame** just flagged adopt-eligible by step 4 (a stalled certified PR the owner should
-   adopt/merge), then an item just reaped by step 4 (now `Status=Ready`, ready to reclaim). Drive that one (render the
+   an **orphaned endgame** just flagged adopt-eligible by step 5 (a stalled certified PR the owner should
+   adopt/merge), then an item just reaped by step 5 (now `Status=Ready`, ready to reclaim). Drive that one (render the
    spec inline / show the PR), or — if nothing waits — offer a short **claim-aware** pick-list: only items
    whose **board `Status=Ready`** AND
    have **no** `refs/claims/issue-<N>` claim ref and **no** legacy `issue-<N>-*` branch on origin

--- a/.claude/skills/flow-finalize/SKILL.md
+++ b/.claude/skills/flow-finalize/SKILL.md
@@ -73,14 +73,16 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
    Confirm with `python3 scripts/delivery-telemetry.py lint`.
 5. **Set the board to Done + release the claim.** The PR-merged / issue-closed server-side automation
    should already have moved the Project item to `Status=Done` (it fires even when you merge from the
-   phone/web — no `flow-*` run needed); if it hasn't, set it yourself, else flip the `status:*` label in
-   the fallback (the Project-vs-labels detection snippet is in `flow-board`):
+   phone/web — no `flow-*` run needed); if it hasn't, set it yourself:
    ```bash
-   # If you must set it yourself, run the flow-board detection snippet first (it switches to the
-   # project-capable account — the EMU flip otherwise makes this write fail silently):
-   # gh project item-edit <item-id> --field Status --single-select-option-id <Done>   # when have_project=1
-   gh issue edit <N> --remove-label status:in-review --add-label status:done 2>/dev/null || true
+   # Run the flow-board detection snippet first (it switches to the project-capable account — the EMU
+   # flip otherwise makes this write fail silently), then set the board Status only:
+   gh project item-edit <item-id> --field Status --single-select-option-id <Done>   # when have_project=1
    ```
+   Do NOT write any `status:*` label here. Done → no board-derived label (board→label mirror #2855:
+   Backlog/Done carry none), and the mirror only reconciles OPEN issues, so a leftover label on the
+   now-closed issue is irrelevant to discovery (`--state open`) and to the detector; a reopen fires
+   the mirror's `issues: reopened` trigger and re-derives from board Status.
    Releasing the claim = deleting the CLAIM REF `refs/claims/issue-<N>` via `claim.sh release` (#2665 — the
    ref is THE cross-machine lock); deleting the `issue-<N>-<slug>` branch is plumbing cleanup of the merged
    PR head, not the lock. Both happen in step 6 below. After finalize, nothing for this issue may remain

--- a/.claude/skills/flow-groom/SKILL.md
+++ b/.claude/skills/flow-groom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flow-groom
-description: Turn a rough idea into one scoped, labeled GitHub issue (one P0–P3 + status:ready, testable acceptance criteria), and decide oracle-vs-design routing. First stage of the CQLite delivery pipeline. Use when the owner says "groom <idea>", "file an issue for X", or brings a rough idea to scope.
+description: Turn a rough idea into one scoped, labeled GitHub issue (one P0–P3, board Status set to Ready/Backlog, testable acceptance criteria), and decide oracle-vs-design routing. First stage of the CQLite delivery pipeline. Use when the owner says "groom <idea>", "file an issue for X", or brings a rough idea to scope.
 ---
 
 # flow-groom — idea → one scoped issue
@@ -19,16 +19,20 @@ You are the CQLite delivery lead. Turn a rough idea into exactly ONE well-scoped
      latitude, no oracle. These go through `flow-activate` (OpenSpec).
 3. **Write testable acceptance criteria.** Each criterion must map to a check (a test or an sstabledump
    parity comparison). Note any no-heuristics / public-surface (wiring-evidence) / memory-budget impact.
-4. **Create the issue** with exactly one priority label and `status:ready`:
+4. **Create the issue** with exactly one priority label. Do NOT set a `status:*` label — the board
+   Status you set in step 5 is the single source of truth, and the enforced board→label mirror
+   (issue #2855, `scripts/ci/board-label-mirror.sh`) DERIVES the `status:*` label from it. Writing
+   one here would be an out-of-band label the mirror's drift-detector reverts (and flags):
    ```bash
    gh issue create --title "<concise>" --body "<context + oracle/design + acceptance criteria>" \
-     --label "P2" --label "status:ready"
+     --label "P2"
    ```
-   (Pick P0–P3 deliberately; confirm priority with the owner if unsure.) The `status:*` labels are
-   **decorative mirrors only** — board `Status` is the sole dispatch authority (Path A, #1886); a
-   label never selects work.
+   (Pick P0–P3 deliberately; confirm priority with the owner if unsure.) The `status:*` labels are a
+   **one-way, board-DERIVED read-mirror** — board `Status` is the sole dispatch authority (Path A,
+   #1886); a label never selects work and is never set by hand.
 5. **Verify the board add — do NOT trust Project auto-add.** Auto-add has been observed missing all
-   new issues, so add the item explicitly and confirm it landed:
+   new issues, so add the item explicitly and confirm it landed; the mirror then projects its
+   `Status` to the matching `status:*` label (Ready→status:ready, etc.):
    ```bash
    gh project item-add 1 --owner pmcfadin --url <issue-url>
    gh project item-edit --project-id <id> --id <item-id> --field-id <status-field> \

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -31,12 +31,12 @@ never gate stdout or review churn.
    In an **attended** session you may ask when you can't confirm approval; in an **unattended** session NEVER
    ask — **park** per the #2666 park-and-resume protocol (post ONE structured question comment + add the
    `needs-decision` label + write a `blocked`/`reason: seam1-approval` marker + EXIT), never `AskUserQuestion`.
-   Oracle-driven: a pinned parity/repro test exists or is written first. Set exactly one
-   lifecycle label — clear ALL `status:*` first so the issue never carries two (oracle issues arrive at
-   `status:ready`, design issues at `status:spec-review`):
+   Oracle-driven: a pinned parity/repro test exists or is written first. Clear the transient
+   skill-managed sub-markers (`spec-review`/`addressing`) so the issue does not carry a stale one — do
+   NOT write a `status:in-progress` label: the board→label mirror (#2855) derives it from the board
+   Status you set, and reverts any hand-written board-derived label on its next pass:
    ```bash
-   gh issue edit <N> --remove-label status:ready --remove-label status:spec-review \
-     --remove-label status:addressing --remove-label status:in-review --add-label status:in-progress
+   gh issue edit <N> --remove-label status:spec-review --remove-label status:addressing
    ```
    (`--remove-label` is a no-op for labels not present, so this is safe regardless of the starting state.)
    Set the Project `Status=In Progress` too. **Run the `flow-board` detection snippet FIRST** — it does
@@ -120,13 +120,14 @@ never gate stdout or review churn.
    this push sends the implementation commits. Use a closing keyword (`Closes #<N>`) so merge auto-closes
    the issue, then refresh the heartbeat (#2089):
    ```bash
-   gh issue edit <N> --remove-label status:in-progress --add-label status:in-review
    git -C <worktree> push -u origin issue-<N>-<slug>
    gh pr create --base main --head issue-<N>-<slug> --fill   # ensure body has "Closes #<N>"
    scripts/flow/claim-heartbeat.sh beat <N>                  # PR-open stage transition
    # Board → In Review fires via GitHub's "Pull request linked to issue" built-in. Belt-and-suspenders:
    # run the flow-board detection snippet first (switches to the project-capable account), then
-   # gh project item-edit ... Status=In Review when have_project=1; else the label above + loud ⚠️ warning.
+   # gh project item-edit ... Status=In Review when have_project=1. Do NOT write a status:in-review
+   # label — the board→label mirror (#2855) derives it from the board Status; if have_project=0 print
+   # the loud ⚠️ board-unavailable warning so the owner knows the board (and thus the mirror) is stale.
    ```
    **GitHub API resilience:** `gh pr create` / `gh issue comment` ride the **GraphQL** bucket, which
    throttles **separately** from REST (each 5k pts/hr, independent per-bucket windows). If GraphQL is

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -46,16 +46,20 @@ on:
 permissions:
   contents: read
 
-# Key the concurrency group PER event/target (issue #2855, F4): the mirror edits
-# labels with the PAT, so each --add/--remove-label re-triggers this workflow via
+# Key the concurrency group PER LANE (issue #2855, F4/G3): the mirror edits labels
+# with the PAT, so each --add/--remove-label re-triggers this workflow via
 # issues:[labeled,unlabeled]. A single shared serialized group would let a burst of
 # label events starve or block a pending pull_request_target:closed (closed-PR ->
-# Done safety net) or the scheduled sweep. Per-(event,target) groups keep those
-# distinct lanes independent; only repeated events for the SAME issue serialize.
-# NOTE: a ${{ }} expression in the concurrency group KEY is not a run: shell body,
-# so this is NOT the command-injection sink the guard flags — safe here.
+# Done safety net) or the scheduled sweep. So the group keys on the ISSUE/PR number
+# for those event lanes — only repeated events for the SAME issue serialize — but
+# collapses to the CONSTANT `sweep` key otherwise, so `schedule` and
+# `workflow_dispatch` share ONE group and their `sweep` + `reap-claims` board
+# writes serialize (they must NOT race / double-comment — G3). Keying on
+# github.event_name would split them into separate groups and let two sweeps run
+# concurrently. NOTE: a ${{ }} expression in the concurrency group KEY is not a
+# run: shell body, so this is NOT the command-injection sink the guard flags.
 concurrency:
-  group: project-board-sync-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || 'sweep' }}
+  group: project-board-sync-${{ github.event.issue.number && format('issue-{0}', github.event.issue.number) || github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || 'sweep' }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -30,9 +30,16 @@ on:
   pull_request_target:
     types: [closed]
   schedule:
-    # Hygiene sweep every 30 min (null-status -> Backlog; closed-PR safety net).
+    # Hygiene sweep every 30 min (null-status -> Backlog; closed-PR safety net;
+    # board->label mirror + drift-detector, issue #2855).
     - cron: '*/30 * * * *'
   workflow_dispatch: {}
+  # Low-latency board->label mirror correction (issue #2855): a hand-tampered
+  # status:* label (or a reopen) is reverted from the issue's board Status quickly
+  # rather than waiting up to 30 min for the cron sweep. The 30-min sweep remains
+  # the correctness guarantee; these events only reduce lag.
+  issues:
+    types: [edited, labeled, unlabeled, reopened]
 
 permissions:
   contents: read
@@ -133,10 +140,14 @@ jobs:
   # issue's own createdAt — never wall-clock-racing a brand-new item.
   # ---------------------------------------------------------------------------
   sweep:
-    if: github.event_name != 'pull_request_target'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       SWEEP_GRACE_MINUTES: '10'
+      # Board->label drift-detector grace (issue #2855): an OPEN issue younger than
+      # this is exempt from the detector so a just-added item (or a race between the
+      # mirror pass and this detector) does not flap the run red.
+      BLM_GRACE_SECS: '600'
     steps:
       - name: Guard token
         id: guard
@@ -145,6 +156,9 @@ jobs:
             echo "::error::PROJECTS_TOKEN not set — board sweep + claim reaper are NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
             exit 1
           fi
+
+      - name: Checkout (for scripts/ci/board-label-mirror.sh)
+        uses: actions/checkout@v4
 
       - name: Reconcile board
         run: |
@@ -256,6 +270,58 @@ jobs:
 
           echo "Sweep complete: $backlogged issue(s) -> Backlog, $doned closed PR card(s) -> Done, $skipped_fresh fresh null-status issue(s) held back (within ${SWEEP_GRACE_MINUTES}m auto-add grace)."
 
+      # Board->label mirror (issue #2855): force every OPEN issue's board-derived
+      # status:* label to match its board Status (Ready->status:ready, In Progress->
+      # status:in-progress, In Review->status:in-review, Backlog/Done->none). The
+      # single-source mapping + mirror lives in scripts/ci/board-label-mirror.sh so
+      # the workflow and the shell test drive the SAME logic. Idempotent: a matching
+      # board makes no edit. Does NOT touch status:spec-review/status:addressing
+      # (transient skill-managed sub-markers, not board Status options).
+      - name: Mirror board Status -> status:* label
+        run: bash scripts/ci/board-label-mirror.sh mirror
+
+      # Drift-detector (issue #2855): AFTER the mirror pass, re-read (Status, labels)
+      # for every OPEN issue and FAIL the run (::error:: + non-zero) on any
+      # board-derived-label != Status disagreement (past the BLM_GRACE_SECS window,
+      # so a just-added item or an in-run race does not flap red). A red here means a
+      # re-drift or an out-of-band label write — surfaced, never silently tolerated.
+      - name: Drift-detect board vs label
+        run: bash scripts/ci/board-label-mirror.sh detect
+
+  # ---------------------------------------------------------------------------
+  # Event path (issue #2855): an issue was edited / (un)labeled / reopened. Re-assert
+  # ONLY that one issue's board-derived label from its board Status (low-latency
+  # correction of a hand-tampered label). Reuses the SAME mapping in
+  # scripts/ci/board-label-mirror.sh as the sweep — single source, no divergent copy.
+  # ---------------------------------------------------------------------------
+  mirror-one:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard token
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::PROJECTS_TOKEN not set — board->label mirror is NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655/#2855)."
+            exit 1
+          fi
+
+      - name: Checkout (for scripts/ci/board-label-mirror.sh)
+        uses: actions/checkout@v4
+
+      # Pass the event-supplied issue number via a QUOTED env var (never inlined
+      # into run:) and validate it is a bare integer before use — the workflow
+      # command-injection guard (issue #2656 / check-workflow-injection.sh).
+      - name: Re-assert this issue's label from board Status
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          case "$ISSUE_NUMBER" in
+            ''|*[!0-9]*)
+              echo "::error::unexpected non-numeric issue number '$ISSUE_NUMBER'"; exit 1 ;;
+          esac
+          bash scripts/ci/board-label-mirror.sh mirror-one "$ISSUE_NUMBER"
+
   # ---------------------------------------------------------------------------
   # Scheduled path: CI-side claim reaper (issue #2655 / #2499 design).
   #
@@ -271,7 +337,7 @@ jobs:
   # Ready with a traceable comment, mirroring flow-board's manual reap.
   # ---------------------------------------------------------------------------
   reap-claims:
-    if: github.event_name != 'pull_request_target'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Needs write to delete stale refs/machine-claims/* refs (the top-level

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -8,8 +8,11 @@ name: Project Board Sync
 #   2. New issues can land with a NULL Status (race with Auto-add). -> sweep
 #      null-status OPEN issues into Backlog.
 #
-# Requires a repo secret PROJECTS_TOKEN: a PAT (or GitHub App token) with the
-# `project` scope. The default GITHUB_TOKEN CANNOT write user/org Projects v2.
+# Requires a repo secret PROJECTS_TOKEN: a PAT (or GitHub App token) with BOTH
+#   * `project` scope — Projects v2 read/write (Status field mutations), and
+#   * repo `issues` read/write — the board->label mirror edits issue labels via
+#     `gh issue edit --add-label/--remove-label` and reads via `gh issue list`.
+# The default GITHUB_TOKEN CANNOT write user/org Projects v2.
 # If the secret is ABSENT the token-guarded jobs emit a LOUD `::error::`
 # annotation and FAIL (issue #2655) — a persistent red run is the alert that
 # board hygiene + claim reaping have silently stopped working, instead of the
@@ -85,7 +88,7 @@ jobs:
         id: guard
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::PROJECTS_TOKEN not set — board sync is NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
+            echo "::error::PROJECTS_TOKEN not set — board sync is NOT running. Add a PAT (or GitHub App token) with 'project' (Projects v2 read/write) AND repo 'issues' read/write scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
             exit 1
           fi
 
@@ -167,7 +170,7 @@ jobs:
         id: guard
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::PROJECTS_TOKEN not set — board sweep + claim reaper are NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
+            echo "::error::PROJECTS_TOKEN not set — board sweep + claim reaper are NOT running. Add a PAT (or GitHub App token) with 'project' (Projects v2 read/write) AND repo 'issues' read/write scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
             exit 1
           fi
 
@@ -331,7 +334,7 @@ jobs:
       - name: Guard token
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::PROJECTS_TOKEN not set — board->label mirror is NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655/#2855)."
+            echo "::error::PROJECTS_TOKEN not set — board->label mirror is NOT running. Add a PAT (or GitHub App token) with 'project' (Projects v2 read/write) AND repo 'issues' read/write scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655/#2855)."
             exit 1
           fi
 
@@ -384,7 +387,7 @@ jobs:
       - name: Guard token
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::PROJECTS_TOKEN not set — claim reaper is NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
+            echo "::error::PROJECTS_TOKEN not set — claim reaper is NOT running. Add a PAT (or GitHub App token) with 'project' (Projects v2 read/write) AND repo 'issues' read/write scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655) so this outage is visible instead of a silent green no-op."
             exit 1
           fi
 

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -307,6 +307,7 @@ jobs:
   mirror-one:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Guard token
         run: |

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -37,15 +37,25 @@ on:
   # Low-latency board->label mirror correction (issue #2855): a hand-tampered
   # status:* label (or a reopen) is reverted from the issue's board Status quickly
   # rather than waiting up to 30 min for the cron sweep. The 30-min sweep remains
-  # the correctness guarantee; these events only reduce lag.
+  # the correctness guarantee; these events only reduce lag. `edited` is
+  # deliberately OMITTED — it fires on title/body edits (pure noise for a label
+  # mirror) and each mirror label write already re-triggers labeled/unlabeled.
   issues:
-    types: [edited, labeled, unlabeled, reopened]
+    types: [labeled, unlabeled, reopened]
 
 permissions:
   contents: read
 
+# Key the concurrency group PER event/target (issue #2855, F4): the mirror edits
+# labels with the PAT, so each --add/--remove-label re-triggers this workflow via
+# issues:[labeled,unlabeled]. A single shared serialized group would let a burst of
+# label events starve or block a pending pull_request_target:closed (closed-PR ->
+# Done safety net) or the scheduled sweep. Per-(event,target) groups keep those
+# distinct lanes independent; only repeated events for the SAME issue serialize.
+# NOTE: a ${{ }} expression in the concurrency group KEY is not a run: shell body,
+# so this is NOT the command-injection sink the guard flags — safe here.
 concurrency:
-  group: project-board-sync
+  group: project-board-sync-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || 'sweep' }}
   cancel-in-progress: false
 
 env:
@@ -308,19 +318,23 @@ jobs:
       - name: Checkout (for scripts/ci/board-label-mirror.sh)
         uses: actions/checkout@v4
 
-      # Pass the event-supplied issue number via a QUOTED env var (never inlined
-      # into run:) and validate it is a bare integer before use — the workflow
-      # command-injection guard (issue #2656 / check-workflow-injection.sh).
+      # Pass the event-supplied issue number + node id via QUOTED env vars (never
+      # inlined into run:) and validate the number is a bare integer before use —
+      # the workflow command-injection guard (issue #2656 / check-workflow-
+      # injection.sh). The node id lets mirror-one resolve the issue's project item
+      # DIRECTLY (node(id){projectItems}) instead of paginating the whole board for
+      # one issue (issue #2855, F4).
       - name: Re-assert this issue's label from board Status
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
         run: |
           set -euo pipefail
           case "$ISSUE_NUMBER" in
             ''|*[!0-9]*)
               echo "::error::unexpected non-numeric issue number '$ISSUE_NUMBER'"; exit 1 ;;
           esac
-          bash scripts/ci/board-label-mirror.sh mirror-one "$ISSUE_NUMBER"
+          bash scripts/ci/board-label-mirror.sh mirror-one "$ISSUE_NUMBER" "$ISSUE_NODE_ID"
 
   # ---------------------------------------------------------------------------
   # Scheduled path: CI-side claim reaper (issue #2655 / #2499 design).

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -305,7 +305,12 @@ jobs:
   # scripts/ci/board-label-mirror.sh as the sweep — single source, no divergent copy.
   # ---------------------------------------------------------------------------
   mirror-one:
-    if: github.event_name == 'issues'
+    # Gate on OPEN state: issues:[labeled,unlabeled] fires for CLOSED issues too
+    # (routine triage tagging). A closed issue has no OPEN board row, so running
+    # mirror-one would exit 1 with an ::error:: on every benign closed-issue label
+    # touch — training readers to ignore this workflow's reds (issue #2855, G2).
+    # The script ALSO exits 0 gracefully on a closed issue as a safety net.
+    if: github.event_name == 'issues' && github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -309,12 +309,22 @@ jobs:
   # scripts/ci/board-label-mirror.sh as the sweep — single source, no divergent copy.
   # ---------------------------------------------------------------------------
   mirror-one:
-    # Gate on OPEN state: issues:[labeled,unlabeled] fires for CLOSED issues too
-    # (routine triage tagging). A closed issue has no OPEN board row, so running
-    # mirror-one would exit 1 with an ::error:: on every benign closed-issue label
-    # touch — training readers to ignore this workflow's reds (issue #2855, G2).
-    # The script ALSO exits 0 gracefully on a closed issue as a safety net.
-    if: github.event_name == 'issues' && github.event.issue.state == 'open'
+    # Gate on OPEN state AND a status:* (or empty) label: issues:[labeled,unlabeled]
+    # fires for CLOSED issues too (routine triage tagging) AND for every non-status
+    # label touch (P2, needs-decision, flow-meta …). A closed issue has no OPEN board
+    # row, and a non-status label touch on an auto-add-missed OPEN issue has no board
+    # row either, so running mirror-one would exit 1 with an ::error:: on every benign
+    # label event — training readers to ignore this workflow's reds and drowning the
+    # load-bearing "persistent red == PROJECTS_TOKEN outage" signal (issue #2855, M1/G2).
+    # So skip unless the touched label is a board-derived status:* one (a hand-tampered
+    # derived label needing correction). github.event.label.name is empty for the
+    # `reopened` event, which the `== ''` clause deliberately lets through. The script
+    # ALSO exits 0 gracefully on a closed / off-board-no-derived-label issue as a
+    # defence in depth.
+    if: >-
+      github.event_name == 'issues'
+      && github.event.issue.state == 'open'
+      && (github.event.label.name == '' || startsWith(github.event.label.name, 'status:'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,9 +341,20 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   one OpenSpec change `<slug>` ↔ one PR. Worktrees lack gitignored Data.db binaries — point
   `CQLITE_DATASETS_ROOT` at the main repo's `test-data/datasets`.
 - **Board = sole dispatch authority (Path A, #1886)**: the GitHub Project `Status` field
-  (`Backlog/Ready/In Progress/In Review/Done`); exactly one `P0`–`P3` per issue. `status:*` labels
-  are decorative, NEVER a selection source. New issues auto-land at `Backlog`. Empty Ready column =
-  no work ready → STOP. Board unreachable (auth/scope) → STOP and fix auth; never label-dispatch.
+  (`Backlog/Ready/In Progress/In Review/Done`); exactly one `P0`–`P3` per issue. New issues auto-land
+  at `Backlog`. Empty Ready column = no work ready → STOP. Board unreachable (auth/scope) → STOP and
+  fix auth; never label-dispatch.
+- **`status:*` labels = an ENFORCED read-mirror of board Status, for DISCOVERY only (#2855)**: the
+  `project-board-sync.yml` workflow is the *single writer*, deriving each OPEN issue's label from its
+  board Status (Ready→`status:ready`, In Progress→`status:in-progress`, In Review→`status:in-review`,
+  Backlog/Done→none) on the 30-min sweep + on issue events, and a drift-detector FAILs the run on any
+  disagreement. So the label is now *trustworthy* for **cheap server-side candidate discovery**
+  (`gh issue list --state open --label status:ready --json number,title` — no issue bodies, no board
+  pagination). It is NEVER the dispatch/claim authority: it is eventually-consistent (≤30-min lag), so
+  it only NARROWS candidates — the claim ref + a fresh board read at claim time remain the sole
+  double-work arbiter. flow-* skills no longer write the board-derived labels (they set board Status
+  only; the mirror follows); `status:spec-review`/`status:addressing` stay transient skill-managed
+  sub-markers the mirror does not touch.
 - **Claim protocol (cross-machine, #2665)**: THE lock is the slugless fixed-name ref
   `refs/claims/issue-<N>`, acquired via `bash scripts/flow/claim.sh claim <N>` — an atomic unique
   root-commit push that git arbitrates server-side, so a model-chosen slug or an identical-SHA base

--- a/docs/development/pm-operating-loop.md
+++ b/docs/development/pm-operating-loop.md
@@ -31,10 +31,16 @@ ORDER: k                # queue rank when several are Ready at once
 ## Worker lifecycle (flow-lead)
 
 1. **Pick up**: take the oldest issue whose **board `Status=Ready`** with **no** `issue-N-*` lock on origin.
-   **Select by board `Status` ONLY — never by the `status:ready` label** (Path A, #1886: the board is the
-   sole dispatch authority; labels are decorative). **Empty Ready → stop** (no work is ready; near a release
-   Ready is meant to drain to zero — do NOT fall back to labels). Board unreachable → STOP and fix auth, do
-   not dispatch from labels. Claim it (`bash scripts/flow/claim.sh claim <N>` = the cross-machine lock, the slugless `refs/claims/issue-<N>` ref, #2665); `CLAIM HELD` wins, `CLAIM LOST` takes the next item.
+   For a cheap first pass you MAY *narrow* candidates with the enforced status mirror
+   (`gh issue list --state open --label status:ready --json number,title` — server-side, no issue
+   bodies, no board pagination; #2855), but the **selection decision is by board `Status` ONLY** (Path A,
+   #1886: the board is the sole dispatch authority). The `status:ready` label is an enforced read-mirror
+   of board Status written solely by `project-board-sync.yml`; it is eventually-consistent (≤30-min lag),
+   so it only narrows — confirm the candidate's live board `Status=Ready` before working it, never treat
+   the label as proof it is Ready/unclaimed. **Empty Ready → stop** (no work is ready; near a release
+   Ready is meant to drain to zero). Board unreachable → STOP and fix auth, do not dispatch from labels.
+   Claim it (`bash scripts/flow/claim.sh claim <N>` = the cross-machine lock, the slugless
+   `refs/claims/issue-<N>` ref, #2665); `CLAIM HELD` wins, `CLAIM LOST` takes the next item.
 2. **Read orders**: read the issue's manager comments. Note any `HOLD` / `ORDER` / instructions.
 3. **Route — spec-first for new work**: design-driven / any new feature → run **`flow-activate` FIRST**
    (produces the OpenSpec proposal/design/specs/tasks, STOPS at Seam 1 for owner spec approval); no code

--- a/openspec/changes/board-label-mirror/design.md
+++ b/openspec/changes/board-label-mirror/design.md
@@ -1,0 +1,99 @@
+# Design — enforced board→label mirror
+
+## The status ↔ label mapping
+
+Board Status has five options: `Backlog / Ready / In Progress / In Review / Done`. The active-work
+states map 1:1 to a `status:*` label; the two terminal-ish states are handled deliberately:
+
+| Board Status | `status:*` label the mirror sets | Rationale |
+|--------------|----------------------------------|-----------|
+| Ready        | `status:ready`                   | the discovery target |
+| In Progress  | `status:in-progress`             | |
+| In Review    | `status:in-review`               | |
+| Backlog      | **none** (all `status:*` removed)| Backlog = "not dispatchable"; absence of a status:* label is the signal. Avoids inventing a `status:backlog` label nobody queries. |
+| Done         | **none** (all `status:*` removed)| Done items are closed; a closed issue carries no dispatch label. |
+
+`status:spec-review` and `status:addressing` are **sub-states of In Progress** the flow-* skills use
+transiently and are NOT board Status options. Decision: the mirror owns ONLY the four board-derived
+labels (`ready`, `in-progress`, `in-review`, and the none-for-Backlog/Done case). `spec-review` /
+`addressing` are removed from the "mirror-owned" set — the mirror maps In Progress → `status:in-progress`
+and does not touch `spec-review`/`addressing` (they remain skill-managed transient markers, OR are
+retired in favor of board sub-signals — see Open decision 1). This keeps the mirror's invariant crisp:
+*for every open issue, exactly the label matching its board Status is present, and no other
+board-derived status label is.*
+
+## Decision: which events fire the mirror
+
+Projects v2 item field-changes are **not** a native GitHub Actions `on:` trigger, so we cannot fire
+precisely when Status changes. The mirror therefore runs on:
+
+- **The existing 30-min `sweep` job** (cron) — the reconciliation backstop. It already paginates
+  every item and reads `fieldValueByName(name:"Status")`, so the mirror is a few lines added to a
+  loop that already exists. This GUARANTEES convergence within ≤30 min regardless of what changed.
+- **`workflow_dispatch`** — manual/immediate reconcile (used by the rollout + on demand).
+- **`issues: [edited, labeled, unlabeled, reopened]`** — cheap low-latency correction so a
+  hand-tampered label is reverted quickly rather than waiting up to 30 min. (An `issues` trigger
+  fires on the issue, and the job re-reads that issue's board Status and re-asserts the label.)
+
+We deliberately do NOT try to trigger on Status-change itself (no such event) — the cron sweep is
+the correctness guarantee; the event triggers only reduce lag. This is why the label is
+discovery-only: the ≤30-min worst-case lag is fine for narrowing candidates, unacceptable for
+claiming (hence claim ref stays authoritative).
+
+## Decision: single writer + idempotent force-set
+
+The mirror is **idempotent**: for each open issue it computes the desired label from Status, then
+`--add-label <desired>` (no-op if present) and `--remove-label <each other status:* label>` (no-op if
+absent). Running it twice changes nothing. This makes the sweep safe to re-run and makes the
+drift-detector trivially the same computation with an assert instead of a write.
+
+**Single-writer enforcement is by convention + the detector, not a GitHub ACL** (GitHub can't
+restrict who sets a label). So: flow-* skills stop writing `status:*` labels (grep-enforced in
+review), and the drift-detector catches any out-of-band write on the next run by failing loud.
+
+## Decision: drift-detector placement
+
+The detector runs as the FINAL step of the sweep job, AFTER the mirror pass, and re-reads the
+(Status, labels) for every open issue:
+- If any open issue's label set violates the invariant → `::error::` + exit non-zero (red run).
+- Because the mirror pass just ran, a red detector means either (a) a race during the run, or (b) a
+  bug in the mirror — both worth a red. To avoid flapping on (a), the detector tolerates the same
+  auto-add grace window the sweep already uses for null-Status issues.
+
+An alternative — detector as a SEPARATE scheduled workflow — was rejected: co-locating it means it
+always validates the state the mirror just wrote, with no second token/PAT to manage.
+
+## Decision: token dependency
+
+The mirror write needs the same `project`-scoped `PROJECTS_TOKEN` PAT the sync already requires (the
+default `GITHUB_TOKEN` cannot read user Projects v2). The existing "Guard token" step already fails
+loud when it's absent (#2655); the mirror + detector sit behind that same guard, so a missing token
+fails the whole run loudly rather than silently skipping the mirror.
+
+## Rollout
+
+1. Merge the workflow change.
+2. `workflow_dispatch` an immediate run → the mirror pass reconciles all open issues (fixes today's
+   19-issue drift), the detector passes.
+3. Land the doctrine + flow-* skill edits in the same PR so no skill re-introduces a hand-written
+   label after rollout.
+
+## Alternatives considered
+
+- **Bidirectional sync (label ↔ Status):** rejected — two writers is exactly the drift cause; a
+  loop hazard; and Status must stay the single truth.
+- **`status:backlog` label for Backlog:** rejected — nothing queries it; "no status:* label = not
+  dispatchable" is simpler and self-documenting.
+- **Trust the label as claim authority (drop the board read):** rejected — eventually-consistent lag
+  makes it unsafe for claiming; the claim ref is the only correct arbiter.
+
+## Test strategy
+
+- A shell test harness for the mirror/detector logic (`scripts/tests/`), driven with a STUBBED
+  `gh`/GraphQL layer (like `test_worker_supervisor.sh` stubs), asserting: Ready→`status:ready` set +
+  others removed; Backlog→all removed; a seeded mismatch makes the detector exit non-zero; a matching
+  state makes it exit 0; idempotency (second run = no change).
+- Doctrine grep test: no flow-* skill contains `add-label status:` / `remove-label status:`.
+- The gate `tooling-tests` component runs the new shell test.
+- Workflow YAML validated (`check-workflow-injection.sh` / actionlint if present) — no
+  `${{ }}`-into-`run:` injection (roborev-lints mechanized class).

--- a/openspec/changes/board-label-mirror/proposal.md
+++ b/openspec/changes/board-label-mirror/proposal.md
@@ -1,0 +1,67 @@
+# Enforced one-way board→label mirror (issue #2855)
+
+## Why
+
+Finding Ready work is both context-expensive and drift-prone today:
+
+- `gh issue list --limit N --json …body…` floods agent context with full issue bodies AND cannot
+  see board `Status` (Status lives on the project *item*, not the issue) — so it can't find Ready.
+- `gh project item-list` sees Status but Projects v2 has **no server-side field filter** — you
+  paginate every item and filter client-side (and `--paginate` can loop; measured live).
+- The `status:*` labels ARE server-side filterable and cheap (`gh issue list --label status:ready`
+  = 0 core-rate, no bodies) — but they **drift** because multiple parties write them (humans +
+  flow-* skills) and nothing reconciles. **Measured 2026-07-24: board Ready = 1 (#1883) vs label
+  `status:ready` = 20 open** — a 19-issue disagreement. Per Path A (#1886) the labels are therefore
+  declared decorative and forbidden as a selection source.
+
+This change makes the label a *trustworthy* projection so it can serve cheap discovery, without
+re-drifting and without weakening the claim authority.
+
+## What Changes
+
+Board `Status` stays the single source of truth. The `status:*` label becomes a **derived
+projection written by exactly one automated writer** — `.github/workflows/project-board-sync.yml`:
+
+- On the workflow's existing reconciliation pass (the 30-min `sweep` job + `workflow_dispatch`) and
+  on issue events, read each OPEN item's board Status and **force-set the one matching `status:*`
+  label, removing the others**. No human or flow-* skill writes a `status:*` label again.
+- Add a **drift-detector** step that FAILS the workflow run (red) if any OPEN issue's `status:*`
+  label disagrees with its board Status — so a regression is caught, never silently re-drifted (same
+  fail-loud posture as the existing PROJECTS_TOKEN guard).
+- **Rollout reconciles the current 19-issue drift**: the first mirror pass corrects every OPEN
+  issue's label to match its board Status; the drift-detector then passes.
+- flow-* skills (activate/implement/address/finalize) **stop writing `status:*` labels** — they set
+  board Status only; the mirror follows. flow-board and dispatch READ `status:ready` for cheap
+  discovery.
+
+## Authority boundary (preserved — must not weaken)
+
+The label is an **enforced read-mirror for DISCOVERY only**. It is eventually-consistent (there is
+an event→workflow lag window), so it narrows the candidate set but is **NEVER the claim authority**:
+
+- The claim ref `refs/claims/issue-<N>` + a fresh board read at claim time remain the sole authority
+  that prevents double-work (Path A / #2665 unchanged).
+- Two machines seeing a stale-Ready label still both go through `claim.sh`; git arbitrates.
+
+## Non-goals
+
+- **No change to the claim protocol or the dispatch authority.** The label never selects or claims
+  work; it only narrows discovery.
+- **No new bidirectional sync.** Strictly one-way (Status → label). Writing a label never changes
+  Status. (In fact the workflow OVERWRITES any hand-set label on its next pass.)
+- **No Rust / product-code change.** GitHub Actions workflow + shell + doctrine + flow-* skills only.
+- **No change to the existing sync jobs' other duties** (null-status→Backlog sweep, closed-PR→Done
+  safety net, claim reaping) beyond adding the mirror + drift-detector.
+
+## Doctrine impact
+
+Labels move from "purely decorative, never a selection source" (Path A) to "an **enforced
+read-mirror for discovery**, still never the claim authority." That is a real doctrine change, so
+`CLAUDE.md`, `docs/development/pm-operating-loop.md`, and the website `agents-developing/` page are
+updated in this same change, and the flow-* skills are updated to stop writing labels + to use the
+cheap label query for discovery.
+
+## Routing
+
+Design-driven (process/tooling; no SSTable/parity oracle). Genuine latitude in the event set, the
+Backlog/Done treatment, and the doctrine change → OpenSpec.

--- a/openspec/changes/board-label-mirror/specs/board-label-mirror/spec.md
+++ b/openspec/changes/board-label-mirror/specs/board-label-mirror/spec.md
@@ -1,0 +1,89 @@
+# board-label-mirror — enforced one-way Status→label projection
+
+## ADDED Requirements
+
+### Requirement: The status label SHALL be a machine-written projection of board Status
+
+The `project-board-sync.yml` workflow SHALL be the single writer of `status:*` labels, deriving each
+OPEN issue's label from its board `Status` on the scheduled reconciliation pass, on
+`workflow_dispatch`, and on issue events, so that the label is a trustworthy projection rather than a
+hand-maintained value. The mapping SHALL be: Ready→`status:ready`, In Progress→`status:in-progress`,
+In Review→`status:in-review`, and Backlog or Done→no `status:*` label.
+
+#### Scenario: A Ready item gets exactly the ready label
+- **GIVEN** an OPEN issue whose board Status is `Ready`
+- **WHEN** the mirror pass runs
+- **THEN** the issue SHALL carry `status:ready`
+- **AND** it SHALL NOT carry `status:in-progress` or `status:in-review`
+
+#### Scenario: Status change is reflected and the stale label removed
+- **GIVEN** an OPEN issue previously labeled `status:ready` whose board Status is now `In Progress`
+- **WHEN** the mirror pass runs
+- **THEN** the issue SHALL carry `status:in-progress`
+- **AND** `status:ready` SHALL be removed
+
+#### Scenario: Backlog and Done carry no status label
+- **GIVEN** an OPEN issue whose board Status is `Backlog` (or `Done`)
+- **WHEN** the mirror pass runs
+- **THEN** the issue SHALL carry none of `status:ready` / `status:in-progress` / `status:in-review`
+
+#### Scenario: The mirror is idempotent
+- **GIVEN** an issue whose label already matches its board Status
+- **WHEN** the mirror pass runs twice
+- **THEN** the second run SHALL make no label change
+
+### Requirement: A drift detector SHALL fail loud on any label/Status disagreement
+
+After the mirror pass, the workflow SHALL verify every OPEN issue's `status:*` label matches its
+board Status and SHALL fail the run (non-zero exit + an `::error::` annotation) on any disagreement,
+so a re-drift or an out-of-band label write is surfaced as a red run rather than silently tolerated.
+
+#### Scenario: Seeded mismatch fails the run
+- **GIVEN** an OPEN issue whose `status:*` label does not match its board Status (past the auto-add
+  grace window)
+- **WHEN** the drift detector runs
+- **THEN** it SHALL emit an `::error::` naming the issue and exit non-zero
+
+#### Scenario: Consistent board passes
+- **GIVEN** every OPEN issue's `status:*` label matches its board Status
+- **WHEN** the drift detector runs
+- **THEN** it SHALL exit zero with no error annotation
+
+#### Scenario: Missing project token fails loud, never silently skips
+- **GIVEN** `PROJECTS_TOKEN` is absent
+- **WHEN** the workflow runs
+- **THEN** it SHALL fail loud (the existing token guard) rather than silently skip the mirror or
+  detector
+
+### Requirement: The label SHALL be discovery-only, never the claim authority
+
+The mirrored label SHALL be usable for cheap server-side discovery of candidate work, but SHALL NOT
+be the authority that selects or claims an issue; the claim ref plus a fresh board read at claim time
+SHALL remain the sole double-work arbiter.
+
+#### Scenario: Cheap discovery reads the label
+- **WHEN** a session needs candidate Ready issues
+- **THEN** it MAY use `gh issue list --state open --label status:ready` (server-side, no issue
+  bodies) to enumerate candidates
+
+#### Scenario: Claiming still goes through the claim ref
+- **GIVEN** a candidate issue discovered via the `status:ready` label
+- **WHEN** a session decides to work it
+- **THEN** it SHALL acquire `refs/claims/issue-<N>` and re-read the board before proceeding
+- **AND** the label alone SHALL NOT be treated as proof the issue is unclaimed or still Ready
+
+### Requirement: Flow skills SHALL stop writing status labels and use the label for discovery
+
+The flow-* skills SHALL NOT write `status:*` labels (they set board Status only, letting the mirror
+follow), and SHALL use the label query for cheap candidate discovery where they previously pulled
+broad issue lists.
+
+#### Scenario: No skill writes a status label
+- **WHEN** the flow-* skill sources are searched for `add-label status:` or `remove-label status:`
+- **THEN** no match SHALL be found
+
+#### Scenario: Doctrine describes the label as an enforced discovery mirror
+- **WHEN** `CLAUDE.md`, `docs/development/pm-operating-loop.md`, and the website
+  `agents-developing/` delivery page are read
+- **THEN** they SHALL describe `status:*` as an enforced read-mirror of board Status for discovery,
+  with the claim ref + fresh board read as the dispatch/claim authority

--- a/openspec/changes/board-label-mirror/tasks.md
+++ b/openspec/changes/board-label-mirror/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — enforced board→label mirror
+
+## 1. Mirror logic in project-board-sync.yml
+- [ ] 1.1 In the `sweep` job's reconcile loop (which already reads each item's `fieldValueByName
+      (name:"Status")`), add: compute desired label from Status (Ready→`status:ready`, In Progress→
+      `status:in-progress`, In Review→`status:in-review`, Backlog/Done→none), then idempotent
+      `gh issue edit <n> --add-label <desired>` + `--remove-label` the other board-derived status
+      labels. Behind the existing "Guard token" step. (surface: sweep job)
+- [ ] 1.2 Add `issues: [edited, labeled, unlabeled, reopened]` to the `on:` triggers and a job that
+      re-asserts the single edited issue's label from its board Status (low-latency correction).
+      Reuse the same compute-desired helper as 1.1 (single source).
+- [ ] 1.3 Keep the existing duties intact: null-status→Backlog grace sweep, closed-PR→Done safety
+      net, claim reaping. The mirror is additive.
+
+## 2. Drift detector
+- [ ] 2.1 Final step of the sweep job (after the mirror pass): re-read (Status, labels) for every
+      OPEN issue; `::error::` naming each violator and exit non-zero on any label≠Status mismatch
+      (respecting the auto-add grace window to avoid flap). Exit 0 when all consistent.
+
+## 3. Rollout / reconcile current drift
+- [ ] 3.1 After merge, `workflow_dispatch` an immediate run so the mirror reconciles all open issues
+      (fixes the measured 19-issue drift: board Ready=1 vs label status:ready=20). Confirm the
+      detector passes. (Documented in the PR; the mirror pass itself performs the reconcile.)
+
+## 4. Flow skills stop writing status labels + use cheap discovery
+- [ ] 4.1 Remove every `--add-label status:*` / `--remove-label status:*` from
+      `.claude/skills/flow-{activate,implement,address,finalize}/SKILL.md`; they set board Status
+      only (the mirror follows).
+- [ ] 4.2 flow-board (and any dispatch discovery) uses `gh issue list --state open --label
+      status:ready --json number,title` for candidate discovery instead of a broad `gh issue list
+      --limit N --json …body…`.
+- [ ] 4.3 Keep the claim protocol unchanged: claim ref + fresh board read remain the authority.
+
+## 5. Doctrine (same change)
+- [ ] 5.1 `CLAUDE.md`: update the Path A / label wording — `status:*` is now an ENFORCED read-mirror
+      of board Status for discovery; claim ref + fresh board read remain the dispatch/claim
+      authority; skills no longer write labels.
+- [ ] 5.2 `docs/development/pm-operating-loop.md`: same reframing + the cheap-discovery query.
+- [ ] 5.3 Website `agents-developing/delivery-pipeline` page: same.
+
+## 6. Tests (gate of record: tooling-tests)
+- [ ] 6.1 `scripts/tests/test_board_label_mirror.sh` (stubbed gh/GraphQL, like test_worker_supervisor.sh):
+      Ready→ready set + others removed; Backlog→none; idempotent second run = no change; seeded
+      mismatch → detector exit non-zero; consistent → exit 0; missing-token → fail loud.
+- [ ] 6.2 Doctrine grep test: no flow-* skill contains `add-label status:` / `remove-label status:`.
+- [ ] 6.3 Workflow injection lint (`scripts/ci/check-workflow-injection.sh`) clean — no
+      `${{ }}`→`run:` interpolation in the new steps (pass event data via env).
+
+## 7. Gate + audit + review (endgame via flow-closer)
+- [ ] 7.1 `--lite` each round (summary-file redirect).
+- [ ] 7.2 roborev review-first on the lite-green diff (workflow-injection + logic review).
+- [ ] 7.3 flow-closer: ONE full `agent-gate.sh` → spec-auditor (C) anchored to
+      `openspec/changes/board-label-mirror/specs/**` → final roborev → merge-on-green → finalize +
+      the workflow_dispatch reconcile (task 3.1).
+
+## Notes
+- GitHub Actions + shell + docs + skills only — no Rust, no no-heuristics/memory-budget impact.
+- One-way only (Status→label); writing a label never changes Status.
+- Do NOT weaken the claim authority: label is discovery narrowing, claim ref decides.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2699,7 +2699,7 @@ run_tooling_tests() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_worker_supervisor.sh"
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh"
   if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_notify.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_smoke_target_dir.sh" >>"$log" 2>&1 &&
@@ -2707,6 +2707,7 @@ run_tooling_tests() {
      bash "$REPO_ROOT/scripts/tests/test_bootstrap_agent_machine.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_claim_lock.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_premerge_assert.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/tests/test_board_label_mirror.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_worker_supervisor.sh" >>"$log" 2>&1; then
     status=PASS
   else

--- a/scripts/ci/board-label-mirror.sh
+++ b/scripts/ci/board-label-mirror.sh
@@ -147,11 +147,13 @@ blm_board_stream() {
 # blm_item_by_node NODE_ID — emit the single board TSV row for the issue with the
 # given GraphQL node id, resolving its project item DIRECTLY (no whole-board scan)
 # via node(id){ projectItems }. Selects only the item in OUR PROJECT_ID. Emits
-# nothing (return 0) when the issue is not on our board — the caller (mirror-one)
-# treats an empty result as the "no board row" ::error:: case (F2). FAIL-CLOSED on
-# a gh/shape failure exactly like blm_board_stream.
+# nothing when the issue is not on our board — the caller (mirror-one) treats an
+# empty result as the "no board row" ::error:: case (F2). RETURNS 4 (no output)
+# when the issue exists but is CLOSED — a benign routine triage label touch on a
+# closed issue is NOT an error (issue #2855, G2). FAIL-CLOSED (return 1) on a
+# gh/shape failure exactly like blm_board_stream.
 blm_item_by_node() {
-  local node="$1" resp
+  local node="$1" resp state
   if ! resp=$(gh api graphql -f query='
     query($id: ID!) {
       node(id: $id) {
@@ -175,6 +177,13 @@ blm_item_by_node() {
   if ! printf '%s' "$resp" | jq -e '.data.node | (.==null) or has("projectItems")' >/dev/null 2>&1; then
     echo "::error::board→label mirror: unexpected GraphQL response for node '$node' — refusing to proceed (issue #2855)." >&2
     return 1
+  fi
+  # Distinguish CLOSED (benign, return 4, no row) from OPEN-off-board (empty row,
+  # caller emits the ::error::). issues:[labeled,unlabeled] fires on closed-issue
+  # triage tagging, which must not red the run (G2).
+  state=$(printf '%s' "$resp" | jq -r '.data.node.state // ""' 2>/dev/null)
+  if [ "$state" != "OPEN" ] && [ -n "$state" ]; then
+    return 4
   fi
   printf '%s' "$resp" | jq -r --arg pid "$PROJECT_ID" '
     .data.node
@@ -385,7 +394,13 @@ main() {
       # (no whole-board scan, F4). Without one (test/manual), fall back to a
       # client-side-filtered board scan.
       if [ -n "${3:-}" ]; then
-        if ! blm_item_by_node "$3" >"$bf"; then rm -f "$bf"; return 1; fi
+        blm_item_by_node "$3" >"$bf"; rc=$?
+        if [ "$rc" = 4 ]; then
+          rm -f "$bf"
+          echo "mirror-one: issue #$2 is closed — routine label touch, nothing to mirror (issue #2855)."
+          return 0
+        fi
+        if [ "$rc" != 0 ]; then rm -f "$bf"; return 1; fi
       else
         if ! blm_board_stream "$2" >"$bf"; then rm -f "$bf"; return 1; fi
       fi

--- a/scripts/ci/board-label-mirror.sh
+++ b/scripts/ci/board-label-mirror.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# scripts/ci/board-label-mirror.sh — the enforced one-way board→label mirror
+# (issue #2855). Factored OUT of .github/workflows/project-board-sync.yml so the
+# mapping + mirror + drift-detector logic is a single source that the workflow
+# CALLS and the shell test (scripts/tests/test_board_label_mirror.sh) can source
+# and drive directly with a stubbed `gh`/GraphQL layer.
+#
+# One-way projection: board Status -> status:* label. Board Status is the single
+# source of truth; the `status:*` label is a DERIVED, enforced read-mirror for
+# cheap discovery (never the claim authority — claim ref + fresh board read stay
+# authoritative; see CLAUDE.md Path A).
+#
+# Board-derived mapping (the ONLY labels the mirror owns):
+#   Ready        -> status:ready
+#   In Progress  -> status:in-progress
+#   In Review    -> status:in-review
+#   Backlog/Done -> (no status:* label)
+#
+# status:spec-review / status:addressing are transient skill-managed sub-markers
+# of In Progress and are NOT board Status options — the mirror NEVER touches them.
+#
+# Sourceable: sourcing this file only DEFINES functions (it must not change the
+# caller's shell options), so `set` lives inside main(). Executing it dispatches
+# a subcommand: mirror | mirror-one <N> | detect | desired <status> | require-token.
+
+# The board-derived labels the mirror is authoritative for. spec-review /
+# addressing are deliberately NOT in this set.
+BLM_DERIVED_LABELS="status:ready status:in-progress status:in-review"
+
+# blm_desired_label STATUS -> the status:* label the mirror sets for that board
+# Status (empty for Backlog/Done/unknown/null). Single source of the mapping.
+blm_desired_label() {
+  case "${1:-}" in
+    Ready) echo "status:ready" ;;
+    "In Progress") echo "status:in-progress" ;;
+    "In Review") echo "status:in-review" ;;
+    Backlog | Done | "") echo "" ;;
+    *) echo "" ;;
+  esac
+}
+
+# _blm_csv_has CSV NEEDLE -> 0 if NEEDLE is an element of the comma-joined CSV.
+_blm_csv_has() {
+  case ",${1}," in
+    *",${2},"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# _blm_iso_to_epoch ISO8601 -> epoch seconds (empty on parse failure). Uses jq's
+# builtin fromdateiso8601 so it is portable across GNU and BSD `date`.
+_blm_iso_to_epoch() {
+  [ -n "${1:-}" ] || { echo ""; return 0; }
+  jq -rn --arg d "$1" 'try ($d|fromdateiso8601|tostring) catch ""' 2>/dev/null
+}
+
+# blm_require_token — fail loud (::error:: + non-zero) when the project-scoped
+# PAT is absent, mirroring the workflow's existing "Guard token" posture (#2655).
+# The mirror/detector cannot read user Projects v2 without it, so a missing token
+# must FAIL the run rather than silently skip.
+blm_require_token() {
+  if [ -z "${GH_TOKEN:-}" ]; then
+    echo "::error::PROJECTS_TOKEN not set — board→label mirror is NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655/#2855) instead of silently skipping the mirror/detector."
+    return 1
+  fi
+  return 0
+}
+
+# blm_board_stream [ISSUE_NUMBER] — emit one TSV row per OPEN issue on the board:
+#   number \t status \t createdAt \t comma-joined-labels
+# Paginates the Projects v2 items (Projects v2 has no server-side field filter,
+# so an optional ISSUE_NUMBER is applied client-side). Requires PROJECT_ID in env
+# and a working `gh`.
+blm_board_stream() {
+  local want="${1:-}"
+  local cursor="" after resp has_next
+  while :; do
+    if [ -z "$cursor" ]; then after="null"; else after="\"$cursor\""; fi
+    resp=$(gh api graphql -f query="
+      query(\$p: ID!) {
+        node(id: \$p) {
+          ... on ProjectV2 {
+            items(first: 100, after: $after) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                fieldValueByName(name: \"Status\") {
+                  ... on ProjectV2ItemFieldSingleSelectValue { name }
+                }
+                content {
+                  __typename
+                  ... on Issue {
+                    number state createdAt
+                    labels(first: 50) { nodes { name } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }" -f p="$PROJECT_ID")
+
+    # Assert the response shape (a jq parse/shape failure FAILs the pipe under
+    # pipefail; a genuinely empty board still satisfies `arrays`).
+    echo "$resp" | jq -e '.data.node.items.nodes | arrays' >/dev/null
+
+    echo "$resp" | jq -r --arg want "$want" '
+      .data.node.items.nodes[]
+      | select(.content.__typename=="Issue")
+      | select(.content.state=="OPEN")
+      | select($want=="" or (.content.number|tostring)==$want)
+      | [ (.content.number|tostring),
+          (.fieldValueByName.name // ""),
+          (.content.createdAt // ""),
+          ([.content.labels.nodes[].name] | join(",")) ]
+      | @tsv'
+
+    has_next=$(echo "$resp" | jq -r '.data.node.items.pageInfo.hasNextPage')
+    cursor=$(echo "$resp" | jq -r '.data.node.items.pageInfo.endCursor')
+    [ "$has_next" = "true" ] || break
+  done
+}
+
+# blm_mirror_stream — read the board TSV on stdin and idempotently reconcile each
+# issue's board-derived label via `gh issue edit`: add the desired label if absent,
+# remove each OTHER board-derived label that is present. spec-review / addressing
+# are never in BLM_DERIVED_LABELS, so they are never touched.
+blm_mirror_stream() {
+  local n status created labels desired lbl
+  while IFS=$'\t' read -r n status created labels; do
+    [ -n "$n" ] || continue
+    desired=$(blm_desired_label "$status")
+    if [ -n "$desired" ] && ! _blm_csv_has "$labels" "$desired"; then
+      gh issue edit "$n" --add-label "$desired" >/dev/null
+      echo "mirror: #$n Status='$status' +$desired"
+    fi
+    for lbl in $BLM_DERIVED_LABELS; do
+      [ "$lbl" = "$desired" ] && continue
+      if _blm_csv_has "$labels" "$lbl"; then
+        gh issue edit "$n" --remove-label "$lbl" >/dev/null
+        echo "mirror: #$n Status='$status' -$lbl"
+      fi
+    done
+  done
+}
+
+# blm_detect_stream — read the board TSV on stdin and FAIL (exit 1 + ::error::) on
+# any board-derived-label ≠ Status disagreement. Issues younger than the grace
+# window (BLM_GRACE_SECS, default 600s) are skipped to avoid flapping on the
+# auto-add / mirror-settle race the sweep already tolerates. spec-review /
+# addressing are not board-derived and are ignored. Exit 0 when all consistent.
+blm_detect_stream() {
+  local grace cutoff now n status created labels desired lbl bad=0 cepoch
+  grace="${BLM_GRACE_SECS:-600}"
+  now=$(date -u +%s)
+  cutoff=$((now - grace))
+  while IFS=$'\t' read -r n status created labels; do
+    [ -n "$n" ] || continue
+    if [ -n "$created" ]; then
+      cepoch=$(_blm_iso_to_epoch "$created")
+      if [ -n "$cepoch" ] && [ "$cepoch" -gt "$cutoff" ]; then
+        continue
+      fi
+    fi
+    desired=$(blm_desired_label "$status")
+    if [ -n "$desired" ] && ! _blm_csv_has "$labels" "$desired"; then
+      echo "::error::issue #$n: board Status='$status' but label '$desired' is missing (labels: ${labels:-none})"
+      bad=$((bad + 1))
+    fi
+    for lbl in $BLM_DERIVED_LABELS; do
+      [ "$lbl" = "$desired" ] && continue
+      if _blm_csv_has "$labels" "$lbl"; then
+        echo "::error::issue #$n: board Status='$status' but carries stale board-derived label '$lbl'"
+        bad=$((bad + 1))
+      fi
+    done
+  done
+  if [ "$bad" -gt 0 ]; then
+    echo "drift-detector: $bad label/Status violation(s) — see ::error:: annotations above"
+    return 1
+  fi
+  echo "drift-detector: all open issues' board-derived labels match board Status"
+  return 0
+}
+
+main() {
+  set -uo pipefail
+  local cmd="${1:-}"
+  case "$cmd" in
+    desired)
+      blm_desired_label "${2:-}"
+      ;;
+    require-token)
+      blm_require_token
+      ;;
+    mirror)
+      blm_require_token || return 1
+      blm_board_stream | blm_mirror_stream
+      ;;
+    mirror-one)
+      blm_require_token || return 1
+      [ -n "${2:-}" ] || { echo "::error::mirror-one needs an issue number" >&2; return 2; }
+      blm_board_stream "$2" | blm_mirror_stream
+      ;;
+    detect)
+      blm_require_token || return 1
+      blm_detect_stream < <(blm_board_stream)
+      ;;
+    *)
+      echo "usage: board-label-mirror.sh {mirror|mirror-one <N>|detect|desired <status>|require-token}" >&2
+      return 2
+      ;;
+  esac
+}
+
+# Sourceable guard: sourcing only defines functions; executing dispatches main.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/scripts/ci/board-label-mirror.sh
+++ b/scripts/ci/board-label-mirror.sh
@@ -245,29 +245,47 @@ blm_mirror_stream() {
   return "$rc"
 }
 
-# _blm_row_bad N STATUS LABELS [emit] -> return 0 if the row is consistent, 1 if
-# drifted (or the Status is unknown). When the 4th arg is "emit", print an
-# ::error:: annotation for each disagreement. Shared by the first-pass scan and
-# the self-heal re-check so both apply the identical rule.
-_blm_row_bad() {
-  local n="$1" status="$2" labels="$3" emit="${4:-}" desired dstat lbl bad=0
+# _blm_row_ok N STATUS LABELS -> PURE predicate: return 0 if the row is CONSISTENT
+# (board-derived label matches board Status), 1 if it drifted or the Status is
+# unknown. Emits NOTHING (annotation is split into _blm_row_annotate). Shared by
+# the first-pass scan and the self-heal re-check so both apply the identical rule.
+_blm_row_ok() {
+  local n="$1" status="$2" labels="$3" desired dstat lbl
   desired=$(blm_desired_label "$status"); dstat=$?
-  if [ "$dstat" -ne 0 ]; then
-    [ "$emit" = emit ] && echo "::error::issue #$n: unknown board Status '$status' — mapping not updated (issue #2855)"
-    return 1
-  fi
+  [ "$dstat" -ne 0 ] && return 1
   if [ -n "$desired" ] && ! _blm_csv_has "$labels" "$desired"; then
-    [ "$emit" = emit ] && echo "::error::issue #$n: board Status='$status' but label '$desired' is missing (labels: ${labels:-none})"
-    bad=1
+    return 1
   fi
   for lbl in $BLM_DERIVED_LABELS; do
     [ "$lbl" = "$desired" ] && continue
     if _blm_csv_has "$labels" "$lbl"; then
-      [ "$emit" = emit ] && echo "::error::issue #$n: board Status='$status' but carries stale board-derived label '$lbl'"
-      bad=1
+      return 1
     fi
   done
-  return "$bad"
+  return 0
+}
+
+# _blm_row_annotate N STATUS LABELS -> print an ::error:: annotation for each
+# board-derived-label ≠ Status disagreement on the row (the emission half, split
+# out of the predicate for G6). Always returns 0; callers use _blm_row_ok for the
+# verdict and this only to describe an already-known drift.
+_blm_row_annotate() {
+  local n="$1" status="$2" labels="$3" desired dstat lbl
+  desired=$(blm_desired_label "$status"); dstat=$?
+  if [ "$dstat" -ne 0 ]; then
+    echo "::error::issue #$n: unknown board Status '$status' — mapping not updated (issue #2855)"
+    return 0
+  fi
+  if [ -n "$desired" ] && ! _blm_csv_has "$labels" "$desired"; then
+    echo "::error::issue #$n: board Status='$status' but label '$desired' is missing (labels: ${labels:-none})"
+  fi
+  for lbl in $BLM_DERIVED_LABELS; do
+    [ "$lbl" = "$desired" ] && continue
+    if _blm_csv_has "$labels" "$lbl"; then
+      echo "::error::issue #$n: board Status='$status' but carries stale board-derived label '$lbl'"
+    fi
+  done
+  return 0
 }
 
 # _blm_offboard_check BOARD_FILE -> FAIL (return 1 + ::error::) when an OPEN issue
@@ -336,7 +354,7 @@ blm_detect_stream() {
       fi
     fi
     # First-pass: consistent -> nothing to do.
-    if _blm_row_bad "$n" "$status" "$labels"; then
+    if _blm_row_ok "$n" "$status" "$labels"; then
       continue
     fi
     # Candidate violation: self-heal by re-reading this one issue fresh. Only a
@@ -351,11 +369,13 @@ blm_detect_stream() {
       # board-vs-label drift; the off-board check below covers a lingering label.
       continue
     fi
-    # fresh is a single TSV row; re-check with emit so the annotation reflects the
-    # authoritative current state.
+    # fresh is a single TSV row; re-check the authoritative current state. A
+    # PERSISTENT drift is annotated (emission split from the predicate, G6) and
+    # counted; a raced Status flip that now agrees resolves silently.
     local fn fstatus fcreated flabels
     IFS=$'\t' read -r fn fstatus fcreated flabels <<<"$fresh"
-    if ! _blm_row_bad "$fn" "$fstatus" "$flabels" emit; then
+    if ! _blm_row_ok "$fn" "$fstatus" "$flabels"; then
+      _blm_row_annotate "$fn" "$fstatus" "$flabels"
       bad=$((bad + 1))
     fi
   done 3<"$board_file"

--- a/scripts/ci/board-label-mirror.sh
+++ b/scripts/ci/board-label-mirror.sh
@@ -19,24 +19,37 @@
 # status:spec-review / status:addressing are transient skill-managed sub-markers
 # of In Progress and are NOT board Status options — the mirror NEVER touches them.
 #
+# FAIL-CLOSED (issue #2855): a failed `gh api graphql` (expired/unscoped PAT,
+# outage, wrong PROJECT_ID) or an unexpected response shape or an unknown board
+# Status must FAIL the run, never degrade to a silent-green "all consistent" with
+# zero rows — the exact outage class this mirror exists to catch. Every fail-close
+# path is CHECKED explicitly (this script deliberately does NOT rely on `set -e`;
+# process substitution masks a producer's exit status, so streams are materialized
+# to temp files with a checked status instead).
+#
 # Sourceable: sourcing this file only DEFINES functions (it must not change the
 # caller's shell options), so `set` lives inside main(). Executing it dispatches
-# a subcommand: mirror | mirror-one <N> | detect | desired <status> | require-token.
+# a subcommand: mirror | mirror-one <N> [NODE_ID] | detect | desired <status> |
+# require-token.
 
 # The board-derived labels the mirror is authoritative for. spec-review /
 # addressing are deliberately NOT in this set.
 BLM_DERIVED_LABELS="status:ready status:in-progress status:in-review"
 
-# blm_desired_label STATUS -> the status:* label the mirror sets for that board
-# Status (empty for Backlog/Done/unknown/null). Single source of the mapping.
+# blm_desired_label STATUS -> echoes the status:* label the mirror sets for that
+# board Status (empty for the KNOWN no-label statuses Backlog/Done/null). Returns
+# non-zero (3) for an UNKNOWN non-empty Status so callers fail closed instead of
+# defaulting an unrecognized/renamed board Status to "strip all labels" (F6). This
+# is the single source of the mapping.
 blm_desired_label() {
   case "${1:-}" in
     Ready) echo "status:ready" ;;
     "In Progress") echo "status:in-progress" ;;
     "In Review") echo "status:in-review" ;;
     Backlog | Done | "") echo "" ;;
-    *) echo "" ;;
+    *) echo ""; return 3 ;;
   esac
+  return 0
 }
 
 # _blm_csv_has CSV NEEDLE -> 0 if NEEDLE is an element of the comma-joined CSV.
@@ -71,12 +84,17 @@ blm_require_token() {
 # Paginates the Projects v2 items (Projects v2 has no server-side field filter,
 # so an optional ISSUE_NUMBER is applied client-side). Requires PROJECT_ID in env
 # and a working `gh`.
+#
+# FAIL-CLOSED: `gh api graphql`'s exit status is captured explicitly and a
+# non-zero read RETURNS 1; an unexpected response shape (no .data.node.items.nodes
+# array) prints ::error:: and RETURNS 1. Neither degrades to zero rows. ::error::
+# goes to stderr so it never pollutes the TSV a caller materializes.
 blm_board_stream() {
   local want="${1:-}"
   local cursor="" after resp has_next
   while :; do
     if [ -z "$cursor" ]; then after="null"; else after="\"$cursor\""; fi
-    resp=$(gh api graphql -f query="
+    if ! resp=$(gh api graphql -f query="
       query(\$p: ID!) {
         node(id: \$p) {
           ... on ProjectV2 {
@@ -97,13 +115,19 @@ blm_board_stream() {
             }
           }
         }
-      }" -f p="$PROJECT_ID")
+      }" -f p="$PROJECT_ID"); then
+      echo "::error::board→label mirror: 'gh api graphql' failed (token scope / PROJECT_ID / API outage). Refusing to proceed on a partial or empty board read (issue #2855)." >&2
+      return 1
+    fi
 
-    # Assert the response shape (a jq parse/shape failure FAILs the pipe under
-    # pipefail; a genuinely empty board still satisfies `arrays`).
-    echo "$resp" | jq -e '.data.node.items.nodes | arrays' >/dev/null
+    # Assert the response shape. A genuinely empty board still satisfies `arrays`;
+    # error JSON ({"errors":[…]}) or any malformed body FAILs closed here.
+    if ! printf '%s' "$resp" | jq -e '.data.node.items.nodes | arrays' >/dev/null 2>&1; then
+      echo "::error::board→label mirror: unexpected GraphQL response (no .data.node.items.nodes array — auth error / wrong PROJECT_ID?). Refusing to proceed (issue #2855)." >&2
+      return 1
+    fi
 
-    echo "$resp" | jq -r --arg want "$want" '
+    printf '%s' "$resp" | jq -r --arg want "$want" '
       .data.node.items.nodes[]
       | select(.content.__typename=="Issue")
       | select(.content.state=="OPEN")
@@ -112,44 +136,164 @@ blm_board_stream() {
           (.fieldValueByName.name // ""),
           (.content.createdAt // ""),
           ([.content.labels.nodes[].name] | join(",")) ]
-      | @tsv'
+      | @tsv' || return 1
 
-    has_next=$(echo "$resp" | jq -r '.data.node.items.pageInfo.hasNextPage')
-    cursor=$(echo "$resp" | jq -r '.data.node.items.pageInfo.endCursor')
+    has_next=$(printf '%s' "$resp" | jq -r '.data.node.items.pageInfo.hasNextPage')
+    cursor=$(printf '%s' "$resp" | jq -r '.data.node.items.pageInfo.endCursor')
     [ "$has_next" = "true" ] || break
   done
+}
+
+# blm_item_by_node NODE_ID — emit the single board TSV row for the issue with the
+# given GraphQL node id, resolving its project item DIRECTLY (no whole-board scan)
+# via node(id){ projectItems }. Selects only the item in OUR PROJECT_ID. Emits
+# nothing (return 0) when the issue is not on our board — the caller (mirror-one)
+# treats an empty result as the "no board row" ::error:: case (F2). FAIL-CLOSED on
+# a gh/shape failure exactly like blm_board_stream.
+blm_item_by_node() {
+  local node="$1" resp
+  if ! resp=$(gh api graphql -f query='
+    query($id: ID!) {
+      node(id: $id) {
+        ... on Issue {
+          number state createdAt
+          labels(first: 50) { nodes { name } }
+          projectItems(first: 20) {
+            nodes {
+              project { id }
+              fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+            }
+          }
+        }
+      }
+    }' -f id="$node"); then
+    echo "::error::board→label mirror: 'gh api graphql' (node lookup) failed for node '$node' — refusing to proceed (issue #2855)." >&2
+    return 1
+  fi
+  if ! printf '%s' "$resp" | jq -e '.data.node | (.==null) or has("projectItems")' >/dev/null 2>&1; then
+    echo "::error::board→label mirror: unexpected GraphQL response for node '$node' — refusing to proceed (issue #2855)." >&2
+    return 1
+  fi
+  printf '%s' "$resp" | jq -r --arg pid "$PROJECT_ID" '
+    .data.node
+    | select(. != null)
+    | select(.state=="OPEN")
+    | . as $iss
+    | ( [ .projectItems.nodes[] | select(.project.id==$pid) ] | first ) as $item
+    | select($item != null)
+    | [ ($iss.number|tostring),
+        ($item.fieldValueByName.name // ""),
+        ($iss.createdAt // ""),
+        ([$iss.labels.nodes[].name] | join(",")) ]
+    | @tsv' || return 1
 }
 
 # blm_mirror_stream — read the board TSV on stdin and idempotently reconcile each
 # issue's board-derived label via `gh issue edit`: add the desired label if absent,
 # remove each OTHER board-derived label that is present. spec-review / addressing
 # are never in BLM_DERIVED_LABELS, so they are never touched.
+#
+# FAIL-CLOSED: an UNKNOWN board Status never strips labels — it emits ::error:: and
+# fails (F6). A failed `gh issue edit` emits ::error:: and fails rather than logging
+# a success that never happened (F7). Returns non-zero if any row failed.
 blm_mirror_stream() {
-  local n status created labels desired lbl
+  local n status created labels desired dstat lbl rc=0
   while IFS=$'\t' read -r n status created labels; do
     [ -n "$n" ] || continue
-    desired=$(blm_desired_label "$status")
+    desired=$(blm_desired_label "$status"); dstat=$?
+    if [ "$dstat" -ne 0 ]; then
+      echo "::error::issue #$n: unknown board Status '$status' — mapping not updated. Refusing to strip labels (issue #2855). Update blm_desired_label if the board schema changed."
+      rc=1
+      continue
+    fi
     if [ -n "$desired" ] && ! _blm_csv_has "$labels" "$desired"; then
-      gh issue edit "$n" --add-label "$desired" >/dev/null
-      echo "mirror: #$n Status='$status' +$desired"
+      if gh issue edit "$n" --add-label "$desired" >/dev/null; then
+        echo "mirror: #$n Status='$status' +$desired"
+      else
+        echo "::error::issue #$n: failed to add label '$desired' (gh issue edit)"
+        rc=1
+      fi
     fi
     for lbl in $BLM_DERIVED_LABELS; do
       [ "$lbl" = "$desired" ] && continue
       if _blm_csv_has "$labels" "$lbl"; then
-        gh issue edit "$n" --remove-label "$lbl" >/dev/null
-        echo "mirror: #$n Status='$status' -$lbl"
+        if gh issue edit "$n" --remove-label "$lbl" >/dev/null; then
+          echo "mirror: #$n Status='$status' -$lbl"
+        else
+          echo "::error::issue #$n: failed to remove stale label '$lbl' (gh issue edit)"
+          rc=1
+        fi
       fi
     done
   done
+  return "$rc"
 }
 
-# blm_detect_stream — read the board TSV on stdin and FAIL (exit 1 + ::error::) on
-# any board-derived-label ≠ Status disagreement. Issues younger than the grace
-# window (BLM_GRACE_SECS, default 600s) are skipped to avoid flapping on the
-# auto-add / mirror-settle race the sweep already tolerates. spec-review /
-# addressing are not board-derived and are ignored. Exit 0 when all consistent.
+# _blm_row_bad N STATUS LABELS [emit] -> return 0 if the row is consistent, 1 if
+# drifted (or the Status is unknown). When the 4th arg is "emit", print an
+# ::error:: annotation for each disagreement. Shared by the first-pass scan and
+# the self-heal re-check so both apply the identical rule.
+_blm_row_bad() {
+  local n="$1" status="$2" labels="$3" emit="${4:-}" desired dstat lbl bad=0
+  desired=$(blm_desired_label "$status"); dstat=$?
+  if [ "$dstat" -ne 0 ]; then
+    [ "$emit" = emit ] && echo "::error::issue #$n: unknown board Status '$status' — mapping not updated (issue #2855)"
+    return 1
+  fi
+  if [ -n "$desired" ] && ! _blm_csv_has "$labels" "$desired"; then
+    [ "$emit" = emit ] && echo "::error::issue #$n: board Status='$status' but label '$desired' is missing (labels: ${labels:-none})"
+    bad=1
+  fi
+  for lbl in $BLM_DERIVED_LABELS; do
+    [ "$lbl" = "$desired" ] && continue
+    if _blm_csv_has "$labels" "$lbl"; then
+      [ "$emit" = emit ] && echo "::error::issue #$n: board Status='$status' but carries stale board-derived label '$lbl'"
+      bad=1
+    fi
+  done
+  return "$bad"
+}
+
+# _blm_offboard_check BOARD_FILE -> FAIL (return 1 + ::error::) when an OPEN issue
+# carries a board-derived label but has NO item on the board (F2). Such an issue
+# (a documented auto-add miss — flow-groom step 5) keeps its creation-time
+# status:* label forever and the board-only detector never sees it → stale label =
+# wrong-grab hazard. Enumerated per label via `gh issue list`; a gh failure here
+# FAILs closed (never a silent "no offenders").
+_blm_offboard_check() {
+  local board_file="$1" lbl listed num rc=0
+  for lbl in $BLM_DERIVED_LABELS; do
+    if ! listed=$(gh issue list --state open --label "$lbl" --json number --jq '.[].number'); then
+      echo "::error::board→label mirror: 'gh issue list --label $lbl' failed — refusing to proceed on a partial off-board scan (issue #2855)."
+      rc=1
+      continue
+    fi
+    while IFS= read -r num; do
+      [ -n "$num" ] || continue
+      if ! awk -F'\t' -v n="$num" '$1==n{found=1} END{exit found?0:1}' "$board_file"; then
+        echo "::error::issue #$num carries board-derived label '$lbl' but is NOT on the project board (auto-add miss?) — stale label = wrong-grab hazard. Add it to the board or strip the label (issue #2855)."
+        rc=1
+      fi
+    done <<<"$listed"
+  done
+  return "$rc"
+}
+
+# blm_detect_stream BOARD_FILE — read the materialized board TSV FILE and FAIL
+# (exit 1 + ::error::) on any board-derived-label ≠ Status disagreement. Issues
+# younger than the grace window (BLM_GRACE_SECS, default 600s) are skipped to avoid
+# flapping on the auto-add / mirror-settle race the sweep already tolerates.
+#
+# SELF-HEALING (F5): a first-pass violation on an OLDER issue is RE-READ fresh
+# (its single row re-fetched from the board) and only counted if the disagreement
+# PERSISTS — a Status flip that races between the mirror and this detect step (a
+# worker claim, or mirror-one racing the sweep) no longer reds the run. Then also
+# runs the off-board check (F2). Exit 0 only when everything is consistent.
 blm_detect_stream() {
-  local grace cutoff now n status created labels desired lbl bad=0 cepoch
+  local board_file="$1"
+  local grace cutoff now n status created labels bad=0 cepoch fresh
   grace="${BLM_GRACE_SECS:-600}"
   now=$(date -u +%s)
   cutoff=$((now - grace))
@@ -161,19 +305,35 @@ blm_detect_stream() {
         continue
       fi
     fi
-    desired=$(blm_desired_label "$status")
-    if [ -n "$desired" ] && ! _blm_csv_has "$labels" "$desired"; then
-      echo "::error::issue #$n: board Status='$status' but label '$desired' is missing (labels: ${labels:-none})"
+    # First-pass: consistent -> nothing to do.
+    if _blm_row_bad "$n" "$status" "$labels"; then
+      continue
+    fi
+    # Candidate violation: self-heal by re-reading this one issue fresh. Only a
+    # PERSISTENT disagreement is a real drift; a raced Status flip resolves here.
+    if ! fresh=$(blm_board_stream "$n"); then
+      echo "::error::issue #$n: drift-detector re-read (self-heal) failed — refusing to declare consistent (issue #2855)"
+      bad=$((bad + 1))
+      continue
+    fi
+    if [ -z "$fresh" ]; then
+      # Vanished from the board between passes (closed/removed) — no longer a
+      # board-vs-label drift; the off-board check below covers a lingering label.
+      continue
+    fi
+    # fresh is a single TSV row; re-check with emit so the annotation reflects the
+    # authoritative current state.
+    local fn fstatus fcreated flabels
+    IFS=$'\t' read -r fn fstatus fcreated flabels <<<"$fresh"
+    if ! _blm_row_bad "$fn" "$fstatus" "$flabels" emit; then
       bad=$((bad + 1))
     fi
-    for lbl in $BLM_DERIVED_LABELS; do
-      [ "$lbl" = "$desired" ] && continue
-      if _blm_csv_has "$labels" "$lbl"; then
-        echo "::error::issue #$n: board Status='$status' but carries stale board-derived label '$lbl'"
-        bad=$((bad + 1))
-      fi
-    done
-  done
+  done <"$board_file"
+
+  if ! _blm_offboard_check "$board_file"; then
+    bad=$((bad + 1))
+  fi
+
   if [ "$bad" -gt 0 ]; then
     echo "drift-detector: $bad label/Status violation(s) — see ::error:: annotations above"
     return 1
@@ -185,6 +345,7 @@ blm_detect_stream() {
 main() {
   set -uo pipefail
   local cmd="${1:-}"
+  local bf rc
   case "$cmd" in
     desired)
       blm_desired_label "${2:-}"
@@ -194,19 +355,46 @@ main() {
       ;;
     mirror)
       blm_require_token || return 1
-      blm_board_stream | blm_mirror_stream
+      # Materialize with a CHECKED status: process substitution / a bare pipe
+      # would mask blm_board_stream's exit status, re-opening the silent-green
+      # hole (issue #2855). A failed read never reaches the mirror.
+      bf=$(mktemp) || return 1
+      if ! blm_board_stream >"$bf"; then rm -f "$bf"; return 1; fi
+      blm_mirror_stream <"$bf"; rc=$?
+      rm -f "$bf"
+      return "$rc"
       ;;
     mirror-one)
       blm_require_token || return 1
       [ -n "${2:-}" ] || { echo "::error::mirror-one needs an issue number" >&2; return 2; }
-      blm_board_stream "$2" | blm_mirror_stream
+      bf=$(mktemp) || return 1
+      # With a node id (workflow path), resolve the issue's project item directly
+      # (no whole-board scan, F4). Without one (test/manual), fall back to a
+      # client-side-filtered board scan.
+      if [ -n "${3:-}" ]; then
+        if ! blm_item_by_node "$3" >"$bf"; then rm -f "$bf"; return 1; fi
+      else
+        if ! blm_board_stream "$2" >"$bf"; then rm -f "$bf"; return 1; fi
+      fi
+      if [ ! -s "$bf" ]; then
+        rm -f "$bf"
+        echo "::error::mirror-one: issue #$2 produced no board row — it is not on the project board (auto-add miss?) or is closed. Not silently no-op'ing (issue #2855)."
+        return 1
+      fi
+      blm_mirror_stream <"$bf"; rc=$?
+      rm -f "$bf"
+      return "$rc"
       ;;
     detect)
       blm_require_token || return 1
-      blm_detect_stream < <(blm_board_stream)
+      bf=$(mktemp) || return 1
+      if ! blm_board_stream >"$bf"; then rm -f "$bf"; return 1; fi
+      blm_detect_stream "$bf"; rc=$?
+      rm -f "$bf"
+      return "$rc"
       ;;
     *)
-      echo "usage: board-label-mirror.sh {mirror|mirror-one <N>|detect|desired <status>|require-token}" >&2
+      echo "usage: board-label-mirror.sh {mirror|mirror-one <N> [NODE_ID]|detect|desired <status>|require-token}" >&2
       return 2
       ;;
   esac

--- a/scripts/ci/board-label-mirror.sh
+++ b/scripts/ci/board-label-mirror.sh
@@ -199,6 +199,28 @@ blm_item_by_node() {
     | @tsv' || return 1
 }
 
+# blm_offboard_derived_label ISSUE_NUMBER — echo the first board-derived label
+# (status:ready/in-progress/in-review) the OPEN off-board issue currently carries,
+# empty if none. Enumerated via `gh issue list --label` per derived label — the same
+# mechanism _blm_offboard_check uses (the workflow PAT can read it). Lets mirror-one
+# tell a STALE derived label on an off-board issue (needs correction -> ::error::)
+# from a benign non-status label touch on an auto-add-missed issue (nothing to
+# mirror -> ::notice::) — issue #2855, M1. A gh failure RETURNS 1 (fail-closed) so a
+# transient list failure is never mistaken for "no derived label" -> silent exit 0.
+blm_offboard_derived_label() {
+  local want="$1" lbl listed num
+  for lbl in $BLM_DERIVED_LABELS; do
+    if ! listed=$(gh issue list --state open --label "$lbl" --json number --jq '.[].number'); then
+      return 1
+    fi
+    while IFS= read -r num; do
+      [ "$num" = "$want" ] && { echo "$lbl"; return 0; }
+    done <<<"$listed"
+  done
+  echo ""
+  return 0
+}
+
 # blm_mirror_stream BOARD_FILE — read the board TSV FILE and idempotently reconcile
 # each issue's board-derived label via `gh issue edit`: add the desired label if
 # absent, remove each OTHER board-derived label that is present. spec-review /
@@ -434,8 +456,22 @@ main() {
       fi
       if [ ! -s "$bf" ]; then
         rm -f "$bf"
-        echo "::error::mirror-one: issue #$2 produced no board row — it is not on the project board (auto-add miss?) or is closed. Not silently no-op'ing (issue #2855)."
-        return 1
+        # Off-board OPEN issue. Only ::error:: (red the run) when it carries a STALE
+        # board-derived status:* label that needs correcting; a benign non-status
+        # label touch (P2/needs-decision/flow-meta) on an auto-add-missed issue with
+        # NO derived label is a ::notice:: + exit 0, not a red run (issue #2855, M1).
+        local off_lbl off_rc
+        off_lbl=$(blm_offboard_derived_label "$2"); off_rc=$?
+        if [ "$off_rc" -ne 0 ]; then
+          echo "::error::mirror-one: issue #$2 is off-board and 'gh issue list' failed while checking for a stale board-derived label — refusing to declare benign (issue #2855)."
+          return 1
+        fi
+        if [ -n "$off_lbl" ]; then
+          echo "::error::mirror-one: issue #$2 carries stale board-derived label '$off_lbl' but is NOT on the project board (auto-add miss?) — stale label = wrong-grab hazard. Add it to the board or strip the label (issue #2855)."
+          return 1
+        fi
+        echo "::notice::mirror-one: issue #$2 is not on the project board and carries no board-derived status label — benign label touch, nothing to mirror (issue #2855)."
+        return 0
       fi
       blm_mirror_stream "$bf"; rc=$?
       rm -f "$bf"

--- a/scripts/ci/board-label-mirror.sh
+++ b/scripts/ci/board-label-mirror.sh
@@ -67,13 +67,14 @@ _blm_iso_to_epoch() {
   jq -rn --arg d "$1" 'try ($d|fromdateiso8601|tostring) catch ""' 2>/dev/null
 }
 
-# blm_require_token — fail loud (::error:: + non-zero) when the project-scoped
-# PAT is absent, mirroring the workflow's existing "Guard token" posture (#2655).
-# The mirror/detector cannot read user Projects v2 without it, so a missing token
+# blm_require_token — fail loud (::error:: + non-zero) when the PAT is absent,
+# mirroring the workflow's existing "Guard token" posture (#2655). The mirror needs
+# BOTH `project` scope (read Projects v2 Status) AND repo `issues` read/write (edit
+# labels via `gh issue edit`, enumerate via `gh issue list`), so a missing token
 # must FAIL the run rather than silently skip.
 blm_require_token() {
   if [ -z "${GH_TOKEN:-}" ]; then
-    echo "::error::PROJECTS_TOKEN not set — board→label mirror is NOT running. Add a PAT (or GitHub App token) with 'project' scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655/#2855) instead of silently skipping the mirror/detector."
+    echo "::error::PROJECTS_TOKEN not set — board→label mirror is NOT running. Add a PAT (or GitHub App token) with 'project' (Projects v2 read/write) AND repo 'issues' read/write scope as repo secret PROJECTS_TOKEN. Failing loudly (issue #2655/#2855) instead of silently skipping the mirror/detector."
     return 1
   fi
   return 0

--- a/scripts/ci/board-label-mirror.sh
+++ b/scripts/ci/board-label-mirror.sh
@@ -263,16 +263,29 @@ _blm_row_bad() {
 # wrong-grab hazard. Enumerated per label via `gh issue list`; a gh failure here
 # FAILs closed (never a silent "no offenders").
 _blm_offboard_check() {
-  local board_file="$1" lbl listed num rc=0
+  local board_file="$1" lbl listed num rc=0 limit count
+  # Bound the per-label list explicitly: `gh issue list` defaults to 30 and would
+  # SILENTLY truncate a larger set (there can be >30 status:ready in a burst),
+  # re-opening the silent-green-partial-read hole (issue #2855). Ask for a large
+  # cap and, if the returned count HITS that cap, fail closed — a full page means
+  # the list may be truncated and the off-board scan cannot be trusted.
+  # BLM_OFFBOARD_LIMIT overridable only for the test's non-truncation assertion.
+  limit="${BLM_OFFBOARD_LIMIT:-1000}"
   for lbl in $BLM_DERIVED_LABELS; do
-    if ! listed=$(gh issue list --state open --label "$lbl" --json number --jq '.[].number'); then
+    if ! listed=$(gh issue list --state open --label "$lbl" --limit "$limit" --json number --jq '.[].number'); then
       echo "::error::board→label mirror: 'gh issue list --label $lbl' failed — refusing to proceed on a partial off-board scan (issue #2855)."
+      rc=1
+      continue
+    fi
+    count=$(printf '%s\n' "$listed" | grep -c '[0-9]' || true)
+    if [ "$count" -ge "$limit" ]; then
+      echo "::error::board→label mirror: 'gh issue list --label $lbl' returned $count issue(s) == --limit ($limit) — the off-board scan may be truncated. Refusing to proceed on a possibly-partial list (issue #2855)."
       rc=1
       continue
     fi
     while IFS= read -r num; do
       [ -n "$num" ] || continue
-      if ! awk -F'\t' -v n="$num" '$1==n{found=1} END{exit found?0:1}' "$board_file"; then
+      if ! awk -F'\t' -v n="$num" '$1==n{found=1} END{exit found?0:1}' "$board_file" </dev/null; then
         echo "::error::issue #$num carries board-derived label '$lbl' but is NOT on the project board (auto-add miss?) — stale label = wrong-grab hazard. Add it to the board or strip the label (issue #2855)."
         rc=1
       fi

--- a/scripts/ci/board-label-mirror.sh
+++ b/scripts/ci/board-label-mirror.sh
@@ -199,17 +199,22 @@ blm_item_by_node() {
     | @tsv' || return 1
 }
 
-# blm_mirror_stream — read the board TSV on stdin and idempotently reconcile each
-# issue's board-derived label via `gh issue edit`: add the desired label if absent,
-# remove each OTHER board-derived label that is present. spec-review / addressing
-# are never in BLM_DERIVED_LABELS, so they are never touched.
+# blm_mirror_stream BOARD_FILE — read the board TSV FILE and idempotently reconcile
+# each issue's board-derived label via `gh issue edit`: add the desired label if
+# absent, remove each OTHER board-derived label that is present. spec-review /
+# addressing are never in BLM_DERIVED_LABELS, so they are never touched.
+#
+# The board rows are read on a DEDICATED fd (3) so the `gh issue edit` children
+# inside the loop can never consume board rows off the loop's stdin and silently
+# skip issues (issue #2855, G4); each child's own stdin is also closed (</dev/null).
 #
 # FAIL-CLOSED: an UNKNOWN board Status never strips labels — it emits ::error:: and
 # fails (F6). A failed `gh issue edit` emits ::error:: and fails rather than logging
 # a success that never happened (F7). Returns non-zero if any row failed.
 blm_mirror_stream() {
+  local board_file="$1"
   local n status created labels desired dstat lbl rc=0
-  while IFS=$'\t' read -r n status created labels; do
+  while IFS=$'\t' read -r -u 3 n status created labels; do
     [ -n "$n" ] || continue
     desired=$(blm_desired_label "$status"); dstat=$?
     if [ "$dstat" -ne 0 ]; then
@@ -218,7 +223,7 @@ blm_mirror_stream() {
       continue
     fi
     if [ -n "$desired" ] && ! _blm_csv_has "$labels" "$desired"; then
-      if gh issue edit "$n" --add-label "$desired" >/dev/null; then
+      if gh issue edit "$n" --add-label "$desired" >/dev/null </dev/null; then
         echo "mirror: #$n Status='$status' +$desired"
       else
         echo "::error::issue #$n: failed to add label '$desired' (gh issue edit)"
@@ -228,7 +233,7 @@ blm_mirror_stream() {
     for lbl in $BLM_DERIVED_LABELS; do
       [ "$lbl" = "$desired" ] && continue
       if _blm_csv_has "$labels" "$lbl"; then
-        if gh issue edit "$n" --remove-label "$lbl" >/dev/null; then
+        if gh issue edit "$n" --remove-label "$lbl" >/dev/null </dev/null; then
           echo "mirror: #$n Status='$status' -$lbl"
         else
           echo "::error::issue #$n: failed to remove stale label '$lbl' (gh issue edit)"
@@ -236,7 +241,7 @@ blm_mirror_stream() {
         fi
       fi
     done
-  done
+  done 3<"$board_file"
   return "$rc"
 }
 
@@ -319,7 +324,10 @@ blm_detect_stream() {
   grace="${BLM_GRACE_SECS:-600}"
   now=$(date -u +%s)
   cutoff=$((now - grace))
-  while IFS=$'\t' read -r n status created labels; do
+  # Read board rows on a DEDICATED fd (3): the self-heal re-read (blm_board_stream)
+  # runs a `gh` child inside this loop, which would otherwise consume board rows
+  # off the loop's stdin and silently skip issues (issue #2855, G4).
+  while IFS=$'\t' read -r -u 3 n status created labels; do
     [ -n "$n" ] || continue
     if [ -n "$created" ]; then
       cepoch=$(_blm_iso_to_epoch "$created")
@@ -350,7 +358,7 @@ blm_detect_stream() {
     if ! _blm_row_bad "$fn" "$fstatus" "$flabels" emit; then
       bad=$((bad + 1))
     fi
-  done <"$board_file"
+  done 3<"$board_file"
 
   if ! _blm_offboard_check "$board_file"; then
     bad=$((bad + 1))
@@ -382,7 +390,7 @@ main() {
       # hole (issue #2855). A failed read never reaches the mirror.
       bf=$(mktemp) || return 1
       if ! blm_board_stream >"$bf"; then rm -f "$bf"; return 1; fi
-      blm_mirror_stream <"$bf"; rc=$?
+      blm_mirror_stream "$bf"; rc=$?
       rm -f "$bf"
       return "$rc"
       ;;
@@ -409,7 +417,7 @@ main() {
         echo "::error::mirror-one: issue #$2 produced no board row — it is not on the project board (auto-add miss?) or is closed. Not silently no-op'ing (issue #2855)."
         return 1
       fi
-      blm_mirror_stream <"$bf"; rc=$?
+      blm_mirror_stream "$bf"; rc=$?
       rm -f "$bf"
       return "$rc"
       ;;

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -508,16 +508,37 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 17. F2 (mirror-one): a #N that is NOT on the board -> mirror-one exits non-zero
-#     + ::error:: (never a silent no-op exit 0).
+# 17. M1: an off-board OPEN #N carrying a STALE board-derived label -> mirror-one
+#     FAILs (non-zero + ::error::): a stale derived label needs correcting.
+# ---------------------------------------------------------------------------
+d="$(new_case)"
+seed_state "$(printf '117\tReady\t%s\t' "$OLD_TS")"
+export ISSUE_LIST_FILE="$d/issuelist.tsv"
+# #900 is off-board but carries status:ready (stale) -> must error.
+printf 'status:ready\t900\n' >"$ISSUE_LIST_FILE"
+out="$(bash "$MIRROR" mirror-one 900 2>&1)"; rc=$?
+unset ISSUE_LIST_FILE
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "::error::" \
+  && printf '%s' "$out" | grep -q "stale board-derived label"; then
+  pass "M1: mirror-one on off-board issue WITH a stale status label fails (::error::)"
+else
+  fail "M1: mirror-one off-board-with-stale-label did not fail (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 17b. M1: an off-board OPEN #N with NO board-derived label (benign non-status
+#      label touch on an auto-add-missed issue) -> mirror-one exits 0 with a
+#      ::notice::, NOT ::error:: — must not train readers to ignore reds (M1/G2).
 # ---------------------------------------------------------------------------
 new_case >/dev/null
-seed_state "$(printf '117\tReady\t%s\t' "$OLD_TS")"
-out="$(bash "$MIRROR" mirror-one 900 2>&1)"; rc=$?
-if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "::error::"; then
-  pass "F2: mirror-one on an off-board issue fails (no silent no-op)"
+seed_state "$(printf '118\tReady\t%s\t' "$OLD_TS")"
+# ISSUE_LIST_FILE unset -> gh issue list returns nothing -> #901 has no derived label.
+out="$(bash "$MIRROR" mirror-one 901 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && ! printf '%s' "$out" | grep -q "::error::" \
+  && printf '%s' "$out" | grep -q "::notice::"; then
+  pass "M1: mirror-one on off-board issue with NO derived label exits 0 (::notice::)"
 else
-  fail "F2: mirror-one off-board did not fail (rc=$rc): $out"
+  fail "M1: off-board-no-derived-label should be a benign notice (rc=$rc): $out"
 fi
 
 # ---------------------------------------------------------------------------
@@ -556,17 +577,21 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 20. G2: mirror-one on an OPEN but OFF-BOARD issue (via node id) still FAILs with
-#     ::error:: — the real off-board hazard is unchanged by the closed-state fix.
+# 20. G2/M1: mirror-one on an OPEN but OFF-BOARD issue (via node id) that carries a
+#     STALE board-derived label still FAILs with ::error:: — the real stale-label
+#     hazard is unchanged by the closed-state + benign-touch (M1) fixes.
 # ---------------------------------------------------------------------------
-new_case >/dev/null
+d="$(new_case)"
 # #900 is not in the board state at all -> node lookup returns null -> off-board.
 seed_state "$(printf '120\tReady\t%s\t' "$OLD_TS")"
+export ISSUE_LIST_FILE="$d/issuelist.tsv"
+printf 'status:ready\t900\n' >"$ISSUE_LIST_FILE"
 out="$(bash "$MIRROR" mirror-one 900 node-900 2>&1)"; rc=$?
+unset ISSUE_LIST_FILE
 if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "::error::"; then
-  pass "G2: mirror-one on an open off-board issue still fails (::error::)"
+  pass "G2/M1: mirror-one on an open off-board issue WITH a stale label still fails (::error::)"
 else
-  fail "G2: open off-board mirror-one should still fail (rc=$rc): $out"
+  fail "G2/M1: open off-board mirror-one with stale label should fail (rc=$rc): $out"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -34,11 +34,21 @@ cleanup() { rm -rf "$TMP_ROOT" 2>/dev/null || true; }
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
-# gh stub: simulates the board + issue labels from a TSV state file.
+# gh stub: simulates the board + issue labels from a TSV state file. Written to
+# be bash-3.2-safe (no `declare -A` / associative arrays) so it runs under stock
+# macOS /bin/bash exactly like it does under CI's bash-5 (issue #2855, F8) — an
+# `declare: -A: invalid option` death would red the whole tooling-tests component
+# for an environmental reason, indistinguishable from a real regression.
 #   STATE_FILE lines: number<TAB>status<TAB>createdAt<TAB>label,csv
-#   - `gh api graphql ...` (items query) -> the Projects v2 JSON, one page.
+#   - `gh api graphql ...` (items/node query) -> the Projects v2 JSON, one page.
 #   - `gh issue edit N --add-label X`     -> add X to #N's label csv.
 #   - `gh issue edit N --remove-label X`  -> remove X from #N's label csv.
+#   - `gh issue list --state open --label L --json number --jq …` -> the numbers
+#       of OPEN issues carrying label L, read from optional ISSUE_LIST_FILE
+#       (lines: label<TAB>number); empty when unset — models off-board issues.
+# Failure injection (fail-closed tests):
+#   GH_FAIL_GRAPHQL=1 -> `gh api graphql` prints an errors JSON and exits 1.
+#   GH_FAIL_EDIT=1    -> `gh issue edit` exits 1 without mutating state.
 # ---------------------------------------------------------------------------
 write_gh_stub() {
   cat >"$1" <<'EOF'
@@ -48,7 +58,36 @@ set -uo pipefail
 
 # --- gh api graphql ... : emit the board items JSON from STATE_FILE ---------
 if [ "${1:-}" = "api" ] && [ "${2:-}" = "graphql" ]; then
-  # Build the items JSON with jq from the TSV state file.
+  if [ -n "${GH_FAIL_GRAPHQL:-}" ]; then
+    printf '%s\n' '{"errors":[{"message":"Bad credentials"}]}'
+    exit 1
+  fi
+  # A node(id:) lookup (mirror-one by node id) — resolve one issue's project item
+  # directly. Emit the single-issue node JSON. The stub keys the node id as
+  # "node-<number>" so tests can pass a deterministic id.
+  wants_node=0
+  for a in "$@"; do
+    case "$a" in id=node-*) wants_node=1; node_num="${a#id=node-}" ;; esac
+  done
+  if [ "$wants_node" = 1 ]; then
+    jq -Rn --arg num "$node_num" '
+      ( [ inputs | select(length>0) | split("\t") | select(.[0]==$num) ] | first ) as $row
+      | if $row == null
+        then { data: { node: null } }
+        else { data: { node: {
+            number: ($row[0]|tonumber),
+            state: "OPEN",
+            createdAt: (if ($row[2]|length)>0 then $row[2] else null end),
+            labels: { nodes: ( if ($row[3]|length)>0
+                               then ($row[3]|split(",")|map({name:.})) else [] end ) },
+            projectItems: { nodes: [ {
+              project: { id: (env.PROJECT_ID // "PVT_stub") },
+              fieldValueByName: (if ($row[1]|length)>0 then {name: $row[1]} else null end)
+            } ] } } } }
+        end' "$STATE_FILE"
+    exit 0
+  fi
+  # Build the board items JSON with jq from the TSV state file.
   nodes=$(jq -Rn '
     [ inputs
       | select(length>0)
@@ -70,6 +109,22 @@ if [ "${1:-}" = "api" ] && [ "${2:-}" = "graphql" ]; then
   exit 0
 fi
 
+# --- gh issue list --state open --label L --json number --jq … --------------
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "list" ]; then
+  want_label=""
+  shift 2
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --label) want_label="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [ -n "${ISSUE_LIST_FILE:-}" ] && [ -f "$ISSUE_LIST_FILE" ]; then
+    awk -F'\t' -v l="$want_label" '$1==l {print $2}' "$ISSUE_LIST_FILE"
+  fi
+  exit 0
+fi
+
 # --- gh issue edit N --add-label X / --remove-label X -----------------------
 if [ "${1:-}" = "issue" ] && [ "${2:-}" = "edit" ]; then
   num="${3:-}"
@@ -83,19 +138,27 @@ if [ "${1:-}" = "issue" ] && [ "${2:-}" = "edit" ]; then
     esac
   done
   [ -n "$op" ] || exit 0
+  if [ -n "${GH_FAIL_EDIT:-}" ]; then
+    exit 1
+  fi
   # record the edit for assertions
   printf '%s\t%s\t%s\n' "$num" "$op" "$lbl" >>"${EDIT_LOG:?EDIT_LOG not set}"
-  # mutate the state file's label csv for #num
+  # mutate the state file's label csv for #num (portable CSV, no associative arrays)
   tmp="$(mktemp)"
   while IFS=$'\t' read -r n st cr labels; do
     if [ "$n" = "$num" ]; then
-      # normalize csv into a set
       newl=""
-      IFS=',' read -ra arr <<<"$labels"
-      declare -A seen=()
-      for e in "${arr[@]}"; do [ -n "$e" ] && seen["$e"]=1; done
-      if [ "$op" = "add" ]; then seen["$lbl"]=1; else unset "seen[$lbl]"; fi
-      for k in "${!seen[@]}"; do newl="${newl:+$newl,}$k"; done
+      # split existing csv, dropping the target label (remove) or any dup (add);
+      # then append it once for add. `set -f` guards against globbing on labels.
+      set -f
+      old_ifs="$IFS"; IFS=','
+      for e in $labels; do
+        [ -n "$e" ] || continue
+        [ "$e" = "$lbl" ] && continue
+        newl="${newl:+$newl,}$e"
+      done
+      IFS="$old_ifs"; set +f
+      if [ "$op" = "add" ]; then newl="${newl:+$newl,}$lbl"; fi
       printf '%s\t%s\t%s\t%s\n' "$n" "$st" "$cr" "$newl" >>"$tmp"
     else
       printf '%s\t%s\t%s\t%s\n' "$n" "$st" "$cr" "$labels" >>"$tmp"
@@ -268,7 +331,15 @@ export GH_TOKEN="stub-token"
 offenders=""
 for f in "$REPO_ROOT"/.claude/skills/flow-*/SKILL.md; do
   [ -f "$f" ] || continue
-  if grep -Eq -- '(add|remove)-label +status:(ready|in-progress|in-review)' "$f"; then
+  # Broadened (F3): catch a board-derived label WRITE — `--add-label`/`--remove-label`
+  # AND a bare `gh issue create … --label "status:ready"` (the case the old narrow
+  # grep missed). The mirror DERIVES status:* from the board, so any skill SETTING
+  # one by hand is an offender. A READ filter (`gh issue list --label status:ready`,
+  # `gh search`, `gh pr list --label`) is legitimate (#2855 cheap discovery) and is
+  # excluded — match the write pattern, then drop lines that are read commands.
+  if grep -En -- '--(add-|remove-)?label[[:space:]]+["'"'"']?status:(ready|in-progress|in-review)' "$f" \
+       | grep -Ev -- '(issue|pr|search)[[:space:]]+(list|status)|gh[[:space:]]+search' \
+       | grep -q .; then
     offenders="${offenders} ${f}"
   fi
 done
@@ -290,6 +361,116 @@ if [ -x "$INJ" ] || [ -f "$INJ" ]; then
   fi
 else
   pass "check-workflow-injection.sh absent (skipped injection lint)"
+fi
+
+# ---------------------------------------------------------------------------
+# 11. F3 regression: broadened grep catches `gh issue create --label "status:ready"`
+# ---------------------------------------------------------------------------
+tmp_skill_dir="$(mktemp -d "$TMP_ROOT/skill.XXXXXX")"
+cat >"$tmp_skill_dir/SKILL.md" <<'EOF'
+gh issue create --title "x" --body "y" --label "P2" --label "status:ready"
+EOF
+if grep -Eq -- '--(add-|remove-)?label[[:space:]]+["'"'"']?status:(ready|in-progress|in-review)' "$tmp_skill_dir/SKILL.md"; then
+  pass "F3 grep catches bare 'gh issue create --label \"status:ready\"' regression"
+else
+  fail "F3 grep does NOT catch 'gh issue create --label \"status:ready\"'"
+fi
+
+# ---------------------------------------------------------------------------
+# 12. F1: gh api graphql failure -> BOTH mirror AND detect exit non-zero (never
+#     a silent-green "all consistent" with zero rows).
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '112\tReady\t%s\t' "$OLD_TS")"
+export GH_FAIL_GRAPHQL=1
+out_m="$(bash "$MIRROR" mirror 2>&1)"; rc_m=$?
+out_d="$(bash "$MIRROR" detect 2>&1)"; rc_d=$?
+unset GH_FAIL_GRAPHQL
+if [ "$rc_m" -ne 0 ] && [ "$rc_d" -ne 0 ] \
+  && printf '%s%s' "$out_m" "$out_d" | grep -q "::error::"; then
+  pass "F1: gh api graphql failure fails BOTH mirror and detect (non-zero + ::error::)"
+else
+  fail "F1: graphql failure not fail-closed (mirror rc=$rc_m detect rc=$rc_d): $out_m | $out_d"
+fi
+
+# ---------------------------------------------------------------------------
+# 13. F2: an OPEN issue carrying a board-derived label but NOT on the board ->
+#     detector FAILs (off-board stale label = wrong-grab hazard).
+# ---------------------------------------------------------------------------
+d="$(new_case)"
+# Board has only #113 (consistent). #199 is OPEN with status:ready but off-board.
+seed_state "$(printf '113\tReady\t%s\tstatus:ready' "$OLD_TS")"
+export ISSUE_LIST_FILE="$d/issuelist.tsv"
+printf 'status:ready\t199\n' >"$ISSUE_LIST_FILE"
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+unset ISSUE_LIST_FILE
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "199"; then
+  pass "F2: off-board OPEN issue with a board-derived label fails the detector"
+else
+  fail "F2: off-board issue not detected (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 14. F6: an unknown/renamed non-empty board Status -> mirror FAILs and does NOT
+#     strip labels (a board-schema change must not silently delete labels).
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '114\tStaging\t%s\tstatus:ready' "$OLD_TS")"
+out="$(bash "$MIRROR" mirror 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] \
+  && printf '%s' "$out" | grep -q "unknown board Status" \
+  && has_label 114 "status:ready"; then
+  pass "F6: unknown board Status fails the mirror and does NOT strip labels"
+else
+  fail "F6: unknown Status not fail-closed (rc=$rc, labels=$(labels_of 114)): $out"
+fi
+# and the detector likewise fails on an unknown Status
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "unknown board Status"; then
+  pass "F6: unknown board Status also fails the detector"
+else
+  fail "F6: unknown Status not caught by detector (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 15. F7: a failing `gh issue edit` -> mirror exits non-zero + ::error:: (never a
+#     log line asserting an edit that never happened).
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '115\tReady\t%s\t' "$OLD_TS")"
+export GH_FAIL_EDIT=1
+out="$(bash "$MIRROR" mirror 2>&1)"; rc=$?
+unset GH_FAIL_EDIT
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "::error::" \
+  && ! printf '%s' "$out" | grep -q "^mirror: #115 .*+status:ready"; then
+  pass "F7: failed gh issue edit fails the mirror (no false success log)"
+else
+  fail "F7: failed edit not fail-closed (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 16. F4: mirror-one by NODE id resolves the item directly and reconciles it.
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '116\tReady\t%s\t' "$OLD_TS")"
+bash "$MIRROR" mirror-one 116 node-116 >/dev/null 2>&1
+if has_label 116 "status:ready"; then
+  pass "F4: mirror-one resolves the item by node id and reconciles the label"
+else
+  fail "F4: mirror-one by node id did not reconcile: #116=$(labels_of 116)"
+fi
+
+# ---------------------------------------------------------------------------
+# 17. F2 (mirror-one): a #N that is NOT on the board -> mirror-one exits non-zero
+#     + ::error:: (never a silent no-op exit 0).
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '117\tReady\t%s\t' "$OLD_TS")"
+out="$(bash "$MIRROR" mirror-one 900 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "::error::"; then
+  pass "F2: mirror-one on an off-board issue fails (no silent no-op)"
+else
+  fail "F2: mirror-one off-board did not fail (rc=$rc): $out"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -330,27 +330,43 @@ fi
 export GH_TOKEN="stub-token"
 
 # ---------------------------------------------------------------------------
-# 9. Doctrine grep: no flow-* skill writes a board-derived status label
+# The doctrine check, factored into ONE helper (issue #2855, G5) so the
+# enforcement scan (test 9) AND the F3 regression (test 11) exercise the IDENTICAL
+# pipeline: match a board-derived label WRITE — `--add-label`/`--remove-label` AND
+# a bare `gh issue create … --label "status:ready"` — then drop lines that are READ
+# commands (`gh issue list --label status:ready`, `gh search`, `gh pr list --label`,
+# legitimate #2855 cheap discovery). The mirror DERIVES status:* from the board, so
+# any doc SETTING one by hand is an offender.
+#   blm_doctrine_hits FILE -> prints offending line(s); exit 0 iff any hit.
+blm_doctrine_hits() {
+  grep -En -- '--(add-|remove-)?label[[:space:]]+["'"'"']?status:(ready|in-progress|in-review)' "$1" \
+    | grep -Ev -- '(issue|pr|search)[[:space:]]+(list|status)|gh[[:space:]]+search'
+}
+
+# ---------------------------------------------------------------------------
+# 9. Doctrine grep: no flow-* skill / worker / flow-lead doc writes a board-derived
+#    status label. Extended set (G5): commands/worker.md + agents/flow-lead.md, not
+#    just skills. Counts scanned files and FAILs if ZERO were scanned (a vacuous
+#    green if skills/docs move or rename).
 # ---------------------------------------------------------------------------
 offenders=""
-for f in "$REPO_ROOT"/.claude/skills/flow-*/SKILL.md; do
+scanned=0
+for f in \
+  "$REPO_ROOT"/.claude/skills/flow-*/SKILL.md \
+  "$REPO_ROOT"/.claude/commands/worker.md \
+  "$REPO_ROOT"/.claude/agents/flow-lead.md; do
   [ -f "$f" ] || continue
-  # Broadened (F3): catch a board-derived label WRITE — `--add-label`/`--remove-label`
-  # AND a bare `gh issue create … --label "status:ready"` (the case the old narrow
-  # grep missed). The mirror DERIVES status:* from the board, so any skill SETTING
-  # one by hand is an offender. A READ filter (`gh issue list --label status:ready`,
-  # `gh search`, `gh pr list --label`) is legitimate (#2855 cheap discovery) and is
-  # excluded — match the write pattern, then drop lines that are read commands.
-  if grep -En -- '--(add-|remove-)?label[[:space:]]+["'"'"']?status:(ready|in-progress|in-review)' "$f" \
-       | grep -Ev -- '(issue|pr|search)[[:space:]]+(list|status)|gh[[:space:]]+search' \
-       | grep -q .; then
+  scanned=$((scanned + 1))
+  if blm_doctrine_hits "$f" | grep -q .; then
     offenders="${offenders} ${f}"
   fi
 done
-if [ -z "$offenders" ]; then
-  pass "No flow-* skill writes status:ready/in-progress/in-review"
+if [ "$scanned" -eq 0 ]; then
+  fail "Doctrine scan matched ZERO files — flow-*/worker/flow-lead docs moved or renamed (vacuous green guard, G5)"
+elif [ -z "$offenders" ]; then
+  pass "No flow-*/worker/flow-lead doc writes a board-derived status label ($scanned file(s) scanned)"
 else
-  fail "flow-* skill(s) still write a board-derived status label:${offenders}"
+  fail "doc(s) still write a board-derived status label:${offenders}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -368,16 +384,22 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 11. F3 regression: broadened grep catches `gh issue create --label "status:ready"`
+# 11. F3 regression: the SAME helper (blm_doctrine_hits) catches a write
+#     `gh issue create --label "status:ready"` AND does not flag a read-only
+#     `gh issue list --label status:ready` — exercising the identical pipeline
+#     (raw pattern + the -Ev read-command exclusion) the enforcement scan uses (G5).
 # ---------------------------------------------------------------------------
 tmp_skill_dir="$(mktemp -d "$TMP_ROOT/skill.XXXXXX")"
 cat >"$tmp_skill_dir/SKILL.md" <<'EOF'
 gh issue create --title "x" --body "y" --label "P2" --label "status:ready"
+gh issue list --label status:ready --json number
 EOF
-if grep -Eq -- '--(add-|remove-)?label[[:space:]]+["'"'"']?status:(ready|in-progress|in-review)' "$tmp_skill_dir/SKILL.md"; then
-  pass "F3 grep catches bare 'gh issue create --label \"status:ready\"' regression"
+hits="$(blm_doctrine_hits "$tmp_skill_dir/SKILL.md")"
+if printf '%s' "$hits" | grep -q "issue create" \
+  && ! printf '%s' "$hits" | grep -q "issue list"; then
+  pass "F3/G5 helper catches the create-write but excludes the list-read (same pipeline)"
 else
-  fail "F3 grep does NOT catch 'gh issue create --label \"status:ready\"'"
+  fail "F3/G5 helper wrong: hits=[$hits]"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -70,13 +70,17 @@ if [ "${1:-}" = "api" ] && [ "${2:-}" = "graphql" ]; then
     case "$a" in id=node-*) wants_node=1; node_num="${a#id=node-}" ;; esac
   done
   if [ "$wants_node" = 1 ]; then
-    jq -Rn --arg num "$node_num" '
+    # CLOSED_NODES (csv of issue numbers) models closed issues for the node lookup
+    # (issue #2855, G2): a closed issue emits state "CLOSED" so mirror-one exits 0.
+    node_state="OPEN"
+    case ",${CLOSED_NODES:-}," in *",${node_num},"*) node_state="CLOSED" ;; esac
+    jq -Rn --arg num "$node_num" --arg st "$node_state" '
       ( [ inputs | select(length>0) | split("\t") | select(.[0]==$num) ] | first ) as $row
       | if $row == null
         then { data: { node: null } }
         else { data: { node: {
             number: ($row[0]|tonumber),
-            state: "OPEN",
+            state: $st,
             createdAt: (if ($row[2]|length)>0 then $row[2] else null end),
             labels: { nodes: ( if ($row[3]|length)>0
                                then ($row[3]|split(",")|map({name:.})) else [] end ) },
@@ -491,6 +495,35 @@ if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "may be truncated"; then
   pass "G1: off-board list hitting --limit fails the detector (non-truncation assert)"
 else
   fail "G1: limit-truncation not caught (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 19. G2: mirror-one on a CLOSED issue (routine triage label touch) -> exit 0, no
+#     ::error:: (a benign closed-issue label event must not red the run).
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '119\tReady\t%s\t' "$OLD_TS")"
+export CLOSED_NODES=119
+out="$(bash "$MIRROR" mirror-one 119 node-119 2>&1)"; rc=$?
+unset CLOSED_NODES
+if [ "$rc" -eq 0 ] && ! printf '%s' "$out" | grep -q "::error::"; then
+  pass "G2: mirror-one on a closed issue exits 0 with no error"
+else
+  fail "G2: closed-issue mirror-one not benign (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 20. G2: mirror-one on an OPEN but OFF-BOARD issue (via node id) still FAILs with
+#     ::error:: — the real off-board hazard is unchanged by the closed-state fix.
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+# #900 is not in the board state at all -> node lookup returns null -> off-board.
+seed_state "$(printf '120\tReady\t%s\t' "$OLD_TS")"
+out="$(bash "$MIRROR" mirror-one 900 node-900 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "::error::"; then
+  pass "G2: mirror-one on an open off-board issue still fails (::error::)"
+else
+  fail "G2: open off-board mirror-one should still fail (rc=$rc): $out"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -110,6 +110,16 @@ if [ "${1:-}" = "api" ] && [ "${2:-}" = "graphql" ]; then
     { data: { node: { items: {
         pageInfo: { hasNextPage: false, endCursor: null },
         nodes: $nodes } } } }'
+  # Self-heal hook (issue #2855, G6): after the FIRST full-board emission (the
+  # detector's materialize pass), swap STATE_FILE to SELF_HEAL_TO so the per-issue
+  # self-heal RE-READ observes a mutated board — models a Status flip racing between
+  # the mirror and the detect step. Counter file keeps it a one-shot.
+  if [ -n "${SELF_HEAL_TO:-}" ]; then
+    cf="$STATE_FILE.sh_calls"
+    c=$(cat "$cf" 2>/dev/null || echo 0)
+    echo $((c + 1)) >"$cf"
+    if [ "$c" = 0 ]; then cp "$SELF_HEAL_TO" "$STATE_FILE"; fi
+  fi
   exit 0
 fi
 

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -58,8 +58,19 @@ set -uo pipefail
 
 # --- gh api graphql ... : emit the board items JSON from STATE_FILE ---------
 if [ "${1:-}" = "api" ] && [ "${2:-}" = "graphql" ]; then
+  # Count graphql calls so a test can fail a SPECIFIC call — e.g. the self-heal
+  # re-read but NOT the initial materialize (issue #2855, G6b F5 re-read-fails).
+  gqf="$STATE_FILE.gq_calls"
+  gqc=$(cat "$gqf" 2>/dev/null || echo 0)
+  echo $((gqc + 1)) >"$gqf"
   if [ -n "${GH_FAIL_GRAPHQL:-}" ]; then
     printf '%s\n' '{"errors":[{"message":"Bad credentials"}]}'
+    exit 1
+  fi
+  # GH_FAIL_GRAPHQL_AFTER=K -> succeed on calls 0..K-1, fail on call K and later.
+  # Models a re-read failure after a successful materialize (issue #2855, G6b).
+  if [ -n "${GH_FAIL_GRAPHQL_AFTER:-}" ] && [ "$gqc" -ge "$GH_FAIL_GRAPHQL_AFTER" ]; then
+    printf '%s\n' '{"errors":[{"message":"Bad credentials on re-read"}]}'
     exit 1
   fi
   # A node(id:) lookup (mirror-one by node id) — resolve one issue's project item
@@ -576,6 +587,82 @@ if has_label 301 "status:ready" && has_label 302 "status:ready" \
   pass "G4: mirror reconciles every row of a multi-issue board (no stdin-eaten skips)"
 else
   fail "G4: some rows skipped: 301=$(labels_of 301) 302=$(labels_of 302) 303=$(labels_of 303) 304=$(labels_of 304) 305=$(labels_of 305)"
+fi
+
+# ---------------------------------------------------------------------------
+# 22. G6b F5 self-heal RESOLVES -> detect exits 0. A first-pass drift that, on the
+#     self-heal RE-READ, is now consistent (Status flip raced between the mirror and
+#     detect) MUST NOT red the run. SELF_HEAL_TO swaps STATE_FILE to a consistent
+#     board AFTER the initial full-board materialize, so the per-issue re-read
+#     observes the healed state.
+# ---------------------------------------------------------------------------
+d="$(new_case)"
+# First-pass board: #310 is Ready but mislabeled status:in-progress (a drift).
+seed_state "$(printf '310\tReady\t%s\tstatus:in-progress' "$OLD_TS")"
+# Healed board the re-read will observe: #310 Ready + status:ready (consistent).
+printf '310\tReady\t%s\tstatus:ready\n' "$OLD_TS" >"$d/healed.tsv"
+export SELF_HEAL_TO="$d/healed.tsv"
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+gq_seen=$(cat "$STATE_FILE.gq_calls" 2>/dev/null || echo 0)
+unset SELF_HEAL_TO
+if [ "$rc" -eq 0 ] && [ "$gq_seen" -ge 2 ]; then
+  pass "G6b F5: self-heal re-read that RESOLVES exits 0 (raced Status flip, $gq_seen graphql calls)"
+else
+  fail "G6b F5: self-heal-resolves should exit 0 with a re-read (rc=$rc, graphql=$gq_seen): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 23. G6b F5 self-heal PERSISTS -> detect exits 1. A drift that is STILL present on
+#     the self-heal re-read (no swap) MUST red the run — and the re-read actually
+#     ran (>=2 graphql calls: materialize + re-read), so the verdict is the
+#     authoritative current state, not the first pass alone.
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '311\tReady\t%s\tstatus:in-progress' "$OLD_TS")"
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+gq_seen=$(cat "$STATE_FILE.gq_calls" 2>/dev/null || echo 0)
+if [ "$rc" -ne 0 ] && [ "$gq_seen" -ge 2 ] \
+  && printf '%s' "$out" | grep -q "::error::"; then
+  pass "G6b F5: persistent drift reds the run after a re-read ($gq_seen graphql calls)"
+else
+  fail "G6b F5: persistent drift should fail after re-read (rc=$rc, graphql=$gq_seen): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 24. G6b F5 self-heal RE-READ FAILS -> detect exits 1. The initial materialize
+#     succeeds (call 0) and observes a drift; the per-issue self-heal re-read
+#     (call 1) FAILS. The detector must NOT declare consistent on a failed re-read
+#     — it counts the candidate and reds the run (GH_FAIL_GRAPHQL_AFTER=1).
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '312\tReady\t%s\tstatus:in-progress' "$OLD_TS")"
+export GH_FAIL_GRAPHQL_AFTER=1
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+unset GH_FAIL_GRAPHQL_AFTER
+if [ "$rc" -ne 0 ] \
+  && printf '%s' "$out" | grep -q "re-read (self-heal) failed"; then
+  pass "G6b F5: a FAILED self-heal re-read reds the run (never declares consistent)"
+else
+  fail "G6b F5: failed re-read not fail-closed (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 25. G6b BLM_GRACE_SECS freshness skip -> a DRIFTED row with a FRESH createdAt and
+#     BLM_GRACE_SECS=600 is SKIPPED (auto-add/mirror-settle race), detect exits 0.
+#     Every other case pins BLM_GRACE_SECS=0, so this grace path is otherwise
+#     untested.
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+fresh_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# #313 is drifted (Ready but status:in-progress) but created just now.
+seed_state "$(printf '313\tReady\t%s\tstatus:in-progress' "$fresh_ts")"
+export BLM_GRACE_SECS=600
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+unset BLM_GRACE_SECS
+if [ "$rc" -eq 0 ] && ! printf '%s' "$out" | grep -q "::error::"; then
+  pass "G6b: a fresh-createdAt drift within BLM_GRACE_SECS is skipped (detect exits 0)"
+else
+  fail "G6b: grace-window skip failed (rc=$rc): $out"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -527,6 +527,26 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 21. G4: many-row board -> mirror reconciles EVERY issue (a child consuming the
+#     loop's stdin would silently skip rows; the dedicated-fd read must not).
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state \
+  "$(printf '301\tReady\t%s\t' "$OLD_TS")" \
+  "$(printf '302\tReady\t%s\t' "$OLD_TS")" \
+  "$(printf '303\tReady\t%s\t' "$OLD_TS")" \
+  "$(printf '304\tReady\t%s\t' "$OLD_TS")" \
+  "$(printf '305\tReady\t%s\t' "$OLD_TS")"
+bash "$MIRROR" mirror >/dev/null 2>&1
+if has_label 301 "status:ready" && has_label 302 "status:ready" \
+  && has_label 303 "status:ready" && has_label 304 "status:ready" \
+  && has_label 305 "status:ready"; then
+  pass "G4: mirror reconciles every row of a multi-issue board (no stdin-eaten skips)"
+else
+  fail "G4: some rows skipped: 301=$(labels_of 301) 302=$(labels_of 302) 303=$(labels_of 303) 304=$(labels_of 304) 305=$(labels_of 305)"
+fi
+
+# ---------------------------------------------------------------------------
 echo "----"
 echo "board-label-mirror: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# scripts/tests/test_board_label_mirror.sh — fast, self-contained tests for the
+# enforced board→label mirror (issue #2855). No cargo, no gate, no network: the
+# `gh`/GraphQL layer is a stub script that SIMULATES the project board + issue
+# labels from a per-test state file, modelled on test_worker_supervisor.sh's
+# stubbing approach. Target: <10s total.
+#
+# The unit under test is the sourceable seam scripts/ci/board-label-mirror.sh
+# (the same code the .github/workflows/project-board-sync.yml workflow calls).
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SELF_DIR/../.." && pwd)"
+MIRROR="$REPO_ROOT/scripts/ci/board-label-mirror.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  echo "PASS: $1"
+}
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  echo "FAIL: $1"
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq unavailable (the mirror + this test's board stub both need jq)"
+  exit 0
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cqlite-blm-test.XXXXXX")"
+cleanup() { rm -rf "$TMP_ROOT" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# gh stub: simulates the board + issue labels from a TSV state file.
+#   STATE_FILE lines: number<TAB>status<TAB>createdAt<TAB>label,csv
+#   - `gh api graphql ...` (items query) -> the Projects v2 JSON, one page.
+#   - `gh issue edit N --add-label X`     -> add X to #N's label csv.
+#   - `gh issue edit N --remove-label X`  -> remove X from #N's label csv.
+# ---------------------------------------------------------------------------
+write_gh_stub() {
+  cat >"$1" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+: "${STATE_FILE:?STATE_FILE not set}"
+
+# --- gh api graphql ... : emit the board items JSON from STATE_FILE ---------
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "graphql" ]; then
+  # Build the items JSON with jq from the TSV state file.
+  nodes=$(jq -Rn '
+    [ inputs
+      | select(length>0)
+      | split("\t")
+      | { fieldValueByName: (if (.[1]|length)>0 then {name: .[1]} else null end),
+          content: {
+            __typename: "Issue",
+            number: (.[0]|tonumber),
+            state: "OPEN",
+            createdAt: (if (.[2]|length)>0 then .[2] else null end),
+            labels: { nodes: ( if (.[3]|length)>0
+                               then (.[3]|split(",")|map({name:.}))
+                               else [] end ) }
+          } } ]' "$STATE_FILE")
+  jq -n --argjson nodes "$nodes" '
+    { data: { node: { items: {
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: $nodes } } } }'
+  exit 0
+fi
+
+# --- gh issue edit N --add-label X / --remove-label X -----------------------
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "edit" ]; then
+  num="${3:-}"
+  op="" lbl=""
+  shift 3
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --add-label) op="add"; lbl="$2"; shift 2 ;;
+      --remove-label) op="remove"; lbl="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -n "$op" ] || exit 0
+  # record the edit for assertions
+  printf '%s\t%s\t%s\n' "$num" "$op" "$lbl" >>"${EDIT_LOG:?EDIT_LOG not set}"
+  # mutate the state file's label csv for #num
+  tmp="$(mktemp)"
+  while IFS=$'\t' read -r n st cr labels; do
+    if [ "$n" = "$num" ]; then
+      # normalize csv into a set
+      newl=""
+      IFS=',' read -ra arr <<<"$labels"
+      declare -A seen=()
+      for e in "${arr[@]}"; do [ -n "$e" ] && seen["$e"]=1; done
+      if [ "$op" = "add" ]; then seen["$lbl"]=1; else unset "seen[$lbl]"; fi
+      for k in "${!seen[@]}"; do newl="${newl:+$newl,}$k"; done
+      printf '%s\t%s\t%s\t%s\n' "$n" "$st" "$cr" "$newl" >>"$tmp"
+    else
+      printf '%s\t%s\t%s\t%s\n' "$n" "$st" "$cr" "$labels" >>"$tmp"
+    fi
+  done <"$STATE_FILE"
+  mv "$tmp" "$STATE_FILE"
+  exit 0
+fi
+
+echo "gh stub: unhandled args: $*" >&2
+exit 3
+EOF
+  chmod +x "$1"
+}
+
+# new_case DIR: set up a case dir with a gh stub on PATH + a fresh edit log.
+# Writes STATE_FILE / EDIT_LOG / GH_TOKEN / PROJECT_ID into the current env.
+new_case() {
+  local d
+  d="$(mktemp -d "$TMP_ROOT/case.XXXXXX")"
+  mkdir -p "$d/bin"
+  write_gh_stub "$d/bin/gh"
+  export PATH="$d/bin:$PATH_ORIG"
+  export STATE_FILE="$d/state.tsv"
+  export EDIT_LOG="$d/edits.tsv"
+  : >"$EDIT_LOG"
+  export GH_TOKEN="stub-token"
+  export PROJECT_ID="PVT_stub"
+  # Old createdAt so the detector's grace window never skips test rows.
+  export BLM_GRACE_SECS="0"
+  echo "$d"
+}
+PATH_ORIG="$PATH"
+
+# seed_state ROW... : write TSV rows (number<TAB>status<TAB>created<TAB>labels).
+seed_state() {
+  : >"$STATE_FILE"
+  local r
+  for r in "$@"; do printf '%s\n' "$r" >>"$STATE_FILE"; done
+}
+
+# labels_of N -> the current label csv for issue N from STATE_FILE.
+labels_of() {
+  awk -F'\t' -v n="$1" '$1==n {print $4}' "$STATE_FILE"
+}
+has_label() { case ",$(labels_of "$1")," in *",$2,"*) return 0 ;; *) return 1 ;; esac; }
+
+OLD_TS="2020-01-01T00:00:00Z"
+
+# ---------------------------------------------------------------------------
+# 1. Ready -> status:ready set, other board labels removed, spec-review/addressing untouched
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state \
+  "$(printf '101\tReady\t%s\tstatus:in-progress,status:spec-review' "$OLD_TS")"
+bash "$MIRROR" mirror >/dev/null 2>&1
+if has_label 101 "status:ready" \
+  && ! has_label 101 "status:in-progress" \
+  && has_label 101 "status:spec-review"; then
+  pass "Ready sets status:ready, removes status:in-progress, keeps status:spec-review"
+else
+  fail "Ready mirror wrong: labels=$(labels_of 101)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. In Progress -> status:in-progress; stale status:ready removed; addressing kept
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '102\tIn Progress\t%s\tstatus:ready,status:addressing' "$OLD_TS")"
+bash "$MIRROR" mirror >/dev/null 2>&1
+if has_label 102 "status:in-progress" \
+  && ! has_label 102 "status:ready" \
+  && has_label 102 "status:addressing"; then
+  pass "In Progress sets status:in-progress, removes status:ready, keeps status:addressing"
+else
+  fail "In Progress mirror wrong: labels=$(labels_of 102)"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Backlog -> all board-derived labels removed (no status:backlog invented)
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '103\tBacklog\t%s\tstatus:in-review' "$OLD_TS")"
+bash "$MIRROR" mirror >/dev/null 2>&1
+if ! has_label 103 "status:in-review" \
+  && ! has_label 103 "status:ready" \
+  && ! has_label 103 "status:in-progress"; then
+  pass "Backlog removes all board-derived status labels"
+else
+  fail "Backlog mirror wrong: labels=$(labels_of 103)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency: a matching state -> second run makes NO edit
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '104\tIn Review\t%s\tstatus:in-review' "$OLD_TS")"
+bash "$MIRROR" mirror >/dev/null 2>&1
+: >"$EDIT_LOG"
+bash "$MIRROR" mirror >/dev/null 2>&1
+if [ ! -s "$EDIT_LOG" ]; then
+  pass "Idempotent: second mirror run on a matching board makes no edit"
+else
+  fail "Idempotency broken: second run edited: $(cat "$EDIT_LOG")"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. mirror-one: only the named issue is reconciled
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state \
+  "$(printf '105\tReady\t%s\t' "$OLD_TS")" \
+  "$(printf '106\tReady\t%s\t' "$OLD_TS")"
+bash "$MIRROR" mirror-one 105 >/dev/null 2>&1
+if has_label 105 "status:ready" && ! has_label 106 "status:ready"; then
+  pass "mirror-one reconciles only the named issue"
+else
+  fail "mirror-one leaked: #105=$(labels_of 105) #106=$(labels_of 106)"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Detector: seeded mismatch -> non-zero exit + ::error::
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '107\tReady\t%s\tstatus:in-progress' "$OLD_TS")"
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "::error::"; then
+  pass "Detector exits non-zero + ::error:: on a seeded mismatch"
+else
+  fail "Detector did not fail on mismatch (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Detector: a consistent board -> exit 0
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state \
+  "$(printf '108\tReady\t%s\tstatus:ready' "$OLD_TS")" \
+  "$(printf '109\tBacklog\t%s\t' "$OLD_TS")" \
+  "$(printf '110\tIn Review\t%s\tstatus:in-review,status:spec-review' "$OLD_TS")"
+if bash "$MIRROR" detect >/dev/null 2>&1; then
+  pass "Detector exits 0 on a fully consistent board (spec-review ignored)"
+else
+  fail "Detector failed on a consistent board"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Missing token -> fail loud (never a silent skip)
+# ---------------------------------------------------------------------------
+new_case >/dev/null
+seed_state "$(printf '111\tReady\t%s\t' "$OLD_TS")"
+unset GH_TOKEN
+out="$(bash "$MIRROR" mirror 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "PROJECTS_TOKEN not set"; then
+  pass "Missing PROJECTS_TOKEN fails loud (mirror)"
+else
+  fail "Missing token did not fail loud (rc=$rc): $out"
+fi
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "PROJECTS_TOKEN not set"; then
+  pass "Missing PROJECTS_TOKEN fails loud (detect)"
+else
+  fail "Missing token did not fail loud on detect (rc=$rc): $out"
+fi
+export GH_TOKEN="stub-token"
+
+# ---------------------------------------------------------------------------
+# 9. Doctrine grep: no flow-* skill writes a board-derived status label
+# ---------------------------------------------------------------------------
+offenders=""
+for f in "$REPO_ROOT"/.claude/skills/flow-*/SKILL.md; do
+  [ -f "$f" ] || continue
+  if grep -Eq -- '(add|remove)-label +status:(ready|in-progress|in-review)' "$f"; then
+    offenders="${offenders} ${f}"
+  fi
+done
+if [ -z "$offenders" ]; then
+  pass "No flow-* skill writes status:ready/in-progress/in-review"
+else
+  fail "flow-* skill(s) still write a board-derived status label:${offenders}"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. Workflow injection lint clean on the edited board-sync workflow
+# ---------------------------------------------------------------------------
+INJ="$REPO_ROOT/scripts/ci/check-workflow-injection.sh"
+if [ -x "$INJ" ] || [ -f "$INJ" ]; then
+  if bash "$INJ" "$REPO_ROOT/.github/workflows/project-board-sync.yml" >/dev/null 2>&1; then
+    pass "check-workflow-injection.sh clean on project-board-sync.yml"
+  else
+    fail "check-workflow-injection.sh flagged project-board-sync.yml"
+  fi
+else
+  pass "check-workflow-injection.sh absent (skipped injection lint)"
+fi
+
+# ---------------------------------------------------------------------------
+echo "----"
+echo "board-label-mirror: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/tests/test_board_label_mirror.sh
+++ b/scripts/tests/test_board_label_mirror.sh
@@ -474,6 +474,26 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 18. G1: off-board `gh issue list` hits the --limit -> detector FAILs (a full
+#     page means the list may be truncated; refuse a possibly-partial scan).
+# ---------------------------------------------------------------------------
+d="$(new_case)"
+seed_state "$(printf '118\tReady\t%s\tstatus:ready' "$OLD_TS")"
+export ISSUE_LIST_FILE="$d/issuelist.tsv"
+# Return exactly BLM_OFFBOARD_LIMIT numbers for status:ready so count == limit.
+: >"$ISSUE_LIST_FILE"
+printf 'status:ready\t118\n' >>"$ISSUE_LIST_FILE"
+printf 'status:ready\t201\n' >>"$ISSUE_LIST_FILE"
+export BLM_OFFBOARD_LIMIT=2
+out="$(bash "$MIRROR" detect 2>&1)"; rc=$?
+unset ISSUE_LIST_FILE BLM_OFFBOARD_LIMIT
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "may be truncated"; then
+  pass "G1: off-board list hitting --limit fails the detector (non-truncation assert)"
+else
+  fail "G1: limit-truncation not caught (rc=$rc): $out"
+fi
+
+# ---------------------------------------------------------------------------
 echo "----"
 echo "board-label-mirror: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -144,7 +144,8 @@ roborev pass actually ran on. Three mechanical rules keep the merge honest:
 
 - **Backlog** = GitHub issues; the Project `Status` field is the authoritative lifecycle
   (`Backlog → Ready → In Progress → In Review → Done`). Each issue carries one `P0`–`P3`; `status:*`
-  labels are decorative only (Path A, #1886 — see [the claim board](#the-shared-claim-board)).
+  labels are an **enforced read-mirror of board Status for discovery only** (Path A, #1886; #2855 — see
+  [the claim board](#the-shared-claim-board)).
 - **1:1:1:1** — one issue ↔ one worktree/branch `issue-<N>-<slug>` ↔ one OpenSpec change `<slug>` ↔ one
   PR. Worktrees branch from `origin/main` and lack the gitignored `Data.db` binaries — run the gate with
   `CQLITE_DATASETS_ROOT` pointed at the main repo's `test-data/datasets`.
@@ -166,10 +167,21 @@ board and normalize the `Status` options. The built-in workflow automations (mer
 assigned → `In Progress`) cannot be set via CLI; the script prints the manual web-UI step for them.
 
 **Path A — the board is the sole dispatch authority (issue #1886):** work is selected and claimed by
-the Project `Status` field ONLY. `status:*` labels are **decorative and non-authoritative** — never use
-them to select or claim work. If the `project` scope or the board is **unreachable, STOP and fix the auth**
-(`gh auth refresh -s project`) — do **not** fall back to labels to find work. An empty `Ready` column means
-no work is ready (near a release it is *meant* to drain to zero), not a cue to dredge labels.
+the Project `Status` field ONLY. If the `project` scope or the board is **unreachable, STOP and fix the
+auth** (`gh auth refresh -s project`) — do **not** fall back to labels to select work. An empty `Ready`
+column means no work is ready (near a release it is *meant* to drain to zero), not a cue to dredge labels.
+
+**`status:*` labels — an enforced read-mirror for cheap discovery (issue #2855):** the labels are no
+longer decorative. `.github/workflows/project-board-sync.yml` is the *single writer*, deriving each OPEN
+issue's `status:*` label from its board Status (Ready→`status:ready`, In Progress→`status:in-progress`,
+In Review→`status:in-review`, Backlog/Done→none) on the 30-min sweep + on issue events, with a
+drift-detector that FAILs the run on any label≠Status disagreement. So a session MAY *narrow* candidates
+cheaply and server-side with `gh issue list --state open --label status:ready --json number,title` (no
+issue bodies, no board pagination). But the label is **eventually-consistent (≤30-min lag) and NEVER the
+dispatch/claim authority**: it only narrows the candidate set — the selection decision is by live board
+`Status`, and the claim ref plus a fresh board read at claim time remain the sole double-work arbiter.
+flow-* skills no longer write the board-derived labels (they set board Status only; the mirror follows);
+`status:spec-review`/`status:addressing` stay transient skill-managed sub-markers the mirror does not touch.
 
 ## The claim protocol (no duplicate work)
 


### PR DESCRIPTION
Closes #2855

## Summary
Makes `status:*` labels a **machine-written projection** of board Status (single writer = `project-board-sync.yml`), so dispatch can cheaply filter Ready work (`gh issue list --label status:ready` — server-side, no bodies, ~0 rate) and *trust* it, instead of the current drift (measured: board Ready=1 vs label status:ready=20).

## Design (approved at Seam 1, option a)
- Board `Status` = single source of truth. Mapping: Ready→`status:ready`, In Progress→`status:in-progress`, In Review→`status:in-review`, Backlog/Done→no `status:*` label.
- `status:spec-review` / `status:addressing` are sub-states of In Progress — **not** board-derived; the mirror leaves them to the skills (option a).
- One-way only (Status→label); label is **discovery-only, never the claim authority** — claim ref + fresh board read stay authoritative.

## Changes
- **`scripts/ci/board-label-mirror.sh`** — sourceable logic (`desired`/`mirror`/`mirror-one`/`detect`/`require-token`); the testable seam.
- **`.github/workflows/project-board-sync.yml`** — sweep mirror + drift-detector steps; new `issues:` trigger → `mirror-one` job (issue number passed via a validated quoted env var — no `${{ }}`-in-`run:`).
- **`scripts/tests/test_board_label_mirror.sh`** — 11 cases (mapping, spec-review/addressing untouched, idempotency, detector mismatch→nonzero + consistent→0, missing-token fail-loud, doctrine grep, injection lint); registered in the `tooling-tests` gate component.
- **flow-{board,implement,finalize,address} skills** — stop writing board-derived status labels; flow-board uses cheap `status:ready` discovery.
- **Doctrine** — CLAUDE.md, pm-operating-loop.md, website delivery-pipeline.md: label reframed as an enforced read-mirror for discovery.

## Verification
- LITE gate **RESULT: PASS** at `08d6b017f`. `board-label-mirror: 11/11`.
- Full `agent-gate.sh` (gate of record) + C audit + drift-reconcile `workflow_dispatch` run via flow-closer/rollout.

## Reviewer note
`flow-groom` still sets `status:ready` at issue-create time (pre-first-mirror label alongside the board Status it also sets) — left intentionally; the mirror reconciles it within one pass. Flag if it should be removed too.