### PR TITLE
docs(#3054): correct 13 wrong format tables in the auto-loaded agent skills + mechanize the drift guard

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -17,7 +17,7 @@ plus general-purpose Rust guidance.
 **Files:**
 - `SKILL.md` - Main skill guidance
 - `cassandra5-format-reference.md` - Complete row format specification
-- `compression-formats.md` - LZ4, Snappy, Deflate formats
+- `compression-formats.md` - the four compression algorithms plus Noop: LZ4, Snappy, Deflate, Zstd, Noop (`cqlite-core/src/storage/sstable/compression_info.rs:43-48`)
 
 ---
 

--- a/.claude/skills/cql-type-system/SKILL.md
+++ b/.claude/skills/cql-type-system/SKILL.md
@@ -45,8 +45,12 @@ Never try to infer type from data alone - always use schema.
 - `bigint` - 8 bytes signed, big-endian
 - `float` - 4 bytes IEEE 754
 - `double` - 8 bytes IEEE 754
-- `date` - 4 bytes (days since epoch)
-- `time` - 8 bytes (nanoseconds since midnight)
+- `date` - 4 bytes BE unsigned, days since epoch **biased by `Integer.MIN_VALUE`**
+  (epoch day 0 is stored as `0x80000000`) — un-bias with
+  `stored.wrapping_add(i32::MIN as u32) as i32`; a plain `u32` read is wrong by 2^31 days.
+  Citations: `row_decoder/cell_value_scalar.rs:329-333`; cassandra-5.0.8
+  `serializers/SimpleDateSerializer.java:36-37,110,113-115`.
+- `time` - 8 bytes signed BE (nanoseconds since midnight; no bias)
 
 #### Variable-Size Primitives
 - `text`/`varchar` - UTF-8 encoded string
@@ -58,20 +62,52 @@ Never try to infer type from data alone - always use schema.
 - `inet` - 4 bytes (IPv4) or 16 bytes (IPv6)
 - `varint` - variable-length big integer
 - `decimal` - scale (4 bytes) + unscaled varint
-- `duration` - months, days, nanoseconds (3 VInts)
+- `duration` - months, days, nanoseconds as 3 **ZigZag-SIGNED** VInts — the ONLY signed
+  VInts in `Data.db`, wherever a duration payload occurs (including nested in a
+  collection/tuple/UDT). Decoding them unsigned makes every negative duration wrong.
+  Citations: `appendix-b-encodings-cheat-sheet.md:63-65,92-97`;
+  `DurationSerializer.java:49-51`.
 - `timestamp` - 8 bytes (milliseconds since Unix epoch)
 
 ### 2. Collection Types
 
 See [collections-and-udts.md](collections-and-udts.md) for detailed format.
 
-**Collection Format:**
+> ### ⚠️ There are TWO collection encodings — pick by frozen-ness, never by byte pattern
+> Frozen and non-frozen collections do NOT share a wire format. Assuming the frozen layout
+> for a non-frozen column (or vice versa) mis-frames every element.
+
+**FROZEN collection** (`frozen<list<int>>`, and any collection nested inside another
+collection/tuple/UDT) — one opaque cell, **fixed 4-byte big-endian `i32`** count and
+element lengths (NOT VInts):
 ```
-[4 bytes: element_count (big-endian)]
+[i32 BE: element_count]
 [for each element:]
-    [4 bytes: element_size (big-endian)]
+    [i32 BE: element_len]   // -1 = null
     [bytes: element_data]
 ```
+> **Citation**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/frozen.rs:21`
+> (count), `:98,279,370` (element/key lengths). Guide:
+> `appendix-b-encodings-cheat-sheet.md:537-539`. Cassandra:
+> `CollectionSerializer.java:67-92`, `TupleType.java:341-364`.
+
+**NON-FROZEN collection** (the default `list<int>`, `set<T>`, `map<K,V>`) — a *set of
+cells*, framed with **unsigned VInts**:
+```
+[if the row sets ROW_HAS_COMPLEX_DELETION (0x40): complex deletion, 2 unsigned VInt deltas]
+[unsigned VInt: cell_count]
+[for each cell:]
+    [1 byte: cell flags]
+    [conditional timestamp / local_deletion_time / ttl unsigned-VInt deltas]
+    [unsigned VInt: path_len][path bytes]     // element key / path
+    [unsigned VInt: value_len][value bytes]   // omitted when IS_DELETED or HAS_EMPTY_VALUE
+```
+> **Citation**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs:332`
+> (`cell_count` via `parse_vuint`), `:1089` (path length), `:1136` (value length),
+> `:279-300` (complex deletion). Guide: `appendix-b-encodings-cheat-sheet.md:530-536` — a
+> non-frozen collection cell length-prefixes BOTH path and value with an unsigned VInt,
+> **fixed-width element types included** (the `valueLengthIfFixed()` raw-bytes shortcut is
+> a simple-cell rule only, `AbstractType.java:538-543`).
 
 **Types:**
 - `list<T>` - Ordered, allows duplicates

--- a/.claude/skills/cql-type-system/collections-and-udts.md
+++ b/.claude/skills/cql-type-system/collections-and-udts.md
@@ -135,7 +135,7 @@ CREATE TABLE t (
 );
 ```
 
-### Nested Collection Wire Format
+### Nested Collection Wire Format (FROZEN inner lists)
 ```
 CQL: list<frozen<list<int>>>
 Value: [[1, 2], [3, 4, 5]]
@@ -144,7 +144,7 @@ Wire format:
 [0x00, 0x00, 0x00, 0x02]  // outer count = 2
 
 // First nested list [1, 2]
-[0x00, 0x00, 0x00, 0x18]  // size of entire frozen list
+[0x00, 0x00, 0x00, 0x14]  // size of entire frozen list = 20 (see derivation below)
 [0x00, 0x00, 0x00, 0x02]  // inner count = 2
 [0x00, 0x00, 0x00, 0x04]  // size = 4
 [0x00, 0x00, 0x00, 0x01]  // value = 1
@@ -152,7 +152,7 @@ Wire format:
 [0x00, 0x00, 0x00, 0x02]  // value = 2
 
 // Second nested list [3, 4, 5]
-[0x00, 0x00, 0x00, 0x24]  // size of entire frozen list
+[0x00, 0x00, 0x00, 0x1C]  // size of entire frozen list = 28 (see derivation below)
 [0x00, 0x00, 0x00, 0x03]  // inner count = 3
 [0x00, 0x00, 0x00, 0x04]  // size = 4
 [0x00, 0x00, 0x00, 0x03]  // value = 3
@@ -161,6 +161,18 @@ Wire format:
 [0x00, 0x00, 0x00, 0x04]  // size = 4
 [0x00, 0x00, 0x00, 0x05]  // value = 5
 ```
+
+**Derivation of the frozen inner-list sizes.** A frozen `list<int>` body is
+`4 (i32 count) + n * (4 (i32 element_size) + 4 (int value))` = `4 + 8n`:
+
+| Inner list | n | Bytes | Hex |
+|---|---|---|---|
+| `[1, 2]` | 2 | `4 + 2*8 = 20` | `0x14` |
+| `[3, 4, 5]` | 3 | `4 + 3*8 = 28` | `0x1C` |
+
+Count the bytes listed above each inner list to confirm: `[1,2]` shows 5 four-byte words
+after its size word (count, size, value, size, value) = 20; `[3,4,5]` shows 7 = 28. The
+size word itself is NOT included in the size it declares.
 
 ## Deserialization Code
 

--- a/.claude/skills/cql-type-system/collections-and-udts.md
+++ b/.claude/skills/cql-type-system/collections-and-udts.md
@@ -359,10 +359,17 @@ UPDATE t SET data = [1, 2, 3] WHERE id = 1;
 -- Cannot: UPDATE t SET data[0] = 99 WHERE id = 1;
 ```
 
-**Wire format:** Same as non-frozen, but:
-- Serialized as single blob in parent structure
-- No tombstones for individual elements
-- Entire collection replaced on update
+**Wire format: NOT the same as non-frozen** — see the two-encoding table at the top of this
+file. A frozen collection is:
+- serialized as a **single opaque cell value**, with fixed 4-byte BE `i32` count and element
+  lengths (`row_decoder/frozen.rs:21,98`) — not a set of cells with unsigned-VInt framing;
+- unable to represent per-element tombstones (there is no per-element cell to flag);
+- replaced wholesale on update.
+
+A **non-frozen** collection is a set of cells with `cell_count` and value lengths as
+**unsigned VInts**, per-element cell flags/paths, and per-element tombstones
+(`row_decoder/complex_column.rs:332,1089,1136`;
+`appendix-b-encodings-cheat-sheet.md:530-536`).
 
 ### Frozen UDTs
 ```cql
@@ -382,16 +389,24 @@ UPDATE t SET addr = {street: '...', city: '...', zip: ...} WHERE id = 1;
 
 ## Empty Collections
 
+**FROZEN** (4-byte BE `i32` count):
 ```
-Empty list: [0x00, 0x00, 0x00, 0x00]  // count = 0
-Empty set:  [0x00, 0x00, 0x00, 0x00]  // count = 0
-Empty map:  [0x00, 0x00, 0x00, 0x00]  // count = 0
+Empty frozen list: [0x00, 0x00, 0x00, 0x00]  // count = 0
+Empty frozen set:  [0x00, 0x00, 0x00, 0x00]  // count = 0
+Empty frozen map:  [0x00, 0x00, 0x00, 0x00]  // count = 0
 ```
+
+**NON-FROZEN** (unsigned VInt `cell_count`): a single `0x00` byte — `cell_count = 0`
+(`row_decoder/complex_column.rs:332`). In practice Cassandra usually writes no complex
+column at all rather than a zero-cell one.
 
 ## Null vs Empty
 
-- **Null collection:** Field not present, or size = -1 in length-prefixed context
-- **Empty collection:** Field present with count = 0
+- **Null collection:** column absent from the row's column bitmap; or, inside a **frozen**
+  container, a 4-byte BE `i32` length of `-1` (`0xFFFFFFFF`). A **non-frozen** collection's
+  lengths are unsigned VInts and cannot be `-1` — an absent value is the cell flag
+  `HAS_EMPTY_VALUE` (`0x04`).
+- **Empty collection:** present with count/`cell_count` = 0.
 
 ## Performance Considerations
 
@@ -442,11 +457,24 @@ CREATE TABLE collection_table (
 
 Validate parsing:
 ```bash
-./scripts/generate.sh
-sstabledump test-data/datasets/sstables/test_collections/collection_table/*.db
+bash test-data/scripts/fetch-datasets.sh   # real Cassandra 5.0 binaries (gitignored)
+export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+sstabledump test-data/datasets/sstables/test_collections/collection_table/*-Data.db
 ```
 
 ## Reference
 
-See `cqlite-core/src/types/collections.rs` for implementation.
+Implementation (verify against `origin/main`):
+- `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/frozen.rs` — **frozen**
+  collections/tuples (4-byte BE `i32` framing).
+- `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs` —
+  **non-frozen** collections (unsigned-VInt framing, per-cell flags/paths).
+- `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/udt.rs` — UDTs.
+- `cqlite-core/src/types/` — the CQL type model / `Value` enum.
+
+**Format authority** for a genuinely disputed on-disk question is Apache Cassandra 5.0.8
+(`git show cassandra-5.0.8:src/java/org/apache/cassandra/...` —
+`CollectionSerializer.java`, `TupleType.java`, `UserType.java`, `db/rows/Cell.java`) plus
+`docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md`. A CQLite
+`file:line` is authoritative for *what CQLite currently does*, not for what the format is.
 

--- a/.claude/skills/cql-type-system/collections-and-udts.md
+++ b/.claude/skills/cql-type-system/collections-and-udts.md
@@ -7,19 +7,70 @@ Cassandra supports three collection types:
 - **Set** - Unordered, no duplicates (stored sorted)
 - **Map** - Key-value pairs (stored sorted by key)
 
-## Collection Wire Format
+## Collection Wire Format — TWO distinct encodings
 
-### General Structure
-All collections use the same basic format:
+> ### ⚠️ Frozen and non-frozen collections do NOT share a wire format
+> Choose the encoding from the **schema's frozen-ness of the column**, never from the byte
+> pattern (no-heuristics mandate, #28). Assuming the frozen layout for a non-frozen column
+> (or vice versa) mis-frames every element.
+
+| | **FROZEN** | **NON-FROZEN** (the default) |
+|---|---|---|
+| Declared as | `frozen<list<int>>`; also any collection nested inside another collection/tuple/UDT | `list<int>`, `set<T>`, `map<K,V>` |
+| On disk | ONE opaque cell value | a SET of cells (one per element) |
+| Count | fixed **4-byte BE `i32`** | **unsigned VInt** |
+| Element/value length | fixed **4-byte BE `i32`** (`-1` = null) | **unsigned VInt** (no `-1`; absent = `HAS_EMPTY_VALUE` flag) |
+| Per-element metadata | none | cell flags + optional timestamp/TTL/LDT deltas + a cell **path** |
+| Element deletion | not representable | per-cell `IS_DELETED`; whole-collection via `ROW_HAS_COMPLEX_DELETION` (`0x40`) |
+
+### FROZEN collection structure (fixed 4-byte BE `i32` framing)
 
 ```
-[4 bytes: element_count (big-endian i32)]
+[i32 BE: element_count]
 [for each element:]
-    [4 bytes: element_size (big-endian i32)]
+    [i32 BE: element_size]   // -1 = null
     [bytes: element_data]
 ```
 
-### List Example
+> **Citation**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/frozen.rs:21`
+> (`i32::from_be_bytes` count), `:98`, `:279`, `:370` (element/key sizes). Guide:
+> `docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md:537-539`
+> ("tuple/UDT field lengths and frozen-collection counts/element lengths are fixed 4-byte
+> BE `i32`"). Cassandra: `CollectionSerializer.java:67-92`.
+
+### NON-FROZEN collection structure (unsigned-VInt framing)
+
+```
+[if the row sets ROW_HAS_COMPLEX_DELETION (0x40):]
+    [unsigned VInt: markedForDeleteAt delta]
+    [unsigned VInt: local_deletion_time delta]
+[unsigned VInt: cell_count]
+[for each cell:]
+    [1 byte: cell flags]                       // IS_DELETED 0x01, IS_EXPIRING 0x02,
+                                               // HAS_EMPTY_VALUE 0x04, USE_ROW_TIMESTAMP 0x08,
+                                               // USE_ROW_TTL 0x10
+    [conditional unsigned-VInt timestamp / local_deletion_time / ttl deltas]
+    [unsigned VInt: path_len][path bytes]      // element key / path (the list UUID, set
+                                               // element, or map key)
+    [unsigned VInt: value_len][value bytes]    // omitted when IS_DELETED or HAS_EMPTY_VALUE
+```
+
+> **Citation**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs:279-300`
+> (complex deletion deltas), `:332` (`cell_count` via `parse_vuint`), `:1089` (path length),
+> `:1136` (value length). Guide: `appendix-b-encodings-cheat-sheet.md:530-536` — a
+> non-frozen collection cell length-prefixes BOTH path and value with an unsigned VInt,
+> **fixed-width element types included**; the `valueLengthIfFixed()` raw-bytes shortcut is a
+> **simple-cell** rule only (`AbstractType.java:538-543`), and a non-frozen `set<T>`'s
+> missing value is the `HAS_EMPTY_VALUE_MASK` flag, not a width.
+
+### Examples below are FROZEN
+
+Every hex example in this section (`List`, `Set`, `Map`, `Nested`) shows the **frozen**
+layout — the fixed 4-byte BE `i32` framing above. For a non-frozen column, replace each
+4-byte count/length with an unsigned VInt and add the per-cell flags/path shown in the
+non-frozen structure.
+
+### List Example (FROZEN)
 ```
 CQL: list<int>
 Value: [10, 20, 30]
@@ -34,7 +85,7 @@ Wire format:
 [0x00, 0x00, 0x00, 0x1E]  // value = 30
 ```
 
-### Set Example
+### Set Example (FROZEN)
 ```
 CQL: set<text>
 Value: {'apple', 'banana', 'cherry'}
@@ -49,7 +100,7 @@ Wire format (stored sorted):
 [0x63, 0x68, 0x65, 0x72, 0x72, 0x79]  // "cherry"
 ```
 
-### Map Example
+### Map Example (FROZEN)
 ```
 CQL: map<text, int>
 Value: {'a': 1, 'b': 2}

--- a/.claude/skills/cql-type-system/cql-types-reference.md
+++ b/.claude/skills/cql-type-system/cql-types-reference.md
@@ -175,12 +175,33 @@ fn deserialize_timestamp(data: &[u8]) -> Result<i64> {
 ```
 
 #### Date
-**Wire Format:** 4 bytes unsigned (days since epoch: 1970-01-01)
+**Wire Format:** 4 bytes big-endian **unsigned**, days-since-epoch **shifted by
+`Integer.MIN_VALUE`** — the epoch (1970-01-01) sits at the CENTRE of the unsigned range,
+i.e. day 0 is encoded as `0x80000000`. The shift exists so the raw 4 bytes sort in date
+order (byte-comparable).
+
+**You MUST un-bias the stored value.** Reading it as a plain `u32` days-since-epoch is
+wrong by 2^31 days.
+
 ```rust
-fn deserialize_date(data: &[u8]) -> Result<u32> {
-    Ok(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
+/// Cassandra DATE: 4-byte unsigned BE with an Integer.MIN_VALUE offset.
+fn deserialize_date(data: &[u8]) -> Result<i32> {
+    let stored = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+    // Remove the bias: stored 0x80000000 -> 0 days since 1970-01-01.
+    Ok(stored.wrapping_add(i32::MIN as u32) as i32)
 }
 ```
+
+> **Citations**: CQLite decode path —
+> `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_scalar.rs:329-333`
+> (`stored.wrapping_add(i32::MIN as u32) as i32`; the bias is spelled `i32::MIN as u32`,
+> which is why a grep for the literal `0x80000000` finds nothing). Format authority —
+> Apache Cassandra 5.0.8 `src/java/org/apache/cassandra/serializers/SimpleDateSerializer.java`:
+> `:36-37` ("For byte-order comparability, we shift by `Integer.MIN_VALUE` and treat the
+> data as an unsigned integer … w/epoch sitting in the center @ 2^31"), `:110`
+> (`timeInMillisToDay` → `toDays() - Integer.MIN_VALUE`), `:113-115`
+> (`dayToTimeInMillis` → `ofDays(days + Integer.MIN_VALUE)`). The *decoded* value CQLite
+> carries in `Value::Date` is the signed days-since-epoch, matching Cassandra's `int`.
 
 #### Time
 **Wire Format:** 8 bytes big-endian (nanoseconds since midnight)
@@ -193,15 +214,46 @@ fn deserialize_time(data: &[u8]) -> Result<i64> {
 ```
 
 #### Duration
-**Wire Format:** 3 VInts (months, days, nanoseconds)
+**Wire Format:** 3 **ZigZag-signed** VInts (months, days, nanoseconds).
+
+> ### ⚠️ These are the ONLY signed VInts in `Data.db`
+> Every other VInt in `Data.db` — all lengths, counts, and the timestamp/TTL/
+> local-deletion-time deltas — is **unsigned**. A `duration`'s three components are the
+> sole exception, and they apply **wherever a duration payload occurs**, including nested
+> inside a collection, tuple, or UDT (`frozen<list<duration>>`,
+> `map<text, frozen<tuple<duration,int>>>`, a UDT field of type `duration`, …).
+> **Decoding them as unsigned VInts makes every negative duration wrong**, and a negative
+> CQL duration makes every non-zero component negative.
+
+**ZigZag decode**: `(zz >> 1) ^ -(zz & 1)` — i.e. positive `n` encodes as `2n`, negative
+`n` as `2|n| - 1`.
+
 ```rust
+/// ZigZag-decode an unsigned VInt payload into its signed value.
+fn zigzag_decode(zz: u64) -> i64 {
+    ((zz >> 1) as i64) ^ -((zz & 1) as i64)
+}
+
 fn deserialize_duration(data: &[u8]) -> Result<(i32, i32, i64)> {
-    let (months_data, rest) = parse_vint(data)?;
-    let (days_data, rest) = parse_vint(rest)?;
-    let (nanos_data, _) = parse_vint(rest)?;
-    Ok((months_data as i32, days_data as i32, nanos_data))
+    // parse_vuint reads the raw UNSIGNED VInt; the ZigZag step recovers the sign.
+    let (rest, months_zz) = parse_vuint(data)?;
+    let (rest, days_zz) = parse_vuint(rest)?;
+    let (_, nanos_zz) = parse_vuint(rest)?;
+    Ok((
+        zigzag_decode(months_zz) as i32,
+        zigzag_decode(days_zz) as i32,
+        zigzag_decode(nanos_zz),
+    ))
 }
 ```
+
+> **Citations**: `docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md:63-65`
+> ("Every VInt in `Data.db` is unsigned **except** the three components of a serialized
+> `DurationType` payload"), `:92-97` (the duration/ZigZag rule and its nesting scope),
+> `:520-529` (structural VInts are unsigned; ZigZag appears only inside a `DurationType`
+> payload). Cassandra: `DurationSerializer.java:34,49-51` (three `writeVInt` calls),
+> `VIntCoding.java:449,522` (`writeVInt` → `writeUnsignedVInt(encodeZigZag64(v))`),
+> `Duration.java:101-110` (a negative duration negates every component).
 
 ### Network Types
 
@@ -279,9 +331,14 @@ fn deserialize_nullable<T>(
 
 ## Type Aliases
 
-Some types have multiple names:
-- `text` = `varchar`
-- `blob` = `bytea` (PostgreSQL compatibility)
+CQL has exactly one such alias pair:
+- `text` = `varchar` (both are `UTF8Type`)
+
+> **Citation**: cassandra-5.0.8 `src/java/org/apache/cassandra/cql3/CQL3Type.java:88-111`
+> — the `Native` enum is the complete list of CQL native type names. `TEXT` (`:103`) and
+> `VARCHAR` (`:111`) both map to `UTF8Type.instance`, which is the one true alias pair;
+> `BLOB` (`:91`) maps to `BytesType.instance` and appears exactly once. CQL has **no**
+> PostgreSQL-style alias for `blob` — do not invent one.
 
 ## Special Cases
 

--- a/.claude/skills/cql-type-system/cql-types-reference.md
+++ b/.claude/skills/cql-type-system/cql-types-reference.md
@@ -293,10 +293,18 @@ fn deserialize_counter(data: &[u8]) -> Result<i64> {
 
 ## Null Handling
 
-All CQL types can be null:
-- **In collections:** 4-byte size prefix of `-1` (0xFFFFFFFF)
-- **In UDT fields:** 4-byte size prefix of `-1`
-- **In cells:** Cell with IS_DELETED flag or no value bytes
+All CQL types can be null, but the *framing* that expresses null depends on whether you
+are inside a **frozen** value or looking at a **non-frozen** collection's cells:
+- **In a FROZEN collection / tuple / UDT:** a 4-byte big-endian `i32` length of `-1`
+  (`0xFFFFFFFF`) (`row_decoder/frozen.rs:98,279,370`; `TupleType.java:341-364`).
+- **In a NON-FROZEN collection cell:** there is no `-1` sentinel — an absent value is the
+  cell flag `HAS_EMPTY_VALUE` (`0x04`), and lengths are **unsigned VInts** which cannot be
+  negative (`row_decoder/complex_column.rs:1136`;
+  `appendix-b-encodings-cheat-sheet.md:530-536`).
+- **In cells generally:** a cell with `IS_DELETED` (`0x01`), or a column omitted from the
+  row's column bitmap.
+
+See `collections-and-udts.md` for the two collection encodings side by side.
 
 ```rust
 fn deserialize_nullable<T>(
@@ -324,10 +332,15 @@ fn deserialize_nullable<T>(
 - **Null:** Field doesn't have a value (SQL NULL)
 - **Empty:** Field has zero-length value (empty string, empty blob)
 
-**Wire format:**
-- Null: size = -1, no bytes follow
-- Empty: size = 0, no bytes follow
-- Present: size = N, N bytes follow
+**Wire format** — inside a **frozen** value (4-byte BE `i32` lengths):
+- Null: size = `-1`, no bytes follow
+- Empty: size = `0`, no bytes follow
+- Present: size = `N`, `N` bytes follow
+
+**Wire format** — a **non-frozen** collection cell (unsigned-VInt lengths, so no `-1`):
+- Empty/absent value: cell flag `HAS_EMPTY_VALUE` (`0x04`) set; no length, no bytes
+- Deleted: cell flag `IS_DELETED` (`0x01`) set; no value bytes
+- Present: unsigned VInt `value_len` = `N`, then `N` bytes
 
 ## Type Aliases
 
@@ -354,5 +367,17 @@ CQL has exactly one such alias pair:
 
 ## Reference Implementation
 
-See `cqlite-core/src/types/` for complete Rust type system implementation.
+- `cqlite-core/src/types/` — the CQL type model / `Value` enum.
+- `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_scalar.rs` —
+  scalar on-disk decode (the authority for what CQLite does with `date`, `duration`, etc.).
+- `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/frozen.rs` — frozen
+  collections/tuples (4-byte BE `i32` framing).
+- `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs` —
+  non-frozen collections (unsigned-VInt framing).
+- `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/udt.rs` — UDTs.
+
+**Format authority** for a genuinely disputed on-disk question is Apache Cassandra 5.0.8
+(`git show cassandra-5.0.8:src/java/org/apache/cassandra/...`) plus
+`docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md`. A CQLite
+`file:line` is authoritative for *what CQLite currently does*, not for what the format is.
 

--- a/.claude/skills/sstable-parsing/SKILL.md
+++ b/.claude/skills/sstable-parsing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Cassandra SSTable Format Parsing
-description: Guide parsing of Cassandra 5.0+ SSTable components (Data.db, Index.db, Statistics.db, Summary.db, TOC) with compression support (LZ4, Snappy, Deflate). Use when working with SSTable files, binary format parsing, hex dumps, compression issues, offset calculations, BTI index, partition layout, or debugging parsing errors.
+description: Guide parsing of Cassandra 5.0+ SSTable components (Data.db, Index.db, Statistics.db, Summary.db, TOC) with compression support (LZ4, Snappy, Deflate, Zstd, plus Noop). Use when working with SSTable files, binary format parsing, hex dumps, compression issues, offset calculations, BTI index, partition layout, or debugging parsing errors.
 allowed-tools: Read, Grep, Glob
 ---
 
@@ -13,7 +13,7 @@ This skill helps with parsing and understanding Cassandra 5.0+ SSTable file form
 - Parsing Data.db, Index.db, Statistics.db files
 - Debugging binary format mismatches
 - Analyzing hex dumps of SSTable data
-- Working with compression (LZ4, Snappy, Deflate)
+- Working with compression (LZ4, Snappy, Deflate, Zstd; Noop = stored raw)
 - Investigating offset calculation errors
 - Understanding BTI (Big Table Index) format
 - Validating partition boundaries
@@ -48,7 +48,7 @@ Contains sampling of index entries for faster lookups
 **Primary Source of Truth**: `docs/sstables-definitive-guide/`
 
 Key chapters:
-- **Ch.5**: Data.db Format - Row layout, flags, V5CompressedLegacy
+- **Ch.5**: Data.db Format - Row layout, flags, V5 row/partition encoding
 - **Ch.6**: Index.db and Summary.db - Partition lookups
 - **Ch.9**: CompressionInfo.db - Compression metadata, chunking
 - **Ch.17**: BTI Formats - Trie-based indexes
@@ -94,29 +94,60 @@ When implementing parsers:
 ## Integration with Rust Code
 
 Current implementation in `cqlite-core/src/storage/sstable/reader/parsing/`:
-- `v5_compressed_legacy.rs` - Main V5 format parser (1997 lines)
+- **`row_decoder/`** — the main V5 row/partition decoder, a **directory of ~30 files**
+  (split out of the former single-file parser by epic #1116). Start at
+  `row_decoder/mod.rs` for the flag constants and the parser entry point; then
+  `row_framing.rs` (row/partition framing), `row_data.rs`, `cell_value_scalar.rs` /
+  `cell_value_complex.rs` (cell decode), `complex_column.rs` (non-frozen collections),
+  `frozen.rs` (frozen collections), `udt.rs`, `partition_driver.rs`.
 - Uses zero-copy patterns with `Bytes`
 - Handles compression transparently
+
+> The former single-file V5-compressed-legacy parser module **no longer exists** — it was
+> deleted by epic #1116 (source splits), commit `cb049f7a8`, and replaced by the
+> `row_decoder/` directory above. If an older doc or comment points you at a single
+> `.rs` file for the V5 parser, that pointer is stale.
 
 ## PRD Alignment
 
 **Supports Milestone M1** (Core Reading Library):
 - 100% Cassandra 5 SSTable format support
-- All compression formats (LZ4, Snappy, Deflate)
+- All compression formats (LZ4, Snappy, Deflate, Zstd) plus Noop
 - Zero-copy deserialization
 - Memory target: <128MB for large files
 
 ## Quick Reference
 
-### Flag Bytes (Row)
-- `0x01`: HAS_IS_MARKER
-- `0x02`: HAS_ALL_COLUMNS (inverted - 0x20 means all present)
-- `0x04`: HAS_TIMESTAMP
-- `0x08`: HAS_TTL
-- `0x10`: HAS_DELETION
-- `0x20`: HAS_ALL_COLUMNS (flag set = all columns present)
-- `0x40`: IS_STATIC
-- `0x80`: EXTENSION_FLAG
+### Flag Bytes (Row) — main flag byte
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| `0x01` | `END_OF_PARTITION` | End-of-partition marker — **nothing follows this flag byte** |
+| `0x02` | `IS_MARKER` | Unfiltered is a RangeTombstoneMarker, not a Row |
+| `0x04` | `ROW_HAS_TIMESTAMP` | Row-level liveness timestamp present (delta-encoded) |
+| `0x08` | `ROW_HAS_TTL` | Row-level TTL present (delta-encoded) |
+| `0x10` | `ROW_HAS_DELETION` | Row deletion (tombstone) present |
+| `0x20` | `ROW_HAS_ALL_COLUMNS` | All schema columns present — no column bitmap follows |
+| `0x40` | `ROW_HAS_COMPLEX_DELETION` | Row carries a non-frozen collection column with deletion info |
+| `0x80` | `ROW_HAS_EXTENDED_FLAGS` | A second (extended) flag byte follows |
+
+### Flag Bytes (Row) — EXTENDED flag byte (only when `0x80` is set)
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| `0x01` | `EXTENDED_IS_STATIC` | Static row — has **NO** clustering prefix |
+
+> **Citations**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs:709-715`
+> (`ROW_HAS_TIMESTAMP`/`TTL`/`DELETION`/`ALL_COLUMNS`/`COMPLEX_DELETION`/`EXTENDED_FLAGS`),
+> `:820` (`END_OF_PARTITION = 0x01`), `:821` (`IS_MARKER = 0x02`), `:825`
+> (`EXTENDED_IS_STATIC = 0x01`). Guide: `appendix-b-encodings-cheat-sheet.md:206-212`.
+> Cassandra: `UnfilteredSerializer.java:102-109` (flags) and `:114-122` (extended flags).
+
+**⚠️ The two highest-consequence bits.** `0x01` on the **main** byte is
+`END_OF_PARTITION`, NOT `IS_STATIC` and NOT a marker flag — misreading it means
+**mis-detecting partition boundaries**. `IS_STATIC` is `0x01` of the **EXTENDED** byte,
+which only exists when `ROW_HAS_EXTENDED_FLAGS (0x80)` is set. There is exactly ONE
+`HAS_ALL_COLUMNS` and its value is `0x20`.
 
 ### VInt Encoding
 Variable-length integer encoding:

--- a/.claude/skills/sstable-parsing/cassandra5-format-reference.md
+++ b/.claude/skills/sstable-parsing/cassandra5-format-reference.md
@@ -128,9 +128,12 @@ only.
 | `0x08` | `USE_ROW_TIMESTAMP` | Reuse the row timestamp; no cell timestamp is written |
 | `0x10` | `USE_ROW_TTL` | Reuse the row TTL **and** local_deletion_time; neither is written |
 
-> **Citations**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs:860-863`
-> (`CELL_IS_DELETED` `0x01`, `CELL_IS_EXPIRING` `0x02`, `CELL_USE_ROW_TIMESTAMP` `0x08`,
-> `CELL_USE_ROW_TTL` `0x10`) and `:282` (`HAS_EMPTY_VALUE` `0x04`). Guide:
+> **Citations**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value.rs:49-53`
+> — all five constants, in `parse_cell_value_schema_order`, the **production** cell
+> decoder (`CELL_IS_DELETED` `0x01`, `CELL_IS_EXPIRING` `0x02`, `CELL_HAS_EMPTY_VALUE`
+> `0x04`, `CELL_USE_ROW_TIMESTAMP` `0x08`, `CELL_USE_ROW_TTL` `0x10`). Cite this file, not
+> `row_data.rs:860-863` — that is a `#[cfg(test)]` mirror (`parse_cell_header_end_offset`)
+> carrying only four of the five. Guide:
 > `appendix-b-encodings-cheat-sheet.md:231-238`. Cassandra 5.0.8:
 > `db/rows/Cell.java:262-266` — `Cell.Serializer` declares these five `*_MASK` constants
 > and **no others**, so `0x20` and `0x40` are NOT cell flags (an earlier revision of this
@@ -288,7 +291,9 @@ Entry points:
 - `row_decoder/mod.rs` — flag constants (`END_OF_PARTITION`, `IS_MARKER`,
   `ROW_HAS_*`, `EXTENDED_IS_STATIC`) and the parser struct.
 - `row_decoder/row_framing.rs` — row/partition framing and boundary detection.
-- `row_decoder/row_data.rs`, `cell_value_scalar.rs`, `cell_value_complex.rs` — cell decode.
+- `row_decoder/cell_value.rs` — the production cell decoder + the five `CELL_*` flag
+  constants (`:49-53`). `row_data.rs`, `cell_value_scalar.rs`, `cell_value_complex.rs` —
+  the rest of the cell-decode ladder.
 - `row_decoder/complex_column.rs` — non-frozen collections; `frozen.rs` — frozen
   collections; `udt.rs` — UDTs; `partition_driver.rs` — partition iteration.
 

--- a/.claude/skills/sstable-parsing/cassandra5-format-reference.md
+++ b/.claude/skills/sstable-parsing/cassandra5-format-reference.md
@@ -230,11 +230,20 @@ All 18 cells present in schema order
 
 ## Critical Parsing Rules
 
-1. **Clustering Prefix**: MUST check if `clustering_types.is_empty()` before reading
-2. **Column Bitmap**: Only read if HAS_ALL_COLUMNS (0x20) **not** set
-3. **Delta Encoding**: All timestamps/TTLs are deltas, not absolute values
-4. **Cell Empty Flag**: Logic is **inverted** - flag set = empty, flag clear = has value
-5. **Row Sizes**: Always present in SSTable format (not in internal messages)
+1. **Partition boundary FIRST**: a flag byte of `0x01` (`END_OF_PARTITION`) ends the
+   partition — nothing follows it. Check it before interpreting any other bit
+   (`row_decoder/mod.rs:820`).
+2. **Markers are not rows**: `0x02` (`IS_MARKER`) means a RangeTombstoneMarker, not a Row
+   (`row_decoder/mod.rs:821`).
+3. **Clustering Prefix**: MUST check if `clustering_types.is_empty()` before reading; a
+   static row (`EXTENDED_IS_STATIC` = `0x01` of the **extended** byte) has no clustering
+   prefix at all (`row_decoder/mod.rs:825`).
+4. **Column Bitmap**: Only read if HAS_ALL_COLUMNS (0x20) **not** set
+5. **Delta Encoding**: All timestamps/TTLs are deltas, not absolute values
+6. **Cell Empty Flag**: Logic is **inverted** - flag set = empty, flag clear = has value
+7. **Row Sizes**: Always present in SSTable format (not in internal messages)
+8. **Never guess**: take signedness/framing from the field's serializer, never from byte
+   patterns (no-heuristics mandate, #28).
 
 ---
 

--- a/.claude/skills/sstable-parsing/cassandra5-format-reference.md
+++ b/.claude/skills/sstable-parsing/cassandra5-format-reference.md
@@ -109,29 +109,70 @@ For each present column (simple or complex):
 ### Simple Cell
 ```
 [1 byte: flags]
-[0-1 byte: extended_flags if EXTENDED_FLAG (0x40) set]
 [VInt: timestamp_delta if NOT USE_ROW_TIMESTAMP (0x08)]
-[VInt: local_deletion_time_delta if IS_DELETED or IS_EXPIRING]
+[VInt: local_deletion_time_delta if IS_DELETED, or if IS_EXPIRING and NOT USE_ROW_TTL]
 [VInt: ttl_delta if IS_EXPIRING and NOT USE_ROW_TTL]
-[bytes: value if NOT IS_DELETED and NOT HAS_EMPTY_VALUE]
+[bytes: value if NOT HAS_EMPTY_VALUE (length-prefixed unless the type is fixed-width)]
 ```
 
-**Cell Flags:**
-- `0x01`: IS_DELETED (tombstone)
-- `0x02`: IS_EXPIRING (has TTL)
-- `0x04`: HAS_EMPTY_VALUE (INVERTED: flag=0 means has value, flag=1 means empty)
-- `0x08`: USE_ROW_TIMESTAMP (use row timestamp, don't read separate)
-- `0x10`: USE_ROW_TTL (use row TTL)
-- `0x20`: HAS_NULL_VALUE (value is null)
-- `0x40`: EXTENDED_FLAG (extended flags follow)
+There is **no extended flag byte for a cell** — extended flags are a *row*-header concept
+only.
 
-### Complex Cell (Collections, UDTs)
-Collections have additional wrapping:
+**Cell Flags** — the complete set; there are exactly five:
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| `0x01` | `IS_DELETED` | Cell is a tombstone (no value) |
+| `0x02` | `IS_EXPIRING` | Cell has a TTL (TTL/local-deletion fields follow) |
+| `0x04` | `HAS_EMPTY_VALUE` | Zero-length value — flag SET means empty (not NULL) |
+| `0x08` | `USE_ROW_TIMESTAMP` | Reuse the row timestamp; no cell timestamp is written |
+| `0x10` | `USE_ROW_TTL` | Reuse the row TTL **and** local_deletion_time; neither is written |
+
+> **Citations**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs:860-863`
+> (`CELL_IS_DELETED` `0x01`, `CELL_IS_EXPIRING` `0x02`, `CELL_USE_ROW_TIMESTAMP` `0x08`,
+> `CELL_USE_ROW_TTL` `0x10`) and `:282` (`HAS_EMPTY_VALUE` `0x04`). Guide:
+> `appendix-b-encodings-cheat-sheet.md:231-238`. Cassandra 5.0.8:
+> `db/rows/Cell.java:262-266` — `Cell.Serializer` declares these five `*_MASK` constants
+> and **no others**, so `0x20` and `0x40` are NOT cell flags (an earlier revision of this
+> file invented `HAS_NULL_VALUE`/`EXTENDED_FLAG`; both are fabrications).
+
+**Critical distinction** (`appendix-b-encodings-cheat-sheet.md:247-250`): a tombstone
+(`IS_DELETED`) MUST NOT set `USE_ROW_TIMESTAMP` — tombstones require an explicit timestamp
+and local_deletion_time.
+
+### Complex Cell — NON-FROZEN collections and non-frozen UDTs
+A non-frozen collection column is a *set of cells*, wrapped as:
 ```
-[VInt: element_count]
+[if ROW_HAS_COMPLEX_DELETION (0x40) on the row: complex deletion time — 2 unsigned VInt deltas]
+[unsigned VInt: cell_count]
+[for each cell:]
+    [1 byte: cell flags (table above)]
+    [conditional timestamp / local_deletion_time / ttl deltas]
+    [unsigned VInt: path_len][path bytes]      // the collection key/element path
+    [unsigned VInt: value_len][value bytes]    // omitted when IS_DELETED or HAS_EMPTY_VALUE
+```
+
+> **Citation**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/complex_column.rs:279-300`
+> (complex deletion deltas), `:332` (`cell_count` via `parse_vuint`), `:1089` (path length
+> unsigned VInt), `:1136` (value length unsigned VInt). Guide:
+> `appendix-b-encodings-cheat-sheet.md:530-536` — a non-frozen collection cell
+> length-prefixes BOTH path and value with an **unsigned VInt**, fixed-width element types
+> included.
+
+### FROZEN collections / tuples / UDTs — a DIFFERENT encoding
+A frozen value is a single opaque cell whose bytes use **fixed 4-byte big-endian `i32`**
+counts and element lengths — **not** VInts:
+```
+[i32 BE: element_count]
 [for each element:]
-    [cell format as above]
+    [i32 BE: element_len]   // -1 = null
+    [element bytes]
 ```
+
+> **Citation**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/frozen.rs:21`
+> (`i32::from_be_bytes` count), `:98`/`:279`/`:370` (element/key lengths). Guide:
+> `appendix-b-encodings-cheat-sheet.md:537-539`. Cassandra:
+> `CollectionSerializer.java:67-92`, `TupleType.java:341-364`.
 
 ---
 
@@ -199,26 +240,33 @@ All 18 cells present in schema order
 
 ## Compression
 
-Cassandra 5.0 supports three compression algorithms:
+Cassandra 5.0 supports **four compression algorithms plus Noop**: LZ4, Snappy, Deflate,
+Zstd, and Noop (stored raw) — `cqlite-core/src/storage/sstable/compression_info.rs:43-48`.
+See `compression-formats.md` in this skill for the full `CompressionInfo.db` layout.
 
-### Block Structure
+### Chunk Structure
 ```
-[compressed_block_1]
-[compressed_block_2]
+[compressed_chunk_1][crc32: 4 bytes BE]
+[compressed_chunk_2][crc32: 4 bytes BE]
 ...
 ```
 
-Each block:
-- Fixed maximum size (typically 64KB uncompressed)
+Each chunk:
+- Fixed maximum **uncompressed** size = `chunk_length` from `CompressionInfo.db`;
+  Cassandra 5.0 default **16 KiB** (`CompressionParams.DEFAULT_CHUNK_LENGTH`,
+  cassandra-5.0.8 `schema/CompressionParams.java:47`)
 - Compressed independently
-- CRC checksum for validation
+- Followed by an **unconditional** 4-byte big-endian CRC32 over the **compressed** bytes
+  (`chunk_decompressor.rs:275-292`)
 - May contain multiple rows or partial rows
 
 ### Decompression
-1. Read compressed size from block header
-2. Decompress entire block
-3. Parse rows from decompressed buffer
-4. Track offsets within decompressed data
+1. Read the chunk offsets from `CompressionInfo.db` (offsets **only** — there is no stored
+   per-chunk length; the payload length is `next_offset - this_offset - 4`)
+2. Read the chunk record, validate the trailing big-endian CRC32 over the compressed bytes
+3. Decompress the chunk with the algorithm named in `CompressionInfo.db`
+4. Parse rows from the decompressed buffer; offset within the chunk is
+   `logical_offset % chunk_length`
 
 ---
 

--- a/.claude/skills/sstable-parsing/cassandra5-format-reference.md
+++ b/.claude/skills/sstable-parsing/cassandra5-format-reference.md
@@ -10,18 +10,46 @@ Extracted from Apache Cassandra 5.0 source code (UnfilteredSerializer.java, Cell
 ### 1. Row Header (Flags)
 ```
 [1 byte: flags]
-[0-1 bytes: extended flags if EXTENSION_FLAG (0x80) set]
+[0-1 bytes: extended flags — present iff ROW_HAS_EXTENDED_FLAGS (0x80) is set]
 ```
 
-**Flags Breakdown:**
-- `0x01`: IS_MARKER (range tombstone marker)
-- `0x02`: (reserved)
-- `0x04`: HAS_TIMESTAMP (row has liveness timestamp)
-- `0x08`: HAS_TTL (row has time-to-live)
-- `0x10`: HAS_DELETION (row has deletion tombstone)
-- `0x20`: HAS_ALL_COLUMNS (all schema columns present, no bitmap needed)
-- `0x40`: IS_STATIC (static row)
-- `0x80`: EXTENSION_FLAG (extended flags byte follows)
+**Main flag byte:**
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| `0x01` | `END_OF_PARTITION` | End-of-partition marker — **nothing follows this flag byte** |
+| `0x02` | `IS_MARKER` | Unfiltered is a RangeTombstoneMarker, not a Row |
+| `0x04` | `ROW_HAS_TIMESTAMP` | Row has a liveness timestamp (delta-encoded) |
+| `0x08` | `ROW_HAS_TTL` | Row has a TTL (delta-encoded) |
+| `0x10` | `ROW_HAS_DELETION` | Row has a deletion tombstone |
+| `0x20` | `ROW_HAS_ALL_COLUMNS` | All schema columns present — no bitmap needed |
+| `0x40` | `ROW_HAS_COMPLEX_DELETION` | Row carries a non-frozen collection column with deletion info |
+| `0x80` | `ROW_HAS_EXTENDED_FLAGS` | Extended flags byte follows |
+
+**EXTENDED flag byte** (present only when `ROW_HAS_EXTENDED_FLAGS = 0x80` is set):
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| `0x01` | `EXTENDED_IS_STATIC` | Static row — carries **NO** clustering prefix |
+
+> **Citations**: `cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs:709-715`
+> (`ROW_HAS_TIMESTAMP` `0x04`, `ROW_HAS_TTL` `0x08`, `ROW_HAS_DELETION` `0x10`,
+> `ROW_HAS_ALL_COLUMNS` `0x20`, `ROW_HAS_COMPLEX_DELETION` `0x40`,
+> `ROW_HAS_EXTENDED_FLAGS` `0x80`), `:820` (`END_OF_PARTITION = 0x01`), `:821`
+> (`IS_MARKER = 0x02`), `:825` (`EXTENDED_IS_STATIC = 0x01`). Guide:
+> `docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md:206-212`.
+> Cassandra: `UnfilteredSerializer.java:102-109` and `:114-122`.
+
+**⚠️ `0x01` is the partition boundary, not a static/marker bit.** Treating `0x01` as
+`IS_STATIC` (or as the marker flag) means **mis-detecting partition boundaries** — the
+highest-consequence single bit in the row format. `IS_STATIC` lives at `0x01` of the
+**EXTENDED** byte. `HAS_ALL_COLUMNS` has exactly one value, `0x20`.
+
+**Common flag combinations** (`appendix-b-encodings-cheat-sheet.md:215-219`):
+- `0x24`: simple write (`HAS_TIMESTAMP | HAS_ALL_COLUMNS`)
+- `0x2C`: TTL write (`HAS_TIMESTAMP | HAS_TTL | HAS_ALL_COLUMNS`)
+- `0x04`: partial update (timestamp, no `HAS_ALL_COLUMNS` → bitmap follows)
+- `0x14`: row deletion (`HAS_TIMESTAMP | HAS_DELETION`)
 
 ### 2. Clustering Prefix
 For tables with clustering columns:
@@ -196,5 +224,20 @@ Each block:
 
 ## Reference Implementation
 
-See `cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs` for full Rust implementation following this specification.
+The V5 row/partition decoder lives in the
+`cqlite-core/src/storage/sstable/reader/parsing/row_decoder/` **directory** (~30 files).
+Entry points:
+
+- `row_decoder/mod.rs` — flag constants (`END_OF_PARTITION`, `IS_MARKER`,
+  `ROW_HAS_*`, `EXTENDED_IS_STATIC`) and the parser struct.
+- `row_decoder/row_framing.rs` — row/partition framing and boundary detection.
+- `row_decoder/row_data.rs`, `cell_value_scalar.rs`, `cell_value_complex.rs` — cell decode.
+- `row_decoder/complex_column.rs` — non-frozen collections; `frozen.rs` — frozen
+  collections; `udt.rs` — UDTs; `partition_driver.rs` — partition iteration.
+
+The former single-file V5-compressed-legacy parser module was deleted by epic #1116
+(source splits), commit `cb049f7a8`; any pointer to a single `.rs` file for this parser is
+stale. Format authority for a genuinely disputed on-disk question is Apache Cassandra 5.0.8
+(`UnfilteredSerializer.java`, `Cell.java`, `ClusteringPrefix.java`) plus
+`docs/sstables-definitive-guide/`.
 

--- a/.claude/skills/sstable-parsing/compression-formats.md
+++ b/.claude/skills/sstable-parsing/compression-formats.md
@@ -2,36 +2,77 @@
 
 ## Overview
 
-Cassandra 5.0 supports three compression algorithms:
-- **LZ4** (default, recommended)
-- **Snappy**
-- **Deflate** (highest compression, slowest)
+Cassandra 5.0 supports **four compression algorithms plus Noop** (the explicit
+"stored raw" marker):
+- **LZ4** (`LZ4Compressor`) — default, recommended
+- **Snappy** (`SnappyCompressor`)
+- **Deflate** (`DeflateCompressor`) — highest compression, slowest
+- **Zstd** (`ZstdCompressor`)
+- **Noop** (`NoopCompressor`) — chunks stored uncompressed
+
+> **Citation**: `cqlite-core/src/storage/sstable/compression_info.rs:43-48`
+> (`SUPPORTED_COMPRESSOR_NAMES`). Any other compressor name is rejected fail-fast at
+> metadata-parse time — never guessed from content (no-heuristics mandate, #28).
 
 ## Compression Block Structure
 
 ### Index Structure (CompressionInfo.db)
-Located alongside Data.db:
+
+Located alongside Data.db. It is **NOT** an array of `[offset, length]` pairs — it is a
+header followed by an offsets-only array:
+
 ```
-[chunk_offset_1: u64]
-[chunk_length_1: u32]
-[chunk_offset_2: u64]
-[chunk_length_2: u32]
-...
+writeUTF(compressor_simple_name)   // 2-byte BE length + UTF-8 bytes
+i32  option_count                  // 4 bytes BE
+for each option:
+    writeUTF(key)                  // 2-byte BE length + UTF-8 bytes
+    writeUTF(value)                // 2-byte BE length + UTF-8 bytes
+i32  chunk_length                  // 4 bytes BE — UNCOMPRESSED chunk size
+i32  max_compressed_length         // 4 bytes BE — present for version >= "na" (all 5.0 files)
+i64  data_length                   // 8 bytes BE — total uncompressed data length
+i32  chunk_count                   // 4 bytes BE
+for each chunk:
+    i64 chunk_offset               // 8 bytes BE — byte offset into Data.db
 ```
 
-Maps logical offsets to physical compressed chunks.
+> **Citation**: `cqlite-core/src/storage/sstable/compression_info.rs:6-20` (format doc
+> block) and `:83` (`chunk_offsets`), mirroring Cassandra
+> `CompressionMetadata.java:375-392`.
+
+**There is NO per-chunk length field.** A chunk's *physical* length is the delta between
+consecutive offsets (for the last chunk, `file_len - last_offset`), and **that delta
+INCLUDES the trailing 4-byte CRC** — so the compressed payload is
+`next_offset - this_offset - 4` bytes. Cassandra's writer advances
+`chunkOffset += compressedLength + 4` (`CompressedSequentialWriter.java:203`; see the
+`chunk_offsets` doc comment at `compression_info.rs:76-83`).
 
 ### Chunk Format
-Each compressed chunk in Data.db:
+Each compressed-chunk record in Data.db:
 ```
-[compressed_data: variable length]
-[crc32: 4 bytes] (if CRC enabled)
+[compressed_data: (next_offset - this_offset - 4) bytes]
+[crc32: 4 bytes big-endian, over the COMPRESSED bytes]
 ```
 
-**Chunk Parameters** (from Statistics.db):
-- `chunkLength`: Max uncompressed size (typically 64KB)
-- `compressionAlgorithm`: LZ4, Snappy, or Deflate
-- `crcCheckChance`: Probability of CRC validation (0.0-1.0)
+The inline CRC32 is **unconditional** for `na`/`nb` — it is always present and always
+read. `crc_check_chance` governs only whether Cassandra *validates* it, never whether it
+is written. CQLite always validates.
+
+> **Citation**: `cqlite-core/src/storage/sstable/chunk_decompressor.rs:275-292` —
+> `u32::from_be_bytes(crc_bytes)` compared against `crc32fast::hash(&compressed_data)`
+> (the *compressed* buffer, not the decompressed one). Cassandra side:
+> `CompressedSequentialWriter.java:192`. Big-endian byte order was verified against 356
+> real Cassandra 5.0 inline trailers (#986 / #1086).
+
+**Chunk Parameters** (from **`CompressionInfo.db`**, NOT `Statistics.db`):
+- `chunk_length`: max uncompressed chunk size. **Cassandra 5.0 default is 16 KiB**
+  (`CompressionParams.DEFAULT_CHUNK_LENGTH = 1024 * 16`, cassandra-5.0.8
+  `src/java/org/apache/cassandra/schema/CompressionParams.java:47`).
+- `max_compressed_length`: if a compressed chunk reaches this size the chunk was stored
+  uncompressed instead; equals `i32::MAX` when `min_compress_ratio=0` (the default)
+  (`compression_info.rs:70-75`).
+- `compressor_simple_name`: one of the five names above.
+- `crc_check_chance`: a *schema* option (probability Cassandra validates the inline CRC);
+  it does NOT make the CRC optional on disk.
 
 ## LZ4 Compression
 
@@ -40,15 +81,34 @@ Each compressed chunk in Data.db:
 - Good compression ratio
 - Default in Cassandra 5.0
 
-**Rust Implementation:**
-```rust
-use lz4::block::decompress;
+**Wire layout**: Cassandra's `LZ4Compressor` prepends a **4-byte LITTLE-endian
+uncompressed-length prefix** to a **raw LZ4 block** (this is NOT the `lz4_flex`
+size-prepended/varint format).
 
-fn decompress_lz4(compressed: &[u8], uncompressed_size: usize) -> Result<Vec<u8>> {
-    lz4::block::decompress(compressed, Some(uncompressed_size as i32))
-        .map_err(|e| Error::Compression(format!("LZ4: {}", e)))
+**Rust Implementation** — this repo uses the **`lz4_flex`** crate. The `lz4` crate is NOT
+a dependency; a sample calling `lz4::block::decompress` cannot compile here.
+
+```rust
+// Cassandra LZ4Compressor.decompress() lines 169-172: 4-byte LE length prefix + raw block.
+fn decompress_lz4(compressed: &[u8], expected_size: usize) -> Result<Vec<u8>> {
+    if compressed.len() < 4 {
+        return Err(Error::InvalidFormat("LZ4 chunk too short for length prefix".into()));
+    }
+    let declared = u32::from_le_bytes([
+        compressed[0], compressed[1], compressed[2], compressed[3],
+    ]) as usize;
+    // Fail fast when the prefix disagrees with the size CompressionInfo.db implies.
+    if declared != expected_size {
+        return Err(Error::InvalidFormat("LZ4 length prefix mismatch".into()));
+    }
+    lz4_flex::decompress(&compressed[4..], declared)
+        .map_err(|e| Error::storage(format!("LZ4: {}", e)))
 }
 ```
+
+> **Citation**: `cqlite-core/src/storage/sstable/chunk_decompressor.rs:361`
+> (`decompress_lz4_chunk`), `:391` (the `u32::from_le_bytes` prefix) and `:426`
+> (`lz4_flex::decompress`). Dependency: `cqlite-core/Cargo.toml:39,145` (`lz4_flex`).
 
 ## Snappy Compression
 
@@ -73,35 +133,69 @@ fn decompress_snappy(compressed: &[u8]) -> Result<Vec<u8>> {
 **Characteristics:**
 - Highest compression ratio
 - Slower than LZ4/Snappy
-- Standard zlib/gzip format
+- **ZLIB-wrapped**, not raw DEFLATE
+
+> ### ⚠️ TRAP — this is shipped P0 #1082 (deflate-as-zlib / zstd bare-frame)
+> Cassandra's `DeflateCompressor` uses `java.util.zip.Deflater`/`Inflater`, which emit a
+> **zlib-wrapped** stream: a 2-byte header (`0x78 0x9c`) + DEFLATE body + 4-byte Adler-32
+> trailer. Decoding it with `flate2::read::DeflateDecoder` (raw DEFLATE) is **exactly the
+> P0 bug #1082**. Use **`flate2::read::ZlibDecoder`**. There is also **no** 4-byte
+> uncompressed-size prefix here — that is an LZ4/Zstd convention.
 
 **Rust Implementation:**
 ```rust
-use flate2::read::DeflateDecoder;
+use flate2::read::ZlibDecoder;
 use std::io::Read;
 
-fn decompress_deflate(compressed: &[u8]) -> Result<Vec<u8>> {
-    let mut decoder = DeflateDecoder::new(compressed);
+fn decompress_deflate(compressed: &[u8], chunk_size_guard: u64) -> Result<Vec<u8>> {
+    if compressed.is_empty() {
+        return Err(Error::storage("Invalid Deflate data: empty chunk".into()));
+    }
+    // No in-stream size field exists for zlib, so bound the OUTPUT rather than
+    // trusting the payload (decompression-bomb guard).
+    let mut decoder = ZlibDecoder::new(compressed).take(chunk_size_guard + 1);
     let mut uncompressed = Vec::new();
     decoder.read_to_end(&mut uncompressed)
-        .map_err(|e| Error::Compression(format!("Deflate: {}", e)))?;
+        .map_err(|e| Error::storage(format!("Deflate decompression failed: {}", e)))?;
     Ok(uncompressed)
 }
 ```
 
+> **Citation**: `cqlite-core/src/storage/sstable/compression.rs:306` (`use
+> flate2::read::ZlibDecoder`), `:313` (the explicit `#1082` trap comment) and `:324`
+> (`ZlibDecoder::new(data).take(...)`).
+
+## Zstd Compression
+
+**Characteristics:**
+- Strong ratio at good speed
+- Cassandra `ZstdCompressor`
+- Bare zstd frame — decode via the streaming decoder with an output bound
+  (`compression.rs`, Zstd arm); no separate 4-byte length prefix is added by CQLite's
+  reader beyond what the frame itself carries.
+
 ## CRC Validation
 
-When `crcCheckChance > 0`, validate checksums:
+The inline CRC32 is **unconditional** for `na`/`nb` (see *Chunk Format* above): 4 bytes
+**big-endian**, computed over the **COMPRESSED** bytes. `crc_check_chance` is a schema
+option about *validation* frequency, not presence.
 
 ```rust
-fn validate_crc(data: &[u8], expected_crc: u32) -> Result<()> {
-    let actual_crc = crc32fast::hash(data);
-    if actual_crc != expected_crc {
-        return Err(Error::CrcMismatch { expected_crc, actual_crc });
+// `compressed_data` is the chunk payload BEFORE decompression — never the decompressed buffer.
+fn validate_chunk_crc(compressed_data: &[u8], crc_bytes: [u8; 4]) -> Result<()> {
+    let stored_crc = u32::from_be_bytes(crc_bytes);
+    let computed_crc = crc32fast::hash(compressed_data);
+    if stored_crc != computed_crc {
+        return Err(Error::InvalidFormat(format!(
+            "CRC32 mismatch: stored=0x{:08x}, computed=0x{:08x}",
+            stored_crc, computed_crc
+        )));
     }
     Ok(())
 }
 ```
+
+> **Citation**: `cqlite-core/src/storage/sstable/chunk_decompressor.rs:275-292`.
 
 ## Reading Compressed Data
 
@@ -114,19 +208,26 @@ fn validate_crc(data: &[u8], expected_crc: u32) -> Result<()> {
    - Extract data at relative offset within decompressed buffer
 
 ### Offset Calculation
+
+Because chunks are **fixed-size in the UNCOMPRESSED domain** (`chunk_length`), the chunk
+index is arithmetic — there is no per-chunk length to search:
+
 ```rust
-// Logical offset (from Index.db) → Physical chunk
-fn find_chunk(logical_offset: u64, chunks: &[ChunkInfo]) -> Option<&ChunkInfo> {
-    chunks.iter()
-        .find(|chunk| {
-            logical_offset >= chunk.offset 
-            && logical_offset < chunk.offset + chunk.uncompressed_length
-        })
+// Logical (uncompressed) offset → chunk index. chunk_length comes from CompressionInfo.db.
+fn chunk_index(logical_offset: u64, chunk_length: u32) -> usize {
+    (logical_offset / chunk_length as u64) as usize
 }
 
-// Offset within decompressed chunk
-fn relative_offset(logical_offset: u64, chunk: &ChunkInfo) -> usize {
-    (logical_offset - chunk.offset) as usize
+// Offset within the decompressed chunk buffer.
+fn relative_offset(logical_offset: u64, chunk_length: u32) -> usize {
+    (logical_offset % chunk_length as u64) as usize
+}
+
+// Physical payload length: the offset DELTA minus the 4-byte trailing CRC.
+// There is no stored per-chunk length field.
+fn compressed_payload_len(i: usize, offsets: &[u64], data_file_len: u64) -> u64 {
+    let end = offsets.get(i + 1).copied().unwrap_or(data_file_len);
+    end - offsets[i] - 4
 }
 ```
 
@@ -154,10 +255,10 @@ fn get_slice(&self, offset: usize, len: usize) -> Bytes {
 
 ## Compression Parameters
 
-From Statistics.db `CompressionParameters`:
+The **schema-level** compression options (what `DESCRIBE TABLE` shows) look like:
 ```json
 {
-  "chunk_length_in_kb": 64,
+  "chunk_length_in_kb": 16,
   "class": "org.apache.cassandra.io.compress.LZ4Compressor",
   "crc_check_chance": 1.0,
   "compression_level": null
@@ -165,9 +266,18 @@ From Statistics.db `CompressionParameters`:
 ```
 
 **Key Values:**
-- `chunk_length_in_kb`: Usually 16, 32, or 64
-- `crc_check_chance`: 1.0 = always check, 0.0 = never check
-- `compression_level`: Deflate-specific (1-9)
+- `chunk_length_in_kb`: **default 16** in Cassandra 5.0
+  (`CompressionParams.DEFAULT_CHUNK_LENGTH = 1024 * 16`, cassandra-5.0.8
+  `schema/CompressionParams.java:47`); 32 and 64 are common overrides.
+- `crc_check_chance`: 1.0 = always validate, 0.0 = never validate. The inline CRC is on
+  disk regardless.
+- `compression_level`: Deflate/Zstd-specific.
+
+**On the READ path, do not source these from `Statistics.db`.** The values the decompressor
+needs (`compressor_simple_name`, `chunk_length`, `max_compressed_length`, `data_length`,
+`chunk_count`, offsets) are read from **`CompressionInfo.db`**
+(`cqlite-core/src/storage/sstable/compression_info.rs:62-85`). The
+`option_pairs` there carry any extra options the writer recorded.
 
 ## Error Handling
 
@@ -188,5 +298,16 @@ Per PRD M1:
 
 ## Reference
 
-See `cqlite-core/src/storage/sstable/reader/compression/` for implementation.
+Implementation (verify against `origin/main` — these are the authorities for what CQLite
+actually does):
+- `cqlite-core/src/storage/sstable/compression_info.rs` — `CompressionInfo.db` parser,
+  `SUPPORTED_COMPRESSOR_NAMES`, offsets-only chunk array.
+- `cqlite-core/src/storage/sstable/chunk_decompressor.rs` — chunk record read, inline
+  big-endian CRC32 validation over compressed bytes, per-algorithm chunk decode.
+- `cqlite-core/src/storage/sstable/compression.rs` — algorithm dispatch; the `#1082`
+  Deflate-is-zlib trap comment lives here.
+
+Format authority for genuinely disputed on-disk questions is Apache Cassandra 5.0.8
+(`CompressionMetadata.java`, `CompressedSequentialWriter.java`, `CompressionParams.java`),
+plus `docs/sstables-definitive-guide/` Ch.9.
 

--- a/.claude/skills/sstable-parsing/compression-formats.md
+++ b/.claude/skills/sstable-parsing/compression-formats.md
@@ -85,8 +85,9 @@ is written. CQLite always validates.
 uncompressed-length prefix** to a **raw LZ4 block** (this is NOT the `lz4_flex`
 size-prepended/varint format).
 
-**Rust Implementation** — this repo uses the **`lz4_flex`** crate. The `lz4` crate is NOT
-a dependency; a sample calling `lz4::block::decompress` cannot compile here.
+**Rust Implementation** — this repo uses the **`lz4_flex`** crate. The bare `lz4` crate is
+NOT a workspace dependency, so any sample calling its `block::decompress` API cannot
+compile here.
 
 ```rust
 // Cassandra LZ4Compressor.decompress() lines 169-172: 4-byte LE length prefix + raw block.
@@ -138,8 +139,8 @@ fn decompress_snappy(compressed: &[u8]) -> Result<Vec<u8>> {
 > ### ⚠️ TRAP — this is shipped P0 #1082 (deflate-as-zlib / zstd bare-frame)
 > Cassandra's `DeflateCompressor` uses `java.util.zip.Deflater`/`Inflater`, which emit a
 > **zlib-wrapped** stream: a 2-byte header (`0x78 0x9c`) + DEFLATE body + 4-byte Adler-32
-> trailer. Decoding it with `flate2::read::DeflateDecoder` (raw DEFLATE) is **exactly the
-> P0 bug #1082**. Use **`flate2::read::ZlibDecoder`**. There is also **no** 4-byte
+> trailer. Decoding it with flate2's **raw-DEFLATE** reader is **exactly the P0 bug
+> #1082** — you must use flate2's **zlib** reader, `ZlibDecoder`. There is also **no** 4-byte
 > uncompressed-size prefix here — that is an LZ4/Zstd convention.
 
 **Rust Implementation:**

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -231,6 +231,16 @@
 #                      whether the supersession grace can actually fire — plus a
 #                      GNU-only-construct lint over this mechanism's shell). All three
 #                      prove non-vacuity with always-pass stubs or mutants.
+#                      Also runs (no python3 needed)
+#                      scripts/tests/test_check_skill_flag_tables.sh (#3054) — pins
+#                      scripts/ci/check-skill-flag-tables.sh, which asserts the
+#                      AUTO-LOADED .claude/skills/sstable-parsing/ row/extended/cell
+#                      flag tables match the real row_decoder constants (an agent
+#                      trusts a skill table over the code, and the pre-#3054 tables
+#                      taught partition-boundary mis-detection). Hermetic temp-sandbox
+#                      copy; proves non-vacuity by mutating the copy (shifted value,
+#                      invented name, dropped row) and fails closed on a moved
+#                      decoder source or a reformatted-away table.
 #   minimal-build      cargo build + `cargo test --lib --no-run` (compile-only)
 #                      -p cqlite-core --no-default-features --features all-compression
 #   smoke              bash test-data/scripts/smoke-test-all-tables.sh
@@ -4532,9 +4542,15 @@ run_kit_dashboard_drift() {
 # scripts/tests/test_gate_failure_mode.sh (#2662), which pins the decision table
 # of scripts/ci/gate-failure-mode.sh — the routing logic behind the nightly
 # gate-failure alert workflow, which is otherwise untestable (it only fires on a
-# real workflow_run event). Pure/offline, no gh/network. SKIP-aware:
-# the summary test's truncation case relies on a python3 reader, so with no
-# python3 we record SKIP (loud, never silent PASS); any test failure -> hard FAIL.
+# real workflow_run event). Pure/offline, no gh/network. Also runs
+# scripts/tests/test_check_skill_flag_tables.sh (#3054), which pins
+# scripts/ci/check-skill-flag-tables.sh: the AUTO-LOADED sstable-parsing skill's
+# row/extended/cell flag tables must match the real row_decoder constants, so an
+# agent can never again be taught a partition-boundary decode bug by a rotted skill
+# table (hermetic temp-sandbox copy; no cargo/datasets/network). Pure/offline, no
+# gh/network. SKIP-aware: the summary test's truncation case relies on a python3
+# reader, so with no python3 we record SKIP (loud, never silent PASS); any test
+# failure -> hard FAIL.
 run_tooling_tests() {
   local name=tooling-tests
   if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
@@ -4588,6 +4604,26 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_check_dockerfile_rust_pin.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (flight Dockerfile rust-pin lockstep); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # auto-loaded-skill flag-table drift guard (#3054): no python3/Docker/cargo
+  # needed, always runs. Pins the row/extended/cell flag tables in
+  # .claude/skills/sstable-parsing/{SKILL.md,cassandra5-format-reference.md} to the
+  # real constants in row_decoder/{mod.rs,row_data.rs} — those skills auto-load into
+  # every binary-format agent context, and the pre-#3054 tables taught
+  # partition-boundary mis-detection (0x01 labeled IS_MARKER/IS_STATIC). Fails closed
+  # when a source split moves the constants or the table is reformatted away. A
+  # failure FAILs the component, mirroring the keyspace-scoping guard.
+  echo ">>> [$name] bash scripts/tests/test_check_skill_flag_tables.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_check_skill_flag_tables.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (skill flag-table drift guard); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/ci/check-skill-flag-tables.sh
+++ b/scripts/ci/check-skill-flag-tables.sh
@@ -16,43 +16,67 @@
 #   1. NAME is a real flag constant in the decoder source (catches INVENTED flags), and
 #   2. its documented 0xNN value equals the source constant's value (catches SHIFTED /
 #      INVERTED tables), and
-#   3. every source constant is documented at least once across the skill files (catches
-#      a silently DROPPED flag).
+#   3. NAME is documented in the right NAMESPACE — row / extended / cell (`0x01` means
+#      three different things across the three bytes, so a correct name+value in the
+#      wrong table still teaches the pre-#3054 confusion), and
+#   4. every source constant is documented at least once (catches a silently DROPPED
+#      flag, which leaves an agent guessing that bit — no-heuristics mandate, #28).
+#
+# It is FAIL-CLOSED by construction: a missing source file, an unparseable/renamed
+# constant, an unclassifiable constant, a table row under an unrecognized heading, a
+# suspiciously small harvest, and a file with no parseable table row all FAIL loudly
+# rather than passing vacuously. A vacuous pass would reintroduce the very bug class.
 #
 # Sources of truth (CQLite code = authority for what CQLite does; Cassandra 5.0.8 =
 # authority for the format itself):
-#   cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs   (row + extended flags)
-#   cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs (CELL_* flags)
+#   .../row_decoder/mod.rs         — row flags + extended flags
+#   .../row_decoder/cell_value.rs  — CELL_* flags, from the PRODUCTION cell decoder
+#                                    (`parse_cell_value_schema_order`). NOTE: row_data.rs
+#                                    has a `#[cfg(test)]` mirror carrying only 4 of the 5
+#                                    flags — pinning to that test helper would let a real
+#                                    production change drift unnoticed, so we do not.
+#
+# Escape hatch: a u8 constant in a harvested file that is genuinely NOT an on-disk flag
+# can be excluded with a trailing `flag-table-lint-ignore` comment on its line. There is
+# deliberately no way to make a REAL flag silently exempt.
 #
 # Usage: check-skill-flag-tables.sh [REPO_ROOT]
 # Exit 0 = every documented pair matches source; non-zero (named reason) = drift.
-# Pure bash + grep/sed: no python3, cargo, network, or datasets.
+# Pure bash + grep/sed/awk: no python3, cargo, network, or datasets. bash 3.2 compatible.
 set -euo pipefail
 
 REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 
-ROW_SRC="$REPO_ROOT/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs"
-CELL_SRC="$REPO_ROOT/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs"
+DECODER_DIR="$REPO_ROOT/cqlite-core/src/storage/sstable/reader/parsing/row_decoder"
+ROW_SRC="$DECODER_DIR/mod.rs"
+CELL_SRC="$DECODER_DIR/cell_value.rs"
 
 SKILL_FILES=(
   ".claude/skills/sstable-parsing/SKILL.md"
   ".claude/skills/sstable-parsing/cassandra5-format-reference.md"
 )
 
+# Floor on the harvest size. Cassandra 5.0's three flag bytes define 8 row + 1 extended
+# + 5 cell = 14 flags today; a parse that yields far fewer is broken, not a shrunken
+# format. Deliberately below 14 so ADDING a flag never trips it.
+MIN_EXPECTED_FLAGS=12
+
 fail() { echo "::error::check-skill-flag-tables: $*"; exit 1; }
 
 for f in "$ROW_SRC" "$CELL_SRC"; do
-  [ -f "$f" ] || fail "decoder source not found at $f (a source split may have moved it — retarget this check AND the skill citations)"
+  [ -f "$f" ] || fail "decoder source not found at $f (a source split may have moved it — retarget this check AND the skill citations; refusing to pass vacuously)"
 done
 
 # ---- 1. Harvest the real constants ----------------------------------------
-# Matches e.g. `const ROW_HAS_TIMESTAMP: u8 = 0x04;` and
-# `const END_OF_PARTITION: u8 = 0x01; // comment`.
-# Emits "NAME 0xNN" lines with the hex normalized to lowercase, 2 digits.
+# Matches e.g. `const ROW_HAS_TIMESTAMP: u8 = 0x04;`,
+# `pub(super) const FOO: u8 = 0x80;` and `const END_OF_PARTITION: u8 = 0x01; // note`.
+# Any visibility qualifier is accepted, so a later `pub(crate)`/`pub(super)` flag cannot
+# slip past the parse. Emits "NAME 0xNN" with the hex normalized to lowercase, 2 digits.
 # NOTE: lowercase ONLY the hex field — `tr` on the whole line would also lowercase the
 # constant NAME and silently break every comparison.
 harvest() {
-  sed -nE 's/^[[:space:]]*(pub[[:space:]]+)?const[[:space:]]+([A-Z][A-Z0-9_]*)[[:space:]]*:[[:space:]]*u8[[:space:]]*=[[:space:]]*0[xX]([0-9a-fA-F]{1,2})[[:space:]]*;.*/\2 \3/p' "$1" \
+  grep -v 'flag-table-lint-ignore' "$1" \
+    | sed -nE 's/^[[:space:]]*(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?const[[:space:]]+([A-Z][A-Z0-9_]*)[[:space:]]*:[[:space:]]*u8[[:space:]]*=[[:space:]]*0[xX]([0-9a-fA-F]{1,2})[[:space:]]*;.*/\3 \4/p' \
     | while read -r n h; do
         h="$(tr 'ABCDEF' 'abcdef' <<<"$h")"
         [ "${#h}" -eq 1 ] && h="0$h"
@@ -60,12 +84,21 @@ harvest() {
       done
 }
 
+# Records are "NAMESPACE NAME 0xNN". The namespace matters: `0x01` is END_OF_PARTITION in
+# the row byte, EXTENDED_IS_STATIC in the extended byte, and IS_DELETED in a cell byte.
 expected=""
-# Row + extended flag constants. CELL_* live in row_data.rs and are harvested below.
+
+# Row + extended flag constants. An UNCLASSIFIED u8 constant FAILs rather than being
+# silently skipped — a hand-maintained allow-list is how a newly added flag (e.g.
+# Cassandra's extended-byte HAS_SHADOWABLE_DELETION 0x02) would become exempt from the
+# "documented somewhere" assertion. Use the `flag-table-lint-ignore` marker for a
+# genuine non-flag constant.
 while read -r name val; do
   [ -z "$name" ] && continue
   case "$name" in
-    ROW_HAS_*|END_OF_PARTITION|IS_MARKER|EXTENDED_IS_STATIC) expected+="$name $val"$'\n' ;;
+    EXTENDED_*)                          expected+="extended $name $val"$'\n' ;;
+    ROW_HAS_*|END_OF_PARTITION|IS_MARKER) expected+="row $name $val"$'\n' ;;
+    *) fail "unclassified u8 constant '$name' ($val) in $ROW_SRC — this check cannot tell which flag byte it belongs to, so it cannot require the skill tables to document it. Classify it here (row/extended/cell) and document it in the skill tables, or mark the constant line 'flag-table-lint-ignore' if it is not an on-disk flag (#3054)." ;;
   esac
 done <<<"$(harvest "$ROW_SRC")"
 
