### PR TITLE
fix(#2945): sanctioned resume past the legacy-branch guard — empty-lease adopt --expect none + audited reason, and close an identity-forgery hole

### DIFF
--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -37,6 +37,8 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
    if ! bash scripts/flow/claim.sh claim <N>; then
      echo "CLAIM LOST — another session holds refs/claims/issue-<N>. Take the next item."
      # (Adopting a reaped claim instead? Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>)
+     # (Refused with reason=legacy-branch-lock — a FREE claim ref but an issue-<N>-* branch
+     #  still on origin? Resume it: claim.sh adopt <N> --expect none --reason <why>, #2945)
    fi
    # CLAIM HELD → set up the worktree + branch. The branch is naming/PR plumbing, NOT the lock:
    wt=".claude/worktrees/issue-<N>-<slug>"

--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -38,7 +38,9 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
      echo "CLAIM LOST — another session holds refs/claims/issue-<N>. Take the next item."
      # (Adopting a reaped claim instead? Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>)
      # (Refused with reason=legacy-branch-lock — a FREE claim ref but an issue-<N>-* branch
-     #  still on origin? Resume it: claim.sh adopt <N> --expect none --reason <why>, #2945)
+     #  still on origin? Resume it: claim.sh adopt <N> --expect none --reason <why>, #2945 —
+     #  but ONLY when the refusal itself prints that command at open-prs=0; a
+     #  `remediation=withheld open-prs=<n>` line means an endgame may be live: confirm first)
    fi
    # CLAIM HELD → set up the worktree + branch. The branch is naming/PR plumbing, NOT the lock:
    wt=".claude/worktrees/issue-<N>-<slug>"

--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -37,14 +37,13 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
    if ! bash scripts/flow/claim.sh claim <N>; then
      echo "CLAIM LOST — another session holds refs/claims/issue-<N>. Take the next item."
      # (Adopting a reaped claim instead? Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>)
-     # (Refused with reason=legacy-branch-lock — a FREE claim ref but an issue-<N>-* branch
-     #  still on origin? Resume it: claim.sh adopt <N> --expect none --reason <concrete why>,
-     #  #2945 — but ONLY by running the command the refusal itself PRINTS (reason pre-filled;
-     #  it is printed only at open-prs=0 + all branch tips carrying their OWN commits and
-     #  staler than 4h + no fresh machine-claim/heartbeat ref; the branch this skill pushes
-     #  below has NO commits of its own, so its lane is never advertised as stale).
-     #  A `remediation=withheld <signals>` line means the lane
-     #  may be LIVE or is unproven: confirm ownership first, never resume blind)
+     # (Refused with reason=legacy-branch-lock ... claim-ref=free — a FREE claim ref but an
+     #  issue-<N>-* branch still on origin? The sanctioned resume is
+     #  `claim.sh adopt <N> --expect none --reason <concrete why>` (#2945). The refusal
+     #  deliberately does NOT print it: CONFIRM the lane is abandoned first —
+     #  `claim-heartbeat.sh should-reap <machine>` (age > 4h AND no open PR AND pid-dead if
+     #  local), board Status, branch/PR author. Never resume blind, never hand-craft a claim
+     #  commit)
    fi
    # CLAIM HELD → set up the worktree + branch. The branch is naming/PR plumbing, NOT the lock:
    wt=".claude/worktrees/issue-<N>-<slug>"

--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -39,7 +39,9 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
      # (Adopting a reaped claim instead? Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>)
      # (Refused with reason=legacy-branch-lock ... claim-ref=free — a FREE claim ref but an
      #  issue-<N>-* branch still on origin? The sanctioned resume is
-     #  `claim.sh adopt <N> --expect none --reason <concrete why>` (#2945). The refusal
+     #  `claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:branch-outlived-claim`
+     #  (#2945 — a placeholder reason, or one still carrying an unsubstituted <…>, is
+     #  rejected with exit 64, so substitute a concrete why). The refusal
      #  deliberately does NOT print it: CONFIRM the lane is abandoned first —
      #  `claim-heartbeat.sh should-reap <machine>` (age > 4h AND no open PR AND pid-dead if
      #  local), board Status, branch/PR author. Never resume blind, never hand-craft a claim

--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -40,8 +40,10 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
      # (Refused with reason=legacy-branch-lock — a FREE claim ref but an issue-<N>-* branch
      #  still on origin? Resume it: claim.sh adopt <N> --expect none --reason <concrete why>,
      #  #2945 — but ONLY by running the command the refusal itself PRINTS (reason pre-filled;
-     #  it is printed only at open-prs=0 + all branch tips staler than 4h + no fresh
-     #  machine-claim/heartbeat ref). A `remediation=withheld <signals>` line means the lane
+     #  it is printed only at open-prs=0 + all branch tips carrying their OWN commits and
+     #  staler than 4h + no fresh machine-claim/heartbeat ref; the branch this skill pushes
+     #  below has NO commits of its own, so its lane is never advertised as stale).
+     #  A `remediation=withheld <signals>` line means the lane
      #  may be LIVE or is unproven: confirm ownership first, never resume blind)
    fi
    # CLAIM HELD → set up the worktree + branch. The branch is naming/PR plumbing, NOT the lock:

--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -38,9 +38,11 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
      echo "CLAIM LOST — another session holds refs/claims/issue-<N>. Take the next item."
      # (Adopting a reaped claim instead? Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>)
      # (Refused with reason=legacy-branch-lock — a FREE claim ref but an issue-<N>-* branch
-     #  still on origin? Resume it: claim.sh adopt <N> --expect none --reason <why>, #2945 —
-     #  but ONLY when the refusal itself prints that command at open-prs=0; a
-     #  `remediation=withheld open-prs=<n>` line means an endgame may be live: confirm first)
+     #  still on origin? Resume it: claim.sh adopt <N> --expect none --reason <concrete why>,
+     #  #2945 — but ONLY by running the command the refusal itself PRINTS (reason pre-filled;
+     #  it is printed only at open-prs=0 + all branch tips staler than 4h + no fresh
+     #  machine-claim/heartbeat ref). A `remediation=withheld <signals>` line means the lane
+     #  may be LIVE or is unproven: confirm ownership first, never resume blind)
    fi
    # CLAIM HELD → set up the worktree + branch. The branch is naming/PR plumbing, NOT the lock:
    wt=".claude/worktrees/issue-<N>-<slug>"

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -66,6 +66,9 @@ never gate stdout or review churn.
      # `reason=legacy-branch-lock` refusal, which prints this command verbatim)?
      # Use: bash scripts/flow/claim.sh adopt <N> --expect none --reason <why>
      # (#2945 — git's empty lease: still server-arbitrated, records who + why).
+     # The refusal prints that command ONLY at open-prs=0; if it says
+     # `remediation=withheld open-prs=<n>`, an endgame may be LIVE — confirm
+     # ownership (board + PR author) before resuming, do not resume blind.
      # NEVER hand-craft a claim commit to get past the guard.
      if ! bash scripts/flow/claim.sh claim <N>; then
        echo "CLAIM LOST — another machine holds refs/claims/issue-<N>. Take the next item (or fetch to RESUME)."; exit 0

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -68,9 +68,11 @@ never gate stdout or review churn.
      #   bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:<branch>
      # (#2945 — git's empty lease: still server-arbitrated, records who + why; a
      # placeholder reason like <why> is refused). It is printed ONLY when the lane
-     # is demonstrably orphaned: open-prs=0 AND every issue-<N>-* branch tip staler
-     # than the 4h reap threshold AND no fresh machine-claim/heartbeat ref naming
-     # the issue. `remediation=withheld <signals>` = LIVE or unproven — confirm
+     # is demonstrably orphaned: open-prs=0 AND every issue-<N>-* branch tip carrying
+     # its OWN commits and staler than the 4h reap threshold AND no fresh machine-
+     # claim/heartbeat ref naming the issue (a commit-less branch, i.e. one still at
+     # origin/main, has NO age signal: newest-branch-tip=no-own-commits, withheld).
+     # `remediation=withheld <signals>` = LIVE or unproven — confirm
      # ownership (board + branch/PR author) before resuming, do not resume blind.
      # NEVER hand-craft a claim commit to get past the guard.
      if ! bash scripts/flow/claim.sh claim <N>; then

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -63,17 +63,15 @@ never gate stdout or review churn.
      # competitor can no longer double-claim. Adopting a reaped claim instead?
      # Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>.
      # RESUMING an issue whose issue-<N>-* branch outlived its claim ref (the
-     # `reason=legacy-branch-lock` refusal, which prints this command verbatim)?
-     # Use the command the refusal PRINTS (reason pre-filled):
+     # `reason=legacy-branch-lock ... claim-ref=free` refusal)? The sanctioned command:
      #   bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:<branch>
      # (#2945 — git's empty lease: still server-arbitrated, records who + why; a
-     # placeholder reason like <why> is refused). It is printed ONLY when the lane
-     # is demonstrably orphaned: open-prs=0 AND every issue-<N>-* branch tip carrying
-     # its OWN commits and staler than the 4h reap threshold AND no fresh machine-
-     # claim/heartbeat ref naming the issue (a commit-less branch, i.e. one still at
-     # origin/main, has NO age signal: newest-branch-tip=no-own-commits, withheld).
-     # `remediation=withheld <signals>` = LIVE or unproven — confirm
-     # ownership (board + branch/PR author) before resuming, do not resume blind.
+     # placeholder reason like <why> is refused). The refusal DIAGNOSES (branch +
+     # claim-ref=free) but deliberately prints NO runnable command: an older-fleet
+     # worker locks with the BRANCH only, so this adopt WOULD succeed against a lane
+     # somebody is actively working. CONFIRM abandonment first — `claim-heartbeat.sh
+     # should-reap <machine>` (age > 4h AND no open PR AND pid-dead if local), the board
+     # Status, the branch/PR author. Never resume blind.
      # NEVER hand-craft a claim commit to get past the guard.
      if ! bash scripts/flow/claim.sh claim <N>; then
        echo "CLAIM LOST — another machine holds refs/claims/issue-<N>. Take the next item (or fetch to RESUME)."; exit 0

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -62,6 +62,11 @@ never gate stdout or review churn.
      # re-read; a UNIQUE root commit means a different-slug or identical-base
      # competitor can no longer double-claim. Adopting a reaped claim instead?
      # Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>.
+     # RESUMING an issue whose issue-<N>-* branch outlived its claim ref (the
+     # `reason=legacy-branch-lock` refusal, which prints this command verbatim)?
+     # Use: bash scripts/flow/claim.sh adopt <N> --expect none --reason <why>
+     # (#2945 — git's empty lease: still server-arbitrated, records who + why).
+     # NEVER hand-craft a claim commit to get past the guard.
      if ! bash scripts/flow/claim.sh claim <N>; then
        echo "CLAIM LOST — another machine holds refs/claims/issue-<N>. Take the next item (or fetch to RESUME)."; exit 0
      fi

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -64,11 +64,14 @@ never gate stdout or review churn.
      # Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>.
      # RESUMING an issue whose issue-<N>-* branch outlived its claim ref (the
      # `reason=legacy-branch-lock` refusal, which prints this command verbatim)?
-     # Use: bash scripts/flow/claim.sh adopt <N> --expect none --reason <why>
-     # (#2945 — git's empty lease: still server-arbitrated, records who + why).
-     # The refusal prints that command ONLY at open-prs=0; if it says
-     # `remediation=withheld open-prs=<n>`, an endgame may be LIVE — confirm
-     # ownership (board + PR author) before resuming, do not resume blind.
+     # Use the command the refusal PRINTS (reason pre-filled):
+     #   bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:<branch>
+     # (#2945 — git's empty lease: still server-arbitrated, records who + why; a
+     # placeholder reason like <why> is refused). It is printed ONLY when the lane
+     # is demonstrably orphaned: open-prs=0 AND every issue-<N>-* branch tip staler
+     # than the 4h reap threshold AND no fresh machine-claim/heartbeat ref naming
+     # the issue. `remediation=withheld <signals>` = LIVE or unproven — confirm
+     # ownership (board + branch/PR author) before resuming, do not resume blind.
      # NEVER hand-craft a claim commit to get past the guard.
      if ! bash scripts/flow/claim.sh claim <N>; then
        echo "CLAIM LOST — another machine holds refs/claims/issue-<N>. Take the next item (or fetch to RESUME)."; exit 0

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -64,9 +64,11 @@ never gate stdout or review churn.
      # Use: bash scripts/flow/claim.sh adopt <N> --expect <old-sha>.
      # RESUMING an issue whose issue-<N>-* branch outlived its claim ref (the
      # `reason=legacy-branch-lock ... claim-ref=free` refusal)? The sanctioned command:
-     #   bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:<branch>
-     # (#2945 — git's empty lease: still server-arbitrated, records who + why; a
-     # placeholder reason like <why> is refused). The refusal DIAGNOSES (branch +
+     #   bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:branch-outlived-claim
+     # (#2945 — git's empty lease: still server-arbitrated, records who + why. The
+     # --reason above is CONCRETE on purpose: a placeholder reason, or one still
+     # carrying an unsubstituted <…>, is a usage error (exit 64)). The refusal
+     # DIAGNOSES (branch +
      # claim-ref=free) but deliberately prints NO runnable command: an older-fleet
      # worker locks with the BRANCH only, so this adopt WOULD succeed against a lane
      # somebody is actively working. CONFIRM abandonment first — `claim-heartbeat.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -995,6 +995,15 @@ jobs:
           "flow-finalize guardrail tests"
           -- /bin/bash scripts/flow/tests/finalize-cleanup.test.sh
 
+      # Claim-lock RESUME path (issue #2945): the legacy-branch guard's escape
+      # hatch, its fail-closed enumeration, and a REAL two-machine race on the
+      # empty-lease adopt. macOS too — claim.sh must stay bash-3.2 clean.
+      - name: Run claim.sh resume-path guardrail tests (${{ matrix.os }} /bin/bash)
+        run: >-
+          bash scripts/ci/ci-timing-summary.sh measure
+          "claim resume-path guardrail tests"
+          -- /bin/bash scripts/flow/tests/claim-resume.test.sh
+
       # Release-train version tooling (issue #2652). Runs on macOS too so the
       # system bash 3.2 (the release preflight's real target) is validated, not
       # just asserted.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -995,9 +995,10 @@ jobs:
           "flow-finalize guardrail tests"
           -- /bin/bash scripts/flow/tests/finalize-cleanup.test.sh
 
-      # Claim-lock RESUME path (issue #2945): the legacy-branch guard's escape
-      # hatch, its fail-closed enumeration, and a REAL two-machine race on the
-      # empty-lease adopt. macOS too — claim.sh must stay bash-3.2 clean.
+      # Claim-lock RESUME path (issue #2945): the sanctioned (but unadvertised)
+      # empty-lease adopt, the guard's diagnosis-only refusal, its fail-closed
+      # enumeration, and a REAL two-machine race on the adopt. macOS too —
+      # claim.sh must stay bash-3.2 clean.
       - name: Run claim.sh resume-path guardrail tests (${{ matrix.os }} /bin/bash)
         run: >-
           bash scripts/ci/ci-timing-summary.sh measure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,11 +385,14 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   adopting a reaped claim = `claim.sh adopt <N> --expect <old-sha>` (compare-and-swap, so a
   resurrected original holder loses the lease immediately — #2467/#2499); **resuming an issue whose
   `issue-<N>-*` branch outlived its claim ref** (released/reaped/parked claim, or a
-  merged-but-undeleted branch) = `claim.sh adopt <N> --expect none --reason <concrete why>` (#2945) —
+  merged-but-undeleted branch) =
+  `claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:branch-outlived-claim` (#2945) —
   git's empty lease, so the create is still server-arbitrated (a machine actually holding the ref keeps
   it, `ADOPT-LOST`) and the claim commit records who took it AND why (a `--reason` with nothing
-  recordable in it, or a bare placeholder like `<why>`/`todo`/`tbd`, is a usage error — not a silent
-  `reason=unspecified`/`reason=why`). That is the ONLY sanctioned
+  recordable in it, a bare placeholder like `why`/`todo`/`tbd`, or one still carrying an
+  **unsubstituted `<…>`** — a copied template such as `--reason resume-legacy-branch-lock:<branch>` —
+  is a usage error, not a silent `reason=unspecified`/`reason=why`; `--actor` is fail-closed the same
+  way, since an unrecordable actor would alias two identities onto one holder). That is the ONLY sanctioned
   way past `reason=legacy-branch-lock`; never hand-craft a claim commit. It is deliberately **NOT
   auto-advertised**: the refusal DIAGNOSES the lane (`reason=legacy-branch-lock detail=<branches>
   claim-ref=free resume=documented-procedure`) and points here, but prints **no runnable command** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,9 +392,11 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   `reason=unspecified`/`reason=why`). That is the ONLY sanctioned
   way past `reason=legacy-branch-lock`; never hand-craft a claim commit. The refusal PRINTS that
   command (reason pre-filled) only when the lane is demonstrably ORPHANED on all three signals:
-  `open-prs=0` AND every `issue-<N>-*` branch tip older than the 4h reap threshold AND no fresh
-  machine-claim/heartbeat ref naming the issue — the tip/liveness signals cover the PRE-PR window,
-  where an older-fleet worker holds only the BRANCH and has no PR yet. Anything live or unreadable
+  `open-prs=0` AND every `issue-<N>-*` branch tip carrying its OWN commits and older than the 4h reap
+  threshold AND no fresh machine-claim/heartbeat ref naming the issue — the tip/liveness signals cover
+  the PRE-PR window, where an older-fleet worker holds only the BRANCH and has no PR yet. A branch
+  pushed at `origin/main` with NO commits of its own (what `flow-activate` creates) has no age signal
+  at all: it reports `newest-branch-tip=no-own-commits` and is WITHHELD. Anything live or unreadable
   prints `remediation=withheld <signals>`; confirm ownership via the board + branch/PR author before
   resuming. `claim.sh release <N>`
   deletes the ref (refuses under an open PR without `--force`). Maintain the liveness heartbeat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,7 +383,12 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   `issue-<N>-<slug>` branch is now **PR plumbing, NOT the lock**. Acquire the claim ref FIRST, then
   worktree+branch; set assignee + `Status=In Progress`. `claim.sh verify <N>` confirms you hold it;
   adopting a reaped claim = `claim.sh adopt <N> --expect <old-sha>` (compare-and-swap, so a
-  resurrected original holder loses the lease immediately — #2467/#2499); `claim.sh release <N>`
+  resurrected original holder loses the lease immediately — #2467/#2499); **resuming an issue whose
+  `issue-<N>-*` branch outlived its claim ref** (released/reaped/parked claim, or a
+  merged-but-undeleted branch) = `claim.sh adopt <N> --expect none --reason <why>` (#2945) — git's
+  empty lease, so the create is still server-arbitrated (a machine actually holding the ref keeps
+  it, `ADOPT-LOST`) and the claim commit records who took it AND why. That is the ONLY sanctioned
+  way past `reason=legacy-branch-lock`; never hand-craft a claim commit. `claim.sh release <N>`
   deletes the ref (refuses under an open PR without `--force`). Maintain the liveness heartbeat
   (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
   `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,8 +387,12 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   `issue-<N>-*` branch outlived its claim ref** (released/reaped/parked claim, or a
   merged-but-undeleted branch) = `claim.sh adopt <N> --expect none --reason <why>` (#2945) — git's
   empty lease, so the create is still server-arbitrated (a machine actually holding the ref keeps
-  it, `ADOPT-LOST`) and the claim commit records who took it AND why. That is the ONLY sanctioned
-  way past `reason=legacy-branch-lock`; never hand-craft a claim commit. `claim.sh release <N>`
+  it, `ADOPT-LOST`) and the claim commit records who took it AND why (a `--reason` with nothing
+  recordable in it is a usage error, not a silent `reason=unspecified`). That is the ONLY sanctioned
+  way past `reason=legacy-branch-lock`; never hand-craft a claim commit. The refusal only PRINTS
+  that command at `open-prs=0`: an older-fleet worker locks with the BRANCH and holds no claim ref,
+  so with an open PR (or an unreadable PR list) it prints `remediation=withheld open-prs=<n>` and
+  you confirm ownership via the board + PR author before resuming. `claim.sh release <N>`
   deletes the ref (refuses under an open PR without `--force`). Maintain the liveness heartbeat
   (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
   `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,14 +385,18 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   adopting a reaped claim = `claim.sh adopt <N> --expect <old-sha>` (compare-and-swap, so a
   resurrected original holder loses the lease immediately — #2467/#2499); **resuming an issue whose
   `issue-<N>-*` branch outlived its claim ref** (released/reaped/parked claim, or a
-  merged-but-undeleted branch) = `claim.sh adopt <N> --expect none --reason <why>` (#2945) — git's
-  empty lease, so the create is still server-arbitrated (a machine actually holding the ref keeps
+  merged-but-undeleted branch) = `claim.sh adopt <N> --expect none --reason <concrete why>` (#2945) —
+  git's empty lease, so the create is still server-arbitrated (a machine actually holding the ref keeps
   it, `ADOPT-LOST`) and the claim commit records who took it AND why (a `--reason` with nothing
-  recordable in it is a usage error, not a silent `reason=unspecified`). That is the ONLY sanctioned
-  way past `reason=legacy-branch-lock`; never hand-craft a claim commit. The refusal only PRINTS
-  that command at `open-prs=0`: an older-fleet worker locks with the BRANCH and holds no claim ref,
-  so with an open PR (or an unreadable PR list) it prints `remediation=withheld open-prs=<n>` and
-  you confirm ownership via the board + PR author before resuming. `claim.sh release <N>`
+  recordable in it, or a bare placeholder like `<why>`/`todo`/`tbd`, is a usage error — not a silent
+  `reason=unspecified`/`reason=why`). That is the ONLY sanctioned
+  way past `reason=legacy-branch-lock`; never hand-craft a claim commit. The refusal PRINTS that
+  command (reason pre-filled) only when the lane is demonstrably ORPHANED on all three signals:
+  `open-prs=0` AND every `issue-<N>-*` branch tip older than the 4h reap threshold AND no fresh
+  machine-claim/heartbeat ref naming the issue — the tip/liveness signals cover the PRE-PR window,
+  where an older-fleet worker holds only the BRANCH and has no PR yet. Anything live or unreadable
+  prints `remediation=withheld <signals>`; confirm ownership via the board + branch/PR author before
+  resuming. `claim.sh release <N>`
   deletes the ref (refuses under an open PR without `--force`). Maintain the liveness heartbeat
   (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
   `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,15 +390,14 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   it, `ADOPT-LOST`) and the claim commit records who took it AND why (a `--reason` with nothing
   recordable in it, or a bare placeholder like `<why>`/`todo`/`tbd`, is a usage error — not a silent
   `reason=unspecified`/`reason=why`). That is the ONLY sanctioned
-  way past `reason=legacy-branch-lock`; never hand-craft a claim commit. The refusal PRINTS that
-  command (reason pre-filled) only when the lane is demonstrably ORPHANED on all three signals:
-  `open-prs=0` AND every `issue-<N>-*` branch tip carrying its OWN commits and older than the 4h reap
-  threshold AND no fresh machine-claim/heartbeat ref naming the issue — the tip/liveness signals cover
-  the PRE-PR window, where an older-fleet worker holds only the BRANCH and has no PR yet. A branch
-  pushed at `origin/main` with NO commits of its own (what `flow-activate` creates) has no age signal
-  at all: it reports `newest-branch-tip=no-own-commits` and is WITHHELD. Anything live or unreadable
-  prints `remediation=withheld <signals>`; confirm ownership via the board + branch/PR author before
-  resuming. `claim.sh release <N>`
+  way past `reason=legacy-branch-lock`; never hand-craft a claim commit. It is deliberately **NOT
+  auto-advertised**: the refusal DIAGNOSES the lane (`reason=legacy-branch-lock detail=<branches>
+  claim-ref=free resume=documented-procedure`) and points here, but prints **no runnable command** —
+  a printed line gets executed literally, and an older-fleet worker holds only the BRANCH (so the
+  empty-lease adopt WOULD succeed against a live lane). Before resuming, CONFIRM the lane is
+  abandoned with the same test `flow-board`'s reaper uses — `claim-heartbeat.sh should-reap
+  <machine>` (age > 4h AND no open PR AND pid-dead-if-local) plus board `Status` and the branch/PR
+  author. `claim.sh release <N>`
   deletes the ref (refuses under an open PR without `--force`). Maintain the liveness heartbeat
   (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
   `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -131,15 +131,18 @@ compare-and-swap — `bash scripts/flow/claim.sh adopt <N> --expect <current-sha
 bare `git fetch`, so a resurrected original holder loses the lease and detects it at once.
 When the claim ref is FREE but an `issue-<N>-*` branch still exists on origin (a resumed,
 parked, or reaped issue, or a merged-but-undeleted branch), `claim` refuses with
-`reason=legacy-branch-lock` and prints the one sanctioned resume:
+`reason=legacy-branch-lock detail=<branches> claim-ref=free resume=documented-procedure` —
+a diagnosis that names the blocking branch and confirms the claim ref itself is free.
+The one sanctioned resume is
 `bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:<branch>`
 (#2945) — git's empty lease, so the create is still server-arbitrated and the claim commit
-records who + why (a placeholder reason like `<why>` is refused). That command is printed
-only when the lane is demonstrably orphaned: `open-prs=0` AND every `issue-<N>-*` branch tip
-carrying its OWN commits and older than the 4h reap threshold AND no fresh machine-claim/heartbeat
-ref naming the issue. A commit-less branch (what `flow-activate` pushes) has no age signal, so it is
-withheld as `newest-branch-tip=no-own-commits`.
-Anything live or unreadable → `remediation=withheld <signals>`; confirm ownership first.
+records who + why (a placeholder reason like `<why>` is refused). It is deliberately **not
+printed** by the refusal: a printed line gets run literally, and an older-fleet worker locks
+with the BRANCH while holding no claim ref, so the empty-lease adopt would succeed against an
+actively-worked lane. Establish abandonment yourself first — `bash scripts/flow/claim-heartbeat.sh
+should-reap <machine>` (the same test `flow-board`'s reaper applies: age > 4h AND no open PR AND
+pid-dead-if-local), plus the board `Status` and the branch/PR author — and never hand-craft a
+claim commit.
 
 ## Full doctrine
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -136,7 +136,9 @@ parked, or reaped issue, or a merged-but-undeleted branch), `claim` refuses with
 (#2945) — git's empty lease, so the create is still server-arbitrated and the claim commit
 records who + why (a placeholder reason like `<why>` is refused). That command is printed
 only when the lane is demonstrably orphaned: `open-prs=0` AND every `issue-<N>-*` branch tip
-older than the 4h reap threshold AND no fresh machine-claim/heartbeat ref naming the issue.
+carrying its OWN commits and older than the 4h reap threshold AND no fresh machine-claim/heartbeat
+ref naming the issue. A commit-less branch (what `flow-activate` pushes) has no age signal, so it is
+withheld as `newest-branch-tip=no-own-commits`.
 Anything live or unreadable → `remediation=withheld <signals>`; confirm ownership first.
 
 ## Full doctrine

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -132,10 +132,12 @@ bare `git fetch`, so a resurrected original holder loses the lease and detects i
 When the claim ref is FREE but an `issue-<N>-*` branch still exists on origin (a resumed,
 parked, or reaped issue, or a merged-but-undeleted branch), `claim` refuses with
 `reason=legacy-branch-lock` and prints the one sanctioned resume:
-`bash scripts/flow/claim.sh adopt <N> --expect none --reason <why>` (#2945) — git's empty
-lease, so the create is still server-arbitrated and the claim commit records who + why.
-That command is printed only at `open-prs=0`; with an open PR (or an unreadable PR list)
-the refusal says `remediation=withheld open-prs=<n>` — confirm ownership before resuming.
+`bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:<branch>`
+(#2945) — git's empty lease, so the create is still server-arbitrated and the claim commit
+records who + why (a placeholder reason like `<why>` is refused). That command is printed
+only when the lane is demonstrably orphaned: `open-prs=0` AND every `issue-<N>-*` branch tip
+older than the 4h reap threshold AND no fresh machine-claim/heartbeat ref naming the issue.
+Anything live or unreadable → `remediation=withheld <signals>`; confirm ownership first.
 
 ## Full doctrine
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -134,6 +134,8 @@ parked, or reaped issue, or a merged-but-undeleted branch), `claim` refuses with
 `reason=legacy-branch-lock` and prints the one sanctioned resume:
 `bash scripts/flow/claim.sh adopt <N> --expect none --reason <why>` (#2945) — git's empty
 lease, so the create is still server-arbitrated and the claim commit records who + why.
+That command is printed only at `open-prs=0`; with an open PR (or an unreadable PR list)
+the refusal says `remediation=withheld open-prs=<n>` — confirm ownership before resuming.
 
 ## Full doctrine
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -129,6 +129,11 @@ server-side (assignee `@me` is identical for one user on two machines, and the
 + `Status=In Progress`. A second machine picking up a reaped/dead claim adopts it via
 compare-and-swap — `bash scripts/flow/claim.sh adopt <N> --expect <current-sha>` — not a
 bare `git fetch`, so a resurrected original holder loses the lease and detects it at once.
+When the claim ref is FREE but an `issue-<N>-*` branch still exists on origin (a resumed,
+parked, or reaped issue, or a merged-but-undeleted branch), `claim` refuses with
+`reason=legacy-branch-lock` and prints the one sanctioned resume:
+`bash scripts/flow/claim.sh adopt <N> --expect none --reason <why>` (#2945) — git's empty
+lease, so the create is still server-arbitrated and the claim commit records who + why.
 
 ## Full doctrine
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -134,9 +134,10 @@ parked, or reaped issue, or a merged-but-undeleted branch), `claim` refuses with
 `reason=legacy-branch-lock detail=<branches> claim-ref=free resume=documented-procedure` —
 a diagnosis that names the blocking branch and confirms the claim ref itself is free.
 The one sanctioned resume is
-`bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:<branch>`
+`bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:branch-outlived-claim`
 (#2945) — git's empty lease, so the create is still server-arbitrated and the claim commit
-records who + why (a placeholder reason like `<why>` is refused). It is deliberately **not
+records who + why (a placeholder reason like `<why>`, or one still carrying an unsubstituted
+`<…>`, is refused — so the `--reason` above is shown already substituted). It is deliberately **not
 printed** by the refusal: a printed line gets run literally, and an older-fleet worker locks
 with the BRANCH while holding no claim ref, so the empty-lease adopt would succeed against an
 actively-worked lane. Establish abandonment yourself first — `bash scripts/flow/claim-heartbeat.sh

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4861,13 +4861,14 @@ run_tooling_tests() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
   if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_notify.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_smoke_target_dir.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_gate_concurrency_cap.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_bootstrap_agent_machine.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_claim_lock.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/flow/tests/claim-resume.test.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_premerge_assert.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_board_label_mirror.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_worker_supervisor.sh" >>"$log" 2>&1 &&

--- a/scripts/flow/claim-heartbeat.sh
+++ b/scripts/flow/claim-heartbeat.sh
@@ -75,6 +75,9 @@
 #                                            # foreign-pid unknowable); exit 2 = no ref.
 #   claim-heartbeat.sh reap <machine>        # delete a machine's claim ref, but
 #                                            # REFUSE if its issue has an open PR.
+#   claim-heartbeat.sh reap-threshold        # print the staleness threshold in
+#                                            # seconds (the single definition of 4h,
+#                                            # reused by claim.sh's liveness check)
 #
 # Run from inside the repo (any cwd under the working tree/worktree is fine —
 # this never touches the working tree or the current branch).
@@ -455,13 +458,20 @@ case "$SUBCOMMAND" in
     shift
     cmd_reap "${1:-}"
     ;;
+  reap-threshold)
+    # The staleness threshold as a machine-readable number of seconds. Exists so a
+    # SIBLING tool (claim.sh's legacy-branch liveness check, #2945) can reuse THIS
+    # file's single definition of "stale enough to hand away" instead of hardcoding a
+    # second copy of 4h that could drift from the documented one.
+    printf '%s\n' "$DEFAULT_REAP_THRESHOLD_SECS"
+    ;;
   -h | --help)
     print_help
     ;;
   "")
-    die_usage "a subcommand is required: beat <issue> | list | clear <machine> | stamp <issue> [pid] | list-claims | should-reap <machine> [secs] | reap <machine>"
+    die_usage "a subcommand is required: beat <issue> | list | clear <machine> | stamp <issue> [pid] | list-claims | should-reap <machine> [secs] | reap <machine> | reap-threshold"
     ;;
   *)
-    die_usage "unknown subcommand: $SUBCOMMAND (expected beat|list|clear|stamp|list-claims|should-reap|reap)"
+    die_usage "unknown subcommand: $SUBCOMMAND (expected beat|list|clear|stamp|list-claims|should-reap|reap|reap-threshold)"
     ;;
 esac

--- a/scripts/flow/claim-heartbeat.sh
+++ b/scripts/flow/claim-heartbeat.sh
@@ -75,9 +75,6 @@
 #                                            # foreign-pid unknowable); exit 2 = no ref.
 #   claim-heartbeat.sh reap <machine>        # delete a machine's claim ref, but
 #                                            # REFUSE if its issue has an open PR.
-#   claim-heartbeat.sh reap-threshold        # print the staleness threshold in
-#                                            # seconds (the single definition of 4h,
-#                                            # reused by claim.sh's liveness check)
 #
 # Run from inside the repo (any cwd under the working tree/worktree is fine —
 # this never touches the working tree or the current branch).
@@ -458,20 +455,13 @@ case "$SUBCOMMAND" in
     shift
     cmd_reap "${1:-}"
     ;;
-  reap-threshold)
-    # The staleness threshold as a machine-readable number of seconds. Exists so a
-    # SIBLING tool (claim.sh's legacy-branch liveness check, #2945) can reuse THIS
-    # file's single definition of "stale enough to hand away" instead of hardcoding a
-    # second copy of 4h that could drift from the documented one.
-    printf '%s\n' "$DEFAULT_REAP_THRESHOLD_SECS"
-    ;;
   -h | --help)
     print_help
     ;;
   "")
-    die_usage "a subcommand is required: beat <issue> | list | clear <machine> | stamp <issue> [pid] | list-claims | should-reap <machine> [secs] | reap <machine> | reap-threshold"
+    die_usage "a subcommand is required: beat <issue> | list | clear <machine> | stamp <issue> [pid] | list-claims | should-reap <machine> [secs] | reap <machine>"
     ;;
   *)
-    die_usage "unknown subcommand: $SUBCOMMAND (expected beat|list|clear|stamp|list-claims|should-reap|reap|reap-threshold)"
+    die_usage "unknown subcommand: $SUBCOMMAND (expected beat|list|clear|stamp|list-claims|should-reap|reap)"
     ;;
 esac

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -641,6 +641,25 @@ cmd_claim() {
     return 1
   fi
   fetch_claim "$issue"
+  # A TOCTOU winner's sha. Route it through the SAME three-outcome identity read as the
+  # rejected-push sibling above and as the pre-check, so all of this file's exit-2 sites
+  # read as ONE rule: a commit of OURS is a re-entrant HELD (we do hold the ref), an
+  # UNREADABLE commit is retryable infra (the holder is UNKNOWN — possibly us — and
+  # `fetch_claim` is best effort AND only ever fetches THIS issue's ref, which the landed
+  # push left at our own sha, so a TOCTOU winner's object may simply not be here;
+  # falling straight through rendered the tell-tale empty `holder-machine= actor=` on a
+  # LOST, which the header rule at the top of this file forbids), and ONLY a
+  # successfully-read FOREIGN holder is a genuine LOST.
+  local crc=0
+  holder_identity "$confirmed" "$actor" || crc=$?
+  if [ "$crc" -eq 0 ]; then
+    emit "HELD issue=$issue ref=refs/claims/issue-$issue sha=$confirmed $(holder_desc "$confirmed") (re-entrant)"
+    return 0
+  fi
+  if [ "$crc" -eq 2 ]; then
+    emit_unreadable_holder "$issue" "$confirmed"
+    return 1
+  fi
   emit "LOST issue=$issue ref=refs/claims/issue-$issue sha=$confirmed $(holder_token "$confirmed")"
   return 2
 }

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -31,10 +31,24 @@
 # so a resurrected ORIGINAL holder loses the fast-forward / lease on its next
 # push and detects the loss immediately (fixes the #2467/#2499 two-writer race).
 #
+# RESUME OF A FREE REF (`adopt <N> --expect none --reason <why>`, issue #2945) is
+# the same mechanism with git's EMPTY LEASE — `--force-with-lease=<ref>:` means
+# "the ref MUST NOT exist", i.e. the update carries the all-zero old value, so the
+# remote creates it only when nobody holds it and rejects every racing claimant.
+# It is the sanctioned, non-`--force` way past the LEGACY GUARD below when an
+# `issue-<N>-*` branch outlived its claim ref (released/reaped/parked claim, or a
+# merged-but-undeleted branch). `--reason` is REQUIRED there: the claim commit
+# records who took it AND why, so a resume is auditable rather than a hand-crafted
+# push. It is NOT a bypass — git still arbitrates, so a machine actively holding
+# the claim ref keeps it (ADOPT-LOST, exit 2).
+#
 # LEGACY GUARD (mixed-fleet safety): older workers still branch-lock with a
 # `refs/heads/issue-<N>-*` branch. `claim` refuses if any such branch exists on
-# origin (treat the issue as already-claimed) UNLESS every such branch tip is
-# our OWN claim (re-entrancy). New claims never create these branches — the
+# origin (treat the issue as already-claimed) and names the resume command above
+# in its refusal. There is NO tip-based re-entrancy exemption: a work branch is
+# cut from origin/main and carries ordinary commits, so its tip NEVER carries the
+# machine=/actor= claim trailers — the old "all-ours -> no block" escape hatch was
+# unreachable dead code (#2945). New claims never create these branches — the
 # `issue-<N>-<slug>` branch is now PR plumbing pushed separately, never the lock.
 #
 # REF LAYOUT
@@ -56,7 +70,14 @@
 # SUBCOMMANDS
 #   claim  <N> [--actor <id>]                 acquire the lock (CLAIM HELD / CLAIM LOST / CLAIM ERROR)
 #   verify <N> [--actor <id>]                 exit 0 iff we hold it (this machine+actor)
-#   adopt  <N> --expect <old-sha> [--actor <id>]  compare-and-swap the ref (adoption/resume)
+#   adopt  <N> --expect <old-sha>|none [--reason <why>] [--actor <id>]
+#                                             compare-and-swap the ref (adoption/resume).
+#                                             --expect <old-sha>: the ref must still be <old-sha>.
+#                                             --expect none:      the ref must NOT exist (empty
+#                                             lease) — the resume path for an issue whose
+#                                             `issue-<N>-*` branch outlived its claim; --reason
+#                                             is REQUIRED and is recorded in the claim commit.
+#                                             An EMPTY --expect '' is a usage error on purpose.
 #   release <N> [--force] [--actor <id>]      delete the ref; without --force requires holder identity
 #                                             (machine+actor) + no open PR, and deletes via CAS lease.
 #                                             --force = reaper/adopt: unconditional delete.
@@ -224,17 +245,34 @@ remote_claim_lookup() {
   return 0
 }
 
-# build_claim_commit <N> <actor> — create a UNIQUE root commit (empty tree, no
-# parent) and print its SHA. The nonce guarantees distinct SHAs even for two
-# claimants at the same base in the same second.
+# sanitize_reason <text> — collapse a free-text reason into ONE parseable token.
+# The claim message is parsed as `<key>=<non-space-run>`, so a reason containing
+# spaces would be silently truncated at the first space. Keeps [A-Za-z0-9._:/#-],
+# maps every other run (spaces, newlines, quotes, shell metacharacters) to a
+# single '-', trims leading/trailing '-', caps at 120 chars, and never prints an
+# empty token.
+sanitize_reason() {
+  local s
+  s="$(printf '%s' "${1:-}" | tr -c 'A-Za-z0-9._:/#-' '-' | sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')"
+  s="$(printf '%.120s' "$s")"
+  [ -n "$s" ] || s="unspecified"
+  printf '%s\n' "$s"
+}
+
+# build_claim_commit <N> <actor> [extra-fields] — create a UNIQUE root commit
+# (empty tree, no parent) and print its SHA. The nonce guarantees distinct SHAs
+# even for two claimants at the same base in the same second. <extra-fields> is
+# an already-sanitized, space-separated `key=value` run appended to the message
+# (e.g. `mode=empty-lease reason=<why>` for an adopt-resume record).
 build_claim_commit() {
-  local issue="$1" actor="$2"
+  local issue="$1" actor="$2" extra="${3:-}"
   local machine pid ts nonce message empty_tree
   machine="$(this_machine)"
   pid="$$"
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   nonce="${pid}-${RANDOM}-${RANDOM}-$(date -u +%s)"
   message="claim issue=${issue} machine=${machine} pid=${pid} actor=${actor} ts=${ts} nonce=${nonce}"
+  [ -z "$extra" ] || message="${message} ${extra}"
   empty_tree="$(git hash-object -t tree --stdin </dev/null)"
   GIT_AUTHOR_NAME="cqlite-claim" GIT_AUTHOR_EMAIL="claim@cqlite.local" \
     GIT_COMMITTER_NAME="cqlite-claim" GIT_COMMITTER_EMAIL="claim@cqlite.local" \
@@ -278,23 +316,38 @@ holder_token() {
   fi
 }
 
-# legacy_lock_blocks <N> — 0 (blocks) iff a refs/heads/issue-<N>-* branch exists
-# on origin whose tip is NOT our own claim. Re-entrancy: all-ours -> no block.
-legacy_lock_blocks() {
-  local issue="$1" actor="$2" raw ref sha found_other=0 found_any=0
-  raw="$(git ls-remote --heads "$REMOTE" "issue-${issue}-*" 2>/dev/null || true)"
-  [ -n "$raw" ] || return 1
+# legacy_branch_scan <N> — enumerate the older fleet's branch lock
+# `refs/heads/issue-<N>-*` on origin (which is ALSO what a merged-but-undeleted PR
+# branch leaves behind). Sets the global LEGACY_BRANCHES to a comma-separated list
+# of matching ref NAMES ("" when there are none) and returns:
+#   0  enumeration SUCCEEDED — LEGACY_BRANCHES is authoritative ("" == genuinely none)
+#   1  ls-remote FAILED — the answer is UNKNOWN, never "none" (issue #2677 item 2:
+#      the old code mapped an outage to "no branches", i.e. an all-clear). Callers
+#      map this to ERROR reason=infra (exit 1), matching every other remote read.
+# There is deliberately NO "is this branch ours" test: a work branch is cut from
+# origin/main and carries ordinary commits, so its tip NEVER carries the claim
+# machine=/actor= trailers, which made the old `holder_is_us`-based "all-ours -> no
+# block" re-entrancy unreachable (#2945). Re-entrancy for a branch you own is now
+# expressed explicitly by `adopt <N> --expect none --reason <why>`, arbitrated by
+# the claim ref itself rather than guessed from a commit message.
+LEGACY_BRANCHES=""
+legacy_branch_scan() {
+  local issue="$1" raw line ref
+  LEGACY_BRANCHES=""
+  if ! raw="$(git ls-remote --heads "$REMOTE" "issue-${issue}-*" 2>/dev/null)"; then
+    return 1
+  fi
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    found_any=1
-    sha="$(printf '%s' "$line" | awk '{print $1}')"
     ref="$(printf '%s' "$line" | awk '{print $2}')"
-    git fetch "$REMOTE" "$ref" >/dev/null 2>&1 || true
-    if ! holder_is_us "$sha" "$actor"; then
-      found_other=1
+    [ -n "$ref" ] || continue
+    if [ -z "$LEGACY_BRANCHES" ]; then
+      LEGACY_BRANCHES="$ref"
+    else
+      LEGACY_BRANCHES="${LEGACY_BRANCHES},${ref}"
     fi
   done <<< "$raw"
-  [ "$found_any" -eq 1 ] && [ "$found_other" -eq 1 ]
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -322,9 +375,18 @@ cmd_claim() {
     return 2
   fi
 
-  # Legacy branch-lock guard (mixed fleet). Re-entrancy: our own branch is fine.
-  if legacy_lock_blocks "$issue" "$actor"; then
-    emit "LOST issue=$issue reason=legacy-branch-lock detail=refs/heads/issue-${issue}-* exists on $REMOTE"
+  # Legacy branch-lock guard (mixed fleet). An `issue-<N>-*` branch on origin is
+  # treated as an older worker's branch lock. The refusal NAMES the sanctioned
+  # resume command (#2945): a bare LOST is what previously sent workers into
+  # hand-crafted claim-commit pushes. An enumeration OUTAGE is UNKNOWN, not an
+  # all-clear (#2677 item 2) — it maps to ERROR infra (retryable), never a claim
+  # granted on an unread guard.
+  if ! legacy_branch_scan "$issue"; then
+    emit_infra "issue=$issue detail=legacy-branch-ls-remote-unreachable-on-$REMOTE (cannot tell 'no legacy branch' from an outage)"
+    return 1
+  fi
+  if [ -n "$LEGACY_BRANCHES" ]; then
+    emit "LOST issue=$issue reason=legacy-branch-lock detail=$LEGACY_BRANCHES exists on $REMOTE claim-ref=free remediation='bash scripts/flow/claim.sh adopt $issue --expect none --reason <why>' (that branch may be an older-fleet branch lock, a parked/reaped resume, or a merged-but-undeleted branch; if it is YOURS to continue, the quoted empty-lease adopt takes the FREE claim ref atomically — git rejects it if any machine holds the ref)"
     return 2
   fi
 
@@ -420,25 +482,61 @@ cmd_verify() {
 
 # ---------------------------------------------------------------------------
 cmd_adopt() {
-  local issue="" actor="${CLAIM_ACTOR:-flow}" expect=""
+  local issue="" actor="${CLAIM_ACTOR:-flow}" expect="" reason="" mode="cas"
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --actor)  [ "$#" -ge 2 ] || die_usage "--actor requires a value";  actor="$2";  shift 2 ;;
       --expect) [ "$#" -ge 2 ] || die_usage "--expect requires a value"; expect="$2"; shift 2 ;;
+      --reason) [ "$#" -ge 2 ] || die_usage "--reason requires a value"; reason="$2"; shift 2 ;;
       -*) die_usage "adopt: unknown flag $1" ;;
       *) [ -z "$issue" ] || die_usage "adopt: unexpected argument $1"; issue="$1"; shift ;;
     esac
   done
   require_numeric_issue "$issue" adopt
-  [ -n "$expect" ] || die_usage "adopt requires --expect <old-sha>"
+  # An EMPTY --expect stays a USAGE ERROR (fail closed): an unset shell variable
+  # expanding to "" must NEVER silently turn a compare-and-swap into a create.
+  # The empty lease is opt-in via the explicit literal `none`.
+  [ -n "$expect" ] || die_usage "adopt requires --expect <old-sha> (CAS against a HELD ref) or --expect none (empty lease: the claim ref must NOT exist — the sanctioned resume when an issue-<N>-* branch outlived its claim, #2945). An empty --expect '' is rejected on purpose."
+  case "$expect" in
+    none) mode="empty" ;;
+    *[!0-9a-fA-F]*) die_usage "adopt: --expect takes a hex sha or the literal 'none' (got '$expect')" ;;
+  esac
+  # An ALL-ZERO expected value is git's own "the ref must not exist", so it carries
+  # exactly the `none` intent — route it through the same AUDITED path (--reason
+  # required) instead of leaving a quiet create-with-no-record. Verified against the
+  # real origin: `--expect 000…0` does create the ref, so it cannot stay unaudited.
+  case "$expect" in
+    *[!0]*) : ;;
+    *) mode="empty" ;;
+  esac
 
-  local sha adopt_err=""
-  sha="$(build_claim_commit "$issue" "$actor")"
-  # Compare-and-swap: replace the ref ONLY if origin is still at <old-sha>. We
-  # ignore the push exit here and let the infra-AWARE confirm read below decide —
-  # mirroring cmd_claim exactly, so a lease-mismatch, a TOCTOU, and an infra blip
+  local extra=""
+  if [ "$mode" = "empty" ]; then
+    # The resume is a judgement call, so it MUST be self-documenting: the claim
+    # commit records who took it (machine/actor/ts) AND why (reason).
+    [ -n "$reason" ] || die_usage "adopt --expect none requires --reason <why> (the resume is recorded in the claim commit: who took it AND why)"
+    extra="mode=empty-lease reason=$(sanitize_reason "$reason")"
+  elif [ -n "$reason" ]; then
+    extra="mode=cas reason=$(sanitize_reason "$reason")"
+  fi
+
+  local sha lease adopt_err=""
+  sha="$(build_claim_commit "$issue" "$actor" "$extra")"
+  if [ "$mode" = "empty" ]; then
+    # EMPTY LEASE: a lease of "<ref>:" (no expected value) means "the ref must NOT
+    # exist" — the ref update carries the all-zero old value, so the REMOTE creates
+    # it only when nobody holds it and rejects every racing claimant. Same single
+    # arbiter as `claim`, no --force, so two machines racing a resume still yield
+    # exactly one winner.
+    lease="refs/claims/issue-${issue}:"
+  else
+    # Compare-and-swap: replace the ref ONLY if origin is still at <old-sha>.
+    lease="refs/claims/issue-${issue}:${expect}"
+  fi
+  # We ignore the push exit here and let the infra-AWARE confirm read below decide
+  # — mirroring cmd_claim exactly, so a lease-mismatch, a TOCTOU, and an infra blip
   # are told apart by the READ, never by the push's opaque non-zero.
-  adopt_err="$(git push --force-with-lease="refs/claims/issue-${issue}:${expect}" \
+  adopt_err="$(git push --force-with-lease="$lease" \
         "$REMOTE" "${sha}:refs/claims/issue-${issue}" 2>&1 >/dev/null)" || true
   # ...with ONE exception (issue #2942): a CREDENTIAL failure is not something the
   # read can diagnose. On a public repo the confirm read succeeds and would report
@@ -459,9 +557,18 @@ cmd_adopt() {
     return 1
   fi
   local now="$REPLY_SHA"
+  local record=""
+  [ -z "$extra" ] || record=" $extra"
   if [ "$now" = "$sha" ]; then
-    emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$sha machine=$(this_machine) actor=$actor from=$expect"
+    emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$sha machine=$(this_machine) actor=$actor from=$expect$record"
     return 0
+  fi
+  if [ -z "$now" ] && [ "$mode" = "empty" ]; then
+    # The empty-lease create did not land AND the ref is absent: nobody holds it,
+    # so this is NOT a lost race — it is a push/infra error (retryable, exit 1),
+    # exactly as `claim` treats a rejected push over an absent ref.
+    emit_infra "issue=$issue detail=adopt-empty-lease-rejected-but-ref-absent-on-$REMOTE (nobody holds it — not a lost race)"
+    return 1
   fi
   fetch_claim "$issue"
   emit "ADOPT-LOST issue=$issue ref=refs/claims/issue-$issue expected=$expect actual=${now:-<gone>} $(holder_token "$now")"
@@ -597,7 +704,7 @@ cmd_status() {
 
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    local sha ref issue msg machine actor ts age epoch
+    local sha ref issue msg machine actor ts age epoch reason record
     sha="$(printf '%s' "$line" | awk '{print $1}')"
     ref="$(printf '%s' "$line" | awk '{print $2}')"
     # Only issue claim refs are rendered — skip stray refs under refs/claims/*
@@ -618,7 +725,12 @@ cmd_status() {
     else
       age="unknown"
     fi
-    emit "STATUS issue=$issue ref=$ref sha=$sha machine=$machine actor=$actor ts=$ts age=$age"
+    # An adopt-resume records why it took the ref (#2945); surface it so a reader
+    # of the board sees the justification, not just the holder.
+    reason="$(msg_field "$msg" reason)"
+    record=""
+    [ -z "$reason" ] || record=" reason=$reason"
+    emit "STATUS issue=$issue ref=$ref sha=$sha machine=$machine actor=$actor ts=$ts age=$age$record"
   done <<< "$raw"
   return 0
 }
@@ -672,6 +784,6 @@ case "$SUBCOMMAND" in
   status)  shift; cmd_status  "${1:-}" ;;
   smoke)   shift; cmd_smoke ;;
   -h | --help) print_help ;;
-  "") die_usage "a subcommand is required: claim <N> | verify <N> | adopt <N> --expect <sha> | release <N> [--force] | status [<N>] | smoke" ;;
+  "") die_usage "a subcommand is required: claim <N> | verify <N> | adopt <N> --expect <sha>|none [--reason <why>] | release <N> [--force] | status [<N>] | smoke" ;;
   *)  die_usage "unknown subcommand: $SUBCOMMAND (expected claim|verify|adopt|release|status|smoke)" ;;
 esac

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -45,11 +45,17 @@
 # LEGACY GUARD (mixed-fleet safety): older workers still branch-lock with a
 # `refs/heads/issue-<N>-*` branch. `claim` refuses if any such branch exists on
 # origin (treat the issue as already-claimed) and names the resume command above
-# in its refusal — but ONLY when the issue has ZERO open PRs. An older-fleet worker
-# holds only the BRANCH, so `claim-ref=free` is true while it works, and advertising
-# the empty-lease adopt would hand an ACTIVE issue to a second machine. With an open
-# PR (or an unreadable PR list) the refusal prints `remediation=withheld open-prs=<n>`
+# in its refusal — but ONLY when the lane is DEMONSTRABLY ORPHANED per
+# `hatch_liveness`: zero open PRs AND every matching branch tip older than
+# claim-heartbeat.sh's reap threshold AND no fresh machine-claim/heartbeat ref naming
+# the issue. An older-fleet worker holds only the BRANCH, so `claim-ref=free` is true
+# while it works — and because a PR is opened LATE in this pipeline, "no open PR" is
+# also true for most of its life, which is why the branch-tip age and the liveness
+# refs (the PRE-PR window) are part of the test. Otherwise — a live signal OR any
+# signal that could not be READ — the refusal prints `remediation=withheld <signals>`
 # instead: fail closed, because the readers run printed remediations literally (#2945).
+# The advertised command carries a CONCRETE `--reason resume-legacy-branch-lock:<branch>`
+# rather than a `<why>` placeholder, since it will be run verbatim.
 # There is NO tip-based re-entrancy exemption: a work branch is
 # cut from origin/main and carries ordinary commits, so its tip NEVER carries the
 # machine=/actor= claim trailers — the old "all-ours -> no block" escape hatch was
@@ -86,7 +92,10 @@
 #                                             is REQUIRED and is recorded in the claim commit.
 #                                             An EMPTY --expect '' is a usage error on purpose,
 #                                             as is a --reason with nothing recordable in it
-#                                             ('   ', '---', '…'): the record must say WHY.
+#                                             ('   ', '---', '…') or one that records as a bare
+#                                             PLACEHOLDER ('why', 'todo', 'tbd', 'xxx', …, the
+#                                             shape a verbatim-run `--reason <why>` produces):
+#                                             the record must say WHY.
 #                                             RE-ENTRANT: if the ref is already held by THIS
 #                                             machine+actor, adopt reports ADOPTED (re-entrant)
 #                                             exit 0 — a retry after a confirm-read blip must
@@ -126,9 +135,17 @@
 #
 # CONSTRAINTS
 #   macOS bash 3.2 compatible (no associative arrays, no readarray/mapfile).
-#   `set -euo pipefail`, shellcheck-clean. gh is used ONLY by `release` (open-PR
-#   guard) and degrades LOUDLY if gh is absent. All informative output is a
-#   single line prefixed `CLAIM:`.
+#   `set -euo pipefail`, shellcheck-clean. All informative output is a single line
+#   prefixed `CLAIM:` (notes/degradations go to stderr).
+#   gh is consulted by exactly TWO paths, both via `open_pr_count`, both degrading
+#   LOUDLY (stderr note + a `-1` count) when gh is absent/errors: `release` without
+#   --force (the open-PR guard) and `claim`'s LEGACY-BRANCH refusal (one
+#   `gh pr list --limit 1000` per refusal, as hatch_liveness's endgame signal, where
+#   `-1` WITHHOLDS the advertised remediation). Nothing else touches gh, and claim/
+#   adopt/release ARBITRATION never depends on it — gh only bounds how loud a refusal
+#   may be. That refusal also shells out to the sibling `claim-heartbeat.sh
+#   reap-threshold` (single source of the 4h staleness threshold); an unreadable
+#   answer withholds rather than defaulting.
 #
 # EXIT CODES
 #   0  success (CLAIM HELD, VERIFY-OK, ADOPTED, RELEASED, SMOKE-OK, status render)
@@ -304,6 +321,11 @@ remote_claim_lookup() {
 # shell metacharacters) to a single '-', trims leading/trailing '-', caps at 120
 # chars, and never prints an empty token.
 #
+# TRIM ORDER IS PART OF THE CONTRACT: the 120-char cut happens BEFORE the final
+# trim, because trimming first and truncating after can re-introduce the very
+# trailing separator the trim promised to remove (a reason whose 120th byte is a
+# '-' recorded as `…foo-`, #2945 review). Collapse -> trim -> cut -> re-trim.
+#
 # LC_ALL=C on BOTH tr and sed is load-bearing: BSD/macOS `tr` aborts with
 # "Illegal byte sequence" on non-ASCII input under a UTF-8 locale, and a `--reason`
 # with an em dash is a likely invocation in this repo. Under `set -euo pipefail`
@@ -313,6 +335,7 @@ sanitize_field() {
   local s
   s="$(printf '%s' "${1:-}" | LC_ALL=C tr -c 'A-Za-z0-9._:/#-' '-' | LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')"
   s="$(LC_ALL=C printf '%.120s' "$s")"
+  s="${s%-}"   # re-trim: the cut may have landed exactly on a separator
   [ -n "$s" ] || s="unspecified"
   printf '%s\n' "$s"
 }
@@ -413,6 +436,113 @@ legacy_branch_scan() {
   return 0
 }
 
+# reap_threshold_secs — "how old is stale enough to hand away", in seconds, read
+# from claim-heartbeat.sh (`reap-threshold`) so the fleet keeps exactly ONE
+# definition of the 4h staleness threshold instead of a second copy here that could
+# drift from the documented one (#2945 review). Prints the seconds (exit 0), or
+# returns 1 when the sibling script is missing/answers non-numerically — an
+# UNREADABLE signal, which callers must treat as "withhold", never as a default.
+reap_threshold_secs() {
+  local hb out
+  hb="$(dirname -- "${BASH_SOURCE[0]}")/claim-heartbeat.sh"
+  [ -f "$hb" ] || return 1
+  out="$(bash "$hb" reap-threshold 2>/dev/null)" || return 1
+  case "$out" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  printf '%s\n' "$out"
+}
+
+# hatch_liveness <N> <threshold-secs> — may the copy-pasteable empty-lease resume be
+# ADVERTISED for this issue, i.e. is its lane demonstrably ORPHANED?
+#
+# The open-PR signal ALONE does not answer this (#2945 review). In this pipeline the
+# PR is opened LATE (implement + review happen first), so an older-fleet worker that
+# is actively implementing has ZERO open PRs for most of its life while holding only
+# the BRANCH — and `claim-ref=free` is true for it. Advertising the hatch there is the
+# two-writer outcome the guard exists to prevent, and the readers run printed
+# remediations literally. So the PRE-PR window needs its own liveness evidence:
+#
+#   1. open PRs == 0                       (the ENDGAME signal; -1 = unreadable)
+#   2. EVERY matching issue-<N>-* branch tip is OLDER than <threshold> (the same
+#      staleness threshold `claim-heartbeat.sh should-reap` uses) — a worker mid-
+#      implementation pushes commits, so a FRESH tip means somebody is on it
+#   3. NO refs/machine-claims/* or refs/heartbeats/* ref FRESHLY names this issue
+#      (the supervisor-authored liveness proof of #2655; a ref older than the
+#      threshold is itself reapable and does not withhold)
+#
+# ANY signal that cannot be READ withholds — an unreachable remote, an unparseable
+# commit date and a missing threshold are all "we could not prove nobody is working
+# this", never an all-clear. Sets HATCH_SIGNALS (a single-line key=value run for the
+# refusal) and returns 0 = orphaned (advertise), 1 = withhold.
+HATCH_SIGNALS=""
+hatch_liveness() {
+  local issue="$1" threshold="$2"
+  local prs now raw line refname msg tip_ct age min_age="" ref_issue ref_ts ref_epoch
+
+  prs="$(open_pr_count "$issue")"
+  HATCH_SIGNALS="open-prs=$prs"
+  [ "$prs" = "0" ] || return 1
+
+  now="$(date -u +%s)"
+  while IFS= read -r refname; do
+    [ -n "$refname" ] || continue
+    if ! git fetch "$REMOTE" "$refname" >/dev/null 2>&1 \
+       || ! tip_ct="$(git log -1 --format=%ct FETCH_HEAD 2>/dev/null)" \
+       || [ -z "$tip_ct" ] || [ -n "${tip_ct//[0-9]/}" ]; then
+      HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=unreadable:${refname}"
+      return 1
+    fi
+    age=$((now - tip_ct))
+    [ "$age" -ge 0 ] || age=0
+    if [ -z "$min_age" ] || [ "$age" -lt "$min_age" ]; then min_age="$age"; fi
+  done <<< "$(printf '%s' "$LEGACY_BRANCHES" | tr ',' '\n')"
+  if [ -z "$min_age" ]; then
+    HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=unreadable"
+    return 1
+  fi
+  HATCH_SIGNALS="$HATCH_SIGNALS newest-branch-tip=$(humanize_age "$min_age") stale-after=$(humanize_age "$threshold")"
+  [ "$min_age" -gt "$threshold" ] || return 1
+
+  if ! raw="$(git ls-remote "$REMOTE" 'refs/machine-claims/*' 'refs/heartbeats/*' 2>/dev/null)"; then
+    HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=unreadable"
+    return 1
+  fi
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    refname="$(printf '%s' "$line" | awk '{print $2}')"
+    [ -n "$refname" ] || continue
+    if ! git fetch "$REMOTE" "$refname" >/dev/null 2>&1 \
+       || ! msg="$(git log -1 --format=%B FETCH_HEAD 2>/dev/null)" || [ -z "$msg" ]; then
+      HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=unreadable:${refname}"
+      return 1
+    fi
+    ref_issue="$(msg_field "$msg" issue)"
+    if [ -z "$ref_issue" ]; then
+      HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=unreadable:${refname}"
+      return 1
+    fi
+    [ "$ref_issue" = "$issue" ] || continue
+    # This ref names OUR issue. Fresh -> a worker is on it. Unparseable ts -> we
+    # cannot age it out, so it withholds (fail closed) exactly like should-reap
+    # refuses to reap on an unknown age.
+    ref_ts="$(msg_field "$msg" ts)"
+    if [ -z "$ref_ts" ] || ! ref_epoch="$(ts_to_epoch "$ref_ts")"; then
+      HATCH_SIGNALS="$HATCH_SIGNALS liveness-ref=${refname}:unparseable-ts"
+      return 1
+    fi
+    age=$((now - ref_epoch))
+    [ "$age" -ge 0 ] || age=0
+    if [ "$age" -le "$threshold" ]; then
+      HATCH_SIGNALS="$HATCH_SIGNALS liveness-ref=${refname}:age=$(humanize_age "$age")"
+      return 1
+    fi
+  done <<< "$raw"
+
+  HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=none-naming-$issue"
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 cmd_claim() {
   local issue="" actor="${CLAIM_ACTOR:-flow}"
@@ -456,17 +586,24 @@ cmd_claim() {
     # so `claim-ref=free` is true for it and the advertised empty-lease adopt WOULD
     # succeed — a second machine on an actively-worked issue. Prose hedging ("if it
     # is YOURS") is not a control: the readers are agents that run printed
-    # remediations literally. So the copy-pasteable command is printed ONLY when the
-    # endgame is demonstrably orphaned — zero open PRs on this issue's branch — using
-    # the same gh signal `release` already trusts for "somebody's endgame is live".
-    # Unknown (gh missing/failed, -1) withholds too: fail closed, never advertise a
-    # hand-away on an unread signal.
-    local prs remedy
-    prs="$(open_pr_count "$issue")"
-    if [ "$prs" = "0" ]; then
-      remedy="remediation='bash scripts/flow/claim.sh adopt $issue --expect none --reason <why>' open-prs=0 (no open PR: that branch is an older-fleet branch lock, a parked/reaped resume, or a merged-but-undeleted branch; the quoted empty-lease adopt takes the FREE claim ref atomically — git rejects it if any machine holds the claim ref)"
+    # remediations literally. So the copy-pasteable command is printed ONLY when
+    # hatch_liveness proves the lane ORPHANED across ALL its signals — no open PR
+    # (endgame), every branch tip staler than the reap threshold (the PRE-PR window,
+    # where an actively-implementing legacy worker has no PR at all), and no fresh
+    # machine-claim/heartbeat ref naming this issue. Any unreadable signal withholds:
+    # fail closed, never advertise a hand-away on evidence we could not read.
+    # The printed --reason is a CONCRETE, self-describing default, not a `<why>`
+    # placeholder: run verbatim, `<why>` recorded as `reason=why` — as uninformative
+    # as the no-reason case the audit gate rejects (cmd_adopt now refuses that token).
+    local remedy threshold hatch_branch
+    if ! threshold="$(reap_threshold_secs)"; then
+      remedy="remediation=withheld liveness=threshold-unreadable (could not read the staleness threshold from claim-heartbeat.sh reap-threshold, so the lane cannot be shown orphaned; fix the checkout, then see 'bash scripts/flow/claim.sh -h')"
+    elif hatch_liveness "$issue" "$threshold"; then
+      hatch_branch="${LEGACY_BRANCHES%%,*}"
+      hatch_branch="${hatch_branch#refs/heads/}"
+      remedy="remediation='bash scripts/flow/claim.sh adopt $issue --expect none --reason resume-legacy-branch-lock:${hatch_branch}' $HATCH_SIGNALS (orphaned lane: no open PR, every branch tip staler than the reap threshold, no fresh liveness ref for this issue — an older-fleet branch lock left behind, a parked/reaped resume, or a merged-but-undeleted branch; the quoted empty-lease adopt takes the FREE claim ref atomically — git rejects it if any machine holds the claim ref)"
     else
-      remedy="remediation=withheld open-prs=$prs (an open PR — or, at -1, an unreadable PR list — means someone's endgame may be LIVE, and an older-fleet worker holds only the BRANCH, so an empty-lease adopt WOULD succeed and create a SECOND writer; confirm ownership via the board and the PR author first, then see 'bash scripts/flow/claim.sh -h')"
+      remedy="remediation=withheld $HATCH_SIGNALS (this lane may be LIVE or is unproven: an open PR (or an unreadable -1 PR list), a branch tip fresher than the reap threshold — an older-fleet worker mid-implementation holds only the BRANCH and has NO PR yet — or a fresh machine-claim/heartbeat ref naming this issue. An empty-lease adopt WOULD succeed there and create a SECOND writer; confirm ownership via the board and the branch/PR author first, then see 'bash scripts/flow/claim.sh -h')"
     fi
     emit "LOST issue=$issue reason=legacy-branch-lock detail=$LEGACY_BRANCHES exists on $REMOTE claim-ref=free $remedy"
     return 2
@@ -623,6 +760,19 @@ cmd_adopt() {
     if [ "$reason_token" = "unspecified" ] || [ "${#reason_token}" -lt 3 ]; then
       die_usage "adopt: --reason must carry at least 3 recordable characters ([A-Za-z0-9._:/#-]); '$reason' records as '$reason_token', which is indistinguishable from no reason at all"
     fi
+    # PLACEHOLDER TOKENS ARE REFUSED (#2945 review). A doc/help line that shows
+    # `--reason <why>` is run VERBATIM by the readers of these commands, and `<why>`
+    # sanitizes to `why` — 3 recordable chars, so the length gate passes and the
+    # record says `reason=why`: exactly as uninformative as the no-reason case this
+    # gate exists to reject. So the sentinel set is refused BY NAME too (the printed
+    # remediation now carries a concrete self-describing default instead, see
+    # cmd_claim). Case-insensitive; the list is the placeholder vocabulary that shows
+    # up in help text and templates, not an attempt at judging prose quality.
+    case "$(printf '%s' "$reason_token" | LC_ALL=C tr 'A-Z' 'a-z')" in
+      why | reason | todo | tbd | tba | xxx | xxxx | placeholder | fixme | none | foo | bar | baz | n/a)
+        die_usage "adopt: --reason '$reason' records as the PLACEHOLDER '$reason_token' — as uninformative as no reason at all. Say what the resume IS, e.g. --reason resume-legacy-branch-lock:issue-$issue-<slug> or --reason 'reaped claim, board says Ready'"
+        ;;
+    esac
   fi
   if [ "$mode" = "empty" ]; then
     # The resume is a judgement call, so it MUST be self-documenting: the claim

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -78,6 +78,10 @@
 #                                             `issue-<N>-*` branch outlived its claim; --reason
 #                                             is REQUIRED and is recorded in the claim commit.
 #                                             An EMPTY --expect '' is a usage error on purpose.
+#                                             RE-ENTRANT: if the ref is already held by THIS
+#                                             machine+actor, adopt reports ADOPTED (re-entrant)
+#                                             exit 0 — a retry after a confirm-read blip must
+#                                             never abandon an issue we still hold.
 #   release <N> [--force] [--actor <id>]      delete the ref; without --force requires holder identity
 #                                             (machine+actor) + no open PR, and deletes via CAS lease.
 #                                             --force = reaper/adopt: unconditional delete.
@@ -94,6 +98,11 @@
 #            re-entrancy / cross-release). Tests also use it to simulate multiple
 #            machines from one clone.
 #   actor    --actor <id>, else CLAIM_ACTOR, else "flow" — a sub-machine role.
+#            SANITIZED to one token before it is written OR compared (see
+#            sanitize_field): the actor is part of the holder identity and lands in
+#            the same commit message the identity parser reads, so an unsanitized
+#            actor (e.g. `--actor 'flow machine=other'`) could forge a holder and win
+#            false re-entrancy on someone else's claim (#2945).
 #   The holder identity that `verify`/`release` match is machine+actor.
 #
 # ENV
@@ -217,8 +226,35 @@ humanize_age() {
 this_machine() { printf '%s\n' "${CLAIM_MACHINE:-$(hostname -s)}"; }
 
 # msg_field <message> <key> — extract "<key>=<value>" (value is a non-space run).
+#
+# EXACT-KEY, FIRST-MATCH, ANCHORED PER TOKEN (identity-forgery hardening, #2945).
+# The old implementation was `sed "s/.*<key>=\([^ ]*\).*/\1/"`: the leading `.*` is
+# GREEDY, so the LAST occurrence won and any key was matched as a SUBSTRING. Since
+# free-text `--reason`/`--actor` values are appended to the very message this parser
+# reads, a value carrying `machine=<other>` could FORGE holder identity — and holder
+# identity is what gates re-entrancy, verify, and release. Fixing that at the parser
+# is the root fix: split the message on whitespace, compare each token's key for
+# EQUALITY (so neither `holder-machine=` nor an appended `machine=` in a later field
+# can answer for `machine`), and return the FIRST match — the trailers this script
+# writes itself, which always precede any user-supplied field. Sanitizing the
+# user-controlled fields (see sanitize_field) is the second, independent layer.
 msg_field() {
-  printf '%s' "$1" | sed -n "s/.*${2}=\\([^ ]*\\).*/\\1/p" | head -1
+  local msg="$1" key="$2" tok glob_was_off=0
+  # Word-splitting needs the tokens UNGLOBBED: a forged message may contain '*'.
+  case "$-" in *f*) glob_was_off=1 ;; esac
+  set -f
+  # shellcheck disable=SC2086  # deliberate word-split of the claim message
+  for tok in $msg; do
+    case "$tok" in
+      "$key"=*)
+        printf '%s\n' "${tok#*=}"
+        [ "$glob_was_off" = 1 ] || set +f
+        return 0
+        ;;
+    esac
+  done
+  [ "$glob_was_off" = 1 ] || set +f
+  return 0
 }
 
 # remote_claim_sha <N> — SHA of refs/claims/issue-<N> on origin ("" if absent).
@@ -245,19 +281,33 @@ remote_claim_lookup() {
   return 0
 }
 
-# sanitize_reason <text> — collapse a free-text reason into ONE parseable token.
-# The claim message is parsed as `<key>=<non-space-run>`, so a reason containing
-# spaces would be silently truncated at the first space. Keeps [A-Za-z0-9._:/#-],
-# maps every other run (spaces, newlines, quotes, shell metacharacters) to a
-# single '-', trims leading/trailing '-', caps at 120 chars, and never prints an
-# empty token.
-sanitize_reason() {
+# sanitize_field <text> — collapse a free-text value into ONE parseable token.
+# Applied to EVERY user-controlled field that lands in the claim message: --reason
+# AND --actor (the latter is part of the holder identity, so an unsanitized actor
+# was itself a forgery vector, #2945). The message is parsed as
+# `<key>=<non-space-run>`, so a value containing spaces would be truncated at the
+# first space. Keeps [A-Za-z0-9._:/#-] — note '=' is NOT kept, so a value can never
+# introduce a new `key=` pair — maps every other run (spaces, newlines, quotes,
+# shell metacharacters) to a single '-', trims leading/trailing '-', caps at 120
+# chars, and never prints an empty token.
+#
+# LC_ALL=C on BOTH tr and sed is load-bearing: BSD/macOS `tr` aborts with
+# "Illegal byte sequence" on non-ASCII input under a UTF-8 locale, and a `--reason`
+# with an em dash is a likely invocation in this repo. Under `set -euo pipefail`
+# that failure inside a command substitution killed the whole script — no `CLAIM:`
+# line at all and a bogus exit 1 the contract reads as "retryable".
+sanitize_field() {
   local s
-  s="$(printf '%s' "${1:-}" | tr -c 'A-Za-z0-9._:/#-' '-' | sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')"
-  s="$(printf '%.120s' "$s")"
+  s="$(printf '%s' "${1:-}" | LC_ALL=C tr -c 'A-Za-z0-9._:/#-' '-' | LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')"
+  s="$(LC_ALL=C printf '%.120s' "$s")"
   [ -n "$s" ] || s="unspecified"
   printf '%s\n' "$s"
 }
+
+# resolve_actor <raw> — the actor identity, sanitized to one token. Sanitizing at
+# the ARG BOUNDARY (every subcommand, before any comparison) keeps the written
+# record and the identity match on exactly the same value.
+resolve_actor() { sanitize_field "${1:-}"; }
 
 # build_claim_commit <N> <actor> [extra-fields] — create a UNIQUE root commit
 # (empty tree, no parent) and print its SHA. The nonce guarantees distinct SHAs
@@ -361,6 +411,7 @@ cmd_claim() {
     esac
   done
   require_numeric_issue "$issue" claim
+  actor="$(resolve_actor "$actor")"
 
   # Pre-check: an existing claim ref that is OURS is re-entrant (idempotent win).
   local existing
@@ -459,6 +510,7 @@ cmd_verify() {
     esac
   done
   require_numeric_issue "$issue" verify
+  actor="$(resolve_actor "$actor")"
 
   # ls-remote failure is INFRA (retryable), not "you don't hold it" — never let a
   # network blip make a worker conclude it lost ownership.
@@ -493,6 +545,7 @@ cmd_adopt() {
     esac
   done
   require_numeric_issue "$issue" adopt
+  actor="$(resolve_actor "$actor")"
   # An EMPTY --expect stays a USAGE ERROR (fail closed): an unset shell variable
   # expanding to "" must NEVER silently turn a compare-and-swap into a create.
   # The empty lease is opt-in via the explicit literal `none`.
@@ -515,9 +568,9 @@ cmd_adopt() {
     # The resume is a judgement call, so it MUST be self-documenting: the claim
     # commit records who took it (machine/actor/ts) AND why (reason).
     [ -n "$reason" ] || die_usage "adopt --expect none requires --reason <why> (the resume is recorded in the claim commit: who took it AND why)"
-    extra="mode=empty-lease reason=$(sanitize_reason "$reason")"
+    extra="mode=empty-lease reason=$(sanitize_field "$reason")"
   elif [ -n "$reason" ]; then
-    extra="mode=cas reason=$(sanitize_reason "$reason")"
+    extra="mode=cas reason=$(sanitize_field "$reason")"
   fi
 
   local sha lease adopt_err=""
@@ -571,6 +624,20 @@ cmd_adopt() {
     return 1
   fi
   fetch_claim "$issue"
+  # RE-ENTRANCY (#2945): the ref is not our NEW sha, but it may already be OURS —
+  # the documented remedy for the `ERROR reason=infra` paths above is "retry", and a
+  # retry builds a FRESH claim commit whose empty-lease push is then correctly
+  # rejected (the ref now exists, because the first attempt's push DID land and only
+  # its confirm read failed). Without this check that lands on ADOPT-LOST — exit 2,
+  # which workers read as "you did not win, take the next item" — so a machine
+  # abandons an issue it demonstrably owns WHILE STILL HOLDING the claim ref, and
+  # nobody else can take it either. `cmd_claim` has had this identity check on both
+  # of its failure paths from the start; `adopt` is now the ONLY way past the legacy
+  # guard, so it needs the same idempotence.
+  if [ -n "$now" ] && holder_is_us "$now" "$actor"; then
+    emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") from=$expect (re-entrant)"
+    return 0
+  fi
   emit "ADOPT-LOST issue=$issue ref=refs/claims/issue-$issue expected=$expect actual=${now:-<gone>} $(holder_token "$now")"
   return 2
 }
@@ -617,6 +684,7 @@ cmd_release() {
     esac
   done
   require_numeric_issue "$issue" release
+  actor="$(resolve_actor "$actor")"
 
   # ls-remote failure is INFRA (retryable), not "already absent" — never delete-
   # or claim-absent on a network blip.

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -42,22 +42,22 @@
 # push. It is NOT a bypass — git still arbitrates, so a machine actively holding
 # the claim ref keeps it (ADOPT-LOST, exit 2).
 #
+# IT IS DELIBERATELY NOT AUTO-ADVERTISED (owner decision, #2945). The refusal below
+# DIAGNOSES the lane (which branch blocks it, and that the claim ref itself is free)
+# and POINTS AT THE DOCUMENTED PROCEDURE — it never prints a copy-pasteable resume
+# command. The readers are agents that run printed remediations LITERALLY, so a
+# printed command is a hand-away, and deciding whether a lane is truly abandoned
+# needs signals this script cannot read soundly (three successive attempts at such a
+# liveness probe each shipped a new way to hand an ACTIVELY-WORKED lane to a second
+# writer). The abandonment test lives where it already has the inputs:
+# `flow-board`'s reaper criteria / `claim-heartbeat.sh should-reap`, plus the board
+# Status and the branch/PR author.
+#
 # LEGACY GUARD (mixed-fleet safety): older workers still branch-lock with a
 # `refs/heads/issue-<N>-*` branch. `claim` refuses if any such branch exists on
-# origin (treat the issue as already-claimed) and names the resume command above
-# in its refusal — but ONLY when the lane is DEMONSTRABLY ORPHANED per
-# `hatch_liveness`: zero open PRs AND every matching branch tip carrying at least one
-# commit of its OWN and older than claim-heartbeat.sh's reap threshold AND no fresh
-# machine-claim/heartbeat ref naming the issue. A branch with no commits beyond
-# origin/main (what `flow-activate` pushes at activation) has NO age signal at all, so
-# it is INDETERMINATE and withholds. An older-fleet worker holds only the BRANCH, so `claim-ref=free` is true
-# while it works — and because a PR is opened LATE in this pipeline, "no open PR" is
-# also true for most of its life, which is why the branch-tip age and the liveness
-# refs (the PRE-PR window) are part of the test. Otherwise — a live signal OR any
-# signal that could not be READ — the refusal prints `remediation=withheld <signals>`
-# instead: fail closed, because the readers run printed remediations literally (#2945).
-# The advertised command carries a CONCRETE `--reason resume-legacy-branch-lock:<branch>`
-# rather than a `<why>` placeholder, since it will be run verbatim.
+# origin (treat the issue as already-claimed), naming the blocking branch(es) and
+# `claim-ref=free` — a diagnosis that used to be missing, and without which a worker
+# cannot tell this refusal from a genuinely held claim.
 # There is NO tip-based re-entrancy exemption: a work branch is
 # cut from origin/main and carries ordinary commits, so its tip NEVER carries the
 # machine=/actor= claim trailers — the old "all-ours -> no block" escape hatch was
@@ -142,15 +142,11 @@
 #   macOS bash 3.2 compatible (no associative arrays, no readarray/mapfile).
 #   `set -euo pipefail`, shellcheck-clean. All informative output is a single line
 #   prefixed `CLAIM:` (notes/degradations go to stderr).
-#   gh is consulted by exactly TWO paths, both via `open_pr_count`, both degrading
-#   LOUDLY (stderr note + a `-1` count) when gh is absent/errors: `release` without
-#   --force (the open-PR guard) and `claim`'s LEGACY-BRANCH refusal (one
-#   `gh pr list --limit 1000` per refusal, as hatch_liveness's endgame signal, where
-#   `-1` WITHHOLDS the advertised remediation). Nothing else touches gh, and claim/
-#   adopt/release ARBITRATION never depends on it — gh only bounds how loud a refusal
-#   may be. That refusal also shells out to the sibling `claim-heartbeat.sh
-#   reap-threshold` (single source of the 4h staleness threshold); an unreadable
-#   answer withholds rather than defaulting.
+#   gh is consulted by exactly ONE path, via `open_pr_count`, degrading LOUDLY
+#   (stderr note + a `-1` count) when gh is absent/errors: `release` without --force
+#   (the open-PR guard). Nothing else touches gh — `claim` (including its
+#   LEGACY-BRANCH refusal), `adopt` and `release --force` never run it, so no
+#   arbitration or refusal text depends on a GitHub read.
 #
 # EXIT CODES
 #   0  success (CLAIM HELD, VERIFY-OK, ADOPTED, RELEASED, SMOKE-OK, status render)
@@ -441,198 +437,6 @@ legacy_branch_scan() {
   return 0
 }
 
-# reap_threshold_secs — "how old is stale enough to hand away", in seconds, read
-# from claim-heartbeat.sh (`reap-threshold`) so the fleet keeps exactly ONE
-# definition of the 4h staleness threshold instead of a second copy here that could
-# drift from the documented one (#2945 review). Prints the seconds (exit 0), or
-# returns 1 when the sibling script is missing/answers non-numerically — an
-# UNREADABLE signal, which callers must treat as "withhold", never as a default.
-reap_threshold_secs() {
-  local hb out
-  hb="$(dirname -- "${BASH_SOURCE[0]}")/claim-heartbeat.sh"
-  [ -f "$hb" ] || return 1
-  out="$(bash "$hb" reap-threshold 2>/dev/null)" || return 1
-  case "$out" in
-    '' | *[!0-9]*) return 1 ;;
-  esac
-  printf '%s\n' "$out"
-}
-
-# hatch_fetch_ref <remote-ref> <slot> — fetch <remote-ref> from origin into the
-# PRIVATE local ref refs/hatch-scan/<slot> and print its commit sha; returns 1 when
-# ANY step is unreadable (callers withhold).
-#
-# EXPLICIT REFSPEC, NEVER FETCH_HEAD: the liveness scan fetches several refs in a
-# row and every `git fetch` REWRITES FETCH_HEAD, so reading FETCH_HEAD is a
-# clobbering hazard — one stale read ages the WRONG commit. Fetching (not just
-# ls-remote'ing) is also what makes the objects local, which the ancestry test below
-# needs. The slots are force-updated (`+`) and deleted by hatch_liveness afterwards.
-hatch_fetch_ref() {
-  local refname="$1" slot="refs/hatch-scan/$2" sha
-  git fetch --quiet --no-tags "$REMOTE" "+${refname}:${slot}" >/dev/null 2>&1 || return 1
-  sha="$(git rev-parse --verify --quiet "${slot}^{commit}")" || return 1
-  [ -n "$sha" ] || return 1
-  printf '%s\n' "$sha"
-}
-
-# hatch_tip_has_own_commits <tip-sha> <base-sha> — does this branch tip carry at
-# least ONE commit beyond origin's default branch?
-#   0  yes — the tip is the worker's OWN work, so its committer date means something
-#   1  no  — the tip IS the base (or an ancestor of it). `flow-activate` creates the
-#            work branch with `git worktree add -b issue-<N>-<slug> origin/main` and
-#            pushes it with NO commits of its own, so such a tip's date is
-#            origin/main's and carries ZERO information about the worker (#2945
-#            review). Age-judging it made an actively-worked lane look "stale"
-#            whenever main had been quiet longer than the threshold (overnight is
-#            routine) and advertised a hand-away for it — two writers on one issue.
-#   2  the ancestry test itself could not be run — an unread signal.
-hatch_tip_has_own_commits() {
-  local rc=0
-  git merge-base --is-ancestor "$1" "$2" >/dev/null 2>&1 || rc=$?
-  case "$rc" in
-    0) return 1 ;;
-    1) return 0 ;;
-    *) return 2 ;;
-  esac
-}
-
-# hatch_liveness <N> <threshold-secs> — may the copy-pasteable empty-lease resume be
-# ADVERTISED for this issue, i.e. is its lane demonstrably ORPHANED?
-#
-# The open-PR signal ALONE does not answer this (#2945 review). In this pipeline the
-# PR is opened LATE (implement + review happen first), so an older-fleet worker that
-# is actively implementing has ZERO open PRs for most of its life while holding only
-# the BRANCH — and `claim-ref=free` is true for it. Advertising the hatch there is the
-# two-writer outcome the guard exists to prevent, and the readers run printed
-# remediations literally. So the PRE-PR window needs its own liveness evidence:
-#
-#   1. open PRs == 0                       (the ENDGAME signal; -1 = unreadable)
-#   2. EVERY matching issue-<N>-* branch tip CARRIES AT LEAST ONE COMMIT OF ITS OWN
-#      (beyond origin's default branch) and is OLDER than <threshold> (the same
-#      staleness threshold `claim-heartbeat.sh should-reap` uses) — a worker mid-
-#      implementation pushes commits, so a FRESH tip means somebody is on it. A tip
-#      with NO own commits is what `flow-activate` pushes at activation time, so its
-#      date is origin/main's: NO INFORMATION, hence INDETERMINATE, hence withheld —
-#      never "stale" (#2945 review). The motivating cases (#2043, #1883) each carried
-#      their own OpenSpec commit, so they stay age-judgeable and still advertise.
-#   3. NO refs/machine-claims/* or refs/heartbeats/* ref that NAMES THIS ISSUE is
-#      fresher than <threshold> (the supervisor-authored liveness proof of #2655; a
-#      ref older than the threshold is itself reapable and does not withhold, and a
-#      ref naming another issue — or naming none at all — is not evidence about THIS
-#      lane, so it does not withhold either)
-#
-# ANY signal that cannot be READ withholds — an unreachable remote, an unreadable
-# default-branch/ancestry test, an unparseable commit date and a missing threshold are
-# all "we could not prove nobody is working this", never an all-clear. Sets
-# HATCH_SIGNALS (a single-line key=value run for the refusal) and returns 0 = orphaned
-# (advertise), 1 = withhold.
-HATCH_SIGNALS=""
-hatch_liveness() {
-  local rc=0
-  hatch_liveness_scan "$@" || rc=$?
-  # The private scan slots are scratch, not state: drop them so the scan never leaves
-  # fetched objects pinned in the caller's checkout.
-  git update-ref -d refs/hatch-scan/base   >/dev/null 2>&1 || true
-  git update-ref -d refs/hatch-scan/branch >/dev/null 2>&1 || true
-  git update-ref -d refs/hatch-scan/live   >/dev/null 2>&1 || true
-  return "$rc"
-}
-
-hatch_liveness_scan() {
-  local issue="$1" threshold="$2"
-  local prs now raw line refname msg base tip tip_ct age min_age="" own_rc ref_issue ref_ts ref_epoch
-
-  prs="$(open_pr_count "$issue")"
-  HATCH_SIGNALS="open-prs=$prs"
-  [ "$prs" = "0" ] || return 1
-
-  # The BASE a work branch is cut from: origin's default branch, read as the remote's
-  # HEAD so no branch name is hardcoded. FETCHED, because the ancestry test needs its
-  # objects locally — and an unreadable base is an UNREAD signal, so it withholds
-  # rather than silently letting every tip count as "own work" (which would restore
-  # the vacuous age verdict this signal exists to remove).
-  if ! base="$(hatch_fetch_ref HEAD base)"; then
-    HATCH_SIGNALS="$HATCH_SIGNALS default-branch-tip=unreadable"
-    return 1
-  fi
-
-  now="$(date -u +%s)"
-  while IFS= read -r refname; do
-    [ -n "$refname" ] || continue
-    if ! tip="$(hatch_fetch_ref "$refname" branch)"; then
-      HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=unreadable:${refname}"
-      return 1
-    fi
-    own_rc=0
-    hatch_tip_has_own_commits "$tip" "$base" || own_rc=$?
-    if [ "$own_rc" = "1" ]; then
-      # INDETERMINATE, not stale: a freshly-activated branch carries no commits of
-      # its own, so there is nothing here to age. Withhold, with a self-describing
-      # marker so the reader sees WHY no age was reported.
-      HATCH_SIGNALS="$HATCH_SIGNALS newest-branch-tip=no-own-commits:${refname}"
-      return 1
-    fi
-    if [ "$own_rc" != "0" ]; then
-      HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=ancestry-unreadable:${refname}"
-      return 1
-    fi
-    if ! tip_ct="$(git log -1 --format=%ct "$tip" 2>/dev/null)" \
-       || [ -z "$tip_ct" ] || [ -n "${tip_ct//[0-9]/}" ]; then
-      HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=unreadable:${refname}"
-      return 1
-    fi
-    age=$((now - tip_ct))
-    [ "$age" -ge 0 ] || age=0
-    if [ -z "$min_age" ] || [ "$age" -lt "$min_age" ]; then min_age="$age"; fi
-  done <<< "$(printf '%s' "$LEGACY_BRANCHES" | tr ',' '\n')"
-  if [ -z "$min_age" ]; then
-    HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=unreadable"
-    return 1
-  fi
-  HATCH_SIGNALS="$HATCH_SIGNALS newest-branch-tip=$(humanize_age "$min_age") stale-after=$(humanize_age "$threshold")"
-  [ "$min_age" -gt "$threshold" ] || return 1
-
-  if ! raw="$(git ls-remote "$REMOTE" 'refs/machine-claims/*' 'refs/heartbeats/*' 2>/dev/null)"; then
-    HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=unreadable"
-    return 1
-  fi
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    refname="$(printf '%s' "$line" | awk '{print $2}')"
-    [ -n "$refname" ] || continue
-    if ! tip="$(hatch_fetch_ref "$refname" live)" \
-       || ! msg="$(git log -1 --format=%B "$tip" 2>/dev/null)"; then
-      # We could not READ this ref at all, so we cannot rule out that it names our
-      # issue → withhold (fail closed).
-      HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=unreadable:${refname}"
-      return 1
-    fi
-    # SCOPED TO THIS ISSUE (#2945 review). A ref we CAN read that does not name this
-    # issue — another issue's claim, or a legacy/foreign ref with no `issue=` trailer
-    # at all — is not evidence about THIS lane. Withholding on it blocked the hatch
-    # FLEET-WIDE for EVERY issue, re-creating the permanent dead end this change
-    # exists to remove. Skipped, not withheld.
-    ref_issue="$(msg_field "$msg" issue)"
-    [ "$ref_issue" = "$issue" ] || continue
-    # This ref names OUR issue. Fresh -> a worker is on it. Unparseable ts -> we
-    # cannot age it out, so it withholds (fail closed) exactly like should-reap
-    # refuses to reap on an unknown age.
-    ref_ts="$(msg_field "$msg" ts)"
-    if [ -z "$ref_ts" ] || ! ref_epoch="$(ts_to_epoch "$ref_ts")"; then
-      HATCH_SIGNALS="$HATCH_SIGNALS liveness-ref=${refname}:unparseable-ts"
-      return 1
-    fi
-    age=$((now - ref_epoch))
-    [ "$age" -ge 0 ] || age=0
-    if [ "$age" -le "$threshold" ]; then
-      HATCH_SIGNALS="$HATCH_SIGNALS liveness-ref=${refname}:age=$(humanize_age "$age")"
-      return 1
-    fi
-  done <<< "$raw"
-
-  HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=none-naming-$issue"
-  return 0
-}
 
 # ---------------------------------------------------------------------------
 cmd_claim() {
@@ -661,42 +465,25 @@ cmd_claim() {
   fi
 
   # Legacy branch-lock guard (mixed fleet). An `issue-<N>-*` branch on origin is
-  # treated as an older worker's branch lock. The refusal NAMES the sanctioned
-  # resume command (#2945): a bare LOST is what previously sent workers into
-  # hand-crafted claim-commit pushes. An enumeration OUTAGE is UNKNOWN, not an
-  # all-clear (#2677 item 2) — it maps to ERROR infra (retryable), never a claim
+  # treated as an older worker's branch lock. An enumeration OUTAGE is UNKNOWN, not
+  # an all-clear (#2677 item 2) — it maps to ERROR infra (retryable), never a claim
   # granted on an unread guard.
   if ! legacy_branch_scan "$issue"; then
     emit_infra "issue=$issue detail=legacy-branch-ls-remote-unreachable-on-$REMOTE (cannot tell 'no legacy branch' from an outage)"
     return 1
   fi
   if [ -n "$LEGACY_BRANCHES" ]; then
-    # The refusal must be ACTIONABLE without being DANGEROUS (#2945 review). "git
-    # rejects it if any machine holds the ref" does NOT cover the case this guard
-    # exists for: an OLDER-fleet worker locks with the BRANCH and holds no claim ref,
-    # so `claim-ref=free` is true for it and the advertised empty-lease adopt WOULD
-    # succeed — a second machine on an actively-worked issue. Prose hedging ("if it
-    # is YOURS") is not a control: the readers are agents that run printed
-    # remediations literally. So the copy-pasteable command is printed ONLY when
-    # hatch_liveness proves the lane ORPHANED across ALL its signals — no open PR
-    # (endgame), every branch tip staler than the reap threshold (the PRE-PR window,
-    # where an actively-implementing legacy worker has no PR at all), and no fresh
-    # machine-claim/heartbeat ref naming this issue. Any unreadable signal withholds:
-    # fail closed, never advertise a hand-away on evidence we could not read.
-    # The printed --reason is a CONCRETE, self-describing default, not a `<why>`
-    # placeholder: run verbatim, `<why>` recorded as `reason=why` — as uninformative
-    # as the no-reason case the audit gate rejects (cmd_adopt now refuses that token).
-    local remedy threshold hatch_branch
-    if ! threshold="$(reap_threshold_secs)"; then
-      remedy="remediation=withheld liveness=threshold-unreadable (could not read the staleness threshold from claim-heartbeat.sh reap-threshold, so the lane cannot be shown orphaned; fix the checkout, then see 'bash scripts/flow/claim.sh -h')"
-    elif hatch_liveness "$issue" "$threshold"; then
-      hatch_branch="${LEGACY_BRANCHES%%,*}"
-      hatch_branch="${hatch_branch#refs/heads/}"
-      remedy="remediation='bash scripts/flow/claim.sh adopt $issue --expect none --reason resume-legacy-branch-lock:${hatch_branch}' $HATCH_SIGNALS (orphaned lane: no open PR, every branch tip carrying its OWN commits and staler than the reap threshold, no fresh liveness ref for this issue — an older-fleet branch lock left behind, a parked/reaped resume, or a merged-but-undeleted branch; the quoted empty-lease adopt takes the FREE claim ref atomically — git rejects it if any machine holds the claim ref)"
-    else
-      remedy="remediation=withheld $HATCH_SIGNALS (this lane may be LIVE or is unproven: an open PR (or an unreadable -1 PR list), a branch tip fresher than the reap threshold — an older-fleet worker mid-implementation holds only the BRANCH and has NO PR yet — a branch with NO commits of its own, whose tip date is just origin/main's and says nothing about the worker (newest-branch-tip=no-own-commits), or a fresh machine-claim/heartbeat ref naming this issue. An empty-lease adopt WOULD succeed there and create a SECOND writer; confirm ownership via the board and the branch/PR author first, then see 'bash scripts/flow/claim.sh -h')"
-    fi
-    emit "LOST issue=$issue reason=legacy-branch-lock detail=$LEGACY_BRANCHES exists on $REMOTE claim-ref=free $remedy"
+    # DIAGNOSE, DO NOT HAND OVER (owner decision, #2945). The refusal names the
+    # blocking branch(es) and says the claim REF is free — the diagnosis a bare LOST
+    # was missing, and the reason workers previously concluded the issue was a dead
+    # end and hand-crafted claim commits. It deliberately prints NO runnable resume
+    # command: the readers are agents that execute printed remediations literally, and
+    # an older-fleet worker locks with the BRANCH while holding no claim ref, so a
+    # printed empty-lease adopt WOULD succeed against an actively-worked lane. Deciding
+    # abandonment needs liveness inputs this script cannot read soundly (three
+    # successive in-script probes each shipped a fresh way to hand away a live lane),
+    # so the pointer goes to the tools that own that judgement.
+    emit "LOST issue=$issue reason=legacy-branch-lock detail=$LEGACY_BRANCHES exists on $REMOTE claim-ref=free resume=documented-procedure (the claim REF is FREE — this is an older worker's BRANCH lock, not a held claim. A sanctioned resume exists and is documented in the claim protocol (CLAUDE.md) and in 'bash scripts/flow/claim.sh -h'; it is intentionally NOT printed here as a runnable line. CONFIRM the lane is abandoned FIRST — flow-board's reaper criteria via claim-heartbeat.sh should-reap, the board Status, and the branch/PR author — then follow that documented procedure. Never resume a lane a live worker owns, and never hand-craft a claim commit)"
     return 2
   fi
 

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -93,7 +93,8 @@
 #                                             `issue-<N>-*` branch outlived its claim; --reason
 #                                             is REQUIRED and is recorded in the claim commit.
 #                                             An EMPTY --expect '' is a usage error on purpose,
-#                                             as is a --reason with nothing recordable in it
+#                                             as is a SUPPLIED --reason '' (on BOTH the empty-lease
+#                                             and the CAS path) or one with nothing recordable in it
 #                                             ('   ', '---', '…'), one that records as a bare
 #                                             PLACEHOLDER ('why', 'todo', 'tbd', 'xxx', …, the
 #                                             shape a verbatim-run `--reason <why>` produces),
@@ -166,9 +167,12 @@
 #      maps an ls-remote/push/delete failure to ERROR (exit 1), so a network blip never
 #      makes a worker conclude it LOST/does-not-hold/RELEASED. `claim` also never reports
 #      LOST when nobody holds the ref (a failed push whose re-read finds it absent), and
-#      neither `claim` nor `adopt` reports LOST/ADOPT-LOST when the holder commit's
-#      message is UNREADABLE (`detail=holder-commit-unreadable`): the best-effort fetch
-#      may simply not have landed the object, so the holder is unknown — possibly US.
+#      and NO subcommand reports LOST/ADOPT-LOST/VERIFY-FAIL/not-holder when the holder
+#      commit's message is UNREADABLE (`detail=holder-commit-unreadable`): the best-effort
+#      fetch may simply not have landed the object, so the holder is unknown — possibly US.
+#      `adopt` in CAS mode also never reports ADOPT-LOST while the ref still sits at
+#      exactly `--expect` (`detail=adopt-cas-rejected-but-ref-unchanged`): the lease
+#      precondition HELD, so the push failed for some other reason — no race happened.
 #      ALSO exit 1: `CLAIM ERROR reason=auth` — a push git could not AUTHENTICATE
 #      (issue #2942). Same exit code (callers keep treating 1 as "not a race"), but the
 #      verdict is explicitly NOT retryable: retrying cannot fix a missing credential.
@@ -188,6 +192,16 @@ emit()      { echo "CLAIM: $*"; }
 # with `return 1` per the header exit-code contract, so a network blip never makes
 # a worker conclude it lost ownership.
 emit_infra() { emit "ERROR reason=infra $* (transient — retry)"; }
+
+# emit_unreadable_holder <issue> <sha> — the claim commit's message could NOT be read
+# (holder_identity state 2). The holder is UNKNOWN — possibly US — so EVERY caller maps
+# it to this ONE retryable infra verdict, never to LOST / ADOPT-LOST / VERIFY-FAIL /
+# not-holder. Shared on purpose: four separate review rounds found this same
+# "an unread signal was reported as abandon/does-not-hold" shape in a different caller,
+# so the wording and the verdict live in exactly one place (#2945 review).
+emit_unreadable_holder() {
+  emit_infra "issue=$1 ref=refs/claims/issue-$1 sha=$2 detail=holder-commit-unreadable (the claim object did not fetch — the holder is UNKNOWN, possibly us; NOT a lost race and NOT a 'you do not hold it' verdict)"
+}
 
 # emit_auth <line> — a push git could not AUTHENTICATE (issue #2942). This is a
 # MACHINE-CONFIGURATION fault, not a blip: it cannot self-clear, so it must never
@@ -266,8 +280,6 @@ humanize_age() {
   else                          printf '%sd\n' "$((s / 86400))"
   fi
 }
-
-this_machine() { printf '%s\n' "${CLAIM_MACHINE:-$(hostname -s)}"; }
 
 # msg_field <message> <key> — extract "<key>=<value>" (value is a non-space run).
 #
@@ -354,6 +366,20 @@ sanitize_field() {
   printf '%s\n' "$s"
 }
 
+# this_machine — the machine identity, SANITIZED to one token (#2945 review). `machine=`
+# is the FIRST identity token in the claim message AND the value `verify`/non-forced
+# `release` compare against, and it was interpolated RAW — the one user-controlled field
+# sanitize_field's contract missed. Two consequences, both reachable through an env var:
+#   - CLAIM_MACHINE="build box" wrote `machine=build box pid=…`, so the parser returned
+#     `build` while the comparison used `build box` — the HOLDER could never verify or
+#     non-force-release its OWN claim: a permanently stuck ref needing --force.
+#   - a value carrying `actor=` shifted the recorded actor — the same forgery class closed
+#     for --reason/--actor.
+# Sanitizing HERE (one definition) rather than at each use guarantees the WRITTEN and the
+# COMPARED token are always the same value. A machine identity must still be UNIQUE per
+# box (see IDENTITY): sanitization makes it parseable, not distinct.
+this_machine() { sanitize_field "${CLAIM_MACHINE:-$(hostname -s)}"; }
+
 # resolve_actor <raw> — the actor identity, sanitized to one token. Sanitizing at
 # the ARG BOUNDARY (every subcommand, before any comparison) keeps the written
 # record and the identity match on exactly the same value.
@@ -405,11 +431,14 @@ build_claim_commit() {
 #      swallows its errors, so a transient fetch failure over an object we do not have
 #      locally lands here), so the holder is UNKNOWN — possibly US.
 # Collapsing 2 into 1 is the "an unread signal must never mean abandon" bug: callers
-# fall through to LOST/ADOPT-LOST (exit 2), which workers read as "you did not win,
-# take the next item". A machine would then drop an issue whose claim ref it still
-# holds, and nobody else could take it either (the ref is held) — a permanent stall,
-# whose tell is the empty `holder-machine= actor=` render. Every caller maps 2 to
-# `emit_infra` + exit 1 (retryable), like every other unread remote signal here.
+# fall through to LOST/ADOPT-LOST/VERIFY-FAIL/not-holder (exit 2), which workers read as
+# "you do not own this, move on". A machine would then drop an issue whose claim ref it
+# still holds, and nobody else could take it either (the ref is held) — a permanent
+# stall, whose tell is the empty `holder-machine= actor=` render. EVERY caller maps 2 to
+# `emit_unreadable_holder` + return 1 (retryable), like every other unread remote signal
+# here — and there is deliberately NO boolean wrapper around this function: the earlier
+# `holder_is_us` helper re-collapsed 2 into "someone else" for `verify` and `release`,
+# which is exactly how that contract was shipped false once already (#2945 review).
 holder_identity() {
   local sha="$1" actor="$2" msg h_machine h_actor
   msg="$(git log -1 --format=%B "$sha" 2>/dev/null || true)"
@@ -419,11 +448,6 @@ holder_identity() {
   [ "$h_machine" = "$(this_machine)" ] && [ "$h_actor" = "$actor" ] && return 0
   return 1
 }
-
-# holder_is_us <sha> <actor> — 0 iff the claim commit was authored by this
-# machine+actor (identity match). A boolean wrapper for the paths whose verdict does
-# not distinguish "someone else" from "unreadable"; use holder_identity where it must.
-holder_is_us() { holder_identity "$1" "$2"; }
 
 # fetch_claim <N> — ensure the claim object is present locally; no-op on absence.
 fetch_claim() {
@@ -460,8 +484,8 @@ holder_token() {
 #      map this to ERROR reason=infra (exit 1), matching every other remote read.
 # There is deliberately NO "is this branch ours" test: a work branch is cut from
 # origin/main and carries ordinary commits, so its tip NEVER carries the claim
-# machine=/actor= trailers, which made the old `holder_is_us`-based "all-ours -> no
-# block" re-entrancy unreachable (#2945). Re-entrancy for a branch you own is now
+# machine=/actor= trailers, which made the old identity-based "all-ours -> no block"
+# re-entrancy unreachable (#2945). Re-entrancy for a branch you own is now
 # expressed explicitly by `adopt <N> --expect none --reason <why>`, arbitrated by
 # the claim ref itself rather than guessed from a commit message.
 LEGACY_BRANCHES=""
@@ -513,7 +537,7 @@ cmd_claim() {
     # fetch is best-effort, so a transient failure leaves the claim object absent and
     # the message unreadable — including when the holder is US.
     if [ "$hrc" -eq 2 ]; then
-      emit_infra "issue=$issue ref=refs/claims/issue-$issue sha=$existing detail=holder-commit-unreadable (the claim object did not fetch — the holder is UNKNOWN, possibly us; NOT a lost race)"
+      emit_unreadable_holder "$issue" "$existing"
       return 1
     fi
     emit "LOST issue=$issue ref=refs/claims/issue-$issue sha=$existing $(holder_token "$existing")"
@@ -584,7 +608,7 @@ cmd_claim() {
     # Same rule as the pre-check: unreadable holder metadata is retryable infra, not a
     # LOST verdict on a ref that may well be ours.
     if [ "$hrc2" -eq 2 ]; then
-      emit_infra "issue=$issue ref=refs/claims/issue-$issue sha=$now detail=holder-commit-unreadable (the claim object did not fetch — the holder is UNKNOWN, possibly us; NOT a lost race)"
+      emit_unreadable_holder "$issue" "$now"
       return 1
     fi
     emit "LOST issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_token "$now")"
@@ -634,9 +658,20 @@ cmd_verify() {
     return 2
   fi
   fetch_claim "$issue"
-  if holder_is_us "$sha" "$actor"; then
+  # THREE outcomes, never two (#2945 review): an UNREADABLE holder commit must not be
+  # reported as "you do not hold it". `fetch_claim` is best effort, so a transient failure
+  # leaves the object absent and the message empty EVEN WHEN THE HOLDER IS US — and a
+  # `VERIFY-FAIL … holder-machine= actor=` exit 2 is precisely the verdict that makes a
+  # worker abandon an issue it still holds.
+  local vrc=0
+  holder_identity "$sha" "$actor" || vrc=$?
+  if [ "$vrc" -eq 0 ]; then
     emit "VERIFY-OK issue=$issue ref=refs/claims/issue-$issue sha=$sha $(holder_desc "$sha")"
     return 0
+  fi
+  if [ "$vrc" -eq 2 ]; then
+    emit_unreadable_holder "$issue" "$sha"
+    return 1
   fi
   emit "VERIFY-FAIL issue=$issue ref=refs/claims/issue-$issue sha=$sha holder-$(holder_desc "$sha") wanted-machine=$(this_machine) wanted-actor=$actor"
   return 2
@@ -644,12 +679,14 @@ cmd_verify() {
 
 # ---------------------------------------------------------------------------
 cmd_adopt() {
-  local issue="" actor="${CLAIM_ACTOR:-flow}" expect="" reason="" mode="cas"
+  local issue="" actor="${CLAIM_ACTOR:-flow}" expect="" reason="" reason_given=0 mode="cas"
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --actor)  [ "$#" -ge 2 ] || die_usage "--actor requires a value";  actor="$2";  shift 2 ;;
       --expect) [ "$#" -ge 2 ] || die_usage "--expect requires a value"; expect="$2"; shift 2 ;;
-      --reason) [ "$#" -ge 2 ] || die_usage "--reason requires a value"; reason="$2"; shift 2 ;;
+      # reason_given records the FLAG's presence, so a supplied-but-empty value cannot
+      # skip validation (see the gate below).
+      --reason) [ "$#" -ge 2 ] || die_usage "--reason requires a value"; reason="$2"; reason_given=1; shift 2 ;;
       -*) die_usage "adopt: unknown flag $1" ;;
       *) [ -z "$issue" ] || die_usage "adopt: unexpected argument $1"; issue="$1"; shift ;;
     esac
@@ -687,6 +724,14 @@ cmd_adopt() {
     *[!0]*) : ;;
     *) mode="empty" ;;
   esac
+  # NORMALIZE THE CASE of a hex lease value. git resolves an object name
+  # case-insensitively, so `--expect <UPPERCASE sha>` satisfies the lease and the push
+  # lands — but every comparison below (`now = expect`) is a STRING compare against
+  # ls-remote's lowercase output, so an uppercase value made a satisfied precondition
+  # read as a violated one. Normalizing here keeps the arbiter and the verdict agreed.
+  if [ "$mode" = "cas" ]; then
+    expect="$(printf '%s' "$expect" | LC_ALL=C tr 'A-F' 'a-f')"
+  fi
 
   # VALIDATE THE RECORDED TOKEN, NOT THE RAW TEXT (#2945 review). The audit value
   # is what lands in the claim commit, so gating on `[ -n "$reason" ]` let '   ',
@@ -696,8 +741,16 @@ cmd_adopt() {
   # actually says something: not the `unspecified` sentinel sanitize_field falls back
   # to (so a literal `--reason unspecified` is refused too — it records nothing), and
   # at least 3 recordable characters. Same fail-closed direction as `--expect ''`.
+  #
+  # AND THE GATE KEYS ON "WAS THE FLAG SUPPLIED", NOT "IS THE RAW TEXT NON-EMPTY"
+  # (#2945 review). Guarding it on `[ -n "$reason" ]` silently EXEMPTED `--reason ""` —
+  # the classic `--reason "$WHY"` with WHY unset — on the CAS path: the adoption recorded
+  # no `reason=` at all, while '   ', '---' and 'x' were exit 64. That was the last
+  # asymmetry in an otherwise fail-closed argument surface, and it is the shape most
+  # likely to happen by accident. A SUPPLIED-but-empty reason is now exit 64 on BOTH
+  # paths (on --expect none the required-reason gate below caught it already).
   local extra="" reason_token=""
-  if [ -n "$reason" ]; then
+  if [ "$reason_given" -eq 1 ]; then
     # AN UNSUBSTITUTED TEMPLATE IS REFUSED BEFORE SANITIZATION (#2945 review). The
     # placeholder gate below only sees the SANITIZED token, so it caught a bare `<why>`
     # but not a template inside a longer value: the documented
@@ -820,7 +873,7 @@ cmd_adopt() {
   if [ -n "$now" ]; then
     holder_identity "$now" "$actor" || arc=$?
     if [ "$arc" -eq 2 ]; then
-      emit_infra "issue=$issue ref=refs/claims/issue-$issue sha=$now detail=holder-commit-unreadable (the claim object did not fetch — the holder is UNKNOWN, possibly us; NOT a lost race)"
+      emit_unreadable_holder "$issue" "$now"
       return 1
     fi
   fi
@@ -831,6 +884,18 @@ cmd_adopt() {
       emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") (re-entrant, lease-mismatch expected=$expect actual=$now — we DO hold the ref, but the compare-and-swap precondition did NOT hold)"
     fi
     return 0
+  fi
+  # A CAS whose push did not land WHILE THE REF IS STILL EXACTLY AT `--expect` did not
+  # lose a race: the lease precondition HELD, so the push failed for some other reason
+  # (transient network, an unrecognized auth signature, a server-side hook). `ADOPT-LOST
+  # … expected=X actual=X` is self-contradictory on its face, and it makes a worker move
+  # on from a claim that is still adoptable and UNTAKEN. So it is retryable infra —
+  # regardless of who the (readable) holder is. The empty-lease sibling above
+  # (`rejected-but-ref-absent`) and the re-entrant `now == expect` case already had this
+  # treatment; the FOREIGN-holder variant was the one missed (#2945 review).
+  if [ "$mode" = "cas" ] && [ -n "$now" ] && [ "$now" = "$expect" ]; then
+    emit_infra "issue=$issue ref=refs/claims/issue-$issue sha=$now expected=$expect detail=adopt-cas-rejected-but-ref-unchanged (the lease precondition still HOLDS — the push failed for another reason; NOT a lost race) $(holder_token "$now")"
+    return 1
   fi
   emit "ADOPT-LOST issue=$issue ref=refs/claims/issue-$issue expected=$expect actual=${now:-<gone>} $(holder_token "$now")"
   return 2
@@ -897,7 +962,17 @@ cmd_release() {
     # not release a ref you do not hold — that is the reaper's job, and the reaper
     # uses --force (which skips BOTH this identity gate and the open-PR guard).
     fetch_claim "$issue"
-    if ! holder_is_us "$sha" "$actor"; then
+    # Same three-outcome rule as `verify` (#2945 review): an UNREADABLE holder commit is
+    # UNKNOWN, so `reason=not-holder` (exit 2) would refuse the TRUE holder its own
+    # release over a best-effort fetch blip — and the refusal's remedy (`--force`) is the
+    # one thing a holder must not need for its own claim.
+    local hrc3=0
+    holder_identity "$sha" "$actor" || hrc3=$?
+    if [ "$hrc3" -eq 2 ]; then
+      emit_unreadable_holder "$issue" "$sha"
+      return 1
+    fi
+    if [ "$hrc3" -ne 0 ]; then
       emit "RELEASE-REFUSED issue=$issue reason=not-holder sha=$sha holder-$(holder_desc "$sha") wanted-machine=$(this_machine) wanted-actor=$actor (only the holder may release without --force)"
       return 2
     fi

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -94,9 +94,14 @@
 #                                             is REQUIRED and is recorded in the claim commit.
 #                                             An EMPTY --expect '' is a usage error on purpose,
 #                                             as is a --reason with nothing recordable in it
-#                                             ('   ', '---', '…') or one that records as a bare
+#                                             ('   ', '---', '…'), one that records as a bare
 #                                             PLACEHOLDER ('why', 'todo', 'tbd', 'xxx', …, the
-#                                             shape a verbatim-run `--reason <why>` produces):
+#                                             shape a verbatim-run `--reason <why>` produces),
+#                                             or one still carrying an UNSUBSTITUTED '<…>'
+#                                             anywhere in it (a copied template such as
+#                                             `--reason resume-legacy-branch-lock:<branch>`
+#                                             sanitizes to a non-sentinel token, so it is
+#                                             rejected on the RAW text, before sanitization):
 #                                             the record must say WHY.
 #                                             RE-ENTRANT: if the ref is already held by THIS
 #                                             machine+actor, adopt reports ADOPTED (re-entrant)
@@ -129,7 +134,12 @@
 #            sanitize_field): the actor is part of the holder identity and lands in
 #            the same commit message the identity parser reads, so an unsanitized
 #            actor (e.g. `--actor 'flow machine=other'`) could forge a holder and win
-#            false re-entrancy on someone else's claim (#2945).
+#            false re-entrancy on someone else's claim (#2945). It must also RECORD
+#            something: an actor with fewer than 3 recordable characters (or the bare
+#            `unspecified` sentinel) is a usage error (exit 64) — otherwise two
+#            distinct-but-unrecordable actors ('***' and '???') aliased onto ONE
+#            identity, letting the second satisfy the holder gate for a claim it does
+#            not own (the opposite of --reason's fail-closed direction).
 #   The holder identity that `verify`/`release` match is machine+actor.
 #
 # ENV
@@ -155,7 +165,10 @@
 #      SMOKE-FAIL). EVERY remote-reading subcommand (claim/verify/adopt/release/status)
 #      maps an ls-remote/push/delete failure to ERROR (exit 1), so a network blip never
 #      makes a worker conclude it LOST/does-not-hold/RELEASED. `claim` also never reports
-#      LOST when nobody holds the ref (a failed push whose re-read finds it absent).
+#      LOST when nobody holds the ref (a failed push whose re-read finds it absent), and
+#      neither `claim` nor `adopt` reports LOST/ADOPT-LOST when the holder commit's
+#      message is UNREADABLE (`detail=holder-commit-unreadable`): the best-effort fetch
+#      may simply not have landed the object, so the holder is unknown — possibly US.
 #      ALSO exit 1: `CLAIM ERROR reason=auth` — a push git could not AUTHENTICATE
 #      (issue #2942). Same exit code (callers keep treating 1 as "not a race"), but the
 #      verdict is explicitly NOT retryable: retrying cannot fix a missing credential.
@@ -344,7 +357,24 @@ sanitize_field() {
 # resolve_actor <raw> — the actor identity, sanitized to one token. Sanitizing at
 # the ARG BOUNDARY (every subcommand, before any comparison) keeps the written
 # record and the identity match on exactly the same value.
-resolve_actor() { sanitize_field "${1:-}"; }
+#
+# IT MUST RECORD SOMETHING (#2945 review) — the same fail-closed gate `--reason`
+# carries, for a stronger reason: the actor is part of the HOLDER IDENTITY that gates
+# re-entrancy, `verify` and non-forced `release`. Letting an unrecordable value fall
+# back to the `unspecified` sentinel ALIASED two distinct actors onto ONE identity:
+# `claim N --actor '***'` recorded `actor=unspecified`, and a later
+# `release N --actor '???'` resolved to `unspecified` too — satisfying the holder gate
+# for a claim it does not own. So an actor that records as the sentinel (including a
+# literal `--actor unspecified`, which records nothing either) or carries fewer than 3
+# recordable characters is a USAGE ERROR, never a silent coercion.
+resolve_actor() {
+  local tok
+  tok="$(sanitize_field "${1:-}")"
+  if [ "$tok" = "unspecified" ] || [ "${#tok}" -lt 3 ]; then
+    die_usage "--actor must carry at least 3 recordable characters ([A-Za-z0-9._:/#-]); '${1:-}' records as '$tok', and the actor is part of the HOLDER IDENTITY — two unrecordable actors must never alias onto one identity"
+  fi
+  printf '%s\n' "$tok"
+}
 
 # build_claim_commit <N> <actor> [extra-fields] — create a UNIQUE root commit
 # (empty tree, no parent) and print its SHA. The nonce guarantees distinct SHAs
@@ -367,16 +397,33 @@ build_claim_commit() {
     git commit-tree "$empty_tree" -m "$message"
 }
 
-# holder_is_us <sha> <actor> — 0 iff the claim commit was authored by this
-# machine+actor (identity match), reading the pushed message.
-holder_is_us() {
+# holder_identity <sha> <actor> — classify the holder of a claim commit by READING
+# its pushed message. THREE outcomes, deliberately distinct (#2945 review):
+#   0  the holder is US (this machine+actor) — re-entrant
+#   1  the holder is SOMEONE ELSE (the message was read; the identity differs)
+#   2  UNREADABLE — the commit object/message could not be read at all (fetch_claim
+#      swallows its errors, so a transient fetch failure over an object we do not have
+#      locally lands here), so the holder is UNKNOWN — possibly US.
+# Collapsing 2 into 1 is the "an unread signal must never mean abandon" bug: callers
+# fall through to LOST/ADOPT-LOST (exit 2), which workers read as "you did not win,
+# take the next item". A machine would then drop an issue whose claim ref it still
+# holds, and nobody else could take it either (the ref is held) — a permanent stall,
+# whose tell is the empty `holder-machine= actor=` render. Every caller maps 2 to
+# `emit_infra` + exit 1 (retryable), like every other unread remote signal here.
+holder_identity() {
   local sha="$1" actor="$2" msg h_machine h_actor
   msg="$(git log -1 --format=%B "$sha" 2>/dev/null || true)"
-  [ -n "$msg" ] || return 1
+  [ -n "$msg" ] || return 2
   h_machine="$(msg_field "$msg" machine)"
   h_actor="$(msg_field "$msg" actor)"
-  [ "$h_machine" = "$(this_machine)" ] && [ "$h_actor" = "$actor" ]
+  [ "$h_machine" = "$(this_machine)" ] && [ "$h_actor" = "$actor" ] && return 0
+  return 1
 }
+
+# holder_is_us <sha> <actor> — 0 iff the claim commit was authored by this
+# machine+actor (identity match). A boolean wrapper for the paths whose verdict does
+# not distinguish "someone else" from "unreadable"; use holder_identity where it must.
+holder_is_us() { holder_identity "$1" "$2"; }
 
 # fetch_claim <N> — ensure the claim object is present locally; no-op on absence.
 fetch_claim() {
@@ -456,9 +503,18 @@ cmd_claim() {
   existing="$(remote_claim_sha "$issue")"
   if [ -n "$existing" ]; then
     fetch_claim "$issue"
-    if holder_is_us "$existing" "$actor"; then
+    local hrc=0
+    holder_identity "$existing" "$actor" || hrc=$?
+    if [ "$hrc" -eq 0 ]; then
       emit "HELD issue=$issue ref=refs/claims/issue-$issue sha=$existing $(holder_desc "$existing") (re-entrant)"
       return 0
+    fi
+    # UNREADABLE holder metadata is UNKNOWN, never "someone else" (#2945 review): the
+    # fetch is best-effort, so a transient failure leaves the claim object absent and
+    # the message unreadable — including when the holder is US.
+    if [ "$hrc" -eq 2 ]; then
+      emit_infra "issue=$issue ref=refs/claims/issue-$issue sha=$existing detail=holder-commit-unreadable (the claim object did not fetch — the holder is UNKNOWN, possibly us; NOT a lost race)"
+      return 1
     fi
     emit "LOST issue=$issue ref=refs/claims/issue-$issue sha=$existing $(holder_token "$existing")"
     return 2
@@ -519,9 +575,17 @@ cmd_claim() {
       return 1
     fi
     fetch_claim "$issue"
-    if holder_is_us "$now" "$actor"; then
+    local hrc2=0
+    holder_identity "$now" "$actor" || hrc2=$?
+    if [ "$hrc2" -eq 0 ]; then
       emit "HELD issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") (re-entrant)"
       return 0
+    fi
+    # Same rule as the pre-check: unreadable holder metadata is retryable infra, not a
+    # LOST verdict on a ref that may well be ours.
+    if [ "$hrc2" -eq 2 ]; then
+      emit_infra "issue=$issue ref=refs/claims/issue-$issue sha=$now detail=holder-commit-unreadable (the claim object did not fetch — the holder is UNKNOWN, possibly us; NOT a lost race)"
+      return 1
     fi
     emit "LOST issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_token "$now")"
     return 2
@@ -634,6 +698,19 @@ cmd_adopt() {
   # at least 3 recordable characters. Same fail-closed direction as `--expect ''`.
   local extra="" reason_token=""
   if [ -n "$reason" ]; then
+    # AN UNSUBSTITUTED TEMPLATE IS REFUSED BEFORE SANITIZATION (#2945 review). The
+    # placeholder gate below only sees the SANITIZED token, so it caught a bare `<why>`
+    # but not a template inside a longer value: the documented
+    # `--reason resume-legacy-branch-lock:<branch>` sanitizes to
+    # `resume-legacy-branch-lock:-branch` — not a sentinel, so it was ACCEPTED and
+    # recorded an unresolved placeholder as the audit reason. These commands are read by
+    # agents that run printed text LITERALLY, which is the whole premise of this change,
+    # so any surviving `<…>` in the RAW value is a caller bug, not a reason.
+    case "$reason" in
+      *'<'*'>'*)
+        die_usage "adopt: --reason '$reason' still carries an UNSUBSTITUTED placeholder (<…>) — substitute it. e.g. --reason resume-legacy-branch-lock:branch-outlived-claim or --reason 'reaped claim, board says Ready'"
+        ;;
+    esac
     reason_token="$(sanitize_field "$reason")"
     if [ "$reason_token" = "unspecified" ] || [ "${#reason_token}" -lt 3 ]; then
       die_usage "adopt: --reason must carry at least 3 recordable characters ([A-Za-z0-9._:/#-]); '$reason' records as '$reason_token', which is indistinguishable from no reason at all"
@@ -648,14 +725,14 @@ cmd_adopt() {
     # up in help text and templates, not an attempt at judging prose quality.
     case "$(printf '%s' "$reason_token" | LC_ALL=C tr 'A-Z' 'a-z')" in
       why | reason | todo | tbd | tba | xxx | xxxx | placeholder | fixme | none | foo | bar | baz | n/a)
-        die_usage "adopt: --reason '$reason' records as the PLACEHOLDER '$reason_token' — as uninformative as no reason at all. Say what the resume IS, e.g. --reason resume-legacy-branch-lock:issue-$issue-<slug> or --reason 'reaped claim, board says Ready'"
+        die_usage "adopt: --reason '$reason' records as the PLACEHOLDER '$reason_token' — as uninformative as no reason at all. Say what the resume IS, e.g. --reason resume-legacy-branch-lock:issue-$issue-branch-outlived-claim or --reason 'reaped claim, board says Ready'"
         ;;
     esac
   fi
   if [ "$mode" = "empty" ]; then
     # The resume is a judgement call, so it MUST be self-documenting: the claim
     # commit records who took it (machine/actor/ts) AND why (reason).
-    [ -n "$reason_token" ] || die_usage "adopt --expect none requires --reason <why> (the resume is recorded in the claim commit: who took it AND why)"
+    [ -n "$reason_token" ] || die_usage "adopt --expect none requires a --reason saying what the resume IS (it is recorded in the claim commit next to who took it), e.g. --reason resume-legacy-branch-lock:issue-$issue-branch-outlived-claim"
     extra="mode=empty-lease reason=$reason_token"
   elif [ -n "$reason_token" ]; then
     extra="mode=cas reason=$reason_token"
@@ -732,7 +809,22 @@ cmd_adopt() {
   # hold (only our own new commit failed to land), so `lease-mismatch expected=X
   # actual=X` named a divergence that never happened. That case takes the plain
   # re-entrant verdict, whose `from=` is the value the ref really has.
-  if [ -n "$now" ] && holder_is_us "$now" "$actor"; then
+  # …and an UNREADABLE holder commit is UNKNOWN, never a foreign holder (#2945 review):
+  # `fetch_claim` swallows its errors, so a transient fetch failure (disk full, partial
+  # outage, ref-advertisement hiccup) leaves the object absent and the message empty —
+  # even when `now` is OUR OWN claim commit. Falling through to ADOPT-LOST there made a
+  # machine abandon an issue it still held the ref for (nobody else can take it either:
+  # the ref is held), and rendered the tell-tale empty `holder-machine= actor=`. Treat it
+  # as retryable infra, exactly like every other unread signal in this file.
+  local arc=0
+  if [ -n "$now" ]; then
+    holder_identity "$now" "$actor" || arc=$?
+    if [ "$arc" -eq 2 ]; then
+      emit_infra "issue=$issue ref=refs/claims/issue-$issue sha=$now detail=holder-commit-unreadable (the claim object did not fetch — the holder is UNKNOWN, possibly us; NOT a lost race)"
+      return 1
+    fi
+  fi
+  if [ -n "$now" ] && [ "$arc" -eq 0 ]; then
     if [ "$mode" = "empty" ] || [ "$now" = "$expect" ]; then
       emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") from=$expect (re-entrant)"
     else

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -45,7 +45,12 @@
 # LEGACY GUARD (mixed-fleet safety): older workers still branch-lock with a
 # `refs/heads/issue-<N>-*` branch. `claim` refuses if any such branch exists on
 # origin (treat the issue as already-claimed) and names the resume command above
-# in its refusal. There is NO tip-based re-entrancy exemption: a work branch is
+# in its refusal — but ONLY when the issue has ZERO open PRs. An older-fleet worker
+# holds only the BRANCH, so `claim-ref=free` is true while it works, and advertising
+# the empty-lease adopt would hand an ACTIVE issue to a second machine. With an open
+# PR (or an unreadable PR list) the refusal prints `remediation=withheld open-prs=<n>`
+# instead: fail closed, because the readers run printed remediations literally (#2945).
+# There is NO tip-based re-entrancy exemption: a work branch is
 # cut from origin/main and carries ordinary commits, so its tip NEVER carries the
 # machine=/actor= claim trailers — the old "all-ours -> no block" escape hatch was
 # unreachable dead code (#2945). New claims never create these branches — the
@@ -73,15 +78,23 @@
 #   adopt  <N> --expect <old-sha>|none [--reason <why>] [--actor <id>]
 #                                             compare-and-swap the ref (adoption/resume).
 #                                             --expect <old-sha>: the ref must still be <old-sha>.
+#                                             A hex value MUST be a full object name (40/64 hex);
+#                                             a truncated sha is a usage error, never a lost race.
 #                                             --expect none:      the ref must NOT exist (empty
 #                                             lease) — the resume path for an issue whose
 #                                             `issue-<N>-*` branch outlived its claim; --reason
 #                                             is REQUIRED and is recorded in the claim commit.
-#                                             An EMPTY --expect '' is a usage error on purpose.
+#                                             An EMPTY --expect '' is a usage error on purpose,
+#                                             as is a --reason with nothing recordable in it
+#                                             ('   ', '---', '…'): the record must say WHY.
 #                                             RE-ENTRANT: if the ref is already held by THIS
 #                                             machine+actor, adopt reports ADOPTED (re-entrant)
 #                                             exit 0 — a retry after a confirm-read blip must
-#                                             never abandon an issue we still hold.
+#                                             never abandon an issue we still hold. In CAS mode
+#                                             that verdict names BOTH shas
+#                                             (re-entrant, lease-mismatch expected=/actual=), so a
+#                                             VIOLATED compare-and-swap is never reported as a
+#                                             satisfied one.
 #   release <N> [--force] [--actor <id>]      delete the ref; without --force requires holder identity
 #                                             (machine+actor) + no open PR, and deletes via CAS lease.
 #                                             --force = reaper/adopt: unconditional delete.
@@ -437,7 +450,25 @@ cmd_claim() {
     return 1
   fi
   if [ -n "$LEGACY_BRANCHES" ]; then
-    emit "LOST issue=$issue reason=legacy-branch-lock detail=$LEGACY_BRANCHES exists on $REMOTE claim-ref=free remediation='bash scripts/flow/claim.sh adopt $issue --expect none --reason <why>' (that branch may be an older-fleet branch lock, a parked/reaped resume, or a merged-but-undeleted branch; if it is YOURS to continue, the quoted empty-lease adopt takes the FREE claim ref atomically — git rejects it if any machine holds the ref)"
+    # The refusal must be ACTIONABLE without being DANGEROUS (#2945 review). "git
+    # rejects it if any machine holds the ref" does NOT cover the case this guard
+    # exists for: an OLDER-fleet worker locks with the BRANCH and holds no claim ref,
+    # so `claim-ref=free` is true for it and the advertised empty-lease adopt WOULD
+    # succeed — a second machine on an actively-worked issue. Prose hedging ("if it
+    # is YOURS") is not a control: the readers are agents that run printed
+    # remediations literally. So the copy-pasteable command is printed ONLY when the
+    # endgame is demonstrably orphaned — zero open PRs on this issue's branch — using
+    # the same gh signal `release` already trusts for "somebody's endgame is live".
+    # Unknown (gh missing/failed, -1) withholds too: fail closed, never advertise a
+    # hand-away on an unread signal.
+    local prs remedy
+    prs="$(open_pr_count "$issue")"
+    if [ "$prs" = "0" ]; then
+      remedy="remediation='bash scripts/flow/claim.sh adopt $issue --expect none --reason <why>' open-prs=0 (no open PR: that branch is an older-fleet branch lock, a parked/reaped resume, or a merged-but-undeleted branch; the quoted empty-lease adopt takes the FREE claim ref atomically — git rejects it if any machine holds the claim ref)"
+    else
+      remedy="remediation=withheld open-prs=$prs (an open PR — or, at -1, an unreadable PR list — means someone's endgame may be LIVE, and an older-fleet worker holds only the BRANCH, so an empty-lease adopt WOULD succeed and create a SECOND writer; confirm ownership via the board and the PR author first, then see 'bash scripts/flow/claim.sh -h')"
+    fi
+    emit "LOST issue=$issue reason=legacy-branch-lock detail=$LEGACY_BRANCHES exists on $REMOTE claim-ref=free $remedy"
     return 2
   fi
 
@@ -550,27 +581,56 @@ cmd_adopt() {
   # expanding to "" must NEVER silently turn a compare-and-swap into a create.
   # The empty lease is opt-in via the explicit literal `none`.
   [ -n "$expect" ] || die_usage "adopt requires --expect <old-sha> (CAS against a HELD ref) or --expect none (empty lease: the claim ref must NOT exist — the sanctioned resume when an issue-<N>-* branch outlived its claim, #2945). An empty --expect '' is rejected on purpose."
+  # A hex --expect must be a FULL object name (40 hex sha1 / 64 hex sha256). Length
+  # was unchecked (#2945 review), and both failure shapes MISREPORT a caller bug:
+  # a TRUNCATED sha (`--expect abc123`, e.g. a bad `cut` in a caller) builds a lease
+  # git cannot resolve, so the push fails and the confirm read reports ADOPT-LOST —
+  # a race-loss verdict for a usage error — while a SHORT all-zero value (`--expect 0`)
+  # slipped into the all-zero branch below and silently became a CREATE instead of a
+  # compare-and-swap. This file is otherwise rigorous about separating usage / infra /
+  # lost-race, so both are now usage errors (exit 64).
   case "$expect" in
     none) mode="empty" ;;
     *[!0-9a-fA-F]*) die_usage "adopt: --expect takes a hex sha or the literal 'none' (got '$expect')" ;;
+    *)
+      case "${#expect}" in
+        40 | 64) : ;;
+        *) die_usage "adopt: --expect needs a FULL object name — 40 hex (sha1) or 64 hex (sha256) — or the literal 'none' (got '$expect', ${#expect} chars). A truncated sha cannot be resolved as a lease and would read as a lost race." ;;
+      esac
+      ;;
   esac
-  # An ALL-ZERO expected value is git's own "the ref must not exist", so it carries
-  # exactly the `none` intent — route it through the same AUDITED path (--reason
-  # required) instead of leaving a quiet create-with-no-record. Verified against the
-  # real origin: `--expect 000…0` does create the ref, so it cannot stay unaudited.
+  # An ALL-ZERO expected value (at full object-name length) is git's own "the ref must
+  # not exist", so it carries exactly the `none` intent — route it through the same
+  # AUDITED path (--reason required) instead of leaving a quiet create-with-no-record.
+  # Verified against the real origin: `--expect 000…0` does create the ref, so it
+  # cannot stay unaudited.
   case "$expect" in
     *[!0]*) : ;;
     *) mode="empty" ;;
   esac
 
-  local extra=""
+  # VALIDATE THE RECORDED TOKEN, NOT THE RAW TEXT (#2945 review). The audit value
+  # is what lands in the claim commit, so gating on `[ -n "$reason" ]` let '   ',
+  # '---', '…' or an expansion like "$UNSET_VAR " through and recorded them as
+  # `reason=unspecified` — indistinguishable from supplying no reason at all, which
+  # defeats the "record WHY" requirement. Sanitize FIRST, then require a token that
+  # actually says something: not the `unspecified` sentinel sanitize_field falls back
+  # to (so a literal `--reason unspecified` is refused too — it records nothing), and
+  # at least 3 recordable characters. Same fail-closed direction as `--expect ''`.
+  local extra="" reason_token=""
+  if [ -n "$reason" ]; then
+    reason_token="$(sanitize_field "$reason")"
+    if [ "$reason_token" = "unspecified" ] || [ "${#reason_token}" -lt 3 ]; then
+      die_usage "adopt: --reason must carry at least 3 recordable characters ([A-Za-z0-9._:/#-]); '$reason' records as '$reason_token', which is indistinguishable from no reason at all"
+    fi
+  fi
   if [ "$mode" = "empty" ]; then
     # The resume is a judgement call, so it MUST be self-documenting: the claim
     # commit records who took it (machine/actor/ts) AND why (reason).
-    [ -n "$reason" ] || die_usage "adopt --expect none requires --reason <why> (the resume is recorded in the claim commit: who took it AND why)"
-    extra="mode=empty-lease reason=$(sanitize_field "$reason")"
-  elif [ -n "$reason" ]; then
-    extra="mode=cas reason=$(sanitize_field "$reason")"
+    [ -n "$reason_token" ] || die_usage "adopt --expect none requires --reason <why> (the resume is recorded in the claim commit: who took it AND why)"
+    extra="mode=empty-lease reason=$reason_token"
+  elif [ -n "$reason_token" ]; then
+    extra="mode=cas reason=$reason_token"
   fi
 
   local sha lease adopt_err=""
@@ -634,8 +694,17 @@ cmd_adopt() {
   # nobody else can take it either. `cmd_claim` has had this identity check on both
   # of its failure paths from the start; `adopt` is now the ONLY way past the legacy
   # guard, so it needs the same idempotence.
+  # In CAS mode the same situation ALSO covers a VIOLATED compare-and-swap: the ref
+  # is at some Y != our --expect X, and Y happens to be ours. We still hold it (so
+  # exit 2 would abandon it), but reporting a plain `ADOPTED … from=X` would print a
+  # value the ref never had and make a FAILED CAS indistinguishable from a satisfied
+  # one. So the CAS path gets its OWN verdict naming BOTH shas (#2945 review).
   if [ -n "$now" ] && holder_is_us "$now" "$actor"; then
-    emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") from=$expect (re-entrant)"
+    if [ "$mode" = "empty" ]; then
+      emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") from=$expect (re-entrant)"
+    else
+      emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") (re-entrant, lease-mismatch expected=$expect actual=$now — we DO hold the ref, but the compare-and-swap precondition did NOT hold)"
+    fi
     return 0
   fi
   emit "ADOPT-LOST issue=$issue ref=refs/claims/issue-$issue expected=$expect actual=${now:-<gone>} $(holder_token "$now")"

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -46,9 +46,11 @@
 # `refs/heads/issue-<N>-*` branch. `claim` refuses if any such branch exists on
 # origin (treat the issue as already-claimed) and names the resume command above
 # in its refusal — but ONLY when the lane is DEMONSTRABLY ORPHANED per
-# `hatch_liveness`: zero open PRs AND every matching branch tip older than
-# claim-heartbeat.sh's reap threshold AND no fresh machine-claim/heartbeat ref naming
-# the issue. An older-fleet worker holds only the BRANCH, so `claim-ref=free` is true
+# `hatch_liveness`: zero open PRs AND every matching branch tip carrying at least one
+# commit of its OWN and older than claim-heartbeat.sh's reap threshold AND no fresh
+# machine-claim/heartbeat ref naming the issue. A branch with no commits beyond
+# origin/main (what `flow-activate` pushes at activation) has NO age signal at all, so
+# it is INDETERMINATE and withholds. An older-fleet worker holds only the BRANCH, so `claim-ref=free` is true
 # while it works — and because a PR is opened LATE in this pipeline, "no open PR" is
 # also true for most of its life, which is why the branch-tip age and the liveness
 # refs (the PRE-PR window) are part of the test. Otherwise — a live signal OR any
@@ -99,11 +101,14 @@
 #                                             RE-ENTRANT: if the ref is already held by THIS
 #                                             machine+actor, adopt reports ADOPTED (re-entrant)
 #                                             exit 0 — a retry after a confirm-read blip must
-#                                             never abandon an issue we still hold. In CAS mode
-#                                             that verdict names BOTH shas
-#                                             (re-entrant, lease-mismatch expected=/actual=), so a
-#                                             VIOLATED compare-and-swap is never reported as a
-#                                             satisfied one.
+#                                             never abandon an issue we still hold. In CAS mode,
+#                                             when the ref sits at some OTHER sha of ours, that
+#                                             verdict names BOTH shas (re-entrant, lease-mismatch
+#                                             expected=/actual=), so a VIOLATED compare-and-swap is
+#                                             never reported as a satisfied one; when the ref is
+#                                             still at --expect (the precondition HELD, only our
+#                                             new commit did not land) it is the plain re-entrant
+#                                             verdict — no mismatch that did not happen.
 #   release <N> [--force] [--actor <id>]      delete the ref; without --force requires holder identity
 #                                             (machine+actor) + no open PR, and deletes via CAS lease.
 #                                             --force = reaper/adopt: unconditional delete.
@@ -453,6 +458,44 @@ reap_threshold_secs() {
   printf '%s\n' "$out"
 }
 
+# hatch_fetch_ref <remote-ref> <slot> — fetch <remote-ref> from origin into the
+# PRIVATE local ref refs/hatch-scan/<slot> and print its commit sha; returns 1 when
+# ANY step is unreadable (callers withhold).
+#
+# EXPLICIT REFSPEC, NEVER FETCH_HEAD: the liveness scan fetches several refs in a
+# row and every `git fetch` REWRITES FETCH_HEAD, so reading FETCH_HEAD is a
+# clobbering hazard — one stale read ages the WRONG commit. Fetching (not just
+# ls-remote'ing) is also what makes the objects local, which the ancestry test below
+# needs. The slots are force-updated (`+`) and deleted by hatch_liveness afterwards.
+hatch_fetch_ref() {
+  local refname="$1" slot="refs/hatch-scan/$2" sha
+  git fetch --quiet --no-tags "$REMOTE" "+${refname}:${slot}" >/dev/null 2>&1 || return 1
+  sha="$(git rev-parse --verify --quiet "${slot}^{commit}")" || return 1
+  [ -n "$sha" ] || return 1
+  printf '%s\n' "$sha"
+}
+
+# hatch_tip_has_own_commits <tip-sha> <base-sha> — does this branch tip carry at
+# least ONE commit beyond origin's default branch?
+#   0  yes — the tip is the worker's OWN work, so its committer date means something
+#   1  no  — the tip IS the base (or an ancestor of it). `flow-activate` creates the
+#            work branch with `git worktree add -b issue-<N>-<slug> origin/main` and
+#            pushes it with NO commits of its own, so such a tip's date is
+#            origin/main's and carries ZERO information about the worker (#2945
+#            review). Age-judging it made an actively-worked lane look "stale"
+#            whenever main had been quiet longer than the threshold (overnight is
+#            routine) and advertised a hand-away for it — two writers on one issue.
+#   2  the ancestry test itself could not be run — an unread signal.
+hatch_tip_has_own_commits() {
+  local rc=0
+  git merge-base --is-ancestor "$1" "$2" >/dev/null 2>&1 || rc=$?
+  case "$rc" in
+    0) return 1 ;;
+    1) return 0 ;;
+    *) return 2 ;;
+  esac
+}
+
 # hatch_liveness <N> <threshold-secs> — may the copy-pasteable empty-lease resume be
 # ADVERTISED for this issue, i.e. is its lane demonstrably ORPHANED?
 #
@@ -464,31 +507,76 @@ reap_threshold_secs() {
 # remediations literally. So the PRE-PR window needs its own liveness evidence:
 #
 #   1. open PRs == 0                       (the ENDGAME signal; -1 = unreadable)
-#   2. EVERY matching issue-<N>-* branch tip is OLDER than <threshold> (the same
+#   2. EVERY matching issue-<N>-* branch tip CARRIES AT LEAST ONE COMMIT OF ITS OWN
+#      (beyond origin's default branch) and is OLDER than <threshold> (the same
 #      staleness threshold `claim-heartbeat.sh should-reap` uses) — a worker mid-
-#      implementation pushes commits, so a FRESH tip means somebody is on it
-#   3. NO refs/machine-claims/* or refs/heartbeats/* ref FRESHLY names this issue
-#      (the supervisor-authored liveness proof of #2655; a ref older than the
-#      threshold is itself reapable and does not withhold)
+#      implementation pushes commits, so a FRESH tip means somebody is on it. A tip
+#      with NO own commits is what `flow-activate` pushes at activation time, so its
+#      date is origin/main's: NO INFORMATION, hence INDETERMINATE, hence withheld —
+#      never "stale" (#2945 review). The motivating cases (#2043, #1883) each carried
+#      their own OpenSpec commit, so they stay age-judgeable and still advertise.
+#   3. NO refs/machine-claims/* or refs/heartbeats/* ref that NAMES THIS ISSUE is
+#      fresher than <threshold> (the supervisor-authored liveness proof of #2655; a
+#      ref older than the threshold is itself reapable and does not withhold, and a
+#      ref naming another issue — or naming none at all — is not evidence about THIS
+#      lane, so it does not withhold either)
 #
-# ANY signal that cannot be READ withholds — an unreachable remote, an unparseable
-# commit date and a missing threshold are all "we could not prove nobody is working
-# this", never an all-clear. Sets HATCH_SIGNALS (a single-line key=value run for the
-# refusal) and returns 0 = orphaned (advertise), 1 = withhold.
+# ANY signal that cannot be READ withholds — an unreachable remote, an unreadable
+# default-branch/ancestry test, an unparseable commit date and a missing threshold are
+# all "we could not prove nobody is working this", never an all-clear. Sets
+# HATCH_SIGNALS (a single-line key=value run for the refusal) and returns 0 = orphaned
+# (advertise), 1 = withhold.
 HATCH_SIGNALS=""
 hatch_liveness() {
+  local rc=0
+  hatch_liveness_scan "$@" || rc=$?
+  # The private scan slots are scratch, not state: drop them so the scan never leaves
+  # fetched objects pinned in the caller's checkout.
+  git update-ref -d refs/hatch-scan/base   >/dev/null 2>&1 || true
+  git update-ref -d refs/hatch-scan/branch >/dev/null 2>&1 || true
+  git update-ref -d refs/hatch-scan/live   >/dev/null 2>&1 || true
+  return "$rc"
+}
+
+hatch_liveness_scan() {
   local issue="$1" threshold="$2"
-  local prs now raw line refname msg tip_ct age min_age="" ref_issue ref_ts ref_epoch
+  local prs now raw line refname msg base tip tip_ct age min_age="" own_rc ref_issue ref_ts ref_epoch
 
   prs="$(open_pr_count "$issue")"
   HATCH_SIGNALS="open-prs=$prs"
   [ "$prs" = "0" ] || return 1
 
+  # The BASE a work branch is cut from: origin's default branch, read as the remote's
+  # HEAD so no branch name is hardcoded. FETCHED, because the ancestry test needs its
+  # objects locally — and an unreadable base is an UNREAD signal, so it withholds
+  # rather than silently letting every tip count as "own work" (which would restore
+  # the vacuous age verdict this signal exists to remove).
+  if ! base="$(hatch_fetch_ref HEAD base)"; then
+    HATCH_SIGNALS="$HATCH_SIGNALS default-branch-tip=unreadable"
+    return 1
+  fi
+
   now="$(date -u +%s)"
   while IFS= read -r refname; do
     [ -n "$refname" ] || continue
-    if ! git fetch "$REMOTE" "$refname" >/dev/null 2>&1 \
-       || ! tip_ct="$(git log -1 --format=%ct FETCH_HEAD 2>/dev/null)" \
+    if ! tip="$(hatch_fetch_ref "$refname" branch)"; then
+      HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=unreadable:${refname}"
+      return 1
+    fi
+    own_rc=0
+    hatch_tip_has_own_commits "$tip" "$base" || own_rc=$?
+    if [ "$own_rc" = "1" ]; then
+      # INDETERMINATE, not stale: a freshly-activated branch carries no commits of
+      # its own, so there is nothing here to age. Withhold, with a self-describing
+      # marker so the reader sees WHY no age was reported.
+      HATCH_SIGNALS="$HATCH_SIGNALS newest-branch-tip=no-own-commits:${refname}"
+      return 1
+    fi
+    if [ "$own_rc" != "0" ]; then
+      HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=ancestry-unreadable:${refname}"
+      return 1
+    fi
+    if ! tip_ct="$(git log -1 --format=%ct "$tip" 2>/dev/null)" \
        || [ -z "$tip_ct" ] || [ -n "${tip_ct//[0-9]/}" ]; then
       HATCH_SIGNALS="$HATCH_SIGNALS branch-tip=unreadable:${refname}"
       return 1
@@ -512,16 +600,19 @@ hatch_liveness() {
     [ -n "$line" ] || continue
     refname="$(printf '%s' "$line" | awk '{print $2}')"
     [ -n "$refname" ] || continue
-    if ! git fetch "$REMOTE" "$refname" >/dev/null 2>&1 \
-       || ! msg="$(git log -1 --format=%B FETCH_HEAD 2>/dev/null)" || [ -z "$msg" ]; then
+    if ! tip="$(hatch_fetch_ref "$refname" live)" \
+       || ! msg="$(git log -1 --format=%B "$tip" 2>/dev/null)"; then
+      # We could not READ this ref at all, so we cannot rule out that it names our
+      # issue → withhold (fail closed).
       HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=unreadable:${refname}"
       return 1
     fi
+    # SCOPED TO THIS ISSUE (#2945 review). A ref we CAN read that does not name this
+    # issue — another issue's claim, or a legacy/foreign ref with no `issue=` trailer
+    # at all — is not evidence about THIS lane. Withholding on it blocked the hatch
+    # FLEET-WIDE for EVERY issue, re-creating the permanent dead end this change
+    # exists to remove. Skipped, not withheld.
     ref_issue="$(msg_field "$msg" issue)"
-    if [ -z "$ref_issue" ]; then
-      HATCH_SIGNALS="$HATCH_SIGNALS liveness-refs=unreadable:${refname}"
-      return 1
-    fi
     [ "$ref_issue" = "$issue" ] || continue
     # This ref names OUR issue. Fresh -> a worker is on it. Unparseable ts -> we
     # cannot age it out, so it withholds (fail closed) exactly like should-reap
@@ -601,9 +692,9 @@ cmd_claim() {
     elif hatch_liveness "$issue" "$threshold"; then
       hatch_branch="${LEGACY_BRANCHES%%,*}"
       hatch_branch="${hatch_branch#refs/heads/}"
-      remedy="remediation='bash scripts/flow/claim.sh adopt $issue --expect none --reason resume-legacy-branch-lock:${hatch_branch}' $HATCH_SIGNALS (orphaned lane: no open PR, every branch tip staler than the reap threshold, no fresh liveness ref for this issue — an older-fleet branch lock left behind, a parked/reaped resume, or a merged-but-undeleted branch; the quoted empty-lease adopt takes the FREE claim ref atomically — git rejects it if any machine holds the claim ref)"
+      remedy="remediation='bash scripts/flow/claim.sh adopt $issue --expect none --reason resume-legacy-branch-lock:${hatch_branch}' $HATCH_SIGNALS (orphaned lane: no open PR, every branch tip carrying its OWN commits and staler than the reap threshold, no fresh liveness ref for this issue — an older-fleet branch lock left behind, a parked/reaped resume, or a merged-but-undeleted branch; the quoted empty-lease adopt takes the FREE claim ref atomically — git rejects it if any machine holds the claim ref)"
     else
-      remedy="remediation=withheld $HATCH_SIGNALS (this lane may be LIVE or is unproven: an open PR (or an unreadable -1 PR list), a branch tip fresher than the reap threshold — an older-fleet worker mid-implementation holds only the BRANCH and has NO PR yet — or a fresh machine-claim/heartbeat ref naming this issue. An empty-lease adopt WOULD succeed there and create a SECOND writer; confirm ownership via the board and the branch/PR author first, then see 'bash scripts/flow/claim.sh -h')"
+      remedy="remediation=withheld $HATCH_SIGNALS (this lane may be LIVE or is unproven: an open PR (or an unreadable -1 PR list), a branch tip fresher than the reap threshold — an older-fleet worker mid-implementation holds only the BRANCH and has NO PR yet — a branch with NO commits of its own, whose tip date is just origin/main's and says nothing about the worker (newest-branch-tip=no-own-commits), or a fresh machine-claim/heartbeat ref naming this issue. An empty-lease adopt WOULD succeed there and create a SECOND writer; confirm ownership via the board and the branch/PR author first, then see 'bash scripts/flow/claim.sh -h')"
     fi
     emit "LOST issue=$issue reason=legacy-branch-lock detail=$LEGACY_BRANCHES exists on $REMOTE claim-ref=free $remedy"
     return 2
@@ -849,8 +940,13 @@ cmd_adopt() {
   # exit 2 would abandon it), but reporting a plain `ADOPTED … from=X` would print a
   # value the ref never had and make a FAILED CAS indistinguishable from a satisfied
   # one. So the CAS path gets its OWN verdict naming BOTH shas (#2945 review).
+  # …but ONLY a GENUINE divergence gets the mismatch wording (#2945 review): when the
+  # ref still sits at exactly our --expect value the compare-and-swap precondition DID
+  # hold (only our own new commit failed to land), so `lease-mismatch expected=X
+  # actual=X` named a divergence that never happened. That case takes the plain
+  # re-entrant verdict, whose `from=` is the value the ref really has.
   if [ -n "$now" ] && holder_is_us "$now" "$actor"; then
-    if [ "$mode" = "empty" ]; then
+    if [ "$mode" = "empty" ] || [ "$now" = "$expect" ]; then
       emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") from=$expect (re-entrant)"
     else
       emit "ADOPTED issue=$issue ref=refs/claims/issue-$issue sha=$now $(holder_desc "$now") (re-entrant, lease-mismatch expected=$expect actual=$now — we DO hold the ref, but the compare-and-swap precondition did NOT hold)"

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -166,7 +166,9 @@
 #      SMOKE-FAIL). EVERY remote-reading subcommand (claim/verify/adopt/release/status)
 #      maps an ls-remote/push/delete failure to ERROR (exit 1), so a network blip never
 #      makes a worker conclude it LOST/does-not-hold/RELEASED. `claim` also never reports
-#      LOST when nobody holds the ref (a failed push whose re-read finds it absent), and
+#      LOST when nobody holds the ref — whether the push was REJECTED or ACCEPTED, a
+#      re-read that finds the ref absent is infra (a reaper delete can land in that
+#      window; either way the lane is FREE, so exit 2 would be a lie), and
 #      and NO subcommand reports LOST/ADOPT-LOST/VERIFY-FAIL/not-holder when the holder
 #      commit's message is UNREADABLE (`detail=holder-commit-unreadable`): the best-effort
 #      fetch may simply not have landed the object, so the holder is unknown — possibly US.
@@ -628,8 +630,18 @@ cmd_claim() {
     emit "HELD issue=$issue ref=refs/claims/issue-$issue sha=$sha machine=$(this_machine) actor=$actor"
     return 0
   fi
+  if [ -z "$confirmed" ]; then
+    # The push was ACCEPTED yet the confirm read finds the ref ABSENT — realistically a
+    # reaper's force-delete landing in this window. NOBODY HOLDS IT, so this is not a
+    # lost race: the SAME rule, and the same shape, as the rejected-push sibling above
+    # (`push-rejected-but-ref-absent`) — ERROR (exit 1, retryable), never a LOST verdict
+    # rendering `sha=<gone> holder=unknown`, which a worker reads as "you did not win,
+    # take the next item" and so walks away from a FREE lane (#2945 review).
+    emit_infra "issue=$issue detail=push-accepted-but-ref-absent-on-confirm-on-$REMOTE (nobody holds it — not a lost race)"
+    return 1
+  fi
   fetch_claim "$issue"
-  emit "LOST issue=$issue ref=refs/claims/issue-$issue sha=${confirmed:-<gone>} $(holder_token "$confirmed")"
+  emit "LOST issue=$issue ref=refs/claims/issue-$issue sha=$confirmed $(holder_token "$confirmed")"
   return 2
 }
 

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -50,8 +50,16 @@ REALGIT="$(command -v git)"   # absolute git, for the shims in TESTS 6/9/10
 
 PASS=0
 FAIL=0
+SKIP=0
 fail() { echo "  ✗ $*"; FAIL=$((FAIL+1)); }
 ok()   { echo "  ✓ $*"; PASS=$((PASS+1)); }
+# skip — a WITNESS whose host dependency is missing. Loud, counted, and reported in
+# the footer, but NOT a failure: this suite runs in the gate of record, where a
+# missing hi-res clock is an environment fact, not a defect (the repo's SKIP-aware
+# convention). Never use it for an assertion the host CAN make.
+skip() { echo "  ⊘ SKIP: $*"; SKIP=$((SKIP+1)); }
+# diag — a measurement worth printing that is NOT a verdict.
+diag() { echo "  · $*"; }
 
 # git in a throwaway identity so commits/pushes work in any sandbox.
 g() { git -c user.email=t@t -c user.name=t -c init.defaultBranch=main -c commit.gpgsign=false "$@"; }
@@ -125,20 +133,44 @@ accepted_olds()    { awk -v r="refs/claims/issue-$1" '$1==r {print $2}' "$HOOKLO
 # test the RECORD, not a verbatim rendering of the whole line.
 line_field() { printf '%s' "$1" | tr ' ' '\n' | grep -m1 "^$2=" | sed "s/^$2=//"; }
 
-# push_work_branch <branch> [msg] — an ORDINARY work branch on origin: cut from
-# main, an ordinary commit on top. Its tip carries NO claim trailers, which is
+# push_work_branch <branch> [msg] [tip-date] — an ORDINARY work branch on origin: cut
+# from main, an ordinary commit on top. Its tip carries NO claim trailers, which is
 # exactly why the old tip-based re-entrancy could never fire.
+#
+# <tip-date> is the tip's committer date and DEFAULTS TO A LONG-STALE FIXED DATE,
+# because the refusal now only advertises the resume hatch for a branch whose tip is
+# older than the reap threshold (#2945 review: a FRESH tip is an older-fleet worker
+# mid-implementation, which has no open PR yet either). A fixed literal date keeps the
+# fixture deterministic — no wall-clock arithmetic in an assertion.
+STALE_TIP_DATE='2020-03-01T12:00:00Z'
 push_work_branch() {
-  local branch="$1" msg="${2:-ordinary work commit}"
+  local branch="$1" msg="${2:-ordinary work commit}" when="${3:-$STALE_TIP_DATE}"
   (
     cd "$A" || exit 1
     g checkout -q -b "$branch" main
-    g commit -q --allow-empty -m "$msg"
+    GIT_AUTHOR_DATE="$when" GIT_COMMITTER_DATE="$when" g commit -q --allow-empty -m "$msg"
     g push -q origin "$branch"
     g checkout -q main
     g branch -q -D "$branch"
   )
 }
+
+# push_machine_claim <ref> <issue> <ts> — a supervisor-authored liveness ref
+# (`refs/machine-claims/<machine>` / `refs/heartbeats/<machine>`, #2655) naming
+# <issue>, with <ts> as its recorded timestamp. Same root-commit shape
+# claim-heartbeat.sh writes, so claim.sh's liveness scan reads a REAL ref, not a mock.
+push_machine_claim() {
+  local ref="$1" issue="$2" ts="$3"
+  (
+    cd "$A" || exit 1
+    local tree commit
+    tree=$(g hash-object -t tree --stdin </dev/null)
+    commit=$(GIT_AUTHOR_DATE="$ts" GIT_COMMITTER_DATE="$ts" \
+      g commit-tree "$tree" -m "claim issue=${issue} machine=machineC pid=1 ts=${ts}")
+    g push -q --force origin "${commit}:${ref}"
+  )
+}
+now_ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 # --- ONE SHARED start signal for the concurrency rounds --------------------
 # The racers must be released TOGETHER. The earlier shape used TWO independent
@@ -149,8 +181,12 @@ push_work_branch() {
 # Now both children announce readiness and then spin on ONE shared flag file the
 # parent creates only after BOTH are ready.
 race_reset() { rm -f "$T/go" "$T/ready-a" "$T/ready-b"; }
-# race_wait_go <ready-file> — announce readiness, then spin on the shared flag.
-race_wait_go() { : >"$1"; while [ ! -e "$T/go" ]; do :; done; }
+# race_wait_go <ready-file> — announce readiness, then poll the shared flag. The
+# poll SLEEPS: a bare `while ...; do :; done` busy-spin burns a core per racer while
+# competing with the very git work the round is timing, and this suite runs inside the
+# gate (whose components share the box) — the racers must wait cheaply, not fight the
+# thing they are measuring. 2ms is far below the git push it gates (tens of ms).
+race_wait_go() { : >"$1"; while [ ! -e "$T/go" ]; do sleep 0.002; done; }
 # race_release — bounded wait for BOTH readiness marks, then flip the one flag.
 race_release() {
   local spins=0
@@ -165,8 +201,9 @@ race_release() {
 # now_ns — a hi-res clock, so the race rounds carry POSITIVE EVIDENCE that they
 # raced (overlapping windows) instead of only asserting invariants that also hold
 # under serialization. GNU date has %N; BSD/macOS date does not (it emits a
-# literal 'N'), hence the perl/python3 fallbacks. No hi-res clock at all is a
-# LOUD failure below, never a silently skipped witness.
+# literal 'N'), hence the perl/python3 fallbacks. No hi-res clock at all is a loud
+# SKIP of the witness below (a missing host dependency, not a defect) — the race
+# INVARIANTS still run and still assert.
 NS_IMPL=none
 nsprobe=$(date -u +%s%N 2>/dev/null || true)
 if [ -n "$nsprobe" ] && [ -z "${nsprobe//[0-9]/}" ] && [ "${#nsprobe}" -ge 16 ]; then
@@ -335,13 +372,22 @@ echo "TEST 3: two machines RACE the resume path — exactly one SERVER-ACCEPTED 
 # — the remote's ref update is the arbiter, and the post-receive log is the witness.
 # Repeated over distinct issue ids because a single interleaving proves little.
 #
-# AND THE ROUND PROVES IT RACED: each racer records a hi-res timestamp immediately
-# before and after its adopt (the push is the bulk of that call), and the round FAILS
-# unless the two windows OVERLAP. Every other assertion here also holds under full
-# serialization, so without this witness a barrier regression is invisible — which is
-# exactly how a non-racing barrier survived two reviews.
+# AND THE ROUNDS PROVE THEY RACED: each racer records a hi-res timestamp immediately
+# before and after its adopt (the push is the bulk of that call), and a MAJORITY of the
+# rounds must show the two windows OVERLAPPING. Every other assertion here also holds
+# under full serialization, so without this witness a barrier regression is invisible —
+# which is exactly how a non-racing barrier survived two reviews.
+#
+# WHY A MAJORITY AND NOT ALL 5: overlap is derived from PROCESS SCHEDULING, and this
+# suite is a gate-of-record component that runs alongside a parallel component pool. One
+# racer can be descheduled long enough for its window to miss the other's, which is a
+# scheduling fact, not a defect — an all-5 requirement makes the gate red for no bug
+# (#2945 review). A majority still kills the regression it exists for: a barrier that
+# serializes the racers yields ZERO overlapping rounds (measured — see the mutation note
+# in this file's header), nowhere near 3/5. Non-overlapping rounds are printed as
+# diagnostics so a drift toward 3/5 is visible before it becomes a failure.
 raceRounds=0; raceOk=0; raceAtomic=0; raceLoser=0; raceWinnerVerified=0; raceDiag=""
-raceOverlapped=0; ovMin=""; ovMax=""
+raceOverlapped=0; ovMin=""; ovMax=""; ovDiag=""
 for id in 2101 2102 2103 2104 2105; do
   raceRounds=$((raceRounds+1))
   push_work_branch "issue-${id}-resumable"
@@ -374,11 +420,11 @@ for id in 2101 2102 2103 2104 2105; do
       [ -n "$ovMin" ] && [ "$ovMin" -le "$ovNs" ] || ovMin="$ovNs"
       [ -n "$ovMax" ] && [ "$ovMax" -ge "$ovNs" ] || ovMax="$ovNs"
     else
-      raceDiag="$raceDiag
-  round $id: the two adopt windows did NOT overlap (gap $((0 - ovNs))ns) — the racers ran SERIALLY, so this round proves nothing"
+      ovDiag="$ovDiag
+  round $id: the two adopt windows did NOT overlap (gap $((0 - ovNs))ns) — that round proves nothing about concurrency"
     fi
   else
-    raceDiag="$raceDiag
+    ovDiag="$ovDiag
   round $id: no usable hi-res timestamps (NS_IMPL=$NS_IMPL) — cannot witness concurrency"
   fi
   rcRaceA="$(cat "$T/race-a.rc" 2>/dev/null || echo missing)"
@@ -445,15 +491,20 @@ done
 [ "$raceWinnerVerified" -eq "$raceRounds" ] \
   && ok "the winner verifies as the holder of the single surviving ref, every round" \
   || fail "the race winner did not verify as holder in $((raceRounds - raceWinnerVerified))/$raceRounds rounds$raceDiag"
-# The barrier itself, measured. A suite with no hi-res clock cannot make this claim,
-# so it fails loudly rather than reporting a vacuous race.
-[ "$NS_IMPL" != none ] \
-  && ok "hi-res clock available to witness concurrency (NS_IMPL=$NS_IMPL)" \
-  || fail "no hi-res clock (date %N / perl Time::HiRes / python3) — the race rounds cannot be witnessed"
-if [ "$raceOverlapped" -eq "$raceRounds" ]; then
-  ok "the two racers' adopt windows OVERLAP every round ($raceOverlapped/$raceRounds; overlap min=$((${ovMin:-0} / 1000000))ms max=$((${ovMax:-0} / 1000000))ms, min=${ovMin:-0}ns) — they really ran concurrently"
+# The barrier itself, measured. Without a hi-res clock the witness is unmeasurable on
+# this host — a loud SKIP of the WITNESS ONLY (the invariants above already asserted),
+# never a failure and never a silent omission.
+[ -n "$ovDiag" ] && diag "concurrency witness, non-overlapping rounds:$ovDiag"
+ovNeeded=$((raceRounds / 2 + 1))
+if [ "$NS_IMPL" = none ]; then
+  skip "no hi-res clock (date %N / perl Time::HiRes / python3) — the racers' overlap could not be MEASURED on this host; the race invariants above still ran"
 else
-  fail "only $raceOverlapped/$raceRounds rounds had overlapping adopt windows — the barrier serialized the racers$raceDiag"
+  ok "hi-res clock available to witness concurrency (NS_IMPL=$NS_IMPL)"
+  if [ "$raceOverlapped" -ge "$ovNeeded" ]; then
+    ok "the two racers' adopt windows OVERLAP in a majority of rounds ($raceOverlapped/$raceRounds, need >=$ovNeeded; overlap min=$((${ovMin:-0} / 1000000))ms max=$((${ovMax:-0} / 1000000))ms, min=${ovMin:-0}ns) — they really ran concurrently"
+  else
+    fail "only $raceOverlapped/$raceRounds rounds had overlapping adopt windows (need >=$ovNeeded) — the barrier serialized the racers$ovDiag"
+  fi
 fi
 
 # ===========================================================================
@@ -812,6 +863,20 @@ if [ "$whyRc" = " 64 64 64 64 64 64" ] && [ -z "$(ref_sha 2023)" ]; then
 else
   fail "expected 64 from every unrecordable --reason with no ref created; got rcs='$whyRc' ref='$(ref_sha 2023)'"
 fi
+# A PLACEHOLDER reason is refused too (#2945 review). `--reason <why>` copy-pasted from
+# a help line sanitizes to `why`: 3 recordable chars, so the length gate passes and the
+# record reads `reason=why` — as uninformative as the no-reason case this gate exists to
+# reject. The sentinel vocabulary is refused by name, case-insensitively.
+placeholderRc=""
+for ph in '<why>' 'why' 'TODO' 'tbd' 'xxx' 'placeholder' 'FIXME' 'n/a'; do
+  runB adopt 2023 --expect none --reason "$ph" >/dev/null 2>&1
+  placeholderRc="$placeholderRc $?"
+done
+if [ "$placeholderRc" = " 64 64 64 64 64 64 64 64" ] && [ -z "$(ref_sha 2023)" ]; then
+  ok "a PLACEHOLDER reason ('<why>', 'why', 'TODO', 'tbd', 'xxx', 'placeholder', 'FIXME', 'n/a') is a usage error (exit 64), nothing acquired"
+else
+  fail "expected 64 from every placeholder --reason with no ref created; got rcs='$placeholderRc' ref='$(ref_sha 2023)'"
+fi
 runB adopt 2023 --expect none --reason 'wip' >/dev/null 2>&1; rcMinWhy=$?
 if [ "$rcMinWhy" -eq 0 ] && [ "$(line_field "$(runB status 2023)" reason)" = "wip" ]; then
   ok "a short but RECORDABLE reason ('wip') is accepted and recorded verbatim"
@@ -825,6 +890,20 @@ if [ "$rcLong" -eq 0 ] && [ "${#longToken}" -eq 120 ]; then
   ok "an over-long reason is truncated to the documented 120 chars"
 else
   fail "expected a 120-char reason token; got rc=$rcLong len=${#longToken}"
+fi
+# TRUNCATION MUST NOT RE-INTRODUCE A TRAILING SEPARATOR (#2945 review). The single-word
+# fixture above cannot see this: the sanitizer trimmed leading/trailing '-' BEFORE the
+# 120-char cut, so a MULTI-WORD reason whose 120th byte is a word separator recorded as
+# '…foo-' — contradicting the documented trim. 31 'abc' words sanitize to 123 chars whose
+# 120th is exactly a '-', so the cut lands on the separator.
+multiReason="$(printf 'abc %.0s' $(seq 1 31))"
+runB adopt 2053 --expect none --reason "$multiReason" >/dev/null 2>&1; rcMulti=$?
+multiToken=$(line_field "$(runB status 2053)" reason)
+if [ "$rcMulti" -eq 0 ] && [ "${#multiToken}" -le 120 ] \
+   && [ "${multiToken%-}" = "$multiToken" ] && [ "${multiToken#abc-abc}" != "$multiToken" ]; then
+  ok "a truncated MULTI-WORD reason keeps the documented trim (len=${#multiToken}, no trailing separator)"
+else
+  fail "expected a <=120-char token with no trailing '-'; got rc=$rcMulti len=${#multiToken} token='$multiToken'"
 fi
 runB adopt 2043 --expect none --reason "$(printf 'first line\nsecond line')" >/dev/null 2>&1; rcNl=$?
 nlStatus=$(runB status 2043)
@@ -896,6 +975,8 @@ echo "TEST 15: the escape hatch is advertised ONLY when the endgame is demonstra
 # empty-lease adopt WOULD succeed — handing an actively-worked issue to a second
 # machine. The readers are agents that run printed remediations literally, so the
 # command is printed only at open-prs=0, and an unreadable PR list withholds too.
+# The fixture tip is LONG STALE (the default), so the PR signal is the ONLY thing that
+# can withhold here — the tip-age/liveness signals are pinned separately in TEST 16.
 push_work_branch "issue-2015-live-endgame"
 ( cd "$B" && g fetch -q origin )
 PRSHIM="$T/shim-gh-open-pr"
@@ -948,6 +1029,146 @@ else
 $outStillWorks"
 fi
 
+# ===========================================================================
+echo "TEST 16: the PRE-PR window — a FRESH branch tip or a fresh liveness ref withholds the hatch; the advertised command is informative VERBATIM"
+# ===========================================================================
+# open-prs=0 alone does NOT prove the lane is orphaned (#2945 review): this pipeline
+# opens the PR LATE, so an older-fleet worker that is actively implementing has zero
+# open PRs for most of its life while holding only the BRANCH. The liveness evidence for
+# that window is the branch TIP AGE plus the supervisor-authored machine-claim/heartbeat
+# refs — and every unreadable signal withholds.
+
+# (a) FRESH tip, no open PR: a worker mid-implementation. The hatch must be WITHHELD.
+push_work_branch "issue-2016-being-worked-right-now" "wip commit" "$(now_ts)"
+( cd "$B" && g fetch -q origin )
+outFresh=$(runB_gh claim 2016); rcFresh=$?
+if [ "$rcFresh" -eq 2 ] && printf '%s\n' "$outFresh" | grep -q 'remediation=withheld' \
+   && printf '%s\n' "$outFresh" | grep -q 'open-prs=0' \
+   && printf '%s\n' "$outFresh" | grep -q 'newest-branch-tip=' \
+   && ! printf '%s\n' "$outFresh" | grep -q 'adopt 2016 --expect none' \
+   && [ "$(printf '%s\n' "$outFresh" | grep -c 'CLAIM:')" = "1" ]; then
+  ok "a FRESH branch tip at open-prs=0 (legacy worker mid-implementation) WITHHOLDS the hatch"
+else
+  fail "expected the hatch withheld for a fresh tip at open-prs=0; got rc=$rcFresh
+$outFresh"
+fi
+
+# (b) STALE tip, no open PR, no liveness ref: demonstrably orphaned → advertised. And
+# the printed command, run VERBATIM (which is what the readers do), must record an
+# INFORMATIVE reason — not the `why` a `--reason <why>` placeholder would have recorded.
+push_work_branch "issue-2017-abandoned-lane"
+( cd "$B" && g fetch -q origin )
+outAdv=$(runB_gh claim 2017); rcAdv=$?
+if [ "$rcAdv" -eq 2 ] && printf '%s\n' "$outAdv" | grep -q "adopt 2017 --expect none --reason resume-legacy-branch-lock:issue-2017-abandoned-lane" \
+   && printf '%s\n' "$outAdv" | grep -q 'liveness-refs=none-naming-2017' \
+   && printf '%s\n' "$outAdv" | grep -q 'stale-after='; then
+  ok "a STALE tip + open-prs=0 + no liveness ref advertises the hatch with a CONCRETE self-describing --reason"
+else
+  fail "expected an advertised hatch with a concrete reason; got rc=$rcAdv
+$outAdv"
+fi
+verbatimArgs=$(printf '%s\n' "$outAdv" | sed -n "s/.*remediation='bash scripts\/flow\/claim.sh \([^']*\)'.*/\1/p")
+# Deliberate word splitting: the point is to run the PRINTED argv, unedited.
+# shellcheck disable=SC2086
+outVerbatim=$(runB $verbatimArgs); rcVerbatim=$?
+verbatimReason=$(line_field "$(runB status 2017)" reason)
+if [ "$rcVerbatim" -eq 0 ] && printf '%s\n' "$outVerbatim" | grep -q 'CLAIM: ADOPTED' \
+   && [ "$verbatimReason" != "why" ] && [ "$verbatimReason" != "unspecified" ] \
+   && printf '%s' "$verbatimReason" | grep -q 'resume-legacy-branch-lock' \
+   && printf '%s' "$verbatimReason" | grep -q 'issue-2017-abandoned-lane'; then
+  ok "copy-pasted VERBATIM the printed command adopts and records an informative reason ('$verbatimReason')"
+else
+  fail "the printed command did not adopt with an informative reason; rc=$rcVerbatim reason='$verbatimReason'
+$outVerbatim"
+fi
+
+# (c) STALE tip but a FRESH machine-claim ref naming the issue: a supervisor says a
+# worker is on it (#2655), so the hatch is WITHHELD even though the tip aged out.
+push_work_branch "issue-2018-stale-branch-live-worker"
+push_machine_claim "refs/machine-claims/machineFresh" 2018 "$(now_ts)"
+( cd "$B" && g fetch -q origin )
+outLiveRef=$(runB_gh claim 2018); rcLiveRef=$?
+if [ "$rcLiveRef" -eq 2 ] && printf '%s\n' "$outLiveRef" | grep -q 'remediation=withheld' \
+   && printf '%s\n' "$outLiveRef" | grep -q 'liveness-ref=refs/machine-claims/machineFresh' \
+   && ! printf '%s\n' "$outLiveRef" | grep -q 'adopt 2018 --expect none'; then
+  ok "a FRESH machine-claim ref naming the issue WITHHOLDS the hatch even with a stale branch tip"
+else
+  fail "expected the hatch withheld for a fresh liveness ref; got rc=$rcLiveRef
+$outLiveRef"
+fi
+
+# (d) …and a liveness ref older than the threshold does NOT withhold forever: it is
+# itself reapable, so an abandoned heartbeat must not lock the lane out permanently.
+push_work_branch "issue-2019-stale-branch-stale-heartbeat"
+push_machine_claim "refs/heartbeats/machineStale" 2019 "$STALE_TIP_DATE"
+( cd "$B" && g fetch -q origin )
+outStaleRef=$(runB_gh claim 2019); rcStaleRef=$?
+if [ "$rcStaleRef" -eq 2 ] && printf '%s\n' "$outStaleRef" | grep -q 'adopt 2019 --expect none --reason resume-legacy-branch-lock:' \
+   && printf '%s\n' "$outStaleRef" | grep -q 'liveness-refs=none-naming-2019'; then
+  ok "a liveness ref STALER than the reap threshold ages out and does not withhold the hatch"
+else
+  fail "expected the hatch advertised despite a stale liveness ref; got rc=$rcStaleRef
+$outStaleRef"
+fi
+
+# (e) UNREADABLE threshold (claim.sh without its claim-heartbeat.sh sibling): the lane
+# cannot be shown orphaned, so the hatch is withheld rather than defaulting to some
+# second copy of "4h".
+push_work_branch "issue-2020-threshold-unreadable"
+( cd "$B" && g fetch -q origin )
+LONE="$T/lone-claim"
+mkdir -p "$LONE"
+cp "$CLAIM" "$LONE/claim.sh"
+outNoThresh=$( cd "$B" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$LONE/claim.sh" claim 2020 2>/dev/null ); rcNoThresh=$?
+if [ "$rcNoThresh" -eq 2 ] && printf '%s\n' "$outNoThresh" | grep -q 'remediation=withheld' \
+   && printf '%s\n' "$outNoThresh" | grep -q 'liveness=threshold-unreadable' \
+   && ! printf '%s\n' "$outNoThresh" | grep -q 'adopt 2020 --expect none'; then
+  ok "an UNREADABLE staleness threshold withholds the hatch (no hardcoded fallback)"
+else
+  fail "expected the hatch withheld when the threshold cannot be read; got rc=$rcNoThresh
+$outNoThresh"
+fi
+
+# (f) UNREADABLE liveness refs (a git shim fails ONLY the machine-claims enumeration,
+# everything else passes through): "we could not prove nobody is on it" withholds.
+push_work_branch "issue-2021-liveness-enumeration-outage"
+( cd "$B" && g fetch -q origin )
+SHIML="$T/shim-liveness-fail"
+mkdir -p "$SHIML"
+cat >"$SHIML/git" <<SHIM
+#!/usr/bin/env bash
+saw_ls=0; saw_liveness=0
+for a in "\$@"; do
+  [ "\$a" = "ls-remote" ] && saw_ls=1
+  case "\$a" in refs/machine-claims/* | refs/heartbeats/*) saw_liveness=1 ;; esac
+done
+if [ "\$saw_ls" = 1 ] && [ "\$saw_liveness" = 1 ]; then exit 128; fi
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIML/git"
+outNoLive=$( cd "$B" && PATH="$SHIML:$GHSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" claim 2021 2>/dev/null ); rcNoLive=$?
+if [ "$rcNoLive" -eq 2 ] && printf '%s\n' "$outNoLive" | grep -q 'remediation=withheld' \
+   && printf '%s\n' "$outNoLive" | grep -q 'liveness-refs=unreadable' \
+   && ! printf '%s\n' "$outNoLive" | grep -q 'adopt 2021 --expect none'; then
+  ok "an UNREADABLE liveness-ref enumeration withholds the hatch (fail closed on an unread signal)"
+else
+  fail "expected the hatch withheld on a liveness enumeration outage; got rc=$rcNoLive
+$outNoLive"
+fi
+
+# (g) …and withholding still changes only ADVICE: the deliberate resume of the
+# actively-worked lane from (a) remains possible for an operator who confirmed ownership.
+outDeliberate=$(runB adopt 2016 --expect none --reason "confirmed with the branch author that the lane is free"); rcDeliberate=$?
+if [ "$rcDeliberate" -eq 0 ] && printf '%s\n' "$outDeliberate" | grep -q 'CLAIM: ADOPTED' \
+   && [ -n "$(ref_sha 2016)" ]; then
+  ok "the liveness gate changes the printed ADVICE only — a deliberate resume still works, git still arbitrates"
+else
+  fail "expected the deliberate resume of a withheld lane to still succeed; got rc=$rcDeliberate
+$outDeliberate"
+fi
+
 echo ""
-echo "================  claim-resume (#2945): $PASS passed, $FAIL failed  ================"
+echo "================  claim-resume (#2945): $PASS passed, $FAIL failed, $SKIP skipped  ================"
 [ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -17,6 +17,14 @@
 # hardening of the two user-controlled fields (--reason, --actor) that land in the
 # very commit message the holder-identity parser reads.
 #
+# THE COMMAND IS SANCTIONED BUT NOT ADVERTISED (owner decision, #2945). The refusal
+# DIAGNOSES the lane — the blocking branch plus `claim-ref=free` — and points at the
+# documented procedure; it prints NO runnable resume command, because the readers are
+# agents that execute printed remediations literally and the printed command would
+# succeed against an actively-worked legacy lane. TEST 15 pins that absence (both the
+# `claim.sh adopt` and the bare `adopt … --expect` shapes) and the fact that the claim
+# path reads no GitHub state at all; TEST 16 pins that the MECHANISM is untouched.
+#
 # WRITES ARE WITNESSED, NOT INFERRED: a `post-receive` hook on the bare origin logs
 # every ACCEPTED ref update ("<ref> <old> <new>"), so tests assert how many writes
 # the SERVER applied and from what old value. Counting refs afterwards cannot do
@@ -133,90 +141,27 @@ accepted_olds()    { awk -v r="refs/claims/issue-$1" '$1==r {print $2}' "$HOOKLO
 # test the RECORD, not a verbatim rendering of the whole line.
 line_field() { printf '%s' "$1" | tr ' ' '\n' | grep -m1 "^$2=" | sed "s/^$2=//"; }
 
-# --- THE TWO WORK-BRANCH PREMISES ------------------------------------------
-# The name of each fixture states which premise a test encodes, because the liveness
-# gate treats them DIFFERENTLY and the difference is the whole point of TEST 17: a tip
-# with own commits is AGE-JUDGEABLE, a tip without any is INDETERMINATE.
+# --- THE WORK-BRANCH FIXTURE -----------------------------------------------
+# push_work_branch <branch> [msg] — an ORDINARY work branch on origin: cut from main,
+# with a commit of its own on top. Its tip carries NO claim trailers, which is exactly
+# why the old tip-based re-entrancy could never fire (TEST 7).
 #
-# push_branch_with_own_commit <branch> [msg] [tip-date] — an ORDINARY work branch on
-# origin: cut from main, WITH an ordinary commit of its own on top. Its tip carries NO
-# claim trailers, which is exactly why the old tip-based re-entrancy could never fire.
-#
-# <tip-date> is the tip's committer date and DEFAULTS TO A LONG-STALE FIXED DATE,
-# because the refusal now only advertises the resume hatch for a branch whose tip is
-# older than the reap threshold (#2945 review: a FRESH tip is an older-fleet worker
-# mid-implementation, which has no open PR yet either). A fixed literal date keeps the
-# fixture deterministic — no wall-clock arithmetic in an assertion.
-STALE_TIP_DATE='2020-03-01T12:00:00Z'
-push_branch_with_own_commit() {
-  local branch="$1" msg="${2:-ordinary work commit}" when="${3:-$STALE_TIP_DATE}"
+# The tip's DATE is deliberately irrelevant: the refusal reports the branch and
+# `claim-ref=free` and then points at the documented procedure, so nothing in claim.sh
+# judges a branch tip's age any more (the in-script liveness probe was deleted by owner
+# decision — three revisions of it each shipped a new way to hand away a live lane).
+# That is also why this suite contains NO clock-dependent branch fixture.
+push_work_branch() {
+  local branch="$1" msg="${2:-ordinary work commit}"
   (
     cd "$A" || exit 1
     g checkout -q -b "$branch" main
-    GIT_AUTHOR_DATE="$when" GIT_COMMITTER_DATE="$when" g commit -q --allow-empty -m "$msg"
+    g commit -q --allow-empty -m "$msg"
     g push -q origin "$branch"
     g checkout -q main
     g branch -q -D "$branch"
   )
 }
-
-# push_branch_without_own_commits <branch> — THE PRODUCTION SHAPE AT ACTIVATION TIME:
-# `flow-activate` runs `git worktree add -b issue-<N>-<slug> origin/main` and pushes the
-# branch immediately, so the tip IS origin/main's tip and the branch has no commits of
-# its own until PR time. Its committer date is therefore main's, not the worker's — the
-# premise under which the tip-age liveness signal is VACUOUS (#2945 round 5).
-push_branch_without_own_commits() {
-  local branch="$1"
-  (
-    cd "$A" || exit 1
-    g fetch -q origin
-    g push -q origin "refs/remotes/origin/main:refs/heads/$branch"
-  )
-}
-
-# advance_main_with_stale_tip — move origin's DEFAULT branch to a long-stale-dated tip,
-# i.e. "main has been quiet longer than the reap threshold" (overnight is routine). This
-# is what made the vacuous tip-age signal dangerous: a commit-less branch inherits that
-# date and reads as reapable. Called once, by TEST 17.
-advance_main_with_stale_tip() {
-  (
-    cd "$A" || exit 1
-    g fetch -q origin
-    g checkout -q main
-    g reset -q --hard origin/main
-    GIT_AUTHOR_DATE="$STALE_TIP_DATE" GIT_COMMITTER_DATE="$STALE_TIP_DATE" \
-      g commit -q --allow-empty -m "main has been quiet since $STALE_TIP_DATE"
-    g push -q origin main
-  )
-}
-
-# push_machine_claim <ref> <issue> <ts> — a supervisor-authored liveness ref;
-# push_raw_liveness_ref <ref> <msg> — the same NAMESPACE with an arbitrary (legacy) message.
-# (`refs/machine-claims/<machine>` / `refs/heartbeats/<machine>`, #2655) naming
-# <issue>, with <ts> as its recorded timestamp. Same root-commit shape
-# claim-heartbeat.sh writes, so claim.sh's liveness scan reads a REAL ref, not a mock.
-push_raw_liveness_ref() {
-  local ref="$1" msg="$2"
-  (
-    cd "$A" || exit 1
-    local tree commit
-    tree=$(g hash-object -t tree --stdin </dev/null)
-    commit=$(g commit-tree "$tree" -m "$msg")
-    g push -q --force origin "${commit}:${ref}"
-  )
-}
-push_machine_claim() {
-  local ref="$1" issue="$2" ts="$3"
-  (
-    cd "$A" || exit 1
-    local tree commit
-    tree=$(g hash-object -t tree --stdin </dev/null)
-    commit=$(GIT_AUTHOR_DATE="$ts" GIT_COMMITTER_DATE="$ts" \
-      g commit-tree "$tree" -m "claim issue=${issue} machine=machineC pid=1 ts=${ts}")
-    g push -q --force origin "${commit}:${ref}"
-  )
-}
-now_ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 # --- ONE SHARED start signal for the concurrency rounds --------------------
 # The racers must be released TOGETHER. The earlier shape used TWO independent
@@ -275,31 +220,29 @@ read_ns() {
 }
 
 # ===========================================================================
-echo "TEST 1: FREE claim ref + foreign-tip issue-<N>-* branch — claim refuses WITH the remediation, adopt --expect none SUCCEEDS"
+echo "TEST 1: FREE claim ref + foreign-tip issue-<N>-* branch — claim refuses with a DIAGNOSIS, adopt --expect none SUCCEEDS"
 # ===========================================================================
-push_branch_with_own_commit "issue-2001-owner-approved-spec" "docs(#2001): OpenSpec change approved by owner"
+push_work_branch "issue-2001-owner-approved-spec" "docs(#2001): OpenSpec change approved by owner"
 ( cd "$B" && g fetch -q origin )
 [ -z "$(ref_sha 2001)" ] && ok "precondition: refs/claims/issue-2001 is FREE" \
   || fail "precondition broken: a claim ref already exists for 2001"
 
-# runB_gh: the gh stub reports NO open PR, i.e. a demonstrably orphaned endgame —
-# the only state in which the escape hatch may be advertised (see TEST 15).
-outClaim=$(runB_gh claim 2001); rcClaim=$?
+outClaim=$(runB claim 2001); rcClaim=$?
 if [ "$rcClaim" -eq 2 ] && printf '%s\n' "$outClaim" | grep -q 'reason=legacy-branch-lock'; then
   ok "claim still refuses (exit 2) while the branch stands"
 else
   fail "expected legacy-branch-lock refusal exit 2; got rc=$rcClaim
 $outClaim"
 fi
-# Option 3 of the issue: the refusal must be ACTIONABLE, not a bare LOST — a bare
-# LOST is what sent two workers into hand-crafted claim-commit pushes.
-if printf '%s\n' "$outClaim" | grep -q 'adopt 2001 --expect none --reason' \
-   && printf '%s\n' "$outClaim" | grep -q 'issue-2001-owner-approved-spec' \
+# The refusal must DIAGNOSE (naming the branch and the free claim ref) — a bare LOST is
+# what sent two workers into hand-crafted claim-commit pushes. It must NOT hand over a
+# runnable command; that separation is pinned in TEST 15.
+if printf '%s\n' "$outClaim" | grep -q 'issue-2001-owner-approved-spec' \
    && printf '%s\n' "$outClaim" | grep -q 'claim-ref=free' \
-   && printf '%s\n' "$outClaim" | grep -q 'open-prs=0'; then
-  ok "refusal names the exact remediation command, the blocking branch, claim-ref=free, and open-prs=0"
+   && printf '%s\n' "$outClaim" | grep -q 'resume=documented-procedure'; then
+  ok "refusal names the blocking branch, claim-ref=free, and the documented resume"
 else
-  fail "refusal is not actionable (missing remediation/branch/claim-ref=free):
+  fail "refusal is not a usable diagnosis (missing branch/claim-ref=free/pointer):
 $outClaim"
 fi
 [ "$(printf '%s\n' "$outClaim" | grep -c 'CLAIM:')" = "1" ] \
@@ -367,7 +310,7 @@ else
   fail "expected RELEASED exit 0 with the ref gone; got rc=$rcRelease ref='$(ref_sha 2001)'
 $outRelease"
 fi
-outAfter=$(runA_gh claim 2001); rcAfter=$?
+outAfter=$(runA claim 2001); rcAfter=$?
 if [ "$rcAfter" -eq 2 ] && printf '%s\n' "$outAfter" | grep -q 'reason=legacy-branch-lock'; then
   ok "after the release the surviving work branch still guards a plain claim (exit 2)"
 else
@@ -378,7 +321,7 @@ fi
 # ===========================================================================
 echo "TEST 2: HELD claim ref + branch present — the resume path is still REFUSED (exit 2, holder keeps it)"
 # ===========================================================================
-push_branch_with_own_commit "issue-2002-active-effort"
+push_work_branch "issue-2002-active-effort"
 ( cd "$B" && g fetch -q origin )
 runA claim 2002 >/dev/null 2>&1   # blocked by the branch guard, so take it via the resume path
 runA adopt 2002 --expect none --reason "machineA is actively working this" >/dev/null 2>&1; rcHold=$?
@@ -437,7 +380,7 @@ raceRounds=0; raceOk=0; raceAtomic=0; raceLoser=0; raceWinnerVerified=0; raceDia
 raceOverlapped=0; ovMin=""; ovMax=""; ovDiag=""
 for id in 2101 2102 2103 2104 2105; do
   raceRounds=$((raceRounds+1))
-  push_branch_with_own_commit "issue-${id}-resumable"
+  push_work_branch "issue-${id}-resumable"
   ( cd "$B" && g fetch -q origin )
   race_reset
   ( race_wait_go "$T/ready-a"
@@ -652,7 +595,7 @@ echo "TEST 6: #2677 item 2 — a legacy-branch enumeration OUTAGE fails CLOSED (
 # A git shim fails ONLY `ls-remote --heads` (the guard's enumeration) and passes
 # everything else through, so the claim push WOULD succeed. The old code mapped that
 # failure to "no legacy branches" and granted the claim; it must now be UNKNOWN.
-push_branch_with_own_commit "issue-2006-invisible-to-the-guard"
+push_work_branch "issue-2006-invisible-to-the-guard"
 SHIMH="$T/shim-heads-fail"
 mkdir -p "$SHIMH"
 cat >"$SHIMH/git" <<SHIM
@@ -684,10 +627,10 @@ echo "TEST 7: no tip-based re-entrancy survives — even a claim-shaped branch t
 # The old guard tried to exempt a branch whose TIP looked like our own claim commit.
 # That exemption is deliberately gone: branch tips are not the lock, so a tip that
 # happens to carry claim trailers must NOT grant a claim. The resume is explicit.
-push_branch_with_own_commit "issue-2007-tip-looks-like-a-claim" \
+push_work_branch "issue-2007-tip-looks-like-a-claim" \
   "claim issue=2007 machine=machineB pid=1 actor=flow ts=2026-07-26T00:00:00Z nonce=x"
 ( cd "$B" && g fetch -q origin )
-outTip=$(runB_gh claim 2007); rcTip=$?
+outTip=$(runB claim 2007); rcTip=$?
 tipRef=$(ref_sha 2007)
 if [ "$rcTip" -eq 2 ] && printf '%s\n' "$outTip" | grep -q 'reason=legacy-branch-lock' && [ -z "$tipRef" ]; then
   ok "a claim-shaped branch tip does not grant a claim — the guard blocks (no ref granted)"
@@ -1032,40 +975,52 @@ done
   || fail "reaper/resumer barrier race produced a bogus owner in $((reapRounds - reapOk))/$reapRounds rounds$reapDiag"
 
 # ===========================================================================
-echo "TEST 15: the escape hatch is advertised ONLY when the endgame is demonstrably orphaned (open PR / unknown → withheld)"
+echo "TEST 15: the refusal DIAGNOSES the lane and prints NO runnable resume command (owner decision, #2945)"
 # ===========================================================================
-# The refusal's safety argument ("git rejects it if any machine holds the ref") does
-# NOT cover the case the guard exists for: an OLDER-fleet worker locks with the
-# BRANCH and holds no claim ref, so `claim-ref=free` is true for it and the advertised
-# empty-lease adopt WOULD succeed — handing an actively-worked issue to a second
-# machine. The readers are agents that run printed remediations literally, so the
-# command is printed only at open-prs=0, and an unreadable PR list withholds too.
-# The fixture tip is LONG STALE (the default), so the PR signal is the ONLY thing that
-# can withhold here — the tip-age/liveness signals are pinned separately in TEST 16.
-push_branch_with_own_commit "issue-2015-live-endgame"
+# The refusal used to PRINT a copy-pasteable `adopt --expect none` line whenever an
+# in-script liveness probe judged the lane orphaned. That probe is deleted: the readers
+# are agents that execute printed remediations LITERALLY, an older-fleet worker locks
+# with the BRANCH while holding no claim ref (so the printed command WOULD succeed
+# against a live lane), and three successive revisions of the probe each shipped a new
+# way to hand away an actively-worked issue. What the refusal owes the reader is the
+# DIAGNOSIS (which branch blocks it, and that the claim ref itself is free) plus a
+# pointer to the documented procedure — never an executable line.
+push_work_branch "issue-2015-diagnose-only"
 ( cd "$B" && g fetch -q origin )
-PRSHIM="$T/shim-gh-open-pr"
-mkdir -p "$PRSHIM"
-cat >"$PRSHIM/gh" <<'GH'
-#!/usr/bin/env bash
-# Fake gh: one OPEN PR whose head branch is this issue's.
-for a in "$@"; do [ "$a" = "list" ] && { echo "issue-2015-live-endgame"; exit 0; }; done
-exit 1
-GH
-chmod +x "$PRSHIM/gh"
-outLive=$( cd "$B" && PATH="$PRSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" claim 2015 ); rcLive=$?
-if [ "$rcLive" -eq 2 ] && printf '%s\n' "$outLive" | grep -q 'reason=legacy-branch-lock' \
-   && printf '%s\n' "$outLive" | grep -q 'remediation=withheld' \
-   && printf '%s\n' "$outLive" | grep -q 'open-prs=1' \
-   && ! printf '%s\n' "$outLive" | grep -q 'adopt 2015 --expect none' \
-   && [ "$(printf '%s\n' "$outLive" | grep -c 'CLAIM:')" = "1" ]; then
-  ok "with an OPEN PR the refusal withholds the hatch (remediation=withheld open-prs=1, no copy-pasteable adopt) on one line"
+outDiag=$(runB claim 2015); rcDiag=$?
+if [ "$rcDiag" -eq 2 ] && printf '%s\n' "$outDiag" | grep -q 'reason=legacy-branch-lock' \
+   && printf '%s\n' "$outDiag" | grep -q 'detail=refs/heads/issue-2015-diagnose-only' \
+   && printf '%s\n' "$outDiag" | grep -q 'claim-ref=free' \
+   && [ "$(printf '%s\n' "$outDiag" | grep -c 'CLAIM:')" = "1" ]; then
+  ok "the refusal names the blocking branch and claim-ref=free on ONE line"
 else
-  fail "expected a withheld remediation with open-prs=1; got rc=$rcLive
-$outLive"
+  fail "refusal lost its diagnosis (branch / claim-ref=free); got rc=$rcDiag
+$outDiag"
 fi
-# gh missing/failing = UNKNOWN, and unknown must fail closed exactly like release's
-# open-PR guard — never advertise a hand-away on an unread signal.
+# THE HARD REQUIREMENT: nothing in the output may be run as-is to take the claim.
+# Both shapes are excluded — the fully-qualified invocation and the bare argv — so a
+# future "helpful" reintroduction in either form fails here.
+if ! printf '%s\n' "$outDiag" | grep -q 'claim\.sh adopt' \
+   && ! printf '%s\n' "$outDiag" | grep -qE 'adopt .*--expect' \
+   && ! printf '%s\n' "$outDiag" | grep -q -- '--expect none'; then
+  ok "the refusal contains NO runnable adopt command (no 'claim.sh adopt', no 'adopt … --expect', no '--expect none')"
+else
+  fail "the refusal advertises a runnable resume command again:
+$outDiag"
+fi
+# …and it points at the documented procedure + the abandonment test, so the reader is
+# not left at a dead end (the dead end is what produced hand-crafted claim pushes).
+if printf '%s\n' "$outDiag" | grep -q 'resume=documented-procedure' \
+   && printf '%s\n' "$outDiag" | grep -q 'should-reap' \
+   && printf '%s\n' "$outDiag" | grep -q 'claim\.sh -h'; then
+  ok "the refusal points at the documented resume + the abandonment test (should-reap), not a command"
+else
+  fail "refusal gives no pointer to the documented procedure/abandonment test:
+$outDiag"
+fi
+# The refusal is now INDEPENDENT of gh: the claim path no longer reads GitHub at all,
+# so a broken gh must not change one byte of it. (A gh probe is exactly what the
+# deleted machinery needed, so this pins its absence.)
 GHFAIL="$T/shim-gh-broken"
 mkdir -p "$GHFAIL"
 cat >"$GHFAIL/gh" <<'GH'
@@ -1074,254 +1029,36 @@ echo "gh: simulated failure" >&2
 exit 1
 GH
 chmod +x "$GHFAIL/gh"
-outUnknown=$( cd "$B" && PATH="$GHFAIL:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" claim 2015 2>/dev/null ); rcUnknown=$?
-if [ "$rcUnknown" -eq 2 ] && printf '%s\n' "$outUnknown" | grep -q 'remediation=withheld' \
-   && printf '%s\n' "$outUnknown" | grep -q 'open-prs=-1' \
-   && ! printf '%s\n' "$outUnknown" | grep -q 'adopt 2015 --expect none'; then
-  ok "an UNREADABLE PR list also withholds the hatch (open-prs=-1) — fail closed on an unread signal"
+outNoGh=$( cd "$B" && PATH="$GHFAIL:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" claim 2015 2>/dev/null ); rcNoGh=$?
+if [ "$rcNoGh" -eq 2 ] && [ "$outNoGh" = "$outDiag" ]; then
+  ok "a broken gh produces the byte-identical refusal — the claim path reads no GitHub state"
 else
-  fail "expected a withheld remediation with open-prs=-1; got rc=$rcUnknown
-$outUnknown"
+  fail "the refusal depends on gh (rc=$rcNoGh); with a broken gh it read:
+$outNoGh"
 fi
-# Withholding is ADVICE, not a lock: an operator who has confirmed ownership can
-# still resume, and git remains the sole arbiter (the claim ref really is free).
-outStillWorks=$(runB adopt 2015 --expect none --reason "ownership confirmed with the PR author"); rcStillWorks=$?
-if [ "$rcStillWorks" -eq 0 ] && printf '%s\n' "$outStillWorks" | grep -q 'CLAIM: ADOPTED' \
+
+# ===========================================================================
+echo "TEST 16: the sanctioned resume is fully functional though unadvertised — and STILL loses to a real holder"
+# ===========================================================================
+# Removing the ADVERTISEMENT must not touch the MECHANISM (AC1). An operator who has
+# confirmed abandonment out-of-band runs the documented command and it works; a lane
+# whose claim ref is genuinely HELD still refuses, with the holder's ref untouched.
+outUnadvertised=$(runB adopt 2015 --expect none --reason "abandonment confirmed via should-reap and the branch author"); rcUnadvertised=$?
+if [ "$rcUnadvertised" -eq 0 ] && printf '%s\n' "$outUnadvertised" | grep -q 'CLAIM: ADOPTED' \
    && [ -n "$(ref_sha 2015)" ]; then
-  ok "the hatch itself still works when invoked deliberately — the guard changes ADVICE, not the arbiter"
+  ok "the unadvertised resume still acquires the FREE ref when run deliberately"
 else
-  fail "expected the deliberate resume to still succeed; got rc=$rcStillWorks
-$outStillWorks"
+  fail "expected the deliberate resume to still succeed; got rc=$rcUnadvertised
+$outUnadvertised"
 fi
-
-# ===========================================================================
-echo "TEST 16: the PRE-PR window — a FRESH branch tip or a fresh liveness ref withholds the hatch; the advertised command is informative VERBATIM"
-# ===========================================================================
-# open-prs=0 alone does NOT prove the lane is orphaned (#2945 review): this pipeline
-# opens the PR LATE, so an older-fleet worker that is actively implementing has zero
-# open PRs for most of its life while holding only the BRANCH. The liveness evidence for
-# that window is the branch TIP AGE plus the supervisor-authored machine-claim/heartbeat
-# refs — and every unreadable signal withholds.
-
-# (a) FRESH tip, no open PR: a worker mid-implementation. The hatch must be WITHHELD.
-push_branch_with_own_commit "issue-2016-being-worked-right-now" "wip commit" "$(now_ts)"
-( cd "$B" && g fetch -q origin )
-outFresh=$(runB_gh claim 2016); rcFresh=$?
-if [ "$rcFresh" -eq 2 ] && printf '%s\n' "$outFresh" | grep -q 'remediation=withheld' \
-   && printf '%s\n' "$outFresh" | grep -q 'open-prs=0' \
-   && printf '%s\n' "$outFresh" | grep -q 'newest-branch-tip=' \
-   && ! printf '%s\n' "$outFresh" | grep -q 'adopt 2016 --expect none' \
-   && [ "$(printf '%s\n' "$outFresh" | grep -c 'CLAIM:')" = "1" ]; then
-  ok "a FRESH branch tip at open-prs=0 (legacy worker mid-implementation) WITHHOLDS the hatch"
+heldBefore=$(ref_sha 2015)
+outSecond=$(runA adopt 2015 --expect none --reason "a second machine tries the same unadvertised path"); rcSecond=$?
+if [ "$rcSecond" -eq 2 ] && printf '%s\n' "$outSecond" | grep -q 'CLAIM: ADOPT-LOST' \
+   && [ "$(ref_sha 2015)" = "$heldBefore" ]; then
+  ok "the same command against a HELD ref is refused (exit 2) with the holder's ref unchanged"
 else
-  fail "expected the hatch withheld for a fresh tip at open-prs=0; got rc=$rcFresh
-$outFresh"
-fi
-
-# (b) STALE tip, no open PR, no liveness ref: demonstrably orphaned → advertised. And
-# the printed command, run VERBATIM (which is what the readers do), must record an
-# INFORMATIVE reason — not the `why` a `--reason <why>` placeholder would have recorded.
-push_branch_with_own_commit "issue-2017-abandoned-lane"
-( cd "$B" && g fetch -q origin )
-outAdv=$(runB_gh claim 2017); rcAdv=$?
-if [ "$rcAdv" -eq 2 ] && printf '%s\n' "$outAdv" | grep -q "adopt 2017 --expect none --reason resume-legacy-branch-lock:issue-2017-abandoned-lane" \
-   && printf '%s\n' "$outAdv" | grep -q 'liveness-refs=none-naming-2017' \
-   && printf '%s\n' "$outAdv" | grep -q 'stale-after='; then
-  ok "a STALE tip + open-prs=0 + no liveness ref advertises the hatch with a CONCRETE self-describing --reason"
-else
-  fail "expected an advertised hatch with a concrete reason; got rc=$rcAdv
-$outAdv"
-fi
-verbatimArgs=$(printf '%s\n' "$outAdv" | sed -n "s/.*remediation='bash scripts\/flow\/claim.sh \([^']*\)'.*/\1/p")
-# Deliberate word splitting: the point is to run the PRINTED argv, unedited.
-# shellcheck disable=SC2086
-outVerbatim=$(runB $verbatimArgs); rcVerbatim=$?
-verbatimReason=$(line_field "$(runB status 2017)" reason)
-if [ "$rcVerbatim" -eq 0 ] && printf '%s\n' "$outVerbatim" | grep -q 'CLAIM: ADOPTED' \
-   && [ "$verbatimReason" != "why" ] && [ "$verbatimReason" != "unspecified" ] \
-   && printf '%s' "$verbatimReason" | grep -q 'resume-legacy-branch-lock' \
-   && printf '%s' "$verbatimReason" | grep -q 'issue-2017-abandoned-lane'; then
-  ok "copy-pasted VERBATIM the printed command adopts and records an informative reason ('$verbatimReason')"
-else
-  fail "the printed command did not adopt with an informative reason; rc=$rcVerbatim reason='$verbatimReason'
-$outVerbatim"
-fi
-
-# (c) STALE tip but a FRESH machine-claim ref naming the issue: a supervisor says a
-# worker is on it (#2655), so the hatch is WITHHELD even though the tip aged out.
-push_branch_with_own_commit "issue-2018-stale-branch-live-worker"
-push_machine_claim "refs/machine-claims/machineFresh" 2018 "$(now_ts)"
-( cd "$B" && g fetch -q origin )
-outLiveRef=$(runB_gh claim 2018); rcLiveRef=$?
-if [ "$rcLiveRef" -eq 2 ] && printf '%s\n' "$outLiveRef" | grep -q 'remediation=withheld' \
-   && printf '%s\n' "$outLiveRef" | grep -q 'liveness-ref=refs/machine-claims/machineFresh' \
-   && ! printf '%s\n' "$outLiveRef" | grep -q 'adopt 2018 --expect none'; then
-  ok "a FRESH machine-claim ref naming the issue WITHHOLDS the hatch even with a stale branch tip"
-else
-  fail "expected the hatch withheld for a fresh liveness ref; got rc=$rcLiveRef
-$outLiveRef"
-fi
-
-# (d) …and a liveness ref older than the threshold does NOT withhold forever: it is
-# itself reapable, so an abandoned heartbeat must not lock the lane out permanently.
-push_branch_with_own_commit "issue-2019-stale-branch-stale-heartbeat"
-push_machine_claim "refs/heartbeats/machineStale" 2019 "$STALE_TIP_DATE"
-( cd "$B" && g fetch -q origin )
-outStaleRef=$(runB_gh claim 2019); rcStaleRef=$?
-if [ "$rcStaleRef" -eq 2 ] && printf '%s\n' "$outStaleRef" | grep -q 'adopt 2019 --expect none --reason resume-legacy-branch-lock:' \
-   && printf '%s\n' "$outStaleRef" | grep -q 'liveness-refs=none-naming-2019'; then
-  ok "a liveness ref STALER than the reap threshold ages out and does not withhold the hatch"
-else
-  fail "expected the hatch advertised despite a stale liveness ref; got rc=$rcStaleRef
-$outStaleRef"
-fi
-
-# (e) UNREADABLE threshold (claim.sh without its claim-heartbeat.sh sibling): the lane
-# cannot be shown orphaned, so the hatch is withheld rather than defaulting to some
-# second copy of "4h".
-push_branch_with_own_commit "issue-2020-threshold-unreadable"
-( cd "$B" && g fetch -q origin )
-LONE="$T/lone-claim"
-mkdir -p "$LONE"
-cp "$CLAIM" "$LONE/claim.sh"
-outNoThresh=$( cd "$B" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
-  bash "$LONE/claim.sh" claim 2020 2>/dev/null ); rcNoThresh=$?
-if [ "$rcNoThresh" -eq 2 ] && printf '%s\n' "$outNoThresh" | grep -q 'remediation=withheld' \
-   && printf '%s\n' "$outNoThresh" | grep -q 'liveness=threshold-unreadable' \
-   && ! printf '%s\n' "$outNoThresh" | grep -q 'adopt 2020 --expect none'; then
-  ok "an UNREADABLE staleness threshold withholds the hatch (no hardcoded fallback)"
-else
-  fail "expected the hatch withheld when the threshold cannot be read; got rc=$rcNoThresh
-$outNoThresh"
-fi
-
-# (f) UNREADABLE liveness refs (a git shim fails ONLY the machine-claims enumeration,
-# everything else passes through): "we could not prove nobody is on it" withholds.
-push_branch_with_own_commit "issue-2021-liveness-enumeration-outage"
-( cd "$B" && g fetch -q origin )
-SHIML="$T/shim-liveness-fail"
-mkdir -p "$SHIML"
-cat >"$SHIML/git" <<SHIM
-#!/usr/bin/env bash
-saw_ls=0; saw_liveness=0
-for a in "\$@"; do
-  [ "\$a" = "ls-remote" ] && saw_ls=1
-  case "\$a" in refs/machine-claims/* | refs/heartbeats/*) saw_liveness=1 ;; esac
-done
-if [ "\$saw_ls" = 1 ] && [ "\$saw_liveness" = 1 ]; then exit 128; fi
-exec "$REALGIT" "\$@"
-SHIM
-chmod +x "$SHIML/git"
-outNoLive=$( cd "$B" && PATH="$SHIML:$GHSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
-  bash "$CLAIM" claim 2021 2>/dev/null ); rcNoLive=$?
-if [ "$rcNoLive" -eq 2 ] && printf '%s\n' "$outNoLive" | grep -q 'remediation=withheld' \
-   && printf '%s\n' "$outNoLive" | grep -q 'liveness-refs=unreadable' \
-   && ! printf '%s\n' "$outNoLive" | grep -q 'adopt 2021 --expect none'; then
-  ok "an UNREADABLE liveness-ref enumeration withholds the hatch (fail closed on an unread signal)"
-else
-  fail "expected the hatch withheld on a liveness enumeration outage; got rc=$rcNoLive
-$outNoLive"
-fi
-
-# (g) …and withholding still changes only ADVICE: the deliberate resume of the
-# actively-worked lane from (a) remains possible for an operator who confirmed ownership.
-outDeliberate=$(runB adopt 2016 --expect none --reason "confirmed with the branch author that the lane is free"); rcDeliberate=$?
-if [ "$rcDeliberate" -eq 0 ] && printf '%s\n' "$outDeliberate" | grep -q 'CLAIM: ADOPTED' \
-   && [ -n "$(ref_sha 2016)" ]; then
-  ok "the liveness gate changes the printed ADVICE only — a deliberate resume still works, git still arbitrates"
-else
-  fail "expected the deliberate resume of a withheld lane to still succeed; got rc=$rcDeliberate
-$outDeliberate"
-fi
-
-# ===========================================================================
-echo "TEST 17: a branch with NO COMMITS OF ITS OWN is INDETERMINATE, never 'stale' — the vacuous tip-age case"
-# ===========================================================================
-# THE PRODUCTION PREMISE THE OTHER FIXTURES MISS (#2945 round 5). Every fixture above
-# uses push_branch_with_own_commit, so its tip has a date of its own. `flow-activate`
-# does NOT: it creates the branch at origin/main and pushes it with no commits, and
-# `flow-implement` pushes again only at PR time. So for a freshly-activated lane the
-# tip's committer date IS main's — zero information about the worker. Whenever main had
-# been quiet longer than the threshold (overnight is routine), that lane presented as
-# open-prs=0 + a stale tip + no liveness refs, and the guard printed the copy-pasteable
-# hand-away FOR AN ACTIVELY-WORKED ISSUE — the two-writer outcome it exists to prevent.
-# So: no own commits => no age signal => remediation WITHHELD, with its own marker.
-advance_main_with_stale_tip
-
-# (a) The vacuous case: commit-less branch, main quiet since 2020, no liveness refs.
-push_branch_without_own_commits "issue-2060-just-activated-no-commits"
-( cd "$B" && g fetch -q origin )
-outVacuous=$(runB_gh claim 2060); rcVacuous=$?
-if [ "$rcVacuous" -eq 2 ] && printf '%s\n' "$outVacuous" | grep -q 'remediation=withheld' \
-   && printf '%s\n' "$outVacuous" | grep -q 'newest-branch-tip=no-own-commits' \
-   && ! printf '%s\n' "$outVacuous" | grep -q 'stale-after=' \
-   && ! printf '%s\n' "$outVacuous" | grep -q 'adopt 2060 --expect none' \
-   && [ "$(printf '%s\n' "$outVacuous" | grep -c 'CLAIM:')" = "1" ]; then
-  ok "a commit-less branch on a LONG-QUIET main withholds the hatch (newest-branch-tip=no-own-commits, no age verdict)"
-else
-  fail "expected the hatch withheld as no-own-commits; got rc=$rcVacuous
-$outVacuous"
-fi
-
-# (b) THE MOTIVATING CASES STILL WORK. #2043 and #1883 each carried their own
-# OpenSpec spec commit, so their tips ARE informative and genuinely old — on the very
-# same long-quiet main, such a branch must still be advertised.
-push_branch_with_own_commit "issue-2061-abandoned-with-its-own-commit"
-( cd "$B" && g fetch -q origin )
-outOwn=$(runB_gh claim 2061); rcOwn=$?
-if [ "$rcOwn" -eq 2 ] && printf '%s\n' "$outOwn" | grep -q 'adopt 2061 --expect none --reason resume-legacy-branch-lock:' \
-   && printf '%s\n' "$outOwn" | grep -q 'newest-branch-tip=' \
-   && printf '%s\n' "$outOwn" | grep -q 'stale-after=' \
-   && ! printf '%s\n' "$outOwn" | grep -q 'no-own-commits'; then
-  ok "a branch carrying its OWN stale commit is still age-judged and still advertises (the #2043/#1883 shape)"
-else
-  fail "expected the hatch advertised for a stale branch with its own commit; got rc=$rcOwn
-$outOwn"
-fi
-
-# (c) …and the new signal opens NO unreadable-signal hole: when the base (origin's
-# default branch) cannot be read, the ancestry test cannot be run, so the tip cannot be
-# judged either way — withhold, never "it must carry own commits".
-push_branch_with_own_commit "issue-2062-base-unreadable"
-( cd "$B" && g fetch -q origin )
-SHIMB="$T/shim-base-fetch-fail"
-mkdir -p "$SHIMB"
-cat >"$SHIMB/git" <<SHIM
-#!/usr/bin/env bash
-saw_fetch=0; saw_base=0
-for a in "\$@"; do
-  [ "\$a" = "fetch" ] && saw_fetch=1
-  case "\$a" in +HEAD:*) saw_base=1 ;; esac
-done
-if [ "\$saw_fetch" = 1 ] && [ "\$saw_base" = 1 ]; then exit 128; fi
-exec "$REALGIT" "\$@"
-SHIM
-chmod +x "$SHIMB/git"
-outNoBase=$( cd "$B" && PATH="$SHIMB:$GHSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
-  bash "$CLAIM" claim 2062 2>/dev/null ); rcNoBase=$?
-if [ "$rcNoBase" -eq 2 ] && printf '%s\n' "$outNoBase" | grep -q 'remediation=withheld' \
-   && printf '%s\n' "$outNoBase" | grep -q 'default-branch-tip=unreadable' \
-   && ! printf '%s\n' "$outNoBase" | grep -q 'adopt 2062 --expect none'; then
-  ok "an UNREADABLE default-branch tip withholds the hatch (the ancestry test is a signal, so it fails closed too)"
-else
-  fail "expected the hatch withheld on an unreadable base; got rc=$rcNoBase
-$outNoBase"
-fi
-
-# (d) The liveness-ref scan is SCOPED TO THIS ISSUE: a readable LEGACY ref in the
-# namespace that names NO issue used to withhold the hatch fleet-wide, for EVERY issue —
-# the permanent dead end this change removes. It must be skipped, not withheld.
-push_raw_liveness_ref "refs/heartbeats/machineLegacyFormat" "heartbeat machine=machineLegacy pid=7 at=whenever"
-push_branch_with_own_commit "issue-2063-legacy-liveness-ref-present"
-( cd "$B" && g fetch -q origin )
-outLegacyRef=$(runB_gh claim 2063); rcLegacyRef=$?
-if [ "$rcLegacyRef" -eq 2 ] && printf '%s\n' "$outLegacyRef" | grep -q 'adopt 2063 --expect none --reason resume-legacy-branch-lock:' \
-   && printf '%s\n' "$outLegacyRef" | grep -q 'liveness-refs=none-naming-2063' \
-   && ! printf '%s\n' "$outLegacyRef" | grep -q 'liveness-refs=unreadable'; then
-  ok "a LEGACY liveness ref naming no issue does not withhold another issue's hatch (the scan is issue-scoped)"
-else
-  fail "expected an issue-scoped liveness scan to still advertise; got rc=$rcLegacyRef
-$outLegacyRef"
+  fail "expected ADOPT-LOST exit 2 with the ref intact; got rc=$rcSecond ref='$(ref_sha 2015)' was='$heldBefore'
+$outSecond"
 fi
 
 echo ""

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -1504,6 +1504,100 @@ else
 $actorEnvStatus"
 fi
 
+# ===========================================================================
+echo "TEST 23: a claim whose push LANDED but whose confirm reads the ref ABSENT is infra (exit 1), never LOST (#2945 review K1)"
+# ===========================================================================
+# The fifth caller of the ONE RULE. The push is ACCEPTED, the confirm `ls-remote`
+# SUCCEEDS, and it reports the ref ABSENT — what a reaper's force-delete landing in that
+# window looks like. NOBODY holds the ref, so `LOST … sha=<gone> holder=unknown` (exit 2)
+# told a worker "you did not win, take the next item" about a lane that is FREE, and
+# contradicted this file's own header rule ("`claim` never reports LOST when nobody holds
+# the ref"). The rejected-push sibling already treated the identical state as infra.
+# The shim answers every `ls-remote refs/claims/*` with an EMPTY SUCCESS (exit 0, no
+# output — exactly a present-then-deleted ref), and lets the push through for real, so
+# the pre-check sees a free lane, the push lands, and the confirm reads it gone.
+SHIMABS="$T/shim-confirm-absent"
+mkdir -p "$SHIMABS"
+cat >"$SHIMABS/git" <<SHIM
+#!/usr/bin/env bash
+saw_ls=0; saw_claims=0
+for a in "\$@"; do
+  [ "\$a" = "ls-remote" ] && saw_ls=1
+  case "\$a" in refs/claims/*) saw_claims=1 ;; esac
+done
+if [ "\$saw_ls" = 1 ] && [ "\$saw_claims" = 1 ]; then exit 0; fi
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMABS/git"
+outAbsConfirm=$( cd "$B" && PATH="$SHIMABS:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" claim 2301 2>&1 ); rcAbsConfirm=$?
+if [ "$rcAbsConfirm" -eq 1 ] && printf '%s\n' "$outAbsConfirm" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outAbsConfirm" | grep -q 'reason=infra' \
+   && printf '%s\n' "$outAbsConfirm" | grep -q 'detail=push-accepted-but-ref-absent-on-confirm' \
+   && [ -n "$(ref_sha 2301)" ] && [ "$(accepted_updates 2301)" = "1" ]; then
+  ok "a LANDED claim push whose confirm reads the ref ABSENT → ERROR infra exit 1 (retryable), the server write still witnessed"
+else
+  fail "expected ERROR infra push-accepted-but-ref-absent-on-confirm exit 1; got rc=$rcAbsConfirm ref='$(ref_sha 2301)' updates=$(accepted_updates 2301)
+$outAbsConfirm"
+fi
+# …and NONE of the abandon-class vocabulary appears — no LOST, and never the tell-tale
+# `sha=<gone> holder=unknown` render that named a holder nobody is.
+if ! printf '%s\n' "$outAbsConfirm" | grep -q 'CLAIM: LOST' \
+   && ! printf '%s\n' "$outAbsConfirm" | grep -q '<gone>' \
+   && ! printf '%s\n' "$outAbsConfirm" | grep -q 'holder=unknown'; then
+  ok "the absent-on-confirm verdict is free of LOST / sha=<gone> / holder=unknown"
+else
+  fail "the absent-on-confirm verdict still renders an abandon-class token:
+$outAbsConfirm"
+fi
+# ANTI-VACUITY: the SAME site must still report a GENUINE LOST when the confirm read
+# succeeds and names a READABLE FOREIGN winner — the infra verdict above is scoped to
+# "nobody holds it", not a blanket softening of the post-push confirm.
+runA claim 2302 >/dev/null 2>&1; rcForeignSetup=$?
+FOREIGN=$(ref_sha 2302)
+g -C "$B" fetch -q origin "refs/claims/issue-2302" 2>/dev/null || true
+if [ "$rcForeignSetup" -eq 0 ] && [ -n "$FOREIGN" ] \
+   && g -C "$B" cat-file -e "${FOREIGN}^{commit}" 2>/dev/null; then
+  ok "setup: machineA's claim commit for issue-2302 is READABLE from clone B (the foreign winner is nameable)"
+else
+  fail "setup failed for the foreign-winner case (rc=$rcForeignSetup foreign='$FOREIGN')"
+fi
+# Same shim shape, but the SECOND claims read (the post-push confirm) advertises the
+# foreign sha; the FIRST (the pre-check) still says free, so the push lands and the
+# verdict comes from the confirm — not from the pre-existing-holder pre-check.
+CTRFOR="$T/confirm-read-count"
+: >"$CTRFOR"
+SHIMFOR="$T/shim-confirm-foreign"
+mkdir -p "$SHIMFOR"
+cat >"$SHIMFOR/git" <<SHIM
+#!/usr/bin/env bash
+saw_ls=0; saw_claims=0
+for a in "\$@"; do
+  [ "\$a" = "ls-remote" ] && saw_ls=1
+  case "\$a" in refs/claims/*) saw_claims=1 ;; esac
+done
+if [ "\$saw_ls" = 1 ] && [ "\$saw_claims" = 1 ]; then
+  n=\$(cat "$CTRFOR" 2>/dev/null || echo 0)
+  n=\$((n + 1)); printf '%s' "\$n" >"$CTRFOR"
+  if [ "\$n" = 1 ]; then exit 0; fi
+  printf '%s\trefs/claims/issue-2303\n' "$FOREIGN"
+  exit 0
+fi
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMFOR/git"
+outForeignConfirm=$( cd "$B" && PATH="$SHIMFOR:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" claim 2303 2>&1 ); rcForeignConfirm=$?
+if [ "$rcForeignConfirm" -eq 2 ] && printf '%s\n' "$outForeignConfirm" | grep -q 'CLAIM: LOST' \
+   && printf '%s\n' "$outForeignConfirm" | grep -q "sha=$FOREIGN" \
+   && printf '%s\n' "$outForeignConfirm" | grep -q 'holder-machine=machineA' \
+   && ! printf '%s\n' "$outForeignConfirm" | grep -q 'holder=unknown'; then
+  ok "a post-push confirm naming a READABLE FOREIGN sha still reports the genuine LOST (exit 2) with that holder named"
+else
+  fail "expected a genuine LOST exit 2 naming holder-machine=machineA at sha=$FOREIGN; got rc=$rcForeignConfirm
+$outForeignConfirm"
+fi
+
 echo ""
 echo "================  claim-resume (#2945): $PASS passed, $FAIL failed, $SKIP skipped  ================"
 [ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -140,6 +140,57 @@ push_work_branch() {
   )
 }
 
+# --- ONE SHARED start signal for the concurrency rounds --------------------
+# The racers must be released TOGETHER. The earlier shape used TWO independent
+# FIFOs whose writers were launched sequentially, so each racer was released the
+# moment ITS OWN writer connected: machine A could finish its whole adopt before
+# B even started, and every assertion in the round still held under full
+# serialization — a "race" test that could not detect that it never raced.
+# Now both children announce readiness and then spin on ONE shared flag file the
+# parent creates only after BOTH are ready.
+race_reset() { rm -f "$T/go" "$T/ready-a" "$T/ready-b"; }
+# race_wait_go <ready-file> — announce readiness, then spin on the shared flag.
+race_wait_go() { : >"$1"; while [ ! -e "$T/go" ]; do :; done; }
+# race_release — bounded wait for BOTH readiness marks, then flip the one flag.
+race_release() {
+  local spins=0
+  while [ ! -e "$T/ready-a" ] || [ ! -e "$T/ready-b" ]; do
+    spins=$((spins + 1))
+    if [ "$spins" -gt 1000 ]; then echo "  ! barrier: a racer never signalled ready" >&2; break; fi
+    sleep 0.01
+  done
+  : >"$T/go"
+}
+
+# now_ns — a hi-res clock, so the race rounds carry POSITIVE EVIDENCE that they
+# raced (overlapping windows) instead of only asserting invariants that also hold
+# under serialization. GNU date has %N; BSD/macOS date does not (it emits a
+# literal 'N'), hence the perl/python3 fallbacks. No hi-res clock at all is a
+# LOUD failure below, never a silently skipped witness.
+NS_IMPL=none
+nsprobe=$(date -u +%s%N 2>/dev/null || true)
+if [ -n "$nsprobe" ] && [ -z "${nsprobe//[0-9]/}" ] && [ "${#nsprobe}" -ge 16 ]; then
+  NS_IMPL=date
+elif command -v perl >/dev/null 2>&1 && perl -MTime::HiRes -e 'exit 0' 2>/dev/null; then
+  NS_IMPL=perl
+elif command -v python3 >/dev/null 2>&1; then
+  NS_IMPL=python3
+fi
+now_ns() {
+  case "$NS_IMPL" in
+    date)    date -u +%s%N ;;
+    perl)    perl -MTime::HiRes -e 'printf "%.0f\n", Time::HiRes::time() * 1000000000' ;;
+    python3) python3 -c 'import time; print(time.time_ns())' ;;
+    *)       printf '0\n' ;;
+  esac
+}
+# read_ns <file> — the recorded timestamp, or 0 when unusable.
+read_ns() {
+  local v
+  v=$(cat "$1" 2>/dev/null || true)
+  if [ -n "$v" ] && [ -z "${v//[0-9]/}" ]; then printf '%s\n' "$v"; else printf '0\n'; fi
+}
+
 # ===========================================================================
 echo "TEST 1: FREE claim ref + foreign-tip issue-<N>-* branch — claim refuses WITH the remediation, adopt --expect none SUCCEEDS"
 # ===========================================================================
@@ -148,7 +199,9 @@ push_work_branch "issue-2001-owner-approved-spec" "docs(#2001): OpenSpec change 
 [ -z "$(ref_sha 2001)" ] && ok "precondition: refs/claims/issue-2001 is FREE" \
   || fail "precondition broken: a claim ref already exists for 2001"
 
-outClaim=$(runB claim 2001); rcClaim=$?
+# runB_gh: the gh stub reports NO open PR, i.e. a demonstrably orphaned endgame —
+# the only state in which the escape hatch may be advertised (see TEST 15).
+outClaim=$(runB_gh claim 2001); rcClaim=$?
 if [ "$rcClaim" -eq 2 ] && printf '%s\n' "$outClaim" | grep -q 'reason=legacy-branch-lock'; then
   ok "claim still refuses (exit 2) while the branch stands"
 else
@@ -159,8 +212,9 @@ fi
 # LOST is what sent two workers into hand-crafted claim-commit pushes.
 if printf '%s\n' "$outClaim" | grep -q 'adopt 2001 --expect none --reason' \
    && printf '%s\n' "$outClaim" | grep -q 'issue-2001-owner-approved-spec' \
-   && printf '%s\n' "$outClaim" | grep -q 'claim-ref=free'; then
-  ok "refusal names the exact remediation command, the blocking branch, and claim-ref=free"
+   && printf '%s\n' "$outClaim" | grep -q 'claim-ref=free' \
+   && printf '%s\n' "$outClaim" | grep -q 'open-prs=0'; then
+  ok "refusal names the exact remediation command, the blocking branch, claim-ref=free, and open-prs=0"
 else
   fail "refusal is not actionable (missing remediation/branch/claim-ref=free):
 $outClaim"
@@ -230,7 +284,7 @@ else
   fail "expected RELEASED exit 0 with the ref gone; got rc=$rcRelease ref='$(ref_sha 2001)'
 $outRelease"
 fi
-outAfter=$(runA claim 2001); rcAfter=$?
+outAfter=$(runA_gh claim 2001); rcAfter=$?
 if [ "$rcAfter" -eq 2 ] && printf '%s\n' "$outAfter" | grep -q 'reason=legacy-branch-lock'; then
   ok "after the release the surviving work branch still guards a plain claim (exit 2)"
 else
@@ -276,34 +330,57 @@ runA verify 2002 >/dev/null 2>&1; rcHolderStill=$?
 # ===========================================================================
 echo "TEST 3: two machines RACE the resume path — exactly one SERVER-ACCEPTED create (git arbitrates), 5 rounds"
 # ===========================================================================
-# Real competing pushes: both machines are released from a FIFO barrier and run the
-# empty-lease adopt concurrently against the same origin. Nothing is mocked — the
-# remote's ref update is the arbiter, and the post-receive log is the witness.
+# Real competing pushes: both machines are released by ONE SHARED start signal and
+# run the empty-lease adopt concurrently against the same origin. Nothing is mocked
+# — the remote's ref update is the arbiter, and the post-receive log is the witness.
 # Repeated over distinct issue ids because a single interleaving proves little.
+#
+# AND THE ROUND PROVES IT RACED: each racer records a hi-res timestamp immediately
+# before and after its adopt (the push is the bulk of that call), and the round FAILS
+# unless the two windows OVERLAP. Every other assertion here also holds under full
+# serialization, so without this witness a barrier regression is invisible — which is
+# exactly how a non-racing barrier survived two reviews.
 raceRounds=0; raceOk=0; raceAtomic=0; raceLoser=0; raceWinnerVerified=0; raceDiag=""
+raceOverlapped=0; ovMin=""; ovMax=""
 for id in 2101 2102 2103 2104 2105; do
   raceRounds=$((raceRounds+1))
   push_work_branch "issue-${id}-resumable"
   ( cd "$B" && g fetch -q origin )
-  rm -f "$T/gate-a" "$T/gate-b"
-  mkfifo "$T/gate-a" "$T/gate-b"
-  ( head -1 <"$T/gate-a" >/dev/null 2>&1
+  race_reset
+  ( race_wait_go "$T/ready-a"
+    now_ns >"$T/race-a.t0"
     runA adopt "$id" --expect none --reason "racing machineA" >"$T/race-a.out" 2>&1
-    echo "$?" >"$T/race-a.rc" ) &
+    echo "$?" >"$T/race-a.rc"
+    now_ns >"$T/race-a.t1" ) &
   pidA=$!
-  ( head -1 <"$T/gate-b" >/dev/null 2>&1
+  ( race_wait_go "$T/ready-b"
+    now_ns >"$T/race-b.t0"
     runB adopt "$id" --expect none --reason "racing machineB" >"$T/race-b.out" 2>&1
-    echo "$?" >"$T/race-b.rc" ) &
+    echo "$?" >"$T/race-b.rc"
+    now_ns >"$T/race-b.t1" ) &
   pidB=$!
-  ( echo go >"$T/gate-a" ) &
-  writerA=$!
-  ( echo go >"$T/gate-b" ) &
-  writerB=$!
+  race_release
   wait "$pidA" "$pidB" 2>/dev/null
-  # Never `wait` on the fifo writers: a writer blocks until its reader opens, so a
-  # child that died before opening would hang the suite. The racers are done here,
-  # so any still-blocked writer is simply killed.
-  kill "$writerA" "$writerB" 2>/dev/null || true
+  # Concurrency witness: [t0,t1] per racer must intersect. Reported in the verdict
+  # so the log carries the measured overlap, not just a boolean.
+  t0a=$(read_ns "$T/race-a.t0"); t1a=$(read_ns "$T/race-a.t1")
+  t0b=$(read_ns "$T/race-b.t0"); t1b=$(read_ns "$T/race-b.t1")
+  if [ "$t0a" -gt 0 ] && [ "$t1a" -gt 0 ] && [ "$t0b" -gt 0 ] && [ "$t1b" -gt 0 ]; then
+    ovStart="$t0a"; [ "$t0b" -gt "$ovStart" ] && ovStart="$t0b"
+    ovEnd="$t1a";   [ "$t1b" -lt "$ovEnd" ]   && ovEnd="$t1b"
+    ovNs=$((ovEnd - ovStart))
+    if [ "$ovNs" -gt 0 ]; then
+      raceOverlapped=$((raceOverlapped+1))
+      [ -n "$ovMin" ] && [ "$ovMin" -le "$ovNs" ] || ovMin="$ovNs"
+      [ -n "$ovMax" ] && [ "$ovMax" -ge "$ovNs" ] || ovMax="$ovNs"
+    else
+      raceDiag="$raceDiag
+  round $id: the two adopt windows did NOT overlap (gap $((0 - ovNs))ns) — the racers ran SERIALLY, so this round proves nothing"
+    fi
+  else
+    raceDiag="$raceDiag
+  round $id: no usable hi-res timestamps (NS_IMPL=$NS_IMPL) — cannot witness concurrency"
+  fi
   rcRaceA="$(cat "$T/race-a.rc" 2>/dev/null || echo missing)"
   rcRaceB="$(cat "$T/race-b.rc" 2>/dev/null || echo missing)"
   winners=0
@@ -368,6 +445,16 @@ done
 [ "$raceWinnerVerified" -eq "$raceRounds" ] \
   && ok "the winner verifies as the holder of the single surviving ref, every round" \
   || fail "the race winner did not verify as holder in $((raceRounds - raceWinnerVerified))/$raceRounds rounds$raceDiag"
+# The barrier itself, measured. A suite with no hi-res clock cannot make this claim,
+# so it fails loudly rather than reporting a vacuous race.
+[ "$NS_IMPL" != none ] \
+  && ok "hi-res clock available to witness concurrency (NS_IMPL=$NS_IMPL)" \
+  || fail "no hi-res clock (date %N / perl Time::HiRes / python3) — the race rounds cannot be witnessed"
+if [ "$raceOverlapped" -eq "$raceRounds" ]; then
+  ok "the two racers' adopt windows OVERLAP every round ($raceOverlapped/$raceRounds; overlap min=$((${ovMin:-0} / 1000000))ms max=$((${ovMax:-0} / 1000000))ms, min=${ovMin:-0}ns) — they really ran concurrently"
+else
+  fail "only $raceOverlapped/$raceRounds rounds had overlapping adopt windows — the barrier serialized the racers$raceDiag"
+fi
 
 # ===========================================================================
 echo "TEST 4: --expect fail-closed — empty '' is a usage error; only the literal 'none' opts into the empty lease"
@@ -386,6 +473,21 @@ outJunk=$(runB adopt 2004 --expect "HEAD~1" 2>&1); rcJunk=$?
 [ "$rcJunk" -eq 64 ] && ok "a non-hex, non-'none' --expect is a usage error (exit 64)" \
   || fail "expected exit 64 for --expect HEAD~1; got rc=$rcJunk
 $outJunk"
+# A hex --expect that is not a FULL object name is a CALLER BUG, and both of its
+# shapes used to misreport: a short all-zero value ('0', '00') slipped into the
+# all-zero branch and became a silent CREATE instead of a compare-and-swap, and a
+# TRUNCATED sha built a lease git cannot resolve, so the push failed and the confirm
+# read said ADOPT-LOST — a race-loss verdict for a usage error.
+lenRc=""
+for badExpect in 0 00 abc123 0000000000000000000000000000000000000; do
+  runB adopt 2004 --expect "$badExpect" --reason "truncated sha from a caller bug" >/dev/null 2>&1
+  lenRc="$lenRc $?"
+done
+if [ "$lenRc" = " 64 64 64 64" ] && [ -z "$(ref_sha 2004)" ] && [ "$(accepted_updates 2004)" = "0" ]; then
+  ok "a short/truncated hex --expect (0, 00, abc123, 39 zeros) is a usage error (exit 64) — never a create, never ADOPT-LOST"
+else
+  fail "expected 64 from every short --expect with nothing created; got rcs='$lenRc' ref='$(ref_sha 2004)' updates=$(accepted_updates 2004)"
+fi
 # A non-numeric issue is a usage error on every subcommand (no ref namespace games).
 argRc=""
 for sub in "claim 20x4" "verify 20x4" "release 20x4" "adopt 20x4 --expect none --reason why"; do
@@ -486,10 +588,10 @@ echo "TEST 7: no tip-based re-entrancy survives — even a claim-shaped branch t
 push_work_branch "issue-2007-tip-looks-like-a-claim" \
   "claim issue=2007 machine=machineB pid=1 actor=flow ts=2026-07-26T00:00:00Z nonce=x"
 ( cd "$B" && g fetch -q origin )
-outTip=$(runB claim 2007); rcTip=$?
+outTip=$(runB_gh claim 2007); rcTip=$?
 tipRef=$(ref_sha 2007)
 if [ "$rcTip" -eq 2 ] && printf '%s\n' "$outTip" | grep -q 'reason=legacy-branch-lock' && [ -z "$tipRef" ]; then
-  ok "a claim-shaped branch tip does not grant a claim — the guard blocks and points at the resume command"
+  ok "a claim-shaped branch tip does not grant a claim — the guard blocks (no ref granted)"
 else
   fail "expected legacy-branch-lock refusal exit 2 with no ref; got rc=$rcTip ref='$tipRef'
 $outTip"
@@ -582,6 +684,32 @@ outOtherMachine=$(runA adopt 2010 --expect none --reason "another machine must n
 [ "$rcOtherMachine" -eq 2 ] && ok "another MACHINE still gets ADOPT-LOST (exit 2) — re-entrancy is not a bypass" \
   || fail "expected ADOPT-LOST exit 2 for another machine; got rc=$rcOtherMachine
 $outOtherMachine"
+# The SAME shortcut in CAS mode covers a VIOLATED compare-and-swap: the ref sits at
+# Y != our --expect X, and Y happens to be ours. Exit 2 would abandon a claim we
+# demonstrably hold, but a plain `ADOPTED … from=X` would print a value the ref never
+# had and make a FAILED CAS indistinguishable from a satisfied one — so the CAS path
+# has its own verdict naming BOTH shas.
+STALE=2222222222222222222222222222222222222222
+heldSha10=$(ref_sha 2010)
+outCasReent=$(runB adopt 2010 --expect "$STALE" --reason "cas retry carrying a stale expected sha"); rcCasReent=$?
+if [ "$rcCasReent" -eq 0 ] && printf '%s\n' "$outCasReent" | grep -q 'CLAIM: ADOPTED' \
+   && printf '%s\n' "$outCasReent" | grep -q 'lease-mismatch' \
+   && printf '%s\n' "$outCasReent" | grep -q "expected=$STALE" \
+   && printf '%s\n' "$outCasReent" | grep -q "actual=$heldSha10" \
+   && ! printf '%s\n' "$outCasReent" | grep -q "from=$STALE" \
+   && [ "$(ref_sha 2010)" = "$heldSha10" ] && [ "$(accepted_updates 2010)" = "1" ]; then
+  ok "a VIOLATED CAS on a ref we already hold reports ADOPTED (re-entrant, lease-mismatch) naming BOTH shas, never a bare from=<expected>"
+else
+  fail "expected a lease-mismatch re-entrant ADOPTED naming expected=$STALE and actual=$heldSha10; got rc=$rcCasReent ref='$(ref_sha 2010)' updates=$(accepted_updates 2010)
+$outCasReent"
+fi
+if printf '%s\n' "$outRetry" | grep -q 'from=none' && ! printf '%s\n' "$outRetry" | grep -q 'lease-mismatch'; then
+  ok "the EMPTY-lease re-entrant verdict stays distinct (from=none, no lease-mismatch marker)"
+else
+  fail "the empty-lease re-entrant verdict is no longer distinguishable from the CAS one:
+$outRetry"
+fi
+# (A legitimate CAS from the CURRENT sha — the reaper-adopt contract — is TEST 13.)
 
 # ===========================================================================
 echo "TEST 11: a NON-ASCII --reason works (BSD/macOS tr aborts on it without a byte locale)"
@@ -669,12 +797,26 @@ else
 $outCas
 $casStatus"
 fi
-runB adopt 2023 --expect none --reason '   ' >/dev/null 2>&1; rcBlank=$?
-blankReason=$(line_field "$(runB status 2023)" reason)
-if [ "$rcBlank" -eq 0 ] && [ "$blankReason" = "unspecified" ]; then
-  ok "a reason with nothing representable records reason=unspecified (never an empty field)"
+# A reason with NOTHING RECORDABLE in it is a usage error, not a recorded
+# `reason=unspecified`. The gate used to validate the RAW argument and record the
+# SANITIZED one, so '   ', '---', '…' or an expansion like "$UNSET_VAR " passed and
+# landed as `reason=unspecified` — indistinguishable from supplying no reason, which
+# defeats the "record WHY" requirement. Same fail-closed direction as --expect ''.
+whyRc=""
+for badWhy in '   ' '---' '…' 'x' '  ' '=='; do
+  runB adopt 2023 --expect none --reason "$badWhy" >/dev/null 2>&1
+  whyRc="$whyRc $?"
+done
+if [ "$whyRc" = " 64 64 64 64 64 64" ] && [ -z "$(ref_sha 2023)" ]; then
+  ok "a --reason with nothing recordable ('   ', '---', '…', 'x', '==') is a usage error (exit 64), nothing acquired"
 else
-  fail "expected reason=unspecified; got rc=$rcBlank reason='$blankReason'"
+  fail "expected 64 from every unrecordable --reason with no ref created; got rcs='$whyRc' ref='$(ref_sha 2023)'"
+fi
+runB adopt 2023 --expect none --reason 'wip' >/dev/null 2>&1; rcMinWhy=$?
+if [ "$rcMinWhy" -eq 0 ] && [ "$(line_field "$(runB status 2023)" reason)" = "wip" ]; then
+  ok "a short but RECORDABLE reason ('wip') is accepted and recorded verbatim"
+else
+  fail "expected a recordable 3-char reason to adopt and record; got rc=$rcMinWhy reason='$(line_field "$(runB status 2023)" reason)'"
 fi
 longReason=$(printf 'a%.0s' $(seq 1 200))
 runB adopt 2033 --expect none --reason "$longReason" >/dev/null 2>&1; rcLong=$?
@@ -707,18 +849,17 @@ for id in 2201 2202 2203; do
   reapRounds=$((reapRounds+1))
   runA claim "$id" >/dev/null 2>&1
   staleSha=$(ref_sha "$id")
-  rm -f "$T/gate-r" "$T/gate-s"
-  mkfifo "$T/gate-r" "$T/gate-s"
-  ( head -1 <"$T/gate-r" >/dev/null 2>&1
+  # Same ONE-shared-signal barrier as TEST 3 (two independent FIFOs released each
+  # side as its own writer connected, which permits full serialization).
+  race_reset
+  ( race_wait_go "$T/ready-a"
     runA_gh release "$id" --force >"$T/reap.out" 2>&1; echo "$?" >"$T/reap.rc" ) &
   pidR=$!
-  ( head -1 <"$T/gate-s" >/dev/null 2>&1
+  ( race_wait_go "$T/ready-b"
     runB adopt "$id" --expect none --reason "resumer racing the reaper" >"$T/resume.out" 2>&1; echo "$?" >"$T/resume.rc" ) &
   pidS=$!
-  ( echo go >"$T/gate-r" ) & wr=$!
-  ( echo go >"$T/gate-s" ) & ws=$!
+  race_release
   wait "$pidR" "$pidS" 2>/dev/null
-  kill "$wr" "$ws" 2>/dev/null || true
   rcResume="$(cat "$T/resume.rc" 2>/dev/null || echo missing)"
   resumeOut="$(cat "$T/resume.out" 2>/dev/null)"
   resumeSha=$(line_field "$resumeOut" sha)
@@ -745,6 +886,67 @@ done
 [ "$reapOk" -eq "$reapRounds" ] \
   && ok "forced-release vs empty-lease-adopt: every round ends at no-ref or the resumer's own ref ($reapOk/$reapRounds)" \
   || fail "reaper/resumer barrier race produced a bogus owner in $((reapRounds - reapOk))/$reapRounds rounds$reapDiag"
+
+# ===========================================================================
+echo "TEST 15: the escape hatch is advertised ONLY when the endgame is demonstrably orphaned (open PR / unknown → withheld)"
+# ===========================================================================
+# The refusal's safety argument ("git rejects it if any machine holds the ref") does
+# NOT cover the case the guard exists for: an OLDER-fleet worker locks with the
+# BRANCH and holds no claim ref, so `claim-ref=free` is true for it and the advertised
+# empty-lease adopt WOULD succeed — handing an actively-worked issue to a second
+# machine. The readers are agents that run printed remediations literally, so the
+# command is printed only at open-prs=0, and an unreadable PR list withholds too.
+push_work_branch "issue-2015-live-endgame"
+( cd "$B" && g fetch -q origin )
+PRSHIM="$T/shim-gh-open-pr"
+mkdir -p "$PRSHIM"
+cat >"$PRSHIM/gh" <<'GH'
+#!/usr/bin/env bash
+# Fake gh: one OPEN PR whose head branch is this issue's.
+for a in "$@"; do [ "$a" = "list" ] && { echo "issue-2015-live-endgame"; exit 0; }; done
+exit 1
+GH
+chmod +x "$PRSHIM/gh"
+outLive=$( cd "$B" && PATH="$PRSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" claim 2015 ); rcLive=$?
+if [ "$rcLive" -eq 2 ] && printf '%s\n' "$outLive" | grep -q 'reason=legacy-branch-lock' \
+   && printf '%s\n' "$outLive" | grep -q 'remediation=withheld' \
+   && printf '%s\n' "$outLive" | grep -q 'open-prs=1' \
+   && ! printf '%s\n' "$outLive" | grep -q 'adopt 2015 --expect none' \
+   && [ "$(printf '%s\n' "$outLive" | grep -c 'CLAIM:')" = "1" ]; then
+  ok "with an OPEN PR the refusal withholds the hatch (remediation=withheld open-prs=1, no copy-pasteable adopt) on one line"
+else
+  fail "expected a withheld remediation with open-prs=1; got rc=$rcLive
+$outLive"
+fi
+# gh missing/failing = UNKNOWN, and unknown must fail closed exactly like release's
+# open-PR guard — never advertise a hand-away on an unread signal.
+GHFAIL="$T/shim-gh-broken"
+mkdir -p "$GHFAIL"
+cat >"$GHFAIL/gh" <<'GH'
+#!/usr/bin/env bash
+echo "gh: simulated failure" >&2
+exit 1
+GH
+chmod +x "$GHFAIL/gh"
+outUnknown=$( cd "$B" && PATH="$GHFAIL:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" claim 2015 2>/dev/null ); rcUnknown=$?
+if [ "$rcUnknown" -eq 2 ] && printf '%s\n' "$outUnknown" | grep -q 'remediation=withheld' \
+   && printf '%s\n' "$outUnknown" | grep -q 'open-prs=-1' \
+   && ! printf '%s\n' "$outUnknown" | grep -q 'adopt 2015 --expect none'; then
+  ok "an UNREADABLE PR list also withholds the hatch (open-prs=-1) — fail closed on an unread signal"
+else
+  fail "expected a withheld remediation with open-prs=-1; got rc=$rcUnknown
+$outUnknown"
+fi
+# Withholding is ADVICE, not a lock: an operator who has confirmed ownership can
+# still resume, and git remains the sole arbiter (the claim ref really is free).
+outStillWorks=$(runB adopt 2015 --expect none --reason "ownership confirmed with the PR author"); rcStillWorks=$?
+if [ "$rcStillWorks" -eq 0 ] && printf '%s\n' "$outStillWorks" | grep -q 'CLAIM: ADOPTED' \
+   && [ -n "$(ref_sha 2015)" ]; then
+  ok "the hatch itself still works when invoked deliberately — the guard changes ADVICE, not the arbiter"
+else
+  fail "expected the deliberate resume to still succeed; got rc=$rcStillWorks
+$outStillWorks"
+fi
 
 echo ""
 echo "================  claim-resume (#2945): $PASS passed, $FAIL failed  ================"

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -14,8 +14,15 @@
 # still refuses), its RE-ENTRANCY (a retry after a confirm blip must not abandon an
 # issue we hold), a REAL two-machine race on that path, the guard's fail-CLOSED
 # behaviour on an enumeration outage (#2677 item 2), and the IDENTITY-FORGERY
-# hardening of the two user-controlled fields (--reason, --actor) that land in the
-# very commit message the holder-identity parser reads.
+# hardening of the three user-controlled fields (--reason, --actor, CLAIM_MACHINE) that
+# land in the very commit message the holder-identity parser reads.
+#
+# ONE RULE RUNS THROUGH TESTS 9/10/17/21: an UNREAD or NON-RACE signal is retryable infra,
+# NEVER a LOST / ADOPT-LOST / VERIFY-FAIL / not-holder verdict. Four review rounds each
+# found the same shape in a different caller (adopt re-entrancy, an unreadable holder in
+# claim/adopt, then in verify/release, and a CAS rejected while the ref still sat at
+# --expect), so every caller of holder_identity and every push-failure branch is pinned
+# here — including the ANTI-VACUITY twin that proves the genuine exit-2 verdict survives.
 #
 # THE COMMAND IS SANCTIONED BUT NOT ADVERTISED (owner decision, #2945). The refusal
 # DIAGNOSES the lane — the blocking branch plus `claim-ref=free` — and points at the
@@ -871,6 +878,34 @@ if [ "$whyRc" = " 64 64 64 64 64 64" ] && [ -z "$(ref_sha 2023)" ]; then
 else
   fail "expected 64 from every unrecordable --reason with no ref created; got rcs='$whyRc' ref='$(ref_sha 2023)'"
 fi
+# THE SAME GATE ON THE CAS PATH, INCLUDING A SUPPLIED-BUT-EMPTY --reason (#2945 review J4).
+# The validation was guarded on the RAW text being non-empty, so `--reason ""` — the classic
+# `--reason "$WHY"` with WHY unset — was silently IGNORED there and the adoption recorded no
+# `reason=` at all, while '   ' / '---' / 'x' were exit 64: the last asymmetry in an otherwise
+# fail-closed argument surface, and the shape most likely to happen by accident. (TEST 5 pins
+# '' only in --expect none mode, where the separate required-reason gate catches it.)
+runB claim 2063 >/dev/null 2>&1
+casGuard=$(ref_sha 2063)
+casWhyRc=""
+for badWhy in '' '   ' '---' '…' 'x' '==' '<why>' 'tbd'; do
+  runA adopt 2063 --expect "$casGuard" --reason "$badWhy" >/dev/null 2>&1
+  casWhyRc="$casWhyRc $?"
+done
+if [ -n "$casGuard" ] && [ "$casWhyRc" = " 64 64 64 64 64 64 64 64" ] \
+   && [ "$(ref_sha 2063)" = "$casGuard" ] && [ "$(accepted_updates 2063)" = "1" ]; then
+  ok "on the CAS path an EMPTY '' or unrecordable/template/placeholder --reason is a usage error (exit 64) — the held ref is never touched"
+else
+  fail "expected 64 from every bad --reason on the CAS path with the ref untouched; got rcs='$casWhyRc' ref='$(ref_sha 2063)' was='$casGuard' updates=$(accepted_updates 2063)"
+fi
+outCasWhyOk=$(runA adopt 2063 --expect "$casGuard" --reason "adopting after should-reap cleared the lane"); rcCasWhyOk=$?
+if [ "$rcCasWhyOk" -eq 0 ] && printf '%s\n' "$outCasWhyOk" | grep -q 'CLAIM: ADOPTED' \
+   && [ "$(ref_sha 2063)" != "$casGuard" ] \
+   && printf '%s' "$(line_field "$(runA status 2063)" reason)" | grep -q 'should-reap'; then
+  ok "a RECORDABLE --reason still adopts on the CAS path and records (the gate is fail-closed, not a blanket refusal)"
+else
+  fail "expected a recordable CAS --reason to adopt and record; got rc=$rcCasWhyOk reason='$(line_field "$(runA status 2063)" reason)'
+$outCasWhyOk"
+fi
 # A PLACEHOLDER reason is refused too (#2945 review). `--reason <why>` copy-pasted from
 # a help line sanitizes to `why`: 3 recordable chars, so the length gate passes and the
 # record reads `reason=why` — as uninformative as the no-reason case this gate exists to
@@ -1120,6 +1155,37 @@ else
   fail "expected adopt ERROR infra holder-commit-unreadable exit 1 with no ADOPT-LOST; got rc=$rcUnreadAdopt ref='$(ref_sha 2017)' updates=$(accepted_updates 2017)
 $outUnreadAdopt"
 fi
+# …and `verify` + non-forced `release` obey the SAME rule (#2945 review J1). Both used to
+# route through a BOOLEAN holder check that collapsed "unreadable" into "someone else", so
+# the very failure mode this change exists to fix still produced `VERIFY-FAIL …
+# holder-machine= actor=` (exit 2 — "you don't hold it") and `RELEASE-REFUSED
+# reason=not-holder`, against the TRUE holder, whose only remedy would be `--force` on its
+# own claim. The boolean wrapper is gone so no caller can re-collapse the states.
+outUnreadVerify=$( cd "$A" && PATH="$SHIMFETCH:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin \
+  bash "$CLAIM" verify 2017 2>&1 ); rcUnreadVerify=$?
+if [ "$rcUnreadVerify" -eq 1 ] && printf '%s\n' "$outUnreadVerify" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outUnreadVerify" | grep -q 'reason=infra' \
+   && printf '%s\n' "$outUnreadVerify" | grep -q 'detail=holder-commit-unreadable' \
+   && ! printf '%s\n' "$outUnreadVerify" | grep -q 'VERIFY-FAIL' \
+   && ! printf '%s\n' "$outUnreadVerify" | grep -qE 'machine= |machine=$|actor= |actor=$'; then
+  ok "verify with an unreadable holder commit → ERROR infra exit 1 (never VERIFY-FAIL, no empty holder field)"
+else
+  fail "expected verify ERROR infra holder-commit-unreadable exit 1 with no VERIFY-FAIL; got rc=$rcUnreadVerify
+$outUnreadVerify"
+fi
+outUnreadRelease=$( cd "$A" && PATH="$SHIMFETCH:$GHSHIM:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin \
+  bash "$CLAIM" release 2017 2>&1 ); rcUnreadRelease=$?
+if [ "$rcUnreadRelease" -eq 1 ] && printf '%s\n' "$outUnreadRelease" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outUnreadRelease" | grep -q 'reason=infra' \
+   && printf '%s\n' "$outUnreadRelease" | grep -q 'detail=holder-commit-unreadable' \
+   && ! printf '%s\n' "$outUnreadRelease" | grep -q 'RELEASE-REFUSED' \
+   && ! printf '%s\n' "$outUnreadRelease" | grep -q 'RELEASED' \
+   && [ "$(ref_sha 2017)" = "$heldSha17" ]; then
+  ok "non-forced release with an unreadable holder commit → ERROR infra exit 1 (never not-holder, never a delete), ref intact"
+else
+  fail "expected release ERROR infra holder-commit-unreadable exit 1 with the ref intact; got rc=$rcUnreadRelease ref='$(ref_sha 2017)'
+$outUnreadRelease"
+fi
 # ANTI-VACUITY: with the fetch WORKING, the very same commands still give the genuine
 # race verdicts — so the infra verdict above comes from the unread signal, nothing else.
 outReadClaim=$(runA claim 2017); rcReadClaim=$?
@@ -1131,6 +1197,17 @@ else
   fail "expected LOST + ADOPT-LOST exit 2 once the holder commit is readable; got rcClaim=$rcReadClaim rcAdopt=$rcReadAdopt
 $outReadClaim
 $outReadAdopt"
+fi
+outReadVerify=$(runA verify 2017 2>&1); rcReadVerify=$?
+outReadRelease=$(runA_gh release 2017 2>&1); rcReadRelease=$?
+if [ "$rcReadVerify" -eq 2 ] && printf '%s\n' "$outReadVerify" | grep -q 'VERIFY-FAIL' \
+   && [ "$rcReadRelease" -eq 2 ] && printf '%s\n' "$outReadRelease" | grep -q 'reason=not-holder' \
+   && [ "$(ref_sha 2017)" = "$heldSha17" ]; then
+  ok "with a healthy fetch verify/release still report the genuine VERIFY-FAIL / not-holder (exit 2) — the infra verdict is scoped to the unread signal"
+else
+  fail "expected VERIFY-FAIL + not-holder exit 2 once the holder commit is readable; got rcVerify=$rcReadVerify rcRelease=$rcReadRelease
+$outReadVerify
+$outReadRelease"
 fi
 
 # ===========================================================================
@@ -1169,10 +1246,19 @@ $outConcrete"
 fi
 # …and no doc/skill may hand the reader a template again: every line that shows a
 # runnable `claim.sh adopt … --reason` must carry a SUBSTITUTED value.
+#
+# SCOPED REPO-WIDE, AND "NOTHING TO CHECK" IS NOT A FAILURE (#2945 review J5). The lint used
+# to hard-code three paths and FAIL when the grep came up empty, so a doc reorganisation or a
+# rewording that drops the literal string turned the GATE OF RECORD red for a non-defect — and
+# it silently stopped covering any new skill/doc directory. Now every tracked *.md is scanned
+# (so no single path is load-bearing and new docs are covered automatically) and only a line
+# that actually carries an unsubstituted `<…>` in its --reason value fails; an empty scan is a
+# loud SKIP. (It caught a real one on this very branch: agent-machine-setup.md shipped
+# `--reason resume-legacy-branch-lock:<branch>`, a command claim.sh now rejects with exit 64.)
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-docHits="$(grep -rn -- 'claim\.sh adopt .*--reason' \
-  "$REPO_ROOT/CLAUDE.md" "$REPO_ROOT/.claude/skills" \
-  "$REPO_ROOT/website/src/content/docs/agents-developing/delivery-pipeline.md" 2>/dev/null || true)"
+docHits="$(cd "$REPO_ROOT" && grep -rn --include='*.md' \
+  --exclude-dir=target --exclude-dir=node_modules --exclude-dir=.git \
+  -- 'claim\.sh adopt .*--reason' . 2>/dev/null || true)"
 badDocs=""
 while IFS= read -r docLine; do
   [ -n "$docLine" ] || continue
@@ -1180,10 +1266,13 @@ while IFS= read -r docLine; do
   case "$docVal" in *'<'*) badDocs="$badDocs
   $docLine" ;; esac
 done <<< "$docHits"
-if [ -n "$docHits" ] && [ -z "$badDocs" ]; then
-  ok "every documented runnable 'claim.sh adopt … --reason' carries a substituted value ($(printf '%s\n' "$docHits" | grep -c . ) line(s) checked)"
+docHitCount="$(printf '%s\n' "$docHits" | grep -c . )"
+if [ -n "$badDocs" ]; then
+  fail "a documented --reason still ships an unsubstituted template (claim.sh rejects it with exit 64):$badDocs"
+elif [ "$docHitCount" = "0" ]; then
+  skip "no runnable 'claim.sh adopt … --reason' line exists in any *.md — nothing for the doc lint to check (a doc reorg/rewording, not a defect)"
 else
-  fail "a documented --reason still ships an unsubstituted template (or the lint found no lines to check):$badDocs"
+  ok "every documented runnable 'claim.sh adopt … --reason' carries a substituted value ($docHitCount line(s) checked, repo-wide)"
 fi
 
 # ===========================================================================
@@ -1301,6 +1390,119 @@ $globStatus
 $outGlobRel"
 fi
 rm -f "$GLOBTRAP"
+
+# ===========================================================================
+echo "TEST 21: a CAS push that did not land while the ref is STILL at --expect is infra (exit 1), never ADOPT-LOST (#2945 review J2)"
+# ===========================================================================
+# A SATISFIED lease precondition means the push failed for a NON-RACE reason (transient
+# network, an unrecognized auth signature, a server-side hook). `ADOPT-LOST … expected=X
+# actual=X` is self-contradictory on its face AND it makes the worker move on from a claim
+# that is still adoptable and untaken. The empty-lease sibling (TEST 9) and the re-entrant
+# `now == expect` case (TEST 10) already had this treatment; the FOREIGN-holder variant did
+# not. Staged with TEST 9's push-fail shim against a ref held by the OTHER machine, so the
+# holder is readable — this is not the unreadable-holder path.
+runA claim 2021 >/dev/null 2>&1
+casHeld=$(ref_sha 2021)
+( cd "$B" && g fetch -q origin "refs/claims/issue-2021" >/dev/null 2>&1 )
+[ -n "$casHeld" ] && ok "setup: machineA holds issue-2021 — a FOREIGN, readable holder for machineB's CAS" \
+  || fail "setup failed: no claim ref for issue-2021"
+casUnchangedOk=0; casUnchangedDiag=""
+# Both cases of the hex lease value: git resolves an object name case-insensitively, so an
+# UPPERCASE --expect satisfies the lease too and must not read as a divergence either.
+for casExp in "$casHeld" "$(printf '%s' "$casHeld" | LC_ALL=C tr 'a-f' 'A-F')"; do
+  outCasUnchanged=$( cd "$B" && PATH="$SHIMP:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+    bash "$CLAIM" adopt 2021 --expect "$casExp" --reason "cas retry while the lease still holds" 2>&1 ); rcCasUnchanged=$?
+  if [ "$rcCasUnchanged" -eq 1 ] && printf '%s\n' "$outCasUnchanged" | grep -q 'CLAIM: ERROR' \
+     && printf '%s\n' "$outCasUnchanged" | grep -q 'reason=infra' \
+     && printf '%s\n' "$outCasUnchanged" | grep -q 'detail=adopt-cas-rejected-but-ref-unchanged' \
+     && ! printf '%s\n' "$outCasUnchanged" | grep -q 'ADOPT-LOST'; then
+    casUnchangedOk=$((casUnchangedOk+1))
+  else
+    casUnchangedDiag="$casUnchangedDiag
+  --expect $casExp: rc=$rcCasUnchanged $outCasUnchanged"
+  fi
+done
+if [ "$casUnchangedOk" -eq 2 ] && [ "$(ref_sha 2021)" = "$casHeld" ] && [ "$(accepted_updates 2021)" = "1" ]; then
+  ok "a failed CAS push over a ref still at --expect (lower- AND upper-case sha) → ERROR infra exit 1, never ADOPT-LOST; the holder's ref is untouched"
+else
+  fail "expected ERROR infra adopt-cas-rejected-but-ref-unchanged for both sha cases; got $casUnchangedOk/2 ref='$(ref_sha 2021)' updates=$(accepted_updates 2021)$casUnchangedDiag"
+fi
+# ANTI-VACUITY 1: a GENUINE divergence (expected != actual) is still a lost race, with the
+# same shim — so the softening is scoped to the satisfied precondition, not to push failures.
+outCasDiverged=$( cd "$B" && PATH="$SHIMP:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" adopt 2021 --expect "$STALE" --reason "cas with a genuinely stale expected sha" 2>&1 ); rcCasDiverged=$?
+if [ "$rcCasDiverged" -eq 2 ] && printf '%s\n' "$outCasDiverged" | grep -q 'CLAIM: ADOPT-LOST' \
+   && printf '%s\n' "$outCasDiverged" | grep -q "expected=$STALE" \
+   && printf '%s\n' "$outCasDiverged" | grep -q "actual=$casHeld" \
+   && printf '%s\n' "$outCasDiverged" | grep -q 'holder-machine=machineA' \
+   && [ "$(ref_sha 2021)" = "$casHeld" ]; then
+  ok "a CAS whose expected != actual still reports ADOPT-LOST (exit 2) naming the true holder — the infra verdict is not a blanket softening"
+else
+  fail "expected ADOPT-LOST exit 2 for a genuinely stale --expect; got rc=$rcCasDiverged ref='$(ref_sha 2021)'
+$outCasDiverged"
+fi
+# ANTI-VACUITY 2: with a WORKING push the same CAS from the current sha SUCCEEDS (the
+# reaper-adopt contract) — so the infra verdict above came from the push failure alone.
+outCasReal=$(runB adopt 2021 --expect "$casHeld" --reason "the same CAS with a working push evicts the stale holder"); rcCasReal=$?
+runB verify 2021 >/dev/null 2>&1; rcCasRealVerify=$?
+if [ "$rcCasReal" -eq 0 ] && printf '%s\n' "$outCasReal" | grep -q 'CLAIM: ADOPTED' \
+   && [ -n "$(ref_sha 2021)" ] && [ "$(ref_sha 2021)" != "$casHeld" ] \
+   && [ "$rcCasRealVerify" -eq 0 ] && [ "$(accepted_updates 2021)" = "2" ]; then
+  ok "the identical CAS with a working push ADOPTS (exit 0, second server-accepted update, new holder verifies)"
+else
+  fail "expected the working-push CAS to adopt; got rc=$rcCasReal verify=$rcCasRealVerify ref='$(ref_sha 2021)' was='$casHeld' updates=$(accepted_updates 2021)
+$outCasReal"
+fi
+
+# ===========================================================================
+echo "TEST 22: CLAIM_MACHINE is SANITIZED — a spaced or 'actor='-carrying machine identity cannot strand or shift its own claim (#2945 review J3)"
+# ===========================================================================
+# `machine=` is the FIRST identity token in the claim message and the value verify/release
+# compare against, and it was interpolated RAW — the one user-controlled field the
+# sanitize_field contract missed. CLAIM_MACHINE="build box" wrote `machine=build box pid=…`,
+# so the parser returned `build` while the comparison used `build box`: the HOLDER could
+# never verify or non-force-release its OWN claim — a permanently stuck ref needing --force.
+# And a value carrying `actor=` shifted the RECORDED actor (first-match parsing) — the same
+# forgery class closed for --reason/--actor, reachable through an env var.
+runM() { ( cd "$A" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE="$1" CLAIM_REMOTE=origin bash "$CLAIM" "${@:2}" ); }
+runM 'build box' claim 2060 >/dev/null 2>&1; rcSpaced=$?
+spacedSha=$(ref_sha 2060)
+spacedMachine=$(line_field "$(runM 'build box' status 2060)" machine)
+if [ "$rcSpaced" -eq 0 ] && [ -n "$spacedSha" ] && [ "$spacedMachine" = "build-box" ]; then
+  ok "a SPACED CLAIM_MACHINE claims and records as ONE token (machine=build-box)"
+else
+  fail "expected a claim recorded as machine=build-box; got rc=$rcSpaced ref='$spacedSha' machine='$spacedMachine'"
+fi
+runM 'build box' verify 2060 >/dev/null 2>&1; rcSpacedVerify=$?
+runM 'build' verify 2060 >/dev/null 2>&1; rcTruncVerify=$?
+if [ "$rcSpacedVerify" -eq 0 ] && [ "$rcTruncVerify" -eq 2 ]; then
+  ok "the spaced holder VERIFIES its own claim (exit 0) and the truncated identity 'build' does NOT (exit 2) — written and compared tokens agree, with no aliasing"
+else
+  fail "expected verify 0 for 'build box' and 2 for 'build'; got $rcSpacedVerify / $rcTruncVerify"
+fi
+runM 'build box' release 2060 >/dev/null 2>&1; rcSpacedRelease=$?
+if [ "$rcSpacedRelease" -eq 0 ] && [ -z "$(ref_sha 2060)" ]; then
+  ok "the spaced holder RELEASES its own claim without --force (exit 0, ref gone) — no permanently stuck ref"
+else
+  fail "expected a non-forced release by the spaced holder; got rc=$rcSpacedRelease ref='$(ref_sha 2060)'"
+fi
+# An `actor=`-carrying CLAIM_MACHINE must not shift the recorded actor: `machine=machineZ
+# actor=lead pid=… actor=flow` parses (first exact match) as actor=lead.
+runM 'machineZ actor=lead' claim 2070 >/dev/null 2>&1; rcActorEnv=$?
+actorEnvStatus=$(runM 'machineZ actor=lead' status 2070)
+actorEnvMachine=$(line_field "$actorEnvStatus" machine)
+actorEnvActor=$(line_field "$actorEnvStatus" actor)
+runM 'machineZ actor=lead' verify 2070 >/dev/null 2>&1; rcActorEnvVerify=$?
+runM 'machineZ actor=lead' release 2070 >/dev/null 2>&1; rcActorEnvRelease=$?
+if [ "$rcActorEnv" -eq 0 ] && [ "$actorEnvActor" = "flow" ] \
+   && [ "$actorEnvMachine" = "${actorEnvMachine%%[[:space:]]*}" ] \
+   && [ "${actorEnvMachine#*=}" = "$actorEnvMachine" ] \
+   && [ "$rcActorEnvVerify" -eq 0 ] && [ "$rcActorEnvRelease" -eq 0 ] && [ -z "$(ref_sha 2070)" ]; then
+  ok "an 'actor='-carrying CLAIM_MACHINE records the REAL actor (flow) in a single '='-free machine token, and still verifies/releases"
+else
+  fail "expected actor=flow with a sanitized machine token and a clean round trip; got rc=$rcActorEnv machine='$actorEnvMachine' actor='$actorEnvActor' verify=$rcActorEnvVerify release=$rcActorEnvRelease ref='$(ref_sha 2070)'
+$actorEnvStatus"
+fi
 
 echo ""
 echo "================  claim-resume (#2945): $PASS passed, $FAIL failed, $SKIP skipped  ================"

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -1597,6 +1597,93 @@ else
   fail "expected a genuine LOST exit 2 naming holder-machine=machineA at sha=$FOREIGN; got rc=$rcForeignConfirm
 $outForeignConfirm"
 fi
+# …and the SIXTH instance of the one rule, at the same site: the confirm names a
+# DIFFERENT sha whose commit is UNREADABLE. `fetch_claim` only ever fetches THIS issue's
+# ref (which the landed push left at OUR OWN sha), so a TOCTOU winner advertised by the
+# confirm is simply not a local object — the identity read cannot say who holds it, and
+# it may be us. Falling straight through to LOST rendered the tell-tale empty
+# `holder-machine= actor=` and contradicted this file's own header rule ("NO subcommand
+# reports LOST/ADOPT-LOST/VERIFY-FAIL/not-holder when the holder commit's message is
+# UNREADABLE"). Same three-outcome triage as the rejected-push sibling now.
+runA claim 2304 >/dev/null 2>&1; rcUnreadSetup=$?
+FOREIGN_UNREAD=$(ref_sha 2304)
+if [ "$rcUnreadSetup" -eq 0 ] && [ -n "$FOREIGN_UNREAD" ] \
+   && ! g -C "$B" cat-file -e "${FOREIGN_UNREAD}^{commit}" 2>/dev/null; then
+  ok "setup: machineA's claim commit for issue-2304 exists on origin and is NOT a local object in clone B (so its identity is unreadable there)"
+else
+  fail "setup failed for the unreadable-confirm case (rc=$rcUnreadSetup foreign='$FOREIGN_UNREAD'; object already local?)"
+fi
+CTRUNR="$T/confirm-read-count-unreadable"
+: >"$CTRUNR"
+SHIMUNR="$T/shim-confirm-unreadable"
+mkdir -p "$SHIMUNR"
+cat >"$SHIMUNR/git" <<SHIM
+#!/usr/bin/env bash
+saw_ls=0; saw_claims=0
+for a in "\$@"; do
+  [ "\$a" = "ls-remote" ] && saw_ls=1
+  case "\$a" in refs/claims/*) saw_claims=1 ;; esac
+done
+if [ "\$saw_ls" = 1 ] && [ "\$saw_claims" = 1 ]; then
+  n=\$(cat "$CTRUNR" 2>/dev/null || echo 0)
+  n=\$((n + 1)); printf '%s' "\$n" >"$CTRUNR"
+  if [ "\$n" = 1 ]; then exit 0; fi
+  printf '%s\trefs/claims/issue-2305\n' "$FOREIGN_UNREAD"
+  exit 0
+fi
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMUNR/git"
+outUnreadConfirm=$( cd "$B" && PATH="$SHIMUNR:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" claim 2305 2>&1 ); rcUnreadConfirm=$?
+if [ "$rcUnreadConfirm" -eq 1 ] && printf '%s\n' "$outUnreadConfirm" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outUnreadConfirm" | grep -q 'reason=infra' \
+   && printf '%s\n' "$outUnreadConfirm" | grep -q 'detail=holder-commit-unreadable' \
+   && ! printf '%s\n' "$outUnreadConfirm" | grep -q 'CLAIM: LOST' \
+   && ! printf '%s\n' "$outUnreadConfirm" | grep -qE 'machine= |machine=$|actor= |actor=$'; then
+  ok "a post-push confirm naming an UNREADABLE sha → ERROR infra exit 1 (never LOST, no empty machine=/actor= render)"
+else
+  fail "expected ERROR infra holder-commit-unreadable exit 1 with no LOST; got rc=$rcUnreadConfirm
+$outUnreadConfirm"
+fi
+# The third outcome of that same triage: the confirm names a sha that is OURS and
+# READABLE — we DO hold a claim, so exit 2 would abandon it. Re-entrant HELD, exactly as
+# the rejected-push sibling and the pre-check already do (TEST 10 pins adopt's twin).
+runB claim 2306 >/dev/null 2>&1; rcOursSetup=$?
+OURS=$(ref_sha 2306)
+CTROUR="$T/confirm-read-count-ours"
+: >"$CTROUR"
+SHIMOUR="$T/shim-confirm-ours"
+mkdir -p "$SHIMOUR"
+cat >"$SHIMOUR/git" <<SHIM
+#!/usr/bin/env bash
+saw_ls=0; saw_claims=0
+for a in "\$@"; do
+  [ "\$a" = "ls-remote" ] && saw_ls=1
+  case "\$a" in refs/claims/*) saw_claims=1 ;; esac
+done
+if [ "\$saw_ls" = 1 ] && [ "\$saw_claims" = 1 ]; then
+  n=\$(cat "$CTROUR" 2>/dev/null || echo 0)
+  n=\$((n + 1)); printf '%s' "\$n" >"$CTROUR"
+  if [ "\$n" = 1 ]; then exit 0; fi
+  printf '%s\trefs/claims/issue-2307\n' "$OURS"
+  exit 0
+fi
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMOUR/git"
+outOursConfirm=$( cd "$B" && PATH="$SHIMOUR:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" claim 2307 2>&1 ); rcOursConfirm=$?
+if [ "$rcOursSetup" -eq 0 ] && [ -n "$OURS" ] && [ "$rcOursConfirm" -eq 0 ] \
+   && printf '%s\n' "$outOursConfirm" | grep -q 'CLAIM: HELD' \
+   && printf '%s\n' "$outOursConfirm" | grep -q 're-entrant' \
+   && printf '%s\n' "$outOursConfirm" | grep -q 'machine=machineB' \
+   && ! printf '%s\n' "$outOursConfirm" | grep -q 'CLAIM: LOST'; then
+  ok "a post-push confirm naming a sha that is OURS reports a re-entrant HELD (exit 0), never LOST — the claim we hold is not abandoned"
+else
+  fail "expected a re-entrant HELD exit 0 for our own sha $OURS; got setup=$rcOursSetup rc=$rcOursConfirm
+$outOursConfirm"
+fi
 
 echo ""
 echo "================  claim-resume (#2945): $PASS passed, $FAIL failed, $SKIP skipped  ================"

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -1061,6 +1061,247 @@ else
 $outSecond"
 fi
 
+# ===========================================================================
+echo "TEST 17: an UNREADABLE holder commit is infra (exit 1), never LOST/ADOPT-LOST (#2945 review H1)"
+# ===========================================================================
+# `fetch_claim` is best-effort (`|| true`), so a transient fetch failure — disk full,
+# partial outage, ref-advertisement hiccup — leaves the claim OBJECT absent and its
+# message unreadable. The identity check then answered "not us", and both `claim` and
+# `adopt` fell through to LOST / ADOPT-LOST (exit 2), which workers read as "you did not
+# win, take the next item". In the reported shape `now` is OUR OWN claim commit, so a
+# machine abandoned an issue it still held the ref for — and nobody else could take it
+# either (the ref is held): a permanent stall whose tell is the empty
+# `holder-machine= actor=` render. An unread signal must be infra, like every other one.
+runB claim 2017 >/dev/null 2>&1; rcSetup17=$?
+heldSha17=$(ref_sha 2017)
+# The object must NOT be present in clone A — that is what makes the read unreadable.
+if [ "$rcSetup17" -eq 0 ] && [ -n "$heldSha17" ] \
+   && ! g -C "$A" cat-file -e "${heldSha17}^{commit}" 2>/dev/null; then
+  ok "setup: machineB holds issue-2017 and clone A does not have the claim object locally"
+else
+  fail "setup failed for the unreadable-holder case (rc=$rcSetup17 ref='$heldSha17'; object already local?)"
+fi
+SHIMFETCH="$T/shim-fetch-fail"
+mkdir -p "$SHIMFETCH"
+cat >"$SHIMFETCH/git" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do [ "\$a" = "fetch" ] && exit 128; done
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMFETCH/git"
+outUnreadClaim=$( cd "$A" && PATH="$SHIMFETCH:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin \
+  bash "$CLAIM" claim 2017 2>&1 ); rcUnreadClaim=$?
+if [ "$rcUnreadClaim" -eq 1 ] && printf '%s\n' "$outUnreadClaim" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outUnreadClaim" | grep -q 'reason=infra' \
+   && printf '%s\n' "$outUnreadClaim" | grep -q 'detail=holder-commit-unreadable' \
+   && ! printf '%s\n' "$outUnreadClaim" | grep -q 'CLAIM: LOST' \
+   && [ "$(ref_sha 2017)" = "$heldSha17" ]; then
+  ok "claim with an unreadable holder commit → ERROR infra exit 1 (never LOST), ref untouched"
+else
+  fail "expected ERROR infra holder-commit-unreadable exit 1 with no LOST; got rc=$rcUnreadClaim ref='$(ref_sha 2017)'
+$outUnreadClaim"
+fi
+# …and the verdict never renders an EMPTY holder (the tell of the old bug).
+if ! printf '%s\n' "$outUnreadClaim" | grep -qE 'machine= |machine=$|actor= |actor=$'; then
+  ok "the unreadable-holder verdict prints no empty machine=/actor= field"
+else
+  fail "the unreadable-holder verdict rendered an empty holder field:
+$outUnreadClaim"
+fi
+outUnreadAdopt=$( cd "$A" && PATH="$SHIMFETCH:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin \
+  bash "$CLAIM" adopt 2017 --expect none --reason "resume attempt over a flaky fetch" 2>&1 ); rcUnreadAdopt=$?
+if [ "$rcUnreadAdopt" -eq 1 ] && printf '%s\n' "$outUnreadAdopt" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outUnreadAdopt" | grep -q 'reason=infra' \
+   && printf '%s\n' "$outUnreadAdopt" | grep -q 'detail=holder-commit-unreadable' \
+   && ! printf '%s\n' "$outUnreadAdopt" | grep -q 'ADOPT-LOST' \
+   && [ "$(ref_sha 2017)" = "$heldSha17" ] && [ "$(accepted_updates 2017)" = "1" ]; then
+  ok "adopt with an unreadable holder commit → ERROR infra exit 1 (never ADOPT-LOST), no server write"
+else
+  fail "expected adopt ERROR infra holder-commit-unreadable exit 1 with no ADOPT-LOST; got rc=$rcUnreadAdopt ref='$(ref_sha 2017)' updates=$(accepted_updates 2017)
+$outUnreadAdopt"
+fi
+# ANTI-VACUITY: with the fetch WORKING, the very same commands still give the genuine
+# race verdicts — so the infra verdict above comes from the unread signal, nothing else.
+outReadClaim=$(runA claim 2017); rcReadClaim=$?
+outReadAdopt=$(runA adopt 2017 --expect none --reason "resume attempt with a healthy fetch"); rcReadAdopt=$?
+if [ "$rcReadClaim" -eq 2 ] && printf '%s\n' "$outReadClaim" | grep -q 'holder-machine=machineB' \
+   && [ "$rcReadAdopt" -eq 2 ] && printf '%s\n' "$outReadAdopt" | grep -q 'CLAIM: ADOPT-LOST'; then
+  ok "with a healthy fetch the same calls still report the genuine LOST/ADOPT-LOST (exit 2) — the infra verdict is not a blanket softening"
+else
+  fail "expected LOST + ADOPT-LOST exit 2 once the holder commit is readable; got rcClaim=$rcReadClaim rcAdopt=$rcReadAdopt
+$outReadClaim
+$outReadAdopt"
+fi
+
+# ===========================================================================
+echo "TEST 18: an UNSUBSTITUTED <…> in --reason is refused on the RAW text (#2945 review H2)"
+# ===========================================================================
+# The placeholder gate only saw the SANITIZED token, so it caught a bare `<why>` but not
+# a template inside a longer value: the documented
+# `--reason resume-legacy-branch-lock:<branch>`, run VERBATIM (the exact mode this change
+# is built around), sanitizes to `resume-legacy-branch-lock:-branch` — 33 chars, no
+# sentinel — and was ACCEPTED, recording an unresolved placeholder as the audit reason.
+tmplRc=""
+for tmpl in 'resume-legacy-branch-lock:<branch>' 'resume-legacy-branch-lock:issue-2018-<slug>' 'resume of <N> after a reap' '<concrete why>'; do
+  runB adopt 2018 --expect none --reason "$tmpl" >/dev/null 2>&1
+  tmplRc="$tmplRc $?"
+done
+if [ "$tmplRc" = " 64 64 64 64" ] && [ -z "$(ref_sha 2018)" ] && [ "$(accepted_updates 2018)" = "0" ]; then
+  ok "every --reason still carrying <…> is a usage error (exit 64), nothing acquired"
+else
+  fail "expected 64 from every unsubstituted --reason template; got rcs='$tmplRc' ref='$(ref_sha 2018)' updates=$(accepted_updates 2018)"
+fi
+outTmpl=$(runB adopt 2018 --expect none --reason 'resume-legacy-branch-lock:<branch>' 2>&1) || true
+if printf '%s\n' "$outTmpl" | grep -qi 'placeholder' && printf '%s\n' "$outTmpl" | grep -qi 'substitute'; then
+  ok "the refusal names the unsubstituted placeholder and tells the caller to substitute it"
+else
+  fail "the template refusal does not explain itself:
+$outTmpl"
+fi
+# The SUBSTITUTED form must work — the point is a documented invocation that runs.
+outConcrete=$(runB adopt 2018 --expect none --reason 'resume-legacy-branch-lock:branch-outlived-claim'); rcConcrete=$?
+if [ "$rcConcrete" -eq 0 ] && printf '%s\n' "$outConcrete" | grep -q 'CLAIM: ADOPTED' \
+   && [ "$(line_field "$(runB status 2018)" reason)" = "resume-legacy-branch-lock:branch-outlived-claim" ]; then
+  ok "the substituted, self-describing reason adopts and records verbatim"
+else
+  fail "expected the concrete reason to adopt and record; got rc=$rcConcrete reason='$(line_field "$(runB status 2018)" reason)'
+$outConcrete"
+fi
+# …and no doc/skill may hand the reader a template again: every line that shows a
+# runnable `claim.sh adopt … --reason` must carry a SUBSTITUTED value.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+docHits="$(grep -rn -- 'claim\.sh adopt .*--reason' \
+  "$REPO_ROOT/CLAUDE.md" "$REPO_ROOT/.claude/skills" \
+  "$REPO_ROOT/website/src/content/docs/agents-developing/delivery-pipeline.md" 2>/dev/null || true)"
+badDocs=""
+while IFS= read -r docLine; do
+  [ -n "$docLine" ] || continue
+  docVal="${docLine#*--reason }"; docVal="${docVal%% *}"
+  case "$docVal" in *'<'*) badDocs="$badDocs
+  $docLine" ;; esac
+done <<< "$docHits"
+if [ -n "$docHits" ] && [ -z "$badDocs" ]; then
+  ok "every documented runnable 'claim.sh adopt … --reason' carries a substituted value ($(printf '%s\n' "$docHits" | grep -c . ) line(s) checked)"
+else
+  fail "a documented --reason still ships an unsubstituted template (or the lint found no lines to check):$badDocs"
+fi
+
+# ===========================================================================
+echo "TEST 19: --actor must RECORD something — two unrecordable actors can no longer alias (#2945 review H3)"
+# ===========================================================================
+# --reason was made fail-closed, but --actor — part of the HOLDER IDENTITY that gates
+# re-entrancy, verify and non-forced release — still coerced to the `unspecified`
+# sentinel. So `claim N --actor '***'` recorded `actor=unspecified` and a later
+# `release N --actor '???'` resolved to `unspecified` too, satisfying the holder gate for
+# a claim it does not own: two distinct-but-unrecordable actors aliased onto ONE identity.
+actorRc=""
+for badActor in '***' '???' '   ' '---' '…' 'unspecified' '=='; do
+  runA claim 2019 --actor "$badActor" >/dev/null 2>&1
+  actorRc="$actorRc $?"
+done
+if [ "$actorRc" = " 64 64 64 64 64 64 64" ] && [ -z "$(ref_sha 2019)" ]; then
+  ok "an unrecordable --actor ('***', '???', '   ', '---', '…', 'unspecified', '==') is a usage error (exit 64), nothing claimed"
+else
+  fail "expected 64 from every unrecordable --actor with no ref created; got rcs='$actorRc' ref='$(ref_sha 2019)'"
+fi
+# THE ALIASING ITSELF: a claim by a recordable actor cannot be released by an
+# unrecordable one, on ANY subcommand — the sentinel identity is unreachable now.
+runA claim 2019 --actor alpha >/dev/null 2>&1; rcAlpha=$?
+alphaSha=$(ref_sha 2019)
+aliasRc=""
+for sub in "verify 2019" "release 2019" "adopt 2019 --expect none --reason retaking-with-an-unrecordable-actor"; do
+  # shellcheck disable=SC2086  # deliberate word-split of the fixed arg list
+  ( cd "$A" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" $sub --actor '???' >/dev/null 2>&1 )
+  aliasRc="$aliasRc $?"
+done
+if [ "$rcAlpha" -eq 0 ] && [ "$aliasRc" = " 64 64 64" ] && [ "$(ref_sha 2019)" = "$alphaSha" ]; then
+  ok "an unrecordable --actor is refused (64) on verify/release/adopt too — it can no longer alias onto the 'alpha' holder's claim"
+else
+  fail "expected 64 from verify/release/adopt with an unrecordable actor and the ref intact; got rcAlpha=$rcAlpha rcs='$aliasRc' ref='$(ref_sha 2019)' was='$alphaSha'"
+fi
+# Non-regression: a RECORDABLE actor still round-trips end to end.
+runA verify 2019 --actor alpha >/dev/null 2>&1; rcVAlpha=$?
+runA verify 2019 >/dev/null 2>&1; rcVDefault=$?
+rcRelAlpha=0; ( cd "$A" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" release 2019 --actor alpha >/dev/null 2>&1 ) || rcRelAlpha=$?
+if [ "$rcVAlpha" -eq 0 ] && [ "$rcVDefault" -eq 2 ] && [ "$rcRelAlpha" -eq 0 ] && [ -z "$(ref_sha 2019)" ]; then
+  ok "a recordable --actor still claims/verifies/releases, and the default actor is correctly a non-holder"
+else
+  fail "recordable-actor round trip broke: verify(alpha)=$rcVAlpha verify(default)=$rcVDefault release(alpha)=$rcRelAlpha ref='$(ref_sha 2019)'"
+fi
+
+# ===========================================================================
+echo "TEST 20: HAND-CRAFTED claim commits reach msg_field UNSANITIZED — first exact key wins, globs stay inert (#2945 review H4)"
+# ===========================================================================
+# The forgery tests above drive --reason/--actor through the CLI, where sanitize_field
+# already strips '=', spaces and '*' — so they exercise the SANITIZER, not the
+# `msg_field` parser the header calls "the root fix" and "a second, independent layer".
+# The one input class that reaches the parser unsanitized is a HAND-CRAFTED claim commit,
+# which this file documents workers pushing twice in one day. Without these cases a
+# refactor reverting msg_field to the greedy `sed` form — or dropping its `set -f` guard
+# — passes every other test in the suite.
+# push_crafted_claim <issue> <full commit message> — a claim ref whose commit message is
+# EXACTLY the given text (a root commit on the empty tree, like claim.sh's own).
+push_crafted_claim() {
+  local issue="$1" msg="$2" tree sha
+  tree="$(g -C "$A" hash-object -t tree --stdin </dev/null)"
+  sha="$(g -C "$A" commit-tree "$tree" -m "$msg")"
+  g -C "$A" push -q origin "$sha:refs/claims/issue-$issue"
+  printf '%s\n' "$sha"
+}
+# (a) GREEDY-vs-FIRST and EXACT-KEY, in one message: a `holder-machine=` token BEFORE the
+# real one (a substring matcher answers machineC) and a trailing `machine=machineA
+# actor=flow` pair (the greedy `.*machine=` matcher answers machineA/flow — clone A's own
+# identity, i.e. a forged holder).
+craftedSha=$(push_crafted_claim 2020 "claim issue=2020 holder-machine=machineC machine=machineB pid=1 actor=lead ts=2026-07-26T00:00:00Z nonce=hand-crafted reason=sneaky machine=machineA actor=flow")
+craftedStatus=$(runA status 2020)
+if [ "$(line_field "$craftedStatus" machine)" = "machineB" ] \
+   && [ "$(line_field "$craftedStatus" actor)" = "lead" ]; then
+  ok "(a) status resolves the FIRST exact machine=/actor= tokens (machineB/lead), not the trailing forged pair nor holder-machine="
+else
+  fail "(a) crafted message resolved to the wrong holder:
+$craftedStatus"
+fi
+runA verify 2020 >/dev/null 2>&1; rcCraftV=$?
+outCraftRel=$( cd "$A" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" release 2020 2>&1 ); rcCraftRel=$?
+if [ "$rcCraftV" -eq 2 ] && [ "$rcCraftRel" -eq 2 ] \
+   && printf '%s\n' "$outCraftRel" | grep -q 'reason=not-holder' \
+   && printf '%s\n' "$outCraftRel" | grep -q 'holder-machine=machineB' \
+   && [ "$(ref_sha 2020)" = "$craftedSha" ]; then
+  ok "(a) the impersonated machineA neither verifies (exit 2) nor releases (not-holder, ref intact) the crafted claim"
+else
+  fail "(a) a trailing forged machine=/actor= pair granted machineA the holder identity; verify=$rcCraftV release=$rcCraftRel ref='$(ref_sha 2020)'
+$outCraftRel"
+fi
+rcCraftTrue=0; ( cd "$B" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" release 2020 --actor lead >/dev/null 2>&1 ) || rcCraftTrue=$?
+if [ "$rcCraftTrue" -eq 0 ] && [ -z "$(ref_sha 2020)" ]; then
+  ok "(a) the TRUE crafted holder (machineB/lead) does resolve and can release it (exit 0, ref gone)"
+else
+  fail "(a) the true holder of the crafted claim could not release it (rc=$rcCraftTrue ref='$(ref_sha 2020)')"
+fi
+# (b) THE GLOB: a crafted `machine=machine*` token plus a file literally named
+# `machine=machineA` in the caller's cwd. Word-splitting the message WITHOUT `set -f`
+# pathname-expands that token into `machine=machineA` — clone A's identity — so the
+# parser hands machineA a holder identity it never had. With the guard it stays the
+# literal `machine*`.
+GLOBTRAP="$A/machine=machineA"
+: >"$GLOBTRAP"
+globSha=$(push_crafted_claim 2030 "claim issue=2030 machine=machine* pid=1 actor=flow ts=2026-07-26T00:00:00Z nonce=hand-crafted-glob")
+[ -e "$GLOBTRAP" ] && ok "(b) glob trap present: a file named 'machine=machineA' sits in the caller's cwd" \
+  || fail "(b) could not create the glob trap file — the case would be vacuous"
+globStatus=$(runA status 2030)
+runA verify 2030 >/dev/null 2>&1; rcGlobV=$?
+outGlobRel=$( cd "$A" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" release 2030 2>&1 ); rcGlobRel=$?
+if [ "$(line_field "$globStatus" machine)" = 'machine*' ] && [ "$rcGlobV" -eq 2 ] \
+   && [ "$rcGlobRel" -eq 2 ] && printf '%s\n' "$outGlobRel" | grep -q 'reason=not-holder' \
+   && [ "$(ref_sha 2030)" = "$globSha" ]; then
+  ok "(b) a '*'-carrying token stays inert: status renders 'machine*', machineA neither verifies nor releases (ref intact)"
+else
+  fail "(b) the crafted glob expanded against the cwd and forged a holder: machine='$(line_field "$globStatus" machine)' verify=$rcGlobV release=$rcGlobRel ref='$(ref_sha 2030)'
+$globStatus
+$outGlobRel"
+fi
+rm -f "$GLOBTRAP"
+
 echo ""
 echo "================  claim-resume (#2945): $PASS passed, $FAIL failed, $SKIP skipped  ================"
 [ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+#
+# Regression tests for the claim.sh RESUME path (issue #2945).
+#
+# The legacy-branch guard used to refuse a claim whenever ANY refs/heads/issue-<N>-*
+# branch existed on origin, with no reachable escape hatch: its documented
+# "all-ours -> no block" re-entrancy compared the BRANCH TIP against claim-commit
+# trailers a real work branch can never carry, so it was dead code. `adopt` could
+# not substitute either (it demanded a --expect <old-sha> CAS against an EXISTING
+# ref). Workers hand-crafted claim commits to get past it — twice in one day.
+#
+# These tests pin the sanctioned replacement: `adopt <N> --expect none --reason <why>`
+# (git's EMPTY LEASE = "the ref must not exist"), the safety direction (a HELD ref
+# still refuses), a REAL two-machine race on that path (git arbitrates, exactly one
+# winner), and the guard's fail-CLOSED behaviour on an enumeration outage
+# (#2677 item 2 — an outage must never read as "no legacy branch").
+#
+# Fast + hermetic: a mktemp BARE repo stands in for origin plus two clones playing
+# machines A and B (each overriding CLAIM_MACHINE). No network, no GitHub, no gh
+# (neither `claim` nor `adopt` uses it). No wall-clock assertions — every verdict is
+# a git-ref state or an exit code.
+#
+# Run standalone:  bash scripts/flow/tests/claim-resume.test.sh
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAIM="$SCRIPT_DIR/../claim.sh"
+REALGIT="$(command -v git)"   # absolute git, for the ls-remote shim in TEST 6
+
+PASS=0
+FAIL=0
+fail() { echo "  ✗ $*"; FAIL=$((FAIL+1)); }
+ok()   { echo "  ✓ $*"; PASS=$((PASS+1)); }
+
+# git in a throwaway identity so commits/pushes work in any sandbox.
+g() { git -c user.email=t@t -c user.name=t -c init.defaultBranch=main -c commit.gpgsign=false "$@"; }
+
+T=$(mktemp -d "${TMPDIR:-/tmp}/claim-resume-test.XXXXXX")
+trap 'rm -rf "$T"' EXIT
+
+ORIGIN="$T/origin.git"
+A="$T/A"
+B="$T/B"
+g init --bare -q "$ORIGIN"
+g clone -q "$ORIGIN" "$A" 2>/dev/null
+g clone -q "$ORIGIN" "$B" 2>/dev/null
+(
+  cd "$A" || exit 1
+  echo seed >seed.txt
+  g add seed.txt
+  g commit -qm seed
+  g push -q -u origin main
+)
+( cd "$B" && g fetch -q origin )
+
+# runA/runB — claim.sh from clone A/B as a distinct machine. The function EXIT CODE
+# is claim.sh's, so callers use `out=$(runA ...); rc=$?`.
+runA() { ( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" "$@" ); }
+runB() { ( cd "$B" && CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" "$@" ); }
+
+ref_sha()      { g -C "$A" ls-remote origin "refs/claims/issue-$1" | awk '{print $1}' | head -1; }
+ref_count()    { g -C "$A" ls-remote origin "refs/claims/issue-$1" | wc -l | tr -d ' '; }
+branch_exists() { [ -n "$(g -C "$A" ls-remote --heads origin "$1" | awk '{print $1}')" ]; }
+
+# push_work_branch <branch> [msg] — an ORDINARY work branch on origin: cut from
+# main, an ordinary commit on top. Its tip carries NO claim trailers, which is
+# exactly why the old tip-based re-entrancy could never fire.
+push_work_branch() {
+  local branch="$1" msg="${2:-ordinary work commit}"
+  (
+    cd "$A" || exit 1
+    g checkout -q -b "$branch" main
+    g commit -q --allow-empty -m "$msg"
+    g push -q origin "$branch"
+    g checkout -q main
+    g branch -q -D "$branch"
+  )
+}
+
+# ===========================================================================
+echo "TEST 1: FREE claim ref + foreign-tip issue-<N>-* branch — claim refuses WITH the remediation, adopt --expect none SUCCEEDS"
+# ===========================================================================
+push_work_branch "issue-2001-owner-approved-spec" "docs(#2001): OpenSpec change approved by owner"
+( cd "$B" && g fetch -q origin )
+[ -z "$(ref_sha 2001)" ] && ok "precondition: refs/claims/issue-2001 is FREE" \
+  || fail "precondition broken: a claim ref already exists for 2001"
+
+outClaim=$(runB claim 2001); rcClaim=$?
+if [ "$rcClaim" -eq 2 ] && printf '%s\n' "$outClaim" | grep -q 'reason=legacy-branch-lock'; then
+  ok "claim still refuses (exit 2) while the branch stands"
+else
+  fail "expected legacy-branch-lock refusal exit 2; got rc=$rcClaim
+$outClaim"
+fi
+# Option 3 of the issue: the refusal must be ACTIONABLE, not a bare LOST — a bare
+# LOST is what sent two workers into hand-crafted claim-commit pushes.
+if printf '%s\n' "$outClaim" | grep -q 'adopt 2001 --expect none --reason' \
+   && printf '%s\n' "$outClaim" | grep -q 'issue-2001-owner-approved-spec' \
+   && printf '%s\n' "$outClaim" | grep -q 'claim-ref=free'; then
+  ok "refusal names the exact remediation command, the blocking branch, and claim-ref=free"
+else
+  fail "refusal is not actionable (missing remediation/branch/claim-ref=free):
+$outClaim"
+fi
+[ "$(printf '%s\n' "$outClaim" | grep -c 'CLAIM:')" = "1" ] \
+  && ok "refusal stays ONE CLAIM: line (single-line output contract)" \
+  || fail "refusal spans multiple CLAIM: lines:
+$outClaim"
+
+outAdopt=$(runB adopt 2001 --expect none --reason "resume of #1883: owner-approved OpenSpec change lives on the branch"); rcAdopt=$?
+adoptSha=$(ref_sha 2001)
+if [ "$rcAdopt" -eq 0 ] && printf '%s\n' "$outAdopt" | grep -q 'CLAIM: ADOPTED' \
+   && printf '%s\n' "$outAdopt" | grep -q 'from=none' && [ -n "$adoptSha" ]; then
+  ok "adopt --expect none acquires the FREE ref (exit 0, ADOPTED, ref created)"
+else
+  fail "expected ADOPTED exit 0 with a ref; got rc=$rcAdopt ref='$adoptSha'
+$outAdopt"
+fi
+runB verify 2001 >/dev/null 2>&1; rcVerify=$?
+[ "$rcVerify" -eq 0 ] && ok "the adopter now VERIFIES as holder (exit 0)" \
+  || fail "expected verify exit 0 for the adopter, got $rcVerify"
+runA verify 2001 >/dev/null 2>&1; rcVerifyOther=$?
+[ "$rcVerifyOther" -eq 2 ] && ok "the other machine does NOT verify as holder (exit 2)" \
+  || fail "expected verify exit 2 for a non-holder, got $rcVerifyOther"
+branch_exists "issue-2001-owner-approved-spec" \
+  && ok "the resumed work branch is left untouched on origin" \
+  || fail "the resume path deleted/moved the work branch"
+
+# Criterion 1: the command records WHO took it and WHY.
+statusOut=$( cd "$B" && CLAIM_MACHINE=machineB bash "$CLAIM" status 2001 )
+if printf '%s\n' "$statusOut" | grep -q 'machine=machineB' \
+   && printf '%s\n' "$statusOut" | grep -q 'reason=resume-of-#1883:-owner-approved-OpenSpec-change-lives-on-the-branch'; then
+  ok "the claim record carries who (machine=machineB) AND why (sanitized one-token reason)"
+else
+  fail "claim record missing holder and/or reason:
+$statusOut"
+fi
+[ "$(printf '%s\n' "$statusOut" | grep -c 'CLAIM: STATUS')" = "1" ] \
+  && ok "a multi-word reason stays ONE parseable status line" \
+  || fail "reason sanitization leaked whitespace into the record:
+$statusOut"
+
+# ===========================================================================
+echo "TEST 2: HELD claim ref + branch present — the resume path is still REFUSED (exit 2, holder keeps it)"
+# ===========================================================================
+push_work_branch "issue-2002-active-effort"
+( cd "$B" && g fetch -q origin )
+runA claim 2002 >/dev/null 2>&1   # blocked by the branch guard, so take it via the resume path
+runA adopt 2002 --expect none --reason "machineA is actively working this" >/dev/null 2>&1; rcHold=$?
+heldSha=$(ref_sha 2002)
+[ "$rcHold" -eq 0 ] && [ -n "$heldSha" ] && ok "machineA holds refs/claims/issue-2002" \
+  || fail "could not set up a HELD ref (rc=$rcHold ref='$heldSha')"
+
+outSteal=$(runB adopt 2002 --expect none --reason "second machine tries the resume path"); rcSteal=$?
+stillSha=$(ref_sha 2002)
+if [ "$rcSteal" -eq 2 ] && printf '%s\n' "$outSteal" | grep -q 'CLAIM: ADOPT-LOST' \
+   && printf '%s\n' "$outSteal" | grep -q 'holder-machine=machineA' \
+   && [ "$stillSha" = "$heldSha" ]; then
+  ok "a second machine's empty-lease adopt is REFUSED (exit 2) and the holder's ref is unchanged"
+else
+  fail "expected ADOPT-LOST exit 2 with the ref intact; got rc=$rcSteal held=$heldSha now=$stillSha
+$outSteal"
+fi
+runA verify 2002 >/dev/null 2>&1; rcHolderStill=$?
+[ "$rcHolderStill" -eq 0 ] && ok "the original holder still verifies after the refused attempt" \
+  || fail "holder lost its claim to a refused resume (verify rc=$rcHolderStill)"
+
+# ===========================================================================
+echo "TEST 3: two machines RACE the resume path — exactly one winner (git arbitrates)"
+# ===========================================================================
+push_work_branch "issue-2003-resumable"
+( cd "$B" && g fetch -q origin )
+# Real competing pushes: both machines are released from a FIFO barrier and run the
+# empty-lease adopt concurrently against the same origin. Nothing is mocked — the
+# remote's ref update is the arbiter.
+mkfifo "$T/gate-a" "$T/gate-b"
+( head -1 <"$T/gate-a" >/dev/null 2>&1
+  runA adopt 2003 --expect none --reason "racing machineA" >"$T/race-a.out" 2>&1
+  echo "$?" >"$T/race-a.rc" ) &
+pidA=$!
+( head -1 <"$T/gate-b" >/dev/null 2>&1
+  runB adopt 2003 --expect none --reason "racing machineB" >"$T/race-b.out" 2>&1
+  echo "$?" >"$T/race-b.rc" ) &
+pidB=$!
+( echo go >"$T/gate-a" ) &
+writerA=$!
+( echo go >"$T/gate-b" ) &
+writerB=$!
+wait "$pidA" "$pidB" 2>/dev/null
+# Never `wait` on the fifo writers: a writer blocks until its reader opens, so a
+# child that died before opening would hang the suite. The racers are done here,
+# so any still-blocked writer is simply killed.
+kill "$writerA" "$writerB" 2>/dev/null || true
+rcRaceA="$(cat "$T/race-a.rc" 2>/dev/null || echo missing)"
+rcRaceB="$(cat "$T/race-b.rc" 2>/dev/null || echo missing)"
+winners=0
+[ "$rcRaceA" = "0" ] && winners=$((winners+1))
+[ "$rcRaceB" = "0" ] && winners=$((winners+1))
+raceRef=$(ref_sha 2003)
+raceRefs=$(ref_count 2003)
+adoptedLines=$(cat "$T/race-a.out" "$T/race-b.out" 2>/dev/null | grep -c 'CLAIM: ADOPTED')
+if [ "$winners" -eq 1 ] && [ "$raceRefs" = "1" ] && [ "$adoptedLines" = "1" ] && [ -n "$raceRef" ]; then
+  ok "concurrent empty-lease adopts: exactly one exit-0 ADOPTED winner, exactly one claim ref"
+else
+  fail "expected exactly one winner and one ref; got winners=$winners refs=$raceRefs adopted-lines=$adoptedLines rcA=$rcRaceA rcB=$rcRaceB
+A: $(cat "$T/race-a.out" 2>/dev/null)
+B: $(cat "$T/race-b.out" 2>/dev/null)"
+fi
+# The loser must never report success. (It reports ADOPT-LOST when it reads the
+# winner's ref, or a RETRYABLE infra ERROR if its push was rejected before the
+# winner's create landed — never ADOPTED, and never a bogus "nobody holds it" win.)
+if [ "$rcRaceA" = "0" ]; then loserOut="$T/race-b.out"; else loserOut="$T/race-a.out"; fi
+if ! grep -q 'CLAIM: ADOPTED' "$loserOut" 2>/dev/null; then
+  ok "the losing machine never printed ADOPTED"
+else
+  fail "the losing machine reported ADOPTED — double-claim:
+$(cat "$loserOut")"
+fi
+# And the surviving ref really belongs to the winner, not a torn state.
+winnerVerify=2
+if [ "$rcRaceA" = "0" ]; then runA verify 2003 >/dev/null 2>&1; winnerVerify=$?
+elif [ "$rcRaceB" = "0" ]; then runB verify 2003 >/dev/null 2>&1; winnerVerify=$?; fi
+[ "$winnerVerify" -eq 0 ] && ok "the winner verifies as the holder of the single surviving ref" \
+  || fail "the race winner does not verify as holder (rc=$winnerVerify)"
+
+# ===========================================================================
+echo "TEST 4: --expect fail-closed — empty '' is a usage error; only the literal 'none' opts into the empty lease"
+# ===========================================================================
+# An unset shell variable (`--expect \"\$sha\"` with sha unset) must NEVER silently
+# turn a compare-and-swap into a create.
+outEmpty=$(runB adopt 2004 --expect "" 2>&1); rcEmpty=$?
+noRef=$(ref_sha 2004)
+if [ "$rcEmpty" -eq 64 ] && [ -z "$noRef" ]; then
+  ok "adopt --expect '' is a usage error (exit 64) and creates nothing"
+else
+  fail "expected exit 64 and no ref for an empty --expect; got rc=$rcEmpty ref='$noRef'
+$outEmpty"
+fi
+outJunk=$(runB adopt 2004 --expect "HEAD~1" 2>&1); rcJunk=$?
+[ "$rcJunk" -eq 64 ] && ok "a non-hex, non-'none' --expect is a usage error (exit 64)" \
+  || fail "expected exit 64 for --expect HEAD~1; got rc=$rcJunk
+$outJunk"
+
+# ===========================================================================
+echo "TEST 5: adopt --expect none REQUIRES --reason (the record must say why)"
+# ===========================================================================
+outNoWhy=$(runB adopt 2005 --expect none 2>&1); rcNoWhy=$?
+noRef5=$(ref_sha 2005)
+if [ "$rcNoWhy" -eq 64 ] && [ -z "$noRef5" ] && printf '%s\n' "$outNoWhy" | grep -q -- '--reason'; then
+  ok "adopt --expect none without --reason is a usage error (exit 64), nothing acquired"
+else
+  fail "expected exit 64 demanding --reason with no ref created; got rc=$rcNoWhy ref='$noRef5'
+$outNoWhy"
+fi
+# An ALL-ZERO --expect is git's own "must not exist": same intent as `none`, so it
+# takes the same AUDITED route rather than a quiet unrecorded create. (Verified on
+# the real origin: an all-zero lease DOES create the ref.)
+ZERO=0000000000000000000000000000000000000000
+outZeroNoWhy=$(runB adopt 2005 --expect "$ZERO" 2>&1); rcZeroNoWhy=$?
+zeroRef=$(ref_sha 2005)
+if [ "$rcZeroNoWhy" -eq 64 ] && [ -z "$zeroRef" ]; then
+  ok "an all-zero --expect also demands --reason (exit 64) — no unaudited create-with-no-record"
+else
+  fail "expected exit 64 and no ref for an all-zero --expect without --reason; got rc=$rcZeroNoWhy ref='$zeroRef'
+$outZeroNoWhy"
+fi
+outZero=$(runB adopt 2005 --expect "$ZERO" --reason "all-zero lease with a recorded why"); rcZero=$?
+if [ "$rcZero" -eq 0 ] && printf '%s\n' "$outZero" | grep -q 'CLAIM: ADOPTED' && [ -n "$(ref_sha 2005)" ]; then
+  ok "an all-zero --expect WITH --reason acquires the free ref (exit 0, recorded)"
+else
+  fail "expected ADOPTED exit 0 for an all-zero --expect with --reason; got rc=$rcZero
+$outZero"
+fi
+
+# ===========================================================================
+echo "TEST 6: #2677 item 2 — a legacy-branch enumeration OUTAGE fails CLOSED (ERROR infra, exit 1), never an all-clear"
+# ===========================================================================
+# A git shim fails ONLY `ls-remote --heads` (the guard's enumeration) and passes
+# everything else through, so the claim push WOULD succeed. The old code mapped that
+# failure to "no legacy branches" and granted the claim; it must now be UNKNOWN.
+push_work_branch "issue-2006-invisible-to-the-guard"
+SHIMH="$T/shim-heads-fail"
+mkdir -p "$SHIMH"
+cat >"$SHIMH/git" <<SHIM
+#!/usr/bin/env bash
+saw_ls=0; saw_heads=0
+for a in "\$@"; do
+  [ "\$a" = "ls-remote" ] && saw_ls=1
+  [ "\$a" = "--heads" ]   && saw_heads=1
+done
+if [ "\$saw_ls" = 1 ] && [ "\$saw_heads" = 1 ]; then exit 128; fi
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMH/git"
+outOutage=$( cd "$B" && PATH="$SHIMH:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" claim 2006 2>&1 ); rcOutage=$?
+grantedRef=$(ref_sha 2006)
+if [ "$rcOutage" -eq 1 ] && printf '%s\n' "$outOutage" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outOutage" | grep -q 'infra' \
+   && ! printf '%s\n' "$outOutage" | grep -q 'CLAIM: LOST' \
+   && [ -z "$grantedRef" ]; then
+  ok "guard enumeration outage → ERROR infra exit 1, no claim ref granted (not a bogus LOST either)"
+else
+  fail "expected ERROR infra exit 1 with NO ref created; got rc=$rcOutage ref='$grantedRef'
+$outOutage"
+fi
+
+# ===========================================================================
+echo "TEST 7: no tip-based re-entrancy survives — even a claim-shaped branch tip blocks (the dead 'all-ours' hatch is gone)"
+# ===========================================================================
+# The old guard tried to exempt a branch whose TIP looked like our own claim commit.
+# That exemption is deliberately gone: branch tips are not the lock, so a tip that
+# happens to carry claim trailers must NOT grant a claim. The resume is explicit.
+push_work_branch "issue-2007-tip-looks-like-a-claim" \
+  "claim issue=2007 machine=machineB pid=1 actor=flow ts=2026-07-26T00:00:00Z nonce=x"
+( cd "$B" && g fetch -q origin )
+outTip=$(runB claim 2007); rcTip=$?
+tipRef=$(ref_sha 2007)
+if [ "$rcTip" -eq 2 ] && printf '%s\n' "$outTip" | grep -q 'reason=legacy-branch-lock' && [ -z "$tipRef" ]; then
+  ok "a claim-shaped branch tip does not grant a claim — the guard blocks and points at the resume command"
+else
+  fail "expected legacy-branch-lock refusal exit 2 with no ref; got rc=$rcTip ref='$tipRef'
+$outTip"
+fi
+
+# ===========================================================================
+echo "TEST 8: unchanged happy path — free ref, no legacy branch → plain claim still wins"
+# ===========================================================================
+outPlain=$(runA claim 2008); rcPlain=$?
+plainRef=$(ref_sha 2008)
+if [ "$rcPlain" -eq 0 ] && printf '%s\n' "$outPlain" | grep -q 'CLAIM: HELD' && [ -n "$plainRef" ]; then
+  ok "a normal claim (no legacy branch) is unaffected by the guard rework"
+else
+  fail "expected CLAIM: HELD exit 0; got rc=$rcPlain ref='$plainRef'
+$outPlain"
+fi
+
+echo ""
+echo "================  claim-resume (#2945): $PASS passed, $FAIL failed  ================"
+[ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -133,9 +133,14 @@ accepted_olds()    { awk -v r="refs/claims/issue-$1" '$1==r {print $2}' "$HOOKLO
 # test the RECORD, not a verbatim rendering of the whole line.
 line_field() { printf '%s' "$1" | tr ' ' '\n' | grep -m1 "^$2=" | sed "s/^$2=//"; }
 
-# push_work_branch <branch> [msg] [tip-date] — an ORDINARY work branch on origin: cut
-# from main, an ordinary commit on top. Its tip carries NO claim trailers, which is
-# exactly why the old tip-based re-entrancy could never fire.
+# --- THE TWO WORK-BRANCH PREMISES ------------------------------------------
+# The name of each fixture states which premise a test encodes, because the liveness
+# gate treats them DIFFERENTLY and the difference is the whole point of TEST 17: a tip
+# with own commits is AGE-JUDGEABLE, a tip without any is INDETERMINATE.
+#
+# push_branch_with_own_commit <branch> [msg] [tip-date] — an ORDINARY work branch on
+# origin: cut from main, WITH an ordinary commit of its own on top. Its tip carries NO
+# claim trailers, which is exactly why the old tip-based re-entrancy could never fire.
 #
 # <tip-date> is the tip's committer date and DEFAULTS TO A LONG-STALE FIXED DATE,
 # because the refusal now only advertises the resume hatch for a branch whose tip is
@@ -143,7 +148,7 @@ line_field() { printf '%s' "$1" | tr ' ' '\n' | grep -m1 "^$2=" | sed "s/^$2=//"
 # mid-implementation, which has no open PR yet either). A fixed literal date keeps the
 # fixture deterministic — no wall-clock arithmetic in an assertion.
 STALE_TIP_DATE='2020-03-01T12:00:00Z'
-push_work_branch() {
+push_branch_with_own_commit() {
   local branch="$1" msg="${2:-ordinary work commit}" when="${3:-$STALE_TIP_DATE}"
   (
     cd "$A" || exit 1
@@ -155,10 +160,51 @@ push_work_branch() {
   )
 }
 
-# push_machine_claim <ref> <issue> <ts> — a supervisor-authored liveness ref
+# push_branch_without_own_commits <branch> — THE PRODUCTION SHAPE AT ACTIVATION TIME:
+# `flow-activate` runs `git worktree add -b issue-<N>-<slug> origin/main` and pushes the
+# branch immediately, so the tip IS origin/main's tip and the branch has no commits of
+# its own until PR time. Its committer date is therefore main's, not the worker's — the
+# premise under which the tip-age liveness signal is VACUOUS (#2945 round 5).
+push_branch_without_own_commits() {
+  local branch="$1"
+  (
+    cd "$A" || exit 1
+    g fetch -q origin
+    g push -q origin "refs/remotes/origin/main:refs/heads/$branch"
+  )
+}
+
+# advance_main_with_stale_tip — move origin's DEFAULT branch to a long-stale-dated tip,
+# i.e. "main has been quiet longer than the reap threshold" (overnight is routine). This
+# is what made the vacuous tip-age signal dangerous: a commit-less branch inherits that
+# date and reads as reapable. Called once, by TEST 17.
+advance_main_with_stale_tip() {
+  (
+    cd "$A" || exit 1
+    g fetch -q origin
+    g checkout -q main
+    g reset -q --hard origin/main
+    GIT_AUTHOR_DATE="$STALE_TIP_DATE" GIT_COMMITTER_DATE="$STALE_TIP_DATE" \
+      g commit -q --allow-empty -m "main has been quiet since $STALE_TIP_DATE"
+    g push -q origin main
+  )
+}
+
+# push_machine_claim <ref> <issue> <ts> — a supervisor-authored liveness ref;
+# push_raw_liveness_ref <ref> <msg> — the same NAMESPACE with an arbitrary (legacy) message.
 # (`refs/machine-claims/<machine>` / `refs/heartbeats/<machine>`, #2655) naming
 # <issue>, with <ts> as its recorded timestamp. Same root-commit shape
 # claim-heartbeat.sh writes, so claim.sh's liveness scan reads a REAL ref, not a mock.
+push_raw_liveness_ref() {
+  local ref="$1" msg="$2"
+  (
+    cd "$A" || exit 1
+    local tree commit
+    tree=$(g hash-object -t tree --stdin </dev/null)
+    commit=$(g commit-tree "$tree" -m "$msg")
+    g push -q --force origin "${commit}:${ref}"
+  )
+}
 push_machine_claim() {
   local ref="$1" issue="$2" ts="$3"
   (
@@ -231,7 +277,7 @@ read_ns() {
 # ===========================================================================
 echo "TEST 1: FREE claim ref + foreign-tip issue-<N>-* branch — claim refuses WITH the remediation, adopt --expect none SUCCEEDS"
 # ===========================================================================
-push_work_branch "issue-2001-owner-approved-spec" "docs(#2001): OpenSpec change approved by owner"
+push_branch_with_own_commit "issue-2001-owner-approved-spec" "docs(#2001): OpenSpec change approved by owner"
 ( cd "$B" && g fetch -q origin )
 [ -z "$(ref_sha 2001)" ] && ok "precondition: refs/claims/issue-2001 is FREE" \
   || fail "precondition broken: a claim ref already exists for 2001"
@@ -332,7 +378,7 @@ fi
 # ===========================================================================
 echo "TEST 2: HELD claim ref + branch present — the resume path is still REFUSED (exit 2, holder keeps it)"
 # ===========================================================================
-push_work_branch "issue-2002-active-effort"
+push_branch_with_own_commit "issue-2002-active-effort"
 ( cd "$B" && g fetch -q origin )
 runA claim 2002 >/dev/null 2>&1   # blocked by the branch guard, so take it via the resume path
 runA adopt 2002 --expect none --reason "machineA is actively working this" >/dev/null 2>&1; rcHold=$?
@@ -378,19 +424,20 @@ echo "TEST 3: two machines RACE the resume path — exactly one SERVER-ACCEPTED 
 # under full serialization, so without this witness a barrier regression is invisible —
 # which is exactly how a non-racing barrier survived two reviews.
 #
-# WHY A MAJORITY AND NOT ALL 5: overlap is derived from PROCESS SCHEDULING, and this
-# suite is a gate-of-record component that runs alongside a parallel component pool. One
-# racer can be descheduled long enough for its window to miss the other's, which is a
-# scheduling fact, not a defect — an all-5 requirement makes the gate red for no bug
-# (#2945 review). A majority still kills the regression it exists for: a barrier that
-# serializes the racers yields ZERO overlapping rounds (measured — see the mutation note
-# in this file's header), nowhere near 3/5. Non-overlapping rounds are printed as
-# diagnostics so a drift toward 3/5 is visible before it becomes a failure.
+# WHY >=1 ROUND AND NOT ALL 5 (NOR A MAJORITY): overlap is derived from PROCESS
+# SCHEDULING, and this suite is a gate-of-record component that runs alongside a parallel
+# component pool (and on macOS CI). A racer can be descheduled long enough for its window
+# to miss the other's, which is a scheduling fact, not a defect — a fatal all-5 or
+# majority threshold makes the gate red for no bug (#2945 review). >=1 still kills the
+# regression the witness exists for, because a serializing barrier fails STRUCTURALLY:
+# it yields ZERO overlapping rounds, never one (measured — see the mutation note in this
+# file's header). EVERY non-overlapping round is still printed as a diagnostic, so a
+# drift from 5/5 toward 1/5 stays visible long before it becomes a failure.
 raceRounds=0; raceOk=0; raceAtomic=0; raceLoser=0; raceWinnerVerified=0; raceDiag=""
 raceOverlapped=0; ovMin=""; ovMax=""; ovDiag=""
 for id in 2101 2102 2103 2104 2105; do
   raceRounds=$((raceRounds+1))
-  push_work_branch "issue-${id}-resumable"
+  push_branch_with_own_commit "issue-${id}-resumable"
   ( cd "$B" && g fetch -q origin )
   race_reset
   ( race_wait_go "$T/ready-a"
@@ -495,15 +542,16 @@ done
 # this host — a loud SKIP of the WITNESS ONLY (the invariants above already asserted),
 # never a failure and never a silent omission.
 [ -n "$ovDiag" ] && diag "concurrency witness, non-overlapping rounds:$ovDiag"
-ovNeeded=$((raceRounds / 2 + 1))
+ovNeeded=1
+diag "concurrency witness: $raceOverlapped/$raceRounds rounds overlapped (fatal below >=$ovNeeded)"
 if [ "$NS_IMPL" = none ]; then
   skip "no hi-res clock (date %N / perl Time::HiRes / python3) — the racers' overlap could not be MEASURED on this host; the race invariants above still ran"
 else
   ok "hi-res clock available to witness concurrency (NS_IMPL=$NS_IMPL)"
   if [ "$raceOverlapped" -ge "$ovNeeded" ]; then
-    ok "the two racers' adopt windows OVERLAP in a majority of rounds ($raceOverlapped/$raceRounds, need >=$ovNeeded; overlap min=$((${ovMin:-0} / 1000000))ms max=$((${ovMax:-0} / 1000000))ms, min=${ovMin:-0}ns) — they really ran concurrently"
+    ok "the two racers' adopt windows OVERLAP in at least one round ($raceOverlapped/$raceRounds, need >=$ovNeeded; overlap min=$((${ovMin:-0} / 1000000))ms max=$((${ovMax:-0} / 1000000))ms, min=${ovMin:-0}ns) — they really ran concurrently"
   else
-    fail "only $raceOverlapped/$raceRounds rounds had overlapping adopt windows (need >=$ovNeeded) — the barrier serialized the racers$ovDiag"
+    fail "NO round ($raceOverlapped/$raceRounds) had overlapping adopt windows (need >=$ovNeeded) — a serializing barrier is the only thing that produces zero$ovDiag"
   fi
 fi
 
@@ -604,7 +652,7 @@ echo "TEST 6: #2677 item 2 — a legacy-branch enumeration OUTAGE fails CLOSED (
 # A git shim fails ONLY `ls-remote --heads` (the guard's enumeration) and passes
 # everything else through, so the claim push WOULD succeed. The old code mapped that
 # failure to "no legacy branches" and granted the claim; it must now be UNKNOWN.
-push_work_branch "issue-2006-invisible-to-the-guard"
+push_branch_with_own_commit "issue-2006-invisible-to-the-guard"
 SHIMH="$T/shim-heads-fail"
 mkdir -p "$SHIMH"
 cat >"$SHIMH/git" <<SHIM
@@ -636,7 +684,7 @@ echo "TEST 7: no tip-based re-entrancy survives — even a claim-shaped branch t
 # The old guard tried to exempt a branch whose TIP looked like our own claim commit.
 # That exemption is deliberately gone: branch tips are not the lock, so a tip that
 # happens to carry claim trailers must NOT grant a claim. The resume is explicit.
-push_work_branch "issue-2007-tip-looks-like-a-claim" \
+push_branch_with_own_commit "issue-2007-tip-looks-like-a-claim" \
   "claim issue=2007 machine=machineB pid=1 actor=flow ts=2026-07-26T00:00:00Z nonce=x"
 ( cd "$B" && g fetch -q origin )
 outTip=$(runB_gh claim 2007); rcTip=$?
@@ -753,6 +801,23 @@ if [ "$rcCasReent" -eq 0 ] && printf '%s\n' "$outCasReent" | grep -q 'CLAIM: ADO
 else
   fail "expected a lease-mismatch re-entrant ADOPTED naming expected=$STALE and actual=$heldSha10; got rc=$rcCasReent ref='$(ref_sha 2010)' updates=$(accepted_updates 2010)
 $outCasReent"
+fi
+# …but the mismatch wording is reserved for a GENUINE divergence (#2945 review). A CAS
+# from the ref's CURRENT sha whose push does not land (the push-fail shim from TEST 9)
+# leaves expected == actual: the precondition DID hold, so `lease-mismatch expected=X
+# actual=X` named a divergence that never happened. It must be the plain re-entrant
+# verdict instead.
+outCasSame=$( cd "$B" && PATH="$SHIMP:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" adopt 2010 --expect "$heldSha10" --reason "cas retry from the ref's current sha" 2>&1 ); rcCasSame=$?
+if [ "$rcCasSame" -eq 0 ] && printf '%s\n' "$outCasSame" | grep -q 'CLAIM: ADOPTED' \
+   && printf '%s\n' "$outCasSame" | grep -q 're-entrant' \
+   && ! printf '%s\n' "$outCasSame" | grep -q 'lease-mismatch' \
+   && printf '%s\n' "$outCasSame" | grep -q "from=$heldSha10" \
+   && [ "$(ref_sha 2010)" = "$heldSha10" ] && [ "$(accepted_updates 2010)" = "1" ]; then
+  ok "a CAS whose expected == actual reports the PLAIN re-entrant verdict — no 'lease-mismatch expected=X actual=X'"
+else
+  fail "expected a plain re-entrant ADOPTED (no lease-mismatch) when expected == actual; got rc=$rcCasSame ref='$(ref_sha 2010)' updates=$(accepted_updates 2010)
+$outCasSame"
 fi
 if printf '%s\n' "$outRetry" | grep -q 'from=none' && ! printf '%s\n' "$outRetry" | grep -q 'lease-mismatch'; then
   ok "the EMPTY-lease re-entrant verdict stays distinct (from=none, no lease-mismatch marker)"
@@ -977,7 +1042,7 @@ echo "TEST 15: the escape hatch is advertised ONLY when the endgame is demonstra
 # command is printed only at open-prs=0, and an unreadable PR list withholds too.
 # The fixture tip is LONG STALE (the default), so the PR signal is the ONLY thing that
 # can withhold here — the tip-age/liveness signals are pinned separately in TEST 16.
-push_work_branch "issue-2015-live-endgame"
+push_branch_with_own_commit "issue-2015-live-endgame"
 ( cd "$B" && g fetch -q origin )
 PRSHIM="$T/shim-gh-open-pr"
 mkdir -p "$PRSHIM"
@@ -1039,7 +1104,7 @@ echo "TEST 16: the PRE-PR window — a FRESH branch tip or a fresh liveness ref 
 # refs — and every unreadable signal withholds.
 
 # (a) FRESH tip, no open PR: a worker mid-implementation. The hatch must be WITHHELD.
-push_work_branch "issue-2016-being-worked-right-now" "wip commit" "$(now_ts)"
+push_branch_with_own_commit "issue-2016-being-worked-right-now" "wip commit" "$(now_ts)"
 ( cd "$B" && g fetch -q origin )
 outFresh=$(runB_gh claim 2016); rcFresh=$?
 if [ "$rcFresh" -eq 2 ] && printf '%s\n' "$outFresh" | grep -q 'remediation=withheld' \
@@ -1056,7 +1121,7 @@ fi
 # (b) STALE tip, no open PR, no liveness ref: demonstrably orphaned → advertised. And
 # the printed command, run VERBATIM (which is what the readers do), must record an
 # INFORMATIVE reason — not the `why` a `--reason <why>` placeholder would have recorded.
-push_work_branch "issue-2017-abandoned-lane"
+push_branch_with_own_commit "issue-2017-abandoned-lane"
 ( cd "$B" && g fetch -q origin )
 outAdv=$(runB_gh claim 2017); rcAdv=$?
 if [ "$rcAdv" -eq 2 ] && printf '%s\n' "$outAdv" | grep -q "adopt 2017 --expect none --reason resume-legacy-branch-lock:issue-2017-abandoned-lane" \
@@ -1084,7 +1149,7 @@ fi
 
 # (c) STALE tip but a FRESH machine-claim ref naming the issue: a supervisor says a
 # worker is on it (#2655), so the hatch is WITHHELD even though the tip aged out.
-push_work_branch "issue-2018-stale-branch-live-worker"
+push_branch_with_own_commit "issue-2018-stale-branch-live-worker"
 push_machine_claim "refs/machine-claims/machineFresh" 2018 "$(now_ts)"
 ( cd "$B" && g fetch -q origin )
 outLiveRef=$(runB_gh claim 2018); rcLiveRef=$?
@@ -1099,7 +1164,7 @@ fi
 
 # (d) …and a liveness ref older than the threshold does NOT withhold forever: it is
 # itself reapable, so an abandoned heartbeat must not lock the lane out permanently.
-push_work_branch "issue-2019-stale-branch-stale-heartbeat"
+push_branch_with_own_commit "issue-2019-stale-branch-stale-heartbeat"
 push_machine_claim "refs/heartbeats/machineStale" 2019 "$STALE_TIP_DATE"
 ( cd "$B" && g fetch -q origin )
 outStaleRef=$(runB_gh claim 2019); rcStaleRef=$?
@@ -1114,7 +1179,7 @@ fi
 # (e) UNREADABLE threshold (claim.sh without its claim-heartbeat.sh sibling): the lane
 # cannot be shown orphaned, so the hatch is withheld rather than defaulting to some
 # second copy of "4h".
-push_work_branch "issue-2020-threshold-unreadable"
+push_branch_with_own_commit "issue-2020-threshold-unreadable"
 ( cd "$B" && g fetch -q origin )
 LONE="$T/lone-claim"
 mkdir -p "$LONE"
@@ -1132,7 +1197,7 @@ fi
 
 # (f) UNREADABLE liveness refs (a git shim fails ONLY the machine-claims enumeration,
 # everything else passes through): "we could not prove nobody is on it" withholds.
-push_work_branch "issue-2021-liveness-enumeration-outage"
+push_branch_with_own_commit "issue-2021-liveness-enumeration-outage"
 ( cd "$B" && g fetch -q origin )
 SHIML="$T/shim-liveness-fail"
 mkdir -p "$SHIML"
@@ -1167,6 +1232,96 @@ if [ "$rcDeliberate" -eq 0 ] && printf '%s\n' "$outDeliberate" | grep -q 'CLAIM:
 else
   fail "expected the deliberate resume of a withheld lane to still succeed; got rc=$rcDeliberate
 $outDeliberate"
+fi
+
+# ===========================================================================
+echo "TEST 17: a branch with NO COMMITS OF ITS OWN is INDETERMINATE, never 'stale' — the vacuous tip-age case"
+# ===========================================================================
+# THE PRODUCTION PREMISE THE OTHER FIXTURES MISS (#2945 round 5). Every fixture above
+# uses push_branch_with_own_commit, so its tip has a date of its own. `flow-activate`
+# does NOT: it creates the branch at origin/main and pushes it with no commits, and
+# `flow-implement` pushes again only at PR time. So for a freshly-activated lane the
+# tip's committer date IS main's — zero information about the worker. Whenever main had
+# been quiet longer than the threshold (overnight is routine), that lane presented as
+# open-prs=0 + a stale tip + no liveness refs, and the guard printed the copy-pasteable
+# hand-away FOR AN ACTIVELY-WORKED ISSUE — the two-writer outcome it exists to prevent.
+# So: no own commits => no age signal => remediation WITHHELD, with its own marker.
+advance_main_with_stale_tip
+
+# (a) The vacuous case: commit-less branch, main quiet since 2020, no liveness refs.
+push_branch_without_own_commits "issue-2060-just-activated-no-commits"
+( cd "$B" && g fetch -q origin )
+outVacuous=$(runB_gh claim 2060); rcVacuous=$?
+if [ "$rcVacuous" -eq 2 ] && printf '%s\n' "$outVacuous" | grep -q 'remediation=withheld' \
+   && printf '%s\n' "$outVacuous" | grep -q 'newest-branch-tip=no-own-commits' \
+   && ! printf '%s\n' "$outVacuous" | grep -q 'stale-after=' \
+   && ! printf '%s\n' "$outVacuous" | grep -q 'adopt 2060 --expect none' \
+   && [ "$(printf '%s\n' "$outVacuous" | grep -c 'CLAIM:')" = "1" ]; then
+  ok "a commit-less branch on a LONG-QUIET main withholds the hatch (newest-branch-tip=no-own-commits, no age verdict)"
+else
+  fail "expected the hatch withheld as no-own-commits; got rc=$rcVacuous
+$outVacuous"
+fi
+
+# (b) THE MOTIVATING CASES STILL WORK. #2043 and #1883 each carried their own
+# OpenSpec spec commit, so their tips ARE informative and genuinely old — on the very
+# same long-quiet main, such a branch must still be advertised.
+push_branch_with_own_commit "issue-2061-abandoned-with-its-own-commit"
+( cd "$B" && g fetch -q origin )
+outOwn=$(runB_gh claim 2061); rcOwn=$?
+if [ "$rcOwn" -eq 2 ] && printf '%s\n' "$outOwn" | grep -q 'adopt 2061 --expect none --reason resume-legacy-branch-lock:' \
+   && printf '%s\n' "$outOwn" | grep -q 'newest-branch-tip=' \
+   && printf '%s\n' "$outOwn" | grep -q 'stale-after=' \
+   && ! printf '%s\n' "$outOwn" | grep -q 'no-own-commits'; then
+  ok "a branch carrying its OWN stale commit is still age-judged and still advertises (the #2043/#1883 shape)"
+else
+  fail "expected the hatch advertised for a stale branch with its own commit; got rc=$rcOwn
+$outOwn"
+fi
+
+# (c) …and the new signal opens NO unreadable-signal hole: when the base (origin's
+# default branch) cannot be read, the ancestry test cannot be run, so the tip cannot be
+# judged either way — withhold, never "it must carry own commits".
+push_branch_with_own_commit "issue-2062-base-unreadable"
+( cd "$B" && g fetch -q origin )
+SHIMB="$T/shim-base-fetch-fail"
+mkdir -p "$SHIMB"
+cat >"$SHIMB/git" <<SHIM
+#!/usr/bin/env bash
+saw_fetch=0; saw_base=0
+for a in "\$@"; do
+  [ "\$a" = "fetch" ] && saw_fetch=1
+  case "\$a" in +HEAD:*) saw_base=1 ;; esac
+done
+if [ "\$saw_fetch" = 1 ] && [ "\$saw_base" = 1 ]; then exit 128; fi
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMB/git"
+outNoBase=$( cd "$B" && PATH="$SHIMB:$GHSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" claim 2062 2>/dev/null ); rcNoBase=$?
+if [ "$rcNoBase" -eq 2 ] && printf '%s\n' "$outNoBase" | grep -q 'remediation=withheld' \
+   && printf '%s\n' "$outNoBase" | grep -q 'default-branch-tip=unreadable' \
+   && ! printf '%s\n' "$outNoBase" | grep -q 'adopt 2062 --expect none'; then
+  ok "an UNREADABLE default-branch tip withholds the hatch (the ancestry test is a signal, so it fails closed too)"
+else
+  fail "expected the hatch withheld on an unreadable base; got rc=$rcNoBase
+$outNoBase"
+fi
+
+# (d) The liveness-ref scan is SCOPED TO THIS ISSUE: a readable LEGACY ref in the
+# namespace that names NO issue used to withhold the hatch fleet-wide, for EVERY issue —
+# the permanent dead end this change removes. It must be skipped, not withheld.
+push_raw_liveness_ref "refs/heartbeats/machineLegacyFormat" "heartbeat machine=machineLegacy pid=7 at=whenever"
+push_branch_with_own_commit "issue-2063-legacy-liveness-ref-present"
+( cd "$B" && g fetch -q origin )
+outLegacyRef=$(runB_gh claim 2063); rcLegacyRef=$?
+if [ "$rcLegacyRef" -eq 2 ] && printf '%s\n' "$outLegacyRef" | grep -q 'adopt 2063 --expect none --reason resume-legacy-branch-lock:' \
+   && printf '%s\n' "$outLegacyRef" | grep -q 'liveness-refs=none-naming-2063' \
+   && ! printf '%s\n' "$outLegacyRef" | grep -q 'liveness-refs=unreadable'; then
+  ok "a LEGACY liveness ref naming no issue does not withhold another issue's hatch (the scan is issue-scoped)"
+else
+  fail "expected an issue-scoped liveness scan to still advertise; got rc=$rcLegacyRef
+$outLegacyRef"
 fi
 
 echo ""

--- a/scripts/flow/tests/claim-resume.test.sh
+++ b/scripts/flow/tests/claim-resume.test.sh
@@ -11,14 +11,34 @@
 #
 # These tests pin the sanctioned replacement: `adopt <N> --expect none --reason <why>`
 # (git's EMPTY LEASE = "the ref must not exist"), the safety direction (a HELD ref
-# still refuses), a REAL two-machine race on that path (git arbitrates, exactly one
-# winner), and the guard's fail-CLOSED behaviour on an enumeration outage
-# (#2677 item 2 — an outage must never read as "no legacy branch").
+# still refuses), its RE-ENTRANCY (a retry after a confirm blip must not abandon an
+# issue we hold), a REAL two-machine race on that path, the guard's fail-CLOSED
+# behaviour on an enumeration outage (#2677 item 2), and the IDENTITY-FORGERY
+# hardening of the two user-controlled fields (--reason, --actor) that land in the
+# very commit message the holder-identity parser reads.
+#
+# WRITES ARE WITNESSED, NOT INFERRED: a `post-receive` hook on the bare origin logs
+# every ACCEPTED ref update ("<ref> <old> <new>"), so tests assert how many writes
+# the SERVER applied and from what old value. Counting refs afterwards cannot do
+# that — an exact ref is structurally <=1, and every claimant reads its verdict back
+# AFTER all the pushes, so last-writer-wins satisfies a ref count.
+#
+# WHERE THE EMPTY LEASE IS ACTUALLY PROVEN (measured, mutation-verified):
+# replacing `--force-with-lease=<ref>:` with a plain `git push --force` is caught
+# DETERMINISTICALLY by TEST 2/TEST 10 (a second claimant whose ref advertisement is
+# FRESH — it saw the holder's ref — sends that sha as the update's old value, so
+# --force overwrites it: the hook log shows TWO applied updates and the holder loses
+# its claim). It is NOT reliably caught by the concurrent race in TEST 3: when both
+# claimants' advertisements say "absent", each sends an all-zero old value and git's
+# own protocol-level stale-info check rejects the second push regardless of the
+# lease. So TEST 3 pins the CONCURRENCY invariants (exactly one winner, exactly one
+# accepted create, the loser fails loudly) and TEST 2/10 are the LEASE oracle — do
+# not "simplify" either one into the other.
 #
 # Fast + hermetic: a mktemp BARE repo stands in for origin plus two clones playing
-# machines A and B (each overriding CLAIM_MACHINE). No network, no GitHub, no gh
-# (neither `claim` nor `adopt` uses it). No wall-clock assertions — every verdict is
-# a git-ref state or an exit code.
+# machines A and B (each overriding CLAIM_MACHINE). No network, no GitHub; `gh` is
+# stubbed only where `release` consults it. No wall-clock assertions — every verdict
+# is a git-ref state, a receive-hook record, or an exit code.
 #
 # Run standalone:  bash scripts/flow/tests/claim-resume.test.sh
 #
@@ -26,7 +46,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAIM="$SCRIPT_DIR/../claim.sh"
-REALGIT="$(command -v git)"   # absolute git, for the ls-remote shim in TEST 6
+REALGIT="$(command -v git)"   # absolute git, for the shims in TESTS 6/9/10
 
 PASS=0
 FAIL=0
@@ -42,7 +62,22 @@ trap 'rm -rf "$T"' EXIT
 ORIGIN="$T/origin.git"
 A="$T/A"
 B="$T/B"
+HOOKLOG="$T/accepted-updates.log"
+ZEROS=0000000000000000000000000000000000000000
 g init --bare -q "$ORIGIN"
+
+# post-receive fires ONLY for ref updates the remote actually APPLIED, so this log
+# is ground truth for "how many writes did the server accept, and from what old
+# value" — the property a race test must assert.
+cat >"$ORIGIN/hooks/post-receive" <<HOOK
+#!/usr/bin/env bash
+while read -r old new ref; do
+  printf '%s %s %s\n' "\$ref" "\$old" "\$new" >>"$HOOKLOG"
+done
+HOOK
+chmod +x "$ORIGIN/hooks/post-receive"
+: >"$HOOKLOG"
+
 g clone -q "$ORIGIN" "$A" 2>/dev/null
 g clone -q "$ORIGIN" "$B" 2>/dev/null
 (
@@ -54,14 +89,41 @@ g clone -q "$ORIGIN" "$B" 2>/dev/null
 )
 ( cd "$B" && g fetch -q origin )
 
+# `gh` stub: `release` (without --force) refuses when it cannot check for an open
+# PR, and the real gh cannot talk to a local bare repo. The stub answers "no open
+# PRs" so the holder-release round trip is exercised, not the gh-missing branch
+# (which test_claim_lock.sh already covers).
+GHSHIM="$T/shim-gh"
+mkdir -p "$GHSHIM"
+cat >"$GHSHIM/gh" <<'GH'
+#!/usr/bin/env bash
+for a in "$@"; do [ "$a" = "list" ] && exit 0; done
+exit 1
+GH
+chmod +x "$GHSHIM/gh"
+
 # runA/runB — claim.sh from clone A/B as a distinct machine. The function EXIT CODE
 # is claim.sh's, so callers use `out=$(runA ...); rc=$?`.
 runA() { ( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" "$@" ); }
 runB() { ( cd "$B" && CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" "$@" ); }
+# …with the gh stub on PATH (release only).
+runA_gh() { ( cd "$A" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" "$@" ); }
+runB_gh() { ( cd "$B" && PATH="$GHSHIM:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin bash "$CLAIM" "$@" ); }
 
 ref_sha()      { g -C "$A" ls-remote origin "refs/claims/issue-$1" | awk '{print $1}' | head -1; }
 ref_count()    { g -C "$A" ls-remote origin "refs/claims/issue-$1" | wc -l | tr -d ' '; }
 branch_exists() { [ -n "$(g -C "$A" ls-remote --heads origin "$1" | awk '{print $1}')" ]; }
+
+# accepted_updates <issue> — how many ref updates the SERVER applied to this claim
+# ref (from the post-receive log).
+accepted_updates() { grep -c "^refs/claims/issue-$1 " "$HOOKLOG" 2>/dev/null || true; }
+# accepted_olds <issue> — the OLD value of each applied update (a create is all-zeros).
+accepted_olds()    { awk -v r="refs/claims/issue-$1" '$1==r {print $2}' "$HOOKLOG" 2>/dev/null; }
+
+# line_field <line> <key> — pull `<key>=<value>` out of a CLAIM: line using the same
+# exact-key/first-match token semantics claim.sh's own msg_field uses, so assertions
+# test the RECORD, not a verbatim rendering of the whole line.
+line_field() { printf '%s' "$1" | tr ' ' '\n' | grep -m1 "^$2=" | sed "s/^$2=//"; }
 
 # push_work_branch <branch> [msg] — an ORDINARY work branch on origin: cut from
 # main, an ordinary commit on top. Its tip carries NO claim trailers, which is
@@ -117,6 +179,12 @@ else
   fail "expected ADOPTED exit 0 with a ref; got rc=$rcAdopt ref='$adoptSha'
 $outAdopt"
 fi
+# The server applied exactly ONE update, and it was a CREATE (old = all-zeros).
+if [ "$(accepted_updates 2001)" = "1" ] && [ "$(accepted_olds 2001)" = "$ZEROS" ]; then
+  ok "the resume was a single server-accepted CREATE (old=all-zeros), not an overwrite"
+else
+  fail "expected 1 accepted create for issue-2001; got $(accepted_updates 2001) update(s), olds='$(accepted_olds 2001)'"
+fi
 runB verify 2001 >/dev/null 2>&1; rcVerify=$?
 [ "$rcVerify" -eq 0 ] && ok "the adopter now VERIFIES as holder (exit 0)" \
   || fail "expected verify exit 0 for the adopter, got $rcVerify"
@@ -127,19 +195,48 @@ branch_exists "issue-2001-owner-approved-spec" \
   && ok "the resumed work branch is left untouched on origin" \
   || fail "the resume path deleted/moved the work branch"
 
-# Criterion 1: the command records WHO took it and WHY.
+# Criterion 1: the command records WHO took it and WHY. Assert PROPERTIES of the
+# record (it re-extracts as one whitespace-free token that still carries the
+# operator's words), not a verbatim sanitized string — a format-coupled literal
+# would break on any future sanitizer tweak without any behaviour regressing.
 statusOut=$( cd "$B" && CLAIM_MACHINE=machineB bash "$CLAIM" status 2001 )
-if printf '%s\n' "$statusOut" | grep -q 'machine=machineB' \
-   && printf '%s\n' "$statusOut" | grep -q 'reason=resume-of-#1883:-owner-approved-OpenSpec-change-lives-on-the-branch'; then
-  ok "the claim record carries who (machine=machineB) AND why (sanitized one-token reason)"
+statusMachine=$(line_field "$statusOut" machine)
+statusReason=$(line_field "$statusOut" reason)
+if [ "$statusMachine" = "machineB" ] && [ -n "$statusReason" ] \
+   && [ "$statusReason" = "${statusReason%%[[:space:]]*}" ] \
+   && printf '%s' "$statusReason" | grep -q 'resume' \
+   && printf '%s' "$statusReason" | grep -q '1883'; then
+  ok "the record round-trips as who=machineB + a single whitespace-free reason token carrying the operator's words"
 else
-  fail "claim record missing holder and/or reason:
+  fail "claim record missing holder and/or a well-formed reason (machine='$statusMachine' reason='$statusReason'):
 $statusOut"
 fi
-[ "$(printf '%s\n' "$statusOut" | grep -c 'CLAIM: STATUS')" = "1" ] \
-  && ok "a multi-word reason stays ONE parseable status line" \
-  || fail "reason sanitization leaked whitespace into the record:
+if [ "$(printf '%s\n' "$statusOut" | grep -c 'CLAIM: STATUS issue=2001 ')" = "1" ] \
+   && printf '%s\n' "$statusOut" | grep -q 'reason='; then
+  ok "a multi-word reason stays ONE parseable status ROW that still reports reason="
+else
+  fail "reason sanitization leaked whitespace into the record (or the row lost reason=):
 $statusOut"
+fi
+
+# Round trip: a resume-adopted claim must be RELEASABLE by its holder. `release`
+# (no --force) is holder-gated AND CAS-deleted, so if the resume record ever broke
+# identity parsing the issue would be permanently unreleasable.
+outRelease=$(runB_gh release 2001); rcRelease=$?
+if [ "$rcRelease" -eq 0 ] && printf '%s\n' "$outRelease" | grep -q 'CLAIM: RELEASED' \
+   && [ -z "$(ref_sha 2001)" ]; then
+  ok "the resume-adopted claim releases cleanly by its holder (exit 0, ref gone)"
+else
+  fail "expected RELEASED exit 0 with the ref gone; got rc=$rcRelease ref='$(ref_sha 2001)'
+$outRelease"
+fi
+outAfter=$(runA claim 2001); rcAfter=$?
+if [ "$rcAfter" -eq 2 ] && printf '%s\n' "$outAfter" | grep -q 'reason=legacy-branch-lock'; then
+  ok "after the release the surviving work branch still guards a plain claim (exit 2)"
+else
+  fail "expected the branch guard to still refuse a plain claim; got rc=$rcAfter
+$outAfter"
+fi
 
 # ===========================================================================
 echo "TEST 2: HELD claim ref + branch present — the resume path is still REFUSED (exit 2, holder keeps it)"
@@ -162,67 +259,115 @@ else
   fail "expected ADOPT-LOST exit 2 with the ref intact; got rc=$rcSteal held=$heldSha now=$stillSha
 $outSteal"
 fi
+# THE lease oracle (see the header): machineB's advertisement SAW the holder's ref,
+# so its push carries that sha as the update's old value. `--force-with-lease=<ref>:`
+# demands all-zeros → the server refuses and applies NOTHING. A plain `--force`
+# would be ACCEPTED here, giving two applied updates and evicting the holder — which
+# is exactly how this assertion kills that mutant, deterministically.
+if [ "$(accepted_updates 2002)" = "1" ] && [ "$(accepted_olds 2002)" = "$ZEROS" ]; then
+  ok "the refused resume produced NO server-accepted write (still exactly one applied update: the holder's create)"
+else
+  fail "expected exactly 1 applied create for issue-2002; got $(accepted_updates 2002) update(s), olds='$(accepted_olds 2002)'"
+fi
 runA verify 2002 >/dev/null 2>&1; rcHolderStill=$?
 [ "$rcHolderStill" -eq 0 ] && ok "the original holder still verifies after the refused attempt" \
   || fail "holder lost its claim to a refused resume (verify rc=$rcHolderStill)"
 
 # ===========================================================================
-echo "TEST 3: two machines RACE the resume path — exactly one winner (git arbitrates)"
+echo "TEST 3: two machines RACE the resume path — exactly one SERVER-ACCEPTED create (git arbitrates), 5 rounds"
 # ===========================================================================
-push_work_branch "issue-2003-resumable"
-( cd "$B" && g fetch -q origin )
 # Real competing pushes: both machines are released from a FIFO barrier and run the
 # empty-lease adopt concurrently against the same origin. Nothing is mocked — the
-# remote's ref update is the arbiter.
-mkfifo "$T/gate-a" "$T/gate-b"
-( head -1 <"$T/gate-a" >/dev/null 2>&1
-  runA adopt 2003 --expect none --reason "racing machineA" >"$T/race-a.out" 2>&1
-  echo "$?" >"$T/race-a.rc" ) &
-pidA=$!
-( head -1 <"$T/gate-b" >/dev/null 2>&1
-  runB adopt 2003 --expect none --reason "racing machineB" >"$T/race-b.out" 2>&1
-  echo "$?" >"$T/race-b.rc" ) &
-pidB=$!
-( echo go >"$T/gate-a" ) &
-writerA=$!
-( echo go >"$T/gate-b" ) &
-writerB=$!
-wait "$pidA" "$pidB" 2>/dev/null
-# Never `wait` on the fifo writers: a writer blocks until its reader opens, so a
-# child that died before opening would hang the suite. The racers are done here,
-# so any still-blocked writer is simply killed.
-kill "$writerA" "$writerB" 2>/dev/null || true
-rcRaceA="$(cat "$T/race-a.rc" 2>/dev/null || echo missing)"
-rcRaceB="$(cat "$T/race-b.rc" 2>/dev/null || echo missing)"
-winners=0
-[ "$rcRaceA" = "0" ] && winners=$((winners+1))
-[ "$rcRaceB" = "0" ] && winners=$((winners+1))
-raceRef=$(ref_sha 2003)
-raceRefs=$(ref_count 2003)
-adoptedLines=$(cat "$T/race-a.out" "$T/race-b.out" 2>/dev/null | grep -c 'CLAIM: ADOPTED')
-if [ "$winners" -eq 1 ] && [ "$raceRefs" = "1" ] && [ "$adoptedLines" = "1" ] && [ -n "$raceRef" ]; then
-  ok "concurrent empty-lease adopts: exactly one exit-0 ADOPTED winner, exactly one claim ref"
-else
-  fail "expected exactly one winner and one ref; got winners=$winners refs=$raceRefs adopted-lines=$adoptedLines rcA=$rcRaceA rcB=$rcRaceB
-A: $(cat "$T/race-a.out" 2>/dev/null)
-B: $(cat "$T/race-b.out" 2>/dev/null)"
-fi
-# The loser must never report success. (It reports ADOPT-LOST when it reads the
-# winner's ref, or a RETRYABLE infra ERROR if its push was rejected before the
-# winner's create landed — never ADOPTED, and never a bogus "nobody holds it" win.)
-if [ "$rcRaceA" = "0" ]; then loserOut="$T/race-b.out"; else loserOut="$T/race-a.out"; fi
-if ! grep -q 'CLAIM: ADOPTED' "$loserOut" 2>/dev/null; then
-  ok "the losing machine never printed ADOPTED"
-else
-  fail "the losing machine reported ADOPTED — double-claim:
-$(cat "$loserOut")"
-fi
-# And the surviving ref really belongs to the winner, not a torn state.
-winnerVerify=2
-if [ "$rcRaceA" = "0" ]; then runA verify 2003 >/dev/null 2>&1; winnerVerify=$?
-elif [ "$rcRaceB" = "0" ]; then runB verify 2003 >/dev/null 2>&1; winnerVerify=$?; fi
-[ "$winnerVerify" -eq 0 ] && ok "the winner verifies as the holder of the single surviving ref" \
-  || fail "the race winner does not verify as holder (rc=$winnerVerify)"
+# remote's ref update is the arbiter, and the post-receive log is the witness.
+# Repeated over distinct issue ids because a single interleaving proves little.
+raceRounds=0; raceOk=0; raceAtomic=0; raceLoser=0; raceWinnerVerified=0; raceDiag=""
+for id in 2101 2102 2103 2104 2105; do
+  raceRounds=$((raceRounds+1))
+  push_work_branch "issue-${id}-resumable"
+  ( cd "$B" && g fetch -q origin )
+  rm -f "$T/gate-a" "$T/gate-b"
+  mkfifo "$T/gate-a" "$T/gate-b"
+  ( head -1 <"$T/gate-a" >/dev/null 2>&1
+    runA adopt "$id" --expect none --reason "racing machineA" >"$T/race-a.out" 2>&1
+    echo "$?" >"$T/race-a.rc" ) &
+  pidA=$!
+  ( head -1 <"$T/gate-b" >/dev/null 2>&1
+    runB adopt "$id" --expect none --reason "racing machineB" >"$T/race-b.out" 2>&1
+    echo "$?" >"$T/race-b.rc" ) &
+  pidB=$!
+  ( echo go >"$T/gate-a" ) &
+  writerA=$!
+  ( echo go >"$T/gate-b" ) &
+  writerB=$!
+  wait "$pidA" "$pidB" 2>/dev/null
+  # Never `wait` on the fifo writers: a writer blocks until its reader opens, so a
+  # child that died before opening would hang the suite. The racers are done here,
+  # so any still-blocked writer is simply killed.
+  kill "$writerA" "$writerB" 2>/dev/null || true
+  rcRaceA="$(cat "$T/race-a.rc" 2>/dev/null || echo missing)"
+  rcRaceB="$(cat "$T/race-b.rc" 2>/dev/null || echo missing)"
+  winners=0
+  [ "$rcRaceA" = "0" ] && winners=$((winners+1))
+  [ "$rcRaceB" = "0" ] && winners=$((winners+1))
+  raceRef=$(ref_sha "$id")
+  adoptedLines=$(cat "$T/race-a.out" "$T/race-b.out" 2>/dev/null | grep -c 'CLAIM: ADOPTED')
+  if [ "$winners" -eq 1 ] && [ "$(ref_count "$id")" = "1" ] && [ "$adoptedLines" = "1" ] && [ -n "$raceRef" ]; then
+    raceOk=$((raceOk+1))
+  else
+    raceDiag="$raceDiag
+  round $id: winners=$winners refs=$(ref_count "$id") adopted-lines=$adoptedLines rcA=$rcRaceA rcB=$rcRaceB
+  A: $(cat "$T/race-a.out" 2>/dev/null)
+  B: $(cat "$T/race-b.out" 2>/dev/null)"
+  fi
+  # The concurrency invariant, from the SERVER's own record: exactly ONE update was
+  # applied to the claim ref and it was a create (old=all-zeros) — so no claimant
+  # ever overwrote another's create, and the surviving ref is not a torn/second write.
+  # (The lease itself is proven in TEST 2/10 — see the header for why a both-see-
+  # absent race cannot discriminate it.)
+  updates=$(accepted_updates "$id")
+  olds=$(accepted_olds "$id")
+  if [ "$updates" = "1" ] && [ "$olds" = "$ZEROS" ]; then
+    raceAtomic=$((raceAtomic+1))
+  else
+    raceDiag="$raceDiag
+  round $id: server accepted $updates update(s) to refs/claims/issue-$id, olds='$olds' (want 1 create)"
+  fi
+  # The loser must fail LOUDLY: never ADOPTED, and never a vacuous silent exit —
+  # exit 2 with ADOPT-LOST (it read the winner's ref) or exit 1 with ERROR infra
+  # (its push was rejected before the winner's create was visible).
+  if [ "$rcRaceA" = "0" ]; then loserOut="$T/race-b.out"; loserRc="$rcRaceB"; else loserOut="$T/race-a.out"; loserRc="$rcRaceA"; fi
+  loserText="$(cat "$loserOut" 2>/dev/null)"
+  loserVerdict=1
+  printf '%s\n' "$loserText" | grep -q 'CLAIM: ADOPTED' && loserVerdict=0
+  if printf '%s\n' "$loserText" | grep -q 'CLAIM: ADOPT-LOST'; then :
+  elif printf '%s\n' "$loserText" | grep -q 'CLAIM: ERROR' && printf '%s\n' "$loserText" | grep -q 'infra'; then :
+  else loserVerdict=0
+  fi
+  case "$loserRc" in 1 | 2) : ;; *) loserVerdict=0 ;; esac
+  if [ "$loserVerdict" -eq 1 ]; then
+    raceLoser=$((raceLoser+1))
+  else
+    raceDiag="$raceDiag
+  round $id: loser rc=$loserRc verdict not in {ADOPT-LOST, ERROR infra}: $loserText"
+  fi
+  # And the surviving ref really belongs to the winner, not a torn state.
+  winnerVerify=2
+  if [ "$rcRaceA" = "0" ]; then runA verify "$id" >/dev/null 2>&1; winnerVerify=$?
+  elif [ "$rcRaceB" = "0" ]; then runB verify "$id" >/dev/null 2>&1; winnerVerify=$?; fi
+  [ "$winnerVerify" -eq 0 ] && raceWinnerVerified=$((raceWinnerVerified+1))
+done
+[ "$raceOk" -eq "$raceRounds" ] \
+  && ok "concurrent empty-lease adopts: exactly one exit-0 ADOPTED winner, every round ($raceRounds/$raceRounds)" \
+  || fail "expected one winner per round; $raceOk/$raceRounds rounds clean$raceDiag"
+[ "$raceAtomic" -eq "$raceRounds" ] \
+  && ok "the SERVER accepted exactly one create per raced ref ($raceAtomic/$raceRounds) — the update is atomic, not last-writer-wins" \
+  || fail "atomicity witness failed: $raceAtomic/$raceRounds rounds had a single all-zeros create$raceDiag"
+[ "$raceLoser" -eq "$raceRounds" ] \
+  && ok "the loser fails loudly every round (exit 1|2 with ADOPT-LOST or ERROR infra, never ADOPTED)" \
+  || fail "loser contract failed in $((raceRounds - raceLoser))/$raceRounds rounds$raceDiag"
+[ "$raceWinnerVerified" -eq "$raceRounds" ] \
+  && ok "the winner verifies as the holder of the single surviving ref, every round" \
+  || fail "the race winner did not verify as holder in $((raceRounds - raceWinnerVerified))/$raceRounds rounds$raceDiag"
 
 # ===========================================================================
 echo "TEST 4: --expect fail-closed — empty '' is a usage error; only the literal 'none' opts into the empty lease"
@@ -241,6 +386,27 @@ outJunk=$(runB adopt 2004 --expect "HEAD~1" 2>&1); rcJunk=$?
 [ "$rcJunk" -eq 64 ] && ok "a non-hex, non-'none' --expect is a usage error (exit 64)" \
   || fail "expected exit 64 for --expect HEAD~1; got rc=$rcJunk
 $outJunk"
+# A non-numeric issue is a usage error on every subcommand (no ref namespace games).
+argRc=""
+for sub in "claim 20x4" "verify 20x4" "release 20x4" "adopt 20x4 --expect none --reason why"; do
+  # shellcheck disable=SC2086  # deliberate word-split of the fixed arg list
+  runB $sub >/dev/null 2>&1
+  argRc="$argRc $?"
+done
+[ "$argRc" = " 64 64 64 64" ] \
+  && ok "a non-numeric issue number is a usage error (exit 64) on claim/verify/release/adopt" \
+  || fail "expected 64 from every subcommand for a non-numeric issue; got rcs='$argRc'"
+# A valid-hex but WRONG --expect against a FREE ref must NOT create the ref: CAS-on-
+# absent stays a refusal, so no refactor can quietly route it into the empty lease.
+WRONG=1111111111111111111111111111111111111111
+outWrong=$(runB adopt 2044 --expect "$WRONG" --reason "cas against a ref that is not there"); rcWrong=$?
+if [ "$rcWrong" -eq 2 ] && printf '%s\n' "$outWrong" | grep -q 'CLAIM: ADOPT-LOST' \
+   && printf '%s\n' "$outWrong" | grep -q 'actual=<gone>' && [ -z "$(ref_sha 2044)" ]; then
+  ok "a wrong-sha CAS on a FREE ref refuses (exit 2, actual=<gone>) and creates nothing"
+else
+  fail "expected ADOPT-LOST exit 2 with actual=<gone> and no ref; got rc=$rcWrong ref='$(ref_sha 2044)'
+$outWrong"
+fi
 
 # ===========================================================================
 echo "TEST 5: adopt --expect none REQUIRES --reason (the record must say why)"
@@ -253,11 +419,17 @@ else
   fail "expected exit 64 demanding --reason with no ref created; got rc=$rcNoWhy ref='$noRef5'
 $outNoWhy"
 fi
+outBlankWhy=$(runB adopt 2005 --expect none --reason "" 2>&1); rcBlankWhy=$?
+if [ "$rcBlankWhy" -eq 64 ] && [ -z "$(ref_sha 2005)" ]; then
+  ok "an EMPTY --reason '' is also a usage error (exit 64) — an unset shell variable cannot slip through"
+else
+  fail "expected exit 64 for --reason ''; got rc=$rcBlankWhy ref='$(ref_sha 2005)'
+$outBlankWhy"
+fi
 # An ALL-ZERO --expect is git's own "must not exist": same intent as `none`, so it
 # takes the same AUDITED route rather than a quiet unrecorded create. (Verified on
 # the real origin: an all-zero lease DOES create the ref.)
-ZERO=0000000000000000000000000000000000000000
-outZeroNoWhy=$(runB adopt 2005 --expect "$ZERO" 2>&1); rcZeroNoWhy=$?
+outZeroNoWhy=$(runB adopt 2005 --expect "$ZEROS" 2>&1); rcZeroNoWhy=$?
 zeroRef=$(ref_sha 2005)
 if [ "$rcZeroNoWhy" -eq 64 ] && [ -z "$zeroRef" ]; then
   ok "an all-zero --expect also demands --reason (exit 64) — no unaudited create-with-no-record"
@@ -265,7 +437,7 @@ else
   fail "expected exit 64 and no ref for an all-zero --expect without --reason; got rc=$rcZeroNoWhy ref='$zeroRef'
 $outZeroNoWhy"
 fi
-outZero=$(runB adopt 2005 --expect "$ZERO" --reason "all-zero lease with a recorded why"); rcZero=$?
+outZero=$(runB adopt 2005 --expect "$ZEROS" --reason "all-zero lease with a recorded why"); rcZero=$?
 if [ "$rcZero" -eq 0 ] && printf '%s\n' "$outZero" | grep -q 'CLAIM: ADOPTED' && [ -n "$(ref_sha 2005)" ]; then
   ok "an all-zero --expect WITH --reason acquires the free ref (exit 0, recorded)"
 else
@@ -334,6 +506,245 @@ else
   fail "expected CLAIM: HELD exit 0; got rc=$rcPlain ref='$plainRef'
 $outPlain"
 fi
+
+# ===========================================================================
+echo "TEST 9: the empty-lease push FAILING while the ref is ABSENT is retryable infra (exit 1), never a lost race"
+# ===========================================================================
+# #2677 direction for the resume path: nobody holds the ref, so a rejected push is
+# an infrastructure failure. A shim fails ONLY `push` and lets every read through.
+SHIMP="$T/shim-push-fail"
+mkdir -p "$SHIMP"
+cat >"$SHIMP/git" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do [ "\$a" = "push" ] && exit 128; done
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMP/git"
+outPushFail=$( cd "$B" && PATH="$SHIMP:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" adopt 2009 --expect none --reason "push blocked by an outage" 2>&1 ); rcPushFail=$?
+if [ "$rcPushFail" -eq 1 ] && printf '%s\n' "$outPushFail" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outPushFail" | grep -q 'infra' \
+   && ! printf '%s\n' "$outPushFail" | grep -q 'ADOPT-LOST' \
+   && [ -z "$(ref_sha 2009)" ] && [ "$(accepted_updates 2009)" = "0" ]; then
+  ok "empty-lease push failure over an ABSENT ref → ERROR infra exit 1, no ADOPT-LOST, nothing created"
+else
+  fail "expected ERROR infra exit 1 with no ref/no ADOPT-LOST; got rc=$rcPushFail ref='$(ref_sha 2009)' updates=$(accepted_updates 2009)
+$outPushFail"
+fi
+
+# ===========================================================================
+echo "TEST 10: adopt is RE-ENTRANT — a retry after a confirm-read blip must never abandon a claim we hold"
+# ===========================================================================
+# Reproduce the reported sequence exactly: a shim fails ONLY the post-push
+# `ls-remote refs/claims/*` confirm, so the push LANDS and adopt still reports the
+# retryable ERROR whose documented remedy is "retry".
+SHIMC="$T/shim-claims-lookup-fail"
+mkdir -p "$SHIMC"
+cat >"$SHIMC/git" <<SHIM
+#!/usr/bin/env bash
+saw_ls=0; saw_claims=0
+for a in "\$@"; do
+  [ "\$a" = "ls-remote" ] && saw_ls=1
+  case "\$a" in refs/claims/*) saw_claims=1 ;; esac
+done
+if [ "\$saw_ls" = 1 ] && [ "\$saw_claims" = 1 ]; then exit 128; fi
+exec "$REALGIT" "\$@"
+SHIM
+chmod +x "$SHIMC/git"
+outBlip=$( cd "$B" && PATH="$SHIMC:$PATH" CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" adopt 2010 --expect none --reason "resume with a flaky confirm read" 2>&1 ); rcBlip=$?
+blipSha=$(ref_sha 2010)
+if [ "$rcBlip" -eq 1 ] && printf '%s\n' "$outBlip" | grep -q 'CLAIM: ERROR' && [ -n "$blipSha" ]; then
+  ok "a confirm-read outage after a LANDED empty-lease push reports retryable ERROR (exit 1) with the ref created"
+else
+  fail "could not stage the confirm-blip case (rc=$rcBlip ref='$blipSha')
+$outBlip"
+fi
+outRetry=$(runB adopt 2010 --expect none --reason "resume with a flaky confirm read"); rcRetry=$?
+retrySha=$(ref_sha 2010)
+if [ "$rcRetry" -eq 0 ] && printf '%s\n' "$outRetry" | grep -q 'CLAIM: ADOPTED' \
+   && printf '%s\n' "$outRetry" | grep -q 're-entrant' \
+   && [ "$retrySha" = "$blipSha" ] && [ "$(accepted_updates 2010)" = "1" ]; then
+  ok "the RETRY by the same machine+actor is re-entrant: ADOPTED exit 0, ref unchanged, no second server write"
+else
+  fail "expected a re-entrant ADOPTED exit 0 leaving the ref at $blipSha; got rc=$rcRetry ref='$retrySha' updates=$(accepted_updates 2010)
+$outRetry"
+fi
+outOtherActor=$(runB adopt 2010 --expect none --reason "a different actor on the same machine"  --actor closer); rcOtherActor=$?
+if [ "$rcOtherActor" -eq 2 ] && printf '%s\n' "$outOtherActor" | grep -q 'CLAIM: ADOPT-LOST' \
+   && [ "$(ref_sha 2010)" = "$blipSha" ]; then
+  ok "re-entrancy is machine+ACTOR scoped: a different actor still gets ADOPT-LOST (exit 2)"
+else
+  fail "expected ADOPT-LOST exit 2 for a different actor; got rc=$rcOtherActor
+$outOtherActor"
+fi
+outOtherMachine=$(runA adopt 2010 --expect none --reason "another machine must not inherit re-entrancy"); rcOtherMachine=$?
+[ "$rcOtherMachine" -eq 2 ] && ok "another MACHINE still gets ADOPT-LOST (exit 2) — re-entrancy is not a bypass" \
+  || fail "expected ADOPT-LOST exit 2 for another machine; got rc=$rcOtherMachine
+$outOtherMachine"
+
+# ===========================================================================
+echo "TEST 11: a NON-ASCII --reason works (BSD/macOS tr aborts on it without a byte locale)"
+# ===========================================================================
+# `tr -c` in a UTF-8 locale fails with "Illegal byte sequence" on BSD/macOS tr, and
+# under `set -euo pipefail` that killed the script inside a command substitution:
+# NO CLAIM: line at all, exit 1 — which the contract reads as "retryable", so the
+# caller retries forever on input that can never succeed. This repo's prose is full
+# of em dashes, so `--reason "resume — parked claim"` is a likely invocation.
+outUtf8=$( cd "$B" && LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 CLAIM_MACHINE=machineB CLAIM_REMOTE=origin \
+  bash "$CLAIM" adopt 2011 --expect none --reason "resume — parked claim (café, naïve)" 2>&1 ); rcUtf8=$?
+utf8Reason=$(line_field "$outUtf8" reason)
+if [ "$rcUtf8" -eq 0 ] && [ "$(printf '%s\n' "$outUtf8" | grep -c 'CLAIM: ADOPTED')" = "1" ] \
+   && [ -n "$utf8Reason" ] && [ "$utf8Reason" = "${utf8Reason%%[[:space:]]*}" ] \
+   && printf '%s' "$utf8Reason" | grep -q 'resume' && [ -n "$(ref_sha 2011)" ]; then
+  ok "a non-ASCII --reason adopts normally (exit 0) and sanitizes to ONE ASCII token"
+else
+  fail "expected exit 0 and a single sanitized reason token for a non-ASCII reason; got rc=$rcUtf8 reason='$utf8Reason'
+$outUtf8"
+fi
+
+# ===========================================================================
+echo "TEST 12: identity FORGERY — neither --reason nor --actor can impersonate another machine"
+# ===========================================================================
+# Both fields are user-controlled text appended to the very commit message the
+# holder-identity parser reads. The parser used to take the LAST `<key>=` match
+# anywhere in the message, so a value carrying `machine=<other>` forged the holder —
+# and holder identity gates re-entrancy, verify, and release.
+runB adopt 2012 --expect none --reason "sneaky machine=machineA actor=flow pid=1" >/dev/null 2>&1; rcForge=$?
+forgeSha=$(ref_sha 2012)
+[ "$rcForge" -eq 0 ] && [ -n "$forgeSha" ] && ok "setup: machineB holds issue-2012 with a machine=-carrying reason" \
+  || fail "setup failed for the forged-reason case (rc=$rcForge)"
+forgeStatus=$(runB status 2012)
+[ "$(line_field "$forgeStatus" machine)" = "machineB" ] \
+  && ok "status names the TRUE holder (machineB), not the machine= smuggled in the reason" \
+  || fail "forged reason changed the rendered holder:
+$forgeStatus"
+outForgeClaim=$(runA claim 2012); rcForgeClaim=$?
+if [ "$rcForgeClaim" -eq 2 ] && printf '%s\n' "$outForgeClaim" | grep -q 'CLAIM: LOST' \
+   && ! printf '%s\n' "$outForgeClaim" | grep -q 're-entrant'; then
+  ok "the impersonated machine's claim is LOST (exit 2), never a re-entrant HELD"
+else
+  fail "expected CLAIM: LOST exit 2 for the impersonated machine; got rc=$rcForgeClaim
+$outForgeClaim"
+fi
+outForgeRelease=$(runA_gh release 2012); rcForgeRelease=$?
+if [ "$rcForgeRelease" -eq 2 ] && printf '%s\n' "$outForgeRelease" | grep -q 'reason=not-holder' \
+   && [ "$(ref_sha 2012)" = "$forgeSha" ]; then
+  ok "the impersonated machine cannot release the forged-reason claim (RELEASE-REFUSED, ref intact)"
+else
+  fail "expected RELEASE-REFUSED not-holder with the ref intact; got rc=$rcForgeRelease ref='$(ref_sha 2012)'
+$outForgeRelease"
+fi
+# Same attack through --actor, which is itself part of the holder identity.
+runB claim 2022 --actor 'flow machine=machineA' >/dev/null 2>&1; rcActorSetup=$?
+actorSha=$(ref_sha 2022)
+[ "$rcActorSetup" -eq 0 ] && [ -n "$actorSha" ] && ok "setup: machineB claims issue-2022 with a machine=-carrying --actor" \
+  || fail "setup failed for the forged-actor case (rc=$rcActorSetup)"
+outActorForge=$(runA claim 2022); rcActorForge=$?
+if [ "$rcActorForge" -eq 2 ] && printf '%s\n' "$outActorForge" | grep -q 'CLAIM: LOST' \
+   && ! printf '%s\n' "$outActorForge" | grep -q 're-entrant'; then
+  ok "a forged --actor does NOT hand machineA re-entrancy on machineB's ref (LOST exit 2)"
+else
+  fail "forged --actor granted a second writer on one issue; got rc=$rcActorForge
+$outActorForge"
+fi
+runB verify 2022 --actor 'flow machine=machineA' >/dev/null 2>&1; rcActorVerify=$?
+[ "$rcActorVerify" -eq 0 ] \
+  && ok "the sanitized actor round-trips for its own holder (verify exit 0) — sanitizing is consistent, not lossy" \
+  || fail "the holder can no longer verify its own sanitized actor (rc=$rcActorVerify)"
+
+# ===========================================================================
+echo "TEST 13: the reason RECORD — CAS mode, unrepresentable text, truncation, embedded newline"
+# ===========================================================================
+runB claim 2013 >/dev/null 2>&1
+casFrom=$(ref_sha 2013)
+outCas=$(runA adopt 2013 --expect "$casFrom" --reason "adopting a reaped claim after the 4h threshold"); rcCas=$?
+casStatus=$(runA status 2013)
+if [ "$rcCas" -eq 0 ] && printf '%s\n' "$outCas" | grep -q 'mode=cas' \
+   && [ "$(line_field "$casStatus" machine)" = "machineA" ] \
+   && printf '%s' "$(line_field "$casStatus" reason)" | grep -q 'reaped'; then
+  ok "--reason is recorded on the CAS path too (mode=cas, new holder, reason readable)"
+else
+  fail "expected a recorded mode=cas adoption by machineA; got rc=$rcCas
+$outCas
+$casStatus"
+fi
+runB adopt 2023 --expect none --reason '   ' >/dev/null 2>&1; rcBlank=$?
+blankReason=$(line_field "$(runB status 2023)" reason)
+if [ "$rcBlank" -eq 0 ] && [ "$blankReason" = "unspecified" ]; then
+  ok "a reason with nothing representable records reason=unspecified (never an empty field)"
+else
+  fail "expected reason=unspecified; got rc=$rcBlank reason='$blankReason'"
+fi
+longReason=$(printf 'a%.0s' $(seq 1 200))
+runB adopt 2033 --expect none --reason "$longReason" >/dev/null 2>&1; rcLong=$?
+longToken=$(line_field "$(runB status 2033)" reason)
+if [ "$rcLong" -eq 0 ] && [ "${#longToken}" -eq 120 ]; then
+  ok "an over-long reason is truncated to the documented 120 chars"
+else
+  fail "expected a 120-char reason token; got rc=$rcLong len=${#longToken}"
+fi
+runB adopt 2043 --expect none --reason "$(printf 'first line\nsecond line')" >/dev/null 2>&1; rcNl=$?
+nlStatus=$(runB status 2043)
+nlToken=$(line_field "$nlStatus" reason)
+if [ "$rcNl" -eq 0 ] && [ "$(printf '%s\n' "$nlStatus" | grep -c 'CLAIM: STATUS issue=2043 ')" = "1" ] \
+   && [ "$nlToken" = "first-line-second-line" ]; then
+  ok "an embedded newline collapses into the single-line record (no injected extra row)"
+else
+  fail "expected one STATUS row with a collapsed reason token; got rc=$rcNl token='$nlToken'
+$nlStatus"
+fi
+
+# ===========================================================================
+echo "TEST 14: reaper vs resumer — a forced release racing an empty-lease adopt never yields a bogus owner"
+# ===========================================================================
+# The realistic fleet collision: flow-board force-releases an abandoned claim at the
+# same moment another machine resumes it. Legal end states are "no ref" (the reaper's
+# delete landed last) or "the resumer's ref" — never machineA's stale sha, and never
+# a resumer that reported ADOPTED while some other commit owns the ref.
+reapRounds=0; reapOk=0; reapDiag=""
+for id in 2201 2202 2203; do
+  reapRounds=$((reapRounds+1))
+  runA claim "$id" >/dev/null 2>&1
+  staleSha=$(ref_sha "$id")
+  rm -f "$T/gate-r" "$T/gate-s"
+  mkfifo "$T/gate-r" "$T/gate-s"
+  ( head -1 <"$T/gate-r" >/dev/null 2>&1
+    runA_gh release "$id" --force >"$T/reap.out" 2>&1; echo "$?" >"$T/reap.rc" ) &
+  pidR=$!
+  ( head -1 <"$T/gate-s" >/dev/null 2>&1
+    runB adopt "$id" --expect none --reason "resumer racing the reaper" >"$T/resume.out" 2>&1; echo "$?" >"$T/resume.rc" ) &
+  pidS=$!
+  ( echo go >"$T/gate-r" ) & wr=$!
+  ( echo go >"$T/gate-s" ) & ws=$!
+  wait "$pidR" "$pidS" 2>/dev/null
+  kill "$wr" "$ws" 2>/dev/null || true
+  rcResume="$(cat "$T/resume.rc" 2>/dev/null || echo missing)"
+  resumeOut="$(cat "$T/resume.out" 2>/dev/null)"
+  resumeSha=$(line_field "$resumeOut" sha)
+  finalSha=$(ref_sha "$id")
+  verdict=1
+  # 1. The stale holder's commit must never survive the round.
+  [ -n "$finalSha" ] && [ "$finalSha" = "$staleSha" ] && verdict=0
+  # 2. A reported ADOPTED must be truthful: the surviving ref (if any) is ours.
+  if printf '%s\n' "$resumeOut" | grep -q 'CLAIM: ADOPTED'; then
+    [ "$rcResume" = "0" ] || verdict=0
+    [ -z "$finalSha" ] || [ "$finalSha" = "$resumeSha" ] || verdict=0
+    if [ -n "$finalSha" ]; then runB verify "$id" >/dev/null 2>&1 || verdict=0; fi
+  else
+    # 3. Otherwise it must have failed loudly (exit 1|2), never a silent exit 0.
+    case "$rcResume" in 1 | 2) : ;; *) verdict=0 ;; esac
+  fi
+  if [ "$verdict" -eq 1 ]; then
+    reapOk=$((reapOk+1))
+  else
+    reapDiag="$reapDiag
+  round $id: stale=$staleSha final='$finalSha' resumeRc=$rcResume resume='$resumeOut' reap='$(cat "$T/reap.out" 2>/dev/null)'"
+  fi
+done
+[ "$reapOk" -eq "$reapRounds" ] \
+  && ok "forced-release vs empty-lease-adopt: every round ends at no-ref or the resumer's own ref ($reapOk/$reapRounds)" \
+  || fail "reaper/resumer barrier race produced a bogus owner in $((reapRounds - reapOk))/$reapRounds rounds$reapDiag"
 
 echo ""
 echo "================  claim-resume (#2945): $PASS passed, $FAIL failed  ================"

--- a/scripts/tests/test_claim_lock.sh
+++ b/scripts/tests/test_claim_lock.sh
@@ -243,11 +243,17 @@ $outInfra"
 fi
 
 # ===========================================================================
-echo "TEST 10: LOST with an empty remote read prints holder=unknown (never our own commit)"
+echo "TEST 10: a LANDED push whose confirm read comes back EMPTY is infra (exit 1), and names NO holder"
 # ===========================================================================
-# A git shim makes every ls-remote return EMPTY while push passes through. The
-# push creates the ref, but the post-push confirm read comes back empty, so the
-# verdict is LOST — and the holder MUST be reported as unknown, never our own sha.
+# A git shim makes every ls-remote return EMPTY while push passes through, so the
+# push CREATES the ref and the post-push confirm read comes back absent.
+# This assertion used to pin `LOST … holder=unknown` (exit 2) — its point being that
+# the verdict must never fabricate a holder out of OUR OWN sha. The no-holder half of
+# that verdict was itself the bug (#2945): nobody holds the ref in this state, so exit 2
+# ("you did not win, take the next item") walked a worker away from a FREE lane, and the
+# rejected-push sibling already called the identical state infra. The original intent is
+# preserved and strengthened — the verdict now names NO holder at all, unknown or
+# otherwise, and is retryable (exit 1).
 SHIMG="$T/shim-git"
 mkdir -p "$SHIMG"
 cat >"$SHIMG/git" <<SHIM
@@ -260,11 +266,15 @@ SHIM
 chmod +x "$SHIMG/git"
 rc=0; outUnk=$( cd "$A" && PATH="$SHIMG:$PATH" CLAIM_MACHINE=machineA bash "$CLAIM" claim 10 ) || rc=$?
 rcUnk=$rc
-if [ "$rcUnk" -eq 2 ] && printf '%s\n' "$outUnk" | grep -q 'CLAIM: LOST' \
-   && printf '%s\n' "$outUnk" | grep -q 'holder=unknown'; then
-  ok "empty-read LOST path prints holder=unknown (exit 2), not our own commit"
+if [ "$rcUnk" -eq 1 ] && printf '%s\n' "$outUnk" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outUnk" | grep -q 'reason=infra' \
+   && printf '%s\n' "$outUnk" | grep -q 'detail=push-accepted-but-ref-absent-on-confirm' \
+   && ! printf '%s\n' "$outUnk" | grep -q 'CLAIM: LOST' \
+   && ! printf '%s\n' "$outUnk" | grep -q 'holder=' \
+   && [ -n "$(ref_sha 10)" ]; then
+  ok "an empty confirm read over a LANDED push → ERROR infra exit 1, naming no holder (never our own commit, never LOST)"
 else
-  bad "expected LOST holder=unknown exit 2; got rc=$rcUnk
+  bad "expected ERROR infra push-accepted-but-ref-absent-on-confirm exit 1 with no holder named; got rc=$rcUnk ref='$(ref_sha 10)'
 $outUnk"
 fi
 

--- a/scripts/tests/test_claim_lock.sh
+++ b/scripts/tests/test_claim_lock.sh
@@ -358,15 +358,24 @@ fi
 echo "TEST 14: push WINS but the confirm ls-remote fails → ERROR infra (exit 1), never a false LOST"
 # ===========================================================================
 # A git shim passes `push` through (the claim really lands) but fails every
-# ls-remote — so the post-push WIN confirmation cannot read the ref. That must be
-# treated as infra (retryable, exit 1), NOT a bogus LOST on a claim we hold.
+# ls-remote of a CLAIM ref — so the post-push WIN confirmation cannot read the ref.
+# That must be treated as infra (retryable, exit 1), NOT a bogus LOST on a claim we
+# hold. The shim deliberately leaves the legacy-branch enumeration
+# (`ls-remote --heads issue-<N>-*`) readable: since #2945 that guard fails CLOSED on
+# an unreadable enumeration and returns BEFORE any push, so a blanket ls-remote
+# failure would never reach the push at all (that whole-remote outage case is
+# TEST 9's / claim-resume.test.sh TEST 6's).
 SHIMF="$T/shim-git-lsfail"
 mkdir -p "$SHIMF"
 cat >"$SHIMF/git" <<SHIM
 #!/usr/bin/env bash
+is_ls=0; is_claims=0
 for a in "\$@"; do
-  if [ "\$a" = "ls-remote" ]; then exit 1; fi   # simulate: ls-remote unreachable
+  [ "\$a" = "ls-remote" ] && is_ls=1
+  case "\$a" in refs/claims/*) is_claims=1 ;; esac
 done
+# simulate: reading a CLAIM ref is unreachable (branch enumeration still works)
+if [ "\$is_ls" = 1 ] && [ "\$is_claims" = 1 ]; then exit 1; fi
 exec "$REALGIT" "\$@"
 SHIM
 chmod +x "$SHIMF/git"

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -239,7 +239,7 @@ free, then points here. The ONE sanctioned resume is documented *only* here and 
 `claim.sh -h` — it is deliberately **never printed as a runnable line** (see below):
 
 ```bash
-bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:issue-<N>-<slug>
+bash scripts/flow/claim.sh adopt 1234 --expect none --reason resume-legacy-branch-lock:branch-outlived-claim
 ```
 
 `--expect none` is git's **empty lease** ("this ref must not exist"), so the create is still arbitrated
@@ -248,7 +248,12 @@ server-side: a machine that actually holds the claim ref keeps it and the resume
 it is recorded in the claim commit next to who took it (machine/actor/ts) and rendered by
 `claim.sh status`, so a resume is auditable; a reason with nothing recordable in it (`'   '`, `'---'`, an
 unset variable) is a **usage error** (exit 64), never a silent `reason=unspecified` — and so is a bare
-**placeholder** (`<why>`, `why`, `todo`, `tbd`, `xxx`, …): the record must say why. A hex
+**placeholder** (`why`, `todo`, `tbd`, `xxx`, …) or a reason still carrying an **unsubstituted `<…>`**
+(a copied `--reason resume-legacy-branch-lock:<branch>` sanitizes to a non-sentinel token, so it is
+rejected on the raw text): the record must say why. That is also why the example above substitutes a
+concrete issue number and reason — the documented invocation is one that works when run verbatim.
+`--actor` is fail-closed the same way (an actor with nothing recordable in it would alias two distinct
+identities onto one holder, and the actor gates re-entrancy/`verify`/`release`). A hex
 `--expect` must be a **full** object name (40/64 hex) — a truncated sha is a usage error, not a lost race.
 
 **Why the command is never printed for you (owner decision, #2945).** `claim.sh` used to decide, from an

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -243,7 +243,15 @@ bash scripts/flow/claim.sh adopt <N> --expect none --reason "<why you are resumi
 server-side: a machine that actually holds the claim ref keeps it and the resumer gets `ADOPT-LOST`
 (exit 2), and two machines racing the resume still yield exactly one winner. `--reason` is **required** —
 it is recorded in the claim commit next to who took it (machine/actor/ts) and rendered by
-`claim.sh status`, so a resume is auditable. Retrying after a transient `ERROR reason=infra` is safe: an
+`claim.sh status`, so a resume is auditable; a reason with nothing recordable in it (`'   '`, `'---'`, an
+unset variable) is a **usage error** (exit 64), never a silent `reason=unspecified`. A hex `--expect` must
+be a **full** object name (40/64 hex) — a truncated sha is a usage error, not a lost race.
+
+The refusal **prints that command only when the endgame is demonstrably orphaned** — `open-prs=0`. An
+older-fleet worker locks with the *branch* and holds no claim ref, so `claim-ref=free` is true while it is
+actively working; with an open PR (or an unreadable PR list, `open-prs=-1`) the refusal instead reports
+`remediation=withheld open-prs=<n>` and you confirm ownership via the board and the PR author first. The
+hatch still works when invoked deliberately — withholding changes the *advice*, not the arbiter. Retrying after a transient `ERROR reason=infra` is safe: an
 adopt whose ref is already held by *this* machine+actor reports `ADOPTED … (re-entrant)` exit 0 rather
 than abandoning an issue you own. This is the only sanctioned way past that refusal — **never hand-craft
 a claim commit or push the ref directly** (the field failure that motivated #2945). The claiming session also maintains a

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -233,10 +233,12 @@ the loss immediately (fixes the #2467/#2499 two-writer race).
 **Resuming past the legacy-branch guard (issue #2945)** — when the claim ref is **free** but an
 `issue-<N>-*` branch still stands on origin (a parked/reaped/released claim, an owner-approved spec that
 lives on that branch, or just a merged-but-undeleted PR branch), `claim` refuses with
-`reason=legacy-branch-lock … claim-ref=free` and prints the ONE sanctioned resume:
+`reason=legacy-branch-lock … claim-ref=free resume=documented-procedure`. That refusal is a
+**diagnosis, not a hand-off**: it names the blocking branch(es) and tells you the claim ref itself is
+free, then points here. The ONE sanctioned resume is documented *only* here and in
+`claim.sh -h` — it is deliberately **never printed as a runnable line** (see below):
 
 ```bash
-# the refusal prints this line with a CONCRETE reason already filled in, e.g.
 bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:issue-<N>-<slug>
 ```
 
@@ -246,26 +248,26 @@ server-side: a machine that actually holds the claim ref keeps it and the resume
 it is recorded in the claim commit next to who took it (machine/actor/ts) and rendered by
 `claim.sh status`, so a resume is auditable; a reason with nothing recordable in it (`'   '`, `'---'`, an
 unset variable) is a **usage error** (exit 64), never a silent `reason=unspecified` — and so is a bare
-**placeholder** (`<why>`, `why`, `todo`, `tbd`, `xxx`, …), because a printed `--reason <why>` run verbatim
-would record the uninformative `reason=why`. That is why the refusal fills the reason in for you. A hex
+**placeholder** (`<why>`, `why`, `todo`, `tbd`, `xxx`, …): the record must say why. A hex
 `--expect` must be a **full** object name (40/64 hex) — a truncated sha is a usage error, not a lost race.
 
-The refusal **prints that command only when the lane is demonstrably orphaned**, judged on THREE signals:
-`open-prs=0` **and** every matching `issue-<N>-*` branch tip **carrying at least one commit of its own**
-and older than `claim-heartbeat.sh`'s reap threshold (4h) **and** no fresh `refs/machine-claims/*` /
-`refs/heartbeats/*` ref naming the issue. The
-last two cover the **pre-PR window**: an older-fleet worker locks with the *branch*, holds no claim ref
-(`claim-ref=free`) — and because a PR is opened LATE in this pipeline it also has **no open PR** for most
-of its life, so `open-prs=0` alone would advertise a hand-away on an actively-worked issue. The
-"own commits" qualifier matters just as much: `flow-activate` pushes the branch at `origin/main` with no
-commits of its own, so a freshly-activated lane's tip date **is main's** — no information about the
-worker. Such a tip is reported `newest-branch-tip=no-own-commits` and **withheld** (indeterminate), never
-judged "stale" because main happened to be quiet overnight. Anything live —
-or any signal that could not be **read** (`open-prs=-1`, an unreachable remote, an unreadable default
-branch, a missing threshold) —
-prints `remediation=withheld <signals>` instead, and you confirm ownership via the board and the
-branch/PR author first. The
-hatch still works when invoked deliberately — withholding changes the *advice*, not the arbiter. Retrying after a transient `ERROR reason=infra` is safe: an
+**Why the command is never printed for you (owner decision, #2945).** `claim.sh` used to decide, from an
+in-script liveness probe, whether to print a copy-pasteable version of that command. That probe is gone.
+The readers of a refusal are agents that run printed remediations **literally**, and an older-fleet worker
+locks with the *branch* while holding **no claim ref** (`claim-ref=free` is true for it) — so a printed
+empty-lease adopt would take an **actively-worked** lane and create a second writer. Judging abandonment
+needs signals `claim.sh` cannot read soundly, and three successive revisions of the probe each shipped a
+fresh version of that hazard (a vacuous branch-tip date, a cross-process ref race, a fleet-wide permanent
+withhold). So the refusal diagnoses and points here, and **you** establish abandonment first with the same
+test `flow-board`'s reaper uses:
+
+```bash
+bash scripts/flow/claim-heartbeat.sh should-reap <machine>   # exit 0 = reapable, 1 = keep, 2 = no ref
+```
+
+i.e. claim age > 4h **and** no open PR **and** (pid-dead, when the claim is local) — plus the board
+`Status` and the branch/PR author. Only then run the documented resume. Retrying after a transient
+`ERROR reason=infra` is safe: an
 adopt whose ref is already held by *this* machine+actor reports `ADOPTED … (re-entrant)` exit 0 rather
 than abandoning an issue you own. This is the only sanctioned way past that refusal — **never hand-craft
 a claim commit or push the ref directly** (the field failure that motivated #2945). The claiming session also maintains a

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -199,7 +199,8 @@ lock**.
 
 1. **Eligibility** — the item is `Ready` AND has **no** `refs/claims/issue-<N>` claim ref
    (`bash scripts/flow/claim.sh status <N>`) and **no** legacy `issue-<N>-*` branch on origin (mixed-fleet
-   safety; older workers still branch-lock).
+   safety; older workers still branch-lock). A surviving branch over a **free** claim ref is not a dead
+   end — see *Resuming past the legacy-branch guard* below.
 2. **Claim** — `bash scripts/flow/claim.sh claim <N>` acquires the lock (`CLAIM HELD` exit 0 / `CLAIM LOST`
    exit 2); only then create the worktree + branch and set assignee `@me` + `Status=In Progress` for board
    visibility. `flow-activate` claims immediately — before any spec work; oracle-driven issues claim in
@@ -227,7 +228,25 @@ the `project` scope string. Full delta list with the identifying messages:
 Another machine that finds an existing claim can `git fetch` the branch to **resume** that work instead of
 colliding; a **reaped** claim is adopted via compare-and-swap — `claim.sh adopt <N> --expect <old-sha>`,
 which replaces the ref with force-with-lease so a resurrected original holder loses the lease and detects
-the loss immediately (fixes the #2467/#2499 two-writer race). The claiming session also maintains a
+the loss immediately (fixes the #2467/#2499 two-writer race).
+
+**Resuming past the legacy-branch guard (issue #2945)** — when the claim ref is **free** but an
+`issue-<N>-*` branch still stands on origin (a parked/reaped/released claim, an owner-approved spec that
+lives on that branch, or just a merged-but-undeleted PR branch), `claim` refuses with
+`reason=legacy-branch-lock … claim-ref=free` and prints the ONE sanctioned resume:
+
+```bash
+bash scripts/flow/claim.sh adopt <N> --expect none --reason "<why you are resuming>"
+```
+
+`--expect none` is git's **empty lease** ("this ref must not exist"), so the create is still arbitrated
+server-side: a machine that actually holds the claim ref keeps it and the resumer gets `ADOPT-LOST`
+(exit 2), and two machines racing the resume still yield exactly one winner. `--reason` is **required** —
+it is recorded in the claim commit next to who took it (machine/actor/ts) and rendered by
+`claim.sh status`, so a resume is auditable. Retrying after a transient `ERROR reason=infra` is safe: an
+adopt whose ref is already held by *this* machine+actor reports `ADOPTED … (re-entrant)` exit 0 rather
+than abandoning an issue you own. This is the only sanctioned way past that refusal — **never hand-craft
+a claim commit or push the ref directly** (the field failure that motivated #2945). The claiming session also maintains a
 liveness **heartbeat** (`scripts/flow/claim-heartbeat.sh beat <N>` — a cheap origin git ref under
 `refs/heartbeats/<machine>`, never a GitHub API call — refreshed at claim time and on every stage
 transition: activate/implement/gate/PR). `flow-board` reaps **abandoned claims deterministically** (issue

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -236,7 +236,8 @@ lives on that branch, or just a merged-but-undeleted PR branch), `claim` refuses
 `reason=legacy-branch-lock … claim-ref=free` and prints the ONE sanctioned resume:
 
 ```bash
-bash scripts/flow/claim.sh adopt <N> --expect none --reason "<why you are resuming>"
+# the refusal prints this line with a CONCRETE reason already filled in, e.g.
+bash scripts/flow/claim.sh adopt <N> --expect none --reason resume-legacy-branch-lock:issue-<N>-<slug>
 ```
 
 `--expect none` is git's **empty lease** ("this ref must not exist"), so the create is still arbitrated
@@ -244,13 +245,20 @@ server-side: a machine that actually holds the claim ref keeps it and the resume
 (exit 2), and two machines racing the resume still yield exactly one winner. `--reason` is **required** —
 it is recorded in the claim commit next to who took it (machine/actor/ts) and rendered by
 `claim.sh status`, so a resume is auditable; a reason with nothing recordable in it (`'   '`, `'---'`, an
-unset variable) is a **usage error** (exit 64), never a silent `reason=unspecified`. A hex `--expect` must
-be a **full** object name (40/64 hex) — a truncated sha is a usage error, not a lost race.
+unset variable) is a **usage error** (exit 64), never a silent `reason=unspecified` — and so is a bare
+**placeholder** (`<why>`, `why`, `todo`, `tbd`, `xxx`, …), because a printed `--reason <why>` run verbatim
+would record the uninformative `reason=why`. That is why the refusal fills the reason in for you. A hex
+`--expect` must be a **full** object name (40/64 hex) — a truncated sha is a usage error, not a lost race.
 
-The refusal **prints that command only when the endgame is demonstrably orphaned** — `open-prs=0`. An
-older-fleet worker locks with the *branch* and holds no claim ref, so `claim-ref=free` is true while it is
-actively working; with an open PR (or an unreadable PR list, `open-prs=-1`) the refusal instead reports
-`remediation=withheld open-prs=<n>` and you confirm ownership via the board and the PR author first. The
+The refusal **prints that command only when the lane is demonstrably orphaned**, judged on THREE signals:
+`open-prs=0` **and** every matching `issue-<N>-*` branch tip older than `claim-heartbeat.sh`'s reap
+threshold (4h) **and** no fresh `refs/machine-claims/*` / `refs/heartbeats/*` ref naming the issue. The
+last two cover the **pre-PR window**: an older-fleet worker locks with the *branch*, holds no claim ref
+(`claim-ref=free`) — and because a PR is opened LATE in this pipeline it also has **no open PR** for most
+of its life, so `open-prs=0` alone would advertise a hand-away on an actively-worked issue. Anything live —
+or any signal that could not be **read** (`open-prs=-1`, an unreachable remote, a missing threshold) —
+prints `remediation=withheld <signals>` instead, and you confirm ownership via the board and the
+branch/PR author first. The
 hatch still works when invoked deliberately — withholding changes the *advice*, not the arbiter. Retrying after a transient `ERROR reason=infra` is safe: an
 adopt whose ref is already held by *this* machine+actor reports `ADOPTED … (re-entrant)` exit 0 rather
 than abandoning an issue you own. This is the only sanctioned way past that refusal — **never hand-craft

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -251,12 +251,18 @@ would record the uninformative `reason=why`. That is why the refusal fills the r
 `--expect` must be a **full** object name (40/64 hex) — a truncated sha is a usage error, not a lost race.
 
 The refusal **prints that command only when the lane is demonstrably orphaned**, judged on THREE signals:
-`open-prs=0` **and** every matching `issue-<N>-*` branch tip older than `claim-heartbeat.sh`'s reap
-threshold (4h) **and** no fresh `refs/machine-claims/*` / `refs/heartbeats/*` ref naming the issue. The
+`open-prs=0` **and** every matching `issue-<N>-*` branch tip **carrying at least one commit of its own**
+and older than `claim-heartbeat.sh`'s reap threshold (4h) **and** no fresh `refs/machine-claims/*` /
+`refs/heartbeats/*` ref naming the issue. The
 last two cover the **pre-PR window**: an older-fleet worker locks with the *branch*, holds no claim ref
 (`claim-ref=free`) — and because a PR is opened LATE in this pipeline it also has **no open PR** for most
-of its life, so `open-prs=0` alone would advertise a hand-away on an actively-worked issue. Anything live —
-or any signal that could not be **read** (`open-prs=-1`, an unreachable remote, a missing threshold) —
+of its life, so `open-prs=0` alone would advertise a hand-away on an actively-worked issue. The
+"own commits" qualifier matters just as much: `flow-activate` pushes the branch at `origin/main` with no
+commits of its own, so a freshly-activated lane's tip date **is main's** — no information about the
+worker. Such a tip is reported `newest-branch-tip=no-own-commits` and **withheld** (indeterminate), never
+judged "stale" because main happened to be quiet overnight. Anything live —
+or any signal that could not be **read** (`open-prs=-1`, an unreachable remote, an unreadable default
+branch, a missing threshold) —
 prints `remediation=withheld <signals>` instead, and you confirm ownership via the board and the
 branch/PR author first. The
 hatch still works when invoked deliberately — withholding changes the *advice*, not the arbiter. Retrying after a transient `ERROR reason=infra` is safe: an


### PR DESCRIPTION
Closes #2945. Oracle-routed (script + tests), no OpenSpec.

## The bug
`claim.sh claim <N>` refused with `reason=legacy-branch-lock` whenever any `refs/heads/issue-<N>-*` branch existed on origin — **even when `refs/claims/issue-<N>` was free**. The documented escape hatch ("Re-entrancy: all-ours -> no block") was **dead code**: it decided "ours" via `holder_is_us`, which parses `machine=`/`actor=` trailers out of the *branch tip's* commit message, and a real work branch cut from `origin/main` never carries those trailers. `adopt` couldn't substitute — it is a CAS against an *existing* ref. So `claim` refused, `adopt` had no expression for the case, and there was no third option.

**Reproduced independently twice on 2026-07-26** while resuming #2043 and #1883, both of which carried an owner-approved OpenSpec change on the branch (so a fresh branch would have orphaned the approved spec). Both times the worker bypassed the guard by hand-crafting a claim commit in the script's exact format and pushing straight to `refs/claims/issue-<N>` — correct semantics, but exactly the human-grade bypass the protocol exists to eliminate.

## The fix
`adopt --expect none` → git **empty-lease** semantics ("the ref must not exist"), so **git still arbitrates server-side** and the single-arbiter property the whole design rests on is preserved. A machine-local `git worktree list` check was considered and rejected: it looks equivalent but cannot arbitrate a cross-machine race. `--reason` is **mandatory** on that path, recorded in the claim commit and rendered by `status` (AC1's "records who took it and why"). The refusal message now names the blocking branch, states `claim-ref=free`, and prints the exact remediation command — a bare `LOST` is what sent two workers into manual bypasses (AC option 3, taken as well).

The dead re-entrancy hatch is **removed**, not patched: tip-based `holder_is_us` re-entrancy is gone, replaced by `legacy_branch_scan`, and a test pins that even a claim-shaped branch tip cannot grant a claim — so the hatch can't be silently revived (AC4).

### Two corrections to the issue's own analysis
- The issue reports `adopt --expect 0000…0` fails the lease. Against the live origin it **creates the ref** — a silent, unrecorded create, arguably worse than the bug being fixed. All-zero leases now route through the same audited `--reason` path, while `--expect ''` stays exit 64 so an unset shell variable can never turn a CAS into a create.
- The "merged but branch not deleted" case in *When this bites* is **live, not hypothetical**: `gh pr merge --delete-branch` reported success on PR #2892 the same day without deleting the branch (cf. #2922 trap 3).

## Review findings fixed (6 blockers, two review passes)
- **`cmd_adopt` had no re-entrancy check** → a retry after the transient `ERROR reason=infra` (whose documented remedy *is* retry) reported `ADOPT-LOST` **against ourselves**, exit 2. Workers read exit 2 as "you didn't win, move on", so a worker that hit a network blip mid-resume would abandon an issue it owns **while the claim ref stayed held** — nobody could take it. Now matches `cmd_claim`: `ADOPTED … (re-entrant)` exit 0.
- **`sanitize_reason` killed the script on macOS**: BSD `tr -c` aborts with `Illegal byte sequence` on non-ASCII in a UTF-8 locale, and under `set -euo pipefail` that emitted **no `CLAIM:` line at all** with exit 1 — which the contract defines as "retryable", so a caller would retry forever on input that can never succeed. `--reason "resume — parked claim"` was enough to trigger it. Fixed with `LC_ALL=C` across the pipeline.
- **Identity forgery in the lock (defeats it outright).** `msg_field` was a greedy `.*key=` (last match wins) and `--actor` was unsanitized, so `claim N --actor 'flow machine=machineA'` from machineB made machineA's `claim N` print `HELD … (re-entrant)` **exit 0** on a ref machineB held — two writers on one issue. Root fix: **exact-key, first-match, per-token** `msg_field` (token *equality* also stops `holder-machine=` answering for `machine`), plus `--actor` sanitized at the arg boundary so the record and the comparison use one value. In scope because this change adds a second user-controlled string to the very commit message that parser reads.
- The brand-new `ERROR reason=infra` path (empty-lease push rejected while the ref is absent) had **zero coverage**; now pinned.
- Doctrine: `website/.../delivery-pipeline.md` still said eligibility requires "no legacy `issue-<N>-*` branch" with no escape hatch — the exact prose that caused the bypasses. Updated in this change, per CLAUDE.md's same-change rule.
- Minimal **#2677 item 2** fold, disclosed: the new refusal asserts "claim-ref=free, a branch blocks you", which must not be printed off an unread guard, so an `ls-remote --heads` failure is now `ERROR reason=infra` exit 1 instead of a false all-clear. #2677 items 1 and 3 untouched — that issue's scope is the owner's.

## An honest negative on the race test
The test-quality review **mutation-tested the suite** and found the original race test vacuous: swapping the empty lease for `git push --force` left it green. Investigating that produced a finding worth recording rather than papering over — **no race shape can catch `push --force`**, because when both claimants advertise "absent" they each send an all-zero old value and git's *protocol-level stale-info check*, not the lease, rejects the second push. The witness was therefore moved to the **fresh-advertisement** shape, where the mutant dies deterministically: it now fails **7 assertions**. A `pre-receive` stagger that passed under the mutant was **deleted rather than kept as theatre**, and both roles are labelled in the test header so they can't be collapsed.

## Coverage (AC3)
New hermetic suite `scripts/flow/tests/claim-resume.test.sh` — **50/50**, wired into the gate's `tooling-tests` and `ci.yml`'s `flow-tooling-tests` (macOS included). Against pre-fix `claim.sh` the suite is **12 pass / 38 fail**. Covers: free ref + foreign-tip branch → resume succeeds; **held** ref + branch → still refused with the foreign ref byte-unchanged; two machines racing → exactly one accepted create with `old` all-zeros (post-receive witness), 5 rounds; reaper `release --force` vs resumer `adopt` barrier race; adversarial forged `--reason`/`--actor`; non-ASCII reason; holder release round trip; and arg-surface pins (`--expect <wrong-hex>` on a free ref must not create; non-numeric → 64; empty reason → `reason=unspecified`; 120-char truncation; newline in reason).

`--only tooling-tests` PASS. The ONE full gate of record runs pre-merge in `flow-closer` and its verbatim summary is posted below.
