### PR TITLE
fix(#3033): make an unreadable ci:waive evidence read loudly distinguishable from nothing-to-waive

### DIFF
--- a/docs/ci/ci-tier-policy.md
+++ b/docs/ci/ci-tier-policy.md
@@ -191,6 +191,11 @@ Rules for `pull_request`-triggered workflows:
   actually IN FORCE, and an untrusted label read makes that count UNKNOWN rather
   than zero. Whether such an event BINDS stays a per-tier verdict. Every one of
   those states is reported and none of them changes the verdict.
+- No two lines of one report may contradict each other. Every claim about labels is
+  phrased against "the label set this run is using" plus that set's provenance (live
+  read, or the run-start payload), because that is the only thing the report observes;
+  and a run that ADMITS a read failed emits no denial that one did — the operator never
+  gets `permissions:` advice beside an "authorization is not the problem" line.
 - A waiver label is `ci:waive:<tier-id>` with a LOWER-CASE tier id
   (`[a-z0-9][a-z0-9-]*`) — the shape the evaluator matches. A `ci:waive:`-prefixed
   label that misses it (`ci:waive:Flight`) waives nothing, and the report says so,

--- a/docs/ci/ci-tier-policy.md
+++ b/docs/ci/ci-tier-policy.md
@@ -191,6 +191,11 @@ Rules for `pull_request`-triggered workflows:
   actually IN FORCE, and an untrusted label read makes that count UNKNOWN rather
   than zero. Whether such an event BINDS stays a per-tier verdict. Every one of
   those states is reported and none of them changes the verdict.
+- A waiver label is `ci:waive:<tier-id>` with a LOWER-CASE tier id
+  (`[a-z0-9][a-z0-9-]*`) — the shape the evaluator matches. A `ci:waive:`-prefixed
+  label that misses it (`ci:waive:Flight`) waives nothing, and the report says so,
+  naming the label: it is neither a waiver in force (nothing is read for it, and no
+  evidence state is reported about it) nor an absence of waiver labels.
 - A registered tier's context is satisfied ONLY by a check run GitHub Actions
   produced. A check-run name is global to the commit and anything with
   `checks:write` can mint one, so provenance (`app` + an Actions run URL) is

--- a/docs/ci/ci-tier-policy.md
+++ b/docs/ci/ci-tier-policy.md
@@ -183,6 +183,14 @@ Rules for `pull_request`-triggered workflows:
 - The honoured-waiver annotation names WHO APPLIED THE LABEL, resolved from the
   PR's `labeled` events — not the actor of the run, who is usually someone else.
   An unresolvable attribution says so rather than naming anyone.
+- The waiver-evidence report states OBSERVATIONS, never a derived capability. It
+  claims that no waiver label is present only when the LIVE label read succeeded on
+  that poll; a read that fell back to the run-start event payload reports UNKNOWN
+  instead, because a label applied mid-run is invisible to that snapshot. `labeled`
+  events are immutable history, so evidence is counted only for a waiver label
+  actually IN FORCE, and an untrusted label read makes that count UNKNOWN rather
+  than zero. Whether such an event BINDS stays a per-tier verdict. Every one of
+  those states is reported and none of them changes the verdict.
 - A registered tier's context is satisfied ONLY by a check run GitHub Actions
   produced. A check-run name is global to the commit and anything with
   `checks:write` can mint one, so provenance (`app` + an Actions run URL) is

--- a/scripts/ci/aggregate-required-tiers.sh
+++ b/scripts/ci/aggregate-required-tiers.sh
@@ -637,9 +637,10 @@ done <"$OBSERVATIONS"
 
 # ----------------------------------------- waiver evidence, always on record --
 # The state is stated for EVERY run, including the ordinary "nothing to waive"
-# one, so that the abnormal states read as abnormal instead of having to be
-# inferred from a silence that also covers a missing `issues: read` grant
-# (issue #3033). This block never changes the verdict.
+# one, so an abnormal state READS as abnormal instead of having to be inferred from
+# a silence the healthy case produces too (issue #3033). One line in the ordinary
+# case; the diagnosis only when there is something to diagnose. This block never
+# changes the verdict.
 emit ""
 case "$WAIVER_EVIDENCE_STATE" in
   none)

--- a/scripts/ci/aggregate-required-tiers.sh
+++ b/scripts/ci/aggregate-required-tiers.sh
@@ -178,7 +178,13 @@ case "$CORE_CONTEXT" in
 esac
 case "$EVENT_ACTION_IN" in
   "" ) : ;;
-  *[!a-z_]* ) fail_closed "--event-action is not a pull_request activity type: '$EVENT_ACTION_IN'" ;;
+  # Spelled out, not `[a-z_]`: a glob range is COLLATION-ordered on bash < 5.0
+  # (`aAbB…`), where `[a-z]` also accepts upper case — so this guard would have been
+  # laxer than the lower-case activity types it validates. Its siblings above are
+  # case-symmetric (`A-Za-z0-9`) and immune; this one and the tier-id shape were the
+  # two case-sensitive ranges in the file (issue #3033 round 7). Stricter is the
+  # fail-closed direction for a validator.
+  *[!abcdefghijklmnopqrstuvwxyz_]* ) fail_closed "--event-action is not a pull_request activity type: '$EVENT_ACTION_IN'" ;;
 esac
 # WAIVER ATTRIBUTION (issue #2910 round 4). This used to name `$GITHUB_ACTOR` —
 # the actor of the event that started THIS run (a pusher, or whoever hit re-run),
@@ -411,6 +417,8 @@ WAIVER_EVIDENCE_COUNT=0         # `labeled` events in the feed, last successful 
 WAIVER_EVIDENCE_HISTORY_COUNT=0 # of those, ones for ANY `ci:waive:` label, ever
 WAIVER_EVIDENCE_INFORCE_COUNT=0 # of those, ones for a waiver label IN FORCE now
 WAIVER_EVIDENCE_FAILURES=0      # polls whose read failed, however it ended up
+WAIVER_EVIDENCE_READS=0         # polls whose read SUCCEEDED, ever — so a later poll
+                                # cannot claim the feed was never read
 WAIVER_UNCONFIGURED_WARNED=false # the unconfigured warning is emitted once per run
 
 # WHETHER `LABELS_NOW` WAS ACTUALLY OBSERVED (issue #3033 round 4). The label
@@ -428,6 +436,8 @@ LABELS_READ_DETAIL=""           # the LAST such failure, condensed; never cleare
 # normalised EXACTLY as gating_registry.rb normalises them (comma split, strip,
 # then the tier-id shape) so the evidence report cannot disagree with the verdict.
 INFORCE_WAIVER_LABELS=""
+INFORCE_LABELS_SHOWN=""         # the same list as an annotation prints it: bounded
+INVALID_LABELS_SHOWN=""         # ditto for the off-shape list below
 # The `ci:waive:`-PREFIXED labels that are NOT waiver labels — an off-shape tier id
 # (issue #3033 round 6). Its own state, because it is neither "no waiver label
 # present" nor an API/authorization problem: a label IS applied, in a shape
@@ -500,31 +510,65 @@ compute_inforce_waiver_labels() {
     # who typed it believes they waived a tier, and only this list can say
     # otherwise. Still pure shell (see the header): a sanitiser that could fail
     # would silently empty the list and take the diagnostic with it.
+    #
+    # THE CHARACTER SET IS SPELLED OUT, NOT A RANGE (issue #3033 round 7). Glob
+    # ranges like `[a-z]` are matched by COLLATION ORDER, not by ASCII, unless
+    # `globasciiranges` is set — and that is only on by default from bash 5.0. Under
+    # glibc with a UTF-8 locale the collation order is `aAbBcC…`, so on bash 3.2/4.x
+    # `[a-z]` matches most UPPER-CASE letters and `ci:waive:BETA` would have been
+    # classified IN FORCE: the report claiming a waiver the ruby evaluator's
+    # /\A…[a-z0-9]…\z/ ignores, on the one code path whose entire purpose is that
+    # the two cannot disagree. macOS ships `/bin/bash` 3.2 and is a first-class host
+    # for these scripts, so this was live. An explicit set is version- and
+    # locale-independent, where `shopt -s globasciiranges` silently no-ops on 3.2.
+    # `-` is last inside the bracket, where it is a literal.
     case "$tier" in
-      ''|[!a-z0-9]*|*[!a-z0-9-]*)
+      ''|[!abcdefghijklmnopqrstuvwxyz0123456789]*|*[!abcdefghijklmnopqrstuvwxyz0123456789-]*)
         # The WHOLE label is recorded, not the tier id, so a bare `ci:waive:` with
         # nothing after it still names itself in the report.
         safe="${item//[[:cntrl:]]/}"   # the summary line must stay ONE line
         safe="${safe//::/__}"          # defang workflow-command syntax
         safe="${safe:0:80}"            # bound one label's contribution
-        # Bounded overall, so a pull request wearing many off-shape labels cannot
-        # produce an unbounded annotation, and deduplicated so a repeated
-        # `--labels` entry is named once.
-        if [ "${#INVALID_WAIVER_LABELS}" -lt 240 ]; then
-          case ",${INVALID_WAIVER_LABELS}," in
-            *",${safe},"*) ;;
-            *) INVALID_WAIVER_LABELS="${INVALID_WAIVER_LABELS}${safe}," ;;
-          esac
-        fi
+        case ",${INVALID_WAIVER_LABELS}," in
+          *",${safe},"*) ;;            # a repeated label is named once
+          *) INVALID_WAIVER_LABELS="${INVALID_WAIVER_LABELS}${safe}," ;;
+        esac
         continue
         ;;
     esac
+    case ",${INFORCE_WAIVER_LABELS}," in
+      *",${item},"*) continue ;;       # ditto: deduplicated, so it is reported once
+    esac
     INFORCE_WAIVER_LABELS="${INFORCE_WAIVER_LABELS}${item},"
   done
+  # WHAT THE ANNOTATIONS PRINT, bounded HERE rather than at collection (issue #3033
+  # round 7). GitHub allows up to 100 labels on a pull request, so an unbounded list
+  # interpolated into a `::warning::` is an unbounded annotation. It is bounded at
+  # DISPLAY because the collected in-force set is what the event match keys on, and
+  # dropping a label from THAT would change what is counted; shortening a sentence
+  # cannot. The in-force names need no sanitising — they passed the shape check above,
+  # so they are lower-case alphanumerics and dashes; the off-shape ones were sanitised
+  # at collection, where their shape is by definition unknown.
+  INFORCE_LABELS_SHOWN="${INFORCE_WAIVER_LABELS%,}"
+  if [ "${#INFORCE_LABELS_SHOWN}" -gt 240 ]; then
+    INFORCE_LABELS_SHOWN="${INFORCE_LABELS_SHOWN:0:240}… (truncated)"
+  fi
+  INVALID_LABELS_SHOWN="${INVALID_WAIVER_LABELS%,}"
+  if [ "${#INVALID_LABELS_SHOWN}" -gt 240 ]; then
+    INVALID_LABELS_SHOWN="${INVALID_LABELS_SHOWN:0:240}… (truncated)"
+  fi
   return 0
 }
 
-# How many `labeled` events in the feed are for a waiver label IN FORCE.
+# THE THREE FEED COUNTS, in one pass: records read, records for ANY `ci:waive:`
+# label (immutable history), and records for a waiver label IN FORCE.
+#
+# RECORDS, NOT LINES (issue #3033 round 7). The feed total was `grep -c ''`, which
+# counts lines — so a trailing newline or an empty `--jq` record made the summary say
+# "2 `labeled` event(s)" when ONE event was read. An overcount is a claim outrunning
+# the evidence just like an over-claimed capability, in the block whose contract is
+# "observations, not conclusions". A blank line is not a record, and is not counted as
+# one anywhere now (the in-force count already refused it).
 #
 # PURE SHELL ON PURPOSE. An external counter (awk) would add a failure mode of its
 # own — and a count that failed to compute may not be reported as zero, so it would
@@ -538,16 +582,26 @@ compute_inforce_waiver_labels() {
 # IFS covers space/tab/CR so the label field is normalised the way
 # gating_registry.rb strips it; no shape that can match a waiver label contains any
 # of those, and an unmatched line only ever WITHHOLDS a claim.
-count_inforce_waiver_events() {
-  local count=0 label=""
+count_waiver_events() {
+  local label=""
+  WAIVER_EVIDENCE_COUNT=0
+  WAIVER_EVIDENCE_HISTORY_COUNT=0
+  WAIVER_EVIDENCE_INFORCE_COUNT=0
   while IFS=$' \t\r' read -r label _ || [ -n "$label" ]; do
-    # A blank feed line must not match the empty slot a trailing comma leaves.
+    # A blank feed line is no record: it must count for nothing, and must not match
+    # the empty slot a trailing comma leaves in the label list.
     [ -n "$label" ] || continue
+    WAIVER_EVIDENCE_COUNT=$((WAIVER_EVIDENCE_COUNT + 1))
+    # The label is field 1 of `<label>\t<actor>\t<iso8601>`, so this counts LABEL
+    # matches and cannot be fooled by an actor's login.
+    case "$label" in
+      ci:waive:*) WAIVER_EVIDENCE_HISTORY_COUNT=$((WAIVER_EVIDENCE_HISTORY_COUNT + 1)) ;;
+    esac
     case ",${INFORCE_WAIVER_LABELS}," in
-      *",${label},"*) count=$((count + 1)) ;;
+      *",${label},"*) WAIVER_EVIDENCE_INFORCE_COUNT=$((WAIVER_EVIDENCE_INFORCE_COUNT + 1)) ;;
     esac
   done <"$WAIVER_EVENTS_FILE"
-  printf '%s' "$count"
+  return 0
 }
 
 # The PR's CURRENT labels, re-read every poll so a waiver applied while this job
@@ -653,7 +707,7 @@ read_waiver_events() {
     # The summary block carries the persistent record.
     if [ "$WAIVER_UNCONFIGURED_WARNED" != "true" ]; then
       WAIVER_UNCONFIGURED_WARNED=true
-      echo "::warning::waiver evidence UNAVAILABLE: the waiver label(s) ${INFORCE_WAIVER_LABELS%,} are in force" \
+      echo "::warning::waiver evidence UNAVAILABLE: the waiver label(s) ${INFORCE_LABELS_SHOWN} are in force" \
            "(shape-checked against what the evaluator accepts), but this run has no label-event" \
            "source (no --waiver-events-cmd, and --repo/--pr-number were not both supplied), so the waiver cannot be" \
            "bound to this head sha or attributed to whoever applied it; it will still apply at the aggregation" \
@@ -666,11 +720,10 @@ read_waiver_events() {
   eval "$WAIVER_EVENTS_CMD" >"$WAIVER_EVENTS_FILE" 2>"$WORK_DIR/waiver-events.err" || rc=$?
   if [ "$rc" -eq 0 ]; then
     WAIVER_EVIDENCE_STATE=read
-    WAIVER_EVIDENCE_COUNT="$(grep -c '' "$WAIVER_EVENTS_FILE" || true)"
-    # The label is field 1 of `<label>\t<actor>\t<iso8601>`, so anchoring at the
-    # line start counts LABEL matches and cannot be fooled by an actor's login.
-    # This is the whole HISTORY of waiver labellings on this pull request.
-    WAIVER_EVIDENCE_HISTORY_COUNT="$(grep -c '^ci:waive:' "$WAIVER_EVENTS_FILE" || true)"
+    # Successful reads are counted like the failures are (issue #3033 round 7): a
+    # later poll must be able to say that the feed WAS read earlier, instead of
+    # claiming nothing ever was.
+    WAIVER_EVIDENCE_READS=$((WAIVER_EVIDENCE_READS + 1))
     # HISTORY IS NOT STATE (issue #3033 round 4). `labeled` events are IMMUTABLE:
     # a `ci:waive:alpha` applied months ago and removed the same day is in this feed
     # forever. Counting those kept the "the evidence is present" claim alive while
@@ -679,8 +732,8 @@ read_waiver_events() {
     # Only events for a label IN FORCE can bind or attribute anything, so the feed
     # is intersected with `INFORCE_WAIVER_LABELS`. When the label read was untrusted
     # that set is itself unobserved, and the reporting section says UNKNOWN rather
-    # than reporting this number.
-    WAIVER_EVIDENCE_INFORCE_COUNT="$(count_inforce_waiver_events)"
+    # than reporting this number. All three counts come from one pure-shell pass.
+    count_waiver_events
     return 0
   fi
   sed 's/^/  /' "$WORK_DIR/waiver-events.err" >&2 || true
@@ -694,7 +747,7 @@ read_waiver_events() {
   # (`gh` absent, a bad --jq), which no re-run fixes.
   echo "::warning::waiver evidence UNREADABLE: the read of this pull request's label events FAILED" \
        "(${WAIVER_EVIDENCE_DETAIL}) — this is a BROKEN READ, NOT an absence of waiver labels, because the label" \
-       "set this poll is using carries the waiver label(s) ${INFORCE_WAIVER_LABELS%,}, shape-checked against what" \
+       "set this poll is using carries the waiver label(s) ${INFORCE_LABELS_SHOWN}, shape-checked against what" \
        "the evaluator accepts. 401/403/404 means the token running this workflow may not read this pull" \
        "request's events (check the workflow's permissions block); a 403 naming a rate limit, or a 5xx, is" \
        "transient; no HTTP status at all means the client failed (gh unavailable, or a bad --jq). Issue #3033." \
@@ -896,20 +949,36 @@ if [ "$LABELS_READ_STATE" = "fallback" ]; then
 fi
 
 # An off-shape `ci:waive:` label was READ from whichever label set this run had, so
-# the trust of that read qualifies what may be said about the absence of a VALID
-# one alongside it — under a failed live read, absence is not claimable at all.
+# the trust of that read qualifies BOTH halves of what may be said: that the off-shape
+# label is applied, and that no VALID one is (issue #3033 round 7 — the first version
+# of this line asserted the presence unconditionally, which is the same claim-outruns-
+# observation defect the round-4 fix removed from the absence line). Only a successful
+# LIVE read observed what is applied NOW; the other two states are the run-start
+# snapshot, under which the label may since have been removed.
+OFFSHAPE_PRESENCE="are applied"
 OFFSHAPE_LABEL_SET_NOTE=""
 case "$LABELS_READ_STATE" in
   fallback)
-    OFFSHAPE_LABEL_SET_NOTE=" No valid \`ci:waive:<tier-id>\` label is in the run-start event payload either, but the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}), so absence of a valid one is NOT claimed."
+    OFFSHAPE_PRESENCE="were in the run-start event payload and the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}), so whether they are still applied was NOT observed"
+    OFFSHAPE_LABEL_SET_NOTE=" No valid \`ci:waive:<tier-id>\` label was in that snapshot either, so absence of a valid one is NOT claimed."
     ;;
   payload)
-    OFFSHAPE_LABEL_SET_NOTE=" No valid \`ci:waive:<tier-id>\` label is in the run-start event payload, which is the only label set this run had (no live label source configured)."
+    OFFSHAPE_PRESENCE="are in the run-start event payload, the only label set this run had (no live label source configured), so whether they are still applied was never looked for"
+    OFFSHAPE_LABEL_SET_NOTE=" No valid \`ci:waive:<tier-id>\` label is in that payload."
     ;;
   *)
     OFFSHAPE_LABEL_SET_NOTE=" No valid \`ci:waive:<tier-id>\` label is present on this pull request."
     ;;
 esac
+# "Nothing was read" is a claim about the RUN, not the poll: a valid waiver label
+# earlier in the run whose feed read SUCCEEDED, then removed and mistyped, makes the
+# unconditional form false. The failure counter has always been carried forward for
+# exactly this reason; the success counter now is too.
+if [ "$WAIVER_EVIDENCE_READS" -gt 0 ]; then
+  OFFSHAPE_EVENTS_NOTE=" No \`labeled\` events were read on this poll — there is no waiver label to gather evidence for — though ${WAIVER_EVIDENCE_READS} earlier poll(s) DID read the feed, while a waiver label was in force."
+else
+  OFFSHAPE_EVENTS_NOTE=" No \`labeled\` events were read at any point: there was never a waiver label to gather evidence for."
+fi
 
 emit ""
 case "$WAIVER_EVIDENCE_STATE" in
@@ -922,10 +991,11 @@ case "$WAIVER_EVIDENCE_STATE" in
     # a ci:waive:<tier-id> label". The operator went looking at the workflow's
     # `permissions:` block for what is a capitalisation typo. This names the typo.
     if [ -n "$INVALID_WAIVER_LABELS" ]; then
-      emit "Waiver evidence: **INVALID WAIVER LABEL — it waives NOTHING** — the label(s) \`${INVALID_WAIVER_LABELS%,}\` are applied but are not waiver labels: a waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), which is the shape the registry evaluator matches, so it IGNORES these and no tier is waived by them.${OFFSHAPE_LABEL_SET_NOTE} No \`labeled\` events were read: there is no waiver label to gather evidence for."
+      emit "Waiver evidence: **INVALID WAIVER LABEL — it waives NOTHING** — the label(s) \`${INVALID_LABELS_SHOWN}\` ${OFFSHAPE_PRESENCE}, but they are not waiver labels: a waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), which is the shape the registry evaluator matches, so it IGNORES these and no tier is waived by them.${OFFSHAPE_LABEL_SET_NOTE}${OFFSHAPE_EVENTS_NOTE}"
       emit ""
       emit "> :warning: This is NOT \"no waiver labels present\", and NOT an authorization or API problem — no"
-      emit "> read was attempted and nothing failed. A \`ci:waive:\`-prefixed label IS applied, in a shape the"
+      emit "> read was attempted for these labels and nothing failed. A \`ci:waive:\`-prefixed label is in the"
+      emit "> label set this run is using, in a shape the"
       emit "> evaluator ignores; a capitalised tier id (\`ci:waive:Flight\` for tier \`flight\`) is the usual"
       emit "> cause. To waive a tier, apply \`ci:waive:<tier-id>\` with the tier id spelled exactly as"
       emit "> \`.github/ci-gating-tiers.yml\` spells it. Issue #3033."
@@ -990,7 +1060,7 @@ case "$WAIVER_EVIDENCE_STATE" in
     emit "Waiver evidence: **UNREADABLE (broken read — authorization, API or client failure)** — the \`labeled\` events for this pull request could not be read (${WAIVER_EVIDENCE_DETAIL}); ${WAIVER_EVIDENCE_FAILURES} failed read(s)."
     emit ""
     emit "> :warning: This is NOT \"no waiver labels present\" — the label set this run is using carries the waiver"
-    emit "> label(s) \`${INFORCE_WAIVER_LABELS%,}\`, shape-checked against what the evaluator accepts (an off-shape"
+    emit "> label(s) \`${INFORCE_LABELS_SHOWN}\`, shape-checked against what the evaluator accepts (an off-shape"
     emit "> \`ci:waive:\` label never reaches this state and is reported separately)."
     emit "> \`401\`/\`403\`/\`404\`: the token running this workflow may not read this pull request's events —"
     emit "> check the workflow's \`permissions:\` block. A \`403\` naming a rate limit, or any \`5xx\`: transient,"
@@ -1000,7 +1070,7 @@ case "$WAIVER_EVIDENCE_STATE" in
     emit "> resolve a tier early and is reported as \`applier UNRESOLVED\`."
     ;;
   unconfigured)
