### PR TITLE
docs(#3055): flow control-plane surfaces — remove forbidden REST merge, claim-ref-not-branch, dead gh flags, gate redirects, park-not-prompt

### DIFF
--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -52,7 +52,7 @@ back into one.
 ## Autonomy: arm `--auto`, GitHub merges on green (default, #2667)
 
 - **Default:** the moment **local certification** is met — `agent-gate.sh` PASS + **C** PASS
-  (design-driven) + roborev clean — the closer runs `scripts/flow/premerge-assert.sh <pr>
+  (design-driven) + roborev clean — the closer runs `bash scripts/flow/premerge-assert.sh <pr>
   <certified-sha>`, re-reads for a fresh `HOLD:` order, then **arms `gh pr merge --auto --squash
   --delete-branch`** and `flow-finalize`s. GitHub owns the CI-green wait — the `required` check
   (#2433, enforced for admins too via `enforce_admins`) lands the PR the instant it passes; **never
@@ -139,7 +139,7 @@ plumbing, NOT the lock); a session claims the ref FIRST (git arbitrates the atom
 then creates the worktree/branch, sets assignee + `Status=In Progress` for visibility, and proceeds only
 on `CLAIM HELD`. See `flow-activate` / `flow-implement` for the steps and `flow-board`
 for the render + reaper. The claiming session also maintains a liveness **heartbeat**
-(`scripts/flow/claim-heartbeat.sh beat <N>` — a cheap origin git ref, never a GitHub API call — refreshed at
+(`bash scripts/flow/claim-heartbeat.sh beat <N>` — a cheap origin git ref, never a GitHub API call — refreshed at
 claim time and every stage transition) that `flow-board` uses for deterministic reaping (age > 4h AND no
 open PR), replacing the old "no recent commits" guesswork (issue #2089).
 

--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -15,8 +15,11 @@ already in context — this file is your operating manual for the *role*, not a 
 
 ## The one job: keep the flow moving, owner in one standing seat
 
-1. **Groom** (`flow-groom`) — a rough idea → one scoped GitHub issue (exactly one `P0`–`P3`,
-   `status:ready`, testable acceptance criteria). Decide **oracle vs design**: oracle-driven bugs
+1. **Groom** (`flow-groom`) — a rough idea → one scoped GitHub issue (exactly one `P0`–`P3`, testable
+   acceptance criteria). **Never hand-write a `status:*` label** — post-#2855 `project-board-sync.yml` is
+   their sole writer and reverts (and FAILs its drift detector on) a hand-written one; a new issue
+   auto-lands at board `Status=Backlog`, so promotion to `Ready` is a **board Status write**, not a label.
+   Decide **oracle vs design**: oracle-driven bugs
    (SSTable parsing, compaction/tombstone parity, type decode) get an issue + a pinned parity test and
    SKIP OpenSpec; design-driven work goes through `activate`.
 2. **Activate** (`flow-activate <N>`) — **Seam 1**. Worktree + branch + `opsx:propose` + design.
@@ -67,6 +70,9 @@ back into one.
 - **Answer questions directly.** If they ask a question, answer it first — do not jump to changing code.
 - **One question at a time.** List the decisions so they see the shape, then ask ONE via
   `AskUserQuestion` (genuine forks only, recommendation first). Pick obvious defaults yourself and say so.
+  **`AskUserQuestion` is attended-sessions-ONLY (#2666)** — an unattended worker that prompts hangs until
+  the log-tail watchdog pages it, so unattended it must **park** instead (question comment +
+  `needs-decision` label + `blocked` marker + EXIT) and release the machine.
 - **Show, don't link.** Render the substance inline at every seam — the proposal, the spec requirements
   + scenarios verbatim, the chosen design and what it beat. A file path is a secondary reference.
 - **Recommend, don't survey.** Give a recommendation with a one-line why; when you have enough to act, act.
@@ -77,7 +83,9 @@ back into one.
 ## Hard rules you enforce (never violate; reject delegate output that does)
 
 - **No-heuristics mandate (#28):** authoritative metadata only — schema, else `Statistics.db`. No type
-  guessing; legacy fallbacks live only behind the `experimental` flag.
+  guessing; legacy heuristic fallbacks live only behind the opt-in **`legacy-heuristics`** feature flag
+  (NOT `experimental`, which gates a different set: `Database::flush()`/`compact()`, the INSERT executor
+  path, the schema JSON exporter, bloom-filter tests, and the `Storage::put`/`delete` stubs).
 - **The gate is `scripts/agent-gate.sh` — the only run that counts.** The AGENT-GATE SUMMARY block is the
   verdict; ad-hoc cargo runs do not count. Run `scripts/agent-gate.sh --list` for the component set. **The
   ONE gate of record runs inside `flow-closer`, not in your context (issue #2084):** you never run the full
@@ -106,12 +114,18 @@ silently fails:
 | intent audit (C) | `spec-auditor` (anchored to `openspec/changes/<name>/specs/**`) | inside flow-closer, after the gate |
 | parity / test execution | `test-validator` | verify |
 | test quality | `coverage-reviewer` | review |
-| code review | roborev (`/roborev-review-branch --base origin/main`) | review-first + final closer pass |
+| code review | roborev (`roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`) | review-first + final closer pass |
 | correctness | `scripts/agent-gate.sh` | the ONE gate of record, inside flow-closer |
 
+- **roborev invocation — there is NO `/roborev-review-branch` slash command.** Run the CLI and pass
+  **BOTH** `--agent` and `--model` (#2433): `.roborev.toml` on `main` pins `review_model = 'opus'`, and
+  `--agent codex` alone inherits it → codex hard-400s (`'opus' model is not supported`), a silent review
+  failure that looks like an outage.
 - Parallelize independent specialists in one message; sequence dependent work. A review finding that is
   **mechanical** (a missing test, a fmt/clippy nit) is the loop's to fix; a genuine **decision** goes to
-  the owner via `AskUserQuestion`.
+  the owner. In an **attended** session ask via `AskUserQuestion`; in an **unattended** session
+  `AskUserQuestion` is FORBIDDEN — **park** per #2666 (one structured question comment + the
+  `needs-decision` label + a `blocked` marker + EXIT), never hang on a prompt.
 - Named subagents can fail to spawn in this environment — omit the `name` field when spawning.
 
 ## Concurrency model (how many of you run, and how you avoid dup work)
@@ -144,9 +158,12 @@ open PR), replacing the old "no recent commits" guesswork (issue #2089).
   **disjoint** work — zero dup by construction. Subagents never self-select overlapping work; the lead
   hands out distinct tasks.
 - **Multiple independent sessions: the claim protocol is mandatory.** If more than one independent lead
-  session touches the backlog, each acquires work ONLY through the claim protocol (push branch → assignee
-  + `Status=In Progress` → re-read). This is how the dup-work race is prevented. Combined with the
-  one-per-machine rule above: independent sessions belong on *separate* machines, each claim-protocol-gated.
+  session touches the backlog, each acquires work ONLY through the claim protocol — **acquire the claim
+  ref FIRST** (`bash scripts/flow/claim.sh claim <N>` → `refs/claims/issue-<N>`, the lock), then create
+  the worktree/branch, then set assignee + `Status=In Progress` for visibility. This is how the dup-work
+  race is prevented; a slug-named-branch check is NOT (that is exactly the #1632 slug-pair double-claim
+  hazard #2665 closed). Combined with the one-per-machine rule above: independent sessions belong on
+  *separate* machines, each claim-protocol-gated.
 - **Agent Teams is optional, desktop-only.** `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` provides a built-in
   file-locked shared task list for coordinated parallel sessions, but it is experimental + desktop/tmux-only
   (no `/resume`, one team per session). Use it if you want; it is not required.
@@ -154,8 +171,9 @@ open PR), replacing the old "no recent commits" guesswork (issue #2089).
   the same top `Ready` item and collide. Either single-lead+subagents, or claim-protocol sessions.
 - **Board unreachable = STOP, not label-dispatch (Path A, #1886).** When the `project` token scope or the
   board is absent, the board is the SOLE dispatch authority so there is nothing safe to select from —
-  surface the auth failure and STOP; do NOT dispatch from `status:*` labels (they are decorative and go
-  stale). You MAY render a read-only label view for status, but no claim/selection without the board.
+  surface the auth failure and STOP; do NOT dispatch from `status:*` labels (a lagging board-derived
+  mirror, ≤30-min stale by construction). You MAY render a read-only label view for status, but no
+  claim/selection without the board.
 
 ## Pipelining independent lanes (don't serialize on waits, retro #1889)
 
@@ -172,24 +190,32 @@ near-independent issues instead of running one to done before starting the next:
   derives `CARGO_BUILD_JOBS`/`--test-threads` from its slot count and runs under `taskpolicy`/`nice`,
   so an accidental overlap no longer oversubscribes the CPU. Only the full-gate step serializes — the
   rest overlaps; no manual `pgrep`-checking needed.
-- **(d) Long waits use scheduled wakeups**, never idle polling: `ScheduleWakeup` (cache-aware) for external
-  CI; harness-tracked Workflows notify you. Poll a queued gate's summary file with a cheap
-  `grep -qE 'RESULT: (PASS|FAIL)'` at <5-min intervals if you must watch — never a bare
-  `grep -q` on the bare `RESULT:` token, which also matches the startup `RESULT: INCOMPLETE (gate did not finish)`
+- **(d) Never poll a PR's own CI (#2667).** `gh pr merge --auto` owns the CI-green wait — GitHub lands the
+  PR the instant the `required` check passes, so a `ScheduleWakeup` on your own PR's CI is pure waste (see
+  the Autonomy section: **never `ScheduleWakeup`-poll a PR's own CI**). Scheduled wakeups are for a *later
+  confirmation* that an armed PR reached `state=MERGED`, or a genuinely external wait you do not control —
+  not for the green itself. For a long local gate, poll its summary file with a cheap
+  `grep -qE 'RESULT: (PASS|FAIL)'` at <5-min intervals rather than idling — **never a bare `grep -q` on the
+  bare `RESULT:` token**, which also matches the startup `RESULT: INCOMPLETE (gate did not finish)`
   **liveness placeholder** (not a verdict) and so false-fires the instant the gate launches (#3041).
   Never a silent wait either (a **queued gate ≠ hung gate**: under load it first prints
-  `waiting for gate slot (N in use)…`, and its summary file already holds the `INCOMPLETE`
-  placeholder).
+  `waiting for gate slot (N in use)…`, and its summary file already holds the `INCOMPLETE` placeholder).
 
 ## State model
 
 - **Backlog = the claim board (GitHub Project) is the source of truth (Path A, #1886).** Exactly one
   `P0`–`P3`; the lifecycle Project `Status` (`Backlog/Ready/In Progress/In Review/Done`) is the **sole
-  dispatch authority**. `status:{ready, spec-review, in-progress, in-review, addressing}` labels are
-  **decorative/non-authoritative** — a convenience mirror, NOT a selection source. Newly created issues
-  auto-land at `Status=Backlog` (Project built-in "item added → Backlog"). "What's next" = highest-priority
-  item whose **board `Status=Ready`** with **no** `issue-<N>-*` branch already on origin (already-claimed
-  items are skipped). **An empty Ready column = no work is ready → STOP; never dredge `status:ready`
+  dispatch authority**. `status:{ready, in-progress, in-review}` are an **ENFORCED board-derived
+  read-mirror** (#2855: `project-board-sync.yml` is the sole writer; a drift detector FAILs on
+  disagreement), so they are trustworthy for **cheap server-side candidate discovery**
+  (`gh issue list --state open --label status:ready --json number,title` — narrowing, no board
+  pagination) but are **NEVER the dispatch/claim authority**: ≤30-min mirror lag means the claim ref plus
+  a **fresh board read at claim time** remain the sole double-work arbiter. (`status:spec-review` /
+  `status:addressing` are transient skill-managed sub-markers the mirror does not touch.) Newly created
+  issues auto-land at `Status=Backlog` (Project built-in "item added → Backlog"). "What's next" =
+  highest-priority item whose **board `Status=Ready`** with **no `refs/claims/issue-<N>` claim ref**
+  (`bash scripts/flow/claim.sh status <N>`; also skip a legacy `issue-<N>-*` branch left by an old-fleet
+  worker). **An empty Ready column = no work is ready → STOP; never dredge `status:ready`
   labels** (near a release Ready is meant to drain to zero — that is the wrong-grab bug that motivated Path A).
 - **1:1:1:1** — one issue ↔ one branch/worktree `issue-<N>-<slug>` (worktrees branch from `origin/main`,
   which leads local `main`) ↔ one OpenSpec change `<slug>` ↔ one PR. Worktrees lack the gitignored
@@ -208,7 +234,8 @@ You are the only long-lived agent, so nothing compacts between issues unless you
   board renders, gate summaries, roborev findings, PR bodies, or spec renders. Pick the next item from the
   board alone.
 - **Be re-runnable from board + disk alone.** All durable state already lives outside your window — the
-  worktree, the origin claim branch, the issue/PR bodies, the OpenSpec files under `openspec/changes/`, the
+  worktree, the origin **claim ref** `refs/claims/issue-<N>` (the lock) and its PR-plumbing branch, the
+  heartbeat ref, the issue/PR bodies, the OpenSpec files under `openspec/changes/`, the
   gate summary files, the telemetry ledger. A fresh session must rehydrate in one board read; if it can't,
   something was being held only in the window — fix that, don't lean on it.
 - **Seam-1 spec bodies are NOT retained after owner approval** — render inline for approval, get the call,

--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -135,7 +135,10 @@ There is a shared **claim board** — a GitHub Project (v2) with a `Status` sing
 same item. The deciding cross-machine lock is the slugless fixed-name ref **`refs/claims/issue-<N>`**
 acquired via `bash scripts/flow/claim.sh claim <N>` (#2665 — assignee `@me` is identical for the same
 GitHub user on two machines, so assignee alone is NOT a lock; the `issue-<N>-<slug>` branch is PR
-plumbing, NOT the lock); a session claims the ref FIRST (git arbitrates the atomic push server-side),
+plumbing, NOT the lock). **`refs/claims/issue-<N>` and `refs/machine-claims/<machine>` are DISTINCT
+namespaces**: the former is the per-issue lock (`claim.sh`), the latter the supervisor-authored
+*machine-busy* stamp (#2655/#2499) that feeds the CI reaper — reading one as the other double-claims.
+A session claims the issue ref FIRST (git arbitrates the atomic push server-side),
 then creates the worktree/branch, sets assignee + `Status=In Progress` for visibility, and proceeds only
 on `CLAIM HELD`. See `flow-activate` / `flow-implement` for the steps and `flow-board`
 for the render + reaper. The claiming session also maintains a liveness **heartbeat**
@@ -210,7 +213,10 @@ near-independent issues instead of running one to done before starting the next:
   disagreement), so they are trustworthy for **cheap server-side candidate discovery**
   (`gh issue list --state open --label status:ready --json number,title` — narrowing, no board
   pagination) but are **NEVER the dispatch/claim authority**: ≤30-min mirror lag means the claim ref plus
-  a **fresh board read at claim time** remain the sole double-work arbiter. (`status:spec-review` /
+  a **fresh board read at claim time** remain the sole double-work arbiter. **Labels NARROW; the filtered
+  board read + the claim ref DECIDE.** Read the board with a **server-side filter**
+  (`gh project item-list <n> --owner <o> --query 'status:Ready' --format json -L 100`) — an unfiltered
+  `item-list` truncates on this 900+ item board and silently under-reports a column. (`status:spec-review` /
   `status:addressing` are transient skill-managed sub-markers the mirror does not touch.) Newly created
   issues auto-land at `Status=Backlog` (Project built-in "item added → Backlog"). "What's next" =
   highest-priority item whose **board `Status=Ready`** with **no `refs/claims/issue-<N>` claim ref**

--- a/.claude/skills/ci-cd-validation/SKILL.md
+++ b/.claude/skills/ci-cd-validation/SKILL.md
@@ -28,22 +28,39 @@ instead of waiting for the process to exit, the predicate is
 `grep -qE 'RESULT: (PASS|FAIL)' "$AGENT_GATE_SUMMARY_FILE"` — a bare `grep -q` on the bare `RESULT:` token fires the
 instant the gate starts and would accept a just-launched (or still-queued) gate as certified.
 
-```bash
-# ITERATE — every fix round (fmt + file-size + workspace clippy + blast-radius-scoped tests, ~1-5 min).
-# Emits a DISTINCT ==== AGENT-GATE LITE SUMMARY ==== block that must NEVER be pasted as the full SUMMARY.
-scripts/agent-gate.sh --lite
+**Every invocation — full, lite, and `--only` — MUST use the summary-file redirect** (#1175/#2079). The
+summary block is the only gate text an agent retains; never stream raw gate stdout into a persistent
+context, and never read `gate.log`.
 
-# BEFORE MERGE — the FULL gate, run EXACTLY ONCE by the lead. Its ==== AGENT-GATE SUMMARY ====
-# (ending RESULT: PASS) is the only run that counts. --lite never replaces it.
-scripts/agent-gate.sh
+```bash
+# ITERATE — every fix round. --lite components (exactly, per scripts/agent-gate.sh LITE_COMPONENTS):
+#   file-size · fmt · clippy (PER-PACKAGE scoped, #1844 — not whole-workspace) · roborev-lints ·
+#   scoped-tests (blast-radius: touched package --lib + the diff's new --test targets). ~1-5 min.
+# Emits a DISTINCT ==== AGENT-GATE LITE SUMMARY ==== block that must NEVER be pasted as the full SUMMARY.
+AGENT_GATE_SUMMARY_FILE=/tmp/lite-<N>.txt \
+  bash scripts/agent-gate.sh --lite > /tmp/lite-<N>.log 2>&1 < /dev/null
+cat /tmp/lite-<N>.txt
+
+# BEFORE MERGE — the FULL gate, run EXACTLY ONCE, inside the flow-closer subagent (#2084).
+# Its ==== AGENT-GATE SUMMARY ==== (ending RESULT: PASS) is the only run that counts; --lite never
+# replaces it.
+AGENT_GATE_SUMMARY_FILE=/tmp/gate-<N>.txt \
+  bash scripts/agent-gate.sh > /tmp/gate-<N>.log 2>&1 < /dev/null
+cat /tmp/gate-<N>.txt
 
 # Debugging only (output marked PARTIAL, never counts as the gate):
-scripts/agent-gate.sh --only fmt,clippy
+AGENT_GATE_SUMMARY_FILE=/tmp/partial-<N>.txt \
+  bash scripts/agent-gate.sh --only fmt,clippy > /tmp/partial-<N>.log 2>&1 < /dev/null
 ```
 
-- **Division of labor (issue #1855):** subagents iterate on `--lite` / targeted tests and end at
-  commit + push + report. The **lead** runs the full gate + roborev — a subagent idle-waiting on a 12-20 min
-  full gate gets killed by the 600s stall watchdog and takes its child gate process down with it.
+- **Division of labor (#1855/#2084/#2079):** the implementing subagent iterates on `--lite` / targeted
+  tests and ends at commit + push + report. **The ONE full gate of record and the final roborev pass run
+  inside the disposable `flow-closer` subagent, NOT in the lead** — the lead never runs the full gate and
+  never reads its stdout; it retains only the closer's terminal packet (verdict, PR URL, summary-file
+  path). The closer launches the gate via `Bash run_in_background` and reads the SUMMARY **from the file**:
+  a subagent that idle-waits on a 12-25 min full gate is killed by the 600s stall watchdog and orphans its
+  child gate process. The closer has no `Agent` tool, so it requests **C** (`spec-auditor`) from the lead
+  via a `NEEDS-SPAWN` packet (#2668).
 - **Queued gate ≠ hung gate:** under load the full gate may **queue for a #1825 slot** (prints
   `waiting for gate slot (N in use)…` once) then run 15-20 min — total wall time can exceed 20 min. Use a
   long Bash `timeout` or `run_in_background` and check for that line before assuming a hang (the default

--- a/.claude/skills/ci-cd-validation/validation-checklist.md
+++ b/.claude/skills/ci-cd-validation/validation-checklist.md
@@ -5,13 +5,20 @@
 
 Validation is `scripts/agent-gate.sh`, run in the tiered loop:
 
-- **Iterate:** `scripts/agent-gate.sh --lite` (fmt + file-size + workspace clippy + blast-radius-scoped
-  tests, ~1-5 min) on every fix round. It emits a distinct `==== AGENT-GATE LITE SUMMARY ====` block that
-  must NEVER be pasted as the full SUMMARY.
-- **Before merge:** the **lead** runs the FULL `scripts/agent-gate.sh` **exactly once**; its
+**Every invocation carries the mandatory summary-file redirect** (#1175/#2079):
+`AGENT_GATE_SUMMARY_FILE=<path> bash scripts/agent-gate.sh [--lite] > gate.log 2>&1 < /dev/null`, then
+read only the summary file — never `gate.log`.
+
+- **Iterate:** `--lite` on every fix round (~1-5 min). Its components are exactly
+  `file-size fmt clippy roborev-lints scoped-tests` (the `scripts/agent-gate.sh` `LITE_COMPONENTS` array),
+  where lite clippy is **per-package scoped** (#1844), not whole-workspace, and `scoped-tests` is
+  blast-radius (touched package `--lib` + the diff's new `--test` targets). It emits a distinct
+  `==== AGENT-GATE LITE SUMMARY ====` block that must NEVER be pasted as the full SUMMARY.
+- **Before merge:** the FULL `scripts/agent-gate.sh` runs **exactly once, inside the `flow-closer`
+  subagent** (#2084) — not in the lead, which never runs the full gate nor reads its stdout. Its
   `==== AGENT-GATE SUMMARY ====` (ending `RESULT: PASS`) is the only run that counts. `--lite` never
   replaces it. Under load the full gate may **queue for a #1825 slot** (prints `waiting for gate slot
-  (N in use)…` once) then run 15-20 min — use a long timeout; queued ≠ hung.
+  (N in use)…` once) then run 15-25 min — launch it with `run_in_background`/a long timeout; queued ≠ hung.
 - **`INCOMPLETE` is a liveness placeholder, not a verdict (#3041).** The startup sentinel puts
   `RESULT: INCOMPLETE (gate did not finish)` in the summary file before any component runs (a queued
   gate already has one), so any completion poll must be

--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -55,11 +55,15 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
    # does `gh auth switch --user "$project_account"` so the project-capable account is active (the EMU
    # account flip otherwise makes the board write fail and degrade to a label SILENTLY).
    gh issue edit <N> --add-assignee @me
-   # have_project=1: gh project item-edit ... --field Status --single-select-option-id <In Progress>
+   # have_project=1 → set the board Status. `--field` is NOT a gh flag (verified gh 2.87.3 offers only
+   # --field-id); all four IDs are required or the write fails:
+   gh project item-edit --id <item-id> --project-id <project-id> \
+     --field-id <status-field-id> --single-select-option-id <In-Progress-option-id>
    # (have_project=0 cannot occur here — Path A eligibility in step 2 already required a reachable board.
    #  Do NOT write a status:in-progress label — the board→label mirror (#2855) derives it from the
    #  board Status you just set; a hand-written board-derived label is reverted on the next mirror pass.)
-   scripts/flow/claim-heartbeat.sh beat <N>   # FIRST beat — establishes refs/heartbeats/<machine> (#2089)
+   # scripts/flow/*.sh blobs are mode 100644 (no +x) — ALWAYS invoke them via `bash`:
+   bash scripts/flow/claim-heartbeat.sh beat <N>   # FIRST beat — establishes refs/heartbeats/<machine> (#2089)
    ```
    If `claim.sh claim` reports `CLAIM LOST`, you did NOT win — do not create the worktree; take the next
    eligible item. All spec work happens in that worktree only after `CLAIM HELD`.

--- a/.claude/skills/flow-address/SKILL.md
+++ b/.claude/skills/flow-address/SKILL.md
@@ -54,5 +54,5 @@ Resolve them in the worktree and reply per thread.
 7. **Re-certify and re-arm merge-on-green (#2667).** The owner's comments are input, NOT a merge
    gate — unless a comment is an explicit `HOLD:` or raises a product/scope question. After addressing
    them, re-certify (lite + any diff-relevant targets; a full/delta gate per the gate contract if the
-   certified SHA changed), re-run `scripts/flow/premerge-assert.sh <pr> <certified-sha>`, then re-arm
+   certified SHA changed), re-run `bash scripts/flow/premerge-assert.sh <pr> <certified-sha>`, then re-arm
    `gh pr merge --auto --squash --delete-branch`.

--- a/.claude/skills/flow-address/SKILL.md
+++ b/.claude/skills/flow-address/SKILL.md
@@ -19,8 +19,12 @@ Resolve them in the worktree and reply per thread.
 2. **Gather the feedback.** `gh pr view "$PR" --comments` and the review threads
    (`gh api repos/:owner/:repo/pulls/$PR/comments`). List the asks.
 3. **Triage** each (receiving-code-review discipline — verify, don't perform agreement): a **mechanical**
-   fix is yours to make; a **genuine design/scope** question goes to the owner via `AskUserQuestion`
-   (one at a time). Push back with a reason where a suggestion is wrong, rather than complying blindly.
+   fix is yours to make; a **genuine design/scope** question goes to the owner. In an **attended** session
+   ask ONE at a time via `AskUserQuestion`. **`AskUserQuestion` is attended-sessions-ONLY (#2666)** — in an
+   **unattended** session it is FORBIDDEN (the worker would hang until the log-tail watchdog pages it):
+   instead **park** — post ONE structured question comment (options + recommendation + default), add the
+   `needs-decision` label, write a `blocked` marker with `reason: needs-decision`, and **EXIT**, releasing
+   the machine. Push back with a reason where a suggestion is wrong, rather than complying blindly.
 4. **Fix in the worktree** (`.claude/worktrees/issue-<N>-<slug>`), spawning `sstable-developer` for
    non-trivial code changes. Set the transient `addressing` sub-marker (a skill-managed marker the
    board→label mirror #2855 does not own); clear the sibling transient `spec-review` marker. Do NOT
@@ -28,9 +32,19 @@ Resolve them in the worktree and reply per thread.
    ```bash
    gh issue edit <N> --remove-label status:spec-review --add-label status:addressing
    ```
-5. **Re-verify** what the change touched: re-run `scripts/agent-gate.sh` (with `CQLITE_DATASETS_ROOT` at
-   the main repo) and re-run C (`spec-auditor`) if requirements/tests changed; roborev again if code
-   changed materially.
+5. **Re-verify what the change touched — `--lite` per address round, NEVER a full gate here.** The tiered
+   loop (#1821/#2087) gives each fix round `--lite`; the ONE full gate of record runs inside `flow-closer`
+   (#2084). Always use the mandatory summary-file redirect (#1175/#2079) — never stream raw gate stdout
+   into a persistent context:
+   ```bash
+   AGENT_GATE_SUMMARY_FILE=/tmp/lite-<N>.txt \
+     bash scripts/agent-gate.sh --lite > /tmp/lite-<N>.log 2>&1 < /dev/null
+   cat /tmp/lite-<N>.txt   # the LITE block (MODE: lite) is the ONLY gate text you retain
+   ```
+   Add any diff-relevant parity/integration `--test` target (run with `CQLITE_DATASETS_ROOT` pointed at
+   the main repo). Re-run C (`spec-auditor`) if requirements/tests changed; roborev again if code changed
+   materially. If the certified SHA moved, re-certification is the closer's full (or `--delta`) gate per
+   the gate contract — not a full gate in this skill.
 6. **Push + reply.** `git -C <worktree> push`, then reply on each `$PR` thread with what changed (commit
    ref), and clear the transient `addressing` sub-marker. The board stays `In Review` (PR still open),
    so the mirror keeps `status:in-review` — do NOT hand-write it:

--- a/.claude/skills/flow-board/SKILL.md
+++ b/.claude/skills/flow-board/SKILL.md
@@ -13,18 +13,27 @@ owner unless a set is pre-authorized for merge-on-green.
 > **GitHub API resilience:** `gh issue`/`gh pr`/`gh project` writes ride the **GraphQL** bucket, which
 > throttles **separately** from REST (each 5k pts/hr, independent per-bucket windows). If GraphQL is
 > exhausted, issue the **same write** via its `gh api` REST endpoint (e.g. comment →
-> `repos/OWNER/REPO/issues/N/comments`, merge → `repos/OWNER/REPO/pulls/N/merge`). Never stall the board
+> `repos/OWNER/REPO/issues/N/comments`, PR create → `repos/OWNER/REPO/pulls`). Never stall the board
 > sweep on one exhausted bucket. This is an **API-endpoint swap for the identical operation only** — it is
 > NOT a dispatch fallback: Path A (#1886) still holds, and selecting/claiming work from `status:*` labels
 > remains forbidden regardless of which API bucket is throttled.
+>
+> **MERGE HAS NO REST FALLBACK — `PUT repos/OWNER/REPO/pulls/N/merge` is FORBIDDEN.** That endpoint merges
+> **immediately**, bypassing the required-check wait that branch protection exists to enforce (#2433 —
+> GitHub-enforced merge gate, `enforce_admins=true`). The only sanctioned merge is
+> `gh pr merge --auto --squash --delete-branch`, which is **set-once/idempotent**: on a GraphQL throttle,
+> **sleep and retry the same `--auto` arm** (a re-arm on an already-armed PR is a safe no-op). Never
+> substitute REST for a merge, and never merge to "unblock" a throttled bucket.
 
 ## Project-or-labels detection (shared by all flow-* skills)
 
 The board is a **GitHub Project (v2)** with a `Status` single-select
 (`Backlog/Ready/In Progress/In Review/Done`). **The board `Status` field is the SOLE dispatch authority
-(Path A, issue #1886).** `status:*` labels are decorative/non-authoritative — they are NOT a dispatch
-fallback and MUST NOT be used to select or claim work. Reading/writing the board needs the `project`
-token scope. Detect it once:
+(Path A, issue #1886).** `status:*` labels are an **ENFORCED board-derived read-mirror** (#2855 —
+`project-board-sync.yml` is their sole writer, and a drift detector FAILs the run on disagreement): they
+are trustworthy for **cheap server-side candidate discovery** (narrowing), but they are **eventually
+consistent (≤30-min lag) and are NEVER the dispatch/claim authority** — MUST NOT be used to select or
+claim work. Reading/writing the board needs the `project` token scope. Detect it once:
 
 ```bash
 # project_owner / project_number identify the CQLite Delivery board (see setup-project-board.sh output).
@@ -47,10 +56,11 @@ fi
 ```
 
 **Path A: the board is the only authority — there is NO label dispatch fallback.** When `have_project=0`
-the board is unreachable, and because `status:*` labels are decorative they are NOT a safe substitute for
-selecting or claiming work (stale labels are exactly what caused the wrong-grabs). So on `have_project=0`:
+the board is unreachable, and because `status:*` labels are only a lagging board-derived mirror (#2855)
+they are NOT a safe substitute for selecting or claiming work (a stale mirror read is exactly what caused
+the wrong-grabs). So on `have_project=0`:
 **do not dispatch.** Print
-`🛑 board unreachable (active gh account lacks 'project' scope) — CANNOT dispatch; status:* labels are decorative, not the queue. Fix auth first.`
+`🛑 board unreachable (active gh account lacks 'project' scope) — CANNOT dispatch; status:* labels are a lagging read-mirror, not the queue. Fix auth first.`
 and STOP. You MAY still render a read-only status view from labels for the owner, but no claim, no
 selection, no "next thing" happens without the board. The one-time fix is the owner's:
 `gh auth refresh -s project` on the `$project_account` + run `test-data/scripts/setup-project-board.sh`.
@@ -77,7 +87,8 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
    ```bash
    gh issue list --state open --json number,title,labels,assignees,url --limit 100
    ```
-   Bucket by `status:*`; read the `P?` label as priority; show assignee from `assignees`. This view is
+   Bucket by `status:*` (the #2855 board-derived mirror — accurate to within its ≤30-min sweep lag, never
+   an authority); read the `P?` label as priority; show assignee from `assignees`. This view is
    informational only — no claim/selection happens without the board.
 3. **PRs + CI:**
    ```bash
@@ -93,11 +104,12 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
    ```
    Each `CLAIM: STATUS issue=<N>` line is an active claim (holder machine/actor + age); a matching
    legacy `issue-<N>-<slug>` branch, if any, is that claim's PR head (or an old-fleet branch-lock).
-3a. **Fleet view (issue #2089).** For each `In Progress` item, join the claim against the shared
+4a. **Fleet view (issue #2089).** For each `In Progress` item, join the claim against the shared
    heartbeat refs — a cheap origin git ref, never a GitHub API call — to show which machine holds it and
-   whether it is alive:
+   whether it is alive. (`scripts/flow/*.sh` blobs are mode `100644` — **always `bash`-prefixed**, never
+   executed directly.)
    ```bash
-   scripts/flow/claim-heartbeat.sh list
+   bash scripts/flow/claim-heartbeat.sh list
    ```
    This renders one line per machine: `machine  issue  ts  age` (e.g. `mbp-2  #2083  2026-07-06T18:03:11Z
    12m`). Join on `issue` against the board's `In Progress` rows and render alongside worktrees/claims:
@@ -109,14 +121,21 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
 5. **Reconcile + reap.** Cross-check the board against GitHub-side state:
    - **Drift:** a PR that is **merged** (or its issue closed) while the item is still `In Progress`
      (or `In Review`) → flag for transition to `Done` (the server-side automation should do this; if it
-     hasn't, set it: `gh project item-edit ... --field Status --single-select-option-id <Done>` or flip
-     the `status:*` label). Also flag an approved spec still `Ready`/`status:spec-review`.
+     hasn't, set the **board `Status` only** — never hand-flip a `status:*` label, which the #2855 mirror
+     owns and will revert):
+     ```bash
+     # `--field` is NOT a gh flag (verified gh 2.87.3 offers only --field-id). All four IDs are required:
+     gh project item-edit --id <item-id> --project-id <project-id> \
+       --field-id <status-field-id> --single-select-option-id <Done-option-id>
+     ```
+     The mirror follows on its next pass (Done → no board-derived label). Also flag an approved spec still
+     `Ready`/`status:spec-review`.
    - **Abandoned claim (reaper) — deterministic rule (issue #2089).** This REPLACES the old "no recent
      commits" guesswork, which false-positived on long no-commit implementation phases and
      false-negatived on a push-then-idle machine. The rule now has two conditions, both required:
      ```bash
-     # 1. heartbeat age for the claiming machine, from the fleet view (step 4a):
-     scripts/flow/claim-heartbeat.sh list   # age column for the issue's machine
+     # 1. heartbeat age for the claiming machine, from the fleet view (step 4a above):
+     bash scripts/flow/claim-heartbeat.sh list   # age column for the issue's machine
      # 2. no open PR for the issue:
      gh pr list --state open --search "issue-<N>" --json number --jq 'length'
      ```
@@ -130,7 +149,7 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
           heartbeat age, and that no PR was open.
        2. Clear the assignee.
        3. Set board `Status` → `Ready`.
-       4. Clear the dead machine's heartbeat ref: `scripts/flow/claim-heartbeat.sh clear <machine>`.
+       4. Clear the dead machine's heartbeat ref: `bash scripts/flow/claim-heartbeat.sh clear <machine>`.
        5. **NEVER delete the `issue-<N>-*` branch if it carries commits.** The branch (PR plumbing) is
           preserved on origin exactly as-is; picking the issue back up means resuming that branch
           (`git fetch` + continue), not starting a fresh `flow-activate`. Only a branch with zero commits
@@ -179,7 +198,10 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
    spec inline / show the PR), or — if nothing waits — offer a short **claim-aware** pick-list: only items
    whose **board `Status=Ready`** AND
    have **no** `refs/claims/issue-<N>` claim ref and **no** legacy `issue-<N>-*` branch on origin
-   (already-claimed items are not offered) to `flow-activate`, highest priority first. Selection is by **board `Status` only** — never by `status:ready` label.
+   (already-claimed items are not offered) to `flow-activate`, highest priority first. Step 1's
+   `status:ready` mirror read may have **narrowed** the candidate set, but the final selection is by
+   **board `Status` only** — the label is never the authority.
    **An empty board Ready column means no work is ready → say so and STOP.** Do NOT fall back to the
-   `status:*` label set to find more (near a release, Ready is *supposed* to drain to zero; dredging
-   labels is the exact wrong-grab bug). Don't dump the whole backlog; show the one, mention the rest.
+   `status:*` label set to find more — a mirror row the board does not confirm as `Ready` is stale by
+   definition (near a release, Ready is *supposed* to drain to zero; dredging labels is the exact
+   wrong-grab bug). Don't dump the whole backlog; show the one, mention the rest.

--- a/.claude/skills/flow-board/SKILL.md
+++ b/.claude/skills/flow-board/SKILL.md
@@ -11,19 +11,27 @@ and drive the **single** item waiting on them. Read-only render; the unblock ste
 owner unless a set is pre-authorized for merge-on-green.
 
 > **GitHub API resilience:** `gh issue`/`gh pr`/`gh project` writes ride the **GraphQL** bucket, which
-> throttles **separately** from REST (each 5k pts/hr, independent per-bucket windows). If GraphQL is
-> exhausted, issue the **same write** via its `gh api` REST endpoint (e.g. comment →
-> `repos/OWNER/REPO/issues/N/comments`, PR create → `repos/OWNER/REPO/pulls`). Never stall the board
-> sweep on one exhausted bucket. This is an **API-endpoint swap for the identical operation only** — it is
+> throttles **separately** from REST (each 5k pts/hr, independent per-bucket windows). GraphQL exhaustion
+> is **routine, not exotic** — fleet polling burns it (observed machine-wide on 2026-07-27). For a
+> **comment or a PR create, SWAP TO REST immediately; do NOT "retry" a hard-exhausted bucket** — retrying a
+> limit that resets on the hour is a hang, not a backoff:
+> ```bash
+> gh api -X POST repos/OWNER/REPO/issues/N/comments -F body=@/tmp/comment.md   # comment
+> gh api -X POST repos/OWNER/REPO/pulls -f title=… -f head=… -f base=main      # PR create
+> ```
+> Never stall the board sweep on one exhausted bucket. This is an **API-endpoint swap for the identical operation only** — it is
 > NOT a dispatch fallback: Path A (#1886) still holds, and selecting/claiming work from `status:*` labels
 > remains forbidden regardless of which API bucket is throttled.
 >
 > **MERGE HAS NO REST FALLBACK — `PUT repos/OWNER/REPO/pulls/N/merge` is FORBIDDEN.** That endpoint merges
 > **immediately**, bypassing the required-check wait that branch protection exists to enforce (#2433 —
 > GitHub-enforced merge gate, `enforce_admins=true`). The only sanctioned merge is
-> `gh pr merge --auto --squash --delete-branch`, which is **set-once/idempotent**: on a GraphQL throttle,
-> **sleep and retry the same `--auto` arm** (a re-arm on an already-armed PR is a safe no-op). Never
-> substitute REST for a merge, and never merge to "unblock" a throttled bucket.
+> `gh pr merge --auto --squash --delete-branch`. **Merge is the ONE operation with no REST swap** — the
+> REST fallback above is for *comments and PR creates*, never merges. `--auto` is
+> **set-once/idempotent**, so on a GraphQL throttle **sleep past the reset window and re-arm** (a re-arm on
+> an already-armed PR is a safe no-op) — and unlike a comment, a merge is never urgent enough to justify
+> bypassing the check wait. Never substitute REST for a merge, and never merge to "unblock" a throttled
+> bucket.
 
 ## Project-or-labels detection (shared by all flow-* skills)
 
@@ -76,10 +84,28 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
    This is discovery only — it narrows candidates. It is **eventually consistent** (≤30-min mirror lag)
    and is **NEVER the dispatch/claim authority**: you MUST still confirm each candidate against the
    live board `Status` in step 6 and acquire the claim ref before working it.
-2. **Render the board.** If `have_project=1`, render from the Project (the authoritative view):
+
+   **The rule, plainly: labels NARROW candidates; the filtered board read + the claim ref DECIDE.** The lag
+   is real and bites both ways — an owner-captured snapshot from 2026-07-27 had #3054 (skill format tables)
+   at board `In Progress` and #3055 (flow doctrine) at `In Review` while **both** still carried
+   `status:ready`, and two freshly-promoted `Ready` P0s (#3058, #3068) carried **no** label yet. So a lead
+   who trusts the label can report an issue as available when an agent is already three stages into it,
+   **and** miss a just-promoted P0 entirely. This is #2855 behaving as designed, not a bug.
+2. **Render the board — FILTER SERVER-SIDE, never page the whole board.** If `have_project=1`, render
+   from the Project (the authoritative view). On this 900+ item board an **unfiltered** `item-list`
+   truncates and silently under-reports a column (it cost the owner a mis-reported Ready column on
+   2026-07-27). The fix is a **server-side Projects filter**, not a different API: `--query` takes
+   Projects filter syntax (`assignee:octocat`, `-status:Done`; **quote multi-word option names**), and the
+   filtered read is exact, faster, and cheaper than the GraphQL `projectItems` path. Owner-verified on the
+   live board: `status:Ready` returned 10 items in ~1.6s.
    ```bash
-   gh project item-list "$project_number" --owner "$project_owner" --format json --limit 200
+   gh project item-list "$project_number" --owner "$project_owner" --query 'status:Ready'         --format json -L 100
+   gh project item-list "$project_number" --owner "$project_owner" --query 'status:"In Progress"' --format json -L 100
+   gh project item-list "$project_number" --owner "$project_owner" --query 'status:"In Review"'   --format json -L 100
    ```
+   Read each lifecycle column with its own filtered call. Do NOT switch to GraphQL `projectItems` to
+   "avoid truncation" — that was a wrong diagnosis; and do NOT raise `-L` on an unfiltered list instead of
+   filtering.
    Show, per item: `#N (slug)  P?  Status  assignee  PR/CI  worktree`. Group by `Status`
    (`Backlog → Ready → In Progress → In Review → Done`); each `In Progress` item MUST show its assignee
    (the claiming session/owner). If `have_project=0`, you may render a **read-only** status view from
@@ -100,8 +126,17 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
    fixed-name **claim refs** are now THE lock (#2665); the `issue-<N>-<slug>` branch is only PR plumbing:
    ```bash
    bash scripts/flow/claim.sh status               # active claim refs: refs/claims/issue-<N> + holder + age
+   git ls-remote origin 'refs/claims/*'            # raw view of the per-issue lock namespace
    git ls-remote --heads origin "issue-*"          # legacy branch-locks (older workers) + PR heads
    ```
+   **Two DISTINCT ref namespaces — never conflate them, or you will double-claim:**
+   - `refs/claims/issue-<N>` — the **per-issue lock** (`claim.sh`, #2665). THE arbiter of who owns an issue.
+   - `refs/machine-claims/<machine>` — the **supervisor-authored machine claim** (#2655/#2499), stamped by
+     `worker-supervisor.sh` via `claim-heartbeat.sh stamp`. It records which *machine* is busy and feeds the
+     CI reaper's `should-reap` predicate. It is **NOT** an issue lock, and its presence/absence says nothing
+     about whether a given issue is claimable.
+   A `refs/machine-claims/` entry read as a per-issue claim (or vice versa) produces exactly the
+   double-claim the ref lock exists to prevent.
    Each `CLAIM: STATUS issue=<N>` line is an active claim (holder machine/actor + age); a matching
    legacy `issue-<N>-<slug>` branch, if any, is that claim's PR head (or an old-fleet branch-lock).
 4a. **Fleet view (issue #2089).** For each `In Progress` item, join the claim against the shared

--- a/.claude/skills/flow-finalize/SKILL.md
+++ b/.claude/skills/flow-finalize/SKILL.md
@@ -76,8 +76,10 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
    phone/web — no `flow-*` run needed); if it hasn't, set it yourself:
    ```bash
    # Run the flow-board detection snippet first (it switches to the project-capable account — the EMU
-   # flip otherwise makes this write fail silently), then set the board Status only:
-   gh project item-edit <item-id> --field Status --single-select-option-id <Done>   # when have_project=1
+   # flip otherwise makes this write fail silently), then set the board Status only.
+   # `--field` is NOT a gh flag (verified gh 2.87.3 offers only --field-id); all four IDs are required:
+   gh project item-edit --id <item-id> --project-id <project-id> \
+     --field-id <status-field-id> --single-select-option-id <Done-option-id>   # when have_project=1
    ```
    Do NOT write any `status:*` label here. Done → no board-derived label (board→label mirror #2855:
    Backlog/Done carry none), and the mirror only reconciles OPEN issues, so a leftover label on the
@@ -96,7 +98,8 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
    ```bash
    # --confirm-unmerged: a squash-merge leaves the branch tip out of `main`; step 1
    # already verified PR state=MERGED, which IS the authority the flag stands for.
-   scripts/flow/finalize-cleanup.sh --issue <N> --merged-branch <merged-branch> --confirm-unmerged
+   # `scripts/flow/*.sh` blobs are mode 100644 (no +x) — ALWAYS invoke them via `bash`.
+   bash scripts/flow/finalize-cleanup.sh --issue <N> --merged-branch <merged-branch> --confirm-unmerged
    # Add --dry-run first to preview. Exit codes: 0 ok · 2 multi-lock · 3 dirty/unpushed · 4 unmerged tip.
    ```
    On a non-zero exit the script changed nothing and surfaced why — resolve the 1:1:1:1 violation or the
@@ -112,7 +115,7 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
    Then clear this machine's claim heartbeat so it doesn't linger on origin until `flow-board`'s 4h reap
    window (issue #2089):
    ```bash
-   scripts/flow/claim-heartbeat.sh clear "$(hostname -s)"
+   bash scripts/flow/claim-heartbeat.sh clear "$(hostname -s)"
    ```
 7. **Close the issue** with a traceable comment referencing the merged PR + commit (only if its
    acceptance criteria are fully met — never close an epic):

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -42,9 +42,13 @@ never gate stdout or review churn.
    Set the Project `Status=In Progress` too. **Run the `flow-board` detection snippet FIRST** — it does
    `gh auth switch --user "$project_account"` so the project-capable account is active (the EMU flip
    otherwise makes `gh project item-edit` fail and the board write degrade to labels SILENTLY). If
-   `have_project=1`, `gh project item-edit ... Status=In Progress`; if `have_project=0`, the label above
-   is the fallback AND you MUST print the loud `⚠️ board unavailable …` warning so the owner knows the
-   board will not reflect this claim.
+   `have_project=1`, set the board Status (`--field` is NOT a gh flag — only `--field-id`):
+   ```bash
+   gh project item-edit --id <item-id> --project-id <project-id> \
+     --field-id <status-field-id> --single-select-option-id <In-Progress-option-id>
+   ```
+   If `have_project=0`, the `--remove-label` cleanup above is all you can do AND you MUST print the loud
+   `⚠️ board unavailable …` warning so the owner knows the board will not reflect this claim.
 2. **Ensure the worktree exists — and that you hold the claim.** Design-driven issues already hold the
    claim ref + pushed branch (acquired in `flow-activate`); reuse them. Oracle-driven issues skip
    `flow-activate`, so they run the claim protocol (D2) HERE: `claim.sh` is the lock (the slugless
@@ -56,7 +60,7 @@ never gate stdout or review churn.
    if git -C <repo-root> worktree list | grep -q "$wt"; then
      # design-driven: claim ref + worktree already exist (from flow-activate).
      # Implementation starting IS a stage transition — refresh the heartbeat (#2089).
-     scripts/flow/claim-heartbeat.sh beat <N>
+     bash scripts/flow/claim-heartbeat.sh beat <N>
    else
      # oracle-driven: acquire the claim ref now. claim.sh does the atomic push +
      # re-read; a UNIQUE root commit means a different-slug or identical-base
@@ -82,7 +86,7 @@ never gate stdout or review churn.
      git -C <repo-root> worktree add "$wt" -b "issue-<N>-<slug>" origin/main
      git -C "$wt" push -u origin "issue-<N>-<slug>"   # PR head — NOT the lock
      gh issue edit <N> --add-assignee @me
-     scripts/flow/claim-heartbeat.sh beat <N>   # FIRST beat — establishes the claim heartbeat (#2089)
+     bash scripts/flow/claim-heartbeat.sh beat <N>   # FIRST beat — establishes the claim heartbeat (#2089)
    fi
    ```
 3. **Test data.** Worktrees lack the gitignored `Data.db` binaries — run the gate and tests with
@@ -101,7 +105,7 @@ never gate stdout or review churn.
       gate stdout into a persistent context):
       ```bash
       AGENT_GATE_SUMMARY_FILE=/tmp/lite-<N>.txt \
-        scripts/agent-gate.sh --lite > lite-<N>.log 2>&1 < /dev/null
+        bash scripts/agent-gate.sh --lite > lite-<N>.log 2>&1 < /dev/null
       cat /tmp/lite-<N>.txt   # the complete LITE block (default recovery: .agent-gate-lite-summary.txt)
       ```
       **Reader contract (#2874):** the exit code is primary, and before trusting the block's
@@ -112,15 +116,20 @@ never gate stdout or review churn.
       `RESULT: INCOMPLETE (gate did not finish)` at launch, so if you poll rather than wait for exit,
       use `grep -qE 'RESULT: (PASS|FAIL)'` — a bare `grep -q` on the bare `RESULT:` token matches that **liveness
       placeholder** and would read a just-launched run as a finished one.
-      Lite runs fmt + file-size + FULL-workspace clippy + blast-radius-scoped tests (~1-5 min). It is the
+      Lite's components are exactly `file-size fmt clippy roborev-lints scoped-tests` (the
+      `scripts/agent-gate.sh` `LITE_COMPONENTS` array), where clippy is **per-package scoped** (#1844) and
+      `scoped-tests` is blast-radius (touched package `--lib` + the diff's new `--test` targets). It is the
       FAST ITERATION gate, NOT the gate of record; its distinct `MODE: lite` block must NEVER be pasted as
       the full SUMMARY.
    3. If lite FAILs, fix and go to step 2. Repeat until lite is PASS and the change is complete.
    Do NOT run the full `scripts/agent-gate.sh` during the fix-round loop — that is the `flow-closer`'s single
    gate of record (step 7).
 5. **Review-first — DEFAULT, BEFORE the first full gate (issues #2086/#2087/#2088).** On the **lite-green**
-   diff, run `rust-reviewer` (explicit `model: opus`) **and** roborev
-   (`/roborev-review-branch --base origin/main`, machine-configured agent) NOW — before any full gate — so
+   diff, run `rust-reviewer` (explicit `model: opus`) **and** roborev NOW — there is **no
+   `/roborev-review-branch` slash command**; run the CLI and pass **BOTH** `--agent` and `--model` (#2433,
+   or codex hard-400s on the config-pinned `opus`):
+   `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`
+   — before any full gate — so
    the ONE full gate certifies already-reviewed code. **Skip review-first ONLY for a genuinely mechanical
    diff:** no `pub`-item change AND a single call site AND no new surface (the narrow inverse of the old
    conditional). When in doubt, review.
@@ -143,18 +152,23 @@ never gate stdout or review churn.
    ```bash
    git -C <worktree> push -u origin issue-<N>-<slug>
    gh pr create --base main --head issue-<N>-<slug> --fill   # ensure body has "Closes #<N>"
-   scripts/flow/claim-heartbeat.sh beat <N>                  # PR-open stage transition
+   bash scripts/flow/claim-heartbeat.sh beat <N>             # PR-open stage transition
    # Board → In Review fires via GitHub's "Pull request linked to issue" built-in. Belt-and-suspenders:
-   # run the flow-board detection snippet first (switches to the project-capable account), then
-   # gh project item-edit ... Status=In Review when have_project=1. Do NOT write a status:in-review
+   # run the flow-board detection snippet first (switches to the project-capable account), then set the
+   # board Status when have_project=1 (`--field` is NOT a gh flag — only --field-id):
+   #   gh project item-edit --id <item-id> --project-id <project-id> \
+   #     --field-id <status-field-id> --single-select-option-id <In-Review-option-id>
+   # Do NOT write a status:in-review
    # label — the board→label mirror (#2855) derives it from the board Status; if have_project=0 print
    # the loud ⚠️ board-unavailable warning so the owner knows the board (and thus the mirror) is stale.
    ```
    **GitHub API resilience:** `gh pr create` / `gh issue comment` ride the **GraphQL** bucket, which
    throttles **separately** from REST (each 5k pts/hr, independent per-bucket windows). If GraphQL is
    exhausted, fall back to `gh api` REST: PR create → `repos/OWNER/REPO/pulls`, comment →
-   `repos/OWNER/REPO/issues/N/comments`, merge → `repos/OWNER/REPO/pulls/N/merge`. Never stall a pipeline
-   step on a single exhausted bucket.
+   `repos/OWNER/REPO/issues/N/comments`. Never stall a pipeline step on a single exhausted bucket.
+   **MERGE HAS NO REST FALLBACK — `PUT repos/OWNER/REPO/pulls/N/merge` is FORBIDDEN**: it merges
+   immediately, bypassing the required-check wait branch protection exists to enforce (#2433,
+   `enforce_admins=true`). `gh pr merge --auto` is set-once/idempotent — on a throttle, sleep and retry it.
 7. **Hand the endgame to `flow-closer` — the disposable per-issue closer (issue #2084).** Spawn
    `flow-closer` (explicit `model: opus`) once, passing `#N`, the worktree/branch, routing, the OpenSpec
    `<slug>` (design only), the open PR number, and `CQLITE_DATASETS_ROOT`. It owns the terminal stages in

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -13,6 +13,14 @@ Implement tasks from an OpenSpec change.
 
 **Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
+> **`AskUserQuestion` is ATTENDED-SESSIONS-ONLY (#2666).** Every prompt below assumes a human is watching.
+> In an **unattended** session (a worker/supervisor run) `AskUserQuestion` is FORBIDDEN — the session hangs
+> until the log-tail watchdog pages it. Unattended, **park** instead: post ONE structured question comment
+> on the issue (options + recommendation + default), add the `needs-decision` label, write a `blocked`
+> marker with `reason: needs-decision` (or `reason: seam1-approval` at Seam 1), and **EXIT**, releasing the
+> machine. Resume only on a strictly-newer owner reply (a durable `resume-dont-ask` label is a standing
+> Seam-1 seal that stands in for the answer).
+
 **Steps**
 
 1. **Select the change**
@@ -20,7 +28,7 @@ Implement tasks from an OpenSpec change.
    If a name is provided, use it. Otherwise:
    - Infer from conversation context if the user mentioned a change
    - Auto-select if only one active change exists
-   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** (attended only — unattended, PARK per the note above) to let the user select
 
    Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
 

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -13,11 +13,19 @@ Archive a completed change in the experimental workflow.
 
 **Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
+> **`AskUserQuestion` is ATTENDED-SESSIONS-ONLY (#2666).** Every prompt below assumes a human is watching.
+> In an **unattended** session (a worker/supervisor run) `AskUserQuestion` is FORBIDDEN — the session hangs
+> until the log-tail watchdog pages it. Unattended, **park** instead: post ONE structured question comment
+> on the issue (options + recommendation + default), add the `needs-decision` label, write a `blocked`
+> marker with `reason: needs-decision`, and **EXIT**, releasing the machine. Resume only on a strictly-newer
+> owner reply (a durable `resume-dont-ask` label is a standing seal that stands in for the answer).
+
 **Steps**
 
 1. **If no change name provided, prompt for selection**
 
-   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** (attended only —
+   unattended, PARK per the note above) to let the user select.
 
    Show only active changes (not already archived).
    Include the schema used for each change if available.
@@ -37,7 +45,7 @@ Archive a completed change in the experimental workflow.
 
    **If any artifacts are not `done`:**
    - Display warning listing incomplete artifacts
-   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Use **AskUserQuestion tool** to confirm user wants to proceed (attended only — unattended, PARK per the note at the top)
    - Proceed if user confirms
 
 3. **Check task completion status**
@@ -48,7 +56,7 @@ Archive a completed change in the experimental workflow.
 
    **If incomplete tasks found:**
    - Display warning showing count of incomplete tasks
-   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Use **AskUserQuestion tool** to confirm user wants to proceed (attended only — unattended, PARK per the note at the top)
    - Proceed if user confirms
 
    **If no tasks file exists:** Proceed without task-related warning.
@@ -68,22 +76,21 @@ Archive a completed change in the experimental workflow.
 
    If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
-5. **Perform the archive**
-
-   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
-   ```bash
-   mkdir -p "<planningHome.changesDir>/archive"
-   ```
-
-   Generate target name using current date: `YYYY-MM-DD-<change-name>`
-
-   **Check if target already exists:**
-   - If yes: Fail with error, suggest renaming existing archive or using different date
-   - If no: Move `changeRoot` to the archive directory
+5. **Perform the archive — via the `openspec` CLI, NEVER a hand-rolled `mkdir`/`mv`**
 
    ```bash
-   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   openspec archive "<name>" --yes
    ```
+
+   The CLI is the only sanctioned archive path: besides moving `changeRoot` under
+   `<planningHome.changesDir>/archive/YYYY-MM-DD-<name>`, it **syncs the delta spec into
+   `openspec/specs/<capability>/spec.md`** — which is exactly what CQLite's definition of done requires
+   (`flow-finalize` step 3 prescribes the same command). A bare `mkdir -p archive` + `mv` moves the
+   directory but **silently skips the spec sync**, leaving the live capability spec stale while the change
+   looks archived. Use `--skip-specs` only for a doc/infra change with no capability delta.
+
+   If the CLI reports the target archive name already exists, resolve it as the CLI directs (rename the
+   existing archive, or re-run on a different date) — do not work around it with `mv`.
 
 6. **Display summary**
 
@@ -108,6 +115,10 @@ All artifacts complete. All tasks complete.
 ```
 
 **Guardrails**
+- **Archive only via `openspec archive <name> --yes`** — never `mkdir -p archive` + `mv`, which skips the
+  delta-spec sync into `openspec/specs/<capability>/spec.md` that done-ness depends on.
+- **`AskUserQuestion` is attended-only (#2666)** — unattended, PARK (question comment + `needs-decision`
+  label + `blocked` marker + EXIT) instead of prompting.
 - Always prompt for change selection if not provided
 - Use artifact graph (openspec status --json) for completion checking
 - Don't block archive on warnings - just inform and confirm

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -22,11 +22,19 @@ When ready to implement, run /opsx:apply
 
 **Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
 
+> **`AskUserQuestion` is ATTENDED-SESSIONS-ONLY (#2666).** Every prompt below assumes a human is watching.
+> In an **unattended** session (a worker/supervisor run) `AskUserQuestion` is FORBIDDEN — the session hangs
+> until the log-tail watchdog pages it. Unattended, **park** instead: post ONE structured question comment
+> on the issue (options + recommendation + default), add the `needs-decision` label, write a `blocked`
+> marker with `reason: needs-decision` (or `reason: seam1-approval` at Seam 1), and **EXIT**, releasing the
+> machine. Resume only on a strictly-newer owner reply (a durable `resume-dont-ask` label is a standing
+> Seam-1 seal that stands in for the answer).
+
 **Steps**
 
 1. **If no clear input provided, ask what they want to build**
 
-   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   Use the **AskUserQuestion tool** (open-ended, no preset options; attended only — unattended, PARK per the note above) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
    From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
@@ -77,7 +85,7 @@ When ready to implement, run /opsx:apply
       - Stop when all `applyRequires` artifacts are done
 
    c. **If an artifact requires user input** (unclear context):
-      - Use **AskUserQuestion tool** to clarify
+      - Use **AskUserQuestion tool** to clarify (attended only — unattended, PARK per the note above)
       - Then continue with creation
 
 5. **Show final status**

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -15,11 +15,19 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
 **Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
+> **`AskUserQuestion` is ATTENDED-SESSIONS-ONLY (#2666).** Every prompt below assumes a human is watching.
+> In an **unattended** session (a worker/supervisor run) `AskUserQuestion` is FORBIDDEN — the session hangs
+> until the log-tail watchdog pages it. Unattended, **park** instead: post ONE structured question comment
+> on the issue (options + recommendation + default), add the `needs-decision` label, write a `blocked`
+> marker with `reason: needs-decision` (or `reason: seam1-approval` at Seam 1), and **EXIT**, releasing the
+> machine. Resume only on a strictly-newer owner reply (a durable `resume-dont-ask` label is a standing
+> Seam-1 seal that stands in for the answer).
+
 **Steps**
 
 1. **If no change name provided, prompt for selection**
 
-   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** (attended only — unattended, PARK per the note above) to let the user select.
 
    Show changes that have delta specs (under `specs/` directory).
 

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -10,6 +10,15 @@ argument-hint: [optional label, milestone, or epic number]
 Produce a prioritized view of the backlog. This skill is READ-ONLY — do not edit,
 comment on, assign, or close anything.
 
+> **ADVISORY ONLY — NOT a claim or dispatch source (Path A, #1886).** This skill ranks from `gh issue list`
+> labels/milestones, which is a *lagging* view: the **GitHub Project `Status` field is the sole dispatch
+> authority**, and `status:*` labels are only its ≤30-min-lagging board-derived mirror (#2855). Nothing
+> here authorizes picking up work. The "START NEXT" line is a **recommendation for the owner**, not a
+> dispatch instruction: actually starting an item goes through `flow-board`/`flow-activate` — a fresh board
+> read confirming `Status=Ready` **plus** acquiring the claim ref
+> (`bash scripts/flow/claim.sh claim <N>`). Selecting work from a label ranking is the exact wrong-grab
+> pattern Path A exists to prevent.
+
 ## 1. Gather
 Use `gh` to list open work. If $ARGUMENTS names a label, milestone, or epic, scope to
 it; otherwise cover all open issues.
@@ -30,3 +39,7 @@ Flag anything blocked (and by what) and anything stale that's silently stuck.
 Output a ranked, skimmable table (rank, #, title, impact/effort, why) and a short
 "START NEXT" line — the single epic or issue you'd pick up now and why. Assume I may be
 reading this on my phone.
+
+Label the "START NEXT" line **advisory** and note that it must be confirmed against the board
+(`Status=Ready`) and claimed via `bash scripts/flow/claim.sh claim <N>` before any work begins — this
+ranking is not the queue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,7 +530,11 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   Branch protection enforces the `required` check for admins too (`enforce_admins`), so `--auto` can
   never land against an unchecked head and bypass is impossible; a known-flake red gets
   `gh run rerun --failed`, never a bypass. This enforcement is load-bearing: if branch-protection
-  settings change, this doc governs catching it (#2433). **What a green `required` now covers
+  settings change, this doc governs catching it (#2433). **`gh pr merge --auto` is the ONLY sanctioned
+  merge — REST `PUT repos/OWNER/REPO/pulls/N/merge` is ABSOLUTELY FORBIDDEN (#3055)**: it merges
+  *immediately*, bypassing the required-check wait branch protection exists to enforce, so it is never a
+  GraphQL-throttle fallback. `--auto` is set-once/idempotent — on a throttle, **sleep and retry the same
+  arm**. (The comment-post and PR-create REST fallbacks remain fine; only merge is forbidden.) **What a green `required` now covers
   (#2910)**: `required` is no longer only its own steps — it also polls the PR head's sibling check
   runs and **fails closed** on any tier declared in `.github/ci-gating-tiers.yml` that is failed,
   still pending at the aggregation deadline (60 min default), or **absent** (absence is an error,


### PR DESCRIPTION
Closes #3055

Corrects all 17 verified defects in the `.claude/` **delivery control plane** — the surfaces an agent reads to decide how to claim, gate, review, and merge. Every defect either silently failed a board/claim write, routed an agent *around* a safety gate, or contradicted doctrine the same file stated correctly a few lines away.

**Routing: doc/instruction-surface only. No design latitude, no oracle → SKIPPED OpenSpec** (no `flow-activate`), per the issue body.

All line references were verified against `origin/main` (`git show origin/main:<path>`), not the ~68-commit-behind root working tree.

## Defects fixed, per file

| File | # fixed | What |
|------|---------|------|
| `.claude/skills/flow-board/SKILL.md` | 5 | REST-merge fallback **removed** (1); `gh project item-edit --field-id` shape (4); `bash`-prefixed heartbeat calls (5); drift remediation sets board Status only (9); mirror semantics (10); step `3a`→`4a` + reaper cross-ref (17) |
| `.claude/agents/flow-lead.md` | 6 | claim **ref** not branch as lock, 3 sites (2); no hand-written `status:ready` in groom (8); mirror = enforced read-mirror for discovery, never authority (10); no `ScheduleWakeup` on own CI (11); real roborev CLI with **both** `--agent` + `--model` (12); `legacy-heuristics` not `experimental` (13); + `AskUserQuestion` attended-only (3) |
| `.claude/skills/ci-cd-validation/{SKILL,validation-checklist}.md` | 3 | `AGENT_GATE_SUMMARY_FILE=` on **every** invocation incl. `--only` (6); closer (not lead) owns the ONE gate + final roborev (7); exact `LITE_COMPONENTS` = `file-size fmt clippy roborev-lints scoped-tests`, clippy **per-package** scoped (16) |
| `.claude/skills/flow-address/SKILL.md` | 2 | `AskUserQuestion` attended-only + park (3); `--lite` **per round** with redirect, not a FULL gate (6) |
| `.claude/skills/openspec-{propose,apply-change,archive-change,sync-specs}/SKILL.md` | 2 | `AskUserQuestion` attended-only + #2666 park protocol at all 8 sites (3); archive via `openspec archive <slug> --yes` — the hand-rolled `mkdir`+`mv` silently skipped the delta-spec sync into `openspec/specs/<capability>/spec.md` (14) |
| `.claude/skills/{flow-finalize,flow-activate}/SKILL.md` | 2 | `--field-id` board-write shape (4); `bash`-prefixed `finalize-cleanup.sh`/`claim-heartbeat.sh` (5) |
| `.claude/skills/prioritize/SKILL.md` | 1 | marked **advisory-only** — a label ranking is never a claim/dispatch source; "START NEXT" must be board-confirmed + claim-ref-acquired (15) |
| `.claude/skills/flow-implement/SKILL.md` | — | *not in the issue's list but carried the same classes*: REST-merge fallback, `/roborev-review-branch`, `--field` board writes, bare heartbeat calls, stale `--lite` description |
| `CLAUDE.md` | — | AC 11 — codified that REST `pulls/N/merge` is ABSOLUTELY FORBIDDEN and `gh pr merge --auto` (set-once/idempotent; sleep-and-retry on throttle) is the only sanctioned merge |

Untouched as verified-clean: `pm-status/`, `start-epic/` (proper deprecated pointers).

## Judgment call: `bash`-prefix, NOT `+x`

**Chose `bash`-prefixing every call site** over `git update-index --chmod=+x` on the three scripts, and applied it consistently (`claim.sh`, `claim-heartbeat.sh`, `finalize-cleanup.sh`, `premerge-assert.sh`).

Why: (a) it keeps this a **markdown-only diff** — no mode-bit change to any executable, so the compiled binary and every script's on-disk contract are provably untouched, which makes the gate waiver below sound; (b) `bash`-prefixing was **already the dominant existing convention** — nearly every `claim.sh` call site on `origin/main` is `bash`-prefixed, so this converges the surface rather than splitting it; (c) it is robust to the mode bit being lost again (the #1190 retro records `finalize-cleanup.sh` losing `+x` once already), whereas `+x` re-breaks silently the next time a checkout/rsync drops it. `+x` is cleaner in the abstract; `bash` is the lower-risk fix that also survives the failure mode that produced the bug.

Doc surfaces now state the mode explicitly (`scripts/flow/*.sh` blobs are mode `100644` — always invoke via `bash`) so the reason is discoverable, not folklore.

## Doc-lint: DEFERRED → #3067

AC 10's `doc-lint` gate component is filed as **#3067** rather than landed here, for two reasons:
1. It is **real shell code**, not markdown — it would require `rust-reviewer` + roborev and would void this PR's markdown-only gate waiver.
2. It would **immediately red the gate for the two sibling doc lanes** (#3054 sstable-parsing + cql-type-system, #3056 agent defs + remaining skills), whose files still carry the same classes. #3067 lands the lint *after* all three lanes merge, so its first run is against an already-clean tree — and its AC requires exactly that.

#3067 enumerates all 7 lint classes (REST-merge, `--field` misuse, missing gate redirect, non-`bash` `scripts/flow` calls, stale `--lite` list parsed from `LITE_COMPONENTS`, dead `git cat-file -e` paths, non-expanding `env VAR=~`) with the `injection-lint-allow` allowlist precedent.

## Verification (the issue's `rg`-checkable ACs)

- **AC2** `rg 'pulls/[^ ]*/merge' .claude/` → 2 hits, **both explicit prohibitions** (`flow-board:21`, `flow-implement:165`). No surface recommends REST merge.
- **AC3** `rg -- '--field ' .claude/` → **0 matches**.
- **AC4** every `scripts/flow/*.sh` **invocation** in the in-scope files is `bash`-prefixed (the 2 remaining unprefixed hits in `flow-board` are prose references to the script's *header* as a doc source, not invocations).
- **AC5** every runnable `scripts/agent-gate.sh` line carries `AGENT_GATE_SUMMARY_FILE=`.
- **AC6** all 8 `AskUserQuestion` sites carry the attended-only + park-instead caveat.
- **AC7** `flow-address` prescribes `--lite` per fix round.
- **AC8** no hand-written board-derived `status:*`; "decorative" is gone everywhere; no slug-named branch is called the lock.
- **AC9** the `--lite` component list matches `LITE_COMPONENTS` exactly.

## Out-of-scope observations (NOT fixed here — other lanes own these files)

`.claude/agents/flow-closer.md` carries three of the same defects — `/roborev-review-branch` (`:110`), bare `scripts/flow/claim-heartbeat.sh` at `:70,:81,:164`, and a gate invocation missing the redirect at `:83`. `.claude/agents/sstable-developer.md:54,68,96` and `.claude/agents/test-validator.md:64` describe `--lite` clippy as "workspace clippy" and invoke the gate without the redirect. `.claude/commands/worker.md` has a bare `scripts/flow` reference. **#3056 owns the agent definitions** — flagging, not editing, per lane discipline.

## Gate

`--lite` PASS on all five components. Diff is **markdown-only** (`.claude/**/*.md` + `CLAUDE.md`) — it cannot change the compiled binary, so any full-gate test failure is pre-existing on `main` or a flake, per the gate contract; no source was touched to green anything.

## Review

Pure-markdown diff → roborev returns "No code changes were included", which is indistinguishable from an outage (#2964). Recorded as **N/A**, deliberately **not banked as clean**. `rust-reviewer` was likewise not applicable (no Rust). Had the doc-lint landed here, both would have been mandatory — that is part of why it went to #3067.