### PR TITLE
ops(roborev): pin repo reviewer to codex + gpt-5.6-sol + thorough

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,7 +1,7 @@
 # Default agent for this repo when no workflow-specific agent is set.
-agent = 'claude-code'
+agent = 'codex'
 # Default model for this repo when no workflow-specific model is set.
-model = 'opus'
+model = 'gpt-5.6-sol'
 # Backup agent for this repo if the primary agent fails.
 backup_agent = ''
 # Backup model for this repo if the primary model fails.
@@ -19,7 +19,7 @@ excluded_commit_patterns = []
 # Display name shown for this repo in the TUI and output.
 display_name = ''
 # Reasoning level for reviews in this repo: fast, standard, medium, thorough, or maximum.
-review_reasoning = ''
+review_reasoning = 'thorough'
 # Reasoning level for refine in this repo: fast, standard, medium, thorough, or maximum.
 refine_reasoning = ''
 # Reasoning level for fix in this repo: fast, standard, medium, thorough, or maximum.
@@ -38,7 +38,7 @@ snapshot_dir = ''
 post_commit_review = 'branch'
 reuse_review_session_lookback = 3
 # Agent override for standard review in this repo.
-review_agent = 'claude-code'
+review_agent = 'codex'
 # Agent override for fast review in this repo.
 review_agent_fast = ''
 # Agent override for standard review in this repo.
@@ -62,7 +62,7 @@ refine_agent_thorough = ''
 # Agent override for maximum refine in this repo.
 refine_agent_maximum = ''
 # Model override for standard review in this repo.
-review_model = 'opus'
+review_model = 'gpt-5.6-sol'
 # Model override for fast review in this repo.
 review_model_fast = ''
 # Model override for standard review in this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,13 +285,22 @@ implement (TDD) → --lite each fix round (summary-file redirect)
 - **Review-first (#2086)**: review BEFORE the first full gate so the ONE gate certifies
   already-reviewed code. Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single
   call site AND no new surface). When in doubt, review.