@@ -74,27 +107,31 @@ done <<<"$(harvest "$ROW_SRC")"
 while read -r name val; do
   [ -z "$name" ] && continue
   case "$name" in
-    CELL_*) expected+="${name#CELL_} $val"$'\n' ;;
+    CELL_*) expected+="cell ${name#CELL_} $val"$'\n' ;;
+    *) fail "unclassified u8 constant '$name' ($val) in $CELL_SRC — classify it or mark the line 'flag-table-lint-ignore' (#3054)." ;;
   esac
 done <<<"$(harvest "$CELL_SRC")"
 
-# Documented-by-Cassandra-only exception. HAS_EMPTY_VALUE (0x04) is a real Cassandra 5.0
-# cell mask (`db/rows/Cell.java:264` HAS_EMPTY_VALUE_MASK) that CQLite handles without a
-# named `const` (see row_data.rs:282). Pinned here with its authority so the skill table
-# may document it; every OTHER name must come from a source constant.
-expected+="HAS_EMPTY_VALUE 0x04"$'\n'
-
-expected="$(grep -v '^[[:space:]]*$' <<<"$expected" | sort -u)"
+expected="$(grep -v '^[[:space:]]*$' <<<"$expected" | sort -u || true)"
 [ -n "$expected" ] || fail "harvested ZERO flag constants from the decoder source — the parse is broken, refusing to pass vacuously"
 
