### PR TITLE
fix(3131,3148): resolve committed schema fixtures checkout-relative, and fail the gate closed when they are unreachable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,18 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   DuckDB amalgamation (cqlite-cli `duckdb-tests`) + OTel stack (`observability`/
   `observability-testing`); parquet/arrow stay linted. `CQLITE_CLIPPY_FULL=1` (nightly `gate.yml`)
   runs the full matrix.
-- The FULL gate FAILs CLOSED when the fetched validation corpus is absent (#2078), stamping
-  `missing-fixtures: FAIL-CLOSED (#2078)`; `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` opts out visibly
-  (`missing-fixtures: OPT-OUT (...)`). Remedy: `bash test-data/scripts/fetch-datasets.sh`.
-  `--lite`/`--only` stay lenient.
+- The FULL gate FAILs CLOSED on **either half** of the fixture contract; `--lite`/`--only` stay
+  lenient for both.
+  - Fetched corpus absent (#2078): `missing-fixtures: FAIL-CLOSED (#2078)`, remedy
+    `bash test-data/scripts/fetch-datasets.sh`; `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` opts out
+    visibly (`missing-fixtures: OPT-OUT (...)`).
+  - Committed CQL schemas unreachable (#3148): `missing-schemas: FAIL-CLOSED (#3148)` — textually
+    distinct from #2078's marker, with two causes, an unreadable `test-data/schemas/*.cql` or a
+    **rejected relative `CQLITE_SCHEMAS_ROOT`**, each carrying its own remedy line. Success stamps a
+    positive `schemas: N/N canonical .cql readable under <root> (<source>)` line, so a pasted SUMMARY
+    shows the check RAN. **There is deliberately NO opt-out env var, and none may be added**:
+    committed source in a checkout is never legitimately absent, so an escape hatch could only buy a
+    vacuous green.
 - **A run whose worktree mutates MID-RUN cannot certify (#2926).** Every mode captures a tree
   identity at start, re-verifies it at each component boundary + the terminal emit, and FAILs closed
   with `tree-integrity: FAIL (tree-mutated-midrun; head <a>→<b>; changed: …)`. Every SUMMARY carries
@@ -160,11 +168,12 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
 
 ```bash
 cargo build
-env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test --package cqlite-core
+cargo test --package cqlite-core            # needs CQLITE_DATASETS_ROOT exported — see "Test Data"
 env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features   # CI mode
 cargo fmt
 bash test-data/scripts/smoke-test-all-tables.sh
-bash test-data/scripts/fetch-datasets.sh    # fetch real SSTable binaries (required for integration tests)
+bash test-data/scripts/fetch-datasets.sh    # fetch real SSTable binaries; USE the export line it prints
+bash test-data/scripts/fetch-datasets.sh --verify-only   # is my root usable? mutates nothing
 ```
 
 Everything else (CLI usage/modes/output precedence, Python/Node build + test + examples, write
@@ -270,7 +279,21 @@ Location: `test-data/datasets/sstables/` — keyspaces `test_basic` (8), `test_c
 `test_timeseries` (9), `test_wide_rows` (8). **Pass rate: 100% (33/33, Dec 2025).**
 
 The repo ships only JSONL reference files; fetch real binaries with
-`bash test-data/scripts/fetch-datasets.sh` and set `CQLITE_DATASETS_ROOT=$PWD/test-data/datasets`.
+`bash test-data/scripts/fetch-datasets.sh`, then export **the exact
+`export CQLITE_DATASETS_ROOT=<abs>` line that script prints** — it names the only root that run
+guarantees, and on a fleet box it is often a machine-local root (e.g. `/data/datasets`), NOT
+`$PWD/test-data/datasets`. The printed line beats any root remembered from this file. The script
+rejects every unrecognized argument (exit 2) because its default path is destructive
+(`rm -rf` on the dataset root); `--verify-only` probes a root without mutating anything, `--help`
+lists the flags.
+
+**`CQLITE_DATASETS_ROOT` alone is sufficient on every layout (#3131/#3148)** — the corpus root needs
+no `schemas` sibling. The CQL schema fixtures (`test-data/schemas`, 23 committed files incl.
+`legacy/` + `udts/`) are **committed source resolved checkout-relative** (anchored on the
+workspace-root `Cargo.toml`), never derived from `CQLITE_DATASETS_ROOT`. `CQLITE_SCHEMAS_ROOT` is an
+optional out-of-tree override and **MUST be absolute**: a relative value is rejected fail-closed by
+both the gate and the tests, because the gate resolves it against the repo root while cargo resolves
+it against each package dir — so it would certify one schemas root while the tests read another.
 Without Data.db files, query tests pass but return 0 rows. Dataset pins:
 [test data](https://pmcfadin.github.io/cqlite/agents-developing/test-data/).
 
@@ -285,8 +308,10 @@ recipes: `docs/development/dev-cookbook.md`.
 
 ## Troubleshooting
 
-- **Missing test data / 0 rows**: `export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets` +
-  `bash test-data/scripts/fetch-datasets.sh`
+- **Missing test data / 0 rows**: `bash test-data/scripts/fetch-datasets.sh`, then export the
+  `CQLITE_DATASETS_ROOT=` line it prints — NOT `$PWD/test-data/datasets`, which on a fleet box is a
+  corpus-less root the fetch never populates. `--verify-only` re-checks an existing root
+  non-destructively. No `schemas` sibling is needed (#3131).
 - **Clippy failures**: run with `RUSTFLAGS="-D warnings"` to match CI
 - **Parsing issues**: `docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md`
 - **Python bindings**: Rust 1.85+, Python 3.9+, `pip install maturin`, then
@@ -462,7 +487,9 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   thing. Doctrine: [delivery pipeline](https://pmcfadin.github.io/cqlite/agents-developing/delivery-pipeline/).
 - **1:1:1:1**: one issue ↔ one worktree/branch `issue-<N>-<slug>` (branched from `origin/main`) ↔
   one OpenSpec change `<slug>` ↔ one PR. Worktrees lack gitignored Data.db binaries — point
-  `CQLITE_DATASETS_ROOT` at the main repo's `test-data/datasets`.
+  `CQLITE_DATASETS_ROOT` at the root the fetch's printed export line names (often machine-local, e.g.
+  `/data/datasets`), which is not necessarily the main repo's `test-data/datasets`. The committed CQL
+  schemas need no env var: they resolve from the worktree's own checkout (#3148).
 - **Board = sole dispatch authority (Path A, #1886)**: the GitHub Project `Status` field
   (`Backlog/Ready/In Progress/In Review/Done`); exactly one `P0`–`P3` per issue. New issues auto-land
   at `Backlog`. Empty Ready column = no work ready → STOP. Board unreachable (auth/scope) → STOP and

--- a/cqlite-cli/benches/export_csv.rs
+++ b/cqlite-cli/benches/export_csv.rs
@@ -21,7 +21,10 @@
 //! type-heavy `test_collections.collection_table` (500 rows × 7 cols). The
 //! fixture-open logic is duplicated here (~30 lines) rather than sharing the
 //! `cqlite-core/benches/fixtures` module across crates — a deliberate,
-//! spec-blessed duplication (no new shared crate).
+//! spec-blessed duplication (no new shared crate). The *root resolution* is NOT
+//! duplicated: since #3148 it comes from the single shared
+//! `test-data/support/fixture_roots.rs`, so the datasets/schemas contract cannot
+//! drift between this bench and cqlite-core.
 //!
 //! Wiring evidence / non-vacuity: the bench runs the real `SELECT *`, **panics**
 //! at setup if it returns zero rows, and asserts the CSV writer produced a real
@@ -42,18 +45,19 @@ use criterion::{criterion_group, criterion_main, Criterion};
 // CSV export writer over a single loaded type-heavy fixture (cli-helpers).
 // ---------------------------------------------------------------------------
 
-/// Locate the `test-data/datasets` root (mirrors the core bench fixture loader).
-/// Prefers `CQLITE_DATASETS_ROOT`; else the workspace-relative fallback (the
-/// crate dir is `<workspace>/cqlite-cli`, so datasets live at
-/// `<workspace>/test-data/datasets`).
+/// The ONE definition of every `test-data/` root (issues #3131 / #3148), shared
+/// verbatim with `cqlite-core`'s benches/tests. Hosted under `test-data/support/`
+/// rather than in either crate: it encodes the layout of `test-data` itself, so the
+/// include path is symmetric (`../../` from any `<crate>/benches/`) and this bench
+/// still takes no dependency on `cqlite-core`'s bench internals.
+#[path = "../../test-data/support/fixture_roots.rs"]
+mod fixture_roots;
+
+/// Locate the `test-data/datasets` root — infallible shape (checkout-relative
+/// fallback when `CQLITE_DATASETS_ROOT` is unset).
 #[cfg(feature = "cli-helpers")]
 fn datasets_root() -> std::path::PathBuf {
-    match std::env::var("CQLITE_DATASETS_ROOT") {
-        Ok(root) => std::path::PathBuf::from(root),
-        Err(_) => {
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../test-data/datasets")
-        }
-    }
+    fixture_roots::datasets_root()
 }
 
 /// Resolve the CFID-suffixed `<keyspace>/<table>-<hash>` SSTable directory, or
@@ -121,7 +125,8 @@ fn bench_csv_export(c: &mut Criterion) {
         .join(src.file_name().expect("fixture dir has a final component"));
     copy_dir_recursive(&src, &dst);
 
-    let schema_path = datasets_root().join("../schemas").join(SCHEMA_FILE);
+    // Committed source, checkout-relative — never `datasets_root/../schemas` (#3148).
+    let schema_path = fixture_roots::schema_path(SCHEMA_FILE);
     let cfg = IngestionConfig {
         schema_paths: vec![schema_path],
         data_dir: tmp.path().to_path_buf(),

--- a/cqlite-core/benches/fixtures/mod.rs
+++ b/cqlite-core/benches/fixtures/mod.rs
@@ -50,28 +50,36 @@ pub fn seeded_rng() -> rand::rngs::StdRng {
     rand::rngs::StdRng::seed_from_u64(BENCH_SEED)
 }
 
-/// Locate the `test-data/datasets` root.
-///
-/// Prefers `CQLITE_DATASETS_ROOT`; otherwise falls back to the workspace-relative
-/// path derived from `CARGO_MANIFEST_DIR` (the crate dir is
-/// `<workspace>/cqlite-core`, so the datasets live at
-/// `<workspace>/test-data/datasets`). The fallback lets the benches run from a
-/// plain checkout with fetched datasets and no environment setup.
+/// The ONE definition of every `test-data/` root (issues #3131 / #3148). Hosted
+/// under `test-data/support/` because it encodes the layout of `test-data` itself
+/// and is shared with `cqlite-cli`'s benches and the integration tests; the
+/// helpers below are thin delegations so there is exactly one implementation.
+/// `#[path]` here is relative to THIS file's directory, so it resolves identically
+/// no matter which bench/test target `#[path]`-includes `fixtures/mod.rs`.
+#[path = "../../../test-data/support/fixture_roots.rs"]
+pub mod roots;
+
+/// Locate the `test-data/datasets` root — infallible shape (checkout-relative
+/// fallback when `CQLITE_DATASETS_ROOT` is unset), so benches run from a plain
+/// checkout with no environment setup. See [`roots`] for the full contract and the
+/// fallible [`roots::datasets_root_if_present`] shape used by SKIP-gated tests.
 pub fn datasets_root() -> PathBuf {
-    match std::env::var("CQLITE_DATASETS_ROOT") {
-        Ok(root) => PathBuf::from(root),
-        Err(_) => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../test-data/datasets"),
-    }
+    roots::datasets_root()
 }
 
 /// The `sstables/` subtree holding per-keyspace fixture data.
 pub fn sstables_root() -> PathBuf {
-    datasets_root().join("sstables")
+    roots::sstables_root()
 }
 
-/// The `test-data/schemas` directory (sibling of `datasets`).
+/// The committed `test-data/schemas` directory.
+///
+/// Resolved CHECKOUT-RELATIVE, never as `datasets_root().join("../schemas")` — these
+/// are committed source, not fetched data, and the old `..` climb mis-resolved through
+/// a symlinked `datasets` (#3148 AC (h)). Prefer [`roots::schema_path`], which also
+/// verifies the file is readable and names the absolute path when it is not.
 pub fn schemas_root() -> PathBuf {
-    datasets_root().join("../schemas")
+    roots::schemas_root()
 }
 
 /// Resolve the on-disk SSTable directory for `<keyspace>/<table>-<hash>`.
@@ -279,7 +287,7 @@ pub fn open_read_db_with_config(fx: &ReadFixture, core_config: cqlite_core::Conf
         .join(src.file_name().expect("fixture dir has a final component"));
     copy_dir_recursive(&src, &dst);
 
-    let schema_path = schemas_root().join(fx.schema_file);
+    let schema_path = roots::schema_path(fx.schema_file);
     let cfg = IngestionConfig {
         schema_paths: vec![schema_path],
         data_dir: tmp.path().to_path_buf(),

--- a/cqlite-core/tests/dead_cache_delete_tests.rs
+++ b/cqlite-core/tests/dead_cache_delete_tests.rs
@@ -33,15 +33,17 @@ fn require_fixtures() -> bool {
     )
 }
 
-fn datasets_root() -> Option<PathBuf> {
-    if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
-        let p = PathBuf::from(root);
-        if p.is_dir() {
-            return Some(p);
-        }
-    }
-    None
-}
+/// The ONE definition of every `test-data/` root (issues #3131 / #3148): the datasets
+/// corpus (`CQLITE_DATASETS_ROOT`, relocatable/fetched) and the committed schema
+/// fixtures (checkout-relative, NEVER `datasets_root().join("../schemas")`).
+#[path = "../../test-data/support/fixture_roots.rs"]
+mod fixture_roots;
+
+/// Fallible shape of the datasets root: `Some` only when `CQLITE_DATASETS_ROOT` is set
+/// and names a directory — no checkout fallback, so these tests SKIP (rather than run
+/// against the committed byte-parity references and report a 0-row pass) when the
+/// fetched corpus is unavailable. See `fixture_roots` for the two-shape contract.
+use fixture_roots::datasets_root_if_present as datasets_root;
 
 fn data_db(ks: &str, tbl: &str) -> Option<PathBuf> {
     let base = datasets_root()?.join("sstables").join(ks);
@@ -588,7 +590,6 @@ async fn open_fixture_db(
 ) -> Option<cqlite_core::Database> {
     use cqlite_core::ingestion::{ingest, IngestionConfig};
 
-    let root = datasets_root()?;
     let src = data_db(ks, tbl)?.parent()?.to_path_buf();
     let tmp = tempfile::TempDir::new().expect("temp dir");
     let dst = tmp
@@ -601,7 +602,10 @@ async fn open_fixture_db(
     // reaping the dir mid-test would break reads.
     let _persisted = tmp.keep();
 
-    let schema_path = root.join("../schemas").join(schema_file);
+    // Committed source, resolved checkout-relative — NOT `datasets_root/../schemas`
+    // (#3148). Verified readable here, so an unreachable fixture names its absolute
+    // path instead of panicking anonymously deep inside ingestion.
+    let schema_path = fixture_roots::schema_path(schema_file);
     let cfg = IngestionConfig {
         schema_paths: vec![schema_path],
         data_dir: dst

--- a/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
+++ b/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
@@ -76,10 +76,59 @@ fn absent_or_blank_override_resolves_to_the_checkout() {
 /// must not break every fixture load. (A relative one is rejected instead; see above.)
 #[test]
 fn absolute_but_unusable_override_degrades_to_the_checkout() {
-    let (root, source) = resolve_schemas_root(Some("/nonexistent-cqlite-schemas-3148"))
+    // A GUARANTEED-absent absolute path, built under a fresh TempDir with native path
+    // handling rather than hard-coded as `/nonexistent-…` (roborev job 10, finding 3): a
+    // hard-coded root-level name is not absolute under Windows path semantics and is not
+    // guaranteed absent on Unix — someone can create it, and then this test would silently
+    // assert the OPPOSITE branch. The TempDir is unique per run and the child is never
+    // created, so absence is a property of the construction.
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let absent = tmp.path().join("no-such-schemas-dir");
+    assert!(absent.is_absolute(), "TempDir children are absolute");
+    assert!(!absent.exists(), "the child is deliberately never created");
+    let raw = absent.to_str().expect("utf-8 temp path");
+
+    let (root, source) = resolve_schemas_root(Some(raw))
         .expect("an absolute-but-absent override degrades, it is not an error");
     assert_eq!(source, SchemasRootSource::Checkout);
     assert_eq!(root, checkout_test_data_dir().join("schemas"));
+}
+
+/// A control-character-bearing override is REJECTED on both sides (roborev job 10, finding
+/// 2). The gate's shell mirror can only obtain the value through command substitution
+/// somewhere in its history, and `$( )` strips trailing newlines — so admitting such a value
+/// let the gate certify `/abs/dir` while this resolver kept the newline, failed `is_dir()`,
+/// and degraded to the checkout. Rejecting closes the divergence for good.
+#[test]
+fn control_character_override_is_rejected_fail_closed() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let dir = tmp.path().to_str().expect("utf-8 temp path");
+
+    for (label, raw) in [
+        ("trailing newline", format!("{dir}\n")),
+        ("leading newline", format!("\n{dir}")),
+        ("carriage return", format!("{dir}\r")),
+        ("embedded tab", format!("{dir}\tsub")),
+    ] {
+        match resolve_schemas_root(Some(&raw)) {
+            Err(e) => {
+                assert!(
+                    e.contains("control characters"),
+                    "{label}: rejection must name the rule; got: {e}"
+                );
+                assert!(
+                    e.contains("remedy"),
+                    "{label}: rejection must be actionable; got: {e}"
+                );
+            }
+            Ok((root, source)) => panic!(
+                "{label}: a control-character override was ACCEPTED ({} via {source:?}) — the \
+                 gate's shell mirror strips trailing newlines, so this is a root-certification \
+                 divergence, not a cosmetic issue",
+                root.display()
+            ),
+        }
+    }
 }
 
 /// An ABSOLUTE override naming a real directory wins, and is reported as an override so

--- a/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
+++ b/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
@@ -12,6 +12,7 @@
 //! mutating `CQLITE_SCHEMAS_ROOT`. Env vars are process-global, so an env-mutating test
 //! races every other test in the binary — and a flaky guard gets deleted, not fixed.
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 #[path = "../../test-data/support/fixture_roots.rs"]
@@ -32,7 +33,7 @@ use fixture_roots::{
 /// fell back to the checkout and read DIFFERENT files.
 #[test]
 fn relative_schemas_override_is_rejected_fail_closed() {
-    let err = resolve_schemas_root(Some("packaged/schemas"))
+    let err = resolve_schemas_root(Some(OsStr::new("packaged/schemas")))
         .expect_err("a relative CQLITE_SCHEMAS_ROOT must be rejected, not resolved");
     assert!(
         err.contains("must be an ABSOLUTE path"),
@@ -51,7 +52,7 @@ fn relative_schemas_override_is_rejected_fail_closed() {
     // Every relative shape, not just the bare one.
     for raw in ["./schemas", "../schemas", "a/b/schemas"] {
         assert!(
-            resolve_schemas_root(Some(raw)).is_err(),
+            resolve_schemas_root(Some(OsStr::new(raw))).is_err(),
             "relative override {raw:?} must be rejected"
         );
     }
@@ -62,7 +63,8 @@ fn relative_schemas_override_is_rejected_fail_closed() {
 #[test]
 fn absent_or_blank_override_resolves_to_the_checkout() {
     for raw in [None, Some(""), Some("   "), Some("\t")] {
-        let (root, source) = resolve_schemas_root(raw).expect("blank override is not an error");
+        let (root, source) =
+            resolve_schemas_root(raw.map(OsStr::new)).expect("blank override is not an error");
         assert_eq!(
             source,
             SchemasRootSource::Checkout,
@@ -89,7 +91,7 @@ fn absolute_but_unusable_override_degrades_to_the_checkout() {
     assert!(!absent.exists(), "the child is deliberately never created");
     let raw = absent.to_str().expect("utf-8 temp path");
 
-    let (root, source) = resolve_schemas_root(Some(raw))
+    let (root, source) = resolve_schemas_root(Some(OsStr::new(raw)))
         .expect("an absolute-but-absent override degrades, it is not an error");
     assert_eq!(source, SchemasRootSource::Checkout);
     assert_eq!(root, checkout_test_data_dir().join("schemas"));
@@ -111,7 +113,7 @@ fn control_character_override_is_rejected_fail_closed() {
         ("carriage return", format!("{dir}\r")),
         ("embedded tab", format!("{dir}\tsub")),
     ] {
-        match resolve_schemas_root(Some(&raw)) {
+        match resolve_schemas_root(Some(OsStr::new(&raw))) {
             Err(e) => {
                 assert!(
                     e.contains("control characters"),
@@ -138,7 +140,8 @@ fn control_character_override_is_rejected_fail_closed() {
 fn absolute_existing_override_wins_and_is_reported_as_such() {
     let tmp = tempfile::TempDir::new().expect("temp dir");
     let raw = tmp.path().to_str().expect("utf-8 temp path");
-    let (root, source) = resolve_schemas_root(Some(raw)).expect("absolute readable dir is valid");
+    let (root, source) =
+        resolve_schemas_root(Some(OsStr::new(raw))).expect("absolute readable dir is valid");
     assert_eq!(source, SchemasRootSource::EnvOverride);
     assert_eq!(root, PathBuf::from(raw));
 }
@@ -329,6 +332,23 @@ fn unreadable_fixture_message_names_path_root_source_and_remedy() {
         err.contains("remedy") && err.contains("restore --source=HEAD -- test-data/schemas"),
         "message must carry the remedy command; got: {err}"
     );
+    // …and the remedy must be CWD-INDEPENDENT (roborev job 11, nit 2). cargo runs each test
+    // binary with CWD = the PACKAGE dir, so a bare `git restore` FAILS when pasted — the same
+    // CWD asymmetry this module rejects relative overrides for. A remedy that does not work
+    // when followed is not a remedy, so it must carry an explicit ABSOLUTE `git -C <root>`.
+    let ws = fixture_roots::workspace_root().expect("a workspace root in a checkout");
+    let expected_restore = format!(
+        "git -C {} restore --source=HEAD -- test-data/schemas",
+        ws.display()
+    );
+    assert!(
+        err.contains(&expected_restore),
+        "remedy must be CWD-independent (`git -C <abs>`); got: {err}"
+    );
+    assert!(
+        ws.is_absolute(),
+        "the remedy's -C argument must be absolute, else it is CWD-relative again"
+    );
     // The override source must be distinguishable in the SAME message slot.
     let err_override = resolve_schema_path(root, SchemasRootSource::EnvOverride, "x.cql")
         .expect_err("an absent fixture must not resolve");
@@ -378,7 +398,7 @@ fn the_two_datasets_root_shapes_differ_as_documented() {
     assert_eq!(resolve_datasets_root(None), checkout_default);
     for blank in ["", "   "] {
         assert_eq!(
-            resolve_datasets_root(Some(blank)),
+            resolve_datasets_root(Some(OsStr::new(blank))),
             checkout_default,
             "an exported-but-blank value is a scripting accident, never a root"
         );
@@ -388,7 +408,7 @@ fn the_two_datasets_root_shapes_differ_as_documented() {
     let tmp = tempfile::TempDir::new().expect("temp dir");
     let absent = tmp.path().join("no-such-corpus");
     let absent_raw = absent.to_str().expect("utf-8");
-    assert_eq!(resolve_datasets_root(Some(absent_raw)), absent);
+    assert_eq!(resolve_datasets_root(Some(OsStr::new(absent_raw))), absent);
 
     // Fallible shape: NO checkout fallback — this is the assertion that catches a collapse.
     assert_eq!(
@@ -398,17 +418,95 @@ fn the_two_datasets_root_shapes_differ_as_documented() {
          run against committed byte-parity references and report a vacuous 0-row pass"
     );
     for blank in ["", "   "] {
-        assert_eq!(resolve_datasets_root_if_present(Some(blank)), None);
+        assert_eq!(
+            resolve_datasets_root_if_present(Some(OsStr::new(blank))),
+            None
+        );
     }
     assert_eq!(
-        resolve_datasets_root_if_present(Some(absent_raw)),
+        resolve_datasets_root_if_present(Some(OsStr::new(absent_raw))),
         None,
         "a value that is not a directory yields None"
     );
     let present = tmp.path().to_str().expect("utf-8");
     assert_eq!(
-        resolve_datasets_root_if_present(Some(present)),
+        resolve_datasets_root_if_present(Some(OsStr::new(present))),
         Some(tmp.path().to_path_buf()),
         "a value naming a real directory is returned"
+    );
+}
+
+/// A NON-UTF-8 override is REJECTED, not silently degraded (roborev job 11, BLOCKER).
+///
+/// `std::env::var` maps such a value to `Err(NotUnicode)`, and the first cut's `env_dir`
+/// collapsed that to `None` via a catch-all — so `resolve_schemas_root` returned
+/// `Ok(checkout)` while the Bash mirror validated the same BYTE path as a legitimate override
+/// (measured: `STATUS: OK` / `SOURCE: CQLITE_SCHEMAS_ROOT override` for
+/// `<dir>/bad\xff\xfedir`). The gate certifying one schemas root while the tests use another is
+/// the third instance of a class already pinned for control-character and relative values;
+/// this is its pin.
+///
+/// Unix-only: constructing an invalid-UTF-8 `OsString` needs `OsStringExt`, and the byte-path
+/// hazard is a Unix property. On other platforms there is nothing to assert.
+#[cfg(unix)]
+#[test]
+fn non_utf8_override_is_rejected_fail_closed() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    // A REAL directory whose name is not valid UTF-8, so the value is one Bash would accept:
+    // the test is about the two sides disagreeing, not about a nonexistent path.
+    let mut bytes = tmp.path().as_os_str().to_os_string().into_vec();
+    bytes.extend_from_slice(b"/bad\xff\xfedir");
+    let raw = std::ffi::OsString::from_vec(bytes);
+    std::fs::create_dir(&raw).expect("create a non-UTF-8 directory");
+    assert!(
+        raw.to_str().is_none(),
+        "the fixture value must actually be invalid UTF-8"
+    );
+    assert!(
+        std::path::Path::new(&raw).is_dir(),
+        "the value must name a REAL directory — a Bash mirror would accept it"
+    );
+
+    let err = resolve_schemas_root(Some(raw.as_os_str()))
+        .expect_err("a non-UTF-8 override must be rejected, not degraded to the checkout");
+    assert!(
+        err.contains("not valid UTF-8"),
+        "rejection must name the rule; got: {err}"
+    );
+    assert!(
+        err.contains("CQLITE_SCHEMAS_ROOT"),
+        "rejection must name the variable; got: {err}"
+    );
+    assert!(
+        err.contains("remedy"),
+        "rejection must be actionable; got: {err}"
+    );
+}
+
+/// The datasets root HONORS a non-UTF-8 value rather than silently substituting the checkout.
+///
+/// `datasets_root()` is infallible, so it cannot report an error — and falling back to the
+/// checkout would recreate the same certify-A-use-B split one variable over, with a WORSE
+/// fallback (the checkout's `datasets` carries only committed byte-parity references, no
+/// `test_basic` corpus). Honoring the value makes it agree with the gate, which counts
+/// `Data.db` under the byte path.
+#[cfg(unix)]
+#[test]
+fn non_utf8_datasets_root_is_honored_not_silently_replaced() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let raw = std::ffi::OsString::from_vec(b"/tmp/cqlite-3148-bad\xff\xfecorpus".to_vec());
+    assert!(raw.to_str().is_none(), "fixture must be invalid UTF-8");
+    assert_eq!(
+        resolve_datasets_root(Some(raw.as_os_str())),
+        PathBuf::from(&raw),
+        "a non-UTF-8 datasets root must be USED, not silently replaced by the checkout"
+    );
+    // The fallible shape still gates on is_dir() — the path above does not exist.
+    assert_eq!(
+        resolve_datasets_root_if_present(Some(raw.as_os_str())),
+        None
     );
 }

--- a/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
+++ b/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
@@ -1,0 +1,188 @@
+//! Contract tests for the shared fixture-root resolver (issues #3148 / #3131).
+//!
+//! These pin the resolution RULES that `scripts/agent-gate.sh` mirrors. The gate stamps a
+//! `schemas: N/N … under <root>` line into the SUMMARY on the strength of its own shell
+//! copy of these rules, so any divergence means the gate certifies a root the tests never
+//! used — the "positively misleading `STATUS: OK`" defect #3148 was filed for. The shell
+//! half is pinned by `scripts/tests/test_agent_gate_schemas_preflight.sh`; this is the
+//! Rust half, and the two assert the SAME table.
+//!
+//! Deliberately env-free: every case drives the PURE
+//! [`fixture_roots::resolve_schemas_root`] with an explicit override value instead of
+//! mutating `CQLITE_SCHEMAS_ROOT`. Env vars are process-global, so an env-mutating test
+//! races every other test in the binary — and a flaky guard gets deleted, not fixed.
+
+use std::path::{Path, PathBuf};
+
+#[path = "../../test-data/support/fixture_roots.rs"]
+mod fixture_roots;
+
+use fixture_roots::{
+    checkout_test_data_dir, readable_file, resolve_schemas_root, schema_path, schemas_root,
+    SchemasRootSource,
+};
+
+/// A RELATIVE override is REJECTED, not resolved.
+///
+/// This is the case that nearly reintroduced #3148's own defect: the gate evaluates a
+/// relative path with CWD = repository root, cargo runs each test binary with CWD = the
+/// PACKAGE directory. Resolving it would let the gate stamp
+/// `schemas: 6/6 … under packaged/schemas (override)` while every test binary silently
+/// fell back to the checkout and read DIFFERENT files.
+#[test]
+fn relative_schemas_override_is_rejected_fail_closed() {
+    let err = resolve_schemas_root(Some("packaged/schemas"))
+        .expect_err("a relative CQLITE_SCHEMAS_ROOT must be rejected, not resolved");
+    assert!(
+        err.contains("must be an ABSOLUTE path"),
+        "rejection must name the rule; got: {err}"
+    );
+    assert!(
+        err.contains("packaged/schemas"),
+        "rejection must quote the offending value; got: {err}"
+    );
+    // Actionability: the message must explain the CWD asymmetry AND give a remedy,
+    // otherwise an operator reads it as an arbitrary restriction and works around it.
+    assert!(
+        err.contains("CWD") && err.contains("remedy"),
+        "rejection must explain why and how to fix; got: {err}"
+    );
+    // Every relative shape, not just the bare one.
+    for raw in ["./schemas", "../schemas", "a/b/schemas"] {
+        assert!(
+            resolve_schemas_root(Some(raw)).is_err(),
+            "relative override {raw:?} must be rejected"
+        );
+    }
+}
+
+/// Absent or blank means "no override" — an exported-but-empty variable is a scripting
+/// accident, never an intentional root. Mirrors the gate's whitespace-stripped check.
+#[test]
+fn absent_or_blank_override_resolves_to_the_checkout() {
+    for raw in [None, Some(""), Some("   "), Some("\t")] {
+        let (root, source) = resolve_schemas_root(raw).expect("blank override is not an error");
+        assert_eq!(
+            source,
+            SchemasRootSource::Checkout,
+            "raw={raw:?} must resolve checkout-relative"
+        );
+        assert_eq!(root, checkout_test_data_dir().join("schemas"));
+    }
+}
+
+/// An ABSOLUTE override that is not a usable directory DEGRADES to the checkout rather
+/// than pinning the run to a path that cannot work — a stale export in a shell profile
+/// must not break every fixture load. (A relative one is rejected instead; see above.)
+#[test]
+fn absolute_but_unusable_override_degrades_to_the_checkout() {
+    let (root, source) = resolve_schemas_root(Some("/nonexistent-cqlite-schemas-3148"))
+        .expect("an absolute-but-absent override degrades, it is not an error");
+    assert_eq!(source, SchemasRootSource::Checkout);
+    assert_eq!(root, checkout_test_data_dir().join("schemas"));
+}
+
+/// An ABSOLUTE override naming a real directory wins, and is reported as an override so
+/// a failure message can distinguish it from the checkout default.
+#[test]
+fn absolute_existing_override_wins_and_is_reported_as_such() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let raw = tmp.path().to_str().expect("utf-8 temp path");
+    let (root, source) = resolve_schemas_root(Some(raw)).expect("absolute readable dir is valid");
+    assert_eq!(source, SchemasRootSource::EnvOverride);
+    assert_eq!(root, PathBuf::from(raw));
+}
+
+/// The checkout is identified by a checkout MARKER (the workspace-root `Cargo.toml`), not
+/// by the fixtures. Keying the ancestor walk on `test-data/schemas` let a sparse checkout
+/// — or a worktree nested inside another checkout — resolve to the OUTER checkout's
+/// fixtures: wrong-but-existing, reported as `Checkout`, no warning.
+///
+/// Asserted structurally: the resolved `test-data` must be a DIRECT child of an ancestor
+/// that carries a `[workspace]` manifest, and that ancestor must be THIS crate's own
+/// workspace root (the parent of `CARGO_MANIFEST_DIR`), never some outer one.
+#[test]
+fn checkout_test_data_dir_is_anchored_on_the_workspace_marker() {
+    let td = checkout_test_data_dir();
+    let root = td.parent().expect("test-data has a parent");
+    let manifest = root.join("Cargo.toml");
+    let text = std::fs::read_to_string(&manifest)
+        .unwrap_or_else(|e| panic!("workspace manifest {} unreadable: {e}", manifest.display()));
+    assert!(
+        text.lines()
+            .any(|l| l.trim_start().starts_with("[workspace]")),
+        "{} must be the WORKSPACE root manifest",
+        manifest.display()
+    );
+    // …and it must be OUR workspace root: the parent of this crate's manifest dir.
+    let expected_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir has a parent");
+    assert_eq!(
+        root, expected_root,
+        "resolution escaped this checkout (nested-worktree hazard)"
+    );
+    assert!(td.is_dir(), "{} must exist in a checkout", td.display());
+}
+
+/// `readable_file` answers "readable REGULAR file", which is the same question the gate's
+/// `[ -f ] && [ -r ]` asks. `Path::is_file()` alone would accept a mode-000 fixture (which
+/// then fails inside ingestion, bypassing the actionable message), and a bare `-r` would
+/// accept a DIRECTORY named `basic-types.cql`.
+#[test]
+fn readable_file_rejects_directories_and_unreadable_files() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+
+    let dir_named_like_a_schema = tmp.path().join("basic-types.cql");
+    std::fs::create_dir(&dir_named_like_a_schema).expect("create dir");
+    assert!(
+        !readable_file(&dir_named_like_a_schema),
+        "a directory named like a schema file is not a readable regular file"
+    );
+
+    let real = tmp.path().join("real.cql");
+    std::fs::write(&real, b"CREATE TABLE x (k int PRIMARY KEY);\n").expect("write");
+    assert!(readable_file(&real), "a real readable file must pass");
+
+    // Permission case, guarded: a run as root (some CI containers) bypasses mode bits, so
+    // only assert it where the OS actually enforces them — proven by a control probe
+    // rather than assumed. Skipping loudly beats a host-conditional flake.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let locked = tmp.path().join("locked.cql");
+        std::fs::write(&locked, b"x").expect("write");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+            .expect("chmod 000");
+        if std::fs::File::open(&locked).is_err() {
+            assert!(
+                !readable_file(&locked),
+                "an unreadable regular file must not pass"
+            );
+        } else {
+            eprintln!("note: permissions not enforced for this user; skipping the mode-000 case");
+        }
+    }
+}
+
+/// End-to-end in a real checkout: every schema file the gate's preflight asserts must be
+/// resolvable through the same public helper the migrated call sites use. This is the
+/// cross-check that makes the gate's `CANONICAL_SCHEMA_FILES` list meaningful — if the
+/// list and the resolver disagreed, the gate would pass while the tests panicked.
+#[test]
+fn every_gate_asserted_schema_resolves_in_a_checkout() {
+    const GATE_ASSERTED: [&str; 6] = [
+        "basic-types.cql",
+        "da-test.cql",
+        "time-series.cql",
+        "wide-table-bti.cql",
+        "collections.cql",
+        "wide-rows.cql",
+    ];
+    let root = schemas_root();
+    for f in GATE_ASSERTED {
+        let p = schema_path(f); // panics with the actionable message if unreadable
+        assert_eq!(p, root.join(f));
+        assert!(readable_file(&p), "{} must be readable", p.display());
+    }
+}

--- a/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
+++ b/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
@@ -19,7 +19,7 @@ mod fixture_roots;
 
 use fixture_roots::{
     checkout_test_data_dir, readable_file, resolve_schemas_root, schema_path, schemas_root,
-    SchemasRootSource,
+    workspace_root_from, SchemasRootSource,
 };
 
 /// A RELATIVE override is REJECTED, not resolved.
@@ -123,6 +123,63 @@ fn checkout_test_data_dir_is_anchored_on_the_workspace_marker() {
         "resolution escaped this checkout (nested-worktree hazard)"
     );
     assert!(td.is_dir(), "{} must exist in a checkout", td.display());
+}
+
+/// The DISCRIMINATING control for the marker rule: a worktree nested inside another
+/// checkout must resolve to ITS OWN root, not the outer one.
+///
+/// The test above cannot catch a revert of that rule — in a healthy checkout the retired
+/// fixtures-keyed walk returns the same path, so it would still pass. This one drives
+/// `workspace_root_from` over a synthetic layout where the two rules DISAGREE:
+///
+/// ```text
+/// outer/Cargo.toml            [workspace]
+/// outer/test-data/schemas/    <- the fixtures the retired walk would have latched onto
+/// outer/inner/Cargo.toml      [workspace]   <- the nested worktree's OWN root
+/// outer/inner/cqlite-core/Cargo.toml        (a member manifest, no [workspace])
+/// ```
+///
+/// Marker walk from `outer/inner/cqlite-core` ⇒ `outer/inner` (correct: this checkout).
+/// Fixtures-keyed walk ⇒ `outer` (wrong: the neighbour's tree, silently, and it EXISTS —
+/// which is exactly why the bug was invisible).
+#[test]
+fn nested_worktree_resolves_to_its_own_root_not_the_outer_checkout() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let outer = tmp.path().join("outer");
+    let inner = outer.join("inner");
+    let member = inner.join("cqlite-core");
+    std::fs::create_dir_all(outer.join("test-data").join("schemas")).expect("outer fixtures");
+    std::fs::create_dir_all(&member).expect("member dir");
+    std::fs::write(outer.join("Cargo.toml"), "[workspace]\nmembers = []\n")
+        .expect("outer manifest");
+    std::fs::write(
+        inner.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"cqlite-core\"]\n",
+    )
+    .expect("inner manifest");
+    // A MEMBER manifest: no `[workspace]`, so the walk must pass through it.
+    std::fs::write(
+        member.join("Cargo.toml"),
+        "[package]\nname = \"cqlite-core\"\n",
+    )
+    .expect("member manifest");
+
+    let resolved = workspace_root_from(&member).expect("a [workspace] ancestor exists");
+    assert_eq!(
+        resolved, inner,
+        "resolution escaped into the OUTER checkout — the marker rule regressed to a \
+         fixtures-keyed walk, which silently borrows a neighbour's test-data"
+    );
+    // Positive control on the layout itself: the outer fixtures really are present, so the
+    // assertion above discriminates the two rules instead of passing on an empty tree.
+    assert!(
+        outer.join("test-data").join("schemas").is_dir(),
+        "the discriminating layout requires the OUTER fixtures to exist"
+    );
+    assert!(
+        !inner.join("test-data").join("schemas").exists(),
+        "the discriminating layout requires the INNER fixtures to be ABSENT"
+    );
 }
 
 /// `readable_file` answers "readable REGULAR file", which is the same question the gate's

--- a/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
+++ b/cqlite-core/tests/issue_3148_fixture_roots_contract.rs
@@ -18,8 +18,9 @@ use std::path::{Path, PathBuf};
 mod fixture_roots;
 
 use fixture_roots::{
-    checkout_test_data_dir, readable_file, resolve_schemas_root, schema_path, schemas_root,
-    workspace_root_from, SchemasRootSource,
+    checkout_test_data_dir, readable_file, resolve_datasets_root, resolve_datasets_root_if_present,
+    resolve_schema_path, resolve_schemas_root, schema_path, schemas_root, workspace_root_from,
+    SchemasRootSource,
 };
 
 /// A RELATIVE override is REJECTED, not resolved.
@@ -291,4 +292,123 @@ fn every_gate_asserted_schema_resolves_in_a_checkout() {
         assert_eq!(p, root.join(f));
         assert!(readable_file(&p), "{} must be readable", p.display());
     }
+}
+
+/// #3148 requirement 5: the unreadable-fixture message is the DELIVERABLE, so it is asserted.
+///
+/// Before this it was covered by nothing — the only test was the happy path, so reverting
+/// `schema_path` to a bare `expect` deep inside ingest left every test green. That is the
+/// diagnosis-free failure this issue was filed for, so the message gets a real assertion:
+/// the absolute path, the root, HOW the root was chosen, the committed-source note, and the
+/// remedy must all be present.
+#[test]
+fn unreadable_fixture_message_names_path_root_source_and_remedy() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let root = tmp.path();
+
+    let err = resolve_schema_path(root, SchemasRootSource::Checkout, "basic-types.cql")
+        .expect_err("an absent fixture must not resolve");
+    let expected_path = root.join("basic-types.cql");
+    assert!(
+        err.contains(&expected_path.display().to_string()),
+        "message must name the ABSOLUTE fixture path; got: {err}"
+    );
+    assert!(
+        err.contains(&root.display().to_string()),
+        "message must name the resolved root; got: {err}"
+    );
+    assert!(
+        err.contains("checkout-relative"),
+        "message must say HOW the root was chosen; got: {err}"
+    );
+    assert!(
+        err.contains("COMMITTED SOURCE") && err.contains("CQLITE_DATASETS_ROOT"),
+        "message must state these are committed source, not fetched data; got: {err}"
+    );
+    assert!(
+        err.contains("remedy") && err.contains("restore --source=HEAD -- test-data/schemas"),
+        "message must carry the remedy command; got: {err}"
+    );
+    // The override source must be distinguishable in the SAME message slot.
+    let err_override = resolve_schema_path(root, SchemasRootSource::EnvOverride, "x.cql")
+        .expect_err("an absent fixture must not resolve");
+    assert!(
+        err_override.contains("CQLITE_SCHEMAS_ROOT override"),
+        "an override root must be reported as such; got: {err_override}"
+    );
+}
+
+/// …and `schema_path` itself must PANIC with that message, not merely be able to build it.
+/// Uses `catch_unwind` over a fixture name that cannot exist in the real checkout, so no
+/// environment mutation is needed.
+#[test]
+fn schema_path_panics_with_the_actionable_message() {
+    let missing = "definitely-not-a-committed-schema-3148.cql";
+    // Silence the default hook so an EXPECTED panic does not print a scary backtrace.
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let outcome = std::panic::catch_unwind(|| schema_path(missing));
+    std::panic::set_hook(prev);
+
+    let payload = outcome.expect_err("schema_path must panic on an unreadable fixture");
+    let msg = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic payload>");
+    let expected_path = schemas_root().join(missing);
+    assert!(
+        msg.contains(&expected_path.display().to_string()),
+        "the panic must name the absolute path (not a bare 'Path does not exist'); got: {msg}"
+    );
+    assert!(
+        msg.contains("remedy"),
+        "the panic must be actionable; got: {msg}"
+    );
+}
+
+/// #3148 AC (e) / requirement 6: the two `datasets_root` shapes DIFFER, and the difference is
+/// the contract. Asserted BEHAVIOURALLY — the previous guard grepped for the function name, so
+/// giving the fallible shape a checkout fallback (collapsing the two into one) reddened nothing.
+#[test]
+fn the_two_datasets_root_shapes_differ_as_documented() {
+    let checkout_default = checkout_test_data_dir().join("datasets");
+
+    // Infallible shape: falls back to the checkout when there is no value…
+    assert_eq!(resolve_datasets_root(None), checkout_default);
+    for blank in ["", "   "] {
+        assert_eq!(
+            resolve_datasets_root(Some(blank)),
+            checkout_default,
+            "an exported-but-blank value is a scripting accident, never a root"
+        );
+    }
+    // …and returns a value it is given even when that value is not a directory (the per-fixture
+    // error later is more actionable than a root-level one — that is the documented choice).
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let absent = tmp.path().join("no-such-corpus");
+    let absent_raw = absent.to_str().expect("utf-8");
+    assert_eq!(resolve_datasets_root(Some(absent_raw)), absent);
+
+    // Fallible shape: NO checkout fallback — this is the assertion that catches a collapse.
+    assert_eq!(
+        resolve_datasets_root_if_present(None),
+        None,
+        "the fallible shape must NOT fall back to the checkout: a skip-gated test would then \
+         run against committed byte-parity references and report a vacuous 0-row pass"
+    );
+    for blank in ["", "   "] {
+        assert_eq!(resolve_datasets_root_if_present(Some(blank)), None);
+    }
+    assert_eq!(
+        resolve_datasets_root_if_present(Some(absent_raw)),
+        None,
+        "a value that is not a directory yields None"
+    );
+    let present = tmp.path().to_str().expect("utf-8");
+    assert_eq!(
+        resolve_datasets_root_if_present(Some(present)),
+        Some(tmp.path().to_path_buf()),
+        "a value naming a real directory is returned"
+    );
 }

--- a/cqlite-core/tests/observability_correctness.rs
+++ b/cqlite-core/tests/observability_correctness.rs
@@ -470,6 +470,12 @@ fn mc_baseline_is_zero(m: &testing::CapturedMetrics) -> bool {
 // Read fixtures (mirrors benches/fixtures, trimmed to what these tests need)
 // ---------------------------------------------------------------------------
 
+/// The ONE definition of every `test-data/` root (issues #3131 / #3148). Replaces the
+/// third hand-written copy of `datasets_root()` and the open-coded
+/// `datasets_root().join("../schemas")` that used to live in `read_fixtures`.
+#[path = "../../test-data/support/fixture_roots.rs"]
+mod fixture_roots;
+
 #[cfg(feature = "cli-helpers")]
 mod read_fixtures {
     use std::path::PathBuf;
@@ -497,11 +503,10 @@ mod read_fixtures {
         _tmp: tempfile::TempDir,
     }
 
+    /// Infallible shape (checkout-relative fallback) — see `crate::fixture_roots` for
+    /// the two-shape contract. Thin delegation: one implementation, no third copy.
     fn datasets_root() -> PathBuf {
-        match std::env::var("CQLITE_DATASETS_ROOT") {
-            Ok(root) => PathBuf::from(root),
-            Err(_) => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../test-data/datasets"),
-        }
+        crate::fixture_roots::datasets_root()
     }
 
     fn table_dir(keyspace: &str, table: &str) -> PathBuf {
@@ -545,7 +550,8 @@ mod read_fixtures {
             .join(src.file_name().expect("dir name"));
         copy_dir(&src, &dst);
 
-        let schema_path = datasets_root().join("../schemas").join(fx.schema_file);
+        // Committed source, checkout-relative — never `datasets_root/../schemas` (#3148).
+        let schema_path = crate::fixture_roots::schema_path(fx.schema_file);
         let cfg = IngestionConfig {
             schema_paths: vec![schema_path],
             data_dir: tmp.path().to_path_buf(),

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -30,7 +30,7 @@ issues itself). Other machines run pure **workers**. A lead is a worker with a h
 ```bash
 git clone https://github.com/pmcfadin/cqlite && cd cqlite
 bash scripts/bootstrap-agent-machine.sh        # or manually: sccache, cargo-nextest, bash>=4.3, mold (Linux)
-bash test-data/scripts/fetch-datasets.sh       # real SSTable binaries — REQUIRED (see below)
+bash test-data/scripts/fetch-datasets.sh       # real SSTable binaries — REQUIRED; export the line it prints
 gh auth setup-git                              # git push credentials — SEPARATE from gh auth (#2942)
 gh auth status                                  # must include the 'project' scope (board access)
 bash scripts/flow/claim.sh smoke               # preflight: prove origin accepts refs/claims/* (see below)
@@ -102,7 +102,18 @@ Sanity check: `bash scripts/agent-gate.sh --lite` should pass in ~1–5 min, and
 **Datasets matter:** without them, parity components skip. The FULL gate FAILs CLOSED when the
 fetched validation corpus is absent (**#2078**), stamping `missing-fixtures: FAIL-CLOSED (#2078)`;
 `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` opts out visibly, and `--lite`/`--only` stay lenient. Fetch
-them on every machine, day one.
+them on every machine, day one — and export the `CQLITE_DATASETS_ROOT=` line the fetch prints, since
+on a box with a machine-local root (e.g. `/data/datasets`) the checkout's `test-data/datasets` stays
+corpus-less (**#3131**).
+
+**The corpus root is all you need (#3131/#3148).** `CQLITE_DATASETS_ROOT` alone is sufficient on every
+layout: the committed CQL schemas (`test-data/schemas`) are resolved **checkout-relative** and are not
+a sibling of the corpus root. Do **not** create a `schemas` symlink next to a relocated corpus, and do
+not assemble a composite root to make one appear — both are retired workarounds. The FULL gate has a
+second fail-closed fixture cause for this half, `missing-schemas: FAIL-CLOSED (#3148)`, which fires on
+an unreadable committed `.cql` **or** on a rejected relative `CQLITE_SCHEMAS_ROOT` (that override must
+be absolute). It has **no opt-out** — committed source in a checkout is never legitimately absent.
+`--lite`/`--only` stay lenient.
 
 ---
 
@@ -327,7 +338,8 @@ machine + heartbeat age (issue #2089). Interpretation:
 | Board unreachable (auth/scope error) | The session STOPS by design (labels are decorative, never a dispatch source). Fix `gh auth refresh -s project` and restart. If the scope is already present and `gh project` still fails for `read:org`, that is the #2942 delta — use the `updateProjectV2ItemFieldValue` GraphQL mutation for board writes, or widen the token with `-s read:org`. |
 | `fatal: could not read Username` on any push | git has no credentials even though `gh` does (#2942). The claim protocol pushes with plain git, so it is fully broken until fixed: `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes`. A claim attempt on such a box reports `reason=auth`, not a retryable transient. |
 | Gate seems hung | It's probably queued: look for `waiting for gate slot (N in use)…`. Queued ≠ hung. |
-| Green SUMMARY but parity lines say SKIP | Datasets missing on that machine — `fetch-datasets.sh`, re-run. The FULL gate FAILs CLOSED here (`missing-fixtures: FAIL-CLOSED (#2078)`) so it can't slip through; `--lite`/`--only` stay lenient. |
+| Green SUMMARY but parity lines say SKIP | Datasets missing on that machine — `fetch-datasets.sh`, export the root it prints, re-run. Probe an existing root with `fetch-datasets.sh --verify-only` (mutates nothing). The FULL gate FAILs CLOSED here (`missing-fixtures: FAIL-CLOSED (#2078)`) so it can't slip through; `--lite`/`--only` stay lenient. |
+| `missing-schemas: FAIL-CLOSED (#3148)` | Either a committed `test-data/schemas/*.cql` is unreadable (broken checkout — `git restore --source=HEAD -- test-data/schemas`) or `CQLITE_SCHEMAS_ROOT` is set to a **relative** path (export an absolute one, or unset it). Never a corpus-layout problem: the schemas root is checkout-relative. No opt-out exists — do not look for one. |
 | Two machines want the same issue | Impossible past the claim: the second claim-ref push is rejected server-side (non-fast-forward on the fixed-name ref, #2665); the loser sees `CLAIM LOST` and picks the next Ready item. |
 
 ---

--- a/docs/reports/issue-3027-row-decode-attribution.md
+++ b/docs/reports/issue-3027-row-decode-attribution.md
@@ -39,9 +39,12 @@ Runs are pinned with `taskset -c 2` (core 2's HT sibling is core 10, left idle) 
   x 64 B/line** — *not* DRAM traffic. It is the right metric for comparing how much data movement a code
   path causes, and it is measurable; it is not the roofline's DRAM term.
 - `perf` needs `kernel.perf_event_paranoid` lowered (default 4 on this image blocks everything).
-- Datasets live at **`/data/datasets`**, not the in-tree `test-data/datasets`. `benches/fixtures/mod.rs`
-  additionally resolves schemas as `$CQLITE_DATASETS_ROOT/../schemas`, so `/data/schemas` must exist
-  (symlink to `test-data/schemas`).
+- Datasets live at **`/data/datasets`**, not the in-tree `test-data/datasets` — use the
+  `export CQLITE_DATASETS_ROOT=…` line `fetch-datasets.sh` prints. **RETIRED (#3131/#3148):** at the
+  time of this run `benches/fixtures/mod.rs` also resolved schemas as
+  `$CQLITE_DATASETS_ROOT/../schemas`, so a `/data/schemas` symlink was needed. That is no longer true
+  and **the symlink must not be created**: the schemas root is resolved checkout-relative, so
+  `CQLITE_DATASETS_ROOT` alone is sufficient.
 - **Do not pin the streaming bench to one core for a throughput number.** `read/scan_partition_dense_stream`
   under `taskset -c 2` spends 5.27 s of 12.43 s in `sys` — a multi-threaded tokio pipeline forced onto one
   core measures the scheduler, not the read path. Unpinned, `native_queued_spin_lock_slowpath` is 5.96%

--- a/openspec/changes/schemas-root-contract/design.md
+++ b/openspec/changes/schemas-root-contract/design.md
@@ -1,0 +1,132 @@
+# Design: checkout-relative schemas root + a schemas-aware gate preflight (issues #3148, #3131)
+
+## Context
+
+The gate's fixture preflight (#2078) exists so that a fixture-absent run FAILs closed instead of
+SKIP-then-PASSing on zero dataset-backed coverage. It validated exactly one thing:
+`$CQLITE_DATASETS_ROOT/sstables/test_basic/*-Data.db` count > 0.
+
+The fixture *contract*, however, has two halves: the SSTable bytes **and** the CQL schema that decodes
+them. Deriving the second half from `CQLITE_DATASETS_ROOT` by climbing `..` produced a layout no single
+root on the fleet satisfied (#3131) and a preflight whose `STATUS: OK` was positively misleading (#3148).
+
+## The decision (#3148 AC (h))
+
+**Resolve the schemas root checkout-relative. Do not make the corpus layout carry it.**
+
+The alternative on the table was to keep the coupling and repair it — ship `schemas/` inside the fetched
+archive, or make the fetch populate `<repo>/test-data/datasets` so the sibling exists. Both were
+rejected:
+
+| Option | Verdict | Reason |
+|--------|---------|--------|
+| ship `schemas/` in the dataset archive (#3131 item 1b) | rejected | duplicates **committed source** into a versioned binary asset; a schema edit then needs a dataset re-release, and the two copies can disagree with no signal |
+| make the fetch populate the repo tree (#3131 item 1a) | rejected | does not fix the general case (any relocated root re-breaks it), and it fights the whole point of `CQLITE_DATASETS_ROOT` — a big, relocatable, machine-local cache |
+| **resolve checkout-relative (#3148 fix 4)** | **ADOPTED** | a checkout ALWAYS holds these files, so the failure mode is structurally impossible; the symlink trap disappears because no `..` climb remains; no data duplicated; every existing corpus layout — including `/data/datasets` — becomes self-sufficient unchanged |
+
+Consequence worth stating plainly: this **supersedes** #3131 item 1's either/or. The "one documented root
+that works" is now *any* corpus root, because the schemas are no longer a property of the corpus root at
+all.
+
+### Why an override still exists
+
+`CQLITE_SCHEMAS_ROOT` is honored when set, non-empty **and** a readable directory. It is not the primary
+mechanism — it exists for a genuinely out-of-tree run (a packaged corpus + schemas shipped together, no
+checkout). The fall-through on an unreadable/empty value is deliberate: a stale export in a shell profile
+degrades to the correct checkout answer instead of pinning every fixture load to a path that cannot work.
+
+## Mechanism: one file, `#[path]`-included
+
+`test-data/support/fixture_roots.rs` is std-only and pulled in with
+`#[path = …] mod fixture_roots;`. Alternatives considered:
+
+- **A new `cqlite-test-support` crate.** Rejected: a whole workspace member (plus manifest, plus
+  dev-dependency edges from two crates) to host ~60 lines of path logic, and it would have to be
+  `publish = false`-managed.
+- **Host it in `cqlite-core/benches/fixtures/roots.rs`.** Rejected: `cqlite-cli`'s bench would then
+  reach cross-crate into `cqlite-core`'s bench internals — which that bench's own module doc explicitly
+  disclaims — and the include paths become asymmetric.
+- **Host it under `test-data/support/`.** **ADOPTED**: the file encodes the layout of `test-data/`
+  itself, it is owned by neither crate, and the include path is symmetric (`../../` from ANY
+  `<crate>/tests/` or `<crate>/benches/`, `../../../` from the nested `benches/fixtures/`). `#[path]` on
+  a module declared at the top level of a file resolves relative to **that file's** directory, so
+  `benches/fixtures/mod.rs` resolves identically no matter which of its ~14 including targets is being
+  built. `cargo fmt` and `clippy --all-targets` both reach it through the including targets, and the
+  gate's `file-size` ratchet globs `*.rs` repo-wide, so it is fully covered by existing lints.
+
+### The two-shape `datasets_root()` contract (#3148 AC (e))
+
+Three copies existed with **two different semantics** for the same logical root — the silent divergence
+that makes this failure class hard to attribute. They are now one implementation with two named shapes,
+and the difference is a stated behavioral choice rather than an accident:
+
+| shape | env unset | env set, not a dir | rationale |
+|-------|-----------|--------------------|-----------|
+| `datasets_root()` | checkout fallback | returns it anyway | benches must run from a plain checkout with no env setup; a per-fixture error later is more actionable than a root-level one |
+| `datasets_root_if_present()` | `None` | `None` | a SKIP-gated test must not silently run against a checkout holding only ~19 committed byte-parity references and report a 0-row pass |
+
+`observability_correctness` and the benches take the first; `dead_cache_delete_tests` takes the second —
+byte-identical to their pre-change behavior, which was a hard constraint (converting a skip into a panic
+would red the gate broadly and is out of scope).
+
+## Mechanism: the gate preflight
+
+`_gate_schemas_root` / `_gate_schemas_root_source` mirror the Rust `schemas_root_resolved()` exactly, so
+the gate asserts the **same path** the tests will resolve; both anchor on the checkout, so they cannot
+drift by construction. `_schemas_status` is a PURE `OK|FAIL` decision (returning `OK` for `--lite` and
+`--only`), and the hidden `--preflight-schemas` hook prints that same decision plus `ROOT`, `SOURCE` and
+the unreadable file list — so the self-test asserts the decision the real gate consumes, not a parallel
+re-implementation of it. This mirrors #2078's `_fixture_status` / `apply_fixture_preflight` /
+`--preflight-fixtures` split deliberately: one idiom for both halves of the fixture contract.
+
+Two decisions inside it:
+
+- **Per-FILE readability, not directory existence.** A root that exists and holds *some* fixtures is the
+  realistic partial-copy failure, and a directory check green-lights it.
+- **No opt-out**, unlike #2078's `AGENT_GATE_ALLOW_MISSING_FIXTURES`. The fetched corpus is legitimately
+  absent on a fresh box; committed source in a checkout never is. An unreachable schemas root means a
+  broken checkout or a stale override, and neither may certify a run.
+
+Ordering: the corpus guard runs first, so a run missing both still reports the #2078 cause — the fetched
+half is the one an operator must act on.
+
+## Why the self-test is the load-bearing part
+
+The defect being fixed is a **verification** defect, the third of its shape recently (#3130, #3127). The
+same mistake is available here: a preflight whose only test is "a good layout passes" is untested, since
+`STATUS: OK` is then never shown to be a decision. So the self-test drives layouts the preflight must
+**reject** — schemas-less, and present-but-incomplete — and asserts the rejection text, the marker's
+separability from #2078's, and the absolute path in the remedy. The same reasoning produced
+`fetch-datasets.sh --verify-only`: on the warm path the `.dataset-pin` fast path implies the content
+check, so without a non-mutating probe the new guarantee could only ever be observed passing.
+
+Symlink-trap independence (#3148 AC (f)) is asserted **behaviorally**, not claimed: the resolved schemas
+root is byte-identical across a real datasets directory, a symlinked one, and a nonexistent one. The
+structural half — zero open-coded `join("../schemas")` **expressions** in Rust (doc comments quoting the
+retired idiom are exempt) — is a reintroduction guard that reddens the gate.
+
+## Facts the docs pass must state (handled separately on this branch)
+
+1. `CQLITE_DATASETS_ROOT` alone is sufficient; the corpus root no longer needs a `schemas` sibling.
+2. The CQL schema fixtures are committed source resolved checkout-relative; `CQLITE_SCHEMAS_ROOT` is an
+   optional out-of-tree override.
+3. `bash test-data/scripts/fetch-datasets.sh` now prints the exact `export CQLITE_DATASETS_ROOT=…` line
+   it guarantees — use THAT, not a remembered default. `--verify-only` probes a root non-destructively.
+4. The FULL gate has a second fail-closed fixture cause, `missing-schemas: FAIL-CLOSED (#3148)`, and
+   stamps a positive `schemas: N/N …` line on success.
+5. The CLAUDE.md line "point `CQLITE_DATASETS_ROOT` at the main repo's `test-data/datasets`" needs the
+   caveat that on a fleet box the fetch may have populated a machine-local root instead — the fetch's own
+   printed export line is authoritative.
+
+## Risks
+
+- **A crate nested deeper than one level below the workspace root.** Handled: resolution walks
+  `CARGO_MANIFEST_DIR`'s ancestors for the first holding `test-data/schemas`, rather than hardcoding
+  `../test-data`. The walk builds no `..` component, so nothing it hands the kernel can be re-rooted by a
+  symlink.
+- **A truly checkout-less run** (fixtures deleted). Then the walk finds no ancestor and returns the
+  canonical one-level-up guess purely so the error message can name a concrete absolute path — the
+  failure is still a failure, just a diagnosable one.
+- **Drift between the gate's shell resolution and the Rust one.** Bounded by both anchoring on the
+  checkout with the same override rule, and by the self-test asserting the gate's resolved `ROOT` equals
+  `<repo>/test-data/schemas`.

--- a/openspec/changes/schemas-root-contract/design.md
+++ b/openspec/changes/schemas-root-contract/design.md
@@ -72,8 +72,13 @@ would red the gate broadly and is out of scope).
 ## Mechanism: the gate preflight
 
 `_gate_schemas_root` / `_gate_schemas_root_source` mirror the Rust `schemas_root_resolved()` exactly, so
-the gate asserts the **same path** the tests will resolve; both anchor on the checkout, so they cannot
-drift by construction. `_schemas_status` is a PURE `OK|FAIL` decision (returning `OK` for `--lite` and
+the gate asserts the **same path** the tests will resolve; both anchor on the same checkout marker. They are
+two **hand-written** mirrors, however — **equivalent today and pinned by
+`scripts/tests/test_agent_gate_schemas_preflight.sh`**, NOT equivalent by construction. Editing either side
+obliges re-walking the input table (unset, `""`, whitespace-only, control-character-bearing, `"  /abs  "`,
+absolute-non-dir, absolute-dir, relative) and re-running that self-test; a silent divergence between them is
+exactly the root-certification mismatch this change exists to prevent, and two of the three review rounds
+found one. `_schemas_status` is a PURE `OK|FAIL` decision (returning `OK` for `--lite` and
 `--only`), and the hidden `--preflight-schemas` hook prints that same decision plus `ROOT`, `SOURCE` and
 the unreadable file list — so the self-test asserts the decision the real gate consumes, not a parallel
 re-implementation of it. This mirrors #2078's `_fixture_status` / `apply_fixture_preflight` /

--- a/openspec/changes/schemas-root-contract/proposal.md
+++ b/openspec/changes/schemas-root-contract/proposal.md
@@ -1,0 +1,132 @@
+# Proposal: separate the committed schemas root from the fetched datasets root (issues #3148, #3131)
+
+**Milestone:** maintenance (test-fixture / gate contract) · **Priority:** P1 ·
+**Routing:** design-driven (a fixture-discovery and gate-preflight **contract** change — which env var
+owns which root, and what the preflight promises; there is no on-disk oracle to pin) ·
+**Issues:** #3148 (gate preflight does not validate the schemas root), #3131 (no single
+`CQLITE_DATASETS_ROOT` works on the fleet) ·
+**Related:** #2078 (the fail-closed corpus preflight this extends), #2878 (the sibling
+`fetch-datasets.sh` `rm -rf` defect — deliberately NOT in scope), #3095 / PR #3141 (the delivery whose
+triage was nearly misattributed), #3130 / #3127 ("the verification was the broken part" siblings).
+
+## Why
+
+Two roots with different natures were conflated:
+
+| Root | Nature | Owner | Present in a bare checkout? |
+|------|--------|-------|-----------------------------|
+| `test-data/datasets` | **fetched, relocatable** binary corpus | `CQLITE_DATASETS_ROOT` | no (fetched) |
+| `test-data/schemas` | **committed source** — 23 files incl. `legacy/`, `udts/` | the checkout | **always** |
+
+Four independently-written call sites derived the *schemas* root from the *datasets* root by climbing
+`..`:
+
+```
+cqlite-core/benches/fixtures/mod.rs:73-75   datasets_root().join("../schemas")
+cqlite-core/tests/dead_cache_delete_tests.rs:604   root.join("../schemas").join(schema_file)
+cqlite-core/tests/observability_correctness.rs:548 datasets_root().join("../schemas").join(...)
+cqlite-cli/benches/export_csv.rs:124              datasets_root().join("../schemas").join(SCHEMA_FILE)
+```
+
+Three consequences, all observed on real runs:
+
+1. **No single root satisfies both halves (#3131).** `/data/datasets` (where `fetch-datasets.sh`
+   caches and extracts on this fleet) holds ~155 `-Data.db` but `/data` has no `schemas/`. The
+   CLAUDE.md-documented `<repo>/test-data/datasets` has the sibling but only ~30 committed byte-parity
+   references and **zero** `test_basic` fixtures. Pointing at the former clears the preflight and then
+   fails 5-8 tests with `Path does not exist: /data/datasets/../schemas/basic-types.cql`.
+
+2. **The gate's preflight validated only half the fixture contract (#3148).**
+   `grep -c schemas scripts/agent-gate.sh` was **0**. `_fixture_status()` counted
+   `$CQLITE_DATASETS_ROOT/sstables/test_basic/*-Data.db` and reported that as *fixture readiness* —
+   `STATUS: OK` — then ~8 minutes of build later `core-tests` and `memory-budget` failed on opaque
+   missing-`.cql` panics. That is **worse than having no preflight**: with no preflight an agent hitting
+   five `.cql` panics investigates its environment; with `STATUS: OK` already recorded it reads
+   "fixtures verified" and suspects its own diff. On #3095 / PR #3141 an environmental failure was
+   nearly attributed to a read-path change it had nothing to do with. A verification step that produces
+   false confidence actively degrades attribution.
+
+3. **`join("..")` is not a lexical parent at the syscall level.** The kernel resolves `datasets/..`
+   against the **symlink target's** parent. So `ln -s <checkout>/test-data/datasets /data/datasets`
+   makes `/data/datasets/../schemas` resolve to `<checkout>/test-data/schemas`, while a real
+   `/data/datasets` directory resolves to `/data/schemas`. Two visually identical layouts, opposite
+   outcomes, and no message explaining why — #3148's "symlink trap".
+
+Compounding it, **`fetch-datasets.sh` exits 0 having named no actionable root** when the cache is warm:
+its sole output was `Dataset <asset> (tag <tag>) already present in <root>; skipping download`. A green
+fetch was therefore not evidence that any particular tree gained fixtures, so the documented remedy
+silently failed to remedy (#3131 item 2).
+
+And the tempting shortcut — `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` — buys a green by letting dataset
+components SKIP: a vacuous PASS, exactly what #2078 exists to prevent. The wrong fix is also the easy one.
+
+## What Changes
+
+1. **The schemas root is resolved CHECKOUT-RELATIVE, never from `CQLITE_DATASETS_ROOT`** — #3148's
+   proposed fix 4, taken as the owner's design decision (#3148 AC (h)). A checkout always holds these
+   files, so the failure mode becomes **structurally impossible** and the symlink trap **disappears**
+   rather than being papered over: the change leaves ZERO `..` climbing from the datasets root, so
+   there is nothing left to mis-resolve. An explicit `CQLITE_SCHEMAS_ROOT` override is honored when set,
+   non-empty and readable, for out-of-tree runs.
+
+2. **One shared resolution file, `test-data/support/fixture_roots.rs`**, pulled into each consuming
+   target with `#[path = …] mod fixture_roots;` (the pattern already used for
+   `#[path = "../benches/fixtures/mod.rs"]`). All four historical sites migrate to it; no open-coded
+   `join("../schemas")` expression remains. `schema_path()` verifies readability and panics naming the
+   resolved **absolute** path, how the root was chosen, and the remedy.
+
+3. **The three divergent `datasets_root()` copies are reconciled** into one implementation exposing two
+   *documented* shapes — `datasets_root()` (infallible, checkout fallback) and
+   `datasets_root_if_present()` (`Option`, env-var-only, no fallback, for SKIP-gated tests) —
+   preserving today's observable per-test behavior exactly.
+
+4. **The FULL gate's preflight validates the schemas root**, checking **readability of the specific
+   `.cql` files the components consume** (not directory existence), and FAILs CLOSED with
+   `missing-schemas: FAIL-CLOSED (#3148)` — textually distinct from #2078's `missing-fixtures:` — plus a
+   remedy naming the exact expected absolute path. A positive `schemas: N/N …` line is stamped on
+   success so a pasted SUMMARY shows the check RAN. `--lite`/`--only` stay lenient. **No opt-out**: the
+   fetched corpus is legitimately absent sometimes; committed source in a checkout never is.
+
+5. **A positive-control self-test** (`scripts/tests/test_agent_gate_schemas_preflight.sh`, wired into
+   `tooling-tests`) proves the preflight **REJECTS** a schemas-less and a present-but-incomplete root.
+   The #3148 gap survived precisely because `STATUS: OK` was only ever observed on the happy path.
+
+6. **`fetch-datasets.sh` never exits 0 leaving an unusable root**: both exit paths re-verify the
+   content at the extraction target and print the exact
+   `export CQLITE_DATASETS_ROOT=<absolute path>` line the run guarantees, plus a NOTE when that differs
+   from the checkout default. A new non-mutating `--verify-only` mode makes the failure path
+   exercisable — a check observable only when passing is not a check.
+
+## Non-goals
+
+- **#2878 is NOT in scope.** The `rm -rf "${DATASET_ROOT}"` and the
+  `[ -n "${CI:-}" ] || return 0` short-circuit in `restore_ci_tracked_dataset_files` are deliberately
+  untouched; a self-test case asserts both remain verbatim so the boundary cannot be silently crossed.
+- **Not relocating the corpus.** #3131 item 1 offered (a) make the fetch populate the repo tree or
+  (b) ship `schemas/` alongside the extracted corpus. This change makes **both moot**: with the
+  schemas decoupled, ANY corpus root works, so `/data/datasets` is self-sufficient by construction and
+  no data is duplicated. Recorded as a deliberate supersession, not an omission.
+- **Not converting the other ad-hoc `CQLITE_DATASETS_ROOT` readers.** ~50 `cqlite-core/tests/**` and
+  `src/**` inline suites resolve the corpus themselves. #3148 names three copies; touching fifty is a
+  different change with a different risk profile.
+- **Not unifying the per-keyspace ad-hoc corpus checks** (`test_compactionparity`,
+  `test_compaction_tombstone_ttl` at `scripts/agent-gate.sh:4238`, `:4295`) — noted as adjacent
+  inconsistency in #3148's scope note and explicitly left out.
+- **Not a docs change in this deliverable.** CLAUDE.md and the `agents-developing/test-data` page are
+  updated on the same branch by a separate pass; the facts they must state are listed in `design.md`.
+- **No library surface, no on-disk format work, no no-heuristics implications.** Nothing touches
+  `cqlite-core`'s public API, the decode path, the bindings, or the <128MB budget. The shared file is
+  test/bench support and is never compiled into the library.
+
+## Impact
+
+- **New:** `test-data/support/fixture_roots.rs` (the single roots contract),
+  `scripts/tests/test_agent_gate_schemas_preflight.sh` (16 assertions, hermetic).
+- **Modified:** `cqlite-core/benches/fixtures/mod.rs`, `cqlite-core/tests/dead_cache_delete_tests.rs`,
+  `cqlite-core/tests/observability_correctness.rs`, `cqlite-cli/benches/export_csv.rs`,
+  `scripts/agent-gate.sh` (schemas preflight + `--preflight-schemas` hook + SUMMARY line +
+  `tooling-tests` wiring), `test-data/scripts/fetch-datasets.sh`.
+- **Gate:** a new FULL-gate fail-closed cause (`missing-schemas:`) and a new positive SUMMARY line
+  (`schemas:`). `--lite`/`--only`/`--delta` behavior unchanged.
+- **Operators:** `CQLITE_DATASETS_ROOT` alone is now sufficient on every layout; `CQLITE_SCHEMAS_ROOT`
+  is a new, optional out-of-tree override.

--- a/openspec/changes/schemas-root-contract/proposal.md
+++ b/openspec/changes/schemas-root-contract/proposal.md
@@ -115,7 +115,10 @@ components SKIP: a vacuous PASS, exactly what #2078 exists to prevent. The wrong
   `issue_693_writetime_threading.rs:42,48`, `issue_1562_perf_gate_access_path.rs:50,56`). Because they
   already fall back to the checkout they DEGRADE correctly on the layout that hard-failed the four sites
   in scope, so they are not part of this defect. The spec delta's single-definition requirement is
-  explicitly scoped to the four, so this change does not claim them. Consolidation is a follow-up.
+  explicitly scoped to the four, so this change does not claim them. Consolidation is deferred to
+  **#3192**, which must also widen the reintroduction guard from the literal `join("../schemas")` to
+  the `parent()`-based form — widening it BEFORE that migration would red the gate on ~15 untouched
+  files, so the guard and the migration have to land together.
 - **Not unifying the per-keyspace ad-hoc corpus checks** (`test_compactionparity`,
   `test_compaction_tombstone_ttl` at `scripts/agent-gate.sh:4238`, `:4295`) — noted as adjacent
   inconsistency in #3148's scope note and explicitly left out.

--- a/openspec/changes/schemas-root-contract/proposal.md
+++ b/openspec/changes/schemas-root-contract/proposal.md
@@ -109,6 +109,13 @@ components SKIP: a vacuous PASS, exactly what #2078 exists to prevent. The wrong
 - **Not converting the other ad-hoc `CQLITE_DATASETS_ROOT` readers.** ~50 `cqlite-core/tests/**` and
   `src/**` inline suites resolve the corpus themselves. #3148 names three copies; touching fifty is a
   different change with a different risk profile.
+- **Not converting the ~15 sites that use the *fallback* schemas idiom.** A separate group of
+  `cqlite-core/tests/**` files tries `datasets_root.parent()?.join("schemas")` **and then** a
+  `CARGO_MANIFEST_DIR`-anchored checkout path (e.g. `issue_1143_windowed_scan_straddle_parity.rs:71,77`,
+  `issue_693_writetime_threading.rs:42,48`, `issue_1562_perf_gate_access_path.rs:50,56`). Because they
+  already fall back to the checkout they DEGRADE correctly on the layout that hard-failed the four sites
+  in scope, so they are not part of this defect. The spec delta's single-definition requirement is
+  explicitly scoped to the four, so this change does not claim them. Consolidation is a follow-up.
 - **Not unifying the per-keyspace ad-hoc corpus checks** (`test_compactionparity`,
   `test_compaction_tombstone_ttl` at `scripts/agent-gate.sh:4238`, `:4295`) — noted as adjacent
   inconsistency in #3148's scope note and explicitly left out.

--- a/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
+++ b/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
@@ -81,6 +81,12 @@ gate.
 - **WHEN** the preflight runs
 - **THEN** the run exits non-zero with the schemas fail-closed marker naming the rejected relative override, stamps NO positive `schemas:` line, and does NOT report a list of "missing" files (the checkout's fixtures are in fact complete)
 
+#### Scenario: An override containing a control character is rejected
+- **GIVEN** `CQLITE_SCHEMAS_ROOT` names an EXISTING absolute directory but carries a control character (a trailing newline, a CR, an embedded tab)
+- **WHEN** the schemas root is resolved, on either side of the contract
+- **THEN** it is REJECTED with a message naming the rule and a remedy
+- **AND** the gate SHALL NOT report it as a validated override with the control character silently removed
+
 #### Scenario: A blank override is not an override
 - **GIVEN** `CQLITE_SCHEMAS_ROOT` is set to an empty or whitespace-only value
 - **WHEN** the schemas root is resolved

--- a/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
+++ b/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
@@ -1,0 +1,222 @@
+# test-fixture-roots — delta for schemas-root-contract (issues #3148, #3131)
+
+**Read this first.** The committed CQL schema fixtures (`test-data/schemas/`, 23 files incl. `legacy/`
+and `udts/`) and the fetched SSTable corpus (`test-data/datasets/`) are **different kinds of thing** with
+**different owners**. The contract below separates them: the corpus root is owned by
+`CQLITE_DATASETS_ROOT` (relocatable, fetched, may legitimately be absent); the schemas root is owned by
+the **checkout** (committed source, always present). No requirement below permits the second to be
+derived from the first.
+
+**Acceptance-criterion → requirement map.**
+
+| AC | Requirement(s) |
+|----|----------------|
+| **#3148 (a)** FULL-gate preflight FAILS CLOSED with a named error + remedy when the schemas root is missing/unreadable | *The FULL gate fails closed when a consumed schema fixture is unreadable*; *The preflight validates individual schema files, not directory existence* |
+| **#3148 (b)** failure text names the exact absolute path + fix command; marker distinguishable from `missing-fixtures:` | *The FULL gate fails closed when a consumed schema fixture is unreadable* |
+| **#3148 (c)** positive-control self-test proves the preflight FAILS on a schemas-less root | *The schemas preflight decision is exposed as a pure hook and positively controlled* |
+| **#3148 (d)** schemas-root resolution exists once, used by every caller; no open-coded `join("../schemas")` | *Schemas-root resolution has exactly one definition, used by every caller*; *An unreadable schema fixture fails with an actionable, path-naming message* |
+| **#3148 (e)** the two divergent `datasets_root()` implementations reconciled or documented | *The datasets root has one implementation with two documented shapes* |
+| **#3148 (f)** the symlinked-`datasets` layout works or is rejected, never silently mis-resolved | *The schemas root is independent of the datasets root* |
+| **#3148 (g)** `--lite` and `--only` remain lenient | *Only the FULL gate is strict about fixture roots* |
+| **#3148 (h)** scope decision recorded | *The schemas root is resolved checkout-relative by decision* |
+| **#3131 (1)** one documented root that works | *The schemas root is independent of the datasets root*; *The schemas root is resolved checkout-relative by decision* (which supersedes #3131's item-1 either/or — see `design.md`) |
+| **#3131 (2)** `fetch-datasets.sh` must not exit 0 without leaving a usable root | *A dataset fetch reports success only with a verified, named root*; *Dataset-root usability is probeable without mutating anything* |
+| **#3131 (3)** preflight detects the schemas half, not just the corpus | *The FULL gate fails closed when a consumed schema fixture is unreadable*; *The preflight validates individual schema files, not directory existence* |
+
+## ADDED Requirements
+
+### Requirement: The schemas root is resolved checkout-relative by decision
+The committed CQL schema fixtures SHALL be located relative to the **checkout** (anchored on
+`CARGO_MANIFEST_DIR`), and SHALL NOT be derived from `CQLITE_DATASETS_ROOT` by any means, including
+`join("..")`. An explicit `CQLITE_SCHEMAS_ROOT` SHALL be honored when it is set, non-empty and names a
+readable directory; otherwise resolution SHALL fall through to the checkout rather than fail. This is a
+recorded scope decision (#3148 AC (h), proposed fix 4): because a checkout always holds these files, the
+"absent schemas root" failure mode is structurally impossible rather than merely detected.
+
+#### Scenario: A machine-local corpus with no schemas sibling resolves correctly
+- **GIVEN** `CQLITE_DATASETS_ROOT` points at a corpus root whose parent directory contains no `schemas/` directory
+- **AND** `CQLITE_SCHEMAS_ROOT` is unset
+- **WHEN** a test or bench loads a fixture that needs a `.cql` schema
+- **THEN** the schema resolves from the checkout's `test-data/schemas` and the fixture loads successfully
+
+#### Scenario: An out-of-tree run may override the schemas root
+- **GIVEN** `CQLITE_SCHEMAS_ROOT` is set to a readable directory holding the schema fixtures
+- **WHEN** a schema fixture is resolved
+- **THEN** the override directory is used, and the resolution source is reported as the override
+
+#### Scenario: An unusable override degrades to the checkout rather than breaking every load
+- **GIVEN** `CQLITE_SCHEMAS_ROOT` is set to an empty string, or to a path that is not a directory
+- **WHEN** a schema fixture is resolved
+- **THEN** the checkout-relative root is used instead of the unusable override
+
+### Requirement: The schemas root is independent of the datasets root
+The resolved schemas root SHALL NOT vary with the value, shape or existence of `CQLITE_DATASETS_ROOT`. No
+Rust code SHALL contain an open-coded `join("../schemas")` expression. Because `join("..")` is resolved by
+the kernel against a **symlink target's** parent rather than lexically, a layout reached through a
+symlinked `datasets` directory previously mis-resolved silently; this requirement removes the possibility
+rather than detecting it.
+
+#### Scenario: Real, symlinked and absent datasets roots resolve the same schemas root
+- **GIVEN** three layouts — a real corpus directory, a symlink to that directory, and a path that does not exist
+- **WHEN** the schemas root is resolved under each in turn
+- **THEN** all three yield the identical checkout-relative schemas root
+
+#### Scenario: Reintroducing the parent-climb idiom fails the gate
+- **GIVEN** a change that re-adds an open-coded `join("../schemas")` expression in Rust code
+- **WHEN** the agent gate runs its shell-tooling component set
+- **THEN** the run FAILs and names the offending file and line
+- **AND** a doc comment that merely quotes the retired idiom does NOT fail it
+
+### Requirement: Schemas-root resolution has exactly one definition, used by every caller
+There SHALL be exactly one definition of schemas-root resolution, and every consumer SHALL use it —
+including consumers in more than one crate. A consumer SHALL NOT re-implement the resolution locally.
+
+#### Scenario: All four historical call sites route through the single definition
+- **GIVEN** the four sites that previously open-coded the resolution (`cqlite-core/benches/fixtures/mod.rs`, `cqlite-core/tests/dead_cache_delete_tests.rs`, `cqlite-core/tests/observability_correctness.rs`, `cqlite-cli/benches/export_csv.rs`)
+- **WHEN** the shared-definition guard runs
+- **THEN** each site is confirmed to include the shared module, and no bench or migrated test reads `CQLITE_DATASETS_ROOT` directly
+
+#### Scenario: A second crate consumes the same definition without a new crate dependency
+- **GIVEN** `cqlite-cli`'s `export_csv` bench, which is not permitted to depend on `cqlite-core`'s bench internals
+- **WHEN** it resolves a schema fixture
+- **THEN** it uses the same shared definition as `cqlite-core`, and the build succeeds with `-D warnings`
+
+### Requirement: An unreadable schema fixture fails with an actionable, path-naming message
+When a requested schema fixture cannot be read, the failure message SHALL name the resolved **absolute**
+path, the resolved root, how that root was chosen, and the remedy. A bare "path does not exist" raised
+from inside ingestion SHALL NOT be the observable failure.
+
+#### Scenario: A missing fixture names its absolute path and the remedy
+- **GIVEN** a schemas root that does not contain `basic-types.cql`
+- **WHEN** a test requests that fixture
+- **THEN** the failure names the absolute `.cql` path, the root and its source, states that these fixtures are committed source not fetched data, and gives the remedy
+
+### Requirement: The datasets root has one implementation with two documented shapes
+The fetched-corpus root SHALL have a single implementation exposing two documented shapes: an
+**infallible** shape with a checkout-relative fallback, and a **fallible** shape that returns nothing
+unless `CQLITE_DATASETS_ROOT` is set and names a directory. The difference SHALL be documented as a
+deliberate behavioral choice with a stated reason, and each existing consumer SHALL retain its current
+observable behavior.
+
+#### Scenario: A skip-gated test still skips when the corpus root is unset
+- **GIVEN** `CQLITE_DATASETS_ROOT` is unset
+- **WHEN** a test that uses the fallible shape runs
+- **THEN** it skips rather than running against the checkout's committed byte-parity references, and does not report a passing result over zero rows
+
+#### Scenario: A bench still runs from a plain checkout with no environment setup
+- **GIVEN** `CQLITE_DATASETS_ROOT` is unset and the checkout holds a fetched corpus
+- **WHEN** a bench that uses the infallible shape runs
+- **THEN** it resolves the checkout-relative corpus root
+
+### Requirement: The FULL gate fails closed when a consumed schema fixture is unreadable
+The FULL agent gate SHALL FAIL CLOSED, before running any compilation or test component, when any schema
+fixture its dataset-backed components consume is unreadable. The emitted SUMMARY SHALL carry a marker
+**textually distinguishable** from the #2078 corpus marker, and a remedy line naming the exact expected
+absolute path and the fix commands. Reporting `STATUS: OK` for such a layout SHALL NOT occur. There SHALL
+be no environment opt-out that permits a run to certify with the schemas root unreachable.
+
+#### Scenario: A complete corpus with an unreachable schemas root fails closed at the preflight
+- **GIVEN** a dataset root whose canonical corpus is present
+- **AND** a schemas root that holds none of the consumed `.cql` files
+- **WHEN** the FULL gate runs
+- **THEN** it exits non-zero at the preflight without running a cargo component
+- **AND** the SUMMARY carries `missing-schemas: FAIL-CLOSED (#3148)` and `RESULT: FAIL`, and never `RESULT: PASS`
+
+#### Scenario: The two fixture failure causes are separable in a pasted SUMMARY
+- **GIVEN** a run that fails on the schemas half while the corpus half is complete
+- **WHEN** the SUMMARY is read
+- **THEN** it carries the schemas marker and does NOT carry the `missing-fixtures:` corpus marker
+
+#### Scenario: The failure names the absolute path and the fix commands
+- **GIVEN** the schemas-unreachable failure above
+- **WHEN** the SUMMARY and stderr are read
+- **THEN** they name the exact expected absolute `.cql` path, the override to unset, and the command that restores the committed fixtures
+
+#### Scenario: A successful check is visible in the SUMMARY
+- **GIVEN** a FULL gate run whose schemas root is complete
+- **WHEN** the SUMMARY is read
+- **THEN** it carries a positive line naming the validated root and how it was resolved, so the block shows the check ran
+
+### Requirement: The preflight validates individual schema files, not directory existence
+The preflight SHALL assert **readability of each specific schema file** the gate's dataset-backed
+components consume, and SHALL report exactly which files are unreadable. A schemas root that exists but is
+incomplete SHALL NOT pass.
+
+#### Scenario: A present-but-incomplete schemas root is rejected, naming only the absentees
+- **GIVEN** a schemas root holding two of the consumed `.cql` files and missing the rest
+- **WHEN** the preflight decision is evaluated
+- **THEN** it is FAIL, and the reported unreadable list contains exactly the missing files and none of the present ones
+
+### Requirement: Only the FULL gate is strict about fixture roots
+`--lite` and `--only` SHALL remain lenient with respect to the schemas root, unchanged from the #2078
+contract. A lenient mode SHALL NOT emit the schemas failure marker.
+
+#### Scenario: --lite is unaffected by an unreachable schemas root
+- **GIVEN** an unreachable schemas root
+- **WHEN** `--lite` runs
+- **THEN** it exits zero with a LITE summary block carrying no schemas marker
+
+#### Scenario: --only stays lenient even for a dataset-backed selection
+- **GIVEN** an unreachable schemas root and an `--only` selection naming a dataset-backed component
+- **WHEN** the preflight decision is evaluated
+- **THEN** it is OK
+
+### Requirement: The schemas preflight decision is exposed as a pure hook and positively controlled
+The preflight's decision SHALL be available as a side-effect-free hook reporting the decision, the
+resolved root, its source and any unreadable files, so a self-test asserts the **same** decision the real
+gate consumes. A self-test SHALL prove the preflight **REJECTS** at least one unusable layout; proving
+only that a good layout passes SHALL NOT be sufficient coverage.
+
+#### Scenario: The hook reports the same decision the gate acts on
+- **GIVEN** a schemas-less root
+- **WHEN** the pure hook is invoked
+- **THEN** it reports a FAIL decision, the resolved root, the resolution source, and every unreadable file, without running any component
+
+#### Scenario: The self-test runs in the gate and fails on a weakened preflight
+- **GIVEN** the agent gate's shell-tooling component set
+- **WHEN** it runs
+- **THEN** the positive-control self-test executes, and a preflight that stopped rejecting an unusable layout FAILs the component
+
+### Requirement: A dataset fetch reports success only with a verified, named root
+`fetch-datasets.sh` SHALL NOT exit zero unless it has verified that the extraction target holds the
+required corpus content, on the warm-cache path as well as after a fresh extraction. On success it SHALL
+print the exact `export CQLITE_DATASETS_ROOT=<absolute path>` line it guarantees; when that root differs
+from the checkout default it SHALL say so and name the cause. On failure it SHALL exit non-zero with a
+remedy. The script's `rm -rf` and CI-tracked-file restore behavior SHALL remain unchanged (that is
+issue #2878).
+
+#### Scenario: A warm cache still names the root it guarantees
+- **GIVEN** a populated dataset root and a matching pin, so the download is skipped
+- **WHEN** the script runs
+- **THEN** it verifies the content, prints the exact `export CQLITE_DATASETS_ROOT=<absolute path>` line for that root, and exits zero
+
+#### Scenario: A populated root that is not the checkout default is called out
+- **GIVEN** `CQLITE_DATASETS_ROOT` already points at a machine-local root
+- **WHEN** the script succeeds
+- **THEN** it states that the checkout default was NOT populated and that exporting it instead would yield a corpus-less root
+
+#### Scenario: An unusable root is never reported as success
+- **GIVEN** a dataset root that does not hold the required content
+- **WHEN** usability is evaluated
+- **THEN** the script exits non-zero, names what is missing, and gives a remedy command
+
+#### Scenario: The #2878-owned behavior is untouched
+- **GIVEN** this change's diff to `fetch-datasets.sh`
+- **WHEN** the boundary guard runs
+- **THEN** the `rm -rf "${DATASET_ROOT}"` statement and the CI-only short-circuit in the tracked-file restore are present verbatim
+
+### Requirement: Dataset-root usability is probeable without mutating anything
+`fetch-datasets.sh` SHALL provide a mode that reports whether the resolved root is usable — and prints the
+guaranteed export line — while performing no download, extraction, removal or re-pin. This exists so the
+usability guarantee's **failure** path is exercisable; a check that can only be observed passing is not a
+check.
+
+#### Scenario: The probe reports a usable root without touching it
+- **GIVEN** a root holding the required content
+- **WHEN** the probe runs
+- **THEN** it exits zero, prints the verbatim export line for that root, and downloads/extracts/removes nothing
+
+#### Scenario: The probe fails loudly on a hollow root
+- **GIVEN** an existing but empty dataset root
+- **WHEN** the probe runs
+- **THEN** it exits non-zero with the missing-content diagnosis and a remedy

--- a/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
+++ b/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
@@ -127,7 +127,8 @@ idiom — `datasets_root.parent()?.join("schemas")` tried **first and then a
 `issue_693_writetime_threading.rs:42,48`, `issue_1562_perf_gate_access_path.rs:50,56`). Because they already
 fall back to the checkout, they DEGRADE correctly on the layout that broke the four sites above; they are
 therefore out of scope here, and no requirement in this delta asserts anything about them. Consolidating them
-is a follow-up, not a silent claim of this change.
+is deferred to **#3192** (which must also widen the reintroduction guard to the `parent()`-based form —
+widening it first would red the gate on ~15 untouched files), not a silent claim of this change.
 
 #### Scenario: The requirement's scope is the four hard-failing sites, not every schemas reference
 - **GIVEN** the ~15 test files that try a datasets-sibling schemas path and then fall back to a checkout-anchored path

--- a/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
+++ b/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
@@ -64,7 +64,12 @@ message SHALL name the offending value, state why relative values cannot be hono
 root, while cargo runs each test binary with CWD = the *package* directory. A relative value therefore
 resolves to two different places, and the gate would stamp a SUMMARY certifying one schemas root for a run
 whose tests read another — the "positively misleading `STATUS: OK`" defect this change exists to remove,
-reintroduced by its own fix. Rejection makes the two sides agree by construction rather than by review.
+reintroduced by its own fix. Rejection removes the one input class on which the two mirrors could not
+possibly agree. Note the guarantee's real strength: the gate's shell resolution and the Rust resolver are two
+HAND-WRITTEN mirrors kept **equivalent and pinned by self-tests** — not equivalent by construction. They have
+been walked case by case over the whole input table (unset, `""`, whitespace-only, `"  /abs  "`,
+absolute-non-dir, absolute-dir, relative) and agree on every one, and each case is asserted against the real
+gate.
 
 #### Scenario: A relative override fails the resolver
 - **GIVEN** `CQLITE_SCHEMAS_ROOT` is a relative path such as `packaged/schemas`, `./schemas` or `../schemas`
@@ -220,9 +225,16 @@ contract. A lenient mode SHALL NOT emit the schemas failure marker.
 
 ### Requirement: A summary line SHALL NOT assert a check the running mode did not perform
 The SUMMARY block SHALL NOT carry a positive assertion about the schemas root in a mode that did not
-validate it. In a lenient mode the block SHALL instead carry an explicitly NAMED non-check. Omitting the
-line silently is insufficient: a reader of a pasted block would assume the FULL contract held, which is the
-same false-confidence failure as a misleading `STATUS: OK`.
+validate it. In a lenient mode **that reached the preflight** the block SHALL instead carry an explicitly
+NAMED non-check. Omitting the line silently is insufficient there: a reader of a pasted block would assume
+the FULL contract held, which is the same false-confidence failure as a misleading `STATUS: OK`.
+
+**Why the qualifier is load-bearing, not hedging.** Two lenient modes never reach the preflight at all, and
+for them there is nothing to name: `--lite` returns before it, and an `--only` selection with no
+dataset-backed component skips the whole dataset preflight block. Those blocks carry no schemas line, which
+is correct — the requirement is about a mode that ran the preflight and was let through leniently, not about
+modes for which the preflight is not part of the run. Without the qualifier this requirement would
+contradict its own `--lite` scenario below.
 
 #### Scenario: A lenient --only run names the non-check instead of asserting readability
 - **GIVEN** an `--only` selection naming a dataset-backed component, with a schemas root holding none of the consumed `.cql` files

--- a/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
+++ b/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
@@ -17,7 +17,7 @@ derived from the first.
 | **#3148 (d)** schemas-root resolution exists once, used by every caller; no open-coded `join("../schemas")` | *Schemas-root resolution has exactly one definition, used by every schemas-consuming fixture site* (scope stated in that requirement); *An unreadable schema fixture fails with an actionable, path-naming message* |
 | **#3148 (e)** the two divergent `datasets_root()` implementations reconciled or documented | *The datasets root has one implementation with two documented shapes* |
 | **#3148 (f)** the symlinked-`datasets` layout works or is rejected, never silently mis-resolved | *The schemas root is independent of the datasets root* |
-| **#3148 (g)** `--lite` and `--only` remain lenient | *Only the FULL gate is strict about fixture roots* |
+| **#3148 (g)** `--lite` and `--only` remain lenient | *Only the FULL gate is strict about fixture roots*; *A summary line SHALL NOT assert a check the running mode did not perform* |
 | **#3148 (h)** scope decision recorded | *The schemas root is resolved checkout-relative by decision*; *A relative schemas-root override is rejected fail-closed* |
 | **#3131 (1)** one documented root that works | *The schemas root is independent of the datasets root*; *The schemas root is resolved checkout-relative by decision* (which supersedes #3131's item-1 either/or — see `design.md`) |
 | **#3131 (2)** `fetch-datasets.sh` must not exit 0 without leaving a usable root | *A dataset fetch reports success only with a verified, named root*; *The guaranteed export line is pasteable, not merely printed*; *Dataset-root usability is probeable without mutating anything*; *Every unrecognized argument to the dataset fetch is rejected fail-closed* |
@@ -212,6 +212,33 @@ contract. A lenient mode SHALL NOT emit the schemas failure marker.
 - **GIVEN** an unreachable schemas root and an `--only` selection naming a dataset-backed component
 - **WHEN** the preflight decision is evaluated
 - **THEN** it is OK
+
+#### Scenario: --only stays lenient for a rejected relative override too
+- **GIVEN** a relative `CQLITE_SCHEMAS_ROOT` and an `--only` selection naming a dataset-backed component
+- **WHEN** the preflight runs
+- **THEN** it returns without failing the run — the strict rejection path SHALL NOT bypass the lenient-mode check
+
+### Requirement: A summary line SHALL NOT assert a check the running mode did not perform
+The SUMMARY block SHALL NOT carry a positive assertion about the schemas root in a mode that did not
+validate it. In a lenient mode the block SHALL instead carry an explicitly NAMED non-check. Omitting the
+line silently is insufficient: a reader of a pasted block would assume the FULL contract held, which is the
+same false-confidence failure as a misleading `STATUS: OK`.
+
+#### Scenario: A lenient --only run names the non-check instead of asserting readability
+- **GIVEN** an `--only` selection naming a dataset-backed component, with a schemas root holding none of the consumed `.cql` files
+- **WHEN** the preflight runs
+- **THEN** the stamped schemas line reads as an explicit "not checked", naming the lenient mode
+- **AND** it SHALL NOT claim that any number of `.cql` files are readable
+
+#### Scenario: The positive assertion still appears when the check did run
+- **GIVEN** a FULL-mode preflight over a complete schemas root
+- **WHEN** the preflight runs
+- **THEN** the stamped schemas line asserts the validated count and the resolved root, so the non-check case above is not satisfied by simply never stamping anything
+
+#### Scenario: A --lite block carries no schemas line at all
+- **GIVEN** a `--lite` run with an unreachable schemas root
+- **WHEN** the LITE summary block is read
+- **THEN** it contains neither the failure marker nor any positive schemas assertion
 
 ### Requirement: The schemas preflight decision is exposed as a pure hook and positively controlled
 The preflight's decision SHALL be available as a side-effect-free hook reporting the decision, the

--- a/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
+++ b/openspec/changes/schemas-root-contract/specs/test-fixture-roots/spec.md
@@ -12,15 +12,15 @@ derived from the first.
 | AC | Requirement(s) |
 |----|----------------|
 | **#3148 (a)** FULL-gate preflight FAILS CLOSED with a named error + remedy when the schemas root is missing/unreadable | *The FULL gate fails closed when a consumed schema fixture is unreadable*; *The preflight validates individual schema files, not directory existence* |
-| **#3148 (b)** failure text names the exact absolute path + fix command; marker distinguishable from `missing-fixtures:` | *The FULL gate fails closed when a consumed schema fixture is unreadable* |
+| **#3148 (b)** failure text names the exact absolute path + fix command; marker distinguishable from `missing-fixtures:` | *The FULL gate fails closed when a consumed schema fixture is unreadable*; *A relative schemas-root override is rejected fail-closed* (a relative value would otherwise be printed on the `expected absolute path:` line) |
 | **#3148 (c)** positive-control self-test proves the preflight FAILS on a schemas-less root | *The schemas preflight decision is exposed as a pure hook and positively controlled* |
-| **#3148 (d)** schemas-root resolution exists once, used by every caller; no open-coded `join("../schemas")` | *Schemas-root resolution has exactly one definition, used by every caller*; *An unreadable schema fixture fails with an actionable, path-naming message* |
+| **#3148 (d)** schemas-root resolution exists once, used by every caller; no open-coded `join("../schemas")` | *Schemas-root resolution has exactly one definition, used by every schemas-consuming fixture site* (scope stated in that requirement); *An unreadable schema fixture fails with an actionable, path-naming message* |
 | **#3148 (e)** the two divergent `datasets_root()` implementations reconciled or documented | *The datasets root has one implementation with two documented shapes* |
 | **#3148 (f)** the symlinked-`datasets` layout works or is rejected, never silently mis-resolved | *The schemas root is independent of the datasets root* |
 | **#3148 (g)** `--lite` and `--only` remain lenient | *Only the FULL gate is strict about fixture roots* |
-| **#3148 (h)** scope decision recorded | *The schemas root is resolved checkout-relative by decision* |
+| **#3148 (h)** scope decision recorded | *The schemas root is resolved checkout-relative by decision*; *A relative schemas-root override is rejected fail-closed* |
 | **#3131 (1)** one documented root that works | *The schemas root is independent of the datasets root*; *The schemas root is resolved checkout-relative by decision* (which supersedes #3131's item-1 either/or — see `design.md`) |
-| **#3131 (2)** `fetch-datasets.sh` must not exit 0 without leaving a usable root | *A dataset fetch reports success only with a verified, named root*; *Dataset-root usability is probeable without mutating anything* |
+| **#3131 (2)** `fetch-datasets.sh` must not exit 0 without leaving a usable root | *A dataset fetch reports success only with a verified, named root*; *The guaranteed export line is pasteable, not merely printed*; *Dataset-root usability is probeable without mutating anything*; *Every unrecognized argument to the dataset fetch is rejected fail-closed* |
 | **#3131 (3)** preflight detects the schemas half, not just the corpus | *The FULL gate fails closed when a consumed schema fixture is unreadable*; *The preflight validates individual schema files, not directory existence* |
 
 ## ADDED Requirements
@@ -39,15 +39,47 @@ recorded scope decision (#3148 AC (h), proposed fix 4): because a checkout alway
 - **WHEN** a test or bench loads a fixture that needs a `.cql` schema
 - **THEN** the schema resolves from the checkout's `test-data/schemas` and the fixture loads successfully
 
+#### Scenario: The checkout is identified by a checkout marker, not by the fixtures
+- **GIVEN** a checkout whose `test-data/schemas` is absent (a sparse checkout, or a worktree created inside another checkout that DOES have fixtures)
+- **WHEN** the checkout's `test-data` directory is resolved
+- **THEN** it resolves to THIS checkout's own root — identified by the workspace-root manifest — and a missing `test-data/schemas` under it fails loudly naming that path
+- **AND** it SHALL NOT silently resolve to an enclosing checkout's fixtures
+
 #### Scenario: An out-of-tree run may override the schemas root
-- **GIVEN** `CQLITE_SCHEMAS_ROOT` is set to a readable directory holding the schema fixtures
+- **GIVEN** `CQLITE_SCHEMAS_ROOT` is set to an ABSOLUTE, readable directory holding the schema fixtures
 - **WHEN** a schema fixture is resolved
 - **THEN** the override directory is used, and the resolution source is reported as the override
 
-#### Scenario: An unusable override degrades to the checkout rather than breaking every load
-- **GIVEN** `CQLITE_SCHEMAS_ROOT` is set to an empty string, or to a path that is not a directory
+#### Scenario: An unusable absolute override degrades to the checkout rather than breaking every load
+- **GIVEN** `CQLITE_SCHEMAS_ROOT` is set to an empty string, or to an ABSOLUTE path that is not a directory
 - **WHEN** a schema fixture is resolved
 - **THEN** the checkout-relative root is used instead of the unusable override
+
+### Requirement: A relative schemas-root override is rejected fail-closed
+`CQLITE_SCHEMAS_ROOT` SHALL be an absolute path. A relative value SHALL be REJECTED — by the resolver and by
+the gate preflight alike — and SHALL NOT be resolved against the current working directory. The rejection
+message SHALL name the offending value, state why relative values cannot be honored, and give a remedy.
+
+**Why this is fail-closed rather than best-effort.** The gate evaluates the override with CWD = repository
+root, while cargo runs each test binary with CWD = the *package* directory. A relative value therefore
+resolves to two different places, and the gate would stamp a SUMMARY certifying one schemas root for a run
+whose tests read another — the "positively misleading `STATUS: OK`" defect this change exists to remove,
+reintroduced by its own fix. Rejection makes the two sides agree by construction rather than by review.
+
+#### Scenario: A relative override fails the resolver
+- **GIVEN** `CQLITE_SCHEMAS_ROOT` is a relative path such as `packaged/schemas`, `./schemas` or `../schemas`
+- **WHEN** the schemas root is resolved
+- **THEN** resolution fails with a message naming the value, the CWD asymmetry, and the remedy — it does NOT silently use either candidate directory
+
+#### Scenario: A relative override fails the FULL gate closed, under its own reason
+- **GIVEN** a FULL gate run with a complete corpus, complete checkout fixtures, and a relative `CQLITE_SCHEMAS_ROOT`
+- **WHEN** the preflight runs
+- **THEN** the run exits non-zero with the schemas fail-closed marker naming the rejected relative override, stamps NO positive `schemas:` line, and does NOT report a list of "missing" files (the checkout's fixtures are in fact complete)
+
+#### Scenario: A blank override is not an override
+- **GIVEN** `CQLITE_SCHEMAS_ROOT` is set to an empty or whitespace-only value
+- **WHEN** the schemas root is resolved
+- **THEN** it is treated as unset and the checkout-relative root is used, on both the resolver and the gate side
 
 ### Requirement: The schemas root is independent of the datasets root
 The resolved schemas root SHALL NOT vary with the value, shape or existence of `CQLITE_DATASETS_ROOT`. No
@@ -67,9 +99,29 @@ rather than detecting it.
 - **THEN** the run FAILs and names the offending file and line
 - **AND** a doc comment that merely quotes the retired idiom does NOT fail it
 
-### Requirement: Schemas-root resolution has exactly one definition, used by every caller
-There SHALL be exactly one definition of schemas-root resolution, and every consumer SHALL use it —
-including consumers in more than one crate. A consumer SHALL NOT re-implement the resolution locally.
+### Requirement: Schemas-root resolution has exactly one definition, used by every schemas-consuming fixture site
+There SHALL be exactly one definition of schemas-root resolution, and every site **in this change's scope**
+SHALL use it — including sites in more than one crate. A site in scope SHALL NOT re-implement the resolution
+locally.
+
+**Scope, stated precisely so the requirement does not overclaim.** "Every caller" means the four sites #3148
+enumerates — the ones that derived the schemas root from `CQLITE_DATASETS_ROOT` by climbing `..` with no
+fallback, and therefore *hard-failed* on a corpus root without a `schemas` sibling:
+`cqlite-core/benches/fixtures/mod.rs`, `cqlite-core/tests/dead_cache_delete_tests.rs`,
+`cqlite-core/tests/observability_correctness.rs`, `cqlite-cli/benches/export_csv.rs`.
+
+Approximately fifteen further `cqlite-core/tests/**` files resolve a schemas directory with a *different*
+idiom — `datasets_root.parent()?.join("schemas")` tried **first and then a
+`CARGO_MANIFEST_DIR`-anchored checkout fallback** (e.g. `issue_1143_windowed_scan_straddle_parity.rs:71,77`,
+`issue_693_writetime_threading.rs:42,48`, `issue_1562_perf_gate_access_path.rs:50,56`). Because they already
+fall back to the checkout, they DEGRADE correctly on the layout that broke the four sites above; they are
+therefore out of scope here, and no requirement in this delta asserts anything about them. Consolidating them
+is a follow-up, not a silent claim of this change.
+
+#### Scenario: The requirement's scope is the four hard-failing sites, not every schemas reference
+- **GIVEN** the ~15 test files that try a datasets-sibling schemas path and then fall back to a checkout-anchored path
+- **WHEN** the single-definition guard runs
+- **THEN** it asserts only the four in-scope sites, and does NOT report those ~15 as violations
 
 #### Scenario: All four historical call sites route through the single definition
 - **GIVEN** the four sites that previously open-coded the resolution (`cqlite-core/benches/fixtures/mod.rs`, `cqlite-core/tests/dead_cache_delete_tests.rs`, `cqlite-core/tests/observability_correctness.rs`, `cqlite-cli/benches/export_csv.rs`)
@@ -205,11 +257,21 @@ issue #2878).
 - **WHEN** the boundary guard runs
 - **THEN** the `rm -rf "${DATASET_ROOT}"` statement and the CI-only short-circuit in the tracked-file restore are present verbatim
 
+### Requirement: The guaranteed export line is pasteable, not merely printed
+The printed `export CQLITE_DATASETS_ROOT=…` line SHALL be shell-quoted, so that pasting it reproduces the
+exact root even when the path contains spaces or shell metacharacters. A line that is correct only for
+metacharacter-free paths does not satisfy "the exact actionable export line".
+
+#### Scenario: A root containing spaces and metacharacters round-trips
+- **GIVEN** a usable dataset root whose absolute path contains a space and a shell metacharacter
+- **WHEN** the printed export line is evaluated by a shell
+- **THEN** the resulting `CQLITE_DATASETS_ROOT` equals the original path exactly
+
 ### Requirement: Dataset-root usability is probeable without mutating anything
 `fetch-datasets.sh` SHALL provide a mode that reports whether the resolved root is usable — and prints the
-guaranteed export line — while performing no download, extraction, removal or re-pin. This exists so the
-usability guarantee's **failure** path is exercisable; a check that can only be observed passing is not a
-check.
+guaranteed export line — while performing **no** download, extraction, removal, re-pin **or directory
+creation**. This exists so the usability guarantee's **failure** path is exercisable; a check that can only be
+observed passing is not a check.
 
 #### Scenario: The probe reports a usable root without touching it
 - **GIVEN** a root holding the required content
@@ -220,3 +282,23 @@ check.
 - **GIVEN** an existing but empty dataset root
 - **WHEN** the probe runs
 - **THEN** it exits non-zero with the missing-content diagnosis and a remedy
+
+#### Scenario: The probe creates no directory, not even a missing parent
+- **GIVEN** a dataset root whose parent directory does not exist
+- **WHEN** the probe runs
+- **THEN** it exits non-zero AND the parent directory has not been created
+
+### Requirement: Every unrecognized argument to the dataset fetch is rejected fail-closed
+`fetch-datasets.sh`'s default path is destructive (it removes the dataset root before extracting), so it SHALL
+reject **any** unrecognized argument with a usage error and a non-zero exit, before performing any filesystem
+work. An unrecognized or misspelled argument SHALL NOT fall through to the destructive path.
+
+#### Scenario: A misspelled or extra flag never reaches the destructive path
+- **GIVEN** an invocation such as `--quiet --verify-only`, `-verify-only`, or any misspelling of the probe flag
+- **WHEN** the script runs against a populated dataset root
+- **THEN** it exits with a usage error naming the unrecognized argument, and the dataset root's contents are untouched
+
+#### Scenario: The recognized flags still work
+- **GIVEN** `--verify-only` or `--help`
+- **WHEN** the script runs
+- **THEN** the flag is honored (and `--help` documents the probe and exits zero)

--- a/openspec/changes/schemas-root-contract/tasks.md
+++ b/openspec/changes/schemas-root-contract/tasks.md
@@ -250,3 +250,38 @@
       re-run because finding 2 changed resolution logic on both sides: hostile-layout 8/8 + 3/3 + 1/1 +
       1/1, empty-override 4-pass/4-fail, relative-override 4 fail-closed, negative-control FULL gate rc=1
       with the marker. Self-test 30 → 32 cases; contract tests 8 → 9.
+
+## 11. Gate of record FAIL + C (spec-auditor) PARTIAL — round 4
+- [x] **`tooling-tests: FAIL` root cause** — NOT nesting (the leading hypothesis is REFUTED: the schemas
+      self-test passed 32/32 INSIDE the gate, `tooling-tests.log:481`). The failure was the PRE-EXISTING
+      `test_agent_gate_tree_portability.sh` derived-inventory UNIQUENESS assert (`n=45 uniq=44`), because
+      round 3's NIT-D fix STUBBED `emit_summary`/`_tree_meta_array` in the
+      `--preflight-schemas-line` hook — a SECOND definition of a `_tree*` function. It passed standalone
+      because that portability test only runs inside `tooling-tests`, which had not been run. Replaced the
+      stubs with `_SCHEMAS_PREFLIGHT_REPORT_ONLY` (the two failure branches return with the marker in
+      `SCHEMAS_LINE` instead of emitting + exiting); a flag on the terminal ACTION carries no decision and
+      stamps no new text. Portability test 28/1 → 29/0.
+- [x] **C (i) requirement 5 UNCOVERED** — the unreadable-fixture message was asserted by nothing (revert
+      `schema_path` to a bare `expect` and every test stayed green). Factored `resolve_schema_path(root,
+      source, file) -> Result<_, String>` and added two tests: the message must name the absolute path,
+      the root, HOW the root was chosen, the committed-source note and the remedy; and `schema_path`
+      itself must PANIC with it (`catch_unwind`, no env mutation). REVERT-PROOF: replacing the body with
+      `Err("Path does not exist: …")` FAILs both.
+- [x] **C (ii) AC (b) partial — a FALSE message** — the reject branch hard-coded the RELATIVE explanation
+      and marker for EVERY rejection, so a control-character value was reported as "relative". Added
+      `_gate_schemas_override_reject_kind` and derived prose + marker from it. Pinned at the REAL FULL-gate
+      emit (`3148-cc-emit-wording`), asserting the control-character wording is present AND the false
+      "relative" wording is absent, in both the block and stderr.
+- [x] **C (iii) requirement 12 partial** — nothing exercised the warm-cache `guarantee_usable_root` call
+      site or the "NOT the checkout default" NOTE. Two cases now drive the REAL fetch script down the
+      warm-skip path (`.dataset-pin` derived from the TRACKED `dataset-pin.env`, never hard-coded), with a
+      failing `curl` stub first on PATH so a future pin mismatch dies without network and without reaching
+      `rm -rf`.
+- [x] **C (iv) requirement 6 partial** — the guard grepped for the function NAME. Factored
+      `resolve_datasets_root` / `resolve_datasets_root_if_present` and asserted both shapes behaviourally.
+      REVERT-PROOF: giving the fallible shape a checkout fallback FAILs
+      `the_two_datasets_root_shapes_differ_as_documented`.
+- [x] **C (v)** — `3148-no-optout`: `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` must not buy a pass on a
+      schemas-less root; and **#3192 is now cited by number** in `proposal.md` and `spec.md`, together with
+      why the reintroduction guard cannot be widened before that migration lands.
+- [x] Self-test 32 → 36 cases; contract tests 9 → 12; portability 29/29.

--- a/openspec/changes/schemas-root-contract/tasks.md
+++ b/openspec/changes/schemas-root-contract/tasks.md
@@ -106,3 +106,37 @@
 - [x] `scripts/agent-gate.sh --lite` PASS with the summary-file redirect.
 - [ ] Doctrine pass (CLAUDE.md + the `agents-developing/test-data` page) — handled separately on this
       branch; the required facts are listed at the end of `design.md`.
+
+## 7. Review round 1 (rust-reviewer blockers B1-B3, nits N4/N6/N7; roborev job 8 findings 1-3)
+- [x] **B1** — reject a RELATIVE `CQLITE_SCHEMAS_ROOT` fail-closed on BOTH sides
+      (`resolve_schemas_root` returns `Err`; `_gate_schemas_override_reject` FAILs the preflight with its
+      own marker text and hint), so the gate can no longer stamp `schemas: … under <relative>` for a run
+      whose test binaries resolved a different root. Also removes the "relative path labelled absolute"
+      remedy line (AC (b)).
+- [x] **B2** — `--verify-only` creates nothing: `canonicalize_dataset_root` skips `mkdir -p "${parent}"`
+      under the probe and reports a nonexistent parent as "root unusable".
+- [x] **B3** — strict argument parsing FIRST, before the pin load and before canonicalization: any
+      unrecognized argument exits 2 with usage, so a typo can no longer fall through to `rm -rf`.
+      Confirmed no existing caller passes an argument.
+- [x] **N4 / roborev finding 1** — anchor the checkout on a MARKER (nearest ancestor `Cargo.toml`
+      declaring `[workspace]`) instead of on `test-data/schemas`, so a sparse checkout or a
+      nested-in-another-checkout worktree can no longer resolve to the OUTER checkout's fixtures; return
+      the path whether or not it exists so a missing tree fails loudly. Gate mirrors the same walk. The
+      `..`-free claim is now true by construction (`Path::parent`, never `join("..")`).
+- [x] **N6** — deleted `check_schema_files` (zero callers, zero tests).
+- [x] **N7 / roborev finding 2** — same readability question on both sides: `readable_file`
+      (`is_file()` AND openable) in Rust, `[ -f ] && [ -r ]` in the gate. Expanding the 6-file canonical
+      list is DEFERRED (see the requirement's scope note) — the list is the set whose absence produced
+      the observed failures.
+- [x] **roborev finding 3** — print the guaranteed export line with `printf %q` so it round-trips a path
+      containing spaces or shell metacharacters.
+- [x] `cqlite-core/tests/issue_3148_fixture_roots_contract.rs` (7 tests) pins the Rust half of the
+      resolution table via the PURE `resolve_schemas_root`, with no env mutation.
+- [x] Self-test grown 16 → 25 cases: relative-override (hook + shapes + blank + FULL-gate emit + the
+      no-relative-labelled-absolute assert), the directory-named-like-a-`.cql` trap, `--verify-only`
+      non-mutation asserted on the FILESYSTEM with a NOT-pre-created parent (the earlier case pre-`mkdir`ed
+      its root and was blind to B2), unrecognized-argument rejection asserted against a POPULATED root so
+      a regression would have to delete a fixture the case then checks for, `--help`, and export-line
+      round-tripping through `eval`.
+- [x] N5 — scope the spec's single-definition requirement to the four hard-failing sites and record why
+      the ~15 `parent()?.join("schemas")`-with-fallback sites are out of scope.

--- a/openspec/changes/schemas-root-contract/tasks.md
+++ b/openspec/changes/schemas-root-contract/tasks.md
@@ -140,3 +140,31 @@
       round-tripping through `eval`.
 - [x] N5 — scope the spec's single-definition requirement to the four hard-failing sites and record why
       the ~15 `parent()?.join("schemas")`-with-fallback sites are out of scope.
+
+## 8. Review round 2 (docs-pass finding: a positive line asserting an unperformed check)
+- [x] `apply_schemas_preflight` gained a LENIENCY early-return: under `--only`/`--lite` it stamps an
+      explicit `schemas: not checked (<mode> is lenient, #3148 AC (g)) — this block asserts NOTHING
+      about the schemas root` and returns. Previously `_schemas_status`'s unconditional OK under
+      `--only` fell into the OK branch and stamped `schemas: 6/6 canonical .cql readable under <root>`
+      for a check that never ran — #3148's misleading `STATUS: OK`, one mode over. Chose the explicit
+      named non-check over silent omission: silence lets a reader of a pasted block assume the FULL
+      contract held.
+- [x] The same early-return also fixes a SECOND instance of the class: the REJECT branch was not
+      governed by `_schemas_status`, so a relative override FAILed even a lenient `--only` run — the
+      effectful guard diverging from the pure decision it is documented to consume. One mode check now
+      governs both.
+- [x] Hidden `--preflight-schemas-line [only-list]` hook drives the REAL `apply_schemas_preflight` and
+      prints the stamped line, so the self-test observes the ACTUAL summary text (a real
+      `--only core-tests` run would spend minutes in cargo before printing anything).
+- [x] Three new positive controls, CONFIRMED FAILING before the fix (with the leniency early-return
+      temporarily removed): the `--only` case then stamped `schemas: 6/6 canonical .cql readable under
+      <empty dir>`, and the relative-override case exited 1. Both pass after; the third asserts the
+      positive line STILL appears in FULL mode so the first two cannot be satisfied by never stamping
+      anything.
+- [x] `--lite` audited: `run_lite` always exits before `apply_schemas_preflight`, so no schemas line was
+      ever reachable there. The lite case now additionally asserts `! grep '^schemas: '` so a future
+      call-site move cannot start asserting readability in a mode that never checked.
+- [x] Audited the rest of this change's SUMMARY output for the same class: the only other lines it adds
+      (`missing-schemas:` ×2 variants, `preflight: FAIL (…)`, `hint: expected …`) are emitted ONLY on the
+      strict path, after the check actually ran and failed, and every value in them is derived from that
+      performed check. Nothing else asserts an unverified fact.

--- a/openspec/changes/schemas-root-contract/tasks.md
+++ b/openspec/changes/schemas-root-contract/tasks.md
@@ -1,20 +1,31 @@
 # Tasks: schemas-root-contract (issues #3148, #3131)
 
 > Design decided in `design.md`: the committed schema fixtures resolve **checkout-relative**
-> (`CARGO_MANIFEST_DIR`-anchored ancestor walk), never from `CQLITE_DATASETS_ROOT` — #3148's proposed
+> (anchored on the WORKSPACE-ROOT `Cargo.toml` found by walking `CARGO_MANIFEST_DIR`'s ancestors — see
+> §7 N4; the first cut keyed that walk on `test-data/schemas` and was corrected in review), never
+> from `CQLITE_DATASETS_ROOT` — #3148's proposed
 > fix 4, taken as the owner's decision (AC (h)). One shared `#[path]`-included file hosted under
 > `test-data/support/` because it encodes the layout of `test-data` itself and is owned by neither crate.
 > The gate preflight becomes a belt-and-braces per-FILE readability assert with no opt-out.
 > AC → requirement map is at the top of `specs/test-fixture-roots/spec.md`.
 
 ## 1. The single roots contract (surface: `test-data/support/fixture_roots.rs`)
-- [x] Create the shared std-only module with `datasets_root`, `datasets_root_if_present`,
-      `sstables_root`, `schemas_root`, `schemas_root_resolved`, `schema_path`, `check_schema_files`.
-- [x] Resolve the checkout by walking `CARGO_MANIFEST_DIR`'s **ancestors** for the first holding
-      `test-data/schemas` (not a hardcoded `../test-data`), so a crate nested deeper than one level
-      still resolves and no `..` component is ever handed to the kernel.
-- [x] Honor `CQLITE_SCHEMAS_ROOT` only when set, non-empty AND a readable directory; fall through to the
-      checkout otherwise (a stale export must degrade, not pin every load to an unusable path).
+- [x] Create the shared std-only module. Delivered surface (as merged, after review round 1):
+      `datasets_root`, `datasets_root_if_present`, `sstables_root`, `schemas_root`,
+      `schemas_root_resolved`, `resolve_schemas_root` (the pure, env-free resolver), `schema_path`,
+      `readable_file`, `checkout_test_data_dir`, `workspace_root`, `workspace_root_from`. A
+      `check_schema_files` helper existed in the first cut and was DELETED in review round 1 (§7 N6):
+      zero callers, zero tests, no wiring evidence.
+- [x] Resolve the checkout by walking `CARGO_MANIFEST_DIR`'s **ancestors** (not a hardcoded
+      `../test-data`), so a crate nested deeper than one level still resolves and no `..` component is
+      ever handed to the kernel. **The walk keys on the workspace-root `Cargo.toml` marker, NOT on
+      `test-data/schemas`** — the fixtures-keyed version shipped in the first cut and was replaced in
+      review round 1 (§7 N4) because it let a sparse checkout, or a worktree nested inside another
+      checkout, silently resolve to the OUTER checkout's fixtures.
+- [x] Honor `CQLITE_SCHEMAS_ROOT` only when set, non-blank, **ABSOLUTE** AND a readable directory; fall
+      through to the checkout for an absolute-but-unusable value (a stale export must degrade, not pin
+      every load to an unusable path). A RELATIVE value is REJECTED fail-closed rather than resolved —
+      added in review round 1 (§7 B1).
 - [x] Treat an exported-but-EMPTY env value as unset for both roots (a scripting accident, never an
       intentional root).
 - [x] `schema_path` verifies readability and panics naming the resolved ABSOLUTE path, the root, the
@@ -132,7 +143,7 @@
       containing spaces or shell metacharacters.
 - [x] `cqlite-core/tests/issue_3148_fixture_roots_contract.rs` (7 tests) pins the Rust half of the
       resolution table via the PURE `resolve_schemas_root`, with no env mutation.
-- [x] Self-test grown 16 → 25 cases: relative-override (hook + shapes + blank + FULL-gate emit + the
+- [x] Self-test grown 16 → 25 cases in this round (30 after §8 and the round-2 corrections): relative-override (hook + shapes + blank + FULL-gate emit + the
       no-relative-labelled-absolute assert), the directory-named-like-a-`.cql` trap, `--verify-only`
       non-mutation asserted on the FILESYSTEM with a NOT-pre-created parent (the earlier case pre-`mkdir`ed
       its root and was blind to B2), unrecognized-argument rejection asserted against a POPULATED root so
@@ -168,3 +179,39 @@
       (`missing-schemas:` ×2 variants, `preflight: FAIL (…)`, `hint: expected …`) are emitted ONLY on the
       strict path, after the check actually ran and failed, and every value in them is derived from that
       performed check. Nothing else asserts an unverified fact.
+
+## 9. Review round 2 corrections (rust-reviewer: no blockers; 6 nits + roborev job 9's 2 findings)
+- [x] Rebased onto `origin/main` `8e85b9e` — roborev job 9 was VOID for certification (`origin/main`
+      advanced 4 commits mid-review, so `sha-assert` FAILed against a stale base). No conflicts.
+- [x] **NIT-A** — the AC-(b) "no relative path labelled absolute" case was VACUOUS: it matched
+      `--preflight-schemas` STDOUT, but `expected absolute path:` is `apply_schemas_preflight` STDERR,
+      so it passed unconditionally — including after a full revert of the fix. Re-pointed at the real
+      FULL-gate emit (stdout+stderr capture + the summary file) and PROVEN discriminating by reverting
+      the reject branch and watching it fail.
+- [x] **NIT-B** — the N4 marker rule had no discriminating control (in a healthy checkout the retired
+      fixtures-keyed walk returns the same path). Factored `workspace_root_from(start)` and added a
+      synthetic `outer/{Cargo.toml,test-data/schemas}` + `outer/inner/{Cargo.toml,cqlite-core}` layout
+      where the two rules DISAGREE; proven by reverting the rule and watching it fail.
+- [x] **NIT-C** — named the in-repo counterexample to "nearest `[workspace]` is always the enclosing
+      checkout": `fuzz/Cargo.toml` declares its own (#1614). Benign (loud failure, never a wrong-tree
+      borrow); recorded in both mirrors' comments.
+- [x] **NIT-D** — corrected the `--preflight-schemas-line` comment: it can NEVER observe a FAIL SUMMARY
+      because `emit_summary`/`_tree_meta_array` are defined after the arg dispatch. The two
+      `command not found` lines are gone: the hook stubs both so the strict-failure path exits non-zero
+      with one named token.
+- [x] **NIT-E** — de-staled this file: the deleted `check_schema_files` no longer listed as delivered,
+      the retired fixtures-keyed walk no longer described as the design, case counts corrected.
+- [x] **NIT-F** — narrowed the "named non-check" requirement to a lenient mode **that reached the
+      preflight**, so it stops contradicting its own `--lite` scenario (and `--only fmt`, which skips the
+      dataset preflight entirely).
+- [x] **B1 prose** — replaced the unearned "agree by construction" in `fixture_roots.rs` and `spec.md`
+      with what is actually true: two hand-written mirrors, EQUIVALENT and PINNED BY SELF-TESTS, walked
+      case by case over the whole input table.
+- [x] **roborev job 9 finding 1** — single-sourced override presence (`_gate_schemas_override`): the
+      reject helper trimmed before deciding presence while the root/source helpers tested the raw `-n`
+      value, so a directory literally named `"   "` would have been reported as the override while Rust
+      treated the var as unset. Pinned with a whitespace-named-directory case in a synthetic checkout.
+- [x] **roborev job 9 finding 2** — `find -H`: a `DATASET_ROOT` that is ITSELF a symlink was never
+      descended, so every count came back 0. The reported symptom understated it — verification FAILED
+      outright, so `--verify-only` called a good corpus unusable on exactly the symlinked layout #3148
+      documents. Fixed and pinned with a symlinked-root case.

--- a/openspec/changes/schemas-root-contract/tasks.md
+++ b/openspec/changes/schemas-root-contract/tasks.md
@@ -285,3 +285,41 @@
       schemas-less root; and **#3192 is now cited by number** in `proposal.md` and `spec.md`, together with
       why the reintroduction guard cannot be widened before that migration lands.
 - [x] Self-test 32 → 36 cases; contract tests 9 → 12; portability 29/29.
+
+## 12. C re-audit round 5 — requirement 8 defeated by the round-4 fix
+> **Process note, recorded deliberately.** This is the **sixth** instance in this delivery of a fix
+> introducing a defect, and the **third** time the introduced defect was the very property the change
+> exists to guarantee: (1) a positive `schemas:` line asserting an unperformed check (round 2), (2) a
+> `$( )`-stripped override diverging the two mirrors (round 3, from round 2's own fix), (3) this — an
+> uninitialized, env-readable report-only flag turning the fail-closed `exit 1` into `return 1` (round 4,
+> from round 3's comment fix). Each was found by review, not by the tests written alongside the fix. The
+> pattern is the argument for the revert-and-watch-it-fail discipline used throughout, and for treating
+> "does this fix reintroduce the class one layer over?" as a required question, not a courtesy.
+- [x] **The defect** — `_SCHEMAS_PREFLIGHT_REPORT_ONLY` was read as `${…:-}` and never initialized
+      (unlike `SCHEMAS_LINE=""`), so an inherited/exported value made the FULL gate's fail-closed branch
+      `return 1` at a bare call site with no `errexit`; the run continued and the
+      `missing-schemas: FAIL-CLOSED` text could be stamped inside a block reading `RESULT: PASS`.
+      Requirement 8 ("no environment opt-out may permit a run to certify with the schemas root
+      unreachable") was violated by construction.
+- [x] **Mechanism chosen: a POSITIONAL ARGUMENT, not a variable.** `apply_schemas_preflight
+      [report-only]`; the hook passes `report-only`, the real gate passes nothing, so STRICT is the
+      default that needs no state to be correct. Initialization alone would have closed only the
+      INHERITED path — an `export` performed after initialization still wins, because the read happens
+      later. `$1` inside a function comes from the CALL; no env var, `export`, or `env -i` can supply it.
+- [x] **Pinned** by `3148-no-env-report-only`: a FULL gate over the schemas-less root with
+      `_SCHEMAS_PREFLIGHT_REPORT_ONLY=1` — plus three other plausible spellings, because the property is
+      that the ENVIRONMENT cannot reach the mode, not that one name was retired — must exit non-zero with
+      `missing-schemas: FAIL-CLOSED`, `RESULT: FAIL`, and never `RESULT: PASS`. REVERT-PROOF: restoring
+      the uninitialized env-readable flag makes it FAIL (rc=124 — the run sailed past the preflight into
+      the components until the case's own `timeout` fired, exactly the "run proceeds" symptom).
+- [x] **Class audit** of every variable this change introduced in `scripts/agent-gate.sh`:
+      `CANONICAL_SCHEMA_FILES` (unconditional assignment — an inherited value is overwritten; SAFE),
+      `SCHEMAS_LINE` (initialized `""`, display-only, carries no decision; SAFE), the hook temporaries
+      `_ps_st`/`_ps_rj` (assigned by command substitution before every read; SAFE), every function
+      temporary — `mode`, `report_only`, `root`, `missing`, `reject`, `kind`, `why`, `marker`, `n`,
+      `_mode`, `d`, `v`, `f`, `out` — declared `local` (unreachable from the environment; SAFE). Env
+      values read on purpose: `CQLITE_SCHEMAS_ROOT` (the documented override, now fail-closed on
+      relative/control-char), `AGENT_GATE_ALLOW_MISSING_FIXTURES` (pre-existing; pinned as NOT applying
+      to schemas by `3148-no-optout`), `ONLY`/`LITE` (gate-internal, initialized at `:1832`/`:1834`).
+      `_SCHEMAS_PREFLIGHT_REPORT_ONLY` no longer exists outside one explanatory comment.
+- [x] Self-test 36 → 37 cases.

--- a/openspec/changes/schemas-root-contract/tasks.md
+++ b/openspec/changes/schemas-root-contract/tasks.md
@@ -215,3 +215,38 @@
       descended, so every count came back 0. The reported symptom understated it — verification FAILED
       outright, so `--verify-only` called a good corpus unusable on exactly the symlinked layout #3148
       documents. Fixed and pinned with a symlinked-root case.
+
+## 10. Review round 3 (rust-reviewer: mergeable as-is; roborev job 10 VALID, 3 findings)
+- [x] **Prose residue** — the "by construction" overclaim survived at `scripts/agent-gate.sh` (the shell
+      mirror's OWN header — the worst possible place, since a future editor reading it would believe
+      shell/Rust equivalence is structural and edit one side without re-walking the input table) and
+      `design.md`. Both now state what is true: two hand-written mirrors, equivalent today, PINNED BY
+      `test_agent_gate_schemas_preflight.sh`, with an explicit "if you edit either side, re-walk the table
+      and re-run that self-test". Blank separator restored so the sentence no longer dangles above
+      `_gate_schemas_override_present`. The genuinely structural uses elsewhere were left alone.
+- [x] **job 10 finding 1** (Medium, real) — `mktemp -d` was unchecked under `set -uo pipefail` (no
+      errexit, deliberately), so a failure left `$tmp` EMPTY and every derived path became root-level
+      (`/ds-corpus`, `/schemas-empty`, …) which a privileged CI job would create, with the EXIT trap then
+      running `rm -rf ""`. Now validated (non-empty AND a directory) BEFORE the trap is armed. Pinned by a
+      case that stubs a failing `mktemp` on PATH and asserts a loud abort plus the absence of root-level
+      paths. That case re-invokes this script, so a bounded CHILD PROBE MODE was added — without it the
+      child ran every case including its own and recursed without bound (observed during the revert proof).
+- [x] **job 10 finding 2** (Low as filed; treated as the mis-certification class) — command substitution
+      STRIPS TRAILING NEWLINES, and the round-2 refactor consumed the override through `$( )`. Measured:
+      with `CQLITE_SCHEMAS_ROOT=$'<real dir>\n'` the gate reported `STATUS: OK` / `SOURCE: override` /
+      `ROOT: <real dir>` while Rust kept the newline, got `is_dir() == false`, and degraded to the
+      checkout — gate certifying the root the run did not use. Note this was a regression INTRODUCED by
+      the round-2 fix for finding 9-1 (pre-refactor the shell read the raw var and agreed with Rust).
+      Closed twice over: presence is now a STATUS-returning predicate with the value read directly from
+      the environment (no substitution anywhere on the value path), AND control-character values are
+      rejected fail-closed on both sides.
+- [x] **job 10 finding 3** (Low, real) — the "absolute but unusable" test hard-coded
+      `/nonexistent-cqlite-schemas-3148`: not absolute under Windows path semantics and not guaranteed
+      absent on Unix, so if someone created it the test would silently assert the OPPOSITE branch. Now
+      built under a fresh `TempDir` with native path handling, asserting both `is_absolute()` and
+      `!exists()` so absence is a property of the construction. Test-hygiene, not a behavior fix — no
+      revert proof applies.
+- [x] Revert proofs performed for findings 1 and 2 (both cases FAIL on a revert, pass restored). Controls
+      re-run because finding 2 changed resolution logic on both sides: hostile-layout 8/8 + 3/3 + 1/1 +
+      1/1, empty-override 4-pass/4-fail, relative-override 4 fail-closed, negative-control FULL gate rc=1
+      with the marker. Self-test 30 → 32 cases; contract tests 8 → 9.

--- a/openspec/changes/schemas-root-contract/tasks.md
+++ b/openspec/changes/schemas-root-contract/tasks.md
@@ -323,3 +323,41 @@
       to schemas by `3148-no-optout`), `ONLY`/`LITE` (gate-internal, initialized at `:1832`/`:1834`).
       `_SCHEMAS_PREFLIGHT_REPORT_ONLY` no longer exists outside one explanatory comment.
 - [x] Self-test 36 → 37 cases.
+
+## 13. Final roborev (job 11) — the THIRD instance of the certify-A-use-B class
+- [x] **BLOCKER: non-UTF-8 override degraded silently.** `env_dir` used `std::env::var` with a
+      catch-all `_ => None`, so `Err(NotUnicode)` collapsed to "unset" and `resolve_schemas_root`
+      returned `Ok(checkout)` — while Bash, which handles the value as BYTES, validated the same path
+      as a legitimate override. MEASURED before the fix: `STATUS: OK` + `SOURCE: CQLITE_SCHEMAS_ROOT
+      override` for a real `bad\xff\xfedir` directory, against Rust's `Err(NotUnicode)`. Same
+      certify-A-use-B split already pinned for control-character and relative values; pinning two of
+      three is an incomplete fail-closed posture in the mechanism the gate now trusts.
+      * **Rust**: `env_os` (`var_os`, no catch-all over an error variant) and
+        `resolve_schemas_root(Option<&OsStr>)` — the signature now makes the non-UTF-8 case
+        REPRESENTABLE, so it gets an explicit `Err` arm instead of inheriting a lossy conversion.
+      * **Bash**: `_gate_schemas_override_is_utf8` → a new `non-utf8` reject kind with its own prose
+        and marker. Pure ASCII is accepted with no external tool (valid UTF-8 by definition); anything
+        else is validated with `iconv -f UTF-8 -t UTF-8`, and an ABSENT `iconv` REJECTS rather than
+        assumes — "could not check" must not mean "accept", or the hole returns on a box without it.
+      * Both sides now agree across the whole table: unset → checkout; empty/whitespace → checkout;
+        **non-UTF-8 → REJECT**; control-char → REJECT; relative → REJECT; absolute-non-dir → checkout;
+        absolute-dir → override. A legitimate MULTIBYTE UTF-8 root is still accepted (asserted), so the
+        guard is not an over-broad ban on non-ASCII paths.
+- [x] **Datasets asymmetry: real, and hardened here rather than deferred.** The hazard is the same and
+      arguably worse — the gate counts `Data.db` under `$CQLITE_DATASETS_ROOT`, so a non-UTF-8 value
+      would have had the gate certify a corpus while every test read the checkout's `datasets`, which
+      holds only committed byte-parity references and NO `test_basic`: a #2078 vacuous pass with the
+      preflight vouching for a corpus the run never used. `datasets_root()` is infallible, so the
+      mechanism chosen is **honor the OS value** (`PathBuf::from(&OsStr)`) rather than an actionable
+      panic: it is three lines, adds no new failure mode, removes a silent fallback, and makes Rust
+      agree with what Bash already does. No follow-up issue needed.
+- [x] **NIT 2 (Medium): the printed remedy was CWD-relative.** `git restore …` fails when pasted from
+      cargo's package-dir CWD — the same CWD asymmetry this module rejects relative overrides for. Now
+      `git -C <workspace_root> …`, with the emitted remedy asserted to carry an ABSOLUTE `-C`.
+- [x] **NIT 3 (Low): the fetch remedy interpolated `PIN_FILE`/`DATASET_ROOT` unquoted.** Now `%q`,
+      asserted by the same `eval` round-trip used for the export line, on a path with a space and `&`.
+- [x] **Three revert-proofs, all three drift instances now covered** (was two of three): reverting the
+      Bash UTF-8 guard FAILs `3148-non-utf8-override` (rc=124 — the run sailed past the preflight);
+      reverting the Rust arm FAILs `non_utf8_override_is_rejected_fail_closed`; reverting nit 2 FAILs
+      `unreadable_fixture_message_names_path_root_source_and_remedy`; reverting nit 3 FAILs
+      `3131-remedy-quoting`. Self-test 37 → 40 cases; contract tests 12 → 14.

--- a/openspec/changes/schemas-root-contract/tasks.md
+++ b/openspec/changes/schemas-root-contract/tasks.md
@@ -1,0 +1,108 @@
+# Tasks: schemas-root-contract (issues #3148, #3131)
+
+> Design decided in `design.md`: the committed schema fixtures resolve **checkout-relative**
+> (`CARGO_MANIFEST_DIR`-anchored ancestor walk), never from `CQLITE_DATASETS_ROOT` — #3148's proposed
+> fix 4, taken as the owner's decision (AC (h)). One shared `#[path]`-included file hosted under
+> `test-data/support/` because it encodes the layout of `test-data` itself and is owned by neither crate.
+> The gate preflight becomes a belt-and-braces per-FILE readability assert with no opt-out.
+> AC → requirement map is at the top of `specs/test-fixture-roots/spec.md`.
+
+## 1. The single roots contract (surface: `test-data/support/fixture_roots.rs`)
+- [x] Create the shared std-only module with `datasets_root`, `datasets_root_if_present`,
+      `sstables_root`, `schemas_root`, `schemas_root_resolved`, `schema_path`, `check_schema_files`.
+- [x] Resolve the checkout by walking `CARGO_MANIFEST_DIR`'s **ancestors** for the first holding
+      `test-data/schemas` (not a hardcoded `../test-data`), so a crate nested deeper than one level
+      still resolves and no `..` component is ever handed to the kernel.
+- [x] Honor `CQLITE_SCHEMAS_ROOT` only when set, non-empty AND a readable directory; fall through to the
+      checkout otherwise (a stale export must degrade, not pin every load to an unusable path).
+- [x] Treat an exported-but-EMPTY env value as unset for both roots (a scripting accident, never an
+      intentional root).
+- [x] `schema_path` verifies readability and panics naming the resolved ABSOLUTE path, the root, the
+      resolution source, that these are committed source, and the remedy.
+- [x] Document the two-shape `datasets_root()` contract in the module docs with the stated reason for
+      each shape (#3148 AC (e)), including why the fallible shape has no checkout fallback.
+- [x] `#![allow(dead_code)]` at module scope — the file is `#[path]`-included into ~14 targets, each
+      using a subset.
+
+## 2. Migrate all four call sites (#3148 AC (d))
+- [x] `cqlite-core/benches/fixtures/mod.rs` — include the shared module as `pub mod roots`; reduce
+      `datasets_root`/`sstables_root`/`schemas_root` to thin delegations; switch `open_read_db_with_config`
+      to `roots::schema_path` so an unreachable fixture is diagnosed at the root, not inside ingest.
+- [x] `cqlite-core/tests/dead_cache_delete_tests.rs` — replace the local fallible `datasets_root()` with
+      `use fixture_roots::datasets_root_if_present as datasets_root;` and the `join("../schemas")` with
+      `schema_path`; drop the now-redundant `datasets_root()?` in `open_fixture_db` (its `data_db(..)?`
+      already short-circuits identically).
+- [x] `cqlite-core/tests/observability_correctness.rs` — delegate the third `datasets_root()` copy and
+      switch to `schema_path`.
+- [x] `cqlite-cli/benches/export_csv.rs` — include the shared module (symmetric `../../` path, no
+      cross-crate reach into cqlite-core's bench internals) and switch to `schema_path`; update the
+      module doc that declared the duplication deliberate so it now scopes that to fixture-OPEN logic only.
+- [x] Verify zero open-coded `join("../schemas")` expressions remain in Rust code.
+- [x] Compile all migrated targets under `RUSTFLAGS="-D warnings"`, including the `cli-helpers`-gated ones
+      and the `cqlite-cli` bench.
+
+## 3. Gate preflight (surface: `scripts/agent-gate.sh`) (#3148 ACs (a) (b) (g))
+- [x] Add `CANONICAL_SCHEMA_FILES` (the 6 `.cql` the dataset-backed components consume) and
+      `SCHEMAS_LINE`.
+- [x] Add `_gate_schemas_root` / `_gate_schemas_root_source` mirroring `schemas_root_resolved()` exactly.
+- [x] Add `_missing_schema_files` (per-FILE readability) and the PURE `_schemas_status` (`OK|FAIL`,
+      returning OK for `--lite`/`--only`).
+- [x] Add `apply_schemas_preflight`: stamp the positive `schemas:` line on OK; on FAIL emit
+      `missing-schemas: FAIL-CLOSED (#3148)` plus a remedy naming the exact absolute path and both fix
+      commands, then exit 1. No opt-out.
+- [x] Call it immediately after `apply_fixture_preflight` inside `if selected_needs_datasets`, so the
+      corpus cause is still reported first when both halves are missing.
+- [x] Stamp `SCHEMAS_LINE` into BOTH the terminal `SUMMARY_META` assembly and the component-boundary
+      block, guarded so a `--lite`/`--delta` boundary omits it rather than inventing it.
+- [x] Add the hidden `--preflight-schemas` hook (STATUS/ROOT/SOURCE/MISSING), with an optional 2nd arg
+      seeding `ONLY` so the `--only` leniency branch is assertable (the arg dispatch is one `case "$1"`).
+- [x] Update the `tooling-tests` doc block and the file-header component description.
+
+## 4. Positive-control self-test (surface: `scripts/tests/test_agent_gate_schemas_preflight.sh`) (#3148 AC (c))
+- [x] Hook cases: OK on the checkout; FAIL naming all 6 on a schemas-less root; FAIL naming ONLY the
+      absentees on a present-but-incomplete root.
+- [x] Real FULL-gate case with a COMPLETE synthetic corpus: non-zero exit, `missing-schemas: FAIL-CLOSED
+      (#3148)`, `RESULT: FAIL`, never `RESULT: PASS`, and no cargo run.
+- [x] Marker-separability case: the schemas failure must not stamp `missing-fixtures:`.
+- [x] Remedy case: the block names the absolute `.cql` path and both fix commands.
+- [x] Leniency cases: `--lite` clean LITE block with no marker; `--only core-tests` decision is OK.
+- [x] Symlink-independence case (#3148 AC (f)): identical resolved root across real / symlinked /
+      nonexistent datasets roots — asserted behaviorally, not claimed.
+- [x] Structural reintroduction guard: zero open-coded `join("../schemas")` expressions in Rust code,
+      exempting doc comments.
+- [x] Single-definition cases: the shared file exists with all three contract fns; all four sites include
+      it; no bench / migrated test reads `CQLITE_DATASETS_ROOT` directly.
+- [x] Scrub inherited `AGENT_GATE_SUMMARY_FILE` and `CQLITE_SCHEMAS_ROOT` so the test measures the
+      committed contract, not the caller's shell.
+- [x] Wire into the `tooling-tests` component.
+
+## 5. `fetch-datasets.sh` usability guarantee (#3131 items 1-2)
+- [x] Add `guarantee_usable_root`, called on BOTH the warm-skip and post-extraction paths: re-verify the
+      content independently of the pin fast path, fail loudly with a remedy naming the pin to clear, and
+      print the exact `export CQLITE_DATASETS_ROOT=<absolute path>` line the run guarantees.
+- [x] Print a NOTE when the populated root differs from the checkout default, naming the already-set env
+      var as the cause, so an operator cannot fall back to the documented default and get a corpus-less root.
+- [x] Print a NOTE that the CQL schema fixtures are committed source resolved checkout-relative and are
+      NOT a sibling of this root (#3148).
+- [x] Add non-mutating `--verify-only`, so the failure path is exercisable and operators/CI get a cheap
+      "is this root usable?" probe.
+- [x] Leave `rm -rf "${DATASET_ROOT}"` and `restore_ci_tracked_dataset_files`' CI-only short-circuit
+      untouched (#2878), with a code comment stating the boundary and a self-test case asserting it.
+- [x] Self-test cases: hollow root exits non-zero with a remedy; a content-complete root exits zero and
+      prints the verbatim export line; the #2878 boundary holds.
+
+## 6. Verification
+- [x] Hostile-layout run (the layout that made this fail): `CQLITE_DATASETS_ROOT` pointed at a scratch
+      root holding the corpus with **no** `../schemas` sibling, `CQLITE_SCHEMAS_ROOT` unset — the
+      previously-failing targets pass (`dead_cache_delete_tests` 8/8 incl. the 4 `stats_*`,
+      `memory_budget` 3/3, `issue_1494_converter_alloc_budget` 1/1,
+      `issue_2075_row_assembly_alloc_budget` 1/1), with `--features cli-helpers` (+ `dhat-heap,arrow` for
+      the budget lanes) so the `cli-helpers`-gated targets are actually compiled rather than silently empty.
+- [x] Non-vacuity control: with `CQLITE_SCHEMAS_ROOT` pointed at an empty directory, exactly the 4
+      schema-consuming `stats_*` tests FAIL with the new actionable message — proving the passes above are
+      real schema loads, not skips.
+- [x] Negative control: a real FULL gate with a complete corpus and an unreachable schemas root exits 1 at
+      the preflight stamping `missing-schemas: FAIL-CLOSED (#3148)`.
+- [x] `scripts/agent-gate.sh --lite` PASS with the summary-file redirect.
+- [ ] Doctrine pass (CLAUDE.md + the `agents-developing/test-data` page) — handled separately on this
+      branch; the required facts are listed at the end of `design.md`.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1401,6 +1401,23 @@ _gate_schemas_override_present() {
 
 # _gate_schemas_override_reject: echoes a non-empty REASON when an override is present but
 # must be REJECTED rather than resolved. Mirrors resolve_schemas_root()'s two Err cases.
+# _gate_schemas_override_reject_kind: `relative` | `control-chars` | (empty when accepted).
+# The KIND, separate from the reason text, so the FAIL emit can name the ACTUAL cause. Before
+# this the emit hard-coded "a RELATIVE schemas root ..." and stamped `... relative
+# CQLITE_SCHEMAS_ROOT rejected` for EVERY rejection — a FALSE message for a
+# control-character value, and untested because the round-3 coverage went through the pure
+# hook and never saw the real emit (spec-auditor, AC (b) partial).
+_gate_schemas_override_reject_kind() {
+  _gate_schemas_override_present || return 0
+  case "${CQLITE_SCHEMAS_ROOT:-}" in
+    *[[:cntrl:]]*) printf '%s' 'control-chars'; return 0 ;;
+  esac
+  case "${CQLITE_SCHEMAS_ROOT:-}" in
+    /*) return 0 ;;
+    *) printf '%s' 'relative' ;;
+  esac
+}
+
 _gate_schemas_override_reject() {
   _gate_schemas_override_present || return 0
   # Control characters (newline, CR, embedded tab, ...). A path carrying one is never a
@@ -1516,16 +1533,37 @@ apply_schemas_preflight() {
   # (the checkout's fixtures may be perfectly complete), and the actionable fact is that
   # the requested root cannot be honored identically by the gate and the test binaries.
   if [ -n "$reject" ]; then
+    local kind why marker
+    kind="$(_gate_schemas_override_reject_kind)"
+    case "$kind" in
+      control-chars)
+        why="a schemas root carrying a CONTROL CHARACTER (newline/CR/tab) cannot round-trip through the gate's shell resolution — command substitution strips trailing newlines — so the gate would validate one path while cargo resolved another."
+        marker="missing-schemas: FAIL-CLOSED (#3148) — CQLITE_SCHEMAS_ROOT contains a control character; the gate and the test binaries would resolve DIFFERENT roots; overall verdict FAIL" ;;
+      *)
+        why="a RELATIVE schemas root cannot mean the same thing on both sides: the gate resolves it against $REPO_ROOT, cargo resolves it against each test binary's PACKAGE dir."
+        marker="missing-schemas: FAIL-CLOSED (#3148) — relative CQLITE_SCHEMAS_ROOT rejected; the gate and the test binaries would resolve DIFFERENT roots; overall verdict FAIL" ;;
+    esac
     echo "agent-gate: FAIL: $reject (#3148)" >&2
-    echo "agent-gate: a RELATIVE schemas root cannot mean the same thing on both sides: the gate resolves it against $REPO_ROOT, cargo resolves it against each test binary's PACKAGE dir." >&2
+    echo "agent-gate: $why" >&2
     echo "agent-gate: continuing would stamp a SUMMARY certifying one schemas root while the tests read another — the exact mis-certification #3148 was filed for." >&2
-    echo "agent-gate: remedy: export an ABSOLUTE CQLITE_SCHEMAS_ROOT, or unset it to use $root" >&2
+    echo "agent-gate: remedy: export a clean ABSOLUTE CQLITE_SCHEMAS_ROOT, or unset it to use $root" >&2
+    # REPORT-ONLY mode (see the --preflight-schemas-line hook): return instead of emitting.
+    # The hook cannot emit a SUMMARY — emit_summary/_tree_meta_array are defined AFTER the
+    # arg dispatch — and STUBBING them there defined a SECOND `_tree_meta_array`, which broke
+    # test_agent_gate_tree_portability.sh's derived-inventory uniqueness assert (n=45
+    # uniq=44) and FAILed `tooling-tests` in the gate of record while passing standalone.
+    # A mode flag on the terminal ACTION carries no decision and stamps no text, so it
+    # cannot make a lenient path assert something it did not check.
+    if [ -n "${_SCHEMAS_PREFLIGHT_REPORT_ONLY:-}" ]; then
+      SCHEMAS_LINE="$marker"
+      return 1
+    fi
     _tree_meta_array   # #2926
     emit_summary FAIL \
       "preflight: FAIL ($reject)" \
-      "missing-schemas: FAIL-CLOSED (#3148) — relative CQLITE_SCHEMAS_ROOT rejected; the gate and the test binaries would resolve DIFFERENT roots; overall verdict FAIL" \
+      "$marker" \
       "${TREE_META_LINES[@]}" \
-      "hint: export an ABSOLUTE CQLITE_SCHEMAS_ROOT, or unset it to use $root"
+      "hint: export a clean ABSOLUTE CQLITE_SCHEMAS_ROOT, or unset it to use $root"
     exit 1
   fi
   case "$(_schemas_status)" in
@@ -1543,6 +1581,10 @@ apply_schemas_preflight() {
       echo "agent-gate: these are COMMITTED SOURCE (test-data/schemas, 23 files incl. legacy/ + udts/) — NOT part of the fetched corpus and NOT derived from CQLITE_DATASETS_ROOT." >&2
       echo "agent-gate: dataset-backed components (core-tests, memory-budget, cli-tests) would build for ~8 min and then panic on the missing .cql." >&2
       echo "agent-gate: remedy: unset CQLITE_SCHEMAS_ROOT (it overrides the checkout default), or restore the committed fixtures: git -C $REPO_ROOT restore --source=HEAD -- test-data/schemas" >&2
+      if [ -n "${_SCHEMAS_PREFLIGHT_REPORT_ONLY:-}" ]; then
+        SCHEMAS_LINE="missing-schemas: FAIL-CLOSED (#3148) — unreadable: $missing"
+        return 1
+      fi
       _tree_meta_array   # #2926: every emitted block carries the tree provenance
       emit_summary FAIL \
         "preflight: FAIL (committed CQL schema fixtures unreadable under $root — missing: $missing)" \
@@ -1891,18 +1933,18 @@ case "${1:-}" in
   #
   # It can NOT observe the FAIL SUMMARY, and saying otherwise would send a reader looking for
   # a block that cannot exist: `emit_summary` and `_tree_meta_array` are defined AFTER this
-  # dispatch point, so the strict-FAILURE branch would otherwise die on two
-  # `command not found` lines. They are stubbed below so that path exits non-zero with ONE
-  # named token instead — which is all the self-test needs from it (it asserts the LENIENT
-  # and the strict-HEALTHY paths; the strict-FAILURE emit is covered by the real full-gate
-  # cases). The stubs are safe: this arm always `exit`s before the real definitions are read.
+  # dispatch point. So the hook sets `_SCHEMAS_PREFLIGHT_REPORT_ONLY=1`, and the two failure
+  # branches then RETURN with the marker in SCHEMAS_LINE instead of emitting + exiting.
+  #
+  # The first attempt STUBBED those two functions here instead. That defined a SECOND
+  # `_tree_meta_array` in this file, which broke test_agent_gate_tree_portability.sh's
+  # derived-inventory uniqueness assert (n=45 uniq=44) and FAILed `tooling-tests` in the gate
+  # of record — while every self-test passed standalone, because that portability test only
+  # runs inside `tooling-tests`. Hence: never add a second definition of a `_tree*` function.
   --preflight-schemas-line)
     [ -n "${2:-}" ] && ONLY="$2"
-    # shellcheck disable=SC2317  # invoked indirectly, from apply_schemas_preflight
-    emit_summary() { echo "HOOK: strict-path FAIL (SUMMARY not emittable at dispatch time)"; }
-    # shellcheck disable=SC2317  # invoked indirectly, from apply_schemas_preflight
-    _tree_meta_array() { TREE_META_LINES=(); }
-    apply_schemas_preflight
+    _SCHEMAS_PREFLIGHT_REPORT_ONLY=1
+    apply_schemas_preflight || true
     echo "SCHEMAS_LINE: ${SCHEMAS_LINE:-<none>}"
     exit 0 ;;
   # Hidden self-test hooks (issue #2081): expose the node-build readiness decision and

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1315,34 +1315,86 @@ CANONICAL_SCHEMA_FILES="basic-types.cql da-test.cql time-series.cql wide-table-b
 # that the schemas root was validated, not merely that nothing complained.
 SCHEMAS_LINE=""
 
-# _gate_schemas_root / _gate_schemas_root_source: mirror schemas_root_resolved() in
-# test-data/support/fixture_roots.rs EXACTLY — env override only when set, non-empty
-# AND a readable directory (a stale/broken export degrades to the checkout rather than
-# pinning the run to a path that cannot work), else checkout-relative. Both sides
-# anchor on the checkout, so the gate asserts the same path the tests will resolve.
+# _gate_checkout_test_data_dir: the enclosing checkout's `test-data`, anchored on the
+# WORKSPACE-ROOT `Cargo.toml` (nearest ancestor manifest declaring `[workspace]`) exactly
+# as workspace_root() does in test-data/support/fixture_roots.rs. Anchoring on a checkout
+# MARKER rather than on the fixtures matters: keying on `test-data/schemas` would let a
+# sparse checkout — or a worktree nested inside another checkout — resolve to the OUTER
+# checkout's fixtures, wrong-but-existing and unreported. Falls back to REPO_ROOT when no
+# `[workspace]` manifest is found (not reachable in this repository).
+_gate_checkout_test_data_dir() {
+  local d="$REPO_ROOT"
+  while [ -n "$d" ] && [ "$d" != "/" ]; do
+    if [ -f "$d/Cargo.toml" ] && grep -q '^[[:space:]]*\[workspace\]' "$d/Cargo.toml" 2>/dev/null; then
+      printf '%s' "$d/test-data"; return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  printf '%s' "$REPO_ROOT/test-data"
+}
+
+# _gate_schemas_override_reject: echoes a non-empty REASON when CQLITE_SCHEMAS_ROOT is set
+# but must be REJECTED rather than resolved. Today there is exactly one such case, and it
+# is the one that nearly reintroduced #3148's own defect: a RELATIVE override.
+#
+# The gate evaluates a relative path with CWD = REPO_ROOT; cargo runs each test binary
+# with CWD = the PACKAGE directory. So `CQLITE_SCHEMAS_ROOT=packaged/schemas` exported
+# from the checkout root passes the gate's `-d` test and gets stamped
+# `schemas: 6/6 … under packaged/schemas (override)`, while every test binary sees
+# `is_dir() == false`, falls back to the checkout, and reads DIFFERENT files. The SUMMARY
+# would then certify root A for a run that used root B — a positively misleading block,
+# which is the entire defect class #3148 was filed for. It also made the `expected
+# absolute path:` remedy line print a relative path, breaking AC (b).
+#
+# Both sides therefore reject it, so they agree BY CONSTRUCTION rather than by review.
+_gate_schemas_override_reject() {
+  local v="${CQLITE_SCHEMAS_ROOT:-}"
+  # Blank (or unset) is not an override at all — an exported-but-empty var is a scripting
+  # accident, and both sides treat it as unset. Whitespace-stripped, matching the Rust
+  # side's `v.trim().is_empty()`.
+  [ -n "$(printf '%s' "$v" | tr -d '[:space:]')" ] || return 0
+  case "$v" in
+    /*) return 0 ;;
+    *) printf '%s' "CQLITE_SCHEMAS_ROOT must be an ABSOLUTE path, got '$v'" ;;
+  esac
+}
+
+# _gate_schemas_root / _gate_schemas_root_source: mirror resolve_schemas_root() in
+# test-data/support/fixture_roots.rs rule for rule — the override applies only when set,
+# non-blank, ABSOLUTE and a readable directory (an absolute-but-unusable export degrades
+# to the checkout rather than pinning the run to a path that cannot work; a RELATIVE one
+# is rejected outright, see above), else checkout-relative. Both sides anchor on the same
+# workspace marker, so the gate asserts the path the tests will actually resolve.
 _gate_schemas_root() {
-  if [ -n "${CQLITE_SCHEMAS_ROOT:-}" ] && [ -d "${CQLITE_SCHEMAS_ROOT}" ]; then
+  if [ -z "$(_gate_schemas_override_reject)" ] \
+     && [ -n "${CQLITE_SCHEMAS_ROOT:-}" ] && [ -d "${CQLITE_SCHEMAS_ROOT}" ]; then
     printf '%s' "$CQLITE_SCHEMAS_ROOT"
   else
-    printf '%s' "$REPO_ROOT/test-data/schemas"
+    printf '%s' "$(_gate_checkout_test_data_dir)/schemas"
   fi
 }
 _gate_schemas_root_source() {
-  if [ -n "${CQLITE_SCHEMAS_ROOT:-}" ] && [ -d "${CQLITE_SCHEMAS_ROOT}" ]; then
+  if [ -n "$(_gate_schemas_override_reject)" ]; then
+    printf '%s' "CQLITE_SCHEMAS_ROOT override REJECTED"
+  elif [ -n "${CQLITE_SCHEMAS_ROOT:-}" ] && [ -d "${CQLITE_SCHEMAS_ROOT}" ]; then
     printf '%s' "CQLITE_SCHEMAS_ROOT override"
   else
     printf '%s' "checkout-relative"
   fi
 }
 
-# _missing_schema_files: the space-separated subset of CANONICAL_SCHEMA_FILES that is
-# not readable under the resolved root. Empty means all present.
+# _missing_schema_files: the space-separated subset of CANONICAL_SCHEMA_FILES that is not
+# a READABLE REGULAR FILE under the resolved root. Empty means all present.
+#
+# `-f` as well as `-r`: bare `-r` accepts a DIRECTORY named `basic-types.cql`, while the
+# Rust side asks for a readable regular file. Same question on both sides or the gate can
+# certify a layout the tests reject (roborev job 8, finding 2; reviewer nit N7).
 _missing_schema_files() {
   local root f out=""
   root="$(_gate_schemas_root)"
   # shellcheck disable=SC2086  # intentional word-split over the space-separated list
   for f in $CANONICAL_SCHEMA_FILES; do
-    [ -r "$root/$f" ] || out="${out:+$out }$f"
+    { [ -f "$root/$f" ] && [ -r "$root/$f" ]; } || out="${out:+$out }$f"
   done
   printf '%s' "$out"
 }
@@ -1355,6 +1407,10 @@ _schemas_status() {
   # Only the FULL gate is strict: --only stays lenient, --lite already returned.
   [ -z "$ONLY" ] || { echo OK; return 0; }
   [ "$LITE" -eq 0 ] || { echo OK; return 0; }
+  # A rejected override FAILs even if the checkout's fixtures happen to be complete: the
+  # operator asked for a root the contract cannot honor, and quietly using a different
+  # one is the mis-certification this guard exists to prevent.
+  [ -z "$(_gate_schemas_override_reject)" ] || { echo FAIL; return 0; }
   [ -z "$(_missing_schema_files)" ] && { echo OK; return 0; }
   echo FAIL
 }
@@ -1365,8 +1421,25 @@ _schemas_status() {
 # #2078's `missing-fixtures:` so the two causes are separable in a pasted block — with
 # a remedy naming the exact expected absolute path, then exit 1.
 apply_schemas_preflight() {
-  local root missing
+  local root missing reject
   root="$(_gate_schemas_root)"
+  reject="$(_gate_schemas_override_reject)"
+  # A REJECTED override gets its own message and hint: "missing files" would be a lie
+  # (the checkout's fixtures may be perfectly complete), and the actionable fact is that
+  # the requested root cannot be honored identically by the gate and the test binaries.
+  if [ -n "$reject" ]; then
+    echo "agent-gate: FAIL: $reject (#3148)" >&2
+    echo "agent-gate: a RELATIVE schemas root cannot mean the same thing on both sides: the gate resolves it against $REPO_ROOT, cargo resolves it against each test binary's PACKAGE dir." >&2
+    echo "agent-gate: continuing would stamp a SUMMARY certifying one schemas root while the tests read another — the exact mis-certification #3148 was filed for." >&2
+    echo "agent-gate: remedy: export an ABSOLUTE CQLITE_SCHEMAS_ROOT, or unset it to use $root" >&2
+    _tree_meta_array   # #2926
+    emit_summary FAIL \
+      "preflight: FAIL ($reject)" \
+      "missing-schemas: FAIL-CLOSED (#3148) — relative CQLITE_SCHEMAS_ROOT rejected; the gate and the test binaries would resolve DIFFERENT roots; overall verdict FAIL" \
+      "${TREE_META_LINES[@]}" \
+      "hint: export an ABSOLUTE CQLITE_SCHEMAS_ROOT, or unset it to use $root"
+    exit 1
+  fi
   case "$(_schemas_status)" in
     OK)
       local n
@@ -1716,7 +1789,9 @@ case "${1:-}" in
     _ps_st=$(_schemas_status); echo "STATUS: $_ps_st"
     echo "ROOT: $(_gate_schemas_root)"
     echo "SOURCE: $(_gate_schemas_root_source)"
-    [ "$_ps_st" = FAIL ] && echo "MISSING: $(_missing_schema_files)"
+    _ps_rj=$(_gate_schemas_override_reject)
+    [ -n "$_ps_rj" ] && echo "REJECT: $_ps_rj"
+    [ "$_ps_st" = FAIL ] && [ -z "$_ps_rj" ] && echo "MISSING: $(_missing_schema_files)"
     exit 0 ;;
   # Hidden self-test hooks (issue #2081): expose the node-build readiness decision and
   # the shell-selftest executor so scripts/tests assert the SAME logic run_delta uses.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1420,9 +1420,35 @@ _schemas_status() {
 # SUMMARY carrying `missing-schemas: FAIL-CLOSED (#3148)` — textually DISTINCT from
 # #2078's `missing-fixtures:` so the two causes are separable in a pasted block — with
 # a remedy naming the exact expected absolute path, then exit 1.
+#
+# The leniency early-return below is load-bearing TWICE over, and both cases are the
+# defect this whole change exists to remove, one mode over:
+#
+#   1. `_schemas_status` returns OK unconditionally under `--only`/`--lite` (leniency, AC
+#      (g)), so the OK branch used to stamp `schemas: 6/6 canonical .cql readable under
+#      <root>` for a check that NEVER RAN. A positive assertion about an unperformed check
+#      is exactly #3148's misleading `STATUS: OK`. It is stamped as an explicit NAMED
+#      non-check rather than simply omitted: silence lets a reader of a pasted block
+#      assume the FULL contract held, whereas `schemas: not checked (…)` cannot be
+#      misread.
+#   2. The REJECT branch below was NOT governed by `_schemas_status`, so a relative
+#      override FAILed even an `--only` run — the effectful guard diverging from the pure
+#      decision it is documented to consume, i.e. the "single-source, no drift" property
+#      claimed for this pair. Gating both on ONE mode check restores it.
 apply_schemas_preflight() {
   local root missing reject
   root="$(_gate_schemas_root)"
+
+  # Leniency (AC (g), unchanged from #2078's contract): only the FULL gate is strict.
+  # --lite never reaches here (run_lite always exits first), but it is checked anyway so
+  # the invariant holds by construction rather than by call-site archaeology.
+  if [ -n "$ONLY" ] || [ "$LITE" -ne 0 ]; then
+    local _mode
+    if [ -n "$ONLY" ]; then _mode="--only $ONLY"; else _mode="--lite"; fi
+    SCHEMAS_LINE="schemas: not checked ($_mode is lenient, #3148 AC (g)) — this block asserts NOTHING about the schemas root"
+    return 0
+  fi
+
   reject="$(_gate_schemas_override_reject)"
   # A REJECTED override gets its own message and hint: "missing files" would be a lie
   # (the checkout's fixtures may be perfectly complete), and the actionable fact is that
@@ -1792,6 +1818,19 @@ case "${1:-}" in
     _ps_rj=$(_gate_schemas_override_reject)
     [ -n "$_ps_rj" ] && echo "REJECT: $_ps_rj"
     [ "$_ps_st" = FAIL ] && [ -z "$_ps_rj" ] && echo "MISSING: $(_missing_schema_files)"
+    exit 0 ;;
+  # Hidden self-test hook (issue #3148): run the REAL apply_schemas_preflight and print the
+  # SCHEMAS_LINE it stamped, so the self-test observes the ACTUAL summary text rather than a
+  # re-implementation of the decision. Optional $2 seeds ONLY (the arg dispatch is a single
+  # `case "$1"`, so `--only X --preflight-schemas-line` is not expressible, and a real
+  # `--only core-tests` run would spend minutes in cargo before printing anything).
+  # Deliberately drives the effectful function: the whole point is that a POSITIVE line must
+  # never be stamped for a check that did not run. On the strict path this may emit a FAIL
+  # SUMMARY and exit non-zero, which the self-test treats as a regression of leniency.
+  --preflight-schemas-line)
+    [ -n "${2:-}" ] && ONLY="$2"
+    apply_schemas_preflight
+    echo "SCHEMAS_LINE: ${SCHEMAS_LINE:-<none>}"
     exit 0 ;;
   # Hidden self-test hooks (issue #2081): expose the node-build readiness decision and
   # the shell-selftest executor so scripts/tests assert the SAME logic run_delta uses.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1708,7 +1708,11 @@ case "${1:-}" in
   # unreadable files — so the positive-control self-test asserts the preflight actually
   # FAILS on a schemas-less root, not merely that it passes on a good one. Pure — the
   # FAIL emit + exit lives in apply_schemas_preflight (exercised by the real gate run).
+  # Optional $2 seeds ONLY, so the self-test can assert the --only LENIENCY branch of
+  # the SAME pure decision without launching a real --only run (the arg dispatch is a
+  # single `case "$1"`, so `--only X --preflight-schemas` is not expressible).
   --preflight-schemas)
+    [ -n "${2:-}" ] && ONLY="$2"
     _ps_st=$(_schemas_status); echo "STATUS: $_ps_st"
     echo "ROOT: $(_gate_schemas_root)"
     echo "SOURCE: $(_gate_schemas_root_source)"
@@ -4714,7 +4718,12 @@ run_kit_dashboard_drift() {
 # row/extended/cell flag tables must match the real row_decoder constants, so an
 # agent can never again be taught a partition-boundary decode bug by a rotted skill
 # table (hermetic temp-sandbox copy; no cargo/datasets/network). Pure/offline, no
-# gh/network. SKIP-aware: the summary test's truncation case relies on a python3
+# gh/network. Also runs scripts/tests/test_agent_gate_schemas_preflight.sh (#3148),
+# the POSITIVE CONTROL for the committed-schemas preflight: it proves the preflight
+# REJECTS a schemas-less / present-but-incomplete root (the #3148 gap survived because
+# `STATUS: OK` was only ever observed on the happy path) and pins the checkout-relative
+# resolution contract. Hermetic temp roots; the FULL-gate cases exit AT the preflight,
+# so no cargo/datasets/network. SKIP-aware: the summary test's truncation case relies on a python3
 # reader, so with no python3 we record SKIP (loud, never silent PASS); any test
 # failure -> hard FAIL.
 run_tooling_tests() {
@@ -4812,6 +4821,27 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_roborev_review_guard.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (roborev vacuous-review guard); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # committed-schemas preflight guard (#3148 AC (c)): hermetic (temp dataset/schemas
+  # roots, no real corpus/network/cargo — the FULL-gate cases exit AT the preflight).
+  # POSITIVE CONTROL: it proves the preflight REJECTS a schemas-less and a
+  # present-but-incomplete root, not merely that it accepts a good one. The #3148 gap
+  # survived precisely because `STATUS: OK` was only ever observed on the happy path,
+  # so a preflight tested one-sided is untested. Also pins the checkout-relative
+  # contract (the schemas root must not vary with CQLITE_DATASETS_ROOT — the retired
+  # `..`-climb symlink trap) and the single-definition invariant. A failure FAILs the
+  # component, mirroring the keyspace-scoping guard.
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_schemas_preflight.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_agent_gate_schemas_preflight.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (committed-schemas preflight guard); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1515,7 +1515,23 @@ _schemas_status() {
 #      decision it is documented to consume, i.e. the "single-source, no drift" property
 #      claimed for this pair. Gating both on ONE mode check restores it.
 apply_schemas_preflight() {
-  local root missing reject
+  # REPORT-ONLY is a POSITIONAL ARGUMENT, deliberately not a variable (spec-auditor,
+  # requirement 8). The first cut used `${_SCHEMAS_PREFLIGHT_REPORT_ONLY:-}`, which was never
+  # initialized — so an INHERITED or EXPORTED value turned the FULL gate's fail-closed
+  # `exit 1` into `return 1` at the bare call site, the run continued, and the
+  # `missing-schemas: FAIL-CLOSED` text could be stamped inside a block reading
+  # `RESULT: PASS`. That is precisely the "no environment opt-out may permit a run to certify
+  # with the schemas root unreachable" requirement, defeated by the mechanism added to satisfy
+  # a comment fix two rounds earlier.
+  #
+  # Initializing the variable would only close the INHERITED path: an `export`ed value set
+  # after initialization still wins, because the read happens later. A positional parameter is
+  # airtight instead — `$1` inside a function comes from the CALL, and no environment variable,
+  # `export`, or `env -i` can supply it. The strict call site (the real gate) passes NOTHING,
+  # so strictness is the default that requires no state to be correct.
+  local mode="${1:-}" root missing reject
+  local report_only=0
+  [ "$mode" = report-only ] && report_only=1
   root="$(_gate_schemas_root)"
 
   # Leniency (AC (g), unchanged from #2078's contract): only the FULL gate is strict.
@@ -1554,7 +1570,7 @@ apply_schemas_preflight() {
     # uniq=44) and FAILed `tooling-tests` in the gate of record while passing standalone.
     # A mode flag on the terminal ACTION carries no decision and stamps no text, so it
     # cannot make a lenient path assert something it did not check.
-    if [ -n "${_SCHEMAS_PREFLIGHT_REPORT_ONLY:-}" ]; then
+    if [ "$report_only" -eq 1 ]; then
       SCHEMAS_LINE="$marker"
       return 1
     fi
@@ -1581,7 +1597,7 @@ apply_schemas_preflight() {
       echo "agent-gate: these are COMMITTED SOURCE (test-data/schemas, 23 files incl. legacy/ + udts/) — NOT part of the fetched corpus and NOT derived from CQLITE_DATASETS_ROOT." >&2
       echo "agent-gate: dataset-backed components (core-tests, memory-budget, cli-tests) would build for ~8 min and then panic on the missing .cql." >&2
       echo "agent-gate: remedy: unset CQLITE_SCHEMAS_ROOT (it overrides the checkout default), or restore the committed fixtures: git -C $REPO_ROOT restore --source=HEAD -- test-data/schemas" >&2
-      if [ -n "${_SCHEMAS_PREFLIGHT_REPORT_ONLY:-}" ]; then
+      if [ "$report_only" -eq 1 ]; then
         SCHEMAS_LINE="missing-schemas: FAIL-CLOSED (#3148) — unreadable: $missing"
         return 1
       fi
@@ -1933,8 +1949,10 @@ case "${1:-}" in
   #
   # It can NOT observe the FAIL SUMMARY, and saying otherwise would send a reader looking for
   # a block that cannot exist: `emit_summary` and `_tree_meta_array` are defined AFTER this
-  # dispatch point. So the hook sets `_SCHEMAS_PREFLIGHT_REPORT_ONLY=1`, and the two failure
-  # branches then RETURN with the marker in SCHEMAS_LINE instead of emitting + exiting.
+  # dispatch point. So the hook passes `report-only` as apply_schemas_preflight's FIRST
+  # ARGUMENT, and the two failure branches then RETURN with the marker in SCHEMAS_LINE instead
+  # of emitting + exiting. An argument, not a variable: an uninitialized env-readable flag was
+  # itself a way to defeat the fail-closed guard (see that function's header).
   #
   # The first attempt STUBBED those two functions here instead. That defined a SECOND
   # `_tree_meta_array` in this file, which broke test_agent_gate_tree_portability.sh's
@@ -1943,8 +1961,7 @@ case "${1:-}" in
   # runs inside `tooling-tests`. Hence: never add a second definition of a `_tree*` function.
   --preflight-schemas-line)
     [ -n "${2:-}" ] && ONLY="$2"
-    _SCHEMAS_PREFLIGHT_REPORT_ONLY=1
-    apply_schemas_preflight || true
+    apply_schemas_preflight report-only || true
     echo "SCHEMAS_LINE: ${SCHEMAS_LINE:-<none>}"
     exit 0 ;;
   # Hidden self-test hooks (issue #2081): expose the node-build readiness decision and

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1354,37 +1354,67 @@ _gate_checkout_test_data_dir() {
 # which is the entire defect class #3148 was filed for. It also made the `expected
 # absolute path:` remedy line print a relative path, breaking AC (b).
 #
-# Both sides therefore reject it, so they agree BY CONSTRUCTION rather than by review.
-# _gate_schemas_override: THE single normalization of "is there an override?", echoing the
-# raw value when there is one and nothing when there is not. Every other helper consults
-# this rather than testing `$CQLITE_SCHEMAS_ROOT` itself.
+# Both sides therefore reject it, removing the one input class on which they could not
+# possibly have agreed.
 #
-# Single-sourcing it is not tidiness (roborev job 9, finding 1): `_gate_schemas_override_reject`
-# treated a WHITESPACE-ONLY value as unset (matching Rust's `v.trim().is_empty()`) while
-# `_gate_schemas_root`/`_gate_schemas_root_source` tested the raw `-n` value. So with a
-# directory literally named "  " present, the gate would have validated and reported it as
-# the override while Rust treated the var as unset and read the checkout's schemas —
-# recreating the very root-certification mismatch this change exists to prevent, in the one
-# input class the two mirrors disagreed on. Exotic, but the whole point of the pair is that
-# they answer identically on EVERY input, so it is fixed rather than argued about.
+# HOW STRONG THAT IS, precisely: this shell resolution and
+# test-data/support/fixture_roots.rs are two HAND-WRITTEN mirrors, EQUIVALENT TODAY and
+# PINNED BY scripts/tests/test_agent_gate_schemas_preflight.sh — not equivalent by
+# construction. They have been walked case by case over the whole input table (unset /
+# "" / whitespace-only / control-character-bearing / "  /abs  " / absolute-non-dir /
+# absolute-dir / relative) and agree on every one. If you edit EITHER side, re-walk that
+# table and re-run that self-test: an unearned "by construction" here is precisely what
+# would stop you doing so, and a silent divergence between these two is the
+# root-certification mismatch this whole change exists to prevent.
+
+# _gate_schemas_override_present: THE single normalization of "is there an override?".
+# Returns a STATUS (0 = present), never text, and every consumer then reads
+# `$CQLITE_SCHEMAS_ROOT` DIRECTLY. Two reasons for that shape, both learned the hard way:
 #
-# Note the deliberate asymmetry: presence is decided on the TRIMMED value, but the value
-# used is the RAW one (never trimmed) — exactly as Rust does, where `trim()` gates presence
-# and `PathBuf::from(raw)` builds the path. Hence `"  /abs  "` is *present* and then
-# REJECTED as non-absolute on both sides, rather than silently trimmed into `/abs`.
-_gate_schemas_override() {
-  local v="${CQLITE_SCHEMAS_ROOT:-}"
-  [ -n "$(printf '%s' "$v" | tr -d '[:space:]')" ] || return 0
-  printf '%s' "$v"
+#   1. Single-sourcing presence (roborev job 9, finding 1): `_gate_schemas_override_reject`
+#      treated a WHITESPACE-ONLY value as unset (matching Rust's `v.trim().is_empty()`)
+#      while `_gate_schemas_root`/`_gate_schemas_root_source` tested the raw `-n` value. The
+#      whole point of the shell/Rust pair is that they answer identically on EVERY input, so
+#      one predicate decides presence for all of them.
+#   2. NO COMMAND SUBSTITUTION anywhere on the value path (roborev job 10, finding 2). The
+#      previous text-returning helper was consumed as `v="$(_gate_schemas_override)"`, and
+#      `$( )` STRIPS TRAILING NEWLINES. Measured: with `CQLITE_SCHEMAS_ROOT=$'/abs/dir\n'`
+#      the gate reported `STATUS: OK` + `SOURCE: CQLITE_SCHEMAS_ROOT override` + `ROOT:
+#      /abs/dir` (newline gone, `-d` true) while Rust kept the newline, got `is_dir() ==
+#      false`, and degraded to the checkout — the gate certifying root A for a run that used
+#      root B, i.e. the exact mis-certification this change exists to prevent, introduced by
+#      the round-2 refactor that fixed (1). Returning a status and reading the variable
+#      directly removes the substitution, and control-character values are additionally
+#      REJECTED below on both sides so no such value can reach a comparison at all.
+#
+# Presence is decided on the TRIMMED value while the value USED is the RAW one — exactly as
+# Rust does (`trim()` gates presence, `PathBuf::from(raw)` builds the path). Hence
+# `"  /abs  "` is *present* and then REJECTED as non-absolute on both sides, never silently
+# trimmed into `/abs`. The test is a pure-bash pattern, not `tr`, so it too is
+# substitution-free.
+_gate_schemas_override_present() {
+  case "${CQLITE_SCHEMAS_ROOT:-}" in
+    *[![:space:]]*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
+# _gate_schemas_override_reject: echoes a non-empty REASON when an override is present but
+# must be REJECTED rather than resolved. Mirrors resolve_schemas_root()'s two Err cases.
 _gate_schemas_override_reject() {
-  local v
-  v="$(_gate_schemas_override)" || return 0
-  [ -n "$v" ] || return 0
-  case "$v" in
+  _gate_schemas_override_present || return 0
+  # Control characters (newline, CR, embedded tab, ...). A path carrying one is never a
+  # legitimate schemas root, and admitting it is what let `$( )`-stripping diverge the two
+  # mirrors (finding 2 above). Rejecting outright keeps them aligned without relying on
+  # every future consumer avoiding command substitution.
+  case "${CQLITE_SCHEMAS_ROOT:-}" in
+    *[[:cntrl:]]*)
+      printf '%s' "CQLITE_SCHEMAS_ROOT must not contain control characters (newline/CR/tab), got $(printf '%q' "${CQLITE_SCHEMAS_ROOT:-}")"
+      return 0 ;;
+  esac
+  case "${CQLITE_SCHEMAS_ROOT:-}" in
     /*) return 0 ;;
-    *) printf '%s' "CQLITE_SCHEMAS_ROOT must be an ABSOLUTE path, got '$v'" ;;
+    *) printf '%s' "CQLITE_SCHEMAS_ROOT must be an ABSOLUTE path, got '${CQLITE_SCHEMAS_ROOT:-}'" ;;
   esac
 }
 
@@ -1395,20 +1425,20 @@ _gate_schemas_override_reject() {
 # is rejected outright, see above), else checkout-relative. Both sides anchor on the same
 # workspace marker, so the gate asserts the path the tests will actually resolve.
 _gate_schemas_root() {
-  local v
-  v="$(_gate_schemas_override)"
-  if [ -z "$(_gate_schemas_override_reject)" ] && [ -n "$v" ] && [ -d "$v" ]; then
-    printf '%s' "$v"
+  # Reads $CQLITE_SCHEMAS_ROOT DIRECTLY — never through `$( )`, which strips trailing
+  # newlines (roborev job 10, finding 2).
+  if _gate_schemas_override_present \
+     && [ -z "$(_gate_schemas_override_reject)" ] \
+     && [ -d "${CQLITE_SCHEMAS_ROOT:-}" ]; then
+    printf '%s' "${CQLITE_SCHEMAS_ROOT:-}"
   else
     printf '%s' "$(_gate_checkout_test_data_dir)/schemas"
   fi
 }
 _gate_schemas_root_source() {
-  local v
-  v="$(_gate_schemas_override)"
   if [ -n "$(_gate_schemas_override_reject)" ]; then
     printf '%s' "CQLITE_SCHEMAS_ROOT override REJECTED"
-  elif [ -n "$v" ] && [ -d "$v" ]; then
+  elif _gate_schemas_override_present && [ -d "${CQLITE_SCHEMAS_ROOT:-}" ]; then
     printf '%s' "CQLITE_SCHEMAS_ROOT override"
   else
     printf '%s' "checkout-relative"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1412,10 +1412,37 @@ _gate_schemas_override_reject_kind() {
   case "${CQLITE_SCHEMAS_ROOT:-}" in
     *[[:cntrl:]]*) printf '%s' 'control-chars'; return 0 ;;
   esac
+  _gate_schemas_override_is_utf8 || { printf '%s' 'non-utf8'; return 0; }
   case "${CQLITE_SCHEMAS_ROOT:-}" in
     /*) return 0 ;;
     *) printf '%s' 'relative' ;;
   esac
+}
+
+# _gate_schemas_override_is_utf8: rc 0 iff CQLITE_SCHEMAS_ROOT is (provably) valid UTF-8.
+#
+# Bash handles the value as BYTES, so without this the gate validated a non-UTF-8 override and
+# stamped it into the SUMMARY while Rust's `var_os(..).to_str()` could not represent it and
+# rejected — the gate certifying one schemas root while the tests resolved another (roborev job
+# 11, BLOCKER; measured `STATUS: OK` + `SOURCE: CQLITE_SCHEMAS_ROOT override` for a
+# `bad\xff\xfedir` path). Now both sides reject it.
+#
+# Two-step so the common case needs no external tool AND an unverifiable value is never
+# accepted:
+#   1. Pure ASCII (no byte outside printable ASCII — control characters are already rejected
+#      above) is valid UTF-8 by definition, so accept without invoking anything. `LC_ALL=C` makes
+#      `[[:print:]]` mean ASCII-printable regardless of the caller's locale.
+#   2. Otherwise validate with `iconv -f UTF-8 -t UTF-8`, which fails on malformed input. If
+#      `iconv` is ABSENT we REJECT rather than assume: "could not check" must not mean "accept",
+#      or the hole comes straight back on a box without it. That is narrow — only non-ASCII
+#      override values are affected, and the remedy (an ASCII path) is always available.
+_gate_schemas_override_is_utf8() {
+  local v="${CQLITE_SCHEMAS_ROOT:-}"
+  if ! LC_ALL=C printf '%s' "$v" | LC_ALL=C grep -q '[^[:print:]]'; then
+    return 0
+  fi
+  command -v iconv >/dev/null 2>&1 || return 1
+  LC_ALL=C printf '%s' "$v" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1
 }
 
 _gate_schemas_override_reject() {
@@ -1429,6 +1456,8 @@ _gate_schemas_override_reject() {
       printf '%s' "CQLITE_SCHEMAS_ROOT must not contain control characters (newline/CR/tab), got $(printf '%q' "${CQLITE_SCHEMAS_ROOT:-}")"
       return 0 ;;
   esac
+  _gate_schemas_override_is_utf8 \
+    || { printf '%s' "CQLITE_SCHEMAS_ROOT must be valid UTF-8, got $(printf '%q' "${CQLITE_SCHEMAS_ROOT:-}")"; return 0; }
   case "${CQLITE_SCHEMAS_ROOT:-}" in
     /*) return 0 ;;
     *) printf '%s' "CQLITE_SCHEMAS_ROOT must be an ABSOLUTE path, got '${CQLITE_SCHEMAS_ROOT:-}'" ;;
@@ -1555,6 +1584,9 @@ apply_schemas_preflight() {
       control-chars)
         why="a schemas root carrying a CONTROL CHARACTER (newline/CR/tab) cannot round-trip through the gate's shell resolution — command substitution strips trailing newlines — so the gate would validate one path while cargo resolved another."
         marker="missing-schemas: FAIL-CLOSED (#3148) — CQLITE_SCHEMAS_ROOT contains a control character; the gate and the test binaries would resolve DIFFERENT roots; overall verdict FAIL" ;;
+      non-utf8)
+        why="this shell handles the value as raw BYTES and would accept it, while the Rust resolver cannot represent a non-UTF-8 value as text and rejects it — so the gate would certify one schemas root while the tests resolved another."
+        marker="missing-schemas: FAIL-CLOSED (#3148) — CQLITE_SCHEMAS_ROOT is not valid UTF-8; the gate and the test binaries would resolve DIFFERENT roots; overall verdict FAIL" ;;
       *)
         why="a RELATIVE schemas root cannot mean the same thing on both sides: the gate resolves it against $REPO_ROOT, cargo resolves it against each test binary's PACKAGE dir."
         marker="missing-schemas: FAIL-CLOSED (#3148) — relative CQLITE_SCHEMAS_ROOT rejected; the gate and the test binaries would resolve DIFFERENT roots; overall verdict FAIL" ;;

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1322,6 +1322,14 @@ SCHEMAS_LINE=""
 # sparse checkout — or a worktree nested inside another checkout — resolve to the OUTER
 # checkout's fixtures, wrong-but-existing and unreported. Falls back to REPO_ROOT when no
 # `[workspace]` manifest is found (not reachable in this repository).
+#
+# KNOWN EXCEPTION: `fuzz/Cargo.toml` declares its OWN `[workspace]` (deliberately — the
+# fuzz crate is excluded from the main workspace, see #1614). So a hypothetical caller
+# anchored inside `fuzz/` would resolve `fuzz/test-data`, which does not exist. Benign in
+# both mirrors: the result is a LOUD failure naming that absent path, never a silent
+# borrow of a wrong tree — and neither the gate (anchored on REPO_ROOT) nor any
+# `#[path]`-including target lives under `fuzz/`. Named here so the next reader does not
+# have to rediscover that the "nearest [workspace]" rule has an in-repo counterexample.
 _gate_checkout_test_data_dir() {
   local d="$REPO_ROOT"
   while [ -n "$d" ] && [ "$d" != "/" ]; do
@@ -1347,12 +1355,33 @@ _gate_checkout_test_data_dir() {
 # absolute path:` remedy line print a relative path, breaking AC (b).
 #
 # Both sides therefore reject it, so they agree BY CONSTRUCTION rather than by review.
-_gate_schemas_override_reject() {
+# _gate_schemas_override: THE single normalization of "is there an override?", echoing the
+# raw value when there is one and nothing when there is not. Every other helper consults
+# this rather than testing `$CQLITE_SCHEMAS_ROOT` itself.
+#
+# Single-sourcing it is not tidiness (roborev job 9, finding 1): `_gate_schemas_override_reject`
+# treated a WHITESPACE-ONLY value as unset (matching Rust's `v.trim().is_empty()`) while
+# `_gate_schemas_root`/`_gate_schemas_root_source` tested the raw `-n` value. So with a
+# directory literally named "  " present, the gate would have validated and reported it as
+# the override while Rust treated the var as unset and read the checkout's schemas —
+# recreating the very root-certification mismatch this change exists to prevent, in the one
+# input class the two mirrors disagreed on. Exotic, but the whole point of the pair is that
+# they answer identically on EVERY input, so it is fixed rather than argued about.
+#
+# Note the deliberate asymmetry: presence is decided on the TRIMMED value, but the value
+# used is the RAW one (never trimmed) — exactly as Rust does, where `trim()` gates presence
+# and `PathBuf::from(raw)` builds the path. Hence `"  /abs  "` is *present* and then
+# REJECTED as non-absolute on both sides, rather than silently trimmed into `/abs`.
+_gate_schemas_override() {
   local v="${CQLITE_SCHEMAS_ROOT:-}"
-  # Blank (or unset) is not an override at all — an exported-but-empty var is a scripting
-  # accident, and both sides treat it as unset. Whitespace-stripped, matching the Rust
-  # side's `v.trim().is_empty()`.
   [ -n "$(printf '%s' "$v" | tr -d '[:space:]')" ] || return 0
+  printf '%s' "$v"
+}
+
+_gate_schemas_override_reject() {
+  local v
+  v="$(_gate_schemas_override)" || return 0
+  [ -n "$v" ] || return 0
   case "$v" in
     /*) return 0 ;;
     *) printf '%s' "CQLITE_SCHEMAS_ROOT must be an ABSOLUTE path, got '$v'" ;;
@@ -1366,17 +1395,20 @@ _gate_schemas_override_reject() {
 # is rejected outright, see above), else checkout-relative. Both sides anchor on the same
 # workspace marker, so the gate asserts the path the tests will actually resolve.
 _gate_schemas_root() {
-  if [ -z "$(_gate_schemas_override_reject)" ] \
-     && [ -n "${CQLITE_SCHEMAS_ROOT:-}" ] && [ -d "${CQLITE_SCHEMAS_ROOT}" ]; then
-    printf '%s' "$CQLITE_SCHEMAS_ROOT"
+  local v
+  v="$(_gate_schemas_override)"
+  if [ -z "$(_gate_schemas_override_reject)" ] && [ -n "$v" ] && [ -d "$v" ]; then
+    printf '%s' "$v"
   else
     printf '%s' "$(_gate_checkout_test_data_dir)/schemas"
   fi
 }
 _gate_schemas_root_source() {
+  local v
+  v="$(_gate_schemas_override)"
   if [ -n "$(_gate_schemas_override_reject)" ]; then
     printf '%s' "CQLITE_SCHEMAS_ROOT override REJECTED"
-  elif [ -n "${CQLITE_SCHEMAS_ROOT:-}" ] && [ -d "${CQLITE_SCHEMAS_ROOT}" ]; then
+  elif [ -n "$v" ] && [ -d "$v" ]; then
     printf '%s' "CQLITE_SCHEMAS_ROOT override"
   else
     printf '%s' "checkout-relative"
@@ -1825,10 +1857,21 @@ case "${1:-}" in
   # `case "$1"`, so `--only X --preflight-schemas-line` is not expressible, and a real
   # `--only core-tests` run would spend minutes in cargo before printing anything).
   # Deliberately drives the effectful function: the whole point is that a POSITIVE line must
-  # never be stamped for a check that did not run. On the strict path this may emit a FAIL
-  # SUMMARY and exit non-zero, which the self-test treats as a regression of leniency.
+  # never be stamped for a check that did not run.
+  #
+  # It can NOT observe the FAIL SUMMARY, and saying otherwise would send a reader looking for
+  # a block that cannot exist: `emit_summary` and `_tree_meta_array` are defined AFTER this
+  # dispatch point, so the strict-FAILURE branch would otherwise die on two
+  # `command not found` lines. They are stubbed below so that path exits non-zero with ONE
+  # named token instead — which is all the self-test needs from it (it asserts the LENIENT
+  # and the strict-HEALTHY paths; the strict-FAILURE emit is covered by the real full-gate
+  # cases). The stubs are safe: this arm always `exit`s before the real definitions are read.
   --preflight-schemas-line)
     [ -n "${2:-}" ] && ONLY="$2"
+    # shellcheck disable=SC2317  # invoked indirectly, from apply_schemas_preflight
+    emit_summary() { echo "HOOK: strict-path FAIL (SUMMARY not emittable at dispatch time)"; }
+    # shellcheck disable=SC2317  # invoked indirectly, from apply_schemas_preflight
+    _tree_meta_array() { TREE_META_LINES=(); }
     apply_schemas_preflight
     echo "SCHEMAS_LINE: ${SCHEMAS_LINE:-<none>}"
     exit 0 ;;

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1429,18 +1429,41 @@ _gate_schemas_override_reject_kind() {
 #
 # Two-step so the common case needs no external tool AND an unverifiable value is never
 # accepted:
-#   1. Pure ASCII (no byte outside printable ASCII — control characters are already rejected
-#      above) is valid UTF-8 by definition, so accept without invoking anything. `LC_ALL=C` makes
-#      `[[:print:]]` mean ASCII-printable regardless of the caller's locale.
+#   1. Pure printable ASCII is valid UTF-8 by definition, so accept without invoking anything.
+#      Done with a SUBPROCESS-FREE `case` under a function-local `LC_ALL=C`, which makes
+#      `[[:print:]]` mean ASCII-printable regardless of the caller's locale (verified identical
+#      under C, C.UTF-8 and en_US.UTF-8).
+#
+#      This replaced a `printf | grep -q` probe. DEFENSIVE HARDENING, not a fixed live bug:
+#      under the script-wide `set -o pipefail` (:369) a NEGATED pipeline whose LEFT side can
+#      take SIGPIPE is a latent branch-inversion hazard (roborev job 12, finding 1) — if it
+#      fired, a malformed override would take the "pure ASCII" branch and skip validation. It
+#      did NOT reproduce here: bash's BUILTIN `printf` gave `PIPESTATUS=[0 0]` at 5 B / 100 KB
+#      / 1 MB / 5 MB on bash 5.2.21, and independently a value big enough to fill a 64 KB pipe
+#      is ~16x this platform's `PATH_MAX` of 4096, so it could never name a real directory.
+#      Hardened anyway because the hazard is platform-scoped: the `case` form removes the
+#      pipeline, the SIGPIPE class, and the `grep` dependency at once.
+#
+#      ORDER IS LOAD-BEARING — `_gate_schemas_override_reject_kind()` screens control
+#      characters BEFORE calling this, and must keep doing so. A newline is VALID UTF-8, so
+#      this function ACCEPTS one; were the order reversed, a newline-bearing ABSOLUTE path
+#      would be accepted outright instead of classified `control-chars`. (This supersedes the
+#      earlier rationale, which cited `grep` treating a newline as a line terminator: the
+#      `grep` is gone, the ordering requirement is not.)
 #   2. Otherwise validate with `iconv -f UTF-8 -t UTF-8`, which fails on malformed input. If
 #      `iconv` is ABSENT we REJECT rather than assume: "could not check" must not mean "accept",
 #      or the hole comes straight back on a box without it. That is narrow — only non-ASCII
-#      override values are affected, and the remedy (an ASCII path) is always available.
+#      override values are affected, and the remedy (an ASCII path) is always available. The
+#      self-test asserts BOTH worlds (accept with `iconv`, fail-closed reject without), so an
+#      `iconv`-less host no longer reds the gate on a valid multibyte root (job 12, finding 2).
 _gate_schemas_override_is_utf8() {
   local v="${CQLITE_SCHEMAS_ROOT:-}"
-  if ! LC_ALL=C printf '%s' "$v" | LC_ALL=C grep -q '[^[:print:]]'; then
-    return 0
-  fi
+  # shellcheck disable=SC2034  # assigned to retarget bash's own pattern-matching locale
+  local LC_ALL=C
+  case "$v" in
+    *[![:print:]]*) : ;;
+    *) return 0 ;;
+  esac
   command -v iconv >/dev/null 2>&1 || return 1
   LC_ALL=C printf '%s' "$v" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1
 }

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1281,6 +1281,117 @@ apply_fixture_preflight() {
   esac
 }
 
+# ---- issue #3148: FULL-gate fail-closed on an unreachable COMMITTED schemas root -
+# #2078 (above) validates the FETCHED SSTable corpus. It says nothing about the
+# COMMITTED CQL schema fixtures under test-data/schemas/ (23 files incl. legacy/ and
+# udts/), which the dataset-backed components must also read to decode those SSTables.
+# Before #3148, `grep -c schemas scripts/agent-gate.sh` was 0: a corpus whose
+# sstables/ was complete but whose schema fixtures were unreachable passed the
+# preflight with STATUS: OK, built for ~8 minutes, then failed core-tests +
+# memory-budget with opaque "Path does not exist: …/basic-types.cql" panics. Worse
+# than no preflight at all: `STATUS: OK` is POSITIVELY MISLEADING, so an agent reads
+# "fixtures verified" and suspects its own diff (this nearly cost #3095/PR #3141 a
+# misattributed triage).
+#
+# Since #3148 the Rust helpers resolve the schemas root CHECKOUT-RELATIVE
+# (test-data/support/fixture_roots.rs — never $CQLITE_DATASETS_ROOT/../schemas), so
+# this check is a cheap BELT-AND-BRACES assert on the same root that helper resolves:
+# an explicit CQLITE_SCHEMAS_ROOT override when set + readable, else the checkout's
+# test-data/schemas. Deliberately NO opt-out (unlike #2078's
+# AGENT_GATE_ALLOW_MISSING_FIXTURES): the fetched corpus is legitimately absent
+# sometimes, but committed source in a checkout never is — an unreachable schemas root
+# is a broken checkout or a stale override, and neither may certify a run.
+# --lite/--only stay lenient, unchanged from #2078's contract (#3148 AC (g)).
+
+# The exact schema files the gate's dataset-backed components consume — a directory
+# existence check is NOT enough (#3148 fix 1). The six from the shared bench fixture
+# catalog (cqlite-core/benches/fixtures/mod.rs, read by memory_budget,
+# issue_1494_converter_alloc_budget, issue_2075_row_assembly_alloc_budget,
+# tail_latency_harness), which also cover dead_cache_delete_tests (basic-types.cql),
+# observability_correctness (basic-types.cql) and cqlite-cli's export_csv bench
+# (collections.cql).
+CANONICAL_SCHEMA_FILES="basic-types.cql da-test.cql time-series.cql wide-table-bti.cql collections.cql wide-rows.cql"
+# Stamped into the SUMMARY on a successful check so the pasted block shows POSITIVELY
+# that the schemas root was validated, not merely that nothing complained.
+SCHEMAS_LINE=""
+
+# _gate_schemas_root / _gate_schemas_root_source: mirror schemas_root_resolved() in
+# test-data/support/fixture_roots.rs EXACTLY — env override only when set, non-empty
+# AND a readable directory (a stale/broken export degrades to the checkout rather than
+# pinning the run to a path that cannot work), else checkout-relative. Both sides
+# anchor on the checkout, so the gate asserts the same path the tests will resolve.
+_gate_schemas_root() {
+  if [ -n "${CQLITE_SCHEMAS_ROOT:-}" ] && [ -d "${CQLITE_SCHEMAS_ROOT}" ]; then
+    printf '%s' "$CQLITE_SCHEMAS_ROOT"
+  else
+    printf '%s' "$REPO_ROOT/test-data/schemas"
+  fi
+}
+_gate_schemas_root_source() {
+  if [ -n "${CQLITE_SCHEMAS_ROOT:-}" ] && [ -d "${CQLITE_SCHEMAS_ROOT}" ]; then
+    printf '%s' "CQLITE_SCHEMAS_ROOT override"
+  else
+    printf '%s' "checkout-relative"
+  fi
+}
+
+# _missing_schema_files: the space-separated subset of CANONICAL_SCHEMA_FILES that is
+# not readable under the resolved root. Empty means all present.
+_missing_schema_files() {
+  local root f out=""
+  root="$(_gate_schemas_root)"
+  # shellcheck disable=SC2086  # intentional word-split over the space-separated list
+  for f in $CANONICAL_SCHEMA_FILES; do
+    [ -r "$root/$f" ] || out="${out:+$out }$f"
+  done
+  printf '%s' "$out"
+}
+
+# _schemas_status: PURE decision for the FULL-gate schemas guard. Echoes exactly one
+# token: OK (all canonical .cql readable, or not the full gate → no-op) or FAIL. No
+# side effects, so the hidden --preflight-schemas hook asserts the SAME decision
+# apply_schemas_preflight consumes (single-source; no drift).
+_schemas_status() {
+  # Only the FULL gate is strict: --only stays lenient, --lite already returned.
+  [ -z "$ONLY" ] || { echo OK; return 0; }
+  [ "$LITE" -eq 0 ] || { echo OK; return 0; }
+  [ -z "$(_missing_schema_files)" ] && { echo OK; return 0; }
+  echo FAIL
+}
+
+# apply_schemas_preflight: EFFECTFUL FULL-gate schemas guard (issue #3148). Consumes
+# _schemas_status. OK → stamp the positive SCHEMAS_LINE and return. FAIL → emit a FAIL
+# SUMMARY carrying `missing-schemas: FAIL-CLOSED (#3148)` — textually DISTINCT from
+# #2078's `missing-fixtures:` so the two causes are separable in a pasted block — with
+# a remedy naming the exact expected absolute path, then exit 1.
+apply_schemas_preflight() {
+  local root missing
+  root="$(_gate_schemas_root)"
+  case "$(_schemas_status)" in
+    OK)
+      local n
+      # shellcheck disable=SC2086  # intentional word-split over the space-separated list
+      n=$(set -- $CANONICAL_SCHEMA_FILES; echo $#)
+      SCHEMAS_LINE="schemas: $n/$n canonical .cql readable under $root ($(_gate_schemas_root_source))"
+      return 0 ;;
+    *)
+      missing="$(_missing_schema_files)"
+      echo "agent-gate: FAIL: committed CQL schema fixtures unreachable under $root ($(_gate_schemas_root_source)) (#3148)" >&2
+      echo "agent-gate: unreadable: $missing" >&2
+      echo "agent-gate: expected absolute path: $root/${missing%% *}" >&2
+      echo "agent-gate: these are COMMITTED SOURCE (test-data/schemas, 23 files incl. legacy/ + udts/) — NOT part of the fetched corpus and NOT derived from CQLITE_DATASETS_ROOT." >&2
+      echo "agent-gate: dataset-backed components (core-tests, memory-budget, cli-tests) would build for ~8 min and then panic on the missing .cql." >&2
+      echo "agent-gate: remedy: unset CQLITE_SCHEMAS_ROOT (it overrides the checkout default), or restore the committed fixtures: git -C $REPO_ROOT restore --source=HEAD -- test-data/schemas" >&2
+      _tree_meta_array   # #2926: every emitted block carries the tree provenance
+      emit_summary FAIL \
+        "preflight: FAIL (committed CQL schema fixtures unreadable under $root — missing: $missing)" \
+        "missing-schemas: FAIL-CLOSED (#3148) — dataset-backed components would panic on an absent .cql; overall verdict FAIL" \
+        "${TREE_META_LINES[@]}" \
+        "hint: expected $root/${missing%% *} — unset CQLITE_SCHEMAS_ROOT, or: git -C $REPO_ROOT restore --source=HEAD -- test-data/schemas"
+      exit 1 ;;
+  esac
+}
+
 # ---- issue #2081: --delta executes node __test__/ + scripts/tests/*.sh ---------
 # --delta re-cert (issue #1892) fail-closed on node jest files + shell self-tests
 # purely because its components could not EXECUTE them. It now can: these helpers
@@ -1591,6 +1702,17 @@ case "${1:-}" in
   --preflight-fixtures)
     _pf_st=$(_fixture_status); echo "STATUS: $_pf_st"
     [ "$_pf_st" = OPTOUT ] && echo "$(_missing_fixtures_marker)"
+    exit 0 ;;
+  # Hidden self-test hook (issue #3148): print the FULL-gate COMMITTED-SCHEMAS decision
+  # (OK|FAIL) from _schemas_status, plus the resolved ROOT, its SOURCE and (on FAIL) the
+  # unreadable files — so the positive-control self-test asserts the preflight actually
+  # FAILS on a schemas-less root, not merely that it passes on a good one. Pure — the
+  # FAIL emit + exit lives in apply_schemas_preflight (exercised by the real gate run).
+  --preflight-schemas)
+    _ps_st=$(_schemas_status); echo "STATUS: $_ps_st"
+    echo "ROOT: $(_gate_schemas_root)"
+    echo "SOURCE: $(_gate_schemas_root_source)"
+    [ "$_ps_st" = FAIL ] && echo "MISSING: $(_missing_schema_files)"
     exit 0 ;;
   # Hidden self-test hooks (issue #2081): expose the node-build readiness decision and
   # the shell-selftest executor so scripts/tests assert the SAME logic run_delta uses.
@@ -3259,6 +3381,9 @@ _tree_boundary_meta_lines() {
     fi
   fi
   [ -n "${MISSING_FIXTURES_MARKER:-}" ] && printf '%s\n' "$MISSING_FIXTURES_MARKER"
+  # #3148: the POSITIVE schemas-root assertion (empty until the full gate's preflight
+  # has run, so a --lite/--delta boundary simply omits it rather than inventing it).
+  [ -n "${SCHEMAS_LINE:-}" ] && printf '%s\n' "$SCHEMAS_LINE"
   [ -n "${PINS:-}" ] && printf 'ci-pins: %s\n' "$PINS"
   # Both printers deliberately emit NO trailing newline (their normal callers capture them
   # into a SUMMARY_META element), so each needs its own '%s\n' here or the whole block
@@ -6246,6 +6371,13 @@ if selected_needs_datasets; then
   # AGENT_GATE_ALLOW_MISSING_FIXTURES=1 (restores SKIP + stamps MISSING_FIXTURES_MARKER
   # into the SUMMARY). May emit a FAIL SUMMARY and exit 1.
   apply_fixture_preflight
+  # FULL-gate COMMITTED-SCHEMAS guard (issue #3148): the SSTable corpus above is only
+  # half the fixture contract — the dataset-backed components must also read the
+  # committed CQL schemas that decode it. Runs AFTER the corpus guard so a run missing
+  # both still reports the #2078 cause first (the corpus is the fetched half an
+  # operator must act on). Checkout-relative, so this is a cheap belt-and-braces
+  # assert; no opt-out. May emit a FAIL SUMMARY and exit 1.
+  apply_schemas_preflight
   # Historical hard preflight: zero Data.db at all is an error. For the FULL gate this
   # is already handled by apply_fixture_preflight above (an empty root has no
   # test_basic corpus either), so restrict it to --only — that way the opt-out can
@@ -6829,6 +6961,11 @@ fi
 # #2078: stamp the opt-out marker so an intentional AGENT_GATE_ALLOW_MISSING_FIXTURES=1
 # run is visible in the pasted SUMMARY block (empty otherwise → no line).
 [ -n "$MISSING_FIXTURES_MARKER" ] && SUMMARY_META+=("$MISSING_FIXTURES_MARKER")
+# #3148: stamp the POSITIVE committed-schemas assertion (which root was validated, and
+# whether via the checkout or a CQLITE_SCHEMAS_ROOT override), so the pasted block shows
+# the check RAN rather than merely that nothing complained. Empty when the preflight was
+# skipped (no dataset-dependent component selected) → no line.
+[ -n "$SCHEMAS_LINE" ] && SUMMARY_META+=("$SCHEMAS_LINE")
 SUMMARY_META+=("ci-pins: $PINS")
 SUMMARY_META+=("$(accelerators_line)")
 SUMMARY_META+=("$(cpu_budget_line)")

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -222,6 +222,54 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 2b. A POSITIVE line must never assert a check that did not run.
+#
+#     `_schemas_status` returns OK unconditionally under --only/--lite (leniency, AC (g)),
+#     so the OK branch used to stamp `schemas: 6/6 canonical .cql readable under <root>`
+#     for a check that NEVER RAN — #3148's own misleading `STATUS: OK`, one mode over. The
+#     assertion is therefore on the SUMMARY TEXT the real apply_schemas_preflight stamps,
+#     driven through the --preflight-schemas-line hook (a real `--only core-tests` run
+#     would spend minutes in cargo before printing anything).
+# ---------------------------------------------------------------------------
+line_field() { printf '%s\n' "$1" | grep '^SCHEMAS_LINE: ' | sed 's/^SCHEMAS_LINE: //'; }
+
+only_line_out=$(CQLITE_SCHEMAS_ROOT="$schemas_empty" \
+  bash "$GATE" --preflight-schemas-line core-tests 2>/dev/null)
+only_line_rc=$?
+only_line=$(line_field "$only_line_out")
+if [ "$only_line_rc" -eq 0 ] \
+   && ! grep -q 'readable' <<<"$only_line" \
+   && grep -q '^schemas: not checked' <<<"$only_line" \
+   && grep -q -- '--only core-tests' <<<"$only_line"; then
+  ok "3148-only-no-false-positive: an --only run stamps an explicit 'not checked', never 'N/N readable'"
+else
+  bad "3148-only-no-false-positive: a lenient --only run must not assert readability (rc=$only_line_rc, line: '$only_line')"
+fi
+
+# Same for a RELATIVE override under --only. This ALSO pins the second half of the same
+# class: the REJECT branch was not governed by _schemas_status, so it FAILed even a
+# lenient --only run — the effectful guard diverging from the pure decision it is
+# documented to consume.
+rel_only_out=$(CQLITE_SCHEMAS_ROOT="packaged/schemas" \
+  bash "$GATE" --preflight-schemas-line core-tests 2>/dev/null)
+rel_only_rc=$?
+rel_only=$(line_field "$rel_only_out")
+if [ "$rel_only_rc" -eq 0 ] && grep -q '^schemas: not checked' <<<"$rel_only"; then
+  ok "3148-only-reject-lenient: --only stays lenient for a relative override too (no strict-path drift)"
+else
+  bad "3148-only-reject-lenient: the reject branch is not governed by the lenient mode check (rc=$rel_only_rc, line: '$rel_only')"
+fi
+
+# …and the POSITIVE line must still appear when the check DID run, otherwise the two
+# asserts above would be satisfied by simply never stamping anything.
+full_line=$(line_field "$(bash "$GATE" --preflight-schemas-line 2>/dev/null)")
+if grep -q "^schemas: 6/6 canonical .cql readable under $REPO/test-data/schemas" <<<"$full_line"; then
+  ok "3148-full-positive-line: a FULL-mode check that ran stamps the positive N/N readable line"
+else
+  bad "3148-full-positive-line: expected the positive line for a real check (got '$full_line')"
+fi
+
+# ---------------------------------------------------------------------------
 # 3. AC (g): --lite and --only stay LENIENT (unchanged from #2078's contract).
 # ---------------------------------------------------------------------------
 lite_block="$tmp/3148-lite.txt"
@@ -229,10 +277,15 @@ CQLITE_DATASETS_ROOT="$ds_corpus" CQLITE_SCHEMAS_ROOT="$schemas_empty" \
   AGENT_GATE_SUMMARY_FILE="$lite_block" \
   bash "$GATE" --lite --emit-summary-selftest >/dev/null 2>&1
 lite_rc=$?
+# `! grep '^schemas: '` as well as the marker: a LITE block must carry NO schemas line at
+# all — neither a failure marker nor a POSITIVE assertion. run_lite always exits before
+# apply_schemas_preflight, so SCHEMAS_LINE is never stamped; this pins that, so a future
+# call-site move cannot start asserting readability in a mode that never checked it.
 if [ "$lite_rc" -eq 0 ] \
    && grep -q "AGENT-GATE LITE SUMMARY" "$lite_block" 2>/dev/null \
-   && ! grep -q "missing-schemas:" "$lite_block" 2>/dev/null; then
-  ok "3148-lite: --lite unaffected by an unreachable schemas root (clean LITE block, no marker)"
+   && ! grep -q "missing-schemas:" "$lite_block" 2>/dev/null \
+   && ! grep -q "^schemas: " "$lite_block" 2>/dev/null; then
+  ok "3148-lite: --lite unaffected by an unreachable schemas root (no schemas line at all)"
 else
   bad "3148-lite: --lite must stay lenient (rc=$lite_rc)"
   cat "$lite_block" 2>/dev/null

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -518,14 +518,66 @@ fi
 utf8_root="$tmp/schémas-ünïcode"
 mkdir -p "$utf8_root"
 for f in "${CANONICAL[@]}"; do printf -- '-- synthetic\n' >"$utf8_root/$f"; done
+#
+# TWO WORLDS, deliberately. `_gate_schemas_override_is_utf8` REJECTS a non-ASCII value when
+# `iconv` is ABSENT ("could not check" must not mean "accept"). Asserting only the ACCEPT
+# outcome made this pin demand a result the implementation does not promise on an iconv-less
+# host, so `tooling-tests` — and with it the whole gate — would have redded there on a
+# perfectly valid root (roborev job 12, finding 2). That is a false RED, not a false green,
+# but a fleet foot-gun now that this self-test runs inside the gate. So assert whichever
+# outcome is DOCUMENTED for the host we are on.
 utf8_out=$(CQLITE_SCHEMAS_ROOT="$utf8_root" bash "$GATE" --preflight-schemas 2>/dev/null)
-if [ "$(hook_field STATUS "$utf8_out")" = OK ] \
-   && [ "$(hook_field SOURCE "$utf8_out")" = "CQLITE_SCHEMAS_ROOT override" ] \
-   && [ "$(hook_field ROOT "$utf8_out")" = "$utf8_root" ]; then
-  ok "3148-utf8-override-ok: a legitimate multibyte-UTF-8 override is still accepted"
+if command -v iconv >/dev/null 2>&1; then
+  if [ "$(hook_field STATUS "$utf8_out")" = OK ] \
+     && [ "$(hook_field SOURCE "$utf8_out")" = "CQLITE_SCHEMAS_ROOT override" ] \
+     && [ "$(hook_field ROOT "$utf8_out")" = "$utf8_root" ]; then
+    ok "3148-utf8-override-ok: a legitimate multibyte-UTF-8 override is still accepted (iconv present)"
+  else
+    bad "3148-utf8-override-ok: the UTF-8 guard over-rejected a valid non-ASCII root"
+    printf '%s\n' "$utf8_out"
+  fi
 else
-  bad "3148-utf8-override-ok: the UTF-8 guard over-rejected a valid non-ASCII root"
-  printf '%s\n' "$utf8_out"
+  # NOT a silent skip — on THIS host the documented result is a fail-closed rejection, so that
+  # is what gets asserted. A case that quietly stops testing is the pattern this change has
+  # already had to dig out of itself three times.
+  if [ "$(hook_field STATUS "$utf8_out")" = FAIL ] \
+     && printf '%s' "$utf8_out" | grep -q "must be valid UTF-8"; then
+    ok "3148-utf8-override-ok: iconv ABSENT here, so a multibyte override fails closed (documented)"
+  else
+    bad "3148-utf8-override-ok: iconv absent, but a multibyte override was not rejected fail-closed"
+    printf '%s\n' "$utf8_out"
+  fi
+fi
+
+# The absent-`iconv` branch above is UNREACHABLE on a host that has iconv, which would leave
+# the fail-closed-when-unverifiable promise permanently untested exactly where it matters.
+# Exercise it for real: re-run the hook with a PATH farm symlinking every executable EXCEPT
+# iconv, so `command -v iconv` genuinely fails while the gate still finds everything else.
+noiconv_bin="$tmp/noiconv-bin"
+mkdir -p "$noiconv_bin"
+farm_n=0
+for d in $(printf '%s\n' "$PATH" | tr ':' '\n'); do
+  [ -d "$d" ] || continue
+  for f in "$d"/*; do
+    [ -x "$f" ] || continue
+    b=${f##*/}
+    [ "$b" = iconv ] && continue
+    [ -e "$noiconv_bin/$b" ] || { ln -s "$f" "$noiconv_bin/$b" 2>/dev/null && farm_n=$((farm_n + 1)); }
+  done
+done
+if [ "$farm_n" -gt 0 ] && [ -e "$noiconv_bin/bash" ] && [ ! -e "$noiconv_bin/iconv" ]; then
+  noiconv_out=$(env PATH="$noiconv_bin" CQLITE_SCHEMAS_ROOT="$utf8_root" \
+    bash "$GATE" --preflight-schemas 2>/dev/null)
+  if [ "$(hook_field STATUS "$noiconv_out")" = FAIL ] \
+     && [ "$(hook_field SOURCE "$noiconv_out")" = "CQLITE_SCHEMAS_ROOT override REJECTED" ] \
+     && printf '%s' "$noiconv_out" | grep -q "must be valid UTF-8"; then
+    ok "3148-utf8-no-iconv: iconv removed from PATH, so a VALID multibyte override fails CLOSED"
+  else
+    bad "3148-utf8-no-iconv: iconv absent from PATH but the multibyte override was not rejected fail-closed"
+    printf '%s\n' "$noiconv_out"
+  fi
+else
+  bad "3148-utf8-no-iconv: could not build an iconv-less PATH farm (symlinked=$farm_n) — case NOT exercised"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -485,6 +485,49 @@ else
   bad "3148-no-env-report-only: an environment value defeated the schemas fail-closed guard (requirement 8)"
 fi
 
+# 2f. A NON-UTF-8 override is REJECTED at the REAL emit (roborev job 11, BLOCKER) — the THIRD
+#     instance of the certify-A-use-B class, alongside control-characters (2c) and relative
+#     paths (2a). Bash handles the value as BYTES and used to accept it (measured: STATUS: OK +
+#     SOURCE: override for a `bad\xff\xfedir` path) while Rust's `var_os(..).to_str()` cannot
+#     represent it. The directory is REAL, so pre-fix the gate genuinely validated it — that is
+#     what makes this discriminating. A legitimate NON-ASCII UTF-8 root must still be ACCEPTED,
+#     asserted below, or the fix would be an over-broad ban on non-ASCII paths.
+nu_root="$tmp/$(printf 'bad\xff\xfedir')"
+mkdir -p "$nu_root"
+for f in "${CANONICAL[@]}"; do printf -- '-- synthetic\n' >"$nu_root/$f"; done
+nu_full="$tmp/3148-nu-full.txt"
+CQLITE_GATE_DISABLE_CAP=1 CQLITE_DATASETS_ROOT="$ds_corpus" \
+  CQLITE_SCHEMAS_ROOT="$nu_root" AGENT_GATE_SUMMARY_FILE="$nu_full" \
+  timeout 180 bash "$GATE" >"$tmp/3148-nu-full.out" 2>&1
+nu_rc=$?
+if [ "$nu_rc" -ne 0 ] \
+   && grep -q "^missing-schemas: FAIL-CLOSED (#3148)" "$nu_full" 2>/dev/null \
+   && grep -q "is not valid UTF-8" "$nu_full" 2>/dev/null \
+   && grep -q "must be valid UTF-8" "$tmp/3148-nu-full.out" 2>/dev/null \
+   && grep -q "^RESULT: FAIL" "$nu_full" 2>/dev/null \
+   && ! grep -q "^RESULT: PASS" "$nu_full" 2>/dev/null \
+   && ! grep -q "^schemas: " "$nu_full" 2>/dev/null; then
+  ok "3148-non-utf8-override: a non-UTF-8 override fails closed at the real emit, naming the cause"
+else
+  bad "3148-non-utf8-override: a non-UTF-8 override did not fail closed (rc=$nu_rc)"
+  cat "$nu_full" 2>/dev/null
+fi
+
+# …and the guard must not become a ban on non-ASCII paths: a legitimate UTF-8 root with
+# multibyte characters is still a VALID override.
+utf8_root="$tmp/schémas-ünïcode"
+mkdir -p "$utf8_root"
+for f in "${CANONICAL[@]}"; do printf -- '-- synthetic\n' >"$utf8_root/$f"; done
+utf8_out=$(CQLITE_SCHEMAS_ROOT="$utf8_root" bash "$GATE" --preflight-schemas 2>/dev/null)
+if [ "$(hook_field STATUS "$utf8_out")" = OK ] \
+   && [ "$(hook_field SOURCE "$utf8_out")" = "CQLITE_SCHEMAS_ROOT override" ] \
+   && [ "$(hook_field ROOT "$utf8_out")" = "$utf8_root" ]; then
+  ok "3148-utf8-override-ok: a legitimate multibyte-UTF-8 override is still accepted"
+else
+  bad "3148-utf8-override-ok: the UTF-8 guard over-rejected a valid non-ASCII root"
+  printf '%s\n' "$utf8_out"
+fi
+
 # ---------------------------------------------------------------------------
 # 3. AC (g): --lite and --only stay LENIENT (unchanged from #2078's contract).
 # ---------------------------------------------------------------------------
@@ -805,6 +848,30 @@ if grep -q "NOTE: this run populated $warm, NOT the checkout default" <<<"$warm_
 else
   bad "3131-warm-cache-note: the divergence NOTE (or the schemas NOTE) is missing"
   printf '%s\n' "$warm_out" | head -12
+fi
+
+# 6e. The fetch script's REMEDY line must be pasteable too (roborev job 11, nit 3) — it
+#     interpolated PIN_FILE/DATASET_ROOT unquoted, so a path with a space or a metacharacter
+#     printed a command that breaks when followed. Same `eval` round-trip proof as the export
+#     line: evaluate the printed `CQLITE_DATASETS_ROOT=...` assignment out of the remedy and
+#     compare it to the real root.
+rem_root="$tmp/rem space & meta/datasets"
+mkdir -p "$rem_root"
+rem_out=$(CQLITE_DATASETS_ROOT="$rem_root" bash "$FETCH" --verify-only 2>&1)
+rem_line=$(printf '%s\n' "$rem_out" | grep 'CQLITE_DATASETS_ROOT=' | grep 'rm -f' | sed 's/^ERROR:   //')
+# Extract ONLY the assignment. Evaluating the whole remedy would run its `rm -f`, and appending
+# a command to the assignment would make it a per-command PREFIX (temporary), which never sets
+# the variable in the shell — that mistake made this case fail on a correctly-quoted line.
+rem_assign=$(printf '%s' "$rem_line" | sed 's/.*&& //; s/ bash .*//')
+rem_eval=$(
+  unset CQLITE_DATASETS_ROOT
+  eval "$rem_assign" 2>/dev/null
+  printf '%s' "${CQLITE_DATASETS_ROOT:-}"
+)
+if [ -n "$rem_line" ] && [ "$rem_eval" = "$rem_root" ]; then
+  ok "3131-remedy-quoting: the failure remedy round-trips a path with spaces/metacharacters"
+else
+  bad "3131-remedy-quoting: the remedy line does not reproduce the root (line: '$rem_line' -> '$rem_eval')"
 fi
 
 # 6c. #2878 boundary: this change must NOT have touched the rm -rf /

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -33,8 +33,35 @@ FAIL=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-schemas.XXXXXX")
+# Scratch root, VALIDATED before anything is built under it (roborev job 10, finding 1).
+# This script runs `set -uo pipefail` deliberately (no `errexit`: every case must run so a
+# single failure does not hide the rest), so an unchecked `mktemp -d` failure would leave
+# `$tmp` EMPTY and every derived path would become root-level — `/ds-corpus`,
+# `/schemas-empty`, `/hollow/datasets`, … — which a privileged CI job WOULD create, and the
+# EXIT trap would then `rm -rf ""`. A verification script that can write to `/` on a bad
+# `mktemp` is not a safe guard, so this fails loudly instead, BEFORE the trap is installed
+# (arming a cleanup trap on an unvalidated path is the second half of the same hazard).
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-schemas.XXXXXX") || {
+  echo "FATAL: mktemp -d failed; refusing to run with an unset scratch root (would resolve to /)" >&2
+  exit 1
+}
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "FATAL: mktemp -d produced no usable directory ('$tmp'); refusing to run (paths would resolve under /)" >&2
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT
+
+# CHILD PROBE MODE. The scratch-root-guard case below re-invokes THIS script with a failing
+# `mktemp` stub on PATH; if the guard is absent the child would otherwise run every case —
+# including that one — and recurse without bound (observed: it did, while proving the case
+# discriminates). So a child stops HERE, immediately after the scratch root is validated,
+# which is the only thing the parent needs from it: with the guard present the child dies
+# above with `refusing to run`; without it, the child reaches this line and exits 0, and the
+# parent's assertion fails. Bounded to depth 1, fast, and the child creates nothing.
+if [ -n "${AGENT_GATE_SCHEMAS_SELFTEST_CHILD:-}" ]; then
+  echo "child: scratch root validated ('$tmp')"
+  exit 0
+fi
 
 # The six canonical .cql the gate's dataset-backed components consume. Kept here as a
 # LITERAL list rather than read back from agent-gate.sh: if someone shrinks
@@ -202,6 +229,55 @@ if [ "$rel_shapes_ok" -eq 1 ]; then
   ok "3148-whitespace-override: a whitespace-only value is unset (trim rule, single-sourced presence)"
 else
   bad "3148-whitespace-override: whitespace-only handling diverges from the Rust resolver"
+fi
+
+# A CONTROL-CHARACTER override must be REJECTED (roborev job 10, finding 2). Measured before
+# the fix: with `CQLITE_SCHEMAS_ROOT=$'<existing-dir>\n'` the gate reported STATUS OK +
+# SOURCE "CQLITE_SCHEMAS_ROOT override" + ROOT "<existing-dir>" — the newline eaten by the
+# `$( )` the helper was consumed through — while Rust kept it, failed `is_dir()`, and
+# degraded to the checkout. Two roots; the gate certifying the unused one. The directory here
+# is REAL and holds all six fixtures, so pre-fix the gate genuinely reported OK: that is what
+# makes this case discriminating rather than decorative.
+cc_root="$tmp/cc-override"
+mkdir -p "$cc_root"
+for f in "${CANONICAL[@]}"; do printf -- '-- synthetic\n' >"$cc_root/$f"; done
+cc_ok=1
+for raw in "$cc_root"$'\n' $'\n'"$cc_root" "$cc_root"$'\r' "$cc_root"$'\tsub'; do
+  cc_out=$(CQLITE_SCHEMAS_ROOT="$raw" bash "$GATE" --preflight-schemas 2>/dev/null)
+  if [ "$(hook_field STATUS "$cc_out")" = FAIL ] \
+     && [ "$(hook_field SOURCE "$cc_out")" = "CQLITE_SCHEMAS_ROOT override REJECTED" ] \
+     && grep -q 'must not contain control characters' <<<"$(hook_field REJECT "$cc_out")" \
+     && [ "$(hook_field ROOT "$cc_out")" = "$REPO/test-data/schemas" ]; then
+    :
+  else
+    cc_ok=0
+    echo "   (control-character override not rejected: $(printf '%q' "$raw"))"
+    printf '%s\n' "$cc_out"
+  fi
+done
+if [ "$cc_ok" -eq 1 ]; then
+  ok "3148-control-char-override: newline/CR/tab-bearing overrides are rejected, never silently trimmed"
+else
+  bad "3148-control-char-override: a control-character override was accepted (shell/Rust root divergence)"
+fi
+
+# The scratch-root guard (roborev job 10, finding 1) must fail LOUDLY rather than let every
+# path resolve under `/`. Driven with a stub `mktemp` that always fails, first on PATH. Safe
+# to run: with the guard the script dies before building anything; the assertion additionally
+# proves no root-level scratch path was created, which is the harm being prevented.
+mk_stub="$tmp/mk-stub"
+mkdir -p "$mk_stub"
+printf '#!/bin/sh\nexit 1\n' >"$mk_stub/mktemp"
+chmod +x "$mk_stub/mktemp"
+guard_out=$(PATH="$mk_stub:$PATH" AGENT_GATE_SCHEMAS_SELFTEST_CHILD=1 bash "$0" 2>&1)
+guard_rc=$?
+if [ "$guard_rc" -ne 0 ] \
+   && grep -q 'refusing to run' <<<"$guard_out" \
+   && [ ! -e /ds-corpus ] && [ ! -e /schemas-empty ]; then
+  ok "3148-scratch-root-guard: a failing mktemp aborts loudly instead of resolving paths under /"
+else
+  bad "3148-scratch-root-guard: expected a loud abort and no root-level scratch paths (rc=$guard_rc)"
+  printf '%s\n' "$guard_out" | head -5
 fi
 
 # The FULL gate must FAIL CLOSED on the relative override too — with its own reason, not

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -100,6 +100,90 @@ else
   bad "3148-hook-partial: expected FAIL naming only the absent files (got '$partial_missing')"
 fi
 
+# A bare `-r` test accepts a DIRECTORY named `basic-types.cql`; the Rust side asks for a
+# readable REGULAR file (`readable_file`). Both sides must ask the same question or the
+# gate can certify a layout the tests reject (reviewer nit N7 / roborev finding 2).
+schemas_dirtrap="$tmp/schemas-dirtrap"
+mkdir -p "$schemas_dirtrap"
+for f in "${CANONICAL[@]}"; do mkdir -p "$schemas_dirtrap/$f"; done
+dirtrap_out=$(CQLITE_SCHEMAS_ROOT="$schemas_dirtrap" bash "$GATE" --preflight-schemas 2>/dev/null)
+dirtrap_missing=$(hook_field MISSING "$dirtrap_out")
+dirtrap_all=1
+for f in "${CANONICAL[@]}"; do
+  grep -qw -- "$f" <<<"$dirtrap_missing" || dirtrap_all=0
+done
+if [ "$(hook_field STATUS "$dirtrap_out")" = FAIL ] && [ "$dirtrap_all" -eq 1 ]; then
+  ok "3148-hook-dirtrap: a DIRECTORY named like a .cql is not a readable regular file"
+else
+  bad "3148-hook-dirtrap: expected FAIL for directories named like the fixtures (got '$dirtrap_missing')"
+fi
+
+# ---------------------------------------------------------------------------
+# 1b. A RELATIVE CQLITE_SCHEMAS_ROOT is REJECTED, not resolved (blocker B1).
+#
+#     The gate evaluates a relative override with CWD = REPO_ROOT; cargo runs each test
+#     binary with CWD = the PACKAGE dir. Resolving it let the gate stamp
+#     `schemas: 6/6 … under packaged/schemas (override)` while the tests silently fell
+#     back to the checkout — the SUMMARY certifying root A for a run that used root B,
+#     which IS #3148's defect. So the decision must be FAIL, the reported ROOT must be
+#     the checkout (never the relative string dressed up as absolute), and the reason
+#     must be named.
+# ---------------------------------------------------------------------------
+rel_out=$(CQLITE_SCHEMAS_ROOT="packaged/schemas" bash "$GATE" --preflight-schemas 2>/dev/null)
+if [ "$(hook_field STATUS "$rel_out")" = FAIL ] \
+   && [ "$(hook_field ROOT "$rel_out")" = "$REPO/test-data/schemas" ] \
+   && [ "$(hook_field SOURCE "$rel_out")" = "CQLITE_SCHEMAS_ROOT override REJECTED" ] \
+   && grep -q 'must be an ABSOLUTE path' <<<"$(hook_field REJECT "$rel_out")"; then
+  ok "3148-relative-override: a relative CQLITE_SCHEMAS_ROOT is rejected, not resolved"
+else
+  bad "3148-relative-override: expected FAIL + REJECTED source + the absolute-path reason"
+  printf '%s\n' "$rel_out"
+fi
+
+# …and it must not smuggle the relative string into the report as an "absolute path".
+if ! grep -q 'expected absolute path: packaged/schemas' <<<"$rel_out"; then
+  ok "3148-relative-override: no relative path is ever labelled absolute (AC (b))"
+else
+  bad "3148-relative-override: a relative path was reported as the expected absolute path"
+fi
+
+# Every relative shape, not just the bare one; and a blank/whitespace value is NOT an
+# override at all (a scripting accident), matching the Rust side's `trim().is_empty()`.
+rel_shapes_ok=1
+for raw in './schemas' '../schemas' 'a/b/schemas'; do
+  st=$(CQLITE_SCHEMAS_ROOT="$raw" bash "$GATE" --preflight-schemas 2>/dev/null \
+    | grep '^STATUS:' | sed 's/^STATUS: //')
+  [ "$st" = FAIL ] || { rel_shapes_ok=0; echo "   (not rejected: $raw -> $st)"; }
+done
+for raw in '' '   '; do
+  st=$(CQLITE_SCHEMAS_ROOT="$raw" bash "$GATE" --preflight-schemas 2>/dev/null \
+    | grep '^STATUS:' | sed 's/^STATUS: //')
+  [ "$st" = OK ] || { rel_shapes_ok=0; echo "   (blank treated as an override: '$raw' -> $st)"; }
+done
+if [ "$rel_shapes_ok" -eq 1 ]; then
+  ok "3148-relative-shapes: every relative form rejected; blank/whitespace is not an override"
+else
+  bad "3148-relative-shapes: relative/blank handling diverges from the Rust resolver"
+fi
+
+# The FULL gate must FAIL CLOSED on the relative override too — with its own reason, not
+# a misleading "missing files" list (the checkout's fixtures are in fact complete).
+rel_full="$tmp/3148-rel-full.txt"
+CQLITE_GATE_DISABLE_CAP=1 CQLITE_DATASETS_ROOT="$ds_corpus" \
+  CQLITE_SCHEMAS_ROOT="packaged/schemas" AGENT_GATE_SUMMARY_FILE="$rel_full" \
+  bash "$GATE" >/dev/null 2>&1
+rel_full_rc=$?
+if [ "$rel_full_rc" -ne 0 ] \
+   && grep -q "^missing-schemas: FAIL-CLOSED (#3148)" "$rel_full" 2>/dev/null \
+   && grep -q "relative CQLITE_SCHEMAS_ROOT rejected" "$rel_full" 2>/dev/null \
+   && grep -q "^RESULT: FAIL" "$rel_full" 2>/dev/null \
+   && ! grep -q "^schemas: " "$rel_full" 2>/dev/null; then
+  ok "3148-relative-full: FULL gate FAILs CLOSED on a relative override and stamps no positive schemas line"
+else
+  bad "3148-relative-full: expected fail-closed with the relative-override reason (rc=$rel_full_rc)"
+  cat "$rel_full" 2>/dev/null
+fi
+
 # ---------------------------------------------------------------------------
 # 2. The FULL gate FAILS CLOSED, with a marker DISTINGUISHABLE from #2078's.
 #    apply_schemas_preflight fires before any cargo component, so this is fast.
@@ -211,6 +295,7 @@ fi
 # ---------------------------------------------------------------------------
 shared="$REPO/test-data/support/fixture_roots.rs"
 if [ -f "$shared" ] \
+   && grep -q 'pub fn resolve_schemas_root' "$shared" \
    && grep -q 'pub fn schemas_root_resolved' "$shared" \
    && grep -q 'pub fn datasets_root_if_present' "$shared" \
    && grep -q 'pub fn datasets_root' "$shared"; then
@@ -272,6 +357,60 @@ else
   printf '%s\n' "$hollow_out"
 fi
 
+# 6a-bis. --verify-only must CREATE NOTHING (blocker B2). The first cut of case 6a
+#         pre-`mkdir`ed its hollow root, which made it BLIND to exactly this bug:
+#         `canonicalize_dataset_root` runs `mkdir -p "${parent}"` before the mode
+#         dispatch, so probing a root under a nonexistent parent silently created that
+#         parent and then reported the root unusable. The root here is therefore
+#         deliberately NOT pre-created, and the assertion is on the filesystem, not on
+#         the message.
+absent_parent="$tmp/verify-nomutate"
+absent_root="$absent_parent/v4/datasets"
+nomutate_out=$(CQLITE_DATASETS_ROOT="$absent_root" bash "$FETCH" --verify-only 2>&1)
+nomutate_rc=$?
+if [ "$nomutate_rc" -ne 0 ] && [ ! -e "$absent_parent" ]; then
+  ok "3131-verify-no-mutation: --verify-only creates nothing, even a missing parent dir"
+else
+  bad "3131-verify-no-mutation: expected non-zero AND no filesystem mutation (rc=$nomutate_rc, created: $(ls -d "$absent_parent" 2>&1))"
+  printf '%s\n' "$nomutate_out"
+fi
+
+# 6a-ter. Unrecognized arguments must be REJECTED, not silently ignored (blocker B3).
+#         The default path is DESTRUCTIVE (`rm -rf "${DATASET_ROOT}"` before extraction),
+#         so `--quiet --verify-only` or any typo previously skipped the probe and reached
+#         the rm -rf against the operator's corpus. Asserted with a real, POPULATED root:
+#         if the rejection ever regresses, this case would attempt the destructive path,
+#         so the surviving fixture is itself part of the assertion.
+argsafe_ok=1
+argsafe_root="$tmp/argsafe/datasets"
+mkdir -p "$argsafe_root/sstables/test_basic/simple_table-0001"
+: >"$argsafe_root/sstables/test_basic/simple_table-0001/nb-1-big-Data.db"
+for badarg in "--quiet --verify-only" "-verify-only" "--verifyonly" "verify-only" "--Verify-Only"; do
+  # shellcheck disable=SC2086  # intentional word-split: some cases pass TWO arguments
+  out=$(CQLITE_DATASETS_ROOT="$argsafe_root" bash "$FETCH" $badarg 2>&1)
+  rc=$?
+  if [ "$rc" -ne 2 ] || ! grep -q "unrecognized argument" <<<"$out"; then
+    argsafe_ok=0; echo "   (not rejected with exit 2: '$badarg' -> rc=$rc)"
+  fi
+done
+if [ ! -f "$argsafe_root/sstables/test_basic/simple_table-0001/nb-1-big-Data.db" ]; then
+  argsafe_ok=0; echo "   (DESTRUCTIVE path reached: the fixture Data.db was deleted)"
+fi
+if [ "$argsafe_ok" -eq 1 ]; then
+  ok "3131-arg-safety: every unrecognized argument exits 2 before any destructive work"
+else
+  bad "3131-arg-safety: an unrecognized argument was not fail-closed"
+fi
+
+# …and the recognized flag plus --help still work (a fail-closed parser that rejects its
+# own flag would be a silent regression of the probe).
+help_out=$(bash "$FETCH" --help 2>&1); help_rc=$?
+if [ "$help_rc" -eq 0 ] && grep -q -- '--verify-only' <<<"$help_out"; then
+  ok "3131-arg-safety: --help documents --verify-only and exits 0"
+else
+  bad "3131-arg-safety: --help should exit 0 and document the flag (rc=$help_rc)"
+fi
+
 # 6b. A root holding the required content must report success AND print the exact
 #     `export CQLITE_DATASETS_ROOT=<absolute path>` line it guarantees — the missing
 #     half of #3131 item 2 (the pre-fix warm path named no actionable root at all).
@@ -295,6 +434,36 @@ if [ "$good_rc" -eq 0 ] \
 else
   bad "3131-export-line: expected exit 0 + the verbatim export line for $good (rc=$good_rc)"
   printf '%s\n' "$good_out"
+fi
+
+# 6b-bis. The export line must be PASTEABLE, not merely printed (roborev job 8, finding
+#         3). A root containing a space or a shell metacharacter would, under plain
+#         interpolation, print a command that breaks (or does something else) when
+#         pasted — so the promise "the exact export line" would be false exactly when it
+#         matters. Asserted by EVALUATING the printed line and comparing the resulting
+#         variable to the real path: the strongest available statement of "pasteable".
+spacey="$tmp/fetch space & meta/datasets"
+spacey_wide="$spacey/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294"
+mkdir -p "$spacey_wide" "$spacey/sstables/test_basic/simple_table-0001"
+printf 'synthetic: true\n' >"$spacey/metadata.yml"
+printf '{}\n' >"$spacey_wide/nb-2-big-Data.db.jsonl"
+for c in nb-2-big-Data.db nb-2-big-Index.db nb-2-big-Digest.crc32 nb-2-big-CompressionInfo.db; do
+  : >"$spacey_wide/$c"
+done
+for c in nb-1-big-Data.db nb-1-big-Index.db nb-1-big-Summary.db nb-1-big-Statistics.db; do
+  : >"$spacey/sstables/test_basic/simple_table-0001/$c"
+done
+spacey_line=$(CQLITE_DATASETS_ROOT="$spacey" bash "$FETCH" --verify-only 2>/dev/null \
+  | grep '^  export CQLITE_DATASETS_ROOT=' | sed 's/^  //')
+spacey_eval=$(
+  unset CQLITE_DATASETS_ROOT
+  eval "$spacey_line" 2>/dev/null
+  printf '%s' "${CQLITE_DATASETS_ROOT:-}"
+)
+if [ -n "$spacey_line" ] && [ "$spacey_eval" = "$spacey" ]; then
+  ok "3131-export-quoting: the printed export line round-trips a path with spaces/metacharacters"
+else
+  bad "3131-export-quoting: pasting the line does not reproduce the root (line: '$spacey_line' -> '$spacey_eval')"
 fi
 
 # 6c. #2878 boundary: this change must NOT have touched the rm -rf /

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Regression test for issues #3148 / #3131: the agent-gate fixture preflight must
+# validate the COMMITTED CQL schemas root, not just the fetched SSTable corpus, and
+# the schemas root must be resolved CHECKOUT-RELATIVE rather than by climbing `..`
+# from $CQLITE_DATASETS_ROOT.
+#
+# POSITIVE CONTROL is the point of this file (#3148 AC (c)). The #3148 gap survived
+# because the preflight was only ever observed passing on a good layout: "STATUS: OK"
+# was never proven to be a *decision*. So every case below drives a layout the
+# preflight must REJECT and asserts the rejection text, alongside the happy path.
+#
+# Fast + hermetic by design: the FULL-gate cases exit at the preflight (before any
+# cargo component), and every dataset/schemas root is a temp dir — no real corpus, no
+# network, no Docker.
+#
+# Run standalone:   bash scripts/tests/test_agent_gate_schemas_preflight.sh
+# Or via the gate:  scripts/agent-gate.sh runs it as part of `tooling-tests`.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# #2751 defense-in-depth: never let an inherited summary path be clobbered — every
+# invocation below pins its own.
+unset AGENT_GATE_SUMMARY_FILE
+# A CQLITE_SCHEMAS_ROOT exported by the caller would silently redirect the "checkout
+# default" cases; scrub it so this file tests the committed contract, not the shell.
+unset CQLITE_SCHEMAS_ROOT
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-schemas.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+# The six canonical .cql the gate's dataset-backed components consume. Kept here as a
+# LITERAL list rather than read back from agent-gate.sh: if someone shrinks
+# CANONICAL_SCHEMA_FILES, this file must redden, not agree with the shrink.
+CANONICAL=(basic-types.cql da-test.cql time-series.cql wide-table-bti.cql collections.cql wide-rows.cql)
+
+# A dataset root whose canonical corpus IS present, so the #2078 corpus guard is
+# satisfied and the run reaches the #3148 schemas guard.
+ds_corpus="$tmp/ds-corpus"
+mkdir -p "$ds_corpus/sstables/test_basic/simple_table-0001"
+: >"$ds_corpus/sstables/test_basic/simple_table-0001/nb-1-big-Data.db"
+
+# Hostile schemas roots.
+schemas_empty="$tmp/schemas-empty"                 # readable dir, zero fixtures
+mkdir -p "$schemas_empty"
+schemas_partial="$tmp/schemas-partial"             # SOME fixtures — the case a
+mkdir -p "$schemas_partial"                        # directory-existence check misses
+: >"$schemas_partial/basic-types.cql"
+: >"$schemas_partial/collections.cql"
+
+hook_field() {  # hook_field <field> <output>
+  printf '%s\n' "$2" | grep "^$1: " | sed "s/^$1: //"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Hidden --preflight-schemas hook: the PURE decision, both ways.
+# ---------------------------------------------------------------------------
+good_out=$(bash "$GATE" --preflight-schemas 2>/dev/null)
+if [ "$(hook_field STATUS "$good_out")" = OK ] \
+   && [ "$(hook_field ROOT "$good_out")" = "$REPO/test-data/schemas" ] \
+   && [ "$(hook_field SOURCE "$good_out")" = "checkout-relative" ]; then
+  ok "3148-hook-good: checkout resolves the committed schemas root -> STATUS OK"
+else
+  bad "3148-hook-good: expected STATUS OK + checkout-relative $REPO/test-data/schemas"
+  printf '%s\n' "$good_out"
+fi
+
+empty_out=$(CQLITE_SCHEMAS_ROOT="$schemas_empty" bash "$GATE" --preflight-schemas 2>/dev/null)
+empty_missing=$(hook_field MISSING "$empty_out")
+missing_all=1
+for f in "${CANONICAL[@]}"; do
+  grep -qw -- "$f" <<<"$empty_missing" || missing_all=0
+done
+if [ "$(hook_field STATUS "$empty_out")" = FAIL ] && [ "$missing_all" -eq 1 ] \
+   && [ "$(hook_field SOURCE "$empty_out")" = "CQLITE_SCHEMAS_ROOT override" ]; then
+  ok "3148-hook-empty: schemas-less root -> STATUS FAIL naming all ${#CANONICAL[@]} unreadable .cql"
+else
+  bad "3148-hook-empty: expected STATUS FAIL listing every canonical .cql"
+  printf '%s\n' "$empty_out"
+fi
+
+# A directory-EXISTENCE check would pass this root: it exists and holds two of the six.
+# Only a per-FILE readability check rejects it, naming exactly the four absentees.
+partial_out=$(CQLITE_SCHEMAS_ROOT="$schemas_partial" bash "$GATE" --preflight-schemas 2>/dev/null)
+partial_missing=$(hook_field MISSING "$partial_out")
+if [ "$(hook_field STATUS "$partial_out")" = FAIL ] \
+   && grep -qw -- 'da-test.cql' <<<"$partial_missing" \
+   && grep -qw -- 'wide-rows.cql' <<<"$partial_missing" \
+   && ! grep -qw -- 'basic-types.cql' <<<"$partial_missing" \
+   && ! grep -qw -- 'collections.cql' <<<"$partial_missing"; then
+  ok "3148-hook-partial: per-FILE readability rejects a present-but-incomplete root"
+else
+  bad "3148-hook-partial: expected FAIL naming only the absent files (got '$partial_missing')"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The FULL gate FAILS CLOSED, with a marker DISTINGUISHABLE from #2078's.
+#    apply_schemas_preflight fires before any cargo component, so this is fast.
+# ---------------------------------------------------------------------------
+full_fail="$tmp/3148-full-fail.txt"
+CQLITE_GATE_DISABLE_CAP=1 CQLITE_DATASETS_ROOT="$ds_corpus" \
+  CQLITE_SCHEMAS_ROOT="$schemas_empty" AGENT_GATE_SUMMARY_FILE="$full_fail" \
+  bash "$GATE" >/dev/null 2>&1
+full_rc=$?
+if [ "$full_rc" -ne 0 ] \
+   && grep -q "^missing-schemas: FAIL-CLOSED (#3148)" "$full_fail" 2>/dev/null \
+   && grep -q "^RESULT: FAIL" "$full_fail" 2>/dev/null \
+   && ! grep -q "^RESULT: PASS" "$full_fail" 2>/dev/null; then
+  ok "3148-full-fail: FULL gate FAILs CLOSED on a schemas-less root (marker + RESULT: FAIL, no cargo)"
+else
+  bad "3148-full-fail: expected non-zero exit + missing-schemas FAIL-CLOSED + RESULT: FAIL (rc=$full_rc)"
+  cat "$full_fail" 2>/dev/null
+fi
+
+# The two causes must be separable in a pasted block: a schemas failure must NEVER
+# stamp #2078's corpus marker (the corpus here is deliberately complete).
+if ! grep -q "missing-fixtures:" "$full_fail" 2>/dev/null; then
+  ok "3148-marker-distinct: schemas failure carries no missing-fixtures line (#2078 vs #3148 separable)"
+else
+  bad "3148-marker-distinct: the schemas failure also stamped #2078's missing-fixtures marker"
+fi
+
+# AC (b): the failure text names the exact expected ABSOLUTE path and the fix command.
+if grep -q "$schemas_empty/basic-types.cql" "$full_fail" 2>/dev/null \
+   && grep -q "unset CQLITE_SCHEMAS_ROOT" "$full_fail" 2>/dev/null \
+   && grep -q "restore --source=HEAD -- test-data/schemas" "$full_fail" 2>/dev/null; then
+  ok "3148-remedy: block names the exact absolute path + both fix commands"
+else
+  bad "3148-remedy: expected the absolute .cql path and the remedy commands in the block"
+  cat "$full_fail" 2>/dev/null
+fi
+
+# ---------------------------------------------------------------------------
+# 3. AC (g): --lite and --only stay LENIENT (unchanged from #2078's contract).
+# ---------------------------------------------------------------------------
+lite_block="$tmp/3148-lite.txt"
+CQLITE_DATASETS_ROOT="$ds_corpus" CQLITE_SCHEMAS_ROOT="$schemas_empty" \
+  AGENT_GATE_SUMMARY_FILE="$lite_block" \
+  bash "$GATE" --lite --emit-summary-selftest >/dev/null 2>&1
+lite_rc=$?
+if [ "$lite_rc" -eq 0 ] \
+   && grep -q "AGENT-GATE LITE SUMMARY" "$lite_block" 2>/dev/null \
+   && ! grep -q "missing-schemas:" "$lite_block" 2>/dev/null; then
+  ok "3148-lite: --lite unaffected by an unreachable schemas root (clean LITE block, no marker)"
+else
+  bad "3148-lite: --lite must stay lenient (rc=$lite_rc)"
+  cat "$lite_block" 2>/dev/null
+fi
+
+# The arg dispatch is a single `case "$1"`, so `--only X --preflight-schemas` is not
+# expressible; the hook's optional 2nd arg seeds ONLY, exercising the SAME pure
+# decision the real --only run consumes. `core-tests` is deliberately a DATASET
+# component: even the selection that most needs schemas must stay lenient under --only.
+only_status=$(CQLITE_SCHEMAS_ROOT="$schemas_empty" \
+  bash "$GATE" --preflight-schemas core-tests 2>/dev/null | grep '^STATUS:' | sed 's/^STATUS: //')
+if [ "$only_status" = OK ]; then
+  ok "3148-only: --only stays lenient (STATUS OK even with the schemas root unreachable)"
+else
+  bad "3148-only: expected the --only selection to stay lenient (got '$only_status')"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. AC (f): the symlink trap is GONE, not papered over.
+#
+#    `join("..")` is not a lexical parent at the syscall level: the kernel resolves
+#    `datasets/..` against the SYMLINK TARGET's parent. So a corpus reached through a
+#    symlinked `datasets` used to mis-resolve `datasets/../schemas` silently. The fix
+#    removes all `..` climbing, which is only meaningful if the schemas decision is
+#    INDEPENDENT of $CQLITE_DATASETS_ROOT — asserted directly here across three
+#    datasets layouts (real dir / symlink-to-elsewhere / nonexistent).
+# ---------------------------------------------------------------------------
+sym_parent="$tmp/sym-parent"
+mkdir -p "$sym_parent"
+ln -s "$ds_corpus" "$sym_parent/datasets"
+indep=1
+for layout in "$ds_corpus" "$sym_parent/datasets" "$tmp/does-not-exist/datasets"; do
+  st=$(CQLITE_DATASETS_ROOT="$layout" bash "$GATE" --preflight-schemas 2>/dev/null \
+    | grep '^STATUS:' | sed 's/^STATUS: //')
+  rt=$(CQLITE_DATASETS_ROOT="$layout" bash "$GATE" --preflight-schemas 2>/dev/null \
+    | grep '^ROOT:' | sed 's/^ROOT: //')
+  { [ "$st" = OK ] && [ "$rt" = "$REPO/test-data/schemas" ]; } || indep=0
+done
+if [ "$indep" -eq 1 ]; then
+  ok "3148-symlink-independence: schemas root is identical for real/symlinked/absent datasets roots"
+else
+  bad "3148-symlink-independence: the schemas root still varies with CQLITE_DATASETS_ROOT"
+fi
+
+# The structural half of AC (f)/(d): no code may reintroduce the `..` climb. Comment
+# text is exempt (the doc comments deliberately quote the retired idiom); a real
+# expression is a hard failure. `grep -v` on a leading `//`/`#` comment marker after
+# the `path:line:` prefix is what makes that distinction.
+climbs=$(grep -rn --include='*.rs' 'join("\.\./schemas")' "$REPO" 2>/dev/null \
+  | grep -v ':[0-9]*: *//' || true)
+if [ -z "$climbs" ]; then
+  ok "3148-no-dotdot-climb: zero open-coded join(\"../schemas\") expressions in Rust code"
+else
+  bad "3148-no-dotdot-climb: an open-coded ../schemas climb was reintroduced:"
+  printf '%s\n' "$climbs"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. AC (d)/(e): ONE shared resolution file, included by every historical site.
+# ---------------------------------------------------------------------------
+shared="$REPO/test-data/support/fixture_roots.rs"
+if [ -f "$shared" ] \
+   && grep -q 'pub fn schemas_root_resolved' "$shared" \
+   && grep -q 'pub fn datasets_root_if_present' "$shared" \
+   && grep -q 'pub fn datasets_root' "$shared"; then
+  ok "3148-shared-file: test-data/support/fixture_roots.rs defines the single contract"
+else
+  bad "3148-shared-file: the shared fixture-roots module is missing or incomplete"
+fi
+
+sites_ok=1
+for site in \
+  cqlite-core/benches/fixtures/mod.rs \
+  cqlite-core/tests/dead_cache_delete_tests.rs \
+  cqlite-core/tests/observability_correctness.rs \
+  cqlite-cli/benches/export_csv.rs
+do
+  grep -q 'test-data/support/fixture_roots.rs' "$REPO/$site" || { sites_ok=0; echo "   (no include: $site)"; }
+done
+if [ "$sites_ok" -eq 1 ]; then
+  ok "3148-all-sites: all four historical call sites include the shared module"
+else
+  bad "3148-all-sites: a call site no longer resolves roots through the shared module"
+fi
+
+# No second copy of the resolution may reappear WHERE #3148 removed one. Scope: the two
+# bench trees plus the three files that carried the divergent `datasets_root()` copies.
+# The wider `cqlite-core/tests/**` and `src/**` inline suites keep their own ad-hoc env
+# reads — out of scope for #3148 (which names three copies), so asserting over them
+# would be a scope claim this change does not make.
+dupes=$(grep -rln --include='*.rs' 'env::var("CQLITE_DATASETS_ROOT")' \
+  "$REPO/cqlite-core/benches" "$REPO/cqlite-cli/benches" \
+  "$REPO/cqlite-core/tests/dead_cache_delete_tests.rs" \
+  "$REPO/cqlite-core/tests/observability_correctness.rs" 2>/dev/null || true)
+if [ -z "$dupes" ]; then
+  ok "3148-no-dupe-root: no bench / migrated test re-reads CQLITE_DATASETS_ROOT directly"
+else
+  bad "3148-no-dupe-root: a datasets-root resolution copy reappeared:"
+  printf '%s\n' "$dupes"
+fi
+
+printf '\n%s\n' "----------------------------------------"
+printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -453,6 +453,38 @@ else
   cat "$optout_full" 2>/dev/null
 fi
 
+# 2e. NO environment value may turn the fail-closed guard into a soft return (requirement 8).
+#     The report-only mode began life as `${_SCHEMAS_PREFLIGHT_REPORT_ONLY:-}`, never
+#     initialized — so an INHERITED or EXPORTED value converted the FULL gate's `exit 1` into
+#     `return 1` at a bare call site with no errexit, the run continued, and the
+#     `missing-schemas: FAIL-CLOSED` text could be stamped inside a block reading
+#     `RESULT: PASS`. It is now a POSITIONAL ARGUMENT, which no export can supply. This case
+#     exports the retired name anyway — and any other plausible spelling — because the point is
+#     that the ENVIRONMENT cannot reach the mode at all, not that one variable was renamed.
+ro_ok=1
+for evil in _SCHEMAS_PREFLIGHT_REPORT_ONLY SCHEMAS_PREFLIGHT_REPORT_ONLY report_only mode; do
+  ro_full="$tmp/3148-report-only-$evil.txt"
+  env "$evil=1" CQLITE_GATE_DISABLE_CAP=1 CQLITE_DATASETS_ROOT="$ds_corpus" \
+    CQLITE_SCHEMAS_ROOT="$schemas_empty" AGENT_GATE_SUMMARY_FILE="$ro_full" \
+    timeout 180 bash "$GATE" >/dev/null 2>&1
+  ro_rc=$?
+  if [ "$ro_rc" -ne 0 ] \
+     && grep -q "^missing-schemas: FAIL-CLOSED (#3148)" "$ro_full" 2>/dev/null \
+     && grep -q "^RESULT: FAIL" "$ro_full" 2>/dev/null \
+     && ! grep -q "^RESULT: PASS" "$ro_full" 2>/dev/null; then
+    :
+  else
+    ro_ok=0
+    echo "   (exported $evil=1 weakened the guard: rc=$ro_rc)"
+    cat "$ro_full" 2>/dev/null
+  fi
+done
+if [ "$ro_ok" -eq 1 ]; then
+  ok "3148-no-env-report-only: no exported variable can turn the fail-closed guard into a soft return"
+else
+  bad "3148-no-env-report-only: an environment value defeated the schemas fail-closed guard (requirement 8)"
+fi
+
 # ---------------------------------------------------------------------------
 # 3. AC (g): --lite and --only stay LENIENT (unchanged from #2078's contract).
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -405,6 +405,55 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 2c. The FAIL emit must name the ACTUAL rejection reason (spec-auditor, AC (b) partial).
+#     The reject branch hard-coded "a RELATIVE schemas root ..." and stamped `... relative
+#     CQLITE_SCHEMAS_ROOT rejected` for EVERY rejection — FALSE for a control-character
+#     value. It was untested because the round-3 control-char coverage went through the pure
+#     `--preflight-schemas` hook, which never reaches the emit. So this case drives the REAL
+#     FULL gate and asserts the emitted block, which is the only place the wording lives.
+# ---------------------------------------------------------------------------
+cc_emit_root="$tmp/cc-emit"
+mkdir -p "$cc_emit_root"
+for f in "${CANONICAL[@]}"; do printf -- '-- synthetic\n' >"$cc_emit_root/$f"; done
+cc_full="$tmp/3148-cc-full.txt"
+CQLITE_GATE_DISABLE_CAP=1 CQLITE_DATASETS_ROOT="$ds_corpus" \
+  CQLITE_SCHEMAS_ROOT="$cc_emit_root"$'\n' AGENT_GATE_SUMMARY_FILE="$cc_full" \
+  timeout 180 bash "$GATE" >"$tmp/3148-cc-full.out" 2>&1
+cc_full_rc=$?
+if [ "$cc_full_rc" -ne 0 ] \
+   && grep -q "^missing-schemas: FAIL-CLOSED (#3148)" "$cc_full" 2>/dev/null \
+   && grep -q "contains a control character" "$cc_full" 2>/dev/null \
+   && ! grep -q "relative CQLITE_SCHEMAS_ROOT rejected" "$cc_full" 2>/dev/null \
+   && grep -q "must not contain control characters" "$tmp/3148-cc-full.out" 2>/dev/null \
+   && ! grep -q "a RELATIVE schemas root" "$tmp/3148-cc-full.out" 2>/dev/null \
+   && grep -q "^RESULT: FAIL" "$cc_full" 2>/dev/null; then
+  ok "3148-cc-emit-wording: the real FAIL emit names the control-character cause, not a false 'relative' one"
+else
+  bad "3148-cc-emit-wording: the emitted block/stderr misnames the rejection cause (rc=$cc_full_rc)"
+  cat "$cc_full" 2>/dev/null
+fi
+
+# 2d. The #2078 opt-out must NOT buy a pass against a schemas-less root (spec-auditor (v)).
+#     The schemas guard deliberately has no opt-out — the fetched corpus is legitimately
+#     absent sometimes, committed source in a checkout never is. The code ignores
+#     AGENT_GATE_ALLOW_MISSING_FIXTURES, but nothing asserted it, so a future "consistency"
+#     patch wiring it in would land GREEN.
+optout_full="$tmp/3148-optout-full.txt"
+CQLITE_GATE_DISABLE_CAP=1 AGENT_GATE_ALLOW_MISSING_FIXTURES=1 \
+  CQLITE_DATASETS_ROOT="$ds_corpus" CQLITE_SCHEMAS_ROOT="$schemas_empty" \
+  AGENT_GATE_SUMMARY_FILE="$optout_full" timeout 180 bash "$GATE" >/dev/null 2>&1
+optout_full_rc=$?
+if [ "$optout_full_rc" -ne 0 ] \
+   && grep -q "^missing-schemas: FAIL-CLOSED (#3148)" "$optout_full" 2>/dev/null \
+   && grep -q "^RESULT: FAIL" "$optout_full" 2>/dev/null \
+   && ! grep -q "^RESULT: PASS" "$optout_full" 2>/dev/null; then
+  ok "3148-no-optout: AGENT_GATE_ALLOW_MISSING_FIXTURES=1 does NOT buy a pass on a schemas-less root"
+else
+  bad "3148-no-optout: the #2078 opt-out must not weaken the schemas guard (rc=$optout_full_rc)"
+  cat "$optout_full" 2>/dev/null
+fi
+
+# ---------------------------------------------------------------------------
 # 3. AC (g): --lite and --only stay LENIENT (unchanged from #2078's contract).
 # ---------------------------------------------------------------------------
 lite_block="$tmp/3148-lite.txt"
@@ -671,6 +720,59 @@ if [ "$sym_rc" -eq 0 ] \
 else
   bad "3131-symlinked-root: expected exit 0 and a non-zero Data.db count (rc=$sym_rc)"
   printf '%s\n' "$sym_out"
+fi
+
+# 6d. The WARM-CACHE call site and the "NOT the checkout default" NOTE (spec-auditor,
+#     requirement 12 partial). Every case above drives `--verify-only`; NOTHING exercised
+#     `guarantee_usable_root "warm cache, download skipped"` or the divergence NOTE, so
+#     deleting either line reddened nothing — and the warm-cache no-op is EXACTLY #3131 item
+#     2's original defect ("a green fetch is not evidence the tree is usable").
+#
+#     Hermetic: the root carries content AND a `.dataset-pin` matching the TRACKED pin, so
+#     `has_required_dataset` succeeds and the download is skipped. A failing `curl` stub is
+#     first on PATH so that if the pin ever stops matching, the case dies WITHOUT network and
+#     WITHOUT reaching `rm -rf` — a self-test must not be one typo away from a download.
+warm="$tmp/fetch-warm/datasets"
+warm_wide="$warm/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294"
+mkdir -p "$warm_wide" "$warm/sstables/test_basic/simple_table-0001"
+printf 'synthetic: true\n' >"$warm/metadata.yml"
+printf '{}\n' >"$warm_wide/nb-2-big-Data.db.jsonl"
+for c in nb-2-big-Data.db nb-2-big-Index.db nb-2-big-Digest.crc32 nb-2-big-CompressionInfo.db; do
+  : >"$warm_wide/$c"
+done
+for c in nb-1-big-Data.db nb-1-big-Index.db nb-1-big-Summary.db nb-1-big-Statistics.db; do
+  : >"$warm/sstables/test_basic/simple_table-0001/$c"
+done
+# The pin comes from the tracked source of truth, never hard-coded (issue #2646).
+# shellcheck disable=SC1090
+. "$REPO/test-data/dataset-pin.env"
+{ echo "tag=${DATASET_TAG}"; echo "asset=${DATASET_ASSET}"; echo "sha256=${DATASET_SHA256}"; } >"$warm/.dataset-pin"
+curl_stub="$tmp/curl-stub"
+mkdir -p "$curl_stub"
+printf '#!/bin/sh\necho "SELFTEST GUARD: curl invoked — the warm-cache path was NOT taken" >&2\nexit 1\n' >"$curl_stub/curl"
+chmod +x "$curl_stub/curl"
+warm_out=$(cd "$REPO" && PATH="$curl_stub:$PATH" CQLITE_DATASETS_ROOT="$warm" bash "$FETCH" 2>&1)
+warm_rc=$?
+if [ "$warm_rc" -eq 0 ] \
+   && grep -q "already present in $warm; skipping download" <<<"$warm_out" \
+   && grep -q "Dataset root VERIFIED (warm cache, download skipped)" <<<"$warm_out" \
+   && grep -q "^  export CQLITE_DATASETS_ROOT=$warm$" <<<"$warm_out" \
+   && ! grep -q "SELFTEST GUARD" <<<"$warm_out"; then
+  ok "3131-warm-cache: the warm-skip path VERIFIES the root and prints the export line it guarantees"
+else
+  bad "3131-warm-cache: expected a verified warm-cache skip naming the root (rc=$warm_rc)"
+  printf '%s\n' "$warm_out" | head -8
+fi
+
+# …and the divergence NOTE: the populated root here is NOT the checkout default, which is the
+# fact that made the documented `CQLITE_DATASETS_ROOT=$PWD/test-data/datasets` silently wrong.
+if grep -q "NOTE: this run populated $warm, NOT the checkout default" <<<"$warm_out" \
+   && grep -q "NOTE:   $REPO/test-data/datasets" <<<"$warm_out" \
+   && grep -q "NOTE: CQL schema fixtures (test-data/schemas) are committed source" <<<"$warm_out"; then
+  ok "3131-warm-cache-note: the run names the root it populated AND the checkout default it did not"
+else
+  bad "3131-warm-cache-note: the divergence NOTE (or the schemas NOTE) is missing"
+  printf '%s\n' "$warm_out" | head -12
 fi
 
 # 6c. #2878 boundary: this change must NOT have touched the rm -rf /

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -140,12 +140,12 @@ else
   printf '%s\n' "$rel_out"
 fi
 
-# …and it must not smuggle the relative string into the report as an "absolute path".
-if ! grep -q 'expected absolute path: packaged/schemas' <<<"$rel_out"; then
-  ok "3148-relative-override: no relative path is ever labelled absolute (AC (b))"
-else
-  bad "3148-relative-override: a relative path was reported as the expected absolute path"
-fi
+# NOTE: the AC-(b) "never labelled absolute" assert deliberately does NOT live here. It
+# used to, matching against `$rel_out` — but `expected absolute path:` is
+# apply_schemas_preflight STDERR, and this hook prints only STATUS/ROOT/SOURCE/REJECT/
+# MISSING on stdout, so the pattern could never appear and the case passed unconditionally,
+# INCLUDING after a full revert of the fix. It now runs against the real FULL-gate emit
+# below, where the string can actually occur.
 
 # Every relative shape, not just the bare one; and a blank/whitespace value is NOT an
 # override at all (a scripting accident), matching the Rust side's `trim().is_empty()`.
@@ -166,12 +166,51 @@ else
   bad "3148-relative-shapes: relative/blank handling diverges from the Rust resolver"
 fi
 
+# A WHITESPACE-ONLY override must be treated as UNSET, matching the Rust resolver's
+# `v.trim().is_empty()` (roborev job 9, finding 1). The two mirrors DID disagree here:
+# `_gate_schemas_override_reject` trimmed before deciding presence, while
+# `_gate_schemas_root`/`_gate_schemas_root_source` tested the RAW `-n` value — so a
+# directory literally named "   " would have been reported as the override while Rust read
+# the checkout's schemas. Presence is now normalized once, in `_gate_schemas_override`.
+#
+# PREMISE CORRECTION, recorded so nobody re-derives it: roborev's exploit path ("if a
+# relative directory named only with whitespace exists") is NOT reachable from a caller's
+# CWD, because agent-gate.sh `cd`s to its OWN repository root before anything else
+# (scripts/agent-gate.sh:410). The whitespace-named directory would have to exist in the
+# repo root itself. The inconsistency was real and is fixed; this case pins the OBSERVABLE
+# rule (whitespace-only ⇒ unset ⇒ checkout-relative), and the discriminating control for
+# the trim rule lives on the Rust side, where the resolver is pure and takes the value as
+# an argument (`absent_or_blank_override_resolves_to_the_checkout`).
+ws_dir_present="$tmp/ws-present"
+mkdir -p "$ws_dir_present/   "
+# `$'\t'` — a REAL tab. A literal '\t' would be a two-character RELATIVE path, which is
+# correctly REJECTED, so writing it that way tests the wrong rule (it did, first try).
+for raw in '   ' $'\t' ' ' $'\n'; do
+  ws_out=$(CQLITE_SCHEMAS_ROOT="$raw" bash "$GATE" --preflight-schemas 2>/dev/null)
+  if [ "$(hook_field STATUS "$ws_out")" = OK ] \
+     && [ "$(hook_field SOURCE "$ws_out")" = "checkout-relative" ] \
+     && [ "$(hook_field ROOT "$ws_out")" = "$REPO/test-data/schemas" ] \
+     && [ -z "$(hook_field REJECT "$ws_out")" ]; then
+    :
+  else
+    rel_shapes_ok=0
+    echo "   (whitespace-only value '$raw' was not treated as unset)"
+    printf '%s\n' "$ws_out"
+  fi
+done
+if [ "$rel_shapes_ok" -eq 1 ]; then
+  ok "3148-whitespace-override: a whitespace-only value is unset (trim rule, single-sourced presence)"
+else
+  bad "3148-whitespace-override: whitespace-only handling diverges from the Rust resolver"
+fi
+
 # The FULL gate must FAIL CLOSED on the relative override too — with its own reason, not
 # a misleading "missing files" list (the checkout's fixtures are in fact complete).
 rel_full="$tmp/3148-rel-full.txt"
+rel_full_out="$tmp/3148-rel-full.out"   # stdout+stderr: where `expected absolute path:` lives
 CQLITE_GATE_DISABLE_CAP=1 CQLITE_DATASETS_ROOT="$ds_corpus" \
   CQLITE_SCHEMAS_ROOT="packaged/schemas" AGENT_GATE_SUMMARY_FILE="$rel_full" \
-  bash "$GATE" >/dev/null 2>&1
+  timeout 180 bash "$GATE" >"$rel_full_out" 2>&1
 rel_full_rc=$?
 if [ "$rel_full_rc" -ne 0 ] \
    && grep -q "^missing-schemas: FAIL-CLOSED (#3148)" "$rel_full" 2>/dev/null \
@@ -184,14 +223,34 @@ else
   cat "$rel_full" 2>/dev/null
 fi
 
+# AC (b), asserted where the string can actually appear: no relative value may ever be
+# printed on an "expected absolute path" line, in the SUMMARY or on stderr. Revert the
+# reject branch and `_gate_schemas_root` resolves `packaged/schemas`, all six fixtures are
+# reported missing, and stderr prints
+# `expected absolute path: packaged/schemas/basic-types.cql` — so this case discriminates.
+if ! grep -q 'expected absolute path: *packaged/schemas' "$rel_full_out" 2>/dev/null \
+   && ! grep -q 'expected absolute path: *packaged/schemas' "$rel_full" 2>/dev/null \
+   && grep -q 'must be an ABSOLUTE path' "$rel_full_out" 2>/dev/null; then
+  ok "3148-relative-absolute-label: no relative path is ever labelled absolute (AC (b), real emit)"
+else
+  bad "3148-relative-absolute-label: a relative path reached an 'expected absolute path' line"
+  grep -n 'expected absolute path' "$rel_full_out" "$rel_full" 2>/dev/null | head -5
+fi
+
 # ---------------------------------------------------------------------------
 # 2. The FULL gate FAILS CLOSED, with a marker DISTINGUISHABLE from #2078's.
 #    apply_schemas_preflight fires before any cargo component, so this is fast.
+#
+#    `timeout 180` on the real gate invocations here and below is part of the contract, not
+#    defensive padding: these cases assert the run exits AT the preflight, so a run that
+#    does not is a FAILURE — and without a bound the regression it catches (the guard
+#    letting the layout through) would instead launch a 15-20 minute full gate inside a
+#    self-test. Observed while proving these cases discriminate.
 # ---------------------------------------------------------------------------
 full_fail="$tmp/3148-full-fail.txt"
 CQLITE_GATE_DISABLE_CAP=1 CQLITE_DATASETS_ROOT="$ds_corpus" \
   CQLITE_SCHEMAS_ROOT="$schemas_empty" AGENT_GATE_SUMMARY_FILE="$full_fail" \
-  bash "$GATE" >/dev/null 2>&1
+  timeout 180 bash "$GATE" >/dev/null 2>&1
 full_rc=$?
 if [ "$full_rc" -ne 0 ] \
    && grep -q "^missing-schemas: FAIL-CLOSED (#3148)" "$full_fail" 2>/dev/null \
@@ -517,6 +576,25 @@ if [ -n "$spacey_line" ] && [ "$spacey_eval" = "$spacey" ]; then
   ok "3131-export-quoting: the printed export line round-trips a path with spaces/metacharacters"
 else
   bad "3131-export-quoting: pasting the line does not reproduce the root (line: '$spacey_line' -> '$spacey_eval')"
+fi
+
+# 6b-ter. A SYMLINKED dataset root must verify, not be reported unusable (roborev job 9,
+#         finding 2). `find <symlink>` without `-H` stats the link and never descends, so
+#         every count came back 0 and `has_required_content` rejected a perfectly good
+#         corpus — and `ln -s <real corpus> <somewhere>/datasets` is precisely the layout
+#         #3148 documents operators reaching for.
+symparent="$tmp/symlinked"
+mkdir -p "$symparent"
+ln -s "$good" "$symparent/datasets"
+sym_out=$(CQLITE_DATASETS_ROOT="$symparent/datasets" bash "$FETCH" --verify-only 2>&1)
+sym_rc=$?
+if [ "$sym_rc" -eq 0 ] \
+   && grep -q "Dataset root VERIFIED" <<<"$sym_out" \
+   && ! grep -q "0 \*-Data.db present" <<<"$sym_out"; then
+  ok "3131-symlinked-root: a datasets root that is itself a symlink verifies with a real count"
+else
+  bad "3131-symlinked-root: expected exit 0 and a non-zero Data.db count (rc=$sym_rc)"
+  printf '%s\n' "$sym_out"
 fi
 
 # 6c. #2878 boundary: this change must NOT have touched the rm -rf /

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -250,6 +250,63 @@ else
   printf '%s\n' "$dupes"
 fi
 
+# ---------------------------------------------------------------------------
+# 6. #3131 items 1-2: fetch-datasets.sh must never report success while leaving a
+#    root an operator cannot use, and must PRINT the export line it guarantees.
+#    Driven through --verify-only, which performs no download/extraction/removal —
+#    so this stays hermetic and never touches the real corpus or the tree.
+# ---------------------------------------------------------------------------
+FETCH="$REPO/test-data/scripts/fetch-datasets.sh"
+
+# 6a. Hollow root (exists, empty): must FAIL LOUDLY with a remedy — never exit 0.
+hollow="$tmp/hollow/datasets"
+mkdir -p "$hollow"
+hollow_out=$(CQLITE_DATASETS_ROOT="$hollow" bash "$FETCH" --verify-only 2>&1)
+hollow_rc=$?
+if [ "$hollow_rc" -ne 0 ] \
+   && grep -q "does not hold a usable dataset corpus" <<<"$hollow_out" \
+   && grep -q "remedy: re-run this script with the pin cleared" <<<"$hollow_out"; then
+  ok "3131-hollow-root: an unusable root exits non-zero with a remedy (never a green no-op)"
+else
+  bad "3131-hollow-root: expected non-zero + remedy text (rc=$hollow_rc)"
+  printf '%s\n' "$hollow_out"
+fi
+
+# 6b. A root holding the required content must report success AND print the exact
+#     `export CQLITE_DATASETS_ROOT=<absolute path>` line it guarantees — the missing
+#     half of #3131 item 2 (the pre-fix warm path named no actionable root at all).
+good="$tmp/fetch-good/datasets"
+wide="$good/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294"
+mkdir -p "$wide" "$good/sstables/test_basic/simple_table-0001"
+printf 'synthetic: true\n' >"$good/metadata.yml"
+printf '{}\n' >"$wide/nb-2-big-Data.db.jsonl"
+for c in nb-2-big-Data.db nb-2-big-Index.db nb-2-big-Digest.crc32 nb-2-big-CompressionInfo.db; do
+  : >"$wide/$c"
+done
+for c in nb-1-big-Data.db nb-1-big-Index.db nb-1-big-Summary.db nb-1-big-Statistics.db; do
+  : >"$good/sstables/test_basic/simple_table-0001/$c"
+done
+good_out=$(CQLITE_DATASETS_ROOT="$good" bash "$FETCH" --verify-only 2>&1)
+good_rc=$?
+if [ "$good_rc" -eq 0 ] \
+   && grep -q "^  export CQLITE_DATASETS_ROOT=$good$" <<<"$good_out" \
+   && grep -q "Dataset root VERIFIED" <<<"$good_out"; then
+  ok "3131-export-line: a usable root is confirmed and prints its exact export line"
+else
+  bad "3131-export-line: expected exit 0 + the verbatim export line for $good (rc=$good_rc)"
+  printf '%s\n' "$good_out"
+fi
+
+# 6c. #2878 boundary: this change must NOT have touched the rm -rf /
+#     restore_ci_tracked_dataset_files behavior. Both must still be present verbatim,
+#     so a future reader can see the sibling defect was left to its own delivery.
+if grep -q 'rm -rf "${DATASET_ROOT}"' "$FETCH" \
+   && grep -q '\[ -n "${CI:-}" \] || return 0' "$FETCH"; then
+  ok "3131-2878-boundary: rm -rf + restore_ci_tracked_dataset_files left untouched (#2878)"
+else
+  bad "3131-2878-boundary: the #2878-owned behavior was modified by this change"
+fi
+
 printf '\n%s\n' "----------------------------------------"
 printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -3,6 +3,36 @@ set -euo pipefail
 
 # Fetch canonical Cassandra 5 datasets into test-data/datasets
 # Usage: DATASET_TAG=datasets-v3 DATASET_ASSET=cassandra5-small-full-v3.5.tar.gz DATASET_SHA256=414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 ./test-data/scripts/fetch-datasets.sh
+#        ./test-data/scripts/fetch-datasets.sh --verify-only   # report usability only; mutates nothing
+
+# ---- STRICT argument validation, FIRST, before ANY filesystem work -------------
+# This script's default path is DESTRUCTIVE (`rm -rf "${DATASET_ROOT}"` before
+# extraction). Until #3131 it accepted no flags, so an unrecognized argument was
+# harmless. Adding `--verify-only` created a data-loss hazard: matching the flag only
+# as `$1` (or ignoring extra args) means `--quiet --verify-only`, `-verify-only`, or any
+# typo SILENTLY selects the destructive path and rm -rf's the operator's corpus while
+# they believe they asked for a read-only probe. Introducing a flag obliges fail-closed
+# rejection of EVERY unrecognized argument, so parsing happens here — before the pin
+# load, before root canonicalization (which used to `mkdir -p` the parent), before
+# anything can touch the filesystem.
+VERIFY_ONLY=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --verify-only) VERIFY_ONLY=1; shift ;;
+    -h|--help)
+      echo "usage: fetch-datasets.sh [--verify-only]"
+      echo "  --verify-only  report whether \$CQLITE_DATASETS_ROOT is usable and print the"
+      echo "                 guaranteed export line; downloads/extracts/removes/creates nothing."
+      exit 0 ;;
+    *)
+      echo "ERROR: unrecognized argument '$1'" >&2
+      echo "ERROR: refusing to continue — this script's default path is DESTRUCTIVE" >&2
+      echo "ERROR: (rm -rf \"\${DATASET_ROOT}\" before extraction), so an unrecognized" >&2
+      echo "ERROR: argument must never be silently ignored." >&2
+      echo "ERROR: usage: fetch-datasets.sh [--verify-only]" >&2
+      exit 2 ;;
+  esac
+done
 
 # The canonical asset/tag/sha live in ONE tracked file (issue #2646):
 # test-data/dataset-pin.env. Load it for the defaults so this helper never
@@ -72,7 +102,18 @@ canonicalize_dataset_root() {
   [ "${base}" = "datasets" ] \
     || fail_unsafe_dataset_root "final path component must be 'datasets'"
 
-  mkdir -p "${parent}"
+  # --verify-only promises to mutate NOTHING (#3131 blocker B2): this `mkdir -p` runs
+  # BEFORE the mode dispatch, so an unqualified call created the parent of a root it was
+  # about to report unusable (e.g. probing /mnt/corpus/v4/datasets on a box where
+  # /mnt/corpus is empty created /mnt/corpus/v4). Under --verify-only we therefore never
+  # create anything: a parent that does not exist simply means the root is unusable, and
+  # saying so is the probe's whole job.
+  if [ "${VERIFY_ONLY}" = 1 ]; then
+    [ -d "${parent}" ] \
+      || fail_unsafe_dataset_root "parent directory ${parent} does not exist — root unusable (nothing created: --verify-only)"
+  else
+    mkdir -p "${parent}"
+  fi
   parent_abs="$(cd "${parent}" && pwd -P)"
   [ "${parent_abs}" != "/" ] \
     || fail_unsafe_dataset_root "refusing to replace a top-level /datasets directory"
@@ -223,7 +264,12 @@ guarantee_usable_root() {
   echo "Dataset root VERIFIED (${phase}): ${DATASET_ROOT} — ${data_count} *-Data.db present"
   echo "Use EXACTLY this root (the only one this run guarantees):"
   echo
-  echo "  export CQLITE_DATASETS_ROOT=${DATASET_ROOT}"
+  # %q, not plain interpolation (roborev job 8, finding 3): the promise is an EXACT
+  # copy-pasteable line, and a root containing a space or a shell metacharacter would
+  # otherwise print a command that breaks (or does something else) when pasted. For a
+  # metacharacter-free path %q is a no-op, so the common case is byte-identical.
+  # shellcheck disable=SC2059  # %q is the point; the value is the argument, not the format
+  printf '  export CQLITE_DATASETS_ROOT=%q\n' "${DATASET_ROOT}"
   echo
 
   # If a pre-existing CQLITE_DATASETS_ROOT sent the corpus somewhere other than the
@@ -257,7 +303,10 @@ guarantee_usable_root() {
 #      a check (the same one-sided-verification mistake as #3148).
 #   2. It gives an operator (or a preflight) a cheap "is this root usable?" probe that
 #      cannot mutate the tree.
-if [ "${1:-}" = "--verify-only" ]; then
+# The flag itself is parsed (and every unrecognized argument rejected) at the TOP of this
+# script, before any filesystem work; canonicalize_dataset_root honors VERIFY_ONLY by
+# never creating the parent directory.
+if [ "${VERIFY_ONLY}" = 1 ]; then
   guarantee_usable_root "verify-only (no download, no extraction)"
   exit 0
 fi

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -184,11 +184,90 @@ has_required_dataset() {
   grep -qx "sha256=${SHA256_EXPECTED}" "${PIN_FILE}" || return 1
 }
 
+# guarantee_usable_root (issue #3131 item 2): a ZERO EXIT MUST MEAN "this root is
+# usable" — on the warm-cache path exactly as much as after a fresh extraction.
+#
+# Before #3131 the warm path's sole output was
+#   Dataset <asset> (tag <tag>) already present in <root>; skipping download
+# and exit 0. Nothing in that told an operator WHICH root was guaranteed, so a green
+# fetch was not evidence that any particular tree gained fixtures — and the
+# CLAUDE.md-documented `CQLITE_DATASETS_ROOT=$PWD/test-data/datasets` could still be
+# corpus-less, because an already-exported CQLITE_DATASETS_ROOT sends the extraction
+# somewhere else entirely. That is how the documented remedy silently failed to remedy.
+#
+# So: re-verify the CONTENT at the extraction target (independently of the
+# .dataset-pin fast path that got us here — a pin file is a claim, not the corpus),
+# fail loudly with a remedy when it is not there, and print the EXACT
+# `export CQLITE_DATASETS_ROOT=<absolute path>` line this run guarantees.
+#
+# Deliberately does NOT touch the `rm -rf "${DATASET_ROOT}"` / the
+# `[ -n "${CI:-}" ] || return 0` short-circuit in restore_ci_tracked_dataset_files:
+# that sibling defect is issue #2878, a separate delivery. Not widened here.
+guarantee_usable_root() {
+  local phase="$1"
+
+  if ! has_required_content; then
+    echo "ERROR: ${DATASET_ROOT} does not hold a usable dataset corpus (${phase})" >&2
+    echo "ERROR: required content missing — expected at least metadata.yml, a" >&2
+    echo "ERROR: test_basic/simple_table-*-Data.db, and the promoted wide_partition" >&2
+    echo "ERROR: reference binaries under" >&2
+    echo "ERROR:   ${WIDE_PARTITION_DIR}" >&2
+    echo "ERROR: remedy: re-run this script with the pin cleared so it re-downloads:" >&2
+    echo "ERROR:   rm -f ${PIN_FILE} && CQLITE_DATASETS_ROOT=${DATASET_ROOT} bash test-data/scripts/fetch-datasets.sh" >&2
+    exit 1
+  fi
+
+  local data_count
+  data_count="$(find "${DATASET_ROOT}" -name '*-Data.db' 2>/dev/null | wc -l | tr -d ' ')"
+
+  echo "Dataset root VERIFIED (${phase}): ${DATASET_ROOT} — ${data_count} *-Data.db present"
+  echo "Use EXACTLY this root (the only one this run guarantees):"
+  echo
+  echo "  export CQLITE_DATASETS_ROOT=${DATASET_ROOT}"
+  echo
+
+  # If a pre-existing CQLITE_DATASETS_ROOT sent the corpus somewhere other than the
+  # checkout's test-data/datasets, say so: the documented default would otherwise look
+  # like a valid choice and yield a corpus-less root (the #3131 report).
+  local repo_root repo_default
+  if repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    repo_default="$(cd "${repo_root}" && pwd -P)/test-data/datasets"
+    if [ "${DATASET_ROOT}" != "${repo_default}" ]; then
+      echo "NOTE: this run populated ${DATASET_ROOT}, NOT the checkout default"
+      echo "NOTE:   ${repo_default}"
+      echo "NOTE: (CQLITE_DATASETS_ROOT was already set in the environment). Exporting the"
+      echo "NOTE: checkout default instead would give you a corpus-less root — use the"
+      echo "NOTE: export line above."
+    fi
+  fi
+  # The CQL schema fixtures are COMMITTED SOURCE resolved checkout-relative (#3148);
+  # they are NOT part of this archive and need no environment variable. Said here
+  # because the pre-#3148 helpers looked for them at <root>/../schemas, so operators
+  # learned to expect a sibling this script never creates.
+  echo "NOTE: CQL schema fixtures (test-data/schemas) are committed source, resolved"
+  echo "NOTE: checkout-relative — not fetched here and not a sibling of this root (#3148)."
+}
+
+# --verify-only (issue #3131): report whether the resolved root is usable and print the
+# guaranteed export line, WITHOUT downloading, extracting, removing or re-pinning
+# anything. Two reasons this exists rather than being a pure internal:
+#   1. It makes guarantee_usable_root's FAILURE path directly exercisable. On the
+#      warm-cache path the pin fast-path implies the content check, so a self-test could
+#      otherwise only ever observe it passing — and a check observed only passing is not
+#      a check (the same one-sided-verification mistake as #3148).
+#   2. It gives an operator (or a preflight) a cheap "is this root usable?" probe that
+#      cannot mutate the tree.
+if [ "${1:-}" = "--verify-only" ]; then
+  guarantee_usable_root "verify-only (no download, no extraction)"
+  exit 0
+fi
+
 restore_ci_tracked_dataset_files
 
 if has_required_dataset; then
   write_pin
   echo "Dataset ${ASSET} (tag ${TAG}) already present in ${DATASET_ROOT}; skipping download"
+  guarantee_usable_root "warm cache, download skipped"
   exit 0
 fi
 
@@ -252,3 +331,4 @@ fi
 
 write_pin
 echo "Dataset extracted to ${DATASET_ROOT}"
+guarantee_usable_root "fresh extraction"

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -187,14 +187,21 @@ has_required_content() {
   [ -s "${WIDE_PARTITION_GOLDEN}" ] || return 1
 
   local core_fixture
-  core_fixture="$(find "${DATASET_ROOT}/sstables/test_basic" -path '*simple_table-*-Data.db' -print -quit 2>/dev/null || true)"
+  core_fixture="$(find -H "${DATASET_ROOT}/sstables/test_basic" -path '*simple_table-*-Data.db' -print -quit 2>/dev/null || true)"
   [ -n "${core_fixture}" ] || return 1
 
   local data_count index_count summary_count statistics_count
-  data_count="$(find "${DATASET_ROOT}" -name '*-Data.db' 2>/dev/null | wc -l | tr -d ' ')"
-  index_count="$(find "${DATASET_ROOT}" -name '*-Index.db' 2>/dev/null | wc -l | tr -d ' ')"
-  summary_count="$(find "${DATASET_ROOT}" -name '*-Summary.db' 2>/dev/null | wc -l | tr -d ' ')"
-  statistics_count="$(find "${DATASET_ROOT}" -name '*-Statistics.db' 2>/dev/null | wc -l | tr -d ' ')"
+  # `-H` (roborev job 9, finding 2): a DATASET_ROOT that is ITSELF a symlink — e.g.
+  # `ln -s /data/datasets <somewhere>/datasets`, the natural operator layout documented as
+  # #3148's "symlink trap" — is otherwise stat'ed as a plain file and never descended, so
+  # every count came back 0 and a perfectly good corpus was reported UNUSABLE. `-H`
+  # follows the COMMAND-LINE symlink only (not symlinks found during traversal), which is
+  # exactly the semantics wanted here. Verified: without it, `--verify-only` on a
+  # symlinked root failed; with it, it reports the real 155.
+  data_count="$(find -H "${DATASET_ROOT}" -name '*-Data.db' 2>/dev/null | wc -l | tr -d ' ')"
+  index_count="$(find -H "${DATASET_ROOT}" -name '*-Index.db' 2>/dev/null | wc -l | tr -d ' ')"
+  summary_count="$(find -H "${DATASET_ROOT}" -name '*-Summary.db' 2>/dev/null | wc -l | tr -d ' ')"
+  statistics_count="$(find -H "${DATASET_ROOT}" -name '*-Statistics.db' 2>/dev/null | wc -l | tr -d ' ')"
 
   [ "${data_count}" -gt 0 ] || return 1
   [ "${index_count}" -gt 0 ] || return 1
@@ -259,7 +266,8 @@ guarantee_usable_root() {
   fi
 
   local data_count
-  data_count="$(find "${DATASET_ROOT}" -name '*-Data.db' 2>/dev/null | wc -l | tr -d ' ')"
+  # -H: see has_required_content — a symlinked DATASET_ROOT must not report 0.
+  data_count="$(find -H "${DATASET_ROOT}" -name '*-Data.db' 2>/dev/null | wc -l | tr -d ' ')"
 
   echo "Dataset root VERIFIED (${phase}): ${DATASET_ROOT} — ${data_count} *-Data.db present"
   echo "Use EXACTLY this root (the only one this run guarantees):"

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -261,7 +261,12 @@ guarantee_usable_root() {
     echo "ERROR: reference binaries under" >&2
     echo "ERROR:   ${WIDE_PARTITION_DIR}" >&2
     echo "ERROR: remedy: re-run this script with the pin cleared so it re-downloads:" >&2
-    echo "ERROR:   rm -f ${PIN_FILE} && CQLITE_DATASETS_ROOT=${DATASET_ROOT} bash test-data/scripts/fetch-datasets.sh" >&2
+    # %q on both interpolations (roborev job 11, nit 3), for the same reason as the export line
+    # below: an unquoted path containing a space or a shell metacharacter prints a command that
+    # BREAKS (or does something else) when pasted, so the "remedy" would not be one.
+    # shellcheck disable=SC2059  # %q is the point; the values are arguments, not the format
+    printf 'ERROR:   rm -f %q && CQLITE_DATASETS_ROOT=%q bash test-data/scripts/fetch-datasets.sh\n' \
+      "${PIN_FILE}" "${DATASET_ROOT}" >&2
     exit 1
   fi
 

--- a/test-data/support/fixture_roots.rs
+++ b/test-data/support/fixture_roots.rs
@@ -237,9 +237,18 @@ pub fn sstables_root() -> PathBuf {
 /// | raw override | result |
 /// |---|---|
 /// | absent / blank | `Ok(checkout)` — an exported-but-empty var is a scripting accident |
+/// | **contains a control char** | **`Err`** — see below |
 /// | **relative** | **`Err`** — cannot mean the same thing under two CWDs (see module docs) |
 /// | absolute + readable dir | `Ok(override)` |
 /// | absolute, not a dir | `Ok(checkout)` — a stale export degrades instead of breaking every load |
+///
+/// The control-character rejection is not hygiene theatre (roborev job 10, finding 2): the
+/// shell mirror could only obtain the value through `$( )`, which **strips trailing
+/// newlines**. Measured with `CQLITE_SCHEMAS_ROOT=$'/abs/dir\n'`, the gate reported
+/// `STATUS: OK` for `/abs/dir` while this resolver kept the newline, got
+/// `is_dir() == false`, and degraded to the checkout — two different roots, the gate
+/// certifying the one the run did not use. The shell no longer uses command substitution on
+/// the value path, AND both sides reject such a value, so the class is closed twice over.
 pub fn resolve_schemas_root(
     raw_override: Option<&str>,
 ) -> Result<(PathBuf, SchemasRootSource), String> {
@@ -252,6 +261,15 @@ pub fn resolve_schemas_root(
     let Some(raw) = raw_override.filter(|v| !v.trim().is_empty()) else {
         return Ok(checkout());
     };
+    if raw.chars().any(char::is_control) {
+        return Err(format!(
+            "{SCHEMAS_ROOT_ENV} must not contain control characters (newline/CR/tab), got {raw:?}.\n\
+             \x20 why    : the gate's shell mirror cannot round-trip such a value (command\n\
+             \x20          substitution strips trailing newlines), so the gate would validate and\n\
+             \x20          certify one root while the tests resolved another.\n\
+             \x20 remedy : export a clean absolute path, or unset {SCHEMAS_ROOT_ENV}."
+        ));
+    }
     let p = PathBuf::from(raw);
     if !p.is_absolute() {
         return Err(format!(

--- a/test-data/support/fixture_roots.rs
+++ b/test-data/support/fixture_roots.rs
@@ -51,7 +51,17 @@
 //!   `schemas: 6/6 … under packaged/schemas` while the tests silently read the
 //!   checkout's schemas — the block certifying root A for a run that used root B, i.e.
 //!   the "positively misleading `STATUS: OK`" defect of #3148 reintroduced by its own
-//!   fix. Rejecting relative values makes the two sides agree by construction.
+//!   fix. Rejecting relative values removes the one input class on which the two
+//!   mirrors could not possibly agree.
+//!
+//! To be precise about how strong that guarantee is: the shell mirror in
+//! `scripts/agent-gate.sh` and this module are two HAND-WRITTEN implementations kept
+//! EQUIVALENT and PINNED BY SELF-TESTS — not equivalent by construction. They have been
+//! walked case by case over the whole input table (unset / `""` / whitespace-only /
+//! `"  /abs  "` / absolute-non-dir / absolute-dir / relative) and agree on every one, and
+//! `scripts/tests/test_agent_gate_schemas_preflight.sh` asserts each case against the real
+//! gate. Claiming "by construction" would be exactly the unearned reassurance that stops
+//! the next reader from re-checking after a change to either side.
 //!
 //! This file is deliberately hosted under `test-data/` rather than inside either
 //! crate: it encodes the layout of `test-data/` itself, it is owned by neither
@@ -139,11 +149,31 @@ pub fn readable_file(p: &Path) -> bool {
 /// `test-data/schemas` (the first cut of this module) meant a sparse checkout or a
 /// worktree nested inside another checkout resolved to the OUTER checkout's `test-data`:
 /// wrong-but-existing fixtures, no warning. `[workspace]` is present in the repository
-/// root manifest and absent from every member manifest, so the NEAREST match is always
-/// the enclosing checkout's own root — nesting depth and fixture presence are both
-/// irrelevant to it.
-fn workspace_root() -> Option<PathBuf> {
-    for ancestor in Path::new(env!("CARGO_MANIFEST_DIR")).ancestors() {
+/// root manifest and absent from every member manifest, so the NEAREST match is the
+/// enclosing checkout's own root — nesting depth and fixture presence are both irrelevant
+/// to it.
+///
+/// KNOWN EXCEPTION: `fuzz/Cargo.toml` declares its own `[workspace]` (deliberately — the
+/// fuzz crate is excluded from the main workspace, #1614), so a caller anchored inside
+/// `fuzz/` would resolve `fuzz/test-data`, which does not exist. Benign: the outcome is a
+/// LOUD failure naming that absent path, never a silent borrow of a wrong tree — and no
+/// `#[path]`-including target lives under `fuzz/`. Named so the "nearest `[workspace]`"
+/// rule is not read as exception-free.
+pub fn workspace_root() -> Option<PathBuf> {
+    workspace_root_from(Path::new(env!("CARGO_MANIFEST_DIR")))
+}
+
+/// [`workspace_root`] parameterized on the starting directory.
+///
+/// Split out purely so the marker rule has a DISCRIMINATING test: in a healthy checkout the
+/// retired fixtures-keyed walk returns the same answer as the marker walk, so a test that
+/// can only run from `CARGO_MANIFEST_DIR` still passes if the rule is reverted — an
+/// assertion that cannot fail. Given an explicit start, a synthetic
+/// `outer/{Cargo.toml,test-data/schemas}` + `outer/inner/{Cargo.toml,member}` layout
+/// separates the two rules: the marker walk answers `outer/inner`, the fixtures-keyed walk
+/// answers `outer`.
+pub fn workspace_root_from(start: &Path) -> Option<PathBuf> {
+    for ancestor in start.ancestors() {
         let manifest = ancestor.join("Cargo.toml");
         if let Ok(text) = std::fs::read_to_string(&manifest) {
             if text

--- a/test-data/support/fixture_roots.rs
+++ b/test-data/support/fixture_roots.rs
@@ -29,8 +29,29 @@
 //! **Owner decision (#3148 AC (h), proposed fix 4): the schemas root is resolved
 //! CHECKOUT-RELATIVE, never from `CQLITE_DATASETS_ROOT`.** A checkout always has
 //! these files, so the failure mode is structurally impossible and the symlink trap
-//! disappears rather than being papered over — this module contains no `..` climbing
-//! from the datasets root, so there is nothing left to mis-resolve.
+//! disappears rather than being papered over — nothing here climbs `..` from the
+//! datasets root, so there is nothing left to mis-resolve.
+//!
+//! # Two rules that keep the resolution honest
+//!
+//! * **The checkout is identified by a checkout MARKER, not by the fixtures.** Keying
+//!   the ancestor walk on `test-data/schemas` looked convenient and was wrong: a sparse
+//!   checkout, or a worktree created *inside* another checkout, would skip past its own
+//!   root and silently resolve BOTH roots to the OUTER checkout's `test-data` —
+//!   wrong-but-existing fixtures, reported as `Checkout`, no warning. That is exactly
+//!   the failure class this module exists to eliminate, so the walk keys on the
+//!   workspace-root `Cargo.toml` (the nearest ancestor manifest declaring
+//!   `[workspace]`) and a missing `test-data/schemas` under it fails LOUDLY at
+//!   [`schema_path`] instead of being papered over by a neighbour's copy.
+//! * **A `CQLITE_SCHEMAS_ROOT` override MUST be absolute.** A *relative* override is
+//!   rejected fail-closed rather than resolved, because it cannot mean the same thing on
+//!   both sides of the contract: `scripts/agent-gate.sh` evaluates it with CWD =
+//!   repository root, while cargo runs each test binary with CWD = the *package*
+//!   directory. A relative value therefore let the gate stamp
+//!   `schemas: 6/6 … under packaged/schemas` while the tests silently read the
+//!   checkout's schemas — the block certifying root A for a run that used root B, i.e.
+//!   the "positively misleading `STATUS: OK`" defect of #3148 reintroduced by its own
+//!   fix. Rejecting relative values makes the two sides agree by construction.
 //!
 //! This file is deliberately hosted under `test-data/` rather than inside either
 //! crate: it encodes the layout of `test-data/` itself, it is owned by neither
@@ -73,7 +94,7 @@ pub const SCHEMAS_ROOT_ENV: &str = "CQLITE_SCHEMAS_ROOT";
 /// an operator can tell an override apart from the checkout default.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SchemasRootSource {
-    /// `CQLITE_SCHEMAS_ROOT` was set, non-empty, and named a readable directory.
+    /// `CQLITE_SCHEMAS_ROOT` was set, ABSOLUTE, and named a readable directory.
     EnvOverride,
     /// Checkout-relative: the `test-data/schemas` of the enclosing checkout.
     Checkout,
@@ -93,40 +114,72 @@ impl SchemasRootSource {
 
 /// A non-empty env var value, or `None`. An empty value is treated as unset: an
 /// exported-but-empty variable is a scripting accident, never an intentional root.
-fn env_dir(key: &str) -> Option<PathBuf> {
+fn env_dir(key: &str) -> Option<String> {
     match std::env::var(key) {
-        Ok(v) if !v.trim().is_empty() => Some(PathBuf::from(v)),
+        Ok(v) if !v.trim().is_empty() => Some(v),
         _ => None,
     }
 }
 
-/// The `test-data` directory of the enclosing checkout.
+/// True when `p` is a regular file that can actually be OPENED for reading.
 ///
-/// Walks up from `CARGO_MANIFEST_DIR` (expanded at compile time to the *consuming
-/// crate's* directory) and returns the first ancestor holding a `test-data/schemas`
-/// directory. Walking ancestors — rather than hardcoding `../test-data` — keeps this
-/// correct for a crate nested deeper than one level (e.g. `bindings/python`), and it
-/// never constructs a `..` component, so no path handed to the kernel can be
-/// re-rooted by a symlink.
+/// `Path::is_file()` alone answers the type question, not the permission question: a
+/// mode-000 fixture is `is_file() == true` and then fails inside ingestion, bypassing the
+/// actionable message this module exists to produce — and disagreeing with the gate's
+/// `[ -f ] && [ -r ]` check, which is the drift the whole change is meant to prevent
+/// (roborev job 8, finding 2). Both sides now answer "readable regular file".
+pub fn readable_file(p: &Path) -> bool {
+    p.is_file() && std::fs::File::open(p).is_ok()
+}
+
+/// The workspace root: the NEAREST ancestor of `CARGO_MANIFEST_DIR` whose `Cargo.toml`
+/// declares `[workspace]`.
 ///
-/// When no ancestor qualifies (a checkout with the fixtures deleted), returns the
-/// canonical one-level-up guess so callers can name a concrete absolute path in their
-/// error message instead of reporting "not found" with no path at all.
-pub fn checkout_test_data_dir() -> PathBuf {
-    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
-    for ancestor in manifest.ancestors() {
-        let candidate = ancestor.join("test-data");
-        if candidate.join("schemas").is_dir() {
-            return candidate;
+/// A checkout MARKER, deliberately — not the fixtures themselves. Keying the walk on
+/// `test-data/schemas` (the first cut of this module) meant a sparse checkout or a
+/// worktree nested inside another checkout resolved to the OUTER checkout's `test-data`:
+/// wrong-but-existing fixtures, no warning. `[workspace]` is present in the repository
+/// root manifest and absent from every member manifest, so the NEAREST match is always
+/// the enclosing checkout's own root — nesting depth and fixture presence are both
+/// irrelevant to it.
+fn workspace_root() -> Option<PathBuf> {
+    for ancestor in Path::new(env!("CARGO_MANIFEST_DIR")).ancestors() {
+        let manifest = ancestor.join("Cargo.toml");
+        if let Ok(text) = std::fs::read_to_string(&manifest) {
+            if text
+                .lines()
+                .any(|l| l.trim_start().starts_with("[workspace]"))
+            {
+                return Some(ancestor.to_path_buf());
+            }
         }
     }
-    manifest.join("../test-data")
+    None
+}
+
+/// The `test-data` directory of the enclosing checkout.
+///
+/// Anchored on [`workspace_root`]. The result is returned **whether or not it exists**,
+/// so a checkout missing its fixtures fails LOUDLY at [`schema_path`] — naming its OWN
+/// absolute path — rather than being silently satisfied by a neighbouring checkout's copy.
+///
+/// Falls back to the manifest's parent only when no `[workspace]` manifest is found at
+/// all (not reachable from a cargo-built target in this repository). Both branches use
+/// `Path::parent`/`join` on the absolute `CARGO_MANIFEST_DIR`, so no `..` component is
+/// ever constructed and nothing handed to the kernel can be re-rooted by a symlink.
+pub fn checkout_test_data_dir() -> PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root =
+        workspace_root().unwrap_or_else(|| manifest.parent().unwrap_or(manifest).to_path_buf());
+    root.join("test-data")
 }
 
 /// The **fetched** dataset corpus root — infallible shape. See the module docs for
 /// the contract; prefer [`datasets_root_if_present`] in a SKIP-gated test.
 pub fn datasets_root() -> PathBuf {
-    env_dir(DATASETS_ROOT_ENV).unwrap_or_else(|| checkout_test_data_dir().join("datasets"))
+    env_dir(DATASETS_ROOT_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| checkout_test_data_dir().join("datasets"))
 }
 
 /// The **fetched** dataset corpus root — fallible shape, for SKIP-gated tests.
@@ -136,7 +189,7 @@ pub fn datasets_root() -> PathBuf {
 /// not instead run against a checkout that carries only committed byte-parity
 /// references and report a vacuous 0-row pass.
 pub fn datasets_root_if_present() -> Option<PathBuf> {
-    let p = env_dir(DATASETS_ROOT_ENV)?;
+    let p = PathBuf::from(env_dir(DATASETS_ROOT_ENV)?);
     p.is_dir().then_some(p)
 }
 
@@ -145,22 +198,58 @@ pub fn sstables_root() -> PathBuf {
     datasets_root().join("sstables")
 }
 
+/// PURE resolution of the schemas root from a raw override value.
+///
+/// Separated from the environment read so the contract is testable without mutating
+/// process-global state (an env-mutating test races every other test in the binary).
+/// Mirrors `_gate_schemas_root` in `scripts/agent-gate.sh` rule for rule:
+///
+/// | raw override | result |
+/// |---|---|
+/// | absent / blank | `Ok(checkout)` — an exported-but-empty var is a scripting accident |
+/// | **relative** | **`Err`** — cannot mean the same thing under two CWDs (see module docs) |
+/// | absolute + readable dir | `Ok(override)` |
+/// | absolute, not a dir | `Ok(checkout)` — a stale export degrades instead of breaking every load |
+pub fn resolve_schemas_root(
+    raw_override: Option<&str>,
+) -> Result<(PathBuf, SchemasRootSource), String> {
+    let checkout = || {
+        (
+            checkout_test_data_dir().join("schemas"),
+            SchemasRootSource::Checkout,
+        )
+    };
+    let Some(raw) = raw_override.filter(|v| !v.trim().is_empty()) else {
+        return Ok(checkout());
+    };
+    let p = PathBuf::from(raw);
+    if !p.is_absolute() {
+        return Err(format!(
+            "{SCHEMAS_ROOT_ENV} must be an ABSOLUTE path, got '{raw}'.\n\
+             \x20 why    : a relative value cannot mean the same thing on both sides of the\n\
+             \x20          contract — scripts/agent-gate.sh evaluates it with CWD = repository\n\
+             \x20          root, while cargo runs each test binary with CWD = the package dir.\n\
+             \x20          The gate would certify one schemas root while the tests read another.\n\
+             \x20 remedy : export an absolute path, or unset {SCHEMAS_ROOT_ENV} to use the\n\
+             \x20          checkout's test-data/schemas."
+        ));
+    }
+    if p.is_dir() {
+        return Ok((p, SchemasRootSource::EnvOverride));
+    }
+    Ok(checkout())
+}
+
 /// The **committed** schema-fixture root plus the provenance of that decision.
 ///
-/// `CQLITE_SCHEMAS_ROOT` wins when set, non-empty, and readable — an unreadable or
-/// empty override falls through to the checkout rather than pinning the run to a path
-/// that cannot work, so a stale export in a shell profile degrades to the correct
-/// answer instead of breaking every fixture load.
+/// Reads `CQLITE_SCHEMAS_ROOT` and applies [`resolve_schemas_root`]. Panics on a
+/// REJECTED override (a relative path) — fail-closed is the point: silently resolving it
+/// is what would let the gate certify a root the run never used.
 pub fn schemas_root_resolved() -> (PathBuf, SchemasRootSource) {
-    if let Some(p) = env_dir(SCHEMAS_ROOT_ENV) {
-        if p.is_dir() {
-            return (p, SchemasRootSource::EnvOverride);
-        }
+    match resolve_schemas_root(env_dir(SCHEMAS_ROOT_ENV).as_deref()) {
+        Ok(v) => v,
+        Err(e) => panic!("{e}"),
     }
-    (
-        checkout_test_data_dir().join("schemas"),
-        SchemasRootSource::Checkout,
-    )
 }
 
 /// The **committed** schema-fixture root (`test-data/schemas`).
@@ -179,7 +268,7 @@ pub fn schemas_root() -> PathBuf {
 pub fn schema_path(schema_file: &str) -> PathBuf {
     let (root, source) = schemas_root_resolved();
     let path = root.join(schema_file);
-    if path.is_file() {
+    if readable_file(&path) {
         return path;
     }
     panic!(
@@ -193,23 +282,4 @@ pub fn schema_path(schema_file: &str) -> PathBuf {
         root.display(),
         source.describe(),
     )
-}
-
-/// Assert every named schema fixture is readable, returning the first failure as an
-/// actionable message (the `Err` shape of [`schema_path`], for a caller that wants to
-/// report rather than panic).
-pub fn check_schema_files(files: &[&str]) -> Result<(), String> {
-    let (root, source) = schemas_root_resolved();
-    for f in files {
-        let path = root.join(f);
-        if !path.is_file() {
-            return Err(format!(
-                "schema fixture '{f}' unreadable at {} (root {} via {})",
-                path.display(),
-                root.display(),
-                source.describe()
-            ));
-        }
-    }
-    Ok(())
 }

--- a/test-data/support/fixture_roots.rs
+++ b/test-data/support/fixture_roots.rs
@@ -111,7 +111,9 @@ pub enum SchemasRootSource {
 }
 
 impl SchemasRootSource {
-    fn describe(self) -> String {
+    /// `pub` because the failure message it composes is now ASSERTED by
+    /// `cqlite-core/tests/issue_3148_fixture_roots_contract.rs` (#3148 requirement 5).
+    pub fn describe(self) -> String {
         match self {
             Self::EnvOverride => format!("{SCHEMAS_ROOT_ENV} override"),
             Self::Checkout => format!(
@@ -207,9 +209,22 @@ pub fn checkout_test_data_dir() -> PathBuf {
 /// The **fetched** dataset corpus root — infallible shape. See the module docs for
 /// the contract; prefer [`datasets_root_if_present`] in a SKIP-gated test.
 pub fn datasets_root() -> PathBuf {
-    env_dir(DATASETS_ROOT_ENV)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| checkout_test_data_dir().join("datasets"))
+    resolve_datasets_root(env_dir(DATASETS_ROOT_ENV).as_deref())
+}
+
+/// PURE form of [`datasets_root`] — the infallible shape, parameterized on the raw value.
+///
+/// Factored for the same reason as [`resolve_schemas_root`]: the two shapes' DIFFERENCE **is**
+/// the contract (#3148 AC (e)), and a test that can only read the ambient environment cannot
+/// assert it without `set_var`, which races every other test in the binary. Before this the
+/// only guard was a grep for the function NAME, so giving the fallible shape a checkout
+/// fallback — collapsing the two shapes into one — reddened nothing (spec-auditor,
+/// requirement 6 partial).
+pub fn resolve_datasets_root(raw: Option<&str>) -> PathBuf {
+    match raw.filter(|v| !v.trim().is_empty()) {
+        Some(v) => PathBuf::from(v),
+        None => checkout_test_data_dir().join("datasets"),
+    }
 }
 
 /// The **fetched** dataset corpus root — fallible shape, for SKIP-gated tests.
@@ -219,7 +234,15 @@ pub fn datasets_root() -> PathBuf {
 /// not instead run against a checkout that carries only committed byte-parity
 /// references and report a vacuous 0-row pass.
 pub fn datasets_root_if_present() -> Option<PathBuf> {
-    let p = PathBuf::from(env_dir(DATASETS_ROOT_ENV)?);
+    resolve_datasets_root_if_present(env_dir(DATASETS_ROOT_ENV).as_deref())
+}
+
+/// PURE form of [`datasets_root_if_present`] — the fallible shape.
+///
+/// `None` unless the value is present AND names a directory. Deliberately has **no** checkout
+/// fallback; see [`datasets_root_if_present`] for why that difference is load-bearing.
+pub fn resolve_datasets_root_if_present(raw: Option<&str>) -> Option<PathBuf> {
+    let p = PathBuf::from(raw.filter(|v| !v.trim().is_empty())?);
     p.is_dir().then_some(p)
 }
 
@@ -315,11 +338,30 @@ pub fn schemas_root() -> PathBuf {
 /// and bench code may panic; this file is never compiled into the library.
 pub fn schema_path(schema_file: &str) -> PathBuf {
     let (root, source) = schemas_root_resolved();
+    match resolve_schema_path(&root, source, schema_file) {
+        Ok(p) => p,
+        Err(e) => panic!("{e}"),
+    }
+}
+
+/// PURE form of [`schema_path`]: resolve + verify a fixture under an EXPLICIT root, returning
+/// the actionable message as `Err` instead of panicking.
+///
+/// Factored because the message TEXT is the deliverable (#3148 requirement 5) and it was
+/// asserted by **nothing**: the only coverage was the happy path, so reverting `schema_path` to
+/// a bare `expect` deep inside ingest left every test green (spec-auditor, requirement 5
+/// UNCOVERED). A message nobody asserts is a message that silently rots back into
+/// `Path does not exist:` — the diagnosis-free failure #3148 was filed for.
+pub fn resolve_schema_path(
+    root: &Path,
+    source: SchemasRootSource,
+    schema_file: &str,
+) -> Result<PathBuf, String> {
     let path = root.join(schema_file);
     if readable_file(&path) {
-        return path;
+        return Ok(path);
     }
-    panic!(
+    Err(format!(
         "committed schema fixture '{schema_file}' is not readable at {}\n\
          \x20 schemas root : {} ({})\n\
          \x20 note         : test-data/schemas is COMMITTED SOURCE — it is NOT part of the fetched\n\
@@ -329,5 +371,5 @@ pub fn schema_path(schema_file: &str) -> PathBuf {
         path.display(),
         root.display(),
         source.describe(),
-    )
+    ))
 }

--- a/test-data/support/fixture_roots.rs
+++ b/test-data/support/fixture_roots.rs
@@ -1,0 +1,215 @@
+//! Single-source resolution of the `test-data/` roots used by tests and benches
+//! (issues #3131 / #3148).
+//!
+//! # Why this file exists, and why it lives here
+//!
+//! Two distinct roots were historically conflated:
+//!
+//! | Root | Nature | Owner |
+//! |------|--------|-------|
+//! | `test-data/datasets` | **fetched, relocatable** binary corpus (`fetch-datasets.sh`) | `CQLITE_DATASETS_ROOT` |
+//! | `test-data/schemas`  | **committed source** (23 files incl. `legacy/`, `udts/`) | the checkout |
+//!
+//! Four independently-written call sites used to derive the *schemas* root from the
+//! *datasets* root by climbing `..` (`datasets_root().join("../schemas")`). That is
+//! wrong in two ways:
+//!
+//! 1. It makes committed source's location depend on an env var whose entire purpose
+//!    is to point at *relocatable fetched data*. A machine whose corpus lives at
+//!    `/data/datasets` then needs a `/data/schemas` that no `git checkout` ever
+//!    creates — the #3131 failure ("no single `CQLITE_DATASETS_ROOT` works").
+//! 2. `join("..")` is **not** a lexical parent at the syscall level: the kernel
+//!    resolves `datasets/..` against the *symlink target's* parent. So
+//!    `ln -s <checkout>/test-data/datasets /data/datasets` makes
+//!    `/data/datasets/../schemas` silently resolve to `<checkout>/test-data/schemas`,
+//!    while a real `/data/datasets` directory resolves to `/data/schemas`. Two
+//!    visually identical layouts, opposite outcomes, no error explaining why
+//!    (#3148, "the symlink trap").
+//!
+//! **Owner decision (#3148 AC (h), proposed fix 4): the schemas root is resolved
+//! CHECKOUT-RELATIVE, never from `CQLITE_DATASETS_ROOT`.** A checkout always has
+//! these files, so the failure mode is structurally impossible and the symlink trap
+//! disappears rather than being papered over — this module contains no `..` climbing
+//! from the datasets root, so there is nothing left to mis-resolve.
+//!
+//! This file is deliberately hosted under `test-data/` rather than inside either
+//! crate: it encodes the layout of `test-data/` itself, it is owned by neither
+//! `cqlite-core` nor `cqlite-cli`, and the include path is symmetric (`../../` from
+//! any `<crate>/tests/` or `<crate>/benches/` directory). It is pulled in with
+//! `#[path = "…/test-data/support/fixture_roots.rs"] mod fixture_roots;`, so it
+//! compiles into each consuming test/bench target with no new crate or dependency.
+//!
+//! # The `datasets_root()` contract (#3148 AC (e))
+//!
+//! There is ONE resolution rule with TWO documented shapes. The distinction is a
+//! real, deliberate behavioral choice — not an accident:
+//!
+//! * [`datasets_root()`] — **infallible**, with a checkout-relative fallback when
+//!   `CQLITE_DATASETS_ROOT` is unset. For benches and for tests that *must* have the
+//!   corpus: they proceed and fail later with an actionable per-fixture message. This
+//!   is the shape that lets `cargo bench` work from a plain checkout with no env setup.
+//! * [`datasets_root_if_present()`] — **fallible**, `Some` only when
+//!   `CQLITE_DATASETS_ROOT` is set AND names a directory; **no checkout fallback**.
+//!   For SKIP-gated tests: with no env var they must skip, not silently run against
+//!   the checkout's ~19 committed byte-parity reference files (which do not contain
+//!   the canonical `test_basic` corpus) and report a 0-row pass.
+//!
+//! Both shapes derive from [`checkout_test_data_dir()`] and the same env var, so the
+//! two cannot drift apart the way the three hand-written copies did.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+/// Environment override for the **fetched** dataset corpus.
+pub const DATASETS_ROOT_ENV: &str = "CQLITE_DATASETS_ROOT";
+
+/// Environment override for the **committed** schema fixtures. Exists only for
+/// out-of-tree runs (a packaged corpus + schemas shipped together); the default is
+/// checkout-relative and needs no environment at all.
+pub const SCHEMAS_ROOT_ENV: &str = "CQLITE_SCHEMAS_ROOT";
+
+/// How [`schemas_root_resolved`] arrived at its path — carried into panic messages so
+/// an operator can tell an override apart from the checkout default.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SchemasRootSource {
+    /// `CQLITE_SCHEMAS_ROOT` was set, non-empty, and named a readable directory.
+    EnvOverride,
+    /// Checkout-relative: the `test-data/schemas` of the enclosing checkout.
+    Checkout,
+}
+
+impl SchemasRootSource {
+    fn describe(self) -> String {
+        match self {
+            Self::EnvOverride => format!("{SCHEMAS_ROOT_ENV} override"),
+            Self::Checkout => format!(
+                "checkout-relative (CARGO_MANIFEST_DIR={})",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        }
+    }
+}
+
+/// A non-empty env var value, or `None`. An empty value is treated as unset: an
+/// exported-but-empty variable is a scripting accident, never an intentional root.
+fn env_dir(key: &str) -> Option<PathBuf> {
+    match std::env::var(key) {
+        Ok(v) if !v.trim().is_empty() => Some(PathBuf::from(v)),
+        _ => None,
+    }
+}
+
+/// The `test-data` directory of the enclosing checkout.
+///
+/// Walks up from `CARGO_MANIFEST_DIR` (expanded at compile time to the *consuming
+/// crate's* directory) and returns the first ancestor holding a `test-data/schemas`
+/// directory. Walking ancestors — rather than hardcoding `../test-data` — keeps this
+/// correct for a crate nested deeper than one level (e.g. `bindings/python`), and it
+/// never constructs a `..` component, so no path handed to the kernel can be
+/// re-rooted by a symlink.
+///
+/// When no ancestor qualifies (a checkout with the fixtures deleted), returns the
+/// canonical one-level-up guess so callers can name a concrete absolute path in their
+/// error message instead of reporting "not found" with no path at all.
+pub fn checkout_test_data_dir() -> PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest.ancestors() {
+        let candidate = ancestor.join("test-data");
+        if candidate.join("schemas").is_dir() {
+            return candidate;
+        }
+    }
+    manifest.join("../test-data")
+}
+
+/// The **fetched** dataset corpus root — infallible shape. See the module docs for
+/// the contract; prefer [`datasets_root_if_present`] in a SKIP-gated test.
+pub fn datasets_root() -> PathBuf {
+    env_dir(DATASETS_ROOT_ENV).unwrap_or_else(|| checkout_test_data_dir().join("datasets"))
+}
+
+/// The **fetched** dataset corpus root — fallible shape, for SKIP-gated tests.
+///
+/// `Some` only when `CQLITE_DATASETS_ROOT` is set and names a directory. Deliberately
+/// has **no** checkout fallback: a test that skips when the corpus is unavailable must
+/// not instead run against a checkout that carries only committed byte-parity
+/// references and report a vacuous 0-row pass.
+pub fn datasets_root_if_present() -> Option<PathBuf> {
+    let p = env_dir(DATASETS_ROOT_ENV)?;
+    p.is_dir().then_some(p)
+}
+
+/// The `sstables/` subtree of the dataset corpus.
+pub fn sstables_root() -> PathBuf {
+    datasets_root().join("sstables")
+}
+
+/// The **committed** schema-fixture root plus the provenance of that decision.
+///
+/// `CQLITE_SCHEMAS_ROOT` wins when set, non-empty, and readable — an unreadable or
+/// empty override falls through to the checkout rather than pinning the run to a path
+/// that cannot work, so a stale export in a shell profile degrades to the correct
+/// answer instead of breaking every fixture load.
+pub fn schemas_root_resolved() -> (PathBuf, SchemasRootSource) {
+    if let Some(p) = env_dir(SCHEMAS_ROOT_ENV) {
+        if p.is_dir() {
+            return (p, SchemasRootSource::EnvOverride);
+        }
+    }
+    (
+        checkout_test_data_dir().join("schemas"),
+        SchemasRootSource::Checkout,
+    )
+}
+
+/// The **committed** schema-fixture root (`test-data/schemas`).
+///
+/// NEVER derived from [`datasets_root`] — see the module docs (#3148 AC (h)).
+pub fn schemas_root() -> PathBuf {
+    schemas_root_resolved().0
+}
+
+/// Absolute path to a committed `.cql`/`.json` schema fixture, verified readable.
+///
+/// Panics with an actionable message naming the resolved **absolute** path, how the
+/// root was chosen, and the remedy — never a bare `Path does not exist:` from deep
+/// inside ingestion, which is the diagnosis-free failure #3148 was filed for. Test
+/// and bench code may panic; this file is never compiled into the library.
+pub fn schema_path(schema_file: &str) -> PathBuf {
+    let (root, source) = schemas_root_resolved();
+    let path = root.join(schema_file);
+    if path.is_file() {
+        return path;
+    }
+    panic!(
+        "committed schema fixture '{schema_file}' is not readable at {}\n\
+         \x20 schemas root : {} ({})\n\
+         \x20 note         : test-data/schemas is COMMITTED SOURCE — it is NOT part of the fetched\n\
+         \x20                dataset corpus and is NOT derived from {DATASETS_ROOT_ENV} (#3148).\n\
+         \x20 remedy       : unset {SCHEMAS_ROOT_ENV} to use the checkout default, or restore the\n\
+         \x20                committed fixtures:  git restore --source=HEAD -- test-data/schemas",
+        path.display(),
+        root.display(),
+        source.describe(),
+    )
+}
+
+/// Assert every named schema fixture is readable, returning the first failure as an
+/// actionable message (the `Err` shape of [`schema_path`], for a caller that wants to
+/// report rather than panic).
+pub fn check_schema_files(files: &[&str]) -> Result<(), String> {
+    let (root, source) = schemas_root_resolved();
+    for f in files {
+        let path = root.join(f);
+        if !path.is_file() {
+            return Err(format!(
+                "schema fixture '{f}' unreadable at {} (root {} via {})",
+                path.display(),
+                root.display(),
+                source.describe()
+            ));
+        }
+    }
+    Ok(())
+}

--- a/test-data/support/fixture_roots.rs
+++ b/test-data/support/fixture_roots.rs
@@ -90,6 +90,7 @@
 
 #![allow(dead_code)]
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 /// Environment override for the **fetched** dataset corpus.
@@ -124,11 +125,21 @@ impl SchemasRootSource {
     }
 }
 
-/// A non-empty env var value, or `None`. An empty value is treated as unset: an
-/// exported-but-empty variable is a scripting accident, never an intentional root.
-fn env_dir(key: &str) -> Option<String> {
-    match std::env::var(key) {
-        Ok(v) if !v.trim().is_empty() => Some(v),
+/// The raw OS value of an env var, or `None` when unset or empty.
+///
+/// `var_os`, deliberately — NOT `var` with a catch-all `_ => None` (roborev job 11, BLOCKER).
+/// `std::env::var` maps a NON-UTF-8 value to `Err(NotUnicode)`, and collapsing that to `None`
+/// made a malformed override silently resolve to the checkout while the Bash mirror validated
+/// the same BYTE path as a legitimate override — the gate certifying one schemas root while
+/// Rust used another. That is the same certify-A-use-B split already pinned for
+/// control-character and relative values, so it must not survive as the third, unpinned
+/// instance. Returning the `OsString` keeps the non-UTF-8 case REPRESENTABLE, so each consumer
+/// makes an explicit decision about it instead of inheriting a lossy conversion.
+///
+/// Blankness is judged only where the value IS valid text; a non-UTF-8 value is never blank.
+fn env_os(key: &str) -> Option<std::ffi::OsString> {
+    match std::env::var_os(key) {
+        Some(v) if !v.is_empty() => Some(v),
         _ => None,
     }
 }
@@ -209,7 +220,7 @@ pub fn checkout_test_data_dir() -> PathBuf {
 /// The **fetched** dataset corpus root — infallible shape. See the module docs for
 /// the contract; prefer [`datasets_root_if_present`] in a SKIP-gated test.
 pub fn datasets_root() -> PathBuf {
-    resolve_datasets_root(env_dir(DATASETS_ROOT_ENV).as_deref())
+    resolve_datasets_root(env_os(DATASETS_ROOT_ENV).as_deref())
 }
 
 /// PURE form of [`datasets_root`] — the infallible shape, parameterized on the raw value.
@@ -220,8 +231,10 @@ pub fn datasets_root() -> PathBuf {
 /// only guard was a grep for the function NAME, so giving the fallible shape a checkout
 /// fallback — collapsing the two shapes into one — reddened nothing (spec-auditor,
 /// requirement 6 partial).
-pub fn resolve_datasets_root(raw: Option<&str>) -> PathBuf {
-    match raw.filter(|v| !v.trim().is_empty()) {
+pub fn resolve_datasets_root(raw: Option<&OsStr>) -> PathBuf {
+    match raw.filter(|v| v.to_str().map(|t| !t.trim().is_empty()).unwrap_or(true)) {
+        // `unwrap_or(true)`: a NON-UTF-8 value is never blank, and it is HONORED rather than
+        // silently replaced by the checkout — see the note on this hazard below.
         Some(v) => PathBuf::from(v),
         None => checkout_test_data_dir().join("datasets"),
     }
@@ -234,15 +247,16 @@ pub fn resolve_datasets_root(raw: Option<&str>) -> PathBuf {
 /// not instead run against a checkout that carries only committed byte-parity
 /// references and report a vacuous 0-row pass.
 pub fn datasets_root_if_present() -> Option<PathBuf> {
-    resolve_datasets_root_if_present(env_dir(DATASETS_ROOT_ENV).as_deref())
+    resolve_datasets_root_if_present(env_os(DATASETS_ROOT_ENV).as_deref())
 }
 
 /// PURE form of [`datasets_root_if_present`] — the fallible shape.
 ///
 /// `None` unless the value is present AND names a directory. Deliberately has **no** checkout
 /// fallback; see [`datasets_root_if_present`] for why that difference is load-bearing.
-pub fn resolve_datasets_root_if_present(raw: Option<&str>) -> Option<PathBuf> {
-    let p = PathBuf::from(raw.filter(|v| !v.trim().is_empty())?);
+pub fn resolve_datasets_root_if_present(raw: Option<&OsStr>) -> Option<PathBuf> {
+    let p =
+        PathBuf::from(raw.filter(|v| v.to_str().map(|t| !t.trim().is_empty()).unwrap_or(true))?);
     p.is_dir().then_some(p)
 }
 
@@ -273,7 +287,7 @@ pub fn sstables_root() -> PathBuf {
 /// certifying the one the run did not use. The shell no longer uses command substitution on
 /// the value path, AND both sides reject such a value, so the class is closed twice over.
 pub fn resolve_schemas_root(
-    raw_override: Option<&str>,
+    raw_override: Option<&OsStr>,
 ) -> Result<(PathBuf, SchemasRootSource), String> {
     let checkout = || {
         (
@@ -281,9 +295,25 @@ pub fn resolve_schemas_root(
             SchemasRootSource::Checkout,
         )
     };
-    let Some(raw) = raw_override.filter(|v| !v.trim().is_empty()) else {
+    let Some(raw_os) = raw_override else {
         return Ok(checkout());
     };
+    // NON-UTF-8 is rejected, not degraded. The Bash mirror treats the value as bytes and would
+    // validate this same path as a usable override; silently falling back here is exactly the
+    // divergence this module exists to prevent (roborev job 11).
+    let Some(raw) = raw_os.to_str() else {
+        return Err(format!(
+            "{SCHEMAS_ROOT_ENV} is not valid UTF-8: {raw_os:?}.\n\
+             \x20 why    : the gate's shell mirror handles the value as raw BYTES and would accept\n\
+             \x20          it, while this resolver cannot represent it as text — so the gate would\n\
+             \x20          certify one schemas root while the tests resolved another.\n\
+             \x20 remedy : export a UTF-8 absolute path, or unset {SCHEMAS_ROOT_ENV} to use the\n\
+             \x20          checkout's test-data/schemas."
+        ));
+    };
+    if raw.trim().is_empty() {
+        return Ok(checkout());
+    }
     if raw.chars().any(char::is_control) {
         return Err(format!(
             "{SCHEMAS_ROOT_ENV} must not contain control characters (newline/CR/tab), got {raw:?}.\n\
@@ -317,7 +347,7 @@ pub fn resolve_schemas_root(
 /// REJECTED override (a relative path) — fail-closed is the point: silently resolving it
 /// is what would let the gate certify a root the run never used.
 pub fn schemas_root_resolved() -> (PathBuf, SchemasRootSource) {
-    match resolve_schemas_root(env_dir(SCHEMAS_ROOT_ENV).as_deref()) {
+    match resolve_schemas_root(env_os(SCHEMAS_ROOT_ENV).as_deref()) {
         Ok(v) => v,
         Err(e) => panic!("{e}"),
     }
@@ -361,13 +391,25 @@ pub fn resolve_schema_path(
     if readable_file(&path) {
         return Ok(path);
     }
+    // `git -C <workspace root>`, not a bare `git restore` (roborev job 11, nit 2): cargo runs
+    // each test binary with CWD = the PACKAGE dir, so a CWD-relative command FAILS when pasted
+    // — the same CWD asymmetry this module rejects relative overrides for. A remedy line that
+    // does not work when followed is not a remedy.
+    let restore = match workspace_root() {
+        Some(ws) => format!(
+            "git -C {} restore --source=HEAD -- test-data/schemas",
+            ws.display()
+        ),
+        None => "git restore --source=HEAD -- test-data/schemas (run from the repository root)"
+            .to_string(),
+    };
     Err(format!(
         "committed schema fixture '{schema_file}' is not readable at {}\n\
          \x20 schemas root : {} ({})\n\
          \x20 note         : test-data/schemas is COMMITTED SOURCE — it is NOT part of the fetched\n\
          \x20                dataset corpus and is NOT derived from {DATASETS_ROOT_ENV} (#3148).\n\
          \x20 remedy       : unset {SCHEMAS_ROOT_ENV} to use the checkout default, or restore the\n\
-         \x20                committed fixtures:  git restore --source=HEAD -- test-data/schemas",
+         \x20                committed fixtures:  {restore}",
         path.display(),
         root.display(),
         source.describe(),

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -212,7 +212,9 @@ nightly full pass is the drift backstop.
 ## Pre-condition: test data must be present
 
 The gate aborts with exit code 1 if no `*-Data.db` files exist under
-`$CQLITE_DATASETS_ROOT/sstables`. Fetch them first:
+`$CQLITE_DATASETS_ROOT/sstables`. Fetch them first, and export **the
+`export CQLITE_DATASETS_ROOT=<abs>` line the script prints** — on a box that already had the
+variable set, the fetch populates *that* root, not the checkout's (issue #3131):
 
 ```bash
 bash test-data/scripts/fetch-datasets.sh
@@ -221,6 +223,11 @@ bash test-data/scripts/fetch-datasets.sh
 This prevents the failure mode where dataset-dependent tests silently pass on an
 empty dataset by returning 0 rows.
 
+The fixture contract has two halves — the SSTable bytes and the committed CQL schemas that
+decode them — and the FULL gate now fails closed on either. The two markers are deliberately
+distinct text so a pasted SUMMARY separates the causes. The corpus guard runs first, so a run
+missing both reports #2078, the half an operator must act on.
+
 **Missing-fixtures fail-closed (issue #2078).** The FULL gate FAILs CLOSED when the
 fetched validation corpus (`test_basic/…`) is absent, even though a fresh worktree's
 committed byte-parity reference `*-Data.db` files keep the raw Data.db count > 0
@@ -228,6 +235,37 @@ committed byte-parity reference `*-Data.db` files keep the raw Data.db count > 0
 with the remedy (`bash test-data/scripts/fetch-datasets.sh`);
 `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` restores the lenient SKIP and stamps a visible
 `missing-fixtures: OPT-OUT (…)` line. `--lite`/`--only` are unchanged (lenient).
+
+**Missing-schemas fail-closed (issue #3148).** The FULL gate also FAILs CLOSED when the
+committed CQL schema fixtures are unreachable, stamping
+`missing-schemas: FAIL-CLOSED (#3148)`. It checks **readability of the specific canonical
+`.cql` files** the dataset-backed components consume, not directory existence, because a
+partial copy is the realistic failure. Two causes, each with its own remedy line:
+
+- a canonical `.cql` under the resolved schemas root is not a readable regular file —
+  remedy: unset `CQLITE_SCHEMAS_ROOT`, or
+  `git restore --source=HEAD -- test-data/schemas`;
+- `CQLITE_SCHEMAS_ROOT` was set to a **relative** path and was rejected — remedy: export an
+  absolute path, or unset it. A relative override cannot mean the same thing on both sides:
+  the gate resolves it against the repository root, cargo resolves it against each test
+  binary's *package* directory, so the SUMMARY would certify one schemas root while the tests
+  read another.
+
+On success the SUMMARY carries a positive
+`schemas: N/N canonical .cql readable under <root> (<source>)` line, so a pasted block shows
+the check RAN. `--lite`/`--only` stay lenient. Before #3148 the preflight validated only the
+corpus: a layout whose `sstables/` was complete but whose schemas were unreachable passed with
+`STATUS: OK`, built for ~8 minutes, then failed `core-tests` + `memory-budget` on opaque
+missing-`.cql` panics — worse than no preflight, since the recorded "fixtures verified" pointed
+triage at the diff under test.
+
+**There is deliberately no opt-out for `missing-schemas:`**, unlike #2078's
+`AGENT_GATE_ALLOW_MISSING_FIXTURES`. The fetched corpus is legitimately absent on a fresh box;
+committed source in a checkout never is. An unreachable schemas root means a broken checkout or
+a stale override, so an escape hatch could only buy a vacuous green.
+
+The schemas root itself is resolved **checkout-relative**, never as a `..` sibling of
+`$CQLITE_DATASETS_ROOT` — see [Test data](/cqlite/agents-developing/test-data/).
 
 ## Running the gate
 
@@ -516,6 +554,7 @@ PR report — prose summaries are not accepted.
 ==== AGENT-GATE SUMMARY ====
 commit: <short-sha> branch: <branch> dirty: yes|no
 datasets: <N> Data.db files under <CQLITE_DATASETS_ROOT>
+schemas: <N>/<N> canonical .cql readable under <root> (checkout-relative|CQLITE_SCHEMAS_ROOT override)
 ci-pins: DATASET_TAG: <tag>  DATASET_ASSET: <asset>  DATASET_SHA256: <sha>  
 tree-start: <head-sha12> dirty: yes|no digest: <digest12>
 tree-end:   <head-sha12> dirty: yes|no digest: <digest12>

--- a/website/src/content/docs/agents-developing/test-data.md
+++ b/website/src/content/docs/agents-developing/test-data.md
@@ -1,6 +1,6 @@
 ---
 title: Test Data
-description: Fetching the dataset, dataset pins, CQLITE_DATASETS_ROOT, and what happens without Data.db files.
+description: Fetching the dataset, dataset pins, CQLITE_DATASETS_ROOT, the checkout-relative schemas root, and what happens without Data.db files.
 sidebar:
   label: Test data
   order: 4
@@ -16,9 +16,40 @@ GitHub release asset.
 bash test-data/scripts/fetch-datasets.sh
 ```
 
-This downloads, verifies (SHA256), and extracts to `test-data/datasets/`. It also
-removes macOS AppleDouble (`._*`) and `.DS_Store` files that macOS `tar` embeds in
-archives and that break file-suffix scanners like `*-Data.db`.
+This downloads, verifies (SHA256), and extracts to `$CQLITE_DATASETS_ROOT` (default
+`test-data/datasets/`). It also removes macOS AppleDouble (`._*`) and `.DS_Store` files
+that macOS `tar` embeds in archives and that break file-suffix scanners like `*-Data.db`.
+
+**Use the export line the script prints (issue #3131).** Both exit paths — fresh
+extraction *and* warm cache — now re-verify the content at the extraction target and print
+the one root that run guarantees:
+
+```
+Dataset root VERIFIED (warm cache, download skipped): /data/datasets — 155 *-Data.db present
+Use EXACTLY this root (the only one this run guarantees):
+
+  export CQLITE_DATASETS_ROOT=/data/datasets
+```
+
+**That printed line takes precedence over any root remembered from CLAUDE.md or from this
+page.** If `CQLITE_DATASETS_ROOT` was already set in the environment, the fetch extracts
+*there* and never populates the checkout's `test-data/datasets` — so exporting
+`$PWD/test-data/datasets` afterwards gives you a corpus-less root. The script prints an
+explicit `NOTE:` when the two differ. Before #3131 the warm path exited 0 having named no
+root at all, which is how the documented remedy silently failed to remedy.
+
+Two flags:
+
+```bash
+bash test-data/scripts/fetch-datasets.sh --verify-only   # is this root usable? mutates NOTHING
+bash test-data/scripts/fetch-datasets.sh --help
+```
+
+`--verify-only` downloads, extracts, removes and creates nothing (it will not even `mkdir`
+the parent of the root it is probing), so it is safe to run against a live corpus. **Every
+unrecognized argument is rejected with exit 2**, deliberately: the script's default path is
+destructive (`rm -rf` on the dataset root), so a typo like `-verify-only` must never
+silently select it.
 
 ## Dataset pins
 
@@ -55,18 +86,71 @@ bsdtar hides `._*` on listing and re-embeds them on repack).
 
 ## CQLITE_DATASETS_ROOT
 
-Set this environment variable to point at the extracted dataset directory:
+This environment variable points at the extracted dataset directory — use the absolute
+path `fetch-datasets.sh` printed, e.g.:
 
 ```bash
-export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+export CQLITE_DATASETS_ROOT=/data/datasets
 ```
 
-The gate script sets it automatically to `$REPO_ROOT/test-data/datasets` if not
-already set. Integration test runners require it; CI sets it in the workflow env.
+The gate script defaults it to `$REPO_ROOT/test-data/datasets` if not already set.
+Integration test runners require it; CI sets it in the workflow env.
+
+**`CQLITE_DATASETS_ROOT` alone is sufficient, on every layout (issues #3131 / #3148).**
+The corpus root does **not** need a `schemas` sibling next to it, and no composite/symlinked
+root has to be assembled to make one appear. Any usable corpus root works, including one
+entirely outside the checkout.
 
 **Without it**, tests that scan for SSTables will find no files and return results as
 if no data exists — not an error, just empty. This is the silent-pass failure mode
 the gate's dataset preflight check was added to catch.
+
+## The schemas root is checkout-relative, not a sibling of the corpus
+
+`test-data/schemas/` (23 **committed** files, including the `legacy/` and `udts/`
+subdirectories) is source, not fetched data. It is never part of the dataset archive.
+
+Tests and benches resolve it **checkout-relative** through the single shared helper
+`test-data/support/fixture_roots.rs`, anchored on the enclosing checkout's workspace-root
+`Cargo.toml` (the nearest ancestor manifest declaring `[workspace]`). Nothing climbs `..`
+from the datasets root any more.
+
+The retired idiom was `datasets_root().join("../schemas")`, and it failed two ways:
+
+1. It made **committed source's** location depend on an env var whose entire purpose is to
+   point at *relocatable fetched data*. A machine caching its corpus at `/data/datasets`
+   then needed a `/data/schemas` that no `git checkout` ever creates — the #3131 report,
+   "no single `CQLITE_DATASETS_ROOT` works."
+2. `join("..")` is **not** a lexical parent at the syscall level: the kernel resolves
+   `datasets/..` against the *symlink target's* parent. So a symlinked `/data/datasets`
+   resolved `../schemas` into the checkout while a real directory resolved it to
+   `/data/schemas` — two visually identical layouts, opposite outcomes, no error explaining
+   why (#3148's "symlink trap"). Anchoring on the checkout removes the `..` component
+   entirely, so there is nothing left to mis-resolve.
+
+Consequence for operators: **do not create a `schemas` symlink next to your corpus.** If a
+runbook or an older report told you to, that instruction is retired.
+
+### CQLITE_SCHEMAS_ROOT (optional, and MUST be absolute)
+
+`CQLITE_SCHEMAS_ROOT` overrides the checkout default. It exists only for a genuinely
+out-of-tree run (a packaged corpus plus schemas shipped together, no checkout) — the normal
+case needs no environment variable at all.
+
+| Value | Result |
+|-------|--------|
+| unset / blank | checkout-relative default (an exported-but-empty var is a scripting accident, never a root) |
+| **relative** | **REJECTED fail-closed** — the gate FAILs, the test helper panics |
+| absolute + readable directory | used, and reported as an override |
+| absolute but not a directory | falls back to the checkout default, so a stale export degrades instead of breaking every fixture load |
+
+**Why a relative value is rejected rather than resolved**: it cannot mean the same thing on
+both sides of the contract. `scripts/agent-gate.sh` evaluates it with CWD = repository root,
+while cargo runs each test binary with CWD = the *package* directory. A relative override
+would let the gate stamp `schemas: 6/6 … under packaged/schemas (override)` while every test
+binary silently read the checkout's schemas instead — a SUMMARY certifying root A for a run
+that used root B, which is exactly the misleading-`STATUS: OK` defect #3148 was filed for.
+Rejecting it makes the two sides agree by construction.
 
 ## What happens without Data.db files
 
@@ -76,15 +160,24 @@ the gate's dataset preflight check was added to catch.
   you must fetch the data first
 - Smoke tests — fail immediately; the smoke script expects at least one Data.db per table
 
-The gate's dataset preflight check:
-```bash
-DATA_COUNT=$(find "$CQLITE_DATASETS_ROOT/sstables" -name "*-Data.db" 2>/dev/null | wc -l | tr -d ' ')
-if [ "$DATA_COUNT" -eq 0 ]; then
-  echo "agent-gate: no Data.db files under $CQLITE_DATASETS_ROOT/sstables" >&2
-  echo "agent-gate: fetch them first: bash test-data/scripts/fetch-datasets.sh" >&2
-  exit 1
-fi
-```
+The FULL gate's fixture preflight has **two** fail-closed causes, one per half of the fixture
+contract, and both are textually distinct in the SUMMARY:
+
+| Marker | Cause | Opt-out |
+|--------|-------|---------|
+| `missing-fixtures: FAIL-CLOSED (#2078)` | the fetched `test_basic` corpus is absent | `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` (stamps a visible `missing-fixtures: OPT-OUT (…)`) |
+| `missing-schemas: FAIL-CLOSED (#3148)` | a canonical `.cql` under the resolved schemas root is not a readable regular file, **or** `CQLITE_SCHEMAS_ROOT` was relative and got rejected | **none, by design** |
+
+The corpus guard runs first, so a run missing both reports the #2078 cause — the fetched half
+is the one an operator must act on. On success the SUMMARY carries a positive
+`schemas: N/N canonical .cql readable under <root> (<source>)` line, so a pasted block shows
+the check ran rather than merely that nothing complained. `--lite` and `--only` stay lenient;
+only the FULL gate is strict. Details: [Gate contract](/cqlite/agents-developing/gate-contract/).
+
+**Why `missing-schemas:` has no opt-out.** The fetched corpus is legitimately absent on a
+fresh box, so #2078 needs an escape hatch. Committed source in a checkout never is — an
+unreachable schemas root means a broken checkout or a stale override, and neither may certify
+a run. An opt-out could only ever buy a vacuous green.
 
 ## Dataset layout
 
@@ -106,6 +199,11 @@ test-data/datasets/
     ├── test_timeseries/
     └── test_wide_rows/
 ```
+
+`test-data/schemas/` is **not** shown above and is not part of this tree: it is committed
+source living beside `datasets/` in the checkout, and it is resolved from the checkout, not
+from `$CQLITE_DATASETS_ROOT`. When the corpus is relocated outside the checkout there is no
+`schemas` sibling next to it, and none is needed.
 
 ## Dataset tiers
 


### PR DESCRIPTION
# Resolve committed CQL schema fixtures checkout-relative; make the gate preflight validate them

Closes #3131
Closes #3148

The CQL schema fixtures under `test-data/schemas/` are **committed source** (23 files including
`legacy/` and `udts/`), but four independently-written call sites located them by climbing `..` from
`$CQLITE_DATASETS_ROOT` — an env var whose entire purpose is to point at *fetched, relocatable* data.
Two failures followed from that one coupling:

* **No single root worked on the fleet (#3131).** `/data/datasets` (where `fetch-datasets.sh` caches
  and extracts) holds ~155 `-Data.db` but `/data` has no `schemas/`; the CLAUDE.md-documented
  `<repo>/test-data/datasets` has the sibling but **zero** `test_basic` fixtures. Pointing at the
  former cleared the preflight and then failed 5–8 tests on
  `Path does not exist: /data/datasets/../schemas/basic-types.cql`.
* **The gate's preflight validated only half the fixture contract (#3148).**
  `grep -c schemas scripts/agent-gate.sh` was **0**: it counted `sstables/test_basic/*-Data.db` and
  reported that as *fixture readiness* — `STATUS: OK` — then failed `core-tests` and `memory-budget`
  ~8 minutes later on opaque missing-`.cql` panics. That is **worse than no preflight**: `STATUS: OK`
  is positively misleading, so the agent looks at its own diff. On #3095 / PR #3141 an environmental
  failure was nearly attributed to an unrelated read-path change.

`join("..")` is also not a lexical parent at the syscall level — the kernel resolves `datasets/..`
against the **symlink target's** parent — so two visually identical layouts gave opposite outcomes
with no error explaining why (#3148's "symlink trap").

## The design decision (#3148 AC (h))

**Resolve the schemas root CHECKOUT-RELATIVE, never from `CQLITE_DATASETS_ROOT`** (#3148's proposed
fix 4). A checkout always holds these files, so the failure mode becomes *structurally impossible* and
the symlink trap **disappears** rather than being papered over: zero `..` climbing from the datasets
root remains, so there is nothing left to mis-resolve. `CQLITE_SCHEMAS_ROOT` is honored as an
absolute-only override for out-of-tree runs.

Two alternatives were considered and rejected:

| Alternative | Why rejected |
|---|---|
| Ship `schemas/` inside the dataset archive (#3131 item 1b) | Duplicates **committed source** into a versioned binary asset — a schema edit would then need a dataset re-release, and the two copies can disagree with no signal. |
| Make the fetch populate `<repo>/test-data/datasets` (#3131 item 1a) | Does not fix the general case (any relocated root re-breaks it) and fights the purpose of `CQLITE_DATASETS_ROOT` as a large, relocatable, machine-local cache. |

This **supersedes #3131 item 1's either/or**: with the schemas decoupled, *any* corpus root works, so
`/data/datasets` is self-sufficient unchanged and no data is duplicated.

## Acceptance criteria → evidence

| AC | Evidence |
|----|----------|
| **#3148 (a)** FULL gate fails closed, named error + remedy | `apply_schemas_preflight` (`scripts/agent-gate.sh`); self-test `3148-full-fail` (real full gate, exits at the preflight, non-zero + `RESULT: FAIL`, never `PASS`); negative-control run below |
| **#3148 (b)** exact absolute path + fix command; marker distinguishable from `missing-fixtures:` | self-tests `3148-remedy`, `3148-marker-distinct`, `3148-relative-absolute-label` (the last asserts no relative path ever reaches an "expected absolute path" line, against the **real emit**) |
| **#3148 (c)** positive-control self-test proves the preflight FAILS | `scripts/tests/test_agent_gate_schemas_preflight.sh` — **32 cases**, wired into `tooling-tests`. Rejection cases: schemas-less root, present-but-**incomplete** root, directory-named-like-a-`.cql`, relative override, control-character override. Every fix in this PR was proven to **fail on a revert** (see review history) |
| **#3148 (d)** one definition, used by every caller; no open-coded `join("../schemas")` | `test-data/support/fixture_roots.rs`; self-tests `3148-shared-file`, `3148-all-sites`, `3148-no-dupe-root`, `3148-no-dotdot-climb` (structural reintroduction guard; zero matches) |
| **#3148 (e)** the divergent `datasets_root()` impls reconciled | one impl, two documented shapes (`datasets_root` infallible-with-fallback / `datasets_root_if_present` env-only). Behaviour preserved per test: `dead_cache_delete_tests` still SKIPs; benches still run from a plain checkout. `cqlite-core/tests/issue_3148_fixture_roots_contract.rs` |
| **#3148 (f)** symlinked-`datasets` layout works or is rejected | asserted **behaviourally**: `3148-symlink-independence` (identical resolved root across real / symlinked / nonexistent datasets roots) + `3148-no-dotdot-climb`. The trap is removed, not detected |
| **#3148 (g)** `--lite` / `--only` stay lenient | self-tests `3148-lite` (no schemas line at all), `3148-only`, `3148-only-reject-lenient`, `3148-only-no-false-positive`, `3148-full-positive-line` |
| **#3148 (h)** scope decision recorded | `openspec/changes/schemas-root-contract/{proposal,design}.md` incl. the rejection table above |
| **#3131 (1)** one documented root that works | superseded by (h) — any corpus root works. `3148-symlink-independence`; hostile-layout run below |
| **#3131 (2)** fetch never exits 0 leaving an unusable root | `guarantee_usable_root` on both exit paths + `--verify-only`; self-tests `3131-hollow-root`, `3131-export-line`, `3131-export-quoting`, `3131-verify-no-mutation`, `3131-arg-safety`, `3131-symlinked-root` |
| **#3131 (3)** preflight detects the schemas half | same as #3148 (a); per-**file** readability, not directory existence (`3148-hook-partial`) |
| **#3131 (4)** docs updated in the same change | commits `3077893` (CLAUDE.md), `2daec4a` (website test-data + gate-contract), `0c44bc0` (fleet-runbook + the #3027 report; retires the `/data/schemas` symlink instruction) |

## Review history — three rounds, and three vacuous verifications found in this PR's own work

Recorded in full because it is the strongest evidence the fix is real. This change is *about* a
verification that was silently not verifying, and the same mistake was made three times while fixing it.

* **Round 1 — 3 blockers, all closed pre-gate.** (B3) `fetch-datasets.sh` matched `--verify-only` only
  as `$1`, so `--quiet --verify-only` or any typo silently selected the **destructive** path and
  reached `rm -rf "${DATASET_ROOT}"` against the operator's corpus — a data-loss hazard introduced by
  adding a flag. (B2) `--verify-only` promised to mutate nothing but created the root's parent
  directory. (B1) a **relative** `CQLITE_SCHEMAS_ROOT` was resolved rather than rejected, and the gate
  (CWD = repo root) and cargo (CWD = package dir) resolve it differently — so the SUMMARY stamped
  `schemas: 6/6 … readable under packaged/schemas` while the tests read the checkout. Plus N4 (the
  checkout was identified by the *fixtures*, so a worktree nested inside another checkout silently
  borrowed the outer tree), N6 (dead helper deleted), N7 (`-r` accepted a *directory* named
  `basic-types.cql`).
* **Round 2 — no blockers; 6 nits; roborev round VOIDED** because `origin/main` advanced 4 commits
  mid-review, so `sha-assert` FAILed against a stale base. Rebased onto `8e85b9e` and re-reviewed.
* **Round 3 — mergeable as-is; roborev job 10 valid, 3 findings**, all triaged and fixed.

**The three vacuous verifications this PR found in itself:**

1. **A positive assertion for a check that never ran.** `_schemas_status` returns `OK` unconditionally
   under `--only` (correct leniency), and the OK branch then stamped
   `schemas: 6/6 canonical .cql readable under <root>` **without checking**. Demonstrated by removing
   the fix: it stamped `6/6 … readable` for a root with **zero** readable fixtures. Now stamps an
   explicit `schemas: not checked (<mode> is lenient) — this block asserts NOTHING about the schemas
   root`; silent omission was rejected because it lets a reader assume the full contract held.
2. **An assert that passed after a full revert of the code it guarded.** The AC-(b) "no relative path
   labelled absolute" case matched hook **stdout**, but the string is `apply_schemas_preflight`
   **stderr** — so it could never appear and the case passed unconditionally. Re-pointed at the real
   full-gate emit and proven to FAIL on a revert.
3. **A control that could not discriminate.** The N4 marker-rule test ran only from
   `CARGO_MANIFEST_DIR`, where the retired fixtures-keyed walk returns the *same* path — so it passed
   either way. Now driven over a synthetic `outer/{Cargo.toml,test-data/schemas}` +
   `outer/inner/{Cargo.toml,cqlite-core}` layout where the two rules disagree; proven to FAIL on a revert.

Two roborev findings had a **real defect behind a wrong stated mechanism**, so each premise was
verified before acting: 9-2 was *understated* (a symlinked datasets root did not "verify with count 0",
it failed verification outright, because `find` never descends an un-`-H`'d symlink base), and 9-1's
exploit path was *mis-sited* (unreachable from a caller's CWD, because the gate `cd`s to its own repo
root — the code inconsistency was still real and fixed). One finding, 10-2, was a **regression
introduced by round 2's own fix**: consuming the override through `$( )` strips trailing newlines, so
the gate certified `/abs/dir` while Rust kept the newline and degraded to the checkout.

Neither the shell mirror nor the Rust resolver claims equivalence "by construction" — the docs now say
what is true: **two hand-written mirrors, equivalent today, pinned by the self-test**, with an explicit
instruction to re-walk the input table when either side changes.

## Scope boundaries

* **#2878 untouched.** `rm -rf "${DATASET_ROOT}"` and the `[ -n "${CI:-}" ] || return 0` short-circuit
  in `restore_ci_tracked_dataset_files` are deliberately unchanged; self-test `3131-2878-boundary`
  asserts both remain verbatim so the boundary cannot be silently crossed later.
* **~15 `parent()?.join("schemas")` sites deferred to #3192.** Those files try the datasets sibling
  **and then** a `CARGO_MANIFEST_DIR` checkout fallback, so they *degrade* correctly on the layout that
  hard-failed the four sites fixed here — duplication and a latent wrong-root hazard, not an outage.
  The reintroduction guard therefore greps only the literal `join("../schemas")`; widening it to the
  `parent()`-based form must land **with** that migration, or it would red the gate on ~15 untouched
  files. The spec's single-definition requirement is explicitly scoped to the four sites.
* **Canonical fixture list scoped to 6 of 23 by consumption** — the `.cql` the gate's dataset-backed
  components actually read. Growing it is guard-*completeness* work needing per-component evidence of
  which file each consumes; deliberately not attempted here.
* **No library surface, no format work.** The shared module is test/bench support and never compiles
  into the library.

## Verification

* **Hostile layout** (the layout that caused this): `CQLITE_DATASETS_ROOT` at a scratch root holding
  the corpus with **no** `../schemas` sibling, `CQLITE_SCHEMAS_ROOT` unset — `dead_cache_delete_tests`
  8/8 (incl. the 4 `stats_*`), `memory_budget` 3/3, `issue_1494_converter_alloc_budget` 1/1,
  `issue_2075_row_assembly_alloc_budget` 1/1. Run with `--features cli-helpers` (+ `dhat-heap,arrow`)
  so the feature-gated targets are actually compiled rather than silently empty.
* **Non-vacuity control 1:** with `CQLITE_SCHEMAS_ROOT` at an empty directory, exactly the 4
  schema-consuming `stats_*` tests FAIL with the new actionable message — proving the passes above are
  real schema loads, not skips.
* **Non-vacuity control 2:** with a *relative* `CQLITE_SCHEMAS_ROOT`, all 4 fail closed on
  `must be an ABSOLUTE path` — no silent fallback.
* **Negative-control FULL gate** (complete `/data/datasets` corpus + unreachable schemas root):
  exits 1 **at the preflight, before any cargo component**, stamping
  `missing-schemas: FAIL-CLOSED (#3148)` + `RESULT: FAIL`.
* Self-test 41/41 (grew across six review rounds; certified by `tooling-tests: PASS (334s)` in the gate of record), contract tests 9/9, `test_agent_gate_summary.sh` 101/101 (unperturbed),
  `check-dataset-pin.sh` green, clippy clean on both touched packages.
* **The gate of record runs with this box's `/data/schemas` symlink REMOVED**, so it cannot borrow the
  local workaround this PR exists to make unnecessary.

## Delivery history (not a clean single-gate history)

**Five full-gate runs, six review rounds, three intent audits.** The superseded runs are recorded
because the review history is the strongest evidence the fix is real — not because any of them
certifies anything. Two of the five were genuine `RESULT: PASS` runs that a later review finding
invalidated; presenting only the last one would hide that this change needed four rounds of
adversarial review to become correct.

### Full-gate runs

1. **Run 1 — `919b921` — FAIL on `tooling-tests`.** *Ours, and not waivable*: the diff touches
   `scripts/agent-gate.sh`, so CLAUDE.md's cite-and-waive path (which requires a diff touching no
   compiled input) did not apply. Root cause: round 3's NIT-D fix stubbed `emit_summary`/
   `_tree_meta_array` and thereby created a **duplicate `_tree*` definition**, caught by the
   *pre-existing* `test_agent_gate_tree_portability.sh` uniqueness assert (`n=45 uniq=44`). Fixed in
   round 4; portability 29/29.
2. **Run 2 — `4c3a4c4` — KILLED MID-FLIGHT, no verdict.** Its summary correctly still holds the
   launch-time `RESULT: INCOMPLETE` liveness placeholder (#3041). The intent audit had just found the
   env opt-out defect below; the fix touches `agent-gate.sh`, so finishing the run would have spent
   ~40 min certifying a dead SHA.
3. **Run 3 — `e40cb68` — `RESULT: PASS`, but SUPERSEDED.** A genuine full PASS that is *not* the gate
   of record: the roborev blocker below required a `src` fix, and any src change invalidates the gate
   that preceded it.
4. **Run 4 — `b64bdab` — `RESULT: PASS`, but SUPERSEDED too.** Certified the non-UTF-8 blocker fix,
   then review round 5 raised two further findings against `scripts/agent-gate.sh` and its self-test,
   which again invalidated it.
5. **Run 5 — `0494f8c` — the gate of record.** Block below. Run under `env -u CQLITE_SCHEMAS_ROOT`
   with `/data/schemas` absent (retired to `/data/schemas.RETIRED-3131`) and
   `CQLITE_DATASETS_ROOT=/data/datasets` — **no fixture env var was set to obtain green** in any of
   the five runs.

### The roborev blocker (job 11, finding 1) — non-UTF-8 override drift

The fourth review round found that the mechanism this change installs had a **third** drift instance
of a class it already pinned twice. `std::env::var` maps a non-UTF-8 `CQLITE_SCHEMAS_ROOT` to
`Err(NotUnicode)`, which a catch-all `_ => None` arm collapsed to "unset", so Rust silently fell back
to the checkout **while Bash validated the same byte-path as an override** — the gate certifying a
root the run never used, which is precisely this change's stated forbidden condition. The premise was
verified empirically before fixing: for a real `bad\xff\xfedir` directory, Bash reported `STATUS: OK`
+ `SOURCE: CQLITE_SCHEMAS_ROOT override` while Rust returned `Err(NotUnicode)` and fell back.

Fixed on **both** sides. Rust takes `resolve_schemas_root(Option<&OsStr>)` via `var_os`, so non-UTF-8
is *representable* and gets an explicit `Err` arm rather than inheriting a lossy conversion — and the
catch-all over an error variant, which is what created the defect, is gone. Bash gained
`_gate_schemas_override_is_utf8` plus a `non-utf8` reject kind with its own prose and marker; pure
ASCII is accepted with no external tool, anything else is validated with `iconv`, and **an absent
`iconv` REJECTS** — "could not check" must not mean "accept". Both sides now agree across the full
input table: unset/empty/whitespace → checkout; non-UTF-8, control-char, relative → REJECT;
absolute-non-dir → checkout; absolute-dir → override. A legitimate **multibyte UTF-8** root is still
accepted and asserted, so this is not a ban on non-ASCII paths.

**The datasets root was hardened in the same round, and its hazard was worse than the reported one.**
A non-UTF-8 `CQLITE_DATASETS_ROOT` would have had the gate certify a corpus while every test silently
read the checkout's `datasets`, which holds only committed byte-parity refs and **no `test_basic`** —
a #2078-class vacuous pass with the preflight vouching for a corpus the run never used. (The schemas
fallback was at least the *complete* committed tree; this one is not.) Since `datasets_root()` is
infallible the mechanism is **honor the OS value** (`PathBuf::from(&OsStr)`), not a panic: three
lines, no new failure mode, one fewer silent fallback, and Rust now agrees with what Bash already did.

**Three drift instances are now pinned, up from two of three**: `3148-non-utf8-override` at the real
emit (revert the Bash guard → FAILS with rc=124, the run sails past the preflight),
`non_utf8_override_is_rejected_fail_closed` (revert the Rust arm → FAILS), and
`3148-utf8-override-ok` guarding against over-rejection. The control-char and relative pins were
re-confirmed green.

Two nits from the same round were fixed in that round rather than deferred, since a full re-gate was
already mandated and they therefore triggered no extra verification round: the `resolve_schema_path`
remedy is now `git -C <workspace_root> restore …` (asserted to carry that exact absolute `-C` and to
be CWD-independent — the previous relative form failed when pasted from cargo's package-dir CWD, the
same CWD asymmetry this module rejects *relative overrides* for), and `fetch-datasets.sh` applies
`%q` to `PIN_FILE`/`DATASET_ROOT`, asserted by an `eval` round-trip on a path containing a space
and `&`.

### Review round 5 (roborev job 12) — two Medium findings, both fixed

Round 5 returned `RESULT: FAIL` with two findings, both against the guard this change installs.
Neither could produce a false green; both were fixed anyway rather than deferred, because each
*removes* a dependency and a failure class rather than papering over one.

**Finding 1 — `_gate_schemas_override_is_utf8` piped ASCII probe. Defensive hardening, with a
measured non-reproduction — NOT a fixed live bug.** The probe was `printf | grep -q`, and under the
script-wide `set -o pipefail` (`agent-gate.sh:369`) a **negated** pipeline whose *left* side can take
SIGPIPE is a latent branch-inversion hazard: had it fired, a malformed override would have taken the
"pure ASCII" branch and skipped validation, so Bash would accept a value Rust rejects — this change's
own forbidden condition.

It **did not reproduce**, and that measurement is recorded rather than quietly replaced by a bug-fix
narrative: bash's **builtin** `printf` (what the code used) yields `PIPESTATUS=[0 0]` at 5 B, 100 KB,
1 MB and **5 MB** on bash 5.2.21, so the inversion never fires; and independently, a value large
enough to fill a 64 KB pipe is ~16× this platform's `PATH_MAX` of **4096** and could therefore never
name a real directory. Hardened regardless, because the hazard is platform-scoped rather than absent:
the probe is now a subprocess-free `case` under a function-local `LC_ALL=C`, which removes the
pipeline, the SIGPIPE class **and** the `grep` dependency at once, and was verified to classify
identically under `C`, `C.UTF-8` and `en_US.UTF-8`.

**Finding 2 — `3148-utf8-override-ok` required `iconv`.** The pin demanded a multibyte override be
*accepted*, while the implementation deliberately **rejects** non-ASCII when `iconv` is absent. On an
`iconv`-less host that pin redded `tooling-tests`, and with it the whole gate, on a perfectly valid
root — a **false RED**, not a false green, but a fleet foot-gun now that the self-test runs inside the
gate. It now asserts whichever outcome is *documented* for the host it runs on.

That conditional branch is unreachable wherever `iconv` exists, which would have left the
fail-closed-when-unverifiable promise untested exactly where it matters — the "coverage that never
runs" pattern this change has had to dig out of itself repeatedly. So a new **`3148-utf8-no-iconv`**
case builds a PATH farm symlinking every executable *except* `iconv` and asserts the **same valid
multibyte root** is rejected fail-closed (`STATUS: FAIL`, `SOURCE: … REJECTED`, `must be valid
UTF-8`). It is not a silent skip: a farm that cannot be built is a loud, named failure. Self-test
41/41 (40 → 41).

The **full input table was re-walked through the real hook** after the rewrite, and all eight rows
classify exactly as the intent audit's table walk established: unset / whitespace → checkout;
relative, non-UTF-8 and control-char → REJECT each naming its own reason; absolute-non-dir →
checkout; absolute-dir and multibyte-UTF-8 → override accepted. No row changed.

### Load-bearing check ORDER in the two classifiers (do not reorder)

The two sides deliberately check in different orders — Bash `cntrl → utf8 → relative`
(`_gate_schemas_override_reject_kind`), Rust `utf8 → cntrl → relative`. Consequences, established by
the intent audit's side-by-side table walk:

* A value that is **both** non-UTF-8 and control-bearing gets a different `kind` **label** on each
  side. Both still **REJECT**, so there is no mis-certification — but the labels are *not*
  interchangeable, and a test asserting a specific `kind` must target the right side.
* **The ordering is load-bearing, and its REASON changed with the round-5 rewrite.** Originally it was
  load-bearing because `grep` treats a newline as a line terminator, so a newline-bearing value would
  slip the ASCII fast path. The `grep` is now gone — but the ordering requirement is not, for a
  different and simpler reason: **a newline is valid UTF-8**, so `_gate_schemas_override_is_utf8`
  accepts one. Were control-char screening not to run first, a newline-bearing **absolute** path would
  be accepted outright instead of classified `control-chars`. The in-line comment in
  `scripts/agent-gate.sh` was corrected to state this rather than left asserting a rationale that no
  longer holds — the stale-justification failure mode is the same one this PR is about.

### Intent audits (C) — three verdicts

First **PARTIAL** on 4 items (all later cleared, 5 of 5 on re-audit). The re-audit then found a **new
blocker**: `_SCHEMAS_PREFLIGHT_REPORT_ONLY` was read as `${…:-}` and never initialized, so an
**inherited/exported value flipped the FULL gate's fail-closed `exit 1` into `return 1`** — the run
could proceed to `RESULT: PASS` with the schemas root unreachable. That is an environment opt-out,
violating this change's own requirement 8. Fixed by replacing the variable with a **positional
argument** (`apply_schemas_preflight [report-only]`): the hook passes `report-only`, the real FULL
gate passes nothing, so strict is the default and *no state has to be correct*. Pinned by
`3148-no-env-report-only` (four plausible env spellings; asserts non-zero + `missing-schemas:
FAIL-CLOSED` + `RESULT: FAIL` present + no `RESULT: PASS`); the real discriminator is `RESULT: FAIL`
**present** — impossible for a run that proceeds, since launch stamps `INCOMPLETE` — so subtler
reintroductions are caught too. A class audit of every variable this change introduces found no other
instance. Final verdict **PASS**: requirement 8 holds *by construction* — mode is a `local` set only
from `$1`, exactly two call sites, and `$1` is unreachable from `export`/`env`/`env -i`/a same-named
variable/an inherited exported function.

### Honest boundaries (informational, verdict-neutral — from the intent audit)

* **`BASH_ENV` is arbitrary pre-parse code execution** and defeats any mechanism, including a
  positional argument. Requirement 8 is therefore read as *"no supported/readable env flag"*, **not**
  *"immune to shell code injection"*.
* **The preflight validates the 6 canonical `.cql` while `test-data/schemas` commits 23.** A root
  holding only those 6 passes the preflight, after which components panic on a missing
  `legacy/`/`udts/` file → `RESULT: FAIL`. That is fail-**late**, not fail-open — it cannot certify a
  bad root — and it is the honest boundary of the 6-of-23 consumption scoping (widening it is
  guard-completeness work; see Scope boundaries).

## Agent gate (gate of record)

```
==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.wJwk9k
commit: 0494f8c branch: issue-3131-schemas-root-contract dirty: no
datasets: 144 Data.db files under /data/datasets
schemas: 6/6 canonical .cql readable under /home/ubuntu/workspace/cqlite-wt/issue-3131/test-data/schemas (checkout-relative)
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=absent
cpu-budget: wrapper=nice ncpu=16 max-concurrency=3 cores-per-gate=5 build-jobs=5(derived) test-threads=5
tree-start: 0494f8cfbadb dirty: no digest: fd0ea68ab67c
tree-end: 0494f8cfbadb dirty: no digest: fd0ea68ab67c
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (5s)
clippy:            PASS (1s)
roborev-lints:     PASS (22s)
core-tests:        PASS (74s)
tombstones-scan:   PASS (0s)
scan-offload-guard: PASS (2s)
work-counters-guard: PASS (18s)
byte-budget-guard: PASS (13s)
arrow-parity-guard: PASS (1s)
memory-budget:     PASS (10s)
integration-tests: PASS (0s)
format-compat:     PASS (0s)
write-tests:       PASS (10s)
cli-tests:         PASS (4s)
compaction-byte-parity: PASS (1s)
query-semantics-oracle: PASS (1s)
flight-query-semantics-oracle: PASS (0s)
python-bindings:   PASS (79s)
node-bindings:     PASS (120s)
delivery-telemetry: PASS (1s)
oom-audit:         PASS (1s)
parity-report:     PASS (0s)
operator-metrics-doc: PASS (0s)
kit-dashboard-drift: PASS (0s)
binding-unwind-profile: PASS (1s)
tooling-tests:     PASS (334s)
minimal-build:     PASS (0s)
smoke:             PASS (2s)
logs: /tmp/agent-gate.wJwk9k
summary-file: /tmp/gate-3131-record5.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Run under `env -u CQLITE_SCHEMAS_ROOT` with `CQLITE_DATASETS_ROOT=/data/datasets` and this box's
`/data/schemas` symlink **retired**, so the run could not borrow the local workaround this PR
exists to make unnecessary. No fixture env var was set to obtain green in any of the five runs.
Reader contract (#2874) discharged by the closer: process **exit code 0**, and
`run-id: /tmp/agent-gate.wJwk9k` **matches the sentinel captured at launch**, so this block
belongs to this run and not to a concurrent peer.

## roborev (final pass)

> [!IMPORTANT]
> **This PR does NOT claim "roborev clean."** The final review round reported
> `RESULT: FAIL`, and the block below is reproduced **verbatim, including that line**.
> It is merged under an explicit, narrowly-scoped owner authorization recorded at
> https://github.com/pmcfadin/cqlite/issues/3131#issuecomment-5145226722
>
> The override covers **round 6's three findings only** — one Medium locale-dependent
> classifier divergence (Rust *panics*, so it is loud and fail-closed, it cannot produce a
> false certification, it is unreachable in the gate of record, and two independent intent
> audits rated it verdict-neutral) and two Low findings (a test-only panic-hook swap, and
> an unquoted interpolation in a *printed* remedy string). It does **NOT** waive the gate
> of record — run 5 is `RESULT: PASS`, 0 FAIL components, `tree-integrity: PASS` on the
> certified SHA — and it does **NOT** waive the intent audit, which returned PASS across
> three audits. All three findings are tracked in the linked follow-up issue, each with
> its reproduction.

```
==== ROBOREV REVIEW SUMMARY ====
repo: /home/ubuntu/workspace/cqlite-wt/issue-3131
branch: issue-3131-schemas-root-contract
base: origin/main
head-sha: 0494f8cfbadb01db81fdc5a2e5cf0e33ad753ad6
reviewed-sha: 221d16dc5ea3927cd15befaf78bf4a5a416d7e62..0494f8cfbadb01db81fdc5a2e5cf0e33ad753ad6
job: 13
model: gpt-5.6-sol
census: 18 files, +3759/-84
tokens: input=180883 cached=119296 output=8073
push-assert: PASS
census-check: PASS
code-free: PASS
job-record: PASS
sha-assert: PASS
review-completed: PASS
prompt-content: PASS (9/9 code census paths present)
vacuity-tier1: PASS
vacuity-tier2: PASS
findings: PRESENT (3)
roborev-exit: FINDINGS (exit 1)
log: /tmp/roborev-3131-r6.log
RESULT: FAIL
==== END ROBOREV REVIEW SUMMARY ====
```

