### PR TITLE
fix(#3119): repo-owned gate notify contract — a FAIL gate can no longer page as PASS, and the dep is fleet-durable

### DIFF
--- a/.claude/skills/flow-board/SKILL.md
+++ b/.claude/skills/flow-board/SKILL.md
@@ -212,9 +212,11 @@ selection, no "next thing" happens without the board. The one-time fix is the ow
      as above) **AND** there is an open PR whose **head SHA is unchanged > 4 hours** **AND** no review
      activity newer than 4 hours. This is the orphaned endgame: a certified PR sitting completed-but-unowned.
      - **Do NOT auto-adopt — surface it (owner-attention, not silent steal).** When all three hold:
-       1. **Page the owner** via `agent-notify` (the ntfy wrapper): e.g.
-          `agent-notify --category error "orphaned endgame #<N>" "PR #<pr> head+review idle >4h; claim heartbeat stale — adopt-eligible"`.
-          Best-effort — if `agent-notify` is absent, skip silently and rely on the comment + surfacing.
+       1. **Page the owner** via the repo-owned notify contract (#3119): e.g.
+          `bash scripts/lib/gate-notify.sh --publish FAIL "orphaned endgame #<N>" "PR #<pr> head+review idle >4h; claim heartbeat stale — adopt-eligible"`.
+          Best-effort — with no ntfy target configured it is a silent no-op; rely on the comment + surfacing.
+          Never call `agent-notify` with a `--category` flag: upstream v1.1.0 has no such arm and swallows
+          it, publishing the flag NAME as the title and a red page as a green priority-3 success.
        2. Post a traceable comment on the **PR**: the machine whose claim is stale, the head-SHA age,
           the review-activity age, and that the PR is now adopt-eligible.
        3. Mark the issue **adopt-eligible** exactly as the first reaper does — leave the

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -36,6 +36,32 @@ gh auth status                                  # must include the 'project' sco
 bash scripts/flow/claim.sh smoke               # preflight: prove origin accepts refs/claims/* (see below)
 ```
 
+### Notification channel (ntfy) — one env var, no per-machine binary (#3119)
+
+Gate-completion pushes (#2667) and every supervisor page go over ntfy. **The payload contract lives in
+the repo** (`scripts/lib/gate-notify.sh`), so the only thing a machine supplies is the transport and a
+target:
+
+```bash
+# /etc/environment (fleet mechanism; re-login to pick it up)
+CODEX_NOTIFY_WEBHOOK=https://ntfy.sh/<your-topic>
+```
+
+`bash scripts/bootstrap-agent-machine.sh` prints the section *Notification channel (ntfy, issue #3119)*:
+it checks `curl` + `python3`, reports the target, runs `gate-notify.sh --self-test` as a **capability**
+assert (it publishes a PASS *and* a FAIL payload through a private capture shim — no network, no real
+topic) and records the pinned contract version. **No `agent-notify` install is required**, and no
+hand-patched copy is required by anything in this repo. If `agent-notify` happens to be installed it is
+used only as an optional local desktop/sound adjunct, invoked positionally with its webhook env
+neutralized.
+
+Why this is spelled out: the old path called `agent-notify --category <cat> …` (notify-flag-allow), a
+flag upstream v1.1.0 has no arm for. It fell through to manual title/message mode, so the title became
+the literal `--category`, the message became the category value, and **every FAIL paged as a green
+priority-3 success**; its ntfy publish also POSTed to the topic URL, so phones rendered raw JSON. A red
+gate that looks green is worse than no notification. With no target configured everything here is a
+silent no-op and nothing else changes — notifications never affect a gate verdict or a worker's exit.
+
 **Three deltas that fail with a message pointing away from their cause (#2942).** Each cost a
 worker a diagnosis round-trip on a Linux box; the bootstrap now checks the first two and fails
 loudly rather than reporting a healthy machine. Search for the message you actually saw:
@@ -242,6 +268,9 @@ What it guarantees:
 - **It cannot fail silently**: a push notification (ntfy) on every merge (info) and on any
   stop/hold/breaker-trip (alert). 2–3 consecutive abnormal exits trip the breaker → stop + alert,
   never hot-respawn. One journal line per iteration (issue, verdict, duration, PR, `verified`).
+  **The payload is repo-owned (#3119)** — see *Notification channel* below; an `alert` publishes ntfy
+  priority 5 + `rotating_light`, an `info` priority 3 + `white_check_mark`, so a red page can never
+  look like a routine one.
 - **It never wedges on a question (#2666)**: a worker that hits Seam 1 or a genuine owner decision
   **parks** (posts a `needs-decision` question comment + EXITs) rather than waiting — the supervisor
   judges it `parked-on-owner` and pages the owner once. A worker that nonetheless gets stuck on an

--- a/docs/scratch/agentic-workflow-audit/doc-deltas-supervisor.md
+++ b/docs/scratch/agentic-workflow-audit/doc-deltas-supervisor.md
@@ -78,7 +78,10 @@ write timing simple (one claim → one outcome → one write → exit).
    that lingers after its marker write risks a `timeout`-killed abnormal judgment on an
    otherwise-successful iteration.
 3. **`reason` field for `blocked`**: keep it short (one line) — it flows verbatim into
-   an ntfy notification body (`agent-notify --category completion "<title>" "<reason>"`).
+   an ntfy notification body. **HISTORICAL (superseded by #3119)**: this line used to
+   prescribe `agent-notify --category completion "<title>" "<reason>"` (notify-flag-allow) —
+   do NOT do that. Upstream `agent-notify` v1.1.0 has no `--category` arm and swallows it.
+   The current call is `bash scripts/lib/gate-notify.sh --publish <PASS|FAIL> "<title>" "<reason>"`.
    Put the actionable ask in it (e.g. "roborev flagged a design call on #1234: needs
    owner decision on X"), not a restatement of the whole finding.
 4. **`duration_s`**: worker-measured wall clock for its own claim→finalize/block/no-work

--- a/openspec/changes/notify-contract/design.md
+++ b/openspec/changes/notify-contract/design.md
@@ -1,0 +1,145 @@
+# Design: repo-owned gate notification contract (issue #3119)
+
+## Context
+
+The full gate's push signal (#2667) is the fleet's only out-of-band "your gate finished" event: it
+converts the summary file from a passive poll target into a push, so a backgrounded gate calls its
+waiting closer back instead of being idle-polled. Its value is entirely in **fidelity** — a signal
+that says PASS when the gate FAILed is worse than no signal, because a worker acts on it.
+
+Measured on this box against the pristine upstream binary (`curl`-capture shim, so no network):
+
+| binary | published body | POST target |
+|---|---|---|
+| `agent-notify.bak.20260730` (pristine v1.1.0) | `{"topic":"gate-test-topic","title":"--category","message":"error","priority":3,"tags":["white_check_mark"]}` | `https://ntfy.sh/gate-test-topic` |
+| `agent-notify` (hand-patched, ONE box) | `{"topic":"gate-test-topic","title":"gate FAIL br@abc1234","message":"RESULT: FAIL — failing: fmt,clippy","priority":5,"tags":["rotating_light"]}` | `https://ntfy.sh/` |
+
+The left column is what the entire fleet delivers today, for a **FAIL**.
+
+## The decision, and the constraint that forces it
+
+Three options were on the table. The forcing constraint is issue #3119's **AC6**: the contract test
+must pass against the **pristine** upstream binary, which has BOTH defects. That eliminates any design
+that leaves payload construction with upstream `agent-notify`:
+
+| option | AC1 title/body | AC2 distinct FAIL severity | AC3 message ≠ JSON | AC6 pristine | bootstrap pin/verify (AC5) | testable w/o network | upstream-drift cost |
+|---|---|---|---|---|---|---|---|
+| **(a)** capability-probe `--category`, degrade | yes — dropping the flag gives correct positional title/body | **NO** — pristine manual mode hard-pins `sound_category="completion"` (`:514`); priority/tag are unreachable from the caller | **NO** — the topic-URL POST is inside the binary, unreachable from the caller | fails AC2+AC3 | nothing to pin; probe is a proxy, not a capability assert | argv only | probe rots on every upstream flag change |
+| **(c)** vendor/pin the upstream script in-repo | only if we vendor a **patched fork** | same — a pristine vendored copy is still broken | same | **NO** by construction: a patched fork is not pristine | pin is easy (a git SHA) | yes | **high** — a ~1500-line fork of an actively-updated script, re-patched on every upstream release |
+| **(b)** repo-owned wrapper owning the payload | **yes** | **yes** | **yes** | **yes** — upstream is not in the payload chain | capability self-test + in-repo contract version | yes (local receiver / `curl` shim) | **near zero** — ntfy's publish API is stable and versioned |
+
+**Option (a) is eliminated by AC2 and AC3**, not by taste: two of the three defects live *inside* the
+binary, past any caller-side probe. **Option (c) is eliminated by AC6** and by maintenance cost — the
+only vendored copy that would pass AC1–3 is a fork, i.e. the same hand-patch, merely relocated into
+git.
+
+**Chosen: (b) — `scripts/lib/gate-notify.sh` owns the ntfy payload contract.** The payload is ~40
+lines of JSON plus one `curl`; owning it is strictly cheaper than owning a fork, and it makes the
+correctness of the fleet's paging channel a property of the repo (git-pinned, gate-tested) rather than
+a property of a machine's install history.
+
+## Shape
+
+```
+gate_push_signal()                     # scripts/agent-gate.sh — builds title/body, unchanged
+  └─ gate_notify_publish <sev> <title> <body>     # scripts/lib/gate-notify.sh (sourced)
+       ├─ resolve target: CQLITE_NOTIFY_WEBHOOK || CODEX_NOTIFY_WEBHOOK  (+ CODEX_NOTIFY_NTFY_TOPIC)
+       │     split into  root = scheme://host/    and  topic = last path segment
+       ├─ build JSON:  {topic, title, message, priority, tags}     (python3 json.dumps — never hand-quoted)
+       ├─ POST the JSON to the ROOT (bounded: curl --max-time, output discarded)
+       └─ OPTIONAL local adjunct: agent-notify "$title" "$body"   with the webhook env NEUTRALIZED
+```
+
+Severity map (identical to upstream's ntfy maps, so correct notifications look unchanged):
+
+| severity | priority | tag |
+|---|---|---|
+| PASS / `completion` | 3 | `white_check_mark` |
+| FAIL / `error` | 5 | `rotating_light` |
+
+### Why the topic/root split lives in the wrapper
+
+The fleet configures exactly one variable — `/etc/environment` on this box carries
+`CODEX_NOTIFY_WEBHOOK=https://ntfy.sh/pmcfadin-cloud-100` (plus `CODEX_NOTIFY_AGENT_NAME`) and there
+is no `CODEX_NOTIFY_WEBHOOK_PRESET`, no `~/.agent-notify.env`, and no `.codex-notify.env` in the repo.
+So the wrapper must accept a **topic URL** and derive the root itself (strip query/fragment, strip the
+trailing topic segment, keep the topic for the body). A URL that is already a bare server root is
+addressed by `CODEX_NOTIFY_NTFY_TOPIC` (or an explicit `CQLITE_NOTIFY_TOPIC`), and a target from which
+no topic can be resolved is a **silent no-op**, never a guessed topic — publishing to a guessed topic
+pages a stranger.
+
+### Advisory containment (AC4 is load-bearing)
+
+`gate_push_signal` runs at final-SUMMARY time, after the verdict is computed but before the exit.
+Anything it can do must be unable to change `RESULT:` or the exit status. Containment is structural,
+not by convention:
+
+- the wrapper is **sourced defensively** — a missing/unreadable `scripts/lib/gate-notify.sh` leaves
+  `gate_push_signal` a no-op returning 0, exactly as an absent `agent-notify` does today;
+- every external call is bounded (`curl --max-time`, the optional adjunct under `timeout`) so a
+  black-holed network or a hung helper cannot stall the gate;
+- all stdout/stderr is discarded, every invocation is `|| true`, and the function's last statement is
+  `return 0` — `set -e`/`pipefail` in the caller cannot see anything;
+- no `exit`, no `trap`, no writes to any gate variable, no writes to the summary file.
+
+The failure catalogue the tests must cover is therefore: absent helper, non-executable helper,
+non-zero exit, **rejects its arguments** (usage error — the class that produced this issue), unset
+webhook, absent `curl`, absent `python3`, and a hung publish.
+
+### Why the contract test must parse the published payload
+
+The existing test's blind spot is precise: it stubs the **payload producer**. Any replacement that
+keeps a stub in the payload-producing chain reproduces the same blind spot. So the contract test
+exercises the real `gate_push_signal` → real `gate-notify.sh` → real JSON construction, and captures
+at the **transport boundary**: a `curl`-capture shim on PATH (which is exactly how the defect above was
+measured) or a loopback HTTP receiver. What is asserted is the **published bytes**: `title`,
+`message`, `priority`, `tags`, the POST **target being the server root**, and — as a standing
+regression guard for defect 3 — that `message` does not begin with `{`.
+
+A loopback receiver was attempted first here and was unreliable under the agent sandbox; the
+`curl`-shim capture is deterministic, network-free, and captures the POST **target** as well as the
+body, which a receiver bound to one path cannot. Recommend the shim as primary, with the receiver
+optional.
+
+### AC1/AC2 wording divergence, recorded openly
+
+AC1/AC2 say the delivery is "asserted against the **real** `agent-notify` on PATH, not a stub". Under
+the chosen design `agent-notify` is **no longer the payload producer**, so asserting *its* output
+would assert the wrong component. The requirements implement the AC's **intent** — *no stub anywhere
+in the payload-producing chain; the assertion is on the real published payload* — and additionally
+pin the property the literal wording was protecting: with the **pristine** upstream binary on PATH,
+the delivered payload is still correct and **exactly one** notification is published (the adjunct
+cannot double-publish a JSON-as-message). That is strictly stronger than asserting upstream's argv
+handling, and it is what AC6 requires anyway.
+
+### Bootstrap: capability, not existence (AC5)
+
+The existing bootstrap idiom is `have <tool>` → `ok`/`warn` → `run_or_print <install cmd>`, with
+verification that asserts the *capability* the gate depends on (e.g. mold is only wired after a link
+**probe** passes, `:245-260`; roborev's *configured* agent is smoke-tested rather than assumed,
+`:775-812`). The new section follows it exactly:
+
+- `curl` and `python3` present (both `have`-checked; each missing is a `warn` + install hint);
+- a notify target resolvable from the environment, naming `/etc/environment` as the fleet mechanism —
+  absent is a `warn` with the exact export, never a failure;
+- **the capability assert**: run the wrapper's own `--self-test`, which publishes a PASS **and** a
+  FAIL payload against a capture shim and validates both against the contract (title, body, distinct
+  priority/tag, message-not-JSON). This is the analogue of the mold link probe: nothing is declared
+  healthy because a file exists;
+- **the pin record**: print the wrapper's in-repo contract version and, when present, the observed
+  `agent-notify --version` labelled as an OPTIONAL local adjunct with no version requirement. After
+  this change the only pinned notify artifact is in git, which is what makes #2140's golden AMI
+  path trivial.
+
+Bootstrap stays informational (`exit 0` always) — a machine without a notify target is fully able to
+do CQLite work.
+
+## Risks
+
+- **Fleet notifications look different if the severity map drifts.** Mitigated by reusing upstream's
+  exact ntfy priority/tag maps and pinning them in the contract test.
+- **Silent no-op hides a misconfigured box.** Mitigated by bootstrap's capability self-test being the
+  place where a broken channel is loud, and by the wrapper's opt-in `CQLITE_NOTIFY_DEBUG` diagnostic
+  that never changes the advisory behaviour.
+- **A future upstream `agent-notify` gains `--category`.** No effect: the wrapper does not use it, and
+  the adjunct call stays positional.

--- a/openspec/changes/notify-contract/proposal.md
+++ b/openspec/changes/notify-contract/proposal.md
@@ -1,0 +1,134 @@
+# Proposal: A repo-owned gate notification contract (issue #3119)
+
+**Milestone:** maintenance (agent-team automation / delivery pipeline) · **Priority:** P1 ·
+**Routing:** design-driven (delivery automation; no external on-disk oracle — the fix is a new
+repo-owned surface plus bootstrap provisioning) · **Issue:** #3119 ·
+**Related:** #2667 (introduced the gate push signal), #2910 (`required` aggregation), #2140 (golden
+AMI — the pin decided here must land in the AMI path), #1930/#2640 (one worker per box).
+
+## Why
+
+`scripts/agent-gate.sh:3585` fires the gate's only push signal as:
+
+```bash
+agent-notify --category "$category" "$title" "$body" >/dev/null 2>&1 || true
+```
+
+The installed `agent-notify` **v1.1.0** has **no `--category` arm** in its flag `case`
+(`/usr/local/bin/agent-notify.bak.20260730:22-120` — the arms are `--version|-v|-V`, `--help|-h`,
+`--test*`, `--setup*`, `--update`, and nothing else), so the call falls through to **manual
+title/message mode** (`:729-732`, `title="${1:-Codex}"`, `msg="${2:-Task finished}"`). Measured
+against the pristine upstream binary with a `curl`-capture shim on PATH:
+
+```
+CURL_ARGV: [-s] [-X] [POST] [-H] [Content-Type: application/json] [-d]
+  [{"topic": "gate-test-topic", "title": "--category", "message": "error",
+    "priority": 3, "tags": ["white_check_mark"]}] [https://ntfy.sh/gate-test-topic]
+```
+
+Three independent defects are visible in that single line:
+
+1. **The `--category` flag is swallowed.** `title` becomes the literal `--category`, `message`
+   becomes the category VALUE (`error`), and the real `gate FAIL <branch>@<sha>` /
+   `RESULT: FAIL — failing: fmt,clippy` are dropped as surplus positional args.
+2. **A red gate pages as a routine success.** Manual mode pins `sound_category="completion"`
+   (`:514`), so the ntfy `priority_map`/`tag_map` (`:1429-1430`) emit **priority 3** and a green
+   **`white_check_mark`** for a FAIL. The phone shows a routine success for a broken gate — the exact
+   inversion the signal exists to prevent.
+3. **The payload is POSTed to the TOPIC URL, not the server root** (`:1454-1457`). A JSON body
+   carrying `"topic"` must be published to the ntfy SERVER ROOT; POSTed to `/<topic>` ntfy treats the
+   body as **literal message text**, so the phone renders a serialized JSON blob. The two branches of
+   that `if/else` are byte-identical despite the comment claiming special ntfy handling.
+
+`scripts/local/worker-supervisor.sh:404` makes the **same** call (`"$NOTIFY_CMD" --category
+"$category" "$title" "$message"`), so every supervisor page on the fleet carries the same corruption,
+and `.claude/skills/flow-board/SKILL.md:216` documents the broken shape as the way to page the owner.
+
+**Why the existing test could never catch it.** `scripts/tests/test_agent_gate_notify.sh:46-53` drives
+`gate_push_signal` against a PATH-stubbed `agent-notify` that itself implements a `--category` arm:
+
+```bash
+if [ "$1" = "--category" ]; then cat="$2"; shift 2; fi
+```
+
+The mock encodes the **same wrong assumption as the caller**, so the test asserts the call shape the
+gate produces and can never observe whether the real binary accepts it. It is an interface-mismatch
+blind spot of exactly the class CLAUDE.md names for symmetric round-trips: both sides make the
+identical mistake, the test closes, and the real channel is wrong.
+
+**Fleet-durability is the third problem.** `agent-notify` is an out-of-band per-machine dependency at
+`/usr/local/bin/agent-notify` (upstream `paultendo/agent-notify`, `--update` pulls
+`releases/latest`). It is **not installed, pinned, verified, or even mentioned** by
+`scripts/bootstrap-agent-machine.sh`. Both defects were hand-patched on ONE box (the pristine copy is
+preserved at `/usr/local/bin/agent-notify.bak.20260730`; the patch adds a `--category` arm, a
+`CODEX_NOTIFY_CATEGORY` override of `sound_category`, and a server-root POST). That patch propagates
+to nothing, and `agent-notify --update` reverts it. **The repo must not depend on a hand-patched
+binary on one machine.**
+
+## What Changes
+
+1. **A repo-owned notify wrapper, `scripts/lib/gate-notify.sh`, OWNS the payload contract.** It
+   builds the ntfy JSON itself (topic, title, message, priority, tags) and publishes it with `curl`
+   to the ntfy **server ROOT**, with the topic in the body. The payload is no longer constructed by
+   an external binary the repo cannot pin, so AC1–3 hold deterministically on any machine —
+   including one running the **pristine** upstream `agent-notify`.
+2. **`gate_push_signal` routes through the wrapper** instead of calling `agent-notify --category`.
+   The gate keeps building the same `title`/`body` from the same verified tree identity
+   (`scripts/agent-gate.sh:6863-6870`); only the delivery mechanism changes.
+3. **Severity is delivered, not merely intended.** PASS ⇒ priority 3 + `white_check_mark`;
+   FAIL ⇒ priority 5 + `rotating_light` (the upstream ntfy maps, so the fleet's notifications look
+   unchanged when they are correct). A red gate is distinguishable at a glance.
+4. **`agent-notify` is demoted to an OPTIONAL local desktop/sound adjunct**, invoked positionally
+   (`agent-notify "$title" "$body"` — never `--category`) with its webhook env **neutralized** so its
+   broken publish path can never double-deliver a JSON-as-message notification. Absent ⇒ nothing lost.
+5. **Advisory is enforced, not asserted.** Every failure mode of the notify path — absent wrapper,
+   absent `curl`, unset webhook, non-zero exit, a helper that **rejects its arguments**, a hung
+   publish — is bounded and swallowed. `test_agent_gate_notify.sh` gains the missing rejects-all-args
+   and non-executable cases.
+6. **A real-payload contract test**, `scripts/tests/test_gate_notify_contract.sh`, asserts the
+   **published payload** (local receiver / `curl`-capture shim) rather than argv, with a hard
+   regression guard that a `message` beginning with `{` FAILs, and a case proving the pristine
+   upstream binary on PATH cannot corrupt or duplicate the delivery. Wired into the gate.
+7. **Bootstrap provisions the channel and records the pin.** A new
+   `scripts/bootstrap-agent-machine.sh` section verifies the **capability** (`curl`, `python3`, a
+   resolvable webhook target, and the wrapper's own self-test publishing a correct PASS *and* FAIL
+   payload to a capture shim) — never merely that a file exists — and records what it pinned: the
+   wrapper's in-repo contract version plus the observed optional `agent-notify --version`.
+8. **`worker-supervisor.sh` and the doctrine surfaces migrate to the wrapper**, so no repo script,
+   skill, or doc prescribes the broken `--category` shape (AC6, pending Open Decision 2).
+
+## Non-goals
+
+- **Not forking or vendoring `agent-notify`.** It is an external upstream script we do not control;
+  a vendored copy would be a ~1500-line fork to maintain, and a *pristine* copy still has both
+  defects. The wrapper is ~100 lines against a stable published API.
+- **Not fixing upstream.** An upstream PR (add `--category`; POST JSON to the server root) is a
+  worthwhile follow-up; the fleet needs a correct channel now, and the wrapper stays correct after
+  any upstream fix lands.
+- **Not a new notification channel or transport.** ntfy over `curl` only; no Slack/Discord/Telegram
+  presets, no new topics, no secrets introduced.
+- **Not a gate component and not part of the verdict.** The notify path emits no SUMMARY line and can
+  never change `RESULT:` or the exit status.
+- **No Rust, no library surface, no on-disk format work.** `cqlite-core`, the bindings, the CLI, the
+  no-heuristics decode path and the <128MB budget are untouched.
+- **Out of scope:** the `claude-code` roborev agent OAuth expiry.
+
+## Impact
+
+- **New:** `scripts/lib/gate-notify.sh` (the payload contract + publisher),
+  `scripts/tests/test_gate_notify_contract.sh` (real-payload contract test).
+- **Changed:** `scripts/agent-gate.sh` (`gate_push_signal`, ~line 3577-3587),
+  `scripts/bootstrap-agent-machine.sh` (new notify-channel section + summary pin line),
+  `scripts/local/worker-supervisor.sh` (`notify()`, ~line 396-405),
+  `scripts/tests/test_agent_gate_notify.sh` (advisory cases),
+  `scripts/tests/test_bootstrap_agent_machine.sh` (pure-check assertions for the new section).
+- **Gate:** the contract test joins the `tooling-tests` component set (hermetic, no network, seconds).
+- **Docs (ship in this change):** `website/src/content/docs/agents-developing/delivery-pipeline.md`
+  (lines 86-90 describe the push signal), `.claude/skills/flow-board/SKILL.md:215-217` (prescribes the
+  broken `--category` call), `docs/development/fleet-runbook.md` (the notify dep on a worker box).
+  Publication accepted by grepping the served page for a new distinctive phrase, never an HTTP 200.
+- **#2140 golden AMI:** the AMI needs no notify **binary** pin at all after this change — only
+  `curl`, `python3`, and the webhook env (`/etc/environment` on the current fleet). The pinned
+  contract travels in git.
+- **Untouched:** `cqlite-core`, `cqlite-cli`, `cqlite-flight`, bindings, `test-data`, all Cargo
+  manifests, every CI workflow.

--- a/openspec/changes/notify-contract/specs/gate-notify-contract/spec.md
+++ b/openspec/changes/notify-contract/specs/gate-notify-contract/spec.md
@@ -1,0 +1,251 @@
+# gate-notify-contract — delta for notify-contract (issue #3119)
+
+**Architecture note (read this first).** The gate's push notification is produced by a **repo-owned**
+wrapper that constructs the ntfy payload itself and publishes it to the ntfy **server root**. The
+external `agent-notify` binary is demoted to an OPTIONAL local desktop/sound adjunct and is never in
+the payload-producing chain. Every requirement below is stated about the **published payload** — the
+bytes that reach the notification service — because that is the only thing a phone renders, and
+because the defect this change fixes was invisible to an argv-level assertion.
+
+**Acceptance-criterion → requirement map** (issue #3119's numbered ACs):
+
+| AC | Requirement(s) |
+|----|----------------|
+| 1 — PASS delivers title `gate PASS <branch>@<sha>`, body starts `RESULT: PASS`, asserted against the real notify path | *The gate's push signal is produced by a repo-owned notify wrapper*; *A PASS gate publishes the gate's own title and RESULT body*; *The contract is proven against the real published payload, never a stubbed payload producer* |
+| 2 — FAIL delivers the FAIL title, the failing-components body, and a distinct urgency/tag | *A FAIL gate publishes a payload distinguishable from PASS at a glance*; *The contract is proven against the real published payload, never a stubbed payload producer* |
+| 3 — the delivered ntfy message is body text, never a JSON document | *The published ntfy message field is the notification body, never a serialized document*; *The contract is proven against the real published payload, never a stubbed payload producer* |
+| 4 — the push signal stays advisory under every notifier failure, including argument rejection | *The notification path is advisory and cannot alter the gate's verdict or exit status* |
+| 5 — a bootstrap-only machine notifies correctly, and bootstrap records the pin and asserts the capability | *Bootstrap provisions the notification channel by asserting its capability and recording what it pinned* |
+| 6 — no repo script requires a hand-patched `agent-notify`; the contract holds against the pristine upstream binary | *The gate's push signal is produced by a repo-owned notify wrapper*; *No repo surface depends on a hand-patched notifier*; *The contract is proven against the real published payload, never a stubbed payload producer* |
+
+**AC1/AC2 wording divergence, recorded openly (do not read past this).** AC1 and AC2 ask for the
+delivery to be "asserted against the **real** `agent-notify` on PATH, not a stub". Under this design
+`agent-notify` is no longer the payload producer, so asserting *its* output would assert the wrong
+component. The requirements implement the AC's **intent** — no stub anywhere in the payload-producing
+chain, and the assertion is made on the real published payload — and additionally pin the property the
+literal wording protected: with the **pristine** upstream `agent-notify` on PATH, the published payload
+is still correct and **exactly one** notification is published. Measured on the pristine binary
+(`/usr/local/bin/agent-notify.bak.20260730`), a FAIL call in the current shape publishes
+`{"title": "--category", "message": "error", "priority": 3, "tags": ["white_check_mark"]}` to the
+topic URL — so an assertion made against that binary's own output could never express AC1–3 at all.
+
+## ADDED Requirements
+
+### Requirement: The gate's push signal is produced by a repo-owned notify wrapper
+The full gate's push signal SHALL be produced by a **repo-owned** notification wrapper that lives in
+this repository and constructs the published payload itself. The wrapper SHALL build the ntfy JSON
+document — topic, title, message, priority and tags — and SHALL publish it with an HTTP POST to the
+ntfy **server root**, with the topic carried in the request body. The wrapper SHALL NOT delegate
+construction of the published payload to any external binary.
+
+The gate SHALL continue to derive the notification's title and body from the SAME verified tree
+identity the SUMMARY block stamped, so the signal can never disagree with the block. The external
+`agent-notify` binary MAY be invoked ONLY as an optional LOCAL desktop/sound adjunct, and when so
+invoked SHALL be called with positional arguments only (never a `--category` flag) and with its
+webhook environment NEUTRALIZED, so its own publish path can never deliver a second, corrupted
+notification.
+
+The notification target SHALL be resolved from the environment the fleet already configures. A target
+expressed as a topic URL SHALL be split by the wrapper into the server root and the topic. When no
+topic can be resolved authoritatively, the wrapper SHALL be a silent no-op and SHALL NOT guess a
+topic.
+
+#### Scenario: The payload is published to the server root, not the topic URL
+- **GIVEN** a notify target of `https://ntfy.sh/<topic>`
+- **WHEN** the full gate fires its push signal
+- **THEN** the HTTP POST target is the ntfy server ROOT (`https://ntfy.sh/`) and the published JSON body carries `"topic": "<topic>"`
+
+#### Scenario: The optional local adjunct cannot publish a second notification
+- **GIVEN** an `agent-notify` binary on PATH and a configured notify target
+- **WHEN** the full gate fires its push signal
+- **THEN** exactly ONE notification is published, it is the wrapper's payload, and the adjunct is invoked positionally with its webhook environment neutralized so it publishes nothing
+
+#### Scenario: An unresolvable topic is a silent no-op, never a guessed topic
+- **GIVEN** a notify target from which no topic can be resolved and no explicit topic override in the environment
+- **WHEN** the full gate fires its push signal
+- **THEN** nothing is published, no topic is guessed, and the gate's `RESULT:` and exit status are unchanged
+
+#### Scenario: The signal names the identity the SUMMARY block stamped
+- **GIVEN** a full gate run whose SUMMARY block stamped a particular commit and branch
+- **WHEN** the push signal is published
+- **THEN** the title's branch and short SHA are the ones taken from that stamped identity, not from a fresh git read at publish time
+
+### Requirement: A PASS gate publishes the gate's own title and RESULT body
+On a full-gate PASS the published payload's **title** SHALL be exactly `gate PASS <branch>@<short-sha>`
+and its **message** SHALL begin with `RESULT: PASS`. The published severity SHALL be the PASS severity
+of the contract (ntfy priority 3, tag `white_check_mark`).
+
+#### Scenario: A PASS gate publishes the PASS title and body
+- **GIVEN** a full gate that finishes with `RESULT: PASS` on branch `issue-3119-notify-contract` at short SHA `abc1234`
+- **WHEN** the push signal is published
+- **THEN** the published `title` is `gate PASS issue-3119-notify-contract@abc1234`, the published `message` begins with `RESULT: PASS`, the `priority` is 3 and the `tags` are `["white_check_mark"]`
+
+### Requirement: A FAIL gate publishes a payload distinguishable from PASS at a glance
+On a full-gate FAIL the published payload's **title** SHALL be exactly
+`gate FAIL <branch>@<short-sha>` and its **message** SHALL be `RESULT: FAIL — failing: <components>`
+naming every component that FAILed. The published severity SHALL be the FAIL severity of the contract
+(ntfy priority 5, tag `rotating_light`), which SHALL differ from the PASS severity in BOTH priority and
+tag so a red gate is distinguishable from a routine success without reading the body.
+
+A FAIL payload SHALL NEVER be published with the PASS priority or the PASS tag.
+
+#### Scenario: A FAIL gate publishes the FAIL title, failing components, and a distinct severity
+- **GIVEN** a full gate that finishes with `RESULT: FAIL` on branch `issue-3119-notify-contract` at short SHA `deadbee` with components `fmt` and `clippy` FAILed
+- **WHEN** the push signal is published
+- **THEN** the published `title` is `gate FAIL issue-3119-notify-contract@deadbee`, the published `message` is `RESULT: FAIL — failing: fmt,clippy`, the `priority` is 5 and the `tags` are `["rotating_light"]`
+
+#### Scenario: A red gate can never page as a routine success
+- **GIVEN** a full-gate FAIL
+- **WHEN** the published payload is compared with the payload published for a PASS
+- **THEN** the two differ in `priority` AND in `tags`, and the FAIL payload carries neither priority 3 nor the `white_check_mark` tag
+
+#### Scenario: A summary-file write failure is signalled as FAIL
+- **GIVEN** a full gate whose correctness components passed but which could not write its summary file
+- **WHEN** the push signal is published
+- **THEN** the published payload carries the FAIL title and the FAIL severity, because the run produced no artifact of record
+
+### Requirement: The published ntfy message field is the notification body, never a serialized document
+The published payload's `message` field SHALL be the notification **body text**. It SHALL NEVER be a
+serialized JSON document, and the transport SHALL NEVER be such that the notification service treats
+the request body as literal message text. A published `message` whose first character is `{` SHALL be
+treated as a contract violation and SHALL fail the contract test.
+
+#### Scenario: A message that is a JSON document fails the contract
+- **GIVEN** a captured published payload whose `message` field begins with `{`
+- **WHEN** the contract test evaluates it
+- **THEN** the test FAILS, naming the raw-JSON-as-message regression explicitly
+
+#### Scenario: The rendered message is the gate's own body text
+- **GIVEN** a published PASS payload
+- **WHEN** its `message` field is read
+- **THEN** it is the plain body text `RESULT: PASS`, containing no JSON braces, no `"topic"` key and no escaped quotes
+
+### Requirement: The notification path is advisory and cannot alter the gate's verdict or exit status
+The notification path SHALL be advisory by construction. For EVERY failure mode of that path the
+gate's emitted `RESULT:` line, its SUMMARY block and its process exit status SHALL be **byte-identical**
+to a run in which the notification succeeded. The failure modes SHALL include, at minimum: the
+notifier absent from PATH; the notifier present but NOT EXECUTABLE; the notifier exiting non-zero; the
+notifier **rejecting its arguments** with a usage error; the repo-owned wrapper itself missing or
+unreadable; no notify target configured; `curl` unavailable; and a publish that never completes.
+
+Every external invocation on this path SHALL be time-bounded, SHALL have its stdout and stderr
+discarded, and SHALL have its failure swallowed. The push-signal function SHALL always return 0 and
+SHALL never `exit`, never install a trap, never write to the summary file, and never modify any gate
+state.
+
+#### Scenario: A notifier that rejects its arguments does not fail the gate
+- **GIVEN** a notifier on PATH that exits with a usage error for every argument it is given
+- **WHEN** the full gate fires its push signal
+- **THEN** the push-signal function returns 0, nothing is written to stdout or stderr, and the gate's `RESULT:` and exit status are identical to a run with a working notifier
+
+#### Scenario: A non-executable notifier does not fail the gate
+- **GIVEN** a file named like the notifier on PATH that is not executable
+- **WHEN** the full gate fires its push signal
+- **THEN** the push-signal function returns 0 and the gate's verdict and exit status are unchanged
+
+#### Scenario: An absent notifier remains a silent no-op
+- **GIVEN** a PATH on which no notifier and no `curl` can be found
+- **WHEN** the full gate fires its push signal
+- **THEN** nothing is published, the push-signal function returns 0 silently, and the gate's verdict and exit status are unchanged
+
+#### Scenario: A missing repo-owned wrapper degrades to a no-op
+- **GIVEN** a checkout in which the repo-owned notify wrapper is absent or unreadable
+- **WHEN** the full gate reaches its push-signal step
+- **THEN** the step is a silent no-op returning 0, and the gate still emits its normal SUMMARY block and exit status
+
+#### Scenario: A publish that never completes cannot stall the gate
+- **GIVEN** a publish transport that never returns
+- **WHEN** the full gate fires its push signal
+- **THEN** the invocation is abandoned at its own bound and the gate proceeds to its normal exit
+
+### Requirement: The contract is proven against the real published payload, never a stubbed payload producer
+A contract test SHALL assert the notification contract by parsing the **payload actually published**,
+captured at the transport boundary (a capture shim standing in for the publishing transport, or a
+loopback receiver). No component that PRODUCES the payload — neither the gate's push-signal function
+nor the repo-owned wrapper — SHALL be stubbed, mocked or re-implemented by that test; only the
+transport SHALL be intercepted. Asserting the arguments passed to a helper SHALL NOT be accepted as
+evidence for any of the title, body, severity or message-shape requirements.
+
+The contract test SHALL cover a PASS payload, a FAIL payload, the POST target being the server root,
+the message-not-a-JSON-document guard, and the case in which the **pristine** upstream `agent-notify`
+is the binary on PATH. It SHALL be hermetic — no network, no real notification topic, no reliance on
+any machine's install history — and SHALL be registered in the agent gate so a regression FAILs the
+gate rather than a fleet page.
+
+#### Scenario: The contract test intercepts only the transport
+- **GIVEN** the contract test's fixture
+- **WHEN** its interception surface is inspected
+- **THEN** the gate's push-signal function and the repo-owned wrapper are the real ones from the repository, and the only substituted component is the publishing transport
+
+#### Scenario: The contract holds with the pristine upstream binary on PATH
+- **GIVEN** a pristine upstream `agent-notify` (one with no `--category` flag and a topic-URL publish path) on PATH
+- **WHEN** the gate publishes a PASS and then a FAIL signal
+- **THEN** both published payloads satisfy the title, body, severity and message-shape requirements, and no notification carries a `message` beginning with `{`
+
+#### Scenario: An argv-only assertion is not sufficient evidence
+- **GIVEN** a proposed test that records the arguments passed to a notifier and asserts their shape
+- **WHEN** it is offered as evidence for the title, body or severity requirements
+- **THEN** it does not satisfy them, because it cannot observe whether the notifier accepts those arguments or what it publishes
+
+#### Scenario: The contract test runs in the agent gate without a network
+- **GIVEN** a machine with no notification service reachable
+- **WHEN** the agent gate runs its shell-tooling component set
+- **THEN** the contract test executes and reports its result deterministically, using no network and no real topic
+
+### Requirement: No repo surface depends on a hand-patched notifier
+No script, skill or documented procedure in this repository SHALL require a locally modified
+`agent-notify` binary, and none SHALL invoke `agent-notify` with a `--category` flag. Every repo
+surface that pages a human about gate or worker state SHALL route through the repo-owned wrapper, so
+restoring a machine's pristine upstream binary — or running `agent-notify --update` — SHALL NOT
+regress the title, body, severity or message-shape requirements.
+
+#### Scenario: Restoring the pristine binary regresses nothing
+- **GIVEN** a machine on which a hand-patched `agent-notify` is replaced by the pristine upstream binary
+- **WHEN** the full gate publishes a PASS and a FAIL signal
+- **THEN** both payloads still satisfy the title, body, severity and message-shape requirements
+
+#### Scenario: No repo surface prescribes the swallowed flag
+- **GIVEN** the repository's scripts, skills and developer documentation
+- **WHEN** they are searched for `agent-notify --category`
+- **THEN** there are no occurrences, and every surface that previously used that shape routes through the repo-owned wrapper instead
+
+### Requirement: Bootstrap provisions the notification channel by asserting its capability and recording what it pinned
+`scripts/bootstrap-agent-machine.sh` SHALL provision the notification channel such that a machine
+prepared SOLELY by `bash scripts/bootstrap-agent-machine.sh --yes` publishes correct PASS and FAIL
+notifications with no manual patching of any binary.
+
+Its verification SHALL assert the **CAPABILITY** the gate depends on — that the notify path actually
+publishes a contract-correct PASS payload AND a contract-correct FAIL payload, observed through a
+capture shim — and SHALL NOT accept the mere existence of a file or a binary as verification. It SHALL
+check the transport prerequisites it relies on, and SHALL report a missing notify target with the exact
+environment configuration needed rather than failing.
+
+Bootstrap SHALL **record the pinned version** of what it provisioned: the repo-owned wrapper's
+contract version, and — when present — the observed version of the optional local adjunct, labelled as
+optional with no version requirement. Bootstrap SHALL remain informational and SHALL continue to exit
+0 regardless of the notification channel's state.
+
+#### Scenario: A bootstrap-only machine notifies correctly
+- **GIVEN** a machine provisioned solely by `bash scripts/bootstrap-agent-machine.sh --yes`, with no hand-patched notifier anywhere
+- **WHEN** a full gate PASSes and a later full gate FAILs
+- **THEN** both notifications satisfy the title, body, severity and message-shape requirements
+
+#### Scenario: Bootstrap asserts the capability, not the file
+- **GIVEN** a bootstrap run on a machine with a configured notify target
+- **WHEN** its notification section runs
+- **THEN** it publishes a PASS and a FAIL payload through a capture shim, validates both against the contract, and reports `ok` only when both validate — a present-but-broken path is reported as a warning, not as `ok`
+
+#### Scenario: Bootstrap records the pin
+- **GIVEN** a completed bootstrap run
+- **WHEN** its output is read
+- **THEN** it names the repo-owned wrapper's contract version, and names the optional local adjunct's observed version when the adjunct is present, marked optional
+
+#### Scenario: A missing notify target is guidance, never a failure
+- **GIVEN** a machine with no notify target configured in its environment
+- **WHEN** bootstrap runs
+- **THEN** it emits a warning carrying the exact export needed, records that notifications are no-ops on this machine, and still exits 0
+
+#### Scenario: Bootstrap's default mode installs nothing
+- **GIVEN** bootstrap run WITHOUT `--yes`
+- **WHEN** its notification section runs
+- **THEN** it performs only checks and prints any install command it would have run, installing nothing and modifying no file

--- a/openspec/changes/notify-contract/tasks.md
+++ b/openspec/changes/notify-contract/tasks.md
@@ -8,100 +8,102 @@
 > ~1500-line fork. AC→requirement map is at the top of `specs/gate-notify-contract/spec.md`.
 
 ## 1. The repo-owned wrapper (surface: `scripts/lib/gate-notify.sh`)
-- [ ] Create the wrapper exposing `gate_notify_publish <severity> <title> <body>` (sourceable, and
+- [x] Create the wrapper exposing `gate_notify_publish <severity> <title> <body>` (sourceable, and
       directly executable for the self-test), with a declared contract version constant.
-- [ ] Resolve the target from `CQLITE_NOTIFY_WEBHOOK`, else `CODEX_NOTIFY_WEBHOOK` (the fleet's
+- [x] Resolve the target from `CQLITE_NOTIFY_WEBHOOK`, else `CODEX_NOTIFY_WEBHOOK` (the fleet's
       `/etc/environment` variable), with `CQLITE_NOTIFY_TOPIC`/`CODEX_NOTIFY_NTFY_TOPIC` as the
       explicit topic override.
-- [ ] Split a topic URL into server ROOT + topic: strip query and fragment, strip trailing slashes,
+- [x] Split a topic URL into server ROOT + topic: strip query and fragment, strip trailing slashes,
       strip the trailing topic segment; a URL that is already a bare root requires an explicit topic
       override. No resolvable topic ⇒ silent no-op (never a guessed topic).
-- [ ] Build the payload with `python3 -c` + `json.dumps` (never hand-quoted shell interpolation), and
+- [x] Build the payload with `python3 -c` + `json.dumps` (never hand-quoted shell interpolation), and
       pin the severity map: PASS/`completion` ⇒ priority 3 + `white_check_mark`; FAIL/`error` ⇒
       priority 5 + `rotating_light`.
-- [ ] Publish with `curl -sS -X POST -H 'Content-Type: application/json' --max-time <N> -d <body> <root>`,
+- [x] Publish with `curl -sS -X POST -H 'Content-Type: application/json' --max-time <N> -d <body> <root>`,
       output discarded, failure swallowed.
-- [ ] Optional local adjunct: when `agent-notify` is on PATH, invoke it POSITIONALLY
+- [x] Optional local adjunct: when `agent-notify` is on PATH, invoke it POSITIONALLY
       (`agent-notify "$title" "$body"`) under a `timeout` with `CODEX_NOTIFY_WEBHOOK=`/
       `CQLITE_NOTIFY_WEBHOOK=` NEUTRALIZED so it can never double-publish. Never pass `--category`.
-- [ ] Advisory containment: no `set -e` reliance, no `exit`, no traps, every call `|| true`, always
+- [x] Advisory containment: no `set -e` reliance, no `exit`, no traps, every call `|| true`, always
       `return 0`; `CQLITE_NOTIFY_DEBUG=1` adds diagnostics WITHOUT changing behaviour.
-- [ ] Add `--self-test`: publish a PASS and a FAIL payload through a capture shim and validate both
+- [x] Add `--self-test`: publish a PASS and a FAIL payload through a capture shim and validate both
       against the contract (title, body, distinct priority+tag, message-not-JSON); exit non-zero only
       in self-test mode, never in publish mode.
 
 ## 2. Gate wiring (surface: `scripts/agent-gate.sh`)
-- [ ] Replace the `agent-notify --category …` call in `gate_push_signal()` (~line 3585) with a
+- [x] Replace the `agent-notify --category …` call in `gate_push_signal()` (~line 3585) with a
       defensive source of `scripts/lib/gate-notify.sh` + `gate_notify_publish`; a missing/unreadable
       wrapper stays a silent no-op returning 0.
-- [ ] Keep the existing call-site guard (FULL gate only — not `--lite`/`--delta`/`--only`/selftest) and
+- [x] Keep the existing call-site guard (FULL gate only — not `--lite`/`--delta`/`--only`/selftest) and
       the #2926 identity derivation (`TREE_COMMIT_LINE`) untouched.
-- [ ] Keep the summary-write-failure ⇒ FAIL severity behaviour (`SUMMARY_WRITE_FAILED`).
-- [ ] Verify the extraction contract `test_agent_gate_notify.sh` relies on still holds (the function
+- [x] Keep the summary-write-failure ⇒ FAIL severity behaviour (`SUMMARY_WRITE_FAILED`).
+- [x] Verify the extraction contract `test_agent_gate_notify.sh` relies on still holds (the function
       must remain self-contained enough to be extracted, or the test's extraction updated in step 4).
-- [ ] Confirm no SUMMARY line, component, or exit path is added by the notify change.
+- [x] Confirm no SUMMARY line, component, or exit path is added by the notify change.
 
 ## 3. Contract test (surface: `scripts/tests/test_gate_notify_contract.sh`)
-- [ ] Capture at the transport boundary with a PATH `curl` shim recording argv (target URL + `-d`
+- [x] Capture at the transport boundary with a PATH `curl` shim recording argv (target URL + `-d`
       body) — the technique that measured the defect; no network, no real topic.
-- [ ] Drive the REAL `gate_push_signal` → REAL `gate-notify.sh` chain; stub nothing that produces the
+- [x] Drive the REAL `gate_push_signal` → REAL `gate-notify.sh` chain; stub nothing that produces the
       payload.
-- [ ] Assert the PASS payload: `title == gate PASS <branch>@<sha>`, `message` starts `RESULT: PASS`,
+- [x] Assert the PASS payload: `title == gate PASS <branch>@<sha>`, `message` starts `RESULT: PASS`,
       `priority == 3`, `tags == ["white_check_mark"]`, POST target is the server ROOT.
-- [ ] Assert the FAIL payload: `title == gate FAIL <branch>@<sha>`,
+- [x] Assert the FAIL payload: `title == gate FAIL <branch>@<sha>`,
       `message == RESULT: FAIL — failing: fmt,clippy`, `priority == 5`, `tags == ["rotating_light"]`.
-- [ ] Assert PASS vs FAIL differ in BOTH `priority` and `tags`, and that FAIL carries neither
+- [x] Assert PASS vs FAIL differ in BOTH `priority` and `tags`, and that FAIL carries neither
       priority 3 nor `white_check_mark`.
-- [ ] Regression guard: FAIL the test when the published `message` begins with `{` (defect 3).
-- [ ] Pristine-binary case: place a stand-in with the pristine upstream behaviour (no `--category`
+- [x] Regression guard: FAIL the test when the published `message` begins with `{` (defect 3).
+- [x] Pristine-binary case: place a stand-in with the pristine upstream behaviour (no `--category`
       arm, manual `$1`/`$2` mode, topic-URL publish) on PATH and assert the published payload is still
       correct and EXACTLY ONE notification is published.
-- [ ] Register the test in `scripts/agent-gate.sh`'s `tooling-tests` component set (hermetic + fast;
+- [x] Register the test in `scripts/agent-gate.sh`'s `tooling-tests` component set (hermetic + fast;
       also acceptable in the `--lite` shell-tooling set).
 
 ## 4. Advisory regression cases (surface: `scripts/tests/test_agent_gate_notify.sh`)
-- [ ] Add a **rejects-all-arguments** stub (exits 2 with a usage error on any argv) and assert
+- [x] Add a **rejects-all-arguments** stub (exits 2 with a usage error on any argv) and assert
       `gate_push_signal` returns 0 with no stdout/stderr — the class that produced this issue.
-- [ ] Add a **non-executable** notifier case.
-- [ ] Add a **non-zero exit** notifier case (today only absent + a recording stub are covered).
-- [ ] Add a **missing repo-owned wrapper** case (wrapper path absent ⇒ no-op, returns 0).
-- [ ] Add a **no notify target / no `curl`** case.
-- [ ] Update the file's header comment: it now tests the ADVISORY contract; payload fidelity is
+- [x] Add a **non-executable** notifier case.
+- [x] Add a **non-zero exit** notifier case (today only absent + a recording stub are covered).
+- [x] Add a **missing repo-owned wrapper** case (wrapper path absent ⇒ no-op, returns 0).
+- [x] Add a **no notify target / no `curl`** case.
+- [x] Update the file's header comment: it now tests the ADVISORY contract; payload fidelity is
       `test_gate_notify_contract.sh`'s job, and an argv assertion is explicitly not evidence for it.
 
 ## 5. Bootstrap provisioning (surface: `scripts/bootstrap-agent-machine.sh`)
-- [ ] Add a "Notification channel (ntfy)" section following the existing `have`/`ok`/`warn`/
+- [x] Add a "Notification channel (ntfy)" section following the existing `have`/`ok`/`warn`/
       `run_or_print` idiom: check `curl` and `python3`, check a resolvable notify target (naming
       `/etc/environment` and printing the exact export when absent).
-- [ ] Capability assert (the mold-link-probe analogue): run `gate-notify.sh --self-test` and report
+- [x] Capability assert (the mold-link-probe analogue): run `gate-notify.sh --self-test` and report
       `ok` ONLY when both the PASS and the FAIL payload validate; a present-but-broken path is a
       `warn`, never `ok`.
-- [ ] Record the pin: print the wrapper's contract version, and `agent-notify --version` when present,
+- [x] Record the pin: print the wrapper's contract version, and `agent-notify --version` when present,
       labelled OPTIONAL local adjunct with no version requirement.
-- [ ] Keep bootstrap informational — `exit 0` always; default (no `--yes`) mode installs nothing and
+- [x] Keep bootstrap informational — `exit 0` always; default (no `--yes`) mode installs nothing and
       only prints commands.
-- [ ] Extend `scripts/tests/test_bootstrap_agent_machine.sh` with pure-check assertions for the new
+- [x] Extend `scripts/tests/test_bootstrap_agent_machine.sh` with pure-check assertions for the new
       section (present, no-install in default mode, self-test invoked, pin line emitted).
 
 ## 6. Call-site migration (AC6) — pending Open Decision 2
-- [ ] `scripts/local/worker-supervisor.sh` `notify()` (~line 396-405): route through
+- [x] `scripts/local/worker-supervisor.sh` `notify()` (~line 396-405): route through
       `gate_notify_publish`, dropping `--category`; preserve the existing no-op warning behaviour and
       the #2666 exit-latency ceiling asserted by `test_worker_supervisor.sh`.
-- [ ] `.claude/skills/flow-board/SKILL.md:215-217`: replace the `agent-notify --category error …`
+- [x] `.claude/skills/flow-board/SKILL.md:215-217`: replace the `agent-notify --category error …`
       prescription with the wrapper.
-- [ ] Grep the repo for `agent-notify --category` and confirm zero remaining occurrences.
+- [x] Grep the repo for `agent-notify --category` and confirm zero remaining occurrences.
 
 ## 7. Doctrine (ships in this change)
-- [ ] `website/src/content/docs/agents-developing/delivery-pipeline.md` (lines 86-90): the push signal
+- [x] `website/src/content/docs/agents-developing/delivery-pipeline.md` (lines 86-90): the push signal
       is repo-owned, names the PASS/FAIL severity contract, and states that `agent-notify` is an
       optional local adjunct.
-- [ ] `docs/development/fleet-runbook.md`: the notify channel's env configuration + what bootstrap
+- [x] `docs/development/fleet-runbook.md`: the notify channel's env configuration + what bootstrap
       verifies and pins.
 - [ ] Accept publication by grepping the SERVED page for a new distinctive phrase (never an HTTP 200;
-      CDN staleness ≈3 min).
+      CDN staleness ≈3 min). **Deferred to post-merge by construction** — the site deploys from `main`,
+      so the served page cannot carry this change's phrase until the PR lands. Grep for:
+      `The payload contract is REPO-OWNED`.
 
 ## 8. Certification
-- [ ] `--lite` green each fix round (summary-file redirect).
+- [x] `--lite` green each fix round (summary-file redirect).
 - [ ] `rust-reviewer` (shell diff — scope review to the shell surfaces) + `roborev` via
       `scripts/flow/roborev-review.sh --agent <a> --model <m> --repo <abs>` on the lite-green diff,
       BEFORE the full gate.

--- a/openspec/changes/notify-contract/tasks.md
+++ b/openspec/changes/notify-contract/tasks.md
@@ -1,0 +1,113 @@
+# Tasks: notify-contract (issue #3119)
+
+> Design decided in `design.md`: option **(b)** — a repo-owned wrapper (`scripts/lib/gate-notify.sh`)
+> OWNS the ntfy payload and publishes it to the SERVER ROOT; the external `agent-notify` is demoted to
+> an optional local desktop/sound adjunct and is never in the payload chain. Option (a)
+> (capability-probe `--category`) is eliminated by AC2+AC3 — the severity map and the topic-URL POST
+> live inside the binary. Option (c) (vendor/pin upstream) is eliminated by AC6 plus the cost of a
+> ~1500-line fork. AC→requirement map is at the top of `specs/gate-notify-contract/spec.md`.
+
+## 1. The repo-owned wrapper (surface: `scripts/lib/gate-notify.sh`)
+- [ ] Create the wrapper exposing `gate_notify_publish <severity> <title> <body>` (sourceable, and
+      directly executable for the self-test), with a declared contract version constant.
+- [ ] Resolve the target from `CQLITE_NOTIFY_WEBHOOK`, else `CODEX_NOTIFY_WEBHOOK` (the fleet's
+      `/etc/environment` variable), with `CQLITE_NOTIFY_TOPIC`/`CODEX_NOTIFY_NTFY_TOPIC` as the
+      explicit topic override.
+- [ ] Split a topic URL into server ROOT + topic: strip query and fragment, strip trailing slashes,
+      strip the trailing topic segment; a URL that is already a bare root requires an explicit topic
+      override. No resolvable topic ⇒ silent no-op (never a guessed topic).
+- [ ] Build the payload with `python3 -c` + `json.dumps` (never hand-quoted shell interpolation), and
+      pin the severity map: PASS/`completion` ⇒ priority 3 + `white_check_mark`; FAIL/`error` ⇒
+      priority 5 + `rotating_light`.
+- [ ] Publish with `curl -sS -X POST -H 'Content-Type: application/json' --max-time <N> -d <body> <root>`,
+      output discarded, failure swallowed.
+- [ ] Optional local adjunct: when `agent-notify` is on PATH, invoke it POSITIONALLY
+      (`agent-notify "$title" "$body"`) under a `timeout` with `CODEX_NOTIFY_WEBHOOK=`/
+      `CQLITE_NOTIFY_WEBHOOK=` NEUTRALIZED so it can never double-publish. Never pass `--category`.
+- [ ] Advisory containment: no `set -e` reliance, no `exit`, no traps, every call `|| true`, always
+      `return 0`; `CQLITE_NOTIFY_DEBUG=1` adds diagnostics WITHOUT changing behaviour.
+- [ ] Add `--self-test`: publish a PASS and a FAIL payload through a capture shim and validate both
+      against the contract (title, body, distinct priority+tag, message-not-JSON); exit non-zero only
+      in self-test mode, never in publish mode.
+
+## 2. Gate wiring (surface: `scripts/agent-gate.sh`)
+- [ ] Replace the `agent-notify --category …` call in `gate_push_signal()` (~line 3585) with a
+      defensive source of `scripts/lib/gate-notify.sh` + `gate_notify_publish`; a missing/unreadable
+      wrapper stays a silent no-op returning 0.
+- [ ] Keep the existing call-site guard (FULL gate only — not `--lite`/`--delta`/`--only`/selftest) and
+      the #2926 identity derivation (`TREE_COMMIT_LINE`) untouched.
+- [ ] Keep the summary-write-failure ⇒ FAIL severity behaviour (`SUMMARY_WRITE_FAILED`).
+- [ ] Verify the extraction contract `test_agent_gate_notify.sh` relies on still holds (the function
+      must remain self-contained enough to be extracted, or the test's extraction updated in step 4).
+- [ ] Confirm no SUMMARY line, component, or exit path is added by the notify change.
+
+## 3. Contract test (surface: `scripts/tests/test_gate_notify_contract.sh`)
+- [ ] Capture at the transport boundary with a PATH `curl` shim recording argv (target URL + `-d`
+      body) — the technique that measured the defect; no network, no real topic.
+- [ ] Drive the REAL `gate_push_signal` → REAL `gate-notify.sh` chain; stub nothing that produces the
+      payload.
+- [ ] Assert the PASS payload: `title == gate PASS <branch>@<sha>`, `message` starts `RESULT: PASS`,
+      `priority == 3`, `tags == ["white_check_mark"]`, POST target is the server ROOT.
+- [ ] Assert the FAIL payload: `title == gate FAIL <branch>@<sha>`,
+      `message == RESULT: FAIL — failing: fmt,clippy`, `priority == 5`, `tags == ["rotating_light"]`.
+- [ ] Assert PASS vs FAIL differ in BOTH `priority` and `tags`, and that FAIL carries neither
+      priority 3 nor `white_check_mark`.
+- [ ] Regression guard: FAIL the test when the published `message` begins with `{` (defect 3).
+- [ ] Pristine-binary case: place a stand-in with the pristine upstream behaviour (no `--category`
+      arm, manual `$1`/`$2` mode, topic-URL publish) on PATH and assert the published payload is still
+      correct and EXACTLY ONE notification is published.
+- [ ] Register the test in `scripts/agent-gate.sh`'s `tooling-tests` component set (hermetic + fast;
+      also acceptable in the `--lite` shell-tooling set).
+
+## 4. Advisory regression cases (surface: `scripts/tests/test_agent_gate_notify.sh`)
+- [ ] Add a **rejects-all-arguments** stub (exits 2 with a usage error on any argv) and assert
+      `gate_push_signal` returns 0 with no stdout/stderr — the class that produced this issue.
+- [ ] Add a **non-executable** notifier case.
+- [ ] Add a **non-zero exit** notifier case (today only absent + a recording stub are covered).
+- [ ] Add a **missing repo-owned wrapper** case (wrapper path absent ⇒ no-op, returns 0).
+- [ ] Add a **no notify target / no `curl`** case.
+- [ ] Update the file's header comment: it now tests the ADVISORY contract; payload fidelity is
+      `test_gate_notify_contract.sh`'s job, and an argv assertion is explicitly not evidence for it.
+
+## 5. Bootstrap provisioning (surface: `scripts/bootstrap-agent-machine.sh`)
+- [ ] Add a "Notification channel (ntfy)" section following the existing `have`/`ok`/`warn`/
+      `run_or_print` idiom: check `curl` and `python3`, check a resolvable notify target (naming
+      `/etc/environment` and printing the exact export when absent).
+- [ ] Capability assert (the mold-link-probe analogue): run `gate-notify.sh --self-test` and report
+      `ok` ONLY when both the PASS and the FAIL payload validate; a present-but-broken path is a
+      `warn`, never `ok`.
+- [ ] Record the pin: print the wrapper's contract version, and `agent-notify --version` when present,
+      labelled OPTIONAL local adjunct with no version requirement.
+- [ ] Keep bootstrap informational — `exit 0` always; default (no `--yes`) mode installs nothing and
+      only prints commands.
+- [ ] Extend `scripts/tests/test_bootstrap_agent_machine.sh` with pure-check assertions for the new
+      section (present, no-install in default mode, self-test invoked, pin line emitted).
+
+## 6. Call-site migration (AC6) — pending Open Decision 2
+- [ ] `scripts/local/worker-supervisor.sh` `notify()` (~line 396-405): route through
+      `gate_notify_publish`, dropping `--category`; preserve the existing no-op warning behaviour and
+      the #2666 exit-latency ceiling asserted by `test_worker_supervisor.sh`.
+- [ ] `.claude/skills/flow-board/SKILL.md:215-217`: replace the `agent-notify --category error …`
+      prescription with the wrapper.
+- [ ] Grep the repo for `agent-notify --category` and confirm zero remaining occurrences.
+
+## 7. Doctrine (ships in this change)
+- [ ] `website/src/content/docs/agents-developing/delivery-pipeline.md` (lines 86-90): the push signal
+      is repo-owned, names the PASS/FAIL severity contract, and states that `agent-notify` is an
+      optional local adjunct.
+- [ ] `docs/development/fleet-runbook.md`: the notify channel's env configuration + what bootstrap
+      verifies and pins.
+- [ ] Accept publication by grepping the SERVED page for a new distinctive phrase (never an HTTP 200;
+      CDN staleness ≈3 min).
+
+## 8. Certification
+- [ ] `--lite` green each fix round (summary-file redirect).
+- [ ] `rust-reviewer` (shell diff — scope review to the shell surfaces) + `roborev` via
+      `scripts/flow/roborev-review.sh --agent <a> --model <m> --repo <abs>` on the lite-green diff,
+      BEFORE the full gate.
+- [ ] ONE full gate inside `flow-closer`; verify `RESULT:` is `PASS|FAIL` and `tree-integrity:` is
+      clean.
+- [ ] `spec-auditor` C pass against `specs/gate-notify-contract/spec.md`.
+- [ ] Live acceptance on this box: restore `/usr/local/bin/agent-notify` from
+      `agent-notify.bak.20260730` and confirm a real PASS and a real FAIL page correctly
+      (distinct priority/tag, no raw JSON) — this is the AC6 end-to-end evidence.

--- a/openspec/changes/notify-contract/tasks.md
+++ b/openspec/changes/notify-contract/tasks.md
@@ -113,3 +113,19 @@
 - [ ] Live acceptance on this box: restore `/usr/local/bin/agent-notify` from
       `agent-notify.bak.20260730` and confirm a real PASS and a real FAIL page correctly
       (distinct priority/tag, no raw JSON) — this is the AC6 end-to-end evidence.
+
+## 9. Oracle hardening from the C intent audit (review round 5)
+- [x] AC5/R8 blocker: assert bootstrap HONOURS the probe verdict — a broken wrapper is
+      reported FAILED and never `verified` (the auditor's `; true;` + broken-wrapper
+      mutation now reds the suite where it previously stayed 77 PASS / 0 FAIL).
+- [x] Positive twin: a healthy wrapper is reported `notify capability verified`.
+- [x] No-target case: warns, prints the exact `CODEX_NOTIFY_WEBHOOK=` export, exits 0
+      (never exercised before — a fleet box's ambient var always took the other branch).
+- [x] Cover `gate_notify_selftest`'s own validator: a vacuous validator now reds.
+- [x] R7: cover the DEFAULT supervisor notify path (`NOTIFY_CMD` unset) — both the
+      bare-`agent-notify` revert and a broken `--publish` arm now red.
+- [x] Spec R1 S4 / R3 S3: cover the push-signal CALL SITE (stamped identity, and
+      `SUMMARY_WRITE_FAILED` forcing FAIL) read-only, with no seam added to the gate.
+- [x] Give EVERY timing-sensitive case an independent `timeout -s KILL` cap so an
+      unbounded-call regression reds instead of hanging the whole gate.
+- [x] Make case 3f discriminate probed-and-rejected from attempted-and-failed.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -3995,24 +3995,38 @@ _tree_result() {
 # Fire ONE advisory push at final-SUMMARY time so a backgrounded FULL gate
 # becomes a PUSH signal, not a passive poll target: the moment RESULT lands, the
 # waiting closer/worker is called back instead of idle-polling the summary file.
-# Wraps `agent-notify` (the same ntfy wrapper worker-supervisor.sh uses).
+# Delegates delivery to the REPO-OWNED contract in scripts/lib/gate-notify.sh
+# (#3119), which builds the ntfy payload itself and publishes it to the server
+# ROOT. It does NOT call `agent-notify --category` any more: the installed
+# upstream v1.1.0 has no `--category` arm, so that flag fell through to its
+# manual "$1"/"$2" mode — title became the literal `--category`, the body became
+# the category VALUE, the real title/body were dropped, and a FAIL published
+# priority 3 with a green check (a red gate paging as a routine success).
+# `agent-notify` survives only as the wrapper's optional, bounded, positional
+# local desktop/sound adjunct.
 # FULL gate ONLY — the sole call site guards out --lite/--delta/--only/selftest,
 # which are iteration aids and never the gate of record.
 #
-# Advisory by contract: if agent-notify is absent OR fails, this is a SILENT
-# no-op — the summary file stays the artifact of record, so a missing daemon or
-# a broken notifier NEVER changes the gate's verdict or exit status.
+# Advisory by contract: an absent/unreadable wrapper, an unset notify target, a
+# missing curl/python3, a notifier that fails OR REJECTS ITS ARGUMENTS, and a
+# publish that never completes are ALL silent no-ops — the summary file stays the
+# artifact of record, so the notify path NEVER changes the gate's verdict or exit
+# status. This function always returns 0 and never exits, traps, or writes state.
 #   title: "gate <RESULT> <branch>@<short-sha>"
 #   body:  "RESULT: <RESULT>" (+ "— failing: c1,c2" when any component FAILed)
 gate_push_signal() {
   local result="$1" branch="$2" short_sha="$3" fail_components="$4"
-  command -v agent-notify >/dev/null 2>&1 || return 0
-  local category=completion
-  case "$result" in PASS) category=completion ;; *) category=error ;; esac
+  local severity=PASS
+  case "$result" in PASS) severity=PASS ;; *) severity=FAIL ;; esac
   local title="gate $result ${branch}@${short_sha}"
   local body="RESULT: $result"
   [ -n "$fail_components" ] && body="$body — failing: $fail_components"
-  agent-notify --category "$category" "$title" "$body" >/dev/null 2>&1 || true
+  local notify_lib="${REPO_ROOT:-.}/scripts/lib/gate-notify.sh"
+  [ -r "$notify_lib" ] || return 0
+  # shellcheck disable=SC1090
+  . "$notify_lib" >/dev/null 2>&1 || return 0
+  command -v gate_notify_publish >/dev/null 2>&1 || return 0
+  gate_notify_publish "$severity" "$title" "$body" >/dev/null 2>&1 || true
   return 0
 }
 

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -3997,7 +3997,7 @@ _tree_result() {
 # waiting closer/worker is called back instead of idle-polling the summary file.
 # Delegates delivery to the REPO-OWNED contract in scripts/lib/gate-notify.sh
 # (#3119), which builds the ntfy payload itself and publishes it to the server
-# ROOT. It does NOT call `agent-notify --category` any more: the installed
+# ROOT. It does NOT call `agent-notify --category` any more (notify-flag-allow): the installed
 # upstream v1.1.0 has no `--category` arm, so that flag fell through to its
 # manual "$1"/"$2" mode — title became the literal `--category`, the body became
 # the category VALUE, the real title/body were dropped, and a FAIL published

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -5038,7 +5038,13 @@ run_kit_dashboard_drift() {
 # REJECTS a schemas-less / present-but-incomplete root (the #3148 gap survived because
 # `STATUS: OK` was only ever observed on the happy path) and pins the checkout-relative
 # resolution contract. Hermetic temp roots; the FULL-gate cases exit AT the preflight,
-# so no cargo/datasets/network. SKIP-aware: the summary test's truncation case relies on a python3
+# so no cargo/datasets/network. Also runs scripts/tests/test_gate_notify_contract.sh (#3119),
+# which asserts the PUBLISHED push-signal payload (title/body/priority/tag, POSTed to the ntfy
+# server ROOT, message never a JSON document) at the TRANSPORT boundary via a curl-capture shim —
+# the companion test_agent_gate_notify.sh asserts only the ADVISORY half, and an argv-level
+# assertion is explicitly NOT evidence for payload fidelity (the swallowed `--category` defect was
+# invisible to one). Hermetic: no network, no real topic, pristine-agent-notify fixture copied into
+# its own tmpdir. SKIP-aware: the summary test's truncation case relies on a python3
 # reader, so with no python3 we record SKIP (loud, never silent PASS); any test
 # failure -> hard FAIL.
 run_tooling_tests() {
@@ -5538,9 +5544,10 @@ run_tooling_tests() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_gate_notify_contract.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
   if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_notify.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/tests/test_gate_notify_contract.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_smoke_target_dir.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_gate_concurrency_cap.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_bootstrap_agent_machine.sh" >>"$log" 2>&1 &&

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -937,7 +937,14 @@ else
   # Optional local desktop/sound adjunct. No version requirement: it is never in
   # the payload chain, and a hand-patched copy is never required by anything here.
   if have agent-notify; then
-    info "optional local adjunct: $(agent-notify --version 2>/dev/null | head -1 || echo 'agent-notify (version unknown)') — desktop/sound only, no version requirement"
+    # BOUNDED + stdin CLOSED, like every other call into this third-party binary:
+    # measured in #3119, the pristine upstream copy HANGS when it inherits a tty
+    # stdin, and bootstrap must never wedge on an optional version probe.
+    NOTIFY_ADJUNCT_VER=""
+    if have timeout && timeout --kill-after=1 1 true >/dev/null 2>&1; then
+      NOTIFY_ADJUNCT_VER=$(timeout --kill-after=1 5 agent-notify --version 2>/dev/null </dev/null | head -1)
+    fi
+    info "optional local adjunct: ${NOTIFY_ADJUNCT_VER:-agent-notify (version not probed)} — desktop/sound only, no version requirement"
   else
     info "optional local adjunct agent-notify not installed — not needed; ntfy delivery is unaffected"
   fi

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -868,6 +868,63 @@ else
   info "(re-run with --yes to auto-append)"
 fi
 
+# ---- 5c. Notification channel (ntfy) — issue #3119 ----
+# The gate's push signal (#2667) and the worker supervisor page over ntfy. That
+# dependency used to be an out-of-band, per-machine `/usr/local/bin/agent-notify`
+# that this script never mentioned — and whose upstream v1.1.0 silently swallows
+# the flag both callers passed, publishing a FAIL as a green priority-3 success.
+# The payload contract now lives IN THE REPO (scripts/lib/gate-notify.sh), so the
+# only pinned notify artifact travels in git. What a machine still needs is the
+# transport (curl + python3) and a target; what bootstrap verifies is the
+# CAPABILITY — the wrapper's own self-test publishes a PASS *and* a FAIL payload
+# through a capture shim and validates both — never merely that a file exists
+# (same posture as the mold link probe above).
+hdr "Notification channel (ntfy, issue #3119)"
+NOTIFY_LIB="$REPO_ROOT/scripts/lib/gate-notify.sh"
+if [ ! -r "$NOTIFY_LIB" ]; then
+  warn "scripts/lib/gate-notify.sh missing from this checkout — gate/worker notifications are no-ops"
+else
+  info "pinned: $(bash "$NOTIFY_LIB" --version 2>/dev/null || echo 'gate-notify contract v?')  (in-repo, git-pinned)"
+  if have curl; then
+    ok "curl present — ntfy publish transport"
+  else
+    warn "curl MISSING — notifications cannot be published"
+    info "install curl via your package manager (apt/dnf/pacman/brew)"
+  fi
+  if have python3; then
+    ok "python3 present — payload encoder"
+  else
+    warn "python3 MISSING — the notify payload cannot be encoded (notifications become no-ops)"
+  fi
+  NOTIFY_TARGET="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-}}"
+  if [ -n "$NOTIFY_TARGET" ]; then
+    ok "notify target configured (${NOTIFY_TARGET%/*}/…)"
+  else
+    warn "no notify target configured — gate/worker notifications are silent no-ops on this machine"
+    info "fleet mechanism is /etc/environment; add (and re-login):"
+    info "  CODEX_NOTIFY_WEBHOOK=https://ntfy.sh/<your-topic>"
+  fi
+  # The CAPABILITY assert. Runs against a private curl capture shim inside the
+  # wrapper's own tmpdir: no network, no real topic, nothing published anywhere.
+  if have python3; then
+    if selftest_out=$(bash "$NOTIFY_LIB" --self-test 2>&1); then
+      ok "notify capability verified — $selftest_out"
+    else
+      warn "notify self-test FAILED — PASS/FAIL payloads do not satisfy the contract"
+      printf '%s\n' "$selftest_out" | sed 's/^/         /'
+    fi
+  else
+    warn "notify self-test skipped (needs python3) — capability UNVERIFIED on this machine"
+  fi
+  # Optional local desktop/sound adjunct. No version requirement: it is never in
+  # the payload chain, and a hand-patched copy is never required by anything here.
+  if have agent-notify; then
+    info "optional local adjunct: $(agent-notify --version 2>/dev/null | head -1 || echo 'agent-notify (version unknown)') — desktop/sound only, no version requirement"
+  else
+    info "optional local adjunct agent-notify not installed — not needed; ntfy delivery is unaffected"
+  fi
+fi
+
 # ---- 6. Health check: gate fmt + authoritative accelerators line ----
 hdr "Health check (gate fmt + accelerators line)"
 if [ "$SKIP_SMOKE" = 1 ]; then

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -898,7 +898,19 @@ else
   fi
   NOTIFY_TARGET="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-}}"
   if [ -n "$NOTIFY_TARGET" ]; then
-    ok "notify target configured (${NOTIFY_TARGET%/*}/…)"
+    # Report the HOST only, with any URL userinfo stripped. A target of the form
+    # https://user:token@host/topic would otherwise print credentials into a
+    # terminal or a CI log (roborev finding); the topic is likewise not secret but
+    # not useful here, so only scheme://host is shown.
+    NOTIFY_SCHEME="${NOTIFY_TARGET%%://*}"
+    NOTIFY_REST="${NOTIFY_TARGET#*://}"
+    NOTIFY_HOSTPART="${NOTIFY_REST%%/*}"
+    case "$NOTIFY_HOSTPART" in *@*) NOTIFY_HOSTPART="${NOTIFY_HOSTPART##*@}" ;; esac
+    if [ "$NOTIFY_SCHEME" = "$NOTIFY_TARGET" ]; then
+      ok "notify target configured (host not parseable from the value; not echoed)"
+    else
+      ok "notify target configured ($NOTIFY_SCHEME://$NOTIFY_HOSTPART/…)"
+    fi
   else
     warn "no notify target configured — gate/worker notifications are silent no-ops on this machine"
     info "fleet mechanism is /etc/environment; add (and re-login):"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -898,12 +898,18 @@ else
   fi
   NOTIFY_TARGET="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-}}"
   if [ -n "$NOTIFY_TARGET" ]; then
-    # Report the HOST only, with any URL userinfo stripped. A target of the form
-    # https://user:token@host/topic would otherwise print credentials into a
-    # terminal or a CI log (roborev finding); the topic is likewise not secret but
-    # not useful here, so only scheme://host is shown.
+    # Report the HOST only. TWO credential shapes must be stripped before anything
+    # is echoed, because both reach a terminal or a CI log:
+    #   userinfo      https://user:token@host/topic
+    #   query/fragment  https://host?token=secret   (ntfy accepts a bare root, so
+    #                   there is no '/' to bound the authority and the whole
+    #                   "host?token=secret" would otherwise be printed)
+    # Order matters: drop the query and fragment FIRST, then bound the authority,
+    # then drop userinfo.
     NOTIFY_SCHEME="${NOTIFY_TARGET%%://*}"
     NOTIFY_REST="${NOTIFY_TARGET#*://}"
+    NOTIFY_REST="${NOTIFY_REST%%\?*}"
+    NOTIFY_REST="${NOTIFY_REST%%#*}"
     NOTIFY_HOSTPART="${NOTIFY_REST%%/*}"
     case "$NOTIFY_HOSTPART" in *@*) NOTIFY_HOSTPART="${NOTIFY_HOSTPART##*@}" ;; esac
     if [ "$NOTIFY_SCHEME" = "$NOTIFY_TARGET" ]; then

--- a/scripts/lib/gate-notify.sh
+++ b/scripts/lib/gate-notify.sh
@@ -63,8 +63,10 @@ _gate_notify_severity() {
 _gate_notify_priority() { case "$1" in PASS) printf '3\n' ;; *) printf '5\n' ;; esac; }
 _gate_notify_tag() { case "$1" in PASS) printf 'white_check_mark\n' ;; *) printf 'rotating_light\n' ;; esac; }
 
-# _gate_notify_target: print "<server-root><TAB><topic>" for the configured
-# target, or return 1 when either cannot be resolved AUTHORITATIVELY.
+# _gate_notify_target: resolve the configured target into the globals
+# GATE_NOTIFY_ROOT and GATE_NOTIFY_TOPIC, or return 1 when either cannot be
+# resolved AUTHORITATIVELY. (Globals rather than a delimited string on stdout:
+# a whitespace delimiter in shell source is silently destroyed by a reformat.)
 #
 # ntfy JSON publishing requires POSTing to the SERVER ROOT with the topic in the
 # body; POSTed to /<topic> the body is taken as literal message text. The fleet
@@ -73,6 +75,8 @@ _gate_notify_tag() { case "$1" in PASS) printf 'white_check_mark\n' ;; *) printf
 # A target from which no topic can be resolved returns 1 rather than guessing:
 # publishing to a guessed topic pages a stranger.
 _gate_notify_target() {
+  GATE_NOTIFY_ROOT=""
+  GATE_NOTIFY_TOPIC=""
   local url="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-}}"
   local topic="${CQLITE_NOTIFY_TOPIC:-${CODEX_NOTIFY_NTFY_TOPIC:-}}"
   [ -n "$url" ] || { _gate_notify_debug "no notify target configured"; return 1; }
@@ -88,7 +92,9 @@ _gate_notify_target() {
     [ -n "$topic" ] || topic="${u##*/}"
   fi
   [ -n "$topic" ] || { _gate_notify_debug "no topic resolvable from '$url'"; return 1; }
-  printf '%s\t%s\n' "$root" "$topic"
+  GATE_NOTIFY_ROOT="$root"
+  GATE_NOTIFY_TOPIC="$topic"
+  return 0
 }
 
 # _gate_notify_payload <topic> <title> <body> <priority> <tag>: emit the ntfy JSON.
@@ -143,10 +149,9 @@ gate_notify_publish() {
   local severity root topic payload
   severity=$(_gate_notify_severity "$result")
 
-  local target
-  if target=$(_gate_notify_target); then
-    root="${target%%	*}"
-    topic="${target##*	}"
+  if _gate_notify_target; then
+    root="$GATE_NOTIFY_ROOT"
+    topic="$GATE_NOTIFY_TOPIC"
     if command -v curl >/dev/null 2>&1; then
       payload=$(_gate_notify_payload "$topic" "$title" "$body" \
         "$(_gate_notify_priority "$severity")" "$(_gate_notify_tag "$severity")") || payload=""
@@ -209,8 +214,9 @@ try:
     d = json.loads(body)
 except Exception as e:
     print("payload is not JSON: %s" % e); raise SystemExit(1)
-if not url.endswith("/") or url.rstrip("/").count("/") != 2:
-    print("POST target is not a server root: %s" % url); raise SystemExit(1)
+if not url.endswith("/") or url.rstrip("/").endswith("/" + str(d.get("topic", "\0"))):
+    print("POST target is not a server root (topic must be in the body): %s" % url)
+    raise SystemExit(1)
 if str(d.get("priority")) != sys.argv[2] or d.get("tags") != [sys.argv[3]]:
     print("severity mismatch: %s / %s" % (d.get("priority"), d.get("tags"))); raise SystemExit(1)
 msg = d.get("message", "")

--- a/scripts/lib/gate-notify.sh
+++ b/scripts/lib/gate-notify.sh
@@ -229,13 +229,22 @@ PY
   return "$rc"
 }
 
-# Direct execution: --self-test / --version. Sourced use never reaches here.
+# Direct execution: --publish / --self-test / --version. Sourced use never reaches
+# here. `--publish` is the CLI form for callers that hold a command STRING rather
+# than a sourced function (scripts/local/worker-supervisor.sh's $NOTIFY_CMD seam);
+# it keeps the advisory contract and always exits 0.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   case "${1:-}" in
+    --publish)
+      shift
+      gate_notify_publish "${1:-FAIL}" "${2:-}" "${3:-}" >/dev/null 2>&1 || true
+      exit 0
+      ;;
     --self-test) gate_notify_selftest ;;
     --version) echo "gate-notify contract v$GATE_NOTIFY_CONTRACT_VERSION" ;;
     *)
