### PR TITLE
fix(2964): fail-closed roborev guard — a vacuous review can no longer pass as clean

### DIFF
--- a/.claude/agents/flow-closer.md
+++ b/.claude/agents/flow-closer.md
@@ -117,10 +117,26 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
    On re-invoke, the verdict MUST be PASS (every requirement `satisfied` with a
    public-surface test as evidence). An `unmet`/uncovered/unjustified-`partial` requirement
    blocks merge → route back (see step 4 escalation).
-3. **Final roborev confirmation pass.** Because review-first already ran, this should
-   converge to **clean-on-arrival**. Run roborev with the machine's configured agent
-   (`/roborev-review-branch --base origin/main`; no `--agent`/`--model` unless the local
-   config is broken). Triage every finding per `docs/development/roborev-severity.md`:
+3. **Final roborev confirmation pass — this GATES arming auto-merge.** Because review-first
+   already ran, this should converge to **clean-on-arrival**. Run the ONLY sanctioned
+   invocation (#2964), with the certified tip **PUSHED** (the wrapper asserts it) and **BOTH**
+   `--agent` and `--model` (#2433 — one alone inherits the `.roborev.toml`-pinned model and
+   hard-400s as a silent-looking outage):
+   ```bash
+   bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol
+   ```
+   NEVER a bare `roborev review --branch --base origin/main` — from a worktree it resolves
+   against the ROOT checkout and enqueues `origin/main`, so it reports clean having reviewed
+   NOTHING — and never the two-positional commit-range form. Retain ONLY the
+   `==== ROBOREV REVIEW SUMMARY ====` block (never the transcript); it is deliberately distinct
+   from every `AGENT-GATE *SUMMARY`, so neither can be pasted as the other. Exit `0` PASS / `1`
+   FAIL / `3` NOTHING-TO-REVIEW / `2` usage error. **Any non-PASS terminal `RESULT` —
+   `NOTHING-TO-REVIEW` included — is a BLOCKED MERGE, not a clean review: do NOT arm
+   `gh pr merge --auto`.** Fix the cause the block names (unpushed branch, mismatched
+   `reviewed-sha`, vacuous verdict) and re-run. A **docs-only diff cannot be roborev-certified
+   at all** — record primary-source verification in the PR body instead of "roborev clean"
+   (https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/).
+   Triage every finding per `docs/development/roborev-severity.md`:
    - **Blockers** (correctness, data-parity, no-heuristics, safety/unwrap-panic paths,
      wiring-evidence gaps, security, any stated acceptance criterion) MUST be fixed pre-merge.
    - **Nits** (style/naming, comment/doc polish, test-robustness suggestions with no failing
@@ -142,7 +158,8 @@ This keeps a genuinely-alive multi-hour close from being reaped by `flow-board`'
      implementer's) or rebased after step 1, **re-run the full gate** (back to step 1).
      `--lite` re-certs are never the gate of record.
 5. **Merge on green (worker-merges-own-PR model).** When gate PASS + C PASS (design) +
-   roborev clean all hold on the final tree: beat the heartbeat, rebase on `origin/main`
+   roborev clean (a terminal `RESULT: PASS` from the wrapper — never `NOTHING-TO-REVIEW`)
+   all hold on the final tree: beat the heartbeat, rebase on `origin/main`
    (resolve conflicts in the worktree — a rebase re-invalidates the gate per step 4),
    `git push` the certified tip, open the nits follow-up issue if any, then — **before** arming
    `gh pr merge --auto` — run the two mechanical pre-merge guards:

--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -114,13 +114,22 @@ silently fails:
 | intent audit (C) | `spec-auditor` (anchored to `openspec/changes/<name>/specs/**`) | inside flow-closer, after the gate |
 | parity / test execution | `test-validator` | verify |
 | test quality | `coverage-reviewer` | review |
-| code review | roborev (`roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`) | review-first + final closer pass |
+| code review | roborev, via the ONLY sanctioned invocation `bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol` (#2964) | review-first + final closer pass |
 | correctness | `scripts/agent-gate.sh` | the ONE gate of record, inside flow-closer |
 
-- **roborev invocation — there is NO `/roborev-review-branch` slash command.** Run the CLI and pass
-  **BOTH** `--agent` and `--model` (#2433): `.roborev.toml` on `main` pins `review_model = 'opus'`, and
-  `--agent codex` alone inherits it → codex hard-400s (`'opus' model is not supported`), a silent review
-  failure that looks like an outage.
+- **roborev invocation — `scripts/flow/roborev-review.sh` is the ONLY sanctioned call (#2964).** There is
+  NO `/roborev-review-branch` slash command, and a bare `roborev review --branch --base origin/main` is
+  **NON-SANCTIONED**: from a worktree it resolves against the ROOT checkout and enqueues `origin/main`, so
+  it reports clean having reviewed NOTHING (the two-positional commit-range form mis-enqueues too). The
+  wrapper verifies the reviewed SHA against branch HEAD, asserts the branch is pushed, and HARD-FAILs a
+  `"contains no code changes to review"` verdict on a non-empty diff; a **docs-only diff cannot be
+  roborev-certified at all** (record primary-source verification in the PR instead). Retain only its
+  `==== ROBOREV REVIEW SUMMARY ====` block; **any** non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW`
+  included — is a failed round and a blocked merge, never "roborev clean". Pass **BOTH** `--agent` and
+  `--model`; the wrapper requires them (#2433 — one alone inherits the `.roborev.toml`-pinned model, e.g.
+  `--agent claude-code` inheriting `review_model = 'gpt-5.6-sol'`, and hard-400s as a silent review
+  failure that looks like an outage). Doctrine: CLAUDE.md +
+  https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/.
 - Parallelize independent specialists in one message; sequence dependent work. A review finding that is
   **mechanical** (a missing test, a fmt/clippy nit) is the loop's to fix; a genuine **decision** goes to
   the owner. In an **attended** session ask via `AskUserQuestion`; in an **unattended** session

--- a/.claude/agents/rust-reviewer.md
+++ b/.claude/agents/rust-reviewer.md
@@ -80,6 +80,11 @@ Cassandra 3.x) is **OUT OF SCOPE** and SHALL NOT be reviewed for correctness or 
 Full guidance: https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/. Severity rubric:
 `docs/development/roborev-severity.md`. Every class here is a **blocker** by definition.
 
+You never invoke roborev yourself — the closer does, through the only sanctioned invocation
+`bash scripts/flow/roborev-review.sh --agent <agent> --model <model>` (#2964). But **flag as a blocker** any
+diff (docs, script, or agent surface) that reintroduces a bare `roborev review --branch` or the
+two-positional commit-range form: both can report clean having reviewed nothing.
+
 - **GitHub Actions injection** — never interpolate `${{ inputs.* }}` or step outputs into `run:`;
   allowlist-validate fail-closed before any secret step and pass via a quoted env var.
 - **Integer overflow / saturation** — use `num_bigint::BigInt` for unscaled decimal math; compare

--- a/.claude/agents/sstable-developer.md
+++ b/.claude/agents/sstable-developer.md
@@ -77,7 +77,11 @@ with `scripts/agent-gate.sh --lite` (~1-5 min) each fix round, iterating until i
 is `LITE_COMPONENTS` in `scripts/agent-gate.sh` — read it there or run `scripts/agent-gate.sh --lite-list`
 rather than trusting a transcribed list; note lite clippy is **per-package scoped** (NOT whole-workspace)
 and lite includes **`roborev-lints`** (#2656). **NEVER invoke the full `scripts/agent-gate.sh` yourself** —
-the `flow-closer` runs the full gate of record and the final roborev pass. A subagent idle-waiting on a
+the `flow-closer` runs the full gate of record and the final roborev pass (via
+`scripts/flow/roborev-review.sh`, the only sanctioned roborev invocation — #2964; never invoke `roborev`
+directly, and never a bare `roborev review --branch`, which from a worktree reviews `origin/main` and
+reports clean having reviewed nothing). **Push your commits** — an unpushed branch is itself an empty-diff
+cause and the wrapper FAILs it. A subagent idle-waiting on a
 12-20 min full gate gets killed by the 600s stall watchdog and takes its child gate process down with it (3
 implementers lost this way 2026-07-03/04). If ever asked to run the full gate: **queued gate ≠ hung gate** —
 under load it may **queue for a #1825 slot** (prints `waiting for gate slot (N in use)…` once) then run

--- a/.claude/agents/test-validator.md
+++ b/.claude/agents/test-validator.md
@@ -92,6 +92,12 @@ slot (N in use)…` once) — use a long timeout or `run_in_background`, never a
 liveness probe on a summary file is `grep -qE 'RESULT: (PASS|FAIL)'` — a bare `INCOMPLETE` is the
 start-of-run placeholder, **not** a verdict (#3041).
 
+Likewise you never invoke roborev: the closer runs it through the only sanctioned invocation,
+`bash scripts/flow/roborev-review.sh --agent <agent> --model <model>` (#2964; both flags required). Its
+`==== ROBOREV REVIEW SUMMARY ====` block is deliberately distinct from every `AGENT-GATE *SUMMARY`, so
+neither can ever be pasted as the other, and any non-PASS terminal `RESULT` (`NOTHING-TO-REVIEW` included)
+is a failed review round, not a clean one.
+
 ### Gate invocation — summary-file redirect is MANDATORY (issues #1175/#2079)
 
 Run EVERY gate, including each `--lite` round, with the summary-file redirect and read the SUMMARY block

--- a/.claude/commands/manager.md
+++ b/.claude/commands/manager.md
@@ -58,8 +58,11 @@ sequence workers with **signed issue comments**. That's it.
 - Design-driven issues pause mid-flow at Seam 1 (owner spec approval) — expect that; don't treat the pause
   as a stalled worker.
 - Never close an epic, change scope/title, or make a product call → put it on a short **NEEDS-YOU** list.
-- Doctrine: `docs/development/pm-operating-loop.md`. (Workers run roborev with **this machine's configured
-  agent** — commonly `claude-code` via `.roborev.toml`, no flags; explicit `--agent`/`--model` is a per-machine
-  troubleshooting override only. See `docs/development/agent-machine-setup.md`.)
+- Doctrine: `docs/development/pm-operating-loop.md`. (Workers run roborev ONLY through the sanctioned
+  wrapper `bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol` (#2964) — **both
+  `--agent` and `--model` always**, branch pushed first; a bare `roborev review --branch` or the
+  two-positional commit-range form is NON-SANCTIONED and can report clean having reviewed nothing. So
+  "roborev clean" above means that wrapper's terminal `RESULT: PASS` — any other terminal `RESULT`,
+  `NOTHING-TO-REVIEW` included, is a failed round and a blocked merge. See CLAUDE.md.)
 
 Start now: one reconcile sweep, then report what you fed to Ready, the tempo, and the one thing that needs me. Go.

--- a/.claude/commands/worker.md
+++ b/.claude/commands/worker.md
@@ -123,8 +123,18 @@ onto its own branch). Rules, non-negotiable:
       `==== AGENT-GATE LITE SUMMARY ====` block + **≤5 lines** of prose (#2080) — never raw logs/diffs.
       Iterate on lite until PASS and the change is complete.
    2. **Review-first is DEFAULT (#2086):** on the lite-green diff, spawn `rust-reviewer` (model: opus) AND
-      run roborev (this machine's configured agent — commonly `claude-code` via `.roborev.toml`; no flags)
-      **before any full gate**. Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single
+      run roborev **before any full gate**, through the ONLY sanctioned invocation (#2964) — **push the
+      branch first** (the wrapper asserts it and FAILs otherwise), then
+      `bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol` (Claude reviewer:
+      `--agent claude-code --model claude-opus-5`; on the fleet boxes only `codex` is healthy — confirm with
+      `roborev check-agents`). **BOTH `--agent` and `--model` are ALWAYS required** — the wrapper rejects a
+      missing one as a usage error, because one alone inherits the `.roborev.toml`-pinned model and fails as
+      a silent-looking review outage. A bare `roborev review --branch` and the two-positional commit-range
+      form are **NON-SANCTIONED** (from a worktree the former reviews `origin/main` and reports clean having
+      reviewed nothing). Retain only the `==== ROBOREV REVIEW SUMMARY ====` block; **any** non-PASS terminal
+      `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round and a blocked merge, never "roborev
+      clean" (why: CLAUDE.md + https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/).
+      Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single
       call site AND no new surface). Triage findings per `docs/development/roborev-severity.md`: **blockers**
       fixed now (each re-triggers `fix → --lite re-cert (+ diff-relevant parity/integration target) →
       re-review`, NEVER a full gate — #2087); **nits** batched into ONE linked follow-up issue at merge time,

--- a/.claude/skills/ci-cd-validation/SKILL.md
+++ b/.claude/skills/ci-cd-validation/SKILL.md
@@ -55,7 +55,11 @@ AGENT_GATE_SUMMARY_FILE=/tmp/partial-<N>.txt \
 
 - **Division of labor (#1855/#2084/#2079):** the implementing subagent iterates on `--lite` / targeted
   tests and ends at commit + push + report. **The ONE full gate of record and the final roborev pass run
-  inside the disposable `flow-closer` subagent, NOT in the lead** — the lead never runs the full gate and
+  inside the disposable `flow-closer` subagent, NOT in the lead** — that roborev pass goes through the ONLY
+  sanctioned invocation, `bash scripts/flow/roborev-review.sh --agent <agent> --model <model>` (#2964; both
+  flags required, never a bare `roborev review --branch`), and the closer retains only its
+  `==== ROBOREV REVIEW SUMMARY ====` block, whose header is deliberately distinct from every
+  `AGENT-GATE *SUMMARY` so neither can be pasted as the other — the lead never runs the full gate and
   never reads its stdout; it retains only the closer's terminal packet (verdict, PR URL, summary-file
   path). The closer launches the gate via `Bash run_in_background` and reads the SUMMARY **from the file**:
   a subagent that idle-waits on a 12-25 min full gate is killed by the 600s stall watchdog and orphans its
@@ -81,7 +85,9 @@ gh run view <run-id> --log-failed # failed-job logs only
 ## Merge
 
 Merge is **autonomous on green** — once **local certification** holds (gate PASS + (design-driven)
-spec-auditor **C** PASS + roborev clean), and after the pre-merge SHA assert + `HOLD` re-read, **arm
+spec-auditor **C** PASS + roborev clean — a terminal `RESULT: PASS` from
+`scripts/flow/roborev-review.sh`, never `NOTHING-TO-REVIEW`), and after the pre-merge SHA assert + `HOLD`
+re-read, **arm
 `gh pr merge --auto --squash --delete-branch`** and stop; GitHub lands the PR when the #2433 `required`
 check goes green (#2667), then `flow-finalize <N>`. **Never `ScheduleWakeup`-poll a PR's own CI** — `--auto`
 replaces the busy-wait. Merge is not a human gate; hold only for a genuine design call, a scope/product

--- a/.claude/skills/ci-cd-validation/merge-process.md
+++ b/.claude/skills/ci-cd-validation/merge-process.md
@@ -4,7 +4,9 @@
 > check) are gone — they encoded a human-merge model the pipeline no longer uses.
 
 Merge is **autonomous on green**: the moment **local certification** is met —
-`scripts/agent-gate.sh` PASS + (design-driven) spec-auditor **C** PASS + roborev clean — a worker (or the
+`scripts/agent-gate.sh` PASS + (design-driven) spec-auditor **C** PASS + roborev clean (a terminal
+`RESULT: PASS` from `scripts/flow/roborev-review.sh`, the only sanctioned roborev invocation — #2964;
+`NOTHING-TO-REVIEW` and FAIL are both blocked merges) — a worker (or the
 lead), after the pre-merge SHA assert + `HOLD` re-read, **arms `gh pr merge --auto --squash --delete-branch`**
 and stops. GitHub lands the PR when the #2433 `required` check goes green (#2667), then `flow-finalize <N>`.
 **Never `ScheduleWakeup`-poll a PR's own CI** — arming `--auto` replaces the busy-wait.

--- a/.claude/skills/flow-activate/SKILL.md
+++ b/.claude/skills/flow-activate/SKILL.md
@@ -70,7 +70,9 @@ committed, owner-approvable OpenSpec change on an isolated worktree. **STOP at a
 4. **Propose** with OpenSpec (use the `opsx:propose` skill / `openspec new change <slug>`): author
    `proposal.md` (state milestone + oracle/design + Non-goals + doctrine impact), `design.md`,
    `specs/<capability>/spec.md` (every requirement gets a verifiable `#### Scenario:`), `tasks.md`
-   (each task names the surface it exercises; include gate + C + roborev steps). Consult specialists for
+   (each task names the surface it exercises; include gate + C + roborev steps — roborev ALWAYS via
+   `bash scripts/flow/roborev-review.sh --agent <agent> --model <model>`, the only sanctioned invocation
+   (#2964), never a bare `roborev review --branch`). Consult specialists for
    facts where useful (e.g. a parity/format question → `test-validator` / `sstable-developer`), but
    **never decide a product/data-model question** — surface options to the owner.
 5. **Validate:** `openspec validate <slug> --strict` (must be clean). Commit the artifacts.

--- a/.claude/skills/flow-address/SKILL.md
+++ b/.claude/skills/flow-address/SKILL.md
@@ -42,8 +42,13 @@ Resolve them in the worktree and reply per thread.
    cat /tmp/lite-<N>.txt   # the LITE block (MODE: lite) is the ONLY gate text you retain
    ```
    Add any diff-relevant parity/integration `--test` target (run with `CQLITE_DATASETS_ROOT` pointed at
-   the main repo). Re-run C (`spec-auditor`) if requirements/tests changed; roborev again if code changed
-   materially. If the certified SHA moved, re-certification is the closer's full (or `--delta`) gate per
+   the main repo). Re-run C (`spec-auditor`) if requirements/tests changed; if code changed materially,
+   **push first**, then re-run roborev through the ONLY sanctioned invocation (#2964) —
+   `bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol` (both flags always; never a bare
+   `roborev review --branch`, which from a worktree reviews `origin/main` and reports clean having reviewed
+   nothing). Retain only its `==== ROBOREV REVIEW SUMMARY ====` block; any non-PASS terminal `RESULT`,
+   `NOTHING-TO-REVIEW` included, is a failed round, not clean.
+   If the certified SHA moved, re-certification is the closer's full (or `--delta`) gate per
    the gate contract — not a full gate in this skill.
 6. **Push + reply.** `git -C <worktree> push`, then reply on each `$PR` thread with what changed (commit
    ref), and clear the transient `addressing` sub-marker. The board stays `In Review` (PR still open),

--- a/.claude/skills/flow-finalize/SKILL.md
+++ b/.claude/skills/flow-finalize/SKILL.md
@@ -45,6 +45,9 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
      --gate pass --gate-runs <runs through the first PASS; don't re-run after a pass> \
      --claim-collisions <rejected claim pushes> --rebase-events <rebases/conflict resolutions> \
      --roborev-findings <roborev findings raised> --rework <re-open / re-review rounds>
+   # This skill NEVER invokes roborev (the closer owns the final pass, via the only sanctioned invocation
+   # `scripts/flow/roborev-review.sh` — #2964). "roborev clean" in this ledger means that wrapper's
+   # terminal `RESULT: PASS`; `NOTHING-TO-REVIEW` or FAIL is not clean and is not finalizable.
    # Land the ledger via a PR — `main` blocks direct pushes (#2433 branch protection: PR required,
    # enforce_admins=true). NEVER `git push`/`push origin HEAD:main` (rejected), and NEVER `git checkout`
    # in the shared root (a closer that switched root to a telemetry branch stranded it off main).

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -125,11 +125,25 @@ never gate stdout or review churn.
    Do NOT run the full `scripts/agent-gate.sh` during the fix-round loop — that is the `flow-closer`'s single
    gate of record (step 7).
 5. **Review-first — DEFAULT, BEFORE the first full gate (issues #2086/#2087/#2088).** On the **lite-green**
-   diff, run `rust-reviewer` (explicit `model: opus`) **and** roborev NOW — there is **no
-   `/roborev-review-branch` slash command**; run the CLI and pass **BOTH** `--agent` and `--model` (#2433,
-   or codex hard-400s on the config-pinned `opus`):
-   `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`
-   — before any full gate — so
+   diff, run `rust-reviewer` (explicit `model: opus`) **and** roborev NOW. **`scripts/flow/roborev-review.sh`
+   is the ONLY sanctioned roborev invocation (#2964)** — there is no `/roborev-review-branch` slash
+   command, and a bare `roborev review --branch --base origin/main` is **NON-SANCTIONED** (from a worktree
+   it resolves against the ROOT checkout and enqueues `origin/main`, reporting clean having reviewed
+   NOTHING), as is the two-positional commit-range form. **PUSH the implementation commit first** — the
+   wrapper asserts the push and FAILs an unpushed branch, since unpushed work is itself an empty-diff
+   cause. Pass **BOTH** `--agent` and `--model`; the wrapper requires them (#2433 — one alone inherits the
+   `.roborev.toml`-pinned model and hard-400s as a silent-looking review outage):
+   ```bash
+   bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol
+   ```
+   Retain ONLY the `==== ROBOREV REVIEW SUMMARY ====` block, never the raw transcript (it goes to the
+   `log:` path in the block). Exit `0` PASS / `1` FAIL / `3` NOTHING-TO-REVIEW / `2` usage error, and
+   **any** non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a FAILED review round, never
+   "roborev clean": fix the cause the block names (unpushed branch, mismatched `reviewed-sha`, vacuous
+   verdict) and re-run. A **docs-only diff cannot be roborev-certified at all** — record primary-source
+   verification in the PR instead. Four rules + evidence:
+   https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/.
+   Run review-first before any full gate — so
    the ONE full gate certifies already-reviewed code. **Skip review-first ONLY for a genuinely mechanical
    diff:** no `pub`-item change AND a single call site AND no new surface (the narrow inverse of the old
    conditional). When in doubt, review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,22 +341,43 @@ implement (TDD) → --lite each fix round (summary-file redirect)
 - **Review-first (#2086)**: review BEFORE the first full gate so the ONE gate certifies
   already-reviewed code. Skip ONLY for a genuinely mechanical diff (no `pub`-item change AND single
   call site AND no new surface). When in doubt, review.
-- **roborev invocation — the default is codex; overriding it means passing BOTH agent and model
-  (#2433/#3037).** `.roborev.toml` on `main` pins `agent`/`review_agent = 'codex'` +
-  `model`/`review_model = 'gpt-5.6-sol'` (the repo pin overrides your global `~/.roborev/config.toml`,
-  so it is the value that actually runs). So the plain
-  `roborev review --branch --base origin/main --wait` already runs codex — **no flags needed**.
-  The trap is the reverse case: to run the **Claude** reviewer you must override BOTH:
-  `roborev review --branch --base origin/main --agent claude-code --model claude-opus-5 --wait`.
-  `--agent claude-code` alone still inherits `review_model = 'gpt-5.6-sol'` from config — an OpenAI
-  model name Claude cannot serve — which fails as a silent review failure that looks like an outage.
-  (Historically the pin ran the other way and codex-on-a-ChatGPT-account rejected the inherited
-  Anthropic name with a hard `400 'opus' model is not supported`; same trap, mirrored.) Run from a
-  checkout whose `.roborev.toml` you know (worktrees inherit `main`'s pinned config); `--model` is the
-  reliable override. Note `gpt-5.6-sol` is **codex's own built-in default, not a config pin** — there
-  is no `~/.codex/config.toml` on the worker boxes; the bare `codex` default moved `gpt-5.5` →
-  `gpt-5.6-sol` in the 0.142.5 → 0.145.0 upgrade, so a future codex version bump can silently move it
-  again. `codex --version` + a bare `codex exec` header is how you check what it actually resolves to.
+- **roborev invocation — `scripts/flow/roborev-review.sh` is the ONLY sanctioned call, and it requires
+  BOTH `--agent` and `--model` (#2964/#2433/#3037).**
+  `bash scripts/flow/roborev-review.sh --agent <agent> --model <model> [--repo <abs-path>] [--base <ref>] [--log <path>]`
+  — codex is `--agent codex --model gpt-5.6-sol`; Claude is `--agent claude-code --model claude-opus-5`.
+  `--repo` defaults to the toplevel of `$PWD` (resolved absolute), `--base` to `origin/main`. Retain ONLY
+  its `==== ROBOREV REVIEW SUMMARY ====` block (header deliberately distinct from all three
+  `AGENT-GATE *SUMMARY` blocks so neither can be pasted as the other), never the transcript — that goes
+  to the `log:` path named in the block. Exit `0` PASS / `1` FAIL / `3` NOTHING-TO-REVIEW / `2` usage
+  error; **any** non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round and
+  a blocked merge, never "roborev clean". Four rules: **(1)** bare
+  `roborev review --branch --base origin/main` is NON-SANCTIONED, and so is the two-positional
+  commit-range form. **(2)** The **reviewed SHA must be VERIFIED against branch HEAD** — the wrapper
+  parses `Enqueued job <N> for <sha>`; a mismatch aborts the round, and a mismatch that equals the base
+  ref is the signature of the worktree bug. **(3)** `"contains no code changes to review"` on a
+  NON-EMPTY diff is a **HARD FAIL**, never a pass. **(4)** A docs-only (code-free) diff **cannot be
+  roborev-certified at all** — the wrapper fails it as vacuous; the sanctioned substitute is
+  primary-source verification recorded in the PR (e.g. `git show cassandra-5.0.8:<path>`), and no
+  docs-only change may ever record "roborev clean". Push first: an unpushed implementation commit is
+  itself an empty-diff cause, and the wrapper asserts the push and FAILs otherwise. **Why:** three
+  confirmed paths make roborev report clean having reviewed NOTHING, and a vacuous pass is TEXTUALLY
+  IDENTICAL to a genuine one — (T1) from a worktree, `--branch` resolves against the ROOT checkout
+  (normally on `main`) and enqueues the BASE commit: enqueued `39900e4db` (= origin/main) while branch
+  HEAD was `4e7ab591e`; (T2) the range form `roborev review 89fdbb895 989d7d2c3` enqueued `90a17d376` —
+  NEITHER endpoint; (T3) a code-free diff is SILENTLY DISCARDED even with the right SHA and the right
+  `--repo`, so **SHA verification alone is insufficient**. Token accounting is the tell: genuine reviews
+  398k–649k input / 314k–554k cached / 5.0k–6.3k output over ~2m30s, vs the vacuous baseline 18.7k input
+  / 0 cached / 53–56 output in 8s. Real cost: on #2950 two vacuous runs "passed"; re-run correctly
+  against the real SHA, the SAME diff produced TWO REAL BLOCKERS. 1:1:1:1 puts EVERY issue in a worktree
+  and `flow-closer`'s final pass is a MERGE GATE — so this could merge unreviewed code fleet-wide.
+  Reviewer-selection trap: `--agent claude-code` alone still inherits `review_model = 'gpt-5.6-sol'` from
+  `.roborev.toml` (the repo pin overrides your global `~/.roborev/config.toml`) — an OpenAI model name
+  Claude cannot serve, which fails as a silent review failure that looks like an outage; historically
+  mirrored (codex-on-a-ChatGPT-account hard-`400 'opus' model is not supported`). Hence the wrapper
+  enforces both. `gpt-5.6-sol` is **codex's own built-in default, not a config pin** — there is no
+  `~/.codex/config.toml` on the worker boxes; the bare `codex` default moved `gpt-5.5` → `gpt-5.6-sol` in
+  the 0.142.5 → 0.145.0 upgrade, so a version bump can silently move it again. `codex --version` + a bare
+  `codex exec` header is how you check what it actually resolves to.
 - **flow-closer (#2084/#2668)**: the full gate, the final roborev pass, and the merge run inside the
   disposable `flow-closer` subagent — the lead retains only its terminal packet (verdict, PR URL,
   summary-file path, ≤10 lines residual), never gate stdout or review churn. The closer has **no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,27 +350,38 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   `AGENT-GATE *SUMMARY` blocks so neither can be pasted as the other), never the transcript — that goes
   to the `log:` path named in the block. Exit `0` PASS / `1` FAIL / `3` NOTHING-TO-REVIEW / `2` usage
   error; **any** non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round and
-  a blocked merge, never "roborev clean". Four rules: **(1)** bare
-  `roborev review --branch --base origin/main` is NON-SANCTIONED, and so is the two-positional
-  commit-range form. **(2)** The **reviewed scope must be VERIFIED against branch HEAD** — the wrapper
-  asserts it from the **job record's structured fields** (`roborev list/show --json`; e.g. the full-sha
-  `git_ref`), with the stdout `Enqueued job <N> for <sha>` line DEMOTED to a cross-check that still
-  fails closed when absent or unparseable (a structured record beats parsing a tool's human-readable
-  prose — the same reasoning that moved the push-assert onto `git ls-remote`). A reviewed scope that
-  does not match, or that equals the base ref, **aborts the round** — base-equality is the signature of
+  a blocked merge, never "roborev clean". Four rules: **(1)** the NON-SANCTIONED direct forms are
+  `--branch` **WITHOUT** an explicit `--repo` (from a worktree it resolves against the ROOT checkout),
+  the two-positional commit-range form (its range base is git's EMPTY TREE), and a SINGLE-SHA review (it
+  covers ONE COMMIT, certifying a multi-commit branch from its last commit alone). `--repo` is what makes
+  `--branch` correct, so the wrapper reviews the RANGE `--branch --base <base> --repo <abs>` — measured
+  5/5 census code files delivered, vs 3/5 for the other two. **(2)** The **reviewed RANGE must be VERIFIED
+  against `<base>...HEAD`** — the wrapper asserts BOTH endpoints from the **job record's structured
+  fields** (`roborev list/show --json`; `git_ref` is `<base40>..<head40>`, echoed in `reviewed-sha:`
+  beside a `job-record:` completeness key), with the stdout `Enqueued job <N> for <sha>` line DEMOTED to
+  the job-id carrier: for a range review it names only the BASE, so an unavailable record FAILs rather
+  than falling back to prose that verifies nothing. A range that does not match, a SINGLE-COMMIT record
+  (even one equal to HEAD), or a base-equal scope **aborts the round** — base-equality is the signature of
   the worktree bug. **(3)** `"contains no code changes to review"` on a
   NON-EMPTY diff is a **HARD FAIL**, never a pass. **(4)** A docs-only (code-free) diff **cannot be
-  roborev-certified at all** — the wrapper's deterministic pre-enqueue `code-free:` check fails it
-  before any review is enqueued; the sanctioned substitute is
+  roborev-certified at all**: roborev **EXCLUDES non-code paths from the diff it builds** (measured — 22
+  markdown absent from the prompt, 5 code present), so for prose-only the constructed diff is genuinely
+  EMPTY and that verdict is a truthful report of an empty input, not a malfunction. The wrapper's
+  deterministic pre-enqueue `code-free:` check fails it before any review is enqueued, and
+  `prompt-content:` therefore asserts the CODE subset of the census (an unretrievable prompt FAILs — there
+  is no passing `UNAVAILABLE` there). The sanctioned substitute is
   primary-source verification recorded in the PR (e.g. `git show cassandra-5.0.8:<path>`), and no
   docs-only change may ever record "roborev clean". Push first: an unpushed implementation commit is
-  itself an empty-diff cause, and the wrapper asserts the push and FAILs otherwise. **Why:** three
-  confirmed paths make roborev report clean having reviewed NOTHING, and a vacuous pass is TEXTUALLY
-  IDENTICAL to a genuine one — (T1) from a worktree, `--branch` resolves against the ROOT checkout
-  (normally on `main`) and enqueues the BASE commit: enqueued `39900e4db` (= origin/main) while branch
-  HEAD was `4e7ab591e`; (T2) the range form `roborev review 89fdbb895 989d7d2c3` enqueued `90a17d376` —
-  NEITHER endpoint; (T3) a code-free diff is SILENTLY DISCARDED even with the right SHA and the right
-  `--repo`, so **SHA verification alone is insufficient**. Token accounting is the tell: genuine reviews
+  itself an empty-diff cause, and the wrapper asserts the push and FAILs otherwise. **Why:** FOUR
+  confirmed paths make roborev report clean having reviewed NOTHING (or only part), and a vacuous pass is
+  TEXTUALLY IDENTICAL to a genuine one — (T1) from a worktree, `--branch` without `--repo` resolves
+  against the ROOT checkout (normally on `main`) and enqueues the BASE commit: enqueued `39900e4db`
+  (= origin/main) while branch HEAD was `4e7ab591e`; (T2) the two-positional range form anchors the range
+  at git's EMPTY TREE (`4b825dc6…`); (T3) a code-free diff is SILENTLY DISCARDED even with the right SHA
+  and the right `--repo`, so **SHA verification alone is insufficient**; (T4) a single-SHA review covers
+  ONE COMMIT — a PARTIAL review whose enqueued sha EQUALS HEAD, so no sha check can see it (this is the
+  form #2964's own AC2 asked for; the wrapper implements the AC's intent instead).
+  Token accounting is the tell: genuine reviews
   398k–649k input / 314k–554k cached / 5.0k–6.3k output over ~2m30s, vs the vacuous baseline 18.7k input
   / 0 cached / 53–56 output in 8s. Real cost: on #2950 two vacuous runs "passed"; re-run correctly
   against the real SHA, the SAME diff produced TWO REAL BLOCKERS. 1:1:1:1 puts EVERY issue in a worktree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,11 +352,16 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   error; **any** non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round and
   a blocked merge, never "roborev clean". Four rules: **(1)** bare
   `roborev review --branch --base origin/main` is NON-SANCTIONED, and so is the two-positional
-  commit-range form. **(2)** The **reviewed SHA must be VERIFIED against branch HEAD** — the wrapper
-  parses `Enqueued job <N> for <sha>`; a mismatch aborts the round, and a mismatch that equals the base
-  ref is the signature of the worktree bug. **(3)** `"contains no code changes to review"` on a
+  commit-range form. **(2)** The **reviewed scope must be VERIFIED against branch HEAD** — the wrapper
+  asserts it from the **job record's structured fields** (`roborev list/show --json`; e.g. the full-sha
+  `git_ref`), with the stdout `Enqueued job <N> for <sha>` line DEMOTED to a cross-check that still
+  fails closed when absent or unparseable (a structured record beats parsing a tool's human-readable
+  prose — the same reasoning that moved the push-assert onto `git ls-remote`). A reviewed scope that
+  does not match, or that equals the base ref, **aborts the round** — base-equality is the signature of
+  the worktree bug. **(3)** `"contains no code changes to review"` on a
   NON-EMPTY diff is a **HARD FAIL**, never a pass. **(4)** A docs-only (code-free) diff **cannot be
-  roborev-certified at all** — the wrapper fails it as vacuous; the sanctioned substitute is
+  roborev-certified at all** — the wrapper's deterministic pre-enqueue `code-free:` check fails it
+  before any review is enqueued; the sanctioned substitute is
   primary-source verification recorded in the PR (e.g. `git show cassandra-5.0.8:<path>`), and no
   docs-only change may ever record "roborev clean". Push first: an unpushed implementation commit is
   itself an empty-diff cause, and the wrapper asserts the push and FAILs otherwise. **Why:** three

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -110,14 +110,29 @@ bash test-data/scripts/fetch-datasets.sh
 export CQLITE_DATASETS_ROOT=/path/to/main/checkout/test-data/datasets
 ```
 
-## roborev: local config, never a pinned agent
+## roborev: the sanctioned wrapper, agent + model always explicit
 
-roborev runs with **this machine's configured agent** — read from `.roborev.toml`
-(commonly `codex`; `roborev config list` shows the resolved values). Run it with **no
-`--agent`/`--model` flags**; it uses your local setup. Explicit `--agent`/`--model` is
-a **per-machine troubleshooting override only** — reach for it when the bootstrap warns
-that your configured agent did not resolve (fix the local config, or override for one
-run). Do not treat any specific agent (claude-code, codex, …) as doctrine.
+Every review goes through the fail-closed wrapper, never the bare CLI (#2964):
+
+```bash
+bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol \
+  [--repo /abs/path/to/checkout] [--base origin/main]     # Claude: --agent claude-code --model claude-opus-5
+```
+
+**Both `--agent` and `--model` are ALWAYS required** — the wrapper rejects a missing one
+as a usage error, because one alone inherits the mismatched `.roborev.toml`-pinned model
+and fails as a silent-looking review outage. **Push the branch first**; the wrapper asserts
+that and FAILs otherwise. A bare `roborev review --branch` and the two-positional
+commit-range form are **NON-SANCTIONED** — from a worktree the former resolves against the
+ROOT checkout and reviews the base commit, reporting clean having reviewed NOTHING. Any
+non-PASS terminal `RESULT`, `NOTHING-TO-REVIEW` included, is a failed round and a blocked
+merge, never a clean pass. Why: CLAUDE.md + the `agents-developing/roborev-findings` page.
+
+**Check per box which reviewer is actually usable: `roborev check-agents`.** A resolved
+`.roborev.toml` value is not a working reviewer — on this fleet box (roborev v0.61.2, daemon
+healthy) only `codex` passes; `claude-code` fails with `OAuth session expired and could not
+be refreshed`. That is exactly why "this machine's configured agent" was bad guidance: name
+the agent + model explicitly, choosing one `check-agents` reports healthy.
 
 ## Multi-machine: the claim protocol in two sentences
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -122,9 +122,14 @@ bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol \
 **Both `--agent` and `--model` are ALWAYS required** — the wrapper rejects a missing one
 as a usage error, because one alone inherits the mismatched `.roborev.toml`-pinned model
 and fails as a silent-looking review outage. **Push the branch first**; the wrapper asserts
-that and FAILs otherwise. A bare `roborev review --branch` and the two-positional
-commit-range form are **NON-SANCTIONED** — from a worktree the former resolves against the
-ROOT checkout and reviews the base commit, reporting clean having reviewed NOTHING. Any
+that and FAILs otherwise. Three direct-CLI forms are **NON-SANCTIONED**:
+`roborev review --branch` **without an explicit `--repo`** (from a worktree it resolves
+against the ROOT checkout and reviews the base commit, reporting clean having reviewed
+NOTHING), the two-positional commit-range form (its range base is git's empty tree), and a
+single-SHA review (it reviews ONE COMMIT, not the branch — partial, with a sha that equals
+HEAD, so no sha check catches it). `--repo` is what makes `--branch` correct: the wrapper
+reviews the RANGE `<base>..HEAD` and asserts both endpoints from the job record, so
+`reviewed-sha:` is a range and `job-record:` reports the record's completeness. Any
 non-PASS terminal `RESULT`, `NOTHING-TO-REVIEW` included, is a failed round and a blocked
 merge, never a clean pass. Why: CLAUDE.md + the `agents-developing/roborev-findings` page.
 

--- a/docs/development/pm-operating-loop.md
+++ b/docs/development/pm-operating-loop.md
@@ -208,9 +208,13 @@ worktree (the manager never rebases someone else's branch).
 - The gate is the only run that counts; paste its summary block.
 - Worktrees only; the claim ref (`claim.sh`, `refs/claims/issue-<N>`) is the lock — the branch push is PR plumbing; stage explicit paths.
 - EMU guard every board op: `gh auth switch --user pmcfadin && gh auth setup-git`.
-- roborev follows **this machine's configured agent** (`.roborev.toml`; commonly `codex` — run with no
-  flags). Pass explicit `--agent`/`--model` ONLY as a per-machine troubleshooting override when the local
-  config is broken; never pin a specific agent as doctrine. See `docs/development/agent-machine-setup.md`.
+- roborev runs ONLY through `bash scripts/flow/roborev-review.sh --agent <agent> --model <model>
+  [--repo <abs-path>] [--base <ref>]` (#2964; fleet form `--agent codex --model gpt-5.6-sol`). **Both flags
+  ALWAYS** — the wrapper rejects a missing one as a usage error. Push the branch first; a bare
+  `roborev review --branch` and the two-positional commit-range form are NON-SANCTIONED (they can report
+  clean having reviewed nothing). Any non-PASS terminal `RESULT`, `NOTHING-TO-REVIEW` included, is a failed
+  round and a blocked merge — never "roborev clean". See CLAUDE.md +
+  `docs/development/agent-machine-setup.md`.
 - Every GitHub write gets a short traceable comment.
 
 ## Field round validation (separate from the agent gate, issue #2399)

--- a/docs/development/pm-operating-loop.md
+++ b/docs/development/pm-operating-loop.md
@@ -210,10 +210,14 @@ worktree (the manager never rebases someone else's branch).
 - EMU guard every board op: `gh auth switch --user pmcfadin && gh auth setup-git`.
 - roborev runs ONLY through `bash scripts/flow/roborev-review.sh --agent <agent> --model <model>
   [--repo <abs-path>] [--base <ref>]` (#2964; fleet form `--agent codex --model gpt-5.6-sol`). **Both flags
-  ALWAYS** — the wrapper rejects a missing one as a usage error. Push the branch first; a bare
-  `roborev review --branch` and the two-positional commit-range form are NON-SANCTIONED (they can report
-  clean having reviewed nothing). Any non-PASS terminal `RESULT`, `NOTHING-TO-REVIEW` included, is a failed
-  round and a blocked merge — never "roborev clean". See CLAUDE.md +
+  ALWAYS** — the wrapper rejects a missing one as a usage error. Push the branch first. NON-SANCTIONED
+  direct forms: `roborev review --branch` **without an explicit `--repo`** (from a worktree it resolves
+  against the ROOT checkout), the two-positional commit-range form (range base = git's empty tree), and a
+  single-SHA review (reviews ONE COMMIT, not the branch — a partial review whose sha equals HEAD). `--repo`
+  is what makes `--branch` correct, so the wrapper reviews the RANGE `<base>..HEAD` and asserts both
+  endpoints from the job record; a docs-only diff cannot be roborev-certified at all, because roborev
+  excludes non-code paths from the diff it builds. Any non-PASS terminal `RESULT`, `NOTHING-TO-REVIEW`
+  included, is a failed round and a blocked merge — never "roborev clean". See CLAUDE.md +
   `docs/development/agent-machine-setup.md`.
 - Every GitHub write gets a short traceable comment.
 

--- a/openspec/changes/roborev-vacuous-review-guard/design.md
+++ b/openspec/changes/roborev-vacuous-review-guard/design.md
@@ -102,24 +102,59 @@ entirely, that is also a FAIL (unparseable ⇒ unverifiable ⇒ fail closed), ne
 
 **Step 7 — Emit a compact, machine-greppable summary block.**
 
+One field per line — a reader greps a single `^<key>: ` anchor, never a column offset. The as-built
+block (pinned by `scripts/tests/test_roborev_review_guard.sh`) is exactly:
+
 ```
 ==== ROBOREV REVIEW SUMMARY ====
-repo: <abs>            branch: <name>
-head-sha: <sha>        reviewed-sha: <sha>     job: <N>
-base: <ref>            census: <F> files, +<A>/-<D>
-tokens: input=<i> cached=<c> output=<o>   (or: tokens: UNAVAILABLE (degraded-signal))
-push-assert: PASS|FAIL
-sha-assert: PASS|FAIL(<reason>)
-vacuity-tier1: PASS|FAIL
-vacuity-tier2: PASS|FAIL|UNAVAILABLE
+repo: <abs>
+branch: <name>
+base: <ref>
+head-sha: <sha>
+reviewed-sha: <sha>|-
+job: <N>|-
+census: <F> files, +<A>/-<D>
+tokens: input=<i> cached=<c> output=<o>   (or: tokens: UNAVAILABLE)
+push-assert: PASS|FAIL(<reason>)|SKIP
+census-check: PASS|FAIL(<reason>)|SKIP
+sha-assert: PASS|FAIL(<reason>)|SKIP
+vacuity-tier1: PASS|FAIL(<reason>)|SKIP
+vacuity-tier2: PASS|FAIL(<reason>)|UNAVAILABLE|SKIP
+log: <transcript path>
 RESULT: PASS|FAIL|NOTHING-TO-REVIEW
 ```
 
-Exit codes: `0` = PASS, `1` = FAIL, `3` = NOTHING-TO-REVIEW. Modeled deliberately on the gate's
+The greppable key set is therefore `repo:` `branch:` `base:` `head-sha:` `reviewed-sha:` `job:`
+`census:` `tokens:` `push-assert:` `census-check:` `sha-assert:` `vacuity-tier1:` `vacuity-tier2:`
+`log:` and the terminal `RESULT:`. `census-check:` carries the census oracle's own verdict (it is the
+key that FAILs when the base ref is unresolvable, and the key that marks the empty-census
+`NOTHING-TO-REVIEW` path); `log:` names the transcript so a caller never needs to retain it. A
+per-check key whose step was never reached reads `SKIP` — a value that can never be mistaken for a
+pass, and never a blank.
+
+Exit codes: `0` = PASS, `1` = FAIL, `3` = NOTHING-TO-REVIEW, and `2` = **usage error**. Exit 2 is
+deliberately NOT a verdict: it emits **no** summary block at all (a loud `ERROR:` naming the missing
+option, on stderr, before any repo identity is resolved and before anything is enqueued), because a
+`RESULT:` line for a run that never happened would alias a usage error onto one of the three real
+outcomes — recreating the very indistinguishability this change exists to eliminate. `--help` (exit 0)
+is likewise not a verdict and emits no block. Modeled deliberately on the gate's
 summary-file contract: **an agent retains only this block, never raw roborev stdout** (the raw
 transcript goes to a log path named in the block). The block name is distinct from
 `AGENT-GATE SUMMARY` / `AGENT-GATE LITE SUMMARY` / `AGENT-GATE DELTA SUMMARY` so it can never be pasted
 as a gate verdict, and vice versa.
+
+**Step 7b — the reviewer's own exit status gets its own key: `roborev-exit:`.** A non-zero exit from the
+underlying `roborev` process is already a fail-closed FAIL (it forces `RESULT: FAIL` and adds an
+`ERROR:` detail line naming the observed code), but a detail line is **prose**: a reader that retains
+only the block and greps the per-check keys sees `push-assert`/`census-check`/`sha-assert`/
+`vacuity-tier1`/`vacuity-tier2` all `PASS` and no key explaining the FAIL. That is exactly the
+"which check tripped?" ambiguity every other key exists to remove, and it is the one failure cause a
+grep-based reader cannot attribute. So the block carries `roborev-exit: PASS` when the process exited
+zero and `roborev-exit: FAIL (exit <N>)` otherwise — placed with the other per-check keys, before
+`log:` — and it participates in the same `FAIL*` scan that computes the terminal verdict. (This key is
+the one field the step-7 sketch above does not yet list, because the sketch records the block as
+currently built: emitting it is a one-line addition to the wrapper's `emit_summary`, and the fail-closed
+BEHAVIOUR it reports is already implemented — only the greppable surfacing is missing.)
 
 **Step 8 — Hygiene.** The script stays small (we adopt the campsite rule's spirit: the gate's
 `file-size` ratchet covers `.rs` only, so this is a review expectation, not a mechanized one) and free
@@ -143,14 +178,27 @@ cannot be *certified* by a tool whose subject is compiled code, in either the ga
 ### Call-site migration
 
 Every roborev invocation in the agent surfaces routes through the wrapper, and bare `--branch` becomes
-non-sanctioned prose:
+non-sanctioned prose. The ten touched surfaces are NOT homogeneous — six carry an invocation, four
+carry only a *reference* — and conflating them would state an obligation four of them cannot satisfy:
 
-- `.claude/skills/`: `flow-implement` (the review-first step — the primary call site, currently
-  documenting `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`),
-  `flow-activate`, `flow-address`, `flow-finalize`, `ci-cd-validation`.
-- `.claude/agents/`: `flow-closer` (the final confirmation pass — the **merge-gating** call site; note
-  it currently documents a `/roborev-review-branch` form, which `flow-lead` correctly says does not
-  exist), `flow-lead` (the stage table), `rust-reviewer`, `sstable-developer`, `test-validator`.
+- **Invocation sites** — the documented procedure runs the wrapper:
+  - Review-round sites (run a round themselves; must also state push-first and non-PASS-is-failed):
+    `.claude/skills/flow-implement/SKILL.md` (the review-first step — the primary call site, previously
+    documenting `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`),
+    `.claude/agents/flow-closer.md` (the final confirmation pass — the **merge-gating** call site;
+    previously documenting a `/roborev-review-branch` form that does not exist),
+    `.claude/skills/flow-address/SKILL.md` (the post-comment re-review).
+  - Prescribing sites (name the wrapper as the invocation to be used, without running a round in-line):
+    `.claude/agents/flow-lead.md` (the stage table + the doctrine bullet),
+    `.claude/skills/ci-cd-validation/SKILL.md` + `.claude/skills/ci-cd-validation/merge-process.md`
+    (the merge-readiness definition), `.claude/skills/flow-activate/SKILL.md` (the tasks it authors
+    must name the wrapper for their roborev step).
+- **Non-invoking surfaces** — they contain no roborev invocation at all and must say so, pointing at
+  the wrapper as the only sanctioned invocation: `.claude/skills/flow-finalize/SKILL.md` (the
+  telemetry `--roborev-findings` counter + what "roborev clean" means in the ledger),
+  `.claude/agents/rust-reviewer.md` (the pre-roborev self-check classes — and it additionally flags a
+  reintroduced bare `--branch`/range form as a **BLOCKER**), `.claude/agents/sstable-developer.md` and
+  `.claude/agents/test-validator.md` (the `roborev-lints` lite component + never-invoke-directly).
 
 ### Regression check + gate wiring
 

--- a/openspec/changes/roborev-vacuous-review-guard/design.md
+++ b/openspec/changes/roborev-vacuous-review-guard/design.md
@@ -20,39 +20,100 @@ Two structural facts constrain every option:
 - **`roborev` is an external binary** (`/usr/local/bin/roborev`), not vendored in this repo. We cannot
   change its resolution logic or its exit codes.
 - **A vacuous verdict is textually identical to a genuine clean one** at the top level ("No issues
-  found"). The only distinguishing signals are (a) the `Summary:` sentence, (b) the enqueued SHA, and
-  (c) token accounting / wall time.
+  found"). Distinguishing them requires evidence obtained OUTSIDE the reviewer's own narration.
 
 So the guard must be a **CQLite-side wrapper**, and it must judge the reviewer's claims against
 something computed **locally**, not against the reviewer's own prose.
 
-## Recommended design
+### The thesis the implementation converged on
+
+The first cut was *prose-primary*: match the reviewer's "no code changes" sentence, with token
+thresholds corroborating. Four rounds of review found that this is the wrong axis, for a reason worth
+recording: **prose matching can only see the half of the defect space where the reviewer TELLS you it
+saw nothing.** The other half — a reviewer that never received the diff, a job that never finished, a
+provider 400, a `failed` status — emits no phrase at all, and "no bad phrase" was being read as proof
+of a review. Every one of those reached `RESULT: PASS`.
+
+The final architecture is therefore **DETERMINISTIC-PRIMARY**. The verdict is carried by checks judged
+against data the wrapper obtains itself:
+
+| Check | Its own oracle | Which half it covers |
+|---|---|---|
+| `push-assert` | the REMOTE, via `git ls-remote` | the reviewer can only see what the remote has |
+| `census-check` | our own `git diff --numstat --no-renames` | what MUST be reviewed |
+| `code-free` | our own classification of that census | T3, before a review is even enqueued |
+| `sha-assert` | the job record's structured `git_ref` | T1/T2 — the wrong commit was reviewed |
+| `review-completed` | job `status` + an allow-list of terminal verdict markers | a review actually FINISHED |
+| `prompt-content` | our census's own paths inside the prompt SENT | the reviewer never GOT the diff |
+
+Prose (`vacuity-tier1`) and token accounting (`vacuity-tier2`) sit on top as **corroboration**. A PASS
+now requires POSITIVE evidence; it is never inferred from the absence of a bad phrase.
+
+## Recommended design (as built)
 
 ### `scripts/flow/roborev-review.sh` — the ONLY sanctioned roborev invocation
 
-Flags: `--repo <path>` (default: `git rev-parse --show-toplevel` of `$PWD`), `--base <ref>` (default
-`origin/main`), `--agent`, `--model`, and passthrough for the rest. Every step is ordered and
-fail-closed; the first failure stops the run, emits the summary block, and exits non-zero.
+Flags: `--agent` and `--model` (**both required**), `--repo <path>` (default: `git rev-parse
+--show-toplevel` of `$PWD`, absolutised), `--base <ref>` (default `origin/main`), `--log <path>`.
+An option given an EMPTY value is a usage error, never a silent fallback to the default — `--repo ""`
+falling back to `$PWD` is exactly how a caller reviews a repository it did not name. Every step is
+ordered and fail-closed; the first hard failure stops the run, emits the summary block, and exits
+non-zero.
+
+Implementation is **three files**, split for size hygiene and one responsibility each:
+
+- `scripts/flow/roborev-review.sh` (796 lines) — flags, identity, invocation, the asserts, the block.
+- `scripts/flow/roborev-review-oracles.sh` (221) — **sourced**: `roborev_push_assert` + `roborev_census`
+  (including the code-free classification). These two are the change's whole thesis in code, and both
+  learned the "never trust a local proxy" lesson the hard way (below).
+- `scripts/flow/roborev-job-facts.py` (178) — JSON decoding of the job record: `git_ref`, `status`,
+  `model`/`requested_model`, the prompt, and the token counts with their three-state extraction.
+
+The sourced path is resolved from `BASH_SOURCE` (never `$PWD` — the wrapper runs from arbitrary
+worktrees) and the wrapper **FAILs CLOSED** when that file is missing OR truncated: an absent oracles
+file that silently turned the push assert and the census into no-ops would be a worse failure than any
+this guard was built to catch.
 
 **Step 1 — Resolve identity.** Repo root (**absolute** — `roborev --repo` must never receive a relative
-path), current branch, HEAD sha. `--repo` is always passed explicitly; the wrapper never relies on
-`roborev` inferring the repo from `$PWD` (that inference is trigger 1).
+path), branch, full 40-char HEAD. `--repo` is always passed explicitly; the wrapper never relies on
+`roborev` inferring the repo from `$PWD` (that inference is trigger 1). `symbolic-ref -q` /
+`rev-parse --verify --quiet` are used deliberately: `rev-parse --abbrev-ref HEAD` ECHOES the literal
+string `HEAD` in a repo with no commits, so a `|| fallback` concatenated onto real-looking values and
+the no-commit guard never fired.
 
-**Step 2 — Push assert (AC3).** `origin/<branch>` must exist and equal HEAD. Otherwise FAIL, naming
-the unpushed commits. Rationale: an unpushed implementation commit is *itself* an empty-diff cause —
-the reviewer can only see what the remote has. Ordering matters: this runs **before** the census so the
-operator gets the actionable cause ("push your commits") rather than a downstream vacuity FAIL.
+**Step 2 — Push assert (AC3), asking the REMOTE.** `git ls-remote --heads <remote> <branch>` is the
+oracle; the remote comes from the branch's configured upstream, else `origin`. Four distinct, correctly
+attributed failures: detached HEAD, `ls-remote` failure (**infra/auth — explicitly NOT "never
+pushed"**, since `git` and `gh` are separate credential paths, #2942), branch absent on the remote, and
+remote tip ≠ HEAD (naming the unpushed commits, or the divergence). This runs **before** the census so
+the operator gets the actionable cause ("push your commits") rather than a downstream vacuity FAIL.
 
-**Step 3 — Local diff census: the oracle.** `git diff --numstat <base>...HEAD` → files changed, lines
-added, lines removed. This locally-computed census is **the authoritative statement of what must be
-reviewed**, and every downstream vacuity claim is judged against it. Using `...` (three-dot,
-merge-base) matches the semantics of the `--base` the reviewer is told to diff against, so the census
-and the review are talking about the same change set.
+**There is no local mirror-ref fast path** — see *Alternatives* 7/8: the fleet's narrow fetch refspec
+means the mirror ref never exists, and a cached one survives a force-push or a branch deletion.
 
-If the census is **genuinely empty**, the wrapper exits with a **distinct `NOTHING-TO-REVIEW` status**
-(its own non-zero exit code, `3`) — explicitly **not** a pass, and explicitly not recordable as
-"roborev clean". A separate status (rather than PASS-with-a-note) is the point: a caller cannot
-accidentally treat "there was nothing to look at" as "it was looked at and was clean".
+**Step 3 — Local diff census: the oracle.** `git diff --numstat --no-renames <base>...HEAD` → files,
+lines added, lines removed, and the list of paths. `--no-renames` is deliberate: with rename detection a
+renamed file renders as the composite `dir/{old => new}.rs`, which is not a real path and so could never
+be found in the reviewer's prompt (step 6b matches literal paths). Three distinguishable failure
+states, none of which may alias to "genuinely empty":
+
+- `FAIL (base '<ref>' unresolvable)` — a narrow-refspec clone that never fetched the base.
+- `FAIL (git diff failed)` — the measurement never happened.
+- `NOTHING-TO-REVIEW` (exit `3`) — genuinely 0 files, no review enqueued, explicitly **not** a pass and
+  not recordable as "roborev clean".
+
+"We could not tell" must never render as "there is nothing to look at".
+
+**Step 3b — Code-free census: a DETERMINISTIC FAIL, pre-enqueue.** roborev structurally discards a
+code-free diff, so a census that is entirely prose cannot be certified by roborev **at all** — and that
+is a property of OUR census, measured locally, so it must not depend on the reviewer admitting it. The
+previous revision computed this classification and used it only for attribution WORDING, so a docs-only
+diff could reach `RESULT: PASS` whenever the verdict happened not to carry the phrase — violating this
+change's own spec requirement and CLAUDE.md rule (4). Classification is by **file EXTENSION**
+(`md markdown mdx txt rst adoc`) with a path assist limited to **extensionless** files under
+`openspec/ docs/ website/ .claude/`. An earlier revision treated everything under `docs/`, `.github/`
+or `.claude/` as prose, which misclassifies `docs/foo.py` and `.github/workflows/*.yml` — and now that
+code-free is a FAIL condition, a false code-free classification is a **false FAIL**.
 
 **Step 4 — Invoke by explicit SHA + explicit repo (AC2).**
 
@@ -61,186 +122,260 @@ roborev review <head-sha> --repo <abs-repo> --agent <a> --model <m> --wait
 ```
 
 **NEVER bare `--branch`** (trigger 1). **NEVER the two-positional range form** (trigger 2). Both
-`--agent` and `--model` are always passed — the wrapper refuses to run with only one of them, preserving
-the already-documented #2433 trap (`--agent codex` alone inherits `review_model` from `.roborev.toml`
-and hard-400s; and to run the Claude reviewer you must override **both**). Enforcing it in the wrapper
-converts a silent-looking outage into a usage error at the call site.
+`--agent` and `--model` are always passed — the wrapper refuses to run with only one, preserving the
+#2433/#3037 trap (`--agent claude-code` alone inherits `review_model` from `.roborev.toml` and fails as
+a silent-looking outage). Enforcing it in the wrapper converts that outage into a usage error at the
+call site. The transcript goes to `--log`; stdout stays reserved for the block.
 
-**Step 5 — Reviewed-SHA assert (AC2).** Parse `Enqueued job <N> for <sha>` from the invocation's
-output and require `<sha>` to prefix-match HEAD (either direction, since roborev may print an
-abbreviated sha). A mismatch FAILs loudly. When the mismatched sha resolves to `<base>` /
-`origin/main`, the message must **say so explicitly** — that equality is the fingerprint of trigger 1,
-and naming it turns a confusing failure into a one-line diagnosis. If the `Enqueued job` line is absent
-entirely, that is also a FAIL (unparseable ⇒ unverifiable ⇒ fail closed), never a skip.
+**Step 5 — Reviewed-SHA assert (AC2): the STRUCTURED field is the oracle.** The job record's `git_ref`
+is a full 40-char sha recorded by roborev itself, so it is compared full-sha to full-sha. The stdout
+`Enqueued job <N> for <sha>` line is **demoted to a cross-check** — parsing a tool's prose is the weaker
+source whenever a structured one exists — but its absence is still a hard FAIL, because it carries the
+job id every structured query needs. Parsing is defensive: lower-cased before matching (so an
+upper-case announcement cannot survive the match and then fall out of field extraction as garbage
+handed to `roborev show`), a **7**-hex-char floor (4 was loose enough that a 4-char prefix satisfied the
+assert), both fields validated, and with several announcements the LAST is the effective enqueue with
+the multiplicity recorded. A mismatch is ATTRIBUTED: equal to the base ⇒ the worktree `--branch`
+signature; neither endpoint ⇒ the range-form signature. A disagreement between stdout and `git_ref` is
+a NOTICE, because it means one of the two surfaces is misreporting.
 
-**Step 6 — Vacuity assert (AC1), two tiers, deterministic tier primary.**
+**Step 5b — `model:`.** `requested_model` ≠ `model` is surfaced as a **loud NOTICE, not a FAIL**: a
+model-alias resolution is legitimate, so a mismatch is not by itself evidence of a bad review, and an
+always-red guard is the failure mode that gets guards bypassed (this change hit that twice). Review
+integrity is carried by the deterministic checks; this line exists so a substitution can never happen
+SILENTLY.
 
-- **Tier 1 — PRIMARY, deterministic, no thresholds.** The reviewer's own output claiming no code
-  changes — `/contains no code changes to review/i`, `/no code changes/i` — while the **step-3 census
-  is NON-empty** is a **HARD FAIL**. This is a comparison against a locally-computed oracle, not a
-  guess: we know the diff is non-empty because we measured it ourselves, so a reviewer asserting the
-  opposite has demonstrably not reviewed the change. This tier alone catches trigger 3 (which passes
-  the SHA assert) and also back-stops triggers 1 and 2.
-- **Tier 2 — CORROBORATING, bounded token accounting.** From `roborev show <N> --json` (fallback
-  `roborev list --json`): on a **non-empty census**, `input < VACUOUS_MAX_INPUT_TOKENS` **OR**
-  `cached_input == 0` **OR** `output < VACUOUS_MIN_OUTPUT_TOKENS` is also a HARD FAIL. The thresholds
-  are **named constants at the top of the script** with the measured evidence table cited in a comment,
-  and the failure message prints the **observed numbers next to the threshold**, so a future
-  recalibration is a one-line, evidenced change rather than an archaeology exercise.
+**Step 6a — `review-completed:` — POSITIVE evidence a review HAPPENED.** Required before PASS is
+reachable: the job `status` must not be a value other than `done`, AND the transcript must carry a
+**terminal verdict marker** from an allow-list (a severity-tagged findings marker, or the clean shape:
+"no issues found" AND a `Summary:` line). Absence ⇒ FAIL CLOSED. This is the inverse of the original
+logic and closes the worst defect found in review: a transcript showing only "waiting for job N", a
+`400 … model is not supported`, or `status: failed (provider timeout)` each contain no vacuous phrase
+and all three used to PASS. When `status` is unavailable, completion may rest on the marker alone — with
+a NOTICE naming it as the weaker of the two signals, never a silent upgrade to `done`.
 
-  Initial calibration from the recorded evidence (genuine: 398k–649k input / 314k–554k cached / ~5k
-  output / 2m25s–2m45s; vacuous: ~18k input / 0 cached / ≤56 output / 8s):
+**Step 6b — `prompt-content:` — DETERMINISTIC, threshold-free.** Reads the prompt actually sent to the
+agent (the job record's `prompt`, else `roborev show <job> --prompt`) and looks for OUR census's own
+paths in it. This is the deterministic complement of tier 1: tier 1 catches "the reviewer GOT the diff
+and discarded it"; this catches "the reviewer never GOT the diff". Bounded by
+`PROMPT_CONTENT_MAX_PATHS_CHECKED=40` — all paths for a small census, an evenly sampled subset (all of
+which must be present) for a large one — and the PASS value reports the coverage it checked. A
+whitespace-only prompt file is a RETRIEVAL FAILURE ⇒ `UNAVAILABLE` (degraded, visible), never a FAIL:
+an unsupported roborev build must not false-FAIL every run.
 
-  | Constant | Value | Margin vs evidence |
-  |---|---|---|
-  | `VACUOUS_MAX_INPUT_TOKENS` | 50,000 | ~2.7× above the vacuous ceiling (18.8k), ~8× below the genuine floor (398k) |
-  | `VACUOUS_MIN_OUTPUT_TOKENS` | 200 | ~3.6× above the vacuous ceiling (56), ~25× below the genuine floor (5,067) |
+**Step 6c — `findings:` and `roborev-exit:`.** roborev **exits non-zero when it REPORTS FINDINGS**. The
+original wording called every non-zero exit a reviewer malfunction, which is dangerous in the OPPOSITE
+direction from the vacuity bug: an agent told the reviewer broke will retry or bypass instead of FIXING
+the findings. So the exit is split — `FINDINGS (exit N)` when the review ran (structured `status` is the
+authority) versus `ERROR (exit N)` when the reviewer itself failed — and the findings state gets its own
+key (`NONE` / `PRESENT` / `PRESENT (n)` / `UNKNOWN` / `SKIP`). Both still force `RESULT: FAIL` (a review
+with open findings is not "roborev clean"), but the FINDINGS message says explicitly: the review is
+genuine, do not retry, do not bypass, triage and fix.
 
-  If token accounting is **unavailable** from the installed roborev build (no `show --json`, or the
-  fields are absent), that is a **degraded-signal notice** stamped in the summary block and tier 1
-  still governs — **never a silent skip**, and never a downgrade of tier 1.
+**Step 6d — `vacuity-tier1:` — AUTHORITATIVE, but ANCHORED and GATED.** The reviewer's own summary
+claiming no code changes, against a census we measured as non-empty, is T3 and must FAIL, not merely
+note. But the naive form false-FAILs: matched anywhere in the transcript, a genuine review that merely
+QUOTED the phrase was failed as vacuous — and this change's own diff carries the phrase in five-plus
+files. Two properties make the strict version safe:
 
-**Step 7 — Emit a compact, machine-greppable summary block.**
+1. **Anchoring** — only the verdict/summary region (the lines carrying `Summary:`) is matched, never
+   arbitrary finding bodies. No such region ⇒ `UNAVAILABLE`.
+2. **Gating on `findings:`** — `NONE` ⇒ the reviewer is CLAIMING CLEANLINESS, so the phrase is a vacuity
+   claim ⇒ **HARD FAIL**. `UNKNOWN` ⇒ **HARD FAIL** too: an unknowable state must never DISARM the
+   check. `PRESENT*` ⇒ the reviewer demonstrably analysed the diff, so the phrase is discussion ⇒
+   advisory `NOTICE`, which does not fail the run.
 
-One field per line — a reader greps a single `^<key>: ` anchor, never a column offset. The as-built
-block (pinned by `scripts/tests/test_roborev_review_guard.sh`) is exactly:
+Why the relaxation is recorded rather than silent: the systemic cost of a false FAIL here is agents
+learning to **WAIVE tier-1 FAILs**, which restores the original defect wholesale. A guard that cries
+wolf is a guard that gets bypassed.
+
+**Step 6e — `vacuity-tier2:` — corroborating, fail-closed only, and now actually alive.** The tier was
+**permanently `UNAVAILABLE` on every real run** before this fix: the real payload's `token_usage` is a
+**JSON-ENCODED STRING** (it must be decoded TWICE) and the output count is `total_output_tokens`, not
+`output_tokens` — so a single decode read no counts, reported a non-failing `UNAVAILABLE`, and the guard
+silently was not there. Hence three explicit states in `roborev-job-facts.py`:
+
+| state | meaning | wrapper |
+|---|---|---|
+| `absent` | no token field at all | `UNAVAILABLE` (legitimate build difference) |
+| `parsed` | counts readable | evaluate the thresholds |
+| `unparseable` | a token field IS present, no alias resolved | **`FAIL` (drift)** |
+
+`unparseable` is a FAIL, not a notice, precisely because that is how the tier was disarmed. The remedy
+in the message is "add the alias to `INPUT/CACHED/OUTPUT_TOKEN_KEYS`", never "waive it". A drift FAIL
+costs one re-run; a silently disarmed guard costs an unreviewed merge.
+
+Calibration, and the two deliberate changes from the original spec:
+
+```
+VACUOUS baseline:  17,333–18,801 input, 0 cached, 21–56 output, 8s   (jobs 4651/4658/4659)
+GENUINE, SMALL:    67,387 input, 43,520 cached, 2,232 output, 68s    (20 files, +2279)
+GENUINE, LARGE:    398k–649k input, 314k–554k cached, 5.0k–6.3k out  (jobs 4652/4654/4656)
+```
+
+- `ROBOREV_VACUITY_MIN_INPUT_TOKENS = 25000` — **lowered from the originally specified 50,000**, and
+  re-anchored on the **vacuous ceiling** rather than the genuine band, because the genuine band scales
+  with diff size. 25,000 is ~1.33× above the highest vacuous run (18,801) and ~2.7× below the smallest
+  genuine one (67,387). The original 50,000 was only 1.35× below that 67k run — one modestly smaller
+  genuine diff away from an always-red guard.
+- **The output-token floor was DROPPED as a FAIL condition** (kept as an advisory NOTICE at 200). A
+  genuine CLEAN review and a vacuous one emit near-identical output: both are "No issues found" plus
+  one sentence (~20–60 tokens; vacuous measured 21–56). The counts COLLIDE, so an output floor would
+  false-FAIL precisely the case we care most about — a real review that is legitimately clean. It cannot
+  discriminate, so it is reported and never asserted.
+- `cached_input_tokens == 0` **stays** a FAIL, with its false-positive caveat documented (a genuinely
+  cold cache can report 0). It is an accepted trade in the fail-closed direction, affordable now that
+  `prompt-content` gives a deterministic primary check — tier 2 is no longer the only thing standing
+  between us and a vacuous pass. Wall time is deliberately NOT asserted (host-dependent, #2642).
+
+**Step 7 — Emit a compact, machine-greppable summary block.** One field per line — a reader greps a
+single `^<key>: ` anchor, never a column offset. The as-built block, in contract order (pinned by
+`scripts/tests/test_roborev_review_guard.sh`):
 
 ```
 ==== ROBOREV REVIEW SUMMARY ====
 repo: <abs>
 branch: <name>
 base: <ref>
-head-sha: <sha>
+head-sha: <sha40>|-
 reviewed-sha: <sha>|-
 job: <N>|-
-census: <F> files, +<A>/-<D>
-tokens: input=<i> cached=<c> output=<o>   (or: tokens: UNAVAILABLE)
-push-assert: PASS|FAIL(<reason>)|SKIP
-census-check: PASS|FAIL(<reason>)|SKIP
-sha-assert: PASS|FAIL(<reason>)|SKIP
-vacuity-tier1: PASS|FAIL(<reason>)|SKIP
-vacuity-tier2: PASS|FAIL(<reason>)|UNAVAILABLE|SKIP
+model: <m> | <m> (SUBSTITUTED — requested '<r>') | <m> (UNCONFIRMED — no model field in the job record) | -
+census: <F> file(s), +<A>/-<D>   |  -
+tokens: input=<i> cached=<c> output=<o|unknown>   |  UNAVAILABLE
+push-assert:      PASS | SKIP | FAIL (detached HEAD) | FAIL (ls-remote failed: infra/auth)
+                                    | FAIL (branch absent on remote <r>) | FAIL (unpushed commits)
+census-check:     PASS | SKIP | FAIL (git diff failed) | FAIL (base '<ref>' unresolvable) | FAIL (empty census)
+code-free:        PASS | SKIP | FAIL (code-free census: n/n files are documentation/specification text)
+sha-assert:       PASS | SKIP | FAIL (roborev not on PATH) | FAIL (no parseable enqueue announcement)
+                                    | FAIL (unparseable enqueue announcement)
+                                    | FAIL (reviewed-sha does not match head-sha)
+review-completed: PASS | SKIP | FAIL (transcript unreadable) | FAIL (job status '<s>' is not done)
+                                    | FAIL (no terminal verdict marker)
+prompt-content:   PASS (k/n census paths present) | FAIL (k/n census paths absent from the prompt)
+                                    | UNAVAILABLE | SKIP
+vacuity-tier1:    PASS | FAIL (vacuous verdict vs non-empty census)
+                                    | NOTICE (phrase present in a findings-bearing review) | UNAVAILABLE | SKIP
+vacuity-tier2:    PASS | FAIL (vacuous token signature)
+                                    | FAIL (token accounting present but unparseable — drift) | UNAVAILABLE | SKIP
+findings:         NONE | PRESENT | PRESENT (n) | UNKNOWN | SKIP
+roborev-exit:     PASS | FINDINGS (exit N) | ERROR (exit N) | SKIP
 log: <transcript path>
 RESULT: PASS|FAIL|NOTHING-TO-REVIEW
 ```
 
-The greppable key set is therefore `repo:` `branch:` `base:` `head-sha:` `reviewed-sha:` `job:`
-`census:` `tokens:` `push-assert:` `census-check:` `sha-assert:` `vacuity-tier1:` `vacuity-tier2:`
-`log:` and the terminal `RESULT:`. `census-check:` carries the census oracle's own verdict (it is the
-key that FAILs when the base ref is unresolvable, and the key that marks the empty-census
-`NOTHING-TO-REVIEW` path); `log:` names the transcript so a caller never needs to retain it. A
-per-check key whose step was never reached reads `SKIP` — a value that can never be mistaken for a
-pass, and never a blank.
+Note `sha-assert: FAIL (roborev not on PATH)`: an absent binary is a pre-enqueue fail-closed condition
+reported under the assert that would have consumed the announcement. Every per-check key participates in
+ONE scan: a value starting `FAIL` / `FINDINGS` / `ERROR` fails the run; `PASS` / `SKIP` / `UNAVAILABLE` /
+`NOTICE` never do (NOTICE is the advisory tier's value and is deliberately non-failing). A key whose
+step was never reached reads `SKIP` — never a blank, and never mistakable for a pass.
 
-Exit codes: `0` = PASS, `1` = FAIL, `3` = NOTHING-TO-REVIEW, and `2` = **usage error**. Exit 2 is
-deliberately NOT a verdict: it emits **no** summary block at all (a loud `ERROR:` naming the missing
-option, on stderr, before any repo identity is resolved and before anything is enqueued), because a
-`RESULT:` line for a run that never happened would alias a usage error onto one of the three real
-outcomes — recreating the very indistinguishability this change exists to eliminate. `--help` (exit 0)
-is likewise not a verdict and emits no block. Modeled deliberately on the gate's
-summary-file contract: **an agent retains only this block, never raw roborev stdout** (the raw
-transcript goes to a log path named in the block). The block name is distinct from
-`AGENT-GATE SUMMARY` / `AGENT-GATE LITE SUMMARY` / `AGENT-GATE DELTA SUMMARY` so it can never be pasted
-as a gate verdict, and vice versa.
+Exit codes: `0` PASS, `1` FAIL, `3` NOTHING-TO-REVIEW, `2` **usage error**. Exit 2 is deliberately NOT a
+verdict: it emits **no** summary block at all (a loud `ERROR:` naming the missing option, before any repo
+identity is resolved and before anything is enqueued), because a `RESULT:` line for a run that never
+happened would alias a usage error onto one of the three real outcomes — recreating the very
+indistinguishability this change exists to eliminate. `--help` (exit 0) is likewise not a verdict. An
+unexpected mid-run abort is caught by an `EXIT` trap that still emits the block with `RESULT: FAIL`: a
+run that died without a verdict must never look like a run that was never made. Modeled on the gate's
+summary-file contract: **an agent retains only this block, never raw roborev stdout**. The block name is
+distinct from `AGENT-GATE SUMMARY` / `… LITE …` / `… DELTA …` so neither can be pasted as the other.
 
-**Step 7b — the reviewer's own exit status gets its own key: `roborev-exit:`.** A non-zero exit from the
-underlying `roborev` process is already a fail-closed FAIL (it forces `RESULT: FAIL` and adds an
-`ERROR:` detail line naming the observed code), but a detail line is **prose**: a reader that retains
-only the block and greps the per-check keys sees `push-assert`/`census-check`/`sha-assert`/
-`vacuity-tier1`/`vacuity-tier2` all `PASS` and no key explaining the FAIL. That is exactly the
-"which check tripped?" ambiguity every other key exists to remove, and it is the one failure cause a
-grep-based reader cannot attribute. So the block carries `roborev-exit: PASS` when the process exited
-zero and `roborev-exit: FAIL (exit <N>)` otherwise — placed with the other per-check keys, before
-`log:` — and it participates in the same `FAIL*` scan that computes the terminal verdict. (This key is
-the one field the step-7 sketch above does not yet list, because the sketch records the block as
-currently built: emitting it is a one-line addition to the wrapper's `emit_summary`, and the fail-closed
-BEHAVIOUR it reports is already implemented — only the greppable surfacing is missing.)
-
-**Step 8 — Hygiene.** The script stays small (we adopt the campsite rule's spirit: the gate's
-`file-size` ratchet covers `.rs` only, so this is a review expectation, not a mechanized one) and free
-of the traps in CLAUDE.md's pre-roborev self-check list — notably no wall-clock threshold asserts in
-the regression test's correctness path (#2642, mechanized by `roborev-lints`) and no unquoted
-interpolation of external output into a shell command.
+**Step 8 — Hygiene.** No wall-clock threshold asserts in the regression test's correctness path (#2642,
+mechanized by `roborev-lints`); no unquoted interpolation of external output into a shell command;
+`shellcheck 0.10.0` clean at info level with `-x` across all three shell files (the `-x` matters — it is
+what resolves the sourced-fragment variables across the source boundary).
 
 ### Docs-only diffs cannot be roborev-certified
 
 Trigger 3 is not a bug we can route around: roborev **structurally discards a code-free diff**. So the
-sanctioned position is explicit — a docs/spec/workflow-only diff **cannot be certified by roborev at
-all**. The wrapper FAILs it as vacuous (tier 1 fires: non-empty census, "no code changes" verdict), and
-the sanctioned substitute is **verification against primary sources**, recorded in the PR body. For
-#2950 that was `git show cassandra-5.0.8:<path>` — reading the pinned Cassandra source that the docs
-claim to describe. A docs-only PR must **never** record "roborev clean".
+sanctioned position is explicit — a docs/spec-only diff **cannot be certified by roborev at all**. The
+wrapper FAILs it deterministically at `code-free:` **before enqueuing anything** (the reviewer's prose is
+not involved), and the sanctioned substitute is **verification against primary sources**, recorded in the
+PR body. For #2950 that was `git show cassandra-5.0.8:<path>`. A docs-only PR must **never** record
+"roborev clean".
 
 This dovetails with existing doctrine rather than fighting it: CLAUDE.md already treats a docs-only diff
 specially for the gate (the #3042 CITE-AND-WAIVE rule). The parallel is deliberate — a docs-only diff
 cannot be *certified* by a tool whose subject is compiled code, in either the gate's or roborev's case.
 
-### Call-site migration
+### Call-site migration — SIXTEEN surfaces, three obligation classes
 
-Every roborev invocation in the agent surfaces routes through the wrapper, and bare `--branch` becomes
-non-sanctioned prose. The ten touched surfaces are NOT homogeneous — six carry an invocation, four
-carry only a *reference* — and conflating them would state an obligation four of them cannot satisfy:
+Every roborev invocation in the agent surfaces and the fleet-facing doctrine routes through the wrapper,
+and bare `--branch` becomes non-sanctioned prose. The surfaces are NOT homogeneous, and conflating them
+would state an obligation four of them cannot satisfy:
 
-- **Invocation sites** — the documented procedure runs the wrapper:
-  - Review-round sites (run a round themselves; must also state push-first and non-PASS-is-failed):
-    `.claude/skills/flow-implement/SKILL.md` (the review-first step — the primary call site, previously
-    documenting `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`),
-    `.claude/agents/flow-closer.md` (the final confirmation pass — the **merge-gating** call site;
-    previously documenting a `/roborev-review-branch` form that does not exist),
-    `.claude/skills/flow-address/SKILL.md` (the post-comment re-review).
-  - Prescribing sites (name the wrapper as the invocation to be used, without running a round in-line):
-    `.claude/agents/flow-lead.md` (the stage table + the doctrine bullet),
-    `.claude/skills/ci-cd-validation/SKILL.md` + `.claude/skills/ci-cd-validation/merge-process.md`
-    (the merge-readiness definition), `.claude/skills/flow-activate/SKILL.md` (the tasks it authors
-    must name the wrapper for their roborev step).
-- **Non-invoking surfaces** — they contain no roborev invocation at all and must say so, pointing at
-  the wrapper as the only sanctioned invocation: `.claude/skills/flow-finalize/SKILL.md` (the
-  telemetry `--roborev-findings` counter + what "roborev clean" means in the ledger),
-  `.claude/agents/rust-reviewer.md` (the pre-roborev self-check classes — and it additionally flags a
-  reintroduced bare `--branch`/range form as a **BLOCKER**), `.claude/agents/sstable-developer.md` and
-  `.claude/agents/test-validator.md` (the `roborev-lints` lite component + never-invoke-directly).
+- **Review-round sites (4)** — run a round themselves; must also state push-first and
+  non-PASS-is-a-failed-round: `.claude/skills/flow-implement/SKILL.md` (the review-first step — the
+  primary call site; *previously* documented the now **NON-SANCTIONED, historical**
+  `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`),
+  `.claude/agents/flow-closer.md` (the final confirmation pass — the **merge-gating** call site;
+  *previously* documented a `/roborev-review-branch` form that does not exist),
+  `.claude/skills/flow-address/SKILL.md` (the post-comment re-review), and `.claude/commands/worker.md`
+  (the fleet's **unattended entry point**, which runs the implement loop's review step itself).
+- **Prescribing sites (5)** — name the wrapper without running a round in-line:
+  `.claude/agents/flow-lead.md` (stage table + doctrine bullet),
+  `.claude/skills/ci-cd-validation/SKILL.md` + `.claude/skills/ci-cd-validation/merge-process.md`
+  (the merge-readiness definition), `.claude/skills/flow-activate/SKILL.md` (the `tasks.md` it authors),
+  and `.claude/commands/manager.md` (what "roborev clean" means for the workers it dispatches).
+- **Non-invoking surfaces (4)** — no roborev invocation at all; each must SAY so and point at the
+  wrapper: `.claude/skills/flow-finalize/SKILL.md` (the telemetry `--roborev-findings` counter + what
+  "roborev clean" means in the ledger), `.claude/agents/rust-reviewer.md` (pre-roborev self-check
+  classes — and it additionally flags a reintroduced bare `--branch`/range form as a **BLOCKER**),
+  `.claude/agents/sstable-developer.md` and `.claude/agents/test-validator.md` (the `roborev-lints`
+  lite component + never-invoke-directly).
+- **Non-`.claude` doctrine surfaces (3)** — `website/src/content/docs/agents-developing/delivery-pipeline.md`,
+  `docs/development/pm-operating-loop.md`, `docs/development/agent-machine-setup.md`. These were the
+  most important discovery of the migration sweep: each carried the **INVERSE** instruction — "roborev
+  follows this machine's configured agent … run it with no `--agent`/`--model` flags", with
+  `delivery-pipeline.md` calling explicit agent/model **"never doctrine"**. Leaving them would have left
+  the fleet's *published* guidance prescribing exactly the invocation this change forbids.
+
+Plus the two AC4 doctrine surfaces (CLAUDE.md and the `roborev-findings` page) = **18 files** referencing
+the wrapper. `.claude/hooks/issue-gate.sh` is deliberately out of scope: it already documents that no
+hook path runs roborev at all (#2671) and has no invocation to migrate.
 
 ### Regression check + gate wiring
 
-`scripts/tests/test_roborev_review_guard.sh` — **hermetic**: a **stub `roborev`** placed first on
-`PATH` replays the recorded real outputs from the evidence table (enqueue lines, verdict text, and
-`show --json` token payloads), driven against throwaway `git init` fixtures with a synthetic `origin`
-remote. No network, no real roborev, no datasets. Cases (a)–(g) map 1:1 to the spec scenarios: base-sha
-mismatch, neither-endpoint sha, "no code changes" against a non-empty census, vacuous token signature,
-unpushed branch, a genuine PASS, and a genuinely-empty census reporting NOTHING-TO-REVIEW.
+`scripts/tests/test_roborev_review_guard.sh` (1232 lines) — **hermetic**: a **stub `roborev`** first on
+`PATH` replays the recorded real outputs (enqueue lines, verdict text, and the `show --json` payload
+*including* the doubly-encoded `token_usage` string with `total_output_tokens` — reproducing that shape
+verbatim is what keeps tier 2 honest), driven against throwaway `git init` fixtures each with its own
+local bare `origin`. Fixture modes cover the fleet's real topologies: wide/`narrow` refspec, behind,
+`narrow-upstream` (a remote named `upstream`), `unreachable` (ls-remote fails), `no-base`,
+`deleted-remote` (mirror ref equals HEAD, branch deleted), docs-only, mixed, workflow-yaml. No network,
+no real roborev, no datasets, no cargo; ~0.5s. **258 assertions across ~60 named cases, 27/27 mutation
+kills.** A fixture-integrity guard fails if a narrow-refspec fixture ever grows a feature mirror ref —
+otherwise it would silently stop testing the condition it exists for. python3 absence is a loud SKIP for
+the structured-payload cases, never a silent pass.
 
-**Wiring (concrete).** `scripts/agent-gate.sh` registers shell self-tests two ways, and this change
-uses both:
+**Wiring (concrete).** Both registration points in `scripts/agent-gate.sh` are used:
 
-- `run_tooling_tests()` (the `tooling-tests` **full-gate** component) runs a sequence of
-  `bash "$REPO_ROOT/scripts/tests/<name>.sh"` guards, each FAILing the component on non-zero — the
-  pattern used by `test_generator_keyspace_scoping.sh`, `test_udt_rowbuilder_tuple_shape.sh`,
-  `test_check_dockerfile_rust_pin.sh`, `test_check_skill_flag_tables.sh`. The new test is appended
-  there.
-- `run_roborev_lints_cmd()` (the `roborev-lints` component) is in **both** `LITE_COMPONENTS` and
-  `COMPONENTS`, and already chains `check-workflow-injection.sh && check-no-wallclock-asserts.sh`.
-  Adding the guard test here is what makes a regression **FAIL the fast `--lite` loop** rather than
-  cost a review round — the stated acceptance goal — and it is thematically exact: `roborev-lints` is
-  precisely the component that mechanizes roborev-related delivery costs (#2656). The test must be
-  fast (hermetic, seconds) to belong in `--lite`.
+- `run_roborev_lints_cmd()` (component `roborev-lints`) is in **both** `LITE_COMPONENTS` and
+  `COMPONENTS`, and already chains `check-workflow-injection.sh && check-no-wallclock-asserts.sh`. The
+  guard test is appended there — this is what makes a regression **FAIL the fast `--lite` loop** rather
+  than cost a review round, and it is thematically exact: `roborev-lints` is the component that
+  mechanizes roborev-related delivery costs (#2656).
+- `run_tooling_tests()` (the full-gate `tooling-tests` component) runs it too, following the
+  `test_check_dockerfile_rust_pin.sh` / `test_check_skill_flag_tables.sh` guard pattern (FAIL the
+  component on non-zero, with a named failure line).
 
-**Live worktree probe (documented, not gate-run).** A short recorded procedure: from a real
-`issue-<N>-*` worktree with a pushed commit, run the wrapper and confirm `reviewed-sha == head-sha`
-(and `!= origin/main`) in the summary block. This is the only check that can prove the real external
-binary honours the explicit `--repo`; it is documented in the wrapper's usage text / the doctrine page
-rather than run in the gate, because it requires network + a live reviewer and would make the gate
-non-hermetic.
+**Live worktree probe (documented, not gate-run).** From a real `issue-<N>-*` worktree with a pushed
+commit and the root checkout on `main`, run the wrapper and confirm `reviewed-sha == head-sha` (and
+`!= origin/main`) in the block. Only this can prove the real external binary honours the explicit
+`--repo`; it needs network + a live reviewer, so it lives in the wrapper's `--help` text (so procedure
+and implementation cannot drift) and the doctrine page, with an instruction to re-run it after any
+roborev version bump.
 
 ### Doctrine (ships in this change)
 
 CLAUDE.md's roborev-invocation bullet (*Agent-Team Conventions*) and
 `website/src/content/docs/agents-developing/roborev-findings.md` both state: the wrapper is the only
 sanctioned invocation; **verify the reviewed SHA**; `"contains no code changes to review"` on a
-non-empty diff is a **HARD FAIL**; docs-only diffs cannot be roborev-certified. The website page
-already has a "**The reviewer default is codex**" section and a mechanized-in-`--lite` table — both are
-the natural homes for the new rule and the new `roborev-lints` entry. Publication acceptance follows
-CLAUDE.md's rule: **grep the served page for a new distinctive phrase**; a `200` is not proof (observed
-CDN staleness ≈3 minutes).
+non-empty diff is a **HARD FAIL**; docs-only diffs cannot be roborev-certified — plus the exit-code
+contract and "any non-PASS `RESULT`, `NOTHING-TO-REVIEW` included, is a blocked merge". The page also
+gains a row in its **mechanized-in-`--lite`** table for the new guard (a mechanized class absent from
+that table gets hand-checked forever). Publication acceptance follows CLAUDE.md's rule: **grep the
+served page for a new distinctive phrase**; a `200` is not proof (observed CDN staleness ≈3 minutes).
 
 ## Why the token thresholds do NOT violate the no-heuristics mandate (#28)
 
@@ -250,44 +385,74 @@ guessing a CQL type or a format version from data content instead of authoritati
 else `Statistics.db`). It says nothing about, and is not weakened by, **review-tooling liveness
 detection**, which is a property of our own CI process, not of Cassandra's on-disk format.
 
-Three structural properties keep this clean anyway:
+Three structural properties keep this clean anyway, and the final architecture strengthens all three:
 
-1. **Tier 1 is authoritative and threshold-free.** The primary check compares the reviewer's claim
-   against a locally-computed, exact census — the review-tooling analogue of "authoritative metadata
-   only". Tier 2 never overrides it.
-2. **Tier 2's only possible action is to FAIL CLOSED.** It can never manufacture a pass, relax a tier-1
-   FAIL, or infer that a review *did* happen. Its worst-case error is a false FAIL, whose cost is one
-   re-run — bounded, visible, and self-correcting. (A false FAIL is also *preferable* to the status quo,
-   whose failure mode is merging unreviewed code.) The `cached_input == 0` clause is the most
-   false-positive-prone of the three — a genuine review against a cold cache could plausibly report it —
-   and that is an accepted, deliberate trade in the fail-closed direction, recorded here so a future
-   recalibration knows it was a choice, not an oversight.
-3. **The thresholds are evidenced, bounded, and named.** They are constants with the measured table
-   cited beside them, and every failure prints observed-vs-threshold, so recalibration is a one-line
-   evidenced edit — the opposite of an unexplained magic number buried in a branch.
+1. **The verdict is carried by DETERMINISTIC, threshold-free checks** compared against locally obtained
+   oracles — the review-tooling analogue of "authoritative metadata only". Token accounting is the
+   third-ranked signal, not the primary one.
+2. **Tier 2's only possible action is to FAIL CLOSED.** It can never manufacture a pass, relax another
+   check's FAIL, or infer that a review *did* happen. Its worst-case error is a false FAIL, whose cost
+   is one re-run — bounded, visible and self-correcting, and preferable to the status quo, whose failure
+   mode is merging unreviewed code. The `cached == 0` clause is the most false-positive-prone term and
+   is an accepted, deliberate trade, recorded so a future recalibration knows it was a choice.
+3. **The thresholds are evidenced, bounded and named**, with the measured table cited beside them, and
+   every failure prints observed-vs-threshold — the opposite of an unexplained magic number. Where a
+   threshold could NOT discriminate (output tokens), it was **dropped** rather than kept for
+   appearances.
 
 ## Alternatives considered (and why the recommendation beat them)
 
 1. **Register worktrees with `roborev repo` so `--branch` resolves correctly.** *Rejected:* there **is
    no `add` subcommand** — repos self-register on first use, so there is nothing to call. Even if there
-   were, it would fix only trigger 1: trigger 2 (range form mis-enqueue) and trigger 3 (code-free diff
-   discarded) would still return an indistinguishable "No issues found".
+   were, it would fix only trigger 1: triggers 2 and 3 would still return an indistinguishable "No
+   issues found".
 2. **Patch/fork `roborev` upstream.** *Rejected for this change:* the binary is outside this repo's
-   control, and the fleet is exposed on **every** issue right now — a guard we own ships today, an
-   upstream change does not. Noted as a possible **upstream follow-up** (worktree-aware `--branch`
-   resolution; a non-zero exit when a code-free diff is discarded). The wrapper stays correct and
-   cheap after such a fix lands.
+   control and the fleet is exposed on **every** issue right now — a guard we own ships today. Noted as
+   a possible **upstream follow-up** (worktree-aware `--branch`; a non-zero exit when a code-free diff
+   is discarded). The wrapper stays correct and cheap after such a fix lands.
 3. **Run roborev from the root checkout instead of the worktree.** *Rejected:* it breaks 1:1:1:1
-   worktree isolation and requires **commandeering the shared root** — explicitly forbidden (a closer
-   that switched the shared root's branch once stranded root off `main` and broke every session on the
-   box). It also serializes concurrent lanes onto one checkout.
-4. **Token-threshold-only detection.** *Rejected as a primary signal:* it is non-deterministic and
-   recalibrates with every model/prompt change (`gpt-5.6-sol` is codex's own moving default, not a
-   config pin — it already shifted once on a version bump). Demoted to a **corroborating tier** behind
-   the deterministic census comparison, where a drifted threshold can only cost a re-run.
-5. **Trust the verdict text.** *Rejected:* that is precisely the defect. "No issues found" is emitted
+   isolation and requires **commandeering the shared root** — explicitly forbidden (a closer that
+   switched the shared root's branch once stranded root off `main` and broke every session on the box).
+   It also serializes concurrent lanes onto one checkout.
+4. **PROSE MATCHING AS THE PRIMARY SIGNAL** (the original design). *Tried and REJECTED with evidence:*
+   it only sees the half of the defect space where the reviewer *tells* you it saw nothing. A job that
+   never finished, a provider `400`, a `status: failed`, and a reviewer that never received the diff all
+   emit **no phrase at all** — and all four reached `RESULT: PASS`, because absence of a phrase was
+   treated as proof of a review. Replaced by `review-completed` (positive evidence) + `prompt-content`
+   (deterministic "did it GET the diff") with the prose check retained, anchored and gated, as
+   corroboration.
+5. **Token-threshold-only detection.** *Rejected as a primary signal:* non-deterministic and
+   recalibrating with every model/prompt change (`gpt-5.6-sol` is codex's own moving default, not a
+   config pin — it already shifted once on a version bump). Demoted to a corroborating tier where a
+   drifted threshold can only cost a re-run.
+6. **An OUTPUT-token floor as a FAIL condition** (originally specified at 200). *Tried and REJECTED with
+   evidence:* a genuine CLEAN review and a vacuous one emit near-identical output counts (~20–60 for
+   both; vacuous measured 21–56), so the signal cannot discriminate them and the floor would false-FAIL
+   precisely the case that matters most. Kept as an advisory NOTICE only.
+7. **A local mirror-ref (`refs/remotes/origin/<branch>`) push assert.** *Tried and REJECTED with
+   evidence:* CQLite clones carry a NARROW fetch refspec
+   (`+refs/heads/main:refs/remotes/origin/main`), so a feature branch's mirror ref is **never** created
+   however often the branch is pushed. The first implementation false-FAILed **100% of the fleet** —
+   which would have made the only sanctioned invocation unusable and pushed agents straight back to the
+   bare `--branch` form. `git ls-remote` asks the REMOTE, which is the authority.
+8. **A mirror-ref FAST PATH in front of `ls-remote`** (short-circuit when the cached ref happens to
+   equal HEAD). *Tried and REJECTED with evidence:* a cached ref survives a **force-push or an outright
+   deletion** of the remote branch, so it can equal HEAD while the remote no longer has the commit —
+   enqueueing a review of a commit the reviewer cannot fetch, i.e. a vacuous-review setup. `ls-remote`
+   costs ~1s, and not trusting local proxies is this wrapper's whole point. Removed entirely.
+9. **Trust the verdict text.** *Rejected:* that is precisely the defect. "No issues found" is emitted
    identically whether 650k tokens of real diff were reviewed or zero bytes were.
-6. **Detect the empty diff by asking roborev what it saw** (e.g. parse the job's reported diffstat).
-   *Rejected:* it re-derives the answer from the same untrusted source. The census must be computed on
-   our side with `git`, or the check is circular — the same reason a CQLite `file:line` is never format
-   authority.
+10. **Detect the empty diff by asking roborev what it saw** (e.g. parse the job's reported diffstat).
+    *Rejected:* it re-derives the answer from the same untrusted source. The census must be computed on
+    our side with `git`, or the check is circular — the same reason a CQLite `file:line` is never format
+    authority.
+11. **Treat a `requested_model` ≠ `model` substitution as a FAIL.** *Rejected:* roborev legitimately
+    resolves model aliases, so this would be red on healthy runs, and an always-red guard is the failure
+    mode that gets guards bypassed (hit twice in this change's own rounds). Surfaced as a loud NOTICE
+    instead, so a substitution can never be SILENT while integrity stays carried by the deterministic
+    checks.
+12. **Treat a present-but-unparseable token payload as a NOTICE.** *Rejected:* that is precisely how the
+    tier was silently disarmed for its entire life before this fix (a double-encoded string and a
+    renamed output field degraded it to a non-failing `UNAVAILABLE` while the real counts were the
+    vacuous baseline). A drift FAIL costs one re-run after a one-line alias addition; a silently
+    disarmed guard costs an unreviewed merge.

--- a/openspec/changes/roborev-vacuous-review-guard/design.md
+++ b/openspec/changes/roborev-vacuous-review-guard/design.md
@@ -7,13 +7,41 @@ runs it review-first on the lite-green diff (#2086), and `flow-closer` runs a fi
 before arming `gh pr merge --auto` (#2084/#2667). "roborev clean" is therefore load-bearing — if it can
 be satisfied without a review having happened, the pipeline merges unreviewed code with no red anywhere.
 
-Three confirmed triggers produce exactly that (evidence table in `proposal.md`):
+**FOUR** confirmed triggers produce exactly that (evidence table in `proposal.md`; T4 was found by this
+change's own live probe, in round 5):
 
-| # | Trigger | Enqueued SHA | Detectable by a SHA check? |
-|---|---------|--------------|----------------------------|
-| 1 | worktree + `--branch` resolves against the ROOT checkout (on `main`) | `origin/main` | **yes** |
-| 2 | two-positional commit-range form mis-enqueues | neither endpoint | **yes** |
-| 3 | code-free (docs-only) diff silently discarded | correct SHA | **NO** |
+| # | Trigger | Enqueued `git_ref` | Detectable by a SHA check? |
+|---|---------|--------------------|----------------------------|
+| 1 | worktree + `--branch` **without `--repo`** resolves against the ROOT checkout (on `main`) | `origin/main` | **yes** |
+| 2 | two-positional commit-range form anchors the range at git's EMPTY TREE | `4b825dc6…..<head>` | **yes** |
+| 3 | code-free (docs-only) diff structurally discarded | correct SHA | **NO** |
+| 4 | single-SHA form reviews ONE COMMIT, not the branch | `<head40>` — *correct*, and still partial | **NO** (it EQUALS HEAD) |
+
+T4 is the one the issue's own AC2 prescribed, and the nastiest of the four: the enqueued sha is exactly
+branch HEAD, so every sha-equality check passes while the reviewer saw only the last commit. On a
+17-commit branch it delivered 3 of 5 code files.
+
+### The measured invocation matrix (round 5, real daemon)
+
+One branch (17 commits, census 27 files = 22 markdown + 5 code), four invocation forms, measuring the
+enqueued `git_ref` AND which files appear as `diff --git` headers in the prompt actually sent:
+
+| form | enqueued `git_ref` | code files in prompt |
+|---|---|---|
+| `--branch --base <base> --repo <abs>` | `<base40>..<head40>` | **5/5 — SANCTIONED** |
+| `--since <base> --repo <abs>` | `<base40>..<head40>` | 5/5 (byte-identical prompt) |
+| `<base> <head>` (two positionals) | `4b825dc6…`(git EMPTY-TREE)`..<head40>` | 3/5 BROKEN |
+| `<sha>` (single commit) | `<head40>` | 3/5 PARTIAL — one commit |
+
+Three conclusions this document exists to preserve: **(1)** `--repo` is what makes `--branch` correct from
+a worktree (with it, roborev reported "17 commits since origin/main"), so the defect was never `--branch`
+— it was `--branch` *without* `--repo`; **(2)** the single-SHA form is a partial review reported as a
+complete one, so we implement AC2's INTENT (reviewed content must match the requested range) rather than
+its letter; **(3)** all 22 markdown files were ABSENT from the prompt while all 5 code files were present
+— roborev **excludes non-code paths from the diff it constructs**, which is the mechanism behind T3 (for a
+markdown-only diff the constructed diff is genuinely empty, so "contains no code changes to review" is a
+truthful report of an empty input, not a malfunction) and the reason `prompt-content` checks the CODE
+subset of the census.
 
 Two structural facts constrain every option:
 
@@ -42,7 +70,7 @@ against data the wrapper obtains itself:
 | `push-assert` | the REMOTE, via `git ls-remote` | the reviewer can only see what the remote has |
 | `census-check` | our own `git diff --numstat --no-renames` | what MUST be reviewed |
 | `code-free` | our own classification of that census | T3, before a review is even enqueued |
-| `sha-assert` | the job record's structured `git_ref` | T1/T2 — the wrong commit was reviewed |
+| `sha-assert` | the job record's structured `git_ref` (BOTH range endpoints) | T1/T2/T4 — the wrong or partial scope was reviewed |
 | `review-completed` | job `status` + an allow-list of terminal verdict markers | a review actually FINISHED |
 | `prompt-content` | our census's own paths inside the prompt SENT | the reviewer never GOT the diff |
 
@@ -60,19 +88,28 @@ falling back to `$PWD` is exactly how a caller reviews a repository it did not n
 ordered and fail-closed; the first hard failure stops the run, emits the summary block, and exits
 non-zero.
 
-Implementation is **three files**, split for size hygiene and one responsibility each:
+Implementation is **five files**, split for size hygiene and one responsibility each:
 
-- `scripts/flow/roborev-review.sh` (796 lines) — flags, identity, invocation, the asserts, the block.
-- `scripts/flow/roborev-review-oracles.sh` (221) — **sourced**: `roborev_push_assert` + `roborev_census`
+- `scripts/flow/roborev-review.sh` (752 lines) — flags, identity, invocation, the range/job-record asserts,
+  the block.
+- `scripts/flow/roborev-review-oracles.sh` (227) — **sourced**: `roborev_push_assert` + `roborev_census`
   (including the code-free classification). These two are the change's whole thesis in code, and both
   learned the "never trust a local proxy" lesson the hard way (below).
-- `scripts/flow/roborev-job-facts.py` (178) — JSON decoding of the job record: `git_ref`, `status`,
-  `model`/`requested_model`, the prompt, and the token counts with their three-state extraction.
+- `scripts/flow/roborev-review-checks.sh` (342) — **sourced**: the five per-review checks
+  (`review-completed`, `prompt-content`, `findings`/`roborev-exit`, tier 1, tier 2). Split out when the
+  wrapper hit 998 lines. Division of labour: the ORACLES file answers *what must be reviewed, and is it
+  even reviewable*, from data we obtain ourselves; the CHECKS file answers *did a review of that actually
+  happen*, from the job record and the transcript.
+- `scripts/flow/roborev-job-facts.py` (203) — JSON decoding of the job record: `git_ref`, `status`,
+  `model`/`requested_model`, `verdict`, the prompt, and the token counts with their three-state extraction.
+- `scripts/tests/test_roborev_review_guard.sh` (1628) — the hermetic regression check.
 
-The sourced path is resolved from `BASH_SOURCE` (never `$PWD` — the wrapper runs from arbitrary
-worktrees) and the wrapper **FAILs CLOSED** when that file is missing OR truncated: an absent oracles
-file that silently turned the push assert and the census into no-ops would be a worse failure than any
-this guard was built to catch.
+Both sourced paths are resolved from `BASH_SOURCE` (never `$PWD` — the wrapper runs from arbitrary
+worktrees), and the wrapper **FAILs CLOSED** when either is missing OR truncated (the test is that every
+required function is actually defined). Both are validated **BEFORE the review is invoked**, so a broken
+installation costs no review — even though the checks file's functions are not called until after the job
+facts exist. A silently absent helper would leave every key it owns reading `SKIP`/`PASS` beside a
+`RESULT: PASS`, which is a worse failure than any this guard was built to catch.
 
 **Step 1 — Resolve identity.** Repo root (**absolute** — `roborev --repo` must never receive a relative
 path), branch, full 40-char HEAD. `--repo` is always passed explicitly; the wrapper never relies on
@@ -115,29 +152,55 @@ change's own spec requirement and CLAUDE.md rule (4). Classification is by **fil
 or `.claude/` as prose, which misclassifies `docs/foo.py` and `.github/workflows/*.yml` — and now that
 code-free is a FAIL condition, a false code-free classification is a **false FAIL**.
 
-**Step 4 — Invoke by explicit SHA + explicit repo (AC2).**
+**Step 4 — Invoke over the CENSUS RANGE with an explicit repo (AC2's intent).**
 
 ```
-roborev review <head-sha> --repo <abs-repo> --agent <a> --model <m> --wait
+roborev review --branch --base <base> --repo <abs-repo> --agent <a> --model <m> --wait
 ```
 
-**NEVER bare `--branch`** (trigger 1). **NEVER the two-positional range form** (trigger 2). Both
-`--agent` and `--model` are always passed — the wrapper refuses to run with only one, preserving the
-#2433/#3037 trap (`--agent claude-code` alone inherits `review_model` from `.roborev.toml` and fails as
-a silent-looking outage). Enforcing it in the wrapper converts that outage into a usage error at the
-call site. The transcript goes to `--log`; stdout stays reserved for the block.
+This reviews the RANGE `<base>..HEAD` — exactly the census — per the matrix above. **NEVER `--branch`
+WITHOUT `--repo`** (T1). **NEVER the two-positional range form** (T2, empty-tree base). **NEVER a single
+sha** (T4, one commit). This is a deliberate, recorded departure from AC2's literal text, which prescribed
+the single-sha form; the AC's *intent* — the reviewed content must match the requested range — is what the
+wrapper implements and asserts. Both `--agent` and `--model` are always passed — the wrapper refuses to run
+with only one, preserving the #2433/#3037 trap (`--agent claude-code` alone inherits `review_model` from
+`.roborev.toml` and fails as a silent-looking outage). Enforcing it in the wrapper converts that outage
+into a usage error at the call site. The transcript goes to `--log`; stdout stays reserved for the block.
 
-**Step 5 — Reviewed-SHA assert (AC2): the STRUCTURED field is the oracle.** The job record's `git_ref`
-is a full 40-char sha recorded by roborev itself, so it is compared full-sha to full-sha. The stdout
-`Enqueued job <N> for <sha>` line is **demoted to a cross-check** — parsing a tool's prose is the weaker
-source whenever a structured one exists — but its absence is still a hard FAIL, because it carries the
-job id every structured query needs. Parsing is defensive: lower-cased before matching (so an
-upper-case announcement cannot survive the match and then fall out of field extraction as garbage
-handed to `roborev show`), a **7**-hex-char floor (4 was loose enough that a 4-char prefix satisfied the
-assert), both fields validated, and with several announcements the LAST is the effective enqueue with
-the multiplicity recorded. A mismatch is ATTRIBUTED: equal to the base ⇒ the worktree `--branch`
-signature; neither endpoint ⇒ the range-form signature. A disagreement between stdout and `git_ref` is
-a NOTICE, because it means one of the two surfaces is misreporting.
+**Step 5 — Reviewed-RANGE assert (AC2's intent): the STRUCTURED field is the only oracle.** The job
+record's `git_ref` for the sanctioned form is `<base40>..<head40>`, and **BOTH endpoints** are compared
+full-sha to full-sha against the census range — strictly stronger than the single-sha equality it
+replaces (it proves the scope neither stops short of the tip nor starts elsewhere). `reviewed-sha:`
+therefore carries a RANGE, not a sha. Four failure shapes:
+`FAIL (reviewed range does not match <base>...HEAD)` naming the offending endpoint (an empty-tree base is
+called out as the two-positional signature); `FAIL (single-commit record, not the census range)` — which
+fires **even when the single sha EQUALS HEAD**, because `prompt-content` matches PATHS, so a review of only
+the last of several commits touching one file passes every path check while the earlier changes go
+unreviewed; `FAIL (reviewed-sha does not match head-sha)` for a single sha that is not HEAD (attributed to
+the base ref where it equals it); and `FAIL (job record unavailable — reviewed range unverifiable)`.
+
+The stdout `Enqueued job <N> for <sha>` line is **demoted all the way to the carrier of the job id**: for
+a RANGE review it announces only the range BASE, so it can establish nothing about HEAD, and the wrapper
+therefore FAILS CLOSED when the record is unavailable rather than falling back to a check that verifies
+nothing. Its absence is still a hard FAIL, because every structured query needs that id. Parsing stays
+defensive: lower-cased before matching (so an upper-case announcement cannot survive the match and then
+fall out of field extraction as garbage handed to `roborev show`), a **7**-hex-char floor (4 was loose
+enough that a 4-char prefix satisfied the old assert), both fields validated, and with several
+announcements the LAST is the effective enqueue with the multiplicity recorded as a NOTICE.
+
+**Step 5a — `job-record:`, its own key.** Four asserts plus `model:` depend on the structured record, so
+its completeness is reported rather than inferred: `PASS` / `PASS (no token accounting in the record)` /
+`DEGRADED (incomplete after <n>s: <fields>)` / `SKIP`. `DEGRADED` is deliberately NON-failing — the
+dependent asserts publish their own verdicts (notably `sha-assert: FAIL (job record unavailable …)`), so
+nothing is silently weakened. **TWO SOURCES OF DIFFERENT SHAPE** are consulted and a source counts only
+when it yields the fields the asserts need: `roborev show <job> --json` returns the **REVIEW** row (id,
+agent, prompt — but no `git_ref`/`status`/`token_usage`) and NESTS the JOB row under a `job` key, while
+`roborev list --json` returns the JOB row directly. Both rows answer to the same id, so returning the
+first id match handed back the poorer row; the extractor now prefers an id match that actually carries
+`git_ref`. **There was never an async/durability problem** — an earlier round diagnosed one from exactly
+this wrong-row read, and that diagnosis is retracted here: with the nested row read as a first-class source
+the record is complete in ONE read, so the bounded poll is a **5×1s sanity retry** (down from 45×1s), not a
+wait. Shortening it can only make the record MORE likely to read `DEGRADED` — the fail-closed direction.
 
 **Step 5b — `model:`.** `requested_model` ≠ `model` is surfaced as a **loud NOTICE, not a FAIL**: a
 model-alias resolution is legitimate, so a mismatch is not by itself evidence of a bad review, and an
@@ -155,22 +218,51 @@ and all three used to PASS. When `status` is unavailable, completion may rest on
 a NOTICE naming it as the weaker of the two signals, never a silent upgrade to `done`.
 
 **Step 6b — `prompt-content:` — DETERMINISTIC, threshold-free.** Reads the prompt actually sent to the
-agent (the job record's `prompt`, else `roborev show <job> --prompt`) and looks for OUR census's own
-paths in it. This is the deterministic complement of tier 1: tier 1 catches "the reviewer GOT the diff
-and discarded it"; this catches "the reviewer never GOT the diff". Bounded by
-`PROMPT_CONTENT_MAX_PATHS_CHECKED=40` — all paths for a small census, an evenly sampled subset (all of
-which must be present) for a large one — and the PASS value reports the coverage it checked. A
-whitespace-only prompt file is a RETRIEVAL FAILURE ⇒ `UNAVAILABLE` (degraded, visible), never a FAIL:
-an unsupported roborev build must not false-FAIL every run.
+agent (the job record's `prompt`, else `roborev show <job> --prompt`) and looks for the **CODE subset** of
+our census's paths in it. This is the deterministic complement of tier 1: tier 1 catches "the reviewer GOT
+the diff and discarded it"; this catches "the reviewer never GOT the diff". Three properties, each of which
+replaced a reproduced defect:
+
+- **The CODE subset, not every path** — roborev excludes non-code paths from the diff it builds (measured
+  22 markdown absent / 5 code present), so requiring all 27 would false-FAIL every documentation-touching
+  branch, i.e. most of them.
+- **Every code path, no sampling cap** — the former `PROMPT_CONTENT_MAX_PATHS_CHECKED=40` even-sampling
+  bound was a hole: a partial prompt naming just the sampled files passed. Exact-header matching is cheap
+  even for a 500-file diff, so the cap is gone.
+- **Both header SIDES, compared whole-line** — the census runs `--no-renames` (a rename = two paths) while
+  the reviewer's diff may have rename detection ON (one `diff --git a/old b/new` header). Same-path-only
+  matching FALSELY REJECTED every review containing a detected rename; collecting the path set from both
+  sides reconciles the two behaviours without weakening exact-header strictness to a substring test (a
+  substring is satisfied by any incidental mention — including this wrapper quoting a path in a comment).
+
+**An unretrievable (whitespace-only) prompt now FAILS** — `FAIL (prompt unretrievable — no evidence any
+diff was delivered)`. The former non-failing `UNAVAILABLE` was a round-6 BLOCKER: with a non-empty code
+census it allowed PASS with no authoritative evidence any diff reached the reviewer, which contradicts the
+wrapper's whole purpose. It is not an always-red risk either — the prompt is measurably retrievable from
+the record's `prompt` field AND from `roborev show <job> --prompt`, so an empty one is a real anomaly.
+Note the value shapes: `PASS (n/n code census paths present)` vs
+`FAIL (k/n code census paths absent …)` — same denominator, opposite numerator sense, so a grep-based
+reader must read the word, not the ratio.
 
 **Step 6c — `findings:` and `roborev-exit:`.** roborev **exits non-zero when it REPORTS FINDINGS**. The
 original wording called every non-zero exit a reviewer malfunction, which is dangerous in the OPPOSITE
 direction from the vacuity bug: an agent told the reviewer broke will retry or bypass instead of FIXING
 the findings. So the exit is split — `FINDINGS (exit N)` when the review ran (structured `status` is the
 authority) versus `ERROR (exit N)` when the reviewer itself failed — and the findings state gets its own
-key (`NONE` / `PRESENT` / `PRESENT (n)` / `UNKNOWN` / `SKIP`). Both still force `RESULT: FAIL` (a review
-with open findings is not "roborev clean"), but the FINDINGS message says explicitly: the review is
-genuine, do not retry, do not bypass, triage and fix.
+key (`NONE` / `PRESENT` / `PRESENT (n)` / `UNKNOWN` / `INCONSISTENT (…)` / `SKIP`). Both still force
+`RESULT: FAIL` (a review with open findings is not "roborev clean"), but the FINDINGS message says
+explicitly: the review is genuine, do not retry, do not bypass, triage and fix.
+
+The PRESENT/NONE answer is derived from the **structured `verdict` field**, with the exit code as fallback,
+because tier 1 is GATED on it: a regex over the whole transcript let an incidental or quoted `[Low]` set
+`PRESENT` and thereby EXEMPT a genuinely vacuous verdict from tier 1's hard failure. Prose is consulted
+only inside the FINDINGS BLOCK (a `Findings` heading/label through to a **line-initial** `Summary`
+heading/label — matched mid-sentence, the terminator closed the block early and under-counted). The `(n)`
+COUNT stays best-effort prose parsing reported for a human; the PRESENT/NONE/INCONSISTENT distinction is
+the load-bearing part. A contradiction — a clean structured verdict, or a zero exit, beside in-block
+severity markers — is `INCONSISTENT (verdict clean, n findings marker(s))` /
+`INCONSISTENT (exit 0, n findings marker(s))`: both FAIL the run, and being neither `PRESENT` nor `NONE`
+neither can exempt tier 1.
 
 **Step 6d — `vacuity-tier1:` — AUTHORITATIVE, but ANCHORED and GATED.** The reviewer's own summary
 claiming no code changes, against a census we measured as non-empty, is T3 and must FAIL, not merely
@@ -178,8 +270,13 @@ note. But the naive form false-FAILs: matched anywhere in the transcript, a genu
 QUOTED the phrase was failed as vacuous — and this change's own diff carries the phrase in five-plus
 files. Two properties make the strict version safe:
 
-1. **Anchoring** — only the verdict/summary region (the lines carrying `Summary:`) is matched, never
-   arbitrary finding bodies. No such region ⇒ `UNAVAILABLE`.
+1. **Anchoring to the whole summary BLOCK** — from a `Summary` HEADING or a `Summary:` label anywhere on a
+   line, through to the next heading or EOF; never arbitrary finding bodies. No such region ⇒
+   `UNAVAILABLE`. The earlier region — only the LINES containing `Summary:` — was a round-6 BLOCKER: the
+   real format is `## Summary` / blank / prose, so the region held the heading and none of the prose, and a
+   vacuous clean review whose "no code changes" sentence sat under the heading reported **PASS** — the
+   exact defect the wrapper exists to stop. The block form is a strict superset of the line form, so the
+   older single-line `No issues found. Summary: …` shape stays covered.
 2. **Gating on `findings:`** — `NONE` ⇒ the reviewer is CLAIMING CLEANLINESS, so the phrase is a vacuity
    claim ⇒ **HARD FAIL**. `UNKNOWN` ⇒ **HARD FAIL** too: an unknowable state must never DISARM the
    check. `PRESENT*` ⇒ the reviewer demonstrably analysed the diff, so the phrase is discussion ⇒
@@ -238,7 +335,7 @@ repo: <abs>
 branch: <name>
 base: <ref>
 head-sha: <sha40>|-
-reviewed-sha: <sha>|-
+reviewed-sha: <base40>..<head40>   |  <sha40> (only if the record reports a single commit)  |  -
 job: <N>|-
 model: <m> | <m> (SUBSTITUTED — requested '<r>') | <m> (UNCONFIRMED — no model field in the job record) | -
 census: <F> file(s), +<A>/-<D>   |  -
@@ -247,18 +344,27 @@ push-assert:      PASS | SKIP | FAIL (detached HEAD) | FAIL (ls-remote failed: i
                                     | FAIL (branch absent on remote <r>) | FAIL (unpushed commits)
 census-check:     PASS | SKIP | FAIL (git diff failed) | FAIL (base '<ref>' unresolvable) | FAIL (empty census)
 code-free:        PASS | SKIP | FAIL (code-free census: n/n files are documentation/specification text)
+job-record:       PASS | PASS (no token accounting in the record) | SKIP
+                                    | DEGRADED (incomplete after <n>s: <fields>)      <-- NON-failing
 sha-assert:       PASS | SKIP | FAIL (roborev not on PATH) | FAIL (no parseable enqueue announcement)
                                     | FAIL (unparseable enqueue announcement)
+                                    | FAIL (reviewed range does not match <base>...HEAD)
+                                    | FAIL (single-commit record, not the census range)
                                     | FAIL (reviewed-sha does not match head-sha)
+                                    | FAIL (job record unavailable — reviewed range unverifiable)
 review-completed: PASS | SKIP | FAIL (transcript unreadable) | FAIL (job status '<s>' is not done)
                                     | FAIL (no terminal verdict marker)
-prompt-content:   PASS (k/n census paths present) | FAIL (k/n census paths absent from the prompt)
-                                    | UNAVAILABLE | SKIP
+prompt-content:   PASS (n/n code census paths present)
+                                    | FAIL (k/n code census paths absent from the prompt)
+                                    | FAIL (prompt unretrievable — no evidence any diff was delivered)
+                                    | SKIP                                  <-- NO passing UNAVAILABLE
 vacuity-tier1:    PASS | FAIL (vacuous verdict vs non-empty census)
                                     | NOTICE (phrase present in a findings-bearing review) | UNAVAILABLE | SKIP
 vacuity-tier2:    PASS | FAIL (vacuous token signature)
                                     | FAIL (token accounting present but unparseable — drift) | UNAVAILABLE | SKIP
 findings:         NONE | PRESENT | PRESENT (n) | UNKNOWN | SKIP
+                                    | INCONSISTENT (verdict clean, n findings marker(s))
+                                    | INCONSISTENT (exit 0, n findings marker(s))
 roborev-exit:     PASS | FINDINGS (exit N) | ERROR (exit N) | SKIP
 log: <transcript path>
 RESULT: PASS|FAIL|NOTHING-TO-REVIEW
@@ -266,9 +372,10 @@ RESULT: PASS|FAIL|NOTHING-TO-REVIEW
 
 Note `sha-assert: FAIL (roborev not on PATH)`: an absent binary is a pre-enqueue fail-closed condition
 reported under the assert that would have consumed the announcement. Every per-check key participates in
-ONE scan: a value starting `FAIL` / `FINDINGS` / `ERROR` fails the run; `PASS` / `SKIP` / `UNAVAILABLE` /
-`NOTICE` never do (NOTICE is the advisory tier's value and is deliberately non-failing). A key whose
-step was never reached reads `SKIP` — never a blank, and never mistakable for a pass.
+ONE scan: a value starting `FAIL` / `FINDINGS` / `ERROR` / `INCONSISTENT` fails the run;
+`PASS*` / `SKIP` / `UNAVAILABLE` / `NOTICE*` / `DEGRADED*` never do (NOTICE is the advisory tier's value;
+DEGRADED reports an incomplete job record whose consequences are carried by the dependent asserts). A key
+whose step was never reached reads `SKIP` — never a blank, and never mistakable for a pass.
 
 Exit codes: `0` PASS, `1` FAIL, `3` NOTHING-TO-REVIEW, `2` **usage error**. Exit 2 is deliberately NOT a
 verdict: it emits **no** summary block at all (a loud `ERROR:` naming the missing option, before any repo
@@ -336,17 +443,21 @@ hook path runs roborev at all (#2671) and has no invocation to migrate.
 
 ### Regression check + gate wiring
 
-`scripts/tests/test_roborev_review_guard.sh` (1232 lines) — **hermetic**: a **stub `roborev`** first on
+`scripts/tests/test_roborev_review_guard.sh` (1628 lines) — **hermetic**: a **stub `roborev`** first on
 `PATH` replays the recorded real outputs (enqueue lines, verdict text, and the `show --json` payload
-*including* the doubly-encoded `token_usage` string with `total_output_tokens` — reproducing that shape
-verbatim is what keeps tier 2 honest), driven against throwaway `git init` fixtures each with its own
+*including* the doubly-encoded `token_usage` string with `total_output_tokens`, and the REVIEW row that
+NESTS the job row under a `job` key — reproducing those shapes verbatim is what keeps tier 2 and the
+job-record read honest), driven against throwaway `git init` fixtures each with its own
 local bare `origin`. Fixture modes cover the fleet's real topologies: wide/`narrow` refspec, behind,
 `narrow-upstream` (a remote named `upstream`), `unreachable` (ls-remote fails), `no-base`,
-`deleted-remote` (mirror ref equals HEAD, branch deleted), docs-only, mixed, workflow-yaml. No network,
-no real roborev, no datasets, no cargo; ~0.5s. **258 assertions across ~60 named cases, 27/27 mutation
-kills.** A fixture-integrity guard fails if a narrow-refspec fixture ever grows a feature mirror ref —
-otherwise it would silently stop testing the condition it exists for. python3 absence is a loud SKIP for
-the structured-payload cases, never a silent pass.
+`deleted-remote` (mirror ref equals HEAD, branch deleted), docs-only, mixed, workflow-yaml, and
+`renamed` (a rename the census sees as two paths). No network,
+no real roborev, no datasets, no cargo. **329 assertions; deliberate wrapper mutations killed 27/27 in the
+round-5 batch and 15/15 in the round-6 batch** (the one survivor found there — the nested-job-row read —
+is now pinned by case x10). A fixture-integrity guard fails if a narrow-refspec fixture ever grows a
+feature mirror ref — otherwise it would silently stop testing the condition it exists for. python3 absence
+is a loud SKIP for the structured-payload cases, never a silent pass. The tally line deliberately does NOT
+start with `RESULT:`, a token that belongs to the gate's summary contract and the wrapper's own block.
 
 **Wiring (concrete).** Both registration points in `scripts/agent-gate.sh` are used:
 
@@ -360,19 +471,39 @@ the structured-payload cases, never a silent pass.
   component on non-zero, with a named failure line).
 
 **Live worktree probe (documented, not gate-run).** From a real `issue-<N>-*` worktree with a pushed
-commit and the root checkout on `main`, run the wrapper and confirm `reviewed-sha == head-sha` (and
-`!= origin/main`) in the block. Only this can prove the real external binary honours the explicit
-`--repo`; it needs network + a live reviewer, so it lives in the wrapper's `--help` text (so procedure
-and implementation cannot drift) and the doctrine page, with an instruction to re-run it after any
-roborev version bump.
+commit and the root checkout on `main`, run the wrapper and confirm the reviewed scope COVERS the worktree
+HEAD: with the sanctioned range invocation `reviewed-sha:` is `<base40>..<head40>`, so the assertion is on
+the range's HEAD endpoint (plus `sha-assert: PASS`, which is only reachable when both endpoints match), and
+a `reviewed-sha` that is the base alone means the explicit `--repo` did not defeat the root-checkout
+resolution. Only this probe can prove the real external binary honours the explicit `--repo`; it needs
+network + a live reviewer, so it lives in the wrapper's `--help` text (so procedure and implementation
+cannot drift) and the doctrine page, with an instruction to re-run it after any roborev version bump.
+
+**Known residual (recorded, not hidden).** The `--help` probe text still phrases step 3 as
+`reviewed-sha == head-sha (prefix match)`, wording that predates the range form and which the pinned
+regression case asserts verbatim; the corrected RANGE phrasing has landed on the doctrine page. Both should
+converge on the range form in a follow-up touch of `scripts/flow/roborev-review.sh` + its test — it is a
+documentation-only staleness (no assert depends on it), but it is exactly the kind of drift this section
+exists to name.
 
 ### Doctrine (ships in this change)
 
 CLAUDE.md's roborev-invocation bullet (*Agent-Team Conventions*) and
 `website/src/content/docs/agents-developing/roborev-findings.md` both state: the wrapper is the only
-sanctioned invocation; **verify the reviewed SHA**; `"contains no code changes to review"` on a
-non-empty diff is a **HARD FAIL**; docs-only diffs cannot be roborev-certified — plus the exit-code
-contract and "any non-PASS `RESULT`, `NOTHING-TO-REVIEW` included, is a blocked merge". The page also
+sanctioned invocation; **verify the reviewed SCOPE against the census range**; `"contains no code changes to
+review"` on a non-empty diff is a **HARD FAIL**; docs-only diffs cannot be roborev-certified — plus the
+exit-code contract and "any non-PASS `RESULT`, `NOTHING-TO-REVIEW` included, is a blocked merge".
+
+**The three measured corrections land on every surface that states the rule** (CLAUDE.md,
+`roborev-findings.md`, `delivery-pipeline.md`, `docs/development/pm-operating-loop.md`,
+`docs/development/agent-machine-setup.md`), because the previous wording FORBADE the form now known to be
+correct: (a) the non-sanctioned form is `--branch` **WITHOUT** an explicit `--repo`, not `--branch` as such;
+(b) the single-SHA form reviews ONE COMMIT — a fourth vacuity class, and the form AC2 literally asked for;
+(c) roborev EXCLUDES non-code paths from the diff it builds, which is why a markdown-only diff yields a
+genuinely empty input (a truthful "no code changes" report), why `prompt-content` checks the CODE subset,
+and why the deterministic pre-enqueue `code-free:` FAIL is the right answer. The block's documented keys
+gain `job-record:` and the corrected `prompt-content:` values, and the live-probe section is restated in the
+range form. The page also
 gains a row in its **mechanized-in-`--lite`** table for the new guard (a mechanized class absent from
 that table gets hand-checked forever). Publication acceptance follows CLAUDE.md's rule: **grep the
 served page for a new distinctive phrase**; a `200` is not proof (observed CDN staleness ≈3 minutes).
@@ -404,7 +535,7 @@ Three structural properties keep this clean anyway, and the final architecture s
 
 1. **Register worktrees with `roborev repo` so `--branch` resolves correctly.** *Rejected:* there **is
    no `add` subcommand** — repos self-register on first use, so there is nothing to call. Even if there
-   were, it would fix only trigger 1: triggers 2 and 3 would still return an indistinguishable "No
+   were, it would fix only T1: T2, T3 and T4 would still return an indistinguishable "No
    issues found".
 2. **Patch/fork `roborev` upstream.** *Rejected for this change:* the binary is outside this repo's
    control and the fleet is exposed on **every** issue right now — a guard we own ships today. Noted as
@@ -456,3 +587,46 @@ Three structural properties keep this clean anyway, and the final architecture s
     renamed output field degraded it to a non-failing `UNAVAILABLE` while the real counts were the
     vacuous baseline). A drift FAIL costs one re-run after a one-line alias addition; a silently
     disarmed guard costs an unreviewed merge.
+13. **The SINGLE-SHA invocation** (`roborev review <sha> --repo <abs>`) — *the form issue #2964's own AC2
+    prescribes*. **Tried and REJECTED with measured evidence:** it enqueues `git_ref = <head40>`, i.e. ONE
+    COMMIT, and delivered **3 of 5** census code files on a 17-commit branch. Every sha-equality check
+    passes (the sha IS branch HEAD), so it is a PARTIAL review reported as a complete one — a fourth
+    vacuity class. Worse, `prompt-content` matches PATHS, so when several commits touch the same file a
+    review of only the last one satisfies every path check. Replaced by the range form, and the wrapper now
+    FAILs a single-commit record even when it equals HEAD. AC2's intent is honoured; its letter is not.
+14. **The TWO-POSITIONAL range form** (`roborev review <base> <head>`). **Tried and REJECTED with measured
+    evidence:** the enqueued range base is git's **EMPTY-TREE** hash `4b825dc6…`, not `<base>`, and it
+    delivered 3/5 code files. The empty-tree base is now called out by name in the mismatch message as
+    this form's signature.
+15. **`--branch` WITHOUT an explicit `--repo`** (the original defect, and — importantly — the thing the
+    first draft of this doctrine banned *categorically*). **Rejected as an invocation, but the categorical
+    ban was itself WRONG and is retracted here:** measured, `--branch` **with** `--repo <abs>` reports "17
+    commits since origin/main" and delivers 5/5 code files, and is now the SANCTIONED form. The defect was
+    always the MISSING `--repo` (which lets roborev resolve against the ROOT checkout, normally on the base
+    branch). A doctrine that forbids `--branch` outright forbids the correct invocation — which is why the
+    narrowing is propagated to every surface that states the rule.
+16. **`prompt-content: UNAVAILABLE` as a NON-FAILING value for an unretrievable prompt.** *Tried and
+    REJECTED (round-6 BLOCKER):* with a non-empty code census it let a run reach PASS with **no**
+    authoritative evidence any diff reached the reviewer — a pass resting on nothing, which is the very
+    thing this wrapper exists to prevent. It is also not a plausible always-red risk: the prompt is
+    measurably retrievable from the job record's `prompt` field AND from `roborev show <job> --prompt`. Now
+    `FAIL (prompt unretrievable — no evidence any diff was delivered)`.
+17. **SAME-PATH-ONLY matching of `diff --git` headers in `prompt-content`.** *Tried and REJECTED (round-6
+    BLOCKER):* our census runs `--no-renames` (a rename = two paths) while the reviewer's diff may have
+    rename detection ON (one `a/old b/new` header), so same-path matching **falsely rejected every review
+    containing a detected rename** — a false FAIL on ordinary work, which is how guards get waived. Fixed
+    by collecting the path set from BOTH header sides and comparing whole-line; exact-header strictness is
+    retained (no weakening to a substring test, which any incidental mention would satisfy).
+18. **A tier-1 verdict region of only the LINES CONTAINING `Summary:`.** *Tried and REJECTED (round-6
+    BLOCKER):* the real reviewer format is a `## Summary` HEADING followed by a blank line and the prose, so
+    the region captured the heading and none of the sentence — and a **vacuous clean review whose "no code
+    changes" claim sat under the heading reported PASS**, the exact defect the wrapper exists to stop. The
+    region is now the whole summary BLOCK (heading or label → next heading/EOF), a strict superset of the
+    line form.
+19. **Diagnosing the incomplete job record as an ASYNCHRONOUS write** (and polling 45×1s for it). *Tried
+    and REJECTED as a MISDIAGNOSIS:* the record was never late. `roborev show <job> --json` returns the
+    REVIEW row and nests the JOB row under a `job` key, and the extractor was matching the outer row, which
+    carries no `git_ref`/`status`/`token_usage`. Reading the nested row as a first-class source makes the
+    record complete in ONE read; the poll is now a 5×1s **sanity retry**. Recorded because the wrong
+    diagnosis had already been written into prose, and a "known" cause that is false costs the next reader
+    more than an open question.

--- a/openspec/changes/roborev-vacuous-review-guard/design.md
+++ b/openspec/changes/roborev-vacuous-review-guard/design.md
@@ -1,0 +1,245 @@
+# Design: fail-closed roborev vacuous-review guard (issue #2964)
+
+## Context
+
+`roborev` is the pipeline's code-review stage. Its verdict is a **merge condition**: `flow-implement`
+runs it review-first on the lite-green diff (#2086), and `flow-closer` runs a final confirmation pass
+before arming `gh pr merge --auto` (#2084/#2667). "roborev clean" is therefore load-bearing — if it can
+be satisfied without a review having happened, the pipeline merges unreviewed code with no red anywhere.
+
+Three confirmed triggers produce exactly that (evidence table in `proposal.md`):
+
+| # | Trigger | Enqueued SHA | Detectable by a SHA check? |
+|---|---------|--------------|----------------------------|
+| 1 | worktree + `--branch` resolves against the ROOT checkout (on `main`) | `origin/main` | **yes** |
+| 2 | two-positional commit-range form mis-enqueues | neither endpoint | **yes** |
+| 3 | code-free (docs-only) diff silently discarded | correct SHA | **NO** |
+
+Two structural facts constrain every option:
+
+- **`roborev` is an external binary** (`/usr/local/bin/roborev`), not vendored in this repo. We cannot
+  change its resolution logic or its exit codes.
+- **A vacuous verdict is textually identical to a genuine clean one** at the top level ("No issues
+  found"). The only distinguishing signals are (a) the `Summary:` sentence, (b) the enqueued SHA, and
+  (c) token accounting / wall time.
+
+So the guard must be a **CQLite-side wrapper**, and it must judge the reviewer's claims against
+something computed **locally**, not against the reviewer's own prose.
+
+## Recommended design
+
+### `scripts/flow/roborev-review.sh` — the ONLY sanctioned roborev invocation
+
+Flags: `--repo <path>` (default: `git rev-parse --show-toplevel` of `$PWD`), `--base <ref>` (default
+`origin/main`), `--agent`, `--model`, and passthrough for the rest. Every step is ordered and
+fail-closed; the first failure stops the run, emits the summary block, and exits non-zero.
+
+**Step 1 — Resolve identity.** Repo root (**absolute** — `roborev --repo` must never receive a relative
+path), current branch, HEAD sha. `--repo` is always passed explicitly; the wrapper never relies on
+`roborev` inferring the repo from `$PWD` (that inference is trigger 1).
+
+**Step 2 — Push assert (AC3).** `origin/<branch>` must exist and equal HEAD. Otherwise FAIL, naming
+the unpushed commits. Rationale: an unpushed implementation commit is *itself* an empty-diff cause —
+the reviewer can only see what the remote has. Ordering matters: this runs **before** the census so the
+operator gets the actionable cause ("push your commits") rather than a downstream vacuity FAIL.
+
+**Step 3 — Local diff census: the oracle.** `git diff --numstat <base>...HEAD` → files changed, lines
+added, lines removed. This locally-computed census is **the authoritative statement of what must be
+reviewed**, and every downstream vacuity claim is judged against it. Using `...` (three-dot,
+merge-base) matches the semantics of the `--base` the reviewer is told to diff against, so the census
+and the review are talking about the same change set.
+
+If the census is **genuinely empty**, the wrapper exits with a **distinct `NOTHING-TO-REVIEW` status**
+(its own non-zero exit code, `3`) — explicitly **not** a pass, and explicitly not recordable as
+"roborev clean". A separate status (rather than PASS-with-a-note) is the point: a caller cannot
+accidentally treat "there was nothing to look at" as "it was looked at and was clean".
+
+**Step 4 — Invoke by explicit SHA + explicit repo (AC2).**
+
+```
+roborev review <head-sha> --repo <abs-repo> --agent <a> --model <m> --wait
+```
+
+**NEVER bare `--branch`** (trigger 1). **NEVER the two-positional range form** (trigger 2). Both
+`--agent` and `--model` are always passed — the wrapper refuses to run with only one of them, preserving
+the already-documented #2433 trap (`--agent codex` alone inherits `review_model` from `.roborev.toml`
+and hard-400s; and to run the Claude reviewer you must override **both**). Enforcing it in the wrapper
+converts a silent-looking outage into a usage error at the call site.
+
+**Step 5 — Reviewed-SHA assert (AC2).** Parse `Enqueued job <N> for <sha>` from the invocation's
+output and require `<sha>` to prefix-match HEAD (either direction, since roborev may print an
+abbreviated sha). A mismatch FAILs loudly. When the mismatched sha resolves to `<base>` /
+`origin/main`, the message must **say so explicitly** — that equality is the fingerprint of trigger 1,
+and naming it turns a confusing failure into a one-line diagnosis. If the `Enqueued job` line is absent
+entirely, that is also a FAIL (unparseable ⇒ unverifiable ⇒ fail closed), never a skip.
+
+**Step 6 — Vacuity assert (AC1), two tiers, deterministic tier primary.**
+
+- **Tier 1 — PRIMARY, deterministic, no thresholds.** The reviewer's own output claiming no code
+  changes — `/contains no code changes to review/i`, `/no code changes/i` — while the **step-3 census
+  is NON-empty** is a **HARD FAIL**. This is a comparison against a locally-computed oracle, not a
+  guess: we know the diff is non-empty because we measured it ourselves, so a reviewer asserting the
+  opposite has demonstrably not reviewed the change. This tier alone catches trigger 3 (which passes
+  the SHA assert) and also back-stops triggers 1 and 2.
+- **Tier 2 — CORROBORATING, bounded token accounting.** From `roborev show <N> --json` (fallback
+  `roborev list --json`): on a **non-empty census**, `input < VACUOUS_MAX_INPUT_TOKENS` **OR**
+  `cached_input == 0` **OR** `output < VACUOUS_MIN_OUTPUT_TOKENS` is also a HARD FAIL. The thresholds
+  are **named constants at the top of the script** with the measured evidence table cited in a comment,
+  and the failure message prints the **observed numbers next to the threshold**, so a future
+  recalibration is a one-line, evidenced change rather than an archaeology exercise.
+
+  Initial calibration from the recorded evidence (genuine: 398k–649k input / 314k–554k cached / ~5k
+  output / 2m25s–2m45s; vacuous: ~18k input / 0 cached / ≤56 output / 8s):
+
+  | Constant | Value | Margin vs evidence |
+  |---|---|---|
+  | `VACUOUS_MAX_INPUT_TOKENS` | 50,000 | ~2.7× above the vacuous ceiling (18.8k), ~8× below the genuine floor (398k) |
+  | `VACUOUS_MIN_OUTPUT_TOKENS` | 200 | ~3.6× above the vacuous ceiling (56), ~25× below the genuine floor (5,067) |
+
+  If token accounting is **unavailable** from the installed roborev build (no `show --json`, or the
+  fields are absent), that is a **degraded-signal notice** stamped in the summary block and tier 1
+  still governs — **never a silent skip**, and never a downgrade of tier 1.
+
+**Step 7 — Emit a compact, machine-greppable summary block.**
+
+```
+==== ROBOREV REVIEW SUMMARY ====
+repo: <abs>            branch: <name>
+head-sha: <sha>        reviewed-sha: <sha>     job: <N>
+base: <ref>            census: <F> files, +<A>/-<D>
+tokens: input=<i> cached=<c> output=<o>   (or: tokens: UNAVAILABLE (degraded-signal))
+push-assert: PASS|FAIL
+sha-assert: PASS|FAIL(<reason>)
+vacuity-tier1: PASS|FAIL
+vacuity-tier2: PASS|FAIL|UNAVAILABLE
+RESULT: PASS|FAIL|NOTHING-TO-REVIEW
+```
+
+Exit codes: `0` = PASS, `1` = FAIL, `3` = NOTHING-TO-REVIEW. Modeled deliberately on the gate's
+summary-file contract: **an agent retains only this block, never raw roborev stdout** (the raw
+transcript goes to a log path named in the block). The block name is distinct from
+`AGENT-GATE SUMMARY` / `AGENT-GATE LITE SUMMARY` / `AGENT-GATE DELTA SUMMARY` so it can never be pasted
+as a gate verdict, and vice versa.
+
+**Step 8 — Hygiene.** The script stays small (we adopt the campsite rule's spirit: the gate's
+`file-size` ratchet covers `.rs` only, so this is a review expectation, not a mechanized one) and free
+of the traps in CLAUDE.md's pre-roborev self-check list — notably no wall-clock threshold asserts in
+the regression test's correctness path (#2642, mechanized by `roborev-lints`) and no unquoted
+interpolation of external output into a shell command.
+
+### Docs-only diffs cannot be roborev-certified
+
+Trigger 3 is not a bug we can route around: roborev **structurally discards a code-free diff**. So the
+sanctioned position is explicit — a docs/spec/workflow-only diff **cannot be certified by roborev at
+all**. The wrapper FAILs it as vacuous (tier 1 fires: non-empty census, "no code changes" verdict), and
+the sanctioned substitute is **verification against primary sources**, recorded in the PR body. For
+#2950 that was `git show cassandra-5.0.8:<path>` — reading the pinned Cassandra source that the docs
+claim to describe. A docs-only PR must **never** record "roborev clean".
+
+This dovetails with existing doctrine rather than fighting it: CLAUDE.md already treats a docs-only diff
+specially for the gate (the #3042 CITE-AND-WAIVE rule). The parallel is deliberate — a docs-only diff
+cannot be *certified* by a tool whose subject is compiled code, in either the gate's or roborev's case.
+
+### Call-site migration
+
+Every roborev invocation in the agent surfaces routes through the wrapper, and bare `--branch` becomes
+non-sanctioned prose:
+
+- `.claude/skills/`: `flow-implement` (the review-first step — the primary call site, currently
+  documenting `roborev review --branch --base origin/main --agent codex --model gpt-5.6-sol --wait`),
+  `flow-activate`, `flow-address`, `flow-finalize`, `ci-cd-validation`.
+- `.claude/agents/`: `flow-closer` (the final confirmation pass — the **merge-gating** call site; note
+  it currently documents a `/roborev-review-branch` form, which `flow-lead` correctly says does not
+  exist), `flow-lead` (the stage table), `rust-reviewer`, `sstable-developer`, `test-validator`.
+
+### Regression check + gate wiring
+
+`scripts/tests/test_roborev_review_guard.sh` — **hermetic**: a **stub `roborev`** placed first on
+`PATH` replays the recorded real outputs from the evidence table (enqueue lines, verdict text, and
+`show --json` token payloads), driven against throwaway `git init` fixtures with a synthetic `origin`
+remote. No network, no real roborev, no datasets. Cases (a)–(g) map 1:1 to the spec scenarios: base-sha
+mismatch, neither-endpoint sha, "no code changes" against a non-empty census, vacuous token signature,
+unpushed branch, a genuine PASS, and a genuinely-empty census reporting NOTHING-TO-REVIEW.
+
+**Wiring (concrete).** `scripts/agent-gate.sh` registers shell self-tests two ways, and this change
+uses both:
+
+- `run_tooling_tests()` (the `tooling-tests` **full-gate** component) runs a sequence of
+  `bash "$REPO_ROOT/scripts/tests/<name>.sh"` guards, each FAILing the component on non-zero — the
+  pattern used by `test_generator_keyspace_scoping.sh`, `test_udt_rowbuilder_tuple_shape.sh`,
+  `test_check_dockerfile_rust_pin.sh`, `test_check_skill_flag_tables.sh`. The new test is appended
+  there.
+- `run_roborev_lints_cmd()` (the `roborev-lints` component) is in **both** `LITE_COMPONENTS` and
+  `COMPONENTS`, and already chains `check-workflow-injection.sh && check-no-wallclock-asserts.sh`.
+  Adding the guard test here is what makes a regression **FAIL the fast `--lite` loop** rather than
+  cost a review round — the stated acceptance goal — and it is thematically exact: `roborev-lints` is
+  precisely the component that mechanizes roborev-related delivery costs (#2656). The test must be
+  fast (hermetic, seconds) to belong in `--lite`.
+
+**Live worktree probe (documented, not gate-run).** A short recorded procedure: from a real
+`issue-<N>-*` worktree with a pushed commit, run the wrapper and confirm `reviewed-sha == head-sha`
+(and `!= origin/main`) in the summary block. This is the only check that can prove the real external
+binary honours the explicit `--repo`; it is documented in the wrapper's usage text / the doctrine page
+rather than run in the gate, because it requires network + a live reviewer and would make the gate
+non-hermetic.
+
+### Doctrine (ships in this change)
+
+CLAUDE.md's roborev-invocation bullet (*Agent-Team Conventions*) and
+`website/src/content/docs/agents-developing/roborev-findings.md` both state: the wrapper is the only
+sanctioned invocation; **verify the reviewed SHA**; `"contains no code changes to review"` on a
+non-empty diff is a **HARD FAIL**; docs-only diffs cannot be roborev-certified. The website page
+already has a "**The reviewer default is codex**" section and a mechanized-in-`--lite` table — both are
+the natural homes for the new rule and the new `roborev-lints` entry. Publication acceptance follows
+CLAUDE.md's rule: **grep the served page for a new distinctive phrase**; a `200` is not proof (observed
+CDN staleness ≈3 minutes).
+
+## Why the token thresholds do NOT violate the no-heuristics mandate (#28)
+
+Worth stating plainly, because "thresholds" reads like a heuristic at a glance. The no-heuristics
+mandate governs **on-disk TYPE/format inference from byte patterns in the SSTable read path** — never
+guessing a CQL type or a format version from data content instead of authoritative metadata (schema,
+else `Statistics.db`). It says nothing about, and is not weakened by, **review-tooling liveness
+detection**, which is a property of our own CI process, not of Cassandra's on-disk format.
+
+Three structural properties keep this clean anyway:
+
+1. **Tier 1 is authoritative and threshold-free.** The primary check compares the reviewer's claim
+   against a locally-computed, exact census — the review-tooling analogue of "authoritative metadata
+   only". Tier 2 never overrides it.
+2. **Tier 2's only possible action is to FAIL CLOSED.** It can never manufacture a pass, relax a tier-1
+   FAIL, or infer that a review *did* happen. Its worst-case error is a false FAIL, whose cost is one
+   re-run — bounded, visible, and self-correcting. (A false FAIL is also *preferable* to the status quo,
+   whose failure mode is merging unreviewed code.) The `cached_input == 0` clause is the most
+   false-positive-prone of the three — a genuine review against a cold cache could plausibly report it —
+   and that is an accepted, deliberate trade in the fail-closed direction, recorded here so a future
+   recalibration knows it was a choice, not an oversight.
+3. **The thresholds are evidenced, bounded, and named.** They are constants with the measured table
+   cited beside them, and every failure prints observed-vs-threshold, so recalibration is a one-line
+   evidenced edit — the opposite of an unexplained magic number buried in a branch.
+
+## Alternatives considered (and why the recommendation beat them)
+
+1. **Register worktrees with `roborev repo` so `--branch` resolves correctly.** *Rejected:* there **is
+   no `add` subcommand** — repos self-register on first use, so there is nothing to call. Even if there
+   were, it would fix only trigger 1: trigger 2 (range form mis-enqueue) and trigger 3 (code-free diff
+   discarded) would still return an indistinguishable "No issues found".
+2. **Patch/fork `roborev` upstream.** *Rejected for this change:* the binary is outside this repo's
+   control, and the fleet is exposed on **every** issue right now — a guard we own ships today, an
+   upstream change does not. Noted as a possible **upstream follow-up** (worktree-aware `--branch`
+   resolution; a non-zero exit when a code-free diff is discarded). The wrapper stays correct and
+   cheap after such a fix lands.
+3. **Run roborev from the root checkout instead of the worktree.** *Rejected:* it breaks 1:1:1:1
+   worktree isolation and requires **commandeering the shared root** — explicitly forbidden (a closer
+   that switched the shared root's branch once stranded root off `main` and broke every session on the
+   box). It also serializes concurrent lanes onto one checkout.
+4. **Token-threshold-only detection.** *Rejected as a primary signal:* it is non-deterministic and
+   recalibrates with every model/prompt change (`gpt-5.6-sol` is codex's own moving default, not a
+   config pin — it already shifted once on a version bump). Demoted to a **corroborating tier** behind
+   the deterministic census comparison, where a drifted threshold can only cost a re-run.
+5. **Trust the verdict text.** *Rejected:* that is precisely the defect. "No issues found" is emitted
+   identically whether 650k tokens of real diff were reviewed or zero bytes were.
+6. **Detect the empty diff by asking roborev what it saw** (e.g. parse the job's reported diffstat).
+   *Rejected:* it re-derives the answer from the same untrusted source. The census must be computed on
+   our side with `git`, or the check is circular — the same reason a CQLite `file:line` is never format
+   authority.

--- a/openspec/changes/roborev-vacuous-review-guard/proposal.md
+++ b/openspec/changes/roborev-vacuous-review-guard/proposal.md
@@ -13,22 +13,38 @@ new sanctioned invocation surface plus doctrine) · **Issue:** #2964 (`flow-meta
 clean" as a merge condition (`flow-closer` runs a final roborev confirmation pass before arming
 `gh pr merge --auto`), a vacuous pass can merge **unreviewed code**.
 
-Three trigger paths are confirmed:
+**Four** trigger paths are confirmed (the fourth was found by this change's own live probe):
 
-1. **Worktree + `--branch`.** `roborev review --branch --base origin/main` run from inside a git
-   worktree resolves `--branch` against the **ROOT checkout**, not `$PWD` — worktrees are not
-   registered in `roborev repo list`, and `roborev repo` has no `add` subcommand (repos self-register
+1. **Worktree + `--branch` WITHOUT an explicit `--repo`.** `roborev review --branch --base origin/main` run
+   from inside a git worktree resolves `--branch` against the **ROOT checkout**, not `$PWD` — worktrees are
+   not registered in `roborev repo list`, and `roborev repo` has no `add` subcommand (repos self-register
    on first use). The root normally sits on `main`, so the run enqueues the **BASE** commit, the diff
    is empty, and the verdict is "No issues found. Summary: The provided combined diff contains no code
    changes to review." Observed: enqueued `39900e4db` (= `origin/main`) while the branch HEAD was
-   `4e7ab591e`; jobs 4649/4651/4653/4655/4657 all enqueued `origin/main`.
-2. **Commit-range form mis-enqueues.** `roborev review 89fdbb895 989d7d2c3` enqueued `90a17d376` —
-   **neither endpoint**.
+   `4e7ab591e`; jobs 4649/4651/4653/4655/4657 all enqueued `origin/main`. **Measured correction:** adding
+   an explicit `--repo <abs>` FIXES this form (it then reports "17 commits since origin/main" and delivers
+   every code file) — so the defect is the MISSING `--repo`, not `--branch` itself, and `--branch --base
+   <base> --repo <abs>` is the SANCTIONED invocation.
+2. **The two-positional commit-range form** anchors the reviewed range at git's **EMPTY-TREE** hash
+   (`4b825dc6…..<head40>`), delivering only 3 of 5 census code files. (An earlier observation of it
+   enqueueing an unrelated `90a17d376` for `roborev review 89fdbb895 989d7d2c3` is the same class:
+   the range it reviews is not the one requested.)
 3. **Code-free diffs are silently discarded even on a correctly-targeted run.** A 5-file / 167+ / 63−
-   **all-markdown** diff, invoked correctly by explicit SHA + `--repo <worktree-abs>`, enqueued the
+   **all-markdown** diff, invoked correctly with an explicit SHA + `--repo <worktree-abs>`, enqueued the
    right SHA and still returned "No issues found. Summary: The provided diff contains no code changes
    to review." Reproducible (jobs 4658, 4659). **This path passes an enqueued-SHA check**, so SHA
-   verification alone is insufficient.
+   verification alone is insufficient. **Mechanism, now measured:** roborev EXCLUDES non-code paths from
+   the diff it constructs (on a 27-file census — 22 markdown + 5 code — the prompt carried headers for
+   exactly the 5 code files), so for an all-prose diff the constructed diff is genuinely EMPTY and the
+   reviewer's report is TRUTHFUL about an empty input rather than a malfunction. Re-running cannot help;
+   only a deterministic pre-enqueue refusal can.
+4. **The single-SHA form reviews ONE COMMIT, not the branch** — and it is the form this issue's own AC2
+   prescribes. Measured: `git_ref = <head40>` (correct!) while only 3 of 5 census code files reached the
+   prompt. On any multi-commit branch — every branch we ship — it certifies the branch from its last commit
+   alone: a PARTIAL review reported as a complete one, invisible to every sha-equality check. Hence the
+   sanctioned invocation reviews the **RANGE** `<base>..HEAD`, and the wrapper FAILs a single-commit job
+   record even when it equals HEAD. This change implements AC2's **intent** — the reviewed content must
+   match the requested range — rather than its letter, and says so in `design.md` and the spec delta.
 
 **Token accounting is the observable tell** (`roborev log <job>` / `roborev show <job> --json`):
 
@@ -51,7 +67,8 @@ and **output counts collide** between a genuine CLEAN review and a vacuous one (
 output floor cannot discriminate them and is advisory only.
 
 **Blast radius is total.** The 1:1:1:1 rule puts **every** issue in a worktree, so **every** flow-\*
-roborev run is exposed to trigger 1. Measured cost on #2950: two vacuous runs "passed"; re-run
+roborev run is exposed to T1, and every multi-commit branch to T4. Measured cost on #2950: two
+vacuous runs "passed"; re-run
 correctly against the real SHA, the **same diff produced TWO REAL BLOCKERS** that would otherwise
 have shipped.
 
@@ -59,9 +76,11 @@ have shipped.
 
 1. **A single sanctioned invocation surface: `scripts/flow/roborev-review.sh`** — a fail-closed
    CQLite-side wrapper. `roborev` is an **external binary** (`/usr/local/bin/roborev`, not vendored
-   here), so the guard cannot live upstream; it lives on our side of the call. Implemented as three
-   files: the wrapper, a sourced `roborev-review-oracles.sh` (push assert + census/code-free), and
-   `roborev-job-facts.py` (job-record/token JSON decoding).
+   here), so the guard cannot live upstream; it lives on our side of the call. Implemented as **five**
+   files: the wrapper, a sourced `roborev-review-oracles.sh` (push assert + census/code-free), a sourced
+   `roborev-review-checks.sh` (the five per-review checks), `roborev-job-facts.py` (job-record/token JSON
+   decoding), and the hermetic regression check. Both sourced files FAIL CLOSED when missing or truncated,
+   validated **before** the review is invoked so a broken install costs no review.
 2. **DETERMINISTIC checks carry the verdict; prose and tokens only corroborate.** Each load-bearing
    check is judged against data the wrapper obtains ITSELF: the REMOTE (`git ls-remote`), its own
    `git diff --numstat --no-renames <base>...HEAD` census, its own code-free classification of that
@@ -75,10 +94,14 @@ have shipped.
 4. **Ordered, fail-closed asserts**: push assert against the REMOTE (an unpushed branch is itself an
    empty-diff cause; a local mirror ref is NOT authority) → census (an unresolvable base or a failed
    `git diff` FAILs, distinctly from an empty census) → **deterministic code-free FAIL before anything
-   is enqueued** → explicit-SHA + explicit-`--repo` invocation (never bare `--branch`, never the
-   two-positional range form) → reviewed-SHA assert against the job record's full-40-char `git_ref`
-   (the stdout `Enqueued job N for <sha>` line demoted to a fail-closed cross-check) →
-   `review-completed` → `prompt-content` → findings-vs-error attribution → the two corroborating
+   is enqueued** → the RANGE invocation with an explicit absolute `--repo` (never `--branch` without
+   `--repo`, never the two-positional range form, never a single sha) → a `job-record:` read that
+   consults BOTH payload shapes and reports its own completeness → reviewed-**RANGE** assert against the
+   job record's `git_ref`, asserting BOTH endpoints against the census range (the stdout `Enqueued job N
+   for <sha>` line demoted to the carrier of the job id — for a range review it names only the base, so an
+   unavailable record FAILs rather than falling back to it) →
+   `review-completed` → `prompt-content` → findings-vs-error attribution (with a contradiction reported
+   `INCONSISTENT` and failed) → the two corroborating
    vacuity tiers → a machine-greppable `==== ROBOREV REVIEW SUMMARY ====` block with a terminal
    `RESULT: PASS|FAIL|NOTHING-TO-REVIEW` and a non-zero exit on anything but PASS.
 5. **A distinct `NOTHING-TO-REVIEW` status** for a genuinely empty census — explicitly **not** a pass,
@@ -105,12 +128,16 @@ have shipped.
    previously prescribed the **inverse** rule ("no `--agent`/`--model` flags"; one called explicit
    agent/model "never doctrine"). Bare `--branch` becomes non-sanctioned everywhere.
 10. **A hermetic regression check** (`scripts/tests/test_roborev_review_guard.sh`, a stub `roborev` on
-    `PATH` replaying the recorded outputs — including the doubly-encoded token payload — against
-    throwaway git fixtures covering the fleet's narrow-refspec topology) wired into BOTH the `--lite`
+    `PATH` replaying the recorded outputs — including the doubly-encoded token payload and the review row
+    that nests the job row — against throwaway git fixtures covering the fleet's narrow-refspec topology
+    and a detected rename) wired into BOTH the `--lite`
     `roborev-lints` component and the full-gate `tooling-tests`, plus a documented **live worktree
-    probe** proving a worktree-launched review reviews the worktree's HEAD.
+    probe** proving a worktree-launched review reviews the worktree's HEAD. **329 assertions.**
 11. **Doctrine in the same change** (CLAUDE.md's roborev-invocation paragraph + the
-    `agents-developing/roborev-findings` page, including a row in its mechanized-in-`--lite` table).
+    `agents-developing/roborev-findings` page, including a row in its mechanized-in-`--lite` table), plus
+    the three measured corrections propagated to every surface that states the rule: the non-sanctioned
+    form is `--branch` **without** `--repo`; the single-SHA form is a partial review; roborev excludes
+    non-code paths from the diff it builds.
 
 ## Non-goals
 
@@ -134,8 +161,9 @@ have shipped.
 
 - **New scripts:** `scripts/flow/roborev-review.sh` (the sanctioned invocation),
   `scripts/flow/roborev-review-oracles.sh` (sourced: push assert + census/code-free oracles),
+  `scripts/flow/roborev-review-checks.sh` (sourced: the five per-review checks),
   `scripts/flow/roborev-job-facts.py` (job-record + token extraction),
-  `scripts/tests/test_roborev_review_guard.sh` (hermetic regression check — 258 assertions).
+  `scripts/tests/test_roborev_review_guard.sh` (hermetic regression check — 329 assertions).
 - **Gate:** the regression check is registered in `scripts/agent-gate.sh`'s shell-tooling component
   set (`tooling-tests`, and `roborev-lints` so it also runs in `--lite`), so a regression FAILs the
   fast loop rather than costing a review round.

--- a/openspec/changes/roborev-vacuous-review-guard/proposal.md
+++ b/openspec/changes/roborev-vacuous-review-guard/proposal.md
@@ -1,0 +1,118 @@
+# Proposal: Fail-closed guard against vacuous roborev reviews (issue #2964)
+
+**Milestone:** maintenance (agent-team automation / delivery pipeline) · **Priority:** P1 ·
+**Routing:** design-driven (the agent-delivery automation itself — no external oracle; the fix is a
+new sanctioned invocation surface plus doctrine) · **Issue:** #2964 (`flow-meta`) ·
+**Related:** #2433 (roborev agent/model pin), #2086/#2087/#2088 (review-first + severity triage),
+#2084 (`flow-closer` endgame), #2950 (the delivery where the defect was caught).
+
+## Why
+
+`roborev` can report **"No issues found"** without having reviewed anything, and a vacuous pass is
+**textually identical** to a genuine clean pass. Because CQLite's delivery pipeline treats "roborev
+clean" as a merge condition (`flow-closer` runs a final roborev confirmation pass before arming
+`gh pr merge --auto`), a vacuous pass can merge **unreviewed code**.
+
+Three trigger paths are confirmed:
+
+1. **Worktree + `--branch`.** `roborev review --branch --base origin/main` run from inside a git
+   worktree resolves `--branch` against the **ROOT checkout**, not `$PWD` — worktrees are not
+   registered in `roborev repo list`, and `roborev repo` has no `add` subcommand (repos self-register
+   on first use). The root normally sits on `main`, so the run enqueues the **BASE** commit, the diff
+   is empty, and the verdict is "No issues found. Summary: The provided combined diff contains no code
+   changes to review." Observed: enqueued `39900e4db` (= `origin/main`) while the branch HEAD was
+   `4e7ab591e`; jobs 4649/4651/4653/4655/4657 all enqueued `origin/main`.
+2. **Commit-range form mis-enqueues.** `roborev review 89fdbb895 989d7d2c3` enqueued `90a17d376` —
+   **neither endpoint**.
+3. **Code-free diffs are silently discarded even on a correctly-targeted run.** A 5-file / 167+ / 63−
+   **all-markdown** diff, invoked correctly by explicit SHA + `--repo <worktree-abs>`, enqueued the
+   right SHA and still returned "No issues found. Summary: The provided diff contains no code changes
+   to review." Reproducible (jobs 4658, 4659). **This path passes an enqueued-SHA check**, so SHA
+   verification alone is insufficient.
+
+**Token accounting is the observable tell** (`roborev log <job>` / `roborev show <job> --json`):
+
+| job | sha | diff | input | cached | output | wall |
+|-----|-----|------|-------|--------|--------|------|
+| 4652 | `4e7ab591e` | 6f 216+/64− | 505,625 | 387,328 | 6,332 | 2m45s |
+| 4654 | `90a17d376` | 5f 140+/54− | 398,204 | 314,624 | 5,073 | 2m28s |
+| 4656 | `89fdbb895` | 5f 207+/110− | 648,582 | 554,496 | 5,067 | 2m25s |
+| 4658 | `989d7d2c3` (docs-only) | 5f 167+/63− | 18,700 | 0 | 53 | 8s |
+| 4659 | `989d7d2c3` retry | same | 18,801 | 0 | 56 | 8s |
+| 4651 | known-EMPTY diff | 0 | 17,333 | — | 21 | — |
+
+A genuine review is 400–650k input tokens with heavy cache reuse and minutes of wall time. The
+vacuous baseline is ~18k input / 0 cached / <60 output / <10s.
+
+**Blast radius is total.** The 1:1:1:1 rule puts **every** issue in a worktree, so **every** flow-\*
+roborev run is exposed to trigger 1. Measured cost on #2950: two vacuous runs "passed"; re-run
+correctly against the real SHA, the **same diff produced TWO REAL BLOCKERS** that would otherwise
+have shipped.
+
+## What Changes
+
+1. **A single sanctioned invocation surface: `scripts/flow/roborev-review.sh`** — a fail-closed
+   CQLite-side wrapper. `roborev` is an **external binary** (`/usr/local/bin/roborev`, not vendored
+   here), so the guard cannot live upstream; it lives on our side of the call.
+2. **A locally-computed diff census as the oracle.** `git diff --numstat <base>...HEAD` produces the
+   authoritative files/+/− census. Every downstream vacuity claim is judged against that census, not
+   against the reviewer's own prose.
+3. **Ordered, fail-closed asserts**: push assert (an unpushed branch is itself an empty-diff cause) →
+   census → explicit-SHA + explicit-`--repo` invocation (never bare `--branch`, never the
+   two-positional range form) → reviewed-SHA assert against the `Enqueued job N for <sha>` line →
+   two-tier vacuity assert (deterministic verdict-text-vs-census comparison primary; bounded token
+   accounting corroborating) → a machine-greppable `==== ROBOREV REVIEW SUMMARY ====` block with a
+   terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW` and a non-zero exit on anything but PASS.
+4. **A distinct `NOTHING-TO-REVIEW` status** for a genuinely empty census — explicitly **not** a pass,
+   and not recordable as "roborev clean".
+5. **Docs-only diffs are declared non-certifiable by roborev.** Trigger 3 makes roborev structurally
+   unable to review a code-free diff, so a docs/spec/workflow-only diff FAILs the wrapper as vacuous;
+   the sanctioned substitute is verification against **primary sources** (for #2950 that was
+   `git show cassandra-5.0.8:<path>`) recorded in the PR.
+6. **Call-site migration.** Every roborev invocation in `.claude/skills/{flow-implement,flow-activate,
+   flow-address,flow-finalize,ci-cd-validation}` and `.claude/agents/{flow-closer,flow-lead,
+   rust-reviewer,sstable-developer,test-validator}` routes through the wrapper; bare `--branch` becomes
+   non-sanctioned.
+7. **A hermetic regression check** (`scripts/tests/test_roborev_review_guard.sh`, stub `roborev` on
+   `PATH` replaying the recorded outputs above) wired into the agent-gate component set, plus a
+   documented **live worktree probe** proving a worktree-launched review reviews the worktree's HEAD.
+8. **Doctrine in the same change** (CLAUDE.md's roborev-invocation paragraph + the
+   `agents-developing/roborev-findings` page).
+
+## Non-goals
+
+- **Not patching or forking `roborev`.** It is an external binary outside this repo's control. An
+  upstream fix (worktree-aware `--branch` resolution; a non-zero exit on a discarded code-free diff)
+  is a worthwhile **follow-up**, not this change — the fleet needs the guard now, and the guard remains
+  correct even after an upstream fix lands.
+- **Not replacing roborev, and not a second reviewer.** The wrapper adds no review capability; it only
+  proves that a review **happened against the right bytes**, and fails closed when it cannot.
+- **Not changing review severity triage.** `docs/development/roborev-severity.md` (blocker vs nit,
+  #2088) is untouched; the wrapper's verdict is about **liveness**, not about finding classes.
+- **Not changing the `--agent`/`--model` pin policy.** The existing #2433 trap (pass **both** or codex
+  hard-400s on the config-pinned Anthropic model name) is preserved and mechanically enforced by the
+  wrapper, not re-litigated.
+- **Not a new gate mode.** The wrapper is not an `agent-gate.sh` component and emits its own distinct
+  summary block; it can never be confused with, or substituted for, `AGENT-GATE SUMMARY`.
+- **No Rust code, no library surface, no on-disk format work.** Nothing touches `cqlite-core`, the
+  bindings, the CLI, the no-heuristics decode path, or the <128MB memory budget.
+
+## Impact
+
+- **New scripts:** `scripts/flow/roborev-review.sh` (the sanctioned invocation),
+  `scripts/tests/test_roborev_review_guard.sh` (hermetic regression check).
+- **Gate:** the regression check is registered in `scripts/agent-gate.sh`'s shell-tooling component
+  set (`tooling-tests`, and `roborev-lints` so it also runs in `--lite`), so a regression FAILs the
+  fast loop rather than costing a review round.
+- **Agent surfaces (call-site migration):** `.claude/skills/{flow-implement,flow-activate,flow-address,
+  flow-finalize,ci-cd-validation}/SKILL.md` and `.claude/agents/{flow-closer,flow-lead,rust-reviewer,
+  sstable-developer,test-validator}.md`.
+- **Doctrine (ships in this change per CLAUDE.md):** CLAUDE.md's roborev-invocation bullet in
+  *Agent-Team Conventions*, plus `website/src/content/docs/agents-developing/roborev-findings.md`.
+  Publication is accepted by **grepping the served page for a new distinctive phrase** — an HTTP 200
+  is not proof (CDN staleness ≈3 min).
+- **No-heuristics mandate (#28):** unaffected. See `design.md` — that mandate governs on-disk
+  TYPE/format inference in the SSTable read path, not review-tooling liveness detection. The
+  deterministic census comparison is the authoritative check; the token thresholds are a bounded,
+  evidenced corroboration whose only possible action is to **fail closed**.
+- **Public binding surfaces (Python/Node/CLI):** untouched.

--- a/openspec/changes/roborev-vacuous-review-guard/proposal.md
+++ b/openspec/changes/roborev-vacuous-review-guard/proposal.md
@@ -40,9 +40,15 @@ Three trigger paths are confirmed:
 | 4658 | `989d7d2c3` (docs-only) | 5f 167+/63− | 18,700 | 0 | 53 | 8s |
 | 4659 | `989d7d2c3` retry | same | 18,801 | 0 | 56 | 8s |
 | 4651 | known-EMPTY diff | 0 | 17,333 | — | 21 | — |
+| 1 (this branch) | `155e12c`-line | 20f +2279 | 67,387 | 43,520 | 2,232 | 68s |
 
-A genuine review is 400–650k input tokens with heavy cache reuse and minutes of wall time. The
-vacuous baseline is ~18k input / 0 cached / <60 output / <10s.
+A genuine review is 400–650k input tokens with heavy cache reuse and minutes of wall time on a LARGE
+diff; the last row is the measured **small** genuine review, added during implementation. The vacuous
+baseline is ~18k input / 0 cached / <60 output / <10s. Two consequences the original framing missed:
+the genuine band **scales with diff size**, so the input floor must be anchored on the vacuous ceiling
+(25,000) rather than on the genuine band (a 50,000 floor would false-FAIL the 67k row's size class);
+and **output counts collide** between a genuine CLEAN review and a vacuous one (both ~20–60), so an
+output floor cannot discriminate them and is advisory only.
 
 **Blast radius is total.** The 1:1:1:1 rule puts **every** issue in a worktree, so **every** flow-\*
 roborev run is exposed to trigger 1. Measured cost on #2950: two vacuous runs "passed"; re-run
@@ -53,31 +59,58 @@ have shipped.
 
 1. **A single sanctioned invocation surface: `scripts/flow/roborev-review.sh`** — a fail-closed
    CQLite-side wrapper. `roborev` is an **external binary** (`/usr/local/bin/roborev`, not vendored
-   here), so the guard cannot live upstream; it lives on our side of the call.
-2. **A locally-computed diff census as the oracle.** `git diff --numstat <base>...HEAD` produces the
-   authoritative files/+/− census. Every downstream vacuity claim is judged against that census, not
-   against the reviewer's own prose.
-3. **Ordered, fail-closed asserts**: push assert (an unpushed branch is itself an empty-diff cause) →
-   census → explicit-SHA + explicit-`--repo` invocation (never bare `--branch`, never the
-   two-positional range form) → reviewed-SHA assert against the `Enqueued job N for <sha>` line →
-   two-tier vacuity assert (deterministic verdict-text-vs-census comparison primary; bounded token
-   accounting corroborating) → a machine-greppable `==== ROBOREV REVIEW SUMMARY ====` block with a
-   terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW` and a non-zero exit on anything but PASS.
-4. **A distinct `NOTHING-TO-REVIEW` status** for a genuinely empty census — explicitly **not** a pass,
+   here), so the guard cannot live upstream; it lives on our side of the call. Implemented as three
+   files: the wrapper, a sourced `roborev-review-oracles.sh` (push assert + census/code-free), and
+   `roborev-job-facts.py` (job-record/token JSON decoding).
+2. **DETERMINISTIC checks carry the verdict; prose and tokens only corroborate.** Each load-bearing
+   check is judged against data the wrapper obtains ITSELF: the REMOTE (`git ls-remote`), its own
+   `git diff --numstat --no-renames <base>...HEAD` census, its own code-free classification of that
+   census, the job record's structured `git_ref`/`status`, and the census's own file paths inside the
+   prompt ACTUALLY SENT to the reviewer. Judging the reviewer by its own narration is the defect, not
+   the fix.
+3. **A PASS requires POSITIVE evidence that a review completed** (`review-completed:` — job status
+   `done` plus a terminal verdict marker from an allow-list). Absence of a vacuity phrase is never
+   proof of a review: an unfinished job, a provider `400 … model is not supported`, and a `failed`
+   status all carry no phrase, and all three previously reached `RESULT: PASS`.
+4. **Ordered, fail-closed asserts**: push assert against the REMOTE (an unpushed branch is itself an
+   empty-diff cause; a local mirror ref is NOT authority) → census (an unresolvable base or a failed
+   `git diff` FAILs, distinctly from an empty census) → **deterministic code-free FAIL before anything
+   is enqueued** → explicit-SHA + explicit-`--repo` invocation (never bare `--branch`, never the
+   two-positional range form) → reviewed-SHA assert against the job record's full-40-char `git_ref`
+   (the stdout `Enqueued job N for <sha>` line demoted to a fail-closed cross-check) →
+   `review-completed` → `prompt-content` → findings-vs-error attribution → the two corroborating
+   vacuity tiers → a machine-greppable `==== ROBOREV REVIEW SUMMARY ====` block with a terminal
+   `RESULT: PASS|FAIL|NOTHING-TO-REVIEW` and a non-zero exit on anything but PASS.
+5. **A distinct `NOTHING-TO-REVIEW` status** for a genuinely empty census — explicitly **not** a pass,
    and not recordable as "roborev clean".
-5. **Docs-only diffs are declared non-certifiable by roborev.** Trigger 3 makes roborev structurally
-   unable to review a code-free diff, so a docs/spec/workflow-only diff FAILs the wrapper as vacuous;
-   the sanctioned substitute is verification against **primary sources** (for #2950 that was
-   `git show cassandra-5.0.8:<path>`) recorded in the PR.
-6. **Call-site migration.** Every roborev invocation in `.claude/skills/{flow-implement,flow-activate,
-   flow-address,flow-finalize,ci-cd-validation}` and `.claude/agents/{flow-closer,flow-lead,
-   rust-reviewer,sstable-developer,test-validator}` routes through the wrapper; bare `--branch` becomes
-   non-sanctioned.
-7. **A hermetic regression check** (`scripts/tests/test_roborev_review_guard.sh`, stub `roborev` on
-   `PATH` replaying the recorded outputs above) wired into the agent-gate component set, plus a
-   documented **live worktree probe** proving a worktree-launched review reviews the worktree's HEAD.
-8. **Doctrine in the same change** (CLAUDE.md's roborev-invocation paragraph + the
-   `agents-developing/roborev-findings` page).
+6. **Docs-only diffs are declared non-certifiable by roborev**, and enforced DETERMINISTICALLY.
+   Trigger 3 makes roborev structurally unable to review a code-free diff, so an all-prose census FAILs
+   under its own `code-free:` key from the wrapper's own classification, before a review is enqueued —
+   never contingent on the reviewer admitting it. The sanctioned substitute is verification against
+   **primary sources** (for #2950 that was `git show cassandra-5.0.8:<path>`) recorded in the PR.
+7. **A non-zero roborev exit is ATTRIBUTED, not merely reported.** roborev exits non-zero **when it
+   reports findings**, so `roborev-exit:` splits `FINDINGS (exit N)` (a genuine review to triage and
+   fix) from `ERROR (exit N)` (the reviewer itself failed), with a new `findings:` key as the
+   deterministic disambiguator. Both FAIL the run; misattributing findings as a malfunction is
+   dangerous in the opposite direction — an agent told the reviewer broke retries or bypasses instead
+   of fixing.
+8. **Token accounting is repaired and demoted.** It was PERMANENTLY `UNAVAILABLE` on every real run
+   (the payload's `token_usage` is a JSON-ENCODED STRING needing a double decode, and the output field
+   is `total_output_tokens`) — i.e. a guard that silently was not there. Now three-state: `absent` ⇒
+   `UNAVAILABLE`, `parsed` ⇒ evaluate, **`present-but-unparseable` ⇒ FAIL (drift)**. The input floor is
+   re-anchored to **25,000** on the measured vacuous ceiling, and the **output-token floor is dropped
+   as a FAIL condition** (it cannot discriminate a genuine CLEAN review from a vacuous one).
+9. **Call-site migration across SIXTEEN surfaces** — thirteen under `.claude/**` (including the
+   `/worker` and `/manager` fleet entry points) plus three non-`.claude` doctrine surfaces that
+   previously prescribed the **inverse** rule ("no `--agent`/`--model` flags"; one called explicit
+   agent/model "never doctrine"). Bare `--branch` becomes non-sanctioned everywhere.
+10. **A hermetic regression check** (`scripts/tests/test_roborev_review_guard.sh`, a stub `roborev` on
+    `PATH` replaying the recorded outputs — including the doubly-encoded token payload — against
+    throwaway git fixtures covering the fleet's narrow-refspec topology) wired into BOTH the `--lite`
+    `roborev-lints` component and the full-gate `tooling-tests`, plus a documented **live worktree
+    probe** proving a worktree-launched review reviews the worktree's HEAD.
+11. **Doctrine in the same change** (CLAUDE.md's roborev-invocation paragraph + the
+    `agents-developing/roborev-findings` page, including a row in its mechanized-in-`--lite` table).
 
 ## Non-goals
 
@@ -100,13 +133,19 @@ have shipped.
 ## Impact
 
 - **New scripts:** `scripts/flow/roborev-review.sh` (the sanctioned invocation),
-  `scripts/tests/test_roborev_review_guard.sh` (hermetic regression check).
+  `scripts/flow/roborev-review-oracles.sh` (sourced: push assert + census/code-free oracles),
+  `scripts/flow/roborev-job-facts.py` (job-record + token extraction),
+  `scripts/tests/test_roborev_review_guard.sh` (hermetic regression check — 258 assertions).
 - **Gate:** the regression check is registered in `scripts/agent-gate.sh`'s shell-tooling component
   set (`tooling-tests`, and `roborev-lints` so it also runs in `--lite`), so a regression FAILs the
   fast loop rather than costing a review round.
-- **Agent surfaces (call-site migration):** `.claude/skills/{flow-implement,flow-activate,flow-address,
-  flow-finalize,ci-cd-validation}/SKILL.md` and `.claude/agents/{flow-closer,flow-lead,rust-reviewer,
-  sstable-developer,test-validator}.md`.
+- **Agent surfaces (call-site migration, 13):** `.claude/skills/{flow-implement,flow-activate,
+  flow-address,flow-finalize,ci-cd-validation}/SKILL.md`,
+  `.claude/skills/ci-cd-validation/merge-process.md`, `.claude/agents/{flow-closer,flow-lead,
+  rust-reviewer,sstable-developer,test-validator}.md`, and `.claude/commands/{worker,manager}.md`.
+- **Fleet doctrine surfaces (3):** `website/src/content/docs/agents-developing/delivery-pipeline.md`,
+  `docs/development/pm-operating-loop.md`, `docs/development/agent-machine-setup.md` — each previously
+  prescribed the INVERSE rule (run roborev with the machine's configured agent and no flags).
 - **Doctrine (ships in this change per CLAUDE.md):** CLAUDE.md's roborev-invocation bullet in
   *Agent-Team Conventions*, plus `website/src/content/docs/agents-developing/roborev-findings.md`.
   Publication is accepted by **grepping the served page for a new distinctive phrase** — an HTTP 200

--- a/openspec/changes/roborev-vacuous-review-guard/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-vacuous-review-guard/specs/roborev-review-guard/spec.md
@@ -1,58 +1,269 @@
 # roborev-review-guard — delta for roborev-vacuous-review-guard (issue #2964)
 
+**Architecture note (read this first).** The as-built guard is **DETERMINISTIC-PRIMARY**: the checks
+that carry the verdict are the ones judged against data the wrapper obtains ITSELF — the remote
+(`git ls-remote`), its own `git` diff census, its own code-free classification of that census, the job
+record's structured `git_ref`/`status`, and the census's own file paths inside the prompt actually sent
+to the reviewer. Reviewer PROSE matching and TOKEN accounting are **corroborating** signals layered on
+top. Any requirement below that reads like "match a phrase" is subordinate to the deterministic set by
+design, and a PASS is reachable ONLY on POSITIVE evidence that a review completed — never on the
+absence of a bad phrase.
+
 **Acceptance-criterion → requirement map** (issue #2964's numbered ACs):
 
 | AC | Requirement(s) |
 |----|----------------|
-| 1 — an empty resolved diff on a non-empty requested range must fail loudly, never "No issues found" | *A non-empty local diff census with a vacuous review verdict is a hard failure*; *A genuinely empty census reports NOTHING-TO-REVIEW, never a pass*; *The wrapper emits a machine-greppable summary block with a terminal verdict*; *A non-zero exit from the roborev process is a hard failure under its own greppable key* |
-| 2 — invoke with explicit SHA + explicit `--repo`, and assert the enqueued SHA equals branch HEAD | *The sanctioned invocation is by explicit SHA and explicit repository path*; *The reviewed SHA is asserted against branch HEAD*; *Every flow-\* roborev call site routes through the sanctioned wrapper* |
-| 3 — push the implementation commit before reviewing | *The branch is asserted pushed before any review is requested* |
-| 4 — doctrine updated (CLAUDE.md + the `agents-developing/roborev-findings` page) | *Doctrine records the verify-the-reviewed-SHA rule and the hard-fail verdict text* |
-| 5 — a regression check proves a worktree-launched review reviews the worktree's HEAD | *A hermetic regression check pins every vacuity trigger and is wired into the agent gate*; *A documented live worktree probe proves the worktree's HEAD is what gets reviewed* |
+| 1 — an empty resolved diff on a non-empty requested range must fail loudly, never "No issues found" | *A PASS requires positive evidence that a review completed*; *The locally computed diff census is the authoritative oracle*; *The reviewer must demonstrably have received the census's own files*; *A code-free census is a deterministic failure before any review is enqueued*; *A vacuous verdict claim against a non-empty census fails, gated on the findings state*; *Token accounting corroborates the deterministic checks and may only fail closed*; *A genuinely empty census reports NOTHING-TO-REVIEW, never a pass*; *A findings-bearing review is distinguished from a reviewer error, both under their own greppable keys*; *The wrapper emits a machine-greppable summary block with a terminal verdict* |
+| 2 — invoke with explicit SHA + explicit `--repo`, and assert the enqueued SHA equals branch HEAD | *The sanctioned invocation is by explicit SHA and explicit repository path*; *The reviewed SHA is asserted against branch HEAD using the job record as the oracle*; *A model substitution is surfaced, never silent*; *Every roborev call site and doctrine surface routes through the sanctioned wrapper* |
+| 3 — push the implementation commit before reviewing | *The branch is asserted pushed by asking the REMOTE, never a local mirror ref* |
+| 4 — doctrine updated (CLAUDE.md + the `agents-developing/roborev-findings` page) | *Doctrine records the four roborev rules*; *Every roborev call site and doctrine surface routes through the sanctioned wrapper* |
+| 5 — a regression check proves a worktree-launched review reviews the worktree's HEAD | *A hermetic regression check pins every vacuity trigger and is wired into the agent gate*; *The wrapper fails closed when its own local oracles are unavailable*; *A documented live worktree probe proves the worktree's HEAD is what gets reviewed* |
 
 ## ADDED Requirements
 
-### Requirement: A non-empty local diff census with a vacuous review verdict is a hard failure
-The sanctioned roborev wrapper SHALL compute a **local diff census** — the files changed and lines
-added/removed for `<base>...HEAD`, obtained from `git` in the target repository — and SHALL treat that
-locally-computed census as the authoritative statement of what must be reviewed. When the census is
-NON-empty, the wrapper SHALL FAIL LOUDLY (non-zero exit and an explicit message) rather than report a
-pass if EITHER of the following holds:
+### Requirement: A PASS requires positive evidence that a review completed
+The wrapper SHALL NOT report `RESULT: PASS` unless it holds POSITIVE evidence that a review actually
+completed, recorded under its own greppable key `review-completed:`. The absence of a vacuity phrase
+SHALL NEVER be treated as evidence that a review happened. The positive evidence SHALL be:
 
-- **Tier 1 (primary, deterministic, threshold-free):** the review output claims there are no code
-  changes to review (e.g. matching `contains no code changes to review` or `no code changes`,
-  case-insensitively).
-- **Tier 2 (corroborating, bounded token accounting):** the job's reported token accounting shows an
-  input token count below the named vacuity input threshold, OR a cached-input count of zero, OR an
-  output token count below the named vacuity output threshold.
+- the job record's structured `status` field, which SHALL NOT be a value other than `done` — a status
+  present and not `done` is `FAIL (job status '<s>' is not done)`; and
+- a **terminal verdict marker** in the transcript, drawn from a declared ALLOW-LIST: a severity-tagged
+  findings marker, or the clean shape (a "no issues found" statement AND a `Summary:` line). No marker
+  ⇒ `FAIL (no terminal verdict marker)`.
 
-Tier 1 SHALL be authoritative: it SHALL NOT be relaxed, overridden, or skipped by tier 2's outcome or
-availability. Tier 2's only permitted effect SHALL be to fail closed — it SHALL NEVER cause a run to
-pass. The tier-2 thresholds SHALL be named constants declared at the top of the wrapper with the
-measured evidence cited in a comment, and every tier-2 failure message SHALL print the observed values
-next to the threshold that tripped. When token accounting is unavailable from the installed roborev
-build, the wrapper SHALL record a degraded-signal notice in its summary block and SHALL still apply
-tier 1 — never a silent skip.
+An unreadable transcript SHALL be `FAIL (transcript unreadable)`. When the structured `status` is
+UNAVAILABLE the check MAY still pass on the transcript marker alone, and SHALL then record a NOTICE
+naming that as the weaker of the two signals — an unavailable status SHALL NEVER be silently treated as
+`done`. This requirement exists because the reproduced defect was exactly the inverse inference: a
+transcript showing only an unfinished job, a provider `400 … model is not supported` outage, or a job
+whose status was `failed` each contained NO vacuous phrase and therefore reached `RESULT: PASS`.
 
-#### Scenario: A "no code changes" verdict against a non-empty census fails loudly
-- **GIVEN** a branch whose local census against the base is non-empty (for example 5 files, +167/−63)
-- **WHEN** the wrapper runs and the review returns "No issues found" with a summary stating the diff contains no code changes to review
-- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, its message names the vacuous-verdict-vs-census contradiction and prints the census, and the run is NOT reportable as "roborev clean"
+#### Scenario: A job that never finished cannot reach PASS
+- **GIVEN** a pushed branch with a non-empty code census whose transcript shows only that the wrapper was waiting for the job to complete, with no terminal verdict marker
+- **WHEN** the wrapper runs
+- **THEN** `review-completed:` reads `FAIL (no terminal verdict marker)`, the terminal `RESULT:` is `FAIL`, and the run is NOT reportable as "roborev clean"
+
+#### Scenario: A provider model-mismatch outage cannot reach PASS
+- **GIVEN** a review whose transcript carries a provider error (for example the #2433/#3037 `400 … model is not supported` mismatch) and no terminal verdict marker
+- **WHEN** the wrapper runs
+- **THEN** `review-completed:` FAILs, the terminal `RESULT:` is `FAIL`, and the failure message states that the absence of a vacuous phrase is never evidence that a review happened
+
+#### Scenario: A non-done job status fails closed
+- **GIVEN** a job whose structured `status` is `failed`
+- **WHEN** the wrapper evaluates completion
+- **THEN** `review-completed:` reads `FAIL (job status 'failed' is not done)` and the terminal `RESULT:` is `FAIL`
+
+#### Scenario: A completed review with a terminal verdict marker passes the completion check
+- **GIVEN** a job whose structured `status` is `done` and whose transcript carries a terminal verdict marker from the allow-list
+- **WHEN** the wrapper evaluates completion
+- **THEN** `review-completed:` reads `PASS`, and an unavailable `status` alongside a present marker instead records a NOTICE naming the weaker signal rather than a silent pass
+
+### Requirement: The locally computed diff census is the authoritative oracle
+The wrapper SHALL compute a **local diff census** — the files changed and lines added/removed for
+`<base>...HEAD`, obtained from `git` in the target repository — and SHALL treat that locally computed
+census as the authoritative statement of what must be reviewed. Every downstream judgement SHALL be
+made against that census and never against the reviewer's own report of what it saw. The census SHALL
+be reported under `census:` and its own verdict under `census-check:`.
+
+Rename detection SHALL be disabled, so every census entry is a REAL path (a rename-composite path such
+as `dir/{old => new}.rs` is not a path and could never be located in the reviewer's prompt).
+
+An unmeasurable census SHALL fail closed and SHALL be DISTINGUISHABLE from an empty one:
+`FAIL (base '<ref>' unresolvable)` when the base ref does not resolve to a commit, and
+`FAIL (git diff failed)` when the diff command itself exits non-zero. Neither SHALL be aliased to
+`FAIL (empty census)` / `NOTHING-TO-REVIEW`, because "we could not tell" is not "there is nothing to
+review". The wrapper SHALL NOT fetch on the caller's behalf to repair an unresolvable base.
+
+#### Scenario: An unresolvable base ref fails closed rather than reporting nothing to review
+- **GIVEN** a clone whose `origin/main` mirror ref does not resolve (a narrow fetch refspec that has never fetched it)
+- **WHEN** the wrapper runs with the default base
+- **THEN** `census-check:` reads `FAIL (base 'origin/main' unresolvable)`, the terminal `RESULT:` is `FAIL` (not `NOTHING-TO-REVIEW`), no review is enqueued, and the message states that an unresolvable base is "we cannot tell", never "there is nothing to review"
+
+#### Scenario: A failed git diff is not "genuinely empty"
+- **GIVEN** a repository in which `git diff --numstat --no-renames <base>...HEAD` exits non-zero
+- **WHEN** the wrapper computes the census
+- **THEN** `census-check:` reads `FAIL (git diff failed)`, the message reproduces what git said, and the outcome is `RESULT: FAIL` rather than `NOTHING-TO-REVIEW`
+
+#### Scenario: The census is the oracle every later judgement is measured against
+- **WHEN** the census is non-empty
+- **THEN** `census:` reports the file count and the added/removed line totals, and the code-free, prompt-content and vacuity checks all state their verdicts relative to that census rather than to anything the reviewer reports
+
+### Requirement: The reviewer must demonstrably have received the census's own files
+The wrapper SHALL assert, under its own greppable key `prompt-content:`, that the census's own changed
+file paths appear in the prompt ACTUALLY SENT to the reviewer, retrieved from the job record (the
+structured `prompt` field, else the reviewer's own prompt-retrieval command). This check SHALL be
+DETERMINISTIC and THRESHOLD-FREE: it catches "the reviewer never received the diff", the half of the
+defect space that a verdict-text comparison cannot see.
+
+Any checked path missing from the prompt SHALL be a `FAIL (<k>/<n> census paths absent from the
+prompt)` that names the missing paths. The number of paths checked MAY be bounded by a named constant
+for a large census, in which case the checked subset SHALL be evenly sampled across the census and ALL
+sampled paths SHALL be required present; the PASS value SHALL report the coverage it actually checked.
+
+A prompt that cannot be RETRIEVED (empty or whitespace-only) SHALL be `UNAVAILABLE` — a visible
+degraded signal, never a FAIL and never a silent skip — because a roborev build that does not expose
+the prompt would otherwise false-FAIL every run. An `UNAVAILABLE` SHALL never turn a FAIL into a PASS.
+
+#### Scenario: A prompt that does not mention the census's files is a hard failure
+- **GIVEN** a pushed branch with a non-empty code census whose review returns a clean verdict with healthy token accounting
+- **WHEN** the prompt actually sent to the reviewer mentions none of the census's file paths
+- **THEN** `prompt-content:` reads `FAIL (<k>/<n> census paths absent from the prompt)`, the message names the missing paths and states that a prompt that does not mention the census's files cannot have reviewed them, and the terminal `RESULT:` is `FAIL`
+
+#### Scenario: An unretrievable prompt degrades visibly instead of failing or skipping
+- **GIVEN** a roborev build from which the prompt for the job cannot be retrieved
+- **WHEN** the wrapper evaluates prompt content
+- **THEN** `prompt-content:` reads `UNAVAILABLE`, a NOTICE records the retrieval attempts and states that the deterministic checks still govern, and the run's verdict is decided by the other checks
+
+#### Scenario: A prompt carrying the census's files passes and reports its coverage
+- **WHEN** every checked census path appears in the prompt
+- **THEN** `prompt-content:` reads `PASS` and names how many census paths it checked, so a reader can see the coverage rather than trusting a bare PASS
+
+### Requirement: A code-free census is a deterministic failure before any review is enqueued
+Because roborev structurally discards a code-free diff, a census consisting ENTIRELY of
+documentation/specification prose SHALL be a DETERMINISTIC FAIL under its own greppable key
+`code-free:`, evaluated from the wrapper's OWN census classification **before any review is enqueued**,
+with no reviewer prose involved. No docs-only change SHALL record "roborev clean", and the sanctioned
+substitute SHALL be verification against primary sources recorded in the pull request.
+
+Classification SHALL be by file EXTENSION against a declared prose-extension set, with a path assist
+limited to EXTENSIONLESS files under declared prose directories. A file with a code-ish extension
+anywhere in the tree — including `docs/foo.py` and `.github/workflows/*.yml` — SHALL count as CODE, so
+the check cannot false-FAIL a code change that merely lives in a documentation directory.
+
+This requirement is deliberately STRONGER than a prose-matched detection: an earlier revision computed
+the same classification and used it only for attribution wording, which let a docs-only diff reach
+`RESULT: PASS` whenever the reviewer's verdict happened not to carry the vacuity phrase.
+
+#### Scenario: A markdown-only census fails deterministically before a review is enqueued
+- **GIVEN** a pushed branch whose census against the base is entirely markdown
+- **WHEN** the wrapper runs
+- **THEN** `code-free:` reads `FAIL (code-free census: <n>/<n> files are documentation/specification text)`, NO review is enqueued, the terminal `RESULT:` is `FAIL`, and the message directs the author to primary-source verification in the PR instead of "roborev clean"
+
+#### Scenario: A code-free census fails even when the review returns clean with healthy accounting
+- **GIVEN** a docs-only census and a reviewer that would return "No issues found" with genuine-looking token accounting
+- **WHEN** the wrapper runs
+- **THEN** the outcome is still `RESULT: FAIL` attributed to `code-free:`, because the failure is a property of the census the wrapper measured and never a bet on the reviewer admitting it
+
+#### Scenario: A workflow YAML or a script under a prose directory is CODE, not documentation
+- **GIVEN** a census consisting only of `.github/workflows/ci.yml`, and separately a census mixing one markdown file with one `.rs` file
+- **WHEN** the wrapper classifies each census
+- **THEN** neither is classified code-free, `code-free:` reads `PASS` for both, and the review proceeds — so a false code-free classification cannot manufacture a false FAIL
+
+#### Scenario: The sanctioned substitute for a docs-only change is primary-source verification
+- **GIVEN** a docs-only change that cannot be roborev-certified
+- **WHEN** the change is prepared for merge
+- **THEN** doctrine directs the author to record primary-source verification in the pull request (for example reading the pinned Cassandra source at the `cassandra-5.0.8` tag that the documentation describes) instead of recording "roborev clean"
+
+### Requirement: A vacuous verdict claim against a non-empty census fails, gated on the findings state
+The wrapper SHALL compare the reviewer's own verdict text against the non-empty census under the
+greppable key `vacuity-tier1:`, and a vacuity claim there SHALL be AUTHORITATIVE — a HARD FAIL that
+blocks the merge, not a note. Two properties SHALL bound the match so it cannot false-FAIL a genuine
+review:
+
+1. **ANCHORING.** The match SHALL be confined to the verdict/summary region of the transcript (the
+   lines carrying a `Summary:`), never to arbitrary finding bodies or quoted text. A transcript with no
+   such region SHALL read `UNAVAILABLE`.
+2. **GATING ON the findings state** (the `findings:` key below):
+   - `findings: NONE` — the reviewer is CLAIMING CLEANLINESS, so the phrase is a vacuity claim about a
+     census we measured as non-empty ⇒ `FAIL (vacuous verdict vs non-empty census)`.
+   - `findings: UNKNOWN` — the state is unknowable ⇒ HARD FAIL as well. An unknowable findings state
+     SHALL NEVER DISARM this check; fail-closed is the correct direction.
+   - `findings: PRESENT` (with or without a count) — the reviewer demonstrably analysed the diff and
+     produced findings, so the phrase is discussion ⇒ an advisory
+     `NOTICE (phrase present in a findings-bearing review)` that does NOT fail the run.
+
+The gating and anchoring SHALL be recorded as an EVIDENCED relaxation, not silent drift: the
+unanchored, ungated form false-FAILed a genuine findings-bearing review that merely QUOTED the phrase
+(this change's own diff carries the phrase in five or more files), and the systemic cost of a false
+FAIL is agents learning to WAIVE tier-1 FAILs — which restores the original defect wholesale.
+
+#### Scenario: A cleanliness claim of no code changes against a code census is a hard failure
+- **GIVEN** a pushed branch whose census against the base is non-empty and contains code
+- **WHEN** the review's summary states the diff contains no code changes to review and the review reports NO findings
+- **THEN** `vacuity-tier1:` reads `FAIL (vacuous verdict vs non-empty census)`, the message prints the census and states that the reviewer's claim contradicts a fact the wrapper measured itself, the terminal `RESULT:` is `FAIL`, and the run is NOT reportable as "roborev clean"
+
+#### Scenario: An UNKNOWN findings state does not disarm the check
+- **GIVEN** a run whose findings state is `UNKNOWN` because the reviewer errored
+- **WHEN** the verdict region carries the vacuity phrase
+- **THEN** `vacuity-tier1:` still reads `FAIL (vacuous verdict vs non-empty census)` and the message states that an unknowable findings state is treated as claiming cleanliness because fail-closed is the correct direction
+
+#### Scenario: A findings-bearing review that quotes the phrase is a NOTICE, not a failure
+- **GIVEN** a review that reported findings and whose summary discusses the phrase "no code changes"
+- **WHEN** the wrapper evaluates tier 1
+- **THEN** `vacuity-tier1:` reads `NOTICE (phrase present in a findings-bearing review)`, the NOTICE explains that the review demonstrably analysed the diff, and the NOTICE does not fail the run
+
+#### Scenario: The match is anchored to the verdict region, not the whole transcript
+- **GIVEN** a clean review whose finding bodies or quoted material mention "no code changes" while its own summary does not
+- **WHEN** the wrapper evaluates tier 1
+- **THEN** `vacuity-tier1:` reads `PASS`, because an unanchored match would false-FAIL a genuine review and teach agents to waive the check
+
+### Requirement: Token accounting corroborates the deterministic checks and may only fail closed
+Token accounting SHALL be a CORROBORATING signal under `vacuity-tier2:` whose only permitted effect is
+to FAIL CLOSED — it SHALL NEVER cause a run to pass, SHALL NEVER relax another check's FAIL, and SHALL
+NEVER be the sole thing standing between the pipeline and a vacuous pass.
+
+Extraction SHALL distinguish THREE states and SHALL be reported so a reader can tell them apart:
+
+- **absent** — the job record carries no token accounting at all ⇒ `UNAVAILABLE`, a visible
+  degraded-signal notice, never a silent skip.
+- **parsed** — counts readable ⇒ the thresholds are evaluated.
+- **present but unparseable** — a token field IS present yet no documented field alias resolves to a
+  number ⇒ `FAIL (token accounting present but unparseable — drift)`. This SHALL be a FAIL and SHALL
+  NOT be downgraded to a notice, because that is exactly how the tier was SILENTLY DISARMED: the real
+  payload double-encodes its token container as a JSON STRING and names the output count
+  `total_output_tokens`, so reading it as a nested object with `output_tokens` yielded no counts, the
+  tier reported a non-failing `UNAVAILABLE` on EVERY real run, and a guard that silently was not there
+  certified runs whose true counts were the vacuous baseline. The remedy named in the failure message
+  SHALL be to add the new field alias, never to waive the check.
+
+The FAIL conditions on parsed counts SHALL be: an input count below the named input floor, OR a cached
+input count of zero. Each SHALL print the OBSERVED value beside the named constant that tripped.
+Thresholds SHALL be named constants declared with the measured evidence cited beside them.
+
+Two calibration decisions SHALL be recorded with their evidence, so each is a documented decision
+rather than silent drift:
+
+- The input floor SHALL be anchored on the measured VACUOUS CEILING, not on the genuine band, because
+  the genuine band scales with diff size: **25,000** sits above the highest observed vacuous run
+  (18,801) and below the smallest observed genuine run (67,387). The originally specified 50,000 would
+  have false-FAILed that genuine run's size class, and an always-red guard is the failure mode that
+  gets a guard bypassed.
+- An output-token floor SHALL NOT be a FAIL condition; it MAY be reported as an advisory NOTICE only.
+  A genuine CLEAN review and a vacuous one emit near-identical output counts (both are "No issues
+  found" plus one sentence; the vacuous baseline measured 21–56), so the counts COLLIDE and any output
+  floor would false-FAIL precisely the case that matters most — a real review that is legitimately
+  clean.
+- A `cached_input_tokens == 0` FAIL SHALL be retained with its false-positive caveat documented (a
+  genuinely cold cache can report zero); it is an accepted trade in the fail-closed direction, made
+  affordable by the deterministic checks now carrying the verdict.
+
+Wall-clock duration SHALL NOT be asserted (host-dependent, #2642).
 
 #### Scenario: The vacuous token signature against a non-empty census fails loudly
-- **GIVEN** a branch whose local census against the base is non-empty
-- **WHEN** the review completes without a "no code changes" phrase, but the job's token accounting reports an input count below the vacuity input threshold, or zero cached input, or an output count below the vacuity output threshold
-- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message prints each observed token value beside the named threshold constant that tripped
+- **GIVEN** a pushed branch with a non-empty code census whose job reports the measured vacuous accounting (input ≈18k, cached 0)
+- **WHEN** the wrapper evaluates tier 2
+- **THEN** `vacuity-tier2:` reads `FAIL (vacuous token signature)`, each trip prints the observed value beside the named threshold constant, and the terminal `RESULT:` is `FAIL`
 
-#### Scenario: A genuine review with healthy accounting passes
-- **GIVEN** a branch whose local census against the base is non-empty, whose branch is pushed, and whose review enqueued the branch HEAD
-- **WHEN** the review returns a verdict containing no "no code changes" claim and reports token accounting above the thresholds (for example ~500k input, ~387k cached, ~6.3k output)
-- **THEN** the wrapper exits zero with `RESULT: PASS` and every per-check line in the summary block reads PASS
+#### Scenario: Token accounting present but unparseable is failed as drift
+- **GIVEN** a job whose token container is present but whose count fields match none of the documented aliases
+- **WHEN** the wrapper evaluates tier 2
+- **THEN** `vacuity-tier2:` reads `FAIL (token accounting present but unparseable — drift)`, the terminal `RESULT:` is `FAIL`, and the message names the extractor's alias sets as the fix and says not to waive it
 
-#### Scenario: Unavailable token accounting degrades visibly and tier 1 still governs
-- **GIVEN** a roborev build from which the wrapper cannot obtain token accounting for the job
-- **WHEN** the wrapper evaluates vacuity on a non-empty census
-- **THEN** the summary block records `vacuity-tier2: UNAVAILABLE` as an explicit degraded-signal notice, the tier-1 check is still applied and can still FAIL the run, and the unavailability alone never turns a FAIL into a PASS nor is recorded as a silent skip
+#### Scenario: The real doubly-encoded payload shape is decoded and the tier actually evaluates
+- **GIVEN** a job whose token container is a JSON-ENCODED STRING carrying `total_output_tokens`, with the measured small-but-genuine counts (67,387 input / 43,520 cached / 2,232 output)
+- **WHEN** the wrapper evaluates tier 2
+- **THEN** the counts appear on the `tokens:` line and `vacuity-tier2:` reads `PASS` — it is not reported as `UNAVAILABLE`, which is what a single decode produced on every real run
+
+#### Scenario: A low output count never fails a genuine clean review
+- **GIVEN** a genuine review with healthy input and cached counts whose output count is below the advisory output constant
+- **WHEN** the wrapper evaluates tier 2
+- **THEN** `vacuity-tier2:` reads `PASS`, and the low output count is reported only as an advisory NOTICE that states output tokens cannot discriminate a genuine clean review from a vacuous one
+
+#### Scenario: Absent token accounting degrades visibly and never rescues a failing run
+- **GIVEN** a roborev build whose job record carries no token accounting at all
+- **WHEN** the wrapper evaluates a run whose deterministic checks pass
+- **THEN** `vacuity-tier2:` reads `UNAVAILABLE` with an explicit degraded-signal notice, the deterministic checks still govern the verdict, and the unavailability alone neither fails the run nor turns any other check's FAIL into a PASS
 
 ### Requirement: A genuinely empty census reports NOTHING-TO-REVIEW, never a pass
 When the local diff census for `<base>...HEAD` is genuinely empty, the wrapper SHALL NOT invoke a review
@@ -74,7 +285,9 @@ The wrapper SHALL invoke roborev with an EXPLICIT commit SHA (the branch HEAD) a
 repository path, and SHALL NEVER use the bare `--branch` form (which resolves against the root checkout
 from inside a git worktree) nor the two-positional commit-range form (which has been observed to enqueue
 a commit that is neither endpoint). The wrapper SHALL require BOTH the reviewer agent and the reviewer
-model to be supplied, refusing to run with only one of them.
+model to be supplied, refusing to run with only one of them. An option supplied with an EMPTY value
+SHALL be a usage error rather than a silent fallback to the default, because a `--repo ""` falling back
+to `$PWD` is exactly how a caller reviews a repository it did not name.
 
 #### Scenario: The invocation names the HEAD sha and an absolute repo path
 - **WHEN** the wrapper invokes roborev
@@ -85,58 +298,173 @@ model to be supplied, refusing to run with only one of them.
 - **WHEN** the wrapper runs
 - **THEN** it refuses with a non-zero exit and a message naming the missing option, before any review is enqueued
 
-### Requirement: The reviewed SHA is asserted against branch HEAD
-The wrapper SHALL parse the enqueued-job announcement (`Enqueued job <N> for <sha>`) and SHALL require
-the announced sha to prefix-match the branch HEAD sha. A mismatch SHALL abort the round with a non-zero
-exit. When the mismatched sha resolves to the base ref (for example `origin/main`), the failure message
-SHALL say so explicitly, because that equality is the signature of the worktree `--branch` resolution
-trigger. An absent or unparseable enqueue announcement SHALL also be a failure, never a skipped check.
+#### Scenario: An empty option value is a usage error, not a default
+- **GIVEN** an invocation that passes an option with an empty value (for example an empty `--repo`)
+- **WHEN** the wrapper parses its arguments
+- **THEN** it refuses with the usage exit code and a message stating that an empty value is never a default, and nothing is enqueued
 
-#### Scenario: An enqueued sha equal to the base ref aborts and names the base
-- **GIVEN** a worktree branch whose HEAD is `4e7ab591e` and whose base `origin/main` is `39900e4db`
-- **WHEN** the review announces `Enqueued job N for 39900e4db`
-- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message states that the enqueued sha equals the base ref `origin/main` and therefore no branch change was reviewed
+### Requirement: The reviewed SHA is asserted against branch HEAD using the job record as the oracle
+The wrapper SHALL assert the reviewed sha against branch HEAD under the greppable key `sha-assert:`,
+using the **job record's structured `git_ref`** as the oracle — a full-length sha recorded by roborev
+itself, compared full-sha to full-sha. Parsing the tool's stdout announcement is the WEAKER source and
+SHALL be DEMOTED to a cross-check: a disagreement between the announcement and the structured field
+SHALL be recorded as a NOTICE (the structured field winning), and the structured field being
+unavailable SHALL fall back to a prefix comparison against the announced sha with a NOTICE naming the
+fallback as the weaker source.
 
-#### Scenario: An enqueued sha that is neither endpoint aborts
-- **GIVEN** a branch HEAD of `989d7d2c3` and a base of `89fdbb895`
-- **WHEN** the review announces `Enqueued job N for 90a17d376`, which matches neither the HEAD nor the base
-- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message prints the announced sha beside the expected HEAD sha
+The announcement SHALL nevertheless remain load-bearing enough to fail closed, because it carries the
+job id every structured query needs: an ABSENT announcement SHALL be `FAIL (no parseable enqueue
+announcement)` and a malformed one (a non-numeric job id, or a sha shorter than the declared hex-length
+floor) SHALL be `FAIL (unparseable enqueue announcement)` — never a skipped check. Parsing SHALL be
+defensive: case-normalised before matching, both fields validated before use, and when several
+announcements are present the LAST one SHALL be the effective enqueue with the multiplicity recorded.
 
-#### Scenario: A missing enqueue announcement fails closed
-- **WHEN** the review output contains no parseable `Enqueued job <N> for <sha>` line
-- **THEN** the wrapper exits non-zero with `RESULT: FAIL` because the reviewed sha is unverifiable, and does not report a pass
+A mismatch SHALL be `FAIL (reviewed-sha does not match head-sha)` and SHALL be ATTRIBUTED: when the
+reviewed sha equals the base ref the message SHALL say so explicitly (the signature of the worktree
+bare-`--branch` resolution trigger), and when it matches neither endpoint the message SHALL name that
+as the signature of the two-positional commit-range form.
 
-#### Scenario: A matching enqueued sha satisfies the assert
-- **WHEN** the announced sha prefix-matches the branch HEAD sha
-- **THEN** the summary block records `sha-assert: PASS` with both the head sha and the reviewed sha printed
+#### Scenario: The structured git_ref wins over a disagreeing stdout announcement
+- **GIVEN** a run whose stdout announces the branch HEAD while the job record's `git_ref` records the base ref as reviewed
+- **WHEN** the wrapper asserts the reviewed sha
+- **THEN** `sha-assert:` FAILs against the structured `git_ref`, the message states the reviewed sha equals the base ref and names the worktree resolution trigger, and the disagreement between the two surfaces is recorded as a NOTICE
 
-### Requirement: The branch is asserted pushed before any review is requested
-Before enqueuing a review, the wrapper SHALL assert that the remote tracking ref for the current branch
-(`origin/<branch>`) exists and equals the local HEAD. If it does not, the wrapper SHALL FAIL with a
-non-zero exit and name the unpushed commits, because an unpushed implementation commit is itself a cause
-of an empty resolved diff.
+#### Scenario: A reviewed sha equal to the base ref aborts and names the base
+- **GIVEN** a worktree branch whose HEAD differs from its base `origin/main`
+- **WHEN** the reviewed sha equals the base ref
+- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message states that the reviewed sha equals the base ref and therefore no branch change was reviewed
 
-#### Scenario: An unpushed commit fails before a review is enqueued
-- **GIVEN** a branch with one local commit that has not been pushed, so `origin/<branch>` is behind HEAD
+#### Scenario: A reviewed sha that is neither endpoint aborts
+- **GIVEN** a branch HEAD and a base that both differ from the reviewed sha
+- **WHEN** the wrapper asserts the reviewed sha
+- **THEN** it exits non-zero with `RESULT: FAIL`, and the message prints the reviewed sha beside the expected HEAD sha and names the two-positional range form as the signature
+
+#### Scenario: A missing or malformed enqueue announcement fails closed
+- **WHEN** the transcript contains no parseable enqueue announcement, or one whose job id is non-numeric or whose sha is shorter than the declared hex floor
+- **THEN** `sha-assert:` reads `FAIL (no parseable enqueue announcement)` or `FAIL (unparseable enqueue announcement)` respectively, the reviewed sha is treated as unverifiable, and the run does not report a pass
+
+#### Scenario: A matching reviewed sha satisfies the assert
+- **WHEN** the job record's `git_ref` equals the branch HEAD sha (or, on fallback, the announced abbreviated sha prefix-matches it)
+- **THEN** `sha-assert:` reads `PASS` with both the head sha and the reviewed sha printed in the block
+
+### Requirement: A model substitution is surfaced, never silent
+The wrapper SHALL report the model the job actually ran under the greppable key `model:`, and SHALL
+surface a difference between the requested model and the model the job ran as a LOUD NOTICE naming both
+values. It SHALL NOT be a FAIL: roborev legitimately canonicalises/resolves a model alias, so a
+mismatch is not by itself evidence of a bad review, and an always-red guard is the failure mode that
+gets a guard bypassed (a failure mode this change hit twice). When the job record carries no model
+field, the line SHALL say so explicitly rather than implying confirmation.
+
+#### Scenario: A substituted model is reported loudly without failing the run
+- **GIVEN** a job whose requested model differs from the model it ran
+- **WHEN** the wrapper emits its block
+- **THEN** `model:` names the model that ran and marks it as SUBSTITUTED, naming the requested model, a NOTICE tells the operator to confirm the substituted model is acceptable for a merge-gating review, and the substitution alone does not fail the run
+
+#### Scenario: A matching model is reported plainly and an absent one is marked unconfirmed
+- **WHEN** the job's model equals the requested model
+- **THEN** `model:` reports it plainly; and when the job record carries no model field at all, the line marks the value UNCONFIRMED rather than presenting it as confirmed
+
+### Requirement: The branch is asserted pushed by asking the REMOTE, never a local mirror ref
+Before enqueuing a review the wrapper SHALL assert, under `push-assert:`, that the branch exists on its
+remote and that the remote tip equals local HEAD — with `git ls-remote` (the REMOTE itself) as the
+AUTHORITATIVE oracle, compared full-sha. There SHALL be NO local mirror-ref (`refs/remotes/<remote>/<branch>`)
+fast path. Two evidenced reasons:
+
+- CQLite clones carry a NARROW fetch refspec (`+refs/heads/main:refs/remotes/origin/main`), so a feature
+  branch's mirror ref is NEVER created however often the branch is pushed — a mirror-based assert
+  false-FAILed 100% of the fleet, which would have made the only sanctioned invocation unusable and
+  pushed agents back to the bare `--branch` form this wrapper exists to replace.
+- A CACHED mirror ref survives a force-push or an outright deletion of the remote branch, so it can
+  equal HEAD while the remote no longer has the commit — enqueueing a review of a commit the reviewer
+  cannot fetch, which is itself a vacuous-review setup.
+
+The remote SHALL be taken from the branch's configured upstream, falling back to `origin`, never
+hard-coded. Failure causes SHALL be DISTINCT and correctly attributed: `FAIL (detached HEAD)`,
+`FAIL (ls-remote failed: infra/auth)` (an unknown remote state — explicitly NOT "never pushed", since
+`git` and `gh` are separate credential paths), `FAIL (branch absent on remote <remote>)`, and
+`FAIL (unpushed commits)` naming the unpushed commits (or the divergence when local HEAD is not a
+descendant of the remote tip). Every one of these SHALL happen BEFORE a review is enqueued.
+
+#### Scenario: A pushed branch under the fleet's narrow fetch refspec passes
+- **GIVEN** a clone whose fetch refspec only mirrors `main`, so `refs/remotes/origin/<branch>` never exists, and whose feature branch IS pushed
 - **WHEN** the wrapper runs
-- **THEN** it exits non-zero with `RESULT: FAIL`, its message names the unpushed commit(s), and no review job is enqueued
+- **THEN** `push-assert:` reads `PASS` because the assert asked the remote via `git ls-remote`, and the run proceeds to enqueue a review
 
-#### Scenario: A missing remote branch fails before a review is enqueued
-- **GIVEN** a branch that has never been pushed, so `origin/<branch>` does not exist
+#### Scenario: A stale mirror ref equal to HEAD does not satisfy the assert
+- **GIVEN** a branch whose local mirror ref equals HEAD but whose branch has been DELETED from the remote
 - **WHEN** the wrapper runs
-- **THEN** it exits non-zero with `RESULT: FAIL` naming the missing remote branch, and no review job is enqueued
+- **THEN** `push-assert:` reads `FAIL (branch absent on remote <remote>)` and no review is enqueued, because a cached local proxy is never authority for what the remote has
+
+#### Scenario: An unpushed or behind branch fails before a review is enqueued
+- **GIVEN** a branch that has never been pushed, and separately a branch whose remote tip is behind HEAD
+- **WHEN** the wrapper runs
+- **THEN** it exits non-zero with `RESULT: FAIL` — `FAIL (branch absent on remote <remote>)` in the first case and `FAIL (unpushed commits)` naming the unpushed commit(s) in the second — and no review job is enqueued
+
+#### Scenario: An ls-remote failure is attributed to infra/auth, not to being unpushed
+- **GIVEN** a remote that cannot be reached or read
+- **WHEN** the push assert runs
+- **THEN** `push-assert:` reads `FAIL (ls-remote failed: infra/auth)`, the message reproduces what git said and states this is NOT evidence the branch is unpushed (naming the separate `git`/`gh` credential paths), and the run fails closed on the unknown remote state
+
+#### Scenario: A detached HEAD fails before anything is enqueued
+- **GIVEN** a repository on a detached HEAD
+- **WHEN** the wrapper runs
+- **THEN** `push-assert:` reads `FAIL (detached HEAD)`, the message says to check out the issue branch, and no review is enqueued
+
+### Requirement: A findings-bearing review is distinguished from a reviewer error, both under their own greppable keys
+The wrapper SHALL report the findings state under its own greppable key `findings:` (`NONE`,
+`PRESENT`, `PRESENT (<n>)`, `UNKNOWN`, or `SKIP`) and the reviewer process's own status under
+`roborev-exit:`, and SHALL DISTINGUISH the two non-zero causes: `FINDINGS (exit <N>)` when the review
+RAN and reported findings, versus `ERROR (exit <N>)` when the reviewer itself failed. The authority for
+which occurred SHALL be the job record's structured `status`, falling back to the completion evidence.
+
+Both cause the terminal `RESULT: FAIL` — a review with open findings is not "roborev clean" — but the
+attribution SHALL be correct, because roborev exits NON-ZERO WHEN IT REPORTS FINDINGS, and calling that
+a reviewer malfunction is dangerous in the OPPOSITE direction from the vacuity defect: an agent told
+the reviewer broke will RETRY or BYPASS instead of FIXING the findings. The `FINDINGS` message SHALL
+therefore say the review is genuine, that the reviewer did not malfunction, and that the findings must
+be triaged and fixed; the `ERROR` message SHALL name it as an infra condition and point at the daemon,
+credentials and transcript. A zero exit SHALL read `roborev-exit: PASS`, and a failure before the
+reviewer ran SHALL read `SKIP`.
+
+A prose detail line alone SHALL NOT satisfy this requirement: because a caller retains ONLY the summary
+block and reads it by grepping the per-check keys, without these keys a reader sees every per-check key
+reading `PASS` beside a `RESULT: FAIL` and cannot attribute the failure.
+
+#### Scenario: A non-zero exit with a completed review is FINDINGS, not a malfunction
+- **GIVEN** a pushed branch with a non-empty census whose job status is `done` and whose reviewer process exited non-zero after reporting findings
+- **WHEN** the wrapper emits its block
+- **THEN** `roborev-exit:` reads `FINDINGS (exit <N>)`, `findings:` reads `PRESENT` (with a count when countable), the terminal `RESULT:` is `FAIL`, and the message states the review is genuine, tells the operator to triage and fix the findings, and says not to retry or bypass the reviewer
+
+#### Scenario: A non-zero exit with a job that did not complete is an ERROR
+- **GIVEN** a reviewer process that exited non-zero on a job whose status is not `done`
+- **WHEN** the wrapper emits its block
+- **THEN** `roborev-exit:` reads `ERROR (exit <N>)`, `findings:` reads `UNKNOWN`, the message names it an infra condition pointing at the daemon/credentials/transcript, and the terminal `RESULT:` is `FAIL`
+
+#### Scenario: A zero exit records the key as PASS and never rescues another check
+- **WHEN** the reviewer process exits zero
+- **THEN** `roborev-exit:` reads `PASS`, `findings:` reads `NONE` (or `PRESENT (<n>)` when severity markers are present), and that key alone never turns any other check's FAIL into a pass
+
+#### Scenario: A pre-invocation failure leaves the reviewer's status SKIPped, not passed
+- **GIVEN** a run that fails its push assert or census before the reviewer process is started
+- **WHEN** the wrapper emits its block
+- **THEN** `roborev-exit:` reads `SKIP`, which can never be mistaken for a pass
 
 ### Requirement: The wrapper emits a machine-greppable summary block with a terminal verdict
 The wrapper SHALL emit a single compact `==== ROBOREV REVIEW SUMMARY ====` block on every **VERDICT**
-exit path — a pass, any failed check, or an empty census — carrying one field per line under the
-greppable keys `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `job:`, `census:`, `tokens:`,
-`push-assert:`, `census-check:`, `sha-assert:`, `vacuity-tier1:`, `vacuity-tier2:`, `log:`, and a
-terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW`. A per-check key whose step was never reached SHALL carry
-an explicit `SKIP` rather than a blank, so an unreached check can never read as a pass. The block's name
-SHALL be distinct from the agent gate's summary block names so neither can be pasted as the other. The
-wrapper SHALL exit non-zero on any outcome other than PASS, and SHALL be usable such that a caller
-retains ONLY this block and never the raw review transcript (which SHALL be written to the log path
-named in the block's `log:` field).
+exit path — a pass, any failed check, or an empty census — carrying one field per line, in a FIXED
+order that is part of the contract, under the greppable keys: `repo:`, `branch:`, `base:`, `head-sha:`,
+`reviewed-sha:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`,
+`sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`,
+`roborev-exit:`, `log:`, and a terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW`.
+
+Every per-check key SHALL participate in ONE verdict scan in which a value beginning `FAIL`, `FINDINGS`
+or `ERROR` fails the run, and `PASS`, `SKIP`, `UNAVAILABLE` and `NOTICE` never do. A per-check key whose
+step was never reached SHALL carry an explicit `SKIP` rather than a blank, so an unreached check can
+never read as a pass. The block's name SHALL be distinct from the agent gate's summary block names so
+neither can be pasted as the other. The wrapper SHALL exit non-zero on any outcome other than PASS, and
+SHALL be usable such that a caller retains ONLY this block and never the raw review transcript (which
+SHALL be written to the log path named in the block's `log:` field). An unexpected mid-run abort SHALL
+still emit the block with `RESULT: FAIL` rather than terminate silently.
 
 A **USAGE ERROR is NOT a verdict.** When a required option is missing or invalid (notably `--agent`
 without `--model`, or the reverse), the wrapper SHALL emit **NO summary block at all**: it SHALL print a
@@ -145,23 +473,30 @@ loud `ERROR:` line naming the missing or invalid option and SHALL exit with the 
 DELIBERATE and SHALL NOT be "fixed" by emitting a block: the three `RESULT:` values are reserved for the
 three real outcomes, so a `RESULT:` line for a run that never happened would ALIAS a usage error onto a
 genuine verdict — precisely the indistinguishability this capability exists to eliminate. The `--help`
-path (exit `0`) is likewise not a verdict and SHALL emit no block. The "exactly one block" obligation
-therefore scopes to the three verdict paths; the verdict paths SHALL be exhaustive for them, including
-an unexpected mid-run abort, which SHALL emit the block with `RESULT: FAIL` rather than terminate
-silently.
+path (exit `0`) is likewise not a verdict and SHALL emit no block.
 
 #### Scenario: Every verdict run emits exactly one block with a terminal RESULT
 - **WHEN** the wrapper finishes on a verdict path (pass, any failed check, or an empty census)
 - **THEN** it emits exactly one `==== ROBOREV REVIEW SUMMARY ====` block whose last line is `RESULT:` followed by exactly one of `PASS`, `FAIL`, or `NOTHING-TO-REVIEW`
+
+#### Scenario: The block carries every per-check key in the contracted order
+- **WHEN** a review was enqueued and completed
+- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:`
+
+#### Scenario: One scan over the per-check keys computes the verdict
+- **GIVEN** a block in which exactly one per-check key carries a failing value while every other reads `PASS`, `SKIP`, `UNAVAILABLE` or `NOTICE`
+- **WHEN** the terminal verdict is computed
+- **THEN** the run is `RESULT: FAIL` and the failing key names the cause, and a `NOTICE`, `UNAVAILABLE` or `SKIP` value never contributes a failure
 
 #### Scenario: A usage error emits no block and exits with its own distinct code
 - **GIVEN** an invocation supplying `--agent` but not `--model` (or `--model` but not `--agent`)
 - **WHEN** the wrapper runs
 - **THEN** it prints an `ERROR:` line naming the missing option, emits NO `==== ROBOREV REVIEW SUMMARY ====` block and NO `RESULT:` line at all, enqueues nothing, and exits `2` — a code distinct from PASS (`0`), FAIL (`1`), and NOTHING-TO-REVIEW (`3`), so a usage error can never be read as any of the three verdicts
 
-#### Scenario: The block carries the census, the reviewed sha, and the token accounting
-- **WHEN** a review was enqueued and completed
-- **THEN** the block reports the base ref and census (files changed, lines added, lines removed), the head sha and the reviewed sha, the job id, and either the observed input/cached/output token counts or an explicit unavailable marker
+#### Scenario: An unexpected abort still emits a block
+- **GIVEN** a run that dies mid-flight after the review was enqueued, before reaching a verdict
+- **WHEN** the process exits
+- **THEN** it still emits exactly one block with `RESULT: FAIL` and a line reporting the unexpected termination, so a run that died without a verdict never looks like a run that was never made
 
 #### Scenario: The block cannot be confused with an agent-gate summary
 - **WHEN** the block is compared with the agent gate's `AGENT-GATE SUMMARY`, `AGENT-GATE LITE SUMMARY`, and `AGENT-GATE DELTA SUMMARY` blocks
@@ -171,72 +506,59 @@ silently.
 - **WHEN** the terminal `RESULT:` is `FAIL` or `NOTHING-TO-REVIEW`
 - **THEN** the wrapper's process exit code is non-zero
 
-### Requirement: A non-zero exit from the roborev process is a hard failure under its own greppable key
-A non-zero exit status from the underlying `roborev` process SHALL be a hard, fail-closed failure: it
-SHALL force the terminal `RESULT: FAIL` on its own, independently of every other check's outcome, and
-SHALL NEVER be reportable as "roborev clean". Because a caller retains ONLY the summary block and reads
-it by grepping the per-check keys, this failure cause SHALL be surfaced in the block under its OWN
-greppable key `roborev-exit:` — value `PASS` when the process exited zero, otherwise a `FAIL` carrying
-the OBSERVED non-zero exit code — placed with the other per-check keys, ahead of the terminal `RESULT:`.
-It SHALL participate in the same per-check scan that computes the terminal verdict. A prose detail line
-alone SHALL NOT satisfy this requirement: without the key, a reader sees every per-check key reading
-`PASS` beside a `RESULT: FAIL` and cannot attribute the failure, which is the one failure cause a
-grep-based reader would otherwise be unable to name.
+### Requirement: The wrapper fails closed when its own local oracles are unavailable
+The wrapper's local oracles and helpers MAY be split across files for size hygiene, but a MISSING or
+TRUNCATED helper SHALL FAIL CLOSED with a named cause rather than silently reducing a check to a no-op
+— an absent oracles file that turned the push assert and the census into no-ops would be a worse
+failure than any this guard was built to catch. Helper paths SHALL be resolved relative to the
+wrapper's OWN file location, never `$PWD`, because the wrapper is invoked from arbitrary worktrees.
+Likewise, an absent `roborev` binary, an unresolvable HEAD, and any other precondition failure SHALL
+fail closed with a named cause and SHALL NOT report a pass.
 
-#### Scenario: A non-zero roborev exit FAILs the run and names itself under its own key
-- **GIVEN** a pushed branch with a non-empty census whose push, census, sha, and both vacuity checks all pass
-- **WHEN** the `roborev` process itself exits non-zero (for example `1`)
-- **THEN** the block reports `roborev-exit: FAIL` carrying the observed exit code, the terminal `RESULT:` is `FAIL`, the wrapper exits non-zero, and the run is NOT reportable as "roborev clean"
+#### Scenario: A missing or truncated oracles helper fails closed
+- **GIVEN** a checkout in which the sourced oracles helper is missing, and separately one in which it is present but truncated so it does not define both oracle functions
+- **WHEN** the wrapper runs
+- **THEN** both cases exit non-zero with `RESULT: FAIL` and a message naming the helper and stating that the push assert and the census cannot run, and neither reports a pass with those checks silently disabled
 
-#### Scenario: A zero roborev exit records the key as PASS
-- **WHEN** the `roborev` process exits zero
-- **THEN** the block reports `roborev-exit: PASS`, and that key alone never turns any other check's FAIL into a pass
+#### Scenario: An absent roborev binary or an unresolvable HEAD fails closed
+- **GIVEN** a PATH with no `roborev` binary, and separately a repository with no commits
+- **WHEN** the wrapper runs
+- **THEN** each exits non-zero with `RESULT: FAIL` naming the cause (the absent binary; no commit to review), and no review is enqueued
 
-### Requirement: A code-free diff cannot be certified by roborev
-Because roborev structurally discards a code-free diff, a diff consisting only of documentation,
-specification, or workflow text SHALL NOT be certifiable by roborev at all: the wrapper SHALL FAIL such a
-run as vacuous, and no docs-only change SHALL record "roborev clean". The sanctioned substitute SHALL be
-verification against primary sources, recorded in the pull request.
+### Requirement: Every roborev call site and doctrine surface routes through the sanctioned wrapper
+Every roborev invocation documented anywhere in the delivery pipeline's agent surfaces, commands,
+skills and doctrine SHALL be expressed as a call to `scripts/flow/roborev-review.sh`, and the bare
+`--branch` form and the two-positional commit-range form SHALL be documented as NON-SANCTIONED
+everywhere they are mentioned. **The migrated set is SIXTEEN surfaces** — thirteen under `.claude/**`
+plus three non-`.claude` doctrine surfaces — carrying THREE different obligations, because some of them
+contain no roborev invocation at all and an obligation to "invoke the wrapper" would be unsatisfiable
+for those. (Two further surfaces, CLAUDE.md and the published `roborev-findings` page, are covered by
+the doctrine requirement below, for eighteen surfaces referencing the wrapper in total.)
 
-#### Scenario: A markdown-only diff is failed as vacuous, not passed
-- **GIVEN** a pushed branch whose census against the base is 5 files, +167/−63, all markdown
-- **WHEN** the wrapper runs and the correctly-targeted review returns "No issues found" with a summary stating the diff contains no code changes to review
-- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the failure is attributed to the code-free-diff condition rather than reported as a clean review
-
-#### Scenario: The sanctioned substitute for a docs-only change is primary-source verification
-- **GIVEN** a docs-only change that cannot be roborev-certified
-- **WHEN** the change is prepared for merge
-- **THEN** doctrine directs the author to record primary-source verification in the pull request (for example reading the pinned Cassandra source at the `cassandra-5.0.8` tag that the documentation describes) instead of recording "roborev clean"
-
-### Requirement: Every flow-* roborev call site routes through the sanctioned wrapper
-Every roborev invocation documented in the delivery-pipeline skills and agents SHALL be expressed as a
-call to the sanctioned wrapper, and the bare `--branch` form SHALL be documented as non-sanctioned
-everywhere it is mentioned. The affected surfaces fall into TWO classes carrying DIFFERENT obligations,
-because four of them contain no roborev invocation at all and an obligation to "invoke the wrapper"
-would be unsatisfiable for them:
-
-**(a) Invocation sites** — surfaces whose documented procedure runs the wrapper. Each SHALL express its
-roborev step as a call to `scripts/flow/roborev-review.sh`, SHALL pass BOTH the reviewer agent and the
-reviewer model, and SHALL NOT instruct a bare `roborev review --branch` invocation nor the
+**(a) Invocation sites (9)** — surfaces whose documented procedure runs or prescribes the wrapper. Each
+SHALL express its roborev step as a call to `scripts/flow/roborev-review.sh`, SHALL pass BOTH the
+reviewer agent and the reviewer model, and SHALL NOT instruct a bare `roborev review --branch` nor the
 two-positional commit-range form. They subdivide by what the surface itself does:
 
-- **Review-round sites** — they run a review round in-line: `.claude/skills/flow-implement/SKILL.md`
+- **Review-round sites (4)** — they run a review round in-line: `.claude/skills/flow-implement/SKILL.md`
   (review-first, the primary call site), `.claude/agents/flow-closer.md` (the final merge-gating
-  confirmation pass), `.claude/skills/flow-address/SKILL.md` (the post-comment re-review). Each of
-  these SHALL ADDITIONALLY state that the branch is pushed BEFORE the review is requested, and SHALL
-  treat ANY non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` INCLUDED — as a failed review round and a
-  blocked merge, never as "roborev clean".
-- **Prescribing sites** — they name the wrapper as the invocation to be used without running a round
-  in-line: `.claude/agents/flow-lead.md` (the stage table and the roborev doctrine bullet),
+  confirmation pass), `.claude/skills/flow-address/SKILL.md` (the post-comment re-review), and
+  `.claude/commands/worker.md` (the fleet's UNATTENDED entry point, which runs the implement loop's
+  review-first step itself). Each SHALL ADDITIONALLY state that the branch is pushed BEFORE the review
+  is requested, and SHALL treat ANY non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` INCLUDED — as a
+  failed review round and a blocked merge, never as "roborev clean".
+- **Prescribing sites (5)** — they name the wrapper as the invocation to be used without running a
+  round in-line: `.claude/agents/flow-lead.md` (the stage table and the roborev doctrine bullet),
   `.claude/skills/ci-cd-validation/SKILL.md` and `.claude/skills/ci-cd-validation/merge-process.md`
   (the merge-readiness definition), `.claude/skills/flow-activate/SKILL.md` (the roborev step of the
-  `tasks.md` it authors). Each SHALL name the wrapper as the ONLY sanctioned invocation, and any
+  `tasks.md` it authors), and `.claude/commands/manager.md` (which defines what "roborev clean" means
+  for the workers it dispatches). Each SHALL name the wrapper as the ONLY sanctioned invocation, and any
   merge-readiness or finalizability rule it states SHALL require a terminal `RESULT: PASS` and SHALL
   NOT accept `NOTHING-TO-REVIEW` or `FAIL`.
 
-**(b) Non-invoking surfaces** — surfaces that reference roborev (the `roborev-lints` gate component,
-the pre-roborev self-check pointer, the telemetry `--roborev-findings` counter) but contain NO roborev
-invocation: `.claude/skills/flow-finalize/SKILL.md`, `.claude/agents/rust-reviewer.md`,
+**(b) Non-invoking surfaces (4)** — surfaces that reference roborev (the `roborev-lints` gate
+component, the pre-roborev self-check pointer, the telemetry `--roborev-findings` counter) but contain
+NO roborev invocation: `.claude/skills/flow-finalize/SKILL.md`, `.claude/agents/rust-reviewer.md`,
 `.claude/agents/sstable-developer.md`, `.claude/agents/test-validator.md`. Each SHALL state explicitly
 that it never invokes roborev directly, SHALL point at `scripts/flow/roborev-review.sh` as the only
 sanctioned invocation, and SHALL NOT contradict any of the four doctrine rules (wrapper-only; verify
@@ -245,25 +567,44 @@ docs-only diff cannot be roborev-certified). `.claude/agents/rust-reviewer.md` S
 require that a diff reintroducing a bare `roborev review --branch` or the two-positional range form is
 flagged as a **BLOCKER**.
 
-No surface in either class SHALL document a bare `--branch` or two-positional-range roborev invocation
-as sanctioned.
+**(c) Non-`.claude` doctrine surfaces (3)** — the fleet-facing prose that prescribes how roborev is
+run: `website/src/content/docs/agents-developing/delivery-pipeline.md`,
+`docs/development/pm-operating-loop.md`, `docs/development/agent-machine-setup.md`. Each SHALL name the
+wrapper as the only sanctioned invocation with BOTH flags required, SHALL state push-first, and SHALL
+state that any non-PASS terminal `RESULT` (`NOTHING-TO-REVIEW` included) is a failed round and a blocked
+merge. These are NOT optional extras: each previously carried the INVERSE instruction — "roborev follows
+this machine's configured agent … run it with no `--agent`/`--model` flags", with
+`delivery-pipeline.md` calling explicit agent/model "never doctrine" — which directly contradicts the
+amended CLAUDE.md rule, so leaving them unmigrated would leave the fleet's published guidance
+prescribing the very invocation this change forbids.
 
-#### Scenario: Every invocation site calls the wrapper and no surface documents a bare --branch invocation
-- **WHEN** the six class-(a) invocation surfaces are inspected for roborev invocations
-- **THEN** each expresses its roborev step as a `scripts/flow/roborev-review.sh` call passing both the reviewer agent and the reviewer model, none instructs a bare `roborev review --branch` invocation or the two-positional commit-range form, and the bare `--branch` form is explicitly marked non-sanctioned wherever it appears across all ten surfaces
+No surface in any class SHALL document a bare `--branch` or two-positional-range roborev invocation as
+sanctioned. A historical quotation of a superseded command in design/spec prose SHALL be marked as
+historical so it cannot be copied as guidance. (`.claude/hooks/issue-gate.sh` is deliberately NOT in
+this set: it documents that no hook path runs roborev at all (#2671) and contains no invocation to
+migrate.)
+
+#### Scenario: All sixteen migrated surfaces route through the wrapper and none documents a bare --branch invocation
+- **WHEN** the sixteen migrated surfaces — the thirteen under `.claude/**` (`skills/flow-implement`, `agents/flow-closer`, `skills/flow-address`, `commands/worker`, `agents/flow-lead`, `skills/ci-cd-validation/SKILL.md`, `skills/ci-cd-validation/merge-process.md`, `skills/flow-activate`, `commands/manager`, `skills/flow-finalize`, `agents/rust-reviewer`, `agents/sstable-developer`, `agents/test-validator`) plus `website/src/content/docs/agents-developing/delivery-pipeline.md`, `docs/development/pm-operating-loop.md` and `docs/development/agent-machine-setup.md` — are inspected for roborev invocations
+- **THEN** every one of them names `scripts/flow/roborev-review.sh` as the sanctioned invocation, each of the nine class-(a) sites expresses its roborev step as a wrapper call passing both the reviewer agent and the reviewer model, none instructs a bare `roborev review --branch` invocation or the two-positional commit-range form as sanctioned, and the bare `--branch` form is explicitly marked non-sanctioned wherever it appears
 
 #### Scenario: Each review-round site states push-first and treats any non-PASS RESULT as a failed round
-- **WHEN** `.claude/skills/flow-implement/SKILL.md`, `.claude/agents/flow-closer.md`, and `.claude/skills/flow-address/SKILL.md` are inspected
+- **WHEN** `.claude/skills/flow-implement/SKILL.md`, `.claude/agents/flow-closer.md`, `.claude/skills/flow-address/SKILL.md` and `.claude/commands/worker.md` are inspected
 - **THEN** each states that the branch is pushed before the review is requested, and each states that any non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round and a blocked merge rather than "roborev clean"
 
 #### Scenario: Each prescribing site names the wrapper and requires RESULT PASS for readiness
-- **WHEN** `.claude/agents/flow-lead.md`, `.claude/skills/ci-cd-validation/SKILL.md`, `.claude/skills/ci-cd-validation/merge-process.md`, and `.claude/skills/flow-activate/SKILL.md` are inspected
+- **WHEN** `.claude/agents/flow-lead.md`, `.claude/skills/ci-cd-validation/SKILL.md`, `.claude/skills/ci-cd-validation/merge-process.md`, `.claude/skills/flow-activate/SKILL.md` and `.claude/commands/manager.md` are inspected
 - **THEN** each names `scripts/flow/roborev-review.sh` as the only sanctioned invocation with both flags, and every merge-readiness or finalizability rule any of them states requires a terminal `RESULT: PASS` and rejects both `NOTHING-TO-REVIEW` and `FAIL`
 
 #### Scenario: Each non-invoking surface says so and points at the wrapper
 - **GIVEN** the four class-(b) surfaces, whose only roborev references are the `roborev-lints` gate component, the pre-roborev self-check pointer, and the telemetry `--roborev-findings` counter
 - **WHEN** `.claude/skills/flow-finalize/SKILL.md`, `.claude/agents/rust-reviewer.md`, `.claude/agents/sstable-developer.md`, and `.claude/agents/test-validator.md` are inspected
 - **THEN** each states that it never invokes roborev directly, each points at `scripts/flow/roborev-review.sh` as the only sanctioned invocation, none contradicts any of the four doctrine rules, and `.claude/agents/rust-reviewer.md` additionally requires flagging a reintroduced bare `--branch` or two-positional range form as a BLOCKER
+
+#### Scenario: The three non-.claude doctrine surfaces no longer prescribe the inverse rule
+- **GIVEN** that `website/src/content/docs/agents-developing/delivery-pipeline.md`, `docs/development/pm-operating-loop.md` and `docs/development/agent-machine-setup.md` previously instructed running roborev with the machine's configured agent and NO `--agent`/`--model` flags, with one of them calling explicit agent/model "never doctrine"
+- **WHEN** they are inspected after this change
+- **THEN** none of them still carries that instruction, each names the wrapper with both flags required and push-first, and each states that any non-PASS terminal `RESULT` (`NOTHING-TO-REVIEW` included) is a failed round and a blocked merge
 
 #### Scenario: The merge-gating confirmation pass routes through the wrapper
 - **GIVEN** the `flow-closer` agent's final roborev confirmation pass, whose verdict gates arming auto-merge
@@ -274,17 +615,25 @@ as sanctioned.
 - **WHEN** each class-(a) invocation site is inspected
 - **THEN** it passes both the reviewer agent and the reviewer model, preserving the documented trap that supplying only one inherits a mismatched model from the repository roborev config and fails as a silent-looking review outage
 
-### Requirement: Doctrine records the verify-the-reviewed-SHA rule and the hard-fail verdict text
+### Requirement: Doctrine records the four roborev rules
 CLAUDE.md's roborev-invocation guidance and the published `agents-developing/roborev-findings` page
 SHALL both state, in this same change: (a) the wrapper is the only sanctioned roborev invocation;
 (b) the reviewed SHA must be verified against branch HEAD; (c) a "contains no code changes to review"
 verdict on a non-empty diff is a HARD FAIL, never a pass; and (d) a docs-only diff cannot be
-roborev-certified. The published page SHALL be accepted by confirming the NEW CONTENT is served — not by
-an HTTP 200 — because the CDN can serve the previous page for minutes after a successful deploy.
+roborev-certified. Both SHALL also record the wrapper's exit-code contract and that ANY non-PASS
+terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed round and a blocked merge. The
+`roborev-findings` page SHALL additionally carry the new guard in its "mechanized in `--lite`" table,
+since a mechanized class that is not listed there will be hand-checked forever. The published page
+SHALL be accepted by confirming the NEW CONTENT is served — not by an HTTP 200 — because the CDN can
+serve the previous page for minutes after a successful deploy.
 
 #### Scenario: Both doctrine surfaces carry all four rules
 - **WHEN** CLAUDE.md and `website/src/content/docs/agents-developing/roborev-findings.md` are inspected after this change
 - **THEN** both state that the wrapper is the only sanctioned invocation, that the reviewed SHA must be verified against branch HEAD, that a "contains no code changes to review" verdict on a non-empty diff is a HARD FAIL, and that a docs-only diff cannot be roborev-certified
+
+#### Scenario: The mechanized-in-lite table lists the new guard
+- **WHEN** the `roborev-findings` page's table of classes mechanized in `--lite` is inspected
+- **THEN** it carries a row for the vacuous-review class naming the hermetic regression check and the components it runs in
 
 #### Scenario: Publication is accepted by the served content, not a status code
 - **WHEN** the published `agents-developing/roborev-findings` page is verified after deployment
@@ -292,22 +641,40 @@ an HTTP 200 — because the CDN can serve the previous page for minutes after a 
 
 ### Requirement: A hermetic regression check pins every vacuity trigger and is wired into the agent gate
 A regression check SHALL exercise the wrapper hermetically — using a stub `roborev` on `PATH` that
-replays recorded real outputs, with no network and no live reviewer — and SHALL assert that the wrapper:
-(a) FAILs when the enqueued sha equals the base ref; (b) FAILs when the enqueued sha is neither endpoint;
-(c) FAILs on a "contains no code changes to review" verdict against a non-empty census; (d) FAILs on the
-vacuous token signature; (e) FAILs on an unpushed branch; (f) PASSes a genuine review with a matching sha
-and healthy token accounting; and (g) reports `NOTHING-TO-REVIEW` rather than PASS on a genuinely empty
-census. The check SHALL be registered in the agent gate's shell-tooling component set such that it runs
-in the fast `--lite` loop as well as the full gate, so a regression FAILs the fast loop rather than
-costing a review round. The check SHALL contain no wall-clock threshold assertion in its correctness path.
+replays recorded real outputs, with no network, no live reviewer, no dataset corpus and no cargo — and
+SHALL assert that the wrapper:
 
-#### Scenario: All seven trigger cases are asserted
+(a) FAILs when the reviewed sha equals the base ref, naming the base; (b) FAILs when the reviewed sha is
+neither endpoint; (c) FAILs a cleanliness vacuity claim against a non-empty code census, and does NOT
+fail a findings-bearing or out-of-summary mention of the same phrase; (d) FAILs the vacuous token
+signature, and pins the input floor at its exact declared value; (e) FAILs an unpushed branch, a branch
+absent from the remote, a stale-mirror/deleted-remote branch, and an `ls-remote` failure attributed to
+infra/auth — including under the fleet's NARROW fetch refspec, where the branch IS pushed and the
+assert must PASS; (f) PASSes a genuine review with a matching sha and healthy accounting; (g) reports
+`NOTHING-TO-REVIEW` rather than PASS on a genuinely empty census, and FAILs (never
+`NOTHING-TO-REVIEW`) on an unresolvable base or a failed `git diff`; (h) FAILs a code-free census
+deterministically while NOT classifying a workflow YAML or a mixed census as code-free; (i) FAILs when
+the job never completed, when the provider returned a model-mismatch error, and when the job status is
+not `done`; (j) FAILs when the prompt actually sent omits the census's paths, and degrades visibly when
+the prompt is unretrievable; (k) distinguishes `FINDINGS` from `ERROR` on a non-zero reviewer exit;
+(l) evaluates token accounting against the REAL doubly-encoded payload shape, accepts the documented
+field aliases, and FAILs a present-but-unparseable payload as drift; and (m) FAILs closed when its
+oracles helper is missing or truncated.
+
+The check SHALL also pin the block's key ORDER, the distinctness of its header from all three
+agent-gate summary headers, the usage-error path emitting no block, and hermeticity itself. It SHALL be
+registered in the agent gate's shell-tooling component set such that it runs in the fast `--lite` loop
+as well as the full gate, so a regression FAILs the fast loop rather than costing a review round. The
+check SHALL contain no wall-clock threshold assertion in its correctness path, and SHALL report a loud
+SKIP rather than a silent pass when an optional prerequisite for a subset of cases is unavailable.
+
+#### Scenario: Every trigger class is asserted against the block's own keys
 - **WHEN** the regression check runs
-- **THEN** it asserts each of the seven cases (a) through (g) above, each against the wrapper's terminal `RESULT` and exit code
+- **THEN** it asserts each of the classes (a) through (m) above against the wrapper's terminal `RESULT`, its per-check key values and its exit code, and it reports an explicit pass/fail tally so a partial run cannot read as a pass
 
 #### Scenario: The check is hermetic
 - **WHEN** the regression check runs on a machine with no network access and no real roborev binary installed
-- **THEN** it still runs to completion using the stub reviewer and throwaway git fixtures, requiring no dataset corpus, no live reviewer, and no network
+- **THEN** it still runs to completion using the stub reviewer and throwaway git fixtures, requiring no dataset corpus, no cargo, no live reviewer and no network
 
 #### Scenario: A regression fails the fast loop
 - **GIVEN** a change that removes or weakens one of the wrapper's asserts
@@ -322,7 +689,9 @@ costing a review round. The check SHALL contain no wall-clock threshold assertio
 The change SHALL include a documented live probe, runnable against the real roborev binary from inside a
 real issue worktree, that proves a worktree-launched review reviews the WORKTREE's HEAD rather than the
 root checkout's commit. The probe SHALL be documented rather than executed by the gate, because it
-requires network access and a live reviewer.
+requires network access and a live reviewer. Its procedure and expected summary-block values SHALL live
+in the wrapper's own `--help` output (so the two cannot drift apart) and in the doctrine page, and SHALL
+include re-running it after any roborev version bump.
 
 #### Scenario: The probe establishes reviewed-sha equals the worktree HEAD
 - **GIVEN** a real issue worktree, on its own branch, with its implementation commit pushed, while the root checkout sits on `main`
@@ -331,4 +700,4 @@ requires network access and a live reviewer.
 
 #### Scenario: The probe is documented, not gate-run
 - **WHEN** the agent gate's component set is inspected
-- **THEN** the live probe is not among its components, and the probe's procedure and expected summary-block values are recorded in the wrapper's usage documentation and the doctrine page instead
+- **THEN** the live probe is not among its components, and the probe's procedure and expected summary-block values are recorded in the wrapper's `--help` usage documentation and the doctrine page instead

--- a/openspec/changes/roborev-vacuous-review-guard/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-vacuous-review-guard/specs/roborev-review-guard/spec.md
@@ -1,0 +1,249 @@
+# roborev-review-guard — delta for roborev-vacuous-review-guard (issue #2964)
+
+**Acceptance-criterion → requirement map** (issue #2964's numbered ACs):
+
+| AC | Requirement(s) |
+|----|----------------|
+| 1 — an empty resolved diff on a non-empty requested range must fail loudly, never "No issues found" | *A non-empty local diff census with a vacuous review verdict is a hard failure*; *A genuinely empty census reports NOTHING-TO-REVIEW, never a pass*; *The wrapper emits a machine-greppable summary block with a terminal verdict* |
+| 2 — invoke with explicit SHA + explicit `--repo`, and assert the enqueued SHA equals branch HEAD | *The sanctioned invocation is by explicit SHA and explicit repository path*; *The reviewed SHA is asserted against branch HEAD*; *Every flow-\* roborev call site routes through the sanctioned wrapper* |
+| 3 — push the implementation commit before reviewing | *The branch is asserted pushed before any review is requested* |
+| 4 — doctrine updated (CLAUDE.md + the `agents-developing/roborev-findings` page) | *Doctrine records the verify-the-reviewed-SHA rule and the hard-fail verdict text* |
+| 5 — a regression check proves a worktree-launched review reviews the worktree's HEAD | *A hermetic regression check pins every vacuity trigger and is wired into the agent gate*; *A documented live worktree probe proves the worktree's HEAD is what gets reviewed* |
+
+## ADDED Requirements
+
+### Requirement: A non-empty local diff census with a vacuous review verdict is a hard failure
+The sanctioned roborev wrapper SHALL compute a **local diff census** — the files changed and lines
+added/removed for `<base>...HEAD`, obtained from `git` in the target repository — and SHALL treat that
+locally-computed census as the authoritative statement of what must be reviewed. When the census is
+NON-empty, the wrapper SHALL FAIL LOUDLY (non-zero exit and an explicit message) rather than report a
+pass if EITHER of the following holds:
+
+- **Tier 1 (primary, deterministic, threshold-free):** the review output claims there are no code
+  changes to review (e.g. matching `contains no code changes to review` or `no code changes`,
+  case-insensitively).
+- **Tier 2 (corroborating, bounded token accounting):** the job's reported token accounting shows an
+  input token count below the named vacuity input threshold, OR a cached-input count of zero, OR an
+  output token count below the named vacuity output threshold.
+
+Tier 1 SHALL be authoritative: it SHALL NOT be relaxed, overridden, or skipped by tier 2's outcome or
+availability. Tier 2's only permitted effect SHALL be to fail closed — it SHALL NEVER cause a run to
+pass. The tier-2 thresholds SHALL be named constants declared at the top of the wrapper with the
+measured evidence cited in a comment, and every tier-2 failure message SHALL print the observed values
+next to the threshold that tripped. When token accounting is unavailable from the installed roborev
+build, the wrapper SHALL record a degraded-signal notice in its summary block and SHALL still apply
+tier 1 — never a silent skip.
+
+#### Scenario: A "no code changes" verdict against a non-empty census fails loudly
+- **GIVEN** a branch whose local census against the base is non-empty (for example 5 files, +167/−63)
+- **WHEN** the wrapper runs and the review returns "No issues found" with a summary stating the diff contains no code changes to review
+- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, its message names the vacuous-verdict-vs-census contradiction and prints the census, and the run is NOT reportable as "roborev clean"
+
+#### Scenario: The vacuous token signature against a non-empty census fails loudly
+- **GIVEN** a branch whose local census against the base is non-empty
+- **WHEN** the review completes without a "no code changes" phrase, but the job's token accounting reports an input count below the vacuity input threshold, or zero cached input, or an output count below the vacuity output threshold
+- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message prints each observed token value beside the named threshold constant that tripped
+
+#### Scenario: A genuine review with healthy accounting passes
+- **GIVEN** a branch whose local census against the base is non-empty, whose branch is pushed, and whose review enqueued the branch HEAD
+- **WHEN** the review returns a verdict containing no "no code changes" claim and reports token accounting above the thresholds (for example ~500k input, ~387k cached, ~6.3k output)
+- **THEN** the wrapper exits zero with `RESULT: PASS` and every per-check line in the summary block reads PASS
+
+#### Scenario: Unavailable token accounting degrades visibly and tier 1 still governs
+- **GIVEN** a roborev build from which the wrapper cannot obtain token accounting for the job
+- **WHEN** the wrapper evaluates vacuity on a non-empty census
+- **THEN** the summary block records `vacuity-tier2: UNAVAILABLE` as an explicit degraded-signal notice, the tier-1 check is still applied and can still FAIL the run, and the unavailability alone never turns a FAIL into a PASS nor is recorded as a silent skip
+
+### Requirement: A genuinely empty census reports NOTHING-TO-REVIEW, never a pass
+When the local diff census for `<base>...HEAD` is genuinely empty, the wrapper SHALL NOT invoke a review
+and SHALL exit with a DISTINCT `NOTHING-TO-REVIEW` status — a non-zero exit code distinct from the
+failure exit code — that is explicitly NOT a pass. A `NOTHING-TO-REVIEW` outcome SHALL NOT be recordable
+as "roborev clean" by any caller.
+
+#### Scenario: An empty census yields NOTHING-TO-REVIEW rather than PASS
+- **GIVEN** a pushed branch whose diff against the base is genuinely empty (no files changed)
+- **WHEN** the wrapper runs
+- **THEN** it does not enqueue a review, its summary block terminates in `RESULT: NOTHING-TO-REVIEW`, and it exits with a non-zero code distinct from the FAIL exit code
+
+#### Scenario: NOTHING-TO-REVIEW is distinguishable from PASS by exit code alone
+- **WHEN** a caller inspects only the wrapper's exit status
+- **THEN** the PASS, FAIL, and NOTHING-TO-REVIEW outcomes are three distinct exit codes, so a caller can never mistake "there was nothing to review" for "it was reviewed and clean"
+
+### Requirement: The sanctioned invocation is by explicit SHA and explicit repository path
+The wrapper SHALL invoke roborev with an EXPLICIT commit SHA (the branch HEAD) and an EXPLICIT absolute
+repository path, and SHALL NEVER use the bare `--branch` form (which resolves against the root checkout
+from inside a git worktree) nor the two-positional commit-range form (which has been observed to enqueue
+a commit that is neither endpoint). The wrapper SHALL require BOTH the reviewer agent and the reviewer
+model to be supplied, refusing to run with only one of them.
+
+#### Scenario: The invocation names the HEAD sha and an absolute repo path
+- **WHEN** the wrapper invokes roborev
+- **THEN** the command line carries the resolved HEAD sha as an explicit argument and an absolute `--repo` path for the target repository, and carries neither a bare `--branch` argument nor two positional commit arguments
+
+#### Scenario: Supplying only an agent or only a model is a usage error
+- **GIVEN** an invocation that supplies a reviewer agent but no reviewer model (which would inherit a mismatched model from the repository's roborev config and fail as a silent-looking review outage)
+- **WHEN** the wrapper runs
+- **THEN** it refuses with a non-zero exit and a message naming the missing option, before any review is enqueued
+
+### Requirement: The reviewed SHA is asserted against branch HEAD
+The wrapper SHALL parse the enqueued-job announcement (`Enqueued job <N> for <sha>`) and SHALL require
+the announced sha to prefix-match the branch HEAD sha. A mismatch SHALL abort the round with a non-zero
+exit. When the mismatched sha resolves to the base ref (for example `origin/main`), the failure message
+SHALL say so explicitly, because that equality is the signature of the worktree `--branch` resolution
+trigger. An absent or unparseable enqueue announcement SHALL also be a failure, never a skipped check.
+
+#### Scenario: An enqueued sha equal to the base ref aborts and names the base
+- **GIVEN** a worktree branch whose HEAD is `4e7ab591e` and whose base `origin/main` is `39900e4db`
+- **WHEN** the review announces `Enqueued job N for 39900e4db`
+- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message states that the enqueued sha equals the base ref `origin/main` and therefore no branch change was reviewed
+
+#### Scenario: An enqueued sha that is neither endpoint aborts
+- **GIVEN** a branch HEAD of `989d7d2c3` and a base of `89fdbb895`
+- **WHEN** the review announces `Enqueued job N for 90a17d376`, which matches neither the HEAD nor the base
+- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message prints the announced sha beside the expected HEAD sha
+
+#### Scenario: A missing enqueue announcement fails closed
+- **WHEN** the review output contains no parseable `Enqueued job <N> for <sha>` line
+- **THEN** the wrapper exits non-zero with `RESULT: FAIL` because the reviewed sha is unverifiable, and does not report a pass
+
+#### Scenario: A matching enqueued sha satisfies the assert
+- **WHEN** the announced sha prefix-matches the branch HEAD sha
+- **THEN** the summary block records `sha-assert: PASS` with both the head sha and the reviewed sha printed
+
+### Requirement: The branch is asserted pushed before any review is requested
+Before enqueuing a review, the wrapper SHALL assert that the remote tracking ref for the current branch
+(`origin/<branch>`) exists and equals the local HEAD. If it does not, the wrapper SHALL FAIL with a
+non-zero exit and name the unpushed commits, because an unpushed implementation commit is itself a cause
+of an empty resolved diff.
+
+#### Scenario: An unpushed commit fails before a review is enqueued
+- **GIVEN** a branch with one local commit that has not been pushed, so `origin/<branch>` is behind HEAD
+- **WHEN** the wrapper runs
+- **THEN** it exits non-zero with `RESULT: FAIL`, its message names the unpushed commit(s), and no review job is enqueued
+
+#### Scenario: A missing remote branch fails before a review is enqueued
+- **GIVEN** a branch that has never been pushed, so `origin/<branch>` does not exist
+- **WHEN** the wrapper runs
+- **THEN** it exits non-zero with `RESULT: FAIL` naming the missing remote branch, and no review job is enqueued
+
+### Requirement: The wrapper emits a machine-greppable summary block with a terminal verdict
+The wrapper SHALL emit a single compact `==== ROBOREV REVIEW SUMMARY ====` block carrying: the
+repository path, branch, head sha, reviewed sha, job id, base ref, the census (files and lines
+added/removed), the token accounting (or an explicit unavailable marker), a verdict line per check
+performed, and a terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW`. The block's name SHALL be distinct from
+the agent gate's summary block names so neither can be pasted as the other. The wrapper SHALL exit
+non-zero on any outcome other than PASS, and SHALL be usable such that a caller retains ONLY this block
+and never the raw review transcript (which SHALL be written to a log path named in the block).
+
+#### Scenario: Every run emits the block with a terminal RESULT
+- **WHEN** the wrapper finishes for any reason (pass, any failed check, or an empty census)
+- **THEN** it emits exactly one `==== ROBOREV REVIEW SUMMARY ====` block whose last line is `RESULT:` followed by exactly one of `PASS`, `FAIL`, or `NOTHING-TO-REVIEW`
+
+#### Scenario: The block carries the census, the reviewed sha, and the token accounting
+- **WHEN** a review was enqueued and completed
+- **THEN** the block reports the base ref and census (files changed, lines added, lines removed), the head sha and the reviewed sha, the job id, and either the observed input/cached/output token counts or an explicit unavailable marker
+
+#### Scenario: The block cannot be confused with an agent-gate summary
+- **WHEN** the block is compared with the agent gate's `AGENT-GATE SUMMARY`, `AGENT-GATE LITE SUMMARY`, and `AGENT-GATE DELTA SUMMARY` blocks
+- **THEN** its header is distinct from all three, so a roborev summary can never be pasted as a gate verdict nor a gate summary recorded as a review verdict
+
+#### Scenario: A non-PASS outcome exits non-zero
+- **WHEN** the terminal `RESULT:` is `FAIL` or `NOTHING-TO-REVIEW`
+- **THEN** the wrapper's process exit code is non-zero
+
+### Requirement: A code-free diff cannot be certified by roborev
+Because roborev structurally discards a code-free diff, a diff consisting only of documentation,
+specification, or workflow text SHALL NOT be certifiable by roborev at all: the wrapper SHALL FAIL such a
+run as vacuous, and no docs-only change SHALL record "roborev clean". The sanctioned substitute SHALL be
+verification against primary sources, recorded in the pull request.
+
+#### Scenario: A markdown-only diff is failed as vacuous, not passed
+- **GIVEN** a pushed branch whose census against the base is 5 files, +167/−63, all markdown
+- **WHEN** the wrapper runs and the correctly-targeted review returns "No issues found" with a summary stating the diff contains no code changes to review
+- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the failure is attributed to the code-free-diff condition rather than reported as a clean review
+
+#### Scenario: The sanctioned substitute for a docs-only change is primary-source verification
+- **GIVEN** a docs-only change that cannot be roborev-certified
+- **WHEN** the change is prepared for merge
+- **THEN** doctrine directs the author to record primary-source verification in the pull request (for example reading the pinned Cassandra source at the `cassandra-5.0.8` tag that the documentation describes) instead of recording "roborev clean"
+
+### Requirement: Every flow-* roborev call site routes through the sanctioned wrapper
+Every roborev invocation documented in the delivery-pipeline skills and agents SHALL be expressed as a
+call to the sanctioned wrapper, and the bare `--branch` form SHALL be documented as non-sanctioned. This
+covers `.claude/skills/flow-implement`, `.claude/skills/flow-activate`, `.claude/skills/flow-address`,
+`.claude/skills/flow-finalize`, `.claude/skills/ci-cd-validation`, and `.claude/agents/flow-closer`,
+`.claude/agents/flow-lead`, `.claude/agents/rust-reviewer`, `.claude/agents/sstable-developer`,
+`.claude/agents/test-validator`. The requirement that both the reviewer agent and the reviewer model are
+always supplied SHALL be preserved at every call site.
+
+#### Scenario: No agent surface documents a bare --branch invocation
+- **WHEN** the delivery-pipeline skills and agents listed above are inspected for roborev invocations
+- **THEN** each one invokes the sanctioned wrapper, none instructs a bare `roborev review --branch` invocation, and the bare `--branch` form is explicitly marked non-sanctioned
+
+#### Scenario: The merge-gating confirmation pass routes through the wrapper
+- **GIVEN** the `flow-closer` agent's final roborev confirmation pass, whose verdict gates arming auto-merge
+- **WHEN** that step is inspected
+- **THEN** it invokes the sanctioned wrapper and treats a non-PASS terminal `RESULT` (including `NOTHING-TO-REVIEW`) as a blocked merge rather than a clean review
+
+#### Scenario: Both agent and model remain required at every call site
+- **WHEN** each migrated call site is inspected
+- **THEN** it passes both the reviewer agent and the reviewer model, preserving the documented trap that supplying only one inherits a mismatched model from the repository roborev config and fails as a silent-looking review outage
+
+### Requirement: Doctrine records the verify-the-reviewed-SHA rule and the hard-fail verdict text
+CLAUDE.md's roborev-invocation guidance and the published `agents-developing/roborev-findings` page
+SHALL both state, in this same change: (a) the wrapper is the only sanctioned roborev invocation;
+(b) the reviewed SHA must be verified against branch HEAD; (c) a "contains no code changes to review"
+verdict on a non-empty diff is a HARD FAIL, never a pass; and (d) a docs-only diff cannot be
+roborev-certified. The published page SHALL be accepted by confirming the NEW CONTENT is served — not by
+an HTTP 200 — because the CDN can serve the previous page for minutes after a successful deploy.
+
+#### Scenario: Both doctrine surfaces carry all four rules
+- **WHEN** CLAUDE.md and `website/src/content/docs/agents-developing/roborev-findings.md` are inspected after this change
+- **THEN** both state that the wrapper is the only sanctioned invocation, that the reviewed SHA must be verified against branch HEAD, that a "contains no code changes to review" verdict on a non-empty diff is a HARD FAIL, and that a docs-only diff cannot be roborev-certified
+
+#### Scenario: Publication is accepted by the served content, not a status code
+- **WHEN** the published `agents-developing/roborev-findings` page is verified after deployment
+- **THEN** acceptance is established by fetching the page and matching a distinctive phrase introduced by this change, and an HTTP 200 without that phrase is treated as not-yet-published rather than as done
+
+### Requirement: A hermetic regression check pins every vacuity trigger and is wired into the agent gate
+A regression check SHALL exercise the wrapper hermetically — using a stub `roborev` on `PATH` that
+replays recorded real outputs, with no network and no live reviewer — and SHALL assert that the wrapper:
+(a) FAILs when the enqueued sha equals the base ref; (b) FAILs when the enqueued sha is neither endpoint;
+(c) FAILs on a "contains no code changes to review" verdict against a non-empty census; (d) FAILs on the
+vacuous token signature; (e) FAILs on an unpushed branch; (f) PASSes a genuine review with a matching sha
+and healthy token accounting; and (g) reports `NOTHING-TO-REVIEW` rather than PASS on a genuinely empty
+census. The check SHALL be registered in the agent gate's shell-tooling component set such that it runs
+in the fast `--lite` loop as well as the full gate, so a regression FAILs the fast loop rather than
+costing a review round. The check SHALL contain no wall-clock threshold assertion in its correctness path.
+
+#### Scenario: All seven trigger cases are asserted
+- **WHEN** the regression check runs
+- **THEN** it asserts each of the seven cases (a) through (g) above, each against the wrapper's terminal `RESULT` and exit code
+
+#### Scenario: The check is hermetic
+- **WHEN** the regression check runs on a machine with no network access and no real roborev binary installed
+- **THEN** it still runs to completion using the stub reviewer and throwaway git fixtures, requiring no dataset corpus, no live reviewer, and no network
+
+#### Scenario: A regression fails the fast loop
+- **GIVEN** a change that removes or weakens one of the wrapper's asserts
+- **WHEN** `scripts/agent-gate.sh --lite` runs
+- **THEN** the component that hosts the regression check FAILs, so the fast loop catches the regression rather than a later review round
+
+#### Scenario: The check also runs in the full gate
+- **WHEN** the full `scripts/agent-gate.sh` runs
+- **THEN** the regression check executes as part of the shell-tooling component set and a failure FAILs that component and the run
+
+### Requirement: A documented live worktree probe proves the worktree's HEAD is what gets reviewed
+The change SHALL include a documented live probe, runnable against the real roborev binary from inside a
+real issue worktree, that proves a worktree-launched review reviews the WORKTREE's HEAD rather than the
+root checkout's commit. The probe SHALL be documented rather than executed by the gate, because it
+requires network access and a live reviewer.
+
+#### Scenario: The probe establishes reviewed-sha equals the worktree HEAD
+- **GIVEN** a real issue worktree, on its own branch, with its implementation commit pushed, while the root checkout sits on `main`
+- **WHEN** the documented probe runs the wrapper from inside that worktree
+- **THEN** the summary block's reviewed sha equals the worktree branch's HEAD sha and does NOT equal the base ref, demonstrating the explicit-repo invocation defeats the root-checkout resolution trigger
+
+#### Scenario: The probe is documented, not gate-run
+- **WHEN** the agent gate's component set is inspected
+- **THEN** the live probe is not among its components, and the probe's procedure and expected summary-block values are recorded in the wrapper's usage documentation and the doctrine page instead

--- a/openspec/changes/roborev-vacuous-review-guard/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-vacuous-review-guard/specs/roborev-review-guard/spec.md
@@ -4,7 +4,7 @@
 
 | AC | Requirement(s) |
 |----|----------------|
-| 1 — an empty resolved diff on a non-empty requested range must fail loudly, never "No issues found" | *A non-empty local diff census with a vacuous review verdict is a hard failure*; *A genuinely empty census reports NOTHING-TO-REVIEW, never a pass*; *The wrapper emits a machine-greppable summary block with a terminal verdict* |
+| 1 — an empty resolved diff on a non-empty requested range must fail loudly, never "No issues found" | *A non-empty local diff census with a vacuous review verdict is a hard failure*; *A genuinely empty census reports NOTHING-TO-REVIEW, never a pass*; *The wrapper emits a machine-greppable summary block with a terminal verdict*; *A non-zero exit from the roborev process is a hard failure under its own greppable key* |
 | 2 — invoke with explicit SHA + explicit `--repo`, and assert the enqueued SHA equals branch HEAD | *The sanctioned invocation is by explicit SHA and explicit repository path*; *The reviewed SHA is asserted against branch HEAD*; *Every flow-\* roborev call site routes through the sanctioned wrapper* |
 | 3 — push the implementation commit before reviewing | *The branch is asserted pushed before any review is requested* |
 | 4 — doctrine updated (CLAUDE.md + the `agents-developing/roborev-findings` page) | *Doctrine records the verify-the-reviewed-SHA rule and the hard-fail verdict text* |
@@ -127,17 +127,37 @@ of an empty resolved diff.
 - **THEN** it exits non-zero with `RESULT: FAIL` naming the missing remote branch, and no review job is enqueued
 
 ### Requirement: The wrapper emits a machine-greppable summary block with a terminal verdict
-The wrapper SHALL emit a single compact `==== ROBOREV REVIEW SUMMARY ====` block carrying: the
-repository path, branch, head sha, reviewed sha, job id, base ref, the census (files and lines
-added/removed), the token accounting (or an explicit unavailable marker), a verdict line per check
-performed, and a terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW`. The block's name SHALL be distinct from
-the agent gate's summary block names so neither can be pasted as the other. The wrapper SHALL exit
-non-zero on any outcome other than PASS, and SHALL be usable such that a caller retains ONLY this block
-and never the raw review transcript (which SHALL be written to a log path named in the block).
+The wrapper SHALL emit a single compact `==== ROBOREV REVIEW SUMMARY ====` block on every **VERDICT**
+exit path — a pass, any failed check, or an empty census — carrying one field per line under the
+greppable keys `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `job:`, `census:`, `tokens:`,
+`push-assert:`, `census-check:`, `sha-assert:`, `vacuity-tier1:`, `vacuity-tier2:`, `log:`, and a
+terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW`. A per-check key whose step was never reached SHALL carry
+an explicit `SKIP` rather than a blank, so an unreached check can never read as a pass. The block's name
+SHALL be distinct from the agent gate's summary block names so neither can be pasted as the other. The
+wrapper SHALL exit non-zero on any outcome other than PASS, and SHALL be usable such that a caller
+retains ONLY this block and never the raw review transcript (which SHALL be written to the log path
+named in the block's `log:` field).
 
-#### Scenario: Every run emits the block with a terminal RESULT
-- **WHEN** the wrapper finishes for any reason (pass, any failed check, or an empty census)
+A **USAGE ERROR is NOT a verdict.** When a required option is missing or invalid (notably `--agent`
+without `--model`, or the reverse), the wrapper SHALL emit **NO summary block at all**: it SHALL print a
+loud `ERROR:` line naming the missing or invalid option and SHALL exit with the dedicated usage code
+`2`, before any repository identity is resolved and before anything is enqueued. This omission is
+DELIBERATE and SHALL NOT be "fixed" by emitting a block: the three `RESULT:` values are reserved for the
+three real outcomes, so a `RESULT:` line for a run that never happened would ALIAS a usage error onto a
+genuine verdict — precisely the indistinguishability this capability exists to eliminate. The `--help`
+path (exit `0`) is likewise not a verdict and SHALL emit no block. The "exactly one block" obligation
+therefore scopes to the three verdict paths; the verdict paths SHALL be exhaustive for them, including
+an unexpected mid-run abort, which SHALL emit the block with `RESULT: FAIL` rather than terminate
+silently.
+
+#### Scenario: Every verdict run emits exactly one block with a terminal RESULT
+- **WHEN** the wrapper finishes on a verdict path (pass, any failed check, or an empty census)
 - **THEN** it emits exactly one `==== ROBOREV REVIEW SUMMARY ====` block whose last line is `RESULT:` followed by exactly one of `PASS`, `FAIL`, or `NOTHING-TO-REVIEW`
+
+#### Scenario: A usage error emits no block and exits with its own distinct code
+- **GIVEN** an invocation supplying `--agent` but not `--model` (or `--model` but not `--agent`)
+- **WHEN** the wrapper runs
+- **THEN** it prints an `ERROR:` line naming the missing option, emits NO `==== ROBOREV REVIEW SUMMARY ====` block and NO `RESULT:` line at all, enqueues nothing, and exits `2` — a code distinct from PASS (`0`), FAIL (`1`), and NOTHING-TO-REVIEW (`3`), so a usage error can never be read as any of the three verdicts
 
 #### Scenario: The block carries the census, the reviewed sha, and the token accounting
 - **WHEN** a review was enqueued and completed
@@ -150,6 +170,27 @@ and never the raw review transcript (which SHALL be written to a log path named 
 #### Scenario: A non-PASS outcome exits non-zero
 - **WHEN** the terminal `RESULT:` is `FAIL` or `NOTHING-TO-REVIEW`
 - **THEN** the wrapper's process exit code is non-zero
+
+### Requirement: A non-zero exit from the roborev process is a hard failure under its own greppable key
+A non-zero exit status from the underlying `roborev` process SHALL be a hard, fail-closed failure: it
+SHALL force the terminal `RESULT: FAIL` on its own, independently of every other check's outcome, and
+SHALL NEVER be reportable as "roborev clean". Because a caller retains ONLY the summary block and reads
+it by grepping the per-check keys, this failure cause SHALL be surfaced in the block under its OWN
+greppable key `roborev-exit:` — value `PASS` when the process exited zero, otherwise a `FAIL` carrying
+the OBSERVED non-zero exit code — placed with the other per-check keys, ahead of the terminal `RESULT:`.
+It SHALL participate in the same per-check scan that computes the terminal verdict. A prose detail line
+alone SHALL NOT satisfy this requirement: without the key, a reader sees every per-check key reading
+`PASS` beside a `RESULT: FAIL` and cannot attribute the failure, which is the one failure cause a
+grep-based reader would otherwise be unable to name.
+
+#### Scenario: A non-zero roborev exit FAILs the run and names itself under its own key
+- **GIVEN** a pushed branch with a non-empty census whose push, census, sha, and both vacuity checks all pass
+- **WHEN** the `roborev` process itself exits non-zero (for example `1`)
+- **THEN** the block reports `roborev-exit: FAIL` carrying the observed exit code, the terminal `RESULT:` is `FAIL`, the wrapper exits non-zero, and the run is NOT reportable as "roborev clean"
+
+#### Scenario: A zero roborev exit records the key as PASS
+- **WHEN** the `roborev` process exits zero
+- **THEN** the block reports `roborev-exit: PASS`, and that key alone never turns any other check's FAIL into a pass
 
 ### Requirement: A code-free diff cannot be certified by roborev
 Because roborev structurally discards a code-free diff, a diff consisting only of documentation,
@@ -169,24 +210,68 @@ verification against primary sources, recorded in the pull request.
 
 ### Requirement: Every flow-* roborev call site routes through the sanctioned wrapper
 Every roborev invocation documented in the delivery-pipeline skills and agents SHALL be expressed as a
-call to the sanctioned wrapper, and the bare `--branch` form SHALL be documented as non-sanctioned. This
-covers `.claude/skills/flow-implement`, `.claude/skills/flow-activate`, `.claude/skills/flow-address`,
-`.claude/skills/flow-finalize`, `.claude/skills/ci-cd-validation`, and `.claude/agents/flow-closer`,
-`.claude/agents/flow-lead`, `.claude/agents/rust-reviewer`, `.claude/agents/sstable-developer`,
-`.claude/agents/test-validator`. The requirement that both the reviewer agent and the reviewer model are
-always supplied SHALL be preserved at every call site.
+call to the sanctioned wrapper, and the bare `--branch` form SHALL be documented as non-sanctioned
+everywhere it is mentioned. The affected surfaces fall into TWO classes carrying DIFFERENT obligations,
+because four of them contain no roborev invocation at all and an obligation to "invoke the wrapper"
+would be unsatisfiable for them:
 
-#### Scenario: No agent surface documents a bare --branch invocation
-- **WHEN** the delivery-pipeline skills and agents listed above are inspected for roborev invocations
-- **THEN** each one invokes the sanctioned wrapper, none instructs a bare `roborev review --branch` invocation, and the bare `--branch` form is explicitly marked non-sanctioned
+**(a) Invocation sites** — surfaces whose documented procedure runs the wrapper. Each SHALL express its
+roborev step as a call to `scripts/flow/roborev-review.sh`, SHALL pass BOTH the reviewer agent and the
+reviewer model, and SHALL NOT instruct a bare `roborev review --branch` invocation nor the
+two-positional commit-range form. They subdivide by what the surface itself does:
+
+- **Review-round sites** — they run a review round in-line: `.claude/skills/flow-implement/SKILL.md`
+  (review-first, the primary call site), `.claude/agents/flow-closer.md` (the final merge-gating
+  confirmation pass), `.claude/skills/flow-address/SKILL.md` (the post-comment re-review). Each of
+  these SHALL ADDITIONALLY state that the branch is pushed BEFORE the review is requested, and SHALL
+  treat ANY non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` INCLUDED — as a failed review round and a
+  blocked merge, never as "roborev clean".
+- **Prescribing sites** — they name the wrapper as the invocation to be used without running a round
+  in-line: `.claude/agents/flow-lead.md` (the stage table and the roborev doctrine bullet),
+  `.claude/skills/ci-cd-validation/SKILL.md` and `.claude/skills/ci-cd-validation/merge-process.md`
+  (the merge-readiness definition), `.claude/skills/flow-activate/SKILL.md` (the roborev step of the
+  `tasks.md` it authors). Each SHALL name the wrapper as the ONLY sanctioned invocation, and any
+  merge-readiness or finalizability rule it states SHALL require a terminal `RESULT: PASS` and SHALL
+  NOT accept `NOTHING-TO-REVIEW` or `FAIL`.
+
+**(b) Non-invoking surfaces** — surfaces that reference roborev (the `roborev-lints` gate component,
+the pre-roborev self-check pointer, the telemetry `--roborev-findings` counter) but contain NO roborev
+invocation: `.claude/skills/flow-finalize/SKILL.md`, `.claude/agents/rust-reviewer.md`,
+`.claude/agents/sstable-developer.md`, `.claude/agents/test-validator.md`. Each SHALL state explicitly
+that it never invokes roborev directly, SHALL point at `scripts/flow/roborev-review.sh` as the only
+sanctioned invocation, and SHALL NOT contradict any of the four doctrine rules (wrapper-only; verify
+the reviewed SHA; a "contains no code changes to review" verdict on a non-empty diff is a HARD FAIL; a
+docs-only diff cannot be roborev-certified). `.claude/agents/rust-reviewer.md` SHALL ADDITIONALLY
+require that a diff reintroducing a bare `roborev review --branch` or the two-positional range form is
+flagged as a **BLOCKER**.
+
+No surface in either class SHALL document a bare `--branch` or two-positional-range roborev invocation
+as sanctioned.
+
+#### Scenario: Every invocation site calls the wrapper and no surface documents a bare --branch invocation
+- **WHEN** the six class-(a) invocation surfaces are inspected for roborev invocations
+- **THEN** each expresses its roborev step as a `scripts/flow/roborev-review.sh` call passing both the reviewer agent and the reviewer model, none instructs a bare `roborev review --branch` invocation or the two-positional commit-range form, and the bare `--branch` form is explicitly marked non-sanctioned wherever it appears across all ten surfaces
+
+#### Scenario: Each review-round site states push-first and treats any non-PASS RESULT as a failed round
+- **WHEN** `.claude/skills/flow-implement/SKILL.md`, `.claude/agents/flow-closer.md`, and `.claude/skills/flow-address/SKILL.md` are inspected
+- **THEN** each states that the branch is pushed before the review is requested, and each states that any non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round and a blocked merge rather than "roborev clean"
+
+#### Scenario: Each prescribing site names the wrapper and requires RESULT PASS for readiness
+- **WHEN** `.claude/agents/flow-lead.md`, `.claude/skills/ci-cd-validation/SKILL.md`, `.claude/skills/ci-cd-validation/merge-process.md`, and `.claude/skills/flow-activate/SKILL.md` are inspected
+- **THEN** each names `scripts/flow/roborev-review.sh` as the only sanctioned invocation with both flags, and every merge-readiness or finalizability rule any of them states requires a terminal `RESULT: PASS` and rejects both `NOTHING-TO-REVIEW` and `FAIL`
+
+#### Scenario: Each non-invoking surface says so and points at the wrapper
+- **GIVEN** the four class-(b) surfaces, whose only roborev references are the `roborev-lints` gate component, the pre-roborev self-check pointer, and the telemetry `--roborev-findings` counter
+- **WHEN** `.claude/skills/flow-finalize/SKILL.md`, `.claude/agents/rust-reviewer.md`, `.claude/agents/sstable-developer.md`, and `.claude/agents/test-validator.md` are inspected
+- **THEN** each states that it never invokes roborev directly, each points at `scripts/flow/roborev-review.sh` as the only sanctioned invocation, none contradicts any of the four doctrine rules, and `.claude/agents/rust-reviewer.md` additionally requires flagging a reintroduced bare `--branch` or two-positional range form as a BLOCKER
 
 #### Scenario: The merge-gating confirmation pass routes through the wrapper
 - **GIVEN** the `flow-closer` agent's final roborev confirmation pass, whose verdict gates arming auto-merge
 - **WHEN** that step is inspected
 - **THEN** it invokes the sanctioned wrapper and treats a non-PASS terminal `RESULT` (including `NOTHING-TO-REVIEW`) as a blocked merge rather than a clean review
 
-#### Scenario: Both agent and model remain required at every call site
-- **WHEN** each migrated call site is inspected
+#### Scenario: Both agent and model remain required at every invocation site
+- **WHEN** each class-(a) invocation site is inspected
 - **THEN** it passes both the reviewer agent and the reviewer model, preserving the documented trap that supplying only one inherits a mismatched model from the repository roborev config and fails as a silent-looking review outage
 
 ### Requirement: Doctrine records the verify-the-reviewed-SHA rule and the hard-fail verdict text

--- a/openspec/changes/roborev-vacuous-review-guard/specs/roborev-review-guard/spec.md
+++ b/openspec/changes/roborev-vacuous-review-guard/specs/roborev-review-guard/spec.md
@@ -13,11 +13,36 @@ absence of a bad phrase.
 
 | AC | Requirement(s) |
 |----|----------------|
-| 1 — an empty resolved diff on a non-empty requested range must fail loudly, never "No issues found" | *A PASS requires positive evidence that a review completed*; *The locally computed diff census is the authoritative oracle*; *The reviewer must demonstrably have received the census's own files*; *A code-free census is a deterministic failure before any review is enqueued*; *A vacuous verdict claim against a non-empty census fails, gated on the findings state*; *Token accounting corroborates the deterministic checks and may only fail closed*; *A genuinely empty census reports NOTHING-TO-REVIEW, never a pass*; *A findings-bearing review is distinguished from a reviewer error, both under their own greppable keys*; *The wrapper emits a machine-greppable summary block with a terminal verdict* |
-| 2 — invoke with explicit SHA + explicit `--repo`, and assert the enqueued SHA equals branch HEAD | *The sanctioned invocation is by explicit SHA and explicit repository path*; *The reviewed SHA is asserted against branch HEAD using the job record as the oracle*; *A model substitution is surfaced, never silent*; *Every roborev call site and doctrine surface routes through the sanctioned wrapper* |
+| 1 — an empty resolved diff on a non-empty requested range must fail loudly, never "No issues found" | *A PASS requires positive evidence that a review completed*; *The locally computed diff census is the authoritative oracle*; *The reviewer must demonstrably have received the census's own code files*; *A code-free census is a deterministic failure before any review is enqueued*; *A vacuous verdict claim against a non-empty census fails, gated on the findings state*; *Token accounting corroborates the deterministic checks and may only fail closed*; *A genuinely empty census reports NOTHING-TO-REVIEW, never a pass*; *A findings-bearing review is distinguished from a reviewer error, both under their own greppable keys*; *The wrapper emits a machine-greppable summary block with a terminal verdict* |
+| 2 — invoke with explicit SHA + explicit `--repo`, and assert the enqueued SHA equals branch HEAD | **Implemented to the AC's INTENT, NOT its letter — see the note below**: *The sanctioned invocation reviews the census RANGE with an explicit repository path*; *The reviewed RANGE is asserted against the census range using the job record as the oracle*; *The job record is read from whichever source answers, and its completeness is reported*; *A model substitution is surfaced, never silent*; *Every roborev call site and doctrine surface routes through the sanctioned wrapper* |
 | 3 — push the implementation commit before reviewing | *The branch is asserted pushed by asking the REMOTE, never a local mirror ref* |
-| 4 — doctrine updated (CLAUDE.md + the `agents-developing/roborev-findings` page) | *Doctrine records the four roborev rules*; *Every roborev call site and doctrine surface routes through the sanctioned wrapper* |
-| 5 — a regression check proves a worktree-launched review reviews the worktree's HEAD | *A hermetic regression check pins every vacuity trigger and is wired into the agent gate*; *The wrapper fails closed when its own local oracles are unavailable*; *A documented live worktree probe proves the worktree's HEAD is what gets reviewed* |
+| 4 — doctrine updated (CLAUDE.md + the `agents-developing/roborev-findings` page) | *Doctrine records the roborev rules, including the measured invocation matrix*; *Every roborev call site and doctrine surface routes through the sanctioned wrapper* |
+| 5 — a regression check proves a worktree-launched review reviews the worktree's HEAD | *A hermetic regression check pins every vacuity trigger and is wired into the agent gate*; *The wrapper fails closed when any of its own sourced helpers is unavailable*; *A documented live worktree probe proves the worktree's HEAD is what gets reviewed* |
+
+**AC2 divergence, recorded openly (do not read past this).** AC2 literally prescribes
+`roborev review <sha> --repo <abs-worktree> …` — a SINGLE-SHA invocation. An empirical matrix against the
+real daemon (a 17-commit branch whose census was 27 files: 22 markdown + 5 code), measuring both the
+enqueued `git_ref` and which files appear as `diff --git` headers in the prompt actually sent, showed that
+form is **PARTIAL**:
+
+| form | enqueued `git_ref` | code files in the prompt |
+|---|---|---|
+| `--branch --base <base> --repo <abs>` | `<base40>..<head40>` | **5/5 — SANCTIONED** |
+| `--since <base> --repo <abs>` | `<base40>..<head40>` | 5/5 (byte-identical prompt) |
+| `<base> <head>` (two positionals) | `4b825dc6…` (git's EMPTY-TREE hash) `..<head40>` | 3/5 — BROKEN |
+| `<sha>` (single commit) | `<head40>` | 3/5 — PARTIAL, one commit only |
+
+So the single-SHA form reviews **ONE COMMIT**, not the branch: on any multi-commit branch — i.e. every
+branch this pipeline ships — it certifies the branch from its last commit alone. That is a **FOURTH
+vacuity class** (a partial review reported as a complete one) which the issue did not anticipate, and
+which AC2's letter would have institutionalised. The requirements below therefore implement AC2's
+**intent** — *the reviewed content must match the requested range, verified against the job record* — via
+the measured-correct `--branch --base <base> --repo <abs>` form, and the wrapper FAILS a single-commit
+record even when it equals HEAD. Two further consequences of the same matrix: `--repo` is what makes
+`--branch` correct from a worktree (so the non-sanctioned form is `--branch` **WITHOUT** an explicit
+`--repo`, not `--branch` as such), and roborev **excludes non-code paths** from the diff it builds (all 22
+markdown files were absent from the prompt; only the 5 code files appeared), which is the empirical
+mechanism behind the code-free trigger.
 
 ## ADDED Requirements
 
@@ -28,9 +53,13 @@ SHALL NEVER be treated as evidence that a review happened. The positive evidence
 
 - the job record's structured `status` field, which SHALL NOT be a value other than `done` — a status
   present and not `done` is `FAIL (job status '<s>' is not done)`; and
-- a **terminal verdict marker** in the transcript, drawn from a declared ALLOW-LIST: a severity-tagged
-  findings marker, or the clean shape (a "no issues found" statement AND a `Summary:` line). No marker
-  ⇒ `FAIL (no terminal verdict marker)`.
+- a **terminal verdict marker** in the transcript, drawn from a declared ALLOW-LIST **built from the REAL
+  measured transcript**, not from invented shapes: a Findings heading (`## Review Findings`), a
+  `**Severity**:` line, a Summary heading or label, or the bracketed/`Medium:` severity shapes other
+  agents emit. No marker ⇒ `FAIL (no terminal verdict marker)`. The allow-list SHALL be measured because
+  an invented one REJECTED a GENUINE codex review — the false-FAIL direction that gets a guard bypassed —
+  and it SHALL remain a closed allow-list because everything that is NOT a review (a still-waiting job, a
+  provider 400, a failed job) matches none of these shapes.
 
 An unreadable transcript SHALL be `FAIL (transcript unreadable)`. When the structured `status` is
 UNAVAILABLE the check MAY still pass on the transcript marker alone, and SHALL then record a NOTICE
@@ -67,7 +96,14 @@ made against that census and never against the reviewer's own report of what it 
 be reported under `census:` and its own verdict under `census-check:`.
 
 Rename detection SHALL be disabled, so every census entry is a REAL path (a rename-composite path such
-as `dir/{old => new}.rs` is not a path and could never be located in the reviewer's prompt).
+as `dir/{old => new}.rs` is not a path and could never be located in the reviewer's prompt). The
+consequence — a rename counts as TWO census paths while the reviewer's diff may render it as ONE two-sided
+header — SHALL be reconciled in `prompt-content:`, never by re-enabling rename detection here.
+
+The census SHALL be partitioned into a CODE subset and a non-code subset by the classification below.
+`census:` SHALL report the TOTAL (`<N> file(s), +<A>/-<D>`, covering both subsets, since that is what
+changed), while `code-free:` is decided by the non-code count equalling the total and `prompt-content:` is
+asserted over the CODE subset alone.
 
 An unmeasurable census SHALL fail closed and SHALL be DISTINGUISHABLE from an empty one:
 `FAIL (base '<ref>' unresolvable)` when the base ref does not resolve to a commit, and
@@ -89,35 +125,67 @@ review". The wrapper SHALL NOT fetch on the caller's behalf to repair an unresol
 - **WHEN** the census is non-empty
 - **THEN** `census:` reports the file count and the added/removed line totals, and the code-free, prompt-content and vacuity checks all state their verdicts relative to that census rather than to anything the reviewer reports
 
-### Requirement: The reviewer must demonstrably have received the census's own files
-The wrapper SHALL assert, under its own greppable key `prompt-content:`, that the census's own changed
-file paths appear in the prompt ACTUALLY SENT to the reviewer, retrieved from the job record (the
-structured `prompt` field, else the reviewer's own prompt-retrieval command). This check SHALL be
-DETERMINISTIC and THRESHOLD-FREE: it catches "the reviewer never received the diff", the half of the
-defect space that a verdict-text comparison cannot see.
+### Requirement: The reviewer must demonstrably have received the census's own code files
+The wrapper SHALL assert, under its own greppable key `prompt-content:`, that the **CODE subset** of the
+census's changed file paths appears in the prompt ACTUALLY SENT to the reviewer, retrieved from the job
+record (the structured `prompt` field, else the reviewer's own prompt-retrieval command). This check
+SHALL be DETERMINISTIC and THRESHOLD-FREE: it catches "the reviewer never received the diff", the half of
+the defect space that a verdict-text comparison cannot see.
 
-Any checked path missing from the prompt SHALL be a `FAIL (<k>/<n> census paths absent from the
-prompt)` that names the missing paths. The number of paths checked MAY be bounded by a named constant
-for a large census, in which case the checked subset SHALL be evenly sampled across the census and ALL
-sampled paths SHALL be required present; the PASS value SHALL report the coverage it actually checked.
+**The code subset — not every census path — is what SHALL be required present**, because roborev
+EXCLUDES non-code paths from the diff it builds (measured: on a census of 22 markdown + 5 code files the
+prompt carried `diff --git` headers for exactly the 5 code files). Requiring all 27 would false-FAIL
+every branch that touches documentation, which is most of them.
 
-A prompt that cannot be RETRIEVED (empty or whitespace-only) SHALL be `UNAVAILABLE` — a visible
-degraded signal, never a FAIL and never a silent skip — because a roborev build that does not expose
-the prompt would otherwise false-FAIL every run. An `UNAVAILABLE` SHALL never turn a FAIL into a PASS.
+**EVERY code path SHALL be checked** — there SHALL be NO sampling cap. A sampled subset was a hole: a
+partial prompt naming just the sampled files passed. Matching SHALL be against the prompt's actual
+`diff --git` HEADER paths, never a bare substring (a substring is satisfied by any incidental mention,
+including this wrapper quoting a path in its own comments), and the header path set SHALL be collected
+from **BOTH sides** of each header and compared WHOLE-LINE: the census runs `--no-renames` (a rename is
+two paths) while the reviewer's diff may have rename detection ON (one `a/old b/new` header), so
+same-path-only matching FALSELY REJECTED every review containing a detected rename. Collecting both sides
+reconciles the two rename behaviours WITHOUT weakening exact-header strictness to a substring test.
 
-#### Scenario: A prompt that does not mention the census's files is a hard failure
+The value set SHALL be exactly:
+
+- `PASS (<n>/<n> code census paths present)` — every code path found;
+- `FAIL (<k>/<n> code census paths absent from the prompt)` — `<k>` MISSING of `<n>` checked, naming the
+  missing paths (first ten). Note the two values carry the SAME denominator `<n>` but OPPOSITE numerator
+  senses (present on PASS, absent on FAIL), so a grep-based reader SHALL read the value word, never the
+  ratio alone;
+- `FAIL (prompt unretrievable — no evidence any diff was delivered)`;
+- `SKIP` — the step was never reached.
+
+**An unretrievable (empty or whitespace-only) prompt SHALL FAIL.** There SHALL be no non-failing
+`UNAVAILABLE` value for this key: with a NON-EMPTY code census an unretrievable prompt means there is NO
+authoritative evidence the reviewer received any diff, and a PASS resting on that contradicts this
+capability's entire purpose. It is also not an always-red risk — the prompt is measurably retrievable
+from the job record's `prompt` field AND from the reviewer's `show <job> --prompt` command, so an empty
+one is a real anomaly.
+
+#### Scenario: A prompt that does not mention the census's code files is a hard failure
 - **GIVEN** a pushed branch with a non-empty code census whose review returns a clean verdict with healthy token accounting
-- **WHEN** the prompt actually sent to the reviewer mentions none of the census's file paths
-- **THEN** `prompt-content:` reads `FAIL (<k>/<n> census paths absent from the prompt)`, the message names the missing paths and states that a prompt that does not mention the census's files cannot have reviewed them, and the terminal `RESULT:` is `FAIL`
+- **WHEN** the prompt actually sent to the reviewer mentions none of the census's code file paths
+- **THEN** `prompt-content:` reads `FAIL (<k>/<n> code census paths absent from the prompt)`, the message names the missing paths and states that a prompt that does not mention the census's files cannot have reviewed them, and the terminal `RESULT:` is `FAIL`
 
-#### Scenario: An unretrievable prompt degrades visibly instead of failing or skipping
-- **GIVEN** a roborev build from which the prompt for the job cannot be retrieved
+#### Scenario: An unretrievable prompt FAILS rather than passing on no evidence
+- **GIVEN** a job for which the prompt cannot be retrieved from either the job record's `prompt` field or the reviewer's prompt-retrieval command, while the code census is non-empty
 - **WHEN** the wrapper evaluates prompt content
-- **THEN** `prompt-content:` reads `UNAVAILABLE`, a NOTICE records the retrieval attempts and states that the deterministic checks still govern, and the run's verdict is decided by the other checks
+- **THEN** `prompt-content:` reads `FAIL (prompt unretrievable — no evidence any diff was delivered)`, the message names both retrieval attempts and the number of code files that went unverified, and the terminal `RESULT:` is `FAIL`
 
-#### Scenario: A prompt carrying the census's files passes and reports its coverage
-- **WHEN** every checked census path appears in the prompt
-- **THEN** `prompt-content:` reads `PASS` and names how many census paths it checked, so a reader can see the coverage rather than trusting a bare PASS
+#### Scenario: A prompt carrying the census's code files passes and reports its coverage
+- **WHEN** every code census path appears on either side of a `diff --git` header in the prompt
+- **THEN** `prompt-content:` reads `PASS (<n>/<n> code census paths present)`, so a reader can see the coverage rather than trusting a bare PASS
+
+#### Scenario: A detected rename in the reviewer's diff is not a false rejection
+- **GIVEN** a census computed with `--no-renames` that lists a rename as two paths (`main.rs` deleted, `renamed.rs` added), and a prompt whose diff has rename detection ON and carries the single header `diff --git a/main.rs b/renamed.rs`
+- **WHEN** the wrapper evaluates prompt content
+- **THEN** both census paths count as covered, `prompt-content:` reads `PASS (2/2 code census paths present)`, and the exact-header match is NOT weakened to a substring test to achieve it
+
+#### Scenario: Every code path is checked, with no sampling cap
+- **GIVEN** a census with many code paths
+- **WHEN** the wrapper evaluates prompt content
+- **THEN** it requires EVERY code census path to be present, so a prompt naming only a sampled subset cannot pass
 
 ### Requirement: A code-free census is a deterministic failure before any review is enqueued
 Because roborev structurally discards a code-free diff, a census consisting ENTIRELY of
@@ -125,6 +193,13 @@ documentation/specification prose SHALL be a DETERMINISTIC FAIL under its own gr
 `code-free:`, evaluated from the wrapper's OWN census classification **before any review is enqueued**,
 with no reviewer prose involved. No docs-only change SHALL record "roborev clean", and the sanctioned
 substitute SHALL be verification against primary sources recorded in the pull request.
+
+The MECHANISM is measured, not inferred: **roborev EXCLUDES non-code paths from the diff it constructs**
+(on a 27-file census — 22 markdown + 5 code — the prompt carried headers for exactly the 5 code files).
+So for a markdown-only diff the constructed diff is genuinely EMPTY, and the reviewer's "contains no code
+changes to review" is a TRUTHFUL report of an empty input rather than a reviewer malfunction. That is
+precisely why the correct response is a DETERMINISTIC pre-enqueue FAIL computed from our own census — the
+reviewer is not misbehaving and no amount of re-running or re-prompting will change the outcome.
 
 Classification SHALL be by file EXTENSION against a declared prose-extension set, with a path assist
 limited to EXTENSIONLESS files under declared prose directories. A file with a code-ish extension
@@ -161,14 +236,22 @@ greppable key `vacuity-tier1:`, and a vacuity claim there SHALL be AUTHORITATIVE
 blocks the merge, not a note. Two properties SHALL bound the match so it cannot false-FAIL a genuine
 review:
 
-1. **ANCHORING.** The match SHALL be confined to the verdict/summary region of the transcript (the
-   lines carrying a `Summary:`), never to arbitrary finding bodies or quoted text. A transcript with no
-   such region SHALL read `UNAVAILABLE`.
+1. **ANCHORING TO THE WHOLE SUMMARY BLOCK.** The match SHALL be confined to the verdict/summary region,
+   and that region SHALL be the whole summary **BLOCK** — from a `Summary` HEADING (`## Summary`) or a
+   `Summary:` label ANYWHERE on a line, through to the next heading or EOF — never merely the lines that
+   themselves CONTAIN `Summary:`. This is a REQUIRED strengthening, not a stylistic detail: the real
+   reviewer format is a heading followed by blank line and prose, so a line-only region missed the prose
+   entirely and a vacuous clean review whose "no code changes" sentence sat UNDER the heading reported
+   **PASS** — the exact defect this capability exists to stop. The block form is a strict SUPERSET of the
+   line form, so the older single-line `No issues found. Summary: …` shape stays covered. A transcript
+   with no such region SHALL read `UNAVAILABLE` (a non-failing degraded value; the deterministic checks
+   still govern, and this tier can never rescue another key's FAIL).
 2. **GATING ON the findings state** (the `findings:` key below):
    - `findings: NONE` — the reviewer is CLAIMING CLEANLINESS, so the phrase is a vacuity claim about a
      census we measured as non-empty ⇒ `FAIL (vacuous verdict vs non-empty census)`.
    - `findings: UNKNOWN` — the state is unknowable ⇒ HARD FAIL as well. An unknowable findings state
-     SHALL NEVER DISARM this check; fail-closed is the correct direction.
+     SHALL NEVER DISARM this check; fail-closed is the correct direction. `INCONSISTENT` (below) is
+     likewise neither `PRESENT` nor `NONE` and SHALL NOT exempt this check.
    - `findings: PRESENT` (with or without a count) — the reviewer demonstrably analysed the diff and
      produced findings, so the phrase is discussion ⇒ an advisory
      `NOTICE (phrase present in a findings-bearing review)` that does NOT fail the run.
@@ -197,6 +280,11 @@ FAIL is agents learning to WAIVE tier-1 FAILs — which restores the original de
 - **GIVEN** a clean review whose finding bodies or quoted material mention "no code changes" while its own summary does not
 - **WHEN** the wrapper evaluates tier 1
 - **THEN** `vacuity-tier1:` reads `PASS`, because an unanchored match would false-FAIL a genuine review and teach agents to waive the check
+
+#### Scenario: A vacuity claim under a `## Summary` HEADING is caught
+- **GIVEN** a clean review reporting no findings whose transcript carries `## Summary` followed by a blank line and then the sentence claiming the diff contains no code changes to review, against a non-empty code census
+- **WHEN** the wrapper evaluates tier 1
+- **THEN** `vacuity-tier1:` reads `FAIL (vacuous verdict vs non-empty census)` and the terminal `RESULT:` is `FAIL` — a region restricted to lines containing `Summary:` would have reported PASS on exactly this transcript
 
 ### Requirement: Token accounting corroborates the deterministic checks and may only fail closed
 Token accounting SHALL be a CORROBORATING signal under `vacuity-tier2:` whose only permitted effect is
@@ -280,18 +368,37 @@ as "roborev clean" by any caller.
 - **WHEN** a caller inspects only the wrapper's exit status
 - **THEN** the PASS, FAIL, and NOTHING-TO-REVIEW outcomes are three distinct exit codes, so a caller can never mistake "there was nothing to review" for "it was reviewed and clean"
 
-### Requirement: The sanctioned invocation is by explicit SHA and explicit repository path
-The wrapper SHALL invoke roborev with an EXPLICIT commit SHA (the branch HEAD) and an EXPLICIT absolute
-repository path, and SHALL NEVER use the bare `--branch` form (which resolves against the root checkout
-from inside a git worktree) nor the two-positional commit-range form (which has been observed to enqueue
-a commit that is neither endpoint). The wrapper SHALL require BOTH the reviewer agent and the reviewer
-model to be supplied, refusing to run with only one of them. An option supplied with an EMPTY value
-SHALL be a usage error rather than a silent fallback to the default, because a `--repo ""` falling back
-to `$PWD` is exactly how a caller reviews a repository it did not name.
+### Requirement: The sanctioned invocation reviews the census RANGE with an explicit repository path
+The wrapper SHALL invoke roborev over the **CENSUS RANGE** with an **EXPLICIT ABSOLUTE `--repo`**, i.e.
+`roborev review --branch --base <base> --repo <abs> --agent <a> --model <m> --wait`, which was MEASURED to
+enqueue `git_ref = <base40>..<head40>` and to deliver every code file of the census to the reviewer (5/5
+in the matrix at the top of this delta). The reviewed scope SHALL therefore be exactly what the census
+measured — the property AC2 was reaching for.
 
-#### Scenario: The invocation names the HEAD sha and an absolute repo path
+Three forms SHALL NEVER be used, each for a MEASURED reason:
+
+- **`--branch` WITHOUT an explicit `--repo`** — from an unregistered worktree it resolves against the ROOT
+  checkout, which normally sits on the base branch. `--repo` is what makes `--branch` correct from a
+  worktree, so the prohibition is on the MISSING `--repo`, NOT on `--branch` itself.
+- **the two-positional commit-range form** (`<base> <head>`) — measured to anchor the range at git's
+  EMPTY-TREE hash (`4b825dc6…`) and to deliver only 3/5 code files.
+- **a single-SHA review** (`<sha>`) — measured to enqueue `git_ref = <head40>` and deliver 3/5 code files:
+  it reviews ONE COMMIT, so on any multi-commit branch it certifies the branch from its last commit alone.
+
+The wrapper SHALL require BOTH the reviewer agent and the reviewer model to be supplied, refusing to run
+with only one of them. An option supplied with an EMPTY value SHALL be a usage error rather than a silent
+fallback to the default, because a `--repo ""` falling back to `$PWD` is exactly how a caller reviews a
+repository it did not name. `--repo` SHALL be resolved to an ABSOLUTE path (roborev must never receive a
+relative one) and SHALL always be passed explicitly — the wrapper SHALL never let roborev infer the
+repository from `$PWD`, because that inference IS the original defect.
+
+#### Scenario: The invocation names the census range and an absolute repo path
 - **WHEN** the wrapper invokes roborev
-- **THEN** the command line carries the resolved HEAD sha as an explicit argument and an absolute `--repo` path for the target repository, and carries neither a bare `--branch` argument nor two positional commit arguments
+- **THEN** the command line is `review --branch --base <base> --repo <abs-repo> --agent <a> --model <m> --wait` — `--branch` PAIRED with an explicit absolute `--repo`, and carrying neither two positional commit arguments nor a single positional sha
+
+#### Scenario: The three non-sanctioned forms are never emitted
+- **WHEN** the wrapper's invocation is inspected
+- **THEN** it never invokes `--branch` without an explicit `--repo`, never passes two positional commits (whose range base was measured to be git's empty-tree hash), and never passes a single positional sha (which reviews one commit only)
 
 #### Scenario: Supplying only an agent or only a model is a usage error
 - **GIVEN** an invocation that supplies a reviewer agent but no reviewer model (which would inherit a mismatched model from the repository's roborev config and fail as a silent-looking review outage)
@@ -303,49 +410,130 @@ to `$PWD` is exactly how a caller reviews a repository it did not name.
 - **WHEN** the wrapper parses its arguments
 - **THEN** it refuses with the usage exit code and a message stating that an empty value is never a default, and nothing is enqueued
 
-### Requirement: The reviewed SHA is asserted against branch HEAD using the job record as the oracle
-The wrapper SHALL assert the reviewed sha against branch HEAD under the greppable key `sha-assert:`,
-using the **job record's structured `git_ref`** as the oracle — a full-length sha recorded by roborev
-itself, compared full-sha to full-sha. Parsing the tool's stdout announcement is the WEAKER source and
-SHALL be DEMOTED to a cross-check: a disagreement between the announcement and the structured field
-SHALL be recorded as a NOTICE (the structured field winning), and the structured field being
-unavailable SHALL fall back to a prefix comparison against the announced sha with a NOTICE naming the
-fallback as the weaker source.
+### Requirement: The reviewed RANGE is asserted against the census range using the job record as the oracle
+The wrapper SHALL assert the reviewed scope under the greppable key `sha-assert:`, using the **job
+record's structured `git_ref`** as the oracle — recorded by roborev itself, compared full-sha to full-sha,
+case-normalised. Because the sanctioned invocation reviews a RANGE, `git_ref` is normally
+`<base40>..<head40>` and **BOTH ENDPOINTS SHALL be asserted** against the census range (`reviewed-sha:`
+SHALL report that range verbatim). This is strictly STRONGER than the single-sha equality it replaces: it
+proves the reviewed scope neither stops short of the branch tip nor starts somewhere other than the
+census base.
 
-The announcement SHALL nevertheless remain load-bearing enough to fail closed, because it carries the
-job id every structured query needs: an ABSENT announcement SHALL be `FAIL (no parseable enqueue
-announcement)` and a malformed one (a non-numeric job id, or a sha shorter than the declared hex-length
-floor) SHALL be `FAIL (unparseable enqueue announcement)` — never a skipped check. Parsing SHALL be
-defensive: case-normalised before matching, both fields validated before use, and when several
-announcements are present the LAST one SHALL be the effective enqueue with the multiplicity recorded.
+The value set SHALL be:
 
-A mismatch SHALL be `FAIL (reviewed-sha does not match head-sha)` and SHALL be ATTRIBUTED: when the
-reviewed sha equals the base ref the message SHALL say so explicitly (the signature of the worktree
-bare-`--branch` resolution trigger), and when it matches neither endpoint the message SHALL name that
-as the signature of the two-positional commit-range form.
+- `PASS` — range head == branch HEAD AND range base == the resolved base sha.
+- `FAIL (reviewed range does not match <base>...HEAD)` — either endpoint disagrees, with the message
+  naming WHICH: a range BASE of git's empty-tree hash SHALL be named as the signature of the
+  non-sanctioned two-positional form, and a range HEAD short of branch HEAD SHALL be named as a reviewed
+  scope that stops short of the tip.
+- `FAIL (single-commit record, not the census range)` — the record reports a SINGLE commit **even when it
+  EQUALS branch HEAD**. This SHALL fail closed: a single-commit review covers one commit, and because
+  `prompt-content` matches PATHS, a review of only the last of several commits touching the same file
+  passes every path check while the earlier changes go unreviewed. The sanctioned invocation always
+  records a range, so a single sha means something else ran.
+- `FAIL (reviewed-sha does not match head-sha)` — a single-commit record that is not branch HEAD;
+  attributed when it equals the base ref (the signature of `--branch` resolved against the ROOT checkout)
+  and otherwise named as matching neither endpoint.
+- `FAIL (job record unavailable — reviewed range unverifiable)` — no `git_ref` after the bounded read.
+  This SHALL FAIL rather than fall back to prose: for a RANGE review the stdout announcement names only
+  the range BASE, so it cannot establish that branch HEAD was reviewed at all, and a fallback to it would
+  be a check that verifies nothing.
+- `FAIL (no parseable enqueue announcement)` / `FAIL (unparseable enqueue announcement)` /
+  `FAIL (roborev not on PATH)` / `SKIP`.
 
-#### Scenario: The structured git_ref wins over a disagreeing stdout announcement
-- **GIVEN** a run whose stdout announces the branch HEAD while the job record's `git_ref` records the base ref as reviewed
-- **WHEN** the wrapper asserts the reviewed sha
-- **THEN** `sha-assert:` FAILs against the structured `git_ref`, the message states the reviewed sha equals the base ref and names the worktree resolution trigger, and the disagreement between the two surfaces is recorded as a NOTICE
+The stdout announcement SHALL be DEMOTED to the **carrier of the job id** — it SHALL NOT be an oracle for
+the reviewed scope — while remaining load-bearing enough to fail closed, because every structured query
+needs that id: an ABSENT announcement SHALL be `FAIL (no parseable enqueue announcement)` and a malformed
+one (a non-numeric job id, or a sha shorter than the declared 7-hex-char floor) SHALL be
+`FAIL (unparseable enqueue announcement)` — never a skipped check. Parsing SHALL be defensive:
+case-normalised before matching, both fields validated before use, and when several announcements are
+present the LAST one SHALL be the effective enqueue with the multiplicity recorded as a NOTICE.
+
+#### Scenario: A matching range satisfies the assert
+- **WHEN** the job record's `git_ref` is `<base40>..<head40>` whose head equals branch HEAD and whose base equals the resolved base sha
+- **THEN** `sha-assert:` reads `PASS` and `reviewed-sha:` reports the full `<base40>..<head40>` range beside `head-sha:`
+
+#### Scenario: A range whose endpoints do not match the census range fails closed
+- **GIVEN** a job record whose reviewed range disagrees with the census range at either endpoint
+- **WHEN** the wrapper asserts the reviewed range
+- **THEN** `sha-assert:` reads `FAIL (reviewed range does not match <base>...HEAD)`, the message names the offending endpoint(s) and the expected values, an empty-tree range base is named as the two-positional-form signature, and the terminal `RESULT:` is `FAIL`
+
+#### Scenario: A single-commit record is refused even when it equals branch HEAD
+- **GIVEN** a job record whose `git_ref` is a single sha equal to branch HEAD
+- **WHEN** the wrapper asserts the reviewed range
+- **THEN** `sha-assert:` reads `FAIL (single-commit record, not the census range)` and the message explains that a single-commit review covers one commit only, so path-based checks cannot see the earlier commits' changes
 
 #### Scenario: A reviewed sha equal to the base ref aborts and names the base
 - **GIVEN** a worktree branch whose HEAD differs from its base `origin/main`
-- **WHEN** the reviewed sha equals the base ref
-- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message states that the reviewed sha equals the base ref and therefore no branch change was reviewed
+- **WHEN** the job record reports the base ref as the reviewed commit
+- **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message states that the reviewed sha equals the base ref, that NO branch change was reviewed, and that base-equality is the signature of a `--branch` review resolved against the ROOT checkout
 
-#### Scenario: A reviewed sha that is neither endpoint aborts
-- **GIVEN** a branch HEAD and a base that both differ from the reviewed sha
-- **WHEN** the wrapper asserts the reviewed sha
-- **THEN** it exits non-zero with `RESULT: FAIL`, and the message prints the reviewed sha beside the expected HEAD sha and names the two-positional range form as the signature
+#### Scenario: An unavailable job record fails closed rather than falling back to the announcement
+- **GIVEN** a job whose record still carries no `git_ref` after the bounded read
+- **WHEN** the wrapper asserts the reviewed range
+- **THEN** `sha-assert:` reads `FAIL (job record unavailable — reviewed range unverifiable)`, the message states that the announcement names only the range BASE and therefore cannot establish that branch HEAD was reviewed, and the run does not report a pass
 
 #### Scenario: A missing or malformed enqueue announcement fails closed
-- **WHEN** the transcript contains no parseable enqueue announcement, or one whose job id is non-numeric or whose sha is shorter than the declared hex floor
-- **THEN** `sha-assert:` reads `FAIL (no parseable enqueue announcement)` or `FAIL (unparseable enqueue announcement)` respectively, the reviewed sha is treated as unverifiable, and the run does not report a pass
+- **WHEN** the transcript contains no parseable enqueue announcement, or one whose job id is non-numeric or whose sha is shorter than the declared 7-hex-char floor
+- **THEN** `sha-assert:` reads `FAIL (no parseable enqueue announcement)` or `FAIL (unparseable enqueue announcement)` respectively, the reviewed scope is treated as unverifiable, and the run does not report a pass
 
-#### Scenario: A matching reviewed sha satisfies the assert
-- **WHEN** the job record's `git_ref` equals the branch HEAD sha (or, on fallback, the announced abbreviated sha prefix-matches it)
-- **THEN** `sha-assert:` reads `PASS` with both the head sha and the reviewed sha printed in the block
+#### Scenario: The announcement carries only the job id, and its multiplicity is recorded
+- **GIVEN** a transcript carrying two enqueue announcements, the last naming job `4656`
+- **WHEN** the wrapper parses it
+- **THEN** `job:` reads `4656`, a NOTICE records that two announcements were present and that the last is the effective enqueue, and the announced sha is used for no scope judgement
+
+### Requirement: The job record is read from whichever source answers, and its completeness is reported
+Four asserts (`sha-assert`, `review-completed`, `findings`, `vacuity-tier2`) and the `model:` line depend
+on the structured job record, so the wrapper SHALL read it explicitly and SHALL report what it got under
+its own greppable key `job-record:`, with the value set:
+
+- `PASS` — the required fields (`git_ref`, a terminal `status`) AND token accounting are all present.
+- `PASS (no token accounting in the record)` — the required fields are present while token accounting is
+  absent. Token accounting SHALL be DESIRABLE, not required: a build may legitimately report none, and
+  spending the whole bound waiting for it would cost the bound on every such run, so it SHALL get one
+  grace poll and then be accepted.
+- `DEGRADED (incomplete after <n>s: <missing fields>)` — the record could not be completed. This value
+  SHALL be NON-FAILING **and** SHALL NOT silently weaken anything: each dependent assert SHALL publish its
+  own verdict under its own key (notably `sha-assert: FAIL (job record unavailable — reviewed range
+  unverifiable)`), so the consequence is always visible where it applies.
+- `SKIP` — no parseable announcement, so there was no job id to query.
+
+**TWO SOURCES OF DIFFERENT SHAPE SHALL both be consulted, and a source SHALL count only when it yields
+the fields the asserts require.** Measured: `roborev show <job> --json` returns the **REVIEW** row, which
+answers to the same id and carries `prompt`/`agent` but NO `git_ref`, `status` or `token_usage`, and
+NESTS the JOB row under a `job` key; `roborev list --json` returns the JOB row directly. Accepting the
+first payload that merely PARSED therefore returned the poorer row, and the record looked permanently
+incomplete. The extractor SHALL prefer an id match that actually carries `git_ref` (so the nested job row
+is a first-class source), falling back to the first id match only when none does, and a payload with no id
+echoed back SHALL be accepted ONLY when it is a single top-level object — for a list or a nested
+collection the first object carrying `git_ref` may be an UNRELATED or EARLIER job, which would falsely
+certify the job just enqueued.
+
+With the nested job row read as a first-class source the record is **complete in ONE read**. The bounded
+poll (5 attempts at 1s) is therefore a **SANITY RETRY, not a wait for asynchronous durability** — an
+earlier diagnosis of an async write was a MISDIAGNOSIS of the wrong-row read, and SHALL NOT be restated as
+the reason. Its two knobs SHALL be overridable for test timing only, and shortening them SHALL only ever
+be able to make the record MORE likely to read `DEGRADED` — the fail-closed direction.
+
+#### Scenario: A complete record reads PASS
+- **GIVEN** a job whose record carries `git_ref`, a terminal `status` and readable token accounting
+- **WHEN** the wrapper reads the record
+- **THEN** `job-record:` reads `PASS` and the dependent asserts evaluate against the structured fields
+
+#### Scenario: The nested job row is used rather than the outer review row
+- **GIVEN** a `show --json` payload whose top-level REVIEW row answers to the job id but carries none of the required fields, while the JOB row nested under its `job` key carries all of them
+- **WHEN** the wrapper reads the record
+- **THEN** `job-record:` reads `PASS` — the id match that actually carries `git_ref` wins, so a record that is in fact complete is never reported as incomplete
+
+#### Scenario: An unreadable record is DEGRADED, and every dependent assert says so itself
+- **GIVEN** a job whose record never yields `git_ref` or `status`
+- **WHEN** the wrapper finishes the bounded read
+- **THEN** `job-record:` reads `DEGRADED (incomplete after <n>s: …)` naming the missing fields, that value alone does not fail the run, and `sha-assert:` independently reads `FAIL (job record unavailable — reviewed range unverifiable)` so the run still cannot pass
+
+#### Scenario: A record without token accounting still passes, explicitly
+- **GIVEN** a job whose record carries the required fields but no token accounting at all
+- **WHEN** the wrapper reads the record
+- **THEN** `job-record:` reads `PASS (no token accounting in the record)` and `vacuity-tier2:` separately reports its own `UNAVAILABLE` degraded-signal notice
 
 ### Requirement: A model substitution is surfaced, never silent
 The wrapper SHALL report the model the job actually ran under the greppable key `model:`, and SHALL
@@ -412,10 +600,26 @@ descendant of the remote tip). Every one of these SHALL happen BEFORE a review i
 
 ### Requirement: A findings-bearing review is distinguished from a reviewer error, both under their own greppable keys
 The wrapper SHALL report the findings state under its own greppable key `findings:` (`NONE`,
-`PRESENT`, `PRESENT (<n>)`, `UNKNOWN`, or `SKIP`) and the reviewer process's own status under
+`PRESENT`, `PRESENT (<n>)`, `UNKNOWN`, `INCONSISTENT (verdict clean, <n> findings marker(s))`,
+`INCONSISTENT (exit 0, <n> findings marker(s))`, or `SKIP`) and the reviewer process's own status under
 `roborev-exit:`, and SHALL DISTINGUISH the two non-zero causes: `FINDINGS (exit <N>)` when the review
 RAN and reported findings, versus `ERROR (exit <N>)` when the reviewer itself failed. The authority for
 which occurred SHALL be the job record's structured `status`, falling back to the completion evidence.
+
+**The PRESENT/NONE decision SHALL be derived from the STRUCTURED `verdict` field**, not from prose over the
+whole transcript. Tier 1 is GATED on this answer, so a regex over the entire output was a real weakness:
+an incidental or QUOTED severity token such as `[Low]` anywhere in the output set `findings: PRESENT`,
+which then EXEMPTED a genuinely vacuous "no code changes" verdict from tier 1's hard failure. Where no
+structured verdict exists the wrapper SHALL fall back to the reviewer's EXIT CODE, and prose SHALL be
+consulted only inside the FINDINGS BLOCK (from a `Findings` heading/label to a LINE-INITIAL `Summary`
+heading/label). The `<n>` COUNT SHALL remain BEST-EFFORT prose parsing of severity markers within that
+block and SHALL be reported for a human, never used as an authority; the PRESENT/NONE/INCONSISTENT
+distinction is the load-bearing part.
+
+**A CONTRADICTION SHALL FAIL.** A structured verdict of "clean" (or, absent one, a zero exit) while the
+findings block DOES carry severity markers SHALL be `INCONSISTENT (verdict clean, <n> findings marker(s))`
+or `INCONSISTENT (exit 0, <n> findings marker(s))` respectively. Both SHALL fail the run, and being
+NEITHER `PRESENT` nor `NONE` neither of them SHALL exempt tier 1 either.
 
 Both cause the terminal `RESULT: FAIL` — a review with open findings is not "roborev clean" — but the
 attribution SHALL be correct, because roborev exits NON-ZERO WHEN IT REPORTS FINDINGS, and calling that
@@ -444,6 +648,21 @@ reading `PASS` beside a `RESULT: FAIL` and cannot attribute the failure.
 - **WHEN** the reviewer process exits zero
 - **THEN** `roborev-exit:` reads `PASS`, `findings:` reads `NONE` (or `PRESENT (<n>)` when severity markers are present), and that key alone never turns any other check's FAIL into a pass
 
+#### Scenario: A clean verdict beside findings markers is INCONSISTENT and fails
+- **GIVEN** a job whose structured `verdict` says the review was clean while its findings block carries one severity marker
+- **WHEN** the wrapper evaluates the findings state
+- **THEN** `findings:` reads `INCONSISTENT (verdict clean, 1 findings marker(s))`, the terminal `RESULT:` is `FAIL`, the message states that one of the two must be wrong, and the value does not exempt tier 1
+
+#### Scenario: A zero exit beside findings markers, with no structured verdict, is INCONSISTENT
+- **GIVEN** a reviewer that exited 0 while the findings block carries a severity marker, and a job record with no structured verdict to arbitrate
+- **WHEN** the wrapper evaluates the findings state
+- **THEN** `findings:` reads `INCONSISTENT (exit 0, 1 findings marker(s))` and the terminal `RESULT:` is `FAIL`
+
+#### Scenario: A quoted severity token outside the findings block does not manufacture PRESENT
+- **GIVEN** a transcript that mentions a severity token in prose outside the findings block
+- **WHEN** the wrapper derives the findings state
+- **THEN** the state comes from the structured verdict (or the exit code), the out-of-block mention does not set `PRESENT`, and it therefore cannot exempt a vacuity claim from tier 1
+
 #### Scenario: A pre-invocation failure leaves the reviewer's status SKIPped, not passed
 - **GIVEN** a run that fails its push assert or census before the reviewer process is started
 - **WHEN** the wrapper emits its block
@@ -454,11 +673,16 @@ The wrapper SHALL emit a single compact `==== ROBOREV REVIEW SUMMARY ====` block
 exit path — a pass, any failed check, or an empty census — carrying one field per line, in a FIXED
 order that is part of the contract, under the greppable keys: `repo:`, `branch:`, `base:`, `head-sha:`,
 `reviewed-sha:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`,
-`sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`,
-`roborev-exit:`, `log:`, and a terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW`.
+`job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`,
+`findings:`, `roborev-exit:`, `log:`, and a terminal `RESULT: PASS|FAIL|NOTHING-TO-REVIEW`.
+`reviewed-sha:` SHALL carry the reviewed RANGE `<base40>..<head40>` on a normal run (a single sha only
+when the record reports one, and `-` when it is unverifiable), so a reader SHALL NOT expect a bare sha
+there.
 
-Every per-check key SHALL participate in ONE verdict scan in which a value beginning `FAIL`, `FINDINGS`
-or `ERROR` fails the run, and `PASS`, `SKIP`, `UNAVAILABLE` and `NOTICE` never do. A per-check key whose
+Every per-check key SHALL participate in ONE verdict scan in which a value beginning `FAIL`, `FINDINGS`,
+`ERROR` or `INCONSISTENT` fails the run, and `PASS*`, `SKIP`, `UNAVAILABLE`, `NOTICE*` and `DEGRADED*`
+never do. `DEGRADED` is non-failing BY DESIGN and only ever appears on `job-record:`, whose consequences
+are published by the dependent asserts under their own keys. A per-check key whose
 step was never reached SHALL carry an explicit `SKIP` rather than a blank, so an unreached check can
 never read as a pass. The block's name SHALL be distinct from the agent gate's summary block names so
 neither can be pasted as the other. The wrapper SHALL exit non-zero on any outcome other than PASS, and
@@ -481,12 +705,16 @@ path (exit `0`) is likewise not a verdict and SHALL emit no block.
 
 #### Scenario: The block carries every per-check key in the contracted order
 - **WHEN** a review was enqueued and completed
-- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:`
+- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:`
 
 #### Scenario: One scan over the per-check keys computes the verdict
-- **GIVEN** a block in which exactly one per-check key carries a failing value while every other reads `PASS`, `SKIP`, `UNAVAILABLE` or `NOTICE`
+- **GIVEN** a block in which exactly one per-check key carries a value beginning `FAIL`, `FINDINGS`, `ERROR` or `INCONSISTENT` while every other reads `PASS*`, `SKIP`, `UNAVAILABLE`, `NOTICE*` or `DEGRADED*`
 - **WHEN** the terminal verdict is computed
-- **THEN** the run is `RESULT: FAIL` and the failing key names the cause, and a `NOTICE`, `UNAVAILABLE` or `SKIP` value never contributes a failure
+- **THEN** the run is `RESULT: FAIL` and the failing key names the cause, and a `NOTICE`, `DEGRADED`, `UNAVAILABLE` or `SKIP` value never contributes a failure
+
+#### Scenario: The reviewed scope is reported as a range
+- **WHEN** a normal run's block is read
+- **THEN** `reviewed-sha:` carries `<base40>..<head40>` rather than a bare sha, so any consumer comparing it for equality with `head-sha:` SHALL compare the range's HEAD endpoint instead
 
 #### Scenario: A usage error emits no block and exits with its own distinct code
 - **GIVEN** an invocation supplying `--agent` but not `--model` (or `--model` but not `--agent`)
@@ -506,19 +734,31 @@ path (exit `0`) is likewise not a verdict and SHALL emit no block.
 - **WHEN** the terminal `RESULT:` is `FAIL` or `NOTHING-TO-REVIEW`
 - **THEN** the wrapper's process exit code is non-zero
 
-### Requirement: The wrapper fails closed when its own local oracles are unavailable
-The wrapper's local oracles and helpers MAY be split across files for size hygiene, but a MISSING or
-TRUNCATED helper SHALL FAIL CLOSED with a named cause rather than silently reducing a check to a no-op
-— an absent oracles file that turned the push assert and the census into no-ops would be a worse
-failure than any this guard was built to catch. Helper paths SHALL be resolved relative to the
-wrapper's OWN file location, never `$PWD`, because the wrapper is invoked from arbitrary worktrees.
-Likewise, an absent `roborev` binary, an unresolvable HEAD, and any other precondition failure SHALL
-fail closed with a named cause and SHALL NOT report a pass.
+### Requirement: The wrapper fails closed when any of its own sourced helpers is unavailable
+The implementation SHALL be **FIVE files** — the wrapper, TWO sourced shell helpers (the local oracles:
+push assert + census/code-free; and the per-review checks: review-completed, prompt-content, findings,
+both vacuity tiers), a python job-facts extractor, and the hermetic regression check — and for **BOTH**
+sourced helpers a MISSING or TRUNCATED file SHALL FAIL CLOSED with a named cause rather than silently
+reducing its checks to no-ops. An absent helper would leave every key it owns reading `SKIP`/`PASS` beside
+a `RESULT: PASS`, which is a worse failure than any this guard was built to catch: the completeness test
+SHALL therefore be that each REQUIRED FUNCTION the file must define is actually defined, not merely that
+the file exists.
+
+**Both helpers SHALL be validated BEFORE the review is invoked**, so a broken installation costs no review
+(the checks helper's functions are only CALLED later, once the job facts exist). Helper paths SHALL be
+resolved relative to the wrapper's OWN file location, never `$PWD`, because the wrapper is invoked from
+arbitrary worktrees. Likewise, an absent `roborev` binary, an unresolvable HEAD, and any other precondition
+failure SHALL fail closed with a named cause and SHALL NOT report a pass.
 
 #### Scenario: A missing or truncated oracles helper fails closed
 - **GIVEN** a checkout in which the sourced oracles helper is missing, and separately one in which it is present but truncated so it does not define both oracle functions
 - **WHEN** the wrapper runs
 - **THEN** both cases exit non-zero with `RESULT: FAIL` and a message naming the helper and stating that the push assert and the census cannot run, and neither reports a pass with those checks silently disabled
+
+#### Scenario: A missing or truncated checks helper fails closed before any review is enqueued
+- **GIVEN** a checkout in which the sourced per-review-checks helper is missing, and separately one truncated so one of its five required functions is undefined
+- **WHEN** the wrapper runs
+- **THEN** both exit non-zero with `RESULT: FAIL`, the message names the helper and the specific missing function, NO review is enqueued (the validation happens before the invocation, so a broken install costs no review), and neither reports a pass with those five checks silently disabled
 
 #### Scenario: An absent roborev binary or an unresolvable HEAD fails closed
 - **GIVEN** a PATH with no `roborev` binary, and separately a repository with no commits
@@ -527,9 +767,14 @@ fail closed with a named cause and SHALL NOT report a pass.
 
 ### Requirement: Every roborev call site and doctrine surface routes through the sanctioned wrapper
 Every roborev invocation documented anywhere in the delivery pipeline's agent surfaces, commands,
-skills and doctrine SHALL be expressed as a call to `scripts/flow/roborev-review.sh`, and the bare
-`--branch` form and the two-positional commit-range form SHALL be documented as NON-SANCTIONED
-everywhere they are mentioned. **The migrated set is SIXTEEN surfaces** — thirteen under `.claude/**`
+skills and doctrine SHALL be expressed as a call to `scripts/flow/roborev-review.sh`, and NO surface SHALL
+document a DIRECT `roborev` CLI invocation as sanctioned — specifically the flag-only `--branch` form (i.e.
+without an explicit `--repo`) and the two-positional commit-range form SHALL be marked NON-SANCTIONED
+wherever they are named. Because the wrapper's INTERNAL invocation form is the wrapper's own business, a
+call site SHALL NOT prescribe the arguments the WRAPPER passes to roborev (it may mark a direct-CLI form
+non-sanctioned; it may not specify the sanctioned one). The corrected, measured statement of which forms
+are sanctioned lives on the doctrine surfaces enumerated in the next requirement, so a later change to the
+wrapper's internal form can never leave sixteen surfaces stale. **The migrated set is SIXTEEN surfaces** — thirteen under `.claude/**`
 plus three non-`.claude` doctrine surfaces — carrying THREE different obligations, because some of them
 contain no roborev invocation at all and an obligation to "invoke the wrapper" would be unsatisfiable
 for those. (Two further surfaces, CLAUDE.md and the published `roborev-findings` page, are covered by
@@ -615,21 +860,53 @@ migrate.)
 - **WHEN** each class-(a) invocation site is inspected
 - **THEN** it passes both the reviewer agent and the reviewer model, preserving the documented trap that supplying only one inherits a mismatched model from the repository roborev config and fails as a silent-looking review outage
 
-### Requirement: Doctrine records the four roborev rules
+### Requirement: Doctrine records the roborev rules, including the measured invocation matrix
 CLAUDE.md's roborev-invocation guidance and the published `agents-developing/roborev-findings` page
 SHALL both state, in this same change: (a) the wrapper is the only sanctioned roborev invocation;
-(b) the reviewed SHA must be verified against branch HEAD; (c) a "contains no code changes to review"
-verdict on a non-empty diff is a HARD FAIL, never a pass; and (d) a docs-only diff cannot be
-roborev-certified. Both SHALL also record the wrapper's exit-code contract and that ANY non-PASS
-terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed round and a blocked merge. The
-`roborev-findings` page SHALL additionally carry the new guard in its "mechanized in `--lite`" table,
-since a mechanized class that is not listed there will be hand-checked forever. The published page
+(b) the reviewed SCOPE must be verified against the census range (branch HEAD included);
+(c) a "contains no code changes to review" verdict on a non-empty diff is a HARD FAIL, never a pass; and
+(d) a docs-only diff cannot be roborev-certified. Both SHALL also record the wrapper's exit-code contract
+and that ANY non-PASS terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed round and a blocked
+merge. The `roborev-findings` page SHALL additionally carry the new guard in its "mechanized in `--lite`"
+table, since a mechanized class that is not listed there will be hand-checked forever. The published page
 SHALL be accepted by confirming the NEW CONTENT is served — not by an HTTP 200 — because the CDN can
 serve the previous page for minutes after a successful deploy.
 
-#### Scenario: Both doctrine surfaces carry all four rules
+**THREE MEASURED CORRECTIONS SHALL land on EVERY surface that states the rule** — CLAUDE.md,
+`website/.../agents-developing/roborev-findings.md`, `website/.../agents-developing/delivery-pipeline.md`,
+`docs/development/pm-operating-loop.md`, `docs/development/agent-machine-setup.md` — because the earlier
+wording FORBIDS the form now known to be correct:
+
+1. **`--repo` is what makes `--branch` correct from a worktree.** The non-sanctioned form is therefore
+   `--branch` **WITHOUT** an explicit `--repo` (it resolves against the ROOT checkout, normally on the
+   base branch) — NOT `--branch` as such. Any absolute "bare `--branch` is non-sanctioned" claim SHALL be
+   narrowed accordingly wherever it appears.
+2. **The single-SHA form reviews ONE COMMIT, not the branch** — a FOURTH vacuity class (a PARTIAL review
+   reported as a complete one) on every multi-commit branch. It SHALL be named non-sanctioned alongside
+   the two-positional form (whose range base is git's EMPTY-TREE hash).
+3. **roborev EXCLUDES non-code paths from the diff it builds**, so for a markdown-only diff the
+   constructed diff is genuinely EMPTY and "contains no code changes to review" is a TRUTHFUL report of an
+   empty input rather than a reviewer malfunction. Doctrine SHALL state that mechanism, that the
+   wrapper's `prompt-content:` check therefore covers the CODE subset of the census, and that the
+   deterministic pre-enqueue `code-free:` FAIL is the correct response.
+
+Where doctrine documents the summary block it SHALL carry the `job-record:` key and the corrected
+`prompt-content:` values (an unretrievable prompt FAILS; there is no non-failing `UNAVAILABLE` for that
+key). Where doctrine documents the live probe it SHALL state the expectation in the RANGE form — the
+`reviewed-sha:` range's HEAD endpoint equals the worktree HEAD and its base equals the base ref — never as
+`reviewed-sha` equalling the worktree HEAD.
+
+#### Scenario: Both AC4 doctrine surfaces carry all four rules
 - **WHEN** CLAUDE.md and `website/src/content/docs/agents-developing/roborev-findings.md` are inspected after this change
-- **THEN** both state that the wrapper is the only sanctioned invocation, that the reviewed SHA must be verified against branch HEAD, that a "contains no code changes to review" verdict on a non-empty diff is a HARD FAIL, and that a docs-only diff cannot be roborev-certified
+- **THEN** both state that the wrapper is the only sanctioned invocation, that the reviewed scope must be verified against the census range, that a "contains no code changes to review" verdict on a non-empty diff is a HARD FAIL, and that a docs-only diff cannot be roborev-certified
+
+#### Scenario: Every rule-stating surface carries the three measured corrections
+- **WHEN** CLAUDE.md, `roborev-findings.md`, `delivery-pipeline.md`, `docs/development/pm-operating-loop.md` and `docs/development/agent-machine-setup.md` are inspected
+- **THEN** none of them still forbids `--branch` unconditionally (each names the non-sanctioned form as `--branch` WITHOUT an explicit `--repo`), each names the single-SHA form as a partial review, and the roborev-findings page records that roborev excludes non-code paths from the diff it builds
+
+#### Scenario: The live-probe expectation is stated in the range form
+- **WHEN** the doctrine page's live worktree probe section is inspected
+- **THEN** it asks the reader to confirm the `reviewed-sha:` RANGE — its HEAD endpoint equal to the worktree branch HEAD and its base equal to the base ref — rather than a `reviewed-sha` equal to the worktree HEAD, which the range value can never satisfy
 
 #### Scenario: The mechanized-in-lite table lists the new guard
 - **WHEN** the `roborev-findings` page's table of classes mechanized in `--lite` is inspected
@@ -644,22 +921,31 @@ A regression check SHALL exercise the wrapper hermetically — using a stub `rob
 replays recorded real outputs, with no network, no live reviewer, no dataset corpus and no cargo — and
 SHALL assert that the wrapper:
 
-(a) FAILs when the reviewed sha equals the base ref, naming the base; (b) FAILs when the reviewed sha is
-neither endpoint; (c) FAILs a cleanliness vacuity claim against a non-empty code census, and does NOT
+(a) FAILs when the reviewed sha equals the base ref, naming the base; (b) FAILs when the reviewed scope
+does not match the census range at either endpoint; (c) FAILs a cleanliness vacuity claim against a
+non-empty code census — INCLUDING one whose sentence sits under a `## Summary` HEADING — and does NOT
 fail a findings-bearing or out-of-summary mention of the same phrase; (d) FAILs the vacuous token
 signature, and pins the input floor at its exact declared value; (e) FAILs an unpushed branch, a branch
 absent from the remote, a stale-mirror/deleted-remote branch, and an `ls-remote` failure attributed to
 infra/auth — including under the fleet's NARROW fetch refspec, where the branch IS pushed and the
-assert must PASS; (f) PASSes a genuine review with a matching sha and healthy accounting; (g) reports
+assert must PASS; (f) PASSes a genuine review with a matching range and healthy accounting, asserting the
+SANCTIONED ARGV itself (`--branch` PAIRED with an explicit absolute `--repo`, both reviewer flags, and
+neither two positionals nor a single positional sha); (g) reports
 `NOTHING-TO-REVIEW` rather than PASS on a genuinely empty census, and FAILs (never
 `NOTHING-TO-REVIEW`) on an unresolvable base or a failed `git diff`; (h) FAILs a code-free census
 deterministically while NOT classifying a workflow YAML or a mixed census as code-free; (i) FAILs when
 the job never completed, when the provider returned a model-mismatch error, and when the job status is
-not `done`; (j) FAILs when the prompt actually sent omits the census's paths, and degrades visibly when
-the prompt is unretrievable; (k) distinguishes `FINDINGS` from `ERROR` on a non-zero reviewer exit;
-(l) evaluates token accounting against the REAL doubly-encoded payload shape, accepts the documented
-field aliases, and FAILs a present-but-unparseable payload as drift; and (m) FAILs closed when its
-oracles helper is missing or truncated.
+not `done`; (j) FAILs when the prompt actually sent omits the census's code paths AND when the prompt is
+UNRETRIEVABLE, and PASSes a census whose rename appears in the prompt as a single two-sided
+`diff --git a/old b/new` header; (k) distinguishes `FINDINGS` from `ERROR` on a non-zero reviewer exit,
+and FAILs both `INCONSISTENT` findings states (a clean structured verdict, and a zero exit, each beside
+in-block severity markers); (l) evaluates token accounting against the REAL doubly-encoded payload shape,
+accepts the documented field aliases, and FAILs a present-but-unparseable payload as drift; (m) FAILs
+closed when EITHER sourced helper — the oracles file or the per-review-checks file — is missing or
+truncated, with no review enqueued; (n) refuses a SINGLE-COMMIT job record even when it equals branch
+HEAD; and (o) pins the job-record read: `PASS` on a complete record, `PASS` when the required fields live
+in the NESTED job row of a `show --json` payload whose outer review row lacks them, and `DEGRADED` plus
+`sha-assert: FAIL (job record unavailable …)` when no source answers.
 
 The check SHALL also pin the block's key ORDER, the distinctness of its header from all three
 agent-gate summary headers, the usage-error path emitting no block, and hermeticity itself. It SHALL be
@@ -670,7 +956,11 @@ SKIP rather than a silent pass when an optional prerequisite for a subset of cas
 
 #### Scenario: Every trigger class is asserted against the block's own keys
 - **WHEN** the regression check runs
-- **THEN** it asserts each of the classes (a) through (m) above against the wrapper's terminal `RESULT`, its per-check key values and its exit code, and it reports an explicit pass/fail tally so a partial run cannot read as a pass
+- **THEN** it asserts each of the classes (a) through (o) above against the wrapper's terminal `RESULT`, its per-check key values and its exit code, and it reports an explicit pass/fail tally so a partial run cannot read as a pass
+
+#### Scenario: The tally line cannot be mistaken for a gate or wrapper verdict
+- **WHEN** the regression check finishes
+- **THEN** its tally line reports the passed/failed counts under its own distinct heading and does NOT begin with the `RESULT:` token, which belongs to the agent gate's summary contract and to the wrapper's own block
 
 #### Scenario: The check is hermetic
 - **WHEN** the regression check runs on a machine with no network access and no real roborev binary installed
@@ -693,10 +983,16 @@ requires network access and a live reviewer. Its procedure and expected summary-
 in the wrapper's own `--help` output (so the two cannot drift apart) and in the doctrine page, and SHALL
 include re-running it after any roborev version bump.
 
-#### Scenario: The probe establishes reviewed-sha equals the worktree HEAD
+The probe's PASS condition SHALL be that the reviewed scope **covers the worktree HEAD**: with the
+sanctioned range invocation, `reviewed-sha:` is `<base40>..<head40>`, so the assertion is on the range's
+HEAD ENDPOINT equalling the worktree branch HEAD (and `sha-assert: PASS`, which the wrapper only reaches
+when BOTH endpoints match). A `reviewed-sha` that is the base ref alone means the explicit-`--repo`
+invocation did not defeat the root-checkout resolution.
+
+#### Scenario: The probe establishes that the reviewed range covers the worktree HEAD
 - **GIVEN** a real issue worktree, on its own branch, with its implementation commit pushed, while the root checkout sits on `main`
 - **WHEN** the documented probe runs the wrapper from inside that worktree
-- **THEN** the summary block's reviewed sha equals the worktree branch's HEAD sha and does NOT equal the base ref, demonstrating the explicit-repo invocation defeats the root-checkout resolution trigger
+- **THEN** the block reports `sha-assert: PASS` with a `reviewed-sha:` range whose HEAD endpoint is the worktree branch's HEAD sha and which is not the base ref alone, demonstrating that the explicit-`--repo` invocation defeats the root-checkout resolution trigger
 
 #### Scenario: The probe is documented, not gate-run
 - **WHEN** the agent gate's component set is inspected

--- a/openspec/changes/roborev-vacuous-review-guard/tasks.md
+++ b/openspec/changes/roborev-vacuous-review-guard/tasks.md
@@ -1,59 +1,123 @@
 # Tasks: roborev-vacuous-review-guard (issue #2964)
 
 > Design decided in `design.md`: a fail-closed CQLite-side wrapper (`roborev` is an external binary we
-> cannot patch), with a locally-computed `git` diff census as the oracle, a deterministic
-> verdict-text-vs-census check as the primary vacuity assert, and bounded token accounting as a
-> corroborating fail-closed-only tier. AC→requirement map is at the top of
+> cannot patch) whose **DETERMINISTIC** checks carry the verdict — the remote (`git ls-remote`), a local
+> `git` diff census, that census's code-free classification, the job record's structured
+> `git_ref`/`status`, and the census's own paths inside the prompt actually sent — with reviewer prose
+> and token accounting CORROBORATING and fail-closed-only. AC→requirement map is at the top of
 > `specs/roborev-review-guard/spec.md`.
 
-## 1. The sanctioned wrapper (surface: `scripts/flow/roborev-review.sh`)
-- [x] Create the wrapper skeleton: flag parsing (`--repo`, `--base`, `--agent`, `--model`, passthrough),
-      absolute repo-root resolution, branch + HEAD resolution, and the three-way exit-code contract
-      (0 = PASS, 1 = FAIL, 3 = NOTHING-TO-REVIEW).
+## 1. The sanctioned wrapper (surfaces: `scripts/flow/roborev-review.sh`, `roborev-review-oracles.sh`, `roborev-job-facts.py`)
+- [x] Create the wrapper skeleton: flag parsing (`--agent`, `--model`, `--repo`, `--base`, `--log`),
+      absolute repo-root resolution, branch + full-40-char HEAD resolution, and the four-way exit-code
+      contract (0 = PASS, 1 = FAIL, 3 = NOTHING-TO-REVIEW, 2 = usage error).
+- [x] Reject an option supplied with an EMPTY value as a usage error (never a silent fallback to the
+      default — `--repo ""` falling back to `$PWD` reviews a repo the caller did not name).
 - [x] Declare the named vacuity threshold constants at the top of the script with the measured evidence
-      table (jobs 4651/4652/4654/4656/4658/4659) cited in a comment.
-- [x] Step 2 — push assert (AC3): `origin/<branch>` exists and equals HEAD, else FAIL naming the
-      unpushed commits, before any review is enqueued.
-- [x] Step 3 — local diff census oracle: `git diff --numstat <base>...HEAD` → files/+/−; a genuinely
-      empty census exits `NOTHING-TO-REVIEW` without enqueuing a review.
+      (jobs 4651/4652/4654/4656/4658/4659 + the small-genuine 67,387/43,520/2,232 run) cited in a comment.
+- [x] Split the local oracles into a sourced `scripts/flow/roborev-review-oracles.sh` (push assert +
+      census + code-free) resolved via `BASH_SOURCE`, and FAIL CLOSED when that file is missing OR
+      truncated (a silently absent oracles file would turn both checks into no-ops).
+- [x] Split JSON/token decoding into `scripts/flow/roborev-job-facts.py` (`git_ref`, `status`,
+      `model`/`requested_model`, prompt, and the three-state token extraction).
+- [x] Step 2 — push assert (AC3) with **`git ls-remote` as the authoritative oracle**: distinct
+      fail-closed causes for detached HEAD, an `ls-remote` failure (infra/auth — NOT "never pushed"), a
+      branch absent on the remote, and a remote tip behind/diverged from HEAD (naming the unpushed
+      commits). Remote taken from the branch upstream, else `origin`.
+- [x] Remove the local mirror-ref fast path entirely: a cached `refs/remotes/<remote>/<branch>` survives
+      a force-push or a branch deletion, so it can equal HEAD while the remote lacks the commit.
+- [x] Step 3 — local diff census oracle: `git diff --numstat --no-renames <base>...HEAD` → files/+/−
+      plus the path list; a genuinely empty census exits `NOTHING-TO-REVIEW` without enqueuing a review;
+      an unresolvable base and a FAILED `git diff` are DISTINCT fail-closed causes, never aliased to
+      "genuinely empty".
+- [x] Step 3b — `code-free:` as a DETERMINISTIC FAIL evaluated pre-enqueue from our own census
+      classification (extension-based, with an extensionless-path assist), so `docs/foo.py` and
+      `.github/**/*.yml` count as CODE and cannot produce a false code-free FAIL.
 - [x] Step 4 — invocation (AC2): explicit HEAD sha + explicit absolute `--repo` + `--wait`; refuse when
       only one of `--agent`/`--model` is supplied; never bare `--branch`, never the two-positional range form.
-- [x] Step 5 — reviewed-SHA assert (AC2): parse `Enqueued job <N> for <sha>`, require a prefix match with
-      HEAD; FAIL on mismatch, naming the base ref explicitly when the mismatched sha equals it; FAIL on an
-      absent/unparseable enqueue line.
-- [x] Step 6 tier 1 (AC1, primary): a "contains no code changes to review" / "no code changes" verdict
-      against a non-empty census is a HARD FAIL.
-- [x] Step 6 tier 2 (AC1, corroborating): read token accounting via `roborev show <N> --json` (fallback
-      `roborev list --json`); FAIL on input below threshold OR zero cached input OR output below threshold;
-      print observed-vs-threshold in the message; stamp an explicit degraded-signal notice (never a silent
-      skip) when accounting is unavailable, with tier 1 still governing.
-- [x] Step 7 — emit the `==== ROBOREV REVIEW SUMMARY ====` block (repo, branch, head-sha, reviewed-sha,
-      job, base, census, tokens, per-check verdicts, terminal `RESULT:`), write the raw transcript to a log
-      path named in the block, and exit non-zero on any non-PASS outcome.
-- [ ] Step 7b — surface the reviewer's own exit status under its own greppable key `roborev-exit:`
-      (`PASS` when the `roborev` process exited zero, else a `FAIL` carrying the observed code), placed
-      with the other per-check keys ahead of the terminal `RESULT:` and included in the per-check scan.
-      The fail-closed BEHAVIOUR already exists (a non-zero reviewer exit forces `RESULT: FAIL` plus an
-      `ERROR:` detail line); only the greppable key is missing, so this is a one-line addition to
-      `emit_summary` plus its verdict-scan entry — and a matching hermetic case.
-- [x] Hygiene pass: keep the script small (campsite spirit), quote every interpolation of external
-      output, and walk CLAUDE.md's pre-roborev self-check list over the diff.
+- [x] Step 5 — reviewed-SHA assert (AC2) with the job record's full-40-char `git_ref` as the oracle and
+      the stdout `Enqueued job <N> for <sha>` parse demoted to a cross-check (disagreement = NOTICE,
+      absent/unparseable announcement = FAIL, ≥7-hex-char floor, case-normalised, last announcement
+      wins with the multiplicity recorded); attribute a mismatch to the base ref or to "neither endpoint".
+- [x] Step 5b — `model:` key surfacing `requested_model` != `model` as a loud NOTICE (not a FAIL: an
+      alias resolution is legitimate and an always-red guard gets bypassed), and marking an absent model
+      field UNCONFIRMED.
+- [x] Step 6a — `review-completed:`: POSITIVE evidence required before PASS is reachable (job status
+      `done` AND a terminal verdict marker from an allow-list); FAIL closed on an unreadable transcript,
+      a non-`done` status, or no marker; NOTICE when the status is unavailable and completion rests on
+      the marker alone.
+- [x] Step 6b — `prompt-content:`: assert the census's own paths appear in the prompt ACTUALLY SENT
+      (job-record `prompt`, else `roborev show <job> --prompt`), threshold-free, bounded by a named
+      constant with even sampling; an unretrievable prompt is `UNAVAILABLE`, never a FAIL or a silent skip.
+- [x] Step 6c — `findings:` key plus `roborev-exit:` splitting `FINDINGS (exit N)` from `ERROR (exit N)`
+      with the structured `status` as authority, so a normal findings outcome is never misreported as a
+      reviewer malfunction.
+- [x] Step 6d — tier 1 (AUTHORITATIVE, gated): anchor the match to the verdict/`Summary:` region and gate
+      it on `findings:` — `NONE`/`UNKNOWN` ⇒ HARD FAIL, `PRESENT*` ⇒ advisory NOTICE.
+- [x] Step 6e — tier 2 (corroborating, fail-closed only): decode the doubly-encoded `token_usage` string
+      and `total_output_tokens`; three-state extraction with `present-but-unparseable` ⇒ FAIL (drift);
+      input floor 25,000 + `cached == 0` as the FAIL conditions with observed-vs-threshold printed; the
+      output floor ADVISORY only; a degraded-signal notice (never a silent skip) when accounting is absent.
+- [x] Step 7 — emit the `==== ROBOREV REVIEW SUMMARY ====` block in its contracted key order (repo,
+      branch, base, head-sha, reviewed-sha, job, model, census, tokens, push-assert, census-check,
+      code-free, sha-assert, review-completed, prompt-content, vacuity-tier1, vacuity-tier2, findings,
+      roborev-exit, log, terminal `RESULT:`), write the raw transcript to the log path named in the block,
+      and exit non-zero on any non-PASS outcome.
+- [x] Step 7b — one verdict scan over every per-check key: `FAIL*`/`FINDINGS*`/`ERROR*` fail the run;
+      `PASS`/`NOTICE`/`UNAVAILABLE`/`SKIP` never do. Unreached checks read `SKIP`, never blank.
+- [x] Emit the block on EVERY verdict path including an unexpected mid-run abort (`trap … EXIT`), while
+      the usage-error and `--help` paths emit NO block at all.
+- [x] Hygiene pass: keep each file small (campsite spirit), quote every interpolation of external
+      output, `shellcheck -x` clean at info level across all three shell files, and walk CLAUDE.md's
+      pre-roborev self-check list over the diff.
 
 ## 2. Hermetic regression check (surface: `scripts/tests/test_roborev_review_guard.sh`)
-- [x] Build the stub `roborev` fixture (first on `PATH`) that replays the recorded enqueue lines, verdict
-      text, and `show --json` token payloads from the evidence table, plus throwaway `git init` fixtures
-      with a synthetic `origin` remote.
-- [x] Case (a): enqueued sha == base ref → FAIL, message names the base ref.
-- [x] Case (b): enqueued sha is neither endpoint → FAIL.
-- [x] Case (c): "contains no code changes to review" against a non-empty census → FAIL.
-- [x] Case (d): vacuous token signature (≈18k input / 0 cached / <60 output) → FAIL.
-- [x] Case (e): unpushed branch → FAIL, no review enqueued.
-- [x] Case (f): genuine review (matching sha, ~500k/387k/6.3k accounting) → PASS.
-- [x] Case (g): genuinely empty census → `NOTHING-TO-REVIEW` with its own non-zero exit code, never PASS.
-- [x] Case: unavailable token accounting → degraded-signal notice stamped, tier 1 still applied.
-- [x] Assert the summary block's header is distinct from all three agent-gate summary headers.
-- [x] Confirm hermeticity: no network, no real roborev, no dataset corpus; and no wall-clock threshold
-      assert in the correctness path (#2642).
+- [x] Build the stub `roborev` fixture (first on `PATH`) replaying the recorded enqueue lines, verdict
+      text, and `show --json` payloads — including `token_usage` as a JSON-ENCODED STRING carrying
+      `total_output_tokens`, the exact shape whose mis-read left tier 2 permanently UNAVAILABLE — plus
+      throwaway `git init` fixtures with their own local bare `origin`.
+- [x] Fixture topologies: wide + **narrow** fetch refspec (the fleet's real configuration), behind,
+      upstream-named remote, unreachable remote, missing base, deleted remote branch with a stale mirror
+      ref, docs-only, mixed, workflow-yaml; plus a fixture-integrity guard so a narrow fixture that grew
+      a mirror ref cannot silently stop testing its condition.
+- [x] Case (a): reviewed sha == base ref → FAIL, message names the base ref.
+- [x] Case (b): reviewed sha is neither endpoint → FAIL.
+- [x] Case (c): a cleanliness vacuity claim against a non-empty CODE census → FAIL; plus the gated and
+      anchored complements (findings UNKNOWN → FAIL; a findings-bearing review quoting the phrase →
+      NOTICE/PASS; the phrase outside the summary region → PASS).
+- [x] Case (d): vacuous token signature → FAIL, and the input floor pinned at exactly 25000.
+- [x] Case (e): unpushed branch → FAIL, no review enqueued; remote behind HEAD names the unpushed commits.
+- [x] Case (f): genuine review (matching sha, healthy accounting) → PASS, with the sanctioned argv
+      asserted (explicit sha, absolute `--repo`, both flags, no `--branch`, no two positionals).
+- [x] Case (g): genuinely empty census → `NOTHING-TO-REVIEW` with its own non-zero exit code, never PASS;
+      an unresolvable base and a failed `git diff` → FAIL, never `NOTHING-TO-REVIEW`.
+- [x] Code-free cases: a docs-only census FAILs deterministically (even with a clean verdict and healthy
+      tokens), while a mixed census and a `.github/workflows/*.yml` census are NOT code-free.
+- [x] Push-assert cases: narrow refspec pushed → PASS; narrow behind → FAIL; upstream-named remote
+      honoured; `ls-remote` failure → infra/auth FAIL; deleted remote branch with a stale mirror ref → FAIL.
+- [x] `review-completed` cases: a job that never finished, the #2433/#3037 model-mismatch 400, and a
+      `failed` job status each must NOT reach PASS.
+- [x] `prompt-content` cases: a prompt without the census paths → FAIL; an unretrievable prompt →
+      UNAVAILABLE (visible, not a skip); a PASS reports the coverage it checked.
+- [x] `sha-assert` cases: the structured `git_ref` wins over a disagreeing stdout announcement; a 9-char
+      real-shape announcement still verifies; an uppercase announcement is normalised; a 4-hex-char
+      announcement is too short; two announcements → the last is effective.
+- [x] `findings`/`roborev-exit` cases: non-zero exit with a completed review → FINDINGS; with a failed
+      job → ERROR; zero exit → PASS; a pre-invocation failure → SKIP; key ORDER pinned.
+- [x] Token cases: the real payload shape evaluates; the legacy `output_tokens` alias still resolves;
+      renamed fields resolve via the alias sets; present-but-unparseable → FAIL (drift);
+      `has_token_data=false` beside real counts → drift NOTICE, not a bypass; a low output count never
+      fails a genuine clean review; absent accounting degrades visibly and does not fail an otherwise
+      clean review.
+- [x] Robustness cases: detached HEAD; a repository with no commits; `roborev` absent from PATH; an abort
+      before a verdict still emits a block; option-value/option-name validation; a MISSING and a
+      TRUNCATED oracles file both FAIL closed.
+- [x] Assert the summary block's header is distinct from all three agent-gate summary headers, and that
+      `--help` documents the exit codes + the live worktree probe and emits no block.
+- [x] Confirm hermeticity: no network, no real roborev, no dataset corpus, no cargo; a loud SKIP (never a
+      silent pass) when python3 is unavailable; and no wall-clock threshold assert in the correctness
+      path (#2642).
+- [x] Verify the suite's own strength: 258 assertions green, and 27/27 deliberate wrapper mutations killed.
 
 ## 3. Gate wiring (surface: `scripts/agent-gate.sh`)
 - [x] Register the check in `run_roborev_lints_cmd()` (component `roborev-lints`, present in BOTH
@@ -63,51 +127,71 @@
 - [x] Append the check to `run_tooling_tests()` (full-gate `tooling-tests`) following the
       `test_check_dockerfile_rust_pin.sh` / `test_check_skill_flag_tables.sh` guard pattern (FAIL the
       component on non-zero, with a named failure line).
-- [x] Verify runtime is fast enough for `--lite` and that `scripts/agent-gate.sh --list` /
+- [x] Verify runtime is fast enough for `--lite` (~0.5s) and that `scripts/agent-gate.sh --list` /
       `--lite-list` still reflect the intended component set.
 
-## 4. Call-site migration (surface: `.claude/skills/**`, `.claude/agents/**`)
+## 4. Call-site migration — 16 surfaces (`.claude/**` ×13 + fleet doctrine ×3)
 - [x] `.claude/skills/flow-implement/SKILL.md` — the review-first step (the primary call site; replaces
       the documented bare `--branch` command).
 - [x] `.claude/agents/flow-closer.md` — the final confirmation pass (the merge-gating call site; also
       removes the non-existent `/roborev-review-branch` form) and treat a non-PASS terminal `RESULT`,
       including `NOTHING-TO-REVIEW`, as a blocked merge.
-- [x] `.claude/agents/flow-lead.md` — the stage table's roborev row.
-- [x] `.claude/skills/{flow-activate,flow-address,flow-finalize,ci-cd-validation}/SKILL.md` — every
-      roborev reference routed through the wrapper.
-- [x] `.claude/agents/{rust-reviewer,sstable-developer,test-validator}.md` — every roborev reference
-      routed through the wrapper.
-- [x] Sweep for any remaining bare `--branch` roborev instruction across `.claude/**` and mark the form
-      non-sanctioned; preserve the both-`--agent`-and-`--model` requirement at every call site.
+- [x] `.claude/skills/flow-address/SKILL.md` — the post-comment re-review (push first, then re-run).
+- [x] `.claude/commands/worker.md` — the fleet's UNATTENDED entry point, which runs the implement loop's
+      review-first step itself (missed by the first migration sweep).
+- [x] `.claude/agents/flow-lead.md` — the stage table's roborev row + the roborev doctrine bullet.
+- [x] `.claude/skills/{flow-activate,flow-finalize,ci-cd-validation}/SKILL.md` +
+      `.claude/skills/ci-cd-validation/merge-process.md` — every roborev reference routed through the
+      wrapper; merge-readiness requires a terminal `RESULT: PASS`.
+- [x] `.claude/commands/manager.md` — define "roborev clean" for dispatched workers as the wrapper's
+      terminal `RESULT: PASS` (missed by the first migration sweep).
+- [x] `.claude/agents/{rust-reviewer,sstable-developer,test-validator}.md` — each states it never invokes
+      roborev directly and points at the wrapper; `rust-reviewer` flags a reintroduced bare `--branch` or
+      two-positional range form as a **BLOCKER**.
+- [x] `website/src/content/docs/agents-developing/delivery-pipeline.md`,
+      `docs/development/pm-operating-loop.md`, `docs/development/agent-machine-setup.md` — replace the
+      INVERSE instruction ("this machine's configured agent … no `--agent`/`--model` flags"; explicit
+      agent/model called "never doctrine") with the wrapper, both flags, push-first, and the non-PASS rule.
+- [x] Sweep for any remaining bare `--branch` roborev instruction across `.claude/**`, `docs/**` and
+      `website/**` and mark the form non-sanctioned; preserve the both-`--agent`-and-`--model` requirement
+      at every call site.
 
 ## 5. Doctrine — ships in this change (AC4)
 - [x] CLAUDE.md — update the roborev-invocation bullet in *Agent-Team Conventions*: the wrapper is the
       only sanctioned invocation; verify the reviewed SHA; "contains no code changes to review" on a
-      non-empty diff is a HARD FAIL; docs-only diffs cannot be roborev-certified.
-- [x] `website/src/content/docs/agents-developing/roborev-findings.md` — same four rules, plus a row in
-      the "mechanized in `--lite`" table for the new `roborev-lints` guard.
+      non-empty diff is a HARD FAIL; docs-only diffs cannot be roborev-certified; plus the exit-code
+      contract and "any non-PASS `RESULT` is a blocked merge".
+- [x] `website/src/content/docs/agents-developing/roborev-findings.md` — the same four rules, the
+      evidence (T1/T2/T3 + token tells), the live-probe procedure, and a row in the "mechanized in
+      `--lite`" table for the new guard.
 - [ ] Verify publication by grepping the SERVED page for a distinctive new phrase (an HTTP 200 is not
-      proof; CDN staleness ≈3 min) and re-check after a wait if absent.
+      proof; CDN staleness ≈3 min) and re-check after a wait if absent. **Open: post-merge, after the
+      site deploys.**
 
 ## 6. Live worktree probe (AC5)
-- [x] Document the probe (wrapper usage text + the doctrine page): from a real `issue-<N>-*` worktree with
-      a pushed commit and the root checkout on `main`, run the wrapper and confirm the summary block's
-      `reviewed-sha` equals the worktree HEAD and does NOT equal the base ref.
+- [x] Document the probe (wrapper `--help` text + the doctrine page): from a real `issue-<N>-*` worktree
+      with a pushed commit and the root checkout on `main`, run the wrapper and confirm the summary
+      block's `reviewed-sha` equals the worktree HEAD and does NOT equal the base ref; re-run after any
+      roborev version bump.
 - [ ] Run the probe once against the real binary and record the observed summary-block values (head-sha,
-      reviewed-sha, job, census, tokens) in the PR body as the AC5 live evidence.
+      reviewed-sha, job, census, tokens) in the PR body as the AC5 live evidence. **Open: needs a live
+      reviewer; the branch's own review rounds are the natural vehicle.**
 
 ## 7. Gate + review + sign-off
 - [x] `scripts/agent-gate.sh --lite` green each fix round (summary-file redirect; anchor the poll on
       `RESULT: (PASS|FAIL)`).
+- [x] Reconcile the OpenSpec change with the as-built deterministic-primary architecture (this pass), so
+      the intent audit anchors on what was actually built: every new key specified, the two evidenced
+      relaxations (input floor 25,000; the dropped output floor) recorded as decisions, and the migrated
+      surface set enumerated count-accurately (16, not the stale 10).
 - [ ] `rust-reviewer` (no Rust here — skip if it has nothing to review) + roborev on the lite-green diff
-      via the NEW wrapper (review-first). Note: this change's own diff is largely docs + shell; if the
-      wrapper FAILs it as code-free, record primary-source/self-test evidence per the docs-only rule
-      instead of "roborev clean".
+      via the NEW wrapper (review-first). Note: this change's own diff mixes shell/python with docs, so
+      it is NOT code-free; four roborev rounds have run against it and their blockers are folded in.
 - [ ] Full gate ONCE via `flow-closer`; verify `tree-integrity:` alongside `RESULT:`.
 - [ ] **C (spec-auditor)** anchored to `openspec/changes/roborev-vacuous-review-guard/specs/**`: every
       requirement `satisfied` with public-surface (wrapper + regression-check + doctrine) evidence.
-- [ ] roborev clean or a recorded docs-only substitute; blockers fixed pre-merge, nits batched to ONE
-      linked follow-up issue.
+- [ ] roborev clean; blockers fixed pre-merge, nits batched to ONE linked follow-up issue.
 - [ ] File the upstream follow-up noted in `design.md` (worktree-aware `--branch` resolution; non-zero
       exit on a discarded code-free diff) so the external-binary gap is tracked.
-- [ ] `openspec validate roborev-vacuous-review-guard --strict` clean; `openspec archive` after merge.
+- [x] `openspec validate roborev-vacuous-review-guard --strict` clean.
+- [ ] `openspec archive` after merge.

--- a/openspec/changes/roborev-vacuous-review-guard/tasks.md
+++ b/openspec/changes/roborev-vacuous-review-guard/tasks.md
@@ -7,91 +7,97 @@
 > `specs/roborev-review-guard/spec.md`.
 
 ## 1. The sanctioned wrapper (surface: `scripts/flow/roborev-review.sh`)
-- [ ] Create the wrapper skeleton: flag parsing (`--repo`, `--base`, `--agent`, `--model`, passthrough),
+- [x] Create the wrapper skeleton: flag parsing (`--repo`, `--base`, `--agent`, `--model`, passthrough),
       absolute repo-root resolution, branch + HEAD resolution, and the three-way exit-code contract
       (0 = PASS, 1 = FAIL, 3 = NOTHING-TO-REVIEW).
-- [ ] Declare the named vacuity threshold constants at the top of the script with the measured evidence
+- [x] Declare the named vacuity threshold constants at the top of the script with the measured evidence
       table (jobs 4651/4652/4654/4656/4658/4659) cited in a comment.
-- [ ] Step 2 — push assert (AC3): `origin/<branch>` exists and equals HEAD, else FAIL naming the
+- [x] Step 2 — push assert (AC3): `origin/<branch>` exists and equals HEAD, else FAIL naming the
       unpushed commits, before any review is enqueued.
-- [ ] Step 3 — local diff census oracle: `git diff --numstat <base>...HEAD` → files/+/−; a genuinely
+- [x] Step 3 — local diff census oracle: `git diff --numstat <base>...HEAD` → files/+/−; a genuinely
       empty census exits `NOTHING-TO-REVIEW` without enqueuing a review.
-- [ ] Step 4 — invocation (AC2): explicit HEAD sha + explicit absolute `--repo` + `--wait`; refuse when
+- [x] Step 4 — invocation (AC2): explicit HEAD sha + explicit absolute `--repo` + `--wait`; refuse when
       only one of `--agent`/`--model` is supplied; never bare `--branch`, never the two-positional range form.
-- [ ] Step 5 — reviewed-SHA assert (AC2): parse `Enqueued job <N> for <sha>`, require a prefix match with
+- [x] Step 5 — reviewed-SHA assert (AC2): parse `Enqueued job <N> for <sha>`, require a prefix match with
       HEAD; FAIL on mismatch, naming the base ref explicitly when the mismatched sha equals it; FAIL on an
       absent/unparseable enqueue line.
-- [ ] Step 6 tier 1 (AC1, primary): a "contains no code changes to review" / "no code changes" verdict
+- [x] Step 6 tier 1 (AC1, primary): a "contains no code changes to review" / "no code changes" verdict
       against a non-empty census is a HARD FAIL.
-- [ ] Step 6 tier 2 (AC1, corroborating): read token accounting via `roborev show <N> --json` (fallback
+- [x] Step 6 tier 2 (AC1, corroborating): read token accounting via `roborev show <N> --json` (fallback
       `roborev list --json`); FAIL on input below threshold OR zero cached input OR output below threshold;
       print observed-vs-threshold in the message; stamp an explicit degraded-signal notice (never a silent
       skip) when accounting is unavailable, with tier 1 still governing.
-- [ ] Step 7 — emit the `==== ROBOREV REVIEW SUMMARY ====` block (repo, branch, head-sha, reviewed-sha,
+- [x] Step 7 — emit the `==== ROBOREV REVIEW SUMMARY ====` block (repo, branch, head-sha, reviewed-sha,
       job, base, census, tokens, per-check verdicts, terminal `RESULT:`), write the raw transcript to a log
       path named in the block, and exit non-zero on any non-PASS outcome.
-- [ ] Hygiene pass: keep the script small (campsite spirit), quote every interpolation of external
+- [ ] Step 7b — surface the reviewer's own exit status under its own greppable key `roborev-exit:`
+      (`PASS` when the `roborev` process exited zero, else a `FAIL` carrying the observed code), placed
+      with the other per-check keys ahead of the terminal `RESULT:` and included in the per-check scan.
+      The fail-closed BEHAVIOUR already exists (a non-zero reviewer exit forces `RESULT: FAIL` plus an
+      `ERROR:` detail line); only the greppable key is missing, so this is a one-line addition to
+      `emit_summary` plus its verdict-scan entry — and a matching hermetic case.
+- [x] Hygiene pass: keep the script small (campsite spirit), quote every interpolation of external
       output, and walk CLAUDE.md's pre-roborev self-check list over the diff.
 
 ## 2. Hermetic regression check (surface: `scripts/tests/test_roborev_review_guard.sh`)
-- [ ] Build the stub `roborev` fixture (first on `PATH`) that replays the recorded enqueue lines, verdict
+- [x] Build the stub `roborev` fixture (first on `PATH`) that replays the recorded enqueue lines, verdict
       text, and `show --json` token payloads from the evidence table, plus throwaway `git init` fixtures
       with a synthetic `origin` remote.
-- [ ] Case (a): enqueued sha == base ref → FAIL, message names the base ref.
-- [ ] Case (b): enqueued sha is neither endpoint → FAIL.
-- [ ] Case (c): "contains no code changes to review" against a non-empty census → FAIL.
-- [ ] Case (d): vacuous token signature (≈18k input / 0 cached / <60 output) → FAIL.
-- [ ] Case (e): unpushed branch → FAIL, no review enqueued.
-- [ ] Case (f): genuine review (matching sha, ~500k/387k/6.3k accounting) → PASS.
-- [ ] Case (g): genuinely empty census → `NOTHING-TO-REVIEW` with its own non-zero exit code, never PASS.
-- [ ] Case: unavailable token accounting → degraded-signal notice stamped, tier 1 still applied.
-- [ ] Assert the summary block's header is distinct from all three agent-gate summary headers.
-- [ ] Confirm hermeticity: no network, no real roborev, no dataset corpus; and no wall-clock threshold
+- [x] Case (a): enqueued sha == base ref → FAIL, message names the base ref.
+- [x] Case (b): enqueued sha is neither endpoint → FAIL.
+- [x] Case (c): "contains no code changes to review" against a non-empty census → FAIL.
+- [x] Case (d): vacuous token signature (≈18k input / 0 cached / <60 output) → FAIL.
+- [x] Case (e): unpushed branch → FAIL, no review enqueued.
+- [x] Case (f): genuine review (matching sha, ~500k/387k/6.3k accounting) → PASS.
+- [x] Case (g): genuinely empty census → `NOTHING-TO-REVIEW` with its own non-zero exit code, never PASS.
+- [x] Case: unavailable token accounting → degraded-signal notice stamped, tier 1 still applied.
+- [x] Assert the summary block's header is distinct from all three agent-gate summary headers.
+- [x] Confirm hermeticity: no network, no real roborev, no dataset corpus; and no wall-clock threshold
       assert in the correctness path (#2642).
 
 ## 3. Gate wiring (surface: `scripts/agent-gate.sh`)
-- [ ] Register the check in `run_roborev_lints_cmd()` (component `roborev-lints`, present in BOTH
+- [x] Register the check in `run_roborev_lints_cmd()` (component `roborev-lints`, present in BOTH
       `LITE_COMPONENTS` and `COMPONENTS`) so a regression FAILs the fast `--lite` loop — the stated
       acceptance goal — following the existing `check-workflow-injection.sh` / `check-no-wallclock-asserts.sh`
       chaining pattern.
-- [ ] Append the check to `run_tooling_tests()` (full-gate `tooling-tests`) following the
+- [x] Append the check to `run_tooling_tests()` (full-gate `tooling-tests`) following the
       `test_check_dockerfile_rust_pin.sh` / `test_check_skill_flag_tables.sh` guard pattern (FAIL the
       component on non-zero, with a named failure line).
-- [ ] Verify runtime is fast enough for `--lite` and that `scripts/agent-gate.sh --list` /
+- [x] Verify runtime is fast enough for `--lite` and that `scripts/agent-gate.sh --list` /
       `--lite-list` still reflect the intended component set.
 
 ## 4. Call-site migration (surface: `.claude/skills/**`, `.claude/agents/**`)
-- [ ] `.claude/skills/flow-implement/SKILL.md` — the review-first step (the primary call site; replaces
+- [x] `.claude/skills/flow-implement/SKILL.md` — the review-first step (the primary call site; replaces
       the documented bare `--branch` command).
-- [ ] `.claude/agents/flow-closer.md` — the final confirmation pass (the merge-gating call site; also
+- [x] `.claude/agents/flow-closer.md` — the final confirmation pass (the merge-gating call site; also
       removes the non-existent `/roborev-review-branch` form) and treat a non-PASS terminal `RESULT`,
       including `NOTHING-TO-REVIEW`, as a blocked merge.
-- [ ] `.claude/agents/flow-lead.md` — the stage table's roborev row.
-- [ ] `.claude/skills/{flow-activate,flow-address,flow-finalize,ci-cd-validation}/SKILL.md` — every
+- [x] `.claude/agents/flow-lead.md` — the stage table's roborev row.
+- [x] `.claude/skills/{flow-activate,flow-address,flow-finalize,ci-cd-validation}/SKILL.md` — every
       roborev reference routed through the wrapper.
-- [ ] `.claude/agents/{rust-reviewer,sstable-developer,test-validator}.md` — every roborev reference
+- [x] `.claude/agents/{rust-reviewer,sstable-developer,test-validator}.md` — every roborev reference
       routed through the wrapper.
-- [ ] Sweep for any remaining bare `--branch` roborev instruction across `.claude/**` and mark the form
+- [x] Sweep for any remaining bare `--branch` roborev instruction across `.claude/**` and mark the form
       non-sanctioned; preserve the both-`--agent`-and-`--model` requirement at every call site.
 
 ## 5. Doctrine — ships in this change (AC4)
-- [ ] CLAUDE.md — update the roborev-invocation bullet in *Agent-Team Conventions*: the wrapper is the
+- [x] CLAUDE.md — update the roborev-invocation bullet in *Agent-Team Conventions*: the wrapper is the
       only sanctioned invocation; verify the reviewed SHA; "contains no code changes to review" on a
       non-empty diff is a HARD FAIL; docs-only diffs cannot be roborev-certified.
-- [ ] `website/src/content/docs/agents-developing/roborev-findings.md` — same four rules, plus a row in
+- [x] `website/src/content/docs/agents-developing/roborev-findings.md` — same four rules, plus a row in
       the "mechanized in `--lite`" table for the new `roborev-lints` guard.
 - [ ] Verify publication by grepping the SERVED page for a distinctive new phrase (an HTTP 200 is not
       proof; CDN staleness ≈3 min) and re-check after a wait if absent.
 
 ## 6. Live worktree probe (AC5)
-- [ ] Document the probe (wrapper usage text + the doctrine page): from a real `issue-<N>-*` worktree with
+- [x] Document the probe (wrapper usage text + the doctrine page): from a real `issue-<N>-*` worktree with
       a pushed commit and the root checkout on `main`, run the wrapper and confirm the summary block's
       `reviewed-sha` equals the worktree HEAD and does NOT equal the base ref.
 - [ ] Run the probe once against the real binary and record the observed summary-block values (head-sha,
       reviewed-sha, job, census, tokens) in the PR body as the AC5 live evidence.
 
 ## 7. Gate + review + sign-off
-- [ ] `scripts/agent-gate.sh --lite` green each fix round (summary-file redirect; anchor the poll on
+- [x] `scripts/agent-gate.sh --lite` green each fix round (summary-file redirect; anchor the poll on
       `RESULT: (PASS|FAIL)`).
 - [ ] `rust-reviewer` (no Rust here — skip if it has nothing to review) + roborev on the lite-green diff
       via the NEW wrapper (review-first). Note: this change's own diff is largely docs + shell; if the

--- a/openspec/changes/roborev-vacuous-review-guard/tasks.md
+++ b/openspec/changes/roborev-vacuous-review-guard/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: roborev-vacuous-review-guard (issue #2964)
+
+> Design decided in `design.md`: a fail-closed CQLite-side wrapper (`roborev` is an external binary we
+> cannot patch), with a locally-computed `git` diff census as the oracle, a deterministic
+> verdict-text-vs-census check as the primary vacuity assert, and bounded token accounting as a
+> corroborating fail-closed-only tier. AC→requirement map is at the top of
+> `specs/roborev-review-guard/spec.md`.
+
+## 1. The sanctioned wrapper (surface: `scripts/flow/roborev-review.sh`)
+- [ ] Create the wrapper skeleton: flag parsing (`--repo`, `--base`, `--agent`, `--model`, passthrough),
+      absolute repo-root resolution, branch + HEAD resolution, and the three-way exit-code contract
+      (0 = PASS, 1 = FAIL, 3 = NOTHING-TO-REVIEW).
+- [ ] Declare the named vacuity threshold constants at the top of the script with the measured evidence
+      table (jobs 4651/4652/4654/4656/4658/4659) cited in a comment.
+- [ ] Step 2 — push assert (AC3): `origin/<branch>` exists and equals HEAD, else FAIL naming the
+      unpushed commits, before any review is enqueued.
+- [ ] Step 3 — local diff census oracle: `git diff --numstat <base>...HEAD` → files/+/−; a genuinely
+      empty census exits `NOTHING-TO-REVIEW` without enqueuing a review.
+- [ ] Step 4 — invocation (AC2): explicit HEAD sha + explicit absolute `--repo` + `--wait`; refuse when
+      only one of `--agent`/`--model` is supplied; never bare `--branch`, never the two-positional range form.
+- [ ] Step 5 — reviewed-SHA assert (AC2): parse `Enqueued job <N> for <sha>`, require a prefix match with
+      HEAD; FAIL on mismatch, naming the base ref explicitly when the mismatched sha equals it; FAIL on an
+      absent/unparseable enqueue line.
+- [ ] Step 6 tier 1 (AC1, primary): a "contains no code changes to review" / "no code changes" verdict
+      against a non-empty census is a HARD FAIL.
+- [ ] Step 6 tier 2 (AC1, corroborating): read token accounting via `roborev show <N> --json` (fallback
+      `roborev list --json`); FAIL on input below threshold OR zero cached input OR output below threshold;
+      print observed-vs-threshold in the message; stamp an explicit degraded-signal notice (never a silent
+      skip) when accounting is unavailable, with tier 1 still governing.
+- [ ] Step 7 — emit the `==== ROBOREV REVIEW SUMMARY ====` block (repo, branch, head-sha, reviewed-sha,
+      job, base, census, tokens, per-check verdicts, terminal `RESULT:`), write the raw transcript to a log
+      path named in the block, and exit non-zero on any non-PASS outcome.
+- [ ] Hygiene pass: keep the script small (campsite spirit), quote every interpolation of external
+      output, and walk CLAUDE.md's pre-roborev self-check list over the diff.
+
+## 2. Hermetic regression check (surface: `scripts/tests/test_roborev_review_guard.sh`)
+- [ ] Build the stub `roborev` fixture (first on `PATH`) that replays the recorded enqueue lines, verdict
+      text, and `show --json` token payloads from the evidence table, plus throwaway `git init` fixtures
+      with a synthetic `origin` remote.
+- [ ] Case (a): enqueued sha == base ref → FAIL, message names the base ref.
+- [ ] Case (b): enqueued sha is neither endpoint → FAIL.
+- [ ] Case (c): "contains no code changes to review" against a non-empty census → FAIL.
+- [ ] Case (d): vacuous token signature (≈18k input / 0 cached / <60 output) → FAIL.
+- [ ] Case (e): unpushed branch → FAIL, no review enqueued.
+- [ ] Case (f): genuine review (matching sha, ~500k/387k/6.3k accounting) → PASS.
+- [ ] Case (g): genuinely empty census → `NOTHING-TO-REVIEW` with its own non-zero exit code, never PASS.
+- [ ] Case: unavailable token accounting → degraded-signal notice stamped, tier 1 still applied.
+- [ ] Assert the summary block's header is distinct from all three agent-gate summary headers.
+- [ ] Confirm hermeticity: no network, no real roborev, no dataset corpus; and no wall-clock threshold
+      assert in the correctness path (#2642).
+
+## 3. Gate wiring (surface: `scripts/agent-gate.sh`)
+- [ ] Register the check in `run_roborev_lints_cmd()` (component `roborev-lints`, present in BOTH
+      `LITE_COMPONENTS` and `COMPONENTS`) so a regression FAILs the fast `--lite` loop — the stated
+      acceptance goal — following the existing `check-workflow-injection.sh` / `check-no-wallclock-asserts.sh`
+      chaining pattern.
+- [ ] Append the check to `run_tooling_tests()` (full-gate `tooling-tests`) following the
+      `test_check_dockerfile_rust_pin.sh` / `test_check_skill_flag_tables.sh` guard pattern (FAIL the
+      component on non-zero, with a named failure line).
+- [ ] Verify runtime is fast enough for `--lite` and that `scripts/agent-gate.sh --list` /
+      `--lite-list` still reflect the intended component set.
+
+## 4. Call-site migration (surface: `.claude/skills/**`, `.claude/agents/**`)
+- [ ] `.claude/skills/flow-implement/SKILL.md` — the review-first step (the primary call site; replaces
+      the documented bare `--branch` command).
+- [ ] `.claude/agents/flow-closer.md` — the final confirmation pass (the merge-gating call site; also
+      removes the non-existent `/roborev-review-branch` form) and treat a non-PASS terminal `RESULT`,
+      including `NOTHING-TO-REVIEW`, as a blocked merge.
+- [ ] `.claude/agents/flow-lead.md` — the stage table's roborev row.
+- [ ] `.claude/skills/{flow-activate,flow-address,flow-finalize,ci-cd-validation}/SKILL.md` — every
+      roborev reference routed through the wrapper.
+- [ ] `.claude/agents/{rust-reviewer,sstable-developer,test-validator}.md` — every roborev reference
+      routed through the wrapper.
+- [ ] Sweep for any remaining bare `--branch` roborev instruction across `.claude/**` and mark the form
+      non-sanctioned; preserve the both-`--agent`-and-`--model` requirement at every call site.
+
+## 5. Doctrine — ships in this change (AC4)
+- [ ] CLAUDE.md — update the roborev-invocation bullet in *Agent-Team Conventions*: the wrapper is the
+      only sanctioned invocation; verify the reviewed SHA; "contains no code changes to review" on a
+      non-empty diff is a HARD FAIL; docs-only diffs cannot be roborev-certified.
+- [ ] `website/src/content/docs/agents-developing/roborev-findings.md` — same four rules, plus a row in
+      the "mechanized in `--lite`" table for the new `roborev-lints` guard.
+- [ ] Verify publication by grepping the SERVED page for a distinctive new phrase (an HTTP 200 is not
+      proof; CDN staleness ≈3 min) and re-check after a wait if absent.
+
+## 6. Live worktree probe (AC5)
+- [ ] Document the probe (wrapper usage text + the doctrine page): from a real `issue-<N>-*` worktree with
+      a pushed commit and the root checkout on `main`, run the wrapper and confirm the summary block's
+      `reviewed-sha` equals the worktree HEAD and does NOT equal the base ref.
+- [ ] Run the probe once against the real binary and record the observed summary-block values (head-sha,
+      reviewed-sha, job, census, tokens) in the PR body as the AC5 live evidence.
+
+## 7. Gate + review + sign-off
+- [ ] `scripts/agent-gate.sh --lite` green each fix round (summary-file redirect; anchor the poll on
+      `RESULT: (PASS|FAIL)`).
+- [ ] `rust-reviewer` (no Rust here — skip if it has nothing to review) + roborev on the lite-green diff
+      via the NEW wrapper (review-first). Note: this change's own diff is largely docs + shell; if the
+      wrapper FAILs it as code-free, record primary-source/self-test evidence per the docs-only rule
+      instead of "roborev clean".
+- [ ] Full gate ONCE via `flow-closer`; verify `tree-integrity:` alongside `RESULT:`.
+- [ ] **C (spec-auditor)** anchored to `openspec/changes/roborev-vacuous-review-guard/specs/**`: every
+      requirement `satisfied` with public-surface (wrapper + regression-check + doctrine) evidence.
+- [ ] roborev clean or a recorded docs-only substitute; blockers fixed pre-merge, nits batched to ONE
+      linked follow-up issue.
+- [ ] File the upstream follow-up noted in `design.md` (worktree-aware `--branch` resolution; non-zero
+      exit on a discarded code-free diff) so the external-binary gap is tracked.
+- [ ] `openspec validate roborev-vacuous-review-guard --strict` clean; `openspec archive` after merge.

--- a/openspec/changes/roborev-vacuous-review-guard/tasks.md
+++ b/openspec/changes/roborev-vacuous-review-guard/tasks.md
@@ -7,7 +7,7 @@
 > and token accounting CORROBORATING and fail-closed-only. AC→requirement map is at the top of
 > `specs/roborev-review-guard/spec.md`.
 
-## 1. The sanctioned wrapper (surfaces: `scripts/flow/roborev-review.sh`, `roborev-review-oracles.sh`, `roborev-job-facts.py`)
+## 1. The sanctioned wrapper (surfaces: `scripts/flow/roborev-review.sh`, `roborev-review-oracles.sh`, `roborev-review-checks.sh`, `roborev-job-facts.py`)
 - [x] Create the wrapper skeleton: flag parsing (`--agent`, `--model`, `--repo`, `--base`, `--log`),
       absolute repo-root resolution, branch + full-40-char HEAD resolution, and the four-way exit-code
       contract (0 = PASS, 1 = FAIL, 3 = NOTHING-TO-REVIEW, 2 = usage error).
@@ -18,8 +18,12 @@
 - [x] Split the local oracles into a sourced `scripts/flow/roborev-review-oracles.sh` (push assert +
       census + code-free) resolved via `BASH_SOURCE`, and FAIL CLOSED when that file is missing OR
       truncated (a silently absent oracles file would turn both checks into no-ops).
+- [x] Split the five per-review checks into a sourced `scripts/flow/roborev-review-checks.sh`
+      (review-completed, prompt-content, findings/roborev-exit, tier 1, tier 2) when the wrapper reached
+      998 lines, resolved via `BASH_SOURCE`, FAIL CLOSED on a missing OR truncated file (each required
+      function checked), and VALIDATED BEFORE the invocation so a broken install costs no review.
 - [x] Split JSON/token decoding into `scripts/flow/roborev-job-facts.py` (`git_ref`, `status`,
-      `model`/`requested_model`, prompt, and the three-state token extraction).
+      `model`/`requested_model`, `verdict`, prompt, and the three-state token extraction).
 - [x] Step 2 — push assert (AC3) with **`git ls-remote` as the authoritative oracle**: distinct
       fail-closed causes for detached HEAD, an `ls-remote` failure (infra/auth — NOT "never pushed"), a
       branch absent on the remote, and a remote tip behind/diverged from HEAD (naming the unpushed
@@ -33,12 +37,25 @@
 - [x] Step 3b — `code-free:` as a DETERMINISTIC FAIL evaluated pre-enqueue from our own census
       classification (extension-based, with an extensionless-path assist), so `docs/foo.py` and
       `.github/**/*.yml` count as CODE and cannot produce a false code-free FAIL.
-- [x] Step 4 — invocation (AC2): explicit HEAD sha + explicit absolute `--repo` + `--wait`; refuse when
-      only one of `--agent`/`--model` is supplied; never bare `--branch`, never the two-positional range form.
-- [x] Step 5 — reviewed-SHA assert (AC2) with the job record's full-40-char `git_ref` as the oracle and
-      the stdout `Enqueued job <N> for <sha>` parse demoted to a cross-check (disagreement = NOTICE,
-      absent/unparseable announcement = FAIL, ≥7-hex-char floor, case-normalised, last announcement
-      wins with the multiplicity recorded); attribute a mismatch to the base ref or to "neither endpoint".
+- [x] Measure the invocation matrix against the real daemon (17-commit branch, 27-file census) and pick the
+      form empirically: `--branch --base <base> --repo <abs>` and `--since <base> --repo <abs>` both enqueue
+      `<base40>..<head40>` with 5/5 code files in the prompt; two positionals anchor at git's EMPTY TREE
+      (3/5); a single sha covers ONE COMMIT (3/5). Record the AC2 divergence (we implement its INTENT).
+- [x] Step 4 — invocation (AC2's intent): `--branch --base <base> --repo <abs-repo> --wait` over the census
+      RANGE; refuse when only one of `--agent`/`--model` is supplied; never `--branch` WITHOUT `--repo`,
+      never the two-positional range form, never a single sha.
+- [x] Step 5 — reviewed-RANGE assert with the job record's `git_ref` as the ONLY oracle, asserting BOTH
+      endpoints against the census range; FAIL a single-commit record even when it equals HEAD; FAIL
+      (never fall back to prose) when the record is unavailable, since a range review announces only the
+      range BASE. The stdout `Enqueued job <N> for <sha>` parse is demoted to the JOB-ID carrier
+      (absent/unparseable announcement = FAIL, ≥7-hex-char floor, case-normalised, last announcement
+      wins with the multiplicity recorded); attribute a mismatch to the base ref, the empty-tree base, or a
+      head short of the tip.
+- [x] Step 5a — `job-record:` key (`PASS` / `PASS (no token accounting in the record)` /
+      `DEGRADED (incomplete after <n>s: <fields>)` / `SKIP`), consulting BOTH payload shapes and keeping
+      only a source that yields the required fields: `show --json` returns the REVIEW row and NESTS the job
+      row under a `job` key, so prefer an id match that actually carries `git_ref`. Retract the earlier
+      async-write misdiagnosis: the record is complete in ONE read, so the poll is a 5×1s sanity retry.
 - [x] Step 5b — `model:` key surfacing `requested_model` != `model` as a loud NOTICE (not a FAIL: an
       alias resolution is legitimate and an always-red guard gets bypassed), and marking an absent model
       field UNCONFIRMED.
@@ -46,30 +63,42 @@
       `done` AND a terminal verdict marker from an allow-list); FAIL closed on an unreadable transcript,
       a non-`done` status, or no marker; NOTICE when the status is unavailable and completion rests on
       the marker alone.
-- [x] Step 6b — `prompt-content:`: assert the census's own paths appear in the prompt ACTUALLY SENT
-      (job-record `prompt`, else `roborev show <job> --prompt`), threshold-free, bounded by a named
-      constant with even sampling; an unretrievable prompt is `UNAVAILABLE`, never a FAIL or a silent skip.
+- [x] Step 6b — `prompt-content:`: assert the CODE SUBSET of the census appears in the prompt ACTUALLY SENT
+      (job-record `prompt`, else `roborev show <job> --prompt`), threshold-free, with EVERY code path checked
+      (the sampling cap removed — a partial prompt naming the sampled files passed) against exact
+      `diff --git` headers, collecting BOTH header sides so a detected rename is not a false rejection; an
+      unretrievable prompt is `FAIL (prompt unretrievable — no evidence any diff was delivered)`, with NO
+      non-failing `UNAVAILABLE` value for this key.
 - [x] Step 6c — `findings:` key plus `roborev-exit:` splitting `FINDINGS (exit N)` from `ERROR (exit N)`
       with the structured `status` as authority, so a normal findings outcome is never misreported as a
-      reviewer malfunction.
-- [x] Step 6d — tier 1 (AUTHORITATIVE, gated): anchor the match to the verdict/`Summary:` region and gate
-      it on `findings:` — `NONE`/`UNKNOWN` ⇒ HARD FAIL, `PRESENT*` ⇒ advisory NOTICE.
+      reviewer malfunction; derive PRESENT/NONE from the structured `verdict` field, scope prose to the
+      findings BLOCK (line-initial `Summary` terminator), keep the count best-effort, and FAIL a
+      contradiction as `INCONSISTENT (verdict clean|exit 0, <n> findings marker(s))`.
+- [x] Step 6d — tier 1 (AUTHORITATIVE, gated): anchor the match to the whole SUMMARY BLOCK (heading or
+      label → next heading/EOF — a region of only the lines CONTAINING `Summary:` missed the `## Summary`
+      heading form and passed a vacuous review) and gate it on `findings:` — `NONE`/`UNKNOWN` ⇒ HARD FAIL,
+      `PRESENT*` ⇒ advisory NOTICE, `INCONSISTENT` ⇒ no exemption.
 - [x] Step 6e — tier 2 (corroborating, fail-closed only): decode the doubly-encoded `token_usage` string
       and `total_output_tokens`; three-state extraction with `present-but-unparseable` ⇒ FAIL (drift);
       input floor 25,000 + `cached == 0` as the FAIL conditions with observed-vs-threshold printed; the
       output floor ADVISORY only; a degraded-signal notice (never a silent skip) when accounting is absent.
 - [x] Step 7 — emit the `==== ROBOREV REVIEW SUMMARY ====` block in its contracted key order (repo,
       branch, base, head-sha, reviewed-sha, job, model, census, tokens, push-assert, census-check,
-      code-free, sha-assert, review-completed, prompt-content, vacuity-tier1, vacuity-tier2, findings,
-      roborev-exit, log, terminal `RESULT:`), write the raw transcript to the log path named in the block,
+      code-free, job-record, sha-assert, review-completed, prompt-content, vacuity-tier1, vacuity-tier2,
+      findings, roborev-exit, log, terminal `RESULT:`), with `reviewed-sha:` carrying the
+      `<base40>..<head40>` RANGE; write the raw transcript to the log path named in the block,
       and exit non-zero on any non-PASS outcome.
-- [x] Step 7b — one verdict scan over every per-check key: `FAIL*`/`FINDINGS*`/`ERROR*` fail the run;
-      `PASS`/`NOTICE`/`UNAVAILABLE`/`SKIP` never do. Unreached checks read `SKIP`, never blank.
+- [x] Step 7b — one verdict scan over every per-check key: `FAIL*`/`FINDINGS*`/`ERROR*`/`INCONSISTENT*`
+      fail the run; `PASS*`/`NOTICE*`/`DEGRADED*`/`UNAVAILABLE`/`SKIP` never do. Unreached checks read
+      `SKIP`, never blank.
 - [x] Emit the block on EVERY verdict path including an unexpected mid-run abort (`trap … EXIT`), while
       the usage-error and `--help` paths emit NO block at all.
 - [x] Hygiene pass: keep each file small (campsite spirit), quote every interpolation of external
       output, `shellcheck -x` clean at info level across all three shell files, and walk CLAUDE.md's
       pre-roborev self-check list over the diff.
+- [x] Round-6 blocker fixes (each now a spec obligation, so a regression is a spec violation): the tier-1
+      region is the whole summary BLOCK; an unretrievable prompt FAILs; rename headers are matched on BOTH
+      sides. Plus the nested-job-row read and the checks-file split.
 
 ## 2. Hermetic regression check (surface: `scripts/tests/test_roborev_review_guard.sh`)
 - [x] Build the stub `roborev` fixture (first on `PATH`) replaying the recorded enqueue lines, verdict
@@ -78,17 +107,19 @@
       throwaway `git init` fixtures with their own local bare `origin`.
 - [x] Fixture topologies: wide + **narrow** fetch refspec (the fleet's real configuration), behind,
       upstream-named remote, unreachable remote, missing base, deleted remote branch with a stale mirror
-      ref, docs-only, mixed, workflow-yaml; plus a fixture-integrity guard so a narrow fixture that grew
-      a mirror ref cannot silently stop testing its condition.
+      ref, docs-only, mixed, workflow-yaml, renamed; plus a fixture-integrity guard so a narrow fixture
+      that grew a mirror ref cannot silently stop testing its condition.
 - [x] Case (a): reviewed sha == base ref → FAIL, message names the base ref.
-- [x] Case (b): reviewed sha is neither endpoint → FAIL.
-- [x] Case (c): a cleanliness vacuity claim against a non-empty CODE census → FAIL; plus the gated and
+- [x] Case (b): the reviewed RANGE does not match the census range at either endpoint → FAIL; a
+      SINGLE-COMMIT record equal to branch HEAD → FAIL (single-commit record, not the census range).
+- [x] Case (c): a cleanliness vacuity claim against a non-empty CODE census → FAIL, INCLUDING one whose
+      sentence sits under a `## Summary` heading; plus the gated and
       anchored complements (findings UNKNOWN → FAIL; a findings-bearing review quoting the phrase →
       NOTICE/PASS; the phrase outside the summary region → PASS).
 - [x] Case (d): vacuous token signature → FAIL, and the input floor pinned at exactly 25000.
 - [x] Case (e): unpushed branch → FAIL, no review enqueued; remote behind HEAD names the unpushed commits.
-- [x] Case (f): genuine review (matching sha, healthy accounting) → PASS, with the sanctioned argv
-      asserted (explicit sha, absolute `--repo`, both flags, no `--branch`, no two positionals).
+- [x] Case (f): genuine review (matching RANGE, healthy accounting) → PASS, with the sanctioned argv
+      asserted (`--branch` PAIRED with an absolute `--repo`, both flags, no two positionals, no single sha).
 - [x] Case (g): genuinely empty census → `NOTHING-TO-REVIEW` with its own non-zero exit code, never PASS;
       an unresolvable base and a failed `git diff` → FAIL, never `NOTHING-TO-REVIEW`.
 - [x] Code-free cases: a docs-only census FAILs deterministically (even with a clean verdict and healthy
@@ -97,13 +128,19 @@
       honoured; `ls-remote` failure → infra/auth FAIL; deleted remote branch with a stale mirror ref → FAIL.
 - [x] `review-completed` cases: a job that never finished, the #2433/#3037 model-mismatch 400, and a
       `failed` job status each must NOT reach PASS.
-- [x] `prompt-content` cases: a prompt without the census paths → FAIL; an unretrievable prompt →
-      UNAVAILABLE (visible, not a skip); a PASS reports the coverage it checked.
-- [x] `sha-assert` cases: the structured `git_ref` wins over a disagreeing stdout announcement; a 9-char
-      real-shape announcement still verifies; an uppercase announcement is normalised; a 4-hex-char
-      announcement is too short; two announcements → the last is effective.
+- [x] `prompt-content` cases: a prompt without the census code paths → FAIL; an unretrievable prompt →
+      FAIL (prompt unretrievable); a PASS reports the coverage it checked; a two-sided rename header covers
+      both `--no-renames` census paths (`PASS (2/2 …)`).
+- [x] `sha-assert` cases: the structured `git_ref` is the only scope oracle (the stdout announcement carries
+      the job id only); the real abbreviated range-base announcement parses; an uppercase announcement is
+      normalised; a 4-hex-char announcement is too short; two announcements → the last is effective.
+- [x] `job-record` cases: a complete record → `PASS`; the NESTED job row of a `show --json` payload is read
+      as a first-class source → `PASS`; an unreadable/mismatched record → `DEGRADED` plus
+      `sha-assert: FAIL (job record unavailable — reviewed range unverifiable)`.
 - [x] `findings`/`roborev-exit` cases: non-zero exit with a completed review → FINDINGS; with a failed
-      job → ERROR; zero exit → PASS; a pre-invocation failure → SKIP; key ORDER pinned.
+      job → ERROR; zero exit → PASS; a pre-invocation failure → SKIP; a clean verdict beside in-block
+      markers → `INCONSISTENT (verdict clean, …)`; exit 0 beside in-block markers → `INCONSISTENT (exit 0,
+      …)`; key ORDER pinned (including `job-record:`).
 - [x] Token cases: the real payload shape evaluates; the legacy `output_tokens` alias still resolves;
       renamed fields resolve via the alias sets; present-but-unparseable → FAIL (drift);
       `has_token_data=false` beside real counts → drift NOTICE, not a bypass; a low output count never
@@ -111,13 +148,15 @@
       clean review.
 - [x] Robustness cases: detached HEAD; a repository with no commits; `roborev` absent from PATH; an abort
       before a verdict still emits a block; option-value/option-name validation; a MISSING and a
-      TRUNCATED oracles file both FAIL closed.
+      TRUNCATED oracles file AND a missing/truncated CHECKS file all FAIL closed with no review enqueued.
 - [x] Assert the summary block's header is distinct from all three agent-gate summary headers, and that
       `--help` documents the exit codes + the live worktree probe and emits no block.
 - [x] Confirm hermeticity: no network, no real roborev, no dataset corpus, no cargo; a loud SKIP (never a
       silent pass) when python3 is unavailable; and no wall-clock threshold assert in the correctness
       path (#2642).
-- [x] Verify the suite's own strength: 258 assertions green, and 27/27 deliberate wrapper mutations killed.
+- [x] Verify the suite's own strength: 329 assertions green; deliberate wrapper mutations killed 27/27
+      (round-5 batch) and 15/15 (round-6 batch), the single round-6 survivor — the nested-job-row read — now
+      pinned by its own case.
 
 ## 3. Gate wiring (surface: `scripts/agent-gate.sh`)
 - [x] Register the check in `run_roborev_lints_cmd()` (component `roborev-lints`, present in BOTH
@@ -158,12 +197,19 @@
 
 ## 5. Doctrine — ships in this change (AC4)
 - [x] CLAUDE.md — update the roborev-invocation bullet in *Agent-Team Conventions*: the wrapper is the
-      only sanctioned invocation; verify the reviewed SHA; "contains no code changes to review" on a
-      non-empty diff is a HARD FAIL; docs-only diffs cannot be roborev-certified; plus the exit-code
-      contract and "any non-PASS `RESULT` is a blocked merge".
+      only sanctioned invocation; verify the reviewed SCOPE against the census range; "contains no code
+      changes to review" on a non-empty diff is a HARD FAIL; docs-only diffs cannot be roborev-certified;
+      plus the exit-code contract and "any non-PASS `RESULT` is a blocked merge".
 - [x] `website/src/content/docs/agents-developing/roborev-findings.md` — the same four rules, the
-      evidence (T1/T2/T3 + token tells), the live-probe procedure, and a row in the "mechanized in
+      evidence (T1/T2/T3/T4 + token tells), the live-probe procedure, and a row in the "mechanized in
       `--lite`" table for the new guard.
+- [x] Propagate the THREE measured corrections to every surface that states the rule (CLAUDE.md,
+      `roborev-findings.md`, `delivery-pipeline.md`, `pm-operating-loop.md`, `agent-machine-setup.md`):
+      the non-sanctioned form is `--branch` WITHOUT an explicit `--repo` (the old absolute ban forbade the
+      form we now use); the single-SHA form reviews ONE COMMIT (a fourth vacuity class, and AC2's letter);
+      roborev EXCLUDES non-code paths from the diff it builds. Add the `job-record:` key and the corrected
+      `prompt-content:` values wherever the block is documented, and restate the live probe in the RANGE
+      form.
 - [ ] Verify publication by grepping the SERVED page for a distinctive new phrase (an HTTP 200 is not
       proof; CDN staleness ≈3 min) and re-check after a wait if absent. **Open: post-merge, after the
       site deploys.**
@@ -171,22 +217,31 @@
 ## 6. Live worktree probe (AC5)
 - [x] Document the probe (wrapper `--help` text + the doctrine page): from a real `issue-<N>-*` worktree
       with a pushed commit and the root checkout on `main`, run the wrapper and confirm the summary
-      block's `reviewed-sha` equals the worktree HEAD and does NOT equal the base ref; re-run after any
-      roborev version bump.
-- [ ] Run the probe once against the real binary and record the observed summary-block values (head-sha,
-      reviewed-sha, job, census, tokens) in the PR body as the AC5 live evidence. **Open: needs a live
-      reviewer; the branch's own review rounds are the natural vehicle.**
+      block's `reviewed-sha` RANGE has its HEAD endpoint at the worktree HEAD and is not the base ref
+      alone; re-run after any roborev version bump. **Residual: the `--help` text still phrases step 3 as
+      `reviewed-sha == head-sha (prefix match)`, wording that predates the range form (the doctrine page
+      carries the corrected range phrasing) — a docs-only staleness in a frozen script, named in
+      `design.md`.**
+- [x] Run the probe against the real binary: round 5 executed it from this issue's own worktree and
+      produced the invocation matrix (17-commit branch, 27-file census, enqueued `git_ref` + prompt code-file
+      coverage per form), recorded in `design.md`/`proposal.md` and the spec delta. The closer mirrors the
+      observed block values into the PR body as the AC5 evidence.
 
 ## 7. Gate + review + sign-off
 - [x] `scripts/agent-gate.sh --lite` green each fix round (summary-file redirect; anchor the poll on
       `RESULT: (PASS|FAIL)`).
-- [x] Reconcile the OpenSpec change with the as-built deterministic-primary architecture (this pass), so
-      the intent audit anchors on what was actually built: every new key specified, the two evidenced
-      relaxations (input floor 25,000; the dropped output floor) recorded as decisions, and the migrated
-      surface set enumerated count-accurately (16, not the stale 10).
+- [x] Reconcile the OpenSpec change with the as-built deterministic-primary architecture (final pass), so
+      the intent audit anchors on what was actually built: the RANGE invocation and the recorded AC2
+      divergence, every new key specified (`job-record:`, the range `sha-assert:` values, the
+      `prompt-content:` FAIL values, the `INCONSISTENT` findings states), the five-file layout, the three
+      round-6 blocker fixes as spec obligations, the evidenced relaxations (input floor 25,000; the dropped
+      output floor; tier 1 gated + `UNAVAILABLE` on an absent region) recorded as decisions, and the
+      migrated surface set enumerated count-accurately (16).
 - [ ] `rust-reviewer` (no Rust here — skip if it has nothing to review) + roborev on the lite-green diff
       via the NEW wrapper (review-first). Note: this change's own diff mixes shell/python with docs, so
-      it is NOT code-free; four roborev rounds have run against it and their blockers are folded in.
+      it is NOT code-free; six roborev rounds have run against it and their blockers are folded in
+      (round-6 blockers in `21bba65`/`83129d5`). **Open: the post-round-6 re-review is the closer's final
+      roborev pass below.**
 - [ ] Full gate ONCE via `flow-closer`; verify `tree-integrity:` alongside `RESULT:`.
 - [ ] **C (spec-auditor)** anchored to `openspec/changes/roborev-vacuous-review-guard/specs/**`: every
       requirement `satisfied` with public-surface (wrapper + regression-check + doctrine) evidence.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -3968,6 +3968,14 @@ run_clippy() {
 #   * check-no-wallclock-asserts.sh — the #2642 wall-clock-race class. It already
 #     ran in the FULL gate (tooling-tests) but NOT in --lite; running it here makes
 #     the fast loop catch a reintroduced wall-clock threshold assert.
+#   * test_roborev_review_guard.sh — the #2964 VACUOUS-REVIEW class: the sanctioned
+#     wrapper scripts/flow/roborev-review.sh must fail closed on every recorded
+#     trigger that lets "roborev clean" be recorded without a review having
+#     happened. Its verdict gates a merge, so a weakened assert in it means the
+#     pipeline merges unreviewed code with no red anywhere. Hermetic (stub roborev
+#     on PATH + throwaway git fixtures; no network, no datasets, no cargo) and
+#     ~0.5s, so it belongs in the fast loop: a regression FAILs --lite instead of
+#     costing a review round.
 # Other candidate classes from the pre-roborev self-check are deliberately NOT
 # mechanized (see the taxonomy on #2656): manual_range_contains is already caught
 # by clippy; integer/decimal overflow, float-ordering-vs-Java, no-heuristics, and
@@ -3978,7 +3986,8 @@ run_clippy() {
 # and FAILs the component.
 run_roborev_lints_cmd() {
   bash "$REPO_ROOT/scripts/ci/check-workflow-injection.sh" &&
-    bash "$REPO_ROOT/scripts/tests/check-no-wallclock-asserts.sh"
+    bash "$REPO_ROOT/scripts/tests/check-no-wallclock-asserts.sh" &&
+    bash "$REPO_ROOT/scripts/tests/test_roborev_review_guard.sh"
 }
 
 run_component() { # run_component <name> <cmd...>
@@ -4633,6 +4642,28 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_check_skill_flag_tables.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (skill flag-table drift guard); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # roborev vacuous-review guard (#2964): hermetic (stub roborev first on PATH +
+  # throwaway git fixtures), no network/datasets/cargo, ~0.5s. Pins every recorded
+  # trigger that lets "roborev clean" be recorded without a review having happened
+  # (worktree bare-`--branch` enqueueing the base sha, the range form enqueueing
+  # neither endpoint, a code-free diff silently discarded, the vacuous token
+  # signature, an unpushed branch, and an empty census reported as PASS). The
+  # wrapper's verdict gates a merge, so a weakened assert means unreviewed code
+  # merges with no red anywhere. Also runs in --lite via roborev-lints; kept here so
+  # the full gate covers it in its shell-tooling component set too. A failure FAILs
+  # the component, mirroring the keyspace-scoping guard.
+  echo ">>> [$name] bash scripts/tests/test_roborev_review_guard.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_roborev_review_guard.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (roborev vacuous-review guard); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/flow/roborev-job-facts.py
+++ b/scripts/flow/roborev-job-facts.py
@@ -31,6 +31,12 @@ a `token_state` so the wrapper can tell three cases apart:
                     the tier to a non-failing UNAVAILABLE while the underlying
                     counts were the recorded vacuous baseline, and the run PASSED.
 
+`verdict` is reported because it is the STRUCTURED findings signal: measured values
+are "F" (the review reported findings) and, by symmetry, a pass letter. Deriving
+"did the reviewer find anything" from a regex over the transcript is a prose
+heuristic, and the wrapper gates its authoritative vacuity check on that answer — so
+the structured field must win wherever it exists.
+
 `has_token_data` is reported rather than obeyed: a `false` there alongside readable
 counts is itself a drift signal, and the counts are what the vacuity check needs.
 """
@@ -54,7 +60,7 @@ OUTPUT_TOKEN_KEYS = (
     "completionTokens",
 )
 TOKEN_CONTAINER_KEYS = ("token_usage", "tokenUsage", "usage", "token_counts")
-STRING_FACTS = ("git_ref", "status", "model", "requested_model")
+STRING_FACTS = ("git_ref", "status", "model", "requested_model", "verdict")
 
 
 def objects(node):

--- a/scripts/flow/roborev-job-facts.py
+++ b/scripts/flow/roborev-job-facts.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Extract the job facts `roborev-review.sh` asserts on, out of a roborev JSON payload.
+
+Usage:  roborev-job-facts.py <job-id> <facts-out> <prompt-out>   # payload on stdin
+
+Exit 0 when the job was located and a facts file was written; 1 otherwise (the
+wrapper then treats the structured data as unavailable and says so in its block).
+
+Why this is its own file (issue #2964): the wrapper is a shell script and this is
+JSON decoding — including a field that is DOUBLY encoded — so keeping it inline cost
+~75 lines of embedded python in a file already over the campsite size guidance. One
+responsibility per file: locate the job, normalise its fields, hand back `key=value`
+lines a shell can read with `sed`.
+
+TOKEN ACCOUNTING — the part that has already broken twice:
+
+* `token_usage` is a JSON-ENCODED STRING in the real payload, so it must be decoded
+  TWICE. Reading it as a nested object silently yielded no counts at all, which the
+  wrapper reported as `UNAVAILABLE` — i.e. the corroborating vacuity tier was DEAD
+  CODE on every real run.
+* the output count is `total_output_tokens`, not `output_tokens`.
+
+So this script accepts a documented ALIAS SET per count, and — critically — reports
+a `token_state` so the wrapper can tell three cases apart:
+
+    absent       no token field at all           -> legitimately UNAVAILABLE
+    parsed       counts readable                 -> the tier evaluates
+    unparseable  a token field IS present but no alias resolved to a number
+                 -> EXTERNAL-TOOL DRIFT. This is the dangerous one: before it was
+                    distinguished, any upstream rename or a `null` value degraded
+                    the tier to a non-failing UNAVAILABLE while the underlying
+                    counts were the recorded vacuous baseline, and the run PASSED.
+
+`has_token_data` is reported rather than obeyed: a `false` there alongside readable
+counts is itself a drift signal, and the counts are what the vacuity check needs.
+"""
+
+import json
+import sys
+
+INPUT_TOKEN_KEYS = ("input_tokens", "inputTokens", "prompt_tokens", "promptTokens")
+CACHED_TOKEN_KEYS = (
+    "cached_input_tokens",
+    "cachedInputTokens",
+    "cached_tokens",
+    "cache_read_tokens",
+    "cacheReadTokens",
+)
+OUTPUT_TOKEN_KEYS = (
+    "total_output_tokens",
+    "output_tokens",
+    "outputTokens",
+    "completion_tokens",
+    "completionTokens",
+)
+TOKEN_CONTAINER_KEYS = ("token_usage", "tokenUsage", "usage", "token_counts")
+STRING_FACTS = ("git_ref", "status", "model", "requested_model")
+
+
+def objects(node):
+    """Yield every dict in an arbitrarily nested JSON document."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            for found in objects(value):
+                yield found
+    elif isinstance(node, list):
+        for value in node:
+            for found in objects(value):
+                yield found
+
+
+def find_job(data, want):
+    for obj in objects(data):
+        for key in ("id", "job_id", "job"):
+            if key in obj and str(obj[key]) == want:
+                return obj
+    # A `show --json` payload may be the single job with no id echoed back.
+    for obj in objects(data):
+        if "git_ref" in obj or any(key in obj for key in TOKEN_CONTAINER_KEYS):
+            return obj
+    return None
+
+
+def token_container(job):
+    """Return (raw_present, mapping) for the job's token accounting."""
+    for key in TOKEN_CONTAINER_KEYS:
+        if key not in job:
+            continue
+        raw = job[key]
+        if isinstance(raw, str):
+            # The real payload double-encodes this. Decode again.
+            try:
+                raw = json.loads(raw)
+            except ValueError:
+                return True, None
+        if isinstance(raw, dict):
+            return True, raw
+        return True, None
+    # Some builds may inline the counts on the job itself.
+    if any(key in job for key in INPUT_TOKEN_KEYS + OUTPUT_TOKEN_KEYS):
+        return True, job
+    return False, None
+
+
+def as_int(mapping, keys):
+    for key in keys:
+        if key not in mapping:
+            continue
+        value = mapping[key]
+        if isinstance(value, bool) or value is None:
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+        if isinstance(value, str):
+            text = value.strip()
+            if text.lstrip("-").isdigit():
+                return int(text)
+    return None
+
+
+def main(argv):
+    if len(argv) != 4:
+        sys.stderr.write("usage: roborev-job-facts.py <job-id> <facts-out> <prompt-out>\n")
+        return 2
+    want, facts_path, prompt_path = argv[1], argv[2], argv[3]
+    try:
+        data = json.load(sys.stdin)
+    except ValueError:
+        return 1
+    job = find_job(data, want)
+    if job is None:
+        return 1
+
+    lines = []
+    for key in STRING_FACTS:
+        value = job.get(key)
+        if isinstance(value, str) and value.strip():
+            lines.append("%s=%s" % (key, " ".join(value.split())))
+    if isinstance(job.get("has_token_data"), bool):
+        lines.append("has_token_data=%s" % str(job["has_token_data"]).lower())
+
+    present, usage = token_container(job)
+    counts = {}
+    if usage is not None:
+        counts = {
+            "input_tokens": as_int(usage, INPUT_TOKEN_KEYS),
+            "cached_input_tokens": as_int(usage, CACHED_TOKEN_KEYS),
+            "output_tokens": as_int(usage, OUTPUT_TOKEN_KEYS),
+        }
+    # `input` and `cached` are the two counts the vacuity check asserts on, so they
+    # decide the state; `output` is advisory and may legitimately be missing.
+    readable = counts.get("input_tokens") is not None and counts.get("cached_input_tokens") is not None
+    if not present:
+        state = "absent"
+    elif readable:
+        state = "parsed"
+    else:
+        state = "unparseable"
+    lines.append("token_state=%s" % state)
+    for key in ("input_tokens", "cached_input_tokens", "output_tokens"):
+        value = counts.get(key)
+        lines.append("%s=%s" % (key, "" if value is None else value))
+
+    with open(facts_path, "w") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+    prompt = job.get("prompt")
+    if isinstance(prompt, str) and prompt.strip():
+        with open(prompt_path, "w") as handle:
+            handle.write(prompt)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/flow/roborev-job-facts.py
+++ b/scripts/flow/roborev-job-facts.py
@@ -77,10 +77,24 @@ def objects(node):
 
 
 def find_job(data, want):
+    # `roborev show <id> --json` returns a REVIEW row whose top level carries
+    # [agent, closed, created_at, id, job, job_id, output, prompt, uuid, verdict_bool]
+    # and nests the JOB row — git_ref, status, model, requested_model, token_usage,
+    # verdict — under a "job" key. Both objects answer to the same id, so returning the
+    # FIRST id match handed back the review row, which has none of the fields the
+    # asserts need. Prefer an id match that actually carries git_ref (measured, issue
+    # #2964 round 6); fall back to the first match only if none does.
+    matches = []
     for obj in objects(data):
         for key in ("id", "job_id", "job"):
-            if key in obj and str(obj[key]) == want:
-                return obj
+            if key in obj and not isinstance(obj[key], (dict, list)) and str(obj[key]) == want:
+                matches.append(obj)
+                break
+    for obj in matches:
+        if "git_ref" in obj:
+            return obj
+    if matches:
+        return matches[0]
     # A `show --json` payload may be the single job with no id echoed back. Accept that
     # ONLY when the payload IS one top-level object (codex, issue #2964 round 5): for a
     # list or a nested collection the first object carrying git_ref/token data can be an

--- a/scripts/flow/roborev-job-facts.py
+++ b/scripts/flow/roborev-job-facts.py
@@ -81,10 +81,15 @@ def find_job(data, want):
         for key in ("id", "job_id", "job"):
             if key in obj and str(obj[key]) == want:
                 return obj
-    # A `show --json` payload may be the single job with no id echoed back.
-    for obj in objects(data):
-        if "git_ref" in obj or any(key in obj for key in TOKEN_CONTAINER_KEYS):
-            return obj
+    # A `show --json` payload may be the single job with no id echoed back. Accept that
+    # ONLY when the payload IS one top-level object (codex, issue #2964 round 5): for a
+    # list or a nested collection the first object carrying git_ref/token data can be an
+    # UNRELATED or EARLIER job, and a previous review of the same range would then
+    # falsely certify the job we just enqueued.
+    if isinstance(data, dict) and (
+        "git_ref" in data or any(key in data for key in TOKEN_CONTAINER_KEYS)
+    ):
+        return data
     return None
 
 

--- a/scripts/flow/roborev-review-checks.sh
+++ b/scripts/flow/roborev-review-checks.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+# roborev-review-checks.sh — the five per-review checks behind roborev-review.sh (#2964).
+#
+# SOURCED, never executed: each function runs inside the wrapper's scope, reads its
+# state (LOG, CENSUS, BASE, census_code_paths, the JOB_* facts, the threshold
+# constants) and sets the summary key it owns. Same pattern as
+# roborev-review-oracles.sh, which holds the two LOCAL oracles (push assert + census).
+#
+# The division of labour: the ORACLES file answers "what must be reviewed, and is it
+# even reviewable" from data we obtain ourselves; THIS file answers "did a review of
+# that actually happen" from the job record and the transcript. Two DETERMINISTIC
+# checks carry the verdict — review-completed (positive evidence a review finished) and
+# prompt-content (our census's own paths inside the prompt actually sent) — with
+# findings-gated prose matching (tier 1) and token accounting (tier 2) corroborating.
+#
+# Split out of the wrapper at 998 lines to stay near the ~800 campsite guidance; the
+# wrapper FAILS CLOSED if this file is missing or does not define all five functions,
+# because a silently absent checks file would turn every one of them into a no-op while
+# the block still read PASS.
+#
+# Self-test: scripts/tests/test_roborev_review_guard.sh.
+
+# shellcheck disable=SC2034
+# ^ every variable assigned here (REVIEW_COMPLETED, PROMPT_CONTENT, FINDINGS, TIER1,
+#   TIER2, TOKENS, ROBOREV_EXIT) is READ by the sourcing wrapper, which shellcheck
+#   cannot see when it lints this fragment standalone. Lint the set together with
+#   `shellcheck -x scripts/flow/roborev-review.sh`.
+
+roborev_check_review_completed() {
+  # --- step 6a: review-completed — POSITIVE evidence that a review HAPPENED ------
+  # The allow-list of terminal verdict markers. A review that finished emits either a
+  # findings block (a Findings heading / '**Severity**:' lines) or a Summary heading —
+  # the shapes a real review actually emits. Anything else — a still-waiting job, a provider 400, a failed
+  # job — matches NOTHING here and therefore cannot reach PASS. This is the inverse of
+  # the old logic, which inferred success from the ABSENCE of a vacuous phrase.
+  # Built from the REAL transcript (MEASURED, issue #2964 round 5), not from guesses:
+  #     ## Review Findings
+  #     - **Severity**: Medium
+  #     ## Summary
+  # A finished review is identified by a Findings heading, a `**Severity**:` line, a
+  # Summary heading/label, or the older bracket / `Medium:` shapes other agents emit.
+  # Anything else — a still-waiting job, a provider 400, a failed job — matches none of
+  # them. The previous list was INVENTED rather than measured and rejected a GENUINE
+  # codex review: the false-FAIL direction that gets a guard bypassed.
+  VERDICT_MARKER_RE='^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?|\*\*severity\*\*[[:space:]]*:|^[[:space:]]*#{1,4}[[:space:]]*summary|(^|[^[:alnum:]])summary:|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): |^[[:space:]]*findings?[[:space:]:]'
+  if [ ! -r "$LOG" ]; then
+    REVIEW_COMPLETED="FAIL (transcript unreadable)"
+    DETAILS+=("ERROR: review-completed: the transcript at $LOG is not readable, so there is no evidence a review happened. Failing closed.")
+  else
+    verdict_marker=0
+    if grep -qiE "$VERDICT_MARKER_RE" "$LOG"; then
+      verdict_marker=1
+    fi
+    if [ -n "$JOB_STATUS" ] && [ "$JOB_STATUS" != "done" ]; then
+      REVIEW_COMPLETED="FAIL (job status '$JOB_STATUS' is not done)"
+      DETAILS+=("ERROR: review-completed: the job record reports status '$JOB_STATUS', not 'done', so the review did NOT complete and nothing was certified. Failing closed — the absence of a vacuous phrase is never evidence that a review happened.")
+    elif [ "$verdict_marker" -eq 0 ]; then
+      REVIEW_COMPLETED="FAIL (no terminal verdict marker)"
+      DETAILS+=("ERROR: review-completed: the transcript carries NO terminal verdict marker — no Findings heading, no '**Severity**:' line and no Summary heading/label. A still-waiting job, a provider error (for example the #2433/#3037 model-mismatch 400) and a failed job all look like this, and none of them is a review. Failing closed. Transcript: $LOG")
+    else
+      REVIEW_COMPLETED="PASS"
+      if [ -z "$JOB_STATUS" ]; then
+        DETAILS+=("NOTICE: review-completed: the job record's 'status' was unavailable, so completion rests on the transcript's terminal verdict marker alone (the weaker of the two signals).")
+      fi
+    fi
+  fi
+}
+
+roborev_check_prompt_content() {
+  # --- step 6b: prompt-content — DETERMINISTIC: did the reviewer GET the diff? ----
+  # The strongest available check: it reads the prompt actually sent to the agent and
+  # looks for OUR census's own file paths in it. Absent paths mean the reviewer never
+  # received the diff — the T1/T2 family and any future variant — threshold-free, and
+  # judged against our own authoritative census rather than the reviewer's prose.
+  # A whitespace-only prompt file is a RETRIEVAL FAILURE — reported distinctly from
+  # "the paths are absent", but still a FAIL: see below.
+  prompt_bytes=$(tr -d '[:space:]' <"$PROMPT_FILE" | wc -c | tr -d '[:space:]')
+  if [ "${prompt_bytes:-0}" -eq 0 ]; then
+    # FAIL, not a non-failing UNAVAILABLE (codex, round 6 — BLOCKER). With a NON-EMPTY
+    # code census, an unretrievable prompt means there is NO authoritative evidence the
+    # reviewer received any diff, and reporting PASS on that basis contradicts the
+    # wrapper's entire purpose. It is also not a plausible always-red risk: the prompt is
+    # measurably retrievable from the job record's `prompt` field AND from
+    # `roborev show <job> --prompt`, so an empty one is a real anomaly.
+    PROMPT_CONTENT="FAIL (prompt unretrievable — no evidence any diff was delivered)"
+    DETAILS+=("ERROR: prompt-content: the prompt sent to the reviewer could not be retrieved for job '$JOB' (tried the job record's 'prompt' field, then 'roborev show <job> --prompt'), so there is NO authoritative evidence the reviewer received the ${#census_code_paths[@]} code file(s) in this census. Failing closed: a pass here would rest on nothing.")
+  else
+    # Check the CODE subset of the census, not every path. MEASURED (issue #2964,
+    # round 5): roborev EXCLUDES non-code paths from the diff it builds — on a census of
+    # 22 markdown + 5 code files, the prompt carried diff headers for exactly the 5 code
+    # files. That is also the empirical mechanism behind the "code-free diff silently
+    # discarded" trigger: there is literally nothing left to review. Checking all 27
+    # would false-FAIL every branch that touches documentation, which is most of them.
+    # EVERY code path is checked against the prompt's actual `diff --git` HEADERS, never a
+    # bare substring (codex, round 5): sampling let a partial prompt pass by naming the
+    # sampled files, and a substring match is satisfied by any incidental mention —
+    # including this wrapper quoting a path in a comment.
+    #
+    # BOTH header sides are collected (codex, round 6 — BLOCKER): our census runs with
+    # `--no-renames`, so a rename is two paths (old + new), while the reviewer's diff may
+    # have rename detection ON and emit a single `diff --git a/old b/new` header. Matching
+    # only same-path headers therefore FALSELY REJECTED any review containing a detected
+    # rename. Extracting the path set from both sides and comparing whole-line makes the
+    # two rename behaviours agree without weakening the check to a substring test.
+    PROMPT_PATHS_FILE="$LOG.promptpaths"
+    { grep -oE '^diff --git a/[^ ]+ b/[^ ]+$' "$PROMPT_FILE" 2>/dev/null || true; } \
+      | sed -E 's|^diff --git a/([^ ]+) b/([^ ]+)$|\1\n\2|' | sort -u >"$PROMPT_PATHS_FILE"
+    checked_paths=("${census_code_paths[@]}")
+    census_total=${#census_code_paths[@]}
+    missing_paths=()
+    for census_path in "${checked_paths[@]}"; do
+      grep -Fxq -- "$census_path" "$PROMPT_PATHS_FILE" || missing_paths+=("$census_path")
+    done
+    if [ "${#missing_paths[@]}" -gt 0 ]; then
+      PROMPT_CONTENT="FAIL (${#missing_paths[@]}/${#checked_paths[@]} code census paths absent from the prompt)"
+      DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} CODE census paths appear on NEITHER side of any 'diff --git' header in the prompt actually sent to the reviewer, so the reviewer never received their diffs. The census is authoritative ($CENSUS for ${BASE}...HEAD); a prompt that does not mention its files cannot have reviewed them. Missing (first 10):")
+      printed=0
+      for census_path in "${missing_paths[@]}"; do
+        [ "$printed" -lt 10 ] || break
+        DETAILS+=("  $census_path")
+        printed=$((printed + 1))
+      done
+    else
+      PROMPT_CONTENT="PASS (${#checked_paths[@]}/$census_total code census paths present)"
+    fi
+  fi
+}
+
+roborev_check_findings() {
+  # --- step 6c: findings — STRUCTURED first, prose only inside the block ----------
+  # Tier 1 (step 6d) is gated on this answer, so deriving it from a regex over the WHOLE
+  # transcript was a real weakness (codex, round 5): incidental or QUOTED severity text
+  # such as "[Low]" anywhere in the output set findings: PRESENT, which then exempted a
+  # genuinely vacuous "no code changes" verdict from the authoritative tier-1 failure. A
+  # gate is only as strong as its input, so:
+  #   1. STRUCTURED FIRST — the job record's `verdict` field ("F" = the review reported
+  #      findings; a pass letter/true = it did not). Measured on real jobs.
+  #   2. PROSE FALLBACK IS SCOPED — only the FINDINGS BLOCK (from a `Findings`/`## Findings`
+  #      header up to the `Summary:` line) is scanned, never the whole transcript.
+  #   3. CONTRADICTIONS FAIL — "clean" (verdict pass, or exit 0) while the findings block
+  #      DOES carry severity markers is an INCONSISTENT state. It fails the run and, being
+  #      neither PRESENT nor NONE, cannot exempt tier 1 either.
+  FINDINGS_BLOCK_FILE="$LOG.findings"
+  # The block runs from a Findings heading/label to the Summary heading/label — the
+  # measured real shapes. Everything outside it (a quoted "[Low]" in prose, a severity
+  # word inside a Problem sentence) is ignored. The terminator must be a LINE-INITIAL
+  # Summary label: matched mid-sentence it closed the block early when a finding's own
+  # prose contained the word, under-counting the findings. (Under-counting is the
+  # fail-closed direction for the tier-1 gate — fewer markers make a vacuity claim MORE
+  # likely to fail — but the count is reported to a human, so it should be right.)
+  { awk 'BEGIN { inblock = 0 }
+         tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?/ { inblock = 1; next }
+         tolower($0) ~ /^[[:space:]]*findings?[[:space:]]*:/ { inblock = 1; next }
+         tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*summary/ { inblock = 0 }
+         tolower($0) ~ /^[[:space:]]*summary[[:space:]]*:/ { inblock = 0 }
+         inblock { print }' "$LOG" 2>/dev/null || true; } >"$FINDINGS_BLOCK_FILE"
+  block_marker_count=$({ grep -oiE '\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
+  block_marker_count=${block_marker_count:-0}
+
+  verdict_findings="unknown"
+  case "$JOB_VERDICT" in
+    P|p|PASS|pass|Pass|true|clean) verdict_findings="none" ;;
+    F|f|FAIL|fail|Fail|false) verdict_findings="present" ;;
+  esac
+
+  review_ran=0
+  if [ -n "$JOB_STATUS" ]; then
+    case "$JOB_STATUS" in "done") review_ran=1 ;; esac
+  elif [ "$REVIEW_COMPLETED" = "PASS" ]; then
+    review_ran=1
+  fi
+
+  if [ "$REVIEW_RC" -eq 0 ]; then
+    ROBOREV_EXIT="PASS"
+  elif [ "$review_ran" -eq 1 ]; then
+    ROBOREV_EXIT="FINDINGS (exit $REVIEW_RC)"
+    DETAILS+=("ERROR: roborev-exit: FINDINGS — 'roborev review' exited $REVIEW_RC because the review REPORTED FINDINGS. The review is GENUINE (job status '${JOB_STATUS:-unknown}') and the reviewer did NOT malfunction: do not retry it and do not bypass it. TRIAGE AND FIX the findings in the transcript ($LOG), then push and re-review. RESULT is FAIL because a review with open findings is not \"roborev clean\".")
+  else
+    ROBOREV_EXIT="ERROR (exit $REVIEW_RC)"
+    DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}'). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
+  fi
+
+  case "$verdict_findings" in
+    present)
+      if [ "$block_marker_count" -gt 0 ]; then
+        FINDINGS="PRESENT ($block_marker_count)"
+      else
+        FINDINGS="PRESENT"
+      fi
+      ;;
+    none)
+      if [ "$block_marker_count" -gt 0 ]; then
+        FINDINGS="INCONSISTENT (verdict clean, $block_marker_count findings marker(s))"
+        DETAILS+=("ERROR: findings: the job record's verdict '$JOB_VERDICT' says the review was clean, but its findings block carries $block_marker_count severity marker(s). One of the two is wrong, so the findings state is INCONSISTENT — failed closed, and it cannot exempt the tier-1 vacuity check either.")
+      else
+        FINDINGS="NONE"
+      fi
+      ;;
+    *)
+      # No structured verdict: fall back to the exit code, still refusing to trust prose
+      # over the whole transcript.
+      if [ "$ROBOREV_EXIT" = "PASS" ]; then
+        if [ "$block_marker_count" -gt 0 ]; then
+          FINDINGS="INCONSISTENT (exit 0, $block_marker_count findings marker(s))"
+          DETAILS+=("ERROR: findings: 'roborev review' exited 0 (which means no findings) while the findings block carries $block_marker_count severity marker(s), and the job record has no structured verdict to arbitrate. INCONSISTENT — failed closed, and it cannot exempt the tier-1 vacuity check.")
+        else
+          FINDINGS="NONE"
+        fi
+      else
+        case "$ROBOREV_EXIT" in
+          FINDINGS*)
+            if [ "$block_marker_count" -gt 0 ]; then
+              FINDINGS="PRESENT ($block_marker_count)"
+            else
+              FINDINGS="PRESENT"
+            fi
+            ;;
+          *) FINDINGS="UNKNOWN" ;;
+        esac
+      fi
+      ;;
+  esac
+}
+
+roborev_check_tier1() {
+  # --- step 6d: tier 1 — AUTHORITATIVE, but gated on `findings:` -----------------
+  # The reviewer's own summary claiming there are no code changes, against a census we
+  # measured as NON-EMPTY, is trigger T3 — and a merge-gating check must FAIL on it,
+  # not merely note it. But the naive form of this check false-FAILs: it once matched
+  # anywhere in the transcript, so a review that merely QUOTED the phrase was failed as
+  # vacuous (this very wrapper's diff carries the phrase in several files). Agents
+  # learning to WAIVE tier-1 failures would restore the defect the guard exists to stop.
+  #
+  # Two things make the strict version safe:
+  #   1. ANCHORING — only the verdict/summary region is matched (the lines carrying a
+  #      `Summary:`), never arbitrary finding bodies.
+  #   2. GATING ON `findings:` — the deterministic disambiguator computed in step 6c:
+  #        findings: NONE     the reviewer is CLAIMING CLEANLINESS, so the phrase is a
+  #                           VACUITY CLAIM about a non-empty census  => HARD FAIL
+  #        findings: PRESENT  the reviewer demonstrably analysed the diff and produced
+  #                           findings, so the phrase is DISCUSSION   => advisory NOTICE
+  #        findings: UNKNOWN  we cannot tell whether a review happened. Treated as
+  #                           claiming cleanliness => HARD FAIL, because fail-closed is
+  #                           the correct direction when the state is unknowable; an
+  #                           unparseable findings state must never DISARM this check.
+  # `code-free:` remains an independent, strictly earlier check (it fires pre-enqueue).
+  # The region is the whole SUMMARY BLOCK, not the lines that happen to contain
+  # "Summary:" (codex, round 6 — BLOCKER). The real format is a HEADING:
+  #     ## Summary
+  #     <blank>
+  #     <the summary prose>
+  # so a line-matching region missed the prose entirely, and a vacuous clean review whose
+  # "no code changes" sentence sits under the heading passed tier 1. The block runs from a
+  # Summary heading/label to the next heading (or EOF). A label ANYWHERE on a line also
+  # opens the region, so the older single-line "No issues found. Summary: ..." shape is
+  # still covered — the block form is a strict superset of the previous line matching.
+  VERDICT_REGION_FILE="$LOG.verdict"
+  { awk 'BEGIN { inblock = 0 }
+         tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*summary/ { inblock = 1; print; next }
+       tolower($0) ~ /(^|[^[:alnum:]])summary[[:space:]]*:/ { inblock = 1; print; next }
+         /^[[:space:]]*#{1,4}[[:space:]]*[^[:space:]]/ { inblock = 0 }
+         inblock { print }' "$LOG" 2>/dev/null || true; } >"$VERDICT_REGION_FILE"
+  if [ ! -s "$VERDICT_REGION_FILE" ]; then
+    TIER1="UNAVAILABLE"
+  elif grep -qi 'no code changes' "$VERDICT_REGION_FILE"; then
+    case "$FINDINGS" in
+      PRESENT*)
+        TIER1="NOTICE (phrase present in a findings-bearing review)"
+        DETAILS+=("NOTICE: vacuity-tier1 (advisory here, does not fail the run): the review's summary mentions 'no code changes' while the census is NON-EMPTY ($CENSUS), but the review reported findings ($FINDINGS) — so it demonstrably analysed the diff and the phrase is discussion, not a vacuity claim.")
+        ;;
+      *)
+        TIER1="FAIL (vacuous verdict vs non-empty census)"
+        DETAILS+=("ERROR: vacuity-tier1: the review's summary claims there are NO CODE CHANGES to review while the locally computed census is NON-EMPTY: $CENSUS (${BASE}...HEAD), and the review reported NO findings (findings: $FINDINGS) — so it is CLAIMING CLEANLINESS on a change it did not review. The reviewer's claim contradicts a fact we measured ourselves: this run is NOT reportable as \"roborev clean\".")
+        if [ "$FINDINGS" = "UNKNOWN" ]; then
+          DETAILS+=("ERROR: vacuity-tier1: the findings state is UNKNOWN (the reviewer errored), which is treated as claiming cleanliness — fail-closed is the correct direction when we cannot tell whether a review happened.")
+        fi
+        ;;
+    esac
+  else
+    TIER1="PASS"
+  fi
+}
+
+roborev_check_tier2() {
+  # --- step 6e: tier 2 — token accounting; drift is FAILED, absence is not -------
+  # Three distinguishable states (see scripts/flow/roborev-job-facts.py):
+  #   absent      -> UNAVAILABLE. A build that reports no token data is a legitimate
+  #                  difference, not a signal.
+  #   unparseable -> FAIL. A token field IS present but no documented alias resolved to
+  #                  a number: EXTERNAL-TOOL DRIFT. Chosen as a FAIL rather than a
+  #                  NOTICE because this is exactly how the tier was silently disarmed
+  #                  (a rename or a `null` degraded it to a non-failing UNAVAILABLE
+  #                  while the real counts were the vacuous baseline and the run
+  #                  PASSED). A drift FAIL costs one re-run after a one-line alias
+  #                  addition; a silently disarmed guard costs an unreviewed merge.
+  #   parsed      -> evaluate the thresholds.
+  case "${TOKEN_STATE:-}" in
+    parsed)
+      TOKENS="input=$TOK_IN cached=$TOK_CACHED output=${TOK_OUT:-unknown}"
+      if [ "$JOB_HAS_TOKEN_DATA" = false ]; then
+        DETAILS+=("NOTICE: vacuity-tier2: the job record says has_token_data=false yet readable counts are present — a payload inconsistency (drift signal). The counts are used, because they are what the vacuity check asserts on.")
+      fi
+      tier2_trips=()
+      if [ "$TOK_IN" -lt "$ROBOREV_VACUITY_MIN_INPUT_TOKENS" ]; then
+        tier2_trips+=("observed input=$TOK_IN < ROBOREV_VACUITY_MIN_INPUT_TOKENS=$ROBOREV_VACUITY_MIN_INPUT_TOKENS (highest observed VACUOUS run: 18801)")
+      fi
+      if [ "$TOK_CACHED" -eq 0 ]; then
+        tier2_trips+=("observed cached=$TOK_CACHED == 0 (every observed vacuous run reports exactly 0; the most false-positive-prone term, retained fail-closed)")
+      fi
+      if [ "${#tier2_trips[@]}" -gt 0 ]; then
+        TIER2="FAIL (vacuous token signature)"
+        DETAILS+=("ERROR: vacuity-tier2: the token accounting for job '$JOB' carries the vacuous signature against a NON-EMPTY census ($CENSUS):")
+        for trip in "${tier2_trips[@]}"; do
+          DETAILS+=("  $trip")
+        done
+      else
+        TIER2="PASS"
+      fi
+      # ADVISORY ONLY — never a FAIL condition (see the constants block: a genuine
+      # CLEAN review and a vacuous one emit near-identical output token counts).
+      if [ -n "$TOK_OUT" ] && [ "$TOK_OUT" -lt "$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS" ]; then
+        DETAILS+=("NOTICE: vacuity-tier2 advisory (NOT a failure condition): observed output=$TOK_OUT < ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS. Output tokens cannot discriminate a genuine CLEAN review from a vacuous one (both emit roughly 20-60), so this is reported and never asserted.")
+      fi
+      ;;
+    unparseable)
+      TOKENS="UNAVAILABLE"
+      TIER2="FAIL (token accounting present but unparseable — drift)"
+      DETAILS+=("ERROR: vacuity-tier2: job '$JOB' DOES carry token accounting, but none of the documented field aliases resolved to a number — the installed roborev build has DRIFTED from the shape this guard reads. That is failed closed on purpose: a silently unreadable payload is exactly how this tier was disarmed while the real counts were the vacuous baseline. Add the new field name to scripts/flow/roborev-job-facts.py (INPUT/CACHED/OUTPUT_TOKEN_KEYS) and re-run; do not waive it.")
+      ;;
+    absent)
+      TOKENS="UNAVAILABLE"
+      TIER2="UNAVAILABLE"
+      DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — the job record for '$JOB' carries no token accounting at all. A build that reports none is a legitimate difference, not a signal, so this is a degraded-signal notice and never a silent skip: the deterministic checks still govern, and an unavailable tier 2 can never turn a FAIL into a PASS.")
+      ;;
+    *)
+      TOKENS="UNAVAILABLE"
+      TIER2="UNAVAILABLE"
+      DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — the structured job record for '$JOB' could not be read at all (no python3, no extractor, or no matching job in 'roborev show --json' / 'roborev list --json'). DEGRADED SIGNAL, never a silent skip.")
+      ;;
+  esac
+}
+

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# roborev-review-oracles.sh — the two LOCAL oracles behind roborev-review.sh (#2964).
+#
+# SOURCED, never executed: it defines `roborev_push_assert` and `roborev_census`,
+# which run inside the wrapper's scope and use its state (REPO, BRANCH, HEAD_SHA,
+# BASE, DETAILS, the summary-state variables) and its `finish` function.
+#
+# Why these two live together, and apart from the wrapper: they are the change's
+# whole thesis in code — every claim is judged against data WE obtain, never against
+# a proxy or against the reviewer's prose. Both learned that the hard way:
+#   * push-assert read the local `refs/remotes/<remote>/<branch>` mirror, which a
+#     narrow fetch refspec never creates, so it false-FAILed 100% of the fleet. It
+#     now asks the REMOTE via `git ls-remote`.
+#   * the census discarded `git diff`'s exit status, so a FAILED diff rendered as
+#     "0 files, genuinely empty" — asserting a measurement that never happened.
+# Keeping them in one sourced file also keeps the wrapper inside the campsite size
+# guidance (issue #1116's spirit; the gate's ratchet covers .rs only).
+#
+# Self-test: scripts/tests/test_roborev_review_guard.sh (which also asserts the
+# wrapper FAILS CLOSED when this file is missing — a silently absent oracles file
+# turning both checks into no-ops would be the worst regression possible here).
+
+# shellcheck disable=SC2034
+# ^ every variable assigned in this file (PUSH_ASSERT, BASE_SHA, CENSUS_CHECK,
+#   CODE_FREE, census_*) is READ by the sourcing wrapper, which shellcheck cannot see
+#   when it lints this fragment standalone. Lint the pair with `shellcheck -x
+#   scripts/flow/roborev-review.sh` to resolve them across the source boundary.
+
+# Code-free (non-code) census classification. A census consisting ENTIRELY of prose
+# is STRUCTURALLY DISCARDED by roborev (trigger 3), so it is a DETERMINISTIC FAIL
+# condition in its own right under the `code-free:` key — never a bet on the
+# reviewer's prose happening to admit it (which is what the previous revision did:
+# it computed this classification and then used it only for wording).
+#
+# EXTENSION-BASED, with a narrow path assist. An earlier revision treated every file
+# under `docs/`, `.github/` or `.claude/` as non-code, which misclassifies
+# `docs/foo.py` and a workflow `.yml` — and now that code-free is a FAIL condition, a
+# false code-free classification is a FALSE FAIL. So the test is the file EXTENSION,
+# and the path assist covers only EXTENSIONLESS files under a prose directory
+# (`docs/LICENSE`, `openspec/NOTES`). Anything with a code-ish extension anywhere —
+# including `.github/workflows/*.yml` — counts as CODE and does not trip this key.
+CODE_FREE_EXTENSIONS="md markdown mdx txt rst adoc"
+CODE_FREE_EXTENSIONLESS_PREFIXES="openspec/ docs/ website/ .claude/"
+
+# roborev_push_assert: sets PUSH_ASSERT (and REMOTE/REMOTE_SHA); calls `finish` on
+# failure, so it never returns when the branch is not pushed.
+roborev_push_assert() {
+  # --- step 2: push assert (AC3) — before the census, so the operator gets the ---
+  # --- actionable cause ("push your commits") rather than a downstream vacuity ---
+  #
+  # THE ORACLE IS THE REMOTE, NOT THE LOCAL MIRROR (#2964 follow-up). The obvious
+  # implementation — read `refs/remotes/<remote>/<branch>` — is WRONG on this fleet
+  # and was a 100%-reproducible false FAIL: CQLite clones carry a NARROW fetch
+  # refspec
+  #     remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main
+  # so `refs/remotes/origin/*` only ever holds `origin/main` (+ `origin/HEAD`). A
+  # remote-tracking ref for a feature branch is NEVER created there, no matter how
+  # many times the branch is pushed — so "mirror ref absent" says NOTHING about
+  # whether the branch is pushed. `git ls-remote` asks the REMOTE, which is the
+  # authoritative answer, exactly as the census asks `git` locally rather than
+  # believing the reviewer's prose. A local proxy is never authority.
+  if [ "$BRANCH" = "HEAD" ]; then
+    PUSH_ASSERT="FAIL (detached HEAD)"
+    DETAILS+=("ERROR: push-assert: $REPO is on a detached HEAD, so there is no branch to assert against. Check out the issue branch. No review was enqueued.")
+    finish FAIL 1
+  fi
+
+  # Prefer the branch's CONFIGURED upstream remote; fall back to `origin`.
+  REMOTE=$(git -C "$REPO" config --get "branch.$BRANCH.remote" 2>/dev/null || printf '')
+  [ -n "$REMOTE" ] || REMOTE=origin
+
+  # NO MIRROR-REF FAST PATH. An earlier revision short-circuited when
+  # `refs/remotes/<remote>/<branch>` happened to equal HEAD; that is unsound, and the
+  # reviewer flagged it. A CACHED mirror ref survives a force-push or an outright
+  # DELETION of the remote branch, so it can equal HEAD while the remote no longer
+  # has the commit at all — the wrapper would then enqueue a review for a commit the
+  # reviewer cannot fetch, which is precisely a vacuous-review setup. `ls-remote`
+  # costs ~1s, and not trusting local proxies is this wrapper's whole point.
+  set +e
+  LS_OUT=$(git -C "$REPO" ls-remote --heads "$REMOTE" "$BRANCH" 2>&1)
+  LS_RC=$?
+  set -e
+  if [ "$LS_RC" -ne 0 ]; then
+    # NOT "never pushed" — a misattributed cause sends people to fix the wrong
+    # thing. `git` and `gh` are SEPARATE credential paths (#2942): an
+    # authenticated `gh` with an unwired git fails every remote read here.
+    PUSH_ASSERT="FAIL (ls-remote failed: infra/auth)"
+    DETAILS+=("ERROR: push-assert: 'git ls-remote --heads $REMOTE $BRANCH' exited $LS_RC, so the remote state is UNKNOWN. This is an INFRA/AUTH condition, NOT evidence that the branch is unpushed — do not 'fix' it by pushing. git and gh are separate credential paths (#2942): check network reachability and git's own credentials ('gh auth setup-git'). git said:")
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      DETAILS+=("  $line")
+    done <<<"$LS_OUT"
+    DETAILS+=("ERROR: push-assert: failing closed on an unknown remote state. No review was enqueued.")
+    finish FAIL 1
+  fi
+  REMOTE_SHA=$(printf '%s\n' "$LS_OUT" | awk -v ref="refs/heads/$BRANCH" '$2 == ref { print $1; exit }')
+  if [ -z "$REMOTE_SHA" ]; then
+    PUSH_ASSERT="FAIL (branch absent on remote $REMOTE)"
+    DETAILS+=("ERROR: push-assert: the remote '$REMOTE' has no branch '$BRANCH' (authoritative: git ls-remote) — this branch has never been pushed. The reviewer can only see what the remote has, so an unpushed branch is itself an empty-diff cause. Push it, then re-run. No review was enqueued.")
+    finish FAIL 1
+  fi
+  if [ "$REMOTE_SHA" != "$HEAD_SHA" ]; then
+    PUSH_ASSERT="FAIL (unpushed commits)"
+    DETAILS+=("ERROR: push-assert: $REMOTE/$BRANCH is at $REMOTE_SHA (authoritative: git ls-remote) but local HEAD is $HEAD_SHA.")
+    unpushed=""
+    if git -C "$REPO" cat-file -e "${REMOTE_SHA}^{commit}" 2>/dev/null; then
+      unpushed=$(git -C "$REPO" log --oneline "$REMOTE_SHA..HEAD" 2>/dev/null || printf '')
+    fi
+    if [ -n "$unpushed" ]; then
+      DETAILS+=("ERROR: push-assert: unpushed commit(s):")
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        DETAILS+=("  $line")
+      done <<<"$unpushed"
+    else
+      DETAILS+=("ERROR: push-assert: local HEAD is not a descendant of the remote tip (or the remote tip is not present locally) — the branch has diverged; reconcile before reviewing.")
+    fi
+    DETAILS+=("ERROR: push-assert: push the branch before reviewing. No review was enqueued.")
+    finish FAIL 1
+  fi
+  PUSH_ASSERT="PASS"
+}
+
+# roborev_census: sets BASE_SHA, CENSUS, CENSUS_CHECK, CODE_FREE and the
+# census_* / census_paths state; calls `finish` on failure or an empty census.
+roborev_census() {
+  # --- step 3: the local diff census — THE ORACLE -------------------------------
+  # `<base>` (default `origin/main`) IS a local mirror ref, so it can be stale or —
+  # on a narrow-refspec clone that has never fetched — absent. Fail CLOSED: an
+  # unresolvable base must never be allowed to produce an empty census, which would
+  # surface as NOTHING-TO-REVIEW and read as "nothing to look at" rather than "we
+  # could not tell". No implicit `git fetch` is performed on the caller's behalf.
+  BASE_SHA=""
+  if ! BASE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "${BASE}^{commit}"); then
+    CENSUS_CHECK="FAIL (base '$BASE' unresolvable)"
+    DETAILS+=("ERROR: census: base ref '$BASE' does not resolve to a commit in $REPO, so the census — and therefore every vacuity judgement — would be unfounded. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW: an unresolvable base is 'we cannot tell', never 'there is nothing to review'. If '$BASE' is a remote-tracking ref, this clone may have a narrow fetch refspec or have never fetched it; fetch it yourself (the wrapper never fetches behind your back) and re-run. No review was enqueued.")
+    finish FAIL 1
+  fi
+
+  # `--no-renames` on purpose: with rename detection a renamed file is reported as the
+  # composite path `dir/{old => new}.rs`, which is not a real path and so can never be
+  # found in the reviewer's prompt (the prompt-content check below matches literal
+  # paths). Splitting a rename into its delete+add pair keeps every census path a real
+  # one, at the cost of counting it as two files.
+  # A FAILED `git diff` must NEVER alias to "genuinely empty". Discarding the exit
+  # status here would assert a measurement that never happened — the same epistemic
+  # error as reading a mirror ref instead of the remote — and it would surface as
+  # NOTHING-TO-REVIEW, i.e. "there is nothing to look at" instead of "we could not
+  # tell". Capture the status and fail CLOSED on it.
+  set +e
+  NUMSTAT=$(git -C "$REPO" diff --numstat --no-renames "${BASE}...HEAD" 2>&1)
+  DIFF_RC=$?
+  set -e
+  if [ "$DIFF_RC" -ne 0 ]; then
+    CENSUS_CHECK="FAIL (git diff failed)"
+    DETAILS+=("ERROR: census: 'git diff --numstat --no-renames ${BASE}...HEAD' exited $DIFF_RC in $REPO, so the census was never measured. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW — an unmeasurable diff is 'we cannot tell', never 'there is nothing to review'. git said:")
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      DETAILS+=("  $line")
+    done <<<"$NUMSTAT"
+    finish FAIL 1
+  fi
+
+  census_files=0
+  census_added=0
+  census_deleted=0
+  census_non_code_files=0
+  census_paths=()
+  while IFS=$'\t' read -r add del path; do
+    [ -n "${path:-}" ] || continue
+    if [ "$add" = "-" ]; then add=0; fi
+    if [ "$del" = "-" ]; then del=0; fi
+    census_files=$((census_files + 1))
+    census_paths+=("$path")
+    census_added=$((census_added + add))
+    census_deleted=$((census_deleted + del))
+    # Non-code classification: a documented prose EXTENSION, or an EXTENSIONLESS file
+    # under a documented prose directory. Anything else — including `docs/foo.py` and
+    # `.github/workflows/*.yml` — is code.
+    file_non_code=0
+    ext=""
+    case "$path" in *.*) ext="${path##*.}" ;; esac
+    if [ -n "$ext" ]; then
+      # shellcheck disable=SC2086 # deliberate split of the space-separated constant
+      for candidate in $CODE_FREE_EXTENSIONS; do
+        if [ "$ext" = "$candidate" ]; then file_non_code=1; fi
+      done
+    else
+      # shellcheck disable=SC2086 # deliberate split of the space-separated constant
+      for prefix in $CODE_FREE_EXTENSIONLESS_PREFIXES; do
+        case "$path" in "$prefix"*) file_non_code=1 ;; esac
+      done
+    fi
+    if [ "$file_non_code" -eq 1 ]; then census_non_code_files=$((census_non_code_files + 1)); fi
+  done <<<"$NUMSTAT"
+
+  census_noun="files"
+  if [ "$census_files" -eq 1 ]; then census_noun="file"; fi
+  CENSUS="$census_files $census_noun, +$census_added/-$census_deleted"
+
+  if [ "$census_files" -eq 0 ]; then
+    CENSUS_CHECK="FAIL (empty census)"
+    DETAILS+=("NOTHING-TO-REVIEW: the local diff census for '${BASE}...HEAD' is genuinely empty (0 files changed), so no review was enqueued. This is explicitly NOT a pass and MUST NOT be recorded as \"roborev clean\".")
+    finish NOTHING-TO-REVIEW 3
+  fi
+  CENSUS_CHECK="PASS"
+
+  # --- step 3b: code-free census — a DETERMINISTIC FAIL, before any review ------
+  # roborev structurally DISCARDS a code-free diff, so such a diff cannot be certified
+  # by roborev at all (this change's own spec requirement, and CLAUDE.md rule 4). That
+  # is a property of OUR census, measured locally — it must not depend on the reviewer
+  # admitting it in prose, which is what the previous revision bet on.
+  if [ "$census_non_code_files" -eq "$census_files" ]; then
+    CODE_FREE="FAIL (code-free census: $census_non_code_files/$census_files files are documentation/specification text)"
+    DETAILS+=("ERROR: code-free: every file in the census ($CENSUS for ${BASE}...HEAD) is documentation/specification prose, and roborev STRUCTURALLY DISCARDS a code-free diff — so this diff CANNOT be certified by roborev at all, whatever verdict it returns. The sanctioned substitute is primary-source verification recorded in the PR (for example 'git show cassandra-5.0.8:<path>' for the source the docs describe). A docs-only change must NEVER record \"roborev clean\".")
+    DETAILS+=("ERROR: code-free: no review was enqueued, because a passing verdict on this diff would be meaningless.")
+    finish FAIL 1
+  fi
+  CODE_FREE="PASS"
+  CODE_FREE="PASS"
+}

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -191,7 +191,14 @@ roborev_census() {
         case "$path" in "$prefix"*) file_non_code=1 ;; esac
       done
     fi
-    if [ "$file_non_code" -eq 1 ]; then census_non_code_files=$((census_non_code_files + 1)); fi
+    if [ "$file_non_code" -eq 1 ]; then
+    census_non_code_files=$((census_non_code_files + 1))
+  else
+    # The CODE subset is what the reviewer is actually sent: roborev EXCLUDES
+    # non-code paths from the diff it builds (measured — see the wrapper's
+    # prompt-content step), so only these paths can be looked for in the prompt.
+    census_code_paths+=("$path")
+  fi
   done <<<"$NUMSTAT"
 
   census_noun="files"
@@ -217,5 +224,4 @@ roborev_census() {
     finish FAIL 1
   fi
   CODE_FREE="PASS"
-  CODE_FREE="PASS"
-}
+  }

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -8,19 +8,30 @@
 # A vacuous review — one where roborev reviewed NOTHING — is textually identical to
 # a genuine clean one ("No issues found"), so "roborev clean" can be satisfied
 # without a review having happened and the pipeline merges unreviewed code with no
-# red anywhere. Three confirmed triggers:
+# red anywhere. FOUR confirmed triggers (the fourth, the partial review, was found by
+# this wrapper's own live probe and was not anticipated by issue #2964):
 #
-#   1. bare `--branch` from inside a git WORKTREE resolves against the ROOT
-#      checkout (which normally sits on `main`), so the enqueued commit is
-#      `origin/main` and the branch's own change is never seen. Worktrees are not
-#      in `roborev repo list`, and `roborev repo` has NO `add` subcommand — repos
-#      self-register on first use — so there is nothing to register and no way to
-#      make the bare form worktree-correct. => bare `--branch` is NON-SANCTIONED.
-#   2. the two-positional commit-RANGE form (`roborev review <a> <b>`) has been
-#      OBSERVED enqueueing a commit that is NEITHER endpoint. => NON-SANCTIONED.
-#   3. a code-free (docs/spec/workflow-only) diff is STRUCTURALLY DISCARDED and
-#      still reported as "No issues found" — with the CORRECT sha enqueued, so no
-#      sha check can catch it. => a docs-only diff CANNOT be roborev-certified at
+#   1. `--branch` WITHOUT an explicit `--repo`, from inside a git WORKTREE, resolves
+#      against the ROOT checkout (which normally sits on `main`), so the enqueued
+#      commit is `origin/main` and the branch's own change is never seen. An explicit
+#      `--repo` IS what makes `--branch` correct (measured: it then reported
+#      "17 commits since origin/main" and recorded `<base40>..<head40>`), so the
+#      sanctioned form is `--branch --base <base> --repo <abs>` and it is `--branch`
+#      WITHOUT `--repo` that is NON-SANCTIONED. (Registering the worktree is not an
+#      option and is not needed: `roborev repo` has no `add` subcommand — repos
+#      self-register on first use.)
+#   2. the two-positional commit-RANGE form (`roborev review <a> <b>`) bases the diff
+#      on git's EMPTY-TREE hash (measured `git_ref` =
+#      `4b825dc642cb6eb9a060e54bf8d69288fbee4904..<head>`), so the reviewer sees a
+#      fraction of the real change. => NON-SANCTIONED.
+#   3. the single-SHA form (`roborev review <sha>`) reviews ONE COMMIT, not the
+#      branch: on a multi-commit branch it certifies the branch from its last commit
+#      alone — a PARTIAL review reported as a complete one. => NON-SANCTIONED.
+#   4. a code-free (docs/spec/workflow-only) diff is DISCARDED and still reported as
+#      "No issues found" — with the CORRECT sha enqueued, so no sha check can catch
+#      it. Mechanism MEASURED: roborev omits non-code paths from the diff it builds
+#      (on a census of 22 markdown + 5 code files the prompt carried diff headers for
+#      exactly the 5 code files), so a docs-only diff leaves nothing to review. => a docs-only diff CANNOT be roborev-certified at
 #      all; the sanctioned substitute is primary-source verification recorded in
 #      the PR (e.g. `git show cassandra-5.0.8:<path>`).
 #
@@ -69,14 +80,33 @@
 #   findings: / roborev-exit: / log:
 #   RESULT: PASS|FAIL|NOTHING-TO-REVIEW
 #
-# Per-check values are PASS | FAIL | SKIP | UNAVAILABLE (a FAIL may carry a
-# parenthesised reason). `census:` is `<N> file(s), +<A>/-<D>`; `tokens:` is
-# `input=<n> cached=<n> output=<n>` or `UNAVAILABLE`. `findings:` is
-# `NONE | PRESENT [(<n>)] | UNKNOWN`. `roborev-exit:` is `PASS | FINDINGS (exit N) |
-# ERROR (exit N) | SKIP` — FINDINGS means the reviewer RAN and reported findings (a
-# GENUINE review to triage and fix), ERROR means the reviewer itself failed.
-# `vacuity-tier1:` is ADVISORY and adds `NOTICE (...)` to the value set; a NOTICE
-# never fails the run.
+# Per-check values, as built:
+#   push-assert / census-check / code-free / review-completed  PASS | FAIL (...) | SKIP
+#   job-record        PASS | PASS (no token accounting in the record) |
+#                     DEGRADED (incomplete after <n> retries: <fields>) | SKIP
+#   sha-assert        PASS | FAIL (...) | SKIP
+#   prompt-content    PASS (<k>/<n> code census paths present) |
+#                     FAIL (<k>/<n> code census paths absent from the prompt) |
+#                     FAIL (prompt unretrievable — ...) | SKIP
+#   vacuity-tier1     PASS | FAIL (vacuous verdict vs non-empty census) |
+#                     NOTICE (phrase present in a findings-bearing review) |
+#                     UNAVAILABLE | SKIP        (ADVISORY when it is a NOTICE)
+#   vacuity-tier2     PASS | FAIL (...) | UNAVAILABLE | SKIP
+#   findings          NONE | PRESENT [(<n>)] | INCONSISTENT (...) | UNKNOWN | SKIP
+#   roborev-exit      PASS | FINDINGS (exit N) | ERROR (exit N) | SKIP
+#   model             <model> | <model> (SUBSTITUTED — requested '<r>') |
+#                     <model> (UNCONFIRMED — no model field in the job record) | -
+#   census            `<N> file(s), +<A>/-<D>` | -
+#   tokens            `input=<n> cached=<n> output=<n>` | UNAVAILABLE
+# FINDINGS means the reviewer RAN and reported findings (a GENUINE review to triage and
+# fix); ERROR means the reviewer itself failed; INCONSISTENT means a "clean" signal is
+# contradicted by markers in the findings block.
+#
+# THE VERDICT SCAN: a key fails the run when its value starts with FAIL, FINDINGS,
+# ERROR or INCONSISTENT. PASS, SKIP, UNAVAILABLE, NOTICE and DEGRADED never do —
+# NOTICE is tier 1's advisory value, and DEGRADED reports an incomplete job record
+# whose consequences are carried by the dependent asserts (which fail on their own
+# terms).
 #
 # WHICH CHECKS CARRY THE VERDICT. The DETERMINISTIC ones, each judged against data we
 # obtained ourselves: `push-assert` (the remote, via ls-remote), `census-check` (our
@@ -163,13 +193,13 @@ ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=200
 # now checked against its exact `diff --git` header, cheap even for a 500-file diff, and
 # sampling was a hole — a partial prompt naming just the sampled files passed.)
 
-# The job record is written ASYNCHRONOUSLY: measured empty for git_ref/status/model/
-# token_usage the instant `--wait` returned — which turned out NOT to be an async
-# durability problem at all (round 6): `roborev show --json` nests the JOB row under a
-# "job" key and the extractor was matching the outer REVIEW row, which carries none of
-# those fields. With the nested row read as a first-class source the record is complete
-# in ONE read, so this is now a short SANITY retry rather than a wait: 5 x 1s. It still
-# fails closed if the record genuinely cannot be read.
+# Job-record read retries. There is NO asynchronous write to wait out (an earlier
+# diagnosis to that effect was wrong and is retracted): `roborev show <id> --json`
+# nests the job row under a "job" key while `roborev list --json` carries the same
+# fields at top level, and the extractor was matching the outer REVIEW row. With the
+# nested row preferred the record is complete in ONE read, so this is a short SANITY
+# retry (transient read failure, not-yet-terminal status): 5 x 1s. It still fails
+# closed if the record genuinely cannot be read.
 # Overridable ONLY as a timing knob (the hermetic self-test shortens it). Shortening
 # it can never weaken a check: fewer polls can only make the record MORE likely to be
 # reported DEGRADED, which is the fail-closed direction.
@@ -225,12 +255,21 @@ a worktree; the gate's hermetic check uses a stub reviewer.
   2. From a real issue worktree on its own branch, with its commit PUSHED:
        cd /path/to/cqlite-wt/issue-<N>
        $PROGNAME --agent codex --model gpt-5.6-sol
-  3. In the emitted block assert: head-sha == the worktree branch HEAD;
-     reviewed-sha == head-sha (prefix match); reviewed-sha != git rev-parse
-     origin/main; sha-assert: PASS; census matching
-     'git diff --numstat origin/main...HEAD'; tokens above both thresholds;
-     RESULT: PASS (exit 0). A reviewed-sha equal to origin/main means the
-     explicit-repo invocation did NOT defeat the root-checkout resolution.
+  3. In the emitted block assert the reviewed SCOPE covers the worktree, remembering
+     that reviewed-sha is a RANGE '<base40>..<head40>', never a single sha:
+       - head-sha == the worktree branch HEAD (git rev-parse HEAD);
+       - sha-assert: PASS;
+       - reviewed-sha ENDS IN that same head-sha, and its base endpoint (before '..')
+         == git rev-parse <base> — i.e. the reviewed range IS <base>...HEAD;
+       - reviewed-sha is NOT the base ref alone, and its head endpoint is NOT the base
+         sha: either means the review never reached the worktree's own commits, which
+         is the root-checkout resolution this probe exists to rule out;
+       - prompt-content: PASS with the full code census covered;
+       - census matching 'git diff --numstat --no-renames <base>...HEAD';
+       - job-record: PASS and tokens above both thresholds.
+     RESULT is PASS (exit 0) only when the review is also finding-free; a review with
+     open findings correctly reports FINDINGS and exits 1 — that is not a probe
+     failure, and the scope assertions above are what the probe is for.
   4. Record the observed head-sha/reviewed-sha/job/census/tokens in the PR body,
      and re-run the probe after any roborev version bump.
 EOF
@@ -548,14 +587,21 @@ extract_job_facts() { # extract_job_facts <job> <json> <facts-out> <prompt-out>
 
 fact() { sed -n "s/^$1=//p" "$FACTS_FILE" | head -1; }
 
-# THE JOB RECORD IS WRITTEN ASYNCHRONOUSLY (issue #2964, round 5). Measured: the
-# instant `--wait` returned, the record for a completed job had NO git_ref, NO status,
-# NO model and NO token_usage; queried moments later it had all four. `--wait`
-# returning does NOT mean the record is durable. Unpolled, that silently weakened FOUR
-# asserts at once on a NORMAL run (sha-assert fell back to prose, review-completed to
-# the transcript alone, tier 2 to UNAVAILABLE, model to UNCONFIRMED) — the same
-# "silently disarmable" class as the token-shape drift.
-# So POLL, bounded, until the fields the asserts need are present.
+# TWO PAYLOAD SHAPES, NOT AN ASYNC WRITE (issue #2964; the round-5 "the job record is
+# written asynchronously" diagnosis was WRONG and is retracted — there is no durability
+# problem and no write race). The fields were always present, one level down:
+#   * `roborev list --json` returns JOB rows with git_ref / status / model /
+#     requested_model / token_usage / verdict at TOP level.
+#   * `roborev show <id> --json` returns a REVIEW row — agent, closed, created_at, id,
+#     job, job_id, output, prompt, uuid, verdict_bool — that NESTS the job row under a
+#     `job` key. Its own `id` equals the job id, so a first-id-match lookup returned
+#     the OUTER row, which carries none of those fields; that looked like an empty
+#     record and silently weakened FOUR asserts at once on a NORMAL run (sha-assert
+#     fell back to prose, review-completed to the transcript alone, tier 2 to
+#     UNAVAILABLE, model to UNCONFIRMED).
+# roborev-job-facts.py now prefers an id match that carries `git_ref`, so the record is
+# complete in ONE read. The loop below is therefore a short SANITY RETRY (it covers a
+# transient read failure and a not-yet-terminal status), never a wait on a write race.
 record_required_present() {
   local status
   [ -n "$(fact git_ref)" ] || return 1
@@ -624,7 +670,7 @@ if [ "$announce_ok" -eq 1 ]; then
   if record_complete; then
     JOB_RECORD="PASS"
     if [ "$record_polls" -gt 0 ]; then
-      DETAILS+=("NOTICE: job-record: the record became complete only after $record_polls poll(s) (~${record_polls}s) — it is written asynchronously, so 'roborev review --wait' returning does not mean it is durable.")
+      DETAILS+=("NOTICE: job-record: the record read complete only on retry $record_polls of $JOB_RECORD_POLL_ATTEMPTS. This is a transient read, NOT an asynchronous write — the job row is present from enqueue; 'roborev list --json' carries its fields at top level and 'roborev show <id> --json' nests them under a 'job' key.")
     fi
   elif record_required_present; then
     JOB_RECORD="PASS (no token accounting in the record)"
@@ -633,8 +679,8 @@ if [ "$announce_ok" -eq 1 ]; then
     [ -n "$(fact git_ref)" ] || missing="$missing git_ref"
     [ -n "$(fact status)" ] || missing="$missing status"
     [ "$(fact token_state)" = "parsed" ] || missing="$missing token_usage"
-    JOB_RECORD="DEGRADED (incomplete after ${JOB_RECORD_POLL_ATTEMPTS}s:${missing:- none})"
-    DETAILS+=("NOTICE: job-record: DEGRADED — after ${JOB_RECORD_POLL_ATTEMPTS} poll(s) the job record for '$JOB' is still missing:${missing:- nothing}. The dependent asserts below report their own verdicts; nothing here is silently weakened.")
+    JOB_RECORD="DEGRADED (incomplete after ${JOB_RECORD_POLL_ATTEMPTS} retries:${missing:- none})"
+    DETAILS+=("NOTICE: job-record: DEGRADED — after ${JOB_RECORD_POLL_ATTEMPTS} retries at ${JOB_RECORD_POLL_INTERVAL_SECS}s the job record for '$JOB' is still missing:${missing:- nothing}. The dependent asserts below report their own verdicts; nothing here is silently weakened.")
   fi
   # The prompt may not be carried in the JSON payload; ask for it directly.
   if [ ! -s "$PROMPT_FILE" ]; then
@@ -703,7 +749,7 @@ if [ "$announce_ok" -eq 1 ]; then
     *)
       SHA_ASSERT="FAIL (job record unavailable — reviewed range unverifiable)"
       REVIEWED_SHA="-"
-      DETAILS+=("ERROR: sha-assert: the job record carries no 'git_ref' after polling (job-record: $JOB_RECORD), so the reviewed RANGE cannot be verified. The stdout announcement names only the range BASE ('$ANNOUNCED_SHA') for a range review, so prose cannot establish that branch HEAD was reviewed — this fails closed rather than accepting a check that verifies nothing. Re-run; the record is written asynchronously and is normally present within seconds.")
+      DETAILS+=("ERROR: sha-assert: the job record carries no 'git_ref' after polling (job-record: $JOB_RECORD), so the reviewed RANGE cannot be verified. The stdout announcement names only the range BASE ('$ANNOUNCED_SHA') for a range review, so prose cannot establish that branch HEAD was reviewed — this fails closed rather than accepting a check that verifies nothing. The job row is present from enqueue — 'roborev list --json' carries git_ref at top level and 'roborev show <job> --json' nests it under a 'job' key — so an absent git_ref means the record could not be READ, not that it was not yet written; re-run, and if it persists check the daemon ('roborev status').")
       ;;
   esac
 fi

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -64,7 +64,7 @@
 #
 #   ==== ROBOREV REVIEW SUMMARY ====
 #   repo: / branch: / base: / head-sha: / reviewed-sha: / job: / model: / census:
-#   tokens: / push-assert: / census-check: / code-free: / sha-assert:
+#   tokens: / push-assert: / census-check: / code-free: / job-record: / sha-assert:
 #   review-completed: / prompt-content: / vacuity-tier1: / vacuity-tier2:
 #   findings: / roborev-exit: / log:
 #   RESULT: PASS|FAIL|NOTHING-TO-REVIEW
@@ -81,9 +81,9 @@
 # WHICH CHECKS CARRY THE VERDICT. The DETERMINISTIC ones, each judged against data we
 # obtained ourselves: `push-assert` (the remote, via ls-remote), `census-check` (our
 # own git diff), `code-free` (our own census classification), `sha-assert` (the job
-# record's git_ref), `review-completed` (job status + an allow-list of terminal
-# verdict markers), `prompt-content` (our census's paths inside the prompt actually
-# sent). Prose matching (`vacuity-tier1`) and token accounting (`vacuity-tier2`)
+# record's git_ref, asserting BOTH endpoints of the reviewed range against the census
+# range), `review-completed` (job status + an allow-list of terminal verdict markers),
+# `prompt-content` (the CODE subset of our census inside the prompt actually sent). Prose matching (`vacuity-tier1`) and token accounting (`vacuity-tier2`)
 # CORROBORATE; tier 1 can only ever raise a NOTICE.
 #
 # EXIT CODES (exactly three outcomes plus a usage code)
@@ -92,8 +92,9 @@
 #                           never inferred from the absence of a bad phrase.
 #   1  FAIL               — any failed check: push-assert, census-check, code-free,
 #                           sha-assert, review-completed, prompt-content,
-#                           vacuity-tier2, or roborev-exit (FINDINGS or ERROR). Each
-#                           names itself under its own key. NOT "roborev clean".
+#                           vacuity-tier1, vacuity-tier2, findings (INCONSISTENT), or
+#                           roborev-exit (FINDINGS or ERROR). Each names itself under
+#                           its own key. NOT reportable as "roborev clean".
 #   3  NOTHING-TO-REVIEW  — the census is genuinely empty; NO review was enqueued.
 #                           DISTINCT from PASS by exit code alone, so a caller can
 #                           never mistake "nothing to review" for "reviewed clean".
@@ -164,6 +165,16 @@ ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=200
 # bounded on a 500-file diff.
 PROMPT_CONTENT_MAX_PATHS_CHECKED=40
 
+# The job record is written ASYNCHRONOUSLY: measured empty for git_ref/status/model/
+# token_usage the instant `--wait` returned, complete moments later. Poll this many
+# times at this interval before declaring the record DEGRADED. 15 x 1s is generous
+# against the observed sub-second lag while still bounded.
+# Overridable ONLY as a timing knob (the hermetic self-test shortens it). Shortening
+# it can never weaken a check: fewer polls can only make the record MORE likely to be
+# reported DEGRADED, which is the fail-closed direction.
+JOB_RECORD_POLL_ATTEMPTS=${ROBOREV_JOB_RECORD_POLL_ATTEMPTS:-15}
+JOB_RECORD_POLL_INTERVAL_SECS=${ROBOREV_JOB_RECORD_POLL_INTERVAL_SECS:-1}
+
 
 PROGNAME=$(basename "$0")
 # Resolve helpers from THIS FILE's directory (BASH_SOURCE), never $PWD: the wrapper
@@ -194,9 +205,13 @@ Outcome: one '==== ROBOREV REVIEW SUMMARY ====' block on stdout, terminal
 RESULT: PASS|FAIL|NOTHING-TO-REVIEW. Exit 0=PASS, 1=FAIL, 3=NOTHING-TO-REVIEW,
 2=usage error. Retain the block, never the transcript.
 
-Non-sanctioned forms this wrapper replaces: bare 'roborev review --branch'
-(resolves against the ROOT checkout from a worktree) and the two-positional
-commit-range form (observed enqueueing a commit that is neither endpoint).
+Sanctioned invocation (measured, issue #2964 round 5):
+  roborev review --branch --base <base> --repo <abs> --agent <a> --model <m> --wait
+which reviews the RANGE <base>..HEAD, i.e. exactly the census. Non-sanctioned:
+'--branch' WITHOUT an explicit --repo (resolves against the ROOT checkout from a
+worktree); the two-positional commit-range form (anchors the range at git's EMPTY
+TREE); and a single-sha review (covers ONE COMMIT, so it certifies a branch from
+its last commit alone).
 A docs-only diff cannot be roborev-certified at all — record primary-source
 verification in the PR instead of "roborev clean".
 
@@ -299,9 +314,11 @@ census_files=0
 # shellcheck disable=SC2034 # read in roborev-review-oracles.sh, not here
 census_non_code_files=0
 census_paths=()
+census_code_paths=()
 PUSH_ASSERT="SKIP"
 CENSUS_CHECK="SKIP"
 CODE_FREE="SKIP"
+JOB_RECORD="SKIP"
 SHA_ASSERT="SKIP"
 # The POSITIVE "a review actually happened" assert. Absence of a vacuous phrase is
 # NOT evidence a review occurred: a transcript that only says "Waiting for job N to
@@ -342,6 +359,7 @@ emit_summary() {
   printf 'push-assert: %s\n' "$PUSH_ASSERT"
   printf 'census-check: %s\n' "$CENSUS_CHECK"
   printf 'code-free: %s\n' "$CODE_FREE"
+  printf 'job-record: %s\n' "$JOB_RECORD"
   printf 'sha-assert: %s\n' "$SHA_ASSERT"
   printf 'review-completed: %s\n' "$REVIEW_COMPLETED"
   printf 'prompt-content: %s\n' "$PROMPT_CONTENT"
@@ -404,17 +422,38 @@ fi
 roborev_push_assert
 roborev_census
 
-# --- step 4: invoke by EXPLICIT sha + EXPLICIT absolute repo (AC2) ------------
+# --- step 4: invoke over the CENSUS RANGE + an EXPLICIT absolute repo (AC2) ----
 if ! command -v roborev >/dev/null 2>&1; then
   SHA_ASSERT="FAIL (roborev not on PATH)"
   DETAILS+=("ERROR: 'roborev' is not on PATH, so the review cannot be performed and the census cannot be certified. Failing closed rather than reporting a pass.")
   finish FAIL 1
 fi
 
-# NEVER a bare `--branch` (trigger 1); NEVER two positional commits (trigger 2).
+# THE SANCTIONED FORM — `--branch --base <base> --repo <abs>` — reviews the RANGE
+# `<base>..HEAD`, i.e. exactly the census. Determined EMPIRICALLY against the real
+# daemon (issue #2964, round 5); the three candidates measured on a 17-commit branch
+# whose census was 27 files (22 markdown + 5 code):
+#
+#   FORM                                              enqueued git_ref            code files in prompt
+#   --branch --base <base> --repo <abs>               <base40>..<head40>          5/5   <-- WINNER
+#   --since <base> --repo <abs>                       <base40>..<head40>          5/5   (identical)
+#   <base> <head> (two positionals)                   <EMPTY-TREE>..<head40>      3/5   BROKEN
+#   <sha> (the previously sanctioned single-sha form)  <head40>                    3/5   PARTIAL
+#
+# The single-sha form reviews ONE COMMIT. On any multi-commit branch it certified the
+# branch while the reviewer had seen only the last commit — a FOURTH vacuity class
+# (a partial review reported as a full one) that the issue never anticipated. The
+# issue's AC2 literally prescribes that form, so this fixes its INTENT (the reviewed
+# content must match the requested range), not its letter.
+#
+# `--repo` is what makes `--branch` correct from a worktree: with it, roborev
+# reported "17 commits since origin/main"; the original defect was `--branch`
+# WITHOUT `--repo`, which resolves against the ROOT checkout. NEVER the
+# two-positional range form (it anchors the range at git's EMPTY TREE).
 # The transcript goes to the log; stdout stays reserved for the summary block.
 set +e
-roborev review "$HEAD_SHA" \
+roborev review --branch \
+  --base "$BASE" \
   --repo "$REPO" \
   --agent "$AGENT" \
   --model "$MODEL" \
@@ -422,7 +461,7 @@ roborev review "$HEAD_SHA" \
 REVIEW_RC=$?
 set -e
 
-# --- step 5: reviewed-SHA assert (AC2) — STRUCTURED data is the oracle ---------
+# --- step 5: reviewed-RANGE assert (AC2) — STRUCTURED data is the oracle -------
 #
 # The job record's `git_ref` field is a FULL 40-char sha recorded by roborev itself,
 # so it is compared full-sha to full-sha. The stdout `Enqueued job <N> for <sha>`
@@ -486,11 +525,70 @@ extract_job_facts() { # extract_job_facts <job> <json> <facts-out> <prompt-out>
 
 fact() { sed -n "s/^$1=//p" "$FACTS_FILE" | head -1; }
 
+# THE JOB RECORD IS WRITTEN ASYNCHRONOUSLY (issue #2964, round 5). Measured: the
+# instant `--wait` returned, the record for a completed job had NO git_ref, NO status,
+# NO model and NO token_usage; queried moments later it had all four. `--wait`
+# returning does NOT mean the record is durable. Unpolled, that silently weakened FOUR
+# asserts at once on a NORMAL run (sha-assert fell back to prose, review-completed to
+# the transcript alone, tier 2 to UNAVAILABLE, model to UNCONFIRMED) — the same
+# "silently disarmable" class as the token-shape drift.
+# So POLL, bounded, until the fields the asserts need are present.
+read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FILE
+  local show_json list_json
+  show_json=$(roborev show "$1" --json 2>/dev/null || printf '')
+  if ! extract_job_facts "$1" "$show_json" "$FACTS_FILE" "$PROMPT_FILE"; then
+    list_json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '')
+    extract_job_facts "$1" "$list_json" "$FACTS_FILE" "$PROMPT_FILE" || return 1
+  fi
+  return 0
+}
+
+# REQUIRED to stop polling: the fields without which an assert cannot run at all.
+record_required_present() {
+  local status
+  [ -n "$(fact git_ref)" ] || return 1
+  status=$(fact status)
+  case "$status" in "done"|"failed") return 0 ;; *) return 1 ;; esac
+}
+
+# Token accounting is DESIRABLE, not required — a build may legitimately report none,
+# and waiting out the whole bound for it would cost the bound on every such run. It
+# gets ONE grace poll after the required fields land.
+record_complete() {
+  record_required_present || return 1
+  [ "$(fact token_state)" = "parsed" ] || return 1
+  return 0
+}
+
 if [ "$announce_ok" -eq 1 ]; then
-  SHOW_JSON=$(roborev show "$JOB" --json 2>/dev/null || printf '')
-  if ! extract_job_facts "$JOB" "$SHOW_JSON" "$FACTS_FILE" "$PROMPT_FILE"; then
-    LIST_JSON=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '')
-    extract_job_facts "$JOB" "$LIST_JSON" "$FACTS_FILE" "$PROMPT_FILE" || true
+  record_polls=0
+  token_grace_used=0
+  while : ; do
+    read_job_record "$JOB" || true
+    if record_complete; then break; fi
+    # Required fields present but tokens absent: spend ONE grace poll, then accept.
+    if record_required_present; then
+      if [ "$token_grace_used" -eq 1 ]; then break; fi
+      token_grace_used=1
+    fi
+    if [ "$record_polls" -ge "$JOB_RECORD_POLL_ATTEMPTS" ]; then break; fi
+    record_polls=$((record_polls + 1))
+    sleep "$JOB_RECORD_POLL_INTERVAL_SECS"
+  done
+  if record_complete; then
+    JOB_RECORD="PASS"
+    if [ "$record_polls" -gt 0 ]; then
+      DETAILS+=("NOTICE: job-record: the record became complete only after $record_polls poll(s) (~${record_polls}s) — it is written asynchronously, so 'roborev review --wait' returning does not mean it is durable.")
+    fi
+  elif record_required_present; then
+    JOB_RECORD="PASS (no token accounting in the record)"
+  else
+    missing=""
+    [ -n "$(fact git_ref)" ] || missing="$missing git_ref"
+    [ -n "$(fact status)" ] || missing="$missing status"
+    [ "$(fact token_state)" = "parsed" ] || missing="$missing token_usage"
+    JOB_RECORD="DEGRADED (incomplete after ${JOB_RECORD_POLL_ATTEMPTS}s:${missing:- none})"
+    DETAILS+=("NOTICE: job-record: DEGRADED — after ${JOB_RECORD_POLL_ATTEMPTS} poll(s) the job record for '$JOB' is still missing:${missing:- nothing}. The dependent asserts below report their own verdicts; nothing here is silently weakened.")
   fi
   # The prompt may not be carried in the JSON payload; ask for it directly.
   if [ ! -s "$PROMPT_FILE" ]; then
@@ -503,47 +601,59 @@ JOB_STATUS=$(fact status)
 JOB_MODEL=$(fact model)
 JOB_REQUESTED_MODEL=$(fact requested_model)
 JOB_HAS_TOKEN_DATA=$(fact has_token_data)
+JOB_VERDICT=$(fact verdict)
 TOKEN_STATE=$(fact token_state)
 TOK_IN=$(fact input_tokens)
 TOK_CACHED=$(fact cached_input_tokens)
 TOK_OUT=$(fact output_tokens)
 
+# The sanctioned form reviews a RANGE, so the job record's `git_ref` is
+# `<base40>..<head40>` and BOTH endpoints are asserted — strictly stronger than the
+# old single-sha equality. The stdout announcement for a range review names only the
+# range BASE ("Enqueued job N for <base>"), so it can no longer verify that HEAD was
+# reviewed at all: when the record is unavailable this assert FAILS rather than
+# falling back to a check that verifies nothing. (A single-sha `git_ref` is still
+# accepted, for a roborev build that reports one.)
 if [ "$announce_ok" -eq 1 ]; then
-  if [ -n "$JOB_GIT_REF" ]; then
-    REVIEWED_SHA="$JOB_GIT_REF"
-    if [ "$JOB_GIT_REF" = "$HEAD_SHA" ]; then
-      SHA_ASSERT="PASS"
-    else
-      SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
-      DETAILS+=("ERROR: sha-assert: the job record's git_ref '$JOB_GIT_REF' does not equal branch HEAD '$HEAD_SHA' (job $JOB).")
-      if [ "$JOB_GIT_REF" = "$BASE_SHA" ]; then
-        DETAILS+=("ERROR: sha-assert: the reviewed sha EQUALS the base ref '$BASE' ($BASE_SHA) — NO branch change was reviewed. That equality is the signature of the worktree bare-'--branch' resolution trigger, where the review resolves against the ROOT checkout instead of this worktree.")
+  case "$JOB_GIT_REF" in
+    *..*)
+      range_base="${JOB_GIT_REF%%..*}"
+      range_head="${JOB_GIT_REF##*..}"
+      REVIEWED_SHA="$JOB_GIT_REF"
+      if [ "$range_head" = "$HEAD_SHA" ] && [ "$range_base" = "$BASE_SHA" ]; then
+        SHA_ASSERT="PASS"
       else
-        DETAILS+=("ERROR: sha-assert: the reviewed sha matches NEITHER endpoint (head '$HEAD_SHA', base '$BASE' $BASE_SHA) — the signature of the non-sanctioned two-positional commit-range form.")
+        SHA_ASSERT="FAIL (reviewed range does not match ${BASE}...HEAD)"
+        DETAILS+=("ERROR: sha-assert: the reviewed range '$JOB_GIT_REF' does not match the census range: expected base '$BASE_SHA' ($BASE) and head '$HEAD_SHA' (job $JOB).")
+        if [ "$range_base" != "$BASE_SHA" ]; then
+          DETAILS+=("ERROR: sha-assert: the range BASE is '$range_base', not '$BASE_SHA'. An empty-tree base (4b825dc6...) is the signature of the non-sanctioned two-positional commit-range form.")
+        fi
+        if [ "$range_head" != "$HEAD_SHA" ]; then
+          DETAILS+=("ERROR: sha-assert: the range HEAD is '$range_head', not branch HEAD '$HEAD_SHA' — the reviewed scope stops short of the branch tip.")
+        fi
       fi
-    fi
-    if [ -n "$ANNOUNCED_SHA" ] && [ "${JOB_GIT_REF:0:${#ANNOUNCED_SHA}}" != "$ANNOUNCED_SHA" ]; then
-      DETAILS+=("NOTICE: sha-assert cross-check: stdout announced '$ANNOUNCED_SHA' but the job record's git_ref is '$JOB_GIT_REF'. The structured field is the oracle; the disagreement is recorded because it means one of the two surfaces is misreporting.")
-    fi
-  else
-    # No structured git_ref: fall back to the weaker stdout parse, and SAY SO. The
-    # real announcement carries an ABBREVIATED sha (9 chars observed), so this
-    # comparison is a prefix match in either direction — never strict equality.
-    REVIEWED_SHA="$ANNOUNCED_SHA"
-    DETAILS+=("NOTICE: sha-assert: the job record's structured 'git_ref' was unavailable, so the assert fell back to the sha announced on stdout (an abbreviated-sha prefix parse of the tool's prose — the weaker source).")
-    if [ "${HEAD_SHA:0:${#ANNOUNCED_SHA}}" = "$ANNOUNCED_SHA" ] \
-      || [ "${ANNOUNCED_SHA:0:${#HEAD_SHA}}" = "$HEAD_SHA" ]; then
-      SHA_ASSERT="PASS"
-    else
-      SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
-      DETAILS+=("ERROR: sha-assert: announced reviewed-sha '$ANNOUNCED_SHA' does not prefix-match branch HEAD '$HEAD_SHA' (job $JOB).")
-      if [ "${BASE_SHA:0:${#ANNOUNCED_SHA}}" = "$ANNOUNCED_SHA" ]; then
-        DETAILS+=("ERROR: sha-assert: the announced sha EQUALS the base ref '$BASE' ($BASE_SHA) — NO branch change was reviewed. That equality is the signature of the worktree bare-'--branch' resolution trigger.")
+      ;;
+    ?*)
+      REVIEWED_SHA="$JOB_GIT_REF"
+      if [ "$JOB_GIT_REF" = "$HEAD_SHA" ]; then
+        SHA_ASSERT="PASS"
+        DETAILS+=("NOTICE: sha-assert: the job record reports a SINGLE commit ('$JOB_GIT_REF'), not a range. It equals branch HEAD, but a single-commit review covers only that commit — prompt-content is what establishes the census was actually sent.")
       else
-        DETAILS+=("ERROR: sha-assert: the announced sha matches NEITHER endpoint (head '$HEAD_SHA', base '$BASE' $BASE_SHA) — the signature of the non-sanctioned two-positional commit-range form.")
+        SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
+        DETAILS+=("ERROR: sha-assert: the job record's git_ref '$JOB_GIT_REF' does not equal branch HEAD '$HEAD_SHA' (job $JOB).")
+        if [ "$JOB_GIT_REF" = "$BASE_SHA" ]; then
+          DETAILS+=("ERROR: sha-assert: the reviewed sha EQUALS the base ref '$BASE' ($BASE_SHA) — NO branch change was reviewed. That equality is the signature of a '--branch' review resolved against the ROOT checkout instead of this worktree.")
+        else
+          DETAILS+=("ERROR: sha-assert: the reviewed sha matches NEITHER endpoint (head '$HEAD_SHA', base '$BASE' $BASE_SHA).")
+        fi
       fi
-    fi
-  fi
+      ;;
+    *)
+      SHA_ASSERT="FAIL (job record unavailable — reviewed range unverifiable)"
+      REVIEWED_SHA="-"
+      DETAILS+=("ERROR: sha-assert: the job record carries no 'git_ref' after polling (job-record: $JOB_RECORD), so the reviewed RANGE cannot be verified. The stdout announcement names only the range BASE ('$ANNOUNCED_SHA') for a range review, so prose cannot establish that branch HEAD was reviewed — this fails closed rather than accepting a check that verifies nothing. Re-run; the record is written asynchronously and is normally present within seconds.")
+      ;;
+  esac
 fi
 
 # --- model-substitution check (review integrity) ------------------------------
@@ -607,15 +717,21 @@ if [ "${prompt_bytes:-0}" -eq 0 ]; then
   PROMPT_CONTENT="UNAVAILABLE"
   DETAILS+=("NOTICE: prompt-content: UNAVAILABLE — the prompt sent to the reviewer could not be retrieved for job '$JOB' (tried the job record's 'prompt' field, then 'roborev show <job> --prompt'). DEGRADED SIGNAL, never a silent skip: the other deterministic checks still govern and this can never upgrade a FAIL to a PASS.")
 else
+  # Check the CODE subset of the census, not every path. MEASURED (issue #2964,
+  # round 5): roborev EXCLUDES non-code paths from the diff it builds — on a census of
+  # 22 markdown + 5 code files, the prompt carried diff headers for exactly the 5 code
+  # files. That is also the empirical mechanism behind the "code-free diff silently
+  # discarded" trigger: there is literally nothing left to review. Checking all 27
+  # would false-FAIL every branch that touches documentation, which is most of them.
   checked_paths=()
-  census_total=${#census_paths[@]}
+  census_total=${#census_code_paths[@]}
   if [ "$census_total" -le "$PROMPT_CONTENT_MAX_PATHS_CHECKED" ]; then
-    checked_paths=("${census_paths[@]}")
+    checked_paths=("${census_code_paths[@]}")
   else
     sample_step=$(((census_total + PROMPT_CONTENT_MAX_PATHS_CHECKED - 1) / PROMPT_CONTENT_MAX_PATHS_CHECKED))
     sample_index=0
     while [ "$sample_index" -lt "$census_total" ]; do
-      checked_paths+=("${census_paths[$sample_index]}")
+      checked_paths+=("${census_code_paths[$sample_index]}")
       sample_index=$((sample_index + sample_step))
     done
   fi
@@ -624,8 +740,8 @@ else
     grep -Fq -- "$census_path" "$PROMPT_FILE" || missing_paths+=("$census_path")
   done
   if [ "${#missing_paths[@]}" -gt 0 ]; then
-    PROMPT_CONTENT="FAIL (${#missing_paths[@]}/${#checked_paths[@]} census paths absent from the prompt)"
-    DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} checked census paths do NOT appear in the prompt actually sent to the reviewer, so the reviewer never received this diff. The census is authoritative ($CENSUS for ${BASE}...HEAD); a prompt that does not mention its files cannot have reviewed them. Missing (first 10):")
+    PROMPT_CONTENT="FAIL (${#missing_paths[@]}/${#checked_paths[@]} code census paths absent from the prompt)"
+    DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} checked CODE census paths do NOT appear in the prompt actually sent to the reviewer, so the reviewer never received this diff. The census is authoritative ($CENSUS for ${BASE}...HEAD); a prompt that does not mention its files cannot have reviewed them. Missing (first 10):")
     printed=0
     for census_path in "${missing_paths[@]}"; do
       [ "$printed" -lt 10 ] || break
@@ -633,49 +749,95 @@ else
       printed=$((printed + 1))
     done
   else
-    PROMPT_CONTENT="PASS (${#checked_paths[@]}/$census_total census paths present)"
+    PROMPT_CONTENT="PASS (${#checked_paths[@]}/$census_total code census paths present)"
   fi
 fi
 
-# --- step 6c: findings vs reviewer error ---------------------------------------
-# roborev exits NON-ZERO when the review REPORTS FINDINGS. That is a NORMAL, GENUINE
-# outcome and must never be misreported as a reviewer malfunction: an agent told the
-# reviewer broke will retry or bypass instead of FIXING THE FINDINGS. The structured
-# `status` field is the authority for which of the two happened.
-#
-# This runs BEFORE tier 1 on purpose: `findings:` is the deterministic disambiguator
-# tier 1 is gated on (step 6d).
-findings_count=$({ grep -oiE '\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$LOG" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
+# --- step 6c: findings — STRUCTURED first, prose only inside the block ----------
+# Tier 1 (step 6d) is gated on this answer, so deriving it from a regex over the WHOLE
+# transcript was a real weakness (codex, round 5): incidental or QUOTED severity text
+# such as "[Low]" anywhere in the output set findings: PRESENT, which then exempted a
+# genuinely vacuous "no code changes" verdict from the authoritative tier-1 failure. A
+# gate is only as strong as its input, so:
+#   1. STRUCTURED FIRST — the job record's `verdict` field ("F" = the review reported
+#      findings; a pass letter/true = it did not). Measured on real jobs.
+#   2. PROSE FALLBACK IS SCOPED — only the FINDINGS BLOCK (from a `Findings`/`## Findings`
+#      header up to the `Summary:` line) is scanned, never the whole transcript.
+#   3. CONTRADICTIONS FAIL — "clean" (verdict pass, or exit 0) while the findings block
+#      DOES carry severity markers is an INCONSISTENT state. It fails the run and, being
+#      neither PRESENT nor NONE, cannot exempt tier 1 either.
+FINDINGS_BLOCK_FILE="$LOG.findings"
+{ awk 'BEGIN { inblock = 0 }
+       /^[[:space:]]*#*[[:space:]]*[Ff]indings?[[:space:]:]*$/ { inblock = 1; next }
+       /^[[:space:]]*#*[[:space:]]*[Ff]indings?:/ { inblock = 1; next }
+       /[Ss]ummary:/ { inblock = 0 }
+       inblock { print }' "$LOG" 2>/dev/null || true; } >"$FINDINGS_BLOCK_FILE"
+block_marker_count=$({ grep -oiE '\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
+block_marker_count=${block_marker_count:-0}
+
+verdict_findings="unknown"
+case "$JOB_VERDICT" in
+  P|p|PASS|pass|Pass|true|clean) verdict_findings="none" ;;
+  F|f|FAIL|fail|Fail|false) verdict_findings="present" ;;
+esac
+
+review_ran=0
+if [ -n "$JOB_STATUS" ]; then
+  case "$JOB_STATUS" in "done") review_ran=1 ;; esac
+elif [ "$REVIEW_COMPLETED" = "PASS" ]; then
+  review_ran=1
+fi
+
 if [ "$REVIEW_RC" -eq 0 ]; then
   ROBOREV_EXIT="PASS"
-  if [ "${findings_count:-0}" -gt 0 ]; then
-    # Exit 0 WITH severity markers: not the documented shape, but the markers are
-    # evidence the reviewer analysed the diff, which is what tier 1 needs to know.
-    FINDINGS="PRESENT ($findings_count)"
-  else
-    FINDINGS="NONE"
-  fi
+elif [ "$review_ran" -eq 1 ]; then
+  ROBOREV_EXIT="FINDINGS (exit $REVIEW_RC)"
+  DETAILS+=("ERROR: roborev-exit: FINDINGS — 'roborev review' exited $REVIEW_RC because the review REPORTED FINDINGS. The review is GENUINE (job status '${JOB_STATUS:-unknown}') and the reviewer did NOT malfunction: do not retry it and do not bypass it. TRIAGE AND FIX the findings in the transcript ($LOG), then push and re-review. RESULT is FAIL because a review with open findings is not \"roborev clean\".")
 else
-  review_ran=0
-  if [ -n "$JOB_STATUS" ]; then
-    case "$JOB_STATUS" in "done") review_ran=1 ;; esac
-  elif [ "$REVIEW_COMPLETED" = "PASS" ]; then
-    review_ran=1
-  fi
-  if [ "$review_ran" -eq 1 ]; then
-    ROBOREV_EXIT="FINDINGS (exit $REVIEW_RC)"
-    if [ "${findings_count:-0}" -gt 0 ]; then
-      FINDINGS="PRESENT ($findings_count)"
+  ROBOREV_EXIT="ERROR (exit $REVIEW_RC)"
+  DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}'). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
+fi
+
+case "$verdict_findings" in
+  present)
+    if [ "$block_marker_count" -gt 0 ]; then
+      FINDINGS="PRESENT ($block_marker_count)"
     else
       FINDINGS="PRESENT"
     fi
-    DETAILS+=("ERROR: roborev-exit: FINDINGS — 'roborev review' exited $REVIEW_RC because the review REPORTED FINDINGS. The review is GENUINE (job status '${JOB_STATUS:-unknown}') and the reviewer did NOT malfunction: do not retry it and do not bypass it. TRIAGE AND FIX the findings in the transcript ($LOG), then push and re-review. RESULT is FAIL because a review with open findings is not \"roborev clean\".")
-  else
-    ROBOREV_EXIT="ERROR (exit $REVIEW_RC)"
-    FINDINGS="UNKNOWN"
-    DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}'). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
-  fi
-fi
+    ;;
+  none)
+    if [ "$block_marker_count" -gt 0 ]; then
+      FINDINGS="INCONSISTENT (verdict clean, $block_marker_count findings marker(s))"
+      DETAILS+=("ERROR: findings: the job record's verdict '$JOB_VERDICT' says the review was clean, but its findings block carries $block_marker_count severity marker(s). One of the two is wrong, so the findings state is INCONSISTENT — failed closed, and it cannot exempt the tier-1 vacuity check either.")
+    else
+      FINDINGS="NONE"
+    fi
+    ;;
+  *)
+    # No structured verdict: fall back to the exit code, still refusing to trust prose
+    # over the whole transcript.
+    if [ "$ROBOREV_EXIT" = "PASS" ]; then
+      if [ "$block_marker_count" -gt 0 ]; then
+        FINDINGS="INCONSISTENT (exit 0, $block_marker_count findings marker(s))"
+        DETAILS+=("ERROR: findings: 'roborev review' exited 0 (which means no findings) while the findings block carries $block_marker_count severity marker(s), and the job record has no structured verdict to arbitrate. INCONSISTENT — failed closed, and it cannot exempt the tier-1 vacuity check.")
+      else
+        FINDINGS="NONE"
+      fi
+    else
+      case "$ROBOREV_EXIT" in
+        FINDINGS*)
+          if [ "$block_marker_count" -gt 0 ]; then
+            FINDINGS="PRESENT ($block_marker_count)"
+          else
+            FINDINGS="PRESENT"
+          fi
+          ;;
+        *) FINDINGS="UNKNOWN" ;;
+      esac
+    fi
+    ;;
+esac
 
 # --- step 6d: tier 1 — AUTHORITATIVE, but gated on `findings:` -----------------
 # The reviewer's own summary claiming there are no code changes, against a census we
@@ -782,12 +944,13 @@ esac
 # the PRESENT/NONE/UNKNOWN distinction is the load-bearing part — tier 1 is gated on it.
 #
 # Every per-check key participates in ONE scan. A key fails the run when its value
-# starts with FAIL, FINDINGS or ERROR; PASS / SKIP / UNAVAILABLE / NOTICE never do
-# (NOTICE is the advisory tier's value and is deliberately non-failing).
+# starts with FAIL, FINDINGS, ERROR or INCONSISTENT; PASS / SKIP / UNAVAILABLE /
+# NOTICE / DEGRADED never do (NOTICE is tier 1's non-failing value; DEGRADED reports
+# an incomplete job record, whose consequences are carried by the dependent asserts).
 failed=0
 for verdict in "$PUSH_ASSERT" "$CENSUS_CHECK" "$CODE_FREE" "$SHA_ASSERT" \
-  "$REVIEW_COMPLETED" "$PROMPT_CONTENT" "$TIER1" "$TIER2" "$ROBOREV_EXIT"; do
-  case "$verdict" in FAIL*|FINDINGS*|ERROR*) failed=1 ;; esac
+  "$REVIEW_COMPLETED" "$PROMPT_CONTENT" "$TIER1" "$TIER2" "$FINDINGS" "$ROBOREV_EXIT"; do
+  case "$verdict" in FAIL*|FINDINGS*|ERROR*|INCONSISTENT*) failed=1 ;; esac
 done
 
 if [ "$failed" -eq 0 ]; then

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -56,7 +56,7 @@
 #   ==== ROBOREV REVIEW SUMMARY ====
 #   repo: / branch: / base: / head-sha: / reviewed-sha: / job: / census: / tokens:
 #   push-assert: / census-check: / sha-assert: / vacuity-tier1: / vacuity-tier2:
-#   log:
+#   roborev-exit: / log:
 #   RESULT: PASS|FAIL|NOTHING-TO-REVIEW
 #
 # Per-check values are PASS | FAIL | SKIP | UNAVAILABLE (a FAIL may carry a
@@ -65,8 +65,10 @@
 #
 # EXIT CODES (exactly three outcomes plus a usage code)
 #   0  PASS               — reviewed, sha verified, no vacuity signal.
-#   1  FAIL               — any failed check (push, census, sha, tier 1, tier 2,
-#                           or a non-zero roborev exit). NOT reportable as clean.
+#   1  FAIL               — any failed check: push-assert, census-check, sha-assert,
+#                           vacuity-tier1, vacuity-tier2, or roborev-exit (the
+#                           reviewer process's own status). Each names itself under
+#                           its own key. NOT reportable as "roborev clean".
 #   3  NOTHING-TO-REVIEW  — the census is genuinely empty; NO review was enqueued.
 #                           DISTINCT from PASS by exit code alone, so a caller can
 #                           never mistake "nothing to review" for "reviewed clean".
@@ -251,6 +253,12 @@ CENSUS_CHECK="SKIP"
 SHA_ASSERT="SKIP"
 TIER1="SKIP"
 TIER2="SKIP"
+# The reviewer process's OWN exit status, under its own greppable key: a caller
+# retains only the block and reads it by grepping the per-check keys, so without
+# this key a non-zero roborev exit shows up as every check reading PASS beside a
+# RESULT: FAIL — the one failure cause a grep-based reader could not attribute.
+# SKIP until the process actually runs (a push/census/PATH failure exits earlier).
+ROBOREV_EXIT="SKIP"
 RESULT="FAIL"
 DETAILS=()
 EMITTED=0
@@ -270,6 +278,7 @@ emit_summary() {
   printf 'sha-assert: %s\n' "$SHA_ASSERT"
   printf 'vacuity-tier1: %s\n' "$TIER1"
   printf 'vacuity-tier2: %s\n' "$TIER2"
+  printf 'roborev-exit: %s\n' "$ROBOREV_EXIT"
   printf 'log: %s\n' "$LOG"
   printf 'RESULT: %s\n' "$RESULT"
 }
@@ -399,6 +408,11 @@ roborev review "$HEAD_SHA" \
   --wait >"$LOG" 2>&1
 REVIEW_RC=$?
 set -e
+if [ "$REVIEW_RC" -eq 0 ]; then
+  ROBOREV_EXIT="PASS"
+else
+  ROBOREV_EXIT="FAIL (exit $REVIEW_RC)"
+fi
 
 # --- step 5: reviewed-SHA assert (AC2) ----------------------------------------
 ANNOUNCE=$(grep -oiE 'enqueued job [0-9]+ for [0-9a-fA-F]{4,40}' "$LOG" | tail -1 || printf '')
@@ -525,11 +539,13 @@ if [ "$REVIEW_RC" -ne 0 ]; then
   DETAILS+=("ERROR: 'roborev review' exited $REVIEW_RC. A non-zero reviewer exit is a fail-closed FAIL — read the transcript at $LOG before treating anything as clean.")
 fi
 
+# `roborev-exit` participates in the SAME per-check scan as every other key, so a
+# non-zero reviewer exit forces RESULT: FAIL through the documented path rather
+# than a special case bolted on beside it.
 failed=0
-for verdict in "$PUSH_ASSERT" "$CENSUS_CHECK" "$SHA_ASSERT" "$TIER1" "$TIER2"; do
+for verdict in "$PUSH_ASSERT" "$CENSUS_CHECK" "$SHA_ASSERT" "$TIER1" "$TIER2" "$ROBOREV_EXIT"; do
   case "$verdict" in FAIL*) failed=1 ;; esac
 done
-if [ "$REVIEW_RC" -ne 0 ]; then failed=1; fi
 
 if [ "$failed" -eq 0 ]; then
   finish PASS 0

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -164,23 +164,13 @@ ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=200
 # bounded on a 500-file diff.
 PROMPT_CONTENT_MAX_PATHS_CHECKED=40
 
-# Code-free (non-code) census classification. A census consisting ENTIRELY of prose
-# is STRUCTURALLY DISCARDED by roborev (trigger 3), so it is a DETERMINISTIC FAIL
-# condition in its own right under the `code-free:` key — never a bet on the
-# reviewer's prose happening to admit it (which is what the previous revision did:
-# it computed this classification and then used it only for wording).
-#
-# EXTENSION-BASED, with a narrow path assist. An earlier revision treated every file
-# under `docs/`, `.github/` or `.claude/` as non-code, which misclassifies
-# `docs/foo.py` and a workflow `.yml` — and now that code-free is a FAIL condition, a
-# false code-free classification is a FALSE FAIL. So the test is the file EXTENSION,
-# and the path assist covers only EXTENSIONLESS files under a prose directory
-# (`docs/LICENSE`, `openspec/NOTES`). Anything with a code-ish extension anywhere —
-# including `.github/workflows/*.yml` — counts as CODE and does not trip this key.
-CODE_FREE_EXTENSIONS="md markdown mdx txt rst adoc"
-CODE_FREE_EXTENSIONLESS_PREFIXES="openspec/ docs/ website/ .claude/"
 
 PROGNAME=$(basename "$0")
+# Resolve helpers from THIS FILE's directory (BASH_SOURCE), never $PWD: the wrapper
+# is invoked from arbitrary worktrees and a $PWD-relative lookup would silently miss.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ORACLES_FILE="$SCRIPT_DIR/roborev-review-oracles.sh"
+JOB_FACTS_TOOL="$SCRIPT_DIR/roborev-job-facts.py"
 
 usage() {
   cat <<EOF
@@ -229,6 +219,7 @@ a worktree; the gate's hermetic check uses a stub reviewer.
 EOF
 }
 
+# shellcheck disable=SC2016 # the backticks in these messages are prose, not expansions
 die_usage() { # die_usage <message>
   printf 'ERROR: %s\n' "$1" >&2
   printf 'ERROR: run `%s --help` for the option contract.\n' "$PROGNAME" >&2
@@ -301,6 +292,13 @@ JOB="-"
 MODEL_LINE="-"
 CENSUS="-"
 TOKENS="UNAVAILABLE"
+# Populated by roborev_census (in the sourced oracles file); declared here so the
+# array always exists even if that oracle ever returns before filling it.
+# shellcheck disable=SC2034 # read in roborev-review-oracles.sh, not here
+census_files=0
+# shellcheck disable=SC2034 # read in roborev-review-oracles.sh, not here
+census_non_code_files=0
+census_paths=()
 PUSH_ASSERT="SKIP"
 CENSUS_CHECK="SKIP"
 CODE_FREE="SKIP"
@@ -367,6 +365,7 @@ finish() { # finish <PASS|FAIL|NOTHING-TO-REVIEW> <exit-code>
 
 # Emit a block on EVERY exit path, including an unexpected `set -e` abort: a run
 # that dies without a verdict must never look like a run that was never made.
+# shellcheck disable=SC2317 # invoked indirectly, by `trap on_exit EXIT` below
 on_exit() {
   local rc=$?
   if [ "$EMITTED" -eq 0 ]; then
@@ -385,174 +384,25 @@ if [ -z "$HEAD_SHA" ]; then
   finish FAIL 1
 fi
 
-# --- step 2: push assert (AC3) — before the census, so the operator gets the ---
-# --- actionable cause ("push your commits") rather than a downstream vacuity ---
-#
-# THE ORACLE IS THE REMOTE, NOT THE LOCAL MIRROR (#2964 follow-up). The obvious
-# implementation — read `refs/remotes/<remote>/<branch>` — is WRONG on this fleet
-# and was a 100%-reproducible false FAIL: CQLite clones carry a NARROW fetch
-# refspec
-#     remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main
-# so `refs/remotes/origin/*` only ever holds `origin/main` (+ `origin/HEAD`). A
-# remote-tracking ref for a feature branch is NEVER created there, no matter how
-# many times the branch is pushed — so "mirror ref absent" says NOTHING about
-# whether the branch is pushed. `git ls-remote` asks the REMOTE, which is the
-# authoritative answer, exactly as the census asks `git` locally rather than
-# believing the reviewer's prose. A local proxy is never authority.
-if [ "$BRANCH" = "HEAD" ]; then
-  PUSH_ASSERT="FAIL (detached HEAD)"
-  DETAILS+=("ERROR: push-assert: $REPO is on a detached HEAD, so there is no branch to assert against. Check out the issue branch. No review was enqueued.")
+# --- the local oracles (sourced) ----------------------------------------------
+# Resolved from BASH_SOURCE, never $PWD, so the wrapper works from any directory.
+# FAIL CLOSED if the file is missing or does not define both functions: an absent
+# oracles file would silently turn the push assert and the census into no-ops, which
+# is a worse failure than any this guard was built to catch.
+if [ ! -f "$ORACLES_FILE" ]; then
+  DETAILS+=("ERROR: the required oracles file '$ORACLES_FILE' is missing, so the push assert and the diff census cannot run. Failing closed rather than proceeding with those checks silently disabled — reinstall/restore scripts/flow/roborev-review-oracles.sh.")
+  finish FAIL 1
+fi
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=roborev-review-oracles.sh
+. "$ORACLES_FILE"
+if [ "$(type -t roborev_push_assert)" != function ] || [ "$(type -t roborev_census)" != function ]; then
+  DETAILS+=("ERROR: '$ORACLES_FILE' did not define roborev_push_assert and roborev_census, so the push assert and the diff census cannot run. Failing closed — the file is truncated or corrupt.")
   finish FAIL 1
 fi
 
-# Prefer the branch's CONFIGURED upstream remote; fall back to `origin`.
-REMOTE=$(git -C "$REPO" config --get "branch.$BRANCH.remote" 2>/dev/null || printf '')
-[ -n "$REMOTE" ] || REMOTE=origin
-
-# NO MIRROR-REF FAST PATH. An earlier revision short-circuited when
-# `refs/remotes/<remote>/<branch>` happened to equal HEAD; that is unsound, and the
-# reviewer flagged it. A CACHED mirror ref survives a force-push or an outright
-# DELETION of the remote branch, so it can equal HEAD while the remote no longer
-# has the commit at all — the wrapper would then enqueue a review for a commit the
-# reviewer cannot fetch, which is precisely a vacuous-review setup. `ls-remote`
-# costs ~1s, and not trusting local proxies is this wrapper's whole point.
-set +e
-LS_OUT=$(git -C "$REPO" ls-remote --heads "$REMOTE" "$BRANCH" 2>&1)
-LS_RC=$?
-set -e
-if [ "$LS_RC" -ne 0 ]; then
-  # NOT "never pushed" — a misattributed cause sends people to fix the wrong
-  # thing. `git` and `gh` are SEPARATE credential paths (#2942): an
-  # authenticated `gh` with an unwired git fails every remote read here.
-  PUSH_ASSERT="FAIL (ls-remote failed: infra/auth)"
-  DETAILS+=("ERROR: push-assert: 'git ls-remote --heads $REMOTE $BRANCH' exited $LS_RC, so the remote state is UNKNOWN. This is an INFRA/AUTH condition, NOT evidence that the branch is unpushed — do not 'fix' it by pushing. git and gh are separate credential paths (#2942): check network reachability and git's own credentials ('gh auth setup-git'). git said:")
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    DETAILS+=("  $line")
-  done <<<"$LS_OUT"
-  DETAILS+=("ERROR: push-assert: failing closed on an unknown remote state. No review was enqueued.")
-  finish FAIL 1
-fi
-REMOTE_SHA=$(printf '%s\n' "$LS_OUT" | awk -v ref="refs/heads/$BRANCH" '$2 == ref { print $1; exit }')
-if [ -z "$REMOTE_SHA" ]; then
-  PUSH_ASSERT="FAIL (branch absent on remote $REMOTE)"
-  DETAILS+=("ERROR: push-assert: the remote '$REMOTE' has no branch '$BRANCH' (authoritative: git ls-remote) — this branch has never been pushed. The reviewer can only see what the remote has, so an unpushed branch is itself an empty-diff cause. Push it, then re-run. No review was enqueued.")
-  finish FAIL 1
-fi
-if [ "$REMOTE_SHA" != "$HEAD_SHA" ]; then
-  PUSH_ASSERT="FAIL (unpushed commits)"
-  DETAILS+=("ERROR: push-assert: $REMOTE/$BRANCH is at $REMOTE_SHA (authoritative: git ls-remote) but local HEAD is $HEAD_SHA.")
-  unpushed=""
-  if git -C "$REPO" cat-file -e "${REMOTE_SHA}^{commit}" 2>/dev/null; then
-    unpushed=$(git -C "$REPO" log --oneline "$REMOTE_SHA..HEAD" 2>/dev/null || printf '')
-  fi
-  if [ -n "$unpushed" ]; then
-    DETAILS+=("ERROR: push-assert: unpushed commit(s):")
-    while IFS= read -r line; do
-      [ -n "$line" ] || continue
-      DETAILS+=("  $line")
-    done <<<"$unpushed"
-  else
-    DETAILS+=("ERROR: push-assert: local HEAD is not a descendant of the remote tip (or the remote tip is not present locally) — the branch has diverged; reconcile before reviewing.")
-  fi
-  DETAILS+=("ERROR: push-assert: push the branch before reviewing. No review was enqueued.")
-  finish FAIL 1
-fi
-PUSH_ASSERT="PASS"
-
-# --- step 3: the local diff census — THE ORACLE -------------------------------
-# `<base>` (default `origin/main`) IS a local mirror ref, so it can be stale or —
-# on a narrow-refspec clone that has never fetched — absent. Fail CLOSED: an
-# unresolvable base must never be allowed to produce an empty census, which would
-# surface as NOTHING-TO-REVIEW and read as "nothing to look at" rather than "we
-# could not tell". No implicit `git fetch` is performed on the caller's behalf.
-BASE_SHA=""
-if ! BASE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "${BASE}^{commit}"); then
-  CENSUS_CHECK="FAIL (base '$BASE' unresolvable)"
-  DETAILS+=("ERROR: census: base ref '$BASE' does not resolve to a commit in $REPO, so the census — and therefore every vacuity judgement — would be unfounded. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW: an unresolvable base is 'we cannot tell', never 'there is nothing to review'. If '$BASE' is a remote-tracking ref, this clone may have a narrow fetch refspec or have never fetched it; fetch it yourself (the wrapper never fetches behind your back) and re-run. No review was enqueued.")
-  finish FAIL 1
-fi
-
-# `--no-renames` on purpose: with rename detection a renamed file is reported as the
-# composite path `dir/{old => new}.rs`, which is not a real path and so can never be
-# found in the reviewer's prompt (the prompt-content check below matches literal
-# paths). Splitting a rename into its delete+add pair keeps every census path a real
-# one, at the cost of counting it as two files.
-# A FAILED `git diff` must NEVER alias to "genuinely empty". Discarding the exit
-# status here would assert a measurement that never happened — the same epistemic
-# error as reading a mirror ref instead of the remote — and it would surface as
-# NOTHING-TO-REVIEW, i.e. "there is nothing to look at" instead of "we could not
-# tell". Capture the status and fail CLOSED on it.
-set +e
-NUMSTAT=$(git -C "$REPO" diff --numstat --no-renames "${BASE}...HEAD" 2>&1)
-DIFF_RC=$?
-set -e
-if [ "$DIFF_RC" -ne 0 ]; then
-  CENSUS_CHECK="FAIL (git diff failed)"
-  DETAILS+=("ERROR: census: 'git diff --numstat --no-renames ${BASE}...HEAD' exited $DIFF_RC in $REPO, so the census was never measured. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW — an unmeasurable diff is 'we cannot tell', never 'there is nothing to review'. git said:")
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    DETAILS+=("  $line")
-  done <<<"$NUMSTAT"
-  finish FAIL 1
-fi
-
-census_files=0
-census_added=0
-census_deleted=0
-census_non_code_files=0
-census_paths=()
-while IFS=$'\t' read -r add del path; do
-  [ -n "${path:-}" ] || continue
-  if [ "$add" = "-" ]; then add=0; fi
-  if [ "$del" = "-" ]; then del=0; fi
-  census_files=$((census_files + 1))
-  census_paths+=("$path")
-  census_added=$((census_added + add))
-  census_deleted=$((census_deleted + del))
-  # Non-code classification: a documented prose EXTENSION, or an EXTENSIONLESS file
-  # under a documented prose directory. Anything else — including `docs/foo.py` and
-  # `.github/workflows/*.yml` — is code.
-  file_non_code=0
-  ext=""
-  case "$path" in *.*) ext="${path##*.}" ;; esac
-  if [ -n "$ext" ]; then
-    # shellcheck disable=SC2086 # deliberate split of the space-separated constant
-    for candidate in $CODE_FREE_EXTENSIONS; do
-      if [ "$ext" = "$candidate" ]; then file_non_code=1; fi
-    done
-  else
-    # shellcheck disable=SC2086 # deliberate split of the space-separated constant
-    for prefix in $CODE_FREE_EXTENSIONLESS_PREFIXES; do
-      case "$path" in "$prefix"*) file_non_code=1 ;; esac
-    done
-  fi
-  if [ "$file_non_code" -eq 1 ]; then census_non_code_files=$((census_non_code_files + 1)); fi
-done <<<"$NUMSTAT"
-
-census_noun="files"
-if [ "$census_files" -eq 1 ]; then census_noun="file"; fi
-CENSUS="$census_files $census_noun, +$census_added/-$census_deleted"
-
-if [ "$census_files" -eq 0 ]; then
-  CENSUS_CHECK="FAIL (empty census)"
-  DETAILS+=("NOTHING-TO-REVIEW: the local diff census for '${BASE}...HEAD' is genuinely empty (0 files changed), so no review was enqueued. This is explicitly NOT a pass and MUST NOT be recorded as \"roborev clean\".")
-  finish NOTHING-TO-REVIEW 3
-fi
-CENSUS_CHECK="PASS"
-
-# --- step 3b: code-free census — a DETERMINISTIC FAIL, before any review ------
-# roborev structurally DISCARDS a code-free diff, so such a diff cannot be certified
-# by roborev at all (this change's own spec requirement, and CLAUDE.md rule 4). That
-# is a property of OUR census, measured locally — it must not depend on the reviewer
-# admitting it in prose, which is what the previous revision bet on.
-if [ "$census_non_code_files" -eq "$census_files" ]; then
-  CODE_FREE="FAIL (code-free census: $census_non_code_files/$census_files files are documentation/specification text)"
-  DETAILS+=("ERROR: code-free: every file in the census ($CENSUS for ${BASE}...HEAD) is documentation/specification prose, and roborev STRUCTURALLY DISCARDS a code-free diff — so this diff CANNOT be certified by roborev at all, whatever verdict it returns. The sanctioned substitute is primary-source verification recorded in the PR (for example 'git show cassandra-5.0.8:<path>' for the source the docs describe). A docs-only change must NEVER record \"roborev clean\".")
-  DETAILS+=("ERROR: code-free: no review was enqueued, because a passing verdict on this diff would be meaningless.")
-  finish FAIL 1
-fi
-CODE_FREE="PASS"
+roborev_push_assert
+roborev_census
 
 # --- step 4: invoke by EXPLICIT sha + EXPLICIT absolute repo (AC2) ------------
 if ! command -v roborev >/dev/null 2>&1; then
@@ -587,6 +437,8 @@ set -e
 # validated before use. When several announcements are present the LAST one is the
 # effective enqueue, and the multiplicity is recorded.
 ANNOUNCE_COUNT=$({ grep -ociE 'enqueued job [0-9]+ for [0-9a-f]{7,40}' "$LOG" 2>/dev/null || printf 0; } | tail -1)
+# shellcheck disable=SC2018,SC2019 # ASCII-only on purpose: this normalises a HEX sha,
+# and the POSIX classes would make the transform locale-dependent for no benefit.
 ANNOUNCE=$({ tr 'A-Z' 'a-z' <"$LOG" 2>/dev/null || printf ''; } | grep -oE 'enqueued job [0-9]+ for [0-9a-f]{7,40}' | tail -1 || printf '')
 ANNOUNCED_SHA=""
 announce_ok=0
@@ -622,7 +474,6 @@ fi
 # Diagnostics live beside the transcript; `log:` names the base path.
 FACTS_FILE="$LOG.facts"
 PROMPT_FILE="$LOG.prompt"
-JOB_FACTS_TOOL="$(cd "$(dirname "$0")" && pwd)/roborev-job-facts.py"
 : >"$FACTS_FILE"
 : >"$PROMPT_FILE"
 
@@ -729,7 +580,7 @@ else
   elif grep -qi 'no issues found' "$LOG" && grep -qiE '(^|[^[:alnum:]])summary:' "$LOG"; then
     verdict_marker=1
   fi
-  if [ -n "$JOB_STATUS" ] && [ "$JOB_STATUS" != done ]; then
+  if [ -n "$JOB_STATUS" ] && [ "$JOB_STATUS" != "done" ]; then
     REVIEW_COMPLETED="FAIL (job status '$JOB_STATUS' is not done)"
     DETAILS+=("ERROR: review-completed: the job record reports status '$JOB_STATUS', not 'done', so the review did NOT complete and nothing was certified. Failing closed — the absence of a vacuous phrase is never evidence that a review happened.")
   elif [ "$verdict_marker" -eq 0 ]; then
@@ -786,28 +637,90 @@ else
   fi
 fi
 
-# --- step 6c: tier 1 — ADVISORY prose corroboration, anchored to the verdict ----
-# DEMOTED from primary to advisory, and deliberately so. It matched anywhere in the
-# transcript, so a review that merely QUOTED the phrase — including any review of
-# THIS wrapper, whose own diff contains it in several files — was failed as vacuous.
-# The systemic cost of that is agents learning to WAIVE tier-1 failures, which
-# restores the very defect the guard exists to prevent. It is no longer load-bearing
-# for anything: the docs-only trigger it was primary for is now caught deterministically
-# by `code-free:`, and "the reviewer never got the diff" by `prompt-content:`. So it
-# reports a NOTICE and never fails the run, matched ONLY within the verdict/summary
-# region (the lines carrying a `Summary:`), not over arbitrary finding bodies.
+# --- step 6c: findings vs reviewer error ---------------------------------------
+# roborev exits NON-ZERO when the review REPORTS FINDINGS. That is a NORMAL, GENUINE
+# outcome and must never be misreported as a reviewer malfunction: an agent told the
+# reviewer broke will retry or bypass instead of FIXING THE FINDINGS. The structured
+# `status` field is the authority for which of the two happened.
+#
+# This runs BEFORE tier 1 on purpose: `findings:` is the deterministic disambiguator
+# tier 1 is gated on (step 6d).
+findings_count=$({ grep -oiE '\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$LOG" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
+if [ "$REVIEW_RC" -eq 0 ]; then
+  ROBOREV_EXIT="PASS"
+  if [ "${findings_count:-0}" -gt 0 ]; then
+    # Exit 0 WITH severity markers: not the documented shape, but the markers are
+    # evidence the reviewer analysed the diff, which is what tier 1 needs to know.
+    FINDINGS="PRESENT ($findings_count)"
+  else
+    FINDINGS="NONE"
+  fi
+else
+  review_ran=0
+  if [ -n "$JOB_STATUS" ]; then
+    case "$JOB_STATUS" in "done") review_ran=1 ;; esac
+  elif [ "$REVIEW_COMPLETED" = "PASS" ]; then
+    review_ran=1
+  fi
+  if [ "$review_ran" -eq 1 ]; then
+    ROBOREV_EXIT="FINDINGS (exit $REVIEW_RC)"
+    if [ "${findings_count:-0}" -gt 0 ]; then
+      FINDINGS="PRESENT ($findings_count)"
+    else
+      FINDINGS="PRESENT"
+    fi
+    DETAILS+=("ERROR: roborev-exit: FINDINGS — 'roborev review' exited $REVIEW_RC because the review REPORTED FINDINGS. The review is GENUINE (job status '${JOB_STATUS:-unknown}') and the reviewer did NOT malfunction: do not retry it and do not bypass it. TRIAGE AND FIX the findings in the transcript ($LOG), then push and re-review. RESULT is FAIL because a review with open findings is not \"roborev clean\".")
+  else
+    ROBOREV_EXIT="ERROR (exit $REVIEW_RC)"
+    FINDINGS="UNKNOWN"
+    DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}'). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
+  fi
+fi
+
+# --- step 6d: tier 1 — AUTHORITATIVE, but gated on `findings:` -----------------
+# The reviewer's own summary claiming there are no code changes, against a census we
+# measured as NON-EMPTY, is trigger T3 — and a merge-gating check must FAIL on it,
+# not merely note it. But the naive form of this check false-FAILs: it once matched
+# anywhere in the transcript, so a review that merely QUOTED the phrase was failed as
+# vacuous (this very wrapper's diff carries the phrase in several files). Agents
+# learning to WAIVE tier-1 failures would restore the defect the guard exists to stop.
+#
+# Two things make the strict version safe:
+#   1. ANCHORING — only the verdict/summary region is matched (the lines carrying a
+#      `Summary:`), never arbitrary finding bodies.
+#   2. GATING ON `findings:` — the deterministic disambiguator computed in step 6c:
+#        findings: NONE     the reviewer is CLAIMING CLEANLINESS, so the phrase is a
+#                           VACUITY CLAIM about a non-empty census  => HARD FAIL
+#        findings: PRESENT  the reviewer demonstrably analysed the diff and produced
+#                           findings, so the phrase is DISCUSSION   => advisory NOTICE
+#        findings: UNKNOWN  we cannot tell whether a review happened. Treated as
+#                           claiming cleanliness => HARD FAIL, because fail-closed is
+#                           the correct direction when the state is unknowable; an
+#                           unparseable findings state must never DISARM this check.
+# `code-free:` remains an independent, strictly earlier check (it fires pre-enqueue).
 VERDICT_REGION_FILE="$LOG.verdict"
 { grep -iE '(^|[^[:alnum:]])summary:' "$LOG" 2>/dev/null || true; } >"$VERDICT_REGION_FILE"
 if [ ! -s "$VERDICT_REGION_FILE" ]; then
   TIER1="UNAVAILABLE"
 elif grep -qi 'no code changes' "$VERDICT_REGION_FILE"; then
-  TIER1="NOTICE (vacuous verdict vs non-empty census)"
-  DETAILS+=("NOTICE: vacuity-tier1 (ADVISORY, does not fail the run): the review's summary claims there are NO CODE CHANGES to review while the locally computed census is NON-EMPTY: $CENSUS (${BASE}...HEAD). Corroborating signal only — the deterministic checks above (code-free, review-completed, prompt-content, sha-assert) carry the verdict.")
+  case "$FINDINGS" in
+    PRESENT*)
+      TIER1="NOTICE (phrase present in a findings-bearing review)"
+      DETAILS+=("NOTICE: vacuity-tier1 (advisory here, does not fail the run): the review's summary mentions 'no code changes' while the census is NON-EMPTY ($CENSUS), but the review reported findings ($FINDINGS) — so it demonstrably analysed the diff and the phrase is discussion, not a vacuity claim.")
+      ;;
+    *)
+      TIER1="FAIL (vacuous verdict vs non-empty census)"
+      DETAILS+=("ERROR: vacuity-tier1: the review's summary claims there are NO CODE CHANGES to review while the locally computed census is NON-EMPTY: $CENSUS (${BASE}...HEAD), and the review reported NO findings (findings: $FINDINGS) — so it is CLAIMING CLEANLINESS on a change it did not review. The reviewer's claim contradicts a fact we measured ourselves: this run is NOT reportable as \"roborev clean\".")
+      if [ "$FINDINGS" = "UNKNOWN" ]; then
+        DETAILS+=("ERROR: vacuity-tier1: the findings state is UNKNOWN (the reviewer errored), which is treated as claiming cleanliness — fail-closed is the correct direction when we cannot tell whether a review happened.")
+      fi
+      ;;
+  esac
 else
   TIER1="PASS"
 fi
 
-# --- step 6d: tier 2 — token accounting; drift is FAILED, absence is not -------
+# --- step 6e: tier 2 — token accounting; drift is FAILED, absence is not -------
 # Three distinguishable states (see scripts/flow/roborev-job-facts.py):
 #   absent      -> UNAVAILABLE. A build that reports no token data is a legitimate
 #                  difference, not a signal.
@@ -864,39 +777,10 @@ case "${TOKEN_STATE:-}" in
     ;;
 esac
 
-# --- step 7: findings vs reviewer error, then the verdict ----------------------
-# roborev exits NON-ZERO when the review REPORTS FINDINGS. That is a NORMAL, GENUINE
-# outcome and must never be misreported as a reviewer malfunction: an agent told the
-# reviewer broke will retry or bypass instead of FIXING THE FINDINGS. The structured
-# `status` field is the authority for which of the two happened.
-findings_count=$({ grep -oiE '\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$LOG" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
-if [ "$REVIEW_RC" -eq 0 ]; then
-  ROBOREV_EXIT="PASS"
-  FINDINGS="NONE"
-else
-  review_ran=0
-  if [ -n "$JOB_STATUS" ]; then
-    case "$JOB_STATUS" in done) review_ran=1 ;; esac
-  elif [ "$REVIEW_COMPLETED" = "PASS" ]; then
-    review_ran=1
-  fi
-  if [ "$review_ran" -eq 1 ]; then
-    ROBOREV_EXIT="FINDINGS (exit $REVIEW_RC)"
-    if [ "${findings_count:-0}" -gt 0 ]; then
-      FINDINGS="PRESENT ($findings_count)"
-    else
-      FINDINGS="PRESENT"
-    fi
-    DETAILS+=("ERROR: roborev-exit: FINDINGS — 'roborev review' exited $REVIEW_RC because the review REPORTED FINDINGS. The review is GENUINE (job status '${JOB_STATUS:-unknown}') and the reviewer did NOT malfunction: do not retry it and do not bypass it. TRIAGE AND FIX the findings in the transcript ($LOG), then push and re-review. RESULT is FAIL because a review with open findings is not \"roborev clean\".")
-  else
-    ROBOREV_EXIT="ERROR (exit $REVIEW_RC)"
-    FINDINGS="UNKNOWN"
-    DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}'). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
-  fi
-fi
+# --- step 7: the verdict ------------------------------------------------------
 # The findings COUNT is best-effort (it counts severity markers in the transcript);
-# the PRESENT/NONE distinction is the load-bearing part.
-
+# the PRESENT/NONE/UNKNOWN distinction is the load-bearing part — tier 1 is gated on it.
+#
 # Every per-check key participates in ONE scan. A key fails the run when its value
 # starts with FAIL, FINDINGS or ERROR; PASS / SKIP / UNAVAILABLE / NOTICE never do
 # (NOTICE is the advisory tier's value and is deliberately non-failing).

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -177,13 +177,21 @@ REPO_ARG=""
 BASE="origin/main"
 LOG_ARG=""
 
+# An option supplied with an EMPTY value is a usage error, never a silent fallback
+# to the default: `--repo ""` falling back to $PWD is exactly how a caller ends up
+# reviewing a repository it did not name.
+need_value() { # need_value <option> <argc> <value>
+  [ "$2" -ge 2 ] || die_usage "$1 requires a value"
+  [ -n "$3" ] || die_usage "$1 was given an empty value (an empty value is never a default)"
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --agent) [ $# -ge 2 ] || die_usage "--agent requires a value"; AGENT="$2"; shift 2 ;;
-    --model) [ $# -ge 2 ] || die_usage "--model requires a value"; MODEL="$2"; shift 2 ;;
-    --repo)  [ $# -ge 2 ] || die_usage "--repo requires a value";  REPO_ARG="$2"; shift 2 ;;
-    --base)  [ $# -ge 2 ] || die_usage "--base requires a value";  BASE="$2"; shift 2 ;;
-    --log)   [ $# -ge 2 ] || die_usage "--log requires a value";   LOG_ARG="$2"; shift 2 ;;
+    --agent) need_value --agent $# "${2:-}"; AGENT="$2"; shift 2 ;;
+    --model) need_value --model $# "${2:-}"; MODEL="$2"; shift 2 ;;
+    --repo)  need_value --repo  $# "${2:-}"; REPO_ARG="$2"; shift 2 ;;
+    --base)  need_value --base  $# "${2:-}"; BASE="$2"; shift 2 ;;
+    --log)   need_value --log   $# "${2:-}"; LOG_ARG="$2"; shift 2 ;;
     --help|-h) usage; exit 0 ;;
     *) die_usage "unknown option '$1'" ;;
   esac

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -160,7 +160,22 @@ commit-range form (observed enqueueing a commit that is neither endpoint).
 A docs-only diff cannot be roborev-certified at all — record primary-source
 verification in the PR instead of "roborev clean".
 
-The live worktree probe procedure is in this script's header comment.
+LIVE WORKTREE PROBE (documented, NOT gate-run: needs network + a live reviewer).
+Only this probe can show the REAL binary honours the explicit --repo from inside
+a worktree; the gate's hermetic check uses a stub reviewer.
+  1. Confirm the ROOT checkout sits on main (what makes the trigger reproducible):
+       git -C <root> rev-parse --abbrev-ref HEAD    # => main
+  2. From a real issue worktree on its own branch, with its commit PUSHED:
+       cd /path/to/cqlite-wt/issue-<N>
+       $PROGNAME --agent codex --model gpt-5.6-sol
+  3. In the emitted block assert: head-sha == the worktree branch HEAD;
+     reviewed-sha == head-sha (prefix match); reviewed-sha != git rev-parse
+     origin/main; sha-assert: PASS; census matching
+     'git diff --numstat origin/main...HEAD'; tokens above both thresholds;
+     RESULT: PASS (exit 0). A reviewed-sha equal to origin/main means the
+     explicit-repo invocation did NOT defeat the root-checkout resolution.
+  4. Record the observed head-sha/reviewed-sha/job/census/tokens in the PR body,
+     and re-run the probe after any roborev version bump.
 EOF
 }
 
@@ -347,9 +362,11 @@ while IFS=$'\t' read -r add del path; do
   # census to "has code".
   file_non_code=0
   ext="${path##*.}"
+  # shellcheck disable=SC2086 # deliberate split of the space-separated constants
   for candidate in $CODE_FREE_EXTENSIONS; do
     if [ "$ext" = "$candidate" ]; then file_non_code=1; fi
   done
+  # shellcheck disable=SC2086 # deliberate split of the space-separated constants
   for prefix in $CODE_FREE_PREFIXES; do
     case "$path" in "$prefix"*) file_non_code=1 ;; esac
   done

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+# roborev-review.sh — THE ONLY SANCTIONED roborev INVOCATION (issue #2964).
+#
+# WHY THIS EXISTS
+# ---------------
+# `roborev`'s verdict is a MERGE CONDITION (flow-implement review-first #2086;
+# flow-closer's confirmation pass before arming `gh pr merge --auto` #2084/#2667).
+# A vacuous review — one where roborev reviewed NOTHING — is textually identical to
+# a genuine clean one ("No issues found"), so "roborev clean" can be satisfied
+# without a review having happened and the pipeline merges unreviewed code with no
+# red anywhere. Three confirmed triggers:
+#
+#   1. bare `--branch` from inside a git WORKTREE resolves against the ROOT
+#      checkout (which normally sits on `main`), so the enqueued commit is
+#      `origin/main` and the branch's own change is never seen. Worktrees are not
+#      in `roborev repo list`, and `roborev repo` has NO `add` subcommand — repos
+#      self-register on first use — so there is nothing to register and no way to
+#      make the bare form worktree-correct. => bare `--branch` is NON-SANCTIONED.
+#   2. the two-positional commit-RANGE form (`roborev review <a> <b>`) has been
+#      OBSERVED enqueueing a commit that is NEITHER endpoint. => NON-SANCTIONED.
+#   3. a code-free (docs/spec/workflow-only) diff is STRUCTURALLY DISCARDED and
+#      still reported as "No issues found" — with the CORRECT sha enqueued, so no
+#      sha check can catch it. => a docs-only diff CANNOT be roborev-certified at
+#      all; the sanctioned substitute is primary-source verification recorded in
+#      the PR (e.g. `git show cassandra-5.0.8:<path>`).
+#
+# This wrapper judges the reviewer's claims against a LOCALLY COMPUTED `git` diff
+# census — never against the reviewer's own prose — and fails closed.
+#
+# USAGE
+# -----
+#   scripts/flow/roborev-review.sh --agent <agent> --model <model> \
+#       [--repo <path>] [--base <ref>] [--log <path>] [--help]
+#
+#   --agent   REQUIRED. Reviewer agent (e.g. `codex`, `claude-code`).
+#   --model   REQUIRED. Reviewer model (e.g. `gpt-5.6-sol`, `claude-opus-5`).
+#             BOTH are required on purpose: `--agent codex` alone INHERITS
+#             `review_model` from the repo's `.roborev.toml`, and a mismatched
+#             agent/model pair hard-400s as a SILENT-LOOKING review OUTAGE
+#             (#2433/#3037). Refusing here converts that outage into a usage error
+#             at the call site, before anything is enqueued.
+#   --repo    Target repository. Default: `git rev-parse --show-toplevel` of $PWD,
+#             resolved to an ABSOLUTE path (roborev --repo must never get a
+#             relative path). Always passed explicitly — never let roborev infer
+#             the repo from $PWD; that inference IS trigger 1.
+#   --base    Base ref for the census. Default: `origin/main`.
+#   --log     Raw roborev transcript path. Default: under ${TMPDIR:-/tmp}, and
+#             always NAMED in the summary block. STDOUT carries the summary block;
+#             a caller retains ONLY that block, NEVER the transcript.
+#
+# OUTPUT CONTRACT
+# ---------------
+# Exactly one block, terminal `RESULT:` last, header distinct from all three
+# agent-gate summary headers so neither can ever be pasted as the other:
+#
+#   ==== ROBOREV REVIEW SUMMARY ====
+#   repo: / branch: / base: / head-sha: / reviewed-sha: / job: / census: / tokens:
+#   push-assert: / census-check: / sha-assert: / vacuity-tier1: / vacuity-tier2:
+#   log:
+#   RESULT: PASS|FAIL|NOTHING-TO-REVIEW
+#
+# Per-check values are PASS | FAIL | SKIP | UNAVAILABLE (a FAIL may carry a
+# parenthesised reason). `census:` is `<N> files, +<A>/-<D>`; `tokens:` is
+# `input=<n> cached=<n> output=<n>` or `UNAVAILABLE`.
+#
+# EXIT CODES (exactly three outcomes plus a usage code)
+#   0  PASS               — reviewed, sha verified, no vacuity signal.
+#   1  FAIL               — any failed check (push, census, sha, tier 1, tier 2,
+#                           or a non-zero roborev exit). NOT reportable as clean.
+#   3  NOTHING-TO-REVIEW  — the census is genuinely empty; NO review was enqueued.
+#                           DISTINCT from PASS by exit code alone, so a caller can
+#                           never mistake "nothing to review" for "reviewed clean".
+#   2  usage error        — a missing/invalid option, detected before any repo
+#                           identity is resolved and before anything is enqueued.
+#                           This path prints `ERROR: ...` and NO summary block: no
+#                           review was attempted, so there is no verdict to state,
+#                           and emitting a `RESULT:` line would alias a usage error
+#                           onto one of the three real outcomes.
+#
+# LIVE WORKTREE PROBE (documented, NOT gate-run — needs network + a live reviewer)
+# -------------------------------------------------------------------------------
+# The hermetic regression check (scripts/tests/test_roborev_review_guard.sh) pins
+# every guard against a stub reviewer. Only this probe can prove the REAL external
+# binary honours the explicit `--repo` from inside a worktree. Procedure:
+#
+#   1. Confirm the ROOT checkout sits on `main` (that is what makes trigger 1
+#      reproducible):  git -C <root> rev-parse --abbrev-ref HEAD   # => main
+#   2. From a real issue worktree on its own branch, with its commit PUSHED:
+#        cd /path/to/cqlite-wt/issue-<N>
+#        scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol
+#   3. Read ONLY the emitted summary block and assert:
+#        head-sha:      == the WORKTREE branch HEAD (git rev-parse HEAD)
+#        reviewed-sha:  == head-sha (prefix match)     <-- the probe's point
+#        reviewed-sha:  != `git rev-parse origin/main` <-- trigger 1 defeated
+#        sha-assert:    PASS
+#        census:        matches `git diff --numstat origin/main...HEAD`
+#        tokens:        input/cached/output all above the thresholds below
+#        RESULT:        PASS   (exit 0)
+#      A `reviewed-sha` equal to `origin/main` means the explicit-repo invocation
+#      did NOT defeat the root-checkout resolution and the wrapper must be fixed
+#      before any verdict from it is trusted.
+#   4. Record the observed head-sha / reviewed-sha / job / census / tokens in the
+#      PR body as the live evidence. Re-run after any roborev version bump.
+set -euo pipefail
+
+# --- Tier-2 vacuity thresholds (named constants; measured evidence below) -------
+#
+# MEASURED EVIDENCE (issue #2964, real jobs on the fleet):
+#   GENUINE reviews:  398k-649k input, 314k-554k cached, 5.0k-6.3k output,
+#                     2m25s-2m45s wall  (jobs 4652 / 4654 / 4656)
+#   VACUOUS baseline: 18,700-18,801 input, 0 cached, 53-56 output, 8s wall
+#                     (jobs 4658 / 4659 — reproducible)
+#   KNOWN-EMPTY diff: 17,333 input, 21 output  (job 4651)
+#
+# So 50,000 input sits ~2.7x above the vacuous ceiling (18,801) and ~8x below the
+# genuine floor (398k); 200 output sits ~3.6x above the vacuous ceiling (56) and
+# ~25x below the genuine floor (5,067). Wall time is deliberately NOT asserted
+# (host-dependent — #2642).
+#
+# Tier 2 is CORROBORATING and can ONLY fail closed: it can never manufacture a
+# PASS, never relax a tier-1 FAIL, and its unavailability is stamped visibly
+# rather than skipped silently. Recalibrating means editing these two constants
+# and this evidence block together.
+ROBOREV_VACUITY_MIN_INPUT_TOKENS=50000
+ROBOREV_VACUITY_MIN_OUTPUT_TOKENS=200
+
+# Code-free (non-code) census classification. A census consisting ENTIRELY of
+# these extensions/prefixes is structurally discarded by roborev (trigger 3), so
+# the tier-1 failure is attributed to the code-free-diff condition specifically.
+CODE_FREE_EXTENSIONS="md markdown mdx txt rst adoc"
+CODE_FREE_PREFIXES="openspec/ docs/ website/ .github/ .claude/"
+
+PROGNAME=$(basename "$0")
+
+usage() {
+  cat <<EOF
+$PROGNAME — the only sanctioned roborev invocation (issue #2964)
+
+Usage:
+  $PROGNAME --agent <agent> --model <model> [--repo <path>] [--base <ref>]
+                     [--log <path>] [--help]
+
+Options:
+  --agent <agent>  REQUIRED reviewer agent (codex, claude-code, ...).
+  --model <model>  REQUIRED reviewer model (gpt-5.6-sol, claude-opus-5, ...).
+                   Both are required: supplying only one inherits a mismatched
+                   model from .roborev.toml and fails as a silent-looking outage.
+  --repo <path>    Target repo (default: git toplevel of \$PWD, absolutised).
+  --base <ref>     Census base ref (default: origin/main).
+  --log <path>     Raw transcript path (default: under \${TMPDIR:-/tmp}).
+  --help           This text.
+
+Outcome: one '==== ROBOREV REVIEW SUMMARY ====' block on stdout, terminal
+RESULT: PASS|FAIL|NOTHING-TO-REVIEW. Exit 0=PASS, 1=FAIL, 3=NOTHING-TO-REVIEW,
+2=usage error. Retain the block, never the transcript.
+
+Non-sanctioned forms this wrapper replaces: bare 'roborev review --branch'
+(resolves against the ROOT checkout from a worktree) and the two-positional
+commit-range form (observed enqueueing a commit that is neither endpoint).
+A docs-only diff cannot be roborev-certified at all — record primary-source
+verification in the PR instead of "roborev clean".
+
+The live worktree probe procedure is in this script's header comment.
+EOF
+}
+
+die_usage() { # die_usage <message>
+  printf 'ERROR: %s\n' "$1" >&2
+  printf 'ERROR: run `%s --help` for the option contract.\n' "$PROGNAME" >&2
+  exit 2
+}
+
+# --- argument parsing ----------------------------------------------------------
+AGENT=""
+MODEL=""
+REPO_ARG=""
+BASE="origin/main"
+LOG_ARG=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --agent) [ $# -ge 2 ] || die_usage "--agent requires a value"; AGENT="$2"; shift 2 ;;
+    --model) [ $# -ge 2 ] || die_usage "--model requires a value"; MODEL="$2"; shift 2 ;;
+    --repo)  [ $# -ge 2 ] || die_usage "--repo requires a value";  REPO_ARG="$2"; shift 2 ;;
+    --base)  [ $# -ge 2 ] || die_usage "--base requires a value";  BASE="$2"; shift 2 ;;
+    --log)   [ $# -ge 2 ] || die_usage "--log requires a value";   LOG_ARG="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) die_usage "unknown option '$1'" ;;
+  esac
+done
+
+if [ -z "$AGENT" ] && [ -z "$MODEL" ]; then
+  die_usage "missing required options --agent AND --model (both are required)"
+fi
+[ -n "$AGENT" ] || die_usage "missing required option --agent (--model alone leaves the reviewer agent inherited from .roborev.toml)"
+[ -n "$MODEL" ] || die_usage "missing required option --model (--agent alone inherits review_model from .roborev.toml and hard-400s as a silent-looking review outage)"
+
+# --- identity resolution (absolute repo, branch, full 40-char HEAD) ------------
+if [ -n "$REPO_ARG" ]; then
+  [ -d "$REPO_ARG" ] || die_usage "--repo path is not a directory: $REPO_ARG"
+  REPO=$(git -C "$REPO_ARG" rev-parse --show-toplevel 2>/dev/null) \
+    || die_usage "--repo is not inside a git repository: $REPO_ARG"
+else
+  REPO=$(git rev-parse --show-toplevel 2>/dev/null) \
+    || die_usage "\$PWD is not inside a git repository and no --repo was given"
+fi
+REPO=$(cd "$REPO" && pwd -P)
+
+BRANCH=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'HEAD')
+HEAD_SHA=$(git -C "$REPO" rev-parse HEAD 2>/dev/null || printf '')
+
+if [ -n "$LOG_ARG" ]; then
+  LOG="$LOG_ARG"
+else
+  log_slug=$(printf '%s' "$BRANCH" | tr -c 'A-Za-z0-9._-' '-')
+  LOG="${TMPDIR:-/tmp}/roborev-review-${log_slug}-${HEAD_SHA:0:8}-$$.log"
+fi
+mkdir -p "$(dirname "$LOG")"
+: >"$LOG"
+
+# --- summary state -------------------------------------------------------------
+REVIEWED_SHA="-"
+JOB="-"
+CENSUS="-"
+TOKENS="UNAVAILABLE"
+PUSH_ASSERT="SKIP"
+CENSUS_CHECK="SKIP"
+SHA_ASSERT="SKIP"
+TIER1="SKIP"
+TIER2="SKIP"
+RESULT="FAIL"
+DETAILS=()
+EMITTED=0
+
+emit_summary() {
+  printf '==== ROBOREV REVIEW SUMMARY ====\n'
+  printf 'repo: %s\n' "$REPO"
+  printf 'branch: %s\n' "$BRANCH"
+  printf 'base: %s\n' "$BASE"
+  printf 'head-sha: %s\n' "${HEAD_SHA:--}"
+  printf 'reviewed-sha: %s\n' "$REVIEWED_SHA"
+  printf 'job: %s\n' "$JOB"
+  printf 'census: %s\n' "$CENSUS"
+  printf 'tokens: %s\n' "$TOKENS"
+  printf 'push-assert: %s\n' "$PUSH_ASSERT"
+  printf 'census-check: %s\n' "$CENSUS_CHECK"
+  printf 'sha-assert: %s\n' "$SHA_ASSERT"
+  printf 'vacuity-tier1: %s\n' "$TIER1"
+  printf 'vacuity-tier2: %s\n' "$TIER2"
+  printf 'log: %s\n' "$LOG"
+  printf 'RESULT: %s\n' "$RESULT"
+}
+
+finish() { # finish <PASS|FAIL|NOTHING-TO-REVIEW> <exit-code>
+  RESULT="$1"
+  if [ "${#DETAILS[@]}" -gt 0 ]; then
+    printf '%s\n' "${DETAILS[@]}"
+  fi
+  EMITTED=1
+  emit_summary
+  exit "$2"
+}
+
+# Emit a block on EVERY exit path, including an unexpected `set -e` abort: a run
+# that dies without a verdict must never look like a run that was never made.
+on_exit() {
+  local rc=$?
+  if [ "$EMITTED" -eq 0 ]; then
+    printf 'ERROR: the wrapper terminated unexpectedly (exit %s) before reaching a verdict.\n' "$rc"
+    RESULT="FAIL"
+    EMITTED=1
+    emit_summary
+    [ "$rc" -ne 0 ] || rc=1
+    exit "$rc"
+  fi
+}
+trap on_exit EXIT
+
+if [ -z "$HEAD_SHA" ]; then
+  DETAILS+=("ERROR: cannot resolve HEAD in $REPO — there is no commit to review.")
+  finish FAIL 1
+fi
+
+# --- step 2: push assert (AC3) — before the census, so the operator gets the ---
+# --- actionable cause ("push your commits") rather than a downstream vacuity ---
+if [ "$BRANCH" = "HEAD" ]; then
+  PUSH_ASSERT="FAIL (detached HEAD)"
+  DETAILS+=("ERROR: push-assert: $REPO is on a detached HEAD, so there is no origin/<branch> to assert against. Check out the issue branch. No review was enqueued.")
+  finish FAIL 1
+fi
+
+REMOTE_SHA=""
+if ! REMOTE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "refs/remotes/origin/$BRANCH"); then
+  PUSH_ASSERT="FAIL (no remote branch origin/$BRANCH)"
+  DETAILS+=("ERROR: push-assert: remote branch 'origin/$BRANCH' does not exist — this branch has never been pushed. The reviewer can only see what the remote has, so an unpushed branch is itself an empty-diff cause. No review was enqueued.")
+  finish FAIL 1
+fi
+
+if [ "$REMOTE_SHA" != "$HEAD_SHA" ]; then
+  PUSH_ASSERT="FAIL (unpushed commits)"
+  DETAILS+=("ERROR: push-assert: origin/$BRANCH ($REMOTE_SHA) != local HEAD ($HEAD_SHA).")
+  unpushed=$(git -C "$REPO" log --oneline "refs/remotes/origin/$BRANCH..HEAD" 2>/dev/null || printf '')
+  if [ -n "$unpushed" ]; then
+    DETAILS+=("ERROR: push-assert: unpushed commit(s):")
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      DETAILS+=("  $line")
+    done <<<"$unpushed"
+  else
+    DETAILS+=("ERROR: push-assert: local HEAD is not ahead of origin/$BRANCH — the branch has diverged from its remote; reconcile before reviewing.")
+  fi
+  DETAILS+=("ERROR: push-assert: push the branch before reviewing. No review was enqueued.")
+  finish FAIL 1
+fi
+PUSH_ASSERT="PASS"
+
+# --- step 3: the local diff census — THE ORACLE -------------------------------
+BASE_SHA=""
+if ! BASE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "${BASE}^{commit}"); then
+  CENSUS_CHECK="FAIL (base '$BASE' unresolvable)"
+  DETAILS+=("ERROR: census: base ref '$BASE' does not resolve to a commit in $REPO — the census, and therefore every vacuity judgement, would be unfounded. No review was enqueued.")
+  finish FAIL 1
+fi
+
+NUMSTAT=$(git -C "$REPO" diff --numstat "${BASE}...HEAD" 2>/dev/null || printf '')
+census_files=0
+census_added=0
+census_deleted=0
+census_code_free=1
+while IFS=$'\t' read -r add del path; do
+  [ -n "${path:-}" ] || continue
+  if [ "$add" = "-" ]; then add=0; fi
+  if [ "$del" = "-" ]; then del=0; fi
+  census_files=$((census_files + 1))
+  census_added=$((census_added + add))
+  census_deleted=$((census_deleted + del))
+  # Code-free classification: the file must match a documented non-code extension
+  # OR sit under a documented non-code path prefix. One code file flips the whole
+  # census to "has code".
+  file_non_code=0
+  ext="${path##*.}"
+  for candidate in $CODE_FREE_EXTENSIONS; do
+    if [ "$ext" = "$candidate" ]; then file_non_code=1; fi
+  done
+  for prefix in $CODE_FREE_PREFIXES; do
+    case "$path" in "$prefix"*) file_non_code=1 ;; esac
+  done
+  if [ "$file_non_code" -eq 0 ]; then census_code_free=0; fi
+done <<<"$NUMSTAT"
+
+CENSUS="$census_files files, +$census_added/-$census_deleted"
+
+if [ "$census_files" -eq 0 ]; then
+  CENSUS_CHECK="FAIL (empty census)"
+  DETAILS+=("NOTHING-TO-REVIEW: the local diff census for '${BASE}...HEAD' is genuinely empty (0 files changed), so no review was enqueued. This is explicitly NOT a pass and MUST NOT be recorded as \"roborev clean\".")
+  finish NOTHING-TO-REVIEW 3
+fi
+CENSUS_CHECK="PASS"
+
+# --- step 4: invoke by EXPLICIT sha + EXPLICIT absolute repo (AC2) ------------
+if ! command -v roborev >/dev/null 2>&1; then
+  SHA_ASSERT="FAIL (roborev not on PATH)"
+  DETAILS+=("ERROR: 'roborev' is not on PATH, so the review cannot be performed and the census cannot be certified. Failing closed rather than reporting a pass.")
+  finish FAIL 1
+fi
+
+# NEVER a bare `--branch` (trigger 1); NEVER two positional commits (trigger 2).
+# The transcript goes to the log; stdout stays reserved for the summary block.
+set +e
+roborev review "$HEAD_SHA" \
+  --repo "$REPO" \
+  --agent "$AGENT" \
+  --model "$MODEL" \
+  --wait >"$LOG" 2>&1
+REVIEW_RC=$?
+set -e
+
+# --- step 5: reviewed-SHA assert (AC2) ----------------------------------------
+ANNOUNCE=$(grep -oiE 'enqueued job [0-9]+ for [0-9a-fA-F]{4,40}' "$LOG" | tail -1 || printf '')
+if [ -z "$ANNOUNCE" ]; then
+  SHA_ASSERT="FAIL (no parseable enqueue announcement)"
+  DETAILS+=("ERROR: sha-assert: the transcript contains no parseable 'Enqueued job <N> for <sha>' line, so the reviewed sha is UNVERIFIABLE. That is a failure, never a skipped check. Transcript: $LOG")
+else
+  JOB=$(printf '%s' "$ANNOUNCE" | sed -E 's/^[Ee]nqueued [Jj]ob ([0-9]+).*/\1/')
+  REVIEWED_SHA=$(printf '%s' "$ANNOUNCE" | sed -E 's/.*[Ff]or ([0-9a-fA-F]+)$/\1/' | tr 'A-F' 'a-f')
+  if [ "${HEAD_SHA:0:${#REVIEWED_SHA}}" = "$REVIEWED_SHA" ] \
+    || [ "${REVIEWED_SHA:0:${#HEAD_SHA}}" = "$HEAD_SHA" ]; then
+    SHA_ASSERT="PASS"
+  else
+    SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
+    DETAILS+=("ERROR: sha-assert: announced reviewed-sha '$REVIEWED_SHA' does not prefix-match branch HEAD '$HEAD_SHA' (job $JOB).")
+    if [ "${BASE_SHA:0:${#REVIEWED_SHA}}" = "$REVIEWED_SHA" ]; then
+      DETAILS+=("ERROR: sha-assert: the announced sha EQUALS the base ref '$BASE' ($BASE_SHA) — NO branch change was reviewed. That equality is the signature of the worktree bare-'--branch' resolution trigger, where the review resolves against the ROOT checkout instead of this worktree.")
+    else
+      DETAILS+=("ERROR: sha-assert: the announced sha matches NEITHER endpoint (head '$HEAD_SHA', base '$BASE' $BASE_SHA) — the signature of the non-sanctioned two-positional commit-range form.")
+    fi
+  fi
+fi
+
+# --- step 6 tier 1: PRIMARY, deterministic, threshold-free (AC1) --------------
+# The census is known NON-empty here (an empty one exited above), so a reviewer
+# claiming there are no code changes contradicts a locally measured fact.
+if grep -qiE 'contains no code changes to review|no code changes' "$LOG"; then
+  TIER1="FAIL (vacuous verdict vs non-empty census)"
+  DETAILS+=("ERROR: vacuity-tier1: the review output claims there are NO CODE CHANGES to review, but the locally computed census is NON-EMPTY: $CENSUS (${BASE}...HEAD). The reviewer's claim contradicts a fact we measured ourselves, so the change was demonstrably NOT reviewed and this run is NOT reportable as \"roborev clean\".")
+  if [ "$census_code_free" -eq 1 ]; then
+    DETAILS+=("ERROR: vacuity-tier1: every file in the census is documentation/specification/workflow text, so this is the CODE-FREE-DIFF condition: a code-free diff cannot be certified by roborev at all (roborev structurally discards it). The sanctioned substitute is primary-source verification recorded in the PR (for example 'git show cassandra-5.0.8:<path>' for the source the docs describe) — never \"roborev clean\".")
+  fi
+else
+  TIER1="PASS"
+fi
+
+# --- step 6 tier 2: CORROBORATING token accounting; can only FAIL CLOSED ------
+json_int() { # json_int <json> <key> -> integer or empty
+  local v=""
+  v=$(printf '%s' "$1" | tr -d ' \t\n' | grep -oE "\"$2\":-?[0-9]+" | head -1 | sed -E 's/.*://') || v=""
+  printf '%s' "$v"
+}
+
+has_token_fields() { # has_token_fields <json>
+  [ -n "$1" ] || return 1
+  printf '%s' "$1" | tr -d ' \t\n' | grep -q '"input_tokens":'
+}
+
+select_job_object() { # select_job_object <list-json> <job-id> -> object json or empty
+  command -v python3 >/dev/null 2>&1 || { printf ''; return 0; }
+  printf '%s' "$1" | python3 -c '
+import json, sys
+want = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+def walk(node):
+    if isinstance(node, dict):
+        for key in ("id", "job_id", "job"):
+            if key in node and str(node[key]) == want:
+                print(json.dumps(node))
+                return True
+        for value in node.values():
+            if walk(value):
+                return True
+    elif isinstance(node, list):
+        for value in node:
+            if walk(value):
+                return True
+    return False
+walk(data)
+' "$2" 2>/dev/null || printf ''
+}
+
+TOKEN_JSON=""
+if [ "$JOB" != "-" ]; then
+  TOKEN_JSON=$(roborev show "$JOB" --json 2>/dev/null || printf '')
+  if ! has_token_fields "$TOKEN_JSON"; then
+    LIST_JSON=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '')
+    TOKEN_JSON=$(select_job_object "$LIST_JSON" "$JOB")
+  fi
+fi
+
+TOK_IN=""
+TOK_CACHED=""
+TOK_OUT=""
+if has_token_fields "$TOKEN_JSON" \
+  && ! printf '%s' "$TOKEN_JSON" | tr -d ' \t\n' | grep -q '"has_token_data":false'; then
+  TOK_IN=$(json_int "$TOKEN_JSON" input_tokens)
+  TOK_CACHED=$(json_int "$TOKEN_JSON" cached_input_tokens)
+  TOK_OUT=$(json_int "$TOKEN_JSON" output_tokens)
+fi
+
+if [ -z "$TOK_IN" ] || [ -z "$TOK_CACHED" ] || [ -z "$TOK_OUT" ]; then
+  TOKENS="UNAVAILABLE"
+  TIER2="UNAVAILABLE"
+  DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — token accounting for job '$JOB' could not be obtained from the installed roborev build (tried 'roborev show <job> --json', then 'roborev list --json'). This is a DEGRADED-SIGNAL notice, never a silent skip: tier 1 still governs, and an unavailable tier 2 can never turn a FAIL into a PASS.")
+else
+  TOKENS="input=$TOK_IN cached=$TOK_CACHED output=$TOK_OUT"
+  tier2_trips=()
+  if [ "$TOK_IN" -lt "$ROBOREV_VACUITY_MIN_INPUT_TOKENS" ]; then
+    tier2_trips+=("observed input=$TOK_IN < ROBOREV_VACUITY_MIN_INPUT_TOKENS=$ROBOREV_VACUITY_MIN_INPUT_TOKENS")
+  fi
+  if [ "$TOK_CACHED" -eq 0 ]; then
+    tier2_trips+=("observed cached=$TOK_CACHED == 0 (a genuine review reports a non-zero cached-input count; the recorded vacuous baseline reports exactly 0)")
+  fi
+  if [ "$TOK_OUT" -lt "$ROBOREV_VACUITY_MIN_OUTPUT_TOKENS" ]; then
+    tier2_trips+=("observed output=$TOK_OUT < ROBOREV_VACUITY_MIN_OUTPUT_TOKENS=$ROBOREV_VACUITY_MIN_OUTPUT_TOKENS")
+  fi
+  if [ "${#tier2_trips[@]}" -gt 0 ]; then
+    TIER2="FAIL (vacuous token signature)"
+    DETAILS+=("ERROR: vacuity-tier2: the token accounting for job '$JOB' carries the vacuous signature against a NON-EMPTY census ($CENSUS):")
+    for trip in "${tier2_trips[@]}"; do
+      DETAILS+=("  $trip")
+    done
+  else
+    TIER2="PASS"
+  fi
+fi
+
+# --- step 7: verdict ----------------------------------------------------------
+if [ "$REVIEW_RC" -ne 0 ]; then
+  DETAILS+=("ERROR: 'roborev review' exited $REVIEW_RC. A non-zero reviewer exit is a fail-closed FAIL — read the transcript at $LOG before treating anything as clean.")
+fi
+
+failed=0
+for verdict in "$PUSH_ASSERT" "$CENSUS_CHECK" "$SHA_ASSERT" "$TIER1" "$TIER2"; do
+  case "$verdict" in FAIL*) failed=1 ;; esac
+done
+if [ "$REVIEW_RC" -ne 0 ]; then failed=1; fi
+
+if [ "$failed" -eq 0 ]; then
+  finish PASS 0
+fi
+finish FAIL 1

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -164,13 +164,16 @@ ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=200
 # sampling was a hole — a partial prompt naming just the sampled files passed.)
 
 # The job record is written ASYNCHRONOUSLY: measured empty for git_ref/status/model/
-# token_usage the instant `--wait` returned. MEASURED AGAIN in round 5: still
-# incomplete 15s after `--wait` returned on a 20-commit review, so the lag is NOT
-# sub-second. 45 x 1s is bounded and proportionate to a review that takes minutes.
+# token_usage the instant `--wait` returned — which turned out NOT to be an async
+# durability problem at all (round 6): `roborev show --json` nests the JOB row under a
+# "job" key and the extractor was matching the outer REVIEW row, which carries none of
+# those fields. With the nested row read as a first-class source the record is complete
+# in ONE read, so this is now a short SANITY retry rather than a wait: 5 x 1s. It still
+# fails closed if the record genuinely cannot be read.
 # Overridable ONLY as a timing knob (the hermetic self-test shortens it). Shortening
 # it can never weaken a check: fewer polls can only make the record MORE likely to be
 # reported DEGRADED, which is the fail-closed direction.
-JOB_RECORD_POLL_ATTEMPTS=${ROBOREV_JOB_RECORD_POLL_ATTEMPTS:-45}
+JOB_RECORD_POLL_ATTEMPTS=${ROBOREV_JOB_RECORD_POLL_ATTEMPTS:-5}
 JOB_RECORD_POLL_INTERVAL_SECS=${ROBOREV_JOB_RECORD_POLL_INTERVAL_SECS:-1}
 
 
@@ -179,6 +182,7 @@ PROGNAME=$(basename "$0")
 # is invoked from arbitrary worktrees and a $PWD-relative lookup would silently miss.
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ORACLES_FILE="$SCRIPT_DIR/roborev-review-oracles.sh"
+CHECKS_FILE="$SCRIPT_DIR/roborev-review-checks.sh"
 JOB_FACTS_TOOL="$SCRIPT_DIR/roborev-job-facts.py"
 
 usage() {
@@ -419,6 +423,27 @@ fi
 
 roborev_push_assert
 roborev_census
+
+# --- the per-review checks (sourced) ------------------------------------------
+# Same contract as the oracles file: resolved from BASH_SOURCE, and FAIL CLOSED if it is
+# missing or incomplete — an absent checks file would silently turn all five checks into
+# no-ops while every key still read PASS. Validated HERE, before any review is
+# enqueued, so a broken installation costs no review; the functions are CALLED further
+# down (steps 6a-6e), once the job facts exist.
+if [ ! -f "$CHECKS_FILE" ]; then
+  DETAILS+=("ERROR: the required checks file '$CHECKS_FILE' is missing, so review-completed, prompt-content, findings and both vacuity tiers cannot run. Failing closed rather than proceeding with those checks silently disabled — restore scripts/flow/roborev-review-checks.sh.")
+  finish FAIL 1
+fi
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=roborev-review-checks.sh
+. "$CHECKS_FILE"
+for roborev_required_check in roborev_check_review_completed roborev_check_prompt_content \
+  roborev_check_findings roborev_check_tier1 roborev_check_tier2; do
+  if [ "$(type -t "$roborev_required_check")" != function ]; then
+    DETAILS+=("ERROR: '$CHECKS_FILE' did not define $roborev_required_check, so that check cannot run. Failing closed — the file is truncated or corrupt.")
+    finish FAIL 1
+  fi
+done
 
 # --- step 4: invoke over the CENSUS RANGE + an EXPLICIT absolute repo (AC2) ----
 if ! command -v roborev >/dev/null 2>&1; then
@@ -700,283 +725,12 @@ else
   MODEL_LINE="$MODEL (UNCONFIRMED — no model field in the job record)"
 fi
 
-# --- step 6a: review-completed — POSITIVE evidence that a review HAPPENED ------
-# The allow-list of terminal verdict markers. A review that finished emits either a
-# findings block (a Findings heading / '**Severity**:' lines) or a Summary heading —
-# the shapes a real review actually emits. Anything else — a still-waiting job, a provider 400, a failed
-# job — matches NOTHING here and therefore cannot reach PASS. This is the inverse of
-# the old logic, which inferred success from the ABSENCE of a vacuous phrase.
-# Built from the REAL transcript (MEASURED, issue #2964 round 5), not from guesses:
-#     ## Review Findings
-#     - **Severity**: Medium
-#     ## Summary
-# A finished review is identified by a Findings heading, a `**Severity**:` line, a
-# Summary heading/label, or the older bracket / `Medium:` shapes other agents emit.
-# Anything else — a still-waiting job, a provider 400, a failed job — matches none of
-# them. The previous list was INVENTED rather than measured and rejected a GENUINE
-# codex review: the false-FAIL direction that gets a guard bypassed.
-VERDICT_MARKER_RE='^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?|\*\*severity\*\*[[:space:]]*:|^[[:space:]]*#{1,4}[[:space:]]*summary|(^|[^[:alnum:]])summary:|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): |^[[:space:]]*findings?[[:space:]:]'
-if [ ! -r "$LOG" ]; then
-  REVIEW_COMPLETED="FAIL (transcript unreadable)"
-  DETAILS+=("ERROR: review-completed: the transcript at $LOG is not readable, so there is no evidence a review happened. Failing closed.")
-else
-  verdict_marker=0
-  if grep -qiE "$VERDICT_MARKER_RE" "$LOG"; then
-    verdict_marker=1
-  fi
-  if [ -n "$JOB_STATUS" ] && [ "$JOB_STATUS" != "done" ]; then
-    REVIEW_COMPLETED="FAIL (job status '$JOB_STATUS' is not done)"
-    DETAILS+=("ERROR: review-completed: the job record reports status '$JOB_STATUS', not 'done', so the review did NOT complete and nothing was certified. Failing closed — the absence of a vacuous phrase is never evidence that a review happened.")
-  elif [ "$verdict_marker" -eq 0 ]; then
-    REVIEW_COMPLETED="FAIL (no terminal verdict marker)"
-    DETAILS+=("ERROR: review-completed: the transcript carries NO terminal verdict marker — no Findings heading, no '**Severity**:' line and no Summary heading/label. A still-waiting job, a provider error (for example the #2433/#3037 model-mismatch 400) and a failed job all look like this, and none of them is a review. Failing closed. Transcript: $LOG")
-  else
-    REVIEW_COMPLETED="PASS"
-    if [ -z "$JOB_STATUS" ]; then
-      DETAILS+=("NOTICE: review-completed: the job record's 'status' was unavailable, so completion rests on the transcript's terminal verdict marker alone (the weaker of the two signals).")
-    fi
-  fi
-fi
-
-# --- step 6b: prompt-content — DETERMINISTIC: did the reviewer GET the diff? ----
-# The strongest available check: it reads the prompt actually sent to the agent and
-# looks for OUR census's own file paths in it. Absent paths mean the reviewer never
-# received the diff — the T1/T2 family and any future variant — threshold-free, and
-# judged against our own authoritative census rather than the reviewer's prose.
-# A whitespace-only prompt file is a RETRIEVAL FAILURE, not evidence the paths are
-# absent: UNAVAILABLE (degraded), never a FAIL, or an unsupported roborev build would
-# false-FAIL every run.
-prompt_bytes=$(tr -d '[:space:]' <"$PROMPT_FILE" | wc -c | tr -d '[:space:]')
-if [ "${prompt_bytes:-0}" -eq 0 ]; then
-  PROMPT_CONTENT="UNAVAILABLE"
-  DETAILS+=("NOTICE: prompt-content: UNAVAILABLE — the prompt sent to the reviewer could not be retrieved for job '$JOB' (tried the job record's 'prompt' field, then 'roborev show <job> --prompt'). DEGRADED SIGNAL, never a silent skip: the other deterministic checks still govern and this can never upgrade a FAIL to a PASS.")
-else
-  # Check the CODE subset of the census, not every path. MEASURED (issue #2964,
-  # round 5): roborev EXCLUDES non-code paths from the diff it builds — on a census of
-  # 22 markdown + 5 code files, the prompt carried diff headers for exactly the 5 code
-  # files. That is also the empirical mechanism behind the "code-free diff silently
-  # discarded" trigger: there is literally nothing left to review. Checking all 27
-  # would false-FAIL every branch that touches documentation, which is most of them.
-  # EVERY code path is checked, and against its EXACT diff header rather than a bare
-  # substring (codex, round 5): sampling a subset let a partial prompt pass by naming
-  # the sampled files, and a substring match is satisfied by any incidental mention —
-  # including this wrapper quoting a path in a comment. A `diff --git a/P b/P` header is
-  # present if and only if the reviewer was sent that file's diff. Exact-header matching
-  # is cheap enough that the sampling cap is gone.
-  checked_paths=("${census_code_paths[@]}")
-  census_total=${#census_code_paths[@]}
-  missing_paths=()
-  for census_path in "${checked_paths[@]}"; do
-    grep -Fq -- "diff --git a/$census_path b/$census_path" "$PROMPT_FILE" \
-      || missing_paths+=("$census_path")
-  done
-  if [ "${#missing_paths[@]}" -gt 0 ]; then
-    PROMPT_CONTENT="FAIL (${#missing_paths[@]}/${#checked_paths[@]} code census paths absent from the prompt)"
-    DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} CODE census paths have NO 'diff --git' header in the prompt actually sent to the reviewer, so the reviewer never received their diffs. The census is authoritative ($CENSUS for ${BASE}...HEAD); a prompt that does not mention its files cannot have reviewed them. Missing (first 10):")
-    printed=0
-    for census_path in "${missing_paths[@]}"; do
-      [ "$printed" -lt 10 ] || break
-      DETAILS+=("  $census_path")
-      printed=$((printed + 1))
-    done
-  else
-    PROMPT_CONTENT="PASS (${#checked_paths[@]}/$census_total code census paths present)"
-  fi
-fi
-
-# --- step 6c: findings — STRUCTURED first, prose only inside the block ----------
-# Tier 1 (step 6d) is gated on this answer, so deriving it from a regex over the WHOLE
-# transcript was a real weakness (codex, round 5): incidental or QUOTED severity text
-# such as "[Low]" anywhere in the output set findings: PRESENT, which then exempted a
-# genuinely vacuous "no code changes" verdict from the authoritative tier-1 failure. A
-# gate is only as strong as its input, so:
-#   1. STRUCTURED FIRST — the job record's `verdict` field ("F" = the review reported
-#      findings; a pass letter/true = it did not). Measured on real jobs.
-#   2. PROSE FALLBACK IS SCOPED — only the FINDINGS BLOCK (from a `Findings`/`## Findings`
-#      header up to the `Summary:` line) is scanned, never the whole transcript.
-#   3. CONTRADICTIONS FAIL — "clean" (verdict pass, or exit 0) while the findings block
-#      DOES carry severity markers is an INCONSISTENT state. It fails the run and, being
-#      neither PRESENT nor NONE, cannot exempt tier 1 either.
-FINDINGS_BLOCK_FILE="$LOG.findings"
-# The block runs from a Findings heading/label to the Summary heading/label — the
-# measured real shapes. Everything outside it (a quoted "[Low]" in prose, a severity
-# word inside a Problem sentence) is ignored. The terminator must be a LINE-INITIAL
-# Summary label: matched mid-sentence it closed the block early when a finding's own
-# prose contained the word, under-counting the findings. (Under-counting is the
-# fail-closed direction for the tier-1 gate — fewer markers make a vacuity claim MORE
-# likely to fail — but the count is reported to a human, so it should be right.)
-{ awk 'BEGIN { inblock = 0 }
-       tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?/ { inblock = 1; next }
-       tolower($0) ~ /^[[:space:]]*findings?[[:space:]]*:/ { inblock = 1; next }
-       tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*summary/ { inblock = 0 }
-       tolower($0) ~ /^[[:space:]]*summary[[:space:]]*:/ { inblock = 0 }
-       inblock { print }' "$LOG" 2>/dev/null || true; } >"$FINDINGS_BLOCK_FILE"
-block_marker_count=$({ grep -oiE '\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
-block_marker_count=${block_marker_count:-0}
-
-verdict_findings="unknown"
-case "$JOB_VERDICT" in
-  P|p|PASS|pass|Pass|true|clean) verdict_findings="none" ;;
-  F|f|FAIL|fail|Fail|false) verdict_findings="present" ;;
-esac
-
-review_ran=0
-if [ -n "$JOB_STATUS" ]; then
-  case "$JOB_STATUS" in "done") review_ran=1 ;; esac
-elif [ "$REVIEW_COMPLETED" = "PASS" ]; then
-  review_ran=1
-fi
-
-if [ "$REVIEW_RC" -eq 0 ]; then
-  ROBOREV_EXIT="PASS"
-elif [ "$review_ran" -eq 1 ]; then
-  ROBOREV_EXIT="FINDINGS (exit $REVIEW_RC)"
-  DETAILS+=("ERROR: roborev-exit: FINDINGS — 'roborev review' exited $REVIEW_RC because the review REPORTED FINDINGS. The review is GENUINE (job status '${JOB_STATUS:-unknown}') and the reviewer did NOT malfunction: do not retry it and do not bypass it. TRIAGE AND FIX the findings in the transcript ($LOG), then push and re-review. RESULT is FAIL because a review with open findings is not \"roborev clean\".")
-else
-  ROBOREV_EXIT="ERROR (exit $REVIEW_RC)"
-  DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}'). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
-fi
-
-case "$verdict_findings" in
-  present)
-    if [ "$block_marker_count" -gt 0 ]; then
-      FINDINGS="PRESENT ($block_marker_count)"
-    else
-      FINDINGS="PRESENT"
-    fi
-    ;;
-  none)
-    if [ "$block_marker_count" -gt 0 ]; then
-      FINDINGS="INCONSISTENT (verdict clean, $block_marker_count findings marker(s))"
-      DETAILS+=("ERROR: findings: the job record's verdict '$JOB_VERDICT' says the review was clean, but its findings block carries $block_marker_count severity marker(s). One of the two is wrong, so the findings state is INCONSISTENT — failed closed, and it cannot exempt the tier-1 vacuity check either.")
-    else
-      FINDINGS="NONE"
-    fi
-    ;;
-  *)
-    # No structured verdict: fall back to the exit code, still refusing to trust prose
-    # over the whole transcript.
-    if [ "$ROBOREV_EXIT" = "PASS" ]; then
-      if [ "$block_marker_count" -gt 0 ]; then
-        FINDINGS="INCONSISTENT (exit 0, $block_marker_count findings marker(s))"
-        DETAILS+=("ERROR: findings: 'roborev review' exited 0 (which means no findings) while the findings block carries $block_marker_count severity marker(s), and the job record has no structured verdict to arbitrate. INCONSISTENT — failed closed, and it cannot exempt the tier-1 vacuity check.")
-      else
-        FINDINGS="NONE"
-      fi
-    else
-      case "$ROBOREV_EXIT" in
-        FINDINGS*)
-          if [ "$block_marker_count" -gt 0 ]; then
-            FINDINGS="PRESENT ($block_marker_count)"
-          else
-            FINDINGS="PRESENT"
-          fi
-          ;;
-        *) FINDINGS="UNKNOWN" ;;
-      esac
-    fi
-    ;;
-esac
-
-# --- step 6d: tier 1 — AUTHORITATIVE, but gated on `findings:` -----------------
-# The reviewer's own summary claiming there are no code changes, against a census we
-# measured as NON-EMPTY, is trigger T3 — and a merge-gating check must FAIL on it,
-# not merely note it. But the naive form of this check false-FAILs: it once matched
-# anywhere in the transcript, so a review that merely QUOTED the phrase was failed as
-# vacuous (this very wrapper's diff carries the phrase in several files). Agents
-# learning to WAIVE tier-1 failures would restore the defect the guard exists to stop.
-#
-# Two things make the strict version safe:
-#   1. ANCHORING — only the verdict/summary region is matched (the lines carrying a
-#      `Summary:`), never arbitrary finding bodies.
-#   2. GATING ON `findings:` — the deterministic disambiguator computed in step 6c:
-#        findings: NONE     the reviewer is CLAIMING CLEANLINESS, so the phrase is a
-#                           VACUITY CLAIM about a non-empty census  => HARD FAIL
-#        findings: PRESENT  the reviewer demonstrably analysed the diff and produced
-#                           findings, so the phrase is DISCUSSION   => advisory NOTICE
-#        findings: UNKNOWN  we cannot tell whether a review happened. Treated as
-#                           claiming cleanliness => HARD FAIL, because fail-closed is
-#                           the correct direction when the state is unknowable; an
-#                           unparseable findings state must never DISARM this check.
-# `code-free:` remains an independent, strictly earlier check (it fires pre-enqueue).
-VERDICT_REGION_FILE="$LOG.verdict"
-{ grep -iE '(^|[^[:alnum:]])summary:' "$LOG" 2>/dev/null || true; } >"$VERDICT_REGION_FILE"
-if [ ! -s "$VERDICT_REGION_FILE" ]; then
-  TIER1="UNAVAILABLE"
-elif grep -qi 'no code changes' "$VERDICT_REGION_FILE"; then
-  case "$FINDINGS" in
-    PRESENT*)
-      TIER1="NOTICE (phrase present in a findings-bearing review)"
-      DETAILS+=("NOTICE: vacuity-tier1 (advisory here, does not fail the run): the review's summary mentions 'no code changes' while the census is NON-EMPTY ($CENSUS), but the review reported findings ($FINDINGS) — so it demonstrably analysed the diff and the phrase is discussion, not a vacuity claim.")
-      ;;
-    *)
-      TIER1="FAIL (vacuous verdict vs non-empty census)"
-      DETAILS+=("ERROR: vacuity-tier1: the review's summary claims there are NO CODE CHANGES to review while the locally computed census is NON-EMPTY: $CENSUS (${BASE}...HEAD), and the review reported NO findings (findings: $FINDINGS) — so it is CLAIMING CLEANLINESS on a change it did not review. The reviewer's claim contradicts a fact we measured ourselves: this run is NOT reportable as \"roborev clean\".")
-      if [ "$FINDINGS" = "UNKNOWN" ]; then
-        DETAILS+=("ERROR: vacuity-tier1: the findings state is UNKNOWN (the reviewer errored), which is treated as claiming cleanliness — fail-closed is the correct direction when we cannot tell whether a review happened.")
-      fi
-      ;;
-  esac
-else
-  TIER1="PASS"
-fi
-
-# --- step 6e: tier 2 — token accounting; drift is FAILED, absence is not -------
-# Three distinguishable states (see scripts/flow/roborev-job-facts.py):
-#   absent      -> UNAVAILABLE. A build that reports no token data is a legitimate
-#                  difference, not a signal.
-#   unparseable -> FAIL. A token field IS present but no documented alias resolved to
-#                  a number: EXTERNAL-TOOL DRIFT. Chosen as a FAIL rather than a
-#                  NOTICE because this is exactly how the tier was silently disarmed
-#                  (a rename or a `null` degraded it to a non-failing UNAVAILABLE
-#                  while the real counts were the vacuous baseline and the run
-#                  PASSED). A drift FAIL costs one re-run after a one-line alias
-#                  addition; a silently disarmed guard costs an unreviewed merge.
-#   parsed      -> evaluate the thresholds.
-case "${TOKEN_STATE:-}" in
-  parsed)
-    TOKENS="input=$TOK_IN cached=$TOK_CACHED output=${TOK_OUT:-unknown}"
-    if [ "$JOB_HAS_TOKEN_DATA" = false ]; then
-      DETAILS+=("NOTICE: vacuity-tier2: the job record says has_token_data=false yet readable counts are present — a payload inconsistency (drift signal). The counts are used, because they are what the vacuity check asserts on.")
-    fi
-    tier2_trips=()
-    if [ "$TOK_IN" -lt "$ROBOREV_VACUITY_MIN_INPUT_TOKENS" ]; then
-      tier2_trips+=("observed input=$TOK_IN < ROBOREV_VACUITY_MIN_INPUT_TOKENS=$ROBOREV_VACUITY_MIN_INPUT_TOKENS (highest observed VACUOUS run: 18801)")
-    fi
-    if [ "$TOK_CACHED" -eq 0 ]; then
-      tier2_trips+=("observed cached=$TOK_CACHED == 0 (every observed vacuous run reports exactly 0; the most false-positive-prone term, retained fail-closed)")
-    fi
-    if [ "${#tier2_trips[@]}" -gt 0 ]; then
-      TIER2="FAIL (vacuous token signature)"
-      DETAILS+=("ERROR: vacuity-tier2: the token accounting for job '$JOB' carries the vacuous signature against a NON-EMPTY census ($CENSUS):")
-      for trip in "${tier2_trips[@]}"; do
-        DETAILS+=("  $trip")
-      done
-    else
-      TIER2="PASS"
-    fi
-    # ADVISORY ONLY — never a FAIL condition (see the constants block: a genuine
-    # CLEAN review and a vacuous one emit near-identical output token counts).
-    if [ -n "$TOK_OUT" ] && [ "$TOK_OUT" -lt "$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS" ]; then
-      DETAILS+=("NOTICE: vacuity-tier2 advisory (NOT a failure condition): observed output=$TOK_OUT < ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS. Output tokens cannot discriminate a genuine CLEAN review from a vacuous one (both emit roughly 20-60), so this is reported and never asserted.")
-    fi
-    ;;
-  unparseable)
-    TOKENS="UNAVAILABLE"
-    TIER2="FAIL (token accounting present but unparseable — drift)"
-    DETAILS+=("ERROR: vacuity-tier2: job '$JOB' DOES carry token accounting, but none of the documented field aliases resolved to a number — the installed roborev build has DRIFTED from the shape this guard reads. That is failed closed on purpose: a silently unreadable payload is exactly how this tier was disarmed while the real counts were the vacuous baseline. Add the new field name to scripts/flow/roborev-job-facts.py (INPUT/CACHED/OUTPUT_TOKEN_KEYS) and re-run; do not waive it.")
-    ;;
-  absent)
-    TOKENS="UNAVAILABLE"
-    TIER2="UNAVAILABLE"
-    DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — the job record for '$JOB' carries no token accounting at all. A build that reports none is a legitimate difference, not a signal, so this is a degraded-signal notice and never a silent skip: the deterministic checks still govern, and an unavailable tier 2 can never turn a FAIL into a PASS.")
-    ;;
-  *)
-    TOKENS="UNAVAILABLE"
-    TIER2="UNAVAILABLE"
-    DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — the structured job record for '$JOB' could not be read at all (no python3, no extractor, or no matching job in 'roborev show --json' / 'roborev list --json'). DEGRADED SIGNAL, never a silent skip.")
-    ;;
-esac
+# --- steps 6a-6e: the per-review checks (defined in the sourced checks file) ---
+roborev_check_review_completed
+roborev_check_prompt_content
+roborev_check_findings
+roborev_check_tier1
+roborev_check_tier2
 
 # --- step 7: the verdict ------------------------------------------------------
 # The findings COUNT is best-effort (it counts severity markers in the transcript);

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -27,6 +27,15 @@
 # This wrapper judges the reviewer's claims against a LOCALLY COMPUTED `git` diff
 # census — never against the reviewer's own prose — and fails closed.
 #
+# Corollary the wrapper itself had to learn: EVERY oracle here must be the
+# authoritative source, never a local proxy. The push assert asks the REMOTE via
+# `git ls-remote` because CQLite clones carry a narrow fetch refspec under which a
+# feature branch's `refs/remotes/origin/<branch>` mirror ref is never created — so
+# reading the mirror produced a 100%-reproducible false FAIL that would have pushed
+# agents back to the bare `--branch` form this wrapper exists to replace. Likewise
+# `<base>` is a mirror ref: if it does not resolve, the run FAILs closed rather
+# than reporting an empty census.
+#
 # USAGE
 # -----
 #   scripts/flow/roborev-review.sh --agent <agent> --model <model> \
@@ -315,42 +324,89 @@ fi
 
 # --- step 2: push assert (AC3) — before the census, so the operator gets the ---
 # --- actionable cause ("push your commits") rather than a downstream vacuity ---
+#
+# THE ORACLE IS THE REMOTE, NOT THE LOCAL MIRROR (#2964 follow-up). The obvious
+# implementation — read `refs/remotes/<remote>/<branch>` — is WRONG on this fleet
+# and was a 100%-reproducible false FAIL: CQLite clones carry a NARROW fetch
+# refspec
+#     remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main
+# so `refs/remotes/origin/*` only ever holds `origin/main` (+ `origin/HEAD`). A
+# remote-tracking ref for a feature branch is NEVER created there, no matter how
+# many times the branch is pushed — so "mirror ref absent" says NOTHING about
+# whether the branch is pushed. `git ls-remote` asks the REMOTE, which is the
+# authoritative answer, exactly as the census asks `git` locally rather than
+# believing the reviewer's prose. A local proxy is never authority.
 if [ "$BRANCH" = "HEAD" ]; then
   PUSH_ASSERT="FAIL (detached HEAD)"
-  DETAILS+=("ERROR: push-assert: $REPO is on a detached HEAD, so there is no origin/<branch> to assert against. Check out the issue branch. No review was enqueued.")
+  DETAILS+=("ERROR: push-assert: $REPO is on a detached HEAD, so there is no branch to assert against. Check out the issue branch. No review was enqueued.")
   finish FAIL 1
 fi
 
-REMOTE_SHA=""
-if ! REMOTE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "refs/remotes/origin/$BRANCH"); then
-  PUSH_ASSERT="FAIL (no remote branch origin/$BRANCH)"
-  DETAILS+=("ERROR: push-assert: remote branch 'origin/$BRANCH' does not exist — this branch has never been pushed. The reviewer can only see what the remote has, so an unpushed branch is itself an empty-diff cause. No review was enqueued.")
-  finish FAIL 1
-fi
+# Prefer the branch's CONFIGURED upstream remote; fall back to `origin`.
+REMOTE=$(git -C "$REPO" config --get "branch.$BRANCH.remote" 2>/dev/null || printf '')
+[ -n "$REMOTE" ] || REMOTE=origin
 
-if [ "$REMOTE_SHA" != "$HEAD_SHA" ]; then
-  PUSH_ASSERT="FAIL (unpushed commits)"
-  DETAILS+=("ERROR: push-assert: origin/$BRANCH ($REMOTE_SHA) != local HEAD ($HEAD_SHA).")
-  unpushed=$(git -C "$REPO" log --oneline "refs/remotes/origin/$BRANCH..HEAD" 2>/dev/null || printf '')
-  if [ -n "$unpushed" ]; then
-    DETAILS+=("ERROR: push-assert: unpushed commit(s):")
+# FAST PATH (optional, saves a remote round trip): a mirror ref that EXISTS and
+# already equals HEAD is proof enough. Its ABSENCE proves nothing — fall through.
+MIRROR_SHA=$(git -C "$REPO" rev-parse --verify --quiet "refs/remotes/$REMOTE/$BRANCH" || printf '')
+if [ "$MIRROR_SHA" = "$HEAD_SHA" ]; then
+  PUSH_ASSERT="PASS"
+else
+  set +e
+  LS_OUT=$(git -C "$REPO" ls-remote --heads "$REMOTE" "$BRANCH" 2>&1)
+  LS_RC=$?
+  set -e
+  if [ "$LS_RC" -ne 0 ]; then
+    # NOT "never pushed" — a misattributed cause sends people to fix the wrong
+    # thing. `git` and `gh` are SEPARATE credential paths (#2942): an
+    # authenticated `gh` with an unwired git fails every remote read here.
+    PUSH_ASSERT="FAIL (ls-remote failed: infra/auth)"
+    DETAILS+=("ERROR: push-assert: 'git ls-remote --heads $REMOTE $BRANCH' exited $LS_RC, so the remote state is UNKNOWN. This is an INFRA/AUTH condition, NOT evidence that the branch is unpushed — do not 'fix' it by pushing. git and gh are separate credential paths (#2942): check network reachability and git's own credentials ('gh auth setup-git'). git said:")
     while IFS= read -r line; do
       [ -n "$line" ] || continue
       DETAILS+=("  $line")
-    done <<<"$unpushed"
-  else
-    DETAILS+=("ERROR: push-assert: local HEAD is not ahead of origin/$BRANCH — the branch has diverged from its remote; reconcile before reviewing.")
+    done <<<"$LS_OUT"
+    DETAILS+=("ERROR: push-assert: failing closed on an unknown remote state. No review was enqueued.")
+    finish FAIL 1
   fi
-  DETAILS+=("ERROR: push-assert: push the branch before reviewing. No review was enqueued.")
-  finish FAIL 1
+  REMOTE_SHA=$(printf '%s\n' "$LS_OUT" | awk -v ref="refs/heads/$BRANCH" '$2 == ref { print $1; exit }')
+  if [ -z "$REMOTE_SHA" ]; then
+    PUSH_ASSERT="FAIL (branch absent on remote $REMOTE)"
+    DETAILS+=("ERROR: push-assert: the remote '$REMOTE' has no branch '$BRANCH' (authoritative: git ls-remote) — this branch has never been pushed. The reviewer can only see what the remote has, so an unpushed branch is itself an empty-diff cause. Push it, then re-run. No review was enqueued.")
+    finish FAIL 1
+  fi
+  if [ "$REMOTE_SHA" != "$HEAD_SHA" ]; then
+    PUSH_ASSERT="FAIL (unpushed commits)"
+    DETAILS+=("ERROR: push-assert: $REMOTE/$BRANCH is at $REMOTE_SHA (authoritative: git ls-remote) but local HEAD is $HEAD_SHA.")
+    unpushed=""
+    if git -C "$REPO" cat-file -e "${REMOTE_SHA}^{commit}" 2>/dev/null; then
+      unpushed=$(git -C "$REPO" log --oneline "$REMOTE_SHA..HEAD" 2>/dev/null || printf '')
+    fi
+    if [ -n "$unpushed" ]; then
+      DETAILS+=("ERROR: push-assert: unpushed commit(s):")
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        DETAILS+=("  $line")
+      done <<<"$unpushed"
+    else
+      DETAILS+=("ERROR: push-assert: local HEAD is not a descendant of the remote tip (or the remote tip is not present locally) — the branch has diverged; reconcile before reviewing.")
+    fi
+    DETAILS+=("ERROR: push-assert: push the branch before reviewing. No review was enqueued.")
+    finish FAIL 1
+  fi
+  PUSH_ASSERT="PASS"
 fi
-PUSH_ASSERT="PASS"
 
 # --- step 3: the local diff census — THE ORACLE -------------------------------
+# `<base>` (default `origin/main`) IS a local mirror ref, so it can be stale or —
+# on a narrow-refspec clone that has never fetched — absent. Fail CLOSED: an
+# unresolvable base must never be allowed to produce an empty census, which would
+# surface as NOTHING-TO-REVIEW and read as "nothing to look at" rather than "we
+# could not tell". No implicit `git fetch` is performed on the caller's behalf.
 BASE_SHA=""
 if ! BASE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "${BASE}^{commit}"); then
   CENSUS_CHECK="FAIL (base '$BASE' unresolvable)"
-  DETAILS+=("ERROR: census: base ref '$BASE' does not resolve to a commit in $REPO — the census, and therefore every vacuity judgement, would be unfounded. No review was enqueued.")
+  DETAILS+=("ERROR: census: base ref '$BASE' does not resolve to a commit in $REPO, so the census — and therefore every vacuity judgement — would be unfounded. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW: an unresolvable base is 'we cannot tell', never 'there is nothing to review'. If '$BASE' is a remote-tracking ref, this clone may have a narrow fetch refspec or have never fetched it; fetch it yourself (the wrapper never fetches behind your back) and re-run. No review was enqueued.")
   finish FAIL 1
 fi
 

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -531,17 +531,6 @@ fact() { sed -n "s/^$1=//p" "$FACTS_FILE" | head -1; }
 # the transcript alone, tier 2 to UNAVAILABLE, model to UNCONFIRMED) — the same
 # "silently disarmable" class as the token-shape drift.
 # So POLL, bounded, until the fields the asserts need are present.
-read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FILE
-  local show_json list_json
-  show_json=$(roborev show "$1" --json 2>/dev/null || printf '')
-  if ! extract_job_facts "$1" "$show_json" "$FACTS_FILE" "$PROMPT_FILE"; then
-    list_json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '')
-    extract_job_facts "$1" "$list_json" "$FACTS_FILE" "$PROMPT_FILE" || return 1
-  fi
-  return 0
-}
-
-# REQUIRED to stop polling: the fields without which an assert cannot run at all.
 record_required_present() {
   local status
   [ -n "$(fact git_ref)" ] || return 1
@@ -558,6 +547,40 @@ record_complete() {
   return 0
 }
 
+# TWO SOURCES, DIFFERENT SHAPES — try both and keep the one that actually answers
+# (MEASURED, issue #2964 round 5). `roborev show <job> --json` returns the REVIEW row:
+# a parseable object carrying id/agent/prompt but NO git_ref, NO status, NO verdict and
+# NO token_usage. `roborev list --json` returns the JOB row, which has all of them.
+# Accepting the first payload that merely PARSED meant the richer source was never
+# consulted, and the record looked permanently incomplete — which read as an async lag
+# and silently downgraded sha-assert, tier 2 and model on every real run. So a source
+# only counts when it yields the fields the asserts require.
+read_job_record() { # read_job_record <job> -> populates FACTS_FILE / PROMPT_FILE
+  local payload best_facts="$FACTS_FILE.candidate"
+  : >"$best_facts"
+  for payload in show list; do
+    local json=""
+    case "$payload" in
+      show) json=$(roborev show "$1" --json 2>/dev/null || printf '') ;;
+      list) json=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '') ;;
+    esac
+    extract_job_facts "$1" "$json" "$FACTS_FILE" "$PROMPT_FILE" || continue
+    if record_required_present; then
+      rm -f "$best_facts"
+      return 0
+    fi
+    # Keep the poorer payload only as a last resort, so nothing is LOST if no source is
+    # complete, but never let it shadow a source that has the required fields.
+    cp "$FACTS_FILE" "$best_facts"
+  done
+  if [ -s "$best_facts" ]; then
+    cp "$best_facts" "$FACTS_FILE"
+  fi
+  rm -f "$best_facts"
+  return 1
+}
+
+# REQUIRED to stop polling: the fields without which an assert cannot run at all.
 if [ "$announce_ok" -eq 1 ]; then
   record_polls=0
   token_grace_used=0

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -63,21 +63,24 @@
 # agent-gate summary headers so neither can ever be pasted as the other:
 #
 #   ==== ROBOREV REVIEW SUMMARY ====
-#   repo: / branch: / base: / head-sha: / reviewed-sha: / job: / census: / tokens:
-#   push-assert: / census-check: / sha-assert: / vacuity-tier1: / vacuity-tier2:
-#   roborev-exit: / log:
+#   repo: / branch: / base: / head-sha: / reviewed-sha: / job: / model: / census:
+#   tokens: / push-assert: / census-check: / sha-assert: / vacuity-tier1:
+#   prompt-content: / vacuity-tier2: / findings: / roborev-exit: / log:
 #   RESULT: PASS|FAIL|NOTHING-TO-REVIEW
 #
 # Per-check values are PASS | FAIL | SKIP | UNAVAILABLE (a FAIL may carry a
 # parenthesised reason). `census:` is `<N> files, +<A>/-<D>`; `tokens:` is
-# `input=<n> cached=<n> output=<n>` or `UNAVAILABLE`.
+# `input=<n> cached=<n> output=<n>` or `UNAVAILABLE`. `findings:` is
+# `NONE | PRESENT [(<n>)] | UNKNOWN`. `roborev-exit:` is `PASS | FINDINGS (exit N) |
+# ERROR (exit N) | SKIP` — FINDINGS means the reviewer RAN and reported findings (a
+# GENUINE review to triage and fix), ERROR means the reviewer itself failed.
 #
 # EXIT CODES (exactly three outcomes plus a usage code)
 #   0  PASS               — reviewed, sha verified, no vacuity signal.
 #   1  FAIL               — any failed check: push-assert, census-check, sha-assert,
-#                           vacuity-tier1, vacuity-tier2, or roborev-exit (the
-#                           reviewer process's own status). Each names itself under
-#                           its own key. NOT reportable as "roborev clean".
+#                           vacuity-tier1, prompt-content, vacuity-tier2, or
+#                           roborev-exit (FINDINGS or ERROR). Each names itself
+#                           under its own key. NOT reportable as "roborev clean".
 #   3  NOTHING-TO-REVIEW  — the census is genuinely empty; NO review was enqueued.
 #                           DISTINCT from PASS by exit code alone, so a caller can
 #                           never mistake "nothing to review" for "reviewed clean".
@@ -91,49 +94,62 @@
 # LIVE WORKTREE PROBE (documented, NOT gate-run — needs network + a live reviewer)
 # -------------------------------------------------------------------------------
 # The hermetic regression check (scripts/tests/test_roborev_review_guard.sh) pins
-# every guard against a stub reviewer. Only this probe can prove the REAL external
-# binary honours the explicit `--repo` from inside a worktree. Procedure:
-#
-#   1. Confirm the ROOT checkout sits on `main` (that is what makes trigger 1
-#      reproducible):  git -C <root> rev-parse --abbrev-ref HEAD   # => main
-#   2. From a real issue worktree on its own branch, with its commit PUSHED:
-#        cd /path/to/cqlite-wt/issue-<N>
-#        scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol
-#   3. Read ONLY the emitted summary block and assert:
-#        head-sha:      == the WORKTREE branch HEAD (git rev-parse HEAD)
-#        reviewed-sha:  == head-sha (prefix match)     <-- the probe's point
-#        reviewed-sha:  != `git rev-parse origin/main` <-- trigger 1 defeated
-#        sha-assert:    PASS
-#        census:        matches `git diff --numstat origin/main...HEAD`
-#        tokens:        input/cached/output all above the thresholds below
-#        RESULT:        PASS   (exit 0)
-#      A `reviewed-sha` equal to `origin/main` means the explicit-repo invocation
-#      did NOT defeat the root-checkout resolution and the wrapper must be fixed
-#      before any verdict from it is trusted.
-#   4. Record the observed head-sha / reviewed-sha / job / census / tokens in the
-#      PR body as the live evidence. Re-run after any roborev version bump.
+# every guard against a stub reviewer. Only the live probe can show the REAL binary
+# honours the explicit `--repo` from inside a worktree. Its full procedure and the
+# summary-block values it must produce are in the `--help` output (the wrapper's
+# usage documentation) — run `roborev-review.sh --help` rather than duplicating it
+# here, so the two can never drift apart.
 set -euo pipefail
 
-# --- Tier-2 vacuity thresholds (named constants; measured evidence below) -------
+# --- Vacuity signals: two DETERMINISTIC checks, then ADVISORY token accounting --
+#
+# The load-bearing checks are threshold-free and judged against our own locally
+# computed census:
+#   * verdict-text-vs-census (tier 1) catches "the reviewer GOT the diff and
+#     DISCARDED it" — the code-free-diff trigger T3.
+#   * prompt-content catches "the reviewer NEVER GOT the diff" — triggers T1/T2 and
+#     any future variant of them, since it reads the prompt actually sent and looks
+#     for our census's own file paths in it.
+# Together they cover both halves deterministically. Token accounting is a THIRD,
+# ADVISORY-corroborating signal that can only ever fail CLOSED.
 #
 # MEASURED EVIDENCE (issue #2964, real jobs on the fleet):
-#   GENUINE reviews:  398k-649k input, 314k-554k cached, 5.0k-6.3k output,
-#                     2m25s-2m45s wall  (jobs 4652 / 4654 / 4656)
-#   VACUOUS baseline: 18,700-18,801 input, 0 cached, 53-56 output, 8s wall
-#                     (jobs 4658 / 4659 — reproducible)
-#   KNOWN-EMPTY diff: 17,333 input, 21 output  (job 4651)
+#   VACUOUS baseline:  17,333-18,801 input, 0 cached, 21-56 output, 8s wall
+#                      (jobs 4651 / 4658 / 4659 — reproducible)
+#   GENUINE, SMALL:    67,387 input, 43,520 cached, 2,232 output, 68s wall
+#                      (job 1 on this branch: 20 files, +2279)
+#   GENUINE, LARGE:    398k-649k input, 314k-554k cached, 5.0k-6.3k output
+#                      (jobs 4652 / 4654 / 4656)
 #
-# So 50,000 input sits ~2.7x above the vacuous ceiling (18,801) and ~8x below the
-# genuine floor (398k); 200 output sits ~3.6x above the vacuous ceiling (56) and
-# ~25x below the genuine floor (5,067). Wall time is deliberately NOT asserted
-# (host-dependent — #2642).
+# INPUT FLOOR is anchored on the VACUOUS CEILING, not the genuine band: the
+# genuine band scales with diff size, so a floor derived from it false-FAILs small
+# genuine reviews. 25,000 sits ~1.33x above the highest observed vacuous run
+# (18,801) and ~2.7x below the smallest observed genuine run (67,387). The
+# original 50,000 was only 1.35x below that 67k run — one modestly smaller genuine
+# diff away from an always-red guard, which is the failure mode that gets a guard
+# bypassed (cf. the mirror-ref push-assert regression).
 #
-# Tier 2 is CORROBORATING and can ONLY fail closed: it can never manufacture a
-# PASS, never relax a tier-1 FAIL, and its unavailability is stamped visibly
-# rather than skipped silently. Recalibrating means editing these two constants
-# and this evidence block together.
-ROBOREV_VACUITY_MIN_INPUT_TOKENS=50000
-ROBOREV_VACUITY_MIN_OUTPUT_TOKENS=200
+# OUTPUT TOKENS ARE ADVISORY ONLY — NEVER a FAIL condition. A genuine CLEAN review
+# and a vacuous one emit nearly IDENTICAL output: both are "No issues found." plus
+# a one-sentence summary (~20-60 tokens; the vacuous baseline measured 21-56). The
+# counts therefore COLLIDE, and any output floor would false-FAIL precisely the
+# case we care most about — a real review that is legitimately clean. Reported for
+# the operator, never asserted.
+#
+# CACHED == 0 stays a FAIL condition. It is the most false-positive-prone term
+# (a genuinely cold cache can report 0), retained deliberately in the fail-closed
+# direction — acceptable now that prompt-content gives a deterministic primary
+# check, so tier 2 is no longer the only thing standing between us and a vacuous
+# pass. Wall time is deliberately NOT asserted (host-dependent — #2642).
+ROBOREV_VACUITY_MIN_INPUT_TOKENS=25000
+# Advisory only (see above): reported next to the observed value, never a FAIL.
+ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=200
+
+# prompt-content check: how many census paths to look for in the prompt actually
+# sent to the reviewer. All of them when the census is small; an evenly sampled
+# subset (still ALL of which must be present) when it is large, so the check stays
+# bounded on a 500-file diff.
+PROMPT_CONTENT_MAX_PATHS_CHECKED=40
 
 # Code-free (non-code) census classification. A census consisting ENTIRELY of
 # these extensions/prefixes is structurally discarded by roborev (trigger 3), so
@@ -255,18 +271,25 @@ mkdir -p "$(dirname "$LOG")"
 # --- summary state -------------------------------------------------------------
 REVIEWED_SHA="-"
 JOB="-"
+MODEL_LINE="-"
 CENSUS="-"
 TOKENS="UNAVAILABLE"
 PUSH_ASSERT="SKIP"
 CENSUS_CHECK="SKIP"
 SHA_ASSERT="SKIP"
 TIER1="SKIP"
+PROMPT_CONTENT="SKIP"
 TIER2="SKIP"
-# The reviewer process's OWN exit status, under its own greppable key: a caller
-# retains only the block and reads it by grepping the per-check keys, so without
-# this key a non-zero roborev exit shows up as every check reading PASS beside a
-# RESULT: FAIL — the one failure cause a grep-based reader could not attribute.
-# SKIP until the process actually runs (a push/census/PATH failure exits earlier).
+FINDINGS="SKIP"
+# The reviewer process's OWN status, under its own greppable key: a caller retains
+# only the block and reads it by grepping the per-check keys, so without this key a
+# non-zero roborev exit shows up as every check reading PASS beside a RESULT: FAIL
+# — the one failure cause a grep-based reader could not attribute. Values:
+#   PASS            process exited 0
+#   FINDINGS (exit N)  the review RAN and reported findings — a GENUINE review whose
+#                   findings must be triaged, NOT a reviewer malfunction
+#   ERROR (exit N)  the reviewer itself failed (status not done / no review body)
+#   SKIP            a push/census/PATH failure exited before the process ran
 ROBOREV_EXIT="SKIP"
 RESULT="FAIL"
 DETAILS=()
@@ -280,13 +303,16 @@ emit_summary() {
   printf 'head-sha: %s\n' "${HEAD_SHA:--}"
   printf 'reviewed-sha: %s\n' "$REVIEWED_SHA"
   printf 'job: %s\n' "$JOB"
+  printf 'model: %s\n' "$MODEL_LINE"
   printf 'census: %s\n' "$CENSUS"
   printf 'tokens: %s\n' "$TOKENS"
   printf 'push-assert: %s\n' "$PUSH_ASSERT"
   printf 'census-check: %s\n' "$CENSUS_CHECK"
   printf 'sha-assert: %s\n' "$SHA_ASSERT"
   printf 'vacuity-tier1: %s\n' "$TIER1"
+  printf 'prompt-content: %s\n' "$PROMPT_CONTENT"
   printf 'vacuity-tier2: %s\n' "$TIER2"
+  printf 'findings: %s\n' "$FINDINGS"
   printf 'roborev-exit: %s\n' "$ROBOREV_EXIT"
   printf 'log: %s\n' "$LOG"
   printf 'RESULT: %s\n' "$RESULT"
@@ -346,56 +372,56 @@ fi
 REMOTE=$(git -C "$REPO" config --get "branch.$BRANCH.remote" 2>/dev/null || printf '')
 [ -n "$REMOTE" ] || REMOTE=origin
 
-# FAST PATH (optional, saves a remote round trip): a mirror ref that EXISTS and
-# already equals HEAD is proof enough. Its ABSENCE proves nothing — fall through.
-MIRROR_SHA=$(git -C "$REPO" rev-parse --verify --quiet "refs/remotes/$REMOTE/$BRANCH" || printf '')
-if [ "$MIRROR_SHA" = "$HEAD_SHA" ]; then
-  PUSH_ASSERT="PASS"
-else
-  set +e
-  LS_OUT=$(git -C "$REPO" ls-remote --heads "$REMOTE" "$BRANCH" 2>&1)
-  LS_RC=$?
-  set -e
-  if [ "$LS_RC" -ne 0 ]; then
-    # NOT "never pushed" — a misattributed cause sends people to fix the wrong
-    # thing. `git` and `gh` are SEPARATE credential paths (#2942): an
-    # authenticated `gh` with an unwired git fails every remote read here.
-    PUSH_ASSERT="FAIL (ls-remote failed: infra/auth)"
-    DETAILS+=("ERROR: push-assert: 'git ls-remote --heads $REMOTE $BRANCH' exited $LS_RC, so the remote state is UNKNOWN. This is an INFRA/AUTH condition, NOT evidence that the branch is unpushed — do not 'fix' it by pushing. git and gh are separate credential paths (#2942): check network reachability and git's own credentials ('gh auth setup-git'). git said:")
+# NO MIRROR-REF FAST PATH. An earlier revision short-circuited when
+# `refs/remotes/<remote>/<branch>` happened to equal HEAD; that is unsound, and the
+# reviewer flagged it. A CACHED mirror ref survives a force-push or an outright
+# DELETION of the remote branch, so it can equal HEAD while the remote no longer
+# has the commit at all — the wrapper would then enqueue a review for a commit the
+# reviewer cannot fetch, which is precisely a vacuous-review setup. `ls-remote`
+# costs ~1s, and not trusting local proxies is this wrapper's whole point.
+set +e
+LS_OUT=$(git -C "$REPO" ls-remote --heads "$REMOTE" "$BRANCH" 2>&1)
+LS_RC=$?
+set -e
+if [ "$LS_RC" -ne 0 ]; then
+  # NOT "never pushed" — a misattributed cause sends people to fix the wrong
+  # thing. `git` and `gh` are SEPARATE credential paths (#2942): an
+  # authenticated `gh` with an unwired git fails every remote read here.
+  PUSH_ASSERT="FAIL (ls-remote failed: infra/auth)"
+  DETAILS+=("ERROR: push-assert: 'git ls-remote --heads $REMOTE $BRANCH' exited $LS_RC, so the remote state is UNKNOWN. This is an INFRA/AUTH condition, NOT evidence that the branch is unpushed — do not 'fix' it by pushing. git and gh are separate credential paths (#2942): check network reachability and git's own credentials ('gh auth setup-git'). git said:")
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    DETAILS+=("  $line")
+  done <<<"$LS_OUT"
+  DETAILS+=("ERROR: push-assert: failing closed on an unknown remote state. No review was enqueued.")
+  finish FAIL 1
+fi
+REMOTE_SHA=$(printf '%s\n' "$LS_OUT" | awk -v ref="refs/heads/$BRANCH" '$2 == ref { print $1; exit }')
+if [ -z "$REMOTE_SHA" ]; then
+  PUSH_ASSERT="FAIL (branch absent on remote $REMOTE)"
+  DETAILS+=("ERROR: push-assert: the remote '$REMOTE' has no branch '$BRANCH' (authoritative: git ls-remote) — this branch has never been pushed. The reviewer can only see what the remote has, so an unpushed branch is itself an empty-diff cause. Push it, then re-run. No review was enqueued.")
+  finish FAIL 1
+fi
+if [ "$REMOTE_SHA" != "$HEAD_SHA" ]; then
+  PUSH_ASSERT="FAIL (unpushed commits)"
+  DETAILS+=("ERROR: push-assert: $REMOTE/$BRANCH is at $REMOTE_SHA (authoritative: git ls-remote) but local HEAD is $HEAD_SHA.")
+  unpushed=""
+  if git -C "$REPO" cat-file -e "${REMOTE_SHA}^{commit}" 2>/dev/null; then
+    unpushed=$(git -C "$REPO" log --oneline "$REMOTE_SHA..HEAD" 2>/dev/null || printf '')
+  fi
+  if [ -n "$unpushed" ]; then
+    DETAILS+=("ERROR: push-assert: unpushed commit(s):")
     while IFS= read -r line; do
       [ -n "$line" ] || continue
       DETAILS+=("  $line")
-    done <<<"$LS_OUT"
-    DETAILS+=("ERROR: push-assert: failing closed on an unknown remote state. No review was enqueued.")
-    finish FAIL 1
+    done <<<"$unpushed"
+  else
+    DETAILS+=("ERROR: push-assert: local HEAD is not a descendant of the remote tip (or the remote tip is not present locally) — the branch has diverged; reconcile before reviewing.")
   fi
-  REMOTE_SHA=$(printf '%s\n' "$LS_OUT" | awk -v ref="refs/heads/$BRANCH" '$2 == ref { print $1; exit }')
-  if [ -z "$REMOTE_SHA" ]; then
-    PUSH_ASSERT="FAIL (branch absent on remote $REMOTE)"
-    DETAILS+=("ERROR: push-assert: the remote '$REMOTE' has no branch '$BRANCH' (authoritative: git ls-remote) — this branch has never been pushed. The reviewer can only see what the remote has, so an unpushed branch is itself an empty-diff cause. Push it, then re-run. No review was enqueued.")
-    finish FAIL 1
-  fi
-  if [ "$REMOTE_SHA" != "$HEAD_SHA" ]; then
-    PUSH_ASSERT="FAIL (unpushed commits)"
-    DETAILS+=("ERROR: push-assert: $REMOTE/$BRANCH is at $REMOTE_SHA (authoritative: git ls-remote) but local HEAD is $HEAD_SHA.")
-    unpushed=""
-    if git -C "$REPO" cat-file -e "${REMOTE_SHA}^{commit}" 2>/dev/null; then
-      unpushed=$(git -C "$REPO" log --oneline "$REMOTE_SHA..HEAD" 2>/dev/null || printf '')
-    fi
-    if [ -n "$unpushed" ]; then
-      DETAILS+=("ERROR: push-assert: unpushed commit(s):")
-      while IFS= read -r line; do
-        [ -n "$line" ] || continue
-        DETAILS+=("  $line")
-      done <<<"$unpushed"
-    else
-      DETAILS+=("ERROR: push-assert: local HEAD is not a descendant of the remote tip (or the remote tip is not present locally) — the branch has diverged; reconcile before reviewing.")
-    fi
-    DETAILS+=("ERROR: push-assert: push the branch before reviewing. No review was enqueued.")
-    finish FAIL 1
-  fi
-  PUSH_ASSERT="PASS"
+  DETAILS+=("ERROR: push-assert: push the branch before reviewing. No review was enqueued.")
+  finish FAIL 1
 fi
+PUSH_ASSERT="PASS"
 
 # --- step 3: the local diff census — THE ORACLE -------------------------------
 # `<base>` (default `origin/main`) IS a local mirror ref, so it can be stale or —
@@ -410,16 +436,23 @@ if ! BASE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "${BASE}^{commit}"); t
   finish FAIL 1
 fi
 
-NUMSTAT=$(git -C "$REPO" diff --numstat "${BASE}...HEAD" 2>/dev/null || printf '')
+# `--no-renames` on purpose: with rename detection a renamed file is reported as the
+# composite path `dir/{old => new}.rs`, which is not a real path and so can never be
+# found in the reviewer's prompt (the prompt-content check below matches literal
+# paths). Splitting a rename into its delete+add pair keeps every census path a real
+# one, at the cost of counting it as two files.
+NUMSTAT=$(git -C "$REPO" diff --numstat --no-renames "${BASE}...HEAD" 2>/dev/null || printf '')
 census_files=0
 census_added=0
 census_deleted=0
 census_code_free=1
+census_paths=()
 while IFS=$'\t' read -r add del path; do
   [ -n "${path:-}" ] || continue
   if [ "$add" = "-" ]; then add=0; fi
   if [ "$del" = "-" ]; then del=0; fi
   census_files=$((census_files + 1))
+  census_paths+=("$path")
   census_added=$((census_added + add))
   census_deleted=$((census_deleted + del))
   # Code-free classification: the file must match a documented non-code extension
@@ -464,37 +497,200 @@ roborev review "$HEAD_SHA" \
   --wait >"$LOG" 2>&1
 REVIEW_RC=$?
 set -e
-if [ "$REVIEW_RC" -eq 0 ]; then
-  ROBOREV_EXIT="PASS"
-else
-  ROBOREV_EXIT="FAIL (exit $REVIEW_RC)"
-fi
 
-# --- step 5: reviewed-SHA assert (AC2) ----------------------------------------
+# --- step 5: reviewed-SHA assert (AC2) — STRUCTURED data is the oracle ---------
+#
+# The job record's `git_ref` field (from `roborev show <job> --json`, falling back
+# to `roborev list --json`) is a FULL 40-char sha recorded by roborev itself, so it
+# is compared full-sha to full-sha. The stdout `Enqueued job <N> for <sha>` line is
+# now a CROSS-CHECK ONLY: parsing a tool's prose is the weaker source whenever a
+# structured one exists. Its ABSENCE is still a hard failure — it carries the job
+# id every structured query needs, so without it nothing is verifiable.
 ANNOUNCE=$(grep -oiE 'enqueued job [0-9]+ for [0-9a-fA-F]{4,40}' "$LOG" | tail -1 || printf '')
+ANNOUNCED_SHA=""
+announce_ok=0
 if [ -z "$ANNOUNCE" ]; then
   SHA_ASSERT="FAIL (no parseable enqueue announcement)"
-  DETAILS+=("ERROR: sha-assert: the transcript contains no parseable 'Enqueued job <N> for <sha>' line, so the reviewed sha is UNVERIFIABLE. That is a failure, never a skipped check. Transcript: $LOG")
+  DETAILS+=("ERROR: sha-assert: the transcript contains no parseable 'Enqueued job <N> for <sha>' line, so neither the job record nor the reviewed sha can be located and the review is UNVERIFIABLE. That is a failure, never a skipped check. Transcript: $LOG")
 else
+  announce_ok=1
   JOB=$(printf '%s' "$ANNOUNCE" | sed -E 's/^[Ee]nqueued [Jj]ob ([0-9]+).*/\1/')
-  REVIEWED_SHA=$(printf '%s' "$ANNOUNCE" | sed -E 's/.*[Ff]or ([0-9a-fA-F]+)$/\1/' | tr 'A-F' 'a-f')
-  if [ "${HEAD_SHA:0:${#REVIEWED_SHA}}" = "$REVIEWED_SHA" ] \
-    || [ "${REVIEWED_SHA:0:${#HEAD_SHA}}" = "$HEAD_SHA" ]; then
-    SHA_ASSERT="PASS"
-  else
-    SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
-    DETAILS+=("ERROR: sha-assert: announced reviewed-sha '$REVIEWED_SHA' does not prefix-match branch HEAD '$HEAD_SHA' (job $JOB).")
-    if [ "${BASE_SHA:0:${#REVIEWED_SHA}}" = "$REVIEWED_SHA" ]; then
-      DETAILS+=("ERROR: sha-assert: the announced sha EQUALS the base ref '$BASE' ($BASE_SHA) — NO branch change was reviewed. That equality is the signature of the worktree bare-'--branch' resolution trigger, where the review resolves against the ROOT checkout instead of this worktree.")
+  ANNOUNCED_SHA=$(printf '%s' "$ANNOUNCE" | sed -E 's/.*[Ff]or ([0-9a-fA-F]+)$/\1/' | tr 'A-F' 'a-f')
+fi
+
+# --- structured job facts ------------------------------------------------------
+# Diagnostics live beside the transcript, both named in the block via `log:`.
+FACTS_FILE="$LOG.facts"
+PROMPT_FILE="$LOG.prompt"
+: >"$FACTS_FILE"
+: >"$PROMPT_FILE"
+
+# extract_job_facts <job> <json> <facts-out> <prompt-out>
+# Emits `key=value` lines for the fields the asserts need, and writes the prompt
+# actually sent to the reviewer to its own file. `token_usage` is a JSON-ENCODED
+# STRING in the real payload (it must be decoded TWICE), and the output field is
+# `total_output_tokens`; both `total_output_tokens` and `output_tokens` are accepted
+# so a rename in either direction keeps working. Absence stays UNAVAILABLE.
+extract_job_facts() {
+  command -v python3 >/dev/null 2>&1 || return 1
+  [ -n "$2" ] || return 1
+  printf '%s' "$2" | python3 -c '
+import json, sys
+want, facts_path, prompt_path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+def objects(node):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            for found in objects(value):
+                yield found
+    elif isinstance(node, list):
+        for value in node:
+            for found in objects(value):
+                yield found
+
+job = None
+for obj in objects(data):
+    for key in ("id", "job_id", "job"):
+        if key in obj and str(obj[key]) == want:
+            job = obj
+            break
+    if job is not None:
+        break
+if job is None:
+    # A `show --json` payload may be the single job with no id echoed back.
+    for obj in objects(data):
+        if "git_ref" in obj or "token_usage" in obj:
+            job = obj
+            break
+if job is None:
+    sys.exit(1)
+
+usage = job.get("token_usage")
+if isinstance(usage, str):
+    try:
+        usage = json.loads(usage)
+    except Exception:
+        usage = None
+if not isinstance(usage, dict):
+    usage = {}
+
+def number(*keys):
+    for key in keys:
+        value = usage.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return str(value)
+        if isinstance(value, float):
+            return str(int(value))
+        if isinstance(value, str):
+            text = value.strip()
+            if text.lstrip("-").isdigit():
+                return str(int(text))
+    return ""
+
+lines = []
+for key in ("git_ref", "status", "model", "requested_model"):
+    value = job.get(key)
+    if isinstance(value, str) and value.strip():
+        lines.append(key + "=" + " ".join(value.split()))
+lines.append("input_tokens=" + number("input_tokens"))
+lines.append("cached_input_tokens=" + number("cached_input_tokens", "cached_tokens"))
+lines.append("output_tokens=" + number("total_output_tokens", "output_tokens"))
+with open(facts_path, "w") as handle:
+    handle.write("\n".join(lines) + "\n")
+
+prompt = job.get("prompt")
+if isinstance(prompt, str) and prompt.strip():
+    with open(prompt_path, "w") as handle:
+        handle.write(prompt)
+' "$1" "$3" "$4" 2>/dev/null
+}
+
+fact() { sed -n "s/^$1=//p" "$FACTS_FILE" | head -1; }
+
+if [ "$announce_ok" -eq 1 ]; then
+  SHOW_JSON=$(roborev show "$JOB" --json 2>/dev/null || printf '')
+  if ! extract_job_facts "$JOB" "$SHOW_JSON" "$FACTS_FILE" "$PROMPT_FILE"; then
+    LIST_JSON=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '')
+    extract_job_facts "$JOB" "$LIST_JSON" "$FACTS_FILE" "$PROMPT_FILE" || true
+  fi
+  # The prompt may not be carried in the JSON payload; ask for it directly.
+  if [ ! -s "$PROMPT_FILE" ]; then
+    roborev show "$JOB" --prompt >"$PROMPT_FILE" 2>/dev/null || : >"$PROMPT_FILE"
+  fi
+fi
+
+JOB_GIT_REF=$(fact git_ref | tr 'A-F' 'a-f')
+JOB_STATUS=$(fact status)
+JOB_MODEL=$(fact model)
+JOB_REQUESTED_MODEL=$(fact requested_model)
+TOK_IN=$(fact input_tokens)
+TOK_CACHED=$(fact cached_input_tokens)
+TOK_OUT=$(fact output_tokens)
+
+if [ "$announce_ok" -eq 1 ]; then
+  if [ -n "$JOB_GIT_REF" ]; then
+    REVIEWED_SHA="$JOB_GIT_REF"
+    if [ "$JOB_GIT_REF" = "$HEAD_SHA" ]; then
+      SHA_ASSERT="PASS"
     else
-      DETAILS+=("ERROR: sha-assert: the announced sha matches NEITHER endpoint (head '$HEAD_SHA', base '$BASE' $BASE_SHA) — the signature of the non-sanctioned two-positional commit-range form.")
+      SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
+      DETAILS+=("ERROR: sha-assert: the job record's git_ref '$JOB_GIT_REF' does not equal branch HEAD '$HEAD_SHA' (job $JOB).")
+      if [ "$JOB_GIT_REF" = "$BASE_SHA" ]; then
+        DETAILS+=("ERROR: sha-assert: the reviewed sha EQUALS the base ref '$BASE' ($BASE_SHA) — NO branch change was reviewed. That equality is the signature of the worktree bare-'--branch' resolution trigger, where the review resolves against the ROOT checkout instead of this worktree.")
+      else
+        DETAILS+=("ERROR: sha-assert: the reviewed sha matches NEITHER endpoint (head '$HEAD_SHA', base '$BASE' $BASE_SHA) — the signature of the non-sanctioned two-positional commit-range form.")
+      fi
+    fi
+    if [ -n "$ANNOUNCED_SHA" ] && [ "${JOB_GIT_REF:0:${#ANNOUNCED_SHA}}" != "$ANNOUNCED_SHA" ]; then
+      DETAILS+=("NOTICE: sha-assert cross-check: stdout announced '$ANNOUNCED_SHA' but the job record's git_ref is '$JOB_GIT_REF'. The structured field is the oracle; the disagreement is recorded because it means one of the two surfaces is misreporting.")
+    fi
+  else
+    # No structured git_ref: fall back to the weaker stdout parse, and SAY SO.
+    REVIEWED_SHA="$ANNOUNCED_SHA"
+    DETAILS+=("NOTICE: sha-assert: the job record's structured 'git_ref' was unavailable, so the assert fell back to the sha announced on stdout (a prefix parse of the tool's prose — the weaker source).")
+    if [ "${HEAD_SHA:0:${#ANNOUNCED_SHA}}" = "$ANNOUNCED_SHA" ] \
+      || [ "${ANNOUNCED_SHA:0:${#HEAD_SHA}}" = "$HEAD_SHA" ]; then
+      SHA_ASSERT="PASS"
+    else
+      SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
+      DETAILS+=("ERROR: sha-assert: announced reviewed-sha '$ANNOUNCED_SHA' does not prefix-match branch HEAD '$HEAD_SHA' (job $JOB).")
+      if [ "${BASE_SHA:0:${#ANNOUNCED_SHA}}" = "$ANNOUNCED_SHA" ]; then
+        DETAILS+=("ERROR: sha-assert: the announced sha EQUALS the base ref '$BASE' ($BASE_SHA) — NO branch change was reviewed. That equality is the signature of the worktree bare-'--branch' resolution trigger.")
+      else
+        DETAILS+=("ERROR: sha-assert: the announced sha matches NEITHER endpoint (head '$HEAD_SHA', base '$BASE' $BASE_SHA) — the signature of the non-sanctioned two-positional commit-range form.")
+      fi
     fi
   fi
 fi
 
-# --- step 6 tier 1: PRIMARY, deterministic, threshold-free (AC1) --------------
-# The census is known NON-empty here (an empty one exited above), so a reviewer
-# claiming there are no code changes contradicts a locally measured fact.
+# --- model-substitution check (review integrity) ------------------------------
+# A NOTICE, not a FAIL, deliberately: roborev legitimately canonicalises/resolves a
+# model alias, so a mismatch is not by itself evidence of a bad review — and an
+# always-red guard is the failure mode that gets guards bypassed. Review integrity
+# is carried by the deterministic checks (sha-assert, tier 1, prompt-content); this
+# line exists so a substitution can never happen SILENTLY.
+if [ -n "$JOB_MODEL" ]; then
+  if [ -n "$JOB_REQUESTED_MODEL" ] && [ "$JOB_REQUESTED_MODEL" != "$JOB_MODEL" ]; then
+    MODEL_LINE="$JOB_MODEL (SUBSTITUTED — requested '$JOB_REQUESTED_MODEL')"
+    DETAILS+=("NOTICE: model: the job ran '$JOB_MODEL' but '$JOB_REQUESTED_MODEL' was requested — a MODEL SUBSTITUTION. Recorded as a loud NOTICE rather than a FAIL (an alias resolution is legitimate), but confirm the substituted model is one you accept for a merge-gating review.")
+  else
+    MODEL_LINE="$JOB_MODEL"
+  fi
+else
+  MODEL_LINE="$MODEL (UNCONFIRMED — no model field in the job record)"
+fi
+
+# --- step 6 tier 1: DETERMINISTIC — verdict text vs the census -----------------
+# Catches "the reviewer GOT the diff and DISCARDED it" (trigger T3). The census is
+# known NON-empty here (an empty one exited above), so a reviewer claiming there are
+# no code changes contradicts a fact we measured ourselves.
 if grep -qiE 'contains no code changes to review|no code changes' "$LOG"; then
   TIER1="FAIL (vacuous verdict vs non-empty census)"
   DETAILS+=("ERROR: vacuity-tier1: the review output claims there are NO CODE CHANGES to review, but the locally computed census is NON-EMPTY: $CENSUS (${BASE}...HEAD). The reviewer's claim contradicts a fact we measured ourselves, so the change was demonstrably NOT reviewed and this run is NOT reportable as \"roborev clean\".")
@@ -505,79 +701,63 @@ else
   TIER1="PASS"
 fi
 
-# --- step 6 tier 2: CORROBORATING token accounting; can only FAIL CLOSED ------
-json_int() { # json_int <json> <key> -> integer or empty
-  local v=""
-  v=$(printf '%s' "$1" | tr -d ' \t\n' | grep -oE "\"$2\":-?[0-9]+" | head -1 | sed -E 's/.*://') || v=""
-  printf '%s' "$v"
-}
-
-has_token_fields() { # has_token_fields <json>
-  [ -n "$1" ] || return 1
-  printf '%s' "$1" | tr -d ' \t\n' | grep -q '"input_tokens":'
-}
-
-select_job_object() { # select_job_object <list-json> <job-id> -> object json or empty
-  command -v python3 >/dev/null 2>&1 || { printf ''; return 0; }
-  printf '%s' "$1" | python3 -c '
-import json, sys
-want = sys.argv[1]
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-def walk(node):
-    if isinstance(node, dict):
-        for key in ("id", "job_id", "job"):
-            if key in node and str(node[key]) == want:
-                print(json.dumps(node))
-                return True
-        for value in node.values():
-            if walk(value):
-                return True
-    elif isinstance(node, list):
-        for value in node:
-            if walk(value):
-                return True
-    return False
-walk(data)
-' "$2" 2>/dev/null || printf ''
-}
-
-TOKEN_JSON=""
-if [ "$JOB" != "-" ]; then
-  TOKEN_JSON=$(roborev show "$JOB" --json 2>/dev/null || printf '')
-  if ! has_token_fields "$TOKEN_JSON"; then
-    LIST_JSON=$(roborev list --json --limit 50 --repo "$REPO" 2>/dev/null || printf '')
-    TOKEN_JSON=$(select_job_object "$LIST_JSON" "$JOB")
+# --- step 6 prompt-content: DETERMINISTIC — did the reviewer GET the diff? -----
+# The complement of tier 1, and the strongest available check: it reads the prompt
+# actually sent to the agent and looks for OUR census's own file paths in it. If the
+# changed paths are absent, the reviewer demonstrably never received the diff — the
+# T1/T2 family and any future variant of it — threshold-free, judged against our own
+# authoritative census, never against the reviewer's prose.
+# A whitespace-only prompt file is a RETRIEVAL FAILURE, not evidence that the paths
+# are absent — treat it as UNAVAILABLE (degraded signal), never as a FAIL, or an
+# unsupported roborev build would false-FAIL every run.
+prompt_bytes=$(tr -d '[:space:]' <"$PROMPT_FILE" | wc -c | tr -d '[:space:]')
+if [ "${prompt_bytes:-0}" -eq 0 ]; then
+  PROMPT_CONTENT="UNAVAILABLE"
+  DETAILS+=("NOTICE: prompt-content: UNAVAILABLE — the prompt sent to the reviewer could not be retrieved for job '$JOB' (tried the job record's 'prompt' field, then 'roborev show <job> --prompt'). DEGRADED SIGNAL, never a silent skip: tier 1 still governs and this can never upgrade a FAIL to a PASS.")
+else
+  checked_paths=()
+  census_total=${#census_paths[@]}
+  if [ "$census_total" -le "$PROMPT_CONTENT_MAX_PATHS_CHECKED" ]; then
+    checked_paths=("${census_paths[@]}")
+  else
+    sample_step=$(((census_total + PROMPT_CONTENT_MAX_PATHS_CHECKED - 1) / PROMPT_CONTENT_MAX_PATHS_CHECKED))
+    sample_index=0
+    while [ "$sample_index" -lt "$census_total" ]; do
+      checked_paths+=("${census_paths[$sample_index]}")
+      sample_index=$((sample_index + sample_step))
+    done
+  fi
+  missing_paths=()
+  for census_path in "${checked_paths[@]}"; do
+    grep -Fq -- "$census_path" "$PROMPT_FILE" || missing_paths+=("$census_path")
+  done
+  if [ "${#missing_paths[@]}" -gt 0 ]; then
+    PROMPT_CONTENT="FAIL (${#missing_paths[@]}/${#checked_paths[@]} census paths absent from the prompt)"
+    DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} checked census paths do NOT appear in the prompt actually sent to the reviewer, so the reviewer never received this diff. The census is authoritative ($CENSUS for ${BASE}...HEAD); a prompt that does not mention its files cannot have reviewed them. Missing (first 10):")
+    printed=0
+    for census_path in "${missing_paths[@]}"; do
+      [ "$printed" -lt 10 ] || break
+      DETAILS+=("  $census_path")
+      printed=$((printed + 1))
+    done
+  else
+    PROMPT_CONTENT="PASS (${#checked_paths[@]}/$census_total census paths present)"
   fi
 fi
 
-TOK_IN=""
-TOK_CACHED=""
-TOK_OUT=""
-if has_token_fields "$TOKEN_JSON" \
-  && ! printf '%s' "$TOKEN_JSON" | tr -d ' \t\n' | grep -q '"has_token_data":false'; then
-  TOK_IN=$(json_int "$TOKEN_JSON" input_tokens)
-  TOK_CACHED=$(json_int "$TOKEN_JSON" cached_input_tokens)
-  TOK_OUT=$(json_int "$TOKEN_JSON" output_tokens)
-fi
-
-if [ -z "$TOK_IN" ] || [ -z "$TOK_CACHED" ] || [ -z "$TOK_OUT" ]; then
+# --- step 6 tier 2: ADVISORY-corroborating token accounting; FAILs CLOSED only --
+if [ -z "$TOK_IN" ] || [ -z "$TOK_CACHED" ]; then
   TOKENS="UNAVAILABLE"
   TIER2="UNAVAILABLE"
-  DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — token accounting for job '$JOB' could not be obtained from the installed roborev build (tried 'roborev show <job> --json', then 'roborev list --json'). This is a DEGRADED-SIGNAL notice, never a silent skip: tier 1 still governs, and an unavailable tier 2 can never turn a FAIL into a PASS.")
+  DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — token accounting for job '$JOB' could not be obtained from the installed roborev build (tried 'roborev show <job> --json', then 'roborev list --json'). DEGRADED SIGNAL, never a silent skip: the two deterministic checks still govern, and an unavailable tier 2 can never turn a FAIL into a PASS.")
 else
-  TOKENS="input=$TOK_IN cached=$TOK_CACHED output=$TOK_OUT"
+  TOKENS="input=$TOK_IN cached=$TOK_CACHED output=${TOK_OUT:-unknown}"
   tier2_trips=()
   if [ "$TOK_IN" -lt "$ROBOREV_VACUITY_MIN_INPUT_TOKENS" ]; then
-    tier2_trips+=("observed input=$TOK_IN < ROBOREV_VACUITY_MIN_INPUT_TOKENS=$ROBOREV_VACUITY_MIN_INPUT_TOKENS")
+    tier2_trips+=("observed input=$TOK_IN < ROBOREV_VACUITY_MIN_INPUT_TOKENS=$ROBOREV_VACUITY_MIN_INPUT_TOKENS (highest observed VACUOUS run: 18801)")
   fi
   if [ "$TOK_CACHED" -eq 0 ]; then
-    tier2_trips+=("observed cached=$TOK_CACHED == 0 (a genuine review reports a non-zero cached-input count; the recorded vacuous baseline reports exactly 0)")
-  fi
-  if [ "$TOK_OUT" -lt "$ROBOREV_VACUITY_MIN_OUTPUT_TOKENS" ]; then
-    tier2_trips+=("observed output=$TOK_OUT < ROBOREV_VACUITY_MIN_OUTPUT_TOKENS=$ROBOREV_VACUITY_MIN_OUTPUT_TOKENS")
+    tier2_trips+=("observed cached=$TOK_CACHED == 0 (every observed vacuous run reports exactly 0; the most false-positive-prone term, retained fail-closed)")
   fi
   if [ "${#tier2_trips[@]}" -gt 0 ]; then
     TIER2="FAIL (vacuous token signature)"
@@ -588,19 +768,53 @@ else
   else
     TIER2="PASS"
   fi
+  # ADVISORY ONLY — never a FAIL condition (see the constants block: a genuine CLEAN
+  # review and a vacuous one emit near-identical output token counts, so any floor
+  # here would false-FAIL a real review that is legitimately clean).
+  if [ -n "$TOK_OUT" ] && [ "$TOK_OUT" -lt "$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS" ]; then
+    DETAILS+=("NOTICE: vacuity-tier2 advisory (NOT a failure condition): observed output=$TOK_OUT < ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS. Output tokens cannot discriminate a genuine CLEAN review from a vacuous one (both emit roughly 20-60), so this is reported and never asserted.")
+  fi
 fi
 
-# --- step 7: verdict ----------------------------------------------------------
-if [ "$REVIEW_RC" -ne 0 ]; then
-  DETAILS+=("ERROR: 'roborev review' exited $REVIEW_RC. A non-zero reviewer exit is a fail-closed FAIL — read the transcript at $LOG before treating anything as clean.")
+# --- step 7: findings vs reviewer error, then the verdict ----------------------
+# roborev exits NON-ZERO when the review REPORTS FINDINGS. That is a NORMAL,
+# GENUINE outcome and must never be misreported as a reviewer malfunction: an agent
+# told the reviewer broke will retry or bypass instead of FIXING THE FINDINGS. The
+# structured `status` field is the authority for which of the two happened.
+findings_count=$({ grep -oiE '\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$LOG" || true; } | wc -l | tr -d '[:space:]')
+if [ "$REVIEW_RC" -eq 0 ]; then
+  ROBOREV_EXIT="PASS"
+  FINDINGS="NONE"
+else
+  review_ran=0
+  if [ -n "$JOB_STATUS" ]; then
+    case "$JOB_STATUS" in done) review_ran=1 ;; esac
+  elif grep -qiE 'no issues found|summary:|\[(critical|high|medium|low)\]|(critical|high|medium|low): ' "$LOG"; then
+    review_ran=1
+  fi
+  if [ "$review_ran" -eq 1 ]; then
+    ROBOREV_EXIT="FINDINGS (exit $REVIEW_RC)"
+    if [ "${findings_count:-0}" -gt 0 ]; then
+      FINDINGS="PRESENT ($findings_count)"
+    else
+      FINDINGS="PRESENT"
+    fi
+    DETAILS+=("ERROR: roborev-exit: FINDINGS — 'roborev review' exited $REVIEW_RC because the review REPORTED FINDINGS. The review is GENUINE (job status '${JOB_STATUS:-unknown}') and the reviewer did NOT malfunction: do not retry it and do not bypass it. TRIAGE AND FIX the findings in the transcript ($LOG), then push and re-review. RESULT is FAIL because a review with open findings is not \"roborev clean\".")
+  else
+    ROBOREV_EXIT="ERROR (exit $REVIEW_RC)"
+    FINDINGS="UNKNOWN"
+    DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}', no parseable review body in the transcript). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
+  fi
 fi
+# The findings COUNT is best-effort (it counts severity markers in the transcript);
+# the PRESENT/NONE distinction is the load-bearing part.
 
-# `roborev-exit` participates in the SAME per-check scan as every other key, so a
-# non-zero reviewer exit forces RESULT: FAIL through the documented path rather
-# than a special case bolted on beside it.
+# Every per-check key participates in ONE scan. A key fails the run when its value
+# starts with FAIL, FINDINGS or ERROR; PASS/SKIP/UNAVAILABLE never do.
 failed=0
-for verdict in "$PUSH_ASSERT" "$CENSUS_CHECK" "$SHA_ASSERT" "$TIER1" "$TIER2" "$ROBOREV_EXIT"; do
-  case "$verdict" in FAIL*) failed=1 ;; esac
+for verdict in "$PUSH_ASSERT" "$CENSUS_CHECK" "$SHA_ASSERT" "$TIER1" \
+  "$PROMPT_CONTENT" "$TIER2" "$ROBOREV_EXIT"; do
+  case "$verdict" in FAIL*|FINDINGS*|ERROR*) failed=1 ;; esac
 done
 
 if [ "$failed" -eq 0 ]; then

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -800,12 +800,16 @@ fi
 FINDINGS_BLOCK_FILE="$LOG.findings"
 # The block runs from a Findings heading/label to the Summary heading/label — the
 # measured real shapes. Everything outside it (a quoted "[Low]" in prose, a severity
-# word inside a Problem sentence) is ignored.
+# word inside a Problem sentence) is ignored. The terminator must be a LINE-INITIAL
+# Summary label: matched mid-sentence it closed the block early when a finding's own
+# prose contained the word, under-counting the findings. (Under-counting is the
+# fail-closed direction for the tier-1 gate — fewer markers make a vacuity claim MORE
+# likely to fail — but the count is reported to a human, so it should be right.)
 { awk 'BEGIN { inblock = 0 }
        tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?/ { inblock = 1; next }
        tolower($0) ~ /^[[:space:]]*findings?[[:space:]]*:/ { inblock = 1; next }
        tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*summary/ { inblock = 0 }
-       tolower($0) ~ /summary[[:space:]]*:/ { inblock = 0 }
+       tolower($0) ~ /^[[:space:]]*summary[[:space:]]*:/ { inblock = 0 }
        inblock { print }' "$LOG" 2>/dev/null || true; } >"$FINDINGS_BLOCK_FILE"
 block_marker_count=$({ grep -oiE '\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
 block_marker_count=${block_marker_count:-0}

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -64,23 +64,36 @@
 #
 #   ==== ROBOREV REVIEW SUMMARY ====
 #   repo: / branch: / base: / head-sha: / reviewed-sha: / job: / model: / census:
-#   tokens: / push-assert: / census-check: / sha-assert: / vacuity-tier1:
-#   prompt-content: / vacuity-tier2: / findings: / roborev-exit: / log:
+#   tokens: / push-assert: / census-check: / code-free: / sha-assert:
+#   review-completed: / prompt-content: / vacuity-tier1: / vacuity-tier2:
+#   findings: / roborev-exit: / log:
 #   RESULT: PASS|FAIL|NOTHING-TO-REVIEW
 #
 # Per-check values are PASS | FAIL | SKIP | UNAVAILABLE (a FAIL may carry a
-# parenthesised reason). `census:` is `<N> files, +<A>/-<D>`; `tokens:` is
+# parenthesised reason). `census:` is `<N> file(s), +<A>/-<D>`; `tokens:` is
 # `input=<n> cached=<n> output=<n>` or `UNAVAILABLE`. `findings:` is
 # `NONE | PRESENT [(<n>)] | UNKNOWN`. `roborev-exit:` is `PASS | FINDINGS (exit N) |
 # ERROR (exit N) | SKIP` — FINDINGS means the reviewer RAN and reported findings (a
 # GENUINE review to triage and fix), ERROR means the reviewer itself failed.
+# `vacuity-tier1:` is ADVISORY and adds `NOTICE (...)` to the value set; a NOTICE
+# never fails the run.
+#
+# WHICH CHECKS CARRY THE VERDICT. The DETERMINISTIC ones, each judged against data we
+# obtained ourselves: `push-assert` (the remote, via ls-remote), `census-check` (our
+# own git diff), `code-free` (our own census classification), `sha-assert` (the job
+# record's git_ref), `review-completed` (job status + an allow-list of terminal
+# verdict markers), `prompt-content` (our census's paths inside the prompt actually
+# sent). Prose matching (`vacuity-tier1`) and token accounting (`vacuity-tier2`)
+# CORROBORATE; tier 1 can only ever raise a NOTICE.
 #
 # EXIT CODES (exactly three outcomes plus a usage code)
-#   0  PASS               — reviewed, sha verified, no vacuity signal.
-#   1  FAIL               — any failed check: push-assert, census-check, sha-assert,
-#                           vacuity-tier1, prompt-content, vacuity-tier2, or
-#                           roborev-exit (FINDINGS or ERROR). Each names itself
-#                           under its own key. NOT reportable as "roborev clean".
+#   0  PASS               — a review demonstrably HAPPENED against branch HEAD with
+#                           no vacuity signal. PASS requires POSITIVE evidence; it is
+#                           never inferred from the absence of a bad phrase.
+#   1  FAIL               — any failed check: push-assert, census-check, code-free,
+#                           sha-assert, review-completed, prompt-content,
+#                           vacuity-tier2, or roborev-exit (FINDINGS or ERROR). Each
+#                           names itself under its own key. NOT "roborev clean".
 #   3  NOTHING-TO-REVIEW  — the census is genuinely empty; NO review was enqueued.
 #                           DISTINCT from PASS by exit code alone, so a caller can
 #                           never mistake "nothing to review" for "reviewed clean".
@@ -151,11 +164,21 @@ ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=200
 # bounded on a 500-file diff.
 PROMPT_CONTENT_MAX_PATHS_CHECKED=40
 
-# Code-free (non-code) census classification. A census consisting ENTIRELY of
-# these extensions/prefixes is structurally discarded by roborev (trigger 3), so
-# the tier-1 failure is attributed to the code-free-diff condition specifically.
+# Code-free (non-code) census classification. A census consisting ENTIRELY of prose
+# is STRUCTURALLY DISCARDED by roborev (trigger 3), so it is a DETERMINISTIC FAIL
+# condition in its own right under the `code-free:` key — never a bet on the
+# reviewer's prose happening to admit it (which is what the previous revision did:
+# it computed this classification and then used it only for wording).
+#
+# EXTENSION-BASED, with a narrow path assist. An earlier revision treated every file
+# under `docs/`, `.github/` or `.claude/` as non-code, which misclassifies
+# `docs/foo.py` and a workflow `.yml` — and now that code-free is a FAIL condition, a
+# false code-free classification is a FALSE FAIL. So the test is the file EXTENSION,
+# and the path assist covers only EXTENSIONLESS files under a prose directory
+# (`docs/LICENSE`, `openspec/NOTES`). Anything with a code-ish extension anywhere —
+# including `.github/workflows/*.yml` — counts as CODE and does not trip this key.
 CODE_FREE_EXTENSIONS="md markdown mdx txt rst adoc"
-CODE_FREE_PREFIXES="openspec/ docs/ website/ .github/ .claude/"
+CODE_FREE_EXTENSIONLESS_PREFIXES="openspec/ docs/ website/ .claude/"
 
 PROGNAME=$(basename "$0")
 
@@ -256,8 +279,12 @@ else
 fi
 REPO=$(cd "$REPO" && pwd -P)
 
-BRANCH=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'HEAD')
-HEAD_SHA=$(git -C "$REPO" rev-parse HEAD 2>/dev/null || printf '')
+# `rev-parse --abbrev-ref HEAD` / `rev-parse HEAD` both ECHO the literal string
+# "HEAD" and exit non-zero in a repo with no commits, so the `|| printf` fallbacks
+# concatenated onto real-looking values and the no-commit guard never fired.
+# `symbolic-ref -q` and `rev-parse --verify --quiet` fail SILENTLY instead.
+BRANCH=$(git -C "$REPO" symbolic-ref --short -q HEAD || printf 'HEAD')
+HEAD_SHA=$(git -C "$REPO" rev-parse --verify --quiet HEAD || printf '')
 
 if [ -n "$LOG_ARG" ]; then
   LOG="$LOG_ARG"
@@ -276,9 +303,17 @@ CENSUS="-"
 TOKENS="UNAVAILABLE"
 PUSH_ASSERT="SKIP"
 CENSUS_CHECK="SKIP"
+CODE_FREE="SKIP"
 SHA_ASSERT="SKIP"
-TIER1="SKIP"
+# The POSITIVE "a review actually happened" assert. Absence of a vacuous phrase is
+# NOT evidence a review occurred: a transcript that only says "Waiting for job N to
+# complete...", or "Error: 400 the requested model is not supported", or "status:
+# failed (provider timeout)" contains no vacuous phrase at all — and every one of
+# them used to reach RESULT: PASS. Positive evidence (job status done AND a terminal
+# verdict marker from an ALLOW-list) is now required before PASS is reachable.
+REVIEW_COMPLETED="SKIP"
 PROMPT_CONTENT="SKIP"
+TIER1="SKIP"
 TIER2="SKIP"
 FINDINGS="SKIP"
 # The reviewer process's OWN status, under its own greppable key: a caller retains
@@ -308,9 +343,11 @@ emit_summary() {
   printf 'tokens: %s\n' "$TOKENS"
   printf 'push-assert: %s\n' "$PUSH_ASSERT"
   printf 'census-check: %s\n' "$CENSUS_CHECK"
+  printf 'code-free: %s\n' "$CODE_FREE"
   printf 'sha-assert: %s\n' "$SHA_ASSERT"
-  printf 'vacuity-tier1: %s\n' "$TIER1"
+  printf 'review-completed: %s\n' "$REVIEW_COMPLETED"
   printf 'prompt-content: %s\n' "$PROMPT_CONTENT"
+  printf 'vacuity-tier1: %s\n' "$TIER1"
   printf 'vacuity-tier2: %s\n' "$TIER2"
   printf 'findings: %s\n' "$FINDINGS"
   printf 'roborev-exit: %s\n' "$ROBOREV_EXIT"
@@ -441,11 +478,29 @@ fi
 # found in the reviewer's prompt (the prompt-content check below matches literal
 # paths). Splitting a rename into its delete+add pair keeps every census path a real
 # one, at the cost of counting it as two files.
-NUMSTAT=$(git -C "$REPO" diff --numstat --no-renames "${BASE}...HEAD" 2>/dev/null || printf '')
+# A FAILED `git diff` must NEVER alias to "genuinely empty". Discarding the exit
+# status here would assert a measurement that never happened — the same epistemic
+# error as reading a mirror ref instead of the remote — and it would surface as
+# NOTHING-TO-REVIEW, i.e. "there is nothing to look at" instead of "we could not
+# tell". Capture the status and fail CLOSED on it.
+set +e
+NUMSTAT=$(git -C "$REPO" diff --numstat --no-renames "${BASE}...HEAD" 2>&1)
+DIFF_RC=$?
+set -e
+if [ "$DIFF_RC" -ne 0 ]; then
+  CENSUS_CHECK="FAIL (git diff failed)"
+  DETAILS+=("ERROR: census: 'git diff --numstat --no-renames ${BASE}...HEAD' exited $DIFF_RC in $REPO, so the census was never measured. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW — an unmeasurable diff is 'we cannot tell', never 'there is nothing to review'. git said:")
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    DETAILS+=("  $line")
+  done <<<"$NUMSTAT"
+  finish FAIL 1
+fi
+
 census_files=0
 census_added=0
 census_deleted=0
-census_code_free=1
+census_non_code_files=0
 census_paths=()
 while IFS=$'\t' read -r add del path; do
   [ -n "${path:-}" ] || continue
@@ -455,23 +510,29 @@ while IFS=$'\t' read -r add del path; do
   census_paths+=("$path")
   census_added=$((census_added + add))
   census_deleted=$((census_deleted + del))
-  # Code-free classification: the file must match a documented non-code extension
-  # OR sit under a documented non-code path prefix. One code file flips the whole
-  # census to "has code".
+  # Non-code classification: a documented prose EXTENSION, or an EXTENSIONLESS file
+  # under a documented prose directory. Anything else — including `docs/foo.py` and
+  # `.github/workflows/*.yml` — is code.
   file_non_code=0
-  ext="${path##*.}"
-  # shellcheck disable=SC2086 # deliberate split of the space-separated constants
-  for candidate in $CODE_FREE_EXTENSIONS; do
-    if [ "$ext" = "$candidate" ]; then file_non_code=1; fi
-  done
-  # shellcheck disable=SC2086 # deliberate split of the space-separated constants
-  for prefix in $CODE_FREE_PREFIXES; do
-    case "$path" in "$prefix"*) file_non_code=1 ;; esac
-  done
-  if [ "$file_non_code" -eq 0 ]; then census_code_free=0; fi
+  ext=""
+  case "$path" in *.*) ext="${path##*.}" ;; esac
+  if [ -n "$ext" ]; then
+    # shellcheck disable=SC2086 # deliberate split of the space-separated constant
+    for candidate in $CODE_FREE_EXTENSIONS; do
+      if [ "$ext" = "$candidate" ]; then file_non_code=1; fi
+    done
+  else
+    # shellcheck disable=SC2086 # deliberate split of the space-separated constant
+    for prefix in $CODE_FREE_EXTENSIONLESS_PREFIXES; do
+      case "$path" in "$prefix"*) file_non_code=1 ;; esac
+    done
+  fi
+  if [ "$file_non_code" -eq 1 ]; then census_non_code_files=$((census_non_code_files + 1)); fi
 done <<<"$NUMSTAT"
 
-CENSUS="$census_files files, +$census_added/-$census_deleted"
+census_noun="files"
+if [ "$census_files" -eq 1 ]; then census_noun="file"; fi
+CENSUS="$census_files $census_noun, +$census_added/-$census_deleted"
 
 if [ "$census_files" -eq 0 ]; then
   CENSUS_CHECK="FAIL (empty census)"
@@ -479,6 +540,19 @@ if [ "$census_files" -eq 0 ]; then
   finish NOTHING-TO-REVIEW 3
 fi
 CENSUS_CHECK="PASS"
+
+# --- step 3b: code-free census — a DETERMINISTIC FAIL, before any review ------
+# roborev structurally DISCARDS a code-free diff, so such a diff cannot be certified
+# by roborev at all (this change's own spec requirement, and CLAUDE.md rule 4). That
+# is a property of OUR census, measured locally — it must not depend on the reviewer
+# admitting it in prose, which is what the previous revision bet on.
+if [ "$census_non_code_files" -eq "$census_files" ]; then
+  CODE_FREE="FAIL (code-free census: $census_non_code_files/$census_files files are documentation/specification text)"
+  DETAILS+=("ERROR: code-free: every file in the census ($CENSUS for ${BASE}...HEAD) is documentation/specification prose, and roborev STRUCTURALLY DISCARDS a code-free diff — so this diff CANNOT be certified by roborev at all, whatever verdict it returns. The sanctioned substitute is primary-source verification recorded in the PR (for example 'git show cassandra-5.0.8:<path>' for the source the docs describe). A docs-only change must NEVER record \"roborev clean\".")
+  DETAILS+=("ERROR: code-free: no review was enqueued, because a passing verdict on this diff would be meaningless.")
+  finish FAIL 1
+fi
+CODE_FREE="PASS"
 
 # --- step 4: invoke by EXPLICIT sha + EXPLICIT absolute repo (AC2) ------------
 if ! command -v roborev >/dev/null 2>&1; then
@@ -500,116 +574,63 @@ set -e
 
 # --- step 5: reviewed-SHA assert (AC2) — STRUCTURED data is the oracle ---------
 #
-# The job record's `git_ref` field (from `roborev show <job> --json`, falling back
-# to `roborev list --json`) is a FULL 40-char sha recorded by roborev itself, so it
-# is compared full-sha to full-sha. The stdout `Enqueued job <N> for <sha>` line is
-# now a CROSS-CHECK ONLY: parsing a tool's prose is the weaker source whenever a
-# structured one exists. Its ABSENCE is still a hard failure — it carries the job
-# id every structured query needs, so without it nothing is verifiable.
-ANNOUNCE=$(grep -oiE 'enqueued job [0-9]+ for [0-9a-fA-F]{4,40}' "$LOG" | tail -1 || printf '')
+# The job record's `git_ref` field is a FULL 40-char sha recorded by roborev itself,
+# so it is compared full-sha to full-sha. The stdout `Enqueued job <N> for <sha>`
+# line is a CROSS-CHECK ONLY — parsing a tool's prose is the weaker source whenever a
+# structured one exists — but its ABSENCE is still a hard failure, because it carries
+# the job id every structured query needs.
+#
+# The announcement is parsed DEFENSIVELY: lower-cased first (so an upper-case
+# announcement cannot survive the match and then fall out of the field extraction as
+# garbage that gets handed to `roborev show`), the sha floor is 7 hex chars (4 was
+# loose enough that a 4-char prefix satisfied the assert), and both fields are
+# validated before use. When several announcements are present the LAST one is the
+# effective enqueue, and the multiplicity is recorded.
+ANNOUNCE_COUNT=$({ grep -ociE 'enqueued job [0-9]+ for [0-9a-f]{7,40}' "$LOG" 2>/dev/null || printf 0; } | tail -1)
+ANNOUNCE=$({ tr 'A-Z' 'a-z' <"$LOG" 2>/dev/null || printf ''; } | grep -oE 'enqueued job [0-9]+ for [0-9a-f]{7,40}' | tail -1 || printf '')
 ANNOUNCED_SHA=""
 announce_ok=0
 if [ -z "$ANNOUNCE" ]; then
   SHA_ASSERT="FAIL (no parseable enqueue announcement)"
-  DETAILS+=("ERROR: sha-assert: the transcript contains no parseable 'Enqueued job <N> for <sha>' line, so neither the job record nor the reviewed sha can be located and the review is UNVERIFIABLE. That is a failure, never a skipped check. Transcript: $LOG")
+  DETAILS+=("ERROR: sha-assert: the transcript contains no parseable 'Enqueued job <N> for <sha>' line (with a sha of at least 7 hex chars), so neither the job record nor the reviewed sha can be located and the review is UNVERIFIABLE. That is a failure, never a skipped check. Transcript: $LOG")
 else
-  announce_ok=1
-  JOB=$(printf '%s' "$ANNOUNCE" | sed -E 's/^[Ee]nqueued [Jj]ob ([0-9]+).*/\1/')
-  ANNOUNCED_SHA=$(printf '%s' "$ANNOUNCE" | sed -E 's/.*[Ff]or ([0-9a-fA-F]+)$/\1/' | tr 'A-F' 'a-f')
+  JOB=$(printf '%s' "$ANNOUNCE" | sed -E 's/^enqueued job ([0-9]+).*/\1/')
+  ANNOUNCED_SHA=$(printf '%s' "$ANNOUNCE" | sed -E 's/.* for ([0-9a-f]+)$/\1/')
+  case "$JOB" in
+    ''|*[!0-9]*)
+      SHA_ASSERT="FAIL (unparseable enqueue announcement)"
+      DETAILS+=("ERROR: sha-assert: the enqueue announcement '$ANNOUNCE' did not yield a numeric job id, so nothing can be queried about the job. Failing closed rather than passing a malformed id to roborev.")
+      JOB="-"
+      ;;
+    *) announce_ok=1 ;;
+  esac
+  if [ "$announce_ok" -eq 1 ]; then
+    case "$ANNOUNCED_SHA" in
+      *[!0-9a-f]*|'')
+        SHA_ASSERT="FAIL (unparseable enqueue announcement)"
+        DETAILS+=("ERROR: sha-assert: the enqueue announcement '$ANNOUNCE' did not yield a hex sha. Failing closed.")
+        announce_ok=0
+        ;;
+    esac
+  fi
+  if [ "${ANNOUNCE_COUNT:-0}" -gt 1 ]; then
+    DETAILS+=("NOTICE: sha-assert: the transcript carries $ANNOUNCE_COUNT enqueue announcements; the LAST one (job $JOB) is the effective enqueue and is the one asserted.")
+  fi
 fi
 
-# --- structured job facts ------------------------------------------------------
-# Diagnostics live beside the transcript, both named in the block via `log:`.
+# --- structured job facts (extracted by scripts/flow/roborev-job-facts.py) -----
+# Diagnostics live beside the transcript; `log:` names the base path.
 FACTS_FILE="$LOG.facts"
 PROMPT_FILE="$LOG.prompt"
+JOB_FACTS_TOOL="$(cd "$(dirname "$0")" && pwd)/roborev-job-facts.py"
 : >"$FACTS_FILE"
 : >"$PROMPT_FILE"
 
-# extract_job_facts <job> <json> <facts-out> <prompt-out>
-# Emits `key=value` lines for the fields the asserts need, and writes the prompt
-# actually sent to the reviewer to its own file. `token_usage` is a JSON-ENCODED
-# STRING in the real payload (it must be decoded TWICE), and the output field is
-# `total_output_tokens`; both `total_output_tokens` and `output_tokens` are accepted
-# so a rename in either direction keeps working. Absence stays UNAVAILABLE.
-extract_job_facts() {
+extract_job_facts() { # extract_job_facts <job> <json> <facts-out> <prompt-out>
   command -v python3 >/dev/null 2>&1 || return 1
+  [ -f "$JOB_FACTS_TOOL" ] || return 1
   [ -n "$2" ] || return 1
-  printf '%s' "$2" | python3 -c '
-import json, sys
-want, facts_path, prompt_path = sys.argv[1], sys.argv[2], sys.argv[3]
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
-
-def objects(node):
-    if isinstance(node, dict):
-        yield node
-        for value in node.values():
-            for found in objects(value):
-                yield found
-    elif isinstance(node, list):
-        for value in node:
-            for found in objects(value):
-                yield found
-
-job = None
-for obj in objects(data):
-    for key in ("id", "job_id", "job"):
-        if key in obj and str(obj[key]) == want:
-            job = obj
-            break
-    if job is not None:
-        break
-if job is None:
-    # A `show --json` payload may be the single job with no id echoed back.
-    for obj in objects(data):
-        if "git_ref" in obj or "token_usage" in obj:
-            job = obj
-            break
-if job is None:
-    sys.exit(1)
-
-usage = job.get("token_usage")
-if isinstance(usage, str):
-    try:
-        usage = json.loads(usage)
-    except Exception:
-        usage = None
-if not isinstance(usage, dict):
-    usage = {}
-
-def number(*keys):
-    for key in keys:
-        value = usage.get(key)
-        if isinstance(value, bool):
-            continue
-        if isinstance(value, int):
-            return str(value)
-        if isinstance(value, float):
-            return str(int(value))
-        if isinstance(value, str):
-            text = value.strip()
-            if text.lstrip("-").isdigit():
-                return str(int(text))
-    return ""
-
-lines = []
-for key in ("git_ref", "status", "model", "requested_model"):
-    value = job.get(key)
-    if isinstance(value, str) and value.strip():
-        lines.append(key + "=" + " ".join(value.split()))
-lines.append("input_tokens=" + number("input_tokens"))
-lines.append("cached_input_tokens=" + number("cached_input_tokens", "cached_tokens"))
-lines.append("output_tokens=" + number("total_output_tokens", "output_tokens"))
-with open(facts_path, "w") as handle:
-    handle.write("\n".join(lines) + "\n")
-
-prompt = job.get("prompt")
-if isinstance(prompt, str) and prompt.strip():
-    with open(prompt_path, "w") as handle:
-        handle.write(prompt)
-' "$1" "$3" "$4" 2>/dev/null
+  printf '%s' "$2" | python3 "$JOB_FACTS_TOOL" "$1" "$3" "$4" 2>/dev/null
 }
 
 fact() { sed -n "s/^$1=//p" "$FACTS_FILE" | head -1; }
@@ -630,6 +651,8 @@ JOB_GIT_REF=$(fact git_ref | tr 'A-F' 'a-f')
 JOB_STATUS=$(fact status)
 JOB_MODEL=$(fact model)
 JOB_REQUESTED_MODEL=$(fact requested_model)
+JOB_HAS_TOKEN_DATA=$(fact has_token_data)
+TOKEN_STATE=$(fact token_state)
 TOK_IN=$(fact input_tokens)
 TOK_CACHED=$(fact cached_input_tokens)
 TOK_OUT=$(fact output_tokens)
@@ -652,9 +675,11 @@ if [ "$announce_ok" -eq 1 ]; then
       DETAILS+=("NOTICE: sha-assert cross-check: stdout announced '$ANNOUNCED_SHA' but the job record's git_ref is '$JOB_GIT_REF'. The structured field is the oracle; the disagreement is recorded because it means one of the two surfaces is misreporting.")
     fi
   else
-    # No structured git_ref: fall back to the weaker stdout parse, and SAY SO.
+    # No structured git_ref: fall back to the weaker stdout parse, and SAY SO. The
+    # real announcement carries an ABBREVIATED sha (9 chars observed), so this
+    # comparison is a prefix match in either direction — never strict equality.
     REVIEWED_SHA="$ANNOUNCED_SHA"
-    DETAILS+=("NOTICE: sha-assert: the job record's structured 'git_ref' was unavailable, so the assert fell back to the sha announced on stdout (a prefix parse of the tool's prose — the weaker source).")
+    DETAILS+=("NOTICE: sha-assert: the job record's structured 'git_ref' was unavailable, so the assert fell back to the sha announced on stdout (an abbreviated-sha prefix parse of the tool's prose — the weaker source).")
     if [ "${HEAD_SHA:0:${#ANNOUNCED_SHA}}" = "$ANNOUNCED_SHA" ] \
       || [ "${ANNOUNCED_SHA:0:${#HEAD_SHA}}" = "$HEAD_SHA" ]; then
       SHA_ASSERT="PASS"
@@ -673,9 +698,9 @@ fi
 # --- model-substitution check (review integrity) ------------------------------
 # A NOTICE, not a FAIL, deliberately: roborev legitimately canonicalises/resolves a
 # model alias, so a mismatch is not by itself evidence of a bad review — and an
-# always-red guard is the failure mode that gets guards bypassed. Review integrity
-# is carried by the deterministic checks (sha-assert, tier 1, prompt-content); this
-# line exists so a substitution can never happen SILENTLY.
+# always-red guard is the failure mode that gets guards bypassed. Review integrity is
+# carried by the deterministic checks; this line exists so a substitution can never
+# happen SILENTLY.
 if [ -n "$JOB_MODEL" ]; then
   if [ -n "$JOB_REQUESTED_MODEL" ] && [ "$JOB_REQUESTED_MODEL" != "$JOB_MODEL" ]; then
     MODEL_LINE="$JOB_MODEL (SUBSTITUTED — requested '$JOB_REQUESTED_MODEL')"
@@ -687,33 +712,49 @@ else
   MODEL_LINE="$MODEL (UNCONFIRMED — no model field in the job record)"
 fi
 
-# --- step 6 tier 1: DETERMINISTIC — verdict text vs the census -----------------
-# Catches "the reviewer GOT the diff and DISCARDED it" (trigger T3). The census is
-# known NON-empty here (an empty one exited above), so a reviewer claiming there are
-# no code changes contradicts a fact we measured ourselves.
-if grep -qiE 'contains no code changes to review|no code changes' "$LOG"; then
-  TIER1="FAIL (vacuous verdict vs non-empty census)"
-  DETAILS+=("ERROR: vacuity-tier1: the review output claims there are NO CODE CHANGES to review, but the locally computed census is NON-EMPTY: $CENSUS (${BASE}...HEAD). The reviewer's claim contradicts a fact we measured ourselves, so the change was demonstrably NOT reviewed and this run is NOT reportable as \"roborev clean\".")
-  if [ "$census_code_free" -eq 1 ]; then
-    DETAILS+=("ERROR: vacuity-tier1: every file in the census is documentation/specification/workflow text, so this is the CODE-FREE-DIFF condition: a code-free diff cannot be certified by roborev at all (roborev structurally discards it). The sanctioned substitute is primary-source verification recorded in the PR (for example 'git show cassandra-5.0.8:<path>' for the source the docs describe) — never \"roborev clean\".")
-  fi
+# --- step 6a: review-completed — POSITIVE evidence that a review HAPPENED ------
+# The allow-list of terminal verdict markers. A review that finished emits either a
+# findings block (severity-tagged) or the clean shape ("no issues found" AND a
+# "Summary:" line). Anything else — a still-waiting job, a provider 400, a failed
+# job — matches NOTHING here and therefore cannot reach PASS. This is the inverse of
+# the old logic, which inferred success from the ABSENCE of a vacuous phrase.
+VERDICT_MARKER_RE='\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): |^[[:space:]]*findings?\b'
+if [ ! -r "$LOG" ]; then
+  REVIEW_COMPLETED="FAIL (transcript unreadable)"
+  DETAILS+=("ERROR: review-completed: the transcript at $LOG is not readable, so there is no evidence a review happened. Failing closed.")
 else
-  TIER1="PASS"
+  verdict_marker=0
+  if grep -qiE "$VERDICT_MARKER_RE" "$LOG"; then
+    verdict_marker=1
+  elif grep -qi 'no issues found' "$LOG" && grep -qiE '(^|[^[:alnum:]])summary:' "$LOG"; then
+    verdict_marker=1
+  fi
+  if [ -n "$JOB_STATUS" ] && [ "$JOB_STATUS" != done ]; then
+    REVIEW_COMPLETED="FAIL (job status '$JOB_STATUS' is not done)"
+    DETAILS+=("ERROR: review-completed: the job record reports status '$JOB_STATUS', not 'done', so the review did NOT complete and nothing was certified. Failing closed — the absence of a vacuous phrase is never evidence that a review happened.")
+  elif [ "$verdict_marker" -eq 0 ]; then
+    REVIEW_COMPLETED="FAIL (no terminal verdict marker)"
+    DETAILS+=("ERROR: review-completed: the transcript carries NO terminal verdict marker — neither a severity-tagged findings block nor the clean 'no issues found' + 'Summary:' shape. A still-waiting job, a provider error (for example the #2433/#3037 model-mismatch 400) and a failed job all look like this, and none of them is a review. Failing closed. Transcript: $LOG")
+  else
+    REVIEW_COMPLETED="PASS"
+    if [ -z "$JOB_STATUS" ]; then
+      DETAILS+=("NOTICE: review-completed: the job record's 'status' was unavailable, so completion rests on the transcript's terminal verdict marker alone (the weaker of the two signals).")
+    fi
+  fi
 fi
 
-# --- step 6 prompt-content: DETERMINISTIC — did the reviewer GET the diff? -----
-# The complement of tier 1, and the strongest available check: it reads the prompt
-# actually sent to the agent and looks for OUR census's own file paths in it. If the
-# changed paths are absent, the reviewer demonstrably never received the diff — the
-# T1/T2 family and any future variant of it — threshold-free, judged against our own
-# authoritative census, never against the reviewer's prose.
-# A whitespace-only prompt file is a RETRIEVAL FAILURE, not evidence that the paths
-# are absent — treat it as UNAVAILABLE (degraded signal), never as a FAIL, or an
-# unsupported roborev build would false-FAIL every run.
+# --- step 6b: prompt-content — DETERMINISTIC: did the reviewer GET the diff? ----
+# The strongest available check: it reads the prompt actually sent to the agent and
+# looks for OUR census's own file paths in it. Absent paths mean the reviewer never
+# received the diff — the T1/T2 family and any future variant — threshold-free, and
+# judged against our own authoritative census rather than the reviewer's prose.
+# A whitespace-only prompt file is a RETRIEVAL FAILURE, not evidence the paths are
+# absent: UNAVAILABLE (degraded), never a FAIL, or an unsupported roborev build would
+# false-FAIL every run.
 prompt_bytes=$(tr -d '[:space:]' <"$PROMPT_FILE" | wc -c | tr -d '[:space:]')
 if [ "${prompt_bytes:-0}" -eq 0 ]; then
   PROMPT_CONTENT="UNAVAILABLE"
-  DETAILS+=("NOTICE: prompt-content: UNAVAILABLE — the prompt sent to the reviewer could not be retrieved for job '$JOB' (tried the job record's 'prompt' field, then 'roborev show <job> --prompt'). DEGRADED SIGNAL, never a silent skip: tier 1 still governs and this can never upgrade a FAIL to a PASS.")
+  DETAILS+=("NOTICE: prompt-content: UNAVAILABLE — the prompt sent to the reviewer could not be retrieved for job '$JOB' (tried the job record's 'prompt' field, then 'roborev show <job> --prompt'). DEGRADED SIGNAL, never a silent skip: the other deterministic checks still govern and this can never upgrade a FAIL to a PASS.")
 else
   checked_paths=()
   census_total=${#census_paths[@]}
@@ -745,43 +786,90 @@ else
   fi
 fi
 
-# --- step 6 tier 2: ADVISORY-corroborating token accounting; FAILs CLOSED only --
-if [ -z "$TOK_IN" ] || [ -z "$TOK_CACHED" ]; then
-  TOKENS="UNAVAILABLE"
-  TIER2="UNAVAILABLE"
-  DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — token accounting for job '$JOB' could not be obtained from the installed roborev build (tried 'roborev show <job> --json', then 'roborev list --json'). DEGRADED SIGNAL, never a silent skip: the two deterministic checks still govern, and an unavailable tier 2 can never turn a FAIL into a PASS.")
+# --- step 6c: tier 1 — ADVISORY prose corroboration, anchored to the verdict ----
+# DEMOTED from primary to advisory, and deliberately so. It matched anywhere in the
+# transcript, so a review that merely QUOTED the phrase — including any review of
+# THIS wrapper, whose own diff contains it in several files — was failed as vacuous.
+# The systemic cost of that is agents learning to WAIVE tier-1 failures, which
+# restores the very defect the guard exists to prevent. It is no longer load-bearing
+# for anything: the docs-only trigger it was primary for is now caught deterministically
+# by `code-free:`, and "the reviewer never got the diff" by `prompt-content:`. So it
+# reports a NOTICE and never fails the run, matched ONLY within the verdict/summary
+# region (the lines carrying a `Summary:`), not over arbitrary finding bodies.
+VERDICT_REGION_FILE="$LOG.verdict"
+{ grep -iE '(^|[^[:alnum:]])summary:' "$LOG" 2>/dev/null || true; } >"$VERDICT_REGION_FILE"
+if [ ! -s "$VERDICT_REGION_FILE" ]; then
+  TIER1="UNAVAILABLE"
+elif grep -qi 'no code changes' "$VERDICT_REGION_FILE"; then
+  TIER1="NOTICE (vacuous verdict vs non-empty census)"
+  DETAILS+=("NOTICE: vacuity-tier1 (ADVISORY, does not fail the run): the review's summary claims there are NO CODE CHANGES to review while the locally computed census is NON-EMPTY: $CENSUS (${BASE}...HEAD). Corroborating signal only — the deterministic checks above (code-free, review-completed, prompt-content, sha-assert) carry the verdict.")
 else
-  TOKENS="input=$TOK_IN cached=$TOK_CACHED output=${TOK_OUT:-unknown}"
-  tier2_trips=()
-  if [ "$TOK_IN" -lt "$ROBOREV_VACUITY_MIN_INPUT_TOKENS" ]; then
-    tier2_trips+=("observed input=$TOK_IN < ROBOREV_VACUITY_MIN_INPUT_TOKENS=$ROBOREV_VACUITY_MIN_INPUT_TOKENS (highest observed VACUOUS run: 18801)")
-  fi
-  if [ "$TOK_CACHED" -eq 0 ]; then
-    tier2_trips+=("observed cached=$TOK_CACHED == 0 (every observed vacuous run reports exactly 0; the most false-positive-prone term, retained fail-closed)")
-  fi
-  if [ "${#tier2_trips[@]}" -gt 0 ]; then
-    TIER2="FAIL (vacuous token signature)"
-    DETAILS+=("ERROR: vacuity-tier2: the token accounting for job '$JOB' carries the vacuous signature against a NON-EMPTY census ($CENSUS):")
-    for trip in "${tier2_trips[@]}"; do
-      DETAILS+=("  $trip")
-    done
-  else
-    TIER2="PASS"
-  fi
-  # ADVISORY ONLY — never a FAIL condition (see the constants block: a genuine CLEAN
-  # review and a vacuous one emit near-identical output token counts, so any floor
-  # here would false-FAIL a real review that is legitimately clean).
-  if [ -n "$TOK_OUT" ] && [ "$TOK_OUT" -lt "$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS" ]; then
-    DETAILS+=("NOTICE: vacuity-tier2 advisory (NOT a failure condition): observed output=$TOK_OUT < ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS. Output tokens cannot discriminate a genuine CLEAN review from a vacuous one (both emit roughly 20-60), so this is reported and never asserted.")
-  fi
+  TIER1="PASS"
 fi
 
+# --- step 6d: tier 2 — token accounting; drift is FAILED, absence is not -------
+# Three distinguishable states (see scripts/flow/roborev-job-facts.py):
+#   absent      -> UNAVAILABLE. A build that reports no token data is a legitimate
+#                  difference, not a signal.
+#   unparseable -> FAIL. A token field IS present but no documented alias resolved to
+#                  a number: EXTERNAL-TOOL DRIFT. Chosen as a FAIL rather than a
+#                  NOTICE because this is exactly how the tier was silently disarmed
+#                  (a rename or a `null` degraded it to a non-failing UNAVAILABLE
+#                  while the real counts were the vacuous baseline and the run
+#                  PASSED). A drift FAIL costs one re-run after a one-line alias
+#                  addition; a silently disarmed guard costs an unreviewed merge.
+#   parsed      -> evaluate the thresholds.
+case "${TOKEN_STATE:-}" in
+  parsed)
+    TOKENS="input=$TOK_IN cached=$TOK_CACHED output=${TOK_OUT:-unknown}"
+    if [ "$JOB_HAS_TOKEN_DATA" = false ]; then
+      DETAILS+=("NOTICE: vacuity-tier2: the job record says has_token_data=false yet readable counts are present — a payload inconsistency (drift signal). The counts are used, because they are what the vacuity check asserts on.")
+    fi
+    tier2_trips=()
+    if [ "$TOK_IN" -lt "$ROBOREV_VACUITY_MIN_INPUT_TOKENS" ]; then
+      tier2_trips+=("observed input=$TOK_IN < ROBOREV_VACUITY_MIN_INPUT_TOKENS=$ROBOREV_VACUITY_MIN_INPUT_TOKENS (highest observed VACUOUS run: 18801)")
+    fi
+    if [ "$TOK_CACHED" -eq 0 ]; then
+      tier2_trips+=("observed cached=$TOK_CACHED == 0 (every observed vacuous run reports exactly 0; the most false-positive-prone term, retained fail-closed)")
+    fi
+    if [ "${#tier2_trips[@]}" -gt 0 ]; then
+      TIER2="FAIL (vacuous token signature)"
+      DETAILS+=("ERROR: vacuity-tier2: the token accounting for job '$JOB' carries the vacuous signature against a NON-EMPTY census ($CENSUS):")
+      for trip in "${tier2_trips[@]}"; do
+        DETAILS+=("  $trip")
+      done
+    else
+      TIER2="PASS"
+    fi
+    # ADVISORY ONLY — never a FAIL condition (see the constants block: a genuine
+    # CLEAN review and a vacuous one emit near-identical output token counts).
+    if [ -n "$TOK_OUT" ] && [ "$TOK_OUT" -lt "$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS" ]; then
+      DETAILS+=("NOTICE: vacuity-tier2 advisory (NOT a failure condition): observed output=$TOK_OUT < ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=$ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS. Output tokens cannot discriminate a genuine CLEAN review from a vacuous one (both emit roughly 20-60), so this is reported and never asserted.")
+    fi
+    ;;
+  unparseable)
+    TOKENS="UNAVAILABLE"
+    TIER2="FAIL (token accounting present but unparseable — drift)"
+    DETAILS+=("ERROR: vacuity-tier2: job '$JOB' DOES carry token accounting, but none of the documented field aliases resolved to a number — the installed roborev build has DRIFTED from the shape this guard reads. That is failed closed on purpose: a silently unreadable payload is exactly how this tier was disarmed while the real counts were the vacuous baseline. Add the new field name to scripts/flow/roborev-job-facts.py (INPUT/CACHED/OUTPUT_TOKEN_KEYS) and re-run; do not waive it.")
+    ;;
+  absent)
+    TOKENS="UNAVAILABLE"
+    TIER2="UNAVAILABLE"
+    DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — the job record for '$JOB' carries no token accounting at all. A build that reports none is a legitimate difference, not a signal, so this is a degraded-signal notice and never a silent skip: the deterministic checks still govern, and an unavailable tier 2 can never turn a FAIL into a PASS.")
+    ;;
+  *)
+    TOKENS="UNAVAILABLE"
+    TIER2="UNAVAILABLE"
+    DETAILS+=("NOTICE: vacuity-tier2: UNAVAILABLE — the structured job record for '$JOB' could not be read at all (no python3, no extractor, or no matching job in 'roborev show --json' / 'roborev list --json'). DEGRADED SIGNAL, never a silent skip.")
+    ;;
+esac
+
 # --- step 7: findings vs reviewer error, then the verdict ----------------------
-# roborev exits NON-ZERO when the review REPORTS FINDINGS. That is a NORMAL,
-# GENUINE outcome and must never be misreported as a reviewer malfunction: an agent
-# told the reviewer broke will retry or bypass instead of FIXING THE FINDINGS. The
-# structured `status` field is the authority for which of the two happened.
-findings_count=$({ grep -oiE '\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$LOG" || true; } | wc -l | tr -d '[:space:]')
+# roborev exits NON-ZERO when the review REPORTS FINDINGS. That is a NORMAL, GENUINE
+# outcome and must never be misreported as a reviewer malfunction: an agent told the
+# reviewer broke will retry or bypass instead of FIXING THE FINDINGS. The structured
+# `status` field is the authority for which of the two happened.
+findings_count=$({ grep -oiE '\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$LOG" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
 if [ "$REVIEW_RC" -eq 0 ]; then
   ROBOREV_EXIT="PASS"
   FINDINGS="NONE"
@@ -789,7 +877,7 @@ else
   review_ran=0
   if [ -n "$JOB_STATUS" ]; then
     case "$JOB_STATUS" in done) review_ran=1 ;; esac
-  elif grep -qiE 'no issues found|summary:|\[(critical|high|medium|low)\]|(critical|high|medium|low): ' "$LOG"; then
+  elif [ "$REVIEW_COMPLETED" = "PASS" ]; then
     review_ran=1
   fi
   if [ "$review_ran" -eq 1 ]; then
@@ -803,17 +891,18 @@ else
   else
     ROBOREV_EXIT="ERROR (exit $REVIEW_RC)"
     FINDINGS="UNKNOWN"
-    DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}', no parseable review body in the transcript). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
+    DETAILS+=("ERROR: roborev-exit: ERROR — 'roborev review' exited $REVIEW_RC and the job did not complete (status '${JOB_STATUS:-unavailable}'). The REVIEWER itself failed, so nothing was certified — this is an infra condition, not a findings outcome: check the daemon ('roborev status'), the agent's credentials, and the transcript at $LOG.")
   fi
 fi
 # The findings COUNT is best-effort (it counts severity markers in the transcript);
 # the PRESENT/NONE distinction is the load-bearing part.
 
 # Every per-check key participates in ONE scan. A key fails the run when its value
-# starts with FAIL, FINDINGS or ERROR; PASS/SKIP/UNAVAILABLE never do.
+# starts with FAIL, FINDINGS or ERROR; PASS / SKIP / UNAVAILABLE / NOTICE never do
+# (NOTICE is the advisory tier's value and is deliberately non-failing).
 failed=0
-for verdict in "$PUSH_ASSERT" "$CENSUS_CHECK" "$SHA_ASSERT" "$TIER1" \
-  "$PROMPT_CONTENT" "$TIER2" "$ROBOREV_EXIT"; do
+for verdict in "$PUSH_ASSERT" "$CENSUS_CHECK" "$CODE_FREE" "$SHA_ASSERT" \
+  "$REVIEW_COMPLETED" "$PROMPT_CONTENT" "$TIER1" "$TIER2" "$ROBOREV_EXIT"; do
   case "$verdict" in FAIL*|FINDINGS*|ERROR*) failed=1 ;; esac
 done
 

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -159,20 +159,18 @@ ROBOREV_VACUITY_MIN_INPUT_TOKENS=25000
 # Advisory only (see above): reported next to the observed value, never a FAIL.
 ROBOREV_VACUITY_ADVISORY_MIN_OUTPUT_TOKENS=200
 
-# prompt-content check: how many census paths to look for in the prompt actually
-# sent to the reviewer. All of them when the census is small; an evenly sampled
-# subset (still ALL of which must be present) when it is large, so the check stays
-# bounded on a 500-file diff.
-PROMPT_CONTENT_MAX_PATHS_CHECKED=40
+# (The former PROMPT_CONTENT_MAX_PATHS_CHECKED sampling cap is gone: every code path is
+# now checked against its exact `diff --git` header, cheap even for a 500-file diff, and
+# sampling was a hole — a partial prompt naming just the sampled files passed.)
 
 # The job record is written ASYNCHRONOUSLY: measured empty for git_ref/status/model/
-# token_usage the instant `--wait` returned, complete moments later. Poll this many
-# times at this interval before declaring the record DEGRADED. 15 x 1s is generous
-# against the observed sub-second lag while still bounded.
+# token_usage the instant `--wait` returned. MEASURED AGAIN in round 5: still
+# incomplete 15s after `--wait` returned on a 20-commit review, so the lag is NOT
+# sub-second. 45 x 1s is bounded and proportionate to a review that takes minutes.
 # Overridable ONLY as a timing knob (the hermetic self-test shortens it). Shortening
 # it can never weaken a check: fewer polls can only make the record MORE likely to be
 # reported DEGRADED, which is the fail-closed direction.
-JOB_RECORD_POLL_ATTEMPTS=${ROBOREV_JOB_RECORD_POLL_ATTEMPTS:-15}
+JOB_RECORD_POLL_ATTEMPTS=${ROBOREV_JOB_RECORD_POLL_ATTEMPTS:-45}
 JOB_RECORD_POLL_INTERVAL_SECS=${ROBOREV_JOB_RECORD_POLL_INTERVAL_SECS:-1}
 
 
@@ -636,8 +634,14 @@ if [ "$announce_ok" -eq 1 ]; then
     ?*)
       REVIEWED_SHA="$JOB_GIT_REF"
       if [ "$JOB_GIT_REF" = "$HEAD_SHA" ]; then
-        SHA_ASSERT="PASS"
-        DETAILS+=("NOTICE: sha-assert: the job record reports a SINGLE commit ('$JOB_GIT_REF'), not a range. It equals branch HEAD, but a single-commit review covers only that commit — prompt-content is what establishes the census was actually sent.")
+        # FAIL CLOSED on a single-commit record even when it equals HEAD (codex, round
+        # 5): a single-commit review covers ONE commit and prompt-content matches
+        # PATHS, so when several commits touch the SAME file a review of only the last
+        # one passes every path check while the earlier changes go unreviewed. The
+        # sanctioned invocation always records a range; a single sha means something
+        # else ran.
+        SHA_ASSERT="FAIL (single-commit record, not the census range)"
+        DETAILS+=("ERROR: sha-assert: the job record reports a SINGLE commit ('$JOB_GIT_REF'), not the census range. It equals branch HEAD, but a single-commit review covers only that commit: when several commits touch the same file, path-based checks cannot tell the difference and the earlier changes go unreviewed. The sanctioned invocation records a '<base>..<head>' range — something else produced this job.")
       else
         SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
         DETAILS+=("ERROR: sha-assert: the job record's git_ref '$JOB_GIT_REF' does not equal branch HEAD '$HEAD_SHA' (job $JOB).")
@@ -675,11 +679,20 @@ fi
 
 # --- step 6a: review-completed — POSITIVE evidence that a review HAPPENED ------
 # The allow-list of terminal verdict markers. A review that finished emits either a
-# findings block (severity-tagged) or the clean shape ("no issues found" AND a
-# "Summary:" line). Anything else — a still-waiting job, a provider 400, a failed
+# findings block (a Findings heading / '**Severity**:' lines) or a Summary heading —
+# the shapes a real review actually emits. Anything else — a still-waiting job, a provider 400, a failed
 # job — matches NOTHING here and therefore cannot reach PASS. This is the inverse of
 # the old logic, which inferred success from the ABSENCE of a vacuous phrase.
-VERDICT_MARKER_RE='\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): |^[[:space:]]*findings?\b'
+# Built from the REAL transcript (MEASURED, issue #2964 round 5), not from guesses:
+#     ## Review Findings
+#     - **Severity**: Medium
+#     ## Summary
+# A finished review is identified by a Findings heading, a `**Severity**:` line, a
+# Summary heading/label, or the older bracket / `Medium:` shapes other agents emit.
+# Anything else — a still-waiting job, a provider 400, a failed job — matches none of
+# them. The previous list was INVENTED rather than measured and rejected a GENUINE
+# codex review: the false-FAIL direction that gets a guard bypassed.
+VERDICT_MARKER_RE='^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?|\*\*severity\*\*[[:space:]]*:|^[[:space:]]*#{1,4}[[:space:]]*summary|(^|[^[:alnum:]])summary:|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): |^[[:space:]]*findings?[[:space:]:]'
 if [ ! -r "$LOG" ]; then
   REVIEW_COMPLETED="FAIL (transcript unreadable)"
   DETAILS+=("ERROR: review-completed: the transcript at $LOG is not readable, so there is no evidence a review happened. Failing closed.")
@@ -687,15 +700,13 @@ else
   verdict_marker=0
   if grep -qiE "$VERDICT_MARKER_RE" "$LOG"; then
     verdict_marker=1
-  elif grep -qi 'no issues found' "$LOG" && grep -qiE '(^|[^[:alnum:]])summary:' "$LOG"; then
-    verdict_marker=1
   fi
   if [ -n "$JOB_STATUS" ] && [ "$JOB_STATUS" != "done" ]; then
     REVIEW_COMPLETED="FAIL (job status '$JOB_STATUS' is not done)"
     DETAILS+=("ERROR: review-completed: the job record reports status '$JOB_STATUS', not 'done', so the review did NOT complete and nothing was certified. Failing closed — the absence of a vacuous phrase is never evidence that a review happened.")
   elif [ "$verdict_marker" -eq 0 ]; then
     REVIEW_COMPLETED="FAIL (no terminal verdict marker)"
-    DETAILS+=("ERROR: review-completed: the transcript carries NO terminal verdict marker — neither a severity-tagged findings block nor the clean 'no issues found' + 'Summary:' shape. A still-waiting job, a provider error (for example the #2433/#3037 model-mismatch 400) and a failed job all look like this, and none of them is a review. Failing closed. Transcript: $LOG")
+    DETAILS+=("ERROR: review-completed: the transcript carries NO terminal verdict marker — no Findings heading, no '**Severity**:' line and no Summary heading/label. A still-waiting job, a provider error (for example the #2433/#3037 model-mismatch 400) and a failed job all look like this, and none of them is a review. Failing closed. Transcript: $LOG")
   else
     REVIEW_COMPLETED="PASS"
     if [ -z "$JOB_STATUS" ]; then
@@ -723,25 +734,22 @@ else
   # files. That is also the empirical mechanism behind the "code-free diff silently
   # discarded" trigger: there is literally nothing left to review. Checking all 27
   # would false-FAIL every branch that touches documentation, which is most of them.
-  checked_paths=()
+  # EVERY code path is checked, and against its EXACT diff header rather than a bare
+  # substring (codex, round 5): sampling a subset let a partial prompt pass by naming
+  # the sampled files, and a substring match is satisfied by any incidental mention —
+  # including this wrapper quoting a path in a comment. A `diff --git a/P b/P` header is
+  # present if and only if the reviewer was sent that file's diff. Exact-header matching
+  # is cheap enough that the sampling cap is gone.
+  checked_paths=("${census_code_paths[@]}")
   census_total=${#census_code_paths[@]}
-  if [ "$census_total" -le "$PROMPT_CONTENT_MAX_PATHS_CHECKED" ]; then
-    checked_paths=("${census_code_paths[@]}")
-  else
-    sample_step=$(((census_total + PROMPT_CONTENT_MAX_PATHS_CHECKED - 1) / PROMPT_CONTENT_MAX_PATHS_CHECKED))
-    sample_index=0
-    while [ "$sample_index" -lt "$census_total" ]; do
-      checked_paths+=("${census_code_paths[$sample_index]}")
-      sample_index=$((sample_index + sample_step))
-    done
-  fi
   missing_paths=()
   for census_path in "${checked_paths[@]}"; do
-    grep -Fq -- "$census_path" "$PROMPT_FILE" || missing_paths+=("$census_path")
+    grep -Fq -- "diff --git a/$census_path b/$census_path" "$PROMPT_FILE" \
+      || missing_paths+=("$census_path")
   done
   if [ "${#missing_paths[@]}" -gt 0 ]; then
     PROMPT_CONTENT="FAIL (${#missing_paths[@]}/${#checked_paths[@]} code census paths absent from the prompt)"
-    DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} checked CODE census paths do NOT appear in the prompt actually sent to the reviewer, so the reviewer never received this diff. The census is authoritative ($CENSUS for ${BASE}...HEAD); a prompt that does not mention its files cannot have reviewed them. Missing (first 10):")
+    DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} CODE census paths have NO 'diff --git' header in the prompt actually sent to the reviewer, so the reviewer never received their diffs. The census is authoritative ($CENSUS for ${BASE}...HEAD); a prompt that does not mention its files cannot have reviewed them. Missing (first 10):")
     printed=0
     for census_path in "${missing_paths[@]}"; do
       [ "$printed" -lt 10 ] || break
@@ -767,12 +775,16 @@ fi
 #      DOES carry severity markers is an INCONSISTENT state. It fails the run and, being
 #      neither PRESENT nor NONE, cannot exempt tier 1 either.
 FINDINGS_BLOCK_FILE="$LOG.findings"
+# The block runs from a Findings heading/label to the Summary heading/label — the
+# measured real shapes. Everything outside it (a quoted "[Low]" in prose, a severity
+# word inside a Problem sentence) is ignored.
 { awk 'BEGIN { inblock = 0 }
-       /^[[:space:]]*#*[[:space:]]*[Ff]indings?[[:space:]:]*$/ { inblock = 1; next }
-       /^[[:space:]]*#*[[:space:]]*[Ff]indings?:/ { inblock = 1; next }
-       /[Ss]ummary:/ { inblock = 0 }
+       tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*(review[[:space:]]+)?findings?/ { inblock = 1; next }
+       tolower($0) ~ /^[[:space:]]*findings?[[:space:]]*:/ { inblock = 1; next }
+       tolower($0) ~ /^[[:space:]]*#{1,4}[[:space:]]*summary/ { inblock = 0 }
+       tolower($0) ~ /summary[[:space:]]*:/ { inblock = 0 }
        inblock { print }' "$LOG" 2>/dev/null || true; } >"$FINDINGS_BLOCK_FILE"
-block_marker_count=$({ grep -oiE '\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
+block_marker_count=$({ grep -oiE '\*\*severity\*\*[[:space:]]*:[[:space:]]*(critical|high|medium|low)|\[(critical|high|medium|low)\]|(^|[^[:alnum:]])(critical|high|medium|low): ' "$FINDINGS_BLOCK_FILE" 2>/dev/null || true; } | wc -l | tr -d '[:space:]')
 block_marker_count=${block_marker_count:-0}
 
 verdict_findings="unknown"

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -54,6 +54,7 @@ trap 'rm -rf "$tmp"' EXIT
 #   STUB_MODEL           job model field
 #   STUB_REQUESTED_MODEL job requested_model field
 #   STUB_PROMPT          prompt text (plain, no quotes/backslashes)
+#   STUB_HAS_TOKEN_DATA  emit a has_token_data field with this value (true/false)
 #   STUB_SHOW_JSON       `none` => `show --json` returns null, forcing the
 #                        `list --json` fallback path
 #   STUB_INVOKED         file the stub appends its argv to (empty => never run)
@@ -67,18 +68,23 @@ cmd="${1:-}"
 shift || true
 
 emit_job_object() {
-  local usage=""
+  local usage="" extra=""
+  if [ -n "${STUB_HAS_TOKEN_DATA:-}" ]; then
+    extra=",\"has_token_data\":${STUB_HAS_TOKEN_DATA}"
+  fi
   if [ "${STUB_TOKEN_USAGE:-NONE}" != "NONE" ]; then
     usage=",\"token_usage\":\"${STUB_TOKEN_USAGE}\""
   fi
+  local git_ref="${STUB_GIT_REF:-${STUB_ANNOUNCE_SHA:-}}"
+  if [ "${STUB_GIT_REF:-}" = none ]; then git_ref=""; fi
   printf '{"id":%s,"git_ref":"%s","status":"%s","model":"%s","requested_model":"%s","prompt":"%s"%s}' \
     "${STUB_JOB:-4600}" \
-    "${STUB_GIT_REF:-${STUB_ANNOUNCE_SHA:-}}" \
+    "$git_ref" \
     "${STUB_STATUS:-done}" \
     "${STUB_MODEL:-gpt-5.6-sol}" \
     "${STUB_REQUESTED_MODEL:-gpt-5.6-sol}" \
     "${STUB_PROMPT:-}" \
-    "$usage"
+    "$usage$extra"
 }
 
 case "$cmd" in
@@ -126,7 +132,10 @@ git_q() { git -C "$1" -c user.email=t@example.invalid -c user.name=Tester -c com
 #   pushed          wide refspec, feature pushed (mirror ref present -> fast path)
 #   unpushed        wide refspec, feature never pushed
 #   empty           wide refspec, feature == main, pushed
-#   docs-only       wide refspec, markdown-only change, pushed
+#   docs-only       wide refspec, markdown-only change, pushed (code-free census)
+#   mixed           one markdown + one .rs file (NOT code-free)
+#   workflow-yaml   only .github/workflows/ci.yml (a .yml extension is CODE, so this
+#                   must NOT be classified code-free)
 #   narrow          NARROW refspec (+refs/heads/main:refs/remotes/origin/main) —
 #                   feature IS pushed but no refs/remotes/origin/feature ever
 #                   exists. This is THE fleet's real configuration, under which a
@@ -179,6 +188,18 @@ make_fixture() { # make_fixture <name> <mode> -> prints work dir
       git_q "$work" add README.md NOTES.md
       git_q "$work" commit -q -m 'docs only'
       ;;
+    mixed)
+      printf 'doc line\n' >>"$work/README.md"
+      printf 'fn helper() {}\n' >>"$work/main.rs"
+      git_q "$work" add README.md main.rs
+      git_q "$work" commit -q -m 'docs plus code'
+      ;;
+    workflow-yaml)
+      mkdir -p "$work/.github/workflows"
+      printf 'name: ci\non: push\n' >"$work/.github/workflows/ci.yml"
+      git_q "$work" add .github/workflows/ci.yml
+      git_q "$work" commit -q -m 'workflow only'
+      ;;
     *)
       printf 'fn helper() {}\n' >>"$work/main.rs"
       git_q "$work" add main.rs
@@ -204,6 +225,19 @@ make_fixture() { # make_fixture <name> <mode> -> prints work dir
       ;;
     no-base)
       git_q "$work" update-ref -d refs/remotes/origin/main
+      ;;
+    detached)
+      git_q "$work" checkout -q --detach HEAD
+      ;;
+    orphan-base)
+      # An unrelated root commit: `git diff <orphan>...HEAD` has NO merge base and
+      # therefore FAILS, which must never render as "census: 0 files".
+      git_q "$work" checkout -q --orphan unrelated
+      git_q "$work" rm -q -rf . >/dev/null 2>&1 || true
+      printf 'unrelated\n' >"$work/UNRELATED.txt"
+      git_q "$work" add UNRELATED.txt
+      git_q "$work" commit -q -m 'unrelated root'
+      git_q "$work" checkout -q feature
       ;;
     deleted-remote)
       # The mirror ref stays, EQUAL to HEAD, while the branch is deleted from the
@@ -260,7 +294,7 @@ assert_verdict() { # assert_verdict <label> <expected RESULT> <expected rc>
 }
 
 assert_says() { # assert_says <label> <extended-regex>
-  if grep -qE "$2" "$OUT"; then
+  if grep -qE -- "$2" "$OUT"; then
     ok "$1"
   else
     bad "$1: pattern '$2' not found in output"
@@ -269,7 +303,7 @@ assert_says() { # assert_says <label> <extended-regex>
 }
 
 assert_lacks() { # assert_lacks <label> <extended-regex>
-  if grep -qE "$2" "$OUT"; then
+  if grep -qE -- "$2" "$OUT"; then
     bad "$1: output unexpectedly matched '$2'"
   else
     ok "$1"
@@ -306,7 +340,7 @@ PROMPT_WITH_PATHS='Review the following change. diff --git a/main.rs b/main.rs @
 PROMPT_WITHOUT_PATHS='Please review the change on this branch. (no diff was attached to this prompt)'
 
 export STUB_JOB=4656
-export STUB_VERDICT='No issues found'
+export STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 export STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 export STUB_PROMPT="$PROMPT_WITH_PATHS"
 export STUB_STATUS=done
@@ -314,12 +348,13 @@ export STUB_GIT_REF=''
 export STUB_MODEL=gpt-5.6-sol
 export STUB_REQUESTED_MODEL=gpt-5.6-sol
 export STUB_SHOW_JSON=object
+export STUB_HAS_TOKEN_DATA=''
 export STUB_REVIEW_RC=0
 export STUB_ANNOUNCE_SHA=''
 
 reset_stub() {
   STUB_JOB=4656
-  STUB_VERDICT='No issues found'
+  STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
   STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
   STUB_PROMPT="$PROMPT_WITH_PATHS"
   STUB_REVIEW_RC=0
@@ -329,6 +364,7 @@ reset_stub() {
   STUB_MODEL=gpt-5.6-sol
   STUB_REQUESTED_MODEL=gpt-5.6-sol
   STUB_SHOW_JSON=object
+  STUB_HAS_TOKEN_DATA=''
 }
 
 printf '== case (a): enqueued sha == base ref ==\n'
@@ -350,38 +386,95 @@ assert_verdict 'case (b)' FAIL 1
 assert_says 'case (b) names neither-endpoint' 'matches NEITHER endpoint'
 assert_says 'case (b) prints the reviewed sha beside expected head' "git_ref '0000000000000000000000000000000000000abc' does not equal branch HEAD"
 
-printf '== case (c): vacuous verdict vs non-empty census ==\n'
+printf '== case (c): a vacuous verdict on a CODE census raises an ADVISORY notice ==\n'
 reset_stub
+# Tier 1 is DEMOTED to advisory (round 3): it matched anywhere in the transcript, so
+# a review that merely QUOTED the phrase — as any review of THIS wrapper would — was
+# failed as vacuous, and agents learning to waive tier-1 FAILs would restore the very
+# defect the guard exists to stop. The docs-only trigger it used to be primary for is
+# now caught deterministically by `code-free:` (case (c2)). See the return packet: the
+# residual gap (reviewer HAD the diff yet concludes "no code changes" on a code
+# census) is now a NOTICE, which the spec's tier-1 requirement calls a hard failure.
 work=$(make_fixture case_c pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
+STUB_VERDICT=$'No issues found.\nSummary: the diff contains no code changes to review.'
 run_wrapper "$work"
-assert_verdict 'case (c)' FAIL 1
-assert_says 'case (c) tier1 FAIL' '^vacuity-tier1: FAIL'
-assert_says 'case (c) names the contradiction' 'NO CODE CHANGES to review, but the locally computed census is NON-EMPTY'
-assert_says 'case (c) prints the census' '^census: [0-9]+ files, \+[0-9]+/-[0-9]+$'
+assert_verdict 'case (c)' PASS 0
+assert_says 'case (c) tier1 raises a NOTICE' '^vacuity-tier1: NOTICE \(vacuous verdict vs non-empty census\)$'
+assert_says 'case (c) the notice says it is advisory' 'ADVISORY, does not fail the run'
+assert_says 'case (c) prints the census' '^census: [0-9]+ files?, \+[0-9]+/-[0-9]+$'
 assert_says 'case (c) sha-assert still PASS' '^sha-assert: PASS$'
 
-printf '== case (c2): a code-free (docs-only) census is attributed to the code-free condition ==\n'
+printf '== case (c1b): the tier-1 match is anchored to the verdict/summary region ==\n'
 reset_stub
+# A genuine findings-bearing review that QUOTES the phrase in a finding body must not
+# be flagged: the match only looks at the Summary line.
+work=$(make_fixture case_c1b pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT=$'Findings:\n[Medium] the tier-1 regex matches the literal phrase no code changes anywhere in the transcript\n[Low] naming nit\nSummary: 2 findings.'
+STUB_REVIEW_RC=1
+run_wrapper "$work"
+STUB_REVIEW_RC=0
+assert_says 'case (c1b) tier1 is NOT tripped by a quote in a finding body' '^vacuity-tier1: PASS$'
+assert_says 'case (c1b) the run fails only for the findings' '^roborev-exit: FINDINGS \(exit 1\)$'
+assert_lacks 'case (c1b) no vacuity notice' 'vacuity-tier1: NOTICE'
+
+printf '== case (c2): a code-free (docs-only) census FAILs deterministically ==\n'
+reset_stub
+# roborev structurally DISCARDS a code-free diff, so such a diff cannot be certified
+# at all. That is a property of OUR census, so it must not depend on the reviewer
+# admitting it: the previous revision computed the classification and used it only for
+# wording, and a docs-only census reached RESULT: PASS.
 work=$(make_fixture case_c2 docs-only)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
 run_wrapper "$work"
 assert_verdict 'case (c2)' FAIL 1
-assert_says 'case (c2) names the code-free condition' 'CODE-FREE-DIFF condition'
+assert_says 'case (c2) code-free is its own FAIL key' '^code-free: FAIL \(code-free census: 2/2 files are documentation/specification text\)$'
+assert_says 'case (c2) names the structural discard' 'roborev STRUCTURALLY DISCARDS a code-free diff'
 assert_says 'case (c2) points at primary-source verification' 'primary-source verification recorded in the PR'
+assert_never_enqueued 'case (c2)'
+assert_says 'case (c2) later checks are SKIPped, not passed' '^review-completed: SKIP$'
+
+printf '== case (c2b): a code-free census FAILs even with a clean verdict and healthy tokens ==\n'
+reset_stub
+work=$(make_fixture case_c2b docs-only)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
+run_wrapper "$work"
+assert_verdict 'case (c2b)' FAIL 1
+assert_lacks 'case (c2b) never reports a pass' '^RESULT: PASS$'
+
+printf '== case (c2c): a mixed census is NOT code-free ==\n'
+reset_stub
+work=$(make_fixture case_c2c mixed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (c2c)' PASS 0
+assert_says 'case (c2c) code-free PASSes when any file is code' '^code-free: PASS$'
+
+printf '== case (c2d): a workflow .yml census is CODE, not documentation ==\n'
+reset_stub
+# The classification is EXTENSION-based: an earlier revision treated everything under
+# .github/ (and docs/) as non-code, which would make this a FALSE code-free FAIL now
+# that code-free fails the run.
+work=$(make_fixture case_c2d workflow-yaml)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_PROMPT='Review this diff: diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml'
+run_wrapper "$work"
+assert_verdict 'case (c2d)' PASS 0
+assert_says 'case (c2d) a .yml file is not classified documentation' '^code-free: PASS$'
 
 printf '== case (d): vacuous token signature vs non-empty census ==\n'
 reset_stub
 work=$(make_fixture case_d pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT='No issues found'
+STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 STUB_TOKEN_USAGE="$TOKENS_VACUOUS"
 run_wrapper "$work"
 assert_verdict 'case (d)' FAIL 1
 assert_says 'case (d) tier2 FAIL' '^vacuity-tier2: FAIL'
 assert_says 'case (d) tier1 unaffected' '^vacuity-tier1: PASS$'
+assert_says 'case (d) code-free PASSes on a code census' '^code-free: PASS$'
 assert_says 'case (d) prints observed input vs named constant' 'observed input=18700 < ROBOREV_VACUITY_MIN_INPUT_TOKENS=25000'
 assert_says 'case (d) prints observed cached vs the zero clause' 'observed cached=0 == 0'
 assert_says 'case (d) output floor is ADVISORY, not a failure condition' 'advisory \(NOT a failure condition\): observed output=53'
@@ -421,7 +514,7 @@ reset_stub
 work=$(make_fixture case_k narrow)
 assert_no_mirror_ref 'case (k)' "$work" origin
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT='No issues found'
+STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 run_wrapper "$work"
 assert_verdict 'case (k)' PASS 0
@@ -566,6 +659,7 @@ assert_says 'case (n) prompt-content FAIL counts the absent paths' '^prompt-cont
 assert_says 'case (n) names the missing path' '^  main\.rs$'
 assert_says 'case (n) says the reviewer never received the diff' 'the reviewer never received this diff'
 assert_says 'case (n) every other check passed' '^vacuity-tier1: PASS$'
+assert_says 'case (n) review-completed still PASS' '^review-completed: PASS$'
 
 printf '== case (n2): an unretrievable prompt degrades visibly, never a silent skip ==\n'
 reset_stub
@@ -579,7 +673,7 @@ assert_says 'case (n2) degraded-signal wording' 'DEGRADED SIGNAL, never a silent
 
 printf '== case (n3): prompt-content PASS reports the coverage it checked ==\n'
 reset_stub
-work=$(make_fixture case_n3 docs-only)
+work=$(make_fixture case_n3 mixed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 run_wrapper "$work"
 assert_says 'case (n3) prompt-content PASS names the counts' '^prompt-content: PASS \(2/2 census paths present\)$'
@@ -624,7 +718,7 @@ reset_stub
 work=$(make_fixture case_f pushed)
 head_sha=$(git -C "$work" rev-parse HEAD)
 STUB_ANNOUNCE_SHA="$head_sha"
-STUB_VERDICT='No issues found'
+STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 run_wrapper "$work"
 assert_verdict 'case (f)' PASS 0
@@ -669,25 +763,24 @@ assert_verdict 'case (h)' FAIL 1
 assert_says 'case (h) sha-assert FAIL (unverifiable)' '^sha-assert: FAIL \(no parseable enqueue announcement\)$'
 assert_says 'case (h) reviewed-sha unknown' '^reviewed-sha: -$'
 
-printf '== case (i): unavailable token accounting degrades visibly, tier 1 still governs ==\n'
+printf '== case (i): unavailable token accounting degrades visibly ==\n'
 reset_stub
 work=$(make_fixture case_i pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
 STUB_TOKEN_USAGE=NONE
 run_wrapper "$work"
-assert_verdict 'case (i)' FAIL 1
+assert_verdict 'case (i)' PASS 0
 assert_says 'case (i) tokens UNAVAILABLE' '^tokens: UNAVAILABLE$'
 assert_says 'case (i) tier2 UNAVAILABLE' '^vacuity-tier2: UNAVAILABLE$'
-assert_says 'case (i) degraded-signal notice, not a skip' 'DEGRADED SIGNAL, never a silent skip'
-assert_says 'case (i) tier1 still FAILs' '^vacuity-tier1: FAIL'
-assert_lacks 'case (i) UNAVAILABLE never upgrades to PASS' '^RESULT: PASS$'
+assert_says 'case (i) degraded notice, not a skip' 'never a silent skip'
+assert_says 'case (i) tier1 records its advisory notice' '^vacuity-tier1: NOTICE'
 
 printf '== case (i2): unavailable accounting alone does not fail an otherwise clean review ==\n'
 reset_stub
 work=$(make_fixture case_i2 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT='No issues found'
+STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 STUB_TOKEN_USAGE=NONE
 run_wrapper "$work"
 assert_verdict 'case (i2)' PASS 0
@@ -700,12 +793,12 @@ reset_stub
 # told the reviewer broke retries or bypasses instead of FIXING THE FINDINGS.
 work=$(make_fixture case_j pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT='Review complete. Findings: 1. [Medium] scripts/flow/roborev-review.sh:350 the fast path bypasses the authoritative remote check'
+STUB_VERDICT=$'Review complete.\nFindings:\n[Medium] scripts/flow/roborev-review.sh:350 the fast path bypasses the authoritative remote check\nSummary: 1 finding.'
 STUB_STATUS=done
 STUB_REVIEW_RC=1
 run_wrapper "$work"
 STUB_REVIEW_RC=0
-STUB_VERDICT='No issues found'
+STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 assert_verdict 'case (j)' FAIL 1
 assert_says 'case (j) roborev-exit is FINDINGS with the observed code' '^roborev-exit: FINDINGS \(exit 1\)$'
 assert_says 'case (j) findings are PRESENT and counted' '^findings: PRESENT \(1\)$'
@@ -730,7 +823,7 @@ STUB_REVIEW_RC=2
 run_wrapper "$work"
 STUB_REVIEW_RC=0
 STUB_STATUS=done
-STUB_VERDICT='No issues found'
+STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 assert_verdict 'case (j1b)' FAIL 1
 assert_says 'case (j1b) roborev-exit is ERROR with the observed code' '^roborev-exit: ERROR \(exit 2\)$'
 assert_says 'case (j1b) findings are UNKNOWN' '^findings: UNKNOWN$'
@@ -762,6 +855,238 @@ assert_verdict 'case (j3)' FAIL 1
 assert_says 'case (j3) roborev-exit SKIP (the process never ran)' '^roborev-exit: SKIP$'
 assert_never_enqueued 'case (j3)'
 
+printf '== case (s1): a job that never finished must NOT reach PASS ==\n'
+reset_stub
+# B1, the worst defect: there was no POSITIVE "a review happened" assert. Absence of
+# a vacuous phrase was treated as proof one occurred, so a still-waiting job passed.
+work=$(make_fixture case_s1 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='Waiting for job 4656 to complete...'
+run_wrapper "$work"
+assert_verdict 'case (s1)' FAIL 1
+assert_says 'case (s1) review-completed FAILs on the missing verdict marker' '^review-completed: FAIL \(no terminal verdict marker\)$'
+assert_says 'case (s1) roborev-exit is still PASS (exit 0)' '^roborev-exit: PASS$'
+assert_says 'case (s1) explains that absence is not evidence' 'none of them is a review'
+assert_lacks 'case (s1) never reports a pass' '^RESULT: PASS$'
+
+printf '== case (s2): the #2433/#3037 model-mismatch 400 must NOT reach PASS ==\n'
+reset_stub
+work=$(make_fixture case_s2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='Error: 400 the requested model is not supported for this account. Review aborted.'
+run_wrapper "$work"
+assert_verdict 'case (s2)' FAIL 1
+assert_says 'case (s2) review-completed FAILs' '^review-completed: FAIL \(no terminal verdict marker\)$'
+assert_says 'case (s2) names the silent-outage class' '#2433/#3037 model-mismatch 400'
+
+printf '== case (s3): a failed job status must NOT reach PASS ==\n'
+reset_stub
+work=$(make_fixture case_s3 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='Job 4656 status: failed (provider timeout). No review was produced.'
+STUB_STATUS=failed
+run_wrapper "$work"
+assert_verdict 'case (s3)' FAIL 1
+assert_says 'case (s3) review-completed FAILs on the job status' "^review-completed: FAIL \(job status 'failed' is not done\)\$"
+assert_says 'case (s3) says nothing was certified' 'nothing was certified'
+
+printf '== case (t1): a 9-char SHORT sha announcement (the real shape) still verifies ==\n'
+reset_stub
+# The recorded real announcement carries an ABBREVIATED sha, so the fallback compare
+# must be a prefix match; strict equality would reject every real announcement.
+work=$(make_fixture case_t1 pushed)
+head_sha=$(git -C "$work" rev-parse HEAD)
+STUB_ANNOUNCE_SHA="${head_sha:0:9}"
+STUB_GIT_REF=none
+run_wrapper "$work"
+assert_verdict 'case (t1)' PASS 0
+assert_says 'case (t1) the abbreviated sha satisfied the assert' '^sha-assert: PASS$'
+assert_says 'case (t1) the weaker source is named' 'abbreviated-sha prefix parse'
+
+printf '== case (t2): an UPPERCASE announcement is normalised, not fed on as garbage ==\n'
+reset_stub
+work=$(make_fixture case_t2 pushed)
+head_sha=$(git -C "$work" rev-parse HEAD)
+STUB_ANNOUNCE_SHA=$(printf '%s' "${head_sha:0:9}" | tr 'a-f' 'A-F')
+STUB_GIT_REF=none
+run_wrapper "$work"
+assert_verdict 'case (t2)' PASS 0
+assert_says 'case (t2) reviewed-sha is lower-cased' "^reviewed-sha: ${head_sha:0:9}\$"
+
+printf '== case (t3): a 4-hex-char announcement is too short to verify ==\n'
+reset_stub
+work=$(make_fixture case_t3 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD | cut -c1-4)
+# git_ref absent on purpose: the ANNOUNCEMENT must be the load-bearing signal here,
+# or the structured oracle rejects the short sha for an unrelated reason and the
+# regex floor goes untested.
+STUB_GIT_REF=none
+run_wrapper "$work"
+assert_verdict 'case (t3)' FAIL 1
+assert_says 'case (t3) the 7-char floor rejects it' '^sha-assert: FAIL \(no parseable enqueue announcement\)$'
+assert_says 'case (t3) mentions the 7-hex-char floor' 'at least 7 hex chars'
+
+printf '== case (t4): with two announcements the LAST one is the effective enqueue ==\n'
+reset_stub
+work=$(make_fixture case_t4 pushed)
+head_sha=$(git -C "$work" rev-parse HEAD)
+base_sha=$(git -C "$work" rev-parse origin/main)
+STUB_ANNOUNCE_SHA="$base_sha"
+STUB_GIT_REF=none
+STUB_VERDICT=$'superseded; retrying\nEnqueued job 4656 for '"$head_sha"$'\nNo issues found.\nSummary: reviewed the diff; no issues found.'
+run_wrapper "$work"
+assert_verdict 'case (t4)' PASS 0
+assert_says 'case (t4) the multiplicity is recorded' 'the transcript carries 2 enqueue announcements'
+assert_says 'case (t4) the LAST announcement was asserted' "^reviewed-sha: $head_sha\$"
+
+printf '== case (t5): a detached HEAD FAILs before anything is enqueued ==\n'
+reset_stub
+work=$(make_fixture case_t5 detached)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (t5)' FAIL 1
+assert_says 'case (t5) push-assert names the detached HEAD' '^push-assert: FAIL \(detached HEAD\)$'
+assert_never_enqueued 'case (t5)'
+
+printf '== case (t6): a census whose git diff FAILS is not "genuinely empty" ==\n'
+reset_stub
+work=$(make_fixture case_t6 orphan-base)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work" --base unrelated
+assert_verdict 'case (t6)' FAIL 1
+assert_says 'case (t6) the diff failure is named' '^census-check: FAIL \(git diff failed\)$'
+assert_says 'case (t6) it is explicitly not NOTHING-TO-REVIEW' 'explicitly NOT a NOTHING-TO-REVIEW'
+assert_lacks 'case (t6) never reports NOTHING-TO-REVIEW' '^RESULT: NOTHING-TO-REVIEW$'
+assert_never_enqueued 'case (t6)'
+
+printf '== case (t7): a repository with no commits FAILs closed ==\n'
+reset_stub
+mkdir -p "$tmp/case_t7"
+git init -q -b main "$tmp/case_t7/work"
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+INVOKED="$tmp/invoked-$CASE_N.txt"
+: >"$INVOKED"
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --repo "$tmp/case_t7/work" \
+  --agent codex --model gpt-5.6-sol --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
+RC=$?
+assert_verdict 'case (t7)' FAIL 1
+assert_says 'case (t7) names the missing commit' 'there is no commit to review'
+assert_never_enqueued 'case (t7)'
+
+printf '== case (t8): roborev absent from PATH FAILs closed ==\n'
+reset_stub
+work=$(make_fixture case_t8 pushed)
+nobin="$tmp/nobin"
+mkdir -p "$nobin"
+missing_tool=0
+for tool in git sed grep awk tr wc head tail cut mkdir dirname basename python3 cat bash; do
+  tool_path=$(command -v "$tool" 2>/dev/null || printf '')
+  if [ -n "$tool_path" ]; then ln -sf "$tool_path" "$nobin/$tool"; else missing_tool=1; fi
+done
+if [ "$missing_tool" -eq 1 ]; then
+  printf 'SKIP - case (t8): could not assemble a roborev-free PATH (a base tool is missing)\n'
+else
+  CASE_N=$((CASE_N + 1))
+  OUT="$tmp/out-$CASE_N.txt"
+  INVOKED="$tmp/invoked-$CASE_N.txt"
+  : >"$INVOKED"
+  STUB_INVOKED="$INVOKED" PATH="$nobin" "$nobin/bash" "$WRAPPER" --repo "$work" \
+    --agent codex --model gpt-5.6-sol --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
+  RC=$?
+  assert_verdict 'case (t8)' FAIL 1
+  assert_says 'case (t8) names the absent binary' "'roborev' is not on PATH"
+  assert_never_enqueued 'case (t8)'
+fi
+
+printf '== case (t9): an abort BEFORE a verdict still emits a block (the EXIT trap) ==\n'
+reset_stub
+# Nothing exercised the on_exit trap. Pre-creating <log>.facts as a DIRECTORY makes
+# the facts-file truncation fail under `set -e` after the review is enqueued.
+work=$(make_fixture case_t9 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+mkdir -p "$tmp/trapcase.log.facts"
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+INVOKED="$tmp/invoked-$CASE_N.txt"
+: >"$INVOKED"
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --repo "$work" \
+  --agent codex --model gpt-5.6-sol --log "$tmp/trapcase.log" >"$OUT" 2>&1
+RC=$?
+assert_verdict 'case (t9)' FAIL 1
+assert_says 'case (t9) the abort is reported, not silent' 'terminated unexpectedly'
+assert_one_block 'case (t9)'
+
+printf '== case (u1): token accounting present but UNPARSEABLE is drift, and FAILs ==\n'
+if [ "$HAVE_PYTHON3" -eq 1 ]; then
+reset_stub
+# B3: any JSON shape change used to degrade the tier to a NON-FAILING UNAVAILABLE
+# while the real counts were the vacuous baseline, and the run PASSED.
+work=$(make_fixture case_u1 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE='{\"input_tokens\":null,\"cached_input_tokens\":\"n/a\",\"total_output_tokens\":53}'
+run_wrapper "$work"
+assert_verdict 'case (u1)' FAIL 1
+assert_says 'case (u1) drift is named under the tier-2 key' '^vacuity-tier2: FAIL \(token accounting present but unparseable — drift\)$'
+assert_says 'case (u1) points at the alias lists' 'INPUT/CACHED/OUTPUT_TOKEN_KEYS'
+assert_says 'case (u1) refuses a waiver' 'do not waive it'
+
+printf '== case (u2): RENAMED token fields resolve via the alias sets ==\n'
+reset_stub
+# The vacuous baseline hiding behind renamed fields: aliases must resolve it so the
+# vacuity check still fires instead of degrading to UNAVAILABLE + PASS.
+work=$(make_fixture case_u2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE='{\"prompt_tokens\":18700,\"cache_read_tokens\":0,\"completion_tokens\":53}'
+run_wrapper "$work"
+assert_verdict 'case (u2)' FAIL 1
+assert_says 'case (u2) the renamed counts were read' '^tokens: input=18700 cached=0 output=53$'
+assert_says 'case (u2) the vacuous signature fires' '^vacuity-tier2: FAIL \(vacuous token signature\)$'
+
+printf '== case (u3): has_token_data=false beside real counts is a drift NOTICE, not a bypass ==\n'
+reset_stub
+work=$(make_fixture case_u3 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE="$TOKENS_VACUOUS"
+STUB_HAS_TOKEN_DATA=false
+run_wrapper "$work"
+STUB_HAS_TOKEN_DATA=''
+assert_verdict 'case (u3)' FAIL 1
+assert_says 'case (u3) the counts were still used' '^tokens: input=18700 cached=0 output=53$'
+assert_says 'case (u3) the inconsistency is recorded' 'has_token_data=false yet readable counts are present'
+assert_says 'case (u3) the vacuous signature still fires' '^vacuity-tier2: FAIL \(vacuous token signature\)$'
+fi  # HAVE_PYTHON3
+
+printf '== case (v): option-value and option-name validation ==\n'
+reset_stub
+work=$(make_fixture case_v pushed)
+for bad in "--repo" "--base" "--log"; do
+  CASE_N=$((CASE_N + 1))
+  OUT="$tmp/out-$CASE_N.txt"
+  INVOKED="$tmp/invoked-$CASE_N.txt"
+  : >"$INVOKED"
+  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" \
+    --agent codex --model gpt-5.6-sol "$bad" '' >"$OUT" 2>&1
+  RC=$?
+  if [ "$RC" -eq 2 ]; then ok "usage: an empty '$bad' value exits 2"; else bad "usage: an empty '$bad' value exited $RC (want 2)"; fi
+  assert_says "usage: an empty '$bad' value is named" "$bad was given an empty value"
+done
+for bad_invocation in "--nonsense" "--repo:$tmp/definitely-not-a-directory" "--repo:$tmp"; do
+  CASE_N=$((CASE_N + 1))
+  OUT="$tmp/out-$CASE_N.txt"
+  INVOKED="$tmp/invoked-$CASE_N.txt"
+  : >"$INVOKED"
+  case "$bad_invocation" in
+    --repo:*) set -- --repo "${bad_invocation#--repo:}" ;;
+    *) set -- "$bad_invocation" ;;
+  esac
+  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" \
+    --agent codex --model gpt-5.6-sol "$@" >"$OUT" 2>&1
+  RC=$?
+  if [ "$RC" -eq 2 ]; then ok "usage: '$bad_invocation' exits 2"; else bad "usage: '$bad_invocation' exited $RC (want 2)"; fi
+  assert_never_enqueued "usage: '$bad_invocation'"
+done
+
 printf '== usage errors: --agent and --model are BOTH required ==\n'
 reset_stub
 work=$(make_fixture case_usage pushed)
@@ -787,7 +1112,7 @@ printf '== the summary header is distinct from every agent-gate header ==\n'
 reset_stub
 work=$(make_fixture case_hdr pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT='No issues found'
+STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 run_wrapper "$work"
 assert_says 'header: roborev block present' '^==== ROBOREV REVIEW SUMMARY ====$'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -126,7 +126,7 @@ case "$cmd" in
     ;;
   show)
     case " $* " in
-      *" --prompt "*) printf '%s\n' "${STUB_PROMPT:-}"; exit 0 ;;
+      *" --prompt "*) printf '%b\n' "${STUB_PROMPT:-}"; exit 0 ;;
     esac
     record_read_blank && { printf 'null\n'; exit 0; }
     [ "${STUB_SHOW_JSON:-object}" != none ] || { printf 'null\n'; exit 0; }
@@ -172,6 +172,7 @@ git_q() { git -C "$1" -c user.email=t@example.invalid -c user.name=Tester -c com
 #   docs-only       wide refspec, markdown-only change, pushed (code-free census)
 #   mixed           one markdown + one .rs file (NOT code-free)
 #   two-code-commits  two commits, each touching a DIFFERENT .rs file
+#   renamed         main.rs renamed to renamed.rs (census sees both paths)
 #   workflow-yaml   only .github/workflows/ci.yml (a .yml extension is CODE, so this
 #                   must NOT be classified code-free)
 #   narrow          NARROW refspec (+refs/heads/main:refs/remotes/origin/main) —
@@ -225,6 +226,12 @@ make_fixture() { # make_fixture <name> <mode> -> prints work dir
       printf '# spec\n' >"$work/NOTES.md"
       git_q "$work" add README.md NOTES.md
       git_q "$work" commit -q -m 'docs only'
+      ;;
+    renamed)
+      # A rename: with `--no-renames` the census sees TWO paths (old deleted, new added)
+      # while the reviewer's diff may carry ONE `diff --git a/old b/new` header.
+      git_q "$work" mv main.rs renamed.rs
+      git_q "$work" commit -q -m 'rename main.rs'
       ;;
     two-code-commits)
       # Two commits touching DIFFERENT code files: a single-commit review would cover
@@ -391,7 +398,10 @@ TOKENS_INPUT_AT_FLOOR='{\"input_tokens\":25000,\"cached_input_tokens\":9000,\"to
 TOKENS_OLD_FIELD_NAMES='{\"input_tokens\":505625,\"cached_input_tokens\":387328,\"output_tokens\":6332}'
 
 # A prompt that mentions every path any fixture touches, and one that mentions none.
-PROMPT_WITH_PATHS='Review the following change. diff --git a/main.rs b/main.rs @@ fn helper() {} @@ diff --git a/README.md b/README.md diff --git a/NOTES.md b/NOTES.md'
+# `\n` stays escaped: it is embedded in a JSON string in the stub payload and rendered
+# by `printf %b` on the --prompt path, so the wrapper sees real line-anchored headers
+# exactly as the measured prompt does.
+PROMPT_WITH_PATHS='Review the following change.\ndiff --git a/main.rs b/main.rs\n@@ fn helper() {} @@\ndiff --git a/README.md b/README.md\ndiff --git a/NOTES.md b/NOTES.md'
 PROMPT_WITHOUT_PATHS='Please review the change on this branch. (no diff was attached to this prompt)'
 
 export STUB_JOB=4656
@@ -553,7 +563,7 @@ reset_stub
 # that code-free fails the run.
 work=$(make_fixture case_c2d workflow-yaml)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_PROMPT='Review this diff: diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml'
+STUB_PROMPT='Review this diff:\ndiff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml'
 run_wrapper "$work"
 assert_verdict 'case (c2d)' PASS 0
 assert_says 'case (c2d) a .yml file is not classified documentation' '^code-free: PASS$'
@@ -756,15 +766,15 @@ assert_says 'case (n) says the reviewer never received the diffs' 'the reviewer 
 assert_says 'case (n) every other check passed' '^vacuity-tier1: PASS$'
 assert_says 'case (n) review-completed still PASS' '^review-completed: PASS$'
 
-printf '== case (n2): an unretrievable prompt degrades visibly, never a silent skip ==\n'
+printf '== case (n2): an unretrievable prompt FAILs — a pass would rest on nothing ==\n'
 reset_stub
 work=$(make_fixture case_n2 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_PROMPT=''
 run_wrapper "$work"
-assert_verdict 'case (n2)' PASS 0
-assert_says 'case (n2) prompt-content UNAVAILABLE' '^prompt-content: UNAVAILABLE$'
-assert_says 'case (n2) degraded-signal wording' 'DEGRADED SIGNAL, never a silent skip'
+assert_verdict 'case (n2)' FAIL 1
+assert_says 'case (n2) prompt-content FAILs on an unretrievable prompt' '^prompt-content: FAIL \(prompt unretrievable — no evidence any diff was delivered\)$'
+assert_says 'case (n2) says a pass would rest on nothing' 'a pass here would rest on nothing'
 
 printf '== case (n3): prompt-content PASS reports the coverage it checked ==\n'
 reset_stub
@@ -1199,7 +1209,7 @@ reset_stub
 # that the whole range actually reached the reviewer.
 work=$(make_fixture case_x1 two-code-commits)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
-STUB_PROMPT='Review this diff: diff --git a/beta.rs b/beta.rs +fn beta() {}'
+STUB_PROMPT='Review this diff:\ndiff --git a/beta.rs b/beta.rs\n+fn beta() {}'
 run_wrapper "$work"
 assert_verdict 'case (x1)' FAIL 1
 assert_says 'case (x1) prompt-content names the uncovered code path' '^prompt-content: FAIL \(1/2 code census paths absent from the prompt\)$'
@@ -1224,7 +1234,7 @@ printf '== case (x2): the full range in the prompt PASSes ==\n'
 reset_stub
 work=$(make_fixture case_x2 two-code-commits)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
-STUB_PROMPT='Review this diff: diff --git a/alpha.rs b/alpha.rs diff --git a/beta.rs b/beta.rs diff --git a/main.rs b/main.rs'
+STUB_PROMPT='Review this diff:\ndiff --git a/alpha.rs b/alpha.rs\ndiff --git a/beta.rs b/beta.rs\ndiff --git a/main.rs b/main.rs'
 run_wrapper "$work"
 assert_verdict 'case (x2)' PASS 0
 assert_says 'case (x2) every code census path was covered' '^prompt-content: PASS \(2/2 code census paths present\)$'
@@ -1332,7 +1342,7 @@ STUB_PROMPT='Review the branch. The wrapper mentions main.rs in prose but no dif
 run_wrapper "$work"
 assert_verdict 'case (x5)' FAIL 1
 assert_says 'case (x5) a bare mention is not coverage' "^prompt-content: FAIL \(1/1 code census paths absent from the prompt\)\$"
-assert_says 'case (x5) the diff-header requirement is named' "have NO 'diff --git' header in the prompt"
+assert_says 'case (x5) the diff-header requirement is named' "appear on NEITHER side of any 'diff --git' header"
 
 printf '== case (x6): the REAL codex review shape counts as a completed review ==\n'
 reset_stub
@@ -1396,6 +1406,77 @@ assert_says 'case (x8) the range oracle worked' '^sha-assert: PASS$'
 assert_says 'case (x8) tokens came from the job row' '^vacuity-tier2: PASS$'
 assert_says 'case (x8) the model was confirmed' '^model: gpt-5\.6-sol$'
 fi  # HAVE_PYTHON3
+
+printf '== case (v1): a multiline "## Summary" heading form is scanned by tier 1 ==\n'
+reset_stub
+# codex, round 6 (BLOCKER): the region used to be the LINES containing "Summary:", so the
+# real heading form — "## Summary", blank line, then the prose — was missed entirely and a
+# vacuous clean review whose "no code changes" sentence sits under the heading PASSED.
+work=$(make_fixture case_v1 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_VERDICT_FIELD=P
+STUB_VERDICT=$'No issues found.\n\n## Summary\n\nThe diff contains no code changes to review.'
+run_wrapper "$work"
+assert_verdict 'case (v1)' FAIL 1
+assert_says 'case (v1) tier1 FAILs on the heading form' '^vacuity-tier1: FAIL \(vacuous verdict vs non-empty census\)$'
+assert_says 'case (v1) findings are NONE, so the gate does not exempt it' '^findings: NONE$'
+
+printf '== case (v2): a RENAME header covers both census paths ==\n'
+reset_stub
+# codex, round 6 (BLOCKER): the census runs with --no-renames (two paths) while the
+# reviewer's diff may have rename detection ON (one a/old b/new header). Requiring
+# same-path headers falsely rejected every review containing a detected rename.
+work=$(make_fixture case_v2 renamed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_PROMPT='Review this diff:\ndiff --git a/main.rs b/renamed.rs\nsimilarity index 100%'
+run_wrapper "$work"
+assert_verdict 'case (v2)' PASS 0
+assert_says 'case (v2) both rename sides count as covered' '^prompt-content: PASS \(2/2 code census paths present\)$'
+
+printf '== case (w3): a MISSING checks file FAILs closed ==\n'
+reset_stub
+# Same bar as the oracles split: an absent checks file would turn review-completed,
+# prompt-content, findings and both vacuity tiers into no-ops while the block read PASS.
+work=$(make_fixture case_w3 pushed)
+lonely_checks="$tmp/lonely-checks"
+mkdir -p "$lonely_checks"
+cp "$WRAPPER" "$lonely_checks/roborev-review.sh"
+cp "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" "$lonely_checks/"
+cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$lonely_checks/" 2>/dev/null || true
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+INVOKED="$tmp/invoked-$CASE_N.txt"
+: >"$INVOKED"
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$lonely_checks/roborev-review.sh" --repo "$work" \
+  --agent codex --model gpt-5.6-sol --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
+RC=$?
+assert_verdict 'case (w3)' FAIL 1
+assert_says 'case (w3) names the missing checks file' 'checks file .* is missing'
+assert_says 'case (w3) refuses to run with the checks disabled' 'Failing closed rather than proceeding'
+assert_says 'case (w3) the checks never claim a pass' '^review-completed: SKIP$'
+assert_never_enqueued 'case (w3)'
+
+printf '== case (w4): a TRUNCATED checks file FAILs closed ==\n'
+reset_stub
+work=$(make_fixture case_w4 pushed)
+trunc_checks="$tmp/trunc-checks"
+mkdir -p "$trunc_checks"
+cp "$WRAPPER" "$trunc_checks/roborev-review.sh"
+cp "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" "$trunc_checks/"
+cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$trunc_checks/" 2>/dev/null || true
+printf '# corrupt: defines nothing\n' >"$trunc_checks/roborev-review-checks.sh"
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+INVOKED="$tmp/invoked-$CASE_N.txt"
+: >"$INVOKED"
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$trunc_checks/roborev-review.sh" --repo "$work" \
+  --agent codex --model gpt-5.6-sol --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
+RC=$?
+assert_verdict 'case (w4)' FAIL 1
+assert_says 'case (w4) names the undefined check function' 'did not define roborev_check_review_completed'
+assert_never_enqueued 'case (w4)'
 
 printf '== case (w): a MISSING oracles file FAILs closed, never silently no-ops ==\n'
 reset_stub

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -84,15 +84,38 @@ chmod +x "$stubbin/roborev"
 # ---------------------------------------------------------------------------
 git_q() { git -C "$1" -c user.email=t@example.invalid -c user.name=Tester -c commit.gpgsign=false "${@:2}"; }
 
-make_fixture() { # make_fixture <name> <mode: pushed|unpushed|empty|docs-only> -> prints work dir
+# Modes:
+#   pushed          wide refspec, feature pushed (mirror ref present -> fast path)
+#   unpushed        wide refspec, feature never pushed
+#   empty           wide refspec, feature == main, pushed
+#   docs-only       wide refspec, markdown-only change, pushed
+#   narrow          NARROW refspec (+refs/heads/main:refs/remotes/origin/main) —
+#                   feature IS pushed but no refs/remotes/origin/feature ever
+#                   exists. This is THE fleet's real configuration, under which a
+#                   mirror-ref push assert false-FAILs unconditionally.
+#   narrow-behind   narrow refspec, pushed, then one extra LOCAL commit
+#   narrow-upstream narrow refspec on a remote named `upstream` with
+#                   branch.feature.remote=upstream (hardcoding `origin` breaks)
+#   unreachable     pushed, mirror ref removed, remote URL repointed at a missing
+#                   path so `git ls-remote` FAILS (infra/auth condition)
+#   no-base         pushed, then refs/remotes/origin/main deleted so the default
+#                   --base origin/main cannot resolve
+make_fixture() { # make_fixture <name> <mode> -> prints work dir
   # NOTE: separate statements on purpose — `local` is a builtin, so ALL of its
   # arguments are expanded before any assignment takes effect; `local a=$1 b=$a`
   # would read an unset `a` and abort under `set -u`.
-  local name mode root work
+  local name mode root work remote narrow
   name="$1"
   mode="$2"
   root="$tmp/$name"
   work="$root/work"
+  remote=origin
+  narrow=0
+  case "$mode" in
+    narrow|narrow-behind) narrow=1 ;;
+    narrow-upstream) narrow=1; remote=upstream ;;
+  esac
+
   mkdir -p "$root"
   git init -q --bare "$root/origin.git"
   git init -q -b main "$work"
@@ -100,33 +123,59 @@ make_fixture() { # make_fixture <name> <mode: pushed|unpushed|empty|docs-only> -
   printf 'fn main() {}\n' >"$work/main.rs"
   git_q "$work" add README.md main.rs
   git_q "$work" commit -q -m base
-  git_q "$work" remote add origin "$root/origin.git"
-  git_q "$work" push -q origin main
+  git_q "$work" remote add "$remote" "$root/origin.git"
+  if [ "$narrow" -eq 1 ]; then
+    git_q "$work" config "remote.$remote.fetch" "+refs/heads/main:refs/remotes/$remote/main"
+  fi
+  git_q "$work" push -q "$remote" main
 
+  git_q "$work" checkout -q -b feature main
   case "$mode" in
-    empty)
-      git_q "$work" checkout -q -b feature main
-      git_q "$work" push -q origin feature
-      ;;
+    empty) : ;;
     docs-only)
-      git_q "$work" checkout -q -b feature main
       printf 'doc line\ndoc line 2\n' >>"$work/README.md"
       printf '# spec\n' >"$work/NOTES.md"
       git_q "$work" add README.md NOTES.md
       git_q "$work" commit -q -m 'docs only'
-      git_q "$work" push -q origin feature
       ;;
     *)
-      git_q "$work" checkout -q -b feature main
       printf 'fn helper() {}\n' >>"$work/main.rs"
       git_q "$work" add main.rs
       git_q "$work" commit -q -m 'code change'
-      if [ "$mode" = pushed ]; then
-        git_q "$work" push -q origin feature
-      fi
+      ;;
+  esac
+  if [ "$mode" != unpushed ]; then
+    git_q "$work" push -q "$remote" feature
+  fi
+
+  case "$mode" in
+    narrow-upstream)
+      git_q "$work" config branch.feature.remote "$remote"
+      ;;
+    narrow-behind)
+      printf 'fn later() {}\n' >>"$work/main.rs"
+      git_q "$work" add main.rs
+      git_q "$work" commit -q -m 'unpushed narrow follow-up'
+      ;;
+    unreachable)
+      git_q "$work" update-ref -d "refs/remotes/origin/feature" 2>/dev/null || true
+      git_q "$work" remote set-url origin "$root/absent-remote.git"
+      ;;
+    no-base)
+      git_q "$work" update-ref -d refs/remotes/origin/main
       ;;
   esac
   printf '%s' "$work"
+}
+
+# Fixture-integrity guard: a narrow-refspec fixture that accidentally grew a
+# feature mirror ref would silently stop testing the condition it exists for.
+assert_no_mirror_ref() { # assert_no_mirror_ref <label> <work> <remote>
+  if git -C "$2" rev-parse --verify --quiet "refs/remotes/$3/feature" >/dev/null; then
+    bad "$1: fixture is not narrow — refs/remotes/$3/feature exists"
+  else
+    ok "$1: no refs/remotes/$3/feature mirror ref (narrow refspec reproduced)"
+  fi
 }
 
 CASE_N=0
@@ -259,7 +308,7 @@ STUB_TOKENS='505625 387328 6332'
 run_wrapper "$work"
 assert_verdict 'case (e)' FAIL 1
 assert_says 'case (e) push-assert FAIL' '^push-assert: FAIL'
-assert_says 'case (e) names the missing remote branch' "remote branch 'origin/feature' does not exist"
+assert_says 'case (e) names the missing remote branch authoritatively' "the remote 'origin' has no branch 'feature' \(authoritative: git ls-remote\)"
 assert_never_enqueued 'case (e)'
 
 printf '== case (e2): remote behind HEAD names the unpushed commits ==\n'
@@ -272,6 +321,64 @@ run_wrapper "$work"
 assert_verdict 'case (e2)' FAIL 1
 assert_says 'case (e2) lists the unpushed commit' 'unpushed follow-up'
 assert_never_enqueued 'case (e2)'
+
+printf '== case (k): NARROW fetch refspec — pushed, but no feature mirror ref ==\n'
+# THE regression case (#2964 follow-up blocker): CQLite clones set
+# remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main, so
+# refs/remotes/origin/<feature> is NEVER created however often the branch is
+# pushed. A mirror-ref push assert false-FAILs here 100% of the time, which would
+# make the only sanctioned roborev invocation unusable fleet-wide and push agents
+# back to the bare --branch form. The remote (git ls-remote) is the authority.
+work=$(make_fixture case_k narrow)
+assert_no_mirror_ref 'case (k)' "$work" origin
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='No issues found'
+STUB_TOKENS='505625 387328 6332'
+run_wrapper "$work"
+assert_verdict 'case (k)' PASS 0
+assert_says 'case (k) push-assert PASS despite the absent mirror ref' '^push-assert: PASS$'
+assert_says 'case (k) the run proceeded to a real review' '^sha-assert: PASS$'
+
+printf '== case (k2): narrow refspec, pushed but behind HEAD ==\n'
+work=$(make_fixture case_k2 narrow-behind)
+assert_no_mirror_ref 'case (k2)' "$work" origin
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (k2)' FAIL 1
+assert_says 'case (k2) push-assert FAIL (unpushed commits)' '^push-assert: FAIL \(unpushed commits\)$'
+assert_says 'case (k2) names the unpushed commit' 'unpushed narrow follow-up'
+assert_says 'case (k2) cites ls-remote as the authority' 'authoritative: git ls-remote'
+assert_never_enqueued 'case (k2)'
+
+printf '== case (k3): the remote is derived from the branch upstream, not hardcoded ==\n'
+work=$(make_fixture case_k3 narrow-upstream)
+assert_no_mirror_ref 'case (k3)' "$work" upstream
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work" --base upstream/main
+assert_verdict 'case (k3)' PASS 0
+assert_says 'case (k3) push-assert PASS against the configured upstream' '^push-assert: PASS$'
+
+printf '== case (k4): ls-remote failure is an infra/auth FAIL, not "never pushed" ==\n'
+work=$(make_fixture case_k4 unreachable)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (k4)' FAIL 1
+assert_says 'case (k4) push-assert FAIL names the ls-remote failure' '^push-assert: FAIL \(ls-remote failed: infra/auth\)$'
+assert_says 'case (k4) attributes it to infra/auth' 'INFRA/AUTH condition, NOT evidence that the branch is unpushed'
+assert_says 'case (k4) points at the separate git credential path' 'gh auth setup-git'
+assert_lacks 'case (k4) does NOT claim the branch was never pushed' 'has never been pushed'
+assert_never_enqueued 'case (k4)'
+
+printf '== case (k5): an unresolvable --base FAILs closed, never NOTHING-TO-REVIEW ==\n'
+work=$(make_fixture case_k5 no-base)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (k5)' FAIL 1
+assert_says 'case (k5) census-check FAIL names the unresolvable base' "^census-check: FAIL \(base 'origin/main' unresolvable\)$"
+assert_says 'case (k5) push-assert still PASS' '^push-assert: PASS$'
+assert_says 'case (k5) says it is not NOTHING-TO-REVIEW' "explicitly NOT a NOTHING-TO-REVIEW"
+assert_lacks 'case (k5) is not NOTHING-TO-REVIEW' '^RESULT: NOTHING-TO-REVIEW$'
+assert_never_enqueued 'case (k5)'
 
 printf '== case (f): genuine review with matching sha + healthy accounting ==\n'
 work=$(make_fixture case_f pushed)

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# Regression check for issue #2964: scripts/flow/roborev-review.sh must FAIL
+# CLOSED on every recorded vacuous-review trigger, and must never let one be
+# reported as "roborev clean".
+#
+# The wrapper's verdict gates a merge (flow-implement's review-first pass and
+# flow-closer's confirmation pass before arming `gh pr merge --auto`), so a
+# weakened assert in it means the pipeline merges unreviewed code with no red
+# anywhere. This check pins all seven triggers so a regression FAILs the fast
+# `--lite` loop instead of costing a review round.
+#
+# HERMETIC BY CONSTRUCTION: no network, no real roborev, no dataset corpus, no
+# cargo. A STUB `roborev` placed FIRST on PATH replays the recorded real outputs
+# (enqueue lines, verdict text, `show --json` token payloads) against throwaway
+# `git init` fixtures that carry their own local bare "origin" so the push assert
+# can be exercised in both directions. Everything lives under one temp dir removed
+# on EXIT. No wall-clock threshold assert anywhere in the correctness path (#2642).
+#
+# Run standalone:   bash scripts/tests/test_roborev_review_guard.sh
+# Or via the gate:  scripts/agent-gate.sh --lite   (roborev-lints component)
+#                   scripts/agent-gate.sh          (roborev-lints + tooling-tests)
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+WRAPPER="$SCRIPT_DIR/../flow/roborev-review.sh"
+BLOCK_HEADER="==== ROBOREV REVIEW SUMMARY ===="
+
+if [ ! -f "$WRAPPER" ]; then
+  printf 'FAIL - wrapper not found at %s\n' "$WRAPPER"
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/roborev-guard-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+# ---------------------------------------------------------------------------
+# The stub reviewer: first on PATH, driven entirely by STUB_* env vars, replaying
+# the recorded shapes of the real binary's output.
+#   STUB_ANNOUNCE_SHA  sha to announce; empty => emit NO enqueue announcement
+#   STUB_JOB           job id in the announcement / show payload
+#   STUB_VERDICT       verdict text written to the transcript
+#   STUB_TOKENS        "<input> <cached> <output>", or NONE for no token data
+#   STUB_REVIEW_RC     exit code of `roborev review`
+#   STUB_INVOKED       file the stub appends its argv to (empty file => never run)
+# ---------------------------------------------------------------------------
+stubbin="$tmp/bin"
+mkdir -p "$stubbin"
+cat >"$stubbin/roborev" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+  review)
+    printf 'review %s\n' "$*" >>"$STUB_INVOKED"
+    if [ -n "${STUB_ANNOUNCE_SHA:-}" ]; then
+      printf 'Enqueued job %s for %s\n' "${STUB_JOB:-4600}" "$STUB_ANNOUNCE_SHA"
+    fi
+    printf '%s\n' "${STUB_VERDICT:-No issues found}"
+    exit "${STUB_REVIEW_RC:-0}"
+    ;;
+  show)
+    [ "${STUB_TOKENS:-NONE}" != "NONE" ] || { printf 'null\n'; exit 0; }
+    # shellcheck disable=SC2086 # deliberate word-split of the "in cached out" triple
+    set -- ${STUB_TOKENS}
+    printf '{"id":%s,"status":"done","usage":{"input_tokens":%s,"cached_input_tokens":%s,"output_tokens":%s}}\n' \
+      "${STUB_JOB:-4600}" "$1" "$2" "$3"
+    exit 0
+    ;;
+  list) printf 'null\n'; exit 0 ;;
+  *) printf 'stub: unsupported roborev subcommand: %s\n' "$cmd" >&2; exit 64 ;;
+esac
+STUB
+chmod +x "$stubbin/roborev"
+
+# ---------------------------------------------------------------------------
+# Fixture: a work repo with a local bare origin. `git push` updates the
+# remote-tracking ref, which is exactly what the wrapper's push assert reads.
+# ---------------------------------------------------------------------------
+git_q() { git -C "$1" -c user.email=t@example.invalid -c user.name=Tester -c commit.gpgsign=false "${@:2}"; }
+
+make_fixture() { # make_fixture <name> <mode: pushed|unpushed|empty|docs-only> -> prints work dir
+  # NOTE: separate statements on purpose — `local` is a builtin, so ALL of its
+  # arguments are expanded before any assignment takes effect; `local a=$1 b=$a`
+  # would read an unset `a` and abort under `set -u`.
+  local name mode root work
+  name="$1"
+  mode="$2"
+  root="$tmp/$name"
+  work="$root/work"
+  mkdir -p "$root"
+  git init -q --bare "$root/origin.git"
+  git init -q -b main "$work"
+  printf 'base\n' >"$work/README.md"
+  printf 'fn main() {}\n' >"$work/main.rs"
+  git_q "$work" add README.md main.rs
+  git_q "$work" commit -q -m base
+  git_q "$work" remote add origin "$root/origin.git"
+  git_q "$work" push -q origin main
+
+  case "$mode" in
+    empty)
+      git_q "$work" checkout -q -b feature main
+      git_q "$work" push -q origin feature
+      ;;
+    docs-only)
+      git_q "$work" checkout -q -b feature main
+      printf 'doc line\ndoc line 2\n' >>"$work/README.md"
+      printf '# spec\n' >"$work/NOTES.md"
+      git_q "$work" add README.md NOTES.md
+      git_q "$work" commit -q -m 'docs only'
+      git_q "$work" push -q origin feature
+      ;;
+    *)
+      git_q "$work" checkout -q -b feature main
+      printf 'fn helper() {}\n' >>"$work/main.rs"
+      git_q "$work" add main.rs
+      git_q "$work" commit -q -m 'code change'
+      if [ "$mode" = pushed ]; then
+        git_q "$work" push -q origin feature
+      fi
+      ;;
+  esac
+  printf '%s' "$work"
+}
+
+CASE_N=0
+OUT=""
+RC=0
+INVOKED=""
+
+run_wrapper() { # run_wrapper <work-dir> [extra wrapper args...]
+  local work="$1"; shift
+  # Fail loudly on a broken fixture rather than letting the wrapper fall back to
+  # $PWD (which would silently run every assert against the REAL repo).
+  if [ -z "$work" ] || [ ! -d "$work/.git" ]; then
+    bad "fixture setup failed: '$work' is not a git work tree"
+    OUT="$tmp/empty-out.txt"; : >"$OUT"; INVOKED="$tmp/empty-invoked.txt"; : >"$INVOKED"; RC=99
+    return 0
+  fi
+  CASE_N=$((CASE_N + 1))
+  OUT="$tmp/out-$CASE_N.txt"
+  INVOKED="$tmp/invoked-$CASE_N.txt"
+  : >"$INVOKED"
+  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" \
+    bash "$WRAPPER" --repo "$work" --agent codex --model gpt-5.6-sol \
+    --log "$tmp/transcript-$CASE_N.txt" "$@" >"$OUT" 2>&1
+  RC=$?
+}
+
+assert_verdict() { # assert_verdict <label> <expected RESULT> <expected rc>
+  local label="$1" want="$2" want_rc="$3" got
+  got=$(grep -E '^RESULT: ' "$OUT" | tail -1 || printf '<none>')
+  if [ "$got" = "RESULT: $want" ] && [ "$RC" -eq "$want_rc" ]; then
+    ok "$label: $got (exit $RC)"
+  else
+    bad "$label: expected 'RESULT: $want' + exit $want_rc, got '$got' + exit $RC"
+    printf -- '------- captured -------\n'; cat "$OUT"; printf -- '------------------------\n'
+  fi
+}
+
+assert_says() { # assert_says <label> <extended-regex>
+  if grep -qE "$2" "$OUT"; then
+    ok "$1"
+  else
+    bad "$1: pattern '$2' not found in output"
+    printf -- '------- captured -------\n'; cat "$OUT"; printf -- '------------------------\n'
+  fi
+}
+
+assert_lacks() { # assert_lacks <label> <extended-regex>
+  if grep -qE "$2" "$OUT"; then
+    bad "$1: output unexpectedly matched '$2'"
+  else
+    ok "$1"
+  fi
+}
+
+assert_one_block() { # assert_one_block <label>
+  local n
+  n=$(grep -cF "$BLOCK_HEADER" "$OUT" || true)
+  if [ "$n" -eq 1 ]; then ok "$1: exactly one summary block"; else bad "$1: $n summary blocks (want 1)"; fi
+}
+
+assert_never_enqueued() { # assert_never_enqueued <label>
+  if [ -s "$INVOKED" ]; then
+    bad "$1: a review WAS enqueued (stub invoked: $(cat "$INVOKED"))"
+  else
+    ok "$1: no review was enqueued"
+  fi
+}
+
+export STUB_JOB=4656
+export STUB_VERDICT='No issues found'
+export STUB_TOKENS='505625 387328 6332'
+export STUB_REVIEW_RC=0
+export STUB_ANNOUNCE_SHA=''
+
+printf '== case (a): enqueued sha == base ref ==\n'
+work=$(make_fixture case_a pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+run_wrapper "$work"
+assert_verdict 'case (a)' FAIL 1
+assert_says 'case (a) names the base ref' "EQUALS the base ref 'origin/main'"
+assert_says 'case (a) sha-assert FAIL' '^sha-assert: FAIL'
+assert_one_block 'case (a)'
+
+printf '== case (b): enqueued sha is neither endpoint ==\n'
+work=$(make_fixture case_b pushed)
+STUB_ANNOUNCE_SHA='0000000000000000000000000000000000000abc'
+run_wrapper "$work"
+assert_verdict 'case (b)' FAIL 1
+assert_says 'case (b) names neither-endpoint' 'matches NEITHER endpoint'
+assert_says 'case (b) prints announced beside expected head' "announced reviewed-sha '0000000000000000000000000000000000000abc'"
+
+printf '== case (c): vacuous verdict vs non-empty census ==\n'
+work=$(make_fixture case_c pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
+run_wrapper "$work"
+assert_verdict 'case (c)' FAIL 1
+assert_says 'case (c) tier1 FAIL' '^vacuity-tier1: FAIL'
+assert_says 'case (c) names the contradiction' 'NO CODE CHANGES to review, but the locally computed census is NON-EMPTY'
+assert_says 'case (c) prints the census' '^census: [0-9]+ files, \+[0-9]+/-[0-9]+$'
+assert_says 'case (c) sha-assert still PASS' '^sha-assert: PASS$'
+
+printf '== case (c2): a code-free (docs-only) census is attributed to the code-free condition ==\n'
+work=$(make_fixture case_c2 docs-only)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
+run_wrapper "$work"
+assert_verdict 'case (c2)' FAIL 1
+assert_says 'case (c2) names the code-free condition' 'CODE-FREE-DIFF condition'
+assert_says 'case (c2) points at primary-source verification' 'primary-source verification recorded in the PR'
+
+printf '== case (d): vacuous token signature vs non-empty census ==\n'
+work=$(make_fixture case_d pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='No issues found'
+STUB_TOKENS='18700 0 53'
+run_wrapper "$work"
+assert_verdict 'case (d)' FAIL 1
+assert_says 'case (d) tier2 FAIL' '^vacuity-tier2: FAIL'
+assert_says 'case (d) tier1 unaffected' '^vacuity-tier1: PASS$'
+assert_says 'case (d) prints observed input vs named constant' 'observed input=18700 < ROBOREV_VACUITY_MIN_INPUT_TOKENS=50000'
+assert_says 'case (d) prints observed cached vs the zero clause' 'observed cached=0 == 0'
+assert_says 'case (d) prints observed output vs named constant' 'observed output=53 < ROBOREV_VACUITY_MIN_OUTPUT_TOKENS=200'
+assert_says 'case (d) tokens line carries the triple' '^tokens: input=18700 cached=0 output=53$'
+
+printf '== case (e): unpushed branch ==\n'
+work=$(make_fixture case_e unpushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKENS='505625 387328 6332'
+run_wrapper "$work"
+assert_verdict 'case (e)' FAIL 1
+assert_says 'case (e) push-assert FAIL' '^push-assert: FAIL'
+assert_says 'case (e) names the missing remote branch' "remote branch 'origin/feature' does not exist"
+assert_never_enqueued 'case (e)'
+
+printf '== case (e2): remote behind HEAD names the unpushed commits ==\n'
+work=$(make_fixture case_e2 pushed)
+printf 'fn later() {}\n' >>"$work/main.rs"
+git_q "$work" add main.rs
+git_q "$work" commit -q -m 'unpushed follow-up'
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (e2)' FAIL 1
+assert_says 'case (e2) lists the unpushed commit' 'unpushed follow-up'
+assert_never_enqueued 'case (e2)'
+
+printf '== case (f): genuine review with matching sha + healthy accounting ==\n'
+work=$(make_fixture case_f pushed)
+head_sha=$(git -C "$work" rev-parse HEAD)
+STUB_ANNOUNCE_SHA="$head_sha"
+STUB_VERDICT='No issues found'
+STUB_TOKENS='505625 387328 6332'
+run_wrapper "$work"
+assert_verdict 'case (f)' PASS 0
+for line in 'push-assert: PASS' 'census-check: PASS' 'sha-assert: PASS' 'vacuity-tier1: PASS' 'vacuity-tier2: PASS'; do
+  assert_says "case (f) $line" "^$line\$"
+done
+assert_says 'case (f) reviewed-sha printed' "^reviewed-sha: $head_sha\$"
+assert_says 'case (f) job printed' '^job: 4656$'
+assert_says 'case (f) log path named' '^log: .+transcript-'
+assert_one_block 'case (f)'
+# The sanctioned invocation form: explicit HEAD sha, explicit ABSOLUTE --repo,
+# --wait, both --agent and --model — and never --branch, never two positionals.
+if grep -qF -- "review $head_sha --repo $work --agent codex --model gpt-5.6-sol --wait" "$INVOKED"; then
+  ok 'case (f): invoked by explicit sha + explicit absolute --repo + --wait'
+else
+  bad "case (f): unexpected invocation form: $(cat "$INVOKED")"
+fi
+if grep -qF -- '--branch' "$INVOKED"; then
+  bad 'case (f): the non-sanctioned --branch form was used'
+else
+  ok 'case (f): no --branch in the invocation'
+fi
+
+printf '== case (g): genuinely empty census ==\n'
+work=$(make_fixture case_g empty)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (g)' NOTHING-TO-REVIEW 3
+assert_says 'case (g) census is zero files' '^census: 0 files, \+0/-0$'
+assert_says 'case (g) says it is not a pass' 'NOT a pass'
+assert_lacks 'case (g) is not a PASS' '^RESULT: PASS$'
+assert_never_enqueued 'case (g)'
+
+printf '== case (h): missing / unparseable enqueue announcement ==\n'
+work=$(make_fixture case_h pushed)
+STUB_ANNOUNCE_SHA=''
+STUB_VERDICT='Review complete. (no enqueue line printed)'
+run_wrapper "$work"
+assert_verdict 'case (h)' FAIL 1
+assert_says 'case (h) sha-assert FAIL (unverifiable)' '^sha-assert: FAIL \(no parseable enqueue announcement\)$'
+assert_says 'case (h) reviewed-sha unknown' '^reviewed-sha: -$'
+
+printf '== case (i): unavailable token accounting degrades visibly, tier 1 still governs ==\n'
+work=$(make_fixture case_i pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
+STUB_TOKENS='NONE'
+run_wrapper "$work"
+assert_verdict 'case (i)' FAIL 1
+assert_says 'case (i) tokens UNAVAILABLE' '^tokens: UNAVAILABLE$'
+assert_says 'case (i) tier2 UNAVAILABLE' '^vacuity-tier2: UNAVAILABLE$'
+assert_says 'case (i) degraded-signal notice, not a skip' 'DEGRADED-SIGNAL notice, never a silent skip'
+assert_says 'case (i) tier1 still FAILs' '^vacuity-tier1: FAIL'
+assert_lacks 'case (i) UNAVAILABLE never upgrades to PASS' '^RESULT: PASS$'
+
+printf '== case (i2): unavailable accounting alone does not fail an otherwise clean review ==\n'
+work=$(make_fixture case_i2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='No issues found'
+STUB_TOKENS='NONE'
+run_wrapper "$work"
+assert_verdict 'case (i2)' PASS 0
+assert_says 'case (i2) tier2 UNAVAILABLE' '^vacuity-tier2: UNAVAILABLE$'
+
+printf '== usage errors: --agent and --model are BOTH required ==\n'
+work=$(make_fixture case_usage pushed)
+for pair in "--agent codex" "--model gpt-5.6-sol"; do
+  CASE_N=$((CASE_N + 1))
+  OUT="$tmp/out-$CASE_N.txt"
+  INVOKED="$tmp/invoked-$CASE_N.txt"
+  : >"$INVOKED"
+  # shellcheck disable=SC2086 # deliberate split of the single-option pair
+  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --repo "$work" $pair >"$OUT" 2>&1
+  RC=$?
+  if [ "$RC" -eq 2 ]; then
+    ok "usage: '$pair' alone exits 2"
+  else
+    bad "usage: '$pair' alone exited $RC (want 2)"
+  fi
+  missing=--model; case "$pair" in "--model"*) missing=--agent ;; esac
+  assert_says "usage: '$pair' names the missing option $missing" "missing required option $missing"
+  assert_never_enqueued "usage: '$pair'"
+done
+
+printf '== the summary header is distinct from every agent-gate header ==\n'
+work=$(make_fixture case_hdr pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='No issues found'
+STUB_TOKENS='505625 387328 6332'
+run_wrapper "$work"
+assert_says 'header: roborev block present' '^==== ROBOREV REVIEW SUMMARY ====$'
+assert_lacks 'header: no AGENT-GATE SUMMARY header' '==== AGENT-GATE SUMMARY ===='
+assert_lacks 'header: no AGENT-GATE LITE SUMMARY header' '==== AGENT-GATE LITE SUMMARY ===='
+assert_lacks 'header: no AGENT-GATE DELTA SUMMARY header' '==== AGENT-GATE DELTA SUMMARY ===='
+
+printf '== hermeticity: the wrapper never reaches a real roborev ==\n'
+if grep -qE '^\s*roborev (review|show|list)' "$WRAPPER"; then
+  ok 'wrapper invokes roborev only through PATH resolution (stubbable)'
+else
+  bad 'wrapper does not invoke `roborev` by bare name — the stub cannot intercept it'
+fi
+
+# The tally line deliberately does NOT start with `RESULT:` — that token belongs to
+# the agent gate's summary contract and to the wrapper's own block, and a bare
+# `RESULT:` here could be mistaken for either by a grep-based reader.
+printf '\n==== ROBOREV REVIEW GUARD TEST TALLY ====\n'
+printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  printf 'GUARD-TEST RESULT: FAIL\n'
+  exit 1
+fi
+printf 'GUARD-TEST RESULT: PASS\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -1365,6 +1365,20 @@ assert_says 'case (x7) sha-assert refuses to certify' '^sha-assert: FAIL \(job r
 fi  # HAVE_PYTHON3
 
 if [ "$HAVE_PYTHON3" -eq 1 ]; then
+printf '== case (x9): a Summary word inside a finding body does not truncate the count ==\n'
+reset_stub
+# Observed on the live probe: the findings count read 3 where the review had 4, because
+# a finding's own prose contained "summary:" and closed the block early. The terminator
+# must be a LINE-INITIAL Summary label.
+work=$(make_fixture case_x9 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_VERDICT_FIELD=F
+STUB_REVIEW_RC=1
+STUB_VERDICT=$'## Review Findings\n\n- **Severity**: Medium\n- **Problem**: the code prints a summary: line that is not a heading\n\n- **Severity**: Low\n- **Problem**: second finding\n\n## Summary\n\nTwo findings.'
+run_wrapper "$work"
+STUB_REVIEW_RC=0
+assert_says 'case (x9) both findings are counted' '^findings: PRESENT \(2\)$'
+
 printf '== case (x8): show --json returns the REVIEW row; list --json must be used ==\n'
 reset_stub
 # MEASURED on the live probe: `roborev show <job> --json` returns the REVIEW row —

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -373,6 +373,21 @@ assert_lacks 'header: no AGENT-GATE SUMMARY header' '==== AGENT-GATE SUMMARY ===
 assert_lacks 'header: no AGENT-GATE LITE SUMMARY header' '==== AGENT-GATE LITE SUMMARY ===='
 assert_lacks 'header: no AGENT-GATE DELTA SUMMARY header' '==== AGENT-GATE DELTA SUMMARY ===='
 
+printf '== --help documents the exit codes and the live worktree probe ==\n'
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+INVOKED="$tmp/invoked-$CASE_N.txt"
+: >"$INVOKED"
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --help >"$OUT" 2>&1
+RC=$?
+if [ "$RC" -eq 0 ]; then ok '--help exits 0'; else bad "--help exited $RC (want 0)"; fi
+assert_says '--help states the exit-code contract' '0=PASS, 1=FAIL, 3=NOTHING-TO-REVIEW'
+assert_says '--help marks bare --branch non-sanctioned' 'Non-sanctioned forms'
+assert_says '--help carries the live worktree probe' 'LIVE WORKTREE PROBE'
+assert_says '--help states the probe expectation' 'reviewed-sha == head-sha'
+assert_says '--help requires both agent and model' 'Both are required'
+assert_never_enqueued '--help'
+
 printf '== hermeticity: the wrapper never reaches a real roborev ==\n'
 if grep -qE '^\s*roborev (review|show|list)' "$WRAPPER"; then
   ok 'wrapper invokes roborev only through PATH resolution (stubbable)'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -342,6 +342,46 @@ run_wrapper "$work"
 assert_verdict 'case (i2)' PASS 0
 assert_says 'case (i2) tier2 UNAVAILABLE' '^vacuity-tier2: UNAVAILABLE$'
 
+printf '== case (j): a non-zero roborev exit FAILs under its own greppable key ==\n'
+work=$(make_fixture case_j pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='No issues found'
+STUB_TOKENS='505625 387328 6332'
+STUB_REVIEW_RC=1
+run_wrapper "$work"
+STUB_REVIEW_RC=0
+assert_verdict 'case (j)' FAIL 1
+assert_says 'case (j) roborev-exit FAIL names the observed code' '^roborev-exit: FAIL \(exit 1\)$'
+# Every OTHER per-check key passes here — that is the point of the key: without it a
+# reader retaining only the block would see all-PASS beside RESULT: FAIL and be
+# unable to attribute the failure.
+for line in 'push-assert: PASS' 'census-check: PASS' 'sha-assert: PASS' 'vacuity-tier1: PASS' 'vacuity-tier2: PASS'; do
+  assert_says "case (j) $line" "^$line\$"
+done
+assert_says 'case (j) names the reviewer exit in prose too' "'roborev review' exited 1"
+assert_lacks 'case (j) is not a PASS' '^RESULT: PASS$'
+
+printf '== case (j2): a zero roborev exit records roborev-exit: PASS ==\n'
+work=$(make_fixture case_j2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (j2)' PASS 0
+assert_says 'case (j2) roborev-exit PASS' '^roborev-exit: PASS$'
+# Key ORDER is part of the contract: roborev-exit sits between vacuity-tier2 and log.
+if [ "$(grep -nE '^(vacuity-tier2|roborev-exit|log):' "$OUT" | cut -d: -f2 | paste -sd,)" = "vacuity-tier2,roborev-exit,log" ]; then
+  ok 'case (j2): roborev-exit is positioned between vacuity-tier2 and log'
+else
+  bad "case (j2): unexpected key order: $(grep -nE '^(vacuity-tier2|roborev-exit|log):' "$OUT" | cut -d: -f2 | paste -sd,)"
+fi
+
+printf '== case (j3): a pre-invocation failure leaves roborev-exit: SKIP ==\n'
+work=$(make_fixture case_j3 unpushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (j3)' FAIL 1
+assert_says 'case (j3) roborev-exit SKIP (the process never ran)' '^roborev-exit: SKIP$'
+assert_never_enqueued 'case (j3)'
+
 printf '== usage errors: --agent and --model are BOTH required ==\n'
 work=$(make_fixture case_usage pushed)
 for pair in "--agent codex" "--model gpt-5.6-sol"; do

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -30,6 +30,12 @@ if [ ! -f "$WRAPPER" ]; then
   exit 1
 fi
 
+# Shorten the wrapper's job-record poll bound: a TIMING knob only — fewer polls can
+# only make the record MORE likely to be reported DEGRADED (the fail-closed
+# direction), so it cannot weaken anything this suite asserts.
+export ROBOREV_JOB_RECORD_POLL_ATTEMPTS=2
+export ROBOREV_JOB_RECORD_POLL_INTERVAL_SECS=1
+
 PASS=0
 FAIL=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
@@ -54,6 +60,10 @@ trap 'rm -rf "$tmp"' EXIT
 #   STUB_MODEL           job model field
 #   STUB_REQUESTED_MODEL job requested_model field
 #   STUB_PROMPT          prompt text (plain, no quotes/backslashes)
+#   STUB_VERDICT_FIELD   the job record's structured `verdict` letter (P/F), '' to omit
+#   STUB_RECORD_BLANK_FOR the first N record reads return an empty record, so the
+#                        wrapper's bounded poll for the ASYNCHRONOUSLY written record
+#                        can be exercised (counter kept in $STUB_INVOKED.reads)
 #   STUB_HAS_TOKEN_DATA  emit a has_token_data field with this value (true/false)
 #   STUB_SHOW_JSON       `none` => `show --json` returns null, forcing the
 #                        `list --json` fallback path
@@ -77,6 +87,9 @@ emit_job_object() {
   fi
   local git_ref="${STUB_GIT_REF:-${STUB_ANNOUNCE_SHA:-}}"
   if [ "${STUB_GIT_REF:-}" = none ]; then git_ref=""; fi
+  if [ -n "${STUB_VERDICT_FIELD:-}" ]; then
+    extra="$extra,\"verdict\":\"${STUB_VERDICT_FIELD}\""
+  fi
   printf '{"id":%s,"git_ref":"%s","status":"%s","model":"%s","requested_model":"%s","prompt":"%s"%s}' \
     "${STUB_JOB:-4600}" \
     "$git_ref" \
@@ -85,6 +98,17 @@ emit_job_object() {
     "${STUB_REQUESTED_MODEL:-gpt-5.6-sol}" \
     "${STUB_PROMPT:-}" \
     "$usage$extra"
+}
+
+# record_read_blank: true while the first STUB_RECORD_BLANK_FOR record reads should
+# come back empty, replaying the real daemon's asynchronous record write.
+record_read_blank() {
+  local want="${STUB_RECORD_BLANK_FOR:-0}" seen=0 counter="$STUB_INVOKED.reads"
+  [ "$want" -gt 0 ] || return 1
+  [ ! -f "$counter" ] || seen=$(cat "$counter")
+  seen=$((seen + 1))
+  printf '%s' "$seen" >"$counter"
+  [ "$seen" -le "$want" ]
 }
 
 case "$cmd" in
@@ -100,11 +124,13 @@ case "$cmd" in
     case " $* " in
       *" --prompt "*) printf '%s\n' "${STUB_PROMPT:-}"; exit 0 ;;
     esac
+    record_read_blank && { printf 'null\n'; exit 0; }
     [ "${STUB_SHOW_JSON:-object}" != none ] || { printf 'null\n'; exit 0; }
     emit_job_object; printf '\n'
     exit 0
     ;;
   list)
+    record_read_blank && { printf 'null\n'; exit 0; }
     printf '['; emit_job_object; printf ']\n'
     exit 0
     ;;
@@ -134,6 +160,7 @@ git_q() { git -C "$1" -c user.email=t@example.invalid -c user.name=Tester -c com
 #   empty           wide refspec, feature == main, pushed
 #   docs-only       wide refspec, markdown-only change, pushed (code-free census)
 #   mixed           one markdown + one .rs file (NOT code-free)
+#   two-code-commits  two commits, each touching a DIFFERENT .rs file
 #   workflow-yaml   only .github/workflows/ci.yml (a .yml extension is CODE, so this
 #                   must NOT be classified code-free)
 #   narrow          NARROW refspec (+refs/heads/main:refs/remotes/origin/main) —
@@ -187,6 +214,16 @@ make_fixture() { # make_fixture <name> <mode> -> prints work dir
       printf '# spec\n' >"$work/NOTES.md"
       git_q "$work" add README.md NOTES.md
       git_q "$work" commit -q -m 'docs only'
+      ;;
+    two-code-commits)
+      # Two commits touching DIFFERENT code files: a single-commit review would cover
+      # only the second, which is the partial-review vacuity class.
+      printf 'fn alpha() {}\n' >"$work/alpha.rs"
+      git_q "$work" add alpha.rs
+      git_q "$work" commit -q -m 'first code commit'
+      printf 'fn beta() {}\n' >"$work/beta.rs"
+      git_q "$work" add beta.rs
+      git_q "$work" commit -q -m 'second code commit'
       ;;
     mixed)
       printf 'doc line\n' >>"$work/README.md"
@@ -258,6 +295,9 @@ assert_no_mirror_ref() { # assert_no_mirror_ref <label> <work> <remote>
   fi
 }
 
+# range_ref <work>: the git_ref shape a RANGE review records, "<base40>..<head40>".
+range_ref() { printf '%s..%s' "$(git -C "$1" rev-parse "${2:-origin/main}")" "$(git -C "$1" rev-parse HEAD)"; }
+
 CASE_N=0
 OUT=""
 RC=0
@@ -276,6 +316,10 @@ run_wrapper() { # run_wrapper <work-dir> [extra wrapper args...]
   OUT="$tmp/out-$CASE_N.txt"
   INVOKED="$tmp/invoked-$CASE_N.txt"
   : >"$INVOKED"
+  # The sanctioned invocation reviews the RANGE <base>..HEAD, so the job record's
+  # git_ref is "<base40>..<head40>". Default the stub to the correct range unless the
+  # case pinned git_ref itself (or asked for it to be absent with `none`).
+  if [ -z "${STUB_GIT_REF:-}" ]; then STUB_GIT_REF=$(range_ref "$work"); fi
   STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" \
     bash "$WRAPPER" --repo "$work" --agent codex --model gpt-5.6-sol \
     --log "$tmp/transcript-$CASE_N.txt" "$@" >"$OUT" 2>&1
@@ -349,6 +393,8 @@ export STUB_MODEL=gpt-5.6-sol
 export STUB_REQUESTED_MODEL=gpt-5.6-sol
 export STUB_SHOW_JSON=object
 export STUB_HAS_TOKEN_DATA=''
+export STUB_VERDICT_FIELD=''
+export STUB_RECORD_BLANK_FOR=0
 export STUB_REVIEW_RC=0
 export STUB_ANNOUNCE_SHA=''
 
@@ -365,12 +411,15 @@ reset_stub() {
   STUB_REQUESTED_MODEL=gpt-5.6-sol
   STUB_SHOW_JSON=object
   STUB_HAS_TOKEN_DATA=''
+  STUB_VERDICT_FIELD=''
+  STUB_RECORD_BLANK_FOR=0
 }
 
 printf '== case (a): enqueued sha == base ref ==\n'
 reset_stub
 work=$(make_fixture case_a pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_GIT_REF=$(git -C "$work" rev-parse origin/main)
 run_wrapper "$work"
 assert_verdict 'case (a)' FAIL 1
 assert_says 'case (a) names the base ref' "EQUALS the base ref 'origin/main'"
@@ -381,6 +430,7 @@ printf '== case (b): enqueued sha is neither endpoint ==\n'
 reset_stub
 work=$(make_fixture case_b pushed)
 STUB_ANNOUNCE_SHA='0000000000000000000000000000000000000abc'
+STUB_GIT_REF='0000000000000000000000000000000000000abc'
 run_wrapper "$work"
 assert_verdict 'case (b)' FAIL 1
 assert_says 'case (b) names neither-endpoint' 'matches NEITHER endpoint'
@@ -569,6 +619,7 @@ reset_stub
 work=$(make_fixture case_k3 narrow-upstream)
 assert_no_mirror_ref 'case (k3)' "$work" upstream
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_GIT_REF=$(range_ref "$work" upstream/main)
 run_wrapper "$work" --base upstream/main
 assert_verdict 'case (k3)' PASS 0
 assert_says 'case (k3) push-assert PASS against the configured upstream' '^push-assert: PASS$'
@@ -686,7 +737,7 @@ STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_PROMPT="$PROMPT_WITHOUT_PATHS"
 run_wrapper "$work"
 assert_verdict 'case (n)' FAIL 1
-assert_says 'case (n) prompt-content FAIL counts the absent paths' '^prompt-content: FAIL \(1/1 census paths absent from the prompt\)$'
+assert_says 'case (n) prompt-content FAIL counts the absent paths' '^prompt-content: FAIL \(1/1 code census paths absent from the prompt\)$'
 assert_says 'case (n) names the missing path' '^  main\.rs$'
 assert_says 'case (n) says the reviewer never received the diff' 'the reviewer never received this diff'
 assert_says 'case (n) every other check passed' '^vacuity-tier1: PASS$'
@@ -707,21 +758,23 @@ reset_stub
 work=$(make_fixture case_n3 mixed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 run_wrapper "$work"
-assert_says 'case (n3) prompt-content PASS names the counts' '^prompt-content: PASS \(2/2 census paths present\)$'
+assert_says 'case (n3) prompt-content counts only the CODE subset' '^prompt-content: PASS \(1/1 code census paths present\)$'
 
 printf '== case (o): the structured git_ref is the sha oracle, stdout is a cross-check ==\n'
 reset_stub
 # stdout announces the right sha while the job record says the base was reviewed:
 # the structured field must win, and the disagreement must be recorded.
 work=$(make_fixture case_o pushed)
-STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_GIT_REF=$(git -C "$work" rev-parse origin/main)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+# stdout announced the range BASE (normal for a range review, and it verifies nothing
+# about HEAD), while the record says the reviewed range STOPPED at the base. Only the
+# structured range can catch that the branch tip was never reviewed.
+STUB_GIT_REF="$(git -C "$work" rev-parse origin/main)..$(git -C "$work" rev-parse origin/main)"
 run_wrapper "$work"
 assert_verdict 'case (o)' FAIL 1
-assert_says 'case (o) sha-assert FAIL from the structured field' '^sha-assert: FAIL \(reviewed-sha does not match head-sha\)$'
-assert_says 'case (o) names the base-ref equality' "EQUALS the base ref 'origin/main'"
-assert_says 'case (o) records the stdout cross-check disagreement' 'sha-assert cross-check: stdout announced'
-assert_says 'case (o) reviewed-sha reports the structured value' "^reviewed-sha: $(git -C "$work" rev-parse origin/main)\$"
+assert_says 'case (o) sha-assert FAIL from the structured range' '^sha-assert: FAIL \(reviewed range does not match origin/main\.\.\.HEAD\)$'
+assert_says 'case (o) names the short-of-tip range head' 'the reviewed scope stops short of the branch tip'
+assert_says 'case (o) reviewed-sha reports the structured range' "^reviewed-sha: $(git -C "$work" rev-parse origin/main)\.\.$(git -C "$work" rev-parse origin/main)\$"
 
 printf '== case (p): a model substitution is surfaced loudly ==\n'
 reset_stub
@@ -756,21 +809,28 @@ assert_verdict 'case (f)' PASS 0
 for line in 'push-assert: PASS' 'census-check: PASS' 'sha-assert: PASS' 'vacuity-tier1: PASS' 'vacuity-tier2: PASS'; do
   assert_says "case (f) $line" "^$line\$"
 done
-assert_says 'case (f) reviewed-sha printed' "^reviewed-sha: $head_sha\$"
+assert_says 'case (f) reviewed-sha reports the RANGE' "^reviewed-sha: $(git -C "$work" rev-parse origin/main)\.\.$head_sha\$"
 assert_says 'case (f) job printed' '^job: 4656$'
 assert_says 'case (f) log path named' '^log: .+transcript-'
 assert_one_block 'case (f)'
 # The sanctioned invocation form: explicit HEAD sha, explicit ABSOLUTE --repo,
 # --wait, both --agent and --model — and never --branch, never two positionals.
-if grep -qF -- "review $head_sha --repo $work --agent codex --model gpt-5.6-sol --wait" "$INVOKED"; then
-  ok 'case (f): invoked by explicit sha + explicit absolute --repo + --wait'
+if grep -qF -- "review --branch --base origin/main --repo $work --agent codex --model gpt-5.6-sol --wait" "$INVOKED"; then
+  ok 'case (f): invoked over the census RANGE with an explicit absolute --repo + --wait'
 else
   bad "case (f): unexpected invocation form: $(cat "$INVOKED")"
 fi
-if grep -qF -- '--branch' "$INVOKED"; then
-  bad 'case (f): the non-sanctioned --branch form was used'
+# `--branch` is correct ONLY with an explicit --repo (without it, it resolves against
+# the ROOT checkout); the two-positional range form must never appear.
+if grep -qF -- '--branch' "$INVOKED" && grep -qF -- "--repo $work" "$INVOKED"; then
+  ok 'case (f): --branch is paired with an explicit absolute --repo'
 else
-  ok 'case (f): no --branch in the invocation'
+  bad "case (f): --branch/--repo pairing missing: $(cat "$INVOKED")"
+fi
+if grep -qE -- 'review [0-9a-f]{7,40} [0-9a-f]{7,40}' "$INVOKED"; then
+  bad 'case (f): the two-positional commit-range form was used'
+else
+  ok 'case (f): no two-positional commit-range form'
 fi
 
 printf '== case (g): genuinely empty census ==\n'
@@ -922,37 +982,35 @@ assert_verdict 'case (s3)' FAIL 1
 assert_says 'case (s3) review-completed FAILs on the job status' "^review-completed: FAIL \(job status 'failed' is not done\)\$"
 assert_says 'case (s3) says nothing was certified' 'nothing was certified'
 
-printf '== case (t1): a 9-char SHORT sha announcement (the real shape) still verifies ==\n'
+printf '== case (t1): the REAL announcement shape (abbreviated range base) parses ==\n'
 reset_stub
-# The recorded real announcement carries an ABBREVIATED sha, so the fallback compare
-# must be a prefix match; strict equality would reject every real announcement.
+# A range review announces "Enqueued job N for <abbreviated RANGE BASE>", so the
+# announcement carries the JOB ID and nothing verifiable about HEAD; the structured
+# range is what verifies the scope. The parse must still accept the short form.
 work=$(make_fixture case_t1 pushed)
-head_sha=$(git -C "$work" rev-parse HEAD)
-STUB_ANNOUNCE_SHA="${head_sha:0:9}"
-STUB_GIT_REF=none
+base_sha=$(git -C "$work" rev-parse origin/main)
+STUB_ANNOUNCE_SHA="${base_sha:0:9}"
 run_wrapper "$work"
 assert_verdict 'case (t1)' PASS 0
-assert_says 'case (t1) the abbreviated sha satisfied the assert' '^sha-assert: PASS$'
-assert_says 'case (t1) the weaker source is named' 'abbreviated-sha prefix parse'
+assert_says 'case (t1) the abbreviated announcement was parsed' '^job: 4656$'
+assert_says 'case (t1) the structured range verified the scope' '^sha-assert: PASS$'
 
 printf '== case (t2): an UPPERCASE announcement is normalised, not fed on as garbage ==\n'
 reset_stub
 work=$(make_fixture case_t2 pushed)
-head_sha=$(git -C "$work" rev-parse HEAD)
-STUB_ANNOUNCE_SHA=$(printf '%s' "${head_sha:0:9}" | tr 'a-f' 'A-F')
-STUB_GIT_REF=none
+base_sha=$(git -C "$work" rev-parse origin/main)
+STUB_ANNOUNCE_SHA=$(printf '%s' "${base_sha:0:9}" | tr 'a-f' 'A-F')
 run_wrapper "$work"
 assert_verdict 'case (t2)' PASS 0
-assert_says 'case (t2) reviewed-sha is lower-cased' "^reviewed-sha: ${head_sha:0:9}\$"
+assert_says 'case (t2) the upper-case announcement was parsed' '^job: 4656$'
+assert_says 'case (t2) sha-assert PASSes' '^sha-assert: PASS$'
 
 printf '== case (t3): a 4-hex-char announcement is too short to verify ==\n'
 reset_stub
 work=$(make_fixture case_t3 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD | cut -c1-4)
-# git_ref absent on purpose: the ANNOUNCEMENT must be the load-bearing signal here,
-# or the structured oracle rejects the short sha for an unrelated reason and the
-# regex floor goes untested.
-STUB_GIT_REF=none
+# The range git_ref is left VALID on purpose, so the ONLY thing that can fail this run
+# is the announcement's 7-hex-char floor.
 run_wrapper "$work"
 assert_verdict 'case (t3)' FAIL 1
 assert_says 'case (t3) the 7-char floor rejects it' '^sha-assert: FAIL \(no parseable enqueue announcement\)$'
@@ -964,12 +1022,13 @@ work=$(make_fixture case_t4 pushed)
 head_sha=$(git -C "$work" rev-parse HEAD)
 base_sha=$(git -C "$work" rev-parse origin/main)
 STUB_ANNOUNCE_SHA="$base_sha"
-STUB_GIT_REF=none
-STUB_VERDICT=$'superseded; retrying\nEnqueued job 4656 for '"$head_sha"$'\nNo issues found.\nSummary: reviewed the diff; no issues found.'
+STUB_JOB=4655
+STUB_VERDICT=$'superseded; retrying\nEnqueued job 4656 for '"$base_sha"$'\nNo issues found.\nSummary: reviewed the diff; no issues found.'
 run_wrapper "$work"
 assert_verdict 'case (t4)' PASS 0
 assert_says 'case (t4) the multiplicity is recorded' 'the transcript carries 2 enqueue announcements'
-assert_says 'case (t4) the LAST announcement was asserted' "^reviewed-sha: $head_sha\$"
+assert_says 'case (t4) the LAST announcement supplied the job id' '^job: 4656$'
+assert_lacks 'case (t4) the FIRST job id was not used' '^job: 4655$'
 
 printf '== case (t5): a detached HEAD FAILs before anything is enqueued ==\n'
 reset_stub
@@ -1119,6 +1178,123 @@ for bad_invocation in "--nonsense" "--repo:$tmp/definitely-not-a-directory" "--r
   assert_never_enqueued "usage: '$bad_invocation'"
 done
 
+printf '== case (x1): a PARTIAL review (only the last commit) FAILs ==\n'
+reset_stub
+# DEFECT 1, the case that fired on the real probe: `roborev review <sha>` reviews ONE
+# COMMIT, so on a multi-commit branch "roborev clean" meant "the last commit was
+# clean". The wrapper now reviews the census RANGE, and prompt-content is the assert
+# that the whole range actually reached the reviewer.
+work=$(make_fixture case_x1 two-code-commits)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_PROMPT='Review this diff: diff --git a/beta.rs b/beta.rs +fn beta() {}'
+run_wrapper "$work"
+assert_verdict 'case (x1)' FAIL 1
+assert_says 'case (x1) prompt-content names the uncovered code path' '^prompt-content: FAIL \(1/2 code census paths absent from the prompt\)$'
+assert_says 'case (x1) lists the missing file' '^  alpha\.rs$'
+assert_says 'case (x1) says the reviewer never received the diff' 'the reviewer never received this diff'
+assert_says 'case (x1) the range itself verified fine' '^sha-assert: PASS$'
+
+printf '== case (x3): a range anchored at the EMPTY TREE FAILs (two-positional form) ==\n'
+reset_stub
+# The measured signature of the two-positional commit-range form: it anchors the range
+# at git's empty tree, so the "diff" is the whole file set and only a fraction of the
+# real change reaches the reviewer. Asserting BOTH range endpoints catches it.
+work=$(make_fixture case_x3 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_GIT_REF="4b825dc642cb6eb9a060e54bf8d69288fbee4904..$(git -C "$work" rev-parse HEAD)"
+run_wrapper "$work"
+assert_verdict 'case (x3)' FAIL 1
+assert_says 'case (x3) the wrong range BASE is named' 'the range BASE is .4b825dc642cb6eb9a060e54bf8d69288fbee4904.'
+assert_says 'case (x3) the empty-tree signature is called out' 'empty-tree base \(4b825dc6\.\.\.\) is the signature of the non-sanctioned two-positional'
+
+printf '== case (x2): the full range in the prompt PASSes ==\n'
+reset_stub
+work=$(make_fixture case_x2 two-code-commits)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_PROMPT='Review this diff: diff --git a/alpha.rs b/alpha.rs diff --git a/beta.rs b/beta.rs diff --git a/main.rs b/main.rs'
+run_wrapper "$work"
+assert_verdict 'case (x2)' PASS 0
+assert_says 'case (x2) every code census path was covered' '^prompt-content: PASS \(2/2 code census paths present\)$'
+
+if [ "$HAVE_PYTHON3" -eq 1 ]; then
+printf '== case (y1): the ASYNCHRONOUSLY written job record is POLLED, not assumed ==\n'
+reset_stub
+# DEFECT 2: the instant `--wait` returned, the record had no git_ref/status/model/
+# token_usage; moments later it had all four. Unpolled, FOUR asserts silently
+# degraded at once on a normal run.
+work=$(make_fixture case_y1 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_RECORD_BLANK_FOR=2
+run_wrapper "$work"
+STUB_RECORD_BLANK_FOR=0
+assert_verdict 'case (y1)' PASS 0
+assert_says 'case (y1) the record is reported complete' '^job-record: PASS$'
+assert_says 'case (y1) the polling is disclosed' 'became complete only after [0-9]+ poll'
+assert_says 'case (y1) the STRONG sha oracle was used' '^sha-assert: PASS$'
+assert_says 'case (y1) tier 2 evaluated rather than degrading' '^vacuity-tier2: PASS$'
+assert_says 'case (y1) the model was confirmed from the record' '^model: gpt-5\.6-sol$'
+
+printf '== case (y2): a permanently absent record FAILs, it does not fall back ==\n'
+reset_stub
+work=$(make_fixture case_y2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_SHOW_JSON=none
+STUB_GIT_REF=none
+run_wrapper "$work"
+assert_verdict 'case (y2)' FAIL 1
+assert_says 'case (y2) the record is DEGRADED, explicitly' '^job-record: DEGRADED'
+assert_says 'case (y2) sha-assert refuses to guess' '^sha-assert: FAIL \(job record unavailable — reviewed range unverifiable\)$'
+assert_says 'case (y2) explains why prose cannot substitute' 'prose cannot establish that branch HEAD was reviewed'
+
+printf '== case (z1): exit 0 + a QUOTED severity marker cannot exempt tier 1 ==\n'
+reset_stub
+# DEFECT 3 (codex): findings used to come from a regex over the WHOLE transcript, so
+# incidental "[Low]" text set findings: PRESENT and exempted a vacuous verdict from
+# the authoritative tier-1 failure. The marker scan is now confined to the findings
+# BLOCK, and the structured verdict wins where it exists.
+work=$(make_fixture case_z1 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_VERDICT=$'No issues found.\nThe severity ladder here is [Critical] > [High] > [Medium] > [Low].\nSummary: the diff contains no code changes to review.'
+run_wrapper "$work"
+assert_verdict 'case (z1)' FAIL 1
+assert_says 'case (z1) the quoted markers did not become findings' '^findings: NONE$'
+assert_says 'case (z1) tier 1 still FAILs authoritatively' '^vacuity-tier1: FAIL \(vacuous verdict vs non-empty census\)$'
+
+printf '== case (z2): a structured verdict of F exempts the phrase (no false-FAIL) ==\n'
+reset_stub
+work=$(make_fixture case_z2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_VERDICT_FIELD=F
+STUB_REVIEW_RC=1
+STUB_VERDICT=$'## Findings\n[Medium] the guard matches no code changes too broadly\n## Summary: 1 finding; it says no code changes.'
+run_wrapper "$work"
+STUB_REVIEW_RC=0
+assert_says 'case (z2) findings come from the structured verdict' '^findings: PRESENT \(1\)$'
+assert_says 'case (z2) tier 1 is a NOTICE, not a FAIL' '^vacuity-tier1: NOTICE \(phrase present in a findings-bearing review\)$'
+assert_lacks 'case (z2) tier 1 does not FAIL' '^vacuity-tier1: FAIL'
+
+printf '== case (z3): verdict says clean while the findings block has markers = INCONSISTENT ==\n'
+reset_stub
+work=$(make_fixture case_z3 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_VERDICT_FIELD=P
+STUB_VERDICT=$'## Findings\n[High] a real finding\n## Summary: clean.'
+run_wrapper "$work"
+assert_verdict 'case (z3)' FAIL 1
+assert_says 'case (z3) the contradiction is named' '^findings: INCONSISTENT \(verdict clean, 1 findings marker\(s\)\)$'
+assert_says 'case (z3) it fails closed' 'One of the two is wrong'
+
+printf '== case (z4): exit 0 with markers INSIDE the findings block = INCONSISTENT ==\n'
+reset_stub
+work=$(make_fixture case_z4 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_VERDICT=$'## Findings\n[High] a real finding the exit code contradicts\n## Summary: 1 finding.'
+run_wrapper "$work"
+assert_verdict 'case (z4)' FAIL 1
+assert_says 'case (z4) the exit-code contradiction is named' '^findings: INCONSISTENT \(exit 0, 1 findings marker\(s\)\)$'
+assert_says 'case (z4) it cannot exempt tier 1' 'cannot exempt the tier-1 vacuity check'
+fi  # HAVE_PYTHON3
+
 printf '== case (w): a MISSING oracles file FAILs closed, never silently no-ops ==\n'
 reset_stub
 # roborev-review.sh sources scripts/flow/roborev-review-oracles.sh for the push assert
@@ -1205,7 +1381,8 @@ STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --help >"$OUT" 2>&
 RC=$?
 if [ "$RC" -eq 0 ]; then ok '--help exits 0'; else bad "--help exited $RC (want 0)"; fi
 assert_says '--help states the exit-code contract' '0=PASS, 1=FAIL, 3=NOTHING-TO-REVIEW'
-assert_says '--help marks bare --branch non-sanctioned' 'Non-sanctioned forms'
+assert_says '--help names the sanctioned range invocation' 'Sanctioned invocation'
+assert_says '--help marks --branch-without-repo non-sanctioned' "WITHOUT an explicit --repo"
 assert_says '--help carries the live worktree probe' 'LIVE WORKTREE PROBE'
 assert_says '--help states the probe expectation' 'reviewed-sha == head-sha'
 assert_says '--help requires both agent and model' 'Both are required'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -67,7 +67,9 @@ trap 'rm -rf "$tmp"' EXIT
 #                        wrapper's bounded poll for the ASYNCHRONOUSLY written record
 #                        can be exercised (counter kept in $STUB_INVOKED.reads)
 #   STUB_HAS_TOKEN_DATA  emit a has_token_data field with this value (true/false)
-#   STUB_SHOW_JSON       `none` => `show --json` returns null, forcing the
+#   STUB_SHOW_JSON       `none` => `show --json` returns null; `review-row` => it
+#                        returns the REAL review-row shape (id/prompt, no git_ref or
+#                        status), forcing the richer `list --json` source; otherwise the
 #                        `list --json` fallback path
 #   STUB_INVOKED         file the stub appends its argv to (empty => never run)
 # ---------------------------------------------------------------------------
@@ -128,6 +130,13 @@ case "$cmd" in
     esac
     record_read_blank && { printf 'null\n'; exit 0; }
     [ "${STUB_SHOW_JSON:-object}" != none ] || { printf 'null\n'; exit 0; }
+    if [ "${STUB_SHOW_JSON:-object}" = review-row ]; then
+      # The REAL `show --json` shape: the REVIEW row — id/agent/prompt, and no
+      # git_ref / status / verdict / token_usage.
+      printf '{"id":%s,"job_id":%s,"agent":"codex","prompt":"%s"}\n' \
+        "${STUB_JOB:-4600}" "${STUB_JOB:-4600}" "${STUB_PROMPT:-}"
+      exit 0
+    fi
     emit_job_object; printf '\n'
     exit 0
     ;;
@@ -1353,6 +1362,25 @@ run_wrapper "$work"
 assert_verdict 'case (x7)' FAIL 1
 assert_says 'case (x7) the mismatched record was refused' '^job-record: DEGRADED'
 assert_says 'case (x7) sha-assert refuses to certify' '^sha-assert: FAIL \(job record unavailable — reviewed range unverifiable\)$'
+fi  # HAVE_PYTHON3
+
+if [ "$HAVE_PYTHON3" -eq 1 ]; then
+printf '== case (x8): `show --json` returns the REVIEW row; `list --json` must be used ==\n'
+reset_stub
+# MEASURED on the live probe: `roborev show <job> --json` returns the REVIEW row —
+# parseable, with id/agent/prompt but NO git_ref, status, verdict or token_usage. The
+# wrapper used to accept the first payload that merely PARSED, so the richer `list
+# --json` source was never consulted and the record looked permanently incomplete,
+# silently downgrading sha-assert, tier 2 and model on every real run.
+work=$(make_fixture case_x8 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_SHOW_JSON=review-row
+run_wrapper "$work"
+assert_verdict 'case (x8)' PASS 0
+assert_says 'case (x8) the richer source was used' '^job-record: PASS$'
+assert_says 'case (x8) the range oracle worked' '^sha-assert: PASS$'
+assert_says 'case (x8) tokens came from the job row' '^vacuity-tier2: PASS$'
+assert_says 'case (x8) the model was confirmed' '^model: gpt-5\.6-sol$'
 fi  # HAVE_PYTHON3
 
 printf '== case (w): a MISSING oracles file FAILs closed, never silently no-ops ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -1365,7 +1365,7 @@ assert_says 'case (x7) sha-assert refuses to certify' '^sha-assert: FAIL \(job r
 fi  # HAVE_PYTHON3
 
 if [ "$HAVE_PYTHON3" -eq 1 ]; then
-printf '== case (x8): `show --json` returns the REVIEW row; `list --json` must be used ==\n'
+printf '== case (x8): show --json returns the REVIEW row; list --json must be used ==\n'
 reset_stub
 # MEASURED on the live probe: `roborev show <job> --json` returns the REVIEW row —
 # parseable, with id/agent/prompt but NO git_ref, status, verdict or token_usage. The

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -40,13 +40,23 @@ trap 'rm -rf "$tmp"' EXIT
 
 # ---------------------------------------------------------------------------
 # The stub reviewer: first on PATH, driven entirely by STUB_* env vars, replaying
-# the recorded shapes of the real binary's output.
-#   STUB_ANNOUNCE_SHA  sha to announce; empty => emit NO enqueue announcement
-#   STUB_JOB           job id in the announcement / show payload
-#   STUB_VERDICT       verdict text written to the transcript
-#   STUB_TOKENS        "<input> <cached> <output>", or NONE for no token data
-#   STUB_REVIEW_RC     exit code of `roborev review`
-#   STUB_INVOKED       file the stub appends its argv to (empty file => never run)
+# the RECORDED SHAPE of the real binary's payload — notably `token_usage`, which is
+# a JSON-ENCODED STRING (decoded twice) carrying `total_output_tokens`, not a nested
+# object with `output_tokens`. Getting that shape wrong is exactly how tier 2 was
+# permanently UNAVAILABLE, so the stub reproduces it verbatim.
+#   STUB_ANNOUNCE_SHA    sha to announce; empty => emit NO enqueue announcement
+#   STUB_JOB             job id in the announcement / json payloads
+#   STUB_VERDICT         verdict text written to the transcript
+#   STUB_TOKEN_USAGE     pre-escaped body of the token_usage JSON string, or NONE
+#   STUB_REVIEW_RC       exit code of `roborev review`
+#   STUB_STATUS          job status field (done / failed / ...)
+#   STUB_GIT_REF         job git_ref field (the structured reviewed sha)
+#   STUB_MODEL           job model field
+#   STUB_REQUESTED_MODEL job requested_model field
+#   STUB_PROMPT          prompt text (plain, no quotes/backslashes)
+#   STUB_SHOW_JSON       `none` => `show --json` returns null, forcing the
+#                        `list --json` fallback path
+#   STUB_INVOKED         file the stub appends its argv to (empty => never run)
 # ---------------------------------------------------------------------------
 stubbin="$tmp/bin"
 mkdir -p "$stubbin"
@@ -55,6 +65,22 @@ cat >"$stubbin/roborev" <<'STUB'
 set -uo pipefail
 cmd="${1:-}"
 shift || true
+
+emit_job_object() {
+  local usage=""
+  if [ "${STUB_TOKEN_USAGE:-NONE}" != "NONE" ]; then
+    usage=",\"token_usage\":\"${STUB_TOKEN_USAGE}\""
+  fi
+  printf '{"id":%s,"git_ref":"%s","status":"%s","model":"%s","requested_model":"%s","prompt":"%s"%s}' \
+    "${STUB_JOB:-4600}" \
+    "${STUB_GIT_REF:-${STUB_ANNOUNCE_SHA:-}}" \
+    "${STUB_STATUS:-done}" \
+    "${STUB_MODEL:-gpt-5.6-sol}" \
+    "${STUB_REQUESTED_MODEL:-gpt-5.6-sol}" \
+    "${STUB_PROMPT:-}" \
+    "$usage"
+}
+
 case "$cmd" in
   review)
     printf 'review %s\n' "$*" >>"$STUB_INVOKED"
@@ -65,18 +91,30 @@ case "$cmd" in
     exit "${STUB_REVIEW_RC:-0}"
     ;;
   show)
-    [ "${STUB_TOKENS:-NONE}" != "NONE" ] || { printf 'null\n'; exit 0; }
-    # shellcheck disable=SC2086 # deliberate word-split of the "in cached out" triple
-    set -- ${STUB_TOKENS}
-    printf '{"id":%s,"status":"done","usage":{"input_tokens":%s,"cached_input_tokens":%s,"output_tokens":%s}}\n' \
-      "${STUB_JOB:-4600}" "$1" "$2" "$3"
+    case " $* " in
+      *" --prompt "*) printf '%s\n' "${STUB_PROMPT:-}"; exit 0 ;;
+    esac
+    [ "${STUB_SHOW_JSON:-object}" != none ] || { printf 'null\n'; exit 0; }
+    emit_job_object; printf '\n'
     exit 0
     ;;
-  list) printf 'null\n'; exit 0 ;;
+  list)
+    printf '['; emit_job_object; printf ']\n'
+    exit 0
+    ;;
   *) printf 'stub: unsupported roborev subcommand: %s\n' "$cmd" >&2; exit 64 ;;
 esac
 STUB
 chmod +x "$stubbin/roborev"
+
+# The structured-payload cases need python3 (the wrapper decodes the doubly-encoded
+# token_usage with it). Loud SKIP, never a silent pass, matching the gate's other
+# SKIP-aware guards.
+HAVE_PYTHON3=1
+if ! command -v python3 >/dev/null 2>&1; then
+  HAVE_PYTHON3=0
+  printf 'SKIP - no python3: the structured-payload cases (tokens, prompt-content, git_ref, model) cannot run\n'
+fi
 
 # ---------------------------------------------------------------------------
 # Fixture: a work repo with a local bare origin. `git push` updates the
@@ -100,6 +138,9 @@ git_q() { git -C "$1" -c user.email=t@example.invalid -c user.name=Tester -c com
 #                   path so `git ls-remote` FAILS (infra/auth condition)
 #   no-base         pushed, then refs/remotes/origin/main deleted so the default
 #                   --base origin/main cannot resolve
+#   deleted-remote  pushed (mirror ref present and EQUAL to HEAD), then the branch
+#                   DELETED from the bare origin — a stale proxy that would still
+#                   satisfy a mirror-ref fast path
 make_fixture() { # make_fixture <name> <mode> -> prints work dir
   # NOTE: separate statements on purpose — `local` is a builtin, so ALL of its
   # arguments are expanded before any assignment takes effect; `local a=$1 b=$a`
@@ -163,6 +204,11 @@ make_fixture() { # make_fixture <name> <mode> -> prints work dir
       ;;
     no-base)
       git_q "$work" update-ref -d refs/remotes/origin/main
+      ;;
+    deleted-remote)
+      # The mirror ref stays, EQUAL to HEAD, while the branch is deleted from the
+      # remote: a cached proxy that still "proves" a push that no longer exists.
+      git -C "$root/origin.git" update-ref -d refs/heads/feature
       ;;
   esac
   printf '%s' "$work"
@@ -244,13 +290,49 @@ assert_never_enqueued() { # assert_never_enqueued <label>
   fi
 }
 
+# Recorded token_usage payloads, PRE-ESCAPED for embedding as a JSON *string* value
+# (the real payload double-encodes it). The small-genuine and vacuous numbers are the
+# measured ones from issue #2964; the boundary pair pins the input floor exactly.
+TOKENS_GENUINE_LARGE='{\"input_tokens\":505625,\"cached_input_tokens\":387328,\"total_output_tokens\":6332,\"usage_source\":\"job_log_turn_completed\"}'
+TOKENS_GENUINE_SMALL='{\"input_tokens\":67387,\"cached_input_tokens\":43520,\"total_output_tokens\":2232,\"usage_source\":\"job_log_turn_completed\",\"thread_id\":\"tid\",\"event_offset\":2366}'
+TOKENS_VACUOUS='{\"input_tokens\":18700,\"cached_input_tokens\":0,\"total_output_tokens\":53,\"usage_source\":\"job_log_turn_completed\"}'
+TOKENS_CLEAN_LOW_OUTPUT='{\"input_tokens\":67387,\"cached_input_tokens\":43520,\"total_output_tokens\":40,\"usage_source\":\"job_log_turn_completed\"}'
+TOKENS_INPUT_BELOW_FLOOR='{\"input_tokens\":24999,\"cached_input_tokens\":9000,\"total_output_tokens\":2000,\"usage_source\":\"job_log_turn_completed\"}'
+TOKENS_INPUT_AT_FLOOR='{\"input_tokens\":25000,\"cached_input_tokens\":9000,\"total_output_tokens\":2000,\"usage_source\":\"job_log_turn_completed\"}'
+TOKENS_OLD_FIELD_NAMES='{\"input_tokens\":505625,\"cached_input_tokens\":387328,\"output_tokens\":6332}'
+
+# A prompt that mentions every path any fixture touches, and one that mentions none.
+PROMPT_WITH_PATHS='Review the following change. diff --git a/main.rs b/main.rs @@ fn helper() {} @@ diff --git a/README.md b/README.md diff --git a/NOTES.md b/NOTES.md'
+PROMPT_WITHOUT_PATHS='Please review the change on this branch. (no diff was attached to this prompt)'
+
 export STUB_JOB=4656
 export STUB_VERDICT='No issues found'
-export STUB_TOKENS='505625 387328 6332'
+export STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
+export STUB_PROMPT="$PROMPT_WITH_PATHS"
+export STUB_STATUS=done
+export STUB_GIT_REF=''
+export STUB_MODEL=gpt-5.6-sol
+export STUB_REQUESTED_MODEL=gpt-5.6-sol
+export STUB_SHOW_JSON=object
 export STUB_REVIEW_RC=0
 export STUB_ANNOUNCE_SHA=''
 
+reset_stub() {
+  STUB_JOB=4656
+  STUB_VERDICT='No issues found'
+  STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
+  STUB_PROMPT="$PROMPT_WITH_PATHS"
+  STUB_REVIEW_RC=0
+  STUB_ANNOUNCE_SHA=''
+  STUB_STATUS=done
+  STUB_GIT_REF=''
+  STUB_MODEL=gpt-5.6-sol
+  STUB_REQUESTED_MODEL=gpt-5.6-sol
+  STUB_SHOW_JSON=object
+}
+
 printf '== case (a): enqueued sha == base ref ==\n'
+reset_stub
 work=$(make_fixture case_a pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
 run_wrapper "$work"
@@ -260,14 +342,16 @@ assert_says 'case (a) sha-assert FAIL' '^sha-assert: FAIL'
 assert_one_block 'case (a)'
 
 printf '== case (b): enqueued sha is neither endpoint ==\n'
+reset_stub
 work=$(make_fixture case_b pushed)
 STUB_ANNOUNCE_SHA='0000000000000000000000000000000000000abc'
 run_wrapper "$work"
 assert_verdict 'case (b)' FAIL 1
 assert_says 'case (b) names neither-endpoint' 'matches NEITHER endpoint'
-assert_says 'case (b) prints announced beside expected head' "announced reviewed-sha '0000000000000000000000000000000000000abc'"
+assert_says 'case (b) prints the reviewed sha beside expected head' "git_ref '0000000000000000000000000000000000000abc' does not equal branch HEAD"
 
 printf '== case (c): vacuous verdict vs non-empty census ==\n'
+reset_stub
 work=$(make_fixture case_c pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
@@ -279,6 +363,7 @@ assert_says 'case (c) prints the census' '^census: [0-9]+ files, \+[0-9]+/-[0-9]
 assert_says 'case (c) sha-assert still PASS' '^sha-assert: PASS$'
 
 printf '== case (c2): a code-free (docs-only) census is attributed to the code-free condition ==\n'
+reset_stub
 work=$(make_fixture case_c2 docs-only)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
@@ -288,23 +373,25 @@ assert_says 'case (c2) names the code-free condition' 'CODE-FREE-DIFF condition'
 assert_says 'case (c2) points at primary-source verification' 'primary-source verification recorded in the PR'
 
 printf '== case (d): vacuous token signature vs non-empty census ==\n'
+reset_stub
 work=$(make_fixture case_d pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found'
-STUB_TOKENS='18700 0 53'
+STUB_TOKEN_USAGE="$TOKENS_VACUOUS"
 run_wrapper "$work"
 assert_verdict 'case (d)' FAIL 1
 assert_says 'case (d) tier2 FAIL' '^vacuity-tier2: FAIL'
 assert_says 'case (d) tier1 unaffected' '^vacuity-tier1: PASS$'
-assert_says 'case (d) prints observed input vs named constant' 'observed input=18700 < ROBOREV_VACUITY_MIN_INPUT_TOKENS=50000'
+assert_says 'case (d) prints observed input vs named constant' 'observed input=18700 < ROBOREV_VACUITY_MIN_INPUT_TOKENS=25000'
 assert_says 'case (d) prints observed cached vs the zero clause' 'observed cached=0 == 0'
-assert_says 'case (d) prints observed output vs named constant' 'observed output=53 < ROBOREV_VACUITY_MIN_OUTPUT_TOKENS=200'
+assert_says 'case (d) output floor is ADVISORY, not a failure condition' 'advisory \(NOT a failure condition\): observed output=53'
 assert_says 'case (d) tokens line carries the triple' '^tokens: input=18700 cached=0 output=53$'
 
 printf '== case (e): unpushed branch ==\n'
+reset_stub
 work=$(make_fixture case_e unpushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_TOKENS='505625 387328 6332'
+STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 run_wrapper "$work"
 assert_verdict 'case (e)' FAIL 1
 assert_says 'case (e) push-assert FAIL' '^push-assert: FAIL'
@@ -312,6 +399,7 @@ assert_says 'case (e) names the missing remote branch authoritatively' "the remo
 assert_never_enqueued 'case (e)'
 
 printf '== case (e2): remote behind HEAD names the unpushed commits ==\n'
+reset_stub
 work=$(make_fixture case_e2 pushed)
 printf 'fn later() {}\n' >>"$work/main.rs"
 git_q "$work" add main.rs
@@ -323,6 +411,7 @@ assert_says 'case (e2) lists the unpushed commit' 'unpushed follow-up'
 assert_never_enqueued 'case (e2)'
 
 printf '== case (k): NARROW fetch refspec — pushed, but no feature mirror ref ==\n'
+reset_stub
 # THE regression case (#2964 follow-up blocker): CQLite clones set
 # remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main, so
 # refs/remotes/origin/<feature> is NEVER created however often the branch is
@@ -333,13 +422,14 @@ work=$(make_fixture case_k narrow)
 assert_no_mirror_ref 'case (k)' "$work" origin
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found'
-STUB_TOKENS='505625 387328 6332'
+STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 run_wrapper "$work"
 assert_verdict 'case (k)' PASS 0
 assert_says 'case (k) push-assert PASS despite the absent mirror ref' '^push-assert: PASS$'
 assert_says 'case (k) the run proceeded to a real review' '^sha-assert: PASS$'
 
 printf '== case (k2): narrow refspec, pushed but behind HEAD ==\n'
+reset_stub
 work=$(make_fixture case_k2 narrow-behind)
 assert_no_mirror_ref 'case (k2)' "$work" origin
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
@@ -351,6 +441,7 @@ assert_says 'case (k2) cites ls-remote as the authority' 'authoritative: git ls-
 assert_never_enqueued 'case (k2)'
 
 printf '== case (k3): the remote is derived from the branch upstream, not hardcoded ==\n'
+reset_stub
 work=$(make_fixture case_k3 narrow-upstream)
 assert_no_mirror_ref 'case (k3)' "$work" upstream
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
@@ -359,6 +450,7 @@ assert_verdict 'case (k3)' PASS 0
 assert_says 'case (k3) push-assert PASS against the configured upstream' '^push-assert: PASS$'
 
 printf '== case (k4): ls-remote failure is an infra/auth FAIL, not "never pushed" ==\n'
+reset_stub
 work=$(make_fixture case_k4 unreachable)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 run_wrapper "$work"
@@ -370,6 +462,7 @@ assert_lacks 'case (k4) does NOT claim the branch was never pushed' 'has never b
 assert_never_enqueued 'case (k4)'
 
 printf '== case (k5): an unresolvable --base FAILs closed, never NOTHING-TO-REVIEW ==\n'
+reset_stub
 work=$(make_fixture case_k5 no-base)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 run_wrapper "$work"
@@ -380,12 +473,159 @@ assert_says 'case (k5) says it is not NOTHING-TO-REVIEW' "explicitly NOT a NOTHI
 assert_lacks 'case (k5) is not NOTHING-TO-REVIEW' '^RESULT: NOTHING-TO-REVIEW$'
 assert_never_enqueued 'case (k5)'
 
+printf '== case (r): mirror ref equals HEAD but the remote branch was DELETED ==\n'
+reset_stub
+# The reviewer flagged the mirror-ref fast path as a Medium, correctly: a CACHED
+# origin/<branch> survives a force-push or a deletion, so it can equal HEAD while
+# the remote no longer has the commit — enqueueing a review for a commit the
+# reviewer cannot fetch, i.e. a vacuous-review setup. There is no fast path now.
+work=$(make_fixture case_r deleted-remote)
+if [ "$(git -C "$work" rev-parse --verify --quiet refs/remotes/origin/feature)" = "$(git -C "$work" rev-parse HEAD)" ]; then
+  ok 'case (r): fixture has a stale mirror ref equal to HEAD'
+else
+  bad 'case (r): fixture did not retain a mirror ref equal to HEAD'
+fi
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (r)' FAIL 1
+assert_says 'case (r) push-assert FAIL despite the stale mirror ref' '^push-assert: FAIL \(branch absent on remote origin\)$'
+assert_says 'case (r) cites ls-remote as the authority' 'authoritative: git ls-remote'
+assert_never_enqueued 'case (r)'
+
+if [ "$HAVE_PYTHON3" -eq 1 ]; then
+printf '== case (l): tier 2 EVALUATES against the real token_usage payload shape ==\n'
+reset_stub
+# The regression that made tier 2 dead code: token_usage is a JSON-ENCODED STRING
+# (decode twice) whose output field is total_output_tokens. These are the EXACT
+# numbers measured on the real job (67387 / 43520 / 2232).
+work=$(make_fixture case_l pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE="$TOKENS_GENUINE_SMALL"
+run_wrapper "$work"
+assert_verdict 'case (l)' PASS 0
+assert_says 'case (l) the doubly-encoded token_usage was decoded' '^tokens: input=67387 cached=43520 output=2232$'
+assert_says 'case (l) tier 2 actually evaluated' '^vacuity-tier2: PASS$'
+assert_lacks 'case (l) tier 2 is NOT permanently unavailable' '^vacuity-tier2: UNAVAILABLE$'
+
+printf '== case (l2): the legacy output_tokens field name is still accepted ==\n'
+reset_stub
+work=$(make_fixture case_l2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE="$TOKENS_OLD_FIELD_NAMES"
+run_wrapper "$work"
+assert_verdict 'case (l2)' PASS 0
+assert_says 'case (l2) output_tokens read as a fallback' '^tokens: input=505625 cached=387328 output=6332$'
+
+printf '== case (l3): the input floor is pinned at exactly 25000 ==\n'
+reset_stub
+work=$(make_fixture case_l3 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE="$TOKENS_INPUT_BELOW_FLOOR"
+run_wrapper "$work"
+assert_verdict 'case (l3) below the floor' FAIL 1
+assert_says 'case (l3) names the floor and the observation' 'observed input=24999 < ROBOREV_VACUITY_MIN_INPUT_TOKENS=25000'
+reset_stub
+work=$(make_fixture case_l3b pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE="$TOKENS_INPUT_AT_FLOOR"
+run_wrapper "$work"
+assert_verdict 'case (l3) at the floor' PASS 0
+
+printf '== case (l4): a low output count NEVER fails a genuine clean review ==\n'
+reset_stub
+# A genuine CLEAN review and a vacuous one emit near-identical output counts, so an
+# output floor would false-FAIL exactly the case we care most about.
+work=$(make_fixture case_l4 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE="$TOKENS_CLEAN_LOW_OUTPUT"
+run_wrapper "$work"
+assert_verdict 'case (l4)' PASS 0
+assert_says 'case (l4) tier 2 still PASSes' '^vacuity-tier2: PASS$'
+assert_says 'case (l4) the low output is reported as advisory only' 'advisory \(NOT a failure condition\): observed output=40'
+
+printf '== case (m): show --json unavailable falls back to list --json ==\n'
+reset_stub
+work=$(make_fixture case_m pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_TOKEN_USAGE="$TOKENS_GENUINE_SMALL"
+STUB_SHOW_JSON=none
+run_wrapper "$work"
+assert_verdict 'case (m)' PASS 0
+assert_says 'case (m) accounting came from the list fallback' '^tokens: input=67387 cached=43520 output=2232$'
+
+printf '== case (n): a prompt without the census paths is a HARD FAIL ==\n'
+reset_stub
+# The deterministic complement of tier 1: tier 1 catches "the reviewer got the diff
+# and discarded it"; this catches "the reviewer never got the diff at all".
+work=$(make_fixture case_n pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_PROMPT="$PROMPT_WITHOUT_PATHS"
+run_wrapper "$work"
+assert_verdict 'case (n)' FAIL 1
+assert_says 'case (n) prompt-content FAIL counts the absent paths' '^prompt-content: FAIL \(1/1 census paths absent from the prompt\)$'
+assert_says 'case (n) names the missing path' '^  main\.rs$'
+assert_says 'case (n) says the reviewer never received the diff' 'the reviewer never received this diff'
+assert_says 'case (n) every other check passed' '^vacuity-tier1: PASS$'
+
+printf '== case (n2): an unretrievable prompt degrades visibly, never a silent skip ==\n'
+reset_stub
+work=$(make_fixture case_n2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_PROMPT=''
+run_wrapper "$work"
+assert_verdict 'case (n2)' PASS 0
+assert_says 'case (n2) prompt-content UNAVAILABLE' '^prompt-content: UNAVAILABLE$'
+assert_says 'case (n2) degraded-signal wording' 'DEGRADED SIGNAL, never a silent skip'
+
+printf '== case (n3): prompt-content PASS reports the coverage it checked ==\n'
+reset_stub
+work=$(make_fixture case_n3 docs-only)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_says 'case (n3) prompt-content PASS names the counts' '^prompt-content: PASS \(2/2 census paths present\)$'
+
+printf '== case (o): the structured git_ref is the sha oracle, stdout is a cross-check ==\n'
+reset_stub
+# stdout announces the right sha while the job record says the base was reviewed:
+# the structured field must win, and the disagreement must be recorded.
+work=$(make_fixture case_o pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_GIT_REF=$(git -C "$work" rev-parse origin/main)
+run_wrapper "$work"
+assert_verdict 'case (o)' FAIL 1
+assert_says 'case (o) sha-assert FAIL from the structured field' '^sha-assert: FAIL \(reviewed-sha does not match head-sha\)$'
+assert_says 'case (o) names the base-ref equality' "EQUALS the base ref 'origin/main'"
+assert_says 'case (o) records the stdout cross-check disagreement' 'sha-assert cross-check: stdout announced'
+assert_says 'case (o) reviewed-sha reports the structured value' "^reviewed-sha: $(git -C "$work" rev-parse origin/main)\$"
+
+printf '== case (p): a model substitution is surfaced loudly ==\n'
+reset_stub
+work=$(make_fixture case_p pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_MODEL=gpt-5.6-mini
+STUB_REQUESTED_MODEL=gpt-5.6-sol
+run_wrapper "$work"
+assert_verdict 'case (p)' PASS 0
+assert_says 'case (p) the model line marks the substitution' "^model: gpt-5\.6-mini \(SUBSTITUTED — requested 'gpt-5\.6-sol'\)\$"
+assert_says 'case (p) a loud NOTICE explains it' 'a MODEL SUBSTITUTION'
+
+printf '== case (p2): a matching model is reported plainly ==\n'
+reset_stub
+work=$(make_fixture case_p2 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (p2)' PASS 0
+assert_says 'case (p2) model line is plain' '^model: gpt-5\.6-sol$'
+assert_lacks 'case (p2) no substitution notice' 'SUBSTITUTED'
+fi  # HAVE_PYTHON3
+
 printf '== case (f): genuine review with matching sha + healthy accounting ==\n'
+reset_stub
 work=$(make_fixture case_f pushed)
 head_sha=$(git -C "$work" rev-parse HEAD)
 STUB_ANNOUNCE_SHA="$head_sha"
 STUB_VERDICT='No issues found'
-STUB_TOKENS='505625 387328 6332'
+STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 run_wrapper "$work"
 assert_verdict 'case (f)' PASS 0
 for line in 'push-assert: PASS' 'census-check: PASS' 'sha-assert: PASS' 'vacuity-tier1: PASS' 'vacuity-tier2: PASS'; do
@@ -409,6 +649,7 @@ else
 fi
 
 printf '== case (g): genuinely empty census ==\n'
+reset_stub
 work=$(make_fixture case_g empty)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 run_wrapper "$work"
@@ -419,6 +660,7 @@ assert_lacks 'case (g) is not a PASS' '^RESULT: PASS$'
 assert_never_enqueued 'case (g)'
 
 printf '== case (h): missing / unparseable enqueue announcement ==\n'
+reset_stub
 work=$(make_fixture case_h pushed)
 STUB_ANNOUNCE_SHA=''
 STUB_VERDICT='Review complete. (no enqueue line printed)'
@@ -428,52 +670,82 @@ assert_says 'case (h) sha-assert FAIL (unverifiable)' '^sha-assert: FAIL \(no pa
 assert_says 'case (h) reviewed-sha unknown' '^reviewed-sha: -$'
 
 printf '== case (i): unavailable token accounting degrades visibly, tier 1 still governs ==\n'
+reset_stub
 work=$(make_fixture case_i pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
-STUB_TOKENS='NONE'
+STUB_TOKEN_USAGE=NONE
 run_wrapper "$work"
 assert_verdict 'case (i)' FAIL 1
 assert_says 'case (i) tokens UNAVAILABLE' '^tokens: UNAVAILABLE$'
 assert_says 'case (i) tier2 UNAVAILABLE' '^vacuity-tier2: UNAVAILABLE$'
-assert_says 'case (i) degraded-signal notice, not a skip' 'DEGRADED-SIGNAL notice, never a silent skip'
+assert_says 'case (i) degraded-signal notice, not a skip' 'DEGRADED SIGNAL, never a silent skip'
 assert_says 'case (i) tier1 still FAILs' '^vacuity-tier1: FAIL'
 assert_lacks 'case (i) UNAVAILABLE never upgrades to PASS' '^RESULT: PASS$'
 
 printf '== case (i2): unavailable accounting alone does not fail an otherwise clean review ==\n'
+reset_stub
 work=$(make_fixture case_i2 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found'
-STUB_TOKENS='NONE'
+STUB_TOKEN_USAGE=NONE
 run_wrapper "$work"
 assert_verdict 'case (i2)' PASS 0
 assert_says 'case (i2) tier2 UNAVAILABLE' '^vacuity-tier2: UNAVAILABLE$'
 
-printf '== case (j): a non-zero roborev exit FAILs under its own greppable key ==\n'
+printf '== case (j): exit non-zero WITH a completed review = FINDINGS, not a malfunction ==\n'
+reset_stub
+# roborev exits non-zero when the review REPORTS FINDINGS. Calling that a reviewer
+# malfunction is dangerous in the opposite direction from the vacuity bug: an agent
+# told the reviewer broke retries or bypasses instead of FIXING THE FINDINGS.
 work=$(make_fixture case_j pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT='No issues found'
-STUB_TOKENS='505625 387328 6332'
+STUB_VERDICT='Review complete. Findings: 1. [Medium] scripts/flow/roborev-review.sh:350 the fast path bypasses the authoritative remote check'
+STUB_STATUS=done
 STUB_REVIEW_RC=1
 run_wrapper "$work"
 STUB_REVIEW_RC=0
+STUB_VERDICT='No issues found'
 assert_verdict 'case (j)' FAIL 1
-assert_says 'case (j) roborev-exit FAIL names the observed code' '^roborev-exit: FAIL \(exit 1\)$'
+assert_says 'case (j) roborev-exit is FINDINGS with the observed code' '^roborev-exit: FINDINGS \(exit 1\)$'
+assert_says 'case (j) findings are PRESENT and counted' '^findings: PRESENT \(1\)$'
+assert_says 'case (j) says the review is GENUINE' 'The review is GENUINE'
+assert_says 'case (j) directs the reader to fix, not retry' 'TRIAGE AND FIX the findings'
+assert_lacks 'case (j) does not call it a reviewer malfunction' 'reviewer malfunction — |ERROR \(exit 1\)'
 # Every OTHER per-check key passes here — that is the point of the key: without it a
 # reader retaining only the block would see all-PASS beside RESULT: FAIL and be
 # unable to attribute the failure.
 for line in 'push-assert: PASS' 'census-check: PASS' 'sha-assert: PASS' 'vacuity-tier1: PASS' 'vacuity-tier2: PASS'; do
   assert_says "case (j) $line" "^$line\$"
 done
-assert_says 'case (j) names the reviewer exit in prose too' "'roborev review' exited 1"
 assert_lacks 'case (j) is not a PASS' '^RESULT: PASS$'
 
+printf '== case (j1b): exit non-zero with a FAILED job = ERROR (infra), not FINDINGS ==\n'
+reset_stub
+work=$(make_fixture case_j1b pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT='agent invocation failed: connection refused'
+STUB_STATUS=failed
+STUB_REVIEW_RC=2
+run_wrapper "$work"
+STUB_REVIEW_RC=0
+STUB_STATUS=done
+STUB_VERDICT='No issues found'
+assert_verdict 'case (j1b)' FAIL 1
+assert_says 'case (j1b) roborev-exit is ERROR with the observed code' '^roborev-exit: ERROR \(exit 2\)$'
+assert_says 'case (j1b) findings are UNKNOWN' '^findings: UNKNOWN$'
+assert_says 'case (j1b) attributes it to the reviewer itself' 'The REVIEWER itself failed'
+assert_says 'case (j1b) names it an infra condition' 'this is an infra condition, not a findings outcome'
+assert_lacks 'case (j1b) is not reported as FINDINGS' '^roborev-exit: FINDINGS'
+
 printf '== case (j2): a zero roborev exit records roborev-exit: PASS ==\n'
+reset_stub
 work=$(make_fixture case_j2 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 run_wrapper "$work"
 assert_verdict 'case (j2)' PASS 0
 assert_says 'case (j2) roborev-exit PASS' '^roborev-exit: PASS$'
+assert_says 'case (j2) findings NONE' '^findings: NONE$'
 # Key ORDER is part of the contract: roborev-exit sits between vacuity-tier2 and log.
 if [ "$(grep -nE '^(vacuity-tier2|roborev-exit|log):' "$OUT" | cut -d: -f2 | paste -sd,)" = "vacuity-tier2,roborev-exit,log" ]; then
   ok 'case (j2): roborev-exit is positioned between vacuity-tier2 and log'
@@ -482,6 +754,7 @@ else
 fi
 
 printf '== case (j3): a pre-invocation failure leaves roborev-exit: SKIP ==\n'
+reset_stub
 work=$(make_fixture case_j3 unpushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 run_wrapper "$work"
@@ -490,6 +763,7 @@ assert_says 'case (j3) roborev-exit SKIP (the process never ran)' '^roborev-exit
 assert_never_enqueued 'case (j3)'
 
 printf '== usage errors: --agent and --model are BOTH required ==\n'
+reset_stub
 work=$(make_fixture case_usage pushed)
 for pair in "--agent codex" "--model gpt-5.6-sol"; do
   CASE_N=$((CASE_N + 1))
@@ -510,10 +784,11 @@ for pair in "--agent codex" "--model gpt-5.6-sol"; do
 done
 
 printf '== the summary header is distinct from every agent-gate header ==\n'
+reset_stub
 work=$(make_fixture case_hdr pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found'
-STUB_TOKENS='505625 387328 6332'
+STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 run_wrapper "$work"
 assert_says 'header: roborev block present' '^==== ROBOREV REVIEW SUMMARY ====$'
 assert_lacks 'header: no AGENT-GATE SUMMARY header' '==== AGENT-GATE SUMMARY ===='
@@ -521,6 +796,7 @@ assert_lacks 'header: no AGENT-GATE LITE SUMMARY header' '==== AGENT-GATE LITE S
 assert_lacks 'header: no AGENT-GATE DELTA SUMMARY header' '==== AGENT-GATE DELTA SUMMARY ===='
 
 printf '== --help documents the exit codes and the live worktree probe ==\n'
+reset_stub
 CASE_N=$((CASE_N + 1))
 OUT="$tmp/out-$CASE_N.txt"
 INVOKED="$tmp/invoked-$CASE_N.txt"
@@ -536,6 +812,7 @@ assert_says '--help requires both agent and model' 'Both are required'
 assert_never_enqueued '--help'
 
 printf '== hermeticity: the wrapper never reaches a real roborev ==\n'
+reset_stub
 if grep -qE '^\s*roborev (review|show|list)' "$WRAPPER"; then
   ok 'wrapper invokes roborev only through PATH resolution (stubbable)'
 else

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -343,7 +343,7 @@ export STUB_JOB=4656
 export STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 export STUB_TOKEN_USAGE="$TOKENS_GENUINE_LARGE"
 export STUB_PROMPT="$PROMPT_WITH_PATHS"
-export STUB_STATUS=done
+export STUB_STATUS="done"
 export STUB_GIT_REF=''
 export STUB_MODEL=gpt-5.6-sol
 export STUB_REQUESTED_MODEL=gpt-5.6-sol
@@ -359,7 +359,7 @@ reset_stub() {
   STUB_PROMPT="$PROMPT_WITH_PATHS"
   STUB_REVIEW_RC=0
   STUB_ANNOUNCE_SHA=''
-  STUB_STATUS=done
+  STUB_STATUS="done"
   STUB_GIT_REF=''
   STUB_MODEL=gpt-5.6-sol
   STUB_REQUESTED_MODEL=gpt-5.6-sol
@@ -386,24 +386,38 @@ assert_verdict 'case (b)' FAIL 1
 assert_says 'case (b) names neither-endpoint' 'matches NEITHER endpoint'
 assert_says 'case (b) prints the reviewed sha beside expected head' "git_ref '0000000000000000000000000000000000000abc' does not equal branch HEAD"
 
-printf '== case (c): a vacuous verdict on a CODE census raises an ADVISORY notice ==\n'
+printf '== case (c): findings NONE + a vacuity claim on a CODE census = HARD FAIL ==\n'
 reset_stub
-# Tier 1 is DEMOTED to advisory (round 3): it matched anywhere in the transcript, so
-# a review that merely QUOTED the phrase — as any review of THIS wrapper would — was
-# failed as vacuous, and agents learning to waive tier-1 FAILs would restore the very
-# defect the guard exists to stop. The docs-only trigger it used to be primary for is
-# now caught deterministically by `code-free:` (case (c2)). See the return packet: the
-# residual gap (reviewer HAD the diff yet concludes "no code changes" on a code
-# census) is now a NOTICE, which the spec's tier-1 requirement calls a hard failure.
+# Tier 1 is AUTHORITATIVE again (round 4) but GATED on `findings:`. With findings NONE
+# the reviewer is CLAIMING CLEANLINESS, so a "no code changes" summary against a
+# census we measured as non-empty is trigger T3 and must block the merge.
 work=$(make_fixture case_c pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT=$'No issues found.\nSummary: the diff contains no code changes to review.'
 run_wrapper "$work"
-assert_verdict 'case (c)' PASS 0
-assert_says 'case (c) tier1 raises a NOTICE' '^vacuity-tier1: NOTICE \(vacuous verdict vs non-empty census\)$'
-assert_says 'case (c) the notice says it is advisory' 'ADVISORY, does not fail the run'
+assert_verdict 'case (c)' FAIL 1
+assert_says 'case (c) tier1 FAILs authoritatively' '^vacuity-tier1: FAIL \(vacuous verdict vs non-empty census\)$'
+assert_says 'case (c) names the claiming-cleanliness gate' 'reported NO findings \(findings: NONE\)'
 assert_says 'case (c) prints the census' '^census: [0-9]+ files?, \+[0-9]+/-[0-9]+$'
 assert_says 'case (c) sha-assert still PASS' '^sha-assert: PASS$'
+assert_says 'case (c) findings are NONE' '^findings: NONE$'
+
+printf '== case (c1c): findings UNKNOWN + the phrase FAILs (fail-closed on unknown) ==\n'
+reset_stub
+# The findings state is UNKNOWN when the reviewer errored. An unparseable/unknowable
+# findings state must never DISARM tier 1, so UNKNOWN is treated as claiming cleanliness.
+work=$(make_fixture case_c1c pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT=$'No issues found.\nSummary: the diff contains no code changes to review.'
+STUB_STATUS=failed
+STUB_REVIEW_RC=3
+run_wrapper "$work"
+STUB_REVIEW_RC=0
+STUB_STATUS="done"
+assert_verdict 'case (c1c)' FAIL 1
+assert_says 'case (c1c) findings are UNKNOWN' '^findings: UNKNOWN$'
+assert_says 'case (c1c) tier1 still FAILs' '^vacuity-tier1: FAIL \(vacuous verdict vs non-empty census\)$'
+assert_says 'case (c1c) says fail-closed is the correct direction' 'treated as claiming cleanliness'
 
 printf '== case (c1b): the tier-1 match is anchored to the verdict/summary region ==\n'
 reset_stub
@@ -411,13 +425,30 @@ reset_stub
 # be flagged: the match only looks at the Summary line.
 work=$(make_fixture case_c1b pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-STUB_VERDICT=$'Findings:\n[Medium] the tier-1 regex matches the literal phrase no code changes anywhere in the transcript\n[Low] naming nit\nSummary: 2 findings.'
+STUB_VERDICT=$'## Findings\n[Medium] the tier-1 regex matches the literal phrase no code changes anywhere in the transcript\n[Low] naming nit\n## Summary: 2 findings; the guard says no code changes too broadly.'
 STUB_REVIEW_RC=1
 run_wrapper "$work"
 STUB_REVIEW_RC=0
-assert_says 'case (c1b) tier1 is NOT tripped by a quote in a finding body' '^vacuity-tier1: PASS$'
+assert_says 'case (c1b) tier1 does not FAIL a findings-bearing review' '^vacuity-tier1: NOTICE \(phrase present in a findings-bearing review\)$'
+assert_says 'case (c1b) the gate names the findings evidence' 'the review reported findings'
+assert_lacks 'case (c1b) tier1 never FAILs here' '^vacuity-tier1: FAIL'
 assert_says 'case (c1b) the run fails only for the findings' '^roborev-exit: FINDINGS \(exit 1\)$'
-assert_lacks 'case (c1b) no vacuity notice' 'vacuity-tier1: NOTICE'
+
+
+printf '== case (c1d): a CLEAN review quoting the phrase OUTSIDE its summary PASSes ==\n'
+reset_stub
+# This is what the verdict/summary ANCHORING buys, and the findings gate cannot cover
+# it: findings NONE (so the gate would fail it) yet the phrase appears only in a body
+# note, not in the review's conclusion. Unanchored matching fails this run; anchored
+# matching correctly passes it.
+work=$(make_fixture case_c1d pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_VERDICT=$'No issues found.\nNote: the guard under review matches the literal phrase no code changes.\nSummary: reviewed 1 file; nothing to report.'
+run_wrapper "$work"
+assert_verdict 'case (c1d)' PASS 0
+assert_says 'case (c1d) tier1 PASSes on an out-of-region mention' '^vacuity-tier1: PASS$'
+assert_says 'case (c1d) findings are NONE' '^findings: NONE$'
+assert_lacks 'case (c1d) tier1 does not FAIL' '^vacuity-tier1: FAIL'
 
 printf '== case (c2): a code-free (docs-only) census FAILs deterministically ==\n'
 reset_stub
@@ -770,11 +801,12 @@ STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT='No issues found. Summary: the diff contains no code changes to review.'
 STUB_TOKEN_USAGE=NONE
 run_wrapper "$work"
-assert_verdict 'case (i)' PASS 0
+assert_verdict 'case (i)' FAIL 1
 assert_says 'case (i) tokens UNAVAILABLE' '^tokens: UNAVAILABLE$'
 assert_says 'case (i) tier2 UNAVAILABLE' '^vacuity-tier2: UNAVAILABLE$'
 assert_says 'case (i) degraded notice, not a skip' 'never a silent skip'
-assert_says 'case (i) tier1 records its advisory notice' '^vacuity-tier1: NOTICE'
+assert_says 'case (i) tier1 governs even with tier 2 unavailable' '^vacuity-tier1: FAIL'
+assert_lacks 'case (i) UNAVAILABLE never upgrades to PASS' '^RESULT: PASS$'
 
 printf '== case (i2): unavailable accounting alone does not fail an otherwise clean review ==\n'
 reset_stub
@@ -794,7 +826,7 @@ reset_stub
 work=$(make_fixture case_j pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 STUB_VERDICT=$'Review complete.\nFindings:\n[Medium] scripts/flow/roborev-review.sh:350 the fast path bypasses the authoritative remote check\nSummary: 1 finding.'
-STUB_STATUS=done
+STUB_STATUS="done"
 STUB_REVIEW_RC=1
 run_wrapper "$work"
 STUB_REVIEW_RC=0
@@ -822,7 +854,7 @@ STUB_STATUS=failed
 STUB_REVIEW_RC=2
 run_wrapper "$work"
 STUB_REVIEW_RC=0
-STUB_STATUS=done
+STUB_STATUS="done"
 STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
 assert_verdict 'case (j1b)' FAIL 1
 assert_says 'case (j1b) roborev-exit is ERROR with the observed code' '^roborev-exit: ERROR \(exit 2\)$'
@@ -1087,6 +1119,49 @@ for bad_invocation in "--nonsense" "--repo:$tmp/definitely-not-a-directory" "--r
   assert_never_enqueued "usage: '$bad_invocation'"
 done
 
+printf '== case (w): a MISSING oracles file FAILs closed, never silently no-ops ==\n'
+reset_stub
+# roborev-review.sh sources scripts/flow/roborev-review-oracles.sh for the push assert
+# and the census. If that file vanished and the wrapper carried on, both checks would
+# become no-ops while every key still read PASS — the worst regression available here.
+work=$(make_fixture case_w pushed)
+lonely="$tmp/lonely"
+mkdir -p "$lonely"
+cp "$WRAPPER" "$lonely/roborev-review.sh"
+cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$lonely/" 2>/dev/null || true
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+INVOKED="$tmp/invoked-$CASE_N.txt"
+: >"$INVOKED"
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$lonely/roborev-review.sh" --repo "$work" \
+  --agent codex --model gpt-5.6-sol --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
+RC=$?
+assert_verdict 'case (w)' FAIL 1
+assert_says 'case (w) names the missing oracles file' 'oracles file .* is missing'
+assert_says 'case (w) refuses to run with the checks disabled' 'Failing closed rather than proceeding'
+assert_never_enqueued 'case (w)'
+assert_says 'case (w) push-assert never claims a pass' '^push-assert: SKIP$'
+
+printf '== case (w2): a TRUNCATED oracles file FAILs closed too ==\n'
+reset_stub
+work=$(make_fixture case_w2 pushed)
+truncated="$tmp/truncated"
+mkdir -p "$truncated"
+cp "$WRAPPER" "$truncated/roborev-review.sh"
+printf '# corrupt: defines nothing\n' >"$truncated/roborev-review-oracles.sh"
+CASE_N=$((CASE_N + 1))
+OUT="$tmp/out-$CASE_N.txt"
+INVOKED="$tmp/invoked-$CASE_N.txt"
+: >"$INVOKED"
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$truncated/roborev-review.sh" --repo "$work" \
+  --agent codex --model gpt-5.6-sol --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
+RC=$?
+assert_verdict 'case (w2)' FAIL 1
+assert_says 'case (w2) names the undefined functions' 'did not define roborev_push_assert and roborev_census'
+assert_never_enqueued 'case (w2)'
+
 printf '== usage errors: --agent and --model are BOTH required ==\n'
 reset_stub
 work=$(make_fixture case_usage pushed)
@@ -1141,6 +1216,7 @@ reset_stub
 if grep -qE '^\s*roborev (review|show|list)' "$WRAPPER"; then
   ok 'wrapper invokes roborev only through PATH resolution (stubbable)'
 else
+  # shellcheck disable=SC2016 # the backticks are prose in the failure message
   bad 'wrapper does not invoke `roborev` by bare name — the stub cannot intercept it'
 fi
 

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -64,8 +64,9 @@ trap 'rm -rf "$tmp"' EXIT
 #   STUB_PAYLOAD_JOB     the id INSIDE the payload (differs from the announced job to
 #                        pin the narrowed ID-less fallback in roborev-job-facts.py)
 #   STUB_RECORD_BLANK_FOR the first N record reads return an empty record, so the
-#                        wrapper's bounded poll for the ASYNCHRONOUSLY written record
-#                        can be exercised (counter kept in $STUB_INVOKED.reads)
+#                        wrapper's bounded read RETRY can be exercised (a transient
+#                        read failure — there is no asynchronous write to wait out;
+#                        counter kept in $STUB_INVOKED.reads)
 #   STUB_HAS_TOKEN_DATA  emit a has_token_data field with this value (true/false)
 #   STUB_LIST_JSON       `none` => `list --json` returns null, so `show` is the only
 #                        record source
@@ -107,8 +108,9 @@ emit_job_object() {
     "$usage$extra"
 }
 
-# record_read_blank: true while the first STUB_RECORD_BLANK_FOR record reads should
-# come back empty, replaying the real daemon's asynchronous record write.
+# record_read_blank: true while the first STUB_RECORD_BLANK_FOR record reads should come
+# back empty, simulating a TRANSIENT read failure. (It does NOT model an asynchronous
+# record write: the job row is present from enqueue — that diagnosis was retracted.)
 record_read_blank() {
   local want="${STUB_RECORD_BLANK_FOR:-0}" seen=0 counter="$STUB_INVOKED.reads"
   [ "$want" -gt 0 ] || return 1
@@ -1255,11 +1257,13 @@ assert_verdict 'case (x2)' PASS 0
 assert_says 'case (x2) every code census path was covered' '^prompt-content: PASS \(2/2 code census paths present\)$'
 
 if [ "$HAVE_PYTHON3" -eq 1 ]; then
-printf '== case (y1): the ASYNCHRONOUSLY written job record is POLLED, not assumed ==\n'
+printf '== case (y1): a transient failed record read is RETRIED, not accepted ==\n'
 reset_stub
-# DEFECT 2: the instant `--wait` returned, the record had no git_ref/status/model/
-# token_usage; moments later it had all four. Unpolled, FOUR asserts silently
-# degraded at once on a normal run.
+# An unreadable-on-first-attempt record must not be accepted as empty: doing so silently
+# degraded FOUR asserts at once (sha-assert, review-completed, tier 2, model). NOTE the
+# retry covers a TRANSIENT READ, not an asynchronous write — the round-5 "written
+# asynchronously" diagnosis was wrong and is retracted; the real cause was the two
+# payload shapes (see case (x10)).
 work=$(make_fixture case_y1 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
 STUB_RECORD_BLANK_FOR=2
@@ -1267,7 +1271,8 @@ run_wrapper "$work"
 STUB_RECORD_BLANK_FOR=0
 assert_verdict 'case (y1)' PASS 0
 assert_says 'case (y1) the record is reported complete' '^job-record: PASS$'
-assert_says 'case (y1) the polling is disclosed' 'became complete only after [0-9]+ poll'
+assert_says 'case (y1) the retry is disclosed' 'read complete only on retry [0-9]+ of [0-9]+'
+assert_lacks 'case (y1) does not repeat the retracted async claim' 'written asynchronously'
 assert_says 'case (y1) the STRONG sha oracle was used' '^sha-assert: PASS$'
 assert_says 'case (y1) tier 2 evaluated rather than degrading' '^vacuity-tier2: PASS$'
 assert_says 'case (y1) the model was confirmed from the record' '^model: gpt-5\.6-sol$'
@@ -1603,7 +1608,12 @@ assert_says '--help states the exit-code contract' '0=PASS, 1=FAIL, 3=NOTHING-TO
 assert_says '--help names the sanctioned range invocation' 'Sanctioned invocation'
 assert_says '--help marks --branch-without-repo non-sanctioned' "WITHOUT an explicit --repo"
 assert_says '--help carries the live worktree probe' 'LIVE WORKTREE PROBE'
-assert_says '--help states the probe expectation' 'reviewed-sha == head-sha'
+# The probe expectation is stated in RANGE terms: reviewed-sha is '<base>..<head>', so
+# 'reviewed-sha == head-sha' could never hold and the old pinned wording defended an
+# instruction that was guaranteed to fail.
+assert_says '--help states the probe expectation in range terms' 'reviewed-sha is a RANGE'
+assert_says '--help says the range must end in the worktree HEAD' 'ENDS IN that same head-sha'
+assert_lacks '--help no longer asks for reviewed-sha == head-sha' 'reviewed-sha == head-sha'
 assert_says '--help requires both agent and model' 'Both are required'
 assert_never_enqueued '--help'
 

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -67,7 +67,10 @@ trap 'rm -rf "$tmp"' EXIT
 #                        wrapper's bounded poll for the ASYNCHRONOUSLY written record
 #                        can be exercised (counter kept in $STUB_INVOKED.reads)
 #   STUB_HAS_TOKEN_DATA  emit a has_token_data field with this value (true/false)
-#   STUB_SHOW_JSON       `none` => `show --json` returns null; `review-row` => it
+#   STUB_LIST_JSON       `none` => `list --json` returns null, so `show` is the only
+#                        record source
+#   STUB_SHOW_JSON       `none` => `show --json` returns null; `nested` => the MEASURED
+#                        shape (review row nesting the job row under "job"); `review-row` => it
 #                        returns the REAL review-row shape (id/prompt, no git_ref or
 #                        status), forcing the richer `list --json` source; otherwise the
 #                        `list --json` fallback path
@@ -130,6 +133,15 @@ case "$cmd" in
     esac
     record_read_blank && { printf 'null\n'; exit 0; }
     [ "${STUB_SHOW_JSON:-object}" != none ] || { printf 'null\n'; exit 0; }
+    if [ "${STUB_SHOW_JSON:-object}" = nested ]; then
+      # The MEASURED `roborev show <id> --json` shape: a REVIEW row carrying its own
+      # `id` (equal to the job id) that NESTS the job row under a "job" key.
+      printf '{"id":%s,"job_id":%s,"agent":"codex","verdict_bool":0,"prompt":"%s","job":' \
+        "${STUB_JOB:-4600}" "${STUB_JOB:-4600}" "${STUB_PROMPT:-}"
+      emit_job_object
+      printf '}\n'
+      exit 0
+    fi
     if [ "${STUB_SHOW_JSON:-object}" = review-row ]; then
       # The REAL `show --json` shape: the REVIEW row — id/agent/prompt, and no
       # git_ref / status / verdict / token_usage.
@@ -142,6 +154,7 @@ case "$cmd" in
     ;;
   list)
     record_read_blank && { printf 'null\n'; exit 0; }
+    [ "${STUB_LIST_JSON:-array}" != none ] || { printf 'null\n'; exit 0; }
     printf '['; emit_job_object; printf ']\n'
     exit 0
     ;;
@@ -417,6 +430,7 @@ export STUB_HAS_TOKEN_DATA=''
 export STUB_VERDICT_FIELD=''
 export STUB_RECORD_BLANK_FOR=0
 export STUB_PAYLOAD_JOB=''
+export STUB_LIST_JSON=array
 export STUB_REVIEW_RC=0
 export STUB_ANNOUNCE_SHA=''
 
@@ -436,6 +450,7 @@ reset_stub() {
   STUB_VERDICT_FIELD=''
   STUB_RECORD_BLANK_FOR=0
   STUB_PAYLOAD_JOB=''
+  STUB_LIST_JSON=array
 }
 
 printf '== case (a): enqueued sha == base ref ==\n'
@@ -1477,6 +1492,27 @@ RC=$?
 assert_verdict 'case (w4)' FAIL 1
 assert_says 'case (w4) names the undefined check function' 'did not define roborev_check_review_completed'
 assert_never_enqueued 'case (w4)'
+
+if [ "$HAVE_PYTHON3" -eq 1 ]; then
+printf '== case (x10): the NESTED job row in show --json is read as a first-class source ==\n'
+reset_stub
+# MEASURED (round 6): `roborev show <id> --json` returns a REVIEW row whose own `id`
+# equals the job id and which NESTS the job row — git_ref, status, model,
+# requested_model, token_usage, verdict — under a "job" key. Returning the FIRST id
+# match handed back the outer row, which has none of those fields; that looked like an
+# async durability problem and silently downgraded sha-assert, tier 2 and model.
+# `list --json` is disabled here so `show` is the ONLY source.
+work=$(make_fixture case_x10 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_SHOW_JSON=nested
+STUB_LIST_JSON=none
+run_wrapper "$work"
+assert_verdict 'case (x10)' PASS 0
+assert_says 'case (x10) the nested job row was used' '^job-record: PASS$'
+assert_says 'case (x10) the range oracle worked from the nested row' '^sha-assert: PASS$'
+assert_says 'case (x10) tokens came from the nested row' '^vacuity-tier2: PASS$'
+assert_says 'case (x10) the model was confirmed from the nested row' '^model: gpt-5\.6-sol$'
+fi  # HAVE_PYTHON3
 
 printf '== case (w): a MISSING oracles file FAILs closed, never silently no-ops ==\n'
 reset_stub

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -61,6 +61,8 @@ trap 'rm -rf "$tmp"' EXIT
 #   STUB_REQUESTED_MODEL job requested_model field
 #   STUB_PROMPT          prompt text (plain, no quotes/backslashes)
 #   STUB_VERDICT_FIELD   the job record's structured `verdict` letter (P/F), '' to omit
+#   STUB_PAYLOAD_JOB     the id INSIDE the payload (differs from the announced job to
+#                        pin the narrowed ID-less fallback in roborev-job-facts.py)
 #   STUB_RECORD_BLANK_FOR the first N record reads return an empty record, so the
 #                        wrapper's bounded poll for the ASYNCHRONOUSLY written record
 #                        can be exercised (counter kept in $STUB_INVOKED.reads)
@@ -91,7 +93,7 @@ emit_job_object() {
     extra="$extra,\"verdict\":\"${STUB_VERDICT_FIELD}\""
   fi
   printf '{"id":%s,"git_ref":"%s","status":"%s","model":"%s","requested_model":"%s","prompt":"%s"%s}' \
-    "${STUB_JOB:-4600}" \
+    "${STUB_PAYLOAD_JOB:-${STUB_JOB:-4600}}" \
     "$git_ref" \
     "${STUB_STATUS:-done}" \
     "${STUB_MODEL:-gpt-5.6-sol}" \
@@ -395,6 +397,7 @@ export STUB_SHOW_JSON=object
 export STUB_HAS_TOKEN_DATA=''
 export STUB_VERDICT_FIELD=''
 export STUB_RECORD_BLANK_FOR=0
+export STUB_PAYLOAD_JOB=''
 export STUB_REVIEW_RC=0
 export STUB_ANNOUNCE_SHA=''
 
@@ -413,6 +416,7 @@ reset_stub() {
   STUB_HAS_TOKEN_DATA=''
   STUB_VERDICT_FIELD=''
   STUB_RECORD_BLANK_FOR=0
+  STUB_PAYLOAD_JOB=''
 }
 
 printf '== case (a): enqueued sha == base ref ==\n'
@@ -739,7 +743,7 @@ run_wrapper "$work"
 assert_verdict 'case (n)' FAIL 1
 assert_says 'case (n) prompt-content FAIL counts the absent paths' '^prompt-content: FAIL \(1/1 code census paths absent from the prompt\)$'
 assert_says 'case (n) names the missing path' '^  main\.rs$'
-assert_says 'case (n) says the reviewer never received the diff' 'the reviewer never received this diff'
+assert_says 'case (n) says the reviewer never received the diffs' 'the reviewer never received their diffs'
 assert_says 'case (n) every other check passed' '^vacuity-tier1: PASS$'
 assert_says 'case (n) review-completed still PASS' '^review-completed: PASS$'
 
@@ -1191,7 +1195,7 @@ run_wrapper "$work"
 assert_verdict 'case (x1)' FAIL 1
 assert_says 'case (x1) prompt-content names the uncovered code path' '^prompt-content: FAIL \(1/2 code census paths absent from the prompt\)$'
 assert_says 'case (x1) lists the missing file' '^  alpha\.rs$'
-assert_says 'case (x1) says the reviewer never received the diff' 'the reviewer never received this diff'
+assert_says 'case (x1) says the reviewer never received the diffs' 'the reviewer never received their diffs'
 assert_says 'case (x1) the range itself verified fine' '^sha-assert: PASS$'
 
 printf '== case (x3): a range anchored at the EMPTY TREE FAILs (two-positional form) ==\n'
@@ -1293,6 +1297,62 @@ run_wrapper "$work"
 assert_verdict 'case (z4)' FAIL 1
 assert_says 'case (z4) the exit-code contradiction is named' '^findings: INCONSISTENT \(exit 0, 1 findings marker\(s\)\)$'
 assert_says 'case (z4) it cannot exempt tier 1' 'cannot exempt the tier-1 vacuity check'
+fi  # HAVE_PYTHON3
+
+printf '== case (x4): a SINGLE-commit record FAILs even when it equals HEAD ==\n'
+reset_stub
+# codex, round 5: a single-commit review covers ONE commit while prompt-content matches
+# PATHS, so when several commits touch the same file a review of only the last one
+# passes every path check. The sanctioned form always records a range.
+work=$(make_fixture case_x4 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_GIT_REF=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work"
+assert_verdict 'case (x4)' FAIL 1
+assert_says 'case (x4) the single-commit record is refused' '^sha-assert: FAIL \(single-commit record, not the census range\)$'
+assert_says 'case (x4) explains the same-file blind spot' 'when several commits touch the same file'
+
+printf '== case (x5): a MENTIONED path without a diff header does NOT count as covered ==\n'
+reset_stub
+# The substring form of this check was satisfied by any incidental mention — including
+# this wrapper quoting a path in a comment. Only a real `diff --git a/P b/P` header is
+# evidence the file's diff was sent.
+work=$(make_fixture case_x5 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_PROMPT='Review the branch. The wrapper mentions main.rs in prose but no diff is attached.'
+run_wrapper "$work"
+assert_verdict 'case (x5)' FAIL 1
+assert_says 'case (x5) a bare mention is not coverage' "^prompt-content: FAIL \(1/1 code census paths absent from the prompt\)\$"
+assert_says 'case (x5) the diff-header requirement is named' "have NO 'diff --git' header in the prompt"
+
+printf '== case (x6): the REAL codex review shape counts as a completed review ==\n'
+reset_stub
+# The previous allow-list was INVENTED and rejected a genuine codex review (measured on
+# the live probe): "## Review Findings" / "- **Severity**: Medium" / "## Summary".
+work=$(make_fixture case_x6 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_VERDICT_FIELD=F
+STUB_REVIEW_RC=1
+STUB_VERDICT=$'## Review Findings\n\n- **Severity**: Medium\n- **Location**: `scripts/flow/roborev-review.sh`\n- **Problem**: something\n- **Fix**: something else\n\n## Summary\n\nOne finding.'
+run_wrapper "$work"
+STUB_REVIEW_RC=0
+assert_says 'case (x6) the real shape is a completed review' '^review-completed: PASS$'
+assert_says 'case (x6) the **Severity** line is counted as a finding' '^findings: PRESENT \(1\)$'
+assert_says 'case (x6) it is reported as FINDINGS, not a malfunction' '^roborev-exit: FINDINGS \(exit 1\)$'
+
+if [ "$HAVE_PYTHON3" -eq 1 ]; then
+printf '== case (x7): a LIST payload whose job id differs is NOT used as a fallback ==\n'
+reset_stub
+# codex, round 5: the ID-less fallback used to return the first nested object carrying
+# git_ref, so a PREVIOUS review of the same range could falsely certify the new job.
+work=$(make_fixture case_x7 pushed)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse origin/main)
+STUB_PAYLOAD_JOB=999
+STUB_SHOW_JSON=none
+run_wrapper "$work"
+assert_verdict 'case (x7)' FAIL 1
+assert_says 'case (x7) the mismatched record was refused' '^job-record: DEGRADED'
+assert_says 'case (x7) sha-assert refuses to certify' '^sha-assert: FAIL \(job record unavailable — reviewed range unverifiable\)$'
 fi  # HAVE_PYTHON3
 
 printf '== case (w): a MISSING oracles file FAILs closed, never silently no-ops ==\n'

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -427,9 +427,18 @@ same board-only rehydration rule applies to worker sessions (see the supervisor 
 A fresh machine that will run the pipeline should first run
 `bash scripts/bootstrap-agent-machine.sh` (details in `docs/development/agent-machine-setup.md`): it
 verifies the gate accelerators (`sccache`, `cargo-nextest`, modern bash — issue #1848), the datasets +
-`CQLITE_DATASETS_ROOT`, `gh` auth + the `project` scope, and roborev's local config. **roborev follows the
-machine's configured agent** (commonly `codex` via `.roborev.toml`; no flags) — explicit `--agent`/`--model`
-is a per-machine troubleshooting override only, never doctrine.
+`CQLITE_DATASETS_ROOT`, `gh` auth + the `project` scope, and roborev's local config. **roborev is invoked
+ONLY through the fail-closed wrapper `bash scripts/flow/roborev-review.sh --agent <agent> --model <model>
+[--repo <abs-path>] [--base <ref>]`** (#2964) — fleet form `--agent codex --model gpt-5.6-sol`; the Claude
+reviewer is `--agent claude-code --model claude-opus-5`. **BOTH `--agent` and `--model` are ALWAYS
+required** (the wrapper rejects a missing one as a usage error; one alone inherits the mismatched
+`.roborev.toml`-pinned model and fails as a silent-looking review outage), and the branch must be **pushed
+first** — the wrapper asserts that and FAILs otherwise. A bare `roborev review --branch` and the
+two-positional commit-range form are **NON-SANCTIONED**: they can report clean having reviewed NOTHING, and
+a vacuous pass is textually identical to a genuine one. **Any** non-PASS terminal `RESULT` —
+`NOTHING-TO-REVIEW` included — is a failed review round and a blocked merge, never a clean pass. Verify
+which reviewer a box can actually serve with `roborev check-agents`; why:
+[roborev findings](/cqlite/agents-developing/roborev-findings/) + CLAUDE.md.
 
 ## Pipelining independent lanes (retro #1889)
 

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -433,9 +433,15 @@ ONLY through the fail-closed wrapper `bash scripts/flow/roborev-review.sh --agen
 reviewer is `--agent claude-code --model claude-opus-5`. **BOTH `--agent` and `--model` are ALWAYS
 required** (the wrapper rejects a missing one as a usage error; one alone inherits the mismatched
 `.roborev.toml`-pinned model and fails as a silent-looking review outage), and the branch must be **pushed
-first** — the wrapper asserts that and FAILs otherwise. A bare `roborev review --branch` and the
-two-positional commit-range form are **NON-SANCTIONED**: they can report clean having reviewed NOTHING, and
-a vacuous pass is textually identical to a genuine one. **Any** non-PASS terminal `RESULT` —
+first** — the wrapper asserts that and FAILs otherwise. Three direct-CLI forms are **NON-SANCTIONED**:
+`roborev review --branch` **without an explicit `--repo`** (from a worktree it resolves against the ROOT
+checkout), the two-positional commit-range form (its range base is git's empty tree), and a single-SHA
+review (it reviews **one commit, not the branch**). Each can report clean having reviewed NOTHING — or, for
+the single-SHA form, only the last commit — and a vacuous pass is textually identical to a genuine one.
+Measured: **`--repo` is what makes `--branch` correct**, so the wrapper reviews the RANGE `<base>..HEAD` and
+verifies BOTH endpoints against the job record (`reviewed-sha:` is a range, not a sha; `job-record:` reports
+the record's completeness). Note too that roborev excludes non-code paths from the diff it builds, so a
+docs-only diff cannot be roborev-certified at all. **Any** non-PASS terminal `RESULT` —
 `NOTHING-TO-REVIEW` included — is a failed review round and a blocked merge, never a clean pass. Verify
 which reviewer a box can actually serve with `roborev check-agents`; why:
 [roborev findings](/cqlite/agents-developing/roborev-findings/) + CLAUDE.md.

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -15,14 +15,15 @@ This mirrors the **Pre-roborev self-check** section in `CLAUDE.md`. Keep both in
 
 ## Which classes are mechanized in `--lite` (issue #2656)
 
-Two of these classes now FAIL in the fast `scripts/agent-gate.sh --lite` loop (component
-`roborev-lints`) — and the full gate — so you no longer spend a review round on them:
+Several of these delivery costs now FAIL in the fast `scripts/agent-gate.sh --lite` loop
+(component `roborev-lints`) — and the full gate — so you no longer spend a review round on them:
 
 | Class | Mechanized by | Where it runs |
 |-------|---------------|---------------|
 | GitHub Actions command injection | `scripts/ci/check-workflow-injection.sh` — flags an *attacker-controlled* `${{ }}` context (issue/PR title/body, `github.head_ref`, commit message, …) inlined into a `run:` shell | `roborev-lints` (`--lite` + full) |
 | clippy `manual_range_contains` | `cargo clippy -D warnings` | `clippy` (`--lite` + full) |
 | Wall-clock races in tests | `scripts/tests/check-no-wallclock-asserts.sh` (#2642) | `roborev-lints` (`--lite`) + `tooling-tests` (full) |
+| Vacuous roborev reviews (a "clean" verdict that reviewed nothing) | `scripts/tests/test_roborev_review_guard.sh` (#2964) — hermetic regression check over every vacuity trigger of `scripts/flow/roborev-review.sh` | `roborev-lints` (`--lite`) + `tooling-tests` (full) |
 
 The other classes below (integer/decimal overflow, float ordering, no-heuristics,
 process-global counters, gitignored references) are **not mechanized**: they are semantic
@@ -118,33 +119,96 @@ fresh `git worktree add --detach HEAD`, never the dirty tree.
 
 1. Before handing an issue off, diff your branch against `origin/main` and walk this list.
 2. Fix matches up front rather than waiting for roborev to flag them.
-3. Then run `scripts/agent-gate.sh` and request review as usual — see the
-   [gate contract](/cqlite/agents-developing/gate-contract/).
+3. Then run `scripts/agent-gate.sh` and request review through the sanctioned wrapper below — see
+   also the [gate contract](/cqlite/agents-developing/gate-contract/).
 
-## The reviewer default is codex — overriding it means BOTH agent and model
+## The only sanctioned invocation is `scripts/flow/roborev-review.sh` (issue #2964)
+
+```bash
+bash scripts/flow/roborev-review.sh --agent <agent> --model <model> \
+  [--repo <abs-path>] [--base <ref>] [--log <path>]
+```
+
+`--repo` defaults to the toplevel of `$PWD` resolved absolute; `--base` defaults to `origin/main`.
+Retain ONLY the wrapper's single `==== ROBOREV REVIEW SUMMARY ====` block — never the raw transcript,
+which is written to the `log:` path named in the block. That header is deliberately distinct from all
+three `AGENT-GATE *SUMMARY` blocks, so a review verdict can never be pasted as a gate verdict nor the
+reverse. Exit codes: `0` PASS, `1` FAIL, `3` NOTHING-TO-REVIEW, `2` usage error. **Any** non-PASS
+terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round and a blocked merge, never
+"roborev clean".
+
+### The four rules
+
+1. **The wrapper is the only sanctioned roborev invocation.** A bare
+   `roborev review --branch --base origin/main` is **NON-SANCTIONED**, and so is the two-positional
+   commit-range form (`roborev review <sha-a> <sha-b>`).
+2. **The reviewed SHA must be VERIFIED against branch HEAD.** The wrapper does this by parsing
+   `Enqueued job <N> for <sha>`; a mismatch aborts the round, and a mismatch that *equals the base ref*
+   is the signature of the worktree bug below. Also push first — an unpushed implementation commit is
+   itself an empty-diff cause, and the wrapper asserts the push and FAILs otherwise.
+3. **`"contains no code changes to review"` on a NON-EMPTY diff is a HARD FAIL**, never a pass. The
+   wrapper judges the reviewer's claim against a *locally computed* `git` diff census, so a reviewer
+   asserting the opposite of a census we measured ourselves has demonstrably not reviewed the change.
+4. **A docs-only (code-free) diff cannot be roborev-certified at all** — the wrapper fails it as
+   vacuous. The sanctioned substitute is primary-source verification recorded in the PR (for a docs
+   change describing the on-disk format, `git show cassandra-5.0.8:<path>`). **No docs-only change may
+   ever record "roborev clean."**
+
+### Why: a vacuous roborev pass is textually identical to a genuine clean pass
+
+Three confirmed trigger paths make roborev report clean **without having reviewed anything**, and at the
+top level ("No issues found") a vacuous verdict reads exactly like a real one:
+
+- **T1 — worktree + `--branch`.** Worktrees are not in `roborev repo list`, and `roborev repo` has no
+  `add` subcommand (repos self-register on first use), so `--branch` resolves against the **ROOT
+  checkout** — which normally sits on `main` — and enqueues the BASE commit. Observed: enqueued
+  `39900e4db` (= `origin/main`) while the branch HEAD was `4e7ab591e`; jobs 4649/4651/4653/4655/4657 all
+  enqueued `origin/main`.
+- **T2 — the commit-range form mis-enqueues.** `roborev review 89fdbb895 989d7d2c3` enqueued
+  `90a17d376` — **neither endpoint**.
+- **T3 — a code-free diff is silently discarded** even on a correctly targeted run: right SHA, right
+  `--repo`, and still *"No issues found. Summary: The provided diff contains no code changes to
+  review."* Reproducible (jobs 4658/4659). **This one passes the SHA check, so SHA verification alone is
+  insufficient** — hence rules 3 and 4.
+
+Token accounting is the tell: genuine reviews run 398k–649k input / 314k–554k cached / 5.0k–6.3k output
+over 2m25s–2m45s, while the vacuous baseline is 18.7k input / 0 cached / 53–56 output in 8s (a
+known-empty diff: 17,333 input / 21 output). The wrapper uses this only to **fail closed** — it can
+never turn a failure into a pass.
+
+The real cost, measured: on #2950 two vacuous runs "passed"; re-run correctly against the real SHA, the
+**same diff produced two real blockers** that would otherwise have shipped. Because 1:1:1:1 puts every
+issue in a worktree, and `flow-closer`'s final roborev pass is a **merge gate**, this could merge
+unreviewed code fleet-wide.
+
+### Live worktree probe (documented, not gate-run)
+
+The hermetic regression check cannot prove the real external binary honours `--repo`. From a real
+`issue-<N>-*` worktree whose commit is pushed, while the root checkout sits on `main`, run the wrapper
+and confirm the summary block shows `reviewed-sha` equal to the worktree branch's HEAD and **not** equal
+to `origin/main`. It stays out of the gate because it needs network and a live reviewer.
+
+## Pass BOTH agent and model — the wrapper requires it
 
 `.roborev.toml` on `main` pins `agent`/`review_agent = 'codex'` and
 `model`/`review_model = 'gpt-5.6-sol'`. That repo-local pin **overrides** whatever your global
-`~/.roborev/config.toml` sets, so it is the value that actually runs. The plain invocation therefore
-already runs codex, with no flags:
+`~/.roborev/config.toml` sets, so it is the value that actually runs — and worktrees inherit `main`'s
+pinned config. The wrapper therefore **requires both** options and treats one alone as a usage error
+(exit `2`), because supplying one alone silently inherits the other from that pin:
 
 ```bash
-roborev review --branch --base origin/main --wait
-```
+# codex (the repo default reviewer)
+bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol
 
-The trap is the reverse case. To run the **Claude** reviewer you must override **both** on the command
-line:
-
-```bash
-roborev review --branch --base origin/main --agent claude-code --model claude-opus-5 --wait
+# the Claude reviewer — override BOTH
+bash scripts/flow/roborev-review.sh --agent claude-code --model claude-opus-5
 ```
 
 `--agent claude-code` **alone** still inherits `review_model = 'gpt-5.6-sol'` from config — an OpenAI
 model name Claude cannot serve — which surfaces as a silent review failure that looks like a backend
 outage rather than a config mismatch. (Historically the pin ran the other way, and codex on a ChatGPT
 account rejected the inherited Anthropic name with a hard `400 'opus' model is not supported`; it is the
-same trap, mirrored.) Worktrees inherit `main`'s pinned config, so the explicit `--model` is the reliable
-override on every checkout.
+same trap, mirrored.) The explicit `--model` is the reliable override on every checkout.
 
 ### `gpt-5.6-sol` is codex's default, not a config pin
 
@@ -153,3 +217,17 @@ There is **no `~/.codex/config.toml`** on the worker boxes — `gpt-5.6-sol` is 
 upgrade, so a future codex version bump can silently move it again and leave `.roborev.toml` pinning a
 model the installed CLI no longer serves. Check what is actually in effect with `codex --version` and the
 model line in a bare `codex exec` header, rather than assuming a config file holds it.
+
+## Verifying an update to this page is actually published
+
+A green deploy plus an HTTP `200` proves the site is up, **not** that your change is live — the CDN can
+keep serving the previous page for roughly **3 minutes** after a successful deploy. Accept a doctrine
+publish by grepping the served page for a distinctive phrase the change introduced, and re-check after a
+wait if it is absent:
+
+```bash
+curl -sS https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/ \
+  | grep -c 'a vacuous roborev pass is textually identical'
+```
+
+A `0` means not-yet-published — never bank it as done.

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -142,15 +142,22 @@ terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round 
 1. **The wrapper is the only sanctioned roborev invocation.** A bare
    `roborev review --branch --base origin/main` is **NON-SANCTIONED**, and so is the two-positional
    commit-range form (`roborev review <sha-a> <sha-b>`).
-2. **The reviewed SHA must be VERIFIED against branch HEAD.** The wrapper does this by parsing
-   `Enqueued job <N> for <sha>`; a mismatch aborts the round, and a mismatch that *equals the base ref*
-   is the signature of the worktree bug below. Also push first — an unpushed implementation commit is
-   itself an empty-diff cause, and the wrapper asserts the push and FAILs otherwise.
+2. **The reviewed scope must be VERIFIED against branch HEAD.** The wrapper asserts it from the **job
+   record's structured fields** (read via `roborev list --json` / `roborev show --json` — e.g. the
+   full-sha `git_ref`), and treats the stdout `Enqueued job <N> for <sha>` announcement as a **demoted
+   cross-check** that still fails closed when it is absent or unparseable. A tool's structured record
+   is a stronger source than its human-readable prose — the same principle that moved the push assert
+   off the local `origin/<branch>` mirror ref onto `git ls-remote`. A reviewed scope that does not
+   match, or that *equals the base ref*, **aborts the round**; base-equality is the signature of the
+   worktree bug below. Also push first — an unpushed implementation commit is itself an empty-diff
+   cause, and the wrapper asserts the push and FAILs otherwise. Which fields are asserted is the
+   wrapper's business — see its `--help`.
 3. **`"contains no code changes to review"` on a NON-EMPTY diff is a HARD FAIL**, never a pass. The
    wrapper judges the reviewer's claim against a *locally computed* `git` diff census, so a reviewer
    asserting the opposite of a census we measured ourselves has demonstrably not reviewed the change.
-4. **A docs-only (code-free) diff cannot be roborev-certified at all** — the wrapper fails it as
-   vacuous. The sanctioned substitute is primary-source verification recorded in the PR (for a docs
+4. **A docs-only (code-free) diff cannot be roborev-certified at all** — the wrapper's deterministic
+   pre-enqueue `code-free:` check fails it before any review is enqueued, rather than matching reviewer
+   prose after the fact. The sanctioned substitute is primary-source verification recorded in the PR (for a docs
    change describing the on-disk format, `git show cassandra-5.0.8:<path>`). **No docs-only change may
    ever record "roborev clean."**
 

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -139,44 +139,65 @@ terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round 
 
 ### The four rules
 
-1. **The wrapper is the only sanctioned roborev invocation.** A bare
-   `roborev review --branch --base origin/main` is **NON-SANCTIONED**, and so is the two-positional
-   commit-range form (`roborev review <sha-a> <sha-b>`).
-2. **The reviewed scope must be VERIFIED against branch HEAD.** The wrapper asserts it from the **job
-   record's structured fields** (read via `roborev list --json` / `roborev show --json` — e.g. the
-   full-sha `git_ref`), and treats the stdout `Enqueued job <N> for <sha>` announcement as a **demoted
-   cross-check** that still fails closed when it is absent or unparseable. A tool's structured record
+1. **The wrapper is the only sanctioned roborev invocation.** Three direct-CLI forms are
+   **NON-SANCTIONED**: `--branch` **WITHOUT an explicit `--repo`** (from a worktree it resolves against the
+   ROOT checkout), the two-positional commit-range form (`roborev review <sha-a> <sha-b>`, whose range base
+   is git's EMPTY TREE), and a single-SHA review (`roborev review <sha>`, which **reviews ONE COMMIT, not
+   the branch**). Measured on a 17-commit branch with a 27-file census: `--branch --base <base> --repo
+   <abs>` delivered **5/5** census code files to the reviewer, the other two **3/5**. So `--repo` is what
+   makes `--branch` correct — the defect was always the missing `--repo`, never `--branch` itself — and the
+   wrapper invokes that range form.
+2. **The reviewed RANGE must be VERIFIED against `<base>...HEAD`.** The wrapper asserts **both endpoints**
+   from the **job record's structured fields** (read via `roborev list --json` / `roborev show --json`:
+   `git_ref` is `<base40>..<head40>`, reported in `reviewed-sha:` beside a `job-record:` completeness key),
+   and demotes the stdout `Enqueued job <N> for <sha>` announcement to the **carrier of the job id** — for
+   a range review it names only the range BASE, so when the record is unavailable the run FAILS rather than
+   falling back to prose that verifies nothing. A tool's structured record
    is a stronger source than its human-readable prose — the same principle that moved the push assert
-   off the local `origin/<branch>` mirror ref onto `git ls-remote`. A reviewed scope that does not
-   match, or that *equals the base ref*, **aborts the round**; base-equality is the signature of the
+   off the local `origin/<branch>` mirror ref onto `git ls-remote`. A range that does not match, a
+   **single-commit record even when it equals HEAD**, or a scope that *equals the base ref*, **aborts the
+   round**; base-equality is the signature of the
    worktree bug below. Also push first — an unpushed implementation commit is itself an empty-diff
    cause, and the wrapper asserts the push and FAILs otherwise. Which fields are asserted is the
    wrapper's business — see its `--help`.
 3. **`"contains no code changes to review"` on a NON-EMPTY diff is a HARD FAIL**, never a pass. The
    wrapper judges the reviewer's claim against a *locally computed* `git` diff census, so a reviewer
    asserting the opposite of a census we measured ourselves has demonstrably not reviewed the change.
-4. **A docs-only (code-free) diff cannot be roborev-certified at all** — the wrapper's deterministic
+4. **A docs-only (code-free) diff cannot be roborev-certified at all.** The mechanism is measured:
+   roborev **excludes non-code paths from the diff it builds** (of a 27-file census — 22 markdown, 5 code —
+   the prompt carried headers for exactly the 5 code files), so for a prose-only diff the constructed diff
+   is genuinely EMPTY and the verdict is a *truthful report of an empty input*, not a reviewer malfunction.
+   Re-running cannot help; the wrapper's deterministic
    pre-enqueue `code-free:` check fails it before any review is enqueued, rather than matching reviewer
-   prose after the fact. The sanctioned substitute is primary-source verification recorded in the PR (for a docs
+   prose after the fact. The same mechanism is why `prompt-content:` asserts the **CODE subset** of the
+   census — and why an unretrievable prompt is a `FAIL` there, never a passing `UNAVAILABLE`. The sanctioned substitute is primary-source verification recorded in the PR (for a docs
    change describing the on-disk format, `git show cassandra-5.0.8:<path>`). **No docs-only change may
    ever record "roborev clean."**
 
 ### Why: a vacuous roborev pass is textually identical to a genuine clean pass
 
-Three confirmed trigger paths make roborev report clean **without having reviewed anything**, and at the
-top level ("No issues found") a vacuous verdict reads exactly like a real one:
+**Four** confirmed trigger paths make roborev report clean **without having reviewed anything** (or having
+reviewed only part), and at the top level ("No issues found") a vacuous verdict reads exactly like a real
+one:
 
-- **T1 — worktree + `--branch`.** Worktrees are not in `roborev repo list`, and `roborev repo` has no
-  `add` subcommand (repos self-register on first use), so `--branch` resolves against the **ROOT
-  checkout** — which normally sits on `main` — and enqueues the BASE commit. Observed: enqueued
+- **T1 — worktree + `--branch` without `--repo`.** Worktrees are not in `roborev repo list`, and
+  `roborev repo` has no `add` subcommand (repos self-register on first use), so `--branch` resolves against
+  the **ROOT checkout** — which normally sits on `main` — and enqueues the BASE commit. Observed: enqueued
   `39900e4db` (= `origin/main`) while the branch HEAD was `4e7ab591e`; jobs 4649/4651/4653/4655/4657 all
-  enqueued `origin/main`.
-- **T2 — the commit-range form mis-enqueues.** `roborev review 89fdbb895 989d7d2c3` enqueued
-  `90a17d376` — **neither endpoint**.
+  enqueued `origin/main`. Adding an explicit `--repo <abs>` FIXES this form: it then reports "17 commits
+  since origin/main" and delivers every census code file — which is why the sanctioned invocation uses it.
+- **T2 — the two-positional commit-range form** anchors the reviewed range at git's **EMPTY-TREE** hash
+  (`4b825dc6…..<head40>`) rather than at the base you named, delivering 3 of 5 census code files.
 - **T3 — a code-free diff is silently discarded** even on a correctly targeted run: right SHA, right
   `--repo`, and still *"No issues found. Summary: The provided diff contains no code changes to
   review."* Reproducible (jobs 4658/4659). **This one passes the SHA check, so SHA verification alone is
-  insufficient** — hence rules 3 and 4.
+  insufficient** — hence rules 3 and 4. The mechanism is rule 4's: non-code paths never reach the
+  constructed diff, so there is genuinely nothing to review.
+- **T4 — a single-SHA review covers ONE COMMIT.** `roborev review <sha>` enqueues `git_ref = <head40>` —
+  *correct*, and still partial: 3 of 5 census code files reached the prompt on a 17-commit branch. Every
+  sha-equality check passes while the reviewer saw only the last commit, so this is a PARTIAL review
+  reported as a complete one, invisible to any SHA check. It is also the form #2964's own AC2 prescribed;
+  the wrapper implements that AC's *intent* — the reviewed content must match the requested range.
 
 Token accounting is the tell: genuine reviews run 398k–649k input / 314k–554k cached / 5.0k–6.3k output
 over 2m25s–2m45s, while the vacuous baseline is 18.7k input / 0 cached / 53–56 output in 8s (a
@@ -191,9 +212,13 @@ unreviewed code fleet-wide.
 ### Live worktree probe (documented, not gate-run)
 
 The hermetic regression check cannot prove the real external binary honours `--repo`. From a real
-`issue-<N>-*` worktree whose commit is pushed, while the root checkout sits on `main`, run the wrapper
-and confirm the summary block shows `reviewed-sha` equal to the worktree branch's HEAD and **not** equal
-to `origin/main`. It stays out of the gate because it needs network and a live reviewer.
+`issue-<N>-*` worktree whose commit is pushed, while the root checkout sits on `main`, run the wrapper and
+confirm the summary block's `sha-assert: PASS` beside a **`reviewed-sha:` RANGE** of the form
+`<base40>..<head40>` whose **HEAD endpoint is the worktree branch's HEAD** and whose base is `origin/main`.
+Because the sanctioned invocation reviews a range, `reviewed-sha` is **not** a bare sha — do not test it for
+equality with `head-sha`; compare the range's head endpoint. A `reviewed-sha` that is `origin/main` alone
+means the explicit `--repo` did not defeat the root-checkout resolution. It stays out of the gate because
+it needs network and a live reviewer, and it should be re-run after any roborev version bump.
 
 ## Pass BOTH agent and model — the wrapper requires it
 


### PR DESCRIPTION
Closes #2964.

## The problem

`roborev` could report `No issues found.` **without having reviewed anything**, and a vacuous pass is
**textually identical** to a genuine clean pass. Because 1:1:1:1 puts every issue in a worktree and
`flow-closer`'s final roborev pass is a **merge gate**, this class could merge unreviewed code fleet-wide.
Real cost already paid: on #2950 two vacuous runs "passed"; re-run correctly, the *same* diff produced **two
genuine blockers**.

## The fix

`roborev` is an external, unpatchable binary, so the guard is a **fail-closed wrapper** —
`scripts/flow/roborev-review.sh` — now the only sanctioned invocation. Its load-bearing idea: a
**locally-computed `git diff --numstat <base>...HEAD` census is the oracle**, and every claim the reviewer
makes is judged against it, never against the reviewer's own prose (which *is* the defect).

Architecture is **deterministic-primary**: `push-assert` → `census` → `code-free` → invoke → `job-record` →
`sha-assert` → `review-completed` → `prompt-content` → `vacuity-tier1` → `vacuity-tier2` → one
`==== ROBOREV REVIEW SUMMARY ====` block. Exit `0` PASS / `1` FAIL / `3` NOTHING-TO-REVIEW / `2` usage error.

## Four vacuity triggers, all measured

The issue described three. **The wrapper's own live probe found a fourth**, and measurement narrowed or
corrected two of the original three:

| # | Trigger | Measured mechanism | Caught by |
|---|---|---|---|
| T1 | `--branch` **without `--repo`** from a worktree | resolves against the ROOT checkout (worktrees unregistered; `roborev repo` has no `add`) → reviews the BASE commit | `sha-assert` |
| T2 | two-positional range form | bases the diff on git's **EMPTY-TREE** hash `4b825dc6…`, not the range | `sha-assert` |
| T3 | code-free (docs-only) diff | roborev **omits non-code paths from the diff it builds** — 22 markdown files absent from the prompt, only the 5 code files present → the input is genuinely EMPTY | `code-free` (pre-enqueue, deterministic) |
| T4 | **single-SHA form** (new) | reviews **ONE COMMIT, not the branch** — a partial review reported as complete | `prompt-content` |

**Divergence from AC2, stated openly:** the issue's AC2 literally prescribes the single-SHA form, which is T4.
We implemented AC2's **intent** — the reviewed content must match the requested range — not its letter. The
sanctioned form is now `--branch --base <base> --repo <abs>`. Measured matrix:

| form | enqueued `git_ref` | code files in prompt |
|---|---|---|
| `--branch --base <base> --repo <abs>` | `<base40>..<head40>` | **5/5** ✅ sanctioned |
| `--since <base> --repo <abs>` | `<base40>..<head40>` | 5/5 (identical prompt) |
| two positionals | **empty-tree**`..<head40>` | 3/5 ❌ |
| single `<sha>` | `<head40>` | 3/5 ⚠️ one commit |

Consequently the doctrine rule is **"`--branch` without an explicit `--repo` is non-sanctioned"**, not "bare
`--branch` is non-sanctioned" — the old absolute wording would forbid the form we now run.

## Verification

- **332 hermetic assertions**, 0 failed. No network, no live reviewer, no datasets — a stub `roborev` replays
  measured real outputs against throwaway git fixtures.
- **Mutation-verified, which is the evidence that matters.** An early suite passed **90/90 while 10 of 11
  mutants survived** — i.e. most asserts were unconstrained. Now every check has a killing test: 27/27 then
  15/15 across the final rounds. One mutant *survived* a 324-case run; rather than re-run, the cause was
  diagnosed (an existing case never exercised the nested-record path) and a case replaying the measured real
  shape was added to kill it.
- `shellcheck` 0.10.0 with `-x` at **info** level: **0 findings** across all four shell files. It had never run
  on this code before.
- Gate wired into **`roborev-lints`** (in `LITE_COMPONENTS`, so a regression fails the *fast* loop per AC5) and
  **`tooling-tests`** (full gate).
- **AC5 live evidence** (real daemon, roborev v0.61.2, codex/`gpt-5.6-sol`), from inside a worktree while the
  root sat on `main`: `reviewed-sha: f603c7f..81d9b57` · `push-assert/census-check/code-free/job-record/
  sha-assert/review-completed: PASS` · `prompt-content: PASS (5/5 code census paths present)` ·
  `vacuity-tier2: PASS` (`input=192613 cached=126464 output=6110`) · `vacuity-tier1: NOTICE` (correctly
  advisory on a findings-bearing review that *discusses* the phrase). Full range reviewed, worktree HEAD
  covered, not the base.

## Blockers found and fixed (each was reproduced, not theorised)

An adversarial review plus seven live-probe rounds found these. Listing them because the history is the
justification for each check:

- **The wrapper reported `PASS` for a review that never completed** — an unfinished job, a
  `400 model not supported` outage, and a provider timeout all passed, because *absence of a phrase* was
  treated as proof a review happened. → `review-completed:` now requires **positive** evidence.
- **Tier 1 matched only lines *containing* `Summary:`**, so a vacuous clean review whose "no code changes"
  sentence sat under a `## Summary` **heading** reported `PASS`. The exact defect this change exists to stop,
  alive inside the guard. → region is the whole summary block.
- **A docs-only census could PASS**, violating this change's own spec: the code-free oracle was *computed and
  discarded*, used only for attribution prose. → deterministic pre-enqueue FAIL.
- **Tier 2 had never once fired.** `token_usage` is a JSON-encoded **string** needing a double decode, and the
  field is `total_output_tokens` — a guard that silently wasn't there. → fixed; drift (present-but-unparseable)
  now FAILs.
- **`push-assert` read the local `origin/<branch>` mirror ref**, which this fleet's **narrow fetch refspec**
  (`+refs/heads/main:refs/remotes/origin/main`) never creates — so it failed **100% of the time**. The guard
  committed the very error class it guards against: trusting a local proxy over the authoritative source. →
  `git ls-remote`, mirror fast path removed entirely.
- **Rename handling false-REJECTED every review containing a detected rename** (census `--no-renames` → two
  paths; reviewer diff may have detection on → one header). → both header sides compared.
- **An unretrievable prompt passed** with no evidence any diff was delivered. → FAILs.
- **The wrapper misdiagnosed a healthy review as broken** — roborev exits non-zero *when it reports findings*,
  and the message told operators the reviewer malfunctioned. Dangerous in the opposite direction: an agent told
  the reviewer broke will retry or bypass instead of **fixing the findings**. → `FINDINGS` vs `ERROR` split.

Calibration corrected with evidence: the output-token floor was **dropped** as a FAIL condition, because a
genuine *clean* review and a vacuous one emit nearly identical output counts (both are just "No issues found.
Summary: …") — it would false-FAIL precisely the case we care most about. Input floor re-anchored 50000 →
**25000** on the measured vacuous ceiling (18,801) vs a measured small genuine run (**67,387**); the issue's
original 398k–649k band came from much larger diffs.

Throughout, false FAILs were treated as seriously as false PASSes: **an always-red guard gets bypassed, and a
bypassed guard is worse than none.** That is why tier 1 is gated on `findings:` rather than merely
better-anonymised, and why a model substitution is a NOTICE rather than a FAIL.

## Doctrine + surfaces

Per repo rule, doctrine ships in the same change: **CLAUDE.md** and the published
**`agents-developing/roborev-findings`** page carry the four rules; **16 surfaces** route through the wrapper.
Two pre-existing contradictions fixed in passing: the published `delivery-pipeline.md` called explicit
`--agent`/`--model` **"never doctrine"** (the exact inverse of CLAUDE.md), and `.claude/commands/worker.md` —
the fleet's *unattended entry point* — told every box to run with **"no flags"**.

## Also filed

- **#3126** + **kenn-io/roborev#1011** — the upstream defects, with one item I filed and then **retracted**
  after verifying I had misdiagnosed it (the job fields were nested under a `job` key, not written
  asynchronously). Same error class as the bug itself: asserting a mechanism from an observation without
  checking the authoritative source. The retraction, and the measured mechanisms, are on the upstream issue.
- **#3133** — batched nits (none can cause a vacuous PASS).

## Gate

Full `scripts/agent-gate.sh` — the ONE gate of record — runs in `flow-closer` immediately pre-merge, followed
by the **C** intent audit against `openspec/changes/roborev-vacuous-review-guard/` (`openspec validate
--strict` clean; the AC2 divergence is recorded in the spec so the audit sees it reasoned, not hidden) and a
final roborev confirmation pass **through the wrapper itself**.
