### PR TITLE
fix(#3220): table-granular fixture resolution + per-case fail-closed guards so the #3032 differential case cannot skip silently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,13 @@ by responsibility (source: epic #1116; tests: #1135). Genuinely out of scope →
   root (env, then checkout) for that table's `*-Data.db`. And never terminate a corpus loop with a
   suite-wide `assert!(ran > 0)`: it cannot see one case skipping behind its siblings — assert per
   case (committed fixtures = `must_run`, fail-closed unconditionally).
+  Resolve by EVIDENCE, never by a preference ordering: neither root is a superset — a fleet
+  `/data/datasets` measured 144 `*-Data.db` over 122 tables yet lacks the one committed
+  `test_da/multiclustering_table`, which the checkout's 31 parity references carry — so *any* fixed
+  env-first/checkout-first rule picks wrong for one set of tables. That dissolves #3104's "prefer
+  the already-exported root" fix for the lanes on this resolver; **#3104 stays open** for what the
+  resolver does not reach (whole-corpus `#2078` preflight, count-naming diagnostics, `--lite`
+  small-corpus warning, and the doctrine text still telling agents to override the exported root).
 - **Two parity oracles (issue #1742)**: *physical-dump parity* (the `*-Data.db.jsonl` sstabledump
   goldens) enumerates every on-disk cell INCLUDING tombstones/deleted/expired-TTL rows, so it CANNOT
   catch a read-time-reconciliation bug (both sides keep the shadowed rows → green while a real

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,14 @@ by responsibility (source: epic #1116; tests: #1135). Genuinely out of scope →
   reference files —
   [validation playbook](https://pmcfadin.github.io/cqlite/agents-developing/validation-playbook/)
 - Never let a dataset-dependent test pass on an empty dataset (0-rows-when-present = failure)
+- **Resolve fixture roots per TABLE, and assert per CASE (issue #3220)**: a lane that picks its
+  corpus root by KEYSPACE (`root.join(keyspace).is_dir()`) and commits to it can pass without ever
+  running — a `CQLITE_DATASETS_ROOT` holding `test_da/` but not the git-committed
+  `test_da/multiclustering_table-*` made the #3032 case skip silently behind a green suite. Use
+  `cqlite-core/tests/support/datasets_root.rs::sstables_root_for_table`, which walks EVERY candidate
+  root (env, then checkout) for that table's `*-Data.db`. And never terminate a corpus loop with a
+  suite-wide `assert!(ran > 0)`: it cannot see one case skipping behind its siblings — assert per
+  case (committed fixtures = `must_run`, fail-closed unconditionally).
 - **Two parity oracles (issue #1742)**: *physical-dump parity* (the `*-Data.db.jsonl` sstabledump
   goldens) enumerates every on-disk cell INCLUDING tombstones/deleted/expired-TTL rows, so it CANNOT
   catch a read-time-reconciliation bug (both sides keep the shadowed rows → green while a real

--- a/cqlite-core/tests/issue_3220_datasets_root_resolution.rs
+++ b/cqlite-core/tests/issue_3220_datasets_root_resolution.rs
@@ -1,0 +1,179 @@
+//! Issue #3220: the TABLE-granular fixture-root selection rule, pinned against
+//! synthetic roots.
+//!
+//! # What defect this exists to catch
+//!
+//! Three dataset lanes selected a corpus root by **keyspace** (`root.join(keyspace)
+//! .is_dir()`) and then committed to it with no fallback, even though every caller
+//! needs a specific **table**. On a machine whose `CQLITE_DATASETS_ROOT` corpus held
+//! `test_da/` but not the git-committed `test_da/multiclustering_table-*`, that rule
+//! selected the env root, missed the table, and the #3032 multi-component clustering
+//! differential case SKIPPED SILENTLY behind a green suite.
+//!
+//! # Why the assertions are against SYNTHETIC roots
+//!
+//! The real candidate list is half environment and half a COMPILE-TIME checkout path,
+//! so a test that reads it can only ever observe THIS machine's layout — and on a
+//! machine where every root happens to hold every table, the broken keyspace-granular
+//! rule and the correct table-granular one return the same answer. Only an explicit
+//! two-root layout where the FIRST root holds the keyspace WITHOUT the table
+//! discriminates between them, which is exactly the layout built below. Hence the
+//! pure `first_root_with_table` seam.
+//!
+//! These are directory-shape assertions, not format assertions: no SSTable is parsed
+//! here, so an empty file named `*-Data.db` is a legitimate stand-in for "the binaries
+//! are present" (whether they DECODE is the lanes' own business, and a truncated one
+//! makes them fail loudly — the second AC2 direction, exercised end-to-end in the PR).
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+#[path = "support/datasets_root.rs"]
+mod datasets_root;
+
+use datasets_root::{first_root_with_table, table_has_data};
+use std::path::{Path, PathBuf};
+
+/// Create `<root>/<keyspace>/<table>-<uuid>/` and populate it with `files`.
+fn make_table_dir(root: &Path, keyspace: &str, table: &str, uuid: &str, files: &[&str]) -> PathBuf {
+    let dir = root.join(keyspace).join(format!("{table}-{uuid}"));
+    std::fs::create_dir_all(&dir).expect("create fixture dir");
+    for f in files {
+        std::fs::write(dir.join(f), b"").expect("write fixture component");
+    }
+    dir
+}
+
+/// THE #3220 case: candidate 1 holds the KEYSPACE but not the TABLE. The rule must
+/// fall through to candidate 2, which actually carries the table's `*-Data.db`.
+///
+/// Under the retired keyspace-granular rule candidate 1 wins and the table is then
+/// reported absent — the silent-skip defect.
+#[test]
+fn a_root_holding_the_keyspace_without_the_table_is_skipped() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let env_root = tmp.path().join("env/sstables");
+    let checkout_root = tmp.path().join("checkout/sstables");
+
+    // Candidate 1: the keyspace exists (another table lives there), the wanted table
+    // does not — the real /data/datasets shape that triggered #3220.
+    make_table_dir(
+        &env_root,
+        "test_da",
+        "wide_table",
+        "aaaa",
+        &["da-2-bti-Data.db"],
+    );
+    // Candidate 2: the committed fixture.
+    make_table_dir(
+        &checkout_root,
+        "test_da",
+        "multiclustering_table",
+        "bbbb",
+        &["da-2-bti-Data.db"],
+    );
+
+    let roots = vec![env_root.clone(), checkout_root.clone()];
+    assert!(
+        env_root.join("test_da").is_dir(),
+        "precondition: candidate 1 must hold the keyspace, else this test cannot \
+         discriminate the keyspace-granular rule from the table-granular one"
+    );
+    assert_eq!(
+        first_root_with_table(&roots, "test_da", "multiclustering_table"),
+        Some(checkout_root.as_path()),
+        "resolution must fall through a root that holds the keyspace but not the table"
+    );
+    // The sibling table still resolves from the FIRST root: preference order is
+    // preserved, the rule only skips roots that cannot serve the request.
+    assert_eq!(
+        first_root_with_table(&roots, "test_da", "wide_table"),
+        Some(env_root.as_path()),
+        "candidate order must still win when the first root does hold the table"
+    );
+}
+
+/// Fixture-absent direction of the fail-closed contract (AC2a): when NO candidate
+/// carries the table, resolution yields `None` — the value every caller turns into a
+/// hard failure (`must_run` / `CQLITE_REQUIRE_FIXTURES`), never a silent success.
+#[test]
+fn absent_everywhere_resolves_to_none() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root_a = tmp.path().join("a/sstables");
+    let root_b = tmp.path().join("b/sstables");
+    make_table_dir(
+        &root_a,
+        "test_da",
+        "wide_table",
+        "aaaa",
+        &["da-2-bti-Data.db"],
+    );
+    std::fs::create_dir_all(root_b.join("test_da")).expect("empty keyspace dir");
+
+    let roots = vec![root_a, root_b];
+    assert_eq!(
+        first_root_with_table(&roots, "test_da", "multiclustering_table"),
+        None,
+        "a table no candidate root carries must resolve to None, so the caller fails closed"
+    );
+}
+
+/// A `<table>-<uuid>/` directory holding only the committed SIDECARS (the
+/// `*-Data.db.jsonl` physical golden, `*-Statistics.db.txt`) is NOT usable: the repo
+/// commits those for fixtures whose binaries are gitignored. Presence must be judged
+/// on a real `*-Data.db` component, else a lane would select a root it cannot read
+/// from and report the fixture as fetched.
+#[test]
+fn a_sidecar_only_directory_does_not_count_as_present() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sidecar_root = tmp.path().join("sidecar/sstables");
+    let real_root = tmp.path().join("real/sstables");
+    make_table_dir(
+        &sidecar_root,
+        "test_tomb",
+        "resurrection_gc0",
+        "aaaa",
+        &[
+            "nb-1-big-Data.db.jsonl",
+            "nb-1-big-Statistics.db.txt",
+            "nb-1-big-TOC.txt",
+        ],
+    );
+    make_table_dir(
+        &real_root,
+        "test_tomb",
+        "resurrection_gc0",
+        "bbbb",
+        &["nb-1-big-Data.db"],
+    );
+
+    assert!(
+        !table_has_data(&sidecar_root, "test_tomb", "resurrection_gc0"),
+        "a sidecar-only directory must not be reported as carrying fetched binaries"
+    );
+    let roots = vec![sidecar_root, real_root.clone()];
+    assert_eq!(
+        first_root_with_table(&roots, "test_tomb", "resurrection_gc0"),
+        Some(real_root.as_path())
+    );
+}
+
+/// `<table>-` is a PREFIX match, so a longer table name sharing the prefix must not
+/// satisfy a request for the shorter one (`wide_table` vs `wide_table_v2`).
+#[test]
+fn a_prefix_sharing_sibling_table_does_not_satisfy_the_request() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("sstables");
+    make_table_dir(
+        &root,
+        "test_da",
+        "wide_table_v2",
+        "aaaa",
+        &["da-2-bti-Data.db"],
+    );
+
+    assert!(
+        !table_has_data(&root, "test_da", "wide_table"),
+        "`wide_table_v2-<uuid>` must not answer a request for `wide_table`"
+    );
+    assert!(table_has_data(&root, "test_da", "wide_table_v2"));
+}

--- a/cqlite-core/tests/issue_3220_datasets_root_resolution.rs
+++ b/cqlite-core/tests/issue_3220_datasets_root_resolution.rs
@@ -25,12 +25,19 @@
 //! are present" (whether they DECODE is the lanes' own business, and a truncated one
 //! makes them fail loudly — the second AC2 direction, exercised end-to-end in the PR).
 
-#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+//! DELIBERATELY UNGATED by cargo features: this target parses no SSTable and calls
+//! no feature-gated API, so a `#![cfg(all(feature = "state_machine", feature =
+//! "cli-helpers"))]` (copied from the lanes that DO need them) would compile the only
+//! pins on the resolution rule away under a plain `cargo test -p cqlite-core` — a
+//! rule guarded by nothing in the very default build most developers run.
 
 #[path = "support/datasets_root.rs"]
 mod datasets_root;
 
-use datasets_root::{first_root_with_table, table_has_data};
+use datasets_root::{
+    first_root_with_table, sstables_root_candidates, table_has_data,
+    CHECKOUT_SSTABLES_ROOT_OVERRIDE_ENV,
+};
 use std::path::{Path, PathBuf};
 
 /// Create `<root>/<keyspace>/<table>-<uuid>/` and populate it with `files`.
@@ -155,6 +162,70 @@ fn a_sidecar_only_directory_does_not_count_as_present() {
         first_root_with_table(&roots, "test_tomb", "resurrection_gc0"),
         Some(real_root.as_path())
     );
+}
+
+/// The CHECKOUT corpus must ALWAYS be a candidate root — the property the whole
+/// fail-closed contract rests on: a `must_run` case may assert unconditionally only
+/// because a committed fixture is reachable whatever `CQLITE_DATASETS_ROOT` names.
+/// Drop the checkout from the candidate list (say, by "preferring" the env root) and
+/// every committed-fixture guard in the sibling lanes turns into a false failure.
+///
+/// NON-RACY: it mutates nothing. The override seam is read ONCE into a local (a second
+/// `var_os` could observe a different value if a sibling test wrote the environment),
+/// and the expectation is derived from that single observation — so this test neither
+/// sets a process-global nor depends on another test's timing.
+#[test]
+fn the_checkout_corpus_is_always_a_candidate_root() {
+    let override_root = match std::env::var_os(CHECKOUT_SSTABLES_ROOT_OVERRIDE_ENV) {
+        Some(v) if !v.is_empty() => Some(PathBuf::from(v)),
+        _ => None,
+    };
+    let expected = override_root.clone().unwrap_or_else(|| {
+        datasets_root::fixture_roots::checkout_test_data_dir()
+            .join("datasets")
+            .join("sstables")
+    });
+
+    let candidates = sstables_root_candidates();
+    assert!(
+        !candidates.is_empty(),
+        "the candidate list must never be empty: the checkout root is unconditional"
+    );
+    assert!(
+        candidates.contains(&expected),
+        "the checkout corpus {} must always be a candidate root, whatever \
+         CQLITE_DATASETS_ROOT names; got {candidates:?}",
+        expected.display()
+    );
+    assert_eq!(
+        candidates.last(),
+        Some(&expected),
+        "the checkout root is the LAST candidate: an env corpus that can serve the request \
+         wins the tie, and the checkout is the always-present fallback"
+    );
+    // Deduplicated: a CQLITE_DATASETS_ROOT that already points at the checkout must not
+    // report the same path twice.
+    let mut deduped = candidates.clone();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(
+        deduped.len(),
+        candidates.len(),
+        "candidate roots must be deduplicated: {candidates:?}"
+    );
+
+    // And it is not merely a path: with no override in force, the checkout candidate
+    // really carries a git-committed fixture, which is what makes `must_run: true`
+    // assertable unconditionally in the sibling lanes. (Skipped when the harness
+    // override is in force — that seam exists precisely to hide fixtures.)
+    if override_root.is_none() {
+        assert!(
+            table_has_data(&expected, "test_da", "multiclustering_table"),
+            "the checkout candidate {} must carry the committed #3032 fixture; remedy: \
+             git restore --source=HEAD -- test-data/datasets/sstables",
+            expected.display()
+        );
+    }
 }
 
 /// `<table>-` is a PREFIX match, so a longer table name sharing the prefix must not

--- a/cqlite-core/tests/point_vs_full_differential.rs
+++ b/cqlite-core/tests/point_vs_full_differential.rs
@@ -175,6 +175,21 @@ struct TableCase {
     /// A declarative flag (rather than a table name hardcoded in the terminal
     /// assertion) so a future committed fixture opts in where it is defined.
     ///
+    /// AUTHORITY for the value is `git ls-files`, NEVER directory presence in the
+    /// working tree: `fetch-datasets.sh` unpacks the fetched corpus into
+    /// `test-data/datasets/` by default, so a GITIGNORED fixture is routinely present
+    /// on disk in a checkout where another machine has nothing. Re-derive with
+    ///
+    /// ```text
+    /// git ls-files 'test-data/datasets/sstables/**-Data.db'
+    /// ```
+    ///
+    /// which (as of #3220) covers exactly four of this corpus's tables —
+    /// `test_tomb/static_with_tombstones`, both `test_compaction_tombstone_ttl`
+    /// tables and both `test_da` tables, i.e. FIVE of the nine cases. Every other
+    /// `test_tomb` table here ships only its `*-Data.db.jsonl` / `*-Statistics.db.txt`
+    /// sidecars, so its binaries are fetched and its absence is legitimate.
+    ///
     /// Why it is load-bearing: `CQLITE_REQUIRE_FIXTURES` is NOT set by the
     /// `core-tests` component that runs this target, and the terminal check used to
     /// be a suite-wide `ran > 0` — so a single case that resolved to no fixture
@@ -211,6 +226,8 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[],
         divergence_classes: &["multi_generation", "tombstone"],
+        // FETCHED (gitignored binaries; only the JSONL/.db.txt sidecars are
+        // committed) — a clean SKIP on a minimal checkout is legitimate.
         must_run: false,
         clustering_slice_predicates: &[],
     },
@@ -221,6 +238,8 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[],
         divergence_classes: &["multi_generation", "tombstone"],
+        // FETCHED (gitignored binaries; only the JSONL/.db.txt sidecars are
+        // committed) — a clean SKIP on a minimal checkout is legitimate.
         must_run: false,
         clustering_slice_predicates: &[],
     },