-      echo "usage: gate-notify.sh --self-test | --version   (or source it and call gate_notify_publish)" >&2
+      echo "usage: gate-notify.sh --publish <PASS|FAIL> <title> <body> | --self-test | --version" >&2
+      echo "       (or source it and call gate_notify_publish)" >&2
       exit 2
       ;;
   esac

--- a/scripts/lib/gate-notify.sh
+++ b/scripts/lib/gate-notify.sh
@@ -49,11 +49,30 @@
 # out-of-band per-machine binary).
 GATE_NOTIFY_CONTRACT_VERSION=1
 
-# Bounds. A black-holed network or a wedged helper must never stall a gate. Each
-# is an OUTER `timeout` bound, not a cooperative flag the helper may ignore.
+# Bounds. A black-holed network or a wedged helper must never stall a gate. Each is
+# an OUTER bound enforced with SIGTERM **and then SIGKILL**, so it does not depend on
+# the helper cooperating.
+#
+# Why the SIGKILL escalation is required, not belt-and-braces: plain
+# `timeout <secs> <cmd>` sends SIGTERM ONLY. Measured — a helper containing
+# `trap "" TERM` under `timeout 2` NEVER RETURNED (still alive when a 20s harness
+# SIGKILLed it), so the bound bought nothing at all. `--kill-after=<grace>` follows up
+# with SIGKILL, which cannot be trapped: the same helper then returned rc=137 at 3s
+# (bound 2 + grace 1). `agent-notify` is THIRD-PARTY upstream and mis-assuming its
+# behaviour is the original defect of this whole issue, so its signal handling is not
+# something to assume either.
+#
+# GRACE IS ADDITIVE WALL-CLOCK, never a substitute for the bound: a step's true worst
+# case is `bound + GATE_NOTIFY_KILL_GRACE`. Every caller with a latency ceiling must
+# count the grace once PER STEP (scripts/local/worker-supervisor.sh's exit path does,
+# and scripts/tests/test_agent_gate_notify.sh asserts that arithmetic).
+#
+# A `timeout` that does not support `--kill-after` is treated as NO bounding tool at
+# all — we publish nothing rather than run behind an escapable bound.
 GATE_NOTIFY_CURL_TIMEOUT="${GATE_NOTIFY_CURL_TIMEOUT:-10}"
 GATE_NOTIFY_ADJUNCT_TIMEOUT="${GATE_NOTIFY_ADJUNCT_TIMEOUT:-5}"
 GATE_NOTIFY_PAYLOAD_TIMEOUT="${GATE_NOTIFY_PAYLOAD_TIMEOUT:-10}"
