### PR TITLE
fix(#2662): revive the nightly gate.yml deep-check — 180m timeout + parallel clippy-full job + red/cancelled alerting

### DIFF
--- a/.github/workflows/gate-failure-issue.yml
+++ b/.github/workflows/gate-failure-issue.yml
@@ -46,8 +46,13 @@ permissions:
   actions: read
 
 concurrency:
-  # Serialize so two near-simultaneous completions cannot race the create/comment.
-  group: gate-failure-issue-${{ github.event.workflow_run.id || github.run_id }}
+  # CONSTANT group (not keyed on the per-run id) so ALL invocations of this
+  # automation serialize into one queue. Two near-simultaneous gate completions
+  # (e.g. the nightly schedule overlapping a dispatch) must NOT both `gh issue
+  # list` -> find none -> `gh issue create` a duplicate tracking issue; a
+  # constant group makes the second wait for the first. cancel-in-progress: false
+  # so the queued run still executes (it may be the one that flips red -> resolve).
+  group: gate-failure-issue
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/gate-failure-issue.yml
+++ b/.github/workflows/gate-failure-issue.yml
@@ -94,6 +94,15 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Checkout so the validate step can call the extracted routing decision
+      # (scripts/ci/gate-failure-mode.sh). Keep the token out of .git/config —
+      # this lane runs no authenticated git.
+      - name: Checkout (for the routing decision script)
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
       - name: Validate origin + determine mode (allowlist, fail-closed)
         id: validate
         if: steps.guard.outputs.skip != 'true'
@@ -108,80 +117,51 @@ jobs:
               echo "conclusion=$4"
             } >> "$GITHUB_OUTPUT"
           }
-          # Map a terminal conclusion to an action: red -> file, green -> resolve.
-          mode_for_conclusion() {
-            case "$1" in
-              failure|cancelled|timed_out) echo "file" ;;
-              success) echo "resolve" ;;
-              *) echo "none" ;;
-            esac
-          }
+          DECIDE="scripts/ci/gate-failure-mode.sh"
 
           if [ "${TRIGGER}" = "workflow_dispatch" ]; then
-            # Manual replay/test: the caller supplies an arbitrary run_id. Validate
-            # it independently the SAME way the auto path validates — a replay must
-            # target a REAL gate.yml run on schedule/main. Fail-closed.
-            if [ -z "${DISPATCH_RUN_ID:-}" ]; then
-              echo "::warning::workflow_dispatch replay requires a 'run_id' input — none given; no issue filed."
-              emit false none "" ""; exit 0
-            fi
-            if ! printf '%s' "${DISPATCH_RUN_ID}" | grep -Eq '^[0-9]+$'; then
-              echo "::warning::run_id '${DISPATCH_RUN_ID}' is not numeric — no issue filed."
-              emit false none "" ""; exit 0
-            fi
+            # Manual replay/test: the caller supplies an arbitrary run_id. The
+            # numeric check + allowlist live in the decision script; here we fetch
+            # the TARGET run's authoritative metadata (the one network step) so the
+            # decision is a pure function of already-resolved fields. Fetch is
+            # best-effort — a fetch failure yields empty fields -> decision `none`.
             # DISPATCH_RUN_ID is passed via a quoted env var, never inlined.
-            META="$(gh run view "${DISPATCH_RUN_ID}" \
-              --json workflowName,headBranch,event,conclusion,url 2>/dev/null)" || META=""
-            if [ -z "${META}" ]; then
-              echo "::warning::could not fetch metadata for run ${DISPATCH_RUN_ID} — no issue filed."
-              emit false none "" ""; exit 0
+            R_NAME=""; R_BRANCH=""; R_EVENT=""; R_CONCLUSION=""; R_URL=""
+            if printf '%s' "${DISPATCH_RUN_ID:-}" | grep -Eq '^[0-9]+$'; then
+              META="$(gh run view "${DISPATCH_RUN_ID}" \
+                --json workflowName,headBranch,event,conclusion,url 2>/dev/null)" || META=""
+              if [ -n "${META}" ]; then
+                R_NAME="$(printf '%s' "${META}" | jq -r '.workflowName // ""')"
+                R_BRANCH="$(printf '%s' "${META}" | jq -r '.headBranch // ""')"
+                R_EVENT="$(printf '%s' "${META}" | jq -r '.event // ""')"
+                R_CONCLUSION="$(printf '%s' "${META}" | jq -r '.conclusion // ""')"
+                R_URL="$(printf '%s' "${META}" | jq -r '.url // ""')"
+              else
+                echo "::warning::could not fetch metadata for run ${DISPATCH_RUN_ID:-<none>} — decision will be 'none'."
+              fi
             fi
-            R_NAME="$(printf '%s' "${META}" | jq -r '.workflowName // ""')"
-            R_BRANCH="$(printf '%s' "${META}" | jq -r '.headBranch // ""')"
-            R_EVENT="$(printf '%s' "${META}" | jq -r '.event // ""')"
-            R_CONCLUSION="$(printf '%s' "${META}" | jq -r '.conclusion // ""')"
-            R_URL="$(printf '%s' "${META}" | jq -r '.url // ""')"
-            if [ "${R_NAME}" != "${GATE_WORKFLOW_NAME}" ]; then
-              echo "::warning::replay target run ${DISPATCH_RUN_ID} workflow '${R_NAME:-<none>}' is not the gate lane — no issue filed."
-              emit false none "" ""; exit 0
-            fi
-            if [ "${R_EVENT}" = "pull_request" ]; then
-              echo "::warning::replay target run ${DISPATCH_RUN_ID} is a pull_request-origin run — no issue filed."
-              emit false none "" ""; exit 0
-            fi
-            # gate.yml runs only on schedule (main) or workflow_dispatch; require main.
-            if [ "${R_BRANCH}" != "main" ]; then
-              echo "::notice::replay target run ${DISPATCH_RUN_ID} head branch '${R_BRANCH:-<none>}' is not main — no issue filed."
-              emit false none "" ""; exit 0
-            fi
-            MODE="$(mode_for_conclusion "${R_CONCLUSION}")"
+            MODE="$(bash "${DECIDE}" \
+              --trigger workflow_dispatch --gate-name "${GATE_WORKFLOW_NAME}" \
+              --name "${R_NAME}" --event "${R_EVENT}" --branch "${R_BRANCH}" \
+              --conclusion "${R_CONCLUSION}" --run-id "${DISPATCH_RUN_ID:-}")"
             if [ "${MODE}" = "none" ]; then
-              echo "::notice::replay target run ${DISPATCH_RUN_ID} concluded '${R_CONCLUSION:-<none>}' — nothing to do."
+              echo "::notice::replay of run ${DISPATCH_RUN_ID:-<none>} -> no action (see decision reason above)."
               emit false none "" ""; exit 0
             fi
             echo "manual replay validated (conclusion '${R_CONCLUSION}', mode '${MODE}') — proceeding"
             emit true "${MODE}" "${R_URL}" "${R_CONCLUSION}"; exit 0
           fi
 
-          # Automatic workflow_run path. Origin event must be schedule, or a
-          # workflow_dispatch of the gate on main (a feature-branch dispatch of
-          # the gate — e.g. a maintainer testing — must NOT file the backstop
-          # issue). WR_HEAD_BRANCH is untrusted -> compared via a quoted env var.
-          case "${WR_EVENT}" in
-            schedule)
-              : ;;
-            workflow_dispatch)
-              if [ "${WR_HEAD_BRANCH:-}" != "main" ]; then
-                echo "::notice::gate dispatch on non-main branch '${WR_HEAD_BRANCH:-<none>}' — no issue filed."
-                emit false none "" ""; exit 0
-              fi ;;
-            *)
-              echo "::notice::origin event '${WR_EVENT}' is not schedule/workflow_dispatch — no issue filed."
-              emit false none "" ""; exit 0 ;;
-          esac
-          MODE="$(mode_for_conclusion "${WR_CONCLUSION}")"
+          # Automatic workflow_run path. All fields come from the untrusted
+          # workflow_run payload via quoted env vars; the decision script applies
+          # the allowlist (schedule, or workflow_dispatch of the gate on main) and
+          # the conclusion->mode mapping.
+          MODE="$(bash "${DECIDE}" \
+            --trigger workflow_run --gate-name "${GATE_WORKFLOW_NAME}" \
+            --name "${WR_NAME}" --event "${WR_EVENT}" --branch "${WR_HEAD_BRANCH}" \
+            --conclusion "${WR_CONCLUSION}")"
           if [ "${MODE}" = "none" ]; then