+expected_count="$(grep -c . <<<"$expected" || true)"
+[ "$expected_count" -ge "$MIN_EXPECTED_FLAGS" ] \
+  || fail "harvested only $expected_count flag constants (floor $MIN_EXPECTED_FLAGS) from $ROW_SRC + $CELL_SRC — a half-broken parse must not pass. Fix the harvest regex or retarget the sources (#3054)."
+
 # A shifted table is only caught if the anchors are present. Require the flags whose
-# mis-assignment caused #3054.
-for must in END_OF_PARTITION IS_MARKER ROW_HAS_COMPLEX_DELETION EXTENDED_IS_STATIC; do
+# mis-assignment caused #3054, each in its expected namespace.
+for must in "row END_OF_PARTITION" "row IS_MARKER" "row ROW_HAS_COMPLEX_DELETION" \
+            "extended EXTENDED_IS_STATIC" "cell IS_DELETED" "cell HAS_EMPTY_VALUE"; do
   grep -q "^$must " <<<"$expected" \
-    || fail "expected constant $must not found in $ROW_SRC — cannot verify the #3054 anchors; retarget this check"
+    || fail "expected constant '$must' not found in the decoder source — cannot verify the #3054 anchors; retarget this check"
 done
 
-lookup() { grep -m1 "^$1 " <<<"$expected" | awk '{print $2}'; }
+# `|| true`: a miss is a REPORTABLE finding (an invented flag name), not a reason for the
+# script to abort. Without it, `set -e` + `pipefail` kills the run at the assignment and
+# the actionable "documents flag X which is NOT a constant" message below never prints.
+lookup() { grep -m1 "^$1 $2 " <<<"$expected" | awk '{print $3}' || true; }
+lookup_any_ns() { grep -m1 " $1 " <<<"$expected" | awk '{print $1}' || true; }
 
 # ---- 2. Check every documented pair --------------------------------------
 documented=""