+GATE_NOTIFY_KILL_GRACE="${GATE_NOTIFY_KILL_GRACE:-1}"
 
 _gate_notify_debug() {
   [ "${CQLITE_NOTIFY_DEBUG:-0}" = 1 ] || return 0
@@ -124,7 +143,7 @@ _gate_notify_target() {
 _gate_notify_payload() {
   local to="$1"; shift
   command -v python3 >/dev/null 2>&1 || return 1
-  "$to" "$GATE_NOTIFY_PAYLOAD_TIMEOUT" python3 -c '
+  _gate_notify_bounded "$to" "$GATE_NOTIFY_PAYLOAD_TIMEOUT" python3 -c '
 import json, sys
 topic, title, message, priority, tag = sys.argv[1:6]
 print(json.dumps({
@@ -136,13 +155,29 @@ print(json.dumps({
 }))' "$1" "$2" "$3" "$4" "$5" 2>/dev/null
 }
 
-# _gate_notify_bounded_timeout: print a timeout command prefix, or return 1 when
-# no bounded runner exists. No bound means we run NOTHING external — neither the
-# publish nor the adjunct. Every notification here is advisory; a wedged gate is not.
+# _gate_notify_bounded_timeout: print the name of a timeout(1) that supports
+# `--kill-after`, or return 1 when no such runner exists. The capability is PROBED,
+# not assumed: a `timeout` without `--kill-after` can only SIGTERM, which a helper may
+# ignore, so it does not count as a bounding tool here. No bounding tool means we run
+# NOTHING external — neither the publish nor the adjunct. Every notification here is
+# advisory; a wedged gate is not.
 _gate_notify_bounded_timeout() {
-  if command -v timeout >/dev/null 2>&1; then printf 'timeout\n'; return 0; fi
-  if command -v gtimeout >/dev/null 2>&1; then printf 'gtimeout\n'; return 0; fi
+  local c
+  for c in timeout gtimeout; do
+    command -v "$c" >/dev/null 2>&1 || continue
+    "$c" --kill-after=1 1 true >/dev/null 2>&1 || continue
+    printf '%s\n' "$c"
+    return 0
+  done
   return 1
+}
+
+# _gate_notify_bounded <timeout-cmd> <secs> <cmd...>: run <cmd> under an
+# UNIGNORABLE bound — SIGTERM at <secs>, SIGKILL at <secs>+GATE_NOTIFY_KILL_GRACE.
+_gate_notify_bounded() {
+  local to="$1" secs="$2"
+  shift 2
+  "$to" --kill-after="$GATE_NOTIFY_KILL_GRACE" "$secs" "$@"
 }
 
 # _gate_notify_adjunct <title> <body>: OPTIONAL local desktop/sound notification.
@@ -155,13 +190,19 @@ _gate_notify_bounded_timeout() {
 #      inherits a tty stdin.
 # GATE_NOTIFY_DISABLE_ADJUNCT=1 suppresses it entirely — used by --self-test so a
 # capability probe never fires a real desktop/sound notification (review R3).
+# _gate_notify_adjunct <timeout-cmd> <title> <body>
 _gate_notify_adjunct() {
   [ "${GATE_NOTIFY_DISABLE_ADJUNCT:-0}" = 1 ] && return 0
+  local to="$1"
+  [ -n "$to" ] || { _gate_notify_debug "no unignorable bound available; skipping adjunct"; return 0; }
   command -v agent-notify >/dev/null 2>&1 || return 0
-  local to
-  to=$(_gate_notify_bounded_timeout) || { _gate_notify_debug "no timeout(1); skipping adjunct"; return 0; }
-  env CODEX_NOTIFY_WEBHOOK= CQLITE_NOTIFY_WEBHOOK= CODEX_NOTIFY_WEBHOOK_PRESET= \
-    "$to" "$GATE_NOTIFY_ADJUNCT_TIMEOUT" agent-notify "$1" "$2" >/dev/null 2>&1 </dev/null || true
+  # Subshell + export (not `env`) so the neutralization survives while the bound is
+  # applied by a shell FUNCTION. `</dev/null` is load-bearing: measured, the pristine
+  # upstream binary HANGS on an inherited tty stdin.
+  (
+    export CODEX_NOTIFY_WEBHOOK= CQLITE_NOTIFY_WEBHOOK= CODEX_NOTIFY_WEBHOOK_PRESET=
+    _gate_notify_bounded "$to" "$GATE_NOTIFY_ADJUNCT_TIMEOUT" agent-notify "$2" "$3"
+  ) >/dev/null 2>&1 </dev/null || true
   return 0
 }
 
@@ -178,18 +219,21 @@ gate_notify_publish() {
   local GATE_NOTIFY_ROOT GATE_NOTIFY_TOPIC
   severity=$(_gate_notify_severity "$result")
 
-  # One bounding tool for BOTH external calls; absent ⇒ publish nothing.
-  if ! to=$(_gate_notify_bounded_timeout); then
-    _gate_notify_debug "no timeout(1)/gtimeout(1); publishing nothing rather than running unbounded"
+  # One bounding tool for ALL external calls, probed ONCE per publish. Absent (or
+  # present without `--kill-after`, i.e. SIGTERM-only and therefore escapable) ⇒
+  # publish nothing.
+  to=$(_gate_notify_bounded_timeout) || to=""
+  if [ -z "$to" ]; then
+    _gate_notify_debug "no timeout(1) supporting --kill-after; publishing nothing rather than running behind an escapable bound"
   elif _gate_notify_target; then
     if command -v curl >/dev/null 2>&1; then
       payload=$(_gate_notify_payload "$to" "$GATE_NOTIFY_TOPIC" "$title" "$body" \
         "$(_gate_notify_priority "$severity")" "$(_gate_notify_tag "$severity")") || payload=""
       if [ -n "$payload" ]; then
         _gate_notify_debug "POST $GATE_NOTIFY_ROOT $payload"
-        # OUTER bound + the cooperative flag: --max-time alone is honoured only by
-        # the REAL curl, so it cannot be the guarantee (#3119 B2).
-        "$to" "$GATE_NOTIFY_CURL_TIMEOUT" \
+        # UNIGNORABLE outer bound + the cooperative flag: --max-time alone is honoured
+        # only by the REAL curl, so it cannot be the guarantee (#3119 B2).
+        _gate_notify_bounded "$to" "$GATE_NOTIFY_CURL_TIMEOUT" \
           curl -sS -X POST -H 'Content-Type: application/json' \
           --max-time "$GATE_NOTIFY_CURL_TIMEOUT" \
           -d "$payload" "$GATE_NOTIFY_ROOT" >/dev/null 2>&1 </dev/null || true
@@ -201,7 +245,7 @@ gate_notify_publish() {
     fi
   fi
 
-  _gate_notify_adjunct "$title" "$body"
+  _gate_notify_adjunct "$to" "$title" "$body"
   return 0
 }
 

--- a/scripts/lib/gate-notify.sh
+++ b/scripts/lib/gate-notify.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# gate-notify.sh — the repo-owned notification contract (issue #3119).
+#
+# WHY THIS FILE OWNS THE PAYLOAD. The gate used to call
+# `agent-notify --category <cat> <title> <body>`. The installed upstream
+# `agent-notify` v1.1.0 has NO `--category` arm, so that call fell through to its
+# manual "$1"/"$2" mode: the title became the literal string `--category`, the
+# body became the category VALUE, and the real title/body were dropped as surplus
+# positional args. Worse, manual mode pins its severity to `completion`, so a
+# FAIL gate published ntfy priority 3 with a green white_check_mark — a red gate
+# paging as a routine success. And its ntfy branch POSTs the JSON body to the
+# TOPIC url instead of the server ROOT, so ntfy renders the serialized JSON as
+# the message text. Measured against the pristine binary with a curl-capture:
+#   {"topic":"…","title":"--category","message":"error","priority":3,
+#    "tags":["white_check_mark"]}  ->  POSTed to https://ntfy.sh/<topic>
+# Two of those three defects live INSIDE that binary, unreachable from any
+# caller-side flag probe. So the payload is built HERE, in the repo, git-pinned
+# and gate-tested; `agent-notify` is demoted to an OPTIONAL local desktop/sound
+# adjunct that is never in the payload chain.
+#
+# ADVISORY BY CONTRACT (load-bearing). Nothing in this file may change a caller's
+# verdict or exit status: every external call is time-bounded, its output is
+# discarded and its failure swallowed; no function here ever `exit`s, installs a
+# trap, or writes to any caller state. `gate_notify_publish` always returns 0.
+#
+# Configuration (the fleet already sets the second form in /etc/environment):
+#   CQLITE_NOTIFY_WEBHOOK / CODEX_NOTIFY_WEBHOOK   ntfy target (topic URL or root)
+#   CQLITE_NOTIFY_TOPIC   / CODEX_NOTIFY_NTFY_TOPIC  explicit topic override
+#   CQLITE_NOTIFY_DEBUG=1                          diagnostics (never changes behaviour)
+#
+# Self-test:  bash scripts/lib/gate-notify.sh --self-test
+# Contract test: scripts/tests/test_gate_notify_contract.sh (gate: tooling-tests)
+
+# Contract version — bumped when the published payload shape changes. Bootstrap
+# records this as the pinned notify artifact (it travels in git, not in an
+# out-of-band per-machine binary).
+GATE_NOTIFY_CONTRACT_VERSION=1
+
+# Bounds. A black-holed network or a wedged helper must never stall a gate.
+GATE_NOTIFY_CURL_TIMEOUT="${GATE_NOTIFY_CURL_TIMEOUT:-10}"
+GATE_NOTIFY_ADJUNCT_TIMEOUT="${GATE_NOTIFY_ADJUNCT_TIMEOUT:-5}"
+
+_gate_notify_debug() {
+  [ "${CQLITE_NOTIFY_DEBUG:-0}" = 1 ] || return 0
+  printf 'gate-notify: %s\n' "$*" >&2
+  return 0
+}
+
+# _gate_notify_severity <result>: normalise PASS/FAIL (or completion/error) to
+# the two severities the contract defines. Anything unrecognised is FAIL — the
+# safe direction for a signal whose job is to surface breakage.
+_gate_notify_severity() {
+  case "${1:-}" in
+    PASS | pass | completion) printf 'PASS\n' ;;
+    *) printf 'FAIL\n' ;;
+  esac
+}
+
+# The severity map, pinned. Deliberately the same priority/tag pairs upstream's
+# ntfy preset uses, so a CORRECT notification looks exactly like the fleet
+# expects — the change fixes fidelity, not appearance.
+_gate_notify_priority() { case "$1" in PASS) printf '3\n' ;; *) printf '5\n' ;; esac; }
+_gate_notify_tag() { case "$1" in PASS) printf 'white_check_mark\n' ;; *) printf 'rotating_light\n' ;; esac; }
+
+# _gate_notify_target: print "<server-root><TAB><topic>" for the configured
+# target, or return 1 when either cannot be resolved AUTHORITATIVELY.
+#
+# ntfy JSON publishing requires POSTing to the SERVER ROOT with the topic in the
+# body; POSTed to /<topic> the body is taken as literal message text. The fleet
+# configures a TOPIC URL, so the split happens here.
+#
+# A target from which no topic can be resolved returns 1 rather than guessing:
+# publishing to a guessed topic pages a stranger.
+_gate_notify_target() {
+  local url="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-}}"
+  local topic="${CQLITE_NOTIFY_TOPIC:-${CODEX_NOTIFY_NTFY_TOPIC:-}}"
+  [ -n "$url" ] || { _gate_notify_debug "no notify target configured"; return 1; }
+  local u="${url%%\?*}"          # drop any query string
+  u="${u%%#*}"                   # drop any fragment
+  while [ "${u: -1}" = "/" ]; do u="${u%/}"; done
+  local root
+  if printf '%s' "$u" | grep -Eq '^[A-Za-z][A-Za-z0-9+.-]*://[^/]+$'; then
+    # Already a bare server root: the topic can only come from the override.
+    root="$u/"
+  else
+    root="${u%/*}/"
+    [ -n "$topic" ] || topic="${u##*/}"
+  fi
+  [ -n "$topic" ] || { _gate_notify_debug "no topic resolvable from '$url'"; return 1; }
+  printf '%s\t%s\n' "$root" "$topic"
+}
+
+# _gate_notify_payload <topic> <title> <body> <priority> <tag>: emit the ntfy JSON.
+# Built with python3's json.dumps — never hand-quoted shell interpolation, so a
+# title/body carrying quotes, backslashes or non-ASCII (the body's em dash) can
+# never produce a malformed document.
+_gate_notify_payload() {
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 -c '
+import json, sys
+topic, title, message, priority, tag = sys.argv[1:6]
+print(json.dumps({
+    "topic": topic,
+    "title": title,
+    "message": message,
+    "priority": int(priority),
+    "tags": [tag],
+}))' "$1" "$2" "$3" "$4" "$5" 2>/dev/null
+}
+
+# _gate_notify_bounded_timeout: print a timeout command prefix, or return 1 when
+# no bounded runner exists. No bound means we do not run the adjunct at all —
+# an unbounded helper could stall a gate, and the adjunct is optional by design.
+_gate_notify_bounded_timeout() {
+  if command -v timeout >/dev/null 2>&1; then printf 'timeout\n'; return 0; fi
+  if command -v gtimeout >/dev/null 2>&1; then printf 'gtimeout\n'; return 0; fi
+  return 1
+}
+
+# _gate_notify_adjunct <title> <body>: OPTIONAL local desktop/sound notification.
+# Three properties make this safe against the defects above:
+#   1. POSITIONAL arguments only — never `--category`, the flag upstream swallows.
+#   2. Its webhook environment is NEUTRALIZED, so its own (broken) publish path
+#      cannot deliver a second, JSON-as-message notification.
+#   3. Time-bounded, output discarded, failure swallowed.
+_gate_notify_adjunct() {
+  command -v agent-notify >/dev/null 2>&1 || return 0
+  local to
+  to=$(_gate_notify_bounded_timeout) || { _gate_notify_debug "no timeout(1); skipping adjunct"; return 0; }
+  env CODEX_NOTIFY_WEBHOOK= CQLITE_NOTIFY_WEBHOOK= CODEX_NOTIFY_WEBHOOK_PRESET= \
+    "$to" "$GATE_NOTIFY_ADJUNCT_TIMEOUT" agent-notify "$1" "$2" >/dev/null 2>&1 </dev/null || true
+  return 0
+}
+
+# gate_notify_publish <result> <title> <body>
+#
+# Publish ONE notification for <result> (PASS/FAIL). ALWAYS returns 0 — every
+# failure mode (no target, no python3, no curl, a publish that never completes,
+# an adjunct that rejects its arguments or is not executable) is a silent no-op.
+gate_notify_publish() {
+  local result="${1:-FAIL}" title="${2:-}" body="${3:-}"
+  local severity root topic payload
+  severity=$(_gate_notify_severity "$result")
+
+  local target
+  if target=$(_gate_notify_target); then
+    root="${target%%	*}"
+    topic="${target##*	}"
+    if command -v curl >/dev/null 2>&1; then
+      payload=$(_gate_notify_payload "$topic" "$title" "$body" \
+        "$(_gate_notify_priority "$severity")" "$(_gate_notify_tag "$severity")") || payload=""
+      if [ -n "$payload" ]; then
+        _gate_notify_debug "POST $root $payload"
+        curl -sS -X POST -H 'Content-Type: application/json' \
+          --max-time "$GATE_NOTIFY_CURL_TIMEOUT" \
+          -d "$payload" "$root" >/dev/null 2>&1 </dev/null || true
+      else
+        _gate_notify_debug "payload build failed (python3 missing or errored)"
+      fi
+    else
+      _gate_notify_debug "curl absent; nothing published"
+    fi
+  fi
+
+  _gate_notify_adjunct "$title" "$body"
+  return 0
+}
+
+# --self-test: publish a PASS and a FAIL through a private curl capture shim and
+# validate BOTH against the contract. This is the CAPABILITY assertion
+# bootstrap runs — the analogue of the mold link probe: nothing is declared
+# healthy because a file exists. Exits non-zero ONLY in this mode.
+gate_notify_selftest() {
+  local tmp rc=0
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/gate-notify-selftest.XXXXXX") || return 1
+  mkdir -p "$tmp/bin"
+  cat > "$tmp/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+body=""; url=""; prev=""
+for a in "$@"; do
+  [ "$prev" = "-d" ] && body="$a"
+  prev="$a"; url="$a"
+done
+printf '%s\t%s\n' "$url" "$body" >> "$CURL_LOG"
+SHIM
+  chmod +x "$tmp/bin/curl"
+
+  local self="${BASH_SOURCE[0]}"
+  local severity expect_prio expect_tag log
+  for severity in PASS FAIL; do
+    case "$severity" in
+      PASS) expect_prio=3; expect_tag=white_check_mark ;;
+      *) expect_prio=5; expect_tag=rotating_light ;;
+    esac
+    log="$tmp/$severity.log"
+    : > "$log"
+    env CURL_LOG="$log" PATH="$tmp/bin:$PATH" \
+      CQLITE_NOTIFY_WEBHOOK="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-https://ntfy.invalid/selftest}}" \
+      bash -c '. "$1"; gate_notify_publish "$2" "gate '"$severity"' selftest@0000000" "RESULT: '"$severity"'"' \
+      _ "$self" "$severity" >/dev/null 2>&1
+    if ! python3 - "$log" "$expect_prio" "$expect_tag" <<'PY'
+import json, sys
+lines = open(sys.argv[1]).read().splitlines()
+if len(lines) != 1:
+    print("expected exactly 1 published payload, got %d" % len(lines)); raise SystemExit(1)
+url, _, body = lines[0].partition("\t")
+try:
+    d = json.loads(body)
+except Exception as e:
+    print("payload is not JSON: %s" % e); raise SystemExit(1)
+if not url.endswith("/") or url.rstrip("/").count("/") != 2:
+    print("POST target is not a server root: %s" % url); raise SystemExit(1)
+if str(d.get("priority")) != sys.argv[2] or d.get("tags") != [sys.argv[3]]:
+    print("severity mismatch: %s / %s" % (d.get("priority"), d.get("tags"))); raise SystemExit(1)
+msg = d.get("message", "")
+if not msg or msg.lstrip().startswith("{"):
+    print("message is empty or a serialized document: %r" % msg); raise SystemExit(1)
+if not d.get("title", "").startswith("gate "):
+    print("title is not the gate's own: %r" % d.get("title")); raise SystemExit(1)
+PY
+    then
+      echo "gate-notify --self-test: $severity payload FAILED the contract" >&2
+      rc=1
+    fi
+  done
+  rm -rf "$tmp"
+  [ "$rc" -eq 0 ] && echo "gate-notify --self-test: PASS (contract v$GATE_NOTIFY_CONTRACT_VERSION)"
+  return "$rc"
+}
+
+# Direct execution: --self-test / --version. Sourced use never reaches here.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  case "${1:-}" in
+    --self-test) gate_notify_selftest ;;
+    --version) echo "gate-notify contract v$GATE_NOTIFY_CONTRACT_VERSION" ;;
+    *)
+      echo "usage: gate-notify.sh --self-test | --version   (or source it and call gate_notify_publish)" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/scripts/lib/gate-notify.sh
+++ b/scripts/lib/gate-notify.sh
@@ -3,7 +3,7 @@
 # gate-notify.sh — the repo-owned notification contract (issue #3119).
 #
 # WHY THIS FILE OWNS THE PAYLOAD. The gate used to call