-            echo "::notice::gate run concluded '${WR_CONCLUSION}' — nothing to do."
+            echo "::notice::gate run '${WR_CONCLUSION}' on '${WR_EVENT}' -> no action (see decision reason above)."
             emit false none "" ""; exit 0
           fi
           echo "gate run concluded '${WR_CONCLUSION}' (mode '${MODE}') — proceeding"
@@ -218,8 +198,12 @@ jobs:
           } > gate-failure-body.md
 
           # Dedup by the label: update the one open tracking issue if present.
+          # `|| true` so a transient gh/API blip on the lookup does NOT abort the
+          # step (set -e) and silently drop the night's alert — an empty EXISTING
+          # falls through to a create attempt (itself || warn-guarded). At worst a
+          # blip creates a second issue (recoverable); dropping the alert is not.
           EXISTING="$(gh issue list --repo "${GH_REPO}" --label "${ISSUE_LABEL}" \
-            --state open --json number --jq '.[0].number // ""')"
+            --state open --json number --jq '.[0].number // ""' 2>/dev/null || true)"
           if [ -n "${EXISTING}" ]; then
             echo "Updating existing gate-failure issue #${EXISTING}"
             gh issue comment "${EXISTING}" --repo "${GH_REPO}" --body-file gate-failure-body.md \
@@ -242,8 +226,12 @@ jobs:
           RUN_URL: ${{ steps.validate.outputs.run_url }}
         run: |
           set -euo pipefail
+          # `|| true`: a transient gh/API blip on the lookup must not abort the
+          # step (set -e). An empty result is treated as "no open issue" (the
+          # resolve comment is best-effort; a missed comment is harmless — the
+          # RED-path filing is the load-bearing side).
           EXISTING="$(gh issue list --repo "${GH_REPO}" --label "${ISSUE_LABEL}" \
-            --state open --json number --jq '.[0].number // ""')"
+            --state open --json number --jq '.[0].number // ""' 2>/dev/null || true)"
           if [ -z "${EXISTING}" ]; then
             echo "::notice::no open gate-failure issue to resolve — green run, nothing to do."
             exit 0

--- a/.github/workflows/gate-failure-issue.yml
+++ b/.github/workflows/gate-failure-issue.yml
@@ -61,6 +61,8 @@ concurrency:
 jobs:
   file-gate-failure-issue:
     runs-on: ubuntu-latest
+    # gh CLI calls only (issue lookup/file/resolve); 10m is ample headroom.
+    timeout-minutes: 10
     # Coarse pre-filter over TRUSTED GitHub-computed fields (event name /
     # conclusion). The validate step below re-checks fail-closed (branch/event
     # allowlist) before any issue write. A manual workflow_dispatch always enters

