### PR TITLE
feat(#2859): bootstrap mold linker on Linux agent workers + gate accelerator stamp

### DIFF
--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -36,6 +36,12 @@ accelerators: sccache=on nextest=on lanes=on sccache-health=ok
 - **`sccache`** — cross-worktree compile cache (~25.6% faster fresh builds).
 - **`nextest`** — parallel `core-tests` (the gate's long pole).
 - **`lanes`** — parallel gate components (needs bash ≥4.3 for `wait -n`).
+- **`mold`** (issue #2859, **Linux only** — no token on macOS) — the fast linker,
+  wired via a per-machine `~/.cargo/config.toml` managed block. On Linux the line
+  gains a trailing `mold=linked | overridden | present-unconfigured | absent` token:
+  `overridden` means a global `RUSTFLAGS` is suppressing the wired flags (don't
+  export one on a worker); `present-unconfigured` means mold is installed but not
+  wired — re-run bootstrap.
 
 States: **`on`** (detected & used) · **`absent`** (missing → the gate prints a loud
 `WARN:` with the install command) · **`off`** (intentionally disabled via
@@ -44,8 +50,8 @@ States: **`on`** (detected & used) · **`absent`** (missing → the gate prints 
 a machine can otherwise run ~3x slower with no signal. Install commands:
 
 ```bash
-brew install sccache cargo-nextest bash     # macOS
-cargo install sccache cargo-nextest         # Linux (bash via the distro package manager)
+brew install sccache cargo-nextest bash          # macOS (mold is Linux-only)
+cargo install sccache cargo-nextest              # Linux (bash + mold via the distro package manager)
 ```
 
 ## Datasets and CQLITE_DATASETS_ROOT

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -29,11 +29,24 @@ issues itself). Other machines run pure **workers**. A lead is a worker with a h
 
 ```bash
 git clone https://github.com/pmcfadin/cqlite && cd cqlite
-bash scripts/bootstrap-agent-machine.sh        # or manually: sccache, cargo-nextest, bash>=4.3
+bash scripts/bootstrap-agent-machine.sh        # or manually: sccache, cargo-nextest, bash>=4.3, mold (Linux)
 bash test-data/scripts/fetch-datasets.sh       # real SSTable binaries — REQUIRED (see below)
 gh auth status                                  # must include the 'project' scope (board access)
 bash scripts/flow/claim.sh smoke               # preflight: prove origin accepts refs/claims/* (see below)
 ```
+
+**Linux workers — mold linker (#2859):** on Linux hosts bootstrap also provisions the **mold**
+linker (linking is the one build cost sccache cannot cache — every `--lite` round and full gate
+re-links every test binary) and wires it through a managed block in the **per-machine**
+`~/.cargo/config.toml`, after a link probe proves the toolchain accepts `-fuse-ld=mold`. It is
+advisory (a missing mold never fails a run) and never touches the repo-committed
+`.cargo/config.toml`. The gate's `accelerators:` line stamps `mold=linked` /
+`present-unconfigured` / `absent` on Linux; if you see `present-unconfigured` (mold installed but
+not wired), re-run `bash scripts/bootstrap-agent-machine.sh`. macOS is out of scope (mold is
+Linux-only; ld-prime is already fastest there) — no change and no token. **One-time cold rebuild
+at enablement:** adding the mold `rustflags` changes sccache's cache keys, so the first gate after
+mold is wired is a **cold rebuild** (no cache hits) — expected, one time per machine; subsequent
+runs are warm again.
 
 **Claim-ref preflight (#2665):** the cross-machine lock is a push to the `refs/claims/*` ref
 namespace on origin — `claim.sh smoke` creates, `ls-remote`s, and deletes a throwaway

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -40,13 +40,16 @@ linker (linking is the one build cost sccache cannot cache — every `--lite` ro
 re-links every test binary) and wires it through a managed block in the **per-machine**
 `~/.cargo/config.toml`, after a link probe proves the toolchain accepts `-fuse-ld=mold`. It is
 advisory (a missing mold never fails a run) and never touches the repo-committed
-`.cargo/config.toml`. The gate's `accelerators:` line stamps `mold=linked` /
+`.cargo/config.toml`. The gate's `accelerators:` line stamps `mold=linked` / `overridden` /
 `present-unconfigured` / `absent` on Linux; if you see `present-unconfigured` (mold installed but
 not wired), re-run `bash scripts/bootstrap-agent-machine.sh`. macOS is out of scope (mold is
-Linux-only; ld-prime is already fastest there) — no change and no token. **One-time cold rebuild
-at enablement:** adding the mold `rustflags` changes sccache's cache keys, so the first gate after
-mold is wired is a **cold rebuild** (no cache hits) — expected, one time per machine; subsequent
-runs are warm again.
+Linux-only; ld-prime is already fastest there) — no change and no token. **Never export a global
+`RUSTFLAGS` on a worker:** env `RUSTFLAGS` suppresses cargo's `target.rustflags` entirely, so the
+wired `-fuse-ld=mold` goes silently inert — the gate stamps `mold=overridden` to surface exactly
+this footgun; scope any `RUSTFLAGS` per-command instead. **One-time cold rebuild at enablement:**
+adding the mold `rustflags` changes sccache's cache keys, so the first gate after mold is wired is
+a **cold rebuild** (no cache hits) — expected, one time per machine; subsequent runs are warm
+again.
 
 **Claim-ref preflight (#2665):** the cross-machine lock is a push to the `refs/claims/*` ref
 namespace on origin — `claim.sh smoke` creates, `ls-remote`s, and deletes a throwaway

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -157,6 +157,11 @@ accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked
 State values (Linux only):
 - `mold=linked` — mold on `$PATH` **and** the bootstrap-managed block is active in
   the resolved cargo config (the wired, fast path).
+- `mold=overridden` — the managed block is active but a **non-empty `RUSTFLAGS`** is
+  exported in the gate environment: env `RUSTFLAGS` suppresses cargo's
+  `target.rustflags` entirely, so the wired `-fuse-ld=mold` is NOT applied and a
+  bare `linked` would lie. **Never export a global `RUSTFLAGS` on a worker** — scope
+  it per-command (as the gate's own clippy/minimal-build components do).
 - `mold=present-unconfigured` — mold on `$PATH` but **no** managed block (bootstrap
   not re-run) → the installed-but-unwired silent-degradation the token exists to
   surface; re-run `bash scripts/bootstrap-agent-machine.sh`.
@@ -169,7 +174,8 @@ the resolved C compiler accepts `-fuse-ld=mold` (fail-safe: a probe failure warn
 and writes nothing — a machine never ends up with a config that breaks linking).
 When only `clang` passes the probe, the block adds `linker = "clang"` per triple.
 Self-test coverage: `scripts/tests/test_agent_gate_summary.sh` (case 9d asserts the
-three Linux states + the Darwin no-token contract) and
+four Linux states — incl. `overridden` and a no-override real-detection case — plus
+the Darwin no-token contract) and
 `scripts/tests/test_bootstrap_agent_machine.sh` (case 6 asserts detection, install
 print-only, the link probe, the managed-block write, idempotency, user-config
 preservation, and the Darwin no-op). See fleet-runbook for the one-time sccache

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -135,6 +135,46 @@ intentional opt-out is `off`, never `absent`, and never warns. Self-test coverag
 `scripts/tests/test_agent_gate_summary.sh` (cases 9a/9b assert the `off`/`absent`
 markers and the WARN).
 
+## mold linker accelerator — Linux only (issue #2859)
+
+Linking is the **one build cost sccache cannot cache**: every `--lite` round and
+full gate re-links every test binary from scratch (`debug = true`), so on a warm
+worker link time is a large slice of the remaining wall-clock. On Linux agent
+workers `scripts/bootstrap-agent-machine.sh` provisions the **mold** linker and
+wires it through a delimited managed block in the **per-machine** `~/.cargo/config.toml`
+(honoring `$CARGO_HOME`) — it never touches the repo-committed `.cargo/config.toml`,
+so GitHub-hosted CI runners (which have no mold) stay on their defaults.
+
+On **Linux** hosts the `accelerators:` line gains a trailing `mold=` token; on
+**macOS** the line is byte-identical to before (mold is Linux-only — Apple's
+ld-prime is already the fastest linker on macOS, so a permanent `n/a` token would
+churn every existing summary parser for zero signal):
+
+```
+accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked
+```
+
+State values (Linux only):
+- `mold=linked` — mold on `$PATH` **and** the bootstrap-managed block is active in
+  the resolved cargo config (the wired, fast path).
+- `mold=present-unconfigured` — mold on `$PATH` but **no** managed block (bootstrap
+  not re-run) → the installed-but-unwired silent-degradation the token exists to
+  surface; re-run `bash scripts/bootstrap-agent-machine.sh`.
+- `mold=absent` — mold not installed.
+
+Provisioning is **advisory** (mirrors sccache/nextest): a missing or uninstallable
+mold never fails the run. Bootstrap installs mold via the native package manager
+(apt/dnf/yum/pacman) and writes the managed block **only after a link probe** proves
+the resolved C compiler accepts `-fuse-ld=mold` (fail-safe: a probe failure warns
+and writes nothing — a machine never ends up with a config that breaks linking).
+When only `clang` passes the probe, the block adds `linker = "clang"` per triple.
+Self-test coverage: `scripts/tests/test_agent_gate_summary.sh` (case 9d asserts the
+three Linux states + the Darwin no-token contract) and
+`scripts/tests/test_bootstrap_agent_machine.sh` (case 6 asserts detection, install
+print-only, the link probe, the managed-block write, idempotency, user-config
+preservation, and the Darwin no-op). See fleet-runbook for the one-time sccache
+cold-rebuild note at enablement.
+
 ## Disk hygiene for multi-worktree gates (issue #1848)
 
 Each active worktree owns its own ~25–30GB `target/` dir. Several concurrent

--- a/openspec/changes/mold-linux-workers/design.md
+++ b/openspec/changes/mold-linux-workers/design.md
@@ -65,6 +65,22 @@ toolchain so the recorded delta is mold-vs-lld (x86_64) and mold-vs-bfd (aarch64
 the fleet will actually run. Target-level `rustflags` in cargo config are additive over the
 toolchain's default linker choice; mold takes precedence via `-fuse-ld`.
 
+## Decision 4: RUSTFLAGS precedence — keep rustflags, add a fourth `overridden` state (CHOSEN)
+
+Cargo applies a config `target.<triple>.rustflags` ONLY when no higher-precedence flag
+source is set; a non-empty environment `RUSTFLAGS` **suppresses** the config value
+entirely (it does not merge). So on a worker that exports a global `RUSTFLAGS`, the managed
+block's `-fuse-ld=mold` is silently inert and a bare `mold=linked` stamp would LIE. We keep
+the config-`rustflags` mechanism (it is the one wiring seen identically by every cargo
+invocation — see Decision 1) and make the dishonesty impossible instead: the gate stamps a
+fourth state `mold=overridden` whenever a non-empty `RUSTFLAGS` is present at stamp time and
+the managed block is active. The fleet rule (fleet-runbook, same change) is therefore:
+**never export a global `RUSTFLAGS` on a worker** — scope it per-command (as the gate's own
+clippy/minimal-build components already do). A wrapper-linker (`[target].linker = mold`)
+would not be RUSTFLAGS-suppressible, but it is rejected for now: it needs mold's own
+`ld`-compatible driver wiring and diverges from the trivial `-fuse-ld` probe, and the
+`overridden` stamp fully closes the honesty gap at zero extra machinery.
+
 ## Known cost
 
 Adding rustflags changes sccache cache keys → one cold rebuild per machine at enablement.

--- a/openspec/changes/mold-linux-workers/design.md
+++ b/openspec/changes/mold-linux-workers/design.md
@@ -1,0 +1,71 @@
+# Design — mold on Linux agent workers (issue #2859)
+
+## Decision 1: wiring mechanism — per-machine `~/.cargo/config.toml` managed block (CHOSEN)
+
+Bootstrap writes an explicitly-delimited managed block:
+
+```toml
+# BEGIN cqlite-mold (managed by scripts/bootstrap-agent-machine.sh — do not edit inside)
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+# END cqlite-mold
+```
+
+Idempotency = replace-the-block: on re-run the block is regenerated in place; everything
+outside the markers is preserved byte-for-byte. Only the two Linux triples are named, so
+the block is inert on any other host arch even if copied around.
+
+**Fail-safe probe before writing:** bootstrap first proves the system C compiler accepts
+mold (`cc -fuse-ld=mold -Wl,--version` on a trivial link, gcc ≥ 12.1 or clang). If the
+probe fails with `cc` but `clang` is present and passes, the block adds
+`linker = "clang"` per triple. If no compiler passes the probe, bootstrap WARNS and writes
+nothing — a machine must never end up with a config that breaks linking.
+
+### Beat (rejected alternatives)
+
+- **`RUSTFLAGS` env exported by the supervisor** — invisible to interactive sessions on the
+  same box (two different sccache key spaces on one machine: every attended/unattended
+  switch is a cold rebuild), and silently lost when a worker is launched outside the
+  supervisor. Config-file wiring is seen identically by every cargo invocation.
+- **Repo-committed `.cargo/config.toml`** — target-scoped sections would also apply to
+  GitHub-hosted CI runners, which don't have mold → hard link failure on every CI job, or
+  else a guard that reintroduces per-machine divergence anyway. Per-machine keeps CI on its
+  defaults (lld post-#2856 on x86_64).
+- **`mold -run <cmd>` wrapper** — must wrap every invocation site (gate, supervisor, ad-hoc
+  cargo, IDE); any missed site silently loses the speedup. Config wiring has one site.
+
+## Decision 2: install path — native package manager, warn-only fallback (CHOSEN)
+
+Detect apt/dnf/yum/pacman and install `mold` when missing (AL2023, Ubuntu 22.04+, Fedora
+all package it). No package manager match → `warn` with the estimated cost (mirrors the
+sccache "MISSING — ~X% slower" message) and skip; bootstrap stays advisory and idempotent,
+never fails the machine. **Beat:** building mold from source (heavy C++ build, toolchain
+deps on a fresh worker — not worth it when every target distro packages it).
+
+## Decision 3: gate stamp semantics — three states, Linux-only token (CHOSEN)
+
+The `accelerators:` line gains a `mold=` token on Linux hosts only:
+
+- `mold=linked` — binary present AND the managed block is active in the resolved cargo config
+- `mold=present-unconfigured` — binary present, no managed block (bootstrap not re-run)
+- `mold=absent` — binary missing
+
+Darwin output is byte-identical to today (no token) — macOS has no mold and adding a
+permanent `n/a` token would churn every existing summary parser/fixture for zero signal.
+**Beat:** a boolean present/absent (hides the "installed but not wired" failure mode, which
+is exactly the silent degradation the accelerators contract exists to surface).
+
+## Interaction with #2856 (rust-1.97.1)
+
+Independent but ordered-after for measurement honesty: the A/B runs on the post-bump
+toolchain so the recorded delta is mold-vs-lld (x86_64) and mold-vs-bfd (aarch64) — what
+the fleet will actually run. Target-level `rustflags` in cargo config are additive over the
+toolchain's default linker choice; mold takes precedence via `-fuse-ld`.
+
+## Known cost
+
+Adding rustflags changes sccache cache keys → one cold rebuild per machine at enablement.
+Documented in fleet-runbook (same change).

--- a/openspec/changes/mold-linux-workers/proposal.md
+++ b/openspec/changes/mold-linux-workers/proposal.md
@@ -1,0 +1,53 @@
+# Bootstrap mold linker on Linux agent workers (issue #2859)
+
+## Why
+
+EC2 Linux agent workers link with the slowest option available. On the pinned 1.88.0
+toolchain the Linux default is GNU bfd; after #2856 (rust-1.97.1 bump) x86_64-linux gets
+lld by default, but **aarch64/Graviton workers get nothing**, and mold outperforms lld on
+both arches. Linking is the one build cost sccache cannot cache — every `--lite` round and
+full gate re-links every test binary (`debug = true`) from scratch, so on a warm worker
+link time is a large slice of remaining wall-clock. Upstream reference point: bfd→lld
+alone measured ~7× link / ~40% e2e incremental (rust-lang 1.90 release notes); mold
+improves on lld and covers both Linux target triples.
+
+macOS is explicitly out of scope: mold is Linux-only (the "sold" macOS fork is
+discontinued/commercial) and Apple's ld-prime is already the fastest linker there.
+
+## What changes
+
+1. `scripts/bootstrap-agent-machine.sh` (Linux branch only): detect `mold`, install via the
+   native package manager where possible, else warn with a cost estimate — mirroring the
+   existing sccache/nextest accelerator `ok/warn` pattern.
+2. Bootstrap writes a **managed block** in the per-machine `~/.cargo/config.toml` with
+   `[target.x86_64-unknown-linux-gnu]` + `[target.aarch64-unknown-linux-gnu]` sections that
+   route linking through mold — only after a link-probe proves the toolchain supports it
+   (fail-safe: never write a config that would break linking). Idempotent; unrelated user
+   config preserved; repo config untouched.
+3. `scripts/agent-gate.sh` `accelerators:` line stamps mold state on Linux (present/absent/
+   configured) — degradation is visible, not silent, same contract as sccache.
+4. One-time A/B measurement on an EC2 worker (full gate + one `--lite` round, with/without
+   mold) recorded on the issue/PR before merge (tasks.md; not a durable requirement).
+
+## Routing
+
+Design-driven (process/tooling) — OpenSpec change `mold-linux-workers`, capability
+`agent-fleet-runtime`. Design shape pre-agreed with owner in-session 2026-07-24.
+
+## Non-goals
+
+- No macOS behavior change of any kind (bootstrap Darwin branch and gate output on Darwin
+  stay byte-identical).
+- No change to the repo-committed `.cargo/config.toml` and no change to GitHub-hosted CI
+  runners (they don't have mold; per-machine config keeps them on their defaults).
+- No Cranelift / codegen-backend work (nightly-only; blocked on arm64-macOS ABI — tracked
+  separately if ever).
+- No toolchain version change (that is #2856).
+- No `RUSTFLAGS` injection via supervisor env (rejected in design.md).
+
+## Doctrine impact
+
+Same-change updates: `docs/development/gate-ops.md` (accelerator: mold) and
+`docs/development/fleet-runbook.md` (Linux worker provisioning + one-time sccache cold
+rebuild after enabling, since rustflags change cache keys). No CLAUDE.md contract change
+(the gate summary `accelerators:` contract already exists; this adds a token on Linux).

--- a/openspec/changes/mold-linux-workers/specs/agent-fleet-runtime/spec.md
+++ b/openspec/changes/mold-linux-workers/specs/agent-fleet-runtime/spec.md
@@ -65,10 +65,12 @@ written only after a successful link probe proving the resolved C compiler accep
 ### Requirement: The gate summary SHALL stamp mold state on Linux hosts
 
 On Linux, every `scripts/agent-gate.sh` summary's `accelerators:` line SHALL carry a
-`mold=` token with one of three states: `linked` (binary present and the managed block is
-active in the resolved cargo config), `present-unconfigured` (binary present, block
-absent), or `absent` (binary missing). On Darwin the `accelerators:` line SHALL be
-unchanged (no mold token).
+`mold=` token with one of four states: `linked` (binary present and the managed block is
+active in the resolved cargo config), `overridden` (managed block active but a non-empty
+`RUSTFLAGS` is exported in the gate environment, which suppresses cargo's
+`target.rustflags` so the wired `-fuse-ld=mold` is NOT applied), `present-unconfigured`
+(binary present, block absent), or `absent` (binary missing). On Darwin the
+`accelerators:` line SHALL be unchanged (no mold token).
 
 #### Scenario: configured Linux worker stamps linked
 - **GIVEN** a Linux host with mold installed and the managed block active
@@ -84,6 +86,13 @@ unchanged (no mold token).
 - **GIVEN** a Linux host without mold
 - **WHEN** the gate emits its summary
 - **THEN** the `accelerators:` line SHALL contain `mold=absent`
+
+#### Scenario: a global RUSTFLAGS override is visible
+- **GIVEN** a Linux host with the managed block active AND a non-empty `RUSTFLAGS`
+  exported in the gate environment
+- **WHEN** the gate emits its summary
+- **THEN** the `accelerators:` line SHALL contain `mold=overridden` (never a bare
+  `linked`, which would misreport a mold link that env RUSTFLAGS actually suppresses)
 
 #### Scenario: Darwin summary unchanged
 - **WHEN** the gate emits its summary on a macOS host

--- a/openspec/changes/mold-linux-workers/specs/agent-fleet-runtime/spec.md
+++ b/openspec/changes/mold-linux-workers/specs/agent-fleet-runtime/spec.md
@@ -1,0 +1,91 @@
+# agent-fleet-runtime — mold linker on Linux agent workers
+
+## ADDED Requirements
+
+### Requirement: Linux bootstrap SHALL provision mold as the cargo link accelerator
+
+On Linux hosts, `scripts/bootstrap-agent-machine.sh` SHALL detect the `mold` linker,
+install it via the native package manager when missing and one is available, and otherwise
+emit an advisory warning with a cost estimate — following the existing accelerator
+`ok/warn` pattern (sccache/nextest). Bootstrap SHALL remain advisory: a missing or
+uninstallable mold never fails the run.
+
+#### Scenario: mold present on Linux
+- **WHEN** bootstrap runs on a Linux host where `mold` is on PATH
+- **THEN** it SHALL report mold `ok` (with version) and proceed to linker configuration
+
+#### Scenario: mold missing with a supported package manager
+- **WHEN** bootstrap runs on a Linux host without `mold` and detects apt, dnf, yum, or pacman
+- **THEN** it SHALL install `mold` via that package manager (or print the exact command in
+  check-only mode)
+
+#### Scenario: mold missing with no supported package manager
+- **WHEN** bootstrap runs on a Linux host without `mold` and no supported package manager
+- **THEN** it SHALL emit a `warn` naming the estimated cost of linking without mold
+- **AND** it SHALL exit successfully without writing any linker configuration
+
+#### Scenario: Darwin behavior unchanged
+- **WHEN** bootstrap runs on a macOS host
+- **THEN** it SHALL perform no mold detection, no install attempt, and no linker
+  configuration, and its output SHALL be byte-identical to pre-change behavior
+
+### Requirement: Per-machine cargo linker configuration SHALL be probe-gated, idempotent, and non-clobbering
+
+When mold is present on Linux, bootstrap SHALL wire it through a delimited managed block in
+the per-machine `~/.cargo/config.toml` containing `[target.x86_64-unknown-linux-gnu]` and
+`[target.aarch64-unknown-linux-gnu]` sections that link via mold. The block SHALL be
+written only after a successful link probe proving the resolved C compiler accepts
+`-fuse-ld=mold`; the repo-committed `.cargo/config.toml` SHALL NOT be modified.
+
+#### Scenario: fresh machine gets the managed block
+- **GIVEN** a Linux host with mold present and a C compiler that passes the link probe
+- **WHEN** bootstrap runs
+- **THEN** `~/.cargo/config.toml` SHALL contain exactly one managed block with both Linux
+  target sections routing linking through mold
+
+#### Scenario: re-run is idempotent
+- **WHEN** bootstrap runs twice on the same host
+- **THEN** the managed block SHALL appear exactly once, with no duplicate or conflicting
+  target sections
+
+#### Scenario: unrelated user configuration is preserved
+- **GIVEN** a `~/.cargo/config.toml` containing user content outside the managed block
+- **WHEN** bootstrap runs
+- **THEN** all content outside the managed-block markers SHALL be preserved byte-for-byte
+
+#### Scenario: failed link probe writes nothing
+- **GIVEN** a Linux host with mold present but no C compiler that accepts `-fuse-ld=mold`
+- **WHEN** bootstrap runs
+- **THEN** it SHALL emit a `warn` and SHALL NOT write or modify the managed block
+
+#### Scenario: repo config untouched
+- **WHEN** bootstrap runs on any host
+- **THEN** the repository's committed `.cargo/config.toml` SHALL be unmodified
+
+### Requirement: The gate summary SHALL stamp mold state on Linux hosts
+
+On Linux, every `scripts/agent-gate.sh` summary's `accelerators:` line SHALL carry a
+`mold=` token with one of three states: `linked` (binary present and the managed block is
+active in the resolved cargo config), `present-unconfigured` (binary present, block
+absent), or `absent` (binary missing). On Darwin the `accelerators:` line SHALL be
+unchanged (no mold token).
+
+#### Scenario: configured Linux worker stamps linked
+- **GIVEN** a Linux host with mold installed and the managed block active
+- **WHEN** any gate mode emits its summary
+- **THEN** the `accelerators:` line SHALL contain `mold=linked`
+
+#### Scenario: installed-but-unwired is visible
+- **GIVEN** a Linux host with mold on PATH but no managed block
+- **WHEN** the gate emits its summary
+- **THEN** the `accelerators:` line SHALL contain `mold=present-unconfigured`
+
+#### Scenario: absent is visible
+- **GIVEN** a Linux host without mold
+- **WHEN** the gate emits its summary
+- **THEN** the `accelerators:` line SHALL contain `mold=absent`
+
+#### Scenario: Darwin summary unchanged
+- **WHEN** the gate emits its summary on a macOS host
+- **THEN** the `accelerators:` line SHALL contain no `mold=` token and SHALL be
+  byte-identical in format to pre-change output

--- a/openspec/changes/mold-linux-workers/tasks.md
+++ b/openspec/changes/mold-linux-workers/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — mold on Linux agent workers (issue #2859)
+
+## 1. Bootstrap: detection + install (surface: `scripts/bootstrap-agent-machine.sh`)
+- [ ] 1.1 Linux branch: detect `mold`; `ok` line with version when present
+- [ ] 1.2 Install via detected package manager (apt/dnf/yum/pacman) when missing; `warn`
+      with cost estimate when no manager matches (advisory, never fails the run)
+- [ ] 1.3 Link probe: verify resolved C compiler accepts `-fuse-ld=mold` (cc, then clang
+      fallback) before any config write
+
+## 2. Bootstrap: managed cargo config block (surface: `~/.cargo/config.toml` writer in bootstrap)
+- [ ] 2.1 Write delimited `BEGIN/END cqlite-mold` block with both Linux target triples;
+      `linker = "clang"` variant when only clang passed the probe
+- [ ] 2.2 Idempotent replace-the-block on re-run; preserve all content outside markers
+- [ ] 2.3 Never touch repo `.cargo/config.toml`; Darwin branch performs none of this
+
+## 3. Gate stamp (surface: `scripts/agent-gate.sh` `accelerators:` line)
+- [ ] 3.1 Linux: emit `mold=linked | present-unconfigured | absent` per spec semantics
+- [ ] 3.2 Darwin: output byte-identical to pre-change (no token)
+
+## 4. Tests (surfaces: `scripts/tests/test_bootstrap_agent_machine.sh`, `scripts/tests/test_agent_gate_summary.sh`)
+- [ ] 4.1 Bootstrap self-tests: Linux present/missing/no-manager/probe-fail paths; Darwin
+      no-op; idempotent re-run; unrelated-config preservation (simulated HOME + stubbed
+      `uname`/`command -v`)
+- [ ] 4.2 Gate summary self-test: three mold states on Linux; Darwin unchanged
+
+## 5. Measurement (one-time, pre-merge; recorded on issue/PR)
+- [ ] 5.1 A/B on one EC2 worker on the post-#2856 toolchain: full gate + one `--lite`
+      round wall-clock, with/without mold, both numbers posted to #2859/PR
+
+## 6. Docs (same change)
+- [ ] 6.1 `docs/development/gate-ops.md`: mold accelerator + stamp states
+- [ ] 6.2 fleet-runbook: Linux worker provisioning step + one-time sccache cold rebuild note
+
+## 7. Quality gates
+- [ ] 7.1 `--lite` green each round (summary-file redirect)
+- [ ] 7.2 rust-reviewer + roborev on the lite-green diff (review-first)
+- [ ] 7.3 flow-closer: ONE full gate of record → C intent audit (spec-auditor vs this
+      change's specs/**) → final roborev → merge-on-green → finalize

--- a/openspec/changes/mold-linux-workers/tasks.md
+++ b/openspec/changes/mold-linux-workers/tasks.md
@@ -1,35 +1,36 @@
 # Tasks — mold on Linux agent workers (issue #2859)
 
 ## 1. Bootstrap: detection + install (surface: `scripts/bootstrap-agent-machine.sh`)
-- [ ] 1.1 Linux branch: detect `mold`; `ok` line with version when present
-- [ ] 1.2 Install via detected package manager (apt/dnf/yum/pacman) when missing; `warn`
+- [x] 1.1 Linux branch: detect `mold`; `ok` line with version when present
+- [x] 1.2 Install via detected package manager (apt/dnf/yum/pacman) when missing; `warn`
       with cost estimate when no manager matches (advisory, never fails the run)
-- [ ] 1.3 Link probe: verify resolved C compiler accepts `-fuse-ld=mold` (cc, then clang
+- [x] 1.3 Link probe: verify resolved C compiler accepts `-fuse-ld=mold` (cc, then clang
       fallback) before any config write
 
 ## 2. Bootstrap: managed cargo config block (surface: `~/.cargo/config.toml` writer in bootstrap)
-- [ ] 2.1 Write delimited `BEGIN/END cqlite-mold` block with both Linux target triples;
+- [x] 2.1 Write delimited `BEGIN/END cqlite-mold` block with both Linux target triples;
       `linker = "clang"` variant when only clang passed the probe
-- [ ] 2.2 Idempotent replace-the-block on re-run; preserve all content outside markers
-- [ ] 2.3 Never touch repo `.cargo/config.toml`; Darwin branch performs none of this
+- [x] 2.2 Idempotent replace-the-block on re-run; preserve all content outside markers
+- [x] 2.3 Never touch repo `.cargo/config.toml`; Darwin branch performs none of this
 
 ## 3. Gate stamp (surface: `scripts/agent-gate.sh` `accelerators:` line)
-- [ ] 3.1 Linux: emit `mold=linked | present-unconfigured | absent` per spec semantics
-- [ ] 3.2 Darwin: output byte-identical to pre-change (no token)
+- [x] 3.1 Linux: emit `mold=linked | present-unconfigured | absent` per spec semantics
+- [x] 3.2 Darwin: output byte-identical to pre-change (no token)
 
 ## 4. Tests (surfaces: `scripts/tests/test_bootstrap_agent_machine.sh`, `scripts/tests/test_agent_gate_summary.sh`)
-- [ ] 4.1 Bootstrap self-tests: Linux present/missing/no-manager/probe-fail paths; Darwin
+- [x] 4.1 Bootstrap self-tests: Linux present/missing/no-manager/probe-fail paths; Darwin
       no-op; idempotent re-run; unrelated-config preservation (simulated HOME + stubbed
       `uname`/`command -v`)
-- [ ] 4.2 Gate summary self-test: three mold states on Linux; Darwin unchanged
+- [x] 4.2 Gate summary self-test: three mold states on Linux; Darwin unchanged
 
 ## 5. Measurement (one-time, pre-merge; recorded on issue/PR)
 - [ ] 5.1 A/B on one EC2 worker on the post-#2856 toolchain: full gate + one `--lite`
       round wall-clock, with/without mold, both numbers posted to #2859/PR
+      (EXTERNAL — cannot run from a macOS dev box; pending an EC2 Linux worker)
 
 ## 6. Docs (same change)
-- [ ] 6.1 `docs/development/gate-ops.md`: mold accelerator + stamp states
-- [ ] 6.2 fleet-runbook: Linux worker provisioning step + one-time sccache cold rebuild note
+- [x] 6.1 `docs/development/gate-ops.md`: mold accelerator + stamp states
+- [x] 6.2 fleet-runbook: Linux worker provisioning step + one-time sccache cold rebuild note
 
 ## 7. Quality gates
 - [ ] 7.1 `--lite` green each round (summary-file redirect)

--- a/openspec/changes/mold-linux-workers/tasks.md
+++ b/openspec/changes/mold-linux-workers/tasks.md
@@ -25,8 +25,9 @@
 
 ## 5. Measurement (one-time, pre-merge; recorded on issue/PR)
 - [ ] 5.1 A/B on one EC2 worker on the post-#2856 toolchain: full gate + one `--lite`
-      round wall-clock, with/without mold, both numbers posted to #2859/PR
-      (EXTERNAL — cannot run from a macOS dev box; pending an EC2 Linux worker)
+      round wall-clock, with/without mold. OWNER WAIVED pre-merge (2026-07-24, in-session):
+      merge on green; numbers recorded POST-merge on the follow-up issue at the next
+      worker provisioning cycle.
 
 ## 6. Docs (same change)
 - [x] 6.1 `docs/development/gate-ops.md`: mold accelerator + stamp states

--- a/openspec/changes/mold-linux-workers/tasks.md
+++ b/openspec/changes/mold-linux-workers/tasks.md
@@ -33,7 +33,7 @@
 - [x] 6.2 fleet-runbook: Linux worker provisioning step + one-time sccache cold rebuild note
 
 ## 7. Quality gates
-- [ ] 7.1 `--lite` green each round (summary-file redirect)
+- [x] 7.1 `--lite` green each round (summary-file redirect)
 - [ ] 7.2 rust-reviewer + roborev on the lite-green diff (review-first)
 - [ ] 7.3 flow-closer: ONE full gate of record → C intent audit (spec-auditor vs this
       change's specs/**) → final roborev → merge-on-green → finalize

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -541,14 +541,69 @@ _sccache_health() {
   printf '%s' "$_SCCACHE_HEALTH"
 }
 
+# ---- mold link-accelerator state (issue #2859) ------------------------------
+# On Linux agent workers the link step is the one build cost sccache cannot cache
+# (every --lite round and full gate re-links every test binary from scratch), so
+# bootstrap-agent-machine.sh provisions the mold linker and wires it through a
+# managed block in the per-machine ~/.cargo/config.toml. The gate surfaces that
+# state on the accelerators: line so an installed-but-unwired worker (silent
+# degradation) is visible in the pasted block — exactly the contract sccache
+# follows. Three states, Linux hosts ONLY:
+#   linked                — mold on PATH AND the managed block is active in the
+#                           resolved cargo config (bootstrap wired it)
+#   present-unconfigured  — mold on PATH but no managed block (bootstrap not re-run)
+#   absent                — mold not on PATH
+# Darwin (and any non-Linux host) emits NO mold token: mold is Linux-only and a
+# permanent n/a token would churn every existing summary parser/fixture for zero
+# signal. Test hooks (issue #2859 self-test): AGENT_GATE_TEST_OS forces the host
+# family and AGENT_GATE_TEST_MOLD_STATE forces the detected state, so linked /
+# present-unconfigured / absent (and the Darwin no-token case) assert
+# deterministically without mold installed or a real ~/.cargo/config.toml.
+
+# _mold_block_active: true when the bootstrap-managed block is present in the
+# resolved per-machine cargo config (config.toml or the extension-less config).
+_mold_block_active() {
+  local cfg_dir="${CARGO_HOME:-$HOME/.cargo}"
+  grep -q '^# BEGIN cqlite-mold' "$cfg_dir/config.toml" 2>/dev/null && return 0
+  grep -q '^# BEGIN cqlite-mold' "$cfg_dir/config" 2>/dev/null && return 0
+  return 1
+}
+
+# _mold_state: resolve linked|present-unconfigured|absent, memoized.
+_MOLD_STATE=""
+_mold_state() {
+  [ -n "$_MOLD_STATE" ] && { printf '%s' "$_MOLD_STATE"; return; }
+  if [ -n "${AGENT_GATE_TEST_MOLD_STATE:-}" ]; then
+    _MOLD_STATE="$AGENT_GATE_TEST_MOLD_STATE"
+  elif ! command -v mold >/dev/null 2>&1; then
+    _MOLD_STATE=absent
+  elif _mold_block_active; then
+    _MOLD_STATE=linked
+  else
+    _MOLD_STATE=present-unconfigured
+  fi
+  printf '%s' "$_MOLD_STATE"
+}
+
+# _mold_accel_token: the ` mold=<state>` suffix on Linux hosts, empty elsewhere.
+_mold_accel_token() {
+  local os="${AGENT_GATE_TEST_OS:-$(uname -s 2>/dev/null || echo unknown)}"
+  case "$os" in
+    Linux|linux) printf ' mold=%s' "$(_mold_state)" ;;
+    *) : ;; # Darwin/other: no token — byte-identical to pre-#2859 output
+  esac
+}
+
 # accelerators_line: the machine-checkable one-liner stamped into every SUMMARY
 # block (full, lite, and the emission selftest). Values: on|absent|off|serial.
 # See the ACCEL_* detection above (#1848). The trailing sccache-health token
-# (na|ok|warn, issue #2641) surfaces sccache's own corruption counters.
+# (na|ok|warn, issue #2641) surfaces sccache's own corruption counters. On Linux
+# a ` mold=linked|present-unconfigured|absent` token follows (issue #2859); Darwin
+# output is unchanged.
 accelerators_line() {
-  printf 'accelerators: sccache=%s nextest=%s lanes=%s sccache-health=%s' \
+  printf 'accelerators: sccache=%s nextest=%s lanes=%s sccache-health=%s%s' \
     "${ACCEL_SCCACHE:-unknown}" "${ACCEL_NEXTEST:-unknown}" "${ACCEL_LANES:-unknown}" \
-    "$(_sccache_health)"
+    "$(_sccache_health)" "$(_mold_accel_token)"
 }
 
 # ---- Per-gate core budget (issue #2640) -------------------------------------

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -572,15 +572,26 @@ _sccache_health() {
 _MOLD_BEGIN_MARKER='# BEGIN cqlite-mold (managed by scripts/bootstrap-agent-machine.sh — do not edit inside)'
 
 # _mold_block_active: true when the bootstrap-managed block is present in the
-# resolved per-machine cargo config (config.toml or the extension-less config).
+# per-machine cargo config file cargo ACTUALLY reads. Cargo prefers the
+# extension-less `config` over `config.toml` when BOTH exist (a documented legacy
+# precedence), so we probe ONLY the effective file — checking both would report
+# `linked` on a both-files machine where the block sits in the ignored `config.toml`.
 _mold_block_active() {
-  local cfg_dir="${CARGO_HOME:-$HOME/.cargo}"
-  grep -Fxq "$_MOLD_BEGIN_MARKER" "$cfg_dir/config.toml" 2>/dev/null && return 0
-  grep -Fxq "$_MOLD_BEGIN_MARKER" "$cfg_dir/config" 2>/dev/null && return 0
-  return 1
+  local cfg_dir="${CARGO_HOME:-$HOME/.cargo}" f
+  if [ -f "$cfg_dir/config" ]; then
+    f="$cfg_dir/config"
+  elif [ -f "$cfg_dir/config.toml" ]; then
+    f="$cfg_dir/config.toml"
+  else
+    return 1
+  fi
+  grep -Fxq "$_MOLD_BEGIN_MARKER" "$f" 2>/dev/null
 }
 
 # _mold_state: resolve linked|overridden|present-unconfigured|absent, memoized.
+# A non-empty RUSTFLAGS **or** CARGO_ENCODED_RUSTFLAGS in the gate environment
+# suppresses cargo's target.rustflags entirely (encoded takes even higher
+# precedence), so either one turns an otherwise-`linked` state into `overridden`.
 _MOLD_STATE=""
 _mold_state() {
   [ -n "$_MOLD_STATE" ] && { printf '%s' "$_MOLD_STATE"; return; }
@@ -588,9 +599,10 @@ _mold_state() {
     _MOLD_STATE="$AGENT_GATE_TEST_MOLD_STATE"
   elif ! command -v mold >/dev/null 2>&1; then
     _MOLD_STATE=absent
-  elif [ -n "${RUSTFLAGS:-}" ] && _mold_block_active; then
-    # Managed block present but a global RUSTFLAGS suppresses it → honest signal
-    # that the wired -fuse-ld=mold is NOT in effect.
+  elif { [ -n "${RUSTFLAGS:-}" ] || [ -n "${CARGO_ENCODED_RUSTFLAGS:-}" ]; } \
+       && _mold_block_active; then
+    # Managed block present but a global (encoded-)RUSTFLAGS suppresses it →
+    # honest signal that the wired -fuse-ld=mold is NOT in effect.
     _MOLD_STATE=overridden
   elif _mold_block_active; then
     _MOLD_STATE=linked

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -548,28 +548,39 @@ _sccache_health() {
 # managed block in the per-machine ~/.cargo/config.toml. The gate surfaces that
 # state on the accelerators: line so an installed-but-unwired worker (silent
 # degradation) is visible in the pasted block — exactly the contract sccache
-# follows. Three states, Linux hosts ONLY:
+# follows. Four states, Linux hosts ONLY:
 #   linked                — mold on PATH AND the managed block is active in the
 #                           resolved cargo config (bootstrap wired it)
+#   overridden            — a non-empty RUSTFLAGS is exported in the gate
+#                           environment: env RUSTFLAGS SUPPRESSES cargo's
+#                           target.rustflags entirely, so the managed block's
+#                           -fuse-ld=mold is NOT applied and a bare `linked` would
+#                           LIE. This is the exact footgun the token exists to
+#                           surface (never export global RUSTFLAGS on a worker).
 #   present-unconfigured  — mold on PATH but no managed block (bootstrap not re-run)
 #   absent                — mold not on PATH
 # Darwin (and any non-Linux host) emits NO mold token: mold is Linux-only and a
 # permanent n/a token would churn every existing summary parser/fixture for zero
 # signal. Test hooks (issue #2859 self-test): AGENT_GATE_TEST_OS forces the host
-# family and AGENT_GATE_TEST_MOLD_STATE forces the detected state, so linked /
-# present-unconfigured / absent (and the Darwin no-token case) assert
-# deterministically without mold installed or a real ~/.cargo/config.toml.
+# family and AGENT_GATE_TEST_MOLD_STATE forces the detected state, so the four
+# states (and the Darwin no-token case) assert deterministically without mold
+# installed or a real ~/.cargo/config.toml.
+
+# The EXACT managed-block begin marker bootstrap-agent-machine.sh writes. Match the
+# full line (grep -Fxq) — NOT a prefix — so a user's own `# BEGIN cqlite-mold-...`
+# comment can never false-positive as the managed block.
+_MOLD_BEGIN_MARKER='# BEGIN cqlite-mold (managed by scripts/bootstrap-agent-machine.sh — do not edit inside)'
 
 # _mold_block_active: true when the bootstrap-managed block is present in the
 # resolved per-machine cargo config (config.toml or the extension-less config).
 _mold_block_active() {
   local cfg_dir="${CARGO_HOME:-$HOME/.cargo}"
-  grep -q '^# BEGIN cqlite-mold' "$cfg_dir/config.toml" 2>/dev/null && return 0
-  grep -q '^# BEGIN cqlite-mold' "$cfg_dir/config" 2>/dev/null && return 0
+  grep -Fxq "$_MOLD_BEGIN_MARKER" "$cfg_dir/config.toml" 2>/dev/null && return 0
+  grep -Fxq "$_MOLD_BEGIN_MARKER" "$cfg_dir/config" 2>/dev/null && return 0
   return 1
 }
 
-# _mold_state: resolve linked|present-unconfigured|absent, memoized.
+# _mold_state: resolve linked|overridden|present-unconfigured|absent, memoized.
 _MOLD_STATE=""
 _mold_state() {
   [ -n "$_MOLD_STATE" ] && { printf '%s' "$_MOLD_STATE"; return; }
@@ -577,6 +588,10 @@ _mold_state() {
     _MOLD_STATE="$AGENT_GATE_TEST_MOLD_STATE"
   elif ! command -v mold >/dev/null 2>&1; then
     _MOLD_STATE=absent
+  elif [ -n "${RUSTFLAGS:-}" ] && _mold_block_active; then
+    # Managed block present but a global RUSTFLAGS suppresses it → honest signal
+    # that the wired -fuse-ld=mold is NOT in effect.
+    _MOLD_STATE=overridden
   elif _mold_block_active; then
     _MOLD_STATE=linked
   else
@@ -598,8 +613,8 @@ _mold_accel_token() {
 # block (full, lite, and the emission selftest). Values: on|absent|off|serial.
 # See the ACCEL_* detection above (#1848). The trailing sccache-health token
 # (na|ok|warn, issue #2641) surfaces sccache's own corruption counters. On Linux
-# a ` mold=linked|present-unconfigured|absent` token follows (issue #2859); Darwin
-# output is unchanged.
+# a ` mold=linked|overridden|present-unconfigured|absent` token follows (issue
+# #2859); Darwin output is unchanged.
 accelerators_line() {
   printf 'accelerators: sccache=%s nextest=%s lanes=%s sccache-health=%s%s' \
     "${ACCEL_SCCACHE:-unknown}" "${ACCEL_NEXTEST:-unknown}" "${ACCEL_LANES:-unknown}" \

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -122,9 +122,10 @@ mold_target_section() {
 # config. Strips any prior block (and one blank line immediately preceding it) so
 # re-runs are byte-idempotent, preserves everything else, then appends the block
 # with both Linux target triples. Writes into whichever config file cargo actually
-# reads — `config.toml` wins when both exist, else the extension-less `config` —
-# so a machine that only has the legacy `~/.cargo/config` never gets a shadow
-# `config.toml` that cargo silently prefers, dropping the user's whole config.
+# reads — the extension-less `config` WINS when both exist (a documented legacy
+# precedence cargo warns about), else `config.toml` — so a machine that only has
+# the legacy `~/.cargo/config` never gets a shadow file that cargo would ignore,
+# and a both-files machine never has the block land in the ignored file.
 mold_write_block() {
   local linker="$1"
   local cfg_dir cfg_file preserved
@@ -133,10 +134,10 @@ mold_write_block() {
     warn "could not create $cfg_dir — skipping mold linker config"
     return 0
   fi
-  if [ -f "$cfg_dir/config.toml" ]; then
-    cfg_file="$cfg_dir/config.toml"
-  elif [ -f "$cfg_dir/config" ]; then
+  if [ -f "$cfg_dir/config" ]; then
     cfg_file="$cfg_dir/config"
+  elif [ -f "$cfg_dir/config.toml" ]; then
+    cfg_file="$cfg_dir/config.toml"
   else
     cfg_file="$cfg_dir/config.toml"
   fi
@@ -159,7 +160,7 @@ mold_write_block() {
   else
     : >"$preserved"
   fi
-  # Fail-safe: a user-defined [target.<triple>-unknown-linux-gnu] section OUTSIDE
+  # Fail-safe #1: a user-defined [target.<triple>-unknown-linux-gnu] section OUTSIDE
   # our markers would collide with the block we append (TOML table redefinition =
   # cargo parse error on EVERY invocation). Never risk it — warn and write nothing,
   # leaving the file byte-identical.
@@ -168,6 +169,30 @@ mold_write_block() {
     rm -f "$preserved"
     return 0
   fi
+  # Fail-safe #2: a pre-existing [build] rustflags (or a dotted build.rustflags) is
+  # first-match-wins over our target.rustflags — writing the block would SILENTLY
+  # disable the user's global flags. Same posture: warn and write nothing.
+  if awk '
+      /^\[build\]/ { inbuild = 1; next }
+      /^\[/        { inbuild = 0 }
+      inbuild && /^[[:space:]]*rustflags[[:space:]]*=/ { found = 1 }
+      /^[[:space:]]*build\.rustflags[[:space:]]*=/     { found = 1 }
+      END { exit(found ? 0 : 1) }
+    ' "$preserved"; then
+    warn "existing [build] rustflags in $cfg_file — writing NO mold block (target.rustflags would silently disable the user's build rustflags); add \"-C link-arg=-fuse-ld=mold\" to that rustflags list by hand, or remove it and re-run bootstrap"
+    rm -f "$preserved"
+    return 0
+  fi
+  # Atomic write: build the new content in a temp file in the SAME directory, then
+  # rename over the target — so an ENOSPC/interrupt mid-write can never leave a
+  # truncated config (which would break every cargo invocation). Resolve a symlink
+  # to its target so we never silently replace a symlinked config with a plain file.
+  local write_target="$cfg_file" tmpw
+  if [ -L "$cfg_file" ]; then
+    write_target=$(readlink -f "$cfg_file" 2>/dev/null || echo "$cfg_file")
+  fi
+  tmpw=$(mktemp "$(dirname "$write_target")/.cqlite-mold.XXXXXX" 2>/dev/null) \
+    || { warn "mktemp failed in $(dirname "$write_target") — skipping mold linker config"; rm -f "$preserved"; return 0; }
   {
     cat "$preserved"
     [ -s "$preserved" ] && printf '\n'
@@ -176,9 +201,14 @@ mold_write_block() {
     printf '\n'
     mold_target_section "aarch64-unknown-linux-gnu" "$linker"
     printf '%s\n' "$MOLD_END"
-  } >"$cfg_file"
+  } >"$tmpw"
   rm -f "$preserved"
-  ok "wrote mold managed block to $cfg_file (both Linux target triples${linker:+, linker=$linker})"
+  if mv -f "$tmpw" "$write_target"; then
+    ok "wrote mold managed block to $cfg_file (both Linux target triples${linker:+, linker=$linker})"
+  else
+    warn "could not install mold config at $write_target — original left intact"
+    rm -f "$tmpw"
+  fi
 }
 
 # mold_configure_linux: link-probe cc (then clang) and, on success, wire mold via
@@ -293,7 +323,15 @@ if [ "$PLATFORM" = linux ]; then
     else
       warn "no supported package manager (apt/dnf/yum/pacman) found — install mold manually"
     fi
-    info "linker config is written only after mold is installed AND a link probe passes — re-run bootstrap once mold is on PATH"
+    # Under --yes the install above may have just placed mold on PATH; wire it NOW
+    # (probe + managed block) so one --yes run delivers the FULL acceleration. In
+    # print-only mode nothing was installed, so keep the re-run hint instead.
+    if [ "$AUTO_YES" = 1 ] && have mold; then
+      ok "mold now present ($(mold --version 2>/dev/null | head -1)) — configuring linker"
+      mold_configure_linux
+    else
+      info "linker config is written only after mold is installed AND a link probe passes — re-run bootstrap once mold is on PATH"
+    fi
   fi
 fi
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -9,9 +9,11 @@
 # What it verifies:
 #   1. Rust toolchain (cargo) — needed to build + to `cargo install` on Linux.
 #   2. Accelerators the gate auto-detects (issue #1848): sccache, cargo-nextest,
-#      modern bash (>=4.3 for parallel component lanes). Detection here MIRRORS
-#      the gate's ACCEL_* block (scripts/agent-gate.sh, "sccache auto-detect" /
-#      "cargo-nextest auto-detect" / "ACCEL_LANES") so the two can never disagree
+#      modern bash (>=4.3 for parallel component lanes), and — on Linux only —
+#      the mold linker (issue #2859), wired via a managed block in the per-machine
+#      ~/.cargo/config.toml. Detection here MIRRORS the gate's ACCEL_* block
+#      (scripts/agent-gate.sh, "sccache auto-detect" / "cargo-nextest auto-detect"
+#      / "ACCEL_LANES" / "mold link-accelerator") so the two can never disagree
 #      about whether an accelerator is present. The final health check below
 #      re-reads the state straight from the gate to reconcile.
 #   3. gh auth + the `project` scope (Path A board dispatch, #1886).
@@ -39,7 +41,7 @@ for arg in "$@"; do
     --yes|-y) AUTO_YES=1 ;;
     --skip-smoke) SKIP_SMOKE=1 ;;
     -h|--help)
-      sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,31p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *) echo "bootstrap: unknown arg: $arg (try --help)" >&2; exit 2 ;;
   esac
@@ -119,15 +121,24 @@ mold_target_section() {
 # mold_write_block <linker>: (re)write the managed block in the per-machine cargo
 # config. Strips any prior block (and one blank line immediately preceding it) so
 # re-runs are byte-idempotent, preserves everything else, then appends the block
-# with both Linux target triples.
+# with both Linux target triples. Writes into whichever config file cargo actually
+# reads — `config.toml` wins when both exist, else the extension-less `config` —
+# so a machine that only has the legacy `~/.cargo/config` never gets a shadow
+# `config.toml` that cargo silently prefers, dropping the user's whole config.
 mold_write_block() {
   local linker="$1"
   local cfg_dir cfg_file preserved
   cfg_dir="${CARGO_HOME:-$HOME/.cargo}"
-  cfg_file="$cfg_dir/config.toml"
   if ! mkdir -p "$cfg_dir" 2>/dev/null; then
     warn "could not create $cfg_dir — skipping mold linker config"
     return 0
+  fi
+  if [ -f "$cfg_dir/config.toml" ]; then
+    cfg_file="$cfg_dir/config.toml"
+  elif [ -f "$cfg_dir/config" ]; then
+    cfg_file="$cfg_dir/config"
+  else
+    cfg_file="$cfg_dir/config.toml"
   fi
   preserved=$(mktemp) || { warn "mktemp failed — skipping mold linker config"; return 0; }
   if [ -f "$cfg_file" ]; then
@@ -147,6 +158,15 @@ mold_write_block() {
     ' "$cfg_file" >"$preserved"
   else
     : >"$preserved"
+  fi
+  # Fail-safe: a user-defined [target.<triple>-unknown-linux-gnu] section OUTSIDE
+  # our markers would collide with the block we append (TOML table redefinition =
+  # cargo parse error on EVERY invocation). Never risk it — warn and write nothing,
+  # leaving the file byte-identical.
+  if grep -Eq '^\[target\.(x86_64|aarch64)-unknown-linux-gnu\]' "$preserved"; then
+    warn "existing [target.<triple>-unknown-linux-gnu] section in $cfg_file — writing NO mold block (a second table would be a cargo parse error); add \"-C link-arg=-fuse-ld=mold\" to that section by hand, or remove it and re-run bootstrap"
+    rm -f "$preserved"
+    return 0
   fi
   {
     cat "$preserved"
@@ -260,8 +280,10 @@ if [ "$PLATFORM" = linux ]; then
     mold_configure_linux
   else
     warn "mold MISSING — $MOLD_COST"
-    if have apt-get || have apt; then
+    if have apt-get; then
       run_or_print mold sudo apt-get install -y mold
+    elif have apt; then
+      run_or_print mold sudo apt install -y mold
     elif have dnf; then
       run_or_print mold sudo dnf install -y mold
     elif have yum; then

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -82,6 +82,102 @@ brew_or_cargo() {
   fi
 }
 
+# ---- mold link accelerator helpers (Linux only, issue #2859) ----
+# mold is the fast Linux linker; linking is the one build cost sccache cannot
+# cache, so every --lite round and full gate re-links every test binary from
+# scratch. These helpers detect/install mold, prove the toolchain accepts it via a
+# link probe, and wire it through a delimited managed block in the PER-MACHINE
+# ~/.cargo/config.toml (honoring $CARGO_HOME). They NEVER touch the repo-committed
+# .cargo/config.toml, are idempotent (replace-the-block), and preserve all content
+# outside the markers. All of this is inert on non-Linux hosts (gated by the caller).
+MOLD_BEGIN='# BEGIN cqlite-mold (managed by scripts/bootstrap-agent-machine.sh — do not edit inside)'
+MOLD_END='# END cqlite-mold'
+
+# mold_link_probe <compiler>: true iff <compiler> links a trivial program with
+# -fuse-ld=mold (proves the toolchain will not break linking before we write config).
+mold_link_probe() {
+  local cc="$1"
+  have "$cc" || return 1
+  local d
+  d=$(mktemp -d 2>/dev/null) || return 1
+  printf 'int main(void){return 0;}\n' >"$d/probe.c"
+  local rc=0
+  "$cc" -fuse-ld=mold "$d/probe.c" -o "$d/probe" >/dev/null 2>&1 || rc=1
+  rm -rf "$d"
+  return $rc
+}
+
+# mold_target_section <triple> <linker>: emit one cargo [target.<triple>] section
+# routing linking through mold; adds `linker = "<linker>"` only when non-empty.
+mold_target_section() {
+  local triple="$1" linker="$2"
+  printf '[target.%s]\n' "$triple"
+  [ -n "$linker" ] && printf 'linker = "%s"\n' "$linker"
+  printf 'rustflags = ["-C", "link-arg=-fuse-ld=mold"]\n'
+}
+
+# mold_write_block <linker>: (re)write the managed block in the per-machine cargo
+# config. Strips any prior block (and one blank line immediately preceding it) so
+# re-runs are byte-idempotent, preserves everything else, then appends the block
+# with both Linux target triples.
+mold_write_block() {
+  local linker="$1"
+  local cfg_dir cfg_file preserved
+  cfg_dir="${CARGO_HOME:-$HOME/.cargo}"
+  cfg_file="$cfg_dir/config.toml"
+  if ! mkdir -p "$cfg_dir" 2>/dev/null; then
+    warn "could not create $cfg_dir — skipping mold linker config"
+    return 0
+  fi
+  preserved=$(mktemp) || { warn "mktemp failed — skipping mold linker config"; return 0; }
+  if [ -f "$cfg_file" ]; then
+    awk -v b="$MOLD_BEGIN" -v e="$MOLD_END" '
+      { lines[NR] = $0 }
+      END {
+        start = 0
+        for (i = 1; i <= NR; i++) if (lines[i] == b) { start = i; break }
+        if (start == 0) { for (i = 1; i <= NR; i++) print lines[i]; exit }
+        endi = 0
+        for (i = start; i <= NR; i++) if (lines[i] == e) { endi = i; break }
+        if (endi == 0) endi = NR
+        rmstart = start
+        if (start > 1 && lines[start-1] == "") rmstart = start - 1
+        for (i = 1; i <= NR; i++) if (i < rmstart || i > endi) print lines[i]
+      }
+    ' "$cfg_file" >"$preserved"
+  else
+    : >"$preserved"
+  fi
+  {
+    cat "$preserved"
+    [ -s "$preserved" ] && printf '\n'
+    printf '%s\n' "$MOLD_BEGIN"
+    mold_target_section "x86_64-unknown-linux-gnu" "$linker"
+    printf '\n'
+    mold_target_section "aarch64-unknown-linux-gnu" "$linker"
+    printf '%s\n' "$MOLD_END"
+  } >"$cfg_file"
+  rm -f "$preserved"
+  ok "wrote mold managed block to $cfg_file (both Linux target triples${linker:+, linker=$linker})"
+}
+
+# mold_configure_linux: link-probe cc (then clang) and, on success, wire mold via
+# the managed block. Fail-safe: if no compiler accepts -fuse-ld=mold, WARN and
+# write NOTHING (a machine must never end up with a config that breaks linking).
+mold_configure_linux() {
+  local linker=""
+  if mold_link_probe cc; then
+    ok "link probe passed (cc accepts -fuse-ld=mold)"
+  elif mold_link_probe clang; then
+    linker="clang"
+    ok 'link probe passed (clang accepts -fuse-ld=mold; managed block sets linker = "clang")'
+  else
+    warn "link probe FAILED — no C compiler accepts -fuse-ld=mold; writing NO linker config (fail-safe)"
+    return 0
+  fi
+  mold_write_block "$linker"
+}
+
 echo "CQLite agent-machine bootstrap (issue #1921) — platform: $PLATFORM"
 
 # ---- 1. Rust toolchain ----
@@ -147,6 +243,35 @@ else
     info "note: macOS ships bash 3.2; brew's bash lands on PATH ahead of /bin/bash"
   else
     info "install a newer bash via your distro package manager (apt/dnf/pacman)"
+  fi
+fi
+
+# ---- 2b. Link accelerator: mold (Linux only, issue #2859) ----
+# Advisory, mirroring the sccache/nextest ok/warn pattern: a missing or
+# uninstallable mold never fails the run. macOS is out of scope (mold is
+# Linux-only; Apple's ld-prime is already the fastest linker there) — this whole
+# section is skipped on Darwin, so Darwin output is byte-identical to pre-change.
+if [ "$PLATFORM" = linux ]; then
+  hdr "Link accelerator: mold (Linux, issue #2859)"
+  MOLD_COST="linking is the one build cost sccache cannot cache — every --lite round and full gate re-links every test binary from scratch (GNU bfd/lld are materially slower, especially on aarch64/Graviton)"
+  if have mold; then
+    ok "mold present ($(mold --version 2>/dev/null | head -1)) — fast Linux linker"
+    # Probe the toolchain, then wire mold via the per-machine cargo config block.
+    mold_configure_linux
+  else
+    warn "mold MISSING — $MOLD_COST"
+    if have apt-get || have apt; then
+      run_or_print mold sudo apt-get install -y mold
+    elif have dnf; then
+      run_or_print mold sudo dnf install -y mold
+    elif have yum; then
+      run_or_print mold sudo yum install -y mold
+    elif have pacman; then
+      run_or_print mold sudo pacman -S --noconfirm mold
+    else
+      warn "no supported package manager (apt/dnf/yum/pacman) found — install mold manually"
+    fi
+    info "linker config is written only after mold is installed AND a link probe passes — re-run bootstrap once mold is on PATH"
   fi
 fi
 

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -70,11 +70,34 @@ assert_accelerators() {
     echo "------- captured -------"; cat "$file"; echo "------------------------"
     return
   fi
+  # The optional trailing ` mold=<state>` token (issue #2859) appears on Linux
+  # hosts only; Darwin output ends at sccache-health, byte-identical to pre-change.
   if printf '%s\n' "$line" \
-       | grep -Eq '^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial) sccache-health=(na|ok|warn)$'; then
+       | grep -Eq '^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial) sccache-health=(na|ok|warn)( mold=(linked|present-unconfigured|absent))?$'; then
     ok "$label: accelerators line well-formed ($line)"
   else
     bad "$label: malformed accelerators line: '$line'"
+  fi
+}
+
+# assert_mold_token <label> <file> <expected>: assert the accelerators line's mold
+# token (issue #2859). <expected> is a state (linked|present-unconfigured|absent)
+# or the literal "none" to require NO mold token (the Darwin contract).
+assert_mold_token() {
+  local label="$1" file="$2" expected="$3" line
+  line=$(grep -E '^accelerators: ' "$file" 2>/dev/null | head -1)
+  if [ "$expected" = none ]; then
+    if printf '%s\n' "$line" | grep -q ' mold='; then
+      bad "$label: mold token present but expected none ($line)"
+    else
+      ok "$label: no mold token (Darwin contract)"
+    fi
+  else
+    if printf '%s\n' "$line" | grep -qE " mold=$expected(\$| )"; then
+      ok "$label: mold=$expected present"
+    else
+      bad "$label: expected mold=$expected, got: '$line'"
+    fi
   fi
 }
 
@@ -812,6 +835,31 @@ else
   bad "sccache-health: expected sccache-health=na when sccache not in use"
   grep '^accelerators:' "$tmp/health-na.txt" 2>/dev/null || cat "$tmp/health-na.txt"
 fi
+
+# 9d. mold link-accelerator token (issue #2859). On Linux the accelerators line
+#     carries a trailing `mold=linked|present-unconfigured|absent` token; on Darwin
+#     it carries NO mold token (byte-identical to pre-change). The host family is
+#     forced via AGENT_GATE_TEST_OS and the detected state via
+#     AGENT_GATE_TEST_MOLD_STATE, so all four cases assert deterministically without
+#     mold installed or a real ~/.cargo/config.toml.
+for state in linked present-unconfigured absent; do
+  mold_file="$tmp/mold-$state.txt"
+  AGENT_GATE_SUMMARY_FILE="$mold_file" \
+    AGENT_GATE_TEST_OS=Linux AGENT_GATE_TEST_MOLD_STATE="$state" \
+    bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+  assert_mold_token "mold-linux-$state" "$mold_file" "$state"
+  # The whole line must also still pass the (mold-aware) well-formed check.
+  assert_accelerators "mold-linux-$state" "$mold_file"
+done
+
+# 9d-darwin. Darwin emits NO mold token even with a forced state present — the
+#            token is Linux-only; macOS output ends at sccache-health.
+mold_darwin="$tmp/mold-darwin.txt"
+AGENT_GATE_SUMMARY_FILE="$mold_darwin" \
+  AGENT_GATE_TEST_OS=Darwin AGENT_GATE_TEST_MOLD_STATE=linked \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_mold_token "mold-darwin" "$mold_darwin" none
+assert_accelerators "mold-darwin" "$mold_darwin"
 
 # ============================================================================
 # ISSUE #2078: FULL gate fails CLOSED when the fetched dataset corpus is absent.

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -905,6 +905,27 @@ PATH="$mold_bin:$PATH" AGENT_GATE_SUMMARY_FILE="$mf4" \
   bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
 assert_mold_token "mold-real-overridden" "$mf4" overridden
 
+# 9e-iv-b. CARGO_ENCODED_RUSTFLAGS (higher precedence than RUSTFLAGS, same
+#          suppression) also -> overridden, even with RUSTFLAGS empty.
+mf4b="$tmp/mold-real-overridden-encoded.txt"
+PATH="$mold_bin:$PATH" AGENT_GATE_SUMMARY_FILE="$mf4b" \
+  AGENT_GATE_TEST_OS=Linux CARGO_HOME="$ch1" RUSTFLAGS='' \
+  CARGO_ENCODED_RUSTFLAGS=$'-C\x1ftarget-cpu=native' \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_mold_token "mold-real-overridden-encoded" "$mf4b" overridden
+
+# 9e-vi. BOTH config files present, block ONLY in the ignored config.toml (cargo reads
+#        the extension-less `config`) -> present-unconfigured, proving the detector
+#        probes the EFFECTIVE file, not either-of-both.
+ch6=$(mktemp -d "$tmp/mold-ch6.XXXXXX")
+printf '[net]\nretry = 1\n' >"$ch6/config"
+printf '%s\n# END cqlite-mold\n' "$MOLD_MARK" >"$ch6/config.toml"
+mf6="$tmp/mold-real-bothfiles.txt"
+PATH="$mold_bin:$PATH" AGENT_GATE_SUMMARY_FILE="$mf6" \
+  AGENT_GATE_TEST_OS=Linux CARGO_HOME="$ch6" RUSTFLAGS='' \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_mold_token "mold-real-both-files-precedence" "$mf6" present-unconfigured
+
 # 9e-v. marker alignment: a user's own `# BEGIN cqlite-mold-notours` comment (a
 #       PREFIX of, but not equal to, the managed marker) must NOT be detected as the
 #       block -> present-unconfigured, proving exact-full-line matching.

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -73,7 +73,7 @@ assert_accelerators() {
   # The optional trailing ` mold=<state>` token (issue #2859) appears on Linux
   # hosts only; Darwin output ends at sccache-health, byte-identical to pre-change.
   if printf '%s\n' "$line" \
-       | grep -Eq '^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial) sccache-health=(na|ok|warn)( mold=(linked|present-unconfigured|absent))?$'; then
+       | grep -Eq '^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial) sccache-health=(na|ok|warn)( mold=(linked|overridden|present-unconfigured|absent))?$'; then
     ok "$label: accelerators line well-formed ($line)"
   else
     bad "$label: malformed accelerators line: '$line'"
@@ -837,12 +837,11 @@ else
 fi
 
 # 9d. mold link-accelerator token (issue #2859). On Linux the accelerators line
-#     carries a trailing `mold=linked|present-unconfigured|absent` token; on Darwin
-#     it carries NO mold token (byte-identical to pre-change). The host family is
-#     forced via AGENT_GATE_TEST_OS and the detected state via
-#     AGENT_GATE_TEST_MOLD_STATE, so all four cases assert deterministically without
-#     mold installed or a real ~/.cargo/config.toml.
-for state in linked present-unconfigured absent; do
+#     carries a trailing `mold=linked|overridden|present-unconfigured|absent` token;
+#     on Darwin it carries NO mold token (byte-identical to pre-change). The host
+#     family is forced via AGENT_GATE_TEST_OS and the detected state via
+#     AGENT_GATE_TEST_MOLD_STATE, so all four states assert deterministically here.
+for state in linked overridden present-unconfigured absent; do
   mold_file="$tmp/mold-$state.txt"
   AGENT_GATE_SUMMARY_FILE="$mold_file" \
     AGENT_GATE_TEST_OS=Linux AGENT_GATE_TEST_MOLD_STATE="$state" \
@@ -860,6 +859,62 @@ AGENT_GATE_SUMMARY_FILE="$mold_darwin" \
   bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
 assert_mold_token "mold-darwin" "$mold_darwin" none
 assert_accelerators "mold-darwin" "$mold_darwin"
+
+# 9e. REAL detection (NO AGENT_GATE_TEST_MOLD_STATE override): exercise the actual
+#     `command -v mold` + `_mold_block_active` + RUSTFLAGS branches. A stub `mold` is
+#     put first on PATH and CARGO_HOME points at a temp dir we (don't) seed with the
+#     managed block, so linked / overridden / present-unconfigured are decided by the
+#     gate's real logic. The block marker must be the EXACT full line the writer emits
+#     (prefix matching would let a user's own `# BEGIN cqlite-mold-*` comment
+#     false-positive) — asserted by the notours case below.
+mold_bin="$tmp/mold-bin"; mkdir -p "$mold_bin"
+printf '#!/usr/bin/env bash\n[ "$1" = --version ] && echo "mold 2.4.0"\nexit 0\n' >"$mold_bin/mold"
+chmod +x "$mold_bin/mold"
+MOLD_MARK='# BEGIN cqlite-mold (managed by scripts/bootstrap-agent-machine.sh — do not edit inside)'
+
+# 9e-i. mold on PATH + managed block in config.toml -> linked (real detection).
+ch1=$(mktemp -d "$tmp/mold-ch1.XXXXXX")
+printf '%s\n[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "link-arg=-fuse-ld=mold"]\n# END cqlite-mold\n' "$MOLD_MARK" >"$ch1/config.toml"
+mf1="$tmp/mold-real-linked.txt"
+PATH="$mold_bin:$PATH" AGENT_GATE_SUMMARY_FILE="$mf1" \
+  AGENT_GATE_TEST_OS=Linux CARGO_HOME="$ch1" RUSTFLAGS='' \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_mold_token "mold-real-linked" "$mf1" linked
+
+# 9e-ii. managed block in the extension-less `config` file -> linked (both names read).
+ch2=$(mktemp -d "$tmp/mold-ch2.XXXXXX")
+printf '%s\n# END cqlite-mold\n' "$MOLD_MARK" >"$ch2/config"
+mf2="$tmp/mold-real-legacy.txt"
+PATH="$mold_bin:$PATH" AGENT_GATE_SUMMARY_FILE="$mf2" \
+  AGENT_GATE_TEST_OS=Linux CARGO_HOME="$ch2" RUSTFLAGS='' \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_mold_token "mold-real-legacy-config" "$mf2" linked
+
+# 9e-iii. mold on PATH, NO managed block -> present-unconfigured (real detection).
+ch3=$(mktemp -d "$tmp/mold-ch3.XXXXXX")
+mf3="$tmp/mold-real-unconf.txt"
+PATH="$mold_bin:$PATH" AGENT_GATE_SUMMARY_FILE="$mf3" \
+  AGENT_GATE_TEST_OS=Linux CARGO_HOME="$ch3" RUSTFLAGS='' \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_mold_token "mold-real-unconfigured" "$mf3" present-unconfigured
+
+# 9e-iv. managed block active BUT a non-empty RUSTFLAGS exported -> overridden.
+mf4="$tmp/mold-real-overridden.txt"
+PATH="$mold_bin:$PATH" AGENT_GATE_SUMMARY_FILE="$mf4" \
+  AGENT_GATE_TEST_OS=Linux CARGO_HOME="$ch1" RUSTFLAGS='-C target-cpu=native' \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_mold_token "mold-real-overridden" "$mf4" overridden
+
+# 9e-v. marker alignment: a user's own `# BEGIN cqlite-mold-notours` comment (a
+#       PREFIX of, but not equal to, the managed marker) must NOT be detected as the
+#       block -> present-unconfigured, proving exact-full-line matching.
+ch5=$(mktemp -d "$tmp/mold-ch5.XXXXXX")
+printf '# BEGIN cqlite-mold-notours my own note\n[build]\njobs = 2\n' >"$ch5/config.toml"
+mf5="$tmp/mold-real-notours.txt"
+PATH="$mold_bin:$PATH" AGENT_GATE_SUMMARY_FILE="$mf5" \
+  AGENT_GATE_TEST_OS=Linux CARGO_HOME="$ch5" RUSTFLAGS='' \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_mold_token "mold-real-marker-alignment" "$mf5" present-unconfigured
 
 # ============================================================================
 # ISSUE #2078: FULL gate fails CLOSED when the fetched dataset corpus is absent.

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -61,8 +61,14 @@ mkshim cargo
 mkshim roborev
 mkshim gh
 
+# Sandbox HOME/CARGO_HOME for these whole-script runs so the Linux mold branch can
+# NEVER mutate the host's real ~/.cargo/config when this runs inside tooling-tests
+# on a Linux gate box that has mold + a working cc (issue #2859 blocker 2).
+host_home="$tmp/host-home"; mkdir -p "$host_home/.cargo"
+
 # Run with the shims FIRST on PATH, default mode (no --yes), skipping the smoke.
-run_out=$(PATH="$tmp:$PATH" bash "$BOOTSTRAP" --skip-smoke 2>&1); run_rc=$?
+run_out=$(PATH="$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1); run_rc=$?
 
 if [ "$run_rc" -eq 0 ]; then
   ok "default (no --yes) run exits 0"
@@ -92,7 +98,8 @@ done
 #        still has coreutils but no sccache; assert the guidance line appears. ---
 # Reset the tripwire so the no-install assertion below reflects ONLY this run.
 : >"$tripwire"
-guard_out=$(PATH="$tmp:/usr/bin:/bin" bash "$BOOTSTRAP" --skip-smoke 2>&1)
+guard_out=$(PATH="$tmp:/usr/bin:/bin" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
 if printf '%s' "$guard_out" | grep -Eq "install sccache:|sccache MISSING"; then
   ok "missing accelerator prints install guidance (does not auto-install)"
 else
@@ -108,7 +115,6 @@ fi
 # All cases below stub `uname` (to simulate the OS), `mold`, and the C compilers,
 # and point HOME/CARGO_HOME at a sandbox so the managed block is written to a
 # throwaway ~/.cargo/config.toml — never the real one and never the repo's.
-REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 
 mk_stub() {
   # mk_stub <dir> <name> <body>
@@ -119,7 +125,14 @@ $body
 EOF
   chmod +x "$dir/$name"
 }
-count_begin() { grep -c '^# BEGIN cqlite-mold' "$1" 2>/dev/null || echo 0; }
+# count_begin <file>: number of managed-block BEGIN markers. grep -c already prints
+# a count (0 on no match) AND exits 1 — a `|| echo 0` would DOUBLE-print "0\n0", so
+# capture the count and default an empty (missing-file) result to 0 instead.
+count_begin() {
+  local n
+  n=$(grep -c '^# BEGIN cqlite-mold' "$1" 2>/dev/null)
+  echo "${n:-0}"
+}
 # Stub gh + roborev + cargo so the (unrelated) auth/agent/toolchain sections stay
 # fast and offline during these mold cases, which run bootstrap under the full PATH
 # with CARGO_HOME pointed at a throwaway dir (a real `cargo --version` there would
@@ -334,12 +347,81 @@ else
   echo "--- config ---"; cat "$cfgK"; echo "--------------"
 fi
 
-# 6i. the repository's committed .cargo/config.toml is never touched.
-repo_cfg="$REPO_ROOT/.cargo/config.toml"
-if [ -e "$repo_cfg" ]; then
-  bad "mold: repo .cargo/config.toml exists unexpectedly (test assumes it does not)"
+# 6l. BOTH config files exist (blocker 1): cargo prefers the extension-less `config`,
+#     so the block must land THERE, not in the ignored `config.toml`.
+sbL=$(mktemp -d "$tmp/moldL.XXXXXX"); mkdir -p "$sbL/.cargo"
+printf '[net]\nretry = 1\n' >"$sbL/.cargo/config"
+printf '[net]\nretry = 2\n' >"$sbL/.cargo/config.toml"
+tomlL_before=$(cat "$sbL/.cargo/config.toml")
+PATH="$stubA:$PATH" HOME="$sbL" CARGO_HOME="$sbL/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+if grep -q '^# BEGIN cqlite-mold' "$sbL/.cargo/config" \
+   && ! grep -q '^# BEGIN cqlite-mold' "$sbL/.cargo/config.toml" \
+   && [ "$tomlL_before" = "$(cat "$sbL/.cargo/config.toml")" ]; then
+  ok "mold: both files present -> block lands in the effective 'config', config.toml untouched"
 else
-  ok "mold: repo-committed .cargo/config.toml left untouched (managed block is per-machine)"
+  bad "mold: both-files precedence wrong (block in the ignored config.toml)"
+  echo "--- config ---"; cat "$sbL/.cargo/config"; echo "--- config.toml ---"; cat "$sbL/.cargo/config.toml"
+fi
+
+# 6m. pre-existing [build] rustflags (blocker 3): our target.rustflags would silently
+#     disable it (first-match-wins), so bootstrap must WARN and write NOTHING.
+sbM=$(mktemp -d "$tmp/moldM.XXXXXX"); mkdir -p "$sbM/.cargo"
+cfgM="$sbM/.cargo/config.toml"
+printf '[build]\nrustflags = ["-C", "target-cpu=native"]\n' >"$cfgM"
+beforeM=$(cat "$cfgM")
+outM=$(PATH="$stubA:$PATH" HOME="$sbM" CARGO_HOME="$sbM/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+if printf '%s' "$outM" | grep -q "existing \[build\] rustflags" \
+   && [ "$beforeM" = "$(cat "$cfgM")" ] \
+   && ! grep -q '^# BEGIN cqlite-mold' "$cfgM"; then
+  ok "mold: pre-existing [build] rustflags -> warn, file byte-identical, no block"
+else
+  bad "mold: [build] rustflags not fail-safe (block written or file changed)"
+  echo "--- config ---"; cat "$cfgM"; echo "--------------"
+fi
+
+# 6n. --yes INSTALLS then WIRES (blocker 4): the install stub places `mold` on PATH,
+#     and the same run must re-detect it and write the managed block — one --yes run
+#     delivers the full acceleration, not just the install. Runs a COPY of bootstrap in
+#     a fake repo so the --yes dataset-fetch path is a fast no-op (no such script → no
+#     network), never the real fetch-datasets.sh.
+nrepo="$tmp/n-repo"; mkdir -p "$nrepo/scripts"
+cp "$BOOTSTRAP" "$nrepo/scripts/bootstrap-agent-machine.sh"
+sbN=$(mktemp -d "$tmp/moldN.XXXXXX"); mkdir -p "$sbN/.cargo"; stubN="$tmp/stubN"
+mk_hermetic_bin "$stubN"
+mk_stub "$stubN" cc 'exit 0'
+mk_stub "$stubN" sudo 'exec "$@"'   # passthrough so `sudo apt-get …` runs the stub
+# apt-get stub: on `install … mold`, drop a real `mold` executable onto PATH.
+apt_body='installed=0; for a in "$@"; do [ "$a" = mold ] && installed=1; done; if [ "$installed" = 1 ]; then printf "#!/usr/bin/env bash\n[ \"\$1\" = --version ] && echo \"mold 2.4.0\"\nexit 0\n" > "'"$stubN/mold"'"; chmod +x "'"$stubN/mold"'"; fi; exit 0'
+mk_stub "$stubN" apt-get "$apt_body"
+PATH="$stubN" HOME="$sbN" CARGO_HOME="$sbN/.cargo" \
+  bash "$nrepo/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke >/dev/null 2>&1
+if grep -q '^# BEGIN cqlite-mold' "$sbN/.cargo/config.toml" 2>/dev/null; then
+  ok "mold: --yes installs mold then wires the managed block in the same run"
+else
+  bad "mold: --yes installed but never wired the linker config"
+  ls -la "$sbN/.cargo" 2>/dev/null
+fi
+
+# 6i. the repo's committed .cargo/config.toml is never touched (blocker 7): run a COPY
+#     of bootstrap whose BASH_SOURCE-derived REPO_ROOT is a fake repo that HAS a
+#     .cargo/config.toml, with HOME/CARGO_HOME sandboxed elsewhere. The block must go
+#     to the per-machine CARGO_HOME and the fake repo config must be byte-identical.
+fakerepo="$tmp/fakerepo"; mkdir -p "$fakerepo/scripts" "$fakerepo/.cargo"
+cp "$BOOTSTRAP" "$fakerepo/scripts/bootstrap-agent-machine.sh"
+repo_cfg="$fakerepo/.cargo/config.toml"
+printf '[registries.example]\nindex = "sparse+https://example.invalid/"\n' >"$repo_cfg"
+repo_before=$(cat "$repo_cfg")
+sbI=$(mktemp -d "$tmp/moldI.XXXXXX"); mkdir -p "$sbI/.cargo"
+PATH="$stubA:$PATH" HOME="$sbI" CARGO_HOME="$sbI/.cargo" \
+  bash "$fakerepo/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1
+if [ "$repo_before" = "$(cat "$repo_cfg")" ] \
+   && grep -q '^# BEGIN cqlite-mold' "$sbI/.cargo/config.toml"; then
+  ok "mold: repo-committed .cargo/config.toml untouched; block written to per-machine CARGO_HOME"
+else
+  bad "mold: repo config was mutated OR block did not land in CARGO_HOME"
+  echo "--- repo cfg now ---"; cat "$repo_cfg"; echo "--------------------"
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -104,6 +104,186 @@ else
   ok "guidance run performed NO installs"
 fi
 
+# --- 6. mold link accelerator on Linux (issue #2859) ------------------------
+# All cases below stub `uname` (to simulate the OS), `mold`, and the C compilers,
+# and point HOME/CARGO_HOME at a sandbox so the managed block is written to a
+# throwaway ~/.cargo/config.toml — never the real one and never the repo's.
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+mk_stub() {
+  # mk_stub <dir> <name> <body>
+  local dir="$1" name="$2" body="$3"
+  cat >"$dir/$name" <<EOF
+#!/usr/bin/env bash
+$body
+EOF
+  chmod +x "$dir/$name"
+}
+count_begin() { grep -c '^# BEGIN cqlite-mold' "$1" 2>/dev/null || echo 0; }
+# Stub gh + roborev + cargo so the (unrelated) auth/agent/toolchain sections stay
+# fast and offline during these mold cases, which run bootstrap under the full PATH
+# with CARGO_HOME pointed at a throwaway dir (a real `cargo --version` there would
+# trigger a multi-minute rustup toolchain provision into the empty CARGO_HOME).
+stub_net() {
+  mk_stub "$1" gh 'exit 0'
+  mk_stub "$1" roborev 'exit 0'
+  mk_stub "$1" cargo '[ "$1" = --version ] && echo "cargo 1.88.0"; exit 0'
+}
+
+# 6a. mold present + cc passes the probe -> managed block written, both Linux
+#     triples, NO linker line (default cc accepts -fuse-ld=mold).
+sbA=$(mktemp -d "$tmp/moldA.XXXXXX"); stubA="$tmp/stubA"; mkdir -p "$stubA"
+mk_stub "$stubA" uname 'echo Linux; exit 0'
+stub_net "$stubA"
+mk_stub "$stubA" mold '[ "$1" = --version ] && echo "mold 2.4.0"; exit 0'
+mk_stub "$stubA" cc 'exit 0'
+outA=$(PATH="$stubA:$PATH" HOME="$sbA" CARGO_HOME="$sbA/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+cfgA="$sbA/.cargo/config.toml"
+if printf '%s' "$outA" | grep -q "Link accelerator: mold"; then
+  ok "mold: Linux run emits the mold section"
+else
+  bad "mold: Linux run did not emit the mold section"
+fi
+if [ -f "$cfgA" ] \
+   && grep -q '^# BEGIN cqlite-mold' "$cfgA" \
+   && grep -q '^# END cqlite-mold' "$cfgA" \
+   && grep -q '^\[target.x86_64-unknown-linux-gnu\]' "$cfgA" \
+   && grep -q '^\[target.aarch64-unknown-linux-gnu\]' "$cfgA" \
+   && grep -q 'link-arg=-fuse-ld=mold' "$cfgA"; then
+  ok "mold: managed block written with both Linux target triples"
+else
+  bad "mold: managed block missing expected markers/triples"
+  [ -f "$cfgA" ] && { echo "--- config ---"; cat "$cfgA"; echo "--------------"; }
+fi
+if [ -f "$cfgA" ] && ! grep -q '^linker = ' "$cfgA"; then
+  ok "mold: cc-passing probe writes NO linker override"
+else
+  bad "mold: cc-passing probe unexpectedly wrote a linker override"
+fi
+
+# 6b. re-run is byte-idempotent: block appears exactly once and the file is
+#     identical to the first run.
+firstA=$(cat "$cfgA")
+PATH="$stubA:$PATH" HOME="$sbA" CARGO_HOME="$sbA/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+secondA=$(cat "$cfgA")
+if [ "$(count_begin "$cfgA")" = 1 ] && [ "$firstA" = "$secondA" ]; then
+  ok "mold: re-run idempotent (exactly one block, file byte-identical)"
+else
+  bad "mold: re-run not idempotent (begin-count=$(count_begin "$cfgA"))"
+fi
+
+# 6c. unrelated user config outside the markers is preserved byte-for-byte.
+sbC=$(mktemp -d "$tmp/moldC.XXXXXX"); mkdir -p "$sbC/.cargo"
+cfgC="$sbC/.cargo/config.toml"
+printf '[build]\njobs = 7\n\n[net]\nretry = 9\n' >"$cfgC"
+PATH="$stubA:$PATH" HOME="$sbC" CARGO_HOME="$sbC/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+if grep -qx 'jobs = 7' "$cfgC" && grep -qx 'retry = 9' "$cfgC" \
+   && grep -qx '\[build\]' "$cfgC" && grep -qx '\[net\]' "$cfgC" \
+   && grep -q '^# BEGIN cqlite-mold' "$cfgC"; then
+  ok "mold: unrelated user config preserved alongside the appended block"
+else
+  bad "mold: user config not preserved when appending the block"
+  echo "--- config ---"; cat "$cfgC"; echo "--------------"
+fi
+# Idempotent even with user content present.
+firstC=$(cat "$cfgC")
+PATH="$stubA:$PATH" HOME="$sbC" CARGO_HOME="$sbC/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+if [ "$firstC" = "$(cat "$cfgC")" ] && [ "$(count_begin "$cfgC")" = 1 ]; then
+  ok "mold: re-run with user content stays byte-identical (one block)"
+else
+  bad "mold: re-run with user content changed the file or duplicated the block"
+fi
+
+# 6d. failed link probe (no compiler accepts -fuse-ld=mold) -> warn, write NOTHING.
+sbD=$(mktemp -d "$tmp/moldD.XXXXXX"); stubD="$tmp/stubD"; mkdir -p "$stubD"
+mk_stub "$stubD" uname 'echo Linux; exit 0'
+stub_net "$stubD"
+mk_stub "$stubD" mold 'exit 0'
+mk_stub "$stubD" cc 'exit 1'
+mk_stub "$stubD" clang 'exit 1'
+outD=$(PATH="$stubD:$PATH" HOME="$sbD" CARGO_HOME="$sbD/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+if printf '%s' "$outD" | grep -q "link probe FAILED" \
+   && [ ! -f "$sbD/.cargo/config.toml" ]; then
+  ok "mold: failed link probe warns and writes no linker config"
+else
+  bad "mold: failed link probe still wrote config or missed the warning"
+  [ -f "$sbD/.cargo/config.toml" ] && cat "$sbD/.cargo/config.toml"
+fi
+
+# 6e. clang-only variant: cc fails the probe, clang passes -> block sets linker.
+sbE=$(mktemp -d "$tmp/moldE.XXXXXX"); stubE="$tmp/stubE"; mkdir -p "$stubE"
+mk_stub "$stubE" uname 'echo Linux; exit 0'
+stub_net "$stubE"
+mk_stub "$stubE" mold 'exit 0'
+mk_stub "$stubE" cc 'exit 1'
+mk_stub "$stubE" clang 'exit 0'
+PATH="$stubE:$PATH" HOME="$sbE" CARGO_HOME="$sbE/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+cfgE="$sbE/.cargo/config.toml"
+if [ -f "$cfgE" ] && [ "$(grep -c '^linker = "clang"' "$cfgE")" = 2 ]; then
+  ok "mold: clang-only probe writes linker = \"clang\" for both triples"
+else
+  bad "mold: clang-only probe did not set linker for both triples"
+  [ -f "$cfgE" ] && { echo "--- config ---"; cat "$cfgE"; echo "--------------"; }
+fi
+
+# 6f. Darwin no-op: mold section skipped, no config written.
+sbF=$(mktemp -d "$tmp/moldF.XXXXXX"); stubF="$tmp/stubF"; mkdir -p "$stubF"
+mk_stub "$stubF" uname 'echo Darwin; exit 0'
+stub_net "$stubF"
+mk_stub "$stubF" mold '[ "$1" = --version ] && echo "mold 2.4.0"; exit 0'
+mk_stub "$stubF" cc 'exit 0'
+outF=$(PATH="$stubF:$PATH" HOME="$sbF" CARGO_HOME="$sbF/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+if ! printf '%s' "$outF" | grep -q "Link accelerator: mold" \
+   && [ ! -f "$sbF/.cargo/config.toml" ]; then
+  ok "mold: Darwin performs no mold detection/config (no-op)"
+else
+  bad "mold: Darwin unexpectedly ran the mold section or wrote config"
+fi
+
+# 6g. missing mold + a supported package manager -> prints the install command in
+#     default (no --yes) mode and installs NOTHING; writes no linker config.
+sbG=$(mktemp -d "$tmp/moldG.XXXXXX"); stubG="$tmp/stubG"; mkdir -p "$stubG"
+tripG="$stubG/tripwire.log"; : >"$tripG"
+mk_stub "$stubG" uname 'echo Linux; exit 0'
+mk_stub "$stubG" apt-get "echo \"apt-get \$*\" >>\"$tripG\"; exit 0"
+outG=$(PATH="$stubG:/usr/bin:/bin" HOME="$sbG" CARGO_HOME="$sbG/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+if printf '%s' "$outG" | grep -q "mold MISSING" \
+   && printf '%s' "$outG" | grep -q "install mold:.*apt-get install -y mold" \
+   && [ ! -s "$tripG" ] \
+   && [ ! -f "$sbG/.cargo/config.toml" ]; then
+  ok "mold: missing + apt prints install command, installs nothing, writes no config"
+else
+  bad "mold: missing+apt path did not print-only (tripwire=$(cat "$tripG" 2>/dev/null))"
+fi
+
+# 6h. missing mold + NO supported package manager -> warn, no config.
+sbH=$(mktemp -d "$tmp/moldH.XXXXXX"); stubH="$tmp/stubH"; mkdir -p "$stubH"
+mk_stub "$stubH" uname 'echo Linux; exit 0'
+outH=$(PATH="$stubH:/usr/bin:/bin" HOME="$sbH" CARGO_HOME="$sbH/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+if printf '%s' "$outH" | grep -q "no supported package manager" \
+   && [ ! -f "$sbH/.cargo/config.toml" ]; then
+  ok "mold: missing + no package manager warns and writes no config"
+else
+  bad "mold: missing + no-manager path missed the warn or wrote config"
+fi
+
+# 6i. the repository's committed .cargo/config.toml is never touched.
+repo_cfg="$REPO_ROOT/.cargo/config.toml"
+if [ -e "$repo_cfg" ]; then
+  bad "mold: repo .cargo/config.toml exists unexpectedly (test assumes it does not)"
+else
+  ok "mold: repo-committed .cargo/config.toml left untouched (managed block is per-machine)"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -130,6 +130,24 @@ stub_net() {
   mk_stub "$1" cargo '[ "$1" = --version ] && echo "cargo 1.88.0"; exit 0'
 }
 
+# mk_hermetic_bin <dir>: a stub-only PATH dir with symlinked coreutils + a Linux
+# `uname` stub, so the missing-mold cases (6g/6h) never depend on the host having (or
+# NOT having) apt-get/dnf/etc. On a real Linux runner `/usr/bin/apt-get` exists, which
+# would otherwise flip the "no supported package manager" assertion and turn the FULL
+# gate RED via tooling-tests (#2859 blocker D). No package-manager binaries are linked;
+# callers add exactly the ones they intend to detect.
+mk_hermetic_bin() {
+  local dir="$1" t p
+  mkdir -p "$dir"
+  for t in bash dirname mktemp grep cp cat sed awk mkdir rm ln mv touch chmod \
+           head tail tr sort cut wc stat env git find xargs basename date sleep expr; do
+    p=$(type -P "$t" 2>/dev/null) || continue
+    [ -n "$p" ] && ln -sf "$p" "$dir/$t" 2>/dev/null || true
+  done
+  mk_stub "$dir" uname 'echo Linux; exit 0'
+  stub_net "$dir"  # gh/roborev/cargo stubs — no live network from these cases
+}
+
 # 6a. mold present + cc passes the probe -> managed block written, both Linux
 #     triples, NO linker line (default cc accepts -fuse-ld=mold).
 sbA=$(mktemp -d "$tmp/moldA.XXXXXX"); stubA="$tmp/stubA"; mkdir -p "$stubA"
@@ -248,12 +266,14 @@ else
 fi
 
 # 6g. missing mold + a supported package manager -> prints the install command in
-#     default (no --yes) mode and installs NOTHING; writes no linker config.
-sbG=$(mktemp -d "$tmp/moldG.XXXXXX"); stubG="$tmp/stubG"; mkdir -p "$stubG"
+#     default (no --yes) mode and installs NOTHING; writes no linker config. Runs in
+#     a HERMETIC stub-only PATH (blocker D): the ONLY package manager visible is the
+#     apt-get stub we add, regardless of what the host has installed.
+sbG=$(mktemp -d "$tmp/moldG.XXXXXX"); stubG="$tmp/stubG"
+mk_hermetic_bin "$stubG"
 tripG="$stubG/tripwire.log"; : >"$tripG"
-mk_stub "$stubG" uname 'echo Linux; exit 0'
 mk_stub "$stubG" apt-get "echo \"apt-get \$*\" >>\"$tripG\"; exit 0"
-outG=$(PATH="$stubG:/usr/bin:/bin" HOME="$sbG" CARGO_HOME="$sbG/.cargo" \
+outG=$(PATH="$stubG" HOME="$sbG" CARGO_HOME="$sbG/.cargo" \
   bash "$BOOTSTRAP" --skip-smoke 2>&1)
 if printf '%s' "$outG" | grep -q "mold MISSING" \
    && printf '%s' "$outG" | grep -q "install mold:.*apt-get install -y mold" \
@@ -262,18 +282,56 @@ if printf '%s' "$outG" | grep -q "mold MISSING" \
   ok "mold: missing + apt prints install command, installs nothing, writes no config"
 else
   bad "mold: missing+apt path did not print-only (tripwire=$(cat "$tripG" 2>/dev/null))"
+  printf '%s\n' "$outG" | grep -i mold
 fi
 
-# 6h. missing mold + NO supported package manager -> warn, no config.
-sbH=$(mktemp -d "$tmp/moldH.XXXXXX"); stubH="$tmp/stubH"; mkdir -p "$stubH"
-mk_stub "$stubH" uname 'echo Linux; exit 0'
-outH=$(PATH="$stubH:/usr/bin:/bin" HOME="$sbH" CARGO_HOME="$sbH/.cargo" \
+# 6h. missing mold + NO supported package manager -> warn, no config. HERMETIC PATH
+#     (blocker D) so no host apt-get/dnf/etc. is visible.
+sbH=$(mktemp -d "$tmp/moldH.XXXXXX"); stubH="$tmp/stubH"
+mk_hermetic_bin "$stubH"
+outH=$(PATH="$stubH" HOME="$sbH" CARGO_HOME="$sbH/.cargo" \
   bash "$BOOTSTRAP" --skip-smoke 2>&1)
 if printf '%s' "$outH" | grep -q "no supported package manager" \
    && [ ! -f "$sbH/.cargo/config.toml" ]; then
   ok "mold: missing + no package manager warns and writes no config"
 else
   bad "mold: missing + no-manager path missed the warn or wrote config"
+  printf '%s\n' "$outH" | grep -i mold
+fi
+
+# 6j. legacy extension-less ~/.cargo/config (blocker A): the block must be written
+#     INTO the existing `config` cargo actually reads — NOT a shadow `config.toml`
+#     that cargo would silently prefer, dropping the user's whole config.
+sbJ=$(mktemp -d "$tmp/moldJ.XXXXXX"); mkdir -p "$sbJ/.cargo"
+printf '[net]\nretry = 4\n' >"$sbJ/.cargo/config"
+PATH="$stubA:$PATH" HOME="$sbJ" CARGO_HOME="$sbJ/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+if grep -q '^# BEGIN cqlite-mold' "$sbJ/.cargo/config" \
+   && grep -qx 'retry = 4' "$sbJ/.cargo/config" \
+   && [ ! -f "$sbJ/.cargo/config.toml" ]; then
+  ok "mold: writes into the legacy extension-less ~/.cargo/config (no shadow config.toml)"
+else
+  bad "mold: legacy config handling wrong (shadow config.toml or lost user config)"
+  ls -la "$sbJ/.cargo" 2>/dev/null
+fi
+
+# 6k. pre-existing user [target.<triple>-unknown-linux-gnu] OUTSIDE the markers
+#     (blocker B): appending our block would be a TOML table redefinition = cargo
+#     parse error on every invocation. Bootstrap must WARN and write NOTHING, leaving
+#     the file byte-identical.
+sbK=$(mktemp -d "$tmp/moldK.XXXXXX"); mkdir -p "$sbK/.cargo"
+cfgK="$sbK/.cargo/config.toml"
+printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "target-cpu=native"]\n' >"$cfgK"
+beforeK=$(cat "$cfgK")
+outK=$(PATH="$stubA:$PATH" HOME="$sbK" CARGO_HOME="$sbK/.cargo" \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+if printf '%s' "$outK" | grep -q "existing \[target" \
+   && [ "$beforeK" = "$(cat "$cfgK")" ] \
+   && ! grep -q '^# BEGIN cqlite-mold' "$cfgK"; then
+  ok "mold: pre-existing [target.<triple>] section -> warn, file byte-identical, no block"
+else
+  bad "mold: pre-existing target section not fail-safe (block written or file changed)"
+  echo "--- config ---"; cat "$cfgK"; echo "--------------"
 fi
 
 # 6i. the repository's committed .cargo/config.toml is never touched.

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -188,9 +188,20 @@ block (full **and** `--lite`) carries a machine-checkable line:
 accelerators: sccache=on nextest=on lanes=on
 ```
 
+On **Linux** the line additionally carries a `mold=` token (byte-identical / no token
+on macOS):
+
+```
+accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked
+```
+
 - **`sccache`** — cross-worktree compile cache (~25.6% faster fresh builds).
 - **`nextest`** — parallel `core-tests` (the gate's long pole).
 - **`lanes`** — parallel gate components (needs bash ≥4.3 for `wait -n`).
+- **`mold`** (issue #2859, **Linux only**) — the fast linker, wired via a per-machine
+  `~/.cargo/config.toml` managed block. States: `mold=linked` (wired) · `overridden`
+  (a global `RUSTFLAGS` is suppressing the wired flags — don't export one on a worker)
+  · `present-unconfigured` (installed but not wired — re-run bootstrap) · `absent`.
 
 State values: **`on`** (detected & used) · **`absent`** (missing → the gate prints a
 loud `WARN:` on STDERR with the one-line install command) · **`off`** (intentionally


### PR DESCRIPTION
Closes #2859

OpenSpec change: `mold-linux-workers` (owner-approved Seam 1; design.md Decisions 1–4).

## What

- `scripts/bootstrap-agent-machine.sh` Linux branch: mold detect / package-manager install / advisory warn; link-probe-gated managed block (`# BEGIN/END cqlite-mold`) written to the per-machine cargo config (`config.toml` or legacy `config`, whichever exists) with both Linux target triples. Fail-safe paths write NOTHING: probe failure, or a pre-existing user `[target.<linux-triple>]` section (TOML redefinition would break all cargo). Idempotent replace-the-block; content outside markers preserved byte-for-byte; repo config never touched; Darwin byte-identical.
- `scripts/agent-gate.sh` `accelerators:` line, Linux only: `mold=linked | overridden | present-unconfigured | absent` (`overridden` = managed block active but env `RUSTFLAGS` suppresses target.rustflags — the stamp never lies about a suppressed link).
- Self-tests: bootstrap 26 cases (hermetic stub-only PATH, no live network in-gate), gate-summary 91 assertions incl. real-detection cases without the state override.
- Docs same-change: gate-ops.md, fleet-runbook (Linux provisioning + no-global-RUSTFLAGS rule + one-time sccache cold rebuild), agent-machine-setup.md, website gate-contract.md, bootstrap `--help`.

## Review history (review-first, #2086)

rust-reviewer + roborev job 1997 on the lite-green diff; 7 blockers fixed in one round (incl. the TOML-redefinition config-corruption path and a Linux-only self-test fragility that would have turned the gate red on the target platform), lite r2 PASS + 117 self-test assertions green.

## Outstanding before merge

- **Task 5.1: EC2 A/B measurement** (full gate + one `--lite` round, with/without mold, post-#2856 toolchain) — pending owner-designated Linux worker; numbers will be posted here.
- Ordered after PR #2863 (#2856 rust-1.97.1) so the A/B measures what the fleet will run.

Deferred nits → #2864 batch (atomic temp+mv write comment, double-block healing, probe output-binary check).