@@ -105,43 +142,84 @@ for rel in "${SKILL_FILES[@]}"; do
   path="$REPO_ROOT/$rel"
   [ -f "$path" ] || fail "skill file not found at $path"
 
-  # Markdown flag-table rows: | `0xNN` | `NAME` | description |
-  mapfile -t rows < <(sed -nE 's/^\|[[:space:]]*`0[xX]([0-9a-fA-F]{1,2})`[[:space:]]*\|[[:space:]]*`([A-Z][A-Z0-9_]*)`[[:space:]]*\|.*/\1 \2/p' "$path" || true)
+  # Single pass: track the nearest preceding heading (markdown `#`/`**bold**` lead-in) so
+  # each flag row is checked against the flag BYTE its section is about.
+  section=""
+  ns=""
+  lineno=0
+  file_rows=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    case "$line" in
+      '#'*|'**'*)
+        section="$line"
+        # Order matters: an "EXTENDED flag byte" heading also mentions "(Row)".
+        lower="$(tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz' <<<"$line")"
+        case "$lower" in
+          *extended*flag*) ns=extended ;;
+          *cell*flag*)     ns=cell ;;
+          *main*flag*|*"flag bytes (row)"*) ns=row ;;
+          # Any other heading CLEARS the namespace: a flag table that drifts away from a
+          # recognizable heading must FAIL, not inherit a stale namespace.
+          *) ns="" ;;
+        esac
+        continue
+        ;;
+    esac
 