--- a/.github/workflows/gate-failure-issue.yml
+++ b/.github/workflows/gate-failure-issue.yml
@@ -1,0 +1,251 @@
+name: Gate Nightly Failure Issue Automation
+
+# Signal routing only (issue #2662). The nightly full-gate backstop
+# (`.github/workflows/gate.yml`, "Nightly agent-gate (deep check)") went dead all
+# of July 2026 — 12 consecutive `cancelled` runs at the old 75m timeout — and
+# NOBODY WAS PAGED, because a `cancelled` (or `timed_out`) conclusion surfaces
+# only on the Actions dashboard. This workflow closes that silent-death gap: when
+# the gate lane completes with a RED conclusion (`failure`, `cancelled`, or
+# `timed_out`) on a SCHEDULED or MAIN-BRANCH run, it files/updates ONE
+# deduplicated `gate-nightly-failure` tracking issue so a dead backstop can never
+# again go unnoticed for weeks. On a green (`success`) run it posts a "resolved"
+# comment on that open issue (never auto-closes — a human confirms + closes).
+#
+# Modelled on the sibling `parity-failure-issue.yml` safety patterns. It is
+# deliberately SELF-CONTAINED (plain `gh` CLI, no external fingerprint script):
+# the gate emits a single run-level verdict, not per-scenario parity failures, so
+# one pinned tracking issue is the right granularity — no fingerprinting needed.
+#
+# NON-GATING + fail-open: this job never changes the gate lane's result. Absent an
+# issue-write token it is a `::notice::` no-op (exit 0). It never auto-closes.
+#
+# SECURITY: this workflow consumes an UNTRUSTED `workflow_run` payload. It NEVER
+# interpolates event fields into a `run:` shell — every event value is passed via
+# a quoted `env:` var (the `run:` bodies reference only `$SHELL_VARS`), and the
+# origin run is allowlist-validated fail-closed before any issue write. In
+# particular `github.event.workflow_run.head_branch` is passed via env only (it is
+# in the injection lint's attacker-controlled set).
+
+on:
+  workflow_run:
+    workflows:
+      - "Nightly agent-gate (deep check)"
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "gate.yml workflow_run id to (re)process (manual replay/test)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+  # `gh run view` reads ANOTHER workflow run's metadata (the manual-replay path);
+  # that requires actions:read. Minimal + complete for this job.
+  actions: read
+
+concurrency:
+  # Serialize so two near-simultaneous completions cannot race the create/comment.
+  group: gate-failure-issue-${{ github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  file-gate-failure-issue:
+    runs-on: ubuntu-latest
+    # Coarse pre-filter over TRUSTED GitHub-computed fields (event name /
+    # conclusion). The validate step below re-checks fail-closed (branch/event
+    # allowlist) before any issue write. A manual workflow_dispatch always enters
+    # (replay path). React to any terminal conclusion; the validate step maps it
+    # to file (red) / resolve (green) / no-op.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event != 'pull_request' &&
+       (github.event.workflow_run.conclusion == 'failure' ||
+        github.event.workflow_run.conclusion == 'cancelled' ||
+        github.event.workflow_run.conclusion == 'timed_out' ||
+        github.event.workflow_run.conclusion == 'success'))
+    env:
+      # Pass untrusted payload fields as env vars, NEVER inline into a run: shell.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      SERVER_URL: ${{ github.server_url }}
+      WR_EVENT: ${{ github.event.workflow_run.event }}
+      WR_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      WR_NAME: ${{ github.event.workflow_run.name }}
+      WR_URL: ${{ github.event.workflow_run.html_url }}
+      WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      DISPATCH_RUN_ID: ${{ github.event.inputs.run_id }}
+      TRIGGER: ${{ github.event_name }}
+      GATE_WORKFLOW_NAME: "Nightly agent-gate (deep check)"
+      ISSUE_LABEL: "gate-nightly-failure"
+    steps:
+      - name: Guard token (fail-open, non-gating)
+        id: guard
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::GITHUB_TOKEN absent — skipping gate-failure issue automation (non-gating no-op)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate origin + determine mode (allowlist, fail-closed)
+        id: validate
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          # Outputs: proceed (true/false), mode (file|resolve|none), run_url, conclusion.
+          emit() {
+            {
+              echo "proceed=$1"
+              echo "mode=$2"
+              echo "run_url=$3"
+              echo "conclusion=$4"
+            } >> "$GITHUB_OUTPUT"
+          }
+          # Map a terminal conclusion to an action: red -> file, green -> resolve.
+          mode_for_conclusion() {
+            case "$1" in
+              failure|cancelled|timed_out) echo "file" ;;
+              success) echo "resolve" ;;
+              *) echo "none" ;;
+            esac
+          }
+
+          if [ "${TRIGGER}" = "workflow_dispatch" ]; then
+            # Manual replay/test: the caller supplies an arbitrary run_id. Validate
+            # it independently the SAME way the auto path validates — a replay must
+            # target a REAL gate.yml run on schedule/main. Fail-closed.
+            if [ -z "${DISPATCH_RUN_ID:-}" ]; then
+              echo "::warning::workflow_dispatch replay requires a 'run_id' input — none given; no issue filed."
+              emit false none "" ""; exit 0
+            fi
+            if ! printf '%s' "${DISPATCH_RUN_ID}" | grep -Eq '^[0-9]+$'; then
+              echo "::warning::run_id '${DISPATCH_RUN_ID}' is not numeric — no issue filed."
+              emit false none "" ""; exit 0
+            fi
+            # DISPATCH_RUN_ID is passed via a quoted env var, never inlined.
+            META="$(gh run view "${DISPATCH_RUN_ID}" \
+              --json workflowName,headBranch,event,conclusion,url 2>/dev/null)" || META=""
+            if [ -z "${META}" ]; then
+              echo "::warning::could not fetch metadata for run ${DISPATCH_RUN_ID} — no issue filed."
+              emit false none "" ""; exit 0
+            fi
+            R_NAME="$(printf '%s' "${META}" | jq -r '.workflowName // ""')"
+            R_BRANCH="$(printf '%s' "${META}" | jq -r '.headBranch // ""')"
+            R_EVENT="$(printf '%s' "${META}" | jq -r '.event // ""')"
+            R_CONCLUSION="$(printf '%s' "${META}" | jq -r '.conclusion // ""')"
+            R_URL="$(printf '%s' "${META}" | jq -r '.url // ""')"
+            if [ "${R_NAME}" != "${GATE_WORKFLOW_NAME}" ]; then
+              echo "::warning::replay target run ${DISPATCH_RUN_ID} workflow '${R_NAME:-<none>}' is not the gate lane — no issue filed."
+              emit false none "" ""; exit 0
+            fi
+            if [ "${R_EVENT}" = "pull_request" ]; then
+              echo "::warning::replay target run ${DISPATCH_RUN_ID} is a pull_request-origin run — no issue filed."
+              emit false none "" ""; exit 0
+            fi
+            # gate.yml runs only on schedule (main) or workflow_dispatch; require main.
+            if [ "${R_BRANCH}" != "main" ]; then
+              echo "::notice::replay target run ${DISPATCH_RUN_ID} head branch '${R_BRANCH:-<none>}' is not main — no issue filed."
+              emit false none "" ""; exit 0
+            fi
+            MODE="$(mode_for_conclusion "${R_CONCLUSION}")"
+            if [ "${MODE}" = "none" ]; then
+              echo "::notice::replay target run ${DISPATCH_RUN_ID} concluded '${R_CONCLUSION:-<none>}' — nothing to do."
+              emit false none "" ""; exit 0
+            fi
+            echo "manual replay validated (conclusion '${R_CONCLUSION}', mode '${MODE}') — proceeding"
+            emit true "${MODE}" "${R_URL}" "${R_CONCLUSION}"; exit 0
+          fi
+
+          # Automatic workflow_run path. Origin event must be schedule, or a
+          # workflow_dispatch of the gate on main (a feature-branch dispatch of
+          # the gate — e.g. a maintainer testing — must NOT file the backstop
+          # issue). WR_HEAD_BRANCH is untrusted -> compared via a quoted env var.
+          case "${WR_EVENT}" in
+            schedule)
+              : ;;
+            workflow_dispatch)
+              if [ "${WR_HEAD_BRANCH:-}" != "main" ]; then
+                echo "::notice::gate dispatch on non-main branch '${WR_HEAD_BRANCH:-<none>}' — no issue filed."
+                emit false none "" ""; exit 0
+              fi ;;
+            *)
+              echo "::notice::origin event '${WR_EVENT}' is not schedule/workflow_dispatch — no issue filed."
+              emit false none "" ""; exit 0 ;;
+          esac
+          MODE="$(mode_for_conclusion "${WR_CONCLUSION}")"
+          if [ "${MODE}" = "none" ]; then
+            echo "::notice::gate run concluded '${WR_CONCLUSION}' — nothing to do."
+            emit false none "" ""; exit 0
+          fi
+          echo "gate run concluded '${WR_CONCLUSION}' (mode '${MODE}') — proceeding"
+          emit true "${MODE}" "${WR_URL}" "${WR_CONCLUSION}"
+
+      - name: File / update the gate-failure tracking issue (RED)
+        if: >-
+          steps.guard.outputs.skip != 'true' &&
+          steps.validate.outputs.proceed == 'true' &&
+          steps.validate.outputs.mode == 'file'
+        env:
+          RUN_URL: ${{ steps.validate.outputs.run_url }}
+          CONCLUSION: ${{ steps.validate.outputs.conclusion }}
+        run: |
+          set -euo pipefail
+          # Ensure the dedup label exists (idempotent; needs issues:write, which we
+          # hold). GH_REPO gives every gh call explicit repo context.
+          gh label create "${ISSUE_LABEL}" \
+            --repo "${GH_REPO}" \
+            --color B60205 \
+            --description "Nightly gate.yml deep-check backstop is failing (issue #2662)" \
+            2>/dev/null || true
+
+          # Assemble the body from shell vars ONLY (no GitHub-expression
+          # interpolation; no command substitution on data). printf treats each
+          # value as literal text.
+          {
+            printf '%s\n\n' "The nightly full-gate backstop (\`.github/workflows/gate.yml\`, \"${GATE_WORKFLOW_NAME}\") concluded **${CONCLUSION}** on its latest run."
+            printf '%s\n' "- Run: ${RUN_URL:-<run url unavailable>}"
+            printf '%s\n' "- Origin event: ${WR_EVENT:-<n/a>}"
+            printf '%s\n\n' "- Branch: ${WR_HEAD_BRANCH:-<n/a>}"
+            printf '%s\n' "A \`cancelled\`/\`timed_out\` conclusion means the deep-check did NOT certify \`main\` this night (issue #2662 — the silent-death mode that hid a dead backstop for all of July). A \`failure\` conclusion means a real gate-component FAIL: open the run above and inspect the uploaded \`agent-gate-summary\` artifact for the failing component."
+            printf '\n%s\n' "This issue is auto-updated on each subsequent red night and gets a resolved comment on the next green night; a human confirms + closes it."
+          } > gate-failure-body.md
+
+          # Dedup by the label: update the one open tracking issue if present.
+          EXISTING="$(gh issue list --repo "${GH_REPO}" --label "${ISSUE_LABEL}" \
+            --state open --json number --jq '.[0].number // ""')"
+          if [ -n "${EXISTING}" ]; then
+            echo "Updating existing gate-failure issue #${EXISTING}"
+            gh issue comment "${EXISTING}" --repo "${GH_REPO}" --body-file gate-failure-body.md \
+              || echo "::warning::failed to comment on issue #${EXISTING} (non-gating)."
+          else
+            echo "Creating new gate-failure tracking issue"
+            gh issue create --repo "${GH_REPO}" \
+              --title "Nightly gate.yml deep-check RED — backstop not certifying main" \
+              --label "${ISSUE_LABEL}" \
+              --body-file gate-failure-body.md \
+              || echo "::warning::failed to create gate-failure issue (non-gating)."
+          fi
+
+      - name: Resolve tracking issue on a green run (comment only, never close)
+        if: >-
+          steps.guard.outputs.skip != 'true' &&
+          steps.validate.outputs.proceed == 'true' &&
+          steps.validate.outputs.mode == 'resolve'
+        env:
+          RUN_URL: ${{ steps.validate.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          EXISTING="$(gh issue list --repo "${GH_REPO}" --label "${ISSUE_LABEL}" \
+            --state open --json number --jq '.[0].number // ""')"
+          if [ -z "${EXISTING}" ]; then
+            echo "::notice::no open gate-failure issue to resolve — green run, nothing to do."
+            exit 0
+          fi
+          {
+            printf '%s\n' "Nightly gate deep-check is GREEN again on run ${RUN_URL:-<run url unavailable>} (conclusion: success)."
+            printf '%s\n' "The backstop certified \`main\`. A human can close this issue after confirming the run."
+          } > gate-resolve-body.md
+          gh issue comment "${EXISTING}" --repo "${GH_REPO}" --body-file gate-resolve-body.md \
+            || echo "::warning::failed to comment resolve on issue #${EXISTING} (non-gating)."

--- a/.github/workflows/gate-failure-issue.yml
+++ b/.github/workflows/gate-failure-issue.yml
@@ -16,8 +16,11 @@ name: Gate Nightly Failure Issue Automation
 # the gate emits a single run-level verdict, not per-scenario parity failures, so
 # one pinned tracking issue is the right granularity — no fingerprinting needed.
 #
-# NON-GATING + fail-open: this job never changes the gate lane's result. Absent an
-# issue-write token it is a `::notice::` no-op (exit 0). It never auto-closes.
+# NON-GATING: this job never changes the gate lane's result — the `gh` writes are
+# each `|| warn`-guarded, and the routing decision + issue lookups fail toward a
+# no-op / retry rather than reddening the run. It never auto-closes. (The hosted
+# `GITHUB_TOKEN` is always present, so there is deliberately no token off-switch —
+# a dead-code guard that only reads `secrets.GITHUB_TOKEN` would be a false one.)
 #
 # SECURITY: this workflow consumes an UNTRUSTED `workflow_run` payload. It NEVER
 # interpolates event fields into a `run:` shell — every event value is passed via
@@ -85,27 +88,16 @@ jobs:
       GATE_WORKFLOW_NAME: "Nightly agent-gate (deep check)"
       ISSUE_LABEL: "gate-nightly-failure"
     steps:
-      - name: Guard token (fail-open, non-gating)
-        id: guard
-        run: |
-          set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::notice::GITHUB_TOKEN absent — skipping gate-failure issue automation (non-gating no-op)."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          fi
-
       # Checkout so the validate step can call the extracted routing decision
       # (scripts/ci/gate-failure-mode.sh). Keep the token out of .git/config —
       # this lane runs no authenticated git.
       - name: Checkout (for the routing decision script)
-        if: steps.guard.outputs.skip != 'true'
         uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Validate origin + determine mode (allowlist, fail-closed)
         id: validate
-        if: steps.guard.outputs.skip != 'true'
         run: |
           set -euo pipefail
           # Outputs: proceed (true/false), mode (file|resolve|none), run_url, conclusion.
@@ -144,7 +136,9 @@ jobs:
               --trigger workflow_dispatch --gate-name "${GATE_WORKFLOW_NAME}" \
               --name "${R_NAME}" --event "${R_EVENT}" --branch "${R_BRANCH}" \
               --conclusion "${R_CONCLUSION}" --run-id "${DISPATCH_RUN_ID:-}")"
-            if [ "${MODE}" = "none" ]; then
+            # Defensive: an empty/unexpected token is treated as `none` (no action).
+            MODE="${MODE:-none}"
+            if [ "${MODE}" != "file" ] && [ "${MODE}" != "resolve" ]; then
               echo "::notice::replay of run ${DISPATCH_RUN_ID:-<none>} -> no action (see decision reason above)."
               emit false none "" ""; exit 0
             fi
@@ -160,7 +154,9 @@ jobs:
             --trigger workflow_run --gate-name "${GATE_WORKFLOW_NAME}" \
             --name "${WR_NAME}" --event "${WR_EVENT}" --branch "${WR_HEAD_BRANCH}" \
             --conclusion "${WR_CONCLUSION}")"