-- **roborev invocation — pass BOTH agent and model (#2433).** `.roborev.toml` on `main` pins
-  `agent = 'claude-code'` + `review_model = 'opus'`. To run the codex reviewer you must override BOTH:
-  `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`. `--agent codex`
-  alone still inherits `review_model = 'opus'` from config, and codex-on-a-ChatGPT-account rejects
-  `opus` with a hard `400 'opus' model is not supported` — a silent review failure that looks like an
-  outage. Run from a checkout whose `.roborev.toml` you know (worktrees inherit `main`'s pinned config);
-  `--model` is the reliable override. codex's own configured model is `gpt-5.6-sol` (`~/.codex/config.toml`).
+- **roborev invocation — the repo pins codex + `gpt-5.6-sol` + `thorough` (#2433).** `.roborev.toml`
+  on `main` pins `agent`/`review_agent = 'codex'`, `model`/`review_model = 'gpt-5.6-sol'`, and
+  `review_reasoning = 'thorough'`, so the plain invocation already runs the intended reviewer:
+  `roborev review --branch --base origin/main --wait`. **This repo-local pin OVERRIDES your global
+  `~/.roborev/config.toml`** — it is the value that actually runs, on every checkout (worktrees inherit
+  `main`'s pinned config). Overriding to another backend requires BOTH flags (`--agent X --model Y`):
+  `--agent` alone still inherits the pinned `review_model`, which the other backend cannot serve, and
+  the resulting hard `400 '<model>' model is not supported` looks like an outage rather than a config
+  mismatch.
+  - **`gpt-5.6-sol` requires codex CLI ≥ 0.145.0.** On 0.142.5 it fails with
+    `400 ... requires a newer version of Codex`. Verify with `codex --version`; upgrade per
+    `docs/development/fleet-runbook.md`. Models this ChatGPT account can serve: `gpt-5.6-sol`,
+    `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`. Plain
+    `gpt-5.6`, `gpt-5.1-codex*` and `gpt-5-codex` are rejected as *not supported on a ChatGPT account*.
+  - **roborev reasoning ladder** is `fast|standard|medium|thorough|maximum` (there is no `high`); it
+    maps onto codex's `model_reasoning_effort`, so `thorough` → `high` and `maximum` → `xhigh`.
 - **flow-closer (#2084/#2668)**: the full gate, the final roborev pass, and the merge run inside the
   disposable `flow-closer` subagent — the lead retains only its terminal packet (verdict, PR URL,
   summary-file path, ≤10 lines residual), never gate stdout or review churn. The closer has **no

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -121,17 +121,38 @@ fresh `git worktree add --detach HEAD`, never the dirty tree.
 3. Then run `scripts/agent-gate.sh` and request review as usual — see the
    [gate contract](/cqlite/agents-developing/gate-contract/).
 
-## Running the codex reviewer — override BOTH agent and model
+## The pinned reviewer — codex, `gpt-5.6-sol`, `thorough`
 
-`.roborev.toml` on `main` pins `agent = 'claude-code'` and `review_model = 'opus'`. To run the codex
-backend you must override **both** on the command line:
+`.roborev.toml` on `main` pins `agent`/`review_agent = 'codex'`, `model`/`review_model =
+'gpt-5.6-sol'`, and `review_reasoning = 'thorough'`. The plain invocation therefore already runs the
+intended reviewer — no flags needed:
 
 ```bash
-roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait
+roborev review --branch --base origin/main --wait
 ```
 
-`--agent codex` **alone** still inherits `review_model = 'opus'` from config, and codex on a ChatGPT
-account rejects `opus` with a hard `400 'opus' model is not supported` — a silent review failure that
-looks like a backend outage rather than a config mismatch. Worktrees inherit `main`'s pinned config, so
-`--model gpt-5.6-sol` (codex's own configured model, from `~/.codex/config.toml`) is the reliable
-override on every checkout.
+That repo-local pin **overrides** whatever your global `~/.roborev/config.toml` sets, so it is the
+value that actually runs. Worktrees inherit `main`'s pinned config, so this holds on every checkout.
+
+To run a *different* backend you must override **both** agent and model:
+
+```bash
+roborev review --branch --base origin/main --agent claude-code --model opus --wait
+```
+
+`--agent` **alone** still inherits the pinned `review_model` from config — a model the other backend
+cannot serve — and the resulting hard `400 '<model>' model is not supported` reads like a backend
+outage rather than a config mismatch.
+
+### Version floor and available models
+
+`gpt-5.6-sol` **requires codex CLI ≥ 0.145.0**. On 0.142.5 it fails with `400 ... requires a newer
+version of Codex`; check with `codex --version`. Models this ChatGPT account can serve:
+
+| Usable | Rejected (*not supported when using Codex with a ChatGPT account*) |
+|---|---|
+| `gpt-5.6-sol` (default), `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` | `gpt-5.6`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5-codex`, `gpt-5.1` |
+
+roborev's reasoning ladder is `fast | standard | medium | thorough | maximum` — there is **no
+`high`**. It maps onto codex's `model_reasoning_effort`, so `thorough` → `high` and `maximum` →
+`xhigh`.


### PR DESCRIPTION
## What

Repin `.roborev.toml` from `claude-code` + `opus` to the backend that is actually healthy on the fleet:

| key | before | after |
|---|---|---|
| `agent` / `review_agent` | `claude-code` | **`codex`** |
| `model` / `review_model` | `opus` | **`gpt-5.6-sol`** |
| `review_reasoning` | `''` (implicit `thorough`) | **`thorough`** |

## Why

The repo-local pin **overrides** the global `~/.roborev/config.toml`, so it is the value that actually runs on every checkout, including worktrees. The previous pin was broken two ways:

- **`claude-code` fails its health check on the agent fleet** — `roborev check-agents` reports `OAuth session expired and could not be refreshed`, so a plain `roborev review --branch` died at the *agent*, before a model was ever selected.
- **`opus` is unservable by codex**, so the documented `--agent codex` escape hatch, used without `--model`, inherited `opus` and returned a hard `400 'opus' model is not supported` — which reads as a backend outage rather than a config mismatch.

`thorough` maps to codex `model_reasoning_effort=high`.

## Verification

`roborev config get` from a fresh worktree — all five keys resolve:

```
agent              codex
model              gpt-5.6-sol
review_agent       codex
review_model       gpt-5.6-sol
review_reasoning   thorough
```

## Version floor (fleet impact)

`gpt-5.6-sol` **requires codex CLI >= 0.145.0**. On 0.142.5 it returns `400 ... requires a newer version of Codex`. This machine has been upgraded to 0.145.0; **other workers are still on 0.142.5** and will fail against this pin until upgraded. There is no codex install logic in the repo (`/opt/codex` comes from the AMI), so this needs an AMI rebuild or provisioning pin — filed separately.

Models this ChatGPT account can serve: `gpt-5.6-sol` (now default), `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`. Rejected as *not supported on a ChatGPT account*: `gpt-5.6`, `gpt-5.1-codex*`, `gpt-5-codex`, `gpt-5.1`.

## Doctrine

Updated in the same change per the keep-doctrine-current rule: `CLAUDE.md` and `website/.../roborev-findings.md` now document the no-flags invocation, the both-flags override rule, the 0.145.0 floor, the available-model table, and that roborev's ladder is `fast|standard|medium|thorough|maximum` with **no `high`** rung.

## Conflicts — needs a decision

Supersedes **#3038** (`ops(roborev): pin repo model + review_model to claude-opus-5`), which edits these same two lines in the opposite direction and is still open. **#3066** also touches the CLAUDE.md roborev block. One of the three has to give; owner call, not mine.

Gate note: this is a `.toml` + Markdown change with no Rust surface, so the `required` CI check is the gate here rather than a full `agent-gate.sh` run.