### PR TITLE
fix(3154): only a merger-ineligible input earns the non-reconciling concat fallback

### DIFF
--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -97,6 +97,40 @@
 //! * `cqlite-flight` enables the feature from its `[dev-dependencies]` (the same
 //!   convention `arrow-shape-corpus` / `test-util` already use), so the shipped
 //!   Flight binary never links it.
+//!
+//! # One seam injects an `Err`, not a panic (issue #3154)
+//!
+//! [`arm_merge_construction_error`] (child module [`construction`]) makes
+//! `KWayMerger::new` REPORT a chosen error variant on the cross-generation merge
+//! path, which is what proves the narrowed fallback classification: an I/O or
+//! corruption failure must propagate, while a merger-ineligible unsupported-format
+//! failure must still degrade to the documented concat. See that module's doc.
+
+/// The `Err`-reporting construction seam (issue #3154), in a child module so this
+/// file stays under the ~800-line campsite target (epic #1116).
+///
+/// Gated to exactly where the seam it injures EXISTS —
+/// `generation_merge::stream_generations_for_read` is `write-support` AND
+/// `not(tombstones)` (a `tombstones` build routes `scan_stream` through the
+/// materializing `scan`, which has no `MergeStreamSetupError` at all) — for the same
+/// reason [`ScanTaskSite::CrossGenerationMerge`] is: a symbol that nothing in a
+/// configuration can ever reach would be a lie about that configuration's coverage,
+/// and `#[allow(dead_code)]` would hide it instead of stating it.
+#[cfg(all(
+    any(test, feature = "producer-fault-injection"),
+    feature = "write-support",
+    not(feature = "tombstones")
+))]
+mod construction;
+#[cfg(all(
+    any(test, feature = "producer-fault-injection"),
+    feature = "write-support",
+    not(feature = "tombstones")
+))]
+pub use construction::{
+    arm_merge_construction_error, ArmedMergeConstructionError, MergeConstructionFault,
+    INJECTED_CONSTRUCTION_MESSAGE,
+};
 
 /// Producer-fault state captured ONCE when a query row stream is opened, then
 /// owned by that stream's producer thread.
@@ -353,6 +387,39 @@ impl FaultScope {
     }
 }
 
+/// The `Err`-reporting construction seam's take side (issue #3154).
+///
+/// Gated to the one configuration whose call site exists — the cross-generation
+/// reconciling merge's construction window in
+/// `generation_merge::stream_generations_for_read` — so no build carries a method
+/// nothing can reach (see [`construction`]'s `mod` declaration above).
+#[cfg(all(feature = "write-support", not(feature = "tombstones")))]
+impl FaultScope {
+    /// The construction error a test armed for this scope, if any — i.e. the error
+    /// `KWayMerger::new` is made to report instead of building the merger.
+    ///
+    /// ALWAYS `None` in a production build, where [`Self::armed_construction_error`]
+    /// is a function that returns `None` without touching (or even compiling) any
+    /// registry.
+    #[inline]
+    pub(crate) fn injected_construction_error(&self) -> Option<crate::Error> {
+        self.armed_construction_error()
+    }
+
+    #[cfg(any(test, feature = "producer-fault-injection"))]
+    #[inline]
+    fn armed_construction_error(&self) -> Option<crate::Error> {
+        construction::take(&self.path.to_string_lossy())
+    }
+
+    /// Production build: nothing can be armed, so there is nothing to take.
+    #[cfg(not(any(test, feature = "producer-fault-injection")))]
+    #[inline]
+    fn armed_construction_error(&self) -> Option<crate::Error> {
+        None
+    }
+}
+
 /// The panic message both checkpoints raise. Exported so a test can (a) assert
 /// the forwarded error carries it and (b) suppress exactly this panic in its
 /// panic hook without silencing a real one.
