### PR TITLE
fix(#2903): un-break the gate self-test on Linux — match sccache-health as a field, not end-of-line

### DIFF
--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -779,13 +779,18 @@ fi
 #     to force the sccache accelerator state, AGENT_GATE_TEST_SCCACHE_ERRORS to
 #     force the error sum) so na/ok/warn assert deterministically without sccache
 #     installed and without PATH surgery.
+#     These three asserts match `sccache-health=<v>` as a FIELD (`( |$)` — the same
+#     idiom as assert_mold_token), never end-anchored on the value: further trailing
+#     accelerator tokens (` mold=` #2859, and any future one) must not break them
+#     (issue #2903). The value itself stays exact — `ok( |$)` cannot match `okay`,
+#     and the whole-line grammar is still asserted by assert_accelerators.
 #
 # 9c-i. sccache in use, ZERO error counters -> sccache-health=ok, NO corruption WARN.
 health_err="$tmp/health-ok.stderr"
 AGENT_GATE_SUMMARY_FILE="$tmp/health-ok.txt" \
   AGENT_GATE_TEST_SCCACHE_STATE=on AGENT_GATE_TEST_SCCACHE_ERRORS=0 \
   bash "$GATE" --emit-summary-selftest >/dev/null 2>"$health_err"
-if grep -qE '^accelerators: .* sccache-health=ok$' "$tmp/health-ok.txt"; then
+if grep -qE '^accelerators: .* sccache-health=ok( |$)' "$tmp/health-ok.txt"; then
   ok "sccache-health: on + 0 errors -> sccache-health=ok"
 else
   bad "sccache-health: expected sccache-health=ok for on + 0 errors"
@@ -801,7 +806,7 @@ fi
 AGENT_GATE_SUMMARY_FILE="$tmp/health-warn.txt" \
   AGENT_GATE_TEST_SCCACHE_STATE=on AGENT_GATE_TEST_SCCACHE_ERRORS=3 \
   bash "$GATE" --emit-summary-selftest >/dev/null 2>"$tmp/health-warn.stderr"
-if grep -qE '^accelerators: .* sccache-health=warn$' "$tmp/health-warn.txt"; then
+if grep -qE '^accelerators: .* sccache-health=warn( |$)' "$tmp/health-warn.txt"; then
   ok "sccache-health: on + >0 errors -> sccache-health=warn"
 else
   bad "sccache-health: expected sccache-health=warn for on + >0 errors"
@@ -829,7 +834,7 @@ fi
 AGENT_GATE_SUMMARY_FILE="$tmp/health-na.txt" \
   AGENT_GATE_TEST_SCCACHE_STATE=off \
   bash "$GATE" --emit-summary-selftest >/dev/null 2>"$tmp/health-na.stderr"
-if grep -qE '^accelerators: .* sccache-health=na$' "$tmp/health-na.txt"; then
+if grep -qE '^accelerators: .* sccache-health=na( |$)' "$tmp/health-na.txt"; then
   ok "sccache-health: sccache not in use -> sccache-health=na"
 else
   bad "sccache-health: expected sccache-health=na when sccache not in use"


### PR DESCRIPTION
Closes #2903. **Unblocks the full `agent-gate.sh` of record on every Linux box.**

## The bug
`scripts/agent-gate.sh:632` appends a mold token on Linux, so the accelerators line ends `... sccache-health=ok mold=absent`. Three assertions in `scripts/tests/test_agent_gate_summary.sh` were **end-anchored** on sccache-health (`sccache-health=ok$`), so the trailing token broke the `$` anchor and `tooling-tests` failed 3 of 93 — on Linux only (Darwin emits no mold token, which is why it went unnoticed). Introduced by `50cf721f` (#2859 mold bootstrap) without updating the anchors.

Consequence: every Linux worker's gate of record ended `RESULT: FAIL`, so delivery either stalls or someone starts merging over a red gate and rationalising which components "don't count" — the exact erosion the gate contract exists to prevent. The self-test is also the summary-format **drift detector**, so the drift detector was itself the drift. Found while gating PR #2892 (#2043); confirmed pre-existing on unmodified `origin/main` @ `bf8dfe14` via a detached baseline worktree (`90 passed / 3 failed`, same three names).

## The fix
`scripts/tests/test_agent_gate_summary.sh:788,808,839` — `sccache-health=ok$` → `sccache-health=ok( |$)` (same for `warn`/`na`), reusing the file's existing `assert_mold_token` field idiom. **Matches the field, not end-of-line**, so a future trailing accelerator token cannot break it again. `scripts/agent-gate.sh` is untouched — its emitted line is well-formed; the bug was purely the stale anchors. Diff is 3 regexes + 5 comment lines.

## Evidence the assertions still bite (this is the part that matters)
A loosened anchor is only a fix if it still fails on a real defect. Verified by mutation testing `agent-gate.sh`, each mutation reverted:
- Forcing `_sccache_health` to return `ok` unconditionally → **RED** on `expected sccache-health=warn`, `missing LOUD corruption WARN`, `expected sccache-health=na` (90/93).
- Suffixing the emitted value (`okx`/`warnx`/`nax`) → **all three RED** (83/93). So `ok( |$)` is an exact-value match, not a prefix match.
- Appending a fake ` lto=thin` → the three sccache-health asserts stay **GREEN** (the future-token goal). The whole-line grammar assert (`:76`) correctly goes red on an undeclared token — that is the "no undeclared token" invariant and was deliberately left strict.

Self-test now **93/93** (was 90/93). Scoped `--only tooling-tests`: **PASS (211s)**.

## Same-class scan
No other `.*<field>=<value>$` partial-field anchor exists in `scripts/tests/*.sh`. The other end-anchored lines (`test_agent_gate_summary.sh:76`, `test_gate_cpu_budget.sh:130,142`) are intentionally-exhaustive whole-line grammar checks, not fragile — left alone.

**Residual risk noted:** nothing enforces that a *new* accelerator token updates the line-76 grammar list, so the next token addition will still fail `tooling-tests` — but loudly and correctly (a malformed-line message naming the token), not via a silent anchor break.

Oracle-driven (the oracle is `agent-gate.sh`'s actual emitted line) — no OpenSpec change. The ONE full gate of record runs pre-merge and its verbatim summary is posted below.