### PR TITLE
fix(#3140,#3146): retire the dead StaticColumnsWithDeletions bypass guard and pin both Flight row-drive loops (residual ACs; both defects already fixed by #3122)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -418,45 +418,6 @@ impl SSTableReader {
             .collect()
     }
 
-    /// Whether this SSTable's OWN `Statistics.db` declares that it may contain a
-    /// DELETION of any kind — a partition/row/range/cell tombstone or a TTL'd cell.
-    ///
-    /// Authoritative on-disk metadata (issue #28), read with CASSANDRA'S OWN
-    /// comparison: `EncodingStats`'s constructor normalizes "no local deletion time"
-    /// to `DELETION_TIME_EPOCH` — `minLocalDeletionTime ==
-    /// LivenessInfo.NO_EXPIRATION_TIME ? DELETION_TIME_EPOCH : minLocalDeletionTime`
-    /// (`db/rows/EncodingStats.java`, pinned `cassandra-5.0.8`) — and Cassandra itself
-    /// tests "this stat records no deletion" as
-    /// `stats.minLocalDeletionTime != DELETION_TIME_EPOCH` before feeding a metadata
-    /// collector. So EPOCH means "no deletion recorded", NOT "a deletion in 2015".
-    ///
-    /// Note for anyone comparing with `sstabledump`: its
-    /// `SSTable min local deletion time: no tombstones (9223372036854775807)` line is
-    /// `StatsMetadata`'s SEPARATE field with its own `Long.MAX_VALUE` sentinel — a
-    /// different stat from the `EncodingStats` one read here.
-    ///
-    /// It is a MAY, deliberately: the metadata cannot distinguish a CELL tombstone from
-    /// a row/range/partition one or a TTL'd cell, so a caller that must fail closed on
-    /// one deletion shape fails closed on all of them.
-    ///
-    /// `false` means "this file declares NO deletion at all" and is authoritative only
-    /// when `Statistics.db` was parsed; with no statistics this reports `true`
-    /// (unknown ⇒ assume deletions ⇒ the caller fails closed).
-    pub fn may_contain_deletions(&self) -> bool {
-        // Cassandra `EncodingStats.DELETION_TIME_EPOCH` — Sept 22 2015 00:00:00 UTC in
-        // SECONDS, the vint base the stat is serialized against
-        // (`writeUnsignedVInt32((int)(stats.minLocalDeletionTime - DELETION_TIME_EPOCH))`).
-        // The repo's writer carries the same constant
-        // (`writer::stats_writer::DELETION_TIME_EPOCH`).
-        const DELETION_TIME_EPOCH: i64 = 1_442_880_000;
-        match self.statistics_reader.as_ref() {
-            Some(stats) => {
-                stats.statistics().timestamp_stats.min_deletion_time != DELETION_TIME_EPOCH
-            }
-            None => true,
-        }
-    }
-
     /// Whether [`Self::on_disk_static_columns`] is an ANSWER rather than an
     /// absence of information: `true` when the serialization header was parsed
     /// (so "no static columns" is authoritative), `false` when there is nothing