-    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — the label set this run is using carries the waiver label(s) \`${INFORCE_WAIVER_LABELS%,}\` (shape-checked against what the evaluator accepts) but this run was given no way to read the \`labeled\` events."
+    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — the label set this run is using carries the waiver label(s) \`${INFORCE_LABELS_SHOWN}\` (shape-checked against what the evaluator accepts) but this run was given no way to read the \`labeled\` events."
     emit ""
     emit "> :warning: The waiver is still honoured at the aggregation deadline, but it cannot resolve a tier"
     emit "> early and is reported as \`applier UNRESOLVED\`."
@@ -1013,7 +1083,7 @@ esac
 # first one did nothing. Said once, and only where it is not already the headline.
 if [ -n "$INVALID_WAIVER_LABELS" ] && [ "$WAIVER_EVIDENCE_STATE" != "none" ]; then
   emit ""
-  emit "> :warning: Also applied, and NOT a waiver label: \`${INVALID_WAIVER_LABELS%,}\`. A waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), so the evaluator IGNORES this one and it waives nothing; nothing above is about it."
+  emit "> :warning: Also applied, and NOT a waiver label: \`${INVALID_LABELS_SHOWN}\`. A waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), so the evaluator IGNORES this one and it waives nothing; nothing above is about it."
 fi
 emit_label_read_note
 

--- a/scripts/ci/aggregate-required-tiers.sh
+++ b/scripts/ci/aggregate-required-tiers.sh
@@ -446,7 +446,15 @@ waiver_error_detail() {
     return 0
   fi
   status="$(grep -o 'HTTP [0-9][0-9][0-9]' "$err" | head -n 1 || true)"
-  text="$(tr -d '[:cntrl:]' <"$err" | sed 's/::/__/g' | cut -c1-200)"
+  # `|| true` is load-bearing on BOTH substitutions, not decoration: this runs under
+  # `set -euo pipefail`, so a non-zero pipeline here would abort the whole aggregator
+  # with no summary and a non-zero exit -- turning UNREADABLE evidence (which must
+  # never change the verdict) into a RED `required`. That is reachable: BSD `tr`/`sed`
+  # exit 1 with "Illegal byte sequence" on non-UTF-8 stderr under a UTF-8 locale, and
+  # macOS is a first-class host for these scripts. A partial/empty detail string is
+  # always preferable to killing the run.
+  text="$(tr -d '[:cntrl:]' <"$err" | sed 's/::/__/g' | cut -c1-200 || true)"
+  [ -n "$text" ] || text='(unprintable error output)'
   if [ -n "$status" ]; then
     printf '%s — %s' "$status" "$text"
   else

--- a/scripts/ci/aggregate-required-tiers.sh
+++ b/scripts/ci/aggregate-required-tiers.sh
@@ -408,24 +408,26 @@ WAIVER_EVIDENCE_DETAIL=""       # the LAST failure's condensed error; never clea
                                 # so a `read`/`none` poll after a failed one can
                                 # still say what went wrong earlier
 WAIVER_EVIDENCE_COUNT=0         # `labeled` events in the feed, last successful read
-WAIVER_EVIDENCE_WAIVER_COUNT=0  # of those, ones for a `ci:waive:` label
+WAIVER_EVIDENCE_HISTORY_COUNT=0 # of those, ones for ANY `ci:waive:` label, ever
+WAIVER_EVIDENCE_INFORCE_COUNT=0 # of those, ones for a waiver label IN FORCE now
 WAIVER_EVIDENCE_FAILURES=0      # polls whose read failed, however it ended up
 WAIVER_UNCONFIGURED_WARNED=false # the unconfigured warning is emitted once per run
 
-# The PR's CURRENT labels, re-read every poll so a waiver applied while this job
-# waits takes effect without a re-run. A failed read falls back to the event
-# payload: withholding a waiver is the safe direction, granting one is not.
-read_labels() {
-  [ -n "$LABELS_CMD" ] || { LABELS_NOW="$PR_LABELS_IN"; return 0; }
-
-  if eval "$LABELS_CMD" >"$WORK_DIR/labels.txt" 2>"$WORK_DIR/labels.err"; then
-    LABELS_NOW="$(tr '\n' ',' <"$WORK_DIR/labels.txt")"
-    return 0
-  fi
-  sed 's/^/  /' "$WORK_DIR/labels.err" >&2 || true
-  echo "::warning::could not read the PR's current labels; falling back to the event payload labels" >&2
-  LABELS_NOW="$PR_LABELS_IN"
-}
+# WHETHER `LABELS_NOW` WAS ACTUALLY OBSERVED (issue #3033 round 4). The label
+# read has always had a fallback — a failed live read reverts to the run-start
+# event payload — but it left no durable trace, only a per-poll `::warning::`. The
+# reporting section then stated absence ("no ci:waive: label is present") off a
+# snapshot that predates the entire polling window, i.e. exactly the scenario the
+# window exists for: a waiver applied WHILE this job waits. A confident false
+# negative about the very thing this issue is about. These three carry the
+# trustworthiness forward so the summary can report what was OBSERVED instead.
+LABELS_READ_STATE=payload       # live | payload | fallback (see read_labels)
+LABELS_READ_FAILURES=0          # polls whose live label read failed
+LABELS_READ_DETAIL=""           # the LAST such failure, condensed; never cleared
+# The `ci:waive:<tier-id>` labels in force per the labels this run is using,
+# normalised EXACTLY as gating_registry.rb normalises them (comma split, strip,
+# then the tier-id shape) so the evidence report cannot disagree with the verdict.
+INFORCE_WAIVER_LABELS=""
 
 # WHAT ACTUALLY WENT WRONG, condensed for a workflow command. The old code threw
 # this away: EVERY failure mode — an authorization refusal, a secondary rate limit,
@@ -438,9 +440,9 @@ read_labels() {
 # The result lands inside a `::warning::` and in the job summary, so it is
 # sanitised first: control characters go (it must stay one line), workflow-command
 # syntax is defanged, and the text is truncated.
-# waiver_error_detail <exit-status>
-waiver_error_detail() {
-  local rc="${1:-?}" err="$WORK_DIR/waiver-events.err" status="" text=""
+# condense_error <errfile> <exit-status>
+condense_error() {
+  local err="$1" rc="${2:-?}" status="" text=""
   if [ ! -s "$err" ]; then
     printf 'exit status %s, no error output' "$rc"
     return 0
@@ -460,6 +462,113 @@ waiver_error_detail() {
   else
     printf 'exit status %s, no HTTP status reported — %s' "$rc" "$text"
   fi
+}
+
+# The waiver labels in force per `LABELS_NOW`, mirroring gating_registry.rb's
+# `waived_tier_ids` normalisation (split on comma, strip, then
+# /\Aci:waive:[a-z0-9][a-z0-9-]*\z/) so the evidence report counts the same labels
+# the verdict does. Pure shell for the same reason as the counter below: an external
+# tool here could fail and leave an EMPTY in-force set, which would silently become
+# a reported zero — a claim of absence nobody observed. Shell parameter expansion
+# has no such failure mode.
+compute_inforce_waiver_labels() {
+  local rest="$LABELS_NOW" item="" tier=""
+  INFORCE_WAIVER_LABELS=""
+  while [ -n "$rest" ]; do
+    item="${rest%%,*}"
+    if [ "$item" = "$rest" ]; then rest=""; else rest="${rest#*,}"; fi
+    item="${item#"${item%%[![:space:]]*}"}"   # lstrip, as ruby's String#strip does
+    item="${item%"${item##*[![:space:]]}"}"   # rstrip
+    case "$item" in
+      ci:waive:*) tier="${item#ci:waive:}" ;;
+      *) continue ;;
+    esac
+    # /[a-z0-9][a-z0-9-]*\z/ — the tier-id shape, so anything that reaches the
+    # comparison below is already allowlisted.
+    case "$tier" in
+      ''|[!a-z0-9]*|*[!a-z0-9-]*) continue ;;
+    esac
+    INFORCE_WAIVER_LABELS="${INFORCE_WAIVER_LABELS}${item},"
+  done
+  return 0
+}
+
+# How many `labeled` events in the feed are for a waiver label IN FORCE.
+#
+# PURE SHELL ON PURPOSE. An external counter (awk) would add a failure mode of its
+# own — and a count that failed to compute may not be reported as zero, so it would
+# need a third "uncomputable" state that no hermetic fixture can reach, i.e.
+# untestable code guarding an untested claim. With no external command there is no
+# such state: the only UNKNOWN left is the one that matters (a label set this run
+# did not observe), and it is covered by a test. Nothing here can fail under
+# `set -euo pipefail` either: `read` returning non-zero at EOF is the loop's
+# condition, and the input file is written by the caller immediately above.
+#
+# IFS covers space/tab/CR so the label field is normalised the way
+# gating_registry.rb strips it; no shape that can match a waiver label contains any
+# of those, and an unmatched line only ever WITHHOLDS a claim.
+count_inforce_waiver_events() {
+  local count=0 label=""
+  while IFS=$' \t\r' read -r label _ || [ -n "$label" ]; do
+    # A blank feed line must not match the empty slot a trailing comma leaves.
+    [ -n "$label" ] || continue
+    case ",${INFORCE_WAIVER_LABELS}," in
+      *",${label},"*) count=$((count + 1)) ;;
+    esac
+  done <"$WAIVER_EVENTS_FILE"
+  printf '%s' "$count"
+}
+
+# The PR's CURRENT labels, re-read every poll so a waiver applied while this job
+# waits takes effect without a re-run. A failed read falls back to the event
+# payload: withholding a waiver is the safe direction, granting one is not.
+#
+# THE FALLBACK IS RECORDED, NOT JUST WARNED ABOUT (issue #3033 round 4). Three
+# states, kept apart, because only the first one licenses a claim about what is on
+# the pull request NOW:
+#   live     — the live read succeeded this poll; `LABELS_NOW` is an observation.
+#   fallback — a live read was configured and FAILED; `LABELS_NOW` is the
+#              run-start payload snapshot, so a label applied or removed since the
+#              run started is invisible. Absence must not be asserted from it.
+#   payload  — no live source was configured at all; the payload is all there is,
+#              and current labels were never looked for.
+# The failure count and the last error persist for the whole run (like
+# WAIVER_EVIDENCE_FAILURES) so a poll that later succeeds cannot erase the record.
+read_labels() {
+  if [ -z "$LABELS_CMD" ]; then
+    LABELS_NOW="$PR_LABELS_IN"
+    LABELS_READ_STATE=payload
+    compute_inforce_waiver_labels
+    return 0
+  fi
+
+  local rc=0 names="" trc=0
+  eval "$LABELS_CMD" >"$WORK_DIR/labels.txt" 2>"$WORK_DIR/labels.err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    # A normalisation failure (BSD `tr` exits 1 on non-UTF-8 input under a UTF-8
+    # locale) is an UNTRUSTED read, not a live one: a truncated label list would
+    # otherwise be reported as observed fact.
+    names="$(tr '\n' ',' <"$WORK_DIR/labels.txt")" || trc=$?
+    if [ "$trc" -eq 0 ]; then
+      LABELS_NOW="$names"
+      LABELS_READ_STATE=live
+      compute_inforce_waiver_labels
+      return 0
+    fi
+    printf 'the label list could not be normalised (tr exit %s)\n' "$trc" >"$WORK_DIR/labels.err"
+    rc="$trc"
+  fi
+  sed 's/^/  /' "$WORK_DIR/labels.err" >&2 || true
+  LABELS_READ_STATE=fallback
+  LABELS_READ_FAILURES=$((LABELS_READ_FAILURES + 1))
+  LABELS_READ_DETAIL="$(condense_error "$WORK_DIR/labels.err" "$rc")"
+  LABELS_NOW="$PR_LABELS_IN"
+  compute_inforce_waiver_labels
+  echo "::warning::could not read the PR's current labels (${LABELS_READ_DETAIL}); falling back to the" \
+       "run-start event payload labels, so a ci:waive:<tier-id> label applied since this run started is" \
+       "INVISIBLE to it — this run cannot observe whether one is present. Issue #3033. The verdict still" \
+       "comes from the tier evaluation alone" >&2
+  return 0
 }
 
 # The `labeled` events behind any ACTIVE waiver label: who applied it and when.
@@ -511,24 +620,32 @@ read_waiver_events() {
     WAIVER_EVIDENCE_COUNT="$(grep -c '' "$WAIVER_EVENTS_FILE" || true)"
     # The label is field 1 of `<label>\t<actor>\t<iso8601>`, so anchoring at the
     # line start counts LABEL matches and cannot be fooled by an actor's login.
-    # This is an upper bound on what gating_registry.rb will accept (it also
-    # requires the tier-id shape), which is why nothing below claims more than
-    # "the evidence is present".
-    WAIVER_EVIDENCE_WAIVER_COUNT="$(grep -c '^ci:waive:' "$WAIVER_EVENTS_FILE" || true)"
+    # This is the whole HISTORY of waiver labellings on this pull request.
+    WAIVER_EVIDENCE_HISTORY_COUNT="$(grep -c '^ci:waive:' "$WAIVER_EVENTS_FILE" || true)"
+    # HISTORY IS NOT STATE (issue #3033 round 4). `labeled` events are IMMUTABLE:
+    # a `ci:waive:alpha` applied months ago and removed the same day is in this feed
+    # forever. Counting those kept the "the evidence is present" claim alive while
+    # the label actually in force had no event of its own — bindability asserted for
+    # a label whose evidence is missing, which is this issue's defect one layer up.
+    # Only events for a label IN FORCE can bind or attribute anything, so the feed
+    # is intersected with `INFORCE_WAIVER_LABELS`. When the label read was untrusted
+    # that set is itself unobserved, and the reporting section says UNKNOWN rather
+    # than reporting this number.
+    WAIVER_EVIDENCE_INFORCE_COUNT="$(count_inforce_waiver_events)"
     return 0
   fi
   sed 's/^/  /' "$WORK_DIR/waiver-events.err" >&2 || true
   WAIVER_EVIDENCE_STATE=unreadable
   WAIVER_EVIDENCE_FAILURES=$((WAIVER_EVIDENCE_FAILURES + 1))
-  WAIVER_EVIDENCE_DETAIL="$(waiver_error_detail "$rc")"
+  WAIVER_EVIDENCE_DETAIL="$(condense_error "$WORK_DIR/waiver-events.err" "$rc")"
   # Say WHY the feed was empty, and how to tell the causes apart. The classes have
   # different remedies: 401/403/404 = the token running this workflow may not read
   # this pull request's events (the `permissions:` block); a 403 naming a rate limit
   # or any 5xx = transient, re-run; no HTTP status at all = the client itself failed
   # (`gh` absent, a bad --jq), which no re-run fixes.
   echo "::warning::waiver evidence UNREADABLE: the read of this pull request's label events FAILED" \
-       "(${WAIVER_EVIDENCE_DETAIL}) — this is a BROKEN READ, NOT an absence of waiver labels, because a" \
-       "ci:waive: label IS present. 401/403/404 means the token running this workflow may not read this pull" \
+       "(${WAIVER_EVIDENCE_DETAIL}) — this is a BROKEN READ, NOT an absence of waiver labels, because the label" \
+       "set this poll is using carries a ci:waive: label. 401/403/404 means the token running this workflow may not read this pull" \
        "request's events (check the workflow's permissions block); a 403 naming a rate limit, or a 5xx, is" \
        "transient; no HTTP status at all means the client failed (gh unavailable, or a bad --jq). Issue #3033." \
        "The waiver still applies at the aggregation deadline, but it cannot resolve a tier early and it will" \
@@ -676,10 +793,72 @@ done <"$OBSERVATIONS"
 # a silence the healthy case produces too (issue #3033). One line in the ordinary
 # case; the diagnosis only when there is something to diagnose. This block never
 # changes the verdict.
+#
+# OBSERVATIONS, NOT CONCLUSIONS (issue #3033 round 4). This block states what was
+# READ, what was FOUND and what is UNKNOWN. It asserts no downstream capability —
+# not "a waiver can be bound", not "the evidence is present", not "no label is
+# present" — unless every input to that assertion was observed ON THIS RUN. Where
+# an input is unobserved or stale, the line itself says so. Three recurrences of
+# the same defect (a claim outrunning its evidence) came from doing otherwise.
+
+# WHERE THE LABELS BEHIND ALL OF THE ABOVE CAME FROM. `LABELS_NOW` is an
+# observation only in the `live` state; the other two are the run-start payload,
+# under which a label applied or removed mid-run is invisible.
+emit_label_read_note() {
+  case "$LABELS_READ_STATE" in
+    fallback)
+      emit ""
+      emit "> :warning: Label read UNTRUSTED: the live read of this pull request's labels FAILED, so the labels"
+      emit "> behind everything above are the RUN-START EVENT PAYLOAD (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL})."
+      emit "> \`401\`/\`403\`/\`404\`: check the workflow's \`permissions:\` block; a \`403\` naming a rate limit or any"
+      emit "> \`5xx\`: transient; no HTTP status: the client itself failed. Degraded, not fatal — the verdict came"
+      emit "> from the tier evaluation either way."
+      ;;
+    payload)
+      emit ""
+      emit "> :information_source: Label read: this run had no live label source, so the labels behind everything above are the run-start event payload; the pull request's current labels were never read."
+      ;;
+    *)
+      if [ "${LABELS_READ_FAILURES:-0}" -gt 0 ]; then
+        emit ""
+        emit "> :warning: ${LABELS_READ_FAILURES} earlier poll(s) could not read this pull request's labels (${LABELS_READ_DETAIL}); the last read succeeded, so the labels behind everything above are live."
+      fi
+      ;;
+  esac
+  return 0
+}
+
+# Was the in-force intersection taken against a label set this run OBSERVED? An
+# untrusted label read is the one way it was not, and then the intersection is
+# itself unknown — reporting it as zero would be a claim of absence again, one
+# variable further down. (The count has no failure mode of its own; see
+# count_inforce_waiver_events.)
+INFORCE_UNKNOWN_REASON=""
+if [ "$LABELS_READ_STATE" = "fallback" ]; then
+  INFORCE_UNKNOWN_REASON="the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}) and the labels fell back to the run-start event payload"
+fi
+
 emit ""
 case "$WAIVER_EVIDENCE_STATE" in
   none)
-    emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is present on this pull request."
+    case "$LABELS_READ_STATE" in
+      live)
+        # Genuinely observed: the live read succeeded on this poll, so absence is
+        # an observation and is stated as one.
+        emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is present on this pull request."
+        ;;
+      fallback)
+        # THE FALSE NEGATIVE THIS REPLACES (issue #3033 round 4). This line used to
+        # state absence flatly here — while the live read had failed and the labels
+        # were a run-start snapshot, i.e. precisely when a waiver applied mid-run
+        # (the reason the polling window exists) is invisible. Report the
+        # observation and the gap in it instead.
+        emit "Waiver evidence: **UNKNOWN (label read UNTRUSTED)** — no \`ci:waive:<tier-id>\` label was OBSERVED, but the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}) and this run fell back to the run-start event payload, so a waiver label applied since the run started would be invisible here. Absence is NOT claimed."
+        ;;
+      *)
+        emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is in the run-start event payload, which is the only label set this run had (no live label source configured), so a label applied since the run started was never looked for."
+        ;;
+    esac
     # A label applied, its events unreadable, then the label removed mid-run: the
     # state is legitimately "nothing to waive" now, but the broken read is history
     # worth keeping, not history to discard.
@@ -689,19 +868,28 @@ case "$WAIVER_EVIDENCE_STATE" in
     fi
     ;;
   read)
-    # WHAT WAS OBSERVED, NOT WHAT IT IMPLIES (issue #3033 round 2). A feed of
-    # `labeled` events for other labels proves the read works and nothing else, and
-    # even a matching `ci:waive:` event only BINDS if its timestamp is at or after
-    # this head sha's first CI activity — which is decided per tier in the rows
-    # above. So this reports presence of the evidence and stops there.
-    if [ "${WAIVER_EVIDENCE_WAIVER_COUNT:-0}" -gt 0 ]; then
-      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), ${WAIVER_EVIDENCE_WAIVER_COUNT} of them for a \`ci:waive:\` label, so the evidence needed for head-binding and attribution is present (whether a waiver actually binds is decided per tier above)."
-    else
-      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), but **0 \`ci:waive:\` labeled events** found, so attribution and head-binding remain UNRESOLVED."
+    # WHAT WAS OBSERVED, NOT WHAT IT IMPLIES (issue #3033 rounds 2 and 4). A feed of
+    # `labeled` events for other labels proves the read works and nothing else; an
+    # event for a waiver label since REMOVED proves even less, because `labeled`
+    # events are immutable history; and even a matching, in-force event only BINDS if
+    # its timestamp is at or after this head sha's first CI activity, which is
+    # decided per tier in the rows above and is NOT observed here.
+    if [ -n "$INFORCE_UNKNOWN_REASON" ]; then
+      emit "Waiver evidence: READ OK, in-force match **UNKNOWN** — the \`labeled\` events read (${WAIVER_EVIDENCE_COUNT} event(s), ${WAIVER_EVIDENCE_HISTORY_COUNT} of them for a \`ci:waive:\` label), but ${INFORCE_UNKNOWN_REASON}, so this run did not observe which waiver labels are in force and cannot say whether any of those events is for one."
       emit ""
-      emit "> :warning: The read succeeded, so this is neither a permission nor an API problem: a \`ci:waive:<tier-id>\`"
-      emit "> label is on the pull request, yet the events feed carried no \`labeled\` event for it. A waiver still"
-      emit "> applies at the aggregation deadline, but it cannot resolve a tier early and no applier is named."
+      emit "> :warning: Neither presence nor absence of usable evidence is claimed here. Degraded, not fatal:"
+      emit "> the waiver is still honoured at the aggregation deadline exactly as before."
+    elif [ "$WAIVER_EVIDENCE_INFORCE_COUNT" -gt 0 ]; then
+      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), ${WAIVER_EVIDENCE_INFORCE_COUNT} of them for a \`ci:waive:\` label in force, so the evidence needed for attribution and head-binding was OBSERVED for that label. Whether a waiver actually resolves a tier — its event must be at or after this head sha's first CI activity, which this line does not observe — is decided per tier above."
+    else
+      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), ${WAIVER_EVIDENCE_HISTORY_COUNT} of them for a \`ci:waive:\` label, but **0 for a waiver label in force now**, so attribution and head-binding remain UNRESOLVED."
+      emit ""
+      emit "> :warning: The read succeeded, so this is neither a permission nor an API problem. \`labeled\` events are"
+      emit "> IMMUTABLE HISTORY: an event for a waiver label since REMOVED stays in this feed forever and can bind"
+      emit "> nothing, so only events for a label IN FORCE are counted. So either the feed carried no \`labeled\`"
+      emit "> event for the waiver label now applied, or every waiver event in it names a label no longer applied."
+      emit "> A waiver still applies at the aggregation deadline, but it cannot resolve a tier early and no applier"
+      emit "> is named."
     fi
     if [ "$WAIVER_EVIDENCE_FAILURES" -gt 0 ]; then
       emit ""
@@ -711,7 +899,7 @@ case "$WAIVER_EVIDENCE_STATE" in
   unreadable)
     emit "Waiver evidence: **UNREADABLE (broken read — authorization, API or client failure)** — the \`labeled\` events for this pull request could not be read (${WAIVER_EVIDENCE_DETAIL}); ${WAIVER_EVIDENCE_FAILURES} failed read(s)."
     emit ""
-    emit "> :warning: This is NOT \"no waiver labels present\" — a \`ci:waive:<tier-id>\` label IS present."
+    emit "> :warning: This is NOT \"no waiver labels present\" — the label set this run is using carries a \`ci:waive:<tier-id>\` label."
     emit "> \`401\`/\`403\`/\`404\`: the token running this workflow may not read this pull request's events —"
     emit "> check the workflow's \`permissions:\` block. A \`403\` naming a rate limit, or any \`5xx\`: transient,"
     emit "> re-run. No HTTP status at all: the client itself failed (\`gh\` unavailable, a bad \`--jq\`), which a"
@@ -720,12 +908,13 @@ case "$WAIVER_EVIDENCE_STATE" in
     emit "> resolve a tier early and is reported as \`applier UNRESOLVED\`."
     ;;
   unconfigured)
-    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — a \`ci:waive:<tier-id>\` label is present but this run was given no way to read the \`labeled\` events."
+    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — the label set this run is using carries a \`ci:waive:<tier-id>\` label but this run was given no way to read the \`labeled\` events."
     emit ""
     emit "> :warning: The waiver is still honoured at the aggregation deadline, but it cannot resolve a tier"
     emit "> early and is reported as \`applier UNRESOLVED\`."
     ;;
 esac
+emit_label_read_note
 
 emit ""
 if [ "$VERDICT" = "pass" ]; then

--- a/scripts/ci/aggregate-required-tiers.sh
+++ b/scripts/ci/aggregate-required-tiers.sh
@@ -388,6 +388,17 @@ VERDICT=""
 LABELS_NOW="$PR_LABELS_IN"
 WAIVER_EVENTS_FILE="$WORK_DIR/waiver-events.tsv"
 : >"$WAIVER_EVENTS_FILE"
+# WHY THE FEED WAS EMPTY (issue #3033). An empty label-event feed used to mean two
+# unrelated things — "this pull request has nothing to waive" and "the API call for
+# the `labeled` events FAILED" — and nothing downstream could tell them apart. The
+# second silently disables the EVIDENCE half of `ci:waive:<tier-id>`
+# (gating_registry.rb's waiver_bound_to_head? and waiver_supersedes_pending? can
+# never be true without it), so the break-glass regresses to deadline-only with no
+# trace. These carry the state forward to the reporting section, which names it.
+WAIVER_EVIDENCE_STATE=none      # none | unconfigured | unreadable | read
+WAIVER_EVIDENCE_DETAIL=""       # condensed API error (HTTP status when available)
+WAIVER_EVIDENCE_COUNT=0         # `labeled` events read on the last successful read
+WAIVER_EVIDENCE_FAILURES=0      # polls whose read failed, however it ended up
 
 # The PR's CURRENT labels, re-read every poll so a waiver applied while this job
 # waits takes effect without a re-run. A failed read falls back to the event
@@ -404,26 +415,89 @@ read_labels() {
   LABELS_NOW="$PR_LABELS_IN"
 }
 
+# WHAT ACTUALLY WENT WRONG, condensed for a workflow command. The old code threw
+# this away: EVERY failure mode — an authorization refusal, a secondary rate limit,
+# a 5xx, an absent `gh`, a `--jq` syntax error — collapsed into one identical
+# warning plus an empty file, which is also what an ordinary PR with nothing to
+# waive produces. The HTTP status (when the client reported one) and the command's
+# EXIT STATUS (when it did not) are the two facts that separate those cases, so
+# both are surfaced. `gh` prints the status as "(HTTP 403)".
+#
+# The result lands inside a `::warning::` and in the job summary, so it is
+# sanitised first: control characters go (it must stay one line), workflow-command
+# syntax is defanged, and the text is truncated.
+# waiver_error_detail <exit-status>
+waiver_error_detail() {
+  local rc="${1:-?}" err="$WORK_DIR/waiver-events.err" status="" text=""
+  if [ ! -s "$err" ]; then
+    printf 'exit status %s, no error output' "$rc"
+    return 0
+  fi
+  status="$(grep -o 'HTTP [0-9][0-9][0-9]' "$err" | head -n 1 || true)"
+  text="$(tr -d '[:cntrl:]' <"$err" | sed 's/::/__/g' | cut -c1-200)"
+  if [ -n "$status" ]; then
+    printf '%s — %s' "$status" "$text"
+  else
+    printf 'exit status %s, no HTTP status reported — %s' "$rc" "$text"
+  fi
+}
+
 # The `labeled` events behind any ACTIVE waiver label: who applied it and when.
 # Two uses, both fail-safe — the attribution in the diagnostic, and the horizon
 # that lets a waiver resolve a tier whose only check run the waiver's own label
 # event minted. An empty file means "unresolved": the waiver still applies at the
 # deadline exactly as before, and no name is claimed. This can never GRANT a
 # waiver the labels did not already carry.
+#
+# THREE STATES, NEVER CONFLATED (issue #3033). "No waiver label present",
+# "unreadable feed" and "read N events" all used to leave the same empty file and
+# the same silence, so a genuinely BROKEN read was indistinguishable from an
+# ordinary pull request with nothing to waive — and the failure it hides is total:
+# without the events feed, waiver_bound_to_head? and waiver_supersedes_pending? in
+# gating_registry.rb can never be true, so the break-glass silently degrades to
+# deadline-only and nobody is named on its audit trail. Each state is now recorded
+# and reported. NONE of them fails the job: an unreadable feed must still fall
+# through to the ordinary polling path and be honoured at the deadline, because
+# reding a break-glass PR for an API blip is the worse outage.
 read_waiver_events() {
   : >"$WAIVER_EVENTS_FILE"
+  WAIVER_EVIDENCE_DETAIL=""
   case "$LABELS_NOW" in
     *ci:waive:*) ;;
-    *) return 0 ;;
+    *) WAIVER_EVIDENCE_STATE=none; return 0 ;;
   esac
-  [ -n "$WAIVER_EVENTS_CMD" ] || return 0
+  if [ -z "$WAIVER_EVENTS_CMD" ]; then
+    WAIVER_EVIDENCE_STATE=unconfigured
+    echo "::warning::waiver evidence UNAVAILABLE: a ci:waive: label is present, but this run has no label-event" \
+         "source (no --waiver-events-cmd, and --repo/--pr-number were not both supplied), so the waiver cannot be" \
+         "bound to this head sha or attributed to whoever applied it; it will still apply at the aggregation" \
+         "deadline" >&2
+    return 0
+  fi
 
-  if eval "$WAIVER_EVENTS_CMD" >"$WAIVER_EVENTS_FILE" 2>"$WORK_DIR/waiver-events.err"; then
+  local rc=0
+  eval "$WAIVER_EVENTS_CMD" >"$WAIVER_EVENTS_FILE" 2>"$WORK_DIR/waiver-events.err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    WAIVER_EVIDENCE_STATE=read
+    WAIVER_EVIDENCE_COUNT="$(grep -c '' "$WAIVER_EVENTS_FILE" || true)"
     return 0
   fi
   sed 's/^/  /' "$WORK_DIR/waiver-events.err" >&2 || true
-  echo "::warning::could not read this pull request's label events; a waiver will still apply at the" \
-       "aggregation deadline, but it will not be attributed to whoever applied it" >&2
+  WAIVER_EVIDENCE_STATE=unreadable
+  WAIVER_EVIDENCE_FAILURES=$((WAIVER_EVIDENCE_FAILURES + 1))
+  WAIVER_EVIDENCE_DETAIL="$(waiver_error_detail "$rc")"
+  # Say WHY the feed was empty, and how to tell the causes apart. The classes have
+  # different remedies: 401/403/404 = the token running this workflow may not read
+  # this pull request's events (the `permissions:` block); a 403 naming a rate limit
+  # or any 5xx = transient, re-run; no HTTP status at all = the client itself failed
+  # (`gh` absent, a bad --jq), which no re-run fixes.
+  echo "::warning::waiver evidence UNREADABLE: the read of this pull request's label events FAILED" \
+       "(${WAIVER_EVIDENCE_DETAIL}) — this is a BROKEN READ, NOT an absence of waiver labels, because a" \
+       "ci:waive: label IS present. 401/403/404 means the token running this workflow may not read this pull" \
+       "request's events (check the workflow's permissions block); a 403 naming a rate limit, or a 5xx, is" \
+       "transient; no HTTP status at all means the client failed (gh unavailable, or a bad --jq). Issue #3033." \
+       "The waiver still applies at the aggregation deadline, but it cannot resolve a tier early and it will" \
+       "not be attributed to whoever applied it" >&2
   : >"$WAIVER_EVENTS_FILE"
 }
 
@@ -560,6 +634,42 @@ while IFS=$'\x1f' read -r state tier context check_id status conclusion url note
       ;;
   esac
 done <"$OBSERVATIONS"
+
+# ----------------------------------------- waiver evidence, always on record --
+# The state is stated for EVERY run, including the ordinary "nothing to waive"
+# one, so that the abnormal states read as abnormal instead of having to be
+# inferred from a silence that also covers a missing `issues: read` grant
+# (issue #3033). This block never changes the verdict.
+emit ""
+case "$WAIVER_EVIDENCE_STATE" in
+  none)
+    emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is present on this pull request."
+    ;;
+  read)
+    emit "Waiver evidence: READ OK — ${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s) read, so a waiver can be bound to this head sha and attributed."
+    if [ "$WAIVER_EVIDENCE_FAILURES" -gt 0 ]; then
+      emit ""
+      emit "> :warning: ${WAIVER_EVIDENCE_FAILURES} earlier poll(s) could not read the label events; the last read succeeded."
+    fi
+    ;;
+  unreadable)
+    emit "Waiver evidence: **UNREADABLE (broken read — authorization, API or client failure)** — the \`labeled\` events for this pull request could not be read (${WAIVER_EVIDENCE_DETAIL}); ${WAIVER_EVIDENCE_FAILURES} failed read(s)."
+    emit ""
+    emit "> :warning: This is NOT \"no waiver labels present\" — a \`ci:waive:<tier-id>\` label IS present."
+    emit "> \`401\`/\`403\`/\`404\`: the token running this workflow may not read this pull request's events —"
+    emit "> check the workflow's \`permissions:\` block. A \`403\` naming a rate limit, or any \`5xx\`: transient,"
+    emit "> re-run. No HTTP status at all: the client itself failed (\`gh\` unavailable, a bad \`--jq\`), which a"
+    emit "> re-run will not fix. Issue #3033."
+    emit "> Degraded, not fatal: the waiver is still honoured at the aggregation deadline, but it cannot"
+    emit "> resolve a tier early and is reported as \`applier UNRESOLVED\`."
+    ;;
+  unconfigured)
+    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — a \`ci:waive:<tier-id>\` label is present but this run was given no way to read the \`labeled\` events."
+    emit ""
+    emit "> :warning: The waiver is still honoured at the aggregation deadline, but it cannot resolve a tier"
+    emit "> early and is reported as \`applier UNRESOLVED\`."
+    ;;
+esac
 
 emit ""
 if [ "$VERDICT" = "pass" ]; then

--- a/scripts/ci/aggregate-required-tiers.sh
+++ b/scripts/ci/aggregate-required-tiers.sh
@@ -432,6 +432,8 @@ WAIVER_UNCONFIGURED_WARNED=false # the unconfigured warning is emitted once per 
 LABELS_READ_STATE=payload       # live | payload | fallback (see read_labels)
 LABELS_READ_FAILURES=0          # polls whose live label read failed
 LABELS_READ_DETAIL=""           # the LAST such failure, condensed; never cleared
+LABELS_READ_WARNED_DETAIL=""    # the detail the annotation last reported, so a
+                                # persistent failure is annotated once, not per poll
 # The `ci:waive:<tier-id>` labels in force per the labels this run is using,
 # normalised EXACTLY as gating_registry.rb normalises them (comma split, strip,
 # then the tier-id shape) so the evidence report cannot disagree with the verdict.
@@ -649,10 +651,19 @@ read_labels() {
   LABELS_READ_DETAIL="$(condense_error "$WORK_DIR/labels.err" "$rc")"
   LABELS_NOW="$PR_LABELS_IN"
   compute_inforce_waiver_labels
-  echo "::warning::could not read the PR's current labels (${LABELS_READ_DETAIL}); falling back to the" \
-       "run-start event payload labels, so a ci:waive:<tier-id> label applied since this run started is" \
-       "INVISIBLE to it — this run cannot observe whether one is present. Issue #3033. The verdict still" \
-       "comes from the tier evaluation alone" >&2
+  # ONCE PER DISTINCT FAILURE (issue #3033 round 7 review). A 60-minute aggregation
+  # against a persistent 403 would otherwise stamp dozens of identical multi-line
+  # annotations — the same noise the `unconfigured` warning was deduped for. Keyed on
+  # the condensed detail, not on a boolean, so a DIFFERENT failure (403 then a 5xx,
+  # then a client failure) is still annotated when it appears. The durable per-run
+  # record is the summary's count, which is unaffected.
+  if [ "$LABELS_READ_DETAIL" != "$LABELS_READ_WARNED_DETAIL" ]; then
+    LABELS_READ_WARNED_DETAIL="$LABELS_READ_DETAIL"
+    echo "::warning::could not read the PR's current labels (${LABELS_READ_DETAIL}); falling back to the" \
+         "run-start event payload labels, so a ci:waive:<tier-id> label applied since this run started is" \
+         "INVISIBLE to it — this run cannot observe whether one is present. Issue #3033. The verdict still" \
+         "comes from the tier evaluation alone" >&2
+  fi
   return 0
 }
 
@@ -707,8 +718,8 @@ read_waiver_events() {
     # The summary block carries the persistent record.
     if [ "$WAIVER_UNCONFIGURED_WARNED" != "true" ]; then
       WAIVER_UNCONFIGURED_WARNED=true
-      echo "::warning::waiver evidence UNAVAILABLE: the waiver label(s) ${INFORCE_LABELS_SHOWN} are in force" \
-           "(shape-checked against what the evaluator accepts), but this run has no label-event" \
+      echo "::warning::waiver evidence UNAVAILABLE: the waiver label(s) ${INFORCE_LABELS_SHOWN} are in the label" \
+           "set this poll is using and match the shape the evaluator accepts, but this run has no label-event" \
            "source (no --waiver-events-cmd, and --repo/--pr-number were not both supplied), so the waiver cannot be" \
            "bound to this head sha or attributed to whoever applied it; it will still apply at the aggregation" \
            "deadline" >&2
@@ -942,10 +953,38 @@ emit_label_read_note() {
 # untrusted label read is the one way it was not, and then the intersection is
 # itself unknown — reporting it as zero would be a claim of absence again, one
 # variable further down. (The count has no failure mode of its own; see
-# count_inforce_waiver_events.)
+# count_waiver_events.)
 INFORCE_UNKNOWN_REASON=""
 if [ "$LABELS_READ_STATE" = "fallback" ]; then
   INFORCE_UNKNOWN_REASON="the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}) and the labels fell back to the run-start event payload"
+fi
+
+# WHERE THE LABEL SET CAME FROM, as a clause any claim about the labels can carry
+# (issue #3033 round 8). The only thing this block ever OBSERVES about labels is "the
+# label set this run is using" plus its provenance, so every line that says more than
+# that — "in force now", "was OBSERVED for that label" — carries this. The `payload`
+# state was the asymmetry the round-7 review named: the `none` branch hedged it
+# ("never looked for") while the `read` branch asserted "in force" flatly, for the
+# identical provenance.
+LABEL_SET_NOTE_SHORT=""
+case "$LABELS_READ_STATE" in
+  fallback)
+    LABEL_SET_NOTE_SHORT=" (that label set is the run-start event payload: the live label read FAILED — see the label-read note below)"
+    ;;
+  payload)
+    LABEL_SET_NOTE_SHORT=" (that label set is the run-start event payload; no live label source was configured, so the pull request's current labels were never read)"
+    ;;
+esac
+
+# DID ANY READ FAIL ON THIS RUN? Two independent reads can fail — the labels and the
+# label events — and a line that DENIES a failure ("nothing failed", "neither a
+# permission nor an API problem") is false if either did. The round-7 review found
+# exactly that: an off-shape label plus a 403 on the label read produced both
+# `permissions:` advice and a flat "NOT an authorization or API problem" denial in one
+# summary. No denial below is emitted without consulting this.
+ANY_READ_FAILED=false
+if [ "${LABELS_READ_FAILURES:-0}" -gt 0 ] || [ "${WAIVER_EVIDENCE_FAILURES:-0}" -gt 0 ]; then
+  ANY_READ_FAILED=true
 fi
 
 # An off-shape `ci:waive:` label was READ from whichever label set this run had, so
@@ -971,13 +1010,16 @@ case "$LABELS_READ_STATE" in
     ;;
 esac
 # "Nothing was read" is a claim about the RUN, not the poll: a valid waiver label
-# earlier in the run whose feed read SUCCEEDED, then removed and mistyped, makes the
-# unconditional form false. The failure counter has always been carried forward for
-# exactly this reason; the success counter now is too.
+# earlier in the run whose feed read SUCCEEDED — or FAILED — then removed and
+# mistyped, makes the unconditional form false. Three cases, one per set of observed
+# facts; "there was never a waiver label" is gone entirely, because non-existence
+# across a run is not something this can observe (issue #3033 round 8).
 if [ "$WAIVER_EVIDENCE_READS" -gt 0 ]; then
-  OFFSHAPE_EVENTS_NOTE=" No \`labeled\` events were read on this poll — there is no waiver label to gather evidence for — though ${WAIVER_EVIDENCE_READS} earlier poll(s) DID read the feed, while a waiver label was in force."
+  OFFSHAPE_EVENTS_NOTE=" No \`labeled\` events were read for these labels; the feed WAS read on ${WAIVER_EVIDENCE_READS} earlier poll(s), while a valid waiver label was in the label set the run was using then."
+elif [ "$WAIVER_EVIDENCE_FAILURES" -gt 0 ]; then
+  OFFSHAPE_EVENTS_NOTE=" No \`labeled\` events were read for these labels, and ${WAIVER_EVIDENCE_FAILURES} earlier read(s) of the feed FAILED (${WAIVER_EVIDENCE_DETAIL}) while a valid waiver label was in the label set the run was using then."
 else
-  OFFSHAPE_EVENTS_NOTE=" No \`labeled\` events were read at any point: there was never a waiver label to gather evidence for."
+  OFFSHAPE_EVENTS_NOTE=" No \`labeled\` events were read on this run: no valid \`ci:waive:<tier-id>\` label was OBSERVED at any point, so there was nothing to gather evidence for."
 fi
 
 emit ""
@@ -993,12 +1035,21 @@ case "$WAIVER_EVIDENCE_STATE" in
     if [ -n "$INVALID_WAIVER_LABELS" ]; then
       emit "Waiver evidence: **INVALID WAIVER LABEL — it waives NOTHING** — the label(s) \`${INVALID_LABELS_SHOWN}\` ${OFFSHAPE_PRESENCE}, but they are not waiver labels: a waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), which is the shape the registry evaluator matches, so it IGNORES these and no tier is waived by them.${OFFSHAPE_LABEL_SET_NOTE}${OFFSHAPE_EVENTS_NOTE}"
       emit ""
-      emit "> :warning: This is NOT \"no waiver labels present\", and NOT an authorization or API problem — no"
-      emit "> read was attempted for these labels and nothing failed. A \`ci:waive:\`-prefixed label is in the"
-      emit "> label set this run is using, in a shape the"
-      emit "> evaluator ignores; a capitalised tier id (\`ci:waive:Flight\` for tier \`flight\`) is the usual"
-      emit "> cause. To waive a tier, apply \`ci:waive:<tier-id>\` with the tier id spelled exactly as"
-      emit "> \`.github/ci-gating-tiers.yml\` spells it. Issue #3033."
+      emit "> :warning: This is NOT \"no waiver labels present\": a \`ci:waive:\`-prefixed label is in the label set"
+      emit "> this run is using, in a shape the evaluator ignores. A capitalised tier id (\`ci:waive:Flight\` for"
+      emit "> tier \`flight\`) is the usual cause; to waive a tier, apply \`ci:waive:<tier-id>\` with the tier id"
+      emit "> spelled exactly as \`.github/ci-gating-tiers.yml\` spells it. Issue #3033."
+      # THE DENIAL IS CONDITIONAL (issue #3033 round 8). "No read failed" was
+      # emitted unconditionally, so an off-shape label plus a 403 on the LABEL read
+      # produced this denial and `permissions:` advice in the same summary. A run
+      # where a read did fail says so, and says which problem is which.
+      if [ "$ANY_READ_FAILED" = "true" ]; then
+        emit "> A read DID fail on this run (see the note(s) below) — a separate problem. It is not what makes"
+        emit "> these labels waive nothing: their shape is."
+      else
+        emit "> It is also not an authorization or API problem: no read failed on this run, and no \`labeled\`"
+        emit "> events read was attempted for these labels."
+      fi
     else
       case "$LABELS_READ_STATE" in
         live)
@@ -1024,7 +1075,7 @@ case "$WAIVER_EVIDENCE_STATE" in
     # worth keeping, not history to discard.
     if [ "$WAIVER_EVIDENCE_FAILURES" -gt 0 ]; then
       emit ""
-      emit "> :warning: no waiver label now, but ${WAIVER_EVIDENCE_FAILURES} earlier read(s) of this pull request's \`labeled\` events FAILED (${WAIVER_EVIDENCE_DETAIL}) while one was present."
+      emit "> :warning: no valid waiver label is in the label set this run is using now, but ${WAIVER_EVIDENCE_FAILURES} earlier read(s) of this pull request's \`labeled\` events FAILED (${WAIVER_EVIDENCE_DETAIL}) while one was.${LABEL_SET_NOTE_SHORT}"
     fi
     ;;
   read)
@@ -1040,14 +1091,21 @@ case "$WAIVER_EVIDENCE_STATE" in
       emit "> :warning: Neither presence nor absence of usable evidence is claimed here. Degraded, not fatal:"
       emit "> the waiver is still honoured at the aggregation deadline exactly as before."
     elif [ "$WAIVER_EVIDENCE_INFORCE_COUNT" -gt 0 ]; then
-      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), ${WAIVER_EVIDENCE_INFORCE_COUNT} of them for a \`ci:waive:\` label in force, so the evidence needed for attribution and head-binding was OBSERVED for that label. Whether a waiver actually resolves a tier — its event must be at or after this head sha's first CI activity, which this line does not observe — is decided per tier above."
+      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), ${WAIVER_EVIDENCE_INFORCE_COUNT} of them for a \`ci:waive:\` label in force, so the evidence needed for attribution and head-binding was OBSERVED for that label. Whether a waiver actually resolves a tier — its event must be at or after this head sha's first CI activity, which this line does not observe — is decided per tier above.${LABEL_SET_NOTE_SHORT}"
     else
-      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), ${WAIVER_EVIDENCE_HISTORY_COUNT} of them for a \`ci:waive:\` label, but **0 for a waiver label in force now**, so attribution and head-binding remain UNRESOLVED."
+      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), ${WAIVER_EVIDENCE_HISTORY_COUNT} of them for a \`ci:waive:\` label, but **0 for a waiver label in force now**, so attribution and head-binding remain UNRESOLVED.${LABEL_SET_NOTE_SHORT}"
       emit ""
-      emit "> :warning: The read succeeded, so this is neither a permission nor an API problem. \`labeled\` events are"
+      if [ "$ANY_READ_FAILED" = "true" ]; then
+        emit "> :warning: The read succeeded on THIS poll, so the empty result is not itself an authorization or"
+        emit "> API failure — though a read did fail earlier on this run (see below). \`labeled\` events are"
+      else
+        emit "> :warning: No read failed on this run, so this is neither a permission nor an API problem."
+        emit "> \`labeled\` events are"
+      fi
       emit "> IMMUTABLE HISTORY: an event for a waiver label since REMOVED stays in this feed forever and can bind"
       emit "> nothing, so only events for a label IN FORCE are counted. So either the feed carried no \`labeled\`"
-      emit "> event for the waiver label now applied, or every waiver event in it names a label no longer applied."
+      emit "> event for the waiver label in the label set this run is using, or every waiver event in it names a"
+      emit "> label that is not in that set."
       emit "> A waiver still applies at the aggregation deadline, but it cannot resolve a tier early and no applier"
       emit "> is named."
     fi
@@ -1061,7 +1119,7 @@ case "$WAIVER_EVIDENCE_STATE" in
     emit ""
     emit "> :warning: This is NOT \"no waiver labels present\" — the label set this run is using carries the waiver"
     emit "> label(s) \`${INFORCE_LABELS_SHOWN}\`, shape-checked against what the evaluator accepts (an off-shape"
-    emit "> \`ci:waive:\` label never reaches this state and is reported separately)."
+    emit "> \`ci:waive:\` label never reaches this state and is reported separately)${LABEL_SET_NOTE_SHORT}."
     emit "> \`401\`/\`403\`/\`404\`: the token running this workflow may not read this pull request's events —"
     emit "> check the workflow's \`permissions:\` block. A \`403\` naming a rate limit, or any \`5xx\`: transient,"
     emit "> re-run. No HTTP status at all: the client itself failed (\`gh\` unavailable, a bad \`--jq\`), which a"
@@ -1070,7 +1128,7 @@ case "$WAIVER_EVIDENCE_STATE" in
     emit "> resolve a tier early and is reported as \`applier UNRESOLVED\`."
     ;;
   unconfigured)
-    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — the label set this run is using carries the waiver label(s) \`${INFORCE_LABELS_SHOWN}\` (shape-checked against what the evaluator accepts) but this run was given no way to read the \`labeled\` events."
+    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — the label set this run is using carries the waiver label(s) \`${INFORCE_LABELS_SHOWN}\` (shape-checked against what the evaluator accepts) but this run was given no way to read the \`labeled\` events.${LABEL_SET_NOTE_SHORT}"
     emit ""
     emit "> :warning: The waiver is still honoured at the aggregation deadline, but it cannot resolve a tier"
     emit "> early and is reported as \`applier UNRESOLVED\`."
@@ -1083,7 +1141,7 @@ esac
 # first one did nothing. Said once, and only where it is not already the headline.
 if [ -n "$INVALID_WAIVER_LABELS" ] && [ "$WAIVER_EVIDENCE_STATE" != "none" ]; then
   emit ""
-  emit "> :warning: Also applied, and NOT a waiver label: \`${INVALID_LABELS_SHOWN}\`. A waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), so the evaluator IGNORES this one and it waives nothing; nothing above is about it."
+  emit "> :warning: Also in the label set this run is using, and NOT a waiver label: \`${INVALID_LABELS_SHOWN}\`. A waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), so the evaluator IGNORES this one and it waives nothing; nothing above is about it."
 fi
 emit_label_read_note
 

--- a/scripts/ci/aggregate-required-tiers.sh
+++ b/scripts/ci/aggregate-required-tiers.sh
@@ -395,10 +395,22 @@ WAIVER_EVENTS_FILE="$WORK_DIR/waiver-events.tsv"
 # (gating_registry.rb's waiver_bound_to_head? and waiver_supersedes_pending? can
 # never be true without it), so the break-glass regresses to deadline-only with no
 # trace. These carry the state forward to the reporting section, which names it.
+#
+# TWO COUNTS, NOT ONE (issue #3033 round 2). The default `--jq` selects
+# `event == "labeled"` for EVERY label, while gating_registry.rb keys only on
+# `ci:waive:<tier-id>` (WAIVER_LABEL_PATTERN). Reporting the feed total alone would
+# claim "evidence read" off a feed of `needs-decision` events — the same
+# unproven-claim defect this issue exists to remove, one layer up. So the
+# waiver-relevant subset is counted separately and the report distinguishes "feed
+# fine, no waiver events" from "feed fine, waiver events present".
 WAIVER_EVIDENCE_STATE=none      # none | unconfigured | unreadable | read
-WAIVER_EVIDENCE_DETAIL=""       # condensed API error (HTTP status when available)
-WAIVER_EVIDENCE_COUNT=0         # `labeled` events read on the last successful read
+WAIVER_EVIDENCE_DETAIL=""       # the LAST failure's condensed error; never cleared,
+                                # so a `read`/`none` poll after a failed one can
+                                # still say what went wrong earlier
+WAIVER_EVIDENCE_COUNT=0         # `labeled` events in the feed, last successful read
+WAIVER_EVIDENCE_WAIVER_COUNT=0  # of those, ones for a `ci:waive:` label
 WAIVER_EVIDENCE_FAILURES=0      # polls whose read failed, however it ended up
+WAIVER_UNCONFIGURED_WARNED=false # the unconfigured warning is emitted once per run
 
 # The PR's CURRENT labels, re-read every poll so a waiver applied while this job
 # waits takes effect without a re-run. A failed read falls back to the event
@@ -461,17 +473,26 @@ waiver_error_detail() {
 # reding a break-glass PR for an API blip is the worse outage.
 read_waiver_events() {
   : >"$WAIVER_EVENTS_FILE"
-  WAIVER_EVIDENCE_DETAIL=""
   case "$LABELS_NOW" in
     *ci:waive:*) ;;
+    # No waiver label on THIS poll. `WAIVER_EVIDENCE_FAILURES` is deliberately NOT
+    # reset: a label applied, read broken, then removed mid-run must not erase the
+    # record that the reads were broken (the reporting section says so).
     *) WAIVER_EVIDENCE_STATE=none; return 0 ;;
   esac
   if [ -z "$WAIVER_EVENTS_CMD" ]; then
     WAIVER_EVIDENCE_STATE=unconfigured
-    echo "::warning::waiver evidence UNAVAILABLE: a ci:waive: label is present, but this run has no label-event" \
-         "source (no --waiver-events-cmd, and --repo/--pr-number were not both supplied), so the waiver cannot be" \
-         "bound to this head sha or attributed to whoever applied it; it will still apply at the aggregation" \
-         "deadline" >&2
+    # ONCE PER RUN. Unlike an unreadable read, this condition cannot change while
+    # the job runs — WAIVER_EVENTS_CMD is fixed at argument-parse time — so a
+    # per-poll annotation would be a dozen identical lines saying the same thing.
+    # The summary block carries the persistent record.
+    if [ "$WAIVER_UNCONFIGURED_WARNED" != "true" ]; then
+      WAIVER_UNCONFIGURED_WARNED=true
+      echo "::warning::waiver evidence UNAVAILABLE: a ci:waive: label is present, but this run has no label-event" \
+           "source (no --waiver-events-cmd, and --repo/--pr-number were not both supplied), so the waiver cannot be" \
+           "bound to this head sha or attributed to whoever applied it; it will still apply at the aggregation" \
+           "deadline" >&2
+    fi
     return 0
   fi
 
@@ -480,6 +501,12 @@ read_waiver_events() {
   if [ "$rc" -eq 0 ]; then
     WAIVER_EVIDENCE_STATE=read
     WAIVER_EVIDENCE_COUNT="$(grep -c '' "$WAIVER_EVENTS_FILE" || true)"
+    # The label is field 1 of `<label>\t<actor>\t<iso8601>`, so anchoring at the
+    # line start counts LABEL matches and cannot be fooled by an actor's login.
+    # This is an upper bound on what gating_registry.rb will accept (it also
+    # requires the tier-id shape), which is why nothing below claims more than
+    # "the evidence is present".
+    WAIVER_EVIDENCE_WAIVER_COUNT="$(grep -c '^ci:waive:' "$WAIVER_EVENTS_FILE" || true)"
     return 0
   fi
   sed 's/^/  /' "$WORK_DIR/waiver-events.err" >&2 || true
@@ -645,12 +672,32 @@ emit ""
 case "$WAIVER_EVIDENCE_STATE" in
   none)
     emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is present on this pull request."
-    ;;
-  read)
-    emit "Waiver evidence: READ OK — ${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s) read, so a waiver can be bound to this head sha and attributed."
+    # A label applied, its events unreadable, then the label removed mid-run: the
+    # state is legitimately "nothing to waive" now, but the broken read is history
+    # worth keeping, not history to discard.
     if [ "$WAIVER_EVIDENCE_FAILURES" -gt 0 ]; then
       emit ""
-      emit "> :warning: ${WAIVER_EVIDENCE_FAILURES} earlier poll(s) could not read the label events; the last read succeeded."
+      emit "> :warning: no waiver label now, but ${WAIVER_EVIDENCE_FAILURES} earlier read(s) of this pull request's \`labeled\` events FAILED (${WAIVER_EVIDENCE_DETAIL}) while one was present."
+    fi
+    ;;
+  read)
+    # WHAT WAS OBSERVED, NOT WHAT IT IMPLIES (issue #3033 round 2). A feed of
+    # `labeled` events for other labels proves the read works and nothing else, and
+    # even a matching `ci:waive:` event only BINDS if its timestamp is at or after
+    # this head sha's first CI activity — which is decided per tier in the rows
+    # above. So this reports presence of the evidence and stops there.
+    if [ "${WAIVER_EVIDENCE_WAIVER_COUNT:-0}" -gt 0 ]; then
+      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), ${WAIVER_EVIDENCE_WAIVER_COUNT} of them for a \`ci:waive:\` label, so the evidence needed for head-binding and attribution is present (whether a waiver actually binds is decided per tier above)."
+    else
+      emit "Waiver evidence: READ OK — feed read (${WAIVER_EVIDENCE_COUNT} \`labeled\` event(s)), but **0 \`ci:waive:\` labeled events** found, so attribution and head-binding remain UNRESOLVED."
+      emit ""
+      emit "> :warning: The read succeeded, so this is neither a permission nor an API problem: a \`ci:waive:<tier-id>\`"
+      emit "> label is on the pull request, yet the events feed carried no \`labeled\` event for it. A waiver still"
+      emit "> applies at the aggregation deadline, but it cannot resolve a tier early and no applier is named."
+    fi
+    if [ "$WAIVER_EVIDENCE_FAILURES" -gt 0 ]; then
+      emit ""
+      emit "> :warning: ${WAIVER_EVIDENCE_FAILURES} earlier poll(s) could not read the label events (${WAIVER_EVIDENCE_DETAIL}); the last read succeeded."
     fi
     ;;
   unreadable)

--- a/scripts/ci/aggregate-required-tiers.sh
+++ b/scripts/ci/aggregate-required-tiers.sh
@@ -428,6 +428,16 @@ LABELS_READ_DETAIL=""           # the LAST such failure, condensed; never cleare
 # normalised EXACTLY as gating_registry.rb normalises them (comma split, strip,
 # then the tier-id shape) so the evidence report cannot disagree with the verdict.
 INFORCE_WAIVER_LABELS=""
+# The `ci:waive:`-PREFIXED labels that are NOT waiver labels — an off-shape tier id
+# (issue #3033 round 6). Its own state, because it is neither "no waiver label
+# present" nor an API/authorization problem: a label IS applied, in a shape
+# gating_registry.rb's WAIVER_LABEL_PATTERN does not match, so it waives nothing.
+# `ci:waive:Flight` (a capitalised tier id) is the realistic way to get here, and
+# reporting it as an absence — or worse, as the "the label set carries a ci:waive:
+# label" evidence diagnostic — sends the operator to the workflow's `permissions:`
+# block for a typo. Sanitised at collection: label names are user-controlled text
+# that lands in a job summary on stdout, where `::` is workflow-command syntax.
+INVALID_WAIVER_LABELS=""
 
 # WHAT ACTUALLY WENT WRONG, condensed for a workflow command. The old code threw
 # this away: EVERY failure mode — an authorization refusal, a secondary rate limit,
@@ -472,8 +482,9 @@ condense_error() {
 # a reported zero — a claim of absence nobody observed. Shell parameter expansion
 # has no such failure mode.
 compute_inforce_waiver_labels() {
-  local rest="$LABELS_NOW" item="" tier=""
+  local rest="$LABELS_NOW" item="" tier="" safe=""
   INFORCE_WAIVER_LABELS=""
+  INVALID_WAIVER_LABELS=""
   while [ -n "$rest" ]; do
     item="${rest%%,*}"
     if [ "$item" = "$rest" ]; then rest=""; else rest="${rest#*,}"; fi
@@ -484,9 +495,29 @@ compute_inforce_waiver_labels() {
       *) continue ;;
     esac
     # /[a-z0-9][a-z0-9-]*\z/ — the tier-id shape, so anything that reaches the
-    # comparison below is already allowlisted.
+    # comparison below is already allowlisted. Anything that does NOT match is
+    # recorded as an off-shape label rather than dropped in silence: the operator
+    # who typed it believes they waived a tier, and only this list can say
+    # otherwise. Still pure shell (see the header): a sanitiser that could fail
+    # would silently empty the list and take the diagnostic with it.
     case "$tier" in
-      ''|[!a-z0-9]*|*[!a-z0-9-]*) continue ;;
+      ''|[!a-z0-9]*|*[!a-z0-9-]*)
+        # The WHOLE label is recorded, not the tier id, so a bare `ci:waive:` with
+        # nothing after it still names itself in the report.
+        safe="${item//[[:cntrl:]]/}"   # the summary line must stay ONE line
+        safe="${safe//::/__}"          # defang workflow-command syntax
+        safe="${safe:0:80}"            # bound one label's contribution
+        # Bounded overall, so a pull request wearing many off-shape labels cannot
+        # produce an unbounded annotation, and deduplicated so a repeated
+        # `--labels` entry is named once.
+        if [ "${#INVALID_WAIVER_LABELS}" -lt 240 ]; then
+          case ",${INVALID_WAIVER_LABELS}," in
+            *",${safe},"*) ;;
+            *) INVALID_WAIVER_LABELS="${INVALID_WAIVER_LABELS}${safe}," ;;
+          esac
+        fi
+        continue
+        ;;
     esac
     INFORCE_WAIVER_LABELS="${INFORCE_WAIVER_LABELS}${item},"
   done
@@ -590,13 +621,30 @@ read_labels() {
 # reding a break-glass PR for an API blip is the worse outage.
 read_waiver_events() {
   : >"$WAIVER_EVENTS_FILE"
-  case "$LABELS_NOW" in
-    *ci:waive:*) ;;
-    # No waiver label on THIS poll. `WAIVER_EVIDENCE_FAILURES` is deliberately NOT
-    # reset: a label applied, read broken, then removed mid-run must not erase the
-    # record that the reads were broken (the reporting section says so).
-    *) WAIVER_EVIDENCE_STATE=none; return 0 ;;
-  esac
+  # THE VALIDATED SHAPE, NOT A `ci:waive:` SUBSTRING (issue #3033 round 6). This
+  # gate used to be `case "$LABELS_NOW" in *ci:waive:*`, while the verdict —
+  # gating_registry.rb's /\Aci:waive:[a-z0-9][a-z0-9-]*\z/ — is far stricter. So an
+  # off-shape label (`ci:waive:Flight`, the capitalisation typo) sent this function
+  # down the evidence path and made the run report "the label set this run is using
+  # carries a ci:waive:<tier-id> label" in an UNREADABLE/UNAVAILABLE diagnostic:
+  # a claim about a break-glass that does not exist and that the evaluator ignores,
+  # pointing the reader at a `permissions:` block while the real fault (a label
+  # that waives nothing) went unnamed. The validated set is what the gate uses now,
+  # so every state below is about a waiver label the evaluator would honour, and an
+  # off-shape label costs no paginated API call.
+  #
+  # PRECONDITION: `INFORCE_WAIVER_LABELS` is current. It is computed at startup and
+  # on ALL THREE exits of read_labels (live, fallback, payload), which is the only
+  # thing that runs before this — and were that ever untrue, an uncomputed set is
+  # EMPTY, which withholds evidence rather than granting a waiver.
+  if [ -z "$INFORCE_WAIVER_LABELS" ]; then
+    # No waiver label in force on THIS poll. `WAIVER_EVIDENCE_FAILURES` is
+    # deliberately NOT reset: a label applied, read broken, then removed mid-run
+    # must not erase the record that the reads were broken (the reporting section
+    # says so).
+    WAIVER_EVIDENCE_STATE=none
+    return 0
+  fi
   if [ -z "$WAIVER_EVENTS_CMD" ]; then
     WAIVER_EVIDENCE_STATE=unconfigured
     # ONCE PER RUN. Unlike an unreadable read, this condition cannot change while
@@ -605,7 +653,8 @@ read_waiver_events() {
     # The summary block carries the persistent record.
     if [ "$WAIVER_UNCONFIGURED_WARNED" != "true" ]; then
       WAIVER_UNCONFIGURED_WARNED=true
-      echo "::warning::waiver evidence UNAVAILABLE: a ci:waive: label is present, but this run has no label-event" \
+      echo "::warning::waiver evidence UNAVAILABLE: the waiver label(s) ${INFORCE_WAIVER_LABELS%,} are in force" \
+           "(shape-checked against what the evaluator accepts), but this run has no label-event" \
            "source (no --waiver-events-cmd, and --repo/--pr-number were not both supplied), so the waiver cannot be" \
            "bound to this head sha or attributed to whoever applied it; it will still apply at the aggregation" \
            "deadline" >&2
@@ -645,7 +694,8 @@ read_waiver_events() {
   # (`gh` absent, a bad --jq), which no re-run fixes.
   echo "::warning::waiver evidence UNREADABLE: the read of this pull request's label events FAILED" \
        "(${WAIVER_EVIDENCE_DETAIL}) — this is a BROKEN READ, NOT an absence of waiver labels, because the label" \
-       "set this poll is using carries a ci:waive: label. 401/403/404 means the token running this workflow may not read this pull" \
+       "set this poll is using carries the waiver label(s) ${INFORCE_WAIVER_LABELS%,}, shape-checked against what" \
+       "the evaluator accepts. 401/403/404 means the token running this workflow may not read this pull" \
        "request's events (check the workflow's permissions block); a 403 naming a rate limit, or a 5xx, is" \
        "transient; no HTTP status at all means the client failed (gh unavailable, or a bad --jq). Issue #3033." \
        "The waiver still applies at the aggregation deadline, but it cannot resolve a tier early and it will" \
@@ -684,6 +734,13 @@ evaluate_once() {
   fi
   return "$rc"
 }
+
+# read_waiver_events gates on `INFORCE_WAIVER_LABELS`, so it is computed from the
+# run-start labels here, before the first poll. read_labels recomputes it on every
+# poll (all three exits), so this only makes the precondition hold independently of
+# call order — it cannot make the set stale, and an uncomputed set is empty, which
+# withholds evidence rather than granting a waiver.
+compute_inforce_waiver_labels
 
 while :; do
   ATTEMPT=$((ATTEMPT + 1))
@@ -838,27 +895,60 @@ if [ "$LABELS_READ_STATE" = "fallback" ]; then
   INFORCE_UNKNOWN_REASON="the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}) and the labels fell back to the run-start event payload"
 fi
 
+# An off-shape `ci:waive:` label was READ from whichever label set this run had, so
+# the trust of that read qualifies what may be said about the absence of a VALID
+# one alongside it — under a failed live read, absence is not claimable at all.
+OFFSHAPE_LABEL_SET_NOTE=""
+case "$LABELS_READ_STATE" in
+  fallback)
+    OFFSHAPE_LABEL_SET_NOTE=" No valid \`ci:waive:<tier-id>\` label is in the run-start event payload either, but the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}), so absence of a valid one is NOT claimed."
+    ;;
+  payload)
+    OFFSHAPE_LABEL_SET_NOTE=" No valid \`ci:waive:<tier-id>\` label is in the run-start event payload, which is the only label set this run had (no live label source configured)."
+    ;;
+  *)
+    OFFSHAPE_LABEL_SET_NOTE=" No valid \`ci:waive:<tier-id>\` label is present on this pull request."
+    ;;
+esac
+
 emit ""
 case "$WAIVER_EVIDENCE_STATE" in
   none)
-    case "$LABELS_READ_STATE" in
-      live)
-        # Genuinely observed: the live read succeeded on this poll, so absence is
-        # an observation and is stated as one.
-        emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is present on this pull request."
-        ;;
-      fallback)
-        # THE FALSE NEGATIVE THIS REPLACES (issue #3033 round 4). This line used to
-        # state absence flatly here — while the live read had failed and the labels
-        # were a run-start snapshot, i.e. precisely when a waiver applied mid-run
-        # (the reason the polling window exists) is invisible. Report the
-        # observation and the gap in it instead.
-        emit "Waiver evidence: **UNKNOWN (label read UNTRUSTED)** — no \`ci:waive:<tier-id>\` label was OBSERVED, but the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}) and this run fell back to the run-start event payload, so a waiver label applied since the run started would be invisible here. Absence is NOT claimed."
-        ;;
-      *)
-        emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is in the run-start event payload, which is the only label set this run had (no live label source configured), so a label applied since the run started was never looked for."
-        ;;
-    esac
+    # AN OFF-SHAPE `ci:waive:` LABEL IS ITS OWN STATE (issue #3033 round 6). It is
+    # not an absence — a label IS applied — and it is not an authorization or API
+    # problem, which is what the reader was previously told: the old substring gate
+    # sent `ci:waive:Flight` into the evidence path, where the UNREADABLE and
+    # UNAVAILABLE lines then asserted that "the label set this run is using carries
+    # a ci:waive:<tier-id> label". The operator went looking at the workflow's
+    # `permissions:` block for what is a capitalisation typo. This names the typo.
+    if [ -n "$INVALID_WAIVER_LABELS" ]; then
+      emit "Waiver evidence: **INVALID WAIVER LABEL — it waives NOTHING** — the label(s) \`${INVALID_WAIVER_LABELS%,}\` are applied but are not waiver labels: a waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), which is the shape the registry evaluator matches, so it IGNORES these and no tier is waived by them.${OFFSHAPE_LABEL_SET_NOTE} No \`labeled\` events were read: there is no waiver label to gather evidence for."
+      emit ""
+      emit "> :warning: This is NOT \"no waiver labels present\", and NOT an authorization or API problem — no"
+      emit "> read was attempted and nothing failed. A \`ci:waive:\`-prefixed label IS applied, in a shape the"
+      emit "> evaluator ignores; a capitalised tier id (\`ci:waive:Flight\` for tier \`flight\`) is the usual"
+      emit "> cause. To waive a tier, apply \`ci:waive:<tier-id>\` with the tier id spelled exactly as"
+      emit "> \`.github/ci-gating-tiers.yml\` spells it. Issue #3033."
+    else
+      case "$LABELS_READ_STATE" in
+        live)
+          # Genuinely observed: the live read succeeded on this poll, so absence is
+          # an observation and is stated as one.
+          emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is present on this pull request."
+          ;;
+        fallback)
+          # THE FALSE NEGATIVE THIS REPLACES (issue #3033 round 4). This line used to
+          # state absence flatly here — while the live read had failed and the labels
+          # were a run-start snapshot, i.e. precisely when a waiver applied mid-run
+          # (the reason the polling window exists) is invisible. Report the
+          # observation and the gap in it instead.
+          emit "Waiver evidence: **UNKNOWN (label read UNTRUSTED)** — no \`ci:waive:<tier-id>\` label was OBSERVED, but the live label read FAILED (${LABELS_READ_FAILURES} failed read(s); ${LABELS_READ_DETAIL}) and this run fell back to the run-start event payload, so a waiver label applied since the run started would be invisible here. Absence is NOT claimed."
+          ;;
+        *)
+          emit "Waiver evidence: n/a — no \`ci:waive:<tier-id>\` label is in the run-start event payload, which is the only label set this run had (no live label source configured), so a label applied since the run started was never looked for."
+          ;;
+      esac
+    fi
     # A label applied, its events unreadable, then the label removed mid-run: the
     # state is legitimately "nothing to waive" now, but the broken read is history
     # worth keeping, not history to discard.
@@ -899,7 +989,9 @@ case "$WAIVER_EVIDENCE_STATE" in
   unreadable)
     emit "Waiver evidence: **UNREADABLE (broken read — authorization, API or client failure)** — the \`labeled\` events for this pull request could not be read (${WAIVER_EVIDENCE_DETAIL}); ${WAIVER_EVIDENCE_FAILURES} failed read(s)."
     emit ""
-    emit "> :warning: This is NOT \"no waiver labels present\" — the label set this run is using carries a \`ci:waive:<tier-id>\` label."
+    emit "> :warning: This is NOT \"no waiver labels present\" — the label set this run is using carries the waiver"
+    emit "> label(s) \`${INFORCE_WAIVER_LABELS%,}\`, shape-checked against what the evaluator accepts (an off-shape"
+    emit "> \`ci:waive:\` label never reaches this state and is reported separately)."
     emit "> \`401\`/\`403\`/\`404\`: the token running this workflow may not read this pull request's events —"
     emit "> check the workflow's \`permissions:\` block. A \`403\` naming a rate limit, or any \`5xx\`: transient,"
     emit "> re-run. No HTTP status at all: the client itself failed (\`gh\` unavailable, a bad \`--jq\`), which a"
@@ -908,12 +1000,21 @@ case "$WAIVER_EVIDENCE_STATE" in
     emit "> resolve a tier early and is reported as \`applier UNRESOLVED\`."
     ;;
   unconfigured)
-    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — the label set this run is using carries a \`ci:waive:<tier-id>\` label but this run was given no way to read the \`labeled\` events."
+    emit "Waiver evidence: **UNAVAILABLE (no label-event source configured)** — the label set this run is using carries the waiver label(s) \`${INFORCE_WAIVER_LABELS%,}\` (shape-checked against what the evaluator accepts) but this run was given no way to read the \`labeled\` events."
     emit ""
     emit "> :warning: The waiver is still honoured at the aggregation deadline, but it cannot resolve a tier"
     emit "> early and is reported as \`applier UNRESOLVED\`."
     ;;
 esac
+# AN OFF-SHAPE LABEL ALONGSIDE A VALID ONE still waives nothing (issue #3033 round
+# 6). The headline above then belongs to the valid label's evidence state, so the
+# off-shape one would otherwise go unmentioned — and the operator who typed
+# `ci:waive:Flight` next to a working `ci:waive:beta` would never learn that the
+# first one did nothing. Said once, and only where it is not already the headline.
+if [ -n "$INVALID_WAIVER_LABELS" ] && [ "$WAIVER_EVIDENCE_STATE" != "none" ]; then
+  emit ""
+  emit "> :warning: Also applied, and NOT a waiver label: \`${INVALID_WAIVER_LABELS%,}\`. A waiver label is \`ci:waive:<tier-id>\` with a LOWER-CASE tier id (\`[a-z0-9][a-z0-9-]*\`), so the evaluator IGNORES this one and it waives nothing; nothing above is about it."
+fi
 emit_label_read_note
 
 emit ""

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -655,6 +655,141 @@ else
   bad "a real app applier was withheld (rc=$RC): $OUT"
 fi
 
+# ------------------- waiver evidence: three states, never conflated (#3033) --
+# THE BUG THIS PINS. An empty label-event feed used to mean two unrelated things —
+# "this pull request has nothing to waive" and "the read of the `labeled` events
+# FAILED" — and both left the same empty file and the same silence. The second kills
+# the entire EVIDENCE half of `ci:waive:<tier-id>` (head-binding and the
+# pending-waiver horizon in gating_registry.rb), whose only symptom is a waiver that
+# quietly takes until the deadline with nobody named. EVERY failure mode collapsed
+# into that one silence: an authorization refusal, a rate limit, a 5xx, an absent
+# `gh`, a bad `--jq`. The states are now named, and this asserts they are
+# DISTINGUISHABLE — the discriminator is the pairwise difference of the reported
+# line, not the presence of any single string.
+#
+# It also pins the direction of the degradation: unreadable evidence must never red
+# the job. The waiver still has to be honoured at the deadline, because reding a
+# break-glass PR for an API blip is the worse outage.
+echo "== the label-event feed's three states are reported distinguishably =="
+
+# An AUTHORIZATION refusal, in the shape `gh` reports one.
+cat >"$WORK/waiver-events-403.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "gh: Resource not accessible by integration (HTTP 403)" >&2
+exit 1
+EOF
+chmod +x "$WORK/waiver-events-403.sh"
+# A CLIENT failure: no HTTP status exists at all, and no re-run fixes it.
+cat >"$WORK/waiver-events-client-fail.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "bash: gh: command not found" >&2
+exit 127
+EOF
+chmod +x "$WORK/waiver-events-client-fail.sh"
+
+evidence_line() { grep 'Waiver evidence' "$1" | head -n 1 || true; }
+
+# STATE 1: no waiver label at all — the ordinary PR.
+invoke "cat $(runs_file all-pass)" "$WORK/self-ids.txt" "$FUTURE" 3
+cp "$SUMMARY" "$WORK/evidence-none.md"
+STATE_NONE=$(evidence_line "$WORK/evidence-none.md")
+if [ "$RC" -eq 0 ] && contains "$STATE_NONE" "n/a" && ! contains "$STATE_NONE" "UNREADABLE"; then
+  ok "a PR with no waiver label reports the 'nothing to waive' state explicitly"
+else
+  bad "the no-waiver state is not stated (rc=$RC): $STATE_NONE"
+fi
+
+# STATE 2: the feed read fine. The fixture carries two `labeled` events.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"
+cp "$SUMMARY" "$WORK/evidence-read.md"
+STATE_READ=$(evidence_line "$WORK/evidence-read.md")
+if [ "$RC" -eq 0 ] && contains "$STATE_READ" "READ OK" && contains "$STATE_READ" '2 `labeled`'; then
+  ok "a readable feed reports READ OK and how many labeled events it read"
+else
+  bad "the readable state is not stated with its event count (rc=$RC): $STATE_READ"
+fi
+
+# STATE 3: a broken read — an authorization refusal, not an absence of labels.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta" --waiver-events-cmd "$WORK/waiver-events-403.sh"
+cp "$SUMMARY" "$WORK/evidence-unreadable.md"
+STATE_BAD=$(evidence_line "$WORK/evidence-unreadable.md")
+if contains "$STATE_BAD" "UNREADABLE" && contains "$STATE_BAD" "broken read"; then
+  ok "an unreadable feed is reported as its own state in the job summary"
+else
+  bad "an unreadable feed is indistinguishable from having nothing to waive: $STATE_BAD"
+fi
+# THE MOST VALUABLE FACT IN THE DIAGNOSTIC: the HTTP status, which is what separates
+# "the token may not read this" from "GitHub was briefly unwell".
+if contains "$STATE_BAD" "HTTP 403" &&
+   contains "$(cat "$WORK/evidence-unreadable.md")" 'permissions:'; then
+  ok "the HTTP status is surfaced and an authorization status names the permissions block"
+else
+  bad "the summary does not identify a 403 as an authorization problem: $(cat "$WORK/evidence-unreadable.md")"
+fi
+if contains "$(cat "$WORK/evidence-unreadable.md")" 'rate limit' &&
+   contains "$(cat "$WORK/evidence-unreadable.md")" '5xx'; then
+  ok "the summary states which statuses are transient, so a re-run is not the reflex for all of them"
+else
+  bad "the summary does not separate transient statuses from authorization ones"
+fi
+if contains "$OUT" "::warning::" && contains "$OUT" "UNREADABLE" && contains "$OUT" "NOT an absence of waiver labels"; then
+  ok "the warning annotation says WHY the feed was empty, not merely that it was"
+else
+  bad "the warning annotation is still ambiguous about the cause: $OUT"
+fi
+# THE GRACEFUL PATH, which must survive all of the above.
+if [ "$RC" -eq 0 ] && contains "$OUT" "WAIVED" && contains "$OUT" "UNRESOLVED" && ! contains "$OUT" "FAIL (harness)"; then
+  ok "an unreadable-evidence run still honours the waiver at the deadline and claims no name"
+else
+  bad "unreadable evidence changed the verdict instead of only the diagnostic (rc=$RC): $OUT"
+fi
+
+# The three lines must actually differ from one another; a shared prefix with a
+# different tail is what made the states inferrable-only in the first place.
+if [ -n "$STATE_NONE" ] && [ -n "$STATE_READ" ] && [ -n "$STATE_BAD" ] &&
+   [ "$STATE_NONE" != "$STATE_READ" ] && [ "$STATE_NONE" != "$STATE_BAD" ] &&
+   [ "$STATE_READ" != "$STATE_BAD" ]; then
+  ok "the three states produce three different summary lines (pairwise distinct)"
+else
+  bad "two evidence states report identically: none='$STATE_NONE' read='$STATE_READ' bad='$STATE_BAD'"
+fi
+
+# A CLIENT failure reports no HTTP status at all: it is neither an authorization
+# problem nor transient, and the diagnostic must not imply either. The command's
+# exit status is the only fact available, so it is the one reported.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta" --waiver-events-cmd "$WORK/waiver-events-client-fail.sh"
+if [ "$RC" -eq 0 ] && contains "$OUT" "UNREADABLE" &&
+   contains "$OUT" "no HTTP status reported" && contains "$OUT" "exit status 127" &&
+   contains "$OUT" "command not found"; then
+  ok "a client failure is reported with its exit status and message, claiming no HTTP status"
+else
+  bad "a client failure was mis-reported as an API status (rc=$RC): $OUT"
+fi
+
+# A silent non-zero exit (no stderr at all) still has to be distinguishable from
+# success: the exit status is reported even when there is nothing else to report.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta" --waiver-events-cmd "false"
+if [ "$RC" -eq 0 ] && contains "$OUT" "UNREADABLE" && contains "$OUT" "exit status 1"; then
+  ok "a silent non-zero read is still reported as unreadable, with its exit status"
+else
+  bad "a silent non-zero read was indistinguishable from a successful one (rc=$RC): $OUT"
+fi
+
+# STATE 4: a waiver label with no label-event source configured at all — the
+# aggregator invoked without --repo/--pr-number. Same degradation, different cause,
+# so it says so rather than borrowing the API-failure wording.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "ci:waive:beta"
+STATE_UNCONF=$(evidence_line "$SUMMARY")
+if [ "$RC" -eq 0 ] && contains "$STATE_UNCONF" "UNAVAILABLE" && ! contains "$STATE_UNCONF" "UNREADABLE"; then
+  ok "a waiver with no configured event source is its own state, not an API failure"
+else
+  bad "the unconfigured-source state is missing or mislabelled (rc=$RC): $STATE_UNCONF"
+fi
+
 invoke "cat $(runs_file one-failed)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"
 if [ "$RC" -ne 0 ]; then ok "a waiver cannot excuse a FAILED tier"; else bad "failed+waived wrongly passed"; fi
 if contains "$OUT" "cannot be waived"; then
@@ -1332,6 +1467,47 @@ if [ "$RC" -eq 2 ] && contains "$OUT" "not a branch ref"; then
   ok "an off-shape --base-ref fails closed as a harness error"
 else
   bad "an off-shape --base-ref was accepted (rc=$RC): $OUT"
+fi
+
+# ------------------- the wiring these fixtures CANNOT prove (issue #3033) ---
+# HONEST SCOPE. Every case above injects `--waiver-events-cmd`, so this suite proves
+# the STATE MACHINE and nothing about production: a fixture can never show that the
+# real `gh api repos/{slug}/issues/{n}/events` call succeeds with the token
+# pr-gate.yml hands the aggregator. Only a live pull request carrying a
+# `ci:waive:<tier-id>` label can show that, and as of #3033 no PR ever has — the
+# read is skipped entirely unless such a label is present, so the call has never
+# executed in production. The states above are what will make that first execution
+# legible; they are not a substitute for it.
+#
+# What IS mechanisable is the AGREEMENT between the two files. The aggregator's
+# default label-event command reads the ISSUES-EVENTS endpoint with a PULL REQUEST
+# number, and GitHub's per-permission reference lists
+# `GET /repos/{owner}/{repo}/issues/{issue_number}/events` under `Pull requests`
+# read as well as `Issues` read ("at least one of"), so `pull-requests: read` — which
+# pr-gate.yml already needs for the live label re-read — is what authorizes it. This
+# asserts that grant is still there, because removing it would break BOTH reads at
+# once. It is deliberately NOT a general "permissions cover every endpoint" checker
+# (out of scope for #3033), and it deliberately does NOT demand `issues: read`:
+# granting that would widen a fork-reachable token over every issue in the repo to
+# authorize nothing new.
+echo "== the aggregator's events endpoint and pr-gate.yml's permissions agree =="
+PR_GATE_WF="$REPO_ROOT/.github/workflows/pr-gate.yml"
+if grep -q 'issues/\${PR_NUMBER_IN}/events' "$AGG_REAL"; then
+  ok "the default label-event command reads the issues-events endpoint with the PR number"
+  if [ ! -f "$PR_GATE_WF" ]; then
+    bad "$PR_GATE_WF not found, so the permission grant behind that endpoint cannot be checked"
+  elif ruby -ryaml -e '
+        wf = YAML.safe_load(File.read(ARGV[0]))
+        perms = wf["permissions"]
+        exit 1 unless perms.is_a?(Hash)
+        exit perms["pull-requests"].to_s == "read" ? 0 : 1
+      ' "$PR_GATE_WF"; then
+    ok "pr-gate.yml grants pull-requests: read, which authorizes that read for a PR number"
+  else
+    bad "pr-gate.yml no longer grants 'pull-requests: read'; the ci:waive: evidence binding dies with it (#3033)"
+  fi
+else
+  bad "the aggregator no longer builds the issues-events command this assertion is about"
 fi
 
 # ------------------------------------------------- non-vacuity (#2910 7.4) --

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -1231,7 +1231,9 @@ echo "== the tier-id shape check is locale- and bash-version-independent =="
 
 # The class as the aggregator actually spells it, read out of the source so the check
 # cannot drift from the code.
-SHAPE_PAT=$(grep -E "^ *''\|\[!" "$AGG_REAL" | head -n 1)
+# `[|]`, not `\|`: a backslash-escaped `|` inside an ERE is a GNU extension the
+# repo's portability lint (rightly) rejects — a bracket expression is POSIX.
+SHAPE_PAT=$(grep -E "^ *''[|]\[!" "$AGG_REAL" | head -n 1)
 SHAPE_PAT=${SHAPE_PAT%)*}
 SHAPE_PAT=${SHAPE_PAT#"${SHAPE_PAT%%[![:space:]]*}"}
 # The pre-fix form, kept as the harness's own control: if THIS does not misclassify in

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -655,7 +655,7 @@ else
   bad "a real app applier was withheld (rc=$RC): $OUT"
 fi
 
-# ------------------- waiver evidence: three states, never conflated (#3033) --
+# --------------- waiver evidence: every state reported distinctly (#3033) ---
 # THE BUG THIS PINS. An empty label-event feed used to mean two unrelated things —
 # "this pull request has nothing to waive" and "the read of the `labeled` events
 # FAILED" — and both left the same empty file and the same silence. The second kills
@@ -670,7 +670,7 @@ fi
 # It also pins the direction of the degradation: unreadable evidence must never red
 # the job. The waiver still has to be honoured at the deadline, because reding a
 # break-glass PR for an API blip is the worse outage.
-echo "== the label-event feed's three states are reported distinguishably =="
+echo "== every state of the label-event feed is reported distinguishably =="
 
 # An AUTHORIZATION refusal, in the shape `gh` reports one.
 cat >"$WORK/waiver-events-403.sh" <<'EOF'
@@ -686,6 +686,23 @@ echo "bash: gh: command not found" >&2
 exit 127
 EOF
 chmod +x "$WORK/waiver-events-client-fail.sh"
+# A HEALTHY read that carries NO waiver event. The default `--jq` selects
+# `event == "labeled"` for every label, so this is the shape that made a feed of
+# `needs-decision` events read as "waiver evidence read": the read works, and
+# nothing in it can attribute or bind anything.
+printf 'needs-decision\tpm-bot\t2025-12-30T00:00:00Z\n' >"$WORK/waiver-events-no-waiver.tsv"
+# A label applied, its events UNREADABLE, then the label REMOVED mid-run. The final
+# state is legitimately "nothing to waive", and the broken read must not vanish
+# with the label.
+cat >"$WORK/labels-then-none.sh" <<EOF
+#!/usr/bin/env bash
+n=\$(cat "$WORK/labels-drop.count" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" >"$WORK/labels-drop.count"
+[ "\$n" -le 1 ] && echo "ci:waive:beta"
+exit 0
+EOF
+chmod +x "$WORK/labels-then-none.sh"
 
 evidence_line() { grep 'Waiver evidence' "$1" | head -n 1 || true; }
 
@@ -699,15 +716,26 @@ else
   bad "the no-waiver state is not stated (rc=$RC): $STATE_NONE"
 fi
 
-# STATE 2: the feed read fine. The fixture carries two `labeled` events.
+# STATE 2: the feed read fine. The fixture carries two `labeled` events, of which
+# exactly ONE is a `ci:waive:` labelling — the discriminator for round 2's finding:
+# the feed total is NOT the number of events the evidence path can use.
 invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
   --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"
 cp "$SUMMARY" "$WORK/evidence-read.md"
 STATE_READ=$(evidence_line "$WORK/evidence-read.md")
-if [ "$RC" -eq 0 ] && contains "$STATE_READ" "READ OK" && contains "$STATE_READ" '2 `labeled`'; then
-  ok "a readable feed reports READ OK and how many labeled events it read"
+if [ "$RC" -eq 0 ] && contains "$STATE_READ" "READ OK" &&
+   contains "$STATE_READ" '2 `labeled`' && contains "$STATE_READ" '1 of them'; then
+  ok "a readable feed reports BOTH the feed total and the ci:waive: subset"
 else
-  bad "the readable state is not stated with its event count (rc=$RC): $STATE_READ"
+  bad "the readable state does not separate the feed total from the waiver events (rc=$RC): $STATE_READ"
+fi
+# And it must not claim the binding SUCCEEDED — a matching event only binds if its
+# timestamp is at or after this head sha's first CI activity, which is a per-tier
+# verdict, not a property of the read.
+if ! contains "$STATE_READ" "can be bound"; then
+  ok "the readable state claims evidence presence, not that a waiver bound"
+else
+  bad "the summary asserts a head-binding it did not observe: $STATE_READ"
 fi
 
 # STATE 3: a broken read — an authorization refusal, not an absence of labels.
@@ -788,6 +816,60 @@ if [ "$RC" -eq 0 ] && contains "$STATE_UNCONF" "UNAVAILABLE" && ! contains "$STA
   ok "a waiver with no configured event source is its own state, not an API failure"
 else
   bad "the unconfigured-source state is missing or mislabelled (rc=$RC): $STATE_UNCONF"
+fi
+# ...and it says it ONCE. The condition cannot change during the run (the command is
+# fixed at argument-parse time), so a per-poll annotation would be a dozen identical
+# lines. THE DISCRIMINATOR is a multi-poll run: 3 polls, still one annotation.
+invoke "cat $(runs_file one-pending)" "$WORK/self-ids.txt" "$FUTURE" 3 --labels "ci:waive:beta"
+UNCONF_WARNINGS=$(printf '%s\n' "$OUT" | grep -c 'waiver evidence UNAVAILABLE' || true)
+if [ "${UNCONF_WARNINGS:-0}" -eq 1 ] && contains "$(evidence_line "$SUMMARY")" "UNAVAILABLE"; then
+  ok "the unconfigured warning is emitted once per run, not once per poll"
+else
+  bad "the unconfigured warning fired ${UNCONF_WARNINGS:-0} times across the poll loop"
+fi
+
+# STATE 5, and the reason round 2 exists: the read SUCCEEDED and carried no
+# `ci:waive:` event at all. The feed total alone would have reported this as
+# "evidence read" — an unproven claim in exactly the shape this issue exists to
+# remove — while attribution and head-binding are as dead as under a 403.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta" --waiver-events-cmd "cat $WORK/waiver-events-no-waiver.tsv"
+STATE_NOWAIVE=$(evidence_line "$SUMMARY")
+if contains "$STATE_NOWAIVE" "READ OK" && contains "$STATE_NOWAIVE" '0 `ci:waive:` labeled events' &&
+   contains "$STATE_NOWAIVE" "UNRESOLVED"; then
+  ok "a healthy feed with no waiver events is reported as unresolved, not as evidence read"
+else
+  bad "a feed of non-waiver events was reported as usable waiver evidence: $STATE_NOWAIVE"
+fi
+if contains "$(cat "$SUMMARY")" "neither a permission nor an API problem"; then
+  ok "the no-waiver-events case rules out the causes it is not, instead of being mistaken for them"
+else
+  bad "the no-waiver-events case borrows the API-failure diagnosis: $(cat "$SUMMARY")"
+fi
+if [ "$RC" -eq 0 ] && contains "$OUT" "WAIVED" && contains "$OUT" "UNRESOLVED"; then
+  ok "it too still honours the waiver at the deadline and claims no name"
+else
+  bad "the no-waiver-events case changed the verdict (rc=$RC): $OUT"
+fi
+if [ "$STATE_NOWAIVE" != "$STATE_READ" ] && [ "$STATE_NOWAIVE" != "$STATE_BAD" ]; then
+  ok "the no-waiver-events line differs from both the usable-evidence and unreadable lines"
+else
+  bad "state 5 reports identically to another state: '$STATE_NOWAIVE'"
+fi
+
+# A BROKEN READ IS NOT ERASED BY THE LABEL GOING AWAY. Label present on poll 1 with
+# an unreadable feed, removed by poll 2: the final state is legitimately "nothing to
+# waive", and the earlier failures are still on the record. The tier is NOT waived
+# (the label is gone), which is the correct verdict and the discriminator.
+rm -f "$WORK/labels-drop.count"
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$FUTURE" 2 \
+  --labels-cmd "$WORK/labels-then-none.sh" --waiver-events-cmd "$WORK/waiver-events-403.sh"
+DROP_SUMMARY="$(cat "$SUMMARY")"
+if [ "$RC" -ne 0 ] && contains "$DROP_SUMMARY" "no waiver label now, but" &&
+   contains "$DROP_SUMMARY" "HTTP 403"; then
+  ok "a waiver label removed mid-run keeps the record that its events were unreadable"
+else
+  bad "the broken-read history was discarded with the label (rc=$RC): $DROP_SUMMARY"
 fi
 
 invoke "cat $(runs_file one-failed)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"
@@ -1470,45 +1552,21 @@ else
 fi
 
 # ------------------- the wiring these fixtures CANNOT prove (issue #3033) ---
-# HONEST SCOPE. Every case above injects `--waiver-events-cmd`, so this suite proves
-# the STATE MACHINE and nothing about production: a fixture can never show that the
-# real `gh api repos/{slug}/issues/{n}/events` call succeeds with the token
-# pr-gate.yml hands the aggregator. Only a live pull request carrying a
-# `ci:waive:<tier-id>` label can show that, and as of #3033 no PR ever has — the
-# read is skipped entirely unless such a label is present, so the call has never
-# executed in production. The states above are what will make that first execution
-# legible; they are not a substitute for it.
+# HONEST SCOPE, stated where it is easy to forget. Every case above injects
+# `--waiver-events-cmd`, so this suite proves the STATE MACHINE and nothing about
+# production: no fixture can show that the real
+# `gh api repos/{slug}/issues/{n}/events` call succeeds with the token pr-gate.yml
+# hands the aggregator. Only a live pull request carrying a `ci:waive:<tier-id>`
+# label can show that, and as of #3033 none ever had — the read is skipped unless
+# such a label is present, so the call had never executed in production. The states
+# above are what make that first execution legible; they are not a substitute for it.
 #
-# What IS mechanisable is the AGREEMENT between the two files. The aggregator's
-# default label-event command reads the ISSUES-EVENTS endpoint with a PULL REQUEST
-# number, and GitHub's per-permission reference lists
-# `GET /repos/{owner}/{repo}/issues/{issue_number}/events` under `Pull requests`
-# read as well as `Issues` read ("at least one of"), so `pull-requests: read` — which
-# pr-gate.yml already needs for the live label re-read — is what authorizes it. This
-# asserts that grant is still there, because removing it would break BOTH reads at
-# once. It is deliberately NOT a general "permissions cover every endpoint" checker
-# (out of scope for #3033), and it deliberately does NOT demand `issues: read`:
-# granting that would widen a fork-reachable token over every issue in the repo to
-# authorize nothing new.
-echo "== the aggregator's events endpoint and pr-gate.yml's permissions agree =="
-PR_GATE_WF="$REPO_ROOT/.github/workflows/pr-gate.yml"
-if grep -q 'issues/\${PR_NUMBER_IN}/events' "$AGG_REAL"; then
-  ok "the default label-event command reads the issues-events endpoint with the PR number"
-  if [ ! -f "$PR_GATE_WF" ]; then
-    bad "$PR_GATE_WF not found, so the permission grant behind that endpoint cannot be checked"
-  elif ruby -ryaml -e '
-        wf = YAML.safe_load(File.read(ARGV[0]))
-        perms = wf["permissions"]
-        exit 1 unless perms.is_a?(Hash)
-        exit perms["pull-requests"].to_s == "read" ? 0 : 1
-      ' "$PR_GATE_WF"; then
-    ok "pr-gate.yml grants pull-requests: read, which authorizes that read for a PR number"
-  else
-    bad "pr-gate.yml no longer grants 'pull-requests: read'; the ci:waive: evidence binding dies with it (#3033)"
-  fi
-else
-  bad "the aggregator no longer builds the issues-events command this assertion is about"
-fi
+# The one mechanisable half — that pr-gate.yml still grants the `pull-requests: read`
+# which authorizes that endpoint for a PR number — is asserted ONCE, in
+# scripts/tests/test_classify_docs_only.sh (the suite that owns pr-gate.yml's
+# structural contract). It is deliberately not duplicated here: one invariant, one
+# home, and a copy here would have had to re-derive the workflow's shape to say
+# anything true about WHY it failed.
 
 # ------------------------------------------------- non-vacuity (#2910 7.4) --
 # Every guard above must be PROVABLY able to fail. Substituting an always-exit-0

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -1218,6 +1218,162 @@ else
   bad "a live-read waiver with usable evidence was not attributed: $OUT"
 fi
 
+# ---- round 7: the shape check must not depend on the shell's collation ------
+# A DEFECT INVISIBLE ON THE MACHINE THAT TESTS IT. Glob RANGES (`[a-z]`) are matched
+# by COLLATION ORDER, not ASCII, unless `globasciiranges` is set — and that is only on
+# by default from bash 5.0. Under glibc with a UTF-8 locale the order is `aAbBcC…`, so
+# on bash 3.2/4.x `[!a-z0-9]*` does NOT reject `BETA`: the shape check would classify
+# `ci:waive:BETA` as IN FORCE, making the report laxer than the ruby evaluator on the
+# one path whose purpose is that they cannot disagree. macOS ships /bin/bash 3.2 and
+# runs these scripts (scripts/agent-gate.sh uses `taskpolicy`), so this was live —
+# and it is invisible to a plain run on this box, which is bash 5.x.
+echo "== the tier-id shape check is locale- and bash-version-independent =="
+
+# The class as the aggregator actually spells it, read out of the source so the check
+# cannot drift from the code.
+SHAPE_PAT=$(grep -E "^ *''\|\[!" "$AGG_REAL" | head -n 1)
+SHAPE_PAT=${SHAPE_PAT%)*}
+SHAPE_PAT=${SHAPE_PAT#"${SHAPE_PAT%%[![:space:]]*}"}
+# The pre-fix form, kept as the harness's own control: if THIS does not misclassify in
+# the reproduction below, the reproduction has no discriminating power and says so
+# instead of reporting a pass it did not earn.
+SHAPE_PAT_OLD="''|[!a-z0-9]*|*[!a-z0-9-]*"
+# bash 3.2 semantics, reproduced on bash 5.x: turn `globasciiranges` off and collate
+# under a locale whose order interleaves the cases.
+shape_verdict() {
+  (
+    LC_ALL=en_US.UTF-8
+    export LC_ALL
+    shopt -u globasciiranges 2>/dev/null || true
+    tier="$1"
+    eval "case \"\$tier\" in
+      $2) printf off-shape ;;
+      *) printf in-force ;;
+    esac"
+  )
+}
+
+# STRUCTURAL PIN, true whatever this box's bash does: the class is spelled out. This
+# is the assertion that cannot be environment-dependent, and it fails the moment the
+# range comes back.
+if contains "$SHAPE_PAT" 'abcdefghijklmnopqrstuvwxyz0123456789' &&
+   ! contains "$SHAPE_PAT" 'a-z' && ! contains "$SHAPE_PAT" 'A-Z'; then
+  ok "the tier-id class is spelled out, so it cannot depend on the shell's collation order"
+else
+  bad "the tier-id shape check uses a collation-dependent range: $SHAPE_PAT"
+fi
+# ...and no OTHER executable line in the aggregator carries a single-case range either
+# (its input validators are case-SYMMETRIC — `A-Za-z0-9` — and therefore immune; the
+# tier-id class and the `--event-action` guard were the two that were not).
+COLLATION_RANGES=$(grep -nE '\[!?[^]]*(a-z|A-Z)' "$AGG_REAL" \
+  | grep -vE '^[0-9]+:[[:space:]]*#' | grep -vE 'emit |echo |A-Za-z|a-zA-Z' || true)
+if [ -z "$COLLATION_RANGES" ]; then
+  ok "no executable line in the aggregator matches a single-case glob range"
+else
+  bad "a collation-dependent glob range remains: $COLLATION_RANGES"
+fi
+
+# BEHAVIOURAL, with the harness's discriminating power checked first.
+if [ "$(shape_verdict BETA "$SHAPE_PAT_OLD")" = "in-force" ]; then
+  if [ "$(shape_verdict BETA "$SHAPE_PAT")" = "off-shape" ] &&
+     [ "$(shape_verdict Flight "$SHAPE_PAT")" = "off-shape" ] &&
+     [ "$(shape_verdict flight "$SHAPE_PAT")" = "in-force" ] &&
+     [ "$(shape_verdict beta-2 "$SHAPE_PAT")" = "in-force" ]; then
+    ok "under bash 3.2 range semantics the class still rejects BETA/Flight and accepts flight/beta-2"
+  else
+    bad "the shape check misclassifies under collation ranges: BETA=$(shape_verdict BETA "$SHAPE_PAT") Flight=$(shape_verdict Flight "$SHAPE_PAT") flight=$(shape_verdict flight "$SHAPE_PAT")"
+  fi
+else
+  # Honest about it rather than banking a pass: the structural pin above is then the
+  # only coverage, and it is environment-independent.
+  echo "note: this environment cannot reproduce collation ranges (no en_US.UTF-8, or codepoint-ordered);"
+  echo "note: the bash-3.2 defect is covered structurally here, not behaviourally"
+fi
+
+# LOW 1: the feed total counts RECORDS, not lines. The blank-line fixture is one real
+# event plus a trailing blank, which used to be reported as "2 `labeled` event(s)".
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels-cmd "$WORK/labels-beta-live.sh" --waiver-events-cmd "cat $WORK/waiver-events-blankline.tsv"
+if contains "$(evidence_line "$SUMMARY")" '1 `labeled` event(s)' &&
+   ! contains "$(evidence_line "$SUMMARY")" '2 `labeled` event(s)'; then
+  ok "a blank feed line is not counted as an event read (records, not lines)"
+else
+  bad "the feed total counted a blank line as an event: $(evidence_line "$SUMMARY")"
+fi
+
+# LOW 2a: presence is a claim too. Under a FAILED live read the off-shape label comes
+# from the run-start payload, so it may have been removed since — the line may not say
+# it "is applied".
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:BETA" --labels-cmd "$WORK/labels-403.sh"
+STATE_OFFSHAPE_UNTRUSTED=$(evidence_line "$SUMMARY")
+if contains "$STATE_OFFSHAPE_UNTRUSTED" "INVALID WAIVER LABEL" &&
+   contains "$STATE_OFFSHAPE_UNTRUSTED" "whether they are still applied was NOT observed" &&
+   ! contains "$STATE_OFFSHAPE_UNTRUSTED" '`ci:waive:BETA` are applied'; then
+  ok "an off-shape label read from the payload is not asserted to be applied NOW"
+else
+  bad "the off-shape line claimed a presence it never observed: $STATE_OFFSHAPE_UNTRUSTED"
+fi
+if [ "$STATE_OFFSHAPE_UNTRUSTED" != "$STATE_OFFSHAPE" ]; then
+  ok "an observed off-shape label and an unobserved one are different lines"
+else
+  bad "the untrusted off-shape line reads identically to the observed one"
+fi
+
+# LOW 2b: "nothing was read" is a claim about the RUN. A valid waiver label on poll 1
+# whose feed read SUCCEEDED, then mistyped: the feed WAS read, and saying otherwise is
+# the same false absence one variable over.
+cat >"$WORK/labels-beta-then-offshape.sh" <<EOF
+#!/usr/bin/env bash
+n=\$(cat "$WORK/labels-typo.count" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" >"$WORK/labels-typo.count"
+if [ "\$n" -le 1 ]; then echo "ci:waive:beta"; else echo "ci:waive:BETA"; fi
+exit 0
+EOF
+chmod +x "$WORK/labels-beta-then-offshape.sh"
+rm -f "$WORK/labels-typo.count"
+invoke "cat $(runs_file one-pending)" "$WORK/self-ids.txt" "$FUTURE" 2 \
+  --labels-cmd "$WORK/labels-beta-then-offshape.sh" --waiver-events-cmd "$WAIVER_EVENTS"
+if contains "$(evidence_line "$SUMMARY")" "earlier poll(s) DID read the feed" &&
+   ! contains "$(evidence_line "$SUMMARY")" "were read at any point"; then
+  ok "an earlier successful feed read is not erased by a later off-shape label"
+else
+  bad "the off-shape line claimed nothing was ever read, after a read succeeded: $(evidence_line "$SUMMARY")"
+fi
+
+# LOW 3: the in-force list is deduplicated and bounded exactly like the off-shape one —
+# it is interpolated into two annotations and two summary lines, and GitHub allows up
+# to 100 labels on a pull request.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta,ci:waive:beta"
+DUP_COUNT=$(printf '%s\n' "$(evidence_line "$SUMMARY")" | grep -o 'ci:waive:beta' | grep -c . || true)
+if [ "${DUP_COUNT:-0}" -eq 1 ]; then
+  ok "a repeated waiver label is named once, not once per occurrence"
+else
+  bad "the in-force list named a duplicated label ${DUP_COUNT:-0} times: $(evidence_line "$SUMMARY")"
+fi
+MANY_VALID=""
+MANY_OFFSHAPE=""
+i=0
+while [ "$i" -lt 40 ]; do
+  i=$((i + 1))
+  MANY_VALID="${MANY_VALID}ci:waive:tier-${i},"
+  MANY_OFFSHAPE="${MANY_OFFSHAPE}ci:waive:Tier-${i},"
+done
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "${MANY_VALID%,}"
+if contains "$(evidence_line "$SUMMARY")" "(truncated)" && contains "$OUT" "(truncated)"; then
+  ok "a heavily-labelled PR gets a BOUNDED in-force list in the summary and the annotation"
+else
+  bad "the in-force list was unbounded: $(evidence_line "$SUMMARY")"
+fi
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "${MANY_OFFSHAPE%,}"
+if contains "$(evidence_line "$SUMMARY")" "(truncated)"; then
+  ok "the off-shape list is bounded the same way"
+else
+  bad "the off-shape list was unbounded: $(evidence_line "$SUMMARY")"
+fi
+
 invoke "cat $(runs_file one-failed)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"
 if [ "$RC" -ne 0 ]; then ok "a waiver cannot excuse a FAILED tier"; else bad "failed+waived wrongly passed"; fi
 if contains "$OUT" "cannot be waived"; then

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -1030,11 +1030,13 @@ fi
 # THE REPORT MAY NOT BE LAXER THAN THE VERDICT. `ci:waive:BETA` is not a waiver
 # label (gating_registry.rb requires a lower-case tier id), so an event for it
 # waives nothing — and must not be counted as usable evidence either, or the summary
-# would claim in-force evidence for a label the evaluator ignores.
+# would claim in-force evidence for a label the evaluator ignores. Round 6 sharpened
+# what this reports: the off-shape label is now its OWN state (see the round-6 block
+# below) rather than a zero-intersection reading of a feed nobody needed to fetch.
 printf 'ci:waive:BETA\tshouty-labeller\t2026-01-01T00:00:00Z\n' >"$WORK/waiver-events-offshape.tsv"
 invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
   --labels "ci:waive:BETA" --waiver-events-cmd "cat $WORK/waiver-events-offshape.tsv"
-if [ "$RC" -ne 0 ] && contains "$(evidence_line "$SUMMARY")" "0 for a waiver label in force now" &&
+if [ "$RC" -ne 0 ] && contains "$(evidence_line "$SUMMARY")" "INVALID WAIVER LABEL" &&
    ! contains "$(evidence_line "$SUMMARY")" "OBSERVED for that label"; then
   ok "an off-shape waiver label counts as no in-force evidence, matching what the evaluator accepts"
 else
@@ -1081,6 +1083,116 @@ if [ -n "$STATE_UNTRUSTED_NONE" ] && [ -n "$STATE_STALE" ] && [ -n "$STATE_UNKNO
   ok "the round-4 states are distinct from one another and from every earlier state"
 else
   bad "a round-4 state reports identically to another: untrusted='$STATE_UNTRUSTED_NONE' stale='$STATE_STALE' unknown='$STATE_UNKNOWN_MATCH'"
+fi
+
+# ---- round 6: a `ci:waive:` SUBSTRING is not a waiver label (issue #3033) ----
+# THE LAST INSTANCE OF THE SAME DEFECT. The evidence read was gated on the raw
+# substring `*ci:waive:*` while the verdict uses gating_registry.rb's
+# /\Aci:waive:[a-z0-9][a-z0-9-]*\z/. So `ci:waive:Flight` — a capitalisation typo on
+# a real tier id, and the shape a first-ever break-glass exercise produces — sent the
+# run into the evidence path, where the UNREADABLE/UNAVAILABLE lines asserted that
+# "the label set this run is using carries a ci:waive:<tier-id> label". That is a
+# claim about a break-glass THAT DOES NOT EXIST and that the evaluator ignores, and
+# it points the reader at the workflow's `permissions:` block for what is a typo.
+# The gate now uses the validated set, and the off-shape label gets its own line
+# naming it. Hermetic fixtures only: `ci:waive:BETA`/`ci:waive:Flight`, never the
+# repo's real `ci:waive:flight`.
+echo "== an off-shape ci:waive: label is named as a typo, not diagnosed as an API problem =="
+
+# A live label read that succeeds and returns ONLY an off-shape waiver label.
+printf '#!/usr/bin/env bash\necho ci:waive:BETA\nexit 0\n' >"$WORK/labels-offshape-live.sh"
+chmod +x "$WORK/labels-offshape-live.sh"
+# An events command that RECORDS being called. An off-shape label must not cost the
+# paginated label-events read at all, so the absence of this file is the evidence
+# that the gate is the validated set and not the substring.
+cat >"$WORK/waiver-events-probe.sh" <<EOF
+#!/usr/bin/env bash
+echo probed >>"$WORK/events-probe.count"
+cat "$WORK/waiver-events-offshape.tsv"
+EOF
+chmod +x "$WORK/waiver-events-probe.sh"
+# A valid waiver label WITH an off-shape one beside it: the valid label owns the
+# headline, and the typo must still be named somewhere or the operator never learns
+# that half of what they applied did nothing.
+printf '#!/usr/bin/env bash\nprintf "ci:waive:beta\\nci:waive:Flight\\n"\nexit 0\n' \
+  >"$WORK/labels-mixed-live.sh"
+chmod +x "$WORK/labels-mixed-live.sh"
+
+rm -f "$WORK/events-probe.count"
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels-cmd "$WORK/labels-offshape-live.sh" --waiver-events-cmd "$WORK/waiver-events-probe.sh"
+STATE_OFFSHAPE=$(evidence_line "$SUMMARY")
+if contains "$STATE_OFFSHAPE" "INVALID WAIVER LABEL" && contains "$STATE_OFFSHAPE" 'ci:waive:BETA' &&
+   contains "$STATE_OFFSHAPE" "waives NOTHING"; then
+  ok "an off-shape ci:waive: label is reported as its own state, naming the offending label"
+else
+  bad "the off-shape label was not named as waiving nothing: $STATE_OFFSHAPE"
+fi
+# THE WHOLE POINT: it must not read as an authorization/API failure, and the remedy
+# it offers must be the typo, not the `permissions:` block.
+if ! contains "$STATE_OFFSHAPE" "UNREADABLE" && ! contains "$STATE_OFFSHAPE" "UNAVAILABLE" &&
+   ! contains "$(cat "$SUMMARY")" 'permissions:' &&
+   contains "$(cat "$SUMMARY")" "capitalised tier id"; then
+  ok "the off-shape state diagnoses the typo instead of sending the reader to the permissions block"
+else
+  bad "an off-shape label still reads as an API/authorization problem: $(cat "$SUMMARY")"
+fi
+if [ ! -f "$WORK/events-probe.count" ]; then
+  ok "an off-shape label costs no label-events read (the gate is the validated shape, not a substring)"
+else
+  bad "the events feed was fetched for a label that waives nothing: $(cat "$WORK/events-probe.count")"
+fi
+# FAIL-SAFE DIRECTION: an off-shape label grants nothing, so the absent tier reds.
+if [ "$RC" -ne 0 ] && contains "$OUT" "beta" && ! contains "$OUT" "WAIVED"; then
+  ok "an off-shape label waives nothing — the absent tier still fails"
+else
+  bad "an off-shape label excused a tier or hid the red (rc=$RC): $OUT"
+fi
+# ...and it is a DIFFERENT line from every neighbouring state, including the plain
+# absence it used to be reported as and the two abnormal states it used to borrow.
+if [ -n "$STATE_OFFSHAPE" ] && [ "$STATE_OFFSHAPE" != "$STATE_NONE" ] &&
+   [ "$STATE_OFFSHAPE" != "$STATE_BAD" ] && [ "$STATE_OFFSHAPE" != "$STATE_UNCONF" ] &&
+   [ "$STATE_OFFSHAPE" != "$STATE_LIVE_NONE" ] && [ "$STATE_OFFSHAPE" != "$STATE_NOWAIVE" ]; then
+  ok "the off-shape state is distinct from the absence, unreadable, unavailable and zero-match lines"
+else
+  bad "the off-shape state reports identically to another: '$STATE_OFFSHAPE'"
+fi
+
+# An off-shape label ALONGSIDE a valid one: the valid label's evidence state owns the
+# headline, and the typo is still named once.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels-cmd "$WORK/labels-mixed-live.sh" --waiver-events-cmd "$WAIVER_EVENTS"
+MIXED_SUMMARY="$(cat "$SUMMARY")"
+if [ "$RC" -eq 0 ] && contains "$(evidence_line "$SUMMARY")" "READ OK" &&
+   contains "$MIXED_SUMMARY" "Also applied, and NOT a waiver label" &&
+   contains "$MIXED_SUMMARY" 'ci:waive:Flight'; then
+  ok "an off-shape label beside a valid one is still named, and the valid one still waives its tier"
+else
+  bad "the off-shape label vanished behind a valid one (rc=$RC): $MIXED_SUMMARY"
+fi
+
+# THE PRODUCTION HAPPY PATH, ASSERTED AT THE SUMMARY LINE. Every other in-force
+# assertion in this suite runs off the event PAYLOAD labels; the live-read path — what
+# CI actually does — was only ever asserted through the exit status, which ruby
+# decides. So a regression that emptied the in-force set under a live read would flip
+# this line to "0 for a waiver label in force now" with the whole suite still green.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels-cmd "$WORK/labels-beta-live.sh" --waiver-events-cmd "$WAIVER_EVENTS"
+STATE_LIVE_MATCH=$(evidence_line "$SUMMARY")
+if [ "$RC" -eq 0 ] && contains "$STATE_LIVE_MATCH" "READ OK" &&
+   contains "$STATE_LIVE_MATCH" '1 of them for a `ci:waive:` label in force' &&
+   contains "$STATE_LIVE_MATCH" "OBSERVED for that label" &&
+   ! contains "$STATE_LIVE_MATCH" "UNKNOWN" &&
+   ! contains "$STATE_LIVE_MATCH" "0 for a waiver label in force now"; then
+  ok "a live label read with a matching event reports the observed evidence, not a zero or an UNKNOWN"
+else
+  bad "the live-read happy path's summary line is wrong (rc=$RC): $STATE_LIVE_MATCH"
+fi
+# And the evidence is USED, not merely reported: the applier is named from the feed.
+if contains "$OUT" "WAIVED" && contains "$OUT" "real-labeller" && ! contains "$OUT" "UNRESOLVED"; then
+  ok "the live-read in-force match attributes the waiver to whoever applied it"
+else
+  bad "a live-read waiver with usable evidence was not attributed: $OUT"
 fi
 
 invoke "cat $(runs_file one-failed)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -792,7 +792,12 @@ else
 fi
 # THE MOST VALUABLE FACT IN THE DIAGNOSTIC: the HTTP status, which is what separates
 # "the token may not read this" from "GitHub was briefly unwell".
-if contains "$STATE_BAD" "HTTP 403" &&
+# Anchored on the CLASSIFIED shape `(HTTP 403 — …)`, not merely on the string "HTTP
+# 403" appearing somewhere: the client's raw stderr contains that string too, so an
+# assertion on it alone survives a broken status extraction and lets a 403 be
+# described as "no HTTP status reported" — the client-failure diagnosis, whose remedy
+# ("no re-run fixes it") is the wrong advice for an authorization refusal.
+if contains "$STATE_BAD" "(HTTP 403 —" && ! contains "$STATE_BAD" "no HTTP status reported" &&
    contains "$(cat "$WORK/evidence-unreadable.md")" 'permissions:'; then
   ok "the HTTP status is surfaced and an authorization status names the permissions block"
 else

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -1163,6 +1163,24 @@ else
   bad "the off-shape state reports identically to another: '$STATE_OFFSHAPE'"
 fi
 
+# A LABEL NAME IS USER-CONTROLLED TEXT, and this line is the only place the report
+# prints one. It goes to stdout, where `::` is workflow-command syntax, and it has to
+# stay a single summary line — so the name is defanged and stripped of control
+# characters at collection, in pure shell (a sanitiser that could fail would take the
+# diagnostic with it).
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "$(printf 'ci:waive:A\nB::error::pwned')"
+OFFSHAPE_LINE=$(grep 'INVALID WAIVER LABEL' "$SUMMARY" || true)
+# ONE line carries the whole name: the embedded newline is gone (a name that wrapped
+# would leave `__error__pwned` on a line of its own), and `::` is defanged.
+OFFSHAPE_SPILL=$(grep -c '__error__pwned' "$SUMMARY" || true)
+if contains "$OFFSHAPE_LINE" 'ci:waive:AB__error__pwned' &&
+   ! contains "$(cat "$SUMMARY")" '::error::pwned' && [ "${OFFSHAPE_SPILL:-0}" -eq 1 ]; then
+  ok "an off-shape label's name is defanged and stays one line (it is attacker-controlled text)"
+else
+  bad "an off-shape label name reached the summary unsanitised (spill=${OFFSHAPE_SPILL:-0}): $(cat "$SUMMARY")"
+fi
+
 # An off-shape label ALONGSIDE a valid one: the valid label's evidence state owns the
 # headline, and the typo is still named once.
 invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -477,6 +477,32 @@ invoke() {
 
 contains() { case "$1" in *"$2"*) return 0 ;; *) return 1 ;; esac; }
 
+# NO TWO LINES OF ONE RUN MAY CONTRADICT EACH OTHER (issue #3033 round 8). The
+# recurring defect in this block has been a claim that outran the run's observations;
+# its worst form is a summary that both ADMITS a read failed and DENIES that anything
+# failed, which is what an off-shape label plus a 403 on the label read used to
+# produce (`permissions:` advice next to "NOT an authorization or API problem"). This
+# is the property, not a spelling: any run that admits a failed read must carry none
+# of the denials.
+admits_read_failure() {
+  case "$1" in
+    *"could not read"*|*"labels FAILED"*|*"read FAILED"*|*"read(s) FAILED"*|*"events FAILED"*|*UNREADABLE*)
+      return 0 ;;
+  esac
+  return 1
+}
+DENIAL_PHRASES="NOT an authorization or API problem|and nothing failed|neither a permission nor an API problem|no read failed on this run|there was never"
+contradictions() {
+  local out="$1" found="" d="" rest="$DENIAL_PHRASES"
+  admits_read_failure "$out" || return 0
+  while [ -n "$rest" ]; do
+    d="${rest%%|*}"
+    if [ "$d" = "$rest" ]; then rest=""; else rest="${rest#*|}"; fi
+    case "$out" in *"$d"*) found="${found}[${d}] " ;; esac
+  done
+  printf '%s' "$found"
+}
+
 FUTURE=$(( $(date +%s) + 86400 ))
 EXPIRED=1
 
@@ -924,7 +950,7 @@ rm -f "$WORK/labels-drop.count"
 invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$FUTURE" 2 \
   --labels-cmd "$WORK/labels-then-none.sh" --waiver-events-cmd "$WORK/waiver-events-403.sh"
 DROP_SUMMARY="$(cat "$SUMMARY")"
-if [ "$RC" -ne 0 ] && contains "$DROP_SUMMARY" "no waiver label now, but" &&
+if [ "$RC" -ne 0 ] && contains "$DROP_SUMMARY" "no valid waiver label is in the label set this run is using now, but" &&
    contains "$DROP_SUMMARY" "HTTP 403"; then
   ok "a waiver label removed mid-run keeps the record that its events were unreadable"
 else
@@ -1187,7 +1213,7 @@ invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
   --labels-cmd "$WORK/labels-mixed-live.sh" --waiver-events-cmd "$WAIVER_EVENTS"
 MIXED_SUMMARY="$(cat "$SUMMARY")"
 if [ "$RC" -eq 0 ] && contains "$(evidence_line "$SUMMARY")" "READ OK" &&
-   contains "$MIXED_SUMMARY" "Also applied, and NOT a waiver label" &&
+   contains "$MIXED_SUMMARY" "Also in the label set this run is using, and NOT a waiver label" &&
    contains "$MIXED_SUMMARY" 'ci:waive:Flight'; then
   ok "an off-shape label beside a valid one is still named, and the valid one still waives its tier"
 else
@@ -1267,8 +1293,14 @@ fi
 # ...and no OTHER executable line in the aggregator carries a single-case range either
 # (its input validators are case-SYMMETRIC — `A-Za-z0-9` — and therefore immune; the
 # tier-id class and the `--event-action` guard were the two that were not).
-COLLATION_RANGES=$(grep -nE '\[!?[^]]*(a-z|A-Z)' "$AGG_REAL" \
-  | grep -vE '^[0-9]+:[[:space:]]*#' | grep -vE 'emit |echo |A-Za-z|a-zA-Z' || true)
+#
+# COMMENTS AND STRING LITERALS ARE STRIPPED, NOT WHOLE LINES. An earlier form dropped
+# every line containing `emit `/`echo `, so a real range on a line that also carried an
+# annotation escaped the check — a guard weaker than the invariant it pins. Stripping
+# `#...`, "..." and '...' leaves exactly the executable glob patterns, which are
+# unquoted by construction.
+COLLATION_RANGES=$(sed -e 's/#.*$//' -e 's/"[^"]*"//g' -e "s/'[^']*'//g" "$AGG_REAL" \
+  | grep -nE '\[!?[^]]*(a-z|A-Z)' | grep -vE 'A-Za-z|a-zA-Z' || true)
 if [ -z "$COLLATION_RANGES" ]; then
   ok "no executable line in the aggregator matches a single-case glob range"
 else