-          if [ "${MODE}" = "none" ]; then
+          # Defensive: an empty/unexpected token is treated as `none` (no action).
+          MODE="${MODE:-none}"
+          if [ "${MODE}" != "file" ] && [ "${MODE}" != "resolve" ]; then
             echo "::notice::gate run '${WR_CONCLUSION}' on '${WR_EVENT}' -> no action (see decision reason above)."
             emit false none "" ""; exit 0
           fi
@@ -169,7 +165,6 @@ jobs:
 
       - name: File / update the gate-failure tracking issue (RED)
         if: >-
-          steps.guard.outputs.skip != 'true' &&
           steps.validate.outputs.proceed == 'true' &&
           steps.validate.outputs.mode == 'file'
         env:
@@ -186,24 +181,32 @@ jobs:
             2>/dev/null || true
 
           # Assemble the body from shell vars ONLY (no GitHub-expression
-          # interpolation; no command substitution on data). printf treats each
-          # value as literal text.
+          # interpolation; no command substitution on data). Every interpolated
+          # value is a `%s` ARGUMENT (never part of the format string), so a `%` in
+          # a value is printed literally rather than eaten as a conversion spec.
+          # Bullet lines pass the `- label: ` prefix as a `%s` arg too, so no
+          # format string begins with `-` (which printf could parse as an option).
           {
-            printf '%s\n\n' "The nightly full-gate backstop (\`.github/workflows/gate.yml\`, \"${GATE_WORKFLOW_NAME}\") concluded **${CONCLUSION}** on its latest run."
-            printf '%s\n' "- Run: ${RUN_URL:-<run url unavailable>}"
-            printf '%s\n' "- Origin event: ${WR_EVENT:-<n/a>}"
-            printf '%s\n\n' "- Branch: ${WR_HEAD_BRANCH:-<n/a>}"
+            printf "The nightly full-gate backstop (\`.github/workflows/gate.yml\`, \"%s\") concluded **%s** on its latest run.\n\n" \
+              "${GATE_WORKFLOW_NAME}" "${CONCLUSION}"
+            printf '%s%s\n' '- Run: ' "${RUN_URL:-<run url unavailable>}"
+            printf '%s%s\n' '- Origin event: ' "${WR_EVENT:-<n/a>}"
+            printf '%s%s\n\n' '- Branch: ' "${WR_HEAD_BRANCH:-<n/a>}"
             printf '%s\n' "A \`cancelled\`/\`timed_out\` conclusion means the deep-check did NOT certify \`main\` this night (issue #2662 — the silent-death mode that hid a dead backstop for all of July). A \`failure\` conclusion means a real gate-component FAIL: open the run above and inspect the uploaded \`agent-gate-summary\` artifact for the failing component."
             printf '\n%s\n' "This issue is auto-updated on each subsequent red night and gets a resolved comment on the next green night; a human confirms + closes it."
           } > gate-failure-body.md
 
-          # Dedup by the label: update the one open tracking issue if present.
-          # `|| true` so a transient gh/API blip on the lookup does NOT abort the
-          # step (set -e) and silently drop the night's alert — an empty EXISTING
-          # falls through to a create attempt (itself || warn-guarded). At worst a
-          # blip creates a second issue (recoverable); dropping the alert is not.
+          # Dedup by the label: update the CANONICAL open tracking issue if present.
+          # Canonical = the OLDEST (lowest issue number) so a rare create-race that
+          # produced two issues still converges on ONE going forward (`min`, not
+          # `.[0]` which depends on gh's default newest-first ordering). `|| true`
+          # so a transient gh/API blip on the lookup does NOT abort the step
+          # (set -e) and silently drop the night's alert — an empty EXISTING falls
+          # through to a create attempt (itself || warn-guarded). At worst a blip
+          # creates a second issue (recoverable); dropping the alert is not.
           EXISTING="$(gh issue list --repo "${GH_REPO}" --label "${ISSUE_LABEL}" \
-            --state open --json number --jq '.[0].number // ""' 2>/dev/null || true)"
+            --state open --limit 100 --json number --jq 'map(.number) | min // ""' \
+            2>/dev/null || true)"
           if [ -n "${EXISTING}" ]; then
             echo "Updating existing gate-failure issue #${EXISTING}"
             gh issue comment "${EXISTING}" --repo "${GH_REPO}" --body-file gate-failure-body.md \
@@ -219,7 +222,6 @@ jobs:
 
       - name: Resolve tracking issue on a green run (comment only, never close)
         if: >-
-          steps.guard.outputs.skip != 'true' &&
           steps.validate.outputs.proceed == 'true' &&
           steps.validate.outputs.mode == 'resolve'
         env:
@@ -231,13 +233,17 @@ jobs:
           # resolve comment is best-effort; a missed comment is harmless — the
           # RED-path filing is the load-bearing side).
           EXISTING="$(gh issue list --repo "${GH_REPO}" --label "${ISSUE_LABEL}" \
-            --state open --json number --jq '.[0].number // ""' 2>/dev/null || true)"
+            --state open --limit 100 --json number --jq 'map(.number) | min // ""' \
+            2>/dev/null || true)"
           if [ -z "${EXISTING}" ]; then
             echo "::notice::no open gate-failure issue to resolve — green run, nothing to do."
             exit 0
           fi
+          # Interpolated value passed as a `%s` ARGUMENT (never in the format
+          # string), so a `%` in the run URL is treated literally.
           {
-            printf '%s\n' "Nightly gate deep-check is GREEN again on run ${RUN_URL:-<run url unavailable>} (conclusion: success)."
+            printf 'Nightly gate deep-check is GREEN again on run %s (conclusion: success).\n' \
+              "${RUN_URL:-<run url unavailable>}"
             printf '%s\n' "The backstop certified \`main\`. A human can close this issue after confirming the run."
           } > gate-resolve-body.md
           gh issue comment "${EXISTING}" --repo "${GH_REPO}" --body-file gate-resolve-body.md \

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -73,7 +73,10 @@ jobs:
     # night yields a REAL verdict instead of a cancel. REVISIT this number with
     # the measured end-to-end runtime from the #2662 verification dispatch
     # (acceptance #4) — tighten toward measured + margin once one true cold run
-    # completes.
+    # completes. Also confirm the July cancels were timeout-not-hang (a slow run,
+    # not a hung/stuck component) from that dispatch's per-component timings
+    # before trusting the raise; a genuinely hung component would need a
+    # per-component watchdog rather than a bigger job budget.
     timeout-minutes: 180
 
     # Cap peak compile memory pressure (issue #1269). The full gate compiles the

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -50,14 +50,31 @@ jobs:
   gate:
     name: Full agent gate
     runs-on: ubuntu-latest
