### PR TITLE
DO NOT MERGE — production exercise of the ci:waive:<tier-id> waiver path (#3033)

### DIFF
--- a/.github/workflows/flight-ci.yml
+++ b/.github/workflows/flight-ci.yml
@@ -215,6 +215,19 @@ jobs:
     if: needs.classify.outputs.run_tier == 'true'
     runs-on: ubuntu-latest
     steps:
+      # TEMPORARY (#3033 verification, revert before close). `Flight tier gate`
+      # is created only once every job it `needs:` has completed, and on this
+      # repo the whole tier concludes in ~11 minutes — FASTER than pr-gate-core
+      # (~15-25 min), which is what gates the `required` job's start. So on a
+      # healthy mandating PR `required` never observes the tier as absent or
+      # pending, and neither early-resolution waiver path is reachable. This
+      # delay holds the tier's gate context ABSENT past the moment `required`
+      # starts polling, which is the state the `ci:waive:<tier-id>` break-glass
+      # exists for. 35 minutes is deterministic: pr-gate-core has
+      # timeout-minutes: 30, so `required` always starts before this lapses.
+      - name: TEMPORARY hold the tier's gate context absent (#3033 verification)
+        run: sleep 2100
+
       - uses: actions/checkout@v5
 
       - name: Setup Rust

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -358,4 +358,13 @@ jobs:
           CORE_RESULT: ${{ needs.pr-gate-core.result }}
           EVENT_ACTION: ${{ github.event.action }}
           GATING_DIR: ${{ steps.source.outputs.dir }}
-        run: bash "$GATING_DIR/scripts/ci/aggregate-required-tiers.sh"
+          # TEMPORARY (#3033 verification, revert before close). Points the waiver
+          # `labeled`-events read at an endpoint that genuinely 404s, to prove on
+          # real infrastructure that an UNREADABLE evidence read only WITHHOLDS
+          # early resolution and never reds `required`. A literal env value, never
+          # a `${{ }}` interpolation into `run:` (scripts/ci/check-workflow-injection.sh).
+          WAIVER_EVENTS_CMD: gh api --paginate "repos/pmcfadin/cqlite/issues/999999999/events?per_page=100" --jq '.[] | select(.event == "labeled") | [.label.name, (.actor.login // "unknown"), .created_at] | @tsv'
+        # TEMPORARY (#3033 verification, revert before close): a short aggregation
+        # deadline so the deadline-honoured waiver path is reached in minutes rather
+        # than the registry's 60. Purely a time-saver; the code path is identical.
+        run: bash "$GATING_DIR/scripts/ci/aggregate-required-tiers.sh" --deadline-minutes 4

--- a/cqlite-flight/src/pathsafe.rs
+++ b/cqlite-flight/src/pathsafe.rs
@@ -8,6 +8,10 @@
 //! `*-Data.db` files. These helpers are the shared, dependency-free guards that
 //! reject such inputs at parse time and, as defense in depth, verify a resolved
 //! path stays within the (canonicalized) data directory.
+//!
+//! NOTE (throwaway — production exercise of the `ci:waive:<tier-id>` break-glass,
+//! issue #3033): this comment exists only to MANDATE the `flight` gating tier on a
+//! non-docs diff. It is reverted and the pull request is closed unmerged.
 use std::path::{Path, PathBuf};
 
 /// A rejected attacker-controlled path component.


### PR DESCRIPTION
**DO NOT MERGE. This PR is a throwaway** — it exists to run the first-ever production
exercise of the `ci:waive:<tier-id>` break-glass on real infrastructure (owner-approved,
follow-up to #3033 / #2910). It will be closed unmerged and its branch deleted.

The diff is a comment-only edit under `cqlite-flight/src/` so that it **mandates the
`flight` gating tier** while not being docs-only.

## What is being verified

**Part A** — a waiver's evidence is READ, attributed to a named actor, and resolves the
tier BEFORE the aggregation deadline (`ci:waive:flight` applied while `required` is
polling and `Flight tier gate` is still absent).

**Part B** — an UNREADABLE evidence read (a `WAIVER_EVENTS_CMD` pointed at a genuinely
404ing endpoint, injected as a workflow-step `env:` literal — the one injection point
the #2910 trust boundary leaves open, since `required` runs the BASE ref's aggregator)
still leaves `required` **GREEN** with the waiver honoured at the deadline. A broken
evidence read must only WITHHOLD early resolution, never red the check.

Part B's temporary commit is reverted before this PR is closed.