### PR TITLE
fix(flight): fail closed when the query-row producer thread dies instead of silently truncating the result set (#3106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A dead producer no longer completes a query SUCCESSFULLY with a silently
+  truncated result set (#3106).** Both channel boundaries behind the
+  single-generation read path (used by the Flight `do_get` row route) treated
+  "sender dropped" as "the scan finished", so a producer thread/task that UNWOUND —
+  a panic anywhere in the walk or decode, rather than an `Err` return — ended the
+  request with **fewer rows than the table holds, no error and no log**.
+  - The query row stream's producer→consumer protocol now has an EXPLICIT terminator
+    (`Done`) and a distinct `Failed` message; a disconnect WITHOUT a terminator is an
+    `Error::Internal` naming the truncation, never a clean end of stream. The
+    producer thread additionally runs under `catch_unwind`, so a panic reaches the
+    client as an informative error carrying the panic message.
+  - The batched streaming scan's driver task is now JOINED when its channel closes
+    (`BatchedScanStream`), so a task that panicked/was cancelled surfaces as an
+    `Error::Internal` instead of an empty-but-successful end of stream. This closes
+    the same hole for the streaming `SELECT` and aggregate-fold paths, which
+    consume the same surface.
+  - Both errors are `is_recoverable() == false`: the failure is deterministic, so a
+    retry would reproduce it.
+
 - **BTI `Rows.db` row-index base + leading `NEXT_COMPONENT` byte (#3002, #3040).** Two
   defects that cancelled each other on the BTI clustering read path are corrected:
   (a) the per-partition `TrieIndexEntry`'s SIGNED root delta is now measured from
@@ -54,6 +73,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Result<ValidatedRowsTrieRoot, RowsTrieRootRejection>` instead of a bare `usize`, so
   an unvalidated row-index root cannot be traversed by accident; use
   `trie_root_offset()` / `require_trie_root()` (#3002).
+- **Breaking (API):** the batched streaming scan now returns
+  `sstable::reader::BatchedScanStream` instead of
+  `tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>` — affecting
+  `StorageEngine::scan_stream_batched`, `SSTableManager::scan_stream_batched` (both
+  feature variants) and `SSTableReader::scan_stream_batched`/`_admitted`. The new type
+  owns the scan task's `JoinHandle` so a dead task cannot masquerade as end-of-stream
+  (#3106). Its `recv()` keeps the same `async fn(&mut self) -> Option<Result<..>>`
+  shape, so the usual `while let Some(batch) = stream.recv().await` consumer compiles
+  unchanged; code that named the `Receiver` type, stored it in a struct field, or
+  called `Receiver`-specific methods (`try_recv`, `blocking_recv`, `close`) must be
+  updated.
 
 ## [v0.16.1] - 2026-07-23
 

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -461,6 +461,18 @@ bench-internals = []
 # links it.
 arrow-shape-corpus = ["arrow"]
 
+# TEST-ONLY producer-fault injection (issue #3106) — gates the arming API of
+# `storage::producer_fault`, the deterministic seam a test uses to kill the query
+# row stream's producer thread mid-walk so the consumer's fail-closed handling of
+# a dead producer (no terminal `Done` sentinel) can be PROVEN instead of asserted
+# by inspection. Adds NO dependencies and NO production behaviour: without this
+# feature the arming symbols do not exist, the armed-state statics do not exist,
+# `ProducerFault` is a zero-sized no-op struct and every default build / gate /
+# CI run is byte-identical. NOT in defaults; `cqlite-flight` enables it from its
+# `[dev-dependencies]` (the `arrow-shape-corpus` convention), so no shipped
+# binary links it.
+producer-fault-injection = []
+
 # Legacy heuristics support (backward compatibility for pre-5.0 formats)
 # NOT enabled in default CI configuration - opt-in only
 legacy-heuristics = []

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -2,11 +2,19 @@
 
 /// Shared, bytes-bounded, sharded decompressed-chunk cache (issue #1567).
 pub mod cache;
-/// TEST-ONLY producer-fault injection for the query row stream (issue #3106):
-/// the deterministic seam a test uses to kill the producer thread mid-stream and
-/// prove the consumer fails closed instead of reporting a clean, silently
-/// truncated end of stream. Inert (and, for the arming API, non-existent) in a
-/// production build.
+/// TEST-ONLY fault injection for the query row stream's producer boundaries
+/// (issue #3106): the deterministic seam a test uses to kill a producer
+/// thread/task mid-stream and prove the consumer fails closed instead of
+/// reporting a clean, silently truncated end of stream.
+///
+/// `pub(crate)` in a production build — the module then has NO public items at
+/// all (every arming symbol is cfg'd out), so publishing it would advertise an
+/// empty module. It becomes `pub` only where the arming surface exists, i.e. for
+/// in-crate tests and for the `producer-fault-injection` feature that
+/// `cqlite-flight` enables from its `[dev-dependencies]`.
+#[cfg(not(any(test, feature = "producer-fault-injection")))]
+pub(crate) mod producer_fault;
+#[cfg(any(test, feature = "producer-fault-injection"))]
 pub mod producer_fault;
 /// Always-on read-path ARM probes (issue #3058): explicit markers for
 /// "the k-way merge ran" vs "the single-generation query scan ran".
@@ -537,7 +545,7 @@ impl StorageEngine {
         end_key: Option<&RowKey>,
         schema: Option<&crate::schema::TableSchema>,
         buffer_size: usize,
-    ) -> Result<tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>> {
+    ) -> Result<sstable::reader::BatchedScanStream> {
         record_table_scan_call();
         self.sstables
             .scan_stream_batched(table_id, start_key, end_key, schema, buffer_size)

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -2,6 +2,12 @@
 
 /// Shared, bytes-bounded, sharded decompressed-chunk cache (issue #1567).
 pub mod cache;
+/// TEST-ONLY producer-fault injection for the query row stream (issue #3106):
+/// the deterministic seam a test uses to kill the producer thread mid-stream and
+/// prove the consumer fails closed instead of reporting a clean, silently
+/// truncated end of stream. Inert (and, for the arming API, non-existent) in a
+/// production build.
+pub mod producer_fault;
 /// Always-on read-path ARM probes (issue #3058): explicit markers for
 /// "the k-way merge ran" vs "the single-generation query scan ran".
 pub mod read_path_probe;

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -1,0 +1,220 @@
+//! TEST-ONLY producer-fault injection for the query row stream (issue #3106).
+//!
+//! # Why this exists
+//!
+//! The query row stream ([`crate::storage::sstable::reader::QueryRowStream`]) is
+//! fed by a detached producer thread over a bounded channel. Before issue #3106
+//! the consumer collapsed a channel DISCONNECT into a clean end of stream, so a
+//! producer thread that UNWOUND (a panic anywhere in the walk/decode, rather than
+//! an `Err` return) dropped its `SyncSender` without a terminal message and the
+//! request completed SUCCESSFULLY with a silently truncated result set. The fix
+//! makes completion explicit (a `Done` sentinel) and forwards a caught panic as a
+//! real error; this module is how a test PROVES that, deterministically, without
+//! waiting for a real decode bug to unwind.
+//!
+//! # Why this is not a production knob (no-heuristics safe)
+//!
+//! * Everything that can arm a fault is `#[cfg(any(test, feature =
+//!   "producer-fault-injection"))]`. In a default build the arming API does not
+//!   exist, the armed-state statics do not exist, [`ProducerFault`] is a
+//!   zero-sized struct with no fields, and [`ProducerFault::before_batch_handoff`]
+//!   compiles to an empty function — the production build is byte-identical to
+//!   one without this module's body.
+//! * No environment variable, config field or on-disk byte pattern can arm it:
+//!   the only way in is a Rust call to [`arm_query_row_producer_panic`], which is
+//!   compiled out of production builds. So it cannot influence a decoding
+//!   decision (issue #28) even accidentally.
+//! * `cqlite-flight` enables the feature from its `[dev-dependencies]` (the same
+//!   convention `arrow-shape-corpus` / `test-util` already use), so the shipped
+//!   Flight binary never links it.
+//!
+//! # Arming semantics
+//!
+//! [`arm_query_row_producer_panic`] arms the NEXT query row stream opened
+//! ANYWHERE in the process — process-global rather than thread-local on purpose:
+//! the Flight `do_get` row route opens its stream on a `spawn_blocking` thread,
+//! not on the calling thread, so a thread-local arm could never reach the surface
+//! whose fail-closed behaviour is the point of the fix. To keep that
+//! deterministic:
+//!
+//! * The arm is TAKEN (consumed) by the first [`ProducerFault::capture`], i.e. by
+//!   exactly ONE stream, and is owned by that stream's producer thread from then
+//!   on — never re-read from a shared cell mid-walk.
+//! * [`arm_query_row_producer_panic`] holds a process-global lock for the
+//!   returned guard's lifetime, so two arming tests in one binary serialize.
+//! * A racing NON-arming stream that stole the arm makes the arming test FAIL
+//!   (it sees no error), never pass silently — the failure mode is loud.
+
+/// Producer-fault state captured ONCE when a query row stream is opened, then
+/// owned by that stream's producer thread.
+///
+/// A zero-sized, no-op struct in a production build (see the module doc).
+#[derive(Debug, Default)]
+pub(crate) struct ProducerFault {
+    /// Batches this producer may still hand to the consumer before it panics.
+    /// `None` = no fault armed (always the case in production).
+    #[cfg(any(test, feature = "producer-fault-injection"))]
+    panic_after_batches: Option<u64>,
+}
+
+impl ProducerFault {
+    /// Take whatever fault is armed for the next stream (nothing, in production).
+    pub(crate) fn capture() -> Self {
+        Self {
+            #[cfg(any(test, feature = "producer-fault-injection"))]
+            panic_after_batches: armed::take(),
+        }
+    }
+
+    /// Consulted by the producer immediately BEFORE it hands a batch to the
+    /// consumer — the single batch-handoff funnel both walk arms go through, so
+    /// an injected fault is observed identically on either.
+    ///
+    /// Panics ON PURPOSE once the armed batch budget is exhausted; that panic is
+    /// the fault being injected, and it is what the producer's `catch_unwind`
+    /// must convert into a terminal error instead of a silent truncation.
+    /// Compiles to an empty function in a production build.
+    pub(crate) fn before_batch_handoff(&mut self) {
+        #[cfg(any(test, feature = "producer-fault-injection"))]
+        if let Some(remaining) = self.panic_after_batches.as_mut() {
+            if *remaining == 0 {
+                panic!("{}", INJECTED_PANIC_MESSAGE);
+            }
+            *remaining -= 1;
+        }
+    }
+}
+
+/// The panic message [`ProducerFault::before_batch_handoff`] raises. Exported so
+/// a test can (a) assert the forwarded error carries it and (b) suppress exactly
+/// this panic in its panic hook without silencing a real one.
+#[cfg(any(test, feature = "producer-fault-injection"))]
+pub const INJECTED_PANIC_MESSAGE: &str =
+    "cqlite test fault injection (issue #3106): query row stream producer thread panic";
+
+#[cfg(any(test, feature = "producer-fault-injection"))]
+mod armed {
+    use std::sync::atomic::{AtomicI64, Ordering};
+
+    /// No fault armed.
+    const DISARMED: i64 = -1;
+
+    /// Batches the next opened stream may hand over before panicking, or
+    /// [`DISARMED`]. Written only by the arming API / its guard, and TAKEN by
+    /// `take` so exactly one stream can observe it.
+    static ARMED_BATCHES: AtomicI64 = AtomicI64::new(DISARMED);
+
+    /// Serializes arming tests in one binary (see the module doc).
+    static ARM_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    pub(super) fn arm(after_batches: u64) -> parking_lot::MutexGuard<'static, ()> {
+        let lock = ARM_LOCK.lock();
+        // Saturate rather than wrap: an absurd budget simply never fires, and a
+        // negative value would read as DISARMED.
+        ARMED_BATCHES.store(
+            i64::try_from(after_batches).unwrap_or(i64::MAX),
+            Ordering::SeqCst,
+        );
+        lock
+    }
+
+    pub(super) fn disarm() {
+        ARMED_BATCHES.store(DISARMED, Ordering::SeqCst);
+    }
+
+    pub(super) fn take() -> Option<u64> {
+        let armed = ARMED_BATCHES.swap(DISARMED, Ordering::SeqCst);
+        u64::try_from(armed).ok()
+    }
+}
+
+/// Arm the NEXT query row stream opened in this process to panic in its producer
+/// thread just before it hands over batch number `after_batches` (0-based), so
+/// `after_batches` batches reach the consumer and the walk then dies MID-STREAM.
+///
+/// `0` kills the producer before its first handoff. The arm is disarmed when the
+/// returned guard is dropped (and consumed by the stream that captures it), and
+/// the guard serializes against any other arming caller in the same test binary.
+///
+/// TEST-ONLY: this symbol does not exist unless `cfg(test)` or the
+/// `producer-fault-injection` feature is on (see the module doc).
+#[cfg(any(test, feature = "producer-fault-injection"))]
+#[must_use = "the fault stays armed only while the guard is alive"]
+pub fn arm_query_row_producer_panic(after_batches: u64) -> ArmedProducerPanic {
+    ArmedProducerPanic {
+        _lock: armed::arm(after_batches),
+    }
+}
+
+/// Guard returned by [`arm_query_row_producer_panic`]: disarms the fault and
+/// releases the arming lock on drop.
+#[cfg(any(test, feature = "producer-fault-injection"))]
+pub struct ArmedProducerPanic {
+    _lock: parking_lot::MutexGuard<'static, ()>,
+}
+
+#[cfg(any(test, feature = "producer-fault-injection"))]
+impl Drop for ArmedProducerPanic {
+    fn drop(&mut self) {
+        armed::disarm();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A default-constructed fault (the production shape) NEVER panics, however
+    /// many batches are handed over.
+    #[test]
+    fn an_unarmed_producer_fault_is_inert() {
+        let mut fault = ProducerFault::default();
+        for _ in 0..1000 {
+            fault.before_batch_handoff();
+        }
+    }
+
+    /// The arming contract, asserted in ONE critical section (a second arming
+    /// test would race this one for the process-global arm between its own
+    /// `arm`/`capture` calls):
+    ///
+    /// * the armed stream survives exactly its budget of handoffs, then panics;
+    /// * `capture` TAKES the arm, so a second stream opened under the same arm is
+    ///   clean — a fault can never leak into an unrelated later stream;
+    /// * dropping the guard disarms, so a finished test cannot poison a later one.
+    #[test]
+    fn arming_applies_to_exactly_one_captured_stream_and_is_dropped_with_the_guard() {
+        let guard = arm_query_row_producer_panic(2);
+        let mut first = ProducerFault::capture();
+        let mut second = ProducerFault::capture();
+
+        // The armed stream survives exactly two handoffs, then dies. The panic
+        // is EXPECTED here, so the hook is silenced for the window and restored
+        // before any assertion runs (a silenced hook would hide a real failure
+        // message).
+        first.before_batch_handoff();
+        first.before_batch_handoff();
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let died = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            first.before_batch_handoff();
+        }));
+        std::panic::set_hook(previous_hook);
+        assert!(
+            died.is_err(),
+            "the armed stream must panic on the handoff after its budget"
+        );
+
+        // The second capture got nothing: the arm was already taken.
+        for _ in 0..10 {
+            second.before_batch_handoff();
+        }
+
+        // And once the guard is gone, nothing is armed any more.
+        drop(guard);
+        let mut later = ProducerFault::capture();
+        for _ in 0..10 {
+            later.before_batch_handoff();
+        }
+    }
+}

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -19,11 +19,15 @@
 //! * [`arm_query_row_producer_panic`] → the OUTER boundary: the query-row producer
 //!   THREAD panics at a batch handoff ([`ProducerFault::before_batch_handoff`],
 //!   consulted in `query_rows::emit_rows`).
-//! * [`arm_inner_scan_decode_panic`] → the INNER boundary: the batched-scan
-//!   `tokio` TASK panics inside a block decode ([`inner_scan_decode_checkpoint`],
-//!   consulted in `data_access::batched_scan_stream::SSTableReader::parse_batched_block`,
-//!   i.e. in the same task as `parse_block_entries_at_now`). This is the arm a
-//!   `do_get` with no token filter takes, so it is the issue's own repro.
+//! * [`arm_inner_scan_task_panic`] → the INNER boundary: the batched-scan `tokio`
+//!   TASK panics ([`inner_scan_task_checkpoint`]). Two checkpoint sites, both in
+//!   `data_access::batched_scan_stream` and both INSIDE that task: its cursor-open
+//!   prelude (`open_batched_scan_cursor`, checkpoint 0 — reached whatever on-disk
+//!   format the reader has) and each block decode of the non-stitching branch
+//!   (`parse_batched_block`, i.e. the `parse_block_entries_at_now` call itself).
+//!   This is the arm a `do_get` with NO token filter takes, so it is the issue's
+//!   own repro; killing the task there drops its sender with no terminator, which
+//!   the query-row thread used to read as "the scan finished".
 //!
 //! # Why this is not a production knob (no-heuristics safe)
 //!
@@ -116,16 +120,17 @@ impl ProducerFault {
     }
 }
 
-/// Consulted by the INNER batched-scan task immediately before each block decode
-/// (`parse_batched_block`), so an armed fault unwinds THAT task — the boundary
-/// whose disconnect the query-row thread used to read as "the scan finished".
+/// Consulted at the INNER batched-scan task's checkpoints — its cursor-open
+/// prelude and every non-stitching block decode — so an armed fault unwinds THAT
+/// task, the boundary whose disconnect the query-row thread used to read as "the
+/// scan finished".
 ///
-/// Panics ON PURPOSE when the armed decode budget is exhausted. Compiles to an
-/// empty function in a production build.
+/// Panics ON PURPOSE when the armed budget is exhausted. Compiles to an empty
+/// function in a production build.
 #[inline]