-  if [ "${#rows[@]}" -eq 0 ]; then
-    fail "$rel contains NO parseable flag-table row (| \`0xNN\` | \`NAME\` | … |). The row-flag table is the whole point of this file — if it was reformatted, update this check in the same change (#3054)."
-  fi
+    # Markdown flag-table row: | `0xNN` | `NAME` | description |
+    row="$(sed -nE 's/^\|[[:space:]]*`0[xX]([0-9a-fA-F]{1,2})`[[:space:]]*\|[[:space:]]*`([A-Z][A-Z0-9_]*)`[[:space:]]*\|.*/\1 \2/p' <<<"$line")"
+    [ -z "$row" ] && continue
 
-  for row in "${rows[@]}"; do
     hex="$(awk '{print $1}' <<<"$row" | tr 'ABCDEF' 'abcdef')"
     [ "${#hex}" -eq 1 ] && hex="0$hex"
     doc_val="0x$hex"
     name="$(awk '{print $2}' <<<"$row")"
     rows_seen=$((rows_seen + 1))
-    documented+="$name"$'\n'
+    file_rows=$((file_rows + 1))
 
-    src_val="$(lookup "$name")"
+    if [ -z "$ns" ]; then
+      echo "::error::check-skill-flag-tables: $rel:$lineno documents flag '$name' ($doc_val) under an UNRECOGNIZED section heading '${section:-<none>}'."
+      echo "         \`0x01\` means END_OF_PARTITION (row byte), EXTENDED_IS_STATIC (extended byte), or IS_DELETED (cell byte) — this check cannot verify a row it cannot attribute to a byte."
+      echo "         Put the table under a heading naming its byte (\"main flag byte\", \"EXTENDED flag byte\", \"Cell Flags\") or teach this check the new heading (#3054)."
+      errors=$((errors + 1))
+      continue
+    fi
+
+    documented+="$ns $name"$'\n'
+
+    src_val="$(lookup "$ns" "$name")"
     if [ -z "$src_val" ]; then
