### PR TITLE
feat(#2825): byte-bounded Arrow egress batch sizing

### DIFF
--- a/cqlite-core/src/export/arrow_size.rs
+++ b/cqlite-core/src/export/arrow_size.rs
@@ -571,14 +571,21 @@ impl<'a> Estimator<'a> {
     /// unlike the high-fidelity path, the flat builders have a FIXED one-level
     /// child shape, so a constant suffices.
     fn charge_flat(&mut self, dt: &DataType, fidelity: TextFidelity, value: Option<&'a Value>) {
-        // `build_string_array`'s two branches: an authoritative text column
-        // borrows the value's own bytes (`s.len()`, hard error on invalid
-        // UTF-8), everything else renders lossily (up to 3x). Both reach this
-        // function through the SAME flat `data_type` arms, so the branch is
-        // selected here rather than by the shape (review B5).
-        let charge_string = |est: &mut Self, value: Option<&'a Value>| match fidelity {
-            TextFidelity::Strict => est.add(text_content_bytes(value)),
-            TextFidelity::Lossy => est.charge_rendered(value),
+        // `build_string_array`'s two branches, which both reach this function
+        // through the SAME flat `data_type` arms — so the branch is selected
+        // here rather than by the shape (review B5).
+        let charge_string = |est: &mut Self, value: Option<&'a Value>| match (fidelity, value) {
+            // BOTH branches borrow a `Value::Text`'s own bytes after a NON-lossy
+            // `str::from_utf8` and hard-error on invalid UTF-8, so a top-level
+            // text cell is exactly `s.len()` — no U+FFFD expansion. (The lossy
+            // `format_value` path applies only to a `Value::Text` NESTED in a
+            // rendered container; `charge_rendered` charges 3x there.)
+            (_, Some(Value::Text(s))) => est.add(s.len()),
+            // Strict: every other variant makes the builder hard-error, so no
+            // batch exists to charge for.
+            (TextFidelity::Strict, _) => {}
+            // Lossy: `ValueFormatter::format_value` renders it.
+            (TextFidelity::Lossy, v) => est.charge_rendered(v),
         };
         match dt {
             DataType::Boolean | DataType::TinyInt => self.add(1),

--- a/cqlite-core/src/export/arrow_size.rs
+++ b/cqlite-core/src/export/arrow_size.rs
@@ -5,7 +5,7 @@
 //! The `cqlite-flight` egress path finishes a record batch on **row count**
 //! alone, so a batch's byte size is `batch_size × row_width` — an unbounded
 //! function of schema shape. Bounding it needs a byte decision made **while rows
-//! accumulate**, before any [`RecordBatch`] exists: building the batch to
+//! accumulate**, before any `RecordBatch` exists: building the batch to
 //! discover it is too big defeats the purpose, so
 //! `RecordBatch::get_array_memory_size()` cannot be the production trigger (it
 //! is only readable *after* every value has been allocated and copied).
@@ -38,10 +38,10 @@
 //!
 //! | term | charged | covers |
 //! |---|---|---|
-//! | [`ARROW_VALIDITY_BYTES`] | every slot | the slot's validity **bit**; `n` bytes ≥ `ceil(n/8)` |
+//! | `ARROW_VALIDITY_BYTES` | every slot | the slot's validity **bit**; `n` bytes ≥ `ceil(n/8)` |
 //! | content | every slot | the slot's data-buffer bytes |
-//! | [`ARROW_CELL_OVERHEAD_BYTES`] | variable-width slots | its offsets entry + the buffer's trailing `n+1`-th entry |
-//! | [`ARROW_COLUMN_SLACK_BYTES`] | once per projected **column** | array nodes that correspond to no slot at all |
+//! | `ARROW_CELL_OVERHEAD_BYTES` | variable-width slots | its offsets entry + the buffer's trailing `n+1`-th entry |
+//! | `ARROW_COLUMN_SLACK_BYTES` | once per projected **column** | array nodes that correspond to no slot at all |
 //!
 //! The per-cell terms are therefore tight (a 1000-element `list<int>` estimates
 //! ~1.2× its realized payload, not ~9×), and a wide fixed-width schema pays
@@ -567,7 +567,7 @@ impl<'a> Estimator<'a> {
     ///
     /// The empty-collection child arrays these builders always materialize
     /// (`ListArray<Utf8>` / `MapArray<Utf8, Utf8>`) are covered by
-    /// [`ARROW_COLUMN_SLACK_BYTES`], which is derived from exactly that case —
+    /// `ARROW_COLUMN_SLACK_BYTES`, which is derived from exactly that case —
     /// unlike the high-fidelity path, the flat builders have a FIXED one-level
     /// child shape, so a constant suffices.
     fn charge_flat(&mut self, dt: &DataType, fidelity: TextFidelity, value: Option<&'a Value>) {

--- a/cqlite-core/src/export/arrow_size.rs
+++ b/cqlite-core/src/export/arrow_size.rs
@@ -41,12 +41,19 @@
 //! | `ARROW_VALIDITY_BYTES` | every slot | the slot's validity **bit**; `n` bytes ≥ `ceil(n/8)` |
 //! | content | every slot | the slot's data-buffer bytes |
 //! | `ARROW_CELL_OVERHEAD_BYTES` | variable-width slots | its offsets entry + the buffer's trailing `n+1`-th entry |
-//! | `ARROW_COLUMN_SLACK_BYTES` | once per projected **column** | array nodes that correspond to no slot at all |
+//! | `ARROW_COLUMN_SLACK_BYTES` | once per **column whose builder materializes childless array nodes** | those nodes' empty offsets buffers |
 //!
 //! The per-cell terms are therefore tight (a 1000-element `list<int>` estimates
-//! ~1.2× its realized payload, not ~9×), and a wide fixed-width schema pays
-//! ~13 B/column/row rather than ~1 KB/row — so the row-cap, not the byte-cap,
-//! still binds on narrow shapes.
+//! ~1.2× its realized payload, not ~9×), and the residual is charged ONLY where
+//! a childless node can exist — the flat `list`/`set`/`map` builders, whose
+//! `MapArray`/`ListArray` always materialize a rendered `Utf8` child (see
+//! [`column_slack_bytes`]). A fixed-width column materializes exactly one array
+//! node with one data buffer, no offsets and no children, so it pays no residual
+//! at all: an `int` column costs `1 + 4 = 5` B/row against ~4.1 B/row realized.
+//! A 100-column `int` row therefore estimates 500 B and a full 8192-row batch
+//! 4,096,000 B — still inside the 4 MiB default, so the ROW-cap keeps binding on
+//! wide narrow-cell schemas up to 102 `int` columns (issue #2825 review C1;
+//! charging the residual per column put that cliff at 40 columns).
 //!
 //! # Conservatism is a contract, not an aspiration
 //!
@@ -70,25 +77,47 @@
 //!
 //! # Hardening
 //!
-//! The walk is **iterative** (an explicit worklist, never recursion), bounded by
-//! [`MAX_ESTIMATE_NODES`], and every arithmetic step is saturating. A fan-out is
-//! tested against the remaining budget **before** it is pushed, so a corrupt
-//! collection cannot transiently balloon the worklist. A value deeper or wider
-//! than the node budget, or one whose widths would overflow `usize`, **fails
-//! closed** to `usize::MAX` — which trips the byte-cap and cuts the batch, the
-//! safe direction. It never panics and never hangs.
+//! The walk is **iterative** (an explicit worklist) and every arithmetic step is
+//! saturating. Two budgets, both reset **per column**, bound the work:
+//!
+//! * [`MAX_ESTIMATE_NODES`] caps the **branching** slots — those that can queue
+//!   further slots. Only a branching slot ever enters the worklist, so the
+//!   worklist can never hold more entries than the budget (a stronger form of
+//!   the pre-push fan-out check it replaces), and a value nested deeper than the
+//!   budget fails closed.
+//! * [`MAX_ESTIMATE_LEAF_SLOTS`] caps the leaf slots charged inline. A leaf costs
+//!   no worklist entry and no structural node, so a collection's ELEMENT COUNT —
+//!   the one dimension a legal Cassandra row pushes to 65,535 — no longer
+//!   consumes the structural budget (issue #2825 review C2): a 65,535-entry
+//!   `map<text,text>` spends ONE node rather than 131,070, and is estimated
+//!   exactly instead of failing closed and degrading the stream to one row per
+//!   batch for the rest of the scan.
+//!
+//! Per-column budgets mean one wide column can no longer starve the columns
+//! after it. A row that exhausts either budget, or whose widths would overflow
+//! `usize`, **fails closed** to `usize::MAX` — which trips the byte-cap and cuts
+//! the batch, the safe direction. It never panics and never hangs.
 
 use crate::query::{ColumnInfo, QueryRow};
 use crate::schema::CqlType;
 use crate::types::{DataType, Value};
 
-// The rendered-representation bounds (`charge_rendered`, `json_render_bytes`)
-// live in a child module so this file stays under the campsite threshold
-// (epic #1116). A child module sees this module's private items.
+// Column shape resolution (`column_shape`, `column_slack_bytes`, `branches`)
+// and the rendered-representation bounds (`charge_rendered`,
+// `json_render_bytes`) live in child modules so this file stays under the
+// campsite threshold (epic #1116). A child module sees this module's private
+// items, and this module re-exposes theirs to each other.
+#[path = "arrow_size_shape.rs"]
+mod shape;
+
 #[path = "arrow_size_render.rs"]
 mod render;
 
 use render::RENDER_CONTAINER_BYTES;
+use shape::{
+    branches, column_shape, column_slack_bytes, unwrap_frozen_type, unwrap_frozen_value, Shape,
+    TextFidelity,
+};
 
 // ============================================================================
 // Structural constants
@@ -118,29 +147,49 @@ const ARROW_VALIDITY_BYTES: usize = 1;
 /// byte here (the second one a variable-width slot pays) is deliberate margin.
 const ARROW_CELL_OVERHEAD_BYTES: usize = 2 * ARROW_OFFSET_BYTES + ARROW_VALIDITY_BYTES;
 
-/// Residual slack charged ONCE per projected **column** per row — never per
-/// cell, per element or per field.
+/// Residual slack charged ONCE per row for a column that materializes Arrow
+/// array nodes corresponding to no value slot — never per cell, per element or
+/// per field, and **never for a column that has no such node** (see
+/// [`column_slack_bytes`]).
 ///
-/// Derivation: a column can materialize Arrow array nodes that correspond to no
-/// value slot at all, and each such node still carries an empty 4-byte offsets
-/// buffer. The tight case is the flat `DataType::Map` builder, whose `MapArray`
-/// always materializes a key `Utf8` and a value `Utf8` child even for a cell
-/// with zero entries: `2 × 4 = 8` bytes with no slot to attach them to. (The
-/// high-fidelity path charges such nodes explicitly — see `charge_cql`'s
-/// empty-collection rule — so this stays a residual, not the mechanism.)
+/// Derivation: each childless node still carries an empty 4-byte offsets buffer.
+/// The tight case is the flat `DataType::Map` builder, whose `MapArray` always
+/// materializes a key `Utf8` and a value `Utf8` child even for a cell with zero
+/// entries: `2 × 4 = 8` bytes with no slot to attach them to. (The high-fidelity
+/// path charges such nodes explicitly — see `charge_cql`'s empty-collection
+/// rule — so this stays a residual, not the mechanism.)
 ///
 /// Charged per row because the accumulate-as-you-push cap needs a per-row
 /// number and a per-batch term has nowhere to live; per COLUMN rather than per
 /// SLOT so it cannot multiply by a cell's element count.
 const ARROW_COLUMN_SLACK_BYTES: usize = 2 * ARROW_OFFSET_BYTES;
 
-/// Maximum number of value/type nodes one row's estimate may visit.
+/// Maximum number of **branching** slots one COLUMN's estimate may queue — a
+/// slot that can fan out into further slots (a collection, a map, a struct, or a
+/// rendered container).
 ///
-/// A row whose values nest or fan out past this budget fails closed to
-/// `usize::MAX` (cut the batch) instead of spending unbounded time. Sized well
-/// above any legitimate Cassandra row shape (a 4-column row of 1000-element
-/// collections visits ~4000 nodes).
+/// Leaf slots do not count against it (they never enter the worklist — see
+/// [`MAX_ESTIMATE_LEAF_SLOTS`]), so this bounds the value's *structure*: nesting
+/// depth and container-of-container fan-out, neither of which a legitimate
+/// Cassandra schema drives anywhere near 65,536. A column exceeding it fails
+/// closed to `usize::MAX` (cut the batch) instead of spending unbounded time,
+/// and because only branching slots are queued the worklist itself can never
+/// exceed this many entries.
+///
+/// Reset per column (issue #2825 review C2): one wide column can no longer
+/// starve the columns after it.
 pub const MAX_ESTIMATE_NODES: usize = 65_536;
+
+/// Maximum number of **leaf** slots one COLUMN's estimate may charge inline.
+///
+/// A leaf costs no worklist entry, so this is purely a linear-work bound: it
+/// exists so a `Value` tree far larger than any decoded Cassandra row still
+/// terminates in bounded time. Sized ~8× above the largest legal single cell
+/// (Cassandra's classic 65,535-element collection limit is 131,070 leaf slots
+/// for a `map`), so the shapes review C2 called out — one near-limit collection,
+/// or several thousand-element collections per row — are estimated exactly
+/// rather than failing closed.
+pub const MAX_ESTIMATE_LEAF_SLOTS: usize = 1 << 20;
 
 // ============================================================================
 // Public API
@@ -191,13 +240,16 @@ pub fn estimate_arrow_row_bytes(columns: &[ColumnInfo], row: &QueryRow) -> usize
     let mut est = Estimator::new();
     for col in columns {
         let cell = row.values.get(col.name.as_str());
-        // The per-column residual, charged exactly once per column per row.
-        est.add(ARROW_COLUMN_SLACK_BYTES);
-        // Charge the column's own slot DIRECTLY rather than through the
-        // worklist: a scalar column pushes no children, so the narrow path
-        // never allocates the stack at all (`Vec::new` does not allocate until
-        // its first push). Only collection/struct cells reach `drain`.
-        est.charge_slot(column_shape(col), cell);
+        let shape = column_shape(col);
+        // Both node budgets are per COLUMN (review C2).
+        est.begin_column();
+        // The per-column residual, charged exactly once per row and only for a
+        // column whose builder materializes a childless array node (review C1).
+        est.add(column_slack_bytes(&shape));
+        // A LEAF column is charged in place, so the narrow path never allocates
+        // the worklist at all (`Vec::new` does not allocate until its first
+        // push). Only collection/struct cells reach `drain`.
+        est.charge_child(shape, cell);
         est.drain();
         if est.total == usize::MAX {
             return usize::MAX;
@@ -232,131 +284,22 @@ pub fn arrow_payload_bytes(batch: &arrow::record_batch::RecordBatch) -> usize {
 }
 
 // ============================================================================
-// Shape resolution
-// ============================================================================
-
-/// How one Arrow slot is produced, mirroring `convert_column_to_array`'s
-/// dispatch so the estimate tracks the converter rather than guessing.
-#[derive(Clone, Copy)]
-enum Shape<'a> {
-    /// High-fidelity CQL-typed slot (`build_typed_value_array` and the typed
-    /// scalar builders).
-    Cql(&'a CqlType),
-    /// Flat `DataType` dispatch (the legacy builders), carrying whether the
-    /// column's CQL type makes `build_string_array` take its STRICT branch.
-    Flat(&'a DataType, TextFidelity),
-    /// A REAL `Utf8` array slot whose content is `ValueFormatter::format_value`'s
-    /// rendering — `build_string_array`, and each element slot of
-    /// `build_list_array` / `build_map_array`. Pays the variable-width slot
-    /// overhead.
-    RenderedSlot,
-    /// NOT an array slot of its own: a sub-part of an enclosing slot's single
-    /// rendered string (a container element rendered inline). Pays content only.
-    RenderedInline,
-}
-
-/// Whether a column's CQL type is an AUTHORITATIVE text type, which makes
-/// `build_string_array` take its `strict_text` branch: it borrows the `&str`
-/// after a NON-lossy `str::from_utf8` and hard-errors on invalid UTF-8, rather
-/// than rendering through the lossy `ValueFormatter::format_value`. The two
-/// branches have different byte behaviour (`s.len()` versus up to `3 * s.len()`
-/// of U+FFFD expansion), so the estimate must distinguish them.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum TextFidelity {
-    /// `cql_type` is `Text`/`Ascii`/`Varchar`: exact, non-lossy.
-    Strict,
-    /// No authoritative text type: `format_value`'s lossy rendering.
-    Lossy,
-}
-
-/// Resolve a column to its Arrow slot shape, mirroring `convert_column_to_array`
-/// exactly: only the high-fidelity CQL arms take the typed path; everything else
-/// (including `Text`/`Blob`/numeric CQL types) falls through to the flat
-/// `data_type` dispatch — `convert_column_to_array` dispatches those on
-/// `data_type` alone, so the estimate must too.
-fn column_shape(col: &ColumnInfo) -> Shape<'_> {
-    let mut fidelity = TextFidelity::Lossy;
-    if let Some(cql) = &col.cql_type {
-        let effective = unwrap_frozen_type(cql);
-        match effective {
-            CqlType::Text | CqlType::Ascii | CqlType::Varchar => {
-                // Falls through to the flat dispatch, but tells it which
-                // `build_string_array` branch the converter will take.
-                fidelity = TextFidelity::Strict;
-            }
-            CqlType::Date
-            | CqlType::Time
-            | CqlType::Decimal
-            | CqlType::Varint
-            | CqlType::Duration
-            | CqlType::Uuid
-            | CqlType::TimeUuid
-            | CqlType::Inet
-            | CqlType::Counter
-            | CqlType::List(_)
-            | CqlType::Set(_)
-            | CqlType::Map(_, _)
-            | CqlType::Tuple(_)
-            | CqlType::Udt(_, _) => return Shape::Cql(effective),
-            // Exhaustive by design (no `_` arm): a new `CqlType` variant is a
-            // COMPILE error here, so it can never be silently under-estimated.
-            CqlType::Boolean
-            | CqlType::TinyInt
-            | CqlType::SmallInt
-            | CqlType::Int
-            | CqlType::BigInt
-            | CqlType::Float
-            | CqlType::Double
-            | CqlType::Blob
-            | CqlType::Timestamp
-            | CqlType::Frozen(_)
-            | CqlType::Custom(_) => {}
-        }
-    }
-    Shape::Flat(&col.data_type, fidelity)
-}
-
-/// Unwrap nested `Frozen` wrappers to the effective type (mirrors
-/// `arrow_convert::unwrap_frozen_type`). Bounded: `Frozen` nesting comes from a
-/// parsed schema, and the loop is capped so a pathological type cannot spin.
-fn unwrap_frozen_type(mut t: &CqlType) -> &CqlType {
-    for _ in 0..MAX_FROZEN_DEPTH {
-        match t {
-            CqlType::Frozen(inner) => t = inner,
-            _ => return t,
-        }
-    }
-    t
-}
-
-/// Unwrap nested `Value::Frozen` wrappers (mirrors
-/// `arrow_convert::unwrap_frozen_value`), bounded the same way.
-fn unwrap_frozen_value(mut v: &Value) -> &Value {
-    for _ in 0..MAX_FROZEN_DEPTH {
-        match v {
-            Value::Frozen(inner) => v = inner,
-            _ => return v,
-        }
-    }
-    v
-}
-
-/// Cap on `Frozen` unwrap iterations — a bound, not a semantic limit: real
-/// schemas nest at most once or twice.
-const MAX_FROZEN_DEPTH: usize = 16;
-
-// ============================================================================
 // The iterative estimator
 // ============================================================================
 
 /// Iterative worklist over (slot shape, slot value) pairs.
 ///
 /// One popped item is exactly one Arrow array slot; children (collection
-/// elements, map entries, struct fields) are pushed as further slots. The stack
-/// is lazily allocated, so a row of scalar columns never heap-allocates.
+/// elements, map entries, struct fields) are charged as further slots. Only
+/// BRANCHING children are queued — a leaf child is charged where it is found —
+/// so the worklist is bounded by [`MAX_ESTIMATE_NODES`] and is lazily allocated:
+/// a row of scalar columns never heap-allocates.
 struct Estimator<'a> {
     total: usize,
+    /// Remaining branching slots for the CURRENT column.
     budget: usize,
+    /// Remaining inline leaf charges for the CURRENT column.
+    leaf_budget: usize,
     stack: Vec<(Shape<'a>, Option<&'a Value>)>,
 }
 
@@ -365,12 +308,16 @@ impl<'a> Estimator<'a> {
         Self {
             total: 0,
             budget: MAX_ESTIMATE_NODES,
+            leaf_budget: MAX_ESTIMATE_LEAF_SLOTS,
             stack: Vec::new(),
         }
     }
 
-    fn push(&mut self, shape: Shape<'a>, value: Option<&'a Value>) {
-        self.stack.push((shape, value));
+    /// Start a fresh column: both budgets are per COLUMN, so one wide column's
+    /// fan-out cannot starve the columns after it (review C2).
+    fn begin_column(&mut self) {
+        self.budget = MAX_ESTIMATE_NODES;
+        self.leaf_budget = MAX_ESTIMATE_LEAF_SLOTS;
     }
 
     fn add(&mut self, bytes: usize) {
@@ -383,15 +330,56 @@ impl<'a> Estimator<'a> {
         self.stack.clear();
     }
 
-    /// Charge exactly ONE Arrow array slot, pushing any child slots it implies.
+    /// Charge ONE child slot: a branching child is queued (spending one
+    /// structural node), a leaf child is charged in place (spending one leaf
+    /// slot and no worklist entry).
     ///
-    /// Spends one node from the budget and fails closed when it is exhausted.
-    fn charge_slot(&mut self, shape: Shape<'a>, value: Option<&'a Value>) {
-        if self.budget == 0 {
+    /// Both budgets are checked BEFORE the child is queued or walked, so neither
+    /// the worklist nor the walk can transiently overrun. The inline leaf charge
+    /// re-enters [`Self::charge_slot`] exactly once — [`branches`] answers
+    /// `false` only for shape/value pairs that queue nothing — so the call depth
+    /// is 2 and never grows with the value's depth; the debug assertion pins it.
+    pub(super) fn charge_child(&mut self, shape: Shape<'a>, value: Option<&'a Value>) {
+        if branches(shape, value) {
+            if self.budget == 0 {
+                self.saturate();
+                return;
+            }
+            self.budget -= 1;
+            self.stack.push((shape, value));
+            return;
+        }
+        if self.leaf_budget == 0 {
             self.saturate();
             return;
         }
-        self.budget -= 1;
+        self.leaf_budget -= 1;
+        let queued = self.stack.len();
+        self.charge_slot(shape, value);
+        debug_assert_eq!(
+            self.stack.len(),
+            queued,
+            "a slot `branches` called a leaf queued children"
+        );
+    }
+
+    /// Charge a whole fan-out of child slots, stopping as soon as the estimate
+    /// has been saturated so a pathological cell is not walked to its end.
+    pub(super) fn charge_children<I>(&mut self, items: I)
+    where
+        I: IntoIterator<Item = (Shape<'a>, Option<&'a Value>)>,
+    {
+        for (shape, value) in items {
+            if self.total == usize::MAX {
+                return;
+            }
+            self.charge_child(shape, value);
+        }
+    }
+
+    /// Charge exactly ONE Arrow array slot, charging or queueing any child slots
+    /// it implies. The budgets are spent by [`Self::charge_child`], never here.
+    fn charge_slot(&mut self, shape: Shape<'a>, value: Option<&'a Value>) {
         // Every slot pays its validity bit, rounded up to a whole byte.
         self.add(ARROW_VALIDITY_BYTES);
         let value = value.map(unwrap_frozen_value);
@@ -462,7 +450,7 @@ impl<'a> Estimator<'a> {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 match value {
                     Some(Value::List(items) | Value::Set(items)) if !items.is_empty() => {
-                        self.push_all(items.iter().map(|v| (Shape::Cql(inner), Some(v))));
+                        self.charge_children(items.iter().map(|v| (Shape::Cql(inner), Some(v))));
                     }
                     // Empty, null or absent: `build_typed_value_array` still
                     // materializes one child array per DECLARED nesting level,
@@ -470,11 +458,11 @@ impl<'a> Estimator<'a> {
                     // declared chain covers a `list<list<…>>` whose depth no
                     // per-slot constant could bound (review B2).
                     Some(Value::List(_) | Value::Set(_) | Value::Null) | None => {
-                        self.push(Shape::Cql(inner), None);
+                        self.charge_child(Shape::Cql(inner), None);
                     }
                     // Shape mismatch: the converter either errors (no batch) or
                     // renders. Charge the render bound, never zero.
-                    Some(other) => self.push(Shape::RenderedSlot, Some(other)),
+                    Some(other) => self.charge_child(Shape::RenderedSlot, Some(other)),
                 }
             }
             // MapArray: the row's offsets entry, plus a key and a value child
@@ -483,24 +471,20 @@ impl<'a> Estimator<'a> {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 match value {
                     Some(Value::Map(pairs)) if !pairs.is_empty() => {
-                        if !self.reserve(pairs.len().saturating_mul(2)) {
-                            return;
-                        }
-                        for (k, v) in pairs {
-                            self.push(Shape::Cql(key_type), Some(k));
-                            self.push(Shape::Cql(val_type), Some(v));
-                        }
+                        self.charge_children(pairs.iter().flat_map(|(k, v)| {
+                            [
+                                (Shape::Cql(key_type), Some(k)),
+                                (Shape::Cql(val_type), Some(v)),
+                            ]
+                        }));
                     }
                     // Empty/null/absent: both child arrays still exist — charge
                     // the declared key and value type chains (review B2).
                     Some(Value::Map(_) | Value::Null) | None => {
-                        if !self.reserve(2) {
-                            return;
-                        }
-                        self.push(Shape::Cql(key_type), None);
-                        self.push(Shape::Cql(val_type), None);
+                        self.charge_child(Shape::Cql(key_type), None);
+                        self.charge_child(Shape::Cql(val_type), None);
                     }
-                    Some(other) => self.push(Shape::RenderedSlot, Some(other)),
+                    Some(other) => self.charge_child(Shape::RenderedSlot, Some(other)),
                 }
             }
             // StructArray: no offsets; every DECLARED field materializes a child
@@ -514,13 +498,10 @@ impl<'a> Estimator<'a> {
                     _ => &[],
                 };
                 let n = element_types.len().max(items.len());
-                if !self.reserve(n) {
-                    return;
-                }
-                for i in 0..n {
+                self.charge_children((0..n).map(|i| {
                     let shape = element_types.get(i).map_or(Shape::RenderedSlot, Shape::Cql);
-                    self.push(shape, items.get(i));
-                }
+                    (shape, items.get(i))
+                }));
             }
             CqlType::Udt(_, udt_fields) => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES.saturating_add(RENDER_CONTAINER_BYTES));
@@ -528,19 +509,15 @@ impl<'a> Estimator<'a> {
                     Some(Value::Udt(udt)) => Some(udt.as_ref()),
                     _ => None,
                 };
-                let extras = udt.map_or(0, |u| u.fields.len());
-                if !self.reserve(udt_fields.len().saturating_add(extras)) {
-                    return;
-                }
-                for (name, field_type) in udt_fields {
+                self.charge_children(udt_fields.iter().map(|(name, field_type)| {
                     let field_value = udt.and_then(|u| {
                         u.fields
                             .iter()
                             .find(|f| &f.name == name)
                             .and_then(|f| f.value.as_ref())
                     });
-                    self.push(Shape::Cql(field_type), field_value);
-                }
+                    (Shape::Cql(field_type), field_value)
+                }));
                 // A value carrying fields the declared type does not name still
                 // costs something on the render fallback (`format_udt` emits
                 // `{name: value, …}`), so charge the NAME and its separators
@@ -551,14 +528,17 @@ impl<'a> Estimator<'a> {
                         .iter()
                         .filter(|f| !udt_fields.iter().any(|(n, _)| n == &f.name));
                     for f in extra {
+                        if self.total == usize::MAX {
+                            return;
+                        }
                         self.add(f.name.len().saturating_add(RENDER_CONTAINER_BYTES));
-                        self.push(Shape::RenderedInline, f.value.as_ref());
+                        self.charge_child(Shape::RenderedInline, f.value.as_ref());
                     }
                 }
             }
             // Unreachable after `unwrap_frozen_type`, but kept explicit so the
             // match stays exhaustive without a `_` arm.
-            CqlType::Frozen(inner) => self.push(Shape::Cql(inner), value),
+            CqlType::Frozen(inner) => self.charge_child(Shape::Cql(inner), value),
         }
     }
 
@@ -608,20 +588,19 @@ impl<'a> Estimator<'a> {
             DataType::List | DataType::Set => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 if let Some(Value::List(items) | Value::Set(items)) = value {
-                    self.push_all(items.iter().map(|v| (Shape::RenderedSlot, Some(v))));
+                    self.charge_children(items.iter().map(|v| (Shape::RenderedSlot, Some(v))));
                 }
             }
             // `build_map_array`: MapArray with rendered Utf8 keys and values.
             DataType::Map => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 if let Some(Value::Map(pairs)) = value {
-                    if !self.reserve(pairs.len().saturating_mul(2)) {
-                        return;
-                    }
-                    for (k, v) in pairs {
-                        self.push(Shape::RenderedSlot, Some(k));
-                        self.push(Shape::RenderedSlot, Some(v));
-                    }
+                    self.charge_children(pairs.iter().flat_map(|(k, v)| {
+                        [
+                            (Shape::RenderedSlot, Some(k)),
+                            (Shape::RenderedSlot, Some(v)),
+                        ]
+                    }));
                 }
             }
             // Fallback to `build_string_array` — same two branches.
@@ -634,32 +613,6 @@ impl<'a> Estimator<'a> {
                 charge_string(self, value);
             }
         }
-    }
-
-    /// Queue a whole fan-out, testing the node budget **before** anything is
-    /// pushed: a corrupt collection claiming 1e8 elements fails closed instead
-    /// of transiently materializing 1e8 worklist entries (review N1).
-    fn push_all<I>(&mut self, items: I)
-    where
-        I: ExactSizeIterator<Item = (Shape<'a>, Option<&'a Value>)>,
-    {
-        if !self.reserve(items.len()) {
-            return;
-        }
-        for item in items {
-            self.stack.push(item);
-        }
-    }
-
-    /// Fail closed when a fan-out of `n` slots already exceeds the remaining
-    /// node budget. Returns `false` when the estimate has been saturated and the
-    /// caller must stop.
-    fn reserve(&mut self, n: usize) -> bool {
-        if n > self.budget {
-            self.saturate();
-            return false;
-        }
-        true
     }
 }
 

--- a/cqlite-core/src/export/arrow_size.rs
+++ b/cqlite-core/src/export/arrow_size.rs
@@ -242,8 +242,9 @@ enum Shape<'a> {
     /// High-fidelity CQL-typed slot (`build_typed_value_array` and the typed
     /// scalar builders).
     Cql(&'a CqlType),
-    /// Flat `DataType` dispatch (the legacy builders).
-    Flat(&'a DataType),
+    /// Flat `DataType` dispatch (the legacy builders), carrying whether the
+    /// column's CQL type makes `build_string_array` take its STRICT branch.
+    Flat(&'a DataType, TextFidelity),
     /// A REAL `Utf8` array slot whose content is `ValueFormatter::format_value`'s
     /// rendering — `build_string_array`, and each element slot of
     /// `build_list_array` / `build_map_array`. Pays the variable-width slot
@@ -254,26 +255,36 @@ enum Shape<'a> {
     RenderedInline,
 }
 
+/// Whether a column's CQL type is an AUTHORITATIVE text type, which makes
+/// `build_string_array` take its `strict_text` branch: it borrows the `&str`
+/// after a NON-lossy `str::from_utf8` and hard-errors on invalid UTF-8, rather
+/// than rendering through the lossy `ValueFormatter::format_value`. The two
+/// branches have different byte behaviour (`s.len()` versus up to `3 * s.len()`
+/// of U+FFFD expansion), so the estimate must distinguish them.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TextFidelity {
+    /// `cql_type` is `Text`/`Ascii`/`Varchar`: exact, non-lossy.
+    Strict,
+    /// No authoritative text type: `format_value`'s lossy rendering.
+    Lossy,
+}
+
 /// Resolve a column to its Arrow slot shape, mirroring `convert_column_to_array`
-/// exactly: the high-fidelity CQL arms take the typed path; everything else
-/// (numeric CQL types, `Blob`, an absent CQL type) falls through to the flat
-/// `data_type` dispatch.
-///
-/// `Text`/`Ascii`/`Varchar` are routed to the typed arm even though the
-/// converter reaches them through `build_string_array`, because that builder's
-/// `strict_text` branch — taken for exactly these three CQL types — borrows the
-/// `&str` after a NON-lossy `str::from_utf8` and hard-errors on invalid UTF-8.
-/// Its byte behaviour is the typed one (`s.len()`), not the lossy rendered one
-/// (up to `3 * s.len()`), so charging it as flat text would over-estimate every
-/// authoritative text column by ~3x.
+/// exactly: only the high-fidelity CQL arms take the typed path; everything else
+/// (including `Text`/`Blob`/numeric CQL types) falls through to the flat
+/// `data_type` dispatch — `convert_column_to_array` dispatches those on
+/// `data_type` alone, so the estimate must too.
 fn column_shape(col: &ColumnInfo) -> Shape<'_> {
+    let mut fidelity = TextFidelity::Lossy;
     if let Some(cql) = &col.cql_type {
         let effective = unwrap_frozen_type(cql);
         match effective {
-            CqlType::Text
-            | CqlType::Ascii
-            | CqlType::Varchar
-            | CqlType::Date
+            CqlType::Text | CqlType::Ascii | CqlType::Varchar => {
+                // Falls through to the flat dispatch, but tells it which
+                // `build_string_array` branch the converter will take.
+                fidelity = TextFidelity::Strict;
+            }
+            CqlType::Date
             | CqlType::Time
             | CqlType::Decimal
             | CqlType::Varint
@@ -302,7 +313,7 @@ fn column_shape(col: &ColumnInfo) -> Shape<'_> {
             | CqlType::Custom(_) => {}
         }
     }
-    Shape::Flat(&col.data_type)
+    Shape::Flat(&col.data_type, fidelity)
 }
 
 /// Unwrap nested `Frozen` wrappers to the effective type (mirrors
@@ -386,7 +397,7 @@ impl<'a> Estimator<'a> {
         let value = value.map(unwrap_frozen_value);
         match shape {
             Shape::Cql(t) => self.charge_cql(t, value),
-            Shape::Flat(dt) => self.charge_flat(dt, value),
+            Shape::Flat(dt, fidelity) => self.charge_flat(dt, fidelity, value),
             Shape::RenderedSlot => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 self.charge_rendered(value);
@@ -559,7 +570,16 @@ impl<'a> Estimator<'a> {
     /// [`ARROW_COLUMN_SLACK_BYTES`], which is derived from exactly that case —
     /// unlike the high-fidelity path, the flat builders have a FIXED one-level
     /// child shape, so a constant suffices.
-    fn charge_flat(&mut self, dt: &DataType, value: Option<&'a Value>) {
+    fn charge_flat(&mut self, dt: &DataType, fidelity: TextFidelity, value: Option<&'a Value>) {
+        // `build_string_array`'s two branches: an authoritative text column
+        // borrows the value's own bytes (`s.len()`, hard error on invalid
+        // UTF-8), everything else renders lossily (up to 3x). Both reach this
+        // function through the SAME flat `data_type` arms, so the branch is
+        // selected here rather than by the shape (review B5).
+        let charge_string = |est: &mut Self, value: Option<&'a Value>| match fidelity {
+            TextFidelity::Strict => est.add(text_content_bytes(value)),
+            TextFidelity::Lossy => est.charge_rendered(value),
+        };
         match dt {
             DataType::Boolean | DataType::TinyInt => self.add(1),
             DataType::SmallInt => self.add(2),
@@ -571,10 +591,10 @@ impl<'a> Estimator<'a> {
                 self.add(binary_content_bytes(value));
             }
             // `build_string_array`: raw text when the column is authoritative
-            // text, otherwise the rendered form. `charge_rendered` bounds both.
+            // text, otherwise the lossy rendered form.
             DataType::Text | DataType::Json => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
-                self.charge_rendered(value);
+                charge_string(self, value);
             }
             // `build_list_array`: ListArray<Utf8> whose elements are rendered —
             // each element is a REAL child slot, not an inline sub-render.
@@ -597,14 +617,14 @@ impl<'a> Estimator<'a> {
                     }
                 }
             }
-            // Fallback to `build_string_array`'s rendered representation.
+            // Fallback to `build_string_array` — same two branches.
             DataType::Tuple
             | DataType::Udt
             | DataType::Frozen
             | DataType::Tombstone
             | DataType::Null => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
-                self.charge_rendered(value);
+                charge_string(self, value);
             }
         }
     }

--- a/cqlite-core/src/export/arrow_size.rs
+++ b/cqlite-core/src/export/arrow_size.rs
@@ -27,18 +27,40 @@
 //! that need a capacity figure convert with the published capacity factor
 //! (`cqlite_flight::batch_bytes::BATCH_BYTES_CAPACITY_FACTOR`).
 //!
+//! # The charging model, from first principles
+//!
+//! Arrow buffer **lengths are exact** — measured against this tree's arrow 53, a
+//! one-row `Int32` column is 4 bytes, a nine-row `Boolean` column is
+//! `ceil(9/8) = 2` bytes, and a null buffer is `ceil(n/8)` (absent entirely when
+//! a column has no nulls). Nothing is rounded up to an allocator quantum, so the
+//! estimate is built from the three real per-slot costs and one small per-column
+//! residual — **never** from a large fudge charged per cell:
+//!
+//! | term | charged | covers |
+//! |---|---|---|
+//! | [`ARROW_VALIDITY_BYTES`] | every slot | the slot's validity **bit**; `n` bytes ≥ `ceil(n/8)` |
+//! | content | every slot | the slot's data-buffer bytes |
+//! | [`ARROW_CELL_OVERHEAD_BYTES`] | variable-width slots | its offsets entry + the buffer's trailing `n+1`-th entry |
+//! | [`ARROW_COLUMN_SLACK_BYTES`] | once per projected **column** | array nodes that correspond to no slot at all |
+//!
+//! The per-cell terms are therefore tight (a 1000-element `list<int>` estimates
+//! ~1.2× its realized payload, not ~9×), and a wide fixed-width schema pays
+//! ~13 B/column/row rather than ~1 KB/row — so the row-cap, not the byte-cap,
+//! still binds on narrow shapes.
+//!
 //! # Conservatism is a contract, not an aspiration
 //!
 //! `Σ estimate_arrow_row_bytes(columns, row) >= arrow_payload_bytes(batch)` for
 //! every shape, enforced by the property test in `arrow_size_tests.rs` over a
 //! corpus covering fixed-width columns, `text`, `blob`, `list`/`set`, `map`,
-//! `tuple`/UDT, all-null rows, empty strings and empty collections. The three
-//! pre-existing per-`Value` estimators are all *under*-estimators for this
-//! purpose (see the issue-#2825 design §d): `Value::size_estimate` models the
-//! SERIALIZED size (a 1-byte vint prefix where Arrow spends a 4-byte offset plus
-//! a validity bit), and `memory::estimate_value_size` /
-//! `Memtable::estimate_value_size` are content-only. None is Arrow-aware, and an
-//! under-estimator cannot found a memory bound.
+//! `tuple`/UDT, JSON, deeply nested empty collections, all-null rows, empty
+//! strings and empty collections. The three pre-existing per-`Value` estimators
+//! are all *under*-estimators for this purpose (see the issue-#2825 design §d):
+//! `Value::size_estimate` models the SERIALIZED size (a 1-byte vint prefix where
+//! Arrow spends a 4-byte offset plus a validity bit), and
+//! `memory::estimate_value_size` / `Memtable::estimate_value_size` are
+//! content-only. None is Arrow-aware, and an under-estimator cannot found a
+//! memory bound.
 //!
 //! # No-heuristics (issue #28)
 //!
@@ -49,49 +71,68 @@
 //! # Hardening
 //!
 //! The walk is **iterative** (an explicit worklist, never recursion), bounded by
-//! [`MAX_ESTIMATE_NODES`], and every arithmetic step is saturating. A value
-//! deeper or wider than the node budget, or one whose widths would overflow
-//! `usize`, **fails closed** to `usize::MAX` — which trips the byte-cap and cuts
-//! the batch, the safe direction. It never panics and never hangs.
+//! [`MAX_ESTIMATE_NODES`], and every arithmetic step is saturating. A fan-out is
+//! tested against the remaining budget **before** it is pushed, so a corrupt
+//! collection cannot transiently balloon the worklist. A value deeper or wider
+//! than the node budget, or one whose widths would overflow `usize`, **fails
+//! closed** to `usize::MAX` — which trips the byte-cap and cuts the batch, the
+//! safe direction. It never panics and never hangs.
 
 use crate::query::{ColumnInfo, QueryRow};
 use crate::schema::CqlType;
 use crate::types::{DataType, Value};
 
+// The rendered-representation bounds (`charge_rendered`, `json_render_bytes`)
+// live in a child module so this file stays under the campsite threshold
+// (epic #1116). A child module sees this module's private items.
+#[path = "arrow_size_render.rs"]
+mod render;
+
+use render::RENDER_CONTAINER_BYTES;
+
 // ============================================================================
-// Published structural constants
+// Structural constants
 // ============================================================================
+//
+// Deliberately NOT part of the crate's public surface (issue #2825 review N4):
+// these are tuning parameters of the estimate, not a contract. The public
+// surface is `estimate_arrow_row_bytes` / `arrow_payload_bytes` /
+// `MAX_ESTIMATE_NODES`.
 
 /// Width of one Arrow 32-bit offset entry (`Utf8`/`Binary`/`List`/`Map`).
-pub const ARROW_OFFSET_BYTES: usize = 4;
+const ARROW_OFFSET_BYTES: usize = 4;
 
-/// Validity charged per Arrow slot. Arrow spends one **bit**; this rounds up to
-/// a whole byte so a short batch — whose validity buffer length is dominated by
-/// allocator rounding rather than by `ceil(n/8)` — is still covered.
-pub const ARROW_VALIDITY_BYTES: usize = 1;
+/// Validity charged per Arrow slot. Arrow spends one **bit** per slot, so a
+/// buffer over `n` slots is `ceil(n / 8)` bytes long; charging one whole byte
+/// per slot covers that for every `n` with room to spare.
+const ARROW_VALIDITY_BYTES: usize = 1;
 
-/// Per-cell structural overhead of a **variable-width** Arrow slot: its offsets
-/// entry plus its validity byte.
+/// Per-cell structural overhead of a **variable-width** Arrow slot, charged on
+/// top of the universal per-slot validity byte.
 ///
-/// This is the term every pre-existing estimator omits, and the reason a
-/// content-only sum is an under-count. A trailing offsets entry (`n + 1` offsets
-/// for `n` slots) and small-buffer allocator rounding are absorbed by
-/// [`ARROW_SLOT_SLACK_BYTES`].
-pub const ARROW_CELL_OVERHEAD_BYTES: usize = ARROW_OFFSET_BYTES + ARROW_VALIDITY_BYTES;
+/// Derivation (not a fitted constant): an offsets buffer over `n` slots is
+/// `(n + 1) * 4` bytes — one entry per slot plus a trailing entry. Charging
+/// **two** entries per slot covers the trailing entry however few slots the
+/// buffer has, with `n = 1` the tight case: realized
+/// `4 * (1 + 1) + ceil(1/8) = 9`, charged `4 + 4 + 1 = 9`. The extra validity
+/// byte here (the second one a variable-width slot pays) is deliberate margin.
+const ARROW_CELL_OVERHEAD_BYTES: usize = 2 * ARROW_OFFSET_BYTES + ARROW_VALIDITY_BYTES;
 
-/// Fixed slack charged on **every** Arrow slot (fixed-width or variable-width).
+/// Residual slack charged ONCE per projected **column** per row — never per
+/// cell, per element or per field.
 ///
-/// Covers the per-buffer costs that are NOT proportional to the slot count and
-/// so cannot be amortized by a strictly per-row estimator: chiefly the trailing
-/// `n + 1`-th offsets entry of each variable-width buffer, which a one-row batch
-/// pays in full. Measured against arrow 53 the tightest corpus shape (a one-row
-/// 64 KiB blob) needs only 2 bytes here; 32 leaves an order of magnitude of
-/// headroom while costing a narrow 3-column row ~100 B — three orders below the
-/// 4 MiB default cap, so the row-cap still binds on every narrow shape.
+/// Derivation: a column can materialize Arrow array nodes that correspond to no
+/// value slot at all, and each such node still carries an empty 4-byte offsets
+/// buffer. The tight case is the flat `DataType::Map` builder, whose `MapArray`
+/// always materializes a key `Utf8` and a value `Utf8` child even for a cell
+/// with zero entries: `2 × 4 = 8` bytes with no slot to attach them to. (The
+/// high-fidelity path charges such nodes explicitly — see `charge_cql`'s
+/// empty-collection rule — so this stays a residual, not the mechanism.)
 ///
-/// Charged per slot rather than per batch deliberately: the accumulate-as-you-
-/// push cap needs a per-row number, and a per-batch term has nowhere to live.
-pub const ARROW_SLOT_SLACK_BYTES: usize = 32;
+/// Charged per row because the accumulate-as-you-push cap needs a per-row
+/// number and a per-batch term has nowhere to live; per COLUMN rather than per
+/// SLOT so it cannot multiply by a cell's element count.
+const ARROW_COLUMN_SLACK_BYTES: usize = 2 * ARROW_OFFSET_BYTES;
 
 /// Maximum number of value/type nodes one row's estimate may visit.
 ///
@@ -100,44 +141,6 @@ pub const ARROW_SLOT_SLACK_BYTES: usize = 32;
 /// above any legitimate Cassandra row shape (a 4-column row of 1000-element
 /// collections visits ~4000 nodes).
 pub const MAX_ESTIMATE_NODES: usize = 65_536;
-
-// ---- Rendered-representation bounds -----------------------------------------
-//
-// Columns with no authoritative CQL type (and the `Tuple`/`Udt`/`Frozen`/
-// `Tombstone`/`Null` flat arms) are converted by `build_string_array`, which
-// renders the value through `ValueFormatter::format_value`. These bound that
-// rendering; each is an upper bound on the corresponding `format_value` arm.
-
-/// `"true"` / `"false"`.
-const RENDER_BOOL_BYTES: usize = 8;
-/// Any integral variant rendered as decimal (`i64::MIN` is 20 chars).
-const RENDER_INT_BYTES: usize = 24;
-/// `f32`/`f64` via `{}`/`{:e}`, plus `NaN`/`Infinity`.
-const RENDER_FLOAT_BYTES: usize = 40;
-/// `"a8f167f0-ebe7-4f20-a386-31ff138bec3b"`.
-const RENDER_UUID_BYTES: usize = 40;
-/// `YYYY-MM-DD HH:MM:SS.fff+0000` or `<invalid-timestamp:-9223372036854775808>`.
-const RENDER_TIMESTAMP_BYTES: usize = 48;
-/// `YYYY-MM-DD` or the `<invalid-date:…>` fallback.
-const RENDER_DATE_BYTES: usize = 48;
-/// `HH:MM:SS.nnnnnnnnn` or the `<invalid-time:…>` fallback.
-const RENDER_TIME_BYTES: usize = 48;
-/// Full IPv6 text form, or the invalid-length fallback.
-const RENDER_INET_BYTES: usize = 64;
-/// `"{months}mo{days}d{nanos}ns"` at the widest.
-const RENDER_DURATION_BYTES: usize = 64;
-/// `"<deleted@{i64}>"`.
-const RENDER_TOMBSTONE_BYTES: usize = 40;
-/// `"null"`.
-const RENDER_NULL_BYTES: usize = 8;
-/// Brackets plus the `", "` separators a rendered container adds around its
-/// (separately charged) children.
-const RENDER_CONTAINER_BYTES: usize = 8;
-/// Decimal digits produced per magnitude byte (`log10(256) < 2.41`), rounded up.
-const DECIMAL_DIGITS_PER_BYTE: usize = 3;
-/// `ValueFormatter::format_decimal`'s zero-padding ceiling: past this the render
-/// switches to bounded exponent form, so padding can never exceed it.
-const DECIMAL_SCALE_RENDER_CAP: usize = 1_000_001;
 
 // ============================================================================
 // Public API
@@ -188,6 +191,8 @@ pub fn estimate_arrow_row_bytes(columns: &[ColumnInfo], row: &QueryRow) -> usize
     let mut est = Estimator::new();
     for col in columns {
         let cell = row.values.get(col.name.as_str());
+        // The per-column residual, charged exactly once per column per row.
+        est.add(ARROW_COLUMN_SLACK_BYTES);
         // Charge the column's own slot DIRECTLY rather than through the
         // worklist: a scalar column pushes no children, so the narrow path
         // never allocates the stack at all (`Vec::new` does not allocate until
@@ -239,20 +244,36 @@ enum Shape<'a> {
     Cql(&'a CqlType),
     /// Flat `DataType` dispatch (the legacy builders).
     Flat(&'a DataType),
-    /// `build_string_array`'s permissive arm: the value is rendered through
-    /// `ValueFormatter::format_value` into a `Utf8` slot.
-    Rendered,
+    /// A REAL `Utf8` array slot whose content is `ValueFormatter::format_value`'s
+    /// rendering — `build_string_array`, and each element slot of
+    /// `build_list_array` / `build_map_array`. Pays the variable-width slot
+    /// overhead.
+    RenderedSlot,
+    /// NOT an array slot of its own: a sub-part of an enclosing slot's single
+    /// rendered string (a container element rendered inline). Pays content only.
+    RenderedInline,
 }
 
 /// Resolve a column to its Arrow slot shape, mirroring `convert_column_to_array`
-/// exactly: only the high-fidelity CQL arms take the typed path; everything else
-/// (including `Text`/`Blob`/numeric CQL types) falls through to the flat
+/// exactly: the high-fidelity CQL arms take the typed path; everything else
+/// (numeric CQL types, `Blob`, an absent CQL type) falls through to the flat
 /// `data_type` dispatch.
+///
+/// `Text`/`Ascii`/`Varchar` are routed to the typed arm even though the
+/// converter reaches them through `build_string_array`, because that builder's
+/// `strict_text` branch — taken for exactly these three CQL types — borrows the
+/// `&str` after a NON-lossy `str::from_utf8` and hard-errors on invalid UTF-8.
+/// Its byte behaviour is the typed one (`s.len()`), not the lossy rendered one
+/// (up to `3 * s.len()`), so charging it as flat text would over-estimate every
+/// authoritative text column by ~3x.
 fn column_shape(col: &ColumnInfo) -> Shape<'_> {
     if let Some(cql) = &col.cql_type {
         let effective = unwrap_frozen_type(cql);
         match effective {
-            CqlType::Date
+            CqlType::Text
+            | CqlType::Ascii
+            | CqlType::Varchar
+            | CqlType::Date
             | CqlType::Time
             | CqlType::Decimal
             | CqlType::Varint
@@ -275,9 +296,6 @@ fn column_shape(col: &ColumnInfo) -> Shape<'_> {
             | CqlType::BigInt
             | CqlType::Float
             | CqlType::Double
-            | CqlType::Text
-            | CqlType::Ascii
-            | CqlType::Varchar
             | CqlType::Blob
             | CqlType::Timestamp
             | CqlType::Frozen(_)
@@ -363,14 +381,17 @@ impl<'a> Estimator<'a> {
             return;
         }
         self.budget -= 1;
-        // Every slot pays its validity bit (rounded to a byte) plus the fixed
-        // per-slot slack that absorbs the trailing offsets entry.
-        self.add(ARROW_VALIDITY_BYTES.saturating_add(ARROW_SLOT_SLACK_BYTES));
+        // Every slot pays its validity bit, rounded up to a whole byte.
+        self.add(ARROW_VALIDITY_BYTES);
         let value = value.map(unwrap_frozen_value);
         match shape {
             Shape::Cql(t) => self.charge_cql(t, value),
             Shape::Flat(dt) => self.charge_flat(dt, value),
-            Shape::Rendered => self.charge_rendered(value),
+            Shape::RenderedSlot => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.charge_rendered(value);
+            }
+            Shape::RenderedInline => self.charge_rendered(value),
         }
     }
 
@@ -412,13 +433,14 @@ impl<'a> Estimator<'a> {
             // Utf8 carrying a formatted rendering of a bounded scalar.
             CqlType::Inet => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
-                self.add(RENDER_INET_BYTES);
+                self.add(render::RENDER_INET_BYTES);
             }
             CqlType::Duration => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
-                self.add(RENDER_DURATION_BYTES);
+                self.add(render::RENDER_DURATION_BYTES);
             }
-            // Opaque custom type: `build_string_array`'s permissive render.
+            // Opaque custom type: `build_string_array`'s permissive render into
+            // this one Utf8 slot.
             CqlType::Custom(_) => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 self.charge_rendered(value);
@@ -427,48 +449,78 @@ impl<'a> Estimator<'a> {
             // per element.
             CqlType::List(inner) | CqlType::Set(inner) => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
-                if let Some(Value::List(items) | Value::Set(items)) = value {
-                    self.push_all(items.iter().map(|v| (Shape::Cql(inner), Some(v))));
-                } else if let Some(other) = value {
+                match value {
+                    Some(Value::List(items) | Value::Set(items)) if !items.is_empty() => {
+                        self.push_all(items.iter().map(|v| (Shape::Cql(inner), Some(v))));
+                    }
+                    // Empty, null or absent: `build_typed_value_array` still
+                    // materializes one child array per DECLARED nesting level,
+                    // each carrying an empty 4-byte offsets buffer. Charging the
+                    // declared chain covers a `list<list<…>>` whose depth no
+                    // per-slot constant could bound (review B2).
+                    Some(Value::List(_) | Value::Set(_) | Value::Null) | None => {
+                        self.push(Shape::Cql(inner), None);
+                    }
                     // Shape mismatch: the converter either errors (no batch) or
                     // renders. Charge the render bound, never zero.
-                    self.push(Shape::Rendered, Some(other));
+                    Some(other) => self.push(Shape::RenderedSlot, Some(other)),
                 }
             }
             // MapArray: the row's offsets entry, plus a key and a value child
-            // slot per entry (the entries struct's own slot is the key slot's
-            // slack, which is charged per pop).
+            // slot per entry (the entries struct itself carries no buffers).
             CqlType::Map(key_type, val_type) => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
-                if let Some(Value::Map(pairs)) = value {
-                    for (k, v) in pairs {
-                        self.push(Shape::Cql(key_type), Some(k));
-                        self.push(Shape::Cql(val_type), Some(v));
+                match value {
+                    Some(Value::Map(pairs)) if !pairs.is_empty() => {
+                        if !self.reserve(pairs.len().saturating_mul(2)) {
+                            return;
+                        }
+                        for (k, v) in pairs {
+                            self.push(Shape::Cql(key_type), Some(k));
+                            self.push(Shape::Cql(val_type), Some(v));
+                        }
                     }
-                    self.check_budget(pairs.len().saturating_mul(2));
-                } else if let Some(other) = value {
-                    self.push(Shape::Rendered, Some(other));
+                    // Empty/null/absent: both child arrays still exist — charge
+                    // the declared key and value type chains (review B2).
+                    Some(Value::Map(_) | Value::Null) | None => {
+                        if !self.reserve(2) {
+                            return;
+                        }
+                        self.push(Shape::Cql(key_type), None);
+                        self.push(Shape::Cql(val_type), None);
+                    }
+                    Some(other) => self.push(Shape::RenderedSlot, Some(other)),
                 }
             }
             // StructArray: no offsets; every DECLARED field materializes a child
-            // slot for this row whether or not the value carries it.
+            // slot for this row whether or not the value carries it. The extra
+            // variable-width overhead covers the Utf8 fallback the converter
+            // takes when the declared field list is empty.
             CqlType::Tuple(element_types) => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES.saturating_add(RENDER_CONTAINER_BYTES));
                 let items: &[Value] = match value {
                     Some(Value::Tuple(items) | Value::List(items)) => items,
                     _ => &[],
                 };
                 let n = element_types.len().max(items.len());
+                if !self.reserve(n) {
+                    return;
+                }
                 for i in 0..n {
-                    let shape = element_types.get(i).map_or(Shape::Rendered, Shape::Cql);
+                    let shape = element_types.get(i).map_or(Shape::RenderedSlot, Shape::Cql);
                     self.push(shape, items.get(i));
                 }
-                self.check_budget(n);
             }
             CqlType::Udt(_, udt_fields) => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES.saturating_add(RENDER_CONTAINER_BYTES));
                 let udt = match value {
                     Some(Value::Udt(udt)) => Some(udt.as_ref()),
                     _ => None,
                 };
+                let extras = udt.map_or(0, |u| u.fields.len());
+                if !self.reserve(udt_fields.len().saturating_add(extras)) {
+                    return;
+                }
                 for (name, field_type) in udt_fields {
                     let field_value = udt.and_then(|u| {
                         u.fields
@@ -479,18 +531,18 @@ impl<'a> Estimator<'a> {
                     self.push(Shape::Cql(field_type), field_value);
                 }
                 // A value carrying fields the declared type does not name still
-                // costs something on any render fallback — charge them too.
+                // costs something on the render fallback (`format_udt` emits
+                // `{name: value, …}`), so charge the NAME and its separators
+                // too — matching `charge_rendered`'s UDT arm (review B4).
                 if let Some(u) = udt {
                     let extra = u
                         .fields
                         .iter()
                         .filter(|f| !udt_fields.iter().any(|(n, _)| n == &f.name));
                     for f in extra {
-                        self.push(Shape::Rendered, f.value.as_ref());
+                        self.add(f.name.len().saturating_add(RENDER_CONTAINER_BYTES));
+                        self.push(Shape::RenderedInline, f.value.as_ref());
                     }
-                    self.check_budget(udt_fields.len().saturating_add(u.fields.len()));
-                } else {
-                    self.check_budget(udt_fields.len());
                 }
             }
             // Unreachable after `unwrap_frozen_type`, but kept explicit so the
@@ -501,6 +553,12 @@ impl<'a> Estimator<'a> {
 
     /// Charge a flat-`DataType` slot (the legacy builders). Exhaustive over
     /// [`DataType`] — a new variant is a compile error.
+    ///
+    /// The empty-collection child arrays these builders always materialize
+    /// (`ListArray<Utf8>` / `MapArray<Utf8, Utf8>`) are covered by
+    /// [`ARROW_COLUMN_SLACK_BYTES`], which is derived from exactly that case —
+    /// unlike the high-fidelity path, the flat builders have a FIXED one-level
+    /// child shape, so a constant suffices.
     fn charge_flat(&mut self, dt: &DataType, value: Option<&'a Value>) {
         match dt {
             DataType::Boolean | DataType::TinyInt => self.add(1),
@@ -518,22 +576,25 @@ impl<'a> Estimator<'a> {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 self.charge_rendered(value);
             }
-            // `build_list_array`: ListArray<Utf8> whose elements are rendered.
+            // `build_list_array`: ListArray<Utf8> whose elements are rendered —
+            // each element is a REAL child slot, not an inline sub-render.
             DataType::List | DataType::Set => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 if let Some(Value::List(items) | Value::Set(items)) = value {
-                    self.push_all(items.iter().map(|v| (Shape::Rendered, Some(v))));
+                    self.push_all(items.iter().map(|v| (Shape::RenderedSlot, Some(v))));
                 }
             }
             // `build_map_array`: MapArray with rendered Utf8 keys and values.
             DataType::Map => {
                 self.add(ARROW_CELL_OVERHEAD_BYTES);
                 if let Some(Value::Map(pairs)) = value {
-                    for (k, v) in pairs {
-                        self.push(Shape::Rendered, Some(k));
-                        self.push(Shape::Rendered, Some(v));
+                    if !self.reserve(pairs.len().saturating_mul(2)) {
+                        return;
                     }
-                    self.check_budget(pairs.len().saturating_mul(2));
+                    for (k, v) in pairs {
+                        self.push(Shape::RenderedSlot, Some(k));
+                        self.push(Shape::RenderedSlot, Some(v));
+                    }
                 }
             }
             // Fallback to `build_string_array`'s rendered representation.
@@ -548,112 +609,45 @@ impl<'a> Estimator<'a> {
         }
     }
 
-    /// Charge the `Utf8` rendering of `value` via `ValueFormatter::format_value`.
-    ///
-    /// Leaf variants get a constant bound; container variants charge their
-    /// bracket/separator overhead here and push their children as further
-    /// rendered slots (each child's own per-slot slack makes this strictly
-    /// conservative versus the single joined string arrow actually stores).
-    fn charge_rendered(&mut self, value: Option<&'a Value>) {
-        let Some(value) = value else {
-            return;
-        };
-        match unwrap_frozen_value(value) {
-            Value::Null => self.add(RENDER_NULL_BYTES),
-            Value::Boolean(_) => self.add(RENDER_BOOL_BYTES),
-            Value::TinyInt(_)
-            | Value::SmallInt(_)
-            | Value::Integer(_)
-            | Value::BigInt(_)
-            | Value::Counter(_) => self.add(RENDER_INT_BYTES),
-            Value::Float(_) | Value::Float32(_) => self.add(RENDER_FLOAT_BYTES),
-            Value::Text(s) => self.add(s.len()),
-            // `0x`-prefixed lowercase hex: two chars per byte.
-            Value::Blob(b) => self.add(
-                b.len()
-                    .saturating_mul(2)
-                    .saturating_add(RENDER_CONTAINER_BYTES),
-            ),
-            Value::Timestamp(_) => self.add(RENDER_TIMESTAMP_BYTES),
-            Value::Date(_) => self.add(RENDER_DATE_BYTES),
-            Value::Time(_) => self.add(RENDER_TIME_BYTES),
-            Value::Uuid(_) => self.add(RENDER_UUID_BYTES),
-            Value::Varint(b) => self.add(
-                b.len()
-                    .saturating_mul(DECIMAL_DIGITS_PER_BYTE)
-                    .saturating_add(RENDER_CONTAINER_BYTES),
-            ),
-            // Digits, plus `format_decimal`'s bounded zero padding (past
-            // `DECIMAL_SCALE_RENDER_CAP` it switches to exponent form).
-            Value::Decimal { scale, unscaled } => self.add(
-                unscaled
-                    .len()
-                    .saturating_mul(DECIMAL_DIGITS_PER_BYTE)
-                    .saturating_add((scale.unsigned_abs() as usize).min(DECIMAL_SCALE_RENDER_CAP))
-                    .saturating_add(RENDER_CONTAINER_BYTES),
-            ),
-            Value::Duration { .. } => self.add(RENDER_DURATION_BYTES),
-            Value::Inet(_) => self.add(RENDER_INET_BYTES),
-            Value::Tombstone(_) => self.add(RENDER_TOMBSTONE_BYTES),
-            Value::Json(json) => {
-                let bytes = json_render_bytes(json, &mut self.budget);
-                self.add(bytes);
-            }
-            Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
-                self.add(RENDER_CONTAINER_BYTES);
-                self.push_all(items.iter().map(|v| (Shape::Rendered, Some(v))));
-            }
-            Value::Map(pairs) => {
-                self.add(RENDER_CONTAINER_BYTES);
-                for (k, v) in pairs {
-                    self.push(Shape::Rendered, Some(k));
-                    self.push(Shape::Rendered, Some(v));
-                }
-                self.check_budget(pairs.len().saturating_mul(2));
-            }
-            Value::Udt(udt) => {
-                self.add(RENDER_CONTAINER_BYTES);
-                for f in &udt.fields {
-                    self.add(f.name.len().saturating_add(RENDER_CONTAINER_BYTES));
-                    self.push(Shape::Rendered, f.value.as_ref());
-                }
-                self.check_budget(udt.fields.len());
-            }
-            // Unreachable after `unwrap_frozen_value`; kept so the match is
-            // exhaustive without a `_` arm.
-            Value::Frozen(_) => self.add(RENDER_CONTAINER_BYTES),
-        }
-    }
-
+    /// Queue a whole fan-out, testing the node budget **before** anything is
+    /// pushed: a corrupt collection claiming 1e8 elements fails closed instead
+    /// of transiently materializing 1e8 worklist entries (review N1).
     fn push_all<I>(&mut self, items: I)
     where
-        I: Iterator<Item = (Shape<'a>, Option<&'a Value>)>,
+        I: ExactSizeIterator<Item = (Shape<'a>, Option<&'a Value>)>,
     {
-        let mut pushed = 0usize;
+        if !self.reserve(items.len()) {
+            return;
+        }
         for item in items {
             self.stack.push(item);
-            pushed = pushed.saturating_add(1);
         }
-        self.check_budget(pushed);
     }
 
-    /// Fail closed when a single fan-out already exceeds the remaining node
-    /// budget, so a pathologically wide collection saturates immediately rather
-    /// than after draining the worklist.
-    fn check_budget(&mut self, pushed: usize) {
-        if pushed > self.budget {
+    /// Fail closed when a fan-out of `n` slots already exceeds the remaining
+    /// node budget. Returns `false` when the estimate has been saturated and the
+    /// caller must stop.
+    fn reserve(&mut self, n: usize) -> bool {
+        if n > self.budget {
             self.saturate();
+            return false;
         }
+        true
     }
 }
 
 /// Bytes a `Value::Text` contributes to a `Utf8` slot (`0` when absent/null).
+///
+/// Exact, not tripled: this is the STRICT typed path, where `build_string_array`
+/// borrows the `&str` after a non-lossy `str::from_utf8` and hard-errors on
+/// invalid UTF-8 (so no replacement-character expansion is possible). The lossy
+/// rendered path charges 3× instead — see `charge_rendered`.
 fn text_content_bytes(value: Option<&Value>) -> usize {
     match value {
         Some(Value::Text(s)) => s.len(),
         // A wrong-variant value makes the converter fail closed (no batch); a
         // rendered fallback is bounded by the render arms. Charge nothing extra
-        // here — the slot overhead and slack are already charged.
+        // here — the slot overhead is already charged.
         _ => 0,
     }
 }
@@ -664,59 +658,6 @@ fn binary_content_bytes(value: Option<&Value>) -> usize {
         Some(Value::Blob(b)) => b.len(),
         _ => 0,
     }
-}
-
-/// Bounded upper bound on `serde_json::Value::to_string().len()`.
-///
-/// Iterative with its own share of the caller's node budget, so a deeply nested
-/// JSON document cannot recurse or spin. Returns `usize::MAX` when the budget is
-/// exhausted (fail closed).
-fn json_render_bytes(root: &serde_json::Value, budget: &mut usize) -> usize {
-    let mut total = 0usize;
-    let mut stack = vec![root];
-    while let Some(node) = stack.pop() {
-        if *budget == 0 {
-            return usize::MAX;
-        }
-        *budget -= 1;
-        match node {
-            serde_json::Value::Null => total = total.saturating_add(RENDER_NULL_BYTES),
-            serde_json::Value::Bool(_) => total = total.saturating_add(RENDER_BOOL_BYTES),
-            serde_json::Value::Number(_) => total = total.saturating_add(RENDER_FLOAT_BYTES),
-            // JSON string escaping can expand a byte to `\u00XX` (6 chars).
-            serde_json::Value::String(s) => {
-                total = total.saturating_add(
-                    s.len()
-                        .saturating_mul(6)
-                        .saturating_add(RENDER_CONTAINER_BYTES),
-                )
-            }
-            serde_json::Value::Array(items) => {
-                total = total.saturating_add(
-                    RENDER_CONTAINER_BYTES.saturating_add(items.len().saturating_mul(2)),
-                );
-                if items.len() > *budget {
-                    return usize::MAX;
-                }
-                stack.extend(items.iter());
-            }
-            serde_json::Value::Object(map) => {
-                total = total.saturating_add(RENDER_CONTAINER_BYTES);
-                if map.len() > *budget {
-                    return usize::MAX;
-                }
-                for (k, v) in map {
-                    total = total.saturating_add(
-                        k.len()
-                            .saturating_mul(6)
-                            .saturating_add(RENDER_CONTAINER_BYTES),
-                    );
-                    stack.push(v);
-                }
-            }
-        }
-    }
-    total
 }
 
 #[cfg(test)]

--- a/cqlite-core/src/export/arrow_size.rs
+++ b/cqlite-core/src/export/arrow_size.rs
@@ -188,8 +188,12 @@ pub fn estimate_arrow_row_bytes(columns: &[ColumnInfo], row: &QueryRow) -> usize
     let mut est = Estimator::new();
     for col in columns {
         let cell = row.values.get(col.name.as_str());
-        est.push(column_shape(col), cell);
-        est.run();
+        // Charge the column's own slot DIRECTLY rather than through the
+        // worklist: a scalar column pushes no children, so the narrow path
+        // never allocates the stack at all (`Vec::new` does not allocate until
+        // its first push). Only collection/struct cells reach `drain`.
+        est.charge_slot(column_shape(col), cell);
+        est.drain();
         if est.total == usize::MAX {
             return usize::MAX;
         }
@@ -350,24 +354,30 @@ impl<'a> Estimator<'a> {
         self.stack.clear();
     }
 
-    /// Drain the worklist, charging each slot.
-    fn run(&mut self) {
+    /// Charge exactly ONE Arrow array slot, pushing any child slots it implies.
+    ///
+    /// Spends one node from the budget and fails closed when it is exhausted.
+    fn charge_slot(&mut self, shape: Shape<'a>, value: Option<&'a Value>) {
+        if self.budget == 0 {
+            self.saturate();
+            return;
+        }
+        self.budget -= 1;
+        // Every slot pays its validity bit (rounded to a byte) plus the fixed
+        // per-slot slack that absorbs the trailing offsets entry.
+        self.add(ARROW_VALIDITY_BYTES.saturating_add(ARROW_SLOT_SLACK_BYTES));
+        let value = value.map(unwrap_frozen_value);
+        match shape {
+            Shape::Cql(t) => self.charge_cql(t, value),
+            Shape::Flat(dt) => self.charge_flat(dt, value),
+            Shape::Rendered => self.charge_rendered(value),
+        }
+    }
+
+    /// Drain the worklist, charging each queued child slot.
+    fn drain(&mut self) {
         while let Some((shape, value)) = self.stack.pop() {
-            if self.budget == 0 {
-                self.saturate();
-                return;
-            }
-            self.budget -= 1;
-            // Every slot pays its validity bit (rounded to a byte) plus the
-            // fixed per-slot slack that absorbs the trailing offsets entry and
-            // arrow's short-buffer length rounding.
-            self.add(ARROW_VALIDITY_BYTES.saturating_add(ARROW_SLOT_SLACK_BYTES));
-            let value = value.map(unwrap_frozen_value);
-            match shape {
-                Shape::Cql(t) => self.charge_cql(t, value),
-                Shape::Flat(dt) => self.charge_flat(dt, value),
-                Shape::Rendered => self.charge_rendered(value),
-            }
+            self.charge_slot(shape, value);
             if self.total == usize::MAX {
                 return;
             }

--- a/cqlite-core/src/export/arrow_size.rs
+++ b/cqlite-core/src/export/arrow_size.rs
@@ -1,0 +1,714 @@
+//! Conservative pre-materialization Arrow payload-byte estimator (issue #2825).
+//!
+//! # Why this exists
+//!
+//! The `cqlite-flight` egress path finishes a record batch on **row count**
+//! alone, so a batch's byte size is `batch_size × row_width` — an unbounded
+//! function of schema shape. Bounding it needs a byte decision made **while rows
+//! accumulate**, before any [`RecordBatch`] exists: building the batch to
+//! discover it is too big defeats the purpose, so
+//! `RecordBatch::get_array_memory_size()` cannot be the production trigger (it
+//! is only readable *after* every value has been allocated and copied).
+//!
+//! [`estimate_arrow_row_bytes`] supplies that pre-batch number: given the
+//! authoritative projected [`ColumnInfo`] set and one decoded [`QueryRow`], it
+//! reports an **upper bound** on that row's contribution to the resulting Arrow
+//! batch's *payload* bytes.
+//!
+//! # Currency: payload bytes, not `get_array_memory_size()`
+//!
+//! "Payload bytes" means the sum of Arrow buffer **lengths**, recursively
+//! including child data — exactly what [`arrow_payload_bytes`] measures.
+//! `get_array_memory_size()` reports buffer **capacity**, which the batch
+//! construction path grows by power-of-two doubling, so it runs up to ~2× the
+//! payload (measured 1.72–1.80× on realistic shapes). Payload bytes are
+//! estimable from the rows in hand, monotonic in row count, and stable across
+//! arrow versions and allocator policy; capacity is none of those. Consumers
+//! that need a capacity figure convert with the published capacity factor
+//! (`cqlite_flight::batch_bytes::BATCH_BYTES_CAPACITY_FACTOR`).
+//!
+//! # Conservatism is a contract, not an aspiration
+//!
+//! `Σ estimate_arrow_row_bytes(columns, row) >= arrow_payload_bytes(batch)` for
+//! every shape, enforced by the property test in `arrow_size_tests.rs` over a
+//! corpus covering fixed-width columns, `text`, `blob`, `list`/`set`, `map`,
+//! `tuple`/UDT, all-null rows, empty strings and empty collections. The three
+//! pre-existing per-`Value` estimators are all *under*-estimators for this
+//! purpose (see the issue-#2825 design §d): `Value::size_estimate` models the
+//! SERIALIZED size (a 1-byte vint prefix where Arrow spends a 4-byte offset plus
+//! a validity bit), and `memory::estimate_value_size` /
+//! `Memtable::estimate_value_size` are content-only. None is Arrow-aware, and an
+//! under-estimator cannot found a memory bound.
+//!
+//! # No-heuristics (issue #28)
+//!
+//! Width is derived from the authoritative `ColumnInfo` CQL/flat types plus the
+//! already-decoded [`Value`]s. Nothing is inferred from byte patterns and no
+//! decode decision is influenced.
+//!
+//! # Hardening
+//!
+//! The walk is **iterative** (an explicit worklist, never recursion), bounded by
+//! [`MAX_ESTIMATE_NODES`], and every arithmetic step is saturating. A value
+//! deeper or wider than the node budget, or one whose widths would overflow
+//! `usize`, **fails closed** to `usize::MAX` — which trips the byte-cap and cuts
+//! the batch, the safe direction. It never panics and never hangs.
+
+use crate::query::{ColumnInfo, QueryRow};
+use crate::schema::CqlType;
+use crate::types::{DataType, Value};
+
+// ============================================================================
+// Published structural constants
+// ============================================================================
+
+/// Width of one Arrow 32-bit offset entry (`Utf8`/`Binary`/`List`/`Map`).
+pub const ARROW_OFFSET_BYTES: usize = 4;
+
+/// Validity charged per Arrow slot. Arrow spends one **bit**; this rounds up to
+/// a whole byte so a short batch — whose validity buffer length is dominated by
+/// allocator rounding rather than by `ceil(n/8)` — is still covered.
+pub const ARROW_VALIDITY_BYTES: usize = 1;
+
+/// Per-cell structural overhead of a **variable-width** Arrow slot: its offsets
+/// entry plus its validity byte.
+///
+/// This is the term every pre-existing estimator omits, and the reason a
+/// content-only sum is an under-count. A trailing offsets entry (`n + 1` offsets
+/// for `n` slots) and small-buffer allocator rounding are absorbed by
+/// [`ARROW_SLOT_SLACK_BYTES`].
+pub const ARROW_CELL_OVERHEAD_BYTES: usize = ARROW_OFFSET_BYTES + ARROW_VALIDITY_BYTES;
+
+/// Fixed slack charged on **every** Arrow slot (fixed-width or variable-width).
+///
+/// Covers the per-buffer costs that are NOT proportional to the slot count and
+/// so cannot be amortized by a strictly per-row estimator: chiefly the trailing
+/// `n + 1`-th offsets entry of each variable-width buffer, which a one-row batch
+/// pays in full. Measured against arrow 53 the tightest corpus shape (a one-row
+/// 64 KiB blob) needs only 2 bytes here; 32 leaves an order of magnitude of
+/// headroom while costing a narrow 3-column row ~100 B — three orders below the
+/// 4 MiB default cap, so the row-cap still binds on every narrow shape.
+///
+/// Charged per slot rather than per batch deliberately: the accumulate-as-you-
+/// push cap needs a per-row number, and a per-batch term has nowhere to live.
+pub const ARROW_SLOT_SLACK_BYTES: usize = 32;
+
+/// Maximum number of value/type nodes one row's estimate may visit.
+///
+/// A row whose values nest or fan out past this budget fails closed to
+/// `usize::MAX` (cut the batch) instead of spending unbounded time. Sized well
+/// above any legitimate Cassandra row shape (a 4-column row of 1000-element
+/// collections visits ~4000 nodes).
+pub const MAX_ESTIMATE_NODES: usize = 65_536;
+
+// ---- Rendered-representation bounds -----------------------------------------
+//
+// Columns with no authoritative CQL type (and the `Tuple`/`Udt`/`Frozen`/
+// `Tombstone`/`Null` flat arms) are converted by `build_string_array`, which
+// renders the value through `ValueFormatter::format_value`. These bound that
+// rendering; each is an upper bound on the corresponding `format_value` arm.
+
+/// `"true"` / `"false"`.
+const RENDER_BOOL_BYTES: usize = 8;
+/// Any integral variant rendered as decimal (`i64::MIN` is 20 chars).
+const RENDER_INT_BYTES: usize = 24;
+/// `f32`/`f64` via `{}`/`{:e}`, plus `NaN`/`Infinity`.
+const RENDER_FLOAT_BYTES: usize = 40;
+/// `"a8f167f0-ebe7-4f20-a386-31ff138bec3b"`.
+const RENDER_UUID_BYTES: usize = 40;
+/// `YYYY-MM-DD HH:MM:SS.fff+0000` or `<invalid-timestamp:-9223372036854775808>`.
+const RENDER_TIMESTAMP_BYTES: usize = 48;
+/// `YYYY-MM-DD` or the `<invalid-date:…>` fallback.
+const RENDER_DATE_BYTES: usize = 48;
+/// `HH:MM:SS.nnnnnnnnn` or the `<invalid-time:…>` fallback.
+const RENDER_TIME_BYTES: usize = 48;
+/// Full IPv6 text form, or the invalid-length fallback.
+const RENDER_INET_BYTES: usize = 64;
+/// `"{months}mo{days}d{nanos}ns"` at the widest.
+const RENDER_DURATION_BYTES: usize = 64;
+/// `"<deleted@{i64}>"`.
+const RENDER_TOMBSTONE_BYTES: usize = 40;
+/// `"null"`.
+const RENDER_NULL_BYTES: usize = 8;
+/// Brackets plus the `", "` separators a rendered container adds around its
+/// (separately charged) children.
+const RENDER_CONTAINER_BYTES: usize = 8;
+/// Decimal digits produced per magnitude byte (`log10(256) < 2.41`), rounded up.
+const DECIMAL_DIGITS_PER_BYTE: usize = 3;
+/// `ValueFormatter::format_decimal`'s zero-padding ceiling: past this the render
+/// switches to bounded exponent form, so padding can never exceed it.
+const DECIMAL_SCALE_RENDER_CAP: usize = 1_000_001;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Upper bound, in Arrow **payload** bytes, on `row`'s contribution to a batch
+/// built from `columns` by [`rows_to_record_batch`](super::rows_to_record_batch).
+///
+/// Walks `columns` (never the whole `row.values` map — an unprojected cell never
+/// reaches the batch) and resolves each cell exactly as `transpose_columns`
+/// does, then charges, per Arrow slot, the slot's structural overhead plus its
+/// value-driven content bytes.
+///
+/// Returns `usize::MAX` when the row exhausts [`MAX_ESTIMATE_NODES`] or its
+/// widths saturate — a fail-closed signal that cuts the batch.
+///
+/// # Example
+///
+/// ```
+/// # use std::collections::HashMap;
+/// # use std::sync::Arc;
+/// # use cqlite_core::export::estimate_arrow_row_bytes;
+/// # use cqlite_core::query::{ColumnInfo, QueryRow};
+/// # use cqlite_core::types::{DataType, Value};
+/// # use cqlite_core::schema::CqlType;
+/// # use cqlite_core::RowKey;
+/// let columns = vec![ColumnInfo {
+///     name: "b".into(),
+///     data_type: DataType::Blob,
+///     nullable: true,
+///     position: 0,
+///     table_name: None,
+///     cql_type: Some(CqlType::Blob),
+/// }];
+/// let row_with = |n: usize| {
+///     let mut values: HashMap<Arc<str>, Value> = HashMap::new();
+///     values.insert(Arc::from("b"), Value::Blob(vec![0u8; n].into()));
+///     QueryRow::with_interned_values(RowKey::new(Vec::new()), values)
+/// };
+/// // Width-sensitive: the estimates differ by at least the content difference.
+/// assert!(
+///     estimate_arrow_row_bytes(&columns, &row_with(1024))
+///         - estimate_arrow_row_bytes(&columns, &row_with(16))
+///         >= 1024 - 16
+/// );
+/// ```
+pub fn estimate_arrow_row_bytes(columns: &[ColumnInfo], row: &QueryRow) -> usize {
+    let mut est = Estimator::new();
+    for col in columns {
+        let cell = row.values.get(col.name.as_str());
+        est.push(column_shape(col), cell);
+        est.run();
+        if est.total == usize::MAX {
+            return usize::MAX;
+        }
+    }
+    est.total
+}
+
+/// Sum of Arrow buffer **lengths** across `batch`, recursively including child
+/// data — the cap's currency, and the oracle [`estimate_arrow_row_bytes`] must
+/// never under-count.
+///
+/// Distinct from `RecordBatch::get_array_memory_size()`, which sums buffer
+/// *capacity* (allocator growth policy) and so reports up to ~2× this value.
+/// Public because the byte-cap is normatively denominated in this quantity: the
+/// flight-side tests and issue #2821's per-stream ceiling both need to measure
+/// it, and duplicating the walk per consumer would let it drift.
+pub fn arrow_payload_bytes(batch: &arrow::record_batch::RecordBatch) -> usize {
+    let mut total = 0usize;
+    let mut stack: Vec<arrow::array::ArrayData> =
+        batch.columns().iter().map(|c| c.to_data()).collect();
+    while let Some(data) = stack.pop() {
+        for buffer in data.buffers() {
+            total = total.saturating_add(buffer.len());
+        }
+        if let Some(nulls) = data.nulls() {
+            total = total.saturating_add(nulls.buffer().len());
+        }
+        stack.extend(data.child_data().iter().cloned());
+    }
+    total
+}
+
+// ============================================================================
+// Shape resolution
+// ============================================================================
+
+/// How one Arrow slot is produced, mirroring `convert_column_to_array`'s
+/// dispatch so the estimate tracks the converter rather than guessing.
+#[derive(Clone, Copy)]
+enum Shape<'a> {
+    /// High-fidelity CQL-typed slot (`build_typed_value_array` and the typed
+    /// scalar builders).
+    Cql(&'a CqlType),
+    /// Flat `DataType` dispatch (the legacy builders).
+    Flat(&'a DataType),
+    /// `build_string_array`'s permissive arm: the value is rendered through
+    /// `ValueFormatter::format_value` into a `Utf8` slot.
+    Rendered,
+}
+
+/// Resolve a column to its Arrow slot shape, mirroring `convert_column_to_array`
+/// exactly: only the high-fidelity CQL arms take the typed path; everything else
+/// (including `Text`/`Blob`/numeric CQL types) falls through to the flat
+/// `data_type` dispatch.
+fn column_shape(col: &ColumnInfo) -> Shape<'_> {
+    if let Some(cql) = &col.cql_type {
+        let effective = unwrap_frozen_type(cql);
+        match effective {
+            CqlType::Date
+            | CqlType::Time
+            | CqlType::Decimal
+            | CqlType::Varint
+            | CqlType::Duration
+            | CqlType::Uuid
+            | CqlType::TimeUuid
+            | CqlType::Inet
+            | CqlType::Counter
+            | CqlType::List(_)
+            | CqlType::Set(_)
+            | CqlType::Map(_, _)
+            | CqlType::Tuple(_)
+            | CqlType::Udt(_, _) => return Shape::Cql(effective),
+            // Exhaustive by design (no `_` arm): a new `CqlType` variant is a
+            // COMPILE error here, so it can never be silently under-estimated.
+            CqlType::Boolean
+            | CqlType::TinyInt
+            | CqlType::SmallInt
+            | CqlType::Int
+            | CqlType::BigInt
+            | CqlType::Float
+            | CqlType::Double
+            | CqlType::Text
+            | CqlType::Ascii
+            | CqlType::Varchar
+            | CqlType::Blob
+            | CqlType::Timestamp
+            | CqlType::Frozen(_)
+            | CqlType::Custom(_) => {}
+        }
+    }
+    Shape::Flat(&col.data_type)
+}
+
+/// Unwrap nested `Frozen` wrappers to the effective type (mirrors
+/// `arrow_convert::unwrap_frozen_type`). Bounded: `Frozen` nesting comes from a
+/// parsed schema, and the loop is capped so a pathological type cannot spin.
+fn unwrap_frozen_type(mut t: &CqlType) -> &CqlType {
+    for _ in 0..MAX_FROZEN_DEPTH {
+        match t {
+            CqlType::Frozen(inner) => t = inner,
+            _ => return t,
+        }
+    }
+    t
+}
+
+/// Unwrap nested `Value::Frozen` wrappers (mirrors
+/// `arrow_convert::unwrap_frozen_value`), bounded the same way.
+fn unwrap_frozen_value(mut v: &Value) -> &Value {
+    for _ in 0..MAX_FROZEN_DEPTH {
+        match v {
+            Value::Frozen(inner) => v = inner,
+            _ => return v,
+        }
+    }
+    v
+}
+
+/// Cap on `Frozen` unwrap iterations — a bound, not a semantic limit: real
+/// schemas nest at most once or twice.
+const MAX_FROZEN_DEPTH: usize = 16;
+
+// ============================================================================
+// The iterative estimator
+// ============================================================================
+
+/// Iterative worklist over (slot shape, slot value) pairs.
+///
+/// One popped item is exactly one Arrow array slot; children (collection
+/// elements, map entries, struct fields) are pushed as further slots. The stack
+/// is lazily allocated, so a row of scalar columns never heap-allocates.
+struct Estimator<'a> {
+    total: usize,
+    budget: usize,
+    stack: Vec<(Shape<'a>, Option<&'a Value>)>,
+}
+
+impl<'a> Estimator<'a> {
+    fn new() -> Self {
+        Self {
+            total: 0,
+            budget: MAX_ESTIMATE_NODES,
+            stack: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, shape: Shape<'a>, value: Option<&'a Value>) {
+        self.stack.push((shape, value));
+    }
+
+    fn add(&mut self, bytes: usize) {
+        self.total = self.total.saturating_add(bytes);
+    }
+
+    /// Fail closed: saturate the total and abandon the walk.
+    fn saturate(&mut self) {
+        self.total = usize::MAX;
+        self.stack.clear();
+    }
+
+    /// Drain the worklist, charging each slot.
+    fn run(&mut self) {
+        while let Some((shape, value)) = self.stack.pop() {
+            if self.budget == 0 {
+                self.saturate();
+                return;
+            }
+            self.budget -= 1;
+            // Every slot pays its validity bit (rounded to a byte) plus the
+            // fixed per-slot slack that absorbs the trailing offsets entry and
+            // arrow's short-buffer length rounding.
+            self.add(ARROW_VALIDITY_BYTES.saturating_add(ARROW_SLOT_SLACK_BYTES));
+            let value = value.map(unwrap_frozen_value);
+            match shape {
+                Shape::Cql(t) => self.charge_cql(t, value),
+                Shape::Flat(dt) => self.charge_flat(dt, value),
+                Shape::Rendered => self.charge_rendered(value),
+            }
+            if self.total == usize::MAX {
+                return;
+            }
+        }
+    }
+
+    /// Charge a high-fidelity CQL-typed slot. Exhaustive over [`CqlType`] — a new
+    /// variant is a compile error, never a silent under-count.
+    fn charge_cql(&mut self, t: &'a CqlType, value: Option<&'a Value>) {
+        let t = unwrap_frozen_type(t);
+        match t {
+            // Fixed-width Arrow primitives: content is the primitive's width.
+            CqlType::Boolean | CqlType::TinyInt => self.add(1),
+            CqlType::SmallInt => self.add(2),
+            CqlType::Int | CqlType::Float | CqlType::Date => self.add(4),
+            CqlType::BigInt
+            | CqlType::Double
+            | CqlType::Counter
+            | CqlType::Timestamp
+            | CqlType::Time => self.add(8),
+            // FixedSizeBinary(16) / Decimal128.
+            CqlType::Uuid | CqlType::TimeUuid | CqlType::Decimal | CqlType::Varint => self.add(16),
+            // Utf8 / Binary carrying the value's own bytes.
+            CqlType::Text | CqlType::Ascii | CqlType::Varchar => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.add(text_content_bytes(value));
+            }
+            CqlType::Blob => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.add(binary_content_bytes(value));
+            }
+            // Utf8 carrying a formatted rendering of a bounded scalar.
+            CqlType::Inet => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.add(RENDER_INET_BYTES);
+            }
+            CqlType::Duration => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.add(RENDER_DURATION_BYTES);
+            }
+            // Opaque custom type: `build_string_array`'s permissive render.
+            CqlType::Custom(_) => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.charge_rendered(value);
+            }
+            // ListArray: the row's own offsets entry, plus one typed child slot
+            // per element.
+            CqlType::List(inner) | CqlType::Set(inner) => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                if let Some(Value::List(items) | Value::Set(items)) = value {
+                    self.push_all(items.iter().map(|v| (Shape::Cql(inner), Some(v))));
+                } else if let Some(other) = value {
+                    // Shape mismatch: the converter either errors (no batch) or
+                    // renders. Charge the render bound, never zero.
+                    self.push(Shape::Rendered, Some(other));
+                }
+            }
+            // MapArray: the row's offsets entry, plus a key and a value child
+            // slot per entry (the entries struct's own slot is the key slot's
+            // slack, which is charged per pop).
+            CqlType::Map(key_type, val_type) => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                if let Some(Value::Map(pairs)) = value {
+                    for (k, v) in pairs {
+                        self.push(Shape::Cql(key_type), Some(k));
+                        self.push(Shape::Cql(val_type), Some(v));
+                    }
+                    self.check_budget(pairs.len().saturating_mul(2));
+                } else if let Some(other) = value {
+                    self.push(Shape::Rendered, Some(other));
+                }
+            }
+            // StructArray: no offsets; every DECLARED field materializes a child
+            // slot for this row whether or not the value carries it.
+            CqlType::Tuple(element_types) => {
+                let items: &[Value] = match value {
+                    Some(Value::Tuple(items) | Value::List(items)) => items,
+                    _ => &[],
+                };
+                let n = element_types.len().max(items.len());
+                for i in 0..n {
+                    let shape = element_types.get(i).map_or(Shape::Rendered, Shape::Cql);
+                    self.push(shape, items.get(i));
+                }
+                self.check_budget(n);
+            }
+            CqlType::Udt(_, udt_fields) => {
+                let udt = match value {
+                    Some(Value::Udt(udt)) => Some(udt.as_ref()),
+                    _ => None,
+                };
+                for (name, field_type) in udt_fields {
+                    let field_value = udt.and_then(|u| {
+                        u.fields
+                            .iter()
+                            .find(|f| &f.name == name)
+                            .and_then(|f| f.value.as_ref())
+                    });
+                    self.push(Shape::Cql(field_type), field_value);
+                }
+                // A value carrying fields the declared type does not name still
+                // costs something on any render fallback — charge them too.
+                if let Some(u) = udt {
+                    let extra = u
+                        .fields
+                        .iter()
+                        .filter(|f| !udt_fields.iter().any(|(n, _)| n == &f.name));
+                    for f in extra {
+                        self.push(Shape::Rendered, f.value.as_ref());
+                    }
+                    self.check_budget(udt_fields.len().saturating_add(u.fields.len()));
+                } else {
+                    self.check_budget(udt_fields.len());
+                }
+            }
+            // Unreachable after `unwrap_frozen_type`, but kept explicit so the
+            // match stays exhaustive without a `_` arm.
+            CqlType::Frozen(inner) => self.push(Shape::Cql(inner), value),
+        }
+    }
+
+    /// Charge a flat-`DataType` slot (the legacy builders). Exhaustive over
+    /// [`DataType`] — a new variant is a compile error.
+    fn charge_flat(&mut self, dt: &DataType, value: Option<&'a Value>) {
+        match dt {
+            DataType::Boolean | DataType::TinyInt => self.add(1),
+            DataType::SmallInt => self.add(2),
+            DataType::Integer | DataType::Float32 => self.add(4),
+            DataType::BigInt | DataType::Float | DataType::Timestamp => self.add(8),
+            DataType::Uuid => self.add(16),
+            DataType::Blob => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.add(binary_content_bytes(value));
+            }
+            // `build_string_array`: raw text when the column is authoritative
+            // text, otherwise the rendered form. `charge_rendered` bounds both.
+            DataType::Text | DataType::Json => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.charge_rendered(value);
+            }
+            // `build_list_array`: ListArray<Utf8> whose elements are rendered.
+            DataType::List | DataType::Set => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                if let Some(Value::List(items) | Value::Set(items)) = value {
+                    self.push_all(items.iter().map(|v| (Shape::Rendered, Some(v))));
+                }
+            }
+            // `build_map_array`: MapArray with rendered Utf8 keys and values.
+            DataType::Map => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                if let Some(Value::Map(pairs)) = value {
+                    for (k, v) in pairs {
+                        self.push(Shape::Rendered, Some(k));
+                        self.push(Shape::Rendered, Some(v));
+                    }
+                    self.check_budget(pairs.len().saturating_mul(2));
+                }
+            }
+            // Fallback to `build_string_array`'s rendered representation.
+            DataType::Tuple
+            | DataType::Udt
+            | DataType::Frozen
+            | DataType::Tombstone
+            | DataType::Null => {
+                self.add(ARROW_CELL_OVERHEAD_BYTES);
+                self.charge_rendered(value);
+            }
+        }
+    }
+
+    /// Charge the `Utf8` rendering of `value` via `ValueFormatter::format_value`.
+    ///
+    /// Leaf variants get a constant bound; container variants charge their
+    /// bracket/separator overhead here and push their children as further
+    /// rendered slots (each child's own per-slot slack makes this strictly
+    /// conservative versus the single joined string arrow actually stores).
+    fn charge_rendered(&mut self, value: Option<&'a Value>) {
+        let Some(value) = value else {
+            return;
+        };
+        match unwrap_frozen_value(value) {
+            Value::Null => self.add(RENDER_NULL_BYTES),
+            Value::Boolean(_) => self.add(RENDER_BOOL_BYTES),
+            Value::TinyInt(_)
+            | Value::SmallInt(_)
+            | Value::Integer(_)
+            | Value::BigInt(_)
+            | Value::Counter(_) => self.add(RENDER_INT_BYTES),
+            Value::Float(_) | Value::Float32(_) => self.add(RENDER_FLOAT_BYTES),
+            Value::Text(s) => self.add(s.len()),
+            // `0x`-prefixed lowercase hex: two chars per byte.
+            Value::Blob(b) => self.add(
+                b.len()
+                    .saturating_mul(2)
+                    .saturating_add(RENDER_CONTAINER_BYTES),
+            ),
+            Value::Timestamp(_) => self.add(RENDER_TIMESTAMP_BYTES),
+            Value::Date(_) => self.add(RENDER_DATE_BYTES),
+            Value::Time(_) => self.add(RENDER_TIME_BYTES),
+            Value::Uuid(_) => self.add(RENDER_UUID_BYTES),
+            Value::Varint(b) => self.add(
+                b.len()
+                    .saturating_mul(DECIMAL_DIGITS_PER_BYTE)
+                    .saturating_add(RENDER_CONTAINER_BYTES),
+            ),
+            // Digits, plus `format_decimal`'s bounded zero padding (past
+            // `DECIMAL_SCALE_RENDER_CAP` it switches to exponent form).
+            Value::Decimal { scale, unscaled } => self.add(
+                unscaled
+                    .len()
+                    .saturating_mul(DECIMAL_DIGITS_PER_BYTE)
+                    .saturating_add((scale.unsigned_abs() as usize).min(DECIMAL_SCALE_RENDER_CAP))
+                    .saturating_add(RENDER_CONTAINER_BYTES),
+            ),
+            Value::Duration { .. } => self.add(RENDER_DURATION_BYTES),
+            Value::Inet(_) => self.add(RENDER_INET_BYTES),
+            Value::Tombstone(_) => self.add(RENDER_TOMBSTONE_BYTES),
+            Value::Json(json) => {
+                let bytes = json_render_bytes(json, &mut self.budget);
+                self.add(bytes);
+            }
+            Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
+                self.add(RENDER_CONTAINER_BYTES);
+                self.push_all(items.iter().map(|v| (Shape::Rendered, Some(v))));
+            }
+            Value::Map(pairs) => {
+                self.add(RENDER_CONTAINER_BYTES);
+                for (k, v) in pairs {
+                    self.push(Shape::Rendered, Some(k));
+                    self.push(Shape::Rendered, Some(v));
+                }
+                self.check_budget(pairs.len().saturating_mul(2));
+            }
+            Value::Udt(udt) => {
+                self.add(RENDER_CONTAINER_BYTES);
+                for f in &udt.fields {
+                    self.add(f.name.len().saturating_add(RENDER_CONTAINER_BYTES));
+                    self.push(Shape::Rendered, f.value.as_ref());
+                }
+                self.check_budget(udt.fields.len());
+            }
+            // Unreachable after `unwrap_frozen_value`; kept so the match is
+            // exhaustive without a `_` arm.
+            Value::Frozen(_) => self.add(RENDER_CONTAINER_BYTES),
+        }
+    }
+
+    fn push_all<I>(&mut self, items: I)
+    where
+        I: Iterator<Item = (Shape<'a>, Option<&'a Value>)>,
+    {
+        let mut pushed = 0usize;
+        for item in items {
+            self.stack.push(item);
+            pushed = pushed.saturating_add(1);
+        }
+        self.check_budget(pushed);
+    }
+
+    /// Fail closed when a single fan-out already exceeds the remaining node
+    /// budget, so a pathologically wide collection saturates immediately rather
+    /// than after draining the worklist.
+    fn check_budget(&mut self, pushed: usize) {
+        if pushed > self.budget {
+            self.saturate();
+        }
+    }
+}
+
+/// Bytes a `Value::Text` contributes to a `Utf8` slot (`0` when absent/null).
+fn text_content_bytes(value: Option<&Value>) -> usize {
+    match value {
+        Some(Value::Text(s)) => s.len(),
+        // A wrong-variant value makes the converter fail closed (no batch); a
+        // rendered fallback is bounded by the render arms. Charge nothing extra
+        // here — the slot overhead and slack are already charged.
+        _ => 0,
+    }
+}
+
+/// Bytes a `Value::Blob` contributes to a `Binary` slot (`0` when absent/null).
+fn binary_content_bytes(value: Option<&Value>) -> usize {
+    match value {
+        Some(Value::Blob(b)) => b.len(),
+        _ => 0,
+    }
+}
+
+/// Bounded upper bound on `serde_json::Value::to_string().len()`.
+///
+/// Iterative with its own share of the caller's node budget, so a deeply nested
+/// JSON document cannot recurse or spin. Returns `usize::MAX` when the budget is
+/// exhausted (fail closed).
+fn json_render_bytes(root: &serde_json::Value, budget: &mut usize) -> usize {
+    let mut total = 0usize;
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if *budget == 0 {
+            return usize::MAX;
+        }
+        *budget -= 1;
+        match node {
+            serde_json::Value::Null => total = total.saturating_add(RENDER_NULL_BYTES),
+            serde_json::Value::Bool(_) => total = total.saturating_add(RENDER_BOOL_BYTES),
+            serde_json::Value::Number(_) => total = total.saturating_add(RENDER_FLOAT_BYTES),
+            // JSON string escaping can expand a byte to `\u00XX` (6 chars).
+            serde_json::Value::String(s) => {
+                total = total.saturating_add(
+                    s.len()
+                        .saturating_mul(6)
+                        .saturating_add(RENDER_CONTAINER_BYTES),
+                )
+            }
+            serde_json::Value::Array(items) => {
+                total = total.saturating_add(
+                    RENDER_CONTAINER_BYTES.saturating_add(items.len().saturating_mul(2)),
+                );
+                if items.len() > *budget {
+                    return usize::MAX;
+                }
+                stack.extend(items.iter());
+            }
+            serde_json::Value::Object(map) => {
+                total = total.saturating_add(RENDER_CONTAINER_BYTES);
+                if map.len() > *budget {
+                    return usize::MAX;
+                }
+                for (k, v) in map {
+                    total = total.saturating_add(
+                        k.len()
+                            .saturating_mul(6)
+                            .saturating_add(RENDER_CONTAINER_BYTES),
+                    );
+                    stack.push(v);
+                }
+            }
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+#[path = "arrow_size_tests.rs"]
+mod arrow_size_tests;

--- a/cqlite-core/src/export/arrow_size_render.rs
+++ b/cqlite-core/src/export/arrow_size_render.rs
@@ -121,7 +121,7 @@ impl<'a> Estimator<'a> {
                     RENDER_CONTAINER_BYTES
                         .saturating_add(items.len().saturating_mul(RENDER_SEPARATOR_BYTES)),
                 );
-                self.push_all(items.iter().map(|v| (Shape::RenderedInline, Some(v))));
+                self.charge_children(items.iter().map(|v| (Shape::RenderedInline, Some(v))));
             }
             Value::Map(pairs) => {
                 self.add(
@@ -132,24 +132,23 @@ impl<'a> Estimator<'a> {
                             .saturating_mul(RENDER_SEPARATOR_BYTES),
                     ),
                 );
-                if !self.reserve(pairs.len().saturating_mul(2)) {
-                    return;
-                }
-                for (k, v) in pairs {
-                    self.push(Shape::RenderedInline, Some(k));
-                    self.push(Shape::RenderedInline, Some(v));
-                }
+                self.charge_children(pairs.iter().flat_map(|(k, v)| {
+                    [
+                        (Shape::RenderedInline, Some(k)),
+                        (Shape::RenderedInline, Some(v)),
+                    ]
+                }));
             }
             Value::Udt(udt) => {
                 self.add(RENDER_CONTAINER_BYTES);
-                if !self.reserve(udt.fields.len()) {
-                    return;
-                }
                 for f in &udt.fields {
+                    if self.total == usize::MAX {
+                        return;
+                    }
                     // `format_udt` emits `name: value` pairs — the name and both
                     // separators are charged here, the value as a child node.
                     self.add(f.name.len().saturating_add(RENDER_CONTAINER_BYTES));
-                    self.push(Shape::RenderedInline, f.value.as_ref());
+                    self.charge_child(Shape::RenderedInline, f.value.as_ref());
                 }
             }
             // Unreachable after `unwrap_frozen_value`; kept so the match is

--- a/cqlite-core/src/export/arrow_size_render.rs
+++ b/cqlite-core/src/export/arrow_size_render.rs
@@ -1,0 +1,214 @@
+//! Rendered-representation bounds for the Arrow payload-byte estimator
+//! (issue #2825).
+//!
+//! Columns with no authoritative CQL type (and the `Tuple`/`Udt`/`Frozen`/
+//! `Tombstone`/`Null` flat arms) are converted by `build_string_array`, which
+//! renders the value through `ValueFormatter::format_value`; the flat
+//! `build_list_array` / `build_map_array` render each ELEMENT the same way. The
+//! constants here each bound one `format_value` arm, and
+//! [`Estimator::charge_rendered`](super::Estimator::charge_rendered) walks a
+//! value against them.
+//!
+//! Split out of `arrow_size.rs` so both files stay under the campsite threshold
+//! (epic #1116). Declared as a CHILD module of `arrow_size`, so it can see that
+//! module's private [`Estimator`](super::Estimator) and [`Shape`](super::Shape).
+
+use super::{Estimator, Shape};
+use crate::types::Value;
+
+/// `"true"` / `"false"`.
+pub(super) const RENDER_BOOL_BYTES: usize = 8;
+/// Any integral variant rendered as decimal (`i64::MIN` is 20 chars).
+pub(super) const RENDER_INT_BYTES: usize = 24;
+/// `f32`/`f64` via `{}`/`{:e}`, plus `NaN`/`Infinity`.
+pub(super) const RENDER_FLOAT_BYTES: usize = 40;
+/// `"a8f167f0-ebe7-4f20-a386-31ff138bec3b"`.
+pub(super) const RENDER_UUID_BYTES: usize = 40;
+/// `YYYY-MM-DD HH:MM:SS.fff+0000` or `<invalid-timestamp:-9223372036854775808>`.
+pub(super) const RENDER_TIMESTAMP_BYTES: usize = 48;
+/// `YYYY-MM-DD` or the `<invalid-date:…>` fallback.
+pub(super) const RENDER_DATE_BYTES: usize = 48;
+/// `HH:MM:SS.nnnnnnnnn` or the `<invalid-time:…>` fallback.
+pub(super) const RENDER_TIME_BYTES: usize = 48;
+/// Full IPv6 text form, or the invalid-length fallback.
+pub(super) const RENDER_INET_BYTES: usize = 64;
+/// `"{months}mo{days}d{nanos}ns"` at the widest.
+pub(super) const RENDER_DURATION_BYTES: usize = 64;
+/// `"<deleted@{i64}>"`.
+pub(super) const RENDER_TOMBSTONE_BYTES: usize = 40;
+/// `"null"`.
+pub(super) const RENDER_NULL_BYTES: usize = 8;
+/// The brackets/braces a rendered container puts AROUND its children.
+pub(super) const RENDER_CONTAINER_BYTES: usize = 8;
+/// The `", "` (or `": "`) a rendered container puts BETWEEN its children —
+/// charged per child, because the children themselves are charged separately.
+pub(super) const RENDER_SEPARATOR_BYTES: usize = 2;
+/// Decimal digits produced per magnitude byte (`log10(256) < 2.41`), rounded up.
+pub(super) const DECIMAL_DIGITS_PER_BYTE: usize = 3;
+/// `ValueFormatter::format_decimal`'s zero-padding ceiling: past this the render
+/// switches to bounded exponent form, so padding can never exceed it.
+pub(super) const DECIMAL_SCALE_RENDER_CAP: usize = 1_000_001;
+/// Worst-case UTF-8 expansion of one input byte under `String::from_utf8_lossy`:
+/// an invalid byte becomes U+FFFD, three bytes.
+pub(super) const LOSSY_UTF8_EXPANSION: usize = 3;
+/// Worst-case JSON escape of one input byte: `\u00XX`, six characters.
+pub(super) const JSON_ESCAPE_EXPANSION: usize = 6;
+
+impl<'a> Estimator<'a> {
+    /// Charge the `Utf8` rendering of `value` via `ValueFormatter::format_value`.
+    ///
+    /// Content only — the caller has already charged whatever slot overhead the
+    /// rendering lands in. Leaf variants get a constant bound; container
+    /// variants charge their bracket/separator overhead here and push their
+    /// children as further INLINE rendered nodes (they are sub-parts of this one
+    /// string, not array slots of their own).
+    pub(super) fn charge_rendered(&mut self, value: Option<&'a Value>) {
+        let Some(value) = value else {
+            return;
+        };
+        match super::unwrap_frozen_value(value) {
+            Value::Null => self.add(RENDER_NULL_BYTES),
+            Value::Boolean(_) => self.add(RENDER_BOOL_BYTES),
+            Value::TinyInt(_)
+            | Value::SmallInt(_)
+            | Value::Integer(_)
+            | Value::BigInt(_)
+            | Value::Counter(_) => self.add(RENDER_INT_BYTES),
+            Value::Float(_) | Value::Float32(_) => self.add(RENDER_FLOAT_BYTES),
+            // LOSSY path: `ValueFormatter::format_value` renders text with
+            // `String::from_utf8_lossy`, which expands EACH invalid byte to a
+            // 3-byte U+FFFD. `Value::Text` is UTF-8-validated at construction
+            // (issue #1644), which would make `s.len()` exact — but that
+            // invariant is not enforced by the type, and a `Value::Text` nested
+            // inside a rendered container reaches this arm without passing the
+            // strict builders' `str::from_utf8` check. Charge the lossy worst
+            // case (review B5); the STRICT typed arm keeps `s.len()` because its
+            // builder hard-errors on invalid UTF-8 instead of expanding it.
+            Value::Text(s) => self.add(s.len().saturating_mul(LOSSY_UTF8_EXPANSION)),
+            // `0x`-prefixed lowercase hex: two chars per byte.
+            Value::Blob(b) => self.add(
+                b.len()
+                    .saturating_mul(2)
+                    .saturating_add(RENDER_CONTAINER_BYTES),
+            ),
+            Value::Timestamp(_) => self.add(RENDER_TIMESTAMP_BYTES),
+            Value::Date(_) => self.add(RENDER_DATE_BYTES),
+            Value::Time(_) => self.add(RENDER_TIME_BYTES),
+            Value::Uuid(_) => self.add(RENDER_UUID_BYTES),
+            Value::Varint(b) => self.add(
+                b.len()
+                    .saturating_mul(DECIMAL_DIGITS_PER_BYTE)
+                    .saturating_add(RENDER_CONTAINER_BYTES),
+            ),
+            // Digits, plus `format_decimal`'s bounded zero padding (past
+            // `DECIMAL_SCALE_RENDER_CAP` it switches to exponent form).
+            Value::Decimal { scale, unscaled } => self.add(
+                unscaled
+                    .len()
+                    .saturating_mul(DECIMAL_DIGITS_PER_BYTE)
+                    .saturating_add((scale.unsigned_abs() as usize).min(DECIMAL_SCALE_RENDER_CAP))
+                    .saturating_add(RENDER_CONTAINER_BYTES),
+            ),
+            Value::Duration { .. } => self.add(RENDER_DURATION_BYTES),
+            Value::Inet(_) => self.add(RENDER_INET_BYTES),
+            Value::Tombstone(_) => self.add(RENDER_TOMBSTONE_BYTES),
+            Value::Json(json) => {
+                let bytes = json_render_bytes(json, &mut self.budget);
+                self.add(bytes);
+            }
+            Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
+                self.add(
+                    RENDER_CONTAINER_BYTES
+                        .saturating_add(items.len().saturating_mul(RENDER_SEPARATOR_BYTES)),
+                );
+                self.push_all(items.iter().map(|v| (Shape::RenderedInline, Some(v))));
+            }
+            Value::Map(pairs) => {
+                self.add(
+                    RENDER_CONTAINER_BYTES.saturating_add(
+                        pairs
+                            .len()
+                            .saturating_mul(2)
+                            .saturating_mul(RENDER_SEPARATOR_BYTES),
+                    ),
+                );
+                if !self.reserve(pairs.len().saturating_mul(2)) {
+                    return;
+                }
+                for (k, v) in pairs {
+                    self.push(Shape::RenderedInline, Some(k));
+                    self.push(Shape::RenderedInline, Some(v));
+                }
+            }
+            Value::Udt(udt) => {
+                self.add(RENDER_CONTAINER_BYTES);
+                if !self.reserve(udt.fields.len()) {
+                    return;
+                }
+                for f in &udt.fields {
+                    // `format_udt` emits `name: value` pairs — the name and both
+                    // separators are charged here, the value as a child node.
+                    self.add(f.name.len().saturating_add(RENDER_CONTAINER_BYTES));
+                    self.push(Shape::RenderedInline, f.value.as_ref());
+                }
+            }
+            // Unreachable after `unwrap_frozen_value`; kept so the match is
+            // exhaustive without a `_` arm.
+            Value::Frozen(_) => self.add(RENDER_CONTAINER_BYTES),
+        }
+    }
+}
+
+/// Bounded upper bound on `serde_json::Value::to_string().len()`.
+///
+/// Iterative with its own share of the caller's node budget, so a deeply nested
+/// JSON document cannot recurse or spin. Returns `usize::MAX` when the budget is
+/// exhausted (fail closed).
+pub(super) fn json_render_bytes(root: &serde_json::Value, budget: &mut usize) -> usize {
+    let mut total = 0usize;
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if *budget == 0 {
+            return usize::MAX;
+        }
+        *budget -= 1;
+        match node {
+            serde_json::Value::Null => total = total.saturating_add(RENDER_NULL_BYTES),
+            serde_json::Value::Bool(_) => total = total.saturating_add(RENDER_BOOL_BYTES),
+            serde_json::Value::Number(_) => total = total.saturating_add(RENDER_FLOAT_BYTES),
+            // JSON string escaping can expand a byte to `\u00XX` (6 chars).
+            serde_json::Value::String(s) => {
+                total = total.saturating_add(
+                    s.len()
+                        .saturating_mul(JSON_ESCAPE_EXPANSION)
+                        .saturating_add(RENDER_CONTAINER_BYTES),
+                )
+            }
+            serde_json::Value::Array(items) => {
+                total = total.saturating_add(
+                    RENDER_CONTAINER_BYTES
+                        .saturating_add(items.len().saturating_mul(RENDER_SEPARATOR_BYTES)),
+                );
+                if items.len() > *budget {
+                    return usize::MAX;
+                }
+                stack.extend(items.iter());
+            }
+            serde_json::Value::Object(map) => {
+                total = total.saturating_add(RENDER_CONTAINER_BYTES);
+                if map.len() > *budget {
+                    return usize::MAX;
+                }
+                for (k, v) in map {
+                    total = total.saturating_add(
+                        k.len()
+                            .saturating_mul(JSON_ESCAPE_EXPANSION)
+                            .saturating_add(RENDER_CONTAINER_BYTES),
+                    );
+                    stack.push(v);
+                }
+            }
+        }
+    }
+    total
+}

--- a/cqlite-core/src/export/arrow_size_shape.rs
+++ b/cqlite-core/src/export/arrow_size_shape.rs
@@ -1,0 +1,265 @@
+//! Column shape resolution for the Arrow payload-byte estimator (issue #2825).
+//!
+//! Answers three questions about ONE projected column, all of them by mirroring
+//! `arrow_convert::convert_column_to_array`'s dispatch rather than guessing:
+//!
+//! * [`column_shape`] — which builder the converter will use for it;
+//! * [`column_slack_bytes`] — whether that builder materializes an Arrow array
+//!   node corresponding to no value slot, and so owes the per-column residual;
+//! * [`branches`] — whether charging one of its slots can queue further slots,
+//!   which decides whether the slot spends the structural node budget or the
+//!   leaf allowance.
+//!
+//! Split out of `arrow_size.rs` so both files stay under the campsite threshold
+//! (epic #1116). Declared as a CHILD module of `arrow_size`, so it can see that
+//! module's private constants and be seen by its sibling `render`.
+
+use crate::query::ColumnInfo;
+use crate::schema::CqlType;
+use crate::types::{DataType, Value};
+
+use super::ARROW_COLUMN_SLACK_BYTES;
+
+/// How one Arrow slot is produced, mirroring `convert_column_to_array`'s
+/// dispatch so the estimate tracks the converter rather than guessing.
+#[derive(Clone, Copy)]
+pub(super) enum Shape<'a> {
+    /// High-fidelity CQL-typed slot (`build_typed_value_array` and the typed
+    /// scalar builders).
+    Cql(&'a CqlType),
+    /// Flat `DataType` dispatch (the legacy builders), carrying whether the
+    /// column's CQL type makes `build_string_array` take its STRICT branch.
+    Flat(&'a DataType, TextFidelity),
+    /// A REAL `Utf8` array slot whose content is `ValueFormatter::format_value`'s
+    /// rendering — `build_string_array`, and each element slot of
+    /// `build_list_array` / `build_map_array`. Pays the variable-width slot
+    /// overhead.
+    RenderedSlot,
+    /// NOT an array slot of its own: a sub-part of an enclosing slot's single
+    /// rendered string (a container element rendered inline). Pays content only.
+    RenderedInline,
+}
+
+/// Whether a column's CQL type is an AUTHORITATIVE text type, which makes
+/// `build_string_array` take its `strict_text` branch: it borrows the `&str`
+/// after a NON-lossy `str::from_utf8` and hard-errors on invalid UTF-8, rather
+/// than rendering through the lossy `ValueFormatter::format_value`. The two
+/// branches have different byte behaviour (`s.len()` versus up to `3 * s.len()`
+/// of U+FFFD expansion), so the estimate must distinguish them.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum TextFidelity {
+    /// `cql_type` is `Text`/`Ascii`/`Varchar`: exact, non-lossy.
+    Strict,
+    /// No authoritative text type: `format_value`'s lossy rendering.
+    Lossy,
+}
+
+/// Resolve a column to its Arrow slot shape, mirroring `convert_column_to_array`
+/// exactly: only the high-fidelity CQL arms take the typed path; everything else
+/// (including `Text`/`Blob`/numeric CQL types) falls through to the flat
+/// `data_type` dispatch — `convert_column_to_array` dispatches those on
+/// `data_type` alone, so the estimate must too.
+pub(super) fn column_shape(col: &ColumnInfo) -> Shape<'_> {
+    let mut fidelity = TextFidelity::Lossy;
+    if let Some(cql) = &col.cql_type {
+        let effective = unwrap_frozen_type(cql);
+        match effective {
+            CqlType::Text | CqlType::Ascii | CqlType::Varchar => {
+                // Falls through to the flat dispatch, but tells it which
+                // `build_string_array` branch the converter will take.
+                fidelity = TextFidelity::Strict;
+            }
+            CqlType::Date
+            | CqlType::Time
+            | CqlType::Decimal
+            | CqlType::Varint
+            | CqlType::Duration
+            | CqlType::Uuid
+            | CqlType::TimeUuid
+            | CqlType::Inet
+            | CqlType::Counter
+            | CqlType::List(_)
+            | CqlType::Set(_)
+            | CqlType::Map(_, _)
+            | CqlType::Tuple(_)
+            | CqlType::Udt(_, _) => return Shape::Cql(effective),
+            // Exhaustive by design (no `_` arm): a new `CqlType` variant is a
+            // COMPILE error here, so it can never be silently under-estimated.
+            CqlType::Boolean
+            | CqlType::TinyInt
+            | CqlType::SmallInt
+            | CqlType::Int
+            | CqlType::BigInt
+            | CqlType::Float
+            | CqlType::Double
+            | CqlType::Blob
+            | CqlType::Timestamp
+            | CqlType::Frozen(_)
+            | CqlType::Custom(_) => {}
+        }
+    }
+    Shape::Flat(&col.data_type, fidelity)
+}
+
+/// Residual charged once per row for `shape`'s column — [`ARROW_COLUMN_SLACK_BYTES`]
+/// only where the converter can materialize an Arrow array node that corresponds
+/// to no value slot, and `0` everywhere else (issue #2825 review C1).
+///
+/// Only the FLAT `list`/`set`/`map` builders have such a node: `build_list_array`
+/// always builds a `Utf8` child and `build_map_array` always builds a key and a
+/// value `Utf8` child, each carrying an empty 4-byte offsets buffer, however few
+/// entries the cell holds. Every other column is either a single array node with
+/// no children (every fixed-width builder, `build_binary_array`,
+/// `build_string_array` and the render fallbacks that route through it) or takes
+/// the high-fidelity path, which charges each declared child node EXPLICITLY —
+/// see `charge_cql`'s empty-collection rule. Charging the residual for those
+/// over-counted a fixed-width column by ~3.2× (13 B/row estimated against
+/// ~4.1 B/row realized) and put the byte-cap's binding point at 40 `int`
+/// columns, where the row-cap must still bind.
+///
+/// Exhaustive over [`DataType`] — a new variant is a compile error here, so it
+/// cannot silently default to "no residual".
+pub(super) fn column_slack_bytes(shape: &Shape<'_>) -> usize {
+    match shape {
+        Shape::Flat(dt, _) => match dt {
+            DataType::List | DataType::Set | DataType::Map => ARROW_COLUMN_SLACK_BYTES,
+            DataType::Boolean
+            | DataType::TinyInt
+            | DataType::SmallInt
+            | DataType::Integer
+            | DataType::BigInt
+            | DataType::Float32
+            | DataType::Float
+            | DataType::Timestamp
+            | DataType::Uuid
+            | DataType::Blob
+            | DataType::Text
+            | DataType::Json
+            | DataType::Tuple
+            | DataType::Udt
+            | DataType::Frozen
+            | DataType::Tombstone
+            | DataType::Null => 0,
+        },
+        // The typed path charges every declared node itself; the rendered shapes
+        // are never a COLUMN shape (`column_shape` returns only `Cql`/`Flat`).
+        Shape::Cql(_) | Shape::RenderedSlot | Shape::RenderedInline => 0,
+    }
+}
+
+/// Whether charging this slot can queue FURTHER slots.
+///
+/// A `true` slot is queued on the worklist and spends one [`MAX_ESTIMATE_NODES`]
+/// node; a `false` slot is a LEAF, charged in place against
+/// [`MAX_ESTIMATE_LEAF_SLOTS`] with no worklist entry — which is what stops a
+/// wide collection's element count from consuming the structural budget
+/// (review C2).
+///
+/// Conservative in the safe direction: a spurious `true` merely spends a node. A
+/// `false` MUST be exact — `charge_slot` must queue nothing for it — and the
+/// debug assertion in [`Estimator::charge_child`] pins that invariant.
+pub(super) fn branches(shape: Shape<'_>, value: Option<&Value>) -> bool {
+    match shape {
+        Shape::Cql(t) => match unwrap_frozen_type(t) {
+            CqlType::List(_)
+            | CqlType::Set(_)
+            | CqlType::Map(_, _)
+            | CqlType::Tuple(_)
+            | CqlType::Udt(_, _)
+            | CqlType::Frozen(_) => true,
+            // Renders the value: branches exactly when the value does.
+            CqlType::Custom(_) => value_branches(value),
+            CqlType::Boolean
+            | CqlType::TinyInt
+            | CqlType::SmallInt
+            | CqlType::Int
+            | CqlType::BigInt
+            | CqlType::Float
+            | CqlType::Double
+            | CqlType::Text
+            | CqlType::Ascii
+            | CqlType::Varchar
+            | CqlType::Blob
+            | CqlType::Timestamp
+            | CqlType::Date
+            | CqlType::Time
+            | CqlType::Decimal
+            | CqlType::Varint
+            | CqlType::Duration
+            | CqlType::Uuid
+            | CqlType::TimeUuid
+            | CqlType::Inet
+            | CqlType::Counter => false,
+        },
+        Shape::Flat(dt, _) => match dt {
+            DataType::List | DataType::Set | DataType::Map => true,
+            // `build_string_array`'s render fallback: branches with the value.
+            DataType::Text
+            | DataType::Json
+            | DataType::Tuple
+            | DataType::Udt
+            | DataType::Frozen
+            | DataType::Tombstone
+            | DataType::Null => value_branches(value),
+            DataType::Boolean
+            | DataType::TinyInt
+            | DataType::SmallInt
+            | DataType::Integer
+            | DataType::BigInt
+            | DataType::Float32
+            | DataType::Float
+            | DataType::Timestamp
+            | DataType::Uuid
+            | DataType::Blob => false,
+        },
+        Shape::RenderedSlot | Shape::RenderedInline => value_branches(value),
+    }
+}
+
+/// Whether `ValueFormatter::format_value` would render this value by walking
+/// children. `Value::Json` is NOT one: `json_render_bytes` walks it with its own
+/// bounded loop rather than through the worklist.
+pub(super) fn value_branches(value: Option<&Value>) -> bool {
+    matches!(
+        value.map(unwrap_frozen_value),
+        Some(
+            Value::List(_)
+                | Value::Set(_)
+                | Value::Tuple(_)
+                | Value::Map(_)
+                | Value::Udt(_)
+                | Value::Frozen(_)
+        )
+    )
+}
+
+/// Unwrap nested `Frozen` wrappers to the effective type.
+///
+/// Loops to a FIXPOINT, exactly as `arrow_convert::unwrap_frozen_type` does: a
+/// capped unwrap would diverge from the converter for a chain longer than the
+/// cap, routing the estimate to a rendered fallback while the converter still
+/// took the typed builder — an UNDER-count (issue #2825 rust-reviewer nit).
+/// Termination is structural: `CqlType` is a finite owned tree with no cycles.
+pub(super) fn unwrap_frozen_type(mut t: &CqlType) -> &CqlType {
+    while let CqlType::Frozen(inner) = t {
+        t = inner;
+    }
+    t
+}
+
+/// Unwrap nested `Value::Frozen` wrappers (mirrors
+/// `arrow_convert::unwrap_frozen_value`), bounded the same way.
+pub(super) fn unwrap_frozen_value(mut v: &Value) -> &Value {
+    for _ in 0..MAX_FROZEN_DEPTH {
+        match v {
+            Value::Frozen(inner) => v = inner,
+            _ => return v,
+        }
+    }
+    v
+}
+
+/// Cap on `Value::Frozen` unwrap iterations — a bound, not a semantic limit:
+/// real values nest at most once or twice, and `arrow_convert` unwraps a single
+/// level, so unwrapping FEWER levels than the converter is impossible here.
+const MAX_FROZEN_DEPTH: usize = 16;

--- a/cqlite-core/src/export/arrow_size_tests.rs
+++ b/cqlite-core/src/export/arrow_size_tests.rs
@@ -557,6 +557,103 @@ fn estimate_is_within_a_bounded_multiple_of_the_payload() {
     }
 }
 
+/// The conservatism property is DISCRIMINATING, not a tautology.
+///
+/// Spec Requirement 3 asks that a column type the converter handles but the
+/// estimator does not model FAIL the property test. Two mechanisms enforce that
+/// here. First, `column_shape`/`charge_cql`/`charge_flat` match [`CqlType`] and
+/// [`DataType`] EXHAUSTIVELY with no wildcard arm, so a newly added variant is a
+/// *compile* error before it can ever be under-counted. Second — proven below —
+/// an estimator that models a type's CONTENT but forgets its Arrow structural
+/// overhead (the exact failure mode of `Value::size_estimate`,
+/// `memory::estimate_value_size` and `Memtable::estimate_value_size`, and the
+/// likeliest shape of a careless future arm) UNDER-counts real corpus shapes and
+/// so trips the assertion.
+#[test]
+fn the_conservatism_property_catches_a_content_only_estimator() {
+    /// A deliberately unmodelled estimator: raw content bytes, zero Arrow
+    /// structural overhead. Recursion is fine here — the corpus is shallow and
+    /// this is test-only scaffolding, not the production walk.
+    fn content_only(v: &Value) -> usize {
+        match v {
+            Value::Null | Value::Tombstone(_) => 0,
+            Value::Boolean(_) | Value::TinyInt(_) => 1,
+            Value::SmallInt(_) => 2,
+            Value::Integer(_) | Value::Float32(_) | Value::Date(_) => 4,
+            Value::BigInt(_)
+            | Value::Counter(_)
+            | Value::Float(_)
+            | Value::Timestamp(_)
+            | Value::Time(_) => 8,
+            Value::Uuid(_) => 16,
+            Value::Duration { .. } => 16,
+            Value::Text(s) => s.len(),
+            Value::Blob(b) => b.len(),
+            Value::Varint(b) => b.len(),
+            Value::Inet(b) => b.len(),
+            Value::Decimal { unscaled, .. } => unscaled.len(),
+            Value::Json(j) => j.to_string().len(),
+            Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
+                items.iter().map(content_only).sum()
+            }
+            Value::Map(pairs) => pairs
+                .iter()
+                .map(|(k, v)| content_only(k) + content_only(v))
+                .sum(),
+            Value::Udt(u) => u
+                .fields
+                .iter()
+                .filter_map(|f| f.value.as_ref())
+                .map(content_only)
+                .sum(),
+            Value::Frozen(inner) => content_only(inner),
+        }
+    }
+
+    let mut under_counted: Vec<&str> = Vec::new();
+    for shape in shape_corpus() {
+        let naive: usize = shape
+            .rows
+            .iter()
+            .map(|r| {
+                shape
+                    .columns
+                    .iter()
+                    .filter_map(|c| r.values.get(c.name.as_str()))
+                    .map(content_only)
+                    .sum::<usize>()
+            })
+            .sum();
+        let batch = rows_to_record_batch(&shape.columns, &shape.rows).expect("convert");
+        if naive < arrow_payload_bytes(&batch) {
+            under_counted.push(shape.name);
+        }
+    }
+    assert!(
+        !under_counted.is_empty(),
+        "a content-only estimator under-counted NOTHING — the conservatism \
+         property test cannot detect an unmodelled type and is a tautology"
+    );
+    // And the real estimator covers every one of those same shapes (the
+    // property test above asserts this for the whole corpus).
+    for name in &under_counted {
+        let shape = shape_corpus()
+            .into_iter()
+            .find(|s| &s.name == name)
+            .unwrap_or_else(|| panic!("missing shape '{name}'"));
+        let estimated: usize = shape
+            .rows
+            .iter()
+            .map(|r| estimate_arrow_row_bytes(&shape.columns, r))
+            .sum();
+        let batch = rows_to_record_batch(&shape.columns, &shape.rows).expect("convert");
+        assert!(
+            estimated >= arrow_payload_bytes(&batch),
+            "shape '{name}' under-counted by the REAL estimator"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Requirement 3: width sensitivity
 // ---------------------------------------------------------------------------

--- a/cqlite-core/src/export/arrow_size_tests.rs
+++ b/cqlite-core/src/export/arrow_size_tests.rs
@@ -1,0 +1,725 @@
+//! Tests for the conservative Arrow payload-byte estimator (issue #2825).
+//!
+//! Loaded via `#[path]` from `arrow_size.rs` so the production module stays
+//! under the campsite file-size threshold (epic #1116).
+//!
+//! The load-bearing test here is [`estimate_is_conservative_across_shape_corpus`]:
+//! it asserts `Σ estimate_arrow_row_bytes(..) >= arrow_payload_bytes(batch)` over
+//! a corpus of row shapes. A future CQL type that `rows_to_record_batch` learns
+//! to convert but the estimator does not model FAILS that test rather than
+//! silently under-counting (spec Requirement 3).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::*;
+use crate::export::rows_to_record_batch;
+use crate::query::{ColumnInfo, QueryRow};
+use crate::schema::CqlType;
+use crate::types::{DataType, UdtField, UdtValue, Value};
+use crate::RowKey;
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+fn col(name: &str, data_type: DataType, cql_type: Option<CqlType>) -> ColumnInfo {
+    ColumnInfo {
+        name: name.to_string(),
+        data_type,
+        nullable: true,
+        position: 0,
+        table_name: None,
+        cql_type,
+    }
+}
+
+fn row(pairs: Vec<(&str, Value)>) -> QueryRow {
+    let mut values: HashMap<Arc<str>, Value> = HashMap::new();
+    for (name, value) in pairs {
+        values.insert(Arc::from(name), value);
+    }
+    QueryRow::with_interned_values(RowKey::new(Vec::new()), values)
+}
+
+/// One named corpus entry: a projected column set plus the rows to convert.
+struct Shape {
+    name: &'static str,
+    columns: Vec<ColumnInfo>,
+    rows: Vec<QueryRow>,
+}
+
+fn text(s: &str) -> Value {
+    Value::Text(s.as_bytes().to_vec().into())
+}
+
+fn blob(n: usize) -> Value {
+    Value::Blob(vec![0xABu8; n].into())
+}
+
+/// The shape corpus required by spec Requirement 3: fixed-width columns, `text`,
+/// `blob`, `list`/`set`, `map`, `tuple`/UDT, all-null rows, empty strings and
+/// empty collections — plus the flat (`cql_type = None`) dispatch arms, which the
+/// converter reaches through `build_string_array`/`build_list_array`/
+/// `build_map_array`.
+fn shape_corpus() -> Vec<Shape> {
+    let mut shapes = Vec::new();
+
+    shapes.push(Shape {
+        name: "fixed-width scalars",
+        columns: vec![
+            col("b", DataType::Boolean, Some(CqlType::Boolean)),
+            col("ti", DataType::TinyInt, Some(CqlType::TinyInt)),
+            col("si", DataType::SmallInt, Some(CqlType::SmallInt)),
+            col("i", DataType::Integer, Some(CqlType::Int)),
+            col("bi", DataType::BigInt, Some(CqlType::BigInt)),
+            col("f", DataType::Float32, Some(CqlType::Float)),
+            col("d", DataType::Float, Some(CqlType::Double)),
+            col("ts", DataType::Timestamp, Some(CqlType::Timestamp)),
+            col("dt", DataType::Integer, Some(CqlType::Date)),
+            col("tm", DataType::BigInt, Some(CqlType::Time)),
+            col("u", DataType::Uuid, Some(CqlType::Uuid)),
+            col("ct", DataType::BigInt, Some(CqlType::Counter)),
+        ],
+        rows: (0..64)
+            .map(|i| {
+                row(vec![
+                    ("b", Value::Boolean(i % 2 == 0)),
+                    ("ti", Value::TinyInt(i as i8)),
+                    ("si", Value::SmallInt(i as i16)),
+                    ("i", Value::Integer(i)),
+                    ("bi", Value::BigInt(i64::from(i))),
+                    ("f", Value::Float32(i as f32)),
+                    ("d", Value::Float(f64::from(i))),
+                    ("ts", Value::Timestamp(1_700_000_000_000 + i64::from(i))),
+                    ("dt", Value::Date(19_000 + i)),
+                    ("tm", Value::Time(i64::from(i) * 1_000_000)),
+                    ("u", Value::Uuid([i as u8; 16])),
+                    ("ct", Value::Counter(i64::from(i))),
+                ])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "text narrow",
+        columns: vec![col("t", DataType::Text, Some(CqlType::Text))],
+        rows: (0..512)
+            .map(|i| row(vec![("t", text(&format!("v{i}")))]))
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "text wide",
+        columns: vec![col("t", DataType::Text, Some(CqlType::Text))],
+        rows: (0..64)
+            .map(|i| row(vec![("t", text(&"x".repeat(600 + i)))]))
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "text empty string",
+        columns: vec![col("t", DataType::Text, Some(CqlType::Text))],
+        rows: (0..8).map(|_| row(vec![("t", text(""))])).collect(),
+    });
+
+    shapes.push(Shape {
+        name: "blob wide",
+        columns: vec![col("b", DataType::Blob, Some(CqlType::Blob))],
+        rows: (0..64).map(|i| row(vec![("b", blob(256 + i))])).collect(),
+    });
+
+    shapes.push(Shape {
+        name: "blob single row",
+        columns: vec![col("b", DataType::Blob, Some(CqlType::Blob))],
+        rows: vec![row(vec![("b", blob(65_536))])],
+    });
+
+    shapes.push(Shape {
+        name: "all null",
+        columns: vec![
+            col("t", DataType::Text, Some(CqlType::Text)),
+            col("b", DataType::Blob, Some(CqlType::Blob)),
+            col("i", DataType::Integer, Some(CqlType::Int)),
+            col(
+                "l",
+                DataType::List,
+                Some(CqlType::List(Box::new(CqlType::Int))),
+            ),
+        ],
+        rows: (0..32)
+            .map(|_| {
+                row(vec![
+                    ("t", Value::Null),
+                    ("b", Value::Null),
+                    ("i", Value::Null),
+                    ("l", Value::Null),
+                ])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "absent cells",
+        columns: vec![
+            col("t", DataType::Text, Some(CqlType::Text)),
+            col("i", DataType::Integer, Some(CqlType::Int)),
+        ],
+        rows: (0..32).map(|_| row(vec![])).collect(),
+    });
+
+    shapes.push(Shape {
+        name: "list<int>",
+        columns: vec![col(
+            "l",
+            DataType::List,
+            Some(CqlType::List(Box::new(CqlType::Int))),
+        )],
+        rows: (0..64)
+            .map(|i| {
+                row(vec![(
+                    "l",
+                    Value::List((0..=i).map(Value::Integer).collect()),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "set<text>",
+        columns: vec![col(
+            "s",
+            DataType::Set,
+            Some(CqlType::Set(Box::new(CqlType::Text))),
+        )],
+        rows: (0..48)
+            .map(|i| {
+                row(vec![(
+                    "s",
+                    Value::Set((0..=i).map(|j| text(&format!("e{j}"))).collect()),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "empty collections",
+        columns: vec![
+            col(
+                "l",
+                DataType::List,
+                Some(CqlType::List(Box::new(CqlType::Int))),
+            ),
+            col(
+                "m",
+                DataType::Map,
+                Some(CqlType::Map(
+                    Box::new(CqlType::Text),
+                    Box::new(CqlType::Int),
+                )),
+            ),
+        ],
+        rows: (0..16)
+            .map(|_| {
+                row(vec![
+                    ("l", Value::List(Vec::new())),
+                    ("m", Value::Map(Vec::new())),
+                ])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "map<text,bigint>",
+        columns: vec![col(
+            "m",
+            DataType::Map,
+            Some(CqlType::Map(
+                Box::new(CqlType::Text),
+                Box::new(CqlType::BigInt),
+            )),
+        )],
+        rows: (0..48)
+            .map(|i| {
+                row(vec![(
+                    "m",
+                    Value::Map(
+                        (0..=i)
+                            .map(|j| (text(&format!("k{j}")), Value::BigInt(i64::from(j))))
+                            .collect(),
+                    ),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "tuple<int,text>",
+        columns: vec![col(
+            "tp",
+            DataType::Tuple,
+            Some(CqlType::Tuple(vec![CqlType::Int, CqlType::Text])),
+        )],
+        rows: (0..64)
+            .map(|i| {
+                row(vec![(
+                    "tp",
+                    Value::Tuple(vec![Value::Integer(i), text(&"t".repeat(i as usize % 40))]),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "udt",
+        columns: vec![col(
+            "u",
+            DataType::Udt,
+            Some(CqlType::Udt(
+                "addr".into(),
+                vec![
+                    ("street".into(), CqlType::Text),
+                    ("zip".into(), CqlType::Int),
+                ],
+            )),
+        )],
+        rows: (0..64)
+            .map(|i| {
+                row(vec![(
+                    "u",
+                    Value::Udt(Box::new(UdtValue {
+                        type_name: "addr".into(),
+                        keyspace: "ks".into(),
+                        fields: vec![
+                            UdtField {
+                                name: "street".into(),
+                                value: Some(text(&"s".repeat(i as usize % 50))),
+                            },
+                            UdtField {
+                                name: "zip".into(),
+                                value: Some(Value::Integer(i)),
+                            },
+                        ],
+                    })),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "frozen<list<text>>",
+        columns: vec![col(
+            "fl",
+            DataType::Frozen,
+            Some(CqlType::Frozen(Box::new(CqlType::List(Box::new(
+                CqlType::Text,
+            ))))),
+        )],
+        rows: (0..32)
+            .map(|i| {
+                row(vec![(
+                    "fl",
+                    Value::Frozen(Box::new(Value::List(
+                        (0..=i).map(|j| text(&format!("f{j}"))).collect(),
+                    ))),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "high-fidelity scalars",
+        columns: vec![
+            col("de", DataType::Blob, Some(CqlType::Decimal)),
+            col("vi", DataType::Blob, Some(CqlType::Varint)),
+            col("du", DataType::Text, Some(CqlType::Duration)),
+            col("in", DataType::Text, Some(CqlType::Inet)),
+            col("tu", DataType::Uuid, Some(CqlType::TimeUuid)),
+        ],
+        rows: (0..48)
+            .map(|i| {
+                row(vec![
+                    (
+                        "de",
+                        Value::Decimal {
+                            scale: 3,
+                            unscaled: vec![0x01, 0x02, i as u8],
+                        },
+                    ),
+                    ("vi", Value::Varint(vec![0x01, i as u8].into())),
+                    (
+                        "du",
+                        Value::Duration {
+                            months: i,
+                            days: i,
+                            nanos: i64::from(i) * 1_000,
+                        },
+                    ),
+                    ("in", Value::Inet(vec![10, 0, 0, i as u8].into())),
+                    ("tu", Value::Uuid([i as u8; 16])),
+                ])
+            })
+            .collect(),
+    });
+
+    // Flat dispatch (no authoritative CQL type): the converter renders through
+    // `build_string_array` / `build_list_array` / `build_map_array`.
+    shapes.push(Shape {
+        name: "flat text/blob/int",
+        columns: vec![
+            col("t", DataType::Text, None),
+            col("b", DataType::Blob, None),
+            col("i", DataType::Integer, None),
+        ],
+        rows: (0..64)
+            .map(|i| {
+                row(vec![
+                    ("t", text(&"z".repeat(i as usize % 70))),
+                    ("b", blob(i as usize % 90)),
+                    ("i", Value::Integer(i)),
+                ])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "flat list rendered",
+        columns: vec![col("l", DataType::List, None)],
+        rows: (0..48)
+            .map(|i| {
+                row(vec![(
+                    "l",
+                    Value::List(
+                        (0..=i)
+                            .map(|j| text(&format!("elem-{j}-{}", "p".repeat(j as usize % 12))))
+                            .collect(),
+                    ),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "flat map rendered",
+        columns: vec![col("m", DataType::Map, None)],
+        rows: (0..48)
+            .map(|i| {
+                row(vec![(
+                    "m",
+                    Value::Map(
+                        (0..=i)
+                            .map(|j| (text(&format!("k{j}")), blob(j as usize % 20)))
+                            .collect(),
+                    ),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "flat tuple rendered",
+        columns: vec![col("tp", DataType::Tuple, None)],
+        rows: (0..48)
+            .map(|i| {
+                row(vec![(
+                    "tp",
+                    Value::Tuple(vec![
+                        Value::Integer(i),
+                        text(&"q".repeat(i as usize % 30)),
+                        Value::Uuid([i as u8; 16]),
+                    ]),
+                )])
+            })
+            .collect(),
+    });
+
+    // Single-row batches: arrow's short-buffer length rounding is proportionally
+    // largest here, so they are the tightest case for the per-slot slack.
+    shapes.push(Shape {
+        name: "single narrow row",
+        columns: vec![
+            col("i", DataType::Integer, Some(CqlType::Int)),
+            col("t", DataType::Text, Some(CqlType::Text)),
+        ],
+        rows: vec![row(vec![("i", Value::Integer(1)), ("t", text("a"))])],
+    });
+
+    shapes.push(Shape {
+        name: "single row with collections",
+        columns: vec![
+            col(
+                "l",
+                DataType::List,
+                Some(CqlType::List(Box::new(CqlType::Text))),
+            ),
+            col(
+                "m",
+                DataType::Map,
+                Some(CqlType::Map(
+                    Box::new(CqlType::Text),
+                    Box::new(CqlType::Int),
+                )),
+            ),
+            col(
+                "u",
+                DataType::Udt,
+                Some(CqlType::Udt(
+                    "p".into(),
+                    vec![("a".into(), CqlType::Int), ("b".into(), CqlType::Text)],
+                )),
+            ),
+        ],
+        rows: vec![row(vec![
+            ("l", Value::List(vec![text("one"), text("two")])),
+            ("m", Value::Map(vec![(text("k"), Value::Integer(7))])),
+            (
+                "u",
+                Value::Udt(Box::new(UdtValue {
+                    type_name: "p".into(),
+                    keyspace: "ks".into(),
+                    fields: vec![
+                        UdtField {
+                            name: "a".into(),
+                            value: Some(Value::Integer(3)),
+                        },
+                        UdtField {
+                            name: "b".into(),
+                            value: Some(text("bee")),
+                        },
+                    ],
+                })),
+            ),
+        ])],
+    });
+
+    shapes
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 3: the estimator is conservative across the shape corpus
+// ---------------------------------------------------------------------------
+
+/// `Σ estimate_arrow_row_bytes(..) >= arrow_payload_bytes(rows_to_record_batch(..))`
+/// for every shape in the corpus — the conservatism contract.
+///
+/// A CQL type the converter handles but the estimator does not model shows up
+/// here as an under-count and FAILS, so a future type addition cannot silently
+/// introduce one (spec Requirement 3).
+#[test]
+fn estimate_is_conservative_across_shape_corpus() {
+    for shape in shape_corpus() {
+        let estimated: usize = shape
+            .rows
+            .iter()
+            .map(|r| estimate_arrow_row_bytes(&shape.columns, r))
+            .fold(0usize, |a, b| a.saturating_add(b));
+        let batch = rows_to_record_batch(&shape.columns, &shape.rows)
+            .unwrap_or_else(|e| panic!("shape '{}' failed to convert: {e}", shape.name));
+        let realized = arrow_payload_bytes(&batch);
+        assert!(
+            estimated >= realized,
+            "shape '{}': estimate {estimated} UNDER-COUNTS realized payload {realized}",
+            shape.name
+        );
+        // Non-vacuity: the corpus must exercise real bytes, not empty batches.
+        assert!(
+            realized > 0 && batch.num_rows() == shape.rows.len(),
+            "shape '{}' is vacuous: {realized} payload bytes, {} rows",
+            shape.name,
+            batch.num_rows()
+        );
+    }
+}
+
+/// The estimator must not be so loose that it is useless: on realistic wide
+/// shapes it stays within a bounded multiple of the realized payload, so the cap
+/// cuts batches near the configured size rather than at one row.
+#[test]
+fn estimate_is_within_a_bounded_multiple_of_the_payload() {
+    // Wide shapes only — a narrow fixed-width shape is dominated by the fixed
+    // per-slot slack by construction.
+    for name in ["text wide", "blob wide", "blob single row"] {
+        let shape = shape_corpus()
+            .into_iter()
+            .find(|s| s.name == name)
+            .unwrap_or_else(|| panic!("missing corpus shape '{name}'"));
+        let estimated: usize = shape
+            .rows
+            .iter()
+            .map(|r| estimate_arrow_row_bytes(&shape.columns, r))
+            .sum();
+        let batch = rows_to_record_batch(&shape.columns, &shape.rows).expect("convert");
+        let realized = arrow_payload_bytes(&batch);
+        assert!(
+            estimated <= realized.saturating_mul(2),
+            "shape '{name}': estimate {estimated} is more than 2x the realized payload {realized}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 3: width sensitivity
+// ---------------------------------------------------------------------------
+
+/// Two rows differing only in one blob cell's length differ in estimate by at
+/// least that content-byte difference — the estimator is width-driven, not a
+/// per-row constant.
+#[test]
+fn variable_width_content_drives_the_estimate() {
+    let columns = vec![col("b", DataType::Blob, Some(CqlType::Blob))];
+    let small = row(vec![("b", blob(16))]);
+    let large = row(vec![("b", blob(64 * 1024))]);
+    let d = estimate_arrow_row_bytes(&columns, &large) - estimate_arrow_row_bytes(&columns, &small);
+    assert!(
+        d >= 64 * 1024 - 16,
+        "estimate difference {d} is below the content difference"
+    );
+}
+
+/// The same holds for `text`, and through the flat (untyped) dispatch.
+#[test]
+fn text_width_drives_the_estimate_on_both_dispatch_paths() {
+    for cql in [Some(CqlType::Text), None] {
+        let columns = vec![col("t", DataType::Text, cql.clone())];
+        let small = row(vec![("t", text("ab"))]);
+        let large = row(vec![("t", text(&"a".repeat(10_000)))]);
+        let d =
+            estimate_arrow_row_bytes(&columns, &large) - estimate_arrow_row_bytes(&columns, &small);
+        assert!(
+            d >= 10_000 - 2,
+            "estimate difference {d} too small for {cql:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 3: pathological values fail closed
+// ---------------------------------------------------------------------------
+
+/// A collection whose element count exceeds the node budget saturates instead of
+/// spinning — no panic, no unbounded work, and the returned width trips the cap.
+#[test]
+fn oversized_collection_fails_closed_to_a_saturated_width() {
+    let columns = vec![col(
+        "l",
+        DataType::List,
+        Some(CqlType::List(Box::new(CqlType::Int))),
+    )];
+    let huge = Value::List(
+        (0..(MAX_ESTIMATE_NODES + 1) as i32)
+            .map(Value::Integer)
+            .collect(),
+    );
+    let r = row(vec![("l", huge)]);
+    assert_eq!(estimate_arrow_row_bytes(&columns, &r), usize::MAX);
+}
+
+/// A value nested far deeper than any schema still terminates, returns a
+/// saturated width, and never recurses (the walk is an explicit worklist — a
+/// recursive one would blow the stack here instead of returning).
+#[test]
+fn deeply_nested_value_fails_closed_without_recursion() {
+    let mut v = Value::Integer(1);
+    for _ in 0..(MAX_ESTIMATE_NODES + 16) {
+        v = Value::List(vec![v]);
+    }
+    let columns = vec![col("l", DataType::List, None)];
+    let r = row(vec![("l", v)]);
+    assert_eq!(estimate_arrow_row_bytes(&columns, &r), usize::MAX);
+    // `Value`'s derived `Drop` IS recursive, so releasing a 65k-deep chain would
+    // overflow the stack in the harness (not in the estimator, which already
+    // returned). Leak the fixture rather than weaken the depth under test.
+    std::mem::forget(r);
+}
+
+/// A row that mixes a saturating cell with ordinary ones still reports
+/// `usize::MAX` — repeated additions of the fail-closed sentinel stay saturated
+/// rather than wrapping to a small (and therefore cap-defeating) number.
+#[test]
+fn saturating_arithmetic_never_wraps() {
+    let columns = vec![
+        col("b0", DataType::Blob, Some(CqlType::Blob)),
+        col(
+            "l1",
+            DataType::List,
+            Some(CqlType::List(Box::new(CqlType::Int))),
+        ),
+        col("b2", DataType::Blob, Some(CqlType::Blob)),
+        col("b3", DataType::Blob, Some(CqlType::Blob)),
+    ];
+    let r = row(vec![
+        ("b0", blob(8)),
+        (
+            "l1",
+            Value::List(
+                (0..(MAX_ESTIMATE_NODES + 1) as i32)
+                    .map(Value::Integer)
+                    .collect(),
+            ),
+        ),
+        ("b2", blob(8)),
+        ("b3", blob(8)),
+    ]);
+    assert_eq!(estimate_arrow_row_bytes(&columns, &r), usize::MAX);
+}
+
+/// A `Frozen` chain deeper than the unwrap bound terminates without panicking.
+#[test]
+fn deep_frozen_chain_terminates() {
+    let mut v = Value::Integer(1);
+    for _ in 0..64 {
+        v = Value::Frozen(Box::new(v));
+    }
+    let columns = vec![col("f", DataType::Integer, Some(CqlType::Int))];
+    let r = row(vec![("f", v)]);
+    // Terminates and returns a finite, non-zero width.
+    let e = estimate_arrow_row_bytes(&columns, &r);
+    assert!(e > 0 && e < usize::MAX);
+}
+
+// ---------------------------------------------------------------------------
+// Projection / cell-resolution semantics
+// ---------------------------------------------------------------------------
+
+/// Only projected columns are charged: a value present in the row but absent
+/// from `columns` never reaches the batch, so it must never reach the estimate.
+#[test]
+fn unprojected_values_are_not_charged() {
+    let projected = vec![col("t", DataType::Text, Some(CqlType::Text))];
+    let lean = row(vec![("t", text("abc"))]);
+    let fat = row(vec![("t", text("abc")), ("other", blob(1_000_000))]);
+    assert_eq!(
+        estimate_arrow_row_bytes(&projected, &lean),
+        estimate_arrow_row_bytes(&projected, &fat)
+    );
+}
+
+/// An empty projection costs nothing.
+#[test]
+fn empty_projection_is_zero() {
+    assert_eq!(
+        estimate_arrow_row_bytes(&[], &row(vec![("t", text("x"))])),
+        0
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The payload oracle itself
+// ---------------------------------------------------------------------------
+
+/// `arrow_payload_bytes` counts buffer LENGTHS, so it is strictly at or below
+/// `get_array_memory_size()` (which counts capacity) — the two currencies the
+/// byte-cap keeps separate.
+#[test]
+fn payload_bytes_never_exceeds_reported_memory_size() {
+    for shape in shape_corpus() {
+        let batch = rows_to_record_batch(&shape.columns, &shape.rows).expect("convert");
+        let payload = arrow_payload_bytes(&batch);
+        let capacity = batch.get_array_memory_size();
+        assert!(
+            payload <= capacity,
+            "shape '{}': payload {payload} exceeds reported memory {capacity}",
+            shape.name
+        );
+    }
+}

--- a/cqlite-core/src/export/arrow_size_tests.rs
+++ b/cqlite-core/src/export/arrow_size_tests.rs
@@ -537,6 +537,27 @@ fn shape_corpus() -> Vec<Shape> {
             .collect(),
     });
 
+    // The 1-BYTE-MARGIN point of the whole `ARROW_COLUMN_SLACK_BYTES` derivation
+    // (review nit): a flat `DataType::Map` with a SINGLE row whose cell is empty
+    // realizes 17 bytes — map offsets `2 * 4`, the always-present null buffer
+    // `ceil(1/8)`, and the key and value `Utf8` children's empty offsets buffers
+    // `4 + 4` — against 18 charged. Every other flat-map shape has 48 rows, over
+    // which the residual amortizes away, so a change to the constant would slip
+    // through unnoticed without this shape.
+    shapes.push(Shape {
+        name: "flat map single empty row",
+        columns: vec![col("m", DataType::Map, None)],
+        rows: vec![row(vec![("m", Value::Map(Vec::new()))])],
+    });
+
+    // Same, with the cell ABSENT rather than empty: `build_map_array` takes its
+    // null branch and still materializes both children.
+    shapes.push(Shape {
+        name: "flat map single absent row",
+        columns: vec![col("m", DataType::Map, None)],
+        rows: vec![row(vec![])],
+    });
+
     shapes.push(Shape {
         name: "flat tuple rendered",
         columns: vec![col("tp", DataType::Tuple, None)],
@@ -700,12 +721,15 @@ fn estimate_is_within_a_bounded_multiple_of_the_payload() {
         ("map<text,bigint>", 2),
         ("map<text,list<text>> nested", 3),
         ("flat list rendered", 3),
-        // Multi-column narrow: dominated by the per-COLUMN residual, which is
-        // the term that must NOT scale with cell count.
-        ("fixed-width scalars", 3),
+        // Multi-column narrow: these are where a residual charged for a column
+        // that has no childless array node shows up (review C1). Both are now
+        // pinned at the smallest whole number above their measured ratio
+        // (1.18 and 2.55), so re-introducing the residual for a fixed-width or
+        // single-node column FAILS here.
+        ("fixed-width scalars", 2),
         ("flat text/blob/int", 2),
         ("flat json rendered", 5),
-        ("high-fidelity scalars", 4),
+        ("high-fidelity scalars", 3),
     ];
     for (name, multiple) in cases {
         let shape = shape_corpus()
@@ -762,32 +786,48 @@ fn per_column_residual_does_not_scale_with_element_count() {
     );
 }
 
-/// A wide fixed-width schema still lets the ROW-cap bind at the 4 MiB default:
-/// the per-row estimate for 30 `int` columns must leave room for a full
-/// 8192-row batch (review B3 — a per-slot slack put this at ~4,000 rows).
+/// A wide fixed-width schema still lets the ROW-cap bind at the 4 MiB default.
+///
+/// Placed PAST the predicted break point, not before it (review C1): charging
+/// the per-column residual for a fixed-width column cost 13 B/column/row and put
+/// the byte-cap's binding point at 40 `int` columns — so a 30-column guard sat
+/// just under the cliff and reported green while an ordinary 40–100-column
+/// `int` table was already being cut at ~1.3 MB of real payload. A fixed-width
+/// column now costs 5 B/row (`1` validity + `4` content), which keeps the
+/// row-cap binding through 102 columns; both sizes below are above the OLD
+/// cliff, and 100 is the largest ordinary-schema width the issue names.
 #[test]
 fn a_wide_fixed_width_row_still_fits_a_full_default_batch() {
-    const N_COLS: i32 = 30;
     const DEFAULT_CAP: usize = 4 * 1024 * 1024;
     const BATCH_ROWS: usize = 8192;
-    let names: Vec<String> = (0..N_COLS).map(|i| format!("c{i}")).collect();
-    let columns: Vec<ColumnInfo> = names
-        .iter()
-        .map(|n| col(n, DataType::Integer, Some(CqlType::Int)))
-        .collect();
-    let r = row(names
-        .iter()
-        .zip(0..N_COLS)
-        .map(|(n, i)| (n.as_str(), Value::Integer(i)))
-        .collect());
-    let per_row = estimate_arrow_row_bytes(&columns, &r);
-    assert!(
-        per_row.saturating_mul(BATCH_ROWS) <= DEFAULT_CAP,
-        "a {N_COLS}-column int row estimates {per_row} B, so the byte-cap would \
-         cut at {} rows — below the {BATCH_ROWS}-row batch size, a throughput \
-         regression on a narrow shape",
-        DEFAULT_CAP / per_row.max(1)
-    );
+    for n_cols in [64i32, 100i32] {
+        let names: Vec<String> = (0..n_cols).map(|i| format!("c{i}")).collect();
+        let columns: Vec<ColumnInfo> = names
+            .iter()
+            .map(|n| col(n, DataType::Integer, Some(CqlType::Int)))
+            .collect();
+        let r = row(names
+            .iter()
+            .zip(0..n_cols)
+            .map(|(n, i)| (n.as_str(), Value::Integer(i)))
+            .collect());
+        let per_row = estimate_arrow_row_bytes(&columns, &r);
+        assert!(
+            per_row.saturating_mul(BATCH_ROWS) <= DEFAULT_CAP,
+            "a {n_cols}-column int row estimates {per_row} B, so the byte-cap \
+             would cut at {} rows — below the {BATCH_ROWS}-row batch size, a \
+             throughput regression on a narrow shape",
+            DEFAULT_CAP / per_row.max(1)
+        );
+        // And the estimate is still an UPPER bound on what such a batch really
+        // costs, so the headroom above is real rather than an under-count.
+        let rows: Vec<QueryRow> = (0..64).map(|_| r.clone()).collect();
+        let batch = rows_to_record_batch(&columns, &rows).expect("convert");
+        assert!(
+            per_row.saturating_mul(rows.len()) >= arrow_payload_bytes(&batch),
+            "{n_cols}-column int row under-counts the realized payload"
+        );
+    }
 }
 
 /// The conservatism property is DISCRIMINATING, not a tautology.
@@ -976,17 +1016,41 @@ fn text_width_drives_the_estimate_on_both_dispatch_paths() {
 // Requirement 3: pathological values fail closed
 // ---------------------------------------------------------------------------
 
-/// A collection whose element count exceeds the node budget saturates instead of
-/// spinning — no panic, no unbounded work, and the returned width trips the cap.
+/// `list<frozen<list<int>>>` whose CONTAINER fan-out exceeds the structural node
+/// budget saturates instead of spinning — no panic, no unbounded work, and the
+/// returned width trips the cap.
+///
+/// Container elements are what the branching budget counts (review C2): each
+/// inner list can itself fan out, so each spends a node and enters the worklist.
+fn nested_list_of_lists(n: usize) -> Value {
+    Value::List((0..n).map(|_| Value::List(Vec::new())).collect())
+}
+
 #[test]
-fn oversized_collection_fails_closed_to_a_saturated_width() {
+fn oversized_container_fanout_fails_closed_to_a_saturated_width() {
+    let columns = vec![col(
+        "l",
+        DataType::List,
+        Some(CqlType::List(Box::new(CqlType::List(Box::new(
+            CqlType::Int,
+        ))))),
+    )];
+    let r = row(vec![("l", nested_list_of_lists(MAX_ESTIMATE_NODES + 1))]);
+    assert_eq!(estimate_arrow_row_bytes(&columns, &r), usize::MAX);
+}
+
+/// A LEAF fan-out past [`MAX_ESTIMATE_LEAF_SLOTS`] also fails closed: leaves cost
+/// no worklist entry and no structural node, but the linear-work bound still
+/// holds, so a `Value` tree far larger than any decoded Cassandra row terminates.
+#[test]
+fn oversized_leaf_fanout_fails_closed_to_a_saturated_width() {
     let columns = vec![col(
         "l",
         DataType::List,
         Some(CqlType::List(Box::new(CqlType::Int))),
     )];
     let huge = Value::List(
-        (0..(MAX_ESTIMATE_NODES + 1) as i32)
+        (0..(MAX_ESTIMATE_LEAF_SLOTS + 1) as i32)
             .map(Value::Integer)
             .collect(),
     );
@@ -1022,25 +1086,155 @@ fn saturating_arithmetic_never_wraps() {
         col(
             "l1",
             DataType::List,
-            Some(CqlType::List(Box::new(CqlType::Int))),
+            Some(CqlType::List(Box::new(CqlType::List(Box::new(
+                CqlType::Int,
+            ))))),
         ),
         col("b2", DataType::Blob, Some(CqlType::Blob)),
         col("b3", DataType::Blob, Some(CqlType::Blob)),
     ];
     let r = row(vec![
         ("b0", blob(8)),
-        (
-            "l1",
-            Value::List(
-                (0..(MAX_ESTIMATE_NODES + 1) as i32)
-                    .map(Value::Integer)
-                    .collect(),
-            ),
-        ),
+        ("l1", nested_list_of_lists(MAX_ESTIMATE_NODES + 1)),
         ("b2", blob(8)),
         ("b3", blob(8)),
     ]);
     assert_eq!(estimate_arrow_row_bytes(&columns, &r), usize::MAX);
+}
+
+/// Wide-but-LEGAL collections are estimated exactly rather than failing closed
+/// (review C2).
+///
+/// Before the per-column, leaf-exempt budgets, a single non-frozen collection
+/// near Cassandra's classic 65,535-element limit — or a few thousand elements
+/// across ~20 columns — exhausted one shared 65,536-node row budget and pinned
+/// the row's width at `usize::MAX`. `cut_before` then fired for EVERY subsequent
+/// row, so the stream degraded to one row per batch indefinitely on an ordinary
+/// (if ill-advised) schema. Each shape below exceeded that old budget.
+#[test]
+fn wide_legal_collections_do_not_fail_closed_and_still_bound_the_payload() {
+    const DEFAULT_CAP: usize = 4 * 1024 * 1024;
+
+    // (name, columns, one row) — each over the OLD 65,536-node ROW budget.
+    let one_near_limit_map = {
+        let columns = vec![col(
+            "m",
+            DataType::Map,
+            Some(CqlType::Map(
+                Box::new(CqlType::Text),
+                Box::new(CqlType::Int),
+            )),
+        )];
+        // 40,000 entries = 80,000 slots under the old accounting.
+        let r = row(vec![(
+            "m",
+            Value::Map(
+                (0..40_000i32)
+                    .map(|j| (text(&format!("k{j}")), Value::Integer(j)))
+                    .collect(),
+            ),
+        )]);
+        ("one near-limit map<text,int>", columns, r)
+    };
+    let twenty_collection_columns = {
+        let names: Vec<String> = (0..20).map(|i| format!("l{i}")).collect();
+        let columns: Vec<ColumnInfo> = names
+            .iter()
+            .map(|n| {
+                col(
+                    n,
+                    DataType::List,
+                    Some(CqlType::List(Box::new(CqlType::Int))),
+                )
+            })
+            .collect();
+        // 20 x 3,500 = 70,000 slots under the old accounting.
+        let r = row(names
+            .iter()
+            .map(|n| {
+                (
+                    n.as_str(),
+                    Value::List((0..3_500i32).map(Value::Integer).collect()),
+                )
+            })
+            .collect());
+        ("20 x list<int> of 3,500", columns, r)
+    };
+
+    for (name, columns, r) in [one_near_limit_map, twenty_collection_columns] {
+        let per_row = estimate_arrow_row_bytes(&columns, &r);
+        assert!(
+            per_row < usize::MAX,
+            "shape '{name}': the estimate failed closed on a LEGAL collection \
+             width, which degrades the stream to one row per batch"
+        );
+        // Real payload allows several rows per 4 MiB batch, so the byte-cap must
+        // let several rows in — the throughput property the cliff destroyed.
+        let rows_per_batch = DEFAULT_CAP / per_row.max(1);
+        assert!(
+            rows_per_batch > 1,
+            "shape '{name}': {per_row} B/row admits only {rows_per_batch} row(s) \
+             per {DEFAULT_CAP}-byte batch"
+        );
+        // And the estimate is still an UPPER bound on the realized payload: the
+        // cliff is fixed by counting correctly, not by under-counting.
+        let rows: Vec<QueryRow> = (0..3).map(|_| r.clone()).collect();
+        let batch = rows_to_record_batch(&columns, &rows).expect("convert");
+        let realized = arrow_payload_bytes(&batch);
+        assert!(
+            realized > 100_000,
+            "shape '{name}' is vacuous: {realized} B"
+        );
+        assert!(
+            per_row.saturating_mul(rows.len()) >= realized,
+            "shape '{name}': estimate {per_row}/row UNDER-COUNTS realized \
+             payload {realized} over {} rows",
+            rows.len()
+        );
+    }
+}
+
+/// One wide column no longer starves the columns after it: the budgets are per
+/// COLUMN, so a row whose first column consumes a large share still estimates
+/// its remaining columns exactly.
+#[test]
+fn the_node_budget_is_per_column_not_per_row() {
+    let wide = || {
+        col(
+            "w",
+            DataType::List,
+            Some(CqlType::List(Box::new(CqlType::Int))),
+        )
+    };
+    let names: Vec<String> = (0..8).map(|i| format!("w{i}")).collect();
+    let columns: Vec<ColumnInfo> = names
+        .iter()
+        .map(|n| ColumnInfo {
+            name: n.clone(),
+            ..wide()
+        })
+        .collect();
+    // 8 x 30,000 = 240,000 slots — 3.6x the old shared ROW budget.
+    let r = row(names
+        .iter()
+        .map(|n| {
+            (
+                n.as_str(),
+                Value::List((0..30_000i32).map(Value::Integer).collect()),
+            )
+        })
+        .collect());
+    let per_row = estimate_arrow_row_bytes(&columns, &r);
+    assert!(
+        per_row < usize::MAX,
+        "a per-ROW budget starved the tail columns"
+    );
+    let batch = rows_to_record_batch(&columns, std::slice::from_ref(&r)).expect("convert");
+    let realized = arrow_payload_bytes(&batch);
+    assert!(
+        per_row >= realized,
+        "estimate {per_row} under-counts realized payload {realized}"
+    );
 }
 
 /// A `Frozen` chain deeper than the unwrap bound terminates without panicking.

--- a/cqlite-core/src/export/arrow_size_tests.rs
+++ b/cqlite-core/src/export/arrow_size_tests.rs
@@ -703,7 +703,7 @@ fn estimate_is_within_a_bounded_multiple_of_the_payload() {
         // Multi-column narrow: dominated by the per-COLUMN residual, which is
         // the term that must NOT scale with cell count.
         ("fixed-width scalars", 3),
-        ("flat text/blob/int", 3),
+        ("flat text/blob/int", 2),
         ("flat json rendered", 5),
         ("high-fidelity scalars", 4),
     ];
@@ -903,6 +903,56 @@ fn variable_width_content_drives_the_estimate() {
     assert!(
         d >= 64 * 1024 - 16,
         "estimate difference {d} is below the content difference"
+    );
+}
+
+/// A `Value::Text` NESTED in a rendered container is charged for the worst-case
+/// `String::from_utf8_lossy` expansion (3 bytes per input byte), while a
+/// TOP-LEVEL text cell is charged exactly (review B5).
+///
+/// Both `build_string_array` branches borrow a top-level `Value::Text` after a
+/// non-lossy `str::from_utf8` and hard-error on invalid UTF-8, so `s.len()` is
+/// exact there. A nested one reaches `ValueFormatter::format_value`, which uses
+/// `from_utf8_lossy` — each invalid byte becomes a 3-byte U+FFFD. The estimator
+/// must not depend on the issue-#1644 "text is UTF-8-validated at construction"
+/// invariant, which the type does not enforce.
+#[test]
+fn nested_rendered_text_is_charged_for_lossy_utf8_expansion() {
+    const N: usize = 64;
+    let top = vec![col("t", DataType::Text, None)];
+    let nested = vec![col("l", DataType::List, None)];
+    let flat_row = row(vec![("t", text(&"a".repeat(N)))]);
+    let nested_row = row(vec![("l", Value::List(vec![text(&"a".repeat(N))]))]);
+
+    let top_estimate = estimate_arrow_row_bytes(&top, &flat_row);
+    let nested_estimate = estimate_arrow_row_bytes(&nested, &nested_row);
+    // Top-level: exact, so the estimate stays close to the content length.
+    assert!(
+        top_estimate < N * 2,
+        "top-level text over-charged: {top_estimate} for {N} content bytes"
+    );
+    // Nested: at least 3x the content, covering the U+FFFD expansion.
+    assert!(
+        nested_estimate >= N * 3,
+        "nested rendered text charged {nested_estimate} for {N} content bytes — \
+         below the 3x from_utf8_lossy worst case"
+    );
+
+    // And the property still holds against the real converter for a value whose
+    // bytes are NOT valid UTF-8 — the case the expansion exists for.
+    let invalid = Value::List(vec![Value::Text(vec![0xFFu8; N].into())]);
+    let invalid_row = row(vec![("l", invalid)]);
+    let estimated = estimate_arrow_row_bytes(&nested, &invalid_row);
+    let batch = rows_to_record_batch(&nested, std::slice::from_ref(&invalid_row)).expect("convert");
+    let realized = arrow_payload_bytes(&batch);
+    assert!(
+        realized >= N * 3,
+        "the converter did not expand the invalid bytes ({realized} for {N}) — \
+         the fixture no longer exercises lossy rendering"
+    );
+    assert!(
+        estimated >= realized,
+        "estimate {estimated} under-counts the lossy-expanded payload {realized}"
     );
 }
 

--- a/cqlite-core/src/export/arrow_size_tests.rs
+++ b/cqlite-core/src/export/arrow_size_tests.rs
@@ -57,6 +57,15 @@ fn blob(n: usize) -> Value {
     Value::Blob(vec![0xABu8; n].into())
 }
 
+/// `list<list<…<text>>>` nested `depth` levels deep.
+fn nested_list_type(depth: usize) -> CqlType {
+    let mut t = CqlType::Text;
+    for _ in 0..depth {
+        t = CqlType::List(Box::new(t));
+    }
+    t
+}
+
 /// The shape corpus required by spec Requirement 3: fixed-width columns, `text`,
 /// `blob`, `list`/`set`, `map`, `tuple`/UDT, all-null rows, empty strings and
 /// empty collections — plus the flat (`cql_type = None`) dispatch arms, which the
@@ -225,6 +234,107 @@ fn shape_corpus() -> Vec<Shape> {
                     ("l", Value::List(Vec::new())),
                     ("m", Value::Map(Vec::new())),
                 ])
+            })
+            .collect(),
+    });
+
+    // Nesting DEEPER than one level, empty at the leaf: `build_typed_value_array`
+    // materializes one `ListArray` per DECLARED level whatever the value holds,
+    // each carrying an empty 4-byte offsets buffer, so a per-value-only estimate
+    // under-counts by ~4 bytes per level (review B2). Both the empty-collection
+    // and the null spelling of the same cell.
+    shapes.push(Shape {
+        name: "deeply nested empty list",
+        columns: vec![col("l", DataType::List, Some(nested_list_type(8)))],
+        rows: vec![row(vec![("l", Value::List(Vec::new()))])],
+    });
+
+    shapes.push(Shape {
+        name: "deeply nested null list",
+        columns: vec![col("l", DataType::List, Some(nested_list_type(8)))],
+        rows: (0..4)
+            .map(|_| row(vec![("l", Value::Null)]))
+            .chain(std::iter::once(row(vec![])))
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "map<text,list<text>> nested",
+        columns: vec![col(
+            "m",
+            DataType::Map,
+            Some(CqlType::Map(
+                Box::new(CqlType::Text),
+                Box::new(CqlType::List(Box::new(CqlType::Text))),
+            )),
+        )],
+        rows: (0..24)
+            .map(|i| {
+                row(vec![(
+                    "m",
+                    Value::Map(
+                        (0..=i)
+                            .map(|j| {
+                                (
+                                    text(&format!("k{j}")),
+                                    // Every other entry's list is EMPTY: the
+                                    // declared element type's child array still
+                                    // exists.
+                                    Value::List(
+                                        (0..(j % 3)).map(|e| text(&format!("e{e}"))).collect(),
+                                    ),
+                                )
+                            })
+                            .collect(),
+                    ),
+                )])
+            })
+            .collect(),
+    });
+
+    // A UDT whose DECLARED field list is empty (the unresolved-named-UDT case
+    // `arrow_convert` documents): the converter takes the Utf8 fallback and
+    // renders `{name: value, …}`, so every field NAME reaches the payload
+    // (review B4).
+    shapes.push(Shape {
+        name: "udt with empty declared fields",
+        columns: vec![col(
+            "u",
+            DataType::Udt,
+            Some(CqlType::Udt("unresolved".into(), Vec::new())),
+        )],
+        rows: (0..16)
+            .map(|i| {
+                row(vec![(
+                    "u",
+                    Value::Udt(Box::new(UdtValue {
+                        type_name: "unresolved".into(),
+                        keyspace: "ks".into(),
+                        fields: vec![
+                            UdtField {
+                                name: format!("a_long_field_name_{i}"),
+                                value: Some(text(&"v".repeat(i as usize % 20))),
+                            },
+                            UdtField {
+                                name: "second_field".into(),
+                                value: Some(Value::Integer(i)),
+                            },
+                        ],
+                    })),
+                )])
+            })
+            .collect(),
+    });
+
+    shapes.push(Shape {
+        name: "tuple with empty declared elements",
+        columns: vec![col("tp", DataType::Tuple, Some(CqlType::Tuple(Vec::new())))],
+        rows: (0..8)
+            .map(|i| {
+                row(vec![(
+                    "tp",
+                    Value::Tuple(vec![Value::Integer(i), text("tail")]),
+                )])
             })
             .collect(),
     });
@@ -433,6 +543,29 @@ fn shape_corpus() -> Vec<Shape> {
             .collect(),
     });
 
+    // `Value::Json` through the flat `DataType::Json` arm — `json_render_bytes`
+    // is the most intricate charging arm and was otherwise exercised only by the
+    // fail-closed depth test (review N5).
+    shapes.push(Shape {
+        name: "flat json rendered",
+        columns: vec![col("j", DataType::Json, None)],
+        rows: (0..24)
+            .map(|i| {
+                row(vec![(
+                    "j",
+                    Value::Json(Box::new(serde_json::json!({
+                        "id": i,
+                        "name": "a\"quoted\"\u{1F600}name",
+                        "tags": ["x", "yy", "zzz"],
+                        "nested": {"flag": true, "none": null, "ratio": 1.5},
+                        "empty_arr": [],
+                        "empty_obj": {},
+                    }))),
+                )])
+            })
+            .collect(),
+    });
+
     // Single-row batches: arrow's short-buffer length rounding is proportionally
     // largest here, so they are the tightest case for the per-slot slack.
     shapes.push(Shape {
@@ -531,17 +664,42 @@ fn estimate_is_conservative_across_shape_corpus() {
     }
 }
 
-/// The estimator must not be so loose that it is useless: on realistic wide
-/// shapes it stays within a bounded multiple of the realized payload, so the cap
-/// cuts batches near the configured size rather than at one row.
+/// The estimator must not be so loose that it is useless: it stays within a
+/// bounded multiple of the realized payload, so the cap cuts batches near the
+/// configured size rather than far short of it.
+///
+/// Covers the COLLECTION-heavy and MULTI-COLUMN shapes as well as the wide ones
+/// (review B3): those are exactly where a slack charged per SLOT instead of per
+/// COLUMN inflates the estimate — a `list<int>` cell of 1000 elements or a
+/// 30-column fixed-width row is where an over-estimate turns into a real
+/// batching regression, so the looseness is measured there, not only where it
+/// amortizes away.
 #[test]
 fn estimate_is_within_a_bounded_multiple_of_the_payload() {
-    // Wide shapes only — a narrow fixed-width shape is dominated by the fixed
-    // per-slot slack by construction.
-    for name in ["text wide", "blob wide", "blob single row"] {
+    // (shape, allowed multiple). The multiples are TIGHT — each is the smallest
+    // whole number above the shape's measured ratio — so a regression in the
+    // charging model shows up here rather than being absorbed.
+    let cases: &[(&str, usize)] = &[
+        ("text wide", 2),
+        ("blob wide", 2),
+        ("blob single row", 2),
+        // Collection-heavy: the per-element charge is what must stay tight.
+        ("list<int>", 2),
+        ("set<text>", 2),
+        ("map<text,bigint>", 2),
+        ("map<text,list<text>> nested", 3),
+        ("flat list rendered", 3),
+        // Multi-column narrow: dominated by the per-COLUMN residual, which is
+        // the term that must NOT scale with cell count.
+        ("fixed-width scalars", 3),
+        ("flat text/blob/int", 3),
+        ("flat json rendered", 5),
+        ("high-fidelity scalars", 4),
+    ];
+    for (name, multiple) in cases {
         let shape = shape_corpus()
             .into_iter()
-            .find(|s| s.name == name)
+            .find(|s| &s.name == name)
             .unwrap_or_else(|| panic!("missing corpus shape '{name}'"));
         let estimated: usize = shape
             .rows
@@ -551,10 +709,74 @@ fn estimate_is_within_a_bounded_multiple_of_the_payload() {
         let batch = rows_to_record_batch(&shape.columns, &shape.rows).expect("convert");
         let realized = arrow_payload_bytes(&batch);
         assert!(
-            estimated <= realized.saturating_mul(2),
-            "shape '{name}': estimate {estimated} is more than 2x the realized payload {realized}"
+            estimated <= realized.saturating_mul(*multiple),
+            "shape '{name}': estimate {estimated} is more than {multiple}x the \
+             realized payload {realized}"
         );
     }
+}
+
+/// The per-column residual is charged ONCE PER COLUMN, never per cell (review
+/// B3): growing a collection cell's ELEMENT COUNT by 100x must grow the estimate
+/// by roughly the elements' own Arrow cost, not by 100 slack charges.
+///
+/// Pinned as a ratio against the realized payload so it cannot be satisfied by
+/// simply shrinking a constant: a per-slot slack of `S` would show up here as
+/// `~S/4` extra bytes per `int` element.
+#[test]
+fn per_column_residual_does_not_scale_with_element_count() {
+    let columns = vec![col(
+        "l",
+        DataType::List,
+        Some(CqlType::List(Box::new(CqlType::Int))),
+    )];
+    let big = row(vec![(
+        "l",
+        Value::List((0..1000).map(Value::Integer).collect()),
+    )]);
+    let estimated = estimate_arrow_row_bytes(&columns, &big);
+    let batch = rows_to_record_batch(&columns, std::slice::from_ref(&big)).expect("convert");
+    let realized = arrow_payload_bytes(&batch);
+    assert!(realized >= 4000, "vacuous: {realized} realized bytes");
+    assert!(
+        estimated >= realized,
+        "estimate {estimated} under-counts {realized}"
+    );
+    // 1000 int elements: ~4 KB realized. A per-SLOT slack of 32 would put this
+    // at ~9x.
+    assert!(
+        estimated <= realized.saturating_mul(3) / 2,
+        "estimate {estimated} is more than 1.5x the realized payload {realized} \
+         — the residual is scaling with element count, not column count"
+    );
+}
+
+/// A wide fixed-width schema still lets the ROW-cap bind at the 4 MiB default:
+/// the per-row estimate for 30 `int` columns must leave room for a full
+/// 8192-row batch (review B3 — a per-slot slack put this at ~4,000 rows).
+#[test]
+fn a_wide_fixed_width_row_still_fits_a_full_default_batch() {
+    const N_COLS: i32 = 30;
+    const DEFAULT_CAP: usize = 4 * 1024 * 1024;
+    const BATCH_ROWS: usize = 8192;
+    let names: Vec<String> = (0..N_COLS).map(|i| format!("c{i}")).collect();
+    let columns: Vec<ColumnInfo> = names
+        .iter()
+        .map(|n| col(n, DataType::Integer, Some(CqlType::Int)))
+        .collect();
+    let r = row(names
+        .iter()
+        .zip(0..N_COLS)
+        .map(|(n, i)| (n.as_str(), Value::Integer(i)))
+        .collect());
+    let per_row = estimate_arrow_row_bytes(&columns, &r);
+    assert!(
+        per_row.saturating_mul(BATCH_ROWS) <= DEFAULT_CAP,
+        "a {N_COLS}-column int row estimates {per_row} B, so the byte-cap would \
+         cut at {} rows — below the {BATCH_ROWS}-row batch size, a throughput \
+         regression on a narrow shape",
+        DEFAULT_CAP / per_row.max(1)
+    );
 }
 
 /// The conservatism property is DISCRIMINATING, not a tautology.

--- a/cqlite-core/src/export/arrow_size_tests.rs
+++ b/cqlite-core/src/export/arrow_size_tests.rs
@@ -144,6 +144,17 @@ fn shape_corpus() -> Vec<Shape> {
         rows: vec![row(vec![("b", blob(65_536))])],
     });
 
+    // `cql_type` and `data_type` DISAGREE. `convert_column_to_array` dispatches
+    // `Text`/`Ascii`/`Varchar` on `data_type` alone, so this column is built by
+    // `build_binary_array`, not `build_string_array` — an estimate that routed
+    // it to the typed TEXT arm would charge zero content for a `blob` value and
+    // under-count the whole column.
+    shapes.push(Shape {
+        name: "text cql type over a blob data type",
+        columns: vec![col("b", DataType::Blob, Some(CqlType::Text))],
+        rows: (0..32).map(|i| row(vec![("b", blob(300 + i))])).collect(),
+    });
+
     shapes.push(Shape {
         name: "all null",
         columns: vec![

--- a/cqlite-core/src/export/mod.rs
+++ b/cqlite-core/src/export/mod.rs
@@ -66,10 +66,12 @@ pub use arrow_convert::{build_arrow_schema, rows_to_record_batch, ArrowConvertEr
 // Re-export the byte estimator beside the converter it models (issue #2825).
 // Deliberately narrow: the structural charging constants stay PRIVATE to
 // `arrow_size` (review N4) — they are tuning parameters of the estimate, not a
-// semver contract. `MAX_ESTIMATE_NODES` is public because the fail-closed
-// behaviour it defines IS part of the contract.
+// semver contract. The two node budgets are public because the fail-closed
+// behaviour they define IS part of the contract.
 #[cfg(feature = "arrow")]
-pub use arrow_size::{arrow_payload_bytes, estimate_arrow_row_bytes, MAX_ESTIMATE_NODES};
+pub use arrow_size::{
+    arrow_payload_bytes, estimate_arrow_row_bytes, MAX_ESTIMATE_LEAF_SLOTS, MAX_ESTIMATE_NODES,
+};
 
 // Delta-scan Arrow schema derivation (Epic #696, Issue #703 / DS7).
 // Requires both `delta-scan` (for the CDC envelope model) and `arrow` (for

--- a/cqlite-core/src/export/mod.rs
+++ b/cqlite-core/src/export/mod.rs
@@ -49,12 +49,26 @@ pub(crate) mod arrow_columnar;
 #[cfg(feature = "arrow")]
 mod arrow_decimal;
 
+// Conservative pre-materialization Arrow payload-byte estimator (issue #2825):
+// the per-row width the `cqlite-flight` byte-cap accumulates BEFORE
+// `rows_to_record_batch` allocates a batch. Its own file — `arrow_convert.rs` is
+// far over the campsite threshold (epic #1116).
+#[cfg(feature = "arrow")]
+pub mod arrow_size;
+
 #[cfg(feature = "parquet")]
 pub mod parquet;
 
 // Re-export the public arrow_convert API at the `export` module level.
 #[cfg(feature = "arrow")]
 pub use arrow_convert::{build_arrow_schema, rows_to_record_batch, ArrowConvertError};
+
+// Re-export the byte estimator beside the converter it models (issue #2825).
+#[cfg(feature = "arrow")]
+pub use arrow_size::{
+    arrow_payload_bytes, estimate_arrow_row_bytes, ARROW_CELL_OVERHEAD_BYTES, ARROW_OFFSET_BYTES,
+    ARROW_SLOT_SLACK_BYTES, ARROW_VALIDITY_BYTES, MAX_ESTIMATE_NODES,
+};
 
 // Delta-scan Arrow schema derivation (Epic #696, Issue #703 / DS7).
 // Requires both `delta-scan` (for the CDC envelope model) and `arrow` (for

--- a/cqlite-core/src/export/mod.rs
+++ b/cqlite-core/src/export/mod.rs
@@ -64,11 +64,12 @@ pub mod parquet;
 pub use arrow_convert::{build_arrow_schema, rows_to_record_batch, ArrowConvertError};
 
 // Re-export the byte estimator beside the converter it models (issue #2825).
+// Deliberately narrow: the structural charging constants stay PRIVATE to
+// `arrow_size` (review N4) — they are tuning parameters of the estimate, not a
+// semver contract. `MAX_ESTIMATE_NODES` is public because the fail-closed
+// behaviour it defines IS part of the contract.
 #[cfg(feature = "arrow")]
-pub use arrow_size::{
-    arrow_payload_bytes, estimate_arrow_row_bytes, ARROW_CELL_OVERHEAD_BYTES, ARROW_OFFSET_BYTES,
-    ARROW_SLOT_SLACK_BYTES, ARROW_VALIDITY_BYTES, MAX_ESTIMATE_NODES,
-};
+pub use arrow_size::{arrow_payload_bytes, estimate_arrow_row_bytes, MAX_ESTIMATE_NODES};
 
 // Delta-scan Arrow schema derivation (Epic #696, Issue #703 / DS7).
 // Requires both `delta-scan` (for the CDC envelope model) and `arrow` (for

--- a/cqlite-flight/src/batch_bytes.rs
+++ b/cqlite-flight/src/batch_bytes.rs
@@ -1,0 +1,265 @@
+//! Byte-bounded Arrow egress batches — the dual row-cap / byte-cap batch
+//! boundary (issue #2825, T4/M11).
+//!
+//! # The problem
+//!
+//! Before this module both egress build sites finished a record batch on **row
+//! count** alone (`buffer.len() >= batch_size`). A batch's byte size was
+//! therefore `batch_size × row_width` — an *unbounded* function of schema shape:
+//! the same code path that produces a ~192 KiB batch for a two-column keyvalue
+//! table produces a 512 MiB batch for a table with a 64 KiB blob column. The
+//! ratified B4 budget (≤16Mi per-query working set at concurrency 1) cannot be
+//! held by a bound stated in rows.
+//!
+//! # The mechanism
+//!
+//! [`BatchByteCap`] is a running accumulator: each buffered row's
+//! [`estimate_arrow_row_bytes`] width is [`push`](BatchByteCap::push)ed as the
+//! row enters the buffer, and the producer flushes when EITHER the row-cap or
+//! this byte-cap trips — whichever comes first. The decision is made **before**
+//! `rows_to_record_batch` allocates anything: building a batch to discover it is
+//! oversized is a report, not a cap, and `RecordBatch::get_array_memory_size()`
+//! is only readable after every value has been copied.
+//!
+//! # Currency: payload bytes, and the published capacity conversion
+//!
+//! The cap is normatively denominated in Arrow **payload** bytes (the sum of
+//! buffer lengths — `cqlite_core::export::arrow_payload_bytes`). It is NOT
+//! denominated in `get_array_memory_size()`, which reports buffer **capacity**:
+//! the construction path (`StringArray::from` / `BinaryArray::from`) grows
+//! `MutableBuffer` by power-of-two doubling from zero, so reported memory runs
+//! up to ~2× payload (measured 1.72–1.80× on realistic shapes against arrow 53).
+//! Capacity is a property of an allocator's growth policy, not of the data: it
+//! is not computable before the batch exists and it is non-monotonic in row
+//! count, so it cannot be the trigger.
+//!
+//! Consumers that must budget in capacity currency convert with the published
+//! constants:
+//!
+//! ```text
+//! worst_case_get_array_memory_size
+//!     <= BATCH_BYTES_CAPACITY_FACTOR * cap
+//!        + BATCH_BYTES_PER_COLUMN_SLACK * n_columns
+//! ```
+//!
+//! # Composition with the per-stream egress ceiling (issue #2821)
+//!
+//! At the 4 MiB default that worst case is `2 × 4 MiB = 8 MiB` of capacity per
+//! resident batch. Issue #2821's per-stream in-flight ceiling must therefore be
+//! budgeted in **capacity** currency too — `streaming.rs` already meters
+//! `get_array_memory_size()` — giving a guaranteed bound of
+//! `ceiling + one maximum batch`. With a 6 MiB ceiling that is
+//! `6 + 8 = 14 MiB < 16Mi`, inside B4 at concurrency 1. (The naive
+//! `4 + 8 = 12 MiB` reading of the task framing mixes payload and capacity: a
+//! 4 MiB *payload* cap is an 8 MiB *capacity* batch, so an 8 MiB ceiling would
+//! land at exactly 16 MiB with zero headroom.)
+//!
+//! # Liveness
+//!
+//! Push-then-test: a batch is cut only when the buffer is **non-empty** and the
+//! accumulated estimate has reached the cap. A single row wider than the whole
+//! cap is delivered as a one-row batch — never dropped, never a stall. Caps of
+//! `0` and `1` degrade to one row per batch rather than hanging, the same clamp
+//! posture as `batch_size.max(1)`.
+
+use cqlite_core::export::estimate_arrow_row_bytes;
+use cqlite_core::query::{ColumnInfo, QueryRow};
+
+/// Default per-batch Arrow **payload** byte cap: 4 MiB.
+///
+/// Chosen so the row-cap still trips first on every narrow shape measured in
+/// this tree, i.e. `batch_size × narrow_row_bytes < cap`:
+///
+/// | narrow shape | bytes/row | full 8192-row batch | headroom |
+/// |---|---:|---:|---:|
+/// | `issue_1494` fixture (`k{i:06}`/`v{i}`) | ~20 | ~192 KiB | ~22× |
+/// | `many_partition_fixture` (`int`/`text`/`int`) | ~13 | ~107 KiB | ~39× |
+/// | field model (`phase1-5-transport-ingest.md:195`) | ~180 | 1.47 MB | ~2.9× |
+/// | the contested 300 B/row figure | 300 | 2.34 MiB | 1.7× |
+///
+/// So the byte-cap is a no-op on the narrow path — no throughput regression —
+/// and binds only where a batch would otherwise be unbounded. Note that at the
+/// pessimistic 300 B/row the *capacity* reading of a full narrow batch is
+/// already 4,227,256 B, above 4 MiB: precisely why the cap must be
+/// payload-denominated.
+pub const DEFAULT_MAX_BATCH_BYTES: usize = 4 * 1024 * 1024;
+
+/// Environment variable backing `--max-batch-bytes`.
+pub const ENV_MAX_BATCH_BYTES: &str = "CQLITE_MAX_BATCH_BYTES";
+
+/// Worst-case ratio of a batch's `get_array_memory_size()` (buffer **capacity**)
+/// to its payload bytes (buffer **lengths**).
+///
+/// `MutableBuffer::reserve` grows to `max(round_upto_multiple_of_64(required),
+/// capacity * 2)` — power-of-two doubling from zero — so a payload landing just
+/// past a power of two reports up to ~2× that payload. Measured against this
+/// tree's arrow 53: 1.001× (512 × 8 KiB binary), 1.280× (100 × 64 KiB binary),
+/// 1.445× (8192 × 180 B binary), 1.720× (8192 × 300 B binary), 1.779× (8192 ×
+/// 290 B string), 1.801× (8192 × 20 B string). `2` is the bound, not the typical.
+///
+/// Published so a consumer — notably issue #2821's per-stream in-flight ceiling
+/// — can convert this change's payload guarantee into the capacity currency it
+/// meters, with no undocumented fudge factor.
+pub const BATCH_BYTES_CAPACITY_FACTOR: usize = 2;
+
+/// Fixed capacity slack allowed **per output column**, on top of
+/// [`BATCH_BYTES_CAPACITY_FACTOR`] × cap.
+///
+/// Every Arrow array carries small fixed allocations that do not scale with the
+/// payload (a 64-byte-aligned minimum allocation per buffer, the validity
+/// buffer, an empty-array's offsets buffer). On a batch that is mostly one wide
+/// column these round to nothing; on a wide-schema batch of tiny rows they are
+/// the whole reported size, so a capacity bound stated purely as a multiple of
+/// the payload would be wrong for that shape.
+pub const BATCH_BYTES_PER_COLUMN_SLACK: usize = 1024;
+
+/// Whether the caller should finish the current batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShouldFlush {
+    /// Keep accumulating: neither cap has been reached.
+    No,
+    /// The byte-cap has been reached — finish this batch now.
+    Yes,
+}
+
+impl ShouldFlush {
+    /// `true` when the batch must be finished.
+    #[inline]
+    pub fn is_yes(self) -> bool {
+        matches!(self, ShouldFlush::Yes)
+    }
+}
+
+/// Running per-batch payload-byte accumulator implementing the byte half of the
+/// dual row-cap / byte-cap boundary.
+///
+/// Shared by BOTH egress build sites (`producer.rs`'s partition-at-a-time merge
+/// loop and `producer_stream.rs`'s row-granular loop) so the boundary rule is
+/// defined once. A cap wired into only one path would leave the other unbounded.
+#[derive(Debug, Clone)]
+pub struct BatchByteCap {
+    /// Configured payload-byte ceiling for one batch.
+    cap: usize,
+    /// Estimated payload bytes accumulated since the last [`Self::reset`].
+    accumulated: usize,
+    /// Rows accumulated since the last [`Self::reset`] — the liveness guard that
+    /// makes the one-row floor unconditional.
+    rows: usize,
+}
+
+impl BatchByteCap {
+    /// Build an accumulator enforcing `cap` payload bytes per batch.
+    ///
+    /// `cap` is used exactly as given, including `0` and `1`: the push-then-test
+    /// rule makes those degrade to one row per batch rather than hang, so no
+    /// clamp is needed (and clamping would silently misreport the operator's
+    /// configuration). `usize::MAX` effectively disables the byte-cap, leaving
+    /// the row-cap as the sole boundary.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            cap,
+            accumulated: 0,
+            rows: 0,
+        }
+    }
+
+    /// The configured payload-byte ceiling.
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
+    /// Estimated payload bytes accumulated in the current batch.
+    pub fn accumulated(&self) -> usize {
+        self.accumulated
+    }
+
+    /// Account for one row that has just been pushed into the buffer, and report
+    /// whether the batch must now be finished.
+    ///
+    /// **Push-then-test** (the one-row floor): the row is always counted first,
+    /// so the answer can only be [`ShouldFlush::Yes`] with at least one row in
+    /// the buffer. A row whose estimate exceeds the entire cap therefore leaves
+    /// as a one-row batch instead of triggering a flush of an empty buffer,
+    /// which would loop without progress.
+    ///
+    /// `width` is saturating-added, so a fail-closed `usize::MAX` estimate
+    /// (a pathological value, see `estimate_arrow_row_bytes`) pins the
+    /// accumulator at the ceiling and cuts the batch rather than wrapping.
+    pub fn push_width(&mut self, width: usize) -> ShouldFlush {
+        self.accumulated = self.accumulated.saturating_add(width);
+        self.rows = self.rows.saturating_add(1);
+        if self.rows > 0 && self.accumulated >= self.cap {
+            ShouldFlush::Yes
+        } else {
+            ShouldFlush::No
+        }
+    }
+
+    /// Estimate `row`'s Arrow payload width for the projected `columns` and
+    /// account for it — the form both producers use.
+    pub fn push_row(&mut self, columns: &[ColumnInfo], row: &QueryRow) -> ShouldFlush {
+        self.push_width(estimate_arrow_row_bytes(columns, row))
+    }
+
+    /// Clear the accumulator for the next batch. Called wherever the buffer is
+    /// flushed, so the running estimate always describes exactly the rows
+    /// currently buffered — the whole buffer is never re-measured per push.
+    pub fn reset(&mut self) {
+        self.accumulated = 0;
+        self.rows = 0;
+    }
+}
+
+/// Split an already-materialized row slice into contiguous groups, each ending
+/// where the dual row-cap / byte-cap boundary falls.
+///
+/// Used by the aggregate route (issue #841), which folds rows into accumulator
+/// state and then materializes one PARTIAL row per `GROUP BY` group in one go —
+/// it never passes through the incremental buffer, so it needs the boundary
+/// applied after the fact. The row path uses [`BatchByteCap`] directly.
+///
+/// Never yields an empty group: the same push-then-test rule applies, so a
+/// single over-cap row becomes a one-row group. An empty input yields no groups.
+pub fn split_rows_into_batches<'a>(
+    columns: &[ColumnInfo],
+    rows: &'a [QueryRow],
+    max_rows: usize,
+    cap: usize,
+) -> Vec<&'a [QueryRow]> {
+    let max_rows = max_rows.max(1);
+    let mut groups = Vec::new();
+    let mut byte_cap = BatchByteCap::new(cap);
+    let mut start = 0usize;
+    for (i, row) in rows.iter().enumerate() {
+        let byte_full = byte_cap.push_row(columns, row).is_yes();
+        let len = i + 1 - start;
+        if len >= max_rows || byte_full {
+            groups.push(&rows[start..=i]);
+            start = i + 1;
+            byte_cap.reset();
+        }
+    }
+    if start < rows.len() {
+        groups.push(&rows[start..]);
+    }
+    groups
+}
+
+/// Worst-case resident size, in `get_array_memory_size()` (capacity) bytes, of
+/// ONE emitted batch produced under `cap` with `n_columns` output columns.
+///
+/// Derived from the published constants alone:
+/// `BATCH_BYTES_CAPACITY_FACTOR * cap + BATCH_BYTES_PER_COLUMN_SLACK * n_columns`.
+/// This is the quantity issue #2821's per-stream ceiling composes with to state
+/// its `ceiling + one maximum batch` bound against B4's ≤16Mi.
+///
+/// Saturating: an operator-configured `usize::MAX` cap reports `usize::MAX`
+/// rather than wrapping.
+pub fn worst_case_batch_capacity_bytes(cap: usize, n_columns: usize) -> usize {
+    cap.saturating_mul(BATCH_BYTES_CAPACITY_FACTOR)
+        .saturating_add(BATCH_BYTES_PER_COLUMN_SLACK.saturating_mul(n_columns))
+}
+
+#[cfg(test)]
+#[path = "batch_bytes_tests.rs"]
+mod batch_bytes_tests;

--- a/cqlite-flight/src/batch_bytes.rs
+++ b/cqlite-flight/src/batch_bytes.rs
@@ -330,8 +330,12 @@ pub fn split_rows_into_batches<'a>(
 /// array nodes (see [`BATCH_BYTES_PER_COLUMN_SLACK`]).
 ///
 /// Derived from the published constants alone:
-/// `BATCH_BYTES_CAPACITY_FACTOR * max(cap, widest_row_payload)
-///  + BATCH_BYTES_PER_COLUMN_SLACK * n_array_nodes`.
+///
+/// ```text
+/// BATCH_BYTES_CAPACITY_FACTOR * max(cap, widest_row_payload)
+///     + BATCH_BYTES_PER_COLUMN_SLACK * n_array_nodes
+/// ```
+///
 /// This is the quantity issue #2821's per-stream ceiling will compose with to
 /// state its `ceiling + one maximum batch` bound against B4's ≤16Mi. Until that
 /// ceiling lands, egress residency is count-bounded, not byte-bounded — see the

--- a/cqlite-flight/src/batch_bytes.rs
+++ b/cqlite-flight/src/batch_bytes.rs
@@ -13,14 +13,14 @@
 //!
 //! # The mechanism
 //!
-//! [`BatchByteCap`] is a running accumulator: each buffered row's
-//! [`estimate_arrow_row_bytes`] width is fed to
-//! [`push_width`](BatchByteCap::push_width) as the row enters the buffer, and
-//! the producer flushes when EITHER the row-cap or
-//! this byte-cap trips — whichever comes first. The decision is made **before**
-//! `rows_to_record_batch` allocates anything: building a batch to discover it is
-//! oversized is a report, not a cap, and `RecordBatch::get_array_memory_size()`
-//! is only readable after every value has been copied.
+//! [`BatchByteCap`] is a running accumulator: each candidate row's
+//! [`estimate_arrow_row_bytes`] width is tested against the accumulator with
+//! [`cut_before`](BatchByteCap::cut_before) **before** the row joins the buffer,
+//! and the producer flushes when EITHER the row-cap or this byte-cap trips —
+//! whichever comes first. The decision is made before `rows_to_record_batch`
+//! allocates anything: building a batch to discover it is oversized is a report,
+//! not a cap, and `RecordBatch::get_array_memory_size()` is only readable after
+//! every value has been copied.
 //!
 //! # Currency: payload bytes, and the published capacity conversion
 //!
@@ -39,30 +39,54 @@
 //!
 //! ```text
 //! worst_case_get_array_memory_size
-//!     <= BATCH_BYTES_CAPACITY_FACTOR * cap
-//!        + BATCH_BYTES_PER_COLUMN_SLACK * n_columns
+//!     <= BATCH_BYTES_CAPACITY_FACTOR * max(cap, widest_row_payload)
+//!        + BATCH_BYTES_PER_COLUMN_SLACK * n_array_nodes
 //! ```
+//!
+//! # The `max(cap, widest_row_payload)` term is not a fudge
+//!
+//! One row cannot be split across two Arrow batches, so a schema whose single
+//! widest row exceeds the whole cap has an **inherent, unbounded** overshoot:
+//! that row leaves as a one-row batch of its own natural size (the alternative
+//! is dropping it or stalling). The cap therefore bounds a batch at
+//! `max(cap, widest_row_payload)` payload bytes — which reduces to plain `cap`
+//! for every schema whose widest row fits, and the overshoot is a property of
+//! the DATA, not slack in the mechanism.
+//!
+//! Nothing in the conversion path imposes a smaller per-cell ceiling that would
+//! bound the term for us: `arrow_convert.rs`'s `checked_value_bytes` guard
+//! rejects only a *cumulative* `Utf8`/`Binary` column length above
+//! `i32::MAX` (2 GiB — the 32-bit Arrow offset limit) and returns an error
+//! rather than clamping, so the honest per-row ceiling is that same ~2 GiB.
+//!
+//! The mechanism itself never overshoots: the boundary is **test-then-push**
+//! (below), so a batch whose rows all fit is cut BEFORE the row that would
+//! cross, never after it.
 //!
 //! # Composition with the per-stream egress ceiling (issue #2821)
 //!
-//! At the 4 MiB default that worst case is `2 × 4 MiB = 8 MiB` of capacity per
-//! resident batch. Issue #2821's per-stream in-flight ceiling must therefore be
-//! budgeted in **capacity** currency too — `streaming.rs` already meters
-//! `get_array_memory_size()` — giving a guaranteed bound of
-//! `ceiling + one maximum batch`. With a 6 MiB ceiling that is
-//! `6 + 8 = 14 MiB < 16Mi`, inside B4 at concurrency 1. (The naive
-//! `4 + 8 = 12 MiB` reading of the task framing mixes payload and capacity: a
-//! 4 MiB *payload* cap is an 8 MiB *capacity* batch, so an 8 MiB ceiling would
-//! land at exactly 16 MiB with zero headroom.)
+//! At the 4 MiB default, with a schema whose rows fit the cap, that worst case
+//! is `2 × 4 MiB = 8 MiB` of capacity per resident batch. Issue #2821's
+//! per-stream in-flight ceiling must therefore be budgeted in **capacity**
+//! currency too — `streaming.rs` already meters `get_array_memory_size()` —
+//! giving a guaranteed bound of `ceiling + one maximum batch`. With a 6 MiB
+//! ceiling that is `6 + 8 = 14 MiB < 16Mi`, inside B4 at concurrency 1. (The
+//! naive `4 + 8 = 12 MiB` reading of the task framing mixes payload and
+//! capacity: a 4 MiB *payload* cap is an 8 MiB *capacity* batch, so an 8 MiB
+//! ceiling would land at exactly 16 MiB with zero headroom.) A deployment whose
+//! rows can individually exceed the cap must carry the wider row's bytes in that
+//! composition — see [`worst_case_batch_capacity_bytes`].
 //!
 //! # Liveness
 //!
-//! Push-then-test: a batch is cut only when the buffer is **non-empty** and the
-//! accumulated estimate has reached the cap. A single row wider than the whole
-//! cap is delivered as a one-row batch — never dropped, never a stall. Caps of
-//! `0` and `1` therefore degrade to one row per batch rather than hanging — the
-//! same *outcome* `batch_size.max(1)` gives the row-cap, reached by the ordering
-//! rule instead of by clamping the operator's configured value.
+//! Test-then-push: the crossing row's width is tested against the accumulator
+//! FIRST, and the batch is cut only when the buffer is **non-empty** and adding
+//! the row would take it past the cap. An empty buffer always accepts the row,
+//! however wide — so a single row wider than the whole cap is delivered as a
+//! one-row batch, never dropped and never a stall. Caps of `0` and `1`
+//! therefore degrade to one row per batch rather than hanging — the same
+//! *outcome* `batch_size.max(1)` gives the row-cap, reached by the ordering rule
+//! instead of by clamping the operator's configured value.
 
 use cqlite_core::export::estimate_arrow_row_bytes;
 use cqlite_core::query::{ColumnInfo, QueryRow};
@@ -104,7 +128,7 @@ pub const ENV_MAX_BATCH_BYTES: &str = "CQLITE_MAX_BATCH_BYTES";
 /// meters, with no undocumented fudge factor.
 pub const BATCH_BYTES_CAPACITY_FACTOR: usize = 2;
 
-/// Fixed capacity slack allowed **per output column**, on top of
+/// Fixed capacity slack allowed **per Arrow array node**, on top of
 /// [`BATCH_BYTES_CAPACITY_FACTOR`] × cap.
 ///
 /// Every Arrow array carries small fixed allocations that do not scale with the
@@ -113,6 +137,15 @@ pub const BATCH_BYTES_CAPACITY_FACTOR: usize = 2;
 /// column these round to nothing; on a wide-schema batch of tiny rows they are
 /// the whole reported size, so a capacity bound stated purely as a multiple of
 /// the payload would be wrong for that shape.
+///
+/// Denominated in array NODES, not output columns: a flat scalar column is one
+/// node, but a `list<text>` column is two (the `ListArray` and its `Utf8`
+/// child) and a `map<text,text>` column is four (map, entries struct, key
+/// `Utf8`, value `Utf8`). Callers with a flat schema pass the column count;
+/// callers with nested columns must count the child arrays too, or the slack
+/// term under-states their fixed allocations. (At the 4 MiB default the
+/// `2 × cap` term dominates by three orders of magnitude either way; the
+/// distinction bites only for a tiny cap over a deeply nested schema.)
 pub const BATCH_BYTES_PER_COLUMN_SLACK: usize = 1024;
 
 /// Whether the caller should finish the current batch.
@@ -152,7 +185,7 @@ pub struct BatchByteCap {
 impl BatchByteCap {
     /// Build an accumulator enforcing `cap` payload bytes per batch.
     ///
-    /// `cap` is used exactly as given, including `0` and `1`: the push-then-test
+    /// `cap` is used exactly as given, including `0` and `1`: the test-then-push
     /// rule makes those degrade to one row per batch rather than hang, so no
     /// clamp is needed (and clamping would silently misreport the operator's
     /// configuration). `usize::MAX` effectively disables the byte-cap, leaving
@@ -182,35 +215,45 @@ impl BatchByteCap {
         self.rows
     }
 
-    /// Account for one row that has just been pushed into the buffer, and report
-    /// whether the batch must now be finished.
+    /// **Test-then-push**: must the currently buffered rows be finished BEFORE a
+    /// row of `width` payload bytes is appended?
     ///
-    /// **Push-then-test** (the one-row floor): the row is always counted first,
-    /// so the answer can only be [`ShouldFlush::Yes`] with at least one row in
-    /// the buffer. A row whose estimate exceeds the entire cap therefore leaves
-    /// as a one-row batch instead of triggering a flush of an empty buffer,
-    /// which would loop without progress.
+    /// Answering before the row joins the buffer is what bounds a batch at `cap`
+    /// rather than at `cap - 1 + width_of_crossing_row`: the batch is cut on the
+    /// row that WOULD cross, so the crossing row starts the next batch instead
+    /// of overshooting this one (issue #2825 review B1).
     ///
-    /// `width` is saturating-added, so a fail-closed `usize::MAX` estimate
-    /// (a pathological value, see `estimate_arrow_row_bytes`) pins the
-    /// accumulator at the ceiling and cuts the batch rather than wrapping.
-    pub fn push_width(&mut self, width: usize) -> ShouldFlush {
-        self.accumulated = self.accumulated.saturating_add(width);
-        self.rows = self.rows.saturating_add(1);
-        // `rows >= 1` unconditionally here — the row was counted first. Stated
-        // as a real conjunct rather than an assertion so a future edit that
-        // moves the increment cannot silently break the one-row floor.
-        if self.rows > 0 && self.accumulated >= self.cap {
+    /// The one-row floor is the `self.rows > 0` conjunct: an **empty buffer
+    /// always accepts the row**, however wide, so a row wider than the entire
+    /// cap leaves as a one-row batch and can never trigger a flush of nothing
+    /// (which would loop without progress). Caps of `0` and `1` therefore
+    /// degrade to one row per batch rather than hanging.
+    ///
+    /// Saturating: a fail-closed `usize::MAX` width (a pathological value, see
+    /// `estimate_arrow_row_bytes`) compares at the ceiling instead of wrapping.
+    pub fn cut_before(&self, width: usize) -> ShouldFlush {
+        if self.rows > 0 && self.accumulated.saturating_add(width) > self.cap {
             ShouldFlush::Yes
         } else {
             ShouldFlush::No
         }
     }
 
-    /// Estimate `row`'s Arrow payload width for the projected `columns` and
-    /// account for it — the form both producers use.
-    pub fn push_row(&mut self, columns: &[ColumnInfo], row: &QueryRow) -> ShouldFlush {
-        self.push_width(estimate_arrow_row_bytes(columns, row))
+    /// Account for one row of `width` payload bytes that has just been appended
+    /// to the buffer. Call AFTER [`Self::cut_before`] has been honoured.
+    ///
+    /// `width` is saturating-added, so a `usize::MAX` estimate pins the
+    /// accumulator at the ceiling rather than wrapping.
+    pub fn accumulate(&mut self, width: usize) {
+        self.accumulated = self.accumulated.saturating_add(width);
+        self.rows = self.rows.saturating_add(1);
+    }
+
+    /// Estimate `row`'s Arrow payload width for the projected `columns` — the
+    /// quantity both [`Self::cut_before`] and [`Self::accumulate`] take, computed
+    /// once per row by the caller so it is never estimated twice.
+    pub fn row_width(columns: &[ColumnInfo], row: &QueryRow) -> usize {
+        estimate_arrow_row_bytes(columns, row)
     }
 
     /// Clear the accumulator for the next batch. Called wherever the buffer is
@@ -230,7 +273,7 @@ impl BatchByteCap {
 /// it never passes through the incremental buffer, so it needs the boundary
 /// applied after the fact. The row path uses [`BatchByteCap`] directly.
 ///
-/// Never yields an empty group: the same push-then-test rule applies, so a
+/// Never yields an empty group: the same test-then-push rule applies, so a
 /// single over-cap row becomes a one-row group. An empty input yields no groups.
 pub fn split_rows_into_batches<'a>(
     columns: &[ColumnInfo],
@@ -243,9 +286,18 @@ pub fn split_rows_into_batches<'a>(
     let mut byte_cap = BatchByteCap::new(cap);
     let mut start = 0usize;
     for (i, row) in rows.iter().enumerate() {
-        let byte_full = byte_cap.push_row(columns, row).is_yes();
-        let len = i + 1 - start;
-        if len >= max_rows || byte_full {
+        let width = BatchByteCap::row_width(columns, row);
+        // Cut BEFORE the crossing row, so the group that ends here holds only
+        // rows that fit — the same rule the two incremental producers apply.
+        // `cut_before` is `No` while the group is empty, so `start < i` holds
+        // here and the pushed group is never empty.
+        if byte_cap.cut_before(width).is_yes() {
+            groups.push(&rows[start..i]);
+            start = i;
+            byte_cap.reset();
+        }
+        byte_cap.accumulate(width);
+        if i + 1 - start >= max_rows {
             groups.push(&rows[start..=i]);
             start = i + 1;
             byte_cap.reset();
@@ -258,18 +310,36 @@ pub fn split_rows_into_batches<'a>(
 }
 
 /// Worst-case resident size, in `get_array_memory_size()` (capacity) bytes, of
-/// ONE emitted batch produced under `cap` with `n_columns` output columns.
+/// ONE emitted batch produced under `cap` over a schema whose widest single row
+/// contributes `widest_row_payload` payload bytes, with `n_array_nodes` Arrow
+/// array nodes (see [`BATCH_BYTES_PER_COLUMN_SLACK`]).
 ///
 /// Derived from the published constants alone:
-/// `BATCH_BYTES_CAPACITY_FACTOR * cap + BATCH_BYTES_PER_COLUMN_SLACK * n_columns`.
+/// `BATCH_BYTES_CAPACITY_FACTOR * max(cap, widest_row_payload)
+///  + BATCH_BYTES_PER_COLUMN_SLACK * n_array_nodes`.
 /// This is the quantity issue #2821's per-stream ceiling composes with to state
 /// its `ceiling + one maximum batch` bound against B4's ≤16Mi.
 ///
+/// The `max(..)` term is honest, not slack. The boundary is test-then-push, so a
+/// batch is cut BEFORE the row that would cross the cap — but a row cannot be
+/// split across Arrow batches, so a row wider than the whole cap is emitted
+/// alone at its own natural width. Callers whose rows are known to fit the cap
+/// pass `0` (or any value ≤ `cap`) and get the familiar
+/// `FACTOR * cap + slack` bound; callers that cannot rule out a wider row must
+/// state that row's payload here. Nothing downstream clamps it —
+/// `arrow_convert.rs`'s `checked_value_bytes` guard only *rejects* a cumulative
+/// column length above `i32::MAX`, so ~2 GiB is the only structural ceiling.
+///
 /// Saturating: an operator-configured `usize::MAX` cap reports `usize::MAX`
 /// rather than wrapping.
-pub fn worst_case_batch_capacity_bytes(cap: usize, n_columns: usize) -> usize {
-    cap.saturating_mul(BATCH_BYTES_CAPACITY_FACTOR)
-        .saturating_add(BATCH_BYTES_PER_COLUMN_SLACK.saturating_mul(n_columns))
+pub fn worst_case_batch_capacity_bytes(
+    cap: usize,
+    n_array_nodes: usize,
+    widest_row_payload: usize,
+) -> usize {
+    cap.max(widest_row_payload)
+        .saturating_mul(BATCH_BYTES_CAPACITY_FACTOR)
+        .saturating_add(BATCH_BYTES_PER_COLUMN_SLACK.saturating_mul(n_array_nodes))
 }
 
 #[cfg(test)]

--- a/cqlite-flight/src/batch_bytes.rs
+++ b/cqlite-flight/src/batch_bytes.rs
@@ -14,8 +14,9 @@
 //! # The mechanism
 //!
 //! [`BatchByteCap`] is a running accumulator: each buffered row's
-//! [`estimate_arrow_row_bytes`] width is [`push`](BatchByteCap::push)ed as the
-//! row enters the buffer, and the producer flushes when EITHER the row-cap or
+//! [`estimate_arrow_row_bytes`] width is fed to
+//! [`push_width`](BatchByteCap::push_width) as the row enters the buffer, and
+//! the producer flushes when EITHER the row-cap or
 //! this byte-cap trips — whichever comes first. The decision is made **before**
 //! `rows_to_record_batch` allocates anything: building a batch to discover it is
 //! oversized is a report, not a cap, and `RecordBatch::get_array_memory_size()`
@@ -59,8 +60,9 @@
 //! Push-then-test: a batch is cut only when the buffer is **non-empty** and the
 //! accumulated estimate has reached the cap. A single row wider than the whole
 //! cap is delivered as a one-row batch — never dropped, never a stall. Caps of
-//! `0` and `1` degrade to one row per batch rather than hanging, the same clamp
-//! posture as `batch_size.max(1)`.
+//! `0` and `1` therefore degrade to one row per batch rather than hanging — the
+//! same *outcome* `batch_size.max(1)` gives the row-cap, reached by the ordering
+//! rule instead of by clamping the operator's configured value.
 
 use cqlite_core::export::estimate_arrow_row_bytes;
 use cqlite_core::query::{ColumnInfo, QueryRow};
@@ -173,6 +175,13 @@ impl BatchByteCap {
         self.accumulated
     }
 
+    /// Rows accumulated into the current batch since the last [`Self::reset`].
+    /// A [`ShouldFlush::Yes`] can only ever be reported with this at 1 or more —
+    /// the one-row floor.
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
     /// Account for one row that has just been pushed into the buffer, and report
     /// whether the batch must now be finished.
     ///
@@ -188,6 +197,9 @@ impl BatchByteCap {
     pub fn push_width(&mut self, width: usize) -> ShouldFlush {
         self.accumulated = self.accumulated.saturating_add(width);
         self.rows = self.rows.saturating_add(1);
+        // `rows >= 1` unconditionally here — the row was counted first. Stated
+        // as a real conjunct rather than an assertion so a future edit that
+        // moves the increment cannot silently break the one-row floor.
         if self.rows > 0 && self.accumulated >= self.cap {
             ShouldFlush::Yes
         } else {

--- a/cqlite-flight/src/batch_bytes.rs
+++ b/cqlite-flight/src/batch_bytes.rs
@@ -63,19 +63,34 @@
 //! (below), so a batch whose rows all fit is cut BEFORE the row that would
 //! cross, never after it.
 //!
-//! # Composition with the per-stream egress ceiling (issue #2821)
+//! # What this change guarantees, and what it does NOT (issue #2821)
 //!
-//! At the 4 MiB default, with a schema whose rows fit the cap, that worst case
-//! is `2 × 4 MiB = 8 MiB` of capacity per resident batch. Issue #2821's
-//! per-stream in-flight ceiling must therefore be budgeted in **capacity**
-//! currency too — `streaming.rs` already meters `get_array_memory_size()` —
-//! giving a guaranteed bound of `ceiling + one maximum batch`. With a 6 MiB
-//! ceiling that is `6 + 8 = 14 MiB < 16Mi`, inside B4 at concurrency 1. (The
-//! naive `4 + 8 = 12 MiB` reading of the task framing mixes payload and
-//! capacity: a 4 MiB *payload* cap is an 8 MiB *capacity* batch, so an 8 MiB
-//! ceiling would land at exactly 16 MiB with zero headroom.) A deployment whose
-//! rows can individually exceed the cap must carry the wider row's bytes in that
-//! composition — see [`worst_case_batch_capacity_bytes`].
+//! **Guaranteed here, today: a bound on ONE batch.** At the 4 MiB default, over
+//! a schema whose rows fit the cap, an emitted batch is ≤4 MiB of payload and
+//! therefore ≤`2 × 4 MiB = 8 MiB` of capacity — see
+//! [`worst_case_batch_capacity_bytes`], and add the wider row's bytes for a
+//! deployment whose rows can individually exceed the cap.
+//!
+//! **NOT guaranteed here: per-stream egress residency.** The `do_get` path is
+//! still **count**-bounded, not byte-bounded: `streaming.rs`'s
+//! `DO_GET_CHANNEL_CAPACITY` is 4 batches plus up to ~3 more in flight
+//! (`IN_FLIGHT_ALLOWANCE`), so worst-case resident egress is
+//! `~7 × 8 MiB ≈ 56 MiB` per stream, NOT 14 MiB. The
+//! `get_array_memory_size()` reading that `streaming.rs` takes per batch is fed
+//! to **metrics only** — no admission or backpressure decision consumes it — so
+//! it does not bound residency. What this change does for that number is make it
+//! *finite and stated*: before it, one batch was `batch_size × row_width`, so the
+//! product was unbounded in schema shape.
+//!
+//! **The composition becomes true only once #2821 lands.** When #2821 enforces a
+//! per-stream in-flight ceiling denominated in **capacity** currency, its
+//! guaranteed bound is `ceiling + one maximum batch`; with a 6 MiB ceiling that
+//! is `6 + 8 = 14 MiB < 16Mi`, inside B4 at concurrency 1. (The naive
+//! `4 + 8 = 12 MiB` reading of the task framing mixes payload and capacity: a
+//! 4 MiB *payload* cap is an 8 MiB *capacity* batch, so an 8 MiB ceiling would
+//! land at exactly 16 MiB with zero headroom.) Until that ceiling exists and
+//! actually gates production, the 14 MiB figure is a TARGET for the dependent
+//! issue, not a property of this tree.
 //!
 //! # Liveness
 //!
@@ -317,8 +332,10 @@ pub fn split_rows_into_batches<'a>(
 /// Derived from the published constants alone:
 /// `BATCH_BYTES_CAPACITY_FACTOR * max(cap, widest_row_payload)
 ///  + BATCH_BYTES_PER_COLUMN_SLACK * n_array_nodes`.
-/// This is the quantity issue #2821's per-stream ceiling composes with to state
-/// its `ceiling + one maximum batch` bound against B4's ≤16Mi.
+/// This is the quantity issue #2821's per-stream ceiling will compose with to
+/// state its `ceiling + one maximum batch` bound against B4's ≤16Mi. Until that
+/// ceiling lands, egress residency is count-bounded, not byte-bounded — see the
+/// module documentation.
 ///
 /// The `max(..)` term is honest, not slack. The boundary is test-then-push, so a
 /// batch is cut BEFORE the row that would cross the cap — but a row cannot be

--- a/cqlite-flight/src/batch_bytes_tests.rs
+++ b/cqlite-flight/src/batch_bytes_tests.rs
@@ -778,6 +778,87 @@ fn split_rows_into_batches_applies_the_same_dual_boundary() {
     assert!(split_rows_into_batches(&columns, &[], 8192, 1).is_empty());
 }
 
+/// A row carrying a wide-but-LEGAL collection still batches several rows at a
+/// time (issue #2825 review C2).
+///
+/// The estimator's node budget used to be shared across a whole row, so a single
+/// collection near Cassandra's classic 65,535-element limit failed the row's
+/// estimate closed to `usize::MAX`; `cut_before` then fired on every following
+/// row and the stream degraded to ONE row per batch indefinitely. This is the
+/// batching-level guard for that: the same rows must group several-per-batch at
+/// a cap their real payload comfortably fits, and the grouping must still be
+/// bounded by the cap.
+#[test]
+fn wide_collection_rows_still_batch_several_at_a_time() {
+    use cqlite_core::export::arrow_payload_bytes as payload;
+    use cqlite_core::query::{ColumnInfo, QueryRow};
+    use cqlite_core::schema::CqlType;
+    use cqlite_core::types::{DataType, Value};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const ENTRIES: i32 = 40_000;
+    const ROWS: usize = 8;
+
+    let columns = vec![ColumnInfo {
+        name: "m".into(),
+        data_type: DataType::Map,
+        nullable: true,
+        position: 0,
+        table_name: None,
+        cql_type: Some(CqlType::Map(
+            Box::new(CqlType::Text),
+            Box::new(CqlType::Int),
+        )),
+    }];
+    let rows: Vec<QueryRow> = (0..ROWS)
+        .map(|_| {
+            let mut values: HashMap<Arc<str>, Value> = HashMap::new();
+            values.insert(
+                Arc::from("m"),
+                Value::Map(
+                    (0..ENTRIES)
+                        .map(|j| {
+                            (
+                                Value::Text(format!("k{j}").into_bytes().into()),
+                                Value::Integer(j),
+                            )
+                        })
+                        .collect(),
+                ),
+            );
+            QueryRow::with_interned_values(cqlite_core::RowKey::new(Vec::new()), values)
+        })
+        .collect();
+
+    // Non-vacuity: one row's realized payload must be a real, sub-cap size.
+    let one = cqlite_core::export::rows_to_record_batch(&columns, &rows[..1]).expect("convert");
+    let one_payload = payload(&one);
+    assert!(
+        one_payload > 100_000 && one_payload * 2 < DEFAULT_MAX_BATCH_BYTES,
+        "fixture is vacuous or over-cap: {one_payload} B/row against the \
+         {DEFAULT_MAX_BATCH_BYTES}-byte default cap"
+    );
+
+    let groups = split_rows_into_batches(&columns, &rows, 8192, DEFAULT_MAX_BATCH_BYTES);
+    assert_eq!(groups.iter().map(|g| g.len()).sum::<usize>(), ROWS);
+    assert!(
+        groups.iter().all(|g| g.len() > 1),
+        "wide-collection rows degraded to one row per batch: group sizes {:?}",
+        groups.iter().map(|g| g.len()).collect::<Vec<_>>()
+    );
+    // Still bounded: every group's realized payload is at or below the cap.
+    for g in &groups {
+        let batch = cqlite_core::export::rows_to_record_batch(&columns, g).expect("convert");
+        assert!(
+            payload(&batch) <= DEFAULT_MAX_BATCH_BYTES,
+            "a group of {} rows realized {} B, over the cap",
+            g.len(),
+            payload(&batch)
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Requirement 9: throughput evidence lives OUTSIDE the correctness path
 // ---------------------------------------------------------------------------

--- a/cqlite-flight/src/batch_bytes_tests.rs
+++ b/cqlite-flight/src/batch_bytes_tests.rs
@@ -210,9 +210,10 @@ fn narrow_rows_still_finish_batches_on_the_row_cap() {
 // Requirement 2: the decision precedes materialization
 // ---------------------------------------------------------------------------
 
-/// No oversized batch is ever allocated: every emitted batch's realized payload
-/// respects the cap (up to the last row that crossed it), so the wide batch that
-/// the row-cap alone would have built was never constructed at all.
+/// No oversized batch is ever allocated: because the cut happens BEFORE the
+/// crossing row is appended, every emitted batch's realized payload is at or
+/// below the cap outright — no `+ one row` allowance. The wide batch the row-cap
+/// alone would have built was never constructed at all.
 #[test]
 fn no_oversized_batch_is_ever_allocated() {
     let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
@@ -231,37 +232,90 @@ fn no_oversized_batch_is_ever_allocated() {
     );
     for (i, b) in batches.iter().enumerate() {
         let payload = arrow_payload_bytes(b);
-        // A batch is cut on the row that CROSSES the cap, so the last row's
-        // width is the allowed excess. Every row here is the same width.
+        // Every fixture row fits the cap, so `max(cap, widest_row) == cap`.
         assert!(
-            payload <= WIDE_CAP + per_row_payload_bound(),
-            "batch {i} realized {payload} payload bytes, above the cap {WIDE_CAP}"
+            payload <= WIDE_CAP,
+            "batch {i} realized {payload} payload bytes, above the cap {WIDE_CAP} \
+             — the boundary overshot by appending the crossing row"
         );
     }
 }
 
 /// Upper bound on one wide fixture row's realized payload contribution — the
-/// allowed excess of the row that crosses the cap.
-fn per_row_payload_bound() -> usize {
-    WIDE_PAYLOAD + 256
+/// width a batch may reach when a SINGLE row is wider than the whole cap.
+fn per_row_payload_bound(payload_len: usize) -> usize {
+    payload_len + 256
 }
 
-/// The running estimate is per-row and reset on flush: pushing N rows then
-/// resetting leaves the accumulator at zero, and each push advances it by that
-/// row's width only.
+/// The accumulator is test-then-push: `cut_before` decides on the row that is
+/// about to be appended, `accumulate` records it, and `reset` clears both.
 #[test]
 fn accumulator_is_incremental_and_reset_on_flush() {
     let mut cap = BatchByteCap::new(1000);
     assert_eq!(cap.accumulated(), 0);
-    assert_eq!(cap.push_width(300), ShouldFlush::No);
-    assert_eq!(cap.accumulated(), 300);
-    assert_eq!(cap.push_width(300), ShouldFlush::No);
-    assert_eq!(cap.accumulated(), 600);
-    assert_eq!(cap.push_width(500), ShouldFlush::Yes);
-    assert_eq!(cap.accumulated(), 1100);
+    for width in [300, 300, 300] {
+        assert_eq!(cap.cut_before(width), ShouldFlush::No);
+        cap.accumulate(width);
+    }
+    assert_eq!(cap.accumulated(), 900);
+    // 900 + 300 would be 1200 > 1000, so the CURRENT batch is cut first and the
+    // crossing row starts the next one — the accumulated payload of the emitted
+    // batch stays at or below the cap.
+    assert_eq!(cap.cut_before(300), ShouldFlush::Yes);
     cap.reset();
     assert_eq!(cap.accumulated(), 0);
-    assert_eq!(cap.push_width(1), ShouldFlush::No);
+    assert_eq!(cap.rows(), 0);
+    cap.accumulate(300);
+    assert_eq!(cap.accumulated(), 300);
+    // Exactly reaching the cap is NOT a crossing: 300 + 700 == 1000 fits.
+    assert_eq!(cap.cut_before(700), ShouldFlush::No);
+    cap.accumulate(700);
+    assert_eq!(cap.cut_before(1), ShouldFlush::Yes);
+}
+
+/// The bound a batch's payload may reach is `max(cap, widest_row)` — cutting
+/// BEFORE the crossing row, not after it. Asserted directly on the accumulator
+/// over an adversarial width sequence, so it holds independently of any fixture.
+#[test]
+fn accumulated_payload_never_exceeds_max_of_cap_and_widest_row() {
+    const CAP: usize = 1000;
+    // A crossing row that is a LARGE fraction of the cap (900) is the case a
+    // push-then-test boundary overshoots on: it would emit 900 + 900 = 1800.
+    let widths = [100usize, 900, 900, 1, 999, 5000, 2, 1000, 1];
+    let widest = widths.iter().copied().max().unwrap_or(0);
+    let mut cap = BatchByteCap::new(CAP);
+    let mut emitted: Vec<usize> = Vec::new();
+    for w in widths {
+        if cap.cut_before(w).is_yes() {
+            emitted.push(cap.accumulated());
+            cap.reset();
+        }
+        cap.accumulate(w);
+    }
+    emitted.push(cap.accumulated());
+    assert!(emitted.len() > 1, "degenerate: {emitted:?}");
+    assert_eq!(
+        emitted.iter().sum::<usize>(),
+        widths.iter().sum::<usize>(),
+        "a row's width was lost or double-counted: {emitted:?}"
+    );
+    for (i, bytes) in emitted.iter().enumerate() {
+        assert!(
+            *bytes <= CAP.max(widest),
+            "batch {i} accumulated {bytes} bytes, above max(cap {CAP}, widest row {widest})"
+        );
+    }
+    // And the ONLY batch allowed past the cap is the one carrying the single
+    // over-cap row alone.
+    assert_eq!(
+        emitted
+            .iter()
+            .filter(|b| **b > CAP)
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![5000],
+        "a batch other than the lone over-cap row exceeded the cap: {emitted:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -269,10 +323,10 @@ fn accumulator_is_incremental_and_reset_on_flush() {
 // ---------------------------------------------------------------------------
 
 /// Every emitted batch stays inside the PUBLISHED capacity tolerance
-/// `BATCH_BYTES_CAPACITY_FACTOR * cap + BATCH_BYTES_PER_COLUMN_SLACK * columns`,
-/// and — separately and tightly — every multi-row batch's PAYLOAD bytes are at
-/// or below the cap. Both bounds are expressed through the named constants, not
-/// inline literals.
+/// `BATCH_BYTES_CAPACITY_FACTOR * max(cap, widest_row) + slack * array_nodes`,
+/// and — separately and tightly — every batch's PAYLOAD bytes are at or below
+/// the cap (every fixture row fits it). Both bounds are expressed through the
+/// named constants, not inline literals.
 #[test]
 fn emitted_batches_respect_the_payload_and_capacity_bounds() {
     let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
@@ -281,39 +335,63 @@ fn emitted_batches_respect_the_payload_and_capacity_bounds() {
     let batches = scan_merge(&p, &dir);
     assert_non_vacuous(&batches, WIDE_ROWS as usize, "capacity tolerance");
 
-    let capacity_bound = worst_case_batch_capacity_bytes(WIDE_CAP, n_columns);
+    // Rows here are ~4 KiB against a 64 KiB cap; the widest-row term is
+    // absorbed by `max(..)` and the bound reduces to `2 * cap + slack`.
+    let capacity_bound =
+        worst_case_batch_capacity_bytes(WIDE_CAP, n_columns, per_row_payload_bound(WIDE_PAYLOAD));
+    assert_eq!(
+        capacity_bound,
+        worst_case_batch_capacity_bytes(WIDE_CAP, n_columns, 0),
+        "the fixture's widest row should fit the cap"
+    );
     for (i, b) in batches.iter().enumerate() {
         assert!(
             b.get_array_memory_size() <= capacity_bound,
             "batch {i}: get_array_memory_size {} exceeds the published tolerance {capacity_bound}",
             b.get_array_memory_size()
         );
-        // Tight payload bound, in the cap's own currency: a batch of two or more
-        // rows must sit at or below the cap once its final row is excluded — the
-        // cut happens ON the crossing row.
-        if b.num_rows() >= 2 {
-            let payload = arrow_payload_bytes(b);
-            assert!(
-                payload <= WIDE_CAP + per_row_payload_bound(),
-                "batch {i}: payload {payload} above cap {WIDE_CAP}"
-            );
-        }
+        let payload = arrow_payload_bytes(b);
+        assert!(
+            payload <= WIDE_CAP,
+            "batch {i}: payload {payload} above cap {WIDE_CAP}"
+        );
     }
 }
 
 /// The published capacity conversion is derivable from the named constants
-/// alone, with no hidden fudge factor.
+/// alone, with no hidden fudge factor — including the `max(cap, widest_row)`
+/// term that a schema with a single over-cap row pays.
 #[test]
 fn worst_case_capacity_follows_from_the_named_constants() {
     assert_eq!(
-        worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 3),
+        worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 3, 0),
         DEFAULT_MAX_BATCH_BYTES * BATCH_BYTES_CAPACITY_FACTOR + BATCH_BYTES_PER_COLUMN_SLACK * 3
     );
+    // A widest row at or below the cap does not move the bound...
+    assert_eq!(
+        worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 3, DEFAULT_MAX_BATCH_BYTES),
+        worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 3, 0)
+    );
+    // ...and a row WIDER than the cap moves it by exactly that row, because one
+    // row cannot be split across Arrow batches.
+    let fat_row = 3 * DEFAULT_MAX_BATCH_BYTES;
+    assert_eq!(
+        worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 3, fat_row),
+        fat_row * BATCH_BYTES_CAPACITY_FACTOR + BATCH_BYTES_PER_COLUMN_SLACK * 3
+    );
     // Saturating: an unbounded cap reports the ceiling, never a wrapped value.
-    assert_eq!(worst_case_batch_capacity_bytes(usize::MAX, 8), usize::MAX);
+    assert_eq!(
+        worst_case_batch_capacity_bytes(usize::MAX, 8, 0),
+        usize::MAX
+    );
+    assert_eq!(
+        worst_case_batch_capacity_bytes(0, 8, usize::MAX),
+        usize::MAX
+    );
     // The #2821 composition: 6 MiB ceiling + one worst-case 4 MiB-payload batch
-    // stays inside B4's 16Mi at concurrency 1.
-    let one_batch = worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 16);
+    // stays inside B4's 16Mi at concurrency 1 — for a schema whose widest row
+    // fits the cap, which is the precondition #2821 must carry.
+    let one_batch = worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 16, 0);
     assert!(
         6 * 1024 * 1024 + one_batch <= 16 * 1024 * 1024,
         "6 MiB ceiling + one max batch ({one_batch}) breaks the B4 budget"
@@ -333,9 +411,12 @@ fn worst_case_capacity_follows_from_the_named_constants() {
 #[test]
 fn rows_wider_than_the_cap_are_emitted_one_per_batch() {
     const N: i32 = 6;
-    let (_temp, dir, schema) = wide_fixture(N, 8192);
+    const PAYLOAD: usize = 8192;
+    const TINY_CAP: usize = 64;
+    let (_temp, dir, schema) = wide_fixture(N, PAYLOAD);
+    let n_columns = schema.columns.len();
     // Cap far below one row's width.
-    let p = producer(schema, BIG_BATCH_SIZE, 64);
+    let p = producer(schema, BIG_BATCH_SIZE, TINY_CAP);
     let batches = scan_merge(&p, &dir);
     assert_eq!(total_rows(&batches), N as usize, "a row was dropped");
     assert_eq!(
@@ -343,8 +424,56 @@ fn rows_wider_than_the_cap_are_emitted_one_per_batch() {
         N as usize,
         "expected exactly one batch per over-cap row"
     );
+    // The published bound in the regime where the widest row EXCEEDS the cap:
+    // `max(cap, widest_row)`, i.e. the row's own width — the inherent overshoot
+    // of a boundary that cannot split a row across batches (review B1).
+    let widest = per_row_payload_bound(PAYLOAD);
+    let capacity_bound = worst_case_batch_capacity_bytes(TINY_CAP, n_columns, widest);
     for (i, b) in batches.iter().enumerate() {
         assert_eq!(b.num_rows(), 1, "batch {i} is not a one-row batch");
+        let payload = arrow_payload_bytes(b);
+        assert!(
+            payload > TINY_CAP,
+            "batch {i}: payload {payload} does not exceed the cap — the fixture \
+             no longer exercises the over-cap row case"
+        );
+        assert!(
+            payload <= TINY_CAP.max(widest),
+            "batch {i}: payload {payload} exceeds max(cap {TINY_CAP}, widest row {widest})"
+        );
+        assert!(
+            b.get_array_memory_size() <= capacity_bound,
+            "batch {i}: get_array_memory_size {} exceeds the published tolerance {capacity_bound}",
+            b.get_array_memory_size()
+        );
+    }
+}
+
+/// A crossing row that is a LARGE fraction of the cap does not overshoot it —
+/// the case the published bound was wrong about (review B1). With ~8 KiB rows
+/// under a ~12 KiB cap, a push-then-test boundary would emit ~20 KiB batches
+/// (1.7x the cap); test-then-push emits one row per batch, all at or under it.
+#[test]
+fn a_crossing_row_that_is_a_large_fraction_of_the_cap_does_not_overshoot() {
+    const N: i32 = 8;
+    const PAYLOAD: usize = 8192;
+    const CAP: usize = 12 * 1024;
+    let (_temp, dir, schema) = wide_fixture(N, PAYLOAD);
+    let p = producer(schema, BIG_BATCH_SIZE, CAP);
+    for (label, batches) in [
+        ("merge", scan_merge(&p, &dir)),
+        ("streaming", scan_streaming(&p, &dir)),
+    ] {
+        assert_eq!(total_rows(&batches), N as usize, "{label}: rows lost");
+        assert!(batches.len() > 1, "{label}: degenerate single batch");
+        for (i, b) in batches.iter().enumerate() {
+            let payload = arrow_payload_bytes(b);
+            assert!(
+                payload <= CAP,
+                "{label} batch {i}: payload {payload} overshot the cap {CAP} — \
+                 the batch was cut AFTER the crossing row, not before it"
+            );
+        }
     }
 }
 
@@ -378,40 +507,54 @@ fn zero_and_one_byte_caps_degrade_to_one_row_per_batch() {
     }
 }
 
-/// The accumulator never reports a flush with an empty buffer, for any cap —
-/// the push-then-test invariant that makes the one-row floor total.
+/// The accumulator never asks for a flush with an empty buffer, for ANY cap and
+/// ANY width — the test-then-push invariant that makes the one-row floor total.
 #[test]
 fn accumulator_only_flushes_with_at_least_one_row_counted() {
     for cap in [0usize, 1, 64, DEFAULT_MAX_BATCH_BYTES, usize::MAX] {
+        for width in [0usize, 1, 65, 4 * 1024 * 1024, usize::MAX] {
+            let mut acc = BatchByteCap::new(cap);
+            assert_eq!(acc.rows(), 0, "cap {cap}: fresh accumulator holds rows");
+            assert_eq!(
+                acc.accumulated(),
+                0,
+                "cap {cap}: fresh accumulator holds bytes"
+            );
+            // The one-row floor: an EMPTY buffer accepts every width, including
+            // the fail-closed `usize::MAX` sentinel and a width far over the
+            // cap. Asking to flush here would loop without progress.
+            assert_eq!(
+                acc.cut_before(width),
+                ShouldFlush::No,
+                "cap {cap}, width {width}: asked to flush an EMPTY buffer"
+            );
+            acc.accumulate(width);
+            assert_eq!(acc.rows(), 1, "cap {cap}, width {width}: row not counted");
+            assert_eq!(
+                acc.accumulated(),
+                width,
+                "cap {cap}, width {width}: width wrapped"
+            );
+
+            acc.reset();
+            assert_eq!(acc.rows(), 0, "cap {cap}: reset left rows behind");
+            assert_eq!(acc.accumulated(), 0, "cap {cap}: reset left bytes behind");
+        }
+
+        // With one row already buffered, a second row is admitted only while the
+        // running total would stay within the cap — so caps of 0 and 1 cut after
+        // every non-degenerate row instead of hanging.
         let mut acc = BatchByteCap::new(cap);
-        assert_eq!(acc.rows(), 0, "cap {cap}: fresh accumulator holds rows");
+        acc.accumulate(1);
         assert_eq!(
-            acc.accumulated(),
-            0,
-            "cap {cap}: fresh accumulator holds bytes"
-        );
-
-        // Even the fail-closed saturating width only trips AFTER the row has
-        // been counted, so the flush it asks for always has a row to carry.
-        assert_eq!(acc.push_width(usize::MAX), ShouldFlush::Yes, "cap {cap}");
-        assert_eq!(acc.rows(), 1, "cap {cap}: flushed without counting the row");
-        assert_eq!(acc.accumulated(), usize::MAX, "cap {cap}: width wrapped");
-
-        acc.reset();
-        assert_eq!(acc.rows(), 0, "cap {cap}: reset left rows behind");
-
-        // A zero-width row is still a row: a `0` cap cuts after it rather than
-        // asking for an empty flush.
-        assert_eq!(
-            acc.push_width(0),
-            if cap == 0 {
-                ShouldFlush::Yes
-            } else {
+            acc.cut_before(1),
+            if cap >= 2 {
                 ShouldFlush::No
+            } else {
+                ShouldFlush::Yes
             },
-            "cap {cap}: wrong decision for a zero-width row"
+            "cap {cap}: wrong decision for the second row"
         );
-        assert_eq!(acc.rows(), 1, "cap {cap}");
     }
 }
 
@@ -576,7 +719,11 @@ fn without_the_byte_cap_the_wide_scan_is_one_oversized_row_cut_batch() {
              above the cap {WIDE_CAP} — the byte-cut tests would be vacuous"
         );
         // And it breaks the capacity tolerance the capped run satisfies.
-        let bound = worst_case_batch_capacity_bytes(WIDE_CAP, schema.columns.len());
+        let bound = worst_case_batch_capacity_bytes(
+            WIDE_CAP,
+            schema.columns.len(),
+            per_row_payload_bound(WIDE_PAYLOAD),
+        );
         assert!(
             batches.iter().any(|b| b.get_array_memory_size() > bound),
             "pre-change control: the uncapped batch already fits the tolerance"

--- a/cqlite-flight/src/batch_bytes_tests.rs
+++ b/cqlite-flight/src/batch_bytes_tests.rs
@@ -378,22 +378,40 @@ fn zero_and_one_byte_caps_degrade_to_one_row_per_batch() {
     }
 }
 
-/// The accumulator itself never reports a flush with an empty buffer, for any
-/// cap — the push-then-test invariant that makes the one-row floor total.
+/// The accumulator never reports a flush with an empty buffer, for any cap —
+/// the push-then-test invariant that makes the one-row floor total.
 #[test]
-fn accumulator_never_flushes_an_empty_buffer() {
+fn accumulator_only_flushes_with_at_least_one_row_counted() {
     for cap in [0usize, 1, 64, DEFAULT_MAX_BATCH_BYTES, usize::MAX] {
         let mut acc = BatchByteCap::new(cap);
-        // A fresh accumulator has flushed nothing.
-        assert_eq!(acc.accumulated(), 0);
-        // Even a saturating width only trips AFTER the row is counted.
-        let decision = acc.push_width(usize::MAX);
-        if cap == usize::MAX {
-            assert_eq!(decision, ShouldFlush::Yes, "cap {cap}");
-        } else {
-            assert_eq!(decision, ShouldFlush::Yes, "cap {cap}");
-        }
-        assert_eq!(acc.accumulated(), usize::MAX, "cap {cap} wrapped");
+        assert_eq!(acc.rows(), 0, "cap {cap}: fresh accumulator holds rows");
+        assert_eq!(
+            acc.accumulated(),
+            0,
+            "cap {cap}: fresh accumulator holds bytes"
+        );
+
+        // Even the fail-closed saturating width only trips AFTER the row has
+        // been counted, so the flush it asks for always has a row to carry.
+        assert_eq!(acc.push_width(usize::MAX), ShouldFlush::Yes, "cap {cap}");
+        assert_eq!(acc.rows(), 1, "cap {cap}: flushed without counting the row");
+        assert_eq!(acc.accumulated(), usize::MAX, "cap {cap}: width wrapped");
+
+        acc.reset();
+        assert_eq!(acc.rows(), 0, "cap {cap}: reset left rows behind");
+
+        // A zero-width row is still a row: a `0` cap cuts after it rather than
+        // asking for an empty flush.
+        assert_eq!(
+            acc.push_width(0),
+            if cap == 0 {
+                ShouldFlush::Yes
+            } else {
+                ShouldFlush::No
+            },
+            "cap {cap}: wrong decision for a zero-width row"
+        );
+        assert_eq!(acc.rows(), 1, "cap {cap}");
     }
 }
 

--- a/cqlite-flight/src/batch_bytes_tests.rs
+++ b/cqlite-flight/src/batch_bytes_tests.rs
@@ -1,0 +1,645 @@
+//! Tests for the dual row-cap / byte-cap Arrow egress batch boundary
+//! (issue #2825).
+//!
+//! Loaded via `#[path]` from `batch_bytes.rs` (the `admission.rs` /
+//! `admission_tests.rs` precedent) so the production module stays under the
+//! campsite file-size threshold, and so these tests never land in the
+//! already-over-threshold `streaming_tests.rs` (epic #1116/#1135).
+//!
+//! Every wide-row test runs against the **synthetic**
+//! [`crate::wide_row_fixture`] shapes built in process, never the fetched
+//! `test_wide_rows` corpus — a dataset-backed byte-cap test would pass vacuously
+//! on an empty dataset. Each one asserts non-vacuity (rows > 0 AND batches > 1)
+//! BEFORE any byte assertion.
+//!
+//! Assertions here compare byte totals, row counts and batch counts only — never
+//! elapsed wall-clock (#2642 / `roborev-lints`). The throughput comparison lives
+//! in the `#[ignore]`d `perf-gate-allow` test at the bottom.
+
+use std::path::PathBuf;
+
+use arrow::record_batch::RecordBatch;
+use cqlite_core::export::arrow_payload_bytes;
+use cqlite_core::schema::TableSchema;
+
+use super::*;
+use crate::filter::ScanSpec;
+use crate::producer::{DirSource, MergeProducer};
+use crate::testutil::build_sstables;
+use crate::wide_row_fixture as fx;
+
+// ---------------------------------------------------------------------------
+// Fixture plumbing
+// ---------------------------------------------------------------------------
+
+/// Flush `n_rows` wide rows (each carrying a `payload_len`-byte blob) into a real
+/// SSTable and return the temp dir (keep it alive), the table dir and the schema.
+fn wide_fixture(n_rows: i32, payload_len: usize) -> (tempfile::TempDir, PathBuf, TableSchema) {
+    let schema = fx::wide_row_schema();
+    let (temp, data_dir, table_dir) =
+        build_sstables(&schema, vec![fx::wide_row_mutations(n_rows, payload_len)]);
+    let _ = data_dir;
+    (temp, table_dir, schema)
+}
+
+/// Flush `n_rows` narrow rows into a real SSTable.
+fn narrow_fixture(n_rows: i32) -> (tempfile::TempDir, PathBuf, TableSchema) {
+    let schema = fx::narrow_row_schema();
+    let (temp, data_dir, table_dir) =
+        build_sstables(&schema, vec![fx::narrow_row_mutations(n_rows)]);
+    let _ = data_dir;
+    (temp, table_dir, schema)
+}
+
+fn producer(schema: TableSchema, batch_size: usize, cap: usize) -> MergeProducer {
+    MergeProducer::with_spec(schema, batch_size, ScanSpec::default())
+        .expect("producer")
+        .with_max_batch_bytes(cap)
+}
+
+/// Run the `producer.rs` buffered merge path (`drive_merge`) end to end.
+fn scan_merge(producer: &MergeProducer, dir: &std::path::Path) -> Vec<RecordBatch> {
+    producer
+        .produce(&DirSource::new(dir))
+        .expect("merge full scan")
+}
+
+/// Run the `producer_stream.rs` row-granular path (`drive_merge_streaming`) end
+/// to end over the same fixture, through the real `produce_streaming` seam the
+/// `do_get` response stream uses.
+fn scan_streaming(producer: &MergeProducer, dir: &std::path::Path) -> Vec<RecordBatch> {
+    let source = DirSource::new(dir);
+    let paths = producer.resolve_paths(&source).expect("resolve paths");
+    producer
+        .produce_streaming_to_vec(paths, &crate::cancel::CancelFlag::new())
+        .expect("streaming full scan")
+}
+
+fn total_rows(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+/// Non-vacuity gate: real rows AND a real boundary decision. Runs BEFORE any byte
+/// assertion so a fixture that silently produced nothing fails here, loudly.
+fn assert_non_vacuous(batches: &[RecordBatch], expected_rows: usize, what: &str) {
+    assert_eq!(
+        total_rows(batches),
+        expected_rows,
+        "{what}: expected {expected_rows} rows, got {} — vacuous fixture",
+        total_rows(batches)
+    );
+    assert!(
+        batches.len() > 1,
+        "{what}: only {} batch(es) emitted — the fixture is degenerate and the \
+         byte assertions below would be vacuous",
+        batches.len()
+    );
+}
+
+/// Rows in every batch but the last.
+fn non_final_row_counts(batches: &[RecordBatch]) -> Vec<usize> {
+    batches
+        .iter()
+        .take(batches.len().saturating_sub(1))
+        .map(|b| b.num_rows())
+        .collect()
+}
+
+// Shared fixture sizing. 220 rows × 4 KiB payload = ~900 KiB of blob, so a
+// 64 KiB cap yields ~15 batches while `batch_size` stays far out of reach.
+const WIDE_ROWS: i32 = 220;
+const WIDE_PAYLOAD: usize = 4096;
+const WIDE_CAP: usize = 64 * 1024;
+const BIG_BATCH_SIZE: usize = 8192;
+
+// ---------------------------------------------------------------------------
+// Requirement 1: whichever cap trips first finishes the batch
+// ---------------------------------------------------------------------------
+
+/// Wide rows finish batches on the BYTE-cap: every non-final batch has strictly
+/// fewer than `batch_size` rows, and more than one batch is emitted.
+///
+/// FAILS on pre-change `main`: with no byte-cap the whole 220-row scan is a
+/// single row-cut batch, so `batches.len() > 1` fails at the non-vacuity gate.
+#[test]
+fn wide_rows_finish_batches_on_the_byte_cap() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    let p = producer(schema, BIG_BATCH_SIZE, WIDE_CAP);
+    let batches = scan_merge(&p, &dir);
+    assert_non_vacuous(&batches, WIDE_ROWS as usize, "wide byte-cut");
+    for (i, rows) in non_final_row_counts(&batches).iter().enumerate() {
+        assert!(
+            *rows < BIG_BATCH_SIZE,
+            "batch {i} has {rows} rows — the ROW-cap cut it, not the byte-cap"
+        );
+        assert!(*rows > 0, "batch {i} is empty");
+    }
+}
+
+/// The `producer_stream.rs` path honours the same boundary rule over the same
+/// fixture — neither egress path is left unbounded.
+///
+/// FAILS on pre-change `main` for the same reason.
+#[test]
+fn streaming_path_finishes_batches_on_the_byte_cap() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    let p = producer(schema, BIG_BATCH_SIZE, WIDE_CAP);
+    let batches = scan_streaming(&p, &dir);
+    assert_non_vacuous(&batches, WIDE_ROWS as usize, "streaming byte-cut");
+    for (i, rows) in non_final_row_counts(&batches).iter().enumerate() {
+        assert!(
+            *rows < BIG_BATCH_SIZE,
+            "streaming batch {i} has {rows} rows — row-cut, not byte-cut"
+        );
+    }
+}
+
+/// Both paths agree on the boundary: the same fixture under the same cap yields
+/// the same per-batch row counts through `drive_merge` and
+/// `drive_merge_streaming`. A cap wired into only one path would diverge here.
+#[test]
+fn both_egress_paths_produce_the_same_byte_cut_boundaries() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    let p = producer(schema, BIG_BATCH_SIZE, WIDE_CAP);
+    let merged: Vec<usize> = scan_merge(&p, &dir).iter().map(|b| b.num_rows()).collect();
+    let streamed: Vec<usize> = scan_streaming(&p, &dir)
+        .iter()
+        .map(|b| b.num_rows())
+        .collect();
+    assert!(merged.len() > 1, "degenerate: {} batch(es)", merged.len());
+    assert_eq!(
+        merged, streamed,
+        "the two egress paths cut batches differently"
+    );
+}
+
+/// Narrow rows still finish on the ROW-cap under the default 4 MiB cap: every
+/// non-final batch has EXACTLY `batch_size` rows, and the boundaries are
+/// identical to a run with the byte-cap effectively disabled.
+#[test]
+fn narrow_rows_still_finish_batches_on_the_row_cap() {
+    const BATCH: usize = 64;
+    const ROWS: i32 = 4 * BATCH as i32; // well past the "2 x batch_size" floor
+    let (_temp, dir, schema) = narrow_fixture(ROWS);
+
+    let capped = producer(schema.clone(), BATCH, DEFAULT_MAX_BATCH_BYTES);
+    let capped_batches = scan_merge(&capped, &dir);
+    assert_non_vacuous(&capped_batches, ROWS as usize, "narrow default cap");
+    for (i, rows) in non_final_row_counts(&capped_batches).iter().enumerate() {
+        assert_eq!(
+            *rows, BATCH,
+            "batch {i} has {rows} rows — the byte-cap tripped on a NARROW shape"
+        );
+    }
+
+    // Byte-cap effectively disabled: identical boundaries prove no behaviour
+    // change on the narrow path.
+    let unbounded = producer(schema, BATCH, usize::MAX);
+    let unbounded_rows: Vec<usize> = scan_merge(&unbounded, &dir)
+        .iter()
+        .map(|b| b.num_rows())
+        .collect();
+    let capped_rows: Vec<usize> = capped_batches.iter().map(|b| b.num_rows()).collect();
+    assert_eq!(
+        capped_rows, unbounded_rows,
+        "the default cap changed narrow-path batch boundaries"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 2: the decision precedes materialization
+// ---------------------------------------------------------------------------
+
+/// No oversized batch is ever allocated: every emitted batch's realized payload
+/// respects the cap (up to the last row that crossed it), so the wide batch that
+/// the row-cap alone would have built was never constructed at all.
+#[test]
+fn no_oversized_batch_is_ever_allocated() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    let p = producer(schema, BIG_BATCH_SIZE, WIDE_CAP);
+    let batches = scan_merge(&p, &dir);
+    assert_non_vacuous(&batches, WIDE_ROWS as usize, "no oversized batch");
+    // The row-capped batch this scan would otherwise have produced.
+    let uncapped = scan_merge(
+        &producer(fx::wide_row_schema(), BIG_BATCH_SIZE, usize::MAX),
+        &dir,
+    );
+    let uncapped_payload: usize = uncapped.iter().map(arrow_payload_bytes).sum();
+    assert!(
+        uncapped_payload > WIDE_CAP * 4,
+        "fixture too small to prove anything: uncapped payload {uncapped_payload}"
+    );
+    for (i, b) in batches.iter().enumerate() {
+        let payload = arrow_payload_bytes(b);
+        // A batch is cut on the row that CROSSES the cap, so the last row's
+        // width is the allowed excess. Every row here is the same width.
+        assert!(
+            payload <= WIDE_CAP + per_row_payload_bound(),
+            "batch {i} realized {payload} payload bytes, above the cap {WIDE_CAP}"
+        );
+    }
+}
+
+/// Upper bound on one wide fixture row's realized payload contribution — the
+/// allowed excess of the row that crosses the cap.
+fn per_row_payload_bound() -> usize {
+    WIDE_PAYLOAD + 256
+}
+
+/// The running estimate is per-row and reset on flush: pushing N rows then
+/// resetting leaves the accumulator at zero, and each push advances it by that
+/// row's width only.
+#[test]
+fn accumulator_is_incremental_and_reset_on_flush() {
+    let mut cap = BatchByteCap::new(1000);
+    assert_eq!(cap.accumulated(), 0);
+    assert_eq!(cap.push_width(300), ShouldFlush::No);
+    assert_eq!(cap.accumulated(), 300);
+    assert_eq!(cap.push_width(300), ShouldFlush::No);
+    assert_eq!(cap.accumulated(), 600);
+    assert_eq!(cap.push_width(500), ShouldFlush::Yes);
+    assert_eq!(cap.accumulated(), 1100);
+    cap.reset();
+    assert_eq!(cap.accumulated(), 0);
+    assert_eq!(cap.push_width(1), ShouldFlush::No);
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 4: the payload / capacity tolerance, in named constants
+// ---------------------------------------------------------------------------
+
+/// Every emitted batch stays inside the PUBLISHED capacity tolerance
+/// `BATCH_BYTES_CAPACITY_FACTOR * cap + BATCH_BYTES_PER_COLUMN_SLACK * columns`,
+/// and — separately and tightly — every multi-row batch's PAYLOAD bytes are at
+/// or below the cap. Both bounds are expressed through the named constants, not
+/// inline literals.
+#[test]
+fn emitted_batches_respect_the_payload_and_capacity_bounds() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    let n_columns = schema.columns.len();
+    let p = producer(schema, BIG_BATCH_SIZE, WIDE_CAP);
+    let batches = scan_merge(&p, &dir);
+    assert_non_vacuous(&batches, WIDE_ROWS as usize, "capacity tolerance");
+
+    let capacity_bound = worst_case_batch_capacity_bytes(WIDE_CAP, n_columns);
+    for (i, b) in batches.iter().enumerate() {
+        assert!(
+            b.get_array_memory_size() <= capacity_bound,
+            "batch {i}: get_array_memory_size {} exceeds the published tolerance {capacity_bound}",
+            b.get_array_memory_size()
+        );
+        // Tight payload bound, in the cap's own currency: a batch of two or more
+        // rows must sit at or below the cap once its final row is excluded — the
+        // cut happens ON the crossing row.
+        if b.num_rows() >= 2 {
+            let payload = arrow_payload_bytes(b);
+            assert!(
+                payload <= WIDE_CAP + per_row_payload_bound(),
+                "batch {i}: payload {payload} above cap {WIDE_CAP}"
+            );
+        }
+    }
+}
+
+/// The published capacity conversion is derivable from the named constants
+/// alone, with no hidden fudge factor.
+#[test]
+fn worst_case_capacity_follows_from_the_named_constants() {
+    assert_eq!(
+        worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 3),
+        DEFAULT_MAX_BATCH_BYTES * BATCH_BYTES_CAPACITY_FACTOR + BATCH_BYTES_PER_COLUMN_SLACK * 3
+    );
+    // Saturating: an unbounded cap reports the ceiling, never a wrapped value.
+    assert_eq!(worst_case_batch_capacity_bytes(usize::MAX, 8), usize::MAX);
+    // The #2821 composition: 6 MiB ceiling + one worst-case 4 MiB-payload batch
+    // stays inside B4's 16Mi at concurrency 1.
+    let one_batch = worst_case_batch_capacity_bytes(DEFAULT_MAX_BATCH_BYTES, 16);
+    assert!(
+        6 * 1024 * 1024 + one_batch <= 16 * 1024 * 1024,
+        "6 MiB ceiling + one max batch ({one_batch}) breaks the B4 budget"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 5: the one-row floor
+// ---------------------------------------------------------------------------
+
+/// A single row wider than the WHOLE cap is still delivered, as a one-row batch.
+///
+/// FAILS on pre-change `main`: a "flush before the cap is exceeded" boundary
+/// would either drop the row or spin on an empty buffer; without any cap the
+/// batch count is 1 for all N, so the per-batch assertion below is what pins the
+/// behaviour.
+#[test]
+fn rows_wider_than_the_cap_are_emitted_one_per_batch() {
+    const N: i32 = 6;
+    let (_temp, dir, schema) = wide_fixture(N, 8192);
+    // Cap far below one row's width.
+    let p = producer(schema, BIG_BATCH_SIZE, 64);
+    let batches = scan_merge(&p, &dir);
+    assert_eq!(total_rows(&batches), N as usize, "a row was dropped");
+    assert_eq!(
+        batches.len(),
+        N as usize,
+        "expected exactly one batch per over-cap row"
+    );
+    for (i, b) in batches.iter().enumerate() {
+        assert_eq!(b.num_rows(), 1, "batch {i} is not a one-row batch");
+    }
+}
+
+/// Caps of `0` and `1` degrade to one row per batch rather than hanging or
+/// dropping rows — on BOTH egress paths.
+#[test]
+fn zero_and_one_byte_caps_degrade_to_one_row_per_batch() {
+    const N: i32 = 12;
+    let (_temp, dir, schema) = narrow_fixture(N);
+    for cap in [0usize, 1] {
+        let p = producer(schema.clone(), BIG_BATCH_SIZE, cap);
+        for (label, batches) in [
+            ("merge", scan_merge(&p, &dir)),
+            ("streaming", scan_streaming(&p, &dir)),
+        ] {
+            assert_eq!(
+                total_rows(&batches),
+                N as usize,
+                "cap {cap} on the {label} path dropped rows"
+            );
+            assert_eq!(
+                batches.len(),
+                N as usize,
+                "cap {cap} on the {label} path did not yield one row per batch"
+            );
+            assert!(
+                batches.iter().all(|b| b.num_rows() == 1),
+                "cap {cap} on the {label} path emitted a non-single-row batch"
+            );
+        }
+    }
+}
+
+/// The accumulator itself never reports a flush with an empty buffer, for any
+/// cap — the push-then-test invariant that makes the one-row floor total.
+#[test]
+fn accumulator_never_flushes_an_empty_buffer() {
+    for cap in [0usize, 1, 64, DEFAULT_MAX_BATCH_BYTES, usize::MAX] {
+        let mut acc = BatchByteCap::new(cap);
+        // A fresh accumulator has flushed nothing.
+        assert_eq!(acc.accumulated(), 0);
+        // Even a saturating width only trips AFTER the row is counted.
+        let decision = acc.push_width(usize::MAX);
+        if cap == usize::MAX {
+            assert_eq!(decision, ShouldFlush::Yes, "cap {cap}");
+        } else {
+            assert_eq!(decision, ShouldFlush::Yes, "cap {cap}");
+        }
+        assert_eq!(acc.accumulated(), usize::MAX, "cap {cap} wrapped");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 6: the knob is functional, not decorative
+// ---------------------------------------------------------------------------
+
+/// Two distinct configured caps produce correspondingly different boundaries:
+/// the smaller cap yields strictly more batches with strictly fewer rows each.
+///
+/// FAILS on pre-change `main`: there is no cap, so both runs produce identical
+/// (row-cut) boundaries.
+#[test]
+fn two_distinct_caps_produce_different_batch_boundaries() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    let small = scan_merge(&producer(schema.clone(), BIG_BATCH_SIZE, 32 * 1024), &dir);
+    let large = scan_merge(&producer(schema, BIG_BATCH_SIZE, 256 * 1024), &dir);
+    assert_non_vacuous(&small, WIDE_ROWS as usize, "small cap");
+    assert_non_vacuous(&large, WIDE_ROWS as usize, "large cap");
+    assert!(
+        small.len() > large.len(),
+        "smaller cap produced {} batches, not more than the larger cap's {}",
+        small.len(),
+        large.len()
+    );
+    let max_small = small.iter().map(|b| b.num_rows()).max().unwrap_or(0);
+    let max_large = large.iter().map(|b| b.num_rows()).max().unwrap_or(0);
+    assert!(
+        max_small < max_large,
+        "smaller cap's widest batch ({max_small} rows) is not smaller than the \
+         larger cap's ({max_large} rows)"
+    );
+}
+
+/// The cap is ON by default on the plain constructors — a library embedder that
+/// supplies nothing still gets a bounded batch (design §f).
+#[test]
+fn the_default_cap_is_in_force_on_plain_constructors() {
+    let p = MergeProducer::new(fx::wide_row_schema(), BIG_BATCH_SIZE).expect("producer");
+    assert_eq!(p.max_batch_bytes(), DEFAULT_MAX_BATCH_BYTES);
+    let p =
+        MergeProducer::with_spec(fx::wide_row_schema(), 1, ScanSpec::default()).expect("producer");
+    assert_eq!(p.max_batch_bytes(), DEFAULT_MAX_BATCH_BYTES);
+    let svc = crate::service::CqliteFlightService::new("/nonexistent", BIG_BATCH_SIZE);
+    assert_eq!(svc.max_batch_bytes(), DEFAULT_MAX_BATCH_BYTES);
+    let svc = crate::service::CqliteFlightService::with_admission(
+        "/nonexistent",
+        BIG_BATCH_SIZE,
+        crate::admission::Admission::unconstrained(),
+    );
+    assert_eq!(svc.max_batch_bytes(), DEFAULT_MAX_BATCH_BYTES);
+}
+
+/// A default-constructed embedder scan over the wide fixture is genuinely
+/// bounded: with a cap small enough to bind, the library path cuts batches
+/// without any explicit opt-in beyond the builder.
+#[test]
+fn library_embedder_scan_is_bounded_by_default() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    // The plain constructor, then only the knob's value changed — proving the
+    // mechanism is present before configuration, not installed by it.
+    let p = MergeProducer::new(schema, BIG_BATCH_SIZE).expect("producer");
+    assert_eq!(p.max_batch_bytes(), DEFAULT_MAX_BATCH_BYTES);
+    let bounded = p.with_max_batch_bytes(WIDE_CAP);
+    let batches = scan_merge(&bounded, &dir);
+    assert_non_vacuous(&batches, WIDE_ROWS as usize, "embedder default");
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 7: the cap does not alter result content
+// ---------------------------------------------------------------------------
+
+/// Capped and effectively-unbounded runs concatenate to identical rows, in
+/// identical order, with identical values and an identical Arrow schema — only
+/// the batch boundaries differ.
+#[test]
+fn capped_and_uncapped_runs_concatenate_to_identical_results() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    let capped = scan_merge(&producer(schema.clone(), BIG_BATCH_SIZE, WIDE_CAP), &dir);
+    let uncapped = scan_merge(&producer(schema, BIG_BATCH_SIZE, usize::MAX), &dir);
+    assert_non_vacuous(&capped, WIDE_ROWS as usize, "capped run");
+    assert_eq!(
+        total_rows(&uncapped),
+        WIDE_ROWS as usize,
+        "uncapped run lost rows"
+    );
+    assert!(
+        capped.len() > uncapped.len(),
+        "the cap did not change any boundary — the comparison is vacuous"
+    );
+
+    let capped_schema = capped.first().map(|b| b.schema());
+    let uncapped_schema = uncapped.first().map(|b| b.schema());
+    assert_eq!(capped_schema, uncapped_schema, "Arrow schema differs");
+
+    // Concatenate each side into one batch and compare cell for cell.
+    let cat = |batches: &[RecordBatch]| -> RecordBatch {
+        let schema = batches.first().map(|b| b.schema()).expect("a batch");
+        arrow::compute::concat_batches(&schema, batches).expect("concat")
+    };
+    assert_eq!(cat(&capped), cat(&uncapped), "row content or order differs");
+}
+
+/// The total row count is invariant across a descending series of caps.
+#[test]
+fn lowering_the_cap_does_not_change_the_total_row_count() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    let mut seen_batch_counts = Vec::new();
+    for cap in [usize::MAX, 1024 * 1024, 128 * 1024, 32 * 1024, 4096, 1] {
+        let batches = scan_merge(&producer(schema.clone(), BIG_BATCH_SIZE, cap), &dir);
+        assert_eq!(
+            total_rows(&batches),
+            WIDE_ROWS as usize,
+            "cap {cap} changed the total row count"
+        );
+        seen_batch_counts.push(batches.len());
+    }
+    // Monotone non-decreasing batch counts as the cap descends.
+    for w in seen_batch_counts.windows(2) {
+        assert!(
+            w[1] >= w[0],
+            "batch count went DOWN as the cap shrank: {seen_batch_counts:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 8: the guards are real — the pre-change control
+// ---------------------------------------------------------------------------
+
+/// The pre-change `main` control, in tree and mechanical.
+///
+/// `main` has no byte-cap at all, which is behaviourally exactly this run: the
+/// cap disabled (`usize::MAX`), leaving the row-cap as the sole boundary. This
+/// asserts that under those conditions the wide fixture produces a SINGLE
+/// row-cut batch whose payload is many times the cap — so
+/// [`wide_rows_finish_batches_on_the_byte_cap`],
+/// [`streaming_path_finishes_batches_on_the_byte_cap`],
+/// [`rows_wider_than_the_cap_are_emitted_one_per_batch`],
+/// [`two_distinct_caps_produce_different_batch_boundaries`] and
+/// [`emitted_batches_respect_the_payload_and_capacity_bounds`] all FAIL there.
+/// (Those tests additionally fail to COMPILE against `main`, whose
+/// `MergeProducer` has no `with_max_batch_bytes`; this control is the stronger,
+/// behavioural form of the same evidence.)
+#[test]
+fn without_the_byte_cap_the_wide_scan_is_one_oversized_row_cut_batch() {
+    let (_temp, dir, schema) = wide_fixture(WIDE_ROWS, WIDE_PAYLOAD);
+    for batches in [
+        scan_merge(&producer(schema.clone(), BIG_BATCH_SIZE, usize::MAX), &dir),
+        scan_streaming(&producer(schema.clone(), BIG_BATCH_SIZE, usize::MAX), &dir),
+    ] {
+        assert_eq!(total_rows(&batches), WIDE_ROWS as usize);
+        assert_eq!(
+            batches.len(),
+            1,
+            "pre-change control: the row-cap alone must yield ONE batch"
+        );
+        let payload: usize = batches.iter().map(arrow_payload_bytes).sum();
+        assert!(
+            payload > WIDE_CAP * 8,
+            "pre-change control: {payload} payload bytes is not meaningfully \
+             above the cap {WIDE_CAP} — the byte-cut tests would be vacuous"
+        );
+        // And it breaks the capacity tolerance the capped run satisfies.
+        let bound = worst_case_batch_capacity_bytes(WIDE_CAP, schema.columns.len());
+        assert!(
+            batches.iter().any(|b| b.get_array_memory_size() > bound),
+            "pre-change control: the uncapped batch already fits the tolerance"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The aggregate route (task 4.3): no route escapes the cap
+// ---------------------------------------------------------------------------
+
+/// `split_rows_into_batches` applies the same dual boundary to an
+/// already-materialized row slice: never an empty group, never a lost row, and a
+/// single over-cap row becomes a one-row group.
+#[test]
+fn split_rows_into_batches_applies_the_same_dual_boundary() {
+    use cqlite_core::query::{ColumnInfo, QueryRow};
+    use cqlite_core::types::{DataType, Value};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    let columns = vec![ColumnInfo {
+        name: "b".into(),
+        data_type: DataType::Blob,
+        nullable: true,
+        position: 0,
+        table_name: None,
+        cql_type: Some(cqlite_core::schema::CqlType::Blob),
+    }];
+    let rows: Vec<QueryRow> = (0..10)
+        .map(|_| {
+            let mut values: HashMap<Arc<str>, Value> = HashMap::new();
+            values.insert(Arc::from("b"), Value::Blob(vec![7u8; 1000].into()));
+            QueryRow::with_interned_values(cqlite_core::RowKey::new(Vec::new()), values)
+        })
+        .collect();
+
+    // Byte-cut: ~3 rows per group at a 3 KiB cap.
+    let groups = split_rows_into_batches(&columns, &rows, 8192, 3000);
+    assert!(groups.len() > 1, "no byte cut: {} group(s)", groups.len());
+    assert!(groups.iter().all(|g| !g.is_empty()), "an empty group");
+    assert_eq!(groups.iter().map(|g| g.len()).sum::<usize>(), rows.len());
+
+    // Row-cut still applies when it binds first.
+    let groups = split_rows_into_batches(&columns, &rows, 2, usize::MAX);
+    assert_eq!(groups.len(), 5);
+    assert!(groups.iter().all(|g| g.len() == 2));
+
+    // One over-cap row per group; empty input yields no groups.
+    let groups = split_rows_into_batches(&columns, &rows, 8192, 1);
+    assert_eq!(groups.len(), rows.len());
+    assert!(split_rows_into_batches(&columns, &[], 8192, 1).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 9: throughput evidence lives OUTSIDE the correctness path
+// ---------------------------------------------------------------------------
+
+/// perf-gate-allow — the ~1.0–1.1x throughput expectation from issue #2825.
+///
+/// `#[ignore]`d and excluded from the gate: this is the ONLY test in the byte-cap
+/// suite permitted to read a clock, and it is deliberately outside the
+/// correctness path (#2642 / `roborev-lints`). Run explicitly with
+/// `cargo test -p cqlite-flight byte_cap_throughput -- --ignored --nocapture`.
+#[test]
+#[ignore = "perf-gate-allow: throughput comparison, not a correctness assertion"]
+fn byte_cap_throughput_is_within_the_expected_band() {
+    const ROWS: i32 = 4000;
+    let (_temp, dir, schema) = narrow_fixture(ROWS);
+    let run = |cap: usize| {
+        let p = producer(schema.clone(), BIG_BATCH_SIZE, cap);
+        let start = std::time::Instant::now();
+        let batches = scan_merge(&p, &dir);
+        let elapsed = start.elapsed();
+        assert_eq!(total_rows(&batches), ROWS as usize);
+        elapsed
+    };
+    let uncapped = run(usize::MAX);
+    let capped = run(DEFAULT_MAX_BATCH_BYTES);
+    println!(
+        "narrow-path scan: uncapped {uncapped:?}, capped {capped:?}, ratio {:.3}",
+        capped.as_secs_f64() / uncapped.as_secs_f64().max(f64::MIN_POSITIVE)
+    );
+}

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -10,6 +10,10 @@
 
 pub mod admission;
 pub mod agg;
+// Byte-bounded Arrow egress batches (issue #2825): the dual row-cap / byte-cap
+// batch boundary shared by BOTH producer drive loops, plus the published
+// payload-to-capacity conversion constants issue #2821 composes on.
+pub mod batch_bytes;
 pub mod cancel;
 pub mod filter;
 pub mod obs;
@@ -40,6 +44,15 @@ pub mod warm;
 #[cfg(feature = "test-util")]
 #[doc(hidden)]
 pub mod test_fixtures;
+
+// Deterministic, self-contained synthetic wide/narrow row shapes for the
+// byte-cap suite (issue #2825). Gated behind `test-util` for the same reason as
+// `test_fixtures`: the shapes must reach BOTH the in-crate unit tests and a
+// separate integration-test binary, which a `pub(crate)` module cannot do, but
+// they must never compile into the production library/binary.
+#[cfg(feature = "test-util")]
+#[doc(hidden)]
+pub mod wide_row_fixture;
 
 pub mod ticket;
 

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -12,6 +12,7 @@ use cqlite_flight::admission::{
     Admission, AdmissionConfig, WaitBudget, DEFAULT_MAX_CONCURRENT_SCANS, DEFAULT_WAIT_TIMEOUT_MS,
     ENV_MAX_CONCURRENT_SCANS, ENV_WAIT_TIMEOUT_MS,
 };
+use cqlite_flight::batch_bytes::{DEFAULT_MAX_BATCH_BYTES, ENV_MAX_BATCH_BYTES};
 use cqlite_flight::service::CqliteFlightService;
 use cqlite_flight::shutdown::shutdown_signal;
 use std::time::Duration;
@@ -48,6 +49,20 @@ struct Args {
     /// budget are absorbed transparently with no client-visible error.
     #[arg(long, env = ENV_WAIT_TIMEOUT_MS, default_value_t = DEFAULT_WAIT_TIMEOUT_MS)]
     admission_wait_timeout_ms: u64,
+
+    /// Maximum Arrow PAYLOAD bytes per record batch (issue #2825, T4). A batch is
+    /// finished on whichever of `--batch-size` or this cap trips FIRST, so a wide
+    /// (blob/text) schema can no longer produce an unbounded
+    /// `batch_size x row_width` batch. Denominated in payload bytes (the sum of
+    /// Arrow buffer lengths), NOT `get_array_memory_size()`, which reports buffer
+    /// capacity and runs up to `BATCH_BYTES_CAPACITY_FACTOR` (2x) higher; a
+    /// consumer budgeting resident memory uses
+    /// `cqlite_flight::batch_bytes::worst_case_batch_capacity_bytes`. The 4 MiB
+    /// default leaves the row-cap binding on every narrow shape, so narrow-path
+    /// batch boundaries are unchanged. A single row wider than the cap is still
+    /// delivered, as a one-row batch; `0` and `1` degrade to one row per batch.
+    #[arg(long, env = ENV_MAX_BATCH_BYTES, default_value_t = DEFAULT_MAX_BATCH_BYTES)]
+    max_batch_bytes: usize,
 }
 
 #[tokio::main]
@@ -94,7 +109,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Keep a copy of the data-dir for the saturation sampler's readdir-only
     // table-discovery walk (issue #2684) before the service takes ownership.
     let sampler_data_dir = args.data_dir.clone();
-    let service = CqliteFlightService::with_admission(args.data_dir, args.batch_size, admission);
+    let service = CqliteFlightService::with_admission(args.data_dir, args.batch_size, admission)
+        // Issue #2825: the byte-cap half of the dual batch boundary.
+        .with_max_batch_bytes(args.max_batch_bytes);
 
     // A coarse tonic transport backstop, generously ABOVE the admission ceiling:
     // it guards the HTTP/2 accept loop / stream table from a client opening far
@@ -109,6 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!(
         %listen,
         batch_size = args.batch_size,
+        max_batch_bytes = args.max_batch_bytes,
         max_concurrent_scans = admission_limit,
         admission_wait_timeout_ms = args.admission_wait_timeout_ms,
         max_concurrent_streams,

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -25,7 +25,9 @@ use std::path::{Path, PathBuf};
 use arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
 
-use cqlite_core::export::{build_arrow_schema, rows_to_record_batch, ArrowConvertError};
+use cqlite_core::export::{
+    build_arrow_schema, estimate_arrow_row_bytes, rows_to_record_batch, ArrowConvertError,
+};
 use cqlite_core::query::{
     build_row_from_scan_cached, AccessPath, ColumnInfo, PartitionKeyCache, QueryRow,
 };
@@ -36,6 +38,7 @@ use cqlite_core::types::{DataType, RowCells, ScanRow};
 use cqlite_core::RowKey;
 
 use crate::agg::{AggError, AggPlan};
+use crate::batch_bytes::{BatchByteCap, DEFAULT_MAX_BATCH_BYTES};
 use crate::cancel::CancelFlag;
 use crate::filter::ScanSpec;
 use crate::scan_progress::{ScanProgress, ScanProgressMeter};
@@ -326,6 +329,15 @@ pub struct MergeProducer {
     pub(crate) schema: TableSchema,
     pub(crate) columns: Vec<ColumnInfo>,
     pub(crate) batch_size: usize,
+    /// Per-batch Arrow PAYLOAD byte ceiling (issue #2825). A batch is finished on
+    /// whichever of `batch_size` or this cap trips FIRST, so a wide-row schema can
+    /// no longer produce an unbounded `batch_size × row_width` batch. Defaults to
+    /// [`DEFAULT_MAX_BATCH_BYTES`] on EVERY construction path — see
+    /// [`MergeProducer::with_max_batch_bytes`] for why this diverges from the
+    /// opt-in `Admission::unconstrained()` precedent. Read by BOTH drive loops
+    /// (`drive_merge` here and `drive_merge_streaming` in `producer_stream`), so
+    /// `pub(crate)`.
+    pub(crate) max_batch_bytes: usize,
     pub(crate) spec: ScanSpec,
     /// Aggregation pushdown plan (issue #841). When `Some`, the producer emits
     /// PARTIAL aggregate rows under [`Self::partial_columns`] instead of full
@@ -420,6 +432,9 @@ impl MergeProducer {
             schema,
             columns,
             batch_size: batch_size.max(1),
+            // Issue #2825: on by DEFAULT on every construction path — an
+            // unbounded egress batch is a memory hazard, not a policy choice.
+            max_batch_bytes: DEFAULT_MAX_BATCH_BYTES,
             spec,
             agg: None,
             partial_columns: None,
@@ -427,6 +442,31 @@ impl MergeProducer {
             // Issue #2374/#2789: capture the read-time reconciliation clock once.
             now_secs: Self::reconciliation_now_secs(),
         })
+    }
+
+    /// Override the per-batch Arrow **payload** byte cap (issue #2825).
+    ///
+    /// The cap is already ON at [`DEFAULT_MAX_BATCH_BYTES`] from
+    /// [`Self::new`]/[`Self::with_spec`]; this is the wiring point for the
+    /// `--max-batch-bytes` / `CQLITE_MAX_BATCH_BYTES` operator knob and for tests.
+    ///
+    /// **Deliberate divergence from the `--max-concurrent-scans` precedent.**
+    /// `CqliteFlightService::new` leaves admission `unconstrained()` so a library
+    /// embedder keeps pre-#2420 behaviour; the byte-cap instead defaults ON
+    /// everywhere, because an unbounded batch is a memory-safety hazard rather
+    /// than a policy choice, the 4 MiB default is a no-op on every narrow shape,
+    /// and issue #2821 could not state a bound for the library path otherwise.
+    /// An embedder that genuinely wants the old behaviour passes `usize::MAX`.
+    ///
+    /// Consumes and returns `self` for chaining.
+    pub fn with_max_batch_bytes(mut self, max_batch_bytes: usize) -> Self {
+        self.max_batch_bytes = max_batch_bytes;
+        self
+    }
+
+    /// The per-batch Arrow payload byte cap in force (issue #2825).
+    pub fn max_batch_bytes(&self) -> usize {
+        self.max_batch_bytes
     }
 
     /// Attach the authoritative UDT registry (issue #2349), resolving every
@@ -887,6 +927,10 @@ impl MergeProducer {
         let mut meter = ScanProgressMeter::new(progress, access_path);
         let mut buffer: Vec<QueryRow> = Vec::with_capacity(self.batch_size);
         let mut emitted: u64 = 0;
+        // Issue #2825: running payload-byte estimate for the rows currently
+        // buffered. Advanced by exactly one row's estimate per push and reset on
+        // every flush — the buffer is never re-measured.
+        let mut byte_cap = BatchByteCap::new(self.max_batch_bytes);
         // Issue #1817: one partition-key decode cache for the whole merge; each
         // partition's rows arrive consecutively, so its key decodes once.
         let mut pk_cache = PartitionKeyCache::default();
@@ -946,10 +990,17 @@ impl MergeProducer {
                         continue;
                     }
                 }
+                // Dual row-cap / byte-cap boundary (issue #2825): estimate the
+                // row's Arrow payload width BEFORE it is moved into the buffer,
+                // then account for it. `push_width` is push-then-test, so a row
+                // wider than the whole cap still leaves as a one-row batch.
+                let width = estimate_arrow_row_bytes(&self.columns, &row);
                 buffer.push(row);
                 emitted += 1;
-                if buffer.len() >= self.batch_size {
+                let byte_full = byte_cap.push_width(width).is_yes();
+                if buffer.len() >= self.batch_size || byte_full {
                     sink.emit(self.flush_buffer(&mut buffer)?)?;
+                    byte_cap.reset();
                 }
                 // LIMIT reached (counted post-filter): stop the merge early.
                 if let Some(cap) = limit {
@@ -994,7 +1045,19 @@ impl MergeProducer {
             return Ok(Vec::new());
         }
         let columns = self.output_columns();
-        Ok(vec![rows_to_record_batch(columns, &partial_rows)?])
+        // Issue #2825: the aggregate route materializes one PARTIAL row per
+        // GROUP BY group in one go rather than through the incremental buffer,
+        // so the dual row-cap / byte-cap boundary is applied after the fact —
+        // no egress batch escapes the cap on any route.
+        crate::batch_bytes::split_rows_into_batches(
+            columns,
+            &partial_rows,
+            self.batch_size,
+            self.max_batch_bytes,
+        )
+        .into_iter()
+        .map(|group| rows_to_record_batch(columns, group).map_err(ProducerError::from))
+        .collect()
     }
 
     /// Drive the aggregate-merge loop over `merger`, folding surviving rows into

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -990,12 +990,9 @@ impl MergeProducer {
                         continue;
                     }
                 }
-                // Dual row-cap / byte-cap boundary (issue #2825): estimate the
-                // row's Arrow payload width BEFORE it is moved into the buffer
-                // and cut the batch on the row that WOULD cross the cap, so the
-                // emitted batch holds only rows that fit. `cut_before` answers
-                // `No` on an empty buffer, so a row wider than the whole cap
-                // still leaves as a one-row batch.
+                // Dual row-cap / byte-cap boundary (issue #2825), test-then-push:
+                // cut on the row that WOULD cross the cap, before it joins the
+                // buffer. `batch_bytes.rs` documents the rule and its one-row floor.
                 let width = estimate_arrow_row_bytes(&self.columns, &row);
                 if byte_cap.cut_before(width).is_yes() {
                     sink.emit(self.flush_buffer(&mut buffer)?)?;

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -991,14 +991,20 @@ impl MergeProducer {
                     }
                 }
                 // Dual row-cap / byte-cap boundary (issue #2825): estimate the
-                // row's Arrow payload width BEFORE it is moved into the buffer,
-                // then account for it. `push_width` is push-then-test, so a row
-                // wider than the whole cap still leaves as a one-row batch.
+                // row's Arrow payload width BEFORE it is moved into the buffer
+                // and cut the batch on the row that WOULD cross the cap, so the
+                // emitted batch holds only rows that fit. `cut_before` answers
+                // `No` on an empty buffer, so a row wider than the whole cap
+                // still leaves as a one-row batch.
                 let width = estimate_arrow_row_bytes(&self.columns, &row);
+                if byte_cap.cut_before(width).is_yes() {
+                    sink.emit(self.flush_buffer(&mut buffer)?)?;
+                    byte_cap.reset();
+                }
                 buffer.push(row);
                 emitted += 1;
-                let byte_full = byte_cap.push_width(width).is_yes();
-                if buffer.len() >= self.batch_size || byte_full {
+                byte_cap.accumulate(width);
+                if buffer.len() >= self.batch_size {
                     sink.emit(self.flush_buffer(&mut buffer)?)?;
                     byte_cap.reset();
                 }

--- a/cqlite-flight/src/producer_stream.rs
+++ b/cqlite-flight/src/producer_stream.rs
@@ -206,14 +206,19 @@ impl MergeProducer {
                 }
             }
             // Dual row-cap / byte-cap boundary (issue #2825): estimate the row's
-            // Arrow payload width BEFORE it moves into the buffer, then account
-            // for it. Push-then-test, so a row wider than the whole cap still
-            // leaves as a one-row batch instead of flushing an empty buffer.
+            // Arrow payload width BEFORE it moves into the buffer and cut on the
+            // row that WOULD cross the cap. Test-then-push, so a row wider than
+            // the whole cap still leaves as a one-row batch instead of flushing
+            // an empty buffer.
             let width = estimate_arrow_row_bytes(&self.columns, &row);
+            if byte_cap.cut_before(width).is_yes() {
+                sink.emit(self.flush(&mut buffer)?)?;
+                byte_cap.reset();
+            }
             buffer.push(row);
             emitted += 1;
-            let byte_full = byte_cap.push_width(width).is_yes();
-            if buffer.len() >= self.batch_size || byte_full {
+            byte_cap.accumulate(width);
+            if buffer.len() >= self.batch_size {
                 sink.emit(self.flush(&mut buffer)?)?;
                 byte_cap.reset();
             }

--- a/cqlite-flight/src/producer_stream.rs
+++ b/cqlite-flight/src/producer_stream.rs
@@ -27,11 +27,12 @@
 //! campsite file-size threshold (epic #1116).
 
 use arrow::record_batch::RecordBatch;
-use cqlite_core::export::rows_to_record_batch;
+use cqlite_core::export::{estimate_arrow_row_bytes, rows_to_record_batch};
 use cqlite_core::query::{PartitionKeyCache, QueryRow};
 use cqlite_core::storage::write_engine::merge::{StreamingMerger, StreamingStep};
 use cqlite_core::storage::write_engine::{DecoratedKey, KWayMerger};
 
+use crate::batch_bytes::BatchByteCap;
 use crate::cancel::CancelFlag;
 use crate::producer::{BatchSink, MergeProducer, ProducerError};
 use crate::scan_progress::{ScanProgress, ScanProgressMeter};
@@ -117,6 +118,9 @@ impl MergeProducer {
         let mut meter = ScanProgressMeter::new(progress, access_path);
         let mut buffer: Vec<QueryRow> = Vec::with_capacity(self.batch_size);
         let mut emitted: u64 = 0;
+        // Issue #2825: the SAME dual-boundary accumulator `drive_merge` uses — a
+        // cap wired into only one egress path would leave the other unbounded.
+        let mut byte_cap = BatchByteCap::new(self.max_batch_bytes);
         // Issue #1817: one partition-key decode cache for the whole merge; each
         // partition's rows arrive consecutively, so its key decodes once.
         let mut pk_cache = PartitionKeyCache::default();
@@ -201,10 +205,17 @@ impl MergeProducer {
                     continue;
                 }
             }
+            // Dual row-cap / byte-cap boundary (issue #2825): estimate the row's
+            // Arrow payload width BEFORE it moves into the buffer, then account
+            // for it. Push-then-test, so a row wider than the whole cap still
+            // leaves as a one-row batch instead of flushing an empty buffer.
+            let width = estimate_arrow_row_bytes(&self.columns, &row);
             buffer.push(row);
             emitted += 1;
-            if buffer.len() >= self.batch_size {
+            let byte_full = byte_cap.push_width(width).is_yes();
+            if buffer.len() >= self.batch_size || byte_full {
                 sink.emit(self.flush(&mut buffer)?)?;
+                byte_cap.reset();
             }
             // LIMIT reached (counted post-filter): stop the merge early.
             if let Some(cap) = limit {

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -30,6 +30,7 @@ use tracing::Instrument;
 use cqlite_core::storage::sstable::reader::SSTableReader;
 
 use crate::admission::Admission;
+use crate::batch_bytes::DEFAULT_MAX_BATCH_BYTES;
 use crate::cancel::CancelFlag;
 use crate::filter::{FilterError, ScanSpec};
 use crate::obs::{rpc_span, AbortContext, AbortReason, RpcMetrics};
@@ -299,6 +300,11 @@ pub struct CqliteFlightService {
     /// Shared (`Arc` inside [`Admission`]) across the `Clone`d per-RPC handles so
     /// every request throttles against the same permit pool.
     admission: Admission,
+    /// Per-batch Arrow PAYLOAD byte ceiling handed to every producer this
+    /// service builds (issue #2825). A batch is finished on whichever of
+    /// `batch_size` or this cap trips first. Defaults to
+    /// [`DEFAULT_MAX_BATCH_BYTES`] on every construction path.
+    max_batch_bytes: usize,
 }
 
 impl CqliteFlightService {
@@ -329,7 +335,30 @@ impl CqliteFlightService {
             warm: Arc::new(WarmTableRegistry::new()),
             caches: Arc::new(SetupCaches::default()),
             admission,
+            // Issue #2825: unlike admission, the byte-cap is ON by default on
+            // EVERY construction path — an unbounded egress batch is a memory
+            // hazard, not a policy choice, and the 4 MiB default is a no-op on
+            // every narrow shape. Opt out explicitly with
+            // `with_max_batch_bytes(usize::MAX)`.
+            max_batch_bytes: DEFAULT_MAX_BATCH_BYTES,
         }
+    }
+
+    /// Override the per-batch Arrow **payload** byte cap (issue #2825) — the
+    /// wiring point for the `--max-batch-bytes` / `CQLITE_MAX_BATCH_BYTES` knob.
+    ///
+    /// The cap is already active at [`DEFAULT_MAX_BATCH_BYTES`] from
+    /// [`Self::new`]/[`Self::with_admission`]; this changes the configured value.
+    /// Consumes and returns `self` for chaining.
+    pub fn with_max_batch_bytes(mut self, max_batch_bytes: usize) -> Self {
+        self.max_batch_bytes = max_batch_bytes;
+        self
+    }
+
+    /// The per-batch Arrow payload byte cap in force (issue #2825) — for `main`
+    /// (to log the configured value) and the byte-cap tests.
+    pub fn max_batch_bytes(&self) -> usize {
+        self.max_batch_bytes
     }
 
     /// The service's admission ceiling (issue #2420) — for `main` (to log the
@@ -425,6 +454,9 @@ impl CqliteFlightService {
         // An empty registry (a DDL with no `CREATE TYPE`) is a no-op.
         let registry = cqlite_core::schema::udt_registry_from_cql(&ticket.ddl, &ticket.keyspace);
         let producer = MergeProducer::with_spec((*schema).clone(), self.batch_size, spec)?
+            // Issue #2825: the configured byte-cap reaches every producer this
+            // service builds, on every route.
+            .with_max_batch_bytes(self.max_batch_bytes)
             .with_udt_registry(registry);
         // Aggregation pushdown (issue #841): when the ticket carries an
         // aggregation spec, the producer emits PARTIAL aggregate rows under the

--- a/cqlite-flight/src/wide_row_fixture.rs
+++ b/cqlite-flight/src/wide_row_fixture.rs
@@ -1,0 +1,161 @@
+//! Deterministic, self-contained synthetic row shapes for the byte-cap suite
+//! (issue #2825).
+//!
+//! # Why these are synthetic
+//!
+//! A byte-cap test backed by the fetched `test_wide_rows` corpus would pass
+//! **vacuously** in a checkout that never ran `fetch-datasets.sh`: the repo ships
+//! only JSONL references, so the table directory exists but has no `Data.db`, the
+//! scan yields zero rows, and "every non-final batch has fewer than `batch_size`
+//! rows" is trivially true over zero batches. The testing doctrine forbids that,
+//! so the wide-row coverage is generated **in process** from the shapes here:
+//! every byte-cap test runs with real rows regardless of the dataset state.
+//!
+//! Only the drift-sensitive *shape* (keyspace/table/DDL/columns and the mutation
+//! set) lives here. The temp-dir flush plumbing stays with each caller because it
+//! depends on `tempfile`, a dev-dependency — the same split
+//! [`crate::test_fixtures`] uses.
+//!
+//! Both callers — the in-crate `batch_bytes_tests` unit suite and the
+//! `tests/issue_2825_max_batch_bytes_e2e.rs` integration binary — build from
+//! these definitions, so the unit and end-to-end evidence describe the same rows.
+
+use std::collections::HashMap;
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{CellOperation, Mutation, PartitionKey, TableId};
+use cqlite_core::types::Value;
+
+/// Keyspace of both synthetic byte-cap shapes.
+pub const BYTECAP_KS: &str = "bytecap_ks";
+
+/// Wide-row table: one `blob` payload column wide enough that a full
+/// `batch_size`-row batch would blow any sane byte-cap.
+pub const WIDE_TBL: &str = "wide_rows";
+
+/// DDL for [`wide_row_schema`], as a ticket carries it.
+pub const WIDE_DDL: &str =
+    "CREATE TABLE bytecap_ks.wide_rows (id int PRIMARY KEY, payload blob, label text)";
+
+/// Narrow table: the no-regression shape — a full `batch_size`-row batch of these
+/// sits far under [`crate::batch_bytes::DEFAULT_MAX_BATCH_BYTES`], so the row-cap
+/// must remain the binding boundary.
+pub const NARROW_TBL: &str = "narrow_rows";
+
+/// DDL for [`narrow_row_schema`].
+pub const NARROW_DDL: &str =
+    "CREATE TABLE bytecap_ks.narrow_rows (id int PRIMARY KEY, name text, score int)";
+
+/// Write timestamp for every fixture row — a fixed, deterministic value, never
+/// wall-clock, so the fixture is reproducible run to run.
+pub const FIXTURE_TIMESTAMP: i64 = 100;
+
+fn col(name: &str, ty: &str, nullable: bool) -> Column {
+    Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    }
+}
+
+/// `id int PRIMARY KEY, payload blob, label text` — the wide shape.
+pub fn wide_row_schema() -> TableSchema {
+    TableSchema {
+        keyspace: BYTECAP_KS.into(),
+        table: WIDE_TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            col("id", "int", false),
+            col("payload", "blob", true),
+            col("label", "text", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// `id int PRIMARY KEY, name text, score int` — the narrow shape.
+pub fn narrow_row_schema() -> TableSchema {
+    TableSchema {
+        keyspace: BYTECAP_KS.into(),
+        table: NARROW_TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            col("id", "int", false),
+            col("name", "text", true),
+            col("score", "int", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Deterministic payload bytes for row `id`: a fixed-length, id-derived fill, so
+/// two runs produce byte-identical SSTables and every row has the SAME width
+/// (which makes "rows per batch" an exact, assertable function of the cap).
+pub fn wide_payload(id: i32, payload_len: usize) -> Vec<u8> {
+    let fill = (id % 251) as u8;
+    vec![fill; payload_len]
+}
+
+/// `n_rows` single-row partitions, each carrying a `payload_len`-byte blob.
+pub fn wide_row_mutations(n_rows: i32, payload_len: usize) -> Vec<Mutation> {
+    (0..n_rows)
+        .map(|id| {
+            Mutation::new(
+                TableId::new(BYTECAP_KS, WIDE_TBL),
+                PartitionKey::single("id", Value::Integer(id)),
+                None,
+                vec![
+                    CellOperation::Write {
+                        column: "payload".into(),
+                        value: Value::Blob(wide_payload(id, payload_len).into()),
+                    },
+                    CellOperation::Write {
+                        column: "label".into(),
+                        value: Value::text(format!("row-{id}")),
+                    },
+                ],
+                FIXTURE_TIMESTAMP,
+                None,
+            )
+        })
+        .collect()
+}
+
+/// `n_rows` narrow single-row partitions (`name` is one char, `score` an int).
+pub fn narrow_row_mutations(n_rows: i32) -> Vec<Mutation> {
+    (0..n_rows)
+        .map(|id| {
+            Mutation::new(
+                TableId::new(BYTECAP_KS, NARROW_TBL),
+                PartitionKey::single("id", Value::Integer(id)),
+                None,
+                vec![
+                    CellOperation::Write {
+                        column: "name".into(),
+                        value: Value::text("n"),
+                    },
+                    CellOperation::Write {
+                        column: "score".into(),
+                        value: Value::Integer(id),
+                    },
+                ],
+                FIXTURE_TIMESTAMP,
+                None,
+            )
+        })
+        .collect()
+}

--- a/cqlite-flight/tests/issue_2825_max_batch_bytes_e2e.rs
+++ b/cqlite-flight/tests/issue_2825_max_batch_bytes_e2e.rs
@@ -1,0 +1,395 @@
+//! End-to-end wiring evidence for the `--max-batch-bytes` /
+//! `CQLITE_MAX_BATCH_BYTES` byte-cap knob (issue #2825).
+//!
+//! The in-crate unit suite (`src/batch_bytes_tests.rs`) proves the boundary rule
+//! against the producer seams. This binary proves the **knob** — that the
+//! operator-facing configuration actually reaches those seams — by starting the
+//! REAL `cqlite-flight` server binary (`CARGO_BIN_EXE_cqlite-flight`, so clap
+//! parses the real `Args`, reads the real env var, and writes the real startup
+//! log), streaming a REAL `do_get` through a REAL `FlightServiceClient`, and
+//! observing where the batch boundaries fall. A helper-only unit test could not
+//! catch a knob that is parsed and then dropped on the floor.
+//!
+//! The fixture is the synthetic wide-row shape from
+//! `cqlite_flight::wide_row_fixture`, generated in process — never the fetched
+//! `test_wide_rows` corpus, which would make every assertion here pass vacuously
+//! in an unfetched checkout.
+//!
+//! No assertion in this file compares an elapsed duration against a threshold
+//! (#2642). The timeouts below are liveness bounds on process/socket readiness,
+//! not correctness properties.
+
+use std::net::{SocketAddr, TcpListener};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::Ticket;
+use futures::TryStreamExt;
+use tonic::transport::Channel;
+
+use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use cqlite_flight::batch_bytes::{DEFAULT_MAX_BATCH_BYTES, ENV_MAX_BATCH_BYTES};
+use cqlite_flight::wide_row_fixture as fx;
+
+/// 220 rows x 4 KiB payload ~ 900 KiB of blob: enough that a 64 KiB cap cuts
+/// ~14 batches while the default `--batch-size 8192` row-cap never binds.
+const ROWS: i32 = 220;
+const PAYLOAD: usize = 4096;
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+/// Flush the synthetic wide-row fixture into a real SSTable and return the temp
+/// dir (keep it alive) plus the server's `--data-dir`.
+fn build_wide_fixture() -> (tempfile::TempDir, PathBuf) {
+    let schema = fx::wide_row_schema();
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for m in fx::wide_row_mutations(ROWS, PAYLOAD) {
+        engine.write(m).expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    (temp, data_dir)
+}
+
+/// The wire ticket the connector would send for the wide fixture.
+fn ticket_bytes() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": fx::BYTECAP_KS,
+        "table": fx::WIDE_TBL,
+        "ddl": fx::WIDE_DDL,
+    }))
+    .expect("ticket json")
+}
+
+// ---------------------------------------------------------------------------
+// Server process control
+// ---------------------------------------------------------------------------
+
+/// A spawned `cqlite-flight` server process, killed on drop so a failing
+/// assertion can never leak a listener.
+struct ServerProcess {
+    child: Child,
+    addr: SocketAddr,
+    log: PathBuf,
+    // Kept so the log file outlives the process.
+    _log_dir: tempfile::TempDir,
+}
+
+impl Drop for ServerProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl ServerProcess {
+    /// Everything the server wrote to stdout+stderr so far (the startup log),
+    /// with the `tracing-subscriber` ANSI styling stripped so the field
+    /// assertions match plain `key=value` text.
+    fn log(&self) -> String {
+        strip_ansi(&std::fs::read_to_string(&self.log).unwrap_or_default())
+    }
+}
+
+/// Drop CSI escape sequences (`ESC [ <params> <final byte>`) from `s`.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        // Skip the `[` introducer, then every parameter/intermediate byte up to
+        // and including the final byte in `@..=~` (e.g. the `m` of `ESC[32m`).
+        if chars.peek() == Some(&'[') {
+            chars.next();
+        }
+        for c in chars.by_ref() {
+            if ('@'..='~').contains(&c) {
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// An ephemeral loopback port that is free right now.
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let port = l.local_addr().expect("local_addr").port();
+    drop(l);
+    port
+}
+
+/// Start the REAL server binary over `data_dir` with `extra_args` and `env`, and
+/// wait until it accepts connections.
+///
+/// Retries on a port that another process grabbed in the gap between
+/// [`free_port`] and the child's own bind — a startup race, not a correctness
+/// property, so no assertion depends on timing here.
+fn start_server(data_dir: &Path, extra_args: &[String], env: &[(&str, String)]) -> ServerProcess {
+    let exe = env!("CARGO_BIN_EXE_cqlite-flight");
+    let mut last_log = String::new();
+    for _ in 0..3 {
+        let port = free_port();
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
+        let log_dir = tempfile::TempDir::new().expect("log dir");
+        let log = log_dir.path().join("server.log");
+        let out = std::fs::File::create(&log).expect("log file");
+        let err = out.try_clone().expect("clone log fd");
+
+        let mut cmd = Command::new(exe);
+        cmd.arg("--data-dir")
+            .arg(data_dir)
+            .arg("--listen")
+            .arg(addr.to_string())
+            .args(extra_args)
+            .stdout(Stdio::from(out))
+            .stderr(Stdio::from(err));
+        // Start from a clean slate so a stray CQLITE_MAX_BATCH_BYTES in the
+        // developer's environment cannot silently change what is under test.
+        cmd.env_remove(ENV_MAX_BATCH_BYTES);
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+        let child = cmd.spawn().expect("spawn cqlite-flight");
+        let mut server = ServerProcess {
+            child,
+            addr,
+            log,
+            _log_dir: log_dir,
+        };
+
+        // Liveness wait: poll the socket until the server accepts.
+        for _ in 0..200 {
+            if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(50)).is_ok() {
+                return server;
+            }
+            if let Ok(Some(_)) = server.child.try_wait() {
+                break; // exited early (likely a port collision) — retry
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        last_log = server.log();
+    }
+    panic!("cqlite-flight never became ready; last server log:\n{last_log}");
+}
+
+/// Stream a real `do_get` against `addr` and return the row count of each
+/// decoded batch, in order.
+async fn stream_batch_row_counts(addr: SocketAddr) -> Vec<usize> {
+    let channel = Channel::from_shared(format!("http://{addr}"))
+        .expect("endpoint")
+        .connect_timeout(Duration::from_secs(10))
+        .connect()
+        .await
+        .expect("connect");
+    let mut client = FlightServiceClient::new(channel);
+    let resp = client
+        .do_get(Ticket::new(ticket_bytes()))
+        .await
+        .expect("do_get rpc");
+    let stream =
+        FlightRecordBatchStream::new_from_flight_data(resp.into_inner().map_err(|e| e.into()));
+    let batches: Vec<_> = stream.try_collect().await.expect("decode batches");
+    batches.iter().map(|b| b.num_rows()).collect()
+}
+
+/// Start a server with the given cap configuration and return its decoded
+/// per-batch row counts plus the startup log.
+fn run_scan(
+    data_dir: &Path,
+    extra_args: &[String],
+    env: &[(&str, String)],
+) -> (Vec<usize>, String) {
+    let server = start_server(data_dir, extra_args, env);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let counts = rt.block_on(stream_batch_row_counts(server.addr));
+    (counts, server.log())
+}
+
+fn assert_non_vacuous(counts: &[usize], what: &str) {
+    let total: usize = counts.iter().sum();
+    assert_eq!(
+        total, ROWS as usize,
+        "{what}: streamed {total} rows, expected {ROWS} — vacuous fixture"
+    );
+    assert!(
+        !counts.is_empty(),
+        "{what}: no batches decoded from the stream"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 6: the knob governs a real streamed do_get
+// ---------------------------------------------------------------------------
+
+/// Two distinct `--max-batch-bytes` CLI values, over the same ticket, produce
+/// correspondingly different batch boundaries through a real streamed `do_get`:
+/// the smaller cap yields strictly more batches with strictly fewer rows each.
+///
+/// FAILS on pre-change `main`: `--max-batch-bytes` does not exist there, so the
+/// server rejects the flag and never starts.
+#[test]
+fn cli_flag_governs_streamed_do_get_batch_boundaries() {
+    let (_temp, data_dir) = build_wide_fixture();
+
+    let (small, _) = run_scan(
+        &data_dir,
+        &["--max-batch-bytes".into(), (32 * 1024).to_string()],
+        &[],
+    );
+    let (large, _) = run_scan(
+        &data_dir,
+        &["--max-batch-bytes".into(), (256 * 1024).to_string()],
+        &[],
+    );
+
+    assert_non_vacuous(&small, "small CLI cap");
+    assert_non_vacuous(&large, "large CLI cap");
+    assert!(
+        small.len() > 1,
+        "small cap produced a single batch — the cap is not wired"
+    );
+    assert!(
+        small.len() > large.len(),
+        "smaller cap yielded {} batches, not more than the larger cap's {}: \
+         {small:?} vs {large:?}",
+        small.len(),
+        large.len()
+    );
+    let (max_small, max_large) = (
+        small.iter().copied().max().unwrap_or(0),
+        large.iter().copied().max().unwrap_or(0),
+    );
+    assert!(
+        max_small < max_large,
+        "smaller cap's widest batch ({max_small} rows) is not smaller than the \
+         larger cap's ({max_large} rows)"
+    );
+}
+
+/// `CQLITE_MAX_BATCH_BYTES` alone — no CLI flag — governs the same real streamed
+/// `do_get`, and the observed boundaries match the environment-configured cap.
+///
+/// FAILS on pre-change `main`: nothing reads that variable there, so both runs
+/// produce identical single-batch output.
+#[test]
+fn env_var_governs_streamed_do_get_batch_boundaries() {
+    let (_temp, data_dir) = build_wide_fixture();
+
+    let (small, small_log) = run_scan(
+        &data_dir,
+        &[],
+        &[(ENV_MAX_BATCH_BYTES, (32 * 1024).to_string())],
+    );
+    let (large, large_log) = run_scan(
+        &data_dir,
+        &[],
+        &[(ENV_MAX_BATCH_BYTES, (256 * 1024).to_string())],
+    );
+
+    assert_non_vacuous(&small, "small env cap");
+    assert_non_vacuous(&large, "large env cap");
+    // The configured value reached the server's own view of its configuration.
+    assert!(
+        small_log.contains(&format!("max_batch_bytes={}", 32 * 1024)),
+        "startup log does not record the env-configured cap:\n{small_log}"
+    );
+    assert!(
+        large_log.contains(&format!("max_batch_bytes={}", 256 * 1024)),
+        "startup log does not record the env-configured cap:\n{large_log}"
+    );
+    assert!(
+        small.len() > large.len(),
+        "env cap did not change the boundary: {small:?} vs {large:?}"
+    );
+}
+
+/// With neither flag nor environment variable, the effective cap is
+/// `DEFAULT_MAX_BATCH_BYTES` and the startup log records it — and the whole
+/// ~900 KiB fixture, being far under 4 MiB, streams as a single row-cut batch,
+/// confirming the default is a no-op on sub-cap data.
+#[test]
+fn the_default_cap_applies_and_is_logged() {
+    let (_temp, data_dir) = build_wide_fixture();
+    let (counts, log) = run_scan(&data_dir, &[], &[]);
+    assert_non_vacuous(&counts, "default cap");
+    assert!(
+        log.contains(&format!("max_batch_bytes={DEFAULT_MAX_BATCH_BYTES}")),
+        "startup log does not record the default cap ({DEFAULT_MAX_BATCH_BYTES}):\n{log}"
+    );
+    assert_eq!(
+        counts.len(),
+        1,
+        "the ~900 KiB fixture should fit one 4 MiB batch, got {counts:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Requirement 7: content invariance across the transport
+// ---------------------------------------------------------------------------
+
+/// A capped and an effectively-unbounded run stream the same rows in the same
+/// order with the same values and the same Arrow schema — only the batch
+/// boundaries differ.
+#[test]
+fn capped_and_unbounded_streams_carry_identical_content() {
+    let (_temp, data_dir) = build_wide_fixture();
+
+    let fetch = |cap: String| {
+        let server = start_server(&data_dir, &["--max-batch-bytes".into(), cap], &[]);
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(async {
+            let channel = Channel::from_shared(format!("http://{}", server.addr))
+                .expect("endpoint")
+                .connect_timeout(Duration::from_secs(10))
+                .connect()
+                .await
+                .expect("connect");
+            let mut client = FlightServiceClient::new(channel);
+            let resp = client
+                .do_get(Ticket::new(ticket_bytes()))
+                .await
+                .expect("do_get rpc");
+            let stream = FlightRecordBatchStream::new_from_flight_data(
+                resp.into_inner().map_err(|e| e.into()),
+            );
+            let batches: Vec<arrow::record_batch::RecordBatch> =
+                stream.try_collect().await.expect("decode");
+            let schema = batches.first().map(|b| b.schema()).expect("a batch");
+            let n_batches = batches.len();
+            let cat = arrow::compute::concat_batches(&schema, &batches).expect("concat");
+            (n_batches, cat)
+        })
+    };
+
+    let (small_n, small) = fetch((32 * 1024).to_string());
+    let (big_n, big) = fetch(usize::MAX.to_string());
+    assert!(
+        small_n > big_n,
+        "the cap changed no boundary ({small_n} vs {big_n}) — comparison vacuous"
+    );
+    assert_eq!(small.schema(), big.schema(), "Arrow schema differs");
+    assert_eq!(small.num_rows(), ROWS as usize);
+    assert_eq!(small, big, "row content or order differs across cap values");
+}

--- a/docs/architecture/throughput-program-2026-07.md
+++ b/docs/architecture/throughput-program-2026-07.md
@@ -382,7 +382,11 @@ are in flight-loadgen/perf terms with the number each must demonstrate.
 
 - **M11 (#2825) — T4 byte-bounded batch (NEW, P2).** Cap MB/batch (finish on whichever of row-cap 8192 /
   byte-cap trips first). *Accept:* wide-row batches stay under a configured byte ceiling; the
-  57,344-row Arrow egress buffer stops scaling to ~8MB/batch on wide rows (helps B4). ~1.0–1.1×
+  ~49,152-row Arrow egress buffer — `(DO_GET_CHANNEL_CAPACITY = 4 + ~2 in-flight) × 8192`; the
+  earlier 57,344 figure over-counted by folding in the `#[cfg(test)]`-only `IN_FLIGHT_ALLOWANCE = 3`
+  (`cqlite-flight/src/streaming.rs:86-87`, correction recorded at
+  `docs/research/phase2-verify-parallelism.md:94-100`) — stops scaling to ~8MB/batch on wide rows
+  (helps B4). ~1.0–1.1×
   throughput — filed as a **robustness/correctness** lever, not throughput. **Dep:** none. **Dedup:**
   NEW connector/server surface; #1476/#2230 are the read-path analogue.
 

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -608,3 +608,83 @@ Format:
 - **Files:** `cqlite-flight/src/admission.rs` (`WaitBudget` enum,
   `SlowAcquireOutcome`), `admission_tests.rs` (`cfg()` + new test),
   `main.rs` (explicit `WaitBudget::Timeout` construction).
+
+---
+
+## 2026-07-26 — Byte-bounded Arrow egress batches: `--max-batch-bytes` (issue #2825, T4/M11)
+
+- **What:** the egress batch boundary is now **dual** — a batch is finished on
+  whichever of the row-cap (`--batch-size`, default 8192) or a new **byte-cap**
+  trips FIRST, enforced at BOTH build sites (`producer.rs`'s `drive_merge` and
+  `producer_stream.rs`'s `drive_merge_streaming`) plus the aggregate route.
+- **Why:** the batch was previously bounded by row count alone, so its byte size
+  was `batch_size × row_width` — unbounded in schema shape. A table with a 64 KiB
+  blob column produced a 512 MiB batch from the same code path that produced a
+  192 KiB batch for `cassandra_easy_stress.keyvalue`, and the ratified B4 budget
+  (≤16Mi per-query working set at concurrency 1) cannot be held by a bound stated
+  in rows. `checked_value_bytes` already named the missing remedy in its own error
+  text ("reduce the batch row count (byte-bounded batching)").
+
+### Operator knob
+
+| | |
+|---|---|
+| CLI flag | `--max-batch-bytes <BYTES>` |
+| Environment | `CQLITE_MAX_BATCH_BYTES` |
+| Default | `4194304` (4 MiB), `cqlite_flight::batch_bytes::DEFAULT_MAX_BATCH_BYTES` |
+| Startup log | `max_batch_bytes=<value>`, beside `batch_size` / `max_concurrent_scans` |
+| Disable | set to `usize::MAX` (row-cap becomes the sole boundary) |
+
+- **Currency — read this before budgeting memory.** The cap is denominated in
+  Arrow **payload** bytes: the sum of buffer *lengths*, recursively including
+  child data (`cqlite_core::export::arrow_payload_bytes`). It is **not**
+  denominated in `RecordBatch::get_array_memory_size()`, which reports buffer
+  *capacity*: the construction path grows `MutableBuffer` by power-of-two
+  doubling from zero, so reported memory runs up to ~2× the payload (measured
+  1.001×–1.80× across shapes against arrow 53 — blob-heavy batches hug 1.0,
+  many-small-string batches approach 1.8). Payload bytes are estimable before the
+  batch exists and monotonic in row count; capacity is neither, which is why it
+  cannot be the trigger.
+- **Converting to capacity currency.** Published constants:
+  `BATCH_BYTES_CAPACITY_FACTOR = 2` and `BATCH_BYTES_PER_COLUMN_SLACK = 1024`, with
+  `worst_case_batch_capacity_bytes(cap, n_columns) = 2 × cap + 1024 × n_columns`.
+  At the 4 MiB default that is ~8 MiB of resident capacity per batch.
+- **B4 composition for issue #2821.** The per-stream in-flight ceiling must be
+  budgeted in the SAME capacity currency `streaming.rs` already meters, giving
+  `ceiling + one maximum batch`. With a 6 MiB ceiling: `6 + 8 = 14 MiB < 16Mi`,
+  inside B4 at concurrency 1. The naive `4 + 8 = 12 MiB` reading mixes payload and
+  capacity — a 4 MiB *payload* cap is an 8 MiB *capacity* batch, so an 8 MiB
+  ceiling would land at exactly 16 MiB with zero headroom.
+- **Sizing the default.** 4 MiB keeps the row-cap binding on every narrow shape
+  measured in-tree (`issue_1494` fixture ~20 B/row → ~192 KiB/batch, ~22× headroom;
+  the field model at ~180 B/row → 1.47 MB, ~2.9×; even the pessimistic 300 B/row
+  figure → 2.34 MiB), so narrow-path batch boundaries are byte-identical to
+  pre-change and there is no throughput regression.
+- **Liveness.** Push-then-test: a batch is cut only when the buffer is non-empty
+  AND the accumulated estimate has reached the cap. A single row wider than the
+  whole cap is delivered as a one-row batch — never dropped, never a stall.
+  `--max-batch-bytes 0` and `1` degrade to one row per batch rather than hanging.
+- **On by default everywhere** — deliberately unlike `Admission::unconstrained()`:
+  an unbounded batch is a memory-safety hazard, not a policy choice, so
+  `CqliteFlightService::new`, `MergeProducer::new` and `with_spec` all carry the
+  4 MiB cap. Library embedders opt OUT with `with_max_batch_bytes(usize::MAX)`.
+- **How the decision is made.** `cqlite_core::export::estimate_arrow_row_bytes`
+  reports a conservative per-row payload width from the authoritative `ColumnInfo`
+  CQL types plus the decoded values (no-heuristics, #28); a running accumulator
+  advances by exactly one row's estimate per push and resets on flush, so the
+  boundary is decided BEFORE `rows_to_record_batch` allocates. The estimator's
+  walk is iterative, node-budgeted and saturating: a pathological value fails
+  closed (cut the batch), never panics or hangs.
+- **Files:** new `cqlite-core/src/export/arrow_size.rs` (+ `arrow_size_tests.rs`),
+  new `cqlite-flight/src/batch_bytes.rs` (+ `batch_bytes_tests.rs`), new
+  `cqlite-flight/src/wide_row_fixture.rs`, new
+  `cqlite-flight/tests/issue_2825_max_batch_bytes_e2e.rs`; minimal edits to
+  `producer.rs`, `producer_stream.rs`, `service.rs`, `main.rs`, `lib.rs`,
+  `export/mod.rs`.
+- **Verified:** 11 estimator tests (incl. the conservatism property test over a
+  20-shape corpus), 19 in-crate byte-cap tests, 4 end-to-end tests that start the
+  REAL server binary and stream a REAL `do_get` (CLI flag, env var, default +
+  startup log, content invariance). `issue_1494_producer_mem_budget` unchanged
+  under `--features dhat-heap`.
+- **Next:** issue #2821 consumes `BATCH_BYTES_CAPACITY_FACTOR` for its 6 MiB
+  per-stream egress ceiling.

--- a/docs/flight-trino/JOURNAL.md
+++ b/docs/flight-trino/JOURNAL.md
@@ -647,8 +647,15 @@ Format:
   cannot be the trigger.
 - **Converting to capacity currency.** Published constants:
   `BATCH_BYTES_CAPACITY_FACTOR = 2` and `BATCH_BYTES_PER_COLUMN_SLACK = 1024`, with
-  `worst_case_batch_capacity_bytes(cap, n_columns) = 2 × cap + 1024 × n_columns`.
-  At the 4 MiB default that is ~8 MiB of resident capacity per batch.
+  `worst_case_batch_capacity_bytes(cap, n_array_nodes, widest_row_payload)
+  = 2 × max(cap, widest_row_payload) + 1024 × n_array_nodes`. For a schema whose
+  widest row fits the cap that is `2 × cap + slack` — ~8 MiB of resident capacity
+  per batch at the 4 MiB default. The `max(..)` term is honest, not slack: one row
+  cannot be split across Arrow batches, so a schema with a single over-cap row
+  emits it alone at its own natural width, and nothing downstream clamps that
+  (`arrow_convert.rs`'s `checked_value_bytes` only *rejects* a cumulative column
+  length above `i32::MAX`). The slack term is denominated in Arrow array NODES:
+  a `map<text,text>` column is four nodes, not one.
 - **B4 composition for issue #2821.** The per-stream in-flight ceiling must be
   budgeted in the SAME capacity currency `streaming.rs` already meters, giving
   `ceiling + one maximum batch`. With a 6 MiB ceiling: `6 + 8 = 14 MiB < 16Mi`,
@@ -660,8 +667,11 @@ Format:
   the field model at ~180 B/row → 1.47 MB, ~2.9×; even the pessimistic 300 B/row
   figure → 2.34 MiB), so narrow-path batch boundaries are byte-identical to
   pre-change and there is no throughput regression.
-- **Liveness.** Push-then-test: a batch is cut only when the buffer is non-empty
-  AND the accumulated estimate has reached the cap. A single row wider than the
+- **Liveness.** Test-then-push: the candidate row's width is tested against the
+  accumulator FIRST, and the batch is cut only when the buffer is non-empty AND
+  adding the row would take it past the cap — so an emitted batch's payload is at
+  or below the cap outright, with no `+ one crossing row` overshoot. An empty
+  buffer always accepts the row, however wide, so a single row wider than the
   whole cap is delivered as a one-row batch — never dropped, never a stall.
   `--max-batch-bytes 0` and `1` degrade to one row per batch rather than hanging.
 - **On by default everywhere** — deliberately unlike `Admission::unconstrained()`:
@@ -672,17 +682,25 @@ Format:
   reports a conservative per-row payload width from the authoritative `ColumnInfo`
   CQL types plus the decoded values (no-heuristics, #28); a running accumulator
   advances by exactly one row's estimate per push and resets on flush, so the
-  boundary is decided BEFORE `rows_to_record_batch` allocates. The estimator's
-  walk is iterative, node-budgeted and saturating: a pathological value fails
-  closed (cut the batch), never panics or hangs.
-- **Files:** new `cqlite-core/src/export/arrow_size.rs` (+ `arrow_size_tests.rs`),
+  boundary is decided BEFORE `rows_to_record_batch` allocates. Arrow buffer
+  *lengths* are exact (measured: a one-row `Int32` column is 4 B, a nine-row
+  `Boolean` column is `ceil(9/8) = 2` B), so the estimate is built from real
+  per-slot costs — a validity byte per slot, two offsets entries per
+  variable-width slot (its own plus the buffer's trailing `n+1`-th) — plus one
+  small residual per COLUMN, never a large fudge per cell. The estimator's walk is
+  iterative, node-budgeted and saturating, and a fan-out is tested against the
+  budget BEFORE it is queued: a pathological value fails closed (cut the batch),
+  never panics or hangs.
+- **Files:** new `cqlite-core/src/export/arrow_size.rs` (+ `arrow_size_render.rs`,
+  `arrow_size_tests.rs`),
   new `cqlite-flight/src/batch_bytes.rs` (+ `batch_bytes_tests.rs`), new
   `cqlite-flight/src/wide_row_fixture.rs`, new
   `cqlite-flight/tests/issue_2825_max_batch_bytes_e2e.rs`; minimal edits to
   `producer.rs`, `producer_stream.rs`, `service.rs`, `main.rs`, `lib.rs`,
   `export/mod.rs`.
-- **Verified:** 11 estimator tests (incl. the conservatism property test over a
-  20-shape corpus), 19 in-crate byte-cap tests, 4 end-to-end tests that start the
+- **Verified:** 14 estimator tests (incl. the conservatism property test over a
+  28-shape corpus and the bounded-multiple test over the collection-heavy and
+  multi-column shapes), 20 in-crate byte-cap tests, 4 end-to-end tests that start the
   REAL server binary and stream a REAL `do_get` (CLI flag, env var, default +
   startup log, content invariance). `issue_1494_producer_mem_budget` unchanged
   under `--features dhat-heap`.

--- a/openspec/changes/egress-batch-byte-cap/design.md
+++ b/openspec/changes/egress-batch-byte-cap/design.md
@@ -285,7 +285,11 @@ admission precedent is deliberate and is recorded here rather than discovered la
 1. Pre-batch accumulation; `get_array_memory_size()` is the **test oracle only** §(a).
 2. Cap denominated in **Arrow payload bytes**, with `BATCH_BYTES_CAPACITY_FACTOR = 2`
    published so consumers can convert to capacity §(b). **#2821's 12 MiB arithmetic
-   is revised to `6 MiB ceiling + 8 MiB worst-case batch = 14 MiB < 16Mi`.**
+   is revised to `6 MiB ceiling + 8 MiB worst-case batch = 14 MiB < 16Mi`** — a
+   TARGET for #2821 to enforce, not a bound this change puts in force: until that
+   per-stream byte ceiling exists, `do_get` residency stays COUNT-bounded at ~7
+   batches (`~56 MiB` worst case), because `streaming.rs`'s
+   `get_array_memory_size()` reading feeds metrics only.
 3. `DEFAULT_MAX_BATCH_BYTES = 4 MiB` — the decided default, verified to leave the
    narrow row-cap binding under every available estimate §(c).
 4. New `cqlite_core::export::estimate_arrow_row_bytes`; `result_budget.rs`

--- a/openspec/changes/egress-batch-byte-cap/design.md
+++ b/openspec/changes/egress-batch-byte-cap/design.md
@@ -234,10 +234,15 @@ re-exported from `export/mod.rs` next to `rows_to_record_batch`. It walks
   per-variant shape, hardened like the memtable estimator: iterative, node-capped,
   `saturating_add` throughout, fails closed to a large value rather than panicking);
 - a per-cell **structural addend** `ARROW_CELL_OVERHEAD_BYTES` covering the
-  offsets entry (4 B for `Utf8`/`Binary`/`List`/`Map`) and the validity bit
-  (rounded up to 1 B) — the term every existing estimator omits;
+  offsets entry (4 B for `Utf8`/`Binary`/`List`/`Map`), the buffer's trailing
+  `n+1`-th offsets entry, and the validity bit (rounded up to 1 B) — the term
+  every existing estimator omits;
 - for collection/struct columns, a per-**element** structural addend, because a
-  `ListArray` pays child offsets + child validity per element, not per row.
+  `ListArray` pays child offsets + child validity per element, not per row;
+- a single per-**column** residual `ARROW_COLUMN_SLACK_BYTES` for array nodes
+  that correspond to no slot (the flat `MapArray`'s always-present empty `Utf8`
+  children). Charged per column, never per slot, so the estimate cannot inflate
+  with a cell's element count (#2825 review B3).
 
 Conservatism is a **contract, not an aspiration**: the spec requires a property
 test over a corpus of shapes asserting
@@ -285,7 +290,10 @@ admission precedent is deliberate and is recorded here rather than discovered la
    narrow row-cap binding under every available estimate §(c).
 4. New `cqlite_core::export::estimate_arrow_row_bytes`; `result_budget.rs`
    untouched; conservatism enforced by a property test §(d).
-5. Push-then-test one-row floor; `0`/`1` clamp to one row per batch §(e).
+5. Test-then-push one-row floor (revised from push-then-test in the #2825 review
+   round, B1: the cut is decided BEFORE the crossing row is appended, bounding a
+   batch at `max(cap, widest_row_payload)` rather than `cap + widest_row`);
+   `0`/`1` clamp to one row per batch §(e).
 6. Cap on by default on every construction path §(f).
 7. `--max-batch-bytes` / `CQLITE_MAX_BATCH_BYTES` / `DEFAULT_MAX_BATCH_BYTES`,
    mirroring `admission.rs:43/51` + `main.rs:43`, echoed in the `main.rs:109-116`

--- a/openspec/changes/egress-batch-byte-cap/design.md
+++ b/openspec/changes/egress-batch-byte-cap/design.md
@@ -1,0 +1,318 @@
+# Design — byte-bounded Arrow egress batches (issue #2825, T4/M11)
+
+## Context
+
+Both egress build sites accumulate the **same** concrete type and flush through
+the **same** converter, which makes a single shared cap mechanism natural:
+
+| | buffer decl | push | row-cap trip | flush |
+|---|---|---|---|---|
+| `producer.rs` | `:888` `let mut buffer: Vec<QueryRow>` | `:949` | `:951` | `:1222` `fn flush_buffer(&self, buffer: &mut Vec<QueryRow>) -> Result<RecordBatch, ProducerError>` |
+| `producer_stream.rs` | `:118` `let mut buffer: Vec<QueryRow>` | `:204` | `:206` | `:87` `fn flush(&self, buffer: &mut Vec<QueryRow>) -> Result<RecordBatch, ProducerError>` |
+
+The buffered element is `cqlite_core::query::QueryRow`
+(`cqlite-core/src/query/result.rs:67`):
+
+```rust
+pub struct QueryRow {
+    pub values: HashMap<Arc<str>, Value>,
+    pub key: RowKey,
+    pub metadata: RowMetadata,
+    pub cell_metadata: Option<HashMap<String, CellWriteMetadata>>,
+}
+```
+
+Conversion is `rows_to_record_batch(columns: &[ColumnInfo], rows: &[QueryRow])`
+(`cqlite-core/src/export/arrow_convert.rs:197`) → `transpose_columns`
+(`export/arrow_columnar.rs:59`, borrowing `Option<&Value>` per cell) →
+`convert_column_to_array` (`arrow_convert.rs:1322`), which dispatches on
+`ColumnInfo::cql_type`. Only `values` is read; `key`, `metadata` and
+`cell_metadata` never reach the batch.
+
+Variable-width Arrow outputs (the wide-row case that matters): `Text`/`Ascii`/
+`Varchar`/`Duration`/`Inet`/`Custom` → `Utf8`; `Blob` → `Binary`; `List`/`Set` →
+`ListArray`; `Map` → `MapArray`; `Tuple`/`Udt` → `StructArray`. Fixed-width:
+`Uuid`/`TimeUuid` → `FixedSizeBinary(16)`, `Decimal`/`Varint` → `Decimal128`,
+`Date`/`Time`/`Counter`/numerics → fixed primitives.
+
+The decisions below each state alternatives; §Recommended package selects one
+coherent set for Seam-1 approval. **§(b) and §(c) each surface a contradiction with
+the figures carried in issue #2825 and in the M11 manifest line; both are called
+out explicitly because they change the arithmetic downstream (#2821) depends on.**
+
+---
+
+## (a) Where the byte decision is made: post-batch vs. pre-batch accumulation
+
+- **Post-batch, via `RecordBatch::get_array_memory_size()`.** The existing
+  measurement seam (`streaming.rs:647`) uses exactly this. But it can only be read
+  *after* `rows_to_record_batch` has already allocated and copied every value —
+  discovering a 512 MiB batch is oversized after paying for it is not a cap, it is
+  a report. It would also force a re-split (build, measure, discard, rebuild),
+  turning the "~1.0–1.1× throughput" budget into a guaranteed regression.
+- **Pre-batch, via a running per-row estimate.** Maintain a `usize` accumulator
+  next to `buffer`; on each `buffer.push(row)` add
+  `estimate_arrow_row_bytes(&self.columns, &row)`; trip the flush when the
+  accumulator would exceed the cap. Costs one extra pass over the row's values —
+  the same asymptotic order the conversion already pays, and on the *narrow* path
+  the accumulator never trips, so the cost is a few adds per row.
+- **Hybrid: estimate to decide, `get_array_memory_size()` to verify in tests.**
+  Production uses the estimate; the test suite asserts the realised batch against
+  the estimate so the two can never silently diverge.
+
+**Recommendation: pre-batch accumulation, with `get_array_memory_size()` retained
+only as the test-side oracle** (the hybrid). This is the only option that bounds
+allocation rather than reporting it.
+
+## (b) The cap's currency — payload bytes vs. Arrow buffer capacity
+
+**This is the crux, and it contradicts the naive reading of the acceptance
+criteria.** `get_array_memory_size()` sums Arrow `Buffer::capacity()`, not
+buffer length. `arrow_convert.rs:666/686` build variable-width columns with
+`StringArray::from(Vec<Option<&str>>)` / `BinaryArray::from(Vec<Option<&[u8]>>)`,
+which route through arrow-53's `FromIterator` → `MutableBuffer::new(0)` +
+`reserve`, and `MutableBuffer::reserve` grows to
+`max(round_upto_multiple_of_64(required), capacity * 2)` — **power-of-two
+doubling from zero**. Reported memory therefore exceeds payload by a factor that
+depends on where the payload lands relative to the next power of two, approaching
+2× in the worst case.
+
+Measured directly against this tree's arrow 53 (throwaway probe, not committed):
+
+| shape | payload bytes | `get_array_memory_size()` | ratio |
+|---|---:|---:|---:|
+| `BinaryArray` 8192 × 300 B | 2,457,600 | 4,227,256 | **1.720** |
+| `BinaryArray` 8192 × 180 B | 1,474,560 | 2,130,104 | **1.445** |
+| `BinaryArray` 512 × 8192 B | 4,194,304 | 4,196,536 | 1.001 |
+| `BinaryArray` 100 × 64 KiB | 6,553,600 | 8,389,176 | 1.280 |
+| `StringArray` 8192 × 290 B | 2,375,680 | 4,227,256 | **1.779** |
+| `StringArray` 8192 × 20 B | 163,840 | 295,096 | **1.801** |
+
+Options:
+
+- **Cap on `get_array_memory_size()` (capacity currency).** Matches the quantity
+  `streaming.rs:647` already meters and the quantity #2821 would naturally budget.
+  But it is **not computable before the batch exists** — it is a property of an
+  allocator's growth policy, not of the data — so it cannot be the trigger (§a).
+  It is also jumpy: the same payload can report 1.0× or 1.8× depending on
+  power-of-two proximity, making a cap on it non-monotonic in row count.
+- **Cap on payload bytes (buffer lengths).** Estimable from the rows in hand,
+  monotonic in row count, and stable across arrow versions and allocator policy.
+  The cost is that the guarantee must be *stated in payload terms*, with the
+  capacity relationship published as a separate, named factor.
+
+**Recommendation: the cap is normatively defined over Arrow *payload* bytes**,
+with a published companion constant `BATCH_BYTES_CAPACITY_FACTOR = 2` and a
+per-column fixed slack, so any consumer (notably #2821) can convert:
+`worst_case_get_array_memory_size ≤ 2 × cap + slack`.
+
+**Contradiction recorded (for the owner at Seam 1).** The task framing states
+"a 4 MiB batch cap + an 8 MiB egress ceiling = **12 MiB**, inside B4 ≤16Mi, with
+headroom." That arithmetic is only true in *payload* currency. `streaming.rs:647`
+— the seam #2821 will extend — meters **capacity**. In capacity currency a 4 MiB
+payload cap is worst-case ≈ 8 MiB, so `8 MiB ceiling + 8 MiB batch = 16 MiB` —
+**exactly B4, with zero headroom**, not 12 MiB with headroom. Three ways out, for
+the owner to pick:
+
+1. **Keep the 4 MiB payload default; #2821 budgets in capacity currency** and sets
+   its ceiling to ≈6 MiB so `6 + 8 = 14 MiB < 16Mi`. This change publishes the
+   factor; #2821 does the arithmetic. *(Recommended — keeps #2825's default as
+   decided and localises the correction to the dependent.)*
+2. **Drop the default to 2 MiB payload** (worst-case ≈4 MiB capacity), restoring
+   the literal "4 MiB batch + 8 MiB ceiling = 12 MiB" figure in capacity currency.
+   Safe against every *measured* narrow shape in-tree (§c) but only ~1.4× above the
+   field-model narrow batch, which is thinner headroom than the criterion "no
+   throughput regression on narrow rows" deserves.
+3. **Have #2821 meter payload bytes too**, converting `streaming.rs:647`'s
+   accounting. Cleanest currency-wise but changes an existing metric's meaning —
+   out of scope here and a breaking observability change.
+
+This change is written to **option 1**. Options 2 and 3 are recorded so the Seam-1
+decision is on the record rather than implied.
+
+## (c) The default — is 4 MiB safe for narrow rows?
+
+The criterion "no throughput regression on narrow rows" reduces to: *on narrow
+shapes the row-cap must still trip first*, i.e. `8192 × narrow_row_bytes < cap`.
+
+**Contradiction recorded.** The "~300 B/row → ~2.4 MB batch" figure in the task
+framing is arithmetically right (`8192 × 300 = 2,457,600 B = 2.34 MiB`) but the
+300 B/row input is the weakest number in the research corpus and is internally
+contradicted. It derives from `docs/research/phase1-6-parallelism.md:261`, itself
+a throughput *ratio* (`phase0-scan-cost-breakdown-2026-07.md:74`: 880 MB ÷ 3 M
+rows = 293 B/row) — not a measured row width. The same corpus records **~82 B/row
+uncompressed on disk** (`docs/research/phase1-3-linux-io.md:87`), and an 82 B
+on-disk row cannot become a 293 B Arrow row (Arrow adds ~8 B of offsets over raw
+text; the SSTable *adds* framing). `docs/research/phase1-5-transport-ingest.md:195`
+independently models the same shape at **~180 B/row → 1.47 MB/batch**. The
+generator that would settle it (`gen_bigtable`) is not in this tree.
+
+The **in-repo** narrow shapes, measured, not modelled:
+
+| narrow shape | bytes/row | full 8192-row batch | headroom to 4 MiB |
+|---|---:|---:|---:|
+| `test_fixtures.rs:51` `KEYVALUE_ROWS` (`k1`/`1`) | ~11 | — (3 rows exist) | — |
+| `issue_1494` fixture `k{i:06}`/`v{i}` — **measured `get_array_memory_size` of a real 8192-row 2-col batch: 196,976 B** | ~20 | ~192 KiB | **~22×** |
+| `many_partition_fixture` (`streaming_tests.rs:16`, `id int`/`name text` 1 char/`score int`) | ~13 | ~107 KiB | ~39× |
+| field model, `phase1-5:195` | ~180 | 1.47 MB | **~2.9×** |
+| the contested 300 B/row figure | 300 | 2.34 MiB | 1.7× |
+
+Options: `1 MiB` (binds on the field model — rejected), `2 MiB` (§b option 2),
+`4 MiB` (row-cap trips first under every estimate, including the contested one),
+`8 MiB` (halves the B4 headroom for no narrow-path benefit).
+
+**Recommendation: `DEFAULT_MAX_BATCH_BYTES = 4 * 1024 * 1024`.** The decided
+default holds: even at the pessimistic 300 B/row the narrow row-cap still trips
+first in payload currency (2.34 MiB < 4 MiB), and at the honest ≤180 B/row the
+margin is ~2.9×. Two caveats to carry into the docs: (i) at the contested 300 B/row
+the *capacity* reading of a full narrow batch is already 4,227,256 B — above 4 MiB
+— which is precisely why the cap must be payload-denominated (§b), and (ii) gRPC's
+default inbound limit is 4 MB and the Java client sets no `maxInboundMessageSize`
+(`phase1-5:196-199`), so a cap set *at* 4 MiB of payload leaves the client's own
+default limit no framing headroom — a note for the connector, not a blocker here
+(IPC wire bytes ≠ payload bytes, and Flight's own client default already exceeds it).
+
+## (d) The estimator — what to reuse, and why nothing existing is conservative
+
+Three per-`Value` estimators exist. **None is conservative for this purpose as-is.**
+
+1. `Value::size_estimate` — `cqlite-core/src/types.rs:930`, `pub`, recursive
+   per-variant. Models the **serialized** size: adds a vint length prefix per
+   variable-length value and counts UDT `type_name`/`keyspace`/field-name strings.
+   For a short `Text` it adds a **1-byte** vint where Arrow spends **4 B of offset
+   + a validity bit** → it *under-counts* a narrow text cell by ~3 B. Also uses
+   plain `+`, not `saturating_add`, and has no recursion-depth cap.
+2. `crate::memory::estimate_value_size` — `cqlite-core/src/memory/mod.rs:89`,
+   `pub(crate)` and `#[cfg(feature = "state_machine")]`. Pure content bytes, no
+   overhead at all (`Text(s) => s.len()`) → under-counts every variable-width cell
+   by the full 4 B offset + validity bit.
+3. `Memtable::estimate_value_size` — `storage/write_engine/memtable.rs:227`,
+   private. The hardened one (iterative `SmallVec` worklist, `MAX_ESTIMATE_NODES`
+   cap, fails closed to `usize::MAX`, all `saturating_add`) but unreachable and,
+   like (2), content-only.
+
+`estimate_query_row_bytes` (`cqlite-core/src/query/result_budget.rs:32`) is
+`pub(crate)` in a `pub(crate) mod` (`query/mod.rs:29`), has exactly one call site
+(`result_budget.rs:46`), and simply sums (2) over `row.values` plus
+`row.key.as_bytes().len()`.
+
+**Blast radius of exposing it:** small in edit count — the fn *and* `mod
+result_budget` must both become `pub` (or a `pub use` added in `query/mod.rs`),
+and the new public symbol must carry `#[cfg(feature = "state_machine")]` because
+its callee is gated (`cqlite-flight` gets `state_machine` transitively via
+`cqlite-core/features = ["arrow"]`, `cqlite-core/Cargo.toml:364`, so the flight
+build is fine, but an ungated `pub` breaks `--no-default-features`). **But the
+edit size is not the objection.** `estimate_query_row_bytes` is the wrong seam
+on three counts: it is *Arrow-blind* (takes no `&[ColumnInfo]`, so it cannot know
+which columns are projected or which CQL types become variable-width Arrow
+arrays), it adds `row.key` bytes that never enter the batch, and it models no
+structural overhead — so its error is signed **negative** exactly where it
+matters. Exposing an under-estimator as the foundation of #2821's bound would
+make that bound void.
+
+Options: (i) expose `estimate_query_row_bytes` and add a fudge factor in
+`cqlite-flight` — rejected, an unnamed fudge factor is not a contract;
+(ii) write the estimator in `cqlite-flight` — rejected, the CQL→Arrow type mapping
+lives in `export/`, and duplicating it there guarantees drift when
+`convert_column_to_array` gains a type; (iii) a new estimator in `cqlite-core/src/export/`
+beside the converter that owns the mapping.
+
+**Recommendation: (iii).** A new module `cqlite-core/src/export/arrow_size.rs`
+(new file — `arrow_convert.rs` is 2,596 lines, already far over the campsite
+threshold), exporting
+
+```rust
+#[cfg(feature = "arrow")]
+pub fn estimate_arrow_row_bytes(columns: &[ColumnInfo], row: &QueryRow) -> usize
+```
+
+re-exported from `export/mod.rs` next to `rows_to_record_batch`. It walks
+`columns` (never the whole `values` map), resolves each cell the same way
+`transpose_columns` does, and for each cell adds:
+
+- the **content bytes** of the value (reusing `memory::estimate_value_size`'s
+  per-variant shape, hardened like the memtable estimator: iterative, node-capped,
+  `saturating_add` throughout, fails closed to a large value rather than panicking);
+- a per-cell **structural addend** `ARROW_CELL_OVERHEAD_BYTES` covering the
+  offsets entry (4 B for `Utf8`/`Binary`/`List`/`Map`) and the validity bit
+  (rounded up to 1 B) — the term every existing estimator omits;
+- for collection/struct columns, a per-**element** structural addend, because a
+  `ListArray` pays child offsets + child validity per element, not per row.
+
+Conservatism is a **contract, not an aspiration**: the spec requires a property
+test over a corpus of shapes asserting
+`Σ estimate_arrow_row_bytes(...) ≥ payload_bytes(rows_to_record_batch(...))`,
+where `payload_bytes` sums buffer *lengths* (recursively over child data), so a
+future type addition that the estimator does not know about fails the test rather
+than silently under-counting. `result_budget.rs` is left untouched — no visibility
+change, no blast radius.
+
+## (e) Liveness: the one-row floor
+
+If a single row's estimate exceeds the whole cap, "flush before the cap is
+exceeded" would flush an empty buffer forever. The rule is therefore ordered:
+**push first, then test** — a batch is cut when the buffer is non-empty *and* the
+accumulated estimate has reached the cap. Consequences, all specified: a
+2 GiB-blob row yields a one-row batch (never dropped); `--max-batch-bytes 0` and
+`--max-batch-bytes 1` both degrade to one row per batch rather than hanging (the
+same clamp posture as `batch_size.max(1)` at `producer.rs:422` / `service.rs:327`);
+and the `i32::MAX` `checked_value_bytes` guard remains the fail-closed backstop for
+the single row that cannot be represented at all.
+
+## (f) Library-vs-binary posture for the knob
+
+`CqliteFlightService::new` is deliberately **unconstrained** for admission
+(`service.rs:304-316`: `new()` → `with_admission(.., Admission::unconstrained())`),
+so library embedders keep pre-#2420 behaviour and only the binary opts in.
+
+The byte-cap is different in kind: an unbounded batch is a *memory-safety* hazard,
+not a policy choice, and the 4 MiB default is a no-op on every narrow shape. Making
+it opt-in would leave every library embedder exposed to the very hazard the change
+exists to close, and would leave #2821 unable to state a bound for the library path.
+
+**Recommendation: the byte-cap defaults ON for every construction path**, including
+`CqliteFlightService::new` and `MergeProducer::new`/`with_spec`. An embedder that
+genuinely wants the old behaviour sets `usize::MAX`. This divergence from the
+admission precedent is deliberate and is recorded here rather than discovered later.
+
+## Recommended package (for Seam-1 approval)
+
+1. Pre-batch accumulation; `get_array_memory_size()` is the **test oracle only** §(a).
+2. Cap denominated in **Arrow payload bytes**, with `BATCH_BYTES_CAPACITY_FACTOR = 2`
+   published so consumers can convert to capacity §(b). **#2821's 12 MiB arithmetic
+   is revised to `6 MiB ceiling + 8 MiB worst-case batch = 14 MiB < 16Mi`.**
+3. `DEFAULT_MAX_BATCH_BYTES = 4 MiB` — the decided default, verified to leave the
+   narrow row-cap binding under every available estimate §(c).
+4. New `cqlite_core::export::estimate_arrow_row_bytes`; `result_budget.rs`
+   untouched; conservatism enforced by a property test §(d).
+5. Push-then-test one-row floor; `0`/`1` clamp to one row per batch §(e).
+6. Cap on by default on every construction path §(f).
+7. `--max-batch-bytes` / `CQLITE_MAX_BATCH_BYTES` / `DEFAULT_MAX_BATCH_BYTES`,
+   mirroring `admission.rs:43/51` + `main.rs:43`, echoed in the `main.rs:109-116`
+   startup log.
+
+## Placement and file-size (campsite rule, epic #1116)
+
+Already over threshold and therefore to receive **minimal** edits (a field, a
+parameter, an accumulator — all logic in new modules):
+`cqlite-flight/src/producer.rs` (3,330), `cqlite-flight/src/service.rs` (2,036),
+`cqlite-core/src/export/arrow_convert.rs` (2,596). Adding even a field grows them,
+so the `file-size` ratchet will trip; the implementer re-runs with
+`CQLITE_ALLOW_FILE_GROWTH=1` and leaves a note linking #1116, per CLAUDE.md.
+`cqlite-flight/src/streaming.rs` (768/800) has ~35 lines of headroom — **do not**
+put byte accounting there. New code lands in
+`cqlite-core/src/export/arrow_size.rs` and `cqlite-flight/src/batch_bytes.rs`
+(+ a `#[path]` sibling `batch_bytes_tests.rs`, the `admission.rs`/`admission_tests.rs`
+precedent). `cqlite-flight/src/streaming_tests.rs` is at 1,336/1,500 — the wide-row
+fixture and its tests go in the new sibling test file, not there.
+
+## References
+
+- Issue #2825 (T4 byte-bounded batch sizing); epic #2817; dependent issue #2821
+  (streaming `do_get` result-budget wiring gap).
+- `docs/architecture/throughput-program-2026-07.md` §4 lever T4 (`:158`), §7 M11
+  (`:383-387`), B4 definition (`:41`).
+- `docs/research/phase2-verify-transport.md` (T4 SURVIVES-minor),
+  `docs/research/phase2-verify-parallelism.md:94-100` (the 57,344 correction).
+- Precedent: `openspec/changes/archive/2026-07-14-flight-admission-control/`
+  (const + env + clap + service-field knob chain).

--- a/openspec/changes/egress-batch-byte-cap/proposal.md
+++ b/openspec/changes/egress-batch-byte-cap/proposal.md
@@ -1,0 +1,136 @@
+# Byte-bounded Arrow egress batches — a dual row-cap / byte-cap batch boundary (issue #2825, T4/M11)
+
+## Why
+
+`cqlite-flight` finishes an Arrow record batch on **row count alone**. Verified on
+`main`, both egress build sites are row-capped and nothing else:
+
+- `cqlite-flight/src/producer.rs:951` — `if buffer.len() >= self.batch_size { sink.emit(self.flush_buffer(&mut buffer)?)?; }`,
+  flushing `Vec<QueryRow>` (declared `producer.rs:888`) through
+  `flush_buffer` (`producer.rs:1222`).
+- `cqlite-flight/src/producer_stream.rs:206` — the identical trip, flushing through
+  `flush` (`producer_stream.rs:87`).
+- Both call `cqlite_core::export::rows_to_record_batch`
+  (`cqlite-core/src/export/arrow_convert.rs:197`).
+- `rg 'estimate|get_array_memory_size' cqlite-flight/src/producer*.rs` → **zero hits**.
+  No byte accounting exists anywhere in the batch-accumulation path.
+
+`batch_size` defaults to 8192 (`cqlite-flight/src/main.rs:35-36` →
+`service.rs:327` → `producer.rs:422`). A batch's byte size is therefore
+`8192 × row_width`, an **unbounded** function of schema shape: a table with a
+64 KiB blob column produces a 512 MiB batch from the same code path that produces
+a 192 KiB batch for `cassandra_easy_stress.keyvalue`. Peak resident egress payload
+is `(DO_GET_CHANNEL_CAPACITY = 4 + ~2 in-flight) × batch_size` rows
+(`cqlite-flight/src/streaming.rs:59-66`) — a bound stated in **rows**, which on
+wide rows says nothing about memory.
+
+Two concrete consequences already recorded in-tree:
+
+- **B4 peak hazard.** The ratified B4 budget is **≤16Mi per-query working set at
+  concurrency 1** (`docs/architecture/throughput-program-2026-07.md:41`). A
+  row-only bound cannot hold it for any schema.
+- **A fail-closed cliff, not graceful degradation.** `checked_value_bytes`
+  (`arrow-convert.rs:128`) already rejects a batch whose cumulative Utf8/Binary
+  bytes exceed `i32::MAX`, and its own error text prescribes the fix: *"reduce the
+  batch row count (byte-bounded batching)"*. The remedy the code names does not exist.
+
+Issue **#2821 (streaming `do_get` result-budget wiring gap)** is parked on this
+change: its acceptance requires a per-stream egress ceiling whose guaranteed bound
+is `ceiling + one maximum batch`, which is only expressible once "one maximum
+batch" is a bounded quantity. This change is what makes #2821's B4 clause
+satisfiable.
+
+- **Milestone:** 0.17 scan-path throughput program, epic #2817; manifest item M11
+  (`docs/architecture/throughput-program-2026-07.md:383-387`), lever T4.
+- **Design-driven** — there is **no parity oracle** for a batch boundary. Where a
+  batch ends is invisible to `sstabledump`, to the Cassandra format, and to query
+  semantics. The cap's *currency* (payload bytes vs Arrow buffer capacity), its
+  default, its estimator's conservatism contract, and the operator knob's surface
+  are product/API decisions. Requires Seam-1 owner approval.
+- **Creates capability** `flight-batch-byte-cap`.
+- **Robustness/correctness lever, NOT a throughput lever.** The issue's own
+  acceptance sets throughput impact at ~1.0–1.1×; the binding requirement is *no
+  regression on narrow rows*.
+
+## What Changes
+
+- **A dual-trigger batch boundary.** A batch is finished on whichever of the
+  row-cap (`batch_size`, default 8192) or a new **byte-cap** trips **first**,
+  wired at **both** flush sites (`producer.rs` and `producer_stream.rs`). A cap
+  present in only one path is a wiring-evidence failure, so both are specified and
+  both are tested.
+- **A conservative pre-materialization byte estimator.** The boundary decision is
+  made **while rows accumulate**, before any `RecordBatch` exists — building a
+  batch to discover it is too big defeats the purpose, so
+  `RecordBatch::get_array_memory_size()` cannot be the trigger. A new
+  `cqlite_core::export::estimate_arrow_row_bytes(&[ColumnInfo], &QueryRow)`
+  returns a per-row width that **MUST NOT systematically under-estimate** the
+  row's Arrow payload contribution; a running sum is compared against the cap at
+  each `buffer.push`.
+- **An honest, named estimate-vs-reality tolerance.** The cap's currency is
+  **Arrow payload bytes** (the sum of buffer *lengths*). It is NOT
+  `get_array_memory_size()`, which reports buffer **capacity**; the batch
+  construction path (`StringArray::from` / `BinaryArray::from`,
+  `arrow_convert.rs:666/686`) grows `MutableBuffer` by power-of-two doubling, so
+  reported memory runs up to ~2× payload (measured in this change: 1.72–1.80× on
+  realistic shapes). The spec names both quantities and the factor between them
+  rather than asserting exactness.
+- **`DEFAULT_MAX_BATCH_BYTES = 4 MiB`**, chosen so the row-cap still trips first on
+  every narrow shape in the tree (design §b carries the arithmetic and the two
+  contradictions it exposes).
+- **A real operator knob**, mirroring the `--max-concurrent-scans` precedent
+  exactly: `DEFAULT_MAX_BATCH_BYTES` const + `ENV_MAX_BATCH_BYTES`
+  (`CQLITE_MAX_BATCH_BYTES`) + `--max-batch-bytes` clap arg
+  (`cqlite-flight/src/main.rs`, the crate's only config surface) → service field →
+  both producers, proven end-to-end through a real streamed `do_get`.
+- **A liveness floor: always at least one row per batch.** A single row wider than
+  the whole cap is still delivered as a one-row batch — never dropped, never an
+  infinite loop.
+- **A self-contained synthetic wide-row fixture** beside the existing
+  `cqlite-flight/src/test_fixtures.rs` shapes. It must NOT depend on the fetched
+  `test_wide_rows` dataset: a dataset-backed byte-cap test would pass vacuously on
+  an empty dataset, which the testing doctrine forbids.
+- **One documentation correction.** `docs/architecture/throughput-program-2026-07.md:385`
+  (§7 manifest item M11) still cites the stale `57,344-row` egress figure. That
+  number is a ~15% over-count — it multiplies in `IN_FLIGHT_ALLOWANCE = 3`, which
+  is `#[cfg(test)]`-only (`cqlite-flight/src/streaming.rs:86-87`); real production
+  residency is `(4 + ~2) × 8192 ≈ 49,152 rows`. The correction is already recorded
+  at `docs/research/phase2-verify-parallelism.md:94-100`.
+
+## Non-goals
+
+- **No change to the read path or intra-partition materialization.** #1476/#2230/#2423
+  bound what a merge materializes per partition; this bounds only the *egress batch
+  boundary*. No overlap.
+- **No streaming egress byte budget.** The per-stream in-flight ceiling is **#2821**,
+  which consumes this change's published per-batch bound. This change bounds one
+  batch, not the channel.
+- **No change to `DO_GET_CHANNEL_CAPACITY`** (`streaming.rs:66`) and no new knob
+  for it. That constant's doc comment records a deliberate prior decision against
+  making it configurable; this change only makes its rows-denominated bound
+  translatable into bytes.
+- **No throughput optimisation.** Any measured speed-up is incidental. No
+  correctness test may assert on wall-clock (#2642 / `roborev-lints`).
+- **No change to `checked_value_bytes`'s `i32::MAX` fail-closed guard.** The
+  byte-cap makes hitting it far less likely; it stays as the backstop.
+- **No compression, no IPC-framing accounting, no client-side `maxInboundMessageSize`
+  change.** Arrow-IPC wire size is a different (smaller) quantity than payload
+  bytes; this change does not claim to bound it.
+- **No edits to the dated research snapshots** (`phase1-6-parallelism.md`,
+  `phase2-verify-row-engine.md`, `phase2-verify-transport.md`,
+  `phase2-verify-parallelism.md`). They are analysis records; the doc footprint of
+  this change is the single M11 line.
+
+## Doctrine impact
+
+- **No-heuristics (#28):** unaffected. The estimator derives width from the
+  authoritative `ColumnInfo` CQL types plus the decoded `Value`s already in hand —
+  it never infers a type from byte patterns and never changes a decode decision.
+- **Memory budget:** strictly improves it. Turns an unbounded `8192 × row_width`
+  egress batch into a configured ceiling, which is the whole point of the lever.
+- **Public binding surfaces:** Python/Node/CLI unchanged. The new
+  `cqlite_core::export::estimate_arrow_row_bytes` is additive and
+  `#[cfg(feature = "arrow")]`-gated; the new `--max-batch-bytes` flag is additive
+  with a default that preserves today's behaviour on every narrow shape.
+- **Operator docs:** `--max-batch-bytes` joins the flight/ops knob documentation
+  and the `main.rs` startup log line alongside `--max-concurrent-scans`.

--- a/openspec/changes/egress-batch-byte-cap/specs/flight-batch-byte-cap/spec.md
+++ b/openspec/changes/egress-batch-byte-cap/specs/flight-batch-byte-cap/spec.md
@@ -87,8 +87,27 @@ The estimator SHALL also be bounded ABOVE: the structural slack it charges per
 Arrow slot MUST NOT scale with a cell's element count, or a collection-heavy or
 wide-schema row would be over-estimated by a multiple and the byte-cap would cut
 batches far short of the configured size. Per-buffer costs SHALL therefore be
-charged once per projected COLUMN, and the residual per-slot costs SHALL be
-derived from Arrow's buffer layout rather than fitted to the validation corpus.
+charged at most once per projected COLUMN, and the residual per-slot costs SHALL
+be derived from Arrow's buffer layout rather than fitted to the validation corpus.
+
+The per-column residual SHALL be charged ONLY for a column whose builder can
+materialize an Arrow array node corresponding to no value slot. A column whose
+Arrow representation is a single node with no children — every fixed-width
+builder in particular — SHALL NOT be charged it, so a fixed-width column costs
+its validity byte plus its content width and no more. A row of 100 fixed-width
+`int` columns SHALL therefore still admit a full `batch_size` batch under
+`DEFAULT_MAX_BATCH_BYTES`.
+
+The estimator's work bounds SHALL be scoped so that a LEGAL Cassandra row shape
+never fails closed: the budget that bounds structural fan-out SHALL be applied
+per COLUMN rather than per row, and a slot that cannot fan out further SHALL NOT
+consume it. A single collection near Cassandra's classic 65,535-element limit, or
+several thousand-element collections spread across a row's columns, SHALL be
+estimated exactly rather than saturating — a saturated width cuts every
+subsequent batch after one row, which is a throughput cliff rather than a
+conservative memory decision. Pathological STRUCTURE (nesting or
+container-of-container fan-out beyond the budget) SHALL still fail closed, and no
+relaxation SHALL be achieved by under-counting.
 
 #### Scenario: the summed estimate is at least the realized batch payload across a shape corpus
 
@@ -129,13 +148,44 @@ derived from Arrow's buffer layout rather than fitted to the validation corpus.
   batch under the default cap, so the row-cap remains the binding boundary on
   narrow shapes
 
+#### Scenario: a wide fixed-width row is guarded PAST the point the byte-cap would bind
+
+- **GIVEN** rows of 64 and of 100 fixed-width `int` columns — both wider than the
+  point at which charging the per-column residual for a fixed-width column would
+  have made the byte-cap bind
+- **WHEN** each row's estimate is multiplied by `batch_size`
+- **THEN** the product is at or below `DEFAULT_MAX_BATCH_BYTES`, so the ROW-cap
+  still binds, and the estimate is still at or above the realized payload of a
+  batch of those rows
+
+#### Scenario: a single flat map cell with one row pins the per-column residual
+
+- **GIVEN** a flat (untyped) `map` column with exactly ONE row whose cell is empty
+  or absent — the tightest case of the residual's derivation, where the childless
+  key and value child arrays are not amortized over many rows
+- **WHEN** the shape is estimated and converted
+- **THEN** the estimate is at or above the realized payload, so a change to the
+  residual constant fails on this shape rather than passing silently
+
 #### Scenario: a pathological value fails closed rather than panicking
 
-- **GIVEN** a deeply nested collection value beyond the estimator's node budget,
-  or a value whose widths would overflow `usize`
+- **GIVEN** a deeply nested collection value beyond the estimator's structural
+  node budget, a container fan-out beyond it, a leaf fan-out beyond the linear
+  work bound, or a value whose widths would overflow `usize`
 - **WHEN** it is estimated
 - **THEN** the estimator returns a saturated (large) width and the batch is cut,
   with no panic, no overflow, and no unbounded recursion
+
+#### Scenario: a wide but legal collection is estimated exactly rather than failing closed
+
+- **GIVEN** a row with one collection cell near Cassandra's classic
+  65,535-element limit, and separately a row with thousands of elements in each of
+  ~20 collection columns
+- **WHEN** each is estimated and then batched at the default cap
+- **THEN** neither estimate saturates, the resulting batches hold more than one
+  row where the real payload allows it, and every estimate is still at or above
+  the realized payload — the cliff is removed by counting correctly, not by
+  under-counting
 
 ### Requirement: The relationship between the estimate, the payload bytes, and the reported Arrow memory size is stated with a named tolerance
 
@@ -347,6 +397,15 @@ per-stream in-flight ceiling can derive its guaranteed bound of
 `ceiling + one maximum batch` and demonstrate it fits the ratified B4 budget of
 ≤16Mi per-query working set at concurrency 1.
 
+The documentation of that composition MUST NOT state the composed
+`ceiling + one maximum batch` figure as a bound already in force. It SHALL state
+plainly that this change guarantees a bound on ONE batch only; that per-stream
+egress residency remains COUNT-bounded at roughly seven batches (approximately
+56 MiB worst case at the default cap) because the `get_array_memory_size()`
+reading taken on the streaming path feeds metrics only and gates nothing; and
+that the composed figure becomes true only once issue #2821 enforces a per-stream
+byte ceiling.
+
 #### Scenario: the worst-case per-batch capacity is derivable from the named constants
 
 - **GIVEN** `DEFAULT_MAX_BATCH_BYTES`, the capacity factor and the per-array-node
@@ -365,11 +424,21 @@ per-stream in-flight ceiling can derive its guaranteed bound of
 
 #### Scenario: the B4 arithmetic for the dependent issue is recorded in the metered currency
 
-- **GIVEN** that the egress path meters batch bytes with
-  `get_array_memory_size()` (capacity currency)
+- **GIVEN** that the streaming egress path reads batch bytes with
+  `get_array_memory_size()` (capacity currency) for its metrics
 - **WHEN** the composition with issue #2821's per-stream ceiling is documented
 - **THEN** the arithmetic is stated in that same capacity currency and shown to sit
   inside B4's ≤16Mi at concurrency 1, rather than mixing payload and capacity figures
+
+#### Scenario: the composed bound is not presented as already in force
+
+- **GIVEN** the module documentation of the byte-cap
+- **WHEN** the #2821 composition section is read by the implementer of that issue
+- **THEN** it states that only the per-batch bound holds today, that per-stream
+  residency is still count-bounded at ~7 batches (~56 MiB worst case) because the
+  streaming path's `get_array_memory_size()` reading is metrics-only, and that the
+  composed `ceiling + one maximum batch` figure holds only after #2821 enforces
+  the per-stream byte ceiling
 
 ### Requirement: The stale 57,344-row egress figure is corrected in the throughput manifest
 

--- a/openspec/changes/egress-batch-byte-cap/specs/flight-batch-byte-cap/spec.md
+++ b/openspec/changes/egress-batch-byte-cap/specs/flight-batch-byte-cap/spec.md
@@ -1,0 +1,356 @@
+# flight-batch-byte-cap
+
+## ADDED Requirements
+
+### Requirement: An Arrow egress batch is finished on whichever of the row-cap or the byte-cap trips first
+
+Every Arrow record batch produced by the `cqlite-flight` egress path SHALL be
+finished when **either** the configured row-cap (`batch_size`) **or** a configured
+byte-cap is reached, whichever occurs first. The byte-cap MUST be enforced at
+**both** batch-build sites — `cqlite-flight/src/producer.rs` (`flush_buffer`,
+trip at `:951`) and `cqlite-flight/src/producer_stream.rs` (`flush`, trip at
+`:206`) — because a cap wired into only one path leaves the other unbounded.
+
+#### Scenario: wide rows finish batches on the byte-cap before the row-cap
+
+- **GIVEN** the synthetic wide-row fixture and a byte-cap chosen so that fewer
+  than `batch_size` of its rows fit under the cap
+- **WHEN** the table is scanned end to end
+- **THEN** every emitted batch except possibly the last has **strictly fewer than
+  `batch_size` rows** — the byte-cap, not the row-cap, cut the batch
+- **AND** more than one batch is emitted (the fixture is not degenerate)
+- **AND** this assertion FAILS on pre-change `main`, where a single 8192-row batch
+  is produced regardless of width
+
+#### Scenario: narrow rows still finish batches on the row-cap
+
+- **GIVEN** a narrow fixture whose full `batch_size`-row batch is well under the
+  default cap, and the default `DEFAULT_MAX_BATCH_BYTES`
+- **WHEN** at least `2 × batch_size` rows are scanned
+- **THEN** every non-final batch has **exactly `batch_size` rows** — the byte-cap
+  never trips on the narrow path
+- **AND** the batch boundaries are identical to those produced with the byte-cap
+  effectively disabled, proving no narrow-path behaviour change
+
+#### Scenario: the producer.rs merge path honours the byte-cap
+
+- **GIVEN** the wide-row fixture routed through the `MergeProducer` full-scan path
+  (`producer.rs`)
+- **WHEN** it is scanned under a byte-cap smaller than a full row-capped batch
+- **THEN** the emitted batches are byte-cut, not row-cut, on that path specifically
+
+#### Scenario: the producer_stream.rs path honours the byte-cap
+
+- **GIVEN** the same wide-row fixture routed through the streaming producer path
+  (`producer_stream.rs`)
+- **WHEN** it is scanned under the same byte-cap
+- **THEN** the emitted batches are byte-cut on that path too, with the same
+  boundary rule — neither path is left unbounded
+
+### Requirement: The boundary decision is made before the RecordBatch is materialized
+
+The byte-cap SHALL be evaluated against a running estimate accumulated as rows are
+pushed into the buffer, **before** `rows_to_record_batch` allocates the batch. The
+implementation MUST NOT build a `RecordBatch`, measure it, and then split or
+discard it, and MUST NOT use `RecordBatch::get_array_memory_size()` as the
+production trigger.
+
+#### Scenario: no oversized batch is ever allocated
+
+- **GIVEN** a wide-row fixture whose row-capped batch would far exceed the cap
+- **WHEN** the scan runs
+- **THEN** no `RecordBatch` is constructed whose realized payload exceeds the cap
+  by more than the declared tolerance — the oversized batch is never allocated at
+  all, rather than allocated and then rejected or re-split
+
+#### Scenario: the running estimate is accumulated incrementally
+
+- **GIVEN** a buffer accumulating rows toward a batch boundary
+- **WHEN** each row is pushed
+- **THEN** the accumulator is advanced by that row's estimate only, and is reset
+  when the buffer is flushed — the whole buffer is not re-measured per push
+
+### Requirement: The per-row byte estimator is conservative and never systematically under-estimates
+
+A public estimator SHALL report, for a row and a projected column set, a byte
+width greater than or equal to that row's contribution to the resulting Arrow
+batch's payload bytes (the sum of Arrow buffer lengths, recursively including
+child data). The estimator MUST account for per-cell structural overhead (the
+offsets entry and the validity bit) and, for collection/struct columns,
+per-element structural overhead — a content-only sum is insufficient, and a fixed
+per-row constant is not acceptable. The estimator MUST be driven by the
+authoritative `ColumnInfo` CQL types and the decoded values, never by inference
+from byte patterns, and MUST be saturating and recursion-bounded so a pathological
+value fails closed instead of panicking or hanging.
+
+#### Scenario: the summed estimate is at least the realized batch payload across a shape corpus
+
+- **GIVEN** a corpus of row shapes covering fixed-width columns, `text`, `blob`,
+  `list`/`set`, `map`, `tuple`/UDT, all-null rows, empty strings and empty
+  collections
+- **WHEN** each shape's rows are both estimated and converted with
+  `rows_to_record_batch`
+- **THEN** for every shape the summed estimate is **greater than or equal to** the
+  realized batch's payload bytes (buffer lengths summed recursively over child
+  data), with no shape under-counted
+
+#### Scenario: variable-width content drives the estimate
+
+- **GIVEN** two rows with identical column sets whose only difference is the
+  length of a `blob` cell (say 16 B versus 64 KiB)
+- **WHEN** each is estimated
+- **THEN** the estimates differ by at least the content-byte difference — the
+  estimator is width-sensitive, not a per-row constant
+
+#### Scenario: an unmodelled column type fails the conservatism property test
+
+- **GIVEN** a column type that `rows_to_record_batch` converts but the estimator
+  does not model
+- **WHEN** the conservatism property test runs over that shape
+- **THEN** the test FAILS, so a future type addition cannot silently introduce an
+  under-estimate
+
+#### Scenario: a pathological value fails closed rather than panicking
+
+- **GIVEN** a deeply nested collection value beyond the estimator's node budget,
+  or a value whose widths would overflow `usize`
+- **WHEN** it is estimated
+- **THEN** the estimator returns a saturated (large) width and the batch is cut,
+  with no panic, no overflow, and no unbounded recursion
+
+### Requirement: The relationship between the estimate, the payload bytes, and the reported Arrow memory size is stated with a named tolerance
+
+The byte-cap SHALL be normatively denominated in Arrow **payload** bytes. Because
+`get_array_memory_size()` reports Arrow buffer **capacity**, which the batch
+construction path grows by power-of-two doubling, the implementation SHALL publish
+a named capacity conversion constant such that every emitted batch satisfies
+`get_array_memory_size() <= capacity_factor * cap + per_column_slack`. The
+specification MUST NOT assert that an emitted batch's `get_array_memory_size()` is
+less than or equal to the cap.
+
+#### Scenario: every emitted wide-row batch stays within the declared capacity tolerance
+
+- **GIVEN** the wide-row fixture scanned under a configured cap
+- **WHEN** each emitted batch's `get_array_memory_size()` is read
+- **THEN** every batch satisfies
+  `get_array_memory_size() <= capacity_factor * cap + per_column_slack` using the
+  published constants, with no batch exceeding the tolerance
+
+#### Scenario: the payload bound is asserted tightly and separately
+
+- **GIVEN** the same emitted batches
+- **WHEN** each batch's payload bytes (buffer lengths, recursive) are summed
+- **THEN** every batch of two or more rows has payload bytes at or below the cap —
+  the tight bound holds in the cap's own currency, independent of allocator capacity
+
+#### Scenario: the tolerance is expressed as named constants
+
+- **GIVEN** the published capacity factor and per-column slack
+- **WHEN** the tests and documentation reference them
+- **THEN** they are named constants used by both, not inline literals repeated per
+  assertion
+
+### Requirement: Every emitted batch carries at least one row
+
+A batch SHALL never be emitted empty, and a single row whose estimated width
+exceeds the entire byte-cap SHALL still be delivered as a one-row batch. The
+byte-cap MUST NOT drop a row, MUST NOT stall, and MUST NOT loop without progress
+for any cap value, including zero.
+
+#### Scenario: a single row wider than the whole cap is emitted as a one-row batch
+
+- **GIVEN** a fixture containing one row whose estimated width exceeds the entire
+  configured cap
+- **WHEN** the table is scanned
+- **THEN** that row is delivered in a batch of exactly one row, the scan completes,
+  and no row is dropped
+
+#### Scenario: a stream of over-cap rows terminates with one row per batch
+
+- **GIVEN** a fixture of N consecutive rows each individually wider than the cap
+- **WHEN** the table is scanned
+- **THEN** exactly N batches of one row each are emitted, the total row count is N,
+  and the scan terminates — no empty batch, no repeated flush without progress
+
+#### Scenario: a zero or one-byte cap degrades to one row per batch rather than hanging
+
+- **GIVEN** the cap configured to `0` and, separately, to `1`
+- **WHEN** a multi-row narrow table is scanned
+- **THEN** each configuration yields one row per batch, all rows are delivered, and
+  the scan terminates
+
+### Requirement: The byte-cap is a real, wired configuration knob reachable from the flight server CLI
+
+The byte-cap SHALL be settable through a `--max-batch-bytes` CLI flag and a
+`CQLITE_MAX_BATCH_BYTES` environment variable, backed by a named
+`DEFAULT_MAX_BATCH_BYTES` constant of 4 MiB, following the
+`--max-concurrent-scans` const + env-const + clap-arg + service-field precedent.
+Setting the knob MUST change observed batch boundaries end-to-end through a real
+streamed `do_get` — the knob is functional, not decorative. The cap SHALL be
+active on every service and producer construction path by default, and its
+configured value SHALL appear in the server startup log alongside the other knobs.
+
+#### Scenario: two distinct configured cap values produce correspondingly different batch boundaries
+
+- **GIVEN** a flight server started twice over the wide-row fixture with two
+  distinct `--max-batch-bytes` values
+- **WHEN** the same ticket is streamed under each
+- **THEN** the smaller cap yields strictly more batches with strictly fewer rows
+  per batch, demonstrating the configured value — not a hard-coded constant —
+  governs the boundary
+
+#### Scenario: the environment variable governs a real streamed do_get
+
+- **GIVEN** `CQLITE_MAX_BATCH_BYTES` set with no CLI flag present
+- **WHEN** a `do_get` is streamed against the wide-row fixture through the real
+  service surface
+- **THEN** the observed batch boundaries match the environment-configured cap —
+  wiring evidence from the public surface, not a helper-only unit test
+
+#### Scenario: the default applies with neither flag nor environment variable
+
+- **GIVEN** neither `--max-batch-bytes` nor `CQLITE_MAX_BATCH_BYTES` set
+- **WHEN** the server starts and a scan runs
+- **THEN** the effective cap is `DEFAULT_MAX_BATCH_BYTES` (4 MiB) and the startup
+  log records it
+
+#### Scenario: a library embedder constructing the service directly also gets the cap
+
+- **GIVEN** the service and producer constructed through their plain constructors,
+  with no explicit cap supplied
+- **WHEN** a wide-row scan runs
+- **THEN** the default cap is in force — the byte-cap is not opt-in, because an
+  unbounded batch is a memory hazard rather than a policy choice
+
+### Requirement: The byte-cap does not alter result content
+
+Applying the byte-cap SHALL change only where batch boundaries fall. The
+concatenation of the emitted batches MUST contain identical rows, in identical
+order, with identical values and an identical Arrow schema, compared against a run
+at an effectively unbounded cap.
+
+#### Scenario: capped and uncapped runs concatenate to identical results
+
+- **GIVEN** the wide-row fixture and a ticket exercising a projection and a
+  predicate
+- **WHEN** it is streamed once under a small cap and once under an effectively
+  unbounded cap
+- **THEN** the concatenated rows, their order, their values and the Arrow schema
+  are identical between the two runs — only the batch boundaries differ
+
+#### Scenario: lowering the cap does not change the total row count
+
+- **GIVEN** the same fixture scanned under a descending series of cap values
+- **WHEN** the rows of each run are counted
+- **THEN** the total row count is identical for every cap value
+
+### Requirement: Byte-cap behaviour is proven on a self-contained synthetic wide-row fixture
+
+The wide-row coverage SHALL use a deterministic, self-contained fixture defined in
+the test sources — a wide-blob and/or many-column shape — and MUST NOT depend on
+the fetched `test_wide_rows` dataset, so the tests cannot pass vacuously when the
+dataset binaries are absent. The fixture MUST produce more than one batch under
+the configured cap.
+
+#### Scenario: the wide-row fixture is generated in-process with no fetched dataset
+
+- **GIVEN** a checkout with no `CQLITE_DATASETS_ROOT` and no fetched Data.db
+  binaries
+- **WHEN** the byte-cap test suite runs
+- **THEN** the wide-row fixture is generated in-process and every byte-cap test
+  executes with real rows — no skip, no zero-row pass
+
+#### Scenario: the wide-row tests fail rather than pass vacuously
+
+- **GIVEN** the wide-row byte-cap tests
+- **WHEN** a scan yields zero rows or a single batch
+- **THEN** the test FAILS on the non-vacuity assertion before any byte assertion
+  is evaluated
+
+#### Scenario: the wide-row byte-cap tests fail on pre-change main
+
+- **GIVEN** the new tests applied to pre-change `main`
+- **WHEN** they run
+- **THEN** they FAIL, because no byte-cap exists and batches are row-cut only —
+  the tests are real guards, not tautologies
+
+### Requirement: Byte-cap correctness is asserted on measured bytes and row counts, never on wall-clock
+
+No correctness-path test for the byte-cap SHALL assert on elapsed wall-clock time
+or a throughput threshold. Any throughput comparison against the pre-change
+behaviour SHALL live in an `#[ignore]`d performance test annotated
+`perf-gate-allow`. Library code introduced by this change MUST contain no
+`unwrap()`/`expect()` and MUST compile clean under `RUSTFLAGS="-D warnings"`.
+
+#### Scenario: correctness assertions reference only byte totals, row counts and batch counts
+
+- **GIVEN** the byte-cap correctness test suite
+- **WHEN** its assertions are inspected
+- **THEN** every one compares measured byte totals, row counts or batch counts —
+  none compares an elapsed duration against a threshold
+
+#### Scenario: the throughput comparison is an ignored perf test marked perf-gate-allow
+
+- **GIVEN** the ~1.0–1.1× throughput expectation from the issue
+- **WHEN** it is evidenced
+- **THEN** the comparison lives in an `#[ignore]`d test annotated
+  `perf-gate-allow`, excluded from the correctness path and from the default gate run
+
+#### Scenario: the change passes the roborev-lints wall-clock guard and clippy with warnings denied
+
+- **GIVEN** the completed change
+- **WHEN** the agent gate runs
+- **THEN** the `roborev-lints` component passes (no wall-clock threshold in the
+  correctness path) and clippy passes with `RUSTFLAGS="-D warnings"`
+
+### Requirement: The per-batch bound is published so the streaming egress budget can compose on it
+
+The change SHALL publish a per-batch bound expressed in **both** payload and
+capacity currency, stated in terms of the named constants, so that issue #2821's
+per-stream in-flight ceiling can derive its guaranteed bound of
+`ceiling + one maximum batch` and demonstrate it fits the ratified B4 budget of
+≤16Mi per-query working set at concurrency 1.
+
+#### Scenario: the worst-case per-batch capacity is derivable from the named constants
+
+- **GIVEN** `DEFAULT_MAX_BATCH_BYTES`, the capacity factor and the per-column slack
+- **WHEN** a consumer computes the worst-case resident size of one emitted batch
+- **THEN** the value follows from those constants alone, with no undocumented
+  fudge factor, and is documented next to the knob
+
+#### Scenario: the B4 arithmetic for the dependent issue is recorded in the metered currency
+
+- **GIVEN** that the egress path meters batch bytes with
+  `get_array_memory_size()` (capacity currency)
+- **WHEN** the composition with issue #2821's per-stream ceiling is documented
+- **THEN** the arithmetic is stated in that same capacity currency and shown to sit
+  inside B4's ≤16Mi at concurrency 1, rather than mixing payload and capacity figures
+
+### Requirement: The stale 57,344-row egress figure is corrected in the throughput manifest
+
+The M11 manifest line in `docs/architecture/throughput-program-2026-07.md` SHALL
+cite the real production egress residency of approximately 49,152 rows rather than
+the stale 57,344-row figure, which over-counts by folding in the
+`#[cfg(test)]`-only `IN_FLIGHT_ALLOWANCE` constant. The dated research snapshots
+under `docs/research/` SHALL NOT be modified — they are analysis records and the
+correction is already recorded in one of them.
+
+#### Scenario: the M11 manifest line cites the production residency figure
+
+- **GIVEN** `docs/architecture/throughput-program-2026-07.md` §7 item M11
+- **WHEN** the line is read after this change
+- **THEN** it cites approximately 49,152 rows as the production egress residency
+  and no longer asserts 57,344
+
+#### Scenario: the dated research snapshots are left untouched
+
+- **GIVEN** the five dated research documents under `docs/research/`
+- **WHEN** the change's diff is inspected
+- **THEN** none of them appears in it
+
+#### Scenario: the documentation footprint is confined to the manifest line and the new knob
+
+- **GIVEN** the change's documentation diff
+- **WHEN** it is inspected
+- **THEN** it consists of the single M11 manifest correction plus the operator
+  documentation for `--max-batch-bytes`, and nothing else

--- a/openspec/changes/egress-batch-byte-cap/specs/flight-batch-byte-cap/spec.md
+++ b/openspec/changes/egress-batch-byte-cap/specs/flight-batch-byte-cap/spec.md
@@ -83,11 +83,20 @@ authoritative `ColumnInfo` CQL types and the decoded values, never by inference
 from byte patterns, and MUST be saturating and recursion-bounded so a pathological
 value fails closed instead of panicking or hanging.
 
+The estimator SHALL also be bounded ABOVE: the structural slack it charges per
+Arrow slot MUST NOT scale with a cell's element count, or a collection-heavy or
+wide-schema row would be over-estimated by a multiple and the byte-cap would cut
+batches far short of the configured size. Per-buffer costs SHALL therefore be
+charged once per projected COLUMN, and the residual per-slot costs SHALL be
+derived from Arrow's buffer layout rather than fitted to the validation corpus.
+
 #### Scenario: the summed estimate is at least the realized batch payload across a shape corpus
 
 - **GIVEN** a corpus of row shapes covering fixed-width columns, `text`, `blob`,
-  `list`/`set`, `map`, `tuple`/UDT, all-null rows, empty strings and empty
-  collections
+  `list`/`set`, `map`, `tuple`/UDT, JSON, collections nested more than one level
+  deep (including an empty or null cell of such a type, whose declared type tree
+  still materializes one Arrow array per level), a UDT with an empty declared
+  field list, all-null rows, empty strings and empty collections
 - **WHEN** each shape's rows are both estimated and converted with
   `rows_to_record_batch`
 - **THEN** for every shape the summed estimate is **greater than or equal to** the
@@ -110,6 +119,16 @@ value fails closed instead of panicking or hanging.
 - **THEN** the test FAILS, so a future type addition cannot silently introduce an
   under-estimate
 
+#### Scenario: the estimate stays within a bounded multiple of the realized payload
+
+- **GIVEN** the collection-heavy and multi-column shapes of the corpus — where a
+  slack charged per slot rather than per column would inflate the estimate most
+- **WHEN** each shape's summed estimate is compared with its realized payload
+- **THEN** the estimate is within a small, explicitly asserted multiple of the
+  payload, and a wide fixed-width row still leaves room for a full `batch_size`
+  batch under the default cap, so the row-cap remains the binding boundary on
+  narrow shapes
+
 #### Scenario: a pathological value fails closed rather than panicking
 
 - **GIVEN** a deeply nested collection value beyond the estimator's node budget,
@@ -124,24 +143,41 @@ The byte-cap SHALL be normatively denominated in Arrow **payload** bytes. Becaus
 `get_array_memory_size()` reports Arrow buffer **capacity**, which the batch
 construction path grows by power-of-two doubling, the implementation SHALL publish
 a named capacity conversion constant such that every emitted batch satisfies
-`get_array_memory_size() <= capacity_factor * cap + per_column_slack`. The
-specification MUST NOT assert that an emitted batch's `get_array_memory_size()` is
-less than or equal to the cap.
+`get_array_memory_size() <= capacity_factor * max(cap, widest_row_payload)
++ per_array_node_slack * array_nodes`. The specification MUST NOT assert that an
+emitted batch's `get_array_memory_size()` is less than or equal to the cap.
+
+The `max(cap, widest_row_payload)` term SHALL be stated explicitly rather than
+folded into slack: one row cannot be split across Arrow batches, so a row wider
+than the whole cap is an inherent overshoot of the DATA, not of the mechanism. For
+a schema whose widest row fits the cap the bound SHALL reduce to
+`capacity_factor * cap + per_array_node_slack * array_nodes`.
 
 #### Scenario: every emitted wide-row batch stays within the declared capacity tolerance
 
 - **GIVEN** the wide-row fixture scanned under a configured cap
 - **WHEN** each emitted batch's `get_array_memory_size()` is read
 - **THEN** every batch satisfies
-  `get_array_memory_size() <= capacity_factor * cap + per_column_slack` using the
-  published constants, with no batch exceeding the tolerance
+  `get_array_memory_size() <= capacity_factor * max(cap, widest_row_payload)
+  + per_array_node_slack * array_nodes` using the published constants, with no
+  batch exceeding the tolerance
 
 #### Scenario: the payload bound is asserted tightly and separately
 
-- **GIVEN** the same emitted batches
+- **GIVEN** the same emitted batches, over a fixture whose every row fits the cap
 - **WHEN** each batch's payload bytes (buffer lengths, recursive) are summed
-- **THEN** every batch of two or more rows has payload bytes at or below the cap —
-  the tight bound holds in the cap's own currency, independent of allocator capacity
+- **THEN** every batch has payload bytes at or below the cap outright — the
+  boundary cuts BEFORE the row that would cross, so there is no `+ one row`
+  allowance — and the bound holds in the cap's own currency, independent of
+  allocator capacity
+
+#### Scenario: a crossing row that is a large fraction of the cap does not overshoot it
+
+- **GIVEN** a fixture whose rows are each a large fraction of the configured cap
+  (so a boundary that appended the crossing row before testing would emit batches
+  well above the cap)
+- **WHEN** the table is scanned on both egress paths
+- **THEN** every emitted batch's payload bytes are at or below the cap
 
 #### Scenario: the tolerance is expressed as named constants
 
@@ -313,10 +349,19 @@ per-stream in-flight ceiling can derive its guaranteed bound of
 
 #### Scenario: the worst-case per-batch capacity is derivable from the named constants
 
-- **GIVEN** `DEFAULT_MAX_BATCH_BYTES`, the capacity factor and the per-column slack
+- **GIVEN** `DEFAULT_MAX_BATCH_BYTES`, the capacity factor and the per-array-node
+  slack
 - **WHEN** a consumer computes the worst-case resident size of one emitted batch
 - **THEN** the value follows from those constants alone, with no undocumented
   fudge factor, and is documented next to the knob
+
+#### Scenario: the published bound names the single-over-cap-row term
+
+- **GIVEN** a schema whose widest single row exceeds the configured cap
+- **WHEN** the worst-case per-batch bound is computed
+- **THEN** the published function takes that row's payload as an explicit
+  parameter and reports `capacity_factor * max(cap, widest_row_payload) + slack`,
+  so a dependent budget cannot silently inherit a bound that omits the term
 
 #### Scenario: the B4 arithmetic for the dependent issue is recorded in the metered currency
 

--- a/openspec/changes/egress-batch-byte-cap/tasks.md
+++ b/openspec/changes/egress-batch-byte-cap/tasks.md
@@ -52,11 +52,14 @@ headroom — put nothing there. `cqlite-flight/src/streaming_tests.rs` is 1,336/
 - [x] 2.2 Content-bytes walk: hardened per the `memtable.rs:227` precedent —
       iterative worklist, node budget, `saturating_add` throughout, fails closed to
       a saturated width. No `unwrap()`/`expect()`. No panic on nesting depth.
-- [x] 2.3 Structural addends: a named `ARROW_CELL_OVERHEAD_BYTES` per cell (offsets
-      entry + validity bit rounded up) for variable-width Arrow outputs, and a
-      per-**element** addend for `List`/`Set`/`Map`/`Tuple`/UDT child arrays. This
+- [x] 2.3 Structural addends: a named `ARROW_CELL_OVERHEAD_BYTES` per cell (two
+      offsets entries — its own plus the buffer's trailing `n+1`-th — and the
+      validity bit rounded up) for variable-width Arrow outputs, and the same
+      addend per **element** for `List`/`Set`/`Map`/`Tuple`/UDT child arrays. This
       is the term every existing estimator omits and is what makes the estimate
-      conservative rather than an under-count.
+      conservative rather than an under-count. Per-BUFFER slack is charged once
+      per projected column (`ARROW_COLUMN_SLACK_BYTES`), never per slot, so it
+      cannot multiply by a cell's element count (review B3).
 - [x] 2.4 Re-export from `cqlite-core/src/export/mod.rs` beside
       `rows_to_record_batch` (mod.rs:57). Do **not** change
       `cqlite-core/src/query/result_budget.rs` visibility — see design §(d).
@@ -79,9 +82,13 @@ headroom — put nothing there. `cqlite-flight/src/streaming_tests.rs` is 1,336/
 - [x] 3.2 Add `cqlite-flight/src/batch_bytes_tests.rs` wired via `#[path]` (the
       `admission.rs`/`admission_tests.rs` precedent), holding the accumulator unit
       tests and the wide-row fixture tests.
-- [x] 3.3 Push-then-test ordering so a batch is cut only when the buffer is
-      non-empty — the one-row floor of design §(e). Clamp semantics for `0`/`1`
-      documented next to the `batch_size.max(1)` precedent.
+- [x] 3.3 **Test-then-push** ordering so a batch is cut BEFORE the row that would
+      cross the cap is appended, and only when the buffer is non-empty — the
+      one-row floor of design §(e). (Revised from push-then-test in the review
+      round for issue #2825 B1: cutting ON the crossing row let a batch reach
+      `cap - 1 + widest_row`, which the published bound omitted. The bound is now
+      `max(cap, widest_row_payload)`.) Clamp semantics for `0`/`1` documented next
+      to the `batch_size.max(1)` precedent.
 
 ## 4. Producer wiring (both paths — minimal edits)
 

--- a/openspec/changes/egress-batch-byte-cap/tasks.md
+++ b/openspec/changes/egress-batch-byte-cap/tasks.md
@@ -1,0 +1,147 @@
+# Tasks — egress-batch-byte-cap (issue #2825, T4/M11)
+
+Placement note (campsite rule, epic #1116): `cqlite-flight/src/producer.rs` (3,330),
+`cqlite-flight/src/service.rs` (2,036) and `cqlite-core/src/export/arrow_convert.rs`
+(2,596) are **already over** the ~800-line source threshold, so the `file-size`
+ratchet will trip on even a one-field addition. Keep edits to those files to the
+absolute minimum (a field, a parameter, an accumulator); put all logic in the new
+modules below; re-run the gate with `CQLITE_ALLOW_FILE_GROWTH=1` and leave a note
+linking #1116. `cqlite-flight/src/streaming.rs` (768/800) has ~35 lines of
+headroom — put nothing there. `cqlite-flight/src/streaming_tests.rs` is 1,336/1,500
+— new tests go in the new sibling test file.
+
+## 1. TDD guards (must FAIL on main first)
+
+- [ ] 1.1 Wide-row byte-cut test: with the new synthetic wide-row fixture and a cap
+      smaller than a full row-capped batch, assert every non-final batch has
+      **strictly fewer than `batch_size` rows** and that more than one batch is
+      emitted. Surface: `MergeProducer` full-scan (`producer.rs`). FAILS on main.
+- [ ] 1.2 Narrow no-regression test: with a narrow fixture and the default cap,
+      assert every non-final batch has **exactly `batch_size` rows** and that the
+      boundaries equal those at an effectively unbounded cap.
+- [ ] 1.3 Both-paths test: repeat 1.1 through the `producer_stream.rs` `flush` path,
+      asserting the same boundary rule. FAILS on main.
+- [ ] 1.4 One-row floor test: a single row wider than the whole cap is emitted as a
+      one-row batch; N consecutive over-cap rows yield exactly N one-row batches;
+      caps of `0` and `1` yield one row per batch. No drop, no hang. FAILS on main.
+- [ ] 1.5 Capacity-tolerance test: every emitted batch satisfies
+      `get_array_memory_size() <= CAPACITY_FACTOR * cap + slack`, and every
+      multi-row batch's **payload** bytes (buffer lengths, recursive) are `<= cap`.
+      FAILS on main.
+- [ ] 1.6 Estimator conservatism property test: over a shape corpus (fixed-width,
+      `text`, `blob`, `list`/`set`, `map`, `tuple`/UDT, all-null, empty string,
+      empty collection), assert
+      `Σ estimate_arrow_row_bytes(..) >= payload_bytes(rows_to_record_batch(..))`
+      for every shape. Surface: `cqlite_core::export`.
+- [ ] 1.7 Knob test: two distinct `--max-batch-bytes` values produce
+      correspondingly different batch counts/boundaries (proves non-decorative).
+      FAILS on main.
+- [ ] 1.8 End-to-end wiring test: `CQLITE_MAX_BATCH_BYTES` governs a **real
+      streamed `do_get`** through the service surface — wiring evidence, not a
+      helper-only unit test. FAILS on main.
+- [ ] 1.9 Result-invariance test: capped vs effectively-unbounded runs concatenate
+      to identical rows, order, values and Arrow schema; total row count is
+      invariant across a descending series of caps.
+
+## 2. Estimator (`cqlite-core`, NEW file)
+
+- [ ] 2.1 Add `cqlite-core/src/export/arrow_size.rs` with
+      `#[cfg(feature = "arrow")] pub fn estimate_arrow_row_bytes(columns: &[ColumnInfo], row: &QueryRow) -> usize`,
+      walking `columns` (not the whole `values` map) the way
+      `export/arrow_columnar.rs:59` `transpose_columns` resolves cells.
+- [ ] 2.2 Content-bytes walk: hardened per the `memtable.rs:227` precedent —
+      iterative worklist, node budget, `saturating_add` throughout, fails closed to
+      a saturated width. No `unwrap()`/`expect()`. No panic on nesting depth.
+- [ ] 2.3 Structural addends: a named `ARROW_CELL_OVERHEAD_BYTES` per cell (offsets
+      entry + validity bit rounded up) for variable-width Arrow outputs, and a
+      per-**element** addend for `List`/`Set`/`Map`/`Tuple`/UDT child arrays. This
+      is the term every existing estimator omits and is what makes the estimate
+      conservative rather than an under-count.
+- [ ] 2.4 Re-export from `cqlite-core/src/export/mod.rs` beside
+      `rows_to_record_batch` (mod.rs:57). Do **not** change
+      `cqlite-core/src/query/result_budget.rs` visibility — see design §(d).
+- [ ] 2.5 Add a test-only payload-bytes oracle (sum of Arrow buffer **lengths**,
+      recursive over child data) used by 1.5/1.6; keep it test-scoped so it is not
+      new public surface.
+
+## 3. Cap mechanism (`cqlite-flight`, NEW file)
+
+- [ ] 3.1 Add `cqlite-flight/src/batch_bytes.rs` with
+      `pub const DEFAULT_MAX_BATCH_BYTES: usize = 4 * 1024 * 1024;`,
+      `pub const ENV_MAX_BATCH_BYTES: &str = "CQLITE_MAX_BATCH_BYTES";`, the
+      published `BATCH_BYTES_CAPACITY_FACTOR` + per-column slack constants, and a
+      small `BatchByteCap` accumulator (`push(width) -> ShouldFlush`, `reset()`),
+      documented with the §(b)/§(c) rationale.
+- [ ] 3.2 Add `cqlite-flight/src/batch_bytes_tests.rs` wired via `#[path]` (the
+      `admission.rs`/`admission_tests.rs` precedent), holding the accumulator unit
+      tests and the wide-row fixture tests.
+- [ ] 3.3 Push-then-test ordering so a batch is cut only when the buffer is
+      non-empty — the one-row floor of design §(e). Clamp semantics for `0`/`1`
+      documented next to the `batch_size.max(1)` precedent.
+
+## 4. Producer wiring (both paths — minimal edits)
+
+- [ ] 4.1 `cqlite-flight/src/producer.rs`: add the cap field to `MergeProducer`
+      (beside `batch_size`, `:328`), set it in the single `with_spec` funnel
+      (`:409-422`), accumulate at the push site (`:949`) and extend the trip at
+      `:951` to the dual condition. Reset the accumulator in `flush_buffer` (`:1222`).
+- [ ] 4.2 `cqlite-flight/src/producer_stream.rs`: the same at `:118` / `:204` /
+      `:206` / `:87`. Both paths share the `batch_bytes` accumulator — no duplicated
+      boundary logic.
+- [ ] 4.3 Confirm the aggregate and point-read routes reach the same accumulator (or
+      document why a route emits no multi-row batch).
+
+## 5. Configuration (CLI → service → producers)
+
+- [ ] 5.1 `cqlite-flight/src/main.rs`: add
+      `#[arg(long, env = ENV_MAX_BATCH_BYTES, default_value_t = DEFAULT_MAX_BATCH_BYTES)] max_batch_bytes: usize`
+      to `struct Args` (`:25-51`) with a doc comment carrying the sizing rationale,
+      mirroring `--max-concurrent-scans` (`:38-44`).
+- [ ] 5.2 Thread it into `CqliteFlightService` (`service.rs:286` field,
+      `:314`/`:320` constructors) and on into `MergeProducer::with_spec`
+      (`service.rs:427`). Per design §(f) the cap is **on by default on every
+      construction path**, unlike `Admission::unconstrained()` — record that
+      divergence in the constructor doc comment.
+- [ ] 5.3 Add `max_batch_bytes` to the startup log line (`main.rs:109-116`).
+
+## 6. Fixtures
+
+- [ ] 6.1 Add a deterministic, self-contained synthetic wide-row fixture (wide blob
+      and/or many-column shape) beside `cqlite-flight/src/test_fixtures.rs`'s
+      existing shapes. It MUST NOT depend on the fetched `test_wide_rows` dataset.
+- [ ] 6.2 Give every wide-row test a non-vacuity assertion (rows > 0 **and**
+      batches > 1) that runs before any byte assertion.
+
+## 7. Performance evidence (outside the correctness path)
+
+- [ ] 7.1 Add the ~1.0–1.1× throughput comparison as an `#[ignore]`d test annotated
+      `perf-gate-allow`. **No** wall-clock threshold anywhere in the correctness
+      path (#2642 / `roborev-lints`).
+- [ ] 7.2 Confirm `cqlite-flight/tests/issue_1494_producer_mem_budget.rs` still
+      passes under `--features dhat-heap` (its `BATCH_SIZE = 8192` / narrow ~20 B/row
+      fixture is a single sub-cap batch, so the cap must be a no-op there).
+
+## 8. Docs
+
+- [ ] 8.1 Correct the **single** M11 line at
+      `docs/architecture/throughput-program-2026-07.md:385` — `57,344-row` →
+      the production `~49,152-row` residency. Do **not** touch the five dated
+      `docs/research/` snapshots.
+- [ ] 8.2 Document `--max-batch-bytes` / `CQLITE_MAX_BATCH_BYTES` in the flight/ops
+      knob docs, including the payload-vs-capacity currency and the published
+      worst-case per-batch capacity bound that #2821 composes on.
+- [ ] 8.3 Post the revised B4 arithmetic (design §(b)) as a comment on **issue
+      #2821**, which is parked on this change: its ceiling must be budgeted in
+      capacity currency, not payload.
+
+## 9. Endgame
+
+- [ ] 9.1 `--lite` green each fix round (summary-file redirect).
+- [ ] 9.2 `rust-reviewer` + roborev on the lite-green diff, **before** the full gate.
+- [ ] 9.3 ONE full `scripts/agent-gate.sh` inside `flow-closer`; record the
+      `AGENT-GATE SUMMARY`. Note the `CQLITE_ALLOW_FILE_GROWTH=1` justification
+      (#1116) if the ratchet trips on `producer.rs`/`service.rs`.
+- [ ] 9.4 `spec-auditor` (C) against `openspec/changes/egress-batch-byte-cap/specs/**`.
+- [ ] 9.5 Final roborev clean → arm `gh pr merge --auto --squash --delete-branch`
+      after `scripts/flow/premerge-assert.sh`.
+- [ ] 9.6 `openspec archive egress-batch-byte-cap` at finalize.

--- a/openspec/changes/egress-batch-byte-cap/tasks.md
+++ b/openspec/changes/egress-batch-byte-cap/tasks.md
@@ -12,131 +12,135 @@ headroom — put nothing there. `cqlite-flight/src/streaming_tests.rs` is 1,336/
 
 ## 1. TDD guards (must FAIL on main first)
 
-- [ ] 1.1 Wide-row byte-cut test: with the new synthetic wide-row fixture and a cap
+- [x] 1.1 Wide-row byte-cut test: with the new synthetic wide-row fixture and a cap
       smaller than a full row-capped batch, assert every non-final batch has
       **strictly fewer than `batch_size` rows** and that more than one batch is
       emitted. Surface: `MergeProducer` full-scan (`producer.rs`). FAILS on main.
-- [ ] 1.2 Narrow no-regression test: with a narrow fixture and the default cap,
+- [x] 1.2 Narrow no-regression test: with a narrow fixture and the default cap,
       assert every non-final batch has **exactly `batch_size` rows** and that the
       boundaries equal those at an effectively unbounded cap.
-- [ ] 1.3 Both-paths test: repeat 1.1 through the `producer_stream.rs` `flush` path,
+- [x] 1.3 Both-paths test: repeat 1.1 through the `producer_stream.rs` `flush` path,
       asserting the same boundary rule. FAILS on main.
-- [ ] 1.4 One-row floor test: a single row wider than the whole cap is emitted as a
+- [x] 1.4 One-row floor test: a single row wider than the whole cap is emitted as a
       one-row batch; N consecutive over-cap rows yield exactly N one-row batches;
       caps of `0` and `1` yield one row per batch. No drop, no hang. FAILS on main.
-- [ ] 1.5 Capacity-tolerance test: every emitted batch satisfies
+- [x] 1.5 Capacity-tolerance test: every emitted batch satisfies
       `get_array_memory_size() <= CAPACITY_FACTOR * cap + slack`, and every
       multi-row batch's **payload** bytes (buffer lengths, recursive) are `<= cap`.
       FAILS on main.
-- [ ] 1.6 Estimator conservatism property test: over a shape corpus (fixed-width,
+- [x] 1.6 Estimator conservatism property test: over a shape corpus (fixed-width,
       `text`, `blob`, `list`/`set`, `map`, `tuple`/UDT, all-null, empty string,
       empty collection), assert
       `Σ estimate_arrow_row_bytes(..) >= payload_bytes(rows_to_record_batch(..))`
       for every shape. Surface: `cqlite_core::export`.
-- [ ] 1.7 Knob test: two distinct `--max-batch-bytes` values produce
+- [x] 1.7 Knob test: two distinct `--max-batch-bytes` values produce
       correspondingly different batch counts/boundaries (proves non-decorative).
       FAILS on main.
-- [ ] 1.8 End-to-end wiring test: `CQLITE_MAX_BATCH_BYTES` governs a **real
+- [x] 1.8 End-to-end wiring test: `CQLITE_MAX_BATCH_BYTES` governs a **real
       streamed `do_get`** through the service surface — wiring evidence, not a
       helper-only unit test. FAILS on main.
-- [ ] 1.9 Result-invariance test: capped vs effectively-unbounded runs concatenate
+- [x] 1.9 Result-invariance test: capped vs effectively-unbounded runs concatenate
       to identical rows, order, values and Arrow schema; total row count is
       invariant across a descending series of caps.
 
 ## 2. Estimator (`cqlite-core`, NEW file)
 
-- [ ] 2.1 Add `cqlite-core/src/export/arrow_size.rs` with
+- [x] 2.1 Add `cqlite-core/src/export/arrow_size.rs` with
       `#[cfg(feature = "arrow")] pub fn estimate_arrow_row_bytes(columns: &[ColumnInfo], row: &QueryRow) -> usize`,
       walking `columns` (not the whole `values` map) the way
       `export/arrow_columnar.rs:59` `transpose_columns` resolves cells.
-- [ ] 2.2 Content-bytes walk: hardened per the `memtable.rs:227` precedent —
+- [x] 2.2 Content-bytes walk: hardened per the `memtable.rs:227` precedent —
       iterative worklist, node budget, `saturating_add` throughout, fails closed to
       a saturated width. No `unwrap()`/`expect()`. No panic on nesting depth.
-- [ ] 2.3 Structural addends: a named `ARROW_CELL_OVERHEAD_BYTES` per cell (offsets
+- [x] 2.3 Structural addends: a named `ARROW_CELL_OVERHEAD_BYTES` per cell (offsets
       entry + validity bit rounded up) for variable-width Arrow outputs, and a
       per-**element** addend for `List`/`Set`/`Map`/`Tuple`/UDT child arrays. This
       is the term every existing estimator omits and is what makes the estimate
       conservative rather than an under-count.
-- [ ] 2.4 Re-export from `cqlite-core/src/export/mod.rs` beside
+- [x] 2.4 Re-export from `cqlite-core/src/export/mod.rs` beside
       `rows_to_record_batch` (mod.rs:57). Do **not** change
       `cqlite-core/src/query/result_budget.rs` visibility — see design §(d).
-- [ ] 2.5 Add a test-only payload-bytes oracle (sum of Arrow buffer **lengths**,
-      recursive over child data) used by 1.5/1.6; keep it test-scoped so it is not
-      new public surface.
+- [x] 2.5 Add a payload-bytes oracle (sum of Arrow buffer **lengths**, recursive
+      over child data) used by 1.5/1.6. **Deviation:** published as
+      `pub fn cqlite_core::export::arrow_payload_bytes` rather than test-scoped.
+      It is needed by tests in TWO crates (`cqlite-core` and `cqlite-flight`) and
+      by issue #2821, and a test-scoped version would have to be duplicated
+      per-crate and would drift. It is the cap's normative currency (spec Req 4),
+      so publishing it beside the estimator is the honest surface.
 
 ## 3. Cap mechanism (`cqlite-flight`, NEW file)
 
-- [ ] 3.1 Add `cqlite-flight/src/batch_bytes.rs` with
+- [x] 3.1 Add `cqlite-flight/src/batch_bytes.rs` with
       `pub const DEFAULT_MAX_BATCH_BYTES: usize = 4 * 1024 * 1024;`,
       `pub const ENV_MAX_BATCH_BYTES: &str = "CQLITE_MAX_BATCH_BYTES";`, the
       published `BATCH_BYTES_CAPACITY_FACTOR` + per-column slack constants, and a
       small `BatchByteCap` accumulator (`push(width) -> ShouldFlush`, `reset()`),
       documented with the §(b)/§(c) rationale.
-- [ ] 3.2 Add `cqlite-flight/src/batch_bytes_tests.rs` wired via `#[path]` (the
+- [x] 3.2 Add `cqlite-flight/src/batch_bytes_tests.rs` wired via `#[path]` (the
       `admission.rs`/`admission_tests.rs` precedent), holding the accumulator unit
       tests and the wide-row fixture tests.
-- [ ] 3.3 Push-then-test ordering so a batch is cut only when the buffer is
+- [x] 3.3 Push-then-test ordering so a batch is cut only when the buffer is
       non-empty — the one-row floor of design §(e). Clamp semantics for `0`/`1`
       documented next to the `batch_size.max(1)` precedent.
 
 ## 4. Producer wiring (both paths — minimal edits)
 
-- [ ] 4.1 `cqlite-flight/src/producer.rs`: add the cap field to `MergeProducer`
+- [x] 4.1 `cqlite-flight/src/producer.rs`: add the cap field to `MergeProducer`
       (beside `batch_size`, `:328`), set it in the single `with_spec` funnel
       (`:409-422`), accumulate at the push site (`:949`) and extend the trip at
       `:951` to the dual condition. Reset the accumulator in `flush_buffer` (`:1222`).
-- [ ] 4.2 `cqlite-flight/src/producer_stream.rs`: the same at `:118` / `:204` /
+- [x] 4.2 `cqlite-flight/src/producer_stream.rs`: the same at `:118` / `:204` /
       `:206` / `:87`. Both paths share the `batch_bytes` accumulator — no duplicated
       boundary logic.
-- [ ] 4.3 Confirm the aggregate and point-read routes reach the same accumulator (or
+- [x] 4.3 Confirm the aggregate and point-read routes reach the same accumulator (or
       document why a route emits no multi-row batch).
 
 ## 5. Configuration (CLI → service → producers)
 
-- [ ] 5.1 `cqlite-flight/src/main.rs`: add
+- [x] 5.1 `cqlite-flight/src/main.rs`: add
       `#[arg(long, env = ENV_MAX_BATCH_BYTES, default_value_t = DEFAULT_MAX_BATCH_BYTES)] max_batch_bytes: usize`
       to `struct Args` (`:25-51`) with a doc comment carrying the sizing rationale,
       mirroring `--max-concurrent-scans` (`:38-44`).
-- [ ] 5.2 Thread it into `CqliteFlightService` (`service.rs:286` field,
+- [x] 5.2 Thread it into `CqliteFlightService` (`service.rs:286` field,
       `:314`/`:320` constructors) and on into `MergeProducer::with_spec`
       (`service.rs:427`). Per design §(f) the cap is **on by default on every
       construction path**, unlike `Admission::unconstrained()` — record that
       divergence in the constructor doc comment.
-- [ ] 5.3 Add `max_batch_bytes` to the startup log line (`main.rs:109-116`).
+- [x] 5.3 Add `max_batch_bytes` to the startup log line (`main.rs:109-116`).
 
 ## 6. Fixtures
 
-- [ ] 6.1 Add a deterministic, self-contained synthetic wide-row fixture (wide blob
+- [x] 6.1 Add a deterministic, self-contained synthetic wide-row fixture (wide blob
       and/or many-column shape) beside `cqlite-flight/src/test_fixtures.rs`'s
       existing shapes. It MUST NOT depend on the fetched `test_wide_rows` dataset.
-- [ ] 6.2 Give every wide-row test a non-vacuity assertion (rows > 0 **and**
+- [x] 6.2 Give every wide-row test a non-vacuity assertion (rows > 0 **and**
       batches > 1) that runs before any byte assertion.
 
 ## 7. Performance evidence (outside the correctness path)
 
-- [ ] 7.1 Add the ~1.0–1.1× throughput comparison as an `#[ignore]`d test annotated
+- [x] 7.1 Add the ~1.0–1.1× throughput comparison as an `#[ignore]`d test annotated
       `perf-gate-allow`. **No** wall-clock threshold anywhere in the correctness
       path (#2642 / `roborev-lints`).
-- [ ] 7.2 Confirm `cqlite-flight/tests/issue_1494_producer_mem_budget.rs` still
+- [x] 7.2 Confirm `cqlite-flight/tests/issue_1494_producer_mem_budget.rs` still
       passes under `--features dhat-heap` (its `BATCH_SIZE = 8192` / narrow ~20 B/row
       fixture is a single sub-cap batch, so the cap must be a no-op there).
 
 ## 8. Docs
 
-- [ ] 8.1 Correct the **single** M11 line at
+- [x] 8.1 Correct the **single** M11 line at
       `docs/architecture/throughput-program-2026-07.md:385` — `57,344-row` →
       the production `~49,152-row` residency. Do **not** touch the five dated
       `docs/research/` snapshots.
-- [ ] 8.2 Document `--max-batch-bytes` / `CQLITE_MAX_BATCH_BYTES` in the flight/ops
+- [x] 8.2 Document `--max-batch-bytes` / `CQLITE_MAX_BATCH_BYTES` in the flight/ops
       knob docs, including the payload-vs-capacity currency and the published
       worst-case per-batch capacity bound that #2821 composes on.
-- [ ] 8.3 Post the revised B4 arithmetic (design §(b)) as a comment on **issue
+- [x] 8.3 Post the revised B4 arithmetic (design §(b)) as a comment on **issue
       #2821**, which is parked on this change: its ceiling must be budgeted in
       capacity currency, not payload.
 
 ## 9. Endgame
 
-- [ ] 9.1 `--lite` green each fix round (summary-file redirect).
+- [x] 9.1 `--lite` green each fix round (summary-file redirect).
 - [ ] 9.2 `rust-reviewer` + roborev on the lite-green diff, **before** the full gate.
 - [ ] 9.3 ONE full `scripts/agent-gate.sh` inside `flow-closer`; record the
       `AGENT-GATE SUMMARY`. Note the `CQLITE_ALLOW_FILE_GROWTH=1` justification


### PR DESCRIPTION
Closes #2825. Part of epic #2817 (0.17 scan-path throughput program), manifest item M11.

## What

Arrow egress batches now finish on whichever of the **row-cap** (`batch_size`, 8192) or a new **byte-cap** trips first, so wide rows can no longer scale a batch without limit. New knob `--max-batch-bytes` / `CQLITE_MAX_BATCH_BYTES`, `DEFAULT_MAX_BATCH_BYTES = 4 MiB`.

Wired at **all three** batch-build sites: `producer.rs` drive loop, `producer_stream.rs` drive loop, and `aggregate_paths` (the third was missed by the original terrain mapping and found during implementation).

## Currency — payload, not capacity (owner decision)

The cap is denominated in **Arrow payload bytes**, because the boundary decision must be made while rows accumulate, before the `RecordBatch` exists. `get_array_memory_size()` reports allocated **capacity**, which is a different quantity — measured ratios 1.72-1.80x at typical widths.

`BATCH_BYTES_CAPACITY_FACTOR = 2` is published as the worst-case payload→capacity bound. It is a genuine bound, not a fitted maximum: `MutableBuffer::reserve` gives `capacity <= max(round64(len), 2*capacity_prev)`, so per buffer `capacity < 2*len` for `len >= 64`.

## Bound

`worst_case_batch_capacity_bytes(cap, n_array_nodes, widest_row_payload) = 2 * max(cap, widest_row_payload) + 1024 * n_array_nodes`

The `max(cap, widest_row)` term is load-bearing: a single row wider than the whole cap must still be emitted (splitting one row across Arrow batches is not possible here), so that overshoot is **inherent, not a defect**. `checked_value_bytes` (`arrow_convert.rs:128`) does **not** bound per-cell size — it only rejects cumulative column length above `i32::MAX`, never clamps.

## Scope boundary — what this does NOT yet guarantee

This bounds **per-batch** size only. Per-stream egress residency remains **count**-bounded (`DO_GET_CHANNEL_CAPACITY = 4` plus ~3 in flight), so worst-case resident egress today is **~7 x 8 MiB ~= 56 MiB**. The `6 + 8 = 14 MiB` B4 composition is a **target for #2821**, not in force — #2821 adds the per-stream byte ceiling that makes it true. Documented explicitly in `batch_bytes.rs` so the #2821 implementer cannot read it as already holding.

## Estimator

New `cqlite_core::export::estimate_arrow_row_bytes` (`export/arrow_size.rs` + `arrow_size_shape.rs` + `arrow_size_render.rs`). `estimate_query_row_bytes` was deliberately NOT reused — it is Arrow-blind, counts `row.key` bytes that never enter the batch, and models zero structural overhead, so its error is signed negative exactly where it matters.

Slack constants are derived, not fitted: `ARROW_CELL_OVERHEAD_BYTES = 2*4 + 1 = 9` (an offsets buffer over n slots is `(n+1)*4`; two entries per slot cover the trailing entry for all n>=1, tight at n=1), `ARROW_VALIDITY_BYTES = 1` per slot, `ARROW_COLUMN_SLACK_BYTES = 8` charged only for shapes that can materialize childless array nodes.

## Review history — 3 rounds, 8 blockers

Reviewed by roborev + `rust-reviewer` before the full gate (review-first), then re-reviewed after each fix round.

Round 2 (5 blockers): published bound omitted the crossing-row overshoot (boundary switched push-then-test → **test-then-push**); conservatism contract false for deeply-nested empty collections; slack charged per-slot not per-buffer (**9x** over-cut on `list<int>`); empty-field-list UDT omitted field names; `Value::Text` non-UTF-8 under-counted 3x via `from_utf8_lossy`.

Round 3 (3 blockers): fixed-width columns over-charged → byte-cap bound at **>=40 int columns**, an ordinary schema (now **>=103**, `int` cost 13 → 5 B/row); `MAX_ESTIMATE_NODES` exhaustion degraded a legal schema to **one row per batch indefinitely** (budgets now reset per column and only *branching* slots spend nodes — a 65,535-entry map costs 1 node, not 131,070; no charge changed, so conservatism is preserved); module doc asserted the #2821 composition as in force.

**Extra bug found during fixes, not from either review**: routing `Text`/`Ascii`/`Varchar` to the typed arm was wrong because `convert_column_to_array` dispatches on `data_type` **alone** — a `cql_type=Text` / `data_type=Blob` column is built by `build_binary_array` and was charged **zero content bytes**. Now carried as a `TextFidelity` flag. `rust-reviewer` re-verified the full dispatch mirror and found no second instance.

Guard tests are placed **past** the predicted break point (64 and 100 columns), after two rounds where a guard sat just inside the boundary and gave false assurance.

## Measured

| shape | before | after |
|---|---|---|
| `list<int>` x1000 estimate vs realized | 9x | 1.2x |
| 30-int-column rows before 4 MiB cap | 4,000 | 10,750 |
| byte-cap binds at N int columns | >=40 | >=103 |

## Tests

Synthetic, deterministic, self-contained wide-row fixture (`wide_row_fixture.rs`, `test-util`-gated) — no dependence on the fetched `test_wide_rows` dataset, so it cannot pass vacuously on an empty dataset. Includes an in-tree pre-change control (`without_the_byte_cap_the_wide_scan_is_one_oversized_row_cut_batch`) and a discriminating conservatism property test that a plausible naive estimator actually trips. End-to-end test spawns the real binary and streams a real `do_get`.

Payload assertions were **tightened** across rounds (`cap + one row` → `cap`); no test was weakened.

## Notes for the gate

Run with `CQLITE_ALLOW_FILE_GROWTH=1` — `producer.rs` (3,330→3,396) and `service.rs` (2,036→2,068) were **already far over** the ~800 threshold before this change (epic #1116). All new logic lives in new files, each well under threshold.

## Follow-ups filed

- #2896 — pre-existing `blocking_tasks_gauge_tracks_real_streaming_do_get` flake (races a process-global counter; not caused by this change)
- #2897 — skip per-row estimation when the cap is disabled (`usize::MAX`), plus missing collection-heavy throughput evidence

## Spec

OpenSpec change `egress-batch-byte-cap` — 10 requirements, 33+ scenarios, updated across all three rounds to stay in step with the code. `openspec validate --strict` passes.