### PR TITLE
docs(#2951): collections/UDT guide corrections — column order, USE_ROW_TTL, UDT name origin, empty multicell, TTL encoding

### DIFF
--- a/docs/sstables-definitive-guide/chapters/05-data-db-format.md
+++ b/docs/sstables-definitive-guide/chapters/05-data-db-format.md
@@ -417,7 +417,7 @@ desynchronizes. Note this is distinct from a NULL: a NULL map *value* is not exp
 NULL top-level column is never represented by a *cell* — for a simple column it is absence from the
 column subset. (A non-frozen collection is the one case where "reads as NULL" does not imply "absent
 from the subset": an emptied collection is present in the subset with a complex deletion and zero
-cells — see "Empty collections" below.)
+cells — see [Empty Collections](#empty-collections) below.)
 
 **Implementation References** (CQLite):
 - Frozen collections: `cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs::serialize_value_into()`
@@ -481,8 +481,10 @@ treats `size < 0` as null, and returns short when the buffer ends early. CQLite 
 - `list<frozen<udt>>` = multi-cell (each UDT element is separate cell)
 - `frozen<list<udt>>` = single-cell (entire list is one blob)
 
-**Empty collections: frozen stores a zero-count blob; non-frozen stores no cells but is *not*
-absent.** The two modes diverge, and the non-frozen side is easy to get wrong:
+#### Empty Collections
+
+**Frozen stores a zero-count blob; non-frozen stores no cells but is *not* absent.** The two modes
+diverge, and the non-frozen side is easy to get wrong:
 
 - **Frozen** (`frozen<set<text>>` written as `{}`): a normal single cell whose value is a
   zero-element blob — the 4-byte BE count `00 00 00 00` and nothing else
@@ -504,8 +506,8 @@ absent.** The two modes diverge, and the non-frozen side is easy to get wrong:
   i.e. zero cells is legal precisely when a complex deletion is present, and a column with neither is
   dropped entirely (`update`, `:229-235`).
 
-Verbatim from the `nb_empty_collections` parity fixture (`test_types`, one row with all six columns
-written empty in a single `INSERT`), via `sstabledump`:
+Abridged `sstabledump` output from the `nb_empty_collections` parity fixture (`test_types`, one row
+with all six columns written empty in a single `INSERT`) — elided (`…`) and annotated, not byte-exact:
 
 ```
 "cells": [

--- a/docs/sstables-definitive-guide/chapters/05-data-db-format.md
+++ b/docs/sstables-definitive-guide/chapters/05-data-db-format.md
@@ -119,6 +119,60 @@ Endianness:
 - **Frozen** (`frozen<list<...>>`): Single-cell storage, entire collection serialized as one blob
 - **Non-frozen** (`list<...>`): Multi-cell storage, each element stored as separate cell
 
+#### Column Ordering: `SerializationHeader` Is the Positional Key
+
+A row body carries **no column names**. Cells are written positionally, and both the cell
+sequence and the missing-columns bitmap index into the column lists recorded in the
+`SerializationHeader` (`Statistics.db`, see Chapter 7). The header order is therefore the
+*only* authority for which cell is which — there is nothing in `Data.db` to fall back on, and
+nothing may be inferred from the bytes (no-heuristics mandate, issue #28).
+
+**The order.** Static columns and regular columns are two independent lists. Within each list,
+Cassandra sorts by `ColumnMetadata.comparisonOrder` — a packed `long`
+(`ColumnMetadata.java:107-116`):
+
+```
+(kind.ordinal() << 61) | (isComplex ? 1L << 60 : 0) | (position << 48) | (name.prefixComparison >>> 16)
+```
+
+The `isComplex` bit sits **above** every name bit, so within one list **all complex (multi-cell)
+columns sort after all simple ones**, and only then does the column name break ties (by
+`ColumnIdentifier.compareTo` → `prefixComparison`, then unsigned byte comparison of the name
+bytes, `ColumnIdentifier.java:90-106`, `:217-225`). Note this partitions the whole list by
+complexity — it is not a per-name adjacency rule: a complex `a_map` still sorts after a simple
+`z_text`. "Complex" means non-frozen collection or non-frozen UDT: `ColumnMetadata.isComplex()` is
+`cellPathComparator != null` (`:418-420`), and that comparator is built only for a non-primary-key
+column whose `type.isMultiCell()` (`makeCellPathComparator`, `:200-207`). A `frozen<…>` column is
+simple.
+
+**Why the two must agree.** The chain is:
+`RegularAndStaticColumns.Builder` builds each list as a BTree in `naturalOrder()`
+(`RegularAndStaticColumns.java:156-172`) → `SerializationHeader.toComponent()` copies that order
+into insertion-ordered `LinkedHashMap`s for the static/regular columns
+(`SerializationHeader.java:250-259`) → the header serializer writes the names in that map order →
+`UnfilteredSerializer.serializeRowBody` walks the row's columns in the same order
+(`UnfilteredSerializer.java:240-259`) and `Columns.Serializer.serializeSubset` numbers bitmap bits
+by that same index (`Columns.java:503-531`). A reader replays it in reverse (`deserializeRowBody`,
+`UnfilteredSerializer.java:564+`, subset at `:606`).
+
+A writer whose header order and cell order disagree produces an SSTable that misdecodes without
+any error: bitmap bit *i* is attributed to the wrong column, a complex column can be dropped, and
+the cells after it are read with the wrong type and framing (complex cells carry a cell path,
+simple cells do not) — desynchronizing the rest of the row.
+
+Authority: `org.apache.cassandra.schema.ColumnMetadata` (`comparisonOrder`, `compareTo`),
+`org.apache.cassandra.db.RegularAndStaticColumns`, `org.apache.cassandra.db.SerializationHeader`,
+`org.apache.cassandra.db.Columns.Serializer`, `org.apache.cassandra.db.rows.UnfilteredSerializer`.
+
+CQLite implements the same key as `column_order_key(column) -> (is_complex, name)` in
+`cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs:9-11`, and applies it to **both**
+sides: the header lists at
+`cqlite-core/src/storage/sstable/writer/stats_writer/serialization_header.rs:159` (static) and
+`:186` (regular), and the cell stream from the same key. Regression guard:
+`cqlite-core/tests/issue_2035_collection_roundtrip.rs` (issue #2035 — `map<text,int>` + `set<int>`
+plus a trailing simple column round-trip; the pre-fix writer sorted the header by name only, so the
+complex columns landed in the wrong positions).
+
 #### Frozen Collection Serialization
 
 Frozen collections are stored as a single cell with the entire collection serialized as a binary blob.
@@ -189,6 +243,35 @@ Field order and presence are authoritative in `Cell.Serializer.serialize` (`Cell
 layout comment at `:242-259`) — note local deletion time comes **before** TTL. The complex column is
 preceded by an unsigned-VInt cell count (`UnfilteredSerializer.java:277`) and, when
 `HAS_COMPLEX_DELETION` is set, a deletion time.
+
+**`USE_ROW_TTL` (`0x10`): element expiry inherited from row liveness.** Collection element cells
+use the *same* `Cell.Serializer` as simple cells, so they get the same TTL-elision optimization —
+and readers of complex columns must implement it. The writer sets the flag only when **all four**
+conditions hold (`Cell.java:275`):
+
+1. the cell is expiring (`cell.isExpiring()`, which also sets `IS_EXPIRING`, `0x02`),
+2. the row's primary-key liveness is itself expiring (`rowLiveness.isExpiring()`),
+3. `cell.ttl() == rowLiveness.ttl()`, and
+4. `cell.localDeletionTime() == rowLiveness.localExpirationTime()`.
+
+When set, **both** the `local_deletion_time` and the `ttl` VInts are omitted from the cell
+(`Cell.java:295-298`) and the reader takes both values from the row's TTL fields
+(`Cell.java:318-322`). So it is not a "may" — given identical row and cell expiry the flag is
+mandatory, and `IS_EXPIRING` is set alongside it (combined byte `0x12`, or `0x1a` with
+`USE_ROW_TIMESTAMP`).
+
+In practice a single `INSERT … USING TTL n` writing a whole non-frozen collection gives every
+element the row's TTL and expiry, so every element cell carries `USE_ROW_TTL`. A later per-element
+update with a different TTL (or into a row with no row-level TTL) fails condition 2 or 3 and writes
+explicit `local_deletion_time` + `ttl` VInts with `USE_ROW_TTL` clear. A reader must therefore be
+prepared for a **mix** of inherited and explicit expiry within one complex column.
+
+Authority: `org.apache.cassandra.db.rows.Cell.Serializer` (`serialize`, `deserialize`).
+CQLite implements the element-level side in
+`cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs:22-132`
+(`ElementExpiryShape` / `ExpiryHomogeneity` — a tri-state tracker that folds per-element
+inherited-vs-explicit expiry back into a column-level answer), with the round-trip pinned by
+`cqlite-core/tests/issue_2038_collection_ttl_expiring_cell.rs` (issue #2038).
 
 **The path is always unsigned-VInt-length-prefixed. The value is unsigned-VInt-length-prefixed *iff*
 `HAS_EMPTY_VALUE` (`0x04`) is clear — and when present it is length-prefixed even for a fixed-width
@@ -331,7 +414,10 @@ cell flags (0x08 USE_ROW_TIMESTAMP | 0x04 HAS_EMPTY_VALUE) — no value length, 
 ```
 A reader that unconditionally reads a value-length VInt here consumes the next cell's flag byte and
 desynchronizes. Note this is distinct from a NULL: a NULL map *value* is not expressible in CQL, and a
-NULL top-level column is represented by absence from the column subset, never by a cell.
+NULL top-level column is never represented by a *cell* — for a simple column it is absence from the
+column subset. (A non-frozen collection is the one case where "reads as NULL" does not imply "absent
+from the subset": an emptied collection is present in the subset with a complex deletion and zero
+cells — see "Empty collections" below.)
 
 **Implementation References** (CQLite):
 - Frozen collections: `cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs::serialize_value_into()`
@@ -394,6 +480,56 @@ treats `size < 0` as null, and returns short when the buffer ends early. CQLite 
 **Critical distinction**: The **outer** type determines storage:
 - `list<frozen<udt>>` = multi-cell (each UDT element is separate cell)
 - `frozen<list<udt>>` = single-cell (entire list is one blob)
+
+**Empty collections: frozen stores a zero-count blob; non-frozen stores no cells but is *not*
+absent.** The two modes diverge, and the non-frozen side is easy to get wrong:
+
+- **Frozen** (`frozen<set<text>>` written as `{}`): a normal single cell whose value is a
+  zero-element blob — the 4-byte BE count `00 00 00 00` and nothing else
+  (`CollectionSerializer.pack` always writes the count, `CollectionSerializer.java:52-64`). This is
+  a present, non-null value and is distinguishable from a column that was never written.
+- **Non-frozen** (`set<text>` written as `{}`): **zero element cells**, but the column is still
+  present in the row — because writing a non-frozen collection is a *replace*, and a replace emits a
+  **complex (collection) deletion** covering the prior contents before adding cells
+  (`Lists.Setter`/`Sets.Setter`/`Maps.Setter` call
+  `UpdateParameters.setComplexDeletionTimeForOverwrite`, `UpdateParameters.java:202-205`, then add
+  zero cells because the literal is empty: `Sets.Adder.doAdd` returns early on
+  `elements.size() == 0`). So the row carries `HAS_COMPLEX_DELETION` and, for that column, a
+  deletion time plus a cell count of `0`.
+
+  On the read side the collection reconciles to zero elements, which CQL surfaces as `NULL` — an
+  empty non-frozen collection and a null one are indistinguishable *to a query*. But they are
+  distinguishable **on disk**, and a reader must not conflate the two: `ComplexColumnData`'s
+  invariant is `cells.length > 0 || !complexDeletion.isLive()` (`ComplexColumnData.java:64-70`) —
+  i.e. zero cells is legal precisely when a complex deletion is present, and a column with neither is
+  dropped entirely (`update`, `:229-235`).
+
+Verbatim from the `nb_empty_collections` parity fixture (`test_types`, one row with all six columns
+written empty in a single `INSERT`), via `sstabledump`:
+
+```
+"cells": [
+  { "name": "fl", "value": [] },                 // frozen<list<int>>  — present, zero-count blob
+  { "name": "fm", "value": {} },                 // frozen<map<text,int>>
+  { "name": "fs", "value": [] },                 // frozen<set<text>>
+  { "name": "ml", "deletion_info": { … } },      // list<int>  — complex deletion, ZERO cells
+  { "name": "mm", "deletion_info": { … } },      // map<text,int>
+  { "name": "ms", "deletion_info": { … } }       // set<text>
+]
+```
+
+Note what the non-frozen entries are *not*: they are neither missing from the row nor a row/cell
+tombstone. `sstabledump` prints a bare `deletion_info` object for a complex column when
+`complexDeletion()` is live-less and there are no cells to follow
+(`JsonTransformer.serializeColumnData`, `:400-429`) — that is exactly the on-disk shape above.
+Reference: `test-data/datasets/sstables/test_types/nb_empty_collections-*/nb-1-big-Data.db.jsonl`;
+generator `test-data/scripts/generate-cql-type-parity.sh` (`[B9]`), schema
+`test-data/schemas/cql-type-parity.cql`.
+
+A genuinely **absent** non-frozen collection — one never written for that row — is signalled the
+same way as any absent column: its bit is set in the missing-columns bitmap (or the column is simply
+outside the subset), with no deletion time and no cells. Distinguishing "written empty" from "never
+written" therefore requires the complex deletion, not the cell count.
 
 See `tables/type-mapping-complex.md` for detailed format specifications.
 
@@ -777,7 +913,7 @@ Cell flags are constructed based on cell properties:
 | Cell has TTL | CELL_IS_EXPIRING | 0x02 | Include TTL fields |
 | Value is empty string | CELL_HAS_EMPTY_VALUE | 0x04 | Zero-length value |
 | Use row timestamp | CELL_USE_ROW_TIMESTAMP | 0x08 | Skip cell timestamp |
-| Use row TTL | CELL_USE_ROW_TTL | 0x10 | Skip cell TTL |
+| Use row TTL | CELL_USE_ROW_TTL | 0x10 | Skip **both** cell TTL and cell local_deletion_time |
 
 **CELL_USE_ROW_TIMESTAMP Truth Table**:
 

--- a/docs/sstables-definitive-guide/chapters/appendix-a-type-mapping.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-a-type-mapping.md
@@ -90,6 +90,35 @@ This appendix consolidates the type mapping tables for Cassandra 5.0 SSTables an
 - **Tuple and UDT field lengths** use **4-byte BE signed int** (not VInt), with no field count on
   disk. Null fields are encoded as 0xFFFFFFFF (-1). Source: `TupleType.java:341-364`;
   `UserType extends TupleType` (`UserType.java:52,194`), so the two are byte-identical.
+- **UDT type names in DDL: accept BOTH bare and keyspace-qualified.** A CQL type string naming a UDT
+  may arrive either as `frozen<addr>` or as `frozen<my_ks.addr>`, and *which* form you get depends on
+  who produced the DDL — not on the SSTable. A schema parser must accept both and resolve the UDT by
+  splitting on the first `.`.
+  - **Cassandra server-side emits the BARE name.** `CQL3Type.UserDefined.toString()` returns
+    `ColumnIdentifier.maybeQuote(name)` (or `"frozen<" + maybeQuote(name) + '>'`) with no keyspace
+    prefix (`CQL3Type.java:413-420`), and every server path funnels through it:
+    `CqlBuilder.append(AbstractType)` uses `type.asCQL3Type().toString()` (`CqlBuilder.java:134-137`),
+    which drives `DESCRIBE TABLE` / `SchemaCQLHelper` snapshot `schema.cql`, and
+    `SchemaKeyspace.addColumnToSchemaMutation` stores the same bare string in
+    `system_schema.columns.type` (`SchemaKeyspace.java:746`). The `DESCRIBE` goldens in
+    `test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java` show exactly
+    `b frozen<<bare type name>>`. `UserType.getCqlTypeName()` *is* keyspace-qualified
+    (`String.format("%s.%s", …)`, `UserType.java:450-452`) but is used only in `ALTER TYPE` error
+    messages, not in emitted DDL.
+  - **The qualified form comes from the DataStax Java driver.**
+    `com.datastax.oss.driver.api.core.type.UserDefinedType.asCql(boolean includeFrozen, boolean pretty)`
+    / `describe(...)` format with `frozen<%s.%s>` / `%s.%s` (verified in the constant pool of
+    `java-driver-core-4.19.2.jar`). Any tool that renders schema through the driver therefore emits
+    `frozen<keyspace.typename>` — including Cassandra Sidecar's
+    `GET /api/v1/keyspaces/<ks>/schema`, which is how CQLite's Trino connector obtains DDL.
+  - CQLite accepts both: `cqlite-core/src/schema/cql_parser.rs` (`qualified_type_name` parses
+    `identifier ('.' identifier)?`) and `split_qualified_udt` in
+    `cqlite-core/src/schema/udt_registry.rs` (re-exported from `cqlite-core/src/schema/mod.rs:24`),
+    used at every registry lookup site (issue #2807).
+  - This is a **DDL/schema-text** concern only. Nothing on disk carries a CQL type string of this
+    form: the `Statistics.db` `SerializationHeader` records the *internal marshal* form,
+    `org.apache.cassandra.db.marshal.UserType(keyspace,hex_encoded_name,field:type,…)`, which is
+    always keyspace-bearing (see Appendix B, "Tuple and UDT Field Encoding").
 - **Vector types**: fixed-element vectors (`vector<float,n>`) write no length prefix -- layout is exactly `n x elementSize` bytes concatenated. Source: `VectorType.java:477-493`, `FixedLengthSerializer`.
 
 ## Key Takeaways

--- a/docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md
@@ -237,7 +237,7 @@ Cell flags appear at the start of each cell and control cell-level metadata.
 | 1 | `IS_EXPIRING` | `0x02` | TTL fields follow (expiring cell) |
 | 2 | `HAS_EMPTY_VALUE` | `0x04` | Zero-length value (not NULL) |
 | 3 | `USE_ROW_TIMESTAMP` | `0x08` | Use row-level timestamp (no cell timestamp) |
-| 4 | `USE_ROW_TTL` | `0x10` | Use row-level TTL (no cell TTL) |
+| 4 | `USE_ROW_TTL` | `0x10` | Inherit row-level TTL **and** local_deletion_time (neither field is written) |
 
 **Common flag combinations**:
 - `0x08`: Normal write (use row timestamp)
@@ -256,7 +256,34 @@ Cell flags appear at the start of each cell and control cell-level metadata.
 - **Empty strings**: `HAS_EMPTY_VALUE` (`0x04`) flag set and **no** value length and no value bytes —
   the flag replaces the length VInt, it does not precede a `0x00` (`Cell.java:277-278`, `:303-304`;
   reader `:310`). Distinct from NULL.
-- **NULL values**: NOT written as cells - represented by absence in column bitmap
+- **NULL values**: NOT written as cells - represented by absence in column bitmap. Caveat for
+  **non-frozen collections**: a collection emptied or overwritten-with-`{}` reads back as NULL but is
+  **present** in the subset, carrying a complex deletion and zero element cells — absence in the
+  bitmap is not the only on-disk shape that surfaces as NULL. See Chapter 5, "Empty collections".
+
+**TTL field range — Cassandra's bound, and the reader-side cast hazard**:
+
+On disk, the cell TTL is an **unsigned VInt32 delta** over `stats.minTTL`:
+`SerializationHeader.writeTTL` emits `writeUnsignedVInt32(ttl - stats.minTTL)` and `readTTL` adds
+`stats.minTTL` back (`SerializationHeader.java:175-178`, `:196-199`). Cassandra itself holds TTL in a
+signed `int`, and enforces the range at request validation, not at parse time:
+`Attributes.MAX_TTL = 20 * 365 * 24 * 60 * 60` — 20 years, `631,152,000` s
+(`Attributes.java:47`) — with `ttl < 0` and `ttl > MAX_TTL` both rejected as
+`InvalidRequestException` (`:135-139`). At *read* time the only check is
+`if (ttl < 0) throw new IOException("Invalid TTL: " + ttl)` (`Cell.java:345-346`). So a
+well-formed Cassandra 5.0 SSTable can never carry a TTL above `MAX_TTL`, which is comfortably
+below `i32::MAX` (`2,147,483,647` s ≈ 68 years).
+
+*Reader-implementation note (CQLite, not a format rule)*: a reader that decodes the delta into a
+`u32`/`u64` and then does a bare `as i32` would wrap an out-of-range value to a **negative** TTL —
+the one thing Cassandra's own reader rejects outright. CQLite therefore saturates instead of
+wrapping, on both cell paths:
+`cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs:46-53`
+(`ttl.min(i32::MAX as u32) as i32`, collection-element path, issue #2498) and
+`cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value.rs:165`
+(`abs_ttl.min(i32::MAX as i64) as i32`, scalar path, issue #2173). No real Cassandra data reaches
+this clamp; it exists so a corrupt or adversarial file yields a saturated positive TTL rather than a
+sign-flipped one.
 
 **Example**:
 ```

--- a/docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md
@@ -259,7 +259,7 @@ Cell flags appear at the start of each cell and control cell-level metadata.
 - **NULL values**: NOT written as cells - represented by absence in column bitmap. Caveat for
   **non-frozen collections**: a collection emptied or overwritten-with-`{}` reads back as NULL but is
   **present** in the subset, carrying a complex deletion and zero element cells — absence in the
-  bitmap is not the only on-disk shape that surfaces as NULL. See Chapter 5, "Empty collections".
+  bitmap is not the only on-disk shape that surfaces as NULL. See Chapter 5, "Empty Collections".
 
 **TTL field range — Cassandra's bound, and the reader-side cast hazard**:
 
@@ -267,7 +267,7 @@ On disk, the cell TTL is an **unsigned VInt32 delta** over `stats.minTTL`:
 `SerializationHeader.writeTTL` emits `writeUnsignedVInt32(ttl - stats.minTTL)` and `readTTL` adds
 `stats.minTTL` back (`SerializationHeader.java:175-178`, `:196-199`). Cassandra itself holds TTL in a
 signed `int`, and enforces the range at request validation, not at parse time:
-`Attributes.MAX_TTL = 20 * 365 * 24 * 60 * 60` — 20 years, `631,152,000` s
+`Attributes.MAX_TTL = 20 * 365 * 24 * 60 * 60` — 20 years (20 × 365 days), `630,720,000` s
 (`Attributes.java:47`) — with `ttl < 0` and `ttl > MAX_TTL` both rejected as
 `InvalidRequestException` (`:135-139`). At *read* time the only check is
 `if (ttl < 0) throw new IOException("Invalid TTL: " + ttl)` (`Cell.java:345-346`). So a


### PR DESCRIPTION
Closes #2951

## DOCS-ONLY

This change touches **zero `.rs` files** — SSTable-guide markdown only. Reviewers can confirm with:

```
git diff --name-only origin/main...HEAD
```

(only `docs/sstables-definitive-guide/chapters/*.md`).

## All 5 ACs: `applied-corrected`

The issue's audit draft was factually wrong on **all five** claims. Each was re-derived from primary
sources (Cassandra 5.0.8 tag + committed parity goldens); the text written is what those sources
actually say, not the draft.

1. **Column order** — `ColumnMetadata.java:107-114`: the `isComplex` bit (`1L<<60`) sits **above** the
   name/prefix bits, so within a kind **ALL** complex columns sort after **ALL** simple ones. (Draft
   said "after simple columns of the same name prefix" — wrong.)
2. **`USE_ROW_TTL`** — `Cell.java:275` computes it **deterministically** from 4 conditions
   (MANDATORY, not an optional writer choice); `:295-298` elides **BOTH** `localDeletionTime` **and**
   `TTL`; `:318-322` / `:390-393` read both back from `rowLiveness`.
3. **Qualified UDT names** — Cassandra emits **BARE** type names (`CQL3Type.java:416/418` via
   `CqlBuilder.java:136` + `SchemaKeyspace.java:746`). The `frozen<ks.type>` form originates in the
   **DataStax java-driver** (`UserDefinedType`, java-driver-core 4.19.2). This **REFUTES the issue's
   stated authority**: #2807's fix remains correct, but the driver — not Cassandra's schema output —
   is the actual source of the qualified form.
4. **Empty multicell collections** — an emptied non-frozen collection is **PRESENT** with a complex
   deletion + zero cells, **NOT** absent/NULL. Proven by golden
   `test_types/nb_empty_collections-4faf9910…/nb-1-big-Data.db.jsonl` (ck=1: `ml`/`mm`/`ms` carry
   `deletion_info` with zero cells) plus `Sets.java:391-393`, `UpdateParameters.java:202`,
   `ComplexColumnData.java:68`.
5. **TTL encoding** — unsigned VInt32 **delta over `stats.minTTL`**
   (`SerializationHeader.java:175-178` / `:196-199`); the reader's only check is rejecting `ttl < 0`
   (`Cell.java:345-346`); `Attributes.MAX_TTL` = **630,720,000 s**. The u32→i32 clamp is labelled a
   **CQLite reader note**, not a format rule.

**sweep**: 4 additional stale contradictions found and fixed in these files — ch.5 `:417-420`,
ch.5 `:916`, appendix-B `:240`, appendix-B `:256-262`.

**verification**: independently, adversarially verified against the `cassandra-5.0.8` tag — 4 of 5
claims CONFIRMED, and the single refutation (the `MAX_TTL` arithmetic: `20 * 365 * 24 * 60 * 60` =
630,720,000 s, not the 365.25-day 631,152,000; `src/java/org/apache/cassandra/cql3/Attributes.java:47`)
is fixed in this PR.

**known follow-up**: stale comments in `test-data/schemas/cql-type-parity.cql:214-216` and
`test-data/scripts/generate-cql-type-parity.sh` (`[B9]`) still assert "empty MULTICELL collection is
stored as ABSENT by Cassandra", now contradicted by correction 4. Being filed separately — those
paths are outside this lane's file allowlist.

## Follow-up polish in this branch

- appendix-B `:270`: corrected `MAX_TTL` to `630,720,000` s (kept the "20 years" gloss — exactly
  20 × 365 days).
- ch.05: promoted the empty-collections **bold lead-in** to a real `#### Empty Collections` heading
  (sibling depth matches `#### Non-Frozen Collection Serialization`) so cross-references resolve to
  a real anchor; the in-file reference now links `[Empty Collections](#empty-collections)`.
- ch.05: relabelled the annotated/elided golden block from "Verbatim" to
  "Abridged `sstabledump` output" so it is not read as byte-exact. Block content unchanged.

## Gate

`scripts/agent-gate.sh --lite` → **RESULT: PASS** (file-size, fmt, clippy, roborev-lints,
scoped-tests). Full gate is the closer's job.
