### PR TITLE
fix(#2849): CLAIM_CMD='' truly disables claim stamping — unblocks the local full gate (tooling-tests hang)

### DIFF
--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -1338,6 +1338,11 @@ main() {
   validate_numeric_knobs
   acquire_lock
   log "started: MAX_ISSUES=$MAX_ISSUES MAX_HOURS=$MAX_HOURS LOAD_MAX=$LOAD_MAX DISK_FLOOR_GB=$DISK_FLOOR_GB BREAKER_N=$BREAKER_N"
+  # #2655 machine-claim liveness is disabled when CLAIM_CMD is empty (a machine with
+  # no origin push rights, or the hermetic tooling tests). Announce it ONCE so a
+  # silently-unclaimed run is visible in the log rather than mistaken for a claim
+  # that simply never refreshed (stamp_claim/clear_claim otherwise return with no line).
+  [[ -n "$CLAIM_CMD" ]] || log "claim stamping DISABLED (CLAIM_CMD empty) — no machine-claim liveness ref this run (#2655)"
   while true; do
     [[ -f "$STOP_FILE" ]] && finalize_exit "stop-file" 0
     [[ $(($(date +%s) - START_TS)) -ge "$MAX_HOURS_SECS" ]] && finalize_exit "budget-wallclock" 0

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -232,8 +232,18 @@ LOG_DIR="${LOG_DIR:-$REPO_ROOT/logs/worker-supervisor}"
 #
 # CLAIM_CMD is the claim-heartbeat.sh entrypoint; overridable so the tests can
 # substitute a hermetic stub (no origin/network). Set CLAIM_CMD="" to disable
-# claim stamping entirely (e.g. a machine with no origin push rights).
-CLAIM_CMD="${CLAIM_CMD:-bash $REPO_ROOT/scripts/flow/claim-heartbeat.sh}"
+# claim stamping entirely (e.g. a machine with no origin push rights, or the
+# tooling tests, which must never touch origin/gh).
+#
+# Use `${VAR-default}` (NO colon), NOT `${VAR:-default}`: the colon form
+# substitutes the default for an EMPTY string too, which silently re-enabled the
+# real claim-heartbeat.sh (git push / gh pr list — network ops) whenever a caller
+# set CLAIM_CMD="" to disable it. That defeated the documented "set to empty to
+# disable" contract and let a slow/contended origin push or `gh pr list` WEDGE the
+# supervisor (issue #2849 — non-deterministic tooling-tests hang: the tests set
+# CLAIM_CMD="" but hit the real network path anyway). The colonless form preserves
+# an explicitly-empty override so disabling truly disables.
+CLAIM_CMD="${CLAIM_CMD-bash $REPO_ROOT/scripts/flow/claim-heartbeat.sh}"
 # The machine identity the claim ref is scoped to — must match what the reaper
 # clears. Defaults to claim-heartbeat.sh's own default (`hostname -s`), honoring
 # HEARTBEAT_MACHINE when the fleet overrides it.

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -2567,68 +2567,93 @@ test_healthy_worker_iterlog_nonempty() {
 # used `${CLAIM_CMD:-default}` (colon), which substitutes the default for an
 # EMPTY string too, so common_env's `export CLAIM_CMD=""` hit the real network
 # path and a slow/contended origin push or `gh pr list` WEDGED the supervisor —
-# the non-deterministic tooling-tests hang. Pinned two ways: (a) the resolved
-# value stays empty when sourced with CLAIM_CMD="" (the source-guard keeps main()
-# from running); (b) the config line uses the colonless `${CLAIM_CMD-` form.
-# A LIVE proof follows: run a full nasty-reason iteration with a poisoned
-# CLAIM_CMD probe and assert it is NEVER invoked (no marker reason — however
-# nasty — can drive a claim call, and the run completes bounded, not hung).
+# the non-deterministic tooling-tests hang. Pinned three ways:
+#   (a) sourced with CLAIM_CMD="", the resolved value stays empty. Guarded against
+#       a VACUOUS pass (an aborted `source "$SUP"` under `set -euo pipefail` would
+#       ALSO print nothing): the sub-bash prints a `MARK:` sentinel, so success is
+#       the exact string `MARK:` (empty CLAIM_CMD) — never empty-because-aborted.
+#   (b) the config line uses the colonless `${CLAIM_CMD-` form (source-level pin,
+#       survives a refactor that moves the resolution).
+#   (c) LIVE: a full nasty-reason iteration with CLAIM_CMD="" invokes NO claim
+#       command on EITHER path — success (`claim stamped/cleared`) OR failure
+#       (`claim stamp/clear failed|declined`, which is what a re-defaulted call
+#       WOULD log in a no-push/hermetic env). The run is BOUNDED by a
+#       background+poll+kill watchdog (macOS has no `timeout(1)`): a re-introduced
+#       slow-network claim path is caught as a wedge (kill + FAIL), not a hang.
 # ---------------------------------------------------------------------------
 test_claim_cmd_empty_truly_disables_no_network() {
-  local resolved cfg_line d sentinel jf rc invoked
-  # (a) resolved CLAIM_CMD stays empty (the exact #2849 parameter-expansion pin).
+  local resolved cfg_line d jf rc invoked sup_pid waited finished
+  # (a) NON-VACUOUS resolved pin: MARK: prefix distinguishes "CLAIM_CMD is empty"
+  # from "source aborted and printed nothing" (mirrors the sibling anti-drift pins).
   # shellcheck disable=SC2016  # $SUP/$CLAIM_CMD expand inside the sub-bash, not here.
-  resolved="$(env CLAIM_CMD="" SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$CLAIM_CMD"' 2>/dev/null)"
-  # (b) config line uses the colonless default form (catches a `:-` regression at
-  # the source level even if a future refactor moves the resolution).
+  resolved="$(env CLAIM_CMD="" SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf "MARK:%s" "$CLAIM_CMD"' 2>/dev/null)"
+  # (b) config line uses the colonless default form.
   cfg_line="$(grep -E '^CLAIM_CMD=' "$SUPERVISOR" | head -1)"
-  # LIVE: with CLAIM_CMD="" the supervisor must invoke NO claim command at all.
-  # Poison the DEFAULT path — if the empty override were re-defaulted, a claim call
-  # would fire; we prove it does not by leaving CLAIM_CMD="" (common_env's default)
-  # and asserting the process table never shows a claim-heartbeat child, AND the
-  # nasty-reason run still completes (bounded, head-blocked stop) with valid JSON.
+  # (c) LIVE, BOUNDED: with CLAIM_CMD="" the supervisor must invoke NO claim command
+  # at all. Background it and poll for exit up to a 60s cap; a re-defaulted slow claim
+  # path would exceed the cap → kill + FAIL (proving the no-hang property), never a
+  # silent suite wedge. The nasty-reason marker still drives a bounded head-blocked stop.
   d="$(new_case_dir)"
-  sentinel="$d/claim-invoked"
   common_env "$d" # sets CLAIM_CMD=""
   write_blocked_nasty_reason_stub "$d/bin/worker.sh"
   export WORKER_CMD="$d/bin/worker.sh" MAX_ISSUES=1 BREAKER_N=1
   jf="$JOURNAL_FILE"
-  bash "$SUPERVISOR" >"$d/stdout.log" 2>&1
+  bash "$SUPERVISOR" >"$d/stdout.log" 2>&1 &
+  sup_pid=$!
+  waited=0
+  finished="no"
+  while [[ "$waited" -lt 600 ]]; do # 600 * 0.1s = 60s bound
+    kill -0 "$sup_pid" 2>/dev/null || { finished="yes"; break; }
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if [[ "$finished" != "yes" ]]; then
+    kill -KILL "$sup_pid" 2>/dev/null || true
+    wait "$sup_pid" 2>/dev/null || true
+    fail "#2849: supervisor did NOT finish within 60s with CLAIM_CMD='' — a re-defaulted claim path is wedging it (see $d/stdout.log)"
+    return
+  fi
+  wait "$sup_pid"
   rc=$?
-  # A real claim-heartbeat.sh call logs "claim stamped"/"claim cleared"; with the
-  # disable honored, neither appears (stamp_claim/clear_claim return early).
+  # Match a claim invocation on BOTH the success AND failure log paths: a real
+  # claim-heartbeat.sh call in a hermetic/no-push env FAILS and logs a WARN
+  # ("claim stamp failed" / "claim clear declined/failed"), which a success-only
+  # grep would miss — letting a reintroduced `${CLAIM_CMD:-…}` pass unnoticed.
   invoked="no"
-  grep -qE 'claim (stamped|cleared)' "$d/stdout.log" && invoked="yes"
-  if [[ -z "$resolved" && "$cfg_line" == *'${CLAIM_CMD-'* && "$cfg_line" != *'${CLAIM_CMD:-'* &&
+  grep -qiE 'claim (stamped|cleared)|claim (stamp|clear) (failed|declined)' "$d/stdout.log" && invoked="yes"
+  if [[ "$resolved" == "MARK:" && "$cfg_line" == *'${CLAIM_CMD-'* && "$cfg_line" != *'${CLAIM_CMD:-'* &&
         "$rc" -eq 0 && "$invoked" == "no" ]] && grep -q '"outcome":"blocked"' "$jf"; then
-    pass "#2849: CLAIM_CMD='' truly disables claim stamping (no network, no re-default); nasty run completes bounded"
+    pass "#2849: CLAIM_CMD='' truly disables claim stamping (no network, no re-default); nasty run completes within 60s bound"
   else
     fail "#2849: resolved='$resolved' cfg='$cfg_line' rc=$rc claim_invoked=$invoked (see $d/stdout.log)"
   fi
-  rm -f "$sentinel"
 }
 
 # ---------------------------------------------------------------------------
-# Test (#2849 HERMETICITY, documented + enforced): every REAL `pgrep -f`
-# invocation in THIS suite scans the whole host process table, so on a dev box
-# concurrently running Claude Code / a gate (cargo|nextest|gate_slot_daemon) it
-# WILL match host processes. Each such line MUST therefore scope its assertion to
-# the test's OWN spawned PID via `grep -qw "$...pid"` on the same line — never
-# assert on a bare match count and never block on a host match. This meta-check
-# fails if a future edit adds an un-PID-scoped real `pgrep -f` command line,
-# re-introducing host contamination.
+# Test (#2849 HERMETICITY, documented + enforced): every REAL pgrep process-table
+# scan in THIS suite matches the whole host, so on a dev box concurrently running
+# Claude Code / a gate (cargo|nextest|gate_slot_daemon) it WILL match host
+# processes. Each such line MUST therefore scope its assertion to the test's OWN
+# spawned PID via `grep -qw "$...pid"` on the same line — never assert on a bare
+# match count and never block on a host match. This meta-check fails if a future
+# edit adds an un-PID-scoped real pgrep scan, re-introducing host contamination.
+# The scan matches `pgrep` + any flag group containing `f` (`-f`, `-af`, `-fl`,
+# `-lf`) in ANY position (`if pgrep`, `out="$(pgrep …)"`, `while ! pgrep`) on a
+# NON-comment line, so it is not fooled by a form other than a line-leading
+# `pgrep -f`. (Its own pass/fail text says "pgrep process scan" — no `-flag` —
+# and the pattern literal has no whitespace after `pgrep`, so neither self-matches.)
 # ---------------------------------------------------------------------------
 test_real_pgrep_usages_are_pid_scoped() {
   local bad="" line
-  # Command lines only (leading whitespace then `pgrep -f`), never prose/comments
-  # (which start with `#`) — assert each pipes into a PID-scoped `grep -qw`.
+  # Strip comment lines (first non-blank char `#`), then flag any real pgrep scan
+  # whose line does not PID-scope via `grep -qw`.
   while IFS= read -r line; do
     [[ "$line" == *'grep -qw'* ]] || bad="${bad}${line}\n"
-  done < <(grep -E '^[[:space:]]*pgrep -f ' "${BASH_SOURCE[0]}")
+  done < <(grep -vE '^[[:space:]]*#' "${BASH_SOURCE[0]}" | grep -E 'pgrep[[:space:]]+-[a-zA-Z]*f')
   if [[ -z "$bad" ]]; then
-    pass "#2849: all real pgrep -f usages are PID-scoped (grep -qw \$pid) — hermetic vs host processes"
+    pass "#2849: every real pgrep process scan is PID-scoped (grep -qw \$pid) — hermetic vs host processes"
   else
-    fail "#2849: un-PID-scoped real pgrep -f line(s) can match host processes:\n$(printf '%b' "$bad")"
+    fail "#2849: un-PID-scoped real pgrep process scan(s) can match host processes:\n$(printf '%b' "$bad")"
   fi
 }
 

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -2561,6 +2561,78 @@ test_healthy_worker_iterlog_nonempty() {
 }
 
 # ---------------------------------------------------------------------------
+# Test (#2849 REGRESSION): setting CLAIM_CMD="" MUST truly disable claim
+# stamping — it must NOT be silently re-defaulted back to the real
+# claim-heartbeat.sh (git push / gh pr list — network ops). The original defect
+# used `${CLAIM_CMD:-default}` (colon), which substitutes the default for an
+# EMPTY string too, so common_env's `export CLAIM_CMD=""` hit the real network
+# path and a slow/contended origin push or `gh pr list` WEDGED the supervisor —
+# the non-deterministic tooling-tests hang. Pinned two ways: (a) the resolved
+# value stays empty when sourced with CLAIM_CMD="" (the source-guard keeps main()
+# from running); (b) the config line uses the colonless `${CLAIM_CMD-` form.
+# A LIVE proof follows: run a full nasty-reason iteration with a poisoned
+# CLAIM_CMD probe and assert it is NEVER invoked (no marker reason — however
+# nasty — can drive a claim call, and the run completes bounded, not hung).
+# ---------------------------------------------------------------------------
+test_claim_cmd_empty_truly_disables_no_network() {
+  local resolved cfg_line d sentinel jf rc invoked
+  # (a) resolved CLAIM_CMD stays empty (the exact #2849 parameter-expansion pin).
+  # shellcheck disable=SC2016  # $SUP/$CLAIM_CMD expand inside the sub-bash, not here.
+  resolved="$(env CLAIM_CMD="" SUP="$SUPERVISOR" bash -c 'source "$SUP"; printf %s "$CLAIM_CMD"' 2>/dev/null)"
+  # (b) config line uses the colonless default form (catches a `:-` regression at
+  # the source level even if a future refactor moves the resolution).
+  cfg_line="$(grep -E '^CLAIM_CMD=' "$SUPERVISOR" | head -1)"
+  # LIVE: with CLAIM_CMD="" the supervisor must invoke NO claim command at all.
+  # Poison the DEFAULT path — if the empty override were re-defaulted, a claim call
+  # would fire; we prove it does not by leaving CLAIM_CMD="" (common_env's default)
+  # and asserting the process table never shows a claim-heartbeat child, AND the
+  # nasty-reason run still completes (bounded, head-blocked stop) with valid JSON.
+  d="$(new_case_dir)"
+  sentinel="$d/claim-invoked"
+  common_env "$d" # sets CLAIM_CMD=""
+  write_blocked_nasty_reason_stub "$d/bin/worker.sh"
+  export WORKER_CMD="$d/bin/worker.sh" MAX_ISSUES=1 BREAKER_N=1
+  jf="$JOURNAL_FILE"
+  bash "$SUPERVISOR" >"$d/stdout.log" 2>&1
+  rc=$?
+  # A real claim-heartbeat.sh call logs "claim stamped"/"claim cleared"; with the
+  # disable honored, neither appears (stamp_claim/clear_claim return early).
+  invoked="no"
+  grep -qE 'claim (stamped|cleared)' "$d/stdout.log" && invoked="yes"
+  if [[ -z "$resolved" && "$cfg_line" == *'${CLAIM_CMD-'* && "$cfg_line" != *'${CLAIM_CMD:-'* &&
+        "$rc" -eq 0 && "$invoked" == "no" ]] && grep -q '"outcome":"blocked"' "$jf"; then
+    pass "#2849: CLAIM_CMD='' truly disables claim stamping (no network, no re-default); nasty run completes bounded"
+  else
+    fail "#2849: resolved='$resolved' cfg='$cfg_line' rc=$rc claim_invoked=$invoked (see $d/stdout.log)"
+  fi
+  rm -f "$sentinel"
+}
+
+# ---------------------------------------------------------------------------
+# Test (#2849 HERMETICITY, documented + enforced): every REAL `pgrep -f`
+# invocation in THIS suite scans the whole host process table, so on a dev box
+# concurrently running Claude Code / a gate (cargo|nextest|gate_slot_daemon) it
+# WILL match host processes. Each such line MUST therefore scope its assertion to
+# the test's OWN spawned PID via `grep -qw "$...pid"` on the same line — never
+# assert on a bare match count and never block on a host match. This meta-check
+# fails if a future edit adds an un-PID-scoped real `pgrep -f` command line,
+# re-introducing host contamination.
+# ---------------------------------------------------------------------------
+test_real_pgrep_usages_are_pid_scoped() {
+  local bad="" line
+  # Command lines only (leading whitespace then `pgrep -f`), never prose/comments
+  # (which start with `#`) — assert each pipes into a PID-scoped `grep -qw`.
+  while IFS= read -r line; do
+    [[ "$line" == *'grep -qw'* ]] || bad="${bad}${line}\n"
+  done < <(grep -E '^[[:space:]]*pgrep -f ' "${BASH_SOURCE[0]}")
+  if [[ -z "$bad" ]]; then
+    pass "#2849: all real pgrep -f usages are PID-scoped (grep -qw \$pid) — hermetic vs host processes"
+  else
+    fail "#2849: un-PID-scoped real pgrep -f line(s) can match host processes:\n$(printf '%b' "$bad")"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 echo "=== worker-supervisor test suite ==="
@@ -2621,5 +2693,7 @@ test_grace_cap_disabled_semantics
 test_mid_grace_stop_is_aborted
 test_default_worker_cmd_is_headless
 test_healthy_worker_iterlog_nonempty
+test_claim_cmd_empty_truly_disables_no_network
+test_real_pgrep_usages_are_pid_scoped
 echo "=== $PASS_COUNT passed, $FAIL_COUNT failed, $SKIP_COUNT skipped ==="
 [[ "$FAIL_COUNT" -eq 0 ]]


### PR DESCRIPTION
Closes #2849.

**Root cause:** `scripts/local/worker-supervisor.sh` resolved `CLAIM_CMD="${CLAIM_CMD:-...}"` (colon form). The `:-` operator substitutes the default when the var is unset **OR empty**, so the tooling-tests' documented `export CLAIM_CMD=""` (meant to disable claim stamping) was silently re-defaulted to the real `claim-heartbeat.sh` — whose `git push` / `gh pr list` **network calls wedged non-deterministically**, hanging `test_worker_supervisor.sh` and therefore the whole `tooling-tests` gate component. This is why the full local gate of record hung on this box while CI (which doesn't hit the same path timing) stayed green.

**Fix:** `${CLAIM_CMD:-...}` → `${CLAIM_CMD-...}` (colonless) so an explicit empty string truly disables (no network), while **production (CLAIM_CMD unset) still gets the default** claim-heartbeat command. Verified against the callers: `stamp`/`reap` already guard `[[ -n "$CLAIM_CMD" ]] || return 0`.

**Regression tests added** (`scripts/tests/test_worker_supervisor.sh`):
- `test_claim_cmd_empty_truly_disables_no_network` — pins the fix (empty CLAIM_CMD ⇒ zero claim calls, bounded run).
- `test_real_pgrep_usages_are_pid_scoped` — enforces every real `pgrep -f` in the suite is PID-scoped (hermetic vs a host `claude`/`cargo`/`nextest`/`gate_slot_daemon` — the dev-machine crossover class).

**Verification:** `test_worker_supervisor.sh` 59/59 standalone with a live Claude Code session; `agent-gate.sh --only tooling-tests` COMPLETES + PASS (265s) — the exact component that was hanging; `--lite` PASS @ `51426c83d`.

Strategic follow-up: #2857 (evaluate containerizing the gate to kill this crossover class by construction). Note: touches an over-threshold test file (#1135 split is out of scope for a bug fix) — full gate run with `CQLITE_ALLOW_FILE_GROWTH=1` if the ratchet flags it.