### PR TITLE
docs(#3042): record the 10 'green signal that meant nothing' lessons into the auto-loaded agent surfaces

### DIFF
--- a/.claude/agents/flow-closer.md
+++ b/.claude/agents/flow-closer.md
@@ -200,17 +200,20 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
      branch-cleanup step fails *after* the merge lands. **A nonzero exit from
      `gh pr merge` is NOT evidence the merge failed.** Verify the merge with `mergedAt`
      (below), then clean the branch separately in `flow-finalize`.
-   - **`mergedAt` is the ONLY reliable probe that a PR merged.** `state=OPEN` with a
-     populated `merge_commit_sha` is **NOT merged**: GitHub populates
+   - **The merge timestamp (`mergedAt` in `gh pr view --json` / GraphQL, `merged_at` in the
+     REST API — same field, two spellings) is the ONLY reliable probe that a PR merged.**
+     `state=open` with a populated `merge_commit_sha` is **NOT merged**: GitHub populates
      `merge_commit_sha` *speculatively* for a merely MERGEABLE PR (it is the SHA of the
      test-merge it computed), so reading that field as a merge receipt reports success on a
-     PR that never landed. Likewise a bare `state` read is ambiguous — `CLOSED` covers both
-     merged and abandoned. Probe:
+     PR that never landed. Verified on this repo: four open PRs each carried a populated
+     `merge_commit_sha` with `merged_at=null` and `merged=false`. Likewise a bare `state`
+     read is ambiguous — REST `closed` covers both merged and abandoned. Probe:
      ```bash
-     gh pr view <pr> --json mergedAt -q .mergedAt   # non-null ⇒ merged; null ⇒ NOT merged
+     gh pr view <pr> --json mergedAt -q .mergedAt        # non-null ⇒ merged; null ⇒ NOT merged
+     gh api repos/{owner}/{repo}/pulls/<pr> --jq .merged_at   # REST spelling, same meaning
      ```
-     Use `mergedAt` for every "did it merge?" decision in step 6 — never `merge_commit_sha`,
-     never a bare `state`, never the arm command's exit code.
+     Use the merge timestamp for every "did it merge?" decision in step 6 — never
+     `merge_commit_sha`, never a bare `state`, never the arm command's exit code.
 6. **Finalize — two paths (the merge may land AFTER you exit).** `--auto` means the merge
    can complete after this session ends, so finalize (telemetry, board, claim release) must
    not assume the PR is already merged. Choose:

--- a/.claude/agents/flow-closer.md
+++ b/.claude/agents/flow-closer.md
@@ -176,18 +176,55 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
    scripts/flow/claim-heartbeat.sh beat <N>
    gh pr merge <pr> --auto --squash --delete-branch
    ```
+
+   **(d) Reading the arm/merge outcome — three observed `--auto` behaviors, and the ONE
+   reliable merged-probe (#3042).** The arm command's exit code and the PR's `state` field
+   are both weak signals here. Three green-looking signals mean nothing:
+
+   - **`gh pr merge --auto` on an ALREADY-GREEN PR has three observed outcomes**:
+     accepted-and-queued; merged immediately; or **REJECTED** with
+     `Pull request is in clean status`. The rejection is not a failure to merge — it means
+     GitHub declined to *queue* a PR that has nothing left to wait for. The fallback is a
+     direct GraphQL `mergePullRequest` carrying `expectedHeadOid` set to your certified SHA
+     (the mutation refuses if the head moved, so it keeps the #2456 guarantee):
+     ```bash
+     gh api graphql -f query='mutation($pr:ID!,$oid:GitObjectID!){
+       mergePullRequest(input:{pullRequestId:$pr, expectedHeadOid:$oid, mergeMethod:SQUASH}){
+         pullRequest{ number mergedAt } } }' -f pr="$PR_NODE_ID" -f oid="<certified-sha>"
+     ```
+     A GraphQL **throttle** on this path is a retry, not a failure (see
+     `.claude/skills/ci-cd-validation/merge-process.md`). **`PUT /repos/.../pulls/N/merge`
+     (REST merge) is never the fallback** — it takes no head-oid expectation.
+   - **`--delete-branch` frequently EXITS NONZERO while the merge itself SUCCEEDED** —
+     `cannot delete local branch used by worktree` (observed 6 times in one session). The
+     branch-cleanup step fails *after* the merge lands. **A nonzero exit from
+     `gh pr merge` is NOT evidence the merge failed.** Verify the merge with `mergedAt`
+     (below), then clean the branch separately in `flow-finalize`.
+   - **`mergedAt` is the ONLY reliable probe that a PR merged.** `state=OPEN` with a
+     populated `merge_commit_sha` is **NOT merged**: GitHub populates
+     `merge_commit_sha` *speculatively* for a merely MERGEABLE PR (it is the SHA of the
+     test-merge it computed), so reading that field as a merge receipt reports success on a
+     PR that never landed. Likewise a bare `state` read is ambiguous — `CLOSED` covers both
+     merged and abandoned. Probe:
+     ```bash
+     gh pr view <pr> --json mergedAt -q .mergedAt   # non-null ⇒ merged; null ⇒ NOT merged
+     ```
+     Use `mergedAt` for every "did it merge?" decision in step 6 — never `merge_commit_sha`,
+     never a bare `state`, never the arm command's exit code.
 6. **Finalize — two paths (the merge may land AFTER you exit).** `--auto` means the merge
    can complete after this session ends, so finalize (telemetry, board, claim release) must
    not assume the PR is already merged. Choose:
    - **(b) Fast path — DEFAULT when the `required` check is already GREEN at arm time**
      (`gh pr checks <pr>` shows the required lane passed): `--auto` lands within seconds —
-     briefly confirm `gh pr view <pr> --json state -q .state` == `MERGED` (poll on the same
+     briefly confirm `gh pr view <pr> --json mergedAt -q .mergedAt` is **non-null** (per
+     step 5(d): `mergedAt`, not `state`, not `merge_commit_sha`; poll on the same
      hard-deadline discipline as the gate wait, NOT a tight loop), then run
      `flow-finalize <N>` in-session.
    - **(a) Deferred path — when the required check is still PENDING at arm time**: do NOT
      idle-wait for CI. Return `verdict: auto-armed` with the PR URL; the merge + finalize
      complete on a **later wake / next session** that first confirms
-     `gh pr view <pr> --json state -q .state` == `MERGED` before running `flow-finalize <N>`.
+     `gh pr view <pr> --json mergedAt -q .mergedAt` is **non-null** (step 5(d)) before
+     running `flow-finalize <N>`.
      The gate completion push-signal (#2667) and GitHub's own auto-merge notification are the
      callbacks — the summary file is a push signal now, not a poll target.
 

--- a/.claude/skills/ci-cd-validation/merge-process.md
+++ b/.claude/skills/ci-cd-validation/merge-process.md
@@ -14,10 +14,11 @@ and stops. GitHub lands the PR when the #2433 `required` check goes green (#2667
   unmet/uncovered requirement, work outside the issue, or a manager `HOLD: merge after #N` order.
 - If `gh pr merge --auto` (GraphQL) is throttled, retry; `--auto` is set-once and idempotent, so GitHub
   still lands the PR when the required check passes.