--- a/cqlite-flight/src/bypass.rs
+++ b/cqlite-flight/src/bypass.rs
@@ -187,34 +187,6 @@ pub enum BypassReason {
     ///   question cannot be answered at all
     ///   ([`SSTableReader::static_columns_are_known`]).
     StaticColumns,
-    /// A STATIC-bearing table whose SSTable declares at least one DELETION, so it may
-    /// contain a simple CELL tombstone — a shape on which the two arms genuinely
-    /// diverge today (issue #3140).
-    ///
-    /// Mechanism, measured on the CASSANDRA-WRITTEN `test_tomb.static_with_tombstones`
-    /// (one generation; its `ck = 3` carries a cell tombstone on `row_col`):
-    /// * the MERGE arm is CORRECT — `assemble_read_cells` drops a simple cell
-    ///   tombstone, the column reads null, and `SELECT *` returns Cassandra's 3 rows;
-    /// * the single-generation FAST arm surfaces the tombstone as a raw
-    ///   `Value::Tombstone`, and the Arrow encoder then hard-errors
-    ///   (`expected Text value, got Tombstone(..)`), aborting `do_get` with ZERO rows.
-    ///
-    /// That is a read-path ARM DIVERGENCE on real Cassandra bytes — precisely what this
-    /// predicate exists to fail closed on — and it is DISTINCT from #3094, which is a
-    /// CQLite-WRITTEN shape reproducing identically on BOTH arms (so not a divergence
-    /// at all). Fixing the fast arm's cell-tombstone handling is issue #3140; when that
-    /// lands, THIS variant and its predicate branch are retired and
-    /// `test_tomb.static_with_tombstones` becomes an ordinary both-arms differential.
-    ///
-    /// Deliberately scoped to STATIC-bearing tables — the tables #3095 newly admitted
-    /// to the fast arm. The same fast-arm defect exists for a NON-static
-    /// single-generation table, but that is pre-existing #3058 behaviour this change
-    /// does not touch (and is #3140's remit). Narrowing further is not possible from
-    /// authoritative metadata: `EncodingStats.minLocalDeletionTime` cannot tell a cell
-    /// tombstone from a row/range/partition one or a TTL'd cell (see
-    /// [`SSTableReader::may_contain_deletions`]), so a static-bearing file that
-    /// declares NO deletion at all still takes the fast arm.
-    StaticColumnsWithDeletions,
 }
 
 impl BypassReason {
@@ -277,18 +249,17 @@ pub fn bypass_reason(
     {
         return BypassReason::StaticColumns;
     }
-    // Issue #3140 (fail-closed, scoped to the static-bearing tables #3095 newly
-    // admitted): a simple CELL tombstone diverges between the arms — the merge arm
-    // drops it (column reads null, matching Cassandra) while the fast arm surfaces a
-    // raw `Value::Tombstone` the Arrow encoder rejects, aborting `do_get` with zero
-    // rows. The narrowest AUTHORITATIVE pre-read signal is "this file declares a
-    // deletion at all" (`EncodingStats.minLocalDeletionTime`); the metadata cannot
-    // single out a cell tombstone. A static-bearing file that declares NO deletion
-    // still takes the fast arm.
-    let has_statics = !declared_static.is_empty() || !only.on_disk_static_columns().is_empty();
-    if has_statics && only.may_contain_deletions() {
-        return BypassReason::StaticColumnsWithDeletions;
-    }
+    // NO deletion guard here (issue #3140, RETIRED). A static-bearing SSTable that may
+    // contain a simple CELL tombstone used to fail closed to the merge arm, because the
+    // fast arm surfaced the deleted cell as a raw `Value::Tombstone` the Arrow encoder
+    // rejected. The single-generation decoder now drops a simple cell tombstone at its
+    // source (`row_decoder`'s `PartitionShadow::cell_tombstone_dropped`, PR #3122), so
+    // both arms return Cassandra's rows with the column NULL and there is nothing left
+    // to fail closed on. Pinned end to end on the CASSANDRA-WRITTEN
+    // `test_tomb.static_with_tombstones` by `issue_3095_flight_static_columns.rs`, whose
+    // `static_with_tombstones/select-star` case is now an ordinary both-arms
+    // differential (and asserts the bypass leg built ZERO mergers, so it cannot pass by
+    // silently routing back to the merge arm).
     if schema
         .columns
         .iter()

--- a/cqlite-flight/src/bypass_tests.rs
+++ b/cqlite-flight/src/bypass_tests.rs
@@ -54,26 +54,21 @@ fn aggregating_request_never_selects_the_fast_path() {
     );
 }
 
-/// Issue #3095: a DECLARED static column no longer forces the merge arm by ITSELF, and
-/// what forces it now is the CELL-TOMBSTONE divergence (issue #3140) — a static-bearing
-/// file that MAY contain a deletion.
+/// Issue #3095: a DECLARED static column does not force the merge arm — and, since the
+/// #3140 deletion guard was RETIRED, nothing else about this file does either.
 ///
-/// The observable statement at this level is that the refusal REASON changed: a
-/// static-bearing schema is no longer refused for BEING static
-/// (`BypassReason::StaticColumns`); it is refused only when the file also declares a
-/// deletion (`StaticColumnsWithDeletions`). The deletion-FREE half — a static-bearing
-/// file SELECTED for the fast arm — cannot be shown on a CQLite-WRITTEN fixture (see the
-/// note below) and is asserted on real Cassandra bytes by
-/// `issue_3095_flight_static_columns.rs`, where `test_deltas.static_with_rows` and
-/// `test_writeparity.static_clustering_shape` both take the bypass.
+/// The fixture is the sharp case for that retirement. CQLite's own `Statistics.db`
+/// writer does not emit Cassandra's `EncodingStats.DELETION_TIME_EPOCH` "no deletion
+/// recorded" sentinel, so every CQLite-written file used to report
+/// `may_contain_deletions() == true` and every static-bearing CQLite fixture therefore
+/// tripped the guard (`BypassReason::StaticColumnsWithDeletions`). With the fast arm's
+/// cell-tombstone handling fixed at its source (PR #3122,
+/// `row_decoder`'s `PartitionShadow::cell_tombstone_dropped`) that guard is gone, so
+/// this same fixture is now SELECTED.
 ///
-/// OUT-OF-SCOPE OBSERVATION, recorded rather than worked around: CQLite's own
-/// `Statistics.db` writer does not emit Cassandra's `EncodingStats.DELETION_TIME_EPOCH`
-/// "no deletion recorded" sentinel for a deletion-free SSTable, so
-/// `may_contain_deletions()` reports `true` for every CQLite-written file. That is the
-/// SAFE direction (the fast arm is refused and the correct merge arm serves the request)
-/// and it affects CQLite-written fixtures only — the real Cassandra fixtures
-/// discriminate correctly.
+/// The Cassandra-bytes half is `issue_3095_flight_static_columns.rs`, where
+/// `test_deltas.static_with_rows`, `test_writeparity.static_clustering_shape` AND the
+/// deletion-bearing `test_tomb.static_with_tombstones` all take the bypass.
 #[test]
 fn a_declared_static_column_no_longer_forces_the_merge_arm() {
     use crate::testutil::{simple_schema, write_row};
@@ -87,51 +82,11 @@ fn a_declared_static_column_no_longer_forces_the_merge_arm() {
     if let Some(c) = schema.columns.iter_mut().find(|c| c.name == "name") {
         c.is_static = true;
     }
-    let reason = bypass_reason(&readers, &schema, ForcedMergePath::Auto, false);
-    assert_ne!(
-        reason,
-        BypassReason::StaticColumns,
-        "issue #3095: a static column the schema DECLARES is no longer refused for \
-         BEING static"
-    );
     assert_eq!(
-        reason,
-        BypassReason::StaticColumnsWithDeletions,
-        "…it is refused only by the #3140 deletion guard, which this CQLite-written \
-         fixture trips (see the note on CQLite's stats writer)"
-    );
-}
-
-/// Issue #3140 fail-closed branch, and its SCOPE: the guard applies to static-bearing
-/// tables ONLY — a deletion-bearing NON-static table keeps its pre-existing #3058 fast
-/// path, so this is not "any tombstone blocks the bypass".
-///
-/// A static-bearing file that MAY contain a simple cell tombstone must take the merge
-/// arm: the merge arm drops the tombstone (column reads null, matching Cassandra) while
-/// the fast arm surfaces a raw `Value::Tombstone` the Arrow encoder rejects, aborting
-/// `do_get` with zero rows. Retire this test with the variant when #3140 lands.
-#[test]
-fn the_deletion_guard_is_scoped_to_static_bearing_tables() {
-    use crate::testutil::{delete_row, simple_schema, write_row};
-    let (_temp, readers) = open_readers(vec![vec![write_row(1, "a", 10, 100), delete_row(2, 200)]]);
-    assert!(
-        readers[0].may_contain_deletions(),
-        "the fixture must declare a deletion for this case to mean anything"
-    );
-    let mut static_schema = simple_schema();
-    if let Some(c) = static_schema.columns.iter_mut().find(|c| c.name == "name") {
-        c.is_static = true;
-    }
-    assert_eq!(
-        bypass_reason(&readers, &static_schema, ForcedMergePath::Auto, false),
-        BypassReason::StaticColumnsWithDeletions,
-        "static + may-contain-deletions fails closed to the merge arm"
-    );
-    assert_eq!(
-        bypass_reason(&readers, &simple_schema(), ForcedMergePath::Auto, false),
+        bypass_reason(&readers, &schema, ForcedMergePath::Auto, false),
         BypassReason::Selected,
-        "a deletion-bearing NON-static table keeps its pre-existing #3058 fast path — \
-         the guard is NOT 'any table with a tombstone'"
+        "issue #3095: a static column the schema DECLARES is not refused for BEING \
+         static; issue #3140: nor is the file refused for declaring a deletion"
     );
 }
 

--- a/cqlite-flight/tests/differential_fixtures/mod.rs
+++ b/cqlite-flight/tests/differential_fixtures/mod.rs
@@ -166,8 +166,9 @@ pub async fn build_shapes_fixture() -> (tempfile::TempDir, PathBuf) {
     // `write_engine::merge::read_assembly::assemble_read_cells`. So the pre-#3094
     // defect WAS an arm divergence, of the same shape as #3140; the two differ only
     // in who WROTE the tombstone (#3140 Cassandra, #3094 CQLite), which is why
-    // #3140's `BypassReason::StaticColumnsWithDeletions` fail-closed guard is
-    // independent of this and stays pinned by `statics/select-star`.)
+    // #3140's `BypassReason::StaticColumnsWithDeletions` fail-closed guard was
+    // independent of this — and, once #3122 landed that same fix, was itself retired,
+    // so `statics/select-star` is now a plain both-arms differential.)
     engine
         .write(base(
             1,

--- a/cqlite-flight/tests/issue_3058_forced_path_differential.rs
+++ b/cqlite-flight/tests/issue_3058_forced_path_differential.rs
@@ -20,13 +20,12 @@
 //!     (`test_compaction_tombstone_ttl`): range tombstone, row deletion,
 //!     expired-TTL cell + expired row-liveness marker, surviving live rows;
 //!   * STATIC columns (issues #3095 / #3140): #3095 retired "any static column
-//!     refuses the fast arm", so a DELETION-FREE static-bearing table now takes the
-//!     fast arm — pinned here by `cassandra/static_clustering_shape(declared static,
-//!     both arms)` and, end to end, by `issue_3095_flight_static_columns.rs`. What
-//!     still fails closed, pinned by `statics/select-star`, is a static-bearing SSTable
-//!     that MAY contain a deletion
-//!     (`BypassReason::StaticColumnsWithDeletions`, the cell-tombstone arm divergence
-//!     #3140) and a static column present ON DISK that the ticket DDL does not declare
+//!     refuses the fast arm" and #3140 retired the follow-on "…and it declares a
+//!     deletion" guard, so a static-bearing table takes the fast arm either way —
+//!     pinned here by `cassandra/static_clustering_shape(declared static, both arms)`
+//!     and by the deletion-bearing `statics/select-star`, and end to end by
+//!     `issue_3095_flight_static_columns.rs`. What still fails closed is a static
+//!     column present ON DISK that the ticket DDL does not declare
 //!     (`BypassReason::StaticColumns`, the `@stale-ddl` case);
 //!   * a CQLite-written fixture carrying a partition deletion, a range tombstone,
 //!     a row deletion, a SIMPLE CELL TOMBSTONE (issue #3094), an expired-TTL cell
@@ -611,65 +610,63 @@ async fn forced_path_differential_agrees_on_every_shape() {
         }
     }
 
-    // ---- Static columns: FAIL-CLOSED to the merge arm (issues #3095 / #3140) ----
-    // #3095 retired the "any static column refuses the fast arm" exclusion, but a
-    // static-bearing SSTable that MAY contain a deletion still fails closed
-    // (`BypassReason::StaticColumnsWithDeletions`): a simple CELL tombstone diverges
-    // between the arms — the merge arm drops it (column reads null, Cassandra's answer)
-    // while the fast arm surfaces a raw `Value::Tombstone` the Arrow encoder rejects.
-    // This fixture contains a row deletion, so it takes that branch.
+    // ---- Static columns: BOTH ARMS (issues #3095 / #3140) -------------------
+    // #3095 retired the "any static column refuses the fast arm" exclusion, and #3140
+    // has now retired the follow-on guard that still refused a static-bearing SSTable
+    // declaring a DELETION (`BypassReason::StaticColumnsWithDeletions`). That guard
+    // existed because a simple CELL tombstone diverged between the arms — the merge arm
+    // dropped it (column reads null, Cassandra's answer) while the fast arm surfaced a
+    // raw `Value::Tombstone` the Arrow encoder rejected. PR #3122 fixed the fast arm at
+    // its source (`row_decoder`'s `PartitionShadow::cell_tombstone_dropped`), so this
+    // fixture — which contains a row deletion — is now SERVED by the fast arm and is an
+    // ordinary both-arms differential. `assert_arms_agree` requires the bypass leg to
+    // build ZERO mergers, so a silent relapse to the merge arm fails the case.
     //
     // SCOPE, so this is not mistaken for a Cassandra oracle: the fixture is
     // CQLITE-WRITTEN, so its ROW CONTENT proves nothing about Cassandra (it is
     // invariant to a uniform error and subject to the write-side #1074 — #3042). What
-    // it proves is that both FORCED values behave identically and that the fast arm is
-    // refused. The Cassandra-parity oracle is
+    // it proves is that both FORCED values return the same rows and that the fast arm
+    // is genuinely taken. The Cassandra-parity oracle is
     // `cqlite-flight/tests/issue_3095_flight_static_columns.rs`, on Cassandra-written
-    // fixtures including a static-ONLY partition; the deletion-FREE static fixtures
-    // there DO take the fast arm, which is where #3095's AC5 is demonstrated.
+    // fixtures including a static-ONLY partition and the deletion-bearing
+    // `test_tomb.static_with_tombstones`.
     let (_stemp, statics_dir) = build_statics_fixture().await;
     let ssvc = CqliteFlightService::new(statics_dir, 8192);
     let sticket = ticket_json(KS, STATIC_TBL, STATIC_DDL);
-    assert_refused_schema_unchanged(
+    // Not just "agreed": pin the SHAPE both arms return, so an agreed-but-wrong result
+    // set (a phantom `ck = null` row alongside the real rows, or a dropped rowless
+    // partition) cannot pass. Expected per Cassandra's `processPartition()`: pk=1's two
+    // clustering rows carrying `s1`; ONE row for the static-only pk=2; ONE row for
+    // pk=3, whose only clustering row was deleted.
+    if let Some(rows) = assert_arms_agree(
         "statics/select-star",
         &ssvc,
         &sticket,
         NOW_BEFORE_EXPIRY,
-        None,
+        4,
         &mut failures,
     )
-    .await;
-    // Not just "refused and identical": pin the SHAPE the merge arm returns, so an
-    // agreed-but-wrong result set (a phantom `ck = null` row alongside the real rows, or
-    // a dropped rowless partition) cannot pass. Expected per Cassandra's
-    // `processPartition()`: pk=1's two clustering rows carrying `s1`; ONE row for the
-    // static-only pk=2; ONE row for pk=3, whose only clustering row was deleted.
-    std::env::set_var(TTL_NOW_ENV, NOW_BEFORE_EXPIRY.to_string());
-    let static_rows = do_get_outcome(&ssvc, &sticket).await;
-    std::env::remove_var(TTL_NOW_ENV);
-    match static_rows {
-        Err(e) => failures.push(format!("statics/select-star: do_get failed: {e}")),
-        Ok(rows) => {
-            let mut shape: Vec<(String, String, String)> = rows
-                .iter()
-                .map(|r| {
-                    let get = |c: &str| r.get(c).cloned().unwrap_or_else(|| "<missing>".into());
-                    (get("pk"), get("ck"), get("s"))
-                })
-                .collect();
-            shape.sort();
-            let expected: Vec<(String, String, String)> = vec![
-                ("1".into(), "1".into(), "s1".into()),
-                ("1".into(), "2".into(), "s1".into()),
-                ("2".into(), "<null>".into(), "s2-only".into()),
-                ("3".into(), "<null>".into(), "s3-rows-deleted".into()),
-            ];
-            if shape != expected {
-                failures.push(format!(
-                    "statics/select-star: the (pk, ck, s) shape is not Cassandra's — \
-                     expected {expected:#?}, got {shape:#?}"
-                ));
-            }
+    .await
+    {
+        let mut shape: Vec<(String, String, String)> = rows
+            .iter()
+            .map(|r| {
+                let get = |c: &str| r.get(c).cloned().unwrap_or_else(|| "<missing>".into());
+                (get("pk"), get("ck"), get("s"))
+            })
+            .collect();
+        shape.sort();
+        let expected: Vec<(String, String, String)> = vec![
+            ("1".into(), "1".into(), "s1".into()),
+            ("1".into(), "2".into(), "s1".into()),
+            ("2".into(), "<null>".into(), "s2-only".into()),
+            ("3".into(), "<null>".into(), "s3-rows-deleted".into()),
+        ];
+        if shape != expected {
+            failures.push(format!(
+                "statics/select-star: the (pk, ck, s) shape is not Cassandra's — \
+                 expected {expected:#?}, got {shape:#?}"
+            ));
         }
     }
 

--- a/cqlite-flight/tests/issue_3094_flight_core_partition_delete_agreement.rs
+++ b/cqlite-flight/tests/issue_3094_flight_core_partition_delete_agreement.rs
@@ -54,12 +54,23 @@
 //! requires a single reader, so a two-generation table always takes the merge arm.
 //! The probe assertion below proves that is what ran.
 //!
-//! ## Both `do_get` row producers
+//! ## All THREE `do_get` producers (issue #3146 AC4)
 //!
-//! `entry_to_row` is shared by `drive_merge` (the row stream) AND
-//! `drive_aggregate` (pushed-down aggregation, #841), so the same phantom corrupts
-//! a `count(*)`. Both are asserted: the row stream must yield exactly `ck = 9`, and
-//! the pushed-down `count(*)` must be `1`, not `2`.
+//! `entry_to_row` is shared by all three drive loops, so the same phantom corrupts
+//! every one of them, and each is pinned here:
+//!
+//! | leg | reached via | asserted |
+//! |---|---|---|
+//! | `drive_merge_streaming` → `MergeRowSource::materialize_pending` | `do_get` itself (`streaming.rs` → `produce_streaming` → `drive_merge_over`), and directly via `MergeProducer::produce_streaming_to_vec` | exactly `ck = 9` |
+//! | `drive_merge` (buffered, whole-partition) | `MergeProducer::produce_from_paths` → `merge_paths` | exactly `ck = 9` |
+//! | `drive_aggregate` (pushed-down aggregation, #841) | an aggregating ticket through `do_get` | `count(*) == 1`, not `2` |
+//!
+//! The two ROW loops are driven through the producer routes that select them by
+//! CONSTRUCTION rather than relying on which one `do_get` currently picks —
+//! measured on this branch, `do_get` routes to the STREAMING loop, so without the
+//! explicit `produce_from_paths` leg the buffered loop would be unpinned. Both
+//! share the `KWayMerger`, so the second leg is correct by construction; "by
+//! construction" is not a regression pin, which is what AC4 asks for.
 //!
 //! ## Oracle choice (#3042)
 //!
@@ -112,6 +123,9 @@ use cqlite_core::storage::write_engine::{
 };
 use cqlite_core::types::{TableId as CqlTableId, Value};
 use cqlite_core::{Config, ScanRow};
+use cqlite_flight::cancel::CancelFlag;
+use cqlite_flight::filter::ScanSpec;
+use cqlite_flight::producer::MergeProducer;
 use cqlite_flight::service::CqliteFlightService;
 
 const TTL_NOW_ENV: &str = "CQLITE_TTL_NOW_OVERRIDE_SECS";
@@ -459,6 +473,45 @@ fn count_star_of(batches: &[RecordBatch]) -> i64 {
     totals[0]
 }
 
+/// The `ck` values each of Flight's TWO row-drive loops yields for the table
+/// directory under `root`, driven through the producer routes that select them by
+/// CONSTRUCTION rather than by whatever `do_get` happens to route to today
+/// (issue #3146 AC4).
+///
+/// * `MergeProducer::produce_from_paths` → `merge_paths` → `drive_merge` — the
+///   BUFFERED, whole-partition-at-a-time collect loop (`producer_drive.rs:43`);
+/// * `MergeProducer::produce_streaming_to_vec` → `produce_streaming` →
+///   `drive_merge_over` → `drive_merge_streaming` → `MergeRowSource::
+///   materialize_pending` (`row_source.rs`) — the ROW-GRANULAR loop, and the one
+///   `do_get` itself streams through (`streaming.rs:477`).
+///
+/// Both drive loops call the same `entry_to_row` over the same `KWayMerger`, so
+/// the streaming leg is correct BY CONSTRUCTION — but "by construction" is not a
+/// pin, and #3146 AC4 requires every arm that can reach this shape to fail if it
+/// regresses. Returns `(buffered ck values, streaming ck values)`.
+fn producer_route_ck_values(root: &Path, schema: &TableSchema) -> (Vec<i32>, Vec<i32>) {
+    let producer = MergeProducer::with_spec(schema.clone(), 8192, ScanSpec::default())
+        .expect("build a MergeProducer over the fixture schema");
+    let paths: Vec<PathBuf> = data_db_paths_by_generation(&root.join(KS).join(TBL))
+        .into_iter()
+        .map(|(_, p)| p)
+        .collect();
+    assert_eq!(
+        paths.len(),
+        2,
+        "both producer routes must see the SAME two generations the surfaces above read"
+    );
+
+    let buffered = producer
+        .produce_from_paths(paths.clone())
+        .unwrap_or_else(|e| panic!("buffered drive_merge route must not error: {e}"));
+    let streaming = producer
+        .produce_streaming_to_vec(paths, &CancelFlag::new())
+        .unwrap_or_else(|e| panic!("streaming drive_merge_streaming route must not error: {e}"));
+
+    (ck_values_of(&buffered), ck_values_of(&streaming))
+}
+
 /// Read one root through BOTH surfaces at the pinned `now` and return
 /// `(core ck values, flight ck values, flight count(*), mergers built)`.
 async fn read_both_surfaces(root: &Path, schema: &TableSchema) -> (Vec<i32>, Vec<i32>, i64, u64) {
@@ -543,6 +596,22 @@ async fn flight_do_get_agrees_with_core_on_a_partition_deleted_row() {
             live_core.len()
         ));
     }
+    // Issue #3146 AC4, anti-vacuity half: BOTH row-drive loops physically see both
+    // rows before any partition tombstone exists, so the `[CK_SURVIVOR]` expectation
+    // below cannot be satisfied by a route that silently reads nothing.
+    let (live_buffered, live_streaming) = producer_route_ck_values(&live_root, &schema);
+    for (leg, got) in [
+        ("buffered drive_merge", &live_buffered),
+        ("streaming drive_merge_streaming", &live_streaming),
+    ] {
+        if got != &live_core {
+            failures.push(format!(
+                "fixture sanity ({leg}): with NO partition deletion present this drive \
+                 loop must return the same rows core does — core {live_core:?}, {leg} \
+                 {got:?}"
+            ));
+        }
+    }
 
     // ---- (2) THE PIN: the patched partition deletion ------------------------
     patch_newest_generation_partition_deletion(&deleted_table_dir);
@@ -585,6 +654,36 @@ async fn flight_do_get_agrees_with_core_on_a_partition_deleted_row() {
              Both drive the same KWayMerger, so the visibility decision must be shared, not \
              re-derived per consumer."
         ));
+    }
+    // ---- (3) Issue #3146 AC4: BOTH row-drive loops, pinned by construction --
+    // `do_get` above streams through `drive_merge_streaming`; the buffered
+    // `drive_merge` collect loop is reached only via `produce_from_paths`. Driving
+    // both explicitly means neither can regress unnoticed, and neither depends on
+    // which route `do_get` happens to select in a future refactor.
+    let (del_buffered, del_streaming) = producer_route_ck_values(&deleted_root, &schema);
+    for (leg, got) in [
+        ("buffered drive_merge", &del_buffered),
+        ("streaming drive_merge_streaming", &del_streaming),
+    ] {
+        if got != &vec![CK_SURVIVOR] {
+            failures.push(format!(
+                "issue #3146 AC4 ({leg}): under the partition deletion \
+                 @{T_PARTITION_DELETE_MICROS}µs this Flight row-drive loop must return \
+                 exactly [{CK_SURVIVOR}], matching core and Cassandra — got {got:?}. \
+                 `[{CK_PHANTOM}, {CK_SURVIVOR}]` is the all-null phantom row: both loops \
+                 call the SAME `entry_to_row` over the SAME `KWayMerger`, so a marker \
+                 whose OWN timestamp is `<= markedForDeleteAt` must already have been \
+                 dropped by `KWayMerger::apply_partition_shadowing` \
+                 (`BTreeRow.filter`: `activeDeletion.deletes(newInfo.timestamp())`)."
+            ));
+        }
+        if got != &del_core {
+            failures.push(format!(
+                "issue #3146 AC4 ({leg}): this Flight row-drive loop and core \
+                 `SSTableManager::scan` DIVERGE on the same bytes at the same pinned \
+                 now — core {del_core:?}, {leg} {got:?}"
+            ));
+        }
     }
     // The aggregate producer (`drive_aggregate`) shares `entry_to_row`, so the
     // phantom corrupts a `count(*)` even when no row bytes are ever emitted.

--- a/cqlite-flight/tests/issue_3094_flight_core_partition_delete_agreement.rs
+++ b/cqlite-flight/tests/issue_3094_flight_core_partition_delete_agreement.rs
@@ -695,6 +695,11 @@ async fn flight_do_get_agrees_with_core_on_a_partition_deleted_row() {
         ));
     }
 
+    // `CQLITE_TTL_NOW_OVERRIDE_SECS` is PROCESS-GLOBAL, so it is cleared before the
+    // verdict below (which may panic) rather than after — the pin must not outlive
+    // the test that set it and leak into any future test in this binary.
+    std::env::remove_var(TTL_NOW_ENV);
+
     assert!(
         failures.is_empty(),
         "issue #3094 Flight-vs-core partition-delete agreement failures:\n{}",

--- a/cqlite-flight/tests/issue_3095_flight_static_columns.rs
+++ b/cqlite-flight/tests/issue_3095_flight_static_columns.rs
@@ -290,14 +290,36 @@ fn sorted(rows: &[Row]) -> Vec<Row> {
     out
 }
 
-/// Assert `ticket` returns exactly `expected` (as a multiset) on BOTH arms at the
-/// pinned `now`, that the two arms genuinely DIFFERED, and that their row ORDER is
-/// identical (issue #3095 AC1/AC2/AC3).
+/// How strongly `expected` pins the shape of the result: the exact EMISSION ORDER,
+/// or only its content.
+///
+/// Cassandra's own order is only a TOTAL order over a result set when that set
+/// comes from a single partition — `UnfilteredRowIterator` walks a partition in
+/// CLUSTERING order (the table comparator) and `processPartition()` emits in
+/// iteration order, but the order BETWEEN partitions is murmur3 TOKEN order, which
+/// these expectations deliberately do not encode. So the order-sensitive
+/// assertion is scoped to the cases where Cassandra genuinely guarantees one.
+#[derive(Clone, Copy)]
+enum ExpectedOrder {
+    /// `expected` IS the sequence Cassandra emits — a single-partition result (in
+    /// clustering order) or a single-row result. Asserted position-by-position.
+    Exact,
+    /// A MULTI-partition result: only the multiset is asserted, because a total
+    /// order across partitions is not guaranteed by clustering alone. The
+    /// arm-vs-arm check still pins BOTH arms to the same order.
+    Multiset,
+}
+
+/// Assert `ticket` returns exactly `expected` on BOTH arms at the pinned `now` —
+/// in EMISSION ORDER for `ExpectedOrder::Exact`, as a multiset otherwise — that the
+/// two arms genuinely DIFFERED, and that their row order is identical (issue #3095
+/// AC1/AC2/AC3).
 async fn assert_static_semantics(
     label: &str,
     svc: &CqliteFlightService,
     ticket: &serde_json::Value,
     expected: &[Row],
+    order: ExpectedOrder,
     failures: &mut Vec<String>,
 ) {
     std::env::set_var(TTL_NOW_ENV, PINNED_NOW.to_string());
@@ -307,16 +329,35 @@ async fn assert_static_semantics(
 
     let want = sorted(expected);
     for (arm, got) in [("merge", &merge_rows), ("bypass", &bypass_rows)] {
-        if sorted(got) != want {
-            failures.push(format!(
-                "case {label} [{arm} arm]: STATIC SEMANTICS MISMATCH vs Cassandra 5.0.8 \
-                 processPartition()\n  expected ({} rows): {:#?}\n  got      ({} rows): {:#?}",
-                want.len(),
-                want,
-                got.len(),
-                sorted(got),
-            ));
+        let matches = match order {
+            ExpectedOrder::Exact => got.as_slice() == expected,
+            ExpectedOrder::Multiset => sorted(got) == want,
+        };
+        if matches {
+            continue;
         }
+        // An order-only divergence gets its own headline: the content is
+        // Cassandra's, the SEQUENCE is not, and that distinction is what makes the
+        // failure actionable.
+        let kind = if matches!(order, ExpectedOrder::Exact) && sorted(got) == want {
+            "CLUSTERING-ORDER MISMATCH vs Cassandra 5.0.8 (content matches; a \
+             single-partition result is emitted in clustering order)"
+        } else {
+            "STATIC SEMANTICS MISMATCH vs Cassandra 5.0.8 processPartition()"
+        };
+        // Show the compared forms, so the printed diff is the one that failed.
+        let (want_shown, got_shown) = match order {
+            ExpectedOrder::Exact => (expected.to_vec(), got.to_vec()),
+            ExpectedOrder::Multiset => (want.clone(), sorted(got)),
+        };
+        failures.push(format!(
+            "case {label} [{arm} arm]: {kind}\n  expected ({} rows): {:#?}\n  \
+             got      ({} rows): {:#?}",
+            want_shown.len(),
+            want_shown,
+            got_shown.len(),
+            got_shown,
+        ));
     }
     // AC3: the two arms agree over the SAME bytes at a PINNED `now`, in ORDER too.
     if merge_rows != bypass_rows {
@@ -443,6 +484,8 @@ async fn flight_static_column_semantics_match_cassandra() {
                     ("sdata", Some("static-val")),
                     ("rdata", Some("row-val")),
                 ])],
+                // ONE partition (`id = 1`), one row — Cassandra's emission order.
+                ExpectedOrder::Exact,
                 &mut failures,
             )
             .await;
@@ -469,6 +512,9 @@ async fn flight_static_column_semantics_match_cassandra() {
                 &svc,
                 &ticket_json(DL_KS, DL_TBL, DL_DDL),
                 &deltas_expected_select_star(),
+                // FOUR partitions (pk = 1, 2, 3, 99): the inter-partition order is
+                // token order, which this expectation does not encode.
+                ExpectedOrder::Multiset,
                 &mut failures,
             )
             .await;
@@ -505,6 +551,8 @@ async fn flight_static_column_semantics_match_cassandra() {
                         ("row_col", Some("row_3_1")),
                     ]),
                 ],
+                // One row from EACH of three partitions — token order across them.
+                ExpectedOrder::Multiset,
                 &mut failures,
             )
             .await;
@@ -534,6 +582,8 @@ async fn flight_static_column_semantics_match_cassandra() {
                     ("static_col", Some("static_only_val")),
                     ("row_col", None),
                 ])],
