### PR TITLE
perf(#3027): row-decode CPU attribution + the row-conversion instrument (#2901 blocker)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -309,6 +309,18 @@ name = "decode"
 path = "benches/decode_bench.rs"
 harness = false
 
+# Row-conversion (row-build) CPU instrument (issue #3027; unblocks #2901). Two
+# groups over N ∈ {8,16,32,64} columns: `row_build/columns_<N>` drives the REAL
+# public `build_row_from_scan_cached` over 2,000 synthetic partition-grouped rows
+# with one shared PartitionKeyCache, and `row_build/hashonly_<N>` isolates the
+# HashMap-construction + SipHash term. Fully synthetic (no dataset fixture), needs
+# only the default `state_machine` feature. NOT a perf-gate entry — an instrument
+# whose absolute rows/sec is machine-dependent.
+[[bench]]
+name = "row_build"
+path = "benches/row_build_bench.rs"
+harness = false
+
 [[bench]]
 name = "write"
 harness = false

--- a/cqlite-core/benches/row_build_bench.rs
+++ b/cqlite-core/benches/row_build_bench.rs
@@ -1,0 +1,632 @@
+//! Row-conversion (row-build) CPU micro-benchmarks (issue #3027; the missing
+//! instrument that blocked issue #2901).
+//!
+//! # Why this target exists
+//!
+//! Issue #2901 was blocked because **#1883 ran no row-conversion benchmark**, so
+//! the projected ~1.04x speedup of a `HashMap`-construction change stayed a
+//! projection: nothing in the tree measured
+//! [`build_row_from_scan_cached`][bs] — the per-row `(RowKey, ScanRow) →
+//! `QueryRow`` conversion every scan pays once per emitted row. The existing
+//! `read/*` and `decode/*` benches measure the layers *below* it (open → seek →
+//! chunk decompress → cell decode); a row-conversion regression hides inside
+//! their I/O. This target isolates the conversion itself.
+//!
+//! [bs]: cqlite_core::query::build_row_from_scan_cached
+//!
+//! # What is measured
+//!
+//! Two criterion groups, both parameterized over the column count `N ∈ {8, 16,
+//! 32, 64}` and both reporting **rows/sec** via `Throughput::Elements(2_000)`:
+//!
+//! - **`row_build/columns_<N>`** — the REAL public function
+//!   `build_row_from_scan_cached(key, row, &[] /* SELECT * */, Some(&schema),
+//!   &mut pk_cache)`, driven over 2,000 prepared rows through ONE shared
+//!   [`PartitionKeyCache`], exactly as the scan loop calls it. This is the whole
+//!   per-row cost: map pre-size, `Arc<str>` name moves, `Value::into_owned()`
+//!   retention copies, and the memoized partition-key reconstruct.
+//! - **`row_build/hashonly_<N>`** — the SAME prepared names/values, but the timed
+//!   routine does ONLY `HashMap::with_capacity(n)` + `n` inserts. No partition-key
+//!   reconstruct, no `into_owned()`, no projection closure. This isolates the
+//!   *map construction + SipHash* term, which is the precise number #2901 needs:
+//!   `columns_<N> − hashonly_<N>` is everything else in the conversion.
+//!
+//! The bench is **NOT** a `benches/perf-gate.json` entry: it is an instrument, and
+//! its absolute rows/sec is machine-dependent. Its value is the ratio between the
+//! two groups (and between column counts) on ONE machine, in ONE run.
+//!
+//! # Fidelity of the synthetic input
+//!
+//! No dataset fixture is used — the input is fully synthetic so the measurement is
+//! independent of any corpus (and so it runs without `CQLITE_DATASETS_ROOT`). The
+//! synthesis deliberately reproduces the shape the V5 decoder hands to the
+//! conversion:
+//!
+//! - **Column names** are realistic Cassandra-style identifiers 16–19 chars long
+//!   (`col_metric_value_07`, `col_session_uuid_12`, …), interned ONCE into shared
+//!   `Arc<str>` handles — name LENGTH is what SipHash consumes, so `a`/`b`/`c`
+//!   would understate the map term.
+//! - **Values** cycle through a realistic mix — `text` (24 B), `int`, `bigint`,
+//!   `uuid`, `timestamp`, `double`, `boolean` (~9.9 B of payload per column, i.e.
+//!   ~79 B/row at N=8 up to ~631 B/row at N=64; the exact per-row average is
+//!   printed at setup).
+//! - **Text payloads are slices of ONE shared backing `Bytes`**, mimicking a
+//!   decompressed chunk. That matters: `Value::into_owned()` (the #1644 D2
+//!   retention boundary inside the conversion) copies a shared payload, so a
+//!   privately-allocated text value would measure a cheaper path than production.
+//! - **Rows are partition-grouped, 10 rows per partition** (200 partitions over
+//!   the 2,000 rows), so the `PartitionKeyCache` sees the production-realistic
+//!   9-hits-per-miss ratio rather than an all-hit or all-miss extreme.
+//!
+//! # What is and is not inside the timed region
+//!
+//! **Input construction is OUTSIDE.** `build_row_from_scan_cached` CONSUMES its
+//! `ScanRow`, so each measured iteration needs fresh inputs; they are rebuilt by
+//! `iter_batched`'s **untimed setup** closure (`BatchSize::LargeInput`). No input
+//! clone is ever measured.
+//!
+//! **Each produced row is consumed and dropped INSIDE, one at a time.** The
+//! routine accumulates a cheap `values.len()` checksum and lets each `QueryRow`
+//! drop before building the next, so the live working set is one row — a streamed
+//! scan's lifetime. The obvious alternative (push all 2,000 outputs into a `Vec`
+//! so their drops fall outside the timer) was measured and REJECTED: retaining the
+//! batch makes the timed region touch ~14 MB of fresh map memory at N=64, and that
+//! memory-bandwidth cliff swamps the CPU term this instrument exists to isolate.
+//! Measured on the same machine, retaining the batch cost 2 790 ns/row for
+//! `hashonly_64` vs 1 869 ns/row when dropping per row (+49%), and broke the
+//! linear scaling — it read out as "map construction = 98% of the conversion at
+//! N=64", an artifact, where the per-row-drop design reads a stable ~72–80% across
+//! all four column counts. The trade is that map DEALLOCATION is now inside the
+//! measurement; that is real per-row work the conversion's caller pays either way,
+//! and both groups pay it identically, so the `columns_<N> − hashonly_<N>` delta
+//! stays clean.
+//!
+//! **Wiring guard over the WHOLE pass.** The checksum both routines return must
+//! equal `2_000 × (N + 1)`, asserted once per bench id, so a pass that dropped or
+//! short-built rows fails loudly instead of measuring less work than advertised.
+//!
+//! # Determinism
+//!
+//! Every name, value, and key is a pure function of `(row_index, column_index)` —
+//! no wall-clock input, no RNG (seeded or otherwise), so the workload is
+//! byte-identical on every run and machine. There are no wall-clock threshold
+//! asserts anywhere; the only `Instant` use is the best-effort ledger pass, which
+//! RECORDS a number and never asserts on one.
+//!
+//! # Gating
+//!
+//! Needs only `state_machine` (the feature that gates `cqlite_core::query`, where
+//! `build_row_from_scan_cached` + `PartitionKeyCache` are re-exported) — it is a
+//! default feature. `fixtures/mod.rs` is deliberately NOT included: this target
+//! opens no SSTable and needs no RNG, so including it would only add compile
+//! cost. Without `state_machine` the target compiles to an empty-but-valid
+//! criterion main (mirrors `read.rs` / `decode_bench.rs`).
+//!
+//! Reproduce:
+//! ```text
+//! cargo bench -p cqlite-core --bench row_build
+//! ```
+
+use criterion::{criterion_group, criterion_main};
+
+#[path = "bench_ledger/mod.rs"]
+mod bench_ledger;
+
+#[path = "profiling/mod.rs"]
+mod profiling;
+
+// ---------------------------------------------------------------------------
+// Real benches (need `state_machine` for cqlite_core::query)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "state_machine")]
+mod row_build_impl {
+    use super::bench_ledger;
+    use bytes::Bytes;
+    use cqlite_core::query::{build_row_from_scan_cached, PartitionKeyCache, QueryRow};
+    use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+    use cqlite_core::types::{RowKey, ScanRow, Value};
+    use criterion::{black_box, BatchSize, Criterion, Throughput};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// The map type the `hashonly_<N>` group constructs. It MUST be the same type
+    /// `QueryRow::values` is — see [`hashonly_map_type_is_pinned_to_query_row`].
+    type ValuesMap = HashMap<Arc<str>, Value>;
+
+    /// **Compile-time pin (issue #3027).** `hashonly_<N>` is only interpretable if
+    /// it builds the SAME map type — and therefore runs the SAME hasher — as the
+    /// real conversion: if `QueryRow::values` switched hasher (e.g. SipHash →
+    /// FxHash) while [`ValuesMap`] did not, the two groups would hash differently
+    /// and `columns_<N> − hashonly_<N>` would be meaningless while still producing
+    /// confident-looking numbers.
+    ///
+    /// This function does nothing at runtime; it exists so that such a change
+    /// BREAKS THE BUILD here (a loud, actionable compile error) instead of
+    /// silently invalidating the instrument. If it fails to compile, update
+    /// [`ValuesMap`] to `QueryRow::values`' new type — do not delete this pin.
+    #[allow(dead_code)]
+    fn hashonly_map_type_is_pinned_to_query_row(row: QueryRow) -> ValuesMap {
+        row.values
+    }
+
+    /// Rows converted per measured iteration (the `Throughput::Elements` unit, so
+    /// criterion reports rows/sec directly).
+    const ROWS: usize = 2_000;
+
+    /// Rows per partition — 10 gives the shared [`PartitionKeyCache`] the
+    /// realistic 9 hits per miss (200 distinct partitions across [`ROWS`]).
+    const ROWS_PER_PARTITION: usize = 10;
+
+    /// Regular-column counts benched (the `_<N>` suffix of each bench id).
+    const COLUMN_COUNTS: [usize; 4] = [8, 16, 32, 64];
+
+    /// Byte length of every synthesized `text` payload.
+    const TEXT_LEN: usize = 24;
+
+    /// The single TEXT partition-key column. Single-component ⇒ the raw row key
+    /// bytes ARE the value (no length prefix), which is the common Cassandra
+    /// shape and the one `decode_partition_key_columns` handles on the hot path.
+    const PK_COLUMN: &str = "pk_device_id";
+
+    /// The repeating value mix applied across a row's columns (`col_index % 7`).
+    #[derive(Clone, Copy)]
+    enum Kind {
+        Text,
+        Int,
+        BigInt,
+        Uuid,
+        Timestamp,
+        Double,
+        Boolean,
+    }
+
+    const KINDS: [Kind; 7] = [
+        Kind::Text,
+        Kind::Int,
+        Kind::BigInt,
+        Kind::Uuid,
+        Kind::Timestamp,
+        Kind::Double,
+        Kind::Boolean,
+    ];
+
+    impl Kind {
+        /// The CQL type string recorded in the schema for this kind.
+        fn cql_type(self) -> &'static str {
+            match self {
+                Kind::Text => "text",
+                Kind::Int => "int",
+                Kind::BigInt => "bigint",
+                Kind::Uuid => "uuid",
+                Kind::Timestamp => "timestamp",
+                Kind::Double => "double",
+                Kind::Boolean => "boolean",
+            }
+        }
+
+        /// On-wire payload width, used only to report the per-row average.
+        fn payload_bytes(self) -> usize {
+            match self {
+                Kind::Text => TEXT_LEN,
+                Kind::Int => 4,
+                Kind::BigInt => 8,
+                Kind::Uuid => 16,
+                Kind::Timestamp => 8,
+                Kind::Double => 8,
+                Kind::Boolean => 1,
+            }
+        }
+
+        /// A realistic Cassandra-style column name (16–19 chars) for position `i`.
+        fn column_name(self, i: usize) -> String {
+            match self {
+                Kind::Text => format!("col_label_text_{i:02}"),
+                Kind::Int => format!("col_metric_count_{i:02}"),
+                Kind::BigInt => format!("col_event_seqno_{i:02}"),
+                Kind::Uuid => format!("col_session_uuid_{i:02}"),
+                Kind::Timestamp => format!("col_updated_at_{i:02}"),
+                Kind::Double => format!("col_metric_value_{i:02}"),
+                Kind::Boolean => format!("col_is_active_{i:02}"),
+            }
+        }
+    }
+
+    /// The kind at column position `i`.
+    fn kind_at(i: usize) -> Kind {
+        KINDS[i % KINDS.len()]
+    }
+
+    /// A `TEXT_LEN`-byte deterministic text payload for `(row, col)`.
+    fn text_payload(row: usize, col: usize) -> String {
+        format!("row{row:06}-col{col:02}-textvabc")
+    }
+
+    /// The raw partition-key bytes for partition `p` (a realistic device id).
+    fn partition_key_bytes(p: usize) -> Vec<u8> {
+        format!("device-{p:06}-region-west").into_bytes()
+    }
+
+    /// A prepared, fully synthetic workload for one column count.
+    struct Prepared {
+        columns: usize,
+        schema: TableSchema,
+        /// The conversion inputs, partition-grouped.
+        rows: Vec<(RowKey, ScanRow)>,
+        /// The same cells PLUS a pre-built partition-key entry, as flat
+        /// `(name, value)` pairs — the input to the `hashonly_<N>` group.
+        hash_rows: Vec<Vec<(Arc<str>, Value)>>,
+        /// Mean cell payload bytes per row (documentary; printed at setup).
+        avg_payload_bytes: usize,
+    }
+
+    /// Build the schema: 1 TEXT partition key + `columns` regular columns.
+    fn build_schema(columns: usize) -> TableSchema {
+        TableSchema {
+            keyspace: "bench_ks".to_string(),
+            table: "row_build".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: PK_COLUMN.to_string(),
+                data_type: "text".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: (0..columns)
+                .map(|i| {
+                    let kind = kind_at(i);
+                    Column {
+                        name: kind.column_name(i),
+                        data_type: kind.cql_type().to_string(),
+                        nullable: true,
+                        default: None,
+                        is_static: false,
+                    }
+                })
+                .collect(),
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// Synthesize the whole workload for one column count.
+    ///
+    /// Text payloads are carved out of ONE shared backing `Bytes` (a stand-in for
+    /// a decompressed chunk) so the conversion's `Value::into_owned()` takes the
+    /// production copy path rather than the cheap already-tight path.
+    fn prepare(columns: usize) -> Prepared {
+        let schema = build_schema(columns);
+
+        // Intern each column name ONCE, exactly as the V5 decoder does.
+        let names: Vec<Arc<str>> = (0..columns)
+            .map(|i| Arc::<str>::from(kind_at(i).column_name(i).as_str()))
+            .collect();
+        let pk_name: Arc<str> = Arc::<str>::from(PK_COLUMN);
+
+        // One shared backing buffer holding every text payload back-to-back.
+        let text_cols: Vec<usize> = (0..columns)
+            .filter(|i| matches!(kind_at(*i), Kind::Text))
+            .collect();
+        let mut backing = Vec::with_capacity(ROWS * text_cols.len() * TEXT_LEN);
+        for row in 0..ROWS {
+            for col in &text_cols {
+                let s = text_payload(row, *col);
+                assert_eq!(
+                    s.len(),
+                    TEXT_LEN,
+                    "row_build: synthesized text payload must be exactly {TEXT_LEN} bytes \
+                     (got {} for row {row} col {col}) — the payload-size accounting and the \
+                     into_owned() copy path both depend on it",
+                    s.len()
+                );
+                backing.extend_from_slice(s.as_bytes());
+            }
+        }
+        let backing = Bytes::from(backing);
+
+        let mut rows = Vec::with_capacity(ROWS);
+        let mut hash_rows = Vec::with_capacity(ROWS);
+        let mut text_slot = 0usize;
+        for row in 0..ROWS {
+            let partition = row / ROWS_PER_PARTITION;
+            let key = RowKey::new(partition_key_bytes(partition));
+            let mut cells: Vec<(Arc<str>, Value)> = Vec::with_capacity(columns);
+            for (col, name) in names.iter().enumerate() {
+                let value = match kind_at(col) {
+                    Kind::Text => {
+                        let start = text_slot * TEXT_LEN;
+                        text_slot += 1;
+                        // A slice of the shared chunk: `into_owned()` must copy it.
+                        Value::Text(backing.slice(start..start + TEXT_LEN))
+                    }
+                    Kind::Int => Value::Integer((row * 31 + col) as i32),
+                    Kind::BigInt => Value::BigInt((row as i64) * 1_000_003 + col as i64),
+                    Kind::Uuid => {
+                        let mut b = [0u8; 16];
+                        for (j, slot) in b.iter_mut().enumerate() {
+                            *slot = ((row + col * 7 + j) % 251) as u8;
+                        }
+                        Value::Uuid(b)
+                    }
+                    Kind::Timestamp => {
+                        Value::Timestamp(1_700_000_000_000 + (row as i64) * 1_000 + col as i64)
+                    }
+                    Kind::Double => Value::Float((row as f64) + (col as f64) / 64.0),
+                    Kind::Boolean => Value::Boolean((row + col) % 2 == 0),
+                };
+                cells.push((Arc::clone(name), value));
+            }
+
+            // `hashonly` input: the same interned names + values, plus the
+            // partition-key entry PRE-BUILT (no reconstruct from the raw key), so
+            // its map ends up with the same N+1 entries and the same capacity hint
+            // as the real conversion's — isolating map construction + SipHash.
+            let mut flat = cells.clone();
+            flat.push((
+                Arc::clone(&pk_name),
+                Value::text(String::from_utf8_lossy(&partition_key_bytes(partition))),
+            ));
+            hash_rows.push(flat);
+
+            rows.push((key, ScanRow::Row(cells)));
+        }
+
+        let avg_payload_bytes = (0..columns).map(|i| kind_at(i).payload_bytes()).sum();
+
+        Prepared {
+            columns,
+            schema,
+            rows,
+            hash_rows,
+            avg_payload_bytes,
+        }
+    }
+
+    /// Setup guard: the REAL conversion must produce a non-empty `QueryRow` with
+    /// exactly `columns + 1` values (the N regular cells plus the reconstructed
+    /// partition-key column), and that PK column must actually be present. A
+    /// silently-empty or PK-less row would mean the bench measures a no-op.
+    fn assert_conversion_is_real(p: &Prepared) {
+        let (key, row) = p
+            .rows
+            .first()
+            .unwrap_or_else(|| panic!("row_build/columns_{}: no prepared rows", p.columns));
+        let mut cache = PartitionKeyCache::default();
+        let built =
+            build_row_from_scan_cached(key.clone(), row.clone(), &[], Some(&p.schema), &mut cache)
+                .unwrap_or_else(|| {
+                    panic!(
+                "row_build/columns_{}: build_row_from_scan_cached returned None for a LIVE \
+                 ScanRow::Row — the bench would measure a suppressed (tombstone) path",
+                p.columns
+            )
+                });
+        assert!(
+            !built.values.is_empty(),
+            "row_build/columns_{}: converted row has zero values — measuring a no-op",
+            p.columns
+        );
+        assert_eq!(
+            built.values.len(),
+            p.columns + 1,
+            "row_build/columns_{}: expected {} values ({} regular cells + 1 reconstructed \
+             partition-key column), got {} — the synthesized cells or the schema's \
+             partition key disagree with the conversion",
+            p.columns,
+            p.columns + 1,
+            p.columns,
+            built.values.len()
+        );
+        assert_eq!(
+            built.values.get(PK_COLUMN),
+            Some(&Value::text("device-000000-region-west".to_string())),
+            "row_build/columns_{}: partition-key column `{PK_COLUMN}` was not reconstructed \
+             from the raw row key — the measured path is missing the PK decode",
+            p.columns
+        );
+    }
+
+    /// Setup guard for the map-only group: the isolated routine must build a map
+    /// with the same `columns + 1` entries the real conversion produces.
+    fn assert_hashonly_is_real(p: &Prepared) {
+        let first = p
+            .hash_rows
+            .first()
+            .unwrap_or_else(|| panic!("row_build/hashonly_{}: no prepared rows", p.columns));
+        let mut map: ValuesMap = ValuesMap::with_capacity(first.len());
+        for (name, value) in first.iter() {
+            map.insert(Arc::clone(name), value.clone());
+        }
+        assert_eq!(
+            map.len(),
+            p.columns + 1,
+            "row_build/hashonly_{}: map holds {} entries, expected {} — duplicate column \
+             names would make this measure fewer inserts than the real conversion",
+            p.columns,
+            map.len(),
+            p.columns + 1
+        );
+    }
+
+    /// Convert every prepared row through the REAL public function with ONE
+    /// shared cache, consuming and dropping each `QueryRow` before the next (see
+    /// the module doc: a streamed row lifetime, NOT a retained 2,000-row batch).
+    ///
+    /// Returns the summed value count across the pass — a cheap checksum that
+    /// (a) keeps the optimizer from eliding the conversion and (b) lets the caller
+    /// assert EVERY row produced `columns + 1` values, not just the sampled one.
+    fn convert_all(
+        batch: Vec<(RowKey, ScanRow)>,
+        schema: &TableSchema,
+        cache: &mut PartitionKeyCache,
+    ) -> usize {
+        let mut values_seen = 0usize;
+        for (key, row) in batch {
+            if let Some(built) = build_row_from_scan_cached(key, row, &[], Some(schema), cache) {
+                let built = black_box(built);
+                values_seen += built.values.len();
+                // `built` drops here — one row's worth of live memory at a time.
+            }
+        }
+        values_seen
+    }
+
+    /// Build the value map for every prepared row — map construction + SipHash
+    /// ONLY (no partition-key reconstruct, no `into_owned()`, no projection).
+    /// Same per-row consume-and-drop lifetime and same checksum contract as
+    /// [`convert_all`], so the two groups' timed regions differ ONLY by the work
+    /// this one omits.
+    fn hashmaps_all(batch: Vec<Vec<(Arc<str>, Value)>>) -> usize {
+        let mut values_seen = 0usize;
+        for row in batch {
+            let mut map: ValuesMap = ValuesMap::with_capacity(row.len());
+            for (name, value) in row {
+                map.insert(name, value);
+            }
+            let map = black_box(map);
+            values_seen += map.len();
+            // `map` drops here — one row's worth of live memory at a time.
+        }
+        values_seen
+    }
+
+    /// The checksum both routines must return for a full pass: every one of the
+    /// [`ROWS`] rows contributes `columns + 1` values.
+    fn expected_checksum(columns: usize) -> usize {
+        ROWS * (columns + 1)
+    }
+
+    /// Whole-pass wiring guard: a pass that converted fewer values than
+    /// [`expected_checksum`] silently measured dropped/short rows.
+    fn assert_full_pass(bench_id: &str, columns: usize, checksum: usize) {
+        assert_eq!(
+            checksum,
+            expected_checksum(columns),
+            "row_build/{bench_id}: pass produced {checksum} column values, expected {} \
+             ({ROWS} rows x {} values) — rows were dropped or built short, so the \
+             measurement is not the full workload",
+            expected_checksum(columns),
+            columns + 1
+        );
+    }
+
+    /// Best-effort append of one recorded pass to the unified perf ledger. Timing
+    /// here is a RECORDED number only — never an assertion (no wall-clock gate).
+    fn record_pass(bench_id: &str, elapsed: std::time::Duration) {
+        let secs = elapsed.as_secs_f64();
+        if secs <= 0.0 {
+            return;
+        }
+        let rows_per_sec = ROWS as f64 / secs;
+        let ns_per_row = secs * 1e9 / ROWS as f64;
+        let m_rps = format!("{bench_id}/rows_per_sec");
+        let m_nspr = format!("{bench_id}/ns_per_row");
+        if let Err(e) = bench_ledger::append_metrics(
+            "row_build",
+            &[
+                (m_rps.as_str(), rows_per_sec, "rows_per_sec"),
+                (m_nspr.as_str(), ns_per_row, "ns"),
+            ],
+        ) {
+            eprintln!(
+                "row_build: could not append unified ledger {}: {e}",
+                bench_ledger::ledger_path().display()
+            );
+        }
+    }
+
+    /// `row_build/columns_<N>` — the real conversion, rows/sec.
+    pub fn bench_columns(c: &mut Criterion) {
+        let mut group = c.benchmark_group("row_build");
+        group.throughput(Throughput::Elements(ROWS as u64));
+        for columns in COLUMN_COUNTS {
+            let p = prepare(columns);
+            assert_conversion_is_real(&p);
+            let bench_id = format!("columns_{columns}");
+            eprintln!(
+                "row_build/{bench_id}: {ROWS} rows, {columns} regular columns + 1 PK, \
+                 {} rows/partition, ~{} payload bytes/row",
+                ROWS_PER_PARTITION, p.avg_payload_bytes
+            );
+
+            // One recorded pass for the longitudinal ledger (inputs cloned first,
+            // outside the timed span). Doubles as the whole-pass wiring guard.
+            {
+                let batch = p.rows.clone();
+                let mut cache = PartitionKeyCache::default();
+                let start = std::time::Instant::now();
+                let checksum = convert_all(batch, &p.schema, &mut cache);
+                let elapsed = start.elapsed();
+                assert_full_pass(&bench_id, columns, checksum);
+                record_pass(&bench_id, elapsed);
+            }
+
+            // ONE shared cache across the whole measurement, as the scan loop does.
+            let mut cache = PartitionKeyCache::default();
+            group.bench_function(&bench_id, |bch| {
+                bch.iter_batched(
+                    || p.rows.clone(),
+                    |batch| convert_all(batch, &p.schema, &mut cache),
+                    BatchSize::LargeInput,
+                );
+            });
+        }
+        group.finish();
+    }
+
+    /// `row_build/hashonly_<N>` — map construction + SipHash only, rows/sec.
+    pub fn bench_hashonly(c: &mut Criterion) {
+        let mut group = c.benchmark_group("row_build");
+        group.throughput(Throughput::Elements(ROWS as u64));
+        for columns in COLUMN_COUNTS {
+            let p = prepare(columns);
+            assert_hashonly_is_real(&p);
+            let bench_id = format!("hashonly_{columns}");
+
+            {
+                let batch = p.hash_rows.clone();
+                let start = std::time::Instant::now();
+                let checksum = hashmaps_all(batch);
+                let elapsed = start.elapsed();
+                assert_full_pass(&bench_id, columns, checksum);
+                record_pass(&bench_id, elapsed);
+            }
+
+            group.bench_function(&bench_id, |bch| {
+                bch.iter_batched(|| p.hash_rows.clone(), hashmaps_all, BatchSize::LargeInput);
+            });
+        }
+        group.finish();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// criterion_group! / criterion_main! — gated so the target builds an empty but
+// valid main without `state_machine` (mirrors read.rs / decode_bench.rs).
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "state_machine")]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = row_build_impl::bench_columns, row_build_impl::bench_hashonly
+);
+
+#[cfg(not(feature = "state_machine"))]
+fn bench_noop(_c: &mut criterion::Criterion) {
+    // `cqlite_core::query` (and with it `build_row_from_scan_cached`) is gated on
+    // `state_machine`; without it there is nothing to convert. The target still
+    // compiles and runs, reporting no measurements.
+    eprintln!(
+        "row_build: requires the `state_machine` feature (default-on). \
+         Run: cargo bench -p cqlite-core --bench row_build"
+    );
+}
+
+#[cfg(not(feature = "state_machine"))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_noop
+);
+
+criterion_main!(benches);

