### PR TITLE
docs(#3041): the live gate-tree-integrity spec no longer legitimizes the bare-RESULT: poll predicate

### DIFF
--- a/openspec/specs/gate-tree-integrity/spec.md
+++ b/openspec/specs/gate-tree-integrity/spec.md
@@ -214,7 +214,9 @@ without the tree lines, and no block SHALL carry a duplicated set of them.
   the existing synthetic `commit: selftest` stamp, and SHALL require no git state
 
 #### Scenario: the RESULT poll predicates are unaffected by the new lines
-- **WHEN** a caller polls a summary file with `grep -q 'RESULT:'` or `grep -qE 'RESULT: (PASS|FAIL)'`
+- **WHEN** a caller polls a summary file with the **known-buggy** bare-`RESULT:`-token match (it also
+  matches the start-of-run `RESULT: INCOMPLETE` placeholder — the #2908/#3041 defect; do NOT copy it) or
+  the **correct** `grep -qE 'RESULT: (PASS|FAIL)'`
 - **THEN** the added lines SHALL NOT match either predicate, so issue #2908's separate concern is
   neither fixed nor regressed by this change
 


### PR DESCRIPTION
Follow-up to #3041 / PR #3066 (merged). Addresses the one roborev finding (**Low**) that landed after #3066 was merged, so it could not be folded into that PR.

## The gap

#3066 swept the copy-pasteable bare-token gate-completion predicate out of `scripts/agent-gate.sh` and `scripts/tests/test_agent_gate_summary.sh`, but `openspec/specs/gate-tree-integrity/spec.md` still presented

```
grep -q 'RESULT:'   or   grep -qE 'RESULT: (PASS|FAIL)'
```

side-by-side as two **equally legitimate** caller poll predicates, with no marker that the bare form is the #2908/#3041 defect (it also matches the start-of-run `RESULT: INCOMPLETE` placeholder).

Unlike the archived OpenSpec copies — correctly left untouched as history — this is a **live requirement surface a `spec-auditor` reads**, so it was the last authoritative place still teaching the buggy predicate.

## The change

Labeling only. The scenario's **non-regression semantics are unchanged**: both predicates must still be unaffected by the added `tree-*` lines, so #2908 is still neither fixed nor regressed. The bare-token form is now named as known-buggy with an explicit do-NOT-copy, mirroring the wording #3066 introduced in the two scripts.

## Verification

- `rg -n "grep -q ['\"]RESULT:['\"]" .claude docs website scripts CLAUDE.md openspec/specs` → **zero** matches (closed-token form; the issue's unclosed regex also matches correct verdict-qualified probes such as `grep -q 'RESULT: INCOMPLETE'`, which are deliberately kept).
- `--lite` re-cert **PASS** at `bb6d1cd` (file-size, fmt, clippy, roborev-lints, scoped-tests all PASS).
- Gate self-test `scripts/tests/test_agent_gate_summary.sh`: **passed: 101, failed: 0**, including `2926-poll-predicates` which pins the "exactly ONE RESULT: token" invariant.

Docs/spec-only diff — no executable line touched. **#2908 stays open** as the stronger MECHANISM follow-up (a `.running` sentinel + a self-test pin).