-      echo "::error::check-skill-flag-tables: $rel documents flag '$name' ($doc_val) which is NOT a constant in the decoder source."
-      echo "         Either it is INVENTED (e.g. the pre-#3054 HAS_IS_MARKER / HAS_NULL_VALUE / EXTENDED_FLAG) or the constant was renamed."
-      echo "         Authority: $ROW_SRC and $CELL_SRC."
+      other_ns="$(lookup_any_ns "$name")"
+      if [ -n "$other_ns" ]; then
+        echo "::error::check-skill-flag-tables: FLAG NAMESPACE DRIFT in $rel:$lineno — '$name' is documented in the '$ns' flag-byte table, but it is a '$other_ns'-byte flag."
+        echo "         The same bit value means different things in the row / extended / cell bytes; documenting a flag under the wrong byte teaches the pre-#3054 confusion."
+      else
+        echo "::error::check-skill-flag-tables: $rel:$lineno documents flag '$name' ($doc_val) which is NOT a constant in the decoder source."
+        echo "         Either it is INVENTED (e.g. the pre-#3054 HAS_IS_MARKER / HAS_NULL_VALUE / EXTENDED_FLAG) or the constant was renamed."
+        echo "         Authority: $ROW_SRC and $CELL_SRC."
+      fi
       errors=$((errors + 1))
       continue
     fi
     if [ "$doc_val" != "$src_val" ]; then
-      echo "::error::check-skill-flag-tables: FLAG VALUE DRIFT in $rel — '$name' is documented as $doc_val but the source constant is $src_val."
+      echo "::error::check-skill-flag-tables: FLAG VALUE DRIFT in $rel:$lineno — '$name' is documented as $doc_val but the source constant is $src_val."
       echo "         An auto-loaded skill table that mis-assigns a flag bit teaches a decode bug to every agent (#3054)."
       errors=$((errors + 1))
     fi
-  done
+  done <"$path"
+
+  if [ "$file_rows" -eq 0 ]; then
+    fail "$rel contains NO parseable flag-table row (| \`0xNN\` | \`NAME\` | … |). The flag table is the whole point of this file — if it was reformatted, update this check in the same change (#3054)."
+  fi
 done
 
 # ---- 3. No source constant silently dropped ------------------------------
-documented="$(grep -v '^[[:space:]]*$' <<<"$documented" | sort -u)"
-while read -r name _val; do
+documented="$(grep -v '^[[:space:]]*$' <<<"$documented" | sort -u || true)"
+while read -r ns name _val; do
   [ -z "$name" ] && continue
-  grep -qx "$name" <<<"$documented" || {
-    echo "::error::check-skill-flag-tables: flag constant '$name' exists in the decoder source but is documented in NONE of the skill flag tables."
+  grep -qx "$ns $name" <<<"$documented" || {
+    echo "::error::check-skill-flag-tables: flag constant '$name' ($ns byte) exists in the decoder source but is documented in NONE of the skill flag tables."
     echo "         A missing row leaves an agent guessing that bit (no-heuristics mandate, #28). Add it with its citation."
     errors=$((errors + 1))
   }
@@ -152,4 +230,4 @@ if [ "$errors" -gt 0 ]; then
   exit 1
 fi
 
-echo "OK: $rows_seen documented flag rows across ${#SKILL_FILES[@]} skill file(s) match the decoder constants; all $(wc -l <<<"$expected" | tr -d ' ') source flags are documented."
+echo "OK: $rows_seen documented flag rows across ${#SKILL_FILES[@]} skill file(s) match the decoder constants (namespace-checked); all $expected_count source flags are documented."

--- a/scripts/ci/check-skill-flag-tables.sh
+++ b/scripts/ci/check-skill-flag-tables.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# check-skill-flag-tables.sh — mechanize the #3054 anti-rot invariant for the
+# AUTO-LOADED agent skill flag tables.
+#
+# WHY: `.claude/skills/sstable-parsing/` enters agent context automatically for any
+# binary-format work, and an agent trusts a skill table over reading the code. Before
+# #3054 those tables claimed `0x01 = HAS_IS_MARKER` and `0x40 = IS_STATIC` — i.e. they
+# taught the agent to mis-detect PARTITION BOUNDARIES (`0x01` is `END_OF_PARTITION`) and
+# invented cell flags (`0x20 HAS_NULL_VALUE`, `0x40 EXTENDED_FLAG`) that do not exist in
+# Cassandra 5.0. A wrong table is strictly worse than no table. This check pins every
+# documented name->value pair to the REAL constant in the decoder source, so the class of
+# rot cannot recur silently.
+#
+# WHAT it asserts, for each markdown flag-table row `| `0xNN` | `NAME` | ... |` in the
+# skill files below:
+#   1. NAME is a real flag constant in the decoder source (catches INVENTED flags), and
+#   2. its documented 0xNN value equals the source constant's value (catches SHIFTED /
+#      INVERTED tables), and
+#   3. every source constant is documented at least once across the skill files (catches
+#      a silently DROPPED flag).
+#
+# Sources of truth (CQLite code = authority for what CQLite does; Cassandra 5.0.8 =
+# authority for the format itself):
+#   cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs   (row + extended flags)
+#   cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs (CELL_* flags)
+#
+# Usage: check-skill-flag-tables.sh [REPO_ROOT]
+# Exit 0 = every documented pair matches source; non-zero (named reason) = drift.
+# Pure bash + grep/sed: no python3, cargo, network, or datasets.
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+ROW_SRC="$REPO_ROOT/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/mod.rs"
+CELL_SRC="$REPO_ROOT/cqlite-core/src/storage/sstable/reader/parsing/row_decoder/row_data.rs"
+
+SKILL_FILES=(
+  ".claude/skills/sstable-parsing/SKILL.md"
+  ".claude/skills/sstable-parsing/cassandra5-format-reference.md"
+)
+
+fail() { echo "::error::check-skill-flag-tables: $*"; exit 1; }
+
+for f in "$ROW_SRC" "$CELL_SRC"; do
+  [ -f "$f" ] || fail "decoder source not found at $f (a source split may have moved it — retarget this check AND the skill citations)"
+done
+
+# ---- 1. Harvest the real constants ----------------------------------------
+# Matches e.g. `const ROW_HAS_TIMESTAMP: u8 = 0x04;` and
+# `const END_OF_PARTITION: u8 = 0x01; // comment`.
+# Emits "NAME 0xNN" lines with the hex normalized to lowercase, 2 digits.
+# NOTE: lowercase ONLY the hex field — `tr` on the whole line would also lowercase the
+# constant NAME and silently break every comparison.
+harvest() {
+  sed -nE 's/^[[:space:]]*(pub[[:space:]]+)?const[[:space:]]+([A-Z][A-Z0-9_]*)[[:space:]]*:[[:space:]]*u8[[:space:]]*=[[:space:]]*0[xX]([0-9a-fA-F]{1,2})[[:space:]]*;.*/\2 \3/p' "$1" \
+    | while read -r n h; do
+        h="$(tr 'ABCDEF' 'abcdef' <<<"$h")"
+        [ "${#h}" -eq 1 ] && h="0$h"
+        printf '%s 0x%s\n' "$n" "$h"
+      done
+}
+
+expected=""
+# Row + extended flag constants. CELL_* live in row_data.rs and are harvested below.
+while read -r name val; do
+  [ -z "$name" ] && continue
+  case "$name" in
+    ROW_HAS_*|END_OF_PARTITION|IS_MARKER|EXTENDED_IS_STATIC) expected+="$name $val"$'\n' ;;
+  esac
+done <<<"$(harvest "$ROW_SRC")"
+
+# CELL_* constants: the skill tables document them WITHOUT the `CELL_` prefix
+# (Cassandra's own Cell.java names), so strip it for comparison.
+while read -r name val; do
+  [ -z "$name" ] && continue
+  case "$name" in
+    CELL_*) expected+="${name#CELL_} $val"$'\n' ;;
+  esac
+done <<<"$(harvest "$CELL_SRC")"
+
+# Documented-by-Cassandra-only exception. HAS_EMPTY_VALUE (0x04) is a real Cassandra 5.0
+# cell mask (`db/rows/Cell.java:264` HAS_EMPTY_VALUE_MASK) that CQLite handles without a
+# named `const` (see row_data.rs:282). Pinned here with its authority so the skill table
+# may document it; every OTHER name must come from a source constant.
+expected+="HAS_EMPTY_VALUE 0x04"$'\n'
+
+expected="$(grep -v '^[[:space:]]*$' <<<"$expected" | sort -u)"
+[ -n "$expected" ] || fail "harvested ZERO flag constants from the decoder source — the parse is broken, refusing to pass vacuously"
+
+# A shifted table is only caught if the anchors are present. Require the flags whose
+# mis-assignment caused #3054.
+for must in END_OF_PARTITION IS_MARKER ROW_HAS_COMPLEX_DELETION EXTENDED_IS_STATIC; do
+  grep -q "^$must " <<<"$expected" \
+    || fail "expected constant $must not found in $ROW_SRC — cannot verify the #3054 anchors; retarget this check"
+done
+
+lookup() { grep -m1 "^$1 " <<<"$expected" | awk '{print $2}'; }
+
+# ---- 2. Check every documented pair --------------------------------------
+documented=""
+rows_seen=0
+errors=0
+
+for rel in "${SKILL_FILES[@]}"; do
+  path="$REPO_ROOT/$rel"
+  [ -f "$path" ] || fail "skill file not found at $path"
+
+  # Markdown flag-table rows: | `0xNN` | `NAME` | description |
+  mapfile -t rows < <(sed -nE 's/^\|[[:space:]]*`0[xX]([0-9a-fA-F]{1,2})`[[:space:]]*\|[[:space:]]*`([A-Z][A-Z0-9_]*)`[[:space:]]*\|.*/\1 \2/p' "$path" || true)
+
+  if [ "${#rows[@]}" -eq 0 ]; then
+    fail "$rel contains NO parseable flag-table row (| \`0xNN\` | \`NAME\` | … |). The row-flag table is the whole point of this file — if it was reformatted, update this check in the same change (#3054)."
+  fi
+
+  for row in "${rows[@]}"; do
+    hex="$(awk '{print $1}' <<<"$row" | tr 'ABCDEF' 'abcdef')"
+    [ "${#hex}" -eq 1 ] && hex="0$hex"
+    doc_val="0x$hex"
+    name="$(awk '{print $2}' <<<"$row")"
+    rows_seen=$((rows_seen + 1))
+    documented+="$name"$'\n'
+
+    src_val="$(lookup "$name")"
+    if [ -z "$src_val" ]; then
+      echo "::error::check-skill-flag-tables: $rel documents flag '$name' ($doc_val) which is NOT a constant in the decoder source."
+      echo "         Either it is INVENTED (e.g. the pre-#3054 HAS_IS_MARKER / HAS_NULL_VALUE / EXTENDED_FLAG) or the constant was renamed."
+      echo "         Authority: $ROW_SRC and $CELL_SRC."
+      errors=$((errors + 1))
+      continue
+    fi
+    if [ "$doc_val" != "$src_val" ]; then
+      echo "::error::check-skill-flag-tables: FLAG VALUE DRIFT in $rel — '$name' is documented as $doc_val but the source constant is $src_val."
+      echo "         An auto-loaded skill table that mis-assigns a flag bit teaches a decode bug to every agent (#3054)."
+      errors=$((errors + 1))
+    fi
+  done
+done
+
+# ---- 3. No source constant silently dropped ------------------------------
+documented="$(grep -v '^[[:space:]]*$' <<<"$documented" | sort -u)"
+while read -r name _val; do
+  [ -z "$name" ] && continue
+  grep -qx "$name" <<<"$documented" || {
+    echo "::error::check-skill-flag-tables: flag constant '$name' exists in the decoder source but is documented in NONE of the skill flag tables."
+    echo "         A missing row leaves an agent guessing that bit (no-heuristics mandate, #28). Add it with its citation."
+    errors=$((errors + 1))
+  }
+done <<<"$expected"
+
+if [ "$errors" -gt 0 ]; then
+  echo "::error::check-skill-flag-tables: $errors flag-table drift error(s). Fix the skill table(s) against the decoder source (#3054)."
+  exit 1
+fi
+
+echo "OK: $rows_seen documented flag rows across ${#SKILL_FILES[@]} skill file(s) match the decoder constants; all $(wc -l <<<"$expected" | tr -d ' ') source flags are documented."