--- a/cqlite-core/benches/row_build_bench.rs
+++ b/cqlite-core/benches/row_build_bench.rs
@@ -28,8 +28,15 @@
 //! - **`row_build/hashonly_<N>`** — the SAME prepared names/values, but the timed
 //!   routine does ONLY `HashMap::with_capacity(n)` + `n` inserts. No partition-key
 //!   reconstruct, no `into_owned()`, no projection closure. This isolates the
-//!   *map construction + SipHash* term, which is the precise number #2901 needs:
-//!   `columns_<N> − hashonly_<N>` is everything else in the conversion.
+//!   *map construction + SipHash* term; `columns_<N> − hashonly_<N>` is everything
+//!   else in the conversion.
+//!
+//!   **Do NOT read `hashonly_<N>` as the upside of a hasher swap (#2901).** It bounds
+//!   map construction AND hashing together — `HashMap::with_capacity`, the hashbrown
+//!   probe/insert, and the map dealloc are all inside it, and a hasher swap removes
+//!   NONE of them. Only the SipHash sub-term is addressable that way. For that,
+//!   use in-situ profile attribution (`sip::Hasher::write` + `RandomState::hash_one`),
+//!   which issue #3027 measured at 4.94% of on-CPU on `read/full_scan`.
 //!
 //! The bench is **NOT** a `benches/perf-gate.json` entry: it is an instrument, and
 //! its absolute rows/sec is machine-dependent. Its value is the ratio between the
