### PR TITLE
build(#2856): bump pinned Rust toolchain 1.88.0 → 1.97.1 + lockstep sweep

### DIFF
--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -5,7 +5,7 @@ inputs:
   toolchain:
     description: Rust toolchain channel or pinned version to install.
     required: false
-    default: 1.88.0
+    default: 1.97.1
   components:
     description: Comma-separated rustup components to install, such as clippy,rustfmt.
     required: false

--- a/.github/workflows/cassandra-parity.yml
+++ b/.github/workflows/cassandra-parity.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v5
 
       # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
-      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.88.0
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.97.1
       # action performs a rustup reconcile that can intermittently try to
       # (re)install the 'clippy-preview' component and fail with
       # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
@@ -92,7 +92,7 @@ jobs:
         run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -219,7 +219,7 @@ jobs:
         run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache cargo
         uses: actions/cache@v5

--- a/.github/workflows/cassandra-validation.yml
+++ b/.github/workflows/cassandra-validation.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # Consolidated caching (issue #2649): shared composite keyed on
-        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.97.1).
         uses: ./.github/actions/setup-rust-ci
         with:
           cache-key: cassandra-validation

--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # Consolidated caching (issue #2649): shared composite keyed on
-        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.97.1).
         # cargo builds from cqlite-core/ still write the workspace-root target/,
         # so the composite's root-level cache is correct for these lanes.
         uses: ./.github/actions/setup-rust-ci
@@ -66,7 +66,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # Consolidated caching (issue #2649): shared composite keyed on
-        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.97.1).
         # cargo builds from cqlite-core/ still write the workspace-root target/,
         # so the composite's root-level cache is correct for these lanes.
         uses: ./.github/actions/setup-rust-ci
@@ -99,7 +99,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # Consolidated caching (issue #2649): shared composite keyed on
-        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.97.1).
         # cargo builds from cqlite-core/ still write the workspace-root target/,
         # so the composite's root-level cache is correct for these lanes.
         uses: ./.github/actions/setup-rust-ci
@@ -126,7 +126,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # Consolidated caching (issue #2649): shared composite keyed on
-        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.97.1).
         # cargo builds from cqlite-core/ still write the workspace-root target/,
         # so the composite's root-level cache is correct for these lanes.
         uses: ./.github/actions/setup-rust-ci
@@ -155,7 +155,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # Consolidated caching (issue #2649): shared composite keyed on
-        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.97.1).
         # cargo builds from cqlite-core/ still write the workspace-root target/,
         # so the composite's root-level cache is correct for these lanes.
         uses: ./.github/actions/setup-rust-ci

--- a/.github/workflows/compaction-parity.yml
+++ b/.github/workflows/compaction-parity.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
+        # (pinned 1.97.1) instead of overriding it with stable (issue #1990).
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Cache Rust dependencies

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      # Honor the repo toolchain pin (rust-toolchain.toml = 1.88.0), issue #1990.
+      # Honor the repo toolchain pin (rust-toolchain.toml = 1.97.1), issue #1990.
       # Omitting `toolchain:` makes setup-rust-toolchain read the pin file.
       # `cache: false` so caching is done by the explicit Swatinem step below with a
       # deliberate Cargo.lock-keyed key matching the repo's other rust caches, rather

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,11 +55,11 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     
-    # Pin to the repo toolchain (rust-toolchain.toml = 1.88.0), issue #1990.
+    # Pin to the repo toolchain (rust-toolchain.toml = 1.97.1), issue #1990.
     # dtolnay/rust-toolchain cannot read the pin file, so pin the version ref
     # explicitly (bump alongside rust-toolchain.toml).
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@1.88.0
+      uses: dtolnay/rust-toolchain@1.97.1
       with:
         components: llvm-tools-preview
         
@@ -75,7 +75,7 @@ jobs:
     # Install PREBUILT pinned binaries instead of `cargo install` from source
     # (issue #1990). Source-building cargo-tarpaulin v0.37.0 fails on newer
     # rustc; a prebuilt pinned binary avoids toolchain/edition drift breaking
-    # the install and runs against the pinned 1.88.0 toolchain.
+    # the install and runs against the pinned 1.97.1 toolchain.
     - name: Install tarpaulin (prebuilt, pinned)
       uses: taiki-e/install-action@v2
       with:

--- a/.github/workflows/delta-roundtrip.yml
+++ b/.github/workflows/delta-roundtrip.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache Cargo build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
-      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.88.0
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.97.1
       # action performs a rustup reconcile that can intermittently try to
       # (re)install the 'clippy-preview' component and fail with
       # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
@@ -126,7 +126,7 @@ jobs:
         run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache Cargo registry and build output
         uses: actions/cache@v4

--- a/.github/workflows/e2e-readback.yml
+++ b/.github/workflows/e2e-readback.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # No `toolchain:` input: setup-rust-toolchain reads rust-toolchain.toml
-        # (pinned 1.88.0) instead of overriding it with stable (issue #1990).
+        # (pinned 1.97.1) instead of overriding it with stable (issue #1990).
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Cache Rust dependencies

--- a/.github/workflows/exhaustive-regeneration.yml
+++ b/.github/workflows/exhaustive-regeneration.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/future-rust-canary.yml
+++ b/.github/workflows/future-rust-canary.yml
@@ -3,7 +3,7 @@ name: "Canary: future Rust (latest stable) — advisory"
 # ADVISORY / NON-REQUIRED forward-compatibility canary (issue #1990).
 #
 # Every other product-validation workflow pins the repository toolchain
-# (rust-toolchain.toml = 1.88.0) so CI matches local builds. THIS is the single
+# (rust-toolchain.toml = 1.97.1) so CI matches local builds. THIS is the single
 # deliberate exception: it builds the workspace on the *latest* `stable` rustc to
 # surface forward-incompatibilities (new trait-solver depth limits, deprecations,
 # tightened lints) BEFORE we bump the pin — exactly the class of drift that broke

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -126,11 +126,11 @@ jobs:
       # explicitly rather than the node-ci/python-ci
       # `rustup component remove clippy` normalization (#1217), which is for
       # build-only lanes that must NOT reinstall clippy-preview. Pinned to
-      # rust-toolchain.toml (1.88.0) via the @1.88.0 ref so the nightly deep
+      # rust-toolchain.toml (1.97.1) via the @1.97.1 ref so the nightly deep
       # gate matches how the gate runs locally instead of tracking latest
       # stable (issue #1990; dtolnay/rust-toolchain cannot read the pin file).
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/live-cell-compaction-parity.yml
+++ b/.github/workflows/live-cell-compaction-parity.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache Cargo build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/nightly-docker-parity.yml
+++ b/.github/workflows/nightly-docker-parity.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-rust-ci
         with:
-          toolchain: 1.88.0
+          toolchain: 1.97.1
           components: ''
           cache-key: nightly-docker-parity
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache-dependency-path: bindings/node/package-lock.json
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -115,7 +115,7 @@ jobs:
           cache-dependency-path: bindings/node/package-lock.json
 
       # Issue #1209: GitHub runner images ship a stable toolchain that already
-      # provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.88.0 action is
+      # provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.97.1 action is
       # invoked with `targets:`, so it performs a rustup reconcile that can
       # intermittently try to (re)install the 'clippy-preview' component and
       # fail with "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
@@ -129,7 +129,7 @@ jobs:
         run: rustup component remove clippy 2>/dev/null || true
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/observability-gate.yml
+++ b/.github/workflows/observability-gate.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Setup Rust toolchain
         # Consolidated caching (issue #2649): shared composite keyed on
-        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.88.0).
+        # Cargo.lock+toolchain, defaulting to the rust-toolchain.toml pin (1.97.1).
         uses: ./.github/actions/setup-rust-ci
         with:
           cache-key: observability-gate

--- a/.github/workflows/parity-regen-matrix.yml
+++ b/.github/workflows/parity-regen-matrix.yml
@@ -283,7 +283,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
-      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.88.0
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.97.1
       # action performs a rustup reconcile that can intermittently try to
       # (re)install the 'clippy-preview' component and fail with a
       # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting component
@@ -294,7 +294,7 @@ jobs:
         run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache Cargo build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v5
 
       # Issue #1209: GitHub runner images ship a stable toolchain that already
-      # provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.88.0 action is
+      # provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.97.1 action is
       # invoked with `targets:`, so it performs a rustup reconcile that can
       # intermittently try to (re)install the 'clippy-preview' component and
       # fail with "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
@@ -118,7 +118,7 @@ jobs:
         run: rustup component remove clippy 2>/dev/null || true
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
         with:
           targets: ${{ matrix.target }}
 
@@ -197,7 +197,7 @@ jobs:
         uses: actions/checkout@v5
 
       # Issue #1209: GitHub runner images ship a stable toolchain that already
-      # provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.88.0 action is
+      # provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.97.1 action is
       # invoked with `targets:`, so it performs a rustup reconcile that can
       # intermittently try to (re)install the 'clippy-preview' component and
       # fail with "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
@@ -211,7 +211,7 @@ jobs:
         run: rustup component remove clippy 2>/dev/null || true
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0  # pinned to rust-toolchain.toml (issue #1990)
+        uses: dtolnay/rust-toolchain@1.97.1  # pinned to rust-toolchain.toml (issue #1990)
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v5
 
       # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
-      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.88.0
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@1.97.1
       # action performs a rustup reconcile that can intermittently try to
       # (re)install the 'clippy-preview' component and fail with
       # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting

--- a/.github/workflows/soak-resource-leak.yml
+++ b/.github/workflows/soak-resource-leak.yml
@@ -37,11 +37,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Pin to the repo toolchain (rust-toolchain.toml = 1.88.0), issue #1990.
+      # Pin to the repo toolchain (rust-toolchain.toml = 1.97.1), issue #1990.
       # dtolnay/rust-toolchain cannot read the pin file, so pin the version ref
       # explicitly (bump alongside rust-toolchain.toml).
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Cache dependencies
         uses: actions/cache@v5

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Setup Rust toolchain
         if: steps.scope.outputs.run_smoke == 'true'
-        # No `toolchain:` input: setup-rust-ci defaults to the pinned 1.88.0
+        # No `toolchain:` input: setup-rust-ci defaults to the pinned 1.97.1
         # (matches rust-toolchain.toml) instead of stable (issue #1990).
         uses: ./.github/actions/setup-rust-ci
         with:
@@ -296,7 +296,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Rust toolchain
-        # No `toolchain:` input: setup-rust-ci defaults to the pinned 1.88.0
+        # No `toolchain:` input: setup-rust-ci defaults to the pinned 1.97.1
         # (matches rust-toolchain.toml) instead of stable (issue #1990).
         uses: ./.github/actions/setup-rust-ci
         with:

--- a/cqlite-cli/src/lib.rs
+++ b/cqlite-cli/src/lib.rs
@@ -14,7 +14,7 @@
 // tui::events::run_tui<B>()}`"). It is a large async event loop, not a genuine
 // type-recursion bug, so a benign limit bump is the correct fix (a source
 // refactor would split that async fn into smaller awaited helpers — out of
-// scope here). Compiles on every supported toolchain (1.88.0 pin and forward)
+// scope here). Compiles on every supported toolchain (the pin and forward)
 // and does not change runtime behavior.
 #![recursion_limit = "256"]
 

--- a/cqlite-core/src/parser/benchmarks.rs
+++ b/cqlite-core/src/parser/benchmarks.rs
@@ -225,11 +225,7 @@ impl ParserBenchmarks {
             }
         }
 
