### PR TITLE
docs(#2952): partition index + Summary.db guide corrections — little-endian layout, exact vs average sampling interval, lazy open

### DIFF
--- a/docs/sstables-definitive-guide/chapters/02-anatomy-of-an-sstable.md
+++ b/docs/sstables-definitive-guide/chapters/02-anatomy-of-an-sstable.md
@@ -12,8 +12,8 @@ This chapter explains each SSTable component and how they fit together. Cassandr
 ## Components Overview
 
 - `Data.db`: The primary row/partition data, optionally compressed in fixed-size chunks.
-- `Index.db`: Per-partition index entries mapping key digests to `Data.db` positions; may include promoted index data for wide partitions.
-- `Summary.db`: A sampled (promoted) index to accelerate binary search into `Index.db`.
+- `Index.db`: Per-partition index entries mapping the **raw partition key** (length-prefixed — not a digest) to its `Data.db` position; may include promoted index data for wide partitions.
+- `Summary.db`: A sampled index over `Index.db`, in decorated-key order, giving a bounded entry point for the `Index.db` walk.
 - `Filter.db` (Bloom): Probabilistic membership filter to skip non-existent partitions.
 - `Statistics.db`: SSTable-level metadata (timestamps, histograms, repair/level info, min/max tokens, etc.).
 - `CompressionInfo.db`: Algorithm, chunk length, and the map of compressed chunk offsets (and optional per-chunk CRCs) for `Data.db`.
@@ -32,12 +32,30 @@ Diagram: sstable components and relationships
 SSTable formats evolved over time. In 5.0, BTI (B-Tree/Trie Indexed) coexists with the long-standing `big` family. The component set is stable, but internal formats and metadata change with version/feature flags. The `Descriptor` defines the `{format}` segment and controls feature availability, while `StatsMetadata` evolves fields used by compaction heuristics and read optimizations. See Chapter 17 for BTI details.
 
 ### Format Version Evolution (concise)
-| Area | Pre-5.x (big) | 5.0 (BTI/big) |
+
+Scope note: this guide targets Cassandra 5.0 — BIG versions `na`/`nb`/`oa` and BTI `da`. The
+"earlier `big`" column below is context only, not a supported target.
+
+| Area | Earlier `big` | 5.0 (`big` / BTI) |
 |---|---|---|
-| Index entry | Simple digest list; promoted index optional | BTI adjusts indexing structures; promoted index layout may differ |
-| Summary | Sampling rate + offsets | Token-sorted with explicit index offsets |
+| Partition index | `Index.db`: length-prefixed **raw** partition key + `Data.db` offset + optional promoted index | `big`: same entry shape (no wire-format change). BTI: no `Index.db` at all — a page-aware trie in `Partitions.db` + `Rows.db` |
+| Summary | `Summary.db`: sampled keys → `Index.db` offsets, in decorated-key order | `big`: unchanged. BTI: **no `Summary.db`** (the trie needs no sampled entry point) |
 | CompressionInfo | Offsets only (legacy) | Optional per-chunk CRCs; format detection supported |
 | Statistics | Fewer fields | Expanded histograms/repair/level fields |
+
+> **The `Index.db` entry has never been a "digest list".** Each entry is a length-prefixed raw
+> partition key followed by VInt offsets — no marker byte and no MD5 digest. See Ch.6 and
+> Ch.21 for the byte layout and the history of that documentation error (Issue #552).
+
+> **Read-path note (algorithm, not format).** For `big`, the entry point at open is
+> `Summary.db`, not `Index.db`: a reader loads the summary (and the first/last keys) and walks
+> `Index.db` only when the summary or Bloom filter must be **rebuilt** — i.e. when `Summary.db`
+> is absent, corrupt, or was written with a different `min_index_interval`
+> ([`BigSSTableReaderLoadingBuilder.java#L96-L130`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L96-L130)).
+> A point read then walks **one summary interval** of `Index.db` rather than the whole file
+> ([`BigTableReader.java#L277-L320`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L277-L320)).
+> This is a property of the reader, not a version feature flag — and it holds only while a
+> usable `Summary.db` is present. See Ch.6 ("Partition Lookup Flow") and Ch.10.
 
 ## Schema and Type Mapping
 

--- a/docs/sstables-definitive-guide/chapters/06-index-and-summary.md
+++ b/docs/sstables-definitive-guide/chapters/06-index-and-summary.md
@@ -18,7 +18,7 @@ entry is:
 ```
 [key_len: u16 BE]                    ← length of the raw partition key
 [raw partition key bytes: key_len]   ← the partition key exactly as serialized in Data.db
-[data_offset: unsigned vint]         ← byte offset into the Data.db data section
+[data_offset: unsigned vint]         ← offset in the UNCOMPRESSED Data.db stream
 [promoted_index_len: unsigned vint]  ← byte length of the promoted index (0 = none)
 [promoted_index_data: promoted_index_len bytes]
 ```
@@ -79,16 +79,37 @@ Example offsets:
 0xc0 0x5f 0x11 -> 3 bytes -> value = 24337
 ```
 
-**Important**: NB format offsets are **relative to the Data.db data section** (excluding the
-compression header, typically 30 bytes). Add the header size when seeking:
-```
-file_offset = index_offset + header_size
-```
+**Important**: `data_offset` is a position in the **uncompressed data stream**, i.e. the offset
+of the partition's first byte as if `Data.db` were fully decompressed. Cassandra takes it
+directly from the partition writer's initial position in that stream
+([`BigTableWriter.createRowIndexEntry`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java#L95-L113)),
+so there is **no header to add**:
+
+- **Uncompressed `Data.db`** — the uncompressed stream *is* the file, and the file has no
+  standalone header, so `file_offset == data_offset`. Verified on
+  `test_basic/uncompressed_table`: `Index.db` entry 0 has `data_offset = 0` and `Data.db` byte 0
+  is that partition's `0010 045e 63fc…` key; entry 1's `data_offset = 0xc5` (197) lands exactly
+  on `0010 5f5e 6b02…`, the next key.
+- **Compressed `Data.db`** — resolve `data_offset` through `CompressionInfo.db`: find the chunk
+  containing it, decompress that chunk, and index into the result. The offset is *not* a raw
+  file position. Verified on `test_basic/compression_test_table`, where `Data.db` byte 0 is
+  Snappy chunk data, not a key.
+
+> **Caution:** any advice of the form "add ~30 bytes of `Data.db` header" is wrong for `na`/`nb`
+> and `oa` BIG SSTables — `Data.db` has no such header. (CQLite carries an
+> `actual_header_size` for other, non-Cassandra-written inputs and it is `0` for real `nb`
+> files: `reader/header_helpers.rs:89-92`; the summary-guided point path passes `data_offset`
+> through unmodified, `reader/data_access/big_point.rs:114-122`.)
 
 Keys and collisions:
-- The on-disk key is the raw partition key, so lookups can compare keys directly (no digest /
-  collision handling is required at the index layer). On a hash-based point lookup that misses,
-  readers fall back to a full scan that compares raw keys (see Issue #517).
+- The on-disk key is the raw partition key, so lookups compare keys **byte-for-byte**. There is
+  no key hash on disk, hence no collision handling at the index layer at all. (CQLite's
+  in-memory lookup map is keyed on those raw bytes; its `key_digest` field name is historical
+  — `index_reader/mod.rs:52-60` documents the misnomer, Issue #552.)
+- A point lookup that misses therefore misses for a real reason (absent key, or an index whose
+  covering range cannot be trusted), not because of a digest collision. When a reader cannot
+  bound the search authoritatively it must widen it rather than report absence — see "Partition
+  Lookup Flow" below and Ch.10.
 
 Promoted index payload (BIG):
 - Emitted for wide partitions to accelerate within-partition seeks. Its length is given
@@ -133,6 +154,22 @@ promoted_index     = read_bytes(promoted_index_len)   // empty when length == 0
 
 `Summary.db` samples index entries for faster navigation. It contains a subset of partition keys at configurable intervals (default: every 128 partitions).
 
+> **Sample order is partitioner order, not byte order.** `Summary.db` samples — and the
+> `Index.db` entries they point into — are ordered by **decorated key**: the table
+> partitioner's token first, then the raw key bytes compared as *unsigned*. With the 5.0
+> default `Murmur3Partitioner` the order is therefore decided by `murmur3(raw_key)`, and the
+> raw bytes only break token ties. A binary search that compares raw keys with `memcmp`
+> lands in the wrong interval on any table whose token order differs from its byte order.
+> The token itself is **not** stored in a summary entry (see "Entry Format" below) — the
+> reader recomputes it by decorating the stored key.
+>
+> Sources: [`IndexSummary.binarySearch(PartitionPosition)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L127)
+> compares with
+> [`DecoratedKey.compareTo(IPartitioner, ByteBuffer, PartitionPosition)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/DecoratedKey.java#L93-L102),
+> which does `getToken().compareTo(...)` first
+> ([`Murmur3Partitioner.LongToken.compareTo`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java#L177)
+> = `Long.compare`) and only then `ByteBufferUtil.compareUnsigned` on the raw keys.
+
 ### File Structure
 
 ```
@@ -142,7 +179,7 @@ promoted_index     = read_bytes(promoted_index_len)   // empty when length == 0
 | Offset Table (LE u32[])| <- Little-endian!
 +------------------------+
 | Entry Data             |
-|   key + position (BE)  |
+|   key + position (LE)  | <- position is little-endian too (#1054)
 +------------------------+
 | First Key (serialized) |
 +------------------------+
@@ -176,15 +213,27 @@ Annotated example:
 **Critical gotcha**: Unlike all other Cassandra formats, the offset table uses **little-endian** encoding.
 
 ```c
-le32 offsets[entries_count];  // Offset to each entry within entry data section
+le32 offsets[entries_count];  // Offset to each entry, measured from the START of the
+                              // offset table (i.e. offsets[0] == entries_count * 4)
 ```
 
-Example for 3 entries:
+**Second gotcha**: the offsets are **absolute within the combined `(offset_table + entry_data)`
+region**, not relative to the entry-data section. Cassandra adds `baseOffset = offsetCount * 4`
+when serializing and subtracts it when deserializing
+([`IndexSummary.java#L405-L420`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L405-L420)),
+and its deserializer rejects an offset smaller than the table itself
+([`#L459-L467`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L459-L467)),
+so a zero-based `offsets[0]` is not readable by Cassandra (CQLite issue #666).
+
+Real bytes — `test_basic/composite_key_table`, `nb-1-big-Summary.db`, one sample with a 16-byte
+key:
 ```
-00000018: 00 00 00 00  // Entry 0 at offset 0
-0000001c: 18 00 00 00  // Entry 1 at offset 24 (LE!)
-00000020: 30 00 00 00  // Entry 2 at offset 48 (LE!)
+00000018: 04 00 00 00  // Entry 0 at absolute offset 4 == entries_count(1) * 4 (LE!)
+0000001c: 24 5d ff 69 02 6f 45 c6 b6 8f ba 0c 96 4d f3 c9  // 16-byte raw key, no prefix
+0000002c: 00 00 00 00 00 00 00 00                          // Index.db position = 0 (LE u64)
 ```
+Here `summary_entries_size` (header) is `0x1c` = 28 = `4` (offset table) + `16` (key) + `8`
+(position), confirming it spans both regions.
 
 ### Entry Format
 
@@ -208,7 +257,17 @@ Key length calculation:
 key_length = next_offset - current_offset - 8  // Subtract 8 for position field
 ```
 
-**Important**: Tokens are NOT stored in Summary.db entries. The `position` field points to a byte offset in Index.db, not a token.
+For the **last** entry there is no `next_offset`; its end is `summary_entries_size` (the header
+field spanning offset table + entry data). Cassandra's in-memory equivalent is
+[`getEndInSummary`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L193-L201),
+which returns `entriesLength` for the last index and `getPositionInSummary(index + 1)` otherwise.
+
+**Important**: Tokens are NOT stored in Summary.db entries. The `position` field points to a
+byte offset in Index.db, not a token. The entries are nevertheless **ordered by token**
+(see "Sample order is partitioner order" above); a reader that needs a sample's token
+recomputes it by decorating the stored raw key
+([`IndexSummary.getKey(int)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L164-L171)
+returns raw bytes; `binarySearch` decorates them via the partitioner).
 
 ### Serialized Keys (File End)
 
@@ -223,11 +282,96 @@ First and last keys are serialized at the end of the file for quick boundary loo
 
 ## Partition Lookup Flow
 
-1. **Summary.db lookup**: Binary search by partition key to find nearest sampled entry
-2. **Index.db scan**: Read from `position` offset, scan forward to find exact partition
-3. **Data.db seek**: Use offset from Index.db entry to read partition data
+A BIG point lookup never parses the whole `Index.db`. Each step below is bounded:
 
-Note: Token-based iteration is not directly supported by Summary.db since tokens are not stored. Token iteration must compute tokens from partition keys.
+1. **Summary.db interval lookup** — binary search the token-ordered samples (decorated-key
+   comparator, above) for the **floor** sample: the greatest sample whose decorated key is
+   `<= target`. Its `position` is where the `Index.db` walk starts; the *next* sample's
+   position is where the covering interval ends. A target below the first sample clamps to
+   the index start. Cassandra:
+   [`IndexSummary.getScanPosition`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L361-L364)
+   → `binarySearch` →
+   [`getScanPositionFromBinarySearchResult`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L367-L373)
+   (a "no sample `<=` target" result yields position `0`).
+2. **Bounded Index.db walk** — read forward from that position, comparing keys, and stop
+   once the interval is exhausted. Cassandra bounds the `EQ` walk by the interval width for
+   *this* sample,
+   [`getEffectiveIndexIntervalAfterIndex(sampledIndex)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L273-L276):
+   while `i <= effectiveInterval` it compares *raw* key bytes for speed; past that bound it
+   compares decorated keys and returns "absent" as soon as an index key sorts above the
+   target
+   ([`BigTableReader.java:277-320`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L277-L320)).
+   Non-matching entries are skipped with
+   [`RowIndexEntry.Serializer.skip`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L349),
+   never re-parsed.
+3. **Data.db seek** — use the matched entry's `data_offset` to read the partition.
+
+**Open cost.** A BIG reader loads `Summary.db` at open and does *not* scan `Index.db`; it
+only walks `Index.db` when the summary (or the Bloom filter) has to be **rebuilt** because
+`Summary.db` is absent, corrupt, or was written with a different `min_index_interval`
+([`BigSSTableReaderLoadingBuilder.java:96-130`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L96-L130),
+[`loadSummary()`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L249-L266)).
+So "open is proportional to the summary, not the partition count" holds **only when a usable
+`Summary.db` is present** — the rebuild path is proportional to `Index.db`. The deserializer
+itself decides "usable": it throws (triggering a rebuild) when the stored `min_index_interval`
+differs from the table's, when the derived effective interval exceeds `max_index_interval`, or
+when the offset table looks big-endian
+([`IndexSummary.java#L423-L467`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L423-L467)).
+
+### Interval width and downsampling
+
+Sample spacing equals `min_index_interval` partitions **only at full sampling**. Under
+index-summary memory pressure Cassandra *downsamples* an existing summary, dropping samples
+according to a fixed pattern
+([`Downsampling.getSamplingPattern`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L48-L76)),
+which widens intervals. Two different quantities matter, and confusing them is a correctness
+trap for reader authors:
+
+- **Average** width — `BASE_SAMPLING_LEVEL / sampling_level * min_index_interval`, where
+  [`BASE_SAMPLING_LEVEL = 128`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L34).
+  This is
+  [`IndexSummary.getEffectiveIndexInterval()`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L208-L211),
+  a `double` estimate.
+- **Exact per-interval** width — `getEffectiveIndexIntervalAfterIndex(index)`, computed from
+  the downsampling pattern
+  ([`Downsampling.java:116-123`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L116-L123)).
+  Individual intervals of a downsampled summary are **uneven, and the widest one can exceed
+  the average**: at `min_index_interval = 128, sampling_level = 96` the average is ~170.7
+  partitions while the widest actual interval is 256. Cassandra's read path uses the exact
+  per-interval value, never the average.
+
+> **Warning:** an entry-count cap derived from the *average* width can cut a walk short
+> before a present key that legitimately sits further into a widened interval. Bound a walk
+> by the authoritative next-sample **byte position** where one exists, and by the exact
+> per-interval width otherwise.
+
+### Token-range iteration
+
+Token-range scans use the same summary search, entered by token rather than by key. Cassandra
+turns a range bound into a "fake" key via
+[`Token.minKeyBound()`/`maxKeyBound()`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/dht/Token.java#L204-L252)
+— a `PartitionPosition` that compares by token first — so
+[`BigTableScanner.seekToCurrentRangeStart()`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java#L67-L97)
+can call
+[`BigTableReader.getIndexScanPosition(range.left)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L493-L499)
+→ `IndexSummary.getScanPosition` and get the floor sample's `Index.db` position. It then
+walks forward, skipping entries until one sorts above `range.left` or falls inside the range.
+`IndexSummary` also exposes range-aware sample enumeration directly —
+[`getSampleIndexesForRanges`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L278)
+and
+[`getKeySamples(Range<Token>)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L320).
+
+So token-range iteration *is* summary-guided: what `Summary.db` lacks is a stored token, not
+the ability to enter by token. There is no `getPosition(Token)` API —
+[`getPosition(int)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L188-L191)
+takes a sample index; tokens enter through the key-bound comparison above, and a reader
+recomputes each sample's token from its stored raw key.
+
+> **CQLite implementation note.** CQLite mirrors this shape for BIG: a reader with a usable
+> `Summary.db` opens the partition index lazily and resolves a point read through exactly one
+> summary-bounded `Index.db` interval, while a token-range scan starts its forward walk at the
+> floor sample. Details, including how CQLite classifies an interval miss, are in Ch.10 and
+> Appendix C.
 
 ### BTI Notes
 - BTI SSTables do **not** use `Index.db` or `Summary.db` at all. The BIG-format
@@ -239,7 +383,15 @@ Note: Token-based iteration is not directly supported by Summary.db since tokens
 ### Key Takeaways
 - `Index.db` maps partition keys to positions; `Summary.db` accelerates binary search.
 - Sampling reduces memory while preserving fast seeks.
-- Token-range iteration combines summary jumps with index scans.
+- Both components are in **decorated-key order** — partitioner token first, raw key bytes
+  (unsigned) only as a tie-break. Never binary-search them with a raw-byte comparator.
+- A point lookup walks **one summary interval** of `Index.db`, not the whole file; open reads
+  only `Summary.db` *unless* the summary is missing/corrupt/interval-mismatched, in which case
+  it is rebuilt from `Index.db`.
+- Interval width is `min_index_interval` only at full sampling; a downsampled summary has
+  uneven, wider intervals, and the widest can exceed the average-width formula.
+- Token-range iteration **is** summary-guided (enter by key bound, walk forward); what
+  `Summary.db` omits is a stored token, not token entry.
 
 ## Writing Index.db
 
@@ -302,7 +454,9 @@ This information is used by Summary.db sampling to record accurate Index.db posi
 Index.db stores the **raw partition key bytes** length-prefixed; it does NOT store an MD5
 digest. (A prior version of this guide incorrectly described an MD5 digest — see Issue #552.)
 Because the raw key is on disk, readers can:
-1. Binary search / scan Index.db comparing the raw partition key directly
+1. Compare the raw partition key directly while walking `Index.db` forward from the summary
+   sample (entries are variable-length, so `Index.db` itself cannot be binary-searched — the
+   binary search happens in `Summary.db`)
 2. Use the inline `data_offset` to seek straight into Data.db
 3. Avoid any hash-collision handling at the index layer
 
@@ -345,7 +499,11 @@ Source: [`BigFormatPartitionWriter.java#L49,L213`](https://github.com/apache/cas
 
 ### Token Ordering Requirement
 
-Index.db entries MUST be written in token order, matching Data.db partition ordering. This is enforced by the writer:
+`Index.db` entries MUST be written in **decorated-key** order, matching `Data.db` partition
+ordering: token first, raw key bytes (unsigned) as the tie-break — the same order readers binary
+search (see "Sample order is partitioner order, not byte order" above).
+
+CQLite's writer enforces this with a strictly-increasing token check:
 
 ```rust
 if key.token <= last_token {
@@ -353,29 +511,58 @@ if key.token <= last_token {
 }
 ```
 
+> **CQLite implementation note.** That check is *stricter* than the format requires: it rejects
+> two distinct partition keys that hash to the same 64-bit Murmur3 token, which the format
+> permits and orders by comparing raw key bytes. A 64-bit token collision is vanishingly rare in
+> practice, so this is a conservative refusal rather than a correctness problem — but a writer
+> aiming for full format generality would tie-break on the raw key instead of erroring.
+> Source: `cqlite-core/src/storage/sstable/writer/incremental.rs:105-112` (and `:213-220`).
+
 ## Writing Summary.db
 
 Summary.db samples Index.db entries for efficient partition lookup without reading the full index.
 
 ### Sampling Strategy
 
-**Default Sampling Interval**: 128 entries
+**Default Sampling Interval**: 128 partitions (`min_index_interval`)
 
-Summary.db samples every Nth entry from Index.db where N = `min_index_interval`. The first entry is always sampled (entry 0), then entries at intervals of 128 (entry 128, 256, 384, etc.).
+`Summary.db` samples every Nth `Index.db` entry where N = `min_index_interval`. The first entry
+is always sampled (entry 0), then entries 128, 256, 384, … at full sampling.
 
 **Sampling Logic:**
 ```rust
-// Sample first entry and every 128th entry
-if entry_count % 128 == 0 {
+// Sample the first partition and every min_index_interval-th partition thereafter
+if partition_index % min_index_interval == 0 {
     summary_writer.add_entry(&key, index_offset)?;
 }
 ```
+
+Cassandra expresses the same rule as a running `nextSamplePosition` advanced by
+`minIndexInterval` per sample, with a `startPoints` filter that *skips* the sample positions a
+target `sampling_level` drops
+([`IndexSummaryBuilder.maybeAddEntry`/`setNextSamplePosition`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryBuilder.java#L200-L243)).
+At `sampling_level == BASE_SAMPLING_LEVEL == 128`, `Downsampling.getStartPoints` returns an empty
+array (`numRounds == 0`,
+[`Downsampling.java#L125-L147`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L125-L147)),
+so nothing is skipped and the two formulations coincide; a builder constructed at a lower level is
+what produces uneven, wider intervals.
+
+`size_at_full_sampling` is `ceil(keys_written / min_index_interval)`
+([`IndexSummaryBuilder.java#L273`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryBuilder.java#L273)),
+which equals `entries_count` for a summary written at full sampling.
 
 **Trade-offs:**
 - Smaller interval (e.g., 64) = more memory, faster lookups
 - Larger interval (e.g., 256) = less memory, more I/O during lookups
 
 Cassandra default of 128 provides a good balance for most workloads.
+
+> **Uniform spacing is a *write-time* property.** A freshly written summary has
+> `sampling_level == BASE_SAMPLING_LEVEL == 128`, so every interval is exactly
+> `min_index_interval` partitions wide. Cassandra may later **downsample** an existing summary
+> under index-summary memory pressure, which drops samples in a fixed pattern and leaves the
+> surviving intervals uneven and wider. Readers must therefore not assume uniform spacing — see
+> "Interval width and downsampling" above.
 
 ### When to Sample
 
@@ -389,7 +576,7 @@ let data_offset = data_writer.write_partition(&key, &mutations, &schema)?;
 let entry_info = index_writer.add_partition(&key, data_offset)?;
 
 // Sample for Summary.db if at interval boundary
-if sample_counter % 128 == 0 {
+if sample_counter % min_index_interval == 0 {
     summary_writer.add_entry(&key, entry_info.index_offset)?;
 }
 sample_counter += 1;
@@ -419,7 +606,8 @@ buffer.extend_from_slice(&index_position.to_le_bytes());
 
 ### Summary.db Offset Table
 
-The offset table records the starting position of each entry within the entry data section.
+The offset table records the starting position of each entry, measured from the **start of the
+offset table itself** — so `offsets[0] == entries_count * 4`, not `0` (see "Offset Table" above).
 
 **Critical Gotcha**: The offset table uses **little-endian** encoding (unlike all other Cassandra components):
 
@@ -431,17 +619,28 @@ for offset in entry_offsets {
 ```
 
 **Offset Calculation:**
+
+Two details are easy to get wrong here, and Cassandra's deserializer rejects both mistakes:
+
+- Offsets are **absolute within the combined `(offset_table + entry_data)` region**, so
+  `offset[0] == offset_table_size` (`= entries_count * 4`), not `0`. Cassandra adds this
+  `baseOffset` on serialize and subtracts it on deserialize
+  ([`IndexSummary.java#L405-L420`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L405-L420)).
+  CQLite biases its offsets the same way (issue #666).
+- The per-entry `position` is **little-endian**, matching the offset table (issue #1054).
+
 ```rust
+let offset_table_size = entries.len() * 4;      // u32 per entry
 let mut entry_offsets = Vec::new();
 let mut entry_data = Vec::new();
 
 for entry in entries {
-    // Record offset BEFORE writing entry data
-    entry_offsets.push(entry_data.len() as u32);
+    // Record the ABSOLUTE offset BEFORE writing entry data
+    entry_offsets.push((offset_table_size + entry_data.len()) as u32);
 
-    // Write key and position
+    // Write key (no length prefix) and Index.db position (little-endian)
     entry_data.extend_from_slice(&entry.key);
-    entry_data.extend_from_slice(&entry.position.to_be_bytes());
+    entry_data.extend_from_slice(&entry.position.to_le_bytes());
 }
 ```
 
@@ -466,14 +665,22 @@ fn write_header(&self, buffer: &mut Vec<u8>, entries_count: u32, summary_entries
     // Source: Downsampling.java:34 (BASE_SAMPLING_LEVEL=128); IndexSummary.java:88-94,226-229
     buffer.extend_from_slice(&self.sampling_level.to_be_bytes()); // 128 for new SSTables
 
-    // size_at_full_sampling (u32, BE) - ESTIMATED entry count at full sampling.
-    // Formula: total_partition_count / min_index_interval  (NOT entries_count).
+    // size_at_full_sampling (u32, BE) - entry count this summary WOULD have at full sampling.
+    // Cassandra computes ceil(keys_written / min_index_interval), NOT entries_count.
     // After downsampling, entries_count < size_at_full_sampling; they are only equal for a
-    // freshly written SSTable when sampling_level == BASE_SAMPLING_LEVEL == 128.
-    // Source: IndexSummary.java:235-237 (getMaxNumberOfEntries() returns sizeAtFullSampling)
+    // freshly written SSTable where sampling_level == BASE_SAMPLING_LEVEL == 128.
+    // Source: IndexSummaryBuilder.java:273 (value written); IndexSummary.getMaxNumberOfEntries()
     buffer.extend_from_slice(&self.size_at_full_sampling.to_be_bytes());
 }
 ```
+
+> **`summary_entries_size` is the combined region length, not just the key/position bytes.**
+> Cassandra writes `getOffHeapSize()` = `entries_count * 4 + entries_length` — the offset table
+> plus the entry data
+> ([`IndexSummary.java#L401-L405`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L401-L405),
+> [`#L258-L261`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L258-L261)).
+> A reader that treats it as the entry-data length alone will mis-locate the trailing
+> first/last keys.
 
 **summary_entries_size Calculation:**
 ```rust
@@ -606,10 +813,43 @@ Summary.db:
   [Entry 128 sampled: key + index_offset=X]  ← (if 128+ partitions)
 ```
 
-**Lookup Flow (Read):**
-1. Summary.db: Binary search by key → find nearest entry → get Index.db offset
-2. Index.db: Scan from offset → find exact partition → get Data.db offset
-3. Data.db: Seek to offset → read partition data
+For the read direction of these same offsets, see "Partition Lookup Flow" above — the
+summary sample bounds where the `Index.db` walk starts and ends, so the walk is never a
+whole-file scan when a usable `Summary.db` is present.
+
+### Read-Side: Full-Scan Enumeration (CQLite implementation note)
+
+Not every read is a point lookup: compaction and unfiltered `SELECT` enumerate *every*
+partition of an SSTable. This subsection is **CQLite behavior**, not a format requirement —
+Cassandra's own enumeration is `BigTableScanner` over `Index.db`. CQLite has three
+enumeration shapes for uncompressed BIG, distinguished by what they hold in memory:
+
+| Shape | `Index.db` entries | Result rows | Source |
+|---|---|---|---|
+| Materializing | whole map resident | whole `Vec` before first emit | `reader/data_access/full_index_scan.rs` |
+| Streaming (#2361/#2366) | whole map resident | emitted per partition | `reader/data_access/full_index_stream.rs` |
+| Summary-guided streaming (#2412/#2413) | forward-streamed, window-bounded | emitted per partition | `reader/data_access/summary_scan/mod.rs` |
+
+Two properties are worth knowing when reasoning about scan I/O:
+
+- **Streaming emission is not the same as a streaming index.** The #2361 streaming walk still
+  materializes the `Index.db` entry map before walking it
+  (`full_index_stream.rs:161` calls `ensure_materialized`); what it avoids is buffering the
+  whole *result*. Only the Summary-guided walk streams the index itself, starting from an
+  authoritative summary sample position (`summary_scan/mod.rs:201-220`).
+- **Sequential windowing beats per-partition positioned reads.** Because entries are visited
+  in ascending `data_offset` order (== physical `Data.db` order), the uncompressed walk fills
+  one forward-only read window (target 4 MiB, grown to fit an oversized partition —
+  `full_index_stream.rs:68`) and serves many consecutive partitions from it, instead of one
+  `seek` + `read_exact` + CRC per partition. Work scales with
+  `data_section_len / window`, not with partition count. Measured on the in-repo fixtures:
+  500 small partitions went from 500 index probes and 500 positioned reads to 0 probes and 1
+  window refill; a 51-partition / ≈9.9 MiB fixture needs 3 window refills and 0 probes
+  (`full_index_stream_tests.rs:408-410,621-623`).
+
+Neither property changes a single on-disk byte — both are consequences of the ordering
+guarantee that `Index.db` entries ascend in token order and therefore in `Data.db` offset
+order.
 
 ### Memory Efficiency
 
@@ -638,12 +878,34 @@ Memory usage is bounded by:
   - RowIndexEntry binary format: [`RowIndexEntry.java#L57-L68`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java#L57)
   - DeletionTime "oa" serialization (mfda first): [`DeletionTime.java#L210-L219`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/DeletionTime.java#L210)
   - BASE_SAMPLING_LEVEL=128: [`Downsampling.java#L34`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L34)
+  - Decorated-key comparator (token first, then `compareUnsigned`): [`DecoratedKey.java#L79-L102`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/DecoratedKey.java#L79-L102)
+  - Murmur3 token comparison: [`Murmur3Partitioner.java#L177-L179`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java#L177-L179)
+  - Summary binary search + scan position: [`IndexSummary.java#L127-L152`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L127-L152), [`#L361-L373`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L361-L373)
+  - Average vs exact interval width: [`IndexSummary.java#L208-L211`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L208-L211), [`#L273-L276`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L273-L276), [`Downsampling.java#L116-L123`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L116-L123)
+  - Bounded `EQ` index walk: [`BigTableReader.java#L277-L320`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L277-L320)
+  - Summary loaded at open; rebuilt from `Index.db` only when absent/corrupt/interval-mismatched: [`BigSSTableReaderLoadingBuilder.java#L96-L130`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L96-L130), [`#L249-L266`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L249-L266)
+  - Token-range scan start: [`BigTableScanner.java#L67-L97`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java#L67-L97), [`BigTableReader.java#L493-L499`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L493-L499), [`Token.java#L204-L252`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/dht/Token.java#L204-L252)
+  - Summary serialize/deserialize (absolute offsets, LE detection, rebuild triggers): [`IndexSummary.java#L399-L420`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L399-L420), [`#L423-L476`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L423-L476)
+  - `summary_entries_size` = offset table + entry data: [`IndexSummary.getOffHeapSize`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L258-L261)
+  - Sampling rule + `size_at_full_sampling`: [`IndexSummaryBuilder.java#L200-L243`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryBuilder.java#L200-L243), [`#L273`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryBuilder.java#L273), [`Downsampling.getStartPoints`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L125-L147)
+  - `data_offset` is an uncompressed-stream position (no `Data.db` header): [`BigTableWriter.java#L95-L113`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java#L95-L113)
 
 - CQLite Implementation:
   - `cqlite-core/src/storage/sstable/writer/index_writer.rs` - Index.db writer
   - `cqlite-core/src/storage/sstable/writer/summary_writer.rs` - Summary.db writer
   - `cqlite-core/src/storage/sstable/writer/data_writer.rs` - Data.db writer
   - `cqlite-core/src/storage/sstable/writer/mod.rs` - SSTableWriter coordinator
+  - `cqlite-core/src/storage/sstable/summary_reader/interval.rs` - token-ordered summary
+    search + bounded `Index.db` interval read
+  - `cqlite-core/src/storage/sstable/summary_reader/mod.rs:229` -
+    `scan_start_position_for_token` (floor sample for a token-range walk)
+  - `cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs` - streaming
+    walk + 4 MiB sequential read window
+  - `cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs` -
+    Summary-guided streaming walk with token pushdown
+  - `cqlite-core/src/storage/sstable/index_reader/mod.rs:52-60` - `key_digest` field is a
+    historical misnomer holding raw key bytes (Issue #552)
+  - `cqlite-core/src/storage/sstable/writer/incremental.rs:105-112` - strict token-order gate
 
 For implementation details, see Appendix C.
 

--- a/docs/sstables-definitive-guide/chapters/10-point-reads-and-slices.md
+++ b/docs/sstables-definitive-guide/chapters/10-point-reads-and-slices.md
@@ -17,6 +17,48 @@ Diagram: read-path decision tree
 
 For an implementation walkthrough of the read flow, see Appendix C.
 
+### Point Lookup Cost (BIG, Cassandra 5.0)
+
+The BIG read path is bounded at every step; nothing in a point read is proportional to the
+SSTable's partition count, *provided* a usable `Summary.db` exists.
+
+| Step | Work | Notes |
+|---|---|---|
+| First/last key range check | comparison only | skips the SSTable entirely when out of range |
+| Key cache | hash lookup | checked before `Summary.db` |
+| Bloom (`Filter.db`) | O(k) hashes | negative → stop |
+| `Summary.db` binary search | O(log s), `s` = samples | decorated-key comparator |
+| `Index.db` interval walk | one interval's entries | bound = exact per-interval width |
+| `Data.db` read | positioned read | promoted index narrows within-partition seeks |
+
+Source order and short-circuits:
+[`BigTableReader.getRowIndexEntry`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L215-L360).
+
+**Open reads the summary, not the index.** A BIG reader loads `Summary.db` (plus first/last
+keys) at open; it walks `Index.db` only to **rebuild** a summary or Bloom filter that is
+absent, corrupt, or written with a different `min_index_interval`
+([`BigSSTableReaderLoadingBuilder.java#L96-L130`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L96-L130)).
+Treat "cheap open" as conditional on a usable `Summary.db`, never unconditional.
+
+**Interval width is not a constant.** `min_index_interval` (default 128) is the spacing only at
+full sampling. A downsampled summary has uneven, wider intervals, and the widest can exceed the
+average `min_index_interval * 128 / sampling_level`; Cassandra bounds its walk with the exact
+per-interval value
+([`IndexSummary.java#L273-L276`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L273-L276)).
+
+**Degraded inputs cost more.** With `Summary.db`/`Index.db` missing, a reader has no bounded
+entry point and must scan. CQLite logs a warning naming the absent components and falls back to
+a full sequential scan of `Data.db` in that case (issue #2295) — correct, but O(data size) per
+read.
+
+> **CQLite implementation note.** With a usable `Summary.db`, CQLite reads exactly the covering
+> interval's `[start, end)` bytes for a point read and classifies a miss by whether that
+> interval is **end-bounded** (a real next sample delimits it above): end-bounded miss =
+> authoritative absence; a miss in the last, read-to-EOF interval falls back to a whole-file key
+> scan, since a truncated tail can only drop entries there. Sources:
+> `cqlite-core/src/storage/sstable/reader/summary_point.rs:53-76`,
+> `cqlite-core/src/storage/sstable/reader/data_access/big_point.rs:140-177`.
+
 ## Slices and Range Reads
 
 - Slices can skip to approximate positions via `Summary.db`, then advance in `Index.db`.
@@ -26,7 +68,12 @@ For an implementation walkthrough of the read flow, see Appendix C.
 - When partitions are wide, a promoted index enables O(log n) within-partition seeks for clustering slices instead of scanning all rows. Ensure readers check for promoted index presence and fall back correctly when absent.
 
 ### Iterators for Range Scans
-- Expose an iterator interface that yields `(key, value)` pairs over token ranges: initialize from `Summary.db` token, then advance through `Index.db` entries. Provide `next()`/`peek()` and bounded `limit` support.
+- Expose an iterator interface that yields `(key, value)` pairs over token ranges: initialize at
+  the **floor sample** for the range's lower bound (the summary search entered by a token key
+  bound, not by a stored token — `Summary.db` stores none), then advance through `Index.db`
+  entries, skipping those below the bound. Provide `next()`/`peek()` and bounded `limit` support.
+  Cassandra's equivalent is
+  [`BigTableScanner.seekToCurrentRangeStart()`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java#L67-L97).
 
 ### BTI Read Path Notes
 - BTI preserves the decision flow but the index entry payload may differ. Gate parsing using the `Descriptor` format; the iterator and seek abstractions remain the same.
@@ -36,8 +83,13 @@ Promoted index (BIG):
 - Readers detect presence and use it for O(log m) within-partition seeks; otherwise, fall back to sequential scan within the partition.
 
 ### Complexity Notes
-- Point read: Bloom O(1), Summary binary search O(log s), Index probe O(log n) or O(1) if direct-offset; fallback scan O(n).
-- Slice read: Initialization O(log s) + sequential advancement; with promoted index, within-partition seek O(log m) over clustering entries.
+- Point read (usable `Summary.db`): Bloom O(k) hashes, summary binary search O(log s) over `s`
+  samples, then a **forward walk of one `Index.db` interval** — not a binary search over
+  `Index.db`, which is not randomly addressable by key. Fallback scan is O(data size) when the
+  index components are absent or a truncated tail cannot be ruled out. See "Point Lookup Cost"
+  above for the per-step table.
+- Slice read: initialization O(log s) + sequential advancement; with a promoted index,
+  within-partition seek is O(log m) over the partition's `IndexInfo` blocks.
 
 ## Minimal Example (trimmed)
 
@@ -49,12 +101,19 @@ From `test_basic/simple_table`:
 - Bloom optimizes negative lookups; positives proceed to index/summary.
 - Summary sampling accelerates binary search; promoted index helps wide rows.
 - Range scans mix summary jumps with sequential index advances.
+- Cheap open and a bounded `Index.db` walk both depend on a **usable `Summary.db`**; without one
+  the summary is rebuilt from `Index.db`, and without an index at all the read degrades to a
+  full `Data.db` scan.
+- Bound the interval walk by the exact per-interval width (or the next sample's byte position),
+  never by the average width of a downsampled summary.
 
 ### References
 - Cassandra 5.0.8 (pinned):
-  - `IndexSummary` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/IndexSummary.java
+  - `IndexSummary` (note the 5.0 package path `io.sstable.indexsummary`) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java
   - `SinglePartitionReadCommand` (read decision tree L701–L807) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java#L701-L807
-  - `BigTableReader` (per-SSTable read order L220–L278) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L220-L278
+  - `BigTableReader.getRowIndexEntry` (per-SSTable read order L215–L360) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L215-L360
+  - Exact per-interval walk bound — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L273-L276
+  - Summary load vs rebuild at open — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L96-L130
   
 For implementation details, see Appendix C.
 

--- a/docs/sstables-definitive-guide/chapters/21-how-to-find-a-row-by-key.md
+++ b/docs/sstables-definitive-guide/chapters/21-how-to-find-a-row-by-key.md
@@ -6,8 +6,14 @@ seeks and failure paths.
 ### Overview
 - Bloom check (`Filter.db`) → early negative exit when absent
 - BIG: Summary jump (`Summary.db`) → locate `index_offset`; **BTI has no `Summary.db`**
-- Index scan (`Index.db` for BIG, `Partitions.db` trie for BTI) → get `data_offset`
+- Index scan (`Index.db` for BIG, `Partitions.db` trie for BTI) → get `data_offset`, bounded by
+  the summary interval for BIG
 - Data read (`Data.db`) → parse partition + rows via `SerializationHeader`
+
+Cassandra also short-circuits before any of this: the reader compares the target to the
+SSTable's first/last keys and skips the file entirely when out of range, and consults the key
+cache before touching `Summary.db`
+([`BigTableReader.java#L228-L275`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L228-L275)).
 
 ### BIG (legacy/newbig) flow
 
@@ -15,12 +21,24 @@ seeks and failure paths.
 - Load `Filter.db` if present; `might_contain(decorated_key)`.
 - Negative → stop. Positive → continue.
 
-**2) Summary**
-- Binary search **partition keys** (decorated-key order, token-first byte comparison) to find
-  the nearest `index_offset` into `Index.db`.
-- Source: `IndexSummary.binarySearch(PartitionPosition key)` —
-  [`IndexSummary.java#L127-L152`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L127)
-- Note: the binary search operates on **decorated keys**, not raw token values.
+**2) Summary** — O(log s) over `s` samples
+- Binary search the samples in **decorated-key order**: partitioner token first
+  (`Murmur3Partitioner.LongToken.compareTo` = `Long.compare`), raw key bytes compared
+  *unsigned* only as a tie-break. A raw-byte (`memcmp`) comparator is **wrong** and lands in
+  the wrong interval.
+- The result is the **floor** sample — the greatest sample whose decorated key is `<= target`
+  — whose `position` is where the `Index.db` walk starts. The *next* sample's position is
+  where the covering interval ends. No sample `<= target` yields position `0` (walk from the
+  index start).
+- Sources: [`IndexSummary.binarySearch(PartitionPosition)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L127-L152)
+  and [`getScanPositionFromBinarySearchResult`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L367-L373);
+  comparator in [`DecoratedKey.java#L93-L102`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/DecoratedKey.java#L93-L102).
+- Note: the binary search operates on **decorated keys**, not raw token values — and the token
+  is not stored in the entry, so it is recomputed from the sample's raw key.
+- A BIG reader loads `Summary.db` at open and does **not** scan `Index.db` — unless the
+  summary is absent, corrupt, or was written with a different `min_index_interval`, in which
+  case it is rebuilt by walking `Index.db`
+  ([`BigSSTableReaderLoadingBuilder.java#L96-L130`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L96-L130)).
 
 **3) Index**
 - From `index_offset`, parse entries sequentially until the target is found or passed.
@@ -51,9 +69,37 @@ seeks and failure paths.
   `CompressionInfo.db`.
 - Parse partition header and rows using `SerializationHeader`.
 
+**Bounded interval scan — the walk is not open-ended**
+
+The `Index.db` walk in step 3 is bounded by the summary interval the floor sample opens, so an
+`EQ` lookup touches roughly one interval's worth of entries, not the whole file:
+
+- Cassandra computes the bound as
+  [`getEffectiveIndexIntervalAfterIndex(sampledIndex)`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L273-L276)
+  — the **exact** width of *this* interval, from the downsampling pattern. While
+  `i <= effectiveInterval` it compares raw key bytes (fast path); beyond that it compares
+  decorated keys and returns "absent" the moment an index key sorts above the target
+  ([`BigTableReader.java#L277-L320`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L277-L320)).
+- Width is `min_index_interval` only at full sampling. A downsampled summary
+  (`sampling_level < 128`) has uneven, wider intervals, and the widest can **exceed** the
+  average-width formula `min_index_interval * 128 / sampling_level` (at `128`/`96`: average
+  ~170.7, widest 256). Never bound a walk by the average.
+
+> **CQLite implementation note.** CQLite's BIG reader, when a usable `Summary.db` is present,
+> reads exactly the covering interval's `[start, end)` bytes and classifies a miss by whether
+> the interval is **end-bounded** (delimited above by a real next sample) — an end-bounded
+> miss is authoritative absence, while a miss in the last (read-to-EOF) interval falls back to
+> a whole-file key scan, because a tail-truncated `Index.db` can only lose entries there.
+> Source: `cqlite-core/src/storage/sstable/reader/summary_point.rs:53-76` and
+> `cqlite-core/src/storage/sstable/reader/data_access/big_point.rs:140-177`.
+
 **Failure/negative path**
 - If raw key != target → call `Serializer.skip()` and advance to the next Index.db entry.
-- If no entry matches within the scan window → partition absent (false-positive bloom hit).
+- If the walk leaves the covering interval without a match, the partition is absent from this
+  SSTable (for an `EQ` search reached through a positive Bloom check, a false-positive Bloom
+  hit). This conclusion is only as authoritative as the interval bound: it assumes the
+  interval's bytes are intact, which is why a reader that cannot rule out a truncated tail
+  must widen the search rather than report absence.
 
 ---
 
@@ -100,7 +146,9 @@ Mismatch → stop. Use `~indexPos` as `dataFilePosition`.
 ### Byte-level seek checklist
 
 - **BIG — Summary → Index:** verify `index_offset` is within file bounds; summary entries are
-  in decorated-key (token-first) order.
+  in decorated-key order (partitioner token first, raw bytes unsigned as tie-break), so search
+  them with a token-order comparator, never `memcmp`. Bound the forward walk by the next
+  sample's position (or by the exact per-interval width), not by the average interval width.
 - **BIG — Index → Data:** the leading `u16` is the key byte length; compare raw key bytes to
   target. No marker, no digest. Call `Serializer.skip()` on mismatch.
 - **BTI — Partitions.db → Data:** sign-bit of `indexPos` routes to `Rows.db` (>= 0) or
@@ -130,6 +178,9 @@ Mismatch → stop. Use `~indexPos` as `dataFilePosition`.
 
 ### References
 - `IndexSummary` (5.0.8): [`org.apache.cassandra.io.sstable.indexsummary.IndexSummary`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java)
+- Decorated-key comparator (token first, then unsigned bytes): [`DecoratedKey.java#L79-L102`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/DecoratedKey.java#L79-L102), [`Murmur3Partitioner.java#L177-L179`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java#L177-L179)
+- Exact per-interval walk bound: [`IndexSummary.java#L273-L276`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L273-L276), [`Downsampling.java#L116-L123`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L116-L123)
+- Summary loaded at open (rebuild only when absent/corrupt/interval-mismatched): [`BigSSTableReaderLoadingBuilder.java#L96-L130`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java#L96-L130)
 - BIG reader: [`BigTableReader.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java)
 - BIG raw-key comparison (no digest): [`BigTableReader.java#L298-L325`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L298)
 - BTI has no Summary.db: [`BtiFormat.java#L100-L108`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java#L83)


### PR DESCRIPTION
Closes #2952

**DOCS-ONLY (zero `.rs`)** — reviewers confirm via `git diff --name-only origin/main...HEAD` (4 files, all under `docs/sstables-definitive-guide/chapters/`).

Corrects the partition-index / `Summary.db` lane of the SSTable guide. Every claim below was independently confirmed against Apache Cassandra at tag `cassandra-5.0.8`.

## Corrections (each with its authority — all CONFIRMED at `cassandra-5.0.8`)

1. **`Summary.db` numeric fields are LITTLE-endian.** `IndexSummaryBuilder.java:127` (`entries…order(ByteOrder.LITTLE_ENDIAN)`) plus `Memory.getLong` → `LittleEndianMemoryUtil`. Reproduced on `simple_table` (8 samples): positions decode LE as 2791 / 5607 / 8423 / 11239 / 14055 / 16871 / 19687 — monotonically ascending and all < the 21975-byte `Index.db`; big-endian would read ~1.6e19. This is the kind of error that silently produces a "working" parser on one sample and garbage on the next.

2. **Key ordering is token-first, then UNSIGNED raw-key compare.** `DecoratedKey.java:100-101` (`compareUnsigned`); the token compare is `Murmur3Partitioner.java:179` `Long.compare`.

3. **The read path uses the EXACT per-index sampling interval, not the average.** `IndexSummary.java:273-276` → `Downsampling.java:116-123`. `getEffectiveIndexInterval()` (`IndexSummary.java:208-211`) is a `double` AVERAGE and must not be used as a bound: recomputed at `min_index_interval=128`, sampling level 96, the average is 170.667 but the **true widest interval is 256**. Documented with an explicit warning, since treating the average as a bound under-reads.

4. **`Summary.db` `baseOffset` = `offsetCount * 4`.** `IndexSummary.java:411`, with rejection at `:465-467`. Reproduced: `composite_key_table` `Summary.db` file offset `0x18` = `04 00 00 00` = LE 4 = offsetCount(1) × 4. `summary_entries_size` at `0x1c` = `4 + 16 + 8` also byte-verified.

5. **`Index.db` entry positions are raw `Data.db` file offsets with no header adjustment.** `BigTableWriter.java:102` uses `partitionWriter.getInitialPosition()`. Reproduced: `uncompressed_table` `Index.db` entry 1's vint at `0x26` (`80 c5` → 197) points at `Data.db@0xc5`, whose 20 bytes are byte-identical to that entry's key; entry 0's offset 0 ↔ `Data.db` byte 0.

6. **`size_at_full_sampling` = `ceil(keys_written / min_index_interval)`.** `IndexSummaryBuilder.java:273`; the two sampling formulations coincide because `Downsampling.java:131` gives `numRounds=0` at sampling level 128 (empty `getStartPoints`).

7. **Cassandra's scan seek is by Token, via `getPosition(int)` only.** `BigTableScanner.java:67-97` → `BigTableReader.java:493-499` → `IndexSummary.java:361-364`. There is **no** `getPosition(Token)` overload; the only `getPosition` is `:188`.

8. **`Summary.db` rebuild is gated.** `loadSummary()` L249-266 plus the rebuild gate at L96-130 (`rebuildFilter||rebuildSummary`). The draft's unconditional-rebuild claim was removed and replaced with a reader-algorithm note.

## Sweep

Removed a stale super-linear-open perf pairing (the 312s figure is #2385's title, not a documented ratio). #2385 / #2361 / #1054 / #2412 / #2430 / #2302 / #2299 (plus #666 / #552 / #2295 / #517) all verified CLOSED — nothing is documented as open-when-closed or fixed-when-open.

## Authority separation

Every CQLite claim sits inside a labeled "CQLite implementation note" block (`interval.rs` / `entry_cap`, `full_index_stream.rs:161` `ensure_materialized`); no CQLite `file:line` is presented as format authority. No #28 heuristic guidance — the big-endian discussion reports Cassandra's own code, not a sniffing recipe. No #1406 compressed-write overclaim. Every cited CQLite `file:line` verified to exist and to say what is claimed.

## Verification

Adversarially verified against `cassandra-5.0.8` — **9 of 9 claims CONFIRMED, verdict SHIP**, zero required fixes. Hex blocks 6/7/8 were re-derived independently with `xxd` on `composite_key_table`, `uncompressed_table`, `simple_table`, and `compression_test_table`; every documented byte matches the fixture exactly.

Lite gate: `RESULT: PASS` at `a5d229c1f` (file-size, fmt, clippy, roborev-lints, scoped-tests).

## Known follow-up (non-blocking, filed separately)

`06-index-and-summary.md` is **912 lines** vs `STYLE_GUIDE.md:50`'s ≤500 target and should be split. The gate's file-size ratchet is `.rs`-only, so it does not catch this; precedent already on `main`: `05-data-db-format.md` at 1081 lines and `appendix-f` at 1552.
