### PR TITLE
Add agent-ami worker onboarding profile

### DIFF
--- a/.agent-ami/profile.yaml
+++ b/.agent-ami/profile.yaml
@@ -1,0 +1,37 @@
+version: 1
+project:
+  name: cqlite
+datasets_root_env: CQLITE_DATASETS_ROOT
+toolchains:
+  - kind: rust
+    version: "stable"
+    components: [clippy, rustfmt]
+    targets: [wasm32-unknown-unknown]
+    # cargo-nextest --locked (unpinned): on latest stable (verified 1.97.1,
+    # 2026-07-24) the newest nextest builds fine, but it ships a build-time
+    # "locked-tripwire" that FAILS unless installed with --locked. So keep
+    # --locked; the old @0.9.114 rustc-version pin is no longer needed.
+    accelerators: [sccache, "cargo-nextest --locked"]
+  - kind: python
+    version: "3.9"
+  - kind: node
+    version: "18"
+datasets:
+  - run: "bash test-data/scripts/fetch-datasets.sh"
+    env:
+      CQLITE_DATASETS_ROOT: "{repo_root}/test-data/datasets"
+env:
+  RUSTFLAGS: "-D warnings"
+  # NOTE: do NOT set RUSTC_WRAPPER=sccache here. Profile env is applied to every
+  # onboard command, including `cargo install sccache` — wrapping rustc with a
+  # not-yet-built sccache deadlocks the toolchain step. cqlite's agent-gate.sh
+  # auto-detects sccache and wires it in itself; these two vars are all it needs.
+  SCCACHE_DIR: "/home/ubuntu/.cache/sccache"
+  SCCACHE_CACHE_SIZE: "30G"
+  CQLITE_DATASETS_ROOT: "{repo_root}/test-data/datasets"
+verify:
+  run: "bash scripts/bootstrap-agent-machine.sh"
+  expect: "All checks green."
+hooks:
+  post_toolchain: []
+  pre_verify: []


### PR DESCRIPTION
Adds **.agent-ami/profile.yaml** (new): rust stable + clippy/rustfmt + wasm32 target, python, node; dataset fetch; bootstrap-agent-machine.sh verify gate. cargo-nextest installed `--locked` (latest builds on stable but ships a build-time tripwire requiring --locked).

Verified live on an agent-ami worker (Rust 1.97.1): toolchain applies, wasm target + components install, cargo-nextest 0.9.140 builds with --locked, datasets fetch.

**Scope note (owner-approved 2026-07-25):** the original `rust-toolchain.toml` 1.88.0→stable float was dropped — main already pins **1.97.1** and #1990 policy keeps the pin (the `future-rust-canary` lane tracks latest stable). The profile's `stable` install is just the AMI-side rustup bootstrap; the repo pin governs builds via rustup override.