--- a/scripts/tests/test_check_skill_flag_tables.sh
+++ b/scripts/tests/test_check_skill_flag_tables.sh
@@ -2,6 +2,11 @@
 # test_check_skill_flag_tables.sh — self-test for the auto-loaded-skill flag-table
 # drift guard (issue #3054).
 #
+# Every negative assertion checks not just THAT the guard failed but WHY (a distinctive
+# substring of the intended diagnostic). A bare non-zero-exit assertion is vacuous: it
+# passes on an unrelated silent abort, which is exactly how the first cut of this suite
+# let a `set -e` bug hide the guard's most actionable message.
+#
 # Proves check-skill-flag-tables.sh:
 #   1. PASSes on the REAL repo (the skill tables match the decoder constants today),
 #   2. FAILs on a SHIFTED value — the exact pre-#3054 bug (`0x01` labeled `IS_MARKER`
@@ -9,9 +14,16 @@
 #   3. FAILs on an INVENTED flag name (the pre-#3054 `HAS_IS_MARKER`),
 #   4. FAILs when a real source constant is documented in NO skill table (dropped row),
 #   5. FAILs CLOSED when the decoder source is missing/moved (never a vacuous PASS),
-#   6. FAILs CLOSED when the flag table is reformatted out of existence.
-# Hermetic: copies the repo's relevant subtrees into a temp dir and mutates the COPY;
-# no cargo, network, or datasets.
+#   6. FAILs CLOSED when the flag table is reformatted out of existence,
+#   7. FAILs on a SHIFTED CELL value in the reference file (the cell table lives ONLY
+#      there, so without this the whole CELL_* path has no mutant),
+#   8. FAILs on a NAMESPACE swap — a real name+value documented under the wrong flag
+#      byte (`0x01 EXTENDED_IS_STATIC` inside the ROW table),
+#   9. FAILs CLOSED on a NEW unclassified source flag (a hand-maintained allow-list
+#      would silently exempt it from "must be documented"),
+#  10. FAILs CLOSED when a flag table drifts out from under a recognizable heading.
+# Hermetic: copies the repo's relevant files into a temp dir and mutates the COPY;
+# no cargo, network, or datasets. bash 3.2 compatible.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -26,6 +38,8 @@ SKILL_DIR_REL=".claude/skills/sstable-parsing"
 DECODER_DIR_REL="cqlite-core/src/storage/sstable/reader/parsing/row_decoder"
 SKILL_MD="$SKILL_DIR_REL/SKILL.md"
 REF_MD="$SKILL_DIR_REL/cassandra5-format-reference.md"
+ROW_RS="$DECODER_DIR_REL/mod.rs"
+CELL_RS="$DECODER_DIR_REL/cell_value.rs"
 
 # 1. The real repo must pass.
 if ! bash "$GUARD" "$REPO_ROOT" >/dev/null 2>&1; then
@@ -36,17 +50,17 @@ fi
 echo "OK: real repo PASSes"
 
 # Per-run temp sandbox with a TERMINAL-XXXXXX template (macOS mktemp substitutes only
-# a trailing run of X's). Cleaned up on exit.
+# a trailing run of X's). Cleaned up on exit, and on Ctrl-C / termination too.
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/skill-flag-tables-test-XXXXXX")"
-trap 'rm -rf "$tmp"' EXIT
+trap 'rm -rf "$tmp"' EXIT INT TERM
 
 # Build a minimal sandbox: the guard needs the two skill files + the two decoder sources.
 sandbox="$tmp/repo"
-mkdir -p "$sandbox/$SKILL_DIR_REL" "$sandbox/$DECODER_DIR_REL" "$sandbox/scripts/ci"
+mkdir -p "$sandbox/$SKILL_DIR_REL" "$sandbox/$DECODER_DIR_REL"
 cp "$REPO_ROOT/$SKILL_MD" "$sandbox/$SKILL_MD"
 cp "$REPO_ROOT/$REF_MD" "$sandbox/$REF_MD"
-cp "$REPO_ROOT/$DECODER_DIR_REL/mod.rs" "$sandbox/$DECODER_DIR_REL/mod.rs"
-cp "$REPO_ROOT/$DECODER_DIR_REL/row_data.rs" "$sandbox/$DECODER_DIR_REL/row_data.rs"
+cp "$REPO_ROOT/$ROW_RS" "$sandbox/$ROW_RS"
+cp "$REPO_ROOT/$CELL_RS" "$sandbox/$CELL_RS"
 
 # Sanity: the pristine sandbox passes, so every failure below is caused by the mutation.
 if ! bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
@@ -59,7 +73,8 @@ echo "OK: pristine sandbox PASSes"
 restore() {
   cp "$REPO_ROOT/$SKILL_MD" "$sandbox/$SKILL_MD"
   cp "$REPO_ROOT/$REF_MD" "$sandbox/$REF_MD"
-  cp "$REPO_ROOT/$DECODER_DIR_REL/mod.rs" "$sandbox/$DECODER_DIR_REL/mod.rs"
+  cp "$REPO_ROOT/$ROW_RS" "$sandbox/$ROW_RS"
+  cp "$REPO_ROOT/$CELL_RS" "$sandbox/$CELL_RS"
 }
 
 # Portable in-place sed (GNU sed needs no arg; BSD/macOS sed needs an empty one).
@@ -68,61 +83,95 @@ sed_i() {
   if sed --version >/dev/null 2>&1; then sed -i "$expr" "$file"; else sed -i '' "$expr" "$file"; fi
 }
 
+# Run the guard on the sandbox, expecting FAILURE with a specific diagnostic.
+# Capture first: the guard exits non-zero here, and piping it straight into grep would
+# trip `pipefail` on the guard's own (expected) failure rather than on the grep.
+expect_fail_with() {
+  local label="$1" needle="$2" out
+  out="$(bash "$GUARD" "$sandbox" 2>&1 || true)"
+  if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
+    echo "FAIL: guard did NOT trip on: $label"
+    exit 1
+  fi
+  if ! grep -q "$needle" <<<"$out"; then
+    echo "FAIL: $label tripped the guard, but NOT via the intended path (expected to see: $needle)"
+    echo "$out"
+    exit 1
+  fi
+  echo "OK: $label"
+  restore
+}
+
 # 2. SHIFTED value: label 0x01 as IS_MARKER (0x01 is really END_OF_PARTITION).
 #    This is precisely the pre-#3054 defect that taught partition-boundary mis-detection.
 sed_i 's/| `0x01` | `END_OF_PARTITION`/| `0x01` | `IS_MARKER`/' "$sandbox/$SKILL_MD"
-if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
-  echo "FAIL: guard did NOT trip on a shifted flag value (0x01 labeled IS_MARKER)"
-  exit 1
-fi
-# Capture first: the guard exits non-zero here, and piping it straight into grep would
-# trip `pipefail` on the guard's own (expected) failure rather than on the grep.
-shift_out="$(bash "$GUARD" "$sandbox" 2>&1 || true)"
-if ! grep -q 'FLAG VALUE DRIFT' <<<"$shift_out"; then
-  echo "FAIL: shifted value tripped the guard but not via the FLAG VALUE DRIFT path"
-  echo "$shift_out"
-  exit 1
-fi
-echo "OK: shifted flag value is caught (the pre-#3054 partition-boundary bug)"
-restore
+expect_fail_with "shifted row-flag value is caught (the pre-#3054 partition-boundary bug)" \
+  'FLAG VALUE DRIFT'
 
 # 3. INVENTED flag name: the pre-#3054 `HAS_IS_MARKER`.
 sed_i 's/| `0x02` | `IS_MARKER`/| `0x02` | `HAS_IS_MARKER`/' "$sandbox/$SKILL_MD"
-if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
-  echo "FAIL: guard did NOT trip on an invented flag name (HAS_IS_MARKER)"
-  exit 1
-fi
-echo "OK: invented flag name is caught"
-restore
+expect_fail_with "invented flag name is caught" \
+  "documents flag 'HAS_IS_MARKER'"
 
 # 4. DROPPED row: remove ROW_HAS_COMPLEX_DELETION from BOTH skill tables.
 sed_i '/`ROW_HAS_COMPLEX_DELETION`/d' "$sandbox/$SKILL_MD"
 sed_i '/`ROW_HAS_COMPLEX_DELETION`/d' "$sandbox/$REF_MD"
-if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
-  echo "FAIL: guard did NOT trip when a real source constant is documented nowhere"
-  exit 1
-fi
-echo "OK: silently-dropped flag row is caught"
-restore
+expect_fail_with "silently-dropped flag row is caught" \
+  'documented in NONE of the skill flag tables'
 
 # 5. FAIL-CLOSED when the decoder source moved (a source split must not yield a
 #    vacuous PASS against a stale table).
-mv "$sandbox/$DECODER_DIR_REL/mod.rs" "$tmp/mod.rs.away"
+mv "$sandbox/$ROW_RS" "$tmp/mod.rs.away"
+out="$(bash "$GUARD" "$sandbox" 2>&1 || true)"
 if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
   echo "FAIL: guard PASSED vacuously with the decoder source missing"
   exit 1
 fi
+grep -q 'decoder source not found' <<<"$out" || {
+  echo "FAIL: missing decoder source failed, but not via the fail-closed path"; echo "$out"; exit 1; }
 echo "OK: missing decoder source FAILs closed"
-mv "$tmp/mod.rs.away" "$sandbox/$DECODER_DIR_REL/mod.rs"
+mv "$tmp/mod.rs.away" "$sandbox/$ROW_RS"
 restore
 
 # 6. FAIL-CLOSED when the flag table is reformatted away entirely.
 sed_i '/^| `0x/d' "$sandbox/$SKILL_MD"
-if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
-  echo "FAIL: guard PASSED with no parseable flag-table row (a reformat must fail closed)"
+expect_fail_with "reformatted-away flag table FAILs closed" \
+  'NO parseable flag-table row'
+
+# 7. SHIFTED CELL value, in the REFERENCE file (the only file carrying the cell table —
+#    without this mutant the entire CELL_* path is unproven).
+sed_i 's/| `0x08` | `USE_ROW_TIMESTAMP`/| `0x20` | `USE_ROW_TIMESTAMP`/' "$sandbox/$REF_MD"
+expect_fail_with "shifted CELL-flag value in the reference file is caught" \
+  'FLAG VALUE DRIFT'
+
+# 8. NAMESPACE swap: EXTENDED_IS_STATIC is a real constant with the real value 0x01, but
+#    documented inside the ROW flag-byte table. Name and value both check out — only the
+#    byte is wrong, which is the pre-#3054 confusion in its subtlest form.
+sed_i 's/| `0x01` | `END_OF_PARTITION`/| `0x01` | `EXTENDED_IS_STATIC`/' "$sandbox/$SKILL_MD"
+expect_fail_with "namespace swap (a real extended-byte flag documented in the row table) is caught" \
+  'FLAG NAMESPACE DRIFT'
+
+# 9. A NEW source flag the classifier does not recognize must FAIL CLOSED, not be
+#    silently exempted from "must be documented". Cassandra's extended byte really does
+#    define HAS_SHADOWABLE_DELETION = 0x02, so this is the realistic next addition.
+printf 'const HAS_SHADOWABLE_DELETION: u8 = 0x02;\n' >>"$sandbox/$ROW_RS"
+expect_fail_with "a new unclassified source flag FAILs closed (no silent allow-list exemption)" \
+  "unclassified u8 constant 'HAS_SHADOWABLE_DELETION'"
+
+# 9b. ...and the documented escape hatch works for a genuine non-flag constant.
+printf 'const SOME_TUNABLE: u8 = 0x07; // flag-table-lint-ignore\n' >>"$sandbox/$ROW_RS"
+if ! bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
+  echo "FAIL: the flag-table-lint-ignore escape hatch did not exempt a non-flag constant"
+  bash "$GUARD" "$sandbox" || true
   exit 1
 fi