@@ -47,9 +54,10 @@
 //!   `Arc<str>` handles — name LENGTH is what SipHash consumes, so `a`/`b`/`c`
 //!   would understate the map term.
 //! - **Values** cycle through a realistic mix — `text` (24 B), `int`, `bigint`,
-//!   `uuid`, `timestamp`, `double`, `boolean` (~9.9 B of payload per column, i.e.
-//!   ~79 B/row at N=8 up to ~631 B/row at N=64; the exact per-row average is
-//!   printed at setup).
+//!   `uuid`, `timestamp`, `double`, `boolean`. Because `kind_at(i) = KINDS[i % 7]`
+//!   restarts on the 24 B `text` arm, per-row payload is NOT a flat multiple of N:
+//!   it is **93 B at N=8, 166 B at N=16, 328 B at N=32, 645 B at N=64** (so the
+//!   ~690 B/row target shape lands at N=64). The exact figure is printed at setup.
 //! - **Text payloads are slices of ONE shared backing `Bytes`**, mimicking a
 //!   decompressed chunk. That matters: `Value::into_owned()` (the #1644 D2
 //!   retention boundary inside the conversion) copies a shared payload, so a
@@ -75,8 +83,8 @@
 //! Measured on the same machine, retaining the batch cost 2 790 ns/row for
 //! `hashonly_64` vs 1 869 ns/row when dropping per row (+49%), and broke the
 //! linear scaling — it read out as "map construction = 98% of the conversion at