-        let iterations = if sample_size > 0 {
-            self.target_file_size / sample_size
-        } else {
-            1000
-        };
+        let iterations = self.target_file_size.checked_div(sample_size).unwrap_or(1000);
 
         for _ in 0..self.iterations {
             let start = Instant::now();

--- a/cqlite-core/src/parser/benchmarks.rs
+++ b/cqlite-core/src/parser/benchmarks.rs
@@ -225,7 +225,10 @@ impl ParserBenchmarks {
             }
         }
 
-        let iterations = self.target_file_size.checked_div(sample_size).unwrap_or(1000);
+        let iterations = self
+            .target_file_size
+            .checked_div(sample_size)
+            .unwrap_or(1000);
 
         for _ in 0..self.iterations {
             let start = Instant::now();

--- a/cqlite-core/src/parser/collection_tests.rs
+++ b/cqlite-core/src/parser/collection_tests.rs
@@ -665,7 +665,7 @@ mod edge_case_tests {
                 assert_eq!(inner1[0], Value::Integer(1));
                 assert_eq!(inner1[1], Value::Integer(2));
             } else {
-                panic!("Expected inner list at index 0, got: {:?}", &outer_list[0]);
+                panic!("Expected inner list at index 0, got: {:?}", outer_list[0]);
             }
 
             // Check second inner list

--- a/cqlite-core/src/query/engine_stats.rs
+++ b/cqlite-core/src/query/engine_stats.rs
@@ -78,7 +78,7 @@ impl AtomicQueryStats {
             (0, 0.0)
         } else {
             (
-                exec_time_us_sum / total_queries,
+                exec_time_us_sum.checked_div(total_queries).unwrap_or(0),
                 // Clamp the numerator: `total_queries` and `cache_hits` are
                 // read as independent `Relaxed` atomics, so a concurrent
                 // snapshot could observe `cache_hits > total_queries` and yield

--- a/cqlite-core/src/query/select_executor/value_ops.rs
+++ b/cqlite-core/src/query/select_executor/value_ops.rs
@@ -521,7 +521,7 @@ mod tests {
     /// `[-Inf, -0.0, +0.0, 1.0, +Inf, NaN, NaN]`.
     #[test]
     fn order_by_double_sort_matches_oracle() {
-        let mut v = vec![
+        let mut v = [
             Value::Float(1.0),
             Value::Float(f64::NAN),
             Value::Float(-0.0),

--- a/cqlite-core/src/query/select_parser.rs
+++ b/cqlite-core/src/query/select_parser.rs
@@ -1469,7 +1469,7 @@ mod tests {
             if let SelectExpression::Literal(Value::BigInt(1)) = &exprs[0] {
                 // Success
             } else {
-                panic!("Expected literal BigInt 1, got: {:?}", &exprs[0]);
+                panic!("Expected literal BigInt 1, got: {:?}", exprs[0]);
             }
         } else {
             panic!("Expected Columns in SELECT clause");

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -537,7 +537,7 @@ impl SchemaRegistry {
         let schemas = self.schemas.read().await;
         let mut results = Vec::new();
 
-        for (_table_id, entry) in schemas.iter() {
+        for entry in schemas.values() {
             // Apply query filters if provided
             if let Some(ref q) = query {
                 if !self.matches_query(&entry.schema, q) {
@@ -893,7 +893,7 @@ impl SchemaRegistry {
         let mut schema_infos = Vec::new();
 
         // Get all schemas in the keyspace
-        for (_table_id, entry) in self.schemas.read().await.iter() {
+        for entry in self.schemas.read().await.values() {
             if entry.schema.keyspace == keyspace {
                 // Try to get extended schema info
                 if let Ok(Some(schema_info)) = self

--- a/cqlite-core/src/storage/sstable/directory/scan.rs
+++ b/cqlite-core/src/storage/sstable/directory/scan.rs
@@ -94,7 +94,7 @@ pub(crate) fn scan_sstable_files(path: &Path, table_name: &str) -> Result<Vec<SS
 
     // Sort generations by number (newest first)
     let mut generations: Vec<SSTableGeneration> = generations_map.into_values().collect();
-    generations.sort_by(|a, b| b.generation.cmp(&a.generation));
+    generations.sort_by_key(|b| std::cmp::Reverse(b.generation));
 
     // Log summary for debugging
     tracing::debug!(

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -338,7 +338,7 @@ pub(super) async fn seek_merge_generations_for_read(
     // NEWEST→OLDEST like `ordered_generation_paths`, so the seeking merger's
     // run_index (= position) equals the full-scan merger's LWW tie-break rank.
     let mut ordered: Vec<Arc<reader::SSTableReader>> = candidates.to_vec();
-    ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
+    ordered.sort_by_key(|b| std::cmp::Reverse(b.generation));
 
     let schema = schema.clone();
     let target_bytes = target_key.as_bytes().to_vec();
@@ -675,7 +675,7 @@ pub(super) async fn stream_generations_for_read(
 /// explicitly by generation descending and collect the input `Data.db` paths.
 fn ordered_generation_paths(reader_list: &[Arc<reader::SSTableReader>]) -> Vec<PathBuf> {
     let mut ordered: Vec<&Arc<reader::SSTableReader>> = reader_list.iter().collect();
-    ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
+    ordered.sort_by_key(|b| std::cmp::Reverse(b.generation));
     ordered.iter().map(|r| r.file_path()).collect()
 }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -509,9 +509,9 @@ impl SSTableReader {
                 let mut values: Vec<crate::types::Value> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck in &schema.clustering_keys {
-                    match simple.iter().find(|c| c.column == ck.name) {
-                        Some(cell) => values.push(cell.value.clone()),
-                        None => return None,
+                    {
+                        let cell = simple.iter().find(|c| c.column == ck.name)?;
+                        values.push(cell.value.clone())
                     }
                 }
                 Some(values)

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -509,8 +509,8 @@ impl SSTableReader {
                 let mut values: Vec<crate::types::Value> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck in &schema.clustering_keys {
-                    // A missing clustering column means no valid key — fall into the
-                    // `None` (unclustered-row) bucket via `?`.
+                    // Any missing clustering column ⇒ the WHOLE key is discarded (the `?`
+                    // returns `None`, treating the row as unclustered).
                     let cell = simple.iter().find(|c| c.column == ck.name)?;
                     values.push(cell.value.clone());
                 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -509,10 +509,10 @@ impl SSTableReader {
                 let mut values: Vec<crate::types::Value> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck in &schema.clustering_keys {
-                    {
-                        let cell = simple.iter().find(|c| c.column == ck.name)?;
-                        values.push(cell.value.clone())
-                    }
+                    // A missing clustering column means no valid key — fall into the
+                    // `None` (unclustered-row) bucket via `?`.
+                    let cell = simple.iter().find(|c| c.column == ck.name)?;
+                    values.push(cell.value.clone());
                 }
                 Some(values)
             }

--- a/cqlite-core/src/storage/sstable/reader/parsing/key_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/key_parsing.rs
@@ -139,7 +139,8 @@ pub(crate) fn decode_key_component_impl(
         }
         // Validate UTF-8 for text keys. Keep this as an explicit arm (NOT a collapsed
         // match guard) so the text-validation branch stays distinct from the `_` accept-as-is
-        // fallthrough — the type-dispatch boundary must remain structural (#2856).
+        // fallthrough — the type-dispatch boundary must remain structural (#2856). The
+        // `collapsible_match` rewrite into a guard would reroute valid Text keys through `_`.
         #[allow(clippy::collapsible_match)]
         ComparatorType::Text => {
             if std::str::from_utf8(component_data).is_err() {

--- a/cqlite-core/src/storage/sstable/reader/parsing/key_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/key_parsing.rs
@@ -137,12 +137,11 @@ pub(crate) fn decode_key_component_impl(
                 return Err(Error::corruption("Invalid BigInt key component length"));
             }
         }
-        ComparatorType::Text => {
+        ComparatorType::Text
             // Validate UTF-8 for text keys
-            if std::str::from_utf8(component_data).is_err() {
+            if std::str::from_utf8(component_data).is_err() => {
                 return Err(Error::corruption("Invalid UTF-8 in text key component"));
             }
-        }
         _ => {
             // For other types, accept as-is for now
         }

--- a/cqlite-core/src/storage/sstable/reader/parsing/key_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/key_parsing.rs
@@ -137,11 +137,15 @@ pub(crate) fn decode_key_component_impl(
                 return Err(Error::corruption("Invalid BigInt key component length"));
             }
         }
-        ComparatorType::Text
-            // Validate UTF-8 for text keys
-            if std::str::from_utf8(component_data).is_err() => {
+        // Validate UTF-8 for text keys. Keep this as an explicit arm (NOT a collapsed
+        // match guard) so the text-validation branch stays distinct from the `_` accept-as-is
+        // fallthrough — the type-dispatch boundary must remain structural (#2856).
+        #[allow(clippy::collapsible_match)]
+        ComparatorType::Text => {
+            if std::str::from_utf8(component_data).is_err() {
                 return Err(Error::corruption("Invalid UTF-8 in text key component"));
             }
+        }
         _ => {
             // For other types, accept as-is for now
         }

--- a/cqlite-core/src/storage/sstable/row_cell_state_machine.rs
+++ b/cqlite-core/src/storage/sstable/row_cell_state_machine.rs
@@ -1325,12 +1325,13 @@ impl RowCellStateMachine {
             | CassandraVersion::V5_0TypedCollections
             | CassandraVersion::V5_0WideRows
             | CassandraVersion::V5_0FormatG
-                if self.schema.is_none() => {
-                    return Err(Error::Schema(format!(
+                if self.schema.is_none() =>
+            {
+                return Err(Error::Schema(format!(
                         "Blob fallback not allowed for static row parsing in modern format {:?}. Schema is required.",
                         self.version
                     )));
-                }
+            }
             _ => {
                 // Legacy formats need schema when legacy-heuristics feature is disabled
                 #[cfg(not(feature = "legacy-heuristics"))]

--- a/cqlite-core/src/storage/sstable/row_cell_state_machine.rs
+++ b/cqlite-core/src/storage/sstable/row_cell_state_machine.rs
@@ -264,7 +264,8 @@ impl RowCellStateMachine {
         match self.version {
             // Keep this as an explicit modern-format arm (NOT a collapsed match guard):
             // the no-heuristics boundary — "modern formats reject blob fallback" — must stay
-            // structurally distinct from the legacy `_` arm below (#28, #2856).
+            // structurally distinct from the legacy `_` arm below (#28, #2856). The
+            // `collapsible_match` rewrite into a guard would reroute modern+schema through `_`.
             #[allow(clippy::collapsible_match)]
             CassandraVersion::V5_0NewBig
             | CassandraVersion::V5_0Bti
@@ -1324,7 +1325,8 @@ impl RowCellStateMachine {
         match self.version {
             // Explicit modern-format arm (NOT a collapsed match guard): the no-heuristics
             // boundary — modern static-row parsing rejects blob fallback — must stay
-            // structurally distinct from the legacy `_` arm below (#28, #2856).
+            // structurally distinct from the legacy `_` arm below (#28, #2856). The
+            // `collapsible_match` rewrite into a guard would reroute modern+schema through `_`.
             #[allow(clippy::collapsible_match)]
             CassandraVersion::V5_0NewBig
             | CassandraVersion::V5_0Bti
@@ -1648,5 +1650,79 @@ mod tests {
             header.local_deletion_time.is_none(),
             "header with no local_deletion_time is not a row tombstone"
         );
+    }
+
+    // ---- No-heuristics boundary regression tests (#28 / #2856) ----
+    //
+    // Pin the modern-format arms in `process` and `parse_static_row_impl` as an
+    // explicit branch, structurally distinct from the legacy `_` arm: a modern
+    // version with no schema is rejected (blob fallback disabled), and with a schema
+    // it proceeds WITHOUT falling through to the legacy path.
+
+    fn empty_modern_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "ks".to_string(),
+            table: "t".to_string(),
+            partition_keys: vec![],
+            clustering_keys: vec![],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn modern_process_without_schema_rejects_blob_fallback() {
+        let mut sm = RowCellStateMachine::with_version(CassandraVersion::V5_0NewBig);
+        match sm.process(&[0x01]) {
+            Err(Error::Schema(msg)) => assert!(
+                msg.contains("Schema is required for modern format"),
+                "expected modern-format schema-required error, got: {msg}"
+            ),
+            other => {
+                panic!("modern format without schema must return Error::Schema, got: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn modern_process_with_schema_proceeds_past_boundary() {
+        let mut sm = RowCellStateMachine::with_schema_and_version(
+            empty_modern_schema(),
+            ComparatorType::Blob,
+            CassandraVersion::V5_0NewBig,
+        );
+        // Schema present ⇒ the modern arm's `if schema.is_none()` is false, so the match
+        // falls through to the byte loop (NOT the legacy `_` arm); empty input consumes
+        // nothing and returns Ok(0). This proves modern+schema never takes the legacy path.
+        assert_eq!(sm.process(&[]).unwrap(), 0);
+    }
+
+    #[test]
+    fn modern_static_row_without_schema_rejects_blob_fallback() {
+        let mut sm = RowCellStateMachine::with_version(CassandraVersion::V5_0NewBig);
+        // Flag byte 0x40 sets the static-row-present bit so parsing reaches the
+        // schema-boundary match (a byte without 0x40 short-circuits to Ok before it).
+        match sm.parse_static_row(&[0x40, 0x00]) {
+            Err(Error::Schema(msg)) => assert!(
+                msg.contains("Blob fallback not allowed for static row parsing"),
+                "expected static-row modern-format schema-required error, got: {msg}"
+            ),
+            other => {
+                panic!("modern static row without schema must return Error::Schema, got: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn modern_static_row_with_schema_proceeds_past_boundary() {
+        let mut sm = RowCellStateMachine::with_schema_and_version(
+            empty_modern_schema(),
+            ComparatorType::Blob,
+            CassandraVersion::V5_0NewBig,
+        );
+        // Flag 0x40 (static row present) + VInt 0x00 (zero static columns); schema present
+        // ⇒ the modern arm proceeds (no legacy path) and parses an empty static row.
+        assert!(sm.parse_static_row(&[0x40, 0x00]).is_ok());
     }
 }

--- a/cqlite-core/src/storage/sstable/row_cell_state_machine.rs
+++ b/cqlite-core/src/storage/sstable/row_cell_state_machine.rs
@@ -262,6 +262,10 @@ impl RowCellStateMachine {
         // For modern formats, ensure schema is available before processing
         // Only enforce schema requirements for explicitly identified modern formats
         match self.version {
+            // Keep this as an explicit modern-format arm (NOT a collapsed match guard):
+            // the no-heuristics boundary — "modern formats reject blob fallback" — must stay
+            // structurally distinct from the legacy `_` arm below (#28, #2856).
+            #[allow(clippy::collapsible_match)]
             CassandraVersion::V5_0NewBig
             | CassandraVersion::V5_0Bti
             | CassandraVersion::V5_0NewBigFormat
@@ -269,14 +273,15 @@ impl RowCellStateMachine {
             | CassandraVersion::V5_0ComplexTypes
             | CassandraVersion::V5_0TypedCollections
             | CassandraVersion::V5_0WideRows
-            | CassandraVersion::V5_0FormatG
+            | CassandraVersion::V5_0FormatG => {
                 // Modern formats always require schema
-                if self.schema.is_none() => {
+                if self.schema.is_none() {
                     return Err(Error::Schema(format!(
                         "Schema is required for modern format {:?}. Blob fallback is disabled for modern format.",
                         self.version
                     )));
                 }
+            }
             _ => {
                 // For legacy formats and unspecified versions, be more permissive
                 // Only require schema if legacy-heuristics feature is explicitly disabled
@@ -1317,6 +1322,10 @@ impl RowCellStateMachine {
         // For modern formats, check if we have schema before attempting to parse static columns
         // This prevents blob fallback for unknown columns in modern formats
         match self.version {
+            // Explicit modern-format arm (NOT a collapsed match guard): the no-heuristics
+            // boundary — modern static-row parsing rejects blob fallback — must stay
+            // structurally distinct from the legacy `_` arm below (#28, #2856).
+            #[allow(clippy::collapsible_match)]
             CassandraVersion::V5_0NewBig
             | CassandraVersion::V5_0Bti
             | CassandraVersion::V5_0NewBigFormat
@@ -1324,13 +1333,13 @@ impl RowCellStateMachine {
             | CassandraVersion::V5_0ComplexTypes
             | CassandraVersion::V5_0TypedCollections
             | CassandraVersion::V5_0WideRows
-            | CassandraVersion::V5_0FormatG
-                if self.schema.is_none() =>
-            {
-                return Err(Error::Schema(format!(
+            | CassandraVersion::V5_0FormatG => {
+                if self.schema.is_none() {
+                    return Err(Error::Schema(format!(
                         "Blob fallback not allowed for static row parsing in modern format {:?}. Schema is required.",
                         self.version
                     )));
+                }
             }
             _ => {
                 // Legacy formats need schema when legacy-heuristics feature is disabled

--- a/cqlite-core/src/storage/sstable/row_cell_state_machine.rs
+++ b/cqlite-core/src/storage/sstable/row_cell_state_machine.rs
@@ -269,15 +269,14 @@ impl RowCellStateMachine {
             | CassandraVersion::V5_0ComplexTypes
             | CassandraVersion::V5_0TypedCollections
             | CassandraVersion::V5_0WideRows
-            | CassandraVersion::V5_0FormatG => {
+            | CassandraVersion::V5_0FormatG
                 // Modern formats always require schema
-                if self.schema.is_none() {
+                if self.schema.is_none() => {
                     return Err(Error::Schema(format!(
                         "Schema is required for modern format {:?}. Blob fallback is disabled for modern format.",
                         self.version
                     )));
                 }
-            }
             _ => {
                 // For legacy formats and unspecified versions, be more permissive
                 // Only require schema if legacy-heuristics feature is explicitly disabled
@@ -1325,14 +1324,13 @@ impl RowCellStateMachine {
             | CassandraVersion::V5_0ComplexTypes
             | CassandraVersion::V5_0TypedCollections
             | CassandraVersion::V5_0WideRows
-            | CassandraVersion::V5_0FormatG => {
-                if self.schema.is_none() {
+            | CassandraVersion::V5_0FormatG
+                if self.schema.is_none() => {
                     return Err(Error::Schema(format!(
                         "Blob fallback not allowed for static row parsing in modern format {:?}. Schema is required.",
                         self.version
                     )));
                 }
-            }
             _ => {
                 // Legacy formats need schema when legacy-heuristics feature is disabled
                 #[cfg(not(feature = "legacy-heuristics"))]

--- a/cqlite-core/src/storage/sstable/tombstone_merger.rs
+++ b/cqlite-core/src/storage/sstable/tombstone_merger.rs
@@ -359,7 +359,7 @@ impl TombstoneMerger {
     ) -> Result<Option<ScanRow>> {
         // Sort by write time (newest first)
         let mut sorted_entries = collection_entries;
-        sorted_entries.sort_by(|a, b| b.metadata.write_time.cmp(&a.metadata.write_time));
+        sorted_entries.sort_by_key(|b| std::cmp::Reverse(b.metadata.write_time));
 
         // Issue #1334: generations now carry whole rows (`ScanRow`), not bare
         // collection values, so reconciliation reduces to last-write-wins with

--- a/cqlite-core/src/storage/sstable/verify.rs
+++ b/cqlite-core/src/storage/sstable/verify.rs
@@ -2667,7 +2667,7 @@ mod tests {
         // base-name derivation accepts must resolve to the SAME base name the
         // reader uses for sibling lookup — never an Err (issue #1283, roborev).
         let p = PathBuf::from("/dir/nb-7-big-Statistics.db");
-        let set = build_component_set(&[p.clone()], p.clone())
+        let set = build_component_set(std::slice::from_ref(&p), p.clone())
             .expect("reader-accepted non-Data.db name must not error");
         assert_eq!(
             Some(set.base_name),
@@ -2690,7 +2690,8 @@ mod tests {
     #[test]
     fn build_component_set_standard_name_still_resolves_canonically() {
         let p = PathBuf::from("/dir/nb-3-big-Data.db");
-        let set = build_component_set(&[p.clone()], p).expect("standard name resolves");
+        let set = build_component_set(std::slice::from_ref(&p), p.clone())
+            .expect("standard name resolves");
         assert_eq!(set.base_name, "nb-3-big");
     }
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/incremental_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/incremental_partition.rs
@@ -171,7 +171,7 @@ fn incremental_matches_whole_slice_for_static_and_regular_rows() {
     // Incremental path resolves statics upfront (matching compaction's own
     // guarantee that the static carrier is a single, already-reconciled
     // entry — stage 5c-iv's design note).
-    let static_ops = resolve_static_ops(&[static_m.clone()], &schema, None);
+    let static_ops = resolve_static_ops(std::slice::from_ref(&static_m), &schema, None);
     let (new_bytes, new_offset, new_blocks, new_emit) = run_incremental(
         &schema,
         &key,
@@ -425,7 +425,11 @@ fn incremental_matches_whole_slice_for_combined_static_tombstones_and_rows() {
     let (old_bytes, old_offset, old_blocks, old_emit) =
         run_whole_slice(&schema, &key, &all_mutations, Some(&pt), &range_tombstones);
 
-    let static_ops = resolve_static_ops(&[static_m.clone()], &schema, Some(pt.deletion_time));
+    let static_ops = resolve_static_ops(
+        std::slice::from_ref(&static_m),
+        &schema,
+        Some(pt.deletion_time),
+    );
     let (new_bytes, new_offset, new_blocks, new_emit) = run_incremental(
         &schema,
         &key,

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/streaming_partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/streaming_partition.rs
@@ -210,7 +210,7 @@ fn streaming_matches_whole_slice_for_static_and_regular_rows() {
     let (old_bytes, old_offset, old_blocks, old_emit) =
         run_whole_slice(&schema, &key, &all_mutations, None, &[]);
 
-    let static_ops = resolve_static_ops(&[static_m.clone()], &schema, None);
+    let static_ops = resolve_static_ops(std::slice::from_ref(&static_m), &schema, None);
     let (new_bytes, new_offset, new_blocks, new_emit) = run_streaming(
         &schema,
         &key,
@@ -444,7 +444,11 @@ fn streaming_split_mid_partition_matches_unbroken_batch_for_static_and_tombstone
         local_deletion_time: 250,
     };
     let range_tombstones = vec![rt];
-    let static_ops = resolve_static_ops(&[static_m.clone()], &schema, Some(pt.deletion_time));
+    let static_ops = resolve_static_ops(
+        std::slice::from_ref(&static_m),
+        &schema,
+        Some(pt.deletion_time),
+    );
 
     let (unbroken_bytes, unbroken_offset, unbroken_blocks, unbroken_emit) = run_streaming(
         &schema,

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
@@ -237,7 +237,7 @@ impl PartitionsTrieWriter {
         // this is typically a no-op — but sorting defensively guarantees a valid
         // trie regardless of caller ordering and rejects duplicate keys.
         let mut entries = self.entries;
-        entries.sort_by(|a, b| a.key.cmp(&b.key));
+        entries.sort_by_key(|a| a.key);
         for w in entries.windows(2) {
             if w[0].key == w[1].key {
                 return Err(Error::InvalidInput(

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer_tests.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer_tests.rs
@@ -239,7 +239,7 @@ fn boundary_raw_keys_match_sorted_first_last() {
         .iter()
         .map(|r| (encode_partition_key_for_bti_trie(r), r.clone()))
         .collect();
-    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    sorted.sort_by_key(|a| a.0);
     let expect_first = sorted.first().map(|(_, r)| r.clone()).unwrap();
     let expect_last = sorted.last().map(|(_, r)| r.clone()).unwrap();
 
@@ -292,7 +292,7 @@ fn entry_for(key: [u8; 9], hash_byte: u8, offset: u64) -> PartitionTrieEntry {
 /// Sort + de-duplicate exactly as [`PartitionsTrieWriter::finish`] does
 /// before emitting.
 fn sorted_unique(mut entries: Vec<PartitionTrieEntry>) -> Vec<PartitionTrieEntry> {
-    entries.sort_by(|a, b| a.key.cmp(&b.key));
+    entries.sort_by_key(|a| a.key);
     entries.dedup_by(|a, b| a.key == b.key);
     entries
 }

--- a/cqlite-core/src/storage/write_engine/merge/from_readers.rs
+++ b/cqlite-core/src/storage/write_engine/merge/from_readers.rs
@@ -667,7 +667,7 @@ mod tests {
 
         let path_based = super::super::build_single_partition_merger(
             paths.clone(),
-            &[key_bytes.clone()],
+            std::slice::from_ref(&key_bytes),
             &schema,
             ScanCancel::default(),
         )

--- a/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
+++ b/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
@@ -378,7 +378,7 @@ mod tests {
         let cand = write_expiry_stats(tmp.path(), 1, 500, 10_000, 5_000);
         std::fs::remove_file(&cand).expect("remove Data.db to prove no read");
 
-        let dropped = fully_expired_sstables(&[cand.clone()], &[], Some(1_000));
+        let dropped = fully_expired_sstables(std::slice::from_ref(&cand), &[], Some(1_000));
         assert_eq!(
             dropped,
             vec![cand],
@@ -443,7 +443,7 @@ mod tests {
         let cand = write_expiry_stats(tmp.path(), 1, 500, 4_000, 1_000);
         // Outside min write ts (5_000) > candidate max_timestamp (4_000) ⇒ drop.
         let outside = write_expiry_stats(tmp.path(), 2, i32::MAX, 20_000, 5_000);
-        let dropped = fully_expired_sstables(&[cand.clone()], &[outside], Some(1_000));
+        let dropped = fully_expired_sstables(std::slice::from_ref(&cand), &[outside], Some(1_000));
         assert_eq!(
             dropped,
             vec![cand],
@@ -620,7 +620,7 @@ mod tests {
 
         // Core surface: `b` is the retained merge input (already deleted) ⇒ only `a`.
         let mut core_deleted = Vec::new();
-        reclaim_dropped_whole(&dropped_whole, &[b.clone()], |p| {
+        reclaim_dropped_whole(&dropped_whole, std::slice::from_ref(&b), |p| {
             core_deleted.push(p.to_path_buf())
         });
         assert_eq!(

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -939,15 +939,12 @@ impl SSTableRowIteratorAdapter {
                 let mut ck_columns: Vec<(String, Value)> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck_col in &schema.clustering_keys {
-                    match simple
+                    {
+                        let pair = simple
                         .iter()
                         .find(|c| c.column == ck_col.name)
-                        .map(|c| (ck_col.name.clone(), c.value.clone()))
-                    {
-                        Some(pair) => ck_columns.push(pair),
-                        // A missing clustering column means we cannot form a valid
-                        // key — fall into the `None` bucket (unclustered row).
-                        None => return None,
+                        .map(|c| (ck_col.name.clone(), c.value.clone()))?;
+                        ck_columns.push(pair)
                     }
                 }
                 Some(ClusteringKey {
@@ -967,13 +964,12 @@ impl SSTableRowIteratorAdapter {
                 let mut ck_columns: Vec<(String, Value)> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck_col in &schema.clustering_keys {
-                    match clustering
+                    {
+                        let pair = clustering
                         .iter()
                         .find(|(name, _)| name == &ck_col.name)
-                        .map(|(name, v)| (name.clone(), v.clone()))
-                    {
-                        Some(pair) => ck_columns.push(pair),
-                        None => return None,
+                        .map(|(name, v)| (name.clone(), v.clone()))?;
+                        ck_columns.push(pair)
                     }
                 }
                 Some(ClusteringKey {

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -941,9 +941,9 @@ impl SSTableRowIteratorAdapter {
                 for ck_col in &schema.clustering_keys {
                     {
                         let pair = simple
-                        .iter()
-                        .find(|c| c.column == ck_col.name)
-                        .map(|c| (ck_col.name.clone(), c.value.clone()))?;
+                            .iter()
+                            .find(|c| c.column == ck_col.name)
+                            .map(|c| (ck_col.name.clone(), c.value.clone()))?;
                         ck_columns.push(pair)
                     }
                 }
@@ -966,9 +966,9 @@ impl SSTableRowIteratorAdapter {
                 for ck_col in &schema.clustering_keys {
                     {
                         let pair = clustering
-                        .iter()
-                        .find(|(name, _)| name == &ck_col.name)
-                        .map(|(name, v)| (name.clone(), v.clone()))?;
+                            .iter()
+                            .find(|(name, _)| name == &ck_col.name)
+                            .map(|(name, v)| (name.clone(), v.clone()))?;
                         ck_columns.push(pair)
                     }
                 }
@@ -6329,7 +6329,7 @@ mod tests {
             .write(&StatisticsMetadata::new(), None)
             .expect("write valid Statistics.db");
         assert!(
-            all_input_stats_readable(&[good_data.clone()]),
+            all_input_stats_readable(std::slice::from_ref(&good_data)),
             "a well-formed input with a valid Statistics.db must be readable"
         );
 
@@ -6339,7 +6339,7 @@ mod tests {
         std::fs::write(&missing_data, b"").expect("touch missing-stats Data.db");
         // (deliberately write NO nb-2-big-Statistics.db)
         assert!(
-            !all_input_stats_readable(&[missing_data.clone()]),
+            !all_input_stats_readable(std::slice::from_ref(&missing_data)),
             "an input whose Statistics.db is missing must NOT be provably deletion-free"
         );
 
@@ -6351,7 +6351,7 @@ mod tests {
         std::fs::write(tmp.path().join("nb-3-big-Statistics.db"), b"\x00\x00")
             .expect("write truncated Statistics.db");
         assert!(
-            !all_input_stats_readable(&[corrupt_data.clone()]),
+            !all_input_stats_readable(std::slice::from_ref(&corrupt_data)),
             "an input whose Statistics.db is unparseable at the top level must fail closed"
         );
 
@@ -12553,7 +12553,7 @@ mod issue_929_bare_udt_compaction {
         );
 
         // The header gate must report NO complex UDT columns for this input.
-        let plan = udt_columns_eligible_for_normalization(&[input.data_path.clone()]);
+        let plan = udt_columns_eligible_for_normalization(std::slice::from_ref(&input.data_path));
         assert!(
             plan.eligible_marshals.is_empty() && plan.conflicts.is_empty(),
             "a simple-cell input must not be reported as eligible or conflicting"
@@ -12902,7 +12902,7 @@ mod issue_929_bare_udt_compaction {
         );
 
         // The plan copies the nested marshal verbatim (NOT a registry re-render).
-        let plan = udt_columns_eligible_for_normalization(&[input.data_path.clone()]);
+        let plan = udt_columns_eligible_for_normalization(std::slice::from_ref(&input.data_path));
         assert_eq!(
             plan.eligible_marshals.get("addr").map(String::as_str),
             Some(outer_marshal.as_str()),
@@ -12994,7 +12994,7 @@ mod issue_929_bare_udt_compaction {
         // `addr` is absent from the input header, so it is registry-normalized.
         crate::storage::write_engine::merge::apply_udt_marshals_from_inputs(
             &mut new_schema,
-            &[input.data_path.clone()],
+            std::slice::from_ref(&input.data_path),
             Some(&registry),
         )
         .expect("apply");
@@ -13012,7 +13012,7 @@ mod issue_929_bare_udt_compaction {
         let mut bare_again = bare_udt_schema();
         crate::storage::write_engine::merge::apply_udt_marshals_from_inputs(
             &mut bare_again,
-            &[input.data_path.clone()],
+            std::slice::from_ref(&input.data_path),
             None,
         )
         .expect("apply no-registry");
@@ -13040,7 +13040,7 @@ mod issue_929_bare_udt_compaction {
         let dir = tempfile::TempDir::new().expect("dir");
         let bogus = dir.path().join("nb-1-big-Data.db");
 
-        let plan = udt_columns_eligible_for_normalization(&[bogus.clone()]);
+        let plan = udt_columns_eligible_for_normalization(std::slice::from_ref(&bogus));
         assert!(
             !plan.headers_verified,
             "an unreadable header must leave the plan unverified"

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -939,13 +939,13 @@ impl SSTableRowIteratorAdapter {
                 let mut ck_columns: Vec<(String, Value)> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck_col in &schema.clustering_keys {
-                    {
-                        let pair = simple
-                            .iter()
-                            .find(|c| c.column == ck_col.name)
-                            .map(|c| (ck_col.name.clone(), c.value.clone()))?;
-                        ck_columns.push(pair)
-                    }
+                    // A missing clustering column means no valid key — fall into the
+                    // `None` (unclustered-row) bucket via `?`.
+                    let pair = simple
+                        .iter()
+                        .find(|c| c.column == ck_col.name)
+                        .map(|c| (ck_col.name.clone(), c.value.clone()))?;
+                    ck_columns.push(pair);
                 }
                 Some(ClusteringKey {
                     columns: ck_columns,
@@ -964,13 +964,13 @@ impl SSTableRowIteratorAdapter {
                 let mut ck_columns: Vec<(String, Value)> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck_col in &schema.clustering_keys {
-                    {
-                        let pair = clustering
-                            .iter()
-                            .find(|(name, _)| name == &ck_col.name)
-                            .map(|(name, v)| (name.clone(), v.clone()))?;
-                        ck_columns.push(pair)
-                    }
+                    // A missing clustering column means no valid key — fall into the
+                    // `None` (unclustered-row) bucket via `?`.
+                    let pair = clustering
+                        .iter()
+                        .find(|(name, _)| name == &ck_col.name)
+                        .map(|(name, v)| (name.clone(), v.clone()))?;
+                    ck_columns.push(pair);
                 }
                 Some(ClusteringKey {
                     columns: ck_columns,

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -939,8 +939,8 @@ impl SSTableRowIteratorAdapter {
                 let mut ck_columns: Vec<(String, Value)> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck_col in &schema.clustering_keys {
-                    // A missing clustering column means no valid key — fall into the
-                    // `None` (unclustered-row) bucket via `?`.
+                    // Any missing clustering column ⇒ the WHOLE key is discarded (the `?`
+                    // returns `None`, treating the row as unclustered).
                     let pair = simple
                         .iter()
                         .find(|c| c.column == ck_col.name)
@@ -964,8 +964,8 @@ impl SSTableRowIteratorAdapter {
                 let mut ck_columns: Vec<(String, Value)> =
                     Vec::with_capacity(schema.clustering_keys.len());
                 for ck_col in &schema.clustering_keys {
-                    // A missing clustering column means no valid key — fall into the
-                    // `None` (unclustered-row) bucket via `?`.
+                    // Any missing clustering column ⇒ the WHOLE key is discarded (the `?`
+                    // returns `None`, treating the row as unclustered).
                     let pair = clustering
                         .iter()
                         .find(|(name, _)| name == &ck_col.name)

--- a/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
+++ b/cqlite-core/src/storage/write_engine/merge/read_assembly.rs
@@ -198,7 +198,7 @@ pub fn assemble_read_cells(
     }
 
     let mut out: RowCells = Vec::with_capacity(order.len());
-    for (name, accum) in order.into_iter().zip(accums.into_iter()) {
+    for (name, accum) in order.into_iter().zip(accums) {
         match accum {
             ColumnAccum::Simple(value) => out.push((name, value)),
             ColumnAccum::Complex(elements) => {

--- a/cqlite-core/tests/compact_command.rs
+++ b/cqlite-core/tests/compact_command.rs
@@ -80,7 +80,7 @@ fn write_row(id: i32, name: &str, timestamp: i64) -> Mutation {
 fn discover_inputs(dir: &std::path::Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1013_rt_index_block_parity.rs
+++ b/cqlite-core/tests/issue_1013_rt_index_block_parity.rs
@@ -400,10 +400,9 @@ fn parse_golden(path: &Path) -> (Vec<GoldenRange>, Vec<i64>) {
 fn parse_bound(row: &JsonValue) -> Option<(bool, bool, Vec<i64>, i64)> {
     let (is_start, inner) = if let Some(s) = row.get("start") {
         (true, s)
-    } else if let Some(e) = row.get("end") {
-        (false, e)
     } else {
-        return None;
+        let e = row.get("end")?;
+        (false, e)
     };
     let bound_type = inner.get("type").and_then(|t| t.as_str()).unwrap_or("");
     let is_inclusive = match bound_type {

--- a/cqlite-core/tests/issue_1017_live_cell_compaction_byte_parity.rs
+++ b/cqlite-core/tests/issue_1017_live_cell_compaction_byte_parity.rs
@@ -458,7 +458,7 @@ async fn cqlite_compact(
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1020_udt_frozen_compaction_byte_parity.rs
+++ b/cqlite-core/tests/issue_1020_udt_frozen_compaction_byte_parity.rs
@@ -569,7 +569,7 @@ async fn cqlite_compact(
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs
+++ b/cqlite-core/tests/issue_1240_nested_frozen_collection_udt_parity.rs
@@ -608,7 +608,7 @@ async fn cqlite_compact_schema(
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1327_writer_estimated_histogram.rs
+++ b/cqlite-core/tests/issue_1327_writer_estimated_histogram.rs
@@ -94,7 +94,7 @@ async fn write_n_partitions(dir: &Path, n: i32, format: SSTableFormat) -> SSTabl
             (key, vec![m])
         })
         .collect();
-    partitions.sort_by(|a, b| a.0.token.cmp(&b.0.token));
+    partitions.sort_by_key(|a| a.0.token);
 
     for (key, muts) in partitions {
         writer.write_partition(key, muts).unwrap();

--- a/cqlite-core/tests/issue_1382_compaction_ttl_expiry.rs
+++ b/cqlite-core/tests/issue_1382_compaction_ttl_expiry.rs
@@ -165,7 +165,7 @@ fn flush_batch(data_dir: &Path, wal_dir: &Path, schema: &TableSchema, muts: Vec<
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1383_rt_boundary_synthesis.rs
+++ b/cqlite-core/tests/issue_1383_rt_boundary_synthesis.rs
@@ -199,7 +199,7 @@ fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();
     collect(dir, &mut found, 8);
     // newest generation first (run index 0 = newest)
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1384_partial_compaction_zombie.rs
+++ b/cqlite-core/tests/issue_1384_partial_compaction_zombie.rs
@@ -343,7 +343,7 @@ fn flush_batch(data_dir: &Path, wal_dir: &Path, sch: &TableSchema, muts: Vec<Mut
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1385_gc_grace_boundary.rs
+++ b/cqlite-core/tests/issue_1385_gc_grace_boundary.rs
@@ -265,7 +265,7 @@ fn flush_batch(data_dir: &Path, wal_dir: &Path, schema: &TableSchema, muts: Vec<
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1387_tombstone_ttl_compaction_byte_parity.rs
+++ b/cqlite-core/tests/issue_1387_tombstone_ttl_compaction_byte_parity.rs
@@ -418,7 +418,7 @@ async fn cqlite_compact(
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1388_fully_expired_drop.rs
+++ b/cqlite-core/tests/issue_1388_fully_expired_drop.rs
@@ -147,7 +147,7 @@ fn flush_batch(data_dir: &Path, wal_dir: &Path, schema: &TableSchema, muts: Vec<
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_1388_fully_expired_drop.rs
+++ b/cqlite-core/tests/issue_1388_fully_expired_drop.rs
@@ -451,7 +451,7 @@ fn mixed_tombstone_and_live_sstable_not_dropped() {
     // Metadata classifier: the mixed SSTable is NOT fully expired (its authoritative
     // max_local_deletion_time is the live sentinel), so it is NOT in the drop-set —
     // even for a major compaction (empty outside set).
-    let drop_set = fully_expired_sstables(&[mixed_path.clone()], &[], Some(GC_BEFORE));
+    let drop_set = fully_expired_sstables(std::slice::from_ref(&mixed_path), &[], Some(GC_BEFORE));
     assert!(
         drop_set.is_empty(),
         "a mixed tombstone+live SSTable must never be classified fully expired (#1728 F1)"

--- a/cqlite-core/tests/issue_1538_ttl_cell_ldt_parity.rs
+++ b/cqlite-core/tests/issue_1538_ttl_cell_ldt_parity.rs
@@ -112,7 +112,7 @@ fn flush_batch(data_dir: &Path, wal_dir: &Path, schema: &TableSchema, muts: Vec<
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_2316_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2316_merge_thread_budget.rs
@@ -232,7 +232,7 @@ fn write_row(id: i32, val: &str, ts: i64) -> Mutation {
 fn discover_inputs(dir: &std::path::Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect_inputs(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_2316_producer_gauge.rs
+++ b/cqlite-core/tests/issue_2316_producer_gauge.rs
@@ -138,7 +138,7 @@ fn build_inputs() -> (TempDir, Vec<PathBuf>, TableSchema) {
 
     let mut found = Vec::new();
     collect_inputs(&data_dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     let inputs: Vec<PathBuf> = found.into_iter().map(|(_, p)| p).collect();
     assert!(
         inputs.len() >= NUM_INPUTS,

--- a/cqlite-core/tests/issue_2370_concurrent_merge_thread_budget.rs
+++ b/cqlite-core/tests/issue_2370_concurrent_merge_thread_budget.rs
@@ -177,7 +177,7 @@ fn write_row(id: i32, val: &str, ts: i64) -> Mutation {
 fn discover_inputs(dir: &std::path::Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect_inputs(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_2419_egress_depth_gauge.rs
+++ b/cqlite-core/tests/issue_2419_egress_depth_gauge.rs
@@ -149,7 +149,7 @@ fn build_inputs() -> (TempDir, Vec<PathBuf>, TableSchema) {
 
     let mut found = Vec::new();
     collect_inputs(&data_dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     let inputs: Vec<PathBuf> = found.into_iter().map(|(_, p)| p).collect();
     assert!(
         inputs.len() >= NUM_INPUTS,

--- a/cqlite-core/tests/issue_2419_reconcile_residual_teardown.rs
+++ b/cqlite-core/tests/issue_2419_reconcile_residual_teardown.rs
@@ -162,7 +162,7 @@ fn build_inputs() -> (TempDir, Vec<PathBuf>, TableSchema) {
 
     let mut found = Vec::new();
     collect_inputs(&data_dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     let inputs: Vec<PathBuf> = found.into_iter().map(|(_, p)| p).collect();
     assert!(
         inputs.len() >= NUM_INPUTS,

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1133,7 +1133,7 @@ fn delete_score_cell(id: i32, ck: i32, ts: i64) -> Mutation {
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_899_per_element_survives_compaction.rs
+++ b/cqlite-core/tests/issue_899_per_element_survives_compaction.rs
@@ -186,7 +186,7 @@ fn per_element_metadata_survives_compaction_of_real_cassandra_sstable() {
         .enable_all()
         .build()
         .expect("runtime");
-    let (min_ts, min_ldt, min_ttl) = compute_baseline_min(&[input.clone()]);
+    let (min_ts, min_ldt, min_ttl) = compute_baseline_min(std::slice::from_ref(&input));
     let _ = (min_ts, min_ldt, min_ttl); // baselines are seeded inside compact_sstables
     let report = rt
         .block_on(compact_sstables(

--- a/cqlite-core/tests/issue_933_range_tombstone_compaction.rs
+++ b/cqlite-core/tests/issue_933_range_tombstone_compaction.rs
@@ -158,7 +158,7 @@ fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();
     collect(dir, &mut found, 8);
     // newest generation first (run index 0 = newest)
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/issue_947_reconcile_parity.rs
+++ b/cqlite-core/tests/issue_947_reconcile_parity.rs
@@ -251,7 +251,7 @@ fn mutation(id: i32, ops: Vec<CellOperation>, ts: i64) -> Mutation {
 fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
     let mut found: Vec<(u64, PathBuf)> = Vec::new();
     collect(dir, &mut found, 8);
-    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.sort_by_key(|b| std::cmp::Reverse(b.0));
     found.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/cqlite-core/tests/parsing_improvements_test.rs
+++ b/cqlite-core/tests/parsing_improvements_test.rs
@@ -212,10 +212,7 @@ mod parsing_improvements_tests {
         // Test various data patterns that could cause false positives
 
         // Test case 1: 16-byte data that looks like UUID but isn't
-        let _fake_uuid_1 = [
-            b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n',
-            b'o', b'p',
-        ]; // 16 letters - should be text, not UUID
+        let _fake_uuid_1 = *b"abcdefghijklmnop"; // 16 letters - should be text, not UUID
 
         // Test case 2: 8-byte data that could be timestamp or bigint
         let _maybe_timestamp = 1234567890123456i64.to_be_bytes();

--- a/cqlite-core/tests/scan_delta_parity_test.rs
+++ b/cqlite-core/tests/scan_delta_parity_test.rs
@@ -304,10 +304,9 @@ fn parse_range_tombstone_bound(v: &JsonValue) -> Option<JsonlRangeBound> {
     // sstabledump emits either `"start": {...}` or `"end": {...}` for each bound.
     let (is_start, inner) = if let Some(s) = v.get("start") {
         (true, s)
-    } else if let Some(e) = v.get("end") {
-        (false, e)
     } else {
-        return None;
+        let e = v.get("end")?;
+        (false, e)
     };
 
     let bound_type = inner.get("type").and_then(|t| t.as_str()).unwrap_or("");

--- a/cqlite-core/tests/sstable_discovery_unit_tests.rs
+++ b/cqlite-core/tests/sstable_discovery_unit_tests.rs
@@ -336,13 +336,10 @@ async fn test_generation_number_parsing() {
                 None
             } else {
                 // Parse as u64 but reject values > i64::MAX to match expected behavior
-                parts[1].parse::<u64>().ok().and_then(|val| {
-                    if val <= i64::MAX as u64 {
-                        Some(val)
-                    } else {
-                        None
-                    }
-                })
+                parts[1]
+                    .parse::<u64>()
+                    .ok()
+                    .filter(|&val| val <= i64::MAX as u64)
             }
         } else {
             None

--- a/cqlite-flight/Dockerfile
+++ b/cqlite-flight/Dockerfile
@@ -5,7 +5,7 @@
 # Run co-located with a Cassandra node, mounting its data dir read-only:
 #   docker run --rm -p 8815:8815 -v /var/lib/cassandra:/var/lib/cassandra:ro \
 #     cqlite-flight --data-dir /var/lib/cassandra/data --listen 0.0.0.0:8815
-FROM rust:1.85-bookworm AS build
+FROM rust:1.97-bookworm AS build
 WORKDIR /src
 COPY . .
 RUN cargo build --release -p cqlite-flight --features observability

--- a/cqlite-flight/Dockerfile
+++ b/cqlite-flight/Dockerfile
@@ -5,7 +5,7 @@
 # Run co-located with a Cassandra node, mounting its data dir read-only:
 #   docker run --rm -p 8815:8815 -v /var/lib/cassandra:/var/lib/cassandra:ro \
 #     cqlite-flight --data-dir /var/lib/cassandra/data --listen 0.0.0.0:8815
-FROM rust:1.97-bookworm AS build
+FROM rust:1.97.1-bookworm AS build
 WORKDIR /src
 COPY . .
 RUN cargo build --release -p cqlite-flight --features observability

--- a/cqlite-flight/benches/flight_do_get.rs
+++ b/cqlite-flight/benches/flight_do_get.rs
@@ -124,6 +124,9 @@ async fn serve_and_connect(
 
 /// Run ONE `do_get` over the real transport with `client` and return the decoded
 /// batches (the throughput unit is total rows decoded).
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_batches(
     client: &mut FlightServiceClient<Channel>,
     ticket: Vec<u8>,

--- a/cqlite-flight/src/admission_tests.rs
+++ b/cqlite-flight/src/admission_tests.rs
@@ -109,6 +109,9 @@ async fn settle() {
     }
 }
 
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn decode(stream: <CqliteFlightService as FlightService>::DoGetStream) -> Vec<RecordBatch> {
     let mapped = stream.map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));
     let mut rb = FlightRecordBatchStream::new_from_flight_data(mapped);

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -142,7 +142,7 @@ impl RpcMetrics {
         self.bytes = self.bytes.saturating_add(bytes);
         let method = method_attr(self.method);
         if rows > 0 {
-            obs::add_counter(catalog::RPC_ROWS, rows, &[method.clone()]);
+            obs::add_counter(catalog::RPC_ROWS, rows, std::slice::from_ref(&method));
         }
         if bytes > 0 {
             obs::add_counter(catalog::RPC_BYTES, bytes, &[method]);

--- a/cqlite-flight/src/point_read_streaming_tests.rs
+++ b/cqlite-flight/src/point_read_streaming_tests.rs
@@ -389,7 +389,7 @@ fn point_read_streaming_is_byte_identical_to_buffered() {
     let buffered = {
         let mut merger = build_single_partition_merger(
             paths.clone(),
-            &[key.clone()],
+            std::slice::from_ref(&key),
             &schema,
             ScanCancel::default(),
         )

--- a/cqlite-flight/src/producer_point.rs
+++ b/cqlite-flight/src/producer_point.rs
@@ -118,7 +118,7 @@ impl MergeProducer {
             }
             let columns: Vec<(String, Value)> = pk_names
                 .iter()
-                .zip(values.into_iter())
+                .zip(values)
                 .map(|(name, v)| ((*name).to_string(), v))
                 .collect();
             let decorated = match PartitionKey::new(columns).to_decorated_key(&self.schema) {

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -8,11 +8,6 @@
 //! `FlightDescriptor.cmd` (for `get_flight_info`/`get_schema`) or as the
 //! `Ticket.ticket` bytes (for `do_get`).
 
-// The Flight gRPC trait mandates `tonic::Status` as the error type, which is
-// large; helpers returning `Result<_, Status>` mirror it so they compose with the
-// trait methods. Boxing would only add churn at every call site.
-#![allow(clippy::result_large_err)]
-
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -361,6 +356,8 @@ impl CqliteFlightService {
     }
 
     /// Parse the table schema from the ticket's CQL DDL.
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     fn parse_schema(ticket: &FlightTicket) -> Result<TableSchema, Status> {
         parse_cql_schema(&ticket.ddl)
             .map_err(|e| Status::invalid_argument(format!("invalid ddl: {e}")))
@@ -370,6 +367,8 @@ impl CqliteFlightService {
     /// (spec Req 8: schema parse elided on a warm hit). The CQL parse runs OUTSIDE
     /// the cache lock; a rare concurrent first-parse of the same DDL just parses
     /// twice (both correct), never holds the lock across the parse.
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     fn cached_schema(&self, ticket: &FlightTicket) -> Result<Arc<TableSchema>, Status> {
         if let Some(hit) = self
             .caches
@@ -396,6 +395,8 @@ impl CqliteFlightService {
     /// request — never cached (roborev 1639, issue #2310 finding 2 round 3; see
     /// [`SetupCaches`] for why a directory-resolve cache is unsound). This
     /// mirrors the pre-PR cold posture exactly.
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     fn resolve_dir(&self, ticket: &FlightTicket) -> Result<PathBuf, Status> {
         let dir = DirSource::resolve(
             &self.data_dir,
@@ -410,6 +411,8 @@ impl CqliteFlightService {
 
     /// Build a producer for a ticket, applying its token-range/predicate/projection
     /// filters. Used by every RPC so the Arrow schema reflects the projection.
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     fn build_producer(&self, ticket: &FlightTicket) -> Result<MergeProducer, Status> {
         let schema = self.cached_schema(ticket)?;
         let spec = ScanSpec::from_ticket(ticket, &schema)?;
@@ -433,6 +436,8 @@ impl CqliteFlightService {
     }
 
     /// Arrow schema for a ticket (no SSTable access required).
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     fn arrow_schema_for(&self, ticket: &FlightTicket) -> Result<ArrowSchema, Status> {
         Ok(self.build_producer(ticket)?.arrow_schema()?)
     }
@@ -517,6 +522,8 @@ impl FlightService for CqliteFlightService {
         .await
     }
 
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     async fn handshake(
         &self,
         request: Request<Streaming<HandshakeRequest>>,
@@ -532,6 +539,8 @@ impl FlightService for CqliteFlightService {
         })
     }
 
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     async fn list_flights(
         &self,
         request: Request<Criteria>,
@@ -546,6 +555,8 @@ impl FlightService for CqliteFlightService {
         })
     }
 
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     async fn poll_flight_info(
         &self,
         request: Request<FlightDescriptor>,
@@ -560,6 +571,8 @@ impl FlightService for CqliteFlightService {
         })
     }
 
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     async fn do_put(
         &self,
         request: Request<Streaming<FlightData>>,
@@ -576,6 +589,8 @@ impl FlightService for CqliteFlightService {
         })
     }
 
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     async fn do_exchange(
         &self,
         request: Request<Streaming<FlightData>>,
@@ -604,6 +619,8 @@ impl FlightService for CqliteFlightService {
         .await
     }
 
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     async fn list_actions(
         &self,
         request: Request<Empty>,
@@ -629,6 +646,8 @@ impl FlightService for CqliteFlightService {
 /// error-rate signal (subsystem `flight`). `RpcMetrics` emits the request
 /// counter, latency histogram, and in-flight gauge on drop, so returning the
 /// result here (which drops `metrics` at the call site) closes the RPC.
+// `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+#[allow(clippy::result_large_err)]
 fn finish<T>(metrics: &mut RpcMetrics, result: Result<T, Status>) -> Result<T, Status> {
     match &result {
         Ok(_) => metrics.ok(),
@@ -862,6 +881,8 @@ impl CqliteFlightService {
     /// how many times it is retried, so it must fail with its own status
     /// immediately: never wait behind the admission semaphore, never consume a
     /// permit, never surface as a retry-inviting `UNAVAILABLE`.
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     fn validate_do_get_ticket(&self, request: Request<Ticket>) -> Result<FlightTicket, Status> {
         Ok(FlightTicket::from_bytes(&request.into_inner().ticket)?)
     }
@@ -886,6 +907,8 @@ impl CqliteFlightService {
     /// F1) so a client disconnect during resolve stops it instead of running to
     /// completion; `do_get_inner`'s `CancelGuard` still covers this whole
     /// `.await` for the future-drop case.
+    // `tonic::Status` Err is large but mandated by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     async fn do_get_resolve(
         &self,
         ticket: FlightTicket,
@@ -1086,6 +1109,8 @@ mod tests {
         FlightDescriptor::new_cmd(ticket.to_bytes().unwrap())
     }
 
+    // `tonic::Status`/`FlightError` Err is large but fixed by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     async fn decode(
         stream: <CqliteFlightService as FlightService>::DoGetStream,
     ) -> Vec<RecordBatch> {
@@ -1974,6 +1999,8 @@ mod tests {
     }
 
     #[test]
+    // `tonic::Status`/`FlightError` Err is large but fixed by the Flight gRPC service trait contract (#2856).
+    #[allow(clippy::result_large_err)]
     fn do_get_empty_table_emits_schema_only() {
         // An existing table directory with no SSTables → valid empty result that
         // still carries the Arrow schema (via FlightDataEncoder `with_schema`).

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -450,6 +450,10 @@ pub(crate) async fn build_aggregate_response(
 /// counted. `record_encoder_error` now routes it through the shared
 /// error-observability hook and bumps `probe.errors_recorded`, so the failure is
 /// visible and deterministically observable in tests.
+// The stream item's `Err` is `tonic::Status`, whose size is fixed by the
+// arrow-flight `FlightService`/`DoGetStream` contract; boxing it (clippy's
+// suggestion) would violate the trait-mandated stream item type (#2856).
+#[allow(clippy::result_large_err)]
 fn encode_do_get(
     batch_stream: impl Stream<Item = Result<RecordBatch, FlightError>> + Send + 'static,
     schema_ref: Arc<ArrowSchema>,

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -373,6 +373,9 @@ fn collect_batches(producer: &MergeProducer, dir: &std::path::Path) -> Vec<Recor
     producer.produce(&DirSource::new(dir)).unwrap()
 }
 
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn drain_stream(stream: DoGetStream) -> Vec<RecordBatch> {
     use arrow_flight::decode::FlightRecordBatchStream;
     let mapped = stream.map(|r| r.map_err(|s| FlightError::ExternalError(Box::new(s))));

--- a/cqlite-flight/tests/bti_do_get_transport_test.rs
+++ b/cqlite-flight/tests/bti_do_get_transport_test.rs
@@ -65,6 +65,9 @@ const WIDE_DDL: &str = "CREATE TABLE test_da.wide_table (\
 /// Stand up a real loopback tonic server serving `svc`, connect a real
 /// `FlightServiceClient` (retrying until it accepts), run `do_get(ticket)`, and
 /// return every decoded `RecordBatch` through the real `FlightRecordBatchStream`.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_batches_over_transport(
     svc: CqliteFlightService,
     ticket: Vec<u8>,

--- a/cqlite-flight/tests/compressed_do_get_transport_test.rs
+++ b/cqlite-flight/tests/compressed_do_get_transport_test.rs
@@ -147,6 +147,9 @@ fn assert_has_compression_info(dir: &Path, table: &str) {
 /// Stand up a real loopback tonic server serving `svc`, connect a real
 /// `FlightServiceClient` (retrying until it accepts), run `do_get(ticket)`, and
 /// return every decoded `RecordBatch` through the real `FlightRecordBatchStream`.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_batches_over_transport(
     svc: CqliteFlightService,
     ticket: Vec<u8>,
@@ -618,6 +621,9 @@ fn uncompressed_control_do_get_leaves_decompress_counter_at_zero() {
 /// regression that makes `do_get` error on the first poll reads zero batches, so
 /// the producer never parks and the in-flight level never leaves its baseline —
 /// a green "no leak" verdict from a stream that exercised nothing.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_drop_after(
     svc: CqliteFlightService,
     ticket: Vec<u8>,

--- a/cqlite-flight/tests/concurrent_support/mod.rs
+++ b/cqlite-flight/tests/concurrent_support/mod.rs
@@ -169,6 +169,9 @@ pub fn point_ticket(key: &str) -> Vec<u8> {
 
 /// Run `do_get(ticket)` against `client`, fully draining the decoded stream, and
 /// return every `RecordBatch`.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 pub async fn do_get_batches(
     client: &mut FlightServiceClient<Channel>,
     ticket: Vec<u8>,

--- a/cqlite-flight/tests/do_get_transport_test.rs
+++ b/cqlite-flight/tests/do_get_transport_test.rs
@@ -136,6 +136,9 @@ async fn do_get_stream_over_transport(
 /// Same real-transport round-trip as [`do_get_rows_over_transport`] but returns
 /// every decoded `RecordBatch` so a caller can assert on the actual column set
 /// and cell values (not just the row count).
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_batches_over_transport(
     svc: CqliteFlightService,
     ticket: Vec<u8>,
@@ -600,6 +603,9 @@ fn do_get_over_transport_reads_live_set_not_snapshot() {
 /// draining it. Returns once the stream is dropped, leaving the server to observe
 /// the client disconnect. The server task is left running so the test can then
 /// observe the server-side in-flight accounting settle.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_drop_after(
     svc: CqliteFlightService,
     ticket: Vec<u8>,

--- a/cqlite-flight/tests/issue_2059_do_get_key_cache_e2e.rs
+++ b/cqlite-flight/tests/issue_2059_do_get_key_cache_e2e.rs
@@ -94,6 +94,9 @@ fn point_ticket(uuid: &str) -> Vec<u8> {
 }
 
 /// Total rows returned by a `do_get`.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_row_count(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
     let resp = svc
         .do_get(Request::new(Ticket::new(ticket)))

--- a/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
+++ b/cqlite-flight/tests/issue_2370_concurrent_doget_test.rs
@@ -71,6 +71,9 @@ enum Shape {
 /// fast-connecting client could complete its whole `do_get` before a
 /// slower-connecting sibling even issues its RPC, undermining the "N truly
 /// concurrent" claim.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn run_shape(
     addr: std::net::SocketAddr,
     shape: Shape,

--- a/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
+++ b/cqlite-flight/tests/issue_2370_gauge_readback_test.rs
@@ -73,6 +73,9 @@ async fn poll_until_at_most(target: i64, timeout: Duration, read: impl Fn() -> i
 }
 
 #[test]
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 fn phase_active_and_in_flight_read_true_concurrent_count_then_settle() {
     // Big multi-SSTable fixture + batch_size 1 so each producer fills the 4-slot
     // do_get channel and PARKS while its slow consumer holds — keeping the RPC in

--- a/cqlite-flight/tests/issue_2398_warm_scan_token_pushdown.rs
+++ b/cqlite-flight/tests/issue_2398_warm_scan_token_pushdown.rs
@@ -137,6 +137,9 @@ fn full_scan_ticket() -> Vec<u8> {
 
 /// Drive the in-process `do_get` handler and fully drain the decoded stream,
 /// returning the total row count.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_rows(svc: &CqliteFlightService, ticket: Vec<u8>) -> usize {
     let resp = svc
         .do_get(Request::new(Ticket::new(ticket)))

--- a/cqlite-flight/tests/issue_2412_do_get_cold_warm_e2e.rs
+++ b/cqlite-flight/tests/issue_2412_do_get_cold_warm_e2e.rs
@@ -103,6 +103,9 @@ fn real_fixture_dirs() -> Option<(PathBuf, PathBuf)> {
 /// value-level correctness check (matches the convention used across the
 /// #2310/#2412 warm-hit wiring-evidence tests), proving the cold and warm runs
 /// resolve byte-identical content, not merely "some rows."
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_sorted_names(svc: &CqliteFlightService, ticket: Vec<u8>) -> Vec<String> {
     let resp = svc
         .do_get(Request::new(Ticket::new(ticket)))

--- a/cqlite-flight/tests/issue_2412_do_get_cold_warm_e2e_compressed.rs
+++ b/cqlite-flight/tests/issue_2412_do_get_cold_warm_e2e_compressed.rs
@@ -78,6 +78,9 @@ fn real_fixture_dirs() -> Option<(PathBuf, PathBuf)> {
 /// Drive `do_get` and decode every batch into sorted `compressed_json` values —
 /// a value-level correctness check proving the cold and warm runs resolve
 /// byte-identical content, not merely "some rows."
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_sorted_values(svc: &CqliteFlightService, ticket: Vec<u8>) -> Vec<String> {
     let resp = svc
         .do_get(Request::new(Ticket::new(ticket)))

--- a/cqlite-flight/tests/query_semantics_flight_parity.rs
+++ b/cqlite-flight/tests/query_semantics_flight_parity.rs
@@ -254,6 +254,9 @@ fn cell_to_json(batch: &RecordBatch, col: &str, i: usize) -> Result<serde_json::
 
 /// Drive one `do_get` in-process and decode every returned batch into rows of
 /// the oracle's `id`/`ck`/`v` projection.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 async fn do_get_rows(
     svc: &CqliteFlightService,
     ticket: Vec<u8>,

--- a/docs/development/ci-toolchain-policy.md
+++ b/docs/development/ci-toolchain-policy.md
@@ -61,8 +61,8 @@ Both were toolchain drift, not source-logic regressions.
 
 | Category | Toolchain | Workflows |
 |----------|-----------|-----------|
-| Honors pin (omit `toolchain:` → reads `rust-toolchain.toml`) | 1.97.1 | `compaction-parity`, `observability-gate`, `cassandra-validation`, `perf-regression`, `e2e-readback`, `ci-minimal-features`, `coverage-baseline`; `sstabledump-parity-gate`, `pr-gate` (via `setup-rust-ci` default) |
-| Honors pin (explicit `@1.97.1` — dtolnay can't read the pin file) | 1.97.1 | `ci`, `gate`, `cassandra-parity`, `compression-corruption-parity`, `cql-type-parity`, `tombstone-ttl-parity`, `smoke-tests`, `delta-roundtrip`, `flight-ci`, `live-cell-compaction-parity`, `quality-gates`, `exhaustive-regeneration`, `docs-site`, `node-ci`, `python-ci`, `coverage` |
+| Honors pin (omit `toolchain:` → reads `rust-toolchain.toml`, or `setup-rust-ci` default) | 1.97.1 | `compaction-parity`, `observability-gate`, `cassandra-validation`, `perf-regression`, `e2e-readback`, `ci-minimal-features`, `coverage-baseline`; `ci`, `flight-ci`, `sstabledump-parity-gate`, `pr-gate` (via `setup-rust-ci` default) |
+| Honors pin (explicit `@1.97.1` — dtolnay can't read the pin file) | 1.97.1 | `gate`, `cassandra-parity`, `smoke-tests`, `delta-roundtrip`, `live-cell-compaction-parity`, `quality-gates`, `exhaustive-regeneration`, `parity-regen-matrix`, `soak-resource-leak`, `docs-site`, `node-ci`, `python-ci`, `coverage` |
 | Already pinned (pre-existing) | 1.97.1 | `nightly-docker-parity` |
 | **Advisory stable canary (the ONE exception)** | latest `stable` | `future-rust-canary` |
 | Nightly toolchain (legitimately needs nightly) | `nightly` | `fuzz` |
@@ -79,14 +79,16 @@ with `rust-toolchain.toml`, or CI silently drifts from the pin again. Exact file
 on the next pin bump:
 
 1. `rust-toolchain.toml` — update `channel` (the source of truth).
-2. `.github/actions/setup-rust-ci/action.yml` — the composite action hardcodes `1.88.0` as
+2. `.github/actions/setup-rust-ci/action.yml` — the composite action hardcodes the pin as
    its `toolchain` input **default**, which its `rustup toolchain install` + `rustup
    default` step consumes. Every workflow that calls it without a `toolchain:` input
-   (e.g. `sstabledump-parity-gate.yml`, `pr-gate.yml`) inherits this default — bump it.
-3. Every literal `dtolnay/rust-toolchain@<old>` ref — grep
-   `dtolnay/rust-toolchain@` under `.github/workflows/` and bump each `@1.88.0`
+   (e.g. `sstabledump-parity-gate.yml`, `pr-gate.yml`) inherits this default — bump it to
+   the new pin.
+3. Every literal `dtolnay/rust-toolchain@<old-pin>` ref — grep
+   `dtolnay/rust-toolchain@` under `.github/workflows/` and bump each to the new pin
    (these action refs cannot read the pin file; see policy rule 1).
-4. `nightly-docker-parity.yml` — passes an explicit `toolchain: 1.88.0` to `setup-rust-ci`.
+4. `nightly-docker-parity.yml` — passes an explicit `toolchain: <old-pin>` to `setup-rust-ci`;
+   bump it to the new pin.
 5. Re-check the prebuilt coverage-tool pins (`cargo-tarpaulin@<ver>`,
    `cargo-llvm-cov@<ver>` in `coverage.yml` / `coverage-baseline.yml`) still run on the
    new toolchain. (Prebuilt binaries are toolchain-independent, so a bump usually needs no

--- a/docs/development/ci-toolchain-policy.md
+++ b/docs/development/ci-toolchain-policy.md
@@ -1,7 +1,7 @@
 # CI toolchain policy (issue #1990)
 
 **Single source of truth for the Rust toolchain is `rust-toolchain.toml`** (currently
-`channel = "1.88.0"`). CI must match what contributors build locally. This page records
+`channel = "1.97.1"`). CI must match what contributors build locally. This page records
 which workflows honor that pin and the one deliberate exception.
 
 ## Why this exists
@@ -27,10 +27,10 @@ Both were toolchain drift, not source-logic regressions.
      input it reads `rust-toolchain.toml`. Passing `toolchain: stable` overrides the pin file
      (this is what broke Compaction Parity).
    - **`./.github/actions/setup-rust-ci`** (local composite) — **omit** `toolchain:`. Its default
-     is already the pin (`1.88.0`).
+     is already the pin (`1.97.1`).
    - **`dtolnay/rust-toolchain`** — this action **cannot** read `rust-toolchain.toml`; it requires
      a toolchain via the `@<ref>` tag or the `toolchain:` input. Pin it **explicitly**:
-     `uses: dtolnay/rust-toolchain@1.88.0`. (In-repo `cargo` invocations already prefer the pin
+     `uses: dtolnay/rust-toolchain@1.97.1`. (In-repo `cargo` invocations already prefer the pin
      file over `rustup default`, but the explicit ref avoids installing an unused `stable` and
      pins out-of-repo `cargo install` steps too.)
 
@@ -46,16 +46,24 @@ Both were toolchain drift, not source-logic regressions.
    PR-required check. A red run is an early-warning signal to investigate forward-incompat
    before bumping the pin — not a merge blocker.
 
-4. **Source is forward-compatible:** `cqlite-cli`'s crate roots (`src/lib.rs`, `src/main.rs`)
-   carry `#![recursion_limit = "256"]` so the crate builds on 1.88.0 **and** 1.96+.
+4. **Source is forward-compatible:** crate roots hosting a large `#[tokio::main]`/async body carry
+   `#![recursion_limit = "256"]` so the crate builds across toolchains — the compiler's async-block
+   layout query overflows the default depth limit (128) on newer rustc (1.96+ hit `cqlite-cli`; 1.97
+   additionally hit the `tests/` integration-test binaries). Sites: `cqlite-cli` (`src/lib.rs`,
+   `src/main.rs`) and the `tests/src/bin/` runners `integration_test_runner`,
+   `compatibility_test_runner`, `complex_type_validation_runner`,
+   `comprehensive_integration_test_runner`, `cql_validation_test_runner`, `issue_17_real_test`,
+   `issue_17_test_runner`, `performance_validator`. When a pin bump reveals
+   `error: queries overflow the depth limit!` on a new crate root, add the attribute there and list
+   it here.
 
 ## Lane classification
 
 | Category | Toolchain | Workflows |
 |----------|-----------|-----------|
-| Honors pin (omit `toolchain:` → reads `rust-toolchain.toml`) | 1.88.0 | `compaction-parity`, `observability-gate`, `cassandra-validation`, `perf-regression`, `e2e-readback`, `ci-minimal-features`, `coverage-baseline`; `sstabledump-parity-gate`, `pr-gate` (via `setup-rust-ci` default) |
-| Honors pin (explicit `@1.88.0` — dtolnay can't read the pin file) | 1.88.0 | `ci`, `gate`, `cassandra-parity`, `compression-corruption-parity`, `cql-type-parity`, `tombstone-ttl-parity`, `smoke-tests`, `delta-roundtrip`, `flight-ci`, `live-cell-compaction-parity`, `quality-gates`, `exhaustive-regeneration`, `docs-site`, `node-ci`, `python-ci`, `coverage` |
-| Already pinned (pre-existing) | 1.88.0 | `nightly-docker-parity` |
+| Honors pin (omit `toolchain:` → reads `rust-toolchain.toml`) | 1.97.1 | `compaction-parity`, `observability-gate`, `cassandra-validation`, `perf-regression`, `e2e-readback`, `ci-minimal-features`, `coverage-baseline`; `sstabledump-parity-gate`, `pr-gate` (via `setup-rust-ci` default) |
+| Honors pin (explicit `@1.97.1` — dtolnay can't read the pin file) | 1.97.1 | `ci`, `gate`, `cassandra-parity`, `compression-corruption-parity`, `cql-type-parity`, `tombstone-ttl-parity`, `smoke-tests`, `delta-roundtrip`, `flight-ci`, `live-cell-compaction-parity`, `quality-gates`, `exhaustive-regeneration`, `docs-site`, `node-ci`, `python-ci`, `coverage` |
+| Already pinned (pre-existing) | 1.97.1 | `nightly-docker-parity` |
 | **Advisory stable canary (the ONE exception)** | latest `stable` | `future-rust-canary` |
 | Nightly toolchain (legitimately needs nightly) | `nightly` | `fuzz` |
 | Release / publish artifacts (deliberately track `stable`; out of scope) | `stable` | `release`, `api-docs`, `python-release`, `node-release` |
@@ -81,7 +89,10 @@ on the next pin bump:
 4. `nightly-docker-parity.yml` — passes an explicit `toolchain: 1.88.0` to `setup-rust-ci`.
 5. Re-check the prebuilt coverage-tool pins (`cargo-tarpaulin@<ver>`,
    `cargo-llvm-cov@<ver>` in `coverage.yml` / `coverage-baseline.yml`) still run on the
-   new toolchain.
+   new toolchain. (Prebuilt binaries are toolchain-independent, so a bump usually needs no
+   change here — but confirm the pinned versions support the new rustc's LLVM/coverage format.)
+6. `cqlite-flight/Dockerfile` — the build stage hardcodes `FROM rust:<major.minor>-bookworm`;
+   bump it to the new pin's `major.minor` (e.g. `rust:1.97-bookworm`).
 
 Lanes that **omit** `toolchain:` (`actions-rust-lang/setup-rust-toolchain@v1` callers)
 follow the pin file automatically — no action needed for those.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]
 

--- a/tests/src/bin/compatibility_test_runner.rs
+++ b/tests/src/bin/compatibility_test_runner.rs
@@ -1,3 +1,7 @@
+// Rust 1.97's async-block layout query can exceed the default recursion limit for
+// this test binary; raised in lockstep with the pin bump (#2856, ci-toolchain-policy.md rule 4).
+#![recursion_limit = "256"]
+
 //! Compatibility Test Runner Executable
 //!
 //! Command-line tool for running comprehensive Cassandra 5+ compatibility tests.

--- a/tests/src/bin/complex_type_validation_runner.rs
+++ b/tests/src/bin/complex_type_validation_runner.rs
@@ -1,3 +1,7 @@
+// Rust 1.97's async-block layout query can exceed the default recursion limit for
+// this test binary; raised in lockstep with the pin bump (#2856, ci-toolchain-policy.md rule 4).
+#![recursion_limit = "256"]
+
 //! Complex Type Validation Test Runner
 //!
 //! Comprehensive validation runner for M3 complex types compatibility testing.

--- a/tests/src/bin/comprehensive_integration_test_runner.rs
+++ b/tests/src/bin/comprehensive_integration_test_runner.rs
@@ -1,3 +1,7 @@
+// Rust 1.97's async-block layout query can exceed the default recursion limit for
+// this test binary; raised in lockstep with the pin bump (#2856, ci-toolchain-policy.md rule 4).
+#![recursion_limit = "256"]
+
 /// Comprehensive Integration Test Runner
 ///
 /// Standalone executable for running the complete CQLite integration test suite.

--- a/tests/src/bin/cql_validation_test_runner.rs
+++ b/tests/src/bin/cql_validation_test_runner.rs
@@ -1,3 +1,7 @@
+// Rust 1.97's async-block layout query can exceed the default recursion limit for
+// this test binary; raised in lockstep with the pin bump (#2856, ci-toolchain-policy.md rule 4).
+#![recursion_limit = "256"]
+
 //! CQL Schema Validation Test Runner
 //!
 //! Comprehensive test runner for CQL parser validation, integration tests,

--- a/tests/src/bin/integration_test_runner.rs
+++ b/tests/src/bin/integration_test_runner.rs
@@ -6,6 +6,10 @@
 //! - Performance validation
 //! - Edge case testing
 
+// Rust 1.97's async-block layout query is deeper than the default limit for
+// this binary's `#[tokio::main]` future (#2856); raise it so the crate compiles.
+#![recursion_limit = "256"]
+
 use clap::{Arg, Command};
 use cqlite_tests::{
     CLIIntegrationTestSuite, CLITestConfig, ComprehensiveIntegrationTestSuite,

--- a/tests/src/bin/issue_17_real_test.rs
+++ b/tests/src/bin/issue_17_real_test.rs
@@ -1,3 +1,7 @@
+// Rust 1.97's async-block layout query can exceed the default recursion limit for
+// this test binary; raised in lockstep with the pin bump (#2856, ci-toolchain-policy.md rule 4).
+#![recursion_limit = "256"]
+
 //! Issue #17 - Real SSTable Reading Test
 //!
 //! Tests actual SSTable reading functionality using cqlite-core

--- a/tests/src/bin/issue_17_test_runner.rs
+++ b/tests/src/bin/issue_17_test_runner.rs
@@ -1,3 +1,7 @@
+// Rust 1.97's async-block layout query can exceed the default recursion limit for
+// this test binary; raised in lockstep with the pin bump (#2856, ci-toolchain-policy.md rule 4).
+#![recursion_limit = "256"]
+
 /// Issue #17 Test Runner - Core SSTable Reading Functionality Validation
 ///
 /// This binary provides a comprehensive test runner specifically for Issue #17:

--- a/tests/src/bin/performance_validator.rs
+++ b/tests/src/bin/performance_validator.rs
@@ -1,3 +1,7 @@
+// Rust 1.97's async-block layout query can exceed the default recursion limit for
+// this test binary; raised in lockstep with the pin bump (#2856, ci-toolchain-policy.md rule 4).
+#![recursion_limit = "256"]
+
 //! CQLite Performance Validation CLI Tool
 //!
 //! This tool runs comprehensive performance validation, benchmarking, and

--- a/tools/flight-loadgen/src/client.rs
+++ b/tools/flight-loadgen/src/client.rs
@@ -59,6 +59,9 @@ pub async fn connect(
 /// `get_array_memory_size()` and then dropped before the next is polled — no
 /// `Vec<RecordBatch>` is ever held, so peak memory is O(one in-flight batch)
 /// regardless of result-set size (spec: memory-bound requirement).
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
 pub async fn do_get_drain(
     client: &mut FlightServiceClient<Channel>,
     ticket_bytes: Vec<u8>,


### PR DESCRIPTION
Closes #2856

## What

- `rust-toolchain.toml` pin 1.88.0 → **1.97.1** + the full #1990 lockstep sweep: `setup-rust-ci` composite default, all 13 `dtolnay/rust-toolchain@` workflow refs, `nightly-docker-parity` input, coverage-tool pin re-check, `cqlite-flight/Dockerfile` base `rust:1.85` → `rust:1.97-bookworm` (tag existence verified on Docker Hub; `--features observability` release build verified locally on 1.97), and `ci-toolchain-policy.md` updated with a de-literalized bump checklist + lane table regenerated from the tree.
- All new 1.97 clippy lints cleared workspace-wide under `-D warnings` (zero blanket allows; per-site `#[allow]`s carry one-line justifications — `result_large_err` per-fn in cqlite-flight [tonic `Status` trait-mandated], `collapsible_match` per-site at the no-heuristics dispatch arms [empirically verified the lint fires without them]).
- No-heuristics boundary kept **structural**: explicit modern-format match arms retained (guard-collapse rewrites reverted) and now pinned by 4 new regression tests (modern+no-schema → `Error::Schema`; modern+schema → proceeds without the legacy path).
- `recursion_limit = 256` on 8 test-bin crate roots (1.97 async depth-limit class), recorded in the policy doc.

## Review history (review-first, #2086)

rust-reviewer + roborev branch review (job 1994) + per-commit terminal round (jobs 1995/1996); all blockers fixed and re-certed (lite r4–r6 green). One roborev finding declined with evidence (allows ARE effective — clippy re-fires without them).

## Known / expected

- **#2576 (pre-existing test failures on main)**: `cqlite-integration-tests --lib` `test_row_cell_state_machine_no_blob_fallback_modern` + `test_vint_length_parsing` fail identically on clean `main`@1.88 (independently adjudicated); outside the full gate of record's component scope. Not introduced here.
- **Full gate needs `CQLITE_ALLOW_FILE_GROWTH=1`**: a required `slice::from_ref` lint fix fmt-wrapped +1 line in the over-threshold `verify.rs` (2723 lines; split tracked under epic #1116).
- One-time sccache cold build fleet-wide after merge (new compiler hash).

## Why

Quarterly pin policy (~4 quarters overdue); clears 3 weeks of red `future-rust-canary`; Rust ≥1.90 makes lld the default linker on x86_64-linux (EC2 workers: ~7× link / ~40% e2e incremental upstream measurement); 1.97.1 LLVM miscompilation fix. Companion: #2859 (mold for Graviton/Linux workers).