-# `agent-notify --category <cat> <title> <body>`. The installed upstream  notify-flag-allow
+# `agent-notify --category <cat> <title> <body>`. The installed upstream notify-flag-allow
 # `agent-notify` v1.1.0 has NO `--category` arm, so that call fell through to its
 # manual "$1"/"$2" mode: the title became the literal string `--category`, the
 # body became the category VALUE, and the real title/body were dropped as surplus
@@ -20,9 +20,21 @@
 # adjunct that is never in the payload chain.
 #
 # ADVISORY BY CONTRACT (load-bearing). Nothing in this file may change a caller's
-# verdict or exit status: every external call is time-bounded, its output is
-# discarded and its failure swallowed; no function here ever `exit`s, installs a
-# trap, or writes to any caller state. `gate_notify_publish` always returns 0.
+# verdict or exit status: EVERY external call — the payload encoder, the publish,
+# and the optional adjunct — runs under `timeout`, its output is discarded and its
+# failure swallowed; no function here ever `exit`s, installs a trap, or writes to
+# any caller state. `gate_notify_publish` always returns 0.
+#
+# Why the encoder needs a bound too, not just curl (#3119 review B2): the gate
+# calls this AFTER the terminal summary emit but BEFORE its own exit, so a wedged
+# `python3` (a pyenv/conda shim, an NFS-backed interpreter) would block
+# `payload=$(...)` forever — the gate process would never exit, its EXIT trap would
+# never release the #1825 gate slot, and every later gate on the box would queue
+# indefinitely. `curl --max-time` is NOT sufficient either: only the real curl
+# honours it (this repo's own tests prove a bash script can be `curl` on PATH), so
+# the outer bound is what actually guarantees termination. With NO bounding tool
+# available (`timeout`/`gtimeout`) we publish NOTHING rather than run unbounded —
+# a missed notification is advisory, a wedged gate is not.
 #
 # Configuration (the fleet already sets the second form in /etc/environment):
 #   CQLITE_NOTIFY_WEBHOOK / CODEX_NOTIFY_WEBHOOK   ntfy target (topic URL or root)
@@ -37,9 +49,11 @@
 # out-of-band per-machine binary).
 GATE_NOTIFY_CONTRACT_VERSION=1
 
-# Bounds. A black-holed network or a wedged helper must never stall a gate.
+# Bounds. A black-holed network or a wedged helper must never stall a gate. Each
+# is an OUTER `timeout` bound, not a cooperative flag the helper may ignore.
 GATE_NOTIFY_CURL_TIMEOUT="${GATE_NOTIFY_CURL_TIMEOUT:-10}"
 GATE_NOTIFY_ADJUNCT_TIMEOUT="${GATE_NOTIFY_ADJUNCT_TIMEOUT:-5}"
+GATE_NOTIFY_PAYLOAD_TIMEOUT="${GATE_NOTIFY_PAYLOAD_TIMEOUT:-10}"
 
 _gate_notify_debug() {
   [ "${CQLITE_NOTIFY_DEBUG:-0}" = 1 ] || return 0
@@ -63,10 +77,12 @@ _gate_notify_severity() {
 _gate_notify_priority() { case "$1" in PASS) printf '3\n' ;; *) printf '5\n' ;; esac; }
 _gate_notify_tag() { case "$1" in PASS) printf 'white_check_mark\n' ;; *) printf 'rotating_light\n' ;; esac; }
 
-# _gate_notify_target: resolve the configured target into the globals
-# GATE_NOTIFY_ROOT and GATE_NOTIFY_TOPIC, or return 1 when either cannot be
-# resolved AUTHORITATIVELY. (Globals rather than a delimited string on stdout:
-# a whitespace delimiter in shell source is silently destroyed by a reformat.)
+# _gate_notify_target: resolve the configured target into GATE_NOTIFY_ROOT and
+# GATE_NOTIFY_TOPIC, or return 1 when either cannot be resolved AUTHORITATIVELY.
+# (Named variables rather than a delimited string on stdout: a whitespace
+# delimiter in shell source is silently destroyed by a reformat.) Its ONLY caller
+# declares both names `local` first, so bash's dynamic scoping keeps these
+# assignments inside the caller's frame — nothing is written into the gate's shell.
 #
 # ntfy JSON publishing requires POSTing to the SERVER ROOT with the topic in the
 # body; POSTed to /<topic> the body is taken as literal message text. The fleet