-//! N=64", an artifact, where the per-row-drop design reads a stable ~72–80% across
-//! all four column counts. The trade is that map DEALLOCATION is now inside the
+//! N=64", an artifact, where the per-row-drop design reads 57–80% across all four
+//! column counts. The trade is that map DEALLOCATION is now inside the
 //! measurement; that is real per-row work the conversion's caller pays either way,
 //! and both groups pay it identically, so the `columns_<N> − hashonly_<N>` delta
 //! stays clean.
@@ -88,10 +96,33 @@
 //! # Determinism
 //!
 //! Every name, value, and key is a pure function of `(row_index, column_index)` —
-//! no wall-clock input, no RNG (seeded or otherwise), so the workload is
-//! byte-identical on every run and machine. There are no wall-clock threshold
-//! asserts anywhere; the only `Instant` use is the best-effort ledger pass, which
-//! RECORDS a number and never asserts on one.
+//! no wall-clock input, no RNG (seeded or otherwise), so the INPUT is byte-identical
+//! on every run and machine. There are no wall-clock threshold asserts anywhere; the
+//! only `Instant` use is the best-effort ledger pass, which RECORDS a number and
+//! never asserts on one.
+//!
+//! The *hashing* is not equally reproducible: `RandomState` seeds per process, so
+//! collision patterns differ run to run. Both groups share the seed within a run, so
+//! the `columns` ∷ `hashonly` ratio is unaffected — but this plausibly contributes to
+//! the spread below.
+//!
+//! # KNOWN LIMITATION — read before quoting a number (issue #3048)
+//!
+//! Run-to-run spread on an idle box is ~2–3% at N=8/16 but **7–26% at N=32/64**
+//! (measured: two runs of the IDENTICAL binary gave `columns_32` 771k vs 722k and
+//! `columns_64` 300k vs 379k; the `hashonly_*` control, which no `QueryRow` hasher
+//! change can affect, moved 8–25%). The noise tracks memory footprint. **Trust
+//! N=8/16; treat N=32/64 as indicative** until #3048 stabilises it. This instrument
+//! cannot currently resolve a <10% effect at realistic column counts.
+//!
+//! # Fidelity caveat
+//!
+//! The synthetic rows carry no clustering columns and no primary-key pseudo-cells.
+//! The real V5 decoder surfaces PK columns into the cell map as pseudo-cells
+//! (`row_decoder/mod.rs:719-723`), so in production the partition-key insert is
+//! often an OVERWRITE into an N-entry map rather than an (N+1)-th insert. That does
+//! not move the ratio, but it means the absolute per-row cost here is not a
+//! production figure.
 //!
 //! # Gating
 //!

