### PR TITLE
docs(#3068): correct stale disk-access-mode + scan-advice comments

### DIFF
--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -53,14 +53,14 @@ pub struct StorageConfig {
     /// Sync mode for durability
     pub sync_mode: SyncMode,
 
-    /// Memory-map SSTable Data.db files instead of using buffered file I/O.
+    /// Legacy promote-only flag: it upgrades an **explicit**
+    /// [`DiskAccessMode::Buffered`] request to [`DiskAccessMode::Mmap`].
     ///
-    /// **Opt-in.** Defaults to `false` (buffered I/O), which is portable and
-    /// safe on every filesystem. When enabled, the reader maps Data.db files at
-    /// or above [`Self::mmap_min_size_bytes`] into the process address space and
-    /// serves reads from the OS page cache with no per-block `read` syscall,
-    /// mirroring Cassandra's `disk_access_mode: mmap`. This speeds up repeated
-    /// local scans of the same files.
+    /// It does **not** select the backend — [`Self::disk_access_mode`] does, and its
+    /// `Auto` default already memory-maps most Data.db files (see that field). So
+    /// `false` does not mean "buffered I/O", and `true` changes nothing unless
+    /// something explicitly requested `Buffered`. A mapped file is served from the
+    /// page cache with no per-block `read` syscall, as Cassandra's mmap mode does.
     ///
     /// # Safety / platform constraints
     ///
@@ -76,10 +76,10 @@ pub struct StorageConfig {
     ///
     /// # Interaction with the write engine (Issue #591)
     ///
-    /// This setting only affects the read path. Compaction always reads its
-    /// input SSTables through buffered I/O regardless of `use_mmap`, and deletes
-    /// each input by removing its `TOC.txt` first (unpublishing it) before the
-    /// data components, best-effort. So enabling mmap for queries is safe
+    /// This setting only affects the read path. Compaction's input readers force
+    /// `use_mmap = false` + explicit `Buffered` (only `CQLITE_USE_MMAP=1` promotes even
+    /// those); each input is unpublished by removing its `TOC.txt` before the data
+    /// components, best-effort. So enabling mmap for queries is safe
     /// alongside background compaction: a compaction never holds a mapping over a
     /// file it then deletes, and on Windows a data file still pinned by a mapped
     /// reader becomes an invisible orphan (reclaimed on the next startup) rather
@@ -92,11 +92,11 @@ pub struct StorageConfig {
     #[serde(default = "default_use_mmap")]
     pub use_mmap: bool,
 
-    /// Minimum Data.db file size (bytes) before [`Self::use_mmap`] takes effect.
+    /// Minimum Data.db size (bytes) at which [`DiskAccessMode::Auto`] maps. Default 4096.
     ///
-    /// Files smaller than this use buffered I/O even when `use_mmap` is set,
-    /// since the per-file mapping overhead is not worthwhile for tiny files and
-    /// mapping a zero-length file is invalid. Defaults to one page (4096).
+    /// It gates ONLY `Auto`, which uses buffered I/O below it (a tiny file does not
+    /// repay the mapping setup); an explicit `Mmap` — including a `Buffered` promoted
+    /// by [`Self::use_mmap`] — is not size-gated, only a zero-length file falls back.
     ///
     /// `#[serde(default)]` for backward compatibility with older payloads.
     #[serde(default = "default_mmap_min_size_bytes")]
@@ -143,10 +143,10 @@ pub struct StorageConfig {
     #[serde(default)]
     pub prefetch: PrefetchMode,
 
-    /// Size in bytes of the read-ahead window used by the direct-I/O backend
-    /// (and the buffered backend's reader capacity hint). Rounded up to the
-    /// I/O alignment. Defaults to 1 MiB. Only takes effect when
-    /// [`Self::prefetch`] is not [`PrefetchMode::Off`].
+    /// Size in bytes of the read-ahead window used by the direct-I/O backend, and by
+    /// nothing else: the buffered backend ignores it (`open_buffered_sources` takes no
+    /// prefetch bytes; its `BufReader::new` capacity is tokio's 8 KiB default). Rounded
+    /// up to the I/O alignment; 1 MiB default; inert while `prefetch` is `Off`.
     #[serde(default = "default_direct_io_prefetch_bytes")]
     pub direct_io_prefetch_bytes: usize,
 }

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -88,7 +88,7 @@ pub struct StorageConfig {
     /// Can also be enabled at runtime by setting `CQLITE_USE_MMAP=1`.
     ///
     /// `#[serde(default)]` keeps configs serialized before this field existed
-    /// (which omit it) deserializing successfully, defaulting to buffered I/O.
+    /// (which omit it) deserializing successfully, defaulting to no promotion.
     #[serde(default = "default_use_mmap")]
     pub use_mmap: bool,
 
@@ -116,8 +116,8 @@ pub struct StorageConfig {
     ///
     /// Set an explicit [`DiskAccessMode::Buffered`], [`DiskAccessMode::Mmap`],
     /// or [`DiskAccessMode::Direct`] to override the heuristic. The legacy
-    /// [`Self::use_mmap`] flag still forces mmap when `Auto` would otherwise
-    /// pick buffered, for backward compatibility.
+    /// [`Self::use_mmap`] flag only PROMOTES an explicit `Buffered` request to
+    /// `Mmap`; it never changes what `Auto` resolves to.
     ///
     /// Can also be set at runtime via `CQLITE_DISK_ACCESS_MODE`
     /// (`auto` / `buffered` / `mmap` / `direct`).
@@ -199,7 +199,7 @@ pub enum PrefetchMode {
     Auto,
 }
 
-/// Default for [`StorageConfig::use_mmap`]: mmap is opt-in, so buffered I/O.
+/// Default for [`StorageConfig::use_mmap`]: no promotion (see the field doc).
 fn default_use_mmap() -> bool {
     false
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/compressed_scan_window.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/compressed_scan_window.rs
@@ -151,7 +151,7 @@ impl SSTableReader {
 ///   CRC-validated chunk reader, just fewer times.
 /// - **SCAN-plane reads** (issue #2876, and the reason the two fixes are
 ///   inseparable): every refill is issued on the positional plane the WALK hands
-///   in — the reader's UNADVISED `scan_positional_source` — never the
+///   in — the reader's never-`MADV_RANDOM` `scan_positional_source` — never the
 ///   `MADV_RANDOM` `point_source`. Coalescing and the read-intent split are
 ///   complementary halves of one mechanism: bigger sequential reads only pay off
 ///   on a mapping that reads ahead, and CASSANDRA-15452 is the upstream precedent

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
@@ -50,7 +50,7 @@ mod compressed_scan_window;
 
 // COMBINED-INTERACTION regression for the #2876 read-intent split x the #2877
 // coalescing window: every widened read this walk issues must land on the
-// UNADVISED scan plane and none on the `MADV_RANDOM` point plane — a property of
+// never-`MADV_RANDOM` scan plane and none on the point plane — a property of
 // the PAIR that neither fix's own tests can observe. Lives in-crate (not
 // `cqlite-core/tests/`) because the per-plane spies and plane setters are
 // `#[cfg(test)] pub(crate)`; lives HERE rather than beside
@@ -296,14 +296,14 @@ impl SSTableReader {
                 // SCAN intent (issue #2876): this forward Summary-guided walk reads
                 // Data.db in mostly-ascending order, so every read — the partition
                 // body AND (uncompressed) its covering `CRC.db` chunks — goes
-                // through the reader's UNADVISED `scan_positional_source`, never the
-                // `MADV_RANDOM` point mapping whose readahead suppression (#2210)
+                // through the reader's never-`MADV_RANDOM` `scan_positional_source`,
+                // not the `MADV_RANDOM` point mapping whose suppressed readahead (#2210)
                 // would cost this walk ~one 4 KiB fault per partition.
                 //
                 // The #2877 coalescing window is the CONSUMER of that plane, never a
                 // bypass of it: it makes the SAME scan-plane reads fewer and larger
                 // (chunk-aligned, ramped to 4 MiB), which is precisely what the
-                // unadvised mapping's kernel readahead rewards. Issuing them on the
+                // scan mapping's kernel readahead rewards. Issuing them on the
                 // advised point plane instead would reinstate the #2876 field
                 // regression while every per-PR test stayed green — the combined
                 // interaction `cqlite-core/tests/issue_2877_scan_chunk_coalescing.rs`

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/scan_plane_coalescing_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/scan_plane_coalescing_tests.rs
@@ -11,7 +11,7 @@
 //!   `MADV_RANDOM` (issue #2210) to suppress kernel readahead for scattered point
 //!   faults. On a forward walk that advice is exactly backwards — ~one 4 KiB fault
 //!   per partition instead of a readahead window. Scan-shaped walks now pass the
-//!   reader's UNADVISED `scan_positional_source`.
+//!   reader's never-`MADV_RANDOM` `scan_positional_source`.
 //! - **#2877** coalesces that walk's reads per CHUNK rather than per PARTITION,
 //!   with a doubling ramp up to a 4 MiB window.
 //!

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -337,8 +337,13 @@ fn mmap_advice_for(prefetch: PrefetchMode) -> Option<memmap2::Advice> {
 /// amplification (~30x) and the cold-cache per-read latency (~35-43%). Threshold
 /// is measurement-derived on Linux/EBS: the win is unambiguous by 4 MiB; 8 MiB
 /// leaves 2x margin above the sub-MB "wash" zone. See
-/// docs/reports/issue-2210-madv-random-point-mmap-ab.md. The SCAN mapping is
-/// NEVER advised (measured #1143 behaviour preserved).
+/// docs/reports/issue-2210-madv-random-point-mmap-ab.md. The SCAN mapping never
+/// gets `MADV_RANDOM`; the default `PrefetchMode::Auto` leaves it unadvised
+/// entirely (measured #1143 behaviour), an explicit `Sequential`/`WillNeed` does
+/// advise it. It backs BOTH `BlockSource::Mapped` and `scan_positional_source`,
+/// and the windowed / Summary-guided scan feed reads through the latter
+/// (`ReadAt`), NOT through `BlockSource` (#2876) — so a claim scoped to
+/// `BlockSource` describes nothing that a real scan does.
 #[cfg(unix)]
 const POINT_MMAP_MADV_RANDOM_MIN_BYTES: u64 = 8 * 1024 * 1024;
 
@@ -595,16 +600,11 @@ impl SSTableReader {
         };
 
         // Build the SCAN-side positional source (issue #2876): the Summary-guided
-        // compressed partition walk and the windowed streaming scan feed must NOT
-        // share `point_source` — for the mmap backend that source is deliberately
-        // advised `MADV_RANDOM` above (issue #2210) to help scattered point faults,
-        // which is exactly backwards for a mostly-sequential scan (one 4 KiB page
-        // fault per positional read instead of the ~128 KiB read-ahead window).
-        // Always the SAME unadvised mapping `ScanSource::Mapped` already holds — an
-        // `Arc` clone, no new mapping / fd (#1143: the scan mapping is never
-        // advised). The Direct/Buffered backends have no per-mapping advice
-        // concept, so they share `point_source` unchanged (no behavior change for
-        // those backends).
+        // walk and the windowed scan feed must NOT share the deliberately
+        // `MADV_RANDOM` `point_source` (#2210) — backwards for a mostly-sequential
+        // scan (a 4 KiB page fault per read, not the ~128 KiB read-ahead window).
+        // Reuse the SAME never-`MADV_RANDOM` mapping `ScanSource::Mapped` holds (an
+        // `Arc` clone, no new mapping / fd); Direct/Buffered share `point_source`.
         let scan_positional_source: Arc<dyn read_at::ReadAt> = match &scan_source {
             ScanSource::Mapped(mmap) => Arc::new(read_at::MmapReadAt::new(mmap.clone())),
             #[cfg(unix)]

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -974,7 +974,7 @@ impl SSTableReader {
     /// Whether this reader's block source is backed by a memory map.
     ///
     /// Test-only hook used to verify that the `use_mmap` config / env wiring
-    /// actually selects the intended backend end-to-end.
+    /// actually promotes an explicit `Buffered` request to mmap end-to-end.
     #[cfg(test)]
     pub(crate) async fn is_mmap_backed(&self) -> bool {
         self.file.lock().await.is_mmap()
@@ -1187,12 +1187,12 @@ impl SSTableReader {
     /// (`file_size >= min_random_bytes`) map a SECOND, dedicated read-only mapping
     /// of the same file and advise it `MADV_RANDOM`, returning that distinct
     /// mapping so scattered point faults read one page instead of the ~128 KiB
-    /// read-ahead window (issue #2210). The returned mapping is a SEPARATE
-    /// allocation from `scan_mmap`, which is left unadvised — advising the point map
-    /// therefore cannot affect the scan map (#1143 preserved). Below the threshold,
-    /// or if the dedicated map / its advice fails, share `scan_mmap` unchanged
-    /// (never keep a redundant unadvised 2nd map). Mapped directly (not via
-    /// `map_file`) so the read-work FILE_OPENS counter is untouched.
+    /// read-ahead window (issue #2210). The returned mapping is a SEPARATE allocation
+    /// from `scan_mmap`, which THIS function never advises (only `build_block_sources`
+    /// does, and only for an explicit `Sequential`/`WillNeed`), so advising the point
+    /// map cannot affect the scan map (#1143 preserved). Below the threshold, or if
+    /// the dedicated map / its advice fails, share `scan_mmap` unchanged (never keep a
+    /// redundant 2nd map). Mapped directly (not via `map_file`): FILE_OPENS untouched.
     #[cfg(unix)]
     fn point_read_mmap(
         path: &Path,

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -1,26 +1,26 @@
 //! Backing store abstraction for SSTable block I/O.
 //!
-//! The SSTable reader accesses Data.db through a single seekable byte source.
-//! Historically this was always a buffered file handle (`BufReader<File>`).
-//! [`BlockSource`] generalizes that to two interchangeable backends:
+//! The SSTable reader accesses Data.db through a single seekable byte source;
+//! [`BlockSource`] offers two interchangeable backends (plus Unix direct I/O):
 //!
-//! - [`BlockSource::Buffered`]: standard buffered async file I/O. Reads go
-//!   through the OS page cache with kernel read-ahead. This is the safe,
-//!   universally-portable default and is used for small files (where mmap
-//!   setup overhead is not worth it) or when mmap is disabled.
-//! - [`BlockSource::Mapped`]: a memory-mapped view of the file. The OS maps
-//!   the file into the process address space and serves reads straight from
-//!   the page cache with no per-block `read` syscall and no extra copy into a
-//!   buffered reader. This is well-suited to local SSTable analysis where the
-//!   same files are scanned repeatedly across queries (the page cache is
-//!   shared and reused), which is also the strategy Cassandra itself uses for
-//!   its read path (`disk_access_mode: mmap`).
+//! - [`BlockSource::Buffered`]: buffered async file I/O through the OS page cache
+//!   with kernel read-ahead; used for files below `mmap_min_size_bytes` and
+//!   wherever `disk_access_mode: buffered` is explicit (the compaction/merge path).
+//! - [`BlockSource::Mapped`]: a memory-mapped view served straight from the page
+//!   cache — no per-block `read` syscall, no copy into a buffered reader; suits
+//!   repeated local scans of immutable files and is Cassandra's own read-path
+//!   strategy (`disk_access_mode: mmap`). **The default `Auto` mode resolves to
+//!   this for any Data.db above one page**, so it, not `Buffered`, is the default.
 //!
-//! Both variants implement [`tokio::io::AsyncRead`] and
-//! [`tokio::io::AsyncSeek`], so every existing call site
-//! (`seek` / `stream_position` / `read` / `read_exact`) works against either
-//! backend without modification. The mmap backend is purely in-memory, so its
-//! poll methods always complete synchronously (`Poll::Ready`).
+//! Both implement [`tokio::io::AsyncRead`] / [`tokio::io::AsyncSeek`], so every
+//! call site (`seek` / `stream_position` / `read` / `read_exact`) works against
+//! either unmodified; the mmap backend is purely in-memory, so its poll methods
+//! always complete synchronously (`Poll::Ready`).
+//!
+//! Buffered capacity is tokio's 8 KiB `DEFAULT_BUF_SIZE` (#3068): both constructors
+//! below use `BufReader::new` (`with_capacity` appears nowhere in `cqlite-core/src`),
+//! and `SSTableReaderConfig::read_buffer_size` (64 KiB) is a `block_io.rs` scratch
+//! cap, not a reader capacity — so it reaches only the explicitly-buffered readers.
 
 use std::io::{self, SeekFrom};
 use std::path::Path;

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -3,24 +3,24 @@
 //! The SSTable reader accesses Data.db through a single seekable byte source;
 //! [`BlockSource`] offers two interchangeable backends (plus Unix direct I/O):
 //!
-//! - [`BlockSource::Buffered`]: buffered async file I/O through the OS page cache
-//!   with kernel read-ahead; used for files below `mmap_min_size_bytes` and
-//!   wherever `disk_access_mode: buffered` is explicit (the compaction/merge path).
-//! - [`BlockSource::Mapped`]: a memory-mapped view served straight from the page
-//!   cache — no per-block `read` syscall, no copy into a buffered reader; suits
-//!   repeated local scans of immutable files and is Cassandra's own read-path
-//!   strategy (`disk_access_mode: mmap`). **The default `Auto` mode resolves to
-//!   this for any Data.db above one page**, so it, not `Buffered`, is the default.
+//! - [`BlockSource::Buffered`]: buffered async file I/O through the OS page cache with
+//!   kernel read-ahead; used under `Auto` below `mmap_min_size_bytes`, for a
+//!   zero-length file, wherever `disk_access_mode: buffered` is explicit and
+//!   `use_mmap` does not promote it (the compaction/merge path), and as the graceful
+//!   fallback when a map or a direct open fails (`build_block_sources`).
+//! - [`BlockSource::Mapped`]: a memory-mapped view served straight from the page cache
+//!   — no per-block `read` syscall, no copy into a buffered reader; Cassandra's own
+//!   read-path strategy (`disk_access_mode: mmap`). Under the default `Auto`, a Data.db
+//!   from one page up to `direct_io_memory_fraction` of RAM lands here, not `Buffered`.
 //!
-//! Both implement [`tokio::io::AsyncRead`] / [`tokio::io::AsyncSeek`], so every
-//! call site (`seek` / `stream_position` / `read` / `read_exact`) works against
-//! either unmodified; the mmap backend is purely in-memory, so its poll methods
-//! always complete synchronously (`Poll::Ready`).
+//! Both implement [`tokio::io::AsyncRead`] / [`tokio::io::AsyncSeek`], so every call site
+//! (`seek` / `stream_position` / `read` / `read_exact`) works against either unmodified;
+//! the mmap backend is in-memory, so its poll methods always return `Poll::Ready`.
 //!
-//! Buffered capacity is tokio's 8 KiB `DEFAULT_BUF_SIZE` (#3068): both constructors
-//! below use `BufReader::new` (`with_capacity` appears nowhere in `cqlite-core/src`),
-//! and `SSTableReaderConfig::read_buffer_size` (64 KiB) is a `block_io.rs` scratch
-//! cap, not a reader capacity — so it reaches only the explicitly-buffered readers.
+//! Buffered capacity is tokio's 8 KiB `DEFAULT_BUF_SIZE` (#3068): both constructors below
+//! use `BufReader::new` (no `BufReader::with_capacity` in `cqlite-core/src`), and
+//! `SSTableReaderConfig::read_buffer_size` (64 KiB) never sizes that reader — it caps
+//! `block_io.rs`'s `read_into_vec_capped` scratch for EVERY backend, `Mapped` included.
 
 use std::io::{self, SeekFrom};
 use std::path::Path;

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -151,7 +151,9 @@ impl Default for SSTableReaderStats {
 /// Configuration for SSTable reader
 #[derive(Debug, Clone)]
 pub struct SSTableReaderConfig {
-    /// Size of the read buffer in bytes
+    /// Cap (bytes) on the scratch buffer `block_io.rs` reads a block through
+    /// (`read_into_vec_capped`), applied to EVERY backend, `Mapped` included. It is
+    /// NOT a `BufReader` capacity — that is tokio's 8 KiB default (#3068).
     pub read_buffer_size: usize,
     /// Legacy promote-only flag: it upgrades an **explicit**
     /// [`Buffered`](crate::config::DiskAccessMode::Buffered) request to
@@ -161,14 +163,17 @@ pub struct SSTableReaderConfig {
     /// The backend is chosen by `storage.disk_access_mode` ([`crate::Config`]),
     /// which defaults to [`Auto`](crate::config::DiskAccessMode::Auto). See
     /// `resolve_disk_access_mode` in the reader module for the exact resolution:
-    /// `Auto` yields buffered I/O only for files below
-    /// [`Self::mmap_min_size_bytes`] (4 KiB), **mmap** for anything larger up to
-    /// `storage.direct_io_memory_fraction` of system RAM (default half), and
-    /// direct I/O above that. So every field reader built from a default
-    /// `Config` memory-maps any Data.db bigger than one page, and no combination
-    /// of this flag's values can produce the buffered path there — only an
-    /// explicit `disk_access_mode: buffered` can (as the write/compaction merge
-    /// readers do).
+    /// `Auto` yields buffered I/O for files below [`Self::mmap_min_size_bytes`]
+    /// (4 KiB) and **mmap** for anything larger, up to
+    /// `storage.direct_io_memory_fraction` of system RAM (default half); above that
+    /// it picks direct I/O where that backend is compiled in (Linux/Android/macOS —
+    /// elsewhere, or when system memory cannot be read, `Auto` never escalates and
+    /// stays on mmap). So a reader built from a default `Config` maps a Data.db
+    /// between one page and that fraction, and this flag cannot make it buffered;
+    /// only an explicit `disk_access_mode: buffered` can (as the write/compaction
+    /// merge readers do). Mapping is still best-effort: if the map itself fails
+    /// (network/overlay mount, `ENOMEM`), `build_block_sources` falls back to
+    /// buffered I/O rather than failing the open.
     ///
     /// A mapped file is served from the OS page cache with no per-block read
     /// syscall, mirroring Cassandra's `disk_access_mode: mmap`. Map only
@@ -176,12 +181,13 @@ pub struct SSTableReaderConfig {
     /// the platform/filesystem constraints (network FS and external mutation can
     /// `SIGBUS`).
     pub use_mmap: bool,
-    /// Minimum file size (bytes) for memory mapping to kick in.
+    /// Minimum file size (bytes) at which the `Auto` heuristic memory-maps.
     ///
-    /// Files smaller than this use buffered I/O — both under the default
-    /// `disk_access_mode: Auto` and when [`Self::use_mmap`] promotes an explicit
-    /// `Buffered` request — since the per-file mapping overhead is not
-    /// worthwhile for tiny files and mapping a zero-length file is invalid.
+    /// Under the default `disk_access_mode: Auto`, files below this use buffered I/O,
+    /// since the per-file mapping overhead is not worthwhile for tiny files. It does
+    /// NOT gate an explicit `Mmap` request — including one [`Self::use_mmap`] promoted
+    /// from an explicit `Buffered` — which is size-independent; only a zero-length
+    /// file, which cannot be mapped at all, always falls back to buffered I/O.
     pub mmap_min_size_bytes: usize,
     /// Maximum number of blocks to cache
     pub block_cache_size: usize,

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -153,21 +153,35 @@ impl Default for SSTableReaderStats {
 pub struct SSTableReaderConfig {
     /// Size of the read buffer in bytes
     pub read_buffer_size: usize,
-    /// Whether to memory-map SSTable files instead of using buffered file I/O.
+    /// Legacy promote-only flag: it upgrades an **explicit**
+    /// [`Buffered`](crate::config::DiskAccessMode::Buffered) request to
+    /// [`Mmap`](crate::config::DiskAccessMode::Mmap). It does **not** select the
+    /// read backend, and `false` does **not** mean "buffered I/O".
     ///
-    /// **Opt-in; defaults to `false`.** When enabled, files at or above
-    /// [`Self::mmap_min_size_bytes`] are mapped into the address space and
-    /// served from the OS page cache with no per-block read syscall. This
-    /// mirrors Cassandra's `disk_access_mode: mmap` and benefits repeated local
-    /// scans of the same files. Enable only for immutable local SSTables — see
-    /// [`crate::Config`]'s `storage.use_mmap` for the platform/filesystem
-    /// constraints (network FS and external mutation can `SIGBUS`).
+    /// The backend is chosen by `storage.disk_access_mode` ([`crate::Config`]),
+    /// which defaults to [`Auto`](crate::config::DiskAccessMode::Auto). See
+    /// `resolve_disk_access_mode` in the reader module for the exact resolution:
+    /// `Auto` yields buffered I/O only for files below
+    /// [`Self::mmap_min_size_bytes`] (4 KiB), **mmap** for anything larger up to
+    /// `storage.direct_io_memory_fraction` of system RAM (default half), and
+    /// direct I/O above that. So every field reader built from a default
+    /// `Config` memory-maps any Data.db bigger than one page, and no combination
+    /// of this flag's values can produce the buffered path there — only an
+    /// explicit `disk_access_mode: buffered` can (as the write/compaction merge
+    /// readers do).
+    ///
+    /// A mapped file is served from the OS page cache with no per-block read
+    /// syscall, mirroring Cassandra's `disk_access_mode: mmap`. Map only
+    /// immutable local SSTables — see [`crate::Config`]'s `storage.use_mmap` for
+    /// the platform/filesystem constraints (network FS and external mutation can
+    /// `SIGBUS`).
     pub use_mmap: bool,
     /// Minimum file size (bytes) for memory mapping to kick in.
     ///
-    /// Files smaller than this use buffered I/O even when [`Self::use_mmap`] is
-    /// set, since the per-file mapping overhead is not worthwhile for tiny
-    /// files and mapping a zero-length file is invalid.
+    /// Files smaller than this use buffered I/O — both under the default
+    /// `disk_access_mode: Auto` and when [`Self::use_mmap`] promotes an explicit
+    /// `Buffered` request — since the per-file mapping overhead is not
+    /// worthwhile for tiny files and mapping a zero-length file is invalid.
     pub mmap_min_size_bytes: usize,
     /// Maximum number of blocks to cache
     pub block_cache_size: usize,
@@ -183,9 +197,12 @@ impl Default for SSTableReaderConfig {
     fn default() -> Self {
         Self {
             read_buffer_size: 64 * 1024, // 64KB
-            use_mmap: false,             // Opt-in; buffered I/O is the portable, safe default
-            mmap_min_size_bytes: 4096,   // Skip mmap for files smaller than a page
-            block_cache_size: 1000,      // Cache 1000 blocks
+            // Promote-only legacy flag (see the field doc); the backend itself
+            // comes from `storage.disk_access_mode`, whose `Auto` default
+            // resolves to mmap for any file above `mmap_min_size_bytes`.
+            use_mmap: false,
+            mmap_min_size_bytes: 4096, // Skip mmap for files smaller than a page
+            block_cache_size: 1000,    // Cache 1000 blocks
             validate_checksums: true,
             use_bloom_filter: true,
             prefetch_size: 128 * 1024, // 128KB


### PR DESCRIPTION
Refs #3068 (track "C" — doc-only; #3068 stays open for the perf lever).

**Comments/docs only. Zero behavior change, zero signature change, zero logic change.**

## The defect class: comments that document a path nobody takes

`use_mmap` does **not** select the read backend. `config.storage.disk_access_mode` defaults to
`DiskAccessMode::Auto` (`cqlite-core/src/config.rs:126`), and `resolve_disk_access_mode`
(`reader/mod.rs:245-282`) maps `Auto` + `size >= mmap_min_size_bytes` (4 KiB) + `size <= 0.5 * RAM`
to `Mmap`. `use_mmap` is folded in at `reader/mod.rs:532-537` only as a **promotion** of an
*explicit* `Buffered` request to `Mmap` — it can never produce the buffered path. Every field reader
construction (cqlite-cli, cqlite-flight, python/node bindings) uses `Config::default()` => `Auto`
=> `Mmap`. The only forced-`Buffered` sites are the write/compaction merge path
(`write_engine/merge/mod.rs:758-770`, `merge/from_readers.rs:39`, `merge/point_read.rs:467`).

Evidence (strace, release `cqlite read-sstable`, 647 KB Data.db, 1000-row scan):
`openat -> mmap(647164, MAP_SHARED) -> close`, and **zero** `read`/`pread64` syscalls against
Data.db. The buffered path documented in these comments is not executed.

Comments that describe a configuration nobody runs are worse than no comment: per the owner, the
"SCAN mapping is NEVER advised" line below is why #2876 stayed hidden for five days.

## The three corrections

1. **`cqlite-core/src/storage/sstable/reader/types.rs`** (`SSTableReaderConfig::use_mmap`) — said
   "Opt-in; buffered I/O is the portable, safe default", describing a field configuration that does
   not exist. Now states that the flag is promote-only (explicit `Buffered` -> `Mmap`), that `false`
   does not mean buffered, and that the backend comes from `storage.disk_access_mode` (`Auto`
   default: buffered below 4 KiB, mmap up to `direct_io_memory_fraction` of RAM, direct above),
   pointing at `resolve_disk_access_mode`. The `mmap_min_size_bytes` doc and the `Default` inline
   comment were corrected to match.

2. **`cqlite-core/src/storage/sstable/reader/mod.rs`** (`POINT_MMAP_MADV_RANDOM_MIN_BYTES`) — said
   "The SCAN mapping is NEVER advised", technically true only of `MADV_RANDOM`. Now says what is
   true: the scan mapping never gets `MADV_RANDOM`; the default `PrefetchMode::Auto` leaves it
   unadvised entirely (#1143) while an explicit `Sequential`/`WillNeed` does advise it
   (`build_block_sources`, `reader/mod.rs:1093`); and that the mapping backs BOTH
   `BlockSource::Mapped` and `scan_positional_source`, with the windowed / Summary-guided scan feed
   reading through the latter — **not** through `BlockSource` — so a `BlockSource`-scoped claim
   describes nothing a real scan does (#2876). The duplicate `#1143: the scan mapping is never
   advised` parenthetical at the `scan_positional_source` construction site was tightened the same
   way.

3. **`cqlite-core/src/storage/sstable/reader/source.rs`** (module doc, where a reader of the two
   `BufReader::new` constructors will see it) — records the dropped observation: both `buffered`
   and `buffered_sized` use `BufReader::new`, i.e. tokio's 8 KiB `DEFAULT_BUF_SIZE`;
   `BufReader::with_capacity` appears nowhere in `cqlite-core/src`; and
   `SSTableReaderConfig::read_buffer_size` (64 KiB) is a `block_io.rs` scratch /
   chunk-materialization cap (lines 281, 825, 833, 942), **not** a reader capacity. Scoped as an
   observation, not a defect: buffered is not the resolved default read backend, so the 8 KiB refill
   reaches only the explicitly-buffered merge readers. **Buffer sizes are unchanged** — explicitly
   out of scope per the owner.

Also corrected in passing (same defect class, same doc, in-place, no line growth):
`cqlite-core/src/config.rs` said the legacy `use_mmap` flag "still forces mmap when `Auto` would
otherwise pick buffered" — it does not; `Auto` is left untouched by the promotion. Two adjacent
"defaults to buffered I/O" phrasings were corrected to "no promotion".

## Verification

- All claims re-verified against the files (not from a prior read) before editing; all three held.
- `cargo doc --no-deps -p cqlite-core` with `-D rustdoc::broken_intra_doc_links`: 66 errors before
  and 66 after (all pre-existing, none in the touched files) — the new intra-doc links resolve.
- Campsite rule: `mod.rs` (1721), `source.rs` (835) and `config.rs` (1133) are over the ~800
  threshold, so their comment rewrites were made **line-count-neutral** (each file is at exactly its
  `origin/main` line count). `CQLITE_ALLOW_FILE_GROWTH` was not needed.

## Gate

`AGENT-GATE LITE SUMMARY` — RESULT: PASS at 983bc82 (file-size PASS, fmt PASS, clippy PASS,
roborev-lints PASS, scoped-tests PASS; tree-integrity PASS). The full gate of record runs once
pre-merge in `flow-closer`.