-    # A full gate run (napi + maturin builds, full workspace test set, smoke
-    # over the corpus) is comparable in weight to node-ci/python-ci. On a
-    # COLD cache (first run, or after GH's 7-day cache eviction / branch
-    # scoping) the workspace compiles from scratch before any tests run; an
-    # observed cold run reached ~11/17 components in 45m before timing out.
-    # Warm runs (Swatinem cache restored) are far faster, but a nightly backstop
-    # must not depend on a warm cache, so budget for the cold case.
-    timeout-minutes: 75
+    # Timeout budget (issue #2662). MEASURED EVIDENCE: from Jul 6 -> Jul 17 this
+    # lane was CANCELLED 12 nights in a row — every run hit the old 75m
+    # `timeout-minutes` and was killed ~76m in. A `cancelled` conclusion pages
+    # nobody, so the backstop was silently dead all month (the alert wiring in
+    # `gate-failure-issue.yml`, added alongside this change, closes that gap).
+    #
+    # A full gate run (napi + maturin builds, full workspace test set, smoke over
+    # the corpus) is comparable in weight to node-ci/python-ci. On a COLD cache
+    # (first run, or after GH's 7-day cache eviction / branch scoping) the whole
+    # workspace + both binding modules compile from scratch before any tests run;
+    # an observed cold run reached only ~11/17 components in 45m before timing
+    # out. Warm runs (Swatinem cache restored) are far faster, but a nightly
+    # backstop must not depend on a warm cache, so budget for the cold case.
+    #
+    # Two changes buy the headroom: (1) the heaviest nightly-only add — the
+    # `CQLITE_CLIPPY_FULL=1` full-matrix clippy that compiles the source-built
+    # DuckDB C++ amalgamation + the OpenTelemetry/OTLP stack — is split into the
+    # parallel `clippy-full` job in this workflow, off this job's critical path;
+    # (2) this timeout is raised 75 -> 180m. 180m is a deliberate over-provision
+    # (~4x the 45m/11-components cold observation) so a slow-but-healthy cold
+    # night yields a REAL verdict instead of a cancel. REVISIT this number with
+    # the measured end-to-end runtime from the #2662 verification dispatch
+    # (acceptance #4) — tighten toward measured + margin once one true cold run
+    # completes.
+    timeout-minutes: 180
 
     # Cap peak compile memory pressure (issue #1269). The full gate compiles the
     # workspace + both binding modules and runs the full test set; the runner
@@ -218,14 +235,16 @@ jobs:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
           CQLITE_REQUIRE_FIXTURES: '1'
           AGENT_GATE_SUMMARY_FILE: ${{ github.workspace }}/agent-gate-summary.txt
-          # Full-matrix clippy backstop (issue #1844). The routine local gate runs a
-          # SCOPED per-package clippy that skips the source-built DuckDB C++
-          # amalgamation (cqlite-cli `duckdb-tests`) and the OpenTelemetry/OTLP stack
-          # (`observability`/`observability-testing`) — pure per-gate tax locally. This
-          # nightly deep-check restores the historical
-          # `cargo clippy --workspace --all-targets --all-features -D warnings` pass so
-          # any lint behind those excluded features is still caught within 24h.
-          CQLITE_CLIPPY_FULL: '1'
+          # NOTE (issue #2662): CQLITE_CLIPPY_FULL is deliberately NOT set here.
+          # The full-matrix clippy backstop (issue #1844) — which compiles the
+          # source-built DuckDB C++ amalgamation (cqlite-cli `duckdb-tests`) + the
+          # OpenTelemetry/OTLP stack (`observability`/`observability-testing`) that
+          # the routine SCOPED per-package clippy skips — now runs in its own
+          # parallel `clippy-full` job in this workflow, to keep that heavy compile
+          # off this job's timeout budget. This step still runs the FULL gate
+          # (never `--only`, so the run "counts" as the gate — the run is stamped
+          # PASS/FAIL, never PARTIAL) with the gate's own SCOPED clippy component;
+          # the two jobs together restore the historical nightly clippy coverage.
         run: bash scripts/agent-gate.sh
 
       # Legibility (issue #1269) — resource state after the gate, on success or
@@ -251,3 +270,93 @@ jobs:
           path: agent-gate-summary.txt
           if-no-files-found: warn
           retention-days: 14