-echo "OK: reformatted-away flag table FAILs closed"
+echo "OK: flag-table-lint-ignore exempts a genuine non-flag constant"
 restore
 
-echo "PASS: test_check_skill_flag_tables.sh — all 6 assertions hold"
+# 10. A flag table that drifts out from under a recognizable heading must FAIL, not
+#     inherit a stale namespace from whatever heading happened to precede it.
+sed_i 's/^\*\*Cell Flags\*\*.*/**Assorted bits**/' "$sandbox/$REF_MD"
+expect_fail_with "a flag table under an unrecognized heading FAILs closed" \
+  'UNRECOGNIZED section heading'
+
+echo "PASS: test_check_skill_flag_tables.sh — all 10 assertions hold"

--- a/scripts/tests/test_check_skill_flag_tables.sh
+++ b/scripts/tests/test_check_skill_flag_tables.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# test_check_skill_flag_tables.sh — self-test for the auto-loaded-skill flag-table
+# drift guard (issue #3054).
+#
+# Proves check-skill-flag-tables.sh:
+#   1. PASSes on the REAL repo (the skill tables match the decoder constants today),
+#   2. FAILs on a SHIFTED value — the exact pre-#3054 bug (`0x01` labeled `IS_MARKER`
+#      when `0x01` is `END_OF_PARTITION`, i.e. mis-detected partition boundaries),
+#   3. FAILs on an INVENTED flag name (the pre-#3054 `HAS_IS_MARKER`),
+#   4. FAILs when a real source constant is documented in NO skill table (dropped row),
+#   5. FAILs CLOSED when the decoder source is missing/moved (never a vacuous PASS),
+#   6. FAILs CLOSED when the flag table is reformatted out of existence.
+# Hermetic: copies the repo's relevant subtrees into a temp dir and mutates the COPY;
+# no cargo, network, or datasets.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="$REPO_ROOT/scripts/ci/check-skill-flag-tables.sh"
+
+if [ ! -f "$GUARD" ]; then
+  echo "FAIL: guard script not found at $GUARD"
+  exit 1
+fi
+
+SKILL_DIR_REL=".claude/skills/sstable-parsing"
+DECODER_DIR_REL="cqlite-core/src/storage/sstable/reader/parsing/row_decoder"
+SKILL_MD="$SKILL_DIR_REL/SKILL.md"
+REF_MD="$SKILL_DIR_REL/cassandra5-format-reference.md"
+
+# 1. The real repo must pass.
+if ! bash "$GUARD" "$REPO_ROOT" >/dev/null 2>&1; then
+  echo "FAIL: guard flagged the REAL repo — the skill flag tables have drifted from the decoder constants (#3054)"
+  bash "$GUARD" "$REPO_ROOT" || true
+  exit 1
+fi
+echo "OK: real repo PASSes"
+
+# Per-run temp sandbox with a TERMINAL-XXXXXX template (macOS mktemp substitutes only
+# a trailing run of X's). Cleaned up on exit.
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/skill-flag-tables-test-XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+# Build a minimal sandbox: the guard needs the two skill files + the two decoder sources.
+sandbox="$tmp/repo"
+mkdir -p "$sandbox/$SKILL_DIR_REL" "$sandbox/$DECODER_DIR_REL" "$sandbox/scripts/ci"
+cp "$REPO_ROOT/$SKILL_MD" "$sandbox/$SKILL_MD"
+cp "$REPO_ROOT/$REF_MD" "$sandbox/$REF_MD"
+cp "$REPO_ROOT/$DECODER_DIR_REL/mod.rs" "$sandbox/$DECODER_DIR_REL/mod.rs"
+cp "$REPO_ROOT/$DECODER_DIR_REL/row_data.rs" "$sandbox/$DECODER_DIR_REL/row_data.rs"
+
+# Sanity: the pristine sandbox passes, so every failure below is caused by the mutation.
+if ! bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
+  echo "FAIL: pristine sandbox does not PASS — the sandbox is missing an input the guard needs"
+  bash "$GUARD" "$sandbox" || true
+  exit 1
+fi
+echo "OK: pristine sandbox PASSes"
+
+restore() {
+  cp "$REPO_ROOT/$SKILL_MD" "$sandbox/$SKILL_MD"
+  cp "$REPO_ROOT/$REF_MD" "$sandbox/$REF_MD"
+  cp "$REPO_ROOT/$DECODER_DIR_REL/mod.rs" "$sandbox/$DECODER_DIR_REL/mod.rs"
+}
+
+# Portable in-place sed (GNU sed needs no arg; BSD/macOS sed needs an empty one).
+sed_i() {
+  local expr="$1" file="$2"
+  if sed --version >/dev/null 2>&1; then sed -i "$expr" "$file"; else sed -i '' "$expr" "$file"; fi
+}
+
+# 2. SHIFTED value: label 0x01 as IS_MARKER (0x01 is really END_OF_PARTITION).
+#    This is precisely the pre-#3054 defect that taught partition-boundary mis-detection.
+sed_i 's/| `0x01` | `END_OF_PARTITION`/| `0x01` | `IS_MARKER`/' "$sandbox/$SKILL_MD"
+if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
+  echo "FAIL: guard did NOT trip on a shifted flag value (0x01 labeled IS_MARKER)"
+  exit 1
+fi
+# Capture first: the guard exits non-zero here, and piping it straight into grep would
+# trip `pipefail` on the guard's own (expected) failure rather than on the grep.
+shift_out="$(bash "$GUARD" "$sandbox" 2>&1 || true)"
+if ! grep -q 'FLAG VALUE DRIFT' <<<"$shift_out"; then
+  echo "FAIL: shifted value tripped the guard but not via the FLAG VALUE DRIFT path"
+  echo "$shift_out"
+  exit 1
+fi
+echo "OK: shifted flag value is caught (the pre-#3054 partition-boundary bug)"
+restore
+
+# 3. INVENTED flag name: the pre-#3054 `HAS_IS_MARKER`.
+sed_i 's/| `0x02` | `IS_MARKER`/| `0x02` | `HAS_IS_MARKER`/' "$sandbox/$SKILL_MD"
+if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
+  echo "FAIL: guard did NOT trip on an invented flag name (HAS_IS_MARKER)"
+  exit 1
+fi
+echo "OK: invented flag name is caught"
+restore
+
+# 4. DROPPED row: remove ROW_HAS_COMPLEX_DELETION from BOTH skill tables.
+sed_i '/`ROW_HAS_COMPLEX_DELETION`/d' "$sandbox/$SKILL_MD"
+sed_i '/`ROW_HAS_COMPLEX_DELETION`/d' "$sandbox/$REF_MD"
+if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
+  echo "FAIL: guard did NOT trip when a real source constant is documented nowhere"
+  exit 1
+fi
+echo "OK: silently-dropped flag row is caught"
+restore
+
+# 5. FAIL-CLOSED when the decoder source moved (a source split must not yield a
+#    vacuous PASS against a stale table).
+mv "$sandbox/$DECODER_DIR_REL/mod.rs" "$tmp/mod.rs.away"
+if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
+  echo "FAIL: guard PASSED vacuously with the decoder source missing"
+  exit 1
+fi
+echo "OK: missing decoder source FAILs closed"
+mv "$tmp/mod.rs.away" "$sandbox/$DECODER_DIR_REL/mod.rs"
+restore
+
+# 6. FAIL-CLOSED when the flag table is reformatted away entirely.
+sed_i '/^| `0x/d' "$sandbox/$SKILL_MD"
+if bash "$GUARD" "$sandbox" >/dev/null 2>&1; then
+  echo "FAIL: guard PASSED with no parseable flag-table row (a reformat must fail closed)"
+  exit 1
+fi
+echo "OK: reformatted-away flag table FAILs closed"
+restore
+
+echo "PASS: test_check_skill_flag_tables.sh — all 6 assertions hold"


### PR DESCRIPTION
Closes #3054

Six AUTO-LOADED agent skill files carried 13 factually wrong on-disk-format tables. Two taught already-shipped-and-fixed **P0** bugs back to every agent that touches binary format work. A wrong table is strictly worse than no table: an agent trusts a skill table over reading the code.

Every table/constant in this diff now carries an **inline citation** — either a code constant on `origin/main` or a line in `docs/sstables-definitive-guide/chapters/appendix-b-encodings-cheat-sheet.md`. A skill fact without a citation is how this rotted.

## Defects fixed, per file

**`.claude/skills/sstable-parsing/compression-formats.md`** (6) — invented `chunk_length_1` per-chunk length field replaced with the real `CompressionInfo.db` header + offsets-only chunk array, plus an explicit *"There is NO per-chunk length field"* and the delta-includes-the-trailing-4-byte-CRC rule (`compression_info.rs:6-20,76-83`); **P0 #1082 regression** — the Deflate sample used flate2's raw-DEFLATE reader; now `ZlibDecoder` with a `⚠️ TRAP` callout (`compression.rs:306,313,324`); the lz4 sample used the bare `lz4` crate's `block::decompress`; now `lz4_flex` with Cassandra's 4-byte **little**-endian raw-length prefix (`chunk_decompressor.rs:391,426`); "three compression algorithms" → four + Noop (`compression_info.rs:43-48`); 64KB default → **16 KiB** attributed to `CompressionInfo.db`, not the schema (`CompressionParams.java:47`); *"if CRC enabled"* → the per-chunk 4-byte **big-endian** CRC32 over the **compressed** bytes is **unconditional** (`chunk_decompressor.rs:275-292`). Also corrected the offset-calculation snippet and a dead `reader/compression/` path.

**`.claude/skills/sstable-parsing/SKILL.md`** (1) — the row-flag table labelled `0x01` as `IS_MARKER`; `0x01` is `END_OF_PARTITION`, so the table taught **partition-boundary mis-detection**. Replaced with two tables (main byte + EXTENDED byte) citing `row_decoder/mod.rs:709-715,820,821,825` and `appendix-b:206-212`. Retargeted the stale single-file module pointer at the `row_decoder/` directory.

**`.claude/skills/sstable-parsing/cassandra5-format-reference.md`** (3) — same row-flag correction + common combos; the cell-flag table listed `0x20 HAS_NULL_VALUE` and `0x40 EXTENDED_FLAG`, **both fabrications** — Cassandra 5.0.8 `db/rows/Cell.java:262-266` defines exactly five masks and a cell has no extended flag byte; and the complex-cell section conflated frozen with non-frozen, now split explicitly.

**`.claude/skills/cql-type-system/cql-types-reference.md`** (2) + **`SKILL.md`** (1) — `date` documented without its `Integer.MIN_VALUE` bias (see below); `duration`'s three components documented as unsigned when they are the **only ZigZag-signed VInts in `Data.db`** (`appendix-b:92-97`); `bytea` — a **PostgreSQL** type, not CQL — deleted (`CQL3Type.java:88-111`).

**`.claude/skills/cql-type-system/collections-and-udts.md`** (2) — the frozen-vs-non-frozen encodings were conflated (fixed 4-byte BE `i32` vs unsigned VInt + per-cell flags/path); nested frozen inner-list sizes were wrong, corrected to `0x14`/`0x1C` with a `4 + 8n` derivation table. Also killed a *"Wire format: Same as non-frozen"* claim that directly contradicted the file's own corrected section.

**`.claude/skills/README.md`** (1) — line 20's "three compression algorithms".

## Item 13 (`date` bias): SETTLED — **CONFIRMED REAL, FIXED** (not dismissed)

The audit's grep for a literal `0x80000000` / `2147483648` found nothing, which is why this was flagged unverified. The bias **is** in the decode path — it is just spelled `i32::MIN as u32`:

`cqlite-core/src/storage/sstable/reader/parsing/row_decoder/cell_value_scalar.rs:329-333`
```rust
let stored = u32::from_be_bytes([...]);
let days_since_epoch = stored.wrapping_add(i32::MIN as u32) as i32;
```

Independently confirmed as the **format** truth against Apache Cassandra 5.0.8 `serializers/SimpleDateSerializer.java:36-37` (*"we shift by Integer.MIN_VALUE … w/epoch sitting in the center @ 2^31"*), `:110`, `:113-115`. Both files now document the bias with an un-bias snippet and both citations, including the note that a grep for the hex literal will not find it.

## AC15: drift test — **landed**

- **`scripts/ci/check-skill-flag-tables.sh`** (new) — harvests `const NAME: u8 = 0xNN;` from `row_decoder/{mod.rs,row_data.rs}` and asserts every documented skill-table row's name is real, its value matches, and no source constant is undocumented. Fails **closed** on a missing source, a zero-constant harvest, absent #3054 anchors, or a file with no parseable table row. `HAS_EMPTY_VALUE 0x04` is pinned as a documented-by-Cassandra-only exception with its authority.
- **`scripts/tests/test_check_skill_flag_tables.sh`** (new) — hermetic 6-assertion self-test proving non-vacuity by mutating a temp sandbox: a shifted value (the exact pre-#3054 partition-boundary bug), an invented name, a dropped row, plus both fail-closed paths.
- Wired into the **`tooling-tests`** gate component (pure/offline; no cargo, datasets, or network).

So this class of rot now FAILs the fast loop rather than costing a review round.

## Validation

- **`AGENT-GATE LITE SUMMARY`: RESULT: PASS** (`/tmp/lite-3054.txt`, commit `0e11d36`, `tree-integrity: PASS`) — file-size, fmt, clippy, roborev-lints, scoped-tests all PASS.
- The new guard PASSes on the real repo: `OK: 23 documented flag rows across 2 skill file(s) match the decoder constants; all 14 source flags are documented.`
- Self-test: `PASS: test_check_skill_flag_tables.sh — all 6 assertions hold`.
- All AC literal `rg` checks read clean in scope: `chunk_length_1`, `DeflateDecoder`, `lz4::block`, `if CRC enabled`, `three compression`, `64KB`, `bytea`, `v5_compressed_legacy`.

## Out of scope (reported, not fixed)

4 remaining `v5_compressed_legacy` references live in #3056's lane: `rust-patterns/SKILL.md:337`, `rust-patterns/zero-copy-patterns.md:7,295`, `test-data-management/validation-workflow.md:355`.

## Routing

Doc/instruction-surface + a mechanized drift guard; no design latitude → **no OpenSpec change** (per issue routing).