@@ -232,6 +251,8 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[1, 2],
         divergence_classes: &["multi_generation", "tombstone"],
+        // FETCHED (gitignored binaries; only the JSONL/.db.txt sidecars are
+        // committed) — a clean SKIP on a minimal checkout is legitimate.
         must_run: false,
         clustering_slice_predicates: &[],
     },
@@ -243,6 +264,8 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[],
         divergence_classes: &["ttl"],
+        // FETCHED (gitignored binaries; only the JSONL/.db.txt sidecars are
+        // committed) — a clean SKIP on a minimal checkout is legitimate.
         must_run: false,
         clustering_slice_predicates: &[],
     },
@@ -254,7 +277,12 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[],
         divergence_classes: &["tombstone"],
-        must_run: false,
+        // COMMITTED: `git ls-files` lists nb-1-big-{Data,Index,Filter,Summary,
+        // Statistics,CompressionInfo}.db under
+        // test-data/datasets/sstables/test_tomb/static_with_tombstones-4cdb9780…/ —
+        // the ONLY test_tomb table in this corpus whose binaries are in git. Present in
+        // every checkout, so a SKIP can only mean the lane failed to RESOLVE it.
+        must_run: true,
         clustering_slice_predicates: &[],
     },
     // Post-major-compaction tombstone/TTL fixtures (single output SSTable).

--- a/cqlite-core/tests/point_vs_full_differential.rs
+++ b/cqlite-core/tests/point_vs_full_differential.rs
@@ -24,13 +24,24 @@
 //! to guard.
 //!
 //! Anti-empty-pass / SKIP contract (matches the query-semantics oracle):
-//!   * When the committed corpus (or its `*.db` binaries) is absent, each case
-//!     SKIPs cleanly — UNLESS `CQLITE_REQUIRE_FIXTURES=1` (the agent-gate
-//!     integration-tests tier sets it), in which case an absent/empty fixture is
-//!     a hard FAIL so the lane can never green-pass without running.
+//!   * Every case whose SSTable binaries are COMMITTED to git carries
+//!     `must_run: true` and is fail-closed UNCONDITIONALLY — a SKIP is a hard
+//!     FAILURE with or without `CQLITE_REQUIRE_FIXTURES` (issue #3220). Those
+//!     fixtures exist in every checkout, so a SKIP can only mean the lane failed to
+//!     RESOLVE them.
+//!   * A case whose binaries are FETCHED (gitignored) SKIPs cleanly when the corpus
+//!     is absent — UNLESS `CQLITE_REQUIRE_FIXTURES=1` (the agent-gate
+//!     integration-tests tier sets it), under which EVERY case must run.
 //!   * A case that discovers ZERO partition keys in a present fixture is a hard
 //!     FAIL (a fixture with rows must yield at least one point query), never a
-//!     silent vacuous pass.
+//!     silent vacuous pass; every clustering slice is additionally anchored to an
+//!     exact expected row count, so a present-but-empty fixture FAILs rather than
+//!     comparing `0 == 0`.
+//!
+//! Fixture roots resolve TABLE-granularly via `support/datasets_root.rs` (#3220):
+//! a `CQLITE_DATASETS_ROOT` corpus holding the keyspace but not the table falls
+//! through to the checkout's committed copy instead of being committed to. The
+//! agent-gate `bti-multiclustering` component runs this target as defense in depth.
 //!
 //! The harness's divergence detection is itself regression-tested by
 //! `comparison_detects_a_seeded_divergence` below (feeding the compare helper two
@@ -347,6 +358,21 @@ const CORPUS: &[TableCase] = &[
 /// Stable identity of a corpus case, used by the per-case must-run bookkeeping.
 fn case_id(case: &TableCase) -> String {
     format!("{}.{}", case.keyspace, case.table)
+}
+
+/// PURE decision behind the must-run assertion: every `must_run` case absent from
+/// `ran`, by table name.
+///
+/// Factored out so the assertion has a proof it CAN fail
+/// (`must_run_violations_flags_a_committed_case_that_did_not_run`). A fail-closed
+/// guard whose failing branch is never exercised is indistinguishable from a guard
+/// that cannot fire — the exact shape of the #3220 defect it replaces.
+fn must_run_violations<'a>(cases: &'a [TableCase], ran: &[String]) -> Vec<&'a str> {
+    cases
+        .iter()
+        .filter(|c| c.must_run && !ran.iter().any(|id| id == &case_id(c)))
+        .map(|c| c.table)
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -672,11 +698,7 @@ async fn point_vs_full_differential_equality() {
     // `CQLITE_REQUIRE_FIXTURES`: this target runs under `core-tests`, which does not
     // set it, and that is exactly where the #3032 multiclustering case skipped
     // unnoticed. Suite-wide `ran > 0` cannot see it — seven siblings ran.
-    let must_run_missing: Vec<&str> = CORPUS
-        .iter()
-        .filter(|c| c.must_run && !ran.iter().any(|id| id == &case_id(c)))
-        .map(|c| c.table)
-        .collect();
+    let must_run_missing = must_run_violations(CORPUS, &ran);
     assert!(
         must_run_missing.is_empty(),
         "{} committed-fixture case(s) did NOT run: {:?} — these fixtures are COMMITTED to git, \
@@ -716,6 +738,50 @@ async fn point_vs_full_differential_equality() {
              (set CQLITE_REQUIRE_FIXTURES=1 to fail-close)"
         );
     }
+}
+
+/// Regression-test the FAIL-CLOSED guard itself (issue #3220): the must-run decision
+/// must FIRE for a committed-fixture case that did not run, and must stay silent for
+/// a fetched-only case that skipped. Without this, the guard's failing branch is
+/// never exercised and "green" would not distinguish a guard that works from a guard
+/// that cannot fire.
+#[test]
+fn must_run_violations_flags_a_committed_case_that_did_not_run() {
+    // The real corpus, minus the #3032 case's id: exactly the state observed on a
+    // machine whose CQLITE_DATASETS_ROOT lacked the committed fixture.
+    let ran_without_multiclustering: Vec<String> = CORPUS
+        .iter()
+        .filter(|c| c.table != "multiclustering_table")
+        .map(case_id)
+        .collect();
+    assert_eq!(
+        must_run_violations(CORPUS, &ran_without_multiclustering),
+        vec!["multiclustering_table"],
+        "a committed-fixture case that did not run must be reported, even though every \
+         other case ran (the suite-wide `ran > 0` blind spot)"
+    );
+
+    // All cases ran: no violation.
+    let all: Vec<String> = CORPUS.iter().map(case_id).collect();
+    assert!(
+        must_run_violations(CORPUS, &all).is_empty(),
+        "no violation when every case ran"
+    );
+
+    // A FETCHED-only (must_run == false) case that skipped is NOT a violation: those
+    // binaries are gitignored, so their absence is legitimate on a minimal checkout.
+    let without_fetched: Vec<String> = CORPUS.iter().filter(|c| c.must_run).map(case_id).collect();
+    assert!(
+        must_run_violations(CORPUS, &without_fetched).is_empty(),
+        "a gitignored-fixture case that skipped must not trip the committed-fixture guard"
+    );
+
+    // The corpus must actually DECLARE some committed cases, else the guard above is
+    // vacuous (an all-`false` corpus can never produce a violation).
+    assert!(
+        CORPUS.iter().any(|c| c.must_run),
+        "at least one corpus case must be declared must_run, else the guard is vacuous"
+    );
 }
 
 /// Regression-test the harness itself: the compare logic MUST flag a divergence

--- a/cqlite-core/tests/point_vs_full_differential.rs
+++ b/cqlite-core/tests/point_vs_full_differential.rs
@@ -58,8 +58,14 @@
 #[path = "point_vs_full_differential/one_vs_n_generation.rs"]
 mod one_vs_n_generation;
 
+// TABLE-granular fixture-root resolution, shared with the sibling dataset lanes
+// (issue #3220). Declared BEFORE first use so both this file and the submodule
+// (`use super::…`) resolve fixtures the same way.
+#[path = "support/datasets_root.rs"]
+mod datasets_root;
+
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serial_test::serial;
 
@@ -344,76 +350,14 @@ fn case_id(case: &TableCase) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Path resolution (mirrors query_semantics_oracle_parity.rs)
+// Path resolution — the shared, TABLE-granular resolver (issue #3220)
 // ---------------------------------------------------------------------------
 
-fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("cqlite-core has a parent repo dir")
-        .to_path_buf()
-}
-
-fn sstables_root(keyspace: &str) -> Option<PathBuf> {
-    let candidates = [
-        std::env::var("CQLITE_DATASETS_ROOT")
-            .ok()
-            .map(|r| PathBuf::from(r).join("sstables")),
-        Some(
-            repo_root()
-                .join("test-data")
-                .join("datasets")
-                .join("sstables"),
-        ),
-    ];
-    candidates
-        .into_iter()
-        .flatten()
-        .find(|root| root.join(keyspace).is_dir())
-}
-
-fn schema_path(file: &str) -> Option<PathBuf> {
-    let candidates = [
-        std::env::var("CQLITE_DATASETS_ROOT").ok().and_then(|r| {
-            PathBuf::from(r)
-                .parent()
-                .map(|p| p.join("schemas").join(file))
-        }),
-        Some(repo_root().join("test-data").join("schemas").join(file)),
-    ];
-    candidates.into_iter().flatten().find(|p| p.exists())
-}
-
-/// True when the keyspace dir holds at least one `*-Data.db` for `table` — i.e.
-/// the (gitignored) binaries have actually been fetched, not just the JSONL.
-fn table_has_data(root: &Path, keyspace: &str, table: &str) -> bool {
-    let ks_dir = root.join(keyspace);
-    let Ok(entries) = std::fs::read_dir(&ks_dir) else {
-        return false;
-    };
-    entries
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| {
-            p.is_dir()
-                && p.file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n.starts_with(&format!("{table}-")))
-                    .unwrap_or(false)
-        })
-        .any(|dir| {
-            std::fs::read_dir(&dir)
-                .map(|rd| {
-                    rd.filter_map(|e| e.ok()).any(|e| {
-                        e.file_name()
-                            .to_str()
-                            .map(|n| n.ends_with("-Data.db"))
-                            .unwrap_or(false)
-                    })
-                })
-                .unwrap_or(false)
-        })
-}
+// Re-exported for the `one_vs_n_generation` submodule (`use super::…`) and shared,
+// byte-for-byte, with `query_semantics_oracle_parity.rs` + `read_path_forcing_e2e.rs`.
+// A private per-file copy is what let the same absence read as a hard FAIL in one
+// lane and a silent SKIP in another.
+use datasets_root::{describe_search, schema_path, sstables_root_for_table};
 
 // ---------------------------------------------------------------------------
 // Result normalization (authoritative; never a byte-pattern guess)
@@ -539,15 +483,12 @@ async fn assert_point_full_equal(
 /// equality. `Ok(true)` = ran a comparison, `Ok(false)` = SKIPped (absent
 /// fixture, non-fail-closed).
 async fn run_case(case: &TableCase) -> Result<bool, String> {
-    let Some(root) = sstables_root(case.keyspace) else {
-        return skip_or_fail(&format!("keyspace {} absent", case.keyspace));
+    // TABLE-granular: every candidate root is searched for THIS table's `*-Data.db`,
+    // so a root holding the keyspace without the table falls through to the next one
+    // instead of being committed to (issue #3220).
+    let Some(root) = sstables_root_for_table(case.keyspace, case.table) else {
+        return skip_or_fail(&describe_search(case.keyspace, case.table));
     };
-    if !table_has_data(&root, case.keyspace, case.table) {
-        return skip_or_fail(&format!(
-            "table {}.{} has no fetched *-Data.db",
-            case.keyspace, case.table
-        ));
-    }
     let Some(schema) = schema_path(case.schema) else {
         return skip_or_fail(&format!("schema {} absent", case.schema));
     };

--- a/cqlite-core/tests/point_vs_full_differential.rs
+++ b/cqlite-core/tests/point_vs_full_differential.rs
@@ -149,6 +149,22 @@ struct TableCase {
     /// Documented reconciliation classes this fixture covers (for the corpus
     /// coverage assertion; not used at query time).
     divergence_classes: &'static [&'static str],
+    /// This case MUST execute — a SKIP is a hard FAILURE, unconditionally (issue
+    /// #3220).
+    ///
+    /// Set for every case whose SSTable binaries are **committed to git** rather than
+    /// fetched: they are present in EVERY checkout, so there is no legitimate
+    /// absence and no reason to require `CQLITE_REQUIRE_FIXTURES=1` before saying so.
+    /// A declarative flag (rather than a table name hardcoded in the terminal
+    /// assertion) so a future committed fixture opts in where it is defined.
+    ///
+    /// Why it is load-bearing: `CQLITE_REQUIRE_FIXTURES` is NOT set by the
+    /// `core-tests` component that runs this target, and the terminal check used to
+    /// be a suite-wide `ran > 0` — so a single case that resolved to no fixture
+    /// skipped silently behind seven siblings that ran. That is exactly how the
+    /// #3032 `test_da.multiclustering_table` case never executed on a machine whose
+    /// `CQLITE_DATASETS_ROOT` held `test_da` without that table.
+    must_run: bool,
     /// Extra WITHIN-partition clustering predicates to run against EVERY probed
     /// partition key, as `(predicate, expected_row_count)` pairs evaluated as
     /// `WHERE <pk> = <k> AND <predicate>` (issue #3002). These exercise the
@@ -178,6 +194,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[],
         divergence_classes: &["multi_generation", "tombstone"],
+        must_run: false,
         clustering_slice_predicates: &[],
     },
     TableCase {
@@ -187,6 +204,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[],
         divergence_classes: &["multi_generation", "tombstone"],
+        must_run: false,
         clustering_slice_predicates: &[],
     },
     // Cross-generation partition tombstone + a tombstone-only partition.
@@ -197,6 +215,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[1, 2],
         divergence_classes: &["multi_generation", "tombstone"],
+        must_run: false,
         clustering_slice_predicates: &[],
     },
     // TTL localDeletionTime boundary (expired vs live cells).
@@ -207,6 +226,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[],
         divergence_classes: &["ttl"],
+        must_run: false,
         clustering_slice_predicates: &[],
     },
     // Live static cell surviving adjacent row/cell/range tombstones.
@@ -217,6 +237,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[],
         divergence_classes: &["tombstone"],
+        must_run: false,
         clustering_slice_predicates: &[],
     },
     // Post-major-compaction tombstone/TTL fixtures (single output SSTable).
@@ -227,6 +248,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "id",
         probe_keys: &[],
         divergence_classes: &["tombstone"],
+        must_run: true,
         clustering_slice_predicates: &[],
     },
     TableCase {
@@ -236,6 +258,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "id",
         probe_keys: &[],
         divergence_classes: &["ttl"],
+        must_run: true,
         clustering_slice_predicates: &[],
     },
     // BTI (`da`) WIDE partition with a per-partition `Rows.db` row index (issue