+
+  # Full-matrix clippy backstop (issue #1844), split off the main gate job's
+  # critical path (issue #2662). The routine local gate runs a SCOPED per-package
+  # clippy that skips the source-built DuckDB C++ amalgamation (cqlite-cli
+  # `duckdb-tests`) and the OpenTelemetry/OTLP stack (`observability`/
+  # `observability-testing`) — pure per-gate tax locally. Compiling those under
+  # `--all-features` is the single heaviest nightly-only add, so it ran as
+  # CQLITE_CLIPPY_FULL=1 INSIDE the gate job and consumed a large slice of the 75m
+  # that the gate then blew past. Running it as its own PARALLEL job restores the
+  # historical `cargo clippy --workspace --all-targets --all-features -D warnings`
+  # coverage within 24h while keeping it off the gate job's timeout budget. This
+  # is the EXACT command the gate script runs when CQLITE_CLIPPY_FULL=1
+  # (scripts/agent-gate.sh `run_clippy`). A FAIL here reds the workflow run just
+  # as a gate-component FAIL does, so the alert wiring in gate-failure-issue.yml
+  # surfaces it.
+  clippy-full:
+    name: Full-matrix clippy (--all-features)
+    runs-on: ubuntu-latest
+    # Clippy of the whole workspace under --all-features compiles the DuckDB C++
+    # amalgamation + the OTel stack from source on a cold cache — heavy, but far
+    # lighter than the full gate (no binding builds, no test set, no datasets,
+    # no smoke corpus). 90m is generous cold headroom; revisit with the measured
+    # runtime from the #2662 verification dispatch (acceptance #4).
+    timeout-minutes: 90
+    # Same peak-memory bounding as the gate job (issue #1269): the --all-features
+    # compile of duckdb-sys + the OTel crates is memory-heavy; cap codegen
+    # parallelism and disable incremental so peak RAM stays under the ceiling.
+    env:
+      CARGO_BUILD_JOBS: '2'
+      CARGO_INCREMENTAL: '0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          # Clippy needs no history (no file-size ratchet here); keep the token
+          # out of .git/config — this lane runs no authenticated git.
+          persist-credentials: false
+
+      # The --all-features compile of the DuckDB amalgamation can sit near the
+      # runner's disk ceiling (issue #722). Reclaim the big unused toolchains with
+      # the same INLINE cleanup the gate job uses (no third-party @main action ref
+      # before a compile step). Leaves the toolcache ROOT in place.
+      - name: Free disk space (issue #722, #2662)
+        run: |
+          df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost || true
+          sudo docker image prune --all --force || true
+          df -h / | tail -1
+
+      # Pinned to rust-toolchain.toml (1.97.1) via the @1.97.1 ref — the #1990
+      # policy method for dtolnay/rust-toolchain, which CANNOT read the pin file
+      # (see docs/development/ci-toolchain-policy.md). Requests clippy explicitly
+      # (this lane's whole purpose), matching the gate job's Setup Rust step.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.97.1
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Distinct cache key from the gate job: the --all-features build graph
+          # (duckdb-sys, OTel) differs from the gate's default-feature graph, so
+          # a shared key would thrash both. cache-on-failure keeps a cold night
+          # from re-compiling everything the next night.
+          key: gate-clippy-full-${{ hashFiles('**/Cargo.lock') }}
+          cache-on-failure: true
+
+      # OOM headroom (issue #1269), mirroring the gate job: provision a swapfile
+      # on /mnt so the peak of the parallel --all-features compile spills to swap
+      # rather than tripping the OOM killer. Inline, guarded against a residual
+      # runner swap.
+      - name: Add swap space
+        run: |
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile || true
+          sudo fallocate -l 13G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          free -h
+
+      # The historical full-matrix clippy pass (issue #1844). This is byte-for-byte
+      # the command scripts/agent-gate.sh runs for its `clippy` component when
+      # CQLITE_CLIPPY_FULL=1, so this job is a faithful stand-in for that env on
+      # the split-out lane. RUSTFLAGS=-D warnings makes any lint a hard failure.
+      - name: Full-matrix clippy
+        run: env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -19,8 +19,9 @@
 #                      so no other component reuses them). parquet/arrow stay linted.
 #                      Set CQLITE_CLIPPY_FULL=1 to run the historical
 #                      `--workspace --all-targets --all-features` matrix instead; the
-#                      nightly gate.yml deep-check sets it so the otel/duckdb-inclusive
-#                      lint still runs within 24h (coverage moved, not deleted).
+#                      nightly gate.yml deep-check runs that full matrix in its own
+#                      parallel `clippy-full` job (issue #2662) so the otel/duckdb-
+#                      inclusive lint still runs within 24h (coverage moved, not deleted).
 #   core-tests         cargo test -p cqlite-core --features cli-helpers (CI skip-list applied)
 #   scan-offload-guard cargo test -p cqlite-core --features cli-helpers,scan-offload-probe
 #                      --test issue_1143_scan_offload_thread (windowed-scan parse
@@ -1907,9 +1908,11 @@ record_result() { # <name> <status> <seconds>
 # Coverage of the excluded features is NOT deleted — it moves to a nightly full
 # matrix: set CQLITE_CLIPPY_FULL=1 to run the historical
 # `--workspace --all-targets --all-features` pass instead. `.github/workflows/gate.yml`
-# (the nightly deep-check) sets it, so the full otel/duckdb-inclusive lint still runs
-# within 24h. The explicit per-package feature lists below can drift as features are
-# added; that nightly `--all-features` pass is the backstop that catches any omission.
+# (the nightly deep-check) runs that full matrix in a dedicated parallel `clippy-full`
+# job (issue #2662) — the `gate` job itself runs the full gate with this SCOPED clippy —
+# so the full otel/duckdb-inclusive lint still runs within 24h. The explicit per-package
+# feature lists below can drift as features are added; that nightly `--all-features` pass
+# is the backstop that catches any omission.
 run_clippy() {
   if [ "${CQLITE_CLIPPY_FULL:-0}" = 1 ]; then
     env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features
@@ -3498,7 +3501,7 @@ run_delta() {
     "delta-anchor: $anchor_sha (full-gate PASS commit)"
     "delta-anchor-run-id: $anchor_run_id"
     "gate-of-record: full agent-gate.sh run at $anchor_sha (this DELTA re-certifies a test/docs-only diff; it is NOT a substitute for the full gate)"
-    "nightly-backstop: .github/workflows/gate.yml deep-check re-runs the FULL gate on main (CQLITE_CLIPPY_FULL=1)"
+    "nightly-backstop: .github/workflows/gate.yml deep-check re-runs the FULL gate on main (gate job = scoped clippy; full --all-features clippy in the parallel clippy-full job, #2662)"
   )
 
   # FAIL-CLOSED: any production file in the diff refuses the delta re-cert. Name the

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2544,7 +2544,11 @@ run_kit_dashboard_drift() {
 # scripts/tests/test_agent_gate_delta.sh (#1892), which drives the hidden
 # --delta-classify hook + --delta entry guards + --delta-...-emit-summary-selftest
 # to assert the test/docs-only fail-closed re-cert policy and DISTINCT delta
-# markers (hermetic — classification/emission only, never runs cargo). SKIP-aware:
+# markers (hermetic — classification/emission only, never runs cargo). Also runs
+# scripts/tests/test_gate_failure_mode.sh (#2662), which pins the decision table
+# of scripts/ci/gate-failure-mode.sh — the routing logic behind the nightly
+# gate-failure alert workflow, which is otherwise untestable (it only fires on a
+# real workflow_run event). Pure/offline, no gh/network. SKIP-aware:
 # the summary test's truncation case relies on a python3 reader, so with no
 # python3 we record SKIP (loud, never silent PASS); any test failure -> hard FAIL.
 run_tooling_tests() {
@@ -2784,7 +2788,7 @@ run_tooling_tests() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh"
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
   if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_notify.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_smoke_target_dir.sh" >>"$log" 2>&1 &&
@@ -2793,7 +2797,8 @@ run_tooling_tests() {
      bash "$REPO_ROOT/scripts/tests/test_claim_lock.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_premerge_assert.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_board_label_mirror.sh" >>"$log" 2>&1 &&
-     bash "$REPO_ROOT/scripts/tests/test_worker_supervisor.sh" >>"$log" 2>&1; then
+     bash "$REPO_ROOT/scripts/tests/test_worker_supervisor.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/tests/test_gate_failure_mode.sh" >>"$log" 2>&1; then
     status=PASS
   else
     status=FAIL

--- a/scripts/ci/gate-failure-mode.sh
+++ b/scripts/ci/gate-failure-mode.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# gate-failure-mode.sh — the pure routing decision for gate-failure-issue.yml
+# (issue #2662). Given an already-resolved gate-run identity, decide what the
+# alert automation should do:
+#
+#   file    — the run is RED (failure/cancelled/timed_out): file/update the
+#             deduplicated `gate-nightly-failure` tracking issue.
+#   resolve — the run is GREEN (success): comment "resolved" on the open issue.
+#   none    — do nothing (origin not allowlisted, wrong workflow, bad replay
+#             input, or a non-terminal/unknown conclusion).
+#
+# WHY A SEPARATE SCRIPT: the routing logic (dispatch-vs-auto validation, the
+# allowlist, the conclusion→mode mapping) is the only non-trivial part of the
+# workflow, and a workflow only executes on a real `workflow_run` event — so it
+# cannot be unit-tested in-repo. Extracting the decision here makes it callable
+# from `scripts/tests/test_gate_failure_mode.sh` and keeps the workflow a thin
+# shell that fetches metadata + performs the `gh` side effects.
+#
+# PURE + OFFLINE: this script performs NO network calls. The caller resolves the
+# run's metadata (for the manual-replay path via `gh run view`) and passes it in;
+# the decision is a function of the inputs only. That is what makes it testable.
+#
+# All inputs are passed as flag values (never positionally interpolated into a
+# shell), so the workflow can hand it untrusted `workflow_run` payload fields
+# safely. Emits EXACTLY one token (`file`|`resolve`|`none`) on stdout and a
+# one-line human reason on stderr; always exits 0 (the stdout token is the
+# decision — a non-zero exit under the workflow's `set -e` would be noise).
+set -euo pipefail
+unset AGENT_GATE_SUMMARY_FILE 2>/dev/null || true
+
+TRIGGER=""      # workflow_run | workflow_dispatch
+GATE_NAME=""    # the expected gate workflow name (constant, from the workflow)
+RUN_NAME=""     # the run's workflow name
+EVENT=""        # the run's origin event (schedule|workflow_dispatch|push|pull_request|…)
+BRANCH=""       # the run's head branch
+CONCLUSION=""   # the run's conclusion (failure|cancelled|timed_out|success|…)
+RUN_ID=""       # the run id (required numeric on the workflow_dispatch replay path)
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --trigger)    TRIGGER="${2:-}"; shift 2 ;;
+    --gate-name)  GATE_NAME="${2:-}"; shift 2 ;;
+    --name)       RUN_NAME="${2:-}"; shift 2 ;;
+    --event)      EVENT="${2:-}"; shift 2 ;;
+    --branch)     BRANCH="${2:-}"; shift 2 ;;
+    --conclusion) CONCLUSION="${2:-}"; shift 2 ;;
+    --run-id)     RUN_ID="${2:-}"; shift 2 ;;
+    *) echo "gate-failure-mode: unknown argument '$1'" >&2; echo none; exit 0 ;;
+  esac
+done
+
+decide() { echo "$1"; }
+
+# Map a terminal conclusion to the side effect: RED → file, GREEN → resolve.
+mode_for_conclusion() {
+  case "$1" in
+    failure|cancelled|timed_out) echo file ;;
+    success) echo resolve ;;
+    *) echo none ;;
+  esac
+}
+
+# The gate workflow must be identified. On the auto workflow_run path the trigger
+# already filters by workflow name, but validating it here too is cheap defense
+# in depth and keeps both paths uniform + testable.
+if [ -z "${GATE_NAME}" ]; then
+  echo "gate-failure-mode: --gate-name is required" >&2
+  decide none; exit 0
+fi
+if [ "${RUN_NAME}" != "${GATE_NAME}" ]; then
+  echo "run workflow '${RUN_NAME:-<none>}' is not the gate lane '${GATE_NAME}' — none" >&2
+  decide none; exit 0
+fi
+
+# Never act on a pull_request-origin run.
+if [ "${EVENT}" = "pull_request" ]; then
+  echo "origin event is pull_request — none" >&2
+  decide none; exit 0
+fi
+
+# Manual replay (workflow_dispatch of the alert workflow): the caller supplied an
+# arbitrary run_id. Require it present + numeric (fail-closed) before trusting the
+# fetched metadata.
+if [ "${TRIGGER}" = "workflow_dispatch" ]; then
+  if [ -z "${RUN_ID}" ]; then
+    echo "workflow_dispatch replay requires a run_id — none given — none" >&2
+    decide none; exit 0
+  fi
+  if ! printf '%s' "${RUN_ID}" | grep -Eq '^[0-9]+$'; then
+    echo "run_id '${RUN_ID}' is not numeric — none" >&2
+    decide none; exit 0
+  fi
+fi
+
+# Origin-event allowlist. The gate lane runs only on schedule (always the default
+# branch = main) or workflow_dispatch; a dispatch on a non-main branch (e.g. a
+# maintainer testing on a feature branch) must NOT touch the backstop issue.
+case "${EVENT}" in
+  schedule)
+    : ;;
+  workflow_dispatch)
+    if [ "${BRANCH}" != "main" ]; then
+      echo "gate dispatch on non-main branch '${BRANCH:-<none>}' — none" >&2
+      decide none; exit 0
+    fi ;;
+  *)
+    echo "origin event '${EVENT:-<none>}' is not schedule/workflow_dispatch — none" >&2
+    decide none; exit 0 ;;
+esac
+
+MODE="$(mode_for_conclusion "${CONCLUSION}")"
+if [ "${MODE}" = "none" ]; then
+  echo "conclusion '${CONCLUSION:-<none>}' is not terminal red/green — none" >&2
+fi
+decide "${MODE}"

