### PR TITLE
docs(process): two delivery lessons from #2043 — gate-summary poll predicate + datasets-root resolution

### DIFF
--- a/process_improvements.md
+++ b/process_improvements.md
@@ -685,3 +685,33 @@ issues have landed). Keep entries short so a future reader can re-run the measur
       Never spend time on Read/Write-based symlink workarounds for this
       again — it is a disk problem, not a task-output-quota problem, and the
       fix is the same `rm -rf <idle-worktree>/target` reclaim as always.
+  23. **2026-07-26 — the gate summary file is PRE-SEEDED, so the documented
+      poll predicate `grep -q 'RESULT:'` false-fires within seconds of gate
+      start.** `agent-gate.sh` writes `RESULT: INCOMPLETE (gate did not
+      finish)` into `AGENT_GATE_SUMMARY_FILE` at launch (so a killed gate
+      leaves an honest verdict rather than an empty file). A `flow-closer`
+      polling for the substring `RESULT:` therefore concludes the gate is
+      done ~seconds in and reads a non-terminal summary — which, if trusted,
+      looks like a mysterious instant FAIL/INCOMPLETE rather than a
+      still-running gate. **Standing lesson:** poll for a TERMINAL verdict
+      only — `grep -qE '^RESULT: (PASS|FAIL)'` — never the bare `RESULT:`
+      substring. Worth fixing in the CLAUDE.md gate-invocation recipe and the
+      `flow-closer` prompt template, since every closer inherits the wrong
+      predicate from the docs. Found by the #2043 closer, which caught it
+      itself and switched predicates rather than reporting a bogus verdict.
+  24. **2026-07-26 — `CQLITE_DATASETS_ROOT` is NOT necessarily
+      `<repo>/test-data/datasets`; on a fetched box the canonical corpus can
+      live entirely outside the checkout (here `/data/datasets`).** The lead
+      briefed a closer with the repo-relative path from CLAUDE.md's worktree
+      guidance; the in-repo tree contains only the committed JSONL byte-parity
+      refs, so the FULL gate fail-fasted in ~20s with
+      `preflight: FAIL (canonical corpus test_basic absent ...)` +
+      `missing-fixtures: FAIL-CLOSED (#2078)`. `fetch-datasets.sh` revealed the
+      real location ("already present in /data/datasets; skipping download").
+      **Standing lesson:** before briefing a gate-running subagent, resolve the
+      corpus location empirically (`find <candidate> -name '*Data.db' | wc -l`,
+      and check `test_basic` specifically) rather than passing the doc path
+      through. And never "fix" this class of failure with
+      `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` — that restores SKIPs and buys a
+      vacuous PASS, which is exactly what #2078's fail-closed exists to
+      prevent.


### PR DESCRIPTION
Docs-only. Appends lessons 23 and 24 to `process_improvements.md`, both found during #2043 (PR #2892) delivery. Not folded into #2892 — they are cross-issue process lessons, not part of that issue's scope (1:1:1:1).

**Lesson 23 — the gate summary file is pre-seeded, so the documented poll predicate false-fires.** `agent-gate.sh` writes `RESULT: INCOMPLETE (gate did not finish)` into `AGENT_GATE_SUMMARY_FILE` at launch, so a `flow-closer` polling for the bare substring `RESULT:` concludes the gate finished seconds in and reads a non-terminal summary — which looks like a mysterious instant FAIL rather than a still-running gate. Poll `grep -qE '^RESULT: (PASS|FAIL)'`. Worth fixing in CLAUDE.md's gate recipe and the `flow-closer` template, since every closer inherits the wrong predicate from the docs.

**Lesson 24 — `CQLITE_DATASETS_ROOT` is not necessarily `<repo>/test-data/datasets`.** On this box the canonical corpus lives entirely outside the checkout (`/data/datasets`); the in-repo tree carries only committed JSONL byte-parity refs. Briefing a closer with the doc path fail-fasted the full gate in ~20s (`preflight: FAIL` + `missing-fixtures: FAIL-CLOSED (#2078)`). Resolve the corpus location empirically before briefing a gate-running subagent — and never paper over that failure with `AGENT_GATE_ALLOW_MISSING_FIXTURES=1`, which restores SKIPs and buys a vacuous PASS.

Both lessons are self-inflicted-mistake records from this session, filed so the next session doesn't repeat them.