@@ -1309,12 +1341,26 @@ fi
 invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
   --labels "ci:waive:BETA" --labels-cmd "$WORK/labels-403.sh"
 STATE_OFFSHAPE_UNTRUSTED=$(evidence_line "$SUMMARY")
+OFFSHAPE_UNTRUSTED_OUT="$OUT"
 if contains "$STATE_OFFSHAPE_UNTRUSTED" "INVALID WAIVER LABEL" &&
    contains "$STATE_OFFSHAPE_UNTRUSTED" "whether they are still applied was NOT observed" &&
    ! contains "$STATE_OFFSHAPE_UNTRUSTED" '`ci:waive:BETA` are applied'; then
   ok "an off-shape label read from the payload is not asserted to be applied NOW"
 else
   bad "the off-shape line claimed a presence it never observed: $STATE_OFFSHAPE_UNTRUSTED"
+fi
+# THE ROUND-7 FINDING, in the same state this case already exercised: the trailing
+# note and the blockquote denied that anything failed while the label read's own 403
+# was reported a few lines further down. Both halves of the denial are pinned, and so
+# is the positive statement that replaces them.
+if ! contains "$OFFSHAPE_UNTRUSTED_OUT" "and nothing failed" &&
+   ! contains "$OFFSHAPE_UNTRUSTED_OUT" "NOT an authorization or API problem" &&
+   ! contains "$OFFSHAPE_UNTRUSTED_OUT" "there was never" &&
+   contains "$OFFSHAPE_UNTRUSTED_OUT" "A read DID fail on this run" &&
+   contains "$OFFSHAPE_UNTRUSTED_OUT" 'permissions:'; then
+  ok "an off-shape label plus a failed label read admits the failure instead of denying it"
+else
+  bad "the off-shape diagnostic contradicted the label-read failure in the same run: $OFFSHAPE_UNTRUSTED_OUT"
 fi
 if [ "$STATE_OFFSHAPE_UNTRUSTED" != "$STATE_OFFSHAPE" ]; then
   ok "an observed off-shape label and an unobserved one are different lines"