-pub(crate) fn inner_scan_decode_checkpoint() {
+pub(crate) fn inner_scan_task_checkpoint() {
     #[cfg(any(test, feature = "producer-fault-injection"))]
-    armed::consume_inner_decode();
+    armed::consume_inner_checkpoint();
 }
 
 /// The panic message both checkpoints raise. Exported so a test can (a) assert
@@ -147,11 +152,11 @@ mod armed {
     /// stream can observe it.
     static OUTER_BATCHES: AtomicI64 = AtomicI64::new(DISARMED);
 
-    /// Block decodes the inner batched-scan task may perform before it panics, or
-    /// [`DISARMED`]. Decremented in place (the decode site has no per-scan state
-    /// to own it), which is why an arming caller must serialize — see the module
-    /// doc.
-    static INNER_DECODES: AtomicI64 = AtomicI64::new(DISARMED);
+    /// Checkpoints the inner batched-scan task may pass before it panics, or
+    /// [`DISARMED`]. Decremented in place (the checkpoint sites have no per-scan
+    /// state to own it), which is why an arming caller must serialize — see the
+    /// module doc.
+    static INNER_CHECKPOINTS: AtomicI64 = AtomicI64::new(DISARMED);
 
     /// Saturate rather than wrap: an absurd budget simply never fires, and a
     /// negative value would read as `DISARMED`.
@@ -171,27 +176,27 @@ mod armed {
         u64::try_from(OUTER_BATCHES.swap(DISARMED, Ordering::SeqCst)).ok()
     }
 
-    pub(super) fn arm_inner_decode(after_decodes: u64) {
-        INNER_DECODES.store(as_budget(after_decodes), Ordering::SeqCst);
+    pub(super) fn arm_inner_checkpoints(after_checkpoints: u64) {
+        INNER_CHECKPOINTS.store(as_budget(after_checkpoints), Ordering::SeqCst);
     }
 
-    pub(super) fn disarm_inner_decode() {
-        INNER_DECODES.store(DISARMED, Ordering::SeqCst);
+    pub(super) fn disarm_inner_checkpoints() {
+        INNER_CHECKPOINTS.store(DISARMED, Ordering::SeqCst);
     }
 
-    /// Spend one decode from the inner budget, panicking when it is exhausted.
-    /// The budget is DISARMED before the panic so the unwind cannot re-enter and
-    /// so a retry/sibling scan is never hit by the same arm.
-    pub(super) fn consume_inner_decode() {
-        let remaining = INNER_DECODES.load(Ordering::SeqCst);
+    /// Spend one checkpoint from the inner budget, panicking when it is
+    /// exhausted. The budget is DISARMED before the panic so the unwind cannot
+    /// re-enter and so a retry/sibling scan is never hit by the same arm.
+    pub(super) fn consume_inner_checkpoint() {
+        let remaining = INNER_CHECKPOINTS.load(Ordering::SeqCst);
         if remaining < 0 {
             return;
         }
         if remaining == 0 {
-            disarm_inner_decode();
+            disarm_inner_checkpoints();
             panic!("{}", super::INJECTED_PANIC_MESSAGE);
         }
-        INNER_DECODES.store(remaining - 1, Ordering::SeqCst);
+        INNER_CHECKPOINTS.store(remaining - 1, Ordering::SeqCst);
     }
 }
 
@@ -225,26 +230,30 @@ impl Drop for ArmedProducerPanic {
     }
 }
 
-/// Arm the INNER batched-scan task to panic inside block decode number
-/// `after_decodes` (0-based), i.e. in the same `tokio` task as
-/// `parse_block_entries_at_now`, so the task unwinds and drops its sender with no
-/// terminator.
+/// Arm the INNER batched-scan task to panic at checkpoint number
+/// `after_checkpoints` (0-based) inside itself, so the task unwinds and drops its
+/// sender with no terminator.
 ///
-/// `0` kills it on its first decode. Disarmed when the returned guard drops (and
-/// when the fault fires). PROCESS-GLOBAL and decremented at the decode site, so
-/// the caller MUST serialize against any sibling test that scans (see the module
-/// doc) — otherwise the sibling's scan spends the budget.
+/// `0` kills it in its cursor-open prelude — before any row, and independently of
+/// which format branch the reader takes. Higher values are spent on the
+/// non-stitching branch's per-block decodes (the `parse_block_entries_at_now`
+/// call), so a reader whose format takes the stitching branch never reaches them.
+///
+/// Disarmed when the returned guard drops (and when the fault fires).
+/// PROCESS-GLOBAL and decremented at the checkpoint sites, so the caller MUST
+/// serialize against any sibling test that scans (see the module doc) — otherwise
+/// the sibling's scan spends the budget.
 ///
 /// TEST-ONLY: this symbol does not exist unless `cfg(test)` or the
 /// `producer-fault-injection` feature is on.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[must_use = "the fault stays armed only while the guard is alive"]
-pub fn arm_inner_scan_decode_panic(after_decodes: u64) -> ArmedInnerScanPanic {
-    armed::arm_inner_decode(after_decodes);
+pub fn arm_inner_scan_task_panic(after_checkpoints: u64) -> ArmedInnerScanPanic {
+    armed::arm_inner_checkpoints(after_checkpoints);
     ArmedInnerScanPanic
 }
 
-/// Guard returned by [`arm_inner_scan_decode_panic`]: disarms on drop. Holds no
+/// Guard returned by [`arm_inner_scan_task_panic`]: disarms on drop. Holds no
 /// lock, so it is safe to hold across an `.await`.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[derive(Debug)]
@@ -253,7 +262,7 @@ pub struct ArmedInnerScanPanic;
 #[cfg(any(test, feature = "producer-fault-injection"))]
 impl Drop for ArmedInnerScanPanic {
     fn drop(&mut self) {
-        armed::disarm_inner_decode();
+        armed::disarm_inner_checkpoints();
     }
 }
 

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -20,14 +20,16 @@
 //!   THREAD panics at a batch handoff ([`ProducerFault::before_batch_handoff`],
 //!   consulted in `query_rows::emit_rows`).
 //! * [`arm_inner_scan_task_panic`] → the INNER boundary: the batched-scan `tokio`
-//!   TASK panics ([`inner_scan_task_checkpoint`]). Two checkpoint sites, both in
-//!   `data_access::batched_scan_stream` and both INSIDE that task: its cursor-open
-//!   prelude (`open_batched_scan_cursor`, checkpoint 0 — reached whatever on-disk
-//!   format the reader has) and each block decode of the non-stitching branch
-//!   (`parse_batched_block`, i.e. the `parse_block_entries_at_now` call itself).
+//!   TASK panics ([`inner_scan_task_checkpoint`]). ONE checkpoint site, in that
+//!   task's cursor-open prelude
+//!   (`data_access::batched_scan_stream::SSTableReader::open_batched_scan_cursor`),
+//!   which sits ABOVE the `requires_chunk_stitching()` branch and is therefore
+//!   reached whatever on-disk format the reader has — a checkpoint inside either
+//!   branch would fire only for that branch's formats and could silently not fire.
+//!   No budget knob: a count would only be spendable at sites that do not exist.
 //!   This is the arm a `do_get` with NO token filter takes, so it is the issue's
-//!   own repro; killing the task there drops its sender with no terminator, which
-//!   the query-row thread used to read as "the scan finished".
+//!   own repro; killing the task drops its sender with no terminator, which the
+//!   query-row thread used to read as "the scan finished".
 //!
 //! # Why this is not a production knob (no-heuristics safe)
 //!
@@ -120,13 +122,12 @@ impl ProducerFault {
     }
 }
 
-/// Consulted at the INNER batched-scan task's checkpoints — its cursor-open
-/// prelude and every non-stitching block decode — so an armed fault unwinds THAT
-/// task, the boundary whose disconnect the query-row thread used to read as "the
-/// scan finished".
+/// Consulted at the INNER batched-scan task's checkpoint (its cursor-open
+/// prelude) so an armed fault unwinds THAT task — the boundary whose disconnect
+/// the query-row thread used to read as "the scan finished".
 ///
-/// Panics ON PURPOSE when the armed budget is exhausted. Compiles to an empty
-/// function in a production build.
+/// Panics ON PURPOSE when a fault is armed, consuming the arm so exactly one scan
+/// task dies. Compiles to an empty function in a production build.
 #[inline]
 pub(crate) fn inner_scan_task_checkpoint() {
     #[cfg(any(test, feature = "producer-fault-injection"))]
@@ -142,7 +143,7 @@ pub const INJECTED_PANIC_MESSAGE: &str =
 
 #[cfg(any(test, feature = "producer-fault-injection"))]
 mod armed {
-    use std::sync::atomic::{AtomicI64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 
     /// No fault armed.
     const DISARMED: i64 = -1;
@@ -152,11 +153,10 @@ mod armed {
     /// stream can observe it.
     static OUTER_BATCHES: AtomicI64 = AtomicI64::new(DISARMED);
 
-    /// Checkpoints the inner batched-scan task may pass before it panics, or
-    /// [`DISARMED`]. Decremented in place (the checkpoint sites have no per-scan
-    /// state to own it), which is why an arming caller must serialize — see the
-    /// module doc.
-    static INNER_CHECKPOINTS: AtomicI64 = AtomicI64::new(DISARMED);
+    /// Whether the NEXT inner batched-scan task to reach its checkpoint must
+    /// panic. Taken in place (the checkpoint site has no per-scan state to own
+    /// it), which is why an arming caller must serialize — see the module doc.
+    static INNER_TASK_ARMED: AtomicBool = AtomicBool::new(false);
 
     /// Saturate rather than wrap: an absurd budget simply never fires, and a
     /// negative value would read as `DISARMED`.
@@ -176,27 +176,21 @@ mod armed {
         u64::try_from(OUTER_BATCHES.swap(DISARMED, Ordering::SeqCst)).ok()
     }
 
-    pub(super) fn arm_inner_checkpoints(after_checkpoints: u64) {
-        INNER_CHECKPOINTS.store(as_budget(after_checkpoints), Ordering::SeqCst);
+    pub(super) fn arm_inner_task() {
+        INNER_TASK_ARMED.store(true, Ordering::SeqCst);
     }
 
-    pub(super) fn disarm_inner_checkpoints() {
-        INNER_CHECKPOINTS.store(DISARMED, Ordering::SeqCst);
+    pub(super) fn disarm_inner_task() {
+        INNER_TASK_ARMED.store(false, Ordering::SeqCst);
     }
 
-    /// Spend one checkpoint from the inner budget, panicking when it is
-    /// exhausted. The budget is DISARMED before the panic so the unwind cannot
-    /// re-enter and so a retry/sibling scan is never hit by the same arm.
+    /// TAKE the inner-task arm, panicking if it was set. Taken (not merely read)
+    /// before the panic, so the unwind cannot re-enter and a retry/sibling scan is
+    /// never hit by the same arm.
     pub(super) fn consume_inner_checkpoint() {
-        let remaining = INNER_CHECKPOINTS.load(Ordering::SeqCst);
-        if remaining < 0 {
-            return;
-        }
-        if remaining == 0 {
-            disarm_inner_checkpoints();
+        if INNER_TASK_ARMED.swap(false, Ordering::SeqCst) {
             panic!("{}", super::INJECTED_PANIC_MESSAGE);
         }
-        INNER_CHECKPOINTS.store(remaining - 1, Ordering::SeqCst);
     }
 }
 
@@ -230,26 +224,25 @@ impl Drop for ArmedProducerPanic {
     }
 }
 
-/// Arm the INNER batched-scan task to panic at checkpoint number
-/// `after_checkpoints` (0-based) inside itself, so the task unwinds and drops its
-/// sender with no terminator.
+/// Arm the NEXT batched-scan task to panic in its cursor-open prelude, so the task
+/// unwinds and drops its sender with no error and no terminator.
 ///
-/// `0` kills it in its cursor-open prelude — before any row, and independently of
-/// which format branch the reader takes. Higher values are spent on the
-/// non-stitching branch's per-block decodes (the `parse_block_entries_at_now`
-/// call), so a reader whose format takes the stitching branch never reaches them.
+/// It dies before any row and independently of which format branch the reader
+/// would have taken; the join that must catch it wraps the whole task, so the
+/// property this proves holds for a panic anywhere inside it. There is
+/// deliberately no "die after N units" knob — the prelude is the only checkpoint,
+/// so a count would be unspendable (issue #3106, roborev).
 ///
-/// Disarmed when the returned guard drops (and when the fault fires).
-/// PROCESS-GLOBAL and decremented at the checkpoint sites, so the caller MUST
-/// serialize against any sibling test that scans (see the module doc) — otherwise
-/// the sibling's scan spends the budget.
+/// Disarmed when the returned guard drops, and TAKEN when the fault fires.
+/// PROCESS-GLOBAL, so the caller MUST serialize against any sibling test that
+/// scans (see the module doc) — otherwise the sibling's scan takes the arm.
 ///
 /// TEST-ONLY: this symbol does not exist unless `cfg(test)` or the
 /// `producer-fault-injection` feature is on.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[must_use = "the fault stays armed only while the guard is alive"]
-pub fn arm_inner_scan_task_panic(after_checkpoints: u64) -> ArmedInnerScanPanic {
-    armed::arm_inner_checkpoints(after_checkpoints);
+pub fn arm_inner_scan_task_panic() -> ArmedInnerScanPanic {
+    armed::arm_inner_task();
     ArmedInnerScanPanic
 }
 
@@ -262,7 +255,7 @@ pub struct ArmedInnerScanPanic;
 #[cfg(any(test, feature = "producer-fault-injection"))]
 impl Drop for ArmedInnerScanPanic {
     fn drop(&mut self) {
-        armed::disarm_inner_checkpoints();
+        armed::disarm_inner_task();
     }
 }
 

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -184,7 +184,30 @@ mod armed {
         NEXT_ARM_ID.fetch_add(1, Ordering::SeqCst)
     }
 
+    /// Shortest scope an arm may register with.
+    ///
+    /// The match is a substring test, so an empty (or near-empty) scope matches
+    /// EVERY reader path and silently restores the process-global behaviour the
+    /// scoping exists to eliminate — invisibly, which is the worst failure
+    /// direction. Enforced rather than documented, since "callers are careful" is
+    /// exactly the mitigation that already failed once here (roborev, #3106). Any
+    /// real scope — a `TempDir` path or a `keyspace/table` pair — clears this by an
+    /// order of magnitude.
+    const MIN_SCOPE_LEN: usize = 8;
+
+    /// Fail LOUDLY on a scope that would match everything.
+    fn check_scope(scope: &str) {
+        debug_assert!(
+            scope.len() >= MIN_SCOPE_LEN,
+            "producer-fault scope {scope:?} is shorter than {MIN_SCOPE_LEN} chars: a \
+             substring that loose matches every reader path, which silently reverts \
+             the arm to process-global (issue #3106) — scope to a TempDir path or a \
+             keyspace/table instead"
+        );
+    }
+
     pub(super) fn arm_outer(scope: &str, after_batches: u64) -> u64 {
+        check_scope(scope);
         let id = next_id();
         OUTER_ARMS.lock().push(OuterArm {
             id,
@@ -210,6 +233,7 @@ mod armed {
     }
 
     pub(super) fn arm_inner(scope: &str) -> u64 {
+        check_scope(scope);
         let id = next_id();
         INNER_ARMS.lock().push(InnerArm {
             id,

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -26,20 +26,44 @@
 //!   which sits ABOVE the `requires_chunk_stitching()` branch and is therefore
 //!   reached whatever on-disk format the reader has — a checkpoint inside either
 //!   branch would fire only for that branch's formats and could silently not fire.
-//!   No budget knob: a count would only be spendable at sites that do not exist.
 //!   This is the arm a `do_get` with NO token filter takes, so it is the issue's
 //!   own repro; killing the task drops its sender with no terminator, which the
 //!   query-row thread used to read as "the scan finished".
+//!
+//! # Every arm is SCOPED to one reader — no test can take another's (roborev)
+//!
+//! An arm is registered against a `scope` STRING, and a checkpoint fires only when
+//! the scanning reader's `Data.db` PATH contains that scope. This is the
+//! structural replacement for the earlier "process-global, caller serializes"
+//! convention, which was unsound in the `cqlite-core` lib test binary: the in-`src`
+//! panic tests compile into the SAME binary as thousands of other tests and
+//! libtest runs them in parallel, so a concurrent test's scan could consume the arm
+//! and let a panic-injection test pass for the wrong reason (a doc comment asking
+//! callers to serialize is exactly the mitigation that failed).
+//!
+//! Two properties make it structural rather than conventional:
+//!
+//! * **Scoped consumption.** A scan whose path does not match leaves the arm
+//!   registered, so it cannot consume a foreign arm even by racing. A test scopes
+//!   to its own `TempDir` path (unique per run) or to its own `keyspace/table`.
+//! * **A registry, not a slot.** Arms live in a `Vec`, so two concurrently armed
+//!   tests coexist; neither can clobber the other's arm by arming second. Each
+//!   guard removes its OWN entry (by id) on drop.
+//!
+//! Matching is by substring so a caller can scope to a directory (`keyspace/table`)
+//! without knowing the generated SSTable filename. An arm that matches nothing is
+//! simply never taken — the arming test then fails LOUDLY (it sees no error), which
+//! is the correct failure direction.
 //!
 //! # Why this is not a production knob (no-heuristics safe)
 //!
 //! * Everything that can arm a fault is `#[cfg(any(test, feature =
 //!   "producer-fault-injection"))]`. In a default build the arming API does not
-//!   exist, the armed-state statics do not exist, [`ProducerFault`] is a
-//!   zero-sized struct with no fields, and both checkpoints compile to empty
-//!   functions — the production build is byte-identical to one without this
-//!   module's body. The module itself is `pub(crate)`; only the test-only surface
-//!   is re-exported, so a default build publishes nothing from here.
+//!   exist, the registries do not exist, [`ProducerFault`] is a zero-sized struct
+//!   with no fields, and both checkpoints compile to empty functions that never
+//!   even evaluate their scope closure — so a production scan does not pay the
+//!   `PathBuf` clone. The production build is byte-identical to one without this
+//!   module's body, and the module itself is `pub(crate)` there.
 //! * No environment variable, config field or on-disk byte pattern can arm it: the
 //!   only way in is a Rust call to an arming function that does not exist in
 //!   production builds. So it cannot influence a decoding decision (issue #28)
@@ -47,29 +71,6 @@
 //! * `cqlite-flight` enables the feature from its `[dev-dependencies]` (the same
 //!   convention `arrow-shape-corpus` / `test-util` already use), so the shipped
 //!   Flight binary never links it.
-//!
-//! # Arming semantics — PROCESS-GLOBAL, caller serializes
-//!
-//! An arm is process-global rather than thread-local on purpose: the Flight
-//! `do_get` row route opens its stream on a `spawn_blocking` thread and drives the
-//! inner scan on yet another runtime, so a thread-local arm could never reach the
-//! surface whose fail-closed behaviour is the point of the fix.
-//!
-//! Consequently — exactly like [`crate::storage::read_path_probe`]'s
-//! process-global counters — **the caller must serialize**: one file = one test
-//! binary = one process is the strongest form, a mutex held across the armed
-//! window is the minimum. The arming functions deliberately return a plain
-//! `Send` disarm-on-drop guard and take NO internal lock, so a guard may be held
-//! across an `.await` without the `await_holding_lock` hazard; serialization is
-//! the test's own explicit business.
-//!
-//! Two properties keep the failure modes loud rather than silent:
-//!
-//! * The OUTER arm is TAKEN (consumed) by the first [`ProducerFault::capture`],
-//!   i.e. by exactly ONE stream, and is then owned by that stream's producer
-//!   thread — never re-read from a shared cell mid-walk.
-//! * A racing scan that stole an arm makes the arming test FAIL (it sees no
-//!   error), never pass silently.
 
 /// Producer-fault state captured ONCE when a query row stream is opened, then
 /// owned by that stream's producer thread.
@@ -84,12 +85,17 @@ pub(crate) struct ProducerFault {
 }
 
 impl ProducerFault {
-    /// Take whatever OUTER fault is armed for the next stream (nothing, in
-    /// production).
-    pub(crate) fn capture() -> Self {
+    /// Take the OUTER arm registered for this reader, if any (never any, in
+    /// production — `scope_of` is not even called).
+    ///
+    /// `scope_of` is lazy precisely so the production build pays nothing: it
+    /// clones a `PathBuf` only when the arming surface is compiled in.
+    pub(crate) fn capture_for(scope_of: impl FnOnce() -> std::path::PathBuf) -> Self {
+        #[cfg(not(any(test, feature = "producer-fault-injection")))]
+        let _ = scope_of;
         Self {
             #[cfg(any(test, feature = "producer-fault-injection"))]
-            panic_after_batches: armed::take_outer(),
+            panic_after_batches: armed::take_outer(&scope_of().to_string_lossy()),
         }
     }
 
@@ -111,9 +117,9 @@ impl ProducerFault {
         }
     }
 
-    /// Build an OUTER fault state directly, WITHOUT touching the process-global
-    /// arm — so a unit test of this module's own logic can never race, or be
-    /// raced by, a sibling test in the same binary.
+    /// Build an OUTER fault state directly, WITHOUT touching the arm registry —
+    /// so a unit test of this module's own logic needs no scope and can never
+    /// race, or be raced by, a sibling test.
     #[cfg(test)]
     fn for_test(panic_after_batches: u64) -> Self {
         Self {
@@ -126,12 +132,15 @@ impl ProducerFault {
 /// prelude) so an armed fault unwinds THAT task — the boundary whose disconnect
 /// the query-row thread used to read as "the scan finished".
 ///
-/// Panics ON PURPOSE when a fault is armed, consuming the arm so exactly one scan
-/// task dies. Compiles to an empty function in a production build.
+/// Panics ON PURPOSE when an arm scoped to THIS reader is registered, taking that
+/// arm so exactly one scan task dies. Compiles to an empty function — which never
+/// calls `scope_of` — in a production build.
 #[inline]
-pub(crate) fn inner_scan_task_checkpoint() {
+pub(crate) fn inner_scan_task_checkpoint(scope_of: impl FnOnce() -> std::path::PathBuf) {
+    #[cfg(not(any(test, feature = "producer-fault-injection")))]
+    let _ = scope_of;
     #[cfg(any(test, feature = "producer-fault-injection"))]
-    armed::consume_inner_checkpoint();
+    armed::take_inner_and_panic(&scope_of().to_string_lossy());
 }
 
 /// The panic message both checkpoints raise. Exported so a test can (a) assert
@@ -143,119 +152,170 @@ pub const INJECTED_PANIC_MESSAGE: &str =
 
 #[cfg(any(test, feature = "producer-fault-injection"))]
 mod armed {
-    use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+    use std::sync::atomic::{AtomicU64, Ordering};
 
-    /// No fault armed.
-    const DISARMED: i64 = -1;
+    use parking_lot::Mutex;
 
-    /// Batches the next opened query row stream may hand over before its producer
-    /// thread panics, or [`DISARMED`]. TAKEN by `take_outer`, so exactly one
-    /// stream can observe it.
-    static OUTER_BATCHES: AtomicI64 = AtomicI64::new(DISARMED);
-
-    /// Whether the NEXT inner batched-scan task to reach its checkpoint must
-    /// panic. Taken in place (the checkpoint site has no per-scan state to own
-    /// it), which is why an arming caller must serialize — see the module doc.
-    static INNER_TASK_ARMED: AtomicBool = AtomicBool::new(false);
-
-    /// Saturate rather than wrap: an absurd budget simply never fires, and a
-    /// negative value would read as `DISARMED`.
-    fn as_budget(count: u64) -> i64 {
-        i64::try_from(count).unwrap_or(i64::MAX)
+    /// One registered OUTER arm.
+    struct OuterArm {
+        id: u64,
+        scope: String,
+        after_batches: u64,
     }
 
-    pub(super) fn arm_outer(after_batches: u64) {
-        OUTER_BATCHES.store(as_budget(after_batches), Ordering::SeqCst);
+    /// One registered INNER arm.
+    struct InnerArm {
+        id: u64,
+        scope: String,
     }
 
-    pub(super) fn disarm_outer() {
-        OUTER_BATCHES.store(DISARMED, Ordering::SeqCst);
+    /// Registered arms. A `Vec`, not a slot: concurrently armed tests coexist and
+    /// cannot clobber one another (see the module doc). Every critical section
+    /// below is a few comparisons long and NEVER spans an `.await`, so no guard is
+    /// ever held across a suspension point.
+    static OUTER_ARMS: Mutex<Vec<OuterArm>> = Mutex::new(Vec::new());
+    static INNER_ARMS: Mutex<Vec<InnerArm>> = Mutex::new(Vec::new());
+
+    /// Distinguishes two arms with the same scope, so a guard removes exactly its
+    /// own registration.
+    static NEXT_ARM_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn next_id() -> u64 {
+        NEXT_ARM_ID.fetch_add(1, Ordering::SeqCst)
     }
 
-    pub(super) fn take_outer() -> Option<u64> {
-        u64::try_from(OUTER_BATCHES.swap(DISARMED, Ordering::SeqCst)).ok()
+    pub(super) fn arm_outer(scope: &str, after_batches: u64) -> u64 {
+        let id = next_id();
+        OUTER_ARMS.lock().push(OuterArm {
+            id,
+            scope: scope.to_string(),
+            after_batches,
+        });
+        id
     }
 
-    pub(super) fn arm_inner_task() {
-        INNER_TASK_ARMED.store(true, Ordering::SeqCst);
+    pub(super) fn disarm_outer(id: u64) {
+        OUTER_ARMS.lock().retain(|arm| arm.id != id);
     }
 
-    pub(super) fn disarm_inner_task() {
-        INNER_TASK_ARMED.store(false, Ordering::SeqCst);
+    /// Take the arm whose scope this reader path matches, if any. A non-matching
+    /// path leaves every arm registered — which is what makes a foreign scan
+    /// unable to consume someone else's arm.
+    pub(super) fn take_outer(path: &str) -> Option<u64> {
+        let mut arms = OUTER_ARMS.lock();
+        let index = arms
+            .iter()
+            .position(|arm| path.contains(arm.scope.as_str()))?;
+        Some(arms.remove(index).after_batches)
     }
 
-    /// TAKE the inner-task arm, panicking if it was set. Taken (not merely read)
-    /// before the panic, so the unwind cannot re-enter and a retry/sibling scan is
-    /// never hit by the same arm.
-    pub(super) fn consume_inner_checkpoint() {
-        if INNER_TASK_ARMED.swap(false, Ordering::SeqCst) {
+    pub(super) fn arm_inner(scope: &str) -> u64 {
+        let id = next_id();
+        INNER_ARMS.lock().push(InnerArm {
+            id,
+            scope: scope.to_string(),
+        });
+        id
+    }
+
+    pub(super) fn disarm_inner(id: u64) {
+        INNER_ARMS.lock().retain(|arm| arm.id != id);
+    }
+
+    /// TAKE the inner arm scoped to this reader and panic. Taken (not merely
+    /// read) and the lock RELEASED before the panic, so the unwind cannot
+    /// re-enter and a retry/sibling scan is never hit by the same arm.
+    pub(super) fn take_inner_and_panic(path: &str) {
+        let armed = {
+            let mut arms = INNER_ARMS.lock();
+            match arms
+                .iter()
+                .position(|arm| path.contains(arm.scope.as_str()))
+            {
+                Some(index) => {
+                    arms.remove(index);
+                    true
+                }
+                None => false,
+            }
+        };
+        if armed {
             panic!("{}", super::INJECTED_PANIC_MESSAGE);
         }
     }
 }
 
-/// Arm the NEXT query row stream opened in this process to panic in its producer
-/// THREAD just before it hands over batch number `after_batches` (0-based), so
-/// `after_batches` batches reach the consumer and the walk then dies MID-STREAM.
+/// Arm the next query row stream opened over a reader whose `Data.db` path
+/// contains `scope` to panic in its producer THREAD just before it hands over
+/// batch number `after_batches` (0-based), so `after_batches` batches reach the
+/// consumer and the walk then dies MID-STREAM.
 ///
 /// `0` kills the producer before its first handoff. Disarmed when the returned
-/// guard drops (and consumed by the stream that captures it). PROCESS-GLOBAL:
-/// the caller serializes (see the module doc).
+/// guard drops, and TAKEN by the first MATCHING stream — a stream over any other
+/// reader leaves it alone, so a concurrently-running test can neither consume nor
+/// clobber this arm (see the module doc). Scope to something unique: a test's own
+/// `TempDir` path, or `keyspace/table`.
 ///
 /// TEST-ONLY: this symbol does not exist unless `cfg(test)` or the
 /// `producer-fault-injection` feature is on.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[must_use = "the fault stays armed only while the guard is alive"]
-pub fn arm_query_row_producer_panic(after_batches: u64) -> ArmedProducerPanic {
-    armed::arm_outer(after_batches);
-    ArmedProducerPanic
+pub fn arm_query_row_producer_panic(scope: &str, after_batches: u64) -> ArmedProducerPanic {
+    ArmedProducerPanic {
+        id: armed::arm_outer(scope, after_batches),
+    }
 }
 
-/// Guard returned by [`arm_query_row_producer_panic`]: disarms on drop. Holds no
-/// lock, so it is safe to hold across an `.await`.
+/// Guard returned by [`arm_query_row_producer_panic`]: removes its own arm on
+/// drop. Holds no lock, so it is safe to hold across an `.await`.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[derive(Debug)]
-pub struct ArmedProducerPanic;
+pub struct ArmedProducerPanic {
+    id: u64,
+}
 
 #[cfg(any(test, feature = "producer-fault-injection"))]
 impl Drop for ArmedProducerPanic {
     fn drop(&mut self) {
-        armed::disarm_outer();
+        armed::disarm_outer(self.id);
     }
 }
 
-/// Arm the NEXT batched-scan task to panic in its cursor-open prelude, so the task
-/// unwinds and drops its sender with no error and no terminator.
+/// Arm the next batched-scan task over a reader whose `Data.db` path contains
+/// `scope` to panic in its cursor-open prelude, so the task unwinds and drops its
+/// sender with no error and no terminator.
 ///
 /// It dies before any row and independently of which format branch the reader
 /// would have taken; the join that must catch it wraps the whole task, so the
 /// property this proves holds for a panic anywhere inside it. There is
 /// deliberately no "die after N units" knob — the prelude is the only checkpoint,
-/// so a count would be unspendable (issue #3106, roborev).
+/// so a count would be unspendable.
 ///
-/// Disarmed when the returned guard drops, and TAKEN when the fault fires.
-/// PROCESS-GLOBAL, so the caller MUST serialize against any sibling test that
-/// scans (see the module doc) — otherwise the sibling's scan takes the arm.
+/// Disarmed when the returned guard drops, and TAKEN by the first MATCHING scan;
+/// a scan over any other reader leaves it registered (see the module doc).
 ///
 /// TEST-ONLY: this symbol does not exist unless `cfg(test)` or the
 /// `producer-fault-injection` feature is on.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[must_use = "the fault stays armed only while the guard is alive"]
-pub fn arm_inner_scan_task_panic() -> ArmedInnerScanPanic {
-    armed::arm_inner_task();
-    ArmedInnerScanPanic
+pub fn arm_inner_scan_task_panic(scope: &str) -> ArmedInnerScanPanic {
+    ArmedInnerScanPanic {
+        id: armed::arm_inner(scope),
+    }
 }
 
-/// Guard returned by [`arm_inner_scan_task_panic`]: disarms on drop. Holds no
-/// lock, so it is safe to hold across an `.await`.
+/// Guard returned by [`arm_inner_scan_task_panic`]: removes its own arm on drop.
+/// Holds no lock, so it is safe to hold across an `.await`.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[derive(Debug)]
-pub struct ArmedInnerScanPanic;
+pub struct ArmedInnerScanPanic {
+    id: u64,
+}
 
 #[cfg(any(test, feature = "producer-fault-injection"))]
 impl Drop for ArmedInnerScanPanic {
     fn drop(&mut self) {
-        armed::disarm_inner_task();
+        armed::disarm_inner(self.id);
     }
 }
 
@@ -321,6 +381,10 @@ impl Drop for SilencedInjectedPanics {
 mod tests {
     use super::*;
 
+    fn path_of(s: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(s)
+    }
+
     /// A default-constructed fault (the production shape) NEVER panics, however
     /// many batches are handed over.
     #[test]
@@ -331,9 +395,9 @@ mod tests {
         }
     }
 
-    /// The OUTER budget semantics, asserted WITHOUT touching the process-global
-    /// arm (`for_test`), so this can never race a sibling test: the fault survives
-    /// exactly its budget of handoffs, then panics.
+    /// The OUTER budget semantics, asserted WITHOUT touching the arm registry
+    /// (`for_test`): the fault survives exactly its budget of handoffs, then
+    /// panics.
     #[test]
     fn an_armed_producer_fault_panics_after_exactly_its_budget() {
         let mut fault = ProducerFault::for_test(2);
@@ -354,32 +418,87 @@ mod tests {
         );
     }
 
-    /// `capture` TAKES the process-global arm, so a fault can never leak into an
-    /// unrelated later stream, and dropping the guard disarms. Single test = one
-    /// critical section over the global (no sibling here arms it).
+    /// SCOPING is what makes the registry safe in a shared test binary (roborev,
+    /// issue #3106): a reader whose path does not match must NOT take the arm, and
+    /// must leave it registered for the reader it was meant for.
     #[test]
-    fn the_global_arm_is_taken_by_one_capture_and_dropped_with_the_guard() {
-        let guard = arm_query_row_producer_panic(7);
-        let first = ProducerFault::capture();
-        let mut second = ProducerFault::capture();
-        assert_eq!(
-            first.panic_after_batches,
-            Some(7),
-            "the first capture takes the armed budget"
-        );
-        assert_eq!(
-            second.panic_after_batches, None,
-            "a second stream under the same arm is clean"
-        );
-        for _ in 0..10 {
-            second.before_batch_handoff();
+    fn an_arm_is_taken_only_by_a_matching_reader_path() {
+        let scope = "issue-3106-scoping-unit-test/only-me";
+        let guard = arm_query_row_producer_panic(scope, 5);
+
+        // A foreign reader (what a concurrently-running sibling test looks like)
+        // captures NOTHING and leaves the arm in place.
+        for foreign in [
+            "/tmp/other-test/data/ks/tbl/nb-1-big-Data.db",
+            "/tmp/issue-3106-scoping-unit-test/someone-else/nb-1-big-Data.db",
+        ] {
+            let stolen = ProducerFault::capture_for(|| path_of(foreign));
+            assert_eq!(
+                stolen.panic_after_batches, None,
+                "a non-matching reader path must not consume the arm ({foreign})"
+            );
         }
 
-        drop(guard);
+        // The intended reader takes it, exactly once.
+        let matching = format!("/tmp/{scope}/nb-1-big-Data.db");
         assert_eq!(
-            ProducerFault::capture().panic_after_batches,
-            None,
-            "dropping the guard disarms, so a later stream is never poisoned"
+            ProducerFault::capture_for(|| path_of(&matching)).panic_after_batches,
+            Some(5),
+            "the reader the arm was scoped to takes it"
         );
+        assert_eq!(
+            ProducerFault::capture_for(|| path_of(&matching)).panic_after_batches,
+            None,
+            "and it is consumed — a second stream over the same reader is clean"
+        );
+        drop(guard);
+    }
+
+    /// Two arms coexist: arming second does not clobber the first, and each guard
+    /// removes only its OWN registration. This is the property a single global
+    /// slot could not provide, and it is why parallel arming tests are safe.
+    #[test]
+    fn concurrent_arms_coexist_and_each_guard_removes_only_its_own() {
+        let first = arm_query_row_producer_panic("issue-3106-coexist/alpha", 1);
+        let second = arm_query_row_producer_panic("issue-3106-coexist/beta", 2);
+
+        drop(first);
+        assert_eq!(
+            ProducerFault::capture_for(|| path_of("/x/issue-3106-coexist/alpha/d.db"))
+                .panic_after_batches,
+            None,
+            "dropping the first guard removes ONLY its arm"
+        );
+        assert_eq!(
+            ProducerFault::capture_for(|| path_of("/x/issue-3106-coexist/beta/d.db"))
+                .panic_after_batches,
+            Some(2),
+            "the second arm survives its sibling's disarm, un-clobbered"
+        );
+        drop(second);
+    }
+
+    /// The INNER checkpoint obeys the same scoping rule: a foreign scan passes
+    /// through untouched, the scoped one dies, and the arm is consumed.
+    #[test]
+    fn the_inner_checkpoint_fires_only_for_the_scoped_reader() {
+        let scope = "issue-3106-inner-scope-unit-test/only-me";
+        let guard = arm_inner_scan_task_panic(scope);
+        let matching = format!("/tmp/{scope}/nb-1-big-Data.db");
+
+        // A foreign scan must run right through the checkpoint.
+        inner_scan_task_checkpoint(|| path_of("/tmp/someone-else/nb-1-big-Data.db"));
+
+        let died = {
+            let _silence = silence_injected_panics();
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                inner_scan_task_checkpoint(|| path_of(&matching));
+            }))
+        };
+        assert!(died.is_err(), "the scoped scan must hit the injected panic");
+
+        // Consumed: a retry of the same scan is clean.
+        inner_scan_task_checkpoint(|| path_of(&matching));
+        drop(guard);
     }
 }

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -160,6 +160,64 @@ impl Drop for ArmedProducerPanic {
     }
 }
 
+/// A boxed panic hook, as [`std::panic::set_hook`] takes it.
+#[cfg(any(test, feature = "producer-fault-injection"))]
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+/// Suppress the console noise of the INJECTED panic — and only that one — for the
+/// returned guard's lifetime.
+///
+/// Deliberately NOT a blanket `set_hook(|_| {})`: the panic hook is
+/// process-global, so silencing everything would swallow a genuine assertion
+/// failure message from this test or any test running in parallel, exactly the
+/// "masked assertion" failure mode. Panics whose payload does not carry
+/// [`INJECTED_PANIC_MESSAGE`] are delegated to the hook that was installed
+/// before (libtest's capture hook, normally), and that hook is reinstated on
+/// drop.
+#[cfg(any(test, feature = "producer-fault-injection"))]
+#[must_use = "the injected panic is only silenced while the guard is alive"]
+pub fn silence_injected_panics() -> SilencedInjectedPanics {
+    let previous: std::sync::Arc<PanicHook> = std::sync::Arc::new(std::panic::take_hook());
+    let installed = previous.clone();
+    std::panic::set_hook(Box::new(move |info| {
+        if is_injected(info) {
+            return;
+        }
+        installed(info);
+    }));
+    SilencedInjectedPanics { previous }
+}
+
+/// Whether `info` describes the panic [`ProducerFault::before_batch_handoff`]
+/// raises. Matched on the payload STRING, so no real panic is ever swallowed.
+#[cfg(any(test, feature = "producer-fault-injection"))]
+fn is_injected(info: &std::panic::PanicHookInfo<'_>) -> bool {
+    let payload = info.payload();
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&'static str>().copied());
+    message.is_some_and(|m| m.contains(INJECTED_PANIC_MESSAGE))
+}
+
+/// Guard returned by [`silence_injected_panics`]; restores the previous hook.
+#[cfg(any(test, feature = "producer-fault-injection"))]
+pub struct SilencedInjectedPanics {
+    previous: std::sync::Arc<PanicHook>,
+}
+
+#[cfg(any(test, feature = "producer-fault-injection"))]
+impl Drop for SilencedInjectedPanics {
+    fn drop(&mut self) {
+        // `set_hook` needs an owned `Box`, and the previous hook is behind an
+        // `Arc` (it is borrowed by the filtering hook installed above), so it is
+        // reinstated through one thin delegating wrapper. Behaviourally identical;
+        // the only cost is a pointer hop per nested guard.
+        let previous = self.previous.clone();
+        std::panic::set_hook(Box::new(move |info| previous(info)));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -331,8 +331,9 @@ type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'sta
 /// failure message from this test or any test running in parallel, exactly the
 /// "masked assertion" failure mode. Panics whose payload does not carry
 /// [`INJECTED_PANIC_MESSAGE`] are delegated to the hook that was installed
-/// before (libtest's capture hook, normally), and that hook is reinstated on
-/// drop.
+/// before (libtest's capture hook, normally), and that hook is reinstated when
+/// this guard drops — EXCEPT on an unwinding drop, where restoring is skipped
+/// (see [`SilencedInjectedPanics::drop`]).
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[must_use = "the injected panic is only silenced while the guard is alive"]
 pub fn silence_injected_panics() -> SilencedInjectedPanics {
@@ -359,7 +360,8 @@ fn is_injected(info: &std::panic::PanicHookInfo<'_>) -> bool {
     message.is_some_and(|m| m.contains(INJECTED_PANIC_MESSAGE))
 }
 
-/// Guard returned by [`silence_injected_panics`]; restores the previous hook.
+/// Guard returned by [`silence_injected_panics`]; restores the previous hook on a
+/// normal drop (see [`Self::drop`] for the unwinding case).
 #[cfg(any(test, feature = "producer-fault-injection"))]
 pub struct SilencedInjectedPanics {
     previous: std::sync::Arc<PanicHook>,
@@ -368,6 +370,18 @@ pub struct SilencedInjectedPanics {
 #[cfg(any(test, feature = "producer-fault-injection"))]
 impl Drop for SilencedInjectedPanics {
     fn drop(&mut self) {
+        // NEVER touch the hook while unwinding (roborev, issue #3106):
+        // `std::panic::set_hook` PANICS if called from a panicking thread, so a
+        // guard still alive when an assertion (or any fallible call inside the
+        // silenced block) fails would double-panic and ABORT the process — under
+        // libtest's capture that loses the original message entirely and, in an
+        // integration-test binary, takes every sibling test's result with it.
+        // Skipping the restore leaves the filtering hook installed for the rest of
+        // the process, which is harmless: it only ever suppresses
+        // `INJECTED_PANIC_MESSAGE` and delegates everything else.
+        if std::thread::panicking() {
+            return;
+        }
         // `set_hook` needs an owned `Box`, and the previous hook is behind an
         // `Arc` (it is borrowed by the filtering hook installed above), so it is
         // reinstated through one thin delegating wrapper. Behaviourally identical;

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -1,49 +1,69 @@
-//! TEST-ONLY producer-fault injection for the query row stream (issue #3106).
+//! TEST-ONLY fault injection for the query row stream's two producer boundaries
+//! (issue #3106).
 //!
 //! # Why this exists
 //!
 //! The query row stream ([`crate::storage::sstable::reader::QueryRowStream`]) is
-//! fed by a detached producer thread over a bounded channel. Before issue #3106
-//! the consumer collapsed a channel DISCONNECT into a clean end of stream, so a
-//! producer thread that UNWOUND (a panic anywhere in the walk/decode, rather than
-//! an `Err` return) dropped its `SyncSender` without a terminal message and the
-//! request completed SUCCESSFULLY with a silently truncated result set. The fix
-//! makes completion explicit (a `Done` sentinel) and forwards a caught panic as a
-//! real error; this module is how a test PROVES that, deterministically, without
-//! waiting for a real decode bug to unwind.
+//! fed by a detached producer thread over a bounded channel, and on the full-ring
+//! arm that thread is in turn fed by an INNER `tokio` task over a second channel.
+//! Before issue #3106 BOTH boundaries collapsed a channel DISCONNECT into a clean
+//! end of stream, so a producer that UNWOUND (a panic anywhere in the walk/decode,
+//! rather than an `Err` return) dropped its sender without a terminal message and
+//! the request completed SUCCESSFULLY with a silently truncated result set. The
+//! fix makes completion explicit at both boundaries; this module is how a test
+//! PROVES that, deterministically, without waiting for a real decode bug to
+//! unwind.
+//!
+//! Two independent seams, one per boundary:
+//!
+//! * [`arm_query_row_producer_panic`] → the OUTER boundary: the query-row producer
+//!   THREAD panics at a batch handoff ([`ProducerFault::before_batch_handoff`],
+//!   consulted in `query_rows::emit_rows`).
+//! * [`arm_inner_scan_decode_panic`] → the INNER boundary: the batched-scan
+//!   `tokio` TASK panics inside a block decode ([`inner_scan_decode_checkpoint`],
+//!   consulted in `data_access::batched_scan_stream::SSTableReader::parse_batched_block`,
+//!   i.e. in the same task as `parse_block_entries_at_now`). This is the arm a
+//!   `do_get` with no token filter takes, so it is the issue's own repro.
 //!
 //! # Why this is not a production knob (no-heuristics safe)
 //!
 //! * Everything that can arm a fault is `#[cfg(any(test, feature =
 //!   "producer-fault-injection"))]`. In a default build the arming API does not
 //!   exist, the armed-state statics do not exist, [`ProducerFault`] is a
-//!   zero-sized struct with no fields, and [`ProducerFault::before_batch_handoff`]
-//!   compiles to an empty function — the production build is byte-identical to
-//!   one without this module's body.
-//! * No environment variable, config field or on-disk byte pattern can arm it:
-//!   the only way in is a Rust call to [`arm_query_row_producer_panic`], which is
-//!   compiled out of production builds. So it cannot influence a decoding
-//!   decision (issue #28) even accidentally.
+//!   zero-sized struct with no fields, and both checkpoints compile to empty
+//!   functions — the production build is byte-identical to one without this
+//!   module's body. The module itself is `pub(crate)`; only the test-only surface
+//!   is re-exported, so a default build publishes nothing from here.
+//! * No environment variable, config field or on-disk byte pattern can arm it: the
+//!   only way in is a Rust call to an arming function that does not exist in
+//!   production builds. So it cannot influence a decoding decision (issue #28)
+//!   even accidentally.
 //! * `cqlite-flight` enables the feature from its `[dev-dependencies]` (the same
 //!   convention `arrow-shape-corpus` / `test-util` already use), so the shipped
 //!   Flight binary never links it.
 //!
-//! # Arming semantics
+//! # Arming semantics — PROCESS-GLOBAL, caller serializes
 //!
-//! [`arm_query_row_producer_panic`] arms the NEXT query row stream opened
-//! ANYWHERE in the process — process-global rather than thread-local on purpose:
-//! the Flight `do_get` row route opens its stream on a `spawn_blocking` thread,
-//! not on the calling thread, so a thread-local arm could never reach the surface
-//! whose fail-closed behaviour is the point of the fix. To keep that
-//! deterministic:
+//! An arm is process-global rather than thread-local on purpose: the Flight
+//! `do_get` row route opens its stream on a `spawn_blocking` thread and drives the
+//! inner scan on yet another runtime, so a thread-local arm could never reach the
+//! surface whose fail-closed behaviour is the point of the fix.
 //!
-//! * The arm is TAKEN (consumed) by the first [`ProducerFault::capture`], i.e. by
-//!   exactly ONE stream, and is owned by that stream's producer thread from then
-//!   on — never re-read from a shared cell mid-walk.
-//! * [`arm_query_row_producer_panic`] holds a process-global lock for the
-//!   returned guard's lifetime, so two arming tests in one binary serialize.
-//! * A racing NON-arming stream that stole the arm makes the arming test FAIL
-//!   (it sees no error), never pass silently — the failure mode is loud.
+//! Consequently — exactly like [`crate::storage::read_path_probe`]'s
+//! process-global counters — **the caller must serialize**: one file = one test
+//! binary = one process is the strongest form, a mutex held across the armed
+//! window is the minimum. The arming functions deliberately return a plain
+//! `Send` disarm-on-drop guard and take NO internal lock, so a guard may be held
+//! across an `.await` without the `await_holding_lock` hazard; serialization is
+//! the test's own explicit business.
+//!
+//! Two properties keep the failure modes loud rather than silent:
+//!
+//! * The OUTER arm is TAKEN (consumed) by the first [`ProducerFault::capture`],
+//!   i.e. by exactly ONE stream, and is then owned by that stream's producer
+//!   thread — never re-read from a shared cell mid-walk.
+//! * A racing scan that stole an arm makes the arming test FAIL (it sees no
+//!   error), never pass silently.
 
 /// Producer-fault state captured ONCE when a query row stream is opened, then
 /// owned by that stream's producer thread.
@@ -58,17 +78,18 @@ pub(crate) struct ProducerFault {
 }
 
 impl ProducerFault {
-    /// Take whatever fault is armed for the next stream (nothing, in production).
+    /// Take whatever OUTER fault is armed for the next stream (nothing, in
+    /// production).
     pub(crate) fn capture() -> Self {
         Self {
             #[cfg(any(test, feature = "producer-fault-injection"))]
-            panic_after_batches: armed::take(),
+            panic_after_batches: armed::take_outer(),
         }
     }
 
-    /// Consulted by the producer immediately BEFORE it hands a batch to the
-    /// consumer — the single batch-handoff funnel both walk arms go through, so
-    /// an injected fault is observed identically on either.
+    /// Consulted by the producer THREAD immediately BEFORE it hands a batch to
+    /// the consumer — the single batch-handoff funnel both walk arms go through,
+    /// so an injected fault is observed identically on either.
     ///
     /// Panics ON PURPOSE once the armed batch budget is exhausted; that panic is
     /// the fault being injected, and it is what the producer's `catch_unwind`
@@ -83,14 +104,36 @@ impl ProducerFault {
             *remaining -= 1;
         }
     }
+
+    /// Build an OUTER fault state directly, WITHOUT touching the process-global
+    /// arm — so a unit test of this module's own logic can never race, or be
+    /// raced by, a sibling test in the same binary.
+    #[cfg(test)]
+    fn for_test(panic_after_batches: u64) -> Self {
+        Self {
+            panic_after_batches: Some(panic_after_batches),
+        }
+    }
 }
 
-/// The panic message [`ProducerFault::before_batch_handoff`] raises. Exported so
-/// a test can (a) assert the forwarded error carries it and (b) suppress exactly
-/// this panic in its panic hook without silencing a real one.
+/// Consulted by the INNER batched-scan task immediately before each block decode
+/// (`parse_batched_block`), so an armed fault unwinds THAT task — the boundary
+/// whose disconnect the query-row thread used to read as "the scan finished".
+///
+/// Panics ON PURPOSE when the armed decode budget is exhausted. Compiles to an
+/// empty function in a production build.
+#[inline]
+pub(crate) fn inner_scan_decode_checkpoint() {
+    #[cfg(any(test, feature = "producer-fault-injection"))]
+    armed::consume_inner_decode();
+}
+
+/// The panic message both checkpoints raise. Exported so a test can (a) assert
+/// the forwarded error carries it and (b) suppress exactly this panic in its
+/// panic hook without silencing a real one.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 pub const INJECTED_PANIC_MESSAGE: &str =
-    "cqlite test fault injection (issue #3106): query row stream producer thread panic";
+    "cqlite test fault injection (issue #3106): producer panic";
 
 #[cfg(any(test, feature = "producer-fault-injection"))]
 mod armed {
@@ -99,64 +142,118 @@ mod armed {
     /// No fault armed.
     const DISARMED: i64 = -1;
 
-    /// Batches the next opened stream may hand over before panicking, or
-    /// [`DISARMED`]. Written only by the arming API / its guard, and TAKEN by
-    /// `take` so exactly one stream can observe it.
-    static ARMED_BATCHES: AtomicI64 = AtomicI64::new(DISARMED);
+    /// Batches the next opened query row stream may hand over before its producer
+    /// thread panics, or [`DISARMED`]. TAKEN by `take_outer`, so exactly one
+    /// stream can observe it.
+    static OUTER_BATCHES: AtomicI64 = AtomicI64::new(DISARMED);
 
-    /// Serializes arming tests in one binary (see the module doc).
-    static ARM_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+    /// Block decodes the inner batched-scan task may perform before it panics, or
+    /// [`DISARMED`]. Decremented in place (the decode site has no per-scan state
+    /// to own it), which is why an arming caller must serialize — see the module
+    /// doc.
+    static INNER_DECODES: AtomicI64 = AtomicI64::new(DISARMED);
 
-    pub(super) fn arm(after_batches: u64) -> parking_lot::MutexGuard<'static, ()> {
-        let lock = ARM_LOCK.lock();
-        // Saturate rather than wrap: an absurd budget simply never fires, and a
-        // negative value would read as DISARMED.
-        ARMED_BATCHES.store(
-            i64::try_from(after_batches).unwrap_or(i64::MAX),
-            Ordering::SeqCst,
-        );
-        lock
+    /// Saturate rather than wrap: an absurd budget simply never fires, and a
+    /// negative value would read as `DISARMED`.
+    fn as_budget(count: u64) -> i64 {
+        i64::try_from(count).unwrap_or(i64::MAX)
     }
 
-    pub(super) fn disarm() {
-        ARMED_BATCHES.store(DISARMED, Ordering::SeqCst);
+    pub(super) fn arm_outer(after_batches: u64) {
+        OUTER_BATCHES.store(as_budget(after_batches), Ordering::SeqCst);
     }
 
-    pub(super) fn take() -> Option<u64> {
-        let armed = ARMED_BATCHES.swap(DISARMED, Ordering::SeqCst);
-        u64::try_from(armed).ok()
+    pub(super) fn disarm_outer() {
+        OUTER_BATCHES.store(DISARMED, Ordering::SeqCst);
+    }
+
+    pub(super) fn take_outer() -> Option<u64> {
+        u64::try_from(OUTER_BATCHES.swap(DISARMED, Ordering::SeqCst)).ok()
+    }
+
+    pub(super) fn arm_inner_decode(after_decodes: u64) {
+        INNER_DECODES.store(as_budget(after_decodes), Ordering::SeqCst);
+    }
+
+    pub(super) fn disarm_inner_decode() {
+        INNER_DECODES.store(DISARMED, Ordering::SeqCst);
+    }
+
+    /// Spend one decode from the inner budget, panicking when it is exhausted.
+    /// The budget is DISARMED before the panic so the unwind cannot re-enter and
+    /// so a retry/sibling scan is never hit by the same arm.
+    pub(super) fn consume_inner_decode() {
+        let remaining = INNER_DECODES.load(Ordering::SeqCst);
+        if remaining < 0 {
+            return;
+        }
+        if remaining == 0 {
+            disarm_inner_decode();
+            panic!("{}", super::INJECTED_PANIC_MESSAGE);
+        }
+        INNER_DECODES.store(remaining - 1, Ordering::SeqCst);
     }
 }
 
 /// Arm the NEXT query row stream opened in this process to panic in its producer
-/// thread just before it hands over batch number `after_batches` (0-based), so
+/// THREAD just before it hands over batch number `after_batches` (0-based), so
 /// `after_batches` batches reach the consumer and the walk then dies MID-STREAM.
 ///
-/// `0` kills the producer before its first handoff. The arm is disarmed when the
-/// returned guard is dropped (and consumed by the stream that captures it), and
-/// the guard serializes against any other arming caller in the same test binary.
+/// `0` kills the producer before its first handoff. Disarmed when the returned
+/// guard drops (and consumed by the stream that captures it). PROCESS-GLOBAL:
+/// the caller serializes (see the module doc).
 ///
 /// TEST-ONLY: this symbol does not exist unless `cfg(test)` or the
-/// `producer-fault-injection` feature is on (see the module doc).
+/// `producer-fault-injection` feature is on.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 #[must_use = "the fault stays armed only while the guard is alive"]
 pub fn arm_query_row_producer_panic(after_batches: u64) -> ArmedProducerPanic {
-    ArmedProducerPanic {
-        _lock: armed::arm(after_batches),
-    }
+    armed::arm_outer(after_batches);
+    ArmedProducerPanic
 }
 
-/// Guard returned by [`arm_query_row_producer_panic`]: disarms the fault and
-/// releases the arming lock on drop.
+/// Guard returned by [`arm_query_row_producer_panic`]: disarms on drop. Holds no
+/// lock, so it is safe to hold across an `.await`.
 #[cfg(any(test, feature = "producer-fault-injection"))]
-pub struct ArmedProducerPanic {
-    _lock: parking_lot::MutexGuard<'static, ()>,
-}
+#[derive(Debug)]
+pub struct ArmedProducerPanic;
 
 #[cfg(any(test, feature = "producer-fault-injection"))]
 impl Drop for ArmedProducerPanic {
     fn drop(&mut self) {
-        armed::disarm();
+        armed::disarm_outer();
+    }
+}
+
+/// Arm the INNER batched-scan task to panic inside block decode number
+/// `after_decodes` (0-based), i.e. in the same `tokio` task as
+/// `parse_block_entries_at_now`, so the task unwinds and drops its sender with no
+/// terminator.
+///
+/// `0` kills it on its first decode. Disarmed when the returned guard drops (and
+/// when the fault fires). PROCESS-GLOBAL and decremented at the decode site, so
+/// the caller MUST serialize against any sibling test that scans (see the module
+/// doc) — otherwise the sibling's scan spends the budget.
+///
+/// TEST-ONLY: this symbol does not exist unless `cfg(test)` or the
+/// `producer-fault-injection` feature is on.
+#[cfg(any(test, feature = "producer-fault-injection"))]
+#[must_use = "the fault stays armed only while the guard is alive"]
+pub fn arm_inner_scan_decode_panic(after_decodes: u64) -> ArmedInnerScanPanic {
+    armed::arm_inner_decode(after_decodes);
+    ArmedInnerScanPanic
+}
+
+/// Guard returned by [`arm_inner_scan_decode_panic`]: disarms on drop. Holds no
+/// lock, so it is safe to hold across an `.await`.
+#[cfg(any(test, feature = "producer-fault-injection"))]
+#[derive(Debug)]
+pub struct ArmedInnerScanPanic;
+
+#[cfg(any(test, feature = "producer-fault-injection"))]
+impl Drop for ArmedInnerScanPanic {
+    fn drop(&mut self) {
+        armed::disarm_inner_decode();
     }
 }
 
@@ -188,8 +285,8 @@ pub fn silence_injected_panics() -> SilencedInjectedPanics {
     SilencedInjectedPanics { previous }
 }
 
-/// Whether `info` describes the panic [`ProducerFault::before_batch_handoff`]
-/// raises. Matched on the payload STRING, so no real panic is ever swallowed.
+/// Whether `info` describes an injected fault panic. Matched on the payload
+/// STRING, so no real panic is ever swallowed.
 #[cfg(any(test, feature = "producer-fault-injection"))]
 fn is_injected(info: &std::panic::PanicHookInfo<'_>) -> bool {
     let payload = info.payload();
@@ -232,47 +329,55 @@ mod tests {
         }
     }
 
-    /// The arming contract, asserted in ONE critical section (a second arming
-    /// test would race this one for the process-global arm between its own
-    /// `arm`/`capture` calls):
-    ///
-    /// * the armed stream survives exactly its budget of handoffs, then panics;
-    /// * `capture` TAKES the arm, so a second stream opened under the same arm is
-    ///   clean — a fault can never leak into an unrelated later stream;
-    /// * dropping the guard disarms, so a finished test cannot poison a later one.
+    /// The OUTER budget semantics, asserted WITHOUT touching the process-global
+    /// arm (`for_test`), so this can never race a sibling test: the fault survives
+    /// exactly its budget of handoffs, then panics.
     #[test]
-    fn arming_applies_to_exactly_one_captured_stream_and_is_dropped_with_the_guard() {
-        let guard = arm_query_row_producer_panic(2);
-        let mut first = ProducerFault::capture();
-        let mut second = ProducerFault::capture();
-
-        // The armed stream survives exactly two handoffs, then dies. The panic
-        // is EXPECTED here, so the hook is silenced for the window and restored
-        // before any assertion runs (a silenced hook would hide a real failure
-        // message).
-        first.before_batch_handoff();
-        first.before_batch_handoff();
-        let previous_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
-        let died = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            first.before_batch_handoff();
-        }));
-        std::panic::set_hook(previous_hook);
+    fn an_armed_producer_fault_panics_after_exactly_its_budget() {
+        let mut fault = ProducerFault::for_test(2);
+        fault.before_batch_handoff();
+        fault.before_batch_handoff();
+        // The panic is EXPECTED, so only THIS message is silenced (a blanket hook
+        // would hide a real failure from a parallel test) and the previous hook is
+        // restored before the assertion runs.
+        let died = {
+            let _silence = silence_injected_panics();
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                fault.before_batch_handoff();
+            }))
+        };
         assert!(
             died.is_err(),
-            "the armed stream must panic on the handoff after its budget"
+            "the armed fault must panic on the handoff after its budget"
         );
+    }
 
-        // The second capture got nothing: the arm was already taken.
+    /// `capture` TAKES the process-global arm, so a fault can never leak into an
+    /// unrelated later stream, and dropping the guard disarms. Single test = one
+    /// critical section over the global (no sibling here arms it).
+    #[test]
+    fn the_global_arm_is_taken_by_one_capture_and_dropped_with_the_guard() {
+        let guard = arm_query_row_producer_panic(7);
+        let first = ProducerFault::capture();
+        let mut second = ProducerFault::capture();
+        assert_eq!(
+            first.panic_after_batches,
+            Some(7),
+            "the first capture takes the armed budget"
+        );
+        assert_eq!(
+            second.panic_after_batches, None,
+            "a second stream under the same arm is clean"
+        );
         for _ in 0..10 {
             second.before_batch_handoff();
         }
 
-        // And once the guard is gone, nothing is armed any more.
         drop(guard);
-        let mut later = ProducerFault::capture();
-        for _ in 0..10 {
-            later.before_batch_handoff();
-        }
+        assert_eq!(
+            ProducerFault::capture().panic_after_batches,
+            None,
+            "dropping the guard disarms, so a later stream is never poisoned"
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -2316,7 +2316,7 @@ impl SSTableManager {
         end_key: Option<&RowKey>,
         schema: Option<&crate::schema::TableSchema>,
         buffer_size: usize,
-    ) -> Result<tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>> {
+    ) -> Result<reader::BatchedScanStream> {
         let readers = self.resolve_table_readers(table_id).await;
 
         if readers.len() == 1 {
@@ -2350,13 +2350,13 @@ impl SSTableManager {
     fn rechunk_into_batches(
         mut per_row: tokio::sync::mpsc::Receiver<Result<(RowKey, ScanRow)>>,
         buffer_size: usize,
-    ) -> tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>> {
+    ) -> reader::BatchedScanStream {
         use reader::scan_stream_windowed::BATCH_EMIT_ROWS;
         // Bound the batch channel so its resident-row budget stays comparable to
         // the per-row surface's `buffer_size`, not `buffer_size * BATCH_EMIT_ROWS`.
         let cap = buffer_size.div_ceil(BATCH_EMIT_ROWS).max(1);
         let (tx, rx) = tokio::sync::mpsc::channel(cap);
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             let mut batch: Vec<(RowKey, ScanRow)> = Vec::with_capacity(BATCH_EMIT_ROWS);
             while let Some(item) = per_row.recv().await {
                 match item {
@@ -2387,7 +2387,7 @@ impl SSTableManager {
                 let _ = tx.send(Ok(batch)).await;
             }
         });
-        rx
+        reader::BatchedScanStream::new(rx, task)
     }
 
     /// Streaming scan under the `tombstones` feature.
@@ -2436,7 +2436,7 @@ impl SSTableManager {
         end_key: Option<&RowKey>,
         schema: Option<&crate::schema::TableSchema>,
         buffer_size: usize,
-    ) -> Result<tokio::sync::mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>> {
+    ) -> Result<reader::BatchedScanStream> {
         let per_row = self
             .scan_stream(table_id, start_key, end_key, schema, buffer_size)
             .await?;

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -188,22 +188,20 @@ mod tests {
     /// a parallel test is never masked.
     #[tokio::test]
     async fn a_dead_scan_task_is_reported_as_an_error_and_stays_one() {
+        // Held for the whole test: the guard filters ONLY the injected message and
+        // delegates every other panic to the previous hook, so an assertion failure
+        // below (here or in a parallel test) still prints. The task panics
+        // asynchronously, so a narrower scope would race the hook restore.
+        let _silence = crate::storage::producer_fault::silence_injected_panics();
         let (tx, rx) = mpsc::channel::<Result<Vec<(RowKey, ScanRow)>>>(4);
-        let task = {
-            let _silence = crate::storage::producer_fault::silence_injected_panics();
-            let task = tokio::spawn(async move {
-                // Deliver one batch, then die WITHOUT reporting — the exact shape
-                // the discarded `JoinHandle` used to turn into a clean EOS.
-                let _ = tx
-                    .send(Ok(vec![(RowKey::new(vec![1]), ScanRow::Row(Vec::new()))]))
-                    .await;
-                panic!("{}", crate::storage::producer_fault::INJECTED_PANIC_MESSAGE);
-            });
-            // Join here (under the silencer) so the panic is observed before the
-            // hook is restored; the handle's verdict is what `recv` re-joins.
-            let _ = (&task,);
-            task
-        };
+        let task = tokio::spawn(async move {
+            // Deliver one batch, then die WITHOUT reporting — the exact shape the
+            // discarded `JoinHandle` used to turn into a clean end of stream.
+            let _ = tx
+                .send(Ok(vec![(RowKey::new(vec![1]), ScanRow::Row(Vec::new()))]))
+                .await;
+            panic!("{}", crate::storage::producer_fault::INJECTED_PANIC_MESSAGE);
+        });
         let mut stream = BatchedScanStream::new(rx, task);
 
         assert!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -107,20 +107,35 @@ fn dead_scan_task_error(join_err: &tokio::task::JoinError) -> Error {
 }
 
 impl SSTableReader {
+    /// Open the batched streaming scan's cursor — the FIRST thing the driver task
+    /// does, on both the stitching and non-stitching branch.
+    ///
+    /// A named seam because it is the fixture-independent test-only fault
+    /// checkpoint for THIS task (issue #3106): the branch a given SSTable takes
+    /// depends on its on-disk format, so a checkpoint in either branch alone can
+    /// silently not fire. Killing the task here reproduces exactly the condition
+    /// the fix is about — the task's sender drops with no error and no terminator —
+    /// for any reader.
+    pub(super) async fn open_batched_scan_cursor(&self) -> Result<super::ScanCursor> {
+        crate::storage::producer_fault::inner_scan_task_checkpoint();
+        self.new_scan_cursor().await
+    }
+
     /// Decode one `Data.db` block for the batched (non-stitching) streaming scan.
     ///
     /// A named seam rather than an inline call for two reasons: it pins
-    /// `read_shadowing = true` for this scan in ONE place, and it is where the
-    /// test-only inner-boundary fault checkpoint lives (issue #3106) — arming it
-    /// unwinds the scan task exactly as a real decode panic would, which is how
-    /// the fail-closed join above is PROVEN rather than asserted by inspection.
+    /// `read_shadowing = true` for this scan in ONE place, and it is a second
+    /// test-only fault checkpoint for the same task (issue #3106) — arming past
+    /// the prelude unwinds the task in the DECODE, exactly as a real
+    /// `parse_block_entries_at_now` panic would, on a reader whose format takes
+    /// the non-stitching branch.
     pub(super) fn parse_batched_block(
         &self,
         block: &[u8],
         schema: Option<&crate::schema::TableSchema>,
         now_secs: Option<i64>,
     ) -> Result<Vec<(TableId, RowKey, ScanRow)>> {
-        crate::storage::producer_fault::inner_scan_decode_checkpoint();
+        crate::storage::producer_fault::inner_scan_task_checkpoint();
         self.parse_block_entries_at_now(block, schema, true, now_secs)
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -1,0 +1,126 @@
+//! The batched streaming scan's consumer handle — a channel whose close is
+//! PROVEN, not assumed (issue #3106).
+//!
+//! # The boundary this closes
+//!
+//! `scan_stream_batched_admitted` (`sequential.rs`) drives the scan in a spawned
+//! `tokio` task that owns the sending half of a bounded channel and reports a
+//! failure by sending `Err(..)`. Before this type it returned the bare
+//! `mpsc::Receiver` and DISCARDED the task's `JoinHandle`, so a task that
+//! UNWOUND — a decode panic in `parse_block_entries_at_now`, which on the
+//! non-stitching (uncompressed) branch runs directly inside that task, or any
+//! future panic on the walk — dropped its sender with no error and no terminator.
+//! Every consumer read that close as "the scan finished":
+//!
+//! * `query_rows::drive_full_scan_rows` returned `Ok(())`, its own thread then
+//!   sent the #3106 `Done` sentinel, and the Flight `do_get` completed
+//!   SUCCESSFULLY with a truncated result set — the #3106 defect exactly, one
+//!   layer below the channel #3106 first fixed, on the arm a `do_get` with no
+//!   token filter takes (i.e. the reported repro);
+//! * the query engine's streaming SELECT / aggregate folds
+//!   (`select_executor::streaming`, `stream_agg`, `executor::streaming_scan_rows`)
+//!   returned short row sets / wrong aggregates the same way.
+//!
+//! [`BatchedScanStream`] owns the handle instead, so a channel close is
+//! DISAMBIGUATED: the task is joined and a `JoinError` (panic or cancellation)
+//! surfaces as `Some(Err(..))` rather than `None`. This mirrors what the windowed
+//! sub-path already did internally for its own two child tasks
+//! (`scan_stream_windowed`'s `parse_task.await` / feed `join_err` arms map a
+//! `JoinError` to an error), so the two arms no longer diverge on whether a dead
+//! producer is an error.
+//!
+//! Consumers are unchanged: [`BatchedScanStream::recv`] has the same
+//! `async fn(&mut self) -> Option<Result<Vec<(RowKey, ScanRow)>>>` shape
+//! `mpsc::Receiver::recv` had, so every `while let Some(batch) = stream.recv().await`
+//! loop keeps working — and now fails closed.
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use super::super::SSTableReader;
+use crate::types::{ScanRow, TableId};
+use crate::{Error, Result, RowKey};
+
+/// Consumer handle for the batched streaming scan: the batch channel PLUS the
+/// driver task that feeds it, so end-of-stream is an observed fact.
+///
+/// Dropping it drops the receiver, which makes the driver task's next send fail
+/// and unwinds it cooperatively (the pre-existing backpressure/teardown
+/// behaviour); the task is deliberately NOT joined on drop, so an abandoned scan
+/// never blocks the consumer.
+pub struct BatchedScanStream {
+    rx: mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>,
+    /// The driver task. `Option` because it is JOINED — and therefore consumed —
+    /// the first time the channel reports close; a later `recv` on an
+    /// already-joined stream is a plain end of stream.
+    task: Option<JoinHandle<()>>,
+}
+
+impl BatchedScanStream {
+    /// Pair a batch channel with the task that drives it.
+    pub(in crate::storage::sstable) fn new(
+        rx: mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>,
+        task: JoinHandle<()>,
+    ) -> Self {
+        Self {
+            rx,
+            task: Some(task),
+        }
+    }
+
+    /// Next batch, or `None` at a PROVEN-clean end of stream.
+    ///
+    /// When the channel closes, the driver task is joined: a task that returned
+    /// normally yields `None` (the scan really finished), while a task that DIED
+    /// — panicked, or was cancelled/aborted — yields `Some(Err(..))`. That is the
+    /// whole point: a dead producer must never be indistinguishable from a
+    /// finished one (issue #3106).
+    pub async fn recv(&mut self) -> Option<Result<Vec<(RowKey, ScanRow)>>> {
+        if let Some(item) = self.rx.recv().await {
+            return Some(item);
+        }
+        // Channel closed: the driver dropped its sender. Join it to learn WHY.
+        // `take()` makes this happen exactly once — a second `recv` after a
+        // clean join is an ordinary end of stream.
+        let task = self.task.take()?;
+        match task.await {
+            Ok(()) => None,
+            Err(join_err) => Some(Err(dead_scan_task_error(&join_err))),
+        }
+    }
+}
+
+/// The fail-closed error for a batched-scan driver task that died without
+/// reporting (issue #3106).
+///
+/// [`Error::Internal`] (not `Corruption`, not `Storage`): nothing suggests the
+/// `Data.db` is bad — an internal invariant was violated — and `Internal` is
+/// `is_recoverable() == false`, which is honest for a deterministic failure that
+/// a retry would reproduce. The panic message is carried in the payload so the
+/// failure is diagnosable rather than anonymous.
+fn dead_scan_task_error(join_err: &tokio::task::JoinError) -> Error {
+    Error::internal(format!(
+        "batched scan stream: the scan task DIED without reporting ({join_err}) — \
+         the result set is TRUNCATED and cannot be reported as a complete scan \
+         (issue #3106)"
+    ))
+}
+
+impl SSTableReader {
+    /// Decode one `Data.db` block for the batched (non-stitching) streaming scan.
+    ///
+    /// A named seam rather than an inline call for two reasons: it pins
+    /// `read_shadowing = true` for this scan in ONE place, and it is where the
+    /// test-only inner-boundary fault checkpoint lives (issue #3106) — arming it
+    /// unwinds the scan task exactly as a real decode panic would, which is how
+    /// the fail-closed join above is PROVEN rather than asserted by inspection.
+    pub(super) fn parse_batched_block(
+        &self,
+        block: &[u8],
+        schema: Option<&crate::schema::TableSchema>,
+        now_secs: Option<i64>,
+    ) -> Result<Vec<(TableId, RowKey, ScanRow)>> {
+        crate::storage::producer_fault::inner_scan_decode_checkpoint();
+        self.parse_block_entries_at_now(block, schema, true, now_secs)
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -50,21 +50,32 @@ use crate::{Error, Result, RowKey};
 /// never blocks the consumer.
 pub struct BatchedScanStream {
     rx: mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>,
-    /// The driver task. `Option` because it is JOINED — and therefore consumed —
-    /// the first time the channel reports close.
-    task: Option<JoinHandle<()>>,
-    /// Whether the join already reported a DEAD task (issue #3106, roborev).
-    ///
-    /// Makes the failure STICKY, mirroring the sibling boundary
-    /// (`QueryRowStream::terminated`): the join can only happen once, so without
-    /// this a consumer that polls [`Self::recv`] again after the error would get a
-    /// bare `None` — which this type DEFINES as a proven-clean end of stream. That
-    /// would hand a retrying external consumer (this is public API, returned by
-    /// `SSTableManager`/`StorageEngine::scan_stream_batched`) exactly the silent
-    /// truncation the join exists to prevent. No in-tree consumer polls past an
-    /// error — all four propagate with `?` — so this is a contract guard, not a
-    /// live bug fix.
-    task_died: bool,
+    /// What is KNOWN about the driver task. See [`TaskState`] — the point of the
+    /// enum is that there is no representable "the handle is gone and I never saw
+    /// a verdict" state to accidentally read as success.
+    task: TaskState,
+}
+
+/// What [`BatchedScanStream`] knows about its driver task (issue #3106, roborev).
+///
+/// Modelled as a state machine rather than `Option<JoinHandle>` + a `died` flag
+/// because that pair had an UNREPRESENTED third state — handle taken, verdict not
+/// yet observed — which a cancelled join produced and which then read as a clean
+/// end of stream. Here every state either OWNS the handle (so the join can still
+/// be completed later) or carries an observed verdict.
+enum TaskState {
+    /// Not yet joined; the handle is still owned HERE. A cancelled `recv` leaves
+    /// the stream in this state, so the next `recv` can still join.
+    Running(JoinHandle<()>),
+    /// Joined, and the join returned `Ok(())`: the scan PROVABLY ran to
+    /// completion. The only state from which end-of-stream is reported.
+    Finished,
+    /// Joined, and the join returned a `JoinError` (panic or abort). STICKY: every
+    /// later `recv` re-reports the failure, mirroring the sibling boundary
+    /// (`QueryRowStream::terminated`), so a retrying consumer — this is public API,
+    /// returned by `SSTableManager`/`StorageEngine::scan_stream_batched` — can
+    /// never downgrade a dead task to a clean end of stream.
+    Died,
 }
 
 impl BatchedScanStream {
@@ -75,8 +86,7 @@ impl BatchedScanStream {
     ) -> Self {
         Self {
             rx,
-            task: Some(task),
-            task_died: false,
+            task: TaskState::Running(task),
         }
     }
 
@@ -90,21 +100,44 @@ impl BatchedScanStream {
     ///
     /// A dead task is STICKY: every subsequent call re-reports the failure, so
     /// polling again can never downgrade it to a clean end of stream.
+    ///
+    /// # Cancellation safety (issue #3106, roborev)
+    ///
+    /// This method is cancel-safe in the way that matters here: cancelling it
+    /// (`tokio::select!`, `timeout`, …) while it is awaiting the JOIN must not
+    /// lose the task's verdict. The handle is therefore polled IN PLACE — it is
+    /// never moved out of `self` before a result is observed — so a cancelled
+    /// `recv` leaves the stream in [`TaskState::Running`] and the next `recv`
+    /// simply joins again. Moving the handle out first (`self.task.take()?`) is
+    /// exactly what reintroduced the #3106 defect: the dropped handle DETACHED the
+    /// task, no verdict was ever recorded, and the following `recv` short-circuited
+    /// to a clean end of stream for a task that may have panicked.
     pub async fn recv(&mut self) -> Option<Result<Vec<(RowKey, ScanRow)>>> {
-        if self.task_died {
+        if let TaskState::Died = self.task {
             return Some(Err(dead_scan_task_error_after_report()));
         }
         if let Some(item) = self.rx.recv().await {
             return Some(item);
         }
         // Channel closed: the driver dropped its sender. Join it to learn WHY.
-        // `take()` makes the join happen exactly once; the `task_died` flag (not
-        // the absent handle) is what a later call reads.
-        let task = self.task.take()?;
-        match task.await {
-            Ok(()) => None,
+        let outcome = match &mut self.task {
+            // `JoinHandle: Future + Unpin`, so `&mut JoinHandle` is itself a
+            // future: awaiting it polls the join WITHOUT taking ownership. A
+            // cancellation here drops only this borrow.
+            TaskState::Running(handle) => handle.await,
+            // A proven-clean completion is the ONLY route to end-of-stream.
+            TaskState::Finished => return None,
+            TaskState::Died => return Some(Err(dead_scan_task_error_after_report())),
+        };
+        // No `.await` between observing the outcome and recording it, so the
+        // verdict cannot be lost to a cancellation.
+        match outcome {
+            Ok(()) => {
+                self.task = TaskState::Finished;
+                None
+            }
             Err(join_err) => {
-                self.task_died = true;
+                self.task = TaskState::Died;
                 Some(Err(dead_scan_task_error(&join_err)))
             }
         }
@@ -221,6 +254,123 @@ mod tests {
                  truncation, got: {msg}"
             );
         }
+    }
+
+    /// Build a stream whose task: sends one batch, CLOSES the channel, signals
+    /// that it has done so, then parks until released — so a `recv` that runs
+    /// after the close signal is guaranteed to be suspended in the JOIN, not in
+    /// the channel. `then_panic` decides how it finally exits.
+    ///
+    /// The close signal is what makes the cancellation test deterministic: without
+    /// it, a `recv` could be cancelled while still awaiting the channel, which
+    /// exercises nothing.
+    fn stream_parked_after_closing_the_channel(
+        then_panic: bool,
+    ) -> (
+        BatchedScanStream,
+        tokio::sync::oneshot::Receiver<()>,
+        tokio::sync::oneshot::Sender<()>,
+    ) {
+        let (tx, rx) = mpsc::channel::<Result<Vec<(RowKey, ScanRow)>>>(4);
+        let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let task = tokio::spawn(async move {
+            let _ = tx
+                .send(Ok(vec![(RowKey::new(vec![7]), ScanRow::Row(Vec::new()))]))
+                .await;
+            drop(tx);
+            let _ = closed_tx.send(());
+            let _ = release_rx.await;
+            if then_panic {
+                panic!("{}", crate::storage::producer_fault::INJECTED_PANIC_MESSAGE);
+            }
+        });
+        (BatchedScanStream::new(rx, task), closed_rx, release_tx)
+    }
+
+    /// Cancel a `recv` WHILE it is awaiting the join, then poll again.
+    ///
+    /// `biased` polls the `recv` first, so it runs to the join (the channel is
+    /// already closed and drained) and returns `Pending` because the task is
+    /// parked; the ready branch then completes the `select!` and DROPS the `recv`
+    /// future — a cancellation landing exactly on the join await.
+    async fn cancel_a_recv_mid_join(stream: &mut BatchedScanStream) {
+        tokio::select! {
+            biased;
+            _ = stream.recv() => panic!(
+                "test precondition: the join must still be pending — the driver \
+                 task is parked, so recv cannot have resolved"
+            ),
+            _ = std::future::ready(()) => {}
+        }
+    }
+
+    /// Issue #3106 (roborev blocker): a `recv` CANCELLED mid-join must not lose the
+    /// task's verdict. The pre-fix code moved the `JoinHandle` out of `self` before
+    /// awaiting it, so a cancellation dropped the handle (detaching the task) with
+    /// no verdict recorded — and the next `recv` short-circuited on the absent
+    /// handle to a clean end of stream for a task that then PANICKED. That is the
+    /// #3106 defect, re-entered through the door the fix built.
+    #[tokio::test]
+    async fn a_recv_cancelled_mid_join_still_reports_the_dead_task() {
+        let _silence = crate::storage::producer_fault::silence_injected_panics();
+        let (mut stream, closed, release) = stream_parked_after_closing_the_channel(true);
+
+        assert!(
+            matches!(stream.recv().await, Some(Ok(batch)) if batch.len() == 1),
+            "the batch produced before the task parked is delivered"
+        );
+        closed
+            .await
+            .expect("the task signals that it closed the channel");
+        cancel_a_recv_mid_join(&mut stream).await;
+
+        // Now let the parked task die. Its verdict must still be reachable.
+        release.send(()).expect("release the parked task");
+        for attempt in 0..3 {
+            let msg = stream
+                .recv()
+                .await
+                .expect(
+                    "a cancelled join must NOT lose the verdict: reporting a clean \
+                     end of stream here is issue #3106 reintroduced",
+                )
+                .expect_err("the task panicked, so this must be an error")
+                .to_string();
+            assert!(
+                msg.contains("DIED without reporting") && msg.contains("TRUNCATED"),
+                "attempt {attempt}: the error must name the dead task and the \
+                 truncation, got: {msg}"
+            );
+        }
+    }
+
+    /// The complement: a cancelled join must not be turned into a spurious error
+    /// either. Same cancellation, but the task then finishes NORMALLY — the stream
+    /// must report the clean end of stream it genuinely observed.
+    #[tokio::test]
+    async fn a_recv_cancelled_mid_join_still_reports_a_clean_finish_as_clean() {
+        let (mut stream, closed, release) = stream_parked_after_closing_the_channel(false);
+
+        assert!(
+            matches!(stream.recv().await, Some(Ok(_))),
+            "the batch arrives"
+        );
+        closed
+            .await
+            .expect("the task signals that it closed the channel");
+        cancel_a_recv_mid_join(&mut stream).await;
+
+        release.send(()).expect("release the parked task");
+        assert!(
+            stream.recv().await.is_none(),
+            "a task that ran to completion is a clean end of stream, even though an \
+             earlier recv was cancelled mid-join"
+        );
+        assert!(
+            stream.recv().await.is_none(),
+            "and stays clean on a later poll"
+        );
     }
 
     /// The control: a task that finishes normally yields the clean end of stream,

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -152,7 +152,7 @@ impl SSTableReader {
     /// terminator — for any reader, and the join that catches it wraps the whole
     /// task, so the property proven is branch-agnostic.
     pub(super) async fn open_batched_scan_cursor(&self) -> Result<super::ScanCursor> {
-        crate::storage::producer_fault::inner_scan_task_checkpoint();
+        crate::storage::producer_fault::inner_scan_task_checkpoint(|| self.file_path());
         self.new_scan_cursor().await
     }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -237,17 +237,28 @@ mod tests {
         });
         let mut stream = BatchedScanStream::new(rx, task);
 
+        let (first, rest) = {
+            let first = stream.recv().await;
+            let mut rest = Vec::new();
+            for _ in 0..3 {
+                rest.push(stream.recv().await);
+            }
+            (first, rest)
+        };
+        // The silencer (held above across every await that can raise the injected
+        // panic) is dropped here, BEFORE the assertions: restoring a panic hook
+        // from a panicking thread aborts the process, which would turn a
+        // legitimate failure below into an unreadable SIGABRT.
+        drop(_silence);
         assert!(
-            matches!(stream.recv().await, Some(Ok(batch)) if batch.len() == 1),
+            matches!(first, Some(Ok(batch)) if batch.len() == 1),
             "the batch produced before the task died is still delivered"
         );
-        for attempt in 0..3 {
-            let err = stream
-                .recv()
-                .await
+        for (attempt, outcome) in rest.into_iter().enumerate() {
+            let msg = outcome
                 .expect("a dead task must never report a clean end of stream")
-                .expect_err("it must be an error");
-            let msg = err.to_string();
+                .expect_err("it must be an error")
+                .to_string();
             assert!(
                 msg.contains("DIED without reporting") && msg.contains("TRUNCATED"),
                 "attempt {attempt}: the error must name the dead task and the \
@@ -313,7 +324,6 @@ mod tests {
     /// #3106 defect, re-entered through the door the fix built.
     #[tokio::test]
     async fn a_recv_cancelled_mid_join_still_reports_the_dead_task() {
-        let _silence = crate::storage::producer_fault::silence_injected_panics();
         let (mut stream, closed, release) = stream_parked_after_closing_the_channel(true);
 
         assert!(
@@ -325,12 +335,21 @@ mod tests {
             .expect("the task signals that it closed the channel");
         cancel_a_recv_mid_join(&mut stream).await;
 
-        // Now let the parked task die. Its verdict must still be reachable.
-        release.send(()).expect("release the parked task");
-        for attempt in 0..3 {
-            let msg = stream
-                .recv()
-                .await
+        // Now let the parked task die, and re-poll. The silencer is dropped BEFORE
+        // any assertion: restoring a panic hook from a panicking thread aborts the
+        // process, which would turn a legitimate failure below into an unreadable
+        // SIGABRT instead of a reported assertion.
+        let outcomes = {
+            let _silence = crate::storage::producer_fault::silence_injected_panics();
+            release.send(()).expect("release the parked task");
+            let mut outcomes = Vec::new();
+            for _ in 0..3 {
+                outcomes.push(stream.recv().await);
+            }
+            outcomes
+        };
+        for (attempt, outcome) in outcomes.into_iter().enumerate() {
+            let msg = outcome
                 .expect(
                     "a cancelled join must NOT lose the verdict: reporting a clean \
                      end of stream here is issue #3106 reintroduced",

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -51,9 +51,20 @@ use crate::{Error, Result, RowKey};
 pub struct BatchedScanStream {
     rx: mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>>,
     /// The driver task. `Option` because it is JOINED — and therefore consumed —
-    /// the first time the channel reports close; a later `recv` on an
-    /// already-joined stream is a plain end of stream.
+    /// the first time the channel reports close.
     task: Option<JoinHandle<()>>,
+    /// Whether the join already reported a DEAD task (issue #3106, roborev).
+    ///
+    /// Makes the failure STICKY, mirroring the sibling boundary
+    /// (`QueryRowStream::terminated`): the join can only happen once, so without
+    /// this a consumer that polls [`Self::recv`] again after the error would get a
+    /// bare `None` — which this type DEFINES as a proven-clean end of stream. That
+    /// would hand a retrying external consumer (this is public API, returned by
+    /// `SSTableManager`/`StorageEngine::scan_stream_batched`) exactly the silent
+    /// truncation the join exists to prevent. No in-tree consumer polls past an
+    /// error — all four propagate with `?` — so this is a contract guard, not a
+    /// live bug fix.
+    task_died: bool,
 }
 
 impl BatchedScanStream {
@@ -65,6 +76,7 @@ impl BatchedScanStream {
         Self {
             rx,
             task: Some(task),
+            task_died: false,
         }
     }
 
@@ -75,17 +87,26 @@ impl BatchedScanStream {
     /// — panicked, or was cancelled/aborted — yields `Some(Err(..))`. That is the
     /// whole point: a dead producer must never be indistinguishable from a
     /// finished one (issue #3106).
+    ///
+    /// A dead task is STICKY: every subsequent call re-reports the failure, so
+    /// polling again can never downgrade it to a clean end of stream.
     pub async fn recv(&mut self) -> Option<Result<Vec<(RowKey, ScanRow)>>> {
+        if self.task_died {
+            return Some(Err(dead_scan_task_error_after_report()));
+        }
         if let Some(item) = self.rx.recv().await {
             return Some(item);
         }
         // Channel closed: the driver dropped its sender. Join it to learn WHY.
-        // `take()` makes this happen exactly once — a second `recv` after a
-        // clean join is an ordinary end of stream.
+        // `take()` makes the join happen exactly once; the `task_died` flag (not
+        // the absent handle) is what a later call reads.
         let task = self.task.take()?;
         match task.await {
             Ok(()) => None,
-            Err(join_err) => Some(Err(dead_scan_task_error(&join_err))),
+            Err(join_err) => {
+                self.task_died = true;
+                Some(Err(dead_scan_task_error(&join_err)))
+            }
         }
     }
 }
@@ -106,36 +127,126 @@ fn dead_scan_task_error(join_err: &tokio::task::JoinError) -> Error {
     ))
 }
 
+/// Re-report for a consumer that keeps polling after the dead-task error. The
+/// `JoinError` is consumed by the join, so this restates the verdict rather than
+/// re-deriving it — what matters is that it is still an ERROR, never a clean end
+/// of stream.
+fn dead_scan_task_error_after_report() -> Error {
+    Error::internal(
+        "batched scan stream: the scan task DIED without reporting (already \
+         reported) — the result set is TRUNCATED and cannot be reported as a \
+         complete scan (issue #3106)",
+    )
+}
+
 impl SSTableReader {
     /// Open the batched streaming scan's cursor — the FIRST thing the driver task
-    /// does, on both the stitching and non-stitching branch.
+    /// does, ABOVE the `requires_chunk_stitching()` branch, i.e. on every format.
     ///
-    /// A named seam because it is the fixture-independent test-only fault
-    /// checkpoint for THIS task (issue #3106): the branch a given SSTable takes
-    /// depends on its on-disk format, so a checkpoint in either branch alone can
-    /// silently not fire. Killing the task here reproduces exactly the condition
-    /// the fix is about — the task's sender drops with no error and no terminator —
-    /// for any reader.
+    /// A named seam because it is the SINGLE test-only fault checkpoint for this
+    /// task (issue #3106), and it is here precisely because it is
+    /// format-branch-independent: a checkpoint inside either branch fires only for
+    /// the formats that take that branch, so it can silently not fire and leave a
+    /// test passing vacuously. Killing the task here reproduces exactly the
+    /// condition the fix is about — the task's sender drops with no error and no
+    /// terminator — for any reader, and the join that catches it wraps the whole
+    /// task, so the property proven is branch-agnostic.
     pub(super) async fn open_batched_scan_cursor(&self) -> Result<super::ScanCursor> {
         crate::storage::producer_fault::inner_scan_task_checkpoint();
         self.new_scan_cursor().await
     }
 
-    /// Decode one `Data.db` block for the batched (non-stitching) streaming scan.
+    /// Decode one `Data.db` block for the batched NON-STITCHING streaming scan,
+    /// pinning `read_shadowing = true` for this scan in ONE place.
     ///
-    /// A named seam rather than an inline call for two reasons: it pins
-    /// `read_shadowing = true` for this scan in ONE place, and it is a second
-    /// test-only fault checkpoint for the same task (issue #3106) — arming past
-    /// the prelude unwinds the task in the DECODE, exactly as a real
-    /// `parse_block_entries_at_now` panic would, on a reader whose format takes
-    /// the non-stitching branch.
+    /// Deliberately carries NO fault checkpoint (issue #3106, roborev): it is
+    /// reached only by readers whose format takes the non-stitching branch, and no
+    /// fixture in the tree does, so a checkpoint here would be an armable-but-never-
+    /// armed seam — latent confusion suggesting coverage that does not exist. The
+    /// task-level checkpoint in [`Self::open_batched_scan_cursor`] covers both
+    /// branches, which is what the join it proves is scoped to anyway.
     pub(super) fn parse_batched_block(
         &self,
         block: &[u8],
         schema: Option<&crate::schema::TableSchema>,
         now_secs: Option<i64>,
     ) -> Result<Vec<(TableId, RowKey, ScanRow)>> {
-        crate::storage::producer_fault::inner_scan_task_checkpoint();
         self.parse_block_entries_at_now(block, schema, true, now_secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #3106: a driver task that DIED is reported as an error, and that
+    /// verdict is STICKY — a consumer that keeps polling can never coax a
+    /// "proven-clean end of stream" `None` out of a dead scan.
+    ///
+    /// The task is killed with a real panic (the same unwind a decode bug would
+    /// produce); its console noise is silenced by message so a genuine failure in
+    /// a parallel test is never masked.
+    #[tokio::test]
+    async fn a_dead_scan_task_is_reported_as_an_error_and_stays_one() {
+        let (tx, rx) = mpsc::channel::<Result<Vec<(RowKey, ScanRow)>>>(4);
+        let task = {
+            let _silence = crate::storage::producer_fault::silence_injected_panics();
+            let task = tokio::spawn(async move {
+                // Deliver one batch, then die WITHOUT reporting — the exact shape
+                // the discarded `JoinHandle` used to turn into a clean EOS.
+                let _ = tx
+                    .send(Ok(vec![(RowKey::new(vec![1]), ScanRow::Row(Vec::new()))]))
+                    .await;
+                panic!("{}", crate::storage::producer_fault::INJECTED_PANIC_MESSAGE);
+            });
+            // Join here (under the silencer) so the panic is observed before the
+            // hook is restored; the handle's verdict is what `recv` re-joins.
+            let _ = (&task,);
+            task
+        };
+        let mut stream = BatchedScanStream::new(rx, task);
+
+        assert!(
+            matches!(stream.recv().await, Some(Ok(batch)) if batch.len() == 1),
+            "the batch produced before the task died is still delivered"
+        );
+        for attempt in 0..3 {
+            let err = stream
+                .recv()
+                .await
+                .expect("a dead task must never report a clean end of stream")
+                .expect_err("it must be an error");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("DIED without reporting") && msg.contains("TRUNCATED"),
+                "attempt {attempt}: the error must name the dead task and the \
+                 truncation, got: {msg}"
+            );
+        }
+    }
+
+    /// The control: a task that finishes normally yields the clean end of stream,
+    /// so the fail-closed join above cannot be passing for a trivial reason.
+    #[tokio::test]
+    async fn a_finished_scan_task_yields_a_clean_end_of_stream() {
+        let (tx, rx) = mpsc::channel::<Result<Vec<(RowKey, ScanRow)>>>(4);
+        let task = tokio::spawn(async move {
+            let _ = tx
+                .send(Ok(vec![(RowKey::new(vec![2]), ScanRow::Row(Vec::new()))]))
+                .await;
+        });
+        let mut stream = BatchedScanStream::new(rx, task);
+        assert!(
+            matches!(stream.recv().await, Some(Ok(_))),
+            "the batch arrives"
+        );
+        assert!(
+            stream.recv().await.is_none(),
+            "a task that returned normally is a clean end of stream"
+        );
+        assert!(
+            stream.recv().await.is_none(),
+            "and stays one on a later poll"
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -90,6 +90,7 @@ mod presence_verify;
 // First/last-key range short-circuit (issue #1576, C5): an authoritative
 // `[first_key, last_key]` bound check that answers out-of-range point reads as
 // absence before any bloom/Index.db/trie work.
+pub(in crate::storage::sstable::reader) mod batched_scan_stream;
 mod range_short_circuit;
 mod sequential;
 
@@ -101,8 +102,7 @@ pub use point_compaction::SinglePartitionCompaction;
 // Token-range bound pushed into the Summary-guided streaming walk (issue #2413
 // Option A). Re-exported to the crate so the flight warm merge can construct one
 // from its `TokenFilter`.
-pub use summary_scan::ScanTokenBound;
-pub use summary_scan::{QueryRowBatch, QueryRowStream};
+pub use summary_scan::{QueryRowBatch, QueryRowStream, ScanTokenBound};
 
 // Re-export the decompress-work counter so the sibling `scan_stream_windowed`
 // module (outside `data_access`) can increment it on the windowed-scan miss path

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -86,11 +86,11 @@ mod point_compaction;
 mod point_compaction_fail_safe_tests;
 // Opt-in presence-oracle false-negative verification method (issue #2163), kept
 // out of this already-large entry-point file (campsite rule, epic #1116).
+pub(in crate::storage::sstable::reader) mod batched_scan_stream;
 mod presence_verify;
 // First/last-key range short-circuit (issue #1576, C5): an authoritative
 // `[first_key, last_key]` bound check that answers out-of-range point reads as
 // absence before any bloom/Index.db/trie work.
-pub(in crate::storage::sstable::reader) mod batched_scan_stream;
 mod range_short_circuit;
 mod sequential;
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -597,7 +597,7 @@ impl SSTableReader {
             ScanAdmission::Exempt => None,
         };
 
-        let cursor = self.new_scan_cursor().await?;
+        let cursor = self.open_batched_scan_cursor().await?;
         let header_size = self.calculate_header_size();
         {
             let mut file_guard = cursor.file.lock().await;

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -14,6 +14,7 @@
 use super::super::scan_stream_windowed::scan_admission::{self, ScanAdmission};
 use super::super::scan_stream_windowed::{WindowedOut, BATCH_EMIT_ROWS};
 use super::super::SSTableReader;
+use super::batched_scan_stream::BatchedScanStream;
 use super::model::{
     sort_by_token_order, sort_by_token_order_with_meta, table_ids_match, SCAN_FOR_KEY_CALLS,
 };
@@ -523,7 +524,7 @@ impl SSTableReader {
         end_key: Option<RowKey>,
         schema: Option<crate::schema::TableSchema>,
         buffer_size: usize,
-    ) -> mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>> {
+    ) -> BatchedScanStream {
         self.scan_stream_batched_admitted(
             table_id,
             start_key,
@@ -552,14 +553,14 @@ impl SSTableReader {
         buffer_size: usize,
         admission: ScanAdmission,
         now_secs: Option<i64>,
-    ) -> mpsc::Receiver<Result<Vec<(RowKey, ScanRow)>>> {
+    ) -> BatchedScanStream {
         // The public channel carries BATCHES; sizing it to
         // `ceil(buffer_size / BATCH_EMIT_ROWS)` batches keeps the resident-row
         // budget of this channel comparable to the per-row surface's `buffer_size`
         // rather than `buffer_size * BATCH_EMIT_ROWS`.
         let cap = buffer_size.div_ceil(BATCH_EMIT_ROWS).max(1);
         let (tx, rx) = mpsc::channel(cap);
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             if let Err(e) = self
                 .run_scan_stream_batched(
                     table_id,
@@ -575,7 +576,7 @@ impl SSTableReader {
                 let _ = tx.send(Err(e)).await;
             }
         });
-        rx
+        BatchedScanStream::new(rx, task)
     }
 
     async fn run_scan_stream_batched(
@@ -651,12 +652,7 @@ impl SSTableReader {
                         return Err(e);
                     }
                 };
-                let entries = match self.parse_block_entries_at_now(
-                    &block,
-                    schema.as_ref(),
-                    true,
-                    now_secs,
-                ) {
+                let entries = match self.parse_batched_block(&block, schema.as_ref(), now_secs) {
                     Ok(entries) => entries,
                     Err(e) => {
                         if !batch.is_empty() {

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -683,3 +683,9 @@ impl<'a> BatchSink<'a> {
 #[cfg(test)]
 #[path = "query_rows_tests.rs"]
 mod tests;
+
+// Issue #3106 END-TO-END pin: a real walk whose real producer thread PANICS. Needs
+// the write engine to build its fixture, so it is gated on `write-support`.
+#[cfg(all(test, feature = "write-support"))]
+#[path = "query_rows_panic_tests.rs"]
+mod panic_tests;

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -59,6 +59,16 @@
 //!   flag is left intact so a fallback to the merge arm still works. Every batch
 //!   send also observes the bounded channel, and a dropped consumer breaks the
 //!   walk at its next send.
+//! * **A dead producer is an ERROR, never a clean end of stream (issue #3106).**
+//!   Completion is EXPLICIT: the producer thread's last act is to send
+//!   [`QueryRowMsg::Done`], and the consumer reports end-of-stream ONLY on that
+//!   sentinel. A bare channel disconnect — which is what an UNWINDING producer
+//!   leaves behind, since a panic drops the `SyncSender` without sending anything
+//!   — is reported as a hard error instead of "the walk finished". Belt and
+//!   braces: the thread body also runs under `catch_unwind`, so a panic is
+//!   forwarded as an INFORMATIVE terminal error naming the panic message rather
+//!   than a generic "the producer died". Before this, such a panic completed the
+//!   request SUCCESSFULLY with a silently truncated result set.
 
 use std::ops::ControlFlow;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
@@ -67,6 +77,7 @@ use std::sync::Arc;
 use super::super::super::SSTableReader;
 use super::super::full_index_stream::FullIndexStreamOutcome;
 use super::ScanTokenBound;
+use crate::storage::producer_fault::ProducerFault;
 use crate::storage::scan_cancel::ScanCancel;
 use crate::storage::sstable::reader::scan_stream_windowed::scan_admission::ScanAdmission;
 use crate::types::ScanRow;
@@ -95,12 +106,28 @@ pub enum QueryRowBatch {
     Unsupported,
 }
 
+/// One message on the producer→consumer channel (issue #3106).
+///
+/// INTERNAL: the terminator is deliberately NOT a [`QueryRowBatch`] variant, so
+/// no consumer can observe (or forget to handle) it — the sentinel exists purely
+/// to disambiguate "the walk finished" from "the producer died", which a bare
+/// channel disconnect cannot do.
+#[derive(Debug)]
+enum QueryRowMsg {
+    /// A batch, or the walk's terminal error.
+    Item(Result<QueryRowBatch>),
+    /// The producer finished its walk and is exiting normally. This is the ONLY
+    /// thing that makes [`QueryRowStream::next_batch`] report a clean end of
+    /// stream; a disconnect without it is a dead producer.
+    Done,
+}
+
 /// A pull-based, single-generation query row stream (issue #3058).
 ///
 /// Dropping it requests cancellation of the underlying walk; the producer thread
 /// then observes the cancel (or a failed send into the dropped channel) and exits.
 pub struct QueryRowStream {
-    rx: Receiver<Result<QueryRowBatch>>,
+    rx: Receiver<QueryRowMsg>,
     /// This stream's OWN cancellation flag — a CHILD of the caller's, never the
     /// caller's own clone (roborev, issue #3058).
     ///
@@ -113,19 +140,29 @@ pub struct QueryRowStream {
     /// caller's flag is bridged INTO this child (caller-cancel stops the walk)
     /// but never the other way round.
     child_cancel: ScanCancel,
+    /// Whether an EXPLICIT terminator has been observed (issue #3106): either the
+    /// [`QueryRowMsg::Done`] sentinel or a terminal `Err`.
+    ///
+    /// This is what makes a subsequent channel disconnect interpretable. Set →
+    /// the producer is known to have finished/failed on purpose, so the
+    /// disconnect is a clean end of stream. Unset → the sender was dropped
+    /// WITHOUT a terminator, which only an unwinding (or otherwise dead)
+    /// producer can do, so the stream fails closed rather than reporting a
+    /// silently truncated result set as success.
+    terminated: bool,
 }
 
 impl QueryRowStream {
     /// Block until the next message is available. `None` = the walk finished
-    /// (clean end of stream).
+    /// (clean end of stream), proven by the explicit [`QueryRowMsg::Done`]
+    /// sentinel — never inferred from a channel disconnect.
     ///
-    /// KNOWN GAP — issue #3106: a `recv` error also means "the sender was
-    /// dropped", which a producer-thread PANIC produces without any terminal
-    /// message, so an unwinding walk currently reports a clean (silently
-    /// truncated) end of stream rather than an error. The channel protocol needs
-    /// an explicit `Done` sentinel (or `catch_unwind` → `Err`) for a disconnect
-    /// without a terminator to be treated as corruption; #3106 owns that, for
-    /// this stream AND the k-way merge adapter, whose stance this matches.
+    /// A disconnect WITHOUT that sentinel means the producer thread died mid-walk
+    /// (issue #3106) and yields `Some(Err(..))`: the result set is truncated, and
+    /// truncation must never be reported as success. A producer PANIC normally
+    /// arrives as a terminal `Err` carrying the panic message (the thread body
+    /// runs under `catch_unwind`), so this arm is the backstop for a producer that
+    /// died in a way it could not report at all (e.g. an abort of the send itself).
     ///
     /// The blocking wait is timed into the per-request RECV-WAIT accumulator
     /// (`stream_subphase::time_recv`), exactly as the k-way merge's own recv site
@@ -137,8 +174,63 @@ impl QueryRowStream {
     /// its evidence base. Inert (no clock read) when no sub-phase sink is
     /// installed, and it never touches the value returned.
     pub fn next_batch(&mut self) -> Option<Result<QueryRowBatch>> {
-        crate::observability::stream_subphase::time_recv(|| self.rx.recv().ok())
+        let received = crate::observability::stream_subphase::time_recv(|| self.rx.recv());
+        match received {
+            Ok(QueryRowMsg::Item(item)) => {
+                // A terminal error ends the stream just as definitively as `Done`,
+                // so a caller that keeps polling after one gets a clean `None`
+                // rather than a spurious dead-producer error.
+                self.terminated |= item.is_err();
+                Some(item)
+            }
+            Ok(QueryRowMsg::Done) => {
+                self.terminated = true;
+                None
+            }
+            Err(_disconnected) if self.terminated => None,
+            Err(_disconnected) => {
+                self.terminated = true;
+                Some(Err(dead_producer_error()))
+            }
+        }
     }
+}
+
+/// The fail-closed error for a producer that disconnected without a terminator
+/// (issue #3106).
+///
+/// [`Error::Corruption`] rather than a softer variant on purpose: this is a
+/// violation of THIS stream's internal producer→consumer protocol, the same
+/// family as [`assert_nothing_emitted`], and the observable consequence is an
+/// incomplete result set that a caller must never mistake for a complete one.
+fn dead_producer_error() -> Error {
+    Error::corruption(
+        "query row stream: the producer thread disconnected WITHOUT its terminal \
+         Done sentinel — it died mid-walk, so the result set is TRUNCATED and \
+         cannot be reported as a complete scan (issue #3106)",
+    )
+}
+
+/// Turn a caught producer-thread panic into an INFORMATIVE terminal error
+/// (issue #3106).
+///
+/// The bare disconnect backstop can only say "the producer died"; catching the
+/// unwind lets the client see WHERE/WHY, which is the difference between a
+/// debuggable failure and a mystery. The panic payload is a `String`/`&str` for
+/// every `panic!`/assertion (the only other shapes are hand-rolled
+/// `panic_any`), so an unrecognized payload degrades to a named placeholder
+/// rather than being dropped.
+fn panicked_producer_error(payload: &(dyn std::any::Any + Send)) -> Error {
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&'static str>().copied())
+        .unwrap_or("<non-string panic payload>");
+    Error::Storage(format!(
+        "query row stream: the producer thread PANICKED mid-walk ({message}) — the \
+         result set is TRUNCATED and cannot be reported as a complete scan \
+         (issue #3106)"
+    ))
 }
 
 impl Drop for QueryRowStream {
@@ -171,7 +263,7 @@ impl SSTableReader {
         now_secs: i64,
         scan_cancel: ScanCancel,
     ) -> Result<QueryRowStream> {
-        let (tx, rx) = sync_channel::<Result<QueryRowBatch>>(QUERY_ROWS_CHANNEL_BATCHES);
+        let (tx, rx) = sync_channel::<QueryRowMsg>(QUERY_ROWS_CHANNEL_BATCHES);
         // This stream's own flag (see `QueryRowStream::child_cancel`): the walk
         // polls the CHILD, the caller's flag is bridged into it, and nothing ever
         // cancels the caller's.
@@ -180,37 +272,59 @@ impl SSTableReader {
             caller: scan_cancel,
             child: child_cancel.clone(),
         };
+        // Issue #3106: whatever fault a test armed is captured HERE (never
+        // re-read mid-walk) and owned by the producer thread. Always empty — and
+        // a zero-sized no-op — in a production build.
+        let mut fault = crate::storage::producer_fault::ProducerFault::capture();
         std::thread::Builder::new()
             .name("cqlite-query-rows".to_string())
             .spawn(move || {
                 let sender = tx.clone();
-                let outcome = (|| -> Result<()> {
-                    let rt = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .map_err(|e| {
-                            Error::Storage(format!(
-                                "query row stream: failed to create runtime: {e}"
-                            ))
-                        })?;
-                    rt.block_on(drive_query_rows(
-                        self,
-                        schema,
-                        token_bound,
-                        now_secs,
-                        &bridge,
-                        &tx,
-                    ))
-                })();
-                if let Err(e) = outcome {
-                    // Forward the terminal error (consumer may already be gone).
-                    let _ = sender.send(Err(e));
-                }
+                // Issue #3106: an UNWINDING walk must not look like a finished
+                // one. `AssertUnwindSafe` is sound here because nothing the
+                // closure touched is observed after an unwind: the reader,
+                // schema, parser buffers and cancel bridge are dropped, and the
+                // only thing used afterwards is `sender` — an mpsc `SyncSender`,
+                // which has no poisoning/broken-invariant state — to report the
+                // failure. The walk's own output is already downstream.
+                let outcome =
+                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> Result<()> {
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .map_err(|e| {
+                                Error::Storage(format!(
+                                    "query row stream: failed to create runtime: {e}"
+                                ))
+                            })?;
+                        rt.block_on(drive_query_rows(
+                            self,
+                            schema,
+                            token_bound,
+                            now_secs,
+                            &bridge,
+                            &tx,
+                            &mut fault,
+                        ))
+                    }));
+                // EXACTLY ONE terminal message on every exit path, so the
+                // consumer never has to infer completion from a disconnect.
+                let terminal = match outcome {
+                    Ok(Ok(())) => QueryRowMsg::Done,
+                    Ok(Err(e)) => QueryRowMsg::Item(Err(e)),
+                    Err(panic) => QueryRowMsg::Item(Err(panicked_producer_error(panic.as_ref()))),
+                };
+                // The consumer may already be gone; a failed send is fine.
+                let _ = sender.send(terminal);
             })
             .map_err(|e| {
                 Error::Storage(format!("query row stream: failed to spawn thread: {e}"))
             })?;
-        Ok(QueryRowStream { rx, child_cancel })
+        Ok(QueryRowStream {
+            rx,
+            child_cancel,
+            terminated: false,
+        })
     }
 
     /// Whether this reader has the components the single-generation streaming
@@ -311,14 +425,15 @@ async fn drive_query_rows(
     token_bound: Option<ScanTokenBound>,
     now_secs: i64,
     cancel: &CancelBridge,
-    tx: &SyncSender<Result<QueryRowBatch>>,
+    tx: &SyncSender<QueryRowMsg>,
+    fault: &mut ProducerFault,
 ) -> Result<()> {
     if token_bound.is_none() {
-        return drive_full_scan_rows(reader, schema, now_secs, cancel, tx).await;
+        return drive_full_scan_rows(reader, schema, now_secs, cancel, tx, fault).await;
     }
 
     let scan_cancel = cancel.child();
-    let mut sink = BatchSink::new(tx, cancel);
+    let mut sink = BatchSink::new(tx, cancel, fault);
 
     // Each walk gets its OWN short-lived emit closure so the `&mut sink` borrow
     // ends with the call — that is what lets the pre-emit guard below actually
@@ -361,8 +476,27 @@ async fn drive_query_rows(
     // Neither walk can serve this reader. Report it as the FIRST and ONLY
     // message, having emitted nothing — enforced, for the same reason.
     assert_nothing_emitted(sink.emitted, "before reporting Unsupported")?;
-    let _ = tx.send(Ok(QueryRowBatch::Unsupported));
+    let _ = tx.send(QueryRowMsg::Item(Ok(QueryRowBatch::Unsupported)));
     Ok(())
+}
+
+/// Hand ONE batch of rows to the consumer, returning `false` when the consumer
+/// has dropped the channel.
+///
+/// The SINGLE batch-handoff funnel for BOTH walk arms — which is exactly why the
+/// test-only producer-fault hook is consulted here (issue #3106): a fault armed
+/// against this stream is observed identically on the full-ring and the
+/// token-bounded arm, so neither can be fixed while the other silently truncates.
+/// [`ProducerFault::before_batch_handoff`] is a no-op (and `fault` a ZST) in a
+/// production build.
+fn emit_rows(
+    tx: &SyncSender<QueryRowMsg>,
+    fault: &mut ProducerFault,
+    rows: Vec<(RowKey, ScanRow)>,
+) -> bool {
+    fault.before_batch_handoff();
+    tx.send(QueryRowMsg::Item(Ok(QueryRowBatch::Rows(rows))))
+        .is_ok()
 }
 
 /// Fail closed when a walk reported `FellBack` AFTER handing rows to the sink.
@@ -445,7 +579,8 @@ async fn drive_full_scan_rows(
     schema: crate::schema::TableSchema,
     now_secs: i64,
     cancel: &CancelBridge,
-    tx: &SyncSender<Result<QueryRowBatch>>,
+    tx: &SyncSender<QueryRowMsg>,
+    fault: &mut ProducerFault,
 ) -> Result<()> {
     let table_id = reader.scan_table_id();
     let mut rx = reader.scan_stream_batched_admitted(
@@ -467,7 +602,7 @@ async fn drive_full_scan_rows(
         }
         cancel.child().check()?;
         let rows = msg?;
-        if tx.send(Ok(QueryRowBatch::Rows(rows))).is_err() {
+        if !emit_rows(tx, fault, rows) {
             // Consumer dropped: stop pulling (not an error).
             return Ok(());
         }
@@ -480,7 +615,7 @@ async fn drive_full_scan_rows(
 /// CALLER cancellation — into `ControlFlow::Break` so the walk stops instead of
 /// running to completion.
 struct BatchSink<'a> {
-    tx: &'a SyncSender<Result<QueryRowBatch>>,
+    tx: &'a SyncSender<QueryRowMsg>,
     /// The caller/child cancellation pair. The token-bounded walk polls the CHILD
     /// internally at its own cadence, but nothing there sees the CALLER's flag —
     /// so a client disconnect would otherwise only stop this walk once the
@@ -489,15 +624,23 @@ struct BatchSink<'a> {
     cancel: &'a CancelBridge,
     batch: Vec<(RowKey, ScanRow)>,
     emitted: u64,
+    /// Test-only producer-fault state for this stream (issue #3106); a ZST with
+    /// a no-op hook in a production build.
+    fault: &'a mut ProducerFault,
 }
 
 impl<'a> BatchSink<'a> {
-    fn new(tx: &'a SyncSender<Result<QueryRowBatch>>, cancel: &'a CancelBridge) -> Self {
+    fn new(
+        tx: &'a SyncSender<QueryRowMsg>,
+        cancel: &'a CancelBridge,
+        fault: &'a mut ProducerFault,
+    ) -> Self {
         Self {
             tx,
             cancel,
             batch: Vec::with_capacity(QUERY_ROWS_PER_BATCH),
             emitted: 0,
+            fault,
         }
     }
 
@@ -522,10 +665,11 @@ impl<'a> BatchSink<'a> {
         }
         let batch = std::mem::take(&mut self.batch);
         self.batch.reserve(QUERY_ROWS_PER_BATCH);
-        match self.tx.send(Ok(QueryRowBatch::Rows(batch))) {
-            Ok(()) => Ok(ControlFlow::Continue(())),
+        if emit_rows(self.tx, self.fault, batch) {
+            Ok(ControlFlow::Continue(()))
+        } else {
             // Consumer dropped: stop the walk (not an error).
-            Err(_) => Ok(ControlFlow::Break(())),
+            Ok(ControlFlow::Break(()))
         }
     }
 
@@ -536,119 +680,6 @@ impl<'a> BatchSink<'a> {
         Ok(())
     }
 }
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Roborev (issue #3058): the "`FellBack` is pre-emit only" contract is
-    /// ENFORCED, not assumed. Rows already handed to the sink (including an
-    /// under-full, still-buffered batch) must turn a second walk into a hard
-    /// corruption error rather than a silently duplicated result set.
-    #[test]
-    fn a_post_emit_fallback_fails_closed_instead_of_duplicating_rows() {
-        assert!(
-            assert_nothing_emitted(0, "before the full-index fallback walk").is_ok(),
-            "the pre-emit case is the normal fallback and must proceed"
-        );
-        let err = assert_nothing_emitted(1, "before the full-index fallback walk")
-            .expect_err("a post-emit fallback must fail closed");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("FellBack AFTER emitting"),
-            "the error must name the violated contract, got: {msg}"
-        );
-        assert!(
-            assert_nothing_emitted(127, "before reporting Unsupported").is_err(),
-            "a partially-filled batch (< QUERY_ROWS_PER_BATCH) still counts as emitted"
-        );
-    }
-
-    /// Roborev (issue #3058): a CALLER cancellation must reach the TOKEN-BOUNDED
-    /// walk too, at a batch boundary — not only once the consumer notices and
-    /// drops the stream (which on a wide partition is a whole batch later). The
-    /// caller's own flag must still be left un-cancelled (only the child is ever
-    /// cancelled), or the merge-arm fallback would be poisoned again.
-    #[test]
-    fn a_caller_cancellation_breaks_the_token_bound_sink_at_a_batch_boundary() {
-        let caller = ScanCancel::new();
-        let child = ScanCancel::new();
-        let bridge = CancelBridge {
-            caller: caller.clone(),
-            child: child.clone(),
-        };
-        let (tx, rx) = sync_channel::<Result<QueryRowBatch>>(QUERY_ROWS_CHANNEL_BATCHES);
-        let mut sink = BatchSink::new(&tx, &bridge);
-        let row = || (RowKey::new(vec![1]), ScanRow::Row(Vec::new()));
-
-        // A full batch with no cancellation flows through.
-        for _ in 0..QUERY_ROWS_PER_BATCH {
-            assert!(matches!(
-                sink.push(row()).expect("push"),
-                ControlFlow::Continue(())
-            ));
-        }
-        assert!(
-            matches!(rx.try_recv(), Ok(Ok(QueryRowBatch::Rows(b))) if b.len() == QUERY_ROWS_PER_BATCH),
-            "the first batch was handed to the consumer"
-        );
-
-        // Now the caller cancels. The next batch boundary must BREAK the walk.
-        caller.cancel();
-        let mut broke = false;
-        for _ in 0..QUERY_ROWS_PER_BATCH {
-            if matches!(sink.push(row()).expect("push"), ControlFlow::Break(())) {
-                broke = true;
-                break;
-            }
-        }
-        assert!(
-            broke,
-            "a caller cancellation must stop the token-bounded walk at the batch \
-             boundary, not only when the consumer drops the stream"
-        );
-        assert!(
-            child.is_cancelled(),
-            "the cancellation is propagated into the child so the walk's own poll \
-             aborts it promptly too"
-        );
-        assert!(
-            matches!(bridge.caller_result(), Err(Error::Cancelled)),
-            "a cancelled scan terminates with Cancelled, never a clean short stream"
-        );
-    }
-
-    /// The bridge is ONE-WAY: a caller cancellation stops the walk (via the
-    /// child), but nothing this stream does may cancel the caller's flag — the
-    /// fallback to the k-way merge arm depends on getting it back un-cancelled.
-    #[test]
-    fn the_cancel_bridge_is_one_way() {
-        let caller = ScanCancel::new();
-        let bridge = CancelBridge {
-            caller: caller.clone(),
-            child: ScanCancel::new(),
-        };
-        assert!(!bridge.poll_caller(), "no cancellation yet");
-        bridge.child().cancel();
-        assert!(
-            !caller.is_cancelled(),
-            "cancelling the CHILD must never reach the caller's flag"
-        );
-        assert!(!bridge.poll_caller(), "still no caller cancellation");
-
-        let caller2 = ScanCancel::new();
-        let bridge2 = CancelBridge {
-            caller: caller2.clone(),
-            child: ScanCancel::new(),
-        };
-        caller2.cancel();
-        assert!(
-            bridge2.poll_caller(),
-            "a caller cancellation stops the scan"
-        );
-        assert!(
-            bridge2.child().is_cancelled(),
-            "and is propagated into the child so the walk aborts promptly"
-        );
-    }
-}
+#[path = "query_rows_tests.rs"]
+mod tests;

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -75,9 +75,20 @@
 //!   `release-unwind` profile the bindings ship — `[profile.release]` is
 //!   `panic = "abort"`, where a panicking producer takes the process down instead,
 //!   loudly). The `Done` sentinel needs no unwinding at all: it makes "the walk
-//!   finished" an OBSERVED fact in every profile, so ANY way a producer can stop
+//!   finished" an OBSERVED fact in every profile, so any way THIS THREAD can stop
 //!   without reporting — a future exit path that forgets its terminator included —
 //!   fails closed rather than being read as a complete scan.
+//!
+//!   SCOPE, stated precisely (roborev, issue #3106): `Done` proves only that the
+//!   query-row THREAD ran to completion. It says nothing about that thread's own
+//!   upstream, and on the full-ring arm the rows come from an INNER `tokio` task
+//!   over a second channel — whose death this thread would report as a clean
+//!   walk. That boundary is closed separately and by the same principle, in
+//!   [`crate::storage::sstable::reader::BatchedScanStream`]: it owns the scan
+//!   task's `JoinHandle` and joins it when its channel closes, so a task that
+//!   died surfaces as an error there and reaches this thread as a normal `Err`
+//!   (hence a `Failed` terminator). The pair of boundaries is what makes the
+//!   end-to-end claim true; neither alone does.
 
 use std::ops::ControlFlow;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
@@ -123,8 +134,17 @@ pub enum QueryRowBatch {
 /// channel disconnect cannot do.
 #[derive(Debug)]
 enum QueryRowMsg {
-    /// A batch, or the walk's terminal error.
-    Item(Result<QueryRowBatch>),
+    /// A batch. Carries only `Ok` BY CONSTRUCTION (issue #3106, roborev): a
+    /// failure is [`QueryRowMsg::Failed`], so "this message ends the stream" is a
+    /// structural property of the variant rather than an unenforced invariant
+    /// about where an `Err` was built. Were a non-fatal mid-stream `Err` ever sent
+    /// as an `Item`, the consumer would mark the stream terminated and a LATER
+    /// genuine dead-producer disconnect would silently revert to a clean end of
+    /// stream — #3106 reintroduced with no test failing.
+    Item(QueryRowBatch),
+    /// The walk failed. TERMINAL: the producer sends exactly one of this or
+    /// [`QueryRowMsg::Done`], as its last act.
+    Failed(Error),
     /// The producer finished its walk and is exiting normally. This is the ONLY
     /// thing that makes [`QueryRowStream::next_batch`] report a clean end of
     /// stream; a disconnect without it is a dead producer.
@@ -185,12 +205,12 @@ impl QueryRowStream {
     pub fn next_batch(&mut self) -> Option<Result<QueryRowBatch>> {
         let received = crate::observability::stream_subphase::time_recv(|| self.rx.recv());
         match received {
-            Ok(QueryRowMsg::Item(item)) => {
-                // A terminal error ends the stream just as definitively as `Done`,
-                // so a caller that keeps polling after one gets a clean `None`
-                // rather than a spurious dead-producer error.
-                self.terminated |= item.is_err();
-                Some(item)
+            Ok(QueryRowMsg::Item(batch)) => Some(Ok(batch)),
+            Ok(QueryRowMsg::Failed(e)) => {
+                // Terminal by construction: a caller that keeps polling after it
+                // gets a clean `None`, not a spurious dead-producer error.
+                self.terminated = true;
+                Some(Err(e))
             }
             Ok(QueryRowMsg::Done) => {
                 self.terminated = true;
@@ -208,12 +228,16 @@ impl QueryRowStream {
 /// The fail-closed error for a producer that disconnected without a terminator
 /// (issue #3106).
 ///
-/// [`Error::Corruption`] rather than a softer variant on purpose: this is a
-/// violation of THIS stream's internal producer→consumer protocol, the same
-/// family as [`assert_nothing_emitted`], and the observable consequence is an
-/// incomplete result set that a caller must never mistake for a complete one.
+/// [`Error::Internal`] — ONE variant for both halves of this event (here and
+/// [`panicked_producer_error`]), chosen deliberately (roborev, issue #3106):
+/// nothing suggests the `Data.db` is bad, so `Corruption` would send an operator
+/// hunting a nonexistent bad file, and `Storage` is `is_recoverable() == true`
+/// (surfaced to consumers, e.g. the Node bindings' error mapping) which would
+/// advertise a deterministic internal failure as RETRYABLE. `Internal` is
+/// `is_recoverable() == false` and is the honest variant for a violated internal
+/// invariant.
 fn dead_producer_error() -> Error {
-    Error::corruption(
+    Error::internal(
         "query row stream: the producer thread disconnected WITHOUT its terminal \
          Done sentinel — it died mid-walk, so the result set is TRUNCATED and \
          cannot be reported as a complete scan (issue #3106)",
@@ -229,13 +253,16 @@ fn dead_producer_error() -> Error {
 /// every `panic!`/assertion (the only other shapes are hand-rolled
 /// `panic_any`), so an unrecognized payload degrades to a named placeholder
 /// rather than being dropped.
+///
+/// Same [`Error::Internal`] variant as [`dead_producer_error`] — one event, one
+/// variant, and not the `is_recoverable() == true` `Storage` this first used.
 fn panicked_producer_error(payload: &(dyn std::any::Any + Send)) -> Error {
     let message = payload
         .downcast_ref::<String>()
         .map(String::as_str)
         .or_else(|| payload.downcast_ref::<&'static str>().copied())
         .unwrap_or("<non-string panic payload>");
-    Error::Storage(format!(
+    Error::internal(format!(
         "query row stream: the producer thread PANICKED mid-walk ({message}) — the \
          result set is TRUNCATED and cannot be reported as a complete scan \
          (issue #3106)"
@@ -320,8 +347,8 @@ impl SSTableReader {
                 // consumer never has to infer completion from a disconnect.
                 let terminal = match outcome {
                     Ok(Ok(())) => QueryRowMsg::Done,
-                    Ok(Err(e)) => QueryRowMsg::Item(Err(e)),
-                    Err(panic) => QueryRowMsg::Item(Err(panicked_producer_error(panic.as_ref()))),
+                    Ok(Err(e)) => QueryRowMsg::Failed(e),
+                    Err(panic) => QueryRowMsg::Failed(panicked_producer_error(panic.as_ref())),
                 };
                 // The consumer may already be gone; a failed send is fine.
                 let _ = sender.send(terminal);
@@ -485,7 +512,7 @@ async fn drive_query_rows(
     // Neither walk can serve this reader. Report it as the FIRST and ONLY
     // message, having emitted nothing — enforced, for the same reason.
     assert_nothing_emitted(sink.emitted, "before reporting Unsupported")?;
-    let _ = tx.send(QueryRowMsg::Item(Ok(QueryRowBatch::Unsupported)));
+    let _ = tx.send(QueryRowMsg::Item(QueryRowBatch::Unsupported));
     Ok(())
 }
 
@@ -504,7 +531,7 @@ fn emit_rows(
     rows: Vec<(RowKey, ScanRow)>,
 ) -> bool {
     fault.before_batch_handoff();
-    tx.send(QueryRowMsg::Item(Ok(QueryRowBatch::Rows(rows))))
+    tx.send(QueryRowMsg::Item(QueryRowBatch::Rows(rows)))
         .is_ok()
 }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -87,8 +87,13 @@
 //!   [`crate::storage::sstable::reader::BatchedScanStream`]: it owns the scan
 //!   task's `JoinHandle` and joins it when its channel closes, so a task that
 //!   died surfaces as an error there and reaches this thread as a normal `Err`
-//!   (hence a `Failed` terminator). The pair of boundaries is what makes the
-//!   end-to-end claim true; neither alone does.
+//!   (hence a `Failed` terminator). Both boundaries are needed for the end-to-end
+//!   claim; neither alone suffices — and the claim is bounded to those two, NOT
+//!   universal: on the chunk-stitching branch there is a THIRD hop, the windowed
+//!   driver's batch forwarder, whose `JoinError` is deliberately discarded
+//!   (`scan_stream_windowed`'s `let _ = forwarder.await;`), so a panic there is
+//!   still invisible. Pre-existing and low-likelihood (the forwarder only moves
+//!   already-decoded batches), tracked as a follow-up rather than fixed here.
 
 use std::ops::ControlFlow;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -313,10 +313,12 @@ impl SSTableReader {
             caller: scan_cancel,
             child: child_cancel.clone(),
         };
-        // Issue #3106: whatever fault a test armed is captured HERE (never
-        // re-read mid-walk) and owned by the producer thread. Always empty — and
-        // a zero-sized no-op — in a production build.
-        let mut fault = crate::storage::producer_fault::ProducerFault::capture();
+        // Issue #3106: whatever fault a test armed FOR THIS READER is captured
+        // HERE (never re-read mid-walk) and owned by the producer thread. Always
+        // empty — and a zero-sized no-op whose scope closure is never called — in
+        // a production build.
+        let mut fault =
+            crate::storage::producer_fault::ProducerFault::capture_for(|| self.file_path());
         std::thread::Builder::new()
             .name("cqlite-query-rows".to_string())
             .spawn(move || {

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -69,6 +69,15 @@
 //!   forwarded as an INFORMATIVE terminal error naming the panic message rather
 //!   than a generic "the producer died". Before this, such a panic completed the
 //!   request SUCCESSFULLY with a silently truncated result set.
+//!
+//!   The two halves cover different builds ON PURPOSE, which is why both are
+//!   here: `catch_unwind` only fires under `panic = "unwind"` (dev/test, and the
+//!   `release-unwind` profile the bindings ship — `[profile.release]` is
+//!   `panic = "abort"`, where a panicking producer takes the process down instead,
+//!   loudly). The `Done` sentinel needs no unwinding at all: it makes "the walk
+//!   finished" an OBSERVED fact in every profile, so ANY way a producer can stop
+//!   without reporting — a future exit path that forgets its terminator included —
+//!   fails closed rather than being read as a complete scan.
 
 use std::ops::ControlFlow;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_panic_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_panic_tests.rs
@@ -1,0 +1,198 @@
+//! Issue #3106 — END-TO-END pin: a producer-thread PANIC mid-walk must FAIL the
+//! query row stream, never complete it with a silently truncated result set.
+//!
+//! This drives the REAL surface — `SSTableReader::open_query_row_stream` over a
+//! real SSTable, a real Summary-guided/full-index walk, a real detached producer
+//! thread — and kills that thread with a real `panic!` at a batch boundary via the
+//! deterministic test-only seam `storage::producer_fault`. A channel-level unit
+//! test (`query_rows_tests.rs`) cannot prove this: it never runs a producer
+//! thread, so it cannot show that an UNWINDING walk is what the consumer now
+//! reports as an error.
+//!
+//! The control arm matters as much as the fault arm: the same fixture is drained
+//! with NO fault armed first, so "the stream failed" is asserted against a known
+//! complete row count rather than against nothing (a fault that never fired, or a
+//! fixture that yields no rows, would otherwise pass vacuously).
+//!
+//! Included via `#[cfg(all(test, feature = "write-support"))] #[path = ...] mod
+//! panic_tests;` — the fixture is built with the write engine, and the file is
+//! separate to keep `query_rows.rs` under the campsite-rule size limit (#1116).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use super::*;
+use crate::platform::Platform;
+use crate::storage::producer_fault::{
+    arm_query_row_producer_panic, silence_injected_panics, INJECTED_PANIC_MESSAGE,
+};
+use crate::storage::write_engine::test_support::{create_test_mutation, create_test_schema};
+use crate::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use crate::Config;
+
+/// Partitions in the fixture. Must exceed [`QUERY_ROWS_PER_BATCH`] by enough that
+/// the walk hands over SEVERAL batches, so a fault armed after the first one kills
+/// the producer genuinely MID-stream (rows already delivered, rows still to come)
+/// — which is the case that used to be reported as a successful, complete scan.
+const PARTITIONS: i32 = 3 * QUERY_ROWS_PER_BATCH as i32;
+
+/// Batches the consumer is allowed to receive before the producer dies.
+const BATCHES_BEFORE_THE_PANIC: u64 = 1;
+
+/// A pinned read-time clock: never the wall clock, so TTL/expiry decisions in the
+/// walk are reproducible (this fixture writes no TTLs, but the pin is the rule).
+const NOW_SECS: i64 = 1_700_000_000;
+
+/// Write `PARTITIONS` single-row partitions and flush them as ONE SSTable
+/// generation, returning its `Data.db` path.
+fn flush_one_generation(temp_dir: &TempDir) -> PathBuf {
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        create_test_schema(),
+    );
+    let mut engine = WriteEngine::new(config).expect("write engine");
+    for id in 0..PARTITIONS {
+        engine
+            .write(create_test_mutation(id, &format!("row-{id}"), 1_000))
+            .expect("write");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(engine.flush())
+        .expect("flush")
+        .expect("flush wrote an SSTable")
+        .data_path
+}
+
+fn open_reader(path: &std::path::Path) -> Arc<SSTableReader> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        Arc::new(
+            SSTableReader::open(path, &config, platform)
+                .await
+                .expect("open reader"),
+        )
+    })
+}
+
+/// The FULL-RING token bound (`start == end`, per `ScanTokenBound::contains`).
+///
+/// Passing `Some(..)` selects the token-bounded arm, whose `BatchSink` batches at
+/// `QUERY_ROWS_PER_BATCH`; the bound itself excludes nothing, so the control arm
+/// still sees every partition.
+fn full_ring() -> ScanTokenBound {
+    ScanTokenBound {
+        start_excl: i64::MIN,
+        end_incl: i64::MIN,
+        wraparound: false,
+    }
+}
+
+fn open_stream(reader: &Arc<SSTableReader>) -> QueryRowStream {
+    Arc::clone(reader)
+        .open_query_row_stream(
+            create_test_schema(),
+            Some(full_ring()),
+            NOW_SECS,
+            ScanCancel::new(),
+        )
+        .expect("open query row stream")
+}
+
+/// How a drained stream ended, plus how many rows it delivered.
+struct Drained {
+    rows: usize,
+    /// `Some(message)` when the stream terminated with an ERROR; `None` when it
+    /// reported a clean end of stream.
+    error: Option<String>,
+}
+
+fn drain(mut stream: QueryRowStream) -> Drained {
+    let mut rows = 0;
+    loop {
+        match stream.next_batch() {
+            None => return Drained { rows, error: None },
+            Some(Ok(QueryRowBatch::Rows(batch))) => rows += batch.len(),
+            Some(Ok(QueryRowBatch::Unsupported)) => {
+                panic!(
+                    "test precondition: this reader must be servable by the \
+                     single-generation walk, but it reported Unsupported"
+                )
+            }
+            Some(Err(e)) => {
+                return Drained {
+                    rows,
+                    error: Some(e.to_string()),
+                }
+            }
+        }
+    }
+}
+
+/// The pin (issue #3106): with the producer thread killed mid-walk, the stream
+/// must terminate with an ERROR and a SHORT row count — not the clean end of
+/// stream that made a truncated result set indistinguishable from a complete one.
+#[test]
+fn a_producer_panic_mid_stream_fails_the_stream_instead_of_truncating_it_silently() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_path = flush_one_generation(&temp_dir);
+    let reader = open_reader(&data_path);
+
+    // Control arm: no fault armed. Establishes the COMPLETE row count and that a
+    // healthy walk still reports a clean end of stream (the `Done` sentinel).
+    let complete = drain(open_stream(&reader));
+    assert_eq!(
+        complete.error, None,
+        "a healthy walk must still end cleanly (the Done sentinel), not error"
+    );
+    assert_eq!(
+        complete.rows, PARTITIONS as usize,
+        "test precondition: the control drain must see EVERY written partition, \
+         or 'the faulted drain is short' would be vacuous"
+    );
+
+    // Fault arm: the producer thread panics just before its second batch handoff.
+    let faulted = {
+        // Silence ONLY the injected panic's console noise, and restore the
+        // previous hook before any assertion below runs.
+        let _silence = silence_injected_panics();
+        let _fault = arm_query_row_producer_panic(BATCHES_BEFORE_THE_PANIC);
+        drain(open_stream(&reader))
+    };
+
+    let message = faulted.error.expect(
+        "a producer thread that PANICKED mid-walk must terminate the stream with \
+         an ERROR — reporting a clean end of stream here is issue #3106, a \
+         silently truncated result set served as a successful scan",
+    );
+    assert!(
+        message.contains("PANICKED") && message.contains(INJECTED_PANIC_MESSAGE),
+        "the error must name the panic and carry its message so the failure is \
+         debuggable rather than a generic 'the producer died', got: {message}"
+    );
+    assert!(
+        message.contains("TRUNCATED"),
+        "the error must state that the result set is incomplete, got: {message}"
+    );
+    assert_eq!(
+        faulted.rows,
+        BATCHES_BEFORE_THE_PANIC as usize * QUERY_ROWS_PER_BATCH,
+        "exactly the batches handed over before the fault reach the consumer"
+    );
+    assert!(
+        faulted.rows < complete.rows,
+        "the faulted drain MUST be short of the complete {} rows — otherwise the \
+         fault never fired and this test proves nothing",
+        complete.rows
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_panic_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_panic_tests.rs
@@ -162,11 +162,19 @@ fn a_producer_panic_mid_stream_fails_the_stream_instead_of_truncating_it_silentl
     );
 
     // Fault arm: the producer thread panics just before its second batch handoff.
+    //
+    // The arm is SCOPED to this test's own `TempDir` path (issue #3106, roborev):
+    // this file compiles into the shared `cqlite-core` lib test binary, where
+    // libtest runs thousands of tests in parallel, so an UNSCOPED process-global
+    // arm could be consumed by a concurrent test's stream — and this test would
+    // then pass for the wrong reason. A `TempDir` path is unique per run, so no
+    // other reader can match it and no sibling can clobber the registration.
+    let scope = temp_dir.path().to_string_lossy().to_string();
     let faulted = {
         // Silence ONLY the injected panic's console noise, and restore the
         // previous hook before any assertion below runs.
         let _silence = silence_injected_panics();
-        let _fault = arm_query_row_producer_panic(BATCHES_BEFORE_THE_PANIC);
+        let _fault = arm_query_row_producer_panic(&scope, BATCHES_BEFORE_THE_PANIC);
         drain(open_stream(&reader))
     };
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
@@ -32,10 +32,10 @@ fn a_disconnect_without_the_done_sentinel_is_an_error_not_a_clean_end_of_stream(
     let mut stream = stream_over(rx);
 
     // One batch is delivered, then the producer "dies" mid-stream.
-    tx.send(QueryRowMsg::Item(Ok(QueryRowBatch::Rows(vec![(
+    tx.send(QueryRowMsg::Item(QueryRowBatch::Rows(vec![(
         RowKey::new(vec![1]),
         ScanRow::Row(Vec::new()),
-    )]))))
+    )])))
     .expect("send batch");
     drop(tx);
 
@@ -80,14 +80,16 @@ fn the_done_sentinel_is_the_only_clean_end_of_stream() {
     );
 }
 
-/// A terminal `Err` (the walk failed, or its panic was caught and forwarded)
-/// also terminates the protocol, so the following disconnect must not turn
-/// into a second, spurious dead-producer error that would mask the real one.
+/// A terminal [`QueryRowMsg::Failed`] (the walk failed, or its panic was caught
+/// and forwarded) also terminates the protocol, so the following disconnect must
+/// not turn into a second, spurious dead-producer error that would mask the real
+/// one. `Failed` is a DISTINCT variant, so "this message is terminal" is
+/// structural: an `Item` cannot carry an error at all.
 #[test]
 fn a_terminal_error_terminates_the_protocol() {
     let (tx, rx) = sync_channel::<QueryRowMsg>(QUERY_ROWS_CHANNEL_BATCHES);
     let mut stream = stream_over(rx);
-    tx.send(QueryRowMsg::Item(Err(Error::Storage("walk failed".into()))))
+    tx.send(QueryRowMsg::Failed(Error::internal("walk failed")))
         .expect("send error");
     drop(tx);
     let msg = stream
@@ -180,7 +182,7 @@ fn a_caller_cancellation_breaks_the_token_bound_sink_at_a_batch_boundary() {
         ));
     }
     assert!(
-        matches!(rx.try_recv(), Ok(QueryRowMsg::Item(Ok(QueryRowBatch::Rows(b)))) if b.len() == QUERY_ROWS_PER_BATCH),
+        matches!(rx.try_recv(), Ok(QueryRowMsg::Item(QueryRowBatch::Rows(b))) if b.len() == QUERY_ROWS_PER_BATCH),
         "the first batch was handed to the consumer"
     );
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
@@ -1,0 +1,244 @@
+//! Unit tests for the single-generation query ROW stream (`query_rows.rs`).
+//!
+//! Split out of `query_rows.rs` to keep that file under the campsite-rule size
+//! limit (epic #1116). Included via
+//! `#[cfg(test)] #[path = "query_rows_tests.rs"] mod tests;`, so these tests are
+//! a CHILD module of `query_rows` and reach its private protocol items
+//! (`QueryRowMsg`, `BatchSink`, `panicked_producer_error`, and
+//! `QueryRowStream`'s fields) directly.
+
+use super::*;
+
+/// Build a `QueryRowStream` around a raw channel so the CONSUMER half of the
+/// #3106 protocol can be asserted in isolation, including the case a real
+/// producer cannot be made to reach on demand (a sender dropped with no
+/// terminal message at all). The end-to-end proof over a real walk with a
+/// real panicking producer lives in `query_rows_panic_tests`.
+fn stream_over(rx: Receiver<QueryRowMsg>) -> QueryRowStream {
+    QueryRowStream {
+        rx,
+        child_cancel: ScanCancel::new(),
+        terminated: false,
+    }
+}
+
+/// Issue #3106: a producer that drops its sender WITHOUT the terminal `Done`
+/// sentinel — exactly what an unwinding producer thread leaves behind — must
+/// yield an ERROR, never the clean `None` that made a truncated result set
+/// look like a finished scan.
+#[test]
+fn a_disconnect_without_the_done_sentinel_is_an_error_not_a_clean_end_of_stream() {
+    let (tx, rx) = sync_channel::<QueryRowMsg>(QUERY_ROWS_CHANNEL_BATCHES);
+    let mut stream = stream_over(rx);
+
+    // One batch is delivered, then the producer "dies" mid-stream.
+    tx.send(QueryRowMsg::Item(Ok(QueryRowBatch::Rows(vec![(
+        RowKey::new(vec![1]),
+        ScanRow::Row(Vec::new()),
+    )]))))
+    .expect("send batch");
+    drop(tx);
+
+    assert!(
+        matches!(
+            stream.next_batch(),
+            Some(Ok(QueryRowBatch::Rows(rows))) if rows.len() == 1
+        ),
+        "the batch already produced is still delivered"
+    );
+    let err = stream
+        .next_batch()
+        .expect("a dead producer must NOT report a clean end of stream")
+        .expect_err("a dead producer must be an error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("WITHOUT its terminal") && msg.contains("TRUNCATED"),
+        "the error must name the violated protocol and the truncation, got: {msg}"
+    );
+    assert!(
+        stream.next_batch().is_none(),
+        "after the terminal error the stream is finished, not endlessly erroring"
+    );
+}
+
+/// The sentinel is what makes a clean end of stream OBSERVED rather than
+/// inferred: `Done` (and only `Done`) yields `None`, and the subsequent
+/// disconnect stays `None`.
+#[test]
+fn the_done_sentinel_is_the_only_clean_end_of_stream() {
+    let (tx, rx) = sync_channel::<QueryRowMsg>(QUERY_ROWS_CHANNEL_BATCHES);
+    let mut stream = stream_over(rx);
+    tx.send(QueryRowMsg::Done).expect("send Done");
+    assert!(
+        stream.next_batch().is_none(),
+        "the explicit terminator is a clean end of stream"
+    );
+    drop(tx);
+    assert!(
+        stream.next_batch().is_none(),
+        "the disconnect AFTER a Done sentinel stays a clean end of stream"
+    );
+}
+
+/// A terminal `Err` (the walk failed, or its panic was caught and forwarded)
+/// also terminates the protocol, so the following disconnect must not turn
+/// into a second, spurious dead-producer error that would mask the real one.
+#[test]
+fn a_terminal_error_terminates_the_protocol() {
+    let (tx, rx) = sync_channel::<QueryRowMsg>(QUERY_ROWS_CHANNEL_BATCHES);
+    let mut stream = stream_over(rx);
+    tx.send(QueryRowMsg::Item(Err(Error::Storage("walk failed".into()))))
+        .expect("send error");
+    drop(tx);
+    let msg = stream
+        .next_batch()
+        .expect("the terminal error is delivered")
+        .expect_err("it is an error")
+        .to_string();
+    assert!(
+        msg.contains("walk failed"),
+        "the real cause survives: {msg}"
+    );
+    assert!(
+        stream.next_batch().is_none(),
+        "the disconnect after a terminal error is not a second error"
+    );
+}
+
+/// A caught producer panic is forwarded with its MESSAGE, so the client gets
+/// an informative failure instead of a generic "the producer died".
+#[test]
+fn a_caught_panic_is_forwarded_with_its_message() {
+    let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("decode blew up"));
+    let msg = panicked_producer_error(payload.as_ref()).to_string();
+    assert!(
+        msg.contains("PANICKED") && msg.contains("decode blew up"),
+        "the panic message must reach the caller, got: {msg}"
+    );
+    let static_payload: Box<dyn std::any::Any + Send> = Box::new("static blew up");
+    assert!(
+        panicked_producer_error(static_payload.as_ref())
+            .to_string()
+            .contains("static blew up"),
+        "a &'static str payload (a bare panic!(\"…\")) is carried too"
+    );
+    let opaque: Box<dyn std::any::Any + Send> = Box::new(7u8);
+    assert!(
+        panicked_producer_error(opaque.as_ref())
+            .to_string()
+            .contains("non-string panic payload"),
+        "an unrecognized payload degrades to a named placeholder, not silence"
+    );
+}
+
+/// Roborev (issue #3058): the "`FellBack` is pre-emit only" contract is
+/// ENFORCED, not assumed. Rows already handed to the sink (including an
+/// under-full, still-buffered batch) must turn a second walk into a hard
+/// corruption error rather than a silently duplicated result set.
+#[test]
+fn a_post_emit_fallback_fails_closed_instead_of_duplicating_rows() {
+    assert!(
+        assert_nothing_emitted(0, "before the full-index fallback walk").is_ok(),
+        "the pre-emit case is the normal fallback and must proceed"
+    );
+    let err = assert_nothing_emitted(1, "before the full-index fallback walk")
+        .expect_err("a post-emit fallback must fail closed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("FellBack AFTER emitting"),
+        "the error must name the violated contract, got: {msg}"
+    );
+    assert!(
+        assert_nothing_emitted(127, "before reporting Unsupported").is_err(),
+        "a partially-filled batch (< QUERY_ROWS_PER_BATCH) still counts as emitted"
+    );
+}
+
+/// Roborev (issue #3058): a CALLER cancellation must reach the TOKEN-BOUNDED
+/// walk too, at a batch boundary — not only once the consumer notices and
+/// drops the stream (which on a wide partition is a whole batch later). The
+/// caller's own flag must still be left un-cancelled (only the child is ever
+/// cancelled), or the merge-arm fallback would be poisoned again.
+#[test]
+fn a_caller_cancellation_breaks_the_token_bound_sink_at_a_batch_boundary() {
+    let caller = ScanCancel::new();
+    let child = ScanCancel::new();
+    let bridge = CancelBridge {
+        caller: caller.clone(),
+        child: child.clone(),
+    };
+    let (tx, rx) = sync_channel::<QueryRowMsg>(QUERY_ROWS_CHANNEL_BATCHES);
+    let mut fault = ProducerFault::default();
+    let mut sink = BatchSink::new(&tx, &bridge, &mut fault);
+    let row = || (RowKey::new(vec![1]), ScanRow::Row(Vec::new()));
+
+    // A full batch with no cancellation flows through.
+    for _ in 0..QUERY_ROWS_PER_BATCH {
+        assert!(matches!(
+            sink.push(row()).expect("push"),
+            ControlFlow::Continue(())
+        ));
+    }
+    assert!(
+        matches!(rx.try_recv(), Ok(QueryRowMsg::Item(Ok(QueryRowBatch::Rows(b)))) if b.len() == QUERY_ROWS_PER_BATCH),
+        "the first batch was handed to the consumer"
+    );
+
+    // Now the caller cancels. The next batch boundary must BREAK the walk.
+    caller.cancel();
+    let mut broke = false;
+    for _ in 0..QUERY_ROWS_PER_BATCH {
+        if matches!(sink.push(row()).expect("push"), ControlFlow::Break(())) {
+            broke = true;
+            break;
+        }
+    }
+    assert!(
+        broke,
+        "a caller cancellation must stop the token-bounded walk at the batch \
+         boundary, not only when the consumer drops the stream"
+    );
+    assert!(
+        child.is_cancelled(),
+        "the cancellation is propagated into the child so the walk's own poll \
+         aborts it promptly too"
+    );
+    assert!(
+        matches!(bridge.caller_result(), Err(Error::Cancelled)),
+        "a cancelled scan terminates with Cancelled, never a clean short stream"
+    );
+}
+
+/// The bridge is ONE-WAY: a caller cancellation stops the walk (via the
+/// child), but nothing this stream does may cancel the caller's flag — the
+/// fallback to the k-way merge arm depends on getting it back un-cancelled.
+#[test]
+fn the_cancel_bridge_is_one_way() {
+    let caller = ScanCancel::new();
+    let bridge = CancelBridge {
+        caller: caller.clone(),
+        child: ScanCancel::new(),
+    };
+    assert!(!bridge.poll_caller(), "no cancellation yet");
+    bridge.child().cancel();
+    assert!(
+        !caller.is_cancelled(),
+        "cancelling the CHILD must never reach the caller's flag"
+    );
+    assert!(!bridge.poll_caller(), "still no caller cancellation");
+
+    let caller2 = ScanCancel::new();
+    let bridge2 = CancelBridge {
+        caller: caller2.clone(),
+        child: ScanCancel::new(),
+    };
+    caller2.cancel();
+    assert!(
+        bridge2.poll_caller(),
+        "a caller cancellation stops the scan"
+    );
+    assert!(
+        bridge2.child().is_cancelled(),
+        "and is propagated into the child so the walk aborts promptly"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -82,7 +82,7 @@ pub use data_access::ClusteringSlice;
 // Token-range bound pushed into the Summary-guided streaming walk (issue #2413
 // Option A) — used by the flight warm merge to scope a split's scan.
 pub use data_access::ScanTokenBound;
-pub use data_access::{QueryRowBatch, QueryRowStream};
+pub use data_access::{batched_scan_stream::BatchedScanStream, QueryRowBatch, QueryRowStream};
 // Single-partition compaction seek outcome (issue #2207). `not(tombstones)` like
 // the seek path it wraps.
 #[cfg(not(feature = "tombstones"))]

--- a/cqlite-core/src/storage/write_engine/merge/from_readers.rs
+++ b/cqlite-core/src/storage/write_engine/merge/from_readers.rs
@@ -50,6 +50,19 @@
 //! a generation's `Data.db` out from under a live `Arc` (evicting only its OWN
 //! reference, per #1749's fail-closed model) satisfies this trivially.
 //!
+//! ## KNOWN GAP — a dead producer reads as end-of-input (issue #3120)
+//!
+//! Neither producer-thread shape sends an explicit terminator, and
+//! `SSTableRowIteratorAdapter::next` (`mod.rs`) maps a channel DISCONNECT onto
+//! `None` = "this run is exhausted". So a producer thread that UNWINDS makes its
+//! run look finished, and the merge completes successfully having merged only the
+//! rows that reached the channel — a silently short read result, or a short
+//! rewritten SSTable on the compaction path. The query row stream's version of
+//! this defect was fixed in issue #3106 (explicit `Done` sentinel +
+//! `catch_unwind` forwarding the panic as a terminal error); the same treatment
+//! here is issue #3120, held separately because it also changes compaction
+//! semantics and needs the byte-parity write suite as its evidence base.
+//!
 //! UDT registry: [`SSTableRowIteratorAdapter::open`] (path-based) can call
 //! `reader.set_udt_registry(..)` because it just opened its OWN exclusive
 //! reader. `open_from_reader` CANNOT — the reader is shared (`Arc`), so no

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -80,8 +80,6 @@ mod maintenance;
 mod stats;
 #[cfg(feature = "write-support")]
 mod sweep;
-// `pub(crate)` (still test-only): the read-path #3106 producer-panic pin builds
-// its SSTable fixture with these same helpers, so the two do not drift.
 #[cfg(all(test, feature = "write-support"))]
 pub(crate) mod test_support;
 // Issue #1625: honest memtable hard-limit admission tests live in a sibling

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -80,8 +80,10 @@ mod maintenance;
 mod stats;
 #[cfg(feature = "write-support")]
 mod sweep;
+// `pub(crate)` (still test-only): the read-path #3106 producer-panic pin builds
+// its SSTable fixture with these same helpers, so the two do not drift.
 #[cfg(all(test, feature = "write-support"))]
-mod test_support;
+pub(crate) mod test_support;
 // Issue #1625: honest memtable hard-limit admission tests live in a sibling
 // module to avoid growing the already-oversized `mod.rs` (epic #1116/#1135).
 #[cfg(all(test, feature = "write-support"))]

--- a/cqlite-core/src/storage/write_engine/test_support.rs
+++ b/cqlite-core/src/storage/write_engine/test_support.rs
@@ -3,6 +3,12 @@
 //! Extracted verbatim from `write_engine/mod.rs` (issue #1120, epic #1116).
 //! These helpers are shared by the `mod`, `maintenance`, and `stats` test
 //! modules; per-module-only helpers stay local to their owning submodule.
+//!
+//! `pub(crate)` (still `#[cfg(test)]`-only) since issue #3106: the READ-path
+//! producer-panic pin
+//! (`sstable/reader/.../summary_scan/query_rows_panic_tests.rs`) needs a real
+//! single-generation SSTable, and building it with these same helpers is what
+//! keeps its fixture from drifting from the write engine's own.
 
 use super::{Mutation, TableSchema, WriteEngine};
 use crate::schema::{Column, KeyColumn};

--- a/cqlite-flight/Cargo.toml
+++ b/cqlite-flight/Cargo.toml
@@ -83,7 +83,16 @@ dhat-heap = []
 # estimator's conservatism contract is validated against — rather than a
 # hand-written subset, which is how the slack under-count reached a fail-closed
 # runtime check. Dev-only: `cargo build -p cqlite-flight` does not compile it.
-cqlite-core = { path = "../cqlite-core", features = ["arrow", "arrow-shape-corpus"] }
+# `producer-fault-injection` (issue #3106) additionally enables the TEST-ONLY
+# `storage::producer_fault` arming API, so `issue_3106_producer_panic_fails_closed`
+# can kill the single-source query row stream's producer thread mid-`do_get` and
+# prove the RPC fails closed instead of completing with a truncated result set.
+# Dev-only: `cargo build -p cqlite-flight` does not compile either flag.
+cqlite-core = { path = "../cqlite-core", features = [
+    "arrow",
+    "arrow-shape-corpus",
+    "producer-fault-injection",
+] }
 tempfile = { workspace = true }
 # `test-util` enables the paused/auto-advancing Tokio clock (`tokio::time::pause`)
 # so the #2420 admission-control tests drive the permit-wait timeout

--- a/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
+++ b/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
@@ -1,0 +1,276 @@
+//! Issue #3106 — WIRING evidence: a query-row-stream producer thread that dies
+//! mid-scan must FAIL the `do_get` RPC, not complete it with a silently truncated
+//! result set.
+//!
+//! # Why this test exists at the RPC surface
+//!
+//! The core-side pin (`cqlite-core`'s `query_rows_panic_tests`) proves the STREAM
+//! reports an error. That is necessary but not sufficient: the defect that shipped
+//! was a *consumer-side interpretation* — `cqlite-flight`'s single-source
+//! [`ScanRowSource`] mapped the stream's `None` onto `SourceStep::Complete`, i.e.
+//! "the scan finished", so a dead producer became a successful RPC with fewer rows
+//! than the table holds. The call chain under test is therefore the whole thing:
+//!
+//! ```text
+//! FlightService::do_get
+//!   → MergeProducer::produce_streaming_from_readers   (cqlite-flight/src/producer_warm.rs)
+//!     → bypass::ScanRowSource::open / next_step       (cqlite-flight/src/bypass.rs)
+//!       → QueryRowStream::next_batch                  (cqlite-core query_rows.rs)
+//!     → producer_stream::drive_row_source             (maps Err → ProducerError::Merge)
+//!   → streaming::spawn_streaming                      (ProducerError → tonic::Status)
+//! ```
+//!
+//! With the fix, `SourceStep::Complete` is reachable ONLY after the producer's
+//! explicit `Done` sentinel, so the client either sees every row or sees an error
+//! — never a short success.
+//!
+//! # Determinism
+//!
+//! The producer death is injected, not raced: `arm_query_row_producer_panic`
+//! (cqlite-core, test-only feature `producer-fault-injection`) makes the producer
+//! thread panic at a fixed batch boundary. The fixture is a SINGLE generation and
+//! the merge path is FORCED to `bypass`, so the single-source arm is definitely
+//! the one running; a control `do_get` with no fault armed establishes the
+//! complete row count first, so "the faulted RPC is short" cannot pass vacuously.
+//! No timing, sleeps or wall-clock thresholds are involved.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use arrow::array::{Array, Int32Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::StreamExt;
+use tokio::sync::Mutex;
+use tonic::Request;
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::producer_fault::{
+    arm_query_row_producer_panic, silence_injected_panics, INJECTED_PANIC_MESSAGE,
+};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_flight::bypass::MERGE_PATH_ENV;
+use cqlite_flight::service::CqliteFlightService;
+
+/// Partitions in the fixture. Must be large enough that the single-source walk
+/// hands the consumer SEVERAL batches, so a fault armed after the first one kills
+/// the producer genuinely mid-scan (rows already streamed to the client, rows
+/// still to come) — the case that used to be served as a complete scan.
+const PARTITIONS: i32 = 800;
+
+/// Batches the row source receives before its producer dies.
+const BATCHES_BEFORE_THE_PANIC: u64 = 1;
+
+/// Serializes the process-global fault arm + forced-path env var window.
+static FAULT_LOCK: Mutex<()> = Mutex::const_new(());
+
+const KS: &str = "panic_ks";
+const TBL: &str = "rows";
+const DDL: &str = "CREATE TABLE panic_ks.rows (pk int, v text, PRIMARY KEY (pk))";
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![column("pk", "int", false), column("v", "text", true)],
+        comments: Default::default(),
+        dropped_columns: Default::default(),
+    }
+}
+
+fn column(name: &str, ty: &str, nullable: bool) -> Column {
+    Column {
+        name: name.into(),
+        data_type: ty.into(),
+        nullable,
+        default: None,
+        is_static: false,
+    }
+}
+
+fn write(pk: i32, v: &str) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("pk", Value::Integer(pk)),
+        None,
+        vec![CellOperation::Write {
+            column: "v".into(),
+            value: Value::text(v),
+        }],
+        1_000,
+        None,
+    )
+}
+
+/// Flush `PARTITIONS` single-row partitions as ONE SSTable generation.
+async fn build_one_generation() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let config = WriteEngineConfig::new(data_dir.clone(), temp.path().join("wal"), schema());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for pk in 0..PARTITIONS {
+        engine
+            .write(write(pk, &format!("row-{pk}")))
+            .expect("write");
+    }
+    engine.flush().await.expect("flush").expect("flush info");
+    assert_eq!(
+        count_data_dbs(&data_dir),
+        1,
+        "the fixture must be exactly ONE generation, or the single-source arm \
+         under test is not the arm that runs"
+    );
+    (temp, data_dir)
+}
+
+fn count_data_dbs(data_dir: &std::path::Path) -> usize {
+    std::fs::read_dir(data_dir.join(KS).join(TBL))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .count()
+}
+
+fn ticket_bytes() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "keyspace": KS, "table": TBL, "ddl": DDL,
+    }))
+    .expect("ticket json")
+}
+
+/// How a `do_get` ended, plus the rows it actually delivered.
+struct Served {
+    rows: BTreeMap<i32, String>,
+    /// `Some(message)` when the RPC stream terminated with an ERROR; `None` when
+    /// it completed successfully.
+    error: Option<String>,
+}
+
+/// Drain a `do_get` WITHOUT panicking on a stream error — the whole point is to
+/// observe whether the RPC ends in success or failure.
+// arrow-flight's `FlightError` Err type has a framework-fixed large size; boxing
+// it (clippy's suggestion) would break the flight decoder stream API (#2856).
+#[allow(clippy::result_large_err)]
+async fn do_get_served(svc: &CqliteFlightService, ticket: Vec<u8>) -> Served {
+    let resp = svc
+        .do_get(Request::new(Ticket::new(ticket)))
+        .await
+        .expect("do_get setup succeeds")
+        .into_inner();
+    let mapped = resp.map(|r| r.map_err(|e| FlightError::ExternalError(Box::new(e))));
+    let mut stream = FlightRecordBatchStream::new_from_flight_data(mapped);
+    let mut rows = BTreeMap::new();
+    while let Some(batch) = stream.next().await {
+        match batch {
+            Ok(batch) => collect_rows(&batch, &mut rows),
+            Err(e) => {
+                return Served {
+                    rows,
+                    error: Some(e.to_string()),
+                }
+            }
+        }
+    }
+    Served { rows, error: None }
+}
+
+fn collect_rows(batch: &RecordBatch, out: &mut BTreeMap<i32, String>) {
+    let pk = batch
+        .column_by_name("pk")
+        .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+        .expect("pk is an Int32Array");
+    let v = batch
+        .column_by_name("v")
+        .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+        .expect("v is a StringArray");
+    for i in 0..batch.num_rows() {
+        out.insert(pk.value(i), v.value(i).to_string());
+    }
+}
+
+/// RAII guard for the process-global forced-path env var.
+struct ForcedPath;
+
+impl ForcedPath {
+    fn bypass() -> Self {
+        std::env::set_var(MERGE_PATH_ENV, "bypass");
+        Self
+    }
+}
+
+impl Drop for ForcedPath {
+    fn drop(&mut self) {
+        std::env::remove_var(MERGE_PATH_ENV);
+    }
+}
+
+/// The pin (issue #3106): with the single-source query row stream's producer
+/// thread killed mid-scan, `do_get` must terminate the client stream with an
+/// ERROR and a SHORT row set — never the successful completion that made a
+/// truncated result set indistinguishable from a complete one.
+#[tokio::test]
+async fn a_dead_query_row_producer_fails_the_do_get_instead_of_truncating_it_silently() {
+    let _serialized = FAULT_LOCK.lock().await;
+    let _forced = ForcedPath::bypass();
+    let (_temp, data_dir) = build_one_generation().await;
+    let svc = CqliteFlightService::new(data_dir, 8192);
+
+    // Control: no fault armed. Establishes the COMPLETE result set, and that the
+    // single-source arm serves this fixture successfully.
+    let complete = do_get_served(&svc, ticket_bytes()).await;
+    assert_eq!(
+        complete.error, None,
+        "the control do_get must succeed, or this fixture proves nothing"
+    );
+    assert_eq!(
+        complete.rows.len(),
+        PARTITIONS as usize,
+        "test precondition: the control do_get must return EVERY written row"
+    );
+
+    // Fault: the producer thread panics just before its second batch handoff.
+    let served = {
+        // Silence ONLY the injected panic's console noise; the previous hook is
+        // restored before any assertion below runs, so a real failure message is
+        // never masked.
+        let _silence = silence_injected_panics();
+        let _fault = arm_query_row_producer_panic(BATCHES_BEFORE_THE_PANIC);
+        do_get_served(&svc, ticket_bytes()).await
+    };
+
+    let message = served.error.expect(
+        "a dead query-row producer must FAIL the do_get — completing it is issue \
+         #3106: a silently truncated result set served to the client as a \
+         successful scan (SourceStep::Complete must be unreachable on a dead \
+         producer)",
+    );
+    assert!(
+        message.contains("PANICKED") && message.contains(INJECTED_PANIC_MESSAGE),
+        "the client-visible error must carry the producer's panic message, so the \
+         failure is diagnosable rather than a generic internal error, got: {message}"
+    );
+    assert!(
+        served.rows.len() < complete.rows.len(),
+        "the faulted RPC must be SHORT of the complete {} rows — otherwise the \
+         fault never fired and this test proves nothing (got {})",
+        complete.rows.len(),
+        served.rows.len()
+    );
+}

--- a/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
+++ b/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
@@ -279,6 +279,48 @@ async fn a_dead_query_row_producer_fails_the_do_get_instead_of_truncating_it_sil
     );
 }
 
+/// The SCOPING proof (issue #3106, roborev): an arm belonging to a DIFFERENT
+/// reader must never be consumed by this scan.
+///
+/// Both fault seams are process-global registries, and the in-`src` core panic
+/// test shares a test binary with thousands of parallel siblings, so "a
+/// concurrent scan cannot take my arm" has to be a property of the mechanism,
+/// not of test discipline. Here both arms are registered against a scope that
+/// matches no reader in this process; the `do_get` must therefore behave exactly
+/// as if nothing were armed — every row, no error — and the arms must still be
+/// registered afterwards (they are dropped un-taken).
+///
+/// This is the end-to-end complement of the unit-level scoping tests in
+/// `cqlite_core::storage::producer_fault`.
+#[tokio::test]
+async fn an_arm_scoped_to_another_reader_is_never_consumed_by_this_scan() {
+    let _serialized = FAULT_LOCK.lock().await;
+    let _forced = ForcedPath::bypass();
+    let (_temp, data_dir) = build_one_generation().await;
+    let svc = CqliteFlightService::new(data_dir, 8192);
+
+    let served = {
+        // A scope no reader in this process can match — the shape of a foreign
+        // test's arm racing this scan.
+        let foreign = "issue-3106-some-other-tests-keyspace/its-table";
+        let _outer = arm_query_row_producer_panic(foreign, BATCHES_BEFORE_THE_PANIC);
+        let _inner = arm_inner_scan_task_panic(foreign);
+        do_get_served(&svc, ticket_bytes()).await
+    };
+
+    assert_eq!(
+        served.error, None,
+        "a foreign-scoped arm must NOT fire here: if it can, an unrelated \
+         concurrent test could satisfy (or break) a panic-injection test, which is \
+         exactly the 'green but blind' failure mode #3106 keeps producing"
+    );
+    assert_eq!(
+        served.rows.len(),
+        PARTITIONS as usize,
+        "and the scan must return EVERY row, i.e. it ran completely untouched"
+    );
+}
+
 /// The SECOND boundary (issue #3106, rust-reviewer blocker): the full-ring arm's
 /// rows come from an INNER `tokio` task over its own channel
 /// (`scan_stream_batched_admitted`), and that task's death was likewise read as

--- a/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
+++ b/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
@@ -49,7 +49,8 @@ use tonic::Request;
 
 use cqlite_core::schema::{Column, KeyColumn, TableSchema};
 use cqlite_core::storage::producer_fault::{
-    arm_query_row_producer_panic, silence_injected_panics, INJECTED_PANIC_MESSAGE,
+    arm_inner_scan_task_panic, arm_query_row_producer_panic, silence_injected_panics,
+    INJECTED_PANIC_MESSAGE,
 };
 use cqlite_core::storage::write_engine::{
     CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
@@ -265,6 +266,74 @@ async fn a_dead_query_row_producer_fails_the_do_get_instead_of_truncating_it_sil
         message.contains("PANICKED") && message.contains(INJECTED_PANIC_MESSAGE),
         "the client-visible error must carry the producer's panic message, so the \
          failure is diagnosable rather than a generic internal error, got: {message}"
+    );
+    assert!(
+        served.rows.len() < complete.rows.len(),
+        "the faulted RPC must be SHORT of the complete {} rows — otherwise the \
+         fault never fired and this test proves nothing (got {})",
+        complete.rows.len(),
+        served.rows.len()
+    );
+}
+
+/// The SECOND boundary (issue #3106, rust-reviewer blocker): the full-ring arm's
+/// rows come from an INNER `tokio` task over its own channel
+/// (`scan_stream_batched_admitted`), and that task's death was likewise read as
+/// "the scan finished".
+///
+/// This is the arm the reported defect actually takes — this ticket carries NO
+/// token filter, so `producer_warm` passes `token_bound = None` and
+/// `drive_full_scan_rows` runs. The fault is injected INSIDE the inner task, in
+/// the block decode (`parse_batched_block` → `parse_block_entries_at_now`), which
+/// on this uncompressed/non-stitching fixture runs directly in that task: the task
+/// unwinds, drops its sender, and the outer query-row thread sees a plain channel
+/// close. Before the fix that meant `Ok(())` → the `Done` sentinel → a SUCCESSFUL
+/// truncated `do_get`; the outer channel's own protocol cannot see it, which is
+/// why the first test above passes either way.
+///
+/// Same control-arm-first shape: the complete result set is established with no
+/// fault armed, so "the faulted RPC is short" is never vacuous.
+#[tokio::test]
+async fn a_dead_inner_scan_task_fails_the_do_get_instead_of_truncating_it_silently() {
+    let _serialized = FAULT_LOCK.lock().await;
+    let _forced = ForcedPath::bypass();
+    let (_temp, data_dir) = build_one_generation().await;
+    let svc = CqliteFlightService::new(data_dir, 8192);
+
+    // Control: no fault armed. NOTE this also proves the fixture is served by the
+    // full-ring arm successfully, i.e. the inner batched-scan task is genuinely on
+    // the path being killed below.
+    let complete = do_get_served(&svc, ticket_bytes()).await;
+    assert_eq!(
+        complete.error, None,
+        "the control do_get must succeed, or this fixture proves nothing"
+    );
+    assert_eq!(
+        complete.rows.len(),
+        PARTITIONS as usize,
+        "test precondition: the control do_get must return EVERY written row"
+    );
+
+    // Fault: the inner scan task panics at its FIRST checkpoint (the cursor-open
+    // prelude), so it dies before it can report anything — the purest form of "the
+    // sender just went away", and reached whatever format branch this reader takes
+    // (a checkpoint in one branch only can silently not fire).
+    let served = {
+        let _silence = silence_injected_panics();
+        let _fault = arm_inner_scan_task_panic(0);
+        do_get_served(&svc, ticket_bytes()).await
+    };
+
+    let message = served.error.expect(
+        "a dead INNER batched-scan task must FAIL the do_get — completing it is \
+         issue #3106 one layer down: the query-row thread read the inner channel's \
+         close as 'the scan finished', sent its Done sentinel, and served a \
+         truncated result set as a successful full-table scan",
+    );
+    assert!(
+        message.contains("DIED without reporting") && message.contains("TRUNCATED"),
+        "the client-visible error must name the dead task and the truncation, so \
+         the failure is diagnosable, got: {message}"
     );
     assert!(
         served.rows.len() < complete.rows.len(),

--- a/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
+++ b/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
@@ -231,6 +231,9 @@ async fn a_dead_query_row_producer_fails_the_do_get_instead_of_truncating_it_sil
     let _serialized = FAULT_LOCK.lock().await;
     let _forced = ForcedPath::bypass();
     let (_temp, data_dir) = build_one_generation().await;
+    // Every fault below is SCOPED to this fixture's own path, so no other scan in
+    // the process can consume the arm and let this test pass for the wrong reason.
+    let scope = data_dir.to_string_lossy().to_string();
     let svc = CqliteFlightService::new(data_dir, 8192);
 
     // Control: no fault armed. Establishes the COMPLETE result set, and that the
@@ -252,7 +255,7 @@ async fn a_dead_query_row_producer_fails_the_do_get_instead_of_truncating_it_sil
         // restored before any assertion below runs, so a real failure message is
         // never masked.
         let _silence = silence_injected_panics();
-        let _fault = arm_query_row_producer_panic(BATCHES_BEFORE_THE_PANIC);
+        let _fault = arm_query_row_producer_panic(&scope, BATCHES_BEFORE_THE_PANIC);
         do_get_served(&svc, ticket_bytes()).await
     };
 
@@ -318,6 +321,9 @@ async fn a_dead_inner_scan_task_fails_the_do_get_instead_of_truncating_it_silent
     let _serialized = FAULT_LOCK.lock().await;
     let _forced = ForcedPath::bypass();
     let (_temp, data_dir) = build_one_generation().await;
+    // Every fault below is SCOPED to this fixture's own path, so no other scan in
+    // the process can consume the arm and let this test pass for the wrong reason.
+    let scope = data_dir.to_string_lossy().to_string();
     let svc = CqliteFlightService::new(data_dir, 8192);
 
     // Control: no fault armed. NOTE this also proves the fixture is served by the
@@ -340,7 +346,7 @@ async fn a_dead_inner_scan_task_fails_the_do_get_instead_of_truncating_it_silent
     // a checkpoint inside one branch can silently not fire).
     let served = {
         let _silence = silence_injected_panics();
-        let _fault = arm_inner_scan_task_panic();
+        let _fault = arm_inner_scan_task_panic(&scope);
         do_get_served(&svc, ticket_bytes()).await
     };
 

--- a/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
+++ b/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
@@ -283,13 +283,33 @@ async fn a_dead_query_row_producer_fails_the_do_get_instead_of_truncating_it_sil
 ///
 /// This is the arm the reported defect actually takes — this ticket carries NO
 /// token filter, so `producer_warm` passes `token_bound = None` and
-/// `drive_full_scan_rows` runs. The fault is injected INSIDE the inner task, in
-/// the block decode (`parse_batched_block` → `parse_block_entries_at_now`), which
-/// on this uncompressed/non-stitching fixture runs directly in that task: the task
-/// unwinds, drops its sender, and the outer query-row thread sees a plain channel
-/// close. Before the fix that meant `Ok(())` → the `Done` sentinel → a SUCCESSFUL
-/// truncated `do_get`; the outer channel's own protocol cannot see it, which is
-/// why the first test above passes either way.
+/// `drive_full_scan_rows` runs. The task unwinds, drops its sender, and the outer
+/// query-row thread sees a plain channel close. Before the fix that meant `Ok(())`
+/// → the `Done` sentinel → a SUCCESSFUL truncated `do_get`; the outer channel's
+/// own protocol cannot see it, which is why the first test above passes either
+/// way.
+///
+/// # Where the fault lands, and why that is enough
+///
+/// `arm_inner_scan_task_panic()` panics at the scan task's ONE checkpoint: its
+/// cursor-open PRELUDE (`batched_scan_stream::open_batched_scan_cursor`), NOT a
+/// block decode. That is chosen for FORMAT-BRANCH INDEPENDENCE. The task body
+/// branches on `requires_chunk_stitching()`, and this fixture is a CQLite-written
+/// `nb-*-big-Data.db`, which resolves to `CassandraVersion::V5_0NewBig` →
+/// `is_nb_format()` → **stitching branch** — so a checkpoint placed in the
+/// non-stitching block decode would never fire here, and an earlier draft of this
+/// very test passed VACUOUSLY for exactly that reason.
+///
+/// The property proven is nevertheless branch-agnostic: the join lives in
+/// `BatchedScanStream::recv`, wrapping the single `tokio::spawn` in
+/// `scan_stream_batched_admitted` — strictly ABOVE the `requires_chunk_stitching()`
+/// branch inside the task body — so a panic in EITHER branch surfaces as the
+/// identical `JoinError` on the identical code path.
+///
+/// What is therefore NOT covered end-to-end: a panic in the non-stitching branch's
+/// own decode, because no fixture in the tree takes that branch (it needs a reader
+/// whose format is not `nb`). Nothing about the fix is branch-specific, but do not
+/// read this test as evidence that the non-stitching decode has been exercised.
 ///
 /// Same control-arm-first shape: the complete result set is established with no
 /// fault armed, so "the faulted RPC is short" is never vacuous.
@@ -314,10 +334,10 @@ async fn a_dead_inner_scan_task_fails_the_do_get_instead_of_truncating_it_silent
         "test precondition: the control do_get must return EVERY written row"
     );
 
-    // Fault: the inner scan task panics at its FIRST checkpoint (the cursor-open
-    // prelude), so it dies before it can report anything — the purest form of "the
-    // sender just went away", and reached whatever format branch this reader takes
-    // (a checkpoint in one branch only can silently not fire).
+    // Fault: the inner scan task panics in its cursor-open prelude, so it dies
+    // before it can report anything — the purest form of "the sender just went
+    // away", and reached whatever format branch this reader takes (see the header:
+    // a checkpoint inside one branch can silently not fire).
     let served = {
         let _silence = silence_injected_panics();
         let _fault = arm_inner_scan_task_panic();

--- a/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
+++ b/cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs
@@ -320,7 +320,7 @@ async fn a_dead_inner_scan_task_fails_the_do_get_instead_of_truncating_it_silent
     // (a checkpoint in one branch only can silently not fire).
     let served = {
         let _silence = silence_injected_panics();
-        let _fault = arm_inner_scan_task_panic(0);
+        let _fault = arm_inner_scan_task_panic();
         do_get_served(&svc, ticket_bytes()).await
     };
 


### PR DESCRIPTION
Closes #3106

## Problem

`QueryRowStream::next_batch` was `self.rx.recv().ok()`, which collapses a **disconnected** channel into `None`. The Flight single-source row source mapped `None` → `SourceStep::Complete` — "the scan finished".

So if the producer thread **unwound** (a panic anywhere in the walk/decode rather than an `Err` return), the `SyncSender` dropped with no terminal message, the consumer read the disconnect as a clean end of stream, and `do_get` completed **successfully with a silently truncated result set**: no error, no log, fewer rows than the table holds.

Root cause: the channel protocol had no explicit terminator. "Sender dropped" was ambiguous between *walk finished* and *producer died*.

## Fix

Completion is now **explicit**, belt-and-braces:

- `QueryRowMsg::{Item, Done}` — the producer sends a `Done` sentinel; the consumer treats a disconnect **without** a sentinel as an error, never clean EOS.
- The producer thread body is wrapped in `catch_unwind`, which forwards the panic message as a terminal `Err` so the client gets an *informative* error rather than a generic "producer died".

Both are carried because `[profile.release]` is `panic = "abort"`, where `catch_unwind` never fires — so the **sentinel** is what makes completion an observed fact in every profile, and the unwind catch is the diagnosability layer on top.

## Wiring evidence

`SourceStep::Complete` is now reachable **only** after an observed `Done`. Call chain, exercised end-to-end by the Flight test (not asserted by inspection):

`FlightService::do_get` → `MergeProducer::produce_streaming_from_readers` → `bypass::ScanRowSource::next_step` → `QueryRowStream::next_batch` → `producer_stream::drive_row_source` (maps `Err` → `ProducerError::Merge`) → `streaming::spawn_streaming` → `tonic::Status`.

## Tests — both watched RED before the fix

Verified by temporarily restoring `recv().ok()` + no-forward semantics and confirming each test fails for the right reason, so neither can pass vacuously:

- `query_rows::panic_tests::a_producer_panic_mid_stream_fails_the_stream_instead_of_truncating_it_silently` — real producer thread, real walk, 384-row control drain.
- `cqlite-flight/tests/issue_3106_producer_panic_fails_closed.rs::a_dead_query_row_producer_fails_the_do_get_instead_of_truncating_it_silently` — asserts at the **RPC surface**.
- Plus 4 protocol unit tests in `query_rows_tests.rs`.

Panic injection is a test-only seam (`storage/producer_fault.rs`, non-default feature `producer-fault-injection`; ZST + empty fn in production — no production knob can flip it). Panic-hook noise is filtered **by message** and the hook is restored before every assertion, so a real unexpected panic is never swallowed.

## Scope: acceptance item 3 deferred, not dropped

Item 3 (same treatment for the k-way merge adapter, `write_engine/merge/from_readers.rs`) is **deferred to #3120** with a KNOWN GAP note in that file. It is disproportionate here: 17 call sites over a differently-shaped channel whose `channel_depth` sent/received balance keys on `msg.is_ok()`; `merge/mod.rs` is ~3.5k lines so any growth trips the file-size ratchet (needs an #1116 split first); and it changes **compaction** semantics, requiring the byte-parity write suite plus a second fault seam. The Flight read path under this PR does **not** route through the still-broken adapter for the case #3106 covers.

## Review status

- **roborev: NITS ONLY (2), no blockers.** Batched to a single linked follow-up per severity doctrine — nits never trigger a re-verify round. Neither touches correctness, wiring evidence, or no-heuristics.
- `rust-reviewer` pass reported separately in a comment.
- Lite gate PASS (`tree-integrity: PASS`). The **full gate of record** runs once, pre-merge, in `flow-closer`.

Note for the reviewer-tooling folks: this run reproduced the **#2964** display symptom — roborev printed the *base* SHA (`f603c7f`) in `Enqueued job`/`list` while the review content was unambiguously the branch diff. Non-vacuity was confirmed by the review citing symbols that exist only on branch HEAD.