+                // The restriction leaves exactly one surviving partition's row.
+                ExpectedOrder::Exact,
                 &mut failures,
             )
             .await;
@@ -553,6 +603,8 @@ async fn flight_static_column_semantics_match_cassandra() {
                     ("static_col", Some("static_val_2")),
                     ("row_col", Some("row_2_3")),
                 ])],
+                // The restriction leaves exactly one row, from one partition.
+                ExpectedOrder::Exact,
                 &mut failures,
             )
             .await;
@@ -619,6 +671,15 @@ async fn flight_static_column_semantics_match_cassandra() {
                         ("row_col", Some("row_6")),
                     ]),
                 ],
+                // ORDER-SENSITIVE, and load-bearing for this PR: a SINGLE partition
+                // (`pk = 1`), so Cassandra's answer is these three rows in ASCENDING
+                // CLUSTERING order (`ck` 1, 3, 6 — the default `ASC` comparator, with
+                // the row-tombstoned `ck = 2` and the range-deleted `ck = 4..5`
+                // absent). Retiring the `StaticColumnsWithDeletions` guard is
+                // justified only if the fast arm's results are CORRECT, and correct
+                // includes Cassandra's clustering order — a both-arms inversion would
+                // slip past a multiset comparison and past the arm-vs-arm check.
+                ExpectedOrder::Exact,
                 &mut failures,
             )
             .await;
