### PR TITLE
test-data(#3068): perf corpus generator, manifest, and memory-contained run wrapper

### DIFF
--- a/docs/development/dev-cookbook.md
+++ b/docs/development/dev-cookbook.md
@@ -22,6 +22,12 @@ See `docs/profiling.md`.
 FD/RSS resource-leak soak (long-running open/scan/drop loop): see
 `docs/development/soak-resource-leak.md`.
 
+Measuring against a **multi-GB** corpus (cold/warm scans, large-I/O work): generate it with
+`test-data/scripts/gen-perf-corpus-3068.sh` and run every measurement through
+`test-data/scripts/perf-run-contained.sh` — an *uncontained* cold read of an 8 GiB mmap'd `Data.db`
+hard-hung a swapless host for 75 minutes with no OOM kill. See
+`docs/development/perf-corpus-and-containment.md`.
+
 ## CLI
 
 ```bash

--- a/docs/development/perf-corpus-and-containment.md
+++ b/docs/development/perf-corpus-and-containment.md
@@ -48,6 +48,10 @@ bytes** — never values assumed from the DDL or from the generator's intent:
   a throwaway memory-capped container. This is **fail-closed**: if `totalRows` cannot be read the
   generator errors out rather than recording an unobserved number.
 
+The DDL is reproducible too: the generator captures `cqlsh DESCRIBE KEYSPACE` into `schema.cql` and
+publishes a copy **next to each SSTable**, so `keyspace_ddl` and the per-table DDL can be rebuilt
+from the corpus alone with no live container. The capture is fail-closed — no `schema.cql`, no run.
+
 Regenerate + re-verify:
 
 ```bash
@@ -61,6 +65,21 @@ python3 test-data/scripts/write-perf-corpus-manifest.py \
 
 The recorded `data_db_sha256` is the reproducibility check: a regenerated corpus with a different
 hash is a *different* corpus, and any perf number measured against it is not comparable.
+
+Generator guardrails (pinned by `scripts/tests/test_gen_perf_corpus_3068.sh`, gate component
+`tooling-tests`):
+
+- **`TABLES` (`both`|`medium`|`wide`) and `CORPUS_ROOT` are validated FIRST**, before the container,
+  the load, or any deletion. A typo used to start a container, generate nothing, and then overwrite
+  the committed manifest with an empty `tables` array; the manifest writer now also **refuses an
+  empty `--table` list** outright, so no caller can produce that.
+- **A regeneration prunes the previous `<table>-<uuid>` directory** for each selected table, so the
+  corpus cannot accumulate multiple multi-GB copies that the manifest does not describe. The
+  deletion is deliberately narrow: direct children of `$CORPUS_ROOT/sstables/<keyspace>` whose name
+  is exactly `<selected-table>-<32 hex>`, never a symlink, never a path resolving outside that
+  directory, never with an empty/relative/`/` corpus root. `PRUNE_STALE=0` keeps them;
+  `--prune-dry-run` lists what a run would remove and deletes nothing (`--validate-only` checks
+  inputs only).
 
 ## Why `perf-run-contained.sh` exists — read this before your first cold scan
 
@@ -89,11 +108,23 @@ bash test-data/scripts/perf-run-contained.sh --mem 8G --swap 2G -- \
 ```
 
 `--mem`/`--swap` take systemd memory syntax (byte count with an optional `K`/`M`/`G`/`T`[`i`]
-suffix, a percentage, `max`, or `infinity`) and are **validated before `sudo`**. That validation is
-safety-critical, not cosmetic: a bare `8` is a legal systemd value meaning *8 bytes*, so a typo
-must not quietly turn every run into an instant OOM that looks like a real result. It is pinned by
-`scripts/tests/test_perf_run_contained.sh` (gate component `tooling-tests`); `--check-args`
-validates and prints the resolved caps without executing anything.
+suffix, or a percentage of physical RAM) and are **validated before `sudo`**. That validation is
+safety-critical, not cosmetic, and it is deliberately *stricter than systemd*:
+
+- **`max` and `infinity` are REFUSED** (either flag, any case). systemd accepts them and they
+  *disable* the limit — a "contained" run with no cap is exactly the state that livelocked the host.
+  A cap must be finite.
+- **`--mem` may not be zero** (`0`, `0G`, `0%`): a zero cap kills the workload instead of containing
+  it. **`--swap 0` is allowed** and is the normal "no swap" cap.
+- **A percentage must be `<= 100%`** (and `> 0%` for `--mem`).
+- **A suffixless number is a BYTE count to systemd** — `--mem 8` means *8 bytes*. Anything under
+  1 MiB is refused outright (a typo must never look like an instant OOM), and a larger suffixless
+  value is accepted but echoes the reading it resolved to (`... reads it as BYTES = 1073741824 B
+  (1.00 GiB)`), so it can never be a silent misunderstanding. A *suffixed* small cap (`64K`) is still
+  accepted: it is explicit, not a typo.
+
+Pinned by `scripts/tests/test_perf_run_contained.sh` (gate component `tooling-tests`);
+`--check-args` validates and prints the resolved caps without executing anything.
 
 Practical caps on a 16 GiB box: `--mem 8G --swap 2G` leaves room for the host. If the measurement
 gets OOM-killed under that cap, that is a **finding about the read path's memory behavior** (see the

--- a/docs/development/perf-corpus-and-containment.md
+++ b/docs/development/perf-corpus-and-containment.md
@@ -1,0 +1,100 @@
+# Perf corpus + memory containment (issue #3068)
+
+Tooling for generating and safely measuring against a **field-shaped, multi-GB, LZ4-compressed,
+single-SSTable** Cassandra 5.0 corpus. Built for issue #3068 (read-plane scan window / large I/O)
+and reusable by any read-path performance work — #3029, #3030, #3031.
+
+| File | Purpose |
+|------|---------|
+| `test-data/scripts/gen-perf-corpus-3068.sh` | Generate the corpus (cassandra:5.0.2 container + `cassandra-stress`) |
+| `test-data/scripts/write-perf-corpus-manifest.py` | Emit the manifest, every value read back off disk |
+| `test-data/scripts/read-compression-info.py` | Parse `CompressionInfo.db` (compressor / chunk length / chunk count) |
+| `test-data/scripts/perf-run-contained.sh` | Run a measurement inside a memory-capped cgroup scope |
+| `test-data/perf-corpus-3068-manifest.json` | Committed manifest of the generated corpus |
+
+## Why a bespoke corpus
+
+The committed `test-data/datasets/` fixtures are tiny, and the Phase-0 perf anchor was
+**uncompressed** — so it never executed the compressed read path at all. Read-path measurement
+needs a corpus that:
+
+1. is **LZ4-compressed at the Cassandra table default `chunk_length_in_kb = 16`** (a compressed
+   scan window is a no-op without real chunks);
+2. has a `Data.db` far larger than any CPU cache and comparable to RAM, so "cold" is genuinely
+   cold and "warm" is a real page-cache state;
+3. is **one SSTable**, so a k-way merge cannot pollute the read-plane number.
+
+Two row shapes are produced, both `nb` (BIG) with 10 rows per partition:
+
+| Table | Row shape | Rows | `Data.db` |
+|-------|-----------|------|-----------|
+| `perf_3068.medium_700b` | ~700 B/row, 11 columns | 11,994,840 | ~8.0 GiB |
+| `perf_3068.wide_4kb` | >= 4 KB/row (large `text` body + blob) | 1,199,890 | ~4.7 GiB |
+
+`wide_4kb`'s payload is close to incompressible, so LZ4 leaves it marginally **larger** than
+its logical size (Cassandra reports a compression ratio of ~1.0006) — that is expected, not a bug.
+
+## The corpus is NOT committed; the manifest is
+
+The corpus is multi-GB and lives outside the repo (default `/home/ubuntu/corpus-3068`, laid out so
+`CQLITE_DATASETS_ROOT=$CORPUS_ROOT` works directly). What is committed is
+`test-data/perf-corpus-3068-manifest.json`, and it records **only values read back from the written
+bytes** — never values assumed from the DDL or from the generator's intent:
+
+- component filenames + sizes from `stat`; `Data.db` sha256 by hashing the file;
+- compressor, chunk length, and chunk count from the **`CompressionInfo.db` header**, not from the
+  table's `compression` option (a later `ALTER` or a Cassandra-side clamp would make the DDL a lie);
+- row count from **Cassandra's own `sstablemetadata`** reading `Statistics.db` (`totalRows`), run in
+  a throwaway memory-capped container. This is **fail-closed**: if `totalRows` cannot be read the
+  generator errors out rather than recording an unobserved number.
+
+Regenerate + re-verify:
+
+```bash
+bash test-data/scripts/gen-perf-corpus-3068.sh           # hours; needs ~30 GiB free
+python3 test-data/scripts/write-perf-corpus-manifest.py \
+  --corpus-root /home/ubuntu/corpus-3068 --keyspace perf_3068 --image cassandra:5.0.2 \
+  --table "medium_700b:$CORPUS/sstables/perf_3068/medium_700b-<uuid>" \
+  --table "wide_4kb:$CORPUS/sstables/perf_3068/wide_4kb-<uuid>" \
+  --out test-data/perf-corpus-3068-manifest.json
+```
+
+The recorded `data_db_sha256` is the reproducibility check: a regenerated corpus with a different
+hash is a *different* corpus, and any perf number measured against it is not comparable.
+
+## Why `perf-run-contained.sh` exists — read this before your first cold scan
+
+**2026-07-28: an uncontained cold scan of the 8.0 GiB `Data.db` hard-hung an entire host for 75
+minutes.** The failure mode is worth internalizing because it is not the one people expect:
+
+- The reader mmap'd the whole `Data.db`. On a **swapless** box, `Committed_AS` reached **105% of
+  `CommitLimit`**.
+- **No OOM kill ever fired.** The kernel livelocked in direct reclaim instead — load average 62.7,
+  every task in `D` state, including `sshd`. There was nothing left to schedule that could observe
+  the problem, so nothing killed the offending process.
+- Recovery took 75 minutes of the kernel grinding, not a reboot-and-continue.
+
+The lesson: **on a swapless host, "the OOM killer will save me" is false.** Reclaim livelock has no
+killer and no timeout. The only reliable protection is an *a priori* cap, so the offending process
+hits a hard limit and dies while the host stays schedulable.
+
+`perf-run-contained.sh` provides that cap. It runs the command in a transient systemd scope with
+`MemoryMax` / `MemorySwapMax` / `OOMPolicy=kill`, and additionally **refuses to start** when the
+system is already `>= 95%` committed — the exact precondition that wedged the box.
+
+```bash
+# Use this for ANY measurement that reads a multi-GB corpus.
+bash test-data/scripts/perf-run-contained.sh --mem 8G --swap 2G -- \
+  ./target/release/cqlite query --data-dir /home/ubuntu/corpus-3068/sstables ...
+```
+
+`--mem`/`--swap` take systemd memory syntax (byte count with an optional `K`/`M`/`G`/`T`[`i`]
+suffix, a percentage, `max`, or `infinity`) and are **validated before `sudo`**. That validation is
+safety-critical, not cosmetic: a bare `8` is a legal systemd value meaning *8 bytes*, so a typo
+must not quietly turn every run into an instant OOM that looks like a real result. It is pinned by
+`scripts/tests/test_perf_run_contained.sh` (gate component `tooling-tests`); `--check-args`
+validates and prints the resolved caps without executing anything.
+
+Practical caps on a 16 GiB box: `--mem 8G --swap 2G` leaves room for the host. If the measurement
+gets OOM-killed under that cap, that is a **finding about the read path's memory behavior** (see the
+`<128MB` memory target and the gate's `oom-audit`) — not a reason to raise the cap.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -241,6 +241,11 @@
 #                      copy; proves non-vacuity by mutating the copy (shifted value,
 #                      invented name, dropped row) and fails closed on a moved
 #                      decoder source or a reformatted-away table.
+#                      Also runs (no python3/sudo/systemd needed)
+#                      scripts/tests/test_perf_run_contained.sh (#3068) — pins the
+#                      --mem/--swap validation of the perf-corpus containment wrapper
+#                      test-data/scripts/perf-run-contained.sh, whose misparsed cap
+#                      would mean a hung host rather than a killed process.
 #   minimal-build      cargo build + `cargo test --lib --no-run` (compile-only)
 #                      -p cqlite-core --no-default-features --features all-compression
 #   smoke              bash test-data/scripts/smoke-test-all-tables.sh
@@ -4624,6 +4629,25 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_check_skill_flag_tables.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (skill flag-table drift guard); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # perf-run-contained argument-safety guard (#3068): no python3/sudo/systemd
+  # needed, always runs (the wrapper's --check-args hook executes nothing). Pins
+  # the --mem/--swap validation of test-data/scripts/perf-run-contained.sh: that
+  # wrapper is the containment around multi-GB perf-corpus reads after an
+  # uncontained one hard-hung a swapless host for 75 minutes, so a silently
+  # misparsed cap is a host-availability bug, not a usability nit. A failure FAILs
+  # the component, mirroring the keyspace-scoping guard.
+  echo ">>> [$name] bash scripts/tests/test_perf_run_contained.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_perf_run_contained.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (perf-run-contained arg-safety guard); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -244,8 +244,12 @@
 #                      Also runs (no python3/sudo/systemd needed)
 #                      scripts/tests/test_perf_run_contained.sh (#3068) — pins the
 #                      --mem/--swap validation of the perf-corpus containment wrapper
-#                      test-data/scripts/perf-run-contained.sh, whose misparsed cap
-#                      would mean a hung host rather than a killed process.
+#                      test-data/scripts/perf-run-contained.sh, whose misparsed or
+#                      UNBOUNDED cap would mean a hung host rather than a killed
+#                      process — and scripts/tests/test_gen_perf_corpus_3068.sh,
+#                      which pins the perf-corpus generator's TABLES validation, its
+#                      manifest writer's refusal of an empty table list, and the
+#                      tight scoping of its multi-GB stale-corpus pruning.
 #   minimal-build      cargo build + `cargo test --lib --no-run` (compile-only)
 #                      -p cqlite-core --no-default-features --features all-compression
 #   smoke              bash test-data/scripts/smoke-test-all-tables.sh
@@ -4648,6 +4652,24 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_perf_run_contained.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (perf-run-contained arg-safety guard); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # perf-corpus generator guard (#3068): hermetic (no docker/sudo/cassandra —
+  # only the generator's --validate-only/--prune-dry-run hooks, which exit before
+  # the container starts). Pins (a) TABLES validation BEFORE any destructive work
+  # plus the manifest writer's refusal to emit an empty `tables` array — together
+  # they stop a typo silently overwriting the committed provenance manifest — and
+  # (b) the tight scoping of stale-corpus pruning, which deletes multi-GB paths.
+  echo ">>> [$name] bash scripts/tests/test_gen_perf_corpus_3068.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_gen_perf_corpus_3068.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (perf-corpus generator guard); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/tests/test_gen_perf_corpus_3068.sh
+++ b/scripts/tests/test_gen_perf_corpus_3068.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Self-test for the issue-#3068 perf-corpus generator + manifest writer.
+#
+# Three properties, all of which were real defects:
+#
+#   1. TABLES is validated BEFORE any destructive or expensive work. An
+#      unvalidated typo (TABLES=medum) used to start a container, generate no
+#      tables, and then overwrite the COMMITTED manifest with an empty `tables`
+#      array -- silent corruption of a provenance artifact.
+#   2. write-perf-corpus-manifest.py REFUSES to emit a manifest with an empty
+#      table list, so that corruption cannot happen from any caller.
+#   3. Stale-corpus pruning is tightly scoped. It deletes MULTI-GB paths, so it
+#      must only ever touch "<selected-table>-<32 hex>" directories that are
+#      direct children of $CORPUS_ROOT/sstables/<keyspace> -- never a symlink,
+#      never an unrelated name, never something outside the corpus root.
+#      Exercised through the generator's --prune-dry-run hook, which enumerates
+#      candidates and deletes nothing.
+#
+# Hermetic: no docker, no sudo, no cassandra, no network, no datasets. The
+# generator is only ever invoked with --validate-only / --prune-dry-run, which
+# exit before the container is started.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GEN="$REPO_ROOT/test-data/scripts/gen-perf-corpus-3068.sh"
+MANIFEST_PY="$REPO_ROOT/test-data/scripts/write-perf-corpus-manifest.py"
+
+fails=0
+pass() { echo "ok   - $1"; }
+fail() { echo "FAIL - $1"; fails=$((fails + 1)); }
+
+[ -f "$GEN" ] || { echo "FAIL - missing $GEN"; exit 1; }
+[ -f "$MANIFEST_PY" ] || { echo "FAIL - missing $MANIFEST_PY"; exit 1; }
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# ------------------------------------------------------- TABLES validation ----
+# Valid selections resolve to the expected table set and run nothing.
+check_valid() { # check_valid <TABLES> <expected table list>
+  local tables="$1" expect="$2" out
+  out=$(TABLES="$tables" CORPUS_ROOT="$TMP/corpus" bash "$GEN" --validate-only 2>&1)
+  if [ $? -eq 0 ] && grep -q "VALIDATE-OK tables=$expect " <<<"$out"; then
+    pass "TABLES=$tables resolves to '$expect'"
+  else
+    fail "TABLES=$tables: expected 'VALIDATE-OK tables=$expect' (out: $out)"
+  fi
+}
+check_valid both   "medium_700b wide_4kb"
+check_valid medium "medium_700b"
+check_valid wide   "wide_4kb"
+
+# An invalid TABLES must fail closed, non-zero, with a clear message, and must
+# not have written ANYTHING (no stress profiles, no corpus dir, no manifest).
+for bad in medum "" MEDIUM "both wide" medium,wide all; do
+  workdir="$TMP/bad-$RANDOM"
+  mkdir -p "$workdir"
+  out=$(TABLES="$bad" CORPUS_ROOT="$workdir/corpus" bash "$GEN" --validate-only 2>&1); rc=$?
+  leftovers=$(find "$workdir" -mindepth 1 | wc -l | tr -d ' ')
+  if [ "$rc" -ne 0 ] && grep -q "invalid TABLES" <<<"$out" && [ "$leftovers" = "0" ]; then
+    pass "rejects TABLES='$bad' before doing any work"
+  else
+    fail "TABLES='$bad': expected non-zero + 'invalid TABLES' + no writes (rc=$rc, leftovers=$leftovers, out: $out)"
+  fi
+done
+
+# A relative or empty CORPUS_ROOT is refused (nothing may be deleted relative to
+# an unknown cwd).
+for badroot in "" "relative/path" "/"; do
+  out=$(TABLES=both CORPUS_ROOT="$badroot" bash "$GEN" --validate-only 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && grep -q "CORPUS_ROOT" <<<"$out"; then
+    pass "rejects CORPUS_ROOT='$badroot'"
+  else
+    fail "CORPUS_ROOT='$badroot': expected non-zero + a CORPUS_ROOT message (rc=$rc, out: $out)"
+  fi
+done
+
+# ------------------------------------------- manifest writer: empty --table ----
+if command -v python3 >/dev/null 2>&1; then
+  out=$(python3 "$MANIFEST_PY" --corpus-root "$TMP" --keyspace perf_3068 \
+          --image cassandra:5.0.2 --out "$TMP/should-not-exist.json" 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && grep -q "empty" <<<"$out" && [ ! -e "$TMP/should-not-exist.json" ]; then
+    pass "manifest writer refuses an empty --table list (writes no file)"
+  else
+    fail "manifest writer with no --table: expected non-zero + no file (rc=$rc, out: $out)"
+  fi
+
+  out=$(python3 "$MANIFEST_PY" --corpus-root "$TMP" --keyspace perf_3068 \
+          --image cassandra:5.0.2 --table "medium_700b" \
+          --out "$TMP/should-not-exist2.json" 2>&1); rc=$?
+  if [ "$rc" -ne 0 ] && grep -q "malformed" <<<"$out"; then
+    pass "manifest writer refuses a --table without a directory"
+  else
+    fail "manifest writer with a bare table name: expected non-zero (rc=$rc, out: $out)"
+  fi
+else
+  echo "skip - python3 unavailable, manifest-writer assertions skipped"
+fi
+
+# ------------------------------------------------ prune scope (dry run only) ---
+# A realistic corpus keyspace dir plus every kind of neighbour the pruner must
+# leave alone.
+CORPUS="$TMP/corpus"
+KSDIR="$CORPUS/sstables/perf_3068"
+OUTSIDE="$TMP/outside-the-corpus"
+mkdir -p "$KSDIR" "$OUTSIDE/precious"
+UUID_A="8cc9d0708a2711f1a82281d620fbe729"
+UUID_B="90c037f08a2711f1a82281d620fbe729"
+mkdir -p "$KSDIR/medium_700b-$UUID_A" \
+         "$KSDIR/medium_700b-$UUID_B" \
+         "$KSDIR/wide_4kb-$UUID_A" \
+         "$KSDIR/medium_700b-backup" \
+         "$KSDIR/medium_700b-$UUID_A/nested/medium_700b-$UUID_B" \
+         "$KSDIR/other_table-$UUID_A"
+touch "$KSDIR/medium_700b-$UUID_A-notes.txt"
+ln -s "$OUTSIDE/precious" "$KSDIR/medium_700b-${UUID_A//8/a}"
+
+out=$(TABLES=both CORPUS_ROOT="$CORPUS" bash "$GEN" --prune-dry-run 2>&1); rc=$?
+would=$(grep '^WOULD-PRUNE ' <<<"$out" | sed 's/^WOULD-PRUNE //' | sort)
+expected=$(printf '%s\n' \
+  "$KSDIR/medium_700b-$UUID_A" \
+  "$KSDIR/medium_700b-$UUID_B" \
+  "$KSDIR/wide_4kb-$UUID_A" | sort)
+
+if [ "$rc" -eq 0 ] && [ "$would" = "$expected" ]; then
+  pass "prune targets exactly the <selected-table>-<uuid> dirs"
+else
+  fail "prune candidate set wrong (rc=$rc)
+  got:
+$would
+  expected:
+$expected"
+fi
+
+# A dry run must delete nothing at all.
+for must_exist in \
+  "$KSDIR/medium_700b-$UUID_A" "$KSDIR/medium_700b-$UUID_B" "$KSDIR/wide_4kb-$UUID_A" \
+  "$KSDIR/medium_700b-backup" "$KSDIR/other_table-$UUID_A" \
+  "$KSDIR/medium_700b-$UUID_A-notes.txt" "$OUTSIDE/precious"; do
+  [ -e "$must_exist" ] || fail "--prune-dry-run deleted $must_exist"
+done
+pass "--prune-dry-run deletes nothing"
+
+# Named exclusions: the non-uuid dir, another table's dir, the symlink, the
+# nested dir, and the non-directory must never be candidates.
+for never in \
+  "$KSDIR/medium_700b-backup" \
+  "$KSDIR/other_table-$UUID_A" \
+  "$KSDIR/medium_700b-${UUID_A//8/a}" \
+  "$KSDIR/medium_700b-$UUID_A/nested/medium_700b-$UUID_B" \
+  "$KSDIR/medium_700b-$UUID_A-notes.txt" \
+  "$OUTSIDE/precious"; do
+  if grep -qF "WOULD-PRUNE $never" <<<"$out"; then
+    fail "prune would have removed '$never'"
+  else
+    pass "prune does not target '${never#"$TMP"/}'"
+  fi
+done
+
+# Only the SELECTED table is pruned.
+out_medium=$(TABLES=medium CORPUS_ROOT="$CORPUS" bash "$GEN" --prune-dry-run 2>&1)
+if grep -q "WOULD-PRUNE $KSDIR/medium_700b-$UUID_A" <<<"$out_medium" &&
+   ! grep -q "WOULD-PRUNE $KSDIR/wide_4kb-" <<<"$out_medium"; then
+  pass "TABLES=medium prunes only medium_700b dirs"
+else
+  fail "TABLES=medium pruned the wrong set (out: $out_medium)"
+fi
+
+# A missing corpus keyspace dir is a no-op, not an error.
+out=$(TABLES=both CORPUS_ROOT="$TMP/never-generated" bash "$GEN" --prune-dry-run 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && ! grep -q WOULD-PRUNE <<<"$out"; then
+  pass "no corpus yet: prune is a no-op"
+else
+  fail "prune on a non-existent corpus root: expected a clean no-op (rc=$rc, out: $out)"
+fi
+
+# --------------------------------------- schema.cql capture is wired + fatal ---
+# keyspace_ddl / per-table DDL can only be rebuilt offline from a captured
+# schema.cql, so the generator must capture one and treat a failure as fatal.
+if grep -q 'DESCRIBE KEYSPACE' "$GEN" &&
+   grep -q 'cp "\$CORPUS_ROOT/schema.cql" "\$dest/schema.cql"' "$GEN"; then
+  pass "generator captures DESCRIBE KEYSPACE and publishes schema.cql per table"
+else
+  fail "generator does not capture/publish schema.cql (manifest would not be reproducible)"
+fi
+if grep -A6 'capture_schema() {' "$GEN" | grep -q 'die '; then
+  pass "schema capture is fail-closed"
+else
+  fail "schema capture does not fail closed"
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "test_gen_perf_corpus_3068: ALL PASS"
+  exit 0
+fi
+echo "test_gen_perf_corpus_3068: $fails FAILURE(S)"
+exit 1

--- a/scripts/tests/test_perf_run_contained.sh
+++ b/scripts/tests/test_perf_run_contained.sh
@@ -31,13 +31,25 @@ else
 fi
 
 # ------------------------------------------------------- accepted mem values --
-# Every form systemd MemoryMax accepts, plus the plain byte count.
-for good in 8G 512M 1.5G 2Gi 64K 1T 50% max infinity 1073741824 512MB; do
-  if out=$(bash "$SCRIPT" --check-args --mem "$good" --swap "$good" -- true 2>&1) &&
+# Every FINITE form systemd MemoryMax accepts, plus the plain byte count. Notes
+# go to stderr, so only stdout is compared.
+for good in 8G 512M 1.5G 2Gi 64K 1T 50% 100% 1073741824 512MB; do
+  if out=$(bash "$SCRIPT" --check-args --mem "$good" --swap "$good" -- true 2>/dev/null) &&
      [[ "$out" == "ARGS-OK mem=$good swap=$good cmd=true" ]]; then
     pass "accepts --mem/--swap '$good'"
   else
     fail "rejected valid memory value '$good' (out: $out)"
+  fi
+done
+
+# `--swap 0` is the legitimate "no swap at all" cap and must stay accepted
+# (unlike `--mem 0`, which is a nonsense cap -- see the rejections below).
+for goodswap in 0 0G 0%; do
+  if out=$(bash "$SCRIPT" --check-args --swap "$goodswap" -- true 2>/dev/null) &&
+     [[ "$out" == "ARGS-OK mem=8G swap=$goodswap cmd=true" ]]; then
+    pass "accepts --swap '$goodswap' (no swap)"
+  else
+    fail "rejected valid zero swap cap '$goodswap' (out: $out)"
   fi
 done
 
@@ -65,12 +77,49 @@ reject "non-numeric --swap"       --swap banana
 reject "negative --swap"          --swap -2G
 reject "unknown flag"             --memory 8G
 
-# A bare integer IS a valid systemd byte count, so it is accepted -- but the
-# usage text must warn about the byte-count reading that makes `8` a footgun.
-if bash "$SCRIPT" --help 2>&1 | grep -q "byte count"; then
+# ------------------------------------------------- UNBOUNDED caps are refused --
+# systemd ACCEPTS MemoryMax=max/infinity and it DISABLES the limit, i.e. runs the
+# "contained" workload uncontained -- the exact state that livelocked a swapless
+# host for 75 minutes. Case-insensitively refused for BOTH caps.
+for unbounded in max infinity MAX INFINITY Max Infinity mAx iNfInItY; do
+  reject "--mem $unbounded (unbounded cap)"  --mem "$unbounded"
+  reject "--swap $unbounded (unbounded cap)" --swap "$unbounded"
+done
+
+# Zero / over-100% --mem caps are nonsense, not containment.
+reject "zero --mem"               --mem 0
+reject "zero --mem (suffixed)"    --mem 0G
+reject "zero --mem (percent)"     --mem 0%
+reject "over-100% --mem"          --mem 200%
+reject "over-100% --swap"         --swap 101%
+
+# A SUFFIXLESS number is BYTES to systemd, so a bare `8` is an 8-BYTE cap: every
+# run would look like an instant OOM and hide the real result. Refused outright
+# below 1 MiB rather than silently producing a uselessly tiny cap.
+reject "bare small integer --mem"   --mem 8
+reject "sub-1MiB byte count --mem"  --mem 1024
+reject "bare small integer --swap"  --swap 8
+
+# A large suffixless count IS a legitimate byte cap, but the resolved reading is
+# echoed so it can never be a silent misunderstanding.
+err=$(bash "$SCRIPT" --check-args --mem 1073741824 -- true 2>&1 >/dev/null)
+if grep -q "reads it as BYTES" <<<"$err"; then
+  pass "suffixless byte count reports its resolved reading"
+else
+  fail "no byte-count note for a suffixless --mem (err: $err)"
+fi
+
+# The usage text must explain the byte-count reading AND the unbounded refusal.
+help_out=$(bash "$SCRIPT" --help 2>&1)
+if grep -q "BYTE count" <<<"$help_out" || grep -q "byte count" <<<"$help_out"; then
   pass "usage documents that a bare number is a byte count"
 else
   fail "usage text does not explain the bare-number/byte-count reading"
+fi
+if grep -qi "REFUSED" <<<"$help_out" && grep -qi "infinity" <<<"$help_out"; then
+  pass "usage documents that max/infinity are refused"
+else
+  fail "usage text does not document the unbounded-cap refusal"
 fi
 
 # ------------------------------------------------------- structural failures --

--- a/scripts/tests/test_perf_run_contained.sh
+++ b/scripts/tests/test_perf_run_contained.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Self-test for test-data/scripts/perf-run-contained.sh (issue #3068).
+#
+# The wrapper exists because an UNCONTAINED cold read of the multi-GB #3068 perf
+# corpus hard-hung a swapless host for 75 minutes. That makes its ARGUMENT
+# PARSING safety-critical: a silently-misread `--mem` is the difference between
+# "the offending process dies" and "the machine dies". In particular a bare `8`
+# must NOT be accepted -- systemd would read it as 8 BYTES, so every run would
+# look like an instant OOM and hide the real result.
+#
+# Hermetic: uses the `--check-args` hook, so nothing is ever executed, no sudo,
+# no systemd, no cargo, no network, no datasets.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/test-data/scripts/perf-run-contained.sh"
+
+fails=0
+pass() { echo "ok   - $1"; }
+fail() { echo "FAIL - $1"; fails=$((fails + 1)); }
+
+# ------------------------------------------------------------------ preflight --
+[ -f "$SCRIPT" ] || { echo "FAIL - missing $SCRIPT"; exit 1; }
+
+# The wrapper is invoked directly in runbooks/measurement scripts, so the
+# committed mode must be executable (git tracks the x bit).
+if [ -x "$SCRIPT" ]; then
+  pass "perf-run-contained.sh is executable"
+else
+  fail "perf-run-contained.sh is NOT executable (chmod +x and commit mode 755)"
+fi
+
+# ------------------------------------------------------- accepted mem values --
+# Every form systemd MemoryMax accepts, plus the plain byte count.
+for good in 8G 512M 1.5G 2Gi 64K 1T 50% max infinity 1073741824 512MB; do
+  if out=$(bash "$SCRIPT" --check-args --mem "$good" --swap "$good" -- true 2>&1) &&
+     [[ "$out" == "ARGS-OK mem=$good swap=$good cmd=true" ]]; then
+    pass "accepts --mem/--swap '$good'"
+  else
+    fail "rejected valid memory value '$good' (out: $out)"
+  fi
+done
+
+# --------------------------------------------------------- rejected garbage ---
+# Each must exit 2 (usage error) and never fall through to execution.
+reject() { # reject <label> <args...>
+  local label="$1"; shift
+  local out rc
+  out=$(bash "$SCRIPT" --check-args "$@" -- true 2>&1); rc=$?
+  if [ "$rc" -eq 2 ] && [[ "$out" != ARGS-OK* ]]; then
+    pass "rejects $label (exit 2)"
+  else
+    fail "accepted $label -- expected exit 2, got rc=$rc (out: $out)"
+  fi
+}
+
+reject "non-numeric --mem"        --mem banana
+reject "trailing junk --mem"      --mem 8G8
+reject "negative --mem"           --mem -1G
+reject "empty --mem"              --mem ""
+reject "space-separated --mem"    --mem "8 G"
+reject "shell metachars in --mem" --mem '8G;reboot'
+reject "bad suffix --mem"         --mem 8Q
+reject "non-numeric --swap"       --swap banana
+reject "negative --swap"          --swap -2G
+reject "unknown flag"             --memory 8G
+
+# A bare integer IS a valid systemd byte count, so it is accepted -- but the
+# usage text must warn about the byte-count reading that makes `8` a footgun.
+if bash "$SCRIPT" --help 2>&1 | grep -q "byte count"; then
+  pass "usage documents that a bare number is a byte count"
+else
+  fail "usage text does not explain the bare-number/byte-count reading"
+fi
+
+# ------------------------------------------------------- structural failures --
+out=$(bash "$SCRIPT" --check-args --mem 2>&1); rc=$?
+if [ "$rc" -eq 2 ] && grep -q "requires a value" <<<"$out"; then
+  pass "rejects --mem with no value (no bash 'unbound variable' leak)"
+else
+  fail "--mem with no value: expected exit 2 + 'requires a value', rc=$rc ($out)"
+fi
+
+out=$(bash "$SCRIPT" --check-args --mem 4G -- 2>&1); rc=$?
+if [ "$rc" -eq 2 ] && grep -q "missing command" <<<"$out"; then
+  pass "rejects an empty command after --"
+else
+  fail "empty command after --: expected exit 2, rc=$rc ($out)"
+fi
+
+# Defaults must be the documented 8G/2G, not empty.
+if out=$(bash "$SCRIPT" --check-args -- true 2>&1) &&
+   [[ "$out" == "ARGS-OK mem=8G swap=2G cmd=true" ]]; then
+  pass "defaults are mem=8G swap=2G"
+else
+  fail "unexpected defaults (out: $out)"
+fi
+
+# Args after `--` are passed through verbatim and NOT parsed as wrapper flags.
+if out=$(bash "$SCRIPT" --check-args -- cargo run --mem 1 2>&1) &&
+   [[ "$out" == "ARGS-OK mem=8G swap=2G cmd=cargo run --mem 1" ]]; then
+  pass "post -- arguments are not reinterpreted as wrapper flags"
+else
+  fail "post -- passthrough broken (out: $out)"
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "test_perf_run_contained: ALL PASS"
+  exit 0
+fi
+echo "test_perf_run_contained: $fails FAILURE(S)"
+exit 1

--- a/test-data/perf-corpus-3068-manifest.json
+++ b/test-data/perf-corpus-3068-manifest.json
@@ -1,0 +1,132 @@
+{
+  "issue": 3068,
+  "purpose": "Field-shaped LZ4-compressed multi-GB single-SSTable Cassandra 5.0 corpus for read-plane (scan window / large I/O) measurement.",
+  "generated_utc": "2026-07-28T21:51:59.943032+00:00",
+  "generator": "test-data/scripts/gen-perf-corpus-3068.sh",
+  "method": "cassandra-stress user profile (ships in the cassandra image), UNLOGGED single-partition batches, 10 rows/partition; durable_writes=false and autocompaction disabled during load (generation-time only \u2014 neither changes SSTable bytes), then nodetool flush + nodetool compact (major) to a single SSTable.",
+  "cassandra_image": "cassandra:5.0.2",
+  "keyspace": "perf_3068",
+  "keyspace_ddl": "CREATE KEYSPACE perf_3068 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = false;",
+  "rows_per_partition": 10,
+  "corpus_root": "/home/ubuntu/corpus-3068",
+  "datasets_root_usage": "CQLITE_DATASETS_ROOT=/home/ubuntu/corpus-3068",
+  "corpus_committed": false,
+  "corpus_note": "The corpus itself is multi-GB and is NOT committed. Regenerate it with the generator above, then re-run this script to reproduce this manifest; the Data.db sha256 recorded per table is the reproducibility check.",
+  "provenance": {
+    "sizes": "os.stat of each component file",
+    "data_db_sha256": "sha256 of the Data.db bytes",
+    "compression": "CompressionInfo.db header (authoritative, not the DDL)",
+    "rows": "Cassandra sstablemetadata totalRows (Statistics.db); fail-closed, never a fabricated 0",
+    "ddl": "recorded per table with its own source field"
+  },
+  "tables": [
+    {
+      "table": "medium_700b",
+      "keyspace_table": "perf_3068.medium_700b",
+      "sstable_dir": "sstables/perf_3068/medium_700b-8cc9d0708a2711f1a82281d620fbe729",
+      "sstable_basename": "nb-34-big",
+      "format": "nb",
+      "format_detail": "nb = BIG, Cassandra 5.0 default storage_compatibility_mode=CASSANDRA_4",
+      "sstable_count": 1,
+      "single_sstable": true,
+      "data_db_count": 1,
+      "rows": 11994840,
+      "statistics": {
+        "source": "cassandra sstablemetadata (cassandra:5.0.2) reading Statistics.db",
+        "total_rows": 11994840,
+        "total_columns_set": 119948400,
+        "partition_count": 1199484,
+        "partitioner": "org.apache.cassandra.dht.Murmur3Partitioner",
+        "cassandra_compression_ratio": "0.9718243898391086",
+        "sstable_level": 0,
+        "estimated_droppable_tombstones": "0.0"
+      },
+      "components": {
+        "nb-34-big-CompressionInfo.db": 4330207,
+        "nb-34-big-Data.db": 8620456540,
+        "nb-34-big-Digest.crc32": 10,
+        "nb-34-big-Filter.db": 1517624,
+        "nb-34-big-Index.db": 33548956,
+        "nb-34-big-Statistics.db": 10766,
+        "nb-34-big-Summary.db": 299944,
+        "nb-34-big-TOC.txt": 92
+      },
+      "missing_components": [],
+      "non_component_files": {
+        "schema.cql": 2379
+      },
+      "data_db_bytes": 8620456540,
+      "data_db_gib": 8.028,
+      "data_db_sha256": "a6242273c2717e5ec439d4957a3db654dc35dc8044d6c54711ab670e8af3fb0d",
+      "compression": {
+        "source": "read from CompressionInfo.db header (authoritative)",
+        "compressor": "LZ4Compressor",
+        "options": {},
+        "chunk_length_bytes": 16384,
+        "chunk_length_kb": 16.0,
+        "chunk_count": 541271,
+        "uncompressed_data_length_bytes": 8868157196,
+        "compression_ratio_on_disk_over_logical": 0.972069
+      },
+      "ddl": {
+        "source": "schema.cql captured at generation time (alongside the SSTable components)",
+        "text": "CREATE TABLE perf_3068.medium_700b (\n    pk text,\n    ck int,\n    name text,\n    note text,\n    payload blob,\n    status text,\n    tags text,\n    ts timestamp,\n    v_bool boolean,\n    v_dbl double,\n    v_int int,\n    v_long bigint,\n    PRIMARY KEY (pk, ck)\n) WITH CLUSTERING ORDER BY (ck ASC)\n    AND additional_write_policy = '99p'\n    AND allow_auto_snapshot = true\n    AND bloom_filter_fp_chance = 0.01\n    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}\n    AND cdc = false\n    AND comment = ''\n    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}\n    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n    AND memtable = 'default'\n    AND crc_check_chance = 1.0\n    AND default_time_to_live = 0\n    AND extensions = {}\n    AND gc_grace_seconds = 864000\n    AND incremental_backups = true\n    AND max_index_interval = 2048\n    AND memtable_flush_period_in_ms = 0\n    AND min_index_interval = 128\n    AND read_repair = 'BLOCKING'\n    AND speculative_retry = '99p';",
+        "extracted_statement": true
+      }
+    },
+    {
+      "table": "wide_4kb",
+      "keyspace_table": "perf_3068.wide_4kb",
+      "sstable_dir": "sstables/perf_3068/wide_4kb-90c037f08a2711f1a82281d620fbe729",
+      "sstable_basename": "nb-11-big",
+      "format": "nb",
+      "format_detail": "nb = BIG, Cassandra 5.0 default storage_compatibility_mode=CASSANDRA_4",
+      "sstable_count": 1,
+      "single_sstable": true,
+      "data_db_count": 1,
+      "rows": 1199890,
+      "statistics": {
+        "source": "cassandra sstablemetadata (cassandra:5.0.2) reading Statistics.db",
+        "total_rows": 1199890,
+        "total_columns_set": 11998900,
+        "partition_count": 119989,
+        "partitioner": "org.apache.cassandra.dht.Murmur3Partitioner",
+        "cassandra_compression_ratio": "1.00059889463006",
+        "sstable_level": 0,
+        "estimated_droppable_tombstones": "0.0"
+      },
+      "components": {
+        "nb-11-big-CompressionInfo.db": 2453415,
+        "nb-11-big-Data.db": 5028730707,
+        "nb-11-big-Digest.crc32": 10,
+        "nb-11-big-Filter.db": 148624,
+        "nb-11-big-Index.db": 3353228,
+        "nb-11-big-Statistics.db": 10766,
+        "nb-11-big-Summary.db": 30088,
+        "nb-11-big-TOC.txt": 92
+      },
+      "missing_components": [],
+      "non_component_files": {
+        "schema.cql": 2379
+      },
+      "data_db_bytes": 5028730707,
+      "data_db_gib": 4.683,
+      "data_db_sha256": "9dad6e61d7845c9b8711a3a2959fed3ad25cca05d2423f83f861362f6095c98a",
+      "compression": {
+        "source": "read from CompressionInfo.db header (authoritative)",
+        "compressor": "LZ4Compressor",
+        "options": {},
+        "chunk_length_bytes": 16384,
+        "chunk_length_kb": 16.0,
+        "chunk_count": 306672,
+        "uncompressed_data_length_bytes": 5024494876,
+        "compression_ratio_on_disk_over_logical": 1.000843
+      },
+      "ddl": {
+        "source": "schema.cql captured at generation time (alongside the SSTable components)",
+        "text": "CREATE TABLE perf_3068.wide_4kb (\n    pk text,\n    ck int,\n    body text,\n    name text,\n    note text,\n    payload blob,\n    status text,\n    ts timestamp,\n    v_bool boolean,\n    v_dbl double,\n    v_int int,\n    v_long bigint,\n    PRIMARY KEY (pk, ck)\n) WITH CLUSTERING ORDER BY (ck ASC)\n    AND additional_write_policy = '99p'\n    AND allow_auto_snapshot = true\n    AND bloom_filter_fp_chance = 0.01\n    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}\n    AND cdc = false\n    AND comment = ''\n    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}\n    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n    AND memtable = 'default'\n    AND crc_check_chance = 1.0\n    AND default_time_to_live = 0\n    AND extensions = {}\n    AND gc_grace_seconds = 864000\n    AND incremental_backups = true\n    AND max_index_interval = 2048\n    AND memtable_flush_period_in_ms = 0\n    AND min_index_interval = 128\n    AND read_repair = 'BLOCKING'\n    AND speculative_retry = '99p';",
+        "extracted_statement": true
+      }
+    }
+  ]
+}

--- a/test-data/scripts/gen-perf-corpus-3068.sh
+++ b/test-data/scripts/gen-perf-corpus-3068.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# gen-perf-corpus-3068.sh — Generate a FIELD-SHAPED, LZ4-COMPRESSED, multi-GB
+# single-SSTable Cassandra 5.0 (nb/BIG) corpus for issue #3068 read-plane
+# performance measurement (scan window / large-I/O).
+#
+# WHY a bespoke corpus: the committed test-data fixtures are tiny and the
+# Phase-0 perf anchor was UNCOMPRESSED, so it never executed the compressed
+# read path at all. #3068 needs a corpus that
+#   (1) is LZ4-compressed at the Cassandra table default chunk_length_in_kb=16
+#       (the compressed scan window is a no-op without real chunks),
+#   (2) has a Data.db far larger than a CPU cache and comparable to RAM, so a
+#       "cold" scan is genuinely cold and "warm" is a real page-cache state,
+#   (3) is ONE SSTable, so a k-way merge cannot pollute the read-plane number.
+#
+# NOT committed: the corpus itself (multi-GB). It is written OUTSIDE the repo,
+# default /home/ubuntu/corpus-3068. Only this script + the emitted manifest are
+# committed.
+#
+# Method: cassandra-stress (ships in the cassandra:5.0.2 image) driving a user
+# profile, NOT a cqlsh INSERT loop — an INSERT-per-row .cql file (the shape used
+# by gen-wide-big.sh) is hopeless at 12M rows. Two generation-time-only
+# optimizations keep the load disk-bound rather than backpressure-bound; NEITHER
+# changes the bytes written into the SSTable:
+#   * keyspace durable_writes = false  -> no commitlog write amplification
+#   * nodetool disableautocompaction   -> no STCS rewrites mid-load; a single
+#                                          `nodetool compact` at the end does
+#                                          the one merge we actually want.
+#
+# Output layout (mirrors the repo's CQLITE_DATASETS_ROOT convention, so
+# CQLITE_DATASETS_ROOT=$CORPUS_ROOT works directly):
+#   $CORPUS_ROOT/sstables/perf_3068/medium_700b-<uuid>/nb-*-*.db
+#   $CORPUS_ROOT/sstables/perf_3068/wide_4kb-<uuid>/nb-*-*.db
+#   $CORPUS_ROOT/manifest-3068.json
+#
+# Usage:
+#   bash test-data/scripts/gen-perf-corpus-3068.sh                # both tables
+#   MEDIUM_PARTITIONS=1200000 WIDE_PARTITIONS=120000 \
+#     CORPUS_ROOT=/home/ubuntu/corpus-3068 bash .../gen-perf-corpus-3068.sh
+#   TABLES=medium bash test-data/scripts/gen-perf-corpus-3068.sh   # medium only
+set -euo pipefail
+
+IMAGE="${IMAGE:-cassandra:5.0.2}"
+CONTAINER="${CONTAINER:-cqlite-perf3068}"
+CORPUS_ROOT="${CORPUS_ROOT:-/home/ubuntu/corpus-3068}"
+KS="perf_3068"
+# Which tables to build: "both" | "medium" | "wide".
+TABLES="${TABLES:-both}"
+# 10 rows per partition (clustering fixed(10)), so rows = partitions * 10.
+# 1.2M partitions * 10 rows * ~718 B/row on disk => ~8.6 GB Data.db.
+MEDIUM_PARTITIONS="${MEDIUM_PARTITIONS:-1200000}"
+# 120k partitions * 10 rows * ~4.2 KB/row on disk => ~5 GB Data.db.
+WIDE_PARTITIONS="${WIDE_PARTITIONS:-120000}"
+STRESS_THREADS="${STRESS_THREADS:-16}"
+# docker needs sudo on the agent fleet machines; override with DOCKER=docker.
+DOCKER="${DOCKER:-sudo -n docker}"
+MAX_HEAP="${MAX_HEAP:-8G}"
+HEAP_NEW="${HEAP_NEW:-2G}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STRESS="/opt/cassandra/tools/bin/cassandra-stress"
+
+log() { echo "[gen-perf-3068] $*"; }
+die() { echo "[gen-perf-3068] FATAL: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------- preflight --
+# `nodetool compact` needs transient room for a full second copy of the table.
+preflight_space() {
+  local need_gib=$1
+  local avail_gib
+  avail_gib=$(df -BG --output=avail "$(dirname "$CORPUS_ROOT")" | tail -1 | tr -dc '0-9')
+  log "free space: ${avail_gib} GiB (need >= ${need_gib} GiB for data + 2x compact headroom)"
+  [[ "$avail_gib" -ge "$need_gib" ]] || die "insufficient free space"
+}
+
+wait_ready() {
+  local max="${1:-90}"
+  log "waiting for Cassandra..."
+  for i in $(seq 1 "$max"); do
+    if $DOCKER exec "$CONTAINER" cqlsh -e "SELECT release_version FROM system.local;" >/dev/null 2>&1; then
+      log "Cassandra ready after $((i * 5))s"
+      return 0
+    fi
+    sleep 5
+  done
+  die "Cassandra not ready after $((max * 5))s"
+}
+
+# ------------------------------------------------------------------ profiles --
+write_profiles() {
+  mkdir -p "$CORPUS_ROOT"
+  cat > "$CORPUS_ROOT/medium.yaml" <<'YAML'
+### cassandra-stress user profile — ~700 B/row "medium" field shape (issue #3068)
+keyspace: perf_3068
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS perf_3068 WITH replication = {'class':'SimpleStrategy','replication_factor':1} AND durable_writes = false;
+
+table: medium_700b
+table_definition: |
+  CREATE TABLE IF NOT EXISTS medium_700b (
+    pk text,
+    ck int,
+    ts timestamp,
+    status text,
+    name text,
+    tags text,
+    note text,
+    payload blob,
+    v_int int,
+    v_long bigint,
+    v_dbl double,
+    v_bool boolean,
+    PRIMARY KEY (pk, ck)
+  ) WITH CLUSTERING ORDER BY (ck ASC)
+    AND compression = {'class':'LZ4Compressor','chunk_length_in_kb':16}
+    AND compaction = {'class':'SizeTieredCompactionStrategy'};
+
+columnspec:
+  - name: pk
+    size: fixed(20)
+    population: uniform(1..1000000000)
+  - name: ck
+    cluster: fixed(10)
+  - name: status
+    size: fixed(8)
+  - name: name
+    size: fixed(24)
+  - name: tags
+    size: fixed(48)
+  - name: note
+    size: fixed(160)
+  - name: payload
+    size: fixed(400)
+
+insert:
+  partitions: fixed(1)
+  batchtype: UNLOGGED
+  select: fixed(1)/1
+
+queries:
+  readpart:
+    cql: select * from medium_700b where pk = ?
+    fields: samerow
+YAML
+
+  cat > "$CORPUS_ROOT/wide.yaml" <<'YAML'
+### cassandra-stress user profile — >= 4 KB/row "wide" field shape (#3068 / #3030)
+keyspace: perf_3068
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS perf_3068 WITH replication = {'class':'SimpleStrategy','replication_factor':1} AND durable_writes = false;
+
+table: wide_4kb
+table_definition: |
+  CREATE TABLE IF NOT EXISTS wide_4kb (
+    pk text,
+    ck int,
+    ts timestamp,
+    status text,
+    name text,
+    note text,
+    body text,
+    payload blob,
+    v_int int,
+    v_long bigint,
+    v_dbl double,
+    v_bool boolean,
+    PRIMARY KEY (pk, ck)
+  ) WITH CLUSTERING ORDER BY (ck ASC)
+    AND compression = {'class':'LZ4Compressor','chunk_length_in_kb':16}
+    AND compaction = {'class':'SizeTieredCompactionStrategy'};
+
+columnspec:
+  - name: pk
+    size: fixed(20)
+    population: uniform(1..1000000000)
+  - name: ck
+    cluster: fixed(10)
+  - name: status
+    size: fixed(8)
+  - name: name
+    size: fixed(24)
+  - name: note
+    size: fixed(256)
+  - name: body
+    size: fixed(1400)
+  - name: payload
+    size: fixed(2400)
+
+insert:
+  partitions: fixed(1)
+  batchtype: UNLOGGED
+  select: fixed(1)/1
+
+queries:
+  readpart:
+    cql: select * from wide_4kb where pk = ?
+    fields: samerow
+YAML
+  log "wrote stress profiles to $CORPUS_ROOT/{medium,wide}.yaml"
+}
+
+# -------------------------------------------------------------------- driver --
+start_container() {
+  log "removing any stale container + data dir..."
+  $DOCKER rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  sudo -n rm -rf "$CORPUS_ROOT/cassandra-data"
+  mkdir -p "$CORPUS_ROOT/cassandra-data"
+  # The image runs as uid 999 (cassandra); the bind mount must be writable by it.
+  sudo -n chown -R 999:999 "$CORPUS_ROOT/cassandra-data"
+  log "starting $IMAGE (heap $MAX_HEAP, data bind-mounted at $CORPUS_ROOT/cassandra-data)..."
+  $DOCKER run -d --name "$CONTAINER" --cpus 14 --memory 22g \
+    -e MAX_HEAP_SIZE="$MAX_HEAP" -e HEAP_NEWSIZE="$HEAP_NEW" \
+    -e CASSANDRA_NUM_TOKENS=1 \
+    -v "$CORPUS_ROOT/cassandra-data:/var/lib/cassandra" \
+    "$IMAGE" >/dev/null
+  wait_ready 90
+}
+
+stress_run() {  # $1 = profile basename (medium|wide), $2 = partitions
+  local prof="$1" n="$2"
+  $DOCKER cp "$CORPUS_ROOT/$prof.yaml" "$CONTAINER:/tmp/$prof.yaml"
+  log "[$prof] creating schema (1-op run)..."
+  $DOCKER exec "$CONTAINER" bash -lc \
+    "$STRESS user profile=/tmp/$prof.yaml ops\\(insert=1\\) n=1 no-warmup cl=ONE -pop seq=1..1 -rate threads=1 -node 127.0.0.1" \
+    >/dev/null 2>&1 || true
+  # Disable autocompaction only AFTER the table exists.
+  $DOCKER exec "$CONTAINER" nodetool disableautocompaction "$KS" >/dev/null 2>&1 || true
+  log "[$prof] loading $n partitions x 10 rows = $((n * 10)) rows (threads=$STRESS_THREADS)..."
+  local t0 t1
+  t0=$(date +%s)
+  $DOCKER exec "$CONTAINER" bash -lc \
+    "$STRESS user profile=/tmp/$prof.yaml ops\\(insert=1\\) n=$n no-warmup cl=ONE -pop seq=1..$n -rate threads=$STRESS_THREADS -node 127.0.0.1" \
+    > "$CORPUS_ROOT/stress-$prof.log" 2>&1 \
+    || die "[$prof] cassandra-stress failed; see $CORPUS_ROOT/stress-$prof.log"
+  t1=$(date +%s)
+  log "[$prof] load wall time: $((t1 - t0))s"
+  grep -E "^Total (partitions|errors)" "$CORPUS_ROOT/stress-$prof.log" || true
+}
+
+finalize_table() {  # $1 = table name
+  local tbl="$1"
+  log "[$tbl] enabling autocompaction, flush + MAJOR compact (this is the slow part)..."
+  $DOCKER exec "$CONTAINER" nodetool enableautocompaction "$KS" "$tbl"
+  $DOCKER exec "$CONTAINER" nodetool flush "$KS" "$tbl"
+  $DOCKER exec "$CONTAINER" nodetool compact "$KS" "$tbl"
+  # A major compaction can leave the old inputs briefly; wait for quiescence.
+  for _ in $(seq 1 60); do
+    local pending
+    pending=$($DOCKER exec "$CONTAINER" nodetool compactionstats 2>/dev/null \
+      | awk '/pending tasks:/ {print $3; exit}')
+    [[ "${pending:-0}" == "0" ]] && break
+    sleep 5
+  done
+
+  local dir count
+  dir=$($DOCKER exec "$CONTAINER" bash -lc "ls -d /var/lib/cassandra/data/$KS/$tbl-* | head -1" | tr -d '\r')
+  count=$($DOCKER exec "$CONTAINER" bash -lc "ls '$dir'/*-Data.db 2>/dev/null | wc -l" | tr -d '\r ')
+  log "[$tbl] Data.db count after major compaction: $count"
+  [[ "$count" == "1" ]] || die "[$tbl] expected exactly 1 Data.db, found $count (k-way merge would pollute the measurement)"
+  echo "$dir"
+}
+
+publish_table() {  # $1 = table, $2 = container sstable dir
+  local tbl="$1" cdir="$2"
+  local host_dir="$CORPUS_ROOT/cassandra-data/data/$KS/$(basename "$cdir")"
+  local dest="$CORPUS_ROOT/sstables/$KS/$(basename "$cdir")"
+  [[ -d "$host_dir" ]] || die "[$tbl] host bind-mount dir missing: $host_dir"
+  mkdir -p "$(dirname "$dest")"
+  sudo -n rm -rf "$dest"
+  mkdir -p "$dest"
+  # Hardlink (same filesystem) — instant, and the corpus survives deletion of
+  # the Cassandra data dir. Fall back to a copy across filesystems.
+  sudo -n cp -l "$host_dir"/nb-*-*.db "$host_dir"/nb-*-TOC.txt "$host_dir"/nb-*-Digest.crc32 "$dest/" 2>/dev/null \
+    || sudo -n cp "$host_dir"/nb-* "$dest/"
+  sudo -n chown -R "$(id -u):$(id -g)" "$dest"
+  echo "$dest"
+}
+
+# ---------------------------------------------------------------------- main --
+preflight_space 40
+write_profiles
+start_container
+
+DIRS=()
+if [[ "$TABLES" == "both" || "$TABLES" == "medium" ]]; then
+  stress_run medium "$MEDIUM_PARTITIONS"
+fi
+if [[ "$TABLES" == "both" || "$TABLES" == "wide" ]]; then
+  stress_run wide "$WIDE_PARTITIONS"
+fi
+if [[ "$TABLES" == "both" || "$TABLES" == "medium" ]]; then
+  DIRS+=("medium_700b:$(finalize_table medium_700b | tail -1)")
+fi
+if [[ "$TABLES" == "both" || "$TABLES" == "wide" ]]; then
+  DIRS+=("wide_4kb:$(finalize_table wide_4kb | tail -1)")
+fi
+
+PUBLISHED=()
+for entry in "${DIRS[@]}"; do
+  tbl="${entry%%:*}"; cdir="${entry#*:}"
+  PUBLISHED+=("$tbl:$(publish_table "$tbl" "$cdir" | tail -1)")
+  log "[$tbl] published"
+done
+
+log "writing manifest..."
+python3 "$SCRIPT_DIR/write-perf-corpus-manifest.py" \
+  --corpus-root "$CORPUS_ROOT" \
+  --keyspace "$KS" \
+  --image "$IMAGE" \
+  ${PUBLISHED[@]+"${PUBLISHED[@]/#/--table=}"}
+
+log "DONE. Corpus at $CORPUS_ROOT/sstables/$KS/"
+log "Use with: CQLITE_DATASETS_ROOT=$CORPUS_ROOT"
+log "Container '$CONTAINER' left running for sstabledump/sstablemetadata; remove with: $DOCKER rm -f $CONTAINER"

--- a/test-data/scripts/gen-perf-corpus-3068.sh
+++ b/test-data/scripts/gen-perf-corpus-3068.sh
@@ -30,7 +30,10 @@
 # CQLITE_DATASETS_ROOT=$CORPUS_ROOT works directly):
 #   $CORPUS_ROOT/sstables/perf_3068/medium_700b-<uuid>/nb-*-*.db
 #   $CORPUS_ROOT/sstables/perf_3068/wide_4kb-<uuid>/nb-*-*.db
-#   $CORPUS_ROOT/manifest-3068.json
+#   $CORPUS_ROOT/manifest-3068.json    (copied to test-data/perf-corpus-3068-manifest.json)
+#
+# See docs/development/perf-corpus-and-containment.md — including why every
+# measurement against this corpus must go through perf-run-contained.sh.
 #
 # Usage:
 #   bash test-data/scripts/gen-perf-corpus-3068.sh                # both tables
@@ -301,12 +304,23 @@ for entry in "${DIRS[@]}"; do
   log "[$tbl] published"
 done
 
+# Two manifests, same content: one next to the (uncommitted) corpus, and one at
+# the COMMITTED path so a regenerated corpus can be diffed against the recorded
+# sha256/row counts. MANIFEST_OUT= disables the in-repo write.
 log "writing manifest..."
+MANIFEST_OUT="${MANIFEST_OUT-$SCRIPT_DIR/../perf-corpus-3068-manifest.json}"
 python3 "$SCRIPT_DIR/write-perf-corpus-manifest.py" \
   --corpus-root "$CORPUS_ROOT" \
   --keyspace "$KS" \
   --image "$IMAGE" \
+  --container "$CONTAINER" \
   ${PUBLISHED[@]+"${PUBLISHED[@]/#/--table=}"}
+# Copied, not re-generated: a second run would re-hash multiple GB for a
+# byte-identical result (the manifest records corpus-root-RELATIVE paths).
+if [[ -n "$MANIFEST_OUT" ]]; then
+  cp "$CORPUS_ROOT/manifest-3068.json" "$MANIFEST_OUT"
+  log "committed-path manifest: $MANIFEST_OUT"
+fi
 
 log "DONE. Corpus at $CORPUS_ROOT/sstables/$KS/"
 log "Use with: CQLITE_DATASETS_ROOT=$CORPUS_ROOT"

--- a/test-data/scripts/gen-perf-corpus-3068.sh
+++ b/test-data/scripts/gen-perf-corpus-3068.sh
@@ -28,9 +28,13 @@
 #
 # Output layout (mirrors the repo's CQLITE_DATASETS_ROOT convention, so
 # CQLITE_DATASETS_ROOT=$CORPUS_ROOT works directly):
-#   $CORPUS_ROOT/sstables/perf_3068/medium_700b-<uuid>/nb-*-*.db
-#   $CORPUS_ROOT/sstables/perf_3068/wide_4kb-<uuid>/nb-*-*.db
+#   $CORPUS_ROOT/sstables/perf_3068/medium_700b-<uuid>/nb-*-*.db + schema.cql
+#   $CORPUS_ROOT/sstables/perf_3068/wide_4kb-<uuid>/nb-*-*.db   + schema.cql
 #   $CORPUS_ROOT/manifest-3068.json    (copied to test-data/perf-corpus-3068-manifest.json)
+#
+# schema.cql is `cqlsh DESCRIBE KEYSPACE` captured at generation time and copied
+# next to each published SSTable, so the manifest's keyspace/table DDL can be
+# regenerated OFFLINE from the corpus alone (no live container needed).
 #
 # See docs/development/perf-corpus-and-containment.md — including why every
 # measurement against this corpus must go through perf-run-contained.sh.
@@ -40,14 +44,20 @@
 #   MEDIUM_PARTITIONS=1200000 WIDE_PARTITIONS=120000 \
 #     CORPUS_ROOT=/home/ubuntu/corpus-3068 bash .../gen-perf-corpus-3068.sh
 #   TABLES=medium bash test-data/scripts/gen-perf-corpus-3068.sh   # medium only
+#   bash .../gen-perf-corpus-3068.sh --validate-only   # validate inputs, run nothing
+#   bash .../gen-perf-corpus-3068.sh --prune-dry-run   # + list the stale corpus
+#                                                     #   dirs a run WOULD remove
 set -euo pipefail
 
 IMAGE="${IMAGE:-cassandra:5.0.2}"
 CONTAINER="${CONTAINER:-cqlite-perf3068}"
-CORPUS_ROOT="${CORPUS_ROOT:-/home/ubuntu/corpus-3068}"
+# `${VAR-default}`, not `${VAR:-default}`: an EXPLICITLY EMPTY CORPUS_ROOT/TABLES
+# (typically a caller's unset variable) must fail validation, never silently
+# become the default — this script deletes multi-GB paths under CORPUS_ROOT.
+CORPUS_ROOT="${CORPUS_ROOT-/home/ubuntu/corpus-3068}"
 KS="perf_3068"
 # Which tables to build: "both" | "medium" | "wide".
-TABLES="${TABLES:-both}"
+TABLES="${TABLES-both}"
 # 10 rows per partition (clustering fixed(10)), so rows = partitions * 10.
 # 1.2M partitions * 10 rows * ~718 B/row on disk => ~8.6 GB Data.db.
 MEDIUM_PARTITIONS="${MEDIUM_PARTITIONS:-1200000}"
@@ -58,12 +68,104 @@ STRESS_THREADS="${STRESS_THREADS:-16}"
 DOCKER="${DOCKER:-sudo -n docker}"
 MAX_HEAP="${MAX_HEAP:-8G}"
 HEAP_NEW="${HEAP_NEW:-2G}"
+# Remove a previously-published <table>-<uuid> dir before publishing the new one.
+# PRUNE_STALE=0 keeps them (accepting several multi-GB copies the manifest does
+# not describe).
+PRUNE_STALE="${PRUNE_STALE:-1}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STRESS="/opt/cassandra/tools/bin/cassandra-stress"
 
 log() { echo "[gen-perf-3068] $*"; }
 die() { echo "[gen-perf-3068] FATAL: $*" >&2; exit 1; }
+
+VALIDATE_ONLY=0
+PRUNE_DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    # Self-test hooks (scripts/tests/test_gen_perf_corpus_3068.sh): validate the
+    # inputs / enumerate prune candidates and EXIT — no container, no writes, no
+    # deletions.
+    --validate-only) VALIDATE_ONLY=1; shift ;;
+    --prune-dry-run) VALIDATE_ONLY=1; PRUNE_DRY_RUN=1; shift ;;
+    -h|--help)
+      echo "usage: $0 [--validate-only|--prune-dry-run]  (config via env: TABLES, CORPUS_ROOT, ...)" >&2
+      exit 0 ;;
+    *) die "unknown argument: $1 (config is via environment variables)" ;;
+  esac
+done
+
+# ---------------------------------------------------------- input validation --
+# BEFORE any destructive or expensive work: an unvalidated TABLES typo used to
+# start a container, generate nothing, and then overwrite the COMMITTED manifest
+# with an empty tables array — silent corruption of a provenance artifact.
+declare -a SELECTED_TABLES=()
+validate_inputs() {
+  case "$TABLES" in
+    both)   SELECTED_TABLES=(medium_700b wide_4kb) ;;
+    medium) SELECTED_TABLES=(medium_700b) ;;
+    wide)   SELECTED_TABLES=(wide_4kb) ;;
+    *) die "invalid TABLES='$TABLES' (expected one of: both | medium | wide)" ;;
+  esac
+  [[ -n "${CORPUS_ROOT// }" ]] || die "CORPUS_ROOT is empty"
+  [[ "$CORPUS_ROOT" == /* ]] || die "CORPUS_ROOT must be an absolute path, got '$CORPUS_ROOT'"
+  [[ "$(printf '%s' "$CORPUS_ROOT" | sed 's:/*$::')" != "" ]] \
+    || die "refusing to use '/' as CORPUS_ROOT"
+  [[ -n "${KS// }" ]] || die "keyspace is empty"
+  log "validated: TABLES=$TABLES -> ${SELECTED_TABLES[*]}; CORPUS_ROOT=$CORPUS_ROOT"
+}
+
+# Resolved (symlink-free) corpus keyspace dir; "" when it does not exist yet.
+corpus_keyspace_dir() {
+  local root
+  root="$(cd "$CORPUS_ROOT" 2>/dev/null && pwd -P)" || return 0
+  [[ -n "$root" && "$root" != "/" ]] || die "CORPUS_ROOT resolved to '/' — refusing"
+  printf '%s/sstables/%s' "$root" "$KS"
+}
+
+# Remove PREVIOUS <table>-<uuid> dirs so repeated regenerations cannot leave
+# several multi-GB copies of a table while the manifest describes only the last.
+#
+# Deliberately narrow — this deletes multi-GB paths:
+#   * only DIRECT children of $CORPUS_ROOT/sstables/$KS,
+#   * only names matching exactly "<selected-table>-<32 hex>" (Cassandra's own
+#     "<table>-<UUID-without-dashes>" layout); anything else is left alone,
+#   * never a symlink, and never a path whose resolved form is outside that
+#     keyspace dir (die, not delete),
+#   * never the directory just published ($2), and
+#   * never with an empty/relative/"/" corpus root (validate_inputs + here).
+prune_stale_table_dirs() {  # $1 = table, $2 = basename to KEEP ("" keeps none)
+  local tbl="$1" keep="${2:-}" ks_dir d base real
+  [[ -n "${tbl// }" ]] || die "prune: empty table name"
+  ks_dir="$(corpus_keyspace_dir)"
+  [[ -n "$ks_dir" && -d "$ks_dir" ]] || return 0
+  local had_nullglob=0
+  shopt -q nullglob && had_nullglob=1
+  shopt -s nullglob
+  for d in "$ks_dir/$tbl"-*; do
+    base="$(basename "$d")"
+    [[ -d "$d" ]] || continue
+    if [[ -L "$d" ]]; then
+      log "[prune] skipping symlink (never followed): $d"
+      continue
+    fi
+    if [[ ! "$base" =~ ^${tbl}-[0-9a-f]{32}$ ]]; then
+      log "[prune] skipping '$base' (not a <table>-<uuid> corpus dir)"
+      continue
+    fi
+    [[ -n "$keep" && "$base" == "$keep" ]] && continue
+    real="$(cd "$d" && pwd -P)" || die "prune: cannot resolve $d"
+    [[ "$real" == "$ks_dir/$base" ]] \
+      || die "prune: '$d' resolves OUTSIDE the corpus keyspace dir ($real) — refusing to delete"
+    if [[ "$PRUNE_DRY_RUN" == 1 ]]; then
+      echo "WOULD-PRUNE $real"
+      continue
+    fi
+    log "[prune] removing stale corpus dir $real"
+    sudo -n rm -rf -- "$real"
+  done
+  [[ "$had_nullglob" == 1 ]] || shopt -u nullglob
+}
 
 # ---------------------------------------------------------------- preflight --
 # `nodetool compact` needs transient room for a full second copy of the table.
@@ -262,12 +364,34 @@ finalize_table() {  # $1 = table name
   echo "$dir"
 }
 
+# Capture the live keyspace + table DDL so the manifest's keyspace_ddl / per-table
+# ddl can be rebuilt from the corpus alone. FAIL-CLOSED: without it a fresh run
+# would emit `keyspace_ddl: null` and the committed manifest would not be
+# reproducible by the committed generator.
+capture_schema() {  # $1 = destination file
+  local out="$1" tmp
+  tmp="$(mktemp)"
+  $DOCKER exec "$CONTAINER" cqlsh -e "DESCRIBE KEYSPACE $KS;" > "$tmp" 2>/dev/null \
+    || die "could not DESCRIBE KEYSPACE $KS (schema.cql is required for a reproducible manifest)"
+  grep -q "^CREATE KEYSPACE $KS " "$tmp" \
+    || die "DESCRIBE KEYSPACE $KS produced no CREATE KEYSPACE statement"
+  grep -q "^CREATE TABLE $KS\." "$tmp" \
+    || die "DESCRIBE KEYSPACE $KS produced no CREATE TABLE statement"
+  mv "$tmp" "$out"
+  log "captured schema -> $out ($(wc -c <"$out" | tr -d ' ') bytes)"
+}
+
 publish_table() {  # $1 = table, $2 = container sstable dir
   local tbl="$1" cdir="$2"
   local host_dir="$CORPUS_ROOT/cassandra-data/data/$KS/$(basename "$cdir")"
   local dest="$CORPUS_ROOT/sstables/$KS/$(basename "$cdir")"
   [[ -d "$host_dir" ]] || die "[$tbl] host bind-mount dir missing: $host_dir"
   mkdir -p "$(dirname "$dest")"
+  # Drop any earlier generation of THIS table first (see prune_stale_table_dirs
+  # for the guards) so the corpus never holds several multi-GB copies.
+  if [[ "$PRUNE_STALE" == 1 ]]; then
+    prune_stale_table_dirs "$tbl" "$(basename "$cdir")"
+  fi
   sudo -n rm -rf "$dest"
   mkdir -p "$dest"
   # Hardlink (same filesystem) — instant, and the corpus survives deletion of
@@ -279,6 +403,19 @@ publish_table() {  # $1 = table, $2 = container sstable dir
 }
 
 # ---------------------------------------------------------------------- main --
+# Input validation runs FIRST — before the container, the load, and any deletion.
+validate_inputs
+
+if [[ "$VALIDATE_ONLY" == 1 ]]; then
+  if [[ "$PRUNE_DRY_RUN" == 1 ]]; then
+    for tbl in "${SELECTED_TABLES[@]}"; do
+      prune_stale_table_dirs "$tbl" ""
+    done
+  fi
+  echo "VALIDATE-OK tables=${SELECTED_TABLES[*]} corpus_root=$CORPUS_ROOT keyspace=$KS"
+  exit 0
+fi
+
 preflight_space 40
 write_profiles
 start_container
@@ -297,12 +434,19 @@ if [[ "$TABLES" == "both" || "$TABLES" == "wide" ]]; then
   DIRS+=("wide_4kb:$(finalize_table wide_4kb | tail -1)")
 fi
 
+# Captured once from the live container, copied into every published dir.
+capture_schema "$CORPUS_ROOT/schema.cql"
+
 PUBLISHED=()
 for entry in "${DIRS[@]}"; do
   tbl="${entry%%:*}"; cdir="${entry#*:}"
-  PUBLISHED+=("$tbl:$(publish_table "$tbl" "$cdir" | tail -1)")
-  log "[$tbl] published"
+  dest="$(publish_table "$tbl" "$cdir" | tail -1)"
+  cp "$CORPUS_ROOT/schema.cql" "$dest/schema.cql"
+  PUBLISHED+=("$tbl:$dest")
+  log "[$tbl] published (with schema.cql)"
 done
+
+[[ ${#PUBLISHED[@]} -gt 0 ]] || die "no tables were published — refusing to write a manifest"
 
 # Two manifests, same content: one next to the (uncommitted) corpus, and one at
 # the COMMITTED path so a regenerated corpus can be diffed against the recorded

--- a/test-data/scripts/perf-run-contained.sh
+++ b/test-data/scripts/perf-run-contained.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run a perf/measurement command inside a memory-capped transient cgroup scope.
+#
+# Why (issue #3068, 2026-07-28): an UNCONTAINED cold scan of an 8.1 GB mmap'd
+# Data.db on a swapless box hard-hung the host for 75 minutes. The kernel never
+# OOM-killed anything -- with %commit at 105% and no swap it livelocked in
+# reclaim with every task in D state. A memory cap makes the *offending process*
+# die instead of the machine.
+#
+# Usage: perf-run-contained.sh [--mem 8G] [--swap 2G] -- <cmd> [args...]
+set -euo pipefail
+
+MEM="8G"; SWAP="2G"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mem)  MEM="$2"; shift 2 ;;
+    --swap) SWAP="$2"; shift 2 ;;
+    --)     shift; break ;;
+    *)      echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ $# -gt 0 ] || { echo "usage: $0 [--mem 8G] [--swap 2G] -- <cmd>" >&2; exit 2; }
+
+# Refuse to run when the system is already over-committed -- that is the exact
+# precondition that wedged the box.
+commit_pct="$(awk '/CommitLimit:/{cl=$2} /Committed_AS:/{ca=$2} END{ if (cl>0) printf "%d", ca*100/cl; else print 0 }' /proc/meminfo)"
+if [ "${commit_pct}" -ge 95 ]; then
+  echo "REFUSING: Committed_AS is ${commit_pct}% of CommitLimit (>=95%). Free memory first." >&2
+  exit 3
+fi
+
+echo "[contained] MemoryMax=${MEM} MemorySwapMax=${SWAP} commit=${commit_pct}% :: $*" >&2
+exec sudo -n systemd-run --scope --collect --quiet \
+  --uid="$(id -u)" --gid="$(id -g)" \
+  -p MemoryMax="${MEM}" -p MemorySwapMax="${SWAP}" -p OOMPolicy=kill \
+  --working-directory="$PWD" \
+  -- "$@"

--- a/test-data/scripts/perf-run-contained.sh
+++ b/test-data/scripts/perf-run-contained.sh
@@ -20,16 +20,94 @@ CHECK_ARGS=0
 usage() {
   echo "usage: $0 [--mem 8G] [--swap 2G] -- <cmd> [args...]" >&2
   echo "  --mem/--swap take a systemd memory value: a byte count with an" >&2
-  echo "  optional K/M/G/T[i] suffix, a percentage, 'max' or 'infinity'." >&2
+  echo "  optional K/M/G/T[i] suffix, or a percentage (>0%, <=100%)." >&2
+  echo "  The cap must be FINITE: 'max' and 'infinity' (any case) are REFUSED --" >&2
+  echo "  a 'contained' run with no cap is not contained. --mem may not be zero;" >&2
+  echo "  --swap 0 IS allowed and means 'no swap'." >&2
+  echo "  A SUFFIXLESS number is a BYTE count to systemd ('8' = 8 bytes), so a" >&2
+  echo "  suffixless value below 1 MiB is refused and a larger one prints the" >&2
+  echo "  byte reading it resolved to." >&2
   echo "  --check-args validates and prints the resolved caps, running nothing." >&2
 }
 
-# systemd MemoryMax/MemorySwapMax syntax. A malformed value must be rejected
-# HERE: systemd-run would otherwise reject it *after* sudo, or (worse) a typo
-# like "8" could be read as 8 bytes and make every run look like an OOM.
-valid_mem_value() {
-  [[ "$1" =~ ^[0-9]+(\.[0-9]+)?([KMGTkmgt]i?)?B?$ || "$1" =~ ^[0-9]+(\.[0-9]+)?%$ \
-     || "$1" == "max" || "$1" == "infinity" ]]
+# Smallest suffixless byte count accepted: below this a "cap" is useless and is
+# almost certainly a missing suffix (the `--mem 8` footgun).
+MIN_SUFFIXLESS_BYTES=1048576
+
+# Classify a systemd MemoryMax/MemorySwapMax value. Sets VAL_KIND
+# (bytes|percent|unbounded), VAL_NUM (numeric part), and for bytes VAL_UNIT
+# (k|m|g|t or empty) + VAL_BYTES (resolved byte count). Returns 1 on a syntax
+# error. Case-insensitive, like systemd.
+classify_mem_value() {
+  local low
+  VAL_KIND=""; VAL_NUM=""; VAL_UNIT=""; VAL_BYTES=""
+  low="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$low" in
+    max|infinity) VAL_KIND=unbounded; return 0 ;;
+  esac
+  if [[ "$low" =~ ^([0-9]+(\.[0-9]+)?)%$ ]]; then
+    VAL_KIND=percent; VAL_NUM="${BASH_REMATCH[1]}"; return 0
+  fi
+  if [[ "$low" =~ ^([0-9]+(\.[0-9]+)?)(([kmgt])i?)?b?$ ]]; then
+    VAL_KIND=bytes; VAL_NUM="${BASH_REMATCH[1]}"; VAL_UNIT="${BASH_REMATCH[4]}"
+    VAL_BYTES=$(awk -v n="${BASH_REMATCH[1]}" -v u="${BASH_REMATCH[4]}" 'BEGIN{
+      m = 1
+      if (u == "k") m = 1024
+      else if (u == "m") m = 1024 * 1024
+      else if (u == "g") m = 1024 * 1024 * 1024
+      else if (u == "t") m = 1024 * 1024 * 1024 * 1024
+      printf "%.0f", n * m }')
+    return 0
+  fi
+  return 1
+}
+
+# A malformed OR UNBOUNDED value must be rejected HERE: systemd-run would
+# otherwise reject a typo *after* sudo, and it would happily ACCEPT
+# MemoryMax=max -- i.e. run the "contained" workload with no cap at all, which
+# is the exact state that livelocked a swapless host for 75 minutes (#3068).
+validate_cap() {  # $1 = --mem|--swap, $2 = value
+  local flag="$1" val="$2"
+  classify_mem_value "$val" || { echo "invalid $flag value: '$val'" >&2; usage; exit 2; }
+  case "$VAL_KIND" in
+    unbounded)
+      echo "invalid $flag value: '$val' -- an unbounded cap is refused." >&2
+      echo "  'max'/'infinity' DISABLE the limit, so the run would not be contained:" >&2
+      echo "  an uncontained multi-GB read livelocked a swapless host for 75 min (#3068)." >&2
+      echo "  Pass a finite, nonzero cap instead, e.g. $flag 8G." >&2
+      exit 2 ;;
+    percent)
+      # >0% for --mem (a 0% cap is nonsense); >=0% for --swap; never over 100%
+      # of physical RAM, which is effectively no cap at all.
+      local strict=0 lower_bound="at least 0%"
+      if [ "$flag" = "--mem" ]; then strict=1; lower_bound="greater than 0%"; fi
+      awk -v p="$VAL_NUM" -v strict="$strict" 'BEGIN{
+        exit !((strict ? p > 0 : p >= 0) && p <= 100) }' || {
+        echo "invalid $flag value: '$val' -- a percentage cap must be" >&2
+        echo "  $lower_bound and at most 100% of physical RAM." >&2
+        exit 2
+      } ;;
+    bytes)
+      if [ "$VAL_BYTES" = "0" ]; then
+        # `--swap 0` is the legitimate "no swap at all" cap; `--mem 0` is not.
+        [ "$flag" = "--swap" ] && return 0
+        echo "invalid --mem value: '$val' -- a zero memory cap is refused" >&2
+        echo "  (it would kill the workload immediately, not contain it)." >&2
+        exit 2
+      fi
+      if [ -z "$VAL_UNIT" ] && [ "$VAL_BYTES" -lt "$MIN_SUFFIXLESS_BYTES" ]; then
+        echo "invalid $flag value: '$val' -- systemd reads a SUFFIXLESS number as" >&2
+        echo "  BYTES, so this is a ${VAL_BYTES}-byte cap (< 1 MiB): every run would" >&2
+        echo "  look like an instant OOM and hide the real result. Add a suffix" >&2
+        echo "  (e.g. $flag ${val}G) or pass an explicit byte count >= 1 MiB." >&2
+        exit 2
+      fi
+      if [ -z "$VAL_UNIT" ]; then
+        awk -v f="$flag" -v v="$val" -v b="$VAL_BYTES" 'BEGIN{
+          printf "note: %s %s has no suffix; systemd reads it as BYTES = %s B (%.2f GiB).\n",
+                 f, v, b, b / (1024 * 1024 * 1024) }' >&2
+      fi ;;
+  esac
 }
 
 MEM="8G"; SWAP="2G"
@@ -37,9 +115,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --mem|--swap)
       [ $# -ge 2 ] || { echo "$1 requires a value" >&2; usage; exit 2; }
-      valid_mem_value "$2" || {
-        echo "invalid $1 value: '$2'" >&2; usage; exit 2
-      }
+      validate_cap "$1" "$2"
       if [ "$1" = "--mem" ]; then MEM="$2"; else SWAP="$2"; fi
       shift 2 ;;
     # Argument-validation self-test hook (scripts/tests/test_perf_run_contained.sh):

--- a/test-data/scripts/perf-run-contained.sh
+++ b/test-data/scripts/perf-run-contained.sh
@@ -1,25 +1,61 @@
 #!/usr/bin/env bash
 # Run a perf/measurement command inside a memory-capped transient cgroup scope.
 #
-# Why (issue #3068, 2026-07-28): an UNCONTAINED cold scan of an 8.1 GB mmap'd
-# Data.db on a swapless box hard-hung the host for 75 minutes. The kernel never
-# OOM-killed anything -- with %commit at 105% and no swap it livelocked in
-# reclaim with every task in D state. A memory cap makes the *offending process*
-# die instead of the machine.
+# Why (issue #3068, 2026-07-28): an UNCONTAINED cold scan of an 8.0 GiB
+# (8,620,456,540 B) mmap'd Data.db on a swapless box hard-hung the host for 75
+# minutes. The kernel never OOM-killed anything -- with %commit at 105% and no
+# swap it livelocked in direct reclaim, load 62.7, every task (sshd included) in
+# D state. A memory cap makes the *offending process* die instead of the machine.
+#
+# WHEN to use it: any measurement that reads a multi-GB corpus (cold scan, warm
+# scan, sstable-to-parquet export, a Flight scan against the #3068 perf corpus).
+# See docs/development/perf-corpus-and-containment.md.
 #
 # Usage: perf-run-contained.sh [--mem 8G] [--swap 2G] -- <cmd> [args...]
+#        perf-run-contained.sh --check-args ...   # validate only, run nothing
 set -euo pipefail
+
+CHECK_ARGS=0
+
+usage() {
+  echo "usage: $0 [--mem 8G] [--swap 2G] -- <cmd> [args...]" >&2
+  echo "  --mem/--swap take a systemd memory value: a byte count with an" >&2
+  echo "  optional K/M/G/T[i] suffix, a percentage, 'max' or 'infinity'." >&2
+  echo "  --check-args validates and prints the resolved caps, running nothing." >&2
+}
+
+# systemd MemoryMax/MemorySwapMax syntax. A malformed value must be rejected
+# HERE: systemd-run would otherwise reject it *after* sudo, or (worse) a typo
+# like "8" could be read as 8 bytes and make every run look like an OOM.
+valid_mem_value() {
+  [[ "$1" =~ ^[0-9]+(\.[0-9]+)?([KMGTkmgt]i?)?B?$ || "$1" =~ ^[0-9]+(\.[0-9]+)?%$ \
+     || "$1" == "max" || "$1" == "infinity" ]]
+}
 
 MEM="8G"; SWAP="2G"
 while [ $# -gt 0 ]; do
   case "$1" in
-    --mem)  MEM="$2"; shift 2 ;;
-    --swap) SWAP="$2"; shift 2 ;;
+    --mem|--swap)
+      [ $# -ge 2 ] || { echo "$1 requires a value" >&2; usage; exit 2; }
+      valid_mem_value "$2" || {
+        echo "invalid $1 value: '$2'" >&2; usage; exit 2
+      }
+      if [ "$1" = "--mem" ]; then MEM="$2"; else SWAP="$2"; fi
+      shift 2 ;;
+    # Argument-validation self-test hook (scripts/tests/test_perf_run_contained.sh):
+    # parse + validate, print the resolved caps, execute NOTHING.
+    --check-args) CHECK_ARGS=1; shift ;;
+    -h|--help) usage; exit 0 ;;
     --)     shift; break ;;
-    *)      echo "unknown arg: $1" >&2; exit 2 ;;
+    *)      echo "unknown arg: $1" >&2; usage; exit 2 ;;
   esac
 done
-[ $# -gt 0 ] || { echo "usage: $0 [--mem 8G] [--swap 2G] -- <cmd>" >&2; exit 2; }
+[ $# -gt 0 ] || { echo "missing command after --" >&2; usage; exit 2; }
+
+if [ "$CHECK_ARGS" = 1 ]; then
+  echo "ARGS-OK mem=${MEM} swap=${SWAP} cmd=$*"
+  exit 0
+fi
 
 # Refuse to run when the system is already over-committed -- that is the exact
 # precondition that wedged the box.

--- a/test-data/scripts/read-compression-info.py
+++ b/test-data/scripts/read-compression-info.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Read the AUTHORITATIVE compression parameters out of a Cassandra
+``*-CompressionInfo.db`` component (issue #3068 corpus verification).
+
+The chunk length used by a written SSTable is recorded in CompressionInfo.db,
+NOT inferred from the table DDL (a schema change after the write, or a
+Cassandra-side clamp, would make the DDL a lie). Per
+``org.apache.cassandra.io.compress.CompressionMetadata.Writer.writeHeader()``
+(and docs/sstables-definitive-guide/chapters/09-compressioninfo-and-chunking.md,
+"CompressionInfo.db Format (serialization exactness)") the layout is:
+
+    UTF   compressor class name                   (2-byte length + modified-UTF8)
+    int   option count
+      UTF key / UTF value  (option count times)
+    int   chunk length (uncompressed bytes per chunk)
+    int   max compressed length                   (>= "na" only; Integer.MAX_VALUE
+                                                   when min_compress_ratio = 0)
+    long  data length (total uncompressed bytes)
+    int   chunk count
+    long  chunk offset  (chunk count times)
+
+All values are Java big-endian, all fixed-width (the chunk map is a flat u64
+array, NOT varint pairs). The parse is self-verifying: the chunk-offset array
+must exactly fill the remainder of the file, which pins every preceding field.
+
+Usage:  read-compression-info.py <path-to-CompressionInfo.db> [--json]
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import sys
+
+
+class Reader:
+    def __init__(self, buf: bytes) -> None:
+        self.buf = buf
+        self.pos = 0
+
+    def take(self, n: int) -> bytes:
+        if self.pos + n > len(self.buf):
+            raise ValueError(
+                f"truncated CompressionInfo.db: want {n} bytes at {self.pos}, "
+                f"file is {len(self.buf)} bytes"
+            )
+        out = self.buf[self.pos : self.pos + n]
+        self.pos += n
+        return out
+
+    def u16(self) -> int:
+        return struct.unpack(">H", self.take(2))[0]
+
+    def i32(self) -> int:
+        return struct.unpack(">i", self.take(4))[0]
+
+    def i64(self) -> int:
+        return struct.unpack(">q", self.take(8))[0]
+
+    def utf(self) -> str:
+        return self.take(self.u16()).decode("utf-8")
+
+
+def parse(path: str) -> dict:
+    with open(path, "rb") as fh:
+        r = Reader(fh.read())
+
+    compressor = r.utf()
+    options = {}
+    for _ in range(r.i32()):
+        key = r.utf()
+        options[key] = r.utf()
+    chunk_length = r.i32()
+    # Present for every format in scope (>= "na"); Integer.MAX_VALUE means
+    # min_compress_ratio = 0, i.e. chunks are stored compressed unconditionally.
+    max_compressed_length = r.i32()
+    data_length = r.i64()
+    chunk_count = r.i32()
+
+    # Offsets are 8 bytes each and must exactly fill the remainder.
+    offsets_bytes = len(r.buf) - r.pos
+    expected = chunk_count * 8
+    if offsets_bytes != expected:
+        raise ValueError(
+            f"chunk offset array size mismatch: header says {chunk_count} chunks "
+            f"({expected} bytes) but {offsets_bytes} bytes remain"
+        )
+    first_offset = struct.unpack(">q", r.take(8))[0] if chunk_count else None
+
+    return {
+        "path": path,
+        "compressor": compressor,
+        "options": options,
+        "chunk_length_bytes": chunk_length,
+        "chunk_length_kb": chunk_length / 1024.0,
+        "max_compressed_length": max_compressed_length,
+        "uncompressed_data_length_bytes": data_length,
+        "chunk_count": chunk_count,
+        "first_chunk_offset": first_offset,
+    }
+
+
+def main(argv: list[str]) -> int:
+    args = [a for a in argv[1:] if not a.startswith("--")]
+    if len(args) != 1:
+        print(__doc__, file=sys.stderr)
+        return 2
+    info = parse(args[0])
+    if "--json" in argv[1:]:
+        print(json.dumps(info, indent=2, sort_keys=True))
+    else:
+        print(f"compressor             : {info['compressor']}")
+        print(f"options                : {info['options']}")
+        print(
+            f"chunk_length           : {info['chunk_length_bytes']} bytes "
+            f"({info['chunk_length_kb']:g} KiB)"
+        )
+        print(f"uncompressed data len  : {info['uncompressed_data_length_bytes']} bytes")
+        print(f"chunk count            : {info['chunk_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/test-data/scripts/read-compression-info.py
+++ b/test-data/scripts/read-compression-info.py
@@ -9,7 +9,10 @@ Cassandra-side clamp, would make the DDL a lie). Per
 (and docs/sstables-definitive-guide/chapters/09-compressioninfo-and-chunking.md,
 "CompressionInfo.db Format (serialization exactness)") the layout is:
 
-    UTF   compressor class name                   (2-byte length + modified-UTF8)
+    UTF   compressor SIMPLE class name            (2-byte length + modified-UTF8;
+                                                   e.g. "LZ4Compressor", NOT the
+                                                   fully-qualified org.apache... name
+                                                   that Statistics.db records)
     int   option count
       UTF key / UTF value  (option count times)
     int   chunk length (uncompressed bytes per chunk)

--- a/test-data/scripts/write-perf-corpus-manifest.py
+++ b/test-data/scripts/write-perf-corpus-manifest.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Emit the issue-#3068 perf-corpus manifest.
+
+Everything recorded here is READ BACK FROM THE WRITTEN BYTES, never assumed:
+the chunk length and compressor come out of the ``CompressionInfo.db``
+component (see ``read-compression-info.py``), the sizes out of ``stat``, the
+sha256 out of the file itself. A DDL string in a manifest is documentation; the
+CompressionInfo header is the fact.
+
+Usage:
+    write-perf-corpus-manifest.py --corpus-root DIR --keyspace KS --image IMG \
+        --table=<name>:<published-sstable-dir> [--table=...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import glob
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+# "read-compression-info.py" is not an importable module name (hyphens), so the
+# CompressionInfo parser is loaded by path — one parser, one source of truth.
+_spec = importlib.util.spec_from_file_location(
+    "read_compression_info",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "read-compression-info.py"),
+)
+_rci = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_rci)
+
+# The 8 components Cassandra 5.0 writes for a compressed BIG ("nb") SSTable.
+EXPECTED_COMPONENTS = [
+    "CompressionInfo.db",
+    "Data.db",
+    "Digest.crc32",
+    "Filter.db",
+    "Index.db",
+    "Statistics.db",
+    "Summary.db",
+    "TOC.txt",
+]
+
+
+def sha256_of(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(8 * 1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def one_component(sstable_dir: str, suffix: str) -> str:
+    hits = glob.glob(os.path.join(sstable_dir, f"nb-*-{suffix}"))
+    if len(hits) != 1:
+        raise SystemExit(
+            f"expected exactly 1 '{suffix}' in {sstable_dir}, found {len(hits)}: {hits}"
+        )
+    return hits[0]
+
+
+def describe_table(keyspace: str, table: str, image_container: str | None) -> str | None:
+    """Best-effort live DDL read; the manifest records it verbatim when available."""
+    if not image_container:
+        return None
+    try:
+        out = subprocess.run(
+            ["sudo", "-n", "docker", "exec", image_container, "cqlsh", "-e",
+             f"DESCRIBE TABLE {keyspace}.{table};"],
+            capture_output=True, text=True, timeout=120,
+        )
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def build_table_record(keyspace: str, table: str, sstable_dir: str,
+                       container: str | None) -> dict:
+    components = {}
+    for entry in sorted(os.listdir(sstable_dir)):
+        components[entry] = os.path.getsize(os.path.join(sstable_dir, entry))
+
+    suffixes = sorted(
+        {e.split("-", 3)[-1] for e in components if e.startswith("nb-")}
+    )
+    missing = [c for c in EXPECTED_COMPONENTS if c not in suffixes]
+
+    data_db = one_component(sstable_dir, "Data.db")
+    comp_info = one_component(sstable_dir, "CompressionInfo.db")
+    ci = _rci.parse(comp_info)
+
+    data_size = os.path.getsize(data_db)
+    uncompressed = ci["uncompressed_data_length_bytes"]
+
+    return {
+        "table": table,
+        "sstable_dir": sstable_dir,
+        "sstable_basename": os.path.basename(data_db).rsplit("-Data.db", 1)[0],
+        "format": "nb (BIG, Cassandra 5.0 default storage_compatibility_mode=CASSANDRA_4)",
+        "data_db_count": len(glob.glob(os.path.join(sstable_dir, "*-Data.db"))),
+        "components": components,
+        "missing_components": missing,
+        "data_db_bytes": data_size,
+        "data_db_gib": round(data_size / 1024**3, 3),
+        "data_db_sha256": sha256_of(data_db),
+        "compression": {
+            "source": "read from CompressionInfo.db header (authoritative)",
+            "compressor": ci["compressor"],
+            "options": ci["options"],
+            "chunk_length_bytes": ci["chunk_length_bytes"],
+            "chunk_length_kb": ci["chunk_length_kb"],
+            "chunk_count": ci["chunk_count"],
+            "uncompressed_data_length_bytes": uncompressed,
+            "compression_ratio_on_disk_over_logical": (
+                round(data_size / uncompressed, 6) if uncompressed else None
+            ),
+        },
+        "ddl": describe_table(keyspace, table, container),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus-root", required=True)
+    ap.add_argument("--keyspace", required=True)
+    ap.add_argument("--image", required=True)
+    ap.add_argument("--container", default="cqlite-perf3068")
+    ap.add_argument("--rows-per-partition", type=int, default=10)
+    ap.add_argument("--table", action="append", default=[],
+                    help="<table-name>:<published sstable dir>")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    tables = []
+    for spec in args.table:
+        name, _, path = spec.partition(":")
+        tables.append(build_table_record(args.keyspace, name, path, args.container))
+
+    manifest = {
+        "issue": 3068,
+        "purpose": (
+            "Field-shaped LZ4-compressed multi-GB single-SSTable Cassandra 5.0 corpus "
+            "for read-plane (scan window / large I/O) measurement."
+        ),
+        "generated_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "generator": "test-data/scripts/gen-perf-corpus-3068.sh",
+        "method": (
+            "cassandra-stress user profile (ships in the cassandra image), UNLOGGED "
+            "single-partition batches, 10 rows/partition; durable_writes=false and "
+            "autocompaction disabled during load (generation-time only — neither "
+            "changes SSTable bytes), then nodetool flush + nodetool compact (major) "
+            "to a single SSTable."
+        ),
+        "cassandra_image": args.image,
+        "keyspace": args.keyspace,
+        "rows_per_partition": args.rows_per_partition,
+        "corpus_root": args.corpus_root,
+        "datasets_root_usage": f"CQLITE_DATASETS_ROOT={args.corpus_root}",
+        "tables": tables,
+    }
+
+    out = args.out or os.path.join(args.corpus_root, "manifest-3068.json")
+    with open(out, "w") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=False)
+        fh.write("\n")
+    print(f"[manifest] wrote {out}")
+    for t in tables:
+        c = t["compression"]
+        print(
+            f"[manifest] {t['table']}: Data.db {t['data_db_bytes']} B "
+            f"({t['data_db_gib']} GiB), {c['compressor']} "
+            f"chunk_length={c['chunk_length_bytes']} B, "
+            f"ratio={c['compression_ratio_on_disk_over_logical']}, "
+            f"sstables={t['data_db_count']}, missing_components={t['missing_components']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test-data/scripts/write-perf-corpus-manifest.py
+++ b/test-data/scripts/write-perf-corpus-manifest.py
@@ -280,10 +280,28 @@ def main() -> int:
     ap.add_argument("--out", default=None)
     args = ap.parse_args()
 
+    # Fail closed on an empty table list: an empty `tables` array is a manifest
+    # that describes nothing, and writing one over the COMMITTED manifest would
+    # silently destroy a provenance artifact (e.g. after a TABLES typo generated
+    # no tables at all).
+    if not args.table:
+        raise SystemExit(
+            "no --table given: refusing to write a manifest with an empty "
+            "'tables' array (it would overwrite a real manifest with nothing). "
+            "Pass at least one --table=<name>:<published sstable dir>."
+        )
+
     docker = args.docker.split()
     tables, sstable_dirs = [], []
     for spec in args.table:
-        name, _, path = spec.partition(":")
+        name, sep, path = spec.partition(":")
+        if not sep or not name.strip() or not path.strip():
+            raise SystemExit(
+                f"malformed --table {spec!r}: expected "
+                "'<table-name>:<published sstable dir>'"
+            )
+        if not os.path.isdir(path):
+            raise SystemExit(f"--table {name}: not a directory: {path}")
         sstable_dirs.append(path)
         tables.append(build_table_record(
             args.keyspace, name, path, args.container, args.image, docker,

--- a/test-data/scripts/write-perf-corpus-manifest.py
+++ b/test-data/scripts/write-perf-corpus-manifest.py
@@ -2,14 +2,21 @@
 """Emit the issue-#3068 perf-corpus manifest.
 
 Everything recorded here is READ BACK FROM THE WRITTEN BYTES, never assumed:
-the chunk length and compressor come out of the ``CompressionInfo.db``
-component (see ``read-compression-info.py``), the sizes out of ``stat``, the
-sha256 out of the file itself. A DDL string in a manifest is documentation; the
-CompressionInfo header is the fact.
+
+* sizes come from ``stat``, the sha256 from hashing the file itself;
+* the compressor / chunk length / chunk count come out of the
+  ``CompressionInfo.db`` header (see ``read-compression-info.py``) -- NOT out of
+  the table DDL, which a later ALTER or a Cassandra-side clamp could make a lie;
+* the row count comes from Cassandra's OWN ``sstablemetadata`` reading
+  ``Statistics.db`` (``totalRows``), run in a throwaway memory-capped container.
+
+The row count is FAIL-CLOSED: if ``totalRows`` cannot be read back, the script
+errors out rather than recording an unobserved number (a counter not observed is
+an error, never a fabricated 0).
 
 Usage:
     write-perf-corpus-manifest.py --corpus-root DIR --keyspace KS --image IMG \
-        --table=<name>:<published-sstable-dir> [--table=...]
+        --table=<name>:<published-sstable-dir> [--table=...] [--out FILE]
 """
 
 from __future__ import annotations
@@ -21,6 +28,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -64,30 +72,143 @@ def one_component(sstable_dir: str, suffix: str) -> str:
     return hits[0]
 
 
-def describe_table(keyspace: str, table: str, image_container: str | None) -> str | None:
-    """Best-effort live DDL read; the manifest records it verbatim when available."""
-    if not image_container:
-        return None
-    try:
-        out = subprocess.run(
-            ["sudo", "-n", "docker", "exec", image_container, "cqlsh", "-e",
-             f"DESCRIBE TABLE {keyspace}.{table};"],
-            capture_output=True, text=True, timeout=120,
+SSTABLEMETADATA = "/opt/cassandra/tools/bin/sstablemetadata"
+
+
+def sstable_metadata(data_db: str, image: str, docker: list[str], mem: str) -> dict:
+    """Read ``Statistics.db`` back with Cassandra's own offline ``sstablemetadata``.
+
+    Runs in a throwaway container with the SSTable directory bind-mounted
+    read-only, memory-capped, and with a small heap: the tool only reads the tiny
+    Statistics component, so it must never be allowed to grow into the host's
+    memory (see ``perf-run-contained.sh`` for why that matters on this corpus).
+    """
+    sstable_dir = os.path.dirname(os.path.abspath(data_db))
+    cmd = [
+        *docker, "run", "--rm",
+        "--memory", mem, "--memory-swap", mem,
+        "-e", "MAX_HEAP_SIZE=1G", "-e", "HEAP_NEWSIZE=256M",
+        "-v", f"{sstable_dir}:/data:ro",
+        "--entrypoint", SSTABLEMETADATA, image,
+        f"/data/{os.path.basename(data_db)}",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    text = proc.stdout
+    rows = re.search(r"^totalRows:\s*(\d+)\s*$", text, re.M)
+    if not rows:
+        raise SystemExit(
+            f"could not read totalRows from sstablemetadata for {data_db}\n"
+            f"  exit={proc.returncode}\n  stderr={proc.stderr.strip()[:2000]}"
         )
-        return out.stdout.strip() or None
-    except Exception:
-        return None
+
+    def _int(pattern: str) -> int | None:
+        m = re.search(pattern, text, re.M)
+        return int(m.group(1)) if m else None
+
+    def _str(pattern: str) -> str | None:
+        m = re.search(pattern, text, re.M)
+        return m.group(1).strip() if m else None
+
+    # Partition count = the sum of the "Partition Size:" histogram bucket counts.
+    # Rendered as "   <size> (<human>) | <count> (<pct>) OOO..." under that header.
+    partitions = None
+    in_hist = False
+    for line in text.splitlines():
+        if line.startswith("Partition Size:"):
+            in_hist = True
+            continue
+        if in_hist:
+            if line.strip().startswith("Percentiles") or not line.startswith("   "):
+                break
+            bucket = re.match(r"\s*\d+.*?\|\s*(\d+)\s", line)
+            if bucket:
+                partitions = (partitions or 0) + int(bucket.group(1))
+    return {
+        "source": f"cassandra sstablemetadata ({image}) reading Statistics.db",
+        "total_rows": int(rows.group(1)),
+        "total_columns_set": _int(r"^totalColumnsSet:\s*(\d+)\s*$"),
+        "partition_count": partitions,
+        "partitioner": _str(r"^Partitioner:\s*(\S+)\s*$"),
+        "cassandra_compression_ratio": _str(r"^Compression ratio:\s*(\S+)\s*$"),
+        "sstable_level": _int(r"^SSTable Level:\s*(\d+)\s*$"),
+        "estimated_droppable_tombstones": _str(
+            r"^Estimated droppable tombstones:\s*(\S+)\s*$"
+        ),
+    }
+
+
+def table_ddl(keyspace: str, table: str, sstable_dir: str,
+              container: str | None, ddl_file: str | None) -> dict:
+    """DDL for the manifest: prefer a live DESCRIBE, else the captured schema.cql.
+
+    The DDL is documentation -- the CompressionInfo header remains the fact --
+    so the source is recorded alongside it rather than silently interchanged.
+    """
+    if container:
+        try:
+            out = subprocess.run(
+                ["sudo", "-n", "docker", "exec", container, "cqlsh", "-e",
+                 f"DESCRIBE TABLE {keyspace}.{table};"],
+                capture_output=True, text=True, timeout=120,
+            )
+            if out.returncode == 0 and out.stdout.strip():
+                return {"source": f"live cqlsh DESCRIBE in container {container}",
+                        "text": out.stdout.strip()}
+        except Exception:
+            pass
+
+    path = ddl_file or os.path.join(sstable_dir, "schema.cql")
+    if os.path.exists(path):
+        with open(path) as fh:
+            captured = fh.read()
+        # Pull just this table's CREATE TABLE statement out of the captured file.
+        # It ends at the first line-final ';' (the statement runs "CREATE TABLE
+        # ks.t (...) WITH ... AND ...;", so the ')' is NOT the terminator).
+        stmt = re.search(
+            rf"^CREATE TABLE {re.escape(keyspace)}\.{re.escape(table)} \(.*?;[ \t]*$",
+            captured, re.M | re.S,
+        )
+        return {
+            "source": (
+                f"{os.path.basename(path)} captured at generation time "
+                "(alongside the SSTable components)"
+            ),
+            "text": (stmt.group(0) if stmt else captured).strip(),
+            "extracted_statement": stmt is not None,
+        }
+    return {"source": "unavailable", "text": None, "extracted_statement": False}
+
+
+def keyspace_ddl(keyspace: str, sstable_dirs: list[str]) -> str | None:
+    """The CREATE KEYSPACE statement from the first captured schema.cql we find."""
+    for sstable_dir in sstable_dirs:
+        path = os.path.join(sstable_dir, "schema.cql")
+        if not os.path.exists(path):
+            continue
+        with open(path) as fh:
+            stmt = re.search(
+                rf"^CREATE KEYSPACE {re.escape(keyspace)} .*?;[ \t]*$",
+                fh.read(), re.M | re.S,
+            )
+        if stmt:
+            return stmt.group(0).strip()
+    return None
 
 
 def build_table_record(keyspace: str, table: str, sstable_dir: str,
-                       container: str | None) -> dict:
-    components = {}
+                       container: str | None, image: str, docker: list[str],
+                       mem: str, ddl_file: str | None,
+                       corpus_root: str) -> dict:
+    # SSTable components only ("<version>-<gen>-<size>-<Component>"). Anything
+    # else in the directory (a captured schema.cql, a stray tool artifact) is
+    # listed separately so it can never masquerade as part of the SSTable.
+    components, other_files = {}, {}
     for entry in sorted(os.listdir(sstable_dir)):
-        components[entry] = os.path.getsize(os.path.join(sstable_dir, entry))
+        size = os.path.getsize(os.path.join(sstable_dir, entry))
+        target = components if re.match(r"^[a-z]{2}-\d+-big-", entry) else other_files
+        target[entry] = size
 
-    suffixes = sorted(
-        {e.split("-", 3)[-1] for e in components if e.startswith("nb-")}
-    )
+    suffixes = sorted({e.split("-", 3)[-1] for e in components})
     missing = [c for c in EXPECTED_COMPONENTS if c not in suffixes]
 
     data_db = one_component(sstable_dir, "Data.db")
@@ -96,15 +217,29 @@ def build_table_record(keyspace: str, table: str, sstable_dir: str,
 
     data_size = os.path.getsize(data_db)
     uncompressed = ci["uncompressed_data_length_bytes"]
+    stats = sstable_metadata(data_db, image, docker, mem)
+    sstable_count = len(glob.glob(os.path.join(sstable_dir, "*-Data.db")))
 
     return {
         "table": table,
-        "sstable_dir": sstable_dir,
+        "keyspace_table": f"{keyspace}.{table}",
+        # Recorded relative to corpus_root: the manifest is committed and must not
+        # pin one machine's absolute layout.
+        "sstable_dir": os.path.relpath(os.path.abspath(sstable_dir),
+                                       os.path.abspath(corpus_root)),
         "sstable_basename": os.path.basename(data_db).rsplit("-Data.db", 1)[0],
-        "format": "nb (BIG, Cassandra 5.0 default storage_compatibility_mode=CASSANDRA_4)",
-        "data_db_count": len(glob.glob(os.path.join(sstable_dir, "*-Data.db"))),
+        "format": "nb",
+        "format_detail": (
+            "nb = BIG, Cassandra 5.0 default storage_compatibility_mode=CASSANDRA_4"
+        ),
+        "sstable_count": sstable_count,
+        "single_sstable": sstable_count == 1,
+        "data_db_count": sstable_count,
+        "rows": stats["total_rows"],
+        "statistics": stats,
         "components": components,
         "missing_components": missing,
+        "non_component_files": other_files,
         "data_db_bytes": data_size,
         "data_db_gib": round(data_size / 1024**3, 3),
         "data_db_sha256": sha256_of(data_db),
@@ -120,7 +255,7 @@ def build_table_record(keyspace: str, table: str, sstable_dir: str,
                 round(data_size / uncompressed, 6) if uncompressed else None
             ),
         },
-        "ddl": describe_table(keyspace, table, container),
+        "ddl": table_ddl(keyspace, table, sstable_dir, container, ddl_file),
     }
 
 
@@ -129,17 +264,31 @@ def main() -> int:
     ap.add_argument("--corpus-root", required=True)
     ap.add_argument("--keyspace", required=True)
     ap.add_argument("--image", required=True)
-    ap.add_argument("--container", default="cqlite-perf3068")
+    ap.add_argument("--container", default=None,
+                    help="live container for a DESCRIBE TABLE read (optional; "
+                         "schema.cql is used when absent or unreachable)")
+    ap.add_argument("--docker", default="sudo -n docker",
+                    help="docker invocation (default: 'sudo -n docker')")
+    ap.add_argument("--metadata-mem", default="3g",
+                    help="memory cap for the throwaway sstablemetadata container")
     ap.add_argument("--rows-per-partition", type=int, default=10)
     ap.add_argument("--table", action="append", default=[],
                     help="<table-name>:<published sstable dir>")
+    ap.add_argument("--ddl-file", default=None,
+                    help="schema.cql to source DDL from (default: "
+                         "<sstable-dir>/schema.cql)")
     ap.add_argument("--out", default=None)
     args = ap.parse_args()
 
-    tables = []
+    docker = args.docker.split()
+    tables, sstable_dirs = [], []
     for spec in args.table:
         name, _, path = spec.partition(":")
-        tables.append(build_table_record(args.keyspace, name, path, args.container))
+        sstable_dirs.append(path)
+        tables.append(build_table_record(
+            args.keyspace, name, path, args.container, args.image, docker,
+            args.metadata_mem, args.ddl_file, args.corpus_root,
+        ))
 
     manifest = {
         "issue": 3068,
@@ -158,9 +307,26 @@ def main() -> int:
         ),
         "cassandra_image": args.image,
         "keyspace": args.keyspace,
+        "keyspace_ddl": keyspace_ddl(args.keyspace, sstable_dirs),
         "rows_per_partition": args.rows_per_partition,
         "corpus_root": args.corpus_root,
         "datasets_root_usage": f"CQLITE_DATASETS_ROOT={args.corpus_root}",
+        "corpus_committed": False,
+        "corpus_note": (
+            "The corpus itself is multi-GB and is NOT committed. Regenerate it with "
+            "the generator above, then re-run this script to reproduce this manifest; "
+            "the Data.db sha256 recorded per table is the reproducibility check."
+        ),
+        "provenance": {
+            "sizes": "os.stat of each component file",
+            "data_db_sha256": "sha256 of the Data.db bytes",
+            "compression": "CompressionInfo.db header (authoritative, not the DDL)",
+            "rows": (
+                "Cassandra sstablemetadata totalRows (Statistics.db); fail-closed, "
+                "never a fabricated 0"
+            ),
+            "ddl": "recorded per table with its own source field",
+        },
         "tables": tables,
     }
 
@@ -172,11 +338,12 @@ def main() -> int:
     for t in tables:
         c = t["compression"]
         print(
-            f"[manifest] {t['table']}: Data.db {t['data_db_bytes']} B "
-            f"({t['data_db_gib']} GiB), {c['compressor']} "
-            f"chunk_length={c['chunk_length_bytes']} B, "
+            f"[manifest] {t['table']}: rows={t['rows']}, "
+            f"Data.db {t['data_db_bytes']} B ({t['data_db_gib']} GiB), "
+            f"{c['compressor']} chunk_length={c['chunk_length_bytes']} B, "
             f"ratio={c['compression_ratio_on_disk_over_logical']}, "
-            f"sstables={t['data_db_count']}, missing_components={t['missing_components']}"
+            f"sstables={t['sstable_count']}, "
+            f"missing_components={t['missing_components']}"
         )
     return 0
 


### PR DESCRIPTION
## What this is

Read-path **performance-measurement infrastructure**, landed independently of #3068's own fate. The
#3068 scan-window lever was killed by measurement, but this tooling is reusable and should not stay
stranded on an unmerged branch.

| File | Purpose |
|------|---------|
| `test-data/scripts/gen-perf-corpus-3068.sh` | Generate the corpus (`cassandra:5.0.2` container + `cassandra-stress`) |
| `test-data/scripts/write-perf-corpus-manifest.py` | Emit the manifest, every value read back off disk |
| `test-data/scripts/read-compression-info.py` | Parse `CompressionInfo.db` (compressor / chunk length / chunk count) |
| `test-data/scripts/perf-run-contained.sh` | Run a measurement inside a memory-capped cgroup scope |
| `test-data/perf-corpus-3068-manifest.json` | **Committed** manifest of the generated corpus |
| `scripts/tests/test_perf_run_contained.sh` | Pins the wrapper's `--mem`/`--swap` validation (gate `tooling-tests`) |
| `docs/development/perf-corpus-and-containment.md` | Why the corpus is shaped this way + why the wrapper exists |

## Corpus properties it produces

LZ4Compressor at the Cassandra table default `chunk_length_in_kb = 16`, a **single** `nb` (BIG)
SSTable per table, 10 rows/partition, in two row shapes:

| Table | Rows | `Data.db` | LZ4 chunks @ 16 KiB |
|-------|------|-----------|---------------------|
| `perf_3068.medium_700b` | 11,994,840 | 8,620,456,540 B (8.0 GiB) | 541,271 |
| `perf_3068.wide_4kb` | 1,199,890 | 5,028,730,707 B (4.7 GiB) | 306,672 |

Why bespoke: the committed `test-data/datasets/` fixtures are tiny and the Phase-0 perf anchor was
**uncompressed**, so it never executed the compressed read path at all. Single-SSTable so a k-way
merge cannot pollute a read-plane number; `Data.db` comparable to RAM so "cold" is genuinely cold.

`wide_4kb`'s payload is near-incompressible, so LZ4 leaves it marginally *larger* than its logical
size (Cassandra reports ratio ~1.0006) — expected, not a bug.

## The manifest is the committed artifact (the corpus is not)

The corpus is multi-GB and stays outside the repo. `test-data/perf-corpus-3068-manifest.json`
records **only values read back from the written bytes**, never assumed:

- component filenames + sizes from `stat`; `Data.db` sha256 by hashing the file;
- compressor / `chunk_length` / chunk count from the **`CompressionInfo.db` header**, not from the
  table's `compression` option — a later `ALTER` or a Cassandra-side clamp would make the DDL a lie;
- row count from **Cassandra's own `sstablemetadata`** reading `Statistics.db` (`totalRows`), run in
  a throwaway memory-capped container. **Fail-closed**: an unreadable count errors out rather than
  recording a fabricated 0.

Paths are corpus-root-relative so the committed manifest pins no machine's layout, and only
`<ver>-<gen>-big-*` entries count as components — a stray tool artifact dropped in the directory can
no longer masquerade as part of the SSTable. `data_db_sha256` is the reproducibility check: a
regenerated corpus with a different hash is a *different* corpus and its numbers are not comparable.

## Why `perf-run-contained.sh` exists — the 75-minute host hang

2026-07-28: an **uncontained** cold scan of the 8.0 GiB mmap'd `Data.db` **hard-hung an entire host
for 75 minutes**. The failure mode is not the expected one:

- swapless box, `Committed_AS` reached **105% of `CommitLimit`**;
- **no OOM kill ever fired** — the kernel livelocked in direct reclaim at load 62.7 with every task,
  `sshd` included, in `D` state, so nothing was left schedulable that could observe the problem;
- recovery was 75 minutes of kernel grinding, not a reboot-and-continue.

On a swapless host, "the OOM killer will save me" is false: reclaim livelock has no killer and no
timeout. The wrapper runs the command in a transient systemd scope with
`MemoryMax`/`MemorySwapMax`/`OOMPolicy=kill`, and **refuses to start** when the system is already
`>= 95%` committed — the exact precondition that wedged the box.

`--mem`/`--swap` are now validated against systemd memory syntax **before `sudo`**. That is
safety-critical, not cosmetic: a bare `8` is a legal systemd value meaning *8 bytes*, so a typo
would turn every run into an instant OOM masquerading as a real result. Pinned by
`scripts/tests/test_perf_run_contained.sh` (27 assertions incl. rejection of `banana`, `8G8`,
`-1G`, `8 G`, `8G;reboot`, `8Q`, a missing value, and a missing command), wired into the gate's
`tooling-tests` component. Hermetic via a `--check-args` hook — executes nothing, no
sudo/systemd/cargo/datasets/network. The wrapper is committed mode 755.

## Relationships

- Unblocks read-path measurement for #3029, #3030, #3031.
- Relates to #3083.
- `Refs #3068` — #3068 stays **open** pending an owner scope call; this PR deliberately does not
  close it.

## Verification

- `AGENT-GATE LITE SUMMARY`: `RESULT: PASS` at `99d2aaa` (file-size, fmt, clippy, roborev-lints,
  scoped-tests; `tree-integrity: PASS`).
- Manifest values independently confirmed against `sstablemetadata` (`totalRows`), `sha256sum`, and
  `stat` on this box; the `CompressionInfo.db` header bytes were also hand-decoded against
  `docs/sstables-definitive-guide/chapters/09-compressioninfo-and-chunking.md` (option count 0,
  `chunk_length` `0x4000`, `max_compressed_length` `Integer.MAX_VALUE`, `data_length`, chunk count),
  and the parser's chunk-offset array exactly fills the file, which pins every preceding field.
- Diff is 9 files / 1,254 insertions, all scripts + docs + one 8 KB JSON. No corpus bytes staged.