--- a/scripts/ci/gate-failure-mode.sh
+++ b/scripts/ci/gate-failure-mode.sh
@@ -36,16 +36,25 @@ BRANCH=""       # the run's head branch
 CONCLUSION=""   # the run's conclusion (failure|cancelled|timed_out|success|…)
 RUN_ID=""       # the run id (required numeric on the workflow_dispatch replay path)
 
+# Every value-taking flag needs a following value; a trailing flag with none
+# would make `shift 2` fail under `set -e` (abort -> silent alert drop). Guard it.
+need_val() {
+  if [ "$#" -lt 2 ]; then
+    echo "gate-failure-mode: missing value for $1 — none" >&2
+    echo none
+    exit 0
+  fi
+}
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --trigger)    TRIGGER="${2:-}"; shift 2 ;;
-    --gate-name)  GATE_NAME="${2:-}"; shift 2 ;;
-    --name)       RUN_NAME="${2:-}"; shift 2 ;;
-    --event)      EVENT="${2:-}"; shift 2 ;;
-    --branch)     BRANCH="${2:-}"; shift 2 ;;
-    --conclusion) CONCLUSION="${2:-}"; shift 2 ;;
-    --run-id)     RUN_ID="${2:-}"; shift 2 ;;
-    *) echo "gate-failure-mode: unknown argument '$1'" >&2; echo none; exit 0 ;;
+    --trigger)    need_val "$@"; TRIGGER="$2"; shift 2 ;;
+    --gate-name)  need_val "$@"; GATE_NAME="$2"; shift 2 ;;
+    --name)       need_val "$@"; RUN_NAME="$2"; shift 2 ;;
+    --event)      need_val "$@"; EVENT="$2"; shift 2 ;;
+    --branch)     need_val "$@"; BRANCH="$2"; shift 2 ;;
+    --conclusion) need_val "$@"; CONCLUSION="$2"; shift 2 ;;
+    --run-id)     need_val "$@"; RUN_ID="$2"; shift 2 ;;
+    *) echo "gate-failure-mode: unknown argument '$1' — none" >&2; echo none; exit 0 ;;
   esac
 done
 

--- a/scripts/tests/test_gate_failure_mode.sh
+++ b/scripts/tests/test_gate_failure_mode.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Regression tests for scripts/ci/gate-failure-mode.sh (issue #2662).
+#
+# The alert automation (gate-failure-issue.yml) only ever executes on a real
+# `workflow_run` event, so its routing decision is untestable in the workflow.
+# That logic lives in gate-failure-mode.sh (pure, offline); this test pins its
+# decision table so a regression is caught by the gate's `tooling-tests`
+# component instead of merging undetected.
+#
+# Fast + hermetic: no network, no `gh`, no datasets. Per-run mktemp scratch with
+# a TERMINAL XXXXXX (macOS-safe); AGENT_GATE_SUMMARY_FILE is unset so a nested
+# invocation can never clobber a parent gate's summary (#2751/#2874).
+#
+# Run standalone:   bash scripts/tests/test_gate_failure_mode.sh
+set -uo pipefail
+unset AGENT_GATE_SUMMARY_FILE 2>/dev/null || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODE_SH="$SCRIPT_DIR/../ci/gate-failure-mode.sh"
+GATE_NAME="Nightly agent-gate (deep check)"
+
+T=$(mktemp -d "${TMPDIR:-/tmp}/gate-failure-mode-test.XXXXXX")
+trap 'rm -rf "$T"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# expect <wanted-mode> <description> <args...> — run the mode script with the
+# given flags and assert stdout equals <wanted-mode>.
+expect() {
+  local want="$1" desc="$2"
+  shift 2
+  local got
+  got="$(bash "$MODE_SH" "$@" 2>/dev/null)" || true
+  if [ "$got" = "$want" ]; then
+    ok "$desc"
+  else
+    bad "$desc (got '$got', wanted '$want')"
+  fi
+}
+
+# --- auto workflow_run path --------------------------------------------------
+# Scheduled red conclusions -> file.
+for c in failure cancelled timed_out; do
+  expect file "workflow_run schedule $c -> file" \
+    --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+    --event schedule --branch main --conclusion "$c"
+done
+
+# Scheduled green -> resolve.
+expect resolve "workflow_run schedule success -> resolve" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion success
+
+# workflow_dispatch origin on main -> honored (red -> file).
+expect file "workflow_run dispatch-on-main failure -> file" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event workflow_dispatch --branch main --conclusion failure
+
+# workflow_dispatch origin on a NON-main branch -> none (feature-branch test).
+expect none "workflow_run dispatch on non-main branch -> none" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event workflow_dispatch --branch issue-2662-x --conclusion failure
+
+# pull_request origin -> none (never file for a PR run).
+expect none "workflow_run pull_request origin -> none" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event pull_request --branch main --conclusion failure
+
+# Wrong workflow name -> none (belt-and-suspenders even on the auto path).
+expect none "workflow_run wrong workflow name -> none" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "Some Other Lane" \
+  --event schedule --branch main --conclusion failure
+
+# Unknown/non-terminal conclusion on an allowlisted origin -> none.
+expect none "workflow_run schedule startup_failure -> none" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion startup_failure
+
+# Unknown origin event (e.g. push) -> none.
+expect none "workflow_run push origin -> none" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event push --branch main --conclusion failure
+
+# --- manual replay (workflow_dispatch of the alert workflow) ------------------
+# Valid numeric run_id, gate lane, schedule/main, red -> file.
+expect file "replay valid numeric run_id red -> file" \
+  --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion cancelled --run-id 12345
+
+# Valid replay of a green run -> resolve.
+expect resolve "replay valid run_id green -> resolve" \
+  --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion success --run-id 12345
+
+# Absent run_id on replay -> none.
+expect none "replay absent run_id -> none" \
+  --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion failure
+
+# Non-numeric run_id on replay -> none.
+expect none "replay non-numeric run_id -> none" \
+  --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion failure --run-id "12; rm -rf /"
+
+# Replay whose target is a DIFFERENT workflow -> none.
+expect none "replay wrong workflow name -> none" \
+  --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "Another Workflow" \
+  --event schedule --branch main --conclusion failure --run-id 999
+
+# Replay of a pull_request-origin run -> none.
+expect none "replay pull_request-origin target -> none" \
+  --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event pull_request --branch main --conclusion failure --run-id 999
+
+# Replay of a non-main dispatch target -> none.
+expect none "replay non-main dispatch target -> none" \
+  --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event workflow_dispatch --branch feature --conclusion failure --run-id 999
+
+# --- misc robustness ---------------------------------------------------------
+# Missing --gate-name -> none (fail-closed).
+expect none "missing gate-name -> none" \
+  --trigger workflow_run --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion failure
+
+# Unknown argument -> none (fail-closed).
+expect none "unknown argument -> none" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion failure --bogus x
+
+printf '\n%s\n' "gate-failure-mode: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_gate_failure_mode.sh
+++ b/scripts/tests/test_gate_failure_mode.sh
@@ -8,9 +8,9 @@
 # decision table so a regression is caught by the gate's `tooling-tests`
 # component instead of merging undetected.
 #
-# Fast + hermetic: no network, no `gh`, no datasets. Per-run mktemp scratch with
-# a TERMINAL XXXXXX (macOS-safe); AGENT_GATE_SUMMARY_FILE is unset so a nested
-# invocation can never clobber a parent gate's summary (#2751/#2874).
+# Fast + hermetic: no network, no `gh`, no datasets, no scratch files.
+# AGENT_GATE_SUMMARY_FILE is unset so a nested invocation can never clobber a
+# parent gate's summary (#2751/#2874).
 #
 # Run standalone:   bash scripts/tests/test_gate_failure_mode.sh
 set -uo pipefail
@@ -19,9 +19,6 @@ unset AGENT_GATE_SUMMARY_FILE 2>/dev/null || true
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODE_SH="$SCRIPT_DIR/../ci/gate-failure-mode.sh"
 GATE_NAME="Nightly agent-gate (deep check)"
-
-T=$(mktemp -d "${TMPDIR:-/tmp}/gate-failure-mode-test.XXXXXX")
-trap 'rm -rf "$T"' EXIT
 
 PASS=0
 FAIL=0
@@ -42,93 +39,87 @@ expect() {
   fi
 }
 
-# --- auto workflow_run path --------------------------------------------------
-# Scheduled red conclusions -> file.
+# expect_reason <stderr-substring> <description> <args...> — assert the decision
+# is `none` AND the stderr reason contains <stderr-substring>, so distinct
+# rejection branches (e.g. pull_request vs allowlist) are distinguishable, not
+# just uniformly "none".
+expect_reason() {
+  local needle="$1" desc="$2"
+  shift 2
+  local out err
+  err="$(bash "$MODE_SH" "$@" 2>&1 >/dev/null)" || true
+  out="$(bash "$MODE_SH" "$@" 2>/dev/null)" || true
+  if [ "$out" != "none" ]; then
+    bad "$desc (mode '$out', wanted 'none')"
+    return
+  fi
+  case "$err" in
+    *"$needle"*) ok "$desc" ;;
+    *) bad "$desc (reason '$err' lacks '$needle')" ;;
+  esac
+}
+
+# --- auto workflow_run path: conclusion -> mode ------------------------------
 for c in failure cancelled timed_out; do
   expect file "workflow_run schedule $c -> file" \
     --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
     --event schedule --branch main --conclusion "$c"
 done