@@ -411,7 +478,10 @@ mod armed {
     /// own registration.
     static NEXT_ARM_ID: AtomicU64 = AtomicU64::new(0);
 
-    fn next_id() -> u64 {
+    /// `pub(super)` so the sibling [`construction`](super::construction) registry
+    /// shares ONE id space with these three, rather than minting a second counter
+    /// whose ids could collide with theirs in a debugger or a log.
+    pub(super) fn next_id() -> u64 {
         NEXT_ARM_ID.fetch_add(1, Ordering::SeqCst)
     }
 
@@ -426,8 +496,10 @@ mod armed {
     /// order of magnitude.
     const MIN_SCOPE_LEN: usize = 8;
 
-    /// Fail LOUDLY on a scope that would match everything.
-    fn check_scope(scope: &str) {
+    /// Fail LOUDLY on a scope that would match everything. `pub(super)` so every
+    /// registry — including the sibling [`construction`](super::construction) one —
+    /// enforces the SAME minimum rather than re-deriving it.
+    pub(super) fn check_scope(scope: &str) {
         debug_assert!(
             scope.len() >= MIN_SCOPE_LEN,
             "producer-fault scope {scope:?} is shorter than {MIN_SCOPE_LEN} chars: a \

--- a/cqlite-core/src/storage/producer_fault.rs
+++ b/cqlite-core/src/storage/producer_fault.rs
@@ -100,22 +100,20 @@
 //!
 //! # One seam injects an `Err`, not a panic (issue #3154)
 //!
-//! [`arm_merge_construction_error`] (child module [`construction`]) makes
+//! [`arm_merge_construction_error`] (child module `construction`) makes
 //! `KWayMerger::new` REPORT a chosen error variant on the cross-generation merge
-//! path, which is what proves the narrowed fallback classification: an I/O or
-//! corruption failure must propagate, while a merger-ineligible unsupported-format
-//! failure must still degrade to the documented concat. See that module's doc.
+//! path, proving the narrowed fallback classification: an I/O or corruption failure
+//! must propagate, while a merger-ineligible unsupported-format failure must still
+//! degrade to the documented concat. See that module's doc.
 
 /// The `Err`-reporting construction seam (issue #3154), in a child module so this
 /// file stays under the ~800-line campsite target (epic #1116).
 ///
 /// Gated to exactly where the seam it injures EXISTS —
 /// `generation_merge::stream_generations_for_read` is `write-support` AND
-/// `not(tombstones)` (a `tombstones` build routes `scan_stream` through the
-/// materializing `scan`, which has no `MergeStreamSetupError` at all) — for the same
-/// reason [`ScanTaskSite::CrossGenerationMerge`] is: a symbol that nothing in a
-/// configuration can ever reach would be a lie about that configuration's coverage,
-/// and `#[allow(dead_code)]` would hide it instead of stating it.
+/// `not(tombstones)` — for the same reason [`ScanTaskSite::CrossGenerationMerge`] is:
+/// a symbol nothing in a configuration can reach would be a lie about that
+/// configuration's coverage, and `#[allow(dead_code)]` would hide it, not state it.
 #[cfg(all(
     any(test, feature = "producer-fault-injection"),
     feature = "write-support",
@@ -387,35 +385,20 @@ impl FaultScope {
     }
 }
 
-/// The `Err`-reporting construction seam's take side (issue #3154).
-///
-/// Gated to the one configuration whose call site exists — the cross-generation
-/// reconciling merge's construction window in
-/// `generation_merge::stream_generations_for_read` — so no build carries a method
-/// nothing can reach (see [`construction`]'s `mod` declaration above).
+/// The `Err`-reporting construction seam's take side (issue #3154), gated to the one
+/// configuration whose call site exists — the cross-generation reconciling merge's
+/// construction window in `generation_merge::stream_generations_for_read` — so no
+/// build carries a method nothing can reach (see the `mod construction` doc above).
 #[cfg(all(feature = "write-support", not(feature = "tombstones")))]
 impl FaultScope {
     /// The construction error a test armed for this scope, if any — i.e. the error
-    /// `KWayMerger::new` is made to report instead of building the merger.
-    ///
-    /// ALWAYS `None` in a production build, where [`Self::armed_construction_error`]
-    /// is a function that returns `None` without touching (or even compiling) any
-    /// registry.
+    /// `KWayMerger::new` is made to report instead of building the merger. ALWAYS
+    /// `None` in a production build, which compiles no registry to consult.
     #[inline]
     pub(crate) fn injected_construction_error(&self) -> Option<crate::Error> {
-        self.armed_construction_error()
-    }
-
-    #[cfg(any(test, feature = "producer-fault-injection"))]
-    #[inline]
-    fn armed_construction_error(&self) -> Option<crate::Error> {
-        construction::take(&self.path.to_string_lossy())
-    }
-
-    /// Production build: nothing can be armed, so there is nothing to take.
-    #[cfg(not(any(test, feature = "producer-fault-injection")))]
-    #[inline]
-    fn armed_construction_error(&self) -> Option<crate::Error> {
+        #[cfg(any(test, feature = "producer-fault-injection"))]
+        return construction::take(&self.path.to_string_lossy());
+        #[cfg(not(any(test, feature = "producer-fault-injection")))]
         None
     }
 }
@@ -751,77 +734,13 @@ impl Drop for ArmedMergeProducerPanic {
     }
 }
 
-/// A boxed panic hook, as [`std::panic::set_hook`] takes it.
+/// Panic-hook silencing, in a child module so this file stays under the ~800-line
+/// campsite target (epic #1116). Re-exported here so every caller keeps the
+/// `producer_fault::silence_injected_panics` path it already uses.
 #[cfg(any(test, feature = "producer-fault-injection"))]
-type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
-
-/// Suppress the console noise of the INJECTED panic — and only that one — for the
-/// returned guard's lifetime.
-///
-/// Deliberately NOT a blanket `set_hook(|_| {})`: the panic hook is
-/// process-global, so silencing everything would swallow a genuine assertion
-/// failure message from this test or any test running in parallel, exactly the
-/// "masked assertion" failure mode. Panics whose payload does not carry
-/// [`INJECTED_PANIC_MESSAGE`] are delegated to the hook that was installed
-/// before (libtest's capture hook, normally), and that hook is reinstated when
-/// this guard drops — EXCEPT on an unwinding drop, where restoring is skipped
-/// (see [`SilencedInjectedPanics::drop`]).
+mod silence;
 #[cfg(any(test, feature = "producer-fault-injection"))]
-#[must_use = "the injected panic is only silenced while the guard is alive"]
-pub fn silence_injected_panics() -> SilencedInjectedPanics {
-    let previous: std::sync::Arc<PanicHook> = std::sync::Arc::new(std::panic::take_hook());
-    let installed = previous.clone();
-    std::panic::set_hook(Box::new(move |info| {
-        if is_injected(info) {
-            return;
-        }
-        installed(info);
-    }));
-    SilencedInjectedPanics { previous }
-}
-
-/// Whether `info` describes an injected fault panic. Matched on the payload
-/// STRING, so no real panic is ever swallowed.
-#[cfg(any(test, feature = "producer-fault-injection"))]
-fn is_injected(info: &std::panic::PanicHookInfo<'_>) -> bool {
-    let payload = info.payload();
-    let message = payload
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| payload.downcast_ref::<&'static str>().copied());
-    message.is_some_and(|m| m.contains(INJECTED_PANIC_MESSAGE))
-}
-
-/// Guard returned by [`silence_injected_panics`]; restores the previous hook on a
-/// normal drop (see [`Self::drop`] for the unwinding case).
-#[cfg(any(test, feature = "producer-fault-injection"))]
-pub struct SilencedInjectedPanics {
-    previous: std::sync::Arc<PanicHook>,
-}
-
-#[cfg(any(test, feature = "producer-fault-injection"))]
-impl Drop for SilencedInjectedPanics {
-    fn drop(&mut self) {
-        // NEVER touch the hook while unwinding (roborev, issue #3106):
-        // `std::panic::set_hook` PANICS if called from a panicking thread, so a
-        // guard still alive when an assertion (or any fallible call inside the
-        // silenced block) fails would double-panic and ABORT the process — under
-        // libtest's capture that loses the original message entirely and, in an
-        // integration-test binary, takes every sibling test's result with it.
-        // Skipping the restore leaves the filtering hook installed for the rest of
-        // the process, which is harmless: it only ever suppresses
-        // `INJECTED_PANIC_MESSAGE` and delegates everything else.
-        if std::thread::panicking() {
-            return;
-        }
-        // `set_hook` needs an owned `Box`, and the previous hook is behind an
-        // `Arc` (it is borrowed by the filtering hook installed above), so it is
-        // reinstated through one thin delegating wrapper. Behaviourally identical;
-        // the only cost is a pointer hop per nested guard.
-        let previous = self.previous.clone();
-        std::panic::set_hook(Box::new(move |info| previous(info)));
-    }
-}
+pub use silence::{silence_injected_panics, SilencedInjectedPanics};
 
 // Unit tests in a `*_tests.rs` sibling so this file stays under the ~800-line
 // campsite target (epic #1116 / #1135) — see that file's header.

--- a/cqlite-core/src/storage/producer_fault/construction.rs
+++ b/cqlite-core/src/storage/producer_fault/construction.rs
@@ -69,9 +69,9 @@ impl MergeConstructionFault {
             Self::Io => Error::Io(std::io::Error::other(format!(
                 "{INJECTED_CONSTRUCTION_MESSAGE} (io)"
             ))),
-            Self::Corruption => Error::corruption(format!(
-                "{INJECTED_CONSTRUCTION_MESSAGE} (corrupt input)"
-            )),
+            Self::Corruption => {
+                Error::corruption(format!("{INJECTED_CONSTRUCTION_MESSAGE} (corrupt input)"))
+            }
             Self::UnsupportedFormat => Error::unsupported_format(format!(
                 "{INJECTED_CONSTRUCTION_MESSAGE} (merger-ineligible input)"
             )),

--- a/cqlite-core/src/storage/producer_fault/construction.rs
+++ b/cqlite-core/src/storage/producer_fault/construction.rs
@@ -1,0 +1,225 @@
+//! TEST-ONLY injection of a `KWayMerger::new` CONSTRUCTION FAILURE on the
+//! cross-generation reconciling merge path (issue #3154).
+//!
+//! # Why this is an ERROR seam, not a panic seam
+//!
+//! Every other arm in [`super`] injects a PANIC, because the defects those seams
+//! prove are about a producer that DIES (issues #3106/#3120/#3124). This one injects
+//! a REPORTED `Err`: the defect is that `generation_merge::stream_generations_for_read`
+//! labelled EVERY error out of `KWayMerger::new` as fallback-eligible, so a transient
+//! I/O hiccup or a corrupt input made `SSTableManager::scan_stream` silently
+//! substitute the NON-reconciling token-order concat and return a FULL-LENGTH,
+//! UNRECONCILED result set under `Ok` — duplicated overwritten rows and resurrected
+//! deleted rows, behind a `tracing::warn!`.
+//!
+//! Proving the narrowed classification therefore needs `KWayMerger::new` to report a
+//! CHOSEN error VARIANT, deterministically: an I/O error and a corruption error must
+//! propagate, while the genuinely merger-ineligible unsupported-format error must
+//! still degrade to the concat exactly as before (over-restricting is its own
+//! regression). No on-disk fixture can produce all three at that one call site on
+//! demand, and none of them can be produced at all without racing a real filesystem.
+//!
+//! # Same structural safety properties as its panic siblings
+//!
+//! * Its own registry, separate from the outer/task/merge ones, so a construction arm
+//!   can neither consume nor be consumed by another seam's arm.
+//! * A `Vec` of arms, each SCOPED to a `Data.db` path substring and TAKEN by the first
+//!   matching merge, so concurrently armed tests in the shared lib test binary cannot
+//!   steal one another's fault (see [`super`]'s module doc).
+//! * Nothing here exists in a production build: the module is `cfg`'d out entirely,
+//!   and the one production-side consumer
+//!   ([`FaultScope::injected_construction_error`](super::FaultScope::injected_construction_error))
+//!   compiles to a function that returns `None` without touching any registry. No
+//!   environment variable, config field or on-disk byte pattern can arm it, so it
+//!   cannot influence a decoding decision (issue #28).
+
+use parking_lot::Mutex;
+
+use crate::Error;
+
+/// Which typed `KWayMerger::new` failure to make the cross-generation merge report.
+///
+/// The three variants are exactly the three classes issue #3154's acceptance criteria
+/// distinguish: two that MUST propagate and one that MUST still fall back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeConstructionFault {
+    /// A transient I/O failure ([`Error::Io`]) — a runtime failure that says nothing
+    /// about whether the reconciling merger supports this input, so it must NOT be
+    /// answered with the concat.
+    Io,
+    /// A corrupt / unparseable input ([`Error::Corruption`]) — likewise a runtime
+    /// failure, and answering it with the concat would serve wrong data from a file
+    /// that is already known to be bad.
+    Corruption,
+    /// The genuinely merger-INELIGIBLE condition ([`Error::UnsupportedFormat`]): an
+    /// input the reconciling merger cannot handle at all, which is the one case the
+    /// documented Issue #883 concat fallback exists to serve.
+    UnsupportedFormat,
+}
+
+/// The message every injected construction error carries, so a test can prove THIS
+/// fault (rather than some unrelated failure) is what the read reported.
+pub const INJECTED_CONSTRUCTION_MESSAGE: &str =
+    "cqlite test fault injection (issue #3154): merge construction failure";
+
+impl MergeConstructionFault {
+    /// The error `KWayMerger::new` is made to return for this fault.
+    fn into_error(self) -> Error {
+        match self {
+            Self::Io => Error::Io(std::io::Error::other(format!(
+                "{INJECTED_CONSTRUCTION_MESSAGE} (io)"
+            ))),
+            Self::Corruption => Error::corruption(format!(
+                "{INJECTED_CONSTRUCTION_MESSAGE} (corrupt input)"
+            )),
+            Self::UnsupportedFormat => Error::unsupported_format(format!(
+                "{INJECTED_CONSTRUCTION_MESSAGE} (merger-ineligible input)"
+            )),
+        }
+    }
+}
+
+/// One registered CONSTRUCTION arm.
+struct ConstructionArm {
+    id: u64,
+    scope: String,
+    fault: MergeConstructionFault,
+}
+
+/// Registered arms — a `Vec`, not a slot, for the same reason as every sibling
+/// registry: two concurrently armed tests must coexist without clobbering each other.
+/// The critical sections below are a few comparisons long and never span an `.await`.
+static CONSTRUCTION_ARMS: Mutex<Vec<ConstructionArm>> = Mutex::new(Vec::new());
+
+/// Arm the next cross-generation reconciling merge over an input whose `Data.db` path
+/// contains `scope` to have its `KWayMerger::new` report `fault` instead of building.
+///
+/// Disarmed when the returned guard drops, and TAKEN by the first MATCHING merge — a
+/// merge over any other table leaves it registered, so a concurrently-running test can
+/// neither consume nor clobber it. Scope to something unique: the test's own `TempDir`
+/// path, or `keyspace/table`.
+///
+/// TEST-ONLY: this symbol does not exist unless (`cfg(test)` or the
+/// `producer-fault-injection` feature) AND `write-support` AND not `tombstones` — the
+/// seam it injures exists in exactly that configuration (see the `mod construction`
+/// declaration in [`super`]).
+#[must_use = "the fault stays armed only while the guard is alive"]
+pub fn arm_merge_construction_error(
+    scope: &str,
+    fault: MergeConstructionFault,
+) -> ArmedMergeConstructionError {
+    super::armed::check_scope(scope);
+    let id = super::armed::next_id();
+    CONSTRUCTION_ARMS.lock().push(ConstructionArm {
+        id,
+        scope: scope.to_string(),
+        fault,
+    });
+    ArmedMergeConstructionError { id }
+}
+
+/// Guard returned by [`arm_merge_construction_error`]: removes its OWN arm (by id) on
+/// drop. Holds no lock, so it is safe to hold across an `.await`.
+#[derive(Debug)]
+pub struct ArmedMergeConstructionError {
+    id: u64,
+}
+
+impl Drop for ArmedMergeConstructionError {
+    fn drop(&mut self) {
+        CONSTRUCTION_ARMS.lock().retain(|arm| arm.id != self.id);
+    }
+}
+
+/// TAKE the arm scoped to this merge's input path, if any, and build its error. A
+/// non-matching path leaves every arm registered, which is what makes a foreign merge
+/// unable to consume someone else's arm.
+pub(super) fn take(path: &str) -> Option<Error> {
+    let fault = {
+        let mut arms = CONSTRUCTION_ARMS.lock();
+        let index = arms
+            .iter()
+            .position(|arm| path.contains(arm.scope.as_str()))?;
+        arms.remove(index).fault
+    };
+    Some(fault.into_error())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The injected errors must carry the VARIANTS the classification under test keys
+    /// on — if this seam handed back, say, `Error::Storage` for `Io`, every end-to-end
+    /// test built on it would be proving the wrong classification.
+    #[test]
+    fn each_fault_injects_its_own_error_variant_and_names_itself() {
+        for (fault, matched) in [
+            (
+                MergeConstructionFault::Io,
+                matches!(MergeConstructionFault::Io.into_error(), Error::Io(_)),
+            ),
+            (
+                MergeConstructionFault::Corruption,
+                matches!(
+                    MergeConstructionFault::Corruption.into_error(),
+                    Error::Corruption(_)
+                ),
+            ),
+            (
+                MergeConstructionFault::UnsupportedFormat,
+                matches!(
+                    MergeConstructionFault::UnsupportedFormat.into_error(),
+                    Error::UnsupportedFormat(_)
+                ),
+            ),
+        ] {
+            assert!(matched, "{fault:?} injected the wrong Error variant");
+            assert!(
+                fault
+                    .into_error()
+                    .to_string()
+                    .contains(INJECTED_CONSTRUCTION_MESSAGE),
+                "{fault:?}: the injected error must name itself so a test can prove \
+                 THIS fault ended the read"
+            );
+        }
+    }
+
+    /// A scan whose path does not match leaves the arm registered (no cross-test
+    /// consumption), and a matching one takes it exactly once.
+    #[test]
+    fn an_arm_is_scoped_and_taken_exactly_once() {
+        let scope = "issue-3154-scoped-take-probe";
+        let _armed = arm_merge_construction_error(scope, MergeConstructionFault::Io);
+
+        assert!(
+            take("/some/other/table/nb-1-big-Data.db").is_none(),
+            "a merge over an unrelated input must not consume this arm"
+        );
+        assert!(
+            take(&format!("/tmp/{scope}/data/nb-1-big-Data.db")).is_some(),
+            "the matching merge must take the arm"
+        );
+        assert!(
+            take(&format!("/tmp/{scope}/data/nb-2-big-Data.db")).is_none(),
+            "the arm must be taken exactly once, so a retry is not hit by it again"
+        );
+    }
+
+    /// The guard removes its own registration, so an armed-but-never-matched fault
+    /// cannot leak into a later test in the shared lib test binary.
+    #[test]
+    fn dropping_the_guard_disarms() {
+        let scope = "issue-3154-disarm-probe";
+        let path = format!("/tmp/{scope}/data/nb-1-big-Data.db");
+        drop(arm_merge_construction_error(
+            scope,
+            MergeConstructionFault::Corruption,
+        ));
+        assert!(
+            take(&path).is_none(),
+            "a dropped guard must leave nothing armed"
+        );
+    }
+}

--- a/cqlite-core/src/storage/producer_fault/silence.rs
+++ b/cqlite-core/src/storage/producer_fault/silence.rs
@@ -1,0 +1,74 @@
+//! Panic-hook silencing for the injected faults (issues #3106/#3124), split out of
+//! [`super`] so that file stays under the ~800-line campsite target (epic #1116).
+//!
+//! The whole module is gated by its `mod` declaration in [`super`] — it exists only
+//! where a fault can be armed at all — so no item below repeats that `cfg`.
+
+use super::INJECTED_PANIC_MESSAGE;
+
+/// A boxed panic hook, as [`std::panic::set_hook`] takes it.
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+/// Suppress the console noise of the INJECTED panic — and only that one — for the
+/// returned guard's lifetime.
+///
+/// Deliberately NOT a blanket `set_hook(|_| {})`: the panic hook is
+/// process-global, so silencing everything would swallow a genuine assertion
+/// failure message from this test or any test running in parallel, exactly the
+/// "masked assertion" failure mode. Panics whose payload does not carry
+/// [`INJECTED_PANIC_MESSAGE`] are delegated to the hook that was installed
+/// before (libtest's capture hook, normally), and that hook is reinstated when
+/// this guard drops — EXCEPT on an unwinding drop, where restoring is skipped
+/// (see [`SilencedInjectedPanics::drop`]).
+#[must_use = "the injected panic is only silenced while the guard is alive"]
+pub fn silence_injected_panics() -> SilencedInjectedPanics {
+    let previous: std::sync::Arc<PanicHook> = std::sync::Arc::new(std::panic::take_hook());
+    let installed = previous.clone();
+    std::panic::set_hook(Box::new(move |info| {
+        if is_injected(info) {
+            return;
+        }
+        installed(info);
+    }));
+    SilencedInjectedPanics { previous }
+}
+
+/// Whether `info` describes an injected fault panic. Matched on the payload
+/// STRING, so no real panic is ever swallowed.
+fn is_injected(info: &std::panic::PanicHookInfo<'_>) -> bool {
+    let payload = info.payload();
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&'static str>().copied());
+    message.is_some_and(|m| m.contains(INJECTED_PANIC_MESSAGE))
+}
+
+/// Guard returned by [`silence_injected_panics`]; restores the previous hook on a
+/// normal drop (see [`Self::drop`] for the unwinding case).
+pub struct SilencedInjectedPanics {
+    previous: std::sync::Arc<PanicHook>,
+}
+
+impl Drop for SilencedInjectedPanics {
+    fn drop(&mut self) {
+        // NEVER touch the hook while unwinding (roborev, issue #3106):
+        // `std::panic::set_hook` PANICS if called from a panicking thread, so a
+        // guard still alive when an assertion (or any fallible call inside the
+        // silenced block) fails would double-panic and ABORT the process — under
+        // libtest's capture that loses the original message entirely and, in an
+        // integration-test binary, takes every sibling test's result with it.
+        // Skipping the restore leaves the filtering hook installed for the rest of
+        // the process, which is harmless: it only ever suppresses
+        // `INJECTED_PANIC_MESSAGE` and delegates everything else.
+        if std::thread::panicking() {
+            return;
+        }
+        // `set_hook` needs an owned `Box`, and the previous hook is behind an
+        // `Arc` (it is borrowed by the filtering hook installed above), so it is
+        // reinstated through one thin delegating wrapper. Behaviourally identical;
+        // the only cost is a pointer hop per nested guard.
+        let previous = self.previous.clone();
+        std::panic::set_hook(Box::new(move |info| previous(info)));
+    }
+}

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -577,15 +577,19 @@ fn push_metadata_rows(
 /// path's [`scan_merge::sort_by_token_order`] output (issue #1579 ordering
 /// guardrail).
 ///
-/// Construction (`KWayMerger::new`, which opens the input files) happens on the
-/// blocking task and is signalled back over a oneshot BEFORE any streaming — and the
-/// ways that can fail are kept apart by the returned [`MergeStreamSetupError`] rather
-/// than flattened into one `Error`. Only a merger-INELIGIBLE input (an unsupported
-/// format/version) is `fallback_eligible`; a REPORTED runtime failure (I/O,
-/// corruption, …) and a producer that DIED without signalling — joined here to recover
-/// its panic — both propagate, because the caller must not answer either with the
-/// non-reconciling concat (issues #3124/#3154, roborev — see that type's module doc
-/// for why the flattened version returned wrong data).
+/// Construction (`KWayMerger::new`, which SPAWNS one producer thread per input —
+/// each input's `SSTableReader::open`, and so every format/version gate, runs inside
+/// that thread, not here) happens on the blocking task and is signalled back over a
+/// oneshot BEFORE any streaming — and the ways that can fail are kept apart by the
+/// returned [`MergeStreamSetupError`] rather than flattened into one `Error`. Only a
+/// merger-INELIGIBLE input (an unsupported format/version) is `fallback_eligible`,
+/// and because of that thread boundary NO production construction failure is ever
+/// classified that way — the reachable ones are `Error::Schema` and `Error::Storage`,
+/// and both now propagate (see [`MergeStreamSetupError`]'s module doc for the full
+/// enumeration and why that arm is kept as a defensive one). A producer that DIED
+/// without signalling — joined here to recover its panic — propagates too, because
+/// the caller must not answer it with the non-reconciling concat (issues
+/// #3124/#3154, roborev).
 ///
 /// A `step()` error mid-stream is delivered as an `Err` item on the channel, and a
 /// task that dies mid-stream is caught by the returned [`reader::RowScanStream`]'s

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -716,3 +716,12 @@ fn ordered_generation_paths(reader_list: &[Arc<reader::SSTableReader>]) -> Vec<P
 
 #[cfg(test)]
 mod read_shadow_tests;
+
+// The multi-generation streaming read path's shared fixture + reconciled/unreconciled
+// oracle, and the issue-#3154 end-to-end pins built on it. `not(tombstones)` because
+// that build routes `scan_stream` through the materializing `scan`, so neither the
+// streaming merge nor its setup-outcome type exists there.
+#[cfg(all(test, not(feature = "tombstones")))]
+pub(super) mod multi_gen_fixture;
+#[cfg(all(test, not(feature = "tombstones")))]
+mod setup_fail_closed_tests;

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -627,7 +627,16 @@ pub(super) async fn stream_generations_for_read(
         fault_scope.checkpoint(crate::storage::producer_fault::ScanTaskSite::CrossGenerationMerge);
         // Issue #1849: capture the read-time TTL clock ONCE per scan.
         let shadow = ReadShadow::new(&schema, now_epoch_secs());
-        let mut merger = match KWayMerger::new(paths, &schema) {
+        // Issue #3154: a test may make construction REPORT a chosen error variant, so
+        // the narrowed fallback classification below can be proven per class (I/O vs
+        // corruption vs merger-ineligible). `None` — and `KWayMerger::new` called
+        // exactly as before — in every production build, where
+        // `injected_construction_error` returns `None` without touching a registry.
+        let constructed = match fault_scope.injected_construction_error() {
+            Some(injected) => Err(injected),
+            None => KWayMerger::new(paths, &schema),
+        };
+        let mut merger = match constructed {
             Ok(m) => {
                 // Signal readiness; if the caller already dropped, stop.
                 if ready_tx.send(Ok(())).is_err() {
@@ -636,7 +645,9 @@ pub(super) async fn stream_generations_for_read(
                 m
             }
             Err(e) => {
-                // Let the caller fall back to the lazy per-reader streaming merge.
+                // REPORT the failure verbatim; whether it earns the caller's fallback
+                // to the lazy per-reader concat is classified from its VARIANT at the
+                // receiving end (issue #3154), not decided here.
                 let _ = ready_tx.send(Err(e));
                 return;
             }

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -579,12 +579,13 @@ fn push_metadata_rows(
 ///
 /// Construction (`KWayMerger::new`, which opens the input files) happens on the
 /// blocking task and is signalled back over a oneshot BEFORE any streaming — and the
-/// TWO ways that can fail are kept apart by the returned
-/// [`MergeStreamSetupError`] rather than flattened into one `Error`. Only a
-/// REPORTED construction failure is `fallback_eligible`; a producer that DIED
-/// without signalling is joined here and reported as `ProducerDied`, which the caller
-/// must not answer with the non-reconciling concat (issue #3124, roborev — see that
-/// type's module doc for why the flattened version returned wrong data).
+/// ways that can fail are kept apart by the returned [`MergeStreamSetupError`] rather
+/// than flattened into one `Error`. Only a merger-INELIGIBLE input (an unsupported
+/// format/version) is `fallback_eligible`; a REPORTED runtime failure (I/O,
+/// corruption, …) and a producer that DIED without signalling — joined here to recover
+/// its panic — both propagate, because the caller must not answer either with the
+/// non-reconciling concat (issues #3124/#3154, roborev — see that type's module doc
+/// for why the flattened version returned wrong data).
 ///
 /// A `step()` error mid-stream is delivered as an `Err` item on the channel, and a
 /// task that dies mid-stream is caught by the returned [`reader::RowScanStream`]'s
@@ -693,7 +694,11 @@ pub(super) async fn stream_generations_for_read(
 
     match ready_rx.await {
         Ok(Ok(())) => Ok(reader::RowScanStream::new(out_rx, task)),
-        Ok(Err(e)) => Err(MergeStreamSetupError::Construction(e)),
+        // A REPORTED construction failure is CLASSIFIED from its `Error` variant (issue
+        // #3154): only a merger-INELIGIBLE input earns the caller's concat fallback, and
+        // an I/O / corruption / other runtime failure propagates. Answering the latter
+        // with the concat returned a full-length UNRECONCILED result set under `Ok`.
+        Ok(Err(e)) => Err(MergeStreamSetupError::from_construction_failure(e)),
         // `ready_tx` is dropped-WITHOUT-send on exactly one condition: the blocking
         // task unwound before either readiness arm ran. So this `Err` ⟺ a dead
         // producer — JOIN the retained handle to recover the real cause (the panic

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_stream_setup.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_stream_setup.rs
@@ -1,6 +1,6 @@
 //! Why the streaming cross-generation merge could not start — and whether the
 //! caller may answer that by falling back to the NON-reconciling concatenation
-//! (issue #3124, roborev).
+//! (issues #3124 and #3154, both roborev).
 //!
 //! # The defect this type exists to make unrepresentable
 //!
@@ -21,18 +21,53 @@
 //! silently WRONG data rather than silently SHORT data.
 //!
 //! Distinguishing the two by inspecting the error's message string would be a
-//! guess. It is a TYPE here instead: only [`MergeStreamSetupError::Construction`]
-//! is [`fallback_eligible`](MergeStreamSetupError::fallback_eligible), and a
-//! caller that ignores the distinction cannot compile past the `match`.
+//! guess. It is a TYPE here instead: exactly one variant is
+//! [`fallback_eligible`](MergeStreamSetupError::fallback_eligible), and a caller that
+//! ignores the distinction cannot compile past the `match`.
+//!
+//! # The second, likelier route to the same wrong data (issue #3154)
+//!
+//! Labelling every REPORTED construction failure fallback-eligible left the wrong-data
+//! route wide open, reached by a far more ordinary trigger than a panic: a transient
+//! I/O error, or a corrupt input encountered while constructing the merger, made the
+//! query return the full-length UNRECONCILED result set under `Ok`.
+//!
+//! The fallback's justification is narrow. It exists so an input the reconciling merger
+//! CANNOT HANDLE still returns something — the documented Issue #883 concat limitation,
+//! accepted for a table that would otherwise be unreadable. That justification covers
+//! an unsupported-format / merger-ineligible condition and NOTHING else: a runtime
+//! failure says nothing about whether the merger supports the input, so answering it
+//! with the concat trades an honest error for silently wrong data.
+//!
+//! So a reported construction failure is CLASSIFIED, by
+//! [`MergeStreamSetupError::from_construction_failure`], into
+//! [`MergeStreamSetupError::MergerIneligible`] (fallback-eligible, unchanged
+//! behaviour) or [`MergeStreamSetupError::ConstructionFailed`] (propagates). The
+//! classification keys on the `Error` VARIANT — never on its message — and
+//! [`fallback_eligible`](MergeStreamSetupError::fallback_eligible) remains the SINGLE
+//! predicate the caller consults.
 
 use crate::Error;
 
 /// A streaming cross-generation merge that never produced a live stream.
 pub(in crate::storage::sstable) enum MergeStreamSetupError {
-    /// `KWayMerger::new` returned `Err` and the task REPORTED it: the merge could
-    /// not be built, nothing was streamed, and the producer is alive and
-    /// well-behaved. The caller MAY fall back to the non-reconciling concat.
-    Construction(Error),
+    /// `KWayMerger::new` reported that it cannot handle this INPUT: an unsupported
+    /// format, or a version outside the supported floor. Nothing was streamed, the
+    /// producer is alive and well-behaved, and the reconciling merge is genuinely
+    /// unavailable for this table — so the caller MAY answer with the non-reconciling
+    /// concat, accepting its documented Issue #883 limitation rather than failing a
+    /// read that CQLite could otherwise serve.
+    MergerIneligible(Error),
+    /// `KWayMerger::new` reported a RUNTIME failure — an I/O error, a corrupt or
+    /// unparseable input, a resource failure, or anything else that is not evidence
+    /// about the input's format (issue #3154).
+    ///
+    /// NOT eligible for the concat fallback. The merger is not known to be unable to
+    /// read this table; something went wrong while it tried. Substituting the concat
+    /// there returns a FULL-LENGTH, UNRECONCILED result set (duplicated overwritten
+    /// rows, resurrected deleted rows) as a success, which is strictly worse than
+    /// reporting the failure the caller can act on.
+    ConstructionFailed(Error),
     /// The producer task ended WITHOUT signalling readiness — it panicked (or was
     /// otherwise lost). The reconciling merge never started for an INTERNAL
     /// reason, and no conclusion about the table's readability is available, so
@@ -41,17 +76,43 @@ pub(in crate::storage::sstable) enum MergeStreamSetupError {
 }
 
 impl MergeStreamSetupError {
+    /// Classify a REPORTED `KWayMerger::new` failure (issue #3154).
+    ///
+    /// Matched on the `Error` VARIANT, never on its message: a message match would be
+    /// exactly the guess this module exists to eliminate, and it would silently
+    /// re-classify itself whenever an error string is reworded.
+    ///
+    /// The catch-all arm deliberately fails CLOSED. A future `Error` variant, or any
+    /// error whose meaning is not "the merger cannot handle this input", propagates
+    /// rather than earning the concat — the wrong direction there returns wrong data
+    /// under `Ok`, while the wrong direction here returns an honest error.
+    pub(in crate::storage::sstable) fn from_construction_failure(cause: Error) -> Self {
+        match &cause {
+            // The merger genuinely cannot read this input, which is the ONE condition
+            // the documented concat fallback exists to serve.
+            Error::UnsupportedFormat(_) | Error::UnsupportedVersion { .. } => {
+                Self::MergerIneligible(cause)
+            }
+            _ => Self::ConstructionFailed(cause),
+        }
+    }
+
     /// Whether the caller may substitute the non-reconciling concatenation.
     ///
-    /// `true` for exactly one variant, on purpose (see the module doc).
+    /// `true` for exactly one variant, on purpose (see the module doc). This stays the
+    /// SINGLE predicate for that decision: a second mechanism could disagree with it.
     pub(in crate::storage::sstable) fn fallback_eligible(&self) -> bool {
-        matches!(self, Self::Construction(_))
+        matches!(self, Self::MergerIneligible(_))
     }
 
     /// The underlying error, for a caller that is reporting rather than falling back.
+    ///
+    /// Returned VERBATIM, keeping the variant the merger reported: an I/O failure that
+    /// a retry might clear must not reach a binding disguised as an internal error (and
+    /// vice versa) — `Error::is_recoverable` is derived from that variant.
     pub(in crate::storage::sstable) fn into_error(self) -> Error {
         match self {
-            Self::Construction(e) | Self::ProducerDied(e) => e,
+            Self::MergerIneligible(e) | Self::ConstructionFailed(e) | Self::ProducerDied(e) => e,
         }
     }
 }
@@ -89,17 +150,86 @@ mod tests {
     use super::*;
 
     #[test]
-    fn only_a_reported_construction_failure_is_fallback_eligible() {
+    fn only_a_merger_ineligible_input_is_fallback_eligible() {
         assert!(
-            MergeStreamSetupError::Construction(Error::unsupported_format("nope"))
+            MergeStreamSetupError::MergerIneligible(Error::unsupported_format("nope"))
                 .fallback_eligible(),
-            "a REPORTED construction failure is the one case the caller may answer \
+            "an input the merger cannot handle is the one case the caller may answer \
              with the non-reconciling concat"
+        );
+        assert!(
+            !MergeStreamSetupError::ConstructionFailed(Error::corruption("bad"))
+                .fallback_eligible(),
+            "a RUNTIME construction failure must NEVER be answered with the concat: \
+             that returns a full-length UNRECONCILED result set as a success (issue #3154)"
         );
         assert!(
             !MergeStreamSetupError::ProducerDied(Error::internal("died")).fallback_eligible(),
             "a dead producer must NEVER be answered with the concat: that returns a \
              full-length UNRECONCILED result set as a success (issue #3124, roborev)"
+        );
+    }
+
+    /// The classification itself (issue #3154): which REPORTED construction errors earn
+    /// the concat. Every case is decided from the `Error` VARIANT, so this table is the
+    /// whole contract — including the fail-CLOSED default for anything unrecognised.
+    #[test]
+    fn a_construction_failure_earns_the_concat_only_when_the_input_is_merger_ineligible() {
+        let eligible: Vec<Error> = vec![
+            Error::unsupported_format("BTI input the k-way merger cannot open"),
+            Error::UnsupportedVersion {
+                version: "ma".to_string(),
+                floor: "na".to_string(),
+            },
+        ];
+        for cause in eligible {
+            let label = cause.to_string();
+            assert!(
+                MergeStreamSetupError::from_construction_failure(cause).fallback_eligible(),
+                "an unsupported input must keep degrading to the documented Issue #883 \
+                 concat — narrowing that away turns a previously-working read into a \
+                 failure: {label}"
+            );
+        }
+
+        let propagates: Vec<Error> = vec![
+            // The two triggers issue #3154 is about: far likelier than a panic, and
+            // both used to return a full-length UNRECONCILED result set under `Ok`.
+            Error::Io(std::io::Error::other("transient read failure")),
+            Error::corruption("truncated partition header"),
+            // Neither is evidence about the input FORMAT, so neither earns the concat.
+            Error::Serialization {
+                message: "cell parse".to_string(),
+                source: None,
+            },
+            Error::invalid_format("unexpected flags byte"),
+            Error::schema("dropped column not declared in columns"),
+            Error::storage("failed to spawn producer thread"),
+            Error::internal("unexpected state"),
+        ];
+        for cause in propagates {
+            let label = cause.to_string();
+            assert!(
+                !MergeStreamSetupError::from_construction_failure(cause).fallback_eligible(),
+                "a runtime construction failure must propagate, never be answered with \
+                 the non-reconciling concat: {label}"
+            );
+        }
+    }
+
+    /// The propagated error keeps the VARIANT the merger reported — bindings derive
+    /// retryability (`Error::is_recoverable`) from it, so re-labelling an I/O hiccup as
+    /// an internal error (or the reverse) would misinform the caller.
+    #[test]
+    fn a_propagated_construction_failure_keeps_its_variant_and_message() {
+        let classified = MergeStreamSetupError::from_construction_failure(Error::Io(
+            std::io::Error::other("transient read failure"),
+        ));
+        assert!(!classified.fallback_eligible());
+        let error = classified.into_error();
+        assert!(
+            matches!(error, Error::Io(_)) && error.to_string().contains("transient read failure"),
+            "expected the reported I/O error verbatim, got: {error:?}"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_stream_setup.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_stream_setup.rs
@@ -7,10 +7,13 @@
 //! `generation_merge::stream_generations_for_read` reports setup back over a
 //! oneshot from its blocking task, and the caller
 //! (`SSTableManager::scan_stream`) is allowed to substitute the lazy per-reader
-//! token-order concat when the merge cannot be CONSTRUCTED — e.g. an input
-//! format the `KWayMerger` cannot open. That substitution is safe there and only
+//! token-order concat when the merge cannot be CONSTRUCTED *because the merger
+//! cannot handle the input at all*. That substitution is safe there and only
 //! there: nothing has been streamed yet, and the concat's documented Issue #883
 //! limitation is accepted for a table the reconciling merge simply cannot read.
+//! (Whether that condition is actually REACHABLE through today's constructor is a
+//! separate question, answered — "no" — two sections down. Read it before
+//! concluding anything about production behaviour from this type.)
 //!
 //! But the oneshot has a SECOND failure mode: the blocking task can DIE (panic)
 //! before signalling anything, dropping its sender. Flattened into one `Error`,
@@ -46,17 +49,83 @@
 //! classification keys on the `Error` VARIANT — never on its message — and
 //! [`fallback_eligible`](MergeStreamSetupError::fallback_eligible) remains the SINGLE
 //! predicate the caller consults.
+//!
+//! # What `KWayMerger::new` can ACTUALLY return — and what issue #3154 changed
+//!
+//! The classification above must be read with the real constructor chain in hand,
+//! because it is NOT the chain the original wording of this module implied.
+//! `KWayMerger::new` (`storage/write_engine/merge/mod.rs:1627`) delegates through
+//! `new_with_gc` (`:1667`) / `new_with_gc_and_registry` (`:1683`) to
+//! `new_with_gc_and_registry_cancellable` (`:1710`), which has exactly THREE
+//! fallible steps:
+//!
+//! 1. `Error::InvalidInput` when `input_paths` is empty (`merge/mod.rs:1718-1721`) —
+//!    unreachable from the `scan_stream` site, which is guarded by
+//!    `readers.len() > 1`.
+//! 2. `schema.validate_dropped_columns()?` (`merge/mod.rs:1728`) → `Error::Schema`
+//!    (`schema/mod.rs:611`).
+//! 3. `SSTableRowIteratorAdapter::open(...)?` (`merge/mod.rs:1746`), whose ONLY error
+//!    is `Error::Storage("streaming producer: failed to spawn thread: …")`
+//!    (`merge/producer_iter.rs:275`).
+//!
+//! Step 3 OPENS NOTHING. `SSTableRowIteratorAdapter::open`
+//! (`merge/producer_iter.rs:201-294`) creates a channel and `Builder::spawn`s a
+//! producer thread; `SSTableReader::open` — and therefore EVERY
+//! `UnsupportedFormat` / `UnsupportedVersion` header- and version-gate check — runs
+//! INSIDE that thread (`merge/producer_iter.rs:385-388`) and surfaces as a failed
+//! producer message observed later at `merger.step()`, i.e. mid-stream on the output
+//! channel, never as a construction error. From the `scan_stream` site it is doubly
+//! impossible: `readers.len() > 1` means every generation ALREADY opened
+//! successfully through `SSTableReader::open`.
+//!
+//! Two consequences, stated plainly so no reader draws the flattering conclusion:
+//!
+//! * [`MergerIneligible`](MergeStreamSetupError::MergerIneligible) is **DEAD IN
+//!   PRODUCTION**. Only the test-only construction-error injection seam
+//!   (`producer_fault::FaultScope::injected_construction_error`) ever constructs it.
+//!   An unsupported-format / below-floor generation does NOT degrade to the concat at
+//!   this site — it errors mid-stream through the channel. **That was already true
+//!   BEFORE issue #3154's narrowing**, so the narrowing removed no real-world
+//!   degradation: AC2's "an unsupported input keeps falling back" property is
+//!   preserved only because the fallback was already unreachable. The AC2 test
+//!   therefore proves the CLASSIFIER, not an end-to-end fallback, and must not be
+//!   read as evidence that a BTI / unsupported multi-generation table currently
+//!   degrades to the concat. It does not.
+//! * The errors that WERE actually reaching the fallback are `Error::Schema`
+//!   (dropped-column validation, step 2) and `Error::Storage` (producer thread-spawn
+//!   failure, step 3). Both used to be answered with the non-reconciling concat under
+//!   `Ok`; both now PROPAGATE as an error. **That is the real behaviour change of
+//!   issue #3154** — not a change to unsupported-format handling.
+//!
+//! The `MergerIneligible` arm is nevertheless KEPT, as a DELIBERATELY DEFENSIVE arm:
+//! should a future constructor validate format/version EAGERLY (opening readers on
+//! the calling thread instead of inside the producer thread), an unsupported input
+//! would start arriving here as a construction error, and the documented Issue #883
+//! degradation must keep working the moment it does.
 
 use crate::Error;
 
 /// A streaming cross-generation merge that never produced a live stream.
 pub(in crate::storage::sstable) enum MergeStreamSetupError {
     /// `KWayMerger::new` reported that it cannot handle this INPUT: an unsupported
-    /// format, or a version outside the supported floor. Nothing was streamed, the
-    /// producer is alive and well-behaved, and the reconciling merge is genuinely
-    /// unavailable for this table — so the caller MAY answer with the non-reconciling
-    /// concat, accepting its documented Issue #883 limitation rather than failing a
-    /// read that CQLite could otherwise serve.
+    /// format, or a version outside the supported floor.
+    ///
+    /// **DEFENSIVE — dead in production.** The current `KWayMerger::new` chain cannot
+    /// return either of those variants: format/version gating happens inside the
+    /// producer thread's `SSTableReader::open`
+    /// (`storage/write_engine/merge/producer_iter.rs:385-388`) and surfaces mid-stream
+    /// at `step()`, not at construction (see this module's doc for the full
+    /// enumeration). Today only the test-only construction-error injection seam
+    /// constructs this variant, so an unsupported multi-generation table does NOT
+    /// currently degrade to the concat here. The arm is retained so that a future
+    /// eagerly-validating constructor keeps the documented Issue #883 degradation
+    /// instead of silently turning a merger-unreadable table into a failed read.
+    ///
+    /// When it IS produced the fallback is sound: nothing was streamed, the producer
+    /// is alive and well-behaved, and the reconciling merge is genuinely unavailable
+    /// for this table — so the caller MAY answer with the non-reconciling concat,
+    /// accepting its documented Issue #883 limitation rather than failing a read that
+    /// CQLite could otherwise serve.
     MergerIneligible(Error),
     /// `KWayMerger::new` reported a RUNTIME failure — an I/O error, a corrupt or
     /// unparseable input, a resource failure, or anything else that is not evidence
@@ -67,6 +136,13 @@ pub(in crate::storage::sstable) enum MergeStreamSetupError {
     /// there returns a FULL-LENGTH, UNRECONCILED result set (duplicated overwritten
     /// rows, resurrected deleted rows) as a success, which is strictly worse than
     /// reporting the failure the caller can act on.
+    ///
+    /// This is the ONLY outcome reachable in production at the `scan_stream` site:
+    /// `Error::Schema` (dropped-column validation, `merge/mod.rs:1728`) and
+    /// `Error::Storage` (producer thread-spawn failure,
+    /// `merge/producer_iter.rs:275`) are the two errors `KWayMerger::new` can actually
+    /// report there, and BOTH were previously answered with the concat. Narrowing them
+    /// to propagate is the real behaviour change of issue #3154.
     ConstructionFailed(Error),
     /// The producer task ended WITHOUT signalling readiness — it panicked (or was
     /// otherwise lost). The reconciling merge never started for an INTERNAL
@@ -82,6 +158,14 @@ impl MergeStreamSetupError {
     /// exactly the guess this module exists to eliminate, and it would silently
     /// re-classify itself whenever an error string is reworded.
     ///
+    /// What the current constructor can actually hand this function is enumerated in
+    /// the module doc, and it is worth being blunt about: `Error::Schema`
+    /// (dropped-column validation, `merge/mod.rs:1728`) and `Error::Storage`
+    /// (thread-spawn failure, `merge/producer_iter.rs:275`) are the reachable cases and
+    /// both propagate, while `UnsupportedFormat` / `UnsupportedVersion` are detected in
+    /// the producer thread (`merge/producer_iter.rs:385-388`) and surface at `step()`,
+    /// never here. The eligible arm below is therefore DEFENSIVE, not live.
+    ///
     /// The catch-all arm deliberately fails CLOSED. A future `Error` variant, or any
     /// error whose meaning is not "the merger cannot handle this input", propagates
     /// rather than earning the concat — the wrong direction there returns wrong data
@@ -89,10 +173,17 @@ impl MergeStreamSetupError {
     pub(in crate::storage::sstable) fn from_construction_failure(cause: Error) -> Self {
         match &cause {
             // The merger genuinely cannot read this input, which is the ONE condition
-            // the documented concat fallback exists to serve.
+            // the documented concat fallback exists to serve. Defensive: unreachable
+            // through today's constructor (see this function's doc).
             Error::UnsupportedFormat(_) | Error::UnsupportedVersion { .. } => {
                 Self::MergerIneligible(cause)
             }
+            // Fail CLOSED. Note the cost of that direction: a future `Error` variant
+            // that SHOULD earn the concat degrades SILENTLY into a propagated error
+            // here, with nothing to notice it. Whoever adds such a variant must also
+            // extend the enumerated classification table in this module's tests —
+            // `a_construction_failure_earns_the_concat_only_when_the_input_is_merger_ineligible`,
+            // whose `eligible` / `propagates` vectors ARE the contract.
             _ => Self::ConstructionFailed(cause),
         }
     }

--- a/cqlite-core/src/storage/sstable/generation_merge/multi_gen_fixture.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/multi_gen_fixture.rs
@@ -1,0 +1,348 @@
+//! Shared TEST fixture for the multi-generation streaming read path: real SSTable
+//! generations written by the write engine, plus the drains and the reconciled /
+//! unreconciled ORACLE both end-to-end suites assert against.
+//!
+//! Two suites share it on purpose, so they cannot drift apart on what "reconciled"
+//! means:
+//!
+//! * `sstable::scan_stream_fanout::panic_tests` (issue #3124) — a producer task that
+//!   DIES must fail the scan instead of truncating it silently, and, at site 5, must
+//!   not be answered with the concat.
+//! * `generation_merge::setup_fail_closed_tests` (issue #3154) — a `KWayMerger::new`
+//!   failure earns the concat fallback ONLY when the input is genuinely
+//!   merger-ineligible; an I/O or corruption failure propagates.
+//!
+//! # The OVERLAPPING fixture is what makes either property provable
+//!
+//! [`flush_generations`] writes DISJOINT partitions per generation, where the
+//! reconciled and the concatenated result sets are the SAME rows — fine when the
+//! property is "short vs complete", useless when it is "reconciled vs unreconciled".
+//! [`flush_overlapping_generations`] rewrites the SAME partitions in every generation
+//! with strictly increasing timestamps, so a reconciling read returns
+//! [`reconciled_rows`] rows all carrying [`newest_value_prefix`], while the
+//! non-reconciling concat returns [`unreconciled_rows`] rows including every
+//! superseded copy. The two answers therefore differ by COUNT and by VALUE, which is
+//! the only way to tell a silent concat fallback from a genuine reconciled read.
+//!
+//! Gated `cfg(test)` + `not(tombstones)`: a `tombstones` build routes `scan_stream`
+//! through the materializing `scan`, so neither streaming path under test exists
+//! there. (`write-support` comes from the enclosing `generation_merge` module.)
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use crate::platform::Platform;
+use crate::storage::sstable::SSTableManager;
+use crate::storage::write_engine::test_support::{create_test_mutation, create_test_schema};
+use crate::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use crate::types::TableId;
+use crate::Config;
+
+/// Partitions written per generation. Comfortably more than one batch's worth on
+/// the batched surface would need, and enough that a short result is unmistakable.
+pub(in crate::storage::sstable) const PARTITIONS_PER_GENERATION: i32 = 12;
+
+/// Generations flushed. `> 1` is what routes `scan_stream` to a multi-generation
+/// merge rather than the single-reader fast path.
+pub(in crate::storage::sstable) const GENERATIONS: i32 = 3;
+
+/// Small enough that the producers park in backpressure mid-scan, so a fault has a
+/// genuinely partial stream to truncate.
+pub(in crate::storage::sstable) const BUFFER: usize = 2;
+
+/// Write `GENERATIONS` flushes of `PARTITIONS_PER_GENERATION` DISJOINT partitions
+/// each, so every generation contributes rows to the merge and the total row count
+/// is exact and predictable.
+///
+/// Returns the write engine's data root (the directory an `SSTableManager` opens).
+///
+/// Runs on a BLOCKING thread: `WriteEngine::flush` drives its own current-thread
+/// runtime, which cannot be started from inside the test's runtime.
+pub(in crate::storage::sstable) async fn flush_generations(temp_dir: &TempDir) -> PathBuf {
+    let root = temp_dir.path().to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        with_engine(&root, |engine, rt| {
+            for generation in 0..GENERATIONS {
+                for offset in 0..PARTITIONS_PER_GENERATION {
+                    let id = generation * PARTITIONS_PER_GENERATION + offset;
+                    engine
+                        .write(create_test_mutation(id, &format!("row-{id}"), 1_000))
+                        .expect("write");
+                }
+                rt.block_on(engine.flush())
+                    .expect("flush")
+                    .expect("flush wrote an SSTable");
+            }
+        })
+    })
+    .await
+    .expect("fixture build task")
+}
+
+/// Total rows a healthy scan of the DISJOINT fixture must return.
+pub(in crate::storage::sstable) const fn expected_rows() -> usize {
+    (GENERATIONS * PARTITIONS_PER_GENERATION) as usize
+}
+
+/// Write `GENERATIONS` flushes that all rewrite the SAME
+/// `PARTITIONS_PER_GENERATION` partitions, each generation with a strictly newer
+/// timestamp and a distinguishable value — the OVERLAPPING fixture (see the header).
+pub(in crate::storage::sstable) async fn flush_overlapping_generations(
+    temp_dir: &TempDir,
+) -> PathBuf {
+    let root = temp_dir.path().to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        with_engine(&root, |engine, rt| {
+            for generation in 0..GENERATIONS {
+                for id in 0..PARTITIONS_PER_GENERATION {
+                    engine
+                        .write(create_test_mutation(
+                            id,
+                            &format!("gen{generation}-row-{id}"),
+                            // Strictly increasing, so the LWW winner is
+                            // unambiguous and the newest generation is the one a
+                            // reconciled read shows.
+                            1_000 + generation as i64,
+                        ))
+                        .expect("write");
+                }
+                rt.block_on(engine.flush())
+                    .expect("flush")
+                    .expect("flush wrote an SSTable");
+            }
+        })
+    })
+    .await
+    .expect("fixture build task")
+}
+
+/// Build a write engine + its own current-thread runtime under `root`, run `writes`
+/// against them, and return the data directory an `SSTableManager` opens.
+fn with_engine(
+    root: &std::path::Path,
+    writes: impl FnOnce(&mut WriteEngine, &tokio::runtime::Runtime),
+) -> PathBuf {
+    let data_dir = root.join("data");
+    let config = WriteEngineConfig::new(data_dir.clone(), root.join("wal"), create_test_schema());
+    let mut engine = WriteEngine::new(config).expect("write engine");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    writes(&mut engine, &rt);
+    data_dir
+}
+
+/// Rows a RECONCILED read of the overlapping fixture returns: last-write-wins
+/// collapses every generation's copy of a partition into one row.
+pub(in crate::storage::sstable) const fn reconciled_rows() -> usize {
+    PARTITIONS_PER_GENERATION as usize
+}
+
+/// Rows the NON-reconciling token-order concat returns over the same fixture: every
+/// generation's copy of every partition, superseded ones included.
+pub(in crate::storage::sstable) const fn unreconciled_rows() -> usize {
+    (GENERATIONS * PARTITIONS_PER_GENERATION) as usize
+}
+
+/// The value prefix only the NEWEST generation's cells carry. Every row of a
+/// reconciled read must have it; a concatenated read also surfaces older prefixes.
+pub(in crate::storage::sstable) fn newest_value_prefix() -> String {
+    format!("gen{}-", GENERATIONS - 1)
+}
+
+pub(in crate::storage::sstable) async fn open_manager(
+    data_dir: &std::path::Path,
+) -> SSTableManager {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+    SSTableManager::new(
+        data_dir,
+        &config,
+        platform,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("manager")
+}
+
+pub(in crate::storage::sstable) fn table_id() -> TableId {
+    let schema = create_test_schema();
+    TableId::from(format!("{}.{}", schema.keyspace, schema.table).as_str())
+}
+
+/// How a drained stream ended, plus how many rows it delivered.
+pub(in crate::storage::sstable) struct Drained {
+    pub(in crate::storage::sstable) rows: usize,
+    /// `Some(message)` when the read terminated with an ERROR — whether the setup
+    /// call itself failed or a stream item did; `None` on a clean end of stream.
+    pub(in crate::storage::sstable) error: Option<String>,
+}
+
+/// Drain the per-row surface (`SSTableManager::scan_stream`) with NO schema.
+///
+/// `schema = None` on purpose: with a schema present and `write-support` on, a
+/// multi-generation read routes to the authoritative `KWayMerger`
+/// (`stream_generations_for_read`), NOT the lazy fan-out merge. Each reader still
+/// resolves its own schema for decoding, so the rows are real.
+pub(in crate::storage::sstable) async fn drain_per_row(manager: &SSTableManager) -> Drained {
+    match manager
+        .scan_stream(&table_id(), None, None, None, BUFFER)
+        .await
+    {
+        Ok(mut stream) => {
+            let mut rows = 0usize;
+            while let Some(item) = stream.recv().await {
+                match item {
+                    Ok(_) => rows += 1,
+                    Err(e) => {
+                        return Drained {
+                            rows,
+                            error: Some(e.to_string()),
+                        }
+                    }
+                }
+            }
+            Drained { rows, error: None }
+        }
+        Err(e) => Drained {
+            rows: 0,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+/// Drain the batched surface (`SSTableManager::scan_stream_batched`), whose
+/// multi-generation arm is the per-row → batch re-chunker.
+pub(in crate::storage::sstable) async fn drain_batched(manager: &SSTableManager) -> Drained {
+    match manager
+        .scan_stream_batched(&table_id(), None, None, None, BUFFER)
+        .await
+    {
+        Ok(mut stream) => {
+            let mut rows = 0usize;
+            while let Some(item) = stream.recv().await {
+                match item {
+                    Ok(batch) => rows += batch.len(),
+                    Err(e) => {
+                        return Drained {
+                            rows,
+                            error: Some(e.to_string()),
+                        }
+                    }
+                }
+            }
+            Drained { rows, error: None }
+        }
+        Err(e) => Drained {
+            rows: 0,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+/// Open the per-row surface WITH a schema — the RECONCILING route
+/// (`stream_generations_for_read`), whose setup outcome the #3154 suite inspects by
+/// TYPE. Kept separate from [`drain_reconciled`] so a caller can assert on the
+/// typed setup `Err` instead of a stringified one.
+pub(in crate::storage::sstable) async fn open_reconciling_stream(
+    manager: &SSTableManager,
+) -> crate::Result<crate::storage::sstable::reader::RowScanStream> {
+    let schema = create_test_schema();
+    manager
+        .scan_stream(&table_id(), None, None, Some(&schema), BUFFER)
+        .await
+}
+
+/// Drain the RECONCILING per-row surface, capturing every row's `name` value.
+///
+/// The captured values are what let a caller tell a reconciled result set from a
+/// concatenated one, which a row COUNT alone cannot do once a fallback returns a
+/// full-length answer.
+pub(in crate::storage::sstable) async fn drain_reconciled(
+    manager: &SSTableManager,
+) -> (Drained, Vec<String>) {
+    match open_reconciling_stream(manager).await {
+        Ok(stream) => drain_stream(stream).await,
+        Err(e) => (
+            Drained {
+                rows: 0,
+                error: Some(e.to_string()),
+            },
+            Vec::new(),
+        ),
+    }
+}
+
+/// Drain an already-open reconciling stream, capturing every row's `name` value.
+pub(in crate::storage::sstable) async fn drain_stream(
+    mut stream: crate::storage::sstable::reader::RowScanStream,
+) -> (Drained, Vec<String>) {
+    let mut rows = 0usize;
+    let mut values = Vec::new();
+    while let Some(item) = stream.recv().await {
+        match item {
+            Ok((_, row)) => {
+                rows += 1;
+                if let crate::types::ScanRow::Row(cells) = row {
+                    for (column, value) in cells.iter() {
+                        if column.as_ref() == "name" {
+                            values.push(value.as_str().unwrap_or_default().to_string());
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                return (
+                    Drained {
+                        rows,
+                        error: Some(e.to_string()),
+                    },
+                    values,
+                )
+            }
+        }
+    }
+    (Drained { rows, error: None }, values)
+}
+
+/// The CONTROL arm both suites run BEFORE injecting anything: the healthy read of
+/// the OVERLAPPING fixture ends cleanly, is RECONCILED (one row per partition) and
+/// shows only the newest generation's values.
+///
+/// Asserted in ONE place because it is a PRECONDITION, not a property: without it,
+/// "the faulted read is not the concat's answer" is vacuous — a fixture that yields
+/// nothing, or one where the two answers coincide, would pass too.
+pub(in crate::storage::sstable) async fn assert_reconciled_control(manager: &SSTableManager) {
+    assert_ne!(
+        reconciled_rows(),
+        unreconciled_rows(),
+        "test precondition: with reconciled == unreconciled no test on this fixture \
+         could tell a reconciled read from a silent concat fallback"
+    );
+    let (control, values) = drain_reconciled(manager).await;
+    assert_eq!(
+        control.error, None,
+        "a healthy multi-generation reconciling read must end CLEANLY — no \
+         fail-closed guard may turn a live producer into an error"
+    );
+    assert_eq!(
+        control.rows,
+        reconciled_rows(),
+        "the control drain must be RECONCILED: {} partitions rewritten in every \
+         generation collapse to {} rows, not the concat's {}",
+        PARTITIONS_PER_GENERATION,
+        reconciled_rows(),
+        unreconciled_rows()
+    );
+    let newest = newest_value_prefix();
+    assert!(
+        values.len() == reconciled_rows() && values.iter().all(|v| v.starts_with(&newest)),
+        "every reconciled row must carry the newest generation's ({newest}) value — \
+         otherwise the control is not the LWW winner set and 'did not fall back' \
+         proves nothing, got: {values:?}"
+    );
+}

--- a/cqlite-core/src/storage/sstable/generation_merge/setup_fail_closed_tests.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/setup_fail_closed_tests.rs
@@ -1,0 +1,178 @@
+//! Issue #3154 — END-TO-END pins for what a `KWayMerger::new` failure earns.
+//!
+//! `SSTableManager::scan_stream` is allowed to answer a multi-generation read with the
+//! NON-reconciling token-order concat when the reconciling merge cannot be built. That
+//! substitution returns a FULL-LENGTH but UNRECONCILED result set — duplicated
+//! overwritten rows, resurrected deleted rows — so it is only ever acceptable for an
+//! input the reconciling merger genuinely cannot handle. Before this issue it was
+//! applied to EVERY reported construction failure, so a transient I/O hiccup or a
+//! corrupt file made the query return the wrong rows and report success, behind a
+//! `tracing::warn!`.
+//!
+//! Three arms, one fixture, one oracle:
+//!
+//! * an I/O failure ⇒ the read FAILS (never the concat);
+//! * a corruption failure ⇒ the read FAILS (never the concat);
+//! * a merger-INELIGIBLE (unsupported-format) failure ⇒ the read still degrades to the
+//!   concat, exactly as before. Over-restricting is its own regression — it would turn
+//!   previously-working queries into failures — so that arm is asserted POSITIVELY:
+//!   the concat's own answer must come back, by count AND by value.
+//!
+//! # Why the fixture must OVERLAP, and why the control arm runs first
+//!
+//! Over the shared `multi_gen_fixture`'s overlapping generations, reconciled and
+//! concatenated answers differ by row COUNT and by row VALUE, so "it fell back" and "it
+//! did not" are distinguishable observations rather than a coin flip. Every arm below
+//! first runs `assert_reconciled_control`, which pins that the healthy read really is
+//! the reconciled LWW winner set — without it, an `is_err()`-only assertion (or a
+//! fixture that yields nothing) would pass while proving nothing.
+//!
+//! # Why the failure is INJECTED
+//!
+//! The classification keys on the error VARIANT `KWayMerger::new` reports, and no
+//! on-disk fixture can make that one call site report an I/O error, then a corruption
+//! error, then an unsupported-format error, on demand and deterministically. The
+//! `storage::producer_fault::construction` seam does exactly that, scoped to this
+//! test's own `TempDir` so a concurrently-running test can neither consume nor be hit
+//! by the arm (see that module's doc).
+
+use tempfile::TempDir;
+
+use super::multi_gen_fixture::{
+    assert_reconciled_control, drain_stream, flush_overlapping_generations, newest_value_prefix,
+    open_manager, open_reconciling_stream, reconciled_rows, unreconciled_rows,
+};
+use crate::storage::producer_fault::{
+    arm_merge_construction_error, MergeConstructionFault, INJECTED_CONSTRUCTION_MESSAGE,
+};
+use crate::Error;
+
+/// An arm whose construction failure must PROPAGATE: the read fails, and it fails with
+/// THIS fault's error — never with a full-length unreconciled result set under `Ok`.
+///
+/// `is_expected_variant` is checked on the returned `Error` rather than on its message:
+/// the fix's whole point is that the decision (and therefore the error the caller sees)
+/// is type-level, so a test that only matched on text could not tell the classification
+/// from a coincidence.
+async fn assert_construction_failure_propagates(
+    fault: MergeConstructionFault,
+    is_expected_variant: fn(&Error) -> bool,
+    expected_variant: &str,
+) {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_dir = flush_overlapping_generations(&temp_dir).await;
+    let manager = open_manager(&data_dir).await;
+
+    // Control arm FIRST: the healthy read is the RECONCILED answer, so the fault arm's
+    // "this is not the concat's answer" below is a real observation.
+    assert_reconciled_control(&manager).await;
+
+    let scope = temp_dir.path().to_string_lossy().to_string();
+    let _fault = arm_merge_construction_error(&scope, fault);
+    let outcome = open_reconciling_stream(&manager).await;
+
+    let error = match outcome {
+        Err(e) => e,
+        Ok(stream) => {
+            let (drained, values) = drain_stream(stream).await;
+            panic!(
+                "issue #3154: `KWayMerger::new` reported {fault:?}, which is a RUNTIME \
+                 failure and says nothing about whether the merger supports this input, \
+                 so the read MUST fail. Succeeding means the non-reconciling concat was \
+                 substituted: {} rows (the reconciled answer is {}, the concat's is {}) \
+                 of UNRECONCILED data served as a successful reconciling scan — \
+                 duplicated overwritten rows and resurrected deleted ones. Values: \
+                 {values:?}",
+                drained.rows,
+                reconciled_rows(),
+                unreconciled_rows()
+            )
+        }
+    };
+
+    assert!(
+        is_expected_variant(&error),
+        "the propagated error must stay the {expected_variant} the merger reported — the \
+         caller (and a binding deciding whether a retry could help) needs the real cause, \
+         not a re-labelled one. Got: {error:?}"
+    );
+    assert!(
+        error.to_string().contains(INJECTED_CONSTRUCTION_MESSAGE),
+        "the error must carry THIS fault's message, proving the injected construction \
+         failure (not some unrelated setup problem) is what failed the read. Got: {error}"
+    );
+}
+
+/// A transient I/O error during construction must FAIL the read.
+///
+/// This is the likelier of the two propagating triggers — an I/O hiccup needs no bug at
+/// all — and pre-fix it silently produced the concat's wrong answer under `Ok`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_io_error_from_merger_construction_fails_the_read_instead_of_serving_the_concat() {
+    assert_construction_failure_propagates(
+        MergeConstructionFault::Io,
+        |e| matches!(e, Error::Io(_)),
+        "I/O error",
+    )
+    .await;
+}
+
+/// A corruption / parse error during construction must FAIL the read.
+///
+/// Answering it with the concat would serve data from a file already known to be bad,
+/// under `Ok`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_corruption_error_from_merger_construction_fails_the_read_instead_of_serving_the_concat()
+{
+    assert_construction_failure_propagates(
+        MergeConstructionFault::Corruption,
+        |e| matches!(e, Error::Corruption(_)),
+        "corruption error",
+    )
+    .await;
+}
+
+/// The one arm that must STILL fall back: a genuinely merger-ineligible input.
+///
+/// Asserted POSITIVELY — the read succeeds AND returns the concat's own answer, by count
+/// and by value — because "it did not error" alone would also pass if the fallback had
+/// been narrowed away and replaced by something else entirely. Narrowing too far is its
+/// own regression: it turns a query that used to return the documented (Issue #883)
+/// unreconciled answer into a hard failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_merger_ineligible_input_still_degrades_to_the_documented_concat() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_dir = flush_overlapping_generations(&temp_dir).await;
+    let manager = open_manager(&data_dir).await;
+
+    // Control arm FIRST: prove the healthy read is the RECONCILED answer, so observing
+    // the UNRECONCILED one below really does mean "the concat ran".
+    assert_reconciled_control(&manager).await;
+
+    let scope = temp_dir.path().to_string_lossy().to_string();
+    let _fault = arm_merge_construction_error(&scope, MergeConstructionFault::UnsupportedFormat);
+    let stream = open_reconciling_stream(&manager)
+        .await
+        .expect("an input the reconciling merger cannot handle must still be READABLE via the concat fallback — narrowing that away turns a previously-working query into a failure (issue #3154 AC2)");
+    let (drained, values) = drain_stream(stream).await;
+
+    assert_eq!(
+        drained.error, None,
+        "the concat fallback must complete cleanly, exactly as before"
+    );
+    assert_eq!(
+        drained.rows,
+        unreconciled_rows(),
+        "the fallback must be the documented NON-reconciling concat: every generation's \
+         copy of every partition ({} rows), not the reconciled {}",
+        unreconciled_rows(),
+        reconciled_rows()
+    );
+    let newest = newest_value_prefix();
+    assert!(
+        values.iter().any(|v| !v.starts_with(&newest)),
+        "the fallback's answer must actually contain superseded older-generation values \
+         — that is what identifies it as the concat rather than as some other path that \
+         merely returned the right number of rows. Got: {values:?}"
+    );
+}

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -2105,10 +2105,11 @@ impl SSTableManager {
     /// O(one partition + channel), and time-to-first-row is O(first partition),
     /// not O(full merge). The merger already emits partitions in `(token, key)`
     /// order, byte-identical to `scan`'s `sort_by_token_order`, so the emitted
-    /// order is unchanged (issue #1579 ordering guardrail). On a REPORTED merger
-    /// CONSTRUCTION error this path FALLS BACK to the lazy per-reader streaming
-    /// merge, mirroring `scan`'s fall-back-to-concat; on a merge producer that DIED
-    /// it fails closed instead, because the concat is not reconciling and answering a
+    /// order is unchanged (issue #1579 ordering guardrail). A merger CONSTRUCTION
+    /// failure now PROPAGATES (issue #3154) — the only two it can report,
+    /// `Error::Schema` and a thread-spawn `Error::Storage`, used to be answered with
+    /// the concat, so this diverges from `scan` there (follow-up #3170) — as does a
+    /// merge producer that DIED, because the concat is not reconciling and answering a
     /// panic with it returns full-length WRONG data (issue #3124). The
     /// single-generation / no-schema / no-`write-support` cases keep the lazy
     /// streaming merge, which already matches `scan`'s concat path exactly and
@@ -2124,14 +2125,17 @@ impl SSTableManager {
     ) -> Result<reader::RowScanStream> {
         let readers = self.resolve_table_readers(table_id).await;
 
-        // Issue #957: keep the materializing `scan` and this streaming path
-        // definitionally in lockstep. Reuse the EXACT guard `scan` uses for
-        // cross-generation reconciliation (`reader_list.len() > 1 && schema present`,
-        // write-support only) and the same merger, then forward the reconciled rows
-        // through the streaming channel. Without this, a partition spread across
-        // generations duplicates overwritten rows and resurrects deleted ones in the
-        // stream while `scan` returns the merged, deduplicated, tombstone-honouring
-        // result.
+        // Issue #957: keep the materializing `scan` and this streaming path in lockstep
+        // ON THE SUCCESS PATH. Reuse the EXACT guard `scan` uses for cross-generation
+        // reconciliation (`reader_list.len() > 1 && schema present`, write-support only)
+        // and the same merger, then forward the reconciled rows through the streaming
+        // channel. Without this, a partition spread across generations duplicates
+        // overwritten rows and resurrects deleted ones in the stream while `scan`
+        // returns the merged, deduplicated, tombstone-honouring result. They are NO
+        // LONGER in lockstep on the ERROR path (issue #3154): a schema whose
+        // `dropped_columns` fails `validate_dropped_columns` (`schema/mod.rs:611`, from
+        // `write_engine/merge/mod.rs:1728`) makes THIS path `Err` while `scan` still
+        // concatenates and returns rows — deliberate; follow-up #3170 owns `scan`.
         #[cfg(feature = "write-support")]
         if readers.len() > 1 {
             // No schema: cross-generation LWW/tombstone reconciliation needs the
@@ -2156,28 +2160,24 @@ impl SSTableManager {
                         );
                         return Ok(rx);
                     }
-                    // Never fail a read because the reconciling merge cannot handle the
-                    // INPUT (unsupported format/version); fall back to the lazy
-                    // streaming merge, matching `scan`'s fall-back-to-concatenation.
-                    // Nothing has been streamed at that point, so falling back cannot
-                    // mix reconciled and unreconciled rows, and the concat's documented
-                    // Issue #883 limitation is accepted for a table the reconciling
-                    // merge cannot open at all.
-                    //
-                    // Gated on the TYPE, not on the message (issues #3124/#3154,
-                    // roborev): `fallback_eligible()` is the single predicate, and it is
-                    // true for the merger-INELIGIBLE input ALONE. The other setup
-                    // failures — a REPORTED runtime failure (I/O, corruption, …) and a
-                    // producer that DIED before signalling — deliberately propagate.
-                    // Falling back on either returned a FULL-LENGTH, UNRECONCILED result
-                    // set (duplicated overwritten rows, resurrected deleted rows) as
-                    // `Ok` with only a warning: silently WRONG data, one notch worse
-                    // than the silent truncation #3124 is about.
+                    // Gated on the TYPE, never the message (issues #3124/#3154, roborev):
+                    // `fallback_eligible()` is true for the merger-INELIGIBLE input ALONE;
+                    // every other setup failure propagates, because answering one with the
+                    // concat returned a FULL-LENGTH UNRECONCILED result set under `Ok`.
+                    // This arm is DEFENSIVE and DEAD IN PRODUCTION: `KWayMerger::new`
+                    // cannot report an unsupported format/version — each input's
+                    // `SSTableReader::open`, with every format/version gate, runs in the
+                    // producer thread it spawns (`merge/producer_iter.rs:385-388`) and
+                    // surfaces mid-stream at `step()`; its reachable errors are
+                    // `Error::Schema` + spawn `Error::Storage`, which THIS PR narrowed to
+                    // propagate. Enumeration + why it is kept: `merge_stream_setup`'s doc.
                     Err(setup) if setup.fallback_eligible() => {
                         tracing::warn!(
-                            "SSTableManager::scan_stream - cross-generation merge could not be \
-                             constructed for '{}' ({}); falling back to lazy per-reader \
-                             streaming merge",
+                            "SSTableManager::scan_stream - cross-generation RECONCILING merge \
+                             could not be constructed for '{}' ({}); falling back to the lazy \
+                             per-reader NON-reconciling token-order CONCATENATION: rows are NOT \
+                             last-write-wins reconciled and may contain duplicated overwritten \
+                             rows and rows resurrected from under a tombstone (issue #883)",
                             table_id,
                             setup.into_error()
                         );

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -2156,23 +2156,23 @@ impl SSTableManager {
                         );
                         return Ok(rx);
                     }
-                    // Never fail a read because the merge could not be CONSTRUCTED
-                    // (unsupported input format); fall back to the lazy streaming
-                    // merge, matching `scan`'s fall-back-to-concatenation.
+                    // Never fail a read because the reconciling merge cannot handle the
+                    // INPUT (unsupported format/version); fall back to the lazy
+                    // streaming merge, matching `scan`'s fall-back-to-concatenation.
+                    // Nothing has been streamed at that point, so falling back cannot
+                    // mix reconciled and unreconciled rows, and the concat's documented
+                    // Issue #883 limitation is accepted for a table the reconciling
+                    // merge cannot open at all.
                     //
-                    // Gated on the TYPE, not on the message (issue #3124, roborev):
-                    // `fallback_eligible()` is true for the REPORTED construction
-                    // failure ONLY. Nothing has been streamed at that point, so
-                    // falling back cannot mix reconciled and unreconciled rows, and
-                    // the concat's documented Issue #883 limitation is accepted for a
-                    // table the reconciling merge cannot open at all.
-                    //
-                    // The other setup failure — the producer task DIED before
-                    // signalling — is deliberately NOT eligible and propagates. Falling
-                    // back on a dead producer returned a FULL-LENGTH, UNRECONCILED
-                    // result set (duplicated overwritten rows, resurrected deleted
-                    // rows) as `Ok` with only a warning: silently WRONG data, one notch
-                    // worse than the silent truncation #3124 is about.
+                    // Gated on the TYPE, not on the message (issues #3124/#3154,
+                    // roborev): `fallback_eligible()` is the single predicate, and it is
+                    // true for the merger-INELIGIBLE input ALONE. The other setup
+                    // failures — a REPORTED runtime failure (I/O, corruption, …) and a
+                    // producer that DIED before signalling — deliberately propagate.
+                    // Falling back on either returned a FULL-LENGTH, UNRECONCILED result
+                    // set (duplicated overwritten rows, resurrected deleted rows) as
+                    // `Ok` with only a warning: silently WRONG data, one notch worse
+                    // than the silent truncation #3124 is about.
                     Err(setup) if setup.fallback_eligible() => {
                         tracing::warn!(
                             "SSTableManager::scan_stream - cross-generation merge could not be \

--- a/cqlite-core/src/storage/sstable/scan_stream_fanout_panic_tests.rs
+++ b/cqlite-core/src/storage/sstable/scan_stream_fanout_panic_tests.rs
@@ -20,7 +20,10 @@
 //!
 //! Each test drives the REAL public surface over a REAL multi-generation SSTable
 //! directory built by the write engine, and kills the task under test with a real
-//! `panic!` through the deterministic `storage::producer_fault` seam.
+//! `panic!` through the deterministic `storage::producer_fault` seam. The fixtures,
+//! the drains and the reconciled/unreconciled oracle live in the shared
+//! `generation_merge::multi_gen_fixture` module, so this suite and the issue-#3154
+//! setup-classification suite cannot drift on what "reconciled" means.
 //!
 //! # Control-arm-first, always (issue #3124 acceptance criterion 3)
 //!
@@ -52,162 +55,27 @@
 //! Included via `#[cfg(all(test, feature = "write-support", not(feature =
 //! "tombstones")))] #[path = ...] mod panic_tests;` in [`super`].
 
-use std::path::PathBuf;
-use std::sync::Arc;
-
 use tempfile::TempDir;
 
-use crate::platform::Platform;
 use crate::storage::producer_fault::{
     arm_scan_task_panic, silence_injected_panics, ScanTaskSite, INJECTED_PANIC_MESSAGE,
 };
-use crate::storage::sstable::SSTableManager;
-use crate::storage::write_engine::test_support::{create_test_mutation, create_test_schema};
-use crate::storage::write_engine::{WriteEngine, WriteEngineConfig};
-use crate::types::TableId;
-use crate::Config;
+use crate::storage::sstable::generation_merge::multi_gen_fixture::{
+    assert_reconciled_control, drain_batched, drain_per_row, drain_reconciled, expected_rows,
+    flush_generations, flush_overlapping_generations, newest_value_prefix, open_manager,
+    unreconciled_rows, Drained,
+};
 
-/// Partitions written per generation. Comfortably more than one batch's worth on the
-/// batched surface would need, and enough that a short result is unmistakable.
-const PARTITIONS_PER_GENERATION: i32 = 12;
-
-/// Generations flushed. `> 1` is what routes `scan_stream` to the fan-out merge (the
-/// ≠1-generation path this issue is about) rather than the single-reader fast path.
-const GENERATIONS: i32 = 3;
-
-/// Small enough that the producers park in backpressure mid-scan, so a fault has a
-/// genuinely partial stream to truncate.
-const BUFFER: usize = 2;
-
-/// Write `GENERATIONS` flushes of `PARTITIONS_PER_GENERATION` DISJOINT partitions
-/// each, so every generation contributes rows to the merge and the total row count is
-/// exact and predictable.
-///
-/// Returns the write engine's data root (the directory an `SSTableManager` opens).
-///
-/// Runs on a BLOCKING thread: `WriteEngine::flush` drives its own current-thread
-/// runtime, which cannot be started from inside the test's runtime.
-async fn flush_generations(temp_dir: &TempDir) -> PathBuf {
-    let root = temp_dir.path().to_path_buf();
-    tokio::task::spawn_blocking(move || flush_generations_blocking(&root))
-        .await
-        .expect("fixture build task")
+/// The two assertion shapes THIS suite adds on top of the shared fixture's control
+/// arm: a healthy scan of the DISJOINT fixture is complete, and a faulted one FAILS
+/// short. (The overlapping fixture's control lives in the fixture module, shared with
+/// the issue-#3154 suite so both assert the same oracle.)
+trait PanicArm {
+    fn assert_is_the_complete_control(&self, surface: &str);
+    fn assert_failed_short(&self, surface: &str);
 }
 
-fn flush_generations_blocking(root: &std::path::Path) -> PathBuf {
-    let data_dir = root.join("data");
-    let config = WriteEngineConfig::new(data_dir.clone(), root.join("wal"), create_test_schema());
-    let mut engine = WriteEngine::new(config).expect("write engine");
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("runtime");
-    for generation in 0..GENERATIONS {
-        for offset in 0..PARTITIONS_PER_GENERATION {
-            let id = generation * PARTITIONS_PER_GENERATION + offset;
-            engine
-                .write(create_test_mutation(id, &format!("row-{id}"), 1_000))
-                .expect("write");
-        }
-        rt.block_on(engine.flush())
-            .expect("flush")
-            .expect("flush wrote an SSTable");
-    }
-    data_dir
-}
-
-/// Total rows a healthy scan of the DISJOINT fixture must return.
-const fn expected_rows() -> usize {
-    (GENERATIONS * PARTITIONS_PER_GENERATION) as usize
-}
-
-/// Write `GENERATIONS` flushes that all rewrite the SAME `PARTITIONS_PER_GENERATION`
-/// partitions, each generation with a strictly newer timestamp and a distinguishable
-/// value — the OVERLAPPING fixture site 5 needs (see the header).
-///
-/// A reconciling read returns [`reconciled_rows`] rows, all carrying
-/// [`newest_value_prefix`]; the non-reconciling concat returns [`unreconciled_rows`]
-/// rows, including every older generation's superseded copy. That gap is what lets the
-/// site-5 test assert "it did not silently fall back to the concat".
-async fn flush_overlapping_generations(temp_dir: &TempDir) -> PathBuf {
-    let root = temp_dir.path().to_path_buf();
-    tokio::task::spawn_blocking(move || {
-        let data_dir = root.join("data");
-        let config =
-            WriteEngineConfig::new(data_dir.clone(), root.join("wal"), create_test_schema());
-        let mut engine = WriteEngine::new(config).expect("write engine");
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("runtime");
-        for generation in 0..GENERATIONS {
-            for id in 0..PARTITIONS_PER_GENERATION {
-                engine
-                    .write(create_test_mutation(
-                        id,
-                        &format!("gen{generation}-row-{id}"),
-                        // Strictly increasing, so the LWW winner is unambiguous and
-                        // the newest generation is the one a reconciled read shows.
-                        1_000 + generation as i64,
-                    ))
-                    .expect("write");
-            }
-            rt.block_on(engine.flush())
-                .expect("flush")
-                .expect("flush wrote an SSTable");
-        }
-        data_dir
-    })
-    .await
-    .expect("fixture build task")
-}
-
-/// Rows a RECONCILED read of the overlapping fixture returns: last-write-wins collapses
-/// every generation's copy of a partition into one row.
-const fn reconciled_rows() -> usize {
-    PARTITIONS_PER_GENERATION as usize
-}
-
-/// Rows the NON-reconciling token-order concat returns over the same fixture: every
-/// generation's copy of every partition, superseded ones included.
-const fn unreconciled_rows() -> usize {
-    (GENERATIONS * PARTITIONS_PER_GENERATION) as usize
-}
-
-/// The value prefix only the NEWEST generation's cells carry. Every row of a reconciled
-/// read must have it; a concatenated read also surfaces older prefixes.
-fn newest_value_prefix() -> String {
-    format!("gen{}-", GENERATIONS - 1)
-}
-
-async fn open_manager(data_dir: &std::path::Path) -> SSTableManager {
-    let config = Config::default();
-    let platform = Arc::new(Platform::new(&config).await.expect("platform"));
-    SSTableManager::new(
-        data_dir,
-        &config,
-        platform,
-        #[cfg(feature = "state_machine")]
-        None,
-    )
-    .await
-    .expect("manager")
-}
-
-fn table_id() -> TableId {
-    let schema = create_test_schema();
-    TableId::from(format!("{}.{}", schema.keyspace, schema.table).as_str())
-}
-
-/// How a drained stream ended, plus how many rows it delivered.
-struct Drained {
-    rows: usize,
-    /// `Some(message)` when the stream terminated with an ERROR; `None` on a clean
-    /// end of stream.
-    error: Option<String>,
-}
-
-impl Drained {
+impl PanicArm for Drained {
     /// The control arm's expectations, asserted in ONE place: a healthy scan of the
     /// fixture ends cleanly AND returns every written row. Both halves matter — the
     /// count makes a later "short" assertion meaningful, and the clean end proves the
@@ -253,123 +121,6 @@ impl Drained {
             expected_rows()
         );
     }
-}
-
-/// Drain the per-row surface (`SSTableManager::scan_stream`).
-///
-/// `schema = None` on purpose: with a schema present and `write-support` on, a
-/// multi-generation read routes to the authoritative `KWayMerger`
-/// (`stream_generations_for_read`), NOT the lazy fan-out merge that sites 1 and 2
-/// live on. Each reader still resolves its own schema for decoding, so the rows are
-/// real.
-async fn drain_per_row(manager: &SSTableManager) -> Drained {
-    let mut stream = match manager
-        .scan_stream(&table_id(), None, None, None, BUFFER)
-        .await
-    {
-        Ok(stream) => stream,
-        Err(e) => {
-            return Drained {
-                rows: 0,
-                error: Some(e.to_string()),
-            }
-        }
-    };
-    let mut rows = 0usize;
-    while let Some(item) = stream.recv().await {
-        match item {
-            Ok(_) => rows += 1,
-            Err(e) => {
-                return Drained {
-                    rows,
-                    error: Some(e.to_string()),
-                }
-            }
-        }
-    }
-    Drained { rows, error: None }
-}
-
-/// Drain the batched surface (`SSTableManager::scan_stream_batched`), whose
-/// multi-generation arm is the [`rechunk_into_batches`] adapter — site 3.
-async fn drain_batched(manager: &SSTableManager) -> Drained {
-    let mut stream = match manager
-        .scan_stream_batched(&table_id(), None, None, None, BUFFER)
-        .await
-    {
-        Ok(stream) => stream,
-        Err(e) => {
-            return Drained {
-                rows: 0,
-                error: Some(e.to_string()),
-            }
-        }
-    };
-    let mut rows = 0usize;
-    while let Some(item) = stream.recv().await {
-        match item {
-            Ok(batch) => rows += batch.len(),
-            Err(e) => {
-                return Drained {
-                    rows,
-                    error: Some(e.to_string()),
-                }
-            }
-        }
-    }
-    Drained { rows, error: None }
-}
-
-/// Drain the per-row surface WITH a schema, capturing every row's `name` value.
-///
-/// The schema is what routes a multi-generation read to the authoritative RECONCILING
-/// `KWayMerger` (`stream_generations_for_read`) instead of the lazy concat — i.e. it is
-/// what puts site 5 on the path at all. The captured values are what let the caller tell
-/// a reconciled result set from a concatenated one, which a row COUNT alone cannot do
-/// once a fallback returns a full-length answer.
-async fn drain_reconciled(manager: &SSTableManager) -> (Drained, Vec<String>) {
-    let schema = create_test_schema();
-    let mut stream = match manager
-        .scan_stream(&table_id(), None, None, Some(&schema), BUFFER)
-        .await
-    {
-        Ok(stream) => stream,
-        Err(e) => {
-            return (
-                Drained {
-                    rows: 0,
-                    error: Some(e.to_string()),
-                },
-                Vec::new(),
-            )
-        }
-    };
-    let mut rows = 0usize;
-    let mut values = Vec::new();
-    while let Some(item) = stream.recv().await {
-        match item {
-            Ok((_, row)) => {
-                rows += 1;
-                if let crate::types::ScanRow::Row(cells) = row {
-                    for (column, value) in cells.iter() {
-                        if column.as_ref() == "name" {
-                            values.push(value.as_str().unwrap_or_default().to_string());
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                return (
-                    Drained {
-                        rows,
-                        error: Some(e.to_string()),
-                    },
-                    values,
-                )
-            }
-        }
-    }
-    (Drained { rows, error: None }, values)
 }
 
 /// Site 1: the fan-out k-way MERGE task dies. Pre-fix its `JoinHandle` was discarded
@@ -479,39 +230,12 @@ async fn a_dead_cross_generation_merge_fails_the_scan_instead_of_falling_back_to
     let data_dir = flush_overlapping_generations(&temp_dir).await;
     let manager = open_manager(&data_dir).await;
 
-    // Test precondition: the fixture must make the two answers distinguishable at all.
-    assert_ne!(
-        reconciled_rows(),
-        unreconciled_rows(),
-        "test precondition: with reconciled == unreconciled this test could not tell a \
-         fail-closed read from a silent concat fallback"
-    );
-
-    // Control arm: the healthy read ends cleanly, is RECONCILED (one row per partition)
-    // and shows the newest generation's values.
-    let (control, control_values) = drain_reconciled(&manager).await;
-    assert_eq!(
-        control.error, None,
-        "a healthy multi-generation reconciling read must still end CLEANLY — the \
-         fail-closed join must not turn a live producer into an error"
-    );
-    assert_eq!(
-        control.rows,
-        reconciled_rows(),
-        "the control drain must be RECONCILED: {} partitions rewritten in every \
-         generation collapse to {} rows, not the concat's {}",
-        PARTITIONS_PER_GENERATION,
-        reconciled_rows(),
-        unreconciled_rows()
-    );
+    // Control arm FIRST (shared with the issue-#3154 suite, so both assert the same
+    // oracle): the healthy read ends cleanly, is RECONCILED (one row per partition),
+    // shows only the newest generation's values, and the fixture's two answers are
+    // distinguishable at all.
+    assert_reconciled_control(&manager).await;
     let newest = newest_value_prefix();
-    assert!(
-        control_values.len() == reconciled_rows()
-            && control_values.iter().all(|v| v.starts_with(&newest)),
-        "every reconciled row must carry the newest generation's ({newest}) value — \
-         otherwise the control is not the LWW winner set and 'did not fall back' below \
-         proves nothing, got: {control_values:?}"
-    );
 
     let scope = temp_dir.path().to_string_lossy().to_string();
     let (faulted, faulted_values) = {


### PR DESCRIPTION
Closes #3154.

> **Note:** an earlier revision of this body claimed the fallback-eligible set is "`UnsupportedFormat | UnsupportedVersion` — the only errors that are evidence about the input". That was **wrong, and the inverse of the truth**; `rust-reviewer` caught it. The body below is corrected, and [the correction is recorded in a comment](https://github.com/pmcfadin/cqlite/pull/3169#issuecomment-5136883657) rather than silently edited away.

## The defect

`generation_merge.rs` built `MergeStreamSetupError::Construction(e)` from **any** error out of
`KWayMerger::new`, and the consumer in `storage/sstable/mod.rs` treats `Construction` as
fallback-eligible — degrading to `spawn_fanout_merge`, the **non-reconciling token-order concat**.

So an I/O error, a corrupt input, or a schema-validation failure made the query return a full-length
**UNRECONCILED** result set under `Ok` — duplicate overwritten rows and resurrected deleted rows —
behind only a `tracing::warn!`. Pre-existing on `main`; found during the #3124 review (PR #3153).

## The fix — a type-level split, one predicate

`Construction` splits into:

- **`MergerIneligible`** — fallback-**eligible**, for errors that are *evidence about the input*
  (`Error::UnsupportedFormat` | `Error::UnsupportedVersion`).
- **`ConstructionFailed`** — anything else: **propagates verbatim**, so `is_recoverable()` stays honest
  for the Python/Node bindings (`Io`/`Storage` → true, `Corruption`/`Schema` → false).

`from_construction_failure` matches on the `Error` variant with a **fail-closed catch-all** (a future
variant cannot silently become fallback-eligible; the arm points at the enumerated test table for a
future author). `fallback_eligible()` remains the **single** predicate. No error-message string
matching anywhere (AC4).

## What actually changes behaviour — read this before the AC table

`KWayMerger::new` **cannot return `UnsupportedFormat` or `UnsupportedVersion`.** Its only fallible
steps are `Error::InvalidInput` on empty inputs (`merge/mod.rs:1718`, unreachable under
`readers.len() > 1`), `Error::Schema` from `validate_dropped_columns` (`:1728` → `schema/mod.rs:611`),
and `Error::Storage("streaming producer: failed to spawn thread")` from
`SSTableRowIteratorAdapter::open` (`:1746` → `producer_iter.rs:275`). That `open` **opens nothing** —
`SSTableReader::open` and every format/version gate run inside the spawned producer thread
(`producer_iter.rs:385-388`) and surface mid-stream at `merger.step()`.

Therefore:

1. **`MergerIneligible` is dead in production** — only the test-only injection seam constructs it. An
   unsupported-format generation never degraded to the concat *at this site*, before or after this
   change. The arm is retained **deliberately defensively**, so a future eager-validating constructor
   keeps the documented #883 degradation.
2. **The real behaviour change is that `Error::Schema` and `Error::Storage` now propagate** — those are
   the two errors that genuinely were reaching the concat and serving unreconciled rows.
3. **AC2 therefore holds for a narrower reason than it looks:** the concat path is preserved, and the
   AC2 test proves the *classifier*, not an end-to-end degradation.

All of that is now stated in the code (`merge_stream_setup.rs` module doc + variant docs + the
consumer comment), which is the substance of the review blocker this PR fixed.

## Evidence the tests can fail

The AC1 arms were **watched RED before the fix**: each observed **36 UNRECONCILED rows under `Ok`**
where the reconciled answer is **12**. The fixture rewrites the *same* 12 partition ids across 3
generations at ts 1000/1001/1002 with values `gen{N}-row-{id}`, so reconciled (12, all `gen2-`) and
concat (36, including older prefixes) differ by row count **and** by value. Every arm calls
`assert_reconciled_control` **first**, on a good run, before injecting the failure (AC3).

| AC | Covered by |
|----|-----------|
| 1 — I/O and corruption each propagate as `Err` | `setup_fail_closed_tests.rs` Io + Corruption arms (RED pre-fix) |
| 2 — a merger-ineligible input still degrades to the concat | `a_merger_ineligible_input_still_degrades_to_the_documented_concat` (36 rows **and** older-gen values present; green before *and* after) |
| 3 — overlapping fixture, control-arm-first | `multi_gen_fixture.rs`; `assert_reconciled_control` in every arm |
| 4 — single type-level predicate, no string matching | `merge_stream_setup.rs` unit table (9 variants, incl. the fail-closed default) |

## Two claims this change invalidated, also fixed here

- **`scan_stream` and `scan` are no longer "definitionally in lockstep"** — for a schema whose
  `dropped_columns` fails validation, `scan_stream` now returns `Err` while `scan` still returns
  concatenated rows. The comment asserting lockstep is corrected and points at #3170.
- **The fallback `tracing::warn!` never told the operator the rows were unreconciled.** It now names
  the non-reconciling concatenation and its consequence (duplicated overwritten rows, resurrected
  deleted rows, #883).

## Review

- **roborev: PASS, findings NONE** — non-vacuous, re-run after the blocker fix
  (`reviewed-sha: f8f7adf..396a649`, 9/9 census paths in the prompt, both vacuity tiers PASS).
- **rust-reviewer: 1 blocker, now fixed** (the claim layer above). It independently verified as clean:
  the fail-closed direction, the honest `cfg` gating (no `#[allow(dead_code)]`; a minimal build compiles
  none of the seam), the `is_recoverable` honesty per variant, and the non-vacuity of every test arm.

## Files

| File | Change |
|------|--------|
| `generation_merge/merge_stream_setup.rs` | 135 → 356 (the split, the predicate, the unit table, the corrected enumeration) |
| `generation_merge.rs` | 707 → 732 |
| `generation_merge/multi_gen_fixture.rs` | new, +349 (overlapping fixture, extracted from the #3124 suite, which shrank 560 → 284) |
| `generation_merge/setup_fail_closed_tests.rs` | new, +177 |
| `producer_fault/construction.rs` | new, +225 (scoped `Err`-injection registry, `cfg`-gated to `write-support ∧ ¬tombstones`) |
| `producer_fault.rs` | 758 → 749 (silencing split to `producer_fault/silence.rs`) |
| `sstable/mod.rs` | **line-neutral** (3138 → 3138, comments only — the file is over the size threshold) |

## Out of scope — follow-up #3170

The materializing `scan` path swallows *any* error from `merge_generations_for_read` — including
mid-collection `step()` failures — on all four sites (`sstable/mod.rs:1134`, `:1482`, `:1650`,
`:1847`), and #3154's predicate is **bypassed** there entirely. A `tombstones` build routes
`scan_stream` through `scan`, so that configuration retains this defect until #3170 lands.