--- a/docs/reports/issue-3027-row-decode-attribution.md
+++ b/docs/reports/issue-3027-row-decode-attribution.md
@@ -209,7 +209,7 @@ performs an **unconditional** `Bytes::copy_from_slice` — a heap allocation + m
 payload is already tight. The rationale (documented in-place) is that `capacity()` cannot see backing
 *behind* the payload offset. For a ~690 B row **every** byte-carrying cell is Tier 1, so every one is
 copied. The repo's own ratchet encodes this as `PER_CELL_ALLOCS = 1`
-(`row_build_alloc_budget_test.rs:52-54`).
+(`row_build_alloc_budget_test.rs:73`, rationale at `:52-54`).
 
 Ledger for one medium row (30 cols, ~690 B), decompressed chunk -> finished `QueryRow`: **~16-17 heap
 allocations and ~12 memcpys**, of which ~10-11 are `into_owned` alone. This is T2 territory (borrow from
@@ -266,7 +266,10 @@ projection:
   on-CPU (557 cycles/row)**; with the `hashbrown` insert it is 7.68%.
 - Streaming profile: SipHash symbols total **8.12%** of on-CPU.
 - Isolated instrument (`row_build/hashonly_*` vs `columns_*`, clean run): map construction + SipHash is
-  **57-80% of the entire row-conversion cost**.
+  **57-80% of the entire row-conversion cost**. **This is NOT the upside of a hasher swap** — it bounds
+  map construction *and* hashing together (`with_capacity`, the hashbrown probe/insert and the map dealloc
+  are all inside it, and a hasher swap removes none of them). Only the SipHash sub-term is addressable
+  that way, and the in-situ 4.94% above is the honest bound on it.
 
 **(b) Non-breaking surface — REFUTED BY CONSTRUCTION.** The issue said *"scope the swap so the map type
 does not appear in any `pub` signature... If it cannot be made non-breaking, say so and stop."* It cannot:
@@ -306,8 +309,8 @@ change and is T2-aligned; it belongs with the "avoid materializing `Value`" work
   `row_build/hashonly_{N}` isolates map construction + SipHash. Carries a compile-time pin
   (`ValuesMap` + `hashonly_map_type_is_pinned_to_query_row`) so that changing `QueryRow.values`' hasher
   **breaks the bench build** rather than silently making the two groups measure different hashers.
-  Known limitation: run-to-run spread at N=32/64 is 7-26% (§6.2); trust N=8/16 and treat the large arms
-  as indicative until stabilised.
+  Known limitation, now recorded in the bench's own module doc: run-to-run spread at N=32/64 is 7-26%
+  (§6.2); trust N=8/16 and treat the large arms as indicative until #3048 stabilises it.
 - This report.
 - No production-code change: both candidate fixes were null results and were reverted.
 

--- a/docs/reports/issue-3027-row-decode-attribution.md
+++ b/docs/reports/issue-3027-row-decode-attribution.md
@@ -1,0 +1,323 @@
+# Issue #3027 (WS1) — row-decode CPU: function-level attribution
+
+Parent: #3023 (T1 exploration). Program epic: #2817. Companion WS: #3028.
+
+**Headline: the WS1 premise is partially refuted.** Row decode is the largest *CPU* consumer, but it is
+**traffic-light**. The memory traffic — the term that binds first, per the #3023 roofline — lives in the
+`QueryRow` **materialize → walk → free** lifecycle, not in the decoder. Cutting decode CPU would move
+CPU% without moving the bandwidth roofline, which is precisely the failure mode the #3023 reporting
+contract warns about.
+
+The stopping condition (row decode < 10% of on-CPU **and** >= 400k rows/s/phys-core warm) was **not met**,
+and no fix in this issue moved the number. Both candidate fixes measured are **null results**, reported
+as such.
+
+---
+
+## 1. Measurement environment (differs from #2818 — read before comparing)
+
+| | #2818 ground truth | This report |
+|---|---|---|
+| CPU | i4i (Ice Lake) | **Intel Xeon Platinum 8488C (Sapphire Rapids), 8 physical / 16 logical** |
+| Corpus | LZ4 compressed, `chunk_length=16384`, server-direct | `test_basic.simple_table`, 999 rows, 647 B/row on disk |
+| Driver | `cqlite-flight` server-direct + loadgen | `cqlite-core/benches/read.rs` (criterion) |
+
+**Docker is unavailable on this box**, so a Cassandra-generated corpus of controlled shape could not be
+produced; every `test-data/scripts/generate-*.sh` path needs it. The largest available fixture is 999
+rows. Absolute rows/s therefore is **not** directly comparable to #2818's server-direct figure — but the
+*bucket proportions* reproduce it closely (§3), which is what licenses the attribution below.
+
+Runs are pinned with `taskset -c 2` (core 2's HT sibling is core 10, left idle) and warm by construction
+(criterion re-runs the same query thousands of times).
+
+### Tooling gotchas found here (add to the #3023 shared list)
+
+- **DRAM-level PMU counters are not virtualized on this EC2 instance.** `longest_lat_cache.miss`,
+  `offcore_requests.*`, `mem_load_retired.l3_miss` and `cache-references` all read **exactly 0**.
+  `uncore_imc/cas_count_read/` does not exist. The one working memory counter is **`l2_lines_in.all`**.
+  All "memory traffic" below is therefore **L2-fill traffic (L1D+L1I miss traffic, includes prefetch),
+  x 64 B/line** — *not* DRAM traffic. It is the right metric for comparing how much data movement a code
+  path causes, and it is measurable; it is not the roofline's DRAM term.
+- `perf` needs `kernel.perf_event_paranoid` lowered (default 4 on this image blocks everything).
+- Datasets live at **`/data/datasets`**, not the in-tree `test-data/datasets`. `benches/fixtures/mod.rs`
+  additionally resolves schemas as `$CQLITE_DATASETS_ROOT/../schemas`, so `/data/schemas` must exist
+  (symlink to `test-data/schemas`).
+- **Do not pin the streaming bench to one core for a throughput number.** `read/scan_partition_dense_stream`
+  under `taskset -c 2` spends 5.27 s of 12.43 s in `sys` — a multi-threaded tokio pipeline forced onto one
+  core measures the scheduler, not the read path. Unpinned, `native_queued_spin_lock_slowpath` is 5.96%
+  of the profile. Absolute streaming throughput here is a **scheduling artifact** and is not reported as
+  a finding.
+
+---
+
+## 2. Baseline (clean, idle box, +-0.2% run-to-run)
+
+| Bench | rows/s / phys-core, warm | cycles/row | L2-fill traffic/row |
+|---|--:|--:|--:|
+| `read/full_scan` (materializing, `db.execute`) | **314.77 k** | **11,283** | **12,456 B** |
+| `read/scan_partition_dense_stream` (`execute_streaming`) | 157.90 k | (confounded — see above) | |
+
+Derivation: `perf stat` over `--profile-time 12` gave 43.52e9 cycles and 750.68e6 `l2_lines_in.all` over
+3.857e6 rows, at 3.499 GHz, IPC 2.27.
+
+**11,283 cycles/row vs #2818's 12,597** — this box reproduces the ground-truth shape within ~10%, despite
+the different CPU and corpus. That is the licence for the attribution.
+
+Note the amplification: **12,456 B of L2-fill traffic per row for a 647 B row (~19x)**.
+
+---
+
+## 3. Bucket-level attribution — corroborates #2818
+
+Flat `perf record -F 1999` over `read/full_scan`, single-threaded.
+
+| Bucket | This report | #2818 | |
+|---|--:|--:|---|
+| Row/cell decode | **22.1%** | 26.7% | corroborated |
+| Allocator (malloc/free/drop_glue) | **20.0%** | 19.6% | corroborated |
+| LZ4 decompress | 0.9% | 0.5% | corroborated |
+| Map build + SipHash | 7.7% | (inside decode) | newly separated |
+| Result-budget estimator | 6.4% | not present | **materializing path only** |
+
+Decode bucket = `parse_row_data_with_offset_impl` 9.64 + `parse_cell_value_schema_order` 6.55 +
+`decode_scalar_cell_value` 3.06 + `parse_block` 1.22 + `parse_row_metadata` 0.87 +
+`read_vint_length_prefixed_bytes` 0.74.
+
+Allocator bucket = `malloc` 6.41 + unnamed libc 6.02 + `drop_glue::<QueryRow>` 4.63 + `cfree` 2.04 +
+`drop_glue::<Value>` 0.89.
+
+---
+
+## 4. The headline: cycles vs memory traffic diverge
+
+Sampling **on the memory event itself** (`perf record -e l2_lines_in.all -c 20000`) attributes traffic
+per function — measured, not inferred from CPU share.
+
+| Function | cycles % | cycles/row | **traffic %** | **B/row** | traffic:cycles |
+|---|--:|--:|--:|--:|--:|
+| `parse_row_data_with_offset_impl` | **9.64** | 1,088 | 4.20 | 523 | **0.44** |
+| `parse_cell_value_schema_order` | 6.55 | 739 | 3.35 | 417 | 0.51 |
+| `decode_scalar_cell_value` | 3.06 | 345 | 4.22 | 526 | 1.38 |
+| `memory::estimate_value_size` | 6.35 | 716 | **11.22** | **1,398** | **1.77** |
+| `drop_glue::<QueryRow>` | 4.63 | 522 | **7.62** | **949** | **1.65** |
+| `Value::into_owned` | 6.22 | 702 | **7.59** | **945** | 1.22 |
+| `malloc` | 6.41 | 723 | 4.23 | 527 | 0.66 |
+| `sip::Hasher::write` | 2.72 | 307 | 2.45 | 305 | 0.90 |
+| `hashbrown insert` | 2.74 | 309 | 2.39 | 298 | 0.87 |
+| `RandomState::hash_one` | 2.22 | 250 | 1.76 | 219 | 0.79 |
+| `build_row_from_scan_cached` | 3.08 | 348 | 1.58 | 197 | 0.51 |
+
+**Read this table before proposing a WS1 fix.**
+
+- The **decoder is compute-bound**: `parse_row_data_with_offset_impl` is the #1 CPU consumer but only #6
+  in traffic (ratio 0.44). Making it faster buys CPU% and moves the roofline barely at all.
+- The **`QueryRow` lifecycle is traffic-bound**: `estimate_value_size` + `drop_glue::<QueryRow>` +
+  `Value::into_owned` = **26.4% of all L2-fill traffic** but only 17.2% of cycles, i.e. **3,292 B/row**
+  of the 12,456 B/row total. All three are pure *materialization overhead* — none of them decodes
+  anything. `estimate_value_size` alone is **1,398 B/row**, which independently reproduces the #3023
+  brief's "~1,400 B of the ~4,408 B/row is the `Value` materialize step."
+
+**Consequence for T1.** A WS1 that cuts decode CPU cannot reach 600k rows/s/phys-core, because the term
+that binds is the materialize/free traffic, not the decode compute. The lever that moves the roofline is
+T2's "avoid materializing `Value` at all — borrow from the decompressed chunk." This is a
+program-level redirect, offered in the same spirit as #2818 Arm 2's flat read histogram.
+
+---
+
+## 5. Findings by scope item
+
+### 5.1 `estimate_value_size` — 6.35% CPU / 11.22% traffic, **materializing path only**
+
+`query/result_budget.rs:36` sums `memory::estimate_value_size` over **every value of every row** of the
+fully-materialized result set, to enforce `max_result_bytes` (#1582). It is a second full pointer-chasing
+pass over data that has just gone cold — hence the 1.77 traffic:cycles ratio, the worst in the profile.
+
+**`cqlite-flight` never calls the result budget** (verified: no reference to `result_budget`,
+`estimate_query_row_bytes` or `enforce_materialized_rows` anywhere in `cqlite-flight/src/`). So this cost
+is absent from the Flight streaming path #2818 measured, and it is **not** part of the 26.7% streaming
+decode bucket. It is real for CLI/embedded/materializing consumers.
+
+The Flight path has its own analogue: `estimate_arrow_row_bytes` is called **per row** at
+`producer.rs:1032` / `producer_stream.rs:326` and re-does an `N x M` by-name `HashMap` probe
+(`arrow_size.rs:253`) that `transpose_columns` exists to eliminate.
+
+### 5.2 Per-partition rebuild of scan-invariant state (streaming path)
+
+`RowColumnResolution::build` is called **once per partition** (`partition_driver.rs:179`, and the code
+comment says so). It depends only on `(schema, reader.header)` — both invariant for the entire scan. Per
+column it allocates two `String`s via `to_lowercase()` on two *different* strings: `CellKind::from_type`
+lowercases the schema type (`cell_kind.rs:72`) and `is_complex_column` lowercases the header marshal type
+(`udt.rs:1216`).
+
+On `simple_table` (999 **one-row** partitions, ~20 columns) that is ~40 `String` allocations + case-folds
+**per row**. The cluster measured **17.4% of on-CPU** on the pinned streaming profile
+(`build` 2.86 + iterator 2.60 + `CellKind::from_type` 1.80 + `to_lowercase` 2.99 + `is_complex_column` 1.41
++ `Vec<ColumnToParse>::from_iter` 1.40 + `drop_glue` 1.32 + `hash_one::<&String>` 1.50 + `make_hash::<str>`
+1.49).
+
+**Caveat that must travel with this number:** 1 row/partition is the *pathological* shape. The cost
+amortizes linearly as rows/partition rises, and #2818 did not record the production rows/partition. On
+the materializing path (which uses `block_emit`, per *block*) this cluster does not appear in the profile
+at all. **This is a gap in the #3023 shared context worth closing before anyone sizes the fix.**
+
+Not landed here: with no Docker there is no realistic-shape corpus on this box, so the fix's true value
+cannot be measured — only modeled. Landing a core-decode refactor on a modeled benefit would violate the
+#3023 contract. Filed as a follow-up instead, with this measurement attached.
+
+This is the residue of #1635 (J1), which removed the per-**cell** `to_lowercase`; the
+per-column-per-partition one survived it.
+
+### 5.3 Redundant UTF-8 validation — CONFIRMED, exactly 2x per text cell
+
+Every text cell on a Flight SELECT is UTF-8-validated twice:
+
+1. `cell_value_scalar.rs:72` — `std::str::from_utf8` at decode; result discarded, bytes stored via
+   `borrow_active`. **Necessary** (establishes the `Value::Text` invariant) and does not copy.
+2. `arrow_convert.rs:1547` (strict), `:1569` (lossy), `:654` (collection element) — re-validated only to
+   satisfy `StringArray::from`'s `&str` API, then `memcpy`d straight back into the Arrow buffer. The
+   `str`-ness is **never inspected**.
+
+`Value::Text`'s UTF-8 invariant is documented as established at construction (`types.rs:88-90`,
+`types.rs:1189-1201`), so the second validation is provably redundant. Removing it requires
+`from_utf8_unchecked`, i.e. `unsafe` on a hostile-input path — **not recommended** without the fuzzing
+epic (#1614) covering it. Recorded, not actioned.
+
+Null result: no path validates the same bytes 3+ times, and no decoded cell's `str` is genuinely
+inspected as text (no `.chars()` anywhere in the row-decode or Arrow-encode call graph).
+
+### 5.4 Per-cell re-parsing
+
+Confirmed instances (all `file:line` verified):
+
+- `raw_value.rs:131` — `to_lowercase()` + ~30-arm string ladder **per collection element**. The surviving
+  instance of the anti-pattern #1635 removed for scalars.
+- `read_assembly.rs:155` — `Arc::from(cell.column.as_str())` **per cell per row** on the Flight merge
+  path, defeating the #1334 interning contract (the name was supposed to be interned once).
+- `complex_column.rs:1124` — unconditional `to_vec()` of the cell path per collection element, discarded
+  for lists on the user-facing read.
+- `row_framing.rs:941` — `peek_partition_boundary` runs after **every** row and walks the header prefix
+  twice; at a partition boundary the same header bytes are structurally walked **4x**.
+- `mod.rs:776` — `row_has_non_key_cell` computed unconditionally. **See §6.1 — this one is a null result.**
+
+Null result: no "compute serialized length by re-running the parser" anywhere on this path, and the
+scalar path's generic re-dispatch was genuinely eliminated by #1635.
+
+### 5.5 `Value::into_owned` — the dominant allocation term
+
+`types.rs:1250-1261`: for any payload <= `RETENTION_SLACK` (4096 B) that is uniquely owned, `into_owned`
+performs an **unconditional** `Bytes::copy_from_slice` — a heap allocation + memcpy — even when the
+payload is already tight. The rationale (documented in-place) is that `capacity()` cannot see backing
+*behind* the payload offset. For a ~690 B row **every** byte-carrying cell is Tier 1, so every one is
+copied. The repo's own ratchet encodes this as `PER_CELL_ALLOCS = 1`
+(`row_build_alloc_budget_test.rs:52-54`).
+
+Ledger for one medium row (30 cols, ~690 B), decompressed chunk -> finished `QueryRow`: **~16-17 heap
+allocations and ~12 memcpys**, of which ~10-11 are `into_owned` alone. This is T2 territory (borrow from
+the chunk) and is the single largest lever on the traffic term.
+
+---
+
+## 6. Candidate fixes attempted — both null results
+
+### 6.1 Lazy `row_has_non_key_cell` — NULL RESULT, hypothesis refuted
+
+`build_display_row` (`row_decoder/mod.rs:776`) computed `has_data_cell` unconditionally although it is
+consumed only by `row_tombstone.is_some() && !has_data_cell`. Moving the call into the short-circuiting
+condition is provably behaviour-identical (the function is pure over `cells`/`schema`, neither mutated in
+between).
+
+| | baseline | with fix (2 runs) |
+|---|--:|--:|
+| `read/full_scan` | 314.77 k | 317.70 k / 313.49 k |
+| `read/scan_partition_dense_stream` | 157.90 k | 157.62 k / 157.32 k |
+
+**No measurable change.** Mechanism: `.any()` **short-circuits on the first non-key cell**, which for a
+live row is typically the first cell examined — so the real cost is ~1 string comparison per row, not the
+~90 an `O(cells x (n_pk + n_ck))` reading suggests. **Reverted; not shipped.** A one-line change with no
+measured benefit is churn.
+
+### 6.2 #2901 FxHashMap end-to-end A/B — INCONCLUSIVE, instrument too noisy
+
+Attempted a real A/B by swapping `QueryRow.values` to `rustc_hash::FxHashMap` and re-running
+`benches/row_build_bench.rs`. **The result is not reportable**, for two compounding reasons:
+
+1. **Run-to-run noise exceeds the effect.** Two runs of the *identical* SipHash binary differ by 6.8% at
+   `columns_32` and **26% at `columns_64`**; the `hashonly_*` control group — which the swap cannot
+   affect — moved 8-25% between runs. N=8/16 are tight (~2-3%); N=32/64 are not. The noise tracks memory
+   footprint, so the larger arms are contention-sensitive.
+2. **My own measurements were self-contaminated.** Part of the A/B ran while a subagent was executing
+   `cargo clippy` and tests **in the same worktree**. That is the #1930 one-worker-per-machine rule being
+   violated from the inside — a lead running measurements while its own subagent builds. The subagent,
+   measuring on a quiet detached worktree, recorded <1.6% spread and `columns_32 = 774 k`, matching my one
+   clean run (771 k) and exposing my contaminated 612 k reading as the outlier.
+
+**Process lesson (worth propagating):** a measurement session must own the box exclusively, subagents
+included. "One worker per machine" is not only about gate concurrency.
+
+---
+
+## 7. #2901 (L5 FxHashMap) — disposition
+
+The issue required all three objections answered. Result: **one answered, one refuted, one stands.**
+
+**(a) Measured benefit — ANSWERED.** SipHash is measurable and larger than the unmeasured 1.04x
+projection:
+- In situ, `read/full_scan`: `sip::Hasher::write` 2.72% + `RandomState::hash_one` 2.22% = **4.94% of
+  on-CPU (557 cycles/row)**; with the `hashbrown` insert it is 7.68%.
+- Streaming profile: SipHash symbols total **8.12%** of on-CPU.
+- Isolated instrument (`row_build/hashonly_*` vs `columns_*`, clean run): map construction + SipHash is
+  **57-80% of the entire row-conversion cost**.
+
+**(b) Non-breaking surface — REFUTED BY CONSTRUCTION.** The issue said *"scope the swap so the map type
+does not appear in any `pub` signature... If it cannot be made non-breaking, say so and stop."* It cannot:
+
+- `QueryRow.values` is a **`pub` field** whose type *is* the map (`query/result.rs:77`).
+- `QueryRow::with_interned_values(key, values: HashMap<Arc<str>, Value>)` is a **`pub fn`** taking it as a
+  parameter (`query/result.rs:595`).
+
+A newtype does not help: `Deref` cannot bridge two `HashMap`s with different `S`. Compiling the swap
+surfaced **6 construction sites in `cqlite-core` alone** before the ripple reaches `cqlite-flight` and
+`cqlite-cli`, reproducing #1883's finding exactly. Per the issue's own instruction: **stop.**
+
+**(c) Untrusted keys — OBJECTION STANDS.** The claim to test was "the keys are column names from the
+schema, not user data." On the default read path the schema is reconstructed from the file's
+`Statistics.db` serialization header, so for a hostile SSTable the attacker supplies the key strings. I
+searched for a bound on the header column count and **found none** — the only nearby limit is a
+per-row cell-count check (`row_cell_state_machine.rs:710`, `column_count > 1000`) on a different path,
+which does not bound schema width. Without such a bound, FxHash's trivial collidability gives O(N^2)
+per-row insert on attacker-chosen colliding column names. The `rustc-hash` invariant in
+`cqlite-core/Cargo.toml` ("NOT for maps exposed to untrusted string keys", #1590 E8) therefore still
+applies.
+
+**Recommendation (owner decision — not taken unilaterally).** Do **not** land L5 as specified. Either
+close #2901, or re-scope it to the shape that dominates it on both axes: the decoder already emits cells
+**positionally in schema order**, and `arrow_columnar.rs` exists to transpose the map back to columnar.
+A positional `Vec` + a shared name->index table would remove the per-row hashing **and** the per-row map
+allocation **and** sidestep hash-DoS entirely — strictly better than FxHashMap. That is a public-surface
+change and is T2-aligned; it belongs with the "avoid materializing `Value`" work, not here.
+
+---
+
+## 8. What shipped
+
+- `cqlite-core/benches/row_build_bench.rs` — the row-conversion instrument #2901 named as its blocker
+  ("#1883 ran no row-conversion benchmark, so the ~1.04x remained a projection"). Groups
+  `row_build/columns_{8,16,32,64}` drive the real public `build_row_from_scan_cached`;
+  `row_build/hashonly_{N}` isolates map construction + SipHash. Carries a compile-time pin
+  (`ValuesMap` + `hashonly_map_type_is_pinned_to_query_row`) so that changing `QueryRow.values`' hasher
+  **breaks the bench build** rather than silently making the two groups measure different hashers.
+  Known limitation: run-to-run spread at N=32/64 is 7-26% (§6.2); trust N=8/16 and treat the large arms
+  as indicative until stabilised.
+- This report.
+- No production-code change: both candidate fixes were null results and were reverted.
+
+## 9. Acceptance criteria
+
+| Criterion | Status |
+|---|---|
+| Function-level attribution with cycles/row **and** bytes-traffic/row | **Met** (§4) |
+| Each candidate fix measured before/after in those units | **Met** — both null (§6) |
+| Stopping condition: decode < 10% on-CPU **and** >= 400k rows/s/phys-core | **NOT met** (22.1%, 314.8 k) |
+| #2901 lands non-breaking, or closed with reason recorded | **Recorded** (§7); close/re-scope is an owner call |
+| No regression on the #1883 alloc ratchet | **Met** — no production code changed |
+</content>


### PR DESCRIPTION
Closes #3027. WS1 of #3023. Full report: `docs/reports/issue-3027-row-decode-attribution.md`.

Measurement-driven work — the deliverable is a defensible number, not a diff. **There is no
production-code change in this PR**: both candidate optimizations were null results and were reverted
rather than shipped as churn.

## Headline: the WS1 premise is partially refuted

Row decode is the largest **CPU** consumer but it is **traffic-light**. Sampling on the memory event
directly (`perf record -e l2_lines_in.all`) instead of inferring traffic from CPU share:

| Function | cycles % | cycles/row | **traffic %** | **B/row** | ratio |
|---|--:|--:|--:|--:|--:|
| `parse_row_data_with_offset_impl` | **9.64** (#1) | 1,088 | 4.20 (#6) | 523 | **0.44** |
| `memory::estimate_value_size` | 6.35 | 716 | **11.22** (#1) | **1,398** | **1.77** |
| `drop_glue::<QueryRow>` | 4.63 | 522 | **7.62** | 949 | **1.65** |
| `Value::into_owned` | 6.22 | 702 | **7.59** | 945 | 1.22 |
| `sip::Hasher::write` | 2.72 | 307 | 2.45 | 305 | 0.90 |

The decoder is **compute-bound**; the `QueryRow` materialize -> walk -> free lifecycle is
**traffic-bound** (26.4% of L2-fill traffic vs 17.2% of cycles = 3,292 B/row of 12,456 B/row). Since
memory bandwidth binds before cycles, **cutting decode CPU cannot reach T1** — the lever is T2's "avoid
materializing `Value` at all." `estimate_value_size` alone is 1,398 B/row, independently reproducing
#3023's "~1,400 B is the `Value` materialize step."

## Baseline and corroboration

`read/full_scan`, Xeon 8488C, 1 physical core, warm, +-0.2%: **314.77 k rows/s**, **11,283 cycles/row**
(vs #2818's 12,597), **12,456 B/row** L2-fill traffic. Buckets corroborate #2818: decode **22.1%** (vs
26.7%), allocator **20.0%** (vs 19.6%), LZ4 **0.9%** (vs 0.5%).

## What ships

- **`cqlite-core/benches/row_build_bench.rs`** — the row-conversion instrument #2901 named as its
  blocker (*"#1883 ran no row-conversion benchmark, so the ~1.04x remained a projection"*).
  `row_build/columns_{8,16,32,64}` drives the real public `build_row_from_scan_cached`;
  `row_build/hashonly_{N}` isolates map construction + SipHash. Carries a **compile-time pin** so that
  changing `QueryRow.values`' hasher **breaks the bench build** rather than silently making the two
  groups measure different hashers.
- **`docs/reports/issue-3027-row-decode-attribution.md`** — full attribution + all null results and confounds.

## #2901 disposition — 1 answered, 1 refuted, 1 stands

- **Measured benefit — ANSWERED.** SipHash = **4.94% of on-CPU / 557 cycles/row** in situ (8.12% on the
  streaming profile); map+SipHash = **57-80% of the entire row conversion**. Materially more than 1.04x.
- **Non-breaking surface — REFUTED BY CONSTRUCTION.** `QueryRow.values` is a **`pub` field** whose type
  *is* the map (`result.rs:77`); `QueryRow::with_interned_values` is a **`pub fn`** taking it
  (`result.rs:595`). A newtype cannot bridge two `HashMap`s with different `S` via `Deref`. Compiling the
  swap surfaced **6 construction sites in `cqlite-core` alone**. Per #3027's own instruction — stop.
- **Untrusted keys — OBJECTION STANDS.** No bound on serialization-header column count exists (the only
  nearby limit, `row_cell_state_machine.rs:710`, is a per-row cell count on a different path). #1590 E8 applies.

**Owner decision requested** (not taken unilaterally): close #2901, or re-scope it to a positional
`Vec` + shared name->index table — which removes the hashing *and* the per-row map allocation *and*
sidesteps hash-DoS, and is T2-aligned.

## Null results (both reported, neither shipped)

- **Lazy `row_has_non_key_cell`**: no measurable change (317.7k/313.5k vs 314.8k). `.any()`
  short-circuits on the first non-key cell, so the real cost is ~1 string compare/row, not ~90. Reverted.
- **End-to-end FxHashMap A/B: INCONCLUSIVE.** Two runs of the *identical* binary differ 26% at
  `columns_64`; the `hashonly_*` control — which the swap cannot affect — moved 8-25%. Filed #3048.

## Stopping condition

**NOT met**: decode 22.1% (target <10%), 314.8 k rows/s/phys-core (target >=400 k). The attribution
explains why — remaining levers are either traffic-bound/T2-shaped or gated on a corpus shape this box
cannot produce.

## Confounds recorded so they are not rediscovered

- **DRAM-level PMU counters are not virtualized on EC2**: `longest_lat_cache.miss`, `offcore_requests.*`,
  `mem_load_retired.l3_miss`, `cache-references` all read exactly 0. Only `l2_lines_in.all` works — all
  traffic figures are L2-fill, not DRAM.
- **Do not pin the streaming bench to one core** for throughput: 5.27 s of 12.43 s goes to `sys`.
- **I contaminated part of my own A/B** by measuring in the same worktree as a working subagent. #1930
  "one worker per machine" is not only about gate concurrency.

## Follow-ups filed

- **#3047** — `RowColumnResolution` rebuilt per-partition though it is scan-invariant: **17.4% of on-CPU**
  on the pathological 1-row/partition shape. Deliberately not rushed — with no Docker there is no
  realistic-shape corpus, so its true value could only be *modeled*, which the #3023 contract forbids.
- **#3048** — `row_build` bench variance.

## Verification

- `--lite`: **PASS** (`file-size`, `fmt`, `clippy`, `roborev-lints`, `scoped-tests`), `tree-integrity: PASS`.
- #1883 alloc ratchet: unaffected — no production code changed.