@@ -253,6 +276,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[1, 2, 3],
         divergence_classes: &["bti_clustering_slice"],
+        must_run: true,
         // Every partition holds ck=0..=299, so each slice's row count is exact and
         // identical for pk=1/2/3 — and every one of them is strictly between 0 and the
         // partition's 300 rows, so neither an empty nor an unnarrowed result can pass.
@@ -282,6 +306,7 @@ const CORPUS: &[TableCase] = &[
         pk_column: "pk",
         probe_keys: &[1, 2, 3],
         divergence_classes: &["bti_clustering_slice", "compound_clustering"],
+        must_run: true,
         // The fixture's partitions are DELIBERATELY non-uniform (pk=1: 3 buckets x
         // 60 rows = 180; pk=2: 5 x 32 = 160; pk=3: 8 x 16 = 128), which is what makes
         // their row-index tries differ structurally. This lane applies one expected
@@ -312,6 +337,11 @@ const CORPUS: &[TableCase] = &[
         ],
     },
 ];
+
+/// Stable identity of a corpus case, used by the per-case must-run bookkeeping.
+fn case_id(case: &TableCase) -> String {
+    format!("{}.{}", case.keyspace, case.table)
+}
 
 // ---------------------------------------------------------------------------
 // Path resolution (mirrors query_semantics_oracle_parity.rs)