@@ -1337,8 +1383,9 @@ chmod +x "$WORK/labels-beta-then-offshape.sh"
 rm -f "$WORK/labels-typo.count"
 invoke "cat $(runs_file one-pending)" "$WORK/self-ids.txt" "$FUTURE" 2 \
   --labels-cmd "$WORK/labels-beta-then-offshape.sh" --waiver-events-cmd "$WAIVER_EVENTS"
-if contains "$(evidence_line "$SUMMARY")" "earlier poll(s) DID read the feed" &&
-   ! contains "$(evidence_line "$SUMMARY")" "were read at any point"; then
+if contains "$(evidence_line "$SUMMARY")" "the feed WAS read on 1 earlier poll(s)" &&
+   ! contains "$(evidence_line "$SUMMARY")" "there was never" &&
+   ! contains "$(evidence_line "$SUMMARY")" "read on this run"; then
   ok "an earlier successful feed read is not erased by a later off-shape label"
 else
   bad "the off-shape line claimed nothing was ever read, after a read succeeded: $(evidence_line "$SUMMARY")"
@@ -1374,6 +1421,149 @@ if contains "$(evidence_line "$SUMMARY")" "(truncated)"; then
   ok "the off-shape list is bounded the same way"
 else
   bad "the off-shape list was unbounded: $(evidence_line "$SUMMARY")"