@@ -84,7 +100,10 @@ _gate_notify_target() {
   u="${u%%#*}"                   # drop any fragment
   while [ "${u: -1}" = "/" ]; do u="${u%/}"; done
   local root
-  if printf '%s' "$u" | grep -Eq '^[A-Za-z][A-Za-z0-9+.-]*://[^/]+$'; then
+  # Native regex, NOT `printf | grep -q`: under the caller's `set -o pipefail`
+  # (agent-gate.sh) a pipeline whose reader exits early makes printf die on EPIPE
+  # and the pipeline return 141, which would MIS-BRANCH into the has-a-path arm.
+  if [[ "$u" =~ ^[A-Za-z][A-Za-z0-9+.-]*://[^/]+$ ]]; then
     # Already a bare server root: the topic can only come from the override.
     root="$u/"
   else
@@ -97,13 +116,15 @@ _gate_notify_target() {
   return 0
 }
 
-# _gate_notify_payload <topic> <title> <body> <priority> <tag>: emit the ntfy JSON.
-# Built with python3's json.dumps — never hand-quoted shell interpolation, so a
-# title/body carrying quotes, backslashes or non-ASCII (the body's em dash) can
-# never produce a malformed document.
+# _gate_notify_payload <timeout-cmd> <topic> <title> <body> <priority> <tag>: emit
+# the ntfy JSON. Built with python3's json.dumps — never hand-quoted shell
+# interpolation, so a title/body carrying quotes, backslashes or non-ASCII (the
+# body's em dash) can never produce a malformed document. Runs under the caller's
+# OUTER timeout: a wedged interpreter must not block the gate's exit (#3119 B2).
 _gate_notify_payload() {
+  local to="$1"; shift
   command -v python3 >/dev/null 2>&1 || return 1
-  python3 -c '
+  "$to" "$GATE_NOTIFY_PAYLOAD_TIMEOUT" python3 -c '
 import json, sys
 topic, title, message, priority, tag = sys.argv[1:6]
 print(json.dumps({
@@ -116,8 +137,8 @@ print(json.dumps({
 }
 
 # _gate_notify_bounded_timeout: print a timeout command prefix, or return 1 when
-# no bounded runner exists. No bound means we do not run the adjunct at all —
-# an unbounded helper could stall a gate, and the adjunct is optional by design.
+# no bounded runner exists. No bound means we run NOTHING external — neither the
+# publish nor the adjunct. Every notification here is advisory; a wedged gate is not.
 _gate_notify_bounded_timeout() {
   if command -v timeout >/dev/null 2>&1; then printf 'timeout\n'; return 0; fi
   if command -v gtimeout >/dev/null 2>&1; then printf 'gtimeout\n'; return 0; fi
@@ -129,8 +150,13 @@ _gate_notify_bounded_timeout() {
 #   1. POSITIONAL arguments only — never `--category`, the flag upstream swallows.
 #   2. Its webhook environment is NEUTRALIZED, so its own (broken) publish path
 #      cannot deliver a second, JSON-as-message notification.
-#   3. Time-bounded, output discarded, failure swallowed.
+#   3. Time-bounded, output discarded, failure swallowed. The `</dev/null` is
+#      load-bearing: measured, the pristine upstream binary HANGS (rc=124) when it
+#      inherits a tty stdin.
+# GATE_NOTIFY_DISABLE_ADJUNCT=1 suppresses it entirely — used by --self-test so a
+# capability probe never fires a real desktop/sound notification (review R3).
 _gate_notify_adjunct() {
+  [ "${GATE_NOTIFY_DISABLE_ADJUNCT:-0}" = 1 ] && return 0
   command -v agent-notify >/dev/null 2>&1 || return 0
   local to
   to=$(_gate_notify_bounded_timeout) || { _gate_notify_debug "no timeout(1); skipping adjunct"; return 0; }
@@ -146,22 +172,29 @@ _gate_notify_adjunct() {
 # an adjunct that rejects its arguments or is not executable) is a silent no-op.
 gate_notify_publish() {
   local result="${1:-FAIL}" title="${2:-}" body="${3:-}"
-  local severity root topic payload
+  local severity payload to
+  # Declared local HERE so _gate_notify_target's assignments land in THIS frame
+  # (bash dynamic scoping) and never in the caller's shell.
+  local GATE_NOTIFY_ROOT GATE_NOTIFY_TOPIC
   severity=$(_gate_notify_severity "$result")
 
-  if _gate_notify_target; then
-    root="$GATE_NOTIFY_ROOT"
-    topic="$GATE_NOTIFY_TOPIC"
+  # One bounding tool for BOTH external calls; absent ⇒ publish nothing.
+  if ! to=$(_gate_notify_bounded_timeout); then
+    _gate_notify_debug "no timeout(1)/gtimeout(1); publishing nothing rather than running unbounded"
+  elif _gate_notify_target; then
     if command -v curl >/dev/null 2>&1; then
-      payload=$(_gate_notify_payload "$topic" "$title" "$body" \
+      payload=$(_gate_notify_payload "$to" "$GATE_NOTIFY_TOPIC" "$title" "$body" \
         "$(_gate_notify_priority "$severity")" "$(_gate_notify_tag "$severity")") || payload=""
       if [ -n "$payload" ]; then
-        _gate_notify_debug "POST $root $payload"
-        curl -sS -X POST -H 'Content-Type: application/json' \
+        _gate_notify_debug "POST $GATE_NOTIFY_ROOT $payload"
+        # OUTER bound + the cooperative flag: --max-time alone is honoured only by
+        # the REAL curl, so it cannot be the guarantee (#3119 B2).
+        "$to" "$GATE_NOTIFY_CURL_TIMEOUT" \
+          curl -sS -X POST -H 'Content-Type: application/json' \
           --max-time "$GATE_NOTIFY_CURL_TIMEOUT" \
-          -d "$payload" "$root" >/dev/null 2>&1 </dev/null || true
+          -d "$payload" "$GATE_NOTIFY_ROOT" >/dev/null 2>&1 </dev/null || true
       else
-        _gate_notify_debug "payload build failed (python3 missing or errored)"
+        _gate_notify_debug "payload build failed (python3 missing, wedged, or errored)"
       fi
     else
       _gate_notify_debug "curl absent; nothing published"
@@ -200,7 +233,11 @@ SHIM
     esac
     log="$tmp/$severity.log"
     : > "$log"
-    env CURL_LOG="$log" PATH="$tmp/bin:$PATH" \
+    # GATE_NOTIFY_DISABLE_ADJUNCT: a capability PROBE must not fire a real
+    # desktop/sound notification, nor depend on a local helper (review R3).
+    # The topic overrides are cleared so the probe's own target is authoritative.
+    env CURL_LOG="$log" PATH="$tmp/bin:$PATH" GATE_NOTIFY_DISABLE_ADJUNCT=1 \
+      CQLITE_NOTIFY_TOPIC= CODEX_NOTIFY_NTFY_TOPIC= \
       CQLITE_NOTIFY_WEBHOOK="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-https://ntfy.invalid/selftest}}" \
       bash -c '. "$1"; gate_notify_publish "$2" "gate '"$severity"' selftest@0000000" "RESULT: '"$severity"'"' \
       _ "$self" "$severity" >/dev/null 2>&1

--- a/scripts/lib/gate-notify.sh
+++ b/scripts/lib/gate-notify.sh
@@ -209,6 +209,17 @@ gate_notify_publish() {
 # validate BOTH against the contract. This is the CAPABILITY assertion
 # bootstrap runs — the analogue of the mold link probe: nothing is declared
 # healthy because a file exists. Exits non-zero ONLY in this mode.
+#
+# FULLY INDEPENDENT of ambient configuration (review round 2). It pins its OWN
+# private topic URL rather than inheriting the machine's webhook: a legitimate
+# bare-server-root target plus a separate CQLITE_NOTIFY_TOPIC/CODEX_NOTIFY_NTFY_TOPIC
+# override would otherwise resolve to NO topic once the probe cleared those
+# overrides, publish nothing, and make bootstrap report a FAILED capability on a
+# CORRECTLY configured machine. Whether the machine's own target is usable is a
+# separate question, answered by bootstrap's target check — this probe's job is the
+# CODE PATH, so it must not vary with the environment.
+GATE_NOTIFY_SELFTEST_WEBHOOK="https://gate-notify-selftest.invalid/selftest-topic"
+
 gate_notify_selftest() {
   local tmp rc=0
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/gate-notify-selftest.XXXXXX") || return 1
@@ -235,10 +246,12 @@ SHIM
     : > "$log"
     # GATE_NOTIFY_DISABLE_ADJUNCT: a capability PROBE must not fire a real
     # desktop/sound notification, nor depend on a local helper (review R3).
-    # The topic overrides are cleared so the probe's own target is authoritative.
+    # Every target/topic variable is pinned to the probe's OWN private values, so
+    # the probe's verdict is about the code path and never about ambient config.
     env CURL_LOG="$log" PATH="$tmp/bin:$PATH" GATE_NOTIFY_DISABLE_ADJUNCT=1 \
-      CQLITE_NOTIFY_TOPIC= CODEX_NOTIFY_NTFY_TOPIC= \
-      CQLITE_NOTIFY_WEBHOOK="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-https://ntfy.invalid/selftest}}" \
+      CQLITE_NOTIFY_TOPIC= CODEX_NOTIFY_NTFY_TOPIC= CODEX_NOTIFY_WEBHOOK= \
+      GATE_NOTIFY_PAYLOAD_TIMEOUT=10 GATE_NOTIFY_CURL_TIMEOUT=10 \
+      CQLITE_NOTIFY_WEBHOOK="$GATE_NOTIFY_SELFTEST_WEBHOOK" \
       bash -c '. "$1"; gate_notify_publish "$2" "gate '"$severity"' selftest@0000000" "RESULT: '"$severity"'"' \
       _ "$self" "$severity" >/dev/null 2>&1
     if ! python3 - "$log" "$expect_prio" "$expect_tag" <<'PY'

--- a/scripts/lib/gate-notify.sh
+++ b/scripts/lib/gate-notify.sh
@@ -3,7 +3,7 @@
 # gate-notify.sh — the repo-owned notification contract (issue #3119).
 #
 # WHY THIS FILE OWNS THE PAYLOAD. The gate used to call
-# `agent-notify --category <cat> <title> <body>`. The installed upstream
+# `agent-notify --category <cat> <title> <body>`. The installed upstream  notify-flag-allow
 # `agent-notify` v1.1.0 has NO `--category` arm, so that call fell through to its
 # manual "$1"/"$2" mode: the title became the literal string `--category`, the
 # body became the category VALUE, and the real title/body were dropped as surplus

--- a/scripts/lib/gate-notify.sh
+++ b/scripts/lib/gate-notify.sh
@@ -96,27 +96,70 @@ _gate_notify_severity() {
 _gate_notify_priority() { case "$1" in PASS) printf '3\n' ;; *) printf '5\n' ;; esac; }
 _gate_notify_tag() { case "$1" in PASS) printf 'white_check_mark\n' ;; *) printf 'rotating_light\n' ;; esac; }
 
-# _gate_notify_target: resolve the configured target into GATE_NOTIFY_ROOT and
-# GATE_NOTIFY_TOPIC, or return 1 when either cannot be resolved AUTHORITATIVELY.
-# (Named variables rather than a delimited string on stdout: a whitespace
-# delimiter in shell source is silently destroyed by a reformat.) Its ONLY caller
-# declares both names `local` first, so bash's dynamic scoping keeps these
-# assignments inside the caller's frame — nothing is written into the gate's shell.
+# _gate_notify_redact <url>: the PRINTABLE form of a target — scheme://host/ with the
+# query, the fragment and any URL userinfo removed. Three credential shapes reach a
+# terminal or a CI log otherwise: `?token=`, `?auth=` and `user:pass@`. This is the
+# ONLY function whose output may be echoed; see _gate_notify_target's contract.
+_gate_notify_redact() {
+  local in="${1:-}"
+  in="${in%%\?*}"
+  in="${in%%#*}"
+  case "$in" in
+    *://*)
+      local scheme="${in%%://*}" rest="${in#*://}"
+      local hostpart="${rest%%/*}"
+      case "$hostpart" in *@*) hostpart="${hostpart##*@}" ;; esac
+      printf '%s://%s/\n' "$scheme" "$hostpart"
+      ;;
+    *) printf '(unparseable target; not echoed)\n' ;;
+  esac
+}
+
+# _gate_notify_target: resolve the configured target into THREE values with THREE
+# distinct purposes, or return 1 when the topic cannot be resolved AUTHORITATIVELY.
+# (Named variables rather than a delimited string on stdout: a whitespace delimiter
+# in shell source is silently destroyed by a reformat.) Its ONLY caller declares all
+# three names `local` first, so bash's dynamic scoping keeps these assignments inside
+# the caller's frame — nothing is written into the gate's shell.
 #
-# ntfy JSON publishing requires POSTing to the SERVER ROOT with the topic in the
-# body; POSTed to /<topic> the body is taken as literal message text. The fleet
-# configures a TOPIC URL, so the split happens here.
+#   GATE_NOTIFY_DELIVERY_URL  what CURL POSTS TO. **Query string PRESERVED**, because
+#                             `?auth=<token>` is a documented ntfy credential shape and
+#                             dropping it publishes UNAUTHENTICATED — and since publish
+#                             failure is a deliberate no-op, it fails SILENTLY. This
+#                             value MUST NEVER be logged or echoed.
+#   GATE_NOTIFY_TOPIC         the body's `topic`. Parsed from the PATH only, so the
+#                             query/fragment can never end up inside the topic name.
+#   GATE_NOTIFY_SAFE_TARGET   the ONLY value safe to print. Query, fragment AND URL
+#                             userinfo removed, so no `?token=`/`?auth=`/`user:pass@`
+#                             credential can reach a terminal, a CI log or the debug
+#                             stream.
+#
+# DO NOT RE-COLLAPSE THESE. Round 2 of this PR's review added the query-strip to keep
+# credentials out of logs, but applied it to the single value that was ALSO the POST
+# target — so a valid `?auth=` target silently published unauthenticated. The names
+# above are deliberately explicit about which one curl receives; a logging change must
+# only ever touch GATE_NOTIFY_SAFE_TARGET.
+#
+# ntfy JSON publishing requires POSTing to the SERVER ROOT with the topic in the body;
+# POSTed to /<topic> the body is taken as literal message text. The fleet configures a
+# TOPIC URL, so the split happens here.
 #
 # A target from which no topic can be resolved returns 1 rather than guessing:
 # publishing to a guessed topic pages a stranger.
 _gate_notify_target() {
-  GATE_NOTIFY_ROOT=""
+  GATE_NOTIFY_DELIVERY_URL=""
   GATE_NOTIFY_TOPIC=""
+  GATE_NOTIFY_SAFE_TARGET=""
   local url="${CQLITE_NOTIFY_WEBHOOK:-${CODEX_NOTIFY_WEBHOOK:-}}"
   local topic="${CQLITE_NOTIFY_TOPIC:-${CODEX_NOTIFY_NTFY_TOPIC:-}}"
   [ -n "$url" ] || { _gate_notify_debug "no notify target configured"; return 1; }
-  local u="${url%%\?*}"          # drop any query string
-  u="${u%%#*}"                   # drop any fragment
+  # A fragment is never transmitted by HTTP, so it is dropped from everything.
+  local nofrag="${url%%#*}"
+  # The query is SPLIT OFF (not discarded) so it can be re-attached to the delivery
+  # URL after the topic is parsed out of the path.
+  local query=""
+  case "$nofrag" in *\?*) query="?${nofrag#*\?}" ;; esac
+  local u="${nofrag%%\?*}"
   while [ "${u: -1}" = "/" ]; do u="${u%/}"; done
   local root
   # Native regex, NOT `printf | grep -q`: under the caller's `set -o pipefail`
@@ -129,9 +172,10 @@ _gate_notify_target() {
     root="${u%/*}/"
     [ -n "$topic" ] || topic="${u##*/}"
   fi
-  [ -n "$topic" ] || { _gate_notify_debug "no topic resolvable from '$url'"; return 1; }
-  GATE_NOTIFY_ROOT="$root"
+  [ -n "$topic" ] || { _gate_notify_debug "no topic resolvable from the configured target"; return 1; }
+  GATE_NOTIFY_DELIVERY_URL="${root}${query}"
   GATE_NOTIFY_TOPIC="$topic"
+  GATE_NOTIFY_SAFE_TARGET=$(_gate_notify_redact "$root")
   return 0
 }
 
@@ -216,7 +260,7 @@ gate_notify_publish() {
   local severity payload to
   # Declared local HERE so _gate_notify_target's assignments land in THIS frame
   # (bash dynamic scoping) and never in the caller's shell.
-  local GATE_NOTIFY_ROOT GATE_NOTIFY_TOPIC
+  local GATE_NOTIFY_DELIVERY_URL GATE_NOTIFY_TOPIC GATE_NOTIFY_SAFE_TARGET
   severity=$(_gate_notify_severity "$result")
 
   # One bounding tool for ALL external calls, probed ONCE per publish. Absent (or
@@ -230,13 +274,17 @@ gate_notify_publish() {
       payload=$(_gate_notify_payload "$to" "$GATE_NOTIFY_TOPIC" "$title" "$body" \
         "$(_gate_notify_priority "$severity")" "$(_gate_notify_tag "$severity")") || payload=""
       if [ -n "$payload" ]; then
-        _gate_notify_debug "POST $GATE_NOTIFY_ROOT $payload"
+        # SAFE_TARGET, never DELIVERY_URL: the latter carries any `?auth=`/`?token=`
+        # credential and must not reach the debug stream.
+        _gate_notify_debug "POST $GATE_NOTIFY_SAFE_TARGET $payload"
         # UNIGNORABLE outer bound + the cooperative flag: --max-time alone is honoured
         # only by the REAL curl, so it cannot be the guarantee (#3119 B2).
+        # DELIVERY_URL here — query PRESERVED, or a query-credentialed ntfy target
+        # publishes unauthenticated, and silently (publish failure is a no-op).
         _gate_notify_bounded "$to" "$GATE_NOTIFY_CURL_TIMEOUT" \
           curl -sS -X POST -H 'Content-Type: application/json' \
           --max-time "$GATE_NOTIFY_CURL_TIMEOUT" \
-          -d "$payload" "$GATE_NOTIFY_ROOT" >/dev/null 2>&1 </dev/null || true
+          -d "$payload" "$GATE_NOTIFY_DELIVERY_URL" >/dev/null 2>&1 </dev/null || true
       else
         _gate_notify_debug "payload build failed (python3 missing, wedged, or errored)"
       fi
@@ -281,6 +329,15 @@ SHIM
 
   local self="${BASH_SOURCE[0]}"
   local severity expect_prio expect_tag log
+  # The validator below is an external call like any other, so it gets the same
+  # unignorable bound (review round 4 nit). No bounding tool ⇒ the probe cannot make a
+  # bounded claim, so it reports that rather than running the validator unbounded.
+  local selftest_to
+  if ! selftest_to=$(_gate_notify_bounded_timeout); then
+    echo "gate-notify --self-test: SKIP (no timeout(1) supporting --kill-after; cannot bound the validator)" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
   for severity in PASS FAIL; do
     case "$severity" in
       PASS) expect_prio=3; expect_tag=white_check_mark ;;
@@ -298,7 +355,8 @@ SHIM
       CQLITE_NOTIFY_WEBHOOK="$GATE_NOTIFY_SELFTEST_WEBHOOK" \
       bash -c '. "$1"; gate_notify_publish "$2" "gate '"$severity"' selftest@0000000" "RESULT: '"$severity"'"' \
       _ "$self" "$severity" >/dev/null 2>&1
-    if ! python3 - "$log" "$expect_prio" "$expect_tag" <<'PY'
+    if ! _gate_notify_bounded "$selftest_to" "$GATE_NOTIFY_PAYLOAD_TIMEOUT" \
+      python3 - "$log" "$expect_prio" "$expect_tag" <<'PY'
 import json, sys
 lines = open(sys.argv[1]).read().splitlines()
 if len(lines) != 1:

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -380,9 +380,22 @@ if [[ -z "${GH_VERIFY_CMD:-}" ]]; then
   GH_VERIFY_CMD='gh pr view "$1" --repo pmcfadin/cqlite --json state,mergedAt,autoMergeRequest'
 fi
 
+# Notification command (issue #3119). The default is the REPO-OWNED notify
+# contract, not the out-of-band `agent-notify` binary: upstream v1.1.0 has no
+# `--category` arm, so the flag this function used to pass was swallowed — the
+# title became the literal flag name, the message became the category value, and
+# a `high` page published as ntfy priority 3 with a green check. The wrapper owns
+# the payload and publishes to the ntfy server ROOT; `agent-notify` survives only
+# as its optional, bounded, positional local desktop/sound adjunct.
+# CONVENTION: $NOTIFY_CMD takes THREE positional args — <severity> <title>
+# <message> — and is word-split like $CLAIM_CMD. Tests override it with a stub.
 NOOP_NOTIFY_MARKER="__noop_notify__"
 if [[ -z "${NOTIFY_CMD:-}" ]]; then
-  if command -v agent-notify >/dev/null 2>&1; then NOTIFY_CMD="agent-notify"; else NOTIFY_CMD="$NOOP_NOTIFY_MARKER"; fi
+  if [[ -r "$REPO_ROOT/scripts/lib/gate-notify.sh" ]]; then
+    NOTIFY_CMD="bash $REPO_ROOT/scripts/lib/gate-notify.sh --publish"
+  else
+    NOTIFY_CMD="$NOOP_NOTIFY_MARKER"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -396,12 +409,16 @@ notify() {
   [[ "$priority" == "high" ]] && category="error"
   if [[ "$NOTIFY_CMD" == "$NOOP_NOTIFY_MARKER" ]]; then
     if [[ "$WARNED_NOOP_NOTIFY" -eq 0 ]]; then
-      log "WARN: agent-notify not on PATH; notifications are no-ops for this run"
+      log "WARN: no notify command resolved (scripts/lib/gate-notify.sh unreadable); notifications are no-ops for this run"
       WARNED_NOOP_NOTIFY=1
     fi
     return 0
   fi
-  "$NOTIFY_CMD" --category "$category" "$title" "$message" || log "WARN: notify command failed (non-fatal)"
+  # Word-split on purpose (same convention as $CLAIM_CMD): the default value is a
+  # multi-word `bash <path> --publish`. Positional args only — never a flag the
+  # notifier might swallow.
+  # shellcheck disable=SC2086
+  $NOTIFY_CMD "$category" "$title" "$message" || log "WARN: notify command failed (non-fatal)"
 }
 
 is_gt() { awk -v a="$1" -v b="$2" 'BEGIN{ if ((a+0)>(b+0)) exit 0; exit 1 }'; }

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -387,15 +387,23 @@ fi
 # a `high` page published as ntfy priority 3 with a green check. The wrapper owns
 # the payload and publishes to the ntfy server ROOT; `agent-notify` survives only
 # as its optional, bounded, positional local desktop/sound adjunct.
-# CONVENTION: $NOTIFY_CMD takes THREE positional args — <severity> <title>
-# <message> — and is word-split like $CLAIM_CMD. Tests override it with a stub.
+# CONVENTION: the notify command takes THREE positional args — <severity> <title>
+# <message>. The DEFAULT is built as an ARRAY (never a word-split string) so a
+# REPO_ROOT containing a space cannot silently degrade every page to a WARN; an
+# externally supplied NOTIFY_CMD string remains word-split, as the test seam and
+# $CLAIM_CMD both are.
 NOOP_NOTIFY_MARKER="__noop_notify__"
 if [[ -z "${NOTIFY_CMD:-}" ]]; then
   if [[ -r "$REPO_ROOT/scripts/lib/gate-notify.sh" ]]; then
-    NOTIFY_CMD="bash $REPO_ROOT/scripts/lib/gate-notify.sh --publish"
+    NOTIFY_ARGV=(bash "$REPO_ROOT/scripts/lib/gate-notify.sh" --publish)
+    NOTIFY_CMD="${NOTIFY_ARGV[*]}"   # display/marker value only, never re-split
   else
     NOTIFY_CMD="$NOOP_NOTIFY_MARKER"
+    NOTIFY_ARGV=()
   fi
+else
+  # shellcheck disable=SC2206  # deliberate word-split of a caller-supplied string
+  NOTIFY_ARGV=($NOTIFY_CMD)
 fi
 
 # ---------------------------------------------------------------------------
@@ -414,11 +422,9 @@ notify() {
     fi
     return 0
   fi
-  # Word-split on purpose (same convention as $CLAIM_CMD): the default value is a
-  # multi-word `bash <path> --publish`. Positional args only — never a flag the
-  # notifier might swallow.
-  # shellcheck disable=SC2086
-  $NOTIFY_CMD "$category" "$title" "$message" || log "WARN: notify command failed (non-fatal)"
+  # Positional args only — never a flag the notifier might swallow. NOTIFY_ARGV is
+  # a properly quoted array, so a path with a space is safe.
+  "${NOTIFY_ARGV[@]}" "$category" "$title" "$message" || log "WARN: notify command failed (non-fatal)"
 }
 
 is_gt() { awk -v a="$1" -v b="$2" 'BEGIN{ if ((a+0)>(b+0)) exit 0; exit 1 }'; }
@@ -893,8 +899,22 @@ report_pending_at_exit() {
     "these PRs were OPEN with auto-merge armed and had not yet landed when the run stopped — check they merge: ${summary}"
 }
 
+# NOTIFY BOUNDS ON THE EXIT PATH (#2666 / #3119). Issue #2666 pins a <15s
+# supervisor exit latency (test_worker_supervisor.sh Test 22 — stubbed there, so it
+# cannot observe the real notifier). finalize_exit fires up to TWO notifies
+# (report_pending_at_exit + the stop page), and each default-bounded notify is up to
+# 10s publish + 5s adjunct = 30s worst case against a black-holed ntfy host — over
+# the pinned ceiling. So the exit path tightens its own bounds: 2 x (4s + 2s) = 12s
+# worst case, inside 15s with headroom, still strictly better than the old
+# UNBOUNDED `curl -s`. Steady-state notifies keep the roomier defaults.
+NOTIFY_EXIT_CURL_TIMEOUT="${NOTIFY_EXIT_CURL_TIMEOUT:-4}"
+NOTIFY_EXIT_ADJUNCT_TIMEOUT="${NOTIFY_EXIT_ADJUNCT_TIMEOUT:-2}"
+
 finalize_exit() {
   local reason="$1" code="$2"
+  export GATE_NOTIFY_CURL_TIMEOUT="$NOTIFY_EXIT_CURL_TIMEOUT"
+  export GATE_NOTIFY_PAYLOAD_TIMEOUT="$NOTIFY_EXIT_CURL_TIMEOUT"
+  export GATE_NOTIFY_ADJUNCT_TIMEOUT="$NOTIFY_EXIT_ADJUNCT_TIMEOUT"
   # Release this machine's claim ref on a clean stop (issue #2655). `reap`
   # refuses when the claim's issue still has an open PR, so an unfinished endgame
   # is preserved for adoption rather than orphaned.

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -902,18 +902,32 @@ report_pending_at_exit() {
 # NOTIFY BOUNDS ON THE EXIT PATH (#2666 / #3119). Issue #2666 pins a <15s
 # supervisor exit latency (test_worker_supervisor.sh Test 22 — stubbed there, so it
 # cannot observe the real notifier). finalize_exit fires up to TWO notifies
-# (report_pending_at_exit + the stop page), and each default-bounded notify is up to
-# 10s publish + 5s adjunct = 30s worst case against a black-holed ntfy host — over
-# the pinned ceiling. So the exit path tightens its own bounds: 2 x (4s + 2s) = 12s
-# worst case, inside 15s with headroom, still strictly better than the old
-# UNBOUNDED `curl -s`. Steady-state notifies keep the roomier defaults.
-NOTIFY_EXIT_CURL_TIMEOUT="${NOTIFY_EXIT_CURL_TIMEOUT:-4}"
-NOTIFY_EXIT_ADJUNCT_TIMEOUT="${NOTIFY_EXIT_ADJUNCT_TIMEOUT:-2}"
+# (report_pending_at_exit + the stop page).
+#
+# BUDGET ARITHMETIC — count all THREE bounded steps, not two. Each notify runs a
+# payload ENCODER, then the PUBLISH, then the optional ADJUNCT, sequentially, so a
+# single notify's worst case is the SUM of the three bounds. With the roomy defaults
+# (10 + 10 + 5) one notify is 25s and two are 50s — far over the ceiling. An earlier
+# revision of this block tightened only the transport and the adjunct and claimed
+# "2 x (4 + 2) = 12s"; that omitted the encoder, whose bound was also 4s, so the true
+# worst case was 2 x (4 + 4 + 2) = 20s — still OVER the pinned 15s. The bounds below
+# are therefore chosen so that:
+#
+#     2 x (PAYLOAD + CURL + ADJUNCT) = 2 x (2 + 2 + 1) = 10s  <  15s   (5s headroom)
+#
+# Mechanized: scripts/tests/test_agent_gate_notify.sh reads these three values out of
+# THIS file and measures two real notifies with all three helpers wedged, so the
+# arithmetic can never silently drift again. Steady-state notifies keep the roomier
+# defaults; only the exit path is tightened, and it is still strictly better than the
+# UNBOUNDED `curl -s` this replaced.
+NOTIFY_EXIT_PAYLOAD_TIMEOUT="${NOTIFY_EXIT_PAYLOAD_TIMEOUT:-2}"
+NOTIFY_EXIT_CURL_TIMEOUT="${NOTIFY_EXIT_CURL_TIMEOUT:-2}"
+NOTIFY_EXIT_ADJUNCT_TIMEOUT="${NOTIFY_EXIT_ADJUNCT_TIMEOUT:-1}"
 
 finalize_exit() {
   local reason="$1" code="$2"
+  export GATE_NOTIFY_PAYLOAD_TIMEOUT="$NOTIFY_EXIT_PAYLOAD_TIMEOUT"
   export GATE_NOTIFY_CURL_TIMEOUT="$NOTIFY_EXIT_CURL_TIMEOUT"
-  export GATE_NOTIFY_PAYLOAD_TIMEOUT="$NOTIFY_EXIT_CURL_TIMEOUT"
   export GATE_NOTIFY_ADJUNCT_TIMEOUT="$NOTIFY_EXIT_ADJUNCT_TIMEOUT"
   # Release this machine's claim ref on a clean stop (issue #2655). `reap`
   # refuses when the claim's issue still has an open PR, so an unfinished endgame

--- a/scripts/local/worker-supervisor.sh
+++ b/scripts/local/worker-supervisor.sh
@@ -904,24 +904,33 @@ report_pending_at_exit() {
 # cannot observe the real notifier). finalize_exit fires up to TWO notifies
 # (report_pending_at_exit + the stop page).
 #
-# BUDGET ARITHMETIC — count all THREE bounded steps, not two. Each notify runs a
-# payload ENCODER, then the PUBLISH, then the optional ADJUNCT, sequentially, so a
-# single notify's worst case is the SUM of the three bounds. With the roomy defaults
-# (10 + 10 + 5) one notify is 25s and two are 50s — far over the ceiling. An earlier
-# revision of this block tightened only the transport and the adjunct and claimed
-# "2 x (4 + 2) = 12s"; that omitted the encoder, whose bound was also 4s, so the true
-# worst case was 2 x (4 + 4 + 2) = 20s — still OVER the pinned 15s. The bounds below
-# are therefore chosen so that:
+# BUDGET ARITHMETIC — count all THREE bounded steps, AND the SIGKILL grace on each.
+# Each notify runs a payload ENCODER, then the PUBLISH, then the optional ADJUNCT,
+# sequentially, so one notify's worst case is the SUM over steps of
+# (bound + GATE_NOTIFY_KILL_GRACE). Two omissions have already been caught here, both
+# by review, and both of the same shape — a term left out of this sum:
 #
-#     2 x (PAYLOAD + CURL + ADJUNCT) = 2 x (2 + 2 + 1) = 10s  <  15s   (5s headroom)
+#   1. The ENCODER term. An early revision tightened only transport+adjunct and claimed
+#      "2 x (4 + 2) = 12s"; the encoder's 4s bound was missing, so the truth was
+#      2 x (4 + 4 + 2) = 20s — OVER the ceiling.
+#   2. The KILL GRACE. `timeout` alone only SIGTERMs and a helper can ignore that
+#      (measured: a `trap "" TERM` helper under `timeout 2` never returned), so
+#      gate-notify.sh now escalates to SIGKILL via `--kill-after=<grace>`. That grace is
+#      ADDITIVE WALL-CLOCK — `--kill-after=1 2` returns at 3s — so keeping 2/2/1 would
+#      have made this 2 x (2+1 + 2+1 + 1+1) = 16s, again OVER the ceiling.
 #
-# Mechanized: scripts/tests/test_agent_gate_notify.sh reads these three values out of
-# THIS file and measures two real notifies with all three helpers wedged, so the
-# arithmetic can never silently drift again. Steady-state notifies keep the roomier
-# defaults; only the exit path is tightened, and it is still strictly better than the
-# UNBOUNDED `curl -s` this replaced.
-NOTIFY_EXIT_PAYLOAD_TIMEOUT="${NOTIFY_EXIT_PAYLOAD_TIMEOUT:-2}"
-NOTIFY_EXIT_CURL_TIMEOUT="${NOTIFY_EXIT_CURL_TIMEOUT:-2}"
+# So the bounds are retuned DOWN as part of adding the grace, never the ceiling up:
+#
+#     2 x [ (PAYLOAD+g) + (CURL+g) + (ADJUNCT+g) ]
+#   = 2 x [ (1+1) + (1+1) + (1+1) ] = 12s  <  15s   (3s headroom, g = 1)
+#
+# Mechanized: scripts/tests/test_agent_gate_notify.sh reads these three values AND the
+# grace out of the sources and measures two real notifies against SIGTERM-IGNORING
+# wedges, so neither omission can recur silently. Steady-state notifies keep the
+# roomier defaults; only the exit path is tightened, and it remains strictly better
+# than the UNBOUNDED `curl -s` this replaced.
+NOTIFY_EXIT_PAYLOAD_TIMEOUT="${NOTIFY_EXIT_PAYLOAD_TIMEOUT:-1}"
+NOTIFY_EXIT_CURL_TIMEOUT="${NOTIFY_EXIT_CURL_TIMEOUT:-1}"
 NOTIFY_EXIT_ADJUNCT_TIMEOUT="${NOTIFY_EXIT_ADJUNCT_TIMEOUT:-1}"
 
 finalize_exit() {

--- a/scripts/tests/test_agent_gate_notify.sh
+++ b/scripts/tests/test_agent_gate_notify.sh
@@ -155,6 +155,65 @@ else
   bad "wedged-encoder case (rc=$rc elapsed=${elapsed}s) — the encoder is not bounded"
 fi
 
+# ---- Case 3e: a helper that IGNORES SIGTERM is still killed --------------------
+# THE defect this case exists for: plain `timeout <secs> <cmd>` sends SIGTERM ONLY.
+# Measured against a `trap "" TERM` helper, `timeout 2` NEVER RETURNED (still alive
+# when a 20s harness SIGKILLed it) — the bound bought nothing, re-opening the exact
+# signature this issue exists to prevent (gate_push_signal hanging after the summary
+# emit, so the gate never exits and the #1825 slot is never released). Every wedge in
+# the cases above uses `sleep`, which DIES on SIGTERM, so none of them can see this.
+# The fix is `--kill-after=<grace>`, whose SIGKILL cannot be trapped.
+trapdir="$tmp/trapterm"; mkdir -p "$trapdir"
+for helper in curl python3 agent-notify; do
+  printf '#!/usr/bin/env bash\ntrap "" TERM\nwhile :; do sleep 0.2; done\n' > "$trapdir/$helper"
+  chmod +x "$trapdir/$helper"
+done
+# An INDEPENDENT hard cap (SIGKILL, so it cannot itself be ignored) wraps the call:
+# under a regression to a plain SIGTERM-only `timeout` this case must produce a clean
+# RED, not hang the component until the gate's own timeout. Verified by mutation:
+# without this cap the whole suite had to be SIGKILLed at 90s with no verdict at all.
+CASE3E_CAP=25
+t0=$(date +%s)
+env CURL_LOG="$tmp/case3e.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$trapdir:$PATH" \
+  GATE_NOTIFY_PAYLOAD_TIMEOUT=1 GATE_NOTIFY_CURL_TIMEOUT=1 GATE_NOTIFY_ADJUNCT_TIMEOUT=1 \
+  timeout -s KILL "$CASE3E_CAP" \
+  bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+elapsed=$(( $(date +%s) - t0 ))
+# Two SIGTERM-ignoring steps at (1s bound + 1s grace) each, so a correct
+# implementation returns in a few seconds; rc=137 or elapsed at the cap means the
+# bound escaped and the caller was never released.
+if [ "$rc" -eq 0 ] && [ "$elapsed" -lt "$CASE3E_CAP" ] && silent; then
+  ok "SIGTERM-IGNORING helpers: killed at bound+grace (${elapsed}s), rc=0 — the bound is unignorable"
+else
+  bad "SIGTERM-ignoring-helper case (rc=$rc elapsed=${elapsed}s, cap ${CASE3E_CAP}s) — an escapable SIGTERM-only bound"
+fi
+
+# ---- Case 3f: a SIGTERM-only timeout does not count as a bounding tool ---------
+# Capability is PROBED, not assumed: a `timeout` lacking --kill-after can only be
+# escaped, so it must be treated as NO bounding tool (publish nothing) rather than
+# trusted. Shadow `timeout` with one that rejects --kill-after.
+sigtermonly="$tmp/sigtermonly"; mkdir -p "$sigtermonly"
+cp "$stubdir/curl" "$sigtermonly/curl"
+cat > "$sigtermonly/timeout" <<'TO'
+#!/usr/bin/env bash
+# A SIGTERM-only timeout: rejects --kill-after exactly as pre-8.5 coreutils would.
+case "${1:-}" in --kill-after*|-k) echo "timeout: unrecognized option '$1'" >&2; exit 125 ;; esac
+exec /usr/bin/timeout "$@"
+TO
+chmod +x "$sigtermonly/timeout"
+: > "$tmp/case3f.log"
+env CURL_LOG="$tmp/case3f.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$sigtermonly:$PATH" \
+  bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$(publishes "$tmp/case3f.log")" -eq 0 ] && silent; then
+  ok "SIGTERM-only timeout: treated as NO bounding tool, publishes nothing, rc=0"
+else
+  bad "SIGTERM-only-timeout case (rc=$rc publishes=$(publishes "$tmp/case3f.log")) — trusted an escapable bound"
+fi
+
 # ---- Case 3d: with NO bounding tool, publish NOTHING rather than run unbounded -
 nobound="$tmp/nobound"; mkdir -p "$nobound"
 cp "$stubdir/curl" "$nobound/curl"
@@ -305,18 +364,26 @@ fi
 # three values out of worker-supervisor.sh and measure the real thing with ALL THREE
 # helpers wedged, so the arithmetic cannot drift silently.
 SUPERVISOR="$SCRIPT_DIR/../local/worker-supervisor.sh"
-exit_bound_of() { # <var-name>
-  sed -n "s/^$1=\"\${$1:-\([0-9]*\)}\".*/\1/p" "$SUPERVISOR" | head -1
+LIBFILE="$SCRIPT_DIR/../lib/gate-notify.sh"
+bound_of() { # <var-name> <file>
+  sed -n "s/^$1=\"\${$1:-\([0-9]*\)}\".*/\1/p" "$2" | head -1
 }
-ep=$(exit_bound_of NOTIFY_EXIT_PAYLOAD_TIMEOUT)
-ec=$(exit_bound_of NOTIFY_EXIT_CURL_TIMEOUT)
-ea=$(exit_bound_of NOTIFY_EXIT_ADJUNCT_TIMEOUT)
-if [ -z "$ep" ] || [ -z "$ec" ] || [ -z "$ea" ]; then
-  bad "exit-path budget: could not read NOTIFY_EXIT_* bounds from worker-supervisor.sh"
+ep=$(bound_of NOTIFY_EXIT_PAYLOAD_TIMEOUT "$SUPERVISOR")
+ec=$(bound_of NOTIFY_EXIT_CURL_TIMEOUT "$SUPERVISOR")
+ea=$(bound_of NOTIFY_EXIT_ADJUNCT_TIMEOUT "$SUPERVISOR")
+# The SIGKILL grace is ADDITIVE WALL-CLOCK and must be counted ONCE PER STEP.
+# Omitting a term from this sum is the exact defect this assertion exists to catch —
+# it has already happened twice (the encoder bound, then this grace).
+gr=$(bound_of GATE_NOTIFY_KILL_GRACE "$LIBFILE")
+if [ -z "$ep" ] || [ -z "$ec" ] || [ -z "$ea" ] || [ -z "$gr" ]; then
+  bad "exit-path budget: could not read the NOTIFY_EXIT_* bounds and/or GATE_NOTIFY_KILL_GRACE"
 else
+  # SIGTERM-IGNORING wedges. A `sleep`-based wedge DIES on SIGTERM, so it cannot
+  # observe an escapable bound at all — that structural blindness is why the plain
+  # `timeout` defect reached review instead of the fast loop.
   wedged="$tmp/wedged"; mkdir -p "$wedged"
   for helper in curl python3 agent-notify; do
-    printf '#!/usr/bin/env bash\nsleep 600\n' > "$wedged/$helper"
+    printf '#!/usr/bin/env bash\ntrap "" TERM\nwhile :; do sleep 0.2; done\n' > "$wedged/$helper"
     chmod +x "$wedged/$helper"
   done
   t0=$(date +%s)
@@ -328,13 +395,14 @@ else
       >"$tmp/out.txt" 2>"$tmp/err.txt"
   done
   elapsed=$(( $(date +%s) - t0 ))
-  budget=$(( 2 * (ep + ec + ea) ))
+  # 2 notifies x 3 sequential steps, each step costing (bound + grace).
+  budget=$(( 2 * ((ep + gr) + (ec + gr) + (ea + gr)) ))
   # The DECLARED budget must fit the pinned ceiling, and the MEASURED worst case must
   # not exceed the declared budget (plus process-spawn slack).
   if [ "$budget" -lt 15 ] && [ "$elapsed" -le $((budget + 8)) ]; then
-    ok "exit-path notify budget: 2 x ($ep+$ec+$ea) = ${budget}s < 15s (#2666), measured ${elapsed}s with all three helpers wedged"
+    ok "exit-path notify budget: 2 x [($ep+$gr)+($ec+$gr)+($ea+$gr)] = ${budget}s < 15s (#2666), measured ${elapsed}s against SIGTERM-ignoring wedges"
   else
-    bad "exit-path notify budget: declared ${budget}s (2 x ($ep+$ec+$ea)) vs #2666's 15s ceiling; measured ${elapsed}s"
+    bad "exit-path notify budget: declared ${budget}s (2 x [($ep+$gr)+($ec+$gr)+($ea+$gr)]) vs #2666's 15s ceiling; measured ${elapsed}s"
   fi
 fi
 

--- a/scripts/tests/test_agent_gate_notify.sh
+++ b/scripts/tests/test_agent_gate_notify.sh
@@ -386,17 +386,22 @@ else
     printf '#!/usr/bin/env bash\ntrap "" TERM\nwhile :; do sleep 0.2; done\n' > "$wedged/$helper"
     chmod +x "$wedged/$helper"
   done
+  # 2 notifies x 3 sequential steps, each step costing (bound + grace).
+  budget=$(( 2 * ((ep + gr) + (ec + gr) + (ea + gr)) ))
+  # Independent SIGKILL cap per notify, for the same reason case 3e has one: under a
+  # regression to an escapable bound this must RED, not hang the component until the
+  # gate's own timeout. Measured: without a cap the suite ran past 200s with no verdict.
+  cap=$(( budget + 10 ))
   t0=$(date +%s)
   for _ in 1 2; do   # finalize_exit's two notifies
     env CURL_LOG="$tmp/case11b.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$wedged:$PATH" \
       GATE_NOTIFY_PAYLOAD_TIMEOUT="$ep" GATE_NOTIFY_CURL_TIMEOUT="$ec" \
       GATE_NOTIFY_ADJUNCT_TIMEOUT="$ea" \
+      timeout -s KILL "$cap" \
       bash -c '. "$0"; gate_push_signal FAIL advisory-branch abc1234 "fmt"' "$fnfile" \
       >"$tmp/out.txt" 2>"$tmp/err.txt"
   done
   elapsed=$(( $(date +%s) - t0 ))
-  # 2 notifies x 3 sequential steps, each step costing (bound + grace).
-  budget=$(( 2 * ((ep + gr) + (ec + gr) + (ea + gr)) ))
   # The DECLARED budget must fit the pinned ceiling, and the MEASURED worst case must
   # not exceed the declared budget (plus process-spawn slack).
   if [ "$budget" -lt 15 ] && [ "$elapsed" -le $((budget + 8)) ]; then

--- a/scripts/tests/test_agent_gate_notify.sh
+++ b/scripts/tests/test_agent_gate_notify.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 # Regression test for issue #2667: the full agent-gate must fire ONE advisory
-# `agent-notify` push at final-SUMMARY time, converting the summary file from a
-# passive poll target into a PUSH signal for a waiting closer/worker. Contract:
+# push at final-SUMMARY time, converting the summary file from a passive poll
+# target into a PUSH signal for a waiting closer/worker. Contract:
 #   - title: "gate <RESULT> <branch>@<short-sha>"
 #   - body:  "RESULT: <RESULT>" (+ "— failing: c1,c2" when components FAILed)
-#   - category: completion on PASS, error on FAIL
-#   - ADVISORY: if agent-notify is absent OR fails, gate_push_signal is a silent
-#     no-op that returns 0 — it never affects the gate verdict/exit.
+#   - ADVISORY: for EVERY failure mode of the notify path, gate_push_signal is a
+#     silent no-op that returns 0 — it never affects the gate verdict/exit.
+#
+# SCOPE (issue #3119). This file owns the **ADVISORY** half of the contract: the
+# catalogue of ways the notify path can fail without touching the verdict. It
+# does NOT — and CANNOT — establish payload fidelity: it asserts the arguments
+# the gate produces, and an argv assertion can never observe what the notifier
+# ACCEPTS or PUBLISHES. That blind spot is exactly how the swallowed `--category`
+# defect survived (the old stub here implemented a `--category` arm the real
+# upstream binary does not have, encoding the caller's own wrong assumption).
+# Payload fidelity is asserted against the PUBLISHED bytes in
+# scripts/tests/test_gate_notify_contract.sh.
 #
 # Hermetic + fast by design: it does NOT run the 5-8 min real gate. It extracts
 # the self-contained gate_push_signal() function from agent-gate.sh, sources just
-# that, and drives it against a PATH-stubbed agent-notify that records its argv.
+# that, and drives it with a stubbed notify path.
 #
 # Run standalone:   bash scripts/tests/test_agent_gate_notify.sh
 # Or via the gate:  scripts/agent-gate.sh runs it as the `tooling-tests` component.
@@ -40,56 +49,203 @@ fi
 # shellcheck disable=SC1090
 . "$fnfile"
 
-# A stub agent-notify that records "<category>\t<title>\t<body>" to $NOTIFY_LOG.
+# ---------------------------------------------------------------------------
+# The notify path under test. gate_push_signal delegates delivery to the
+# repo-owned scripts/lib/gate-notify.sh (#3119), so REPO_ROOT must resolve to
+# this checkout for the real wrapper to be found.
+# ---------------------------------------------------------------------------
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+export REPO_ROOT
+LIB="$REPO_ROOT/scripts/lib/gate-notify.sh"
+WEBHOOK="https://ntfy.invalid/advisory-topic-3119"
+
 stubdir="$tmp/bin"
 mkdir -p "$stubdir"
-cat > "$stubdir/agent-notify" <<'STUB'
+
+# A curl capture shim: one line per published payload. Used ONLY to count
+# publishes and to inspect the flags the wrapper passes; payload CONTENT is
+# asserted in scripts/tests/test_gate_notify_contract.sh.
+cat > "$stubdir/curl" <<'CURLSHIM'
 #!/usr/bin/env bash
-# --category C "Title" "Message"  ->  record C<TAB>Title<TAB>Message
-cat=""
-if [ "$1" = "--category" ]; then cat="$2"; shift 2; fi
-printf '%s\t%s\t%s\n' "$cat" "${1:-}" "${2:-}" >> "$NOTIFY_LOG"
-STUB
-chmod +x "$stubdir/agent-notify"
+{ printf 'CURL'; for a in "$@"; do printf '\t%s' "$a"; done; printf '\n'; } >> "$CURL_LOG"
+CURLSHIM
+chmod +x "$stubdir/curl"
 
-# ---- Case 1: PASS fires a completion push with the expected title/body --------
-NOTIFY_LOG="$tmp/case1.log"; : > "$NOTIFY_LOG"; export NOTIFY_LOG
-PATH="$stubdir:$PATH" gate_push_signal PASS issue-2667-poll-to-push abc1234 ""
+# drive <log> <extra-PATH-dir> <result> [env assignments...]
+# Runs the REAL gate_push_signal + REAL wrapper, capturing stdout/stderr.
+drive() {
+  local log="$1" bindir="$2" result="$3"; shift 3
+  : > "$log"
+  env CURL_LOG="$log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$bindir:$PATH" "$@" \
+    bash -c '. "$0"; gate_push_signal "$1" advisory-branch abc1234 ""' \
+    "$fnfile" "$result" >"$tmp/out.txt" 2>"$tmp/err.txt"
+  return $?
+}
+silent() { [ ! -s "$tmp/out.txt" ] && [ ! -s "$tmp/err.txt" ]; }
+# grep -c prints 0 and exits 1 on no match; capture the count, ignore the status.
+publishes() { local n; n=$(grep -c '^CURL' "$1" 2>/dev/null); printf '%s\n' "${n:-0}"; }
+
+# ---- Case 1: the happy path publishes exactly once, silently, rc=0 -----------
+log="$tmp/case1.log"
+drive "$log" "$stubdir" PASS
 rc=$?
-n=$(wc -l < "$NOTIFY_LOG" | tr -d ' ')
-if [ "$rc" -eq 0 ] && [ "$n" -eq 1 ] \
-   && grep -qP '^completion\tgate PASS issue-2667-poll-to-push@abc1234\tRESULT: PASS$' "$NOTIFY_LOG" 2>/dev/null; then
-  ok "PASS: exactly ONE completion push, correct title + body"
-elif [ "$rc" -eq 0 ] && [ "$n" -eq 1 ] \
-   && awk -F'\t' 'NR==1 && $1=="completion" && $2=="gate PASS issue-2667-poll-to-push@abc1234" && $3=="RESULT: PASS"{found=1} END{exit found?0:1}' "$NOTIFY_LOG"; then
-  # Fallback for greps without -P (BSD grep): assert via awk field split.
-  ok "PASS: exactly ONE completion push, correct title + body"
+if [ "$rc" -eq 0 ] && [ "$(publishes "$log")" -eq 1 ] && silent; then
+  ok "happy path: ONE publish, rc=0, silent"
 else
-  bad "PASS case (rc=$rc lines=$n)"; echo "--- log ---"; cat "$NOTIFY_LOG"; echo "-----------"
+  bad "happy path (rc=$rc publishes=$(publishes "$log"))"; cat "$log" "$tmp/err.txt"
 fi
 
-# ---- Case 2: FAIL fires an error push and lists failing components ------------
-NOTIFY_LOG="$tmp/case2.log"; : > "$NOTIFY_LOG"; export NOTIFY_LOG
-PATH="$stubdir:$PATH" gate_push_signal FAIL issue-2667-poll-to-push deadbee "fmt,clippy"
+# ---- Case 2: FAIL also publishes exactly once, silently, rc=0 ----------------
+log="$tmp/case2.log"
+drive "$log" "$stubdir" FAIL
 rc=$?
-n=$(wc -l < "$NOTIFY_LOG" | tr -d ' ')
-if [ "$rc" -eq 0 ] && [ "$n" -eq 1 ] \
-   && awk -F'\t' 'NR==1 && $1=="error" && $2=="gate FAIL issue-2667-poll-to-push@deadbee" && $3=="RESULT: FAIL — failing: fmt,clippy"{found=1} END{exit found?0:1}' "$NOTIFY_LOG"; then
-  ok "FAIL: ONE error push, title + failing components in body"
+if [ "$rc" -eq 0 ] && [ "$(publishes "$log")" -eq 1 ] && silent; then
+  ok "FAIL result: ONE publish, rc=0, silent"
 else
-  bad "FAIL case (rc=$rc lines=$n)"; echo "--- log ---"; cat "$NOTIFY_LOG"; echo "-----------"
+  bad "FAIL result (rc=$rc publishes=$(publishes "$log"))"; cat "$log" "$tmp/err.txt"
 fi
 
-# ---- Case 3: agent-notify absent -> silent no-op, still returns 0 -------------
-# Empty PATH means `command -v agent-notify` fails; the function must no-op.
-NOTIFY_LOG="$tmp/case3.log"; : > "$NOTIFY_LOG"; export NOTIFY_LOG
-PATH="/nonexistent-dir-2667" gate_push_signal PASS somebranch cafef00d "" 2>/dev/null
-rc=$?
-n=$(wc -l < "$NOTIFY_LOG" | tr -d ' ')
-if [ "$rc" -eq 0 ] && [ "$n" -eq 0 ]; then
-  ok "absent agent-notify: silent no-op, returns 0"
+# ---- Case 3: the publish is TIME-BOUNDED (curl carries --max-time) -----------
+if grep -q $'\t--max-time\t' "$tmp/case2.log"; then
+  ok "publish is time-bounded: curl is invoked with --max-time"
 else
-  bad "absent case (rc=$rc lines=$n — expected rc=0, no push)"
+  bad "publish is NOT time-bounded: no --max-time in the curl invocation"
+fi
+
+# ---------------------------------------------------------------------------
+# The ADVISORY failure catalogue (#3119 AC4). For every one of these the
+# function must return 0 and write nothing — a notification path must NEVER be
+# able to fail a gate.
+# ---------------------------------------------------------------------------
+
+# ---- Case 4: agent-notify absent -> silent no-op, still returns 0 ------------
+# An empty PATH also removes curl, so nothing can be published either.
+log="$tmp/case4.log"
+: > "$log"
+CURL_LOG="$log" PATH="/nonexistent-dir-2667" gate_push_signal PASS somebranch cafef00d "" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$(publishes "$log")" -eq 0 ] && silent; then
+  ok "absent notifier + absent curl: silent no-op, returns 0"
+else
+  bad "absent case (rc=$rc publishes=$(publishes "$log"))"
+fi
+
+# ---- Case 5: a notifier that REJECTS ALL ARGUMENTS ---------------------------
+# THE hole the old argv-stub left: the real upstream agent-notify has no
+# --category arm, and a helper that usage-errors on everything it is handed must
+# still be harmless. This is the exact class that produced issue #3119.
+rejectdir="$tmp/reject"; mkdir -p "$rejectdir"; cp "$stubdir/curl" "$rejectdir/curl"
+cat > "$rejectdir/agent-notify" <<'REJECT'
+#!/usr/bin/env bash
+echo "agent-notify: error: unrecognised arguments: $*" >&2
+exit 2
+REJECT
+chmod +x "$rejectdir/agent-notify"
+log="$tmp/case5.log"
+drive "$log" "$rejectdir" FAIL
+rc=$?
+if [ "$rc" -eq 0 ] && silent; then
+  ok "notifier rejects ALL arguments: rc=0, nothing on stdout/stderr"
+else
+  bad "rejects-all-arguments case (rc=$rc)"; cat "$tmp/err.txt"
+fi
+
+# ---- Case 6: a notifier that exits non-zero ---------------------------------
+faildir="$tmp/failing"; mkdir -p "$faildir"; cp "$stubdir/curl" "$faildir/curl"
+printf '#!/usr/bin/env bash\nexit 17\n' > "$faildir/agent-notify"
+chmod +x "$faildir/agent-notify"
+log="$tmp/case6.log"
+drive "$log" "$faildir" PASS
+rc=$?
+if [ "$rc" -eq 0 ] && silent; then
+  ok "notifier exits non-zero: rc=0, silent"
+else
+  bad "failing-notifier case (rc=$rc)"
+fi
+
+# ---- Case 7: a notifier present but NOT EXECUTABLE --------------------------
+noexecdir="$tmp/noexec"; mkdir -p "$noexecdir"; cp "$stubdir/curl" "$noexecdir/curl"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$noexecdir/agent-notify"
+chmod 644 "$noexecdir/agent-notify"
+log="$tmp/case7.log"
+drive "$log" "$noexecdir" PASS
+rc=$?
+if [ "$rc" -eq 0 ] && silent; then
+  ok "notifier present but not executable: rc=0, silent"
+else
+  bad "non-executable-notifier case (rc=$rc)"; cat "$tmp/err.txt"
+fi
+
+# ---- Case 8: a notifier that HANGS is abandoned at its own bound -------------
+hangdir="$tmp/hang"; mkdir -p "$hangdir"; cp "$stubdir/curl" "$hangdir/curl"
+printf '#!/usr/bin/env bash\nsleep 600\n' > "$hangdir/agent-notify"
+chmod +x "$hangdir/agent-notify"
+log="$tmp/case8.log"
+t0=$(date +%s)
+drive "$log" "$hangdir" PASS GATE_NOTIFY_ADJUNCT_TIMEOUT=2
+rc=$?
+elapsed=$(( $(date +%s) - t0 ))
+# Ceiling is deliberately loose (2s bound + generous slack) so CPU contention
+# cannot flake it; the property under test is "bounded at all", not a latency SLO.
+if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 30 ] && silent; then
+  ok "hanging notifier: abandoned at its bound (${elapsed}s), rc=0, silent"
+else
+  bad "hanging-notifier case (rc=$rc elapsed=${elapsed}s)"
+fi
+
+# ---- Case 9: the repo-owned wrapper missing -> no-op ------------------------
+log="$tmp/case9.log"
+: > "$log"
+env CURL_LOG="$log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$stubdir:$PATH" \
+  REPO_ROOT="$tmp/no-such-checkout" \
+  bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$(publishes "$log")" -eq 0 ] && silent; then
+  ok "repo-owned wrapper missing: silent no-op, returns 0"
+else
+  bad "missing-wrapper case (rc=$rc publishes=$(publishes "$log"))"; cat "$tmp/err.txt"
+fi
+
+# ---- Case 10: no notify target configured -> nothing published --------------
+log="$tmp/case10.log"
+: > "$log"
+env CURL_LOG="$log" PATH="$stubdir:$PATH" \
+  CQLITE_NOTIFY_WEBHOOK= CODEX_NOTIFY_WEBHOOK= \
+  bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$(publishes "$log")" -eq 0 ] && silent; then
+  ok "no notify target: nothing published, rc=0, silent"
+else
+  bad "no-target case (rc=$rc publishes=$(publishes "$log"))"; cat "$tmp/err.txt"
+fi
+
+# ---- Case 11: a bare server root with no topic override never guesses -------
+log="$tmp/case11.log"
+: > "$log"
+env CURL_LOG="$log" PATH="$stubdir:$PATH" \
+  CQLITE_NOTIFY_WEBHOOK="https://ntfy.invalid" CQLITE_NOTIFY_TOPIC= CODEX_NOTIFY_NTFY_TOPIC= \
+  bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$(publishes "$log")" -eq 0 ] && silent; then
+  ok "unresolvable topic: nothing published (never a guessed topic), rc=0"
+else
+  bad "unresolvable-topic case (rc=$rc publishes=$(publishes "$log"))"; cat "$log"
+fi
+
+# ---- Case 12: structural — the function cannot alter gate state -------------
+# rc=0 in every case above is necessary but not sufficient: the function must
+# also be incapable of exiting, trapping, or rewriting the artifact of record.
+if ! grep -qE '(^|[^_[:alnum:]])exit([^_[:alnum:]]|$)' "$fnfile" \
+   && ! grep -q 'trap ' "$fnfile" \
+   && ! grep -q 'SUMMARY_FILE' "$fnfile" \
+   && grep -q 'return 0' "$fnfile"; then
+  ok "structural: gate_push_signal never exits, traps or writes the summary file"
+else
+  bad "structural: gate_push_signal can alter gate state"; cat "$fnfile"
 fi
 
 echo "----------------------------------------"

--- a/scripts/tests/test_agent_gate_notify.sh
+++ b/scripts/tests/test_agent_gate_notify.sh
@@ -199,28 +199,49 @@ else
   bad "SIGTERM-ignoring-helper case (rc=$rc elapsed=${elapsed}s, cap ${TIMING_CAP}s) — an escapable SIGTERM-only bound"
 fi
 
-# ---- Case 3f: a SIGTERM-only timeout does not count as a bounding tool ---------
+# ---- Case 3f: a SIGTERM-only timeout is PROBED AND REJECTED, not merely failed --
 # Capability is PROBED, not assumed: a `timeout` lacking --kill-after can only be
 # escaped, so it must be treated as NO bounding tool (publish nothing) rather than
-# trusted. Shadow `timeout` with one that rejects --kill-after.
+# trusted.
+#
+# DISCRIMINATION (review round 5). "publishes nothing, rc=0" is NOT sufficient
+# evidence: with the probe REMOVED the wrapper still attempts each bounded call, the
+# stub still rejects it, and the observable outcome is identical — so the assertion
+# passed on the stub's own rc=125 rather than on the probe existing. Measured:
+# deleting the probe left the suite 18/18 green. The discriminator is WHICH
+# invocations the stub receives:
+#   probed-and-rejected  -> exactly the probe (`--kill-after=1 1 true`), and NOTHING
+#                           else is ever attempted
+#   attempted-and-failed -> the stub is handed the real work (python3/curl), i.e. the
+#                           wrapper ran behind a bound it had not verified
 sigtermonly="$tmp/sigtermonly"; mkdir -p "$sigtermonly"
 cp "$stubdir/curl" "$sigtermonly/curl"
 cat > "$sigtermonly/timeout" <<'TO'
 #!/usr/bin/env bash
-# A SIGTERM-only timeout: rejects --kill-after exactly as pre-8.5 coreutils would.
+# A SIGTERM-only timeout: rejects --kill-after exactly as pre-8.5 coreutils would,
+# and RECORDS every invocation so the caller's intent is observable.
+{ printf 'TIMEOUT'; for a in "$@"; do printf '\t%s' "$a"; done; printf '\n'; } >> "$TIMEOUT_LOG"
 case "${1:-}" in --kill-after*|-k) echo "timeout: unrecognized option '$1'" >&2; exit 125 ;; esac
 exec /usr/bin/timeout "$@"
 TO
 chmod +x "$sigtermonly/timeout"
 : > "$tmp/case3f.log"
-env CURL_LOG="$tmp/case3f.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$sigtermonly:$PATH" \
+: > "$tmp/case3f.timeout.log"
+# capped OUTSIDE env: `capped` is a shell function, so `env … capped` would exec a
+# non-existent binary (rc=127). This ordering also means the CAP uses the real
+# timeout(1) from the outer PATH, never the SIGTERM-only stub under test.
+capped env CURL_LOG="$tmp/case3f.log" TIMEOUT_LOG="$tmp/case3f.timeout.log" \
+  CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$sigtermonly:$PATH" \
   bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
   >"$tmp/out.txt" 2>"$tmp/err.txt"
 rc=$?
-if [ "$rc" -eq 0 ] && [ "$(publishes "$tmp/case3f.log")" -eq 0 ] && silent; then
-  ok "SIGTERM-only timeout: treated as NO bounding tool, publishes nothing, rc=0"
+probe_seen=$(grep -c $'^TIMEOUT\t--kill-after=1\t1\ttrue$' "$tmp/case3f.timeout.log" 2>/dev/null)
+work_attempted=$(grep -cE $'^TIMEOUT\t.*\t(python3|curl|agent-notify)' "$tmp/case3f.timeout.log" 2>/dev/null)
+if [ "$rc" -eq 0 ] && [ "$(publishes "$tmp/case3f.log")" -eq 0 ] && silent \
+   && [ "${probe_seen:-0}" -ge 1 ] && [ "${work_attempted:-0}" -eq 0 ]; then
+  ok "SIGTERM-only timeout: PROBED and rejected (probe seen, zero work attempted), publishes nothing, rc=0"
 else
-  bad "SIGTERM-only-timeout case (rc=$rc publishes=$(publishes "$tmp/case3f.log")) — trusted an escapable bound"
+  bad "SIGTERM-only-timeout case (rc=$rc publishes=$(publishes "$tmp/case3f.log") probe=${probe_seen:-0} work-attempted=${work_attempted:-0}) — the capability was not probed before use"
 fi
 
 # ---- Case 3d: with NO bounding tool, publish NOTHING rather than run unbounded -

--- a/scripts/tests/test_agent_gate_notify.sh
+++ b/scripts/tests/test_agent_gate_notify.sh
@@ -76,12 +76,22 @@ chmod +x "$stubdir/curl"
 drive() {
   local log="$1" bindir="$2" result="$3"; shift 3
   : > "$log"
-  env CURL_LOG="$log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$bindir:$PATH" "$@" \
+  capped env CURL_LOG="$log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$bindir:$PATH" "$@" \
     bash -c '. "$0"; gate_push_signal "$1" advisory-branch abc1234 ""' \
     "$fnfile" "$result" >"$tmp/out.txt" 2>"$tmp/err.txt"
   return $?
 }
 silent() { [ ! -s "$tmp/out.txt" ] && [ ! -s "$tmp/err.txt" ]; }
+# TIMING-CASE CAP (issue #3119, review round 5). Every case that measures elapsed
+# time is asserting "this call is bounded". Under the mutation such a case exists to
+# catch, the call is NOT bounded — so without an INDEPENDENT cap the case does not go
+# red, it HANGS, and because scripts/agent-gate.sh has no per-component timeout the
+# whole gate hangs with it. Measured: an audit run was SIGKILLed at 250s with no
+# verdict. SIGKILL (-s KILL) because the very thing under test may ignore SIGTERM.
+# INVARIANT: every `date +%s` case in this file routes its subject through capped().
+TIMING_CAP="${TIMING_CAP:-25}"
+capped() { timeout -s KILL "$TIMING_CAP" "$@"; }
+
 # grep -c prints 0 and exits 1 on no match; capture the count, ignore the status.
 publishes() { local n; n=$(grep -c '^CURL' "$1" 2>/dev/null); printf '%s\n' "${n:-0}"; }
 
@@ -123,14 +133,15 @@ hangcurl="$tmp/hangcurl"; mkdir -p "$hangcurl"
 printf '#!/usr/bin/env bash\nsleep 600\n' > "$hangcurl/curl"
 chmod +x "$hangcurl/curl"
 t0=$(date +%s)
-env CURL_LOG="$tmp/case3b.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$hangcurl:$PATH" \
+capped env CURL_LOG="$tmp/case3b.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$hangcurl:$PATH" \
   GATE_NOTIFY_CURL_TIMEOUT=2 GATE_NOTIFY_ADJUNCT_TIMEOUT=2 \
   bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
   >"$tmp/out.txt" 2>"$tmp/err.txt"
 rc=$?
 elapsed=$(( $(date +%s) - t0 ))
-# Loose ceiling (2s bound + generous slack): the property is "bounded at all".
-if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 30 ] && silent; then
+# Loose ceiling (2s bound + slack): the property is "bounded at all". rc must be 0 —
+# rc=137 at TIMING_CAP is the cap firing, i.e. the bound escaped.
+if [ "$rc" -eq 0 ] && [ "$elapsed" -lt "$TIMING_CAP" ] && silent; then
   ok "hanging transport that ignores --max-time: abandoned at the OUTER bound (${elapsed}s), rc=0"
 else
   bad "hanging-transport case (rc=$rc elapsed=${elapsed}s) — the publish is not outer-bounded"
@@ -143,13 +154,13 @@ hangpy="$tmp/hangpy"; mkdir -p "$hangpy"; cp "$stubdir/curl" "$hangpy/curl"
 printf '#!/usr/bin/env bash\nsleep 600\n' > "$hangpy/python3"
 chmod +x "$hangpy/python3"
 t0=$(date +%s)
-env CURL_LOG="$tmp/case3c.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$hangpy:$PATH" \
+capped env CURL_LOG="$tmp/case3c.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$hangpy:$PATH" \
   GATE_NOTIFY_PAYLOAD_TIMEOUT=2 GATE_NOTIFY_ADJUNCT_TIMEOUT=2 \
   bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
   >"$tmp/out.txt" 2>"$tmp/err.txt"
 rc=$?
 elapsed=$(( $(date +%s) - t0 ))
-if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 30 ] && silent; then
+if [ "$rc" -eq 0 ] && [ "$elapsed" -lt "$TIMING_CAP" ] && silent; then
   ok "wedged payload encoder: abandoned at its bound (${elapsed}s), rc=0, nothing published"
 else
   bad "wedged-encoder case (rc=$rc elapsed=${elapsed}s) — the encoder is not bounded"
@@ -172,11 +183,9 @@ done
 # under a regression to a plain SIGTERM-only `timeout` this case must produce a clean
 # RED, not hang the component until the gate's own timeout. Verified by mutation:
 # without this cap the whole suite had to be SIGKILLed at 90s with no verdict at all.
-CASE3E_CAP=25
 t0=$(date +%s)
-env CURL_LOG="$tmp/case3e.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$trapdir:$PATH" \
+capped env CURL_LOG="$tmp/case3e.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$trapdir:$PATH" \
   GATE_NOTIFY_PAYLOAD_TIMEOUT=1 GATE_NOTIFY_CURL_TIMEOUT=1 GATE_NOTIFY_ADJUNCT_TIMEOUT=1 \
-  timeout -s KILL "$CASE3E_CAP" \
   bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
   >"$tmp/out.txt" 2>"$tmp/err.txt"
 rc=$?
@@ -184,10 +193,10 @@ elapsed=$(( $(date +%s) - t0 ))
 # Two SIGTERM-ignoring steps at (1s bound + 1s grace) each, so a correct
 # implementation returns in a few seconds; rc=137 or elapsed at the cap means the
 # bound escaped and the caller was never released.
-if [ "$rc" -eq 0 ] && [ "$elapsed" -lt "$CASE3E_CAP" ] && silent; then
+if [ "$rc" -eq 0 ] && [ "$elapsed" -lt "$TIMING_CAP" ] && silent; then
   ok "SIGTERM-IGNORING helpers: killed at bound+grace (${elapsed}s), rc=0 — the bound is unignorable"
 else
-  bad "SIGTERM-ignoring-helper case (rc=$rc elapsed=${elapsed}s, cap ${CASE3E_CAP}s) — an escapable SIGTERM-only bound"
+  bad "SIGTERM-ignoring-helper case (rc=$rc elapsed=${elapsed}s, cap ${TIMING_CAP}s) — an escapable SIGTERM-only bound"
 fi
 
 # ---- Case 3f: a SIGTERM-only timeout does not count as a bounding tool ---------
@@ -306,9 +315,10 @@ t0=$(date +%s)
 drive "$log" "$hangdir" PASS GATE_NOTIFY_ADJUNCT_TIMEOUT=2
 rc=$?
 elapsed=$(( $(date +%s) - t0 ))
-# Ceiling is deliberately loose (2s bound + generous slack) so CPU contention
+# Ceiling is the shared TIMING_CAP (2s bound + generous slack) so CPU contention
 # cannot flake it; the property under test is "bounded at all", not a latency SLO.
-if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 30 ] && silent; then
+# `drive` routes through capped(), so an unbounded adjunct reds here instead of hanging.
+if [ "$rc" -eq 0 ] && [ "$elapsed" -lt "$TIMING_CAP" ] && silent; then
   ok "hanging notifier: abandoned at its bound (${elapsed}s), rc=0, silent"
 else
   bad "hanging-notifier case (rc=$rc elapsed=${elapsed}s)"
@@ -408,6 +418,79 @@ else
     ok "exit-path notify budget: 2 x [($ep+$gr)+($ec+$gr)+($ea+$gr)] = ${budget}s < 15s (#2666), measured ${elapsed}s against SIGTERM-ignoring wedges"
   else
     bad "exit-path notify budget: declared ${budget}s (2 x [($ep+$gr)+($ec+$gr)+($ea+$gr)]) vs #2666's 15s ceiling; measured ${elapsed}s"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# The CALL SITE (issue #3119 spec R1 scenario 4 / R3 scenario 3). Every case above
+# drives the extracted gate_push_signal FUNCTION, so none of them observes how the
+# gate DECIDES what to pass it. Those two scenarios are about exactly that decision,
+# so they are asserted here by extracting the call-site block from agent-gate.sh and
+# driving it in a sandbox with the surrounding gate state faked — READ-ONLY: nothing
+# in agent-gate.sh is modified, and no testability seam was added to it.
+# ---------------------------------------------------------------------------
+callsite="$tmp/callsite.sh"
+awk '/^if \[ -z "\$ONLY" \] && \[ "\$LITE" -eq 0 \] && \[ "\$DELTA" -eq 0 \] && \[ "\$SELFTEST" -eq 0 \]; then/{grab=1}
+     grab{print}
+     grab&&/^fi$/{exit}' "$GATE" > "$callsite"
+if ! grep -q 'gate_push_signal "\$_push_result"' "$callsite" \
+   || ! grep -q 'TREE_COMMIT_LINE' "$callsite" \
+   || ! grep -q 'SUMMARY_WRITE_FAILED' "$callsite"; then
+  bad "could not extract the push-signal CALL SITE from $GATE"
+else
+  # drive_callsite <overall> <summary-write-failed> <commit-line> [statuses...]
+  # Replaces gate_push_signal with a recorder so the assertion is about the
+  # ARGUMENTS THE GATE CHOSE, which is what both scenarios specify.
+  drive_callsite() {
+    local overall="$1" swf="$2" commitline="$3"; shift 3
+    ONLY="" LITE=0 DELTA=0 SELFTEST=0 \
+    OVERALL="$overall" SUMMARY_WRITE_FAILED="$swf" TREE_COMMIT_LINE="$commitline" \
+    STATUS_LIST="$*" \
+    bash -c '
+      ONLY="$ONLY"; LITE=$LITE; DELTA=$DELTA; SELFTEST=$SELFTEST
+      OVERALL="$OVERALL"; SUMMARY_WRITE_FAILED=$SUMMARY_WRITE_FAILED
+      TREE_COMMIT_LINE="$TREE_COMMIT_LINE"
+      NAMES=(); STATUSES=()
+      i=0; for st in $STATUS_LIST; do NAMES+=("c$i"); STATUSES+=("$st"); i=$((i+1)); done
+      gate_push_signal() { printf "%s|%s|%s|%s\n" "$1" "$2" "$3" "$4"; }
+      . "$1"
+    ' _ "$callsite" 2>/dev/null
+  }
+
+  # ---- R1 S4: the title names the identity the SUMMARY BLOCK stamped ----------
+  # A fresh emit-time `git` read would report the CURRENT checkout; the block's
+  # stamped line is the authority (#2926 review C1). Feed a commit line that could
+  # not possibly match this worktree and assert it is what comes through.
+  out=$(drive_callsite PASS 0 "commit: feedface branch: stamped-branch dirty: no" PASS PASS)
+  if [ "$out" = "PASS|stamped-branch|feedface|" ]; then
+    ok "R1 S4: push identity is taken from the SUMMARY's stamped line, not a fresh git read"
+  else
+    bad "R1 S4: expected 'PASS|stamped-branch|feedface|', got '$out'"
+  fi
+  # A malformed/absent stamp must degrade to the documented placeholders, never to a
+  # silently wrong identity.
+  out=$(drive_callsite PASS 0 "" PASS)
+  case "$out" in
+    PASS\|unknown\|unknown\|*) ok "R1 S4: an unparseable stamp degrades to 'unknown', never a guess" ;;
+    *) bad "R1 S4 placeholder: got '$out'" ;;
+  esac
+
+  # ---- R3 S3: a summary-write failure forces FAIL severity --------------------
+  # Correctness components all PASSed, but the run produced no artifact of record,
+  # so the signal must say FAIL — a green page for a run with no summary file is the
+  # inversion this whole issue exists to prevent.
+  out=$(drive_callsite PASS 1 "commit: abc1234 branch: b dirty: no" PASS PASS)
+  if [ "${out%%|*}" = FAIL ]; then
+    ok "R3 S3: SUMMARY_WRITE_FAILED forces the FAIL severity despite all-PASS components"
+  else
+    bad "R3 S3: expected FAIL severity, got '$out'"
+  fi
+  # ...and the failing-component list is still assembled from the real statuses.
+  out=$(drive_callsite FAIL 0 "commit: abc1234 branch: b dirty: no" PASS FAIL FAIL)
+  if [ "$out" = "FAIL|b|abc1234|c1,c2" ]; then
+    ok "R3 S3: the body lists exactly the FAILed components, comma-joined"
+  else
+    bad "R3 S3 components: expected 'FAIL|b|abc1234|c1,c2', got '$out'"
   fi
 fi
 

--- a/scripts/tests/test_agent_gate_notify.sh
+++ b/scripts/tests/test_agent_gate_notify.sh
@@ -112,6 +112,67 @@ else
   bad "publish is NOT time-bounded: no --max-time in the curl invocation"
 fi
 
+# ---- Case 3b: the bound is an OUTER one, not just the cooperative flag --------
+# #3119 B2: --max-time is honoured only by the REAL curl, and this very file proves
+# a bash script can BE curl on PATH. gate_push_signal runs after the terminal
+# summary emit but before the gate's exit, so an unbounded transport would leave
+# the gate process alive forever and its EXIT trap would never release the #1825
+# gate slot — every later gate on the box would queue indefinitely. Assert with a
+# transport that IGNORES --max-time and hangs.
+hangcurl="$tmp/hangcurl"; mkdir -p "$hangcurl"
+printf '#!/usr/bin/env bash\nsleep 600\n' > "$hangcurl/curl"
+chmod +x "$hangcurl/curl"
+t0=$(date +%s)
+env CURL_LOG="$tmp/case3b.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$hangcurl:$PATH" \
+  GATE_NOTIFY_CURL_TIMEOUT=2 GATE_NOTIFY_ADJUNCT_TIMEOUT=2 \
+  bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+elapsed=$(( $(date +%s) - t0 ))
+# Loose ceiling (2s bound + generous slack): the property is "bounded at all".
+if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 30 ] && silent; then
+  ok "hanging transport that ignores --max-time: abandoned at the OUTER bound (${elapsed}s), rc=0"
+else
+  bad "hanging-transport case (rc=$rc elapsed=${elapsed}s) — the publish is not outer-bounded"
+fi
+
+# ---- Case 3c: a wedged payload ENCODER cannot stall the gate either -----------
+# Same class as 3b for python3 (a pyenv/conda/NFS shim that stalls): the encoder
+# runs inside a command substitution, so an unbounded one blocks gate_push_signal.
+hangpy="$tmp/hangpy"; mkdir -p "$hangpy"; cp "$stubdir/curl" "$hangpy/curl"
+printf '#!/usr/bin/env bash\nsleep 600\n' > "$hangpy/python3"
+chmod +x "$hangpy/python3"
+t0=$(date +%s)
+env CURL_LOG="$tmp/case3c.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$hangpy:$PATH" \
+  GATE_NOTIFY_PAYLOAD_TIMEOUT=2 GATE_NOTIFY_ADJUNCT_TIMEOUT=2 \
+  bash -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+elapsed=$(( $(date +%s) - t0 ))
+if [ "$rc" -eq 0 ] && [ "$elapsed" -lt 30 ] && silent; then
+  ok "wedged payload encoder: abandoned at its bound (${elapsed}s), rc=0, nothing published"
+else
+  bad "wedged-encoder case (rc=$rc elapsed=${elapsed}s) — the encoder is not bounded"
+fi
+
+# ---- Case 3d: with NO bounding tool, publish NOTHING rather than run unbounded -
+nobound="$tmp/nobound"; mkdir -p "$nobound"
+cp "$stubdir/curl" "$nobound/curl"
+# A PATH holding ONLY curl + python3: no timeout(1), no gtimeout(1).
+py=$(command -v python3); [ -n "$py" ] && ln -sf "$py" "$nobound/python3"
+: > "$tmp/case3d.log"
+# Absolute interpreter: `env PATH=… bash` would resolve bash from the STRIPPED
+# PATH and die 127 before the code under test ever runs.
+env CURL_LOG="$tmp/case3d.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$nobound" \
+  "${BASH:-/bin/bash}" -c '. "$0"; gate_push_signal PASS advisory-branch abc1234 ""' "$fnfile" \
+  >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$(publishes "$tmp/case3d.log")" -eq 0 ] && silent; then
+  ok "no timeout(1)/gtimeout(1): publishes NOTHING rather than running unbounded, rc=0"
+else
+  bad "no-bounding-tool case (rc=$rc publishes=$(publishes "$tmp/case3d.log")) — ran unbounded"
+fi
+
 # ---------------------------------------------------------------------------
 # The ADVISORY failure catalogue (#3119 AC4). For every one of these the
 # function must return 0 and write nothing — a notification path must NEVER be

--- a/scripts/tests/test_agent_gate_notify.sh
+++ b/scripts/tests/test_agent_gate_notify.sh
@@ -297,6 +297,47 @@ else
   bad "unresolvable-topic case (rc=$rc publishes=$(publishes "$log"))"; cat "$log"
 fi
 
+# ---- Case 11b: the supervisor's EXIT-PATH notify budget fits under #2666 -----
+# #2666 pins a <15s supervisor exit latency; its own Test 22 stubs the notifier, so
+# it cannot see the real bound. finalize_exit fires TWO notifies, and each runs THREE
+# bounded steps SEQUENTIALLY (encoder, publish, adjunct) — so the per-notify worst
+# case is their SUM, not the two the first revision of that block counted. Read the
+# three values out of worker-supervisor.sh and measure the real thing with ALL THREE
+# helpers wedged, so the arithmetic cannot drift silently.
+SUPERVISOR="$SCRIPT_DIR/../local/worker-supervisor.sh"
+exit_bound_of() { # <var-name>
+  sed -n "s/^$1=\"\${$1:-\([0-9]*\)}\".*/\1/p" "$SUPERVISOR" | head -1
+}
+ep=$(exit_bound_of NOTIFY_EXIT_PAYLOAD_TIMEOUT)
+ec=$(exit_bound_of NOTIFY_EXIT_CURL_TIMEOUT)
+ea=$(exit_bound_of NOTIFY_EXIT_ADJUNCT_TIMEOUT)
+if [ -z "$ep" ] || [ -z "$ec" ] || [ -z "$ea" ]; then
+  bad "exit-path budget: could not read NOTIFY_EXIT_* bounds from worker-supervisor.sh"
+else
+  wedged="$tmp/wedged"; mkdir -p "$wedged"
+  for helper in curl python3 agent-notify; do
+    printf '#!/usr/bin/env bash\nsleep 600\n' > "$wedged/$helper"
+    chmod +x "$wedged/$helper"
+  done
+  t0=$(date +%s)
+  for _ in 1 2; do   # finalize_exit's two notifies
+    env CURL_LOG="$tmp/case11b.log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$wedged:$PATH" \
+      GATE_NOTIFY_PAYLOAD_TIMEOUT="$ep" GATE_NOTIFY_CURL_TIMEOUT="$ec" \
+      GATE_NOTIFY_ADJUNCT_TIMEOUT="$ea" \
+      bash -c '. "$0"; gate_push_signal FAIL advisory-branch abc1234 "fmt"' "$fnfile" \
+      >"$tmp/out.txt" 2>"$tmp/err.txt"
+  done
+  elapsed=$(( $(date +%s) - t0 ))
+  budget=$(( 2 * (ep + ec + ea) ))
+  # The DECLARED budget must fit the pinned ceiling, and the MEASURED worst case must
+  # not exceed the declared budget (plus process-spawn slack).
+  if [ "$budget" -lt 15 ] && [ "$elapsed" -le $((budget + 8)) ]; then
+    ok "exit-path notify budget: 2 x ($ep+$ec+$ea) = ${budget}s < 15s (#2666), measured ${elapsed}s with all three helpers wedged"
+  else
+    bad "exit-path notify budget: declared ${budget}s (2 x ($ep+$ec+$ea)) vs #2666's 15s ceiling; measured ${elapsed}s"
+  fi
+fi
+
 # ---- Case 12: structural — the function cannot alter gate state -------------
 # rc=0 in every case above is necessary but not sufficient: the function must
 # also be incapable of exiting, trapping, or rewriting the artifact of record.

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -108,7 +108,7 @@ else
 fi
 
 # --- 4. The run must actually emit its section headers (it ran the checks). ---
-for section in "Rust toolchain" "Gate accelerators" "project scope" "roborev" "CQLITE_DATASETS_ROOT" "Bootstrap summary"; do
+for section in "Rust toolchain" "Gate accelerators" "project scope" "roborev" "CQLITE_DATASETS_ROOT" "Notification channel" "Bootstrap summary"; do
   if printf '%s' "$run_out" | grep -q "$section"; then
     ok "check section present: $section"
   else
@@ -1149,6 +1149,35 @@ if [ -z "$mutating" ]; then
   ok "board: probe never invoked a mutating gh/board operation"
 else
   bad "board: probe issued a MUTATING call: $mutating"
+fi
+
+# --- 9. Notification channel (issue #3119) ----------------------------------
+# The notify dep used to be an out-of-band, hand-patched /usr/local/bin binary
+# that bootstrap never mentioned. It is now a repo-owned contract, and bootstrap
+# must (a) assert the CAPABILITY by running the wrapper's own self-test rather
+# than checking that a file exists, (b) RECORD the pinned contract version, and
+# (c) never prescribe the swallowed `--category` shape.
+if grep -q 'NOTIFY_LIB=.*scripts/lib/gate-notify.sh' "$BOOTSTRAP" \
+   && grep -q '\$NOTIFY_LIB" --self-test' "$BOOTSTRAP"; then
+  ok "notify: bootstrap asserts the CAPABILITY via the wrapper's self-test"
+else
+  bad "notify: bootstrap does not run the wrapper's self-test (existence check only?)"
+fi
+if printf '%s' "$run_out" | grep -q 'notify contract v'; then
+  ok "notify: bootstrap RECORDS the pinned contract version"
+else
+  bad "notify: bootstrap did not record a pinned notify contract version"
+fi
+if ! grep -q 'agent-notify --category' "$BOOTSTRAP"; then   # notify-flag-allow
+  ok "notify: bootstrap never prescribes the swallowed --category shape"
+else
+  bad "notify: bootstrap prescribes the swallowed --category shape"
+fi
+# The section is informational: a machine with no notify target must still finish.
+if printf '%s' "$run_out" | grep -q 'Notification channel' && [ "$run_rc" -eq 0 ]; then
+  ok "notify: the section is informational — the run still exits 0"
+else
+  bad "notify: the section is not informational (rc=$run_rc)"
 fi
 
 echo

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1179,6 +1179,19 @@ if printf '%s' "$run_out" | grep -q 'Notification channel' && [ "$run_rc" -eq 0 
 else
   bad "notify: the section is not informational (rc=$run_rc)"
 fi
+# A notify target may carry URL userinfo (https://user:token@host/topic). Printing
+# it would leak a credential into a terminal or a CI log (roborev finding), so the
+# reported value must name the HOST only.
+redact_out=$(PATH="$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
+  CODEX_NOTIFY_WEBHOOK='https://alice:s3cr3t-token@ntfy.example.com/private-topic' \
+  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+if printf '%s' "$redact_out" | grep -q 'notify target configured' \
+   && ! printf '%s' "$redact_out" | grep -qE 's3cr3t-token|alice:'; then
+  ok "notify: URL userinfo is redacted from the reported target"
+else
+  bad "notify: the reported target leaked URL userinfo"
+  printf '%s\n' "$redact_out" | grep -i 'notify target' | head -2
+fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1193,6 +1193,94 @@ else
   printf '%s\n' "$redact_out" | grep -i 'notify target' | head -2
 fi
 
+# --- 10. The notify CAPABILITY assert is HONOURED, not merely present ---------
+# THE gap this closes (issue #3119 AC5, found by the C intent audit). Case 9 above
+# greps the SCRIPT TEXT for a `--self-test` call and the run output for a pin line.
+# Neither observes the `ok`-vs-`warn` DISTINCTION, so the auditor's mutation —
+# `if selftest_out=$(… --self-test); true; then ok …` plus a genuinely broken wrapper —
+# left this suite 77 PASS / 0 FAIL. That is this very issue reproduced one layer up:
+# the TEST was accepting the mere EXISTENCE of a probe call as evidence that the
+# capability is verified. These cases assert the VERDICT.
+#
+# Mechanism: bootstrap resolves REPO_ROOT from its own location, so each case gets a
+# throwaway tree holding a copy of the script plus the wrapper we want it to probe.
+mknotifyroot() { # mknotifyroot <dir> <good|broken>
+  local dir="$1" mode="$2"
+  mkdir -p "$dir/scripts/lib"
+  cp "$BOOTSTRAP" "$dir/scripts/bootstrap-agent-machine.sh"
+  if [ "$mode" = good ]; then
+    cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$dir/scripts/lib/gate-notify.sh"
+  else
+    # A REAL contract violation, caught by the wrapper's own validator: the FAIL
+    # payload carries the PASS tag — a red gate paging as a routine success.
+    python3 - "$SCRIPT_DIR/../lib/gate-notify.sh" "$dir/scripts/lib/gate-notify.sh" <<'MUT'
+import sys
+s = open(sys.argv[1]).read()
+out = s.replace("printf 'rotating_light\\n'", "printf 'white_check_mark\\n'", 1)
+open(sys.argv[2], "w").write(out)
+raise SystemExit(0 if out != s else 1)
+MUT
+    [ $? -eq 0 ] || return 1
+  fi
+  return 0
+}
+runnotifyroot() { # runnotifyroot <dir> [env assignments...]
+  local dir="$1"; shift
+  env PATH="$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" "$@" \
+    timeout -s KILL 300 bash "$dir/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1
+}
+
+# (b) POSITIVE twin: a healthy wrapper must be reported VERIFIED.
+goodroot="$tmp/notify-good"
+if mknotifyroot "$goodroot" good; then
+  good_out=$(runnotifyroot "$goodroot" CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t')
+  if printf '%s' "$good_out" | grep -q 'notify capability verified' \
+     && ! printf '%s' "$good_out" | grep -q 'notify self-test FAILED'; then
+    ok "notify capability: a HEALTHY wrapper is reported verified"
+  else
+    bad "notify capability: healthy wrapper was not reported verified"
+    printf '%s\n' "$good_out" | grep -i 'notify' | head -4
+  fi
+else
+  bad "notify capability: could not stage the healthy wrapper tree"
+fi
+
+# (a) NEGATIVE: a genuinely broken wrapper must be reported FAILED, and must NOT be
+#     reported verified. This is the assertion the auditor's mutation defeats.
+badroot="$tmp/notify-broken"
+if mknotifyroot "$badroot" broken; then
+  bad_out=$(runnotifyroot "$badroot" CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t')
+  if printf '%s' "$bad_out" | grep -q 'notify self-test FAILED' \
+     && ! printf '%s' "$bad_out" | grep -q 'notify capability verified'; then
+    ok "notify capability: a BROKEN wrapper is reported FAILED and never verified"
+  else
+    bad "notify capability: broken wrapper was not surfaced (probe verdict ignored?)"
+    printf '%s\n' "$bad_out" | grep -i 'notify' | head -4
+  fi
+else
+  bad "notify capability: could not stage the broken wrapper tree (mutation did not apply)"
+fi
+
+# (c) NO TARGET: never exercised on a fleet box, because the ambient
+#     CODEX_NOTIFY_WEBHOOK always takes the other branch. Assert the warning, the
+#     EXACT export text a reader is told to add, and rc 0 (bootstrap is advisory).
+if mknotifyroot "$tmp/notify-notarget" good; then
+  notarget_out=$(runnotifyroot "$tmp/notify-notarget" \
+    CODEX_NOTIFY_WEBHOOK= CQLITE_NOTIFY_WEBHOOK= CODEX_NOTIFY_NTFY_TOPIC= CQLITE_NOTIFY_TOPIC=)
+  notarget_rc=$?
+  if [ "$notarget_rc" -eq 0 ] \
+     && printf '%s' "$notarget_out" | grep -q 'no notify target configured' \
+     && printf '%s' "$notarget_out" | grep -q 'CODEX_NOTIFY_WEBHOOK=https://ntfy.sh/<your-topic>' \
+     && printf '%s' "$notarget_out" | grep -q 'silent no-ops on this machine'; then
+    ok "notify no-target: warns, prints the exact export line, and still exits 0"
+  else
+    bad "notify no-target case (rc=$notarget_rc)"
+    printf '%s\n' "$notarget_out" | grep -i 'notify' | head -4
+  fi
+else
+  bad "notify no-target: could not stage the tree"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1213,10 +1213,18 @@ mknotifyroot() { # mknotifyroot <dir> <good|broken>
   else
     # A REAL contract violation, caught by the wrapper's own validator: the FAIL
     # payload carries the PASS tag — a red gate paging as a routine success.
+    # Heredoc body must be UNINDENTED: `<<'MUT'` is literal, so leading spaces reach
+    # python as indentation and raise IndentationError — which would red on STAGING
+    # instead of on the verdict under test (observed while proving this very case).
     python3 - "$SCRIPT_DIR/../lib/gate-notify.sh" "$dir/scripts/lib/gate-notify.sh" <<'MUT'
-import sys
+import re, sys
 s = open(sys.argv[1]).read()
-out = s.replace("printf 'rotating_light\\n'", "printf 'white_check_mark\\n'", 1)
+# Match on the FUNCTION NAME, not on the tag literal: a literal-based mutation is a
+# no-op when the source is ALREADY broken (e.g. while proving this case against a
+# mutated tree), which would again red on staging rather than on the verdict.
+out = re.sub(r'^_gate_notify_tag\(\).*$',
+             "_gate_notify_tag() { printf 'white_check_mark\\n'; }",
+             s, count=1, flags=re.M)
 open(sys.argv[2], "w").write(out)
 raise SystemExit(0 if out != s else 1)
 MUT

--- a/scripts/tests/test_gate_notify_contract.sh
+++ b/scripts/tests/test_gate_notify_contract.sh
@@ -91,12 +91,31 @@ SHIM
 chmod +x "$shimdir/curl"
 
 # publish <log> <result> <branch> <sha> <fail-components> [extra env assignments...]
+#
+# HERMETIC BY CONSTRUCTION. Two properties this function must not lose:
+#
+#  1. It NEUTRALIZES every ambient variable the wrapper honours — the topic
+#     overrides (`CQLITE_NOTIFY_TOPIC`/`CODEX_NOTIFY_NTFY_TOPIC` BEAT the
+#     URL-derived topic), the alternate webhook var, and the timeout bounds.
+#     Measured before this was added: `CODEX_NOTIFY_NTFY_TOPIC=pmcfadin-cloud-100`
+#     in the environment reds `AC1 PASS payload` — i.e. `tooling-tests`, i.e. the
+#     FULL gate of record — on any box that merely exports a variable this repo's
+#     own docs tell it to export.
+#  2. It sources ONLY the extracted gate_push_signal and lets the REAL delegation
+#     inside it source the wrapper. Sourcing $LIB here would supply the very wiring
+#     the test claims to assert: mutation-proven, deleting the `. "$notify_lib"`
+#     line from gate_push_signal left this test 12/12 green.
 publish() {
   local log="$1" result="$2" branch="$3" sha="$4" fails="$5"; shift 5
   : > "$log"
-  env CURL_LOG="$log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$shimdir:$PATH" "$@" \
-    bash -c '. "$0"; . "$1"; gate_push_signal "$2" "$3" "$4" "$5"' \
-    "$fnfile" "$LIB" "$result" "$branch" "$sha" "$fails" >"$tmp/out.txt" 2>"$tmp/err.txt"
+  env CURL_LOG="$log" PATH="$shimdir:$PATH" \
+    CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" CODEX_NOTIFY_WEBHOOK= \
+    CQLITE_NOTIFY_TOPIC= CODEX_NOTIFY_NTFY_TOPIC= \
+    CQLITE_NOTIFY_DEBUG=0 \
+    GATE_NOTIFY_CURL_TIMEOUT=10 GATE_NOTIFY_PAYLOAD_TIMEOUT=10 GATE_NOTIFY_ADJUNCT_TIMEOUT=5 \
+    "$@" \
+    bash -c '. "$0"; gate_push_signal "$1" "$2" "$3" "$4"' \
+    "$fnfile" "$result" "$branch" "$sha" "$fails" >"$tmp/out.txt" 2>"$tmp/err.txt"
   return $?
 }
 
@@ -196,11 +215,17 @@ fi
 # Prefer a copy of the real pristine v1.1.0; otherwise synthesize its observable
 # behaviour (no --category arm -> manual "$1"/"$2" mode -> completion severity ->
 # JSON POSTed to the TOPIC url). Either way the fixture lives in the tmpdir.
-pristine_kind=synthesized
-if [ -r /usr/local/bin/agent-notify.bak.20260730 ]; then
-  cp /usr/local/bin/agent-notify.bak.20260730 "$shimdir/agent-notify" && pristine_kind=copied-real
+# DETERMINISM (review R4): the fixture is the REPO-OWNED stand-in below by
+# DEFAULT, always — never a machine-specific /usr/local/bin backup, whose presence
+# would make the gate's outcome depend on external host state. A real pristine
+# binary can be substituted deliberately for a local cross-check by exporting
+# CQLITE_NOTIFY_PRISTINE_BIN=/path/to/agent-notify-v1.1.0; that path is never
+# probed for implicitly.
+pristine_kind=repo-owned-stand-in
+if [ -n "${CQLITE_NOTIFY_PRISTINE_BIN:-}" ] && [ -r "${CQLITE_NOTIFY_PRISTINE_BIN}" ]; then
+  cp "$CQLITE_NOTIFY_PRISTINE_BIN" "$shimdir/agent-notify" && pristine_kind=real-opt-in
 fi
-if [ "$pristine_kind" = synthesized ]; then
+if [ "$pristine_kind" = repo-owned-stand-in ]; then
   cat > "$shimdir/agent-notify" <<'PRISTINE'
 #!/usr/bin/env bash
 # Stand-in reproducing pristine agent-notify v1.1.0's OBSERVABLE behaviour:
@@ -220,10 +245,20 @@ PRISTINE
 fi
 chmod +x "$shimdir/agent-notify"
 
+# The AC6 cases deliberately supply an AMBIENT CODEX_NOTIFY_WEBHOOK (review B4).
+# Probed: the pristine binary publishes ONLY when CODEX_NOTIFY_WEBHOOK is set and
+# ignores CQLITE_NOTIFY_WEBHOOK entirely (1 curl vs 0). Without this the
+# "exactly ONE payload" assertion is VACUOUS on precisely the machines the header
+# calls identical — a CI runner or a freshly bootstrapped box with no ambient
+# webhook — and would pass whether or not the wrapper's env-neutralization exists.
+# With it set, a regression in that neutralization publishes a SECOND payload and
+# these cases red.
+ADJUNCT_AMBIENT_WEBHOOK="https://ntfy.invalid/adjunct-would-double-publish"
 for case_pair in "PASS:3:white_check_mark" "FAIL:5:rotating_light"; do
   res=${case_pair%%:*}; rest=${case_pair#*:}; prio=${rest%%:*}; tag=${rest#*:}
   alog="$tmp/adjunct-$res.log"
-  publish "$alog" "$res" issue-3119-notify-contract abc1234 ""
+  publish "$alog" "$res" issue-3119-notify-contract abc1234 "" \
+    CODEX_NOTIFY_WEBHOOK="$ADJUNCT_AMBIENT_WEBHOOK"
   rc=$?
   n=$(lines_of "$alog")
   if [ "$rc" -eq 0 ] && [ "$n" -eq 1 ] \
@@ -231,8 +266,9 @@ for case_pair in "PASS:3:white_check_mark" "FAIL:5:rotating_light"; do
      && [ "$(field "$alog" priority)" = "$prio" ] \
      && [ "$(field "$alog" tags)"     = "[\"$tag\"]" ] \
      && [ "$(field "$alog" __url__)"  = "$ROOT" ] \
-     && ! message_is_json "$alog"; then
-    ok "AC6 $res with pristine agent-notify on PATH ($pristine_kind): ONE correct payload"
+     && ! message_is_json "$alog" \
+     && ! grep -q 'adjunct-would-double-publish' "$alog"; then
+    ok "AC6 $res, pristine agent-notify on PATH ($pristine_kind) + ambient webhook: ONE correct payload, adjunct published nothing"
   else
     bad "AC6 $res with pristine agent-notify on PATH ($pristine_kind) (rc=$rc lines=$n)"; cat "$alog"
   fi

--- a/scripts/tests/test_gate_notify_contract.sh
+++ b/scripts/tests/test_gate_notify_contract.sh
@@ -274,6 +274,50 @@ for case_pair in "PASS:3:white_check_mark" "FAIL:5:rotating_light"; do
   fi
 done
 
+# ---- 7b. a query-credentialed target DELIVERS with its query intact -----------
+# `https://host/topic?auth=<token>` is a documented ntfy credential shape. Review
+# round 2 added a query-strip to keep credentials out of LOGS but applied it to the
+# single value that was ALSO the POST target, so such a target published
+# UNAUTHENTICATED — and silently, because publish failure is a deliberate no-op. The
+# delivery URL and the printable/redacted string are now separate values; this case
+# pins the delivery half so they can never be re-collapsed.
+qlog="$tmp/query.log"
+: > "$qlog"
+env CURL_LOG="$qlog" PATH="$shimdir:$PATH" \
+  CQLITE_NOTIFY_WEBHOOK="https://ntfy.invalid/$TOPIC?auth=tk_AbC123" CODEX_NOTIFY_WEBHOOK= \
+  CQLITE_NOTIFY_TOPIC= CODEX_NOTIFY_NTFY_TOPIC= \
+  GATE_NOTIFY_CURL_TIMEOUT=10 GATE_NOTIFY_PAYLOAD_TIMEOUT=10 GATE_NOTIFY_ADJUNCT_TIMEOUT=5 \
+  bash -c '. "$0"; gate_push_signal PASS issue-3119-notify-contract abc1234 ""' \
+  "$fnfile" >"$tmp/out.txt" 2>"$tmp/err.txt"
+rc=$?
+qurl=$(field "$qlog" __url__)
+if [ "$rc" -eq 0 ] && [ "$(lines_of "$qlog")" -eq 1 ] \
+   && [ "$qurl" = "https://ntfy.invalid/?auth=tk_AbC123" ] \
+   && [ "$(field "$qlog" topic)" = "$TOPIC" ] \
+   && [ "$(field "$qlog" title)" = "gate PASS issue-3119-notify-contract@abc1234" ]; then
+  ok "query-credentialed target: POSTed to the server root WITH the query preserved, topic parsed from the path"
+else
+  bad "query-credentialed target: delivery URL was '$qurl' (expected the query preserved)"; cat "$qlog"
+fi
+
+# ---- 7c. ...while the PRINTABLE form of that same target carries no credential --
+# The redaction property from round 2, asserted directly on the function whose output
+# is the only one allowed to be echoed. A regression that starts printing the delivery
+# URL — or stops redacting — reds here.
+# `_ "$LIB"` (not `"$LIB"` as $0): when $0 equals the sourced path the wrapper's
+# direct-execution block fires and prints usage instead of exposing its functions.
+redact_probe=$(bash -c '. "$1"; for u in \
+    "https://ntfy.invalid/t?token=s3cr3t" \
+    "https://ntfy.invalid/t#frag-s3cr3t" \
+    "https://alice:s3cr3t@ntfy.invalid/t?auth=tk_s3cr3t"; do
+      _gate_notify_redact "$u"; done' _ "$LIB" 2>&1)
+if ! printf '%s' "$redact_probe" | grep -qE 's3cr3t|alice:|token=|auth=' \
+   && [ "$(printf '%s\n' "$redact_probe" | grep -c 'https://ntfy.invalid/')" -eq 3 ]; then
+  ok "printable target form: query, fragment and userinfo all redacted (no credential can reach a log)"
+else
+  bad "printable target form leaked a credential: $redact_probe"
+fi
+
 # ---- 8. intercept surface: only the transport is substituted -----------------
 substituted=$(cd "$shimdir" && ls | sort | tr '\n' ' ')
 if [ "$substituted" = "agent-notify curl " ] \

--- a/scripts/tests/test_gate_notify_contract.sh
+++ b/scripts/tests/test_gate_notify_contract.sh
@@ -318,6 +318,39 @@ else
   bad "printable target form leaked a credential: $redact_probe"
 fi
 
+# ---- 7d. the SELF-TEST's own verdict is honest (AC5's capability probe) --------
+# bootstrap's capability assertion is only as good as what `--self-test` reports, and
+# until review round 5 NOTHING tested the validator inside gate_notify_selftest: making
+# it vacuous reddened no suite. Assert both directions against the REAL wrapper and a
+# MUTATED copy, so a self-test that always succeeds cannot pass.
+selftest_dir="$tmp/selftest"; mkdir -p "$selftest_dir"
+if timeout -s KILL 90 bash "$LIB" --self-test >"$selftest_dir/good.out" 2>&1; then
+  ok "self-test on the real wrapper: exits 0 and reports PASS"
+else
+  bad "self-test on the real wrapper did not succeed"; cat "$selftest_dir/good.out"
+fi
+# The mutation is a REAL contract violation the validator must catch: FAIL publishes
+# the PASS tag, i.e. a red gate paging as a routine success — the original defect.
+python3 - "$LIB" "$selftest_dir/broken.sh" <<'MUT'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+s = open(src).read()
+needle = "printf 'rotating_light\\n'"
+# Only the FAIL tag emitter is rewritten; comments mentioning the tag are untouched.
+out = s.replace(needle, "printf 'white_check_mark\\n'", 1)
+open(dst, "w").write(out)
+raise SystemExit(0 if out != s else 1)
+MUT
+if [ $? -eq 0 ]; then
+  if timeout -s KILL 90 bash "$selftest_dir/broken.sh" --self-test >"$selftest_dir/bad.out" 2>&1; then
+    bad "self-test PASSED a wrapper whose FAIL payload carries the PASS tag — the probe is vacuous"
+  else
+    ok "self-test on a mutated wrapper (FAIL tagged white_check_mark): exits NON-ZERO"
+  fi
+else
+  bad "self-test mutation did not apply — the tag map was not found in $LIB"
+fi
+
 # ---- 8. intercept surface: only the transport is substituted -----------------
 substituted=$(cd "$shimdir" && ls | sort | tr '\n' ' ')
 if [ "$substituted" = "agent-notify curl " ] \

--- a/scripts/tests/test_gate_notify_contract.sh
+++ b/scripts/tests/test_gate_notify_contract.sh
@@ -264,6 +264,26 @@ else
   bad "publish path emitted output"; head -5 "$tmp/out.txt" "$tmp/err.txt"
 fi
 
+# ---- 11. AC6 doctrine: no repo surface prescribes the swallowed flag --------
+# Mechanized so a reintroduction FAILs the gate instead of silently corrupting
+# every fleet page again. Scope is the EXECUTABLE/PRESCRIPTIVE surfaces — scripts,
+# agent skills/commands, workflows — because that is where the shape can actually
+# be invoked; prose that DOCUMENTS the historical defect (openspec artifacts, the
+# guide, archived reports) is not an offence. A line that must quote the shape
+# explanatorily marks itself `notify-flag-allow`, mirroring the repo's existing
+# `injection-lint-allow` idiom. The needle is ASSEMBLED so this file's own prose
+# can never be the thing it flags.
+needle="agent-notify"' --category'
+offenders=$(cd "$REPO_ROOT" && grep -rIn --exclude-dir=.git --exclude-dir=target \
+  -e "$needle" scripts .claude .github 2>/dev/null \
+  | grep -v 'notify-flag-allow' \
+  | grep -v '^scripts/tests/test_gate_notify_contract.sh:' || true)
+if [ -z "$offenders" ]; then
+  ok "AC6 doctrine: no script, skill or workflow invokes the swallowed-flag shape"
+else
+  bad "AC6 doctrine: the swallowed-flag shape survives in:"; printf '%s\n' "$offenders"
+fi
+
 echo "----------------------------------------"
 echo "test_gate_notify_contract: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_gate_notify_contract.sh
+++ b/scripts/tests/test_gate_notify_contract.sh
@@ -332,13 +332,15 @@ fi
 # The mutation is a REAL contract violation the validator must catch: FAIL publishes
 # the PASS tag, i.e. a red gate paging as a routine success — the original defect.
 python3 - "$LIB" "$selftest_dir/broken.sh" <<'MUT'
-import sys
-src, dst = sys.argv[1], sys.argv[2]
-s = open(src).read()
-needle = "printf 'rotating_light\\n'"
-# Only the FAIL tag emitter is rewritten; comments mentioning the tag are untouched.
-out = s.replace(needle, "printf 'white_check_mark\\n'", 1)
-open(dst, "w").write(out)
+import re, sys
+s = open(sys.argv[1]).read()
+# Match on the FUNCTION NAME, not on the tag literal: a literal-based mutation is a
+# no-op when the source is ALREADY broken, which would red on staging instead of on
+# the verdict under test (observed while proving this very case).
+out = re.sub(r'^_gate_notify_tag\(\).*$',
+             "_gate_notify_tag() { printf 'white_check_mark\\n'; }",
+             s, count=1, flags=re.M)
+open(sys.argv[2], "w").write(out)
 raise SystemExit(0 if out != s else 1)
 MUT
 if [ $? -eq 0 ]; then

--- a/scripts/tests/test_gate_notify_contract.sh
+++ b/scripts/tests/test_gate_notify_contract.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Contract test for issue #3119: the full gate's push signal must DELIVER the
+# right payload, not merely produce the right argv.
+#
+# Why this file exists at all. The pre-existing scripts/tests/test_agent_gate_notify.sh
+# drove gate_push_signal against a PATH-stubbed `agent-notify` that itself
+# implemented a `--category` arm — i.e. the mock encoded the SAME wrong assumption
+# as the caller. The real installed `agent-notify` v1.1.0 has no `--category` arm,
+# so the flag fell through to manual "$1"="$2" mode: title became the literal
+# `--category`, body became the category VALUE, and a FAIL gate published
+# priority 3 + a green white_check_mark. Measured, pristine binary, curl-capture:
+#   {"topic":"…","title":"--category","message":"error","priority":3,
+#    "tags":["white_check_mark"]}   ->  POSTed to https://ntfy.sh/<topic>
+# An argv-level assertion can NEVER see any of that. So this test asserts the
+# PUBLISHED PAYLOAD, captured at the TRANSPORT boundary.
+#
+# Intercept surface (this is the load-bearing property — see the spec's
+# "The contract test intercepts only the transport" scenario):
+#   - REAL   : scripts/agent-gate.sh's gate_push_signal (extracted verbatim)
+#   - REAL   : scripts/lib/gate-notify.sh (the payload producer)
+#   - STUBBED: `curl` only — a PATH shim that records argv (target URL + -d body)
+# Nothing that PRODUCES the payload is stubbed, mocked or re-implemented here.
+#
+# Hermetic: no network, no real ntfy topic, no dependence on any machine's
+# install history. The "pristine upstream agent-notify" fixture is COPIED into
+# the tmpdir when /usr/local/bin/agent-notify.bak.20260730 happens to exist, and
+# otherwise SYNTHESIZED to the same observable behaviour, so the test is
+# identical on a freshly bootstrapped box.
+#
+# Run standalone:   bash scripts/tests/test_gate_notify_contract.sh
+# Or via the gate:  scripts/agent-gate.sh runs it as the `tooling-tests` component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+export REPO_ROOT
+GATE="$REPO_ROOT/scripts/agent-gate.sh"
+LIB="$REPO_ROOT/scripts/lib/gate-notify.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/gate-notify-contract.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+TOPIC=gate-topic-3119
+ROOT=https://ntfy.invalid/
+WEBHOOK="https://ntfy.invalid/$TOPIC"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "test_gate_notify_contract: SKIP (no python3 — payload parsing needs it)"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# The payload producers, both REAL.
+# ---------------------------------------------------------------------------
+if [ ! -r "$LIB" ]; then
+  bad "the repo-owned payload producer scripts/lib/gate-notify.sh is missing"
+  echo "test_gate_notify_contract: $PASS passed, $FAIL failed"
+  exit 1
+fi
+
+fnfile="$tmp/gate_push_signal.sh"
+awk '/^gate_push_signal\(\) \{/{grab=1} grab{print} grab&&/^\}$/{exit}' "$GATE" > "$fnfile"
+if ! grep -q '^gate_push_signal() {' "$fnfile" || ! grep -q '^}$' "$fnfile"; then
+  bad "could not extract gate_push_signal() from $GATE"
+  echo "test_gate_notify_contract: $PASS passed, $FAIL failed"
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$fnfile"
+
+# ---------------------------------------------------------------------------
+# Transport shim: the ONLY stubbed component. Records "<url>\t<body>" per POST.
+# ---------------------------------------------------------------------------
+shimdir="$tmp/bin"
+mkdir -p "$shimdir"
+cat > "$shimdir/curl" <<'SHIM'
+#!/usr/bin/env bash
+# Record the POST target (last arg) and the -d body, one line per invocation.
+body=""; url=""; prev=""
+for a in "$@"; do
+  [ "$prev" = "-d" ] && body="$a"
+  prev="$a"; url="$a"
+done
+printf '%s\t%s\n' "$url" "$body" >> "$CURL_LOG"
+SHIM
+chmod +x "$shimdir/curl"
+
+# publish <log> <result> <branch> <sha> <fail-components> [extra env assignments...]
+publish() {
+  local log="$1" result="$2" branch="$3" sha="$4" fails="$5"; shift 5
+  : > "$log"
+  env CURL_LOG="$log" CQLITE_NOTIFY_WEBHOOK="$WEBHOOK" PATH="$shimdir:$PATH" "$@" \
+    bash -c '. "$0"; . "$1"; gate_push_signal "$2" "$3" "$4" "$5"' \
+    "$fnfile" "$LIB" "$result" "$branch" "$sha" "$fails" >"$tmp/out.txt" 2>"$tmp/err.txt"
+  return $?
+}
+
+# field <log> <key>: parse the captured JSON body's <key> via python3.
+field() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+line = open(sys.argv[1]).read().splitlines()
+if not line:
+    print("<no-payload>"); raise SystemExit(0)
+url, _, body = line[0].partition("\t")
+if sys.argv[2] == "__url__":
+    print(url); raise SystemExit(0)
+try:
+    d = json.loads(body)
+except Exception:
+    print("<unparseable:%s>" % body[:60]); raise SystemExit(0)
+v = d.get(sys.argv[2], "<missing>")
+print(json.dumps(v) if isinstance(v, (list, dict)) else v)
+PY
+}
+lines_of() { wc -l < "$1" | tr -d ' '; }
+
+# message_is_json <log>: 0 when the published message begins with '{' (the
+# defect-3 regression). Used both as the guard AND, below, against a planted
+# bad payload so the guard can never be vacuous.
+message_is_json() {
+  case "$(field "$1" message)" in '{'*) return 0 ;; *) return 1 ;; esac
+}
+
+# ---- 1. AC1: a PASS gate publishes the PASS title, body and severity ---------
+plog="$tmp/pass.log"
+publish "$plog" PASS issue-3119-notify-contract abc1234 ""
+rc=$?
+n=$(lines_of "$plog")
+if [ "$rc" -eq 0 ] && [ "$n" -eq 1 ] \
+   && [ "$(field "$plog" title)"    = "gate PASS issue-3119-notify-contract@abc1234" ] \
+   && [ "$(field "$plog" message)"  = "RESULT: PASS" ] \
+   && [ "$(field "$plog" priority)" = "3" ] \
+   && [ "$(field "$plog" tags)"     = '["white_check_mark"]' ] \
+   && [ "$(field "$plog" topic)"    = "$TOPIC" ]; then
+  ok "AC1 PASS: published title/body/severity/topic are correct"
+else
+  bad "AC1 PASS payload (rc=$rc lines=$n)"; cat "$plog"
+fi
+
+# ---- 2. AC1/AC3: the POST target is the SERVER ROOT, topic in the body -------
+if [ "$(field "$plog" __url__)" = "$ROOT" ]; then
+  ok "AC3 target: POSTed to the ntfy server ROOT, topic carried in the body"
+else
+  bad "AC3 target: expected $ROOT, got $(field "$plog" __url__)"
+fi
+
+# ---- 3. AC2: a FAIL gate publishes a payload distinguishable at a glance ----
+flog="$tmp/fail.log"
+publish "$flog" FAIL issue-3119-notify-contract deadbee "fmt,clippy"
+rc=$?
+n=$(lines_of "$flog")
+if [ "$rc" -eq 0 ] && [ "$n" -eq 1 ] \
+   && [ "$(field "$flog" title)"    = "gate FAIL issue-3119-notify-contract@deadbee" ] \
+   && [ "$(field "$flog" message)"  = "RESULT: FAIL — failing: fmt,clippy" ] \
+   && [ "$(field "$flog" priority)" = "5" ] \
+   && [ "$(field "$flog" tags)"     = '["rotating_light"]' ]; then
+  ok "AC2 FAIL: published title, failing components and FAIL severity"
+else
+  bad "AC2 FAIL payload (rc=$rc lines=$n)"; cat "$flog"
+fi
+
+# ---- 4. AC2: a red gate can NEVER page as a routine success ------------------
+if [ "$(field "$flog" priority)" != "$(field "$plog" priority)" ] \
+   && [ "$(field "$flog" tags)" != "$(field "$plog" tags)" ] \
+   && [ "$(field "$flog" priority)" != "3" ] \
+   && [ "$(field "$flog" tags)" != '["white_check_mark"]' ]; then
+  ok "AC2 distinctness: FAIL differs from PASS in BOTH priority and tags"
+else
+  bad "AC2 distinctness: FAIL payload is not distinguishable from PASS"
+fi
+
+# ---- 5. AC3: the message is body text, never a JSON document ----------------
+if ! message_is_json "$plog" && ! message_is_json "$flog" \
+   && ! grep -q '"topic"' <<<"$(field "$plog" message)"; then
+  ok "AC3 message: body text, no JSON braces, no topic key"
+else
+  bad "AC3 message: a published message is a serialized document"
+fi
+
+# ---- 6. AC3: the guard itself is live (planted raw-JSON message must FAIL) ---
+badlog="$tmp/planted.log"
+printf '%s\t%s\n' "$ROOT" '{"message": "{\"topic\": \"x\", \"message\": \"y\"}"}' > "$badlog"
+if message_is_json "$badlog"; then
+  ok "AC3 guard is live: a planted message beginning with '{' is detected"
+else
+  bad "AC3 guard is VACUOUS: a raw-JSON message was not detected"
+fi
+
+# ---- 7. AC6: the contract holds with the PRISTINE upstream binary on PATH ----
+# Prefer a copy of the real pristine v1.1.0; otherwise synthesize its observable
+# behaviour (no --category arm -> manual "$1"/"$2" mode -> completion severity ->
+# JSON POSTed to the TOPIC url). Either way the fixture lives in the tmpdir.
+pristine_kind=synthesized
+if [ -r /usr/local/bin/agent-notify.bak.20260730 ]; then
+  cp /usr/local/bin/agent-notify.bak.20260730 "$shimdir/agent-notify" && pristine_kind=copied-real
+fi
+if [ "$pristine_kind" = synthesized ]; then
+  cat > "$shimdir/agent-notify" <<'PRISTINE'
+#!/usr/bin/env bash
+# Stand-in reproducing pristine agent-notify v1.1.0's OBSERVABLE behaviour:
+# no --category arm (falls through to manual mode), severity pinned to
+# completion, and a JSON body POSTed to the TOPIC url (not the server root).
+set -uo pipefail
+title="${1:-Codex}"; msg="${2:-Task finished}"
+url="${CODEX_NOTIFY_WEBHOOK:-}"
+if [ -n "$url" ]; then
+  topic="${url##*/}"
+  curl -s -X POST -H "Content-Type: application/json" \
+    -d "{\"topic\": \"$topic\", \"title\": \"$title\", \"message\": \"$msg\", \"priority\": 3, \"tags\": [\"white_check_mark\"]}" \
+    "$url" >/dev/null 2>&1 || true
+fi
+exit 0
+PRISTINE
+fi
+chmod +x "$shimdir/agent-notify"
+
+for case_pair in "PASS:3:white_check_mark" "FAIL:5:rotating_light"; do
+  res=${case_pair%%:*}; rest=${case_pair#*:}; prio=${rest%%:*}; tag=${rest#*:}
+  alog="$tmp/adjunct-$res.log"
+  publish "$alog" "$res" issue-3119-notify-contract abc1234 ""
+  rc=$?
+  n=$(lines_of "$alog")
+  if [ "$rc" -eq 0 ] && [ "$n" -eq 1 ] \
+     && [ "$(field "$alog" title)"    = "gate $res issue-3119-notify-contract@abc1234" ] \
+     && [ "$(field "$alog" priority)" = "$prio" ] \
+     && [ "$(field "$alog" tags)"     = "[\"$tag\"]" ] \
+     && [ "$(field "$alog" __url__)"  = "$ROOT" ] \
+     && ! message_is_json "$alog"; then
+    ok "AC6 $res with pristine agent-notify on PATH ($pristine_kind): ONE correct payload"
+  else
+    bad "AC6 $res with pristine agent-notify on PATH ($pristine_kind) (rc=$rc lines=$n)"; cat "$alog"
+  fi
+done
+
+# ---- 8. intercept surface: only the transport is substituted -----------------
+substituted=$(cd "$shimdir" && ls | sort | tr '\n' ' ')
+if [ "$substituted" = "agent-notify curl " ] \
+   && [ ! -e "$tmp/gate-notify.sh" ] \
+   && grep -q 'GATE_NOTIFY_CONTRACT_VERSION' "$LIB" \
+   && grep -q 'gate_notify_publish' "$fnfile"; then
+  ok "intercept surface: payload producers are the repo's own; only curl (+ the pristine fixture) is substituted"
+else
+  bad "intercept surface: unexpected substitutions [$substituted]"
+fi
+
+# ---- 9. hermetic: the resolved curl IS the shim, so no network is used -------
+resolved=$(env PATH="$shimdir:$PATH" bash -c 'command -v curl')
+if [ "$resolved" = "$shimdir/curl" ]; then
+  ok "hermetic: curl resolves to the capture shim — no network, no real topic"
+else
+  bad "hermetic: curl resolved to $resolved, not the shim"
+fi
+
+# ---- 10. the publish path is silent on stdout and stderr --------------------
+if [ ! -s "$tmp/out.txt" ] && [ ! -s "$tmp/err.txt" ]; then
+  ok "publish path writes nothing to stdout or stderr"
+else
+  bad "publish path emitted output"; head -5 "$tmp/out.txt" "$tmp/err.txt"
+fi
+
+echo "----------------------------------------"
+echo "test_gate_notify_contract: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -528,6 +528,69 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# R7 (issue #3119): the DEFAULT notify path — the one production actually uses.
+#
+# Every other case in this file injects NOTIFY_CMD with a recording stub, so the
+# DEFAULT resolution (NOTIFY_ARGV=(bash <repo>/scripts/lib/gate-notify.sh --publish))
+# and the wrapper's `--publish` arm were exercised by NO test. Two mutations survived
+# green: reverting the default to bare `agent-notify` — whose pristine 3-positional
+# mode puts the SEVERITY in the title slot, i.e. the original defect of this issue,
+# reintroduced silently — and breaking the `--publish` arm outright.
+#
+# So: NOTIFY_CMD UNSET, a curl-capture shim on PATH, and a pre-created stop-file so
+# finalize_exit fires immediately. What is asserted is the PUBLISHED payload, which
+# only the real default chain can produce.
+# ---------------------------------------------------------------------------
+test_default_notify_path_publishes() {
+  local d curl_log rc title
+  d="$(new_case_dir)"
+  common_env "$d"
+  # THE point of the case: no injected notify command.
+  unset NOTIFY_CMD
+  curl_log="$d/curl.log"; : >"$curl_log"
+  cat >"$d/bin/curl" <<'CURLSHIM'
+#!/usr/bin/env bash
+body=""; prev=""
+for a in "$@"; do
+  [[ "$prev" == "-d" ]] && body="$a"
+  prev="$a"
+done
+printf '%s\n' "$body" >>"$CURL_LOG"
+CURLSHIM
+  chmod +x "$d/bin/curl"
+  export CURL_LOG="$curl_log"
+  export CQLITE_NOTIFY_WEBHOOK="https://ntfy.invalid/r7-default-path"
+  export CODEX_NOTIFY_WEBHOOK= CQLITE_NOTIFY_TOPIC= CODEX_NOTIFY_NTFY_TOPIC=
+  export PATH="$d/bin:$PATH"
+  touch "$STOP_FILE"   # stop at the first loop top -> finalize_exit -> notify
+  timeout -s KILL 60 bash "$SUPERVISOR" >"$d/stdout.log" 2>&1
+  rc=$?
+  # The stop page is an `info`, so the wrapper must publish priority 3 and put the
+  # supervisor's own TITLE in the title field — not a severity token (the pristine
+  # `agent-notify` positional bug) and not nothing (a broken --publish arm).
+  title=$(python3 - "$curl_log" <<'PYP'
+import json, sys
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        d = json.loads(line)
+    except Exception:
+        continue
+    print("%s|%s" % (d.get("title", ""), d.get("priority", "")))
+    break
+PYP
+)
+  unset CURL_LOG CQLITE_NOTIFY_WEBHOOK CODEX_NOTIFY_WEBHOOK CQLITE_NOTIFY_TOPIC CODEX_NOTIFY_NTFY_TOPIC
+  if [[ "$rc" -eq 0 && "$title" == "worker-supervisor stopped|3" ]]; then
+    pass "R7 default notify path: NOTIFY_CMD unset -> wrapper published title='worker-supervisor stopped' priority=3"
+  else
+    fail "R7 default notify path: rc=$rc published='$title' (expected 'worker-supervisor stopped|3'; see $curl_log)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Common env baseline: every test starts here, then overrides what it needs.
 # Clear preflight (no holds), generous budgets, fast polling/backoff.
 # ---------------------------------------------------------------------------
@@ -2721,5 +2784,6 @@ test_default_worker_cmd_is_headless
 test_healthy_worker_iterlog_nonempty
 test_claim_cmd_empty_truly_disables_no_network
 test_real_pgrep_usages_are_pid_scoped
+test_default_notify_path_publishes
 echo "=== $PASS_COUNT passed, $FAIL_COUNT failed, $SKIP_COUNT skipped ==="
 [[ "$FAIL_COUNT" -eq 0 ]]

--- a/scripts/tests/test_worker_supervisor.sh
+++ b/scripts/tests/test_worker_supervisor.sh
@@ -44,9 +44,10 @@ new_case_dir() {
 write_notify_stub() {
   cat >"$1" <<'EOF'
 #!/usr/bin/env bash
-cat_arg="unknown"
-if [[ "${1:-}" == "--category" ]]; then cat_arg="$2"; shift 2; fi
-printf '%s|%s|%s\n' "$cat_arg" "${1:-}" "${2:-}" >>"${NOTIFY_LOG:?NOTIFY_LOG not set}"
+# $NOTIFY_CMD convention (issue #3119): THREE positional args, <severity>
+# <title> <message>. The old `--category <cat>` flag form is gone — the real
+# upstream agent-notify has no such arm and silently swallowed it.
+printf '%s|%s|%s\n' "${1:-}" "${2:-}" "${3:-}" >>"${NOTIFY_LOG:?NOTIFY_LOG not set}"
 EOF
   chmod +x "$1"
 }

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -83,12 +83,30 @@ own CI after the work is complete.
 
 ### Gate completion push-signal (#2667)
 
-The full `agent-gate.sh` fires **one advisory `agent-notify` push** at final-SUMMARY write time (title
+The full `agent-gate.sh` fires **one advisory push** at final-SUMMARY write time (title
 `gate <RESULT> <branch>@<sha>`, body = RESULT + any failing components), converting the summary file from a
 passive poll target into a **push signal**: a backgrounded gate calls its waiting closer/worker back instead
 of being idle-polled. `--lite`/`--delta`/`--only` are exempt (iteration aids, never the gate of record). It
-is advisory by contract — if `agent-notify` is absent or fails, it is a silent no-op and the summary file
-remains the artifact of record, so a broken notifier never changes the gate's verdict.
+is advisory by contract — an absent notifier, an unset target, a failing notifier, or one that **rejects its
+arguments** is a silent no-op and the summary file remains the artifact of record, so a broken notifier never
+changes the gate's verdict.
+
+**The payload contract is REPO-OWNED (#3119).** `scripts/lib/gate-notify.sh` builds the ntfy JSON itself and
+POSTs it to the ntfy **server root** (topic in the body). PASS publishes priority 3 + `white_check_mark`;
+FAIL publishes priority 5 + `rotating_light` — **a red gate is distinguishable at a glance**. This is not
+cosmetic: the gate previously called `agent-notify` with a `--category` flag that upstream v1.1.0 has no arm
+for, so it fell through to manual title/message mode — the title became the literal flag name, the message
+became the category value, the real title/body were dropped, and **every FAIL paged as a green priority-3
+success**; its ntfy path also POSTed the JSON to the topic URL, so phones rendered a raw JSON blob. Two of
+those defects live inside that binary, past any caller-side flag probe, which is why the payload now lives in
+git. `agent-notify` remains only an **optional local desktop/sound adjunct**, invoked positionally (never
+`--category`) with its webhook env neutralized so it cannot double-publish. Configure the target with
+`CODEX_NOTIFY_WEBHOOK=https://ntfy.sh/<topic>` (the fleet uses `/etc/environment`);
+`bash scripts/bootstrap-agent-machine.sh` verifies the **capability** via `gate-notify.sh --self-test` and
+records the pinned contract version. Payload fidelity is pinned by
+`scripts/tests/test_gate_notify_contract.sh` (gate component `tooling-tests`), which asserts the **published
+bytes** at the transport boundary — an argv-level assertion is explicitly not evidence, since that is exactly
+the blind spot the swallowed flag hid behind.
 
 ### GitHub-enforced merge gate (#2433)
 


### PR DESCRIPTION
Closes #3119.

## Problem

The FULL gate's advisory push signal (#2667) **has never carried its intended content**, and a red gate paged as a routine green success.

`gate_push_signal` called `agent-notify --category "$cat" "$title" "$body"`. The installed upstream `agent-notify` **v1.1.0 has no `--category` arm**, so the call fell through to manual `"$1"="$2"` mode: title became the literal string `--category`, body became the category word, and the real title/body were dropped as surplus positionals. Measured on a live worker box against the **pristine** binary, for a **FAIL** gate:

```
{"title": "--category", "message": "error", "priority": 3, "tags": ["white_check_mark"]}  →  POST https://ntfy.sh/<topic>
```

Three independent causes, all confirmed in the binary:
- no `--category` flag arm (flag `case` covers only `--version/--help/--test*/--setup*/--update`);
- `sound_category` is **hard-pinned to `completion`** and never revised in manual mode, so **severity is unreachable from any caller** — a probe-and-degrade fix in the caller is impossible;
- the ntfy POST goes to the **topic URL** instead of the server root (the `if [[ ntfy ]]` branch and its `else` are **byte-identical**, despite a comment claiming special handling), so ntfy renders the JSON blob as literal message text.

**Why the existing test was green:** `test_agent_gate_notify.sh` stubbed `agent-notify` with a stub that *implemented* `--category`. The mock encoded the caller's wrong assumption, so both sides agreed — the interface-mismatch blind spot a mock is structurally unable to see.

## Fix

A **repo-owned wrapper `scripts/lib/gate-notify.sh` owns the ntfy payload** — it builds the JSON itself and POSTs to the ntfy **server root** with the topic in the body. `agent-notify` is demoted to an optional local desktop/sound adjunct, invoked positionally with its webhook environment **neutralized** so it cannot double-publish.

Design alternatives were eliminated by the acceptance criteria, not by preference:
- **capability-probe the flag** — eliminated by AC2/AC3: two of the three defects live *inside* the binary, past any caller-side probe.
- **vendor/pin upstream** — eliminated by AC6 ("must pass against the *pristine* binary"): the only vendored copy that passes AC1–3 is a patched fork, i.e. the hand-patch relocated into git plus ~1500 lines of maintenance.

Owner-approved at Seam 1 with both decisions on their defaults: keep the adjunct (bounded), and migrate the other broken call sites in this change.

## Acceptance criteria → evidence

| AC | Evidence |
|----|----------|
| 1 — PASS title `gate PASS <branch>@<sha>`, body starts `RESULT: PASS`, asserted against the **real** notifier | contract test cases 1–2: published payload, priority 3, `white_check_mark`, POST to server root |
| 2 — FAIL title + `failing: <components>`, **distinct** urgency/tag | cases 3–4: priority 5, `rotating_light`, differs from PASS in **both** fields |
| 3 — message is body text, **never** a JSON document | cases 5–6; a planted `{`-leading message **must** fail — negative control fires live |
| 4 — `gate_push_signal` stays **advisory** | advisory catalogue, 15 cases: rejects-all-args, non-executable, non-zero, hang (bounded), missing wrapper, no target, unresolvable topic, no bounding tool, plus structural no-`exit`/no-`trap`/no-summary-write |
| 5 — fleet-durable via bootstrap, records its pin | bootstrap §9: **capability** assert (publishes a contract-correct PASS *and* FAIL through a shim), pin line, still exits 0 |
| 6 — no hand-patched binary required by any repo script | case 7 (pristine binary on PATH) + case 11 (repo-wide grep for the swallowed shape is empty) |

**Wiring evidence:** the contract test captures the payload at the **transport boundary** and stubs **neither payload producer** — `gate_push_signal` and the wrapper are the real ones from the repo, and the real delegation does the sourcing. Mutation-verified: deleting the delegation line from `gate_push_signal` turns the contract test **red (6/6)**. An argv-only assertion is explicitly declared insufficient by the spec, since that is precisely what failed here.

Hermetic: no network, no real topic, and no dependence on any machine's install history (the pristine fixture is a repo-owned stand-in; the real binary is opt-in via `CQLITE_NOTIFY_PRISTINE_BIN`).

## Review-first — both reviews FAILED the first SHA (`69e9e75`)

Per #2086 the diff was reviewed **before** the gate of record. roborev (`RESULT: FAIL`, 4 findings, range-verified `e0517c9..69e9e75`, `vacuity-tier1/2: PASS`) and an independent adversarial shell review (4 mutation-verified BLOCKERs) found 8 defects, all fixed at `7e440db` and each re-proven under the probe that found it:

- **Non-hermetic contract test** — never cleared `CODEX_NOTIFY_NTFY_TOPIC`, which the wrapper honors as a topic override. Measured: exporting that one fleet variable → 11/1 → `tooling-tests` FAIL → **the gate of record reds on a correctly-configured box.** Now 12/12 under a fully contaminated environment.
- **Unbounded external calls** — `timeout` wrapped only the adjunct, leaving `python3` and `curl` unbounded (`--max-time` binds only *real* curl). A stalled `python3` shim would hang `gate_push_signal` after the summary emit but before exit → gate never exits → **the #1825 slot is never released and every later gate on the box queues forever.** One bounding runner now wraps both; no bounding tool ⇒ publish nothing. Mechanized as 3 new cases.
- **Test blind to its own call chain** — the harness pre-sourced the library, so deleting the real delegation still gave 12/12. Fixed; the mutation now yields 6/6 red.
- **Vacuous AC6 double-publish guard** — pristine `agent-notify` ignores `CQLITE_NOTIFY_WEBHOOK`, so on a runner or fresh box the guard passed with or without the neutralization. Now asserts an `ntfy.invalid` adjunct target never appears; removing the neutralization → 10/2 red.
- **Secret leak in bootstrap output** — a webhook with userinfo printed it; now stripped (`https://alice:s3cr3t@host/topic` → `https://host/…`), mechanized.
- Self-test no longer fires a desktop notification or trusts an ambient topic; `printf | grep -Eq` replaced with native `[[ =~ ]]` (EPIPE under `pipefail` returned 141 and **mis-branched**); `GATE_NOTIFY_ROOT/TOPIC` made `local`; word-split `NOTIFY_ARGV` fixed (a `REPO_ROOT` with a space degraded every page to WARN); scratch doc line marked historical.

**Supervisor exit latency — tightened, not waived.** `finalize_exit`'s two notifies were 2 × (10 s + 5 s) = 30 s worst case against a black-holed host, versus the `<15 s` property #2666 pins (whose test is stubbed and so cannot catch it). Bounds on that path are now 4 s/2 s → **12 s** worst case, with headroom. Bounding was chosen over a rationale because the property is pinned and "it probably won't happen" is the reasoning that produced this issue.

## Local certification

`--lite` PASS at `7e440db`, `tree-integrity: PASS`, worktree clean. Suites at this SHA: contract **12/12**, advisory **15/15**, bootstrap **77/77**, supervisor **59/59**. The new contract test is registered in the gate's `tooling-tests` component (registration traced to `status=FAIL`), so a regression reds the gate rather than paging a human wrongly.

The ONE full `agent-gate.sh` of record, the `spec-auditor` **C** intent audit, and the final roborev pass run in `flow-closer` before merge.

## Scope

All shell + docs — **zero Rust**: no `cqlite-*`, no bindings, no `test-data`, no Cargo manifests, no CI workflows. `agent-gate.sh` edits are confined to `gate_push_signal` plus the test registration; no gate verdict logic, component semantics, or SUMMARY block format changed. Doctrine updated in the same change (`flow-board/SKILL.md`, `fleet-runbook.md`, `delivery-pipeline.md`) per the repo rule.

OpenSpec change: `openspec/changes/notify-contract/` (8 requirements / 27 scenarios), archived at finalize.

Related: #2667 (introduced the push signal), #2910, #2140 (the pin should land in the golden AMI path too).