@@ -742,6 +803,9 @@ async fn flight_static_column_semantics_match_cassandra() {
                 &svc,
                 &ticket,
                 &want,
+                // TWO partitions — token order across them is not encoded here (and
+                // `partition_key` is projected out, so it could not be checked).
+                ExpectedOrder::Multiset,
                 &mut failures,
             )
             .await;

--- a/cqlite-flight/tests/issue_3095_flight_static_columns.rs
+++ b/cqlite-flight/tests/issue_3095_flight_static_columns.rs
@@ -290,59 +290,6 @@ fn sorted(rows: &[Row]) -> Vec<Row> {
     out
 }
 
-/// Assert `ticket` returns exactly `expected` on the MERGE arm under BOTH forced
-/// values — i.e. the bypass predicate FAILS CLOSED for this shape and the fast arm is
-/// never taken (issue #3095 / #3140).
-///
-/// Used for the one static shape the arms genuinely diverge on: an SSTable that may
-/// contain a simple CELL tombstone. The merge arm is Cassandra-correct there; the fast
-/// arm surfaces a raw `Value::Tombstone` the Arrow encoder rejects. So the contract is
-/// "the correct rows, on the merge arm, under both forced values", plus positive proof
-/// that a merger really was built on BOTH legs.
-async fn assert_fail_closed_to_merge_arm(
-    label: &str,
-    svc: &CqliteFlightService,
-    ticket: &serde_json::Value,
-    expected: &[Row],
-    failures: &mut Vec<String>,
-) {
-    std::env::set_var(TTL_NOW_ENV, PINNED_NOW.to_string());
-    let (merge_rows, merge_delta) = run_forced(svc, ticket, "merge").await;
-    let (bypass_rows, bypass_delta) = run_forced(svc, ticket, "bypass").await;
-    std::env::remove_var(TTL_NOW_ENV);
-
-    let want = sorted(expected);
-    for (arm, got) in [("merge", &merge_rows), ("bypass", &bypass_rows)] {
-        if sorted(got) != want {
-            failures.push(format!(
-                "case {label} [{arm} arm]: STATIC SEMANTICS MISMATCH vs Cassandra 5.0.8 \
-                 processPartition()\n  expected ({} rows): {:#?}\n  got      ({} rows): {:#?}",
-                want.len(),
-                want,
-                got.len(),
-                sorted(got),
-            ));
-        }
-    }
-    if merge_rows != bypass_rows {
-        failures.push(format!(
-            "case {label}: the two forced values must behave IDENTICALLY (both take the \
-             merge arm)\n  merge: {merge_rows:#?}\n  bypass: {bypass_rows:#?}"
-        ));
-    }
-    // THE fail-closed assertion: a merger is built on BOTH legs, so the fast arm was
-    // refused even when explicitly requested. Without this the case would silently
-    // become a plain both-arms differential if the exclusion were dropped.
-    for (arm, delta) in [("merge", &merge_delta), ("bypass", &bypass_delta)] {
-        if delta.mergers_built == 0 {
-            failures.push(format!(
-                "case {label} [{arm} arm]: no merger was built — this shape must FAIL \
-                 CLOSED to the merge arm under both forced values until #3140 lands"
-            ));
-        }
-    }
-}
-
 /// Assert `ticket` returns exactly `expected` (as a multiset) on BOTH arms at the
 /// pinned `now`, that the two arms genuinely DIFFERED, and that their row ORDER is
 /// identical (issue #3095 AC1/AC2/AC3).