+fi
+
+# ---- round 8: the sweep — no site claims more than the run observed -----------
+# EACH ROUND HARDENED THE SITE THE REVIEWER NAMED and left its siblings alone, which
+# is why there was a round 5, 6 and 7. So this pins the PROPERTY across combined
+# states rather than three more strings: a run that admits a read failed may carry no
+# denial that one did, in any of its lines.
+echo "== no run contradicts itself across two lines of one summary =="
+
+# An events read that FAILS on the first poll and succeeds (with no waiver event) on
+# the second: the zero-in-force blockquote used to say "The read succeeded, so this is
+# neither a permission nor an API problem" while the failure was reported below it.
+cat >"$WORK/waiver-events-403-then-ok.sh" <<EOF
+#!/usr/bin/env bash
+n=\$(cat "$WORK/events-403.count" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" >"$WORK/events-403.count"
+if [ "\$n" -le 1 ]; then echo "gh: Resource not accessible by integration (HTTP 403)" >&2; exit 1; fi
+cat "$WORK/waiver-events-no-waiver.tsv"
+EOF
+chmod +x "$WORK/waiver-events-403-then-ok.sh"
+rm -f "$WORK/events-403.count"
+invoke "cat $(runs_file one-pending)" "$WORK/self-ids.txt" "$FUTURE" 2 \
+  --labels-cmd "$WORK/labels-beta-live.sh" --waiver-events-cmd "$WORK/waiver-events-403-then-ok.sh"
+RECOVERED_OUT="$OUT"
+if contains "$RECOVERED_OUT" "The read succeeded on THIS poll" &&
+   ! contains "$RECOVERED_OUT" "neither a permission nor an API problem"; then
+  ok "a feed read that failed earlier is not denied by the poll that succeeded"
+else
+  bad "the recovered-read case denied the earlier failure: $RECOVERED_OUT"
+fi
+
+# An off-shape label NOW, with a valid one earlier whose feed read FAILED.
+cat >"$WORK/labels-beta-then-offshape-2.sh" <<EOF
+#!/usr/bin/env bash
+n=\$(cat "$WORK/labels-typo2.count" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" >"$WORK/labels-typo2.count"
+if [ "\$n" -le 1 ]; then echo "ci:waive:beta"; else echo "ci:waive:BETA"; fi
+exit 0
+EOF
+chmod +x "$WORK/labels-beta-then-offshape-2.sh"
+rm -f "$WORK/labels-typo2.count"
+invoke "cat $(runs_file one-pending)" "$WORK/self-ids.txt" "$FUTURE" 2 \
+  --labels-cmd "$WORK/labels-beta-then-offshape-2.sh" --waiver-events-cmd "$WORK/waiver-events-403.sh"
+OFFSHAPE_AFTER_FAIL="$OUT"
+if contains "$OFFSHAPE_AFTER_FAIL" "earlier read(s) of the feed FAILED" &&
+   contains "$OFFSHAPE_AFTER_FAIL" "A read DID fail on this run" &&
+   ! contains "$OFFSHAPE_AFTER_FAIL" "read on this run: no valid"; then
+  ok "an off-shape label after a FAILED feed read reports the failure, not 'nothing was read'"
+else
+  bad "the off-shape line erased an earlier failed read: $OFFSHAPE_AFTER_FAIL"
+fi
+
+# THE PROPERTY ITSELF, over every combined state this suite can build. A future
+# unhedged sibling fails here instead of waiting for a reviewer.
+CONTRA=""
+for combo in "offshape+failed-label-read:$OFFSHAPE_UNTRUSTED_OUT" \
+             "offshape+failed-feed-read:$OFFSHAPE_AFTER_FAIL" \
+             "recovered-feed-read:$RECOVERED_OUT"; do
+  found=$(contradictions "${combo#*:}")
+  [ -n "$found" ] && CONTRA="${CONTRA}${combo%%:*} => ${found}; "
+done
+# ...and the four remaining states, re-run here so the check covers all of them.
+rm -f "$WORK/labels-typo.count"
+for spec in "untrusted-labels+inforce-unknown:--labels|ci:waive:beta|--labels-cmd|$WORK/labels-403.sh|--waiver-events-cmd|$WAIVER_EVENTS" \
+            "unreadable-feed:--labels|ci:waive:beta|--waiver-events-cmd|$WORK/waiver-events-403.sh" \
+            "unconfigured:--labels|ci:waive:beta" \
+            "offshape-live:--labels-cmd|$WORK/labels-offshape-live.sh" \
+            "zero-inforce:--labels-cmd|$WORK/labels-beta-live.sh|--waiver-events-cmd|cat $WORK/waiver-events-stale.tsv" \
+            "plain-none:--labels-cmd|$WORK/labels-none-live.sh"; do
+  name="${spec%%:*}"
+  args="${spec#*:}"
+  OLD_IFS="$IFS"; IFS='|'
+  # shellcheck disable=SC2086 # deliberate word split on the | separator
+  set -- $args
+  IFS="$OLD_IFS"
+  invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 "$@"
+  found=$(contradictions "$OUT")
+  [ -n "$found" ] && CONTRA="${CONTRA}${name} => ${found}; "
+done
+if [ -z "$CONTRA" ]; then
+  ok "no state's output admits a failed read and denies one at the same time (9 combinations)"
+else
+  bad "a summary contradicted itself: $CONTRA"
+fi
+# THE DETECTOR MUST DETECT, or the sweep above passes on nine states it never
+# examined. Exercised on the exact shape the round-7 finding quoted, and on a text that
+# denies without admitting (where the denial is legitimate).
+if [ -n "$(contradictions 'the live read of this pull request labels FAILED ... and nothing failed')" ] &&
+   [ -z "$(contradictions 'the read succeeded; no read failed on this run')" ]; then
+  ok "the self-contradiction detector fires on an admission+denial pair and stays quiet otherwise"
+else
+  bad "the contradiction detector is vacuous: it did not fire on a known contradiction"
+fi
+
+# Low (round 7): the in-force line must carry the same provenance the `none` branch
+# carries for the identical label source. Payload labels: the count is real, but "in
+# force" means in force in a run-start snapshot nobody re-read.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"
+if contains "$(evidence_line "$SUMMARY")" "OBSERVED for that label" &&
+   contains "$(evidence_line "$SUMMARY")" "that label set is the run-start event payload"; then
+  ok "an in-force claim from payload labels says the labels are the payload, as the absence line does"
+else
+  bad "the in-force line asserted 'in force' without its label provenance: $(evidence_line "$SUMMARY")"
+fi
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels-cmd "$WORK/labels-beta-live.sh" --waiver-events-cmd "$WAIVER_EVENTS"
+if ! contains "$(evidence_line "$SUMMARY")" "that label set is the run-start event payload"; then
+  ok "a live label read carries no payload caveat — the hedge appears only where it is true"
+else
+  bad "a live read was hedged as a payload snapshot: $(evidence_line "$SUMMARY")"
+fi
+
+# Low (round 7): a PERSISTENT label-read failure is annotated once, not per poll — the
+# durable record is the summary's count. A DIFFERENT failure still annotates.
+invoke "cat $(runs_file one-pending)" "$WORK/self-ids.txt" "$FUTURE" 3 \
+  --labels-cmd "$WORK/labels-403.sh"
+LABEL_WARNINGS=$(printf '%s\n' "$OUT" | grep -c "could not read the PR's current labels" || true)
+if [ "${LABEL_WARNINGS:-0}" -eq 1 ] && contains "$(cat "$SUMMARY")" "failed read(s)"; then
+  ok "a persistent label-read failure is annotated once per run, with the count in the summary"
+else
+  bad "the label-read warning fired ${LABEL_WARNINGS:-0} times across the poll loop"
+fi
+cat >"$WORK/labels-403-then-client-fail.sh" <<EOF
+#!/usr/bin/env bash
+n=\$(cat "$WORK/labels-mixed-fail.count" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" >"$WORK/labels-mixed-fail.count"
+if [ "\$n" -le 1 ]; then echo "gh: Resource not accessible by integration (HTTP 403)" >&2; exit 1; fi
+echo "bash: gh: command not found" >&2
+exit 127
+EOF
+chmod +x "$WORK/labels-403-then-client-fail.sh"
+rm -f "$WORK/labels-mixed-fail.count"
+invoke "cat $(runs_file one-pending)" "$WORK/self-ids.txt" "$FUTURE" 3 \
+  --labels-cmd "$WORK/labels-403-then-client-fail.sh"
+MIXED_WARNINGS=$(printf '%s\n' "$OUT" | grep -c "could not read the PR's current labels" || true)
+if [ "${MIXED_WARNINGS:-0}" -ge 2 ] && contains "$OUT" "HTTP 403" && contains "$OUT" "exit status 127"; then
+  ok "a DIFFERENT label-read failure is still annotated — the dedup keys on the detail, not a boolean"
+else
+  bad "a changed failure detail was swallowed by the dedup (${MIXED_WARNINGS:-0} annotation(s)): $OUT"
 fi
 
 invoke "cat $(runs_file one-failed)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -711,6 +711,32 @@ echo "\$n" >"$WORK/labels-drop.count"
 exit 0
 EOF
 chmod +x "$WORK/labels-then-none.sh"
+# ---- round 4 fixtures: the LABEL read's own trustworthiness -----------------
+# A live label read that FAILS, in the shape `gh` reports an authorization refusal.
+# The run-start payload is then all the run has, and that snapshot predates the
+# whole polling window — which is precisely where a waiver applied mid-run lives.
+cat >"$WORK/labels-403.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "gh: Resource not accessible by integration (HTTP 403)" >&2
+exit 1
+EOF
+chmod +x "$WORK/labels-403.sh"
+# A live label read that SUCCEEDS and returns nothing: the ONLY state in which "no
+# waiver label is present" is an observation rather than a guess.
+printf '#!/usr/bin/env bash\nexit 0\n' >"$WORK/labels-none-live.sh"
+chmod +x "$WORK/labels-none-live.sh"
+# A live label read that succeeds and returns the waiver label in force NOW.
+printf '#!/usr/bin/env bash\necho ci:waive:beta\nexit 0\n' >"$WORK/labels-beta-live.sh"
+chmod +x "$WORK/labels-beta-live.sh"
+# IMMUTABLE HISTORY: a `ci:waive:alpha` labelling from months ago whose label was
+# removed the same day. `labeled` events are never deleted, so it is in this feed
+# forever — and it can attribute or bind exactly nothing.
+printf 'ci:waive:alpha\tancient-labeller\t2025-06-01T00:00:00Z\n' >"$WORK/waiver-events-stale.tsv"
+# A feed carrying a BLANK line (a trailing newline from the API, a `--jq` that
+# emitted an empty record). An empty label must never match the empty slot a
+# label list's trailing separator leaves, or a blank line would count as evidence
+# for a waiver label in force — a false "the evidence was observed" from nothing.
+printf 'needs-decision\tpm-bot\t2025-12-30T00:00:00Z\n\n' >"$WORK/waiver-events-blankline.tsv"
 
 evidence_line() { grep 'Waiver evidence' "$1" | head -n 1 || true; }
 
@@ -863,7 +889,7 @@ fi
 invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
   --labels "ci:waive:beta" --waiver-events-cmd "cat $WORK/waiver-events-no-waiver.tsv"
 STATE_NOWAIVE=$(evidence_line "$SUMMARY")
-if contains "$STATE_NOWAIVE" "READ OK" && contains "$STATE_NOWAIVE" '0 `ci:waive:` labeled events' &&
+if contains "$STATE_NOWAIVE" "READ OK" && contains "$STATE_NOWAIVE" "0 for a waiver label in force now" &&
    contains "$STATE_NOWAIVE" "UNRESOLVED"; then
   ok "a healthy feed with no waiver events is reported as unresolved, not as evidence read"
 else
@@ -898,6 +924,163 @@ if [ "$RC" -ne 0 ] && contains "$DROP_SUMMARY" "no waiver label now, but" &&
   ok "a waiver label removed mid-run keeps the record that its events were unreadable"
 else
   bad "the broken-read history was discarded with the label (rc=$RC): $DROP_SUMMARY"
+fi
+
+# ---- round 4: a claim may not outrun the LABEL read either (issue #3033) ----
+# THE SAME DEFECT CLASS, ONE LAYER FURTHER OUT. Both of these were the summary
+# asserting something derived from state it had not observed:
+#   M1 — the `none` line stated "no ci:waive:<tier-id> label is present" even when
+#        the LIVE label read had FAILED and the labels in hand were the run-start
+#        payload snapshot. The polling window exists so a waiver applied mid-run
+#        takes effect, so that was a confident FALSE NEGATIVE about exactly the
+#        thing this issue is about, in a line this change added.
+#   M2 — the waiver-event count was the whole `ci:waive:` HISTORY. `labeled` events
+#        are immutable, so a label applied and removed months ago kept the "the
+#        evidence is present" claim alive while the label actually IN FORCE had no
+#        event of its own.
+# The fix for both is to report the observation and name the gap: an UNKNOWN, never
+# a confident absence and never a zero that was not counted. And neither state may
+# touch the verdict — the aggregator's exit status comes from tier evaluation alone.
+echo "== the label read's trustworthiness is reported, never assumed =="
+
+# M1's false negative, reproduced: the live read fails, the payload has no waiver
+# label, and a waiver applied since the run started would be invisible.
+invoke "cat $(runs_file all-pass)" "$WORK/self-ids.txt" "$FUTURE" 3 \
+  --labels-cmd "$WORK/labels-403.sh"
+STATE_UNTRUSTED_NONE=$(evidence_line "$SUMMARY")
+if contains "$STATE_UNTRUSTED_NONE" "UNKNOWN" && contains "$STATE_UNTRUSTED_NONE" "UNTRUSTED" &&
+   contains "$STATE_UNTRUSTED_NONE" "run-start event payload" &&
+   ! contains "$STATE_UNTRUSTED_NONE" "label is present on this pull request"; then
+  ok "a failed live label read reports UNKNOWN instead of claiming no waiver label is present"
+else
+  bad "the summary claimed an absence it never observed: $STATE_UNTRUSTED_NONE"
+fi
+# The per-poll `::warning::` was never enough on its own — the finding is that the
+# fallback has to reach the SUMMARY. The durable counter is what proves it did.
+if contains "$STATE_UNTRUSTED_NONE" "1 failed read(s)" && contains "$STATE_UNTRUSTED_NONE" "HTTP 403"; then
+  ok "the failed-label-read count and its HTTP status reach the summary, not just a per-poll warning"
+else
+  bad "the label-read failure left no durable record in the summary: $STATE_UNTRUSTED_NONE"
+fi
+if contains "$OUT" "HTTP 403" && contains "$OUT" "INVISIBLE to it"; then
+  ok "the annotation says what the fallback makes invisible, not merely that it happened"
+else
+  bad "the label-read failure is not diagnosable from the annotation: $OUT"
+fi
+if [ "$RC" -eq 0 ] && ! contains "$OUT" "FAIL (harness)"; then
+  ok "an untrusted label read changes the diagnostic only, never the verdict"
+else
+  bad "an untrusted label read altered the verdict (rc=$RC): $OUT"
+fi
+
+# THE CONTRAST that keeps the guard above non-vacuous: when the live read SUCCEEDS,
+# absence IS an observation and stays stated plainly.
+invoke "cat $(runs_file all-pass)" "$WORK/self-ids.txt" "$FUTURE" 3 \
+  --labels-cmd "$WORK/labels-none-live.sh"
+STATE_LIVE_NONE=$(evidence_line "$SUMMARY")
+if [ "$RC" -eq 0 ] && contains "$STATE_LIVE_NONE" "label is present on this pull request" &&
+   ! contains "$STATE_LIVE_NONE" "UNTRUSTED"; then
+  ok "a successful live read still states the absence plainly — an observation, not a hedge"
+else
+  bad "the genuinely-observed absence lost its plain statement (rc=$RC): $STATE_LIVE_NONE"
+fi
+if [ "$STATE_LIVE_NONE" != "$STATE_UNTRUSTED_NONE" ]; then
+  ok "an observed absence and an unobserved one are different lines"
+else
+  bad "a failed label read reads identically to a successful one: $STATE_LIVE_NONE"
+fi
+
+# M2, reproduced: `ci:waive:beta` is in force, and the only `ci:waive:` event in the
+# feed is the ancient `ci:waive:alpha` whose label is long gone. The old count of 1
+# claimed "the evidence needed for head-binding and attribution is present"; the
+# intersection with the labels in force is 0, and beta's evidence is missing.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels-cmd "$WORK/labels-beta-live.sh" --waiver-events-cmd "cat $WORK/waiver-events-stale.tsv"
+STATE_STALE=$(evidence_line "$SUMMARY")
+if contains "$STATE_STALE" "0 for a waiver label in force now" &&
+   contains "$STATE_STALE" '1 of them for a `ci:waive:` label' &&
+   ! contains "$STATE_STALE" "OBSERVED for that label"; then
+  ok "a waiver event whose label was removed counts as history, never as usable evidence"
+else
+  bad "a stale waiver event was reported as evidence for the label in force: $STATE_STALE"
+fi
+if contains "$(cat "$SUMMARY")" "IMMUTABLE HISTORY"; then
+  ok "the summary explains how a waiver event can be present yet bind nothing"
+else
+  bad "the removed-label case offers no explanation: $(cat "$SUMMARY")"
+fi
+if [ "$RC" -eq 0 ] && contains "$OUT" "WAIVED" && contains "$OUT" "UNRESOLVED"; then
+  ok "a zero intersection still honours the waiver at the deadline and names nobody"
+else
+  bad "a zero intersection changed the verdict (rc=$RC): $OUT"
+fi
+
+# NOTHING COUNTS AS EVIDENCE. A blank line in the feed must not match the in-force
+# label list's empty trailing slot; if it did, an empty record would be reported as
+# an observed `ci:waive:` event for the label in force.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels-cmd "$WORK/labels-beta-live.sh" --waiver-events-cmd "cat $WORK/waiver-events-blankline.tsv"
+if [ "$RC" -eq 0 ] && contains "$(evidence_line "$SUMMARY")" "0 for a waiver label in force now" &&
+   ! contains "$(evidence_line "$SUMMARY")" "OBSERVED for that label"; then
+  ok "a blank feed line counts as nothing, not as evidence for the label in force"
+else
+  bad "an empty record was counted as waiver evidence (rc=$RC): $(evidence_line "$SUMMARY")"
+fi
+
+# THE REPORT MAY NOT BE LAXER THAN THE VERDICT. `ci:waive:BETA` is not a waiver
+# label (gating_registry.rb requires a lower-case tier id), so an event for it
+# waives nothing — and must not be counted as usable evidence either, or the summary
+# would claim in-force evidence for a label the evaluator ignores.
+printf 'ci:waive:BETA\tshouty-labeller\t2026-01-01T00:00:00Z\n' >"$WORK/waiver-events-offshape.tsv"
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:BETA" --waiver-events-cmd "cat $WORK/waiver-events-offshape.tsv"
+if [ "$RC" -ne 0 ] && contains "$(evidence_line "$SUMMARY")" "0 for a waiver label in force now" &&
+   ! contains "$(evidence_line "$SUMMARY")" "OBSERVED for that label"; then
+  ok "an off-shape waiver label counts as no in-force evidence, matching what the evaluator accepts"
+else
+  bad "the report was laxer than the verdict about what a waiver label is (rc=$RC): $(evidence_line "$SUMMARY")"
+fi
+
+# THE ORDERING DEPENDENCY between the two fixes: an intersection is only sound
+# against a label set that was OBSERVED. Live read fails, the payload carries
+# `ci:waive:beta`, the feed is healthy and DOES carry a beta event — the honest
+# report is UNKNOWN, because which labels are in force was never seen.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta" --labels-cmd "$WORK/labels-403.sh" --waiver-events-cmd "$WAIVER_EVENTS"
+STATE_UNKNOWN_MATCH=$(evidence_line "$SUMMARY")
+if contains "$STATE_UNKNOWN_MATCH" "in-force match **UNKNOWN**" &&
+   contains "$STATE_UNKNOWN_MATCH" "did not observe which waiver labels are in force" &&
+   ! contains "$STATE_UNKNOWN_MATCH" "OBSERVED for that label" &&
+   ! contains "$STATE_UNKNOWN_MATCH" "0 for a waiver label in force now"; then
+  ok "an untrusted label read makes the in-force match UNKNOWN — neither present nor zero"
+else
+  bad "the intersection was reported against a label set this run never observed: $STATE_UNKNOWN_MATCH"
+fi
+if [ "$RC" -eq 0 ] && contains "$OUT" "WAIVED" && ! contains "$OUT" "FAIL (harness)"; then
+  ok "the unknown-intersection state is non-fatal and the waiver is still honoured"
+else
+  bad "an unknown intersection changed the verdict (rc=$RC): $OUT"
+fi
+
+# FAIL-SAFE DIRECTION, unchanged by all of the above: a failed label read can only
+# ever WITHHOLD a waiver. No waiver in the payload, so the absent tier still reds.
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels-cmd "$WORK/labels-403.sh"
+if [ "$RC" -ne 0 ] && contains "$OUT" "beta" && contains "$(evidence_line "$SUMMARY")" "UNKNOWN"; then
+  ok "an untrusted label read withholds a waiver rather than inventing one"
+else
+  bad "a failed label read granted a waiver or hid the red (rc=$RC): $OUT"
+fi
+
+# Pairwise distinctness again, now across the round-4 states: an UNKNOWN that reads
+# like a zero, or like an absence, would be the same defect wearing a new word.
+if [ -n "$STATE_UNTRUSTED_NONE" ] && [ -n "$STATE_STALE" ] && [ -n "$STATE_UNKNOWN_MATCH" ] &&
+   [ "$STATE_UNTRUSTED_NONE" != "$STATE_UNKNOWN_MATCH" ] && [ "$STATE_STALE" != "$STATE_READ" ] &&
+   [ "$STATE_STALE" != "$STATE_NOWAIVE" ] && [ "$STATE_UNKNOWN_MATCH" != "$STATE_BAD" ] &&
+   [ "$STATE_UNKNOWN_MATCH" != "$STATE_READ" ]; then
+  ok "the round-4 states are distinct from one another and from every earlier state"
+else
+  bad "a round-4 state reports identically to another: untrusted='$STATE_UNTRUSTED_NONE' stale='$STATE_STALE' unknown='$STATE_UNKNOWN_MATCH'"
 fi
 
 invoke "cat $(runs_file one-failed)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"
@@ -1004,10 +1187,18 @@ fi
 
 invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
   --labels-cmd "false" --labels "ci:waive:beta" --waiver-events-cmd "$WAIVER_EVENTS"
-if [ "$RC" -eq 0 ] && contains "$OUT" "falling back to the event payload labels"; then
+if [ "$RC" -eq 0 ] && contains "$OUT" "falling back to the run-start event payload labels"; then
   ok "an unreadable label source falls back to the payload labels and says so"
 else
   bad "the label-read fallback did not hold (rc=$RC): $OUT"
+fi
+# ...and the fallback is DURABLE, not just a per-poll annotation: the summary has to
+# carry it, because the summary is what a human reads after the fact (issue #3033).
+if contains "$(cat "$SUMMARY")" "Label read UNTRUSTED" &&
+   contains "$(cat "$SUMMARY")" "RUN-START EVENT PAYLOAD"; then
+  ok "the label-read fallback is recorded in the job summary, not only warned about"
+else
+  bad "the fallback left no trace in the summary: $(cat "$SUMMARY")"
 fi
 
 invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 --labels-cmd "printf 'needs-decision\n'"

--- a/scripts/tests/test_aggregate_required_tiers.sh
+++ b/scripts/tests/test_aggregate_required_tiers.sh
@@ -686,6 +686,14 @@ echo "bash: gh: command not found" >&2
 exit 127
 EOF
 chmod +x "$WORK/waiver-events-client-fail.sh"
+# A failure whose stderr survives sanitisation as NOTHING: control characters only.
+# `[ -s ]` sees a non-empty file, so the detail builder takes the sanitising path and
+# is left with an empty string -- the state that used to trail the diagnostic off into
+# a dangling em dash. Also the portable stand-in for the abort hazard the round-3
+# finding named: the sanitising pipeline must never be allowed to end the run.
+printf '#!/usr/bin/env bash\nprintf "\\001\\002\\r" >&2\nexit 4\n' \
+  >"$WORK/waiver-events-unprintable.sh"
+chmod +x "$WORK/waiver-events-unprintable.sh"
 # A HEALTHY read that carries NO waiver event. The default `--jq` selects
 # `event == "labeled"` for every label, so this is the shape that made a feed of
 # `needs-decision` events read as "waiver evidence read": the read works, and
@@ -732,8 +740,16 @@ fi
 # And it must not claim the binding SUCCEEDED — a matching event only binds if its
 # timestamp is at or after this head sha's first CI activity, which is a per-tier
 # verdict, not a property of the read.
-if ! contains "$STATE_READ" "can be bound"; then
-  ok "the readable state claims evidence presence, not that a waiver bound"
+#
+# This guard is deliberately anchored on the hedge the implementation MUST emit, not
+# only on an over-claiming phrase it must not: a purely negative assertion against a
+# string no code path produces passes unconditionally (the round-3 finding — the
+# earlier `! contains "can be bound"` form was vacuous the moment round 2 reworded
+# the line, so it would have accepted "the waiver IS bound to this head sha"). The
+# positive half fails the moment the deferral to the per-tier verdict is dropped.
+if contains "$STATE_READ" "decided per tier above" &&
+   ! contains "$STATE_READ" "is bound" && ! contains "$STATE_READ" "can be bound"; then
+  ok "the readable state defers the binding verdict per tier instead of asserting it"
 else
   bad "the summary asserts a head-binding it did not observe: $STATE_READ"
 fi
@@ -795,6 +811,18 @@ if [ "$RC" -eq 0 ] && contains "$OUT" "UNREADABLE" &&
   ok "a client failure is reported with its exit status and message, claiming no HTTP status"
 else
   bad "a client failure was mis-reported as an API status (rc=$RC): $OUT"
+fi
+
+# Stderr that sanitises down to nothing must still yield a legible diagnostic AND,
+# above all, must not end the run: the verdict has to survive it exactly like every
+# other unreadable shape (rc 0, WAIVED, tier UNRESOLVED).
+invoke "cat $(runs_file one-absent)" "$WORK/self-ids.txt" "$EXPIRED" 1 \
+  --labels "ci:waive:beta" --waiver-events-cmd "$WORK/waiver-events-unprintable.sh"
+if [ "$RC" -eq 0 ] && contains "$OUT" "UNREADABLE" &&
+   contains "$OUT" "exit status 4" && contains "$OUT" "unprintable error output"; then
+  ok "stderr that sanitises to nothing is named as such, and the run still completes"
+else
+  bad "unprintable stderr broke or blanked the diagnostic (rc=$RC): $OUT"
 fi
 
 # A silent non-zero exit (no stderr at all) still has to be distinguishable from

--- a/scripts/tests/test_classify_docs_only.sh
+++ b/scripts/tests/test_classify_docs_only.sh
@@ -139,6 +139,16 @@ if [ -f "$WORKFLOW" ]; then
       # `ci:waive:<tier-id>` applied to a wedged PR takes effect. That read needs
       # both the PR number and `pull-requests: read`; without them the break-glass
       # silently degrades to the event payload snapshot.
+      #
+      # ISSUE #3033: the same `pull-requests: read` also authorizes the SECOND half
+      # of the break-glass — `gh api repos/{slug}/issues/{n}/events`, the `labeled`
+      # events behind waiver attribution and head-binding. GitHub's per-permission
+      # reference lists that endpoint under `Pull requests` read as well as `Issues`
+      # read, so `issues: read` must NOT be added to pr-gate.yml: it would widen a
+      # fork-reachable token over every issue in the repo to authorize nothing new.
+      # This single assertion is therefore the only home for that invariant — the
+      # sibling suite (test_aggregate_required_tiers.sh) deliberately does not
+      # duplicate it. A missing grant kills BOTH reads at once.
       abort("`required` must pass the PR number for the live label read") unless body.include?("pull_request.number")
       perms = wf["permissions"]
       abort("pr-gate.yml must grant `pull-requests: read` for the live label read") unless perms.is_a?(Hash) && perms["pull-requests"].to_s == "read"

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -123,7 +123,11 @@ carry).
   tracked and reported: a fallback to the payload reports **`UNKNOWN (label read UNTRUSTED)`** with the
   failed-read count and status, and it makes the in-force count **UNKNOWN** rather than zero. A failed or
   ambiguous read can only ever *withhold* a waiver, never grant one, and none of these states can change
-  `required`'s verdict — that comes from tier evaluation alone.
+  `required`'s verdict — that comes from tier evaluation alone. The same discipline was then applied to
+  **every** line of the block, not only the ones a reviewer named: claims about labels are phrased against
+  "the label set this run is using" plus that set's provenance, and a run that admits a read failed carries
+  no denial that one did — so you never get `permissions:` advice beside an "authorization is not the
+  problem" line, and the suite pins that property across the combined states rather than the wording.
 - **A mistyped waiver label is named as a typo (issue #3033 round 6).** A waiver label is
   `ci:waive:<tier-id>` with a LOWER-CASE tier id (`[a-z0-9][a-z0-9-]*`), which is what the evaluator
   matches. Anything else — `ci:waive:Flight` for tier `flight` — waives nothing, so the evidence read is

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -124,6 +124,13 @@ carry).
   failed-read count and status, and it makes the in-force count **UNKNOWN** rather than zero. A failed or
   ambiguous read can only ever *withhold* a waiver, never grant one, and none of these states can change
   `required`'s verdict — that comes from tier evaluation alone.
+- **A mistyped waiver label is named as a typo (issue #3033 round 6).** A waiver label is
+  `ci:waive:<tier-id>` with a LOWER-CASE tier id (`[a-z0-9][a-z0-9-]*`), which is what the evaluator
+  matches. Anything else — `ci:waive:Flight` for tier `flight` — waives nothing, so the evidence read is
+  never even attempted for it and the summary reports **`INVALID WAIVER LABEL — it waives NOTHING`**, naming
+  the offending label and the fix. Previously such a label was reported through the `UNREADABLE`/`UNAVAILABLE`
+  diagnostics, which sent the reader to the workflow's `permissions:` block for what is a capitalisation
+  typo. An off-shape label applied beside a valid one is still named once, under the valid label's state.
 - **Labelling is cheap.** Subscribing to label events must not make every `ci:perf` / board-mirror /
   `needs-decision` label — or the waiver itself — restart a 30-minute gate. So a label mutation never
   cancels the in-flight run (cancellation is conditional on the event action; the shared concurrency group

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -100,6 +100,16 @@ carry).
   the full deadline, and if it reports a failure in that time it reds the gate. The waiver still applies at
   the deadline, so it delays a verdict rather than pre-empting one. To get the instant hatch back on the
   new head, **remove and re-apply the label** — the diagnostic says so.
+- **The waiver's EVIDENCE state is always on the record (issue #3033).** Both behaviours above depend on
+  reading this PR's `labeled` events, and a broken read used to look exactly like an ordinary PR: an empty
+  feed, one vague warning, a waiver that quietly waited for the deadline with nobody named. The job summary
+  now always states which of three things happened — `Waiver evidence: n/a` (no `ci:waive:` label present),
+  `READ OK — N labeled event(s)`, or **`UNREADABLE (broken read …)`** carrying the HTTP status (or the
+  command's exit status when there is none). `401`/`403`/`404` means the token may not read this PR's
+  events — check the workflow's `permissions:`; a `403` naming a rate limit or any `5xx` is transient; no
+  HTTP status means the client failed (`gh` absent, bad `--jq`) and a re-run will not help. An unreadable
+  read is **never** a failure of `required`: it withholds the early waiver and the attribution, and the
+  waiver is still honoured at the deadline.
 - **Labelling is cheap.** Subscribing to label events must not make every `ci:perf` / board-mirror /
   `needs-decision` label — or the waiver itself — restart a 30-minute gate. So a label mutation never
   cancels the in-flight run (cancellation is conditional on the event action; the shared concurrency group

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -104,16 +104,26 @@ carry).
   reading this PR's `labeled` events, and a broken read used to look exactly like an ordinary PR: an empty
   feed, one vague warning, a waiver that quietly waited for the deadline with nobody named. The job summary
   now always states what happened — `Waiver evidence: n/a` (no `ci:waive:` label present); `READ OK — feed
-  read (N labeled event(s)), M of them for a ci:waive: label`; the same `READ OK` with **`0 ci:waive:
-  labeled events`** (the read worked and carried nothing usable, so attribution stays `UNRESOLVED`); or
-  **`UNREADABLE (broken read …)`** carrying the HTTP status, or the command's exit status when there is
-  none. `401`/`403`/`404` means the token may not read this PR's events — check the workflow's
+  read (N labeled event(s)), M of them for a ci:waive: label in force`; the same `READ OK` with **`0 for a
+  waiver label in force now`** (the read worked and carried nothing usable, so attribution stays
+  `UNRESOLVED`); or **`UNREADABLE (broken read …)`** carrying the HTTP status, or the command's exit status
+  when there is none. `401`/`403`/`404` means the token may not read this PR's events — check the workflow's
   `permissions:`; a `403` naming a rate limit or any `5xx` is transient; no HTTP status means the client
-  failed (`gh` absent, bad `--jq`) and a re-run will not help. The counts are **feed total** and
-  **`ci:waive:` subset** precisely because the feed carries every label's events: a healthy read is
-  evidence that the read works, never that a waiver bound — binding is a per-tier verdict against that
-  head sha's first CI activity. An unreadable read is **never** a failure of `required`: it withholds the
-  early waiver and the attribution, and the waiver is still honoured at the deadline.
+  failed (`gh` absent, bad `--jq`) and a re-run will not help. The counts are **feed total**, the
+  **`ci:waive:` history** and the subset **in force** precisely because the feed carries every label's
+  events and `labeled` events are immutable: an event for a label since removed is history that can bind
+  nothing. A healthy read is evidence that the read works, never that a waiver bound — binding is a
+  per-tier verdict against that head sha's first CI activity. An unreadable read is **never** a failure of
+  `required`: it withholds the early waiver and the attribution, and the waiver is still honoured at the
+  deadline.
+- **The report never claims more than it observed (issue #3033 round 4).** The same defect recurred one
+  layer out: the summary asserted absence (`no ci:waive: label is present`) even when the LIVE label read
+  had failed and the labels in hand were the run-start payload — a confident false negative about a waiver
+  applied mid-run, which is what the polling window exists for. So the label read's trustworthiness is now
+  tracked and reported: a fallback to the payload reports **`UNKNOWN (label read UNTRUSTED)`** with the
+  failed-read count and status, and it makes the in-force count **UNKNOWN** rather than zero. A failed or
+  ambiguous read can only ever *withhold* a waiver, never grant one, and none of these states can change
+  `required`'s verdict — that comes from tier evaluation alone.
 - **Labelling is cheap.** Subscribing to label events must not make every `ci:perf` / board-mirror /
   `needs-decision` label — or the waiver itself — restart a 30-minute gate. So a label mutation never
   cancels the in-flight run (cancellation is conditional on the event action; the shared concurrency group

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -103,13 +103,17 @@ carry).
 - **The waiver's EVIDENCE state is always on the record (issue #3033).** Both behaviours above depend on
   reading this PR's `labeled` events, and a broken read used to look exactly like an ordinary PR: an empty
   feed, one vague warning, a waiver that quietly waited for the deadline with nobody named. The job summary
-  now always states which of three things happened — `Waiver evidence: n/a` (no `ci:waive:` label present),
-  `READ OK — N labeled event(s)`, or **`UNREADABLE (broken read …)`** carrying the HTTP status (or the
-  command's exit status when there is none). `401`/`403`/`404` means the token may not read this PR's
-  events — check the workflow's `permissions:`; a `403` naming a rate limit or any `5xx` is transient; no
-  HTTP status means the client failed (`gh` absent, bad `--jq`) and a re-run will not help. An unreadable
-  read is **never** a failure of `required`: it withholds the early waiver and the attribution, and the
-  waiver is still honoured at the deadline.
+  now always states what happened — `Waiver evidence: n/a` (no `ci:waive:` label present); `READ OK — feed
+  read (N labeled event(s)), M of them for a ci:waive: label`; the same `READ OK` with **`0 ci:waive:
+  labeled events`** (the read worked and carried nothing usable, so attribution stays `UNRESOLVED`); or
+  **`UNREADABLE (broken read …)`** carrying the HTTP status, or the command's exit status when there is
+  none. `401`/`403`/`404` means the token may not read this PR's events — check the workflow's
+  `permissions:`; a `403` naming a rate limit or any `5xx` is transient; no HTTP status means the client
+  failed (`gh` absent, bad `--jq`) and a re-run will not help. The counts are **feed total** and
+  **`ci:waive:` subset** precisely because the feed carries every label's events: a healthy read is
+  evidence that the read works, never that a waiver bound — binding is a per-tier verdict against that
+  head sha's first CI activity. An unreadable read is **never** a failure of `required`: it withholds the
+  early waiver and the attribution, and the waiver is still honoured at the deadline.
 - **Labelling is cheap.** Subscribing to label events must not make every `ci:perf` / board-mirror /
   `needs-decision` label — or the waiver itself — restart a 30-minute gate. So a label mutation never
   cancels the in-flight run (cancellation is conditional on the event action; the shared concurrency group


### PR DESCRIPTION
Fixes #3033 (re-scoped — see below).

## The filed premise was false; this PR does not act on it

#3033 asserted that `pr-gate.yml` lacking `issues: read` makes the `ci:waive:<tier-id>` evidence-binding 403 and go inert. **It does not.** GitHub's [per-permission endpoint reference](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28) lists `GET /repos/{owner}/{repo}/issues/{issue_number}/events` under **both** `Issues → read` **and** `Pull requests → read`, with installation-access-token support; the per-issue variant needs *at least one of* them. `pr-gate.yml` already grants `pull-requests: read`, and the aggregator always passes `github.event.pull_request.number` under the default `GITHUB_TOKEN`.

**This is run-proven, not merely doc-inferred.** Probe run [`30288793373`](https://github.com/pmcfadin/cqlite/actions/runs/30288793373) called the endpoint with `contents: read` + `pull-requests: read` and **no `issues` grant** (runner-logged token scopes: `Contents: read` / `Metadata: read` / `PullRequests: read`) and got **HTTP 200 with real attribution rows**.

**Honest caveat, recorded on the issue:** the `contents`-only contrast job in that same run *also* succeeded, because this repository is **public**. So the run proves that `pull-requests: read` is **sufficient**, not that it is the grant doing the carrying. Either way the conclusion for this repo holds and the direction of the filed fix is wrong.

`.github/workflows/pr-gate.yml` is therefore **untouched** by this PR. Adding `issues: read` would authorize nothing here and would slightly widen a fork-PR-reachable token (repo-wide read over all issue bodies/comments/timelines).

There was also no production evidence in either direction: no `ci:waive:*` label existed in the repo when this was filed, no PR has ever carried one, and `read_waiver_events` early-returns before touching the endpoint — so **the call has never executed in production.**

## What this PR actually fixes — the real defect

`read_waiver_events` swallowed *any* failure (403, 404, rate limit, `gh` absent, bad `--jq`) into one `::warning::` plus an empty file, **indistinguishable from "this PR has nothing to waive."** A broken read was invisible unless a human read the log of a waiver run. Worse, `gh api --jq` exits 0 when the filter matches nothing, so a successful-but-empty read looked identical too.

`WAIVER_EVIDENCE_STATE` is now one of `none | unconfigured | unreadable | read`, and **one line is emitted on every run** so healthy silence can no longer mask a broken read.

The governing rule, arrived at after the same over-claim recurred repeatedly across **nine review rounds** (see history): **report observations, never derived conclusions, and name what was NOT observed.** "No label present" is a conclusion; "no label was OBSERVED, and the read that would have seen one FAILED" is an observation. Each recurrence was the same mistake in a new place — the feed total, the label read, the immutable event history, then the label's shape — which is why the last fix changed the rule rather than the wording. The reported states, with their literal shapes:

No waiver label observed — three different epistemic situations, no longer one line:

```
Waiver evidence: n/a — no `ci:waive:<tier-id>` label is present on this pull request.

Waiver evidence: **UNKNOWN (label read UNTRUSTED)** — no `ci:waive:<tier-id>` label was OBSERVED, but the live label read FAILED (N failed read(s); <detail>) and this run fell back to the run-start event payload, so a waiver label applied since the run started would be invisible here. Absence is NOT claimed.

Waiver evidence: n/a — no `ci:waive:<tier-id>` label is in the run-start event payload, which is the only label set this run had (no live label source configured), so a label applied since the run started was never looked for.
```

A waiver label is in play and the event feed was read:

```
Waiver evidence: READ OK — feed read (N `labeled` event(s)), M of them for a `ci:waive:` label in force, so the evidence needed for attribution and head-binding was OBSERVED for that label. Whether a waiver actually resolves a tier — its event must be at or after this head sha's first CI activity, which this line does not observe — is decided per tier above.

Waiver evidence: READ OK — feed read (N `labeled` event(s)), H of them for a `ci:waive:` label, but **0 for a waiver label in force now**, so attribution and head-binding remain UNRESOLVED.

Waiver evidence: READ OK, in-force match **UNKNOWN** — the `labeled` events read (N event(s), H of them for a `ci:waive:` label), but <reason>, so this run did not observe which waiver labels are in force and cannot say whether any of those events is for one.
```

A `ci:waive:`-prefixed label is applied but is **not** a valid waiver label — the case that previously masqueraded as a permissions problem:

```
Waiver evidence: **INVALID WAIVER LABEL — it waives NOTHING** — the label(s) `ci:waive:Flight` are applied but are not waiver labels: a waiver label is `ci:waive:<tier-id>` with a LOWER-CASE tier id (`[a-z0-9][a-z0-9-]*`), which is the shape the registry evaluator matches, so it IGNORES these and no tier is waived by them. No `labeled` events were read: there is no waiver label to gather evidence for.
```

Its `::warning::` states explicitly that this is **NOT** "no waiver labels present" and **NOT** an authorization/API problem, names `ci:waive:Flight` for tier `flight` as the usual cause, and points at `.github/ci-gating-tiers.yml`. An off-shape label sitting *beside* a valid one gets its own note (`Also applied, and NOT a waiver label: …`) so it cannot hide behind the healthy one. The label name is user-controlled, so it is sanitised before it reaches a workflow command.

**The shape check is spelled out, not a range** — this is the subtlest bug in the change and it was *reproduced before it was fixed*:

```sh
case "$tier" in
  ''|[!abcdefghijklmnopqrstuvwxyz0123456789]*|*[!abcdefghijklmnopqrstuvwxyz0123456789-]*)
```

Under `shopt -u globasciiranges` with a UTF-8 locale, `case "BETA" in [!a-z0-9]*` does **not** match, because `a-z` is a collation range and upper-case letters interleave — so `ci:waive:BETA` was classified as *in force* and would have been reported as a live waiver. `shopt -s globasciiranges` was rejected as the fix because it is itself a bash-5.0+ knob that silently no-ops on bash 3.2, the exact host where the defect lives: it would have looked like a fix and not been one. Verified immune under `en_US.UTF-8` and `C.UTF-8` with the option off. A **second** occurrence was found by sweeping for the class — `--event-action`'s validator at `:187`, where collation would have made it *accept* upper case, laxer than the activity types it validates — and a suite assertion now sweeps the whole aggregator for single-case ranges, so a third cannot appear silently.

Because this defect cannot fail on the CI host (bash 5.2), it is covered three ways rather than trusted: **behaviourally**, by reading the class from source and evaluating it in a subshell with `globasciiranges` off under a UTF-8 locale — with the *pre-fix* class retained as the harness's own discriminating-power control, printing a `note:` if it fails to misclassify rather than banking a false pass; **structurally**, asserting the extracted class contains the spelled-out set and no `a-z`/`A-Z`; and by the **file-wide sweep**. Under the corresponding mutation all three fail while every pre-existing runtime off-shape test still passes.

The read failed, or there was nothing to read with:

```
Waiver evidence: **UNREADABLE (broken read — authorization, API or client failure)** — the `labeled` events for this pull request could not be read (<detail>); N failed read(s).

Waiver evidence: **UNAVAILABLE (no label-event source configured)** — the label set this run is using carries a `ci:waive:<tier-id>` label but this run was given no way to read the `labeled` events.
```

**Every claim is driven by two derived facts, not by per-site reasoning.** The recurrence pattern above was per-site drift: each line decided independently what it could assert, so a new line reintroduced an old mistake. The final round replaced that with `LABEL_SET_NOTE_SHORT` (the label set's provenance) and `ANY_READ_FAILED` (true if the label read **or** the event read failed), and made every denial conditional on them — so no denial is ever emitted blind. All **24 claim-bearing sites were enumerated with their dependencies: 12 changed, 12 verified correct as-is with recorded reasons.** The round-7 instance was fixed by *deleting* the claim "there was never a waiver label" rather than hedging it, and the "nothing failed / NOT an authorization problem" denial is now gated on `ANY_READ_FAILED`.

This is enforced rather than reviewed: a **self-contradiction detector** cross-checks `admits_read_failure` against five denial phrases across nine combined-state runs, so an unhedged future sibling fails the suite instead of waiting for a reviewer — **and the detector is itself proved non-vacuous by a positive/negative pair**, the lesson from round 3.

Every state additionally carries a **label-read provenance note** (`Label read UNTRUSTED: …` / `Label read: this run had no live label source …`), so the trustworthiness of the label set behind every claim above is stated rather than assumed.

The unreadable state splits the causes so the diagnosis is actionable: `401`/`403`/`404` → check the workflow's `permissions:` block; a rate-limit `403` or any `5xx` → transient, re-run; **no HTTP status at all** → the client itself failed (`gh` unavailable, bad `--jq`), which a re-run will not fix. When no HTTP status is reported it surfaces the command's **exit status** instead (`exit status 127, no HTTP status reported — bash: gh: command not found`), sanitised for a workflow command (control chars stripped, `::` defanged, 200-char cap, and a stderr that sanitises to nothing degrades to `(unprintable error output)` rather than a dangling em dash).

**Counted three ways, because two of them are wrong on their own.** `gating_registry.rb#parse_waiver_events` only keys on `ci:waive:*`, so a feed full of `needs-decision` labelling events is not waiver evidence — hence the feed total and the `ci:waive:`-anchored subset are reported separately (anchored `^ci:waive:`, so an actor login cannot inflate the count). But `labeled` events are **immutable history**: a `ci:waive:alpha` applied and removed weeks ago sits in that feed forever. So the number that actually matters is the subset intersected with the waiver labels **in force now**, and that is what the `READ OK` line reports; the stale-history case gets an explicit `IMMUTABLE HISTORY` note. When the label set itself is untrusted, the in-force count is reported as **UNKNOWN** rather than as `0` — an unknown is not an absence.

**Graceful degradation is preserved exactly.** The verdict is untouched in every state — exit 0/1 comes only from tier evaluation. A 403 still exits 0, still emits `WAIVED`, still reports `applier UNRESOLVED`, and the waiver is still honoured at the aggregation deadline. Fails stricter, never green-when-unproven, and cannot wedge `main`.

## Tests

`scripts/tests/test_aggregate_required_tiers.sh` — **170 assertions PASS, 0 FAIL** (was 107), registered in the `tooling-tests` gate component (`scripts/agent-gate.sh`), so the gate runs it. Covers: every state above reported and **pairwise distinct** as summary lines (the discriminator is the difference, not one substring); label-read trust tracking and the untrusted→`UNKNOWN` mapping; the feed-total / `ci:waive:`-subset / in-force-intersection split and the stale-history case; HTTP status surfaced; transient-vs-authorization separated; a client failure (exit 127, no HTTP status), a silent `false`, and stderr that sanitises to nothing each legible; `unconfigured` never mislabelled as an API failure; and the graceful path — a 403 fixture still exits 0 / `WAIVED` / `UNRESOLVED` with no harness failure. Non-vacuity still holds mechanically: the real aggregator fails all discriminating states, an always-exit-0 stub fails none.

**Every guard is mutation-checked**, a discipline adopted after review round 3 caught a guard that had quietly become vacuous (below). Removing trust tracking → 7 FAILs including "the summary claimed an absence it never observed"; reverting the in-force count to raw history → the round-4 Medium reappears; replacing the shape-checked gate with the old substring test → the round-5 Medium reappears; disabling the untrusted→`UNKNOWN` mapping, deleting the provenance note, counting every feed line, and removing the blank-line guard each FAIL; and removing `|| rc=$?` from the label `eval` → FAILs including "a failed label read granted a waiver or hid the red". An `awk` implementation was **deleted** during this work precisely because it created a branch no hermetic fixture could reach.

**Two mutations initially SURVIVED across the last two rounds, and both are recorded here deliberately.** Deleting the HTTP-status extraction did **not** fail the suite — the 403 assertion was weak enough to pass without it; it was strengthened to require the classified shape (`(HTTP 403 —` present *and* `no HTTP status reported` absent) and now fails. In the final 25-mutation sweep one anchor mutation was reported SURVIVED because the mutation itself was a semantic no-op; rewritten as a faithful revert, it fails. Both were self-reported rather than quietly dropped, which is the only reason they are known.

A guard that cannot fail is worth less than no guard, because it also reports success — the vacuous-guard defect in round 3 was exactly that, found by review instead of by the suite. This is why counts here are quoted as *observed* failures rather than as "mutation-tested". The final tally is **34 mutations, zero survivors** (nine new, plus all 25 prior ones re-run). The standout is a real `[a-z]` range hidden inside a string literal behind an `echo`: it proves the round-7 scan fix, because the previous scan dropped that entire line and would have missed it.

This round also **removed two external commands** (`grep -c` ×2, with their `|| true` hazards) in favour of one pure-shell pass, shrinking the `set -euo pipefail` surface that produced a blocker in round 3.

Fail-safe direction is pinned, not asserted: an untrusted label read with no waiver in the payload still reds the absent tier and exits 1. Fixtures use `ci:waive:alpha/beta/BETA` and never the real `ci:waive:flight`.

Also clean: `test_classify_docs_only.sh` 26/0, `test_gating_workflow_semantics.sh` 26/0, `test_gating_registry_policy.sh` 74/0, `validate-workflows.rb`, `check-workflow-injection.sh`, `check-no-wallclock-asserts.sh`.

**What these tests cannot prove:** every case injects `--waiver-events-cmd`, so they pin the state machine and nothing about production. No fixture can show the real `gh api` call succeeds with the token `pr-gate` hands the aggregator.

## This PR cannot self-verify — by construction

For a same-repo `pull_request` GitHub takes the *workflow definition* from the head, but `required` deliberately checks out and runs the **base ref's** `scripts/ci/aggregate-required-tiers.sh` (the #2910 trust boundary). So this new state machine only takes effect on PRs opened **after** this merges, and verification is a post-merge exercise.

**This generalises: any future fix to the waiver mechanism is unverifiable on its own PR.** That is a structural property of the trust boundary worth knowing before the next one.

## Review history

- **roborev round 1** — 1 Medium + 3 Lows, **all fixed in round 2.** The Medium: the `READ OK` line counted the whole `labeled` feed (`grep -c ''`) while the registry only keys on `ci:waive:*`, so it could announce that a waiver was bindable when zero waiver events existed.
- **roborev round 3** — 1 Medium + 4 Lows; **both blockers fixed** in `f9cb57e`:
  - *Medium (vacuous guard).* The over-claim guard asserted `! contains "can be bound"` — a string round 2's reword left in no code path, so it passed **unconditionally** and would have accepted "the waiver **is** bound to this head sha", the exact claim it exists to forbid. It now anchors positively on the hedge the implementation must emit (`decided per tier above`) plus negatives, and was **mutation-checked**: reintroducing the over-claim makes the guard FAIL.
  - *Low, triaged up to blocker (run-ending hazard).* `waiver_error_detail`'s sanitising substitution lacked the `|| true` its sibling line has. Under `set -euo pipefail` a non-zero `tr`/`sed`/`cut` there aborts the whole aggregator with no summary and a non-zero exit — converting UNREADABLE evidence, which must **never** move the verdict, into a **RED `required`**. Reachable: BSD `tr`/`sed` exit 1 on non-UTF-8 stderr under a UTF-8 locale, and macOS is a first-class host for these scripts. This contradicted the change's own stated invariant, so it was fixed rather than deferred.
  - Remaining Lows batched to a linked follow-up (two of them are the deliberately-accepted annotation-noise judgement calls: the per-poll `UNREADABLE` warning and the summary-only zero-subset state — the per-tier `applier UNRESOLVED` warning already fires, and a per-poll annotation for a mid-run-resolvable condition is noise).
- **roborev round 4** — 2 Mediums + 4 Lows. **Both Mediums fixed** in `f40c0ab`, and this is the round that changed the approach: the over-claim family had now recurred **three times**, so rather than patch the wording a third time the fix went to the root rule — *report observations, never derived conclusions, and name what was NOT observed.*
  - *Medium: the `none` line asserted an absence it never observed.* `read_labels` falls back to the run-start event payload on a failed live read. Since the polling loop exists **specifically** so a waiver applied mid-run takes effect, that is the primary scenario — and there the new line flatly claimed "no `ci:waive:` label is present" when one did. Label-read trustworthiness is now tracked durably (`LABELS_READ_STATE`, failure count, last error) and surfaced.
  - *Medium: the waiver-event count was not intersected with the labels in force* (round 3's Low, re-raised after the round-2 fix) — `labeled` events are immutable history, so a since-removed waiver's event kept the claim alive. Now intersected, with `UNKNOWN` rather than `0` when the label set is untrusted.
  - Also fixed: the `read` line now states explicitly that it does **not** observe the `timestamp >= head_anchor` condition, and `docs/ci/ci-tier-policy.md` gained the break-glass bullet naming the states (doctrine requires the doc update in the same change).
- **roborev round 5** — 1 Medium + 2 Lows. **The Medium was a fourth recurrence of the over-claim family and was fixed** in `bfb1e85`: the "a waiver label is present, read its evidence" decision was still a raw substring test on the label set, while the evaluator and the new in-force set both require the shape `ci:waive:[a-z0-9][a-z0-9-]*`. A realistic typo (`ci:waive:Flight`) therefore entered the waiver path and made the `unreadable`/`unconfigured` lines assert that a waiver label was present — sending an operator to the workflow's `permissions:` block while the real defect, a mistyped label that waives nothing, was never named. The irony was load-bearing: that is the same wrong conclusion the filed issue drew. The gate is now the shape-checked in-force set with no substring fallback, and the case has its own **INVALID WAIVER LABEL** state (above). Round 5's test-coverage Low was folded in: the live-read + in-force-match production happy path is now asserted at the summary-line level, not just via exit status.
- **roborev round 6** — 1 Medium + 3 Lows, **all fixed** in `de9c626`. The Medium was the collation-dependent shape check described above: a real, reproduced misclassification of `ci:waive:BETA` as an in-force waiver on bash below 5.0. Its fix also turned up a second case-sensitive range in the file and produced the file-wide sweep that mechanizes the class.
- **roborev round 7** — the last blocker: one more site asserting more than it observed. Fixed by **deleting** the claim rather than hedging it, which is also what motivated the structural sweep instead of a ninth patch.
- **roborev round 8 (structural sweep)** — the 24-site enumeration, the two derived facts, the self-contradiction detector, and the 34-mutation re-run described above. The annotation-noise Low is deliberately **half**-done: the label-read annotation is now deduped on its condensed detail (so a *different* failure still annotates — tested both ways), while the `UNREADABLE` annotation stays per-poll, which is a deliberate accepted decision rather than an oversight.
- **roborev round 9 (final)** — **no Medium or High: three Lows, none verdict-affecting**, all filed as follow-ups rather than fixed here (the structural sweep was the agreed last fix round). For the record, since a future reader deserves to know what is known-open: (a) the `unconfigured` lane can reach a closing line that says no valid waiver label was observed at any point, contradicting an earlier `UNAVAILABLE` on the same run — the claim-precision class again, in the one lane the sweep's fixtures did not combine; (b) a label name containing a backtick can terminate the markdown code span in `$GITHUB_STEP_SUMMARY` — the workflow-command vector is closed, this one is markdown-only, cannot change the verdict, and needs label-management rights to reach; (c) the collation sweep strips comments before string literals, so a `#` inside a quoted string truncates the line and the guard could stop seeing a reintroduced range — a one-line `sed` reordering, and the most worth doing of the three because it is guard vacuity, the failure mode this PR already paid for twice.

**Nine rounds, blockers in six of them.** That is the honest headline. The cost was concentrated in one recurring mistake — a diagnostic asserting more than the run observed — which reappeared in four different places (the feed total, the label read, immutable event history, the label's shape) before the fix moved from wording to structure. The two named mechanisms that finally ended it, the derived facts and the self-contradiction detector, are the transferable result.

## Gate of record

The ONE full `agent-gate.sh` run of record, at the shipping tip `a469180` (post-rebase onto `origin/main` `dd4e2bd`), clean tree, `tree-integrity: PASS`. **`tooling-tests` — the component that runs this PR's suite — PASSed specifically.**

```
==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.xndPeU
commit: a469180 branch: issue-3033-waiver-issues-read dirty: no
datasets: 144 Data.db files under /home/ubuntu/workspace/repo/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=absent
cpu-budget: wrapper=nice ncpu=16 max-concurrency=1 cores-per-gate=16 build-jobs=16(derived) test-threads=16
tree-start: a469180c3bde dirty: no digest: 19cbf73e7de5
tree-end: a469180c3bde dirty: no digest: 19cbf73e7de5
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (5s)
clippy:            PASS (2s)
roborev-lints:     PASS (1s)
core-tests:        PASS (40s)
tombstones-scan:   PASS (1s)
scan-offload-guard: PASS (86s)
work-counters-guard: PASS (87s)
byte-budget-guard: PASS (13s)
arrow-parity-guard: PASS (63s)
memory-budget:     PASS (12s)
integration-tests: PASS (54s)
format-compat:     PASS (37s)
write-tests:       PASS (130s)
cli-tests:         PASS (164s)
compaction-byte-parity: PASS (10s)
query-semantics-oracle: PASS (0s)
flight-query-semantics-oracle: PASS (71s)
python-bindings:   PASS (95s)
node-bindings:     PASS (116s)
delivery-telemetry: PASS (0s)
oom-audit:         PASS (5s)
parity-report:     PASS (1s)
operator-metrics-doc: PASS (25s)
kit-dashboard-drift: PASS (1s)
binding-unwind-profile: PASS (0s)
tooling-tests:     PASS (313s)
minimal-build:     PASS (52s)
smoke:             PASS (3s)
logs: /tmp/agent-gate.xndPeU
summary-file: /tmp/gate-3033-full.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```


## Related findings (not fixed here)

- `cassandra-parity.yml` and `flight-image.yml` declare **no `permissions:` block at all** while using `GH_TOKEN: ${{ github.token }}` (both are `MISSING_PERMISSION_EXEMPTIONS` in `validate-workflows.rb`). Same class as #3033 — declared permissions vs endpoints actually called — but the direction is "undeclared, possibly over-broad," not a missing grant.
- **The durable fix is to delete the shell mirror.** This report is a shell reimplementation of facts `gating_registry.rb` already owns, including the tier-id shape regex — and that duplication is the direct cause of **two** of this PR's blockers: the substring gate (round 5) and the collation bug (round 6). The reporting block does not need restructuring to be *correct* now (the two derived facts plus the detector close the drift), but the right long-term shape is a fact-tuple → sentence table, or better, moving the report into the registry that already holds every fact. That is a real refactor with its own risk and belongs in a follow-up issue, not in a merge-now round.
- The waiver path has still **never executed in production.** A first-ever live exercise (the `ci:waive:flight` label now exists) is an owner-run post-merge step.

Routing: oracle-driven — no OpenSpec change.
