### PR TITLE
docs(process): lesson 25 — re-read issue state at claim time (CLOSED and abandoned look identical to the lock signals)

### DIFF
--- a/process_improvements.md
+++ b/process_improvements.md
@@ -715,3 +715,28 @@ issues have landed). Keep entries short so a future reader can re-run the measur
       `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` — that restores SKIPs and buys a
       vacuous PASS, which is exactly what #2078's fail-closed exists to
       prevent.
+  25. **2026-07-26 — re-read the ISSUE STATE at claim time, not just the claim ref
+      and branch: a CLOSED issue is indistinguishable from an abandoned one by
+      the lock signals alone.** A lead working #2043 had read #1883 at session
+      start (genuinely OPEN, board `In Progress`, spec Seam-1 approved, spec-only
+      branch on origin). Hours later, on finishing #2043, it claimed #1883 and
+      created a worktree — but a *different* session had delivered #1883 in the
+      meantime (PR #2904 merged, issue CLOSED COMPLETED, OpenSpec change
+      archived). Every signal the claim protocol checks was clean and *looked
+      like an abandoned claim to adopt*: no `refs/claims/issue-1883` (the finisher
+      released it on completion), no `issue-1883-*` branch (deleted on merge), and
+      a stale board `Status=In Progress`. The near-miss was caught only
+      incidentally — `git rebase origin/main` replayed the stale spec commit and
+      printed the parent, `chore(#1883): archive rust-per-row-alloc-budget …`,
+      which is what revealed the work was already done. **Standing lesson:** the
+      absence of a claim ref + absence of a branch is ambiguous — it means EITHER
+      "abandoned, adopt it" OR "finished, stay away." The disambiguator is the
+      issue's own state. Re-read `gh issue view <N> --json state,stateReason`
+      IMMEDIATELY before `claim.sh claim`, and treat `CLOSED` as a hard stop
+      regardless of board Status (the board mirror lags; a completed issue's
+      board item is routinely left stale by the finishing session). Note the
+      deleted branch is itself weak evidence of completion — a finished 1:1:1:1
+      cycle deletes its branch, so branch-absence + issue-CLOSED is the
+      already-shipped signature. Cost here: one wasted claim/worktree cycle and a
+      duplicate spec commit that had to be discarded; cost had it gone unnoticed:
+      a second PR re-implementing merged work.


### PR DESCRIPTION
Docs-only. Records a real dup-work near-miss from this session so the pickup rule closes the gap.

**What happened.** A lead working #2043 read #1883 at session start — genuinely OPEN, board `Status=In Progress`, Seam 1 approved, spec-only branch on origin. Hours later, on finishing #2043, it claimed #1883 and built a worktree. But a **different session had already delivered #1883** in the meantime: PR #2904 merged 17:35:47Z, issue CLOSED COMPLETED, OpenSpec change archived at `openspec/changes/archive/2026-07-26-rust-per-row-alloc-budget`, telemetry stamped via #2929.

**Why the claim protocol didn't catch it.** Every signal it checks was clean, and all of them read as *"abandoned claim, go adopt it"*:
- no `refs/claims/issue-1883` — the finishing session correctly released it on completion;
- no `issue-1883-*` branch — correctly deleted on merge;
- board `Status=In Progress` — stale, left behind by the finishing session.

The near-miss surfaced only incidentally: `git rebase origin/main` replayed the stale spec commit and printed its new parent, `chore(#1883): archive rust-per-row-alloc-budget …`.

**The lesson.** Absence of a claim ref + absence of a branch is **ambiguous** — it means EITHER "abandoned, adopt it" OR "finished, stay away." The disambiguator is the issue's own state, and nothing in the current pickup rule re-reads it at claim time. So: run `gh issue view <N> --json state,stateReason` **immediately before** `claim.sh claim`, and treat `CLOSED` as a hard stop regardless of board Status — the board mirror lags, and a completed issue's board item is routinely left stale by the session that finished it. Branch-absence is itself weak evidence of completion (a finished 1:1:1:1 cycle deletes its branch), so **branch-absent + issue-CLOSED is the already-shipped signature**.

Cost this time: one wasted claim/worktree cycle and a duplicate spec commit, discarded before any implementation. Cost if unnoticed: a second PR re-implementing merged work.

No code changes; appends lesson 25 to `process_improvements.md`.