@@ -655,7 +685,17 @@ async fn point_vs_full_differential_equality() {
         .iter()
         .flat_map(|c| c.divergence_classes.iter().copied())
         .collect();
-    for required in ["multi_generation", "tombstone", "ttl"] {
+    for required in [
+        "multi_generation",
+        "tombstone",
+        "ttl",
+        // The BTI (`da`) clustering-slice classes (#3002 / #3032): the point path's
+        // `Rows.db` row-index window, and its multi-component (`text` then `int`)
+        // clustering form. Listed so dropping either fixture reds this lane instead
+        // of quietly narrowing the corpus.
+        "bti_clustering_slice",
+        "compound_clustering",
+    ] {
         assert!(
             covered.contains(required),
             "corpus must cover the {required:?} reconciliation class (issue #1741 divergence set)"
@@ -667,13 +707,14 @@ async fn point_vs_full_differential_equality() {
     // AND this test is `#[serial]` against every sibling that writes the same var.
     let _clock = pin_read_clock();
 
-    let mut ran = 0usize;
+    let mut ran: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
     for case in CORPUS {
         match run_case(case).await {
-            Ok(true) => ran += 1,
-            Ok(false) => {}
-            Err(e) => failures.push(format!("{}.{}: {e}", case.keyspace, case.table)),
+            Ok(true) => ran.push(case_id(case)),
+            Ok(false) => skipped.push(case_id(case)),
+            Err(e) => failures.push(format!("{}: {e}", case_id(case))),
         }
     }
 
@@ -683,10 +724,50 @@ async fn point_vs_full_differential_equality() {
         failures.join("\n\n")
     );
 
+    // PER-CASE must-run, UNCONDITIONALLY (issue #3220). Every `must_run` fixture is
+    // COMMITTED to git, so it is present in every checkout and a SKIP can only mean
+    // the case failed to RESOLVE its fixture — the silent-skip defect this assertion
+    // exists to make impossible. Deliberately NOT gated on
+    // `CQLITE_REQUIRE_FIXTURES`: this target runs under `core-tests`, which does not
+    // set it, and that is exactly where the #3032 multiclustering case skipped
+    // unnoticed. Suite-wide `ran > 0` cannot see it — seven siblings ran.
+    let must_run_missing: Vec<&str> = CORPUS
+        .iter()
+        .filter(|c| c.must_run && !ran.iter().any(|id| id == &case_id(c)))
+        .map(|c| c.table)
+        .collect();
+    assert!(
+        must_run_missing.is_empty(),
+        "{} committed-fixture case(s) did NOT run: {:?} — these fixtures are COMMITTED to git, \
+         so absence means the lane failed to RESOLVE them, never that they are legitimately \
+         missing.\n  ran    : {:?}\n  skipped: {:?}\n  remedy : git restore --source=HEAD -- \
+         test-data/datasets/sstables (or fix root resolution — see \
+         tests/support/datasets_root.rs)",
+        must_run_missing.len(),
+        must_run_missing,
+        ran,
+        skipped
+    );
+
+    let ran = ran.len();
     if require_fixtures() {
+        // Fail closed per CASE, not merely suite-wide (matching the query-semantics
+        // oracle): this lane has no per-case opt-out, so under REQUIRE_FIXTURES every
+        // corpus case must have run. A suite-wide `ran > 0` would let a newly added
+        // case skip silently behind its siblings.
         assert!(
-            ran > 0,
-            "CQLITE_REQUIRE_FIXTURES=1 but no differential case ran (fixtures absent) — fail-closed"
+            skipped.is_empty(),
+            "CQLITE_REQUIRE_FIXTURES=1 but {} of {} differential cases SKIPped ({:?}) — \
+             fail-closed",
+            skipped.len(),
+            CORPUS.len(),
+            skipped
+        );
+        assert_eq!(
+            ran,
+            CORPUS.len(),
+            "CQLITE_REQUIRE_FIXTURES=1: {ran} of {} differential cases ran — fail-closed",
+            CORPUS.len()
         );
     } else if ran == 0 {
         eprintln!(

--- a/cqlite-core/tests/point_vs_full_differential/one_vs_n_generation.rs
+++ b/cqlite-core/tests/point_vs_full_differential/one_vs_n_generation.rs
@@ -90,8 +90,8 @@ use cqlite_core::config::ReadPathMode;
 use cqlite_core::query::result::QueryRow;
 
 use super::{
-    discover_pk_ints, normalize, open_db, pin_read_clock, schema_path, skip_or_fail, sstables_root,
-    table_has_data, MAX_KEYS_PER_TABLE,
+    describe_search, discover_pk_ints, normalize, open_db, pin_read_clock, schema_path,
+    skip_or_fail, sstables_root_for_table, MAX_KEYS_PER_TABLE,
 };
 
 /// Sidecar files that live next to the real SSTable components in the committed
@@ -595,15 +595,12 @@ async fn run_case(case: &GenerationCase) -> Result<bool, String> {
             case.keyspace, case.table
         ));
     }
-    let Some(root) = sstables_root(case.keyspace) else {
-        return skip_or_fail(&format!("keyspace {} absent", case.keyspace));
+    // TABLE-granular root resolution (issue #3220): search every candidate root for
+    // THIS table's `*-Data.db` rather than committing to the first root that merely
+    // holds the keyspace.
+    let Some(root) = sstables_root_for_table(case.keyspace, case.table) else {
+        return skip_or_fail(&describe_search(case.keyspace, case.table));
     };
-    if !table_has_data(&root, case.keyspace, case.table) {
-        return skip_or_fail(&format!(
-            "table {}.{} has no fetched *-Data.db",
-            case.keyspace, case.table
-        ));
-    }
     let Some(schema) = schema_path(case.schema) else {
         return skip_or_fail(&format!("schema {} absent", case.schema));
     };

--- a/cqlite-core/tests/point_vs_full_differential/one_vs_n_generation.rs
+++ b/cqlite-core/tests/point_vs_full_differential/one_vs_n_generation.rs
@@ -75,7 +75,11 @@
 //!   * **Fixture-drift detection** — a case whose source directory stops holding
 //!     exactly one generation FAILs (the axis would otherwise silently compare
 //!     N-vs-M and lose its meaning).
-//!   * **SKIP contract** — absent keyspace/`*-Data.db`/schema SKIPs cleanly unless
+//!   * **SKIP contract** — a case whose binaries are COMMITTED to git carries
+//!     `must_run: true` and may never SKIP: its absence is a hard failure
+//!     UNCONDITIONALLY, in whichever lane owns it (issue #3220), because a committed
+//!     fixture exists in every checkout and can only go missing by failing to
+//!     RESOLVE. A FETCHED (gitignored) case SKIPs cleanly unless
 //!     `CQLITE_REQUIRE_FIXTURES=1` (then it fails closed), matching the parent.
 //!   * **Divergence detection is itself tested** — `one_vs_n_comparator_reports_a_seeded_divergence`
 //!     feeds the comparator deliberately divergent row sets and asserts the
@@ -400,6 +404,28 @@ struct GenerationCase {
     empty_probe_keys: &'static [i64],
     /// Reconciliation classes covered (asserted exhaustive by the driver).
     divergence_classes: &'static [&'static str],
+    /// This case MUST execute — a SKIP is a hard FAILURE, UNCONDITIONALLY (issue
+    /// #3220), in whichever lane owns it: the enforcing lane for a case with
+    /// `known_divergent: None`, the expected-divergence pin otherwise.
+    ///
+    /// Set exactly for the cases whose SSTable binaries are **committed to git**, so
+    /// they are present in every checkout and an absence can only mean the lane failed
+    /// to RESOLVE them. AUTHORITY is `git ls-files`, never directory presence in the
+    /// working tree (`fetch-datasets.sh` unpacks the FETCHED corpus into
+    /// `test-data/datasets/` by default, so a gitignored fixture is routinely on disk
+    /// here and absent elsewhere):
+    ///
+    /// ```text
+    /// git ls-files 'test-data/datasets/sstables/**-Data.db'
+    /// ```
+    ///
+    /// Why the field exists: the terminal checks used to be suite-wide
+    /// `assert!(ran > 0)` / `assert!(pinned > 0)`, BOTH gated on
+    /// `CQLITE_REQUIRE_FIXTURES` — which the `bti-multiclustering` component
+    /// deliberately does not set and `core-tests` never sets. A committed case that
+    /// failed to resolve therefore returned `Ok(false)`, its siblings still tallied,
+    /// and it skipped silently: the exact #3220 defect, in this very file.
+    must_run: bool,
     /// `Some(reason)` = this shape ALREADY diverges on `main` for a defect tracked
     /// elsewhere, so it is NOT part of the enforcing lane (it would make the axis
     /// permanently red and hide a future regression in the shapes that do agree).
@@ -434,6 +460,8 @@ const CORPUS: &[GenerationCase] = &[
         // N-gen seek path's MISS branch (no generation holds the key).
         empty_probe_keys: &[999],
         divergence_classes: &["tombstone", "absent_partition"],
+        // COMMITTED (nb-3-big-* in `git ls-files`).
+        must_run: true,
         known_divergent: None,
     },
     // Partition TOMBSTONES covering whole partitions, in the SAME single generation
@@ -458,6 +486,8 @@ const CORPUS: &[GenerationCase] = &[
             "absent_partition",
             "compressed",
         ],
+        // FETCHED: only `test_deltas/static_with_rows` has committed binaries.
+        must_run: false,
         known_divergent: None,
     },
     // Range tombstone spanning generations, compacted to one SSTable: the range
@@ -472,6 +502,8 @@ const CORPUS: &[GenerationCase] = &[
         expected_partitions: 1,
         empty_probe_keys: &[999],
         divergence_classes: &["range_tombstone", "absent_partition"],
+        // COMMITTED (nb-3-big-* in `git ls-files`).
+        must_run: true,
         known_divergent: None,
     },
     // WIDE range tombstone (~3k live rows): the axis at scale, and the only case
@@ -487,6 +519,8 @@ const CORPUS: &[GenerationCase] = &[
         expected_partitions: 1,
         empty_probe_keys: &[999],
         divergence_classes: &["range_tombstone", "wide_partition", "absent_partition"],
+        // FETCHED (sidecars only in git).
+        must_run: false,
         known_divergent: None,
     },
     // BTI (`da`) WIDE partitions (3 × 300 rows, LZ4-compressed): the
@@ -503,6 +537,8 @@ const CORPUS: &[GenerationCase] = &[
         expected_partitions: 3,
         empty_probe_keys: &[999],
         divergence_classes: &["bti", "wide_partition", "compressed", "absent_partition"],
+        // COMMITTED (da-2-bti-* in `git ls-files`).
+        must_run: true,
         known_divergent: None,
     },
     // ---------------------------------------------------------------------
@@ -526,6 +562,8 @@ const CORPUS: &[GenerationCase] = &[
         expected_partitions: 1,
         empty_probe_keys: &[],
         divergence_classes: &["ttl"],
+        // FETCHED (sidecars only in git).
+        must_run: false,
         known_divergent: Some(
             "issue #2189: the 2-gen arm resurrects the TTL-EXPIRED rows ck=1,ck=2 as all-null \
              phantom rows. Root cause is that `MergeEntry` carries no primary-key row-liveness \
@@ -547,6 +585,9 @@ const CORPUS: &[GenerationCase] = &[
         expected_partitions: 1,
         empty_probe_keys: &[],
         divergence_classes: &["ttl"],
+        // COMMITTED (nb-3-big-* in `git ls-files`) — quarantined, so the
+        // expected-divergence pin is what must not let it skip.
+        must_run: true,
         known_divergent: Some(
             "issue #2189: the 3-gen arm returns 2 rows where the 1-gen arm returns 1 — the same \
              missing multi-generation row-liveness rule as gc_before_boundary (`MergeEntry` has no \
@@ -570,6 +611,9 @@ const CORPUS: &[GenerationCase] = &[
         expected_partitions: 1,
         empty_probe_keys: &[],
         divergence_classes: &["static", "tombstone"],
+        // COMMITTED (nb-1-big-* in `git ls-files`; the only committed
+        // test_tomb table) — quarantined, so the expected-divergence pin owns it.
+        must_run: true,
         known_divergent: Some(
             "issue #3168: the multi-generation read path never injects static cells, so the N-gen \
              arm emits an extra static-only row AND drops `stat_col` from every clustering row, \
@@ -836,6 +880,60 @@ const REQUIRED_ENFORCED_CLASSES: &[&str] = &[
 /// how those two shapes went unguarded.
 const REQUIRED_ASSERTED_CLASSES: &[&str] = &["ttl", "static"];
 
+/// Stable identity of a 1-vs-N case, used by the per-case must-run bookkeeping.
+fn case_id(case: &GenerationCase) -> String {
+    format!("{}.{}", case.keyspace, case.table)
+}
+
+/// PURE decision behind BOTH lanes' must-run assertions: every `must_run` case in
+/// `cases` whose id is absent from `exercised`, by table name.
+///
+/// Factored out (mirroring the parent lane's `super::must_run_violations`) so the
+/// guard has a proof it CAN fire —
+/// `must_run_violations_flags_a_committed_case_that_did_not_run` below. A fail-closed
+/// guard whose failing branch is never exercised is indistinguishable from one that
+/// cannot fire, which is the #3220 shape itself.
+fn must_run_violations<'a, I>(cases: I, exercised: &[String]) -> Vec<&'a str>
+where
+    I: IntoIterator<Item = &'a GenerationCase>,
+{
+    cases
+        .into_iter()
+        .filter(|c| c.must_run && !exercised.iter().any(|id| id == &case_id(c)))
+        .map(|c| c.table)
+        .collect()
+}
+
+/// The two lanes' shared must-run assertion: `lane` names which lane owns `cases`
+/// (enforcing vs the expected-divergence pin), so a failure says where to look.
+///
+/// UNCONDITIONAL by design — deliberately NOT gated on `CQLITE_REQUIRE_FIXTURES`.
+/// Every `must_run` fixture is committed to git, so it is present in every checkout
+/// and a SKIP can only mean the lane failed to RESOLVE it.
+fn assert_must_run_cases_were_exercised<'a, I>(
+    lane: &str,
+    cases: I,
+    exercised: &[String],
+    skipped: &[String],
+) where
+    I: IntoIterator<Item = &'a GenerationCase>,
+{
+    let missing = must_run_violations(cases, exercised);
+    assert!(
+        missing.is_empty(),
+        "{} committed-fixture 1-vs-N case(s) did NOT run in the {lane} lane: {:?} — these \
+         fixtures are COMMITTED to git (`git ls-files \
+         'test-data/datasets/sstables/**-Data.db'`), so absence means the lane failed to \
+         RESOLVE them, never that they are legitimately missing.\n  exercised: {:?}\n  \
+         skipped  : {:?}\n  remedy   : git restore --source=HEAD -- test-data/datasets/sstables \
+         (or fix root resolution — see tests/support/datasets_root.rs)",
+        missing.len(),
+        missing,
+        exercised,
+        skipped
+    );
+}
+
 /// True when `reason` cites a tracking issue (`#` followed by at least one digit).
 /// Doctrine: a waiver with no cited issue is not a waiver.
 fn cites_an_issue(reason: &str) -> bool {
@@ -887,6 +985,19 @@ fn assert_corpus_invariants() {
          deleted or absent partition reaches `seek_merge_generations_for_read` (issue #3129)"
     );
 
+    // Both lanes' unconditional must-run guards must be NON-VACUOUS: each lane has to
+    // own at least one committed-fixture case, else `must_run_violations` can never
+    // report anything for it and the guard is decoration (#3220).
+    for (lane, quarantined) in [("ENFORCING", false), ("expected-divergence", true)] {
+        assert!(
+            CORPUS
+                .iter()
+                .any(|c| c.known_divergent.is_some() == quarantined && c.must_run),
+            "the {lane} lane must own at least one `must_run` (committed-fixture) case, else its \
+             unconditional must-run guard can never fire"
+        );
+    }
+
     // Every quarantined case must carry a substantive reason that CITES its tracking
     // issue, so an exclusion can never be undocumented or untracked.
     for case in CORPUS.iter() {
@@ -920,13 +1031,19 @@ async fn one_vs_n_generation_differential_equality() {
 
     let _clock = pin_read_clock();
 
-    let mut ran = 0usize;
+    let enforcing: Vec<&GenerationCase> = CORPUS
+        .iter()
+        .filter(|c| c.known_divergent.is_none())
+        .collect();
+
+    let mut ran: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
-    for case in CORPUS.iter().filter(|c| c.known_divergent.is_none()) {
+    for case in &enforcing {
         match run_case(case).await {
-            Ok(true) => ran += 1,
-            Ok(false) => {}
-            Err(e) => failures.push(format!("{}.{}: {e}", case.keyspace, case.table)),
+            Ok(true) => ran.push(case_id(case)),
+            Ok(false) => skipped.push(case_id(case)),
+            Err(e) => failures.push(format!("{}: {e}", case_id(case))),
         }
     }
 
@@ -936,6 +1053,13 @@ async fn one_vs_n_generation_differential_equality() {
         failures.join("\n\n")
     );
 
+    // PER-CASE must-run, UNCONDITIONALLY (issue #3220) — the suite-wide
+    // `assert!(ran > 0)` this replaces was gated on `CQLITE_REQUIRE_FIXTURES` (which
+    // neither `core-tests` nor `bti-multiclustering` sets) and could not see a single
+    // committed case skipping behind its siblings.
+    assert_must_run_cases_were_exercised("ENFORCING", enforcing.iter().copied(), &ran, &skipped);
+
+    let ran = ran.len();
     if super::require_fixtures() {
         assert!(
             ran > 0,
@@ -992,12 +1116,23 @@ async fn one_vs_n_generation_quarantine_still_diverges() {
         .collect();
 
     let mut pinned = 0usize;
+    // Ids of the quarantined cases this run actually EXERCISED — pinned, cleared or
+    // failed in the harness. Only `Ok(false)` (an unresolved fixture) leaves a case
+    // out, which is precisely what the must-run guard below must catch.
+    let mut exercised: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
     let mut cleared: Vec<String> = Vec::new();
     let mut harness_failures: Vec<String> = Vec::new();
     for case in &quarantined {
-        let label = format!("{}.{}", case.keyspace, case.table);
+        let label = case_id(case);
         let reason = case.known_divergent.unwrap_or_default();
-        match run_case(case).await {
+        let outcome = run_case(case).await;
+        if matches!(outcome, Ok(false)) {
+            skipped.push(label.clone());
+        } else {
+            exercised.push(label.clone());
+        }
+        match outcome {
             // The case now AGREES at 1 vs N generations: the cited defect is fixed
             // (or the quarantine was wrong). Either way it must move into the
             // enforcing lane — that is this test's whole purpose.
@@ -1031,6 +1166,18 @@ async fn one_vs_n_generation_quarantine_still_diverges() {
         cleared.join("\n\n")
     );
 
+    // PER-CASE must-run, UNCONDITIONALLY (issue #3220): a quarantined case backed by
+    // COMMITTED binaries must have been exercised. Otherwise a resolution failure
+    // would silently retire the pin — the quarantined shape would then be guarded by
+    // nothing at all, green whether broken or fixed, behind `pinned > 0` from its
+    // siblings.
+    assert_must_run_cases_were_exercised(
+        "expected-divergence",
+        quarantined.iter().copied(),
+        &exercised,
+        &skipped,
+    );
+
     if quarantined.is_empty() {
         eprintln!(
             "NOTE the 1-vs-N quarantine is EMPTY — every corpus case is enforced. \
@@ -1046,6 +1193,61 @@ async fn one_vs_n_generation_quarantine_still_diverges() {
         eprintln!(
             "SKIP one_vs_n_generation_quarantine_still_diverges: no fixtures present \
              (set CQLITE_REQUIRE_FIXTURES=1 to fail-close)"
+        );
+    }
+}
+
+/// The unconditional must-run guard (issue #3220) must have a demonstrable failing
+/// branch, in BOTH lanes: a committed-fixture case that did not run has to be
+/// reported even when every sibling ran — the suite-wide `assert!(ran > 0)` /
+/// `assert!(pinned > 0)` blind spot this replaces.
+#[test]
+fn must_run_violations_flags_a_committed_case_that_did_not_run() {
+    let enforcing: Vec<&GenerationCase> = CORPUS
+        .iter()
+        .filter(|c| c.known_divergent.is_none())
+        .collect();
+    let quarantined: Vec<&GenerationCase> = CORPUS
+        .iter()
+        .filter(|c| c.known_divergent.is_some())
+        .collect();
+
+    for (lane, cases) in [("enforcing", &enforcing), ("quarantined", &quarantined)] {
+        // Everything ran: no violation.
+        let all: Vec<String> = cases.iter().map(|c| case_id(c)).collect();
+        assert!(
+            must_run_violations(cases.iter().copied(), &all).is_empty(),
+            "{lane}: no violation when every case ran"
+        );
+
+        // Drop ONE committed case while every sibling still ran — the exact state a
+        // resolution failure produces, and the one a suite-wide counter cannot see.
+        let dropped = cases
+            .iter()
+            .find(|c| c.must_run)
+            .unwrap_or_else(|| panic!("{lane} lane must own a must_run case"));
+        let without: Vec<String> = cases
+            .iter()
+            .filter(|c| c.table != dropped.table)
+            .map(|c| case_id(c))
+            .collect();
+        assert_eq!(
+            must_run_violations(cases.iter().copied(), &without),
+            vec![dropped.table],
+            "{lane}: a committed-fixture case that did not run must be reported even though \
+             every other case ran"
+        );
+
+        // A FETCHED-only case that skipped is NOT a violation: its binaries are
+        // gitignored, so absence on a minimal checkout is legitimate.
+        let committed_only: Vec<String> = cases
+            .iter()
+            .filter(|c| c.must_run)
+            .map(|c| case_id(c))
+            .collect();
+        assert!(
+            must_run_violations(cases.iter().copied(), &committed_only).is_empty(),
+            "{lane}: a gitignored-fixture case that skipped must not trip the guard"
         );
     }
 }

--- a/cqlite-core/tests/query_semantics_oracle_parity.rs
+++ b/cqlite-core/tests/query_semantics_oracle_parity.rs
@@ -41,6 +41,11 @@
 //! seam is never mutated concurrently by a sibling test in this binary.
 #![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
 
+// TABLE-granular fixture-root resolution, shared with the sibling dataset lanes
+// (issue #3220).
+#[path = "support/datasets_root.rs"]
+mod datasets_root;
+
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -112,45 +117,39 @@ struct Case {
 // Path resolution
 // ---------------------------------------------------------------------------
 
-/// Repo root = the parent of this crate's manifest dir (`<repo>/cqlite-core`).
-fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("cqlite-core has a parent repo dir")
-        .to_path_buf()
-}
+// Repo root, candidate `sstables/` roots and committed-schema resolution come from
+// the shared, TABLE-granular resolver (issue #3220). This file used to carry a
+// private copy of a KEYSPACE-granular `sstables_root`, byte-identical to the copies
+// in `point_vs_full_differential.rs` and `read_path_forcing_e2e.rs` — so the same
+// absence (a root holding the keyspace but not the table) surfaced as a confusing
+// hard FAIL here and a silent SKIP there.
+use datasets_root::{repo_root, schema_path};
 
-/// The `sstables/` root. Prefer `CQLITE_DATASETS_ROOT` when it actually holds the
-/// committed keyspace; otherwise fall back to the in-repo committed corpus (these
-/// fixtures are committed, not gitignored, so the repo copy is always present).
-fn sstables_root(keyspace: &str) -> Option<PathBuf> {
-    let candidates = [
-        std::env::var("CQLITE_DATASETS_ROOT")
-            .ok()
-            .map(|r| PathBuf::from(r).join("sstables")),
-        Some(
-            repo_root()
-                .join("test-data")
-                .join("datasets")
-                .join("sstables"),
-        ),
-    ];
+/// The candidate root that actually carries THIS case's fixture.
+///
+/// Table-granular (issue #3220): every candidate root is probed with the case's own
+/// `fixture_dir_prefix`/`sstable_prefix` and the first one holding the `Data.db`
+/// wins, so a `CQLITE_DATASETS_ROOT` corpus lacking a git-committed table falls
+/// through to the checkout instead of being committed to. When NO root resolves the
+/// fixture, a root merely holding the keyspace is returned so the caller's
+/// "dir absent" / "not fetched" messages still name a real path.
+fn sstables_root_for_case(case: &Case) -> Option<PathBuf> {
+    let candidates = datasets_root::sstables_root_candidates();
+    let data_db = format!("{}-Data.db", case.sstable_prefix);
     candidates
-        .into_iter()
-        .flatten()
-        .find(|root| root.join(keyspace).is_dir())
-}
-
-fn schema_path(file: &str) -> Option<PathBuf> {
-    let candidates = [
-        std::env::var("CQLITE_DATASETS_ROOT").ok().and_then(|r| {
-            PathBuf::from(r)
-                .parent()
-                .map(|p| p.join("schemas").join(file))
-        }),
-        Some(repo_root().join("test-data").join("schemas").join(file)),
-    ];
-    candidates.into_iter().flatten().find(|p| p.exists())
+        .iter()
+        .find(|root| {
+            fixture_dir(
+                root,
+                &case.keyspace,
+                &case.fixture_dir_prefix,
+                &case.sstable_prefix,
+            )
+            .map(|dir| dir.join(&data_db).exists())
+            .unwrap_or(false)
+        })
+        .or_else(|| candidates.iter().find(|r| r.join(&case.keyspace).is_dir()))
+        .cloned()
 }
 
 /// Resolve `<sstables>/<keyspace>/<prefix><uuid>/` for a case.
@@ -358,8 +357,16 @@ async fn run_case(case: &Case) -> Result<bool, String> {
         }
     }
 
-    let Some(root) = sstables_root(&case.keyspace) else {
-        let msg = format!("case {}: keyspace {} absent", case.id, case.keyspace);
+    let Some(root) = sstables_root_for_case(case) else {
+        // Names the table AND every root searched: "keyspace absent" was actively
+        // misleading when the keyspace existed and only the table did not (#3220).
+        let msg = format!(
+            "case {}: no candidate sstables root holds {}.{}* — {}",
+            case.id,
+            case.keyspace,
+            case.fixture_dir_prefix,
+            datasets_root::describe_roots()
+        );
         if require_fixtures() {
             return Err(format!("REQUIRE_FIXTURES: {msg}"));
         }

--- a/cqlite-core/tests/read_path_forcing_e2e.rs
+++ b/cqlite-core/tests/read_path_forcing_e2e.rs
@@ -38,70 +38,17 @@ fn require_fixtures() -> bool {
         .unwrap_or(false)
 }
 
-fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("cqlite-core has a parent repo dir")
-        .to_path_buf()
-}
+// TABLE-granular fixture-root resolution, shared with the sibling dataset lanes
+// (issue #3220): this file used to carry a private, byte-identical copy of a
+// KEYSPACE-granular `sstables_root` + `table_has_data` pair, which selects a corpus
+// root that may not hold the table and then reports the table as absent.
+#[path = "support/datasets_root.rs"]
+mod datasets_root;
 
-fn sstables_root() -> Option<PathBuf> {
-    let candidates = [
-        std::env::var("CQLITE_DATASETS_ROOT")
-            .ok()
-            .map(|r| PathBuf::from(r).join("sstables")),
-        Some(
-            repo_root()
-                .join("test-data")
-                .join("datasets")
-                .join("sstables"),
-        ),
-    ];
-    candidates
-        .into_iter()
-        .flatten()
-        .find(|root| root.join(KEYSPACE).is_dir())
-}
+use datasets_root::{describe_search, sstables_root_for_table};
 
 fn schema_path() -> Option<PathBuf> {
-    let candidates = [
-        std::env::var("CQLITE_DATASETS_ROOT").ok().and_then(|r| {
-            PathBuf::from(r)
-                .parent()
-                .map(|p| p.join("schemas").join(SCHEMA))
-        }),
-        Some(repo_root().join("test-data").join("schemas").join(SCHEMA)),
-    ];
-    candidates.into_iter().flatten().find(|p| p.exists())
-}
-
-fn table_has_data(root: &Path) -> bool {
-    let ks_dir = root.join(KEYSPACE);
-    let Ok(entries) = std::fs::read_dir(&ks_dir) else {
-        return false;
-    };
-    entries
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| {
-            p.is_dir()
-                && p.file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n.starts_with(&format!("{TABLE}-")))
-                    .unwrap_or(false)
-        })
-        .any(|dir| {
-            std::fs::read_dir(&dir)
-                .map(|rd| {
-                    rd.filter_map(|e| e.ok()).any(|e| {
-                        e.file_name()
-                            .to_str()
-                            .map(|n| n.ends_with("-Data.db"))
-                            .unwrap_or(false)
-                    })
-                })
-                .unwrap_or(false)
-        })
+    datasets_root::schema_path(SCHEMA)
 }
 
 async fn open_db(root: &Path, schema: &Path, mode: Option<ReadPathMode>) -> Database {
@@ -137,14 +84,10 @@ fn normalize(rows: &[QueryRow]) -> Vec<String> {
 
 /// Resolve the fixture paths, or `None` (SKIP / fail-closed) when absent.
 fn resolve() -> Option<(PathBuf, PathBuf)> {
-    let Some(root) = sstables_root() else {
-        handle_absent("keyspace absent");
+    let Some(root) = sstables_root_for_table(KEYSPACE, TABLE) else {
+        handle_absent(&describe_search(KEYSPACE, TABLE));
         return None;
     };
-    if !table_has_data(&root) {
-        handle_absent("no fetched *-Data.db");
-        return None;
-    }
     let Some(schema) = schema_path() else {
         handle_absent("schema absent");
         return None;

--- a/cqlite-core/tests/read_path_forcing_e2e.rs
+++ b/cqlite-core/tests/read_path_forcing_e2e.rs
@@ -13,8 +13,15 @@
 //!
 //! Assertions read the PER-QUERY `metadata.access_path` (not the process-global
 //! `access_path::last()` probe), so the three `#[tokio::test]`s are safe to run in
-//! parallel. Against a committed INT-partition-key fixture; SKIP-loud when the
-//! fixture is absent, fail-closed under `CQLITE_REQUIRE_FIXTURES=1`.
+//! parallel.
+//!
+//! Fixture contract (issue #3220): the fixture is COMMITTED to git, so it is present
+//! in every checkout and there is no legitimate absence — resolution failure is a hard
+//! FAILURE, UNCONDITIONALLY, with or without `CQLITE_REQUIRE_FIXTURES`. This lane runs
+//! under `core-tests`, which does NOT set that variable, so the previous
+//! require-fixtures-gated `SKIP` meant a resolution break would return early from all
+//! three tests and report green — the exact silent-skip defect #3220 exists to remove.
+//! Roots resolve TABLE-granularly via `support/datasets_root.rs`.
 #![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
 
 use std::collections::BTreeMap;
@@ -31,12 +38,6 @@ const KEYSPACE: &str = "test_compaction_tombstone_ttl";
 const TABLE: &str = "shadow_row_delete";
 const SCHEMA: &str = "compaction-tombstone-ttl-parity.cql";
 const PK_COLUMN: &str = "id";
-
-fn require_fixtures() -> bool {
-    std::env::var("CQLITE_REQUIRE_FIXTURES")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
 
 // TABLE-granular fixture-root resolution, shared with the sibling dataset lanes
 // (issue #3220): this file used to carry a private, byte-identical copy of a
@@ -82,24 +83,31 @@ fn normalize(rows: &[QueryRow]) -> Vec<String> {
         .collect()
 }
 
-/// Resolve the fixture paths, or `None` (SKIP / fail-closed) when absent.
-fn resolve() -> Option<(PathBuf, PathBuf)> {
-    let Some(root) = sstables_root_for_table(KEYSPACE, TABLE) else {
-        handle_absent(&describe_search(KEYSPACE, TABLE));
-        return None;
-    };
-    let Some(schema) = schema_path() else {
-        handle_absent("schema absent");
-        return None;
-    };
-    Some((root, schema))
-}
-
-fn handle_absent(msg: &str) {
-    if require_fixtures() {
-        panic!("REQUIRE_FIXTURES: {KEYSPACE}.{TABLE}: {msg}");
-    }
-    eprintln!("SKIP {KEYSPACE}.{TABLE}: {msg}");
+/// Resolve the fixture paths, or FAIL — never skip (issue #3220).
+///
+/// Both inputs are COMMITTED source: the SSTable binaries are force-added under
+/// `test-data/datasets/sstables/test_compaction_tombstone_ttl/shadow_row_delete-*`
+/// (`git ls-files`), and the schema is a committed `.cql` resolved checkout-relative
+/// (#3148). Neither can be legitimately absent in any checkout, so a failure here is
+/// a resolution defect and must be loud. Panicking (rather than returning `Option`)
+/// removes the early-return branch that let all three tests report green.
+fn resolve() -> (PathBuf, PathBuf) {
+    let root = sstables_root_for_table(KEYSPACE, TABLE).unwrap_or_else(|| {
+        panic!(
+            "{KEYSPACE}.{TABLE} is COMMITTED to git and must resolve in every checkout, \
+             unconditionally (issue #3220) — {}.\n  remedy: git restore --source=HEAD -- \
+             test-data/datasets/sstables (or fix root resolution — see \
+             tests/support/datasets_root.rs)",
+            describe_search(KEYSPACE, TABLE)
+        )
+    });
+    let schema = schema_path().unwrap_or_else(|| {
+        panic!(
+            "committed schema {SCHEMA} is unreadable — it is checkout-relative source \
+             (#3148), so this is a resolution defect, never a legitimate absence"
+        )
+    });
+    (root, schema)
 }
 
 /// Discover the first live INT partition key via an unforced (auto) scan.
@@ -119,9 +127,7 @@ async fn first_live_pk(db: &Database) -> Option<i64> {
 
 #[tokio::test]
 async fn forced_full_records_forced_fallback_and_matches_auto_rows() {
-    let Some((root, schema)) = resolve() else {
-        return;
-    };
+    let (root, schema) = resolve();
     let auto_db = open_db(&root, &schema, None).await;
     let Some(pk) = first_live_pk(&auto_db).await else {
         panic!("fixture {KEYSPACE}.{TABLE} has no live partition to point-query");
@@ -153,9 +159,7 @@ async fn forced_full_records_forced_fallback_and_matches_auto_rows() {
 
 #[tokio::test]
 async fn forced_point_on_non_targeted_query_fails_closed() {
-    let Some((root, schema)) = resolve() else {
-        return;
-    };
+    let (root, schema) = resolve();
     let point_db = open_db(&root, &schema, Some(ReadPathMode::Point)).await;
     // A full-table SELECT (no partition key constraint) is NOT partition-targeted,
     // so forced point must fail closed rather than silently full-scan.
@@ -174,9 +178,7 @@ async fn forced_point_on_non_targeted_query_fails_closed() {
 
 #[tokio::test]
 async fn forced_point_on_full_pk_takes_targeted_path() {
-    let Some((root, schema)) = resolve() else {
-        return;
-    };
+    let (root, schema) = resolve();
     let auto_db = open_db(&root, &schema, None).await;
     let Some(pk) = first_live_pk(&auto_db).await else {
         panic!("fixture {KEYSPACE}.{TABLE} has no live partition to point-query");

--- a/cqlite-core/tests/support/datasets_root.rs
+++ b/cqlite-core/tests/support/datasets_root.rs
@@ -3,9 +3,11 @@
 //!
 //! # The defect this module exists to remove
 //!
-//! Three lanes — `point_vs_full_differential.rs` (+ its `one_vs_n_generation`
-//! submodule), `query_semantics_oracle_parity.rs` and `read_path_forcing_e2e.rs` —
-//! each carried a private, byte-identical copy of:
+//! FOUR lanes carried a private, byte-identical copy of the same broken selection —
+//! the three in `cqlite-core/tests` reconciled here (`point_vs_full_differential.rs`
+//! + its `one_vs_n_generation` submodule, `query_semantics_oracle_parity.rs`,
+//! `read_path_forcing_e2e.rs`) and a fourth, `cqlite-flight/tests/
+//! query_semantics_flight_parity.rs`, which is **NOT** reconciled (see below):
 //!
 //! ```ignore
 //! candidates.into_iter().flatten().find(|root| root.join(keyspace).is_dir())
@@ -36,6 +38,28 @@
 //! Presence is judged by an actual `*-Data.db` component, never by directory
 //! existence: the repo commits JSONL sidecars for fixtures whose binaries are
 //! gitignored, so `<table>-<uuid>/` can exist with no readable SSTable in it.
+//!
+//! # The FOURTH lane, and why it is deliberately not reconciled here
+//!
+//! `cqlite-flight/tests/query_semantics_flight_parity.rs` still carries the
+//! keyspace-granular `sstables_root(keyspace)` copy. It is LOWER RISK — its gate
+//! component pins `CQLITE_REQUIRE_FIXTURES=1`, so a miss FAILs there instead of
+//! skipping silently — and reconciling it is NOT a mechanical swap:
+//!
+//!   * it is a DIFFERENT CRATE, so it cannot reach this module without real
+//!     plumbing (a shared test-support crate wired as a `dev-dependency`, or a
+//!     cross-crate `#[path]` include whose own nested `#[path]` to
+//!     `test-data/support/fixture_roots.rs` then resolves from a foreign manifest);
+//!   * its lookup is GENERATION-granular, not table-granular: `fixture_dir` requires
+//!     a specific `<sstable_prefix>-Data.db` (`nb-1-big-…`) inside a
+//!     `<prefix><uuid>/` directory, where [`table_has_data`] accepts ANY `*-Data.db`,
+//!     so the shared helper would need a new generation-aware entry point; and
+//!   * its `schema_path` climbs `..` from `CQLITE_DATASETS_ROOT` — the #3148 trap
+//!     this module refuses — so swapping it in is a behaviour change to that lane,
+//!     not a refactor.
+//!
+//! Tracked as follow-up work rather than smuggled into #3220. Update this note (and
+//! the count above) if that lane moves onto the shared helper.
 //!
 //! # Roots, and which one owns what
 //!

--- a/cqlite-core/tests/support/datasets_root.rs
+++ b/cqlite-core/tests/support/datasets_root.rs
@@ -130,6 +130,17 @@ pub fn sstables_root_for_table(keyspace: &str, table: &str) -> Option<PathBuf> {
         .find(|root| table_has_data(root, keyspace, table))
 }
 
+/// A diagnostic naming every candidate root, for callers whose fixture lookup is not
+/// `<keyspace>/<table>-*` shaped (e.g. the oracle's `fixture_dir_prefix` form).
+pub fn describe_roots() -> String {
+    let roots = sstables_root_candidates()
+        .iter()
+        .map(|r| r.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("searched [{roots}] (fetch: bash test-data/scripts/fetch-datasets.sh)")
+}
+
 /// A diagnostic naming EVERY root searched for `<keyspace>.<table>` — so a SKIP or a
 /// fail-closed message says where the lane looked, not merely that something was
 /// "absent" (issue #3220: the previous message named neither the table nor the roots,

--- a/cqlite-core/tests/support/datasets_root.rs
+++ b/cqlite-core/tests/support/datasets_root.rs
@@ -67,19 +67,54 @@ pub fn repo_root() -> PathBuf {
         .unwrap_or_else(|| manifest.parent().unwrap_or(manifest).to_path_buf())
 }
 
+/// TEST-HARNESS ONLY: substitute for the CHECKOUT candidate root.
+///
+/// # Why this seam has to exist
+///
+/// The fail-closed contract has two directions, and both must be DEMONSTRABLE
+/// (#3220 AC2): a fixture that is *present but empty* must fail, and a fixture that
+/// is *absent from every candidate root* must fail. The first is easy to stage —
+/// point `CQLITE_DATASETS_ROOT` at a temp root holding a truncated `Data.db`. The
+/// second is not: the checkout candidate is derived from `CARGO_MANIFEST_DIR`, a
+/// COMPILE-TIME constant, so no runtime environment can make a committed fixture
+/// invisible. Staging it for real would mean deleting a git-tracked fixture from the
+/// working tree — which also trips the gate's mid-run `tree-integrity` check — or
+/// recompiling the whole crate inside a throwaway worktree, far too slow for a
+/// committed self-test. So the candidate list takes this substitution instead.
+///
+/// # Why it cannot weaken anything
+///
+/// It can only ever REMOVE fixtures from view, never add or fake one: every
+/// resolution still requires a real `*-Data.db` under the substituted root. So the
+/// only reachable effect of a stray value is that lanes FAIL (a `must_run` case that
+/// did not run), never that one passes vacuously — the safe direction. It lives in
+/// test-support code compiled solely into test binaries, never into the library, and
+/// its own behavior is asserted by `scripts/tests/test_point_vs_full_failclosed.sh`.
+pub const CHECKOUT_SSTABLES_ROOT_OVERRIDE_ENV: &str = "CQLITE_TEST_CHECKOUT_SSTABLES_ROOT";
+
 /// Every `sstables/` root to search, in preference order: the `CQLITE_DATASETS_ROOT`
 /// corpus (when set and present) first, then the checkout's committed corpus.
 ///
 /// Deduplicated, so a `CQLITE_DATASETS_ROOT` that already points at the checkout does
 /// not report the same path twice in a diagnostic.
+///
+/// Note this is an ORDER, not a PREFERENCE: [`first_root_with_table`] picks by
+/// EVIDENCE (which root actually holds the table), so the order only breaks ties
+/// between roots that can both serve the request. Neither root is a superset of the
+/// other — the fetched corpus carries keyspaces the checkout does not, and the
+/// checkout carries committed parity fixtures the fetched corpus does not — so any
+/// fixed preference between them is wrong for one set of tables (#3104).
 pub fn sstables_root_candidates() -> Vec<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Some(env_root) = fixture_roots::datasets_root_if_present() {
         candidates.push(env_root.join("sstables"));
     }
-    let checkout = fixture_roots::checkout_test_data_dir()
-        .join("datasets")
-        .join("sstables");
+    let checkout = match std::env::var_os(CHECKOUT_SSTABLES_ROOT_OVERRIDE_ENV) {
+        Some(v) if !v.is_empty() => PathBuf::from(v),
+        _ => fixture_roots::checkout_test_data_dir()
+            .join("datasets")
+            .join("sstables"),
+    };
     if !candidates.contains(&checkout) {
         candidates.push(checkout);
     }

--- a/cqlite-core/tests/support/datasets_root.rs
+++ b/cqlite-core/tests/support/datasets_root.rs
@@ -125,9 +125,25 @@ pub fn table_has_data(root: &Path, keyspace: &str, table: &str) -> bool {
 /// it commits to a root that may not hold the table and reports a fixture that exists
 /// in the checkout as absent.
 pub fn sstables_root_for_table(keyspace: &str, table: &str) -> Option<PathBuf> {
-    sstables_root_candidates()
-        .into_iter()
+    first_root_with_table(&sstables_root_candidates(), keyspace, table).map(Path::to_path_buf)
+}
+
+/// PURE form of [`sstables_root_for_table`], parameterized on the candidate list.
+///
+/// Factored so the selection rule is testable against SYNTHETIC roots
+/// (`issue_3220_datasets_root_resolution.rs`): the real candidate list is half
+/// environment and half a COMPILE-TIME checkout path, so a test reading it can only
+/// ever observe this machine's layout — and the defect (#3220) was a rule that looked
+/// fine on a machine where every root happened to hold every table.
+pub fn first_root_with_table<'a>(
+    roots: &'a [PathBuf],
+    keyspace: &str,
+    table: &str,
+) -> Option<&'a Path> {
+    roots
+        .iter()
         .find(|root| table_has_data(root, keyspace, table))
+        .map(PathBuf::as_path)
 }
 
 /// A diagnostic naming every candidate root, for callers whose fixture lookup is not

--- a/cqlite-core/tests/support/datasets_root.rs
+++ b/cqlite-core/tests/support/datasets_root.rs
@@ -5,9 +5,9 @@
 //!
 //! FOUR lanes carried a private, byte-identical copy of the same broken selection —
 //! the three in `cqlite-core/tests` reconciled here (`point_vs_full_differential.rs`
-//! + its `one_vs_n_generation` submodule, `query_semantics_oracle_parity.rs`,
-//! `read_path_forcing_e2e.rs`) and a fourth, `cqlite-flight/tests/
-//! query_semantics_flight_parity.rs`, which is **NOT** reconciled (see below):
+//! with its `one_vs_n_generation` submodule, `query_semantics_oracle_parity.rs` and
+//! `read_path_forcing_e2e.rs`) plus a fourth in `cqlite-flight`
+//! (`query_semantics_flight_parity.rs`) which is **NOT** reconciled (see below):
 //!
 //! ```ignore
 //! candidates.into_iter().flatten().find(|root| root.join(keyspace).is_dir())

--- a/cqlite-core/tests/support/datasets_root.rs
+++ b/cqlite-core/tests/support/datasets_root.rs
@@ -1,0 +1,159 @@
+//! TABLE-granular datasets-root resolution for the dataset-backed read-path lanes
+//! (issue #3220).
+//!
+//! # The defect this module exists to remove
+//!
+//! Three lanes — `point_vs_full_differential.rs` (+ its `one_vs_n_generation`
+//! submodule), `query_semantics_oracle_parity.rs` and `read_path_forcing_e2e.rs` —
+//! each carried a private, byte-identical copy of:
+//!
+//! ```ignore
+//! candidates.into_iter().flatten().find(|root| root.join(keyspace).is_dir())
+//! ```
+//!
+//! That selects a corpus root by **keyspace**, then COMMITS to it with no fallback,
+//! even though what every caller actually needs is a specific **table**. A root that
+//! holds the keyspace but not the table therefore wins the selection and the table is
+//! then declared absent — while a *different* candidate root (typically the checkout's
+//! own committed corpus) has the fixture right there.
+//!
+//! That is not hypothetical. On a fleet box `fetch-datasets.sh --verify-only` names
+//! `CQLITE_DATASETS_ROOT=/data/datasets`, whose `sstables/test_da/` holds
+//! `wide_table` but NOT the git-committed `multiclustering_table` (#3032). The
+//! keyspace-granular resolver picked `/data/datasets/sstables`, missed the table, and
+//! the #3032 multi-component clustering differential case SKIPPED SILENTLY while the
+//! suite reported green (#3220) — precisely the "dataset-dependent assertion that can
+//! pass without ever running" class the fail-closed doctrine exists to eliminate.
+//!
+//! # The rule
+//!
+//! [`sstables_root_for_table`] walks EVERY candidate root in preference order and
+//! returns the first one that actually carries `<keyspace>/<table>-*/…-Data.db`. A
+//! committed fixture is therefore always found in the checkout, whatever a machine's
+//! `CQLITE_DATASETS_ROOT` happens to contain. Modelled on the already-correct
+//! `issue_3032_multiclustering_clustering_slice_select.rs::datasets_root`.
+//!
+//! Presence is judged by an actual `*-Data.db` component, never by directory
+//! existence: the repo commits JSONL sidecars for fixtures whose binaries are
+//! gitignored, so `<table>-<uuid>/` can exist with no readable SSTable in it.
+//!
+//! # Roots, and which one owns what
+//!
+//! Dataset (fetched, relocatable) vs schemas (committed source) resolution is owned by
+//! `test-data/support/fixture_roots.rs` (#3131/#3148); this module builds the
+//! table-granular search on top of it rather than re-deriving either root. In
+//! particular [`schema_path`] resolves the COMMITTED schema fixtures
+//! checkout-relative — it never climbs `..` from the datasets root, the symlink trap
+//! #3148 removed.
+//!
+//! Included with `#[path = "support/datasets_root.rs"] mod datasets_root;` from a
+//! `cqlite-core/tests/*.rs` target root.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+#[path = "../../../test-data/support/fixture_roots.rs"]
+pub mod fixture_roots;
+
+/// The repository root (the parent of `cqlite-core/`).
+///
+/// Anchored on the workspace-root `Cargo.toml` marker (see
+/// [`fixture_roots::workspace_root`]), falling back to the manifest's parent — the
+/// shape the private copies used — when no `[workspace]` manifest is found.
+pub fn repo_root() -> PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    fixture_roots::workspace_root()
+        .unwrap_or_else(|| manifest.parent().unwrap_or(manifest).to_path_buf())
+}
+
+/// Every `sstables/` root to search, in preference order: the `CQLITE_DATASETS_ROOT`
+/// corpus (when set and present) first, then the checkout's committed corpus.
+///
+/// Deduplicated, so a `CQLITE_DATASETS_ROOT` that already points at the checkout does
+/// not report the same path twice in a diagnostic.
+pub fn sstables_root_candidates() -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(env_root) = fixture_roots::datasets_root_if_present() {
+        candidates.push(env_root.join("sstables"));
+    }
+    let checkout = fixture_roots::checkout_test_data_dir()
+        .join("datasets")
+        .join("sstables");
+    if !candidates.contains(&checkout) {
+        candidates.push(checkout);
+    }
+    candidates
+}
+
+/// True when `<root>/<keyspace>` holds at least one `<table>-*` directory carrying a
+/// `*-Data.db` — i.e. the binaries are really there, not just the JSONL sidecars.
+pub fn table_has_data(root: &Path, keyspace: &str, table: &str) -> bool {
+    let ks_dir = root.join(keyspace);
+    let Ok(entries) = std::fs::read_dir(&ks_dir) else {
+        return false;
+    };
+    let prefix = format!("{table}-");
+    entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(&prefix))
+                    .unwrap_or(false)
+        })
+        .any(|dir| {
+            std::fs::read_dir(&dir)
+                .map(|rd| {
+                    rd.filter_map(|e| e.ok()).any(|e| {
+                        e.file_name()
+                            .to_str()
+                            .map(|n| n.ends_with("-Data.db"))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        })
+}
+
+/// The first candidate `sstables/` root that actually carries
+/// `<keyspace>/<table>-*/…-Data.db`, or `None` when no candidate does.
+///
+/// TABLE-granular BY CONTRACT: selecting on the keyspace alone is the #3220 defect —
+/// it commits to a root that may not hold the table and reports a fixture that exists
+/// in the checkout as absent.
+pub fn sstables_root_for_table(keyspace: &str, table: &str) -> Option<PathBuf> {
+    sstables_root_candidates()
+        .into_iter()
+        .find(|root| table_has_data(root, keyspace, table))
+}
+
+/// A diagnostic naming EVERY root searched for `<keyspace>.<table>` — so a SKIP or a
+/// fail-closed message says where the lane looked, not merely that something was
+/// "absent" (issue #3220: the previous message named neither the table nor the roots,
+/// which is what made the same absence read as a confusing hard FAIL in one lane and a
+/// silent SKIP in another).
+pub fn describe_search(keyspace: &str, table: &str) -> String {
+    let roots = sstables_root_candidates()
+        .iter()
+        .map(|r| r.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "no *-Data.db for {keyspace}.{table} under any candidate sstables root [{roots}] \
+         (fetch: bash test-data/scripts/fetch-datasets.sh)"
+    )
+}
+
+/// Absolute path to a COMMITTED schema fixture, or `None` when it is unreadable.
+///
+/// Delegates to `fixture_roots` (checkout-relative, honoring an ABSOLUTE
+/// `CQLITE_SCHEMAS_ROOT` override), so the schemas root is never derived from
+/// `CQLITE_DATASETS_ROOT` by climbing `..` (#3148). Returns `Option` rather than
+/// panicking so a caller keeps its own SKIP-vs-fail-closed decision.
+pub fn schema_path(schema_file: &str) -> Option<PathBuf> {
+    let (root, source) = fixture_roots::schemas_root_resolved();
+    fixture_roots::resolve_schema_path(&root, source, schema_file).ok()
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4815,6 +4815,15 @@ run_compaction_byte_parity() {
 # falls back to the in-repo committed fixture when CQLITE_DATASETS_ROOT names a corpus
 # that lacks it. Under the previous keyspace-granular resolution the case skipped.
 #
+# Third invocation — scripts/tests/test_point_vs_full_failclosed.sh (#3220 AC2), the
+# POSITIVE CONTROL for everything above: a green lane proves nothing unless the same
+# lane FAILs on a fixture that is absent from every candidate root AND on one that is
+# present-but-empty. Both are staged in temp dirs (the tracked fixture and
+# $CQLITE_DATASETS_ROOT are never mutated — asserted by the self-test) and the absent
+# staging is surgical, hiding exactly one fixture, so the assertion cannot be satisfied
+# by some other case failing. It runs HERE rather than in tooling-tests because it
+# drives the very test binary this component has just built.
+#
 # Fixture policy: FAIL-CLOSED, unconditionally. Unlike the fetched-corpus lanes,
 # these fixtures are COMMITTED to git (test-data/datasets/sstables/test_da/
 # multiclustering_table-fd74ad508d2311f1a29b6d2c15dcffdf/**, 9 components incl. the
@@ -4838,7 +4847,8 @@ run_bti_multiclustering() {
         --test issue_3032_multiclustering_clustering_slice_select >"$log" 2>&1 \
     && env ${CQLITE_DATASETS_ROOT:+CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT"} \
       cargo test -p cqlite-core --features "state_machine cli-helpers" \
-        --test point_vs_full_differential >>"$log" 2>&1; then
+        --test point_vs_full_differential >>"$log" 2>&1 \
+    && bash "$REPO_ROOT/scripts/tests/test_point_vs_full_failclosed.sh" >>"$log" 2>&1; then
     status=PASS
   else
     status=FAIL

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4802,7 +4802,12 @@ run_compaction_byte_parity() {
 # both files asserts instead of skipping.
 #
 # point_vs_full_differential is run in a SECOND invocation, deliberately WITHOUT
-# CQLITE_REQUIRE_FIXTURES: most of its corpus (test_tomb/**) is FETCHED and gitignored,
+# CQLITE_REQUIRE_FIXTURES — enforced with `env -u`, not merely by omitting it: plain
+# `env` INHERITS an exported value, and exporting CQLITE_REQUIRE_FIXTURES=1 is routine
+# after a manual fail-closed run. Inherited, the target's `skipped.is_empty()` branch
+# fires on any box lacking the fetched test_tomb corpus and this component FAILs for a
+# reason unrelated to the fixture it exists to guard (#3220 review B3/R1).
+# Why it must not be pinned: most of its corpus (test_tomb/**) is FETCHED and gitignored,
 # so pinning that variable here would make this component depend on the fetched corpus
 # and break its "no fetched corpus at all" contract below. Its fail-closure instead
 # comes from the target itself — `TableCase::must_run`, asserted UNCONDITIONALLY, so
@@ -4839,13 +4844,17 @@ run_bti_multiclustering() {
   local log="$LOG_DIR/$name.log"
   local start end status
   start=$(date +%s)
+  # An ARRAY, not `${VAR:+NAME="$VAR"}`: the unquoted parameter-expansion form
+  # word-splits a root containing whitespace, and `env` would then run its second
+  # word as the command.
+  local -a ds_env=()
+  [ -n "${CQLITE_DATASETS_ROOT:-}" ] && ds_env=(CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT")
   echo ">>> [$name] compound-clustering BTI trie shape + SELECT + point-vs-full lanes, fail-closed (#3032/#3220)"
-  if env CQLITE_REQUIRE_FIXTURES=1 \
-      ${CQLITE_DATASETS_ROOT:+CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT"} \
+  if env CQLITE_REQUIRE_FIXTURES=1 "${ds_env[@]}" \
       cargo test -p cqlite-core --features "state_machine cli-helpers" \
         --test issue_3032_multiclustering_rows_trie_shape \
         --test issue_3032_multiclustering_clustering_slice_select >"$log" 2>&1 \
-    && env ${CQLITE_DATASETS_ROOT:+CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT"} \
+    && env -u CQLITE_REQUIRE_FIXTURES "${ds_env[@]}" \
       cargo test -p cqlite-core --features "state_machine cli-helpers" \
         --test point_vs_full_differential >>"$log" 2>&1 \
     && bash "$REPO_ROOT/scripts/tests/test_point_vs_full_failclosed.sh" >>"$log" 2>&1; then

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -118,13 +118,16 @@
 #                      the write-support-gated targets derived from Cargo.toml
 #                      required-features + two self-gated ground-truth targets. New
 #                      files are auto-covered; fails closed on zero targets.
-#   bti-multiclustering  the compound-clustering BTI ('da') lane (issue #3032):
+#   bti-multiclustering  the compound-clustering BTI ('da') lane (issue #3032/#3220):
 #                      issue_3032_multiclustering_rows_trie_shape +
 #                      issue_3032_multiclustering_clustering_slice_select against the
 #                      COMMITTED test_da/multiclustering_table fixture, pinned to
 #                      CQLITE_REQUIRE_FIXTURES=1 so an absent fixture FAILs rather
-#                      than silently skipping. Unconditionally fail-closed (the
-#                      fixture is in git, so it is present in every checkout).
+#                      than silently skipping, PLUS point_vs_full_differential (#3220)
+#                      whose AC6 case compares the point and full READ PATHS over that
+#                      same fixture and is fail-closed by its own must_run assertion.
+#                      Unconditionally fail-closed (the fixtures are in git, so they
+#                      are present in every checkout).
 #   python-bindings    maturin develop + pytest bindings/python/tests in a throwaway
 #                      venv; SKIPs (never silently PASSes) if python3 is unavailable.
 #                      Set RUN_SLOW_TESTS=1 to also run the CLI-parity suite.
@@ -4781,17 +4784,36 @@ run_compaction_byte_parity() {
   echo ">>> [$name] $status ($((end - start))s)"
 }
 
-# bti-multiclustering: the compound-clustering BTI (`da`) lane (issue #3032). The
-# two targets read the real Cassandra 5.0 `test_da/multiclustering_table` fixture —
-# a 3-component PRIMARY KEY ((pk), bucket, seq) whose Rows.db trie is the only
-# in-corpus oracle for the OSS50 byte-comparable clustering encoding and for the
-# `ClusteringPrefix.Kind` bound markers.
+# bti-multiclustering: the compound-clustering BTI (`da`) lane (issue #3032, extended
+# by #3220). The targets read the real Cassandra 5.0 `test_da/multiclustering_table`
+# fixture — a 3-component PRIMARY KEY ((pk), bucket, seq) whose Rows.db trie is the
+# only in-corpus oracle for the OSS50 byte-comparable clustering encoding and for the
+# `ClusteringPrefix.Kind` bound markers. Coverage:
+#   * issue_3032_multiclustering_rows_trie_shape          (trie/byte shape)
+#   * issue_3032_multiclustering_clustering_slice_select  (SELECT vs JSONL golden)
+#   * point_vs_full_differential                          (#3220: the AC6 point-vs-full
+#     differential case over the SAME fixture — the only lane comparing the two READ
+#     PATHS on a multi-component clustering key)
 #
-# Why a DEDICATED component (issue #3032 roborev B1): both targets self-skip when
-# the fixture is missing, and core-tests runs them WITHOUT CQLITE_REQUIRE_FIXTURES —
-# so a deleted/renamed fixture would turn both into silent green no-ops. This lane
-# pins them to CQLITE_REQUIRE_FIXTURES=1, under which every absence path in both
-# files asserts instead of skipping.
+# Why a DEDICATED component (issue #3032 roborev B1): the targets self-skip when the
+# fixture is missing, and core-tests runs them WITHOUT CQLITE_REQUIRE_FIXTURES — so a
+# deleted/renamed fixture would turn them into silent green no-ops. This lane pins the
+# two #3032 targets to CQLITE_REQUIRE_FIXTURES=1, under which every absence path in
+# both files asserts instead of skipping.
+#
+# point_vs_full_differential is run in a SECOND invocation, deliberately WITHOUT
+# CQLITE_REQUIRE_FIXTURES: most of its corpus (test_tomb/**) is FETCHED and gitignored,
+# so pinning that variable here would make this component depend on the fetched corpus
+# and break its "no fetched corpus at all" contract below. Its fail-closure instead
+# comes from the target itself — `TableCase::must_run`, asserted UNCONDITIONALLY, so
+# every COMMITTED-fixture case (both test_da cases + the two committed
+# test_compaction_tombstone_ttl ones) must have run while the fetched-only cases still
+# SKIP cleanly on a minimal checkout (#3220).
+#
+# Ordering note (#3220): this is only meaningful because that target now resolves its
+# root TABLE-granularly (cqlite-core/tests/support/datasets_root.rs) and therefore
+# falls back to the in-repo committed fixture when CQLITE_DATASETS_ROOT names a corpus
+# that lacks it. Under the previous keyspace-granular resolution the case skipped.
 #
 # Fixture policy: FAIL-CLOSED, unconditionally. Unlike the fetched-corpus lanes,
 # these fixtures are COMMITTED to git (test-data/datasets/sstables/test_da/
@@ -4808,12 +4830,15 @@ run_bti_multiclustering() {
   local log="$LOG_DIR/$name.log"
   local start end status
   start=$(date +%s)
-  echo ">>> [$name] compound-clustering BTI trie shape + SELECT lanes, fail-closed (#3032)"
+  echo ">>> [$name] compound-clustering BTI trie shape + SELECT + point-vs-full lanes, fail-closed (#3032/#3220)"
   if env CQLITE_REQUIRE_FIXTURES=1 \
       ${CQLITE_DATASETS_ROOT:+CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT"} \
       cargo test -p cqlite-core --features "state_machine cli-helpers" \
         --test issue_3032_multiclustering_rows_trie_shape \
-        --test issue_3032_multiclustering_clustering_slice_select >"$log" 2>&1; then
+        --test issue_3032_multiclustering_clustering_slice_select >"$log" 2>&1 \
+    && env ${CQLITE_DATASETS_ROOT:+CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT"} \
+      cargo test -p cqlite-core --features "state_machine cli-helpers" \
+        --test point_vs_full_differential >>"$log" 2>&1; then
     status=PASS
   else
     status=FAIL

--- a/scripts/tests/test_point_vs_full_failclosed.sh
+++ b/scripts/tests/test_point_vs_full_failclosed.sh
@@ -107,13 +107,45 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 2. ABSENT: no candidate root carries the table.
+# 2. ABSENT: no candidate root carries THIS table — while every other fixture
+#    stays resolvable.
+#
+#    The staging is deliberately SURGICAL, not "hide the whole corpus". Hiding
+#    everything makes every case skip, so the guard fires for some other committed
+#    case and the assertion passes even with `multiclustering_table`'s `must_run`
+#    removed — i.e. exactly the regression this file exists to catch would slip
+#    through (measured: a coarse staging did not discriminate). So the checkout
+#    candidate is mirrored by SYMLINK, table by table, minus the one fixture, and the
+#    expected message is the EXACT one-element list.
 # ---------------------------------------------------------------------------
-mkdir -p "$tmp/absent-env/sstables/test_da" "$tmp/absent-checkout/sstables/test_da"
+absent_checkout="$tmp/absent-checkout/sstables"
+mkdir -p "$absent_checkout" "$tmp/absent-env/sstables"
+src_sstables="$REPO/test-data/datasets/sstables"
+for ks_dir in "$src_sstables"/*/; do
+  [ -d "$ks_dir" ] || continue
+  ks_name=$(basename "$ks_dir")
+  mkdir -p "$absent_checkout/$ks_name"
+  for tbl_dir in "$ks_dir"*/; do
+    [ -d "$tbl_dir" ] || continue
+    tbl_name=$(basename "$tbl_dir")
+    case "$tbl_name" in
+      multiclustering_table-*) continue ;;   # the ONLY thing hidden
+    esac
+    ln -s "${tbl_dir%/}" "$absent_checkout/$ks_name/$tbl_name"
+  done
+done
+if [ -d "$absent_checkout/test_da" ] \
+   && [ -n "$(ls -A "$absent_checkout/test_da" 2>/dev/null)" ] \
+   && [ ! -e "$absent_checkout/test_da/$(basename "$FIXTURE_REL")" ]; then
+  ok "absent: staging is surgical (test_da present with sibling tables, fixture hidden)"
+else
+  bad "absent: staging is wrong — test_da must exist with siblings and without the fixture"
+fi
+
 absent_out="$tmp/absent.log"
 run_lane "$absent_out" \
   CQLITE_DATASETS_ROOT="$tmp/absent-env" \
-  CQLITE_TEST_CHECKOUT_SSTABLES_ROOT="$tmp/absent-checkout/sstables"
+  CQLITE_TEST_CHECKOUT_SSTABLES_ROOT="$absent_checkout"
 absent_rc=$?
 if [ "$absent_rc" -ne 0 ]; then
   ok "absent: the lane FAILS when no candidate root holds the fixture (rc=$absent_rc)"
@@ -121,15 +153,23 @@ else
   bad "absent: the lane PASSED with the fixture absent from every candidate root — \
 this is the #3220 silent-skip defect; see $absent_out"
 fi
-if grep -q "committed-fixture case(s) did NOT run" "$absent_out" \
-   && grep -q "multiclustering_table" "$absent_out"; then
-  ok "absent: the failure names the unconditional must_run guard and the case"
+if grep -q 'committed-fixture case(s) did NOT run: \["multiclustering_table"\]' "$absent_out"; then
+  ok "absent: the unconditional must_run guard names EXACTLY the hidden case"
 else
-  bad "absent: the failure does not name the must_run guard + multiclustering_table \
-(it may be failing for an unrelated reason); see $absent_out"
+  bad "absent: no 'did NOT run: [\"multiclustering_table\"]' — the guard did not fire \
+for the hidden fixture (a failure for any other reason does not prove the contract); \
+see $absent_out"
 fi
-# The keyspace dir EXISTS in both staged roots, so this case also pins the specific
-# defect: keyspace-granular selection would have accepted these roots.
+# The sibling committed case still ran in that same run: the failure above is the
+# guard firing for the hidden fixture, not the corpus being unavailable.
+if grep -q "PASS test_da.wide_table" "$absent_out"; then
+  ok "absent: sibling committed cases still ran (the staging hid one fixture only)"
+else
+  bad "absent: test_da.wide_table did not run — the staging hid more than intended, so \
+the guard's target is ambiguous; see $absent_out"
+fi
+# The keyspace dir EXISTS in the staged checkout, so this case also pins the specific
+# defect: keyspace-granular selection would have accepted that root.
 if grep -q "no \*-Data.db for test_da.multiclustering_table under any candidate" "$absent_out"; then
   ok "absent: resolution reports searching EVERY candidate root, per table"
 else

--- a/scripts/tests/test_point_vs_full_failclosed.sh
+++ b/scripts/tests/test_point_vs_full_failclosed.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Regression test for issue #3220 AC2: the point-vs-full differential lane must FAIL
+# — never skip green — in BOTH fixture-absence directions.
+#
+# POSITIVE CONTROL is the point of this file. #3220 existed because the lane's
+# green was never proven to be a DECISION: with `CQLITE_DATASETS_ROOT=/data/datasets`
+# (a corpus holding `test_da/` but not the git-committed
+# `test_da/multiclustering_table-*`), the #3032 AC6 case skipped silently while the
+# suite reported PASS. So a green run alone means nothing here; each case below
+# stages a layout the lane MUST reject, and asserts the rejection text.
+#
+# The three cases:
+#   control  — the ambient corpus: the lane PASSES and the committed BTI case RUNS.
+#              Without this, the two failures below could equally be a broken harness.
+#   absent   — NO candidate root holds `multiclustering_table-*/…-Data.db`: the
+#              unconditional `must_run` guard FAILs (a resolver that falls back to the
+#              checkout must still fail loudly when neither root has the table).
+#   empty    — the fixture dir and its `-Data.db` EXIST but the file is empty (0 rows):
+#              the anti-vacuous slice-count anchors FAIL rather than comparing 0 == 0
+#              ("never let a dataset-dependent test pass on an empty dataset").
+#
+# Safety: nothing here mutates `$CQLITE_DATASETS_ROOT` or the git-tracked fixture —
+# every staged root is a temp dir, and case 4 re-asserts the tracked fixture is
+# untouched (a self-test that dirtied the worktree would also trip the gate's mid-run
+# tree-integrity check).
+#
+# Run standalone:   bash scripts/tests/test_point_vs_full_failclosed.sh
+# Or via the gate:  scripts/agent-gate.sh runs it inside `bti-multiclustering`, where
+#                   the test binary it drives is already built.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+FIXTURE_REL="test-data/datasets/sstables/test_da/multiclustering_table-fd74ad508d2311f1a29b6d2c15dcffdf"
+DATA_DB="da-2-bti-Data.db"
+TEST_TARGET="point_vs_full_differential"
+TEST_NAME="point_vs_full_differential_equality"
+
+# #2751 defense-in-depth: never clobber an inherited gate summary path.
+unset AGENT_GATE_SUMMARY_FILE
+# The guard under test is the UNCONDITIONAL one, so an inherited
+# CQLITE_REQUIRE_FIXTURES must not decide any case (it would also fail the control on
+# a machine without the fetched corpus).
+unset CQLITE_REQUIRE_FIXTURES
+# Scrub the seam this file itself drives, so a stale export cannot pre-decide a case.
+unset CQLITE_TEST_CHECKOUT_SSTABLES_ROOT
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# Scratch root, VALIDATED before anything is built under it and before the cleanup
+# trap is armed: this script runs without `errexit` (every case must run, so one
+# failure cannot hide the rest), so an unchecked `mktemp -d` would leave `$tmp` empty,
+# resolve every derived path under `/`, and hand the EXIT trap an `rm -rf ""`.
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/pvf-failclosed.XXXXXX") || {
+  echo "FATAL: mktemp -d failed; refusing to run with an unset scratch root" >&2
+  exit 1
+}
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "FATAL: mktemp -d produced no usable directory ('$tmp'); refusing to run" >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+
+# The committed fixture must be there for ANY of this to mean anything: the lane's
+# expected behavior in the control case is "it runs", and both failure cases are
+# defined relative to it. An absent fixture is a hard error, not a skip (#3032).
+if [ ! -f "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
+  echo "FATAL: committed fixture $FIXTURE_REL/$DATA_DB is missing from the checkout;" >&2
+  echo "       remedy: git -C $REPO restore --source=HEAD -- test-data/datasets" >&2
+  exit 1
+fi
+
+# Run the lane with an explicit environment. Prints nothing; the caller greps $out.
+run_lane() {
+  local out=$1; shift
+  # `env -u` clears the two seams unless the case re-supplies them, so no case can
+  # inherit another's staging.
+  ( cd "$REPO" && env -u CQLITE_DATASETS_ROOT -u CQLITE_TEST_CHECKOUT_SSTABLES_ROOT "$@" \
+      cargo test -p cqlite-core --features "state_machine cli-helpers" \
+        --test "$TEST_TARGET" "$TEST_NAME" -- --nocapture ) >"$out" 2>&1
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# 1. CONTROL: the ambient corpus. The lane passes AND the committed case RUNS.
+# ---------------------------------------------------------------------------
+control_out="$tmp/control.log"
+control_env=()
+[ -n "${CQLITE_DATASETS_ROOT:-}" ] && control_env=(CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT")
+run_lane "$control_out" "${control_env[@]}"
+control_rc=$?
+if [ "$control_rc" -eq 0 ]; then
+  ok "control: the lane passes against the ambient corpus"
+else
+  bad "control: the lane FAILED against the ambient corpus (rc=$control_rc) — the two \
+failure cases below prove nothing until this passes; see $control_out"
+  sed -n '1,40p' "$control_out"
+fi
+if grep -q "PASS test_da.multiclustering_table" "$control_out"; then
+  ok "control: the committed BTI case actually RAN (not skipped behind its siblings)"
+else
+  bad "control: no 'PASS test_da.multiclustering_table' line — the #3220 case did not run"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. ABSENT: no candidate root carries the table.
+# ---------------------------------------------------------------------------
+mkdir -p "$tmp/absent-env/sstables/test_da" "$tmp/absent-checkout/sstables/test_da"
+absent_out="$tmp/absent.log"
+run_lane "$absent_out" \
+  CQLITE_DATASETS_ROOT="$tmp/absent-env" \
+  CQLITE_TEST_CHECKOUT_SSTABLES_ROOT="$tmp/absent-checkout/sstables"
+absent_rc=$?
+if [ "$absent_rc" -ne 0 ]; then
+  ok "absent: the lane FAILS when no candidate root holds the fixture (rc=$absent_rc)"
+else
+  bad "absent: the lane PASSED with the fixture absent from every candidate root — \
+this is the #3220 silent-skip defect; see $absent_out"
+fi
+if grep -q "committed-fixture case(s) did NOT run" "$absent_out" \
+   && grep -q "multiclustering_table" "$absent_out"; then
+  ok "absent: the failure names the unconditional must_run guard and the case"
+else
+  bad "absent: the failure does not name the must_run guard + multiclustering_table \
+(it may be failing for an unrelated reason); see $absent_out"
+fi
+# The keyspace dir EXISTS in both staged roots, so this case also pins the specific
+# defect: keyspace-granular selection would have accepted these roots.
+if grep -q "no \*-Data.db for test_da.multiclustering_table under any candidate" "$absent_out"; then
+  ok "absent: resolution reports searching EVERY candidate root, per table"
+else
+  bad "absent: no per-table 'under any candidate' diagnostic; see $absent_out"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. EMPTY: the fixture is present but carries no rows.
+# ---------------------------------------------------------------------------
+empty_root="$tmp/empty/sstables/test_da"
+mkdir -p "$empty_root"
+cp -r "$REPO/$FIXTURE_REL" "$empty_root/"
+: > "$empty_root/$(basename "$FIXTURE_REL")/$DATA_DB"
+empty_out="$tmp/empty.log"
+run_lane "$empty_out" CQLITE_DATASETS_ROOT="$tmp/empty"
+empty_rc=$?
+if [ "$empty_rc" -ne 0 ]; then
+  ok "empty: the lane FAILS on a present-but-empty fixture (rc=$empty_rc)"
+else
+  bad "empty: the lane PASSED against a 0-byte Data.db — a dataset-dependent test \
+must never pass on an empty dataset; see $empty_out"
+fi
+if grep -q "SKIP.*multiclustering_table" "$empty_out"; then
+  bad "empty: the case SKIPped instead of failing — an empty fixture must be a hard \
+failure, not an absence; see $empty_out"
+else
+  ok "empty: the case did not degrade into a SKIP"
+fi
+if grep -qE "must yield exactly|no partition keys to probe|multiclustering_table" "$empty_out"; then
+  ok "empty: the failure is attributed to the multiclustering case"
+else
+  bad "empty: the failure does not mention the multiclustering case; see $empty_out"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. SAFETY: neither the tracked fixture nor the ambient corpus was mutated.
+# ---------------------------------------------------------------------------
+if [ -z "$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null)" ]; then
+  ok "safety: the git-tracked fixture is untouched"
+else
+  bad "safety: this self-test dirtied the tracked fixture $FIXTURE_REL"
+fi
+
+printf '\n%s\n' "----------------------------------------"
+printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/tests/test_point_vs_full_failclosed.sh
+++ b/scripts/tests/test_point_vs_full_failclosed.sh
@@ -9,6 +9,16 @@
 # suite reported PASS. So a green run alone means nothing here; each case below
 # stages a layout the lane MUST reject, and asserts the rejection text.
 #
+# ASSERTION CONTRACT — every check here is held to the standard #3220 is about: it must
+# be UNSATISFIABLE by output that does not demonstrate the property claimed. Two forms
+# are therefore banned in the two failure cases: a bare nonzero exit code (it proves
+# only that SOMETHING failed, not that the STAGED case was rejected) and a bare mention
+# of the table name (the SUCCESS line `PASS test_da.multiclustering_table — …` carries
+# it too, so a fallback to the healthy fixture would satisfy the control meant to rule
+# that out). Each rejection is instead pinned to a message naming the staged case AND
+# the specific guard, on ONE line; the success line is separately rejected; and the
+# terminal `EXPECTED_CHECKS` anchor keeps a dropped case from reading as green.
+#
 # The three cases:
 #   control  — the ambient corpus: the lane PASSES and the committed BTI case RUNS.
 #              Without this, the two failures below could equally be a broken harness.
@@ -100,7 +110,11 @@ else
 failure cases below prove nothing until this passes; see $control_out"
   sed -n '1,40p' "$control_out"
 fi
-if grep -q "PASS test_da.multiclustering_table" "$control_out"; then
+# Anchored at line start: the lane prints this line ONLY at the end of a successful
+# `run_case`, so an anchored match cannot be satisfied by a diagnostic that merely
+# quotes the table name (the `ran: [...]`/`skipped: [...]` lists of the must-run
+# assertion do, for instance).
+if grep -qE "^PASS test_da\.multiclustering_table " "$control_out"; then
   ok "control: the committed BTI case actually RAN (not skipped behind its siblings)"
 else
   bad "control: no 'PASS test_da.multiclustering_table' line — the #3220 case did not run"
@@ -162,7 +176,7 @@ see $absent_out"
 fi
 # The sibling committed case still ran in that same run: the failure above is the
 # guard firing for the hidden fixture, not the corpus being unavailable.
-if grep -q "PASS test_da.wide_table" "$absent_out"; then
+if grep -qE "^PASS test_da\.wide_table " "$absent_out"; then
   ok "absent: sibling committed cases still ran (the staging hid one fixture only)"
 else
   bad "absent: test_da.wide_table did not run — the staging hid more than intended, so \
@@ -198,19 +212,64 @@ failure, not an absence; see $empty_out"
 else
   ok "empty: the case did not degrade into a SKIP"
 fi
-if grep -qE "must yield exactly|no partition keys to probe|multiclustering_table" "$empty_out"; then
-  ok "empty: the failure is attributed to the multiclustering case"
+# TARGET-SPECIFIC, in BOTH directions. The rc check above proves only that SOMETHING
+# in the run failed, and the bare substring `multiclustering_table` is carried by the
+# SUCCESS line too (`PASS test_da.multiclustering_table — …`) — so accepting it would
+# let a run in which resolution fell back to the HEALTHY checkout fixture (the case
+# passing, some sibling supplying the nonzero exit) satisfy the very control that
+# exists to rule that out. Hence: the case must NOT report PASS, and the failure must
+# be THIS case's own anti-vacuous anchor, named on one line.
+if grep -qE "^PASS test_da\.multiclustering_table " "$empty_out"; then
+  bad "empty: 'PASS test_da.multiclustering_table' — the case SUCCEEDED against a \
+0-byte Data.db, so resolution fell back to a healthy fixture and the empty one was \
+never rejected; see $empty_out"
 else
-  bad "empty: the failure does not mention the multiclustering case; see $empty_out"
+  ok "empty: the multiclustering case did not report PASS"
+fi
+# The two anchors are the only ways this case can legitimately reject an empty
+# fixture: the clustering-slice row-count anchor (`must yield exactly N`, the one that
+# fires while `probe_keys` are declared) or the partition-key discovery guard. Both are
+# required to name the case on the SAME line, so a sibling's failure cannot satisfy it.
+if grep -qE "case test_da\.multiclustering_table: .*(must yield exactly [0-9]+|no partition keys to probe)" "$empty_out"; then
+  ok "empty: the rejection is THIS case's anti-vacuous anchor (slice row count or \
+partition-key discovery), not merely a nonzero exit"
+else
+  bad "empty: no 'case test_da.multiclustering_table: … must yield exactly N' (or \
+'… no partition keys to probe') line — the run failed for some OTHER reason, which \
+does not prove the empty fixture was rejected; see $empty_out"
 fi
 
 # ---------------------------------------------------------------------------
 # 4. SAFETY: neither the tracked fixture nor the ambient corpus was mutated.
 # ---------------------------------------------------------------------------
-if [ -z "$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null)" ]; then
-  ok "safety: the git-tracked fixture is untouched"
-else
+# `git status` is the evidence, so a git that could not ANSWER (not a repo, git
+# missing) must not read as "untouched" — an unanswerable question is not a clean
+# answer. The `-s` check is the independent second leg: case 3 truncates a COPY, and a
+# staging bug that truncated the ORIGINAL in place would leave a 0-byte tracked file.
+fixture_status=$(git -C "$REPO" status --porcelain -- "$FIXTURE_REL" 2>/dev/null)
+fixture_status_rc=$?
+if [ "$fixture_status_rc" -ne 0 ]; then
+  bad "safety: 'git status' failed (rc=$fixture_status_rc) — the untouched-fixture \
+check has no evidence and must not report green"
+elif [ -n "$fixture_status" ]; then
   bad "safety: this self-test dirtied the tracked fixture $FIXTURE_REL"
+elif [ ! -s "$REPO/$FIXTURE_REL/$DATA_DB" ]; then
+  bad "safety: the tracked $FIXTURE_REL/$DATA_DB is now EMPTY — case 3 truncated the \
+original instead of its copy"
+else
+  ok "safety: the git-tracked fixture is untouched (git-clean and non-empty)"
+fi
+
+# Anti-vacuity for THIS harness, mirroring the row-count anchors the lane itself uses:
+# `failed: 0` is only meaningful if every case actually asserted. A deleted case, an
+# early `exit`, or a block skipped by an editing accident would otherwise report green.
+EXPECTED_CHECKS=12
+total_checks=$((PASS + FAIL))
+if [ "$total_checks" -ne "$EXPECTED_CHECKS" ]; then
+  printf 'FAIL - harness: %d assertions ran, expected %d — a dropped or short-circuited \
+case must never read as green (update EXPECTED_CHECKS when adding one)\n' \
+    "$total_checks" "$EXPECTED_CHECKS"
+  FAIL=$((FAIL + 1))
 fi
 
 printf '\n%s\n' "----------------------------------------"

--- a/website/src/content/docs/agents-developing/validation-playbook.md
+++ b/website/src/content/docs/agents-developing/validation-playbook.md
@@ -77,6 +77,37 @@ The `CQLITE_READ_PATH` knob is a **test/debug** control (not a perf recommendati
 `point` fails closed rather than silently full-scanning. See the CLI reference for the
 user-facing knob docs.
 
+#### Fixture roots resolve per TABLE, and committed cases must RUN (issue #3220)
+
+A dataset lane that picks its corpus root by **keyspace** can pass without ever running.
+Three lanes did exactly that (`point_vs_full_differential`, `query_semantics_oracle_parity`,
+`read_path_forcing_e2e`): each selected the first candidate root whose `<keyspace>/` was a
+directory and then **committed to it with no fallback**, although what each needs is a
+specific **table**. On a machine whose `CQLITE_DATASETS_ROOT` corpus held `test_da/` but
+not the git-committed `test_da/multiclustering_table-*`, the env root won, the table was
+declared absent, and the #3032 multi-component clustering case **skipped silently** behind
+a green suite.
+
+Two rules now close it, and both apply to any new dataset lane:
+
+* **Resolve TABLE-granularly.** `cqlite-core/tests/support/datasets_root.rs` —
+  `sstables_root_for_table(keyspace, table)` walks *every* candidate root
+  (`CQLITE_DATASETS_ROOT`, then the checkout's committed corpus) and returns the first that
+  actually carries `<keyspace>/<table>-*/…-Data.db`. Presence is judged on a real `*-Data.db`
+  component, never on directory existence: the repo commits JSONL sidecars for fixtures whose
+  binaries are gitignored. Schemas keep resolving checkout-relative through
+  `test-data/support/fixture_roots.rs` (#3148) — never by climbing `..` from the datasets root.
+* **Assert per CASE, not suite-wide.** `assert!(ran > 0)` over a whole corpus cannot see one
+  case skipping behind its siblings. Every case whose binaries are **committed to git** carries
+  `must_run: true` and is fail-closed **unconditionally** (with or without
+  `CQLITE_REQUIRE_FIXTURES`, because `core-tests` does not set it); under
+  `CQLITE_REQUIRE_FIXTURES=1` *every* case must run, matching the query-semantics oracle's
+  per-case `assert!(skipped.is_empty())`.
+
+Defense in depth: the agent-gate `bti-multiclustering` component also runs
+`point_vs_full_differential`, so the committed BTI fixtures are covered by a fail-closed gate
+component rather than by `core-tests` alone.
+
 #### Second axis: 1 generation vs N generations (issue #3129)
 
 The point-vs-full comparison above holds the **generation count fixed**, so both of its

--- a/website/src/content/docs/agents-developing/validation-playbook.md
+++ b/website/src/content/docs/agents-developing/validation-playbook.md
@@ -104,6 +104,19 @@ Two rules now close it, and both apply to any new dataset lane:
   `CQLITE_REQUIRE_FIXTURES=1` *every* case must run, matching the query-semantics oracle's
   per-case `assert!(skipped.is_empty())`.
 
+**Resolve by evidence, not by preference — and why no ordering can be fixed here.** Neither root is
+a superset of the other. Measured on a fleet box, `/data/datasets` holds 144 `*-Data.db` across 122
+tables but lacks the one git-committed `test_da/multiclustering_table`; the checkout holds only its
+31 committed parity references, which include it. Env-first loses that committed fixture,
+checkout-first loses 92 fetched tables — so a *preference ordering* is wrong for one set of tables
+whichever way you point it, and only "walk every candidate, take the first that actually holds THIS
+table's `*-Data.db`" is right for both. That supersedes issue **#3104**'s suggested "prefer the
+already-exported `CQLITE_DATASETS_ROOT`" fix **for the lanes on this resolver**. #3104 stays **open**
+for the work the resolver does not reach: the whole-corpus `#2078` preflight fail-close, a diagnostic
+naming the found `Data.db` count and the overridden candidate root, the `--lite`
+implausibly-small-corpus warning, and the CLAUDE.md / flow-* / `agents-developing/test-data` text
+that still tells agents to override the exported root with the checkout path.
+
 Defense in depth: the agent-gate `bti-multiclustering` component also runs
 `point_vs_full_differential`, so the committed BTI fixtures are covered by a fail-closed gate
 component rather than by `core-tests` alone.


### PR DESCRIPTION
Closes #3220

## The defect, reproduced on a fleet box

`point_vs_full_differential` selected its datasets root by **keyspace** presence (`root.join(keyspace).is_dir()`), committed to that candidate with no fallback, then checked the table only against the already-chosen root. Its terminal assertion was suite-wide `assert!(ran > 0)`.

On `ip-172-31-5-109`, `CQLITE_DATASETS_ROOT=/data/datasets` holds `test_da/` but **not** the git-committed `test_da/multiclustering_table-*`. So the #3032 AC6 multi-component clustering case **skipped silently behind a green suite** — the exact class of failure #3032 exists to eliminate.

Measured asymmetry (this is why no preference ordering can fix it):

| root | `*-Data.db` | tables |
|---|--:|--:|
| `/data/datasets` (fleet, exported) | 144 | 122 |
| `<repo>/test-data/datasets` (checkout) | 31 | committed parity refs |

Overlap 30; only-in-fleet 92; **only-in-checkout 1 — `test_da/multiclustering_table`**. Neither root is a superset. "Prefer the exported root" silently skips the #3032 case; "prefer the checkout" fail-closes the corpus lanes (#3104). **Resolution must be by evidence, not preference.**

## The fix

- **Shared table-granular resolver** `cqlite-core/tests/support/datasets_root.rs::sstables_root_for_table` — walks *every* candidate root and selects the first that actually holds that table's `*-Data.db`. Consumed by `point_vs_full_differential.rs`, `one_vs_n_generation.rs`, `query_semantics_oracle_parity.rs`, `read_path_forcing_e2e.rs`. (AC3)
- **Per-case must-run guards, unconditional** — declarative `must_run` on `TableCase` *and* `GenerationCase`, replacing suite-wide `ran > 0` in all three lanes. All nine values audited against `git ls-files` as authority. (AC1b)
- **Gate coverage** — `bti-multiclustering` now also runs `point_vs_full_differential` and the AC2 self-test. (AC1a, applied *after* the resolver fix so it cannot red for the wrong reason)
- **`scripts/tests/test_point_vs_full_failclosed.sh`** — committed automated positive control, 11 assertions. (AC2)

## AC2 — fail-closed demonstrated in both directions

| direction | staging | result |
|---|---|---|
| control | untouched corpus | lane passes, `PASS test_da.multiclustering_table` observed |
| **absent** | checkout candidate mirrored minus exactly that fixture | `rc=101`, `did NOT run: ["multiclustering_table"]` |
| **present-but-empty** | 0-byte `da-2-bti-Data.db` in temp root | `rc=101` on the slice-count anchor, **no SKIP** |

Plus a safety assert that the tracked fixture is unmutated. An early non-discriminating staging (hiding the whole corpus) was rejected — it stayed green under a mutated `must_run`; the surgical version reds 2/11 when mutated.

**Before/after proof for the 1-vs-N lane:** with `test_da/wide_table-*` deleted in a throwaway worktree, `one_vs_n_generation_differential_equality` now FAILs naming `["wide_table"]`; the *same* staging at pre-fix `e8bf96d` reported `ok`. Silent skip reproduced, then closed.

**Gate-wiring proof:** a temporary `exit 1` in the self-test drove `--only bti-multiclustering` to `FAIL (12s)`; restored, `PASS (3s)`, `passed: 11 failed: 0`.

## Review findings resolved

`rust-reviewer` (4 blockers) + roborev (2 findings) on the pre-fix diff:

- **B1** suite-wide `ran > 0`/`pinned > 0` survived in the edited `one_vs_n_generation.rs` submodule — the same defect, same target, same new gate component. Fixed via a pure `must_run_violations` seam, failing branch proven for both lanes.
- **B2** `test_tomb.static_with_tombstones` had `must_run: false` despite committed binaries. Fixed; other four `test_tomb` cases ship sidecars only and correctly stay `false`.
- **B3 / roborev-medium** (found independently by both reviewers) plain `env` does not unset an inherited `CQLITE_REQUIRE_FIXTURES`, so the "deliberately without require-fixtures" invocation was not. Now `env -u`.
- **B4** `read_path_forcing_e2e` still SKIPped unless require-fixtures, for a fixture it calls committed. Now panics with searched roots + remedy.
- **roborev-low, escalated to blocker** the AC2 self-test existed but the component never ran it — a positive control that cannot fail is the very pattern this PR removes. Now wired and proven to red.
- Nits N5 (unquoted passthrough → quoted array), N6, N7 (pins ungated so plain `cargo test -p cqlite-core` builds them) folded in.

## Scope boundaries (deliberate, not omissions)

- **#3104 — punted, narrowed, documented.** The resolver dissolves its suggested fix #1 for these lanes (evidence beats preference; see the table above), but does not reach its `#2078` whole-corpus preflight, the count-naming diagnostic, the `--lite` small-corpus warning, or the doctrine text. Recorded in CLAUDE.md + the validation playbook and commented on #3104.
- **`cqlite-flight/tests/query_semantics_flight_parity.rs` is a fourth lane with the same keyspace-granular resolver, left unreconciled** — different crate (needs a dev-dependency test-support crate), *generation*-granular `fixture_dir` vs the helper's table-granular match, and a `..`-climbing `schema_path` (the #3148 trap). Lower risk: its component pins `CQLITE_REQUIRE_FIXTURES=1`, so a miss FAILs rather than skipping. Named in the module doc; follow-up filed.

## Verification

- `--lite` **PASS** at `e4f067d`, `tree-integrity: PASS`.
- `--only bti-multiclustering` **PASS**.
- Full `agent-gate.sh` required and run by the closer — the diff touches `scripts/agent-gate.sh`, so `--delta` fails closed and is unavailable.

Doctrine updated in the same change: CLAUDE.md (resolve-per-table, assert-per-case) and `agents-developing/validation-playbook`.