@@ -634,20 +581,22 @@ async fn flight_static_column_semantics_match_cassandra() {
         Some(dir) => {
             let temp = stage(TB_KS, &dir).expect("stage fixture");
             let svc = CqliteFlightService::new(temp.path().to_path_buf(), 8192);
-            // FULL `SELECT *`, asserted on the MERGE arm under both forced values.
-            // This fixture's `ck = 3` carries a simple CELL tombstone on `row_col`,
-            // which the arms handle differently: the merge arm drops it (the column
-            // reads null — Cassandra's answer), while the single-generation fast arm
-            // surfaces a raw `Value::Tombstone` that the Arrow encoder rejects,
-            // aborting `do_get` with zero rows. That divergence is issue #3140, and
-            // #3095 FAILS CLOSED on it (`BypassReason::StaticColumnsWithDeletions`), so
-            // the correct rows are what a client sees today. `row_col` is deliberately
-            // PROJECTED IN — the whole point is that Cassandra's `row_col` values,
-            // including the null on `ck = 3`, are asserted; the fail-closed helper is
-            // what pins that the fast arm is refused rather than papering over it.
-            // When #3140 lands this becomes a plain `assert_static_semantics` case.
-            assert_fail_closed_to_merge_arm(
-                "static_with_tombstones/select-star(fail-closed to merge, #3140)",
+            // FULL `SELECT *`, asserted on BOTH arms (issue #3140, the fail-closed
+            // guard now RETIRED). This fixture's `ck = 3` carries a simple CELL
+            // tombstone on `row_col`, which the arms used to handle differently: the
+            // merge arm dropped it (the column reads null — Cassandra's answer) while
+            // the single-generation fast arm surfaced a raw `Value::Tombstone` that the
+            // Arrow encoder rejected, aborting `do_get` with zero rows. PR #3122 fixed
+            // the fast arm at its source (`row_decoder`'s
+            // `PartitionShadow::cell_tombstone_dropped`), so this is now an ordinary
+            // both-arms differential — and `assert_static_semantics` is what makes that
+            // load-bearing: it requires the forced-bypass leg to build ZERO mergers, so
+            // the case cannot pass by silently routing back to the merge arm. `row_col`
+            // is deliberately PROJECTED IN — the whole point is that Cassandra's
+            // `row_col` values, including the null on `ck = 3`, are asserted on the FAST
+            // arm's own decode.
+            assert_static_semantics(
+                "static_with_tombstones/select-star(both arms, #3140)",
                 &svc,
                 &ticket_json(TB_KS, TB_TBL, TB_DDL),
                 &[


### PR DESCRIPTION
## What this is — and what it is NOT

**Neither #3140 nor #3146 is a live bug on `main`.** Both were filed on 2026-07-30 against PR #3122's *unmerged* branch; #3122 merged at 22:59 UTC (squash `69ce160`, 15 commits) and **fixed both defects**. This PR discharges the residual acceptance criteria: retiring now-dead defensive code and pinning an unpinned path.

Net **199+ / 266−** — mostly deletion.

### Verification that the defects are fixed (OBSERVED both directions, real Cassandra 5.0 `nb` bytes)

| Issue | Fixed at | Revert-verified |
|---|---|---|
| #3140 | `row_data.rs:650` — `PartitionShadow::cell_tombstone_dropped(cell_ctx.is_some(), …)` | re-seeding the defect reproduces the issue's error verbatim: `column 'row_col': expected Text value, got Tombstone(...)` |
| #3146 | `merge/mod.rs:2874` — `RowLiveness::marker_survives_floor` | restoring `marker_live = entry.timestamp > pmfda` reproduces `got [3, 9]` vs core `[9]` |

## Changes

**#3140 AC3 — retire the `StaticColumnsWithDeletions` bypass guard.** With #3122 in place the fast arm returns correct static semantics, so the guard that force-routed static-bearing tables with deletions onto the merge arm is dead weight. Deleted: the `has_statics && may_contain_deletions()` branch and the `BypassReason` variant (`cqlite-flight/src/bypass.rs`), `SSTableReader::may_contain_deletions` (`query_rows.rs` — the guard was its **sole** consumer, grep-verified), and the guard's test.

**#3140 AC3 — the load-bearing conversion.** `issue_3095_flight_static_columns.rs`'s `static_with_tombstones` lane moves from `assert_fail_closed_to_merge_arm` ("we correctly refused the fast path") to `assert_static_semantics` ("the fast path is correct"). Returns Cassandra's 3 rows — `ck=1 row_1`, `ck=3 row_col=<null>`, `ck=6 row_6`. `issue_3058_forced_path_differential.rs`'s statics/select-star lane converts to `assert_arms_agree` for the same reason.

**#3146 AC4 — pin Flight-vs-core partition-delete agreement across BOTH row-drive loops.** Note the brief's premise was inverted on inspection: `do_get` routes to `drive_merge_streaming`, so the streaming leg was *already* pinned and the **buffered** `drive_merge` was the gap. Both are now pinned by construction (`produce_from_paths` + `produce_streaming_to_vec`), so AC4 holds regardless of which route `do_get` takes later.

**#3146 AC6 — sibling audit: DONE, and it found a real P1 → #3188.** See below.

### Anti-vacuity (why these tests can actually fail)

- `assert_static_semantics` **requires** `bypass_delta.mergers_built == 0` and `merge_delta.mergers_built != 0`, so it cannot pass by silently falling back to the merge arm. `assert_arms_agree` additionally requires `reconcile_entries == 0` and `cell_metadata_maps == 0` on the bypass leg.
- Every new/converted assertion was **watched RED before GREEN**:
  - seeding out #3122's `cell_tombstone_dropped` → RED with the `expected Text value, got Tombstone(...)` error
  - seeding `marker_live = entry.timestamp > pmfda` → RED on **both** new AC4 arms (`got [3, 9]` vs core `[9]`)
  - swapping the expected `ck=1`/`ck=3` rows → RED with `CLUSTERING-ORDER MISMATCH … (content matches …)`, proving order (not content) carries the assertion

### Review nits fixed in-tree

- **Order-sensitive rows** — rows were compared as a sorted multiset, so a both-arms clustering-order inversion would have passed. Now `ExpectedOrder::Exact` (position-by-position) for single-partition cases; `Multiset` retained for the three genuinely multi-partition callers, where inter-partition order is murmur3 token order that Cassandra does not guarantee via clustering — each carries a comment saying why.
- **Leaked env var** — `CQLITE_TTL_NOW_OVERRIDE_SECS` was set process-globally and never removed; the paired `remove_var` is placed **before** the verdict assert so the pin clears even when the test fails.

## Discovered during AC6: #3188 (P1)

The audit confirmed **by execution** that `merge/mod.rs:3167` (the **range**-tombstone arm) still has the pre-#3122 defect — it compares `entry.timestamp` (reconcile's max over surviving cells) instead of the marker's own timestamp, emitting a phantom all-null row where Cassandra returns none:

```
RANGE_ARM_DISAGREE floor=100 entry_ts=150 marker_ts=Some(50) cqlite=true cassandra=false
```

Authority (`cassandra-5.0.8`): range and partition deletions route through the **identical** `activeDeletion → Row.Merger.merge` path — `RangeTombstoneMarker.java:191-197` → `UnfilteredRowIterators.java:579` → `BTreeRow.java:339` → `DeletionTime.java:163-175`. Filed as **#3188** with fix shape, smallest failing input, and a warning that the one test it breaks encodes the buggy behavior via an unreachable fixture.

**Does retiring the guard widen exposure to #3188? No.** `mod.rs:3167` is in the k-way merge arm; the fast arm never executes it (its range coverage is the independent `PartitionShadow::feed_range_marker` FSM). Retiring the guard routes static+deletion tables **away** from the defective code, and the converted lane asserts a real range tombstone over `ck 4..5` on both arms.

## Certification

- `--lite` **PASS** at `76f0a83` (pre-rebase content), `tree-integrity: PASS`
- roborev **PASS**, verified non-vacuous — range `99e24ed..99e3aa3`, tokens input 133,703 / cached 103,424 / output 4,549, `prompt-content: PASS (7/7)`, findings NONE
- `rust-reviewer`: **APPROVE-WITH-NITS** — guard confirmed dead, conversions judged "strictly stronger, not weaker"
- Remaining nits batched into **#3189** (P3); its oracle item was already resolved on main by `dafd015` (#3164/#3187) and is struck there

Full `agent-gate.sh` runs once, pre-merge.

Closes #3140
Closes #3146


---

## Gate of record — full `agent-gate.sh` PASS at `a4c1014`

run-id `/tmp/agent-gate.lKIawb`, `tree-integrity: PASS`, `tree-start == tree-end`, `dirty: no`, 144 `Data.db` under `/data/datasets`. **29 components, 0 FAIL, 0 SKIP.**

Recorded verbatim per #3146 AC6 (byte-parity half must be recorded in the PR):

```
compaction-byte-parity: PASS (13s)
```

Full verdict line: `RESULT: PASS` (summary `/tmp/gate-3191.txt`).

## C — intent audit: PASS

`spec-auditor` anchored to the issue ACs (oracle-driven; no OpenSpec artifact). It **executed** `issue_3095_flight_static_columns`, `issue_3094_flight_core_partition_delete_agreement` and `issue_3058_forced_path_differential` at `a4c1014` under `CQLITE_REQUIRE_FIXTURES=1` rather than reading them.

- **#3122 attributions verified TRUE, not taken on trust** — `git log -S` shows `cell_tombstone_dropped` (`row_data.rs:650`) and `marker_survives_floor` (`merge/mod.rs:2874`) were each introduced by exactly one commit, `69ce160` (#3122), and neither file appears in this diff. Semantics anchored to the pinned tag, not to CQLite (#3041): `cassandra-5.0.8:src/java/org/apache/cassandra/db/rows/BTreeRow.java:335-340` — `if (activeDeletion.deletes(newInfo.timestamp())) newInfo = LivenessInfo.EMPTY;` — the marker is judged on its **own** timestamp with no cell timestamps consulted, exactly the marker-present arm of `marker_survives_floor`.
- **AC6 ruled satisfied** — AC6's words are "**audited** in the same change", not *fixed*. The audit was performed, is evidence-bearing, and its outcome is recorded as #3188 (P1) with pinned-tag authority, reachability direction, smallest failing input and fix shape. The auditor independently reproduced the defect at `merge/mod.rs:3167`. It notes this would **not** discharge a *fix* AC — and this one is not.
- **Anti-vacuity confirmed a strengthening, not a substitution** — nothing the old `assert_fail_closed_to_merge_arm` asserted is lost (it only required mergers on both legs plus correct rows on the *merge* arm). The new form asserts correct rows on the **fast arm's own decode**, arm-vs-arm order equality, and `ExpectedOrder::Exact` on the single-partition case. The `statics/select-star` shape assert now runs on the **bypass** rows, where it previously ran on an auto-mode (merge) read.
- **AC4's inverted-premise claim verified** — `streaming.rs:543` sends only the AGGREGATE ticket to `produce_from_resolved`; row tickets go `spawn_streaming → drive_merge_over → drive_merge_streaming`. The **buffered** loop was the real gap. Each leg carries a pre-patch sanity assert requiring `[3, 9]`, so a route that reads nothing fails.

### One justified `partial`, tracked not buried: #3146 AC5

Over Flight, the only survivor lives by a **live data cell** newer than the deletion. The marker-newer / key-only-INSERT complement AC5 names is pinned on the **core** public surface (`cqlite-core/tests/issue_3094_multigen_partition_deleted_row_not_resurrected.rs:561`) but not on the Flight fixture. Non-blocking — Flight↔core agreement on the shared `KWayMerger` is asserted on these bytes and the Flight lane explicitly rejects `[]` as an over-hide — but the residual is real. Filed as a tracked follow-up rather than merged over silently; the fix is ~3 lines (`insert_liveness_marker_only(11, T_SIBLING_LIVE_MICROS)`).
