### PR TITLE
fix(#3006): publish the three unpublished guide appendices + guard against a fourth

### DIFF
--- a/docs/sstables-definitive-guide/chapters/appendix-g-algorithm-reference.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-g-algorithm-reference.md
@@ -390,10 +390,9 @@ fn test_compression_format(algorithm: &str, data_file: &str) {
 
 ## See Also
 
-- Full specification: appendix-g-compression-chunk-formats.md
-- Quick reference: appendix-g-quick-reference.md
-- Research notes: /docs/archive/issues/COMPRESSION_CHUNK_FORMAT_RESEARCH.md
-- CQLite source: `/cqlite-core/src/storage/sstable/compression.rs`
+- Full specification: [Appendix G: Compression Chunk Formats](./appendix-g-compression-chunk-formats.md)
+- Quick reference: [Appendix G Quick Reference](./appendix-g-quick-reference.md)
+- CQLite source: `cqlite-core/src/storage/sstable/compression.rs`
 - [`CompressionMetadata.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java)
 - [`schema/CompressionParams.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/schema/CompressionParams.java) — `DEFAULT_CHUNK_LENGTH = 1024 * 16` (line 47)
 - [`BigFormat.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java) — `hasMaxCompressedLength` gate (line 401)

--- a/docs/sstables-definitive-guide/chapters/appendix-g-quick-reference.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-g-quick-reference.md
@@ -135,9 +135,9 @@ pub fn decompress(algorithm: &str, data: &[u8]) -> Result<Vec<u8>> {
 
 ## Files to Reference
 
-- **Full spec**: `/docs/sstables-definitive-guide/chapters/appendix-g-compression-chunk-formats.md`
-- **Research notes**: `/docs/archive/issues/COMPRESSION_CHUNK_FORMAT_RESEARCH.md`
-- **CQLite code**: `/cqlite-core/src/storage/sstable/compression.rs`
+- **Full spec**: [Appendix G: Compression Chunk Formats](./appendix-g-compression-chunk-formats.md)
+- **Algorithm reference**: [Appendix G: Algorithm Reference Sheet](./appendix-g-algorithm-reference.md)
+- **CQLite code**: `cqlite-core/src/storage/sstable/compression.rs`
 - **Cassandra source**: `apache/cassandra:5.0.8` in `/src/java/org/apache/cassandra/io/compress/`
   - [`CompressionMetadata.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java)
   - [`CompressedSequentialWriter.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java)

--- a/website/scripts/sync-format-guide.mjs
+++ b/website/scripts/sync-format-guide.mjs
@@ -229,6 +229,25 @@ console.log('[sync-format-guide] Starting...');
     f => !onDisk.includes(f)
   );
   const doublyListed = [...UNPUBLISHED_BY_DESIGN.keys()].filter(f => FILE_TO_SLUG.has(f));
+  // A CHAPTERS entry whose source is gone must FAIL, not warn-and-skip: the
+  // emit loop below would otherwise `continue` past it and produce a green
+  // build with the published page silently missing (the same class of
+  // fail-open bug this guard exists to prevent).
+  const missingSources = CHAPTERS.map(ch => ch.file).filter(f => !onDisk.includes(f));
+  // Output paths derive from `prefix`, and FILE_TO_SLUG is keyed by `file`, so
+  // neither a duplicate prefix (one page silently overwrites another) nor a
+  // duplicate file is caught by the set-equality check alone.
+  const dupes = (values) => {
+    const seen = new Set();
+    const dup = new Set();
+    for (const v of values) {
+      if (seen.has(v)) dup.add(v);
+      seen.add(v);
+    }
+    return [...dup].sort();
+  };
+  const duplicatePrefixes = dupes(CHAPTERS.map(ch => ch.prefix));
+  const duplicateFiles = dupes(CHAPTERS.map(ch => ch.file));
 
   const problems = [];
   if (unaccounted.length > 0) {
@@ -249,6 +268,26 @@ console.log('[sync-format-guide] Starting...');
     problems.push(
       'These files are in BOTH CHAPTERS and UNPUBLISHED_BY_DESIGN (pick one):\n' +
         doublyListed.map(f => `    - ${f}`).join('\n')
+    );
+  }
+
+  if (missingSources.length > 0) {
+    problems.push(
+      'These CHAPTERS entries have no source file on disk (would silently not publish):\n' +
+        missingSources.map(f => `    - ${f}`).join('\n') +
+        '\n  FIX: restore the chapter file, or remove/rename its CHAPTERS entry.'
+    );
+  }
+  if (duplicatePrefixes.length > 0) {
+    problems.push(
+      'These CHAPTERS prefixes are used more than once (pages would overwrite each other):\n' +
+        duplicatePrefixes.map(p => `    - ${p}`).join('\n')
+    );
+  }
+  if (duplicateFiles.length > 0) {
+    problems.push(
+      'These CHAPTERS files are listed more than once:\n' +
+        duplicateFiles.map(f => `    - ${f}`).join('\n')
     );
   }
 
@@ -285,8 +324,10 @@ let count = 0;
 for (const ch of CHAPTERS) {
   const srcPath = path.join(CHAPTERS_DIR, ch.file);
   if (!fs.existsSync(srcPath)) {
-    console.warn(`[sync-format-guide] WARN: source not found: ${srcPath}`);
-    continue;
+    // Unreachable via the publication guard above; kept as a fail-closed
+    // backstop so a published chapter can never be skipped silently.
+    console.error(`[sync-format-guide] ERROR: source not found: ${srcPath}`);
+    process.exit(1);
   }
 
   const rawContent = fs.readFileSync(srcPath, 'utf-8');

--- a/website/scripts/sync-format-guide.mjs
+++ b/website/scripts/sync-format-guide.mjs
@@ -77,7 +77,23 @@ const CHAPTERS = [
   { file: 'appendix-e-glossary.md',             order: 105, prefix: 'appendix-e' },
   { file: 'appendix-f-known-limitations.md',    order: 106, prefix: 'appendix-f' },
   { file: 'appendix-g-compression-chunk-formats.md', order: 107, prefix: 'appendix-g' },
+  { file: 'appendix-g-algorithm-reference.md',   order: 108, prefix: 'appendix-g-algorithms' },
+  { file: 'appendix-g-quick-reference.md',       order: 109, prefix: 'appendix-g-quickref' },
+  { file: 'appendix-h-commitlog-segment-format.md', order: 110, prefix: 'appendix-h' },
 ];
+
+// Chapter-directory files that are deliberately NOT published to the site.
+// Every entry needs a reason — the publication guard below fails the build on
+// any chapters/*.md that is neither in CHAPTERS nor listed here, so a new
+// chapter can no longer rot out of the site unnoticed (issue #3006).
+const UNPUBLISHED_BY_DESIGN = new Map([
+  [
+    'APPENDIX_G_INDEX.md',
+    'Stale meta "document map" for the Appendix G family: wrong line count and ' +
+      'two references to files that no longer exist. Delete-vs-correct-and-publish ' +
+      'is an open owner decision on issue #3006 — do not publish as-is.',
+  ],
+]);
 
 // Map from source filename → output slug for link rewriting
 const FILE_TO_SLUG = new Map();
@@ -194,6 +210,58 @@ function extractDescription(content) {
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 console.log('[sync-format-guide] Starting...');
+
+// ── Publication guard (issue #3006) ──────────────────────────────────────────
+// The generated pages are gitignored, so CHAPTERS is the only record of what is
+// published. Forgetting an entry used to produce a green build with the chapter
+// silently unreachable (and inbound links degraded to GitHub blob URLs via the
+// TODO(W8) fallback below). Assert set-equality instead: every chapters/*.md is
+// either published or explicitly excluded with a reason.
+{
+  const onDisk = fs
+    .readdirSync(CHAPTERS_DIR)
+    .filter(f => f.endsWith('.md') && f !== 'README.md')
+    .sort();
+  const unaccounted = onDisk.filter(
+    f => !FILE_TO_SLUG.has(f) && !UNPUBLISHED_BY_DESIGN.has(f)
+  );
+  const staleExclusions = [...UNPUBLISHED_BY_DESIGN.keys()].filter(
+    f => !onDisk.includes(f)
+  );
+  const doublyListed = [...UNPUBLISHED_BY_DESIGN.keys()].filter(f => FILE_TO_SLUG.has(f));
+
+  const problems = [];
+  if (unaccounted.length > 0) {
+    problems.push(
+      'These chapter files are neither published nor explicitly excluded:\n' +
+        unaccounted.map(f => `    - ${f}`).join('\n') +
+        '\n  FIX: add a { file, order, prefix } entry to CHAPTERS to publish it, or add\n' +
+        '       it to UNPUBLISHED_BY_DESIGN with a reason if it must stay off the site.'
+    );
+  }
+  if (staleExclusions.length > 0) {
+    problems.push(
+      'These UNPUBLISHED_BY_DESIGN entries no longer exist on disk (drop them):\n' +
+        staleExclusions.map(f => `    - ${f}`).join('\n')
+    );
+  }
+  if (doublyListed.length > 0) {
+    problems.push(
+      'These files are in BOTH CHAPTERS and UNPUBLISHED_BY_DESIGN (pick one):\n' +
+        doublyListed.map(f => `    - ${f}`).join('\n')
+    );
+  }
+
+  if (problems.length > 0) {
+    console.error('[sync-format-guide] ERROR: chapter publication set mismatch (issue #3006)');
+    for (const p of problems) console.error(`  ${p}`);
+    process.exit(1);
+  }
+  console.log(
+    `[sync-format-guide] Publication guard OK: ${FILE_TO_SLUG.size} published, ` +
+      `${UNPUBLISHED_BY_DESIGN.size} excluded by design, ${onDisk.length} on disk.`
+  );
+}
 
 // Ensure output directories exist
 fs.mkdirSync(OUTPUT_DIR, { recursive: true });

--- a/website/src/content/docs/sstable-format/index.md
+++ b/website/src/content/docs/sstable-format/index.md
@@ -46,3 +46,6 @@ A 22-chapter reference for the Apache Cassandra 5.0 SSTable binary format, audit
 - [Appendix E — Glossary](/cqlite/sstable-format/appendix-e/)
 - [Appendix F — Known Limitations](/cqlite/sstable-format/appendix-f/)
 - [Appendix G: Cassandra 5.0 Compression Chunk Formats](/cqlite/sstable-format/appendix-g/)
+- [Appendix G: Algorithm Reference Sheet](/cqlite/sstable-format/appendix-g-algorithms/)
+- [Appendix G Quick Reference - Compression Formats at a Glance](/cqlite/sstable-format/appendix-g-quickref/)
+- [Appendix H — Cassandra 5.0 CommitLog Segment Format](/cqlite/sstable-format/appendix-h/)


### PR DESCRIPTION
Three authored chapters under docs/sstables-definitive-guide/chapters/ had never
been published to the site (~770 lines unreachable), because the site sync's
hardcoded CHAPTERS array omitted them. #2955 (PR #2992) just corrected
appendix-h-commitlog-segment-format.md, which readers still could not see.

- Add CHAPTERS entries for appendix-g-algorithm-reference.md (order 108,
  prefix appendix-g-algorithms), appendix-g-quick-reference.md (109,
  appendix-g-quickref) and appendix-h-commitlog-segment-format.md (110,
  appendix-h) — orders continue the appendix block after appendix-g (107),
  prefixes follow the established short-slug convention.
- Add a fail-closed publication guard to sync-format-guide.mjs: every
  chapters/*.md must be either in CHAPTERS or in UNPUBLISHED_BY_DESIGN with a
  written reason, else the sync exits non-zero. Because the sync is the
  website prebuild hook, this runs in the docs-site.yml CI lane, closing the
  silent-degradation mode where a forgotten entry produced a green build and
  degraded inbound links to GitHub blob URLs via the TODO(W8) fallback.
- Fix dangling cross-refs in the two Appendix G sheets: bare/absolute path
  references become relative sibling links the sync rewrites to
  /cqlite/sstable-format/ URLs, and two references to a since-deleted
  docs/archive/issues/COMPRESSION_CHUNK_FORMAT_RESEARCH.md are dropped.

APPENDIX_G_INDEX.md is deliberately untouched pending the owner's
delete-vs-correct-and-publish decision; it is recorded in
UNPUBLISHED_BY_DESIGN with that reason so the guard stays green without
hiding it. No astro.config.mjs change is needed — the sstable-format sidebar
autogenerates from the output directory.

Validation: website build PASS ("All internal links are valid", 101 pages),
validate-agent-plumbing PASS (100 pages, llms-full + raw .md coverage), all
three new pages present in dist/ with raw .md endpoints, zero TODO(W8)
markers in generated output, and the guard verified to fail on a probe file.

Closes #3006