-
-# Scheduled green -> resolve.
 expect resolve "workflow_run schedule success -> resolve" \
   --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event schedule --branch main --conclusion success
-
-# workflow_dispatch origin on main -> honored (red -> file).
 expect file "workflow_run dispatch-on-main failure -> file" \
   --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event workflow_dispatch --branch main --conclusion failure
-
-# workflow_dispatch origin on a NON-main branch -> none (feature-branch test).
-expect none "workflow_run dispatch on non-main branch -> none" \
-  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
-  --event workflow_dispatch --branch issue-2662-x --conclusion failure
-
-# pull_request origin -> none (never file for a PR run).
-expect none "workflow_run pull_request origin -> none" \
-  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
-  --event pull_request --branch main --conclusion failure
-
-# Wrong workflow name -> none (belt-and-suspenders even on the auto path).
-expect none "workflow_run wrong workflow name -> none" \
-  --trigger workflow_run --gate-name "$GATE_NAME" --name "Some Other Lane" \
-  --event schedule --branch main --conclusion failure
-
-# Unknown/non-terminal conclusion on an allowlisted origin -> none.
 expect none "workflow_run schedule startup_failure -> none" \
   --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event schedule --branch main --conclusion startup_failure
 
-# Unknown origin event (e.g. push) -> none.
-expect none "workflow_run push origin -> none" \
+# --- auto path rejections, each with a DISTINCT stderr reason -----------------
+expect_reason "is not the gate lane" "wrong workflow name -> none (name reason)" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "Some Other Lane" \
+  --event schedule --branch main --conclusion failure
+expect_reason "pull_request" "pull_request origin -> none (pr reason)" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event pull_request --branch main --conclusion failure
+expect_reason "not schedule/workflow_dispatch" "push origin -> none (allowlist reason)" \
   --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event push --branch main --conclusion failure
+expect_reason "non-main branch" "dispatch on non-main branch -> none (branch reason)" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event workflow_dispatch --branch issue-2662-x --conclusion failure
 
-# --- manual replay (workflow_dispatch of the alert workflow) ------------------
-# Valid numeric run_id, gate lane, schedule/main, red -> file.
+# --- manual replay path ------------------------------------------------------
 expect file "replay valid numeric run_id red -> file" \
   --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event schedule --branch main --conclusion cancelled --run-id 12345
-
-# Valid replay of a green run -> resolve.
 expect resolve "replay valid run_id green -> resolve" \
   --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event schedule --branch main --conclusion success --run-id 12345
-
-# Absent run_id on replay -> none.
-expect none "replay absent run_id -> none" \
+expect_reason "requires a run_id" "replay absent run_id -> none (missing-run-id reason)" \
   --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event schedule --branch main --conclusion failure
-
-# Non-numeric run_id on replay -> none.
-expect none "replay non-numeric run_id -> none" \
+expect_reason "is not numeric" "replay non-numeric run_id -> none (numeric reason)" \
   --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event schedule --branch main --conclusion failure --run-id "12; rm -rf /"
-
-# Replay whose target is a DIFFERENT workflow -> none.
 expect none "replay wrong workflow name -> none" \
   --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "Another Workflow" \
   --event schedule --branch main --conclusion failure --run-id 999
-
-# Replay of a pull_request-origin run -> none.
 expect none "replay pull_request-origin target -> none" \
   --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event pull_request --branch main --conclusion failure --run-id 999
-
-# Replay of a non-main dispatch target -> none.
 expect none "replay non-main dispatch target -> none" \
   --trigger workflow_dispatch --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event workflow_dispatch --branch feature --conclusion failure --run-id 999
 
-# --- misc robustness ---------------------------------------------------------
-# Missing --gate-name -> none (fail-closed).
-expect none "missing gate-name -> none" \
+# --- argument robustness -----------------------------------------------------
+expect_reason "gate-name is required" "missing gate-name -> none (required reason)" \
   --trigger workflow_run --name "$GATE_NAME" \
   --event schedule --branch main --conclusion failure
-
-# Unknown argument -> none (fail-closed).
-expect none "unknown argument -> none" \
+expect_reason "missing value for --conclusion" "trailing flag with no value -> none" \
+  --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
+  --event schedule --branch main --conclusion
+expect_reason "unknown argument" "unknown argument -> none (unknown reason)" \
   --trigger workflow_run --gate-name "$GATE_NAME" --name "$GATE_NAME" \
   --event schedule --branch main --conclusion failure --bogus x
 


### PR DESCRIPTION
Closes #2662 (nightly deep-check dead all July: 12+ straight 75m timeout-cancels).

## What
- **gate.yml**: `timeout-minutes` 75→180 on the `gate` job (comment documents the 12-night cancel evidence + a revisit note to tighten with measured runtime and confirm timeout-not-hang); `CQLITE_CLIPPY_FULL=1` moved out of the gate job into a new parallel `clippy-full` job (90m, same OOM prep, byte-identical clippy matrix command) — the gate job stays a FULL `agent-gate.sh` run (never `--only`), conforming to the `gate-ci-coverage` spec.
- **gate-failure-issue.yml** (new): `workflow_run` alert that files/updates ONE deduplicated tracking issue on `failure`/`cancelled`/`timed_out` (cancelled was the silent-death mode) and comments resolved on green. All untrusted fields via quoted env; origin allowlist fail-closed; injection-lint + actionlint clean.
- **scripts/ci/gate-failure-mode.sh** (new): pure offline routing decision, unit-tested by **scripts/tests/test_gate_failure_mode.sh** (20 cases incl. per-branch stderr reasons), wired into the gate's `tooling-tests` component.
- **agent-gate.sh**: doctrine strings updated (nightly clippy-full location); tooling-tests wiring.

## Verification
- Lite gate: `RESULT: PASS` (r4) + actionlint + check-workflow-injection.sh clean each round.
- Branch verification dispatch (one true cold end-to-end timing + real verdict): https://github.com/pmcfadin/cqlite/actions/runs/30167819044 — feeds acceptance #4 (timing headroom) and #2 (pre-Jul-6 reds shown fixed; triage table on the issue thread).
- Review: rust-reviewer + 2 roborev rounds, all blockers fixed (concurrency-group dedup, routing test coverage, fail-open lookups, arg-parse guards, dead token guard removed, printf %s hygiene, oldest-issue dedup).
- Acceptance #1 (consecutive real-conclusion nights) and the alert's live firing complete post-merge by observation — recorded as residual on the issue.

## Nit batch (follow-up, not blocking)
Replay-path `<n/a>` event/branch rendering; resolve-comment on every green night; per-component gate watchdog idea.