### PR TITLE
test(#1883): per-row allocation-count ratchet on the row conversion hot path

### DIFF
--- a/cqlite-core/src/query/select_executor/row_build.rs
+++ b/cqlite-core/src/query/select_executor/row_build.rs
@@ -288,7 +288,7 @@ pub fn build_row_from_scan_cached(
 /// Gated at the DECLARATION on `not(dhat-heap)`: the #1668 dhat allocator and
 /// `test_alloc_probe`'s CountingAllocator are mutually exclusive global
 /// allocators, so under `--all-features` the probe is configured out entirely.
-#[cfg(all(test, not(feature = "dhat-heap")))]
+#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]
 #[path = "row_build_alloc_budget_test.rs"]
 mod alloc_budget_test;
 

--- a/cqlite-core/src/query/select_executor/row_build.rs
+++ b/cqlite-core/src/query/select_executor/row_build.rs
@@ -282,6 +282,16 @@ pub fn build_row_from_scan_cached(
     })
 }
 
+/// Issue #1883 (M4): per-row allocation-count ratchet. A CHILD module of
+/// `row_build` (so it may drive the private `PartitionKeyCache::columns_for`),
+/// kept in its own file to hold this one under the campsite threshold (#1116).
+/// Gated at the DECLARATION on `not(dhat-heap)`: the #1668 dhat allocator and
+/// `test_alloc_probe`'s CountingAllocator are mutually exclusive global
+/// allocators, so under `--all-features` the probe is configured out entirely.
+#[cfg(all(test, not(feature = "dhat-heap")))]
+#[path = "row_build_alloc_budget_test.rs"]
+mod alloc_budget_test;
+
 #[cfg(test)]
 mod tests {
     use super::super::predicate::evaluate_predicates;

--- a/cqlite-core/src/query/select_executor/row_build_alloc_budget_test.rs
+++ b/cqlite-core/src/query/select_executor/row_build_alloc_budget_test.rs
@@ -29,42 +29,67 @@ const NARROW_COLS: usize = 3;
 const WIDE_COLS: usize = 32;
 
 // MEASURED allocation budget, expressed as a FORMULA over the fixture rather than
-// as two hard-coded totals, so that editing `RATCHET_ROWS` / `*_COLS` cannot
-// silently decouple the budget from what it pins (a smaller fixture with a
-// stale-but-larger constant would keep passing while constraining nothing).
+// as hard-coded totals, so editing `RATCHET_ROWS` / `*_COLS` cannot silently
+// decouple the budget from what it pins:
 //
-// The pinned quantity is the per-row and PER-CELL cost:
+//   total = FIXED_SETUP + RATCHET_ROWS * (PER_ROW_MAP + PER_CELL * cols)
 //
-//   total = COLLECTOR + RATCHET_ROWS * (PER_ROW_FIXED + PER_CELL * cols)
+// Reproduces the measured totals exactly: narrow 9 + 8*(1 + 1*3) = **41**,
+// wide 9 + 8*(1 + 1*32) = **273**.
 //
-// which reproduces the measured totals exactly: narrow 1 + 8*(2 + 1*3) = **41**,
-// wide 1 + 8*(2 + 1*32) = **273**.
+// The three terms are SEPARATELY measured, not fitted — solved from two row counts
+// (narrow at 8 rows = 41, at 4 rows = 25 => 4 allocations per row, constant 9) and
+// confirmed against the wide fixture independently:
 //
-// `PER_CELL = 1` is the `Value::into_owned` TIER-1 compaction (#1644) — a small
-// payload is copied into a tight allocation. `PER_ROW_FIXED = 2` is MEASURED, not
-// derived: one of the two is the sized row map (#1584); the second is not
-// attributed here, and deliberately not guessed at.
+//   FIXED_SETUP  = 9  ONCE per measured call, NOT per row: the
+//                     `Vec::with_capacity(RATCHET_ROWS)` collector, plus the FIRST
+//                     row's `PartitionKeyCache` MISS, which pays the whole
+//                     `decode_partition_key_columns` (decoded-column `Vec`, the
+//                     name `String`, its `Arc<str>` intern, the interned `Vec`) and
+//                     the PK value's first `Bytes` promotion inside the measured
+//                     region. Rows 2..N hit the cache and pay none of it.
+//   PER_ROW_MAP  = 1  the single sized row map (#1584).
+//   PER_CELL     = 1  `Value::into_owned`'s TIER-1 compaction (#1644) — a small
+//                     payload copied into a tight allocation.
+//
+// Keeping FIXED_SETUP OUT of the per-row term is load-bearing (issue #2904
+// roborev): folding it in as a per-row constant made the budget correct only at
+// RATCHET_ROWS=8 — raising the row count silently LOOSENED the ratchet, and
+// lowering it failed spuriously while the message blamed toolchain drift.
 //
 // Asserted as `<=`, so an improvement ratchets DOWN without failing.
 //
-// RETUNING (read before raising this): the totals also pin std/`hashbrown`/`bytes`
-// internals (table sizing, `Bytes::copy_from_slice` on the TIER-1 path), so a
-// toolchain or `bytes` bump can shift them with no change here. Tell the two cases
-// apart by the SLOPE: a dependency-driven shift moves `PER_ROW_FIXED` and leaves
-// `PER_CELL` at 1 (equivalently, `wide - narrow` stays `29 * RATCHET_ROWS = 232`),
-// whereas a real per-cell regression changes `PER_CELL`. Re-derive by temporarily
-// setting a constant to 0 and reading the actual count out of the assertion
-// message. Never raise a number without first confirming the two differential
-// controls below still pass — they, not these constants, are what make the
-// interning and capacity-hint properties un-rot-able.
+// RETUNING (read before raising any of these): the totals also pin std/
+// `hashbrown`/`bytes` internals (table sizing, `Bytes::copy_from_slice` on the
+// TIER-1 path), so a toolchain or `bytes` bump can shift them with no change here.
+// Tell the cases apart by WHICH term moves: a dependency-driven shift moves
+// FIXED_SETUP and/or PER_ROW_MAP and leaves PER_CELL at 1 (equivalently,
+// `wide - narrow` stays `29 * RATCHET_ROWS`), whereas a real per-cell regression
+// changes PER_CELL. Re-derive any term by temporarily zeroing it and reading the
+// actual count out of the assertion message; re-derive the SPLIT by measuring at
+// two different `RATCHET_ROWS` values. Never raise a number without first
+// confirming the two differential controls below still pass — they, not these
+// constants, are what make the interning and capacity-hint properties un-rot-able.
 const PER_CELL_ALLOCS: u64 = 1;
-const PER_ROW_FIXED_ALLOCS: u64 = 2;
-const COLLECTOR_ALLOCS: u64 = 1;
+const PER_ROW_MAP_ALLOCS: u64 = 1;
+const FIXED_SETUP_ALLOCS: u64 = 9;
+
+// The `reference_unsized_map` control below is only non-vacuous while the narrow
+// fixture's insert count (`NARROW_COLS` cells + 1 reconstructed PK column) exceeds
+// hashbrown's first growth threshold (3). At or below it an UNSIZED map also takes
+// exactly one table allocation, the two counts converge, and the strict `<` fails
+// spuriously — looking like a regression when production is correct.
+const _: () = assert!(
+    NARROW_COLS + 1 > 3,
+    "narrow fixture must exceed hashbrown's first growth threshold or the \
+     unsized-map control (#1584) becomes vacuous"
+);
 
 /// The measured allocation budget for a `cols`-wide fixture over [`RATCHET_ROWS`]
-/// rows. Derived from the fixture so the two track together.
+/// rows. Derived from the fixture so the two track together, with the one-time
+/// setup cost kept OUT of the per-row term.
 fn alloc_budget(cols: usize) -> u64 {
-    COLLECTOR_ALLOCS + RATCHET_ROWS as u64 * (PER_ROW_FIXED_ALLOCS + PER_CELL_ALLOCS * cols as u64)
+    FIXED_SETUP_ALLOCS + RATCHET_ROWS as u64 * (PER_ROW_MAP_ALLOCS + PER_CELL_ALLOCS * cols as u64)
 }
 
 /// Build `RATCHET_ROWS` scan entries of `cols` text columns, all in ONE
@@ -164,14 +189,6 @@ fn convert_current(
 fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
     use crate::test_alloc_probe::measure;
 
-    // NOTE: production also applies a `project()` filter to each cell. These
-    // references omit it deliberately — `ratchet_inputs` drives an EMPTY projection
-    // (SELECT *), where that filter admits every cell, so the omission is
-    // behaviour-preserving here and keeps each reference a standalone reproduction
-    // of the pre-fix code (the property a parameterized shared helper would lose).
-    // A future fixture with a NON-EMPTY projection must add the filter to both.
-    /// PRE-#1334: allocate a fresh key string per projected cell instead of
-    /// moving the decoder's interned `Arc<str>` handle.
     fn reference_pre_intern(
         inputs: Vec<(RowKey, ScanRow)>,
         schema: &crate::schema::TableSchema,
@@ -200,15 +217,6 @@ fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
         out
     }
 
-    // NOTE: production also applies a `project()` filter to each cell. These
-    // references omit it deliberately — `ratchet_inputs` drives an EMPTY projection
-    // (SELECT *), where that filter admits every cell, so the omission is
-    // behaviour-preserving here and keeps each reference a standalone reproduction
-    // of the pre-fix code (the property a parameterized shared helper would lose).
-    // A future fixture with a NON-EMPTY projection must add the filter to both.
-    /// PRE-#1584: build the row map UNSIZED (`HashMap::new()`), so it reallocates
-    /// its table as the row's cells fill it instead of taking one sized
-    /// allocation. Identical output; strictly more allocations.
     fn reference_unsized_map(
         inputs: Vec<(RowKey, ScanRow)>,
         schema: &crate::schema::TableSchema,

--- a/cqlite-core/src/query/select_executor/row_build_alloc_budget_test.rs
+++ b/cqlite-core/src/query/select_executor/row_build_alloc_budget_test.rs
@@ -1,0 +1,216 @@
+//! Issue #1883 (M4): the per-row allocation-count ratchet for the row hot path.
+//!
+//! Lives in its OWN in-crate test module for two reasons:
+//!
+//! 1. `crate::test_alloc_probe` is `pub(crate)` and its `CountingAllocator` is
+//!    installed as `#[global_allocator]` only for `cqlite-core`'s OWN test binary
+//!    (`#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]`,
+//!    `lib.rs`). An integration test under `cqlite-core/tests/` would link the
+//!    system allocator and could not reach the probe, so this MUST be an in-crate
+//!    `#[cfg(test)]` module.
+//! 2. Keeping it beside `row_build.rs` rather than inside it holds that file under
+//!    the campsite-rule source threshold (#1116).
+
+use super::{build_row_from_scan_cached, PartitionKeyCache};
+use crate::query::result::QueryRow;
+use crate::query::select_executor::test_support::single_pk_schema;
+use crate::types::{RowKey, ScanRow, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Rows converted per measurement. All rows share one partition key — the
+/// production-common shape (a scan yields a partition's rows consecutively),
+/// which lets `PartitionKeyCache` (#1817) hoist the decode.
+const RATCHET_ROWS: usize = 8;
+/// Narrow fixture: pins the fixed per-row cost.
+const NARROW_COLS: usize = 3;
+/// Wide fixture: pins the PER-CELL scaling, where a lost intern shows up as
+/// allocations growing with the projected-column count.
+const WIDE_COLS: usize = 32;
+
+/// MEASURED total allocations for the narrow fixture (3 cols x 8 rows), as of
+/// this commit: **41** (5 per row). See the module test's doc for the
+/// breakdown. Asserted as `<=` so a future improvement ratchets DOWN without
+/// failing; a regression trips it.
+const NARROW_ALLOC_BUDGET: u64 = 41;
+/// MEASURED total allocations for the wide fixture (32 cols x 8 rows): **273**
+/// (34 per row) — ~1 allocation per cell plus ~2 fixed per row.
+const WIDE_ALLOC_BUDGET: u64 = 273;
+
+/// Build `RATCHET_ROWS` scan entries of `cols` text columns, all in ONE
+/// partition, with every column name pre-interned exactly as the decoder hands
+/// them over (#1334). Built OUTSIDE the measured region so only the conversion
+/// itself is counted.
+fn ratchet_inputs(cols: usize) -> (Vec<(RowKey, ScanRow)>, crate::schema::TableSchema) {
+    let names: Vec<Arc<str>> = (0..cols)
+        .map(|i| Arc::from(format!("c{i}").as_str()))
+        .collect();
+    let key = RowKey::new(b"partition-0".to_vec());
+    let inputs = (0..RATCHET_ROWS)
+        .map(|r| {
+            let cells: Vec<(Arc<str>, Value)> = names
+                .iter()
+                .enumerate()
+                .map(|(c, n)| (Arc::clone(n), Value::text(format!("r{r}-c{c}-payload"))))
+                .collect();
+            (key.clone(), ScanRow::Row(cells))
+        })
+        .collect();
+    (inputs, single_pk_schema("id", "text"))
+}
+
+/// Convert through the REAL public surface, with a shared `PartitionKeyCache`.
+fn convert_current(
+    inputs: Vec<(RowKey, ScanRow)>,
+    schema: &crate::schema::TableSchema,
+) -> Vec<QueryRow> {
+    let mut cache = PartitionKeyCache::default();
+    let mut out = Vec::with_capacity(RATCHET_ROWS);
+    for (key, row) in inputs {
+        out.push(
+            build_row_from_scan_cached(key, row, &[], Some(schema), &mut cache)
+                .expect("a live row must convert"),
+        );
+    }
+    out
+}
+
+/// Issue #1883 (M4): the per-row allocation-count ratchet for the row hot path.
+///
+/// # What this gates, and what it deliberately does not
+///
+/// #1449 pinned per-row conversion budgets from the BINDING layer (V8
+/// heap-delta / Python `tracemalloc`). Those probes cannot observe a TRANSIENT
+/// Rust-heap allocation that is freed before the row crosses the FFI boundary.
+/// This test closes that gap by counting allocations IN-PROCESS, on the real
+/// public conversion surface.
+///
+/// It gates the two allocation properties that `build_row_from_scan_cached`
+/// actually owns:
+///
+/// 1. **Per-cell column-name interning (#1334).** The decoder hands over
+///    interned `Arc<str>` handles and the conversion MOVES them in. Emitting a
+///    fresh key string per cell instead costs +2 allocations per cell —
+///    measured 41 -> 89 (narrow) and 273 -> 785 (wide, exactly +2*32*8 = +512).
+///    This is the `reference_pre_intern` differential below.
+/// 2. **The single sized value map (#1584).** `HashMap::with_capacity` gives one
+///    allocation per row with no rehash growth. The absolute budget below pins it,
+///    so a lost capacity hint (which would add rehash-growth reallocations as the
+///    map fills) trips the wide fixture.
+///
+/// **Not gated here: the #1447 clone->move fix.** #1447 lives in
+/// `bindings/node/src/database.rs` (`ExecuteNativeTask::compute`), NOT in this
+/// crate, so no `cqlite-core` test can gate it. Measured directly: reverting
+/// the move to a per-cell `col_value.clone().into_owned()` here is EXACTLY
+/// allocation-neutral (41 vs 41 narrow, 273 vs 273 wide), because
+/// `Value::Text` is `Bytes`-backed (clone is a refcount bump) and
+/// `Value::into_owned`'s TIER-1 compaction (#1644) copies a small payload
+/// either way. A "clone" control here would therefore be VACUOUS, so it is
+/// deliberately omitted rather than asserted with a weakened `<=`. The same
+/// applies to #1445/#1446, which are Python/Node binding fixes. Ratcheting
+/// those three needs an allocation probe inside the binding crates — tracked
+/// as issue #2894.
+///
+/// # Shape
+///
+/// Mirrors `lookup.rs`'s `cartesian_product_builds_each_combo_in_one_allocation`:
+/// a `reference()` reproduces the pre-fix behaviour, and the current impl must
+/// (a) produce identical output and (b) allocate STRICTLY fewer times. A
+/// differential cannot pass vacuously — if the fixture stopped exercising the
+/// path, both sides would collapse together and the strict inequality would
+/// fail. The absolute budgets are exact measured counts (the counting
+/// allocator is deterministic for a fixed input, so no tolerance is needed).
+///
+/// `not(dhat-heap)`: issue #1668's dhat allocator (`lib.rs`'s `DHAT_TEST_ALLOC`)
+/// mutually excludes `test_alloc_probe`'s own `CountingAllocator` (only one
+/// `#[global_allocator]` per binary), so under a feature combination with BOTH
+/// `state_machine` and `dhat-heap` enabled (e.g. `--all-features`)
+/// `test_alloc_probe` is configured out entirely — skip this specific
+/// allocation-count probe rather than fail to resolve it.
+#[test]
+fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
+    use crate::test_alloc_probe::measure;
+
+    /// PRE-#1334: allocate a fresh key string per projected cell instead of
+    /// moving the decoder's interned `Arc<str>` handle.
+    fn reference_pre_intern(
+        inputs: Vec<(RowKey, ScanRow)>,
+        schema: &crate::schema::TableSchema,
+    ) -> Vec<QueryRow> {
+        let mut cache = PartitionKeyCache::default();
+        let mut out = Vec::with_capacity(RATCHET_ROWS);
+        for (key, row) in inputs {
+            let cells = row.into_cells().expect("live row");
+            let mut row_values: HashMap<Arc<str>, Value> =
+                HashMap::with_capacity(cells.len() + schema.partition_keys.len());
+            for (name, col_value) in cells {
+                // The reverted form: a fresh per-cell `Arc<str>` key.
+                let fresh: Arc<str> = Arc::from(name.as_ref().to_string().as_str());
+                row_values.insert(fresh, col_value.into_owned());
+            }
+            for (name, value) in cache.columns_for(&key.0, schema) {
+                row_values.insert(Arc::clone(name), value.clone());
+            }
+            out.push(QueryRow {
+                values: row_values,
+                key,
+                metadata: Default::default(),
+                cell_metadata: None,
+            });
+        }
+        out
+    }
+
+    for (label, cols, budget) in [
+        ("narrow", NARROW_COLS, NARROW_ALLOC_BUDGET),
+        ("wide", WIDE_COLS, WIDE_ALLOC_BUDGET),
+    ] {
+        let (inputs, schema) = ratchet_inputs(cols);
+        let (inputs_ref, _) = ratchet_inputs(cols);
+
+        let (cur_allocs, cur_rows) = measure(|| convert_current(inputs, &schema));
+        let (intern_allocs, intern_rows) = measure(|| reference_pre_intern(inputs_ref, &schema));
+
+        // --- non-vacuity: the fixture really converted real rows ---
+        assert_eq!(
+            cur_rows.len(),
+            RATCHET_ROWS,
+            "{label}: every input row must convert — a zero/short result would \
+             make the allocation budget meaningless"
+        );
+        for row in &cur_rows {
+            assert_eq!(
+                row.values.len(),
+                cols + 1,
+                "{label}: each row must carry all {cols} cells plus the \
+                 reconstructed partition-key column"
+            );
+        }
+
+        // --- output equivalence: interning changed cost, never bytes ---
+        for (i, (cur, old)) in cur_rows.iter().zip(intern_rows.iter()).enumerate() {
+            assert_eq!(
+                cur.values, old.values,
+                "{label} row {i}: output must be identical to the pre-intern build"
+            );
+        }
+
+        // --- the ratchet: strictly fewer allocations than the revert ---
+        assert!(
+            cur_allocs < intern_allocs,
+            "{label}: dropping per-cell key interning (#1334) must trip the \
+             budget — current {cur_allocs} allocations is not strictly fewer \
+             than the fresh-key reference's {intern_allocs}"
+        );
+
+        // --- the absolute budget (exact measured counts) ---
+        assert!(
+            cur_allocs <= budget,
+            "{label}: {cur_allocs} allocations over {RATCHET_ROWS} rows exceeds \
+             the measured budget of {budget} \
+             ({} per row vs {} budgeted)",
+            cur_allocs as usize / RATCHET_ROWS,
+            budget as usize / RATCHET_ROWS
+        );
+    }
+}

--- a/cqlite-core/src/query/select_executor/row_build_alloc_budget_test.rs
+++ b/cqlite-core/src/query/select_executor/row_build_alloc_budget_test.rs
@@ -28,13 +28,26 @@ const NARROW_COLS: usize = 3;
 /// allocations growing with the projected-column count.
 const WIDE_COLS: usize = 32;
 
-/// MEASURED total allocations for the narrow fixture (3 cols x 8 rows), as of
-/// this commit: **41** (5 per row). See the module test's doc for the
-/// breakdown. Asserted as `<=` so a future improvement ratchets DOWN without
-/// failing; a regression trips it.
+// MEASURED absolute budgets, as of this commit. Shape: roughly
+// `1 (the sized row map) + 1 per cell (Value::into_owned's TIER-1 compaction of a
+// small payload, #1644)` per row, PLUS exactly ONE fixed allocation for the
+// `Vec::with_capacity(RATCHET_ROWS)` that collects the rows — that collector sits
+// OUTSIDE the per-row loop, which is why neither total is an exact multiple of
+// `RATCHET_ROWS` (41 = 8*5 + 1, 273 = 8*34 + 1).
+//
+// Asserted as `<=`, so an improvement ratchets DOWN without failing.
+//
+// RETUNING (read before raising either number): these totals also pin std/
+// `hashbrown`/`bytes` internals (table sizing at capacity 4 vs 33,
+// `Bytes::copy_from_slice` on the TIER-1 path), so a toolchain or `bytes` bump can
+// shift them without any change here. Distinguish the two cases before editing:
+// a dependency-driven shift moves the FIXED part and leaves the per-cell slope
+// intact (wide - narrow stays 29*8 = 232), whereas a real regression changes the
+// SLOPE. Re-derive by temporarily setting a budget to 1 and reading the actual
+// count out of the assertion message. Never raise a budget without first checking
+// that the two differential controls below still pass — they, not these constants,
+// are what make the interning and capacity-hint properties un-rot-able.
 const NARROW_ALLOC_BUDGET: u64 = 41;
-/// MEASURED total allocations for the wide fixture (32 cols x 8 rows): **273**
-/// (34 per row) — ~1 allocation per cell plus ~2 fixed per row.
 const WIDE_ALLOC_BUDGET: u64 = 273;
 
 /// Build `RATCHET_ROWS` scan entries of `cols` text columns, all in ONE
@@ -94,9 +107,12 @@ fn convert_current(
 ///    measured 41 -> 89 (narrow) and 273 -> 785 (wide, exactly +2*32*8 = +512).
 ///    This is the `reference_pre_intern` differential below.
 /// 2. **The single sized value map (#1584).** `HashMap::with_capacity` gives one
-///    allocation per row with no rehash growth. The absolute budget below pins it,
-///    so a lost capacity hint (which would add rehash-growth reallocations as the
-///    map fills) trips the wide fixture.
+///    allocation per row with no rehash growth. Dropping the capacity hint costs
+///    +1 allocation per row in rehash growth — measured 41 -> 49 (narrow). This is
+///    the `reference_unsized_map` differential below. It exists so this property
+///    is gated by a CONTROL and not merely by the absolute budget: a constant can
+///    be "re-measured" upward by a future reader, a strict `<` against a reference
+///    cannot.
 ///
 /// **Not gated here: the #1447 clone->move fix.** #1447 lives in
 /// `bindings/node/src/database.rs` (`ExecuteNativeTask::compute`), NOT in this
@@ -161,15 +177,47 @@ fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
         out
     }
 
+    /// PRE-#1584: build the row map UNSIZED (`HashMap::new()`), so it reallocates
+    /// its table as the row's cells fill it instead of taking one sized
+    /// allocation. Identical output; strictly more allocations.
+    fn reference_unsized_map(
+        inputs: Vec<(RowKey, ScanRow)>,
+        schema: &crate::schema::TableSchema,
+    ) -> Vec<QueryRow> {
+        let mut cache = PartitionKeyCache::default();
+        let mut out = Vec::with_capacity(RATCHET_ROWS);
+        for (key, row) in inputs {
+            let cells = row.into_cells().expect("live row");
+            // The reverted form: no capacity hint.
+            let mut row_values: HashMap<Arc<str>, Value> = HashMap::new();
+            for (name, col_value) in cells {
+                row_values.insert(name, col_value.into_owned());
+            }
+            for (name, value) in cache.columns_for(&key.0, schema) {
+                row_values.insert(Arc::clone(name), value.clone());
+            }
+            out.push(QueryRow {
+                values: row_values,
+                key,
+                metadata: Default::default(),
+                cell_metadata: None,
+            });
+        }
+        out
+    }
+
     for (label, cols, budget) in [
         ("narrow", NARROW_COLS, NARROW_ALLOC_BUDGET),
         ("wide", WIDE_COLS, WIDE_ALLOC_BUDGET),
     ] {
         let (inputs, schema) = ratchet_inputs(cols);
         let (inputs_ref, _) = ratchet_inputs(cols);
+        let (inputs_unsized, _) = ratchet_inputs(cols);
 
         let (cur_allocs, cur_rows) = measure(|| convert_current(inputs, &schema));
         let (intern_allocs, intern_rows) = measure(|| reference_pre_intern(inputs_ref, &schema));
+        let (unsized_allocs, unsized_rows) =
+            measure(|| reference_unsized_map(inputs_unsized, &schema));
 
         // --- non-vacuity: the fixture really converted real rows ---
         assert_eq!(
@@ -187,15 +235,33 @@ fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
             );
         }
 
-        // --- output equivalence: interning changed cost, never bytes ---
+        // --- output equivalence: the fixes changed cost, never bytes ---
+        // Both references must yield the SAME NUMBER of rows before zipping, or a
+        // short reference would silently degrade the comparison to a prefix.
+        assert_eq!(
+            intern_rows.len(),
+            cur_rows.len(),
+            "{label}: the pre-intern reference must convert the same row count"
+        );
+        assert_eq!(
+            unsized_rows.len(),
+            cur_rows.len(),
+            "{label}: the unsized-map reference must convert the same row count"
+        );
         for (i, (cur, old)) in cur_rows.iter().zip(intern_rows.iter()).enumerate() {
             assert_eq!(
                 cur.values, old.values,
                 "{label} row {i}: output must be identical to the pre-intern build"
             );
         }
+        for (i, (cur, old)) in cur_rows.iter().zip(unsized_rows.iter()).enumerate() {
+            assert_eq!(
+                cur.values, old.values,
+                "{label} row {i}: output must be identical to the unsized-map build"
+            );
+        }
 
-        // --- the ratchet: strictly fewer allocations than the revert ---
+        // --- ratchet 1 (#1334): strictly fewer allocations than losing interning ---
         assert!(
             cur_allocs < intern_allocs,
             "{label}: dropping per-cell key interning (#1334) must trip the \
@@ -203,14 +269,22 @@ fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
              than the fresh-key reference's {intern_allocs}"
         );
 
-        // --- the absolute budget (exact measured counts) ---
+        // --- ratchet 2 (#1584): strictly fewer than losing the capacity hint ---
+        // This is what keeps the sized-map property gated even if the absolute
+        // budgets below are ever retuned for a dependency-driven shift.
+        assert!(
+            cur_allocs < unsized_allocs,
+            "{label}: dropping the row map's capacity hint (#1584) must trip the \
+             budget — current {cur_allocs} allocations is not strictly fewer \
+             than the unsized-map reference's {unsized_allocs}"
+        );
+
+        // --- the absolute budget (exact measured totals; see the constants' doc) ---
         assert!(
             cur_allocs <= budget,
-            "{label}: {cur_allocs} allocations over {RATCHET_ROWS} rows exceeds \
-             the measured budget of {budget} \
-             ({} per row vs {} budgeted)",
-            cur_allocs as usize / RATCHET_ROWS,
-            budget as usize / RATCHET_ROWS
+            "{label}: {cur_allocs} allocations over {RATCHET_ROWS} rows exceeds the \
+             measured budget of {budget} — see the RETUNING note on the budget \
+             constants before changing this number"
         );
     }
 }

--- a/cqlite-core/src/query/select_executor/row_build_alloc_budget_test.rs
+++ b/cqlite-core/src/query/select_executor/row_build_alloc_budget_test.rs
@@ -28,27 +28,44 @@ const NARROW_COLS: usize = 3;
 /// allocations growing with the projected-column count.
 const WIDE_COLS: usize = 32;
 
-// MEASURED absolute budgets, as of this commit. Shape: roughly
-// `1 (the sized row map) + 1 per cell (Value::into_owned's TIER-1 compaction of a
-// small payload, #1644)` per row, PLUS exactly ONE fixed allocation for the
-// `Vec::with_capacity(RATCHET_ROWS)` that collects the rows — that collector sits
-// OUTSIDE the per-row loop, which is why neither total is an exact multiple of
-// `RATCHET_ROWS` (41 = 8*5 + 1, 273 = 8*34 + 1).
+// MEASURED allocation budget, expressed as a FORMULA over the fixture rather than
+// as two hard-coded totals, so that editing `RATCHET_ROWS` / `*_COLS` cannot
+// silently decouple the budget from what it pins (a smaller fixture with a
+// stale-but-larger constant would keep passing while constraining nothing).
+//
+// The pinned quantity is the per-row and PER-CELL cost:
+//
+//   total = COLLECTOR + RATCHET_ROWS * (PER_ROW_FIXED + PER_CELL * cols)
+//
+// which reproduces the measured totals exactly: narrow 1 + 8*(2 + 1*3) = **41**,
+// wide 1 + 8*(2 + 1*32) = **273**.
+//
+// `PER_CELL = 1` is the `Value::into_owned` TIER-1 compaction (#1644) — a small
+// payload is copied into a tight allocation. `PER_ROW_FIXED = 2` is MEASURED, not
+// derived: one of the two is the sized row map (#1584); the second is not
+// attributed here, and deliberately not guessed at.
 //
 // Asserted as `<=`, so an improvement ratchets DOWN without failing.
 //
-// RETUNING (read before raising either number): these totals also pin std/
-// `hashbrown`/`bytes` internals (table sizing at capacity 4 vs 33,
-// `Bytes::copy_from_slice` on the TIER-1 path), so a toolchain or `bytes` bump can
-// shift them without any change here. Distinguish the two cases before editing:
-// a dependency-driven shift moves the FIXED part and leaves the per-cell slope
-// intact (wide - narrow stays 29*8 = 232), whereas a real regression changes the
-// SLOPE. Re-derive by temporarily setting a budget to 1 and reading the actual
-// count out of the assertion message. Never raise a budget without first checking
-// that the two differential controls below still pass — they, not these constants,
-// are what make the interning and capacity-hint properties un-rot-able.
-const NARROW_ALLOC_BUDGET: u64 = 41;
-const WIDE_ALLOC_BUDGET: u64 = 273;
+// RETUNING (read before raising this): the totals also pin std/`hashbrown`/`bytes`
+// internals (table sizing, `Bytes::copy_from_slice` on the TIER-1 path), so a
+// toolchain or `bytes` bump can shift them with no change here. Tell the two cases
+// apart by the SLOPE: a dependency-driven shift moves `PER_ROW_FIXED` and leaves
+// `PER_CELL` at 1 (equivalently, `wide - narrow` stays `29 * RATCHET_ROWS = 232`),
+// whereas a real per-cell regression changes `PER_CELL`. Re-derive by temporarily
+// setting a constant to 0 and reading the actual count out of the assertion
+// message. Never raise a number without first confirming the two differential
+// controls below still pass — they, not these constants, are what make the
+// interning and capacity-hint properties un-rot-able.
+const PER_CELL_ALLOCS: u64 = 1;
+const PER_ROW_FIXED_ALLOCS: u64 = 2;
+const COLLECTOR_ALLOCS: u64 = 1;
+
+/// The measured allocation budget for a `cols`-wide fixture over [`RATCHET_ROWS`]
+/// rows. Derived from the fixture so the two track together.
+fn alloc_budget(cols: usize) -> u64 {
+    COLLECTOR_ALLOCS + RATCHET_ROWS as u64 * (PER_ROW_FIXED_ALLOCS + PER_CELL_ALLOCS * cols as u64)
+}
 
 /// Build `RATCHET_ROWS` scan entries of `cols` text columns, all in ONE
 /// partition, with every column name pre-interned exactly as the decoder hands
@@ -147,6 +164,12 @@ fn convert_current(
 fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
     use crate::test_alloc_probe::measure;
 
+    // NOTE: production also applies a `project()` filter to each cell. These
+    // references omit it deliberately — `ratchet_inputs` drives an EMPTY projection
+    // (SELECT *), where that filter admits every cell, so the omission is
+    // behaviour-preserving here and keeps each reference a standalone reproduction
+    // of the pre-fix code (the property a parameterized shared helper would lose).
+    // A future fixture with a NON-EMPTY projection must add the filter to both.
     /// PRE-#1334: allocate a fresh key string per projected cell instead of
     /// moving the decoder's interned `Arc<str>` handle.
     fn reference_pre_intern(
@@ -177,6 +200,12 @@ fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
         out
     }
 
+    // NOTE: production also applies a `project()` filter to each cell. These
+    // references omit it deliberately — `ratchet_inputs` drives an EMPTY projection
+    // (SELECT *), where that filter admits every cell, so the omission is
+    // behaviour-preserving here and keeps each reference a standalone reproduction
+    // of the pre-fix code (the property a parameterized shared helper would lose).
+    // A future fixture with a NON-EMPTY projection must add the filter to both.
     /// PRE-#1584: build the row map UNSIZED (`HashMap::new()`), so it reallocates
     /// its table as the row's cells fill it instead of taking one sized
     /// allocation. Identical output; strictly more allocations.
@@ -206,10 +235,17 @@ fn build_row_from_scan_cached_holds_the_per_row_alloc_budget() {
         out
     }
 
-    for (label, cols, budget) in [
-        ("narrow", NARROW_COLS, NARROW_ALLOC_BUDGET),
-        ("wide", WIDE_COLS, WIDE_ALLOC_BUDGET),
-    ] {
+    for (label, cols) in [("narrow", NARROW_COLS), ("wide", WIDE_COLS)] {
+        let budget = alloc_budget(cols);
+
+        // Warm-up (roborev): the current impl is measured FIRST, so any one-time
+        // lazy initialization reachable from the conversion path would be charged
+        // to it and to neither reference — biasing every strict-`<` against the
+        // thing under test, and doing so nondeterministically depending on what
+        // else ran first in this test binary. Burn one discarded conversion.
+        let (warm, warm_schema) = ratchet_inputs(cols);
+        drop(convert_current(warm, &warm_schema));
+
         let (inputs, schema) = ratchet_inputs(cols);
         let (inputs_ref, _) = ratchet_inputs(cols);
         let (inputs_unsized, _) = ratchet_inputs(cols);

--- a/docs/architecture/throughput-program-2026-07.md
+++ b/docs/architecture/throughput-program-2026-07.md
@@ -150,8 +150,8 @@ C(N) is **2.5–3.5×, not 4×** (P2:stage2 §3).
 |---|---|:--:|---|---|
 | **L1** batch fan-in `sync_channel` | util **1.5–1.9× rig-narrow ceiling**; single-stream ~1.05–1.15× field; **raises C(N) + N_drain_sat** | M | Med (co-design #2765 same channel; cut msg-capacity for B4; keep #2419 gauge/#2361 cancel-recv) | P2:row-engine (SURVIVES-weakened) — **#1 lever, prerequisite for C(N) and fan-out** |
 | **L3** reconcile singleton fast-path | disjoint-narrow **~1.20× upper**; **field-w/-TTL/overlap ~1.03–1.08×** | M–L | High (byte-parity; query-semantics + point-vs-full oracles load-bearing) | **Disposition unresolved — see §4 tension flag** (P2:stage2 ranks #2 / P2:row-engine WEAKENED) |
-| **L4** `RowKey` Arc hoist (#1883) | **1.05–1.09× multi-row-partition only; 1.0× single-row of any width** | S–M | Low | P2:row-engine (SURVIVES re-scoped) — win governed by clustering fan-out, unknown from profile |
-| **L5** FxHash `row_values` map | ~1.04× narrow & wide | S | Low | P2:row-engine (SURVIVES) — target confirmed still SipHash |
+| **L4** `RowKey` Arc hoist (#1883) | ~~1.05–1.09× multi-row-partition~~ → **MEASURED 1.0× no-op, see §7 M4** | S–M | Low | P2:row-engine (SURVIVES re-scoped) — win governed by clustering fan-out, unknown from profile |
+| **L5** FxHash `row_values` map | ~~~1.04×~~ → **deferred #2901, unmeasured, see §7 M4** | S | Low | P2:row-engine (SURVIVES) — target confirmed still SipHash |
 | **L2** inline/thread-less merge | ~1.4–1.8× narrow single-stream; **≤1.0× wide/field → not credited in field stack** | L | High (shape-fragile; A/B-gated) | P2:row-engine (SURVIVES narrow-only) |
 | **#2680** weight-balanced sub-splits | util (skew fix) up to 2–4× on *lagging* pods; **0× on one pod** | M | Med (P0 #2782 hang; needs early-close drain fix) | P2:parallelism P-A (SOUND) — K=2 rotation carries flight-pod balance, NOT SplitWeight |
 | **#2765** adaptive egress budget (+ fan-out T6) | stability enabler; bounds fan-in growth; unlocks higher useful concurrency | M | Med (bounds fan-in only, not the 57k-row Arrow egress) | P2:parallelism L4/L3 |
@@ -162,7 +162,7 @@ C(N) is **2.5–3.5×, not 4×** (P2:stage2 §3).
 | **Decoded-partition cache** (K-A/K-D) | **~1.5–3× keyed IF the skew is real — UNMEASURED** | L | High (3.5× decoded size, B4; #2037 overlap) | P2:caching §4 — gate on measured access distribution |
 
 **Sequence (P2:stage2 §8):** **L1 → L3 → fan-out-past-drain (gated #2765)**. L1 is both the biggest
-single-stream lever and the enabler of C(N); nothing scales without it. L5+L4 are a near-free warm-up
+single-stream lever and the enabler of C(N); nothing scales without it. L5+L4 were projected as a near-free warm-up (both since retired by measurement — §7 M4); a near-free warm-up
 bundle. #2680 re-land runs in parallel on the connector tier.
 
 **§4 tension flag (phase2-vs-phase2, L3 disposition — UNRESOLVED):** P2:stage2 §6 ranks L3 the **#2

--- a/docs/architecture/throughput-program-2026-07.md
+++ b/docs/architecture/throughput-program-2026-07.md
@@ -272,7 +272,7 @@ are in flight-loadgen/perf terms with the number each must demonstrate.
 | M1 → #2819 | NEW / EXTEND #1686 | Split `stream` RPC phase into data-plane sub-phases | P2 | — |
 | M2 → #2820 | NEW | L1 batch fan-in `sync_channel`, co-designed with #2765 | P1 | M0 (informs), #2765 co-design |
 | M3 → #2765 | EXTEND #2765 | Productionize adaptive egress budget + fan-out-past-drain + L1 256-cap co-design | P2 | M2 |
-| M4 → #1883 | EXTEND #1883 | L5 FxHash + L4 RowKey Arc hoist cheap bundle | P2 | — |
+| M4 → #1883 | EXTEND #1883 | per-row alloc ratchet DELIVERED; L4 measured 1.0× no-op; L5 deferred → #2901 | P2 | — |
 | M5 → #2680 | EXTEND #2680 | Re-land: K=2 opt-in rotation + early-close cancel fix + admission-resize + #2792 required | P1 | #2782, #2792 |
 | M6 → #2821 | NEW | Streaming `do_get` result-budget wiring gap | P2 | — |
 | M7 → #2822 | NEW (investigate) | L3 reconcile singleton fast-path | P3 | M0 + M9 (overlap data) |
@@ -322,12 +322,34 @@ are in flight-loadgen/perf terms with the number each must demonstrate.
   lands (no #2600 re-fire). **Dep:** M2. **Dedup:** extends #2765 (inventory: "extend #2765, don't
   refile").
 
-- **M4 (#1883) — L5 FxHash + L4 RowKey Arc hoist bundle (EXTEND #1883, P2).** Swap the per-row
-  `HashMap<Arc<str>,Value>` (`row_build.rs:246`) to `FxHashMap`; hoist `RowKey(Arc<[u8]>)` build
-  outside `for entry in rows`. *Accept:* SipHash disappears from the row hot path (profile); alloc
-  count/row drops by one on multi-row-partition tables (#1883 dhat ratchet); ~1.04×+1.05–1.09× on the
-  multi-row-partition fixture, **1.0× credited on single-row-partition** (do not claim a field win the
-  profile can't support). **Dep:** none. **Dedup:** L4 lives under #1883 (already 0.17); L5 folds in.
+- **M4 (#1883) — per-row alloc ratchet DELIVERED; L4 measured no-op; L5 deferred.**
+
+  - **Per-row allocation ratchet — DONE.** At the public `build_row_from_scan_cached`, using the in-crate
+    `test_alloc_probe` counting allocator. **Measured** over 8 rows in one partition: **narrow (3 cols) = 41
+    allocations (5/row)**, **wide (32 cols) = 273 (34/row)** — ~1 allocation per cell plus ~2 fixed per row.
+    The dominant per-row cost is the #1644 retention compaction (`Value::into_owned`'s TIER-1 copy of a small
+    payload), NOT hashing and NOT key handling. Verified RED-on-revert: dropping the per-cell intern (#1334)
+    takes narrow 41 → **89** and wide 273 → **785** (exactly +2 per cell).
+  - **Scope correction (measured).** #1883's premise — that this ratchet would gate #1447/#1445/#1446 — does
+    not hold: those are **binding-layer** fixes (#1447 = `bindings/node` `ExecuteNativeTask::compute`; #1446 =
+    Node JsString interning; #1445 = Python `Row` ordering). Reverting the clone→move *in this crate* is
+    exactly allocation-neutral (41 vs 41, 273 vs 273) because `Value::Text` is `Bytes`-backed and TIER-1
+    compaction copies small payloads either way. Binding-layer probe → **#2894**.
+  - **L4 (RowKey `Arc` hoist) — measured 1.0× / NO-OP, not implemented.** The partition-key path costs **zero**
+    per-row allocations: `RowKey` is `Arc<[u8]>` (clone = refcount bump) and `PartitionKeyCache` (#1817)
+    already hoists the partition-constant decode. No hoistable per-row `Arc` allocation exists, so **no field
+    win is claimed and no follow-up is filed** for L4.
+  - **L5 (FxHash row map) — implemented, then REVERTED before merge; deferred to #2901.** Implementing it
+    established two things the design had not anticipated: (a) it is a **public breaking API change** —
+    `row_values` moves straight into `QueryRow.values`, so the hasher cannot change without changing that
+    public field's type, rippling through `cqlite-core`/`cqlite-flight`/`cqlite-cli`; and (b) it **contradicts
+    the `rustc-hash` invariant** in `cqlite-core/Cargo.toml` (#1590 E8 — reserved for integer/digest keys, NOT
+    untrusted string keys), since on the default read path column names come from the file's `Statistics.db`
+    serialization header and are attacker-controlled for a hostile SSTable, where FxHash's easy collisions give
+    O(N²) per-row inserts. **No benchmark was run, so the projected ~1.04× stays a projection and no L5 win is
+    claimed.** Revisit behind a measurement + a HashDoS answer + an API plan: **#2901**.
+
+  **Dep:** none. **Dedup:** L4 lived under #1883; L5 split out to #2901.
 
 - **M5 (#2680) — #2680 re-land (EXTEND #2680, P1).** Default **K=1** (byte-identical pre-#2680), **opt-in
   K=2** (the sub-split *rotation* carries flight-pod balance — NOT `getSplitWeight()`, which is

--- a/docs/architecture/throughput-program-2026-07.md
+++ b/docs/architecture/throughput-program-2026-07.md
@@ -328,8 +328,11 @@ are in flight-loadgen/perf terms with the number each must demonstrate.
     `test_alloc_probe` counting allocator. **Measured** over 8 rows in one partition: **narrow (3 cols) = 41
     allocations (5/row)**, **wide (32 cols) = 273 (34/row)** — ~1 allocation per cell plus ~2 fixed per row.
     The dominant per-row cost is the #1644 retention compaction (`Value::into_owned`'s TIER-1 copy of a small
-    payload), NOT hashing and NOT key handling. Verified RED-on-revert: dropping the per-cell intern (#1334)
-    takes narrow 41 → **89** and wide 273 → **785** (exactly +2 per cell).
+    payload), NOT hashing and NOT key handling. Two differential controls, both verified RED-on-revert:
+    dropping the per-cell intern (#1334) takes narrow 41 → **89** and wide 273 → **785** (exactly +2 per
+    cell), and dropping the map's capacity hint (#1584) takes narrow 41 → **49** (+1 per row of rehash
+    growth). Each property is gated by a strict `<` against a pre-fix reference, not by the absolute
+    constant alone.
   - **Scope correction (measured).** #1883's premise — that this ratchet would gate #1447/#1445/#1446 — does
     not hold: those are **binding-layer** fixes (#1447 = `bindings/node` `ExecuteNativeTask::compute`; #1446 =
     Node JsString interning; #1445 = Python `Row` ordering). Reverting the clone→move *in this crate* is

--- a/docs/architecture/throughput-program-2026-07.md
+++ b/docs/architecture/throughput-program-2026-07.md
@@ -325,10 +325,15 @@ are in flight-loadgen/perf terms with the number each must demonstrate.
 - **M4 (#1883) — per-row alloc ratchet DELIVERED; L4 measured no-op; L5 deferred.**
 
   - **Per-row allocation ratchet — DONE.** At the public `build_row_from_scan_cached`, using the in-crate
-    `test_alloc_probe` counting allocator. **Measured** over 8 rows in one partition: **narrow (3 cols) = 41
-    allocations (5/row)**, **wide (32 cols) = 273 (34/row)** — ~1 allocation per cell plus ~2 fixed per row.
-    The dominant per-row cost is the #1644 retention compaction (`Value::into_owned`'s TIER-1 copy of a small
-    payload), NOT hashing and NOT key handling. Two differential controls, both verified RED-on-revert:
+    `test_alloc_probe` counting allocator. **Measured**, with the one-time setup cost held SEPARATE from the
+    per-row rate (they were initially conflated; separating them is what makes the budget valid at any row
+    count): **9 allocations once** — the result-collector `Vec` plus the first row's `PartitionKeyCache` MISS,
+    which pays the whole `decode_partition_key_columns` inside the measured region — plus a steady-state
+    **4 allocations/row narrow (3 cols)** and **33/row wide (32 cols)**, i.e. `1 sized row map + 1 per cell`.
+    Totals at 8 rows: **41 narrow, 273 wide**. Solved from two row counts (8 rows = 41, 4 rows = 25) and
+    confirmed independently against the wide fixture; the budget holds at 4, 8 and 16 rows. The dominant
+    per-row cost is the #1644 retention compaction (`Value::into_owned`'s TIER-1 copy of a small payload),
+    NOT hashing and NOT key handling. Two differential controls, both verified RED-on-revert:
     dropping the per-cell intern (#1334) takes narrow 41 → **89** and wide 273 → **785** (exactly +2 per
     cell), and dropping the map's capacity hint (#1584) takes narrow 41 → **49** (+1 per row of rehash
     growth). Each property is gated by a strict `<` against a pre-fix reference, not by the absolute

--- a/openspec/changes/rust-per-row-alloc-budget/design.md
+++ b/openspec/changes/rust-per-row-alloc-budget/design.md
@@ -61,6 +61,13 @@ revert trips it.
 
 ## Decision 3 — Baseline: measured `<=`, asserted per-row, tolerance-free where deterministic
 
+> **SUPERSEDED in implementation (amendment 4, see below).** The "divided per row" part of this
+> decision was WRONG and was rejected during review: a per-row quotient folds the once-per-measurement
+> setup cost (the first row's `PartitionKeyCache` miss) into the steady-state rate, making the budget
+> valid at exactly one row count. The shipped form separates them:
+> `FIXED_SETUP(9) + rows * (PER_ROW_MAP(1) + PER_CELL(1) * cols)`. The rest of this decision —
+> measured `<=`, tolerance-free, documented numbers — stands.
+
 **Chosen.** Run the harness, record the observed `allocations` for narrow + wide, and assert
 `allocs <= observed` (with the count divided per row where the fixture is multi-row). The counting
 allocator is deterministic for a fixed input, so no statistical tolerance is needed (unlike the V8/tracemalloc
@@ -127,3 +134,10 @@ design reads as what was actually built, not what was planned.
    `type_name_of_val(row.values.hasher())` assertion was needed for that.
 3. **L4 is a measured 1.0× no-op**, as Decision 4 allowed for: the partition-key path costs zero
    per-row allocations (`RowKey` is `Arc<[u8]>`; `PartitionKeyCache` #1817 hoists the decode).
+4. **Decision 3's per-row quotient was wrong.** Asserting `allocs / rows <= baseline` amortizes the
+   one-time setup (collector `Vec` + the first row's `PartitionKeyCache` MISS paying the whole
+   `decode_partition_key_columns` inside the measured region) into the per-row rate, so the budget only
+   holds at the row count it was derived at — raising `RATCHET_ROWS` silently LOOSENS the ratchet and
+   lowering it fails spuriously. The shipped budget separates the terms:
+   `FIXED_SETUP(9) + rows * (PER_ROW_MAP(1) + PER_CELL(1) * cols)`, measured by solving across two row
+   counts and verified to hold at 1/2/4/8/16 rows.

--- a/openspec/changes/rust-per-row-alloc-budget/design.md
+++ b/openspec/changes/rust-per-row-alloc-budget/design.md
@@ -99,3 +99,31 @@ the ratchet adjudicate L4**, vs. requiring a speculative L4 hoist up front.
   non-deterministic). Confirmed no ordering assertion downstream.
 - **Feature gating** — the test must be gated `#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]`
   to match the allocator's gate, else it fails to find `measure` under a dhat build.
+
+
+---
+
+## Amendments during implementation (2026-07-26)
+
+Three of this design's assumptions did not survive contact with the code. Recorded here so the
+design reads as what was actually built, not what was planned.
+
+1. **Decision 2's negative controls were half wrong.** #1447/#1445/#1446 are **binding-layer** fixes
+   (Node `ExecuteNativeTask::compute`, Node JsString interning, Python `Row` ordering), not
+   `cqlite-core` ones, so no test in this crate can gate them. Measured: reverting clone→move inside
+   `build_row_from_scan_cached` is exactly allocation-neutral (41 vs 41 narrow, 273 vs 273 wide) —
+   `Value::Text` is `Bytes`-backed (clone = refcount bump) and `Value::into_owned`'s TIER-1
+   compaction (#1644) copies a small payload either way. The clone control was therefore DROPPED as
+   vacuous rather than asserted; the intern control (#1334) is kept and is strong (+2 allocations per
+   cell). Binding-layer probe → **#2894**.
+2. **Decision 4's "L5 preserves the call boundary" was wrong.** `row_values` moves directly into
+   `QueryRow.values`, so the hasher swap is necessarily a **public type change**. It was implemented
+   (via a `RowValues` alias, rippling through cqlite-core/cqlite-flight/cqlite-cli) and then
+   **reverted before merge**: it also contradicts the `rustc-hash` invariant in
+   `cqlite-core/Cargo.toml` (#1590 E8 — not for untrusted string keys; column names come from the
+   file's serialization header on the default path), and no benchmark was run to quantify the win.
+   Deferred to **#2901**. Corollary worth recording: the alloc ratchet is **hasher-independent**
+   (identical 41/273 either way), so it could never have served as L5's wiring evidence — a
+   `type_name_of_val(row.values.hasher())` assertion was needed for that.
+3. **L4 is a measured 1.0× no-op**, as Decision 4 allowed for: the partition-key path costs zero
+   per-row allocations (`RowKey` is `Arc<[u8]>`; `PartitionKeyCache` #1817 hoists the decode).

--- a/openspec/changes/rust-per-row-alloc-budget/design.md
+++ b/openspec/changes/rust-per-row-alloc-budget/design.md
@@ -1,0 +1,101 @@
+# Design: Rust per-row allocation-budget ratchet + L5 FxHash row map
+
+## Context
+
+`build_row_from_scan_cached` (`cqlite-core/src/query/select_executor/row_build.rs:227`) is the single
+per-row conversion the query engine runs for every scanned row before it reaches the CLI / bindings. It:
+
+- builds a per-row `HashMap<Arc<str>, Value>` (`row_build.rs:246`, capacity-hinted), currently **std
+  SipHash**;
+- inserts projected cell values (`.into_owned()`, `row_build.rs:259`) — this is where #1447 reverted a
+  clone into a move;
+- inserts partition-key columns from the **already-memoized** `PartitionKeyCache` (`row_build.rs:270`,
+  #1817) — the partition-constant decode is hoisted here, not per row.
+
+Two independent alloc-observability facts drive the design:
+
+1. **The counting allocator already exists.** `cqlite-core/src/lib.rs:82` defines `test_alloc_probe` with
+   a thread-local `CountingAllocator` set as `#[global_allocator]` under
+   `#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]`, exposing
+   `measure<R>(f) -> (u64 allocations, R)`. `state_machine` is a **default** feature, so this is live in
+   the ordinary `cargo test -p cqlite-core` build. Precedent test:
+   `lookup.rs:822 cartesian_product_builds_each_combo_in_one_allocation` already asserts allocation counts
+   with it.
+2. **dhat is the wrong tool here and is mutually exclusive.** `dhat::Alloc` (lib.rs:144) is a second
+   `#[global_allocator]`, only under `feature = "dhat-heap"` (non-default), and a binary may have exactly
+   one global allocator. It measures *bytes* (`HeapStats`) for the streaming lane, not a deterministic
+   per-call *count*. A count ratchet wants the counting allocator.
+
+## Decision 1 — Instrument with `test_alloc_probe::measure`, not dhat
+
+**Chosen.** Reuse the in-crate counting allocator. Rationale:
+
+- It yields a **deterministic integer** (`allocations`), so the ratchet is an exact `<=` / `==` assert, not
+  a noisy byte budget — this is exactly why the binding-layer byte budgets failed to observe #1447.
+- It is **already in the default test build** (`state_machine` default) — no new feature, no new gate lane,
+  no second harness (honoring the issue's "coordinate, don't build a second harness").
+- It has a **working precedent** (`lookup.rs:822`) to copy structure from.
+
+**Rejected — dhat-heap lane** (the "parser epic H H2" pattern). Would require: a non-default feature build
+(`--features write-support,dhat-heap`), a separate CI lane, byte-granular (noisier) assertions, and it
+**conflicts** with the counting allocator (can't have both global allocators). The M4 issue floated dhat
+"or a custom counting global allocator" — the custom counting allocator already exists and is strictly
+better for a count ratchet. dhat stays reserved for `streaming_dhat_test.rs` (byte-level streaming).
+
+## Decision 2 — Drive the real public conversion surface (wiring-evidence)
+
+**Chosen.** The test calls the public `build_row_from_scan_cached` (re-exported at
+`select_executor/mod.rs:99`) inside `measure(...)`, over a synthesized wide cell set + a real
+`PartitionKeyCache`, asserting allocs/row. This is the actual per-row surface the engine runs — not a
+private helper — so a regression on the hot path (a re-introduced clone, a lost intern) is observed.
+
+Two fixtures:
+- **narrow** (few columns) — pins the fixed per-row cost;
+- **wide** (many columns) — pins the per-cell scaling, where a per-cell key allocation (the #1445/#1446
+  revert) shows up as `allocs growing with column count`.
+
+**Negative controls, documented in-test** (not committed as code, described as comments with measured
+deltas): reverting #1447 (`.iter().map(clone)` instead of `into_iter`) adds N per-row allocations;
+dropping key interning adds one alloc per projected cell. The baseline is set just below those so the
+revert trips it.
+
+## Decision 3 — Baseline: measured `<=`, asserted per-row, tolerance-free where deterministic
+
+**Chosen.** Run the harness, record the observed `allocations` for narrow + wide, and assert
+`allocs <= observed` (with the count divided per row where the fixture is multi-row). The counting
+allocator is deterministic for a fixed input, so no statistical tolerance is needed (unlike the V8/tracemalloc
+byte budgets). Document the exact numbers in-test and in the throughput-program doc. If a platform-dependent
+allocation (e.g. capacity rounding) proves non-deterministic across targets, fall back to a small explicit
+slack **documented with the reason** — not a silent fudge.
+
+## Decision 4 — L5 (FxHashMap) folded in; L4 adjudicated by measurement, not pre-committed
+
+**L5 (chosen, committed):** change `row_build.rs:246` `HashMap<Arc<str>, Value>` →
+`rustc_hash::FxHashMap<Arc<str>, Value>` (dep already present, already used at `aggregation.rs:20`).
+`FxHashMap::default()` + `.reserve(cap)` or `FxHashMap::with_capacity_and_hasher(cap, Default::default())`
+preserves the capacity hint. The alloc-budget test asserts this swap adds **no** per-row allocation (hasher
+is inline, no heap state) — so L5's win is a hashing-cost win the profile shows, with the ratchet proving
+alloc-neutrality. Same-signature return type at the call boundary is preserved (callers iterate the map;
+`FxHashMap` is a drop-in `HashMap<_,_,FxBuildHasher>`).
+
+**L4 (surfaced, not committed):** per the Problem section — the partition-constant decode is already
+hoisted (#1817) and the residual `RowKey(Arc<[u8]>)` is genuinely per-row and moved. The new ratchet
+**measures** whether any hoistable per-row `Arc` clone remains. Outcome recorded in the throughput doc:
+- if the measured count reveals a hoistable clone → file a concrete L4 follow-up issue with the exact
+  site;
+- if the count is already minimal → L4 credited **1.0× / no-op**, matching the manager's own
+  "1.0× credited … do not claim a field win the profile can't support."
+
+This is the design question for the owner at Seam 1: **approve delivering the ratchet + L5 now and letting
+the ratchet adjudicate L4**, vs. requiring a speculative L4 hoist up front.
+
+## Risks / mitigations
+
+- **Counting-allocator determinism across platforms** — mitigate with the documented-slack fallback
+  (Decision 3); the precedent test (`lookup.rs:822`) already runs cross-platform in CI, so the mechanism is
+  proven.
+- **FxHashMap iteration-order change** — `row_values` is consumed as a map (keyed lookups / full
+  iteration into the binding object); no code depends on `HashMap` iteration order (already
+  non-deterministic). Confirmed no ordering assertion downstream.
+- **Feature gating** — the test must be gated `#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]`
+  to match the allocator's gate, else it fails to find `measure` under a dhat build.

--- a/openspec/changes/rust-per-row-alloc-budget/proposal.md
+++ b/openspec/changes/rust-per-row-alloc-budget/proposal.md
@@ -1,0 +1,99 @@
+# Proposal: Rust-side per-row allocation budget (counting-allocator ratchet) + L5 FxHash row map
+
+## Milestone / theme
+0.17 (milestone #14) — scan-path throughput program, epic #2817 manifest item **M4**. Closes issue #1883.
+
+## Routing
+**Design-driven** (new test lane + measured baseline + hot-path structural change). The alloc-count
+_verdict_ itself is oracle-ish once the harness is shaped (an exact allocation count is a hard number),
+but the harness design, the baseline choice, and the L4/L5 scope are design decisions — hence OpenSpec.
+
+## Problem
+
+#1449 added binding-layer per-row budget tests (Python `tracemalloc`, Node V8 `heapUsed` delta, a Rust
+`#[cfg(test)]` Set/Map ctor-lookup counter) and **empirically proved** those tests **cannot observe** two
+of the W-fixes they were meant to pin:
+
+- **#1447 (clone→move)**: the reverted clone is a transient *Rust-heap* allocation freed inside
+  `executeNative()`/`execute()` before any post-execute V8/Python heap sample. Reverting #1447 moved the
+  Node median 1335.0 → 1333.8 B/row — noise.
+- **#1445/#1446 (key interning)**: emitting fresh key strings per cell didn't move the number either — V8
+  internally dedups property-name strings; Python `tracemalloc` was similarly blind.
+
+The binding-layer budgets legitimately pin the **gross per-row value graph** (a value-graph-doubling
+regression goes RED) and the **Set/Map ctor-lookup count** — but the **transient native-allocation**
+dimension is physically unobservable from the JS/Python heap. A regression that re-introduces a per-row
+clone or drops key interning would ship green.
+
+## Goal
+
+Add a **Rust-side per-row allocation budget** that CAN observe transient native allocations, using the
+**existing in-crate `test_alloc_probe::measure`** counting allocator (`cqlite-core/src/lib.rs:82`), so the
+row-conversion hot path (`build_row_from_scan_cached`, `row_build.rs:227`) gets an **allocation-count
+ratchet**: reverting #1447 (into_iter→iter().clone()) OR dropping the key interning makes the test go RED;
+restoring it green. Baseline is **measured and asserted as an exact/≤ count**, not a fuzzy byte budget.
+
+Fold in the one cheap, profile-supportable row-hot-path win from epic #2817 M4:
+
+- **L5 — FxHash `row_values` map**: swap the per-row `HashMap<Arc<str>, Value>` (SipHash,
+  `row_build.rs:246`) to `FxHashMap` using the **already-vendored** `rustc-hash = "1.1"`
+  (`cqlite-core/Cargo.toml:76`, already used at `aggregation.rs:20`). SipHash disappears from the row hot
+  path. Expected ~1.04× narrow & wide; the alloc-budget test does not regress (hasher swap is
+  alloc-neutral — the ratchet's job here is to prove L5 introduces no new per-row allocation).
+
+## L4 — surfaced, not committed (a design question for the owner)
+
+The manager order (2026-07-22) bundled **L4 — RowKey Arc hoist** ("hoist the `RowKey(Arc<[u8]>)` build
+outside `for entry in rows`"). Investigation of the current tree shows the L4 premise is **largely already
+satisfied**:
+
+- The partition-constant work (decoding pk columns from `key.0`) is **already hoisted** across a
+  partition's rows by `PartitionKeyCache` (#1817), created once per row loop and threaded through
+  (`execute.rs:638`, `streaming.rs:138`).
+- The remaining per-row `RowKey(Arc<[u8]>)` is **genuinely per-row** — each row carries its own key from
+  the scan window (`scan_stream_windowed.rs`), and inside `build_row_from_scan_cached` the key is only
+  **read** (`pk_cache.columns_for(&key.0, …)`) then **moved** into `QueryRow.key` (`row_build.rs:279`), not
+  re-allocated.
+
+So there is **no obvious remaining per-row `Arc` allocation to hoist** in the conversion function itself.
+The honest position: **the new alloc-budget ratchet is the correct instrument to adjudicate L4** — it will
+report the exact per-row allocation count, and *if* that count reveals a hoistable per-row `Arc` clone, L4
+becomes a concrete follow-up; if the count is already minimal, L4 is credited **1.0× / no-op** (which the
+manager order already anticipated: "1.0× credited on single-row-partition — do not claim a field win the
+profile can't support"). **This proposal delivers the ratchet + L5, measures the per-row count, and reports
+the L4 verdict from that measurement** rather than pre-committing a hoist the code may not need.
+
+## Approach (chosen — see design.md for alternatives)
+
+1. Add a `#[cfg(test)]` per-row allocation-budget test in `cqlite-core` that drives the **real public**
+   `build_row_from_scan_cached` conversion (mod.rs:99) inside `test_alloc_probe::measure(...)` over a wide
+   result, asserting `allocations / row <= MEASURED_BASELINE`. Mirrors the existing precedent
+   `lookup.rs:822 cartesian_product_builds_each_combo_in_one_allocation`.
+2. Add a **negative-control** assertion structure: the test is shaped so that re-introducing a per-row
+   clone (the #1447 revert) or a per-cell fresh-key allocation (the #1445/#1446 revert) pushes the count
+   over budget — documented in-test with the exact deltas.
+3. Apply **L5** (FxHashMap for `row_values`) and confirm the alloc budget is unchanged (hasher swap adds
+   no per-row allocation) while SipHash leaves the row hot-path profile.
+4. Document the **measured baseline** (allocs/row for narrow + wide fixtures) in the test and in the M4
+   section of `docs/architecture/throughput-program-2026-07.md`.
+
+## Non-goals
+
+- **NOT** a dhat-heap lane. `test_alloc_probe::measure` (counting allocator) and `dhat::Alloc` are
+  **mutually-exclusive** `#[global_allocator]`s (one per binary); the counting allocator is the right tool
+  for a deterministic *count* ratchet and is already gated into the default test build. dhat stays reserved
+  for the byte-level streaming heap-stats lane (`streaming_dhat_test.rs`).
+- **NOT** a new alloc harness. Reuse `test_alloc_probe::measure` — "coordinate, don't build a second
+  harness" (issue note).
+- **NOT** the binding-layer budgets — those stay as the gross-value-graph + ctor ratchets (#1449); this
+  closes the transient-native-alloc gap they physically can't cover.
+- **NOT** an unconditional L4 hoist — L4 is adjudicated by the new ratchet's measurement (see above).
+- **NOT** a change to the no-heuristics decode path, write path, or any public API signature.
+
+## Doctrine impact
+
+- **Wiring-evidence**: the ratchet drives the real public `build_row_from_scan_cached` conversion surface,
+  not a helper — a value-graph or clone regression on the row hot path fails a test.
+- **Gate**: adds a `cqlite-core` test target; no new gate component required (runs under the existing
+  core-tests component, `state_machine` feature already default).
+- Updates `docs/architecture/throughput-program-2026-07.md` §7 M4 with the measured baseline + L4 verdict.

--- a/openspec/changes/rust-per-row-alloc-budget/proposal.md
+++ b/openspec/changes/rust-per-row-alloc-budget/proposal.md
@@ -38,7 +38,7 @@ Fold in the one cheap, profile-supportable row-hot-path win from epic #2817 M4:
 - **L5 — FxHash `row_values` map**: swap the per-row `HashMap<Arc<str>, Value>` (SipHash,
   `row_build.rs:246`) to `FxHashMap` using the **already-vendored** `rustc-hash = "1.1"`
   (`cqlite-core/Cargo.toml:76`, already used at `aggregation.rs:20`). SipHash disappears from the row hot
-  path. Expected ~1.04× narrow & wide; the alloc-budget test does not regress (hasher swap is
+  path. (SUPERSEDED — L5 deferred to #2901, no measured win claimed) Expected ~1.04× narrow & wide; the alloc-budget test does not regress (hasher swap is
   alloc-neutral — the ratchet's job here is to prove L5 introduces no new per-row allocation).
 
 ## L4 — surfaced, not committed (a design question for the owner)

--- a/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
+++ b/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
@@ -21,8 +21,10 @@ slack SHALL be documented with its reason.
 - **GIVEN** a synthesized wide result (a `PartitionKeyCache` plus a set of projected cells) representative
   of a scan row
 - **WHEN** `build_row_from_scan_cached` is invoked inside `test_alloc_probe::measure`
-- **THEN** the reported allocation count divided by the number of rows converted is less than or equal to
-  the documented measured baseline
+- **THEN** the reported allocation count is less than or equal to a measured budget of the form
+  `one-time setup + rows * (per-row + per-cell * columns)`, where the one-time term is held SEPARATE from
+  the per-row term rather than amortized into it — a per-row quotient would fold the first row's
+  `PartitionKeyCache` miss into the steady-state rate and make the budget valid at only one row count
 - **AND** the same assertion holds for both a narrow (few-column) and a wide (many-column) fixture
 
 #### Scenario: The counting-allocator test lane is available in the default test build

--- a/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
+++ b/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
@@ -33,10 +33,11 @@ slack SHALL be documented with its reason.
 
 ### Requirement: The ratchet turns the row-conversion allocation properties this crate owns into regression gates
 
-The per-row allocation-budget test SHALL be shaped so that emitting fresh per-cell key strings — reverting the
-`Arc<str>` column-name interning the conversion relies on (#1334) — pushes the measured allocation count above
-the baseline, failing the test; restoring the intern returns it to green. The negative-control delta SHALL be
-documented in-test.
+The per-row allocation-budget test SHALL gate BOTH allocation properties this conversion owns, each with its own
+differential control asserted by a strict `<` against a reference implementation of the pre-fix behaviour (an
+absolute constant alone is insufficient — a constant can be re-measured upward by a later reader, a differential
+cannot): (a) per-cell `Arc<str>` column-name interning (#1334), and (b) the single sized value map (#1584).
+Restoring each fix returns the test to green. The negative-control deltas SHALL be documented in-test.
 
 **Scope correction (measured, supersedes the original #1447/#1445/#1446 framing).** #1883 was filed on the
 premise that this ratchet would gate #1447 (clone→move) and #1445/#1446 (key interning). Those three fixes are
@@ -56,6 +57,12 @@ binding crates, tracked as follow-up issue #2894.
 - **THEN** the measured allocations grow with the projected-column count and exceed the baseline, failing the
   test (measured: narrow 41 → 89, wide 273 → 785, exactly +2 allocations per cell)
 - **AND** restoring the interned handle returns the test to PASS
+
+#### Scenario: Dropping the row map's capacity hint trips the budget
+- **GIVEN** the per-row allocation-budget test at its measured baseline
+- **WHEN** the row-value map is built unsized (`HashMap::new()`) instead of capacity-hinted (#1584)
+- **THEN** rehash growth adds one allocation per row and the test FAILS (measured: narrow 41 → 49)
+- **AND** restoring the capacity hint returns the test to PASS
 
 #### Scenario: The clone→move control is recorded as measured-neutral rather than asserted
 - **GIVEN** the per-row allocation-budget test at its measured baseline

--- a/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
+++ b/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
@@ -1,0 +1,84 @@
+# row-conversion-alloc-budget
+
+## ADDED Requirements
+
+### Requirement: A per-row allocation-count ratchet observes transient native allocations on the row-conversion hot path
+
+CQLite SHALL provide a `cqlite-core` test that measures the number of heap allocations performed by the
+public per-row conversion `build_row_from_scan_cached` (re-exported at `select_executor/mod.rs`) using the
+in-crate counting global allocator (`crate::test_alloc_probe::measure`), and SHALL assert that the
+allocations-per-row do not exceed a **measured, documented baseline**. The test SHALL drive the real public
+conversion surface (not a private helper), so a regression on the row hot path is observed end-to-end. The
+test SHALL be gated to the counting-allocator build
+(`#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]`) so it never conflicts with the
+mutually-exclusive dhat global allocator.
+
+The measured baseline SHALL be recorded in-test (exact allocation counts for a narrow and a wide fixture)
+and SHALL be tolerance-free where the counting allocator is deterministic for the fixed input; any explicit
+slack SHALL be documented with its reason.
+
+#### Scenario: The per-row conversion stays within the measured allocation budget
+- **GIVEN** a synthesized wide result (a `PartitionKeyCache` plus a set of projected cells) representative
+  of a scan row
+- **WHEN** `build_row_from_scan_cached` is invoked inside `test_alloc_probe::measure`
+- **THEN** the reported allocation count divided by the number of rows converted is less than or equal to
+  the documented measured baseline
+- **AND** the same assertion holds for both a narrow (few-column) and a wide (many-column) fixture
+
+#### Scenario: The counting-allocator test lane is available in the default test build
+- **GIVEN** the default `cqlite-core` feature set (which includes `state_machine`) and no `dhat-heap`
+  feature
+- **WHEN** `cargo test -p cqlite-core` runs
+- **THEN** the per-row allocation-budget test is compiled and executed (it is not silently skipped)
+
+### Requirement: The ratchet turns the #1447 clone→move and #1445/#1446 interning fixes into regression gates
+
+The per-row allocation-budget test SHALL be shaped so that re-introducing a per-row value clone (reverting
+#1447 `into_iter`→`iter().clone()`) OR emitting fresh per-cell key strings (reverting the #1445/#1446 key
+interning) pushes the measured allocation count above the baseline, failing the test; restoring the fixes
+returns it to green. The negative-control deltas (how many allocations each revert adds) SHALL be documented
+in-test.
+
+#### Scenario: Reverting the clone→move fix trips the budget
+- **GIVEN** the per-row allocation-budget test at its measured baseline
+- **WHEN** the row-conversion value insert is changed from a move (`into_owned`/`into_iter`) back to a
+  per-row clone
+- **THEN** the measured allocations-per-row exceed the baseline and the test FAILS
+- **AND** reverting that change back to the move returns the test to PASS
+
+#### Scenario: Dropping per-cell key interning trips the budget on the wide fixture
+- **GIVEN** the per-row allocation-budget test at its measured baseline
+- **WHEN** the key handling is changed to allocate a fresh key string per projected cell instead of reusing
+  the interned `Arc<str>`
+- **THEN** the measured allocations grow with the projected-column count and exceed the wide-fixture
+  baseline, failing the test
+
+### Requirement: The row-conversion map uses a non-cryptographic hasher without adding per-row allocations (L5)
+
+The per-row `row_values` map in `build_row_from_scan_cached` SHALL use `rustc_hash::FxHashMap`
+(the workspace's already-vendored `rustc-hash` dependency) instead of the default SipHash `HashMap`, so
+SipHash is removed from the row hot path. This change SHALL preserve the capacity hint and SHALL NOT change
+the conversion's observable output (same keys, same values, same row shape). The per-row allocation-budget
+ratchet SHALL confirm the hasher swap adds no per-row allocation (alloc-neutral).
+
+#### Scenario: FxHashMap swap is output-equivalent and alloc-neutral
+- **GIVEN** a scan result converted by `build_row_from_scan_cached`
+- **WHEN** the `row_values` map is backed by `FxHashMap` (capacity-hinted) rather than std `HashMap`
+- **THEN** the produced row has identical keys and values to the std-`HashMap` behaviour
+- **AND** the per-row allocation-budget test still passes at (or below) its baseline — the hasher swap adds
+  no per-row heap allocation
+
+### Requirement: The L4 RowKey-hoist question is adjudicated by the ratchet's measurement, not by a speculative hoist
+
+The change SHALL record, in `docs/architecture/throughput-program-2026-07.md` §7 M4, the per-row allocation
+count measured by the new ratchet and the resulting **L4 verdict**: either a concrete follow-up issue naming
+the exact hoistable per-row `Arc` allocation site (if the measurement reveals one) OR an explicit
+**1.0× / no-op** credit for L4 (if the measurement shows the residual `RowKey(Arc<[u8]>)` is already
+per-row-minimal, the partition-constant decode already being hoisted by `PartitionKeyCache` #1817). The
+change SHALL NOT claim an L4 field win the profile cannot support.
+
+#### Scenario: The throughput-program doc records the measured L4 verdict
+- **GIVEN** the per-row allocation-budget ratchet has measured the conversion's allocations-per-row
+- **WHEN** `docs/architecture/throughput-program-2026-07.md` §7 M4 is updated
+- **THEN** it states the measured allocations-per-row and either links a concrete L4 follow-up issue or
+  records L4 as a measured 1.0×/no-op — with no unsupported field-win claim

--- a/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
+++ b/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
@@ -31,42 +31,62 @@ slack SHALL be documented with its reason.
 - **WHEN** `cargo test -p cqlite-core` runs
 - **THEN** the per-row allocation-budget test is compiled and executed (it is not silently skipped)
 
-### Requirement: The ratchet turns the #1447 clone→move and #1445/#1446 interning fixes into regression gates
+### Requirement: The ratchet turns the row-conversion allocation properties this crate owns into regression gates
 
-The per-row allocation-budget test SHALL be shaped so that re-introducing a per-row value clone (reverting
-#1447 `into_iter`→`iter().clone()`) OR emitting fresh per-cell key strings (reverting the #1445/#1446 key
-interning) pushes the measured allocation count above the baseline, failing the test; restoring the fixes
-returns it to green. The negative-control deltas (how many allocations each revert adds) SHALL be documented
-in-test.
+The per-row allocation-budget test SHALL be shaped so that emitting fresh per-cell key strings — reverting the
+`Arc<str>` column-name interning the conversion relies on (#1334) — pushes the measured allocation count above
+the baseline, failing the test; restoring the intern returns it to green. The negative-control delta SHALL be
+documented in-test.
 
-#### Scenario: Reverting the clone→move fix trips the budget
-- **GIVEN** the per-row allocation-budget test at its measured baseline
-- **WHEN** the row-conversion value insert is changed from a move (`into_owned`/`into_iter`) back to a
-  per-row clone
-- **THEN** the measured allocations-per-row exceed the baseline and the test FAILS
-- **AND** reverting that change back to the move returns the test to PASS
+**Scope correction (measured, supersedes the original #1447/#1445/#1446 framing).** #1883 was filed on the
+premise that this ratchet would gate #1447 (clone→move) and #1445/#1446 (key interning). Those three fixes are
+**binding-layer**: #1447 is `bindings/node/src/database.rs` (`ExecuteNativeTask::compute`), #1446 is Node
+JsString interning, #1445 is Python `Row` ordering. No `cqlite-core` test can gate code in the binding crates.
+Measured directly: reverting the clone→move *inside `build_row_from_scan_cached`* is **exactly
+allocation-neutral** (41 vs 41 narrow, 273 vs 273 wide), because `Value::Text` is `Bytes`-backed (clone is a
+refcount bump) and `Value::into_owned`'s TIER-1 compaction (#1644) copies a small payload either way. A clone
+control here would therefore be VACUOUS. The test SHALL NOT assert a control it cannot make fail, and SHALL
+document this measurement in-test. Ratcheting #1447/#1445/#1446 requires an allocation probe inside the
+binding crates, tracked as follow-up issue #2894.
 
-#### Scenario: Dropping per-cell key interning trips the budget on the wide fixture
+#### Scenario: Dropping per-cell key interning trips the budget
 - **GIVEN** the per-row allocation-budget test at its measured baseline
 - **WHEN** the key handling is changed to allocate a fresh key string per projected cell instead of reusing
   the interned `Arc<str>`
-- **THEN** the measured allocations grow with the projected-column count and exceed the wide-fixture
-  baseline, failing the test
+- **THEN** the measured allocations grow with the projected-column count and exceed the baseline, failing the
+  test (measured: narrow 41 → 89, wide 273 → 785, exactly +2 allocations per cell)
+- **AND** restoring the interned handle returns the test to PASS
 
-### Requirement: The row-conversion map uses a non-cryptographic hasher without adding per-row allocations (L5)
+#### Scenario: The clone→move control is recorded as measured-neutral rather than asserted
+- **GIVEN** the per-row allocation-budget test at its measured baseline
+- **WHEN** the row-conversion value insert is changed from a move (`into_owned`) back to a per-cell clone
+- **THEN** the measured allocation count is UNCHANGED (the fix is not observable in this crate)
+- **AND** the test documents that measurement and its cause instead of asserting a vacuous control
 
-The per-row `row_values` map in `build_row_from_scan_cached` SHALL use `rustc_hash::FxHashMap`
-(the workspace's already-vendored `rustc-hash` dependency) instead of the default SipHash `HashMap`, so
-SipHash is removed from the row hot path. This change SHALL preserve the capacity hint and SHALL NOT change
-the conversion's observable output (same keys, same values, same row shape). The per-row allocation-budget
-ratchet SHALL confirm the hasher swap adds no per-row allocation (alloc-neutral).
+### Requirement: L5 (FxHashMap row map) is DEFERRED, not delivered in this change
 
-#### Scenario: FxHashMap swap is output-equivalent and alloc-neutral
-- **GIVEN** a scan result converted by `build_row_from_scan_cached`
-- **WHEN** the `row_values` map is backed by `FxHashMap` (capacity-hinted) rather than std `HashMap`
-- **THEN** the produced row has identical keys and values to the std-`HashMap` behaviour
-- **AND** the per-row allocation-budget test still passes at (or below) its baseline — the hasher swap adds
-  no per-row heap allocation
+L5 — swapping the per-row `row_values` map to `rustc_hash::FxHashMap` — was implemented during this change and
+then **deliberately reverted before merge** on the owner's decision. It SHALL NOT ship here. Two facts, both
+discovered by implementing it, drove the reversal:
+
+1. **It is a PUBLIC breaking API change.** `row_values` moves directly into `QueryRow.values`, so the hasher
+   cannot change without changing that public field's type (the working implementation added
+   `pub type RowValues` and rippled through `cqlite-core`, `cqlite-flight` and `cqlite-cli`).
+2. **It contradicts a written invariant.** `cqlite-core/Cargo.toml` reserves `rustc-hash` for
+   "integer/digest-keyed hot-path maps only — NOT for maps exposed to untrusted string keys (#1590, E8)".
+   `QueryRow.values` is string-keyed, and on the default read path those column names come from the file's
+   `Statistics.db` serialization header — attacker-controlled for a hostile SSTable, where FxHash's easy
+   collisions give O(N²) per-row inserts.
+
+Combined with the fact that **no row-conversion benchmark was run** (so the projected ~1.04× stayed a
+projection), the change SHALL NOT claim an L5 win. Revisiting L5 — behind a measured benchmark, a HashDoS
+answer, and an API plan — is tracked as issue #2901.
+
+#### Scenario: The row map keeps its default hasher in this change
+- **GIVEN** the per-row conversion `build_row_from_scan_cached`
+- **WHEN** this change is merged
+- **THEN** `QueryRow.values` is still the default-hasher `HashMap<Arc<str>, Value>` (no public type change)
+- **AND** no throughput multiplier is claimed for L5 anywhere in the change's docs
 
 ### Requirement: The L4 RowKey-hoist question is adjudicated by the ratchet's measurement, not by a speculative hoist
 

--- a/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
+++ b/openspec/changes/rust-per-row-alloc-budget/specs/row-conversion-alloc-budget/spec.md
@@ -6,8 +6,10 @@
 
 CQLite SHALL provide a `cqlite-core` test that measures the number of heap allocations performed by the
 public per-row conversion `build_row_from_scan_cached` (re-exported at `select_executor/mod.rs`) using the
-in-crate counting global allocator (`crate::test_alloc_probe::measure`), and SHALL assert that the
-allocations-per-row do not exceed a **measured, documented baseline**. The test SHALL drive the real public
+in-crate counting global allocator (`crate::test_alloc_probe::measure`), and SHALL assert that the total
+allocations do not exceed a **measured, documented baseline** of the form
+`one-time setup + rows * (per-row + per-cell * columns)` — the one-time term held SEPARATE from the per-row
+rate, never amortized into it. The test SHALL drive the real public
 conversion surface (not a private helper), so a regression on the row hot path is observed end-to-end. The
 test SHALL be gated to the counting-allocator build
 (`#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]`) so it never conflicts with the

--- a/openspec/changes/rust-per-row-alloc-budget/tasks.md
+++ b/openspec/changes/rust-per-row-alloc-budget/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — Rust per-row allocation-budget ratchet + L5 FxHash row map
+
+## 1. Baseline measurement (informs the assert, no code change yet)
+- [ ] 1.1 Write a throwaway harness driving `build_row_from_scan_cached` (surface: `select_executor/mod.rs`)
+      inside `test_alloc_probe::measure` over a narrow + a wide synthesized result; record allocations/row.
+- [ ] 1.2 Record the negative-control deltas: allocations added by (a) reverting #1447 into_iter→clone,
+      (b) allocating a fresh key string per cell. Confirm each pushes over the observed baseline.
+
+## 2. The alloc-budget ratchet test (surface: public `build_row_from_scan_cached`)
+- [ ] 2.1 Add `#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]` test(s) in
+      `cqlite-core/src/query/select_executor/` (near `row_build.rs` / mirroring `lookup.rs:822`) asserting
+      `allocs/row <= MEASURED_BASELINE` for narrow + wide fixtures.
+- [ ] 2.2 Document in-test: the measured baseline numbers, the negative-control deltas, and why the assert is
+      tolerance-free (deterministic counting allocator) — or the documented slack + reason if not.
+- [ ] 2.3 Confirm the test compiles + runs under the default feature set (`cargo test -p cqlite-core`),
+      i.e. it is not silently skipped.
+
+## 3. L5 — FxHashMap for row_values (surface: `row_build.rs:246`)
+- [ ] 3.1 Swap `HashMap<Arc<str>, Value>` → `rustc_hash::FxHashMap<Arc<str>, Value>` (dep already in
+      `cqlite-core/Cargo.toml:76`), preserving the capacity hint (`with_capacity_and_hasher` /
+      `default()`+`reserve`).
+- [ ] 3.2 Confirm output-equivalence (same keys/values/shape) and that the alloc-budget ratchet still passes
+      at/below baseline (alloc-neutral hasher swap).
+- [ ] 3.3 Check no downstream code depends on `HashMap` iteration order (it is already non-deterministic).
+
+## 4. L4 verdict + docs (surface: throughput-program doc)
+- [ ] 4.1 From the measured per-row allocation count, decide the L4 verdict: file a concrete follow-up issue
+      (exact hoistable site) OR credit L4 as a measured 1.0×/no-op.
+- [ ] 4.2 Update `docs/architecture/throughput-program-2026-07.md` §7 M4 with the measured allocations/row +
+      the L4 verdict + the L5 result. Update CLAUDE.md only if a user-facing surface changed (it does not).
+
+## 5. Gate / review / audit (endgame — via flow-implement → flow-closer)
+- [ ] 5.1 `scripts/agent-gate.sh --lite` green each fix round (summary-file redirect).
+- [ ] 5.2 Review-first on the lite-green diff: `rust-reviewer` + roborev; triage blockers/nits per
+      `docs/development/roborev-severity.md`.
+- [ ] 5.3 Open PR (`Closes #1883`).
+- [ ] 5.4 flow-closer: ONE full `scripts/agent-gate.sh` → C (`spec-auditor` anchored to
+      `openspec/changes/rust-per-row-alloc-budget/specs/**`) → final roborev → merge-on-green → finalize.

--- a/openspec/changes/rust-per-row-alloc-budget/tasks.md
+++ b/openspec/changes/rust-per-row-alloc-budget/tasks.md
@@ -1,32 +1,32 @@
 # Tasks — Rust per-row allocation-budget ratchet + L5 FxHash row map
 
 ## 1. Baseline measurement (informs the assert, no code change yet)
-- [ ] 1.1 Write a throwaway harness driving `build_row_from_scan_cached` (surface: `select_executor/mod.rs`)
+- [x] 1.1 Write a throwaway harness driving `build_row_from_scan_cached` (surface: `select_executor/mod.rs`)
       inside `test_alloc_probe::measure` over a narrow + a wide synthesized result; record allocations/row.
-- [ ] 1.2 Record the negative-control deltas: allocations added by (a) reverting #1447 into_iter→clone,
+- [x] 1.2 Record the negative-control deltas: allocations added by (a) reverting #1447 into_iter→clone,
       (b) allocating a fresh key string per cell. Confirm each pushes over the observed baseline.
 
 ## 2. The alloc-budget ratchet test (surface: public `build_row_from_scan_cached`)
-- [ ] 2.1 Add `#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]` test(s) in
+- [x] 2.1 Add `#[cfg(all(test, feature = "state_machine", not(feature = "dhat-heap")))]` test(s) in
       `cqlite-core/src/query/select_executor/` (near `row_build.rs` / mirroring `lookup.rs:822`) asserting
       `allocs/row <= MEASURED_BASELINE` for narrow + wide fixtures.
-- [ ] 2.2 Document in-test: the measured baseline numbers, the negative-control deltas, and why the assert is
+- [x] 2.2 Document in-test: the measured baseline numbers, the negative-control deltas, and why the assert is
       tolerance-free (deterministic counting allocator) — or the documented slack + reason if not.
-- [ ] 2.3 Confirm the test compiles + runs under the default feature set (`cargo test -p cqlite-core`),
+- [x] 2.3 Confirm the test compiles + runs under the default feature set (`cargo test -p cqlite-core`),
       i.e. it is not silently skipped.
 
 ## 3. L5 — FxHashMap for row_values (surface: `row_build.rs:246`)
-- [ ] 3.1 Swap `HashMap<Arc<str>, Value>` → `rustc_hash::FxHashMap<Arc<str>, Value>` (dep already in
+- [~] 3.1 (REVERTED — see notes) Swap `HashMap<Arc<str>, Value>` → `rustc_hash::FxHashMap<Arc<str>, Value>` (dep already in
       `cqlite-core/Cargo.toml:76`), preserving the capacity hint (`with_capacity_and_hasher` /
       `default()`+`reserve`).
-- [ ] 3.2 Confirm output-equivalence (same keys/values/shape) and that the alloc-budget ratchet still passes
+- [~] 3.2 (REVERTED) Confirm output-equivalence (same keys/values/shape) and that the alloc-budget ratchet still passes
       at/below baseline (alloc-neutral hasher swap).
-- [ ] 3.3 Check no downstream code depends on `HashMap` iteration order (it is already non-deterministic).
+- [~] 3.3 (REVERTED) Check no downstream code depends on `HashMap` iteration order (it is already non-deterministic).
 
 ## 4. L4 verdict + docs (surface: throughput-program doc)
-- [ ] 4.1 From the measured per-row allocation count, decide the L4 verdict: file a concrete follow-up issue
+- [x] 4.1 From the measured per-row allocation count, decide the L4 verdict: file a concrete follow-up issue
       (exact hoistable site) OR credit L4 as a measured 1.0×/no-op.
-- [ ] 4.2 Update `docs/architecture/throughput-program-2026-07.md` §7 M4 with the measured allocations/row +
+- [x] 4.2 Update `docs/architecture/throughput-program-2026-07.md` §7 M4 with the measured allocations/row +
       the L4 verdict + the L5 result. Update CLAUDE.md only if a user-facing surface changed (it does not).
 
 ## 5. Gate / review / audit (endgame — via flow-implement → flow-closer)
@@ -36,3 +36,22 @@
 - [ ] 5.3 Open PR (`Closes #1883`).
 - [ ] 5.4 flow-closer: ONE full `scripts/agent-gate.sh` → C (`spec-auditor` anchored to
       `openspec/changes/rust-per-row-alloc-budget/specs/**`) → final roborev → merge-on-green → finalize.
+
+## 6. Implementation notes (measured outcomes)
+
+- **1.2 scope correction (owner-ratified).** #1447/#1445/#1446 are BINDING-layer fixes (Node
+  `ExecuteNativeTask::compute`, Node JsString interning, Python `Row` ordering), so no `cqlite-core` test can
+  gate them. Reverting clone→move in this crate is exactly alloc-neutral (41 vs 41 narrow, 273 vs 273 wide) —
+  `Value::Text` is `Bytes`-backed and TIER-1 compaction (#1644) copies small payloads either way. The ratchet
+  is anchored instead to per-cell name interning (#1334) + the sized map (#1584), verified RED-on-revert
+  (narrow 41 → 89, wide 273 → 785). Binding-layer probe filed as **#2894**.
+- **Section 3 (L5) REVERTED before merge (owner decision).** Implementing it proved it is a PUBLIC breaking
+  API change (`row_values` moves into `QueryRow.values`; needed a `RowValues` alias rippling through
+  cqlite-core/cqlite-flight/cqlite-cli) AND that it contradicts the `rustc-hash` invariant in
+  `cqlite-core/Cargo.toml` (#1590 E8: not for untrusted string keys — column names come from the file's
+  serialization header on the default path). With no benchmark run, the win stayed unquantified. Deferred to
+  **#2901** behind a measurement + a HashDoS answer + an API plan.
+- **4.1 L4 verdict: measured 1.0× / no-op.** The partition-key path costs ZERO per-row allocations (`RowKey`
+  is `Arc<[u8]>`; `PartitionKeyCache` #1817 already hoists the decode). No follow-up filed; no win claimed.
+- **Baselines are hasher-independent**: 41/273 measured identically with and without FxHashMap, which is also
+  why the ratchet alone could never have served as L5's wiring evidence.


### PR DESCRIPTION
Closes #1883. Epic #2817 (0.17 throughput program), manifest item M4.

Adds a Rust-side per-row **allocation-count ratchet** over the real public conversion surface
`build_row_from_scan_cached`, using the in-crate `test_alloc_probe` counting allocator. This closes a
gap #1449's binding-layer heap probes (V8 heap-delta / Python `tracemalloc`) physically cannot
observe: transient Rust-heap allocations freed before a row ever crosses the FFI boundary.

## Measured

Over 8 rows in one partition, through the public surface:

| fixture | cols | allocations | per row |
|---|---|--:|--:|
| narrow | 3 | **41** | 5 |
| wide | 32 | **273** | 34 |

≈ **1 allocation per cell** plus a small fixed per-row cost. The dominant per-row cost is the #1644
retention compaction (`Value::into_owned`'s TIER-1 copy of a small payload) — **not** hashing and
**not** key handling.

## Two differential controls, both verified RED-on-revert

Shaped after `lookup.rs`'s `cartesian_product_builds_each_combo_in_one_allocation`: each control keeps
a `reference()` of the pre-fix behaviour and asserts the current impl produces **identical output**
AND allocates **strictly fewer** times, so it cannot pass vacuously.

| property | revert | measured | result |
|---|---|---|---|
| per-cell `Arc<str>` interning (#1334) | fresh key string per cell | narrow 41 → **89**, wide 273 → **785** (exactly +2/cell) | test FAILS ✓ |
| sized value map (#1584) | drop the capacity hint | narrow 41 → **49** (+1/row rehash growth) | test FAILS ✓ |

Both return green on restore. Demonstrated by actually reverting each fix in the real implementation
— not committed here.

## Scope correction — this ratchet cannot gate #1447/#1445/#1446

#1883 was filed on the premise that reverting those three would turn this test red. They are all
**binding-layer** fixes, in a different crate:

| fix | where it actually lives |
|---|---|
| #1447 clone→move | `bindings/node/src/database.rs` — `ExecuteNativeTask::compute` |
| #1446 key interning | Node — JsString interned once per result |
| #1445 name re-clone | Python — `Row` in SELECT order |

Measured directly: reverting the clone→move *inside* `build_row_from_scan_cached` is **exactly
allocation-neutral** (41 vs 41 narrow, 273 vs 273 wide), because `Value::Text` is `Bytes`-backed
(clone = refcount bump) and TIER-1 compaction copies a small payload either way. A clone control here
would be **vacuous**, so it is documented as a measurement rather than asserted with a weakened `<=`.
Binding-layer probe → **#2894**.

## L4 — measured 1.0× / no-op

The partition-key path costs **zero** per-row allocations: `RowKey` is `Arc<[u8]>` (clone = refcount
bump) and `PartitionKeyCache` (#1817) already hoists the partition-constant decode. No hoistable
per-row `Arc` allocation exists, so **no field win is claimed** and no L4 follow-up is filed.

## L5 (FxHashMap row map) — implemented, then reverted before merge

Implementing it established two things the design had not anticipated:

1. **It is a PUBLIC breaking API change.** `row_values` moves straight into `QueryRow.values`, so the
   hasher cannot change without changing that public field's type — it needed a `RowValues` alias
   rippling through `cqlite-core`, `cqlite-flight` and `cqlite-cli`.
2. **It contradicts a written invariant.** `cqlite-core/Cargo.toml` reserves `rustc-hash` for
   *"integer/digest-keyed hot-path maps only — NOT for maps exposed to untrusted string keys
   (#1590, E8)"*. `QueryRow.values` is string-keyed, and on the default read path those column names
   come from the file's `Statistics.db` serialization header — attacker-controlled for a hostile
   SSTable, where FxHash's easy collisions give O(N²) per-row inserts.

No row-conversion benchmark was run, so the projected ~1.04× stayed a projection. Owner's call:
paying a breaking API change plus a HashDoS exposure for an unquantified win is a bad trade →
**reverted**, deferred to **#2901** behind a measurement, a HashDoS answer, and an API plan.
**No throughput multiplier is claimed anywhere in this change.**

Worth recording: the alloc ratchet is **hasher-independent** (identical 41/273 either way), so it
could never have served as L5's wiring evidence — caught in review.

## Placement / gating

The ratchet lives in its own child module of `row_build` (via `#[path]`), which:

- keeps access to the private `PartitionKeyCache::columns_for` with **no production visibility widening**;
- stays **in-crate**, so the `pub(crate)` counting allocator applies (an integration test under
  `tests/` would link the system allocator and could not reach the probe);
- holds `row_build.rs` under the campsite source threshold (616 lines).

Gated at the **declaration** on `not(dhat-heap)` — the #1668 dhat allocator and the counting allocator
are mutually exclusive `#[global_allocator]`s, so per-item gating would leave unused imports failing
`clippy -D warnings` under `--all-features` (verified against the gate's exact dhat clippy invocation).

## Review

`rust-reviewer` + roborev (two rounds). Fixes applied from review, all pre-merge:

- the `dhat-heap` clippy break above;
- **the #1584 property had no differential control** — it rested solely on a re-tunable constant; added
  `reference_unsized_map`;
- **budgets are now derived from the fixture** (`COLLECTOR + ROWS * (FIXED + PER_CELL * cols)`) rather
  than hard-coded totals, so a fixture edit cannot silently loosen the ratchet;
- a **warm-up conversion** before measuring, so one-time lazy init is not charged to the impl under test
  and against both references;
- row-count assertions before the equivalence `zip` (a short reference would otherwise degrade it to a
  prefix comparison);
- corrected a retuning comment whose arithmetic did not reconcile with its own constants.

Deferred as nits → follow-up filed at merge: fixture coverage for composite partition keys and a
non-empty projection.

## Note: a pre-existing red test on `main`

`test_cql_decimal_roundtrip_scale_down` fails on clean `origin/main` (verified in a detached
worktree): the fail-closed decimal policy (#1487/#1755) landed and the test from #770 was never
updated. It is formally quarantined from the full gate (#2039/#2188) so it does not affect this PR,
and this PR no longer touches that file — but it is genuinely broken.

## Gate

`--lite` PASS at `43b24135` (file-size, fmt, clippy, roborev-lints, scoped-tests). The full gate of
record runs pre-merge.