### PR TITLE
fix(#2896): de-flake blocking-task gauge wiring test via own-guard-attributable probe

### DIFF
--- a/cqlite-flight/src/saturation.rs
+++ b/cqlite-flight/src/saturation.rs
@@ -316,11 +316,15 @@ impl BlockingTaskGuard {
     }
 
     /// The shared in-use level observed at this guard's OWN entry — the exact
-    /// post-increment value [`Self::enter`] published to the gauge, so it is
-    /// `>= 1` by construction and can never be invalidated by another guard
-    /// dropping afterwards (issue #2896). Published through
+    /// post-increment value [`Self::enter`] published to the gauge, and an
+    /// immutable snapshot thereafter, so no later guard drop can invalidate it
+    /// (issue #2896). For a BALANCED counter — which this RAII guard guarantees,
+    /// every `+1` paired with exactly one `-1` on drop — it is `>= 1`: every
+    /// other guard contributes `0` or `+1` at any instant, and this guard's own
+    /// `+1` is already applied. Published through
     /// `crate::streaming::StreamProbe` so the streaming wiring test observes the
-    /// production arithmetic on the REAL shared atomic.
+    /// production arithmetic on the REAL shared atomic, with a LOWER bound the
+    /// test raises by holding a guard of its own.
     pub(crate) fn entry_level(&self) -> i64 {
         self.entry_level
     }
@@ -354,12 +358,18 @@ impl Drop for BlockingTaskGuard {
 
 /// Read the current process-wide flight blocking-task in-use level (issue #2419).
 ///
-/// Exposes the same atomic that drives `cqlite.flight.blocking_tasks_in_use`, so
-/// an end-to-end streaming test can assert the level rises while blocking tasks
-/// are outstanding and returns to its pre-load baseline after every task exits
-/// (asserting on the LEVEL, never on timing). Feature-independent (the atomic is
-/// maintained regardless of the `observability` OTel feature; only the emission
-/// is gated), mirroring [`crate::obs::in_flight_level`].
+/// Exposes the same atomic that drives `cqlite.flight.blocking_tasks_in_use`
+/// (assert on the LEVEL, never on timing). Read it ONLY for bounds concurrent
+/// guards cannot invalidate — e.g. "at least the guards I myself hold". Do NOT
+/// difference it against a pre-load baseline: a peer holding a guard when the
+/// baseline is read inflates it and then releases, which is exactly the flake
+/// issue #2896 removed. Exact rise/balance arithmetic belongs against a private
+/// atomic ([`BlockingTaskGuard::enter_on`], see
+/// `tests::blocking_task_guard_rises_and_balances`); an end-to-end wiring test
+/// observes its own guard's [`BlockingTaskGuard::entry_level`].
+/// Feature-independent (the atomic is maintained regardless of the
+/// `observability` OTel feature; only the emission is gated), mirroring
+/// [`crate::obs::in_flight_level`].
 pub fn blocking_tasks_in_use_level() -> i64 {
     BLOCKING_TASKS.load(Ordering::SeqCst)
 }

--- a/cqlite-flight/src/saturation.rs
+++ b/cqlite-flight/src/saturation.rs
@@ -293,12 +293,7 @@ pub(crate) struct BlockingTaskGuard {
     /// `cqlite.flight.blocking_tasks_in_use`.
     emit: bool,
     /// The level [`Self::atomic`] held immediately AFTER this guard's own
-    /// increment — i.e. a value that provably includes this guard's `+1`
-    /// (issue #2896). Retained (it is already computed by [`adjust`]) so the
-    /// end-to-end streaming wiring test can assert on an observation
-    /// attributable to ITS OWN guard, instead of differencing the shared global
-    /// against a baseline snapshot that concurrently-running peer tests can
-    /// inflate and then deflate.
+    /// increment (issue #2896). See [`Self::entry_level`].
     entry_level: i64,
 }
 
@@ -315,16 +310,12 @@ impl BlockingTaskGuard {
         }
     }
 
-    /// The shared in-use level observed at this guard's OWN entry — the exact
+    /// The in-use level observed at this guard's OWN entry — the exact
     /// post-increment value [`Self::enter`] published to the gauge, and an
-    /// immutable snapshot thereafter, so no later guard drop can invalidate it
-    /// (issue #2896). For a BALANCED counter — which this RAII guard guarantees,
-    /// every `+1` paired with exactly one `-1` on drop — it is `>= 1`: every
-    /// other guard contributes `0` or `+1` at any instant, and this guard's own
-    /// `+1` is already applied. Published through
-    /// `crate::streaming::StreamProbe` so the streaming wiring test observes the
-    /// production arithmetic on the REAL shared atomic, with a LOWER bound the
-    /// test raises by holding a guard of its own.
+    /// immutable snapshot thereafter (issue #2896), so it is `>= 1` for a
+    /// balanced counter (which this RAII guard guarantees) and no later guard
+    /// drop can invalidate it. Published through `crate::streaming::StreamProbe`;
+    /// see [`blocking_tasks_in_use_level`] for how to bound it soundly.
     pub(crate) fn entry_level(&self) -> i64 {
         self.entry_level
     }
@@ -359,14 +350,21 @@ impl Drop for BlockingTaskGuard {
 /// Read the current process-wide flight blocking-task in-use level (issue #2419).
 ///
 /// Exposes the same atomic that drives `cqlite.flight.blocking_tasks_in_use`
-/// (assert on the LEVEL, never on timing). Read it ONLY for bounds concurrent
-/// guards cannot invalidate — e.g. "at least the guards I myself hold". Do NOT
-/// difference it against a pre-load baseline: a peer holding a guard when the
-/// baseline is read inflates it and then releases, which is exactly the flake
-/// issue #2896 removed. Exact rise/balance arithmetic belongs against a private
-/// atomic ([`BlockingTaskGuard::enter_on`], see
-/// `tests::blocking_task_guard_rises_and_balances`); an end-to-end wiring test
-/// observes its own guard's [`BlockingTaskGuard::entry_level`].
+/// (assert on the LEVEL, never on timing).
+///
+/// **NORMATIVE RULE for observing this gauge (issue #2896) — stated ONCE here;
+/// other sites reference it rather than re-derive it.** Every live
+/// [`BlockingTaskGuard`] contributes `0` or `+1` at any instant, so a concurrent
+/// guard can only RAISE the level. Therefore: SOUND — a lower bound counting only
+/// guards the observer itself keeps live ("I hold `k`, so the level is `>= k`"),
+/// and likewise [`BlockingTaskGuard::entry_level`], an immutable post-increment
+/// snapshot. UNSOUND — differencing against a pre-load baseline: a peer holding a
+/// guard when the baseline is read inflates it and then releases, so the level can
+/// sit at or below that baseline while the observer's own guard is legitimately
+/// held (the exact flake #2896 removed). OUT OF SCOPE — exact rise/balance
+/// arithmetic; pin that against a private atomic
+/// ([`BlockingTaskGuard::enter_on`], `tests::blocking_task_guard_rises_and_balances`).
+///
 /// Feature-independent (the atomic is maintained regardless of the
 /// `observability` OTel feature; only the emission is gated), mirroring
 /// [`crate::obs::in_flight_level`].

--- a/cqlite-flight/src/saturation.rs
+++ b/cqlite-flight/src/saturation.rs
@@ -292,17 +292,37 @@ pub(crate) struct BlockingTaskGuard {
     /// against a private atomic never publishes a synthetic reading over
     /// `cqlite.flight.blocking_tasks_in_use`.
     emit: bool,
+    /// The level [`Self::atomic`] held immediately AFTER this guard's own
+    /// increment — i.e. a value that provably includes this guard's `+1`
+    /// (issue #2896). Retained (it is already computed by [`adjust`]) so the
+    /// end-to-end streaming wiring test can assert on an observation
+    /// attributable to ITS OWN guard, instead of differencing the shared global
+    /// against a baseline snapshot that concurrently-running peer tests can
+    /// inflate and then deflate.
+    entry_level: i64,
 }
 
 impl BlockingTaskGuard {
     /// Enter a flight blocking task: increment the in-use gauge and return the
     /// guard whose drop decrements it.
     pub(crate) fn enter() -> Self {
-        record_blocking(adjust(&BLOCKING_TASKS, 1));
+        let entry_level = adjust(&BLOCKING_TASKS, 1);
+        record_blocking(entry_level);
         Self {
             atomic: &BLOCKING_TASKS,
             emit: true,
+            entry_level,
         }
+    }
+
+    /// The shared in-use level observed at this guard's OWN entry — the exact
+    /// post-increment value [`Self::enter`] published to the gauge, so it is
+    /// `>= 1` by construction and can never be invalidated by another guard
+    /// dropping afterwards (issue #2896). Published through
+    /// `crate::streaming::StreamProbe` so the streaming wiring test observes the
+    /// production arithmetic on the REAL shared atomic.
+    pub(crate) fn entry_level(&self) -> i64 {
+        self.entry_level
     }
 
     /// Test-only: enter a guard tracking `atomic` instead of the shared
@@ -314,10 +334,11 @@ impl BlockingTaskGuard {
     /// blocking-pool reading).
     #[cfg(test)]
     fn enter_on(atomic: &'static AtomicI64) -> Self {
-        adjust(atomic, 1);
+        let entry_level = adjust(atomic, 1);
         Self {
             atomic,
             emit: false,
+            entry_level,
         }
     }
 }

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -22,7 +22,7 @@
 
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use arrow::datatypes::Schema as ArrowSchema;
@@ -144,6 +144,19 @@ pub(crate) struct StreamProbe {
     /// eager-setup errors always did, independent of whether OTel counters are
     /// compiled in.
     errors_recorded: Arc<AtomicUsize>,
+    /// Blocking-task guards THIS stream's own `spawn_blocking` merge closure
+    /// entered (issue #2896): exactly one per streaming merge. Paired with
+    /// [`Self::blocking_entry_level`] it makes the
+    /// `cqlite.flight.blocking_tasks_in_use` wiring observable per-stream,
+    /// instead of by differencing the process-global gauge against a baseline
+    /// snapshot that a concurrently-running peer test can inflate.
+    blocking_entries: Arc<AtomicUsize>,
+    /// The shared in-use level the merge closure's own
+    /// [`crate::saturation::BlockingTaskGuard`] observed at ITS entry — the real
+    /// post-increment value of the production atomic, so it always includes this
+    /// guard's `+1` and is `>= 1` no matter what peer guards do afterwards
+    /// (issue #2896).
+    blocking_entry_level: Arc<AtomicI64>,
     /// Egress credit accounting (issue #2821): charged permit bytes, REALIZED
     /// resident capacity bytes and their high-water marks, plus the
     /// reservations-granted / batches-materialized pair that makes
@@ -393,6 +406,11 @@ pub(crate) fn spawn_streaming(
     // The incremental scan-progress seam (issue #2162) is threaded into the merge
     // loop so `cqlite.query.rows_scanned` climbs while the scan is in progress.
     let scan_progress = probe.scan_progress.clone();
+    // The blocking-task-guard observation seam (issue #2896): the closure below
+    // publishes its OWN guard's entry through these, so the wiring assertion is
+    // attributable to THIS stream and immune to peer streams' guard timing.
+    let blocking_entries = probe.blocking_entries.clone();
+    let blocking_entry_level = probe.blocking_entry_level.clone();
 
     // Issue #2819 (roborev L5): capture the `flight.do_get` RPC span HERE — this fn
     // runs synchronously inside the handler's `.instrument(span)` future, so
@@ -413,7 +431,14 @@ pub(crate) fn spawn_streaming(
         // `cqlite.flight.blocking_tasks_in_use` for the whole closure — the guard
         // is the FIRST act here and its Drop decrements on every exit path
         // (normal, error, cancel, panic).
-        let _blocking_guard = crate::saturation::BlockingTaskGuard::enter();
+        let blocking_guard = crate::saturation::BlockingTaskGuard::enter();
+        // Issue #2896: publish THIS guard's own entry through the probe — the
+        // number of guards this closure entered, plus the post-increment level the
+        // guard read off the shared production atomic (always `>= 1`, since it
+        // includes our own `+1`). Declared after the guard, so the guard is still
+        // the first act and still drops LAST.
+        blocking_entries.fetch_add(1, Ordering::Relaxed);
+        blocking_entry_level.store(blocking_guard.entry_level(), Ordering::Relaxed);
         // Issue #2819: per-request in-`stream` sub-phase accumulator, installed on
         // THIS merge consumer thread; emitted ONCE at teardown. Roborev B1 — the
         // emitter MUST flush its samples BEFORE any egress sender is released, or a

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -145,17 +145,15 @@ pub(crate) struct StreamProbe {
     /// compiled in.
     errors_recorded: Arc<AtomicUsize>,
     /// Blocking-task guards THIS stream's own `spawn_blocking` merge closure
-    /// entered (issue #2896): exactly one per streaming merge. Paired with
-    /// [`Self::blocking_entry_level`] it makes the
-    /// `cqlite.flight.blocking_tasks_in_use` wiring observable per-stream,
-    /// instead of by differencing the process-global gauge against a baseline
-    /// snapshot that a concurrently-running peer test can inflate.
+    /// entered (issue #2896): exactly one per streaming merge. Makes the
+    /// `cqlite.flight.blocking_tasks_in_use` wiring observable PER-STREAM rather
+    /// than through the process-global gauge.
     blocking_entries: Arc<AtomicUsize>,
-    /// The shared in-use level the merge closure's own
-    /// [`crate::saturation::BlockingTaskGuard`] observed at ITS entry — the real
-    /// post-increment value of the production atomic, so it always includes this
-    /// guard's `+1` and is `>= 1` no matter what peer guards do afterwards
-    /// (issue #2896).
+    /// The shared in-use level that closure's own
+    /// [`crate::saturation::BlockingTaskGuard`] observed at ITS entry (issue
+    /// #2896) — see [`crate::saturation::BlockingTaskGuard::entry_level`], and
+    /// [`crate::saturation::blocking_tasks_in_use_level`] for the normative rule
+    /// on bounding it soundly.
     blocking_entry_level: Arc<AtomicI64>,
     /// Egress credit accounting (issue #2821): charged permit bytes, REALIZED
     /// resident capacity bytes and their high-water marks, plus the
@@ -432,10 +430,8 @@ pub(crate) fn spawn_streaming(
         // is the FIRST act here and its Drop decrements on every exit path
         // (normal, error, cancel, panic).
         let blocking_guard = crate::saturation::BlockingTaskGuard::enter();
-        // Issue #2896: publish THIS guard's own entry through the probe — the
-        // number of guards this closure entered, plus the post-increment level the
-        // guard read off the shared production atomic (`>= 1`, since it includes
-        // our own `+1`). These are plain statements on captured `Arc`s, not
+        // Issue #2896: publish THIS guard's own entry through the probe (see the
+        // `StreamProbe` fields). These are plain statements on captured `Arc`s, not
         // ordering-relevant locals: the invariant they preserve is that the guard
         // is entered BEFORE any other statement in this closure, and that no local
         // declared after it can outlive it (so the accounting still spans the whole

--- a/cqlite-flight/src/streaming.rs
+++ b/cqlite-flight/src/streaming.rs
@@ -434,9 +434,12 @@ pub(crate) fn spawn_streaming(
         let blocking_guard = crate::saturation::BlockingTaskGuard::enter();
         // Issue #2896: publish THIS guard's own entry through the probe — the
         // number of guards this closure entered, plus the post-increment level the
-        // guard read off the shared production atomic (always `>= 1`, since it
-        // includes our own `+1`). Declared after the guard, so the guard is still
-        // the first act and still drops LAST.
+        // guard read off the shared production atomic (`>= 1`, since it includes
+        // our own `+1`). These are plain statements on captured `Arc`s, not
+        // ordering-relevant locals: the invariant they preserve is that the guard
+        // is entered BEFORE any other statement in this closure, and that no local
+        // declared after it can outlive it (so the accounting still spans the whole
+        // closure body, including the merge below).
         blocking_entries.fetch_add(1, Ordering::Relaxed);
         blocking_entry_level.store(blocking_guard.entry_level(), Ordering::Relaxed);
         // Issue #2819: per-request in-`stream` sub-phase accumulator, installed on

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -760,16 +760,26 @@ fn metrics_parity_on_full_consumption() {
 /// [`crate::saturation::BlockingTaskGuard`] is entered by the REAL streaming
 /// `spawn_blocking` merge closure — not merely a standalone unit of the guard.
 ///
-/// While the merge is producing into the bounded channel (the closure has
-/// entered its guard and is parked on backpressure / still emitting), the
-/// process-wide in-use level is at least the pre-load baseline + 1. This is a
-/// robust LOWER bound: concurrent tests can only ADD to the shared count, never
-/// pull it below this merge's own +1, so it does not flake under the parallel
-/// runner (the exact balance-to-baseline property is pinned deterministically by
-/// `saturation::tests::blocking_task_guard_rises_and_balances`).
+/// The observation is OWN-GUARD-ATTRIBUTABLE, so it cannot flake under the
+/// parallel runner (issue #2896). Two probe readings, both written by the
+/// production closure itself:
+///
+/// * `blocking_entries == 1` — this stream's closure entered exactly one real
+///   `BlockingTaskGuard` (the wiring evidence: the guard lives in the REAL
+///   `spawn_blocking` merge closure, not in a standalone unit test);
+/// * `blocking_entry_level >= 1` — the level that guard read off the shared
+///   production atomic at its own entry. It is a POST-increment value, so it
+///   includes our own `+1` and stays valid however peer guards come and go.
+///
+/// The earlier form differenced the process-global gauge against a `base`
+/// snapshot; a peer streaming test holding a guard when `base` was read (and
+/// dropping it before the assert) inflated the baseline and flaked the assert
+/// (#2896). The global gauge only supports its underflow invariant (`>= 0`),
+/// asserted after drain here; the exact rise/balance arithmetic is pinned
+/// deterministically against a private atomic by
+/// `saturation::tests::blocking_task_guard_rises_and_balances`.
 #[test]
 fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
-    let base = crate::saturation::blocking_tasks_in_use_level();
     let n = 40;
     let (_temp, dir, schema) = many_partition_fixture(n);
     let producer = MergeProducer::with_spec(schema, 1, crate::filter::ScanSpec::default()).unwrap();
@@ -777,6 +787,8 @@ fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
     let schema_ref = Arc::new(producer.arrow_schema().unwrap());
 
     let rt = tokio::runtime::Runtime::new().unwrap();
+    let pr = probe();
+    let pr_check = pr.clone();
     rt.block_on(async move {
         let (mut stream, handle) = spawn_streaming(
             producer,
@@ -785,31 +797,36 @@ fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
             RpcMetrics::start("do_get"),
             DO_GET_CHANNEL_CAPACITY,
             EgressBudget::default(),
-            probe(),
+            pr,
             CancelFlag::new(),
             timer(),
         );
         // Pull the schema + first batch: to emit a batch the merge closure must
-        // have entered its `BlockingTaskGuard` and started producing. With
-        // n ≫ channel capacity it is still running / backpressured here, so the
-        // guard is held.
+        // have entered its `BlockingTaskGuard` and started producing.
         let _schema_msg = read_one(&mut stream).await.expect("schema message");
         let _first_batch = read_one(&mut stream).await.expect("first batch");
+        assert_eq!(
+            pr_check.blocking_entries.load(Ordering::Relaxed),
+            1,
+            "the real spawn_blocking merge closure must enter exactly one \
+             BlockingTaskGuard (proves the gauge is wired into the production path)"
+        );
         assert!(
-            crate::saturation::blocking_tasks_in_use_level() > base,
-            "the real spawn_blocking merge closure must hold a BlockingTaskGuard \
-             while producing (proves the gauge is wired into the production path). \
-             A robust lower bound: concurrent tests only ADD to the shared count."
+            pr_check.blocking_entry_level.load(Ordering::Relaxed) >= 1,
+            "that guard's own post-increment reading of the shared \
+             cqlite.flight.blocking_tasks_in_use atomic must include its own +1"
         );
         // Drop the stream to cancel + join the merge; the guard drops on exit.
         drop(stream);
         let _ = handle.await;
     });
 
-    // The gauge never underflows its baseline (the RAII drop balanced the entry).
+    // The RAII drop balanced the entry: the process-global gauge is a count of
+    // live guards, so it never goes negative (the only global invariant a
+    // concurrently-running peer test cannot invalidate).
     assert!(
-        crate::saturation::blocking_tasks_in_use_level() >= base,
-        "the blocking-task gauge must never underflow its pre-load baseline"
+        crate::saturation::blocking_tasks_in_use_level() >= 0,
+        "the blocking-task gauge must never underflow"
     );
 }
 

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -760,36 +760,28 @@ fn metrics_parity_on_full_consumption() {
 /// [`crate::saturation::BlockingTaskGuard`] is entered by the REAL streaming
 /// `spawn_blocking` merge closure — not merely a standalone unit of the guard.
 ///
-/// The observation is OWN-GUARD-ATTRIBUTABLE *and* anchored to the shared
-/// process-global atomic that actually backs the gauge, so it cannot flake under
-/// the parallel runner (issue #2896). The test enters a REAL guard of its own
-/// (`BlockingTaskGuard::enter`, the same production constructor — never the
-/// private-atomic `enter_on`) and holds it across the whole observation, then
-/// asserts:
+/// The test holds a REAL guard of its own (the production
+/// `BlockingTaskGuard::enter`, never the private-atomic `enter_on`) across the
+/// whole observation, then asserts four links — each a lower bound of the SOUND
+/// kind defined normatively on
+/// [`crate::saturation::blocking_tasks_in_use_level`] (issue #2896), so peer
+/// tests can only raise these values and none can flake:
 ///
-/// * `blocking_entries == 1` — this stream's closure entered exactly one real
-///   `BlockingTaskGuard` (the wiring evidence: the guard lives in the REAL
-///   `spawn_blocking` merge closure, not in a standalone unit test);
-/// * `blocking_entry_level >= 2` — the level THAT guard read off the shared
-///   atomic at its own entry. Since this test holds a live guard, the level was
-///   already `>= 1` when the closure entered, so its post-increment read is
-///   `>= 2`. This is what ties the closure's guard to the SAME atomic as ours:
-///   re-pointing `enter()` at a private/different counter (or dropping the
-///   increment and reporting a synthetic level) breaks it.
-/// * after the merge is joined, `blocking_tasks_in_use_level() >= 1` — the
-///   closure's RAII drop did not decrement the shared atomic past our own still
-///   -held contribution (an underflow bound, NOT a proof that the drop was
-///   exactly `-1`).
+/// 1. `blocking_tasks_in_use_level() >= 1` while our guard is live — a real
+///    `enter()` reaches the shared atomic the gauge is published from;
+/// 2. `blocking_entries == 1` — the REAL `spawn_blocking` merge closure entered
+///    exactly one guard (not a standalone unit of the guard);
+/// 3. `blocking_entry_level >= 2` — that guard's own post-increment reading
+///    counts our live guard plus its own `+1`, tying it to the SAME atomic;
+/// 4. `blocking_tasks_in_use_level() >= 2` while the merge is still producing —
+///    the closure HOLDS its guard for the merge's duration (the actual production
+///    signal). Without this, an entered-and-immediately-dropped guard — leaving
+///    the gauge reading 0 for the whole merge — would satisfy 1-3.
 ///
-/// Each bound is peer-proof because every other live guard contributes `0` or
-/// `+1` at any instant: peers can only push these values HIGHER, never lower,
-/// and `blocking_entry_level` is an immutable `i64` snapshot once taken. The
-/// earlier form instead differenced the global against a pre-load `base`
-/// snapshot, so a peer holding a guard at `base`-read time (and releasing before
-/// the assert) inflated the baseline and flaked the assert (#2896). Exact
-/// rise/balance arithmetic is not provable here (peers mutate the same atomic
-/// concurrently) and is pinned deterministically against a private atomic by
-/// `saturation::tests::blocking_task_guard_rises_and_balances`.
+/// After the merge is joined, a final `>= 1` bounds the closure's RAII decrement
+/// against underflow past our own still-held contribution (NOT a claim that the
+/// drop was exactly `-1`; the exact rise/balance arithmetic is pinned against a
+/// private atomic by `saturation::tests::blocking_task_guard_rises_and_balances`).
 #[test]
 fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
     let n = 40;
@@ -803,18 +795,13 @@ fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
     let pr_check = pr.clone();
     // A REAL guard on the shared production atomic (never the private-atomic
     // `enter_on`), held for the rest of the test: it raises the floor the merge
-    // closure's own guard must read, which is what anchors the assertions below to
-    // the SAME atomic the gauge is published from. It emits one true gauge reading,
-    // as any production entry does; no test asserts on recorded gauge VALUES for
+    // closure's own guard must read, anchoring every assertion below to the SAME
+    // atomic the gauge is published from. It emits one true gauge reading, as any
+    // production entry does; no test asserts on recorded gauge VALUES for
     // `cqlite.flight.blocking_tasks_in_use` (the OTel capture harness runs in a
     // separate integration-test process), so nothing else is perturbed.
     let own_guard = crate::saturation::BlockingTaskGuard::enter();
-    // Our end of the anchor: a real `enter()` must be visible on the SHARED atomic
-    // the public read seam (and the gauge) reads. Peer-proof — our guard is live, so
-    // the level is at least our own `+1` whatever peers do. Together with the
-    // `blocking_entry_level >= 2` assert below (which ties the closure's guard to
-    // the same atomic as ours) this chains the production closure to
-    // `saturation::BLOCKING_TASKS` without any baseline differencing.
+    // Link 1: our end of the anchor.
     assert!(
         crate::saturation::blocking_tasks_in_use_level() >= 1,
         "a real BlockingTaskGuard::enter() must increment the shared atomic that \
@@ -852,17 +839,34 @@ fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
              cqlite.flight.blocking_tasks_in_use atomic this test holds a guard on: \
              its own post-increment reading counts our live guard plus its own +1"
         );
+        // Link 4: the closure still HOLDS its guard here, so the live level counts
+        // both guards. Deterministic, not probabilistic: `batch_size = 1` over
+        // n = 40 single-row partitions means the merge owes 40 sends, while
+        // DO_GET_CHANNEL_CAPACITY is 4 — so having consumed only the first batch,
+        // the producer can be at most ~capacity + in-flight-send + encoder-prefetch
+        // batches ahead (the bound `first_batch_available_before_merge_completes`
+        // and `slow_consumer_bounds_produced_batches` pin at this same point) and
+        // is parked in `send` on the full channel with >30 batches still to emit. It
+        // cannot leave the closure (dropping the guard) until it has sent them all
+        // or is cancelled, and nothing cancels before the `drop(stream)` below. The
+        // egress credit pool cannot end it early either: 12 MiB of default budget
+        // versus 1-row batches, so the count governor binds first. If
+        // DO_GET_CHANNEL_CAPACITY ever rises to >= n, this premise dies — keep the
+        // two numbers apart rather than weakening the assert.
+        assert!(
+            crate::saturation::blocking_tasks_in_use_level() >= 2,
+            "the merge closure's guard must still be HELD while it produces (our \
+             guard + its guard); an entered-and-immediately-dropped guard would \
+             leave cqlite.flight.blocking_tasks_in_use reading 0 for the whole merge"
+        );
         // Drop the stream to cancel + join the merge; the guard drops on exit.
         drop(stream);
         let _ = handle.await;
     });
 
-    // The merge's guard has dropped (the closure returned). Its decrement did not
+    // The merge's guard has dropped (the closure returned): its decrement did not
     // take the shared atomic below the contribution of the guard THIS test still
-    // holds — an underflow bound, not a claim that the drop was exactly -1 (peers
-    // mutate the same atomic concurrently, so the exact magnitude is unprovable
-    // here; `saturation::tests::blocking_task_guard_rises_and_balances` pins the
-    // rise/balance arithmetic against a private atomic).
+    // holds. An underflow bound only — see the doc comment.
     assert!(
         crate::saturation::blocking_tasks_in_use_level() >= 1,
         "the blocking-task gauge must not underflow past this test's own live guard"

--- a/cqlite-flight/src/streaming_tests.rs
+++ b/cqlite-flight/src/streaming_tests.rs
@@ -760,23 +760,35 @@ fn metrics_parity_on_full_consumption() {
 /// [`crate::saturation::BlockingTaskGuard`] is entered by the REAL streaming
 /// `spawn_blocking` merge closure — not merely a standalone unit of the guard.
 ///
-/// The observation is OWN-GUARD-ATTRIBUTABLE, so it cannot flake under the
-/// parallel runner (issue #2896). Two probe readings, both written by the
-/// production closure itself:
+/// The observation is OWN-GUARD-ATTRIBUTABLE *and* anchored to the shared
+/// process-global atomic that actually backs the gauge, so it cannot flake under
+/// the parallel runner (issue #2896). The test enters a REAL guard of its own
+/// (`BlockingTaskGuard::enter`, the same production constructor — never the
+/// private-atomic `enter_on`) and holds it across the whole observation, then
+/// asserts:
 ///
 /// * `blocking_entries == 1` — this stream's closure entered exactly one real
 ///   `BlockingTaskGuard` (the wiring evidence: the guard lives in the REAL
 ///   `spawn_blocking` merge closure, not in a standalone unit test);
-/// * `blocking_entry_level >= 1` — the level that guard read off the shared
-///   production atomic at its own entry. It is a POST-increment value, so it
-///   includes our own `+1` and stays valid however peer guards come and go.
+/// * `blocking_entry_level >= 2` — the level THAT guard read off the shared
+///   atomic at its own entry. Since this test holds a live guard, the level was
+///   already `>= 1` when the closure entered, so its post-increment read is
+///   `>= 2`. This is what ties the closure's guard to the SAME atomic as ours:
+///   re-pointing `enter()` at a private/different counter (or dropping the
+///   increment and reporting a synthetic level) breaks it.
+/// * after the merge is joined, `blocking_tasks_in_use_level() >= 1` — the
+///   closure's RAII drop did not decrement the shared atomic past our own still
+///   -held contribution (an underflow bound, NOT a proof that the drop was
+///   exactly `-1`).
 ///
-/// The earlier form differenced the process-global gauge against a `base`
-/// snapshot; a peer streaming test holding a guard when `base` was read (and
-/// dropping it before the assert) inflated the baseline and flaked the assert
-/// (#2896). The global gauge only supports its underflow invariant (`>= 0`),
-/// asserted after drain here; the exact rise/balance arithmetic is pinned
-/// deterministically against a private atomic by
+/// Each bound is peer-proof because every other live guard contributes `0` or
+/// `+1` at any instant: peers can only push these values HIGHER, never lower,
+/// and `blocking_entry_level` is an immutable `i64` snapshot once taken. The
+/// earlier form instead differenced the global against a pre-load `base`
+/// snapshot, so a peer holding a guard at `base`-read time (and releasing before
+/// the assert) inflated the baseline and flaked the assert (#2896). Exact
+/// rise/balance arithmetic is not provable here (peers mutate the same atomic
+/// concurrently) and is pinned deterministically against a private atomic by
 /// `saturation::tests::blocking_task_guard_rises_and_balances`.
 #[test]
 fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
@@ -789,6 +801,25 @@ fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let pr = probe();
     let pr_check = pr.clone();
+    // A REAL guard on the shared production atomic (never the private-atomic
+    // `enter_on`), held for the rest of the test: it raises the floor the merge
+    // closure's own guard must read, which is what anchors the assertions below to
+    // the SAME atomic the gauge is published from. It emits one true gauge reading,
+    // as any production entry does; no test asserts on recorded gauge VALUES for
+    // `cqlite.flight.blocking_tasks_in_use` (the OTel capture harness runs in a
+    // separate integration-test process), so nothing else is perturbed.
+    let own_guard = crate::saturation::BlockingTaskGuard::enter();
+    // Our end of the anchor: a real `enter()` must be visible on the SHARED atomic
+    // the public read seam (and the gauge) reads. Peer-proof — our guard is live, so
+    // the level is at least our own `+1` whatever peers do. Together with the
+    // `blocking_entry_level >= 2` assert below (which ties the closure's guard to
+    // the same atomic as ours) this chains the production closure to
+    // `saturation::BLOCKING_TASKS` without any baseline differencing.
+    assert!(
+        crate::saturation::blocking_tasks_in_use_level() >= 1,
+        "a real BlockingTaskGuard::enter() must increment the shared atomic that \
+         backs cqlite.flight.blocking_tasks_in_use"
+    );
     rt.block_on(async move {
         let (mut stream, handle) = spawn_streaming(
             producer,
@@ -802,7 +833,11 @@ fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
             timer(),
         );
         // Pull the schema + first batch: to emit a batch the merge closure must
-        // have entered its `BlockingTaskGuard` and started producing.
+        // have entered its `BlockingTaskGuard` and started producing. That channel
+        // recv is ALSO the release/acquire edge that makes the `Relaxed` probe loads
+        // below sound: the closure's probe writes happen-before its batch send, so
+        // they are visible here. Do NOT hoist these asserts above the batch read —
+        // without that edge they would be racy.
         let _schema_msg = read_one(&mut stream).await.expect("schema message");
         let _first_batch = read_one(&mut stream).await.expect("first batch");
         assert_eq!(
@@ -812,22 +847,27 @@ fn blocking_tasks_gauge_tracks_real_streaming_do_get() {
              BlockingTaskGuard (proves the gauge is wired into the production path)"
         );
         assert!(
-            pr_check.blocking_entry_level.load(Ordering::Relaxed) >= 1,
-            "that guard's own post-increment reading of the shared \
-             cqlite.flight.blocking_tasks_in_use atomic must include its own +1"
+            pr_check.blocking_entry_level.load(Ordering::Relaxed) >= 2,
+            "the closure's guard must increment the SAME shared \
+             cqlite.flight.blocking_tasks_in_use atomic this test holds a guard on: \
+             its own post-increment reading counts our live guard plus its own +1"
         );
         // Drop the stream to cancel + join the merge; the guard drops on exit.
         drop(stream);
         let _ = handle.await;
     });
 
-    // The RAII drop balanced the entry: the process-global gauge is a count of
-    // live guards, so it never goes negative (the only global invariant a
-    // concurrently-running peer test cannot invalidate).
+    // The merge's guard has dropped (the closure returned). Its decrement did not
+    // take the shared atomic below the contribution of the guard THIS test still
+    // holds — an underflow bound, not a claim that the drop was exactly -1 (peers
+    // mutate the same atomic concurrently, so the exact magnitude is unprovable
+    // here; `saturation::tests::blocking_task_guard_rises_and_balances` pins the
+    // rise/balance arithmetic against a private atomic).
     assert!(
-        crate::saturation::blocking_tasks_in_use_level() >= 0,
-        "the blocking-task gauge must never underflow"
+        crate::saturation::blocking_tasks_in_use_level() >= 1,
+        "the blocking-task gauge must not underflow past this test's own live guard"
     );
+    drop(own_guard);
 }
 
 // ---- Issue #2162 Stage 1: rpc.rows/rpc.bytes move per batch ----------------


### PR DESCRIPTION
Fixes #2896.

## Problem

`blocking_tasks_gauge_tracks_real_streaming_do_get` read the **process-global** `saturation::BLOCKING_TASKS` counter into `base`, then asserted `level() > base`. Its doc comment justified this as a robust lower bound because "concurrent tests can only ADD to the shared count" — **that reasoning was wrong**. Peer `spawn_streaming` tests in the same binary hold real guards against the same global, so `base` could be *inflated*; when those peers finished before the assertion, the level legitimately fell to `<= base` while this test's guard was correctly held.

The trailing `level() >= base` assert had the identical latent defect and is also fixed here.

Per #2896's escalation, this flake became **merge-blocking on every `cqlite-core/**` PR** once the Flight tier was mandated and `required` began failing closed.

## Fix — own-guard-attributable observation

Race-freedom now comes from *attribution*, not from assuming exclusivity on a shared global. The test holds a REAL production guard of its own across the whole observation, then asserts four links, each a **sound lower bound** (peers can only raise these values, so none can flake):

| Link | Assertion | Proves |
|------|-----------|--------|
| 1 | `blocking_tasks_in_use_level() >= 1` while the test's own guard is live | a real `enter()` reaches the shared atomic the gauge is published from |
| 2 | `pr.blocking_entries == 1` | the REAL `spawn_blocking` merge closure entered exactly one guard (not a standalone unit of the guard) |
| 3 | `pr.blocking_entry_level >= 2` | that guard's own post-increment reading counts the test's live guard **plus** its own `+1` — tying it to the SAME atomic |
| 4 | `blocking_tasks_in_use_level() >= 2` while the merge is still producing | the closure **HOLDS** its guard for the merge's duration; an entered-and-immediately-dropped guard would leave the gauge reading 0 for the whole merge |

Implementation:

- `saturation.rs` — `BlockingTaskGuard` retains the post-increment level that `adjust(&BLOCKING_TASKS, 1)` already computes (`entry_level` field + `pub(crate) entry_level()`). No second read of the atomic, so no new observation race. `blocking_tasks_in_use_level` carries the normative soundness rule for lower-bound assertions against this global.
- `streaming.rs` — the REAL `spawn_blocking` merge closure publishes its guard's entry through two always-maintained `StreamProbe` atomics, `blocking_entries` and `blocking_entry_level`, matching the existing `produced_batches`/`emitted_batches`/`errors_recorded` pattern. The guard remains the closure's first act and still drops last.
- `streaming_tests.rs` — the four links above. After the merge is joined, a final `>= 1` bounds the closure's RAII decrement against underflow past the test's own still-held contribution (an underflow bound only — the exact rise/balance arithmetic stays pinned against a *private* atomic by `saturation::tests::blocking_task_guard_rises_and_balances`).

Because the guard binding is now *used*, the classic `let _ = BlockingTaskGuard::enter();` immediate-drop regression no longer compiles.

### Link 4's timing premise is deterministic, not probabilistic

`batch_size = 1` over `n = 40` single-row partitions means the merge owes 40 sends, while `DO_GET_CHANNEL_CAPACITY = 4` — a **10x margin**. Having consumed only the first batch, the producer can be at most ~capacity + in-flight-send + encoder-prefetch batches ahead and is parked in `send` on a full channel with >30 batches still to emit; it cannot leave the closure (dropping the guard) until it has sent them all or is cancelled, and nothing cancels before `drop(stream)`. The egress credit pool cannot end it early either (12 MiB default budget vs 1-row batches, so the count governor binds first). **If `DO_GET_CHANNEL_CAPACITY` ever rises to `>= n` this premise dies — keep the two numbers apart rather than weakening the assert** (noted in-code).

## Verification

### Negative controls — proof this is not a vacuous pass

Four controls were run during the implementation rounds, each tripping a **different** assertion link, each then restored **byte-identically** (`md5sum`-verified, clean tree):

| # | Mutation | Trips |
|---|----------|-------|
| a | closure's `BlockingTaskGuard::enter()` removed | link 2 — `left: 0 right: 1`, "must enter exactly one BlockingTaskGuard" |
| b | closure's `enter()` re-pointed at a private atomic | link 3 — entry level no longer counts the test's live guard |
| c | closure publishes a synthetic entry level instead of the guard's real post-increment read | link 3 |
| d | closure's guard entered then immediately dropped | link 4 — the held-for-duration signal |

The gate of record below ran on the **restored** tree (`tree-integrity: PASS`, `tree-start == tree-end`, `dirty: no`).

### Flake reproduction retired

**20/20 consecutive green** runs of the full `cqlite-flight` lib binary at default parallelism (the flake condition), 354 passed / 1 ignored per run.

### Memory ordering

The `Relaxed` probe reads are ordered by the tokio mpsc send/recv release/acquire pair on the first-batch receive: the closure's probe writes happen-before its batch send, so they are visible at the assertion point. The asserts must not be hoisted above the batch read (noted in-code).

## Review history (three rounds, not zero)

- **rust-reviewer** (round 1): no blockers — but flagged the missing **hold-duration** coverage as a nit.
- **roborev round 1**: one **Medium** — the new assertions no longer proved the closure's guard touched the *shared* global. Fixed in round 2 (link 3: the guard's own post-increment read, anchored by the test's own real guard).
- **roborev round 2**: one **Medium** — the *held-for-duration* property was still unproven. Fixed in round 3 (link 4 + negative control (d)).
- **roborev round 3**: **0 blockers, 2 Low nits** — merge-clean. Nits are batched into a linked follow-up, per `docs/development/roborev-severity.md` (nits never trigger a re-verify round):
  1. link 4's `>= 2` is a global lower bound a concurrent peer guard could also satisfy, so the doc overstates per-stream attributability. This is a **false-negative / sensitivity** limit only — it cannot cause a spurious failure, so it reintroduces no flake.
  2. `read_one(...).expect(...)` unwraps only the `Option`, discarding the inner `Result<FlightData, Status>`, so a mid-stream merge error would misattribute to a gauge-wiring bug. Diagnosability, not a wrong pass/fail.

## Acceptance criteria (#2896)

- [x] Race-free lower bound attributable to the test's own guard, rather than reading a shared global and assuming exclusivity.
- [x] Passes deterministically with the full `cqlite-flight` test binary at parallel test threads (the flake condition): **20/20 consecutive green**, 354 passed / 1 ignored per run.
- [x] No wall-clock threshold assertions introduced (#2642 — `roborev-lints` PASS).
- [x] Not a vacuous pass — four negative controls, one per assertion link.

Routing: **oracle-driven** (deterministic race in a test's own bookkeeping) — no OpenSpec change, so no `spec-auditor` (C) stage applies.

File sizes (campsite rule, no `CQLITE_ALLOW_FILE_GROWTH` used): `saturation.rs` 797/800, `streaming.rs` 681/800, `streaming_tests.rs` 1449/1500 — `file-size: PASS`.

## Gate of record

The ONE full `scripts/agent-gate.sh` run that counts, in the issue worktree at the certified SHA, with `CQLITE_DATASETS_ROOT` pointed at a checkout holding the real Data.db binaries (144 present, so no fail-closed on missing fixtures):

```
==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.AG31Cz
commit: 1c49fcb branch: issue-2896-blocking-gauge-flake dirty: no
datasets: 144 Data.db files under /home/ubuntu/workspace/repo/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=absent
cpu-budget: wrapper=nice ncpu=16 max-concurrency=3 cores-per-gate=5 build-jobs=5(derived) test-threads=5
tree-start: 1c49fcbeb5f0 dirty: no digest: 3779e68949ec
tree-end: 1c49fcbeb5f0 dirty: no digest: 3779e68949ec
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (5s)
clippy:            PASS (3s)
roborev-lints:     PASS (1s)
core-tests:        PASS (684s)
tombstones-scan:   PASS (42s)
scan-offload-guard: PASS (140s)
work-counters-guard: PASS (92s)
byte-budget-guard: PASS (24s)
arrow-parity-guard: PASS (63s)
memory-budget:     PASS (623s)
integration-tests: PASS (53s)
format-compat:     PASS (37s)
write-tests:       PASS (132s)
cli-tests:         PASS (151s)
compaction-byte-parity: PASS (11s)
query-semantics-oracle: PASS (0s)
flight-query-semantics-oracle: PASS (9s)
python-bindings:   PASS (722s)
node-bindings:     PASS (509s)
delivery-telemetry: PASS (1s)
oom-audit:         PASS (6s)
parity-report:     PASS (19s)
operator-metrics-doc: PASS (28s)
kit-dashboard-drift: PASS (1s)
binding-unwind-profile: PASS (1s)
tooling-tests:     PASS (305s)
minimal-build:     PASS (51s)
smoke:             PASS (111s)
logs: /tmp/agent-gate.AG31Cz
summary-file: /tmp/gate-2896-full.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Certified SHA: `1c49fcbeb5f0da55f348bbeda75798cbf3d3f3b2`. Pre-merge SHA assert (`scripts/flow/premerge-assert.sh`) confirms the PR head still equals it before auto-merge is armed.
