### PR TITLE
ops(roborev): switch repo reviewer default to codex/gpt-5.6-sol (#3037)

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,7 +1,7 @@
 # Default agent for this repo when no workflow-specific agent is set.
 agent = 'claude-code'
 # Default model for this repo when no workflow-specific model is set.
-model = 'opus'
+model = 'claude-opus-5'
 # Backup agent for this repo if the primary agent fails.
 backup_agent = ''
 # Backup model for this repo if the primary model fails.
@@ -62,7 +62,7 @@ refine_agent_thorough = ''
 # Agent override for maximum refine in this repo.
 refine_agent_maximum = ''
 # Model override for standard review in this repo.
-review_model = 'opus'
+review_model = 'claude-opus-5'
 # Model override for fast review in this repo.
 review_model_fast = ''
 # Model override for standard review in this repo.

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,7 +1,7 @@
 # Default agent for this repo when no workflow-specific agent is set.
-agent = 'claude-code'
+agent = 'codex'
 # Default model for this repo when no workflow-specific model is set.
-model = 'claude-opus-5'
+model = 'gpt-5.6-sol'
 # Backup agent for this repo if the primary agent fails.
 backup_agent = ''
 # Backup model for this repo if the primary model fails.
@@ -38,7 +38,7 @@ snapshot_dir = ''
 post_commit_review = 'branch'
 reuse_review_session_lookback = 3
 # Agent override for standard review in this repo.
-review_agent = 'claude-code'
+review_agent = 'codex'
 # Agent override for fast review in this repo.
 review_agent_fast = ''
 # Agent override for standard review in this repo.
@@ -62,7 +62,7 @@ refine_agent_thorough = ''
 # Agent override for maximum refine in this repo.
 refine_agent_maximum = ''
 # Model override for standard review in this repo.
-review_model = 'claude-opus-5'
+review_model = 'gpt-5.6-sol'
 # Model override for fast review in this repo.
 review_model_fast = ''
 # Model override for standard review in this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,16 +285,22 @@ implement (TDD) → --lite each fix round (summary-file redirect)
 - **Review-first (#2086)**: review BEFORE the first full gate so the ONE gate certifies
   already-reviewed code. Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single
   call site AND no new surface). When in doubt, review.
-- **roborev invocation — pass BOTH agent and model (#2433/#3037).** `.roborev.toml` on `main` pins
-  `agent = 'claude-code'` + `review_model = 'claude-opus-5'` (the repo pin overrides your global
-  `~/.roborev/config.toml`, so it is the value that actually runs). To run the codex reviewer you must
-  override BOTH:
-  `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`. `--agent codex`
-  alone still inherits the pinned `review_model` from config — an Anthropic model name codex cannot
-  serve — and codex-on-a-ChatGPT-account rejects it with a hard `400 '<model>' model is not supported`
-  (historically `400 'opus' model is not supported`) — a silent review failure that looks like an
-  outage. Run from a checkout whose `.roborev.toml` you know (worktrees inherit `main`'s pinned config);
-  `--model` is the reliable override. codex's own configured model is `gpt-5.6-sol` (`~/.codex/config.toml`).
+- **roborev invocation — the default is codex; overriding it means passing BOTH agent and model
+  (#2433/#3037).** `.roborev.toml` on `main` pins `agent`/`review_agent = 'codex'` +
+  `model`/`review_model = 'gpt-5.6-sol'` (the repo pin overrides your global `~/.roborev/config.toml`,
+  so it is the value that actually runs). So the plain
+  `roborev review --branch --base origin/main --wait` already runs codex — **no flags needed**.
+  The trap is the reverse case: to run the **Claude** reviewer you must override BOTH:
+  `roborev review --branch --base origin/main --agent claude-code --model claude-opus-5 --wait`.
+  `--agent claude-code` alone still inherits `review_model = 'gpt-5.6-sol'` from config — an OpenAI
+  model name Claude cannot serve — which fails as a silent review failure that looks like an outage.
+  (Historically the pin ran the other way and codex-on-a-ChatGPT-account rejected the inherited
+  Anthropic name with a hard `400 'opus' model is not supported`; same trap, mirrored.) Run from a
+  checkout whose `.roborev.toml` you know (worktrees inherit `main`'s pinned config); `--model` is the
+  reliable override. Note `gpt-5.6-sol` is **codex's own built-in default, not a config pin** — there
+  is no `~/.codex/config.toml` on the worker boxes; the bare `codex` default moved `gpt-5.5` →
+  `gpt-5.6-sol` in the 0.142.5 → 0.145.0 upgrade, so a future codex version bump can silently move it
+  again. `codex --version` + a bare `codex exec` header is how you check what it actually resolves to.
 - **flow-closer (#2084/#2668)**: the full gate, the final roborev pass, and the merge run inside the
   disposable `flow-closer` subagent — the lead retains only its terminal packet (verdict, PR URL,
   summary-file path, ≤10 lines residual), never gate stdout or review churn. The closer has **no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,11 +285,14 @@ implement (TDD) → --lite each fix round (summary-file redirect)
 - **Review-first (#2086)**: review BEFORE the first full gate so the ONE gate certifies
   already-reviewed code. Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single
   call site AND no new surface). When in doubt, review.
-- **roborev invocation — pass BOTH agent and model (#2433).** `.roborev.toml` on `main` pins
-  `agent = 'claude-code'` + `review_model = 'opus'`. To run the codex reviewer you must override BOTH:
+- **roborev invocation — pass BOTH agent and model (#2433/#3037).** `.roborev.toml` on `main` pins
+  `agent = 'claude-code'` + `review_model = 'claude-opus-5'` (the repo pin overrides your global
+  `~/.roborev/config.toml`, so it is the value that actually runs). To run the codex reviewer you must
+  override BOTH:
   `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`. `--agent codex`
-  alone still inherits `review_model = 'opus'` from config, and codex-on-a-ChatGPT-account rejects
-  `opus` with a hard `400 'opus' model is not supported` — a silent review failure that looks like an
+  alone still inherits the pinned `review_model` from config — an Anthropic model name codex cannot
+  serve — and codex-on-a-ChatGPT-account rejects it with a hard `400 '<model>' model is not supported`
+  (historically `400 'opus' model is not supported`) — a silent review failure that looks like an
   outage. Run from a checkout whose `.roborev.toml` you know (worktrees inherit `main`'s pinned config);
   `--model` is the reliable override. codex's own configured model is `gpt-5.6-sol` (`~/.codex/config.toml`).
 - **flow-closer (#2084/#2668)**: the full gate, the final roborev pass, and the merge run inside the

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -123,15 +123,17 @@ fresh `git worktree add --detach HEAD`, never the dirty tree.
 
 ## Running the codex reviewer — override BOTH agent and model
 
-`.roborev.toml` on `main` pins `agent = 'claude-code'` and `review_model = 'opus'`. To run the codex
-backend you must override **both** on the command line:
+`.roborev.toml` on `main` pins `agent = 'claude-code'` and `review_model = 'claude-opus-5'`. That
+repo-local pin **overrides** whatever your global `~/.roborev/config.toml` sets, so it is the value that
+actually runs. To run the codex backend you must override **both** on the command line:
 
 ```bash
 roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait
 ```
 
-`--agent codex` **alone** still inherits `review_model = 'opus'` from config, and codex on a ChatGPT
-account rejects `opus` with a hard `400 'opus' model is not supported` — a silent review failure that
-looks like a backend outage rather than a config mismatch. Worktrees inherit `main`'s pinned config, so
-`--model gpt-5.6-sol` (codex's own configured model, from `~/.codex/config.toml`) is the reliable
-override on every checkout.
+`--agent codex` **alone** still inherits the pinned `review_model` from config — an Anthropic model name
+codex cannot serve — and codex on a ChatGPT account rejects it with a hard
+`400 '<model>' model is not supported` (historically `400 'opus' model is not supported`) — a silent
+review failure that looks like a backend outage rather than a config mismatch. Worktrees inherit `main`'s
+pinned config, so `--model gpt-5.6-sol` (codex's own configured model, from `~/.codex/config.toml`) is the
+reliable override on every checkout.

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -121,19 +121,35 @@ fresh `git worktree add --detach HEAD`, never the dirty tree.
 3. Then run `scripts/agent-gate.sh` and request review as usual — see the
    [gate contract](/cqlite/agents-developing/gate-contract/).
 
-## Running the codex reviewer — override BOTH agent and model
+## The reviewer default is codex — overriding it means BOTH agent and model
 
-`.roborev.toml` on `main` pins `agent = 'claude-code'` and `review_model = 'claude-opus-5'`. That
-repo-local pin **overrides** whatever your global `~/.roborev/config.toml` sets, so it is the value that
-actually runs. To run the codex backend you must override **both** on the command line:
+`.roborev.toml` on `main` pins `agent`/`review_agent = 'codex'` and
+`model`/`review_model = 'gpt-5.6-sol'`. That repo-local pin **overrides** whatever your global
+`~/.roborev/config.toml` sets, so it is the value that actually runs. The plain invocation therefore
+already runs codex, with no flags:
 
 ```bash
-roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait
+roborev review --branch --base origin/main --wait
 ```
 
-`--agent codex` **alone** still inherits the pinned `review_model` from config — an Anthropic model name
-codex cannot serve — and codex on a ChatGPT account rejects it with a hard
-`400 '<model>' model is not supported` (historically `400 'opus' model is not supported`) — a silent
-review failure that looks like a backend outage rather than a config mismatch. Worktrees inherit `main`'s
-pinned config, so `--model gpt-5.6-sol` (codex's own configured model, from `~/.codex/config.toml`) is the
-reliable override on every checkout.
+The trap is the reverse case. To run the **Claude** reviewer you must override **both** on the command
+line:
+
+```bash
+roborev review --branch --base origin/main --agent claude-code --model claude-opus-5 --wait
+```
+
+`--agent claude-code` **alone** still inherits `review_model = 'gpt-5.6-sol'` from config — an OpenAI
+model name Claude cannot serve — which surfaces as a silent review failure that looks like a backend
+outage rather than a config mismatch. (Historically the pin ran the other way, and codex on a ChatGPT
+account rejected the inherited Anthropic name with a hard `400 'opus' model is not supported`; it is the
+same trap, mirrored.) Worktrees inherit `main`'s pinned config, so the explicit `--model` is the reliable
+override on every checkout.
+
+### `gpt-5.6-sol` is codex's default, not a config pin
+
+There is **no `~/.codex/config.toml`** on the worker boxes — `gpt-5.6-sol` is simply what the bare
+`codex` binary resolves to. That default moved `gpt-5.5` → `gpt-5.6-sol` across the 0.142.5 → 0.145.0
+upgrade, so a future codex version bump can silently move it again and leave `.roborev.toml` pinning a
+model the installed CLI no longer serves. Check what is actually in effect with `codex --version` and the
+model line in a bare `codex exec` header, rather than assuming a config file holds it.


### PR DESCRIPTION
Closes #3037

## What — reviewer default switches to codex

**Direction changed mid-PR, by explicit owner decision.** This branch originally standardized the
repo-local `.roborev.toml` pins on `claude-opus-5` (the stale `'opus'` name was silently overriding the
owner's global `~/.roborev/config.toml`). The owner has since upgraded the codex CLI on the worker box
**0.142.5 → 0.145.0**, which makes `gpt-5.6-sol` resolvable, and decided to move the **repo-wide reviewer
default to codex**. Offered the alternatives — keep Claude default with codex on demand, or Claude primary
with codex as backup — they chose the full switch. Rationale and the superseded acceptance criteria are
recorded on #3037.

`.roborev.toml` now pins:

```toml
agent        = 'codex'
model        = 'gpt-5.6-sol'
review_agent = 'codex'
review_model = 'gpt-5.6-sol'
```

**Agent and model move together** — nothing else in the file changes. Changing one without the other is
exactly the silent-failure trap this issue exists to close.

**The diff is config + docs only** — no production code, no public surface, no parity oracle touched.

## Doctrine updated in the same change — the trap inverts

CLAUDE.md's rule is that doctrine stays current in the same change, and two docs quoted the old pin
verbatim: `CLAUDE.md` (the "roborev invocation" bullet) and
`website/src/content/docs/agents-developing/roborev-findings.md`.

Both are **rewritten, not string-substituted**, because the failure mode now runs the other way:

- A plain `roborev review --branch --base origin/main --wait` now runs **codex, with no flags**.
- The trap is the reverse case — running the **Claude** reviewer requires BOTH `--agent claude-code`
  **and** `--model claude-opus-5`. `--agent claude-code` alone still inherits
  `review_model = 'gpt-5.6-sol'`, an OpenAI model name Claude cannot serve.
- The historical `400 'opus' model is not supported` symptom is kept only as a parenthetical so it stays
  searchable, worded as history rather than as the current failure mode.

### Factual correction: `~/.codex/config.toml` does not exist

Both docs claimed codex's model is pinned via `~/.codex/config.toml`. **That file does not exist on this
machine.** `gpt-5.6-sol` is codex 0.145.0's **built-in default**, not a config pin. The docs now say so,
and point at `codex --version` plus the model line in a bare `codex exec` header as the way to check what
actually resolves — because a future codex version bump can move the default again and silently leave
`.roborev.toml` pinning a model the installed CLI no longer serves.

A `grep` for `claude-opus-5|review_model|claude-code|gpt-5` across `*.md`/`*.toml` in `docs/`, `website/`,
`CLAUDE.md` and `.roborev.toml` leaves no doc asserting a wrong current default. The remaining `gpt-5.5`
hits are in `docs/automation-overhaul-2026.md`, a dated (2026-06-24) research snapshot describing the
setup as it stood then — historical record, left alone on the same principle as the dated
`process_improvements.md` retro entries. `.claude/` and `scripts/` contain no hard-coded roborev
agent/model invocations.

## Verification (empirical, on this box)

- `codex --version` → **`codex-cli 0.145.0`**.
- `codex exec -m gpt-5.6-sol -c approval_policy=on-request -s read-only` returns a clean **`OK`** — the
  new pin is not a speculative model name.
- **0.145.0's bare default is `gpt-5.6-sol`**, confirmed by comparing against the retained 0.142.5 binary:
  `/opt/codex-0.142.5/bin/codex exec` reports `model: gpt-5.5` in its header, `/usr/local/bin/codex exec`
  reports `model: gpt-5.6-sol` — same invocation, no `-m`, no config file.
- `roborev config get review_agent` → **`codex`**; `roborev config get review_model` → **`gpt-5.6-sol`**,
  both run from this worktree after the edit (`agent` and `model` likewise). The daemon picks up the pin.

## Gate

Lite gate PASS on this diff at the pushed head `e0085ca` (`tree-integrity: PASS`):

```
==== AGENT-GATE LITE SUMMARY ====
run-id: /tmp/agent-gate.5Rgchx
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: e0085ca branch: issue-3037-roborev-opus5-pin dirty: no
lite-scope: file-size fmt clippy roborev-lints scoped-tests (full gate NOT run — run it once before merge)
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=absent
cpu-budget: wrapper=nice ncpu=16 max-concurrency=3 cores-per-gate=5 build-jobs=5(derived) test-threads=5
tree-start: e0085ca9c815 dirty: no digest: e1ee8a3914b3
tree-end: e0085ca9c815 dirty: no digest: e1ee8a3914b3
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (6s)
clippy:            PASS (124s)
roborev-lints:     PASS (1s)
scoped-tests:      PASS (97s)
logs: /tmp/agent-gate.5Rgchx
summary-file: /tmp/gate-lite-3037b.txt
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

**The full gate of record is deliberately deferred to the reviewing lead**, who owns and serialises full
gates on this machine. Lite is explicitly not the gate of record.

## Merge posture

**Auto-merge deliberately NOT armed.** Left open for the lead.
