### PR TITLE
fix(#2876): split scan-side positional reads off the MADV_RANDOM point mapping

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
@@ -582,11 +582,15 @@ impl SSTableReader {
                  at Data.db offset 0x{offset:x}"
             ))
         })?;
-        // Verify the covering CRC.db chunk(s) BEFORE returning any bytes.
-        self.verify_uncompressed_range(offset, size).await?;
+        // Verify the covering CRC.db chunk(s) BEFORE returning any bytes, on the
+        // SAME plane the bytes themselves come off (issue #2876): this is a POINT
+        // path, so both stay on the advised `MADV_RANDOM` mapping (issue #2210).
+        let point_source = self.point_source.clone();
+        self.verify_uncompressed_range(point_source.as_ref(), offset, size)
+            .await?;
 
         let mut buf = vec![0u8; len];
-        self.point_source.read_exact_at(offset, &mut buf)?;
+        point_source.read_exact_at(offset, &mut buf)?;
         Ok(buf)
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti_point.rs
@@ -166,7 +166,12 @@ impl SSTableReader {
         // transferred from disk EXACTLY ONCE (issue #1573 roborev), preserving the
         // CRC-before-use ordering and the CRC algorithm unchanged.
         if self.crc_reader.is_some() {
-            self.verify_uncompressed_section_in_buffer(header_size, &whole)
+            // POINT intent (issue #2876): the only I/O the verifier can still need
+            // is the straddling-chunk re-read below `header_size`, and this is a
+            // point path, so it stays on the advised `MADV_RANDOM` mapping (#2210) —
+            // the same plane the section itself was just read from.
+            let point_source = self.point_source.clone();
+            self.verify_uncompressed_section_in_buffer(point_source.as_ref(), header_size, &whole)
                 .await?;
         }
         Ok(whole)

--- a/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
@@ -1,12 +1,24 @@
 //! CRC-validated compressed offset-read window (issue #1773).
 //!
-//! The compressed offset-read point-lookup path
+//! The compressed offset-read path
 //! ([`read_value_at_offset`](super::super::SSTableReader::read_value_at_offset) →
-//! `get_cached_data`) used to read `size` raw bytes at an offset and LZ4-decompress
+//! `get_cached_data`, and the Summary-guided compressed scan walk in
+//! `summary_scan.rs`) used to read `size` raw bytes at an offset and LZ4-decompress
 //! them WITHOUT validating the trailing 4-byte inline per-chunk CRC32 — re-introducing
 //! the #1411 CRC bypass on a latent path (unreachable today via `get`, but live the
 //! moment `find_entry` hits for a compressed table). This module carries the helper
 //! that routes that case through the shared CRC-enforcing chunk reader.
+//!
+//! Reads through the reader's SCAN-side positional source
+//! ([`scan_positional_source`](super::super::SSTableReader), issue #2876), NOT the
+//! dedicated `MADV_RANDOM` point-read mapping: every caller here is a scan-shaped
+//! walk (`summary_scan.rs`'s Summary-guided partition walk, `full_index_scan.rs` /
+//! `full_index_stream.rs`'s full-`Index.db` enumeration, and `get_cached_data`'s
+//! compressed branch) that reads Data.db largely sequentially, so the advised
+//! mapping's readahead suppression — a deliberate win for genuinely scattered point
+//! lookups (issue #2210) — was exactly backwards here (#2210 × #1940 cross-path
+//! regression). Genuine point lookups (`bti_point.rs`, `big_promoted.rs`) do not
+//! route through this helper; they read `point_source` directly.
 
 use std::sync::atomic::Ordering;
 
@@ -41,7 +53,7 @@ impl SSTableReader {
             .transpose()?;
 
         read_compressed_offset_window_impl(
-            self.point_source.as_ref(),
+            self.scan_positional_source.as_ref(),
             comp_info,
             compression.as_ref(),
             self.stats.file_size,
@@ -58,7 +70,7 @@ impl SSTableReader {
 ///
 /// [`CompressionInfo`]: crate::storage::sstable::compression_info::CompressionInfo
 pub(super) fn read_compressed_offset_window_impl(
-    point_source: &dyn super::super::read_at::ReadAt,
+    positional_source: &dyn super::super::read_at::ReadAt,
     comp_info: &crate::storage::sstable::compression_info::CompressionInfo,
     compression: Option<&crate::storage::sstable::compression::Compression>,
     file_size: u64,
@@ -118,8 +130,13 @@ pub(super) fn read_compressed_offset_window_impl(
         // corrupt/out-of-range offset or size. Returning the partial `assembled`
         // bytes as `Ok` would silently truncate; this must surface as a typed,
         // non-recoverable corruption error instead.
-        let Some(compressed) =
-            block_io::read_compressed_chunk_at(point_source, comp_info, chunk_idx, file_size, 0)?
+        let Some(compressed) = block_io::read_compressed_chunk_at(
+            positional_source,
+            comp_info,
+            chunk_idx,
+            file_size,
+            0,
+        )?
         else {
             return Err(Error::corruption(format!(
                 "compressed offset read requires chunk {chunk_idx} past EOF for range \

--- a/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
@@ -13,8 +13,7 @@
 //! helper serves BOTH read intents, so each caller passes the source its intent
 //! selects. The scan-shaped walks (`summary_scan.rs`'s Summary-guided partition
 //! walk, `full_index_scan.rs` / `full_index_stream.rs`'s full-`Index.db`
-//! enumeration, and `get_cached_data`'s compressed branch reached from
-//! `read_value_at_offset_for_scan`) pass the reader's UNADVISED
+//! enumeration, and the windowed scan) pass the reader's UNADVISED
 //! `scan_positional_source`, because they read Data.db largely sequentially and the
 //! advised mapping's readahead suppression is exactly backwards for them (the
 //! #2210 × #1940 cross-path regression). A genuine point lookup — `get_cached_data`

--- a/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compressed_offset.rs
@@ -9,16 +9,18 @@
 //! moment `find_entry` hits for a compressed table). This module carries the helper
 //! that routes that case through the shared CRC-enforcing chunk reader.
 //!
-//! Reads through the reader's SCAN-side positional source
-//! ([`scan_positional_source`](super::super::SSTableReader), issue #2876), NOT the
-//! dedicated `MADV_RANDOM` point-read mapping: every caller here is a scan-shaped
-//! walk (`summary_scan.rs`'s Summary-guided partition walk, `full_index_scan.rs` /
-//! `full_index_stream.rs`'s full-`Index.db` enumeration, and `get_cached_data`'s
-//! compressed branch) that reads Data.db largely sequentially, so the advised
-//! mapping's readahead suppression — a deliberate win for genuinely scattered point
-//! lookups (issue #2210) — was exactly backwards here (#2210 × #1940 cross-path
-//! regression). Genuine point lookups (`bti_point.rs`, `big_promoted.rs`) do not
-//! route through this helper; they read `point_source` directly.
+//! The positional plane is the CALLER's, never hardcoded here (issue #2876): this
+//! helper serves BOTH read intents, so each caller passes the source its intent
+//! selects. The scan-shaped walks (`summary_scan.rs`'s Summary-guided partition
+//! walk, `full_index_scan.rs` / `full_index_stream.rs`'s full-`Index.db`
+//! enumeration, and `get_cached_data`'s compressed branch reached from
+//! `read_value_at_offset_for_scan`) pass the reader's UNADVISED
+//! `scan_positional_source`, because they read Data.db largely sequentially and the
+//! advised mapping's readahead suppression is exactly backwards for them (the
+//! #2210 × #1940 cross-path regression). A genuine point lookup — `get_cached_data`
+//! reached from `read_value_at_offset` — passes the dedicated `MADV_RANDOM`
+//! `point_source`, keeping the advice issue #2210 gave it. (`bti_point.rs` /
+//! `big_promoted.rs` read `point_source` directly and do not route through here.)
 
 use std::sync::atomic::Ordering;
 
@@ -37,9 +39,15 @@ impl SSTableReader {
     /// offset) that scan / `scan_for_key` return, never garbage. No heuristics: the
     /// authoritative CRC trailer is checked, never inferred.
     ///
+    /// `source` is the positional plane the CALLER's read intent selects (issue
+    /// #2876) — see the module doc. It is a parameter rather than a field read so
+    /// that this one helper can serve the scan walks and the point offset read
+    /// without either losing its intended mapping advice.
+    ///
     /// [`read_compressed_chunk_at`]: super::super::block_io::read_compressed_chunk_at
-    pub(super) async fn read_compressed_offset_window(
+    pub(in crate::storage::sstable::reader) async fn read_compressed_offset_window(
         &self,
+        source: &dyn super::super::read_at::ReadAt,
         comp_info: &crate::storage::sstable::compression_info::CompressionInfo,
         block_offset: u64,
         size: u32,
@@ -53,7 +61,7 @@ impl SSTableReader {
             .transpose()?;
 
         read_compressed_offset_window_impl(
-            self.scan_positional_source.as_ref(),
+            source,
             comp_info,
             compression.as_ref(),
             self.stats.file_size,

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -233,16 +233,26 @@ impl SSTableReader {
             // Read the partition's Data.db slice into the UNCOMPRESSED byte domain,
             // then parse it with the NB-aware V5 block parser — the same producer
             // `sequential_scan` uses.
+            // SCAN intent (issue #2876): a full-`Index.db` enumeration walks Data.db
+            // in ascending offset order, so both the body read and the uncompressed
+            // `CRC.db` covering-chunk reads use the reader's UNADVISED
+            // `scan_positional_source`, not the `MADV_RANDOM` point mapping (#2210).
+            let scan_source = self.scan_positional_source.clone();
             let raw = if let Some(ci) = self.compression_info.as_deref() {
                 // Compressed: `data_offset` is an uncompressed-domain offset; map it
                 // to the covering compression chunk(s) and decompress.
-                self.read_compressed_offset_window(ci, data_offset, size)
+                self.read_compressed_offset_window(scan_source.as_ref(), ci, data_offset, size)
                     .await?
             } else {
                 // Uncompressed: raw file offset = data_offset + header (0 for `nb`).
                 let absolute_offset = data_offset + self.actual_header_size as u64;
-                self.read_uncompressed_verified(&self.file, absolute_offset, size as usize)
-                    .await?
+                self.read_uncompressed_verified(
+                    scan_source.as_ref(),
+                    &self.file,
+                    absolute_offset,
+                    size as usize,
+                )
+                .await?
             };
 
             // Completeness + corruption Signal B (issue #2302, roborev jobs 1606 +

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -262,11 +262,16 @@ impl SSTableReader {
                 )));
             };
 
+            // SCAN intent (issue #2876): a full-`Index.db` stream walks Data.db in
+            // ascending offset order, so its body reads and (uncompressed) `CRC.db`
+            // covering-chunk reads use the reader's UNADVISED
+            // `scan_positional_source`, not the `MADV_RANDOM` point mapping (#2210).
+            let scan_source = self.scan_positional_source.clone();
             let control = if let Some(ci) = self.compression_info.as_deref() {
                 // Rare non-nb compressed non-stitching branch: unchanged per-partition
                 // windowed read (issue #2366 targets the uncompressed field case only).
                 let raw = self
-                    .read_compressed_offset_window(ci, data_offset, size)
+                    .read_compressed_offset_window(scan_source.as_ref(), ci, data_offset, size)
                     .await?;
                 self.emit_partition_slice(i, &raw, &parser, schema, emit)?
             } else {
@@ -290,7 +295,12 @@ impl SSTableReader {
                     // O(N/window) read-pattern evidence for issue #2366.
                     crate::storage::sstable::read_work_counters::record_seek();
                     window = self
-                        .read_uncompressed_verified(&self.file, absolute_offset, want as usize)
+                        .read_uncompressed_verified(
+                            scan_source.as_ref(),
+                            &self.file,
+                            absolute_offset,
+                            want as usize,
+                        )
                         .await?;
                     window_filled = true;
                 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -643,14 +643,23 @@ impl SSTableReader {
             self.read_compressed_offset_window(comp_info, block_offset, size)
                 .await?
         } else {
-            // UNCOMPRESSED offset read. Positioned read on the shared point source
-            // (issue #1573, C2): no cursor mutex is held across this I/O, so
-            // concurrent point reads do not convoy. The covering CRC.db chunks were
-            // already verified by `verify_uncompressed_range` before we got here
-            // (issue #1396), so these bytes are integrity-checked too.
+            // UNCOMPRESSED offset read. Positioned read on the SCAN-side positional
+            // source (issue #2876, was `point_source` under issue #1573/C2): no
+            // cursor mutex is held across this I/O, so concurrent reads do not
+            // convoy. `get_cached_data` is reached both by genuine point lookups
+            // (the rare index-less/legacy fallback in `big_point.rs`) and by every
+            // index-driven scan (`sequential.rs`), so it must NOT use the dedicated
+            // `MADV_RANDOM` point mapping (issue #2210) — that advice is a
+            // deliberate loss for a scan's mostly-sequential access pattern. The
+            // covering CRC.db chunks were already verified by
+            // `verify_uncompressed_range` before we got here (issue #1396, still on
+            // `point_source` — that helper is also reached directly by the
+            // protected point-lookup paths in `bti_point.rs` / `big_promoted.rs`),
+            // so these bytes are integrity-checked too.
             model::CHUNK_READ_CALLS.fetch_add(1, Ordering::Relaxed);
             let mut buffer = vec![0u8; size as usize];
-            self.point_source.read_exact_at(block_offset, &mut buffer)?;
+            self.scan_positional_source
+                .read_exact_at(block_offset, &mut buffer)?;
             buffer
         };
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -555,31 +555,18 @@ impl SSTableReader {
     ///
     /// Reads Data.db through the reader's dedicated `MADV_RANDOM` point mapping
     /// ([`point_source`](Self::point_source), issue #2210), which is the right
-    /// advice for a scattered point fault. The index-driven SCAN calls
-    /// [`read_value_at_offset_for_scan`](Self::read_value_at_offset_for_scan)
-    /// instead — same decode, but on the unadvised scan plane (issue #2876).
+    /// advice for a scattered fault.
+    ///
+    /// Note (issue #2876, roborev job 4634): the index-driven range scan in
+    /// `sequential.rs` also uses THIS point-intent entry, and that is deliberate.
+    /// It looks like a scan, but `Index::get_range` yields entries in raw key-BYTE
+    /// order while Data.db is laid out in Murmur3 TOKEN order — uncorrelated for the
+    /// default partitioner — so its access really is scattered and `MADV_RANDOM` is
+    /// correct. The genuinely sequential walks (the Summary-guided walk, the full
+    /// index scan/stream, the windowed scan) reach the unadvised scan plane through
+    /// the positional helpers below, which take their plane from the caller.
     pub async fn read_value_at_offset(&self, offset: u64, size: u32) -> Result<Option<ScanRow>> {
         self.read_value_at_offset_via(self.point_source.as_ref(), offset, size)
-            .await
-    }
-
-    /// SCAN-intent sibling of [`read_value_at_offset`](Self::read_value_at_offset)
-    /// (issue #2876): identical decode, but every Data.db byte — the partition
-    /// body AND its covering `CRC.db` chunks — is read through the reader's
-    /// unadvised scan mapping ([`scan_positional_source`](Self::scan_positional_source)).
-    ///
-    /// The index-driven range scan (`sequential.rs`) walks `Index.db` entries in
-    /// token order, so its Data.db access is mostly sequential and MUST NOT be
-    /// served from the `MADV_RANDOM` point mapping: that advice suppresses kernel
-    /// readahead, turning the walk into one ~4 KiB page fault per partition instead
-    /// of one ~128 KiB readahead window per many (the #2210 × #1940 cross-path
-    /// regression).
-    pub(in crate::storage::sstable::reader) async fn read_value_at_offset_for_scan(
-        &self,
-        offset: u64,
-        size: u32,
-    ) -> Result<Option<ScanRow>> {
-        self.read_value_at_offset_via(self.scan_positional_source.as_ref(), offset, size)
             .await
     }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -551,8 +551,53 @@ impl SSTableReader {
         }
     }
 
-    /// Read value at a specific offset with caching
+    /// Read value at a specific offset with caching — the POINT-intent entry.
+    ///
+    /// Reads Data.db through the reader's dedicated `MADV_RANDOM` point mapping
+    /// ([`point_source`](Self::point_source), issue #2210), which is the right
+    /// advice for a scattered point fault. The index-driven SCAN calls
+    /// [`read_value_at_offset_for_scan`](Self::read_value_at_offset_for_scan)
+    /// instead — same decode, but on the unadvised scan plane (issue #2876).
     pub async fn read_value_at_offset(&self, offset: u64, size: u32) -> Result<Option<ScanRow>> {
+        self.read_value_at_offset_via(self.point_source.as_ref(), offset, size)
+            .await
+    }
+
+    /// SCAN-intent sibling of [`read_value_at_offset`](Self::read_value_at_offset)
+    /// (issue #2876): identical decode, but every Data.db byte — the partition
+    /// body AND its covering `CRC.db` chunks — is read through the reader's
+    /// unadvised scan mapping ([`scan_positional_source`](Self::scan_positional_source)).
+    ///
+    /// The index-driven range scan (`sequential.rs`) walks `Index.db` entries in
+    /// token order, so its Data.db access is mostly sequential and MUST NOT be
+    /// served from the `MADV_RANDOM` point mapping: that advice suppresses kernel
+    /// readahead, turning the walk into one ~4 KiB page fault per partition instead
+    /// of one ~128 KiB readahead window per many (the #2210 × #1940 cross-path
+    /// regression).
+    pub(in crate::storage::sstable::reader) async fn read_value_at_offset_for_scan(
+        &self,
+        offset: u64,
+        size: u32,
+    ) -> Result<Option<ScanRow>> {
+        self.read_value_at_offset_via(self.scan_positional_source.as_ref(), offset, size)
+            .await
+    }
+
+    /// Shared body of the two offset-read entry points, parameterized by the
+    /// positional plane its caller's read intent selects (issue #2876).
+    ///
+    /// `source` is threaded all the way down — through the `CRC.db` verifier AND
+    /// the byte read / compressed-window decode — so a read never mixes planes:
+    /// no helper below hardcodes one, which is what made an index-driven scan's CRC
+    /// reads land on the advised point mapping while its bodies came off the scan
+    /// mapping (roborev #2882, Finding 1) and, symmetrically, made a genuine point
+    /// lookup lose the advised mapping entirely (Finding 2).
+    async fn read_value_at_offset_via(
+        &self,
+        source: &dyn super::read_at::ReadAt,
+        offset: u64,
+        size: u32,
+    ) -> Result<Option<ScanRow>> {
         // Size must be non-zero for offset-based reading
         if size == 0 {
             return Err(Error::corruption(format!(
@@ -567,8 +612,10 @@ impl SSTableReader {
         // chunk(s) covering [offset, offset+size) BEFORE returning any bytes. A
         // mismatch is a typed Error::Corruption naming the chunk + offset (never
         // wrong values / never a silent result). No-op when no CRC.db is present
-        // (compressed tables / BTI / absent-CRC.db warn-and-proceed).
-        self.verify_uncompressed_range(offset, size).await?;
+        // (compressed tables / BTI / absent-CRC.db warn-and-proceed). The CRC read
+        // uses the CALLER's plane (issue #2876): a scan's covering-chunk reads are
+        // part of its sequential walk, not scattered point faults.
+        self.verify_uncompressed_range(source, offset, size).await?;
 
         // Read + decompress in ONE decode plane (issue #1598, G2). `get_cached_data`
         // returns the final DECODED window: for a compressed Data.db it routes through
@@ -577,7 +624,7 @@ impl SSTableReader {
         // now resolves inside `ChunkSource`), or the CRC.db-verified raw bytes for an
         // uncompressed one. There is no second decode here — doing so used to
         // double-decompress the compressed path (and skip its inline CRC, the #1411 bug).
-        let data = self.get_cached_data(offset, size).await?;
+        let data = self.get_cached_data(source, offset, size).await?;
 
         // Preserve raw data until schema is available. Pre-#1334 this offset-read
         // placeholder returned a bare `Value::Blob` of the row's raw value bytes,
@@ -617,8 +664,18 @@ impl SSTableReader {
     /// runs `verify_uncompressed_range` before calling this, so a hit returns
     /// bytes verified when they were first inserted.
     ///
+    /// `source` is the positional plane the CALLER's read intent selected (issue
+    /// #2876) — the advised point mapping for a point lookup, the unadvised scan
+    /// mapping for the index-driven scan. It is threaded in rather than read off
+    /// `self` precisely because this helper serves BOTH intents.
+    ///
     /// [`DecompressedChunkCache`]: crate::storage::cache::DecompressedChunkCache
-    async fn get_cached_data(&self, block_offset: u64, size: u32) -> Result<Vec<u8>> {
+    async fn get_cached_data(
+        &self,
+        source: &dyn super::read_at::ReadAt,
+        block_offset: u64,
+        size: u32,
+    ) -> Result<Vec<u8>> {
         // The shared B1 cache tracks its own hit/miss counters (issue #1567). The
         // ranged BIG-point key carries `size` as its aux discriminant so two reads at
         // the same offset with different sizes can never alias (roborev #1567).
@@ -640,26 +697,23 @@ impl SSTableReader {
             // backing read HERE (point-read site only), symmetric with the uncompressed
             // branch below (#2167) — scan callers of the shared helper must NOT bump it.
             model::CHUNK_READ_CALLS.fetch_add(1, Ordering::Relaxed);
-            self.read_compressed_offset_window(comp_info, block_offset, size)
+            self.read_compressed_offset_window(source, comp_info, block_offset, size)
                 .await?
         } else {
-            // UNCOMPRESSED offset read. Positioned read on the SCAN-side positional
-            // source (issue #2876, was `point_source` under issue #1573/C2): no
-            // cursor mutex is held across this I/O, so concurrent reads do not
-            // convoy. `get_cached_data` is reached both by genuine point lookups
-            // (the rare index-less/legacy fallback in `big_point.rs`) and by every
-            // index-driven scan (`sequential.rs`), so it must NOT use the dedicated
-            // `MADV_RANDOM` point mapping (issue #2210) — that advice is a
-            // deliberate loss for a scan's mostly-sequential access pattern. The
-            // covering CRC.db chunks were already verified by
-            // `verify_uncompressed_range` before we got here (issue #1396, still on
-            // `point_source` — that helper is also reached directly by the
-            // protected point-lookup paths in `bti_point.rs` / `big_promoted.rs`),
-            // so these bytes are integrity-checked too.
+            // UNCOMPRESSED offset read. Positioned read on the caller's positional
+            // plane (issue #1573/C2 for the lock-free part, issue #2876 for the
+            // plane): no cursor mutex is held across this I/O, so concurrent reads
+            // do not convoy. `get_cached_data` is reached both by genuine point
+            // lookups (`big_point.rs`) and by every index-driven scan
+            // (`sequential.rs`), so the plane comes from the caller's intent — a
+            // point read keeps the dedicated `MADV_RANDOM` mapping (issue #2210), a
+            // scan takes the unadvised one, for which that readahead suppression is
+            // a deliberate loss. The covering CRC.db chunks were already verified on
+            // the SAME plane by `verify_uncompressed_range` (issue #1396), so these
+            // bytes are integrity-checked too.
             model::CHUNK_READ_CALLS.fetch_add(1, Ordering::Relaxed);
             let mut buffer = vec![0u8; size as usize];
-            self.scan_positional_source
-                .read_exact_at(block_offset, &mut buffer)?;
+            source.read_exact_at(block_offset, &mut buffer)?;
             buffer
         };
 
@@ -683,7 +737,21 @@ impl SSTableReader {
     ///
     /// No-op when this reader has no `CRC.db` (compressed tables carry inline
     /// per-chunk CRCs; BTI ships none; an absent `CRC.db` is warn-and-proceed).
-    async fn verify_uncompressed_range(&self, offset: u64, size: u32) -> Result<()> {
+    ///
+    /// `source` is the positional plane the CALLER's read intent selected (issue
+    /// #2876). A chunk CRC read is I/O on the same Data.db bytes the caller is
+    /// about to consume, so it belongs on the caller's plane: a scan's
+    /// covering-chunk reads are part of its sequential walk (the advised
+    /// `MADV_RANDOM` point mapping would suppress readahead over a whole 64 KiB
+    /// chunk), while a point lookup's stay on the advised mapping (issue #2210).
+    /// This is why the plane is a parameter and never read off `self` here —
+    /// hardcoding it split one logical read across two planes (roborev #2882).
+    async fn verify_uncompressed_range(
+        &self,
+        source: &dyn super::read_at::ReadAt,
+        offset: u64,
+        size: u32,
+    ) -> Result<()> {
         let Some(crc) = self.crc_reader.as_deref() else {
             return Ok(());
         };
@@ -707,12 +775,13 @@ impl SSTableReader {
                 ))
             })?;
         // Each covering chunk is CRC'd over its on-disk bytes via a positioned
-        // read on the shared point source (issue #1573, C2): the verifier never
-        // holds a cursor mutex across I/O, so it neither convoys concurrent point
-        // reads nor disturbs any scan cursor's position.
+        // read on the caller's plane (issue #1573 C2 for the lock-free part, issue
+        // #2876 for the plane): the verifier never holds a cursor mutex across I/O,
+        // so it neither convoys concurrent point reads nor disturbs any scan
+        // cursor's position.
         self.verify_covering_chunks(crc, offset, end, |lo, hi, chunk| {
             let mut buf = vec![0u8; (hi - lo) as usize];
-            self.point_source.read_exact_at(lo, &mut buf).map_err(|e| {
+            source.read_exact_at(lo, &mut buf).map_err(|e| {
                 Error::corruption(format!(
                     "failed to read uncompressed chunk {chunk} at Data.db offset 0x{lo:x} for CRC verification: {e}"
                 ))
@@ -731,8 +800,15 @@ impl SSTableReader {
     /// that does not fall on a chunk boundary) re-reads just that one chunk so the
     /// CRC-before-use guarantee holds regardless of header alignment. Same CRC32
     /// algorithm, chunk layout, memoization, and mismatch/typed-error semantics as
-    /// [`Self::verify_uncompressed_range`].
-    async fn verify_uncompressed_section_in_buffer(&self, base: u64, section: &[u8]) -> Result<()> {
+    /// [`Self::verify_uncompressed_range`] — including its `source` contract: the
+    /// straddling-chunk re-read uses the CALLER's positional plane (issue #2876),
+    /// never a hardcoded one.
+    async fn verify_uncompressed_section_in_buffer(
+        &self,
+        source: &dyn super::read_at::ReadAt,
+        base: u64,
+        section: &[u8],
+    ) -> Result<()> {
         let Some(crc) = self.crc_reader.as_deref() else {
             return Ok(());
         };
@@ -760,7 +836,7 @@ impl SSTableReader {
             } else {
                 // Chunk extends below `base` (unaligned header) — read just it.
                 let mut buf = vec![0u8; (hi - lo) as usize];
-                self.point_source.read_exact_at(lo, &mut buf).map_err(|e| {
+                source.read_exact_at(lo, &mut buf).map_err(|e| {
                     Error::corruption(format!(
                         "failed to read uncompressed chunk {chunk} at Data.db offset 0x{lo:x} for CRC verification: {e}"
                     ))
@@ -850,13 +926,21 @@ impl SSTableReader {
     /// `offset` is an ABSOLUTE Data.db file offset (post-header). `file` is the
     /// handle to read the range from — the shared point-read handle
     /// ([`Self::file`]) or a scan-local cursor's private handle (issue #815).
-    /// CRC verification always uses the reader's own handle, so it is independent
-    /// of `file` and never disturbs a scan cursor's position.
+    /// CRC verification reads positionally via `source` instead, so it is
+    /// independent of `file` and never disturbs a scan cursor's position.
+    ///
+    /// `source` is the positional plane the CALLER's read intent selects (issue
+    /// #2876), threaded through for the CRC chunk reads exactly as in
+    /// [`Self::verify_uncompressed_range`]. Every caller today is a scan walk
+    /// (`summary_scan.rs`, `full_index_scan.rs`, `full_index_stream.rs`) and passes
+    /// the unadvised scan mapping; a future point caller passes the advised one and
+    /// gets the right advice without editing this helper.
     ///
     /// Future uncompressed offset reads MUST call this instead of doing their own
     /// `seek` + `read_exact`, so the CRC check can never be forgotten again.
     pub(in crate::storage::sstable::reader) async fn read_uncompressed_verified(
         &self,
+        source: &dyn super::read_at::ReadAt,
         file: &tokio::sync::Mutex<super::source::BlockSource>,
         offset: u64,
         len: usize,
@@ -870,7 +954,7 @@ impl SSTableReader {
             ))
         })?;
         // Verify the covering CRC.db chunk(s) BEFORE returning any bytes.
-        self.verify_uncompressed_range(offset, size).await?;
+        self.verify_uncompressed_range(source, offset, size).await?;
 
         let mut buf = vec![0u8; len];
         {

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -936,6 +936,16 @@ impl SSTableReader {
     /// the unadvised scan mapping; a future point caller passes the advised one and
     /// gets the right advice without editing this helper.
     ///
+    /// SCOPE NOTE (#2876): `source` governs the **CRC chunk reads only**. The payload
+    /// bytes below are read through `file` — a seek-based [`BlockSource`], which is NOT
+    /// an mmap and therefore carries no `madvise` advice on any backend. So the
+    /// uncompressed path never suffered the MADV_RANDOM readahead suppression this
+    /// issue fixes (that regression was mmap-specific, hence compressed-walk-specific),
+    /// and threading the plane here closes the CRC-read half completely: after this
+    /// change NO read on an uncompressed scan touches an advised mapping. The
+    /// separate cost on this path is the shared `file` mutex serializing concurrent
+    /// scans (#815's domain), which is deliberately out of scope here.
+    ///
     /// Future uncompressed offset reads MUST call this instead of doing their own
     /// `seek` + `read_exact`, so the CRC check can never be forgotten again.
     pub(in crate::storage::sstable::reader) async fn read_uncompressed_verified(

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -156,15 +156,28 @@ impl SSTableReader {
                     i, entry.offset, file_offset, entry.size
                 );
 
-                // SCAN intent (issue #2876): this walks the index's entries in
-                // order, so it uses the scan-plane sibling of
-                // `read_value_at_offset` — same decode, but off the reader's
-                // UNADVISED mapping instead of the `MADV_RANDOM` point one (#2210),
-                // whose readahead suppression is exactly backwards here.
-                if let Some(value) = self
-                    .read_value_at_offset_for_scan(file_offset, entry.size)
-                    .await?
-                {
+                // POINT intent, deliberately (issue #2876, roborev job 4634).
+                //
+                // This legacy index path looks like a scan but does NOT read
+                // sequentially: `Index::get_range` walks `sorted_keys`, i.e. raw
+                // key-BYTE order (index.rs:270-277), while Data.db is laid out in
+                // Murmur3 TOKEN order. For the default partitioner those two orders
+                // are uncorrelated, so these reads are genuinely scattered and
+                // `MADV_RANDOM` is the CORRECT advice — the same reasoning that put
+                // point lookups on the advised plane in #2210. Routing them to the
+                // scan plane would invite readahead that mostly fetches pages this
+                // walk never touches.
+                //
+                // Do NOT "fix" this by sorting `entries` by `entry.offset` before
+                // reading to make the access sequential: `results` is sorted into
+                // token order AFTER the loop (`sort_by_token_order`, see below) and
+                // `limit` is applied AFTER that sort, so LIMIT N must mean "the N
+                // token-smallest partitions". Read order is independent of result
+                // order here, so an offset-ordered read is safe in principle — but
+                // it is a separate optimization with its own regression-test burden,
+                // NOT part of removing a wrong advice from the true scan walks.
+                // Tracked as follow-up; this line stays on the point plane.
+                if let Some(value) = self.read_value_at_offset(file_offset, entry.size).await? {
                     tracing::debug!(
                         "SSTableReader::scan - Successfully read value at offset {}",
                         entry.offset

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -156,7 +156,15 @@ impl SSTableReader {
                     i, entry.offset, file_offset, entry.size
                 );
 
-                if let Some(value) = self.read_value_at_offset(file_offset, entry.size).await? {
+                // SCAN intent (issue #2876): this walks the index's entries in
+                // order, so it uses the scan-plane sibling of
+                // `read_value_at_offset` — same decode, but off the reader's
+                // UNADVISED mapping instead of the `MADV_RANDOM` point one (#2210),
+                // whose readahead suppression is exactly backwards here.
+                if let Some(value) = self
+                    .read_value_at_offset_for_scan(file_offset, entry.size)
+                    .await?
+                {
                     tracing::debug!(
                         "SSTableReader::scan - Successfully read value at offset {}",
                         entry.offset

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan.rs
@@ -261,12 +261,25 @@ impl SSTableReader {
                     )));
                 };
 
+                // SCAN intent (issue #2876): this forward Summary-guided walk reads
+                // Data.db in mostly-ascending order, so every read — the partition
+                // body AND (uncompressed) its covering `CRC.db` chunks — goes
+                // through the reader's UNADVISED `scan_positional_source`, never the
+                // `MADV_RANDOM` point mapping whose readahead suppression (#2210)
+                // would cost this walk ~one 4 KiB fault per partition.
+                let scan_source = self.scan_positional_source.clone();
                 let raw = if let Some(ci) = self.compression_info.as_deref() {
-                    self.read_compressed_offset_window(ci, start, size).await?
+                    self.read_compressed_offset_window(scan_source.as_ref(), ci, start, size)
+                        .await?
                 } else {
                     let absolute_offset = start + self.actual_header_size as u64;
-                    self.read_uncompressed_verified(&self.file, absolute_offset, size as usize)
-                        .await?
+                    self.read_uncompressed_verified(
+                        scan_source.as_ref(),
+                        &self.file,
+                        absolute_offset,
+                        size as usize,
+                    )
+                    .await?
                 };
 
                 // Structural coverage (Signal B): the slice must decode as exactly

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -594,6 +594,24 @@ impl SSTableReader {
             }
         };
 
+        // Build the SCAN-side positional source (issue #2876): the Summary-guided
+        // compressed partition walk and the windowed streaming scan feed must NOT
+        // share `point_source` — for the mmap backend that source is deliberately
+        // advised `MADV_RANDOM` above (issue #2210) to help scattered point faults,
+        // which is exactly backwards for a mostly-sequential scan (one 4 KiB page
+        // fault per positional read instead of the ~128 KiB read-ahead window).
+        // Always the SAME unadvised mapping `ScanSource::Mapped` already holds — an
+        // `Arc` clone, no new mapping / fd (#1143: the scan mapping is never
+        // advised). The Direct/Buffered backends have no per-mapping advice
+        // concept, so they share `point_source` unchanged (no behavior change for
+        // those backends).
+        let scan_positional_source: Arc<dyn read_at::ReadAt> = match &scan_source {
+            ScanSource::Mapped(mmap) => Arc::new(read_at::MmapReadAt::new(mmap.clone())),
+            #[cfg(unix)]
+            ScanSource::Direct { .. } => point_source.clone(),
+            ScanSource::Buffered { .. } => point_source.clone(),
+        };
+
         // Parse header - read available bytes, not a fixed size
         // NOTE: For NB format files (Cassandra 4.x+), Data.db often contains compressed row data
         // with no embedded header. The header.rs module detects this via filename pattern and
@@ -914,6 +932,7 @@ impl SSTableReader {
             file,
             scan_source,
             point_source,
+            scan_positional_source,
             header,
             parser,
             index,
@@ -964,17 +983,39 @@ impl SSTableReader {
     /// Clone the reader's shared positional point source (issue #1573 convoy
     /// scenario). Test-only: lets a test wrap the real source in a slow/serializing
     /// decorator, then reinstall it via [`set_point_source`](Self::set_point_source).
-    #[cfg(test)]
+    ///
+    /// Sole caller (issue #2876) is the write-support+lz4-gated compressed-fixture
+    /// regression test in `read_at_point_tests.rs`, so this is gated identically —
+    /// under the minimal-build feature set (no `write-support`) that test does not
+    /// exist and this method would otherwise be flagged dead code under `-D warnings`.
+    #[cfg(all(test, feature = "write-support", feature = "lz4"))]
     pub(crate) fn clone_point_source(&self) -> Arc<dyn read_at::ReadAt> {
         self.point_source.clone()
     }
 
     /// Replace the reader's point source (issue #1573 convoy scenario). Test-only;
     /// requires `&mut self`, so it must be called BEFORE the reader is shared
-    /// behind an `Arc` across the concurrent point reads under test.
-    #[cfg(test)]
+    /// behind an `Arc` across the concurrent point reads under test. Gated
+    /// identically to [`clone_point_source`](Self::clone_point_source) — see there.
+    #[cfg(all(test, feature = "write-support", feature = "lz4"))]
     pub(crate) fn set_point_source(&mut self, src: Arc<dyn read_at::ReadAt>) {
         self.point_source = src;
+    }
+
+    /// Clone the reader's scan-side positional source (issue #2876). Test-only:
+    /// mirrors [`clone_point_source`](Self::clone_point_source) for the sibling
+    /// scan-side plane.
+    #[cfg(test)]
+    pub(crate) fn clone_scan_positional_source(&self) -> Arc<dyn read_at::ReadAt> {
+        self.scan_positional_source.clone()
+    }
+
+    /// Replace the reader's scan-side positional source (issue #2876). Test-only;
+    /// mirrors [`set_point_source`](Self::set_point_source) — requires `&mut self`,
+    /// so call it BEFORE the reader is shared behind an `Arc`.
+    #[cfg(test)]
+    pub(crate) fn set_scan_positional_source(&mut self, src: Arc<dyn read_at::ReadAt>) {
+        self.scan_positional_source = src;
     }
 
     /// Whether this reader's block source is backed by direct I/O.

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -983,21 +983,15 @@ impl SSTableReader {
     /// Clone the reader's shared positional point source (issue #1573 convoy
     /// scenario). Test-only: lets a test wrap the real source in a slow/serializing
     /// decorator, then reinstall it via [`set_point_source`](Self::set_point_source).
-    ///
-    /// Sole caller (issue #2876) is the write-support+lz4-gated compressed-fixture
-    /// regression test in `read_at_point_tests.rs`, so this is gated identically —
-    /// under the minimal-build feature set (no `write-support`) that test does not
-    /// exist and this method would otherwise be flagged dead code under `-D warnings`.
-    #[cfg(all(test, feature = "write-support", feature = "lz4"))]
+    #[cfg(test)]
     pub(crate) fn clone_point_source(&self) -> Arc<dyn read_at::ReadAt> {
         self.point_source.clone()
     }
 
     /// Replace the reader's point source (issue #1573 convoy scenario). Test-only;
     /// requires `&mut self`, so it must be called BEFORE the reader is shared
-    /// behind an `Arc` across the concurrent point reads under test. Gated
-    /// identically to [`clone_point_source`](Self::clone_point_source) — see there.
-    #[cfg(all(test, feature = "write-support", feature = "lz4"))]
+    /// behind an `Arc` across the concurrent point reads under test.
+    #[cfg(test)]
     pub(crate) fn set_point_source(&mut self, src: Arc<dyn read_at::ReadAt>) {
         self.point_source = src;
     }
@@ -1005,15 +999,21 @@ impl SSTableReader {
     /// Clone the reader's scan-side positional source (issue #2876). Test-only:
     /// mirrors [`clone_point_source`](Self::clone_point_source) for the sibling
     /// scan-side plane.
-    #[cfg(test)]
+    ///
+    /// Sole callers are the write-support+lz4-gated Summary-guided scan-plane
+    /// regressions in `read_at_point_tests.rs`, so this is gated identically —
+    /// under the minimal-build feature set (no `write-support`) those tests do not
+    /// exist and this method would otherwise be flagged dead code under `-D warnings`.
+    #[cfg(all(test, feature = "write-support", feature = "lz4"))]
     pub(crate) fn clone_scan_positional_source(&self) -> Arc<dyn read_at::ReadAt> {
         self.scan_positional_source.clone()
     }
 
     /// Replace the reader's scan-side positional source (issue #2876). Test-only;
     /// mirrors [`set_point_source`](Self::set_point_source) — requires `&mut self`,
-    /// so call it BEFORE the reader is shared behind an `Arc`.
-    #[cfg(test)]
+    /// so call it BEFORE the reader is shared behind an `Arc`. Gated identically to
+    /// [`clone_scan_positional_source`](Self::clone_scan_positional_source).
+    #[cfg(all(test, feature = "write-support", feature = "lz4"))]
     pub(crate) fn set_scan_positional_source(&mut self, src: Arc<dyn read_at::ReadAt>) {
         self.scan_positional_source = src;
     }

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -75,13 +75,11 @@ async fn concurrent_point_reads(
 /// because positioned reads on a shared source are independent (`&self`, no
 /// cursor mutex).
 ///
-/// `read_value_at_offset`'s UNCOMPRESSED branch (`get_cached_data`) is wrapped
-/// here, not `point_source`: it is reached by every index-driven scan
-/// (`sequential.rs`) as well as the rare index-less point-lookup fallback
-/// (`big_point.rs`), so issue #2876 repointed it at `scan_positional_source` —
-/// the shared plane must NOT alias the reader's dedicated `MADV_RANDOM`
-/// point-read mapping (issue #2210), which is exactly backwards for a scan's
-/// mostly-sequential access pattern.
+/// `point_source` is the wrapped plane: `read_value_at_offset` is the POINT-intent
+/// entry point (issue #2876 — the scan-intent sibling is
+/// `read_value_at_offset_for_scan`, which `sequential.rs`'s index-driven scan
+/// calls), so a point read must reach the reader's dedicated `MADV_RANDOM`
+/// point-read mapping (issue #2210) and this convoy proof belongs on that plane.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn eight_concurrent_point_reads_do_not_convoy() {
     let Some(path) = find_data_db("test_basic", "uncompressed_table") else {
@@ -96,8 +94,8 @@ async fn eight_concurrent_point_reads_do_not_convoy() {
     // --- Control: a lock-holding source serializes (reproduces the convoy). ---
     let control = {
         let mut reader = open_reader(&path).await.expect("open control reader");
-        let real = reader.clone_scan_positional_source();
-        reader.set_scan_positional_source(Arc::new(SerializingReadAt::new(real, delay)));
+        let real = reader.clone_point_source();
+        reader.set_point_source(Arc::new(SerializingReadAt::new(real, delay)));
         let reader = Arc::new(reader);
         concurrent_point_reads(reader, &offsets, size).await
     };
@@ -106,24 +104,20 @@ async fn eight_concurrent_point_reads_do_not_convoy() {
     let calls = Arc::new(AtomicUsize::new(0));
     let treatment = {
         let mut reader = open_reader(&path).await.expect("open treatment reader");
-        let real = reader.clone_scan_positional_source();
-        reader.set_scan_positional_source(Arc::new(SleepingReadAt::new(
-            real,
-            delay,
-            calls.clone(),
-        )));
+        let real = reader.clone_point_source();
+        reader.set_point_source(Arc::new(SleepingReadAt::new(real, delay, calls.clone())));
         let reader = Arc::new(reader);
         concurrent_point_reads(reader, &offsets, size).await
     };
 
     // Routing proof (deterministic; this is what is RED on `main`, where
     // get_cached_data/verify_uncompressed_range still lock `self.file` and never
-    // touch `scan_positional_source`): the read path must reach the injected
+    // touch a positional source): the point read path must reach the injected
     // source.
     assert!(
         calls.load(Ordering::Relaxed) >= offsets.len(),
-        "read path must route through `scan_positional_source` (>= {} reads); got {} \
-         — a 0 here means the read path no longer uses scan_positional_source",
+        "point read path must route through `point_source` (>= {} reads); got {} \
+         — a 0 here means the point read path no longer uses point_source",
         offsets.len(),
         calls.load(Ordering::Relaxed)
     );
@@ -179,26 +173,42 @@ async fn concurrent_point_reads_return_correct_bytes() {
     }
 }
 
-/// Build a genuine COMPRESSED BIG ("nb") SSTable with a USABLE `Summary.db`
-/// (issue #2876): `N` single-int-PK partitions via the production `WriteEngine`
-/// (a valid uncompressed BIG Data.db + Index.db/Summary.db/Statistics.db), then
-/// LZ4-compress the flushed Data.db IN PLACE — the same recipe
+/// Number of partitions every Summary-guided fixture below writes. Comfortably
+/// over the default `min_index_interval` (128, see
+/// `issue_2412_wraparound_scan.rs`'s identical rationale) so `Summary.db` carries
+/// multiple samples spanning distinct `Index.db` positions — a single-sample
+/// summary would make `stream_all_partitions_for_query`'s summary-guided branch
+/// untestable (it requires non-empty `Summary.db` entries). Also the EXACT row
+/// count the walk must emit, so a walk that silently emits nothing (or a
+/// fallback that emits a different shape) cannot pass.
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+const SUMMARY_FIXTURE_PARTITIONS: i32 = 400;
+
+/// Build a genuine BIG ("nb") SSTable with a USABLE `Summary.db` (issue #2876):
+/// [`SUMMARY_FIXTURE_PARTITIONS`] single-int-PK partitions via the production
+/// `WriteEngine` (a valid uncompressed BIG Data.db + Index.db / Summary.db /
+/// Statistics.db / CRC.db) and, when `compress` is set, the flushed Data.db
+/// LZ4-compressed IN PLACE — the same recipe
 /// `issue_1293_compressed_big_reverse_seek.rs` established. CQLite's own write
-/// surface never emits compression (issue #1406 claim boundary), so this is the
+/// surface never emits compression (issue #1406 claim boundary), so that is the
 /// only way to get a genuine compressed-nb fixture without a fetched real-
 /// Cassandra dataset (whose small tables don't reliably clear the
-/// `min_index_interval` sampling threshold either). `N` is comfortably over the
-/// default `min_index_interval` (128) so `Summary.db` carries multiple samples —
-/// a single-sample summary would make `stream_all_partitions_for_query`'s
-/// summary-guided branch untestable (it requires non-empty `Summary.db` entries).
+/// `min_index_interval` sampling threshold either).
 ///
-/// Sound because the uncompressed-BIG Data.db is HEADERLESS (data starts at byte
-/// 0) and `Index.db` offsets are in the uncompressed domain — exactly what the
-/// compressed reader assumes (`CompressionInfo` chunk offsets are relative to
-/// `Data.db` byte 0), so re-chunking + compressing the bytes in place needs no
-/// change to Index.db/Summary.db/Statistics.db.
+/// `compress = false` keeps the writer's UNCOMPRESSED output verbatim —
+/// including its `CRC.db`, which is what makes the uncompressed scan's
+/// `verify_uncompressed_range` CRC reads observable (issue #2876 Finding 1).
+///
+/// Compressing in place is sound because the uncompressed-BIG Data.db is
+/// HEADERLESS (data starts at byte 0) and `Index.db` offsets are in the
+/// uncompressed domain — exactly what the compressed reader assumes
+/// (`CompressionInfo` chunk offsets are relative to `Data.db` byte 0), so
+/// re-chunking + compressing the bytes in place needs no change to
+/// Index.db/Summary.db/Statistics.db.
 #[cfg(all(feature = "write-support", feature = "lz4"))]
-async fn build_compressed_summary_guided_fixture() -> (
+async fn build_summary_guided_fixture(
+    compress: bool,
+) -> (
     tempfile::TempDir,
     std::path::PathBuf,
     crate::schema::TableSchema,
@@ -214,10 +224,7 @@ async fn build_compressed_summary_guided_fixture() -> (
 
     const KS: &str = "issue_2876_ks";
     const TBL: &str = "items";
-    /// Comfortably over the default `min_index_interval` (128, see
-    /// `issue_2412_wraparound_scan.rs`'s identical rationale) so `Summary.db`
-    /// carries multiple samples spanning distinct `Index.db` positions.
-    const N: i32 = 400;
+    const N: i32 = SUMMARY_FIXTURE_PARTITIONS;
     /// Small chunks so the fixture's LZ4-compressed Data.db spans several
     /// compressed chunks, not just one.
     const CHUNK_SIZE: usize = 4096;
@@ -283,6 +290,13 @@ async fn build_compressed_summary_guided_fixture() -> (
     let (data_path, base) =
         locate_data_db_under(&data_dir).expect("no *-Data.db produced under data_dir");
 
+    if !compress {
+        // Keep the writer's genuine UNCOMPRESSED output (Data.db + CRC.db) as-is:
+        // the CRC.db is exactly what makes the uncompressed scan's
+        // `verify_uncompressed_range` reads observable (issue #2876, Finding 1).
+        return (temp, data_path, schema);
+    }
+
     // Compress Data.db in place (issue #1293 recipe).
     let uncompressed = std::fs::read(&data_path).expect("read uncompressed Data.db");
     let compressor = create_compressor(CompressionAlgorithm::Lz4).expect("lz4 compressor");
@@ -331,42 +345,52 @@ fn locate_data_db_under(dir: &std::path::Path) -> Option<(std::path::PathBuf, St
     None
 }
 
-/// Regression test (issue #2876): the Summary-guided COMPRESSED scan walk —
-/// `stream_all_partitions_for_query` → `stream_partitions_summary_guided_compaction`
-/// → `walk_in_range_partition_slices` (`summary_scan.rs`) →
-/// `read_compressed_offset_window` (`compressed_offset.rs`) — must NOT read
-/// Data.db through the reader's dedicated `MADV_RANDOM` point-read mapping
-/// (`point_source`). That advice exists to suppress kernel readahead for
-/// scattered point-lookup faults (issue #2210); on this mostly-sequential walk it
-/// was exactly backwards, forcing one 4 KiB page fault per partition instead of
-/// the ~128 KiB read-ahead window (the #2210 × #1940 cross-path regression).
+/// Drive `stream_all_partitions_for_query` over a Summary-guided fixture with a
+/// call-counting spy on BOTH positional planes, and return
+/// `(rows_seen, point_reads, scan_reads, partitions_parsed)`.
 ///
-/// RED before the fix: `compressed_offset.rs` passed `self.point_source` into
-/// the shared offset-window reader, so every partition slice the walk
-/// decompresses bumps the spy installed on `point_source` below. GREEN after the
-/// fix: the walk reads through the new `scan_positional_source` instead, so the
-/// spy on `point_source` sees ZERO calls while the walk still emits every row
-/// (never a silent 0-rows pass — CLAUDE.md's dataset-dependent-test guardrail).
+/// Shared by the compressed and uncompressed scan-plane regressions below so the
+/// preconditions, the spy installation, and the branch proof are written ONCE.
+/// `partitions_parsed` comes from the thread-local
+/// [`StreamWalkScope`](crate::storage::sstable::work_counters::stream_walk_scope::StreamWalkScope)
+/// (issue #2428): it counts ONLY the per-partition
+/// `add_stream_walk_partition_parsed()` increments executed by THIS test's own
+/// inline walk, so it is a POSITIVE, pollution-immune proof that
+/// `walk_in_range_partition_slices` — the Summary-guided branch, not the
+/// full-ring fallback — actually ran.
 #[cfg(all(feature = "write-support", feature = "lz4"))]
-#[tokio::test]
-async fn summary_guided_compressed_scan_walk_avoids_point_source() {
+async fn summary_guided_scan_plane_probe(
+    compress: bool,
+) -> (usize, usize, usize, u64, tempfile::TempDir) {
     use std::ops::ControlFlow;
 
     use super::compaction_row::CompactionRow;
     use crate::storage::scan_cancel::ScanCancel;
+    use crate::storage::sstable::work_counters::stream_walk_scope::StreamWalkScope;
 
-    let (_temp, data_path, schema) = build_compressed_summary_guided_fixture().await;
+    let (temp, data_path, schema) = build_summary_guided_fixture(compress).await;
     let mut reader = open_reader(&data_path)
         .await
-        .expect("open compressed fixture reader");
+        .expect("open summary-guided fixture reader");
 
     // Fixture preconditions (fail LOUD, never silently skip: this fixture is
     // built in-test, not a fetched dataset that can legitimately be absent) —
-    // the walk under test requires compression, a raw-key Index.db, no BTI
-    // trie, and a `Summary.db` with at least one sample.
-    assert!(
+    // the walk under test requires a raw-key Index.db, no BTI trie, a
+    // `Summary.db` with at least one sample, and the requested compression state.
+    assert_eq!(
         reader.compression_info.is_some(),
-        "fixture must be a genuine compressed nb SSTable"
+        compress,
+        "fixture compression state must match the requested one (compress={compress})"
+    );
+    // The uncompressed fixture MUST carry the writer's `CRC.db`: the covering-chunk
+    // CRC read is the very I/O this scenario proves stays off the point plane
+    // (issue #2876, Finding 1). A missing CRC.db would make the whole scenario
+    // vacuously green.
+    assert_eq!(
+        reader.crc_reader.is_some(),
+        !compress,
+        "uncompressed fixture must carry CRC.db (and the compressed one must not) — \
+         the CRC read is the I/O under test"
     );
     assert!(
         reader.index_reader.is_some(),
@@ -387,16 +411,32 @@ async fn summary_guided_compressed_scan_walk_avoids_point_source() {
          the summary-guided walk under test requires a usable Summary.db"
     );
 
-    let calls = Arc::new(AtomicUsize::new(0));
-    let real = reader.clone_point_source();
+    // Independent spies on the two planes: `point_source` (the dedicated
+    // `MADV_RANDOM` point mapping, issue #2210) and `scan_positional_source` (the
+    // unadvised scan mapping, issue #2876). They are separate reader fields, so
+    // replacing one never redirects the other — even on the Buffered/Direct
+    // backends where both start out as clones of the same backing source.
+    let point_calls = Arc::new(AtomicUsize::new(0));
+    let scan_calls = Arc::new(AtomicUsize::new(0));
+    let real_point = reader.clone_point_source();
     reader.set_point_source(Arc::new(SleepingReadAt::new(
-        real,
+        real_point,
         Duration::ZERO,
-        calls.clone(),
+        point_calls.clone(),
+    )));
+    let real_scan = reader.clone_scan_positional_source();
+    reader.set_scan_positional_source(Arc::new(SleepingReadAt::new(
+        real_scan,
+        Duration::ZERO,
+        scan_calls.clone(),
     )));
 
     let scan_cancel = ScanCancel::default();
     let mut rows_seen = 0usize;
+    // Scope opened on THIS thread around the inline walk (default `#[tokio::test]`
+    // drives every `.await` on the test's own thread), so the count is exactly
+    // this walk's partition parses.
+    let scope = StreamWalkScope::new();
     reader
         .stream_all_partitions_for_query(
             Some(&schema),
@@ -408,22 +448,195 @@ async fn summary_guided_compressed_scan_walk_avoids_point_source() {
             },
         )
         .await
-        .expect("summary-guided compressed scan walk");
+        .expect("summary-guided scan walk");
+    let partitions_parsed = scope.count();
+    drop(scope);
 
-    // Non-vacuity (never let a dataset-dependent assertion pass on zero rows,
-    // per CLAUDE.md): the fixture wrote 400 partitions, so the walk must emit
-    // them, proving the summary-guided branch — not some fallback — ran.
-    assert!(
-        rows_seen > 0,
-        "the summary-guided walk must have emitted rows; got 0 — the fixture or the \
-         summary-guided routing itself is broken, not just the point_source wiring"
+    (
+        rows_seen,
+        point_calls.load(Ordering::Relaxed),
+        scan_calls.load(Ordering::Relaxed),
+        partitions_parsed,
+        temp,
+    )
+}
+
+/// Regression test (issue #2876): the Summary-guided COMPRESSED scan walk —
+/// `stream_all_partitions_for_query` → `stream_partitions_summary_guided_compaction`
+/// → `walk_in_range_partition_slices` (`summary_scan.rs`) →
+/// `read_compressed_offset_window` (`compressed_offset.rs`) — must NOT read
+/// Data.db through the reader's dedicated `MADV_RANDOM` point-read mapping
+/// (`point_source`). That advice exists to suppress kernel readahead for
+/// scattered point-lookup faults (issue #2210); on this mostly-sequential walk it
+/// was exactly backwards, forcing one 4 KiB page fault per partition instead of
+/// the ~128 KiB read-ahead window (the #2210 × #1940 cross-path regression).
+///
+/// Three assertions, none of which a broken walk can satisfy (roborev #2882
+/// Finding 3): the walk emits EXACTLY the fixture's partition count, the
+/// Summary-guided branch is POSITIVELY proven to have run (that many partition
+/// parses recorded on this thread + non-zero reads on the scan plane), and the
+/// point plane is untouched.
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+#[tokio::test]
+#[serial_test::serial(work_counters)]
+async fn summary_guided_compressed_scan_walk_avoids_point_source() {
+    let (rows_seen, point_reads, scan_reads, partitions_parsed, _temp) =
+        summary_guided_scan_plane_probe(true).await;
+
+    // Non-vacuity: the fixture wrote exactly this many single-row partitions, so
+    // an under-emitting walk (or a fallback with a different emit shape) fails
+    // here instead of passing on 0 rows (CLAUDE.md's dataset-test guardrail).
+    assert_eq!(
+        rows_seen, SUMMARY_FIXTURE_PARTITIONS as usize,
+        "the summary-guided walk must emit exactly one row per fixture partition"
     );
+    // POSITIVE branch proof: `walk_in_range_partition_slices` bumped its
+    // per-partition work probe once per partition. The full-ring fallback bumps a
+    // DIFFERENT site (`drain_compaction_window`) once per partition too, so this is
+    // paired with the scan-plane read proof below, which the fallback (a cursor
+    // walk on `self.file`) cannot satisfy.
+    assert_eq!(
+        partitions_parsed, SUMMARY_FIXTURE_PARTITIONS as u64,
+        "the Summary-guided walk must parse exactly one body per fixture partition"
+    );
+    assert!(
+        scan_reads > 0,
+        "the Summary-guided compressed walk must read Data.db through \
+         `scan_positional_source`; got 0 reads there — the branch under test did not run"
+    );
+    assert_eq!(
+        point_reads, 0,
+        "the Summary-guided compressed scan walk must not read Data.db through the \
+         MADV_RANDOM point_source mapping (issue #2876)"
+    );
+}
+
+/// Regression test (issue #2876, roborev #2882 Finding 1): the Summary-guided
+/// UNCOMPRESSED scan walk must ALSO keep every Data.db read off the
+/// `MADV_RANDOM` point mapping — including the `CRC.db` covering-chunk reads.
+///
+/// The uncompressed walk (`walk_in_range_partition_slices` →
+/// `read_uncompressed_verified` → `verify_uncompressed_range`) reads each covering
+/// `CRC.db` chunk before handing back bytes (issue #1396). Verifying a 64 KiB
+/// chunk on the point plane is exactly the readahead-suppressed access the split
+/// exists to avoid, so the scan-side verifier must read the scan plane.
+///
+/// RED before the fix: `verify_uncompressed_range` hardcoded `self.point_source`,
+/// so the walk bumps the point spy. GREEN after: the CRC read follows the caller's
+/// plane, so the point spy stays at zero while the walk still emits every row.
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+#[tokio::test]
+#[serial_test::serial(work_counters)]
+async fn summary_guided_uncompressed_scan_walk_avoids_point_source() {
+    let (rows_seen, point_reads, scan_reads, partitions_parsed, _temp) =
+        summary_guided_scan_plane_probe(false).await;
 
     assert_eq!(
-        calls.load(Ordering::Relaxed),
-        0,
-        "the Summary-guided compressed scan walk must not read Data.db through the \
-         MADV_RANDOM point_source mapping (issue #2876) — got {} call(s)",
-        calls.load(Ordering::Relaxed)
+        rows_seen, SUMMARY_FIXTURE_PARTITIONS as usize,
+        "the summary-guided walk must emit exactly one row per fixture partition"
     );
+    assert_eq!(
+        partitions_parsed, SUMMARY_FIXTURE_PARTITIONS as u64,
+        "the Summary-guided walk must parse exactly one body per fixture partition"
+    );
+    assert!(
+        scan_reads > 0,
+        "the Summary-guided uncompressed walk must read Data.db (its CRC.db covering \
+         chunks) through `scan_positional_source`; got 0 reads there"
+    );
+    assert_eq!(
+        point_reads, 0,
+        "the Summary-guided uncompressed scan walk must not read Data.db through the \
+         MADV_RANDOM point_source mapping — including its CRC.db covering-chunk reads \
+         (issue #2876, Finding 1)"
+    );
+}
+
+/// Regression test (issue #2876, roborev #2882 Finding 2): a genuine POINT read
+/// must still go through the reader's dedicated `MADV_RANDOM` point mapping.
+///
+/// The scan-plane split must not sweep the point path along with it: issue #2210
+/// gave point lookups an advised mapping precisely because their faults are
+/// scattered, and `read_value_at_offset` is the point-intent offset read (the
+/// index-driven scan uses its scan-intent sibling). So a `read_value_at_offset`
+/// must read `point_source` and must NOT touch `scan_positional_source` — on a
+/// COMPRESSED reader (whose window comes from `read_compressed_offset_window`) as
+/// well as an UNCOMPRESSED one (raw bytes + `CRC.db` verification).
+///
+/// RED before the fix: the shared helpers hardcoded `scan_positional_source`, so
+/// the point read reached the UNADVISED plane — for the compressed reader the
+/// point spy stayed at exactly 0.
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+#[tokio::test]
+#[serial_test::serial(work_counters)]
+async fn point_offset_read_uses_advised_point_source() {
+    // A window comfortably inside the fixture's data section, spanning several
+    // small partitions; `read_value_at_offset` returns the raw bytes without
+    // parsing, so any in-bounds window exercises the plane routing.
+    const OFFSET: u64 = 0;
+    const SIZE: u32 = 64;
+
+    for compress in [false, true] {
+        let (_temp, data_path, _schema) = build_summary_guided_fixture(compress).await;
+        let mut reader = open_reader(&data_path)
+            .await
+            .expect("open summary-guided fixture reader");
+        assert_eq!(
+            reader.compression_info.is_some(),
+            compress,
+            "fixture compression state must match the requested one"
+        );
+
+        let point_calls = Arc::new(AtomicUsize::new(0));
+        let scan_calls = Arc::new(AtomicUsize::new(0));
+        let real_point = reader.clone_point_source();
+        reader.set_point_source(Arc::new(SleepingReadAt::new(
+            real_point,
+            Duration::ZERO,
+            point_calls.clone(),
+        )));
+        let real_scan = reader.clone_scan_positional_source();
+        reader.set_scan_positional_source(Arc::new(SleepingReadAt::new(
+            real_scan,
+            Duration::ZERO,
+            scan_calls.clone(),
+        )));
+
+        let row = reader
+            .read_value_at_offset(OFFSET, SIZE)
+            .await
+            .expect("point offset read")
+            .expect("point offset read must return the raw window");
+        // Non-vacuity: the read really produced the requested window.
+        match &row {
+            crate::types::ScanRow::RawRow(bytes) => assert_eq!(
+                bytes.len(),
+                SIZE as usize,
+                "point offset read must return exactly the requested window"
+            ),
+            other => panic!("expected a RawRow window, got {other:?}"),
+        }
+
+        assert!(
+            point_calls.load(Ordering::Relaxed) > 0,
+            "a point offset read on a {} reader must read Data.db through the advised \
+             `point_source` mapping (issue #2210); got 0 reads there",
+            if compress {
+                "compressed"
+            } else {
+                "uncompressed"
+            }
+        );
+        assert_eq!(
+            scan_calls.load(Ordering::Relaxed),
+            0,
+            "a point offset read on a {} reader must not read Data.db through the \
+             scan-side plane (issue #2876, Finding 2)",
+            if compress {
+                "compressed"
+            } else {
+                "uncompressed"
+            }
+        );
+    }
 }

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -76,10 +76,10 @@ async fn concurrent_point_reads(
 /// cursor mutex).
 ///
 /// `point_source` is the wrapped plane: `read_value_at_offset` is the POINT-intent
-/// entry point (issue #2876 — the scan-intent sibling is
-/// `read_value_at_offset_for_scan`, which `sequential.rs`'s index-driven scan
-/// calls), so a point read must reach the reader's dedicated `MADV_RANDOM`
-/// point-read mapping (issue #2210) and this convoy proof belongs on that plane.
+/// entry point (issue #2876), so a point read must reach the reader's dedicated
+/// `MADV_RANDOM` point-read mapping (issue #2210) and this convoy proof belongs on
+/// that plane. The genuinely sequential walks reach the unadvised scan plane via the
+/// positional helpers, which take their plane from the caller.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn eight_concurrent_point_reads_do_not_convoy() {
     let Some(path) = find_data_db("test_basic", "uncompressed_table") else {
@@ -557,8 +557,8 @@ async fn summary_guided_uncompressed_scan_walk_avoids_point_source() {
 ///
 /// The scan-plane split must not sweep the point path along with it: issue #2210
 /// gave point lookups an advised mapping precisely because their faults are
-/// scattered, and `read_value_at_offset` is the point-intent offset read (the
-/// index-driven scan uses its scan-intent sibling). So a `read_value_at_offset`
+/// scattered, and `read_value_at_offset` is the point-intent offset read. So a
+/// `read_value_at_offset`
 /// must read `point_source` and must NOT touch `scan_positional_source` — on a
 /// COMPRESSED reader (whose window comes from `read_compressed_offset_window`) as
 /// well as an UNCOMPRESSED one (raw bytes + `CRC.db` verification).

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -67,12 +67,21 @@ async fn concurrent_point_reads(
 
 /// Scenario: 8 concurrent point reads do NOT convoy.
 ///
-/// The reader's `point_source` is wrapped in a 12ms-sleeping [`SleepingReadAt`]
-/// (no lock) for the treatment, and in a lock-holding [`SerializingReadAt`] for
-/// the control. The control proves the harness CAN serialize (the pre-#1573
-/// `Arc<Mutex<BlockSource>>` convoy: ~N×delay); the treatment proves the migrated
-/// positional path does NOT (well under 8×delay), because positioned reads on a
-/// shared source are independent (`&self`, no cursor mutex).
+/// The reader's scan-side positional source is wrapped in a 12ms-sleeping
+/// [`SleepingReadAt`] (no lock) for the treatment, and in a lock-holding
+/// [`SerializingReadAt`] for the control. The control proves the harness CAN
+/// serialize (the pre-#1573 `Arc<Mutex<BlockSource>>` convoy: ~N×delay); the
+/// treatment proves the migrated positional path does NOT (well under 8×delay),
+/// because positioned reads on a shared source are independent (`&self`, no
+/// cursor mutex).
+///
+/// `read_value_at_offset`'s UNCOMPRESSED branch (`get_cached_data`) is wrapped
+/// here, not `point_source`: it is reached by every index-driven scan
+/// (`sequential.rs`) as well as the rare index-less point-lookup fallback
+/// (`big_point.rs`), so issue #2876 repointed it at `scan_positional_source` —
+/// the shared plane must NOT alias the reader's dedicated `MADV_RANDOM`
+/// point-read mapping (issue #2210), which is exactly backwards for a scan's
+/// mostly-sequential access pattern.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn eight_concurrent_point_reads_do_not_convoy() {
     let Some(path) = find_data_db("test_basic", "uncompressed_table") else {
@@ -87,8 +96,8 @@ async fn eight_concurrent_point_reads_do_not_convoy() {
     // --- Control: a lock-holding source serializes (reproduces the convoy). ---
     let control = {
         let mut reader = open_reader(&path).await.expect("open control reader");
-        let real = reader.clone_point_source();
-        reader.set_point_source(Arc::new(SerializingReadAt::new(real, delay)));
+        let real = reader.clone_scan_positional_source();
+        reader.set_scan_positional_source(Arc::new(SerializingReadAt::new(real, delay)));
         let reader = Arc::new(reader);
         concurrent_point_reads(reader, &offsets, size).await
     };
@@ -97,19 +106,24 @@ async fn eight_concurrent_point_reads_do_not_convoy() {
     let calls = Arc::new(AtomicUsize::new(0));
     let treatment = {
         let mut reader = open_reader(&path).await.expect("open treatment reader");
-        let real = reader.clone_point_source();
-        reader.set_point_source(Arc::new(SleepingReadAt::new(real, delay, calls.clone())));
+        let real = reader.clone_scan_positional_source();
+        reader.set_scan_positional_source(Arc::new(SleepingReadAt::new(
+            real,
+            delay,
+            calls.clone(),
+        )));
         let reader = Arc::new(reader);
         concurrent_point_reads(reader, &offsets, size).await
     };
 
     // Routing proof (deterministic; this is what is RED on `main`, where
     // get_cached_data/verify_uncompressed_range still lock `self.file` and never
-    // touch `point_source`): the point path must reach the injected source.
+    // touch `scan_positional_source`): the read path must reach the injected
+    // source.
     assert!(
         calls.load(Ordering::Relaxed) >= offsets.len(),
-        "point path must route through `point_source` (>= {} reads); got {} \
-         — a 0 here means the point path no longer uses point_source",
+        "read path must route through `scan_positional_source` (>= {} reads); got {} \
+         — a 0 here means the read path no longer uses scan_positional_source",
         offsets.len(),
         calls.load(Ordering::Relaxed)
     );
@@ -163,4 +177,253 @@ async fn concurrent_point_reads_return_correct_bytes() {
     for h in handles {
         h.await.expect("task");
     }
+}
+
+/// Build a genuine COMPRESSED BIG ("nb") SSTable with a USABLE `Summary.db`
+/// (issue #2876): `N` single-int-PK partitions via the production `WriteEngine`
+/// (a valid uncompressed BIG Data.db + Index.db/Summary.db/Statistics.db), then
+/// LZ4-compress the flushed Data.db IN PLACE — the same recipe
+/// `issue_1293_compressed_big_reverse_seek.rs` established. CQLite's own write
+/// surface never emits compression (issue #1406 claim boundary), so this is the
+/// only way to get a genuine compressed-nb fixture without a fetched real-
+/// Cassandra dataset (whose small tables don't reliably clear the
+/// `min_index_interval` sampling threshold either). `N` is comfortably over the
+/// default `min_index_interval` (128) so `Summary.db` carries multiple samples —
+/// a single-sample summary would make `stream_all_partitions_for_query`'s
+/// summary-guided branch untestable (it requires non-empty `Summary.db` entries).
+///
+/// Sound because the uncompressed-BIG Data.db is HEADERLESS (data starts at byte
+/// 0) and `Index.db` offsets are in the uncompressed domain — exactly what the
+/// compressed reader assumes (`CompressionInfo` chunk offsets are relative to
+/// `Data.db` byte 0), so re-chunking + compressing the bytes in place needs no
+/// change to Index.db/Summary.db/Statistics.db.
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+async fn build_compressed_summary_guided_fixture() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    crate::schema::TableSchema,
+) {
+    use crate::schema::{Column, KeyColumn, TableSchema};
+    use crate::storage::sstable::writer::{
+        create_compressor, CompressedDataWriter, CompressionAlgorithm, CompressionInfoWriter,
+    };
+    use crate::storage::write_engine::{
+        CellOperation, Durability, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+    };
+    use crate::types::Value;
+
+    const KS: &str = "issue_2876_ks";
+    const TBL: &str = "items";
+    /// Comfortably over the default `min_index_interval` (128, see
+    /// `issue_2412_wraparound_scan.rs`'s identical rationale) so `Summary.db`
+    /// carries multiple samples spanning distinct `Index.db` positions.
+    const N: i32 = 400;
+    /// Small chunks so the fixture's LZ4-compressed Data.db spans several
+    /// compressed chunks, not just one.
+    const CHUNK_SIZE: usize = 4096;
+
+    let schema = TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    };
+
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone())
+        .with_flush_threshold(1usize << 30)
+        .with_durability(Durability::Disabled);
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    for id in 0..N {
+        let mutation = Mutation::new(
+            TableId::new(KS, TBL),
+            PartitionKey::single("id", Value::Integer(id)),
+            None,
+            vec![CellOperation::Write {
+                column: "name".to_string(),
+                value: Value::text(format!("v{id}")),
+            }],
+            1_000_000 + id as i64,
+            None,
+        );
+        engine.write(mutation).expect("write row");
+    }
+    engine
+        .flush()
+        .await
+        .expect("flush")
+        .expect("flush must produce an SSTable");
+    engine.close().await.expect("close engine");
+
+    let (data_path, base) =
+        locate_data_db_under(&data_dir).expect("no *-Data.db produced under data_dir");
+
+    // Compress Data.db in place (issue #1293 recipe).
+    let uncompressed = std::fs::read(&data_path).expect("read uncompressed Data.db");
+    let compressor = create_compressor(CompressionAlgorithm::Lz4).expect("lz4 compressor");
+    let mut writer = CompressedDataWriter::with_chunk_size(compressor, CHUNK_SIZE);
+    writer.write(&uncompressed).expect("compress Data.db");
+    let (compressed, metadata) = writer.finish().expect("finish compression");
+    std::fs::write(&data_path, &compressed).expect("overwrite Data.db with compressed bytes");
+
+    let parent = data_path.parent().expect("Data.db parent dir");
+    let info_path = parent.join(format!("{base}-CompressionInfo.db"));
+    CompressionInfoWriter::new(info_path)
+        .write(&metadata)
+        .expect("write CompressionInfo.db");
+
+    // The uncompressed-BIG CRC.db describes the old chunking and no longer
+    // matches; compressed BIG carries per-chunk CRCs inline in Data.db instead.
+    let crc_path = parent.join(format!("{base}-CRC.db"));
+    let _ = std::fs::remove_file(&crc_path);
+
+    (temp, data_path, schema)
+}
+
+/// Recursively locate the single `*-Data.db` under `dir` and derive its `<base>`
+/// (e.g. `nb-1-big`).
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+fn locate_data_db_under(dir: &std::path::Path) -> Option<(std::path::PathBuf, String)> {
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                stack.push(p);
+                continue;
+            }
+            let Some(name) = p.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if let Some(base) = name.strip_suffix("-Data.db") {
+                return Some((p.clone(), base.to_string()));
+            }
+        }
+    }
+    None
+}
+
+/// Regression test (issue #2876): the Summary-guided COMPRESSED scan walk —
+/// `stream_all_partitions_for_query` → `stream_partitions_summary_guided_compaction`
+/// → `walk_in_range_partition_slices` (`summary_scan.rs`) →
+/// `read_compressed_offset_window` (`compressed_offset.rs`) — must NOT read
+/// Data.db through the reader's dedicated `MADV_RANDOM` point-read mapping
+/// (`point_source`). That advice exists to suppress kernel readahead for
+/// scattered point-lookup faults (issue #2210); on this mostly-sequential walk it
+/// was exactly backwards, forcing one 4 KiB page fault per partition instead of
+/// the ~128 KiB read-ahead window (the #2210 × #1940 cross-path regression).
+///
+/// RED before the fix: `compressed_offset.rs` passed `self.point_source` into
+/// the shared offset-window reader, so every partition slice the walk
+/// decompresses bumps the spy installed on `point_source` below. GREEN after the
+/// fix: the walk reads through the new `scan_positional_source` instead, so the
+/// spy on `point_source` sees ZERO calls while the walk still emits every row
+/// (never a silent 0-rows pass — CLAUDE.md's dataset-dependent-test guardrail).
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+#[tokio::test]
+async fn summary_guided_compressed_scan_walk_avoids_point_source() {
+    use std::ops::ControlFlow;
+
+    use super::compaction_row::CompactionRow;
+    use crate::storage::scan_cancel::ScanCancel;
+
+    let (_temp, data_path, schema) = build_compressed_summary_guided_fixture().await;
+    let mut reader = open_reader(&data_path)
+        .await
+        .expect("open compressed fixture reader");
+
+    // Fixture preconditions (fail LOUD, never silently skip: this fixture is
+    // built in-test, not a fetched dataset that can legitimately be absent) —
+    // the walk under test requires compression, a raw-key Index.db, no BTI
+    // trie, and a `Summary.db` with at least one sample.
+    assert!(
+        reader.compression_info.is_some(),
+        "fixture must be a genuine compressed nb SSTable"
+    );
+    assert!(
+        reader.index_reader.is_some(),
+        "fixture must have a raw-key Index.db"
+    );
+    assert!(
+        reader.bti_partitions_db.is_none(),
+        "fixture must be BIG, not BTI"
+    );
+    let summary_entries = reader
+        .summary_reader
+        .as_ref()
+        .map(|s| s.get_entries().len())
+        .unwrap_or(0);
+    assert!(
+        summary_entries > 0,
+        "fixture's Summary.db must carry at least one sample (got {summary_entries}) — \
+         the summary-guided walk under test requires a usable Summary.db"
+    );
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let real = reader.clone_point_source();
+    reader.set_point_source(Arc::new(SleepingReadAt::new(
+        real,
+        Duration::ZERO,
+        calls.clone(),
+    )));
+
+    let scan_cancel = ScanCancel::default();
+    let mut rows_seen = 0usize;
+    reader
+        .stream_all_partitions_for_query(
+            Some(&schema),
+            &scan_cancel,
+            None,
+            |_row: CompactionRow| {
+                rows_seen += 1;
+                Ok(ControlFlow::Continue(()))
+            },
+        )
+        .await
+        .expect("summary-guided compressed scan walk");
+
+    // Non-vacuity (never let a dataset-dependent assertion pass on zero rows,
+    // per CLAUDE.md): the fixture wrote 400 partitions, so the walk must emit
+    // them, proving the summary-guided branch — not some fallback — ran.
+    assert!(
+        rows_seen > 0,
+        "the summary-guided walk must have emitted rows; got 0 — the fixture or the \
+         summary-guided routing itself is broken, not just the point_source wiring"
+    );
+
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        0,
+        "the Summary-guided compressed scan walk must not read Data.db through the \
+         MADV_RANDOM point_source mapping (issue #2876) — got {} call(s)",
+        calls.load(Ordering::Relaxed)
+    );
 }

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -517,7 +517,8 @@ impl SSTableReader {
         // decompression (`decode_scan_chunk`). Neither may run on the small async
         // worker pool — decode CPU on the reactor is the Epic F starvation the
         // parse-offload (#1143) and IO-offload (#1593) fixes exist to prevent. The
-        // read is now a SYNCHRONOUS positional read on `self.point_source` for
+        // read is now a SYNCHRONOUS positional read on `self.scan_positional_source`
+        // (issue #2876 — the unadvised scan plane, NOT the MADV_RANDOM point plane) for
         // EVERY backend (issue #1940 restructure): no `tokio::fs`, no
         // `futures::executor::block_on`, and therefore ZERO blocking-pool
         // amplification (the former `block_on(read_next_block_parts(..))` re-
@@ -537,7 +538,8 @@ impl SSTableReader {
         .await;
         // `cursor` is retained in the signature for the caller's data-section-start
         // convention (and the non-windowed branch of the same scan functions), but
-        // the windowed feed now reads positionally via `point_source`, so it does
+        // the windowed feed now reads positionally via `scan_positional_source`
+        // (issue #2876), so it does
         // not use the cursor's file handle or chunk index.
         let _ = cursor;
 
@@ -635,8 +637,9 @@ impl SSTableReader {
     /// (mirroring the parse half — one offload per scan, never per chunk, which
     /// would over-spawn; per-scan admission is F4's scope).
     ///
-    /// The read is a SYNCHRONOUS positional read on `reader.point_source` (issue
-    /// #1940 restructure): a `pread`-style call carrying its offset as a parameter,
+    /// The read is a SYNCHRONOUS positional read on `reader.scan_positional_source`
+    /// (issue #1940 restructure; repointed off the MADV_RANDOM point plane onto the
+    /// unadvised scan plane by #2876): a `pread`-style call carrying its offset as a parameter,
     /// which touches NO tokio reactor/timer and completes fully on THIS blocking
     /// thread for every backend (mmap = resident slice; `O_DIRECT` = aligned pread;
     /// buffered = `pread` on a dedicated `std::fs::File`). This deliberately

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_decode.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_decode.rs
@@ -88,7 +88,14 @@ impl SSTableReader {
             chunk_offsets: vec![],
         };
         let chunk_source = super::super::chunk_source::ChunkSource::new(
-            self.point_source.as_ref(), // unused by decode_borrowed
+            // Correct-by-intent: this is a SCAN path, so hand it the unadvised
+            // scan plane (issue #2876). `decode_borrowed` performs no I/O today, so
+            // this is inert — but `ChunkSource::chunk()` CAN read, and a future
+            // fallback here (a decode-error re-read, or a chunk absent from the
+            // caller's buffer) would otherwise silently route full-scan I/O back
+            // through the MADV_RANDOM point mapping and re-create #2876 with no
+            // test failure. Free to get right now; a trap to leave wrong.
+            self.scan_positional_source.as_ref(),
             &comp_info_dummy,
             compression.as_ref(),
             &self.chunk_cache,

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_read.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_read.rs
@@ -15,16 +15,25 @@
 //! read SYNCHRONOUSLY on the `spawn_blocking` thread, with zero nested async and
 //! zero blocking-pool amplification.
 //!
-//! These helpers read via the reader's `point_source` — the positional
+//! These helpers read via the reader's `scan_positional_source` (issue #2876; was
+//! `point_source` under the original #1940 restructure) — the positional
 //! [`ReadAt`](super::read_at::ReadAt) plane built once at open for EVERY backend
-//! (buffered = `pread` on a dedicated `std::fs::File`; mmap = a resident slice;
-//! `O_DIRECT` = an aligned positioned read). A positional read carries its offset
-//! as a parameter and touches no tokio reactor/timer, so it completes fully on the
-//! calling (blocking) thread — no `tokio::fs`, no `block_on`, no second blocking
-//! thread. `read_at.rs`'s module docs anticipated exactly this adoption ("shaped so
-//! the windowed streaming scan can adopt it later"). Decompression continues to run
-//! in `decode_scan_chunk` on the same blocking thread (the D2 substrate placement,
-//! unchanged).
+//! (buffered = `pread` on a dedicated `std::fs::File`; mmap = a resident slice over
+//! the SAME unadvised mapping the scan backend uses; `O_DIRECT` = an aligned
+//! positioned read). A positional read carries its offset as a parameter and
+//! touches no tokio reactor/timer, so it completes fully on the calling (blocking)
+//! thread — no `tokio::fs`, no `block_on`, no second blocking thread. `read_at.rs`'s
+//! module docs anticipated exactly this adoption ("shaped so the windowed streaming
+//! scan can adopt it later"). Decompression continues to run in `decode_scan_chunk`
+//! on the same blocking thread (the D2 substrate placement, unchanged).
+//!
+//! This whole feed is scan-only (`feed_compressed_chunks` / `feed_uncompressed_pieces`
+//! are driven exclusively by the windowed streaming scan, never a point lookup), so
+//! EVERY read here uses `scan_positional_source`, never the reader's dedicated
+//! `MADV_RANDOM` point-read mapping (`point_source`, issue #2210) — that advice
+//! suppresses kernel readahead, which is exactly backwards for this mostly-
+//! sequential feed (issue #2876, the #2210 × #1940 cross-path regression this file
+//! was the other half of).
 //!
 //! Byte-parity + integrity are preserved verbatim from the former cursor path:
 //! - **compressed NB** (`CompressionInfo` present): the same per-chunk record
@@ -99,7 +108,7 @@ impl SSTableReader {
     /// [`io_error_with_context`] (never collapsed to `Error::other`).
     ///
     /// The `record_io_read_thread` probe fires HERE, at the actual
-    /// `point_source.read_exact_at` call site (not at the top of the feed closure),
+    /// `scan_positional_source.read_exact_at` call site (not at the top of the feed closure),
     /// so the #1940 no-nesting guard records the thread that performs the real read
     /// — making its `io_read_thread == decode_thread` equality a true detector of a
     /// read dispatched off the feed thread. Compiled only under `scan-offload-probe`.
@@ -118,7 +127,7 @@ impl SSTableReader {
             // mmap/plain-file backends it defers to `read_exact_at` and `scratch`
             // stays empty, so those paths are byte-for-byte unchanged (#1940).
             match self
-                .point_source
+                .scan_positional_source
                 .read_exact_at_reusing(offset, buf, scratch)
             {
                 Ok(()) => return Ok(()),
@@ -137,7 +146,7 @@ impl SSTableReader {
         }
     }
 
-    /// Read compressed chunk `chunk_index` SYNCHRONOUSLY via `point_source`,
+    /// Read compressed chunk `chunk_index` SYNCHRONOUSLY via `scan_positional_source`,
     /// verifying its trailing CRC32 before returning the compressed payload (issue
     /// #1940). Returns `Ok(None)` at EOF (past the last chunk, or the degenerate
     /// empty trailing chunk, issue #2225). Mirrors `read_nb_format_chunk_data`'s
@@ -154,7 +163,7 @@ impl SSTableReader {
             // Callers gate on `compression_info.is_some()`; a None here is a bug.
             None => return Ok(None),
         };
-        let file_size = self.point_source.len();
+        let file_size = self.scan_positional_source.len();
 
         if chunk_index >= comp_info.chunk_offsets.len() {
             return Ok(None); // EOF
@@ -278,7 +287,7 @@ impl SSTableReader {
     }
 
     /// Read the next bounded piece of an UNCOMPRESSED-NB data section
-    /// SYNCHRONOUSLY via `point_source`, starting at byte `pos` (an absolute
+    /// SYNCHRONOUSLY via `scan_positional_source`, starting at byte `pos` (an absolute
     /// Data.db offset). Returns `Ok(None)` at EOF, else `Ok(Some((piece, next_pos)))`.
     /// Every `CRC.db` chunk covering the piece is verified (once per reader
     /// lifetime) BEFORE the piece is returned — from the resident bytes when a
@@ -289,7 +298,7 @@ impl SSTableReader {
         pos: u64,
         direct_scratch: &mut DirectScratch,
     ) -> Result<Option<(Vec<u8>, u64)>> {
-        let file_size = self.point_source.len();
+        let file_size = self.scan_positional_source.len();
         let remaining = file_size.saturating_sub(pos);
         if remaining == 0 {
             return Ok(None); // EOF
@@ -328,7 +337,7 @@ impl SSTableReader {
                     // backends this defers to `read_exact_at` (scratch stays empty),
                     // so those paths are unchanged.
                     let mut cbuf = vec![0u8; (hi - lo) as usize];
-                    self.point_source
+                    self.scan_positional_source
                         .read_exact_at_reusing(lo, &mut cbuf, direct_scratch)
                         .map_err(|e| {
                             Error::corruption(format!(
@@ -377,7 +386,7 @@ impl SSTableReader {
         // as `Error::memory`, never a panic. Authoritative metadata, no heuristic.
         let mut scratch: Vec<u8> = Vec::new();
         if let Some(ci) = reader.compression_info.as_ref() {
-            let file_size = reader.point_source.len();
+            let file_size = reader.scan_positional_source.len();
             let max_record = (0..ci.chunk_offsets.len())
                 .filter_map(|i| ci.compressed_chunk_size(i, file_size))
                 .max()

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -252,6 +252,19 @@ pub struct SSTableReader {
     /// source is intentionally shaped so scans could adopt it later (audit F3)
     /// without requiring it now.
     pub(crate) point_source: std::sync::Arc<dyn super::read_at::ReadAt>,
+    /// Positional source for SCAN-side offset reads (issue #2876): the
+    /// Summary-guided compressed partition walk (`compressed_offset.rs`) and the
+    /// windowed streaming scan feed (`scan_stream_windowed_read.rs`) read Data.db
+    /// positionally too, but they must NOT share [`point_source`](Self::point_source)
+    /// — that source is deliberately advised `MADV_RANDOM` for a large mmap-backed
+    /// file (issue #2210) to suppress kernel readahead for scattered point faults,
+    /// which is exactly backwards for a mostly-sequential scan walk (one 4 KiB page
+    /// fault per positional read, #2210 × #1940 cross-path regression). Built once
+    /// at open from the SAME unadvised mapping [`scan_source`](Self::scan_source)
+    /// already uses for the mmap backend (an `Arc` clone, no new mapping / fd,
+    /// #1143 preserved); the Direct/Buffered backends have no per-mapping advice
+    /// concept, so they share `point_source` unchanged.
+    pub(crate) scan_positional_source: std::sync::Arc<dyn super::read_at::ReadAt>,
     /// SSTable header information
     pub(crate) header: SSTableHeader,
     /// Parser for SSTable format


### PR DESCRIPTION
Fixes #2876

## Summary

The Summary-guided compressed scan walk (`stream_all_partitions_for_query` →
`stream_partitions_summary_guided_compaction` → `walk_in_range_partition_slices`
→ `read_compressed_offset_window`) and the windowed streaming scan feed
(`scan_stream_windowed_read.rs`) were reading Data.db through the reader's
dedicated `MADV_RANDOM` point-read mapping (`point_source`). That advice
exists to suppress kernel readahead for scattered point-lookup faults
(#2210), which is exactly backwards for a mostly-sequential scan — each small
partition body faulted ~one 4 KiB page instead of using the ~128 KiB
read-ahead window (#2210 × #1940 cross-path regression).

## Fix

Added `scan_positional_source`: a positional source built from the SAME
unadvised mapping `BlockSource::Mapped` already uses (an `Arc` clone — no new
mmap, no new fd, #1143 preserved), and repointed the scan-side callers at it:

- `compressed_offset.rs`'s `read_compressed_offset_window` (the summary-guided
  walk's read, plus its other callers: `full_index_scan`/`full_index_stream`,
  `get_cached_data`'s compressed branch).
- `data_access/mod.rs`'s `get_cached_data` uncompressed branch (reached by
  index-driven scans and the rare index-less point-lookup fallback).
- Every read in `scan_stream_windowed_read.rs` (the windowed scan feed, which
  is scan-only).

Genuine point lookups (`bti_point.rs`, `big_promoted.rs`) are untouched and
stay on the advised `point_source`, per the issue's scope.

## Regression test

`summary_guided_compressed_scan_walk_avoids_point_source`
(`cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs`) — builds a
genuine compressed BIG fixture (400 partitions via `WriteEngine` + in-place
LZ4 compression, since CQLite's own write surface never emits compression,
#1406) with a `Summary.db` large enough to route through the summary-guided
branch, installs a call-counting spy on `point_source`, and asserts it sees
**zero** calls while the walk still emits every row (never a silent
0-rows-when-present pass). Verified RED before the fix (402 calls observed)
and GREEN after.

`issue_1143_mmap_prefetch_tail_guard.rs` stays green (no `MADV_SEQUENTIAL`
introduced — this is a strict revert of a wrong advice, not a new one).

## File-size note (campsite rule, epic #1116)

`cqlite-core/src/storage/sstable/reader/mod.rs` and
`.../reader/data_access/mod.rs` were already over the ~800-line source
threshold on `main` before this change (1680 and 966 lines respectively).
This fix's field/construction-site addition is tightly coupled to the exact
`point_source` construction logic in `mod.rs` and would not meaningfully
shrink by splitting those files — that's out of scope for a perf-regression
fix. The gate was run with `CQLITE_ALLOW_FILE_GROWTH=1` to acknowledge this;
splitting these files is tracked under epic #1116.

## Gate

**Gate of record** — full `scripts/agent-gate.sh`, **29/29 PASS**, on the merged
commit `8a23eb6cf` with a **clean** tree (`dirty: no`), run by `flow-closer` after
the roborev-4634 revert in `data_access/sequential.rs`. This postdates the final
src change, so it is the run that certifies what merged. `CQLITE_ALLOW_FILE_GROWTH=1`
(pre-existing over-threshold `reader/mod.rs`, epic #1116) and
`CQLITE_GATE_MAX_CONCURRENCY=1`.

```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/5y/bs2cq5v92sqdkq8lks52g__r0000gn/T//agent-gate.JuWpYa
commit: 8a23eb6cf branch: issue-2876-scan-read-plane-split dirty: no
datasets: 144 Data.db files under /Users/pmcfadin/projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=ok
cpu-budget: wrapper=taskpolicy ncpu=16 max-concurrency=1 cores-per-gate=16 build-jobs=16(derived) test-threads=16
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (3s)
roborev-lints:     PASS (1s)
core-tests:        PASS (730s)
tombstones-scan:   PASS (34s)
scan-offload-guard: PASS (144s)
work-counters-guard: PASS (103s)
byte-budget-guard: PASS (31s)
arrow-parity-guard: PASS (30s)
memory-budget:     PASS (371s)
integration-tests: PASS (5s)
format-compat:     PASS (1s)
write-tests:       PASS (146s)
cli-tests:         PASS (59s)
compaction-byte-parity: PASS (9s)
query-semantics-oracle: PASS (1s)
flight-query-semantics-oracle: PASS (1s)
python-bindings:   PASS (473s)
node-bindings:     PASS (463s)
delivery-telemetry: PASS (1s)
oom-audit:         PASS (1s)
parity-report:     PASS (3s)
operator-metrics-doc: PASS (13s)
kit-dashboard-drift: PASS (1s)
binding-unwind-profile: PASS (3s)
tooling-tests:     PASS (297s)
minimal-build:     PASS (47s)
smoke:             PASS (44s)
logs: /var/folders/5y/bs2cq5v92sqdkq8lks52g__r0000gn/T//agent-gate.JuWpYa
summary-file: /tmp/gate-2876-v2.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Final confirmation roborev pass (job 4638, `codex` / `gpt-5.6-sol`): **clean** — no
blockers, 4 Severity-Low findings only (3 doc/comment-wording + 2 suggestions for
additional test coverage), batched to a follow-up rather than re-verified. One of
them (a claimed test-vacuity via the full-ring fallback) was verified and
**refuted**: the fallback reads through `BlockSource` (`read_next_block` →
`block_io::read_next_block`), which is neither spied plane, so a fallback scores
`scan_reads == 0` and fails the test's `scan_reads > 0` assertion.

Not-required CI lanes `PR smoke (fuzz_*)` are RED — pre-existing on `main` since
`44e49a59c`, tracked as #2852; this diff touches no `fuzz/` file.

## Test plan
- [x] `summary_guided_compressed_scan_walk_avoids_point_source` (new, RED→GREEN verified)
- [x] `issue_1143_mmap_prefetch_tail_guard` stays green
- [x] `issue_2412_wraparound_scan`, `issue_1293_compressed_big_reverse_seek` (adjacent paths) still pass
- [x] Full `scripts/agent-gate.sh` PASS (29/29 components)

