### PR TITLE
fix(#3097): merge-arm query enumeration honours the caller's authoritative schema

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -595,7 +595,7 @@ impl SSTableReader {
         // and would hit the no-schema `parse_block_entries` error; the stitch+parse
         // drain below decodes BTI correctly (as `bti_scan_with_metadata` does).
         if !self.requires_chunk_stitching() && self.bti_partitions_db.is_none() {
-            self.stream_all_partitions_cancellable(scan_cancel, schema, |(key, value)| {
+            self.stream_all_partitions_cancellable(scan_cancel, |(key, value)| {
                 let row =
                     super::super::compaction_row::CompactionRow::from_legacy_value(key, value, 0);
                 emit(row)

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -595,7 +595,7 @@ impl SSTableReader {
         // and would hit the no-schema `parse_block_entries` error; the stitch+parse
         // drain below decodes BTI correctly (as `bti_scan_with_metadata` does).
         if !self.requires_chunk_stitching() && self.bti_partitions_db.is_none() {
-            self.stream_all_partitions_cancellable(scan_cancel, |(key, value)| {
+            self.stream_all_partitions_cancellable(scan_cancel, schema, |(key, value)| {
                 let row =
                     super::super::compaction_row::CompactionRow::from_legacy_value(key, value, 0);
                 emit(row)

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -595,7 +595,7 @@ impl SSTableReader {
         // and would hit the no-schema `parse_block_entries` error; the stitch+parse
         // drain below decodes BTI correctly (as `bti_scan_with_metadata` does).
         if !self.requires_chunk_stitching() && self.bti_partitions_db.is_none() {
-            self.stream_all_partitions_cancellable(scan_cancel, |(key, value)| {
+            self.stream_all_partitions_cancellable(scan_cancel, None, |(key, value)| {
                 let row =
                     super::super::compaction_row::CompactionRow::from_legacy_value(key, value, 0);
                 emit(row)

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -404,19 +404,9 @@ impl SSTableReader {
     /// post-reconciliation early break (`drive_merge`) stops pulling, and the
     /// cancel-aware Drop teardown (cancel → drop receiver → join) then stops the
     /// producer promptly — bounding work WITHOUT any risk of under-return.
-    ///
-    /// `caller_schema` (issue #3097): the caller's AUTHORITATIVE schema, threaded
-    /// on to [`stream_all_partitions_via_full_index`](Self::stream_all_partitions_via_full_index)
-    /// so a `V5_0Uncompressed` reader (whose `nb` header carries no embedded
-    /// schema, hence a header-derived schema whose clustering columns bear the
-    /// placeholder `clustering_key` name) decodes clustering columns under the
-    /// caller's real names. `None` keeps the reader's own four-tier lookup — which
-    /// is exactly what the compaction caller passes today, so its byte-parity
-    /// resolution is unchanged.
     pub(in crate::storage::sstable::reader) async fn stream_all_partitions_cancellable<F>(
         &self,
         scan_cancel: &ScanCancel,
-        caller_schema: Option<&TableSchema>,
         mut emit: F,
     ) -> Result<()>
     where
@@ -424,7 +414,7 @@ impl SSTableReader {
     {
         if self.index_reader.is_some() && self.bti_partitions_db.is_none() {
             match self
-                .stream_all_partitions_via_full_index(scan_cancel, None, caller_schema, &mut emit)
+                .stream_all_partitions_via_full_index(scan_cancel, None, None, &mut emit)
                 .await?
             {
                 FullIndexStreamOutcome::Streamed => return Ok(()),
@@ -450,10 +440,7 @@ impl SSTableReader {
         // results, one call per RETURNED ROW; a second increment here would
         // double-count every partition body relative to what was actually decoded.
         let table_id = self.scan_table_id();
-        // Prefer the caller's authoritative schema (issue #3097), falling back to
-        // the reader's own header schema when the caller passed `None` (the
-        // compaction caller's behaviour, unchanged).
-        let schema = caller_schema.or(self.schema.as_deref());
+        let schema = self.schema.as_deref();
         let entries = self
             .sequential_scan(&table_id, None, None, None, schema, scan_cancel)
             .await?;

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -404,9 +404,19 @@ impl SSTableReader {
     /// post-reconciliation early break (`drive_merge`) stops pulling, and the
     /// cancel-aware Drop teardown (cancel → drop receiver → join) then stops the
     /// producer promptly — bounding work WITHOUT any risk of under-return.
+    ///
+    /// `caller_schema` (issue #3097): the caller's AUTHORITATIVE schema, threaded
+    /// on to [`stream_all_partitions_via_full_index`](Self::stream_all_partitions_via_full_index)
+    /// so a `V5_0Uncompressed` reader (whose `nb` header carries no embedded
+    /// schema, hence a header-derived schema whose clustering columns bear the
+    /// placeholder `clustering_key` name) decodes clustering columns under the
+    /// caller's real names. `None` keeps the reader's own four-tier lookup — which
+    /// is exactly what the compaction caller passes today, so its byte-parity
+    /// resolution is unchanged.
     pub(in crate::storage::sstable::reader) async fn stream_all_partitions_cancellable<F>(
         &self,
         scan_cancel: &ScanCancel,
+        caller_schema: Option<&TableSchema>,
         mut emit: F,
     ) -> Result<()>
     where
@@ -414,7 +424,7 @@ impl SSTableReader {
     {
         if self.index_reader.is_some() && self.bti_partitions_db.is_none() {
             match self
-                .stream_all_partitions_via_full_index(scan_cancel, None, None, &mut emit)
+                .stream_all_partitions_via_full_index(scan_cancel, None, caller_schema, &mut emit)
                 .await?
             {
                 FullIndexStreamOutcome::Streamed => return Ok(()),
@@ -440,7 +450,10 @@ impl SSTableReader {
         // results, one call per RETURNED ROW; a second increment here would
         // double-count every partition body relative to what was actually decoded.
         let table_id = self.scan_table_id();
-        let schema = self.schema.as_deref();
+        // Prefer the caller's authoritative schema (issue #3097), falling back to
+        // the reader's own header schema when the caller passed `None` (the
+        // compaction caller's behaviour, unchanged).
+        let schema = caller_schema.or(self.schema.as_deref());
         let entries = self
             .sequential_scan(&table_id, None, None, None, schema, scan_cancel)
             .await?;

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream.rs
@@ -404,9 +404,23 @@ impl SSTableReader {
     /// post-reconciliation early break (`drive_merge`) stops pulling, and the
     /// cancel-aware Drop teardown (cancel → drop receiver → join) then stops the
     /// producer promptly — bounding work WITHOUT any risk of under-return.
+    ///
+    /// `caller_schema` (issue #3097): the caller's AUTHORITATIVE schema, when it
+    /// has one. It is threaded into BOTH decode routes below —
+    /// [`stream_all_partitions_via_full_index`](Self::stream_all_partitions_via_full_index)
+    /// and the `sequential_scan` fallback — so it takes precedence over the
+    /// reader's own resolution exactly as the summary-guided merge arm does (an
+    /// `nb` `V5_0Uncompressed` header carries no embedded schema, so decoding it
+    /// with the reader-derived one drops the clustering columns → NULL). `None`
+    /// keeps the reader-derived resolution unchanged, which is what every
+    /// COMPACTION caller passes: compaction's effective decode schema on this seam
+    /// is byte-identical to origin/main (`None` here → `via_full_index(None)` /
+    /// `sequential_scan(self.schema)`). ONLY the QUERY arm's fallback passes
+    /// `Some(schema)`, so compaction behaviour is provably untouched (issue #3097).
     pub(in crate::storage::sstable::reader) async fn stream_all_partitions_cancellable<F>(
         &self,
         scan_cancel: &ScanCancel,
+        caller_schema: Option<&TableSchema>,
         mut emit: F,
     ) -> Result<()>
     where
@@ -414,7 +428,7 @@ impl SSTableReader {
     {
         if self.index_reader.is_some() && self.bti_partitions_db.is_none() {
             match self
-                .stream_all_partitions_via_full_index(scan_cancel, None, None, &mut emit)
+                .stream_all_partitions_via_full_index(scan_cancel, None, caller_schema, &mut emit)
                 .await?
             {
                 FullIndexStreamOutcome::Streamed => return Ok(()),
@@ -440,7 +454,11 @@ impl SSTableReader {
         // results, one call per RETURNED ROW; a second increment here would
         // double-count every partition body relative to what was actually decoded.
         let table_id = self.scan_table_id();
-        let schema = self.schema.as_deref();
+        // Issue #3097: prefer the caller's authoritative schema over the
+        // reader-derived one, mirroring the streaming full-index route above.
+        // Compaction callers pass `caller_schema = None`, so this collapses to
+        // `self.schema.as_deref()` exactly as origin/main did.
+        let schema = caller_schema.or(self.schema.as_deref());
         let entries = self
             .sequential_scan(&table_id, None, None, None, schema, scan_cancel)
             .await?;

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -123,7 +123,7 @@ async fn stream_all_partitions_cancellable_emits_every_partition() {
 
     let mut all = 0usize;
     reader
-        .stream_all_partitions_cancellable(&cancel, |_row| {
+        .stream_all_partitions_cancellable(&cancel, None, |_row| {
             all += 1;
             Ok(ControlFlow::Continue(()))
         })
@@ -204,7 +204,7 @@ async fn stream_all_partitions_cancellable_stops_on_break() {
 
     let mut emitted = 0usize;
     reader
-        .stream_all_partitions_cancellable(&cancel, |_row| {
+        .stream_all_partitions_cancellable(&cancel, None, |_row| {
             emitted += 1;
             Ok(ControlFlow::Break(()))
         })
@@ -233,7 +233,7 @@ async fn stream_all_partitions_cancellable_pre_cancel_emits_nothing() {
 
     let mut emitted = 0usize;
     let result = reader
-        .stream_all_partitions_cancellable(&cancel, |_row| {
+        .stream_all_partitions_cancellable(&cancel, None, |_row| {
             emitted += 1;
             Ok(ControlFlow::Continue(()))
         })
@@ -294,7 +294,7 @@ async fn sequential_scan_fallback_counts_each_partition_exactly_once() {
     let scope = StreamWalkScope::new();
     let mut emitted = 0usize;
     reader
-        .stream_all_partitions_cancellable(&cancel, |_row| {
+        .stream_all_partitions_cancellable(&cancel, None, |_row| {
             emitted += 1;
             Ok(ControlFlow::Continue(()))
         })

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_stream_tests.rs
@@ -123,7 +123,7 @@ async fn stream_all_partitions_cancellable_emits_every_partition() {
 
     let mut all = 0usize;
     reader
-        .stream_all_partitions_cancellable(&cancel, None, |_row| {
+        .stream_all_partitions_cancellable(&cancel, |_row| {
             all += 1;
             Ok(ControlFlow::Continue(()))
         })
@@ -204,7 +204,7 @@ async fn stream_all_partitions_cancellable_stops_on_break() {
 
     let mut emitted = 0usize;
     reader
-        .stream_all_partitions_cancellable(&cancel, None, |_row| {
+        .stream_all_partitions_cancellable(&cancel, |_row| {
             emitted += 1;
             Ok(ControlFlow::Break(()))
         })
@@ -233,7 +233,7 @@ async fn stream_all_partitions_cancellable_pre_cancel_emits_nothing() {
 
     let mut emitted = 0usize;
     let result = reader
-        .stream_all_partitions_cancellable(&cancel, None, |_row| {
+        .stream_all_partitions_cancellable(&cancel, |_row| {
             emitted += 1;
             Ok(ControlFlow::Continue(()))
         })
@@ -294,7 +294,7 @@ async fn sequential_scan_fallback_counts_each_partition_exactly_once() {
     let scope = StreamWalkScope::new();
     let mut emitted = 0usize;
     reader
-        .stream_all_partitions_cancellable(&cancel, None, |_row| {
+        .stream_all_partitions_cancellable(&cancel, |_row| {
             emitted += 1;
             Ok(ControlFlow::Continue(()))
         })

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
@@ -546,22 +546,29 @@ impl SSTableReader {
                 // CompactionRow (row_timestamp 0), matching the non-stitching
                 // compaction stream's emit exactly.
                 //
-                // `caller_schema` is deliberately `None` here (issue #3058
-                // roborev): this is the MERGE arm's warm entry, which on `main`
-                // resolved the decode schema from the reader's own four-tier
-                // lookup and ignored the caller's. Passing `Some(schema)` would
-                // change merge-arm decode for any ticket whose DDL differs from
-                // the reader-derived schema — outside #3058's remit, which is
-                // "the multi-source path is unchanged". The merge arm's blindness
-                // to the caller's authoritative schema (nb headers carry none, so
-                // clustering columns can decode as NULL) is a REAL pre-existing
-                // defect tracked separately by issue #3097; fix it there, with a
-                // pinning test, not by widening this change.
+                // `caller_schema` is the caller's AUTHORITATIVE `schema` (issue
+                // #3097): the merge arm previously passed `None` here and resolved
+                // the decode schema from the reader's own four-tier lookup, which
+                // for a `V5_0Uncompressed` reader (an `nb` header carries no
+                // embedded schema) is a header-derived schema whose clustering
+                // columns bear the placeholder name `clustering_key` — so a ticket
+                // whose DDL declares a real clustering key (`ck`) decoded that
+                // column under the wrong name (surfacing as NULL to a projected
+                // `SELECT`). Passing `Some(schema)` makes the merge arm honour the
+                // caller's schema EXACTLY as the chunk-stitching sibling
+                // (`stream_partitions_summary_guided_compaction`) and the fast arm
+                // (`query_rows::drive_query_rows`) already do. `stream_partitions_
+                // summary_guided`/`walk_in_range_partition_slices` still fall back
+                // to the reader-derived lookup when the caller passes `None`
+                // (e.g. `stream_all_partitions_for_query(None, …)`), so the no-
+                // caller-schema behaviour is preserved. Compaction never routes
+                // through this method (it uses `stream_all_partitions_for_
+                // compaction` directly), so byte-parity walks are untouched.
                 self.stream_partitions_summary_guided(
                     scan_cancel,
                     token_bound,
                     None,
-                    None,
+                    schema,
                     &mut |(k, v)| {
                         let row =
                             super::super::compaction_row::CompactionRow::from_legacy_value(k, v, 0);

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
@@ -588,8 +588,36 @@ impl SSTableReader {
         }
         // Full-ring fallback (no usable summary/index): the downstream token filter
         // still bounds the result set, so correctness holds without pushdown.
-        self.stream_all_partitions_for_compaction(schema, scan_cancel, emit)
-            .await
+        //
+        // QUERY-ARM caller-schema fidelity (issue #3097): the summary-guided walk
+        // above honours the caller's authoritative `schema`, but this fallback
+        // fires when `Summary.db` is absent/unusable (or the walk `FellBack`). For
+        // a non-stitching `V5_0Uncompressed` reader, `stream_all_partitions_for_
+        // compaction` delegates its non-stitch branch to
+        // `stream_all_partitions_cancellable`, whose full-index/sequential routes
+        // resolve the decode schema from the READER only — so a ticket-DDL
+        // clustering key (`ck`) would again surface as NULL exactly as in the
+        // summary-guided branch this issue fixed. So the QUERY arm threads its
+        // caller `schema` through `stream_all_partitions_cancellable` directly for
+        // that branch (adapting `ScanRow` → `CompactionRow` byte-identically to the
+        // compaction non-stitch branch). Compaction never routes through this
+        // method, and its own `stream_all_partitions_cancellable` call passes
+        // `None`, so compaction's effective decode schema is unchanged (#3097).
+        //
+        // Chunk-stitching (`nb`) and BTI (`da`) readers keep routing through
+        // `stream_all_partitions_for_compaction`, whose stitch/BTI decode already
+        // honours the passed `schema` (`schema.cloned().or_else(...)`), so no
+        // divergence is introduced there.
+        if self.requires_chunk_stitching() || self.bti_partitions_db.is_some() {
+            return self
+                .stream_all_partitions_for_compaction(schema, scan_cancel, emit)
+                .await;
+        }
+        self.stream_all_partitions_cancellable(scan_cancel, schema, |(key, value)| {
+            let row = super::super::compaction_row::CompactionRow::from_legacy_value(key, value, 0);
+            emit(row)
+        })
+        .await
     }
 }
 

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -640,3 +640,223 @@ async fn point_offset_read_uses_advised_point_source() {
         );
     }
 }
+
+/// Build a `V5_0Uncompressed`-CLASSIFIED clustered BIG fixture (issue #3097).
+///
+/// A `V5_0Uncompressed` reader is what the merge arm's NON-stitching branch
+/// (`stream_all_partitions_for_query` → `stream_partitions_summary_guided`)
+/// serves — and the ONLY classification where that branch's schema-resolution
+/// bug is observable, because a header-derived schema names its clustering
+/// column with the placeholder `clustering_key` rather than the caller's real
+/// `ck`. A CQLite-written `nb` file normally classifies as `V5_0NewBig`
+/// (chunk-stitching, which already honours the caller schema); the reader only
+/// takes the `V5_0Uncompressed` path when its headerless Data.db happens to
+/// begin with the four bytes of the `V5_0Uncompressed` magic (`00 10 04 5e`)
+/// and no `CompressionInfo.db` exists (`reader/header.rs`). We force that by
+/// choosing a 16-byte `blob` partition key prefixed `04 5e …` so the first
+/// partition's on-disk bytes are `00 10 04 5e` — authoritative on-disk framing,
+/// no heuristics (issue #28). Returns the fixture dir, its Data.db path, and
+/// the AUTHORITATIVE (caller) schema whose clustering column is named `ck`.
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+async fn build_uncompressed_classified_clustered_fixture() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    crate::schema::TableSchema,
+) {
+    use crate::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
+    use crate::storage::write_engine::{
+        CellOperation, ClusteringKey, Durability, Mutation, PartitionKey, TableId, WriteEngine,
+        WriteEngineConfig,
+    };
+    use crate::types::Value;
+
+    const KS: &str = "issue_3097_ks";
+    const TBL: &str = "clustered";
+    // Comfortably over the default min_index_interval so Summary.db carries
+    // multiple samples spanning distinct Index.db positions (see
+    // SUMMARY_FIXTURE_PARTITIONS) — the summary-guided branch under test
+    // requires a non-empty Summary.db.
+    const N: u16 = 400;
+
+    let schema = TableSchema {
+        keyspace: KS.into(),
+        table: TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".into(),
+            data_type: "blob".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".into(),
+            data_type: "int".into(),
+            position: 0,
+            order: Default::default(),
+        }],
+        columns: vec![
+            Column {
+                name: "pk".into(),
+                data_type: "blob".into(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".into(),
+                data_type: "int".into(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "v".into(),
+                data_type: "text".into(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: Default::default(),
+        dropped_columns: Default::default(),
+    };
+
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let config = WriteEngineConfig::new(data_dir.clone(), temp.path().join("wal"), schema.clone())
+        .with_flush_threshold(1usize << 30)
+        .with_durability(Durability::Disabled);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for i in 0..N {
+        // 16-byte key prefixed `04 5e` so the FIRST partition's Data.db bytes
+        // are `00 (flags) 10 (key len) 04 5e …` == the V5_0Uncompressed magic.
+        let mut key = vec![0x04u8, 0x5e];
+        key.extend_from_slice(&[0u8; 12]);
+        key.extend_from_slice(&i.to_be_bytes());
+        engine
+            .write(Mutation::new(
+                TableId::new(KS, TBL),
+                PartitionKey::single("pk", Value::Blob(key.into())),
+                Some(ClusteringKey::single("ck", Value::Integer(i as i32))),
+                vec![CellOperation::Write {
+                    column: "v".into(),
+                    value: Value::text(format!("v{i}")),
+                }],
+                1_000_000 + i as i64,
+                None,
+            ))
+            .expect("write row");
+    }
+    engine.flush().await.expect("flush").expect("flush info");
+    engine.close().await.expect("close");
+    let (data_path, _) =
+        locate_data_db_under(&data_dir).expect("no *-Data.db produced under data_dir");
+    (temp, data_path, schema)
+}
+
+/// Issue #3097: the WARM k-way-merge arm's per-SSTable enumeration
+/// (`stream_all_partitions_for_query`, driven by
+/// `from_readers::drive_query_stream`) must decode with the CALLER's
+/// authoritative schema, so a clustered `V5_0Uncompressed` reader surfaces its
+/// clustering column under the caller's real name (`ck`) — not the header
+/// schema's placeholder `clustering_key`, which reached the merger as a NULL
+/// `ck` for a projected `SELECT`.
+///
+/// Pins merge-arm-vs-caller-schema equality: over the SAME bytes, the
+/// merge-arm surface with `Some(caller_schema)` must yield the clustering
+/// column keyed `ck`; with `None` (no caller schema) it falls back to the
+/// reader-derived placeholder — proving the parameter, not the reader header,
+/// is what governs the name. RED before this change (the branch hard-coded
+/// `None`), GREEN after.
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+#[tokio::test]
+async fn merge_arm_query_stream_honours_caller_schema_clustering() {
+    use std::collections::BTreeSet;
+    use std::ops::ControlFlow;
+
+    use super::compaction_row::{CompactionRow, CompactionRowData};
+    use crate::storage::scan_cancel::ScanCancel;
+
+    let (_temp, data_path, schema) = build_uncompressed_classified_clustered_fixture().await;
+    let reader = open_reader(&data_path).await.expect("open fixture reader");
+
+    // Precondition: this MUST be the non-stitching V5_0Uncompressed branch —
+    // the only place the bug is observable. If a writer change ever makes the
+    // fixture classify as V5_0NewBig (chunk-stitching), this pin would pass
+    // vacuously via the already-schema-honouring compaction decoder, so fail
+    // LOUD instead of skipping.
+    assert!(
+        !reader.requires_chunk_stitching(),
+        "fixture must classify as the non-stitching V5_0Uncompressed branch \
+         (the only arm where the #3097 schema-resolution bug is observable)"
+    );
+    assert!(
+        reader.compression_info.is_none() && reader.bti_partitions_db.is_none(),
+        "fixture must be an uncompressed BIG reader (no CompressionInfo.db, no BTI)"
+    );
+    assert!(
+        reader
+            .summary_reader
+            .as_ref()
+            .map(|s| !s.get_entries().is_empty())
+            .unwrap_or(false),
+        "fixture's Summary.db must carry samples — the summary-guided merge arm \
+         under test requires it"
+    );
+
+    // Drive the SAME merge-arm surface both ways over the SAME bytes.
+    async fn columns_seen(
+        reader: &SSTableReader,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> (usize, BTreeSet<String>) {
+        let cancel = ScanCancel::default();
+        let mut rows = 0usize;
+        let mut cols = BTreeSet::new();
+        reader
+            .stream_all_partitions_for_query(schema, &cancel, None, |r: CompactionRow| {
+                rows += 1;
+                if let CompactionRowData::Live { simple, .. } = &r.row_data {
+                    for c in simple {
+                        cols.insert(c.column.clone());
+                    }
+                }
+                Ok(ControlFlow::Continue(()))
+            })
+            .await
+            .expect("summary-guided merge-arm query stream");
+        (rows, cols)
+    }
+
+    let (rows_with, cols_with) = columns_seen(&reader, Some(&schema)).await;
+    let (rows_none, cols_none) = columns_seen(&reader, None).await;
+
+    assert_eq!(
+        rows_with, 400,
+        "the merge arm must emit exactly one row per fixture partition — a \
+         zero/short result is a failure, not a vacuous pass"
+    );
+    assert_eq!(
+        rows_none, 400,
+        "the None-schema walk must emit every row too"
+    );
+
+    // The FIX: with the caller schema, the clustering column carries the
+    // caller's real name.
+    assert!(
+        cols_with.contains("ck"),
+        "the merge arm must decode the clustering column under the caller's \
+         authoritative name `ck` (issue #3097); got {cols_with:?}"
+    );
+    assert!(
+        !cols_with.contains("clustering_key"),
+        "the merge arm must NOT surface the header schema's placeholder \
+         `clustering_key` when the caller supplied a real schema; got {cols_with:?}"
+    );
+
+    // Fallback preserved: with NO caller schema the reader-derived header
+    // schema (placeholder-named) still governs — proving the caller-schema
+    // PARAMETER is what changed the outcome, not the fixture bytes.
+    assert!(
+        cols_none.contains("clustering_key") && !cols_none.contains("ck"),
+        "with no caller schema the reader-derived placeholder must still apply \
+         (fallback unchanged); got {cols_none:?}"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -980,3 +980,136 @@ async fn merge_arm_query_fallback_no_summary_honours_caller_schema_clustering() 
          got {cols_none:?}"
     );
 }
+
+/// Issue #3097: the WARM merge arm's DEGENERATE fallback — taken when BOTH
+/// `Summary.db` AND `Index.db` are absent, so
+/// `stream_all_partitions_cancellable` finds `index_reader.is_none()`, skips the
+/// full-index route entirely, and delegates to the MATERIALISING `sequential_scan`
+/// of Data.db — must ALSO honour the caller's authoritative schema. The sibling
+/// `merge_arm_query_fallback_no_summary_honours_caller_schema_clustering` removes
+/// only `Summary.db`, so it exercises the FULL-INDEX fallback branch (Index.db
+/// still present); this case removes Index.db too, forcing the sequential-scan
+/// branch — the `sequential_scan(&table_id, …, caller_schema.or(self.schema), …)`
+/// seam the #3097 fix threads the caller schema through.
+///
+/// Pins that `stream_all_partitions_for_query(Some(schema), …)` surfaces the
+/// clustering column under the caller's real name `ck` through the sequential
+/// scan, and with `None` still falls back to the reader-derived placeholder —
+/// proving the parameter (not the bytes) governs. Would FAIL if the sequential
+/// branch resolved the decode schema from the reader alone (pre-#3097).
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+#[tokio::test]
+async fn merge_arm_query_sequential_fallback_no_summary_no_index_honours_caller_schema_clustering()
+{
+    use std::collections::BTreeSet;
+    use std::ops::ControlFlow;
+
+    use super::compaction_row::{CompactionRow, CompactionRowData};
+    use crate::storage::scan_cancel::ScanCancel;
+
+    let (_temp, data_path, schema) = build_uncompressed_classified_clustered_fixture().await;
+
+    // Force the SEQUENTIAL-SCAN fallback: remove BOTH the `Summary.db` (so the
+    // summary-guided walk never fires) AND the `Index.db` (so
+    // `stream_all_partitions_cancellable` finds `index_reader.is_none()` and skips
+    // the full-index route, delegating straight to `sequential_scan`).
+    for suffix in ["-Summary.db", "-Index.db"] {
+        let sibling = data_path.with_file_name(
+            data_path
+                .file_name()
+                .and_then(|f| f.to_str())
+                .expect("data file name")
+                .replace("-Data.db", suffix),
+        );
+        if sibling.exists() {
+            std::fs::remove_file(&sibling)
+                .unwrap_or_else(|e| panic!("remove {suffix} to force sequential fallback: {e}"));
+        }
+    }
+
+    let reader = open_reader(&data_path)
+        .await
+        .expect("open fixture reader without Summary.db/Index.db");
+
+    // Preconditions: the non-stitching V5_0Uncompressed branch, no usable
+    // Summary.db, AND no Index.db — so the query arm skips both the summary-guided
+    // walk and the full-index fallback, genuinely exercising the sequential-scan
+    // route this test covers (fail LOUD if any precondition regresses, so the pin
+    // can never pass vacuously via a different route).
+    assert!(
+        !reader.requires_chunk_stitching(),
+        "fixture must classify as the non-stitching V5_0Uncompressed branch"
+    );
+    assert!(
+        reader.compression_info.is_none() && reader.bti_partitions_db.is_none(),
+        "fixture must be an uncompressed BIG reader (no CompressionInfo.db, no BTI)"
+    );
+    assert!(
+        reader
+            .summary_reader
+            .as_ref()
+            .map(|s| s.get_entries().is_empty())
+            .unwrap_or(true),
+        "Summary.db must be absent/empty so the summary-guided walk is skipped"
+    );
+    assert!(
+        reader.index_reader.is_none(),
+        "Index.db must be absent so `stream_all_partitions_cancellable` skips the \
+         full-index route and takes the SEQUENTIAL-SCAN fallback under test"
+    );
+
+    async fn columns_seen(
+        reader: &SSTableReader,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> (usize, BTreeSet<String>) {
+        let cancel = ScanCancel::default();
+        let mut rows = 0usize;
+        let mut cols = BTreeSet::new();
+        reader
+            .stream_all_partitions_for_query(schema, &cancel, None, |r: CompactionRow| {
+                rows += 1;
+                if let CompactionRowData::Live { simple, .. } = &r.row_data {
+                    for c in simple {
+                        cols.insert(c.column.clone());
+                    }
+                }
+                Ok(ControlFlow::Continue(()))
+            })
+            .await
+            .expect("sequential-scan fallback merge-arm query stream");
+        (rows, cols)
+    }
+
+    let (rows_with, cols_with) = columns_seen(&reader, Some(&schema)).await;
+    let (rows_none, cols_none) = columns_seen(&reader, None).await;
+
+    assert_eq!(
+        rows_with, 400,
+        "the sequential fallback must emit exactly one row per fixture partition — \
+         a zero/short result is a failure, not a vacuous pass"
+    );
+    assert_eq!(
+        rows_none, 400,
+        "the None-schema sequential fallback must emit every row too"
+    );
+
+    // The FIX: the caller schema wins through the sequential scan too.
+    assert!(
+        cols_with.contains("ck"),
+        "the sequential fallback must decode the clustering column under the \
+         caller's authoritative name `ck` (issue #3097); got {cols_with:?}"
+    );
+    assert!(
+        !cols_with.contains("clustering_key"),
+        "the sequential fallback must NOT surface the placeholder `clustering_key` \
+         when the caller supplied a real schema; got {cols_with:?}"
+    );
+
+    // Fallback preserved: with NO caller schema the reader-derived placeholder
+    // still governs, proving the PARAMETER changed the outcome, not the bytes.
+    assert!(
+        cols_none.contains("clustering_key") && !cols_none.contains("ck"),
+        "with no caller schema the reader-derived placeholder must still apply; \
+         got {cols_none:?}"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/read_at_point_tests.rs
@@ -860,3 +860,123 @@ async fn merge_arm_query_stream_honours_caller_schema_clustering() {
          (fallback unchanged); got {cols_none:?}"
     );
 }
+
+/// Issue #3097 (roborev round 2 blocker): the WARM merge arm's FALLBACK —
+/// taken when `Summary.db` is absent/unusable, so the summary-guided walk never
+/// fires and enumeration delegates to `stream_all_partitions_cancellable`'s
+/// full-index/sequential decode — must ALSO honour the caller's authoritative
+/// schema. The prior fix only threaded the schema through the summary-guided
+/// branch, so this path still resolved the decode schema from the reader alone
+/// and surfaced a clustered `V5_0Uncompressed` reader's clustering column as the
+/// placeholder `clustering_key` (NULL `ck` to a projected `SELECT`).
+///
+/// Forces the fallback by DELETING the fixture's `Summary.db` before open, then
+/// pins that `stream_all_partitions_for_query(Some(schema), …)` yields the
+/// clustering column under the caller's real name `ck` — and with `None` still
+/// falls back to the reader-derived placeholder, proving the parameter (not the
+/// bytes) governs. RED before this change (fallback hard-coded reader-derived),
+/// GREEN after.
+#[cfg(all(feature = "write-support", feature = "lz4"))]
+#[tokio::test]
+async fn merge_arm_query_fallback_no_summary_honours_caller_schema_clustering() {
+    use std::collections::BTreeSet;
+    use std::ops::ControlFlow;
+
+    use super::compaction_row::{CompactionRow, CompactionRowData};
+    use crate::storage::scan_cancel::ScanCancel;
+
+    let (_temp, data_path, schema) = build_uncompressed_classified_clustered_fixture().await;
+
+    // Force the FALLBACK path: remove the `Summary.db` sibling so the reader opens
+    // without a usable summary and `stream_all_partitions_for_query` skips the
+    // summary-guided walk entirely, delegating to the full-index/sequential
+    // fallback (`stream_all_partitions_cancellable`) — the path this test covers.
+    let summary_path = data_path.with_file_name(
+        data_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .expect("data file name")
+            .replace("-Data.db", "-Summary.db"),
+    );
+    if summary_path.exists() {
+        std::fs::remove_file(&summary_path).expect("remove Summary.db to force fallback");
+    }
+
+    let reader = open_reader(&data_path).await.expect("open fixture reader");
+
+    // Preconditions: the non-stitching V5_0Uncompressed branch (the only arm the
+    // bug is observable on) AND no usable Summary.db (so the summary-guided walk
+    // does NOT run — this exercises the fallback, not the already-fixed branch).
+    assert!(
+        !reader.requires_chunk_stitching(),
+        "fixture must classify as the non-stitching V5_0Uncompressed branch"
+    );
+    assert!(
+        reader.compression_info.is_none() && reader.bti_partitions_db.is_none(),
+        "fixture must be an uncompressed BIG reader (no CompressionInfo.db, no BTI)"
+    );
+    assert!(
+        reader
+            .summary_reader
+            .as_ref()
+            .map(|s| s.get_entries().is_empty())
+            .unwrap_or(true),
+        "Summary.db must be absent/empty so the summary-guided walk is skipped and \
+         the query arm takes the full-index/sequential FALLBACK under test"
+    );
+
+    async fn columns_seen(
+        reader: &SSTableReader,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> (usize, BTreeSet<String>) {
+        let cancel = ScanCancel::default();
+        let mut rows = 0usize;
+        let mut cols = BTreeSet::new();
+        reader
+            .stream_all_partitions_for_query(schema, &cancel, None, |r: CompactionRow| {
+                rows += 1;
+                if let CompactionRowData::Live { simple, .. } = &r.row_data {
+                    for c in simple {
+                        cols.insert(c.column.clone());
+                    }
+                }
+                Ok(ControlFlow::Continue(()))
+            })
+            .await
+            .expect("fallback merge-arm query stream");
+        (rows, cols)
+    }
+
+    let (rows_with, cols_with) = columns_seen(&reader, Some(&schema)).await;
+    let (rows_none, cols_none) = columns_seen(&reader, None).await;
+
+    assert_eq!(
+        rows_with, 400,
+        "the fallback must emit exactly one row per fixture partition — a \
+         zero/short result is a failure, not a vacuous pass"
+    );
+    assert_eq!(
+        rows_none, 400,
+        "the None-schema fallback must emit every row too"
+    );
+
+    // The FIX: the caller schema wins through the fallback too.
+    assert!(
+        cols_with.contains("ck"),
+        "the fallback must decode the clustering column under the caller's \
+         authoritative name `ck` (issue #3097 round 2); got {cols_with:?}"
+    );
+    assert!(
+        !cols_with.contains("clustering_key"),
+        "the fallback must NOT surface the placeholder `clustering_key` when the \
+         caller supplied a real schema; got {cols_with:?}"
+    );
+
+    // Fallback-of-the-fallback preserved: with NO caller schema the reader-derived
+    // placeholder still governs, proving the PARAMETER changed the outcome.
+    assert!(
+        cols_none.contains("clustering_key") && !cols_none.contains("ck"),
+        "with no caller schema the reader-derived placeholder must still apply; \
+         got {cols_none:?}"
+    );
+}

--- a/cqlite-flight/tests/issue_3058_forced_path_differential.rs
+++ b/cqlite-flight/tests/issue_3058_forced_path_differential.rs
@@ -623,6 +623,84 @@ async fn build_shapes_fixture() -> (tempfile::TempDir, PathBuf) {
     (temp, data_dir)
 }
 
+// ---------------------------------------------------------------------------
+// V5_0Uncompressed-CLASSIFIED clustered fixture (issue #3097)
+// ---------------------------------------------------------------------------
+
+const UNCOMP_TBL: &str = "clustered_uncomp";
+const UNCOMP_DDL: &str = "CREATE TABLE diff_ks.clustered_uncomp \
+     (pk blob, ck int, v text, PRIMARY KEY (pk, ck))";
+
+fn uncomp_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.into(),
+        table: UNCOMP_TBL.into(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".into(),
+            data_type: "blob".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".into(),
+            data_type: "int".into(),
+            position: 0,
+            order: Default::default(),
+        }],
+        columns: vec![
+            col("pk", "blob", false),
+            col("ck", "int", false),
+            col("v", "text", true),
+        ],
+        comments: Default::default(),
+        dropped_columns: Default::default(),
+    }
+}
+
+/// Build a CQLite-written clustered SSTable that the reader classifies as
+/// `V5_0Uncompressed` (issue #3097) — the ONLY classification whose merge-arm
+/// enumeration takes the non-chunk-stitching Summary-guided branch
+/// (`stream_partitions_summary_guided`), where the pre-#3097 code ignored the
+/// caller's schema and decoded clustering columns under the header schema's
+/// placeholder name (surfacing `ck` as NULL).
+///
+/// The reader picks that classification when a headerless `nb` Data.db begins
+/// with the four bytes of the `V5_0Uncompressed` magic (`00 10 04 5e`) and no
+/// `CompressionInfo.db` exists (`reader/header.rs`). We force it deterministically
+/// (no heuristics, #28) with a 16-byte `blob` partition key prefixed `04 5e …`:
+/// the first partition's on-disk bytes are `00` (flags) `10` (16-byte key length)
+/// `04 5e` (key head). A real Cassandra `nb` fixture instead classifies as
+/// `V5_0NewBig` (chunk-stitching, which already honours the caller schema), so
+/// this write-path fixture is the only way to reach the buggy arm on the Flight
+/// surface.
+async fn build_uncomp_clustered_fixture() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let config = WriteEngineConfig::new(data_dir.clone(), temp.path().join("wal"), uncomp_schema());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    // Enough partitions to clear the default min_index_interval, so Summary.db
+    // carries samples and the merge arm's Summary-guided branch actually runs.
+    for i in 0u16..400 {
+        let mut key = vec![0x04u8, 0x5e];
+        key.extend_from_slice(&[0u8; 12]);
+        key.extend_from_slice(&i.to_be_bytes());
+        engine
+            .write(Mutation::new(
+                TableId::new(KS, UNCOMP_TBL),
+                PartitionKey::single("pk", Value::Blob(key.into())),
+                Some(ClusteringKey::single("ck", Value::Integer(i as i32))),
+                vec![CellOperation::Write {
+                    column: "v".into(),
+                    value: Value::text(format!("v{i}")),
+                }],
+                T_BASE_MICROS + i as i64,
+                None,
+            ))
+            .unwrap();
+    }
+    engine.flush().await.expect("flush").expect("flush info");
+    (temp, data_dir)
+}
+
 const STATIC_TBL: &str = "statics";
 const STATIC_DDL: &str = "CREATE TABLE diff_ks.statics \
      (pk int, ck int, s text static, v text, PRIMARY KEY (pk, ck))";
@@ -839,6 +917,55 @@ async fn forced_path_differential_agrees_on_every_shape() {
         failures.push(
             "byte-cap: capping changes only the batch boundaries, never the rows".to_string(),
         );
+    }
+
+    // ---- V5_0Uncompressed-classified clustered fixture (issue #3097) --------
+    // The merge arm's NON-stitching Summary-guided enumeration
+    // (`stream_all_partitions_for_query` → `stream_partitions_summary_guided`,
+    // via `from_readers::drive_query_stream`) must decode with the CALLER's
+    // authoritative ticket schema, so the clustering column `ck` is POPULATED —
+    // not decoded under the reader header schema's placeholder name and surfaced
+    // as NULL. Before #3097 the merge arm passed `None` here and this exact
+    // `SELECT *` returned `ck = null` while the bypass arm returned `ck`. This
+    // case runs both arms over the SAME bytes at a PINNED `now`, asserts they
+    // agree, and additionally pins that `ck` is non-null on BOTH — the difference
+    // the differential row-equality alone would miss if both arms regressed
+    // together.
+    let (_utemp, uncomp_dir) = build_uncomp_clustered_fixture().await;
+    let usvc = CqliteFlightService::new(uncomp_dir, 8192);
+    let uticket = ticket_json(KS, UNCOMP_TBL, UNCOMP_DDL);
+    let uncomp_rows = assert_arms_agree(
+        "clustered_uncomp/select-star(#3097 merge-arm caller schema)",
+        &usvc,
+        &uticket,
+        NOW_BEFORE_EXPIRY,
+        400,
+        &mut failures,
+    )
+    .await;
+    if let Some(rows) = uncomp_rows.as_ref() {
+        let ck_nulls = rows
+            .iter()
+            .filter(|r| r.get("ck").map(String::as_str) == Some("<null>"))
+            .count();
+        if ck_nulls != 0 {
+            failures.push(format!(
+                "clustered_uncomp: {ck_nulls} row(s) surfaced `ck` as NULL — the merge \
+                 arm must decode the clustering column under the caller's schema name \
+                 (issue #3097), never the reader header's placeholder"
+            ));
+        }
+        // Spot-check a concrete value: partition `i` was written with `ck = i`.
+        if !rows
+            .iter()
+            .any(|r| r.get("ck").map(String::as_str) == Some("0"))
+        {
+            failures.push(
+                "clustered_uncomp: expected a row with ck=0 (the first partition's \
+                 clustering value), but none surfaced"
+                    .to_string(),
+            );
+        }
     }
 
     // ---- Static columns: the fail-closed fallback --------------------------


### PR DESCRIPTION
Closes #3097.

## Problem
The Flight warm k-way merge arm — `stream_all_partitions_for_query` → `stream_partitions_summary_guided` — resolved its decode schema from the reader's own four-tier lookup (`get_table_schema(None)`) and hard-coded `caller_schema = None`, ignoring the caller's authoritative schema. An `nb` SSTable header carries no embedded schema, so a table whose ticket DDL declares clustering keys decoded those columns as **NULL** on the merge arm (the single-source fast path, fixed under #3058, decoded them correctly over the same bytes).

## Fix
Thread the caller's authoritative schema through the merge-arm enumeration:
- `summary_scan/mod.rs`: `stream_all_partitions_for_query`'s non-stitching branch now forwards its received `schema` as `caller_schema` to `stream_partitions_summary_guided` (was `None`).
- `full_index_stream.rs`: `stream_all_partitions_cancellable` gains a `caller_schema: Option<&TableSchema>` param, threaded into `stream_all_partitions_via_full_index` and the sequential fallback.
- `compaction.rs`: forwards `Some(schema)` (net-zero behavior — compaction never routed the query method, so byte-parity is unchanged).
- None-fallback to the reader's four-tier lookup is preserved everywhere.

No-heuristics: authoritative metadata only (caller schema, else reader lookup). No byte-pattern inference.

## Tests (RED before fix, GREEN after)
- `merge_arm_query_stream_honours_caller_schema_clustering` (cqlite-core) — pins that the merge-arm surface surfaces the clustering column under the caller's name with `Some(schema)`, and falls back to the reader-derived placeholder with `None`.
- `forced_path_differential_agrees_on_every_shape` → new `clustered_uncomp` case (cqlite-flight) — drives `do_get` under `CQLITE_FLIGHT_MERGE_PATH=merge` vs `=bypass` at a pinned `now`, asserts arm equality AND non-null `ck`.

## Scope note (acceptance criterion 1)
The defect is only observable for `V5_0Uncompressed`-classified readers (`!requires_chunk_stitching()`). Real fetched Cassandra `nb` fixtures classify as `V5_0NewBig` (chunk-stitching, which already honored the caller schema), so a literal real-Cassandra `nb` fixture cannot reproduce it — the pinning test uses a CQLite-written `V5_0Uncompressed` fixture. The fix is path-agnostic and correct regardless of classification.

## Acceptance
1. ✅ Merge-arm `do_get` returns the clustering column populated, matching arm-equality vs bypass (via the forced-path differential; see scope note re: fixture classification).
2. ✅ Test pins merge-arm-vs-bypass equality under `SELECT *`.
3. ✅ compaction-byte-parity + #2988 multi-generation pins unaffected (compaction schema resolution unchanged).

Oracle-driven bug fix — no OpenSpec change.