### PR TITLE
fix(#2942): worker environment preflight — verify the operation, not the configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,6 +379,13 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   deletes the ref (refuses under an open PR without `--force`). Maintain the liveness heartbeat
   (`scripts/flow/claim-heartbeat.sh beat <N>`, refreshed at claim + every stage transition);
   `flow-board` reaps deterministically (age > 4h AND no open PR) (#2089).
+  **The lock is a plain `git push`, so git — not just `gh` — must be authenticated (#2942).** They
+  are separate credential paths: an authenticated `gh` with an unwired git fails every claim with
+  `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT
+  retryable)` instead of the old misleading `reason=infra (transient — retry)` — do not retry it,
+  fix the box (`gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes`, which also
+  probes board access functionally rather than trusting the `project` scope string). The three
+  worker-environment deltas and the messages that identify them: `docs/development/fleet-runbook.md`.
 - **Supervisor-authored machine claim + CI reaper (#2655/#2499)**: liveness is now MECHANISM-driven,
   not prose. `worker-supervisor.sh` stamps `refs/machine-claims/<machine>` (issue+supervisor-PID+ts)
   via `claim-heartbeat.sh stamp` at every spawn, refreshes it each iteration, and clears it on a

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -23,8 +23,9 @@ without it, it prints the exact command for each gap. It verifies, in order:
    a `project` scope-string match (#2942 — see the deltas below); the scope check
    survives only as a cheap pre-filter. Missing scope → `gh auth refresh -s project`.
    Point it elsewhere with `CQLITE_PROJECT_OWNER` / `CQLITE_PROJECT_NUMBER`.
-3b. **git push credentials** (#2942) — a *separate* credential path from `gh`.
-   Under `--yes` it configures one; the token value is never written to disk.
+   It also checks **git push credentials** (#2942) — a *separate* credential path from
+   `gh`. Under `--yes` it configures one, **scoped to the origin host**, and the token
+   value is never written to disk.
 4. **roborev** — installed, and this machine's *configured* agent resolves.
 5. **Datasets** + `CQLITE_DATASETS_ROOT` guidance.
 6. **Health check** — runs the gate's fmt smoke and prints the authoritative
@@ -38,15 +39,22 @@ The bootstrap now checks the first two and fails loudly; the third is a hand-typ
 
 | You see | Real cause | Working form |
 |---|---|---|
-| `fatal: could not read Username for 'https://github.com'` | `gh` is authenticated but **git is not** — they are separate credential paths. `scripts/flow/claim.sh` + `claim-heartbeat.sh` push with plain git on 10+ call sites, so the claim protocol itself does not work. | `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes` (configures a helper that dereferences `$GH_TOKEN` at call time). |
+| `fatal: could not read Username for 'https://github.com'` | `gh` is authenticated but **git is not** — they are separate credential paths. `scripts/flow/claim.sh` + `claim-heartbeat.sh` push with plain git on 10+ call sites, so the claim protocol itself does not work. | `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes` (configures an origin-host-scoped helper that dereferences `$GH_TOKEN` at call time). |
 | `gh project …` fails for a missing **`read:org`** scope on a token whose scopes DO include `project` | A scope match is evidence about a token, not about the operation. `gh project item-edit` needs `read:org`; the equivalent GraphQL mutation does not. | Widen the token (`gh auth refresh -s read:org`), **or** do board writes through the `updateProjectV2ItemFieldValue` GraphQL mutation — it succeeds with the same token. |
 | `stale info` from a **bare** `git push --force-with-lease`, even when local and remote refs demonstrably match | The bare form leases against a remote-tracking ref your checkout may never have fetched. | Always the explicit CAS form: `git push --force-with-lease=<ref>:<sha>` (what the flow scripts already use). |
 
-**Claim verdicts encode this too (#2942).** An unauthenticated claim push now reports
-`CLAIM: ERROR reason=auth … (NOT retryable …)` and names the fix. It used to report
-`reason=infra … (transient — retry)`, which sent workers into a retry loop on a machine
-fault that can never self-clear. `reason=infra (transient — retry)` still means what it
-says: a real blip, retry it.
+**Claim verdicts encode this too (#2942).** An unauthenticated push now reports
+`CLAIM: ERROR reason=auth … (NOT retryable …)` and names the fix, for `claim.sh`'s
+`claim`, `adopt`, `release` and `smoke`. It used to report `reason=infra … (transient —
+retry)`, which sent workers into a retry loop on a machine fault that can never
+self-clear. `reason=infra (transient — retry)` still means what it says: a real blip,
+retry it. **Scope:** this classification covers `claim.sh` only —
+`claim-heartbeat.sh` surfaces git's raw error on its pushes and does not classify.
+
+**The `--yes` credential helper reads `$GH_TOKEN` from the environment.** That is
+deliberate (no secret on disk), but it means the helper only works in shells where
+`GH_TOKEN` is exported — a systemd/cron worker started without it will still fail every
+push. For unattended workers prefer `gh auth setup-git`.
 
 ## Accelerators: what the SUMMARY line means
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -22,7 +22,11 @@ without it, it prints the exact command for each gap. It verifies, in order:
    (Path A, #1886). The verdict is a **read-only functional probe** of the board, not
    a `project` scope-string match (#2942 — see the deltas below); the scope check
    survives only as a cheap pre-filter. Missing scope → `gh auth refresh -s project`.
-   Point it elsewhere with `CQLITE_PROJECT_OWNER` / `CQLITE_PROJECT_NUMBER`.
+   Scopes are read from the **active account's** stanza only, and the probe runs as
+   `CQLITE_PROJECT_ACCOUNT` — the same account `flow-board` forces active before every
+   board op — switching back afterwards so a *check* never leaves your active account
+   changed. The output names the account it measured. Point it elsewhere with
+   `CQLITE_PROJECT_OWNER` / `CQLITE_PROJECT_NUMBER` / `CQLITE_PROJECT_ACCOUNT`.
    It also checks **git push credentials** (#2942) — a *separate* credential path from
    `gh`. Under `--yes` it configures one, **scoped to the origin host**, and the token
    value is never written to disk.
@@ -42,6 +46,15 @@ The bootstrap now checks the first two and fails loudly; the third is a hand-typ
 | `fatal: could not read Username for 'https://github.com'` | `gh` is authenticated but **git is not** — they are separate credential paths. `scripts/flow/claim.sh` + `claim-heartbeat.sh` push with plain git on 10+ call sites, so the claim protocol itself does not work. | `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes` (configures an origin-host-scoped helper that dereferences `$GH_TOKEN` at call time). |
 | `gh project …` fails for a missing **`read:org`** scope on a token whose scopes DO include `project` | A scope match is evidence about a token, not about the operation. `gh project item-edit` needs `read:org`; the equivalent GraphQL mutation does not. | Widen the token (`gh auth refresh -s read:org`), **or** do board writes through the `updateProjectV2ItemFieldValue` GraphQL mutation — it succeeds with the same token. |
 | `stale info` from a **bare** `git push --force-with-lease`, even when local and remote refs demonstrably match | The bare form leases against a remote-tracking ref your checkout may never have fetched. | Always the explicit CAS form: `git push --force-with-lease=<ref>:<sha>` (what the flow scripts already use). |
+
+**A note on *which account* any of this is about.** `gh auth status` prints one stanza
+**per logged-in account**, and the active one is not guaranteed first — so a plain grep
+of its output can report a different account's scopes than the one your commands will
+actually use. The documented instance is in `.claude/skills/flow-board/SKILL.md`: gh's
+active account silently flips to an EMU account lacking `project`, and every board write
+then degrades to labels **silently**. When diagnosing a board problem, always establish
+the active account first (`gh auth status` → `Active account: true`), and remember
+`flow-board` forces `CQLITE_PROJECT_ACCOUNT` active before each board op.
 
 **Claim verdicts encode this too (#2942).** An unauthenticated push now reports
 `CLAIM: ERROR reason=auth … (NOT retryable …)` and names the fix, for `claim.sh`'s

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -18,12 +18,35 @@ without it, it prints the exact command for each gap. It verifies, in order:
 2. **Gate accelerators** (issue #1848) — `sccache`, `cargo-nextest`, modern bash
    (≥4.3). Detection mirrors the gate's own `ACCEL_*` block, so the script and
    `scripts/agent-gate.sh` can never disagree.
-3. **`gh` auth + the `project` scope** — the board is the sole dispatch authority
-   (Path A, #1886). Missing scope → `gh auth refresh -s project`.
+3. **`gh` auth + board access** — the board is the sole dispatch authority
+   (Path A, #1886). The verdict is a **read-only functional probe** of the board, not
+   a `project` scope-string match (#2942 — see the deltas below); the scope check
+   survives only as a cheap pre-filter. Missing scope → `gh auth refresh -s project`.
+   Point it elsewhere with `CQLITE_PROJECT_OWNER` / `CQLITE_PROJECT_NUMBER`.
+3b. **git push credentials** (#2942) — a *separate* credential path from `gh`.
+   Under `--yes` it configures one; the token value is never written to disk.
 4. **roborev** — installed, and this machine's *configured* agent resolves.
 5. **Datasets** + `CQLITE_DATASETS_ROOT` guidance.
 6. **Health check** — runs the gate's fmt smoke and prints the authoritative
    `accelerators:` line.
+
+## Three deltas that fail with a message pointing away from the cause (#2942)
+
+Each of these cost a worker a diagnosis round-trip on a Linux box. They are listed by
+the **message you will actually see**, because none of the three reads as its real cause.
+The bootstrap now checks the first two and fails loudly; the third is a hand-typed footgun.
+
+| You see | Real cause | Working form |
+|---|---|---|
+| `fatal: could not read Username for 'https://github.com'` | `gh` is authenticated but **git is not** — they are separate credential paths. `scripts/flow/claim.sh` + `claim-heartbeat.sh` push with plain git on 10+ call sites, so the claim protocol itself does not work. | `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes` (configures a helper that dereferences `$GH_TOKEN` at call time). |
+| `gh project …` fails for a missing **`read:org`** scope on a token whose scopes DO include `project` | A scope match is evidence about a token, not about the operation. `gh project item-edit` needs `read:org`; the equivalent GraphQL mutation does not. | Widen the token (`gh auth refresh -s read:org`), **or** do board writes through the `updateProjectV2ItemFieldValue` GraphQL mutation — it succeeds with the same token. |
+| `stale info` from a **bare** `git push --force-with-lease`, even when local and remote refs demonstrably match | The bare form leases against a remote-tracking ref your checkout may never have fetched. | Always the explicit CAS form: `git push --force-with-lease=<ref>:<sha>` (what the flow scripts already use). |
+
+**Claim verdicts encode this too (#2942).** An unauthenticated claim push now reports
+`CLAIM: ERROR reason=auth … (NOT retryable …)` and names the fix. It used to report
+`reason=infra … (transient — retry)`, which sent workers into a retry loop on a machine
+fault that can never self-clear. `reason=infra (transient — retry)` still means what it
+says: a real blip, retry it.
 
 ## Accelerators: what the SUMMARY line means
 

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -45,10 +45,14 @@ loudly rather than reporting a healthy machine. Search for the message you actua
   `scripts/flow/claim-heartbeat.sh` push with plain `git` on 10+ call sites, so the claim protocol
   — the cross-machine lock — simply does not work while `gh auth status` reports a happy machine.
   Fix: `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes`, which configures a
-  helper that dereferences `$GH_TOKEN` **at call time** (the token itself is never written to disk,
-  so rotating it needs no reconfiguration). Related: an unauthenticated claim push now reports
+  helper **scoped to the origin host** that dereferences `$GH_TOKEN` **at call time** (the token
+  itself is never written to disk, so rotating it needs no reconfiguration). Because that helper
+  reads the environment, it only works in shells where `GH_TOKEN` is exported — for an unattended
+  systemd/cron worker prefer `gh auth setup-git`. Related: an unauthenticated push now reports
   `CLAIM: ERROR reason=auth … (NOT retryable …)` — it used to say `reason=infra … (transient —
-  retry)` and send workers into a retry loop on a fault that can never self-clear.
+  retry)` and send workers into a retry loop on a fault that can never self-clear. That
+  classification covers `claim.sh` (`claim`/`adopt`/`release`/`smoke`) only; `claim-heartbeat.sh`
+  surfaces git's raw error on its own pushes and does not classify them.
 - **A `gh project` failure citing a missing `read:org` scope on a token whose scopes DO include
   `project`** — a scope match is evidence about a token, not about the operation. `gh project
   item-edit` needs `read:org`; the `updateProjectV2ItemFieldValue` GraphQL mutation does **not**

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -59,7 +59,11 @@ loudly rather than reporting a healthy machine. Search for the message you actua
   and succeeds with the same token. Fix: `gh auth refresh -s read:org`, or route board WRITES
   through that mutation (which is what `project-board-sync.yml` already does). The bootstrap's
   board check is now a read-only functional probe for exactly this reason — it can no longer print
-  "board dispatch works" on the strength of the scope string.
+  "board dispatch works" on the strength of the scope string. It also reads scopes from the
+  **active account's** stanza only and probes as `CQLITE_PROJECT_ACCOUNT` (the account `flow-board`
+  forces active), restoring your previous account afterwards: `gh auth status` prints one stanza per
+  logged-in account, so a whole-output grep can describe an account your commands never use — the
+  EMU-account flip documented in `.claude/skills/flow-board/SKILL.md`.
 - **`stale info` from a bare `git push --force-with-lease`**, even when local and remote refs
   demonstrably match — the bare form leases against a remote-tracking ref this checkout may never
   have fetched. Always use the explicit CAS form `git push --force-with-lease=<ref>:<sha>`, which

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -31,9 +31,35 @@ issues itself). Other machines run pure **workers**. A lead is a worker with a h
 git clone https://github.com/pmcfadin/cqlite && cd cqlite
 bash scripts/bootstrap-agent-machine.sh        # or manually: sccache, cargo-nextest, bash>=4.3, mold (Linux)
 bash test-data/scripts/fetch-datasets.sh       # real SSTable binaries — REQUIRED (see below)
+gh auth setup-git                              # git push credentials — SEPARATE from gh auth (#2942)
 gh auth status                                  # must include the 'project' scope (board access)
 bash scripts/flow/claim.sh smoke               # preflight: prove origin accepts refs/claims/* (see below)
 ```
+
+**Three deltas that fail with a message pointing away from their cause (#2942).** Each cost a
+worker a diagnosis round-trip on a Linux box; the bootstrap now checks the first two and fails
+loudly rather than reporting a healthy machine. Search for the message you actually saw:
+
+- **`fatal: could not read Username for 'https://github.com'`** — `gh` is authenticated but **git
+  is not**. They are separate credential paths, and `scripts/flow/claim.sh` +
+  `scripts/flow/claim-heartbeat.sh` push with plain `git` on 10+ call sites, so the claim protocol
+  — the cross-machine lock — simply does not work while `gh auth status` reports a happy machine.
+  Fix: `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes`, which configures a
+  helper that dereferences `$GH_TOKEN` **at call time** (the token itself is never written to disk,
+  so rotating it needs no reconfiguration). Related: an unauthenticated claim push now reports
+  `CLAIM: ERROR reason=auth … (NOT retryable …)` — it used to say `reason=infra … (transient —
+  retry)` and send workers into a retry loop on a fault that can never self-clear.
+- **A `gh project` failure citing a missing `read:org` scope on a token whose scopes DO include
+  `project`** — a scope match is evidence about a token, not about the operation. `gh project
+  item-edit` needs `read:org`; the `updateProjectV2ItemFieldValue` GraphQL mutation does **not**
+  and succeeds with the same token. Fix: `gh auth refresh -s read:org`, or route board WRITES
+  through that mutation (which is what `project-board-sync.yml` already does). The bootstrap's
+  board check is now a read-only functional probe for exactly this reason — it can no longer print
+  "board dispatch works" on the strength of the scope string.
+- **`stale info` from a bare `git push --force-with-lease`**, even when local and remote refs
+  demonstrably match — the bare form leases against a remote-tracking ref this checkout may never
+  have fetched. Always use the explicit CAS form `git push --force-with-lease=<ref>:<sha>`, which
+  is what the flow scripts already do; the bare form only bites a human or agent typing it ad hoc.
 
 **Linux workers — mold linker (#2859):** on Linux hosts bootstrap also provisions the **mold**
 linker (linking is the one build cost sccache cannot cache — every `--lite` round and full gate
@@ -290,7 +316,8 @@ machine + heartbeat age (issue #2089). Interpretation:
 |---|---|
 | Laptop lid closed mid-issue | Nothing. Commits are on the origin branch. Reopen and say `implement <N>` — it resumes from the worktree. |
 | Session feels degraded / bloated | Kill it, start fresh. Board + disk are the state; the new session rehydrates in one board read. |
-| Board unreachable (auth/scope error) | The session STOPS by design (labels are decorative, never a dispatch source). Fix `gh auth refresh -s project` and restart. |
+| Board unreachable (auth/scope error) | The session STOPS by design (labels are decorative, never a dispatch source). Fix `gh auth refresh -s project` and restart. If the scope is already present and `gh project` still fails for `read:org`, that is the #2942 delta — use the `updateProjectV2ItemFieldValue` GraphQL mutation for board writes, or widen the token with `-s read:org`. |
+| `fatal: could not read Username` on any push | git has no credentials even though `gh` does (#2942). The claim protocol pushes with plain git, so it is fully broken until fixed: `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes`. A claim attempt on such a box reports `reason=auth`, not a retryable transient. |
 | Gate seems hung | It's probably queued: look for `waiting for gate slot (N in use)…`. Queued ≠ hung. |
 | Green SUMMARY but parity lines say SKIP | Datasets missing on that machine — `fetch-datasets.sh`, re-run. The FULL gate FAILs CLOSED here (`missing-fixtures: FAIL-CLOSED (#2078)`) so it can't slip through; `--lite`/`--only` stay lenient. |
 | Two machines want the same issue | Impossible past the claim: the second claim-ref push is rejected server-side (non-fast-forward on the fixed-name ref, #2665); the loser sees `CLAIM LOST` and picks the next Ready item. |

--- a/openspec/changes/worker-env-preflight/design.md
+++ b/openspec/changes/worker-env-preflight/design.md
@@ -1,0 +1,73 @@
+# Design: worker environment preflight
+
+## Context
+
+`scripts/bootstrap-agent-machine.sh` (480 lines) is the established "check everything, print the fix"
+entry point, with `--yes` to auto-apply, a self-test at `scripts/tests/test_bootstrap_agent_machine.sh`
+(429 lines), and an idiom of `ok`/`warn`/`info` + `run_or_print`. Sections already cover the Rust
+toolchain, accelerators, mold, gh auth, roborev, datasets, and the single-gate default. It is the right
+home: workers are told to run it, and `fleet-runbook.md` already points at it.
+
+`worker-supervisor.sh` has a bounded `preflight_wait`/`preflight_reason`, but that is a *per-iteration*
+hold for leftover processes — the wrong layer for a machine-provisioning fact that cannot self-clear.
+
+## Decision 1 — Fix at bootstrap (check + optional auto-fix), not at per-iteration preflight
+
+**Chosen.** These are machine-provisioning facts. They do not change between iterations, so paying the
+check once at setup is correct, and `--yes` can remediate. Putting them in the supervisor's per-iteration
+preflight would either spin (a hold that never clears — explicitly guarded against by #2670) or re-check
+an invariant hundreds of times.
+
+**Rejected — supervisor preflight.** The supervisor's hold loop is bounded precisely because a
+non-self-clearing hold is a hang. A missing credential helper never self-clears.
+
+## Decision 2 — Auto-configure the credential helper, but write NO secret to disk
+
+**Chosen.** Configure a helper that reads `$GH_TOKEN` from the environment at call time:
+
+```
+git config --global credential.helper '!f(){ echo username=x-access-token; echo password=$GH_TOKEN; };f'
+```
+
+The token is **never written to disk** — the helper is a shell snippet that dereferences the env var when
+git asks. Rotating `GH_TOKEN` needs no reconfiguration, and a leaked `~/.gitconfig` leaks no credential.
+
+**Rejected — `gh auth setup-git`.** It is the obvious answer and may be the better one on boxes where it
+works; it configures `gh` as the credential helper. It is listed as the preferred form when available,
+with the env-var helper as the fallback, because the failure observed here is precisely that the `gh`
+credential path was not wired.
+
+**Rejected — writing the token into `~/.git-credentials`.** Persists a secret in plaintext, and survives
+rotation as a stale credential. This change deliberately does not do it.
+
+**Security note.** Under `--yes` this writes a helper to the user's global git config. That is a real (if
+small) posture change on a shared box, so it is called out for owner approval rather than slipped in.
+
+## Decision 3 — The board check becomes a FUNCTIONAL probe
+
+**Chosen.** Replace the scope-string match with an actual attempt against the board, because the observed
+failure is a scope-string match passing while the operation fails. Probe read-only, then report which
+write path works:
+
+- `gh project item-list` / a `projectV2` GraphQL read to confirm reachability;
+- report explicitly that `gh project item-edit` may fail for `read:org` while the
+  `updateProjectV2ItemFieldValue` GraphQL mutation succeeds with the same token, and name the mutation as
+  the supported fallback.
+
+Keep the scope check as a *cheap pre-filter* (its `project`-token-boundary matching is careful and worth
+keeping), but it may no longer be the thing that prints "board dispatch works".
+
+**Rejected — probing with a write.** A bootstrap must not mutate a real board item as a side effect.
+
+## Decision 4 — `claim.sh` must not call an auth failure "transient"
+
+**Chosen.** Distinguish "push rejected because unauthenticated" from a genuine transient. Emitting
+`transient — retry` for a permanent failure is worse than a bare error: it tells the worker to do the one
+thing guaranteed not to help. Detect the credential signature and emit a distinct, non-retryable verdict
+naming the fix.
+
+## Decision 5 — `--force-with-lease` is documented, not mechanized
+
+**Chosen.** Document the explicit `=<ref>:<sha>` form in the runbook. No code change: the flow scripts
+already use the explicit form (`claim.sh:30,385,481`); the bare form only bites a human or agent typing
+it ad hoc. Mechanizing would mean wrapping git, which is disproportionate.

--- a/openspec/changes/worker-env-preflight/proposal.md
+++ b/openspec/changes/worker-env-preflight/proposal.md
@@ -1,0 +1,44 @@
+# Worker environment preflight — fail loudly on the deltas that silently break a non-macOS worker
+
+## Why
+
+Issue #2942. Three pipeline steps failed on a Linux worker during the #1883 delivery in ways the
+doctrine does not describe. Each cost a diagnosis round-trip, and each fails with a message that points
+away from the real cause.
+
+1. **`git push` has no credentials.** `gh` is authenticated (`GH_TOKEN`), but git is not, so every raw
+   `git push` fails with `fatal: could not read Username for 'https://github.com'`. This is not a corner
+   case: `scripts/flow/claim.sh` and `scripts/flow/claim-heartbeat.sh` push on **10+ call sites** — the
+   claim ref, adoption CAS, release, heartbeats. The claim protocol itself does not work.
+2. **The bootstrap's board check gives a FALSE OK.** `scripts/bootstrap-agent-machine.sh` §3 matches the
+   `project` scope string and prints `'project' scope present — board dispatch works`. On this box that
+   scope IS present and `gh project item-edit` still fails for a missing `read:org` scope. The check
+   validates a scope, not the operation.
+3. **Bare `--force-with-lease` fails "stale info"** even when local and remote refs demonstrably match;
+   only the explicit `--force-with-lease=<ref>:<sha>` CAS form works.
+
+The unifying defect is not "the docs are incomplete" — it is that **the failures are misattributed**. The
+worst instance: `claim.sh` reports a credential failure as a *transient* error and advises a retry —
+
+```
+CLAIM: ERROR reason=infra detail=push-rejected-but-ref-absent-on-origin (transient — retry)
+```
+
+— so a worker retries a permanently broken operation instead of fixing auth. A preflight that fails loudly
+at machine setup is worth more than any amount of prose, because the current failures do not read as auth
+problems at the point they occur.
+
+## What changes
+
+- **`scripts/bootstrap-agent-machine.sh`** gains a git-credential check (new section) and its §3 board
+  check becomes a **functional probe** rather than a scope-string match.
+- **`scripts/flow/claim.sh`** stops classifying an auth failure as `transient — retry`.
+- **Doctrine** (`docs/development/fleet-runbook.md` + `agent-machine-setup.md`) records the three deltas
+  with the failure message that identifies each.
+- **`scripts/tests/test_bootstrap_agent_machine.sh`** covers the new checks.
+
+## Non-goals
+
+- Not fixing the gate poll predicate (#2908), the merge-path silent failures (#2922), closer orphaning
+  (#2748), gate disk footprint (#2758), or the claim resume gap (#2945). Cross-linked, separately owned.
+- Not changing how credentials are *obtained* — `GH_TOKEN` remains the source of truth.

--- a/openspec/changes/worker-env-preflight/specs/worker-environment-preflight/spec.md
+++ b/openspec/changes/worker-env-preflight/specs/worker-environment-preflight/spec.md
@@ -1,0 +1,93 @@
+# worker-environment-preflight
+
+## ADDED Requirements
+
+### Requirement: The machine bootstrap verifies git push credentials, not just `gh` auth
+
+`scripts/bootstrap-agent-machine.sh` SHALL check that a raw `git push` to `origin` can authenticate, and
+SHALL NOT treat an authenticated `gh` CLI as evidence that git itself is authenticated — they are separate
+credential paths, and the flow tooling (`scripts/flow/claim.sh`, `scripts/flow/claim-heartbeat.sh`) pushes
+directly with `git` on 10+ call sites.
+
+When no working credential path is present the check SHALL warn with the exact remediation. Under `--yes`
+it SHALL configure one, preferring `gh auth setup-git` when that works and otherwise a helper that
+dereferences `$GH_TOKEN` **at call time**. It SHALL NOT write the token itself to disk.
+
+#### Scenario: A box with authenticated gh but no git credential helper is flagged
+- **GIVEN** `gh auth status` succeeds and no git credential helper is configured for `github.com`
+- **WHEN** `scripts/bootstrap-agent-machine.sh` runs
+- **THEN** it reports the git-credential gap as a warning (not an `ok`) and prints the remediation
+- **AND** it does NOT report success merely because `gh` is authenticated
+
+#### Scenario: `--yes` configures a credential path that persists no secret
+- **GIVEN** the same box
+- **WHEN** `scripts/bootstrap-agent-machine.sh --yes` runs
+- **THEN** a subsequent `git push` to `origin` authenticates without an explicit `-c credential.helper`
+- **AND** no file written by the bootstrap contains the token value
+
+### Requirement: The board check probes the board operation, not the scope string
+
+The bootstrap's board check SHALL verify that the board is actually reachable with the current
+credentials, and SHALL NOT report that board dispatch works on the strength of the `project` scope string
+alone. A machine has been observed with the `project` scope present where `gh project item-edit` fails for
+a missing `read:org` scope while the equivalent `updateProjectV2ItemFieldValue` GraphQL mutation succeeds
+with the same token — so a scope match is not evidence the operation works.
+
+The check SHALL name the GraphQL mutation as the supported write path when `gh project` subcommands are
+unavailable. The probe SHALL be read-only — a bootstrap SHALL NOT mutate a real board item.
+
+#### Scenario: `project` scope present but `gh project` unusable is reported accurately
+- **GIVEN** a token whose scopes include `project` but not `read:org`
+- **WHEN** the bootstrap's board check runs
+- **THEN** it does NOT print an unqualified "board dispatch works"
+- **AND** it names the GraphQL `updateProjectV2ItemFieldValue` fallback as the working write path
+
+#### Scenario: The board probe never mutates board state
+- **GIVEN** any credential state
+- **WHEN** the bootstrap's board check runs
+- **THEN** no board item's field values are modified
+
+### Requirement: An authentication failure is never reported as a retryable transient
+
+`scripts/flow/claim.sh` SHALL distinguish a push that failed because git could not authenticate from a
+genuine transient (network/outage) failure, and SHALL NOT emit `transient — retry` for the former.
+Observed today: a missing git credential helper surfaces as
+`CLAIM: ERROR reason=infra detail=push-rejected-but-ref-absent-on-origin (transient — retry)`, which
+directs a worker to retry an operation that can never succeed until the machine is fixed.
+
+#### Scenario: An unauthenticated claim push reports a non-retryable auth verdict
+- **GIVEN** a machine with no git credential helper and a free `refs/claims/issue-<N>`
+- **WHEN** `claim.sh claim <N>` runs
+- **THEN** the emitted verdict identifies the failure as an authentication/configuration problem and names
+  the remediation
+- **AND** it does NOT describe the failure as transient or advise a retry
+
+#### Scenario: A genuine transient still reports as retryable
+- **GIVEN** a machine WITH working credentials and an unreachable remote
+- **WHEN** `claim.sh claim <N>` runs
+- **THEN** the verdict is still the retryable infra error (no regression in the #2665 contract)
+
+### Requirement: The three deltas are recorded in the fleet doctrine with their identifying symptoms
+
+`docs/development/fleet-runbook.md` (and/or `agent-machine-setup.md`) SHALL record the git-credential
+requirement, the explicit `--force-with-lease=<ref>:<sha>` form, and the GraphQL board-write fallback —
+each paired with the **failure message that identifies it**, since all three currently fail with messages
+that point away from the cause (`fatal: could not read Username`, `stale info`, a `read:org` scope error
+on a token that has `project`).
+
+#### Scenario: A worker hitting any of the three symptoms can find the cause by searching the message
+- **GIVEN** a worker encounters `fatal: could not read Username`, a `--force-with-lease` `stale info`
+  rejection, or a `gh project` `read:org` failure
+- **WHEN** they search the fleet doctrine for that message
+- **THEN** they find the delta, its cause, and the working form
+
+### Requirement: The new bootstrap checks are covered by the bootstrap self-test
+
+`scripts/tests/test_bootstrap_agent_machine.sh` SHALL cover the git-credential check and the board probe,
+including the false-OK case the board check exists to prevent (scope present, operation unavailable), so
+a future refactor cannot silently restore a scope-string-only verdict.
+
+#### Scenario: The self-test fails if the board check regresses to a scope-string match
+- **GIVEN** a simulated environment with the `project` scope present but `gh project` unusable
+- **WHEN** the bootstrap self-test runs
+- **THEN** it FAILS if the board check reports unqualified success

--- a/openspec/changes/worker-env-preflight/tasks.md
+++ b/openspec/changes/worker-env-preflight/tasks.md
@@ -1,28 +1,28 @@
 # Tasks — worker environment preflight
 
 ## 1. Git credential check (surface: `scripts/bootstrap-agent-machine.sh`)
-- [ ] 1.1 New section: detect whether a raw `git push` to `origin` can authenticate, independent of `gh auth status`.
-- [ ] 1.2 Warn + print remediation when absent; under `--yes` configure `gh auth setup-git` when it works,
+- [x] 1.1 New section: detect whether a raw `git push` to `origin` can authenticate, independent of `gh auth status`.
+- [x] 1.2 Warn + print remediation when absent; under `--yes` configure `gh auth setup-git` when it works,
       else the `$GH_TOKEN`-dereferencing helper. Never persist the token value.
-- [ ] 1.3 Verify no bootstrap-written file contains the token.
+- [x] 1.3 Verify no bootstrap-written file contains the token.
 
 ## 2. Board probe (surface: `scripts/bootstrap-agent-machine.sh` §3)
-- [ ] 2.1 Replace the scope-string verdict with a READ-ONLY functional probe.
-- [ ] 2.2 Keep the `project` token-boundary scope match as a cheap pre-filter, not as the verdict.
-- [ ] 2.3 Name the `updateProjectV2ItemFieldValue` GraphQL fallback when `gh project` is unusable.
+- [x] 2.1 Replace the scope-string verdict with a READ-ONLY functional probe.
+- [x] 2.2 Keep the `project` token-boundary scope match as a cheap pre-filter, not as the verdict.
+- [x] 2.3 Name the `updateProjectV2ItemFieldValue` GraphQL fallback when `gh project` is unusable.
 
 ## 3. Claim auth verdict (surface: `scripts/flow/claim.sh`)
-- [ ] 3.1 Detect the credential-failure signature on a push and emit a distinct non-retryable verdict.
-- [ ] 3.2 Preserve the existing retryable infra verdict for genuine transients (#2665 contract).
+- [x] 3.1 Detect the credential-failure signature on a push and emit a distinct non-retryable verdict.
+- [x] 3.2 Preserve the existing retryable infra verdict for genuine transients (#2665 contract).
 
 ## 4. Doctrine
-- [ ] 4.1 Record all three deltas + identifying symptoms in `fleet-runbook.md` / `agent-machine-setup.md`.
-- [ ] 4.2 Update CLAUDE.md only if a worker-facing instruction changes.
+- [x] 4.1 Record all three deltas + identifying symptoms in `fleet-runbook.md` / `agent-machine-setup.md`.
+- [x] 4.2 Update CLAUDE.md only if a worker-facing instruction changes.
 
 ## 5. Tests
-- [ ] 5.1 Extend `scripts/tests/test_bootstrap_agent_machine.sh` for the credential check + board probe,
+- [x] 5.1 Extend `scripts/tests/test_bootstrap_agent_machine.sh` for the credential check + board probe,
       including the scope-present-but-operation-unavailable false-OK case.
-- [ ] 5.2 `claim.sh` coverage for auth-failure vs transient classification.
+- [x] 5.2 `claim.sh` coverage for auth-failure vs transient classification.
 
 ## 6. Gate / review / audit
 - [ ] 6.1 `--lite` green each round; full gate once pre-merge; review-first; C anchored to this change's specs.

--- a/openspec/changes/worker-env-preflight/tasks.md
+++ b/openspec/changes/worker-env-preflight/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — worker environment preflight
+
+## 1. Git credential check (surface: `scripts/bootstrap-agent-machine.sh`)
+- [ ] 1.1 New section: detect whether a raw `git push` to `origin` can authenticate, independent of `gh auth status`.
+- [ ] 1.2 Warn + print remediation when absent; under `--yes` configure `gh auth setup-git` when it works,
+      else the `$GH_TOKEN`-dereferencing helper. Never persist the token value.
+- [ ] 1.3 Verify no bootstrap-written file contains the token.
+
+## 2. Board probe (surface: `scripts/bootstrap-agent-machine.sh` §3)
+- [ ] 2.1 Replace the scope-string verdict with a READ-ONLY functional probe.
+- [ ] 2.2 Keep the `project` token-boundary scope match as a cheap pre-filter, not as the verdict.
+- [ ] 2.3 Name the `updateProjectV2ItemFieldValue` GraphQL fallback when `gh project` is unusable.
+
+## 3. Claim auth verdict (surface: `scripts/flow/claim.sh`)
+- [ ] 3.1 Detect the credential-failure signature on a push and emit a distinct non-retryable verdict.
+- [ ] 3.2 Preserve the existing retryable infra verdict for genuine transients (#2665 contract).
+
+## 4. Doctrine
+- [ ] 4.1 Record all three deltas + identifying symptoms in `fleet-runbook.md` / `agent-machine-setup.md`.
+- [ ] 4.2 Update CLAUDE.md only if a worker-facing instruction changes.
+
+## 5. Tests
+- [ ] 5.1 Extend `scripts/tests/test_bootstrap_agent_machine.sh` for the credential check + board probe,
+      including the scope-present-but-operation-unavailable false-OK case.
+- [ ] 5.2 `claim.sh` coverage for auth-failure vs transient classification.
+
+## 6. Gate / review / audit
+- [ ] 6.1 `--lite` green each round; full gate once pre-merge; review-first; C anchored to this change's specs.

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -358,6 +358,26 @@ fi
 BOARD_OWNER="${CQLITE_PROJECT_OWNER:-pmcfadin}"
 BOARD_NUMBER="${CQLITE_PROJECT_NUMBER:-1}"
 BOARD_GRAPHQL_WRITE="updateProjectV2ItemFieldValue"
+
+# board_graphql_read <owner> <number> — READ-ONLY projectV2 lookup, the read
+# counterpart of the write fallback, so its result says whether that fallback is
+# actually available on this token. Success requires a NON-EMPTY project id:
+# `gh api graphql` exits 0 on a well-formed query that resolves to null (e.g. an
+# org-owned board queried as a user), which would otherwise read as a false OK.
+# Tries user-owned first (what project-board-sync.yml uses), then org-owned.
+board_graphql_read() {
+  local owner="$1" number="$2" id
+  id=$(gh api graphql -f owner="$owner" -F number="$number" \
+        -f query='query($owner:String!,$number:Int!){user(login:$owner){projectV2(number:$number){id}}}' \
+        --jq '.data.user.projectV2.id' 2>/dev/null)
+  if [ -z "$id" ] || [ "$id" = null ]; then
+    id=$(gh api graphql -f owner="$owner" -F number="$number" \
+          -f query='query($owner:String!,$number:Int!){organization(login:$owner){projectV2(number:$number){id}}}' \
+          --jq '.data.organization.projectV2.id' 2>/dev/null)
+  fi
+  [ -n "$id" ] && [ "$id" != null ]
+}
+
 hdr "GitHub board access + project scope (Path A, #1886)"
 if have gh; then
   if gh auth status >/dev/null 2>&1; then
@@ -366,7 +386,9 @@ if have gh; then
     # Token-boundary match on the scopes line so a scope like 'project:read-only'
     # (or any 'xprojecty' substring) can never false-positive as 'project'.
     scopes_line=$(printf '%s\n' "$auth_out" | grep "Token scopes:" | head -1)
+    scope_prefilter=0
     if printf '%s\n' "$scopes_line" | grep -qE "(^|[ ,'])project([ ,']|$)"; then
+      scope_prefilter=1
       info "pre-filter: 'project' scope present (NOT the verdict — the probe below decides)"
     else
       warn "'project' scope MISSING — the board is the SOLE dispatch authority (Path A). Fix:"
@@ -381,12 +403,8 @@ if have gh; then
     board_read=1
     gh project view "$BOARD_NUMBER" --owner "$BOARD_OWNER" >/dev/null 2>&1 || board_read=0
     # READ-ONLY probe 2: does the GraphQL projectV2 surface answer with this token?
-    # This is the read counterpart of the write fallback, so its result tells the
-    # operator whether the fallback path is actually available.
     graphql_read=1
-    gh api graphql -f owner="$BOARD_OWNER" -F number="$BOARD_NUMBER" \
-      -f query='query($owner:String!,$number:Int!){user(login:$owner){projectV2(number:$number){id title}}}' \
-      >/dev/null 2>&1 || graphql_read=0
+    board_graphql_read "$BOARD_OWNER" "$BOARD_NUMBER" || graphql_read=0
     if [ "$board_read" = 1 ] && [ -z "$missing_scopes" ]; then
       ok "board #$BOARD_NUMBER ($BOARD_OWNER) reachable — 'gh project' read probe OK, no missing token scopes"
     elif [ "$board_read" = 1 ]; then
@@ -394,7 +412,7 @@ if have gh; then
       info "board WRITES: fall back to the GraphQL \`$BOARD_GRAPHQL_WRITE\` mutation (it succeeds with the SAME token; graphql projectV2 read probe: $([ "$graphql_read" = 1 ] && echo OK || echo FAILED))"
       info "or widen the token:  gh auth refresh -s read:org"
     elif [ "$graphql_read" = 1 ]; then
-      warn "'gh project' CANNOT use board #$BOARD_NUMBER ($BOARD_OWNER) even though the scope pre-filter passed${missing_list:+ — gh reports missing required scopes ($missing_list)}"
+      warn "'gh project' CANNOT use board #$BOARD_NUMBER ($BOARD_OWNER)$([ "$scope_prefilter" = 1 ] && printf ' even though the scope pre-filter passed')${missing_list:+ — gh reports missing required scopes ($missing_list)}"
       info "the GraphQL projectV2 read probe SUCCEEDED with the same token — board WRITES must go through the \`$BOARD_GRAPHQL_WRITE\` mutation, not \`gh project item-edit\`"
       info "or widen the token:  gh auth refresh -s read:org"
     else

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -71,6 +71,20 @@ esac
 
 WARNINGS=0
 have() { command -v "$1" >/dev/null 2>&1; }
+
+# ---- bounded execution (issue #2942) ----
+# GNU coreutils installs its timeout as `gtimeout` on stock macOS, so resolving only
+# `timeout` leaves every bound below INERT on macOS — which is the fleet's platform and
+# the one where two of the three hang scenarios live (a locked osxkeychain, a Git
+# Credential Manager browser flow). Resolve both, and degrade visibly (unbounded) only
+# when neither exists.
+TIMEOUT_BIN="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
+# bounded <secs> <cmd...> — run <cmd...> under the resolved timeout binary if there is
+# one, else run it directly. Use `env VAR=... cmd` when the call needs env prefixes.
+bounded() {
+  local secs="$1"; shift
+  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" "$secs" "$@"; else "$@"; fi
+}
 ok()   { printf '  \033[32m[ok]\033[0m   %s\n' "$1"; }
 warn() { printf '  \033[33m[warn]\033[0m %s\n' "$1"; WARNINGS=$((WARNINGS + 1)); }
 info() { printf '         %s\n' "$1"; }
@@ -370,9 +384,28 @@ fi
 # Both are the same defect this section exists to remove, one level up: a verdict
 # derived from something other than the operation actually performed.
 BOARD_OWNER="${CQLITE_PROJECT_OWNER:-pmcfadin}"
-BOARD_NUMBER="${CQLITE_PROJECT_NUMBER:-1}"
 BOARD_ACCOUNT="${CQLITE_PROJECT_ACCOUNT:-pmcfadin}"   # same var flow-board honors
+BOARD_TITLE="${PROJECT_TITLE:-CQLite Delivery}"       # same title setup-project-board.sh uses
 BOARD_GRAPHQL_WRITE="updateProjectV2ItemFieldValue"
+# CQLITE_PROJECT_NUMBER must NOT be defaulted to a guess. flow-board reads
+# `project_number="${CQLITE_PROJECT_NUMBER:-}"` and sets have_project=0 → "board
+# unreachable, STOP" when it is unset, so defaulting to 1 here would print a green
+# "board reachable" on a box where every flow-* skill refuses to dispatch — the same
+# false green this section exists to kill, one layer out. Unset is a REPORTABLE STATE.
+BOARD_NUMBER="${CQLITE_PROJECT_NUMBER:-}"
+BOARD_NUMBER_SRC=env
+[ -z "$BOARD_NUMBER" ] && BOARD_NUMBER_SRC=unset
+
+# board_discover_number <owner> <title> — resolve the board number by TITLE, the way
+# test-data/scripts/setup-project-board.sh does, so an unset env var can still be
+# diagnosed precisely ("it is #N, you just haven't exported it") instead of vaguely.
+# Needs jq (as that script does); prints nothing when unavailable or not found.
+board_discover_number() {
+  have jq || return 0
+  bounded 20 gh project list --owner "$1" --format json --limit 200 2>/dev/null \
+    | jq -r --arg t "$2" '(.projects // [])[] | select(.title == $t) | .number' 2>/dev/null \
+    | head -n1
+}
 
 # gh_active_block <auth-status-output> — ONLY the active account's stanza. Stanzas
 # start at a "Logged in to <host> account <name>" line; the active one carries
@@ -401,15 +434,30 @@ gh_block_account() {
 # Tries user-owned first (what project-board-sync.yml uses), then org-owned.
 board_graphql_read() {
   local owner="$1" number="$2" id
-  id=$(gh api graphql -f owner="$owner" -F number="$number" \
+  [ -n "$number" ] || return 1
+  id=$(bounded 20 gh api graphql -f owner="$owner" -F number="$number" \
         -f query='query($owner:String!,$number:Int!){user(login:$owner){projectV2(number:$number){id}}}' \
         --jq '.data.user.projectV2.id' 2>/dev/null)
   if [ -z "$id" ] || [ "$id" = null ]; then
-    id=$(gh api graphql -f owner="$owner" -F number="$number" \
+    id=$(bounded 20 gh api graphql -f owner="$owner" -F number="$number" \
           -f query='query($owner:String!,$number:Int!){organization(login:$owner){projectV2(number:$number){id}}}' \
           --jq '.data.organization.projectV2.id' 2>/dev/null)
   fi
   [ -n "$id" ] && [ "$id" != null ]
+}
+
+# restore_board_account — put the operator's active gh account back. Idempotent, and
+# installed as a TRAP: between the switch and the restore sit network calls, so a hang
+# plus Ctrl-C, or a supervisor SIGTERM, would otherwise kill the script mid-bracket and
+# SILENTLY leave the active account changed. A check must never mutate host state.
+restore_board_account() {
+  [ "${BOARD_SWITCHED:-0}" = 1 ] || return 0
+  BOARD_SWITCHED=0
+  if gh auth switch --user "$PRE_PROBE_ACCOUNT" >/dev/null 2>&1; then
+    info "restored gh's active account to '$PRE_PROBE_ACCOUNT'"
+  else
+    warn "could NOT restore gh's active account — it is left as '$BOARD_ACCOUNT'. Fix: gh auth switch --user $PRE_PROBE_ACCOUNT"
+  fi
 }
 
 hdr "GitHub board access + project scope (Path A, #1886)"
@@ -438,6 +486,10 @@ if have gh; then
     if [ "$GH_ENV_TOKEN" = 0 ] && [ -n "$ACTIVE_ACCOUNT" ] && [ "$ACTIVE_ACCOUNT" != "$BOARD_ACCOUNT" ]; then
       if gh auth switch --user "$BOARD_ACCOUNT" >/dev/null 2>&1; then
         BOARD_SWITCHED=1
+        # Arm the restore BEFORE anything that can hang or be interrupted.
+        trap 'restore_board_account' EXIT
+        trap 'restore_board_account; exit 130' INT
+        trap 'restore_board_account; exit 143' TERM
         info "temporarily switched gh's active account '$ACTIVE_ACCOUNT' -> '$BOARD_ACCOUNT' for the probe (what flow-board does); will switch back"
         auth_out=$(gh auth status 2>&1)
         ACTIVE_BLOCK=$(gh_active_block "$auth_out")
@@ -463,29 +515,46 @@ if have gh; then
     # `read:org` is missing, and `gh project item-edit` fails on that alone.
     missing_scopes=$(printf '%s\n' "$ACTIVE_BLOCK" | grep -i "Missing required token scopes" | head -1)
     missing_list="${missing_scopes##*scopes:}"; missing_list="${missing_list# }"
-    # READ-ONLY probe 1: can `gh project` see the board at all?
-    board_read=1
-    gh project view "$BOARD_NUMBER" --owner "$BOARD_OWNER" >/dev/null 2>&1 || board_read=0
-    # READ-ONLY probe 2: does the GraphQL projectV2 surface answer with this token?
-    graphql_read=1
-    board_graphql_read "$BOARD_OWNER" "$BOARD_NUMBER" || graphql_read=0
-
-    # Restore the operator's account BEFORE reporting: running a CHECK must not leave
-    # the active account changed.
-    if [ "$BOARD_SWITCHED" = 1 ]; then
-      if gh auth switch --user "$PRE_PROBE_ACCOUNT" >/dev/null 2>&1; then
-        info "restored gh's active account to '$PRE_PROBE_ACCOUNT'"
-      else
-        warn "could NOT restore gh's active account — it is left as '$BOARD_ACCOUNT'. Fix: gh auth switch --user $PRE_PROBE_ACCOUNT"
-      fi
+    # Resolve the board number when it is not exported, so the gap can be reported
+    # precisely rather than papered over with a guess.
+    if [ "$BOARD_NUMBER_SRC" = unset ]; then
+      BOARD_NUMBER="$(board_discover_number "$BOARD_OWNER" "$BOARD_TITLE")"
+      [ -n "$BOARD_NUMBER" ] && BOARD_NUMBER_SRC=discovered
     fi
+
+    # READ-ONLY probes, both BOUNDED: they sit between the account switch and its
+    # restore, so an unbounded hang here is what strands the operator's account.
+    board_read=0
+    graphql_read=0
+    if [ -n "$BOARD_NUMBER" ]; then
+      bounded 20 gh project view "$BOARD_NUMBER" --owner "$BOARD_OWNER" >/dev/null 2>&1 && board_read=1
+      board_graphql_read "$BOARD_OWNER" "$BOARD_NUMBER" && graphql_read=1
+    fi
+
+    # Restore the operator's account BEFORE reporting (the trap is the backstop for an
+    # interrupt; this is the normal path, and it is idempotent with the trap).
+    restore_board_account
 
     # An unqualified ok requires ALL THREE: the read probe passed, gh reports no
     # missing required scopes, AND the 'project' WRITE scope is present. Without the
     # last one a read-only token (e.g. read:project) would print the earlier
     # "'project' scope MISSING" warn and then a reassuring ok as the section's LAST
     # word, while every dispatch write still fails.
-    if [ "$board_read" = 1 ] && [ -z "$missing_scopes" ] && [ "$scope_prefilter" = 1 ]; then
+    # An unexported CQLITE_PROJECT_NUMBER is a DISPATCH BLOCKER even when every probe
+    # passes, because flow-board defaults it to empty and stops. Report it first: it is
+    # the one gap the operator can fix with a single export.
+    if [ "$BOARD_NUMBER_SRC" != env ]; then
+      if [ "$BOARD_NUMBER_SRC" = discovered ]; then
+        warn "CQLITE_PROJECT_NUMBER is NOT exported — flow-* skills default it to EMPTY and STOP ('board unreachable'), whatever this probe says"
+        info "the board titled '$BOARD_TITLE' is #$BOARD_NUMBER — export it:  export CQLITE_PROJECT_NUMBER=$BOARD_NUMBER"
+      else
+        warn "CQLITE_PROJECT_NUMBER is NOT exported and no board titled '$BOARD_TITLE' could be resolved for owner '$BOARD_OWNER' — flow-* skills will STOP (Path A: no board, no dispatch)"
+        info "run:  bash test-data/scripts/setup-project-board.sh    (it discovers/creates the board and prints the export line)"
+      fi
+    fi
+
+    if [ "$board_read" = 1 ] && [ -z "$missing_scopes" ] && [ "$scope_prefilter" = 1 ] \
+       && [ "$BOARD_NUMBER_SRC" = env ]; then
       ok "board #$BOARD_NUMBER ($BOARD_OWNER) reachable as '${ACTIVE_ACCOUNT:-<unknown>}' — 'gh project' read probe OK, 'project' scope present, no missing token scopes"
     elif [ "$board_read" = 1 ]; then
       board_dq=""
@@ -494,7 +563,11 @@ if have gh; then
         [ -n "$board_dq" ] && board_dq="$board_dq; "
         board_dq="${board_dq}gh reports missing required scopes ($missing_list)"
       fi
-      warn "board READ works as '${ACTIVE_ACCOUNT:-<unknown>}' but $board_dq — board WRITES ('gh project item-edit') can still FAIL"
+      if [ "$BOARD_NUMBER_SRC" != env ]; then
+        [ -n "$board_dq" ] && board_dq="$board_dq; "
+        board_dq="${board_dq}CQLITE_PROJECT_NUMBER is not exported"
+      fi
+      warn "board READ works as '${ACTIVE_ACCOUNT:-<unknown>}' but $board_dq — board dispatch can still FAIL"
       info "board WRITES: fall back to the GraphQL \`$BOARD_GRAPHQL_WRITE\` mutation (it succeeds with the SAME token; graphql projectV2 read probe: $([ "$graphql_read" = 1 ] && echo OK || echo FAILED))"
       info "or widen the token:  gh auth refresh -s project -s read:org"
     elif [ "$graphql_read" = 1 ]; then
@@ -502,7 +575,7 @@ if have gh; then
       info "the GraphQL projectV2 read probe SUCCEEDED with the same token — board WRITES must go through the \`$BOARD_GRAPHQL_WRITE\` mutation, not \`gh project item-edit\`"
       info "or widen the token:  gh auth refresh -s read:org"
     else
-      warn "board #$BOARD_NUMBER ($BOARD_OWNER) UNREACHABLE as '${ACTIVE_ACCOUNT:-<unknown>}' — BOTH probes failed ('gh project view' and the GraphQL projectV2 read). Path A: a session with no board access must STOP, never label-dispatch"
+      warn "board #${BOARD_NUMBER:-<unresolved>} ($BOARD_OWNER) UNREACHABLE as '${ACTIVE_ACCOUNT:-<unknown>}' — BOTH probes failed ('gh project view' and the GraphQL projectV2 read). Path A: a session with no board access must STOP, never label-dispatch"
       info "check the account (CQLITE_PROJECT_ACCOUNT=$BOARD_ACCOUNT) and owner/number (CQLITE_PROJECT_OWNER / CQLITE_PROJECT_NUMBER), then: gh auth refresh -s project -s read:org"
       info "neither 'gh project item-edit' nor the \`$BOARD_GRAPHQL_WRITE\` GraphQL fallback can work until a probe passes"
     fi
@@ -549,13 +622,11 @@ GIT_CRED_HELPER='!f(){ test "$1" = get || exit 0; t="${GH_TOKEN:-${GITHUB_TOKEN:
 # The output is captured into a variable rather than piped into grep so that grep -q
 # closing the pipe early can never turn a SIGPIPE into a false "no credential".
 git_cred_probe() {
-  local host="$1" out to=""
-  command -v timeout >/dev/null 2>&1 && to="timeout 10"
-  # shellcheck disable=SC2086  # $to is an intentional (possibly empty) command prefix
+  local host="$1" out
   out=$(printf 'protocol=https\nhost=%s\n\n' "$host" \
-    | GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=cqlite-bootstrap-no-askpass \
+    | bounded 10 env GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=cqlite-bootstrap-no-askpass \
       SSH_ASKPASS=cqlite-bootstrap-no-askpass \
-      $to git -C "$REPO_ROOT" credential fill 2>/dev/null) || true
+      git -C "$REPO_ROOT" credential fill 2>/dev/null) || true
   printf '%s\n' "$out" | grep -q '^password=.'
 }
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -480,14 +480,17 @@ git_global_helper_configured() {
   git config --global --get-regexp '^credential\..*helper$' >/dev/null 2>&1
 }
 
-# git_env_token_helper_active <host> — 0 iff the helper answering for <host> is OUR
-# $GH_TOKEN-dereferencing one, at any scope. Used to attach the env-var dependency
-# caveat to an otherwise-green verdict.
+# git_env_token_helper_active <host> — 0 iff a configured helper for <host> is an
+# ENV-DEREFERENCING one, at any scope. Used to attach the "$GH_TOKEN must be exported"
+# caveat to an otherwise-green verdict. Both markers must appear in the SAME helper
+# value (grep is line-wise, one value per line): a helper with a token BAKED IN also
+# says x-access-token but has no environment dependency, and claiming otherwise would
+# be its own small misattribution.
 git_env_token_helper_active() {
   { git config --global --get-all "credential.https://$1.helper" 2>/dev/null
     git config --global --get-all credential.helper 2>/dev/null
     git -C "$REPO_ROOT" config --get-all credential.helper 2>/dev/null
-  } | grep -qF 'x-access-token'
+  } | grep -F 'x-access-token' | grep -qF 'GH_TOKEN'
 }
 
 # git_origin_host <url> — host of an http(s) origin ("" for any other form). The

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -20,14 +20,17 @@
 #      from a READ-ONLY functional probe of the board, never from the `project`
 #      scope string (issue #2942): a token can carry `project` and still fail
 #      `gh project item-edit` for a missing `read:org` while the equivalent
-#      `updateProjectV2ItemFieldValue` GraphQL mutation works. Overridable with
-#      CQLITE_PROJECT_OWNER / CQLITE_PROJECT_NUMBER.
+#      `updateProjectV2ItemFieldValue` GraphQL mutation works. Scopes are read from
+#      the ACTIVE account's stanza only, and the probe runs as the account flow-board
+#      forces active, restoring the operator's account afterwards. Overridable with
+#      CQLITE_PROJECT_OWNER / CQLITE_PROJECT_NUMBER / CQLITE_PROJECT_ACCOUNT.
 #   3b. git push CREDENTIALS (issue #2942) — separate from `gh` auth. The claim
 #      protocol (scripts/flow/claim.sh, claim-heartbeat.sh) pushes with plain git
 #      on 10+ call sites, so an authenticated gh with an unauthenticated git means
 #      the cross-machine lock does not work. Under --yes this configures a
-#      credential path, preferring `gh auth setup-git`, else a helper that
-#      dereferences $GH_TOKEN at call time. The token is never written to disk.
+#      credential path scoped to the origin host, preferring `gh auth setup-git`,
+#      else a helper that dereferences $GH_TOKEN at call time. The token is never
+#      written to disk.
 #   4. roborev installed and its LOCAL config resolves — roborev follows THIS
 #      machine's configured agent (commonly codex via .roborev.toml); we warn
 #      only if the local config is broken, never prescribe an agent.
@@ -52,7 +55,7 @@ for arg in "$@"; do
     --yes|-y) AUTO_YES=1 ;;
     --skip-smoke) SKIP_SMOKE=1 ;;
     -h|--help)
-      sed -n '2,42p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *) echo "bootstrap: unknown arg: $arg (try --help)" >&2; exit 2 ;;
   esac
@@ -355,9 +358,40 @@ fi
 # SAME token. A scope match is evidence about a token, not about the operation.
 # The scope check survives as a cheap PRE-FILTER; the verdict comes from a probe.
 # The probe is strictly READ-ONLY — a bootstrap must never mutate a real board item.
+#
+# Both facts the verdict rests on must also be attributed to the RIGHT IDENTITY.
+# `gh auth status` prints one stanza PER logged-in account on a host and the active
+# one is not guaranteed first, so a plain grep can read a different account's scopes
+# than the one every gh call will use — this repo has a documented instance
+# (.claude/skills/flow-board/SKILL.md: the active account silently flips to an EMU
+# account lacking `project`, and board writes then degrade SILENTLY). And `flow-board`
+# FORCES CQLITE_PROJECT_ACCOUNT active before any board op, so probing as whatever
+# account happens to be active measures a different identity than board dispatch uses.
+# Both are the same defect this section exists to remove, one level up: a verdict
+# derived from something other than the operation actually performed.
 BOARD_OWNER="${CQLITE_PROJECT_OWNER:-pmcfadin}"
 BOARD_NUMBER="${CQLITE_PROJECT_NUMBER:-1}"
+BOARD_ACCOUNT="${CQLITE_PROJECT_ACCOUNT:-pmcfadin}"   # same var flow-board honors
 BOARD_GRAPHQL_WRITE="updateProjectV2ItemFieldValue"
+
+# gh_active_block <auth-status-output> — ONLY the active account's stanza. Stanzas
+# start at a "Logged in to <host> account <name>" line; the active one carries
+# "Active account: true". Falls back to the whole output when no such marker exists
+# (older gh / single account), so this never returns empty.
+gh_active_block() {
+  printf '%s\n' "$1" | awk '
+    /Logged in to/ { n++ }
+    { blk[n] = blk[n] $0 "\n"; if ($0 ~ /Active account: true/) active = n }
+    END {
+      if (active) { printf "%s", blk[active]; exit }
+      for (i = 0; i <= n; i++) printf "%s", blk[i]
+    }'
+}
+
+# gh_block_account <stanza> — the account name a stanza belongs to ("" if unknown).
+gh_block_account() {
+  printf '%s\n' "$1" | sed -n 's/.*Logged in to [^ ]* account \([^ ][^ ]*\).*/\1/p' | head -1
+}
 
 # board_graphql_read <owner> <number> — READ-ONLY projectV2 lookup, the read
 # counterpart of the write fallback, so its result says whether that fallback is
@@ -384,21 +418,50 @@ if have gh; then
   auth_out=$(gh auth status 2>&1); auth_rc=$?
   if [ "$auth_rc" -eq 0 ]; then
     ok "gh authenticated"
-    # Token-boundary match on the scopes line so a scope like 'project:read-only'
-    # (or any 'xprojecty' substring) can never false-positive as 'project'.
-    scopes_line=$(printf '%s\n' "$auth_out" | grep "Token scopes:" | head -1)
+    # ---- attribute every fact below to the ACTIVE account, and say which one ----
+    ACTIVE_BLOCK=$(gh_active_block "$auth_out")
+    ACTIVE_ACCOUNT=$(gh_block_account "$ACTIVE_BLOCK")
+    # An env token outranks the keyring, so there is exactly ONE identity and
+    # `gh auth switch` cannot change it — detect that up front rather than
+    # attempting (and reporting) a switch that could never take effect.
+    GH_ENV_TOKEN=0
+    [ -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ] && GH_ENV_TOKEN=1
+    info "measuring gh account '${ACTIVE_ACCOUNT:-<unknown>}'$([ "$GH_ENV_TOKEN" = 1 ] && printf ' (from GH_TOKEN in the environment)')"
+
+    # Mirror flow-board: it forces CQLITE_PROJECT_ACCOUNT active before EVERY board
+    # op, so probing as a different account would answer a question nobody asks —
+    # loudly failing a box where dispatch works, or greenlighting an account dispatch
+    # never uses. Switching mutates real gh state, so we only switch when we must and
+    # we always switch BACK; a failed restore is a loud warn, never a silent leftover.
+    BOARD_SWITCHED=0
+    PRE_PROBE_ACCOUNT="$ACTIVE_ACCOUNT"   # what the operator had active; restored below
+    if [ "$GH_ENV_TOKEN" = 0 ] && [ -n "$ACTIVE_ACCOUNT" ] && [ "$ACTIVE_ACCOUNT" != "$BOARD_ACCOUNT" ]; then
+      if gh auth switch --user "$BOARD_ACCOUNT" >/dev/null 2>&1; then
+        BOARD_SWITCHED=1
+        info "temporarily switched gh's active account '$ACTIVE_ACCOUNT' -> '$BOARD_ACCOUNT' for the probe (what flow-board does); will switch back"
+        auth_out=$(gh auth status 2>&1)
+        ACTIVE_BLOCK=$(gh_active_block "$auth_out")
+        ACTIVE_ACCOUNT=$(gh_block_account "$ACTIVE_BLOCK")
+      else
+        info "could not switch to '$BOARD_ACCOUNT' (CQLITE_PROJECT_ACCOUNT) — probing as '$ACTIVE_ACCOUNT'; flow-board would attempt the same switch"
+      fi
+    fi
+
+    # Token-boundary match on the ACTIVE account's scopes line so a scope like
+    # 'project:read-only' (or any 'xprojecty' substring) can never false-positive.
+    scopes_line=$(printf '%s\n' "$ACTIVE_BLOCK" | grep "Token scopes:" | head -1)
     scope_prefilter=0
     if printf '%s\n' "$scopes_line" | grep -qE "(^|[ ,'])project([ ,']|$)"; then
       scope_prefilter=1
-      info "pre-filter: 'project' scope present (NOT the verdict — the probe below decides)"
+      info "pre-filter: 'project' scope present on '${ACTIVE_ACCOUNT:-<unknown>}' (NOT the verdict — the probe below decides)"
     else
-      warn "'project' scope MISSING — the board is the SOLE dispatch authority (Path A). Fix:"
+      warn "'project' scope MISSING on gh account '${ACTIVE_ACCOUNT:-<unknown>}' — the board is the SOLE dispatch authority (Path A). Fix:"
       info "gh auth refresh -s project"
     fi
     # gh's OWN declaration that the ACTIVE token lacks scopes gh requires. This is
     # the discriminator behind the observed false OK: scopes include 'project',
     # `read:org` is missing, and `gh project item-edit` fails on that alone.
-    missing_scopes=$(printf '%s\n' "$auth_out" | grep -i "Missing required token scopes" | head -1)
+    missing_scopes=$(printf '%s\n' "$ACTIVE_BLOCK" | grep -i "Missing required token scopes" | head -1)
     missing_list="${missing_scopes##*scopes:}"; missing_list="${missing_list# }"
     # READ-ONLY probe 1: can `gh project` see the board at all?
     board_read=1
@@ -406,19 +469,41 @@ if have gh; then
     # READ-ONLY probe 2: does the GraphQL projectV2 surface answer with this token?
     graphql_read=1
     board_graphql_read "$BOARD_OWNER" "$BOARD_NUMBER" || graphql_read=0
-    if [ "$board_read" = 1 ] && [ -z "$missing_scopes" ]; then
-      ok "board #$BOARD_NUMBER ($BOARD_OWNER) reachable — 'gh project' read probe OK, no missing token scopes"
+
+    # Restore the operator's account BEFORE reporting: running a CHECK must not leave
+    # the active account changed.
+    if [ "$BOARD_SWITCHED" = 1 ]; then
+      if gh auth switch --user "$PRE_PROBE_ACCOUNT" >/dev/null 2>&1; then
+        info "restored gh's active account to '$PRE_PROBE_ACCOUNT'"
+      else
+        warn "could NOT restore gh's active account — it is left as '$BOARD_ACCOUNT'. Fix: gh auth switch --user $PRE_PROBE_ACCOUNT"
+      fi
+    fi
+
+    # An unqualified ok requires ALL THREE: the read probe passed, gh reports no
+    # missing required scopes, AND the 'project' WRITE scope is present. Without the
+    # last one a read-only token (e.g. read:project) would print the earlier
+    # "'project' scope MISSING" warn and then a reassuring ok as the section's LAST
+    # word, while every dispatch write still fails.
+    if [ "$board_read" = 1 ] && [ -z "$missing_scopes" ] && [ "$scope_prefilter" = 1 ]; then
+      ok "board #$BOARD_NUMBER ($BOARD_OWNER) reachable as '${ACTIVE_ACCOUNT:-<unknown>}' — 'gh project' read probe OK, 'project' scope present, no missing token scopes"
     elif [ "$board_read" = 1 ]; then
-      warn "board READ works but gh reports the active token is MISSING required scopes ($missing_list) — 'gh project item-edit' can still FAIL for read:org"
+      board_dq=""
+      [ "$scope_prefilter" = 0 ] && board_dq="the 'project' WRITE scope is MISSING"
+      if [ -n "$missing_scopes" ]; then
+        [ -n "$board_dq" ] && board_dq="$board_dq; "
+        board_dq="${board_dq}gh reports missing required scopes ($missing_list)"
+      fi
+      warn "board READ works as '${ACTIVE_ACCOUNT:-<unknown>}' but $board_dq — board WRITES ('gh project item-edit') can still FAIL"
       info "board WRITES: fall back to the GraphQL \`$BOARD_GRAPHQL_WRITE\` mutation (it succeeds with the SAME token; graphql projectV2 read probe: $([ "$graphql_read" = 1 ] && echo OK || echo FAILED))"
-      info "or widen the token:  gh auth refresh -s read:org"
+      info "or widen the token:  gh auth refresh -s project -s read:org"
     elif [ "$graphql_read" = 1 ]; then
-      warn "'gh project' CANNOT use board #$BOARD_NUMBER ($BOARD_OWNER)$([ "$scope_prefilter" = 1 ] && printf ' even though the scope pre-filter passed')${missing_list:+ — gh reports missing required scopes ($missing_list)}"
+      warn "'gh project' CANNOT use board #$BOARD_NUMBER ($BOARD_OWNER) as '${ACTIVE_ACCOUNT:-<unknown>}'$([ "$scope_prefilter" = 1 ] && printf ' even though the scope pre-filter passed')${missing_list:+ — gh reports missing required scopes ($missing_list)}"
       info "the GraphQL projectV2 read probe SUCCEEDED with the same token — board WRITES must go through the \`$BOARD_GRAPHQL_WRITE\` mutation, not \`gh project item-edit\`"
       info "or widen the token:  gh auth refresh -s read:org"
     else
-      warn "board #$BOARD_NUMBER ($BOARD_OWNER) UNREACHABLE — BOTH probes failed ('gh project view' and the GraphQL projectV2 read). Path A: a session with no board access must STOP, never label-dispatch"
-      info "check the owner/number (CQLITE_PROJECT_OWNER / CQLITE_PROJECT_NUMBER), then: gh auth refresh -s project -s read:org"
+      warn "board #$BOARD_NUMBER ($BOARD_OWNER) UNREACHABLE as '${ACTIVE_ACCOUNT:-<unknown>}' — BOTH probes failed ('gh project view' and the GraphQL projectV2 read). Path A: a session with no board access must STOP, never label-dispatch"
+      info "check the account (CQLITE_PROJECT_ACCOUNT=$BOARD_ACCOUNT) and owner/number (CQLITE_PROJECT_OWNER / CQLITE_PROJECT_NUMBER), then: gh auth refresh -s project -s read:org"
       info "neither 'gh project item-edit' nor the \`$BOARD_GRAPHQL_WRITE\` GraphQL fallback can work until a probe passes"
     fi
   else
@@ -474,22 +559,32 @@ git_cred_probe() {
   printf '%s\n' "$out" | grep -q '^password=.'
 }
 
-# git_global_helper_configured — 0 iff ANY global credential helper exists, scoped
-# (credential.https://host.helper) or not (credential.helper).
+# Both helper-inspection predicates below use a --get-regexp over the whole
+# `credential.*.helper` key space rather than the bare `credential.helper` key. The
+# helper THIS script writes is host-scoped (credential.https://<host>.helper), as is
+# anything `gh auth setup-git` writes — so a bare-key lookup would miss exactly the
+# configurations the script itself creates, and the two advisories that matter most to
+# an unattended worker would go silent on the very machines they were written for.
+
+# git_global_helper_configured — 0 iff ANY global credential helper exists, scoped or not.
 git_global_helper_configured() {
   git config --global --get-regexp '^credential\..*helper$' >/dev/null 2>&1
 }
 
-# git_env_token_helper_active <host> — 0 iff a configured helper for <host> is an
-# ENV-DEREFERENCING one, at any scope. Used to attach the "$GH_TOKEN must be exported"
-# caveat to an otherwise-green verdict. Both markers must appear in the SAME helper
-# value (grep is line-wise, one value per line): a helper with a token BAKED IN also
-# says x-access-token but has no environment dependency, and claiming otherwise would
-# be its own small misattribution.
+# git_local_helper_configured — 0 iff ANY repo-local credential helper exists.
+git_local_helper_configured() {
+  git -C "$REPO_ROOT" config --local --get-regexp '^credential\..*helper$' >/dev/null 2>&1
+}
+
+# git_env_token_helper_active — 0 iff a configured helper (any scope, any host key) is
+# an ENV-DEREFERENCING one. Used to attach the "$GH_TOKEN must be exported" caveat to
+# an otherwise-green verdict. Both markers must appear in the SAME line (--get-regexp
+# prints one key+value per line): a helper with a token BAKED IN also says
+# x-access-token but has no environment dependency, and claiming otherwise would be
+# its own small misattribution.
 git_env_token_helper_active() {
-  { git config --global --get-all "credential.https://$1.helper" 2>/dev/null
-    git config --global --get-all credential.helper 2>/dev/null
-    git -C "$REPO_ROOT" config --get-all credential.helper 2>/dev/null
+  { git config --global --get-regexp '^credential\..*helper$' 2>/dev/null
+    git -C "$REPO_ROOT" config --get-regexp '^credential\..*helper$' 2>/dev/null
   } | grep -F 'x-access-token' | grep -qF 'GH_TOKEN'
 }
 
@@ -538,12 +633,11 @@ elif [ "$GIT_ORIGIN_KIND" = other ]; then
   info "origin is a '$GIT_ORIGIN_KIND' remote (neither http(s) nor SSH) — no credential helper applies"
 elif git_cred_probe "$GIT_ORIGIN_HOST"; then
   ok "git push credentials resolve for $GIT_ORIGIN_HOST (a helper answers with a non-empty secret)"
-  if git -C "$REPO_ROOT" config --local --get-all credential.helper >/dev/null 2>&1 \
-     && ! git_global_helper_configured; then
+  if git_local_helper_configured && ! git_global_helper_configured; then
     info "note: the helper is configured at REPO-LOCAL scope only — a fresh clone or a"
     info "      new checkout on this box will NOT inherit it. Re-run with --yes to add a global one."
   fi
-  if git_env_token_helper_active "$GIT_ORIGIN_HOST"; then
+  if git_env_token_helper_active; then
     info "note: that helper reads \$GH_TOKEN from the ENVIRONMENT, so it works only in shells"
     info "      where GH_TOKEN is exported — a systemd/cron worker started without it will"
     info "      fail every push. For unattended workers prefer:  gh auth setup-git"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -380,9 +380,10 @@ board_graphql_read() {
 
 hdr "GitHub board access + project scope (Path A, #1886)"
 if have gh; then
-  if gh auth status >/dev/null 2>&1; then
+  # ONE invocation: capture output and status together (gh auth status hits the API).
+  auth_out=$(gh auth status 2>&1); auth_rc=$?
+  if [ "$auth_rc" -eq 0 ]; then
     ok "gh authenticated"
-    auth_out=$(gh auth status 2>&1)
     # Token-boundary match on the scopes line so a scope like 'project:read-only'
     # (or any 'xprojecty' substring) can never false-positive as 'project'.
     scopes_line=$(printf '%s\n' "$auth_out" | grep "Token scopes:" | head -1)
@@ -439,17 +440,54 @@ fi
 #
 # The probe is `git credential fill`: it runs the CONFIGURED helper chain and answers
 # exactly the question that matters ("would git find a credential for this host?")
-# without contacting the network and without pushing anything. Prompts are disabled
-# two ways so it can never hang a headless bootstrap — an askpass pointing at a
-# deliberately nonexistent command, plus GIT_TERMINAL_PROMPT=0. The filled credential
-# goes to /dev/null: it is never printed, logged, or stored.
-GIT_CRED_HELPER='!f(){ test "$1" = get || exit 0; echo username=x-access-token; echo "password=${GH_TOKEN:-${GITHUB_TOKEN:-}}"; };f'
+# without contacting the network and without pushing anything. The filled credential
+# is held only in a local shell variable — never printed, logged, or stored.
+#
+# The helper DECLINES (exit 1) when no token is in the environment rather than
+# emitting an empty password. That matters because git treats a `password=` line as
+# satisfied even when the value is EMPTY, so an empty-emitting helper produces a
+# green probe on a machine where every push fails. This is highly reachable: --yes
+# writes the helper globally and PERSISTENTLY while $GH_TOKEN is a per-shell env var,
+# so bootstrapping in an interactive shell and then running the supervisor from
+# systemd/cron would otherwise yield a green bootstrap and a dead claim protocol —
+# the very "validated the configuration, not the operation" defect this change exists
+# to kill. The probe correspondingly requires a NON-EMPTY password, not exit 0.
+GIT_CRED_HELPER='!f(){ test "$1" = get || exit 0; t="${GH_TOKEN:-${GITHUB_TOKEN:-}}"; [ -n "$t" ] || exit 1; echo username=x-access-token; echo "password=$t"; };f'
 
+# git_cred_probe <host> — 0 iff the configured helper chain yields a non-empty
+# secret for <host>. Three hang guards, because this runs inside the gate's
+# tooling-tests against a developer's REAL helper chain:
+#   - GIT_TERMINAL_PROMPT=0 + a deliberately nonexistent askpass stop GIT's own prompt;
+#   - `timeout` bounds a HELPER SUBPROCESS, which neither variable governs — a Git
+#     Credential Manager device-code/browser flow, a credential-cache waiting on a
+#     dead daemon socket, or a locked osxkeychain would otherwise block indefinitely.
+# The output is captured into a variable rather than piped into grep so that grep -q
+# closing the pipe early can never turn a SIGPIPE into a false "no credential".
 git_cred_probe() {
-  printf 'protocol=https\nhost=%s\n\n' "$1" \
+  local host="$1" out to=""
+  command -v timeout >/dev/null 2>&1 && to="timeout 10"
+  # shellcheck disable=SC2086  # $to is an intentional (possibly empty) command prefix
+  out=$(printf 'protocol=https\nhost=%s\n\n' "$host" \
     | GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=cqlite-bootstrap-no-askpass \
       SSH_ASKPASS=cqlite-bootstrap-no-askpass \
-      git -C "$REPO_ROOT" credential fill >/dev/null 2>&1
+      $to git -C "$REPO_ROOT" credential fill 2>/dev/null) || true
+  printf '%s\n' "$out" | grep -q '^password=.'
+}
+
+# git_global_helper_configured — 0 iff ANY global credential helper exists, scoped
+# (credential.https://host.helper) or not (credential.helper).
+git_global_helper_configured() {
+  git config --global --get-regexp '^credential\..*helper$' >/dev/null 2>&1
+}
+
+# git_env_token_helper_active <host> — 0 iff the helper answering for <host> is OUR
+# $GH_TOKEN-dereferencing one, at any scope. Used to attach the env-var dependency
+# caveat to an otherwise-green verdict.
+git_env_token_helper_active() {
+  { git config --global --get-all "credential.https://$1.helper" 2>/dev/null
+    git config --global --get-all credential.helper 2>/dev/null
+    git -C "$REPO_ROOT" config --get-all credential.helper 2>/dev/null
+  } | grep -qF 'x-access-token'
 }
 
 # git_origin_host <url> — host of an http(s) origin ("" for any other form). The
@@ -494,13 +532,18 @@ elif [ "$GIT_ORIGIN_KIND" = ssh ]; then
   ok "origin is an SSH remote — git push authenticates via SSH keys, not a credential helper (no helper needed)"
   info "verify separately if pushes fail:  ssh -T git@github.com"
 elif [ "$GIT_ORIGIN_KIND" = other ]; then
-  info "origin ($GIT_ORIGIN_URL) is neither http(s) nor SSH — no credential helper applies"
+  info "origin is a '$GIT_ORIGIN_KIND' remote (neither http(s) nor SSH) — no credential helper applies"
 elif git_cred_probe "$GIT_ORIGIN_HOST"; then
-  ok "git push credentials resolve for $GIT_ORIGIN_HOST (a credential helper answers)"
+  ok "git push credentials resolve for $GIT_ORIGIN_HOST (a helper answers with a non-empty secret)"
   if git -C "$REPO_ROOT" config --local --get-all credential.helper >/dev/null 2>&1 \
-     && ! git config --global --get-all credential.helper >/dev/null 2>&1; then
+     && ! git_global_helper_configured; then
     info "note: the helper is configured at REPO-LOCAL scope only — a fresh clone or a"
     info "      new checkout on this box will NOT inherit it. Re-run with --yes to add a global one."
+  fi
+  if git_env_token_helper_active "$GIT_ORIGIN_HOST"; then
+    info "note: that helper reads \$GH_TOKEN from the ENVIRONMENT, so it works only in shells"
+    info "      where GH_TOKEN is exported — a systemd/cron worker started without it will"
+    info "      fail every push. For unattended workers prefer:  gh auth setup-git"
   fi
 else
   warn "git push has NO credentials for $GIT_ORIGIN_HOST — an authenticated 'gh' does NOT authenticate git"
@@ -531,14 +574,26 @@ else
         # asks — the token itself never lands on disk, so rotating it needs no
         # reconfiguration and a leaked ~/.gitconfig leaks no credential. (Decision 2
         # of the worker-env-preflight change: explicitly NOT ~/.git-credentials.)
-        info "configuring a global credential.helper that dereferences \$GH_TOKEN at call time (the token is NOT written to disk)"
-        # Idempotence: never stack a second copy of our helper on a re-run. Reaching
-        # here with one already present means the token itself is the problem.
-        if git config --global --get-all credential.helper 2>/dev/null | grep -qF 'x-access-token'; then
-          warn "a \$GH_TOKEN-style helper is ALREADY in the global git config yet the probe still fails — check that GH_TOKEN is valid/unexpired (not re-adding it)"
-        elif git config --global --add credential.helper "$GIT_CRED_HELPER" 2>/dev/null \
+        #
+        # HOST-SCOPED, never a bare [credential] helper. An unscoped helper offers the
+        # GitHub token to EVERY https host git talks to — a submodule, a cargo/pip git
+        # dependency, a mistyped clone, or any host that answers 401 would receive it.
+        # `gh auth setup-git` (the preferred path this falls back FROM) scopes per host,
+        # so an unscoped fallback would make --yes strictly less safe than its own
+        # preferred branch. "A leaked ~/.gitconfig leaks no credential" is true of the
+        # env-var indirection but says nothing about who git hands the token TO.
+        cred_key="credential.https://$GIT_ORIGIN_HOST.helper"
+        info "configuring $cred_key to dereference \$GH_TOKEN at call time (scoped to $GIT_ORIGIN_HOST; the token is NOT written to disk)"
+        # Idempotence: never stack a second copy on a re-run. The check is the EXACT
+        # key we write — a copy scoped to some other host is unrelated and must not
+        # suppress this one.
+        if git config --global --get-all "$cred_key" 2>/dev/null | grep -qF 'x-access-token'; then
+          warn "a \$GH_TOKEN-style helper is ALREADY configured for $GIT_ORIGIN_HOST yet the probe still fails — check that GH_TOKEN is set, valid and unexpired (not re-adding it)"
+        elif git config --global --add "$cred_key" "$GIT_CRED_HELPER" 2>/dev/null \
            && git_cred_probe "$GIT_ORIGIN_HOST"; then
-          ok "git credentials configured via a \$GH_TOKEN-dereferencing helper (no secret written to disk)"
+          ok "git credentials configured for $GIT_ORIGIN_HOST via a \$GH_TOKEN-dereferencing helper (no secret written to disk)"
+          info "this helper reads \$GH_TOKEN from the ENVIRONMENT — an unattended worker (systemd/cron)"
+          info "started without GH_TOKEN exported will still fail every push; prefer 'gh auth setup-git' there"
         else
           warn "could not configure a working git credential helper — fix manually: gh auth setup-git"
         fi

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -16,7 +16,18 @@
 #      / "ACCEL_LANES" / "mold link-accelerator") so the two can never disagree
 #      about whether an accelerator is present. The final health check below
 #      re-reads the state straight from the gate to reconcile.
-#   3. gh auth + the `project` scope (Path A board dispatch, #1886).
+#   3. gh auth + BOARD ACCESS (Path A board dispatch, #1886). The verdict comes
+#      from a READ-ONLY functional probe of the board, never from the `project`
+#      scope string (issue #2942): a token can carry `project` and still fail
+#      `gh project item-edit` for a missing `read:org` while the equivalent
+#      `updateProjectV2ItemFieldValue` GraphQL mutation works. Overridable with
+#      CQLITE_PROJECT_OWNER / CQLITE_PROJECT_NUMBER.
+#   3b. git push CREDENTIALS (issue #2942) — separate from `gh` auth. The claim
+#      protocol (scripts/flow/claim.sh, claim-heartbeat.sh) pushes with plain git
+#      on 10+ call sites, so an authenticated gh with an unauthenticated git means
+#      the cross-machine lock does not work. Under --yes this configures a
+#      credential path, preferring `gh auth setup-git`, else a helper that
+#      dereferences $GH_TOKEN at call time. The token is never written to disk.
 #   4. roborev installed and its LOCAL config resolves — roborev follows THIS
 #      machine's configured agent (commonly codex via .roborev.toml); we warn
 #      only if the local config is broken, never prescribe an agent.
@@ -26,7 +37,7 @@
 #
 # Usage:
 #   bash scripts/bootstrap-agent-machine.sh            # check + print install cmds
-#   bash scripts/bootstrap-agent-machine.sh --yes      # also auto-run brew/cargo installs
+#   bash scripts/bootstrap-agent-machine.sh --yes      # also auto-run installs + git credentials
 #   bash scripts/bootstrap-agent-machine.sh --skip-smoke   # skip the final gate run
 #   bash scripts/bootstrap-agent-machine.sh --help
 set -uo pipefail
@@ -41,7 +52,7 @@ for arg in "$@"; do
     --yes|-y) AUTO_YES=1 ;;
     --skip-smoke) SKIP_SMOKE=1 ;;
     -h|--help)
-      sed -n '2,31p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,42p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *) echo "bootstrap: unknown arg: $arg (try --help)" >&2; exit 2 ;;
   esac
@@ -335,25 +346,189 @@ if [ "$PLATFORM" = linux ]; then
   fi
 fi
 
-# ---- 3. gh auth + project scope (Path A, #1886) ----
-hdr "GitHub CLI auth + project scope (Path A, #1886)"
+# ---- 3. GitHub board access + project scope (Path A, #1886; #2942) ----
+# The board is the SOLE dispatch authority, so "can this machine use the board?"
+# must be answered by TRYING it. Until #2942 this section matched the `project`
+# scope STRING and declared "board dispatch works" — and a box was observed where
+# that scope IS present, `gh project item-edit` fails for a missing `read:org`, and
+# the equivalent `updateProjectV2ItemFieldValue` GraphQL mutation succeeds with the
+# SAME token. A scope match is evidence about a token, not about the operation.
+# The scope check survives as a cheap PRE-FILTER; the verdict comes from a probe.
+# The probe is strictly READ-ONLY — a bootstrap must never mutate a real board item.
+BOARD_OWNER="${CQLITE_PROJECT_OWNER:-pmcfadin}"
+BOARD_NUMBER="${CQLITE_PROJECT_NUMBER:-1}"
+BOARD_GRAPHQL_WRITE="updateProjectV2ItemFieldValue"
+hdr "GitHub board access + project scope (Path A, #1886)"
 if have gh; then
   if gh auth status >/dev/null 2>&1; then
     ok "gh authenticated"
+    auth_out=$(gh auth status 2>&1)
     # Token-boundary match on the scopes line so a scope like 'project:read-only'
     # (or any 'xprojecty' substring) can never false-positive as 'project'.
-    scopes_line=$(gh auth status 2>&1 | grep "Token scopes:" | head -1)
+    scopes_line=$(printf '%s\n' "$auth_out" | grep "Token scopes:" | head -1)
     if printf '%s\n' "$scopes_line" | grep -qE "(^|[ ,'])project([ ,']|$)"; then
-      ok "'project' scope present — board dispatch works"
+      info "pre-filter: 'project' scope present (NOT the verdict — the probe below decides)"
     else
       warn "'project' scope MISSING — the board is the SOLE dispatch authority (Path A). Fix:"
       info "gh auth refresh -s project"
+    fi
+    # gh's OWN declaration that the ACTIVE token lacks scopes gh requires. This is
+    # the discriminator behind the observed false OK: scopes include 'project',
+    # `read:org` is missing, and `gh project item-edit` fails on that alone.
+    missing_scopes=$(printf '%s\n' "$auth_out" | grep -i "Missing required token scopes" | head -1)
+    missing_list="${missing_scopes##*scopes:}"; missing_list="${missing_list# }"
+    # READ-ONLY probe 1: can `gh project` see the board at all?
+    board_read=1
+    gh project view "$BOARD_NUMBER" --owner "$BOARD_OWNER" >/dev/null 2>&1 || board_read=0
+    # READ-ONLY probe 2: does the GraphQL projectV2 surface answer with this token?
+    # This is the read counterpart of the write fallback, so its result tells the
+    # operator whether the fallback path is actually available.
+    graphql_read=1
+    gh api graphql -f owner="$BOARD_OWNER" -F number="$BOARD_NUMBER" \
+      -f query='query($owner:String!,$number:Int!){user(login:$owner){projectV2(number:$number){id title}}}' \
+      >/dev/null 2>&1 || graphql_read=0
+    if [ "$board_read" = 1 ] && [ -z "$missing_scopes" ]; then
+      ok "board #$BOARD_NUMBER ($BOARD_OWNER) reachable — 'gh project' read probe OK, no missing token scopes"
+    elif [ "$board_read" = 1 ]; then
+      warn "board READ works but gh reports the active token is MISSING required scopes ($missing_list) — 'gh project item-edit' can still FAIL for read:org"
+      info "board WRITES: fall back to the GraphQL \`$BOARD_GRAPHQL_WRITE\` mutation (it succeeds with the SAME token; graphql projectV2 read probe: $([ "$graphql_read" = 1 ] && echo OK || echo FAILED))"
+      info "or widen the token:  gh auth refresh -s read:org"
+    elif [ "$graphql_read" = 1 ]; then
+      warn "'gh project' CANNOT use board #$BOARD_NUMBER ($BOARD_OWNER) even though the scope pre-filter passed${missing_list:+ — gh reports missing required scopes ($missing_list)}"
+      info "the GraphQL projectV2 read probe SUCCEEDED with the same token — board WRITES must go through the \`$BOARD_GRAPHQL_WRITE\` mutation, not \`gh project item-edit\`"
+      info "or widen the token:  gh auth refresh -s read:org"
+    else
+      warn "board #$BOARD_NUMBER ($BOARD_OWNER) UNREACHABLE — BOTH probes failed ('gh project view' and the GraphQL projectV2 read). Path A: a session with no board access must STOP, never label-dispatch"
+      info "check the owner/number (CQLITE_PROJECT_OWNER / CQLITE_PROJECT_NUMBER), then: gh auth refresh -s project -s read:org"
+      info "neither 'gh project item-edit' nor the \`$BOARD_GRAPHQL_WRITE\` GraphQL fallback can work until a probe passes"
     fi
   else
     warn "gh not authenticated — run: gh auth login (then gh auth refresh -s project)"
   fi
 else
   warn "gh CLI NOT installed — $(brew_or_cargo gh gh 2>/dev/null || echo 'install GitHub CLI: https://cli.github.com')"
+fi
+
+# ---- 3b. git push credentials (issue #2942) ----
+# `gh` auth and `git` auth are SEPARATE credential paths. An authenticated gh CLI is
+# NOT evidence that a raw `git push` can authenticate — and the flow tooling
+# (scripts/flow/claim.sh, scripts/flow/claim-heartbeat.sh) pushes with plain git on
+# 10+ call sites (the claim ref, the adoption CAS, release, heartbeats). On a box
+# where only gh is wired, every one of those fails with
+#     fatal: could not read Username for 'https://github.com'
+# so the claim protocol — the cross-machine lock the whole fleet depends on — simply
+# does not work, while `gh auth status` reports a happy machine.
+#
+# The probe is `git credential fill`: it runs the CONFIGURED helper chain and answers
+# exactly the question that matters ("would git find a credential for this host?")
+# without contacting the network and without pushing anything. Prompts are disabled
+# two ways so it can never hang a headless bootstrap — an askpass pointing at a
+# deliberately nonexistent command, plus GIT_TERMINAL_PROMPT=0. The filled credential
+# goes to /dev/null: it is never printed, logged, or stored.
+GIT_CRED_HELPER='!f(){ test "$1" = get || exit 0; echo username=x-access-token; echo "password=${GH_TOKEN:-${GITHUB_TOKEN:-}}"; };f'
+
+git_cred_probe() {
+  printf 'protocol=https\nhost=%s\n\n' "$1" \
+    | GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=cqlite-bootstrap-no-askpass \
+      SSH_ASKPASS=cqlite-bootstrap-no-askpass \
+      git -C "$REPO_ROOT" credential fill >/dev/null 2>&1
+}
+
+# git_origin_host <url> — host of an http(s) origin ("" for any other form). The
+# path is stripped FIRST so an '@' inside the path can never be mistaken for the
+# user[:password]@ prefix.
+git_origin_host() {
+  local url="$1" rest hostport
+  case "$url" in
+    https://*) rest="${url#https://}" ;;
+    http://*)  rest="${url#http://}" ;;
+    *) return 0 ;;
+  esac
+  hostport="${rest%%/*}"
+  printf '%s' "${hostport#*@}"
+}
+
+hdr "git push credentials (issue #2942)"
+# Classify origin BEFORE probing: only an http(s) remote uses a credential helper.
+# An SSH remote authenticates with a key (a helper is irrelevant), and a local/file
+# remote needs no credential at all — mislabeling either would send an operator
+# after the wrong fix, which is the exact failure mode this whole change exists to end.
+GIT_ORIGIN_URL=""; GIT_ORIGIN_HOST=""; GIT_ORIGIN_KIND=none
+if have git; then
+  GIT_ORIGIN_URL=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
+  case "$GIT_ORIGIN_URL" in
+    "")                    GIT_ORIGIN_KIND=none ;;
+    https://*|http://*)    GIT_ORIGIN_KIND=https; GIT_ORIGIN_HOST=$(git_origin_host "$GIT_ORIGIN_URL") ;;
+    ssh://*|git+ssh://*)   GIT_ORIGIN_KIND=ssh ;;
+    *@*:*)                 GIT_ORIGIN_KIND=ssh ;;   # scp-like git@host:owner/repo.git
+    *)                     GIT_ORIGIN_KIND=other ;; # file:// or a local path
+  esac
+  [ "$GIT_ORIGIN_KIND" = https ] && [ -z "$GIT_ORIGIN_HOST" ] && GIT_ORIGIN_KIND=other
+fi
+
+if ! have git; then
+  warn "git NOT installed — the claim protocol pushes with plain git"
+elif [ "$GIT_ORIGIN_KIND" = none ]; then
+  warn "no 'origin' remote in $REPO_ROOT — cannot check push credentials"
+elif [ "$GIT_ORIGIN_KIND" = ssh ]; then
+  # SSH (git@host:… / ssh://…): git authenticates with your SSH key, and an https
+  # credential helper is irrelevant. Report it and configure nothing.
+  ok "origin is an SSH remote — git push authenticates via SSH keys, not a credential helper (no helper needed)"
+  info "verify separately if pushes fail:  ssh -T git@github.com"
+elif [ "$GIT_ORIGIN_KIND" = other ]; then
+  info "origin ($GIT_ORIGIN_URL) is neither http(s) nor SSH — no credential helper applies"
+elif git_cred_probe "$GIT_ORIGIN_HOST"; then
+  ok "git push credentials resolve for $GIT_ORIGIN_HOST (a credential helper answers)"
+  if git -C "$REPO_ROOT" config --local --get-all credential.helper >/dev/null 2>&1 \
+     && ! git config --global --get-all credential.helper >/dev/null 2>&1; then
+    info "note: the helper is configured at REPO-LOCAL scope only — a fresh clone or a"
+    info "      new checkout on this box will NOT inherit it. Re-run with --yes to add a global one."
+  fi
+else
+  warn "git push has NO credentials for $GIT_ORIGIN_HOST — an authenticated 'gh' does NOT authenticate git"
+  info "symptom: every push fails with  fatal: could not read Username for 'https://$GIT_ORIGIN_HOST'"
+  info "impact: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — the claim protocol does not work"
+  info "fix:    gh auth setup-git    (preferred; wires gh as git's credential helper)"
+  info "        or re-run with --yes to configure a helper that reads \$GH_TOKEN at call time"
+  if [ "$AUTO_YES" = 1 ]; then
+    cred_fixed=0
+    # Preferred form: let gh wire itself in. Verified by RE-PROBING — on the box
+    # that motivated #2942 the gh credential path was precisely what was not wired,
+    # so "the command exited 0" is not evidence.
+    if have gh && gh auth status >/dev/null 2>&1; then
+      info "configuring: gh auth setup-git"
+      if gh auth setup-git >/dev/null 2>&1 && git_cred_probe "$GIT_ORIGIN_HOST"; then
+        ok "git credentials configured via 'gh auth setup-git' (no secret written to disk)"
+        cred_fixed=1
+      else
+        info "'gh auth setup-git' did not yield a usable credential — falling back to the \$GH_TOKEN helper"
+      fi
+    fi
+    if [ "$cred_fixed" = 0 ]; then
+      if [ -z "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]; then
+        warn "cannot auto-configure: neither GH_TOKEN nor GITHUB_TOKEN is set in this environment"
+        info "export GH_TOKEN=<token>, then re-run:  bash scripts/bootstrap-agent-machine.sh --yes"
+      else
+        # The value written is a shell snippet that DEREFERENCES $GH_TOKEN when git
+        # asks — the token itself never lands on disk, so rotating it needs no
+        # reconfiguration and a leaked ~/.gitconfig leaks no credential. (Decision 2
+        # of the worker-env-preflight change: explicitly NOT ~/.git-credentials.)
+        info "configuring a global credential.helper that dereferences \$GH_TOKEN at call time (the token is NOT written to disk)"
+        # Idempotence: never stack a second copy of our helper on a re-run. Reaching
+        # here with one already present means the token itself is the problem.
+        if git config --global --get-all credential.helper 2>/dev/null | grep -qF 'x-access-token'; then
+          warn "a \$GH_TOKEN-style helper is ALREADY in the global git config yet the probe still fails — check that GH_TOKEN is valid/unexpired (not re-adding it)"
+        elif git config --global --add credential.helper "$GIT_CRED_HELPER" 2>/dev/null \
+           && git_cred_probe "$GIT_ORIGIN_HOST"; then
+          ok "git credentials configured via a \$GH_TOKEN-dereferencing helper (no secret written to disk)"
+        else
+          warn "could not configure a working git credential helper — fix manually: gh auth setup-git"
+        fi
+      fi
+    fi
+  else
+    info "(re-run with --yes to auto-configure)"
+  fi
 fi
 
 # ---- 4. roborev (follows LOCAL machine config — never pin an agent, #1921 owner correction) ----

--- a/scripts/flow/claim-heartbeat.sh
+++ b/scripts/flow/claim-heartbeat.sh
@@ -109,6 +109,13 @@ note()      { echo "[claim-heartbeat] $*" >&2; }
 
 REMOTE="${HEARTBEAT_REMOTE:-origin}"
 
+# Never block on an interactive credential prompt (issue #2942). On a tty-attached
+# worker with no git credential helper, the ref pushes below would sit waiting for a
+# username forever instead of failing. Prompts off = they fail fast and visibly.
+# NOTE: unlike claim.sh, this script does NOT classify auth-vs-transient on its
+# pushes — it surfaces git's raw error.
+export GIT_TERMINAL_PROMPT=0
+
 # Default reap threshold: 4h (matches the heartbeat threshold documented above).
 DEFAULT_REAP_THRESHOLD_SECS="${DEFAULT_REAP_THRESHOLD_SECS:-14400}"
 

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -132,6 +132,12 @@ emit_auth() {
 # CREDENTIAL/AUTHORIZATION failure rather than a network/outage one. Deliberately
 # conservative: anything unrecognized stays an infra (retryable) verdict, so the
 # #2665 contract can only ever be narrowed by a signature we positively identify.
+# Every pattern below is unambiguously credential-shaped. Two candidates were
+# deliberately REJECTED because they are emitted by non-credential faults too, and
+# misclassifying a transient as permanent is the one direction #2665 says never to
+# move: `403 Forbidden` (a proxy or edge outage returns it; GitHub's rate-limit text
+# is `HTTP 403`, so nothing real is lost) and `remote: Repository not found` (seen
+# during brief degradations and in the window right after a token rotation).
 git_stderr_is_auth() {
   case "$1" in
     *"could not read Username"*      | *"could not read Password"*        | \
@@ -139,8 +145,7 @@ git_stderr_is_auth() {
     *"terminal prompts disabled"*    | *"Invalid username or token"*      | \
     *"Invalid username or password"* | *"Permission denied (publickey)"*  | \
     *"Permission to "*" denied"*     | *"Write access to repository not granted"* | \
-    *"remote: Repository not found"* | *"Support for password authentication was removed"* | \
-    *"403 Forbidden"*                | *"401 Unauthorized"*)
+    *"Support for password authentication was removed"* | *"401 Unauthorized"*)
       return 0 ;;
   esac
   return 1
@@ -439,7 +444,9 @@ cmd_adopt() {
   # read can diagnose. On a public repo the confirm read succeeds and would report
   # ADOPT-LOST — blaming the lease for what is a broken machine. A lease mismatch
   # says "stale info", never an auth signature, so this cannot swallow a real CAS loss.
-  if [ -n "$adopt_err" ] && git_stderr_is_auth "$adopt_err"; then
+  # No `[ -n "$adopt_err" ]` pre-guard: it was redundant (an empty string matches no
+  # signature) and it read as if empty stderr were a meaningful state to skip on.
+  if git_stderr_is_auth "$adopt_err"; then
     emit_auth "issue=$issue detail=adopt-cas-push-unauthenticated ref=refs/claims/issue-$issue"
     return 1
   fi

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -95,6 +95,9 @@
 #      maps an ls-remote/push/delete failure to ERROR (exit 1), so a network blip never
 #      makes a worker conclude it LOST/does-not-hold/RELEASED. `claim` also never reports
 #      LOST when nobody holds the ref (a failed push whose re-read finds it absent).
+#      ALSO exit 1: `CLAIM ERROR reason=auth` — a push git could not AUTHENTICATE
+#      (issue #2942). Same exit code (callers keep treating 1 as "not a race"), but the
+#      verdict is explicitly NOT retryable: retrying cannot fix a missing credential.
 #   64 usage error
 #
 # ---END-HELP---
@@ -112,7 +115,44 @@ emit()      { echo "CLAIM: $*"; }
 # a worker conclude it lost ownership.
 emit_infra() { emit "ERROR reason=infra $* (transient — retry)"; }
 
+# emit_auth <line> — a push git could not AUTHENTICATE (issue #2942). This is a
+# MACHINE-CONFIGURATION fault, not a blip: it cannot self-clear, so it must never
+# wear the `transient — retry` wording. Observed: a box with an authenticated `gh`
+# but no git credential helper failed every claim push and was reported as
+# `reason=infra ... (transient — retry)`, sending the worker into a retry loop on an
+# operation that can never succeed. Callers pair this with `return 1` (same exit code
+# as infra — still "not a race-loss" — but the text names the fix, not a retry).
+# The remediation is deliberately fixed text: git's raw stderr is NEVER echoed,
+# because a remote URL can carry an embedded token.
+emit_auth() {
+  emit "ERROR reason=auth $* (NOT retryable — git cannot authenticate to $REMOTE; fix credentials: 'gh auth setup-git' or 'bash scripts/bootstrap-agent-machine.sh --yes', then re-run)"
+}
+
+# git_stderr_is_auth <captured-stderr> — 0 iff the text carries the signature of a
+# CREDENTIAL/AUTHORIZATION failure rather than a network/outage one. Deliberately
+# conservative: anything unrecognized stays an infra (retryable) verdict, so the
+# #2665 contract can only ever be narrowed by a signature we positively identify.
+git_stderr_is_auth() {
+  case "$1" in
+    *"could not read Username"*      | *"could not read Password"*        | \
+    *"Authentication failed"*        | *"authentication failed"*          | \
+    *"terminal prompts disabled"*    | *"Invalid username or token"*      | \
+    *"Invalid username or password"* | *"Permission denied (publickey)"*  | \
+    *"Permission to "*" denied"*     | *"Write access to repository not granted"* | \
+    *"remote: Repository not found"* | *"Support for password authentication was removed"* | \
+    *"403 Forbidden"*                | *"401 Unauthorized"*)
+      return 0 ;;
+  esac
+  return 1
+}
+
 REMOTE="${CLAIM_REMOTE:-origin}"
+
+# Never let a remote operation block on an interactive credential prompt: an
+# unattended worker would hang forever instead of failing with a diagnosable
+# verdict (issue #2942). With prompts disabled git fails fast and its stderr
+# carries the `could not read Username` signature emit_auth keys on.
+export GIT_TERMINAL_PROMPT=0
 
 print_help() {
   awk 'NR>=2 && /^# ---END-HELP---/{exit} NR>=2 {sub(/^# ?/,""); print}' "$0"
@@ -284,11 +324,22 @@ cmd_claim() {
   fi
 
   # Build our unique claim commit and attempt the atomic create.
-  local sha
+  local sha push_err
   sha="$(build_claim_commit "$issue" "$actor")"
-  if git push "$REMOTE" "${sha}:refs/claims/issue-${issue}" >/dev/null 2>&1; then
+  # Capture the push's stderr (stdout discarded) so a CREDENTIAL failure can be told
+  # apart from a race-loss and from a genuine transient (issue #2942). The captured
+  # text is only ever CLASSIFIED, never emitted — a remote URL can embed a token.
+  if push_err="$(git push "$REMOTE" "${sha}:refs/claims/issue-${issue}" 2>&1 >/dev/null)"; then
     : # push accepted — confirm below.
   else
+    # Auth is checked FIRST and independently of the re-read: on a public repo an
+    # unauthenticated box still ls-remotes fine (so the ref reads as absent and the
+    # old code called it a transient), while on a private repo BOTH fail. Either way
+    # the cause is the same permanent, non-retryable credential fault.
+    if git_stderr_is_auth "$push_err"; then
+      emit_auth "issue=$issue detail=claim-push-unauthenticated ref=refs/claims/issue-$issue"
+      return 1
+    fi
     # Push failed. Distinguish a genuine race-loss (another holder present) from
     # an infra failure (remote unreachable, or a push error with NO holder) — a
     # LOST verdict must NEVER be emitted when nobody actually holds the ref.
@@ -376,14 +427,22 @@ cmd_adopt() {
   require_numeric_issue "$issue" adopt
   [ -n "$expect" ] || die_usage "adopt requires --expect <old-sha>"
 
-  local sha
+  local sha adopt_err=""
   sha="$(build_claim_commit "$issue" "$actor")"
   # Compare-and-swap: replace the ref ONLY if origin is still at <old-sha>. We
   # ignore the push exit here and let the infra-AWARE confirm read below decide —
   # mirroring cmd_claim exactly, so a lease-mismatch, a TOCTOU, and an infra blip
   # are told apart by the READ, never by the push's opaque non-zero.
-  git push --force-with-lease="refs/claims/issue-${issue}:${expect}" \
-        "$REMOTE" "${sha}:refs/claims/issue-${issue}" >/dev/null 2>&1 || true
+  adopt_err="$(git push --force-with-lease="refs/claims/issue-${issue}:${expect}" \
+        "$REMOTE" "${sha}:refs/claims/issue-${issue}" 2>&1 >/dev/null)" || true
+  # ...with ONE exception (issue #2942): a CREDENTIAL failure is not something the
+  # read can diagnose. On a public repo the confirm read succeeds and would report
+  # ADOPT-LOST — blaming the lease for what is a broken machine. A lease mismatch
+  # says "stale info", never an auth signature, so this cannot swallow a real CAS loss.
+  if [ -n "$adopt_err" ] && git_stderr_is_auth "$adopt_err"; then
+    emit_auth "issue=$issue detail=adopt-cas-push-unauthenticated ref=refs/claims/issue-$issue"
+    return 1
+  fi
 
   # Confirm via the infra-AWARE lookup: a lookup failure is infra (retryable,
   # exit 1), NEVER a false ADOPT-LOST on a claim we actually landed. If the read
@@ -478,21 +537,32 @@ cmd_release() {
     fi
     # Compare-and-swap delete: remove the ref ONLY if it is still at <sha> we just
     # read and own — a ref that changed under us (adopted/reaped) fails the lease.
-    if git push "$REMOTE" --force-with-lease="refs/claims/issue-${issue}:${sha}" \
-          ":refs/claims/issue-${issue}" >/dev/null 2>&1; then
+    local rel_err
+    if rel_err="$(git push "$REMOTE" --force-with-lease="refs/claims/issue-${issue}:${sha}" \
+          ":refs/claims/issue-${issue}" 2>&1 >/dev/null)"; then
       emit "RELEASED issue=$issue ref=refs/claims/issue-$issue sha=$sha (cas)"
       return 0
     fi
-    # CAS delete failed: the ref changed under us OR the remote is unreachable —
-    # either way a retryable ERROR (exit 1), never a silent success.
+    # CAS delete failed: an unauthenticated push is a permanent machine fault, not
+    # something a retry fixes (#2942); anything else is the ref changing under us OR
+    # an unreachable remote — a retryable ERROR (exit 1), never a silent success.
+    if git_stderr_is_auth "$rel_err"; then
+      emit_auth "issue=$issue detail=release-cas-delete-unauthenticated sha=$sha"
+      return 1
+    fi
     emit_infra "issue=$issue detail=cas-delete-failed-on-$REMOTE (ref changed or remote unreachable) sha=$sha"
     return 1
   fi
 
   # --force: reaper/adopt semantics — unconditional delete, no identity/PR gate.
-  if git push "$REMOTE" --delete "refs/claims/issue-${issue}" >/dev/null 2>&1; then
+  local force_err
+  if force_err="$(git push "$REMOTE" --delete "refs/claims/issue-${issue}" 2>&1 >/dev/null)"; then
     emit "RELEASED issue=$issue ref=refs/claims/issue-$issue sha=$sha (force)"
     return 0
+  fi
+  if git_stderr_is_auth "$force_err"; then
+    emit_auth "issue=$issue detail=release-force-delete-unauthenticated sha=$sha"
+    return 1
   fi
   emit_infra "issue=$issue detail=delete-failed-on-$REMOTE sha=$sha"
   return 1
@@ -560,7 +630,15 @@ cmd_smoke() {
   ref="refs/claims/smoke-${nonce}"
   note "smoke preflight: does $REMOTE accept a push to refs/claims/* ? (ref=$ref)"
   sha="$(build_claim_commit "smoke" "smoke")" || { emit "SMOKE-FAIL remote=$REMOTE reason=commit-build"; return 1; }
-  if ! git push "$REMOTE" "${sha}:${ref}" >/dev/null 2>&1; then
+  local smoke_err
+  if ! smoke_err="$(git push "$REMOTE" "${sha}:${ref}" 2>&1 >/dev/null)"; then
+    # An unauthenticated git is the #1 reason this preflight fails on a fresh box,
+    # and blaming the ref namespace sends the operator hunting the wrong thing
+    # (#2942) — so name the credential fault when the stderr says so.
+    if git_stderr_is_auth "$smoke_err"; then
+      emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=auth (git cannot authenticate — NOT a namespace restriction; fix with 'gh auth setup-git' or 'bash scripts/bootstrap-agent-machine.sh --yes')"
+      return 1
+    fi
     emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=push-rejected (does $REMOTE permit the refs/claims/* namespace?)"
     return 1
   fi

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -168,7 +168,7 @@ mk_hermetic_bin() {
   local dir="$1" t p
   mkdir -p "$dir"
   for t in bash dirname mktemp grep cp cat sed awk mkdir rm ln mv touch chmod \
-           head tail tr sort cut wc stat env git find xargs basename date sleep expr; do
+           head tail tr sort cut wc stat env git find xargs basename date sleep expr timeout; do
     p=$(type -P "$t" 2>/dev/null) || continue
     [ -n "$p" ] && ln -sf "$p" "$dir/$t" 2>/dev/null || true
   done
@@ -517,6 +517,18 @@ else
   bad "cred: --yes did not configure the \$GH_TOKEN fallback helper"
   [ -f "$gc7b" ] && { echo "--- gitconfig ---"; cat "$gc7b"; echo "-----------------"; }
 fi
+# The helper MUST be host-scoped. A bare [credential] helper offers the GitHub token
+# to every https host git talks to (submodules, cargo/pip git deps, a mistyped clone,
+# anything answering 401) — and `gh auth setup-git`, the path this falls back FROM,
+# scopes per host, so an unscoped fallback is strictly less safe than the preferred one.
+if [ -f "$gc7b" ] \
+   && git config --file "$gc7b" --get-all 'credential.https://github.com.helper' 2>/dev/null | grep -qF 'x-access-token' \
+   && ! git config --file "$gc7b" --get-all credential.helper 2>/dev/null | grep -qF 'x-access-token'; then
+  ok "cred: fallback helper is HOST-SCOPED (credential.https://github.com.helper), not a bare credential.helper"
+else
+  bad "cred: fallback helper is host-UNSCOPED — the token would be offered to every https host"
+  [ -f "$gc7b" ] && { echo "--- gitconfig ---"; cat "$gc7b"; echo "-----------------"; }
+fi
 # The whole point of Decision 2: no file written by the bootstrap holds the secret.
 leak7b=$(grep -rlF "$FAKE_TOKEN" "$sb7b" "$gc7b" "$repo7b" 2>/dev/null | head -5)
 if [ -z "$leak7b" ]; then
@@ -565,6 +577,71 @@ if printf '%s' "$out7d" | grep -qi "SSH" \
 else
   bad "cred: SSH origin case wrote a helper or did not report the SSH path"
   [ -f "$gc7d" ] && cat "$gc7d"
+fi
+
+# 7f. FUNCTIONAL confinement of the config 7b actually produced: github.com gets a
+#     credential, an unrelated host gets NOTHING. This is the assertion that would
+#     have caught a bare [credential] helper regardless of how it was written.
+cred_fill_host() {
+  # cred_fill_host <config> <host> -> prints the resolved password line, if any
+  printf 'protocol=https\nhost=%s\n\n' "$2" \
+    | GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=nonexistent-askpass SSH_ASKPASS=nonexistent-askpass \
+      GIT_CONFIG_GLOBAL="$1" GIT_CONFIG_NOSYSTEM=1 GH_TOKEN="$FAKE_TOKEN" \
+      git -C "$tmp" credential fill 2>/dev/null | grep '^password=.' || true
+}
+if [ -n "$(cred_fill_host "$gc7b" github.com)" ] \
+   && [ -z "$(cred_fill_host "$gc7b" evil.example)" ] \
+   && [ -z "$(cred_fill_host "$gc7b" gitlab.com)" ]; then
+  ok "cred: helper answers for github.com and NOT for evil.example / gitlab.com"
+else
+  bad "cred: helper leaks the token to non-origin hosts (or fails for the origin host)"
+fi
+
+# 7g. Helper installed but GH_TOKEN absent from the environment — the reachable
+#     production case, since --yes writes the helper GLOBALLY and PERSISTENTLY while
+#     GH_TOKEN is per-shell (bootstrap interactively, then run the worker from
+#     systemd/cron). git treats an empty `password=` as satisfied, so an
+#     exit-status-only probe would report ok while every push fails.
+sb7g=$(mktemp -d "$tmp/cred7g.XXXXXX"); stub7g="$tmp/stub7g"
+mk_hermetic_bin "$stub7g"
+repo7g="$tmp/repo7g"; mk_fake_repo "$repo7g" "https://github.com/pmcfadin/cqlite.git"
+gc7g="$sb7g/gitconfig"
+cp "$gc7b" "$gc7g" 2>/dev/null || :   # the exact helper config --yes produced in 7b
+out7g=$(PATH="$stub7g" HOME="$sb7g" CARGO_HOME="$sb7g/.cargo" GIT_CONFIG_GLOBAL="$gc7g" \
+  GH_TOKEN="" GITHUB_TOKEN="" bash "$repo7g/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+if printf '%s' "$out7g" | grep -q "\[warn\].*git push has NO credentials" \
+   && ! printf '%s' "$out7g" | grep -Eq '\[ok\].*git push credentials resolve'; then
+  ok "cred: helper present but GH_TOKEN unset -> WARN (an empty password is not a credential)"
+else
+  bad "cred: empty-token case reported ok — probe accepted an empty password"
+  printf '%s\n' "$out7g" | grep -i -A2 "git push"
+fi
+
+# 7h. A HANGING credential helper must not hang the bootstrap. Neither
+#     GIT_TERMINAL_PROMPT nor GIT_ASKPASS governs a helper SUBPROCESS — real cases are
+#     a Git Credential Manager device-code/browser flow, credential-cache waiting on a
+#     dead daemon socket, and a locked osxkeychain. This matters beyond the operator:
+#     section 3 above runs the real bootstrap against the real REPO_ROOT, so
+#     `tooling-tests` probes a developer's ACTUAL helper chain and a hang there would
+#     stall the gate of record. This is a deadlock/liveness guard, not a latency
+#     budget: the helper sleeps 120s, the probe's own bound is 10s, and the outer
+#     ceiling is 60s — ~6x slack, so host load can never flip it.
+if command -v timeout >/dev/null 2>&1; then
+  sb7h=$(mktemp -d "$tmp/cred7h.XXXXXX"); stub7h="$tmp/stub7h"
+  mk_hermetic_bin "$stub7h"
+  repo7h="$tmp/repo7h"; mk_fake_repo "$repo7h" "https://github.com/pmcfadin/cqlite.git"
+  gc7h="$sb7h/gitconfig"
+  git config --file "$gc7h" --add 'credential.https://github.com.helper' '!f(){ sleep 120; };f'
+  rc7h=0
+  timeout 60 env PATH="$stub7h" HOME="$sb7h" CARGO_HOME="$sb7h/.cargo" GIT_CONFIG_GLOBAL="$gc7h" \
+    GH_TOKEN="" bash "$repo7h/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1 || rc7h=$?
+  if [ "$rc7h" -ne 124 ]; then
+    ok "cred: a hanging credential helper is bounded — bootstrap still completes (rc=$rc7h)"
+  else
+    bad "cred: bootstrap HUNG on a blocking credential helper (killed at the outer ceiling)"
+  fi
+else
+  echo "skip - cred: hanging-helper guard needs 'timeout' (absent on this host)"
 fi
 
 # 7e. Re-running --yes must not STACK a second copy of the helper. Bootstrap is
@@ -671,12 +748,17 @@ else
 fi
 
 # 8c. Fully healthy token: probe succeeds, gh reports no missing scopes -> an ok.
+#     The assertion names PROBE-DERIVED text on purpose: a looser `[ok].*board` also
+#     matches the old scope-string verdict ("[ok] 'project' scope present — board
+#     dispatch works"), so it would pass against the very bug this section exists to
+#     catch. In a change about false OKs, a test that passes against the bug is the
+#     one thing that must not ship.
 run_board_case healthy "'project', 'read:org', 'repo', 'workflow'" "" 0 0
-if printf '%s' "$BOARD_OUT" | grep -Eq '\[ok\].*board'; then
-  ok "board: healthy token + successful probe reports ok"
+if printf '%s' "$BOARD_OUT" | grep -Eq "\[ok\].*board #1 \(pmcfadin\) reachable.*read probe OK"; then
+  ok "board: healthy token reports ok with a PROBE-derived verdict"
 else
-  bad "board: healthy token did not produce an ok verdict"
-  printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board"
+  bad "board: healthy token did not produce a probe-derived ok verdict"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board #"
 fi
 
 # 8d. Unreachable board (both probes fail) -> a loud warn, never a scope-based pass.

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -652,16 +652,44 @@ mk_hermetic_bin "$stub7e"
 mk_stub "$stub7e" gh 'exit 0'   # setup-git is a no-op -> the fallback helper is used
 repo7e="$tmp/repo7e"; mk_fake_repo "$repo7e" "https://github.com/pmcfadin/cqlite.git"
 gc7e="$sb7e/gitconfig"
-for _ in 1 2 3; do
+for _ in 1 2; do
   PATH="$stub7e" HOME="$sb7e" CARGO_HOME="$sb7e/.cargo" GIT_CONFIG_GLOBAL="$gc7e" \
     GH_TOKEN="$FAKE_TOKEN" bash "$repo7e/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke >/dev/null 2>&1
 done
+out7e=$(PATH="$stub7e" HOME="$sb7e" CARGO_HOME="$sb7e/.cargo" GIT_CONFIG_GLOBAL="$gc7e" \
+  GH_TOKEN="$FAKE_TOKEN" bash "$repo7e/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
 helper_count=$(grep -c 'x-access-token' "$gc7e" 2>/dev/null); helper_count="${helper_count:-0}"
 if [ "$helper_count" = 1 ]; then
   ok "cred: repeated --yes runs keep exactly one credential helper (idempotent)"
 else
   bad "cred: helper stacked across re-runs (count=$helper_count)"
   [ -f "$gc7e" ] && cat "$gc7e"
+fi
+# On the re-run the probe SUCCEEDS, so the verdict comes from the ok branch — and its
+# advisories must see the HOST-SCOPED key this script itself writes. A bare
+# `credential.helper` lookup would go silent on exactly the config it just created,
+# muting the caveat that matters most to a systemd/cron worker.
+if printf '%s' "$out7e" | grep -q 'reads \$GH_TOKEN from the ENVIRONMENT'; then
+  ok "cred: env-dependency caveat fires for the HOST-SCOPED helper the script writes"
+else
+  bad "cred: env-dependency caveat missed a host-scoped helper"
+  printf '%s\n' "$out7e" | grep -i -A2 "git push credentials"
+fi
+
+# 7i. Same blind spot on the other advisory: a host-scoped helper at REPO-LOCAL scope
+#     with no global one must still raise the "a fresh clone won't inherit it" note.
+sb7i=$(mktemp -d "$tmp/cred7i.XXXXXX"); stub7i="$tmp/stub7i"
+mk_hermetic_bin "$stub7i"
+repo7i="$tmp/repo7i"; mk_fake_repo "$repo7i" "https://github.com/pmcfadin/cqlite.git"
+git -C "$repo7i" config --local --add 'credential.https://github.com.helper' \
+  '!f(){ test "$1" = get || exit 0; echo username=x; echo password=local-only-secret; };f'
+out7i=$(PATH="$stub7i" HOME="$sb7i" CARGO_HOME="$sb7i/.cargo" GIT_CONFIG_GLOBAL="$sb7i/gitconfig" \
+  GH_TOKEN="" bash "$repo7i/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+if printf '%s' "$out7i" | grep -q 'REPO-LOCAL scope only'; then
+  ok "cred: repo-local-scope note fires for a HOST-SCOPED local helper"
+else
+  bad "cred: repo-local-scope note missed a host-scoped local helper"
+  printf '%s\n' "$out7i" | grep -i -A3 "git push credentials"
 fi
 
 # --- 8. Board check is a FUNCTIONAL, READ-ONLY probe (issue #2942) ----------
@@ -703,6 +731,8 @@ EOF
 }
 
 # run_board_case <name> <scopes> <missing> <project-rc> <api-rc> -> sets BOARD_OUT/BOARD_LOG
+# CQLITE_PROJECT_ACCOUNT is pinned to the stub's account so these cases exercise the
+# VERDICT logic with no account switch in play (switching has its own cases below).
 run_board_case() {
   local name="$1" scopes="$2" missing="$3" prc="$4" arc="$5"
   local sb stub repo
@@ -712,7 +742,35 @@ run_board_case() {
   mk_board_gh "$stub" "$BOARD_LOG" "$scopes" "$missing" "$prc" "$arc"
   repo="$tmp/repo-board-$name"; mk_fake_repo "$repo" "https://github.com/pmcfadin/cqlite.git"
   BOARD_OUT=$(PATH="$stub" HOME="$sb" CARGO_HOME="$sb/.cargo" GIT_CONFIG_GLOBAL="$sb/gitconfig" \
+    CQLITE_PROJECT_ACCOUNT=tester \
     GH_TOKEN="" bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+}
+
+# run_board_auth_case <name> <auth-status-body> [env...] -> BOARD_OUT/BOARD_LOG
+# Like run_board_case but the caller supplies the VERBATIM `gh auth status` body, so a
+# multi-account host can be modelled exactly. `gh project`/`gh api` always succeed, so
+# any non-green verdict is attributable purely to which account's stanza was parsed.
+run_board_auth_case() {
+  local name="$1" body="$2"; shift 2
+  local sb stub repo
+  sb=$(mktemp -d "$tmp/bauth-$name.XXXXXX"); stub="$tmp/stub-bauth-$name"
+  mk_hermetic_bin "$stub"
+  BOARD_LOG="$tmp/gh-bauth-$name.log"; : >"$BOARD_LOG"
+  printf '%s\n' "$body" >"$tmp/authbody-$name.txt"
+  cat >"$stub/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$BOARD_LOG"
+case "\$1" in
+  auth) [ "\$2" = status ] && cat "$tmp/authbody-$name.txt"; exit 0 ;;
+  project) exit 0 ;;
+  api)     echo "PVT_kwStubProjectId"; exit 0 ;;
+  *)       exit 0 ;;
+esac
+EOF
+  chmod +x "$stub/gh"
+  repo="$tmp/repo-bauth-$name"; mk_fake_repo "$repo" "https://github.com/pmcfadin/cqlite.git"
+  BOARD_OUT=$(PATH="$stub" HOME="$sb" CARGO_HOME="$sb/.cargo" GIT_CONFIG_GLOBAL="$sb/gitconfig" \
+    GH_TOKEN="" "$@" bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 }
 
 # 8a. THE false-OK case: `project` scope present, `read:org` missing, `gh project`
@@ -779,6 +837,158 @@ if printf '%s' "$BOARD_OUT" | grep -Eq '\[warn\].*(UNREACHABLE|BOTH probes faile
 else
   bad "board: null-project GraphQL reply was treated as a working fallback"
   printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board #"
+fi
+
+# 8g. READ-ONLY project access ('read:project', no 'project') with a clean probe and
+#     no gh-reported missing scopes. Board WRITES — the whole dispatch loop — still
+#     fail, so an unqualified ok as the section's LAST word would be a false OK even
+#     though an earlier line warned about the scope.
+run_board_case readonlyscope "'read:project', 'repo', 'workflow'" "" 0 0
+if printf '%s' "$BOARD_OUT" | grep -Eq '\[ok\].*board #1.*reachable'; then
+  bad "board: read-only project scope still printed an unqualified 'reachable' ok"
+elif printf '%s' "$BOARD_OUT" | grep -Eq "\[warn\].*board READ works.*'project' WRITE scope is MISSING"; then
+  ok "board: read-only project scope -> READ-works warn naming the missing WRITE scope"
+else
+  bad "board: read-only project scope produced neither the ok nor the expected warn"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A2 "board"
+fi
+
+# --- 8h. The verdict must be attributed to the ACTIVE account ----------------
+# `gh auth status` prints one stanza PER logged-in account and the active one is not
+# guaranteed first, so a whole-output grep can read a DIFFERENT account's scopes than
+# the one every gh call uses. This repo documents the exact hazard
+# (.claude/skills/flow-board/SKILL.md): the active account silently flips to an EMU
+# account lacking `project`, and board writes then degrade SILENTLY. Both cases below
+# are built so a whole-output grep gives the WRONG verdict.
+
+# 8h-i. ACTIVE account is clean; a NON-active account reports missing scopes. A
+#       whole-output grep sees that stray line and wrongly qualifies the verdict.
+run_board_auth_case active-clean 'github.com
+  ✓ Logged in to github.com account other-emu (keyring)
+  - Active account: false
+  - Token scopes: '"'"'project'"'"', '"'"'repo'"'"'
+  ! Missing required token scopes: '"'"'read:org'"'"'
+  ✓ Logged in to github.com account pmcfadin (keyring)
+  - Active account: true
+  - Token scopes: '"'"'project'"'"', '"'"'read:org'"'"', '"'"'repo'"'"''
+if printf '%s' "$BOARD_OUT" | grep -Eq "\[ok\].*board #1.*reachable as 'pmcfadin'"; then
+  ok "board: a NON-active account's missing-scopes line does not qualify the verdict"
+else
+  bad "board: verdict read a non-active account's stanza"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A2 "board\|account"
+fi
+
+# 8h-ii. A NON-active account listed FIRST has 'project'; the ACTIVE one does not. A
+#        whole-output `grep 'Token scopes:' | head -1` picks the wrong stanza and would
+#        greenlight a machine whose dispatch writes all fail.
+run_board_auth_case active-noproject 'github.com
+  ✓ Logged in to github.com account other-emu (keyring)
+  - Active account: false
+  - Token scopes: '"'"'project'"'"', '"'"'read:org'"'"', '"'"'repo'"'"'
+  ✓ Logged in to github.com account pmcfadin (keyring)
+  - Active account: true
+  - Token scopes: '"'"'read:project'"'"', '"'"'repo'"'"''
+if ! printf '%s' "$BOARD_OUT" | grep -Eq '\[ok\].*board #1.*reachable' \
+   && printf '%s' "$BOARD_OUT" | grep -q "'project' scope MISSING on gh account 'pmcfadin'"; then
+  ok "board: scopes are read from the ACTIVE stanza, not the first one printed"
+else
+  bad "board: scopes were read from a non-active (first-listed) account"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A2 "scope\|board #"
+fi
+
+# 8h-iii. The operator must be able to see WHICH account the verdict is about.
+if printf '%s' "$BOARD_OUT" | grep -q "measuring gh account 'pmcfadin'"; then
+  ok "board: names the account the verdict is about"
+else
+  bad "board: verdict does not name the account it measured"
+fi
+
+# --- 8i. Probe the account board dispatch actually uses ----------------------
+# flow-board forces CQLITE_PROJECT_ACCOUNT active before EVERY board op. Probing as
+# whatever happens to be active measures a different identity: with an EMU account
+# active, bootstrap would shout "board UNREACHABLE — a session must STOP" about a
+# machine where flow-board switches and works fine. Mirroring the switch is required —
+# and because it mutates real gh state, the operator's account must be RESTORED.
+mk_switch_gh() {
+  # mk_switch_gh <dir> <log> <statefile> <acctA> <acctB>  (acctA starts active)
+  local dir="$1" log="$2" state="$3" a="$4" b="$5"
+  printf '%s' "$a" >"$state"
+  cat >"$dir/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$log"
+cur=\$(cat "$state" 2>/dev/null)
+case "\$1" in
+  auth)
+    case "\$2" in
+      status)
+        echo "github.com"
+        for acct in $a $b; do
+          echo "  ✓ Logged in to github.com account \$acct (keyring)"
+          if [ "\$acct" = "\$cur" ]; then echo "  - Active account: true"
+          else echo "  - Active account: false"; fi
+          echo "  - Token scopes: 'project', 'read:org', 'repo'"
+        done
+        exit 0 ;;
+      switch)
+        shift 2
+        while [ \$# -gt 0 ]; do
+          [ "\$1" = --user ] && printf '%s' "\$2" >"$state"
+          shift
+        done
+        exit 0 ;;
+      *) exit 0 ;;
+    esac ;;
+  project) exit 0 ;;
+  api)     echo "PVT_kwStubProjectId"; exit 0 ;;
+  *)       exit 0 ;;
+esac
+EOF
+  chmod +x "$dir/gh"
+}
+
+sb8i=$(mktemp -d "$tmp/board8i.XXXXXX"); stub8i="$tmp/stub8i"
+mk_hermetic_bin "$stub8i"
+log8i="$tmp/gh8i.log"; : >"$log8i"; state8i="$tmp/gh8i.state"
+mk_switch_gh "$stub8i" "$log8i" "$state8i" other-emu pmcfadin   # EMU active at start
+repo8i="$tmp/repo8i"; mk_fake_repo "$repo8i" "https://github.com/pmcfadin/cqlite.git"
+out8i=$(PATH="$stub8i" HOME="$sb8i" CARGO_HOME="$sb8i/.cargo" GIT_CONFIG_GLOBAL="$sb8i/gitconfig" \
+  GH_TOKEN="" bash "$repo8i/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+if grep -q -- 'auth switch --user pmcfadin' "$log8i"; then
+  ok "board: switches to CQLITE_PROJECT_ACCOUNT before probing (mirrors flow-board)"
+else
+  bad "board: never switched to the board account — probes a different identity than dispatch uses"
+fi
+if grep -q -- 'auth switch --user other-emu' "$log8i" && [ "$(cat "$state8i")" = other-emu ]; then
+  ok "board: RESTORES the operator's active account after the probe (a check must not mutate)"
+else
+  bad "board: left the active account switched to '$(cat "$state8i")' — a check mutated host state"
+fi
+if printf '%s' "$out8i" | grep -Eq '\[ok\].*board #1.*reachable' ; then
+  ok "board: reports reachable for the account dispatch actually uses"
+else
+  bad "board: did not reach a green verdict after switching to the board account"
+  printf '%s\n' "$out8i" | grep -i -A2 "board #"
+fi
+
+# 8j. With an env token, gh ignores the keyring and `gh auth switch` cannot change the
+#     identity — attempting it would be theatre, and mutating host state for a no-op
+#     is worse than not trying.
+sb8j=$(mktemp -d "$tmp/board8j.XXXXXX"); stub8j="$tmp/stub8j"
+mk_hermetic_bin "$stub8j"
+log8j="$tmp/gh8j.log"; : >"$log8j"; state8j="$tmp/gh8j.state"
+mk_switch_gh "$stub8j" "$log8j" "$state8j" other-emu pmcfadin
+repo8j="$tmp/repo8j"; mk_fake_repo "$repo8j" "https://github.com/pmcfadin/cqlite.git"
+out8j=$(PATH="$stub8j" HOME="$sb8j" CARGO_HOME="$sb8j/.cargo" GIT_CONFIG_GLOBAL="$sb8j/gitconfig" \
+  GH_TOKEN="$FAKE_TOKEN" bash "$repo8j/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+if ! grep -q -- 'auth switch' "$log8j" && [ "$(cat "$state8j")" = other-emu ]; then
+  ok "board: an env token suppresses the switch entirely (no pointless host mutation)"
+else
+  bad "board: attempted an account switch while GH_TOKEN was in force"
+fi
+if printf '%s' "$out8j" | grep -q "from GH_TOKEN in the environment"; then
+  ok "board: names the env token as the identity source"
+else
+  bad "board: did not disclose that the identity came from GH_TOKEN"
 fi
 
 # 8e. The probe is READ-ONLY: across every case above, the bootstrap must never

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -41,6 +41,21 @@ trap 'rm -rf "$tmp"' EXIT
 tripwire="$tmp/tripwire.log"
 : >"$tripwire"
 
+# --- GLOBAL git-config isolation (issue #2942) -----------------------------
+# The bootstrap's git-credential section READS the configured helper chain and,
+# under --yes, WRITES a helper into the user's GLOBAL git config. This self-test
+# must never touch (or be perturbed by) the host machine's real credential setup —
+# clobbering it would break the live delivery session running on this box. These
+# two exports are inherited by EVERY bootstrap child below, so the isolation holds
+# for cases added later without remembering to opt in:
+#   GIT_CONFIG_GLOBAL   redirects `git config --global` + global reads to a throwaway
+#   GIT_CONFIG_NOSYSTEM ignores /etc/gitconfig, so a host-wide helper cannot leak in
+# (HOME is sandboxed per case as well; GIT_CONFIG_GLOBAL is the belt to that braces —
+# it also covers an XDG_CONFIG_HOME that survives a HOME override.)
+export GIT_CONFIG_GLOBAL="$tmp/global-gitconfig"
+export GIT_CONFIG_NOSYSTEM=1
+: >"$GIT_CONFIG_GLOBAL"
+
 mkshim() {
   # mkshim <name>: a fake tool that records "install"/"add" invocations and is
   # otherwise a harmless no-op (version/status queries succeed emptily).
@@ -422,6 +437,260 @@ if [ "$repo_before" = "$(cat "$repo_cfg")" ] \
 else
   bad "mold: repo config was mutated OR block did not land in CARGO_HOME"
   echo "--- repo cfg now ---"; cat "$repo_cfg"; echo "--------------------"
+fi
+
+# --- 7. git push credentials (issue #2942) ---------------------------------
+# `gh` auth and `git` auth are SEPARATE credential paths: an authenticated gh CLI is
+# NOT evidence that a raw `git push` can authenticate, and scripts/flow/claim.sh +
+# claim-heartbeat.sh push with plain git on 10+ call sites. Every case below runs a
+# COPY of bootstrap inside a throwaway git repo with a sandboxed HOME and its OWN
+# GIT_CONFIG_GLOBAL, so the credential write under --yes can only ever land in the
+# sandbox — never in this machine's real global git config.
+
+# mk_fake_repo <dir> <origin-url>: a throwaway git repo holding a COPY of bootstrap
+# at <dir>/scripts/, with `origin` set to <origin-url> and NO repo-local credential
+# helper. The copy makes BASH_SOURCE-derived REPO_ROOT resolve to <dir>, so the
+# credential probe reads THIS remote/config, never the real checkout's — and the
+# --yes dataset fetch is a fast no-op (no test-data/scripts/fetch-datasets.sh here).
+mk_fake_repo() {
+  local dir="$1" url="$2"
+  mkdir -p "$dir/scripts"
+  cp "$BOOTSTRAP" "$dir/scripts/bootstrap-agent-machine.sh"
+  git -c init.defaultBranch=main init -q "$dir" >/dev/null 2>&1
+  git -C "$dir" remote add origin "$url" >/dev/null 2>&1
+}
+
+FAKE_TOKEN='ghp_FAKEtoken2942FAKEtoken2942FAKEtoken'
+
+# 7a. HTTPS origin, NO credential helper anywhere, default (no --yes) mode ->
+#     must WARN (never `ok`), print the identifying `could not read Username`
+#     symptom + remediation, and write NOTHING.
+sb7a=$(mktemp -d "$tmp/cred7a.XXXXXX"); stub7a="$tmp/stub7a"
+mk_hermetic_bin "$stub7a"
+repo7a="$tmp/repo7a"; mk_fake_repo "$repo7a" "https://github.com/pmcfadin/cqlite.git"
+gc7a="$sb7a/gitconfig"   # deliberately absent
+out7a=$(PATH="$stub7a" HOME="$sb7a" CARGO_HOME="$sb7a/.cargo" GIT_CONFIG_GLOBAL="$gc7a" \
+  GH_TOKEN="" GITHUB_TOKEN="" bash "$repo7a/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+if printf '%s' "$out7a" | grep -q "git push credentials"; then
+  ok "cred: bootstrap emits the git-credential section"
+else
+  bad "cred: git-credential section MISSING from bootstrap output"
+fi
+if printf '%s' "$out7a" | grep -q "\[warn\].*git push" \
+   && printf '%s' "$out7a" | grep -q "could not read Username" \
+   && printf '%s' "$out7a" | grep -q "gh auth setup-git"; then
+  ok "cred: no helper -> warn naming the 'could not read Username' symptom + remediation"
+else
+  bad "cred: no-helper case did not warn with the symptom/remediation"
+  printf '%s\n' "$out7a" | grep -i -A3 "credential"
+fi
+if printf '%s' "$out7a" | grep -Eq '\[ok\].*(git push credentials|git credentials).*(resolve|configured)'; then
+  bad "cred: reported OK for git push credentials while no helper is configured"
+else
+  ok "cred: authenticated gh alone is NOT reported as git push credentials"
+fi
+if [ ! -f "$gc7a" ]; then
+  ok "cred: default (no --yes) run wrote NO global git config"
+else
+  bad "cred: default run wrote a global git config"; cat "$gc7a"
+fi
+
+# 7b. --yes with `gh auth setup-git` a no-op -> falls back to the $GH_TOKEN helper.
+#     The config must carry the LITERAL `$GH_TOKEN` (dereferenced at call time) and
+#     must NOT contain the token value; nothing the bootstrap wrote may contain it.
+sb7b=$(mktemp -d "$tmp/cred7b.XXXXXX"); stub7b="$tmp/stub7b"
+mk_hermetic_bin "$stub7b"
+gh7b_log="$tmp/gh7b.log"; : >"$gh7b_log"
+mk_stub "$stub7b" gh "echo \"\$*\" >>\"$gh7b_log\"; exit 0"   # setup-git succeeds but wires nothing
+repo7b="$tmp/repo7b"; mk_fake_repo "$repo7b" "https://github.com/pmcfadin/cqlite.git"
+gc7b="$sb7b/gitconfig"
+out7b=$(PATH="$stub7b" HOME="$sb7b" CARGO_HOME="$sb7b/.cargo" GIT_CONFIG_GLOBAL="$gc7b" \
+  GH_TOKEN="$FAKE_TOKEN" bash "$repo7b/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
+if grep -q "auth setup-git" "$gh7b_log"; then
+  ok "cred: --yes prefers 'gh auth setup-git' first"
+else
+  bad "cred: --yes never attempted 'gh auth setup-git'"
+fi
+if [ -f "$gc7b" ] && grep -q 'x-access-token' "$gc7b" && grep -qF 'GH_TOKEN' "$gc7b"; then
+  ok "cred: --yes fell back to a helper that dereferences \$GH_TOKEN at call time"
+else
+  bad "cred: --yes did not configure the \$GH_TOKEN fallback helper"
+  [ -f "$gc7b" ] && { echo "--- gitconfig ---"; cat "$gc7b"; echo "-----------------"; }
+fi
+# The whole point of Decision 2: no file written by the bootstrap holds the secret.
+leak7b=$(grep -rlF "$FAKE_TOKEN" "$sb7b" "$gc7b" "$repo7b" 2>/dev/null | head -5)
+if [ -z "$leak7b" ]; then
+  ok "cred: token VALUE never written to disk by the bootstrap"
+else
+  bad "cred: token value leaked into: $leak7b"
+fi
+if printf '%s' "$out7b" | grep -Eq '\[ok\].*git.*credential'; then
+  ok "cred: --yes run reports the configured credential path as ok"
+else
+  bad "cred: --yes run never confirmed a working credential path"
+  printf '%s\n' "$out7b" | grep -i -A2 "credential"
+fi
+
+# 7c. --yes where `gh auth setup-git` genuinely works -> use it, and do NOT also
+#     add the $GH_TOKEN fallback helper (preferred form wins, Decision 2).
+sb7c=$(mktemp -d "$tmp/cred7c.XXXXXX"); stub7c="$tmp/stub7c"
+mk_hermetic_bin "$stub7c"
+mk_stub "$stub7c" gh 'if [ "$1" = auth ] && [ "$2" = setup-git ]; then
+  git config --global --add credential.helper "!f(){ test \"\$1\" = get || exit 0; echo username=gh-stub; echo password=stub-helper-secret; };f"
+fi
+exit 0'
+repo7c="$tmp/repo7c"; mk_fake_repo "$repo7c" "https://github.com/pmcfadin/cqlite.git"
+gc7c="$sb7c/gitconfig"
+out7c=$(PATH="$stub7c" HOME="$sb7c" CARGO_HOME="$sb7c/.cargo" GIT_CONFIG_GLOBAL="$gc7c" \
+  GH_TOKEN="$FAKE_TOKEN" bash "$repo7c/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
+if [ -f "$gc7c" ] && grep -q 'gh-stub' "$gc7c" && ! grep -q 'x-access-token' "$gc7c" \
+   && printf '%s' "$out7c" | grep -q "gh auth setup-git"; then
+  ok "cred: a working 'gh auth setup-git' is preferred; no \$GH_TOKEN fallback added"
+else
+  bad "cred: working setup-git path did not win (fallback added or not reported)"
+  [ -f "$gc7c" ] && { echo "--- gitconfig ---"; cat "$gc7c"; echo "-----------------"; }
+fi
+
+# 7d. SSH origin -> the https credential helper is irrelevant; report it and write
+#     nothing, even under --yes.
+sb7d=$(mktemp -d "$tmp/cred7d.XXXXXX"); stub7d="$tmp/stub7d"
+mk_hermetic_bin "$stub7d"
+repo7d="$tmp/repo7d"; mk_fake_repo "$repo7d" "git@github.com:pmcfadin/cqlite.git"
+gc7d="$sb7d/gitconfig"
+out7d=$(PATH="$stub7d" HOME="$sb7d" CARGO_HOME="$sb7d/.cargo" GIT_CONFIG_GLOBAL="$gc7d" \
+  GH_TOKEN="$FAKE_TOKEN" bash "$repo7d/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke 2>&1)
+if printf '%s' "$out7d" | grep -qi "SSH" \
+   && ! { [ -f "$gc7d" ] && grep -q 'x-access-token' "$gc7d"; }; then
+  ok "cred: SSH origin reported as its own credential path; no helper written"
+else
+  bad "cred: SSH origin case wrote a helper or did not report the SSH path"
+  [ -f "$gc7d" ] && cat "$gc7d"
+fi
+
+# 7e. Re-running --yes must not STACK a second copy of the helper. Bootstrap is
+#     documented as idempotent, and a credential.helper list that grows every run
+#     is a real footgun (git consults each entry in order).
+sb7e=$(mktemp -d "$tmp/cred7e.XXXXXX"); stub7e="$tmp/stub7e"
+mk_hermetic_bin "$stub7e"
+mk_stub "$stub7e" gh 'exit 0'   # setup-git is a no-op -> the fallback helper is used
+repo7e="$tmp/repo7e"; mk_fake_repo "$repo7e" "https://github.com/pmcfadin/cqlite.git"
+gc7e="$sb7e/gitconfig"
+for _ in 1 2 3; do
+  PATH="$stub7e" HOME="$sb7e" CARGO_HOME="$sb7e/.cargo" GIT_CONFIG_GLOBAL="$gc7e" \
+    GH_TOKEN="$FAKE_TOKEN" bash "$repo7e/scripts/bootstrap-agent-machine.sh" --yes --skip-smoke >/dev/null 2>&1
+done
+helper_count=$(grep -c 'x-access-token' "$gc7e" 2>/dev/null); helper_count="${helper_count:-0}"
+if [ "$helper_count" = 1 ]; then
+  ok "cred: repeated --yes runs keep exactly one credential helper (idempotent)"
+else
+  bad "cred: helper stacked across re-runs (count=$helper_count)"
+  [ -f "$gc7e" ] && cat "$gc7e"
+fi
+
+# --- 8. Board check is a FUNCTIONAL, READ-ONLY probe (issue #2942) ----------
+# The false OK this exists to prevent: a token whose scopes INCLUDE `project` while
+# `gh project` still fails for a missing `read:org`, and the equivalent
+# `updateProjectV2ItemFieldValue` GraphQL mutation succeeds with the SAME token. A
+# scope-string match therefore proves nothing about the operation, and must never be
+# the verdict.
+
+# mk_board_gh <dir> <log> <scopes> <missing-scopes|""> <gh-project-rc> <gh-api-rc>
+mk_board_gh() {
+  local dir="$1" log="$2" scopes="$3" missing="$4" prc="$5" arc="$6"
+  local missing_echo=""
+  [ -n "$missing" ] && missing_echo="echo \"  ! Missing required token scopes: $missing\""
+  cat >"$dir/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$log"
+case "\$1" in
+  auth)
+    if [ "\$2" = status ]; then
+      echo "github.com"
+      echo "  ✓ Logged in to github.com account tester (GH_TOKEN)"
+      echo "  - Token scopes: $scopes"
+      $missing_echo
+    fi
+    exit 0 ;;
+  project) exit $prc ;;
+  api)     exit $arc ;;
+  *)       exit 0 ;;
+esac
+EOF
+  chmod +x "$dir/gh"
+}
+
+# run_board_case <name> <scopes> <missing> <project-rc> <api-rc> -> sets BOARD_OUT/BOARD_LOG
+run_board_case() {
+  local name="$1" scopes="$2" missing="$3" prc="$4" arc="$5"
+  local sb stub repo
+  sb=$(mktemp -d "$tmp/board-$name.XXXXXX"); stub="$tmp/stub-board-$name"
+  mk_hermetic_bin "$stub"
+  BOARD_LOG="$tmp/gh-board-$name.log"; : >"$BOARD_LOG"
+  mk_board_gh "$stub" "$BOARD_LOG" "$scopes" "$missing" "$prc" "$arc"
+  repo="$tmp/repo-board-$name"; mk_fake_repo "$repo" "https://github.com/pmcfadin/cqlite.git"
+  BOARD_OUT=$(PATH="$stub" HOME="$sb" CARGO_HOME="$sb/.cargo" GIT_CONFIG_GLOBAL="$sb/gitconfig" \
+    GH_TOKEN="" bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+}
+
+# 8a. THE false-OK case: `project` scope present, `read:org` missing, `gh project`
+#     unusable, GraphQL fine. Today's scope-string check prints an unqualified
+#     "board dispatch works" here — that verdict must be impossible.
+run_board_case falseok "'project', 'repo', 'workflow'" "'read:org'" 1 0
+if printf '%s' "$BOARD_OUT" | grep -q "board dispatch works"; then
+  bad "board: scope-present-but-gh-project-unusable STILL prints 'board dispatch works'"
+else
+  ok "board: scope present + gh project unusable -> no unqualified 'board dispatch works'"
+fi
+if printf '%s' "$BOARD_OUT" | grep -q "updateProjectV2ItemFieldValue"; then
+  ok "board: names the updateProjectV2ItemFieldValue GraphQL write fallback"
+else
+  bad "board: never named the updateProjectV2ItemFieldValue fallback"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board"
+fi
+if printf '%s' "$BOARD_OUT" | grep -qi "read:org"; then
+  ok "board: surfaces the read:org scope gap gh itself reports"
+else
+  bad "board: did not surface the read:org gap"
+fi
+
+# 8b. `gh project` READ works but gh still reports missing required scopes — the
+#     write (`item-edit`) can fail. Still not an unqualified success.
+run_board_case partial "'project', 'repo', 'workflow'" "'read:org'" 0 0
+if ! printf '%s' "$BOARD_OUT" | grep -q "board dispatch works" \
+   && printf '%s' "$BOARD_OUT" | grep -q "updateProjectV2ItemFieldValue"; then
+  ok "board: read-OK + missing required scopes -> qualified verdict naming the fallback"
+else
+  bad "board: read-OK + missing scopes reported as unqualified success"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board"
+fi
+
+# 8c. Fully healthy token: probe succeeds, gh reports no missing scopes -> an ok.
+run_board_case healthy "'project', 'read:org', 'repo', 'workflow'" "" 0 0
+if printf '%s' "$BOARD_OUT" | grep -Eq '\[ok\].*board'; then
+  ok "board: healthy token + successful probe reports ok"
+else
+  bad "board: healthy token did not produce an ok verdict"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board"
+fi
+
+# 8d. Unreachable board (both probes fail) -> a loud warn, never a scope-based pass.
+run_board_case unreachable "'project', 'repo', 'workflow'" "" 1 1
+if printf '%s' "$BOARD_OUT" | grep -Eq '\[warn\].*board' \
+   && ! printf '%s' "$BOARD_OUT" | grep -q "board dispatch works"; then
+  ok "board: both probes failing -> warn (scope match never rescues the verdict)"
+else
+  bad "board: unreachable board did not warn"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board"
+fi
+
+# 8e. The probe is READ-ONLY: across every case above, the bootstrap must never
+#     have invoked a board-mutating gh call.
+mutating=$(cat "$tmp"/gh-board-*.log 2>/dev/null \
+  | grep -Ei 'item-edit|item-add|item-delete|item-archive|--field|mutation' | head -5)
+if [ -z "$mutating" ]; then
+  ok "board: probe never invoked a mutating gh/board operation"
+else
+  bad "board: probe issued a MUTATING call: $mutating"
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -612,7 +612,13 @@ case "\$1" in
     fi
     exit 0 ;;
   project) exit $prc ;;
-  api)     exit $arc ;;
+  # The GraphQL probe demands a NON-EMPTY project id — `gh api graphql` exits 0 on a
+  # query that RESOLVES TO NULL, so an exit code alone would be a false OK. api-rc
+  # 'null' simulates exactly that: a clean exit carrying no project.
+  api)
+    if [ "$arc" = null ]; then exit 0; fi
+    [ "$arc" = 0 ] && echo "PVT_kwStubProjectId"
+    exit "$arc" ;;
   *)       exit 0 ;;
 esac
 EOF
@@ -681,6 +687,16 @@ if printf '%s' "$BOARD_OUT" | grep -Eq '\[warn\].*board' \
 else
   bad "board: unreachable board did not warn"
   printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board"
+fi
+
+# 8f. GraphQL exits 0 but resolves to NO project (wrong owner kind / wrong number).
+#     An exit-code-only probe would call that reachable — it must not.
+run_board_case nullproject "'project', 'repo', 'workflow'" "" 1 null
+if printf '%s' "$BOARD_OUT" | grep -Eq '\[warn\].*(UNREACHABLE|BOTH probes failed)'; then
+  ok "board: GraphQL exit 0 with a null project counts as a FAILED probe, not reachable"
+else
+  bad "board: null-project GraphQL reply was treated as a working fallback"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A3 "board #"
 fi
 
 # 8e. The probe is READ-ONLY: across every case above, the bootstrap must never

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -56,6 +56,14 @@ export GIT_CONFIG_GLOBAL="$tmp/global-gitconfig"
 export GIT_CONFIG_NOSYSTEM=1
 : >"$GIT_CONFIG_GLOBAL"
 
+# --- BOARD env isolation (issue #2942) -------------------------------------
+# The board section reads CQLITE_PROJECT_{OWNER,NUMBER,ACCOUNT} and PROJECT_TITLE from
+# the environment, and a worker shell commonly EXPORTS them (the fleet exports
+# CQLITE_PROJECT_NUMBER). Inheriting them makes this suite's verdict depend on the shell
+# it runs in — it silently masked the entire "number not exported" path until a case was
+# written for it. Clear them once; every case sets exactly what it means to test.
+unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
+
 mkshim() {
   # mkshim <name>: a fake tool that records "install"/"add" invocations and is
   # otherwise a harmless no-op (version/status queries succeed emptily).
@@ -168,7 +176,8 @@ mk_hermetic_bin() {
   local dir="$1" t p
   mkdir -p "$dir"
   for t in bash dirname mktemp grep cp cat sed awk mkdir rm ln mv touch chmod \
-           head tail tr sort cut wc stat env git find xargs basename date sleep expr timeout; do
+           head tail tr sort cut wc stat env git find xargs basename date sleep expr \
+           timeout gtimeout; do   # BOTH: stock macOS has only gtimeout (GNU coreutils)
     p=$(type -P "$t" 2>/dev/null) || continue
     [ -n "$p" ] && ln -sf "$p" "$dir/$t" 2>/dev/null || true
   done
@@ -607,14 +616,49 @@ mk_hermetic_bin "$stub7g"
 repo7g="$tmp/repo7g"; mk_fake_repo "$repo7g" "https://github.com/pmcfadin/cqlite.git"
 gc7g="$sb7g/gitconfig"
 cp "$gc7b" "$gc7g" 2>/dev/null || :   # the exact helper config --yes produced in 7b
+# Guard the guard: an EMPTY $gc7g would satisfy the warn assertion for the wrong
+# reason (no helper at all), making this case vacuous.
+if ! grep -q 'x-access-token' "$gc7g" 2>/dev/null; then
+  bad "cred: 7g precondition FAILED — no helper installed, the warn below would be vacuous"
+fi
 out7g=$(PATH="$stub7g" HOME="$sb7g" CARGO_HOME="$sb7g/.cargo" GIT_CONFIG_GLOBAL="$gc7g" \
   GH_TOKEN="" GITHUB_TOKEN="" bash "$repo7g/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if printf '%s' "$out7g" | grep -q "\[warn\].*git push has NO credentials" \
    && ! printf '%s' "$out7g" | grep -Eq '\[ok\].*git push credentials resolve'; then
-  ok "cred: helper present but GH_TOKEN unset -> WARN (an empty password is not a credential)"
+  ok "cred: helper present but GH_TOKEN unset -> WARN (a declining helper is not a credential)"
 else
-  bad "cred: empty-token case reported ok — probe accepted an empty password"
+  bad "cred: empty-token case reported ok — probe accepted a non-answer"
   printf '%s\n' "$out7g" | grep -i -A2 "git push"
+fi
+
+# 7g-ii. The case the `^password=.` check exists for, which nothing covered: a helper
+#        that ANSWERS with a literal EMPTY password line. git treats `password=` as
+#        satisfied, so `git credential fill` exits 0 — an exit-status-only probe reports
+#        a green machine on which every push fails. Our own helper declines instead of
+#        emitting empty (7g), so without this case the non-empty check could be reverted
+#        to an exit-status check with the suite still fully green.
+sb7ge=$(mktemp -d "$tmp/cred7ge.XXXXXX"); stub7ge="$tmp/stub7ge"
+mk_hermetic_bin "$stub7ge"
+repo7ge="$tmp/repo7ge"; mk_fake_repo "$repo7ge" "https://github.com/pmcfadin/cqlite.git"
+gc7ge="$sb7ge/gitconfig"
+git config --file "$gc7ge" --add 'credential.https://github.com.helper' \
+  '!f(){ test "$1" = get || exit 0; echo username=x-access-token; echo "password="; };f'
+# Sanity: git itself considers this helper "satisfied" (exit 0) — that is the trap.
+if printf 'protocol=https\nhost=github.com\n\n' \
+   | GIT_CONFIG_GLOBAL="$gc7ge" GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0 \
+     GIT_ASKPASS=nonexistent-askpass git -C "$tmp" credential fill >/dev/null 2>&1; then
+  ok "cred: (precondition) git credential fill EXITS 0 on an empty password — the trap is real"
+else
+  bad "cred: (precondition) expected git to accept an empty password line"
+fi
+out7ge=$(PATH="$stub7ge" HOME="$sb7ge" CARGO_HOME="$sb7ge/.cargo" GIT_CONFIG_GLOBAL="$gc7ge" \
+  GH_TOKEN="" GITHUB_TOKEN="" bash "$repo7ge/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+if printf '%s' "$out7ge" | grep -q "\[warn\].*git push has NO credentials" \
+   && ! printf '%s' "$out7ge" | grep -Eq '\[ok\].*git push credentials resolve'; then
+  ok "cred: a helper answering with an EMPTY password is not accepted as a credential"
+else
+  bad "cred: empty-password helper reported ok — the probe trusted exit status"
+  printf '%s\n' "$out7ge" | grep -i -A2 "git push"
 fi
 
 # 7h. A HANGING credential helper must not hang the bootstrap. Neither
@@ -626,22 +670,47 @@ fi
 #     stall the gate of record. This is a deadlock/liveness guard, not a latency
 #     budget: the helper sleeps 120s, the probe's own bound is 10s, and the outer
 #     ceiling is 60s — ~6x slack, so host load can never flip it.
-if command -v timeout >/dev/null 2>&1; then
+#     Resolution MUST match the script's (timeout || gtimeout): the fleet is macOS,
+#     where GNU coreutils installs `gtimeout` — keying this case off `timeout` alone
+#     would skip it on the one platform whose hang scenarios (locked osxkeychain, a GCM
+#     browser flow) motivated the bound, leaving it uncovered exactly where it matters.
+TIMEOUT_BIN_TEST="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
+if [ -n "$TIMEOUT_BIN_TEST" ]; then
   sb7h=$(mktemp -d "$tmp/cred7h.XXXXXX"); stub7h="$tmp/stub7h"
   mk_hermetic_bin "$stub7h"
   repo7h="$tmp/repo7h"; mk_fake_repo "$repo7h" "https://github.com/pmcfadin/cqlite.git"
   gc7h="$sb7h/gitconfig"
   git config --file "$gc7h" --add 'credential.https://github.com.helper' '!f(){ sleep 120; };f'
   rc7h=0
-  timeout 60 env PATH="$stub7h" HOME="$sb7h" CARGO_HOME="$sb7h/.cargo" GIT_CONFIG_GLOBAL="$gc7h" \
+  "$TIMEOUT_BIN_TEST" 60 env PATH="$stub7h" HOME="$sb7h" CARGO_HOME="$sb7h/.cargo" GIT_CONFIG_GLOBAL="$gc7h" \
     GH_TOKEN="" bash "$repo7h/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1 || rc7h=$?
   if [ "$rc7h" -ne 124 ]; then
     ok "cred: a hanging credential helper is bounded — bootstrap still completes (rc=$rc7h)"
   else
     bad "cred: bootstrap HUNG on a blocking credential helper (killed at the outer ceiling)"
   fi
+  # 7h-ii. The same guard on a STOCK-macOS-SHAPED host: GNU coreutils present only as
+  #        `gtimeout`, no plain `timeout`. The fleet is macOS and two of the three hang
+  #        scenarios are macOS-only, so a bound that resolves `timeout` alone is inert
+  #        exactly where it is needed — and a Linux-only CI would never notice.
+  sb7hm=$(mktemp -d "$tmp/cred7hm.XXXXXX"); stub7hm="$tmp/stub7hm"
+  mk_hermetic_bin "$stub7hm"
+  rm -f "$stub7hm/timeout"                          # <- the macOS shape
+  ln -sf "$TIMEOUT_BIN_TEST" "$stub7hm/gtimeout"
+  repo7hm="$tmp/repo7hm"; mk_fake_repo "$repo7hm" "https://github.com/pmcfadin/cqlite.git"
+  gc7hm="$sb7hm/gitconfig"
+  git config --file "$gc7hm" --add 'credential.https://github.com.helper' '!f(){ sleep 120; };f'
+  rc7hm=0
+  "$TIMEOUT_BIN_TEST" 60 env PATH="$stub7hm" HOME="$sb7hm" CARGO_HOME="$sb7hm/.cargo" \
+    GIT_CONFIG_GLOBAL="$gc7hm" GH_TOKEN="" \
+    bash "$repo7hm/scripts/bootstrap-agent-machine.sh" --skip-smoke >/dev/null 2>&1 || rc7hm=$?
+  if [ "$rc7hm" -ne 124 ]; then
+    ok "cred: the hang bound also applies on a gtimeout-only (macOS-shaped) host (rc=$rc7hm)"
+  else
+    bad "cred: bootstrap HUNG on a gtimeout-only host — the bound is inert on macOS"
+  fi
 else
-  echo "skip - cred: hanging-helper guard needs 'timeout' (absent on this host)"
+  echo "skip - cred: hanging-helper guard needs timeout/gtimeout (neither on this host)"
 fi
 
 # 7e. Re-running --yes must not STACK a second copy of the helper. Bootstrap is
@@ -742,7 +811,7 @@ run_board_case() {
   mk_board_gh "$stub" "$BOARD_LOG" "$scopes" "$missing" "$prc" "$arc"
   repo="$tmp/repo-board-$name"; mk_fake_repo "$repo" "https://github.com/pmcfadin/cqlite.git"
   BOARD_OUT=$(PATH="$stub" HOME="$sb" CARGO_HOME="$sb/.cargo" GIT_CONFIG_GLOBAL="$sb/gitconfig" \
-    CQLITE_PROJECT_ACCOUNT=tester \
+    CQLITE_PROJECT_ACCOUNT=tester CQLITE_PROJECT_NUMBER=1 \
     GH_TOKEN="" bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 }
 
@@ -769,8 +838,12 @@ esac
 EOF
   chmod +x "$stub/gh"
   repo="$tmp/repo-bauth-$name"; mk_fake_repo "$repo" "https://github.com/pmcfadin/cqlite.git"
+  # Caller overrides go through `env`: a VAR=value coming from "$@" is the result of an
+  # expansion, so bash would treat it as a COMMAND NAME, not an assignment — the
+  # override would silently do nothing and the case would assert against the default.
   BOARD_OUT=$(PATH="$stub" HOME="$sb" CARGO_HOME="$sb/.cargo" GIT_CONFIG_GLOBAL="$sb/gitconfig" \
-    GH_TOKEN="" "$@" bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+    CQLITE_PROJECT_NUMBER=1 \
+    GH_TOKEN="" env "$@" bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 }
 
 # 8a. THE false-OK case: `project` scope present, `read:org` missing, `gh project`
@@ -952,7 +1025,7 @@ log8i="$tmp/gh8i.log"; : >"$log8i"; state8i="$tmp/gh8i.state"
 mk_switch_gh "$stub8i" "$log8i" "$state8i" other-emu pmcfadin   # EMU active at start
 repo8i="$tmp/repo8i"; mk_fake_repo "$repo8i" "https://github.com/pmcfadin/cqlite.git"
 out8i=$(PATH="$stub8i" HOME="$sb8i" CARGO_HOME="$sb8i/.cargo" GIT_CONFIG_GLOBAL="$sb8i/gitconfig" \
-  GH_TOKEN="" bash "$repo8i/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  CQLITE_PROJECT_NUMBER=1 GH_TOKEN="" bash "$repo8i/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if grep -q -- 'auth switch --user pmcfadin' "$log8i"; then
   ok "board: switches to CQLITE_PROJECT_ACCOUNT before probing (mirrors flow-board)"
 else
@@ -979,7 +1052,7 @@ log8j="$tmp/gh8j.log"; : >"$log8j"; state8j="$tmp/gh8j.state"
 mk_switch_gh "$stub8j" "$log8j" "$state8j" other-emu pmcfadin
 repo8j="$tmp/repo8j"; mk_fake_repo "$repo8j" "https://github.com/pmcfadin/cqlite.git"
 out8j=$(PATH="$stub8j" HOME="$sb8j" CARGO_HOME="$sb8j/.cargo" GIT_CONFIG_GLOBAL="$sb8j/gitconfig" \
-  GH_TOKEN="$FAKE_TOKEN" bash "$repo8j/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+  CQLITE_PROJECT_NUMBER=1 GH_TOKEN="$FAKE_TOKEN" bash "$repo8j/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 if ! grep -q -- 'auth switch' "$log8j" && [ "$(cat "$state8j")" = other-emu ]; then
   ok "board: an env token suppresses the switch entirely (no pointless host mutation)"
 else
@@ -991,9 +1064,86 @@ else
   bad "board: did not disclose that the identity came from GH_TOKEN"
 fi
 
-# 8e. The probe is READ-ONLY: across every case above, the bootstrap must never
-#     have invoked a board-mutating gh call.
-mutating=$(cat "$tmp"/gh-board-*.log 2>/dev/null \
+# --- 8k. CQLITE_PROJECT_NUMBER unset is a DISPATCH BLOCKER -------------------
+# flow-board reads `${CQLITE_PROJECT_NUMBER:-}` and STOPs when it is empty. A bootstrap
+# that defaulted the number to a guess would print a green "board reachable" on a box
+# where every flow-* skill refuses to dispatch — the same false green, one layer out.
+# 8k-i: the board is discoverable by title -> warn naming the exact export line.
+sb8k=$(mktemp -d "$tmp/board8k.XXXXXX"); stub8k="$tmp/stub8k"
+mk_hermetic_bin "$stub8k"
+jqp=$(type -P jq 2>/dev/null) && ln -sf "$jqp" "$stub8k/jq"
+cat >"$stub8k/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  auth) [ "$2" = status ] && { echo "github.com"
+        echo "  ✓ Logged in to github.com account tester (keyring)"
+        echo "  - Active account: true"
+        echo "  - Token scopes: 'project', 'read:org', 'repo'"; }; exit 0 ;;
+  project)
+    [ "$2" = list ] && { echo '{"projects":[{"title":"CQLite Delivery","number":7}]}'; exit 0; }
+    exit 0 ;;
+  api) echo "PVT_kwStubProjectId"; exit 0 ;;
+  *)   exit 0 ;;
+esac
+EOF
+chmod +x "$stub8k/gh"
+repo8k="$tmp/repo8k"; mk_fake_repo "$repo8k" "https://github.com/pmcfadin/cqlite.git"
+out8k=$(PATH="$stub8k" HOME="$sb8k" CARGO_HOME="$sb8k/.cargo" GIT_CONFIG_GLOBAL="$sb8k/gitconfig" \
+  CQLITE_PROJECT_ACCOUNT=tester GH_TOKEN="" bash "$repo8k/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+if printf '%s' "$out8k" | grep -Eq '\[ok\].*board #.*reachable'; then
+  bad "board: unexported CQLITE_PROJECT_NUMBER still produced a green 'reachable' verdict"
+elif printf '%s' "$out8k" | grep -q 'CQLITE_PROJECT_NUMBER is NOT exported'; then
+  ok "board: unexported CQLITE_PROJECT_NUMBER is reported as a dispatch blocker"
+else
+  bad "board: unexported CQLITE_PROJECT_NUMBER neither warned nor blocked the green verdict"
+  printf '%s\n' "$out8k" | grep -i -A2 "board"
+fi
+if [ -n "$jqp" ]; then
+  if printf '%s' "$out8k" | grep -q 'export CQLITE_PROJECT_NUMBER=7'; then
+    ok "board: discovers the number by title and prints the exact export line"
+  else
+    bad "board: did not resolve the board by title / print the export line"
+    printf '%s\n' "$out8k" | grep -i "PROJECT_NUMBER"
+  fi
+else
+  echo "skip - board: title discovery needs jq (absent on this host)"
+fi
+
+# 8k-ii: not discoverable -> point at setup-project-board.sh, still no green.
+run_board_auth_case nonumber 'github.com
+  ✓ Logged in to github.com account pmcfadin (keyring)
+  - Active account: true
+  - Token scopes: '"'"'project'"'"', '"'"'read:org'"'"', '"'"'repo'"'"'' CQLITE_PROJECT_NUMBER=
+if ! printf '%s' "$BOARD_OUT" | grep -Eq '\[ok\].*board #.*reachable' \
+   && printf '%s' "$BOARD_OUT" | grep -q 'setup-project-board.sh'; then
+  ok "board: unresolvable board number -> no green, points at setup-project-board.sh"
+else
+  bad "board: unresolvable board number did not block the green verdict"
+  printf '%s\n' "$BOARD_OUT" | grep -i -A2 "board"
+fi
+
+# 8l. The account restore must be armed by a TRAP, not just an inline block: two
+#     network calls sit between the switch and the restore, so an interrupt or a
+#     supervisor SIGTERM in that window would strand the operator's active account.
+if grep -q "trap 'restore_board_account' EXIT" "$BOOTSTRAP" \
+   && grep -q "trap 'restore_board_account; exit 130' INT" "$BOOTSTRAP" \
+   && grep -q "trap 'restore_board_account; exit 143' TERM" "$BOOTSTRAP"; then
+  ok "board: account restore is armed on EXIT/INT/TERM, not only the happy path"
+else
+  bad "board: no EXIT/INT/TERM trap arming the account restore"
+fi
+# ...and the probes it brackets must be BOUNDED, so the window cannot hang open.
+if grep -q 'bounded 20 gh project view' "$BOOTSTRAP" \
+   && grep -q 'bounded 20 gh api graphql' "$BOOTSTRAP"; then
+  ok "board: both probes inside the switch/restore bracket are time-bounded"
+else
+  bad "board: an unbounded probe sits between the account switch and its restore"
+fi
+
+# 8e. The probe is READ-ONLY: across EVERY board case above, the bootstrap must never
+#     have invoked a board-mutating gh call. The glob covers all three log families —
+#     the identity-switching cases most of all, where a mutating call would matter most.
+mutating=$(cat "$tmp"/gh-board-*.log "$tmp"/gh-bauth-*.log "$tmp"/gh8i.log "$tmp"/gh8j.log 2>/dev/null \
   | grep -Ei 'item-edit|item-add|item-delete|item-archive|--field|mutation' | head -5)
 if [ -z "$mutating" ]; then
   ok "board: probe never invoked a mutating gh/board operation"

--- a/scripts/tests/test_claim_lock.sh
+++ b/scripts/tests/test_claim_lock.sh
@@ -517,6 +517,82 @@ $statusOut"
 fi
 
 # ===========================================================================
+echo "TEST 20: an AUTH failure is reason=auth (never 'transient — retry'); a real transient still is"
+# ===========================================================================
+# Issue #2942. A box whose `gh` is authenticated but whose GIT has no credential
+# helper fails every claim push with `fatal: could not read Username`. That is a
+# machine-configuration fault that CANNOT self-clear, yet it was reported as
+#   CLAIM: ERROR reason=infra detail=push-rejected-but-ref-absent (transient — retry)
+# telling the worker to retry the one thing guaranteed never to work. The auth
+# signature must produce a DISTINCT non-retryable verdict — and, per the #2665
+# contract, a genuine transient must still report as the retryable infra error.
+#
+# Both shims fail only `push` (ls-remote passes through, as it does for a public
+# repo readable anonymously) and differ ONLY in the stderr git emits.
+mk_push_fail_shim() {
+  # mk_push_fail_shim <dir> <stderr-line>
+  mkdir -p "$1"
+  cat >"$1/git" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [ "\$a" = "push" ]; then
+    echo "$2" >&2
+    exit 128
+  fi
+done
+exec "$REALGIT" "\$@"
+SHIM
+  chmod +x "$1/git"
+}
+
+# (a) credential failure -> reason=auth, no "transient", no retry advice.
+AUTHSHIM="$T/shim-git-noauth"
+mk_push_fail_shim "$AUTHSHIM" "fatal: could not read Username for 'https://github.com': terminal prompts disabled"
+rc=0; outAuth=$( cd "$A" && PATH="$AUTHSHIM:$PATH" CLAIM_MACHINE=machineA bash "$CLAIM" claim 20 ) || rc=$?
+rcAuth=$rc
+if [ "$rcAuth" -eq 1 ] && printf '%s\n' "$outAuth" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outAuth" | grep -q 'reason=auth' \
+   && printf '%s\n' "$outAuth" | grep -q 'NOT retryable' \
+   && ! printf '%s\n' "$outAuth" | grep -q 'transient' \
+   && ! printf '%s\n' "$outAuth" | grep -q -- '— retry' \
+   && ! printf '%s\n' "$outAuth" | grep -q 'CLAIM: LOST'; then
+  ok "(a) unauthenticated push → CLAIM ERROR reason=auth, no transient/retry advice"
+else
+  bad "(a) expected reason=auth exit 1 with no transient/retry wording; got rc=$rcAuth
+$outAuth"
+fi
+# The verdict must name the remediation, not just the fault.
+if printf '%s\n' "$outAuth" | grep -q 'gh auth setup-git' \
+   || printf '%s\n' "$outAuth" | grep -q 'bootstrap-agent-machine'; then
+  ok "(a) auth verdict names the remediation"
+else
+  bad "(a) auth verdict named no remediation:
+$outAuth"
+fi
+# It must NOT echo git's raw stderr (a remote URL can carry an embedded secret).
+if ! printf '%s\n' "$outAuth" | grep -q 'terminal prompts disabled'; then
+  ok "(a) auth verdict does not echo raw git stderr"
+else
+  bad "(a) auth verdict echoed raw git stderr (secret-leak surface):
+$outAuth"
+fi
+
+# (b) genuine transient (unreachable host) -> unchanged retryable infra verdict.
+NETSHIM="$T/shim-git-netfail"
+mk_push_fail_shim "$NETSHIM" "fatal: unable to access 'https://github.com/x.git/': Could not resolve host: github.com"
+rc=0; outNet=$( cd "$A" && PATH="$NETSHIM:$PATH" CLAIM_MACHINE=machineA bash "$CLAIM" claim 21 ) || rc=$?
+rcNet=$rc
+if [ "$rcNet" -eq 1 ] && printf '%s\n' "$outNet" | grep -q 'CLAIM: ERROR' \
+   && printf '%s\n' "$outNet" | grep -q 'reason=infra' \
+   && printf '%s\n' "$outNet" | grep -q 'transient' \
+   && ! printf '%s\n' "$outNet" | grep -q 'reason=auth'; then
+  ok "(b) genuine transient still reports the retryable infra verdict (#2665 contract intact)"
+else
+  bad "(b) expected reason=infra transient exit 1; got rc=$rcNet
+$outNet"
+fi
+
+# ===========================================================================
 echo
 echo "==== CLAIM-LOCK TEST SUMMARY: PASS=$PASS FAIL=$FAIL ===="
 if [ "$FAIL" -eq 0 ]; then echo "RESULT: PASS"; exit 0; else echo "RESULT: FAIL"; exit 1; fi

--- a/scripts/tests/test_claim_lock.sh
+++ b/scripts/tests/test_claim_lock.sh
@@ -592,6 +592,60 @@ else
 $outNet"
 fi
 
+# (c) `403 Forbidden` must NOT be treated as auth. A proxy or edge outage returns it,
+# and turning a transient into a permanent stop is the one direction the #2665
+# contract says never to move. (GitHub's rate-limit text is `HTTP 403`.)
+F403="$T/shim-git-403"
+mk_push_fail_shim "$F403" "fatal: unable to access 'https://github.com/x.git/': The requested URL returned error: 403 Forbidden"
+rc=0; out403=$( cd "$A" && PATH="$F403:$PATH" CLAIM_MACHINE=machineA bash "$CLAIM" claim 24 ) || rc=$?
+if [ "$rc" -eq 1 ] && printf '%s\n' "$out403" | grep -q 'reason=infra' \
+   && ! printf '%s\n' "$out403" | grep -q 'reason=auth'; then
+  ok "(c) a 403 stays a RETRYABLE transient (an edge/proxy outage is not a credential fault)"
+else
+  bad "(c) expected reason=infra for a 403; got rc=$rc
+$out403"
+fi
+
+# (d) adopt: the CAS push is unauthenticated. The confirm read succeeds on a public
+# repo, so without the auth check this reports ADOPT-LOST — blaming the lease for a
+# broken machine.
+runA claim 25 >/dev/null
+oldsha25=$(ref_sha 25)
+rc=0; outAdoptAuth=$( cd "$B" && PATH="$AUTHSHIM:$PATH" CLAIM_MACHINE=machineB bash "$CLAIM" adopt 25 --expect "$oldsha25" ) || rc=$?
+if [ "$rc" -eq 1 ] && printf '%s\n' "$outAdoptAuth" | grep -q 'reason=auth' \
+   && ! printf '%s\n' "$outAdoptAuth" | grep -q 'ADOPT-LOST'; then
+  ok "(d) adopt under an auth failure → reason=auth, never ADOPT-LOST"
+else
+  bad "(d) expected adopt reason=auth exit 1 with no ADOPT-LOST; got rc=$rc
+$outAdoptAuth"
+fi
+
+# (e) release --force (the reaper path): an unauthenticated delete is not transient.
+runA claim 26 >/dev/null
+rc=0; outRelAuth=$( cd "$A" && PATH="$AUTHSHIM:$PATH" CLAIM_MACHINE=machineA bash "$CLAIM" release 26 --force ) || rc=$?
+ref26=$(ref_sha 26)
+if [ "$rc" -eq 1 ] && printf '%s\n' "$outRelAuth" | grep -q 'reason=auth' \
+   && ! printf '%s\n' "$outRelAuth" | grep -q 'transient' \
+   && [ -n "$ref26" ]; then
+  ok "(e) release --force under an auth failure → reason=auth (ref intact, no false RELEASED)"
+else
+  bad "(e) expected release reason=auth exit 1 with the ref intact; got rc=$rc ref=$ref26
+$outRelAuth"
+fi
+
+# (f) smoke: the preflight's whole job is diagnosing the remote, so blaming the
+# refs/claims/* namespace for a credential fault sends the operator hunting the
+# wrong thing on a brand-new box.
+rc=0; outSmokeAuth=$( cd "$A" && PATH="$AUTHSHIM:$PATH" CLAIM_MACHINE=machineA bash "$CLAIM" smoke 2>/dev/null ) || rc=$?
+if [ "$rc" -eq 1 ] && printf '%s\n' "$outSmokeAuth" | grep -q 'SMOKE-FAIL' \
+   && printf '%s\n' "$outSmokeAuth" | grep -q 'reason=auth' \
+   && ! printf '%s\n' "$outSmokeAuth" | grep -q 'push-rejected'; then
+  ok "(f) smoke under an auth failure → reason=auth, not 'does origin permit refs/claims/*?'"
+else
+  bad "(f) expected SMOKE-FAIL reason=auth; got rc=$rc
+$outSmokeAuth"
+fi
+
 # ===========================================================================
 echo
 echo "==== CLAIM-LOCK TEST SUMMARY: PASS=$PASS FAIL=$FAIL ===="

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -214,11 +214,15 @@ helper fails every claim with `fatal: could not read Username for 'https://githu
 protocol does not work at all while `gh auth status` reports a healthy machine. `claim.sh` classifies that
 signature as **`CLAIM: ERROR reason=auth … (NOT retryable)`** naming the fix, *not* the old
 `reason=infra … (transient — retry)` that sent workers into a retry loop on a fault which can never
-self-clear; `reason=infra (transient — retry)` continues to mean a genuine, retryable blip. Fix a box with
-`gh auth setup-git` or `bash scripts/bootstrap-agent-machine.sh --yes`, whose preflight checks git push
-credentials (configuring a helper that dereferences `$GH_TOKEN` at call time — never writing the token to
-disk) and probes **board access functionally** instead of trusting the `project` scope string. Full delta
-list with the identifying messages: `docs/development/fleet-runbook.md`.
+self-clear; `reason=infra (transient — retry)` continues to mean a genuine, retryable blip. That
+classification covers `claim.sh` (`claim`/`adopt`/`release`/`smoke`) only — `claim-heartbeat.sh` surfaces
+git's raw error on its own pushes. Fix a box with `gh auth setup-git` or
+`bash scripts/bootstrap-agent-machine.sh --yes`, whose preflight checks git push credentials (configuring
+a helper **scoped to the origin host** that dereferences `$GH_TOKEN` at call time — never writing the
+token to disk; because it reads the environment it works only where `GH_TOKEN` is exported, so prefer
+`gh auth setup-git` for systemd/cron workers) and probes **board access functionally** instead of trusting
+the `project` scope string. Full delta list with the identifying messages:
+`docs/development/fleet-runbook.md`.
 
 Another machine that finds an existing claim can `git fetch` the branch to **resume** that work instead of
 colliding; a **reaped** claim is adopted via compare-and-swap — `claim.sh adopt <N> --expect <old-sha>`,

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -208,6 +208,18 @@ lock**.
    (`claim.sh verify <N>` re-checks holder identity later); on `CLAIM LOST`, back off and take the next
    eligible item.
 
+**Machine prerequisite: git itself must be authenticated (issue #2942).** The lock is a plain `git push`,
+and `gh` auth is a *separate* credential path — a box with an authenticated `gh` CLI but no git credential
+helper fails every claim with `fatal: could not read Username for 'https://github.com'`, so the claim
+protocol does not work at all while `gh auth status` reports a healthy machine. `claim.sh` classifies that
+signature as **`CLAIM: ERROR reason=auth … (NOT retryable)`** naming the fix, *not* the old
+`reason=infra … (transient — retry)` that sent workers into a retry loop on a fault which can never
+self-clear; `reason=infra (transient — retry)` continues to mean a genuine, retryable blip. Fix a box with
+`gh auth setup-git` or `bash scripts/bootstrap-agent-machine.sh --yes`, whose preflight checks git push
+credentials (configuring a helper that dereferences `$GH_TOKEN` at call time — never writing the token to
+disk) and probes **board access functionally** instead of trusting the `project` scope string. Full delta
+list with the identifying messages: `docs/development/fleet-runbook.md`.
+
 Another machine that finds an existing claim can `git fetch` the branch to **resume** that work instead of
 colliding; a **reaped** claim is adopted via compare-and-swap — `claim.sh adopt <N> --expect <old-sha>`,
 which replaces the ref with force-with-lease so a resurrected original holder loses the lease and detects


### PR DESCRIPTION
Closes #2942. Design-driven; owner-approved at Seam 1 ("Option A as written"). OpenSpec change: `openspec/changes/worker-env-preflight/`.

## Why

Three pipeline steps failed on a Linux worker during the #1883 delivery. The unifying defect is **not** that the docs were incomplete — it is that each failure was **misattributed**, so the diagnosis pointed away from the cause:

| symptom | actual cause |
|---|---|
| `fatal: could not read Username for 'https://github.com'` | git has no credentials, though `gh` is authenticated — separate paths. `claim.sh`/`claim-heartbeat.sh` push on 10+ sites, so the claim protocol itself doesn't work |
| `CLAIM: ERROR reason=infra … (transient — retry)` | a permanent credential fault, advising a retry that can never succeed |
| `[ok] 'project' scope present — board dispatch works` | the scope *was* present; `gh project item-edit` still failed on `read:org` |

## What changed

- **`scripts/bootstrap-agent-machine.sh`** — a new git-credential preflight, and §3's board check rewritten from a scope-string match into a **read-only functional probe**.
- **`scripts/flow/claim.sh`** — an unauthenticated push reports `reason=auth (NOT retryable)`; unrecognized failures keep the retryable infra verdict, so the #2665 contract is only ever *narrowed* by positively-identified signatures.
- **Docs** — `fleet-runbook.md`, `agent-machine-setup.md`, `CLAIM.md`/`CLAUDE.md`, website `delivery-pipeline.md`: the three deltas indexed **by their identifying failure message**.

## Design decisions worth knowing

- **The `--yes` credential helper dereferences `$GH_TOKEN` at call time and is host-scoped.** No secret is written to disk, and rotation needs no reconfiguration. `gh auth setup-git` is preferred where it works — and is **re-probed** afterwards, because its exit 0 was precisely the non-evidence that hid the original bug.
- **A check must not mutate host state.** The board probe mirrors `flow-board`'s `gh auth switch` so it measures the identity dispatch actually uses, but the restore is `trap`-armed on `EXIT`/`INT`/`TERM` and both probes inside the bracket are bounded — so a hang plus Ctrl-C cannot leave the operator's account switched. On a box where `GH_TOKEN` is in force the switch is skipped entirely (gh ignores the keyring, so it would be theatre).
- **`--force-with-lease` is documented, not mechanized** — the flow scripts already use the explicit `=<ref>:<sha>` form; wrapping git would be disproportionate.

## Review — four rounds, each finding the thesis failing one layer deeper

roborev plus an independent shell review. Every round found the change reproducing the very defect it exists to kill:

| round | the verdict was still derived from… | fixed |
|---|---|---|
| 1 | a scope *string*, not the operation | functional probe |
| 2 | a credential-fill *exit code*, not a usable secret | require non-empty `password=` |
| 3 | an account-ambiguous grep, and a *different identity* than board ops use | active-stanza parse + `CQLITE_PROJECT_ACCOUNT` |
| 4 | a hang bound inert on macOS; a guessed board number | `timeout`→`gtimeout`; resolve-by-title, no guess |

Two blockers were **security**-shaped and are worth calling out: the auto-configured helper was initially **host-unscoped** (demonstrated handing the GitHub PAT to `gitlab.com`, `evil.example`, `internal-registry.corp`), and the probe accepted an **empty password**, which re-created the exact false-OK the change exists to kill.

## Evidence

| suite | before | after |
|---|---|---|
| `test_bootstrap_agent_machine.sh` | 34 / 12 | **71 / 0** |
| `test_claim_lock.sh` | 25 / 2 | **31 / 0** |
| `test_claim_heartbeat.sh` | 23 / 0 | 23 / 0 |

**Non-vacuity is proven per-fix, not in aggregate** — each blocker reverted *in isolation* fails only its own cases (`70/1`, `70/1`, `70/1`, `68/3`). The pre-fix run reproduces the issue's verbatim `reason=infra … (transient — retry)` line, and `7h-ii` simulates a stock-macOS host (`gtimeout` only) that *hangs* against the old resolution — without it a Linux-only CI could never catch that regression.

Two **harness** bugs were found and fixed along the way, both of which had been silently weakening the suite: it inherited `CQLITE_PROJECT_NUMBER` from the invoking shell (masking the entire not-exported path in every prior run), and env overrides passed through `"$@"` were inert (bash treats an expanded `VAR=value` as a command name).

## Test isolation

`GIT_CONFIG_GLOBAL` + `GIT_CONFIG_NOSYSTEM` exported once at the top so every case — including ones added later — inherits it, plus per-case `HOME`/`CARGO_HOME` sandboxes and a throwaway git repo per case. Verified after each round: no `~/.gitconfig`, zero global credential helpers, `~/.cargo/config.toml` absent, **active gh account unchanged**, and no board mutation (8e greps every board log family for `item-edit|item-add|item-delete|--field|mutation`).

## Deliberately out of scope — filed, not folded in

Requirement 3 is push-scoped, so widening it silently would run past Seam 1:

- **#2957** — `claim-heartbeat.sh` reports a failed push as *success* (`push_liveness_ref` returns `printf`'s status), which the 4h reaper keys on. This PR adds only the one-line `GIT_TERMINAL_PROMPT=0` hang fix and narrows the docs so they stop claiming coverage the code lacks.
- **#2961** — `claim.sh`'s `ls-remote` read paths still call a permanent credential fault transient.
- **#2965** — environment variants: GHE multi-host stanza selection, `http://` origins, fine-grained/App tokens reporting `Token scopes: none`. Also notes that if #2957 and #2961 both land, `git_stderr_is_auth` should be factored once rather than copied a third time.

## Known limitation

Requirement 1 scenario 2 ("a subsequent `git push` authenticates") is proven by the credential-fill probe plus a manual `--dry-run` push, **not** by an automated end-to-end push — a hermetic test cannot push to a real remote.

## Gate

`--lite` **PASS** and `--only tooling-tests` **PASS (242s)** at `e405833c`, `dirty: no`, both run independently by the lead. `tooling-tests` is the component that actually executes both shell suites — lite's blast radius defaults to `cqlite-core --lib` and would not have run them. The full gate of record runs pre-merge.