-- **Reading the outcome (full rules in `.claude/agents/flow-closer.md` step 5(d), #3042):** `mergedAt`
-  is the ONLY reliable merged-probe (an OPEN PR's `merge_commit_sha` is populated speculatively and is
-  NOT a merge); a nonzero `--delete-branch` exit often accompanies a SUCCESSFUL merge; and `--auto` on an
-  already-green PR may be rejected with `Pull request is in clean status`, whose fallback is a GraphQL
-  `mergePullRequest` with `expectedHeadOid` — never a REST merge.
+- **Reading the outcome (full rules in `.claude/agents/flow-closer.md` step 5(d), #3042):** the merge
+  timestamp (`mergedAt` / REST `merged_at`) is the ONLY reliable merged-probe (an OPEN PR's
+  `merge_commit_sha` is populated speculatively and is NOT a merge); a nonzero `--delete-branch` exit
+  often accompanies a SUCCESSFUL merge; and `--auto` on an already-green PR may be rejected with
+  `Pull request is in clean status`, whose fallback is a GraphQL `mergePullRequest` with
+  `expectedHeadOid` — never a REST merge.
 
 Full doctrine: `docs/development/pm-operating-loop.md`; pipeline stages: the `flow-*` skills.

--- a/.claude/skills/ci-cd-validation/merge-process.md
+++ b/.claude/skills/ci-cd-validation/merge-process.md
@@ -14,5 +14,10 @@ and stops. GitHub lands the PR when the #2433 `required` check goes green (#2667
   unmet/uncovered requirement, work outside the issue, or a manager `HOLD: merge after #N` order.
 - If `gh pr merge --auto` (GraphQL) is throttled, retry; `--auto` is set-once and idempotent, so GitHub
   still lands the PR when the required check passes.
+- **Reading the outcome (full rules in `.claude/agents/flow-closer.md` step 5(d), #3042):** `mergedAt`
+  is the ONLY reliable merged-probe (an OPEN PR's `merge_commit_sha` is populated speculatively and is
+  NOT a merge); a nonzero `--delete-branch` exit often accompanies a SUCCESSFUL merge; and `--auto` on an
+  already-green PR may be rejected with `Pull request is in clean status`, whose fallback is a GraphQL
+  `mergePullRequest` with `expectedHeadOid` — never a REST merge.
 
 Full doctrine: `docs/development/pm-operating-loop.md`; pipeline stages: the `flow-*` skills.

--- a/.claude/skills/test-data-management/SKILL.md
+++ b/.claude/skills/test-data-management/SKILL.md
@@ -24,6 +24,29 @@ CQLite uses real Cassandra 5.0 instances to generate test data, ensuring:
 - Compression validation (actual compressed SSTables)
 - Schema variety (all CQL types)
 
+## A fixture proves nothing about a property it does not VARY (issue #3042)
+
+Before choosing or generating a fixture, name the property under test and ask whether this
+fixture **varies** it. If it does not, the fixture cannot validate it — the property is
+**UNTESTED**, not proven, and the resulting green is meaningless. This is a *selection-time*
+check: once the fixture is in place the test passes and nothing flags the gap.
+
+- **A single-component clustering key cannot validate a multi-component invariant.** Component
+  separators, `NEXT_COMPONENT` framing between components, and mixed ASC/DESC inversion all
+  need arity ≥ 2 to be exercised at all.
+- **Values that happen to share a first byte cannot validate byte-discriminated trie/index
+  logic.** BTI partition/row tries branch on transition bytes; keys with an identical leading
+  byte never force the discriminating branch.
+- **Correctness resting on an incidental property of one fixture is untested.** Real instance:
+  the pre-fix BTI root-delta base was 2 bytes low, and the wrong root pointed *straight at the
+  root's only child* purely because that fixture's child node happened to be 2 bytes wide —
+  the defect was invisible until a fixture varied the node width (issue #3002, pinned in
+  `cqlite-core/tests/issue_3002_bti_rows_root_base.rs`).
+
+So: vary the arity, vary the leading bytes, vary the widths and the orders. A corpus of one
+shape is a corpus of one datapoint. See also the self-round-trip blind spot in `CLAUDE.md`
+§Testing — a fixture you generated with CQLite cannot be the oracle for CQLite.
+
 ## Test Data Workflow
 
 See [dataset-generation.md](dataset-generation.md) for complete workflow details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,18 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   a **just-launched or still-queued** gate as its gate of record — a verdict that does not exist.
   Anchor every poll (agents, skills, docs, helper scripts) on `PASS|FAIL`; a sentinel-only summary
   means "still running, died, or queued", never certified.
+- **A markdown/docs-only diff cannot change the compiled binary — so a test failure in its full gate
+  is BY DEFINITION pre-existing on `main` or a flake, and the correct response is CITE-AND-WAIVE
+  (#3042).** If your diff touches no compiled input (no `src`, no `Cargo.*`, no build script, no
+  workflow, no test-data), it cannot have caused a test to fail. **NEVER patch source to turn such a
+  gate green** — that is a real change smuggled in under a docs diff, certified by nothing, and it
+  masks the actual main-red. Instead: (1) confirm the diff really is non-compiling-input
+  (`git diff --stat origin/main...HEAD`); (2) identify the failure as a known main-red issue or a
+  known flake — reproduce it on a clean `origin/main` checkout if it is not already filed, and FILE it
+  if it is not; (3) record the waiver in the PR body naming the failing component and the issue number
+  it belongs to. A waiver with no cited issue is not a waiver — it is an unexplained red. Conversely,
+  if ANY compiled input is in the diff the waiver is void: the failure is presumed yours until proven
+  otherwise.
 - Defaults if `AGENT_GATE_SUMMARY_FILE` unset (per-checkout; give concurrent gates in ONE checkout
   unique paths): `.agent-gate-summary.txt` / `.agent-gate-lite-summary.txt` / `.agent-gate-delta-summary.txt`.
   **Nested exception (#2874):** a gate started with `AGENT_GATE_PARENT_RUN_ID` in its env (i.e. spawned
@@ -229,6 +241,22 @@ by responsibility (source: epic #1116; tests: #1135). Genuinely out of scope →
   `cqlite-core/tests/point_vs_full_differential.rs`): it runs the same point-eligible query under
   forced `CQLITE_READ_PATH=point` and `=full` and asserts identical rows/values/order at a PINNED
   `now` — catching a divergence between the two read paths that a physical dump cannot see.
+- **Third blind spot: a CQLite-WRITTEN + CQLite-READ round-trip test is INVARIANT to a uniform
+  framing/serialization error (issue #3042).** Both sides make the *identical* mistake, so the
+  round-trip closes and the test stays green while real Cassandra-written data reads wrong — and,
+  symmetrically, CQLite-written data is unreadable by Cassandra. Such a test can **never** substitute
+  for a Cassandra-written fixture; it validates self-consistency, which is not the property anyone
+  cares about. Concrete instance: the only arity-2 BTI test,
+  `cqlite-core/tests/issue_908_bti_canonical_write.rs`, is CQLite-written and CQLite-read and asserts
+  only ordering/structure, so it is invariant to exactly the framing defect of **#3002 (BTI `Rows.db`
+  row-index root base 2 bytes low — missing the `writeWithShortLength` 2-byte prefix, masked by a
+  compensating encoder defect that omitted the leading `0x40 NEXT_COMPONENT`)**. Two defects that
+  cancel are undetectable by a symmetric test *by construction*. The oracle that caught it is
+  `cqlite-core/tests/issue_3002_bti_rows_root_base.rs`, asserting against the real Cassandra 5.0 `da`
+  fixture with every expectation derived from Cassandra's writer/reader source — never from CQLite's
+  prior behavior. Rule: for any on-disk framing/encoding property, the oracle must be
+  **Cassandra-written bytes** (or Cassandra source), never CQLite's own output. Long form:
+  [validation playbook](https://pmcfadin.github.io/cqlite/agents-developing/validation-playbook/).
 
 ### Fuzzing (issue #1614)
 `fuzz/` is a cargo-fuzz/libFuzzer crate in its own workspace, excluded from the main one — the gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,13 @@ order: (1) the pinned `cassandra-5.0.8` Cassandra source, (2) `sstabledump` outp
 
 ## Agent-Team Conventions
 
-- Implementers commit after each meaningful unit of work so reviews land while context is fresh.
+- **Implementers commit after each meaningful unit of work — this is WORK-LOSS insurance, not just
+  review hygiene (#3042).** Reviews landing while context is fresh is the smaller half. The larger
+  half: a subagent starved of CPU (a co-scheduled gate, a heavy sibling lane) is killed by the **600s
+  stall watchdog** and **loses every uncommitted change** — 3 agents lost all their work this way in a
+  single session. A commit is the only thing that survives the kill; the harness re-invoke starts from
+  the last commit, not the last edit. So commit early and often, before any long-running or
+  CPU-contended step, even mid-refactor and even when the unit feels too small to review.
 - Stay within your assigned issue's scope; flag cross-cutting changes to the lead instead of editing
   another teammate's files.
 - An issue is "done" only when tests pass, coverage meets threshold, roborev is clean, and both the
@@ -518,6 +524,17 @@ end-to-end test. Green helper-only unit tests are not sufficient.
     the telemetry PR — return its number as residual if its CI is still pending.
 - **Keep doctrine current in the same change** — user-facing or workflow changes update CLAUDE.md
   and the website `agents-developing/` page as part of the change.
+  - **Acceptance step: a publish is verified by the NEW CONTENT being served, never by HTTP 200
+    (#3042).** A green deploy plus a `200` proves the site is up, not that your change is live: the CDN
+    can keep serving the **previous** page for roughly **3 minutes** afterward (observed twice — two
+    successive `curl`s returned stale content after a successful deploy). Grep the response for a
+    distinctive string your change introduced, and re-check after a wait if it is absent:
+    ```bash
+    curl -sS https://pmcfadin.github.io/cqlite/agents-developing/<page>/ | grep -c '<new phrase>'
+    ```
+    A `0` means not-yet-published (or not published) — not a failure to report immediately, but never
+    bank it as done. For a NEW SSTable-guide chapter there is a second, separate requirement: it must
+    be registered in `CHAPTERS` (`docs/sstables-definitive-guide/README.md`).
 
 ## Product-Manager Behavior (lead)
 

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -350,6 +350,49 @@ Corollaries:
 - The reader contract still applies on top of this: validate the block's `run-id:` line and read `tree-integrity:` alongside the verdict (#2874/#2926) — a foreign `RESULT: PASS` is a peer's verdict, not yours.
 - The stronger *mechanism* fix (a distinct `.running` sentinel that cannot be misread, plus a pin in `scripts/tests/test_agent_gate_summary.sh`) is tracked in **#2908**; #3041 corrected the documented predicate everywhere.
 
+## Liveness diagnosis: is my gate alive, queued, or dead? (issue #3042)
+
+The sentinel above tells you a gate has not *finished*; it says nothing about whether it is still
+running. Diagnosing that wrongly is expensive in both directions — killing and relaunching a healthy
+queued gate wastes 15–25 min, and waiting on a dead one wastes the whole session. Use these probes,
+in this order:
+
+- **The authoritative aliveness probe is the gate LOG FILE's mtime advancing.** A live gate writes
+  continuously; a dead one stops. Sample it twice, a minute or two apart:
+  ```bash
+  stat -f %m gate-<N>.log   # macOS; GNU: stat -c %Y
+  ```
+  An advancing mtime means alive, full stop. (You are only reading the *timestamp* here — never read
+  `gate-<N>.log`'s contents into context; the SUMMARY file remains the only gate text you retain.)
+- **`ps` is unreliable for this** and should not be your primary signal. A gate spends long stretches
+  inside child `cargo`/`nextest`/`rustc` processes under different names, and a **queued** gate is
+  legitimately running no cargo at all — so "I don't see it in `ps`" is not evidence of death.
+- **`waiting for gate slot (N in use)…` means QUEUED and ALIVE, not hung.** Under the #1825 cap a
+  gate can sit in the queue for 20+ minutes before executing anything. It already has a
+  sentinel-bearing summary file (written before the slot is granted), so neither the file's existence
+  nor its `INCOMPLETE` content is progress. A queued gate's wall-clock does not count against an
+  active-gate deadline — extend the deadline by the observed queue wait
+  (`.claude/agents/flow-closer.md` step 1).
+- **A missing slot daemon IS meaningful evidence of death — but only comparatively.** Each live full
+  gate has its own background `scripts/lib/gate_slot_daemon.py` holding its slot for as long as the
+  gate process lives. So the total absence of *your own* gate's daemon **while sibling gates' daemons
+  are present** is real evidence your gate died (the daemon polls the gate PID and exits when it
+  vanishes). No daemons at all for anyone is inconclusive — the cap fails open when `python3` or the
+  daemon script is unavailable, and `--lite`/`--delta`/`--only` runs never take a slot.
+  ```bash
+  pgrep -fl gate_slot_daemon.py   # one line per gate currently holding a slot
+  ```
+- **Gate slot acquisition is NOT FIFO.** The daemon sweeps the N slot lockfiles with non-blocking
+  `flock` and retries the whole sweep after a poll interval, so there is no queue order and no
+  fairness guarantee: a gate that started waiting later can win a freed slot first, and an unlucky
+  gate can be passed over repeatedly. Do not infer "my gate must be next" from having waited longest,
+  and do not read a long wait as a stall.
+
+Putting it together: an `INCOMPLETE` summary + an advancing log mtime = **alive, keep waiting**. An
+`INCOMPLETE` summary + a log mtime frozen for many minutes + your daemon absent while peers' daemons
+are present = **dead, relaunch**. Anything else is inconclusive — prefer waiting to relaunching, and
+report `gate-timeout` on the hard deadline rather than guessing.
+
 ## Nested / concurrent-gate isolation (issue #2874)
 
 The gate of record is **structurally immune** to nested and concurrent gate activity — no box-exclusive ops rule and no "serialize every self-test lane" discipline is needed. The historical `#2751` workaround ("run the full gate **without** `AGENT_GATE_SUMMARY_FILE`") is **OBSOLETE**: the summary-file redirect invocation (`AGENT_GATE_SUMMARY_FILE=… bash scripts/agent-gate.sh`) is once again the documented default for callers, and running it concurrently with another lane's gate self-tests on the same box is safe. Three mechanisms guarantee this:

--- a/docs/sstables-definitive-guide/README.md
+++ b/docs/sstables-definitive-guide/README.md
@@ -11,6 +11,26 @@ This directory contains the evolving manuscript for our SSTables reference in th
 
 Contributions: keep chapters under ~300-600 lines; split when larger.
 
+## Adding a new chapter or appendix — it is NOT published until registered
+
+Creating a file under `chapters/` does **not** publish it to the docs site. The published set is the
+hardcoded `CHAPTERS` array in `website/scripts/sync-format-guide.mjs`; a chapter absent from it is
+simply never synced. Four appendices were silently unpublished this way (issue #3006).
+
+To publish a new chapter or appendix:
+
+1. Add a `{ file, order, prefix }` entry to the `CHAPTERS` array in
+   `website/scripts/sync-format-guide.mjs`.
+2. Add it to the chapter/appendix list below, so the guide's own front door matches the site.
+
+If a file must deliberately stay off the site, register it in that script's
+`UNPUBLISHED_BY_DESIGN` map with a reason instead.
+
+Either way you will be told: the sync script runs as the website `prebuild` and **exits 1** on an
+unregistered chapter (as well as on a stale exclusion, a doubly-listed file, a missing source, or a
+duplicate prefix), so an unregistered chapter now fails the build rather than vanishing quietly. Do
+not work around the guard — register the chapter.
+
 ## Chapters
 
 - 01 — [What Are SSTables?](chapters/01-what-are-sstables.md)

--- a/website/src/content/docs/agents-developing/validation-playbook.md
+++ b/website/src/content/docs/agents-developing/validation-playbook.md
@@ -77,6 +77,51 @@ The `CQLITE_READ_PATH` knob is a **test/debug** control (not a perf recommendati
 `point` fails closed rather than silently full-scanning. See the CLI reference for the
 user-facing knob docs.
 
+### The self-round-trip blind spot (CQLite-written + CQLite-read, issue #3042)
+
+Both lanes above compare CQLite against an *external* oracle or against its own two read
+paths. A third class of test compares CQLite only to itself in a single direction — write
+with CQLite, read back with CQLite, assert the values survived — and it carries a blind spot
+severe enough to name explicitly:
+
+> **A CQLite-written + CQLite-read round-trip test is INVARIANT to a uniform
+> framing/serialization error.**
+
+The writer and the reader share the same encoding assumption. If that assumption is wrong,
+*both sides make the identical mistake*, the round-trip still closes, and the test is green —
+while real Cassandra-written data reads wrong, and CQLite-written data is unreadable by
+Cassandra. The test validates **self-consistency**, which is not the property that matters.
+It therefore can **never** substitute for a Cassandra-written fixture on any on-disk framing
+or encoding property.
+
+**The concrete instance (issue #3002).** The only arity-2 BTI test,
+`cqlite-core/tests/issue_908_bti_canonical_write.rs`, is CQLite-written and CQLite-read and
+asserts only ordering/structure. It stayed green across a defect pair that cancelled:
+
+1. `resolve_rows_db_entry` computed the signed root-delta base as `RowsOffset + key_length` —
+   **2 bytes low**, because Cassandra 5.0 captures `basePosition` *after*
+   `writeWithShortLength`, i.e. `RowsOffset + 2 + key_length`.
+2. The OSS50 clustering-bound encoders emitted the `0x40 NEXT_COMPONENT` byte only *between*
+   components, while `ClusteringComparator.ByteComparableClustering` emits it before **each**
+   component including the first.
+
+The 2-low root pointed at exactly the subtree the un-prefixed bounds were keyed for, so the
+two errors masked each other perfectly. Fixing *either alone* regresses BTI clustering reads —
+which is precisely why a symmetric test cannot see the pair. It is also why the fixture matters
+independently: the wrong root landed on the root's only child only because that fixture's child
+node happened to be 2 bytes wide (see the fixture-must-vary rule in
+`.claude/skills/test-data-management/SKILL.md`).
+
+**What caught it:** `cqlite-core/tests/issue_3002_bti_rows_root_base.rs`, pinned against the
+real Cassandra 5.0 `da` fixture (`test_da/wide_table`), with every expectation derived from
+Cassandra's own writer/reader source — never from CQLite's prior behavior. That last clause is
+the load-bearing one: an expectation reverse-engineered from current CQLite output re-encodes
+the bug as the specification.
+
+**Rule.** For any on-disk framing/encoding property, the oracle must be **Cassandra-written
+bytes or Cassandra source**, never CQLite's own output. A round-trip test is a useful
+regression net for internal invariants; it is not parity evidence.
+
 ## Golden JSONL files
 
 Every Data.db in the dataset has a companion `.jsonl` file containing


### PR DESCRIPTION
Closes #3042

Records the ten "green signal that meant nothing" lessons from the 2026-07 guide-refresh fleet into
the surfaces agents actually auto-load. **Markdown-only, additive** — no source, no build inputs, no
behavior change.

## Per-item landing + the `rg` pattern that confirms it

| # | Lesson | File | `rg` pattern |
|---|--------|------|--------------|
| 1 | Self-round-trip test is invariant to a uniform framing error; names `issue_908_bti_canonical_write.rs` + cross-links #3002 | `CLAUDE.md` §Testing (3rd blind spot in the #1742 block) + long form in `website/.../validation-playbook.md` | `rg -n "issue_908_bti_canonical_write" CLAUDE.md website/src/content/docs/agents-developing/validation-playbook.md` |
| 2 | A fixture proves nothing about a property it does not VARY | `.claude/skills/test-data-management/SKILL.md` | `rg -n "does not VARY\|UNTESTED"` |
| 3 | Docs-only diff ⇒ gate failure is pre-existing/flake ⇒ **cite-and-waive**, never patch source | `CLAUDE.md` gate-tier bullets | `rg -n "CITE-AND-WAIVE"` |
| 4 | Liveness: log **mtime** is authoritative, `ps` is not, queued ≠ hung, slot acquisition is **NOT FIFO** | `docs/development/gate-ops.md` (new "Liveness diagnosis" subsection) | `rg -n "mtime\|NOT FIFO" docs/development/gate-ops.md` |
| 5 | Merge timestamp (`mergedAt`/`merged_at`) is the ONLY merged-probe; open-PR `merge_commit_sha` is speculative | `.claude/agents/flow-closer.md` step 5(d) | `rg -n "merged_at" .claude/agents/flow-closer.md` |
| 6 | `--delete-branch` nonzero exit ≠ failed merge | `.claude/agents/flow-closer.md` step 5(d) | `rg -n "delete-branch" .claude/agents/flow-closer.md` |
| 7 | `--auto` three behaviors incl. `Pull request is in clean status` → GraphQL `expectedHeadOid` fallback | `.claude/agents/flow-closer.md` + 1-line cross-ref in `merge-process.md` | `rg -n "clean status\|expectedHeadOid" .claude/agents/flow-closer.md` |
| 8 | Commit cadence is **watchdog work-loss insurance**, not just review hygiene (600s stall watchdog, 3 agents lost work) | `CLAUDE.md` §Agent-Team Conventions | `rg -n "WORK-LOSS insurance" CLAUDE.md` |
| 9 | Publish verified by **new content served**, not HTTP 200 (CDN serves stale ~3 min) | `CLAUDE.md` "Keep doctrine current" bullet, as an acceptance step | `rg -n "NEW CONTENT being served" CLAUDE.md` |
| 10 | A new chapter is unpublished until registered in `CHAPTERS` | `docs/sstables-definitive-guide/README.md` | `rg -n "CHAPTERS" docs/sstables-definitive-guide/README.md` |

Items 5, 6, 7 also propagated to step 6's two merged-probes, which previously read
`--json state -q .state == MERGED`; they now read `mergedAt`.

## Items dropped as ALREADY SHIPPED on `origin/main`

- **The `INCOMPLETE`-placeholder-is-not-a-verdict lesson** (issue #3042's items 3/4 framing) was
  landed by **PR #3066 (#3041)** in `CLAUDE.md` (gate bullets), `.claude/agents/flow-closer.md`
  (step 1 + the polling section), and `docs/development/gate-ops.md` (its own section, "The startup
  `INCOMPLETE` sentinel is a liveness placeholder, not a verdict"). **Not re-asserted** — doubling it
  would create competing doctrine. Item 4's *new* content here is strictly the liveness-diagnosis
  material that #3066 does not cover (mtime probe, `ps` unreliability, slot-daemon comparative
  evidence, non-FIFO acquisition), written to *build on* #3066's section, which it cites.
- **Item 10's fail-closed guard** — `UNPUBLISHED_BY_DESIGN` + `prebuild` + `exit 1` already exists on
  `main` from #3006. Per the issue, item 10 is documentation-only:
  `website/scripts/sync-format-guide.mjs` is **unchanged** (`git diff --stat` shows no entry).

## Verification

- **Every factual claim verified against `origin/main` or a live probe**, not the stale root checkout.
  - `merge_commit_sha`-is-speculative: verified empirically — 4 open PRs (#3081, #3080, #3069, #3038)
    each carry a populated `merge_commit_sha` with `merged_at=null`, `merged=false`.
  - Both field spellings verified on merged PR #3066: REST `merged_at`, GraphQL/`gh --json` `mergedAt`.
  - non-FIFO: read from `scripts/lib/gate_slot_daemon.py` — a non-blocking `flock` sweep over N slots
    retried after a poll interval, with no queue or fairness structure.
  - slot-daemon-per-gate: read from `acquire_gate_slot` in `scripts/agent-gate.sh`.
  - `stat -f %m` confirmed working on this darwin box.
  - #3002 / #3006 / #2908 / #3041 issue titles confirmed via `gh issue view`.
- Nothing unverifiable was written: no invented line numbers, constants, or exit codes.

## Gate

**Markdown-only diff (7 files, all `.md`)** — `git diff --name-only origin/main...HEAD | grep -v '\.md$'`
returns empty. Per item 3's own newly-written rule, a docs-only diff cannot change the compiled binary,
so the **full gate of record is not required** for this change.

- `AGENT-GATE LITE SUMMARY` — **RESULT: PASS** (`/tmp/lite-3042.txt`), exit 0,
  `tree-integrity: PASS`, `file-size/fmt/clippy/roborev-lints/scoped-tests` all PASS.
- **roborev: N/A** — a code-free diff makes roborev return "No code changes were included", which is
  indistinguishable from an outage, so it is **not banked as clean** (#2964).

## Conflict posture vs the in-flight #3069

#3069 (#3055) touches 14 files; the only overlap with this PR is `CLAUDE.md`, and its single
`CLAUDE.md` hunk is at line ~530 while this PR's nearest edit ends at ~520 — disjoint, trivial merge.
No language from #3069 or #3066 is reverted or contradicted.
