### PR TITLE
fix(#3249): persist a profileable perf configuration on agent boxes — sysctl drop-in, functional verification, gate visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,8 +161,12 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   block's `commit:`/`dirty:` are derived from that verified capture, never a fresh emit-time git
   read. No env var bypasses it; remedy is to re-run on a stable tree (don't edit a worktree while
   its gate runs).
-- Every SUMMARY carries an `accelerators:` line (sccache/nextest/lane state) — degradation there is
-  actionable, not noise. Self-test: `bash scripts/tests/test_agent_gate_summary.sh`.
+- Every SUMMARY carries an `accelerators:` line (sccache/nextest/lane state, plus a `mold=` token and
+  a `perf=` profiling-capability token on Linux hosts, #2859/#3249) — degradation there is
+  actionable, not noise. `perf=paranoid-<N>`/`kptr-restricted` means THIS BOX CANNOT BE PROFILED (a
+  PERMISSION verdict, not a missing capability): re-run `bash scripts/bootstrap-agent-machine.sh
+  --yes`, which installs + verifies `/etc/sysctl.d/99-cqlite-perf.conf`. Self-test:
+  `bash scripts/tests/test_agent_gate_summary.sh`.
 
 ## Core Commands
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -93,7 +93,7 @@ accelerators: sccache=on nextest=on lanes=on sccache-health=ok
   **`paranoid-<N>`** (`perf_event_paranoid = N >= 1`
   forbids **CPU-wide** events, so the `perf stat -C <cpu>` the measurement doctrine
   mandates is DENIED — a *permission* verdict, not a missing capability; images ship
-  `4`) · **`kptr-restricted`** (paranoid is fine but `kptr_restrict != 0`, so kernel
+  `4`, and Debian/Ubuntu's extra `>= 3` level denies unprivileged perf *entirely*) · **`kptr-restricted`** (paranoid is fine but `kptr_restrict != 0`, so kernel
   frames resolve to bare addresses — a silent attribution loss) · **`absent`** (the
   `/proc` controls are not present, e.g. a container — tune the host) ·
   **`unknown`** (present but unparseable; never guessed). Anything but `ok` on a box

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -86,6 +86,21 @@ accelerators: sccache=on nextest=on lanes=on sccache-health=ok
   `overridden` means a global `RUSTFLAGS` is suppressing the wired flags (don't
   export one on a worker); `present-unconfigured` means mold is installed but not
   wired — re-run bootstrap.
+- **`perf`** (issue #3249, **Linux only** — no token on macOS) — can this box be
+  profiled *at all*? Read free from `/proc/sys/kernel/{perf_event_paranoid,kptr_restrict}`
+  (never a `perf` exec, so the gate pays nothing for it). Values:
+  **`ok`** (unprivileged per-CPU profiling **and** kernel symbols available) ·
+  **`paranoid-<N>`** (`perf_event_paranoid = N >= 1`
+  forbids **CPU-wide** events, so the `perf stat -C <cpu>` the measurement doctrine
+  mandates is DENIED — a *permission* verdict, not a missing capability; images ship
+  `4`) · **`kptr-restricted`** (paranoid is fine but `kptr_restrict != 0`, so kernel
+  frames resolve to bare addresses — a silent attribution loss) · **`absent`** (the
+  `/proc` controls are not present, e.g. a container — tune the host) ·
+  **`unknown`** (present but unparseable; never guessed). Anything but `ok` on a box
+  you intend to measure means **re-run `bash scripts/bootstrap-agent-machine.sh --yes`**,
+  which installs `/etc/sysctl.d/99-cqlite-perf.conf` and then *verifies* it by running
+  `perf stat -C 0 -e cycles`. Rationale (`-1`, not `1`), the BPF-still-needs-sudo
+  caveat, and the single-tenant security posture: `docs/development/fleet-runbook.md`.
 
 States: **`on`** (detected & used) · **`absent`** (missing → the gate prints a loud
 `WARN:` with the install command) · **`off`** (intentionally disabled via

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -327,7 +327,8 @@ grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.c
   /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
 ```
 
-**Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` in a shell.** They are test-only path
+**Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` / `CQLITE_PERF_SYSCTL_EXTRA_DIRS` /
+`CQLITE_PERF_TEST_SANDBOX` in a shell.** They are test-only path
 seams for `scripts/tests/test_perf_capability*.sh` and are **inert** unless `CQLITE_PERF_TEST_MODE=1`
 is also set — which in turn refuses to run if a real `sudo`/`sysctl` is reachable. The privileged
 destination is a hardcoded `/etc/sysctl.d` literal precisely so no exported variable can ever steer
@@ -335,23 +336,39 @@ a `sudo tee` at another file, and bootstrap fails closed (skips the section with
 finds a seam set without the marker.
 
 **Test mode has NO production fallback (it is enforced, not conventional).** Under
-`CQLITE_PERF_TEST_MODE=1` **both** path seams are **mandatory** and each must be absolute and outside
-`/etc`, `/proc` and `/sys`. A missing or production-shaped seam is a loud refusal in the env guard
-*and* in the path resolvers, so an unsandboxed test-mode run resolves no drop-in path at all and reads
-no `/proc`. The earlier shape fell back to the real directories, which meant a root `--yes` run under
-the marker could `tee` the host's **real** `/etc/sysctl.d/99-cqlite-perf.conf` — a test run mutating
-the machine. There is deliberately no opt-out.
+`CQLITE_PERF_TEST_MODE=1` the sandbox root and **both** path seams are **mandatory**. An unusable seam
+is a loud refusal in the env guard *and* in the path resolvers, so an unsandboxed test-mode run
+resolves no drop-in path at all and reads no `/proc`. The earlier shape fell back to the real
+directories, which meant a root `--yes` run under the marker could `tee` the host's **real**
+`/etc/sysctl.d/99-cqlite-perf.conf` — a test run mutating the machine. There is deliberately no opt-out.
 
-**On the write path the seam is judged by its CANONICAL DESTINATION, not its spelling.** A textual
-check accepts an unbounded set of paths that *resolve* into production — `/tmp/../etc/sysctl.d`, or a
-seam under a symlinked ancestor (`ln -s /etc /tmp/a`, seam `/tmp/a/sysctl.d`) — and each of those
-would land a root `tee` on the host's own drop-in. So the env guard and the drop-in-path resolver
-canonicalize the whole path (`cd -P` + `pwd -P`: no `realpath`/`readlink -f` dependency, correct on
-bash 3.2) and validate the resolved destination; an unenterable path resolves to nothing and is
-refused too. The gate's **emit-time read path** is contractually fork-free and writes nothing, so it
-keeps the builtin-only textual check (which rejects `.`/`..` components and a symlinked seam): the
-worst a mis-accepted seam can do there is mis-read a stand-in `/proc`, which the token reports as
-`absent`/`unknown` rather than as a capability.
+**The rule is POSITIVE CONTAINMENT in one declared sandbox — not a list of forbidden places.** Four
+review rounds each closed one more *spelling* of "the production directory": the raw path, then a
+symlinked seam, then `..`, then `//etc` (POSIX leaves two leading slashes implementation-defined,
+`pwd -P` may preserve them, and on Linux `//etc` **is** `/etc`). A denylist over path spellings cannot
+be completed — `.`, `..`, symlinks, `//`, trailing slashes, bind mounts, `/proc/self/root/…` all name
+the same directory — and scattered prohibitions also let a *new* seam consumer miss them (that was the
+`CQLITE_PERF_SYSCTL_EXTRA_DIRS` defect). So test mode now takes **one** caller-declared sandbox root,
+`CQLITE_PERF_TEST_SANDBOX`, and a seam is usable **iff it is strictly inside it** (resolved-path prefix
+match with an explicit `/` boundary, so `/tmp/sandboxevil` is not inside `/tmp/sandbox`). Anything not
+provably inside is refused — every spelling above, and every future one, for the same single reason.
+
+- The **root itself must prove it is a sandbox**: absolute, canonically spelled, existing, and holding
+  the stamp file `.cqlite-perf-sandbox`. So `CQLITE_PERF_TEST_SANDBOX=/etc` cannot make containment
+  vacuous — the proof lives on the filesystem, where placing it already needs the privilege the guard
+  protects.
+- **Every** consumer routes through that one check: the env guard, the drop-in path a root `tee` is
+  aimed at, the `/proc` stand-in, and every configuration read (the lower-precedence search-path
+  entries, plus an optional `sysctl.conf` **file** entry, whose parent is canonicalized and the
+  resulting file path validated). `test_perf_capability.sh` enforces that **structurally**: it
+  enumerates from the source every function that dereferences a seam and fails if one does not reach
+  the containment check, so a new entry point cannot silently skip it.
+- Paths that **write** or that **read host configuration** canonicalize both sides (`cd -P` + `pwd -P`:
+  no `realpath`/`readlink -f` dependency, correct on bash 3.2); an unenterable path resolves to nothing
+  and is refused. The gate's **emit-time read path** is contractually fork-free and writes nothing, so
+  it applies the same containment check *syntactically* — its guarantee is that the seams are honoured
+  only under the marker, which is never set in production, and the worst a mis-accepted spelling can do
+  there is read a caller-chosen file, reported as `absent`/`unknown` rather than as a capability.
 
 Every gate SUMMARY's `accelerators:` line stamps the same state as a Linux-only `perf=` token
 (`ok` / `paranoid-<N>` / `kptr-restricted` / `absent` / `unknown`), so "this box cannot be profiled"

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -204,10 +204,25 @@ line wins the reader's attention. A functional pass without a matching `/proc` v
 installing the drop-in needs root) would run `perf stat -C 0 -e cycles` *as root*, where it **succeeds
 on a `paranoid=4` box on which every unprivileged agent process still gets `EACCES`** — a textbook
 false verification of an unprofileable box. Bootstrap therefore **drops privilege for the probe** when
-it can: `setpriv --reuid/--regid --clear-groups` (preferred), else `runuser -u`, else `sudo -n -u`,
-targeting `SUDO_UID`/`SUDO_GID` (the account that invoked `sudo` — the one whose capability is
-actually in question) and falling back to `nobody` resolved from the passwd database, never a
-hardcoded uid. The run says which identity it measured:
+it can: `setpriv --reuid/--regid --clear-groups` (preferred), else `runuser -u <name>`, else
+`sudo -n -u '#<uid>'` (sudo's numeric form), targeting `SUDO_UID`/`SUDO_GID` (the account that invoked
+`sudo` — the one whose capability is actually in question) and falling back to `nobody` resolved from
+the passwd database, never a hardcoded uid.
+
+**The numeric ids are the target; the NAME is only used when passwd confirms it.** `SUDO_UID` and
+`SUDO_USER` are independent environment strings, so `SUDO_UID=1000 SUDO_USER=root` — stale, hand-set
+or simply inconsistent — would make a name-based `runuser -u root` run the probe **as root** while the
+run reported a successful privilege drop: a false "VERIFIED" through the drop mechanism itself. A name
+is therefore used only after `id -u`/`id -g` confirm it resolves to exactly the validated **non-zero**
+uid/gid (and only if it is shell-token safe, since the prefix is word-split); otherwise it is
+discarded and the numeric mechanisms carry the drop.
+
+**An unknown identity is never treated as "unprivileged".** If `id -u` is missing, fails, or prints
+something unparseable, the state is `identity-unknown` and the functional result is **not** evidence
+either way — the run says the identity could not be determined and makes no capability claim (it does
+not assert the probe ran as root either). Nothing substitutes a plausible uid.
+
+The run says which identity it measured:
 `DROPS PRIVILEGE (dropped:setpriv:uid=1000)`. When **no** mechanism or no unprivileged account exists
 (`root-no-drop-mechanism` / `root-no-unprivileged-target`), the root result is labelled **not evidence
 that an unprivileged process can profile this box** and never reported as verification — the `/proc`
@@ -234,6 +249,43 @@ so a stale `kernel.perf_event_paranoid` there wins over `99-cqlite-perf.conf` no
 sorts. That is the single likeliest cause of "applied, still restricted", and bootstrap's diagnostics
 name it explicitly.
 
+#### The "silent revert" has a NAME: `/etc/sysctl.d/10-kernel-hardening.conf`
+
+Three separate reports recorded that a hand-set `perf_event_paranoid`/`kptr_restrict` "silently
+reverts" without ever identifying a cause (`docs/reports/ws0-3217-report.md:214`,
+`ws3-3029-report.md:63`, `ws0-cassandra-baseline-2026-07-27.md:847`). The cause is a **stock Ubuntu
+drop-in**, present on the fleet boxes:
+
+```conf
+# /etc/sysctl.d/10-kernel-hardening.conf   (ships with the image; NOT ours, do not delete)
+kernel.kptr_restrict = 1
+```
+
+It is re-asserted at **every boot** and by **every `sysctl --system`** — including the one bootstrap
+runs. So a hand `sysctl -w kernel.kptr_restrict=0` survives only until the next boot or the next
+`--system`, which is exactly the "it reverts on its own" experience. Nothing is wrong with the box;
+a second file is simply also setting the knob.
+
+**This makes the `99-` prefix LOAD-BEARING, not cosmetic.** `sysctl.d` files are applied in
+lexicographic **basename** order and the **last** assignment wins, so `99-cqlite-perf.conf` beats
+`10-kernel-hardening.conf` *only because of the number*. Renaming ours to `cqlite-perf.conf` — or to
+any prefix below `10-` — silently hands `kptr_restrict` back to the hardening drop-in at the next
+boot, with no error anywhere. **Never "tidy" the filename.** The managed file's own header says so
+too, so the warning travels with the bytes.
+
+**Bootstrap names the competitor for you.** Whenever the read-back shows a non-`ok` token, the
+diagnostics scan the `sysctl.d` directory and report every *other* file that sets
+`perf_event_paranoid`/`kptr_restrict`, ranked by whether it actually wins:
+
+```text
+[warn] OVERRIDE: /etc/sysctl.d/99-zzz-late.conf also sets perf_event_paranoid/kptr_restrict and its
+       name sorts AFTER 99-cqlite-perf.conf, so it is applied LAST and WINS — fix or rename that file
+[info] competing file: /etc/sysctl.d/10-kernel-hardening.conf also sets
+       perf_event_paranoid/kptr_restrict but sorts BEFORE 99-cqlite-perf.conf, so ours wins
+```
+
+A run with no competitor says so explicitly, so a silent scan can never be mistaken for no scan.
+
 Verify by hand, in the same order bootstrap does:
 
 ```bash
@@ -250,11 +302,19 @@ grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.c
 ```
 
 **Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` in a shell.** They are test-only path
-seams for `scripts/tests/test_perf_capability.sh` and are **inert** unless `CQLITE_PERF_TEST_MODE=1`
+seams for `scripts/tests/test_perf_capability*.sh` and are **inert** unless `CQLITE_PERF_TEST_MODE=1`
 is also set — which in turn refuses to run if a real `sudo`/`sysctl` is reachable. The privileged
 destination is a hardcoded `/etc/sysctl.d` literal precisely so no exported variable can ever steer
 a `sudo tee` at another file, and bootstrap fails closed (skips the section with a `[warn]`) if it
 finds a seam set without the marker.
+
+**Test mode has NO production fallback (it is enforced, not conventional).** Under
+`CQLITE_PERF_TEST_MODE=1` **both** path seams are **mandatory** and each must be absolute and outside
+`/etc`, `/proc` and `/sys`. A missing or production-shaped seam is a loud refusal in the env guard
+*and* in the path resolvers, so an unsandboxed test-mode run resolves no drop-in path at all and reads
+no `/proc`. The earlier shape fell back to the real directories, which meant a root `--yes` run under
+the marker could `tee` the host's **real** `/etc/sysctl.d/99-cqlite-perf.conf` — a test run mutating
+the machine. There is deliberately no opt-out.
 
 Every gate SUMMARY's `accelerators:` line stamps the same state as a Linux-only `perf=` token
 (`ok` / `paranoid-<N>` / `kptr-restricted` / `absent` / `unknown`), so "this box cannot be profiled"

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -141,6 +141,67 @@ an unreadable committed `.cql` **or** on a rejected relative `CQLITE_SCHEMAS_ROO
 be absolute). It has **no opt-out** — committed source in a checkout is never legitimately absent.
 `--lite`/`--only` stay lenient.
 
+### Perf profiling capability (`perf_event_paranoid`) — Linux workers (#3249)
+
+Agent/worker images ship with `kernel.perf_event_paranoid = 4` — **all** unprivileged `perf` use
+denied — and set it in **no** sysctl file. So every profiling run started from a hard `EACCES` whose
+help text ("access limited") reads like a *capability* verdict when it is a *permission* verdict;
+that alone cost two measurement cycles. A box left permissive by a hand-probe is no better: with no
+drop-in it reverts on reboot/reprovision, i.e. the fleet was profileable only by accident.
+
+`bash scripts/bootstrap-agent-machine.sh --yes` now installs a reboot-surviving drop-in:
+
+```conf
+# /etc/sysctl.d/99-cqlite-perf.conf   (whole file is managed; byte-compared on re-run)
+kernel.perf_event_paranoid = -1
+kernel.kptr_restrict = 0
+```
+
+**Why `-1` and not `1`.** `perf_event_paranoid` is **cumulative** — higher is *more* restrictive and
+each level keeps the ones below it: `>= 2` no kernel profiling, `>= 1` **no CPU-wide event access**,
+`>= 0` no raw tracepoints, `-1` no restriction. CQLite's measurement doctrine mandates per-CPU
+collection (`perf stat -C <cpu>`), which is exactly what `>= 1` forbids — so `1` is not "almost
+right", it is a hard denial. `0` is the bare minimum that works; `-1` additionally lifts the perf
+mlock limit, avoiding `perf record` ring-buffer surprises. `kernel.kptr_restrict = 0` is a
+**separate** control needed for kernel *symbol* resolution — without it kernel frames render as
+unresolved addresses, a **silent attribution loss, not an error**.
+
+**BPF collectors still need `sudo`.** A permissive `perf_event_paranoid` does **not** grant BPF map
+creation, so `bpftrace`/`bcc` collectors remain root-only (the #3217 finding). This drop-in buys
+unprivileged `perf stat`/`perf record`, nothing more.
+
+**Security posture — read this before copying the file anywhere.** This is a **deliberate
+loosening**, appropriate for **dedicated single-tenant measurement/agent boxes** (what the fleet is:
+one worker per machine, no other tenants, no untrusted logins). It **must not** be applied to shared
+or multi-tenant hosts: unrestricted `perf_event_open` plus unmasked kernel pointers lets any local
+user observe other users' execution and leak kernel addresses.
+
+**Bootstrap verifies rather than assumes** — the whole point, since a bootstrap that silently leaves
+a box unprofileable is the failure mode being fixed. The section probes `/proc` first (writing
+nothing when the drop-in is already current), writes the managed file, applies it, **reads the values
+back out of `/proc/sys/kernel`** (a `sysctl` write's return code proves nothing — a container or a
+later-sorting drop-in can swallow it), and finishes by running the collection itself:
+`perf stat -C 0 -e cycles -- sleep 0.1`, requiring exit 0 **and a non-zero cycle count**. An rc-0
+`perf stat` printing `<not supported>` (or a virtualised PMU counting a flat 0) is reported as
+**NOT verified**. No sudo, no `perf`, or an absent `/proc` control degrades to a `[warn]` plus the
+exact remedy line — bootstrap stays advisory and always exits 0.
+
+Verify by hand, in the same order bootstrap does:
+
+```bash
+cat /proc/sys/kernel/perf_event_paranoid /proc/sys/kernel/kptr_restrict   # want -1 and 0
+bash scripts/perf-capability.sh --token                                   # want: ok
+bash scripts/perf-capability.sh --verify                                  # want: cycles=<non-zero>
+# apply by hand (identical bytes to what bootstrap writes, so a later run is a no-op):
+bash scripts/perf-capability.sh --drop-in | sudo tee /etc/sysctl.d/99-cqlite-perf.conf >/dev/null
+sudo sysctl -q --system
+```
+
+Every gate SUMMARY's `accelerators:` line stamps the same state as a Linux-only `perf=` token
+(`ok` / `paranoid-<N>` / `kptr-restricted` / `absent` / `unknown`), so "this box cannot be profiled"
+is visible in any pasted block instead of being discovered at the start of a measurement cycle.
+`paranoid-4` on a box you expected to profile means **re-run bootstrap**, not "perf is unavailable".
+
 ---
 
 ## Laptop A — your lead session (lead + worker)

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -188,7 +188,19 @@ later-sorting drop-in can swallow it), and finishes by running the collection it
 `perf stat -C 0 -e cycles -- sleep 0.1`, requiring exit 0 **and a non-zero cycle count**. An rc-0
 `perf stat` printing `<not supported>` (or a virtualised PMU counting a flat 0) is reported as
 **NOT verified**. No sudo, no `perf`, or an absent `/proc` control degrades to a `[warn]` plus the
-exact remedy line — bootstrap stays advisory and always exits 0.
+exact remedy line — bootstrap stays advisory and always exits 0. When the drop-in is already current
+the remedy is **apply-only** (`sysctl -q --system`, prefixed with `sudo` only where a `sudo` binary
+exists), never a pointless re-write.
+
+**The apply's exit code and the capability verdict are SEPARATE facts, reported separately.**
+`sysctl --system` applies *every* drop-in on the box, so it can apply ours perfectly and still exit
+non-zero because an unrelated pre-existing entry failed (a stale `/etc/sysctl.conf` line, a foreign
+drop-in naming a knob this kernel lacks) — one such entry anywhere is enough. Bootstrap therefore
+re-reads `/proc` after **every** attempted apply, whatever the rc, and prints the command's failure
+as a fact about the *command*. So a box can legitimately show "`sysctl -q --system` exited 1"
+**and** a good read-back on the same run; that is not a contradiction, and the verdict is always the
+`/proc` line. (Gating the read-back on that rc is what used to print "nothing was applied" about a
+box that had just become profileable.)
 
 **`/etc/sysctl.conf` BEATS our drop-in — check it first when the value does not take.** Both
 `sysctl --system` and `systemd-sysctl` apply `/etc/sysctl.conf` **after** every `sysctl.d` drop-in,

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -327,8 +327,7 @@ grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.c
   /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
 ```
 
-**Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` / `CQLITE_PERF_SYSCTL_EXTRA_DIRS` /
-`CQLITE_PERF_TEST_SANDBOX` in a shell.** They are test-only path
+**Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` in a shell.** They are test-only path
 seams for `scripts/tests/test_perf_capability*.sh` and are **inert** unless `CQLITE_PERF_TEST_MODE=1`
 is also set — which in turn refuses to run if a real `sudo`/`sysctl` is reachable. The privileged
 destination is a hardcoded `/etc/sysctl.d` literal precisely so no exported variable can ever steer
@@ -336,39 +335,23 @@ a `sudo tee` at another file, and bootstrap fails closed (skips the section with
 finds a seam set without the marker.
 
 **Test mode has NO production fallback (it is enforced, not conventional).** Under
-`CQLITE_PERF_TEST_MODE=1` the sandbox root and **both** path seams are **mandatory**. An unusable seam
-is a loud refusal in the env guard *and* in the path resolvers, so an unsandboxed test-mode run
-resolves no drop-in path at all and reads no `/proc`. The earlier shape fell back to the real
-directories, which meant a root `--yes` run under the marker could `tee` the host's **real**
-`/etc/sysctl.d/99-cqlite-perf.conf` — a test run mutating the machine. There is deliberately no opt-out.
+`CQLITE_PERF_TEST_MODE=1` **both** path seams are **mandatory** and each must be absolute and outside
+`/etc`, `/proc` and `/sys`. A missing or production-shaped seam is a loud refusal in the env guard
+*and* in the path resolvers, so an unsandboxed test-mode run resolves no drop-in path at all and reads
+no `/proc`. The earlier shape fell back to the real directories, which meant a root `--yes` run under
+the marker could `tee` the host's **real** `/etc/sysctl.d/99-cqlite-perf.conf` — a test run mutating
+the machine. There is deliberately no opt-out.
 
-**The rule is POSITIVE CONTAINMENT in one declared sandbox — not a list of forbidden places.** Four
-review rounds each closed one more *spelling* of "the production directory": the raw path, then a
-symlinked seam, then `..`, then `//etc` (POSIX leaves two leading slashes implementation-defined,
-`pwd -P` may preserve them, and on Linux `//etc` **is** `/etc`). A denylist over path spellings cannot
-be completed — `.`, `..`, symlinks, `//`, trailing slashes, bind mounts, `/proc/self/root/…` all name
-the same directory — and scattered prohibitions also let a *new* seam consumer miss them (that was the
-`CQLITE_PERF_SYSCTL_EXTRA_DIRS` defect). So test mode now takes **one** caller-declared sandbox root,
-`CQLITE_PERF_TEST_SANDBOX`, and a seam is usable **iff it is strictly inside it** (resolved-path prefix
-match with an explicit `/` boundary, so `/tmp/sandboxevil` is not inside `/tmp/sandbox`). Anything not
-provably inside is refused — every spelling above, and every future one, for the same single reason.
-
-- The **root itself must prove it is a sandbox**: absolute, canonically spelled, existing, and holding
-  the stamp file `.cqlite-perf-sandbox`. So `CQLITE_PERF_TEST_SANDBOX=/etc` cannot make containment
-  vacuous — the proof lives on the filesystem, where placing it already needs the privilege the guard
-  protects.
-- **Every** consumer routes through that one check: the env guard, the drop-in path a root `tee` is
-  aimed at, the `/proc` stand-in, and every configuration read (the lower-precedence search-path
-  entries, plus an optional `sysctl.conf` **file** entry, whose parent is canonicalized and the
-  resulting file path validated). `test_perf_capability.sh` enforces that **structurally**: it
-  enumerates from the source every function that dereferences a seam and fails if one does not reach
-  the containment check, so a new entry point cannot silently skip it.
-- Paths that **write** or that **read host configuration** canonicalize both sides (`cd -P` + `pwd -P`:
-  no `realpath`/`readlink -f` dependency, correct on bash 3.2); an unenterable path resolves to nothing
-  and is refused. The gate's **emit-time read path** is contractually fork-free and writes nothing, so
-  it applies the same containment check *syntactically* — its guarantee is that the seams are honoured
-  only under the marker, which is never set in production, and the worst a mis-accepted spelling can do
-  there is read a caller-chosen file, reported as `absent`/`unknown` rather than as a capability.
+**On the write path the seam is judged by its CANONICAL DESTINATION, not its spelling.** A textual
+check accepts an unbounded set of paths that *resolve* into production — `/tmp/../etc/sysctl.d`, or a
+seam under a symlinked ancestor (`ln -s /etc /tmp/a`, seam `/tmp/a/sysctl.d`) — and each of those
+would land a root `tee` on the host's own drop-in. So the env guard and the drop-in-path resolver
+canonicalize the whole path (`cd -P` + `pwd -P`: no `realpath`/`readlink -f` dependency, correct on
+bash 3.2) and validate the resolved destination; an unenterable path resolves to nothing and is
+refused too. The gate's **emit-time read path** is contractually fork-free and writes nothing, so it
+keeps the builtin-only textual check (which rejects `.`/`..` components and a symlinked seam): the
+worst a mis-accepted seam can do there is mis-read a stand-in `/proc`, which the token reports as
+`absent`/`unknown` rather than as a capability.
 
 Every gate SUMMARY's `accelerators:` line stamps the same state as a Linux-only `perf=` token
 (`ok` / `paranoid-<N>` / `kptr-restricted` / `absent` / `unknown`), so "this box cannot be profiled"

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -273,18 +273,43 @@ any prefix below `10-` — silently hands `kptr_restrict` back to the hardening 
 boot, with no error anywhere. **Never "tidy" the filename.** The managed file's own header says so
 too, so the warning travels with the bytes.
 
-**Bootstrap names the competitor for you.** Whenever the read-back shows a non-`ok` token, the
-diagnostics scan the `sysctl.d` directory and report every *other* file that sets
-`perf_event_paranoid`/`kptr_restrict`, ranked by whether it actually wins:
+**Bootstrap names the competitor for you — across the WHOLE `sysctl --system` search path.**
+Whenever the read-back shows a non-`ok` token, the diagnostics scan every location `sysctl --system`
+and `systemd-sysctl` load and report each *other* file that sets
+`perf_event_paranoid`/`kptr_restrict`, ranked by whether it actually wins. **The search path, in
+descending name-masking precedence** (`sysctl(8)` SYSTEM FILE PRECEDENCE / `sysctl.d(5)`):
+
+| # | location | notes |
+|---|----------|-------|
+| 1 | `/etc/sysctl.d/*.conf` | where our managed `99-cqlite-perf.conf` lives |
+| 2 | `/run/sysctl.d/*.conf` | volatile; a package or unit can drop a file here at runtime |
+| 3 | `/usr/local/lib/sysctl.d/*.conf` | |
+| 4 | `/usr/lib/sysctl.d/*.conf` | vendor drop-ins |
+| 5 | `/lib/sysctl.d/*.conf` | usually a symlink to #4 on merged-`/usr` systems |
+| 6 | `/etc/sysctl.conf` | **applied after every drop-in — wins regardless of filename** |
+
+Two *independent* rules decide the outcome, and the scan implements both:
+
+- **Masking** — "once a file of a given filename is loaded, any file of the same name in subsequent
+  directories is ignored". So `/etc/sysctl.d/50-x.conf` replaces `/usr/lib/sysctl.d/50-x.conf`
+  outright, and the diagnostic deliberately does **not** name the masked copy: it is not in effect.
+- **Ordering** — the surviving files are applied in lexicographic **basename** order regardless of
+  which directory they came from, and the **last** assignment wins. (`/etc/sysctl.conf` is outside
+  this contest — it runs after all of them.)
 
 ```text
-[warn] OVERRIDE: /etc/sysctl.d/99-zzz-late.conf also sets perf_event_paranoid/kptr_restrict and its
+[warn] OVERRIDE: /run/sysctl.d/99-zzz-late.conf also sets perf_event_paranoid/kptr_restrict and its
        name sorts AFTER 99-cqlite-perf.conf, so it is applied LAST and WINS — fix or rename that file
+[warn] OVERRIDE: /etc/sysctl.conf also sets perf_event_paranoid/kptr_restrict and is applied AFTER
+       every sysctl.d drop-in ... so it WINS regardless of our filename — fix that file
 [info] competing file: /etc/sysctl.d/10-kernel-hardening.conf also sets
        perf_event_paranoid/kptr_restrict but sorts BEFORE 99-cqlite-perf.conf, so ours wins
 ```
 
-A run with no competitor says so explicitly, so a silent scan can never be mistaken for no scan.
+A run with no competitor says so explicitly **and names the path it covered**, so a silent scan can
+never be mistaken for no scan. Scanning only `/etc/sysctl.d` used to let a later-sorting file in
+`/run/sysctl.d` or `/usr/lib/sysctl.d` override us while bootstrap reported *no competitor* — the
+same "reverts and nobody knows why" mystery wearing a different directory.
 
 Verify by hand, in the same order bootstrap does:
 
@@ -298,7 +323,8 @@ bash scripts/perf-capability.sh --verify-unpriv   # want: cycles=<non-zero> iden
 bash scripts/perf-capability.sh --drop-in | sudo tee /etc/sysctl.d/99-cqlite-perf.conf >/dev/null
 sudo sysctl -q --system
 # still restricted? the override is almost always here (applied AFTER the drop-ins):
-grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.conf
+grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.conf \
+  /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
 ```
 
 **Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` in a shell.** They are test-only path
@@ -315,6 +341,17 @@ finds a seam set without the marker.
 no `/proc`. The earlier shape fell back to the real directories, which meant a root `--yes` run under
 the marker could `tee` the host's **real** `/etc/sysctl.d/99-cqlite-perf.conf` — a test run mutating
 the machine. There is deliberately no opt-out.
+
+**On the write path the seam is judged by its CANONICAL DESTINATION, not its spelling.** A textual
+check accepts an unbounded set of paths that *resolve* into production — `/tmp/../etc/sysctl.d`, or a
+seam under a symlinked ancestor (`ln -s /etc /tmp/a`, seam `/tmp/a/sysctl.d`) — and each of those
+would land a root `tee` on the host's own drop-in. So the env guard and the drop-in-path resolver
+canonicalize the whole path (`cd -P` + `pwd -P`: no `realpath`/`readlink -f` dependency, correct on
+bash 3.2) and validate the resolved destination; an unenterable path resolves to nothing and is
+refused too. The gate's **emit-time read path** is contractually fork-free and writes nothing, so it
+keeps the builtin-only textual check (which rejects `.`/`..` components and a symlinked seam): the
+worst a mis-accepted seam can do there is mis-read a stand-in `/proc`, which the token reports as
+`absent`/`unknown` rather than as a capability.
 
 Every gate SUMMARY's `accelerators:` line stamps the same state as a Linux-only `perf=` token
 (`ok` / `paranoid-<N>` / `kptr-restricted` / `absent` / `unknown`), so "this box cannot be profiled"

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -192,6 +192,32 @@ exact remedy line — bootstrap stays advisory and always exits 0. When the drop
 the remedy is **apply-only** (`sysctl -q --system`, prefixed with `sudo` only where a `sudo` binary
 exists), never a pointless re-write.
 
+**"VERIFIED" requires BOTH facts — the `/proc` token *and* the functional pass.** The functional
+result alone is never the verdict: a box whose `/proc` says `paranoid-2` or `kptr-restricted` would
+otherwise print its own diagnosis *and* a reassuring "VERIFIED" in the same run, and the reassuring
+line wins the reader's attention. A functional pass without a matching `/proc` verdict is labelled
+**partial diagnostic information**, explicitly subordinate to `/proc`.
+
+**If you run bootstrap under `sudo`, know what the functional check can and cannot prove.**
+`perf_event_paranoid` restricts **unprivileged** users — **root bypasses it entirely**. So
+`sudo bash scripts/bootstrap-agent-machine.sh` (a normal invocation, and the likeliest one, since
+installing the drop-in needs root) would run `perf stat -C 0 -e cycles` *as root*, where it **succeeds
+on a `paranoid=4` box on which every unprivileged agent process still gets `EACCES`** — a textbook
+false verification of an unprofileable box. Bootstrap therefore **drops privilege for the probe** when
+it can: `setpriv --reuid/--regid --clear-groups` (preferred), else `runuser -u`, else `sudo -n -u`,
+targeting `SUDO_UID`/`SUDO_GID` (the account that invoked `sudo` — the one whose capability is
+actually in question) and falling back to `nobody` resolved from the passwd database, never a
+hardcoded uid. The run says which identity it measured:
+`DROPS PRIVILEGE (dropped:setpriv:uid=1000)`. When **no** mechanism or no unprivileged account exists
+(`root-no-drop-mechanism` / `root-no-unprivileged-target`), the root result is labelled **not evidence
+that an unprivileged process can profile this box** and never reported as verification — the `/proc`
+token, which is identity-independent, stays the authority. Two operator consequences: install
+`util-linux` (for `setpriv`) on any box you provision as root, and to check by hand as the agent
+account use `sudo -u <agent-user> perf stat -C 0 -e cycles -- sleep 0.1` (or
+`bash scripts/perf-capability.sh --verify-unpriv`, which does the drop itself and fails when the
+result cannot be attributed to an unprivileged identity). Plain `--verify` measures **whoever runs
+it**, so as root it answers a question nobody asked.
+
 **The apply's exit code and the capability verdict are SEPARATE facts, reported separately.**
 `sysctl --system` applies *every* drop-in on the box, so it can apply ours perfectly and still exit
 non-zero because an unrelated pre-existing entry failed (a stale `/etc/sysctl.conf` line, a foreign
@@ -213,7 +239,9 @@ Verify by hand, in the same order bootstrap does:
 ```bash
 cat /proc/sys/kernel/perf_event_paranoid /proc/sys/kernel/kptr_restrict   # want -1 and 0
 bash scripts/perf-capability.sh --token                                   # want: ok
-bash scripts/perf-capability.sh --verify                                  # want: cycles=<non-zero>
+bash scripts/perf-capability.sh --verify-unpriv   # want: cycles=<non-zero> identity=self-unprivileged
+#   (as root, --verify-unpriv drops privilege first; plain --verify measures whoever runs it, and
+#    root BYPASSES perf_event_paranoid, so a root `--verify` pass proves nothing about an agent)
 # apply by hand (identical bytes to what bootstrap writes, so a later run is a no-op):
 bash scripts/perf-capability.sh --drop-in | sudo tee /etc/sysctl.d/99-cqlite-perf.conf >/dev/null
 sudo sysctl -q --system

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -158,8 +158,12 @@ kernel.kptr_restrict = 0
 ```
 
 **Why `-1` and not `1`.** `perf_event_paranoid` is **cumulative** — higher is *more* restrictive and
-each level keeps the ones below it: `>= 2` no kernel profiling, `>= 1` **no CPU-wide event access**,
-`>= 0` no raw tracepoints, `-1` no restriction. CQLite's measurement doctrine mandates per-CPU
+each level keeps the ones below it: `>= 3` (an extra level Debian/Ubuntu kernels carry) **disallow
+all unprivileged perf event use**, `>= 2` no kernel profiling, `>= 1` **no CPU-wide event access**,
+`>= 0` no raw tracepoints, `-1` **(almost) all events permitted**. That `>= 3` level is what makes
+the images' shipped **`4`** deny *everything* — down to a plain `perf stat` — rather than only the
+CPU-wide collection, which is why the first probe on a fresh box fails outright.
+CQLite's measurement doctrine mandates per-CPU
 collection (`perf stat -C <cpu>`), which is exactly what `>= 1` forbids — so `1` is not "almost
 right", it is a hard denial. `0` is the bare minimum that works; `-1` additionally lifts the perf
 mlock limit, avoiding `perf record` ring-buffer surprises. `kernel.kptr_restrict = 0` is a
@@ -186,6 +190,12 @@ later-sorting drop-in can swallow it), and finishes by running the collection it
 **NOT verified**. No sudo, no `perf`, or an absent `/proc` control degrades to a `[warn]` plus the
 exact remedy line — bootstrap stays advisory and always exits 0.
 
+**`/etc/sysctl.conf` BEATS our drop-in — check it first when the value does not take.** Both
+`sysctl --system` and `systemd-sysctl` apply `/etc/sysctl.conf` **after** every `sysctl.d` drop-in,
+so a stale `kernel.perf_event_paranoid` there wins over `99-cqlite-perf.conf` no matter how the file
+sorts. That is the single likeliest cause of "applied, still restricted", and bootstrap's diagnostics
+name it explicitly.
+
 Verify by hand, in the same order bootstrap does:
 
 ```bash
@@ -195,7 +205,16 @@ bash scripts/perf-capability.sh --verify                                  # want
 # apply by hand (identical bytes to what bootstrap writes, so a later run is a no-op):
 bash scripts/perf-capability.sh --drop-in | sudo tee /etc/sysctl.d/99-cqlite-perf.conf >/dev/null
 sudo sysctl -q --system
+# still restricted? the override is almost always here (applied AFTER the drop-ins):
+grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.conf
 ```
+
+**Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` in a shell.** They are test-only path
+seams for `scripts/tests/test_perf_capability.sh` and are **inert** unless `CQLITE_PERF_TEST_MODE=1`
+is also set — which in turn refuses to run if a real `sudo`/`sysctl` is reachable. The privileged
+destination is a hardcoded `/etc/sysctl.d` literal precisely so no exported variable can ever steer
+a `sudo tee` at another file, and bootstrap fails closed (skips the section with a `[warn]`) if it
+finds a seam set without the marker.
 
 Every gate SUMMARY's `accelerators:` line stamps the same state as a Linux-only `perf=` token
 (`ok` / `paranoid-<N>` / `kptr-restricted` / `absent` / `unknown`), so "this box cannot be profiled"

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -222,8 +222,13 @@ and the `/etc/sysctl.conf` precedence trap: `docs/development/fleet-runbook.md`.
 Self-test coverage: `scripts/tests/test_agent_gate_summary.sh` (cases 9f* assert every
 state via the test seam, the Darwin no-token contract, **and** the production branch
 against a real `/proc` fixture with the seam unset) and
-`scripts/tests/test_perf_capability.sh` (the helper contract + the bootstrap
-write/read-back/verify path, including the silent-revert and denied-`perf` cases).
+the pair `scripts/tests/test_perf_capability.sh` (the helper's unit contract) +
+`scripts/tests/test_perf_capability_bootstrap.sh` (the bootstrap
+write/read-back/verify path, including the silent-revert and denied-`perf` cases),
+which share `scripts/tests/lib/perf-capability-test-lib.sh`. Both are in the
+`tooling-tests` `&&`-chain; together they also pin the fail-closed identity rules (an
+unusable `id -u`, an inconsistent `SUDO_USER`) and the enforced hermeticity of test
+mode (both path seams mandatory, no production fallback).
 
 ## Disk hygiene for multi-worktree gates (issue #1848)
 

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -191,9 +191,16 @@ accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked perf=
 ```
 
 It is a **free** read of `/proc/sys/kernel/{perf_event_paranoid,kptr_restrict}` through
-shell builtins — no `perf` exec, no subprocess, no new binary dependency (the
-functional `perf stat -C 0 -e cycles` verification is **bootstrap's** job, not the
-gate's). State values (Linux only):
+shell builtins — no `perf` exec, no new binary dependency (the functional
+`perf stat -C 0 -e cycles` verification is **bootstrap's** job, not the gate's). "Free"
+is a *measured* cost, enforced by `test_agent_gate_summary.sh` case `perf-free`: the
+emit-time path performs **0 external processes and 0 command substitutions** — each
+`$( )` is a forked subshell, so the token is returned through a caller-named variable
+(`perf_capability_token_into <outvar>`) rather than stdout — and
+`scripts/perf-capability.sh` is sourced **once per gate run**, never per summary. The
+test asserts both halves: the substitution count statically, and the extracted path
+re-executed with an unresolvable `PATH` under xtrace subshell counting (so a
+stderr-silenced exec cannot hide). State values (Linux only):
 - `perf=ok` — unprivileged per-CPU profiling **and** kernel symbol resolution available.
 - `perf=paranoid-<N>` — `perf_event_paranoid = N >= 1`. Cumulative: `>= 1` forbids
   **CPU-wide** event access, which is exactly what the mandated `perf stat -C <cpu>`

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -181,6 +181,43 @@ print-only, the link probe, the managed-block write, idempotency, user-config
 preservation, and the Darwin no-op). See fleet-runbook for the one-time sccache
 cold-rebuild note at enablement.
 
+### The `perf=` profiling-capability token (Linux only, issue #3249)
+
+After `mold=`, a Linux `accelerators:` line carries a `perf=` token answering *can this
+box be profiled at all?*
+
+```
+accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked perf=ok
+```
+
+It is a **free** read of `/proc/sys/kernel/{perf_event_paranoid,kptr_restrict}` through
+shell builtins — no `perf` exec, no subprocess, no new binary dependency (the
+functional `perf stat -C 0 -e cycles` verification is **bootstrap's** job, not the
+gate's). State values (Linux only):
+- `perf=ok` — unprivileged per-CPU profiling **and** kernel symbol resolution available.
+- `perf=paranoid-<N>` — `perf_event_paranoid = N >= 1`. Cumulative: `>= 1` forbids
+  **CPU-wide** event access, which is exactly what the mandated `perf stat -C <cpu>`
+  needs, so it is **denied**. Agent images ship `4`; on Debian/Ubuntu kernels `>= 3`
+  denies unprivileged perf entirely. This is a **permission** verdict whose "access
+  limited" help text reads like a missing *capability* — the confusion that cost two
+  measurement cycles.
+- `perf=kptr-restricted` — paranoid is fine, `kptr_restrict != 0`: kernel frames render
+  as bare addresses (a **silent attribution loss**, not an error).
+- `perf=absent` — the `/proc` controls are not present (container without a writable
+  procfs → tune the HOST). `perf=unknown` — present but unparseable, never guessed.
+
+Anything but `ok` on a box you intend to measure means **re-run
+`bash scripts/bootstrap-agent-machine.sh --yes`** (installs + applies + verifies
+`/etc/sysctl.d/99-cqlite-perf.conf`), not "perf is unavailable here". Rationale
+(`-1`, not `1`), the BPF-still-needs-sudo caveat, the single-tenant security posture
+and the `/etc/sysctl.conf` precedence trap: `docs/development/fleet-runbook.md`.
+
+Self-test coverage: `scripts/tests/test_agent_gate_summary.sh` (cases 9f* assert every
+state via the test seam, the Darwin no-token contract, **and** the production branch
+against a real `/proc` fixture with the seam unset) and
+`scripts/tests/test_perf_capability.sh` (the helper contract + the bootstrap
+write/read-back/verify path, including the silent-revert and denied-`perf` cases).
+
 ## Disk hygiene for multi-worktree gates (issue #1848)
 
 Each active worktree owns its own ~25–30GB `target/` dir. Several concurrent

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -200,9 +200,13 @@ event access and therefore DENIES the `perf stat -C <cpu>` collection the measur
 doctrine mandates), `kptr-restricted` (paranoid permissive but `kptr_restrict != 0`, so
 kernel frames resolve to bare addresses — a silent attribution loss), `absent` (the
 `/proc` controls are not present, e.g. a container), or `unknown` (present but
-unparseable — never guessed). The read SHALL be free: no `perf` exec and no subprocess
-in the gate's path. On Darwin the `accelerators:` line SHALL be unchanged (no `perf=`
-token), since both controls are Linux kernel knobs.
+unparseable — never guessed). The read SHALL be free, and free SHALL be enforced by a
+test rather than asserted in prose: the gate's emit-time path SHALL exec no `perf`, SHALL
+spawn no external process, and SHALL contain no command substitution (each `$( )` forks
+a subshell, so the token SHALL be returned through a caller-named variable rather than
+stdout); the helper SHALL be sourced once per gate run, not per summary. On Darwin the
+`accelerators:` line SHALL be unchanged (no `perf=` token), since both controls are Linux
+kernel knobs.
 
 #### Scenario: a profileable Linux worker stamps ok
 - **GIVEN** a Linux host whose `perf_event_paranoid` is `<= 0` and `kptr_restrict` is `0`
@@ -231,6 +235,15 @@ token), since both controls are Linux kernel knobs.
 - **WHEN** the gate emits its summary on a macOS host
 - **THEN** the `accelerators:` line SHALL contain no `perf=` token
 
+#### Scenario: the free-read cost is enforced by a test, not claimed
+- **GIVEN** the gate's emit-time perf path (its token functions plus every helper
+  function they reach)
+- **WHEN** the tooling suite audits it
+- **THEN** the audit SHALL count zero command substitutions statically AND SHALL
+  re-execute that same extracted path with an unresolvable `PATH`, asserting the correct
+  token, zero spawned subshells and zero attempted external commands — so a
+  reintroduced `$( )` or exec FAILS the fast loop instead of surviving as prose
+
 ### Requirement: Bootstrap SHALL install and VERIFY the perf sysctl drop-in on Linux
 
 On Linux, `scripts/bootstrap-agent-machine.sh` SHALL install the reboot-surviving
@@ -240,9 +253,32 @@ assume it. The verdict SHALL come from reading the values back out of `/proc/sys
 (a `sysctl` write's return code proves nothing) and from a FUNCTIONAL
 `perf stat -C 0 -e cycles` collection requiring BOTH exit 0 AND a non-zero cycle count.
 The privileged destination path SHALL be a hardcoded literal, never derived from the
-environment. The section SHALL be advisory: a box without non-interactive root, without
-`perf`, or without the `/proc` controls SHALL warn with an actionable write-AND-apply
-remedy and the run SHALL still exit 0. On Darwin the section SHALL be an explicit no-op.
+environment. The read-back SHALL happen after EVERY attempted apply, REGARDLESS of the
+apply command's exit status, and the apply command's own failure SHALL be reported
+separately from the capability verdict — `sysctl --system` applies every drop-in on the
+box, so a non-zero exit may belong to an unrelated pre-existing entry, and no wording
+SHALL claim "nothing was applied" alongside a good read-back (or the reverse). The
+section SHALL be advisory: a box without non-interactive root, without `perf`, or without
+the `/proc` controls SHALL warn with an actionable remedy — a write-AND-apply remedy when
+the drop-in is missing, an APPLY-ONLY remedy (root-shell or interactive `sudo`, matching
+the detected privilege state) when the drop-in is already current — and the run SHALL
+still exit 0. On Darwin the section SHALL be an explicit no-op.
+
+#### Scenario: a failing apply whose controls DID take is reported honestly
+- **GIVEN** a Linux host where `sysctl --system` exits non-zero (an unrelated
+  pre-existing sysctl entry failed) while our controls DID take
+- **WHEN** bootstrap runs with `--yes`
+- **THEN** it SHALL still read `/proc` back, SHALL report the good verdict from that
+  read, SHALL report the command's non-zero exit as a DISTINCT fact about the command,
+  SHALL NOT claim that nothing was applied, and SHALL exit 0
+
+#### Scenario: a current drop-in that cannot be applied still prints a runnable remedy
+- **GIVEN** a Linux host whose drop-in is already current, whose runtime controls are not
+  profileable, and where bootstrap has no non-interactive privilege
+- **WHEN** bootstrap runs
+- **THEN** it SHALL print an apply remedy runnable ON THAT BOX — `sysctl -q --system` from
+  a root shell where no `sudo` binary exists, `sudo sysctl -q --system` where `sudo` needs
+  a password — never a diagnosis with no remedy
 
 #### Scenario: an applied value that did not take is reported, not claimed
 - **GIVEN** a Linux host where `sysctl --system` exits 0 but `/proc` still reports a

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -189,3 +189,82 @@ active in the resolved cargo config), `overridden` (managed block active but a n
 - **THEN** the `accelerators:` line SHALL contain no `mold=` token and SHALL be
   byte-identical in format to pre-change output
 
+### Requirement: The gate summary SHALL stamp perf profiling capability on Linux hosts
+
+On Linux, every `scripts/agent-gate.sh` summary's `accelerators:` line SHALL carry a
+`perf=` token, after the `mold=` token, with one of five states read from
+`/proc/sys/kernel/{perf_event_paranoid,kptr_restrict}`: `ok` (`perf_event_paranoid <= 0`
+AND `kptr_restrict == 0` — unprivileged per-CPU profiling and kernel symbol resolution
+both available), `paranoid-<N>` (`perf_event_paranoid = N >= 1`, which forbids CPU-wide
+event access and therefore DENIES the `perf stat -C <cpu>` collection the measurement
+doctrine mandates), `kptr-restricted` (paranoid permissive but `kptr_restrict != 0`, so
+kernel frames resolve to bare addresses — a silent attribution loss), `absent` (the
+`/proc` controls are not present, e.g. a container), or `unknown` (present but
+unparseable — never guessed). The read SHALL be free: no `perf` exec and no subprocess
+in the gate's path. On Darwin the `accelerators:` line SHALL be unchanged (no `perf=`
+token), since both controls are Linux kernel knobs.
+
+#### Scenario: a profileable Linux worker stamps ok
+- **GIVEN** a Linux host whose `perf_event_paranoid` is `<= 0` and `kptr_restrict` is `0`
+- **WHEN** any gate mode emits its summary
+- **THEN** the `accelerators:` line SHALL contain `perf=ok`
+
+#### Scenario: the shipped-image denial is visible
+- **GIVEN** a Linux host with `perf_event_paranoid = 4` (the value agent images ship)
+- **WHEN** the gate emits its summary
+- **THEN** the `accelerators:` line SHALL contain `perf=paranoid-4`, never `perf=ok` —
+  a PERMISSION verdict made visible in every pasted block rather than discovered at the
+  start of a measurement cycle
+
+#### Scenario: kernel symbols unavailable is visible
+- **GIVEN** a Linux host with a permissive `perf_event_paranoid` but `kptr_restrict != 0`
+- **WHEN** the gate emits its summary
+- **THEN** the `accelerators:` line SHALL contain `perf=kptr-restricted`
+
+#### Scenario: an unreadable or unparseable control is never guessed
+- **GIVEN** a Linux host where a `/proc` control is missing or holds a non-integer
+- **WHEN** the gate emits its summary
+- **THEN** the `accelerators:` line SHALL contain `perf=absent` or `perf=unknown`
+  respectively, and SHALL NOT infer a capability from the surrounding state
+
+#### Scenario: Darwin summary unchanged by the perf token
+- **WHEN** the gate emits its summary on a macOS host
+- **THEN** the `accelerators:` line SHALL contain no `perf=` token
+
+### Requirement: Bootstrap SHALL install and VERIFY the perf sysctl drop-in on Linux
+
+On Linux, `scripts/bootstrap-agent-machine.sh` SHALL install the reboot-surviving
+drop-in `/etc/sysctl.d/99-cqlite-perf.conf` (`kernel.perf_event_paranoid = -1`,
+`kernel.kptr_restrict = 0`) idempotently, apply it, and then verify the outcome — never
+assume it. The verdict SHALL come from reading the values back out of `/proc/sys/kernel`
+(a `sysctl` write's return code proves nothing) and from a FUNCTIONAL
+`perf stat -C 0 -e cycles` collection requiring BOTH exit 0 AND a non-zero cycle count.
+The privileged destination path SHALL be a hardcoded literal, never derived from the
+environment. The section SHALL be advisory: a box without non-interactive root, without
+`perf`, or without the `/proc` controls SHALL warn with an actionable write-AND-apply
+remedy and the run SHALL still exit 0. On Darwin the section SHALL be an explicit no-op.
+
+#### Scenario: an applied value that did not take is reported, not claimed
+- **GIVEN** a Linux host where `sysctl --system` exits 0 but `/proc` still reports a
+  restrictive value (container, read-only procfs, a later-sorting drop-in or
+  `/etc/sysctl.conf` overriding ours)
+- **WHEN** bootstrap runs with `--yes`
+- **THEN** it SHALL warn that the value did NOT take, SHALL NOT report a successful
+  read-back, and SHALL exit 0
+
+#### Scenario: an rc-0 collection with an unusable counter is NOT verified
+- **GIVEN** a `perf stat` that exits 0 while reporting `<not supported>`, `<not counted>`
+  or a zero count (a virtualised or masked PMU)
+- **WHEN** bootstrap runs the functional verification
+- **THEN** it SHALL report the capability as NOT verified
+
+#### Scenario: check mode mutates nothing
+- **WHEN** bootstrap runs without `--yes` on a Linux host lacking the drop-in
+- **THEN** it SHALL write no file and invoke no privileged mutating command, and SHALL
+  print the complete write-AND-apply remedy using the detected privilege prefix
+
+#### Scenario: Darwin bootstrap no-op
+- **WHEN** bootstrap runs on a macOS host
+- **THEN** the perf section SHALL state that the controls are Linux-only, write nothing,
+  and exit 0
+

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -283,13 +283,22 @@ test-only path seams SHALL be inert without their explicit marker, and UNDER the
 BOTH seams SHALL be MANDATORY, absolute and outside `/etc`, `/proc` and `/sys`: a missing
 or production-shaped seam SHALL be a loud refusal in the env guard AND in the path
 resolvers, so a test-mode run can never fall back to a production directory and mutate the
-host.
+host. On every path that WRITES or gates a write, that judgement SHALL be made on the
+seam's CANONICAL destination — `.`, `..` and symlinked ancestors resolved — and not on its
+spelling, since a textual check accepts an unbounded set of paths that resolve into the
+production directory. The emit-time read path, which writes nothing and is contractually
+fork-free, MAY validate textually (rejecting `.`/`..` components and a symlinked seam).
 
 When the read-back reports a restrictive `perf_event_paranoid`/`kptr_restrict` state, the
-diagnostics SHALL NAME the competing configuration files — every other file in the
-`sysctl.d` directory that also sets either control — and SHALL distinguish one whose
-basename sorts AFTER the managed drop-in (an actual override, since the last assignment
-wins) from one that sorts before it; a run with no competitor SHALL say so explicitly. The read-back SHALL happen after EVERY attempted apply, REGARDLESS of the
+diagnostics SHALL NAME the competing configuration files across the COMPLETE
+`sysctl --system` search path — `/etc/sysctl.d`, `/run/sysctl.d`,
+`/usr/local/lib/sysctl.d`, `/usr/lib/sysctl.d`, `/lib/sysctl.d` and `/etc/sysctl.conf` —
+honouring same-basename masking (a basename supplied by a higher-precedence directory makes
+the lower copy inert, so naming it would point at a file that is not in effect), and SHALL
+distinguish one whose basename sorts AFTER the managed drop-in (an actual override, since
+the last assignment wins) from one that sorts before it, and from `/etc/sysctl.conf` (which
+is applied after every drop-in and therefore wins regardless of name); a run with no
+competitor SHALL say so explicitly. The read-back SHALL happen after EVERY attempted apply, REGARDLESS of the
 apply command's exit status, and the apply command's own failure SHALL be reported
 separately from the capability verdict — `sysctl --system` applies every drop-in on the
 box, so a non-zero exit may belong to an unrelated pre-existing entry, and no wording
@@ -368,21 +377,34 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
   command, SHALL write nothing (in particular not the real `/etc/sysctl.d` drop-in), SHALL
   claim no verdict, and SHALL exit 0
 
+#### Scenario: a test seam that RESOLVES into production refuses to act
+- **GIVEN** the test-mode marker set, a root identity, and a sysctl path seam that passes
+  every textual non-production check but resolves into `/etc/sysctl.d` — `/tmp/../etc/sysctl.d`,
+  or `<symlink-to-/etc>/sysctl.d`
+- **WHEN** bootstrap runs with `--yes`
+- **THEN** it SHALL refuse the section with a loud diagnosis, SHALL invoke no privileged
+  command, SHALL leave the real drop-in byte- and metadata-unchanged, SHALL name no write
+  target at all, and SHALL exit 0
+
 #### Scenario: a non-canonical drop-in is rewritten
 - **GIVEN** an existing drop-in whose bytes differ from the canonical content only in
-  trailing newlines (a missing final newline, or an extra trailing blank line)
+  trailing newlines (a missing final newline, or an extra trailing blank line), or which
+  carries the canonical content followed by a NUL byte and arbitrary trailing bytes
 - **WHEN** bootstrap runs with `--yes`
 - **THEN** it SHALL NOT report "already current", SHALL rewrite the file, and the result
   SHALL be byte-identical to the canonical content
 
-#### Scenario: a competing sysctl file is named
-- **GIVEN** a Linux host whose read-back is non-`ok` and whose `sysctl.d` directory holds
-  another file setting `perf_event_paranoid`/`kptr_restrict` (e.g. the stock Ubuntu
-  `10-kernel-hardening.conf`, plus one sorting after the managed drop-in)
+#### Scenario: a competing sysctl file is named, anywhere on the search path
+- **GIVEN** a Linux host whose read-back is non-`ok` and whose `sysctl --system` search path
+  holds other files setting `perf_event_paranoid`/`kptr_restrict` — the stock Ubuntu
+  `/etc/sysctl.d/10-kernel-hardening.conf`, a later-sorting file in a LOWER-precedence
+  directory such as `/run/sysctl.d`, an `/etc/sysctl.conf` entry, and a same-basename copy
+  masked by a higher-precedence directory
 - **WHEN** bootstrap runs
-- **THEN** the diagnostics SHALL name each competing file by path, SHALL flag the
-  later-sorting one as an actual OVERRIDE, and SHALL state that the earlier-sorting one
-  loses to the managed `99-` prefix
+- **THEN** the diagnostics SHALL name each competing file that is IN EFFECT by path, SHALL
+  flag the later-sorting one as an actual OVERRIDE, SHALL flag `/etc/sysctl.conf` as applied
+  after every drop-in (winning regardless of name), SHALL state that the earlier-sorting one
+  loses to the managed `99-` prefix, and SHALL NOT name the masked copy
 
 #### Scenario: an inherited environment variable cannot enter the section
 - **GIVEN** an ambient `PERF_SECTION_OK=1` in bootstrap's environment

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -258,15 +258,38 @@ DIAGNOSTIC INFORMATION, explicitly subordinate to the `/proc` verdict, and no ru
 emit a non-`ok` token diagnosis and an unqualified "VERIFIED" together. Because
 `perf_event_paranoid` restricts UNPRIVILEGED users and ROOT BYPASSES IT, the functional
 collection SHALL be attributed to an identity: when bootstrap runs as root it SHALL DROP
-PRIVILEGE for the probe where a mechanism exists (`setpriv`, else `runuser`, else
-`sudo -u`) targeting an unprivileged identity resolved from `SUDO_UID`/`SUDO_GID` else the
-passwd database's `nobody` — never an invented uid — and where no mechanism or no such
-identity exists it SHALL label the root result as NOT evidence of unprivileged capability
-and SHALL NOT report it as verification. The privileged destination path SHALL be a
-hardcoded literal, never derived from the environment, and every variable the section's
-control flow reads SHALL be initialised by the section BEFORE the platform/library guards,
-so no inherited environment value can enter a Linux-only implementation on another
-platform or without its helper library. The read-back SHALL happen after EVERY attempted apply, REGARDLESS of the
+PRIVILEGE for the probe where a mechanism exists (`setpriv`, else `runuser -u <name>`, else
+`sudo -u '#<uid>'`) targeting an unprivileged identity resolved from `SUDO_UID`/`SUDO_GID`
+else the passwd database's `nobody` — never an invented uid — and where no mechanism or no
+such identity exists it SHALL label the root result as NOT evidence of unprivileged
+capability and SHALL NOT report it as verification.
+
+NO PATH SHALL REACH A CAPABLE/VERIFIED VERDICT FROM AN UNVALIDATED INPUT. Specifically:
+the process's own privilege SHALL be determined from an `id -u` that exists, exits 0 and
+prints a validated non-negative integer — an unusable `id -u` SHALL yield an explicit
+`identity-unknown` state that is NOT evidence of unprivileged capability, and SHALL NEVER
+be substituted with an assumed uid; a `SUDO_USER` name SHALL be used only when the passwd
+database confirms it resolves to exactly the validated NON-ZERO `SUDO_UID`/`SUDO_GID` and
+the name is shell-token safe, otherwise the numeric ids alone SHALL carry the drop; and
+the drop-in comparison SHALL be BYTE-exact including trailing newlines, so a file
+differing only in a missing final newline or an extra trailing blank line SHALL be judged
+NOT current and rewritten.
+
+The privileged destination path SHALL be a hardcoded literal, never derived from the
+environment, and every variable the section's control flow reads SHALL be initialised by
+the section BEFORE the platform/library guards, so no inherited environment value can
+enter a Linux-only implementation on another platform or without its helper library. The
+test-only path seams SHALL be inert without their explicit marker, and UNDER the marker
+BOTH seams SHALL be MANDATORY, absolute and outside `/etc`, `/proc` and `/sys`: a missing
+or production-shaped seam SHALL be a loud refusal in the env guard AND in the path
+resolvers, so a test-mode run can never fall back to a production directory and mutate the
+host.
+
+When the read-back reports a restrictive `perf_event_paranoid`/`kptr_restrict` state, the
+diagnostics SHALL NAME the competing configuration files — every other file in the
+`sysctl.d` directory that also sets either control — and SHALL distinguish one whose
+basename sorts AFTER the managed drop-in (an actual override, since the last assignment
+wins) from one that sorts before it; a run with no competitor SHALL say so explicitly. The read-back SHALL happen after EVERY attempted apply, REGARDLESS of the
 apply command's exit status, and the apply command's own failure SHALL be reported
 separately from the capability verdict — `sysctl --system` applies every drop-in on the
 box, so a non-zero exit may belong to an unrelated pre-existing entry, and no wording
@@ -324,6 +347,42 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
 - **WHEN** no such mechanism or identity is available
 - **THEN** bootstrap SHALL label the result as NOT evidence that an unprivileged process
   can profile the box, SHALL NOT report VERIFIED even with `/proc` = `ok`, and SHALL exit 0
+
+#### Scenario: an unknown identity is not evidence of unprivileged capability
+- **GIVEN** a Linux host on which `id -u` is missing, exits non-zero, or prints
+  unparseable output, while `perf stat -C 0 -e cycles` succeeds and `/proc` reports `ok`
+- **WHEN** bootstrap runs
+- **THEN** it SHALL report the identity as UNKNOWN, SHALL NOT report VERIFIED, SHALL NOT
+  assert that the probe ran as root either, and SHALL exit 0
+
+#### Scenario: an inconsistent SUDO_USER cannot become the drop target
+- **GIVEN** `SUDO_UID=1000` with `SUDO_USER=root` (stale or inconsistent) and no `setpriv`
+- **WHEN** the privilege-dropping prefix is resolved
+- **THEN** the name SHALL be rejected and the drop SHALL use the validated numeric uid
+  (`sudo -u '#1000'`), so the probe can never run as root under a "dropped" label
+
+#### Scenario: test mode without a sandbox refuses to act
+- **GIVEN** the test-mode marker set, a root identity, and NO path seams set
+- **WHEN** bootstrap runs with `--yes`
+- **THEN** it SHALL refuse the section with a loud diagnosis, SHALL invoke no privileged
+  command, SHALL write nothing (in particular not the real `/etc/sysctl.d` drop-in), SHALL
+  claim no verdict, and SHALL exit 0
+
+#### Scenario: a non-canonical drop-in is rewritten
+- **GIVEN** an existing drop-in whose bytes differ from the canonical content only in
+  trailing newlines (a missing final newline, or an extra trailing blank line)
+- **WHEN** bootstrap runs with `--yes`
+- **THEN** it SHALL NOT report "already current", SHALL rewrite the file, and the result
+  SHALL be byte-identical to the canonical content
+
+#### Scenario: a competing sysctl file is named
+- **GIVEN** a Linux host whose read-back is non-`ok` and whose `sysctl.d` directory holds
+  another file setting `perf_event_paranoid`/`kptr_restrict` (e.g. the stock Ubuntu
+  `10-kernel-hardening.conf`, plus one sorting after the managed drop-in)
+- **WHEN** bootstrap runs
+- **THEN** the diagnostics SHALL name each competing file by path, SHALL flag the
+  later-sorting one as an actual OVERRIDE, and SHALL state that the earlier-sorting one
+  loses to the managed `99-` prefix
 
 #### Scenario: an inherited environment variable cannot enter the section
 - **GIVEN** an ambient `PERF_SECTION_OK=1` in bootstrap's environment

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -386,6 +386,11 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
   command, SHALL leave the real drop-in byte- and metadata-unchanged, SHALL name no write
   target at all, and SHALL exit 0
 
+#### Scenario: re-run writes nothing
+- **WHEN** bootstrap runs twice on the same host
+- **THEN** the second run SHALL report the drop-in as already current and SHALL NOT
+  re-write it, invoking no privileged write command
+
 #### Scenario: a non-canonical drop-in is rewritten
 - **GIVEN** an existing drop-in whose bytes differ from the canonical content only in
   trailing newlines (a missing final newline, or an extra trailing blank line), or which

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -280,32 +280,14 @@ environment, and every variable the section's control flow reads SHALL be initia
 the section BEFORE the platform/library guards, so no inherited environment value can
 enter a Linux-only implementation on another platform or without its helper library. The
 test-only path seams SHALL be inert without their explicit marker, and UNDER the marker
-BOTH seams SHALL be MANDATORY: a seam that is not usable SHALL be a loud refusal in the env
-guard AND in the path resolvers, so a test-mode run can never fall back to a production
-directory and mutate the host.
-
-A seam's usability SHALL be decided by POSITIVE CONTAINMENT and by nothing else: test mode
-SHALL take ONE caller-declared sandbox root, and a seam SHALL be usable IFF it is STRICTLY
-contained within that root (a resolved-path prefix match with an explicit `/` boundary, so a
-sibling whose name merely starts with the root's is outside). Anything not provably inside
-the sandbox SHALL be refused. The implementation SHALL NOT decide usability from a list of
-forbidden locations or path spellings: such a list cannot be completed — `.`, `..`,
-symlinks, `//` (POSIX leaves two leading slashes implementation-defined and `pwd -P` may
-preserve them, while on Linux `//etc` opens `/etc`), trailing slashes, bind mounts and
-`/proc/self/root/…` all name the same directory — and a set of scattered prohibitions also
-lets a NEW seam consumer silently miss them. The sandbox root SHALL itself prove it is a
-sandbox by evidence on the filesystem (an absolute, canonically spelled, existing directory
-carrying a stamp file), so no environment value alone can nominate a production directory as
-the sandbox. EVERY consumer of a seam SHALL route through that one containment check —
-writes, write gating, the drop-in path, and every read of configuration (including the
-lower-precedence search-path entries and an optional `sysctl.conf` FILE entry, whose parent
-SHALL be canonicalized and the resulting file path validated) — and a consumer that does not
-SHALL be a failure of the test suite's structural audit rather than an unvalidated path. On
-every path that WRITES, gates a write, or reads host configuration, containment SHALL be
-judged on the CANONICALIZED candidate and root (`.`, `..` and symlinked ancestors resolved).
-The emit-time read path, which writes nothing and is contractually fork-free, MAY apply the
-same containment check syntactically, since its guarantee rests on the marker being absent
-in production and a mis-accepted spelling there can only read a caller-chosen file.
+BOTH seams SHALL be MANDATORY, absolute and outside `/etc`, `/proc` and `/sys`: a missing
+or production-shaped seam SHALL be a loud refusal in the env guard AND in the path
+resolvers, so a test-mode run can never fall back to a production directory and mutate the
+host. On every path that WRITES or gates a write, that judgement SHALL be made on the
+seam's CANONICAL destination — `.`, `..` and symlinked ancestors resolved — and not on its
+spelling, since a textual check accepts an unbounded set of paths that resolve into the
+production directory. The emit-time read path, which writes nothing and is contractually
+fork-free, MAY validate textually (rejecting `.`/`..` components and a symlinked seam).
 
 When the read-back reports a restrictive `perf_event_paranoid`/`kptr_restrict` state, the
 diagnostics SHALL NAME the competing configuration files across the COMPLETE
@@ -395,31 +377,14 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
   command, SHALL write nothing (in particular not the real `/etc/sysctl.d` drop-in), SHALL
   claim no verdict, and SHALL exit 0
 
-#### Scenario: a test seam outside the declared sandbox refuses to act
-- **GIVEN** the test-mode marker set, a root identity, and a sysctl path seam that is not
-  strictly contained in the declared sandbox root — `/tmp/../etc/sysctl.d`,
-  `<symlink-to-/etc>/sysctl.d`, `//etc/sysctl.d`, a symlink whose target is outside the
-  sandbox, a relative path, or a sibling whose name merely starts with the root's
+#### Scenario: a test seam that RESOLVES into production refuses to act
+- **GIVEN** the test-mode marker set, a root identity, and a sysctl path seam that passes
+  every textual non-production check but resolves into `/etc/sysctl.d` — `/tmp/../etc/sysctl.d`,
+  or `<symlink-to-/etc>/sysctl.d`
 - **WHEN** bootstrap runs with `--yes`
-- **THEN** it SHALL refuse the section with a loud diagnosis NAMING the offending seam, SHALL
-  invoke no privileged command, SHALL leave the real drop-in byte- and metadata-unchanged,
-  SHALL name no write target at all, and SHALL exit 0
-- **AND** the refusal SHALL come from the single containment check, so no per-spelling rule
-  is required for any of those forms, nor for a form not yet enumerated
-
-#### Scenario: an unproven sandbox root cannot make containment vacuous
-- **GIVEN** the test-mode marker set and a sandbox root that is unset, relative,
-  `//`-spelled, non-existent, or an existing directory carrying no sandbox stamp
-- **WHEN** any seam consumer resolves a path
-- **THEN** it SHALL refuse, naming the sandbox-root variable, so declaring a production
-  directory as the sandbox by environment alone cannot succeed
-
-#### Scenario: a seam consumer cannot skip the containment check
-- **GIVEN** the helper's source
-- **WHEN** the test suite audits every function that dereferences a seam variable
-- **THEN** each SHALL route through the containment check, with only an explicitly named and
-  justified allowlist (a presence-only predicate and the root reader itself), and finding no
-  consumers at all SHALL be a failure rather than a vacuous pass
+- **THEN** it SHALL refuse the section with a loud diagnosis, SHALL invoke no privileged
+  command, SHALL leave the real drop-in byte- and metadata-unchanged, SHALL name no write
+  target at all, and SHALL exit 0
 
 #### Scenario: a non-canonical drop-in is rewritten
 - **GIVEN** an existing drop-in whose bytes differ from the canonical content only in

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -280,14 +280,32 @@ environment, and every variable the section's control flow reads SHALL be initia
 the section BEFORE the platform/library guards, so no inherited environment value can
 enter a Linux-only implementation on another platform or without its helper library. The
 test-only path seams SHALL be inert without their explicit marker, and UNDER the marker
-BOTH seams SHALL be MANDATORY, absolute and outside `/etc`, `/proc` and `/sys`: a missing
-or production-shaped seam SHALL be a loud refusal in the env guard AND in the path
-resolvers, so a test-mode run can never fall back to a production directory and mutate the
-host. On every path that WRITES or gates a write, that judgement SHALL be made on the
-seam's CANONICAL destination — `.`, `..` and symlinked ancestors resolved — and not on its
-spelling, since a textual check accepts an unbounded set of paths that resolve into the
-production directory. The emit-time read path, which writes nothing and is contractually
-fork-free, MAY validate textually (rejecting `.`/`..` components and a symlinked seam).
+BOTH seams SHALL be MANDATORY: a seam that is not usable SHALL be a loud refusal in the env
+guard AND in the path resolvers, so a test-mode run can never fall back to a production
+directory and mutate the host.
+
+A seam's usability SHALL be decided by POSITIVE CONTAINMENT and by nothing else: test mode
+SHALL take ONE caller-declared sandbox root, and a seam SHALL be usable IFF it is STRICTLY
+contained within that root (a resolved-path prefix match with an explicit `/` boundary, so a
+sibling whose name merely starts with the root's is outside). Anything not provably inside
+the sandbox SHALL be refused. The implementation SHALL NOT decide usability from a list of
+forbidden locations or path spellings: such a list cannot be completed — `.`, `..`,
+symlinks, `//` (POSIX leaves two leading slashes implementation-defined and `pwd -P` may
+preserve them, while on Linux `//etc` opens `/etc`), trailing slashes, bind mounts and
+`/proc/self/root/…` all name the same directory — and a set of scattered prohibitions also
+lets a NEW seam consumer silently miss them. The sandbox root SHALL itself prove it is a
+sandbox by evidence on the filesystem (an absolute, canonically spelled, existing directory
+carrying a stamp file), so no environment value alone can nominate a production directory as
+the sandbox. EVERY consumer of a seam SHALL route through that one containment check —
+writes, write gating, the drop-in path, and every read of configuration (including the
+lower-precedence search-path entries and an optional `sysctl.conf` FILE entry, whose parent
+SHALL be canonicalized and the resulting file path validated) — and a consumer that does not
+SHALL be a failure of the test suite's structural audit rather than an unvalidated path. On
+every path that WRITES, gates a write, or reads host configuration, containment SHALL be
+judged on the CANONICALIZED candidate and root (`.`, `..` and symlinked ancestors resolved).
+The emit-time read path, which writes nothing and is contractually fork-free, MAY apply the
+same containment check syntactically, since its guarantee rests on the marker being absent
+in production and a mis-accepted spelling there can only read a caller-chosen file.
 
 When the read-back reports a restrictive `perf_event_paranoid`/`kptr_restrict` state, the
 diagnostics SHALL NAME the competing configuration files across the COMPLETE
@@ -377,14 +395,31 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
   command, SHALL write nothing (in particular not the real `/etc/sysctl.d` drop-in), SHALL
   claim no verdict, and SHALL exit 0
 
-#### Scenario: a test seam that RESOLVES into production refuses to act
-- **GIVEN** the test-mode marker set, a root identity, and a sysctl path seam that passes
-  every textual non-production check but resolves into `/etc/sysctl.d` — `/tmp/../etc/sysctl.d`,
-  or `<symlink-to-/etc>/sysctl.d`
+#### Scenario: a test seam outside the declared sandbox refuses to act
+- **GIVEN** the test-mode marker set, a root identity, and a sysctl path seam that is not
+  strictly contained in the declared sandbox root — `/tmp/../etc/sysctl.d`,
+  `<symlink-to-/etc>/sysctl.d`, `//etc/sysctl.d`, a symlink whose target is outside the
+  sandbox, a relative path, or a sibling whose name merely starts with the root's
 - **WHEN** bootstrap runs with `--yes`
-- **THEN** it SHALL refuse the section with a loud diagnosis, SHALL invoke no privileged
-  command, SHALL leave the real drop-in byte- and metadata-unchanged, SHALL name no write
-  target at all, and SHALL exit 0
+- **THEN** it SHALL refuse the section with a loud diagnosis NAMING the offending seam, SHALL
+  invoke no privileged command, SHALL leave the real drop-in byte- and metadata-unchanged,
+  SHALL name no write target at all, and SHALL exit 0
+- **AND** the refusal SHALL come from the single containment check, so no per-spelling rule
+  is required for any of those forms, nor for a form not yet enumerated
+
+#### Scenario: an unproven sandbox root cannot make containment vacuous
+- **GIVEN** the test-mode marker set and a sandbox root that is unset, relative,
+  `//`-spelled, non-existent, or an existing directory carrying no sandbox stamp
+- **WHEN** any seam consumer resolves a path
+- **THEN** it SHALL refuse, naming the sandbox-root variable, so declaring a production
+  directory as the sandbox by environment alone cannot succeed
+
+#### Scenario: a seam consumer cannot skip the containment check
+- **GIVEN** the helper's source
+- **WHEN** the test suite audits every function that dereferences a seam variable
+- **THEN** each SHALL route through the containment check, with only an explicitly named and
+  justified allowlist (a presence-only predicate and the root reader itself), and finding no
+  consumers at all SHALL be a failure rather than a vacuous pass
 
 #### Scenario: a non-canonical drop-in is rewritten
 - **GIVEN** an existing drop-in whose bytes differ from the canonical content only in

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -252,8 +252,21 @@ drop-in `/etc/sysctl.d/99-cqlite-perf.conf` (`kernel.perf_event_paranoid = -1`,
 assume it. The verdict SHALL come from reading the values back out of `/proc/sys/kernel`
 (a `sysctl` write's return code proves nothing) and from a FUNCTIONAL
 `perf stat -C 0 -e cycles` collection requiring BOTH exit 0 AND a non-zero cycle count.
-The privileged destination path SHALL be a hardcoded literal, never derived from the
-environment. The read-back SHALL happen after EVERY attempted apply, REGARDLESS of the
+An overall "VERIFIED" report SHALL require BOTH the `/proc` token `ok` AND that functional
+pass; a functional result that is not accompanied by both SHALL be reported as PARTIAL
+DIAGNOSTIC INFORMATION, explicitly subordinate to the `/proc` verdict, and no run SHALL
+emit a non-`ok` token diagnosis and an unqualified "VERIFIED" together. Because
+`perf_event_paranoid` restricts UNPRIVILEGED users and ROOT BYPASSES IT, the functional
+collection SHALL be attributed to an identity: when bootstrap runs as root it SHALL DROP
+PRIVILEGE for the probe where a mechanism exists (`setpriv`, else `runuser`, else
+`sudo -u`) targeting an unprivileged identity resolved from `SUDO_UID`/`SUDO_GID` else the
+passwd database's `nobody` — never an invented uid — and where no mechanism or no such
+identity exists it SHALL label the root result as NOT evidence of unprivileged capability
+and SHALL NOT report it as verification. The privileged destination path SHALL be a
+hardcoded literal, never derived from the environment, and every variable the section's
+control flow reads SHALL be initialised by the section BEFORE the platform/library guards,
+so no inherited environment value can enter a Linux-only implementation on another
+platform or without its helper library. The read-back SHALL happen after EVERY attempted apply, REGARDLESS of the
 apply command's exit status, and the apply command's own failure SHALL be reported
 separately from the capability verdict — `sysctl --system` applies every drop-in on the
 box, so a non-zero exit may belong to an unrelated pre-existing entry, and no wording
@@ -293,6 +306,30 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
   or a zero count (a virtualised or masked PMU)
 - **WHEN** bootstrap runs the functional verification
 - **THEN** it SHALL report the capability as NOT verified
+
+#### Scenario: a functional pass never overrides a non-ok /proc verdict
+- **GIVEN** a Linux host whose `/proc` reports `paranoid-4` (or `kptr-restricted`) while
+  `perf stat -C 0 -e cycles` succeeds with a non-zero count
+- **WHEN** bootstrap runs
+- **THEN** it SHALL NOT report an unqualified "VERIFIED", SHALL report the functional
+  result as partial diagnostic information subordinate to `/proc`, SHALL name `/proc` as
+  the authority with the token it read, and SHALL exit 0
+
+#### Scenario: a root-run functional pass is not evidence of unprivileged capability
+- **GIVEN** a Linux host where bootstrap runs AS ROOT (e.g. under `sudo`) and
+  `perf stat -C 0 -e cycles` succeeds
+- **WHEN** a privilege-dropping mechanism and an unprivileged identity are available
+- **THEN** bootstrap SHALL run the probe with privilege dropped, SHALL state which
+  identity it measured, and only then MAY report VERIFIED (given `/proc` = `ok`)
+- **WHEN** no such mechanism or identity is available
+- **THEN** bootstrap SHALL label the result as NOT evidence that an unprivileged process
+  can profile the box, SHALL NOT report VERIFIED even with `/proc` = `ok`, and SHALL exit 0
+
+#### Scenario: an inherited environment variable cannot enter the section
+- **GIVEN** an ambient `PERF_SECTION_OK=1` in bootstrap's environment
+- **WHEN** bootstrap runs on macOS, or on a checkout with no `scripts/perf-capability.sh`
+- **THEN** the section SHALL take its no-op / missing-library path, SHALL call no helper
+  from the Linux-only implementation, and SHALL exit 0
 
 #### Scenario: check mode mutates nothing
 - **WHEN** bootstrap runs without `--yes` on a Linux host lacking the drop-in

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -747,22 +747,25 @@ _mold_accel_token() {
 # SUMMARY instead of being discovered at the start of a measurement cycle.
 #
 # HARD CONSTRAINT: this is the FREE /proc read from scripts/perf-capability.sh and
-# nothing else — no `perf stat` exec, no new binary dependency, no measurable time
-# cost in the gate's path. The functional verification (which DOES exec perf) is
+# nothing else — no `perf stat` exec, no new binary dependency, no subprocess at all
+# (perf_capability_proc_value reads through the `read` builtin), so no measurable
+# time cost in the gate's path. The functional verification (which DOES exec perf) is
 # bootstrap's job, not the gate's.
-_PERF_STATE=""
+#
+# NO MEMOIZATION here, deliberately: every call site is inside a `$( )`, so an
+# assignment to a script-level cache would land in a subshell and be discarded — a
+# cache that looks real and never hits. Two `read`-builtin /proc reads cost nothing,
+# so the honest implementation is to just do them.
 _perf_state() {
-  [ -n "$_PERF_STATE" ] && { printf '%s' "$_PERF_STATE"; return; }
+  local state=""
   if [ -n "${AGENT_GATE_TEST_PERF_STATE:-}" ]; then
-    _PERF_STATE="$AGENT_GATE_TEST_PERF_STATE"
+    state="$AGENT_GATE_TEST_PERF_STATE"
   elif [ -r "$REPO_ROOT/scripts/perf-capability.sh" ] &&
        . "$REPO_ROOT/scripts/perf-capability.sh" 2>/dev/null; then
-    _PERF_STATE="$(perf_capability_token)"
-  else
-    _PERF_STATE=unknown
+    state="$(perf_capability_token)"
   fi
-  [ -n "$_PERF_STATE" ] || _PERF_STATE=unknown
-  printf '%s' "$_PERF_STATE"
+  [ -n "$state" ] || state=unknown
+  printf '%s' "$state"
 }
 
 # _perf_accel_token: the ` perf=<state>` suffix on Linux hosts, empty elsewhere —

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -260,6 +260,16 @@
 #                      which pins the perf-corpus generator's TABLES validation, its
 #                      manifest writer's refusal of an empty table list, and the
 #                      tight scoping of its multi-GB stale-corpus pruning.
+#                      Also runs (no python3/sudo/perf needed)
+#                      scripts/tests/test_perf_capability.sh (#3249) — pins the perf
+#                      profiling capability path: the shared scripts/perf-capability.sh
+#                      (free /proc token, canonical /etc/sysctl.d/99-cqlite-perf.conf
+#                      bytes, side-effect-free sourcing) and bootstrap's install +
+#                      VERIFY section. Its load-bearing arm is that the FUNCTIONAL
+#                      check is HONOURED: a shimmed perf that EXITS 0 while reporting
+#                      0 / `<not supported>` must WARN, never "verified". Hermetic —
+#                      test-only seams stand in for /proc and /etc/sysctl.d and every
+#                      privileged tool is a recording shim, asserted mutation-free.
 #                      Also runs (no python3/network/datasets needed)
 #                      scripts/tests/test_fetch_datasets_tracked_guard.sh (#2878) —
 #                      pins fetch-datasets.sh's tracked-fixture guard: its `rm -rf
@@ -5752,13 +5762,14 @@ run_tooling_tests() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_gate_notify_contract.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_gate_notify_contract.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_perf_capability.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
   if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_notify.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_gate_notify_contract.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_smoke_target_dir.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_gate_concurrency_cap.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_bootstrap_agent_machine.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/tests/test_perf_capability.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_claim_lock.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/flow/tests/claim-resume.test.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_premerge_assert.sh" >>"$log" 2>&1 &&

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -746,38 +746,68 @@ _mold_accel_token() {
 # Stamping it here makes "this box cannot be profiled" visible in every pasted
 # SUMMARY instead of being discovered at the start of a measurement cycle.
 #
-# HARD CONSTRAINT: this is the FREE /proc read from scripts/perf-capability.sh and
-# nothing else — no `perf stat` exec, no new binary dependency, no subprocess at all
-# (perf_capability_proc_value reads through the `read` builtin), so no measurable
-# time cost in the gate's path. The functional verification (which DOES exec perf) is
-# bootstrap's job, not the gate's.
+# HARD CONSTRAINT — and it is ENFORCED, not asserted in prose (issue #3249 review):
+# the emit-time perf path is the FREE /proc read from scripts/perf-capability.sh and
+# NOTHING else: no `perf stat` exec, no new binary dependency, no external process,
+# and no command substitution — a `$( )` is a forked subshell, so "no subprocess" that
+# is read back through `$( )` would be self-contradictory. That is why the functions
+# below take an <outvar> and assign into it instead of printing (and why the helper is
+# sourced ONCE, at script scope, rather than re-read on every summary). Case 9f-free
+# of scripts/tests/test_agent_gate_summary.sh kills any regression: it runs this exact
+# code with an EMPTY PATH and with xtrace subshell-depth counting. The functional
+# verification (which DOES exec perf) is bootstrap's job, not the gate's.
 #
-# NO MEMOIZATION here, deliberately: every call site is inside a `$( )`, so an
+# NO MEMOIZATION of the state, deliberately: every emit runs inside a `$( )`, so an
 # assignment to a script-level cache would land in a subshell and be discarded — a
 # cache that looks real and never hits. Two `read`-builtin /proc reads cost nothing,
 # so the honest implementation is to just do them.
-_perf_state() {
-  local state=""
+#
+# Sourced HERE, at script scope: the helper is 300+ lines, and re-reading it on every
+# emit bought nothing (its functions are all a subshell inherits anyway). Sourcing it
+# is documented side-effect free — functions plus PERF_CAPABILITY_* constants only.
+_PERF_CAP_LOADED=0
+if [ -r "$REPO_ROOT/scripts/perf-capability.sh" ]; then
+  # shellcheck source=scripts/perf-capability.sh
+  if . "$REPO_ROOT/scripts/perf-capability.sh" 2>/dev/null; then _PERF_CAP_LOADED=1; fi
+fi
+
+# _AGENT_GATE_OS: the host OS, resolved ONCE per gate run. `uname` is an external
+# process, so the OS question cannot be asked inside the per-emit token path above;
+# asking it at script scope costs one fork per RUN instead of one per summary. The
+# AGENT_GATE_TEST_OS seam is honoured exactly as before (tests export it before the
+# gate starts, so call-time vs init-time resolution is equivalent).
+_AGENT_GATE_OS="${AGENT_GATE_TEST_OS:-$(uname -s 2>/dev/null || echo unknown)}"
+
+# _perf_state_into <outvar>: the state token, assigned into <outvar>. Never left
+# empty — an empty token would emit a bare `perf=`, which no consumer can parse.
+_perf_state_into() {
+  local __ps_out="$1" __ps_v=""
   if [ -n "${AGENT_GATE_TEST_PERF_STATE:-}" ]; then
-    state="$AGENT_GATE_TEST_PERF_STATE"
-  elif [ -r "$REPO_ROOT/scripts/perf-capability.sh" ] &&
-       . "$REPO_ROOT/scripts/perf-capability.sh" 2>/dev/null; then
-    state="$(perf_capability_token)"
+    __ps_v="$AGENT_GATE_TEST_PERF_STATE"
+  elif [ "${_PERF_CAP_LOADED:-0}" = 1 ]; then
+    perf_capability_token_into __ps_v
   fi
-  [ -n "$state" ] || state=unknown
-  printf '%s' "$state"
+  [ -n "$__ps_v" ] || __ps_v=unknown
+  eval "$__ps_out=\$__ps_v"
 }
 
-# _perf_accel_token: the ` perf=<state>` suffix on Linux hosts, empty elsewhere —
-# the controls are Linux kernel knobs, so Darwin output stays byte-identical
-# (same contract as _mold_accel_token above).
-_perf_accel_token() {
-  local os="${AGENT_GATE_TEST_OS:-$(uname -s 2>/dev/null || echo unknown)}"
-  case "$os" in
-    Linux|linux) printf ' perf=%s' "$(_perf_state)" ;;
-    *) : ;;
+# _perf_accel_token_into <outvar>: the ` perf=<state>` suffix on Linux hosts, empty
+# elsewhere — the controls are Linux kernel knobs, so Darwin output stays
+# byte-identical (same contract as _mold_accel_token above).
+_perf_accel_token_into() {
+  local __pat_out="$1" __pat_state=""
+  case "${_AGENT_GATE_OS:-unknown}" in
+    Linux|linux)
+      _perf_state_into __pat_state
+      eval "$__pat_out=\" perf=\$__pat_state\"" ;;
+    *) eval "$__pat_out=" ;;
   esac
 }
+
+# stdout forms, for debugging/ad-hoc use only — NOT the emit path (reading them costs
+# the caller the very `$( )` the `_into` forms exist to avoid).
+_perf_state()       { local v; _perf_state_into v; printf '%s' "$v"; }
+_perf_accel_token() { local v; _perf_accel_token_into v; printf '%s' "$v"; }
 
 # accelerators_line: the machine-checkable one-liner stamped into every SUMMARY
 # block (full, lite, and the emission selftest). Values: on|absent|off|serial.
@@ -786,10 +816,15 @@ _perf_accel_token() {
 # a ` mold=linked|overridden|present-unconfigured|absent` token follows (issue
 # #2859), then ` perf=ok|paranoid-<N>|kptr-restricted|absent|unknown` (issue
 # #3249); Darwin output is unchanged.
+# The perf token is fetched through a VARIABLE, not a `$( )`: its path is
+# contractually free of forks (see above), and reading it back through a command
+# substitution here would reintroduce exactly the subshell that contract excludes.
 accelerators_line() {
+  local perf_tok=""
+  _perf_accel_token_into perf_tok
   printf 'accelerators: sccache=%s nextest=%s lanes=%s sccache-health=%s%s%s' \
     "${ACCEL_SCCACHE:-unknown}" "${ACCEL_NEXTEST:-unknown}" "${ACCEL_LANES:-unknown}" \
-    "$(_sccache_health)" "$(_mold_accel_token)" "$(_perf_accel_token)"
+    "$(_sccache_health)" "$(_mold_accel_token)" "$perf_tok"
 }
 
 # ---- Per-gate core budget (issue #2640) -------------------------------------

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -729,16 +729,54 @@ _mold_accel_token() {
   esac
 }
 
+# ---- perf profiling capability token (Linux only, issue #3249) --------------
+# Agent boxes ship with kernel.perf_event_paranoid = 4, which denies ALL
+# unprivileged perf use — a PERMISSION verdict that reads like a missing
+# CAPABILITY, and one that reverts on reboot when no /etc/sysctl.d drop-in exists.
+# Stamping it here makes "this box cannot be profiled" visible in every pasted
+# SUMMARY instead of being discovered at the start of a measurement cycle.
+#
+# HARD CONSTRAINT: this is the FREE /proc read from scripts/perf-capability.sh and
+# nothing else — no `perf stat` exec, no new binary dependency, no measurable time
+# cost in the gate's path. The functional verification (which DOES exec perf) is
+# bootstrap's job, not the gate's.
+_PERF_STATE=""
+_perf_state() {
+  [ -n "$_PERF_STATE" ] && { printf '%s' "$_PERF_STATE"; return; }
+  if [ -n "${AGENT_GATE_TEST_PERF_STATE:-}" ]; then
+    _PERF_STATE="$AGENT_GATE_TEST_PERF_STATE"
+  elif [ -r "$REPO_ROOT/scripts/perf-capability.sh" ] &&
+       . "$REPO_ROOT/scripts/perf-capability.sh" 2>/dev/null; then
+    _PERF_STATE="$(perf_capability_token)"
+  else
+    _PERF_STATE=unknown
+  fi
+  [ -n "$_PERF_STATE" ] || _PERF_STATE=unknown
+  printf '%s' "$_PERF_STATE"
+}
+
+# _perf_accel_token: the ` perf=<state>` suffix on Linux hosts, empty elsewhere —
+# the controls are Linux kernel knobs, so Darwin output stays byte-identical
+# (same contract as _mold_accel_token above).
+_perf_accel_token() {
+  local os="${AGENT_GATE_TEST_OS:-$(uname -s 2>/dev/null || echo unknown)}"
+  case "$os" in
+    Linux|linux) printf ' perf=%s' "$(_perf_state)" ;;
+    *) : ;;
+  esac
+}
+
 # accelerators_line: the machine-checkable one-liner stamped into every SUMMARY
 # block (full, lite, and the emission selftest). Values: on|absent|off|serial.
 # See the ACCEL_* detection above (#1848). The trailing sccache-health token
 # (na|ok|warn, issue #2641) surfaces sccache's own corruption counters. On Linux
 # a ` mold=linked|overridden|present-unconfigured|absent` token follows (issue
-# #2859); Darwin output is unchanged.
+# #2859), then ` perf=ok|paranoid-<N>|kptr-restricted|absent|unknown` (issue
+# #3249); Darwin output is unchanged.
 accelerators_line() {
-  printf 'accelerators: sccache=%s nextest=%s lanes=%s sccache-health=%s%s' \
+  printf 'accelerators: sccache=%s nextest=%s lanes=%s sccache-health=%s%s%s' \
     "${ACCEL_SCCACHE:-unknown}" "${ACCEL_NEXTEST:-unknown}" "${ACCEL_LANES:-unknown}" \
-    "$(_sccache_health)" "$(_mold_accel_token)"
+    "$(_sccache_health)" "$(_mold_accel_token)" "$(_perf_accel_token)"
 }
 
 # ---- Per-gate core budget (issue #2640) -------------------------------------

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -260,15 +260,23 @@
 #                      which pins the perf-corpus generator's TABLES validation, its
 #                      manifest writer's refusal of an empty table list, and the
 #                      tight scoping of its multi-GB stale-corpus pruning.
-#                      Also runs (no python3/sudo/perf needed)
-#                      scripts/tests/test_perf_capability.sh (#3249) — pins the perf
-#                      profiling capability path: the shared scripts/perf-capability.sh
+#                      Also runs (no python3/sudo/perf needed) the PAIR
+#                      scripts/tests/test_perf_capability.sh (the helper's unit
+#                      contract) and scripts/tests/test_perf_capability_bootstrap.sh
+#                      (the bootstrap section end-to-end), sharing
+#                      scripts/tests/lib/perf-capability-test-lib.sh (#3249) — they pin
+#                      the perf profiling capability path: scripts/perf-capability.sh
 #                      (free /proc token, canonical /etc/sysctl.d/99-cqlite-perf.conf
-#                      bytes, side-effect-free sourcing) and bootstrap's install +
-#                      VERIFY section. Its load-bearing arm is that the FUNCTIONAL
-#                      check is HONOURED: a shimmed perf that EXITS 0 while reporting
-#                      0 / `<not supported>` must WARN, never "verified". Hermetic —
-#                      test-only seams stand in for /proc and /etc/sysctl.d and every
+#                      bytes, byte-exact idempotency compare, side-effect-free
+#                      sourcing, privilege-drop identity resolution) and bootstrap's
+#                      install + VERIFY section. Load-bearing arms: the FUNCTIONAL
+#                      check is HONOURED (a shimmed perf that EXITS 0 while reporting
+#                      0 / `<not supported>` must WARN, never "verified"), and NO path
+#                      reaches a capable/verified verdict from an UNVALIDATED input —
+#                      an unusable `id -u`, an inconsistent SUDO_USER, a missing test
+#                      sandbox and a non-canonical drop-in all fail closed. Hermetic —
+#                      test-only seams stand in for /proc and /etc/sysctl.d (and test
+#                      mode REFUSES to fall back to either production directory), every
 #                      privileged tool is a recording shim, asserted mutation-free.
 #                      Also runs (no python3/network/datasets needed)
 #                      scripts/tests/test_fetch_datasets_tracked_guard.sh (#2878) —
@@ -5800,7 +5808,7 @@ run_tooling_tests() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_gate_notify_contract.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_perf_capability.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_notify.sh; bash scripts/tests/test_gate_notify_contract.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh; bash scripts/tests/test_bootstrap_agent_machine.sh; bash scripts/tests/test_perf_capability.sh; bash scripts/tests/test_perf_capability_bootstrap.sh; bash scripts/tests/test_claim_lock.sh; bash scripts/flow/tests/claim-resume.test.sh; bash scripts/tests/test_premerge_assert.sh; bash scripts/tests/test_board_label_mirror.sh; bash scripts/tests/test_worker_supervisor.sh; bash scripts/tests/test_gate_failure_mode.sh"
   if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_agent_gate_notify.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_gate_notify_contract.sh" >>"$log" 2>&1 &&
@@ -5808,6 +5816,7 @@ run_tooling_tests() {
      bash "$REPO_ROOT/scripts/tests/test_gate_concurrency_cap.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_bootstrap_agent_machine.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_perf_capability.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/tests/test_perf_capability_bootstrap.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_claim_lock.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/flow/tests/claim-resume.test.sh" >>"$log" 2>&1 &&
      bash "$REPO_ROOT/scripts/tests/test_premerge_assert.sh" >>"$log" 2>&1 &&

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -417,11 +417,11 @@ else
   # FAIL CLOSED on a misused test seam BEFORE anything privileged happens: this
   # section pipes the drop-in through `sudo tee <path>`, so a stray
   # CQLITE_PERF_SYSCTL_DIR / CQLITE_PERF_PROC_DIR export must never steer that write
-  # or fabricate a /proc verdict. The seams are inert without
-  # CQLITE_PERF_TEST_MODE=1, and the marker itself forbids a reachable real
-  # sudo/sysctl (see scripts/perf-capability.sh).
+  # or fabricate a /proc verdict. The seams are inert without CQLITE_PERF_TEST_MODE=1;
+  # under the marker each must be provably INSIDE the declared sandbox root, and the
+  # marker itself forbids a reachable real sudo/sysctl (see scripts/perf-capability.sh).
   if ! perf_capability_env_guard; then
-    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1; or test mode WITHOUT both non-production path seams, which has no production fallback; or test mode with a reachable real sudo/sysctl — details on stderr) — refusing to run a privileged write against an env-chosen path"
+    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1; or test mode without a proven CQLITE_PERF_TEST_SANDBOX and both path seams strictly inside it, which has no production fallback; or test mode with a reachable real sudo/sysctl — details on stderr) — refusing to run a privileged write against an env-chosen path"
     PERF_SECTION_OK=0
   else
     PERF_SECTION_OK=1

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -415,17 +415,35 @@ fi
 if [ "${PERF_SECTION_OK:-0}" = 1 ]; then
   PERF_DROPIN=$(perf_capability_dropin_path)
 
-  # perf_do_or_print <label> <cmd...>: run_or_print's exact semantics (do it under
-  # --yes, else print the line verbatim) with CONFIG-APPLY wording — run_or_print's
-  # text says "install <label>", which would be misleading for a sysctl write.
-  perf_do_or_print() {
-    local label="$1"; shift
-    if [ "$AUTO_YES" = 1 ]; then
-      info "$label: $*"
-      if "$@"; then return 0; else warn "$label FAILED — run manually: $*"; return 1; fi
+  # perf_apply_now: run (under --yes) or PRINT (check mode) `sysctl -q --system`,
+  # recording THREE INDEPENDENT FACTS instead of collapsing them into one rc:
+  #   PERF_APPLY_RAN  1 iff the command actually executed (0 = check mode printed it)
+  #   PERF_APPLY_RC   that command's exit status when it ran ('' otherwise)
+  # and, separately, the /proc read-back the caller performs afterwards.
+  #
+  # WHY THE SPLIT (issue #3249 review). `sysctl --system` applies EVERY drop-in on the
+  # box, so it can apply OURS perfectly and still exit non-zero because an unrelated
+  # pre-existing entry failed (a stale /etc/sysctl.conf line, a foreign drop-in naming
+  # a knob this kernel lacks). Gating the read-back on its rc therefore left the token
+  # STALE and printed "nothing was applied" on a box that had just become profileable —
+  # a FALSE verdict, and the verdict is the whole point of AC2. "The apply command
+  # failed" and "the controls are not in effect" are independent facts and are reported
+  # as such: the read-back happens after EVERY attempt, whatever the rc.
+  PERF_APPLY_RAN=0
+  PERF_APPLY_RC=''
+  perf_apply_now() {
+    PERF_APPLY_RAN=0
+    PERF_APPLY_RC=''
+    local -a cmd=(${PERF_ROOT[@]+"${PERF_ROOT[@]}"} sysctl -q --system)
+    if [ "$AUTO_YES" != 1 ]; then
+      info "apply the drop-in now:  ${cmd[*]}"
+      return 0
     fi
-    info "$label:  $*"
-    return 1
+    info "apply the drop-in now: ${cmd[*]}"
+    PERF_APPLY_RAN=1
+    "${cmd[@]}"
+    PERF_APPLY_RC=$?
+    return 0
   }
 
   # Privilege is OPTIONAL: probe it non-interactively (`sudo -n`) so bootstrap can
@@ -467,6 +485,19 @@ if [ "${PERF_SECTION_OK:-0}" = 1 ]; then
       info "(or ask the image/host owner to install it; without the drop-in this box reverts to perf_event_paranoid=4 on reboot)"
     else
       info "write + apply the drop-in:  bash scripts/perf-capability.sh --drop-in | ${PERF_RUN_AS}tee $PERF_DROPIN >/dev/null && ${PERF_RUN_AS}sysctl -q --system"
+    fi
+  }
+
+  # perf_apply_remedy_line: the APPLY-ONLY remedy, for the box whose drop-in is ALREADY
+  # current — re-writing the file is not the fix there, applying it is. Same no-sudo /
+  # needs-a-password / already-root split as perf_remedy_line above, because a printed
+  # `sudo` is un-runnable on a box with no sudo binary and wrong on a root box.
+  perf_apply_remedy_line() {
+    if [ "$PERF_PRIV_STATE" = no-sudo-binary ]; then
+      info "no 'sudo' on this box — apply it from a ROOT shell:  sysctl -q --system"
+      info "(or ask the image/host owner; the drop-in is already on disk, so this is the only step left)"
+    else
+      info "apply the drop-in now:  ${PERF_RUN_AS}sysctl -q --system"
     fi
   }
 
@@ -532,34 +563,56 @@ if [ "${PERF_SECTION_OK:-0}" = 1 ]; then
   if [ "$PERF_TOKEN" = ok ]; then
     ok "kernel controls verified from /proc: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid) kptr_restrict=$(perf_capability_proc_value kptr_restrict)"
   elif [ "$PERF_DROPIN_OK" = 1 ] && [ "$PERF_PRIV" = 1 ]; then
-    PERF_APPLIED=0
-    if perf_do_or_print "apply the drop-in now" ${PERF_ROOT[@]+"${PERF_ROOT[@]}"} sysctl -q --system; then
-      PERF_APPLIED=1
+    perf_apply_now
+    # READ BACK after EVERY attempt, regardless of the command's exit status: the rc
+    # says something about `sysctl --system`, the /proc read says something about THIS
+    # BOX, and only the latter is the capability verdict.
+    if [ "$PERF_APPLY_RAN" = 1 ]; then
       PERF_TOKEN=$(perf_capability_token)
+      # FACT 1, reported on its own line and never mixed with the verdict: the command
+      # itself failed. It applies every drop-in on the box, so this may be an unrelated
+      # entry — it does NOT mean our controls are unset (the read-back below answers
+      # that, and the two lines are allowed to disagree).
+      if [ "${PERF_APPLY_RC:-0}" != 0 ]; then
+        warn "'sysctl -q --system' exited $PERF_APPLY_RC — it applies EVERY sysctl drop-in on this box, so an UNRELATED pre-existing entry may be the failure; the perf verdict below comes from /proc, not from this exit code"
+        perf_inspect_lines
+      fi
     fi
+    # FACT 2, independent of FACT 1: what /proc reports now.
     if [ "$PERF_TOKEN" = ok ]; then
-      ok "kernel controls applied and READ BACK from /proc: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid) kptr_restrict=$(perf_capability_proc_value kptr_restrict)"
-    elif [ "$PERF_APPLIED" = 1 ]; then
+      ok "kernel controls READ BACK from /proc as profileable: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid) kptr_restrict=$(perf_capability_proc_value kptr_restrict)"
+    elif [ "$PERF_APPLY_RAN" = 1 ] && [ "${PERF_APPLY_RC:-0}" = 0 ]; then
       # The apply RAN and reported success, and /proc still disagrees — the silent
       # revert this whole section exists to catch.
       warn "sysctl --system reported success but /proc still reports perf=$PERF_TOKEN — the value did NOT take (container, read-only /proc, or a later-sorting drop-in / /etc/sysctl.conf overrides ours)"
       perf_diagnose_token "$PERF_TOKEN"
       perf_inspect_lines
+    elif [ "$PERF_APPLY_RAN" = 1 ]; then
+      # The command failed AND the controls are not in effect. Both facts are already
+      # on the record; state only the second one here, with no claim about which
+      # drop-in failed.
+      warn "/proc still reports perf=$PERF_TOKEN after the apply — the controls are NOT in effect (and the apply command itself exited $PERF_APPLY_RC; see above)"
+      perf_diagnose_token "$PERF_TOKEN"
     else
-      # The apply did NOT run (check mode printed the line) or FAILED — do not claim
-      # it was applied. Without this branch a check-mode run with a current drop-in
-      # and a non-ok runtime printed NO warn at all and never counted a WARNING.
-      if [ "$AUTO_YES" = 1 ]; then
-        warn "the sysctl apply did not succeed — /proc still reports perf=$PERF_TOKEN (nothing was applied)"
-      else
-        warn "kernel controls NOT in the profileable state (gate stamps perf=$PERF_TOKEN) — the drop-in is on disk but has NOT been applied to the running kernel"
-        info "apply it now (or re-run with --yes):  ${PERF_RUN_AS}sysctl -q --system"
-      fi
+      # The apply did NOT run: check mode printed the line. Never claim it was applied.
+      # Without this branch a check-mode run with a current drop-in and a non-ok
+      # runtime printed NO warn at all and never counted a WARNING.
+      warn "kernel controls NOT in the profileable state (gate stamps perf=$PERF_TOKEN) — the drop-in is on disk but has NOT been applied to the running kernel"
+      info "apply it now (or re-run with --yes):  ${PERF_RUN_AS}sysctl -q --system"
       perf_diagnose_token "$PERF_TOKEN"
     fi
   else
     warn "kernel controls NOT in the profileable state (gate stamps perf=$PERF_TOKEN)"
     perf_diagnose_token "$PERF_TOKEN"
+    # The drop-in is already on disk (so there is nothing to WRITE) but we have no
+    # non-interactive privilege to apply it. Without this the branch diagnosed the
+    # state and offered NO remedy at all, contradicting every other unprivileged path
+    # in this section — the no-sudo / needs-a-password boxes are exactly the ones that
+    # need a runnable command printed.
+    if [ "$PERF_DROPIN_OK" = 1 ]; then
+      info "the drop-in is on disk but has NOT been applied to the running kernel, and bootstrap has no non-interactive privilege to apply it"
+      perf_apply_remedy_line
+    fi
   fi
 
   # ---- 3. FUNCTIONAL verification (AC2): run the collection, count the cycles ----

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -421,7 +421,7 @@ else
   # CQLITE_PERF_TEST_MODE=1, and the marker itself forbids a reachable real
   # sudo/sysctl (see scripts/perf-capability.sh).
   if ! perf_capability_env_guard; then
-    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1, or test mode with a reachable real sudo/sysctl; details on stderr) — refusing to run a privileged write against an env-chosen path"
+    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1; or test mode WITHOUT both non-production path seams, which has no production fallback; or test mode with a reachable real sudo/sysctl — details on stderr) — refusing to run a privileged write against an env-chosen path"
     PERF_SECTION_OK=0
   else
     PERF_SECTION_OK=1

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -548,13 +548,19 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
   # applied in basename order, last assignment wins) and is reported as such; one that
   # sorts before is reported as harmless, which also documents WHY the 99- prefix is
   # load-bearing and must never be "tidied" to a lower number.
+  #
+  # THE SCAN COVERS THE WHOLE `sysctl --system` SEARCH PATH (issue #3249 review R5-4) —
+  # /etc/sysctl.d, /run/sysctl.d, /usr/local/lib/sysctl.d, /usr/lib/sysctl.d,
+  # /lib/sysctl.d and /etc/sysctl.conf — with same-basename masking honoured, because a
+  # later-sorting file in /run or /usr/lib overriding us while this reported "no
+  # competitor" is the same silent-revert mystery wearing a different directory.
   perf_name_competitors() {
     local scan verdict path found=0
     # A FAILED scan is reported as a failed scan, never as "no competitors" — the whole
     # point of this diagnostic is to replace an unknown with a named file, so silently
     # printing the reassuring line on an unreadable directory would recreate the mystery.
     if ! scan=$(perf_capability_competing_files); then
-      info "could not scan the sysctl.d directory for competing perf_event_paranoid/kptr_restrict settings — inspect it by hand"
+      info "could not scan the 'sysctl --system' search path for competing perf_event_paranoid/kptr_restrict settings — inspect it by hand"
       return 0
     fi
     while IFS=' ' read -r verdict path; do
@@ -562,12 +568,13 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
       found=1
       case "$verdict" in
         override) warn "OVERRIDE: $path also sets perf_event_paranoid/kptr_restrict and its name sorts AFTER $PERF_CAPABILITY_DROPIN_BASENAME, so it is applied LAST and WINS — fix or rename that file" ;;
+        last)     warn "OVERRIDE: $path also sets perf_event_paranoid/kptr_restrict and is applied AFTER every sysctl.d drop-in (both by 'sysctl --system' and systemd-sysctl), so it WINS regardless of our filename — fix that file" ;;
         *)        info "competing file: $path also sets perf_event_paranoid/kptr_restrict but sorts BEFORE $PERF_CAPABILITY_DROPIN_BASENAME, so ours wins (this is exactly why the '99-' prefix is load-bearing — never rename the drop-in)" ;;
       esac
     done <<EOF
 $scan
 EOF
-    [ "$found" = 1 ] || info "no other file in the sysctl.d directory sets perf_event_paranoid/kptr_restrict"
+    [ "$found" = 1 ] || info "no other file on the 'sysctl --system' search path (/etc/sysctl.d, /run/sysctl.d, /usr/local/lib/sysctl.d, /usr/lib/sysctl.d, /lib/sysctl.d, /etc/sysctl.conf) sets perf_event_paranoid/kptr_restrict"
   }
 
   # perf_inspect_lines: where a value that did not take actually comes from.
@@ -575,7 +582,7 @@ EOF
   # `sysctl --system` and systemd-sysctl, so a stale entry there BEATS our 99- file —
   # listing only /etc/sysctl.d would hide the most likely culprit.
   perf_inspect_lines() {
-    info "inspect:  sysctl -a --pattern 'perf_event_paranoid|kptr_restrict'; grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.conf"
+    info "inspect:  sysctl -a --pattern 'perf_event_paranoid|kptr_restrict'; grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf"
     info "precedence: /etc/sysctl.conf is applied AFTER the sysctl.d drop-ins (both by 'sysctl --system' and systemd-sysctl), so a stale entry THERE overrides our 99- file"
   }
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -16,6 +16,16 @@
 #      / "ACCEL_LANES" / "mold link-accelerator") so the two can never disagree
 #      about whether an accelerator is present. The final health check below
 #      re-reads the state straight from the gate to reconcile.
+#   2c. Perf profiling capability (issue #3249, LINUX only): the reboot-surviving
+#      /etc/sysctl.d/99-cqlite-perf.conf drop-in (kernel.perf_event_paranoid = -1,
+#      kernel.kptr_restrict = 0), applied now, READ BACK out of /proc — a `sysctl`
+#      write's return code proves nothing — and then FUNCTIONALLY verified by running
+#      the collection the measurement doctrine mandates (`perf stat -C 0 -e cycles`),
+#      requiring exit 0 AND a non-zero cycle count. Images ship paranoid=4, which
+#      denies ALL unprivileged perf use: a PERMISSION verdict whose "access limited"
+#      help text reads like a missing CAPABILITY. Advisory like mold — no sudo, no
+#      perf, or an absent /proc control degrades to a `[warn]` plus the exact
+#      write-AND-apply remedy line, and the run still exits 0.
 #   3. gh auth + BOARD ACCESS (Path A board dispatch, #1886). The verdict comes
 #      from a READ-ONLY functional probe of the board, never from the `project`
 #      scope string (issue #2942): a token can carry `project` and still fail
@@ -55,7 +65,10 @@ for arg in "$@"; do
     --yes|-y) AUTO_YES=1 ;;
     --skip-smoke) SKIP_SMOKE=1 ;;
     -h|--help)
-      sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      # Print the whole leading comment block, bounded by the FIRST `set -` line
+      # rather than a hardcoded line number: a fixed `2,45p` silently truncates the
+      # help the moment the header grows (it already omitted the perf section).
+      awk 'NR == 1 { next } /^set -/ { exit } { sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
       exit 0 ;;
     *) echo "bootstrap: unknown arg: $arg (try --help)" >&2; exit 2 ;;
   esac
@@ -386,6 +399,20 @@ elif [ "$PLATFORM" != linux ]; then
 else
   # shellcheck source=scripts/perf-capability.sh
   . "$PERF_CAP_LIB"
+  # FAIL CLOSED on a misused test seam BEFORE anything privileged happens: this
+  # section pipes the drop-in through `sudo tee <path>`, so a stray
+  # CQLITE_PERF_SYSCTL_DIR / CQLITE_PERF_PROC_DIR export must never steer that write
+  # or fabricate a /proc verdict. The seams are inert without
+  # CQLITE_PERF_TEST_MODE=1, and the marker itself forbids a reachable real
+  # sudo/sysctl (see scripts/perf-capability.sh).
+  if ! perf_capability_env_guard; then
+    warn "perf capability SKIPPED — a test-only env seam is set without a hermetic CQLITE_PERF_TEST_MODE=1 (details on stderr); refusing to run a privileged write against an env-chosen path"
+    PERF_SECTION_OK=0
+  else
+    PERF_SECTION_OK=1
+  fi
+fi
+if [ "${PERF_SECTION_OK:-0}" = 1 ]; then
   PERF_DROPIN=$(perf_capability_dropin_path)
 
   # perf_do_or_print <label> <cmd...>: run_or_print's exact semantics (do it under
@@ -406,13 +433,63 @@ else
   # Every privileged call below goes through PERF_ROOT (an ARRAY: empty when we are
   # already root) and always carries `-n`, so no code path can ever sit on a
   # password prompt.
+  #
+  # `sudo -n` failing is TWO different boxes and they need DIFFERENT remedies: no
+  # sudo binary at all (a printed `sudo tee` line is useless there — the fix is a
+  # root shell or the image owner) versus a sudo that needs a password (the same line
+  # works, just interactively). PERF_PRIV_STATE distinguishes them.
   PERF_ROOT=()
   PERF_PRIV=0
+  PERF_PRIV_STATE=unknown
   if [ "$(id -u 2>/dev/null || echo 1000)" = 0 ]; then
-    PERF_PRIV=1
-  elif have sudo && bounded 10 sudo -n true >/dev/null 2>&1; then
-    PERF_PRIV=1; PERF_ROOT=(sudo -n)
+    PERF_PRIV=1; PERF_PRIV_STATE=root
+  elif ! have sudo; then
+    PERF_PRIV_STATE=no-sudo-binary
+  elif bounded 10 sudo -n true >/dev/null 2>&1; then
+    PERF_PRIV=1; PERF_ROOT=(sudo -n); PERF_PRIV_STATE=sudo-nopasswd
+  else
+    PERF_PRIV_STATE=sudo-needs-password
   fi
+  # Prefix for PRINTED remedy lines: empty when we are already root (a printed
+  # `sudo` would be wrong there, and on many root images sudo is not even
+  # installed), plain `sudo` (never `-n`) otherwise, since a human running the line
+  # by hand may legitimately be prompted.
+  PERF_RUN_AS=""
+  [ "$PERF_PRIV_STATE" = root ] || PERF_RUN_AS="sudo "
+
+  # perf_remedy_line: the COMPLETE write-AND-APPLY remedy. Write-only was the bug —
+  # an operator who pasted it had a reboot-persistent file and an unprofileable box
+  # until the next reboot, which is precisely what the functional verification exists
+  # to prevent, on the path most people take (no --yes).
+  perf_remedy_line() {
+    if [ "$PERF_PRIV_STATE" = no-sudo-binary ]; then
+      info "no 'sudo' on this box — write + apply from a ROOT shell:  bash scripts/perf-capability.sh --drop-in > $PERF_DROPIN && sysctl -q --system"
+      info "(or ask the image/host owner to install it; without the drop-in this box reverts to perf_event_paranoid=4 on reboot)"
+    else
+      info "write + apply the drop-in:  bash scripts/perf-capability.sh --drop-in | ${PERF_RUN_AS}tee $PERF_DROPIN >/dev/null && ${PERF_RUN_AS}sysctl -q --system"
+    fi
+  }
+
+  # perf_diagnose_token <token>: translate a non-ok token into the ACTIONABLE
+  # sentence. Shared by both non-ok paths below, so the diagnosis can never be
+  # reachable from one and silently missing from the other.
+  perf_diagnose_token() {
+    case "$1" in
+      paranoid-*) info "perf_event_paranoid >= 1 forbids CPU-WIDE events, so 'perf stat -C <cpu>' is DENIED — this is a PERMISSION verdict, not a missing capability" ;;
+      kptr-restricted) info "kptr_restrict != 0 — kernel frames resolve to bare addresses (a SILENT attribution loss, not an error)" ;;
+      absent) info "/proc/sys/kernel/{perf_event_paranoid,kptr_restrict} not present — a container without a writable procfs cannot be tuned from here; tune the HOST" ;;
+      unknown) info "the /proc controls are present but unparseable — never guessed; inspect them by hand" ;;
+    esac
+  }
+
+  # perf_inspect_lines: where a value that did not take actually comes from.
+  # /etc/sysctl.conf is applied AFTER every sysctl.d drop-in by both
+  # `sysctl --system` and systemd-sysctl, so a stale entry there BEATS our 99- file —
+  # listing only /etc/sysctl.d would hide the most likely culprit.
+  perf_inspect_lines() {
+    info "inspect:  sysctl -a --pattern 'perf_event_paranoid|kptr_restrict'; grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.conf"
+    info "precedence: /etc/sysctl.conf is applied AFTER the sysctl.d drop-ins (both by 'sysctl --system' and systemd-sysctl), so a stale entry THERE overrides our 99- file"
+  }
 
   PERF_TOKEN_BEFORE=$(perf_capability_token)
   info "runtime now: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid || echo '<unreadable>') kptr_restrict=$(perf_capability_proc_value kptr_restrict || echo '<unreadable>')  (gate stamps perf=$PERF_TOKEN_BEFORE)"
@@ -423,8 +500,12 @@ else
     PERF_DROPIN_OK=1
   elif [ "$PERF_PRIV" = 0 ]; then
     PERF_DROPIN_OK=0
-    warn "no non-interactive root (sudo -n) — cannot install $PERF_DROPIN; this box reverts to perf_event_paranoid=4 on reboot"
-    info "run as a user with sudo:  bash scripts/perf-capability.sh --drop-in | sudo tee $PERF_DROPIN >/dev/null && sudo sysctl -q --system"
+    if [ "$PERF_PRIV_STATE" = no-sudo-binary ]; then
+      warn "no 'sudo' binary on this box — cannot install $PERF_DROPIN; it reverts to perf_event_paranoid=4 on reboot"
+    else
+      warn "sudo needs a password (sudo -n failed) and bootstrap never prompts — cannot install $PERF_DROPIN unattended; it reverts to perf_event_paranoid=4 on reboot"
+    fi
+    perf_remedy_line
   else
     PERF_DROPIN_OK=0
     if [ "$AUTO_YES" = 1 ]; then
@@ -434,11 +515,12 @@ else
         ok "wrote $PERF_DROPIN (kernel.perf_event_paranoid = -1, kernel.kptr_restrict = 0)"
         PERF_DROPIN_OK=1
       else
-        warn "could NOT write $PERF_DROPIN — run manually: bash scripts/perf-capability.sh --drop-in | sudo tee $PERF_DROPIN >/dev/null"
+        warn "could NOT write $PERF_DROPIN"
+        perf_remedy_line
       fi
     else
-      info "write the drop-in:  bash scripts/perf-capability.sh --drop-in | sudo tee $PERF_DROPIN >/dev/null"
-      info "(re-run with --yes to write it automatically)"
+      perf_remedy_line
+      info "(re-run with --yes to write AND apply it automatically)"
     fi
   fi
 
@@ -450,29 +532,41 @@ else
   if [ "$PERF_TOKEN" = ok ]; then
     ok "kernel controls verified from /proc: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid) kptr_restrict=$(perf_capability_proc_value kptr_restrict)"
   elif [ "$PERF_DROPIN_OK" = 1 ] && [ "$PERF_PRIV" = 1 ]; then
+    PERF_APPLIED=0
     if perf_do_or_print "apply the drop-in now" ${PERF_ROOT[@]+"${PERF_ROOT[@]}"} sysctl -q --system; then
+      PERF_APPLIED=1
       PERF_TOKEN=$(perf_capability_token)
     fi
     if [ "$PERF_TOKEN" = ok ]; then
       ok "kernel controls applied and READ BACK from /proc: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid) kptr_restrict=$(perf_capability_proc_value kptr_restrict)"
-    elif [ "$AUTO_YES" = 1 ]; then
-      warn "sysctl was applied but /proc still reports perf=$PERF_TOKEN — the value did NOT take (container, read-only /proc, or a later-sorting drop-in overrides ours)"
-      info "inspect:  sysctl -a --pattern 'perf_event_paranoid|kptr_restrict'; ls /etc/sysctl.d"
+    elif [ "$PERF_APPLIED" = 1 ]; then
+      # The apply RAN and reported success, and /proc still disagrees — the silent
+      # revert this whole section exists to catch.
+      warn "sysctl --system reported success but /proc still reports perf=$PERF_TOKEN — the value did NOT take (container, read-only /proc, or a later-sorting drop-in / /etc/sysctl.conf overrides ours)"
+      perf_diagnose_token "$PERF_TOKEN"
+      perf_inspect_lines
+    else
+      # The apply did NOT run (check mode printed the line) or FAILED — do not claim
+      # it was applied. Without this branch a check-mode run with a current drop-in
+      # and a non-ok runtime printed NO warn at all and never counted a WARNING.
+      if [ "$AUTO_YES" = 1 ]; then
+        warn "the sysctl apply did not succeed — /proc still reports perf=$PERF_TOKEN (nothing was applied)"
+      else
+        warn "kernel controls NOT in the profileable state (gate stamps perf=$PERF_TOKEN) — the drop-in is on disk but has NOT been applied to the running kernel"
+        info "apply it now (or re-run with --yes):  ${PERF_RUN_AS}sysctl -q --system"
+      fi
+      perf_diagnose_token "$PERF_TOKEN"
     fi
   else
     warn "kernel controls NOT in the profileable state (gate stamps perf=$PERF_TOKEN)"
-    case "$PERF_TOKEN" in
-      paranoid-*) info "perf_event_paranoid >= 1 forbids CPU-WIDE events, so 'perf stat -C <cpu>' is DENIED — this is a PERMISSION verdict, not a missing capability" ;;
-      kptr-restricted) info "kptr_restrict != 0 — kernel frames resolve to bare addresses (a SILENT attribution loss, not an error)" ;;
-      absent) info "/proc/sys/kernel/{perf_event_paranoid,kptr_restrict} not present — a container without a writable procfs cannot be tuned from here; tune the HOST" ;;
-    esac
+    perf_diagnose_token "$PERF_TOKEN"
   fi
 
   # ---- 3. FUNCTIONAL verification (AC2): run the collection, count the cycles ----
   if ! have perf; then
     warn "perf MISSING — profiling capability UNVERIFIED on this machine"
     if have apt-get; then
-      info "install perf:  sudo apt-get install -y linux-tools-common linux-tools-\$(uname -r)"
+      info "install perf:  ${PERF_RUN_AS}apt-get install -y linux-tools-common linux-tools-\$(uname -r)"
     else
       info "install perf via your distro's linux-tools/perf package"
     fi

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -417,11 +417,11 @@ else
   # FAIL CLOSED on a misused test seam BEFORE anything privileged happens: this
   # section pipes the drop-in through `sudo tee <path>`, so a stray
   # CQLITE_PERF_SYSCTL_DIR / CQLITE_PERF_PROC_DIR export must never steer that write
-  # or fabricate a /proc verdict. The seams are inert without CQLITE_PERF_TEST_MODE=1;
-  # under the marker each must be provably INSIDE the declared sandbox root, and the
-  # marker itself forbids a reachable real sudo/sysctl (see scripts/perf-capability.sh).
+  # or fabricate a /proc verdict. The seams are inert without
+  # CQLITE_PERF_TEST_MODE=1, and the marker itself forbids a reachable real
+  # sudo/sysctl (see scripts/perf-capability.sh).
   if ! perf_capability_env_guard; then
-    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1; or test mode without a proven CQLITE_PERF_TEST_SANDBOX and both path seams strictly inside it, which has no production fallback; or test mode with a reachable real sudo/sysctl — details on stderr) — refusing to run a privileged write against an env-chosen path"
+    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1; or test mode WITHOUT both non-production path seams, which has no production fallback; or test mode with a reachable real sudo/sysctl — details on stderr) — refusing to run a privileged write against an env-chosen path"
     PERF_SECTION_OK=0
   else
     PERF_SECTION_OK=1

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -406,7 +406,7 @@ else
   # CQLITE_PERF_TEST_MODE=1, and the marker itself forbids a reachable real
   # sudo/sysctl (see scripts/perf-capability.sh).
   if ! perf_capability_env_guard; then
-    warn "perf capability SKIPPED — a test-only env seam is set without a hermetic CQLITE_PERF_TEST_MODE=1 (details on stderr); refusing to run a privileged write against an env-chosen path"
+    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1, or test mode with a reachable real sudo/sysctl; details on stderr) — refusing to run a privileged write against an env-chosen path"
     PERF_SECTION_OK=0
   else
     PERF_SECTION_OK=1

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -549,7 +549,14 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
   # sorts before is reported as harmless, which also documents WHY the 99- prefix is
   # load-bearing and must never be "tidied" to a lower number.
   perf_name_competitors() {
-    local verdict path found=0
+    local scan verdict path found=0
+    # A FAILED scan is reported as a failed scan, never as "no competitors" — the whole
+    # point of this diagnostic is to replace an unknown with a named file, so silently
+    # printing the reassuring line on an unreadable directory would recreate the mystery.
+    if ! scan=$(perf_capability_competing_files); then
+      info "could not scan the sysctl.d directory for competing perf_event_paranoid/kptr_restrict settings — inspect it by hand"
+      return 0
+    fi
     while IFS=' ' read -r verdict path; do
       [ -n "$path" ] || continue
       found=1
@@ -558,7 +565,7 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
         *)        info "competing file: $path also sets perf_event_paranoid/kptr_restrict but sorts BEFORE $PERF_CAPABILITY_DROPIN_BASENAME, so ours wins (this is exactly why the '99-' prefix is load-bearing — never rename the drop-in)" ;;
       esac
     done <<EOF
-$(perf_capability_competing_files)
+$scan
 EOF
     [ "$found" = 1 ] || info "no other file in the sysctl.d directory sets perf_event_paranoid/kptr_restrict"
   }

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -392,6 +392,17 @@ fi
 # assumption that writing the file worked.
 hdr "Perf profiling capability (issue #3249)"
 PERF_CAP_LIB="$REPO_ROOT/scripts/perf-capability.sh"
+# INITIALISE BEFORE THE GUARDS, never after (issue #3249 review). The gate below is
+# read as `${PERF_SECTION_OK:-0}`, so an INHERITED `PERF_SECTION_OK=1` from the
+# ambient environment would carry a macOS host — or a checkout with no
+# scripts/perf-capability.sh — straight into the Linux-only implementation, calling
+# helper functions that were never sourced. Every variable this section reads is
+# initialised here, so no ambient export can steer any of it.
+PERF_SECTION_OK=0
+PERF_DROPIN=''
+PERF_DROPIN_OK=0
+PERF_TOKEN=''
+PERF_TOKEN_BEFORE=''
 if [ ! -r "$PERF_CAP_LIB" ]; then
   warn "scripts/perf-capability.sh missing from this checkout — perf capability UNVERIFIED"
 elif [ "$PLATFORM" != linux ]; then
@@ -412,7 +423,7 @@ else
     PERF_SECTION_OK=1
   fi
 fi
-if [ "${PERF_SECTION_OK:-0}" = 1 ]; then
+if [ "$PERF_SECTION_OK" = 1 ]; then
   PERF_DROPIN=$(perf_capability_dropin_path)
 
   # perf_apply_now: run (under --yes) or PRINT (check mode) `sysctl -q --system`,
@@ -615,7 +626,34 @@ if [ "${PERF_SECTION_OK:-0}" = 1 ]; then
     fi
   fi
 
-  # ---- 3. FUNCTIONAL verification (AC2): run the collection, count the cycles ----
+  # ---- 3. FUNCTIONAL verification (AC2), attributed to the RIGHT IDENTITY -------
+  # Two rules, and together they make a FALSE "VERIFIED" unreachable (issue #3249
+  # review):
+  #
+  # (a) OVERALL verification requires BOTH facts: the /proc token = ok AND a
+  #     functional pass. Reporting the functional result alone as the verdict let a
+  #     box whose /proc says `paranoid-2`/`kptr-restricted` print its diagnosis AND
+  #     "VERIFIED" in the same run — contradictory output in which the reassuring line
+  #     wins the reader's attention. Anything short of both facts is reported as
+  #     PARTIAL DIAGNOSTIC INFORMATION, explicitly subordinate to the /proc verdict.
+  #
+  # (b) THE PRIVILEGE DIMENSION. perf_event_paranoid restricts UNPRIVILEGED users and
+  #     ROOT BYPASSES IT. `sudo bash scripts/bootstrap-agent-machine.sh` is a normal
+  #     invocation — arguably the most likely one, since this section needs root to
+  #     write /etc/sysctl.d — and as root `perf stat -C 0 -e cycles` SUCCEEDS on a
+  #     paranoid=4 box where every unprivileged agent process still gets EACCES. So a
+  #     root-run probe cannot demonstrate the property we care about ("an UNPRIVILEGED
+  #     process can collect CPU-wide cycles"). CHOSEN FIX: DROP PRIVILEGE for the
+  #     probe when a mechanism exists (setpriv/runuser/`sudo -u`, targeting SUDO_UID
+  #     — the account that invoked sudo — else `nobody`), because that measures the
+  #     real property; and when no mechanism exists, label the root result as NOT
+  #     evidence of unprivileged capability and let the identity-independent /proc
+  #     token be the authority. Never imply the stronger claim.
+  PERF_FUNC=untested            # untested | pass | fail
+  PERF_VERIFY_OUT=''
+  PERF_DROP_PREFIX=''
+  PERF_DROP_STATE=''
+  PERF_UNPRIV_EVIDENCE=0        # 1 iff the probe measured an UNPRIVILEGED process
   if ! have perf; then
     warn "perf MISSING — profiling capability UNVERIFIED on this machine"
     if have apt-get; then
@@ -623,12 +661,44 @@ if [ "${PERF_SECTION_OK:-0}" = 1 ]; then
     else
       info "install perf via your distro's linux-tools/perf package"
     fi
-  elif PERF_VERIFY_OUT=$(perf_capability_verify); then
-    ok "perf capability VERIFIED — perf stat -C 0 -e cycles reports $PERF_VERIFY_OUT"
   else
+    if perf_capability_drop_prefix_into PERF_DROP_PREFIX PERF_DROP_STATE; then
+      PERF_UNPRIV_EVIDENCE=1
+    fi
+    if [ -n "$PERF_DROP_PREFIX" ]; then
+      info "this run is ROOT and root BYPASSES perf_event_paranoid, so the probe DROPS PRIVILEGE ($PERF_DROP_STATE) — otherwise it would measure root's capability, not an agent's"
+    fi
+    # shellcheck disable=SC2086  # deliberate split of our own literal prefix tokens
+    if PERF_VERIFY_OUT=$(perf_capability_verify $PERF_DROP_PREFIX); then
+      PERF_FUNC=pass
+    else
+      PERF_FUNC=fail
+    fi
+  fi
+  if [ "$PERF_FUNC" = pass ] && [ "$PERF_TOKEN" = ok ] && [ "$PERF_UNPRIV_EVIDENCE" = 1 ]; then
+    ok "perf capability VERIFIED — /proc reports perf=ok and an UNPRIVILEGED perf stat -C 0 -e cycles reports $PERF_VERIFY_OUT"
+  elif [ "$PERF_FUNC" = pass ]; then
+    # A functional PASS that is NOT a verification: either /proc disagrees, or the
+    # probe could not be attributed to an unprivileged identity. Reported as partial
+    # information and never as a verdict — no run may print a non-ok token diagnosis
+    # and an unqualified "VERIFIED" together.
+    warn "perf capability NOT verified — the 'perf stat -C 0 -e cycles' probe succeeded ($PERF_VERIFY_OUT), but that is PARTIAL DIAGNOSTIC INFORMATION only, subordinate to the /proc verdict (gate stamps perf=$PERF_TOKEN)"
+    if [ "$PERF_TOKEN" != ok ]; then
+      info "/proc is the AUTHORITY here: perf=$PERF_TOKEN, so an unprivileged agent process is still restricted whatever this probe reported"
+      perf_diagnose_token "$PERF_TOKEN"
+    fi
+    if [ "$PERF_UNPRIV_EVIDENCE" = 0 ]; then
+      info "the probe ran AS ROOT ($PERF_DROP_STATE) and root BYPASSES perf_event_paranoid — its success is NOT evidence that an UNPRIVILEGED process can profile this box"
+      info "prove it as the agent account:  sudo -u <agent-user> perf stat -C 0 -e cycles -- sleep 0.1   (or install util-linux so bootstrap can drop privilege itself via setpriv)"
+    fi
+  elif [ "$PERF_FUNC" = fail ]; then
     warn "perf capability NOT verified — perf stat -C 0 -e cycles: $PERF_VERIFY_OUT"
     info "an rc-0 perf stat with a zero/<not supported> counter is NOT a working setup — a virtualised or masked PMU counts nothing"
-    info "reproduce by hand:  perf stat -C 0 -e cycles -- sleep 0.1"
+    if [ -n "$PERF_DROP_PREFIX" ]; then
+      info "the probe ran with privilege DROPPED ($PERF_DROP_STATE), so this failure may be the drop mechanism rather than perf itself — reproduce exactly:  $PERF_DROP_PREFIX perf stat -C 0 -e cycles -- sleep 0.1"
+    else
+      info "reproduce by hand:  perf stat -C 0 -e cycles -- sleep 0.1"
+    fi
   fi
   info "note: BPF collectors (bpftrace/bcc) still require sudo — a permissive perf_event_paranoid does NOT grant BPF map creation (#3217)"
   info "posture: this loosening is for DEDICATED SINGLE-TENANT measurement/agent boxes; never apply it to a shared or multi-tenant host"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -471,10 +471,18 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
   # sudo binary at all (a printed `sudo tee` line is useless there — the fix is a
   # root shell or the image owner) versus a sudo that needs a password (the same line
   # works, just interactively). PERF_PRIV_STATE distinguishes them.
+  #
+  # The root test goes through perf_capability_self_uid_into, which reports rc 1 for an
+  # UNKNOWN identity instead of substituting a plausible uid (issue #3249 review R4-1):
+  # `$(id -u || echo 1000)` invented an unprivileged answer whenever `id` was missing or
+  # broken. Here an unknown identity simply is not root, so the `sudo -n` probe below
+  # decides — the fail-closed direction (no privilege claimed, nothing written unless
+  # sudo actually works).
   PERF_ROOT=()
   PERF_PRIV=0
   PERF_PRIV_STATE=unknown
-  if [ "$(id -u 2>/dev/null || echo 1000)" = 0 ]; then
+  PERF_SELF_UID=''
+  if perf_capability_self_uid_into PERF_SELF_UID && [ "$PERF_SELF_UID" = 0 ]; then
     PERF_PRIV=1; PERF_PRIV_STATE=root
   elif ! have sudo; then
     PERF_PRIV_STATE=no-sudo-binary
@@ -526,6 +534,33 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
       absent) info "/proc/sys/kernel/{perf_event_paranoid,kptr_restrict} not present — a container without a writable procfs cannot be tuned from here; tune the HOST" ;;
       unknown) info "the /proc controls are present but unparseable — never guessed; inspect them by hand" ;;
     esac
+    case "$1" in paranoid-*|kptr-restricted) perf_name_competitors ;; esac
+  }
+
+  # perf_name_competitors: NAME THE FILE THAT IS FIGHTING US, rather than reporting only
+  # that the value did not take. Stock Ubuntu ships
+  # /etc/sysctl.d/10-kernel-hardening.conf with `kernel.kptr_restrict = 1`, and that is
+  # the concrete mechanism behind the "it silently reverts" note in three separate
+  # measurement reports (ws0-3217, ws3-3029, the 2026-07-27 Cassandra baseline) — none of
+  # which identified a cause. A named file is actionable; "it reverts" is not.
+  #
+  # A competitor that sorts AFTER our 99- drop-in is an ACTUAL override (sysctl.d is
+  # applied in basename order, last assignment wins) and is reported as such; one that
+  # sorts before is reported as harmless, which also documents WHY the 99- prefix is
+  # load-bearing and must never be "tidied" to a lower number.
+  perf_name_competitors() {
+    local verdict path found=0
+    while IFS=' ' read -r verdict path; do
+      [ -n "$path" ] || continue
+      found=1
+      case "$verdict" in
+        override) warn "OVERRIDE: $path also sets perf_event_paranoid/kptr_restrict and its name sorts AFTER $PERF_CAPABILITY_DROPIN_BASENAME, so it is applied LAST and WINS — fix or rename that file" ;;
+        *)        info "competing file: $path also sets perf_event_paranoid/kptr_restrict but sorts BEFORE $PERF_CAPABILITY_DROPIN_BASENAME, so ours wins (this is exactly why the '99-' prefix is load-bearing — never rename the drop-in)" ;;
+      esac
+    done <<EOF
+$(perf_capability_competing_files)
+EOF
+    [ "$found" = 1 ] || info "no other file in the sysctl.d directory sets perf_event_paranoid/kptr_restrict"
   }
 
   # perf_inspect_lines: where a value that did not take actually comes from.
@@ -692,8 +727,16 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
       perf_diagnose_token "$PERF_TOKEN"
     fi
     if [ "$PERF_UNPRIV_EVIDENCE" = 0 ]; then
-      info "the probe ran AS ROOT ($PERF_DROP_STATE) and root BYPASSES perf_event_paranoid — its success is NOT evidence that an UNPRIVILEGED process can profile this box"
-      info "prove it as the agent account:  sudo -u <agent-user> perf stat -C 0 -e cycles -- sleep 0.1   (or install util-linux so bootstrap can drop privilege itself via setpriv)"
+      # `identity-unknown` is its own sentence: with `id -u` unusable we do NOT know the
+      # probe ran as root, and asserting it would be as unfounded as asserting it did
+      # not (issue #3249 review R4-1). Report the unknown as an unknown.
+      if [ "$PERF_DROP_STATE" = identity-unknown ]; then
+        info "the identity of this process could NOT be determined ('id -u' unusable), so the probe's success is NOT attributable to an unprivileged process — no capability claim is made from it"
+        info "install/repair coreutils so 'id -u' works, then re-run; or prove it as the agent account:  sudo -u <agent-user> perf stat -C 0 -e cycles -- sleep 0.1"
+      else
+        info "the probe ran AS ROOT ($PERF_DROP_STATE) and root BYPASSES perf_event_paranoid — its success is NOT evidence that an UNPRIVILEGED process can profile this box"
+        info "prove it as the agent account:  sudo -u <agent-user> perf stat -C 0 -e cycles -- sleep 0.1   (or install util-linux so bootstrap can drop privilege itself via setpriv)"
+      fi
     fi
   elif [ "$PERF_FUNC" = fail ]; then
     warn "perf capability NOT verified — perf stat -C 0 -e cycles: $PERF_VERIFY_OUT"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -16,6 +16,10 @@
 #      / "ACCEL_LANES" / "mold link-accelerator") so the two can never disagree
 #      about whether an accelerator is present. The final health check below
 #      re-reads the state straight from the gate to reconcile.
+#      2c's functional check additionally reports WHOSE capability it measured: root
+#      BYPASSES perf_event_paranoid, so under `sudo bootstrap` the probe drops privilege
+#      (setpriv/runuser/sudo -u) and, where it cannot, says the result is not evidence
+#      about an unprivileged agent process. "VERIFIED" needs BOTH /proc=ok and that pass.
 #   2c. Perf profiling capability (issue #3249, LINUX only): the reboot-surviving
 #      /etc/sysctl.d/99-cqlite-perf.conf drop-in (kernel.perf_event_paranoid = -1,
 #      kernel.kptr_restrict = 0), applied now, READ BACK out of /proc — a `sysctl`

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -363,6 +363,130 @@ if [ "$PLATFORM" = linux ]; then
   fi
 fi
 
+# ---- 2c. Perf profiling capability (issue #3249) ----------------------------
+# Agent/worker images ship with kernel.perf_event_paranoid = 4 and set it NOWHERE
+# in /etc/sysctl.conf or /etc/sysctl.d, so every profiling run starts from a hard
+# EACCES whose help text ("access limited") reads like a CAPABILITY verdict when it
+# is a PERMISSION verdict — two measurement cycles were lost to that. A box left
+# permissive by a hand-probe is no better: with no drop-in, it reverts on
+# reboot/reprovision, i.e. the fleet is profileable only by accident.
+#
+# Posture mirrors mold above: PROBE FIRST, write only what is needed, and never
+# fail the run — a box without sudo or without perf degrades to a warn plus the
+# exact remedy line. What is NOT advisory is the VERDICT: a bootstrap that
+# silently leaves a box unprofileable is the failure mode being fixed, so the
+# section ends with a FUNCTIONAL `perf stat -C 0` verification (AC2), never with an
+# assumption that writing the file worked.
+hdr "Perf profiling capability (issue #3249)"
+PERF_CAP_LIB="$REPO_ROOT/scripts/perf-capability.sh"
+if [ ! -r "$PERF_CAP_LIB" ]; then
+  warn "scripts/perf-capability.sh missing from this checkout — perf capability UNVERIFIED"
+elif [ "$PLATFORM" != linux ]; then
+  info "perf_event_paranoid/kptr_restrict are Linux kernel controls — nothing to configure on $PLATFORM"
+else
+  # shellcheck source=scripts/perf-capability.sh
+  . "$PERF_CAP_LIB"
+  PERF_DROPIN=$(perf_capability_dropin_path)
+
+  # perf_do_or_print <label> <cmd...>: run_or_print's exact semantics (do it under
+  # --yes, else print the line verbatim) with CONFIG-APPLY wording — run_or_print's
+  # text says "install <label>", which would be misleading for a sysctl write.
+  perf_do_or_print() {
+    local label="$1"; shift
+    if [ "$AUTO_YES" = 1 ]; then
+      info "$label: $*"
+      if "$@"; then return 0; else warn "$label FAILED — run manually: $*"; return 1; fi
+    fi
+    info "$label:  $*"
+    return 1
+  }
+
+  # Privilege is OPTIONAL: probe it non-interactively (`sudo -n`) so bootstrap can
+  # never block on a password prompt on an unattended worker.
+  # Every privileged call below goes through PERF_ROOT (an ARRAY: empty when we are
+  # already root) and always carries `-n`, so no code path can ever sit on a
+  # password prompt.
+  PERF_ROOT=()
+  PERF_PRIV=0
+  if [ "$(id -u 2>/dev/null || echo 1000)" = 0 ]; then
+    PERF_PRIV=1
+  elif have sudo && bounded 10 sudo -n true >/dev/null 2>&1; then
+    PERF_PRIV=1; PERF_ROOT=(sudo -n)
+  fi
+
+  PERF_TOKEN_BEFORE=$(perf_capability_token)
+  info "runtime now: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid || echo '<unreadable>') kptr_restrict=$(perf_capability_proc_value kptr_restrict || echo '<unreadable>')  (gate stamps perf=$PERF_TOKEN_BEFORE)"
+
+  # ---- 1. the reboot-surviving drop-in (AC1), applied idempotently ----
+  if perf_capability_dropin_current; then
+    ok "drop-in already current: $PERF_DROPIN (survives reboot) — wrote nothing"
+    PERF_DROPIN_OK=1
+  elif [ "$PERF_PRIV" = 0 ]; then
+    PERF_DROPIN_OK=0
+    warn "no non-interactive root (sudo -n) — cannot install $PERF_DROPIN; this box reverts to perf_event_paranoid=4 on reboot"
+    info "run as a user with sudo:  bash scripts/perf-capability.sh --drop-in | sudo tee $PERF_DROPIN >/dev/null && sudo sysctl -q --system"
+  else
+    PERF_DROPIN_OK=0
+    if [ "$AUTO_YES" = 1 ]; then
+      info "writing perf sysctl drop-in: $PERF_DROPIN"
+      if perf_capability_dropin_content | ${PERF_ROOT[@]+"${PERF_ROOT[@]}"} tee "$PERF_DROPIN" >/dev/null 2>&1 \
+         && perf_capability_dropin_current; then
+        ok "wrote $PERF_DROPIN (kernel.perf_event_paranoid = -1, kernel.kptr_restrict = 0)"
+        PERF_DROPIN_OK=1
+      else
+        warn "could NOT write $PERF_DROPIN — run manually: bash scripts/perf-capability.sh --drop-in | sudo tee $PERF_DROPIN >/dev/null"
+      fi
+    else
+      info "write the drop-in:  bash scripts/perf-capability.sh --drop-in | sudo tee $PERF_DROPIN >/dev/null"
+      info "(re-run with --yes to write it automatically)"
+    fi
+  fi
+
+  # ---- 2. apply now + READ BACK from /proc (never trust the write's rc) ----
+  # A `sysctl -w`/`--system` can report success while the value does not take
+  # (container, read-only /proc, a later-sorting drop-in overriding ours), so the
+  # verdict is always the value read back out of /proc/sys/kernel.
+  PERF_TOKEN=$(perf_capability_token)
+  if [ "$PERF_TOKEN" = ok ]; then
+    ok "kernel controls verified from /proc: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid) kptr_restrict=$(perf_capability_proc_value kptr_restrict)"
+  elif [ "$PERF_DROPIN_OK" = 1 ] && [ "$PERF_PRIV" = 1 ]; then
+    if perf_do_or_print "apply the drop-in now" ${PERF_ROOT[@]+"${PERF_ROOT[@]}"} sysctl -q --system; then
+      PERF_TOKEN=$(perf_capability_token)
+    fi
+    if [ "$PERF_TOKEN" = ok ]; then
+      ok "kernel controls applied and READ BACK from /proc: perf_event_paranoid=$(perf_capability_proc_value perf_event_paranoid) kptr_restrict=$(perf_capability_proc_value kptr_restrict)"
+    elif [ "$AUTO_YES" = 1 ]; then
+      warn "sysctl was applied but /proc still reports perf=$PERF_TOKEN — the value did NOT take (container, read-only /proc, or a later-sorting drop-in overrides ours)"
+      info "inspect:  sysctl -a --pattern 'perf_event_paranoid|kptr_restrict'; ls /etc/sysctl.d"
+    fi
+  else
+    warn "kernel controls NOT in the profileable state (gate stamps perf=$PERF_TOKEN)"
+    case "$PERF_TOKEN" in
+      paranoid-*) info "perf_event_paranoid >= 1 forbids CPU-WIDE events, so 'perf stat -C <cpu>' is DENIED — this is a PERMISSION verdict, not a missing capability" ;;
+      kptr-restricted) info "kptr_restrict != 0 — kernel frames resolve to bare addresses (a SILENT attribution loss, not an error)" ;;
+      absent) info "/proc/sys/kernel/{perf_event_paranoid,kptr_restrict} not present — a container without a writable procfs cannot be tuned from here; tune the HOST" ;;
+    esac
+  fi
+
+  # ---- 3. FUNCTIONAL verification (AC2): run the collection, count the cycles ----
+  if ! have perf; then
+    warn "perf MISSING — profiling capability UNVERIFIED on this machine"
+    if have apt-get; then
+      info "install perf:  sudo apt-get install -y linux-tools-common linux-tools-\$(uname -r)"
+    else
+      info "install perf via your distro's linux-tools/perf package"
+    fi
+  elif PERF_VERIFY_OUT=$(perf_capability_verify); then
+    ok "perf capability VERIFIED — perf stat -C 0 -e cycles reports $PERF_VERIFY_OUT"
+  else
+    warn "perf capability NOT verified — perf stat -C 0 -e cycles: $PERF_VERIFY_OUT"
+    info "an rc-0 perf stat with a zero/<not supported> counter is NOT a working setup — a virtualised or masked PMU counts nothing"
+    info "reproduce by hand:  perf stat -C 0 -e cycles -- sleep 0.1"
+  fi
+  info "note: BPF collectors (bpftrace/bcc) still require sudo — a permissive perf_event_paranoid does NOT grant BPF map creation (#3217)"
+  info "posture: this loosening is for DEDICATED SINGLE-TENANT measurement/agent boxes; never apply it to a shared or multi-tenant host"
+fi
+
 # ---- 3. GitHub board access + project scope (Path A, #1886; #2942) ----
 # The board is the SOLE dispatch authority, so "can this machine use the board?"
 # must be answered by TRYING it. Until #2942 this section matched the `project`

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -99,6 +99,20 @@ perf_capability_proc_value() {
   printf '%s' "$v"
 }
 
+# perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative
+# integer NARROW ENOUGH for shell arithmetic. Both halves are load-bearing: `[ 1abc
+# -ge 1 ]` and `[ 99999999999999999999999 -ge 1 ]` do NOT compare — each prints
+# "integer expression expected" to stderr and returns FALSE, so a malformed or
+# oversized value would fall past the `>= 1` test and be reported as `ok` (a WRONG
+# capability claim) while leaking an error line into the gate's output. Validate the
+# shape here instead of trusting the read.
+perf_capability_is_int() {
+  local body="${1#-}"
+  [ -n "$body" ] || return 1
+  case "$body" in *[!0-9]*) return 1 ;; esac
+  [ "${#body}" -le 10 ]
+}
+
 # perf_capability_token: the FREE capability read — pure /proc, ZERO subprocesses
 # that fork a binary beyond `cat`, no `perf` exec, no measurable time cost. This is
 # what the gate's accelerators line calls, so it may never grow an exec.
@@ -111,8 +125,8 @@ perf_capability_token() {
   local p k
   p=$(perf_capability_proc_value perf_event_paranoid) || { printf 'absent'; return 0; }
   k=$(perf_capability_proc_value kptr_restrict) || { printf 'absent'; return 0; }
-  case "$p" in -[0-9]*|[0-9]*) : ;; *) printf 'unknown'; return 0 ;; esac
-  case "$k" in -[0-9]*|[0-9]*) : ;; *) printf 'unknown'; return 0 ;; esac
+  perf_capability_is_int "$p" || { printf 'unknown'; return 0; }
+  perf_capability_is_int "$k" || { printf 'unknown'; return 0; }
   if [ "$p" -ge 1 ]; then printf 'paranoid-%s' "$p"; return 0; fi
   if [ "$k" -ne 0 ]; then printf 'kptr-restricted'; return 0; fi
   printf 'ok'

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -3,51 +3,62 @@
 # perf-capability.sh — the ONE place that knows how a CQLite box is made
 # profileable, and how that is VERIFIED (issue #3249).
 #
-# WHY THIS FILE EXISTS. Agent/worker images ship `kernel.perf_event_paranoid = 4` and set
-# it NOWHERE in /etc/sysctl.conf or /etc/sysctl.d — so every profiling run starts from a
-# hard EACCES whose help text ("access limited") reads like a CAPABILITY verdict when it is
-# a PERMISSION verdict. That has already cost two measurement cycles. The same three-line
-# incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is git-pinned,
-# and is asserted by the gate's tooling-tests.
+# WHY THIS FILE EXISTS. Agent/worker images ship with
+# `kernel.perf_event_paranoid = 4` and set it NOWHERE in /etc/sysctl.conf or
+# /etc/sysctl.d — so every profiling run starts from a hard EACCES whose help text
+# ("access limited") reads like a CAPABILITY verdict when it is a PERMISSION
+# verdict. That has already cost two measurement cycles. The same three-line
+# incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is
+# git-pinned, and is asserted by the gate's tooling-tests.
 #
-# WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE restrictive and
-# each level keeps the ones below it: `>= 3` (an extra Debian/Ubuntu level) denies ALL
-# unprivileged perf use, which is why the images' `4` kills even a plain `perf stat`;
-# `>= 2` no kernel profiling; `>= 1` no CPU-WIDE access, which is exactly what
-# `perf stat -C <cpu>` needs; `>= 0` no raw tracepoints; `-1` (almost) everything, and the
-# perf mlock limit lifted too. CQLite's doctrine mandates per-CPU collection, so `1` is
-# not "almost right", it is a hard denial. `kernel.kptr_restrict = 0` is a SEPARATE control
-# for kernel SYMBOL resolution — without it kernel frames are unresolved addresses, a
-# SILENT attribution loss rather than an error. Same rationale in the drop-in's own bytes.
+# WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE
+# restrictive, and each level keeps the restrictions of the levels below it:
+#   >= 3  (Debian/Ubuntu kernels carry this extra level) disallow ALL unprivileged
+#         perf event use — which is why the images' `4` denies EVERYTHING, down to a
+#         plain `perf stat`, not just the CPU-wide collection
+#   >= 2  no kernel profiling
+#   >= 1  no CPU-WIDE event access  <-- kills `perf stat -C <cpu>`
+#   >= 0  no raw tracepoint access
+#     -1  (almost) all events permitted, and the perf mlock limit is lifted too
+# CQLite's measurement doctrine mandates per-CPU collection (`perf stat -C`), so
+# `1` is not "almost right", it is a hard denial. `0` is the bare minimum that
+# works; `-1` additionally avoids `perf record` ring-buffer surprises.
+# `kernel.kptr_restrict = 0` is a separate control needed for kernel SYMBOL
+# resolution — without it kernel frames render as unresolved addresses, which is a
+# SILENT attribution loss, not an error.
 #
-# SECURITY POSTURE. A deliberate loosening, appropriate for DEDICATED SINGLE-TENANT
-# measurement/agent boxes. Never apply it to a shared or multi-tenant host. See
-# docs/development/fleet-runbook.md. BPF IS A DIFFERENT PERMISSION: a permissive
-# perf_event_paranoid does NOT grant BPF map creation — bpftrace/bcc collectors still need
-# sudo (#3217 finding).
+# SECURITY POSTURE. This is a deliberate loosening appropriate for DEDICATED
+# SINGLE-TENANT measurement/agent boxes. Never apply it to a shared or
+# multi-tenant host. See docs/development/fleet-runbook.md.
 #
-# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call the
-# functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO side
-# effects: this file only defines `perf_capability_*` functions plus the four
-# `PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
-# outside those namespaces are touched). Every function is `set -u` safe.
+# BPF IS A DIFFERENT PERMISSION. A permissive perf_event_paranoid does NOT grant
+# BPF map creation — bpftrace/bcc collectors still need sudo (#3217 finding).
 #
-# Usage when executed: `bash scripts/perf-capability.sh --help` (the modes are listed by
-# perf_capability_usage below, so they are not duplicated here).
+# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call
+# the functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO
+# side effects: this file only defines
+# `perf_capability_*` functions plus the three `PERF_CAPABILITY_*` path constants
+# (nothing runs, no shell options are changed, no variables outside those namespaces
+# are touched). Every function is `set -u` safe.
+#
+# Usage (executed):
+#   bash scripts/perf-capability.sh --token        # free /proc read -> one token
+#   bash scripts/perf-capability.sh --verify       # functional perf stat check
+#   bash scripts/perf-capability.sh --drop-in      # canonical sysctl.d file bytes
+#   bash scripts/perf-capability.sh --drop-in-path # where that file belongs
 #
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
-# The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
-# bootstrap pipes the drop-in through `sudo tee <path>`: were that path env-derived, one stray
-# export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d) would make ROOT write an
-# attacker/accident-chosen file while the real drop-in was never installed — and an unparsable
-# sudoers entry can wedge `sudo` outright. Likewise an env-chosen /proc stand-in would let a
-# paranoid-4 box print a FABRICATED "verified" verdict. So the seams take effect ONLY under
-# the explicit marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
-# reachable on PATH is a hard refusal (the suite PATH-shims both and declares the shim
-# directory), so test mode can never reach a real privileged tool.
-#   CQLITE_PERF_TEST_MODE=1     the marker; without it every seam below is INERT
-#   CQLITE_PERF_TEST_SANDBOX    THE SANDBOX ROOT — the one absolute directory every other
-#                               seam must be provably INSIDE (test mode only)
+# The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel)
+# because bootstrap pipes the drop-in through `sudo tee <path>`: if that path were
+# env-derived, a single stray export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d)
+# would make ROOT write an attacker/accident-chosen file while the real drop-in was
+# never installed — and an unparsable sudoers entry can wedge `sudo` outright.
+# Likewise an env-chosen /proc stand-in would let a paranoid-4 box print a
+# FABRICATED "verified" verdict. So the seams take effect ONLY under the explicit
+# marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
+# reachable on PATH is a hard refusal (the suite PATH-shims both and declares the
+# shim directory), so test mode can never reach a real privileged tool.
+#   CQLITE_PERF_TEST_MODE=1     the marker; without it the two seams below are INERT
 #   CQLITE_PERF_PROC_DIR        stand-in for /proc/sys/kernel   (test mode only)
 #   CQLITE_PERF_SYSCTL_DIR      stand-in for /etc/sysctl.d      (test mode only)
 #   CQLITE_PERF_SYSCTL_EXTRA_DIRS  colon-separated stand-ins for the LOWER-precedence
@@ -56,61 +67,57 @@
 #                               optional, test mode only
 #   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
 #
-# POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds each
-# closed ONE MORE SPELLING of "the production directory": the raw path (B3), a symlinked seam,
-# `..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes implementation-defined,
-# `pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A denylist over path spellings
-# cannot be completed — `.`, `..`, symlinks, `//`, trailing slashes, bind mounts,
-# `/proc/self/root/…` all name the same directory — and scattered prohibitions also let a NEW
-# entry point silently miss them (R6-2). So the rule is INVERTED and there is exactly ONE: a
-# seam is usable IFF it is strictly contained in the declared sandbox root. Every spelling of
-# "somewhere else", including every future one, fails that single check for the same reason.
-# TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams are
-# MANDATORY. The earlier shape — marker set, seam unset, fall back to the real directory —
-# meant test mode could pass the env guard (sudo/sysctl absent, or present as declared shims)
-# and a subsequent root `--yes` run would `tee` the REAL /etc/sysctl.d, mutating the host from
-# a test run. "Hermetic" cannot be a claim that depends on a variable being set.
+# TEST MODE HAS NO FALLBACK (issue #3249 review R4-3). Under the marker BOTH path
+# seams are MANDATORY and must be absolute, non-production directories. The earlier
+# shape — marker set, seam unset, fall back to the real directory — meant test mode
+# could pass the env guard (sudo/sysctl absent, or present as declared shims) and a
+# subsequent root `--yes` run would then invoke a bare `tee` against the REAL
+# /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim that
+# depends on a variable being set: it is enforced here, fail-closed and loudly.
 
 # FAIL-OPEN AUDIT — every path that can reach a POSITIVE verdict, and what validates it
-# (review round 4; four findings in this file were one defect class: "identity/state unknown
-# => assume the good case"). Keep this list CLOSED: a new positive-verdict path SHALL be added
-# here with its validator, or it is a regression.
-#   token = ok                  both /proc values READ (non-empty) from the resolved dir AND
-#                               both `is_int`-validated AND paranoid <= 0 AND kptr == 0.
-#                               Whitespace trimmed, never TRUNCATED — `0 1` stays malformed.
-#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count is a
-#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` + `-le
-#                               0`. `<not supported>`/`<not counted>`/empty/oversized/malformed
-#                               all return 1.
-#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0 and
-#                               prints a validated non-negative int) AND that uid != 0; an
-#                               unusable `id -u` => identity-unknown, rc 1.
+# (issue #3249 review round 4; four findings in this file were all one defect class:
+# "identity/state unknown => assume the good case"). Keep this list closed: a new
+# positive-verdict path SHALL be added here with its validator, or it is a regression.
+#   token = ok                  both /proc values READ (non-empty) from the resolved dir
+#                               AND both `perf_capability_is_int`-validated AND
+#                               paranoid <= 0 AND kptr == 0. Whitespace is trimmed, never
+#                               TRUNCATED — `0 1` stays malformed -> `unknown`.
+#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count
+#                               is a positive integer by BOTH awk's `^[0-9]+$` and
+#                               `is_int` + `-le 0`. `<not supported>`/`<not counted>`/
+#                               empty/oversized/malformed all return 1.
+#   state = self-unprivileged   `perf_capability_self_uid_into` succeeded (an `id -u` that
+#                               EXISTS, exits 0, prints a validated non-negative int) AND
+#                               that uid != 0. An unusable `id -u` => identity-unknown, rc 1.
 #   state = dropped:setpriv     numeric uid+gid, both validated ints AND both > 0.
 #   state = dropped:runuser     the same numerics PLUS a `SUDO_USER` the passwd database
-#                               confirms IS that non-zero uid/gid, with characters safe for
-#                               the caller's word-split.
+#                               confirms IS that non-zero uid/gid, and whose characters are
+#                               safe for the caller's word-split.
 #   state = dropped:sudo        numeric uid only (sudo's `#<uid>` form) — no name trusted.
 #   env_guard rc 0              production: NO test seam set (paths are hardcoded literals).
-#                               test mode: a PROVEN sandbox root plus BOTH seams RESOLVING
-#                               strictly inside it, plus every reachable sudo/sysctl inside
-#                               an absolute declared shim dir.
-#   dropin_path rc 0            its directory came from `sysctl_dir`, i.e. RESOLVES inside the
-#                               sandbox — the single gate between the bytes and a root `tee`.
-#   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against the
-#                               canonical content from a read that reached EOF — a
-#                               NUL-delimited read is NOT current (R5-3).
+#                               test mode: BOTH seams present and their CANONICAL
+#                               destinations (`.`, `..` and symlinked ancestors resolved)
+#                               absolute and outside the production dirs and /etc /proc
+#                               /sys; plus every reachable sudo/sysctl resolving inside an
+#                               absolute declared shim dir.
+#   dropin_path rc 0            in test mode, the seam RESOLVES inside its sandbox (R5-1) —
+#                               re-checked independently of the guard, because this is the
+#                               last thing between the canonical bytes and a root `tee`.
+#   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against
+#                               the generated canonical content, from a read that reached
+#                               EOF — a NUL-delimited read is NOT current, whatever the
+#                               bytes before the NUL are (R5-3).
 # KNOWN RESIDUALS, deliberately not papered over:
-#   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel changed
-#     uid. Harmless by construction: the caller's verdict is `token = ok` AND the functional
-#     pass, and a box whose /proc says ok IS profileable unprivileged, so a mislabelled drop
-#     cannot manufacture a capability that is absent.
-#   * the READ-side containment check is SYNTACTIC (fork-free, gate contract) while every
-#     write / host-config read canonicalizes — SAME predicate, different input form. The read
-#     side judges the spelling, so a symlinked ancestor INSIDE the sandbox could still steer a
-#     test-mode /proc STAND-IN read. Bounded by that path's whole contract: the seams are
-#     honoured only under the test marker, which is never set in production, and nothing there
-#     writes — so the worst case is a read of a caller-chosen file reported as
-#     `absent`/`unknown`, never a fabricated capability.
+#   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel
+#     changed uid. Harmless by construction: the caller's verdict is `token = ok` AND the
+#     functional pass, and a box whose /proc says ok IS profileable by an unprivileged
+#     process, so a mislabelled drop cannot manufacture a capability that is absent.
+#   * the READ-side seam check is textual (fork-free, gate contract): it rejects `.`/`..`
+#     components and a symlinked seam, but a symlinked ANCESTOR could still steer a
+#     test-mode /proc STAND-IN read. Bounded and harmless: nothing on that path writes,
+#     and a wrong read yields `absent`/`unknown`, never a fabricated capability. Every
+#     WRITE-side check canonicalizes instead (R5-1).
 #
 # ---- production locations: HARDCODED. Never env-derived outside test mode. ----
 PERF_CAPABILITY_PROC_DIR_DEFAULT='/proc/sys/kernel'
@@ -120,122 +127,95 @@ PERF_CAPABILITY_DROPIN_BASENAME='99-cqlite-perf.conf'
 # perf_capability_test_mode: rc 0 iff the explicit test marker is set.
 perf_capability_test_mode() { [ "${CQLITE_PERF_TEST_MODE:-}" = 1 ]; }
 
-# perf_capability_seam_set: rc 0 iff either test-only path seam is non-empty. The ONE
-# seam reader outside the containment gate below, and deliberately so: it asks only
-# "was a seam handed to us at all" (for the marker-less refusal) and never uses the
-# VALUE as a path. The structural audit in test_perf_capability.sh allowlists it by
-# name, so a future function cannot join it silently.
+# perf_capability_seam_set: rc 0 iff either test-only path seam is non-empty.
 perf_capability_seam_set() {
   [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ]
 }
 
-# ---- ONE GATE: POSITIVE SANDBOX CONTAINMENT (review R6-1/R6-2) --------------------
-# THE sandbox root is caller-declared (CQLITE_PERF_TEST_SANDBOX) and must PROVE itself: an
-# absolute, canonically spelled, existing directory carrying the stamp file below. The stamp is
-# what makes the declaration unforgeable by environment alone — a stray
-# CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on the
-# FILESYSTEM and writing it into a system directory already needs the privilege this guard
-# protects. No denylist appears below: a path is usable because it is provably INSIDE the
-# sandbox, never because it failed to look like somewhere forbidden.
+# TWO VALIDATORS, SPLIT BY WHAT THE CALLER DOES (issue #3249 review R5-1). Textual
+# validation of a path is the wrong tool for a guard that steers a privileged write:
+# each round closed one more SPELLING of "somewhere else" (raw production path, then a
+# symlinked seam, then `..`). So the two callers get different validators:
+#   READ side  (the gate's emit-time token chain) -> perf_capability_test_dir_valid:
+#              pure builtins, ZERO forks, because that path is contractually free. It
+#              never writes anything, so a mis-accepted seam there can only mis-READ a
+#              stand-in /proc, which the token then reports as `absent`/`unknown`.
+#   WRITE side (env guard + the drop-in path a root `tee` is pointed at) ->
+#              perf_capability_test_dir_resolved_valid: CANONICALIZES the whole path
+#              (resolving `.`, `..` AND symlinked ancestors) and validates the RESOLVED
+#              destination. A fork costs nothing there, and the destination — not its
+#              spelling — is what gets written.
 #
-# FIVE thin functions, ONE predicate — everything ends in perf_capability_path_within:
-#   sandbox_root_into O        the declared root, validated; rc 1 + empty when unproven
-#   path_within P R            THE predicate (below)
-#   sandbox_ok P               FORK-FREE entry point (the gate's emit-time token chain, which
-#                              may not fork): judges the SPELLING — sound there for the reason
-#                              in the fail-open audit's second residual above
-#   sandbox_ok_resolved P      every path WRITTEN, or whose CONTENTS are read: canonicalizes
-#                              candidate AND root, then the SAME predicate. An unenterable
-#                              path resolves to nothing and is refused — fail-closed, and
-#                              correct for a write target, which must exist to be written into
-#   sandbox_file_ok_resolved F the FILE form (the optional `sysctl.conf` entry): judged by
-#                              canonicalizing its PARENT, plus a plain-basename check
-# `cd -P` + `pwd -P` is the canonicalizer: one subshell, no external binary, correct on bash
-# 3.2 (no `realpath`, no `readlink -f` — absent or non-GNU on some supported hosts).
-PERF_CAPABILITY_SANDBOX_STAMP='.cqlite-perf-sandbox'
-
-perf_capability_sandbox_root_into() {
-  local __psr_v="${CQLITE_PERF_TEST_SANDBOX:-}"
-  eval "$1="
-  __psr_v="${__psr_v%/}"
-  case "$__psr_v" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
-  case "/$__psr_v/" in */../*|*/./*) return 1 ;; esac
-  [ -d "$__psr_v" ] && [ -f "$__psr_v/$PERF_CAPABILITY_SANDBOX_STAMP" ] || return 1
-  eval "$1=\$__psr_v"
-}
-
-# THE containment predicate, and the only place a path is ever judged: rc 0 iff <path> is
-# absolute, canonically spelled (no `.`, `..` or `//` component — `//etc` IS `/etc`, R6-1)
-# and STRICTLY inside <root>, with the `/` boundary explicit so `/tmp/sandboxevil` is NOT
-# inside `/tmp/sandbox`. An empty root refuses; it is never a wildcard.
-perf_capability_path_within() {
-  [ -n "${2:-}" ] || return 1
-  case "${1:-}" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
+# perf_capability_test_dir_valid <value> <production-default>: rc 0 iff <value> is a
+# usable NON-PRODUCTION stand-in — non-empty, ABSOLUTE, free of `.`/`..` components (a
+# path whose spelling is not its destination cannot be validated textually at all), and
+# neither the production directory itself nor a path under it, nor anywhere under the
+# host's own configuration surfaces (/proc, /sys, /etc), nor itself a symlink
+# (`ln -s /etc/sysctl.d /tmp/x` passes every other textual test). An unset or
+# production-shaped seam is NOT "use the real thing": in test mode it is a refusal
+# (R4-3). Builtins only — this is reached from the gate's fork-free token path.
+perf_capability_test_dir_valid() {
+  [ -n "${1:-}" ] || return 1
+  case "$1" in /*) ;; *) return 1 ;; esac
   case "/$1/" in */../*|*/./*) return 1 ;; esac
-  case "$1" in "$2"/?*) return 0 ;; esac
-  return 1
+  case "$1" in
+    "${2:-/dev/null/never}"|"${2:-/dev/null/never}"/*) return 1 ;;
+    /proc|/proc/*|/sys|/sys/*|/etc|/etc/*) return 1 ;;
+  esac
+  [ ! -L "$1" ]
 }
 
-perf_capability_sandbox_ok() {
-  local __pso_root=''
-  perf_capability_sandbox_root_into __pso_root || return 1
-  perf_capability_path_within "${1:-}" "$__pso_root"
+# perf_capability_test_dir_resolved_valid <value> <production-default>: the WRITE-side
+# validator. It canonicalizes <value> and requires the RESOLVED path to satisfy the same
+# non-production predicate, so `/tmp/../etc/sysctl.d` and a symlinked ANCESTOR
+# (`ln -s /etc /tmp/a`, seam `/tmp/a/sysctl.d`) are refused by their DESTINATION rather
+# than by a new textual special case. `cd -P` + `pwd -P` is the canonicalizer: one
+# subshell, no external binary, and correct on bash 3.2 (no `realpath`, no `readlink -f`,
+# both of which are absent or non-GNU on some supported hosts). A path that cannot be
+# entered at all resolves to nothing and is refused — fail-closed, and correct for a
+# write target, which must exist to be written into.
+perf_capability_test_dir_resolved_valid() {
+  local __ptv_real=''
+  perf_capability_test_dir_valid "$1" "$2" || return 1
+  __ptv_real=$(cd -P -- "$1" 2>/dev/null && pwd -P) || return 1
+  [ -n "$__ptv_real" ] || return 1
+  perf_capability_test_dir_valid "$__ptv_real" "$2"
 }
 
-perf_capability_sandbox_ok_resolved() {
-  local __pdr_root='' __pdr_real=''
-  perf_capability_sandbox_root_into __pdr_root || return 1
-  # BOTH sides canonicalized the same way, so the comparison is between destinations
-  __pdr_root=$(cd -P -- "$__pdr_root" 2>/dev/null && pwd -P) || return 1
-  __pdr_real=$(cd -P -- "${1:-/dev/null/never}" 2>/dev/null && pwd -P) || return 1
-  perf_capability_path_within "$__pdr_real" "${__pdr_root%/}"
-}
-
-perf_capability_sandbox_file_ok_resolved() {
-  case "${1:-}" in */?*) ;; *) return 1 ;; esac
-  case "${1##*/}" in ''|.|..) return 1 ;; esac
-  # the FILE path is judged by canonicalizing its PARENT: a canonical parent strictly inside
-  # the sandbox puts <parent>/<basename> strictly inside it too, for any plain basename.
-  perf_capability_sandbox_ok_resolved "${1%/*}"
-}
-
-# ONE message shape for both mandatory seams: the refusal must NAME the offending seam (that
-# is what makes it actionable), so it is parameterised rather than duplicated per seam.
-perf_capability_seam_refusal() {
-  printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires %s INSIDE the declared sandbox %s — its RESOLVED destination (. / .. / // / symlinked ancestors and all) must be strictly contained there; got %s. Test mode NEVER falls back to the real directory.\n' \
-    "${1:-<seam>}" "'${3:-}'" "'${2:-<unset>}'" >&2
-}
-
-# perf_capability_test_seams_ok: rc 0 iff test mode has a PROVEN sandbox root and BOTH
-# mandatory seams RESOLVING strictly inside it. This is the gate on every privileged action
-# below, so it takes the resolving form: refusing here is what stops a root `--yes` test run
-# from resolving a seam back into the production directory and overwriting the host's own
-# drop-in. It refuses loudly, because the failure it prevents is silent otherwise.
+# perf_capability_test_seams_ok: rc 0 iff test mode has BOTH mandatory seams pointing
+# at explicit non-production directories, JUDGED BY THEIR CANONICAL DESTINATION (R5-1).
+# This is the gate on every privileged action below, so it takes the strict validator:
+# refusing here is what stops a root `--yes` test run from resolving a seam back into
+# the production directory and overwriting the host's own drop-in. Refuses loudly and
+# names the offending seam, because the failure it prevents is silent otherwise.
 perf_capability_test_seams_ok() {
-  local ok=0 root=''
-  if ! perf_capability_sandbox_root_into root; then
-    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires CQLITE_PERF_TEST_SANDBOX to name an absolute existing directory holding the stamp file %s; got %s. Test mode acts only INSIDE a proven sandbox and NEVER falls back to the real directory.\n' \
-      "$PERF_CAPABILITY_SANDBOX_STAMP" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" >&2
-    return 1
+  local ok=0
+  if ! perf_capability_test_dir_resolved_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT"; then
+    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR (absolute, and RESOLVING — . / .. / symlinked ancestors and all — outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
+      "$PERF_CAPABILITY_PROC_DIR_DEFAULT" "'${CQLITE_PERF_PROC_DIR:-<unset>}'" >&2
+    ok=1
   fi
-  perf_capability_sandbox_ok_resolved "${CQLITE_PERF_PROC_DIR:-}" \
-    || { perf_capability_seam_refusal CQLITE_PERF_PROC_DIR "${CQLITE_PERF_PROC_DIR:-}" "$root"; ok=1; }
-  perf_capability_sandbox_ok_resolved "${CQLITE_PERF_SYSCTL_DIR:-}" \
-    || { perf_capability_seam_refusal CQLITE_PERF_SYSCTL_DIR "${CQLITE_PERF_SYSCTL_DIR:-}" "$root"; ok=1; }
+  if ! perf_capability_test_dir_resolved_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
+    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR (absolute, and RESOLVING — . / .. / symlinked ancestors and all — outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
+      "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" >&2
+    ok=1
+  fi
   [ "$ok" = 0 ]
 }
 
-# perf_capability_env_guard: rc 0 iff this process may act on the perf capability path at
-# all. Every refusal is LOUD on stderr and FAILS CLOSED (the caller does nothing privileged
-# and claims no verdict):
-#   * a seam set WITHOUT the marker — the seams are inert there, so a caller handed one is
-#     misconfigured and nothing privileged may proceed;
-#   * the marker set WITHOUT a proven sandbox root and both seams inside it — test mode has
-#     no fallback (R4-3): allowing one would let a root `--yes` test run `tee` the REAL
-#     /etc/sysctl.d, the host mutation the marker promises cannot happen. Checked FIRST,
-#     before the tool checks: a test run with no sandbox has nowhere safe to act;
-#   * the marker set while a REAL sudo/sysctl is reachable — test mode is hermetic by
-#     construction, so a reachable real privileged tool is a harness bug, not something to run.
+# perf_capability_env_guard: rc 0 iff this process may act on the perf capability
+# path at all. Every refusal is LOUD on stderr and FAILS CLOSED (the caller does
+# nothing privileged and claims no verdict):
+#   * a seam set WITHOUT the marker — the seams are inert there, and a caller that
+#     was handed one is misconfigured, so nothing privileged may proceed;
+#   * the marker set WITHOUT both non-production path seams — test mode has no
+#     fallback (R4-3): allowing one would let a root `--yes` test run `tee` the REAL
+#     /etc/sysctl.d, which is exactly the host mutation the marker promises cannot
+#     happen. Checked FIRST, before the tool checks, because it is the more
+#     fundamental precondition: a test run with no sandbox has nowhere safe to act;
+#   * the marker set while a REAL sudo/sysctl is reachable — test mode is hermetic
+#     by construction, so a reachable real privileged tool is a bug in the harness,
+#     not something to run.
 perf_capability_env_guard() {
   if ! perf_capability_test_mode; then
     perf_capability_seam_set || return 0
@@ -252,39 +232,40 @@ perf_capability_env_guard() {
       *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 with a reachable real %s and no absolute CQLITE_PERF_TEST_PRIV_DIR — test mode must PATH-shim every privileged tool.\n' "$tool" >&2
          return 1 ;;
     esac
-    # The seams' containment predicate, one level down: the tool must be strictly inside the
-    # DECLARED shim dir, not merely spelled that way.
-    perf_capability_path_within "$resolved" "${dir%/}" || {
-      printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
-        "$tool" "$resolved" "$dir" >&2
-      return 1
-    }
+    case "$resolved" in
+      "$dir"/*) ;;
+      *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
+           "$tool" "$resolved" "$dir" >&2
+         return 1 ;;
+    esac
   done
   return 0
 }
 
 # ---- resolved locations (the seams apply ONLY in test mode) -------------------
-# THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain below and
-# is contractually FREE — no external process AND no command substitution (each `$( )` forks
-# a subshell, which is a process too). A function that answers on stdout therefore CANNOT be
-# on that path: its caller must fork to read it. So every function the gate touches has an
-# `_into <outvar>` core assigning through a caller-named variable, and the stdout-printing
-# form is a thin wrapper for CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork
-# is paid, and it is not on the gate's path. Assignment is `eval "$1=\$var"`, NOT a
-# `local -n` nameref: bash 3.2 (macOS /bin/bash, a supported gate host) has none. The RHS is
-# an assignment, so no word-splitting or globbing applies; <outvar> must be a plain
-# identifier (every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_` prefixes
-# keep a caller-named variable from colliding with an internal one).
-#   In TEST MODE the seam is MANDATORY and gated (R4-3): a value not provably inside the
-#   declared sandbox is rc 1 with an empty answer, never a silent fallback to the real /proc
-#   or /etc/sysctl.d. Every caller propagates that rc, so an unsandboxed test run reads
-#   nothing and writes nothing.
+# THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain
+# below and is contractually FREE — no external process AND no command substitution
+# (each `$( )` forks a subshell, which is a process too). A function that answers on
+# stdout therefore CANNOT be on that path: its caller must fork to read it. So every
+# function the gate touches has an `_into <outvar>` core that assigns through a
+# caller-named variable, and the stdout-printing form is a thin wrapper kept for the
+# CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork is paid, and it is
+# not on the gate's path.
+#   Assignment is `eval "$1=\$var"`, NOT a `local -n` nameref: bash 3.2 (macOS
+#   /bin/bash, a supported gate host) has no namerefs. The RHS is an assignment, so no
+#   word-splitting or globbing applies to the value. <outvar> must be a plain shell
+#   identifier; every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_`
+#   local prefixes keep a caller-named variable from colliding with an internal one.
+#   In TEST MODE the seam is MANDATORY and validated (R4-3): an unset or
+#   production-shaped value is rc 1 with an empty answer, never a silent fallback to
+#   the real /proc or the real /etc/sysctl.d. Every caller propagates that rc, so an
+#   unsandboxed test run reads nothing and writes nothing.
 perf_capability_proc_dir_into() {
   eval "$1="
   if perf_capability_test_mode; then
-    perf_capability_sandbox_ok "${CQLITE_PERF_PROC_DIR:-}" || {
-      printf 'perf-capability: REFUSING to read /proc: CQLITE_PERF_TEST_MODE=1 with CQLITE_PERF_PROC_DIR (%s) not INSIDE the declared sandbox %s — test mode never falls back to %s.\n' \
-        "'${CQLITE_PERF_PROC_DIR:-<unset>}'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
+    perf_capability_test_dir_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" || {
+      printf 'perf-capability: REFUSING to read /proc: CQLITE_PERF_TEST_MODE=1 with no valid non-production CQLITE_PERF_PROC_DIR (got %s) — test mode never falls back to %s.\n' \
+        "'${CQLITE_PERF_PROC_DIR:-<unset>}'" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
       return 1
     }
     eval "$1=\$CQLITE_PERF_PROC_DIR"
@@ -297,15 +278,11 @@ perf_capability_proc_dir() {
   perf_capability_proc_dir_into __pcd_v || return 1
   printf '%s' "$__pcd_v"
 }
-# perf_capability_sysctl_dir: the sysctl.d directory — the WRITE side (a root `tee` is aimed
-# inside it) and the directory whose CONTENTS the competing-file scan reads, so it takes the
-# RESOLVING gate. EVERY consumer of that location comes through this one function, so there is
-# exactly one place the check could be forgotten — and it is here.
 perf_capability_sysctl_dir() {
   if perf_capability_test_mode; then
-    perf_capability_sandbox_ok_resolved "${CQLITE_PERF_SYSCTL_DIR:-}" || {
-      printf 'perf-capability: REFUSING to resolve a sysctl.d path: CQLITE_PERF_TEST_MODE=1 with CQLITE_PERF_SYSCTL_DIR (%s) not RESOLVING inside the declared sandbox %s (or unenterable) — test mode never falls back to %s.\n' \
-        "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" >&2
+    perf_capability_test_dir_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" || {
+      printf 'perf-capability: REFUSING to resolve a sysctl.d path: CQLITE_PERF_TEST_MODE=1 with no valid non-production CQLITE_PERF_SYSCTL_DIR (got %s) — test mode never falls back to %s.\n' \
+        "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" >&2
       return 1
     }
     printf '%s' "$CQLITE_PERF_SYSCTL_DIR"
@@ -313,21 +290,29 @@ perf_capability_sysctl_dir() {
   fi
   printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
-# perf_capability_dropin_path: the path a root `tee` is pointed at. Its gate lives in
-# perf_capability_sysctl_dir (the single source of that directory) and RESOLVES the
-# destination, so there is deliberately no second copy here — one gate, not a prohibition a
-# future entry point could skip (R6-2).
+# perf_capability_dropin_path: the path a root `tee` is pointed at, so this is the WRITE
+# side and it takes the STRICT validator (R5-1) — the seam's CANONICAL destination is
+# checked, not its spelling. Independent of the env guard on purpose: the guard is the
+# gate, this is the last line before the bytes land, and a write target may never be
+# named from a path that resolves into production.
 perf_capability_dropin_path() {
   local __pdi_d
   __pdi_d=$(perf_capability_sysctl_dir) || return 1
+  if perf_capability_test_mode \
+     && ! perf_capability_test_dir_resolved_valid "$__pdi_d" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
+    printf 'perf-capability: REFUSING to name a write target: CQLITE_PERF_SYSCTL_DIR=%s RESOLVES (through . / .. / a symlinked ancestor) outside its sandbox or is unenterable — the canonical DESTINATION is what a root tee writes, not the spelling.\n' \
+      "'$__pdi_d'" >&2
+    return 1
+  fi
   printf '%s/%s' "$__pdi_d" "$PERF_CAPABILITY_DROPIN_BASENAME"
 }
 
-# perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a WHOLE
-# managed file (not a delimited block inside a foreign one), so idempotency is a plain
-# byte-compare of the entire file — simpler and safer than editing someone else's config.
-# Callers may pipe this straight into `sudo tee`, which is also the remedy line bootstrap
-# prints, so a hand-applied fix is byte-identical and the next bootstrap run is a no-op.
+# perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a
+# WHOLE managed file (not a delimited block inside a foreign one), so idempotency
+# is a plain byte-compare of the entire file — simpler and safer than editing
+# someone else's config. Callers may pipe this straight into `sudo tee`, which is
+# also the remedy line bootstrap prints, so a hand-applied fix produces
+# byte-identical content and the next bootstrap run is a silent no-op.
 perf_capability_dropin_content() {
   cat <<'EOF'
 # Managed by scripts/bootstrap-agent-machine.sh — CQLite issue #3249. Do not edit.
@@ -358,24 +343,27 @@ kernel.kptr_restrict = 0
 EOF
 }
 
-# perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the managed
-# bytes (the idempotency test — a matching file means write nothing). The compare is an
-# in-shell string compare, NOT `diff -q`: on a box without diffutils `diff` exits 127,
-# which reads as "different" on every run — so bootstrap would re-write the file each time
-# AND then report it could not write it.
+# perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the
+# managed bytes (the idempotency test — a matching file means write nothing). The
+# compare is an in-shell string compare, NOT `diff -q`: on a box without diffutils
+# `diff` exits 127, which would report "different" on every run — so bootstrap
+# would re-write the file each time AND then report it could not write it.
 #
-# TRAILING NEWLINES ARE PART OF THE BYTES (review R4-4). `$( )` strips EVERY trailing
-# newline, so comparing two command substitutions made a file missing its final newline —
-# or carrying extra trailing blank lines — compare EQUAL: "byte-exact" was a false claim
-# and such a file was never rewritten. The file side is read with `read -r -d ''`, which
-# consumes it verbatim (builtin, no `cat`/`diff` dependency), and the canonical side carries
-# an in-substitution sentinel so its own final newline survives the stripping.
+# TRAILING NEWLINES ARE PART OF THE BYTES (issue #3249 review R4-4). `$( )` strips
+# EVERY trailing newline from its output, so comparing two command substitutions made
+# a file missing its final newline — or carrying extra blank lines at the end —
+# compare EQUAL to the canonical content: "byte-exact" was a false claim, and such a
+# file was never rewritten. The file side is now read with `read -r -d ''`, which
+# consumes the whole file verbatim (builtin, so no `cat`/`diff` dependency), and the
+# canonical side carries an in-substitution sentinel so its own final newline survives
+# the stripping.
 #
-# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (review R5-3). `read -d ''` stops at a NUL
-# and returns SUCCESS with only the bytes BEFORE it, so canonical content + NUL + ARBITRARY
-# trailing bytes compared EQUAL and was judged current. Read's rc is therefore load-bearing:
-# rc 0 means a NUL was consumed — not our text drop-in, and the rest never even seen — so it
-# is NOT current; only rc != 0 (EOF, whole file in `got`) may be compared.
+# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (issue #3249 review R5-3). `read -d ''`
+# stops at a NUL and returns SUCCESS, leaving `got` holding only the bytes BEFORE it — so
+# canonical content followed by a NUL and ARBITRARY trailing bytes compared EQUAL and was
+# judged current. Read's rc is therefore load-bearing: rc 0 means a NUL delimiter was
+# consumed, i.e. the file is not our text drop-in AND the rest of it was never even seen,
+# so it is NOT current; only an rc != 0 (EOF reached, whole file in `got`) may be compared.
 perf_capability_dropin_current() {
   local path want got=''
   path=$(perf_capability_dropin_path) || return 1
@@ -388,31 +376,32 @@ perf_capability_dropin_current() {
 }
 
 # perf_capability_sysctl_search_path: the COMPLETE set of locations `sysctl --system`
-# (procps-ng) and systemd-sysctl load, one per line, in DESCENDING NAME-MASKING PRECEDENCE —
-# the order both tools scan (sysctl(8) SYSTEM FILE PRECEDENCE, sysctl.d(5) CONFIGURATION
-# DIRECTORIES AND PRECEDENCE): /etc/sysctl.d, /run/sysctl.d, /usr/local/lib/sysctl.d,
-# /usr/lib/sysctl.d, /lib/sysctl.d, and finally the FILE /etc/sysctl.conf.
+# (procps-ng) and systemd-sysctl load, one per line, in DESCENDING NAME-MASKING
+# PRECEDENCE — the order both tools scan (sysctl(8) SYSTEM FILE PRECEDENCE, sysctl.d(5)
+# CONFIGURATION DIRECTORIES AND PRECEDENCE):
+#   /etc/sysctl.d  /run/sysctl.d  /usr/local/lib/sysctl.d  /usr/lib/sysctl.d
+#   /lib/sysctl.d  and finally the FILE /etc/sysctl.conf
 # TWO INDEPENDENT RULES decide who wins, and the scan below implements both:
 #   MASKING  "once a file of a given filename is loaded, any file of the same name in
 #            subsequent directories is ignored" — so /etc/sysctl.d/50-x.conf REPLACES
-#            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would name
-#            a file that is not in effect.
-#   ORDERING the survivors are applied in lexicographic BASENAME order regardless of which
-#            directory they came from; the LAST assignment wins. /etc/sysctl.conf is applied
-#            AFTER every drop-in, so it wins on grounds unrelated to its name and gets its
-#            own verdict rather than a sort comparison.
-# WHY THE WHOLE PATH (review R5-4). Scanning only /etc/sysctl.d meant a later-sorting file in
-# /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in while bootstrap reported NO
-# competitor — recreating the "it silently reverts and nobody knows why" mystery this
-# diagnostic exists to end.
+#            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would
+#            name a file that is not in effect.
+#   ORDERING the surviving files are applied in lexicographic BASENAME order regardless
+#            of which directory they came from; the LAST assignment wins.
+#   /etc/sysctl.conf is applied AFTER every drop-in, so it wins on grounds that have
+#   nothing to do with its name — it gets its own verdict rather than a sort comparison.
+#
+# WHY THE WHOLE PATH (issue #3249 review R5-4). Scanning only /etc/sysctl.d meant a
+# later-sorting file in /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in
+# while bootstrap reported NO competitor — recreating the exact "it silently reverts and
+# nobody knows why" mystery this diagnostic exists to end.
 #
 # In TEST MODE the path is the sandbox seam plus the optional colon-separated
-# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, same descending order): the real
-# /run and /usr/lib are never read. EVERY entry goes through the SAME RESOLVING gate as the
-# write path (R6-2 — this entry point once used the syntactic one, so a symlinked ancestor
-# could point a "sandboxed" scan at the host's real configuration).
+# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, in the same descending
+# order, each validated non-production): the real /run and /usr/lib are never read, so a
+# case's verdict can never depend on the host's own drop-ins.
 perf_capability_sysctl_search_path() {
-  local __psp_d __psp_e __psp_ok
+  local __psp_d __psp_e
   if perf_capability_test_mode; then
     __psp_d=$(perf_capability_sysctl_dir) || return 1
     printf '%s\n' "$__psp_d"
@@ -421,14 +410,9 @@ perf_capability_sysctl_search_path() {
     IFS=':' read -r -a __psp_extra <<<"${CQLITE_PERF_SYSCTL_EXTRA_DIRS:-}"
     for __psp_e in ${__psp_extra[@]+"${__psp_extra[@]}"}; do
       [ -n "$__psp_e" ] || continue
-      __psp_ok=0
-      case "${__psp_e##*/}" in
-        sysctl.conf) perf_capability_sandbox_file_ok_resolved "$__psp_e" && __psp_ok=1 ;;
-        *)           perf_capability_sandbox_ok_resolved "$__psp_e" && __psp_ok=1 ;;
-      esac
-      [ "$__psp_ok" = 1 ] || {
-        printf 'perf-capability: REFUSING: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry %s does not RESOLVE inside the declared sandbox %s — a test-mode scan may never read the host'"'"'s real sysctl configuration.\n' \
-          "'$__psp_e'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" >&2
+      perf_capability_test_dir_valid "$__psp_e" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" || {
+        printf 'perf-capability: REFUSING: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry %s is not an absolute NON-PRODUCTION path — a test-mode scan may never read the host'"'"'s real sysctl.d directories.\n' \
+          "'$__psp_e'" >&2
         return 1
       }
       printf '%s\n' "$__psp_e"
@@ -439,9 +423,9 @@ perf_capability_sysctl_search_path() {
                 /lib/sysctl.d /etc/sysctl.conf
 }
 
-# rc 0 iff the file ASSIGNS either control. Both spellings sysctl accepts are matched
-# (`kernel.x` and `kernel/x`, sysctl.d(5)) plus the optional leading `-` ignore-failure
-# prefix; a commented-out line assigns nothing.
+# perf_capability_file_sets_controls <path>: rc 0 iff the file ASSIGNS either control.
+# Both spellings sysctl accepts are matched (`kernel.x` and `kernel/x`, sysctl.d(5)) plus
+# the optional leading `-` ignore-failure prefix; a commented-out line assigns nothing.
 perf_capability_file_sets_controls() {
   grep -Eq '^[[:space:]]*-?kernel[./](perf_event_paranoid|kptr_restrict)[[:space:]]*=' "$1" 2>/dev/null
 }
@@ -455,15 +439,16 @@ perf_capability_file_sets_controls() {
 # wins regardless of name.
 #
 # WHY THIS EXISTS. Three separate reports (ws0-3217, ws3-3029, the 2026-07-27 Cassandra
-# baseline) recorded a hand-set perf_event_paranoid/kptr_restrict "silently reverting" and
-# none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
+# baseline) recorded that a hand-set perf_event_paranoid/kptr_restrict "silently
+# reverts" and none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
 # /etc/sysctl.d/10-kernel-hardening.conf with `kernel.kptr_restrict = 1`, re-asserted at
 # every boot and by every `sysctl --system`. "It silently reverts" is unactionable;
-# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins" is a
-# diagnosis. Ordering is lexicographic by BASENAME in BYTE order (what systemd-sysctl and
-# `sysctl --system` use) and `[ "$a" \> "$b" ]` is the right operator: the `[` builtin
-# compares with strcmp (verified: byte order even under a UTF-8 LC_ALL), whereas `[[ > ]]`
-# switches to locale collation and could mis-rank names differing only in punctuation.
+# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins"
+# is a diagnosis. Ordering is lexicographic by BASENAME in BYTE order, which is what
+# systemd-sysctl/`sysctl --system` use — and `[ "$a" \> "$b" ]` is the right operator
+# for it: the `[` builtin compares with strcmp (verified: byte order even under a UTF-8
+# LC_ALL), whereas `[[ > ]]` would switch to locale collation and could mis-rank names
+# whose only difference is punctuation.
 perf_capability_competing_files() {
   local base f name entry seen paths lf='
 '
@@ -471,9 +456,10 @@ perf_capability_competing_files() {
   paths=$(perf_capability_sysctl_search_path) || return 1
   seen="$lf"
   # An entry that does not exist genuinely holds no competitor (skipped, no output — most
-  # boxes have no /run/sysctl.d at all). One that exists but cannot be READ is an UNKNOWN and
-  # returns rc 1: this diagnostic exists to replace an unknown with a NAMED file, so it may
-  # not answer an unknown with the reassuring "no competing file".
+  # boxes have no /run/sysctl.d at all). One that exists but cannot be READ is an UNKNOWN
+  # and returns rc 1, so the caller reports a failed scan instead of the reassuring "no
+  # competing file" — this diagnostic exists to replace an unknown with a named file, so
+  # it may not answer an unknown with good news.
   while IFS= read -r entry; do
     [ -n "$entry" ] || continue
     if [ "${entry##*/}" = sysctl.conf ]; then
@@ -488,9 +474,9 @@ perf_capability_competing_files() {
       [ -f "$f" ] && [ -r "$f" ] || continue
       name="${f##*/}"
       [ "$name" = "$base" ] && continue
-      # MASKING (precedence rules above): a higher-precedence directory already supplied this
-      # basename, so sysctl ignores THIS file. Recorded BEFORE the content test, because a
-      # same-named file that sets nothing still masks one that does.
+      # MASKING (see the precedence rules above): a higher-precedence directory already
+      # supplied this basename, so sysctl ignores THIS file entirely. Recorded BEFORE the
+      # content test, because a same-named file that sets nothing still masks one that does.
       case "$seen" in *"$lf$name$lf"*) continue ;; esac
       seen="$seen$name$lf"
       perf_capability_file_sets_controls "$f" || continue
@@ -505,25 +491,26 @@ $paths
 EOF
 }
 
-# perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight from
-# /proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when unreadable). NEVER
-# trust a `sysctl -w`/`--system` return code — a write can report success while the value
-# does not take (container, read-only sysfs, a competing drop-in applied later), and it can
-# report FAILURE for an unrelated entry while ours applied fine. Read back.
-# Fully fork-free: `read` is a builtin, the directory comes back through a variable, and
-# nothing here is wrapped in `$( )` — this sits in the gate's summary path, which may not
-# grow a process for a diagnostic line. `read` returns non-zero at EOF on a file with no
-# trailing newline yet still assigns, so emptiness — not read's rc — is the failure test. It
-# also propagates the test-mode sandbox refusal (R4-3): with no seam inside the sandbox there
-# is no directory to read, and that is rc 1, never the real /proc.
+# perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight
+# from /proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when
+# unreadable). NEVER trust a `sysctl -w`/`--system` return code — a write can report
+# success while the value does not take (container, read-only sysfs, a competing
+# drop-in applied later), and it can report FAILURE for an unrelated entry while ours
+# applied fine. Read back.
+# Fully fork-free: `read` is a builtin, the directory comes back through a variable,
+# and nothing here is wrapped in `$( )`. This sits in the gate's summary path, which
+# may not grow a process for a diagnostic line. `read` returns non-zero at EOF on a
+# file with no trailing newline yet still assigns, so emptiness — not read's rc — is
+# the failure test. It also propagates the test-mode sandbox refusal (R4-3): with no
+# valid seam there is no directory to read, and that is rc 1, never the real /proc.
 #
 # WHITESPACE IS TRIMMED, NEVER TRUNCATED AT (fail-open audit, R4 round). The earlier
 # `${v%%[[:space:]]*}` cut the value at its FIRST space, so a malformed `0 1` became a
-# perfectly capable-looking `0` — an unknown resolving to the good case, in the one function
-# the gate's `perf=` token comes from. Surrounding whitespace (a CRLF's `\r` included) is
-# stripped; anything interior stays so `is_int` rejects it and the token becomes `unknown`.
-# `IFS=` makes that independent of the caller's IFS, and both trims are parameter
-# expansions — no fork on the gate's emit path.
+# perfectly capable-looking `0` — an unknown resolving to the good case, in the one
+# function the gate's `perf=` token is computed from. Surrounding whitespace (including a
+# CRLF's `\r`) is stripped; anything interior is left in place so `is_int` rejects it and
+# the token becomes `unknown`. `IFS=` makes that independent of the caller's IFS, and both
+# trims are parameter expansions — no fork on the gate's emit path.
 perf_capability_proc_read() {
   local __pcr_out="$1" __pcr_dir="" __pcr_v=""
   eval "$__pcr_out="
@@ -536,20 +523,21 @@ perf_capability_proc_read() {
   eval "$__pcr_out=\$__pcr_v"
 }
 
-# the stdout form of the read above, for CLI/bootstrap use — NOT the gate path (reading it
-# costs the caller a `$( )`).
+# perf_capability_proc_value <name>: the stdout form of the read above, for CLI and
+# bootstrap use (NOT the gate path — reading it costs the caller a `$( )`).
 perf_capability_proc_value() {
   local __pcv_v
   perf_capability_proc_read __pcv_v "$1" || return 1
   printf '%s' "$__pcv_v"
 }
 
-# perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative integer
-# NARROW ENOUGH for shell arithmetic. Both halves are load-bearing: `[ 1abc -ge 1 ]` and
-# `[ 99999999999999999999999 -ge 1 ]` do NOT compare — each prints "integer expression
-# expected" and returns 2 (neither true NOR false), so a malformed or oversized value would
-# fall past BOTH a `>= 1` and a `<= 0` test and be reported as good (a WRONG capability
-# claim) while leaking an error line into the gate's output.
+# perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative
+# integer NARROW ENOUGH for shell arithmetic. Both halves are load-bearing: `[ 1abc
+# -ge 1 ]` and `[ 99999999999999999999999 -ge 1 ]` do NOT compare — each prints
+# "integer expression expected" to stderr and returns 2 (neither true NOR false), so
+# a malformed or oversized value would fall past BOTH a `>= 1` and a `<= 0` test and
+# be reported as good (a WRONG capability claim) while leaking an error line into the
+# gate's output. Validate the shape here instead of trusting the read.
 perf_capability_is_int() {
   local body="${1#-}"
   [ -n "$body" ] || return 1
@@ -557,11 +545,13 @@ perf_capability_is_int() {
   [ "${#body}" -le 10 ]
 }
 
-# perf_capability_token_into <outvar>: the FREE capability read, and THE function the gate's
-# accelerators line calls. Free is a hard contract, enforced by test_agent_gate_summary.sh
-# case 9f-free: pure /proc through shell builtins — no `perf` exec, no external process of
-# ANY kind, and no command substitution anywhere in the chain (hence the <outvar>: every
-# `$( )` is a forked subshell, and the gate emits this line on every summary).
+# perf_capability_token_into <outvar>: the FREE capability read, and THE function the
+# gate's accelerators line calls. Free is a hard contract, enforced by
+# test_agent_gate_summary.sh case 9f-free: pure /proc through shell builtins — no
+# `perf` exec, no external process of ANY kind, and no command substitution anywhere
+# in the chain (which is why the answer comes back through <outvar> rather than
+# stdout; every `$( )` is a forked subshell, and the gate emits this line on every
+# summary).
 #   ok               unprivileged per-CPU profiling AND kernel symbols available
 #   paranoid-<N>     perf_event_paranoid = N >= 1 -> CPU-wide `perf stat -C` denied
 #   kptr-restricted  paranoid is fine but kptr_restrict != 0 -> no kernel symbols
@@ -587,8 +577,9 @@ perf_capability_token_into() {
   eval "$__pct_out=ok"
 }
 
-# the stdout form, for the `--token` CLI and bootstrap. NOT the gate path — reading stdout
-# costs the caller the very `$( )` fork the `_into` core above exists to avoid.
+# perf_capability_token: the stdout form, for the `--token` CLI and bootstrap. NOT the
+# gate path — reading stdout costs the caller a `$( )` fork, which is precisely what
+# the `_into` core above exists to avoid.
 perf_capability_token() {
   local __ptk_v
   perf_capability_token_into __ptk_v
@@ -597,23 +588,29 @@ perf_capability_token() {
 
 # ---- WHOSE capability? the privilege dimension (issue #3249 review) -----------
 # perf_event_paranoid restricts UNPRIVILEGED users; ROOT BYPASSES IT ENTIRELY. So
-# `perf stat -C 0 -e cycles` run by root SUCCEEDS on a paranoid=4 box where every
+# `perf stat -C 0 -e cycles` run by root SUCCEEDS on a paranoid=4 box on which every
 # unprivileged agent process still gets EACCES — and `sudo bash
 # scripts/bootstrap-agent-machine.sh` is a completely normal provisioning invocation
-# (arguably the most likely one, since installing the drop-in needs root). A root-run
-# functional check reported as "perf capability verified" is therefore a FALSE verification
-# of an unprofileable box: the failure mode the functional check exists to remove,
-# reintroduced through the privilege dimension. The property under test is "an UNPRIVILEGED
-# process can collect CPU-WIDE cycles", which a root-run probe cannot demonstrate — so the
-# probe DROPS PRIVILEGE when it can and SAYS SO when it cannot, and the caller then
-# subordinates the functional result to the identity-independent /proc token.
+# (arguably the most likely one, since installing /etc/sysctl.d/99-cqlite-perf.conf
+# needs root). A root-run functional check reported as "perf capability verified" is
+# therefore a FALSE verification of an unprofileable box: precisely the failure mode
+# the functional check exists to remove, reintroduced through the privilege dimension.
 #
-# perf_capability_self_uid_into <outvar>: THIS process's uid, rc 0 ONLY when genuinely known
-# — `id -u` must EXIST, exit 0, and print a validated non-negative integer. rc 1 (<outvar>
-# emptied) means "identity unknown", which is NOT "unprivileged" (review R4-1). The previous
-# shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or broken `id` made a
-# ROOT process look unprivileged, so its root perf run was accepted as unprivileged evidence
-# and printed a false VERIFIED — the R3-1 defect, through the detector written to prevent it.
+# The property actually under test is "an UNPRIVILEGED process can collect CPU-WIDE
+# cycles", and a root-run probe cannot demonstrate it. So the probe DROPS PRIVILEGE
+# when it can, and when it cannot it says so — the caller then subordinates the
+# functional result to the /proc token, which is identity-independent.
+#
+# perf_capability_self_uid_into <outvar>: THIS process's uid, and rc 0 ONLY when it is
+# genuinely known — `id -u` must EXIST, exit 0, and print a validated non-negative
+# integer. rc 1 (with <outvar> emptied) means "identity unknown", which is NOT the same
+# as "unprivileged" (issue #3249 review R4-1).
+#
+# The previous shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or
+# broken `id` made a ROOT process look unprivileged, so its root perf run was accepted
+# as unprivileged evidence and printed a false VERIFIED — the very R3-1 defect, through
+# the detector written to prevent it. An unknown identity can never resolve to the
+# reassuring case.
 perf_capability_self_uid_into() {
   local __psu_v=''
   eval "$1="
@@ -628,13 +625,14 @@ perf_capability_self_uid_into() {
 # the passwd database whose uid AND gid equal the supplied (already validated) numerics
 # and whose uid is non-zero.
 #
-# WHY (review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever the NAME
-# resolves to, not to the numeric ids we validated, and SUDO_USER/SUDO_UID are independent
-# environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale or hand-set) would run the probe
-# AS ROOT while the code reported a successful drop — a false VERIFIED again. So a name is
-# usable only once the passwd database confirms it IS the validated uid/gid. The shape check
-# is equally load-bearing: the prefix is word-split by the caller, so a name containing
-# whitespace or glob characters could inject extra argv tokens.
+# WHY (issue #3249 review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever
+# the NAME resolves to, not to the numeric ids we validated. SUDO_USER and SUDO_UID are
+# independent environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale, hand-set, or
+# inconsistent) would run the probe AS ROOT while the code reported a successful
+# privilege drop — a false VERIFIED again. A name is therefore only usable once the
+# passwd database confirms it IS the validated uid/gid.
+# The shape check is equally load-bearing: the prefix is word-split by the caller, so a
+# name containing whitespace or glob characters could inject extra argv tokens.
 perf_capability_name_is_uid() {
   local __pni_n="${1:-}" __pni_u="${2:-}" __pni_g="${3:-}" __pni_ru __pni_rg
   [ -n "$__pni_n" ] || return 1
@@ -654,10 +652,11 @@ perf_capability_name_is_uid() {
 #      Strongest available evidence.
 #   2. `nobody`, resolved from the passwd database (never a hardcoded 65534: a box
 #      without that account must report "no target", not probe a uid nobody owns).
-# THE NUMERIC IDS ARE THE TARGET; the NAME is optional and set only when the passwd database
-# confirms it resolves to exactly those non-zero ids (R4-2). An unverifiable SUDO_USER is
-# dropped, not trusted: the numeric-only mechanisms (setpriv, `sudo -u '#<uid>'`) still work,
-# and a name-requiring mechanism correctly reports it has nothing safe to use.
+# THE NUMERIC IDS ARE THE TARGET; the NAME is optional and only ever set when the
+# passwd database confirms it resolves to exactly those non-zero ids (R4-2). An
+# unverifiable SUDO_USER is dropped, not trusted: the numeric-only mechanisms
+# (setpriv, `sudo -u '#<uid>'`) still work, and a name-requiring mechanism correctly
+# reports that it has nothing safe to use.
 perf_capability_drop_target_into() {
   local __pdt_u='' __pdt_g='' __pdt_n=''
   if perf_capability_is_int "${SUDO_UID:-}" && perf_capability_is_int "${SUDO_GID:-}" \
@@ -695,16 +694,18 @@ perf_capability_drop_target_into() {
 #                                 and the result is not evidence either way (rc 1)
 #   root-no-unprivileged-target   root, and no unprivileged identity is resolvable (rc 1)
 #   root-no-drop-mechanism        root, target known, but no usable setpriv/runuser/sudo (rc 1)
-# Mechanism order: `setpriv` (util-linux; a plain setresuid — no PAM, no session, no shell),
-# then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC ids and
-# never a name — `setpriv --reuid/--regid` and `sudo -u '#<uid>'` (sudo's documented
-# numeric-uid form) — so no name has to be trusted (R4-2); `runuser` accepts only a name and
-# is used ONLY with a passwd-confirmed one. The `#<uid>` token survives the caller's
-# word-split intact: `#` starts a comment only while TOKENISING a source line, and this value
-# arrives by EXPANSION afterwards. The prefix holds only literal tokens plus a validated
-# numeric uid/gid or a confirmed name, so the caller may word-split it. A non-zero rc is NOT
-# an error to fail on: it is the caller's cue to label the functional result as what it is —
-# not evidence about an unprivileged process — and to let the /proc token be the authority.
+# Mechanism order: `setpriv` (util-linux; a plain setresuid, no PAM, no session, no
+# shell), then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC
+# ids and never a name — `setpriv --reuid/--regid`, and `sudo -u '#<uid>'` (sudo's
+# documented numeric-uid form) — so no name has to be trusted (R4-2). `runuser` accepts
+# only a name and is therefore used ONLY with a passwd-confirmed one.
+#   The `#<uid>` token is safe through the caller's word-split: `#` only starts a comment
+#   during tokenisation of the source line, and this value arrives by EXPANSION
+#   afterwards, so it is passed to sudo as a literal argument.
+# The prefix is composed ONLY of literal tokens plus a validated numeric uid/gid or a
+# passwd-confirmed name, so the caller may word-split it. A non-zero rc is NOT an error
+# to fail on: it is the caller's cue to label the functional result as what it is — not
+# evidence about an unprivileged process — and to let the /proc token be the authority.
 perf_capability_drop_prefix_into() {
   local __pdp_u='' __pdp_g='' __pdp_n='' __pdp_self=''
   eval "$1="
@@ -736,22 +737,24 @@ perf_capability_drop_prefix_into() {
   return 1
 }
 
-# perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (AC2). A bootstrap
-# that silently leaves a box unprofileable is the failure mode being fixed, so the verdict
-# comes from RUNNING the collection the doctrine mandates — `perf stat -C 0 -e cycles` — and
-# requires BOTH exit 0 AND a non-zero cycle count: `perf stat` exits 0 while printing
-# `<not supported>`/`<not counted>` (and a virtualised PMU can report a flat 0), so an
-# rc-only check is exactly the false green this exists to prevent.
+# perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (issue #3249
+# AC2). A bootstrap that silently leaves a box unprofileable is the failure mode being
+# fixed, so the verdict comes from RUNNING the collection the doctrine mandates —
+# `perf stat -C 0 -e cycles` — and requires BOTH exit 0 AND a non-zero cycle
+# count. `perf stat` exits 0 while printing `<not supported>` / `<not counted>`
+# (and a virtualised PMU can report a flat 0), so an rc-only check is exactly the
+# false green this exists to prevent.
 #
-# Any arguments are a command prefix the collection runs under — the privilege-dropping
-# prefix above. This function makes NO claim about identity: it runs what it is given and
-# reports the counter. Deciding WHOSE capability was measured is the caller's job, because
-# the caller owns the verdict.
+# Any arguments are a command prefix the collection runs under — the
+# privilege-dropping prefix above. This function makes NO claim about identity: it
+# runs what it is given and reports the counter. Deciding WHOSE capability was
+# measured (and whether that answers the question) is the caller's job, because the
+# caller is the one that owns the verdict.
 #
 # CSV mode (`-x,`) is parsed rather than the human table: the human renderer is
-# locale-formatted (`1.234.567`) and its column layout has changed across perf releases,
-# while the CSV shape `<count>,<unit>,<event>,...` is stable. Prints a short
-# machine-greppable reason (stdout) either way; rc 0 = verified.
+# locale-formatted (`1.234.567`) and column layout has changed across perf
+# releases, while the CSV shape `<count>,<unit>,<event>,...` is stable.
+# Prints a short machine-greppable reason (stdout) either way; rc 0 = verified.
 perf_capability_verify() {
   command -v perf >/dev/null 2>&1 || { printf 'no-perf-binary'; return 1; }
   local bound="" out rc count
@@ -768,13 +771,14 @@ perf_capability_verify() {
     printf 'perf-stat-failed rc=%s: %s' "$rc" "$(printf '%s' "$out" | tr '\n' ';' | cut -c1-160)"
     return 1
   fi
-  # Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU (Intel
-  # 12th-gen+ P/E cores) perf emits one row per PMU (`cpu_core/cycles/`, `cpu_atom/cycles/`),
-  # commonly with `<not supported>` on the sibling that did not run — so a parser keyed on a
-  # literal leading `cycles` reports `no-cycles-row` on a perfectly good collection. Normalise
-  # the event field (drop PMU prefix, trailing `/`, any `:u`/`:k` modifier) and take the FIRST
-  # row with a positive numeric count; keep the first matching row's raw field as the fallback
-  # so the `<not supported>` / zero diagnostics below still fire when none is positive.
+  # Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU
+  # (Intel 12th-gen+ P/E cores) perf emits one row per PMU named `cpu_core/cycles/`
+  # and `cpu_atom/cycles/`, commonly with `<not supported>` on the sibling that did
+  # not run — so a parser keyed on a literal leading `cycles` reports `no-cycles-row`
+  # on a perfectly good collection. Normalise the event field (drop the PMU prefix, a
+  # trailing `/`, and any `:u`/`:k` modifier) and take the FIRST row carrying a
+  # positive numeric count; keep the first matching row's raw field as the fallback so
+  # the `<not supported>` / zero diagnostics below still fire when none is positive.
   count=$(printf '%s\n' "$out" | awk -F, '
     {
       ev = tolower($3)
@@ -815,9 +819,9 @@ perf_capability_main() {
     --token)        perf_capability_token; printf '\n' ;;
     --verify)       local v rc=0; v=$(perf_capability_verify) || rc=1; printf '%s\n' "$v"; return $rc ;;
     --verify-unpriv)
-      # rc 0 requires BOTH a functional pass AND that it came from an unprivileged
-      # identity: a root run with no way to drop privilege reports its result AND that
-      # the result is not evidence about an agent process.
+      # Identity-aware form: rc 0 requires BOTH a functional pass AND that the pass
+      # came from an unprivileged identity. A root run with no way to drop privilege
+      # reports its result AND that the result is not evidence about an agent process.
       local pre='' state='' v rc=0 unpriv=0
       perf_capability_drop_prefix_into pre state && unpriv=1
       # shellcheck disable=SC2086  # deliberate split of our own literal prefix tokens
@@ -826,16 +830,17 @@ perf_capability_main() {
       [ "$unpriv" = 1 ] || rc=1
       return $rc ;;
     --drop-in)      perf_capability_dropin_content ;;
-    # rc PROPAGATED, never masked by the trailing newline: an unsandboxed test mode can
-    # resolve no path at all (R4-3), and that is a failure, not an empty success.
+    # rc PROPAGATED, never masked by the trailing newline: under an unsandboxed test
+    # mode the path cannot be resolved at all (R4-3), and a caller must see that as a
+    # failure rather than as an empty-but-successful answer.
     --drop-in-path) perf_capability_dropin_path || return 1; printf '\n' ;;
     -h|--help|'')   perf_capability_usage ;;
     *)              printf 'perf-capability: unknown arg: %s\n' "$1" >&2; perf_capability_usage >&2; return 2 ;;
   esac
 }
 
-# Executed directly (never when sourced): shell options are set HERE, inside the guard, so
-# sourcing can never change a caller's `set` flags.
+# Executed directly (never when sourced): shell options are set HERE, inside the
+# guard, so sourcing can never change a caller's `set` flags.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   set -uo pipefail
   perf_capability_main "$@"

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -459,7 +459,8 @@ perf_capability_competing_files() {
   # boxes have no /run/sysctl.d at all). One that exists but cannot be READ is an UNKNOWN
   # and returns rc 1, so the caller reports a failed scan instead of the reassuring "no
   # competing file" — this diagnostic exists to replace an unknown with a named file, so
-  # it may not answer an unknown with good news.
+  # it may not answer an unknown with good news. The SAME rule applies per FILE inside a
+  # readable directory (R8-4, in the loop below).
   while IFS= read -r entry; do
     [ -n "$entry" ] || continue
     if [ "${entry##*/}" = sysctl.conf ]; then
@@ -471,7 +472,20 @@ perf_capability_competing_files() {
     [ -e "$entry" ] || continue
     [ -d "$entry" ] && [ -r "$entry" ] || return 1
     for f in "$entry"/*.conf; do
-      [ -f "$f" ] && [ -r "$f" ] || continue
+      # AN UNMATCHED GLOB IS NOT AN UNREADABLE FILE (issue #3249 review R8-4). With no
+      # match bash leaves the PATTERN itself in $f (nullglob is not set) and it does not
+      # exist — that directory genuinely holds no competitor, skip it. But a file that
+      # EXISTS and cannot be READ is an UNKNOWN, and `sysctl --system` runs as ROOT: it
+      # can read and APPLY exactly the file we could not open. Skipping it would let the
+      # caller print "no other file sets these keys" about an unexamined competitor —
+      # the reassuring answer this whole diagnostic exists to stop giving. Fail the scan.
+      if [ ! -r "$f" ]; then
+        [ -e "$f" ] || continue
+        printf 'perf-capability: could not scan %s — it exists but is unreadable, and a privileged `sysctl --system` CAN read it, so whether it competes for perf_event_paranoid/kptr_restrict is UNKNOWN.\n' \
+          "'$f'" >&2
+        return 1
+      fi
+      [ -f "$f" ] || continue   # readable but a directory/socket named *.conf: sysctl reads none
       name="${f##*/}"
       [ "$name" = "$base" ] && continue
       # MASKING (see the precedence rules above): a higher-precedence directory already

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -71,6 +71,43 @@
 # /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim that
 # depends on a variable being set: it is enforced here, fail-closed and loudly.
 
+# FAIL-OPEN AUDIT — every path that can reach a POSITIVE verdict, and what validates it
+# (issue #3249 review round 4; four findings in this file were all one defect class:
+# "identity/state unknown => assume the good case"). Keep this list closed: a new
+# positive-verdict path SHALL be added here with its validator, or it is a regression.
+#   token = ok                  both /proc values READ (non-empty) from the resolved dir
+#                               AND both `perf_capability_is_int`-validated AND
+#                               paranoid <= 0 AND kptr == 0. Whitespace is trimmed, never
+#                               TRUNCATED — `0 1` stays malformed -> `unknown`.
+#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count
+#                               is a positive integer by BOTH awk's `^[0-9]+$` and
+#                               `is_int` + `-le 0`. `<not supported>`/`<not counted>`/
+#                               empty/oversized/malformed all return 1.
+#   state = self-unprivileged   `perf_capability_self_uid_into` succeeded (an `id -u` that
+#                               EXISTS, exits 0, prints a validated non-negative int) AND
+#                               that uid != 0. An unusable `id -u` => identity-unknown, rc 1.
+#   state = dropped:setpriv     numeric uid+gid, both validated ints AND both > 0.
+#   state = dropped:runuser     the same numerics PLUS a `SUDO_USER` the passwd database
+#                               confirms IS that non-zero uid/gid, and whose characters are
+#                               safe for the caller's word-split.
+#   state = dropped:sudo        numeric uid only (sudo's `#<uid>` form) — no name trusted.
+#   env_guard rc 0              production: NO test seam set (paths are hardcoded literals).
+#                               test mode: BOTH seams present, absolute, outside the
+#                               production dirs and outside /etc /proc /sys, and not
+#                               symlinks; plus every reachable sudo/sysctl resolving inside
+#                               an absolute declared shim dir.
+#   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against
+#                               the generated canonical content.
+# KNOWN RESIDUALS, deliberately not papered over:
+#   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel
+#     changed uid. Harmless by construction: the caller's verdict is `token = ok` AND the
+#     functional pass, and a box whose /proc says ok IS profileable by an unprivileged
+#     process, so a mislabelled drop cannot manufacture a capability that is absent.
+#   * a test seam with a SYMLINKED ANCESTOR (`/tmp/a -> /etc`, seam `/tmp/a/sysctl.d`)
+#     passes the textual + `[ -L ]` checks; detecting it needs `realpath`/`stat`, i.e. a
+#     fork on the gate's emit path. Bounded: it requires deliberately pointing a TEST-ONLY
+#     variable through a symlink into production.
+#
 # ---- production locations: HARDCODED. Never env-derived outside test mode. ----
 PERF_CAPABILITY_PROC_DIR_DEFAULT='/proc/sys/kernel'
 PERF_CAPABILITY_SYSCTL_DIR_DEFAULT='/etc/sysctl.d'
@@ -90,6 +127,12 @@ perf_capability_seam_set() {
 # configuration surfaces (/proc, /sys, /etc). An unset or production-shaped seam is
 # NOT "use the real thing": in test mode it is a refusal (R4-3). Builtins only — this
 # is reached from the gate's fork-free token path.
+#
+# The final check is that the seam is not ITSELF a symlink: `ln -s /etc/sysctl.d /tmp/x`
+# passes every textual test above and would still land a root `tee` in the production
+# directory. `[ -L ]` is a builtin, so it costs no fork. A symlinked ANCESTOR is not
+# detectable without `realpath`/`stat` — i.e. a fork on the gate's emit path — so that
+# residual is recorded in the fail-open audit rather than papered over.
 perf_capability_test_dir_valid() {
   [ -n "${1:-}" ] || return 1
   case "$1" in /*) ;; *) return 1 ;; esac
@@ -97,7 +140,8 @@ perf_capability_test_dir_valid() {
     "${2:-/dev/null/never}"|"${2:-/dev/null/never}"/*) return 1 ;;
     /proc|/proc/*|/sys|/sys/*|/etc|/etc/*) return 1 ;;
   esac
-  return 0
+  # not a symlink either (see the note above the function)
+  [ ! -L "$1" ]
 }
 
 # perf_capability_test_seams_ok: rc 0 iff test mode has BOTH mandatory seams pointing
@@ -293,7 +337,12 @@ perf_capability_competing_files() {
   local dir base f name
   dir=$(perf_capability_sysctl_dir) || return 1
   base="$PERF_CAPABILITY_DROPIN_BASENAME"
-  [ -d "$dir" ] || return 0
+  # A directory that does not exist genuinely holds no competitor (rc 0, no output). One
+  # that exists but cannot be READ is an UNKNOWN and returns rc 1, so the caller reports a
+  # failed scan instead of the reassuring "no competing file" — this diagnostic exists to
+  # replace an unknown with a named file, so it may not answer an unknown with good news.
+  [ -e "$dir" ] || return 0
+  [ -d "$dir" ] && [ -r "$dir" ] || return 1
   for f in "$dir"/*.conf; do
     [ -f "$f" ] && [ -r "$f" ] || continue
     name="${f##*/}"
@@ -317,15 +366,24 @@ perf_capability_competing_files() {
 # and nothing here is wrapped in `$( )`. This sits in the gate's summary path, which
 # may not grow a process for a diagnostic line. `read` returns non-zero at EOF on a
 # file with no trailing newline yet still assigns, so emptiness — not read's rc — is
-# the failure test.
+# the failure test. It also propagates the test-mode sandbox refusal (R4-3): with no
+# valid seam there is no directory to read, and that is rc 1, never the real /proc.
+#
+# WHITESPACE IS TRIMMED, NEVER TRUNCATED AT (fail-open audit, R4 round). The earlier
+# `${v%%[[:space:]]*}` cut the value at its FIRST space, so a malformed `0 1` became a
+# perfectly capable-looking `0` — an unknown resolving to the good case, in the one
+# function the gate's `perf=` token is computed from. Surrounding whitespace (including a
+# CRLF's `\r`) is stripped; anything interior is left in place so `is_int` rejects it and
+# the token becomes `unknown`. `IFS=` makes that independent of the caller's IFS, and both
+# trims are parameter expansions — no fork on the gate's emit path.
 perf_capability_proc_read() {
   local __pcr_out="$1" __pcr_dir="" __pcr_v=""
-  perf_capability_proc_dir_into __pcr_dir
   eval "$__pcr_out="
   perf_capability_proc_dir_into __pcr_dir || return 1
   [ -r "$__pcr_dir/$2" ] || return 1
-  read -r __pcr_v <"$__pcr_dir/$2" 2>/dev/null
-  __pcr_v="${__pcr_v%%[[:space:]]*}"
+  IFS= read -r __pcr_v <"$__pcr_dir/$2" 2>/dev/null
+  __pcr_v="${__pcr_v#"${__pcr_v%%[![:space:]]*}"}"
+  __pcr_v="${__pcr_v%"${__pcr_v##*[![:space:]]}"}"
   [ -n "$__pcr_v" ] || return 1
   eval "$__pcr_out=\$__pcr_v"
 }
@@ -477,8 +535,11 @@ perf_capability_drop_target_into() {
   else
     __pdt_u=$(id -u nobody 2>/dev/null) || __pdt_u=''
     __pdt_g=$(id -g nobody 2>/dev/null) || __pdt_g=''
+    # gid > 0 as well, matching the SUDO branch above: a target resolving to gid 0 is a
+    # partial drop, and "partially dropped" is not a state this code is allowed to
+    # report as an unprivileged probe (fail-open audit).
     if perf_capability_is_int "$__pdt_u" && perf_capability_is_int "$__pdt_g" \
-       && [ "${__pdt_u:-0}" -gt 0 ]; then
+       && [ "${__pdt_u:-0}" -gt 0 ] && [ "${__pdt_g:-0}" -gt 0 ]; then
       __pdt_n=nobody
     else
       __pdt_u=''; __pdt_g=''; __pdt_n=''

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -62,6 +62,14 @@
 #   CQLITE_PERF_PROC_DIR        stand-in for /proc/sys/kernel   (test mode only)
 #   CQLITE_PERF_SYSCTL_DIR      stand-in for /etc/sysctl.d      (test mode only)
 #   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
+#
+# TEST MODE HAS NO FALLBACK (issue #3249 review R4-3). Under the marker BOTH path
+# seams are MANDATORY and must be absolute, non-production directories. The earlier
+# shape — marker set, seam unset, fall back to the real directory — meant test mode
+# could pass the env guard (sudo/sysctl absent, or present as declared shims) and a
+# subsequent root `--yes` run would then invoke a bare `tee` against the REAL
+# /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim that
+# depends on a variable being set: it is enforced here, fail-closed and loudly.
 
 # ---- production locations: HARDCODED. Never env-derived outside test mode. ----
 PERF_CAPABILITY_PROC_DIR_DEFAULT='/proc/sys/kernel'
@@ -76,11 +84,51 @@ perf_capability_seam_set() {
   [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ]
 }
 
+# perf_capability_test_dir_valid <value> <production-default>: rc 0 iff <value> is a
+# usable NON-PRODUCTION stand-in — non-empty, ABSOLUTE, and neither the production
+# directory itself nor a path under it, nor anywhere under the host's own
+# configuration surfaces (/proc, /sys, /etc). An unset or production-shaped seam is
+# NOT "use the real thing": in test mode it is a refusal (R4-3). Builtins only — this
+# is reached from the gate's fork-free token path.
+perf_capability_test_dir_valid() {
+  [ -n "${1:-}" ] || return 1
+  case "$1" in /*) ;; *) return 1 ;; esac
+  case "$1" in
+    "${2:-/dev/null/never}"|"${2:-/dev/null/never}"/*) return 1 ;;
+    /proc|/proc/*|/sys|/sys/*|/etc|/etc/*) return 1 ;;
+  esac
+  return 0
+}
+
+# perf_capability_test_seams_ok: rc 0 iff test mode has BOTH mandatory seams pointing
+# at explicit non-production directories. Refuses loudly and names the offending seam,
+# because the failure it prevents (a root test run writing the real /etc/sysctl.d) is
+# silent otherwise.
+perf_capability_test_seams_ok() {
+  local ok=0
+  if ! perf_capability_test_dir_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT"; then
+    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR (absolute, outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
+      "$PERF_CAPABILITY_PROC_DIR_DEFAULT" "'${CQLITE_PERF_PROC_DIR:-<unset>}'" >&2
+    ok=1
+  fi
+  if ! perf_capability_test_dir_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
+    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR (absolute, outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
+      "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" >&2
+    ok=1
+  fi
+  [ "$ok" = 0 ]
+}
+
 # perf_capability_env_guard: rc 0 iff this process may act on the perf capability
-# path at all. Both refusals are LOUD on stderr and FAIL CLOSED (the caller does
+# path at all. Every refusal is LOUD on stderr and FAILS CLOSED (the caller does
 # nothing privileged and claims no verdict):
 #   * a seam set WITHOUT the marker — the seams are inert there, and a caller that
 #     was handed one is misconfigured, so nothing privileged may proceed;
+#   * the marker set WITHOUT both non-production path seams — test mode has no
+#     fallback (R4-3): allowing one would let a root `--yes` test run `tee` the REAL
+#     /etc/sysctl.d, which is exactly the host mutation the marker promises cannot
+#     happen. Checked FIRST, before the tool checks, because it is the more
+#     fundamental precondition: a test run with no sandbox has nowhere safe to act;
 #   * the marker set while a REAL sudo/sysctl is reachable — test mode is hermetic
 #     by construction, so a reachable real privileged tool is a bug in the harness,
 #     not something to run.
@@ -91,6 +139,7 @@ perf_capability_env_guard() {
       "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
     return 1
   fi
+  perf_capability_test_seams_ok || return 1
   local dir="${CQLITE_PERF_TEST_PRIV_DIR:-}" tool resolved
   for tool in sudo sysctl; do
     resolved=$(command -v "$tool" 2>/dev/null) || continue
@@ -123,27 +172,44 @@ perf_capability_env_guard() {
 #   word-splitting or globbing applies to the value. <outvar> must be a plain shell
 #   identifier; every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_`
 #   local prefixes keep a caller-named variable from colliding with an internal one.
+#   In TEST MODE the seam is MANDATORY and validated (R4-3): an unset or
+#   production-shaped value is rc 1 with an empty answer, never a silent fallback to
+#   the real /proc or the real /etc/sysctl.d. Every caller propagates that rc, so an
+#   unsandboxed test run reads nothing and writes nothing.
 perf_capability_proc_dir_into() {
+  eval "$1="
   if perf_capability_test_mode; then
-    eval "$1=\${CQLITE_PERF_PROC_DIR:-\$PERF_CAPABILITY_PROC_DIR_DEFAULT}"
-  else
-    eval "$1=\$PERF_CAPABILITY_PROC_DIR_DEFAULT"
+    perf_capability_test_dir_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" || {
+      printf 'perf-capability: REFUSING to read /proc: CQLITE_PERF_TEST_MODE=1 with no valid non-production CQLITE_PERF_PROC_DIR (got %s) — test mode never falls back to %s.\n' \
+        "'${CQLITE_PERF_PROC_DIR:-<unset>}'" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
+      return 1
+    }
+    eval "$1=\$CQLITE_PERF_PROC_DIR"
+    return 0
   fi
+  eval "$1=\$PERF_CAPABILITY_PROC_DIR_DEFAULT"
 }
 perf_capability_proc_dir() {
   local __pcd_v
-  perf_capability_proc_dir_into __pcd_v
+  perf_capability_proc_dir_into __pcd_v || return 1
   printf '%s' "$__pcd_v"
 }
 perf_capability_sysctl_dir() {
   if perf_capability_test_mode; then
-    printf '%s' "${CQLITE_PERF_SYSCTL_DIR:-$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT}"
-  else
-    printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
+    perf_capability_test_dir_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" || {
+      printf 'perf-capability: REFUSING to resolve a sysctl.d path: CQLITE_PERF_TEST_MODE=1 with no valid non-production CQLITE_PERF_SYSCTL_DIR (got %s) — test mode never falls back to %s.\n' \
+        "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" >&2
+      return 1
+    }
+    printf '%s' "$CQLITE_PERF_SYSCTL_DIR"
+    return 0
   fi
+  printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
 perf_capability_dropin_path() {
-  printf '%s/%s' "$(perf_capability_sysctl_dir)" "$PERF_CAPABILITY_DROPIN_BASENAME"
+  local __pdi_d
+  __pdi_d=$(perf_capability_sysctl_dir) || return 1
+  printf '%s/%s' "$__pdi_d" "$PERF_CAPABILITY_DROPIN_BASENAME"
 }
 
 # perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a
@@ -163,6 +229,14 @@ perf_capability_dropin_content() {
 # kernel symbols resolve — otherwise kernel frames are unresolved addresses, a
 # silent attribution loss rather than an error.
 #
+# THE "99-" PREFIX IS LOAD-BEARING — DO NOT RENAME THIS FILE. sysctl.d drop-ins are
+# applied in lexicographic order of BASENAME and the LAST assignment wins. Stock Ubuntu
+# ships /etc/sysctl.d/10-kernel-hardening.conf containing `kernel.kptr_restrict = 1`,
+# so this file only wins because "99-cqlite-perf.conf" sorts after "10-...". Renaming it
+# to cqlite-perf.conf or any lower number silently hands kptr_restrict back to the
+# hardening drop-in at the next boot — the "it silently reverts" mystery in three
+# separate measurement reports.
+#
 # NOTE ON PRECEDENCE: /etc/sysctl.conf is applied AFTER every sysctl.d drop-in by
 # both `sysctl --system` and systemd-sysctl, so a stale perf_event_paranoid there
 # BEATS this file. Check it if the values do not take.
@@ -179,13 +253,58 @@ EOF
 # compare is an in-shell string compare, NOT `diff -q`: on a box without diffutils
 # `diff` exits 127, which would report "different" on every run — so bootstrap
 # would re-write the file each time AND then report it could not write it.
+#
+# TRAILING NEWLINES ARE PART OF THE BYTES (issue #3249 review R4-4). `$( )` strips
+# EVERY trailing newline from its output, so comparing two command substitutions made
+# a file missing its final newline — or carrying extra blank lines at the end —
+# compare EQUAL to the canonical content: "byte-exact" was a false claim, and such a
+# file was never rewritten. The file side is now read with `read -r -d ''`, which
+# consumes the whole file verbatim (builtin, so no `cat`/`diff` dependency), and the
+# canonical side carries an in-substitution sentinel so its own final newline survives
+# the stripping. A NUL byte in the file truncates the read and therefore compares
+# unequal — fail-closed, and correct: a file with a NUL is not our text drop-in.
 perf_capability_dropin_current() {
-  local path want got
-  path=$(perf_capability_dropin_path)
+  local path want got=''
+  path=$(perf_capability_dropin_path) || return 1
   [ -f "$path" ] && [ -r "$path" ] || return 1
-  want=$(perf_capability_dropin_content)
-  got=$(<"$path") || return 1
-  [ "$want" = "$got" ]
+  want=$(perf_capability_dropin_content; printf 'X')
+  IFS= read -r -d '' got <"$path"
+  [ "$want" = "${got}X" ]
+}
+
+# perf_capability_competing_files: every OTHER file in the sysctl.d directory that also
+# sets kernel.perf_event_paranoid or kernel.kptr_restrict, one per line as
+#   <override|earlier> <path>
+# `override` = its basename sorts AFTER ours, so `sysctl --system`/systemd-sysctl apply
+# it LAST and IT WINS; `earlier` = ours wins.
+#
+# WHY THIS EXISTS. Three separate reports (ws0-3217, ws3-3029, the 2026-07-27 Cassandra
+# baseline) recorded that a hand-set perf_event_paranoid/kptr_restrict "silently
+# reverts" and none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
+# /etc/sysctl.d/10-kernel-hardening.conf with `kernel.kptr_restrict = 1`, re-asserted at
+# every boot and by every `sysctl --system`. "It silently reverts" is unactionable;
+# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins"
+# is a diagnosis. Ordering is lexicographic by BASENAME in BYTE order, which is what
+# systemd-sysctl/`sysctl --system` use — and `[ "$a" \> "$b" ]` is the right operator
+# for it: the `[` builtin compares with strcmp (verified: byte order even under a UTF-8
+# LC_ALL), whereas `[[ > ]]` would switch to locale collation and could mis-rank names
+# whose only difference is punctuation.
+perf_capability_competing_files() {
+  local dir base f name
+  dir=$(perf_capability_sysctl_dir) || return 1
+  base="$PERF_CAPABILITY_DROPIN_BASENAME"
+  [ -d "$dir" ] || return 0
+  for f in "$dir"/*.conf; do
+    [ -f "$f" ] && [ -r "$f" ] || continue
+    name="${f##*/}"
+    [ "$name" = "$base" ] && continue
+    grep -Eq '^[[:space:]]*kernel\.(perf_event_paranoid|kptr_restrict)[[:space:]]*=' "$f" 2>/dev/null || continue
+    if [ "$name" \> "$base" ]; then
+      printf 'override %s\n' "$f"
+    else
+      printf 'earlier %s\n' "$f"
+    fi
+  done
 }
 
 # perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight
@@ -203,6 +322,7 @@ perf_capability_proc_read() {
   local __pcr_out="$1" __pcr_dir="" __pcr_v=""
   perf_capability_proc_dir_into __pcr_dir
   eval "$__pcr_out="
+  perf_capability_proc_dir_into __pcr_dir || return 1
   [ -r "$__pcr_dir/$2" ] || return 1
   read -r __pcr_v <"$__pcr_dir/$2" 2>/dev/null
   __pcr_v="${__pcr_v%%[[:space:]]*}"
@@ -288,6 +408,49 @@ perf_capability_token() {
 # when it can, and when it cannot it says so — the caller then subordinates the
 # functional result to the /proc token, which is identity-independent.
 #
+# perf_capability_self_uid_into <outvar>: THIS process's uid, and rc 0 ONLY when it is
+# genuinely known — `id -u` must EXIST, exit 0, and print a validated non-negative
+# integer. rc 1 (with <outvar> emptied) means "identity unknown", which is NOT the same
+# as "unprivileged" (issue #3249 review R4-1).
+#
+# The previous shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or
+# broken `id` made a ROOT process look unprivileged, so its root perf run was accepted
+# as unprivileged evidence and printed a false VERIFIED — the very R3-1 defect, through
+# the detector written to prevent it. An unknown identity can never resolve to the
+# reassuring case.
+perf_capability_self_uid_into() {
+  local __psu_v=''
+  eval "$1="
+  command -v id >/dev/null 2>&1 || return 1
+  __psu_v=$(id -u 2>/dev/null) || return 1
+  perf_capability_is_int "$__psu_v" || return 1
+  case "$__psu_v" in -*) return 1 ;; esac   # a negative uid is not an identity
+  eval "$1=\$__psu_v"
+}
+
+# perf_capability_name_is_uid <name> <uid> <gid>: rc 0 iff <name> is a real account in
+# the passwd database whose uid AND gid equal the supplied (already validated) numerics
+# and whose uid is non-zero.
+#
+# WHY (issue #3249 review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever
+# the NAME resolves to, not to the numeric ids we validated. SUDO_USER and SUDO_UID are
+# independent environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale, hand-set, or
+# inconsistent) would run the probe AS ROOT while the code reported a successful
+# privilege drop — a false VERIFIED again. A name is therefore only usable once the
+# passwd database confirms it IS the validated uid/gid.
+# The shape check is equally load-bearing: the prefix is word-split by the caller, so a
+# name containing whitespace or glob characters could inject extra argv tokens.
+perf_capability_name_is_uid() {
+  local __pni_n="${1:-}" __pni_u="${2:-}" __pni_g="${3:-}" __pni_ru __pni_rg
+  [ -n "$__pni_n" ] || return 1
+  case "$__pni_n" in -*|*[!A-Za-z0-9._-]*) return 1 ;; esac
+  command -v id >/dev/null 2>&1 || return 1
+  __pni_ru=$(id -u "$__pni_n" 2>/dev/null) || return 1
+  __pni_rg=$(id -g "$__pni_n" 2>/dev/null) || return 1
+  perf_capability_is_int "$__pni_ru" && perf_capability_is_int "$__pni_rg" || return 1
+  [ "$__pni_ru" = "$__pni_u" ] && [ "$__pni_rg" = "$__pni_g" ] && [ "$__pni_ru" -gt 0 ]
+}
+
 # perf_capability_drop_target_into <outvar_uid> <outvar_gid> <outvar_name>:
 # resolve an UNPRIVILEGED identity to probe as. Never invented — a box that offers
 # none reports none (rc 1) rather than guessing a uid:
@@ -296,11 +459,21 @@ perf_capability_token() {
 #      Strongest available evidence.
 #   2. `nobody`, resolved from the passwd database (never a hardcoded 65534: a box
 #      without that account must report "no target", not probe a uid nobody owns).
+# THE NUMERIC IDS ARE THE TARGET; the NAME is optional and only ever set when the
+# passwd database confirms it resolves to exactly those non-zero ids (R4-2). An
+# unverifiable SUDO_USER is dropped, not trusted: the numeric-only mechanisms
+# (setpriv, `sudo -u '#<uid>'`) still work, and a name-requiring mechanism correctly
+# reports that it has nothing safe to use.
 perf_capability_drop_target_into() {
   local __pdt_u='' __pdt_g='' __pdt_n=''
   if perf_capability_is_int "${SUDO_UID:-}" && perf_capability_is_int "${SUDO_GID:-}" \
      && [ "${SUDO_UID:-0}" -gt 0 ] && [ "${SUDO_GID:-0}" -gt 0 ]; then
-    __pdt_u="${SUDO_UID}"; __pdt_g="${SUDO_GID}"; __pdt_n="${SUDO_USER:-}"
+    __pdt_u="${SUDO_UID}"; __pdt_g="${SUDO_GID}"
+    if perf_capability_name_is_uid "${SUDO_USER:-}" "$__pdt_u" "$__pdt_g"; then
+      __pdt_n="${SUDO_USER}"
+    else
+      __pdt_n=''
+    fi
   else
     __pdt_u=$(id -u nobody 2>/dev/null) || __pdt_u=''
     __pdt_g=$(id -g nobody 2>/dev/null) || __pdt_g=''
@@ -321,18 +494,29 @@ perf_capability_drop_target_into() {
 #   self-unprivileged             we are not root: the probe already measures the
 #                                 right thing, prefix empty (rc 0)
 #   dropped:<mech>:<identity>     root, and privilege is dropped for the probe (rc 0)
+#   identity-unknown              `id -u` is unusable, so WHO runs the probe is unknown
+#                                 and the result is not evidence either way (rc 1)
 #   root-no-unprivileged-target   root, and no unprivileged identity is resolvable (rc 1)
-#   root-no-drop-mechanism        root, target known, but no setpriv/runuser/sudo (rc 1)
+#   root-no-drop-mechanism        root, target known, but no usable setpriv/runuser/sudo (rc 1)
 # Mechanism order: `setpriv` (util-linux; a plain setresuid, no PAM, no session, no
-# shell), then `runuser`, then `sudo -n -u`. The prefix is composed ONLY of literal
-# tokens plus a validated numeric uid/gid or a passwd-resolved name, so the caller may
-# word-split it. A non-zero rc is NOT an error to fail on: it is the caller's cue to
-# label the functional result as what it is — not evidence about an unprivileged
-# process — and to let the /proc token be the authority.
+# shell), then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC
+# ids and never a name — `setpriv --reuid/--regid`, and `sudo -u '#<uid>'` (sudo's
+# documented numeric-uid form) — so no name has to be trusted (R4-2). `runuser` accepts
+# only a name and is therefore used ONLY with a passwd-confirmed one.
+#   The `#<uid>` token is safe through the caller's word-split: `#` only starts a comment
+#   during tokenisation of the source line, and this value arrives by EXPANSION
+#   afterwards, so it is passed to sudo as a literal argument.
+# The prefix is composed ONLY of literal tokens plus a validated numeric uid/gid or a
+# passwd-confirmed name, so the caller may word-split it. A non-zero rc is NOT an error
+# to fail on: it is the caller's cue to label the functional result as what it is — not
+# evidence about an unprivileged process — and to let the /proc token be the authority.
 perf_capability_drop_prefix_into() {
-  local __pdp_u='' __pdp_g='' __pdp_n=''
+  local __pdp_u='' __pdp_g='' __pdp_n='' __pdp_self=''
   eval "$1="
-  if [ "$(id -u 2>/dev/null || echo 1000)" != 0 ]; then
+  if ! perf_capability_self_uid_into __pdp_self; then
+    eval "$2=identity-unknown"; return 1
+  fi
+  if [ "$__pdp_self" != 0 ]; then
     eval "$2=self-unprivileged"; return 0
   fi
   if ! perf_capability_drop_target_into __pdp_u __pdp_g __pdp_n; then
@@ -348,9 +532,9 @@ perf_capability_drop_prefix_into() {
     eval "$2=\"dropped:runuser:\$__pdp_n\""
     return 0
   fi
-  if [ -n "$__pdp_n" ] && command -v sudo >/dev/null 2>&1; then
-    eval "$1=\"sudo -n -u \$__pdp_n --\""
-    eval "$2=\"dropped:sudo:\$__pdp_n\""
+  if command -v sudo >/dev/null 2>&1; then
+    eval "$1=\"sudo -n -u #\$__pdp_u --\""
+    eval "$2=\"dropped:sudo:uid=\$__pdp_u\""
     return 0
   fi
   eval "$2=root-no-drop-mechanism"
@@ -450,7 +634,10 @@ perf_capability_main() {
       [ "$unpriv" = 1 ] || rc=1
       return $rc ;;
     --drop-in)      perf_capability_dropin_content ;;
-    --drop-in-path) perf_capability_dropin_path; printf '\n' ;;
+    # rc PROPAGATED, never masked by the trailing newline: under an unsandboxed test
+    # mode the path cannot be resolved at all (R4-3), and a caller must see that as a
+    # failure rather than as an empty-but-successful answer.
+    --drop-in-path) perf_capability_dropin_path || return 1; printf '\n' ;;
     -h|--help|'')   perf_capability_usage ;;
     *)              printf 'perf-capability: unknown arg: %s\n' "$1" >&2; perf_capability_usage >&2; return 2 ;;
   esac

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -61,6 +61,10 @@
 #   CQLITE_PERF_TEST_MODE=1     the marker; without it the two seams below are INERT
 #   CQLITE_PERF_PROC_DIR        stand-in for /proc/sys/kernel   (test mode only)
 #   CQLITE_PERF_SYSCTL_DIR      stand-in for /etc/sysctl.d      (test mode only)
+#   CQLITE_PERF_SYSCTL_EXTRA_DIRS  colon-separated stand-ins for the LOWER-precedence
+#                               search-path entries (/run/sysctl.d, /usr/lib/sysctl.d, …
+#                               and a `sysctl.conf` file), in descending precedence;
+#                               optional, test mode only
 #   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
 #
 # TEST MODE HAS NO FALLBACK (issue #3249 review R4-3). Under the marker BOTH path
@@ -92,21 +96,28 @@
 #                               safe for the caller's word-split.
 #   state = dropped:sudo        numeric uid only (sudo's `#<uid>` form) — no name trusted.
 #   env_guard rc 0              production: NO test seam set (paths are hardcoded literals).
-#                               test mode: BOTH seams present, absolute, outside the
-#                               production dirs and outside /etc /proc /sys, and not
-#                               symlinks; plus every reachable sudo/sysctl resolving inside
-#                               an absolute declared shim dir.
+#                               test mode: BOTH seams present and their CANONICAL
+#                               destinations (`.`, `..` and symlinked ancestors resolved)
+#                               absolute and outside the production dirs and /etc /proc
+#                               /sys; plus every reachable sudo/sysctl resolving inside an
+#                               absolute declared shim dir.
+#   dropin_path rc 0            in test mode, the seam RESOLVES inside its sandbox (R5-1) —
+#                               re-checked independently of the guard, because this is the
+#                               last thing between the canonical bytes and a root `tee`.
 #   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against
-#                               the generated canonical content.
+#                               the generated canonical content, from a read that reached
+#                               EOF — a NUL-delimited read is NOT current, whatever the
+#                               bytes before the NUL are (R5-3).
 # KNOWN RESIDUALS, deliberately not papered over:
 #   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel
 #     changed uid. Harmless by construction: the caller's verdict is `token = ok` AND the
 #     functional pass, and a box whose /proc says ok IS profileable by an unprivileged
 #     process, so a mislabelled drop cannot manufacture a capability that is absent.
-#   * a test seam with a SYMLINKED ANCESTOR (`/tmp/a -> /etc`, seam `/tmp/a/sysctl.d`)
-#     passes the textual + `[ -L ]` checks; detecting it needs `realpath`/`stat`, i.e. a
-#     fork on the gate's emit path. Bounded: it requires deliberately pointing a TEST-ONLY
-#     variable through a symlink into production.
+#   * the READ-side seam check is textual (fork-free, gate contract): it rejects `.`/`..`
+#     components and a symlinked seam, but a symlinked ANCESTOR could still steer a
+#     test-mode /proc STAND-IN read. Bounded and harmless: nothing on that path writes,
+#     and a wrong read yields `absent`/`unknown`, never a fabricated capability. Every
+#     WRITE-side check canonicalizes instead (R5-1).
 #
 # ---- production locations: HARDCODED. Never env-derived outside test mode. ----
 PERF_CAPABILITY_PROC_DIR_DEFAULT='/proc/sys/kernel'
@@ -121,42 +132,71 @@ perf_capability_seam_set() {
   [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ]
 }
 
-# perf_capability_test_dir_valid <value> <production-default>: rc 0 iff <value> is a
-# usable NON-PRODUCTION stand-in — non-empty, ABSOLUTE, and neither the production
-# directory itself nor a path under it, nor anywhere under the host's own
-# configuration surfaces (/proc, /sys, /etc). An unset or production-shaped seam is
-# NOT "use the real thing": in test mode it is a refusal (R4-3). Builtins only — this
-# is reached from the gate's fork-free token path.
+# TWO VALIDATORS, SPLIT BY WHAT THE CALLER DOES (issue #3249 review R5-1). Textual
+# validation of a path is the wrong tool for a guard that steers a privileged write:
+# each round closed one more SPELLING of "somewhere else" (raw production path, then a
+# symlinked seam, then `..`). So the two callers get different validators:
+#   READ side  (the gate's emit-time token chain) -> perf_capability_test_dir_valid:
+#              pure builtins, ZERO forks, because that path is contractually free. It
+#              never writes anything, so a mis-accepted seam there can only mis-READ a
+#              stand-in /proc, which the token then reports as `absent`/`unknown`.
+#   WRITE side (env guard + the drop-in path a root `tee` is pointed at) ->
+#              perf_capability_test_dir_resolved_valid: CANONICALIZES the whole path
+#              (resolving `.`, `..` AND symlinked ancestors) and validates the RESOLVED
+#              destination. A fork costs nothing there, and the destination — not its
+#              spelling — is what gets written.
 #
-# The final check is that the seam is not ITSELF a symlink: `ln -s /etc/sysctl.d /tmp/x`
-# passes every textual test above and would still land a root `tee` in the production
-# directory. `[ -L ]` is a builtin, so it costs no fork. A symlinked ANCESTOR is not
-# detectable without `realpath`/`stat` — i.e. a fork on the gate's emit path — so that
-# residual is recorded in the fail-open audit rather than papered over.
+# perf_capability_test_dir_valid <value> <production-default>: rc 0 iff <value> is a
+# usable NON-PRODUCTION stand-in — non-empty, ABSOLUTE, free of `.`/`..` components (a
+# path whose spelling is not its destination cannot be validated textually at all), and
+# neither the production directory itself nor a path under it, nor anywhere under the
+# host's own configuration surfaces (/proc, /sys, /etc), nor itself a symlink
+# (`ln -s /etc/sysctl.d /tmp/x` passes every other textual test). An unset or
+# production-shaped seam is NOT "use the real thing": in test mode it is a refusal
+# (R4-3). Builtins only — this is reached from the gate's fork-free token path.
 perf_capability_test_dir_valid() {
   [ -n "${1:-}" ] || return 1
   case "$1" in /*) ;; *) return 1 ;; esac
+  case "/$1/" in */../*|*/./*) return 1 ;; esac
   case "$1" in
     "${2:-/dev/null/never}"|"${2:-/dev/null/never}"/*) return 1 ;;
     /proc|/proc/*|/sys|/sys/*|/etc|/etc/*) return 1 ;;
   esac
-  # not a symlink either (see the note above the function)
   [ ! -L "$1" ]
 }
 
+# perf_capability_test_dir_resolved_valid <value> <production-default>: the WRITE-side
+# validator. It canonicalizes <value> and requires the RESOLVED path to satisfy the same
+# non-production predicate, so `/tmp/../etc/sysctl.d` and a symlinked ANCESTOR
+# (`ln -s /etc /tmp/a`, seam `/tmp/a/sysctl.d`) are refused by their DESTINATION rather
+# than by a new textual special case. `cd -P` + `pwd -P` is the canonicalizer: one
+# subshell, no external binary, and correct on bash 3.2 (no `realpath`, no `readlink -f`,
+# both of which are absent or non-GNU on some supported hosts). A path that cannot be
+# entered at all resolves to nothing and is refused — fail-closed, and correct for a
+# write target, which must exist to be written into.
+perf_capability_test_dir_resolved_valid() {
+  local __ptv_real=''
+  perf_capability_test_dir_valid "$1" "$2" || return 1
+  __ptv_real=$(cd -P -- "$1" 2>/dev/null && pwd -P) || return 1
+  [ -n "$__ptv_real" ] || return 1
+  perf_capability_test_dir_valid "$__ptv_real" "$2"
+}
+
 # perf_capability_test_seams_ok: rc 0 iff test mode has BOTH mandatory seams pointing
-# at explicit non-production directories. Refuses loudly and names the offending seam,
-# because the failure it prevents (a root test run writing the real /etc/sysctl.d) is
-# silent otherwise.
+# at explicit non-production directories, JUDGED BY THEIR CANONICAL DESTINATION (R5-1).
+# This is the gate on every privileged action below, so it takes the strict validator:
+# refusing here is what stops a root `--yes` test run from resolving a seam back into
+# the production directory and overwriting the host's own drop-in. Refuses loudly and
+# names the offending seam, because the failure it prevents is silent otherwise.
 perf_capability_test_seams_ok() {
   local ok=0
-  if ! perf_capability_test_dir_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT"; then
-    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR (absolute, outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
+  if ! perf_capability_test_dir_resolved_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT"; then
+    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR (absolute, and RESOLVING — . / .. / symlinked ancestors and all — outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
       "$PERF_CAPABILITY_PROC_DIR_DEFAULT" "'${CQLITE_PERF_PROC_DIR:-<unset>}'" >&2
     ok=1
   fi
-  if ! perf_capability_test_dir_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
-    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR (absolute, outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
+  if ! perf_capability_test_dir_resolved_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
+    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR (absolute, and RESOLVING — . / .. / symlinked ancestors and all — outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
       "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" >&2
     ok=1
   fi
@@ -250,9 +290,20 @@ perf_capability_sysctl_dir() {
   fi
   printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
+# perf_capability_dropin_path: the path a root `tee` is pointed at, so this is the WRITE
+# side and it takes the STRICT validator (R5-1) — the seam's CANONICAL destination is
+# checked, not its spelling. Independent of the env guard on purpose: the guard is the
+# gate, this is the last line before the bytes land, and a write target may never be
+# named from a path that resolves into production.
 perf_capability_dropin_path() {
   local __pdi_d
   __pdi_d=$(perf_capability_sysctl_dir) || return 1
+  if perf_capability_test_mode \
+     && ! perf_capability_test_dir_resolved_valid "$__pdi_d" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
+    printf 'perf-capability: REFUSING to name a write target: CQLITE_PERF_SYSCTL_DIR=%s RESOLVES (through . / .. / a symlinked ancestor) outside its sandbox or is unenterable — the canonical DESTINATION is what a root tee writes, not the spelling.\n' \
+      "'$__pdi_d'" >&2
+    return 1
+  fi
   printf '%s/%s' "$__pdi_d" "$PERF_CAPABILITY_DROPIN_BASENAME"
 }
 
@@ -305,22 +356,87 @@ EOF
 # file was never rewritten. The file side is now read with `read -r -d ''`, which
 # consumes the whole file verbatim (builtin, so no `cat`/`diff` dependency), and the
 # canonical side carries an in-substitution sentinel so its own final newline survives
-# the stripping. A NUL byte in the file truncates the read and therefore compares
-# unequal — fail-closed, and correct: a file with a NUL is not our text drop-in.
+# the stripping.
+#
+# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (issue #3249 review R5-3). `read -d ''`
+# stops at a NUL and returns SUCCESS, leaving `got` holding only the bytes BEFORE it — so
+# canonical content followed by a NUL and ARBITRARY trailing bytes compared EQUAL and was
+# judged current. Read's rc is therefore load-bearing: rc 0 means a NUL delimiter was
+# consumed, i.e. the file is not our text drop-in AND the rest of it was never even seen,
+# so it is NOT current; only an rc != 0 (EOF reached, whole file in `got`) may be compared.
 perf_capability_dropin_current() {
   local path want got=''
   path=$(perf_capability_dropin_path) || return 1
   [ -f "$path" ] && [ -r "$path" ] || return 1
   want=$(perf_capability_dropin_content; printf 'X')
-  IFS= read -r -d '' got <"$path"
+  if IFS= read -r -d '' got <"$path"; then
+    return 1
+  fi
   [ "$want" = "${got}X" ]
 }
 
-# perf_capability_competing_files: every OTHER file in the sysctl.d directory that also
-# sets kernel.perf_event_paranoid or kernel.kptr_restrict, one per line as
-#   <override|earlier> <path>
-# `override` = its basename sorts AFTER ours, so `sysctl --system`/systemd-sysctl apply
-# it LAST and IT WINS; `earlier` = ours wins.
+# perf_capability_sysctl_search_path: the COMPLETE set of locations `sysctl --system`
+# (procps-ng) and systemd-sysctl load, one per line, in DESCENDING NAME-MASKING
+# PRECEDENCE — the order both tools scan (sysctl(8) SYSTEM FILE PRECEDENCE, sysctl.d(5)
+# CONFIGURATION DIRECTORIES AND PRECEDENCE):
+#   /etc/sysctl.d  /run/sysctl.d  /usr/local/lib/sysctl.d  /usr/lib/sysctl.d
+#   /lib/sysctl.d  and finally the FILE /etc/sysctl.conf
+# TWO INDEPENDENT RULES decide who wins, and the scan below implements both:
+#   MASKING  "once a file of a given filename is loaded, any file of the same name in
+#            subsequent directories is ignored" — so /etc/sysctl.d/50-x.conf REPLACES
+#            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would
+#            name a file that is not in effect.
+#   ORDERING the surviving files are applied in lexicographic BASENAME order regardless
+#            of which directory they came from; the LAST assignment wins.
+#   /etc/sysctl.conf is applied AFTER every drop-in, so it wins on grounds that have
+#   nothing to do with its name — it gets its own verdict rather than a sort comparison.
+#
+# WHY THE WHOLE PATH (issue #3249 review R5-4). Scanning only /etc/sysctl.d meant a
+# later-sorting file in /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in
+# while bootstrap reported NO competitor — recreating the exact "it silently reverts and
+# nobody knows why" mystery this diagnostic exists to end.
+#
+# In TEST MODE the path is the sandbox seam plus the optional colon-separated
+# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, in the same descending
+# order, each validated non-production): the real /run and /usr/lib are never read, so a
+# case's verdict can never depend on the host's own drop-ins.
+perf_capability_sysctl_search_path() {
+  local __psp_d __psp_e
+  if perf_capability_test_mode; then
+    __psp_d=$(perf_capability_sysctl_dir) || return 1
+    printf '%s\n' "$__psp_d"
+    local -a __psp_extra=()
+    # `read -a` splits on IFS WITHOUT globbing (an unquoted `for x in $var` would glob).
+    IFS=':' read -r -a __psp_extra <<<"${CQLITE_PERF_SYSCTL_EXTRA_DIRS:-}"
+    for __psp_e in ${__psp_extra[@]+"${__psp_extra[@]}"}; do
+      [ -n "$__psp_e" ] || continue
+      perf_capability_test_dir_valid "$__psp_e" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" || {
+        printf 'perf-capability: REFUSING: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry %s is not an absolute NON-PRODUCTION path — a test-mode scan may never read the host'"'"'s real sysctl.d directories.\n' \
+          "'$__psp_e'" >&2
+        return 1
+      }
+      printf '%s\n' "$__psp_e"
+    done
+    return 0
+  fi
+  printf '%s\n' /etc/sysctl.d /run/sysctl.d /usr/local/lib/sysctl.d /usr/lib/sysctl.d \
+                /lib/sysctl.d /etc/sysctl.conf
+}
+
+# perf_capability_file_sets_controls <path>: rc 0 iff the file ASSIGNS either control.
+# Both spellings sysctl accepts are matched (`kernel.x` and `kernel/x`, sysctl.d(5)) plus
+# the optional leading `-` ignore-failure prefix; a commented-out line assigns nothing.
+perf_capability_file_sets_controls() {
+  grep -Eq '^[[:space:]]*-?kernel[./](perf_event_paranoid|kptr_restrict)[[:space:]]*=' "$1" 2>/dev/null
+}
+
+# perf_capability_competing_files: every OTHER file ANYWHERE ON THE SEARCH PATH ABOVE
+# that also sets kernel.perf_event_paranoid or kernel.kptr_restrict AND is actually in
+# effect (masked files are skipped), one per line as
+#   <override|earlier|last> <path>
+# `override` = its basename sorts AFTER ours, so it is applied LAST and IT WINS;
+# `earlier` = ours wins; `last` = /etc/sysctl.conf, applied after every drop-in, so it
+# wins regardless of name.
 #
 # WHY THIS EXISTS. Three separate reports (ws0-3217, ws3-3029, the 2026-07-27 Cassandra
 # baseline) recorded that a hand-set perf_event_paranoid/kptr_restrict "silently
@@ -334,26 +450,45 @@ perf_capability_dropin_current() {
 # LC_ALL), whereas `[[ > ]]` would switch to locale collation and could mis-rank names
 # whose only difference is punctuation.
 perf_capability_competing_files() {
-  local dir base f name
-  dir=$(perf_capability_sysctl_dir) || return 1
+  local base f name entry seen paths lf='
+'
   base="$PERF_CAPABILITY_DROPIN_BASENAME"
-  # A directory that does not exist genuinely holds no competitor (rc 0, no output). One
-  # that exists but cannot be READ is an UNKNOWN and returns rc 1, so the caller reports a
-  # failed scan instead of the reassuring "no competing file" — this diagnostic exists to
-  # replace an unknown with a named file, so it may not answer an unknown with good news.
-  [ -e "$dir" ] || return 0
-  [ -d "$dir" ] && [ -r "$dir" ] || return 1
-  for f in "$dir"/*.conf; do
-    [ -f "$f" ] && [ -r "$f" ] || continue
-    name="${f##*/}"
-    [ "$name" = "$base" ] && continue
-    grep -Eq '^[[:space:]]*kernel\.(perf_event_paranoid|kptr_restrict)[[:space:]]*=' "$f" 2>/dev/null || continue
-    if [ "$name" \> "$base" ]; then
-      printf 'override %s\n' "$f"
-    else
-      printf 'earlier %s\n' "$f"
+  paths=$(perf_capability_sysctl_search_path) || return 1
+  seen="$lf"
+  # An entry that does not exist genuinely holds no competitor (skipped, no output — most
+  # boxes have no /run/sysctl.d at all). One that exists but cannot be READ is an UNKNOWN
+  # and returns rc 1, so the caller reports a failed scan instead of the reassuring "no
+  # competing file" — this diagnostic exists to replace an unknown with a named file, so
+  # it may not answer an unknown with good news.
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    if [ "${entry##*/}" = sysctl.conf ]; then
+      [ -e "$entry" ] || continue
+      [ -f "$entry" ] && [ -r "$entry" ] || return 1
+      perf_capability_file_sets_controls "$entry" && printf 'last %s\n' "$entry"
+      continue
     fi
-  done
+    [ -e "$entry" ] || continue
+    [ -d "$entry" ] && [ -r "$entry" ] || return 1
+    for f in "$entry"/*.conf; do
+      [ -f "$f" ] && [ -r "$f" ] || continue
+      name="${f##*/}"
+      [ "$name" = "$base" ] && continue
+      # MASKING (see the precedence rules above): a higher-precedence directory already
+      # supplied this basename, so sysctl ignores THIS file entirely. Recorded BEFORE the
+      # content test, because a same-named file that sets nothing still masks one that does.
+      case "$seen" in *"$lf$name$lf"*) continue ;; esac
+      seen="$seen$name$lf"
+      perf_capability_file_sets_controls "$f" || continue
+      if [ "$name" \> "$base" ]; then
+        printf 'override %s\n' "$f"
+      else
+        printf 'earlier %s\n' "$f"
+      fi
+    done
+  done <<EOF
+$paths
+EOF
 }
 
 # perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -13,10 +13,13 @@
 #
 # WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE
 # restrictive, and each level keeps the restrictions of the levels below it:
+#   >= 3  (Debian/Ubuntu kernels carry this extra level) disallow ALL unprivileged
+#         perf event use — which is why the images' `4` denies EVERYTHING, down to a
+#         plain `perf stat`, not just the CPU-wide collection
 #   >= 2  no kernel profiling
 #   >= 1  no CPU-WIDE event access  <-- kills `perf stat -C <cpu>`
 #   >= 0  no raw tracepoint access
-#     -1  no restriction, and the perf mlock limit is lifted too
+#     -1  (almost) all events permitted, and the perf mlock limit is lifted too
 # CQLite's measurement doctrine mandates per-CPU collection (`perf stat -C`), so
 # `1` is not "almost right", it is a hard denial. `0` is the bare minimum that
 # works; `-1` additionally avoids `perf record` ring-buffer surprises.
@@ -41,15 +44,86 @@
 #   bash scripts/perf-capability.sh --drop-in      # canonical sysctl.d file bytes
 #   bash scripts/perf-capability.sh --drop-in-path # where that file belongs
 #
-# Test-only env seams (NEVER set these in production; they exist so the gate's
-# tooling-tests can exercise the write/read-back paths without touching /etc):
-#   CQLITE_PERF_PROC_DIR    stand-in for /proc/sys/kernel
-#   CQLITE_PERF_SYSCTL_DIR  stand-in for /etc/sysctl.d
+# TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
+# The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel)
+# because bootstrap pipes the drop-in through `sudo tee <path>`: if that path were
+# env-derived, a single stray export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d)
+# would make ROOT write an attacker/accident-chosen file while the real drop-in was
+# never installed — and an unparsable sudoers entry can wedge `sudo` outright.
+# Likewise an env-chosen /proc stand-in would let a paranoid-4 box print a
+# FABRICATED "verified" verdict. So the seams take effect ONLY under the explicit
+# marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
+# reachable on PATH is a hard refusal (the suite PATH-shims both and declares the
+# shim directory), so test mode can never reach a real privileged tool.
+#   CQLITE_PERF_TEST_MODE=1     the marker; without it the two seams below are INERT
+#   CQLITE_PERF_PROC_DIR        stand-in for /proc/sys/kernel   (test mode only)
+#   CQLITE_PERF_SYSCTL_DIR      stand-in for /etc/sysctl.d      (test mode only)
+#   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
 
-# ---- locations (both overridable for tests only) ----------------------------
-perf_capability_proc_dir()   { printf '%s' "${CQLITE_PERF_PROC_DIR:-/proc/sys/kernel}"; }
-perf_capability_sysctl_dir() { printf '%s' "${CQLITE_PERF_SYSCTL_DIR:-/etc/sysctl.d}"; }
-perf_capability_dropin_path() { printf '%s/99-cqlite-perf.conf' "$(perf_capability_sysctl_dir)"; }
+# ---- production locations: HARDCODED. Never env-derived outside test mode. ----
+PERF_CAPABILITY_PROC_DIR_DEFAULT='/proc/sys/kernel'
+PERF_CAPABILITY_SYSCTL_DIR_DEFAULT='/etc/sysctl.d'
+PERF_CAPABILITY_DROPIN_BASENAME='99-cqlite-perf.conf'
+
+# perf_capability_test_mode: rc 0 iff the explicit test marker is set.
+perf_capability_test_mode() { [ "${CQLITE_PERF_TEST_MODE:-}" = 1 ]; }
+
+# perf_capability_seam_set: rc 0 iff either test-only path seam is non-empty.
+perf_capability_seam_set() {
+  [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ]
+}
+
+# perf_capability_env_guard: rc 0 iff this process may act on the perf capability
+# path at all. Both refusals are LOUD on stderr and FAIL CLOSED (the caller does
+# nothing privileged and claims no verdict):
+#   * a seam set WITHOUT the marker — the seams are inert there, and a caller that
+#     was handed one is misconfigured, so nothing privileged may proceed;
+#   * the marker set while a REAL sudo/sysctl is reachable — test mode is hermetic
+#     by construction, so a reachable real privileged tool is a bug in the harness,
+#     not something to run.
+perf_capability_env_guard() {
+  if ! perf_capability_test_mode; then
+    perf_capability_seam_set || return 0
+    printf 'perf-capability: REFUSING to act: CQLITE_PERF_PROC_DIR/CQLITE_PERF_SYSCTL_DIR are TEST-ONLY seams (inert without CQLITE_PERF_TEST_MODE=1). Unset them; the production paths are %s and %s.\n' \
+      "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
+    return 1
+  fi
+  local dir="${CQLITE_PERF_TEST_PRIV_DIR:-}" tool resolved
+  for tool in sudo sysctl; do
+    resolved=$(command -v "$tool" 2>/dev/null) || continue
+    case "$dir" in
+      /*) ;;
+      *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 with a reachable real %s and no absolute CQLITE_PERF_TEST_PRIV_DIR — test mode must PATH-shim every privileged tool.\n' "$tool" >&2
+         return 1 ;;
+    esac
+    case "$resolved" in
+      "$dir"/*) ;;
+      *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
+           "$tool" "$resolved" "$dir" >&2
+         return 1 ;;
+    esac
+  done
+  return 0
+}
+
+# ---- resolved locations (the seams apply ONLY in test mode) -------------------
+perf_capability_proc_dir() {
+  if perf_capability_test_mode; then
+    printf '%s' "${CQLITE_PERF_PROC_DIR:-$PERF_CAPABILITY_PROC_DIR_DEFAULT}"
+  else
+    printf '%s' "$PERF_CAPABILITY_PROC_DIR_DEFAULT"
+  fi
+}
+perf_capability_sysctl_dir() {
+  if perf_capability_test_mode; then
+    printf '%s' "${CQLITE_PERF_SYSCTL_DIR:-$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT}"
+  else
+    printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
+  fi
+}
+perf_capability_dropin_path() {
+  printf '%s/%s' "$(perf_capability_sysctl_dir)" "$PERF_CAPABILITY_DROPIN_BASENAME"
+}
 
 # perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a
 # WHOLE managed file (not a delimited block inside a foreign one), so idempotency
@@ -68,6 +142,10 @@ perf_capability_dropin_content() {
 # kernel symbols resolve — otherwise kernel frames are unresolved addresses, a
 # silent attribution loss rather than an error.
 #
+# NOTE ON PRECEDENCE: /etc/sysctl.conf is applied AFTER every sysctl.d drop-in by
+# both `sysctl --system` and systemd-sysctl, so a stale perf_event_paranoid there
+# BEATS this file. Check it if the values do not take.
+#
 # This is a deliberate loosening. NOT for shared or multi-tenant hosts.
 # Rationale + verification: docs/development/fleet-runbook.md
 kernel.perf_event_paranoid = -1
@@ -76,24 +154,32 @@ EOF
 }
 
 # perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the
-# managed bytes (the idempotency test — a matching file means write nothing).
+# managed bytes (the idempotency test — a matching file means write nothing). The
+# compare is an in-shell string compare, NOT `diff -q`: on a box without diffutils
+# `diff` exits 127, which would report "different" on every run — so bootstrap
+# would re-write the file each time AND then report it could not write it.
 perf_capability_dropin_current() {
-  local path
+  local path want got
   path=$(perf_capability_dropin_path)
-  [ -f "$path" ] || return 1
-  perf_capability_dropin_content | diff -q - "$path" >/dev/null 2>&1
+  [ -f "$path" ] && [ -r "$path" ] || return 1
+  want=$(perf_capability_dropin_content)
+  got=$(<"$path") || return 1
+  [ "$want" = "$got" ]
 }
 
 # perf_capability_proc_value <name>: the CURRENT kernel value read straight from
 # /proc/sys/kernel/<name> (rc 1 + no output when unreadable). NEVER trust a
 # `sysctl -w`'s return code — a write can report success while the value does not
 # take (container, read-only sysfs, a competing drop-in applied later). Read back.
+# Fork-free (`read` is a builtin): this sits in the gate's summary path, which may
+# not grow a subprocess for a diagnostic line. `read` returns non-zero at EOF on a
+# file with no trailing newline yet still assigns, so emptiness — not read's rc —
+# is the failure test.
 perf_capability_proc_value() {
-  local f
+  local f v=""
   f="$(perf_capability_proc_dir)/$1"
   [ -r "$f" ] || return 1
-  local v
-  v=$(cat "$f" 2>/dev/null) || return 1
+  read -r v <"$f" 2>/dev/null
   v="${v%%[[:space:]]*}"
   [ -n "$v" ] || return 1
   printf '%s' "$v"
@@ -102,10 +188,10 @@ perf_capability_proc_value() {
 # perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative
 # integer NARROW ENOUGH for shell arithmetic. Both halves are load-bearing: `[ 1abc
 # -ge 1 ]` and `[ 99999999999999999999999 -ge 1 ]` do NOT compare — each prints
-# "integer expression expected" to stderr and returns FALSE, so a malformed or
-# oversized value would fall past the `>= 1` test and be reported as `ok` (a WRONG
-# capability claim) while leaking an error line into the gate's output. Validate the
-# shape here instead of trusting the read.
+# "integer expression expected" to stderr and returns 2 (neither true NOR false), so
+# a malformed or oversized value would fall past BOTH a `>= 1` and a `<= 0` test and
+# be reported as good (a WRONG capability claim) while leaking an error line into the
+# gate's output. Validate the shape here instead of trusting the read.
 perf_capability_is_int() {
   local body="${1#-}"
   [ -n "$body" ] || return 1
@@ -113,16 +199,22 @@ perf_capability_is_int() {
   [ "${#body}" -le 10 ]
 }
 
-# perf_capability_token: the FREE capability read — pure /proc, ZERO subprocesses
-# that fork a binary beyond `cat`, no `perf` exec, no measurable time cost. This is
-# what the gate's accelerators line calls, so it may never grow an exec.
+# perf_capability_token: the FREE capability read — pure /proc through shell
+# builtins: no `perf` exec, no forked binary, no measurable time cost. This is what
+# the gate's accelerators line calls, so it may never grow one.
 #   ok               unprivileged per-CPU profiling AND kernel symbols available
 #   paranoid-<N>     perf_event_paranoid = N >= 1 -> CPU-wide `perf stat -C` denied
 #   kptr-restricted  paranoid is fine but kptr_restrict != 0 -> no kernel symbols
 #   absent           the /proc controls are not present (container, non-Linux)
 #   unknown          present but unparseable (never guess a capability)
+# A seam exported without the marker cannot steer this read (the seams are inert
+# there), but it IS reported once on stderr so a stray export is never silent.
 perf_capability_token() {
   local p k
+  if ! perf_capability_test_mode && perf_capability_seam_set; then
+    printf 'perf-capability: ignoring CQLITE_PERF_PROC_DIR/CQLITE_PERF_SYSCTL_DIR — TEST-ONLY seams, inert without CQLITE_PERF_TEST_MODE=1; reading %s\n' \
+      "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
+  fi
   p=$(perf_capability_proc_value perf_event_paranoid) || { printf 'absent'; return 0; }
   k=$(perf_capability_proc_value kptr_restrict) || { printf 'absent'; return 0; }
   perf_capability_is_int "$p" || { printf 'unknown'; return 0; }
@@ -157,14 +249,34 @@ perf_capability_verify() {
     printf 'perf-stat-failed rc=%s: %s' "$rc" "$(printf '%s' "$out" | tr '\n' ';' | cut -c1-160)"
     return 1
   fi
-  count=$(printf '%s\n' "$out" | awk -F, '$3 ~ /^cycles/ { print $1; exit }')
+  # Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU
+  # (Intel 12th-gen+ P/E cores) perf emits one row per PMU named `cpu_core/cycles/`
+  # and `cpu_atom/cycles/`, commonly with `<not supported>` on the sibling that did
+  # not run — so a parser keyed on a literal leading `cycles` reports `no-cycles-row`
+  # on a perfectly good collection. Normalise the event field (drop the PMU prefix, a
+  # trailing `/`, and any `:u`/`:k` modifier) and take the FIRST row carrying a
+  # positive numeric count; keep the first matching row's raw field as the fallback so
+  # the `<not supported>` / zero diagnostics below still fire when none is positive.
+  count=$(printf '%s\n' "$out" | awk -F, '
+    {
+      ev = tolower($3)
+      sub(/\/$/, "", ev)
+      sub(/^.*\//, "", ev)
+      sub(/:.*$/, "", ev)
+      if (ev != "cycles") next
+      if (fallback == "") fallback = $1
+      if ($1 ~ /^[0-9]+$/ && $1 + 0 > 0) { print $1; found = 1; exit }
+    }
+    END { if (!found && fallback != "") print fallback }
+  ')
   case "$count" in
     '') printf 'no-cycles-row: %s' "$(printf '%s' "$out" | tr '\n' ';' | cut -c1-160)"; return 1 ;;
     *'not supported'*|*'not counted'*) printf 'counter-%s' "$(printf '%s' "$count" | tr -d '<>' | tr ' ' '-')"; return 1 ;;
   esac
-  case "$count" in
-    ''|*[!0-9]*) printf 'unparseable-count=%s' "$count"; return 1 ;;
-  esac
+  # Shape-validate BEFORE any arithmetic: `[ <malformed> -le 0 ]` returns 2, which is
+  # FALSE, so an unvalidated operand would fall straight through to the VERIFIED
+  # return while leaking "integer expression expected" onto stderr.
+  perf_capability_is_int "$count" || { printf 'unparseable-count=%s' "$count"; return 1; }
   if [ "$count" -le 0 ]; then printf 'zero-cycles'; return 1; fi
   printf 'cycles=%s' "$count"
 }

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -35,8 +35,9 @@
 # BPF map creation — bpftrace/bcc collectors still need sudo (#3217 finding).
 #
 # Sourceable AND executable. Sourcing has NO side effects: this file only defines
-# `perf_capability_*` functions (nothing runs, no shell options are changed, no
-# variables outside that namespace are touched). Every function is `set -u` safe.
+# `perf_capability_*` functions plus the three `PERF_CAPABILITY_*` path constants
+# (nothing runs, no shell options are changed, no variables outside those namespaces
+# are touched). Every function is `set -u` safe.
 #
 # Usage (executed):
 #   bash scripts/perf-capability.sh --token        # free /proc read -> one token

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -34,7 +34,9 @@
 # BPF IS A DIFFERENT PERMISSION. A permissive perf_event_paranoid does NOT grant
 # BPF map creation — bpftrace/bcc collectors still need sudo (#3217 finding).
 #
-# Sourceable AND executable. Sourcing has NO side effects: this file only defines
+# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call
+# the functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO
+# side effects: this file only defines
 # `perf_capability_*` functions plus the three `PERF_CAPABILITY_*` path constants
 # (nothing runs, no shell options are changed, no variables outside those namespaces
 # are touched). Every function is `set -u` safe.
@@ -108,12 +110,30 @@ perf_capability_env_guard() {
 }
 
 # ---- resolved locations (the seams apply ONLY in test mode) -------------------
-perf_capability_proc_dir() {
+# THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain
+# below and is contractually FREE — no external process AND no command substitution
+# (each `$( )` forks a subshell, which is a process too). A function that answers on
+# stdout therefore CANNOT be on that path: its caller must fork to read it. So every
+# function the gate touches has an `_into <outvar>` core that assigns through a
+# caller-named variable, and the stdout-printing form is a thin wrapper kept for the
+# CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork is paid, and it is
+# not on the gate's path.
+#   Assignment is `eval "$1=\$var"`, NOT a `local -n` nameref: bash 3.2 (macOS
+#   /bin/bash, a supported gate host) has no namerefs. The RHS is an assignment, so no
+#   word-splitting or globbing applies to the value. <outvar> must be a plain shell
+#   identifier; every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_`
+#   local prefixes keep a caller-named variable from colliding with an internal one.
+perf_capability_proc_dir_into() {
   if perf_capability_test_mode; then
-    printf '%s' "${CQLITE_PERF_PROC_DIR:-$PERF_CAPABILITY_PROC_DIR_DEFAULT}"
+    eval "$1=\${CQLITE_PERF_PROC_DIR:-\$PERF_CAPABILITY_PROC_DIR_DEFAULT}"
   else
-    printf '%s' "$PERF_CAPABILITY_PROC_DIR_DEFAULT"
+    eval "$1=\$PERF_CAPABILITY_PROC_DIR_DEFAULT"
   fi
+}
+perf_capability_proc_dir() {
+  local __pcd_v
+  perf_capability_proc_dir_into __pcd_v
+  printf '%s' "$__pcd_v"
 }
 perf_capability_sysctl_dir() {
   if perf_capability_test_mode; then
@@ -168,22 +188,34 @@ perf_capability_dropin_current() {
   [ "$want" = "$got" ]
 }
 
-# perf_capability_proc_value <name>: the CURRENT kernel value read straight from
-# /proc/sys/kernel/<name> (rc 1 + no output when unreadable). NEVER trust a
-# `sysctl -w`'s return code — a write can report success while the value does not
-# take (container, read-only sysfs, a competing drop-in applied later). Read back.
-# Fork-free (`read` is a builtin): this sits in the gate's summary path, which may
-# not grow a subprocess for a diagnostic line. `read` returns non-zero at EOF on a
-# file with no trailing newline yet still assigns, so emptiness — not read's rc —
-# is the failure test.
+# perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight
+# from /proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when
+# unreadable). NEVER trust a `sysctl -w`/`--system` return code — a write can report
+# success while the value does not take (container, read-only sysfs, a competing
+# drop-in applied later), and it can report FAILURE for an unrelated entry while ours
+# applied fine. Read back.
+# Fully fork-free: `read` is a builtin, the directory comes back through a variable,
+# and nothing here is wrapped in `$( )`. This sits in the gate's summary path, which
+# may not grow a process for a diagnostic line. `read` returns non-zero at EOF on a
+# file with no trailing newline yet still assigns, so emptiness — not read's rc — is
+# the failure test.
+perf_capability_proc_read() {
+  local __pcr_out="$1" __pcr_dir="" __pcr_v=""
+  perf_capability_proc_dir_into __pcr_dir
+  eval "$__pcr_out="
+  [ -r "$__pcr_dir/$2" ] || return 1
+  read -r __pcr_v <"$__pcr_dir/$2" 2>/dev/null
+  __pcr_v="${__pcr_v%%[[:space:]]*}"
+  [ -n "$__pcr_v" ] || return 1
+  eval "$__pcr_out=\$__pcr_v"
+}
+
+# perf_capability_proc_value <name>: the stdout form of the read above, for CLI and
+# bootstrap use (NOT the gate path — reading it costs the caller a `$( )`).
 perf_capability_proc_value() {
-  local f v=""
-  f="$(perf_capability_proc_dir)/$1"
-  [ -r "$f" ] || return 1
-  read -r v <"$f" 2>/dev/null
-  v="${v%%[[:space:]]*}"
-  [ -n "$v" ] || return 1
-  printf '%s' "$v"
+  local __pcv_v
+  perf_capability_proc_read __pcv_v "$1" || return 1
+  printf '%s' "$__pcv_v"
 }
 
 # perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative
@@ -200,9 +232,13 @@ perf_capability_is_int() {
   [ "${#body}" -le 10 ]
 }
 
-# perf_capability_token: the FREE capability read — pure /proc through shell
-# builtins: no `perf` exec, no forked binary, no measurable time cost. This is what
-# the gate's accelerators line calls, so it may never grow one.
+# perf_capability_token_into <outvar>: the FREE capability read, and THE function the
+# gate's accelerators line calls. Free is a hard contract, enforced by
+# test_agent_gate_summary.sh case 9f-free: pure /proc through shell builtins — no
+# `perf` exec, no external process of ANY kind, and no command substitution anywhere
+# in the chain (which is why the answer comes back through <outvar> rather than
+# stdout; every `$( )` is a forked subshell, and the gate emits this line on every
+# summary).
 #   ok               unprivileged per-CPU profiling AND kernel symbols available
 #   paranoid-<N>     perf_event_paranoid = N >= 1 -> CPU-wide `perf stat -C` denied
 #   kptr-restricted  paranoid is fine but kptr_restrict != 0 -> no kernel symbols
@@ -210,19 +246,31 @@ perf_capability_is_int() {
 #   unknown          present but unparseable (never guess a capability)
 # A seam exported without the marker cannot steer this read (the seams are inert
 # there), but it IS reported once on stderr so a stray export is never silent.
-perf_capability_token() {
-  local p k
+perf_capability_token_into() {
+  local __pct_out="$1" __pct_p="" __pct_k=""
   if ! perf_capability_test_mode && perf_capability_seam_set; then
     printf 'perf-capability: ignoring CQLITE_PERF_PROC_DIR/CQLITE_PERF_SYSCTL_DIR — TEST-ONLY seams, inert without CQLITE_PERF_TEST_MODE=1; reading %s\n' \
       "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
   fi
-  p=$(perf_capability_proc_value perf_event_paranoid) || { printf 'absent'; return 0; }
-  k=$(perf_capability_proc_value kptr_restrict) || { printf 'absent'; return 0; }
-  perf_capability_is_int "$p" || { printf 'unknown'; return 0; }
-  perf_capability_is_int "$k" || { printf 'unknown'; return 0; }
-  if [ "$p" -ge 1 ]; then printf 'paranoid-%s' "$p"; return 0; fi
-  if [ "$k" -ne 0 ]; then printf 'kptr-restricted'; return 0; fi
-  printf 'ok'
+  if ! perf_capability_proc_read __pct_p perf_event_paranoid \
+     || ! perf_capability_proc_read __pct_k kptr_restrict; then
+    eval "$__pct_out=absent"; return 0
+  fi
+  if ! perf_capability_is_int "$__pct_p" || ! perf_capability_is_int "$__pct_k"; then
+    eval "$__pct_out=unknown"; return 0
+  fi
+  if [ "$__pct_p" -ge 1 ]; then eval "$__pct_out=\"paranoid-\$__pct_p\""; return 0; fi
+  if [ "$__pct_k" -ne 0 ]; then eval "$__pct_out=kptr-restricted"; return 0; fi
+  eval "$__pct_out=ok"
+}
+
+# perf_capability_token: the stdout form, for the `--token` CLI and bootstrap. NOT the
+# gate path — reading stdout costs the caller a `$( )` fork, which is precisely what
+# the `_into` core above exists to avoid.
+perf_capability_token() {
+  local __ptk_v
+  perf_capability_token_into __ptk_v
+  printf '%s' "$__ptk_v"
 }
 
 # perf_capability_verify: the FUNCTIONAL verification (issue #3249 AC2). A

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# perf-capability.sh — the ONE place that knows how a CQLite box is made
+# profileable, and how that is VERIFIED (issue #3249).
+#
+# WHY THIS FILE EXISTS. Agent/worker images ship with
+# `kernel.perf_event_paranoid = 4` and set it NOWHERE in /etc/sysctl.conf or
+# /etc/sysctl.d — so every profiling run starts from a hard EACCES whose help text
+# ("access limited") reads like a CAPABILITY verdict when it is a PERMISSION
+# verdict. That has already cost two measurement cycles. The same three-line
+# incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is
+# git-pinned, and is asserted by the gate's tooling-tests.
+#
+# WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE
+# restrictive, and each level keeps the restrictions of the levels below it:
+#   >= 2  no kernel profiling
+#   >= 1  no CPU-WIDE event access  <-- kills `perf stat -C <cpu>`
+#   >= 0  no raw tracepoint access
+#     -1  no restriction, and the perf mlock limit is lifted too
+# CQLite's measurement doctrine mandates per-CPU collection (`perf stat -C`), so
+# `1` is not "almost right", it is a hard denial. `0` is the bare minimum that
+# works; `-1` additionally avoids `perf record` ring-buffer surprises.
+# `kernel.kptr_restrict = 0` is a separate control needed for kernel SYMBOL
+# resolution — without it kernel frames render as unresolved addresses, which is a
+# SILENT attribution loss, not an error.
+#
+# SECURITY POSTURE. This is a deliberate loosening appropriate for DEDICATED
+# SINGLE-TENANT measurement/agent boxes. Never apply it to a shared or
+# multi-tenant host. See docs/development/fleet-runbook.md.
+#
+# BPF IS A DIFFERENT PERMISSION. A permissive perf_event_paranoid does NOT grant
+# BPF map creation — bpftrace/bcc collectors still need sudo (#3217 finding).
+#
+# Sourceable AND executable. Sourcing has NO side effects: this file only defines
+# `perf_capability_*` functions (nothing runs, no shell options are changed, no
+# variables outside that namespace are touched). Every function is `set -u` safe.
+#
+# Usage (executed):
+#   bash scripts/perf-capability.sh --token        # free /proc read -> one token
+#   bash scripts/perf-capability.sh --verify       # functional perf stat check
+#   bash scripts/perf-capability.sh --drop-in      # canonical sysctl.d file bytes
+#   bash scripts/perf-capability.sh --drop-in-path # where that file belongs
+#
+# Test-only env seams (NEVER set these in production; they exist so the gate's
+# tooling-tests can exercise the write/read-back paths without touching /etc):
+#   CQLITE_PERF_PROC_DIR    stand-in for /proc/sys/kernel
+#   CQLITE_PERF_SYSCTL_DIR  stand-in for /etc/sysctl.d
+
+# ---- locations (both overridable for tests only) ----------------------------
+perf_capability_proc_dir()   { printf '%s' "${CQLITE_PERF_PROC_DIR:-/proc/sys/kernel}"; }
+perf_capability_sysctl_dir() { printf '%s' "${CQLITE_PERF_SYSCTL_DIR:-/etc/sysctl.d}"; }
+perf_capability_dropin_path() { printf '%s/99-cqlite-perf.conf' "$(perf_capability_sysctl_dir)"; }
+
+# perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a
+# WHOLE managed file (not a delimited block inside a foreign one), so idempotency
+# is a plain byte-compare of the entire file — simpler and safer than editing
+# someone else's config. Callers may pipe this straight into `sudo tee`, which is
+# also the remedy line bootstrap prints, so a hand-applied fix produces
+# byte-identical content and the next bootstrap run is a silent no-op.
+perf_capability_dropin_content() {
+  cat <<'EOF'
+# Managed by scripts/bootstrap-agent-machine.sh — CQLite issue #3249. Do not edit.
+# Unprivileged perf profiling on a DEDICATED SINGLE-TENANT measurement/agent box.
+#
+# perf_event_paranoid is cumulative (higher = more restrictive). >= 1 forbids
+# CPU-WIDE event access, which is exactly what `perf stat -C <cpu>` needs, so -1
+# (not 1) is required; -1 also lifts the perf mlock limit. kptr_restrict = 0 lets
+# kernel symbols resolve — otherwise kernel frames are unresolved addresses, a
+# silent attribution loss rather than an error.
+#
+# This is a deliberate loosening. NOT for shared or multi-tenant hosts.
+# Rationale + verification: docs/development/fleet-runbook.md
+kernel.perf_event_paranoid = -1
+kernel.kptr_restrict = 0
+EOF
+}
+
+# perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the
+# managed bytes (the idempotency test — a matching file means write nothing).
+perf_capability_dropin_current() {
+  local path
+  path=$(perf_capability_dropin_path)
+  [ -f "$path" ] || return 1
+  perf_capability_dropin_content | diff -q - "$path" >/dev/null 2>&1
+}
+
+# perf_capability_proc_value <name>: the CURRENT kernel value read straight from
+# /proc/sys/kernel/<name> (rc 1 + no output when unreadable). NEVER trust a
+# `sysctl -w`'s return code — a write can report success while the value does not
+# take (container, read-only sysfs, a competing drop-in applied later). Read back.
+perf_capability_proc_value() {
+  local f
+  f="$(perf_capability_proc_dir)/$1"
+  [ -r "$f" ] || return 1
+  local v
+  v=$(cat "$f" 2>/dev/null) || return 1
+  v="${v%%[[:space:]]*}"
+  [ -n "$v" ] || return 1
+  printf '%s' "$v"
+}
+
+# perf_capability_token: the FREE capability read — pure /proc, ZERO subprocesses
+# that fork a binary beyond `cat`, no `perf` exec, no measurable time cost. This is
+# what the gate's accelerators line calls, so it may never grow an exec.
+#   ok               unprivileged per-CPU profiling AND kernel symbols available
+#   paranoid-<N>     perf_event_paranoid = N >= 1 -> CPU-wide `perf stat -C` denied
+#   kptr-restricted  paranoid is fine but kptr_restrict != 0 -> no kernel symbols
+#   absent           the /proc controls are not present (container, non-Linux)
+#   unknown          present but unparseable (never guess a capability)
+perf_capability_token() {
+  local p k
+  p=$(perf_capability_proc_value perf_event_paranoid) || { printf 'absent'; return 0; }
+  k=$(perf_capability_proc_value kptr_restrict) || { printf 'absent'; return 0; }
+  case "$p" in -[0-9]*|[0-9]*) : ;; *) printf 'unknown'; return 0 ;; esac
+  case "$k" in -[0-9]*|[0-9]*) : ;; *) printf 'unknown'; return 0 ;; esac
+  if [ "$p" -ge 1 ]; then printf 'paranoid-%s' "$p"; return 0; fi
+  if [ "$k" -ne 0 ]; then printf 'kptr-restricted'; return 0; fi
+  printf 'ok'
+}
+
+# perf_capability_verify: the FUNCTIONAL verification (issue #3249 AC2). A
+# bootstrap that silently leaves a box unprofileable is the failure mode being
+# fixed, so the verdict comes from RUNNING the collection the doctrine mandates —
+# `perf stat -C 0 -e cycles` — and requires BOTH exit 0 AND a non-zero cycle
+# count. `perf stat` exits 0 while printing `<not supported>` / `<not counted>`
+# (and a virtualised PMU can report a flat 0), so an rc-only check is exactly the
+# false green this exists to prevent.
+#
+# CSV mode (`-x,`) is parsed rather than the human table: the human renderer is
+# locale-formatted (`1.234.567`) and column layout has changed across perf
+# releases, while the CSV shape `<count>,<unit>,<event>,...` is stable.
+# Prints a short machine-greppable reason (stdout) either way; rc 0 = verified.
+perf_capability_verify() {
+  command -v perf >/dev/null 2>&1 || { printf 'no-perf-binary'; return 1; }
+  local bound="" out rc count
+  bound=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
+  if [ -n "$bound" ]; then
+    out=$(LC_ALL=C "$bound" 30 perf stat -x, -e cycles -C 0 -- sleep 0.1 2>&1); rc=$?
+  else
+    out=$(LC_ALL=C perf stat -x, -e cycles -C 0 -- sleep 0.1 2>&1); rc=$?
+  fi
+  if [ "$rc" -ne 0 ]; then
+    printf 'perf-stat-failed rc=%s: %s' "$rc" "$(printf '%s' "$out" | tr '\n' ';' | cut -c1-160)"
+    return 1
+  fi
+  count=$(printf '%s\n' "$out" | awk -F, '$3 ~ /^cycles/ { print $1; exit }')
+  case "$count" in
+    '') printf 'no-cycles-row: %s' "$(printf '%s' "$out" | tr '\n' ';' | cut -c1-160)"; return 1 ;;
+    *'not supported'*|*'not counted'*) printf 'counter-%s' "$(printf '%s' "$count" | tr -d '<>' | tr ' ' '-')"; return 1 ;;
+  esac
+  case "$count" in
+    ''|*[!0-9]*) printf 'unparseable-count=%s' "$count"; return 1 ;;
+  esac
+  if [ "$count" -le 0 ]; then printf 'zero-cycles'; return 1; fi
+  printf 'cycles=%s' "$count"
+}
+
+perf_capability_usage() {
+  printf 'usage: %s --token | --verify | --drop-in | --drop-in-path\n' "${0##*/}"
+  printf '  --token         free /proc capability read: ok|paranoid-<N>|kptr-restricted|absent|unknown\n'
+  printf '  --verify        functional check: perf stat -C 0 -e cycles (rc 0 = verified)\n'
+  printf '  --drop-in       print the canonical /etc/sysctl.d/99-cqlite-perf.conf bytes\n'
+  printf '  --drop-in-path  print where that file belongs\n'
+}
+
+perf_capability_main() {
+  case "${1:-}" in
+    --token)        perf_capability_token; printf '\n' ;;
+    --verify)       local v rc=0; v=$(perf_capability_verify) || rc=1; printf '%s\n' "$v"; return $rc ;;
+    --drop-in)      perf_capability_dropin_content ;;
+    --drop-in-path) perf_capability_dropin_path; printf '\n' ;;
+    -h|--help|'')   perf_capability_usage ;;
+    *)              printf 'perf-capability: unknown arg: %s\n' "$1" >&2; perf_capability_usage >&2; return 2 ;;
+  esac
+}
+
+# Executed directly (never when sourced): shell options are set HERE, inside the
+# guard, so sourcing can never change a caller's `set` flags.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  set -uo pipefail
+  perf_capability_main "$@"
+fi

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -273,13 +273,103 @@ perf_capability_token() {
   printf '%s' "$__ptk_v"
 }
 
-# perf_capability_verify: the FUNCTIONAL verification (issue #3249 AC2). A
-# bootstrap that silently leaves a box unprofileable is the failure mode being
+# ---- WHOSE capability? the privilege dimension (issue #3249 review) -----------
+# perf_event_paranoid restricts UNPRIVILEGED users; ROOT BYPASSES IT ENTIRELY. So
+# `perf stat -C 0 -e cycles` run by root SUCCEEDS on a paranoid=4 box on which every
+# unprivileged agent process still gets EACCES — and `sudo bash
+# scripts/bootstrap-agent-machine.sh` is a completely normal provisioning invocation
+# (arguably the most likely one, since installing /etc/sysctl.d/99-cqlite-perf.conf
+# needs root). A root-run functional check reported as "perf capability verified" is
+# therefore a FALSE verification of an unprofileable box: precisely the failure mode
+# the functional check exists to remove, reintroduced through the privilege dimension.
+#
+# The property actually under test is "an UNPRIVILEGED process can collect CPU-WIDE
+# cycles", and a root-run probe cannot demonstrate it. So the probe DROPS PRIVILEGE
+# when it can, and when it cannot it says so — the caller then subordinates the
+# functional result to the /proc token, which is identity-independent.
+#
+# perf_capability_drop_target_into <outvar_uid> <outvar_gid> <outvar_name>:
+# resolve an UNPRIVILEGED identity to probe as. Never invented — a box that offers
+# none reports none (rc 1) rather than guessing a uid:
+#   1. SUDO_UID/SUDO_GID/SUDO_USER — the identity that actually invoked `sudo
+#      bootstrap`, i.e. the very account whose profiling capability is in question.
+#      Strongest available evidence.
+#   2. `nobody`, resolved from the passwd database (never a hardcoded 65534: a box
+#      without that account must report "no target", not probe a uid nobody owns).
+perf_capability_drop_target_into() {
+  local __pdt_u='' __pdt_g='' __pdt_n=''
+  if perf_capability_is_int "${SUDO_UID:-}" && perf_capability_is_int "${SUDO_GID:-}" \
+     && [ "${SUDO_UID:-0}" -gt 0 ] && [ "${SUDO_GID:-0}" -gt 0 ]; then
+    __pdt_u="${SUDO_UID}"; __pdt_g="${SUDO_GID}"; __pdt_n="${SUDO_USER:-}"
+  else
+    __pdt_u=$(id -u nobody 2>/dev/null) || __pdt_u=''
+    __pdt_g=$(id -g nobody 2>/dev/null) || __pdt_g=''
+    if perf_capability_is_int "$__pdt_u" && perf_capability_is_int "$__pdt_g" \
+       && [ "${__pdt_u:-0}" -gt 0 ]; then
+      __pdt_n=nobody
+    else
+      __pdt_u=''; __pdt_g=''; __pdt_n=''
+    fi
+  fi
+  eval "$1=\$__pdt_u"; eval "$2=\$__pdt_g"; eval "$3=\$__pdt_n"
+  [ -n "$__pdt_u" ]
+}
+
+# perf_capability_drop_prefix_into <outvar_prefix> <outvar_state>: the command prefix
+# that makes the probe UNPRIVILEGED, plus the honest state label for it. rc 0 iff the
+# result IS evidence about an unprivileged process.
+#   self-unprivileged             we are not root: the probe already measures the
+#                                 right thing, prefix empty (rc 0)
+#   dropped:<mech>:<identity>     root, and privilege is dropped for the probe (rc 0)
+#   root-no-unprivileged-target   root, and no unprivileged identity is resolvable (rc 1)
+#   root-no-drop-mechanism        root, target known, but no setpriv/runuser/sudo (rc 1)
+# Mechanism order: `setpriv` (util-linux; a plain setresuid, no PAM, no session, no
+# shell), then `runuser`, then `sudo -n -u`. The prefix is composed ONLY of literal
+# tokens plus a validated numeric uid/gid or a passwd-resolved name, so the caller may
+# word-split it. A non-zero rc is NOT an error to fail on: it is the caller's cue to
+# label the functional result as what it is — not evidence about an unprivileged
+# process — and to let the /proc token be the authority.
+perf_capability_drop_prefix_into() {
+  local __pdp_u='' __pdp_g='' __pdp_n=''
+  eval "$1="
+  if [ "$(id -u 2>/dev/null || echo 1000)" != 0 ]; then
+    eval "$2=self-unprivileged"; return 0
+  fi
+  if ! perf_capability_drop_target_into __pdp_u __pdp_g __pdp_n; then
+    eval "$2=root-no-unprivileged-target"; return 1
+  fi
+  if command -v setpriv >/dev/null 2>&1; then
+    eval "$1=\"setpriv --reuid=\$__pdp_u --regid=\$__pdp_g --clear-groups\""
+    eval "$2=\"dropped:setpriv:uid=\$__pdp_u\""
+    return 0
+  fi
+  if [ -n "$__pdp_n" ] && command -v runuser >/dev/null 2>&1; then
+    eval "$1=\"runuser -u \$__pdp_n --\""
+    eval "$2=\"dropped:runuser:\$__pdp_n\""
+    return 0
+  fi
+  if [ -n "$__pdp_n" ] && command -v sudo >/dev/null 2>&1; then
+    eval "$1=\"sudo -n -u \$__pdp_n --\""
+    eval "$2=\"dropped:sudo:\$__pdp_n\""
+    return 0
+  fi
+  eval "$2=root-no-drop-mechanism"
+  return 1
+}
+
+# perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (issue #3249
+# AC2). A bootstrap that silently leaves a box unprofileable is the failure mode being
 # fixed, so the verdict comes from RUNNING the collection the doctrine mandates —
 # `perf stat -C 0 -e cycles` — and requires BOTH exit 0 AND a non-zero cycle
 # count. `perf stat` exits 0 while printing `<not supported>` / `<not counted>`
 # (and a virtualised PMU can report a flat 0), so an rc-only check is exactly the
 # false green this exists to prevent.
+#
+# Any arguments are a command prefix the collection runs under — the
+# privilege-dropping prefix above. This function makes NO claim about identity: it
+# runs what it is given and reports the counter. Deciding WHOSE capability was
+# measured (and whether that answers the question) is the caller's job, because the
+# caller is the one that owns the verdict.
 #
 # CSV mode (`-x,`) is parsed rather than the human table: the human renderer is
 # locale-formatted (`1.234.567`) and column layout has changed across perf
@@ -288,11 +378,14 @@ perf_capability_token() {
 perf_capability_verify() {
   command -v perf >/dev/null 2>&1 || { printf 'no-perf-binary'; return 1; }
   local bound="" out rc count
+  local -a pre=()
+  [ "$#" -eq 0 ] || pre=("$@")
   bound=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
+  # `timeout` stays OUTERMOST so the bound covers the privilege-dropping helper too.
   if [ -n "$bound" ]; then
-    out=$(LC_ALL=C "$bound" 30 perf stat -x, -e cycles -C 0 -- sleep 0.1 2>&1); rc=$?
+    out=$(LC_ALL=C "$bound" 30 ${pre[@]+"${pre[@]}"} perf stat -x, -e cycles -C 0 -- sleep 0.1 2>&1); rc=$?
   else
-    out=$(LC_ALL=C perf stat -x, -e cycles -C 0 -- sleep 0.1 2>&1); rc=$?
+    out=$(LC_ALL=C ${pre[@]+"${pre[@]}"} perf stat -x, -e cycles -C 0 -- sleep 0.1 2>&1); rc=$?
   fi
   if [ "$rc" -ne 0 ]; then
     printf 'perf-stat-failed rc=%s: %s' "$rc" "$(printf '%s' "$out" | tr '\n' ';' | cut -c1-160)"
@@ -331,9 +424,12 @@ perf_capability_verify() {
 }
 
 perf_capability_usage() {
-  printf 'usage: %s --token | --verify | --drop-in | --drop-in-path\n' "${0##*/}"
+  printf 'usage: %s --token | --verify | --verify-unpriv | --drop-in | --drop-in-path\n' "${0##*/}"
   printf '  --token         free /proc capability read: ok|paranoid-<N>|kptr-restricted|absent|unknown\n'
-  printf '  --verify        functional check: perf stat -C 0 -e cycles (rc 0 = verified)\n'
+  printf '  --verify        functional check AS THIS USER: perf stat -C 0 -e cycles (rc 0 = it worked\n'
+  printf '                  for THIS identity; run as root that proves nothing about an agent process)\n'
+  printf '  --verify-unpriv the same check as an UNPRIVILEGED identity (drops privilege when root);\n'
+  printf '                  prints "<result> identity=<state>" — rc 0 only when the state is unprivileged\n'
   printf '  --drop-in       print the canonical /etc/sysctl.d/99-cqlite-perf.conf bytes\n'
   printf '  --drop-in-path  print where that file belongs\n'
 }
@@ -342,6 +438,17 @@ perf_capability_main() {
   case "${1:-}" in
     --token)        perf_capability_token; printf '\n' ;;
     --verify)       local v rc=0; v=$(perf_capability_verify) || rc=1; printf '%s\n' "$v"; return $rc ;;
+    --verify-unpriv)
+      # Identity-aware form: rc 0 requires BOTH a functional pass AND that the pass
+      # came from an unprivileged identity. A root run with no way to drop privilege
+      # reports its result AND that the result is not evidence about an agent process.
+      local pre='' state='' v rc=0 unpriv=0
+      perf_capability_drop_prefix_into pre state && unpriv=1
+      # shellcheck disable=SC2086  # deliberate split of our own literal prefix tokens
+      v=$(perf_capability_verify $pre) || rc=1
+      printf '%s identity=%s\n' "$v" "$state"
+      [ "$unpriv" = 1 ] || rc=1
+      return $rc ;;
     --drop-in)      perf_capability_dropin_content ;;
     --drop-in-path) perf_capability_dropin_path; printf '\n' ;;
     -h|--help|'')   perf_capability_usage ;;

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -3,43 +3,34 @@
 # perf-capability.sh — the ONE place that knows how a CQLite box is made
 # profileable, and how that is VERIFIED (issue #3249).
 #
-# WHY THIS FILE EXISTS. Agent/worker images ship with
-# `kernel.perf_event_paranoid = 4` and set it NOWHERE in /etc/sysctl.conf or
-# /etc/sysctl.d — so every profiling run starts from a hard EACCES whose help text
-# ("access limited") reads like a CAPABILITY verdict when it is a PERMISSION
-# verdict. That has already cost two measurement cycles. The same three-line
-# incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is
-# git-pinned, and is asserted by the gate's tooling-tests.
+# WHY THIS FILE EXISTS. Agent/worker images ship `kernel.perf_event_paranoid = 4` and set
+# it NOWHERE in /etc/sysctl.conf or /etc/sysctl.d — so every profiling run starts from a
+# hard EACCES whose help text ("access limited") reads like a CAPABILITY verdict when it is
+# a PERMISSION verdict. That has already cost two measurement cycles. The same three-line
+# incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is git-pinned,
+# and is asserted by the gate's tooling-tests.
 #
-# WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE
-# restrictive, and each level keeps the restrictions of the levels below it:
-#   >= 3  (Debian/Ubuntu kernels carry this extra level) disallow ALL unprivileged
-#         perf event use — which is why the images' `4` denies EVERYTHING, down to a
-#         plain `perf stat`, not just the CPU-wide collection
-#   >= 2  no kernel profiling
-#   >= 1  no CPU-WIDE event access  <-- kills `perf stat -C <cpu>`
-#   >= 0  no raw tracepoint access
-#     -1  (almost) all events permitted, and the perf mlock limit is lifted too
-# CQLite's measurement doctrine mandates per-CPU collection (`perf stat -C`), so
-# `1` is not "almost right", it is a hard denial. `0` is the bare minimum that
-# works; `-1` additionally avoids `perf record` ring-buffer surprises.
-# `kernel.kptr_restrict = 0` is a separate control needed for kernel SYMBOL
-# resolution — without it kernel frames render as unresolved addresses, which is a
-# SILENT attribution loss, not an error.
+# WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE restrictive and
+# each level keeps the ones below it: `>= 3` (an extra Debian/Ubuntu level) denies ALL
+# unprivileged perf use, which is why the images' `4` kills even a plain `perf stat`;
+# `>= 2` no kernel profiling; `>= 1` no CPU-WIDE access, which is exactly what
+# `perf stat -C <cpu>` needs; `>= 0` no raw tracepoints; `-1` (almost) everything, and the
+# perf mlock limit lifted too. CQLite's doctrine mandates per-CPU collection, so `1` is
+# not "almost right", it is a hard denial. `kernel.kptr_restrict = 0` is a SEPARATE control
+# for kernel SYMBOL resolution — without it kernel frames are unresolved addresses, a
+# SILENT attribution loss rather than an error. Same rationale in the drop-in's own bytes.
 #
-# SECURITY POSTURE. This is a deliberate loosening appropriate for DEDICATED
-# SINGLE-TENANT measurement/agent boxes. Never apply it to a shared or
-# multi-tenant host. See docs/development/fleet-runbook.md.
+# SECURITY POSTURE. A deliberate loosening, appropriate for DEDICATED SINGLE-TENANT
+# measurement/agent boxes. Never apply it to a shared or multi-tenant host. See
+# docs/development/fleet-runbook.md. BPF IS A DIFFERENT PERMISSION: a permissive
+# perf_event_paranoid does NOT grant BPF map creation — bpftrace/bcc collectors still need
+# sudo (#3217 finding).
 #
-# BPF IS A DIFFERENT PERMISSION. A permissive perf_event_paranoid does NOT grant
-# BPF map creation — bpftrace/bcc collectors still need sudo (#3217 finding).
-#
-# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call
-# the functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO
-# side effects: this file only defines
-# `perf_capability_*` functions plus the three `PERF_CAPABILITY_*` path constants
-# (nothing runs, no shell options are changed, no variables outside those namespaces
-# are touched). Every function is `set -u` safe.
+# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call the
+# functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO side
+# effects: this file only defines `perf_capability_*` functions plus the four
+# `PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
+# outside those namespaces are touched). Every function is `set -u` safe.
 #
 # Usage (executed):
 #   bash scripts/perf-capability.sh --token        # free /proc read -> one token
@@ -48,17 +39,18 @@
 #   bash scripts/perf-capability.sh --drop-in-path # where that file belongs
 #
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
-# The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel)
-# because bootstrap pipes the drop-in through `sudo tee <path>`: if that path were
-# env-derived, a single stray export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d)
-# would make ROOT write an attacker/accident-chosen file while the real drop-in was
-# never installed — and an unparsable sudoers entry can wedge `sudo` outright.
-# Likewise an env-chosen /proc stand-in would let a paranoid-4 box print a
-# FABRICATED "verified" verdict. So the seams take effect ONLY under the explicit
-# marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
-# reachable on PATH is a hard refusal (the suite PATH-shims both and declares the
-# shim directory), so test mode can never reach a real privileged tool.
-#   CQLITE_PERF_TEST_MODE=1     the marker; without it the two seams below are INERT
+# The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
+# bootstrap pipes the drop-in through `sudo tee <path>`: were that path env-derived, one stray
+# export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d) would make ROOT write an
+# attacker/accident-chosen file while the real drop-in was never installed — and an unparsable
+# sudoers entry can wedge `sudo` outright. Likewise an env-chosen /proc stand-in would let a
+# paranoid-4 box print a FABRICATED "verified" verdict. So the seams take effect ONLY under
+# the explicit marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
+# reachable on PATH is a hard refusal (the suite PATH-shims both and declares the shim
+# directory), so test mode can never reach a real privileged tool.
+#   CQLITE_PERF_TEST_MODE=1     the marker; without it every seam below is INERT
+#   CQLITE_PERF_TEST_SANDBOX    THE SANDBOX ROOT — the one absolute directory every other
+#                               seam must be provably INSIDE (test mode only)
 #   CQLITE_PERF_PROC_DIR        stand-in for /proc/sys/kernel   (test mode only)
 #   CQLITE_PERF_SYSCTL_DIR      stand-in for /etc/sysctl.d      (test mode only)
 #   CQLITE_PERF_SYSCTL_EXTRA_DIRS  colon-separated stand-ins for the LOWER-precedence
@@ -67,57 +59,63 @@
 #                               optional, test mode only
 #   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
 #
-# TEST MODE HAS NO FALLBACK (issue #3249 review R4-3). Under the marker BOTH path
-# seams are MANDATORY and must be absolute, non-production directories. The earlier
-# shape — marker set, seam unset, fall back to the real directory — meant test mode
-# could pass the env guard (sudo/sysctl absent, or present as declared shims) and a
-# subsequent root `--yes` run would then invoke a bare `tee` against the REAL
-# /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim that
-# depends on a variable being set: it is enforced here, fail-closed and loudly.
+# POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds
+# each closed ONE MORE SPELLING of "the production directory": the raw path (B3), then a
+# symlinked seam, then `..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes
+# implementation-defined, `pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A
+# denylist over path spellings cannot be completed — `.`, `..`, symlinks, `//`, trailing
+# slashes, bind mounts, `/proc/self/root/…` all name the same directory — and a scattered
+# set of prohibitions also lets a NEW entry point silently miss them (R6-2). So the rule is
+# INVERTED and there is exactly ONE: a seam is usable IFF it is strictly contained in the
+# declared sandbox root. Every spelling of "somewhere else" — including every future one —
+# fails that single check for the same reason: it is not inside the sandbox.
+# TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams
+# are MANDATORY. The earlier shape — marker set, seam unset, fall back to the real
+# directory — meant test mode could pass the env guard (sudo/sysctl absent, or present as
+# declared shims) and a subsequent root `--yes` run would then invoke a bare `tee` against
+# the REAL /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim
+# that depends on a variable being set: it is enforced here, fail-closed and loudly.
 
 # FAIL-OPEN AUDIT — every path that can reach a POSITIVE verdict, and what validates it
-# (issue #3249 review round 4; four findings in this file were all one defect class:
-# "identity/state unknown => assume the good case"). Keep this list closed: a new
-# positive-verdict path SHALL be added here with its validator, or it is a regression.
-#   token = ok                  both /proc values READ (non-empty) from the resolved dir
-#                               AND both `perf_capability_is_int`-validated AND
-#                               paranoid <= 0 AND kptr == 0. Whitespace is trimmed, never
-#                               TRUNCATED — `0 1` stays malformed -> `unknown`.
-#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count
-#                               is a positive integer by BOTH awk's `^[0-9]+$` and
-#                               `is_int` + `-le 0`. `<not supported>`/`<not counted>`/
-#                               empty/oversized/malformed all return 1.
-#   state = self-unprivileged   `perf_capability_self_uid_into` succeeded (an `id -u` that
-#                               EXISTS, exits 0, prints a validated non-negative int) AND
-#                               that uid != 0. An unusable `id -u` => identity-unknown, rc 1.
+# (review round 4; four findings in this file were one defect class: "identity/state unknown
+# => assume the good case"). Keep this list CLOSED: a new positive-verdict path SHALL be added
+# here with its validator, or it is a regression.
+#   token = ok                  both /proc values READ (non-empty) from the resolved dir AND
+#                               both `is_int`-validated AND paranoid <= 0 AND kptr == 0.
+#                               Whitespace trimmed, never TRUNCATED — `0 1` stays malformed.
+#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count is a
+#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` +
+#                               `-le 0`. `<not supported>`/`<not counted>`/empty/oversized/
+#                               malformed all return 1.
+#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0,
+#                               prints a validated non-negative int) AND that uid != 0. An
+#                               unusable `id -u` => identity-unknown, rc 1.
 #   state = dropped:setpriv     numeric uid+gid, both validated ints AND both > 0.
 #   state = dropped:runuser     the same numerics PLUS a `SUDO_USER` the passwd database
-#                               confirms IS that non-zero uid/gid, and whose characters are
-#                               safe for the caller's word-split.
+#                               confirms IS that non-zero uid/gid, with characters safe for
+#                               the caller's word-split.
 #   state = dropped:sudo        numeric uid only (sudo's `#<uid>` form) — no name trusted.
 #   env_guard rc 0              production: NO test seam set (paths are hardcoded literals).
-#                               test mode: BOTH seams present and their CANONICAL
-#                               destinations (`.`, `..` and symlinked ancestors resolved)
-#                               absolute and outside the production dirs and /etc /proc
-#                               /sys; plus every reachable sudo/sysctl resolving inside an
-#                               absolute declared shim dir.
-#   dropin_path rc 0            in test mode, the seam RESOLVES inside its sandbox (R5-1) —
-#                               re-checked independently of the guard, because this is the
-#                               last thing between the canonical bytes and a root `tee`.
-#   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against
-#                               the generated canonical content, from a read that reached
-#                               EOF — a NUL-delimited read is NOT current, whatever the
-#                               bytes before the NUL are (R5-3).
+#                               test mode: a PROVEN sandbox root plus BOTH seams RESOLVING
+#                               strictly inside it, plus every reachable sudo/sysctl inside
+#                               an absolute declared shim dir.
+#   dropin_path rc 0            its directory came from `sysctl_dir`, i.e. RESOLVES inside the
+#                               sandbox — the single gate between the bytes and a root `tee`.
+#   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against the
+#                               generated canonical content, from a read that reached EOF — a
+#                               NUL-delimited read is NOT current (R5-3).
 # KNOWN RESIDUALS, deliberately not papered over:
-#   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel
-#     changed uid. Harmless by construction: the caller's verdict is `token = ok` AND the
-#     functional pass, and a box whose /proc says ok IS profileable by an unprivileged
-#     process, so a mislabelled drop cannot manufacture a capability that is absent.
-#   * the READ-side seam check is textual (fork-free, gate contract): it rejects `.`/`..`
-#     components and a symlinked seam, but a symlinked ANCESTOR could still steer a
-#     test-mode /proc STAND-IN read. Bounded and harmless: nothing on that path writes,
-#     and a wrong read yields `absent`/`unknown`, never a fabricated capability. Every
-#     WRITE-side check canonicalizes instead (R5-1).
+#   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel changed
+#     uid. Harmless by construction: the caller's verdict is `token = ok` AND the functional
+#     pass, and a box whose /proc says ok IS profileable unprivileged, so a mislabelled drop
+#     cannot manufacture a capability that is absent.
+#   * the READ-side containment check is SYNTACTIC (fork-free, gate contract) while every
+#     write / host-config read canonicalizes — SAME predicate, different input form. The read
+#     side judges the spelling, so a symlinked ancestor INSIDE the sandbox could still steer a
+#     test-mode /proc STAND-IN read. Bounded by that path's whole contract: the seams are
+#     honoured only under the test marker, which is never set in production, and nothing there
+#     writes — so the worst case is a read of a caller-chosen file reported as
+#     `absent`/`unknown`, never a fabricated capability.
 #
 # ---- production locations: HARDCODED. Never env-derived outside test mode. ----
 PERF_CAPABILITY_PROC_DIR_DEFAULT='/proc/sys/kernel'
@@ -127,95 +125,139 @@ PERF_CAPABILITY_DROPIN_BASENAME='99-cqlite-perf.conf'
 # perf_capability_test_mode: rc 0 iff the explicit test marker is set.
 perf_capability_test_mode() { [ "${CQLITE_PERF_TEST_MODE:-}" = 1 ]; }
 
-# perf_capability_seam_set: rc 0 iff either test-only path seam is non-empty.
+# perf_capability_seam_set: rc 0 iff either test-only path seam is non-empty. The ONE
+# seam reader outside the containment gate below, and deliberately so: it asks only
+# "was a seam handed to us at all" (for the marker-less refusal) and never uses the
+# VALUE as a path. The structural audit in test_perf_capability.sh allowlists it by
+# name, so a future function cannot join it silently.
 perf_capability_seam_set() {
   [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ]
 }
 
-# TWO VALIDATORS, SPLIT BY WHAT THE CALLER DOES (issue #3249 review R5-1). Textual
-# validation of a path is the wrong tool for a guard that steers a privileged write:
-# each round closed one more SPELLING of "somewhere else" (raw production path, then a
-# symlinked seam, then `..`). So the two callers get different validators:
-#   READ side  (the gate's emit-time token chain) -> perf_capability_test_dir_valid:
-#              pure builtins, ZERO forks, because that path is contractually free. It
-#              never writes anything, so a mis-accepted seam there can only mis-READ a
-#              stand-in /proc, which the token then reports as `absent`/`unknown`.
-#   WRITE side (env guard + the drop-in path a root `tee` is pointed at) ->
-#              perf_capability_test_dir_resolved_valid: CANONICALIZES the whole path
-#              (resolving `.`, `..` AND symlinked ancestors) and validates the RESOLVED
-#              destination. A fork costs nothing there, and the destination — not its
-#              spelling — is what gets written.
+# ---- ONE GATE: POSITIVE SANDBOX CONTAINMENT (review R6-1/R6-2) --------------------
+# THE sandbox root is caller-declared (CQLITE_PERF_TEST_SANDBOX) and must PROVE itself: an
+# absolute, canonically spelled, existing directory carrying the stamp file below. The
+# stamp is what makes the declaration unforgeable by environment alone — a stray
+# CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on
+# the FILESYSTEM and writing it into a system directory already needs the privilege this
+# guard protects. No denylist appears anywhere below: a path is usable because it is
+# provably INSIDE the sandbox, never because it failed to look like somewhere forbidden.
 #
-# perf_capability_test_dir_valid <value> <production-default>: rc 0 iff <value> is a
-# usable NON-PRODUCTION stand-in — non-empty, ABSOLUTE, free of `.`/`..` components (a
-# path whose spelling is not its destination cannot be validated textually at all), and
-# neither the production directory itself nor a path under it, nor anywhere under the
-# host's own configuration surfaces (/proc, /sys, /etc), nor itself a symlink
-# (`ln -s /etc/sysctl.d /tmp/x` passes every other textual test). An unset or
-# production-shaped seam is NOT "use the real thing": in test mode it is a refusal
-# (R4-3). Builtins only — this is reached from the gate's fork-free token path.
-perf_capability_test_dir_valid() {
-  [ -n "${1:-}" ] || return 1
-  case "$1" in /*) ;; *) return 1 ;; esac
+# FIVE thin functions, ONE predicate — everything ends in perf_capability_path_within:
+#   sandbox_root_into O        the declared root, validated; rc 1 + empty when unproven
+#   path_within P R            THE predicate (below)
+#   sandbox_ok P               FORK-FREE entry point, for the gate's emit-time token chain
+#                              (contractually free of external processes AND command
+#                              substitutions): judges the SPELLING. Sound there because that
+#                              path only READS a caller-chosen file — its contract is "seams
+#                              are honoured only under the test marker, never set in
+#                              production" — so a mis-accepted spelling can at worst make the
+#                              token `absent`/`unknown`; it can never write.
+#   sandbox_ok_resolved P      for every path WRITTEN, or whose CONTENTS are read (host
+#                              configuration): canonicalizes candidate AND root (`.`, `..`,
+#                              symlinked ancestors and a `//`-rooted `pwd -P` answer all
+#                              included), then the SAME predicate. An unenterable path
+#                              resolves to nothing and is refused — fail-closed, and correct
+#                              for a write target, which must exist to be written into.
+#   sandbox_file_ok_resolved F the file form (the optional `sysctl.conf` entry): the PARENT is
+#                              canonicalized and the RESULTING FILE PATH is validated.
+# `cd -P` + `pwd -P` is the canonicalizer: one subshell, no external binary, correct on bash
+# 3.2 (no `realpath`, no `readlink -f` — absent or non-GNU on some supported hosts).
+PERF_CAPABILITY_SANDBOX_STAMP='.cqlite-perf-sandbox'
+
+perf_capability_sandbox_root_into() {
+  local __psr_v="${CQLITE_PERF_TEST_SANDBOX:-}"
+  eval "$1="
+  __psr_v="${__psr_v%/}"
+  case "$__psr_v" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
+  case "/$__psr_v/" in */../*|*/./*) return 1 ;; esac
+  [ -d "$__psr_v" ] && [ -f "$__psr_v/$PERF_CAPABILITY_SANDBOX_STAMP" ] || return 1
+  eval "$1=\$__psr_v"
+}
+
+# THE containment predicate, and the only place a path is ever judged: rc 0 iff <path> is
+# absolute, canonically spelled (no `.`, `..` or `//` component — `//etc` IS `/etc`, R6-1)
+# and STRICTLY inside <root>, with the `/` boundary explicit so `/tmp/sandboxevil` is NOT
+# inside `/tmp/sandbox`. An empty root refuses; it is never a wildcard.
+perf_capability_path_within() {
+  [ -n "${2:-}" ] || return 1
+  case "${1:-}" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
   case "/$1/" in */../*|*/./*) return 1 ;; esac
-  case "$1" in
-    "${2:-/dev/null/never}"|"${2:-/dev/null/never}"/*) return 1 ;;
-    /proc|/proc/*|/sys|/sys/*|/etc|/etc/*) return 1 ;;
-  esac
-  [ ! -L "$1" ]
+  case "$1" in "$2"/?*) return 0 ;; esac
+  return 1
 }
 
-# perf_capability_test_dir_resolved_valid <value> <production-default>: the WRITE-side
-# validator. It canonicalizes <value> and requires the RESOLVED path to satisfy the same
-# non-production predicate, so `/tmp/../etc/sysctl.d` and a symlinked ANCESTOR
-# (`ln -s /etc /tmp/a`, seam `/tmp/a/sysctl.d`) are refused by their DESTINATION rather
-# than by a new textual special case. `cd -P` + `pwd -P` is the canonicalizer: one
-# subshell, no external binary, and correct on bash 3.2 (no `realpath`, no `readlink -f`,
-# both of which are absent or non-GNU on some supported hosts). A path that cannot be
-# entered at all resolves to nothing and is refused — fail-closed, and correct for a
-# write target, which must exist to be written into.
-perf_capability_test_dir_resolved_valid() {
-  local __ptv_real=''
-  perf_capability_test_dir_valid "$1" "$2" || return 1
-  __ptv_real=$(cd -P -- "$1" 2>/dev/null && pwd -P) || return 1
-  [ -n "$__ptv_real" ] || return 1
-  perf_capability_test_dir_valid "$__ptv_real" "$2"
+perf_capability_sandbox_ok() {
+  local __pso_root=''
+  perf_capability_sandbox_root_into __pso_root || return 1
+  perf_capability_path_within "${1:-}" "$__pso_root"
 }
 
-# perf_capability_test_seams_ok: rc 0 iff test mode has BOTH mandatory seams pointing
-# at explicit non-production directories, JUDGED BY THEIR CANONICAL DESTINATION (R5-1).
-# This is the gate on every privileged action below, so it takes the strict validator:
-# refusing here is what stops a root `--yes` test run from resolving a seam back into
-# the production directory and overwriting the host's own drop-in. Refuses loudly and
-# names the offending seam, because the failure it prevents is silent otherwise.
+# the root CANONICALIZED, so both sides of a resolved containment test are in one form
+perf_capability_sandbox_root_resolved_into() {
+  local __prr_v=''
+  eval "$1="
+  perf_capability_sandbox_root_into __prr_v || return 1
+  __prr_v=$(cd -P -- "$__prr_v" 2>/dev/null && pwd -P) || return 1
+  eval "$1=\${__prr_v%/}"
+}
+
+perf_capability_sandbox_ok_resolved() {
+  local __pdr_root='' __pdr_real=''
+  perf_capability_sandbox_root_resolved_into __pdr_root || return 1
+  __pdr_real=$(cd -P -- "${1:-/dev/null/never}" 2>/dev/null && pwd -P) || return 1
+  perf_capability_path_within "$__pdr_real" "$__pdr_root"
+}
+
+perf_capability_sandbox_file_ok_resolved() {
+  local __pfr_root='' __pfr_real='' __pfr_base=''
+  case "${1:-}" in */?*) ;; *) return 1 ;; esac
+  __pfr_base="${1##*/}"
+  case "$__pfr_base" in ''|.|..) return 1 ;; esac
+  perf_capability_sandbox_root_resolved_into __pfr_root || return 1
+  __pfr_real=$(cd -P -- "${1%/*}" 2>/dev/null && pwd -P) || return 1
+  perf_capability_path_within "${__pfr_real%/}/$__pfr_base" "$__pfr_root"
+}
+
+# perf_capability_seam_refusal <VARNAME> <value> <root>: ONE message shape for both
+# mandatory seams. The refusal must NAME the offending seam — that is what makes it
+# actionable — so this is parameterised rather than duplicated per seam.
+perf_capability_seam_refusal() {
+  printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires %s INSIDE the declared sandbox %s — its RESOLVED destination (. / .. / // / symlinked ancestors and all) must be strictly contained there; got %s. Test mode NEVER falls back to the real directory.\n' \
+    "${1:-<seam>}" "'${3:-}'" "'${2:-<unset>}'" >&2
+}
+
+# perf_capability_test_seams_ok: rc 0 iff test mode has a PROVEN sandbox root and BOTH
+# mandatory seams RESOLVING strictly inside it. This is the gate on every privileged
+# action below, so it takes the resolving form: refusing here is what stops a root `--yes`
+# test run from resolving a seam back into the production directory and overwriting the
+# host's own drop-in. Refuses loudly and names what failed, because the failure it
+# prevents is silent otherwise.
 perf_capability_test_seams_ok() {
-  local ok=0
-  if ! perf_capability_test_dir_resolved_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT"; then
-    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR (absolute, and RESOLVING — . / .. / symlinked ancestors and all — outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
-      "$PERF_CAPABILITY_PROC_DIR_DEFAULT" "'${CQLITE_PERF_PROC_DIR:-<unset>}'" >&2
-    ok=1
+  local ok=0 root=''
+  if ! perf_capability_sandbox_root_into root; then
+    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires CQLITE_PERF_TEST_SANDBOX to name an absolute existing directory holding the stamp file %s; got %s. Test mode acts only INSIDE a proven sandbox and NEVER falls back to the real directory.\n' \
+      "$PERF_CAPABILITY_SANDBOX_STAMP" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" >&2
+    return 1
   fi
-  if ! perf_capability_test_dir_resolved_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
-    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR (absolute, and RESOLVING — . / .. / symlinked ancestors and all — outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
-      "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" >&2
-    ok=1
-  fi
+  perf_capability_sandbox_ok_resolved "${CQLITE_PERF_PROC_DIR:-}" \
+    || { perf_capability_seam_refusal CQLITE_PERF_PROC_DIR "${CQLITE_PERF_PROC_DIR:-}" "$root"; ok=1; }
+  perf_capability_sandbox_ok_resolved "${CQLITE_PERF_SYSCTL_DIR:-}" \
+    || { perf_capability_seam_refusal CQLITE_PERF_SYSCTL_DIR "${CQLITE_PERF_SYSCTL_DIR:-}" "$root"; ok=1; }
   [ "$ok" = 0 ]
 }
 
-# perf_capability_env_guard: rc 0 iff this process may act on the perf capability
-# path at all. Every refusal is LOUD on stderr and FAILS CLOSED (the caller does
-# nothing privileged and claims no verdict):
-#   * a seam set WITHOUT the marker — the seams are inert there, and a caller that
-#     was handed one is misconfigured, so nothing privileged may proceed;
-#   * the marker set WITHOUT both non-production path seams — test mode has no
-#     fallback (R4-3): allowing one would let a root `--yes` test run `tee` the REAL
-#     /etc/sysctl.d, which is exactly the host mutation the marker promises cannot
-#     happen. Checked FIRST, before the tool checks, because it is the more
-#     fundamental precondition: a test run with no sandbox has nowhere safe to act;
-#   * the marker set while a REAL sudo/sysctl is reachable — test mode is hermetic
-#     by construction, so a reachable real privileged tool is a bug in the harness,
-#     not something to run.
+# perf_capability_env_guard: rc 0 iff this process may act on the perf capability path at
+# all. Every refusal is LOUD on stderr and FAILS CLOSED (the caller does nothing privileged
+# and claims no verdict):
+#   * a seam set WITHOUT the marker — the seams are inert there, so a caller handed one is
+#     misconfigured and nothing privileged may proceed;
+#   * the marker set WITHOUT a proven sandbox root and both seams inside it — test mode has
+#     no fallback (R4-3): allowing one would let a root `--yes` test run `tee` the REAL
+#     /etc/sysctl.d, the host mutation the marker promises cannot happen. Checked FIRST,
+#     before the tool checks: a test run with no sandbox has nowhere safe to act;
+#   * the marker set while a REAL sudo/sysctl is reachable — test mode is hermetic by
+#     construction, so a reachable real privileged tool is a harness bug, not something to run.
 perf_capability_env_guard() {
   if ! perf_capability_test_mode; then
     perf_capability_seam_set || return 0
@@ -232,40 +274,39 @@ perf_capability_env_guard() {
       *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 with a reachable real %s and no absolute CQLITE_PERF_TEST_PRIV_DIR — test mode must PATH-shim every privileged tool.\n' "$tool" >&2
          return 1 ;;
     esac
-    case "$resolved" in
-      "$dir"/*) ;;
-      *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
-           "$tool" "$resolved" "$dir" >&2
-         return 1 ;;
-    esac
+    # The same containment predicate as the seams, one level down: the tool must be
+    # strictly inside the DECLARED shim dir (not merely spelled that way).
+    perf_capability_path_within "$resolved" "${dir%/}" || {
+      printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
+        "$tool" "$resolved" "$dir" >&2
+      return 1
+    }
   done
   return 0
 }
 
 # ---- resolved locations (the seams apply ONLY in test mode) -------------------
-# THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain
-# below and is contractually FREE — no external process AND no command substitution
-# (each `$( )` forks a subshell, which is a process too). A function that answers on
-# stdout therefore CANNOT be on that path: its caller must fork to read it. So every
-# function the gate touches has an `_into <outvar>` core that assigns through a
-# caller-named variable, and the stdout-printing form is a thin wrapper kept for the
-# CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork is paid, and it is
-# not on the gate's path.
-#   Assignment is `eval "$1=\$var"`, NOT a `local -n` nameref: bash 3.2 (macOS
-#   /bin/bash, a supported gate host) has no namerefs. The RHS is an assignment, so no
-#   word-splitting or globbing applies to the value. <outvar> must be a plain shell
-#   identifier; every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_`
-#   local prefixes keep a caller-named variable from colliding with an internal one.
-#   In TEST MODE the seam is MANDATORY and validated (R4-3): an unset or
-#   production-shaped value is rc 1 with an empty answer, never a silent fallback to
-#   the real /proc or the real /etc/sysctl.d. Every caller propagates that rc, so an
-#   unsandboxed test run reads nothing and writes nothing.
+# THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain below and
+# is contractually FREE — no external process AND no command substitution (each `$( )` forks
+# a subshell, which is a process too). A function that answers on stdout therefore CANNOT be
+# on that path: its caller must fork to read it. So every function the gate touches has an
+# `_into <outvar>` core assigning through a caller-named variable, and the stdout-printing
+# form is a thin wrapper for CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork
+# is paid, and it is not on the gate's path. Assignment is `eval "$1=\$var"`, NOT a
+# `local -n` nameref: bash 3.2 (macOS /bin/bash, a supported gate host) has none. The RHS is
+# an assignment, so no word-splitting or globbing applies; <outvar> must be a plain
+# identifier (every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_` prefixes
+# keep a caller-named variable from colliding with an internal one).
+#   In TEST MODE the seam is MANDATORY and gated (R4-3): a value not provably inside the
+#   declared sandbox is rc 1 with an empty answer, never a silent fallback to the real /proc
+#   or /etc/sysctl.d. Every caller propagates that rc, so an unsandboxed test run reads
+#   nothing and writes nothing.
 perf_capability_proc_dir_into() {
   eval "$1="
   if perf_capability_test_mode; then
-    perf_capability_test_dir_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" || {
-      printf 'perf-capability: REFUSING to read /proc: CQLITE_PERF_TEST_MODE=1 with no valid non-production CQLITE_PERF_PROC_DIR (got %s) — test mode never falls back to %s.\n' \
-        "'${CQLITE_PERF_PROC_DIR:-<unset>}'" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
+    perf_capability_sandbox_ok "${CQLITE_PERF_PROC_DIR:-}" || {
+      printf 'perf-capability: REFUSING to read /proc: CQLITE_PERF_TEST_MODE=1 with CQLITE_PERF_PROC_DIR (%s) not INSIDE the declared sandbox %s — test mode never falls back to %s.\n' \
+        "'${CQLITE_PERF_PROC_DIR:-<unset>}'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
       return 1
     }
     eval "$1=\$CQLITE_PERF_PROC_DIR"
@@ -278,11 +319,16 @@ perf_capability_proc_dir() {
   perf_capability_proc_dir_into __pcd_v || return 1
   printf '%s' "$__pcd_v"
 }
+# perf_capability_sysctl_dir: the sysctl.d directory — the WRITE side (a root `tee` is
+# pointed inside it) and the directory whose CONTENTS the competing-file scan reads, so it
+# takes the RESOLVING gate: the canonical DESTINATION is what gets written, not the
+# spelling. Every consumer of the sysctl.d location goes through this one function, so
+# there is exactly one place the check can be forgotten — and it is here.
 perf_capability_sysctl_dir() {
   if perf_capability_test_mode; then
-    perf_capability_test_dir_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" || {
-      printf 'perf-capability: REFUSING to resolve a sysctl.d path: CQLITE_PERF_TEST_MODE=1 with no valid non-production CQLITE_PERF_SYSCTL_DIR (got %s) — test mode never falls back to %s.\n' \
-        "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" >&2
+    perf_capability_sandbox_ok_resolved "${CQLITE_PERF_SYSCTL_DIR:-}" || {
+      printf 'perf-capability: REFUSING to resolve a sysctl.d path: CQLITE_PERF_TEST_MODE=1 with CQLITE_PERF_SYSCTL_DIR (%s) not RESOLVING inside the declared sandbox %s (or unenterable) — test mode never falls back to %s.\n' \
+        "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" >&2
       return 1
     }
     printf '%s' "$CQLITE_PERF_SYSCTL_DIR"
@@ -290,29 +336,21 @@ perf_capability_sysctl_dir() {
   fi
   printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
-# perf_capability_dropin_path: the path a root `tee` is pointed at, so this is the WRITE
-# side and it takes the STRICT validator (R5-1) — the seam's CANONICAL destination is
-# checked, not its spelling. Independent of the env guard on purpose: the guard is the
-# gate, this is the last line before the bytes land, and a write target may never be
-# named from a path that resolves into production.
+# perf_capability_dropin_path: the path a root `tee` is pointed at. The containment gate
+# lives in perf_capability_sysctl_dir — the single place that directory comes from — and
+# it RESOLVES the destination, so there is deliberately no second copy of the check here:
+# one gate, not a prohibition a future entry point could skip (R6-2).
 perf_capability_dropin_path() {
   local __pdi_d
   __pdi_d=$(perf_capability_sysctl_dir) || return 1
-  if perf_capability_test_mode \
-     && ! perf_capability_test_dir_resolved_valid "$__pdi_d" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
-    printf 'perf-capability: REFUSING to name a write target: CQLITE_PERF_SYSCTL_DIR=%s RESOLVES (through . / .. / a symlinked ancestor) outside its sandbox or is unenterable — the canonical DESTINATION is what a root tee writes, not the spelling.\n' \
-      "'$__pdi_d'" >&2
-    return 1
-  fi
   printf '%s/%s' "$__pdi_d" "$PERF_CAPABILITY_DROPIN_BASENAME"
 }
 
-# perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a
-# WHOLE managed file (not a delimited block inside a foreign one), so idempotency
-# is a plain byte-compare of the entire file — simpler and safer than editing
-# someone else's config. Callers may pipe this straight into `sudo tee`, which is
-# also the remedy line bootstrap prints, so a hand-applied fix produces
-# byte-identical content and the next bootstrap run is a silent no-op.
+# perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a WHOLE
+# managed file (not a delimited block inside a foreign one), so idempotency is a plain
+# byte-compare of the entire file — simpler and safer than editing someone else's config.
+# Callers may pipe this straight into `sudo tee`, which is also the remedy line bootstrap
+# prints, so a hand-applied fix is byte-identical and the next bootstrap run is a no-op.
 perf_capability_dropin_content() {
   cat <<'EOF'
 # Managed by scripts/bootstrap-agent-machine.sh — CQLite issue #3249. Do not edit.
@@ -343,27 +381,24 @@ kernel.kptr_restrict = 0
 EOF
 }
 
-# perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the
-# managed bytes (the idempotency test — a matching file means write nothing). The
-# compare is an in-shell string compare, NOT `diff -q`: on a box without diffutils
-# `diff` exits 127, which would report "different" on every run — so bootstrap
-# would re-write the file each time AND then report it could not write it.
+# perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the managed
+# bytes (the idempotency test — a matching file means write nothing). The compare is an
+# in-shell string compare, NOT `diff -q`: on a box without diffutils `diff` exits 127,
+# which reads as "different" on every run — so bootstrap would re-write the file each time
+# AND then report it could not write it.
 #
-# TRAILING NEWLINES ARE PART OF THE BYTES (issue #3249 review R4-4). `$( )` strips
-# EVERY trailing newline from its output, so comparing two command substitutions made
-# a file missing its final newline — or carrying extra blank lines at the end —
-# compare EQUAL to the canonical content: "byte-exact" was a false claim, and such a
-# file was never rewritten. The file side is now read with `read -r -d ''`, which
-# consumes the whole file verbatim (builtin, so no `cat`/`diff` dependency), and the
-# canonical side carries an in-substitution sentinel so its own final newline survives
-# the stripping.
+# TRAILING NEWLINES ARE PART OF THE BYTES (review R4-4). `$( )` strips EVERY trailing
+# newline, so comparing two command substitutions made a file missing its final newline —
+# or carrying extra trailing blank lines — compare EQUAL: "byte-exact" was a false claim
+# and such a file was never rewritten. The file side is read with `read -r -d ''`, which
+# consumes it verbatim (builtin, no `cat`/`diff` dependency), and the canonical side carries
+# an in-substitution sentinel so its own final newline survives the stripping.
 #
-# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (issue #3249 review R5-3). `read -d ''`
-# stops at a NUL and returns SUCCESS, leaving `got` holding only the bytes BEFORE it — so
-# canonical content followed by a NUL and ARBITRARY trailing bytes compared EQUAL and was
-# judged current. Read's rc is therefore load-bearing: rc 0 means a NUL delimiter was
-# consumed, i.e. the file is not our text drop-in AND the rest of it was never even seen,
-# so it is NOT current; only an rc != 0 (EOF reached, whole file in `got`) may be compared.
+# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (review R5-3). `read -d ''` stops at a NUL
+# and returns SUCCESS with only the bytes BEFORE it, so canonical content + NUL + ARBITRARY
+# trailing bytes compared EQUAL and was judged current. Read's rc is therefore load-bearing:
+# rc 0 means a NUL was consumed — not our text drop-in, and the rest never even seen — so it
+# is NOT current; only rc != 0 (EOF, whole file in `got`) may be compared.
 perf_capability_dropin_current() {
   local path want got=''
   path=$(perf_capability_dropin_path) || return 1
@@ -376,32 +411,33 @@ perf_capability_dropin_current() {
 }
 
 # perf_capability_sysctl_search_path: the COMPLETE set of locations `sysctl --system`
-# (procps-ng) and systemd-sysctl load, one per line, in DESCENDING NAME-MASKING
-# PRECEDENCE — the order both tools scan (sysctl(8) SYSTEM FILE PRECEDENCE, sysctl.d(5)
-# CONFIGURATION DIRECTORIES AND PRECEDENCE):
-#   /etc/sysctl.d  /run/sysctl.d  /usr/local/lib/sysctl.d  /usr/lib/sysctl.d
-#   /lib/sysctl.d  and finally the FILE /etc/sysctl.conf
+# (procps-ng) and systemd-sysctl load, one per line, in DESCENDING NAME-MASKING PRECEDENCE —
+# the order both tools scan (sysctl(8) SYSTEM FILE PRECEDENCE, sysctl.d(5) CONFIGURATION
+# DIRECTORIES AND PRECEDENCE): /etc/sysctl.d, /run/sysctl.d, /usr/local/lib/sysctl.d,
+# /usr/lib/sysctl.d, /lib/sysctl.d, and finally the FILE /etc/sysctl.conf.
 # TWO INDEPENDENT RULES decide who wins, and the scan below implements both:
 #   MASKING  "once a file of a given filename is loaded, any file of the same name in
 #            subsequent directories is ignored" — so /etc/sysctl.d/50-x.conf REPLACES
-#            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would
-#            name a file that is not in effect.
-#   ORDERING the surviving files are applied in lexicographic BASENAME order regardless
-#            of which directory they came from; the LAST assignment wins.
-#   /etc/sysctl.conf is applied AFTER every drop-in, so it wins on grounds that have
-#   nothing to do with its name — it gets its own verdict rather than a sort comparison.
-#
-# WHY THE WHOLE PATH (issue #3249 review R5-4). Scanning only /etc/sysctl.d meant a
-# later-sorting file in /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in
-# while bootstrap reported NO competitor — recreating the exact "it silently reverts and
-# nobody knows why" mystery this diagnostic exists to end.
+#            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would name
+#            a file that is not in effect.
+#   ORDERING the survivors are applied in lexicographic BASENAME order regardless of which
+#            directory they came from; the LAST assignment wins. /etc/sysctl.conf is applied
+#            AFTER every drop-in, so it wins on grounds unrelated to its name and gets its
+#            own verdict rather than a sort comparison.
+# WHY THE WHOLE PATH (review R5-4). Scanning only /etc/sysctl.d meant a later-sorting file in
+# /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in while bootstrap reported NO
+# competitor — recreating the "it silently reverts and nobody knows why" mystery this
+# diagnostic exists to end.
 #
 # In TEST MODE the path is the sandbox seam plus the optional colon-separated
 # CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, in the same descending
-# order, each validated non-production): the real /run and /usr/lib are never read, so a
-# case's verdict can never depend on the host's own drop-ins.
+# order): the real /run and /usr/lib are never read, so a case's verdict can never depend
+# on the host's own drop-ins. EVERY entry goes through the SAME RESOLVING gate as the
+# write path (R6-2 — this entry point once used the syntactic one, so a symlinked ancestor
+# could point a "sandboxed" scan at the host's real configuration). A `sysctl.conf` entry
+# is a FILE, so its parent is canonicalized and the resulting file path validated.
 perf_capability_sysctl_search_path() {
-  local __psp_d __psp_e
+  local __psp_d __psp_e __psp_ok
   if perf_capability_test_mode; then
     __psp_d=$(perf_capability_sysctl_dir) || return 1
     printf '%s\n' "$__psp_d"
@@ -410,9 +446,14 @@ perf_capability_sysctl_search_path() {
     IFS=':' read -r -a __psp_extra <<<"${CQLITE_PERF_SYSCTL_EXTRA_DIRS:-}"
     for __psp_e in ${__psp_extra[@]+"${__psp_extra[@]}"}; do
       [ -n "$__psp_e" ] || continue
-      perf_capability_test_dir_valid "$__psp_e" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" || {
-        printf 'perf-capability: REFUSING: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry %s is not an absolute NON-PRODUCTION path — a test-mode scan may never read the host'"'"'s real sysctl.d directories.\n' \
-          "'$__psp_e'" >&2
+      __psp_ok=0
+      case "${__psp_e##*/}" in
+        sysctl.conf) perf_capability_sandbox_file_ok_resolved "$__psp_e" && __psp_ok=1 ;;
+        *)           perf_capability_sandbox_ok_resolved "$__psp_e" && __psp_ok=1 ;;
+      esac
+      [ "$__psp_ok" = 1 ] || {
+        printf 'perf-capability: REFUSING: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry %s does not RESOLVE inside the declared sandbox %s — a test-mode scan may never read the host'"'"'s real sysctl configuration.\n' \
+          "'$__psp_e'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" >&2
         return 1
       }
       printf '%s\n' "$__psp_e"
@@ -439,16 +480,15 @@ perf_capability_file_sets_controls() {
 # wins regardless of name.
 #
 # WHY THIS EXISTS. Three separate reports (ws0-3217, ws3-3029, the 2026-07-27 Cassandra
-# baseline) recorded that a hand-set perf_event_paranoid/kptr_restrict "silently
-# reverts" and none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
+# baseline) recorded a hand-set perf_event_paranoid/kptr_restrict "silently reverting" and
+# none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
 # /etc/sysctl.d/10-kernel-hardening.conf with `kernel.kptr_restrict = 1`, re-asserted at
 # every boot and by every `sysctl --system`. "It silently reverts" is unactionable;
-# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins"
-# is a diagnosis. Ordering is lexicographic by BASENAME in BYTE order, which is what
-# systemd-sysctl/`sysctl --system` use — and `[ "$a" \> "$b" ]` is the right operator
-# for it: the `[` builtin compares with strcmp (verified: byte order even under a UTF-8
-# LC_ALL), whereas `[[ > ]]` would switch to locale collation and could mis-rank names
-# whose only difference is punctuation.
+# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins" is a
+# diagnosis. Ordering is lexicographic by BASENAME in BYTE order (what systemd-sysctl and
+# `sysctl --system` use) and `[ "$a" \> "$b" ]` is the right operator: the `[` builtin
+# compares with strcmp (verified: byte order even under a UTF-8 LC_ALL), whereas `[[ > ]]`
+# switches to locale collation and could mis-rank names differing only in punctuation.
 perf_capability_competing_files() {
   local base f name entry seen paths lf='
 '
@@ -491,26 +531,25 @@ $paths
 EOF
 }
 
-# perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight
-# from /proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when
-# unreadable). NEVER trust a `sysctl -w`/`--system` return code — a write can report
-# success while the value does not take (container, read-only sysfs, a competing
-# drop-in applied later), and it can report FAILURE for an unrelated entry while ours
-# applied fine. Read back.
-# Fully fork-free: `read` is a builtin, the directory comes back through a variable,
-# and nothing here is wrapped in `$( )`. This sits in the gate's summary path, which
-# may not grow a process for a diagnostic line. `read` returns non-zero at EOF on a
-# file with no trailing newline yet still assigns, so emptiness — not read's rc — is
-# the failure test. It also propagates the test-mode sandbox refusal (R4-3): with no
-# valid seam there is no directory to read, and that is rc 1, never the real /proc.
+# perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight from
+# /proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when unreadable). NEVER
+# trust a `sysctl -w`/`--system` return code — a write can report success while the value
+# does not take (container, read-only sysfs, a competing drop-in applied later), and it can
+# report FAILURE for an unrelated entry while ours applied fine. Read back.
+# Fully fork-free: `read` is a builtin, the directory comes back through a variable, and
+# nothing here is wrapped in `$( )` — this sits in the gate's summary path, which may not
+# grow a process for a diagnostic line. `read` returns non-zero at EOF on a file with no
+# trailing newline yet still assigns, so emptiness — not read's rc — is the failure test. It
+# also propagates the test-mode sandbox refusal (R4-3): with no seam inside the sandbox there
+# is no directory to read, and that is rc 1, never the real /proc.
 #
 # WHITESPACE IS TRIMMED, NEVER TRUNCATED AT (fail-open audit, R4 round). The earlier
 # `${v%%[[:space:]]*}` cut the value at its FIRST space, so a malformed `0 1` became a
-# perfectly capable-looking `0` — an unknown resolving to the good case, in the one
-# function the gate's `perf=` token is computed from. Surrounding whitespace (including a
-# CRLF's `\r`) is stripped; anything interior is left in place so `is_int` rejects it and
-# the token becomes `unknown`. `IFS=` makes that independent of the caller's IFS, and both
-# trims are parameter expansions — no fork on the gate's emit path.
+# perfectly capable-looking `0` — an unknown resolving to the good case, in the one function
+# the gate's `perf=` token comes from. Surrounding whitespace (a CRLF's `\r` included) is
+# stripped; anything interior stays so `is_int` rejects it and the token becomes `unknown`.
+# `IFS=` makes that independent of the caller's IFS, and both trims are parameter
+# expansions — no fork on the gate's emit path.
 perf_capability_proc_read() {
   local __pcr_out="$1" __pcr_dir="" __pcr_v=""
   eval "$__pcr_out="
@@ -531,13 +570,12 @@ perf_capability_proc_value() {
   printf '%s' "$__pcv_v"
 }
 
-# perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative
-# integer NARROW ENOUGH for shell arithmetic. Both halves are load-bearing: `[ 1abc
-# -ge 1 ]` and `[ 99999999999999999999999 -ge 1 ]` do NOT compare — each prints
-# "integer expression expected" to stderr and returns 2 (neither true NOR false), so
-# a malformed or oversized value would fall past BOTH a `>= 1` and a `<= 0` test and
-# be reported as good (a WRONG capability claim) while leaking an error line into the
-# gate's output. Validate the shape here instead of trusting the read.
+# perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative integer
+# NARROW ENOUGH for shell arithmetic. Both halves are load-bearing: `[ 1abc -ge 1 ]` and
+# `[ 99999999999999999999999 -ge 1 ]` do NOT compare — each prints "integer expression
+# expected" and returns 2 (neither true NOR false), so a malformed or oversized value would
+# fall past BOTH a `>= 1` and a `<= 0` test and be reported as good (a WRONG capability
+# claim) while leaking an error line into the gate's output.
 perf_capability_is_int() {
   local body="${1#-}"
   [ -n "$body" ] || return 1
@@ -545,13 +583,11 @@ perf_capability_is_int() {
   [ "${#body}" -le 10 ]
 }
 
-# perf_capability_token_into <outvar>: the FREE capability read, and THE function the
-# gate's accelerators line calls. Free is a hard contract, enforced by
-# test_agent_gate_summary.sh case 9f-free: pure /proc through shell builtins — no
-# `perf` exec, no external process of ANY kind, and no command substitution anywhere
-# in the chain (which is why the answer comes back through <outvar> rather than
-# stdout; every `$( )` is a forked subshell, and the gate emits this line on every
-# summary).
+# perf_capability_token_into <outvar>: the FREE capability read, and THE function the gate's
+# accelerators line calls. Free is a hard contract, enforced by test_agent_gate_summary.sh
+# case 9f-free: pure /proc through shell builtins — no `perf` exec, no external process of
+# ANY kind, and no command substitution anywhere in the chain (hence the <outvar>: every
+# `$( )` is a forked subshell, and the gate emits this line on every summary).
 #   ok               unprivileged per-CPU profiling AND kernel symbols available
 #   paranoid-<N>     perf_event_paranoid = N >= 1 -> CPU-wide `perf stat -C` denied
 #   kptr-restricted  paranoid is fine but kptr_restrict != 0 -> no kernel symbols
@@ -588,29 +624,23 @@ perf_capability_token() {
 
 # ---- WHOSE capability? the privilege dimension (issue #3249 review) -----------
 # perf_event_paranoid restricts UNPRIVILEGED users; ROOT BYPASSES IT ENTIRELY. So
-# `perf stat -C 0 -e cycles` run by root SUCCEEDS on a paranoid=4 box on which every
+# `perf stat -C 0 -e cycles` run by root SUCCEEDS on a paranoid=4 box where every
 # unprivileged agent process still gets EACCES — and `sudo bash
 # scripts/bootstrap-agent-machine.sh` is a completely normal provisioning invocation
-# (arguably the most likely one, since installing /etc/sysctl.d/99-cqlite-perf.conf
-# needs root). A root-run functional check reported as "perf capability verified" is
-# therefore a FALSE verification of an unprofileable box: precisely the failure mode
-# the functional check exists to remove, reintroduced through the privilege dimension.
+# (arguably the most likely one, since installing the drop-in needs root). A root-run
+# functional check reported as "perf capability verified" is therefore a FALSE verification
+# of an unprofileable box: the failure mode the functional check exists to remove,
+# reintroduced through the privilege dimension. The property under test is "an UNPRIVILEGED
+# process can collect CPU-WIDE cycles", which a root-run probe cannot demonstrate — so the
+# probe DROPS PRIVILEGE when it can and SAYS SO when it cannot, and the caller then
+# subordinates the functional result to the identity-independent /proc token.
 #
-# The property actually under test is "an UNPRIVILEGED process can collect CPU-WIDE
-# cycles", and a root-run probe cannot demonstrate it. So the probe DROPS PRIVILEGE
-# when it can, and when it cannot it says so — the caller then subordinates the
-# functional result to the /proc token, which is identity-independent.
-#
-# perf_capability_self_uid_into <outvar>: THIS process's uid, and rc 0 ONLY when it is
-# genuinely known — `id -u` must EXIST, exit 0, and print a validated non-negative
-# integer. rc 1 (with <outvar> emptied) means "identity unknown", which is NOT the same
-# as "unprivileged" (issue #3249 review R4-1).
-#
-# The previous shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or
-# broken `id` made a ROOT process look unprivileged, so its root perf run was accepted
-# as unprivileged evidence and printed a false VERIFIED — the very R3-1 defect, through
-# the detector written to prevent it. An unknown identity can never resolve to the
-# reassuring case.
+# perf_capability_self_uid_into <outvar>: THIS process's uid, rc 0 ONLY when genuinely known
+# — `id -u` must EXIST, exit 0, and print a validated non-negative integer. rc 1 (<outvar>
+# emptied) means "identity unknown", which is NOT "unprivileged" (review R4-1). The previous
+# shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or broken `id` made a
+# ROOT process look unprivileged, so its root perf run was accepted as unprivileged evidence
+# and printed a false VERIFIED — the R3-1 defect, through the detector written to prevent it.
 perf_capability_self_uid_into() {
   local __psu_v=''
   eval "$1="
@@ -625,14 +655,13 @@ perf_capability_self_uid_into() {
 # the passwd database whose uid AND gid equal the supplied (already validated) numerics
 # and whose uid is non-zero.
 #
-# WHY (issue #3249 review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever
-# the NAME resolves to, not to the numeric ids we validated. SUDO_USER and SUDO_UID are
-# independent environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale, hand-set, or
-# inconsistent) would run the probe AS ROOT while the code reported a successful
-# privilege drop — a false VERIFIED again. A name is therefore only usable once the
-# passwd database confirms it IS the validated uid/gid.
-# The shape check is equally load-bearing: the prefix is word-split by the caller, so a
-# name containing whitespace or glob characters could inject extra argv tokens.
+# WHY (review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever the NAME
+# resolves to, not to the numeric ids we validated, and SUDO_USER/SUDO_UID are independent
+# environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale or hand-set) would run the probe
+# AS ROOT while the code reported a successful drop — a false VERIFIED again. So a name is
+# usable only once the passwd database confirms it IS the validated uid/gid. The shape check
+# is equally load-bearing: the prefix is word-split by the caller, so a name containing
+# whitespace or glob characters could inject extra argv tokens.
 perf_capability_name_is_uid() {
   local __pni_n="${1:-}" __pni_u="${2:-}" __pni_g="${3:-}" __pni_ru __pni_rg
   [ -n "$__pni_n" ] || return 1
@@ -652,11 +681,10 @@ perf_capability_name_is_uid() {
 #      Strongest available evidence.
 #   2. `nobody`, resolved from the passwd database (never a hardcoded 65534: a box
 #      without that account must report "no target", not probe a uid nobody owns).
-# THE NUMERIC IDS ARE THE TARGET; the NAME is optional and only ever set when the
-# passwd database confirms it resolves to exactly those non-zero ids (R4-2). An
-# unverifiable SUDO_USER is dropped, not trusted: the numeric-only mechanisms
-# (setpriv, `sudo -u '#<uid>'`) still work, and a name-requiring mechanism correctly
-# reports that it has nothing safe to use.
+# THE NUMERIC IDS ARE THE TARGET; the NAME is optional and set only when the passwd database
+# confirms it resolves to exactly those non-zero ids (R4-2). An unverifiable SUDO_USER is
+# dropped, not trusted: the numeric-only mechanisms (setpriv, `sudo -u '#<uid>'`) still work,
+# and a name-requiring mechanism correctly reports it has nothing safe to use.
 perf_capability_drop_target_into() {
   local __pdt_u='' __pdt_g='' __pdt_n=''
   if perf_capability_is_int "${SUDO_UID:-}" && perf_capability_is_int "${SUDO_GID:-}" \
@@ -694,18 +722,16 @@ perf_capability_drop_target_into() {
 #                                 and the result is not evidence either way (rc 1)
 #   root-no-unprivileged-target   root, and no unprivileged identity is resolvable (rc 1)
 #   root-no-drop-mechanism        root, target known, but no usable setpriv/runuser/sudo (rc 1)
-# Mechanism order: `setpriv` (util-linux; a plain setresuid, no PAM, no session, no
-# shell), then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC
-# ids and never a name — `setpriv --reuid/--regid`, and `sudo -u '#<uid>'` (sudo's
-# documented numeric-uid form) — so no name has to be trusted (R4-2). `runuser` accepts
-# only a name and is therefore used ONLY with a passwd-confirmed one.
-#   The `#<uid>` token is safe through the caller's word-split: `#` only starts a comment
-#   during tokenisation of the source line, and this value arrives by EXPANSION
-#   afterwards, so it is passed to sudo as a literal argument.
-# The prefix is composed ONLY of literal tokens plus a validated numeric uid/gid or a
-# passwd-confirmed name, so the caller may word-split it. A non-zero rc is NOT an error
-# to fail on: it is the caller's cue to label the functional result as what it is — not
-# evidence about an unprivileged process — and to let the /proc token be the authority.
+# Mechanism order: `setpriv` (util-linux; a plain setresuid — no PAM, no session, no shell),
+# then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC ids and
+# never a name — `setpriv --reuid/--regid` and `sudo -u '#<uid>'` (sudo's documented
+# numeric-uid form) — so no name has to be trusted (R4-2); `runuser` accepts only a name and
+# is used ONLY with a passwd-confirmed one. The `#<uid>` token survives the caller's
+# word-split intact: `#` starts a comment only while TOKENISING a source line, and this value
+# arrives by EXPANSION afterwards. The prefix holds only literal tokens plus a validated
+# numeric uid/gid or a confirmed name, so the caller may word-split it. A non-zero rc is NOT
+# an error to fail on: it is the caller's cue to label the functional result as what it is —
+# not evidence about an unprivileged process — and to let the /proc token be the authority.
 perf_capability_drop_prefix_into() {
   local __pdp_u='' __pdp_g='' __pdp_n='' __pdp_self=''
   eval "$1="
@@ -737,24 +763,22 @@ perf_capability_drop_prefix_into() {
   return 1
 }
 
-# perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (issue #3249
-# AC2). A bootstrap that silently leaves a box unprofileable is the failure mode being
-# fixed, so the verdict comes from RUNNING the collection the doctrine mandates —
-# `perf stat -C 0 -e cycles` — and requires BOTH exit 0 AND a non-zero cycle
-# count. `perf stat` exits 0 while printing `<not supported>` / `<not counted>`
-# (and a virtualised PMU can report a flat 0), so an rc-only check is exactly the
-# false green this exists to prevent.
+# perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (AC2). A bootstrap
+# that silently leaves a box unprofileable is the failure mode being fixed, so the verdict
+# comes from RUNNING the collection the doctrine mandates — `perf stat -C 0 -e cycles` — and
+# requires BOTH exit 0 AND a non-zero cycle count: `perf stat` exits 0 while printing
+# `<not supported>`/`<not counted>` (and a virtualised PMU can report a flat 0), so an
+# rc-only check is exactly the false green this exists to prevent.
 #
-# Any arguments are a command prefix the collection runs under — the
-# privilege-dropping prefix above. This function makes NO claim about identity: it
-# runs what it is given and reports the counter. Deciding WHOSE capability was
-# measured (and whether that answers the question) is the caller's job, because the
-# caller is the one that owns the verdict.
+# Any arguments are a command prefix the collection runs under — the privilege-dropping
+# prefix above. This function makes NO claim about identity: it runs what it is given and
+# reports the counter. Deciding WHOSE capability was measured is the caller's job, because
+# the caller owns the verdict.
 #
 # CSV mode (`-x,`) is parsed rather than the human table: the human renderer is
-# locale-formatted (`1.234.567`) and column layout has changed across perf
-# releases, while the CSV shape `<count>,<unit>,<event>,...` is stable.
-# Prints a short machine-greppable reason (stdout) either way; rc 0 = verified.
+# locale-formatted (`1.234.567`) and its column layout has changed across perf releases,
+# while the CSV shape `<count>,<unit>,<event>,...` is stable. Prints a short
+# machine-greppable reason (stdout) either way; rc 0 = verified.
 perf_capability_verify() {
   command -v perf >/dev/null 2>&1 || { printf 'no-perf-binary'; return 1; }
   local bound="" out rc count
@@ -771,14 +795,13 @@ perf_capability_verify() {
     printf 'perf-stat-failed rc=%s: %s' "$rc" "$(printf '%s' "$out" | tr '\n' ';' | cut -c1-160)"
     return 1
   fi
-  # Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU
-  # (Intel 12th-gen+ P/E cores) perf emits one row per PMU named `cpu_core/cycles/`
-  # and `cpu_atom/cycles/`, commonly with `<not supported>` on the sibling that did
-  # not run — so a parser keyed on a literal leading `cycles` reports `no-cycles-row`
-  # on a perfectly good collection. Normalise the event field (drop the PMU prefix, a
-  # trailing `/`, and any `:u`/`:k` modifier) and take the FIRST row carrying a
-  # positive numeric count; keep the first matching row's raw field as the fallback so
-  # the `<not supported>` / zero diagnostics below still fire when none is positive.
+  # Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU (Intel
+  # 12th-gen+ P/E cores) perf emits one row per PMU (`cpu_core/cycles/`, `cpu_atom/cycles/`),
+  # commonly with `<not supported>` on the sibling that did not run — so a parser keyed on a
+  # literal leading `cycles` reports `no-cycles-row` on a perfectly good collection. Normalise
+  # the event field (drop PMU prefix, trailing `/`, any `:u`/`:k` modifier) and take the FIRST
+  # row with a positive numeric count; keep the first matching row's raw field as the fallback
+  # so the `<not supported>` / zero diagnostics below still fire when none is positive.
   count=$(printf '%s\n' "$out" | awk -F, '
     {
       ev = tolower($3)

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -32,11 +32,8 @@
 # `PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
 # outside those namespaces are touched). Every function is `set -u` safe.
 #
-# Usage (executed):
-#   bash scripts/perf-capability.sh --token        # free /proc read -> one token
-#   bash scripts/perf-capability.sh --verify       # functional perf stat check
-#   bash scripts/perf-capability.sh --drop-in      # canonical sysctl.d file bytes
-#   bash scripts/perf-capability.sh --drop-in-path # where that file belongs
+# Usage when executed: `bash scripts/perf-capability.sh --help` (the modes are listed by
+# perf_capability_usage below, so they are not duplicated here).
 #
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
 # The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
@@ -59,22 +56,20 @@
 #                               optional, test mode only
 #   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
 #
-# POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds
-# each closed ONE MORE SPELLING of "the production directory": the raw path (B3), then a
-# symlinked seam, then `..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes
-# implementation-defined, `pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A
-# denylist over path spellings cannot be completed — `.`, `..`, symlinks, `//`, trailing
-# slashes, bind mounts, `/proc/self/root/…` all name the same directory — and a scattered
-# set of prohibitions also lets a NEW entry point silently miss them (R6-2). So the rule is
-# INVERTED and there is exactly ONE: a seam is usable IFF it is strictly contained in the
-# declared sandbox root. Every spelling of "somewhere else" — including every future one —
-# fails that single check for the same reason: it is not inside the sandbox.
-# TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams
-# are MANDATORY. The earlier shape — marker set, seam unset, fall back to the real
-# directory — meant test mode could pass the env guard (sudo/sysctl absent, or present as
-# declared shims) and a subsequent root `--yes` run would then invoke a bare `tee` against
-# the REAL /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim
-# that depends on a variable being set: it is enforced here, fail-closed and loudly.
+# POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds each
+# closed ONE MORE SPELLING of "the production directory": the raw path (B3), a symlinked seam,
+# `..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes implementation-defined,
+# `pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A denylist over path spellings
+# cannot be completed — `.`, `..`, symlinks, `//`, trailing slashes, bind mounts,
+# `/proc/self/root/…` all name the same directory — and scattered prohibitions also let a NEW
+# entry point silently miss them (R6-2). So the rule is INVERTED and there is exactly ONE: a
+# seam is usable IFF it is strictly contained in the declared sandbox root. Every spelling of
+# "somewhere else", including every future one, fails that single check for the same reason.
+# TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams are
+# MANDATORY. The earlier shape — marker set, seam unset, fall back to the real directory —
+# meant test mode could pass the env guard (sudo/sysctl absent, or present as declared shims)
+# and a subsequent root `--yes` run would `tee` the REAL /etc/sysctl.d, mutating the host from
+# a test run. "Hermetic" cannot be a claim that depends on a variable being set.
 
 # FAIL-OPEN AUDIT — every path that can reach a POSITIVE verdict, and what validates it
 # (review round 4; four findings in this file were one defect class: "identity/state unknown
@@ -84,11 +79,11 @@
 #                               both `is_int`-validated AND paranoid <= 0 AND kptr == 0.
 #                               Whitespace trimmed, never TRUNCATED — `0 1` stays malformed.
 #   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count is a
-#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` +
-#                               `-le 0`. `<not supported>`/`<not counted>`/empty/oversized/
-#                               malformed all return 1.
-#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0,
-#                               prints a validated non-negative int) AND that uid != 0. An
+#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` + `-le
+#                               0`. `<not supported>`/`<not counted>`/empty/oversized/malformed
+#                               all return 1.
+#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0 and
+#                               prints a validated non-negative int) AND that uid != 0; an
 #                               unusable `id -u` => identity-unknown, rc 1.
 #   state = dropped:setpriv     numeric uid+gid, both validated ints AND both > 0.
 #   state = dropped:runuser     the same numerics PLUS a `SUDO_USER` the passwd database
@@ -102,7 +97,7 @@
 #   dropin_path rc 0            its directory came from `sysctl_dir`, i.e. RESOLVES inside the
 #                               sandbox — the single gate between the bytes and a root `tee`.
 #   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against the
-#                               generated canonical content, from a read that reached EOF — a
+#                               canonical content from a read that reached EOF — a
 #                               NUL-delimited read is NOT current (R5-3).
 # KNOWN RESIDUALS, deliberately not papered over:
 #   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel changed
@@ -136,31 +131,25 @@ perf_capability_seam_set() {
 
 # ---- ONE GATE: POSITIVE SANDBOX CONTAINMENT (review R6-1/R6-2) --------------------
 # THE sandbox root is caller-declared (CQLITE_PERF_TEST_SANDBOX) and must PROVE itself: an
-# absolute, canonically spelled, existing directory carrying the stamp file below. The
-# stamp is what makes the declaration unforgeable by environment alone — a stray
-# CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on
-# the FILESYSTEM and writing it into a system directory already needs the privilege this
-# guard protects. No denylist appears anywhere below: a path is usable because it is
-# provably INSIDE the sandbox, never because it failed to look like somewhere forbidden.
+# absolute, canonically spelled, existing directory carrying the stamp file below. The stamp is
+# what makes the declaration unforgeable by environment alone — a stray
+# CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on the
+# FILESYSTEM and writing it into a system directory already needs the privilege this guard
+# protects. No denylist appears below: a path is usable because it is provably INSIDE the
+# sandbox, never because it failed to look like somewhere forbidden.
 #
 # FIVE thin functions, ONE predicate — everything ends in perf_capability_path_within:
 #   sandbox_root_into O        the declared root, validated; rc 1 + empty when unproven
 #   path_within P R            THE predicate (below)
-#   sandbox_ok P               FORK-FREE entry point, for the gate's emit-time token chain
-#                              (contractually free of external processes AND command
-#                              substitutions): judges the SPELLING. Sound there because that
-#                              path only READS a caller-chosen file — its contract is "seams
-#                              are honoured only under the test marker, never set in
-#                              production" — so a mis-accepted spelling can at worst make the
-#                              token `absent`/`unknown`; it can never write.
-#   sandbox_ok_resolved P      for every path WRITTEN, or whose CONTENTS are read (host
-#                              configuration): canonicalizes candidate AND root (`.`, `..`,
-#                              symlinked ancestors and a `//`-rooted `pwd -P` answer all
-#                              included), then the SAME predicate. An unenterable path
-#                              resolves to nothing and is refused — fail-closed, and correct
-#                              for a write target, which must exist to be written into.
-#   sandbox_file_ok_resolved F the file form (the optional `sysctl.conf` entry): the PARENT is
-#                              canonicalized and the RESULTING FILE PATH is validated.
+#   sandbox_ok P               FORK-FREE entry point (the gate's emit-time token chain, which
+#                              may not fork): judges the SPELLING — sound there for the reason
+#                              in the fail-open audit's second residual above
+#   sandbox_ok_resolved P      every path WRITTEN, or whose CONTENTS are read: canonicalizes
+#                              candidate AND root, then the SAME predicate. An unenterable
+#                              path resolves to nothing and is refused — fail-closed, and
+#                              correct for a write target, which must exist to be written into
+#   sandbox_file_ok_resolved F the FILE form (the optional `sysctl.conf` entry): judged by
+#                              canonicalizing its PARENT, plus a plain-basename check
 # `cd -P` + `pwd -P` is the canonicalizer: one subshell, no external binary, correct on bash
 # 3.2 (no `realpath`, no `readlink -f` — absent or non-GNU on some supported hosts).
 PERF_CAPABILITY_SANDBOX_STAMP='.cqlite-perf-sandbox'
@@ -193,46 +182,35 @@ perf_capability_sandbox_ok() {
   perf_capability_path_within "${1:-}" "$__pso_root"
 }
 
-# the root CANONICALIZED, so both sides of a resolved containment test are in one form
-perf_capability_sandbox_root_resolved_into() {
-  local __prr_v=''
-  eval "$1="
-  perf_capability_sandbox_root_into __prr_v || return 1
-  __prr_v=$(cd -P -- "$__prr_v" 2>/dev/null && pwd -P) || return 1
-  eval "$1=\${__prr_v%/}"
-}
-
 perf_capability_sandbox_ok_resolved() {
   local __pdr_root='' __pdr_real=''
-  perf_capability_sandbox_root_resolved_into __pdr_root || return 1
+  perf_capability_sandbox_root_into __pdr_root || return 1
+  # BOTH sides canonicalized the same way, so the comparison is between destinations
+  __pdr_root=$(cd -P -- "$__pdr_root" 2>/dev/null && pwd -P) || return 1
   __pdr_real=$(cd -P -- "${1:-/dev/null/never}" 2>/dev/null && pwd -P) || return 1
-  perf_capability_path_within "$__pdr_real" "$__pdr_root"
+  perf_capability_path_within "$__pdr_real" "${__pdr_root%/}"
 }
 
 perf_capability_sandbox_file_ok_resolved() {
-  local __pfr_root='' __pfr_real='' __pfr_base=''
   case "${1:-}" in */?*) ;; *) return 1 ;; esac
-  __pfr_base="${1##*/}"
-  case "$__pfr_base" in ''|.|..) return 1 ;; esac
-  perf_capability_sandbox_root_resolved_into __pfr_root || return 1
-  __pfr_real=$(cd -P -- "${1%/*}" 2>/dev/null && pwd -P) || return 1
-  perf_capability_path_within "${__pfr_real%/}/$__pfr_base" "$__pfr_root"
+  case "${1##*/}" in ''|.|..) return 1 ;; esac
+  # the FILE path is judged by canonicalizing its PARENT: a canonical parent strictly inside
+  # the sandbox puts <parent>/<basename> strictly inside it too, for any plain basename.
+  perf_capability_sandbox_ok_resolved "${1%/*}"
 }
 
-# perf_capability_seam_refusal <VARNAME> <value> <root>: ONE message shape for both
-# mandatory seams. The refusal must NAME the offending seam — that is what makes it
-# actionable — so this is parameterised rather than duplicated per seam.
+# ONE message shape for both mandatory seams: the refusal must NAME the offending seam (that
+# is what makes it actionable), so it is parameterised rather than duplicated per seam.
 perf_capability_seam_refusal() {
   printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires %s INSIDE the declared sandbox %s — its RESOLVED destination (. / .. / // / symlinked ancestors and all) must be strictly contained there; got %s. Test mode NEVER falls back to the real directory.\n' \
     "${1:-<seam>}" "'${3:-}'" "'${2:-<unset>}'" >&2
 }
 
 # perf_capability_test_seams_ok: rc 0 iff test mode has a PROVEN sandbox root and BOTH
-# mandatory seams RESOLVING strictly inside it. This is the gate on every privileged
-# action below, so it takes the resolving form: refusing here is what stops a root `--yes`
-# test run from resolving a seam back into the production directory and overwriting the
-# host's own drop-in. Refuses loudly and names what failed, because the failure it
-# prevents is silent otherwise.
+# mandatory seams RESOLVING strictly inside it. This is the gate on every privileged action
+# below, so it takes the resolving form: refusing here is what stops a root `--yes` test run
+# from resolving a seam back into the production directory and overwriting the host's own
+# drop-in. It refuses loudly, because the failure it prevents is silent otherwise.
 perf_capability_test_seams_ok() {
   local ok=0 root=''
   if ! perf_capability_sandbox_root_into root; then
@@ -274,8 +252,8 @@ perf_capability_env_guard() {
       *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 with a reachable real %s and no absolute CQLITE_PERF_TEST_PRIV_DIR — test mode must PATH-shim every privileged tool.\n' "$tool" >&2
          return 1 ;;
     esac
-    # The same containment predicate as the seams, one level down: the tool must be
-    # strictly inside the DECLARED shim dir (not merely spelled that way).
+    # The seams' containment predicate, one level down: the tool must be strictly inside the
+    # DECLARED shim dir, not merely spelled that way.
     perf_capability_path_within "$resolved" "${dir%/}" || {
       printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
         "$tool" "$resolved" "$dir" >&2
@@ -319,11 +297,10 @@ perf_capability_proc_dir() {
   perf_capability_proc_dir_into __pcd_v || return 1
   printf '%s' "$__pcd_v"
 }
-# perf_capability_sysctl_dir: the sysctl.d directory — the WRITE side (a root `tee` is
-# pointed inside it) and the directory whose CONTENTS the competing-file scan reads, so it
-# takes the RESOLVING gate: the canonical DESTINATION is what gets written, not the
-# spelling. Every consumer of the sysctl.d location goes through this one function, so
-# there is exactly one place the check can be forgotten — and it is here.
+# perf_capability_sysctl_dir: the sysctl.d directory — the WRITE side (a root `tee` is aimed
+# inside it) and the directory whose CONTENTS the competing-file scan reads, so it takes the
+# RESOLVING gate. EVERY consumer of that location comes through this one function, so there is
+# exactly one place the check could be forgotten — and it is here.
 perf_capability_sysctl_dir() {
   if perf_capability_test_mode; then
     perf_capability_sandbox_ok_resolved "${CQLITE_PERF_SYSCTL_DIR:-}" || {
@@ -336,10 +313,10 @@ perf_capability_sysctl_dir() {
   fi
   printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
-# perf_capability_dropin_path: the path a root `tee` is pointed at. The containment gate
-# lives in perf_capability_sysctl_dir — the single place that directory comes from — and
-# it RESOLVES the destination, so there is deliberately no second copy of the check here:
-# one gate, not a prohibition a future entry point could skip (R6-2).
+# perf_capability_dropin_path: the path a root `tee` is pointed at. Its gate lives in
+# perf_capability_sysctl_dir (the single source of that directory) and RESOLVES the
+# destination, so there is deliberately no second copy here — one gate, not a prohibition a
+# future entry point could skip (R6-2).
 perf_capability_dropin_path() {
   local __pdi_d
   __pdi_d=$(perf_capability_sysctl_dir) || return 1
@@ -430,12 +407,10 @@ perf_capability_dropin_current() {
 # diagnostic exists to end.
 #
 # In TEST MODE the path is the sandbox seam plus the optional colon-separated
-# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, in the same descending
-# order): the real /run and /usr/lib are never read, so a case's verdict can never depend
-# on the host's own drop-ins. EVERY entry goes through the SAME RESOLVING gate as the
+# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, same descending order): the real
+# /run and /usr/lib are never read. EVERY entry goes through the SAME RESOLVING gate as the
 # write path (R6-2 — this entry point once used the syntactic one, so a symlinked ancestor
-# could point a "sandboxed" scan at the host's real configuration). A `sysctl.conf` entry
-# is a FILE, so its parent is canonicalized and the resulting file path validated.
+# could point a "sandboxed" scan at the host's real configuration).
 perf_capability_sysctl_search_path() {
   local __psp_d __psp_e __psp_ok
   if perf_capability_test_mode; then
@@ -464,9 +439,9 @@ perf_capability_sysctl_search_path() {
                 /lib/sysctl.d /etc/sysctl.conf
 }
 
-# perf_capability_file_sets_controls <path>: rc 0 iff the file ASSIGNS either control.
-# Both spellings sysctl accepts are matched (`kernel.x` and `kernel/x`, sysctl.d(5)) plus
-# the optional leading `-` ignore-failure prefix; a commented-out line assigns nothing.
+# rc 0 iff the file ASSIGNS either control. Both spellings sysctl accepts are matched
+# (`kernel.x` and `kernel/x`, sysctl.d(5)) plus the optional leading `-` ignore-failure
+# prefix; a commented-out line assigns nothing.
 perf_capability_file_sets_controls() {
   grep -Eq '^[[:space:]]*-?kernel[./](perf_event_paranoid|kptr_restrict)[[:space:]]*=' "$1" 2>/dev/null
 }
@@ -496,10 +471,9 @@ perf_capability_competing_files() {
   paths=$(perf_capability_sysctl_search_path) || return 1
   seen="$lf"
   # An entry that does not exist genuinely holds no competitor (skipped, no output — most
-  # boxes have no /run/sysctl.d at all). One that exists but cannot be READ is an UNKNOWN
-  # and returns rc 1, so the caller reports a failed scan instead of the reassuring "no
-  # competing file" — this diagnostic exists to replace an unknown with a named file, so
-  # it may not answer an unknown with good news.
+  # boxes have no /run/sysctl.d at all). One that exists but cannot be READ is an UNKNOWN and
+  # returns rc 1: this diagnostic exists to replace an unknown with a NAMED file, so it may
+  # not answer an unknown with the reassuring "no competing file".
   while IFS= read -r entry; do
     [ -n "$entry" ] || continue
     if [ "${entry##*/}" = sysctl.conf ]; then
@@ -514,9 +488,9 @@ perf_capability_competing_files() {
       [ -f "$f" ] && [ -r "$f" ] || continue
       name="${f##*/}"
       [ "$name" = "$base" ] && continue
-      # MASKING (see the precedence rules above): a higher-precedence directory already
-      # supplied this basename, so sysctl ignores THIS file entirely. Recorded BEFORE the
-      # content test, because a same-named file that sets nothing still masks one that does.
+      # MASKING (precedence rules above): a higher-precedence directory already supplied this
+      # basename, so sysctl ignores THIS file. Recorded BEFORE the content test, because a
+      # same-named file that sets nothing still masks one that does.
       case "$seen" in *"$lf$name$lf"*) continue ;; esac
       seen="$seen$name$lf"
       perf_capability_file_sets_controls "$f" || continue
@@ -562,8 +536,8 @@ perf_capability_proc_read() {
   eval "$__pcr_out=\$__pcr_v"
 }
 
-# perf_capability_proc_value <name>: the stdout form of the read above, for CLI and
-# bootstrap use (NOT the gate path — reading it costs the caller a `$( )`).
+# the stdout form of the read above, for CLI/bootstrap use — NOT the gate path (reading it
+# costs the caller a `$( )`).
 perf_capability_proc_value() {
   local __pcv_v
   perf_capability_proc_read __pcv_v "$1" || return 1
@@ -613,9 +587,8 @@ perf_capability_token_into() {
   eval "$__pct_out=ok"
 }
 
-# perf_capability_token: the stdout form, for the `--token` CLI and bootstrap. NOT the
-# gate path — reading stdout costs the caller a `$( )` fork, which is precisely what
-# the `_into` core above exists to avoid.
+# the stdout form, for the `--token` CLI and bootstrap. NOT the gate path — reading stdout
+# costs the caller the very `$( )` fork the `_into` core above exists to avoid.
 perf_capability_token() {
   local __ptk_v
   perf_capability_token_into __ptk_v
@@ -842,9 +815,9 @@ perf_capability_main() {
     --token)        perf_capability_token; printf '\n' ;;
     --verify)       local v rc=0; v=$(perf_capability_verify) || rc=1; printf '%s\n' "$v"; return $rc ;;
     --verify-unpriv)
-      # Identity-aware form: rc 0 requires BOTH a functional pass AND that the pass
-      # came from an unprivileged identity. A root run with no way to drop privilege
-      # reports its result AND that the result is not evidence about an agent process.
+      # rc 0 requires BOTH a functional pass AND that it came from an unprivileged
+      # identity: a root run with no way to drop privilege reports its result AND that
+      # the result is not evidence about an agent process.
       local pre='' state='' v rc=0 unpriv=0
       perf_capability_drop_prefix_into pre state && unpriv=1
       # shellcheck disable=SC2086  # deliberate split of our own literal prefix tokens
@@ -853,17 +826,16 @@ perf_capability_main() {
       [ "$unpriv" = 1 ] || rc=1
       return $rc ;;
     --drop-in)      perf_capability_dropin_content ;;
-    # rc PROPAGATED, never masked by the trailing newline: under an unsandboxed test
-    # mode the path cannot be resolved at all (R4-3), and a caller must see that as a
-    # failure rather than as an empty-but-successful answer.
+    # rc PROPAGATED, never masked by the trailing newline: an unsandboxed test mode can
+    # resolve no path at all (R4-3), and that is a failure, not an empty success.
     --drop-in-path) perf_capability_dropin_path || return 1; printf '\n' ;;
     -h|--help|'')   perf_capability_usage ;;
     *)              printf 'perf-capability: unknown arg: %s\n' "$1" >&2; perf_capability_usage >&2; return 2 ;;
   esac
 }
 
-# Executed directly (never when sourced): shell options are set HERE, inside the
-# guard, so sourcing can never change a caller's `set` flags.
+# Executed directly (never when sourced): shell options are set HERE, inside the guard, so
+# sourcing can never change a caller's `set` flags.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   set -uo pipefail
   perf_capability_main "$@"

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Shared harness for the PERF PROFILING CAPABILITY suites (issue #3249):
+#   scripts/tests/test_perf_capability.sh            — the helper's own contract
+#   scripts/tests/test_perf_capability_bootstrap.sh  — the bootstrap section end-to-end
+#
+# WHY A LIB. The two suites were one 1333-line file, over the ~800/~1500 campsite
+# targets and still growing a case per review round. They are split by RESPONSIBILITY
+# (helper unit contract vs bootstrap integration), and everything both need lives here
+# ONCE so the identity/platform stubs and the host-safety asserts can never drift apart
+# between them.
+#
+# HOST SAFETY IS THE POINT OF THIS FILE. Nothing in either suite may touch the real
+# /etc/sysctl.d or /proc: the two test-only env seams stand in (CQLITE_PERF_PROC_DIR,
+# CQLITE_PERF_SYSCTL_DIR), every privileged/mutating tool is a recording PATH shim, and
+# `perf_test_assert_host_clean` asserts the mutation-freedom directly at the end of each
+# suite. Since #3249 review R4-3 the seams are MANDATORY under the marker — test mode
+# refuses to fall back to a production directory — so a case that forgets one fails
+# closed and loudly instead of writing the host's real drop-in.
+#
+# Sourced, never executed. The sourcing suite must NOT have `set -e` (the cases test
+# failing commands on purpose); `set -uo pipefail` is what both use.
+
+PERF_TEST_LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT_DIR=$(cd "$PERF_TEST_LIB_DIR/.." && pwd)          # scripts/tests
+BOOTSTRAP="$SCRIPT_DIR/../bootstrap-agent-machine.sh"
+PERFLIB="$SCRIPT_DIR/../perf-capability.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# sudo_perf_offenders <tripwire-log>: the recorded `sudo` lines belonging to the PERF
+# path (its `-n` availability probe, its `tee`, its `sysctl`) that do NOT carry `-n`.
+# `-n` is what makes bootstrap unpromptable on an unattended worker, so dropping it
+# from PERF_ROOT is a defect every functional assert would still pass. Lines from other
+# bootstrap sections (e.g. the mold `sudo apt-get install`) are out of this issue's scope.
+sudo_perf_offenders() {
+  grep -E '^sudo ' "$1" 2>/dev/null | grep -E '(\btee\b|\bsysctl\b|\btrue\b)' | grep -v '^sudo -n ' || true
+}
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+# Reference file for the "did WE create the real /etc/sysctl.d drop-in?" attribution
+# in the host-clean assert: a plain `-nt` comparison against a file created NOW, so no
+# `stat -c %Y` (GNU-only) and no wall-clock arithmetic anywhere in these suites.
+suite_ref="$tmp/.suite-start"; : >"$suite_ref"
+
+# Global-state isolation, same posture as test_bootstrap_agent_machine.sh: the
+# bootstrap runs below read/write git config and read board env, and these suites run
+# inside `tooling-tests` on the very box hosting a live delivery session.
+export GIT_CONFIG_GLOBAL="$tmp/global-gitconfig"
+export GIT_CONFIG_NOSYSTEM=1
+: >"$GIT_CONFIG_GLOBAL"
+unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
+# A worker shell may export the seams themselves; a test must set exactly what it means.
+unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR
+# ...and so may a `sudo bash scripts/tests/...` invocation export SUDO_UID/GID/USER,
+# which the privilege-drop target resolution reads. A case that means to exercise that
+# path sets them itself; inheriting them would make the suite's verdict depend on how
+# it was launched (the same env-inheritance class as PERF_SECTION_OK).
+unset SUDO_UID SUDO_GID SUDO_USER
+# The section under test must never be steered by an ambient export either: bootstrap
+# initialises PERF_SECTION_OK itself, and the bootstrap suite proves it.
+unset PERF_SECTION_OK
+# The two path seams are INERT unless this marker is set; under the marker they are
+# MANDATORY, must be absolute and non-production, and a real sudo/sysctl on PATH is a
+# hard refusal (the shim dir is declared per case in CQLITE_PERF_TEST_PRIV_DIR). Cases
+# that must exercise the PRODUCTION defaults run with `env -u CQLITE_PERF_TEST_MODE`.
+export CQLITE_PERF_TEST_MODE=1
+
+# mkuname <dir> <sysname>: a `uname` stub, so the Linux/Darwin branch under test is
+# the one selected by the CASE, not by whatever host runs the suite. Without this the
+# whole suite was silently Linux-host-only: on a Darwin gate host every bootstrap run
+# would take the "nothing to configure on macos" path and 10 cases would fail.
+# `-r`/`-m` answer too, because bootstrap uses them elsewhere.
+mkuname() {
+  # rm FIRST: several dirs below `ln -sf` the real uname into place, and writing
+  # through that symlink would clobber the host's /usr/bin/uname.
+  rm -f "$1/uname"
+  cat >"$1/uname" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  -r) echo 6.0.0-cqlite-test ;;
+  -m) echo x86_64 ;;
+  *)  echo $2 ;;
+esac
+EOF
+  chmod +x "$1/uname"
+}
+
+# mkid <dir> <self-uid> [<other-uid>]: an `id` stub, so the ROOT / NON-ROOT branch
+# under test is the one selected by the CASE, not by whatever UID runs the suite.
+# Without this the suite was silently NON-ROOT-runner-only: nearly every case asserts
+# the unprivileged behaviour (a `sudo -n true` probe, a `sudo -n tee`, a printed `sudo`
+# remedy), so running the whole thing as root — a container, a CI image, anyone's
+# `sudo bash` — took the root branch and FAILED, reddening the mandatory
+# `tooling-tests` gate component. Same class as the Linux-host-only bug mkuname fixes,
+# and the same `rm -f` first: several dirs below `ln -sf` the real `id` into place, and
+# writing through that symlink would clobber the host's /usr/bin/id.
+#
+# <other-uid> answers a USER OPERAND (`id -u nobody` / `id -g nobody`), which the
+# privilege-drop target resolution asks for: a shim that answered its OWN uid there
+# would let a root case "resolve" root as the unprivileged probe identity — the exact
+# false verification the drop exists to prevent. Omitted => the operand form FAILS
+# (that box has no such account), which is the honest answer for a case that offers
+# no unprivileged identity.
+mkid() {
+  rm -f "$1/id"
+  cat >"$1/id" <<EOF
+#!/usr/bin/env bash
+other='${3:-}'
+case "\${1:-}" in
+  -u|-g)
+    if [ -n "\${2:-}" ]; then
+      [ -n "\$other" ] || exit 1        # no such account on this box
+      echo "\$other"
+    else
+      echo $2
+    fi ;;
+  -un|-nu) echo cqlite-test-user ;;
+  *)  echo $2 ;;
+esac
+EOF
+  chmod +x "$1/id"
+}
+
+# Inert shims for the tools the surrounding bootstrap sections would otherwise
+# reach (network / installs). Only the perf-specific shims below are functional.
+mkshim() {
+  local name="$1"
+  cat >"$tmp/$name" <<EOF
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$tmp/$name"
+}
+mkshim brew
+mkshim cargo
+mkshim roborev
+mkshim gh
+mkuname "$tmp" Linux   # every bootstrap run that includes $tmp in PATH is Linux
+mkid "$tmp" 1000       # ...and is a NON-ROOT runner, whatever UID runs the suite
+host_home="$tmp/host-home"; mkdir -p "$host_home/.cargo"
+
+# ---- the `perf` shims -------------------------------------------------------------
+# The FUNCTIONAL verification must be HONOURED, not merely attempted (the #3119 lesson
+# applied to this issue): `perf stat` exits 0 while printing `<not supported>` /
+# `<not counted>`, and a virtualised PMU can report a flat 0, so an rc-only check is
+# exactly the false green being fixed. Every negative case drives a shim that EXITS 0
+# with an unusable counter.
+perfbin="$tmp/perfbin"; mkdir -p "$perfbin"
+export PERFSHIM_LOG="$tmp/perfshim.log"; : >"$PERFSHIM_LOG"
+
+# mkperfshim <csv-count-field>: an rc-0 perf printing ONE cycles row with that count.
+mkperfshim() {
+  cat >"$perfbin/perf" <<EOF
+#!/usr/bin/env bash
+echo "perf \$*" >>"\$PERFSHIM_LOG"
+printf '%s\n' '$1,,cycles,100000000,100.00,,'
+exit 0
+EOF
+  chmod +x "$perfbin/perf"
+}
+
+# mkperfshim_raw <exit-code> <stdout-line>...: the general shim — an EXACT exit code
+# and arbitrary CSV rows (or none). The `perf stat` failure and empty-output paths are
+# the REAL states on an unbootstrapped box (paranoid=4 denies the syscall outright, so
+# perf exits non-zero), and every shim above exits 0 — so without this those two
+# branches were never driven and a mutation making either RETURN SUCCESS survived.
+mkperfshim_raw() {
+  local rc="$1"; shift
+  local data="$perfbin/perf.rows" line
+  : >"$data"
+  for line in "$@"; do printf '%s\n' "$line" >>"$data"; done
+  cat >"$perfbin/perf" <<EOF
+#!/usr/bin/env bash
+echo "perf \$*" >>"\$PERFSHIM_LOG"
+cat "$data"
+exit $rc
+EOF
+  chmod +x "$perfbin/perf"
+}
+
+# perf_test_assert_host_clean: nothing in the suite may have touched the REAL
+# /etc/sysctl.d. Run LAST by every suite that sources this lib — each suite asserts it
+# for itself, because "the other file checked it" is not a property either file can rely
+# on when they are run independently.
+perf_test_assert_host_clean() {
+  if [ ! -e /etc/sysctl.d/99-cqlite-perf.conf ] || [ -n "${CQLITE_PERF_ALLOW_REAL_DROPIN:-}" ]; then
+    ok "perf section: the suite never created the real /etc/sysctl.d/99-cqlite-perf.conf"
+  else
+    # Pre-existing on a bootstrapped box is legitimate; only report if WE made it.
+    # `-nt` against a file stamped at suite start — no GNU-only `stat -c %Y`.
+    if [ /etc/sysctl.d/99-cqlite-perf.conf -nt "$suite_ref" ]; then
+      bad "perf section: the suite wrote the REAL /etc/sysctl.d/99-cqlite-perf.conf"
+    else
+      ok "perf section: the real drop-in pre-dates this suite (not written by it)"
+    fi
+  fi
+}
+
+# perf_test_report: the trailing count line + the suite's exit status.
+perf_test_report() {
+  echo
+  echo "PASS=$PASS FAIL=$FAIL"
+  [ "$FAIL" -eq 0 ]
+}

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -42,10 +42,6 @@ sudo_perf_offenders() {
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-test.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT
-# Reference file for the "did WE create the real /etc/sysctl.d drop-in?" attribution
-# in the host-clean assert: a plain `-nt` comparison against a file created NOW, so no
-# `stat -c %Y` (GNU-only) and no wall-clock arithmetic anywhere in these suites.
-suite_ref="$tmp/.suite-start"; : >"$suite_ref"
 
 # Global-state isolation, same posture as test_bootstrap_agent_machine.sh: the
 # bootstrap runs below read/write git config and read board env, and these suites run
@@ -183,21 +179,46 @@ EOF
   chmod +x "$perfbin/perf"
 }
 
-# perf_test_assert_host_clean: nothing in the suite may have touched the REAL
-# /etc/sysctl.d. Run LAST by every suite that sources this lib — each suite asserts it
-# for itself, because "the other file checked it" is not a property either file can rely
-# on when they are run independently.
-perf_test_assert_host_clean() {
-  if [ ! -e /etc/sysctl.d/99-cqlite-perf.conf ] || [ -n "${CQLITE_PERF_ALLOW_REAL_DROPIN:-}" ]; then
-    ok "perf section: the suite never created the real /etc/sysctl.d/99-cqlite-perf.conf"
+# perf_test_real_dropin_state [path]: the content-AND-metadata identity of the REAL
+# managed drop-in, for a BEFORE/AFTER "this run changed nothing" comparison.
+#
+# WHY NOT "IT DOES NOT EXIST" (issue #3249 review R5-2). The obvious assertion — the real
+# /etc/sysctl.d/99-cqlite-perf.conf must not exist — is SELF-DEFEATING: the whole purpose
+# of this change is to install that file on the fleet, so the moment a host is legitimately
+# bootstrapped the mandatory `tooling-tests` gate component would go red on exactly the
+# machines where the feature WORKED. Hermeticity is "this run changed nothing", not "this
+# file has never existed", so it is asserted as a before/after comparison of the real path
+# (plus the tripwire proving no mutating command was invoked at all).
+# `ls -ldn` + the bytes, so a create, a delete, a content change and a mode/owner change
+# all show up; no GNU-only `stat -c`. The path is an argument so the comparator itself is
+# testable against a file the suite may legitimately write (case 6c).
+perf_test_real_dropin_state() {
+  local p="${1:-/etc/sysctl.d/99-cqlite-perf.conf}"
+  if [ -e "$p" ]; then
+    ls -ldn "$p" 2>/dev/null || printf 'unstatable\n'
+    cat "$p" 2>/dev/null || printf 'unreadable\n'
   else
-    # Pre-existing on a bootstrapped box is legitimate; only report if WE made it.
-    # `-nt` against a file stamped at suite start — no GNU-only `stat -c %Y`.
-    if [ /etc/sysctl.d/99-cqlite-perf.conf -nt "$suite_ref" ]; then
-      bad "perf section: the suite wrote the REAL /etc/sysctl.d/99-cqlite-perf.conf"
-    else
-      ok "perf section: the real drop-in pre-dates this suite (not written by it)"
-    fi
+    printf 'absent\n'
+  fi
+}
+
+# The real drop-in's state as it was when this suite STARTED — the baseline every
+# host-clean assertion compares against.
+perf_real_dropin_before="$tmp/.real-dropin-before"
+perf_test_real_dropin_state >"$perf_real_dropin_before" 2>/dev/null
+
+# perf_test_assert_host_clean: nothing in the suite may have CHANGED the real
+# /etc/sysctl.d drop-in. Run LAST by every suite that sources this lib — each suite
+# asserts it for itself, because "the other file checked it" is not a property either
+# file can rely on when they are run independently.
+perf_test_assert_host_clean() {
+  local after="$tmp/.real-dropin-after"
+  perf_test_real_dropin_state >"$after" 2>/dev/null
+  if cmp -s "$perf_real_dropin_before" "$after"; then
+    ok "perf section: the real /etc/sysctl.d/99-cqlite-perf.conf is byte- and metadata-identical to its pre-suite state (this suite changed nothing)"
+  else
+    bad "perf section: the suite CHANGED the real /etc/sysctl.d/99-cqlite-perf.conf (before/after differ)"
+    diff "$perf_real_dropin_before" "$after" 2>/dev/null | head -6
   fi
 }
 

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -18,13 +18,6 @@
 # refuses to fall back to a production directory — so a case that forgets one fails
 # closed and loudly instead of writing the host's real drop-in.
 #
-# ONE SANDBOX ROOT (review R6-1/R6-2). Every seam must now be provably INSIDE the declared
-# root CQLITE_PERF_TEST_SANDBOX, which is exported ONCE here as this suite's `$tmp` and
-# proves itself with the stamp file the helper looks for. That is why every seam a case sets
-# is a path under `$tmp`: containment is the whole check, so anything outside — `//etc`,
-# `/tmp/../etc/sysctl.d`, a symlinked ancestor, a relative path — is refused without the
-# helper needing to know the name of a single forbidden place.
-#
 # Sourced, never executed. The sourcing suite must NOT have `set -e` (the cases test
 # failing commands on purpose); `set -uo pipefail` is what both use.
 
@@ -58,7 +51,7 @@ export GIT_CONFIG_NOSYSTEM=1
 : >"$GIT_CONFIG_GLOBAL"
 unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
 # A worker shell may export the seams themselves; a test must set exactly what it means.
-unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_SYSCTL_EXTRA_DIRS
+unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR
 # ...and so may a `sudo bash scripts/tests/...` invocation export SUDO_UID/GID/USER,
 # which the privilege-drop target resolution reads. A case that means to exercise that
 # path sets them itself; inheriting them would make the suite's verdict depend on how
@@ -67,16 +60,11 @@ unset SUDO_UID SUDO_GID SUDO_USER
 # The section under test must never be steered by an ambient export either: bootstrap
 # initialises PERF_SECTION_OK itself, and the bootstrap suite proves it.
 unset PERF_SECTION_OK
-# The path seams are INERT unless this marker is set; under the marker they are MANDATORY,
-# must be provably INSIDE the declared sandbox root, and a real sudo/sysctl on PATH is a hard
-# refusal (the shim dir is declared per case in CQLITE_PERF_TEST_PRIV_DIR). Cases that must
-# exercise the PRODUCTION defaults run with `env -u CQLITE_PERF_TEST_MODE`.
+# The two path seams are INERT unless this marker is set; under the marker they are
+# MANDATORY, must be absolute and non-production, and a real sudo/sysctl on PATH is a
+# hard refusal (the shim dir is declared per case in CQLITE_PERF_TEST_PRIV_DIR). Cases
+# that must exercise the PRODUCTION defaults run with `env -u CQLITE_PERF_TEST_MODE`.
 export CQLITE_PERF_TEST_MODE=1
-# THE sandbox root for both suites, STAMPED so the helper can PROVE the declaration instead
-# of trusting the variable (a bare CQLITE_PERF_TEST_SANDBOX=/etc buys nothing without a stamp
-# that only privilege could place there). Every seam any case sets lives under it.
-export CQLITE_PERF_TEST_SANDBOX="$tmp"
-: >"$tmp/.cqlite-perf-sandbox"
 
 # mkuname <dir> <sysname>: a `uname` stub, so the Linux/Darwin branch under test is
 # the one selected by the CASE, not by whatever host runs the suite. Without this the

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -40,7 +40,27 @@ sudo_perf_offenders() {
   grep -E '^sudo ' "$1" 2>/dev/null | grep -E '(\btee\b|\bsysctl\b|\btrue\b)' | grep -v '^sudo -n ' || true
 }
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-test.XXXXXX")
+# `mktemp` IS A COMMAND THAT CAN FAIL, and these suites deliberately run WITHOUT
+# `set -e` (issue #3249 review R8-3). An unchecked `tmp=$(mktemp -d …)` that fails —
+# full/read-only $TMPDIR, a hostile PATH `mktemp`, a container out of inodes — leaves
+# `tmp` EMPTY while every path below is spelled "$tmp/…", so the very next lines would
+# write ROOT-LEVEL paths (/global-gitconfig, /perfbin, /perfshim.log, /host-home) and
+# the EXIT trap would `rm -rf ""`. These suites run in the MANDATORY `tooling-tests`
+# gate component, sometimes under a root identity, so that is host damage caused by a
+# test run. Four things must hold — rc 0, non-empty, absolute, and actually a
+# directory — or NOTHING happens at all. `exit`, not `return`: this file is sourced by
+# a suite with no `set -e`, where a `return 1` would be ignored and execution would
+# continue with the empty `tmp` this guard exists to stop.
+# Observed firing: case 1x of scripts/tests/test_perf_capability.sh drives both
+# failure shapes (non-zero rc, and rc 0 with empty output) and asserts no root-level
+# path is created.
+if ! tmp=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-test.XXXXXX"); then tmp=''; fi
+case "$tmp" in /*) ;; *) tmp='' ;; esac
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  printf 'perf-capability-test-lib: REFUSING TO RUN (reason: unusable-temp-dir): `mktemp -d` did not yield an existing absolute directory (got %s). Every path in these suites is "$tmp/...", so continuing would write ROOT-LEVEL paths on a box that may be running this suite as root. Check TMPDIR=%s.\n' \
+    "'${tmp:-<empty>}'" "'${TMPDIR:-/tmp}'" >&2
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT
 
 # Global-state isolation, same posture as test_bootstrap_agent_machine.sh: the

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -18,6 +18,13 @@
 # refuses to fall back to a production directory — so a case that forgets one fails
 # closed and loudly instead of writing the host's real drop-in.
 #
+# ONE SANDBOX ROOT (review R6-1/R6-2). Every seam must now be provably INSIDE the declared
+# root CQLITE_PERF_TEST_SANDBOX, which is exported ONCE here as this suite's `$tmp` and
+# proves itself with the stamp file the helper looks for. That is why every seam a case sets
+# is a path under `$tmp`: containment is the whole check, so anything outside — `//etc`,
+# `/tmp/../etc/sysctl.d`, a symlinked ancestor, a relative path — is refused without the
+# helper needing to know the name of a single forbidden place.
+#
 # Sourced, never executed. The sourcing suite must NOT have `set -e` (the cases test
 # failing commands on purpose); `set -uo pipefail` is what both use.
 
@@ -51,7 +58,7 @@ export GIT_CONFIG_NOSYSTEM=1
 : >"$GIT_CONFIG_GLOBAL"
 unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
 # A worker shell may export the seams themselves; a test must set exactly what it means.
-unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR
+unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_SYSCTL_EXTRA_DIRS
 # ...and so may a `sudo bash scripts/tests/...` invocation export SUDO_UID/GID/USER,
 # which the privilege-drop target resolution reads. A case that means to exercise that
 # path sets them itself; inheriting them would make the suite's verdict depend on how
@@ -60,11 +67,16 @@ unset SUDO_UID SUDO_GID SUDO_USER
 # The section under test must never be steered by an ambient export either: bootstrap
 # initialises PERF_SECTION_OK itself, and the bootstrap suite proves it.
 unset PERF_SECTION_OK
-# The two path seams are INERT unless this marker is set; under the marker they are
-# MANDATORY, must be absolute and non-production, and a real sudo/sysctl on PATH is a
-# hard refusal (the shim dir is declared per case in CQLITE_PERF_TEST_PRIV_DIR). Cases
-# that must exercise the PRODUCTION defaults run with `env -u CQLITE_PERF_TEST_MODE`.
+# The path seams are INERT unless this marker is set; under the marker they are MANDATORY,
+# must be provably INSIDE the declared sandbox root, and a real sudo/sysctl on PATH is a hard
+# refusal (the shim dir is declared per case in CQLITE_PERF_TEST_PRIV_DIR). Cases that must
+# exercise the PRODUCTION defaults run with `env -u CQLITE_PERF_TEST_MODE`.
 export CQLITE_PERF_TEST_MODE=1
+# THE sandbox root for both suites, STAMPED so the helper can PROVE the declaration instead
+# of trusting the variable (a bare CQLITE_PERF_TEST_SANDBOX=/etc buys nothing without a stamp
+# that only privilege could place there). Every seam any case sets lives under it.
+export CQLITE_PERF_TEST_SANDBOX="$tmp"
+: >"$tmp/.cqlite-perf-sandbox"
 
 # mkuname <dir> <sysname>: a `uname` stub, so the Linux/Darwin branch under test is
 # the one selected by the CASE, not by whatever host runs the suite. Without this the

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -30,6 +30,10 @@ PASS=0
 FAIL=0
 ok()   { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad()  { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+# A case whose PROPERTY IS UNOBSERVABLE on this box (a Linux-only kernel control on
+# Darwin, an unreadable /proc entry) is reported as a SKIP — counted in neither total,
+# so it can never be mistaken for a passing assertion (issue #3249 AC3).
+skipped() { printf 'skip - %s\n' "$1"; }
 
 # assert_complete <label> <file>: file must contain start marker, end marker,
 # RESULT line, and a representative stage line.
@@ -1084,6 +1088,51 @@ for pair in "ok:$perf_fixture_ok" "paranoid-4:$perf_fixture_p4"; do
   assert_perf_token "perf-real-$want" "$real_file" "$want"
   assert_accelerators "perf-real-$want" "$real_file"
 done
+
+# 9f-host. THE HOST'S OWN /proc, WITH NO SEAM SET AT ALL (issue #3249 AC3(a)). Every
+#          case above — 9f-real included — sets the LIBRARY's fixture seams
+#          (CQLITE_PERF_TEST_MODE + CQLITE_PERF_PROC_DIR), so they prove the production
+#          BRANCH runs but not that it reads this box's real kernel state. Here every
+#          seam the code reads is unset (the five CQLITE_PERF_* seams plus both
+#          AGENT_GATE_TEST_* forcings), so the token can only come from
+#          /proc/sys/kernel. The expectation is DERIVED from the box's own two controls
+#          by the documented rule and asserted as an EXACT whole-field token — never
+#          hardcoded to `ok` (a paranoid-4 box MUST fail this case if the gate claims
+#          otherwise) and never as a member of the alternation (which every state
+#          satisfies). Skipped, not passed, off Linux or when a control is unreadable:
+#          a case that cannot observe the property must say so, not bank a green.
+perf_host_par_f=/proc/sys/kernel/perf_event_paranoid
+perf_host_kptr_f=/proc/sys/kernel/kptr_restrict
+perf_host_os=$(uname -s 2>/dev/null || echo unknown)
+if [ "$perf_host_os" != Linux ]; then
+  skipped "perf-host: host is $perf_host_os, not Linux — perf_event_paranoid/kptr_restrict are Linux controls (9f-darwin covers the no-token contract)"
+elif [ ! -r "$perf_host_par_f" ] || [ ! -r "$perf_host_kptr_f" ]; then
+  skipped "perf-host: $perf_host_par_f / $perf_host_kptr_f unreadable on this box — no real state to derive an expectation from"
+else
+  perf_host_par=$(tr -d '[:space:]' <"$perf_host_par_f")
+  perf_host_kptr=$(tr -d '[:space:]' <"$perf_host_kptr_f")
+  # The rule, from openspec/specs/agent-fleet-runtime/spec.md: paranoid <= 0 AND kptr == 0
+  # => ok; paranoid >= 1 => paranoid-<N>; else kptr != 0 => kptr-restricted.
+  if ! printf '%s' "$perf_host_par" | grep -Eq '^-?[0-9]+$' \
+     || ! printf '%s' "$perf_host_kptr" | grep -Eq '^-?[0-9]+$'; then
+    perf_host_want=unknown
+  elif [ "$perf_host_par" -ge 1 ]; then
+    perf_host_want="paranoid-$perf_host_par"
+  elif [ "$perf_host_kptr" -ne 0 ]; then
+    perf_host_want=kptr-restricted
+  else
+    perf_host_want=ok
+  fi
+  perf_host_file="$tmp/perf-host.txt"
+  env -u AGENT_GATE_TEST_PERF_STATE -u AGENT_GATE_TEST_OS \
+      -u CQLITE_PERF_TEST_MODE -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR \
+      -u CQLITE_PERF_SYSCTL_EXTRA_DIRS -u CQLITE_PERF_TEST_PRIV_DIR \
+      AGENT_GATE_SUMMARY_FILE="$perf_host_file" \
+      bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+  assert_perf_token "perf-host (real /proc: paranoid=$perf_host_par kptr=$perf_host_kptr, no seam set)" \
+    "$perf_host_file" "$perf_host_want"
+  assert_accelerators "perf-host" "$perf_host_file"
+fi
 
 # 9f-free. The gate's emit-time perf path is documented as FREE — in the code, in
 #          openspec/specs/agent-fleet-runtime/spec.md, in gate-contract.md and in

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1085,17 +1085,122 @@ for pair in "ok:$perf_fixture_ok" "paranoid-4:$perf_fixture_p4"; do
   assert_accelerators "perf-real-$want" "$real_file"
 done
 
-# 9f-free. The gate's token must stay a FREE /proc read: if it ever grew a `perf
-#          stat` exec, every gate on every box would pay a new subprocess (and a new
-#          binary dependency) for a diagnostic line. Assert BOTH directions —
-#          structurally, that the gate's token function does not exec perf, and
-#          behaviourally, that a run emits the token its /proc fixture implies with
-#          `perf` REMOVED from PATH (which an exec-based implementation could not do).
-perf_fn_body=$(sed -n '/^_perf_state()/,/^}/p;/^_perf_accel_token()/,/^}/p' "$GATE")
-if [ -n "$perf_fn_body" ] && ! body_mentions "$perf_fn_body" 'perf stat'; then
-  ok "perf-free: the gate's token functions never exec 'perf stat' (free /proc read only)"
+# 9f-free. The gate's emit-time perf path is documented as FREE — in the code, in
+#          openspec/specs/agent-fleet-runtime/spec.md, in gate-contract.md and in
+#          gate-ops.md: no `perf` exec, NO EXTERNAL PROCESS AT ALL, and no command
+#          substitution. That last clause is not pedantry: a `$( )` forks a subshell,
+#          so a "no subprocess" claim whose value is read back through one is
+#          self-contradictory — and the original assert here only rejected a literal
+#          `perf stat`, so the claim shipped UNENFORCED while the path in fact forked
+#          several `$( )` per emit and re-sourced the 300-line helper each time.
+#          THE STATED COST IS ZERO: zero external processes, zero command
+#          substitutions, one source of the helper per gate RUN (not per emit).
+#          Asserted three ways below, because each catches a different regression.
+PERF_LIB="$(dirname "$GATE")/perf-capability.sh"
+
+# fn_text <file> <name>: a function's verbatim definition text, whether written as a
+# single line (`f() { …; }`) or a block ending in a column-0 `}`. Empty output means
+# NOT FOUND, which the asserts treat as a FAILURE — a renamed function must never drop
+# out of this audit silently.
+fn_text() {
+  awk -v n="$2" '
+    index($0, n "()") == 1 {
+      print
+      if ($0 ~ /\}[[:space:]]*$/) exit
+      inb = 1; next
+    }
+    inb { print; if ($0 ~ /^\}/) exit }
+  ' "$1"
+}
+
+# The FULL emit-time path: the gate's two token functions plus every helper function
+# they reach. Enumerated explicitly so the audit is a closed set, not a guess.
+perf_path_text=""
+perf_path_missing=""
+for _fn in _perf_state_into _perf_accel_token_into; do
+  _t=$(fn_text "$GATE" "$_fn")
+  [ -n "$_t" ] || perf_path_missing="$perf_path_missing $_fn"
+  perf_path_text="$perf_path_text$_t
+"
+done
+for _fn in perf_capability_token_into perf_capability_proc_read \
+           perf_capability_proc_dir_into perf_capability_test_mode \
+           perf_capability_seam_set perf_capability_is_int; do
+  _t=$(fn_text "$PERF_LIB" "$_fn")
+  [ -n "$_t" ] || perf_path_missing="$perf_path_missing $_fn"
+  perf_path_text="$perf_path_text$_t
+"
+done
+if [ -z "$perf_path_missing" ]; then
+  ok "perf-free: every function on the emit-time perf path was located (closed audit set)"
 else
-  bad "perf-free: the gate's perf token function execs perf stat (or was not found)"
+  bad "perf-free: perf-path function(s) not found — renamed without updating this audit?$perf_path_missing"
+fi
+# (a) STATIC: the whole path contains ZERO command substitutions and ZERO backticks.
+#     Counted (not merely grepped) so the failure message states the real number
+#     against the documented one.
+perf_subs=$(printf '%s\n' "$perf_path_text" | grep -o '\$(' | wc -l | tr -d ' ')
+perf_ticks=$(printf '%s\n' "$perf_path_text" | grep -o '`' | wc -l | tr -d ' ')
+if [ "$perf_subs" -eq 0 ] && [ "$perf_ticks" -eq 0 ]; then
+  ok "perf-free: the emit-time perf path contains 0 command substitutions (documented cost: 0)"
+else
+  bad "perf-free: the emit-time perf path forks $perf_subs command substitution(s) + $perf_ticks backtick(s) — documented cost is 0; either remove them or correct the claim in the code comment, the spec, gate-contract.md and gate-ops.md"
+fi
+if ! body_mentions "$perf_path_text" 'perf stat'; then
+  ok "perf-free: the emit-time perf path never execs 'perf stat' (free /proc read only)"
+else
+  bad "perf-free: the emit-time perf path execs perf stat"
+fi
+# ...and the 300-line helper is sourced ONCE at script scope, not from inside the
+# per-emit path (a per-emit source re-reads the file on every summary).
+if grep -q '^_PERF_CAP_LOADED=' "$GATE" \
+   && ! body_mentions "$perf_path_text" 'perf-capability.sh'; then
+  ok "perf-free: the helper is sourced once at script scope, never from the per-emit path"
+else
+  bad "perf-free: the perf helper is (re-)sourced inside the per-emit path, or the script-scope load flag is gone"
+fi
+# ...and the call site must consume the token through a VARIABLE: reading
+# `$(_perf_accel_token)` there would reintroduce the very fork the path excludes.
+accel_fn_text=$(fn_text "$GATE" accelerators_line)
+if printf '%s' "$accel_fn_text" | grep -q '_perf_accel_token_into' \
+   && ! printf '%s' "$accel_fn_text" | grep -q '\$(_perf_accel_token\|`_perf_accel_token'; then
+  ok "perf-free: accelerators_line consumes the perf token through a variable, not a subshell"
+else
+  bad "perf-free: accelerators_line reads the perf token through a command substitution"
+fi
+# (b) RUNTIME: run the gate's OWN extracted path with an EMPTY PATH (so ANY external
+#     command fails loudly) and with xtrace stamping ${BASH_SUBSHELL} (so ANY subshell
+#     — command substitution, pipeline, `( )` — is visible). A static scan can be
+#     fooled by an indirection; this cannot. Correct token + no subshell + no failed
+#     exec is the whole claim, executed.
+perf_probe="$tmp/perf-free-probe.sh"
+{
+  printf '%s\n' 'set -uo pipefail'
+  printf '%s\n' '. "$1"'
+  fn_text "$GATE" _perf_state_into
+  fn_text "$GATE" _perf_accel_token_into
+  printf '%s\n' '_PERF_CAP_LOADED=1'
+  printf '%s\n' '_AGENT_GATE_OS=Linux'
+  printf '%s\n' 'tok=""'
+  printf '%s\n' 'PATH=""'
+  printf '%s\n' "PS4='+SUB\${BASH_SUBSHELL} '"
+  printf '%s\n' 'set -x'
+  printf '%s\n' '_perf_accel_token_into tok'
+  printf '%s\n' 'set +x'
+  printf '%s\n' 'printf "TOKEN[%s]\n" "$tok"'
+} >"$perf_probe"
+perf_trace="$tmp/perf-free-trace.txt"
+perf_probe_out=$(env -u AGENT_GATE_TEST_PERF_STATE -u AGENT_GATE_TEST_OS \
+  CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_PROC_DIR="$perf_fixture_p4" \
+  bash "$perf_probe" "$PERF_LIB" 2>"$perf_trace")
+perf_probe_subshells=$(grep -c 'SUB[1-9]' "$perf_trace" 2>/dev/null || true)
+perf_probe_execfail=$(grep -c 'No such file or directory\|command not found' "$perf_trace" 2>/dev/null || true)
+if [ "$perf_probe_out" = 'TOKEN[ perf=paranoid-4]' ] \
+   && [ "${perf_probe_subshells:-0}" -eq 0 ] && [ "${perf_probe_execfail:-0}" -eq 0 ]; then
+  ok "perf-free: the extracted path yields perf=paranoid-4 with an EMPTY PATH and spawns 0 subshells (xtrace-verified)"
+else
+  bad "perf-free: runtime probe failed (out='$perf_probe_out' subshells=$perf_probe_subshells exec-failures=$perf_probe_execfail)"
+  head -20 "$perf_trace"
 fi
 perf_nopath="$tmp/perf-nopath.txt"
 nopath_dir="$tmp/nopath-bin"; mkdir -p "$nopath_dir"

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1034,7 +1034,7 @@ AGENT_GATE_SUMMARY_FILE="$mold_darwin" \
 assert_mold_token "mold-darwin" "$mold_darwin" none
 assert_accelerators "mold-darwin" "$mold_darwin"
 
-# 9e. perf profiling capability token (issue #3249). Boxes ship with
+# 9f. perf profiling capability token (issue #3249). Boxes ship with
 #     kernel.perf_event_paranoid = 4, which denies ALL unprivileged perf use — a
 #     PERMISSION verdict that reads like a missing CAPABILITY, and one that reverts
 #     on reboot when no /etc/sysctl.d drop-in exists. The token makes "this box
@@ -1051,7 +1051,7 @@ for state in ok paranoid-4 paranoid-2 kptr-restricted absent unknown; do
   assert_accelerators "perf-linux-$state" "$perf_file"
 done
 
-# 9e-darwin. perf_event_paranoid/kptr_restrict are Linux kernel controls, so Darwin
+# 9f-darwin. perf_event_paranoid/kptr_restrict are Linux kernel controls, so Darwin
 #            emits NO perf token even with a forced state — its line still ends at
 #            sccache-health, byte-identical to pre-#3249 output.
 perf_darwin="$tmp/perf-darwin.txt"
@@ -1061,12 +1061,36 @@ AGENT_GATE_SUMMARY_FILE="$perf_darwin" \
 assert_perf_token "perf-darwin" "$perf_darwin" none
 assert_accelerators "perf-darwin" "$perf_darwin"
 
-# 9e-free. The gate's token must stay a FREE /proc read: if it ever grew a `perf
+# 9f-real. REAL detection, NO AGENT_GATE_TEST_PERF_STATE: the production branch of
+#          _perf_state, reading an actual /proc directory. Without this every case
+#          above set the test seam, so hardcoding `_PERF_STATE="ok"` — a gate stamping
+#          `perf=ok` on a paranoid-4 box, exactly what AC3 exists to prevent — passed
+#          the whole suite, and so did forcing the real branch to always yield
+#          `unknown`. The fixture is scripts/perf-capability.sh's own test seam, which
+#          is inert without its hermetic marker.
+perf_fixture_ok="$tmp/perf-proc-ok"; mkdir -p "$perf_fixture_ok"
+printf -- '-1\n' >"$perf_fixture_ok/perf_event_paranoid"
+printf '0\n'     >"$perf_fixture_ok/kptr_restrict"
+perf_fixture_p4="$tmp/perf-proc-p4"; mkdir -p "$perf_fixture_p4"
+printf '4\n' >"$perf_fixture_p4/perf_event_paranoid"
+printf '1\n' >"$perf_fixture_p4/kptr_restrict"
+for pair in "ok:$perf_fixture_ok" "paranoid-4:$perf_fixture_p4"; do
+  want="${pair%%:*}"; fixture="${pair#*:}"
+  real_file="$tmp/perf-real-$want.txt"
+  env -u AGENT_GATE_TEST_PERF_STATE \
+    AGENT_GATE_SUMMARY_FILE="$real_file" AGENT_GATE_TEST_OS=Linux \
+    CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_PROC_DIR="$fixture" \
+    bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+  assert_perf_token "perf-real-$want" "$real_file" "$want"
+  assert_accelerators "perf-real-$want" "$real_file"
+done
+
+# 9f-free. The gate's token must stay a FREE /proc read: if it ever grew a `perf
 #          stat` exec, every gate on every box would pay a new subprocess (and a new
 #          binary dependency) for a diagnostic line. Assert BOTH directions —
 #          structurally, that the gate's token function does not exec perf, and
-#          behaviourally, that a run emits a real token with `perf` REMOVED from PATH
-#          (which an exec-based implementation could not do).
+#          behaviourally, that a run emits the token its /proc fixture implies with
+#          `perf` REMOVED from PATH (which an exec-based implementation could not do).
 perf_fn_body=$(sed -n '/^_perf_state()/,/^}/p;/^_perf_accel_token()/,/^}/p' "$GATE")
 if [ -n "$perf_fn_body" ] && ! body_mentions "$perf_fn_body" 'perf stat'; then
   ok "perf-free: the gate's token functions never exec 'perf stat' (free /proc read only)"
@@ -1079,15 +1103,15 @@ for t in bash sed awk grep cat env date mktemp uname tr cut sort head tail wc gi
   src=$(command -v "$t" 2>/dev/null) && ln -sf "$src" "$nopath_dir/$t"
 done
 (
-  PATH="$nopath_dir" AGENT_GATE_SUMMARY_FILE="$perf_nopath" AGENT_GATE_TEST_OS=Linux \
+  env -u AGENT_GATE_TEST_PERF_STATE PATH="$nopath_dir" \
+    AGENT_GATE_SUMMARY_FILE="$perf_nopath" AGENT_GATE_TEST_OS=Linux \
+    CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_PROC_DIR="$perf_fixture_p4" \
     bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
 )
-if [ -s "$perf_nopath" ] && grep -qE '^accelerators: .* perf=(ok|kptr-restricted|absent|unknown|paranoid-[0-9]+)' "$perf_nopath"; then
-  ok "perf-free: a real perf token is stamped with no 'perf' binary on PATH (no exec dependency)"
-else
-  bad "perf-free: no perf token stamped without the perf binary on PATH"
-  grep '^accelerators:' "$perf_nopath" 2>/dev/null || cat "$perf_nopath" 2>/dev/null
-fi
+# Asserted as an EXACT whole-field value (not a `.*` presence grep that any state
+# would satisfy — including the `unknown`/`absent` states a broken read produces).
+assert_perf_token "perf-nopath" "$perf_nopath" paranoid-4
+assert_accelerators "perf-nopath" "$perf_nopath"
 
 # 9e. REAL detection (NO AGENT_GATE_TEST_MOLD_STATE override): exercise the actual
 #     `command -v mold` + `_mold_block_active` + RUSTFLAGS branches. A stub `mold` is

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1067,7 +1067,12 @@ assert_accelerators "perf-darwin" "$perf_darwin"
 #          `perf=ok` on a paranoid-4 box, exactly what AC3 exists to prevent — passed
 #          the whole suite, and so did forcing the real branch to always yield
 #          `unknown`. The fixture is scripts/perf-capability.sh's own test seam, which
-#          is inert without its hermetic marker.
+#          is inert without its hermetic marker — and which, since #3249 review R6-1/R6-2,
+#          must be provably INSIDE a declared, STAMPED sandbox root. This suite's `$tmp` is
+#          that root (every fixture below lives under it), so an out-of-sandbox seam — the
+#          real /proc included — cannot steer these cases.
+export CQLITE_PERF_TEST_SANDBOX="$tmp"
+: >"$tmp/.cqlite-perf-sandbox"
 perf_fixture_ok="$tmp/perf-proc-ok"; mkdir -p "$perf_fixture_ok"
 printf -- '-1\n' >"$perf_fixture_ok/perf_event_paranoid"
 printf '0\n'     >"$perf_fixture_ok/kptr_restrict"
@@ -1123,10 +1128,15 @@ for _fn in _perf_state_into _perf_accel_token_into; do
   perf_path_text="$perf_path_text$_t
 "
 done
+# The containment gate reached from here is the SYNTACTIC one and its two builtin-only
+# helpers (#3249 review R6-1/R6-2). Its resolving sibling — perf_capability_sandbox_ok_resolved
+# — canonicalizes with `$(cd -P …)` and is deliberately NOT on this path: naming it here would
+# be the tell that a fork had been introduced into the emit chain.
 for _fn in perf_capability_token_into perf_capability_proc_read \
            perf_capability_proc_dir_into perf_capability_test_mode \
            perf_capability_seam_set perf_capability_is_int \
-           perf_capability_test_dir_valid; do
+           perf_capability_sandbox_ok perf_capability_sandbox_root_into \
+           perf_capability_path_within; do
   _t=$(fn_text "$PERF_LIB" "$_fn")
   [ -n "$_t" ] || perf_path_missing="$perf_path_missing $_fn"
   perf_path_text="$perf_path_text$_t

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1125,7 +1125,8 @@ for _fn in _perf_state_into _perf_accel_token_into; do
 done
 for _fn in perf_capability_token_into perf_capability_proc_read \
            perf_capability_proc_dir_into perf_capability_test_mode \
-           perf_capability_seam_set perf_capability_is_int; do
+           perf_capability_seam_set perf_capability_is_int \
+           perf_capability_test_dir_valid; do
   _t=$(fn_text "$PERF_LIB" "$_fn")
   [ -n "$_t" ] || perf_path_missing="$perf_path_missing $_fn"
   perf_path_text="$perf_path_text$_t

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1168,12 +1168,20 @@ if printf '%s' "$accel_fn_text" | grep -q '_perf_accel_token_into' \
 else
   bad "perf-free: accelerators_line reads the perf token through a command substitution"
 fi
-# (b) RUNTIME: run the gate's OWN extracted path with an EMPTY PATH (so ANY external
-#     command fails loudly) and with xtrace stamping ${BASH_SUBSHELL} (so ANY subshell
-#     — command substitution, pipeline, `( )` — is visible). A static scan can be
-#     fooled by an indirection; this cannot. Correct token + no subshell + no failed
-#     exec is the whole claim, executed.
+# (b) RUNTIME: run the gate's OWN extracted path with PATH pointing at a NONEXISTENT
+#     directory (so no external command can resolve) and with xtrace stamping
+#     ${BASH_SUBSHELL} (so ANY subshell — command substitution, pipeline, `( )` — is
+#     visible). A static scan can be fooled by an indirection; this cannot. Correct
+#     token + no subshell + no attempted exec is the whole claim, executed.
+#     Every attempted exec is recorded by `command_not_found_handle`, which appends to
+#     a FILE — deliberately NOT to stderr, because a `2>/dev/null` on the offending
+#     line inside the code under test hides a stderr-only signal completely (measured:
+#     a `id -u >/dev/null 2>&1` mutation was invisible until this handler existed).
+#     PATH must name a MISSING DIRECTORY, not be empty: an empty PATH is one empty
+#     element = the current directory, so bash tries `./id`, reports ENOENT and never
+#     consults the handler. bash 4+; on bash 3.2 the xtrace/stderr grep still fires.
 perf_probe="$tmp/perf-free-probe.sh"
+perf_extlog="$tmp/perf-free-external.txt"; : >"$perf_extlog"
 {
   printf '%s\n' 'set -uo pipefail'
   printf '%s\n' '. "$1"'
@@ -1182,7 +1190,8 @@ perf_probe="$tmp/perf-free-probe.sh"
   printf '%s\n' '_PERF_CAP_LOADED=1'
   printf '%s\n' '_AGENT_GATE_OS=Linux'
   printf '%s\n' 'tok=""'
-  printf '%s\n' 'PATH=""'
+  printf 'command_not_found_handle() { printf "EXTERNAL:%%s\\n" "$1" >>"%s"; return 127; }\n' "$perf_extlog"
+  printf 'PATH=%s\n' "$tmp/perf-free-no-such-bin"
   printf '%s\n' "PS4='+SUB\${BASH_SUBSHELL} '"
   printf '%s\n' 'set -x'
   printf '%s\n' '_perf_accel_token_into tok'
@@ -1195,11 +1204,13 @@ perf_probe_out=$(env -u AGENT_GATE_TEST_PERF_STATE -u AGENT_GATE_TEST_OS \
   bash "$perf_probe" "$PERF_LIB" 2>"$perf_trace")
 perf_probe_subshells=$(grep -c 'SUB[1-9]' "$perf_trace" 2>/dev/null || true)
 perf_probe_execfail=$(grep -c 'No such file or directory\|command not found' "$perf_trace" 2>/dev/null || true)
+perf_probe_ext=$(grep -c '^EXTERNAL:' "$perf_extlog" 2>/dev/null || true)
 if [ "$perf_probe_out" = 'TOKEN[ perf=paranoid-4]' ] \
-   && [ "${perf_probe_subshells:-0}" -eq 0 ] && [ "${perf_probe_execfail:-0}" -eq 0 ]; then
-  ok "perf-free: the extracted path yields perf=paranoid-4 with an EMPTY PATH and spawns 0 subshells (xtrace-verified)"
+   && [ "${perf_probe_subshells:-0}" -eq 0 ] && [ "${perf_probe_execfail:-0}" -eq 0 ] \
+   && [ "${perf_probe_ext:-0}" -eq 0 ]; then
+  ok "perf-free: the extracted path yields perf=paranoid-4 with an unresolvable PATH, 0 subshells and 0 external commands (xtrace + not-found-handler verified)"
 else
-  bad "perf-free: runtime probe failed (out='$perf_probe_out' subshells=$perf_probe_subshells exec-failures=$perf_probe_execfail)"
+  bad "perf-free: runtime probe failed (out='$perf_probe_out' subshells=$perf_probe_subshells exec-failures=$perf_probe_execfail external=$perf_probe_ext: $(head -3 "$perf_extlog" | tr '\n' ' '))"
   head -20 "$perf_trace"
 fi
 perf_nopath="$tmp/perf-nopath.txt"

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -77,7 +77,11 @@ trap 'rm -rf "$tmp"' EXIT
 #     which names the offending line and points here. That is loud and uniform by
 #     design — one grammar to extend, not N per-token asserts to chase. Do NOT relax
 #     it to a `.*` tail; that is the failure mode this design prevents.
-ACCEL_LINE_RE='^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial) sccache-health=(na|ok|warn)( mold=(linked|overridden|present-unconfigured|absent))?$'
+# The ` perf=` group (issue #3249) is appended AFTER the optional ` mold=` group,
+# because that is the order accelerators_line emits them; both are Linux-only and
+# therefore both are optional here, so a Darwin line (which ends at
+# sccache-health) and a Linux line (which carries both) satisfy one grammar.
+ACCEL_LINE_RE='^accelerators: sccache=(on|absent|off) nextest=(on|absent|off) lanes=(on|absent|off|serial) sccache-health=(na|ok|warn)( mold=(linked|overridden|present-unconfigured|absent))?( perf=(ok|kptr-restricted|absent|unknown|paranoid-[0-9]+))?$'
 
 # accel_line_of <file>: print the FIRST `accelerators: ` line of <file> (rc 0), or
 # print nothing (rc 1). `grep -m1` + capture-to-a-variable, deliberately with NO
@@ -144,6 +148,10 @@ accel_token_is() {
 # by the 9c-iv regression guard, which must assert both the TRUE and the FALSE outcome.
 mold_token_is()          { accel_token_is "$1" mold "$2"; }
 accel_health_token_is()  { accel_token_is "$1" sccache-health "$2"; }
+# perf_token_is: the same tier-1 whole-field idiom for the ` perf=` token (#3249).
+# Today it is the LAST token, i.e. the most exposed to the next appended one — so it
+# is built from accel_token_is rather than an end-anchored match, by construction.
+perf_token_is()          { accel_token_is "$1" perf "$2"; }
 
 # assert_mold_token <label> <file> <expected>: assert the accelerators line's mold
 # token (issue #2859). <expected> is a state (linked|present-unconfigured|absent)
@@ -160,6 +168,25 @@ assert_mold_token() {
     ok "$label: mold=$expected present"
   else
     bad "$label: expected mold=$expected, got: '$line'"
+  fi
+}
+
+# assert_perf_token <label> <file> <expected>: assert the accelerators line's perf
+# capability token (issue #3249). <expected> is a state
+# (ok|paranoid-<N>|kptr-restricted|absent|unknown) or the literal "none" to require
+# NO perf token (the Darwin contract — perf_event_paranoid is a Linux control).
+assert_perf_token() {
+  local label="$1" file="$2" expected="$3" line
+  line=$(accel_line_of "$file")
+  if [ "$expected" = none ]; then
+    case " $line " in
+      *" perf="*) bad "$label: perf token present but expected none ($line)" ;;
+      *)          ok  "$label: no perf token (Darwin contract)" ;;
+    esac
+  elif perf_token_is "$file" "$expected"; then
+    ok "$label: perf=$expected present"
+  else
+    bad "$label: expected perf=$expected, got: '$line'"
   fi
 }
 
@@ -913,23 +940,24 @@ fi
 #        could ever legitimately ship as an accelerator token: a plausible name (say
 #        `lto=thin`) would turn this guard into a false accusation on the day someone
 #        correctly adds that token AND extends $ACCEL_LINE_RE.
-#        The base fixture forces OS=Linux + mold=linked + sccache-health=ok so the
-#        line deterministically carries BOTH tier-1 tokens on any host, and the
-#        sentinel lands immediately after ` mold=` — the position tomorrow's token
-#        will actually occupy.
+#        The base fixture forces OS=Linux + mold=linked + perf=ok +
+#        sccache-health=ok so the line deterministically carries EVERY tier-1 token
+#        on any host, and the sentinel lands immediately after the CURRENT last
+#        token (` perf=` since #3249) — the position tomorrow's token will actually
+#        occupy. When a token is appended, move this expectation to the new last one.
 FUTURE_TOKEN='__unknown-future-token__=x'
 future_base="$tmp/health-future-base.txt"
 future_accel="$tmp/health-future-token.txt"
 AGENT_GATE_SUMMARY_FILE="$future_base" \
-  AGENT_GATE_TEST_OS=Linux AGENT_GATE_TEST_MOLD_STATE=linked \
+  AGENT_GATE_TEST_OS=Linux AGENT_GATE_TEST_MOLD_STATE=linked AGENT_GATE_TEST_PERF_STATE=ok \
   AGENT_GATE_TEST_SCCACHE_STATE=on AGENT_GATE_TEST_SCCACHE_ERRORS=0 \
   bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
 # The UNMUTATED base must satisfy the grammar — otherwise the canary below would be
 # "armed" by a pre-existing defect rather than by the synthesized token.
 assert_accelerators "accel-future-token-base" "$future_base"
 sed "s/^accelerators: .*/& $FUTURE_TOKEN/" "$future_base" >"$future_accel"
-if grep -qF " mold=linked $FUTURE_TOKEN" "$future_accel"; then
-  ok "accel-future-token: guard fixture really carries an unknown token after ' mold='"
+if grep -qF " perf=ok $FUTURE_TOKEN" "$future_accel"; then
+  ok "accel-future-token: guard fixture really carries an unknown token after the last known token"
 else
   bad "accel-future-token: guard fixture did not gain a trailing token (guard is vacuous)"
   grep '^accelerators:' "$future_accel" 2>/dev/null || cat "$future_accel"
@@ -943,6 +971,8 @@ else
   grep '^accelerators:' "$future_accel" 2>/dev/null || cat "$future_accel"
 fi
 assert_mold_token "accel-future-token" "$future_accel" linked
+# ...and the CURRENT last token, the one most exposed to an appended sibling (#3249).
+assert_perf_token "accel-future-token" "$future_accel" ok
 # ...and neither may have been weakened into accepting a WRONG value, nor a value of
 # which the truth is a prefix/superstring. Tolerating a new token != tolerating a
 # bad token value. (The negative direction is asserted through the same predicates
@@ -960,8 +990,14 @@ for wrong in absent overridden present-unconfigured linke linkedx; do
     wrong_val_ok=0
   fi
 done
+for wrong in absent unknown kptr-restricted paranoid-4 o okx; do
+  if perf_token_is "$future_accel" "$wrong"; then
+    bad "accel-future-token: perf assert wrongly matched perf=$wrong (value check weakened)"
+    wrong_val_ok=0
+  fi
+done
 if [ "$wrong_val_ok" -eq 1 ]; then
-  ok "accel-future-token: wrong/partial health+mold values still FAIL (values matched exactly)"
+  ok "accel-future-token: wrong/partial health+mold+perf values still FAIL (values matched exactly)"
 fi
 # Tier 2: the whole-line grammar is the canary and must REJECT the unknown token, so
 # a future token addition reddens the assert_accelerators call sites with an
@@ -997,6 +1033,61 @@ AGENT_GATE_SUMMARY_FILE="$mold_darwin" \
   bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
 assert_mold_token "mold-darwin" "$mold_darwin" none
 assert_accelerators "mold-darwin" "$mold_darwin"
+
+# 9e. perf profiling capability token (issue #3249). Boxes ship with
+#     kernel.perf_event_paranoid = 4, which denies ALL unprivileged perf use — a
+#     PERMISSION verdict that reads like a missing CAPABILITY, and one that reverts
+#     on reboot when no /etc/sysctl.d drop-in exists. The token makes "this box
+#     cannot be profiled" visible in every pasted SUMMARY. Linux-only, same
+#     contract as mold: NO token on Darwin. State forced via
+#     AGENT_GATE_TEST_PERF_STATE so every value asserts deterministically
+#     regardless of the host's real sysctls.
+for state in ok paranoid-4 paranoid-2 kptr-restricted absent unknown; do
+  perf_file="$tmp/perf-$state.txt"
+  AGENT_GATE_SUMMARY_FILE="$perf_file" \
+    AGENT_GATE_TEST_OS=Linux AGENT_GATE_TEST_MOLD_STATE=linked AGENT_GATE_TEST_PERF_STATE="$state" \
+    bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+  assert_perf_token "perf-linux-$state" "$perf_file" "$state"
+  assert_accelerators "perf-linux-$state" "$perf_file"
+done
+
+# 9e-darwin. perf_event_paranoid/kptr_restrict are Linux kernel controls, so Darwin
+#            emits NO perf token even with a forced state — its line still ends at
+#            sccache-health, byte-identical to pre-#3249 output.
+perf_darwin="$tmp/perf-darwin.txt"
+AGENT_GATE_SUMMARY_FILE="$perf_darwin" \
+  AGENT_GATE_TEST_OS=Darwin AGENT_GATE_TEST_MOLD_STATE=linked AGENT_GATE_TEST_PERF_STATE=ok \
+  bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+assert_perf_token "perf-darwin" "$perf_darwin" none
+assert_accelerators "perf-darwin" "$perf_darwin"
+
+# 9e-free. The gate's token must stay a FREE /proc read: if it ever grew a `perf
+#          stat` exec, every gate on every box would pay a new subprocess (and a new
+#          binary dependency) for a diagnostic line. Assert BOTH directions —
+#          structurally, that the gate's token function does not exec perf, and
+#          behaviourally, that a run emits a real token with `perf` REMOVED from PATH
+#          (which an exec-based implementation could not do).
+perf_fn_body=$(sed -n '/^_perf_state()/,/^}/p;/^_perf_accel_token()/,/^}/p' "$GATE")
+if [ -n "$perf_fn_body" ] && ! body_mentions "$perf_fn_body" 'perf stat'; then
+  ok "perf-free: the gate's token functions never exec 'perf stat' (free /proc read only)"
+else
+  bad "perf-free: the gate's perf token function execs perf stat (or was not found)"
+fi
+perf_nopath="$tmp/perf-nopath.txt"
+nopath_dir="$tmp/nopath-bin"; mkdir -p "$nopath_dir"
+for t in bash sed awk grep cat env date mktemp uname tr cut sort head tail wc git printf sleep python3 rm mv cp mkdir touch dirname basename find id hostname stat diff; do
+  src=$(command -v "$t" 2>/dev/null) && ln -sf "$src" "$nopath_dir/$t"
+done
+(
+  PATH="$nopath_dir" AGENT_GATE_SUMMARY_FILE="$perf_nopath" AGENT_GATE_TEST_OS=Linux \
+    bash "$GATE" --emit-summary-selftest >/dev/null 2>&1
+)
+if [ -s "$perf_nopath" ] && grep -qE '^accelerators: .* perf=(ok|kptr-restricted|absent|unknown|paranoid-[0-9]+)' "$perf_nopath"; then
+  ok "perf-free: a real perf token is stamped with no 'perf' binary on PATH (no exec dependency)"
+else
+  bad "perf-free: no perf token stamped without the perf binary on PATH"
+  grep '^accelerators:' "$perf_nopath" 2>/dev/null || cat "$perf_nopath" 2>/dev/null
+fi
 
 # 9e. REAL detection (NO AGENT_GATE_TEST_MOLD_STATE override): exercise the actual
 #     `command -v mold` + `_mold_block_active` + RUSTFLAGS branches. A stub `mold` is

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1067,12 +1067,7 @@ assert_accelerators "perf-darwin" "$perf_darwin"
 #          `perf=ok` on a paranoid-4 box, exactly what AC3 exists to prevent — passed
 #          the whole suite, and so did forcing the real branch to always yield
 #          `unknown`. The fixture is scripts/perf-capability.sh's own test seam, which
-#          is inert without its hermetic marker — and which, since #3249 review R6-1/R6-2,
-#          must be provably INSIDE a declared, STAMPED sandbox root. This suite's `$tmp` is
-#          that root (every fixture below lives under it), so an out-of-sandbox seam — the
-#          real /proc included — cannot steer these cases.
-export CQLITE_PERF_TEST_SANDBOX="$tmp"
-: >"$tmp/.cqlite-perf-sandbox"
+#          is inert without its hermetic marker.
 perf_fixture_ok="$tmp/perf-proc-ok"; mkdir -p "$perf_fixture_ok"
 printf -- '-1\n' >"$perf_fixture_ok/perf_event_paranoid"
 printf '0\n'     >"$perf_fixture_ok/kptr_restrict"
@@ -1128,15 +1123,10 @@ for _fn in _perf_state_into _perf_accel_token_into; do
   perf_path_text="$perf_path_text$_t
 "
 done
-# The containment gate reached from here is the SYNTACTIC one and its two builtin-only
-# helpers (#3249 review R6-1/R6-2). Its resolving sibling — perf_capability_sandbox_ok_resolved
-# — canonicalizes with `$(cd -P …)` and is deliberately NOT on this path: naming it here would
-# be the tell that a fork had been introduced into the emit chain.
 for _fn in perf_capability_token_into perf_capability_proc_read \
            perf_capability_proc_dir_into perf_capability_test_mode \
            perf_capability_seam_set perf_capability_is_int \
-           perf_capability_sandbox_ok perf_capability_sandbox_root_into \
-           perf_capability_path_within; do
+           perf_capability_test_dir_valid; do
   _t=$(fn_text "$PERF_LIB" "$_fn")
   [ -n "$_t" ] || perf_path_missing="$perf_path_missing $_fn"
   perf_path_text="$perf_path_text$_t

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -121,6 +121,21 @@ check_token 2 0 paranoid-2
 check_token -1 1 kptr-restricted
 check_token 0 2 kptr-restricted
 check_token garbage 0 unknown
+# A malformed or oversized value must NOT slip past the `>= 1` comparison and be
+# reported as `ok`: `[ 1abc -ge 1 ]` / `[ 99999999999999999999999 -ge 1 ]` do not
+# compare — they print "integer expression expected" and return FALSE.
+check_token '1abc' 0 unknown
+check_token 99999999999999999999999 0 unknown
+check_token -1 '0x0' unknown
+# ...and that rejection must be SILENT: this runs inside the gate's summary emit,
+# where a stray stderr line lands in the gate's own output.
+noise=$(printf '1abc\n' >"$perfproc/perf_event_paranoid"; printf '0\n' >"$perfproc/kptr_restrict"
+  CQLITE_PERF_PROC_DIR="$perfproc" bash "$PERFLIB" --token 2>&1 >/dev/null)
+if [ -z "$noise" ]; then
+  ok "perf-capability: a malformed /proc value is rejected SILENTLY (no stderr noise)"
+else
+  bad "perf-capability: malformed value leaked to stderr: $noise"
+fi
 if [ "$tok_fail" -eq 0 ]; then
   ok "perf-capability: token reflects /proc exactly (ok / paranoid-N / kptr-restricted / unknown)"
 fi

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -241,24 +241,24 @@ fi
 noseam_out=$(env -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_TEST_MODE=1 \
   bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); noseam_rc=$?
 if [ "$noseam_rc" -ne 0 ] \
-   && printf '%s' "$noseam_out" | grep -q 'requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR' \
-   && printf '%s' "$noseam_out" | grep -q 'requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR' \
+   && printf '%s' "$noseam_out" | grep -q 'requires CQLITE_PERF_PROC_DIR INSIDE the declared sandbox' \
+   && printf '%s' "$noseam_out" | grep -q 'requires CQLITE_PERF_SYSCTL_DIR INSIDE the declared sandbox' \
    && printf '%s' "$noseam_out" | grep -q 'NEVER falls back'; then
   ok "perf-capability: test mode with NO path seams REFUSES loudly and names BOTH missing sandbox dirs"
 else
   bad "perf-capability: test mode without seams was allowed to act (rc=$noseam_rc, out='$noseam_out')"
 fi
-# A seam pointing AT production (or anywhere under /etc, /proc, /sys) is the same hole
-# wearing a seam, and a RELATIVE path is not a sandbox either.
-# Each rejection is asserted BY ITS REASON, not merely by a non-zero rc: this guard has a
-# second refusal (a real sudo/sysctl on PATH) that would otherwise satisfy an rc-only
-# check and let a seam-validation regression pass unnoticed.
+# A seam pointing AT production (or anywhere under /etc, /proc, /sys) is refused because it
+# is not inside the sandbox — no forbidden name is consulted — and a RELATIVE path is not a
+# sandbox path either. Each rejection is asserted BY ITS REASON, not merely by a non-zero rc:
+# this guard has a second refusal (a real sudo/sysctl on PATH) that would otherwise satisfy
+# an rc-only check and let a containment regression pass unnoticed.
 guard_rejects_seam() { # guard_rejects_seam <which:PROC|SYSCTL> <proc-seam> <sysctl-seam>
   local out
   out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
           CQLITE_PERF_PROC_DIR="$2" CQLITE_PERF_SYSCTL_DIR="$3" \
           bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1) && return 1
-  printf '%s' "$out" | grep -q "NON-PRODUCTION CQLITE_PERF_${1}_DIR"
+  printf '%s' "$out" | grep -q "CQLITE_PERF_${1}_DIR INSIDE the declared sandbox"
 }
 for badseam in /etc/sysctl.d /etc/sysctl.d/sub /etc /proc /proc/sys/kernel /sys relative/dir ''; do
   guard_rejects_seam SYSCTL "$seamed_proc" "$badseam" || {
@@ -275,20 +275,70 @@ guard_rejects_seam SYSCTL "$seamed_proc" "$symseam" || {
   bad "perf-capability: test mode ACCEPTED a sysctl seam that is a SYMLINK to /etc/sysctl.d"; badseam_fail=1; }
 guard_rejects_seam PROC "$symproc" "$seamed_d" || {
   bad "perf-capability: test mode ACCEPTED a proc seam that is a SYMLINK to /proc/sys/kernel"; badseam_fail=1; }
-# ...and the SPELLING is not the destination (issue #3249 review R5-1): `/tmp/../etc/sysctl.d`
-# and `<symlink-to-/etc>/sysctl.d` pass every textual test above, and a root `--yes` run
-# resolves BOTH to the production directory. Each escape so far was one more spelling of
-# "somewhere else", so the write-side guard now judges the CANONICAL destination. An
-# UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
+# ...and the SPELLING is not the destination. `/tmp/../etc/sysctl.d`, `<symlink-to-/etc>/…`
+# and — the R6-1 escape — `//etc/sysctl.d` (POSIX leaves two leading slashes
+# implementation-defined and `pwd -P` may PRESERVE them, while on Linux `//etc` IS `/etc`)
+# each passed the textual checks of an earlier round. There is no per-spelling check any
+# more: containment refuses all of them, plus every future spelling, for the SAME reason.
+# An UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
 symanc="$tmp/symlinked-ancestor"; rm -f "$symanc"; ln -s /etc "$symanc"
+symout="$tmp/symlink-out-of-sandbox"; rm -f "$symout"; ln -s /tmp "$symout"
 for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d" "$tmp/./nonexistent-sandbox.d" \
-                   "$tmp/no-such-sandbox.d"; do
+                   "$tmp/no-such-sandbox.d" "//etc/sysctl.d" "//etc/sysctl.d/sub" \
+                   "$symout" "$tmp"; do
   guard_rejects_seam SYSCTL "$seamed_proc" "$resolveseam" || {
-    bad "perf-capability: test mode ACCEPTED a sysctl seam that RESOLVES outside its sandbox: '$resolveseam'"; badseam_fail=1; }
+    bad "perf-capability: test mode ACCEPTED a sysctl seam that is not strictly inside its sandbox: '$resolveseam'"; badseam_fail=1; }
 done
-guard_rejects_seam PROC "$symanc/sysctl.d" "$seamed_d" || {
-  bad "perf-capability: test mode ACCEPTED a proc seam with a SYMLINKED ANCESTOR into /etc"; badseam_fail=1; }
-[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam AND one that merely RESOLVES into production (.. or a symlinked ancestor), on BOTH sandbox dirs, naming the offending seam"
+for resolveseam in "$symanc/sysctl.d" "//proc/sys/kernel" "$symout"; do
+  guard_rejects_seam PROC "$resolveseam" "$seamed_d" || {
+    bad "perf-capability: test mode ACCEPTED a proc seam outside its sandbox: '$resolveseam'"; badseam_fail=1; }
+done
+[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam, one that RESOLVES out of the sandbox (.., a symlinked ancestor, a symlink to /tmp), the '//etc' double-slash spelling, a sibling-prefix path and the sandbox ROOT itself — on BOTH sandbox dirs, naming the offending seam"
+# 1c-iii-b. THE CONTAINMENT BOUNDARY AND THE SANDBOX ROOT ITSELF (issue #3249 review
+#           R6-1/R6-2). Containment is only as good as its boundary and its root:
+#             * `/tmp/sandboxevil` must NOT count as inside `/tmp/sandbox` — a plain string
+#               prefix would accept it, which is why the `/` boundary is explicit;
+#             * a path genuinely inside the declared root must still WORK, so the guard is
+#               not vacuously refusing everything (the failure mode a negative-only test
+#               cannot see);
+#             * the ROOT must PROVE itself — unset, relative, `//`-spelled, non-existent, or
+#               an existing directory with no stamp are all refusals NAMING
+#               CQLITE_PERF_TEST_SANDBOX. Without that, `CQLITE_PERF_TEST_SANDBOX=/etc`
+#               would make containment vacuous, and the inversion would have bought nothing.
+sbx="$tmp/sandbox"; mkdir -p "$sbx/inside" "$sbx/inside-proc"; : >"$sbx/.cqlite-perf-sandbox"
+mkdir -p "${sbx}evil"                       # the sibling whose NAME starts with the root's
+nostamp="$tmp/unstamped-root"; mkdir -p "$nostamp/inside"
+guard_with_root() { # guard_with_root <sandbox-root> <proc-seam> <sysctl-seam> -> rc + stderr
+  # $realpriv FIRST on PATH with the same dir declared: the guard's OTHER refusal (a real
+  # sudo/sysctl reachable) must not be what decides these cases.
+  env PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
+    CQLITE_PERF_TEST_SANDBOX="$1" CQLITE_PERF_PROC_DIR="$2" CQLITE_PERF_SYSCTL_DIR="$3" \
+    bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1
+}
+bnd_fail=0
+guard_with_root "$sbx" "$sbx/inside-proc" "$sbx/inside" >/dev/null 2>&1 \
+  || { bad "perf-capability: a seam genuinely INSIDE the declared sandbox was refused (the guard is vacuous)"; bnd_fail=1; }
+bnd_out=$(guard_with_root "$sbx" "$sbx/inside-proc" "${sbx}evil") && bnd_fail=1
+printf '%s' "$bnd_out" | grep -q 'CQLITE_PERF_SYSCTL_DIR INSIDE the declared sandbox' || bnd_fail=1
+[ "$bnd_fail" -eq 0 ] || bad "perf-capability: '${sbx}evil' was treated as inside '$sbx' (prefix match without a / boundary), or a contained seam was refused"
+[ "$bnd_fail" -ne 0 ] || ok "perf-capability: containment is boundary-exact — a seam inside the declared sandbox is ACCEPTED while the sibling '<root>evil' is REFUSED by name"
+root_fail=0
+for badroot in '' relative/sandbox "//$tmp" "$tmp/no-such-root" "$nostamp"; do
+  ro=$(guard_with_root "$badroot" "$sbx/inside-proc" "$sbx/inside") && root_fail=1
+  printf '%s' "$ro" | grep -q 'requires CQLITE_PERF_TEST_SANDBOX' || root_fail=1
+  [ "$root_fail" -eq 0 ] || { bad "perf-capability: sandbox root '$badroot' was accepted (or refused without naming CQLITE_PERF_TEST_SANDBOX)"; break; }
+done
+[ "$root_fail" -ne 0 ] || ok "perf-capability: the sandbox ROOT must prove itself — unset/relative/'//'-spelled/absent/UNSTAMPED are refusals naming CQLITE_PERF_TEST_SANDBOX (so a stray CQLITE_PERF_TEST_SANDBOX=/etc cannot make containment vacuous)"
+# ...and the FORK-FREE read path applies the same containment: a `//`-spelled or
+# out-of-sandbox proc seam reads NOTHING (token `absent`), never the host's real /proc —
+# whose paranoid/kptr values would otherwise show up as ok/paranoid-N/kptr-restricted here.
+read_fail=0
+for badproc in "//proc/sys/kernel" "$symanc/sysctl.d" "/proc/sys/kernel" "${sbx}evil"; do
+  rt=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$sbx" \
+         CQLITE_PERF_PROC_DIR="$badproc" bash "$PERFLIB" --token 2>/dev/null)
+  [ "$rt" = absent ] || { bad "perf-capability: the read path used an out-of-sandbox proc seam '$badproc' (token '$rt', expected 'absent')"; read_fail=1; }
+done
+[ "$read_fail" -ne 0 ] || ok "perf-capability: the fork-free READ path refuses an out-of-sandbox proc seam (including the '//proc' spelling) — token 'absent', the real /proc never read"
 # ...and the write TARGET is re-validated independently of the guard: --drop-in-path may
 # never NAME a production file, because that string is what a root `tee` is pointed at.
 for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d"; do
@@ -547,17 +597,24 @@ if printf '%s\n' "$sp_out" | grep -q "^earlier $sp_hi/10-hardening.conf$" \
 else
   bad "perf-capability: search-path scan wrong: '$sp_out'"
 fi
-# ...and an EXTRA-DIRS entry that is not an absolute non-production path fails the whole
-# scan CLOSED (rc 1, no output): a test-mode scan may never read the host's real /run or
-# /usr/lib, and a bad entry is an UNKNOWN, not "no competitor".
-for spbad in /etc/sysctl.d relative/dir "/tmp/../etc/sysctl.d"; do
+# ...and an EXTRA-DIRS entry that is not provably inside the sandbox fails the whole scan
+# CLOSED (rc 1, no output): a test-mode scan may never read the host's real /run or /usr/lib,
+# and a bad entry is an UNKNOWN, not "no competitor". THIS ENTRY POINT IS R6-2: it used the
+# textual validator while the write path canonicalized, so a SYMLINKED ANCESTOR (and the
+# `//etc` spelling) could point a "sandboxed" scan at the host's real configuration. It now
+# goes through the same resolving gate — dirs and the `sysctl.conf` FILE entry alike.
+for spbad in /etc/sysctl.d relative/dir "/tmp/../etc/sysctl.d" "//etc/sysctl.d" \
+             "$symanc/sysctl.d" "$symanc/sysctl.conf" "$symout" "$tmp/../etc/sysctl.d"; do
+  sp_this=0
   sp_bad_out=$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$sp_hi" \
     CQLITE_PERF_SYSCTL_EXTRA_DIRS="$spbad" \
-    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null) && sp_bad_fail=1
-  [ -z "$sp_bad_out" ] || sp_bad_fail=1
-  [ -z "${sp_bad_fail:-}" ] || bad "perf-capability: a production/relative CQLITE_PERF_SYSCTL_EXTRA_DIRS entry '$spbad' did not fail the scan closed"
+    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null) && sp_this=1
+  # No output at all, and in particular NOT ONE host path: this is the "no host file read"
+  # half of the property, so it is asserted rather than inferred from the rc.
+  [ -z "$sp_bad_out" ] || sp_this=1
+  [ "$sp_this" -eq 0 ] || { bad "perf-capability: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry '$spbad' did not fail the scan closed (out='$sp_bad_out')"; sp_bad_fail=1; }
 done
-[ -n "${sp_bad_fail:-}" ] || ok "perf-capability: a production-shaped/relative/resolving-into-production extra search-path entry fails the scan CLOSED (rc 1, no output)"
+[ -n "${sp_bad_fail:-}" ] || ok "perf-capability: an extra search-path entry outside the sandbox — production-shaped, relative, '//etc'-spelled, or reached through a SYMLINKED ANCESTOR (dir or sysctl.conf FILE) — fails the scan CLOSED (rc 1, no output, no host path named)"
 # ...and an UNREADABLE directory is an UNKNOWN (rc 1), never "no competing file": this
 # diagnostic exists to replace an unknown with a named file, so answering an unknown with
 # the reassuring line would recreate the mystery it was written to end.
@@ -713,6 +770,62 @@ else
     *no-perf-binary*) ok "perf-capability: verify fails with 'no-perf-binary' when perf is absent" ;;
     *) bad "perf-capability: unexpected no-perf verdict: $noperf_out" ;;
   esac
+fi
+
+# 1f. THE GATE IS SINGULAR AND UNSKIPPABLE — a STRUCTURAL audit (issue #3249 review R6-2).
+#     R6-2 was not a wrong check, it was a MISSING one: CQLITE_PERF_SYSCTL_EXTRA_DIRS was a
+#     new seam consumer, and the canonicalizing validation added for the write path simply
+#     never reached it. No behavioural case can catch that class, because the defect is a
+#     path nobody thought to test. So this audit enumerates, FROM THE SOURCE, every function
+#     that dereferences a seam variable and requires each one to route through the
+#     containment family (`perf_capability_sandbox_*` / `perf_capability_path_within`) — with
+#     ONE named, justified allowlist entry. A future entry point that reads a seam without
+#     the gate FAILS here, and joining the allowlist is a visible, reviewable act.
+#
+#     Same shape as the fork-free audit in test_agent_gate_summary.sh: parse the function
+#     bodies (a column-0 `name() {` … column-0 `}`), and treat FINDING NOTHING as a failure,
+#     so a parser that stops matching can never pass this vacuously.
+seam_audit=$(awk \
+  -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX)' \
+  -v gatere='perf_capability_(sandbox_|path_within)' '
+  /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
+    fn = $1; sub(/\(\)$/, "", fn); seam = 0; gate = 0
+    if ($0 ~ seamre) seam = 1
+    if ($0 ~ gatere) gate = 1
+    if ($0 ~ /\}[[:space:]]*$/) { printf "%s %d %d\n", fn, seam, gate; inb = 0 }
+    else inb = 1
+    next
+  }
+  inb && /^\}/ { printf "%s %d %d\n", fn, seam, gate; inb = 0; next }
+  inb {
+    if ($0 ~ seamre) seam = 1
+    if ($0 ~ gatere) gate = 1
+  }
+' "$PERFLIB")
+# The ONLY function allowed to read a seam without the gate, and why: it asks whether a seam
+# was handed to us AT ALL (for the marker-less refusal) and never uses the value as a path.
+# The containment family's own root reader is the gate, so it is named here too.
+seam_audit_allow=' perf_capability_seam_set perf_capability_sandbox_root_into '
+seam_consumers=0; seam_ungated=''
+while read -r fn seam gate; do
+  [ -n "$fn" ] || continue
+  [ "$seam" = 1 ] || continue
+  seam_consumers=$((seam_consumers + 1))
+  case "$seam_audit_allow" in *" $fn "*) continue ;; esac
+  [ "$gate" = 1 ] || seam_ungated="$seam_ungated $fn"
+done <<EOF
+$seam_audit
+EOF
+# 4 is the count at the time of writing (proc_dir_into, sysctl_dir, sysctl_search_path,
+# test_seams_ok) plus the two allowlisted readers; the assert is a FLOOR, so adding a
+# consumer is fine and losing the parse is not.
+if [ "$seam_consumers" -ge 5 ] && [ -z "$seam_ungated" ] \
+   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_sysctl_search_path 1 1$' \
+   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_proc_dir_into 1 1$'; then
+  ok "perf-capability: STRUCTURAL — all $seam_consumers seam-dereferencing functions route through the single containment gate (only the documented presence-check + the root reader are allowlisted), so a new entry point cannot silently skip it"
+else
+  bad "perf-capability: STRUCTURAL audit failed — seam consumers found: $seam_consumers; UNGATED:${seam_ungated:- none}"
+  printf '%s\n' "$seam_audit"
 fi
 
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -275,7 +275,31 @@ guard_rejects_seam SYSCTL "$seamed_proc" "$symseam" || {
   bad "perf-capability: test mode ACCEPTED a sysctl seam that is a SYMLINK to /etc/sysctl.d"; badseam_fail=1; }
 guard_rejects_seam PROC "$symproc" "$seamed_d" || {
   bad "perf-capability: test mode ACCEPTED a proc seam that is a SYMLINK to /proc/sys/kernel"; badseam_fail=1; }
-[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam on BOTH sandbox dirs, naming the offending seam"
+# ...and the SPELLING is not the destination (issue #3249 review R5-1): `/tmp/../etc/sysctl.d`
+# and `<symlink-to-/etc>/sysctl.d` pass every textual test above, and a root `--yes` run
+# resolves BOTH to the production directory. Each escape so far was one more spelling of
+# "somewhere else", so the write-side guard now judges the CANONICAL destination. An
+# UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
+symanc="$tmp/symlinked-ancestor"; rm -f "$symanc"; ln -s /etc "$symanc"
+for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d" "$tmp/./nonexistent-sandbox.d" \
+                   "$tmp/no-such-sandbox.d"; do
+  guard_rejects_seam SYSCTL "$seamed_proc" "$resolveseam" || {
+    bad "perf-capability: test mode ACCEPTED a sysctl seam that RESOLVES outside its sandbox: '$resolveseam'"; badseam_fail=1; }
+done
+guard_rejects_seam PROC "$symanc/sysctl.d" "$seamed_d" || {
+  bad "perf-capability: test mode ACCEPTED a proc seam with a SYMLINKED ANCESTOR into /etc"; badseam_fail=1; }
+[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam AND one that merely RESOLVES into production (.. or a symlinked ancestor), on BOTH sandbox dirs, naming the offending seam"
+# ...and the write TARGET is re-validated independently of the guard: --drop-in-path may
+# never NAME a production file, because that string is what a root `tee` is pointed at.
+for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d"; do
+  rp=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$resolveseam" \
+         bash "$PERFLIB" --drop-in-path 2>/dev/null); rp_rc=$?
+  if [ "$rp_rc" -eq 0 ] || [ -n "$rp" ]; then
+    bad "perf-capability: --drop-in-path named a write target from a seam resolving into production ('$resolveseam' -> '$rp')"
+    dropinpath_fail=1
+  fi
+done
+[ -n "${dropinpath_fail:-}" ] || ok "perf-capability: the drop-in write TARGET is refused (rc 1, empty) for a seam that resolves into production, independently of the env guard"
 # ...and the refusal reaches the RESOLVERS, not only the guard: an unsandboxed test mode
 # must not be able to name a production path at all (this is what the `tee` would use).
 noseam_path=$(env -u CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_TEST_MODE=1 bash "$PERFLIB" --drop-in-path 2>/dev/null)
@@ -429,7 +453,21 @@ if dropin_current_is "$bytes_d"; then
   bad "perf-capability: a drop-in with altered trailing whitespace on a value line was judged current"
   bytes_fail=1
 fi
-[ "$bytes_fail" -ne 0 ] || ok "perf-capability: the idempotency compare is BYTE-exact — a missing final newline, an extra blank line and altered trailing whitespace are all NOT current"
+# variant 4/5: THE NUL CASE (issue #3249 review R5-3). `read -d ''` stops at a NUL and
+# returns SUCCESS, leaving only the bytes BEFORE it in the variable — so canonical content
+# followed by a NUL and ARBITRARY trailing bytes compared EQUAL and the file was never
+# rewritten. Both a bare trailing NUL and a NUL with junk after it must be NOT current.
+bash "$PERFLIB" --drop-in >"$bytes_f"; printf '\0' >>"$bytes_f"
+if dropin_current_is "$bytes_d"; then
+  bad "perf-capability: canonical content + a trailing NUL was judged current"
+  bytes_fail=1
+fi
+bash "$PERFLIB" --drop-in >"$bytes_f"; printf '\0kernel.perf_event_paranoid = 4\n' >>"$bytes_f"
+if dropin_current_is "$bytes_d"; then
+  bad "perf-capability: canonical content + NUL + arbitrary trailing bytes was judged current (the read stopped at the NUL and never saw them)"
+  bytes_fail=1
+fi
+[ "$bytes_fail" -ne 0 ] || ok "perf-capability: the idempotency compare is BYTE-exact — a missing final newline, an extra blank line, altered trailing whitespace, a trailing NUL and a NUL followed by arbitrary bytes are all NOT current"
 
 # 1d-vii. THE '99-' PREFIX IS LOAD-BEARING, and the drop-in says so in its own bytes.
 #         This box ships /etc/sysctl.d/10-kernel-hardening.conf with
@@ -467,12 +505,59 @@ if printf '%s\n' "$comp_out" | grep -q "^earlier $comp_d/10-kernel-hardening.con
 else
   bad "perf-capability: competing-file detection wrong: '$comp_out'"
 fi
-if [ -z "$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$tmp/perf-nocomp.d" \
+nocomp_empty_d="$tmp/perf-nocomp-empty.d"; mkdir -p "$nocomp_empty_d"
+if [ -z "$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$nocomp_empty_d" \
              bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null)" ]; then
-  ok "perf-capability: a missing/empty sysctl.d directory yields no competitors (and no error output)"
+  ok "perf-capability: an empty sysctl.d directory yields no competitors (and no error output)"
 else
   bad "perf-capability: an empty sysctl.d dir produced competitor output"
 fi
+
+# 1d-ix. THE SCAN COVERS THE WHOLE `sysctl --system` SEARCH PATH, WITH MASKING (issue #3249
+#        review R5-4). `sysctl --system`/systemd-sysctl load /etc/sysctl.d, /run/sysctl.d,
+#        /usr/local/lib/sysctl.d, /usr/lib/sysctl.d, /lib/sysctl.d and finally the FILE
+#        /etc/sysctl.conf; scanning only the first meant a later-sorting file in one of the
+#        others overrode our drop-in while the diagnostic reported NO competitor. Two
+#        independent rules are asserted here:
+#          MASKING  a basename supplied by a HIGHER-precedence directory makes the lower
+#                   copy ignored entirely — and it masks even when the higher copy sets
+#                   NOTHING, which is the subtle half.
+#          ORDERING among the surviving files, basename order decides; /etc/sysctl.conf is
+#                   applied after them all, so it gets the distinct `last` verdict.
+sp_hi="$tmp/perf-sp-hi.d";   mkdir -p "$sp_hi"
+sp_run="$tmp/perf-sp-run.d"; mkdir -p "$sp_run"
+sp_lib="$tmp/perf-sp-lib.d"; mkdir -p "$sp_lib"
+sp_conf_d="$tmp/perf-sp-conf"; mkdir -p "$sp_conf_d"
+bash "$PERFLIB" --drop-in >"$sp_hi/99-cqlite-perf.conf"
+printf 'kernel.kptr_restrict = 1\n'       >"$sp_hi/10-hardening.conf"
+printf '# nothing set here at all\n'      >"$sp_hi/60-inert.conf"     # masks the copy below
+printf 'kernel.perf_event_paranoid = 3\n' >"$sp_run/60-inert.conf"    # IGNORED (masked)
+printf 'kernel.perf_event_paranoid = 3\n' >"$sp_run/99-zzz-run.conf"  # later-sorting: WINS
+printf '%s\n' '-kernel/kptr_restrict = 1' >"$sp_lib/95-usrlib.conf"   # slash + `-` spelling
+printf 'kernel.perf_event_paranoid = 2\n' >"$sp_conf_d/sysctl.conf"   # applied LAST of all
+sp_out=$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$sp_hi" \
+  CQLITE_PERF_SYSCTL_EXTRA_DIRS="$sp_run:$sp_lib:$sp_conf_d/sysctl.conf" \
+  bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1)
+if printf '%s\n' "$sp_out" | grep -q "^earlier $sp_hi/10-hardening.conf$" \
+   && printf '%s\n' "$sp_out" | grep -q "^override $sp_run/99-zzz-run.conf$" \
+   && printf '%s\n' "$sp_out" | grep -q "^earlier $sp_lib/95-usrlib.conf$" \
+   && printf '%s\n' "$sp_out" | grep -q "^last $sp_conf_d/sysctl.conf$" \
+   && ! printf '%s\n' "$sp_out" | grep -q "$sp_run/60-inert.conf"; then
+  ok "perf-capability: competing files are found across the WHOLE search path, ranked by basename, /etc/sysctl.conf gets the applied-last verdict, and a masked same-basename copy is skipped"
+else
+  bad "perf-capability: search-path scan wrong: '$sp_out'"
+fi
+# ...and an EXTRA-DIRS entry that is not an absolute non-production path fails the whole
+# scan CLOSED (rc 1, no output): a test-mode scan may never read the host's real /run or
+# /usr/lib, and a bad entry is an UNKNOWN, not "no competitor".
+for spbad in /etc/sysctl.d relative/dir "/tmp/../etc/sysctl.d"; do
+  sp_bad_out=$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$sp_hi" \
+    CQLITE_PERF_SYSCTL_EXTRA_DIRS="$spbad" \
+    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null) && sp_bad_fail=1
+  [ -z "$sp_bad_out" ] || sp_bad_fail=1
+  [ -z "${sp_bad_fail:-}" ] || bad "perf-capability: a production/relative CQLITE_PERF_SYSCTL_EXTRA_DIRS entry '$spbad' did not fail the scan closed"
+done
+[ -n "${sp_bad_fail:-}" ] || ok "perf-capability: a production-shaped/relative/resolving-into-production extra search-path entry fails the scan CLOSED (rc 1, no output)"
 # ...and an UNREADABLE directory is an UNKNOWN (rc 1), never "no competing file": this
 # diagnostic exists to replace an unknown with a named file, so answering an unknown with
 # the reassuring line would recreate the mystery it was written to end.

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -716,6 +716,42 @@ else
   bad "perf section: a sudo invocation without -n was recorded (or none at all): $(cat "$pwtrip")"
 fi
 
+# 4c-iii. ALREADY ROOT: the printed remedy must carry NO `sudo` prefix — many root
+#         images have no sudo installed at all, so a hardcoded `sudo tee` line is
+#         un-runnable exactly where it is printed. Check mode, so nothing is written.
+rootbox="$tmp/perf-rootbox"; mkdir -p "$rootbox"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$rootbox/$t"
+done
+mkuname "$rootbox" Linux
+printf '#!/usr/bin/env bash\ncase "${1:-}" in -u) echo 0 ;; *) echo 0 ;; esac\n' >"$rootbox/id"
+chmod +x "$rootbox/id"
+roottrip="$tmp/perf-rootbox-tripwire.log"; : >"$roottrip"
+for t in sudo sysctl; do
+  cat >"$rootbox/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$roottrip"
+exit 0
+EOF
+  chmod +x "$rootbox/$t"
+done
+ln -sf "$perfbin/perf" "$rootbox/perf"
+mkperfshim 3333333
+rootbox_d="$tmp/perf-rootbox.d"; mkdir -p "$rootbox_d"
+rootbox_out=$(PATH="$rootbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$rootbox_d" CQLITE_PERF_TEST_PRIV_DIR="$rootbox" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+rootbox_rc=$?
+rootbox_remedy=$(printf '%s\n' "$rootbox_out" | grep 'write + apply the drop-in' || true)
+if [ "$rootbox_rc" -eq 0 ] && [ -z "$(ls -A "$rootbox_d")" ] \
+   && printf '%s' "$rootbox_remedy" | grep -q '| tee .*99-cqlite-perf.conf >/dev/null && sysctl -q --system' \
+   && ! printf '%s' "$rootbox_remedy" | grep -q 'sudo'; then
+  ok "perf section: when ALREADY ROOT the printed write+apply remedy carries no 'sudo' prefix"
+else
+  bad "perf section: root-box remedy line wrong (rc=$rootbox_rc, line='$rootbox_remedy')"
+fi
+
 # 4d. THE SILENT REVERT — the real-world trap this whole issue exists to fix, and so
 #      the path that must be best-tested. `sysctl` exits 0 while the value does NOT
 #      take (container, read-only /proc, a later-sorting drop-in or /etc/sysctl.conf

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+# Regression test for the PERF PROFILING CAPABILITY path (issue #3249):
+# scripts/perf-capability.sh (the shared helper) plus the bootstrap section that
+# installs and VERIFIES /etc/sysctl.d/99-cqlite-perf.conf.
+#
+# WHY THIS EXISTS. Agent/worker images ship kernel.perf_event_paranoid = 4 — ALL
+# unprivileged perf use denied — and set it in no sysctl file, so a box is
+# profileable only by accident and reverts on reboot. Two measurement cycles were
+# lost to that, largely because the denial's help text ("access limited") reads
+# like a CAPABILITY verdict when it is a PERMISSION verdict.
+#
+# WHAT IT ASSERTS, beyond "the code is there": that the FUNCTIONAL verification is
+# HONOURED. `perf stat` exits 0 while printing `<not supported>`/`<not counted>`,
+# and a virtualised PMU can report a flat 0 — so an rc-only check is precisely the
+# false green being fixed, and every negative case here drives a shimmed perf that
+# EXITS 0 with an unusable counter.
+#
+# HOST SAFETY. Nothing here touches the real /etc/sysctl.d or /proc: two test-only
+# env seams stand in (CQLITE_PERF_PROC_DIR, CQLITE_PERF_SYSCTL_DIR) and every
+# privileged/mutating tool (sudo, sysctl, tee, the package managers) is a recording
+# PATH shim. The final case asserts that mutation-freedom directly.
+#
+# Run standalone:   bash scripts/tests/test_perf_capability.sh
+# Or via the gate:  scripts/agent-gate.sh runs it in the `tooling-tests` component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+BOOTSTRAP="$SCRIPT_DIR/../bootstrap-agent-machine.sh"
+PERFLIB="$SCRIPT_DIR/../perf-capability.sh"
+
+PASS=0
+FAIL=0
+# Wall-clock stamp used ONLY to attribute a pre-existing host file (the last case
+# asks "did WE create /etc/sysctl.d/99-cqlite-perf.conf, or was the box already
+# bootstrapped?"). Never a threshold on a measured duration. perf-gate-allow
+SUITE_START=$(date +%s)
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+# Global-state isolation, same posture as test_bootstrap_agent_machine.sh: the
+# bootstrap runs below read/write git config and read board env, and this suite runs
+# inside `tooling-tests` on the very box hosting a live delivery session.
+export GIT_CONFIG_GLOBAL="$tmp/global-gitconfig"
+export GIT_CONFIG_NOSYSTEM=1
+: >"$GIT_CONFIG_GLOBAL"
+unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
+# A worker shell may export the seams themselves; a test must set exactly what it means.
+unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR
+
+# Inert shims for the tools the surrounding bootstrap sections would otherwise
+# reach (network / installs). Only the perf-specific shims below are functional.
+mkshim() {
+  local name="$1"
+  cat >"$tmp/$name" <<EOF
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$tmp/$name"
+}
+mkshim brew
+mkshim cargo
+mkshim roborev
+mkshim gh
+host_home="$tmp/host-home"; mkdir -p "$host_home/.cargo"
+
+# --- 1. The shared helper: scripts/perf-capability.sh ------------------------------
+# Agent images ship kernel.perf_event_paranoid = 4 (all unprivileged perf DENIED)
+# and set it in no sysctl file, so a box is profileable only by accident and
+# reverts on reboot. Bootstrap now installs /etc/sysctl.d/99-cqlite-perf.conf and
+# — the part that matters — VERIFIES the result instead of assuming it.
+#
+# Cases below cover the helper contract, then the two bootstrap modes, and are
+# written so NOTHING touches the host: two test-only env seams stand in for the
+# real paths (CQLITE_PERF_PROC_DIR for /proc/sys/kernel, CQLITE_PERF_SYSCTL_DIR for
+# /etc/sysctl.d) and every privileged/mutating tool is a recording PATH shim. The
+# real /etc/sysctl.d is never opened by this suite.
+if bash -n "$PERFLIB" 2>/dev/null; then
+  ok "perf-capability.sh parses (bash -n)"
+else
+  bad "perf-capability.sh has a syntax error"
+fi
+
+# 1a. Sourcing must have NO side effects: no output, no `set` flag changes, no
+#      exit — the gate sources this file inside a summary emit, where any of those
+#      would corrupt an unrelated run.
+src_probe=$(bash -c '
+  set +u +o pipefail
+  before=$-
+  out=$(. "$1" 2>&1)
+  after=$-
+  [ -z "$out" ] || echo "OUTPUT:$out"
+  [ "$before" = "$after" ] || echo "FLAGS:$before->$after"
+  echo DONE' _ "$PERFLIB" 2>&1)
+if [ "$src_probe" = DONE ]; then
+  ok "perf-capability: sourcing is side-effect free (no output, no set-flag change)"
+else
+  bad "perf-capability: sourcing had a side effect: $src_probe"
+fi
+
+# 1b. The FREE token read: every state comes from /proc alone, and a bad value is
+#      reported as unknown rather than GUESSED (no-heuristics, #28).
+perfproc="$tmp/perfproc"; mkdir -p "$perfproc"
+token_for() { # token_for <paranoid> <kptr>
+  printf '%s\n' "$1" >"$perfproc/perf_event_paranoid"
+  printf '%s\n' "$2" >"$perfproc/kptr_restrict"
+  CQLITE_PERF_PROC_DIR="$perfproc" bash "$PERFLIB" --token
+}
+tok_fail=0
+check_token() { # check_token <paranoid> <kptr> <expected>
+  local got; got=$(token_for "$1" "$2")
+  [ "$got" = "$3" ] || { bad "perf-capability: paranoid=$1 kptr=$2 -> '$got' (expected '$3')"; tok_fail=1; }
+}
+check_token -1 0 ok
+check_token 0 0 ok
+check_token 1 0 paranoid-1
+check_token 4 1 paranoid-4
+check_token 2 0 paranoid-2
+check_token -1 1 kptr-restricted
+check_token 0 2 kptr-restricted
+check_token garbage 0 unknown
+if [ "$tok_fail" -eq 0 ]; then
+  ok "perf-capability: token reflects /proc exactly (ok / paranoid-N / kptr-restricted / unknown)"
+fi
+if [ "$(CQLITE_PERF_PROC_DIR="$tmp/no-such-proc" bash "$PERFLIB" --token)" = absent ]; then
+  ok "perf-capability: missing /proc controls report 'absent' (container), never a guess"
+else
+  bad "perf-capability: missing /proc controls did not report 'absent'"
+fi
+# The token read must be MUTATION-FREE: it is what the gate calls on every run.
+before_hash=$(cat "$perfproc"/* | cksum)
+CQLITE_PERF_PROC_DIR="$perfproc" CQLITE_PERF_SYSCTL_DIR="$tmp/perf-sysctl-untouched" \
+  bash "$PERFLIB" --token >/dev/null 2>&1
+if [ "$(cat "$perfproc"/* | cksum)" = "$before_hash" ] && [ ! -d "$tmp/perf-sysctl-untouched" ]; then
+  ok "perf-capability: the token read mutates nothing (no /proc write, no sysctl.d dir)"
+else
+  bad "perf-capability: the token read mutated state"
+fi
+
+# 1c. The drop-in bytes carry the -1-not-1 rationale and BOTH controls, and the
+#      printed remedy (`--drop-in | sudo tee …`) is what produces them — so a
+#      hand-applied fix is byte-identical and the next bootstrap run is a no-op.
+dropin=$(bash "$PERFLIB" --drop-in)
+if printf '%s\n' "$dropin" | grep -q '^kernel.perf_event_paranoid = -1$' \
+   && printf '%s\n' "$dropin" | grep -q '^kernel.kptr_restrict = 0$' \
+   && printf '%s\n' "$dropin" | grep -qi 'cumulative' \
+   && printf '%s\n' "$dropin" | grep -qi 'multi-tenant'; then
+  ok "perf-capability: drop-in sets both controls and states the rationale + posture"
+else
+  bad "perf-capability: drop-in content is missing a control, the rationale or the posture"
+  printf '%s\n' "$dropin"
+fi
+if [ "$(CQLITE_PERF_SYSCTL_DIR=/etc/sysctl.d bash "$PERFLIB" --drop-in-path)" = /etc/sysctl.d/99-cqlite-perf.conf ]; then
+  ok "perf-capability: drop-in path is /etc/sysctl.d/99-cqlite-perf.conf (survives reboot)"
+else
+  bad "perf-capability: unexpected drop-in path"
+fi
+
+# 1d. The FUNCTIONAL verification is HONOURED, not merely attempted — the #3119
+#      lesson (test_bootstrap_agent_machine.sh case 10) applied to this issue. `perf stat` exits 0 while
+#      printing `<not supported>` / `<not counted>`, and a virtualised PMU can
+#      report a flat 0, so an rc-only check is exactly the false green being fixed.
+perfbin="$tmp/perfbin"; mkdir -p "$perfbin"
+mkperfshim() { # mkperfshim <csv-count-field>
+  cat >"$perfbin/perf" <<EOF
+#!/usr/bin/env bash
+echo "perf \$*" >>"\$PERFSHIM_LOG"
+printf '%s\n' '$1,,cycles,100000000,100.00,,'
+exit 0
+EOF
+  chmod +x "$perfbin/perf"
+}
+export PERFSHIM_LOG="$tmp/perfshim.log"; : >"$PERFSHIM_LOG"
+verify_verdict() { # verify_verdict <csv-count-field> -> "<rc> <stdout>"
+  mkperfshim "$1"
+  local out rc
+  out=$(PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>&1); rc=$?
+  printf '%s %s' "$rc" "$out"
+}
+ver_fail=0
+case "$(verify_verdict 4242424)" in
+  "0 cycles=4242424") ;;
+  *) bad "perf-capability: a real non-zero cycle count was not accepted: $(verify_verdict 4242424)"; ver_fail=1 ;;
+esac
+for badcount in 0 '<not supported>' '<not counted>' 'nonsense'; do
+  v=$(verify_verdict "$badcount")
+  case "$v" in
+    0\ *) bad "perf-capability: rc-0 perf with count '$badcount' was accepted as verified ($v)"; ver_fail=1 ;;
+  esac
+done
+if [ "$ver_fail" -eq 0 ]; then
+  ok "perf-capability: verify requires a NON-ZERO cycle count (0 / <not supported> / <not counted> all FAIL)"
+fi
+# ...and it must actually run the per-CPU collection the doctrine mandates.
+if grep -q 'stat .*-C 0' "$PERFSHIM_LOG" && grep -q '\-e cycles' "$PERFSHIM_LOG"; then
+  ok "perf-capability: verify runs 'perf stat -C 0 -e cycles' (per-CPU, as doctrine requires)"
+else
+  bad "perf-capability: verify did not run a per-CPU 'perf stat -C 0 -e cycles'"
+  cat "$PERFSHIM_LOG"
+fi
+# No perf binary at all is a warn-worthy UNVERIFIED, never a silent pass.
+noperf_dir="$tmp/noperf"; mkdir -p "$noperf_dir"
+for t in bash cat awk printf tr cut command timeout; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$noperf_dir/$t"
+done
+if noperf_out=$(PATH="$noperf_dir" bash "$PERFLIB" --verify 2>&1); then
+  bad "perf-capability: verify PASSED with no perf binary on PATH"
+else
+  case "$noperf_out" in
+    *no-perf-binary*) ok "perf-capability: verify fails with 'no-perf-binary' when perf is absent" ;;
+    *) bad "perf-capability: unexpected no-perf verdict: $noperf_out" ;;
+  esac
+fi
+
+# --- 2. Bootstrap perf section: the DEFAULT (no --yes) run mutates NOTHING ----
+# Tripwire shims for every privileged/mutating tool the write path could use, so
+# "wrote nothing" is PROVEN rather than assumed. `perf` may be invoked (the
+# verification is read-only and is the point of the section); `sudo`, `sysctl` and
+# `tee` may not.
+perfshims="$tmp/perf-shims"; mkdir -p "$perfshims"
+perftrip="$tmp/perf-tripwire.log"; : >"$perftrip"
+for t in sudo sysctl tee; do
+  cat >"$perfshims/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$perftrip"
+exit 0
+EOF
+  chmod +x "$perfshims/$t"
+done
+mkperfroot() { # mkperfroot <dir>: a throwaway REPO_ROOT bootstrap can resolve
+  local dir="$1"
+  mkdir -p "$dir/scripts/lib"
+  cp "$BOOTSTRAP" "$dir/scripts/bootstrap-agent-machine.sh"
+  cp "$PERFLIB" "$dir/scripts/perf-capability.sh"
+  cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$dir/scripts/lib/gate-notify.sh" 2>/dev/null || true
+}
+perf_sysctl_d="$tmp/perf-sysctl.d"; mkdir -p "$perf_sysctl_d"
+perf_proc="$tmp/perf-proc"; mkdir -p "$perf_proc"
+printf '4\n' >"$perf_proc/perf_event_paranoid"
+printf '1\n' >"$perf_proc/kptr_restrict"
+mkperfroot "$tmp/perf-root-check"
+mkperfshim 999999
+check_out=$(PATH="$perfshims:$perfbin:$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$perf_sysctl_d" \
+  bash "$tmp/perf-root-check/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+check_rc=$?
+if printf '%s' "$check_out" | grep -q 'Perf profiling capability'; then
+  ok "perf section: present in the bootstrap run"
+else
+  bad "perf section: MISSING from the bootstrap run"
+fi
+# The ONLY tolerated privileged invocation is the non-mutating `sudo -n true`
+# availability probe (bootstrap must know whether to print a sudo remedy at all);
+# anything else — a `tee`, a `sysctl`, or any other sudo command — is a mutation.
+perf_mutating=$(grep -vE '^sudo -n true$' "$perftrip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
+if [ "$check_rc" -eq 0 ] && [ -z "$(ls -A "$perf_sysctl_d")" ] && [ -z "$perf_mutating" ]; then
+  ok "perf section: default (no --yes) run wrote NO drop-in and invoked no privileged/mutating command"
+else
+  bad "perf section: default run mutated state (rc=$check_rc, dir='$(ls -A "$perf_sysctl_d")', tripwire below)"
+  cat "$perftrip"
+fi
+# It must instead PRINT the exact remedy — including the reboot-persistent file and
+# the apply — plus the AC5 posture and the BPF caveat (#3217).
+if printf '%s' "$check_out" | grep -q 'perf-capability.sh --drop-in | sudo tee .*99-cqlite-perf.conf' \
+   && printf '%s' "$check_out" | grep -q 're-run with --yes'; then
+  ok "perf section: prints the exact drop-in remedy line instead of running it"
+else
+  bad "perf section: no exact remedy line printed"
+  printf '%s\n' "$check_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+if printf '%s' "$check_out" | grep -qi 'BPF collectors .* require sudo' \
+   && printf '%s' "$check_out" | grep -qi 'never apply it to a shared or multi-tenant host'; then
+  ok "perf section: states the BPF-still-needs-sudo caveat and the single-tenant posture"
+else
+  bad "perf section: missing the BPF caveat or the security posture"
+fi
+# A blocked box must be DIAGNOSED as a permission verdict, not a capability one.
+if printf '%s' "$check_out" | grep -q 'perf=paranoid-4' \
+   && printf '%s' "$check_out" | grep -qi 'PERMISSION verdict'; then
+  ok "perf section: paranoid-4 is reported as a PERMISSION verdict with the gate's token"
+else
+  bad "perf section: a blocked box was not diagnosed as a permission verdict"
+  printf '%s\n' "$check_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# --- 3. Bootstrap perf section under --yes: write -> READ BACK -> verify ------
+# The privileged shims here are FUNCTIONAL, not inert: `sudo` records and execs,
+# `sysctl --system` records and (like the kernel would) updates the fake procfs, so
+# the read-back has something real to read. Order is asserted, because a read-back
+# that runs BEFORE the apply proves nothing.
+yesshims="$tmp/perf-yes-shims"; mkdir -p "$yesshims"
+yestrip="$tmp/perf-yes-tripwire.log"; : >"$yestrip"
+cat >"$yesshims/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >>"$yestrip"
+while [ "\${1:-}" = "-n" ]; do shift; done
+exec "\$@"
+EOF
+cat >"$yesshims/sysctl" <<EOF
+#!/usr/bin/env bash
+echo "sysctl \$*" >>"$yestrip"
+case " \$* " in *" --system "*)
+  printf -- '-1\n' >"$tmp/perf-proc-yes/perf_event_paranoid"
+  printf '0\n'     >"$tmp/perf-proc-yes/kptr_restrict" ;;
+esac
+exit 0
+EOF
+# apt-get/apt: --yes would otherwise reach the real package manager via the mold
+# section. Record-only, so this suite can never install anything on the host.
+for t in apt-get apt dnf yum pacman; do
+  cat >"$yesshims/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$yestrip"
+exit 0
+EOF
+done
+chmod +x "$yesshims"/*
+proc_yes="$tmp/perf-proc-yes"; mkdir -p "$proc_yes"
+printf '4\n' >"$proc_yes/perf_event_paranoid"
+printf '1\n' >"$proc_yes/kptr_restrict"
+sysctl_yes="$tmp/perf-sysctl-yes.d"; mkdir -p "$sysctl_yes"
+mkperfroot "$tmp/perf-root-yes"
+mkperfshim 7777777
+yes_home="$tmp/perf-yes-home"; mkdir -p "$yes_home/.cargo"
+yes_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+yes_rc=$?
+if [ "$yes_rc" -eq 0 ]; then
+  ok "perf section: --yes run exits 0"
+else
+  bad "perf section: --yes run exited non-zero (rc=$yes_rc)"
+fi
+if [ -f "$sysctl_yes/99-cqlite-perf.conf" ] \
+   && diff -q <(bash "$PERFLIB" --drop-in) "$sysctl_yes/99-cqlite-perf.conf" >/dev/null 2>&1; then
+  ok "perf section: --yes wrote the drop-in with EXACTLY the canonical bytes"
+else
+  bad "perf section: --yes did not write the canonical drop-in"
+  ls -l "$sysctl_yes" 2>&1 | head -3
+fi
+if grep -q 'tee .*99-cqlite-perf.conf' "$yestrip" && grep -q 'sysctl -q --system' "$yestrip"; then
+  ok "perf section: --yes wrote through sudo tee and applied with 'sysctl --system'"
+else
+  bad "perf section: --yes did not use sudo tee + sysctl --system"
+  cat "$yestrip"
+fi
+# ORDER: the apply must precede the read-back verdict, and the functional verify
+# must come last (it is the verdict on the whole section).
+yes_perf_block=$(printf '%s\n' "$yes_out" | sed -n '/Perf profiling capability/,/^$/p')
+n_wrote=$(printf '%s\n' "$yes_perf_block" | grep -n 'wrote .*99-cqlite-perf.conf' | head -1 | cut -d: -f1)
+n_read=$(printf '%s\n' "$yes_perf_block" | grep -n 'READ BACK from /proc' | head -1 | cut -d: -f1)
+n_verify=$(printf '%s\n' "$yes_perf_block" | grep -n 'perf capability VERIFIED' | head -1 | cut -d: -f1)
+if [ -n "$n_wrote" ] && [ -n "$n_read" ] && [ -n "$n_verify" ] \
+   && [ "$n_wrote" -lt "$n_read" ] && [ "$n_read" -lt "$n_verify" ]; then
+  ok "perf section: order is write -> read-back from /proc -> functional verify"
+else
+  bad "perf section: wrong order (wrote=$n_wrote read-back=$n_read verify=$n_verify)"
+  printf '%s\n' "$yes_perf_block"
+fi
+# Idempotency: a SECOND --yes run must write nothing (byte-compare no-op).
+: >"$yestrip"
+yes2_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+if printf '%s' "$yes2_out" | grep -q 'drop-in already current' \
+   && ! grep -q 'tee .*99-cqlite-perf.conf' "$yestrip"; then
+  ok "perf section: a second --yes run is an idempotent no-op (no re-write)"
+else
+  bad "perf section: second --yes run re-wrote the drop-in"
+  printf '%s\n' "$yes2_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# --- 4. The verification VERDICT is honoured, and no-sudo degrades gracefully --
+# 4a. A perf that exits 0 but reports an unusable counter must produce a WARN and
+#      must NEVER be reported as verified. This is the #3119-style mutation (test_bootstrap_agent_machine.sh case 10) applied
+#      to AC2: without it, "the check exists" would pass while the box is unusable.
+mkperfshim '<not supported>'
+unsup_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+unsup_rc=$?
+if printf '%s' "$unsup_out" | grep -q 'perf capability NOT verified' \
+   && ! printf '%s' "$unsup_out" | grep -q 'perf capability VERIFIED' \
+   && [ "$unsup_rc" -eq 0 ]; then
+  ok "perf section: an rc-0 perf with an unusable counter WARNs (never 'verified'), run still exits 0"
+else
+  bad "perf section: unusable counter was not surfaced (rc=$unsup_rc)"
+  printf '%s\n' "$unsup_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# 4b. Zero cycles is the virtualised-PMU case — same verdict.
+mkperfshim 0
+zero_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+if printf '%s' "$zero_out" | grep -q 'perf capability NOT verified' \
+   && ! printf '%s' "$zero_out" | grep -q 'perf capability VERIFIED'; then
+  ok "perf section: a zero cycle count WARNs (never 'verified')"
+else
+  bad "perf section: a zero cycle count was accepted as verified"
+  printf '%s\n' "$zero_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# 4c. A box with NO sudo at all: warn + the exact remedy, no write, still exit 0.
+nosudo="$tmp/perf-nosudo"; mkdir -p "$nosudo"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp uname id \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nosudo/$t"
+done
+ln -sf "$perfbin/perf" "$nosudo/perf"
+mkperfshim 5555555
+nosudo_sysctl="$tmp/perf-nosudo.d"; mkdir -p "$nosudo_sysctl"
+nosudo_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$nosudo_sysctl" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+nosudo_rc=$?
+if [ "$nosudo_rc" -eq 0 ] && [ -z "$(ls -A "$nosudo_sysctl")" ] \
+   && printf '%s' "$nosudo_out" | grep -q 'no non-interactive root' \
+   && printf '%s' "$nosudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf'; then
+  ok "perf section: no-sudo box warns with the exact remedy, writes nothing, exits 0"
+else
+  bad "perf section: no-sudo box mishandled (rc=$nosudo_rc, dir='$(ls -A "$nosudo_sysctl")')"
+  printf '%s\n' "$nosudo_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# 4d. Nothing in this whole suite may have touched the REAL /etc/sysctl.d.
+if [ ! -e /etc/sysctl.d/99-cqlite-perf.conf ] || [ -n "${CQLITE_PERF_ALLOW_REAL_DROPIN:-}" ]; then
+  ok "perf section: the suite never created the real /etc/sysctl.d/99-cqlite-perf.conf"
+else
+  # Pre-existing on a bootstrapped box is legitimate; only report if WE made it.
+  if [ "$(stat -c %Y /etc/sysctl.d/99-cqlite-perf.conf 2>/dev/null || echo 0)" -gt "$SUITE_START" ]; then
+    bad "perf section: the suite wrote the REAL /etc/sysctl.d/99-cqlite-perf.conf"
+  else
+    ok "perf section: the real drop-in pre-dates this suite (not written by it)"
+  fi
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -84,6 +84,29 @@ EOF
   chmod +x "$1/uname"
 }
 
+# mkid <dir> <uid>: an `id` stub, so the ROOT / NON-ROOT branch under test is the one
+# selected by the CASE, not by whatever UID runs the suite. Without this the suite was
+# silently NON-ROOT-runner-only: nearly every case asserts the unprivileged behaviour
+# (a `sudo -n true` probe, a `sudo -n tee`, a printed `sudo` remedy), so running the
+# whole thing as root — a container, a CI image, anyone's `sudo bash` — took the root
+# branch and FAILED, reddening the mandatory `tooling-tests` gate component. Same class
+# as the Linux-host-only bug mkuname fixes, and the same `rm -f` first: several dirs
+# below `ln -sf` the real `id` into place, and writing through that symlink would
+# clobber the host's /usr/bin/id. The root-specific case (4c-iii) keeps its OWN uid-0
+# shim, which is the only place the root branch is exercised.
+mkid() {
+  rm -f "$1/id"
+  cat >"$1/id" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  -u) echo $2 ;;
+  -un|-nu) echo cqlite-test-user ;;
+  *)  echo $2 ;;
+esac
+EOF
+  chmod +x "$1/id"
+}
+
 # Inert shims for the tools the surrounding bootstrap sections would otherwise
 # reach (network / installs). Only the perf-specific shims below are functional.
 mkshim() {
@@ -99,6 +122,7 @@ mkshim cargo
 mkshim roborev
 mkshim gh
 mkuname "$tmp" Linux   # every bootstrap run below that includes $tmp in PATH is Linux
+mkid "$tmp" 1000       # ...and is a NON-ROOT runner, whatever UID runs the suite
 host_home="$tmp/host-home"; mkdir -p "$host_home/.cargo"
 
 # --- 1. The shared helper: scripts/perf-capability.sh ------------------------------
@@ -654,11 +678,12 @@ fi
 #      case asserts the root-shell remedy AND the absence of the sudo one — the two
 #      `sudo -n` failure modes (no binary vs needs a password) are different boxes.
 nosudo="$tmp/perf-nosudo"; mkdir -p "$nosudo"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp id \
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
          diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
   s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nosudo/$t"
 done
 mkuname "$nosudo" Linux
+mkid "$nosudo" 1000    # non-root, whatever UID runs the suite
 ln -sf "$perfbin/perf" "$nosudo/perf"
 mkperfshim 5555555
 nosudo_sysctl="$tmp/perf-nosudo.d"; mkdir -p "$nosudo_sysctl"
@@ -680,11 +705,12 @@ fi
 #        box: the `sudo tee` line does work there, interactively. Bootstrap must say so
 #        and must still never prompt.
 pwsudo="$tmp/perf-pwsudo"; mkdir -p "$pwsudo"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp id \
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
          diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
   s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$pwsudo/$t"
 done
 mkuname "$pwsudo" Linux
+mkid "$pwsudo" 1000    # non-root, whatever UID runs the suite
 ln -sf "$perfbin/perf" "$pwsudo/perf"
 pwtrip="$tmp/perf-pwsudo-tripwire.log"; : >"$pwtrip"
 cat >"$pwsudo/sudo" <<EOF
@@ -846,11 +872,12 @@ fi
 #      break every box without linux-tools. Every other case has perf on PATH, so an
 #      `exit 1` inserted in this branch previously survived the whole suite.
 noperfbox="$tmp/perf-noperfbox"; mkdir -p "$noperfbox"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp id \
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
          diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
   s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$noperfbox/$t"
 done
 mkuname "$noperfbox" Linux
+mkid "$noperfbox" 1000    # non-root, whatever UID runs the suite
 cat >"$noperfbox/sudo" <<EOF
 #!/usr/bin/env bash
 while [ "\${1:-}" = "-n" ]; do shift; done

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -58,6 +58,14 @@ export GIT_CONFIG_NOSYSTEM=1
 unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
 # A worker shell may export the seams themselves; a test must set exactly what it means.
 unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR
+# ...and so may a `sudo bash scripts/tests/...` invocation export SUDO_UID/GID/USER,
+# which the privilege-drop target resolution reads. A case that means to exercise that
+# path sets them itself; inheriting them would make the suite's verdict depend on how
+# it was launched (the same env-inheritance class as PERF_SECTION_OK).
+unset SUDO_UID SUDO_GID SUDO_USER
+# The section under test must never be steered by an ambient export either: bootstrap
+# initialises PERF_SECTION_OK itself, and this suite proves it (case 4h).
+unset PERF_SECTION_OK
 # The two path seams are INERT unless this marker is set, and the marker itself
 # forbids reaching a real sudo/sysctl (the shim dir is declared per case in
 # CQLITE_PERF_TEST_PRIV_DIR). Cases that must exercise the PRODUCTION defaults run
@@ -84,22 +92,35 @@ EOF
   chmod +x "$1/uname"
 }
 
-# mkid <dir> <uid>: an `id` stub, so the ROOT / NON-ROOT branch under test is the one
-# selected by the CASE, not by whatever UID runs the suite. Without this the suite was
-# silently NON-ROOT-runner-only: nearly every case asserts the unprivileged behaviour
-# (a `sudo -n true` probe, a `sudo -n tee`, a printed `sudo` remedy), so running the
-# whole thing as root — a container, a CI image, anyone's `sudo bash` — took the root
-# branch and FAILED, reddening the mandatory `tooling-tests` gate component. Same class
-# as the Linux-host-only bug mkuname fixes, and the same `rm -f` first: several dirs
-# below `ln -sf` the real `id` into place, and writing through that symlink would
-# clobber the host's /usr/bin/id. The root-specific case (4c-iii) keeps its OWN uid-0
-# shim, which is the only place the root branch is exercised.
+# mkid <dir> <self-uid> [<other-uid>]: an `id` stub, so the ROOT / NON-ROOT branch
+# under test is the one selected by the CASE, not by whatever UID runs the suite.
+# Without this the suite was silently NON-ROOT-runner-only: nearly every case asserts
+# the unprivileged behaviour (a `sudo -n true` probe, a `sudo -n tee`, a printed `sudo`
+# remedy), so running the whole thing as root — a container, a CI image, anyone's
+# `sudo bash` — took the root branch and FAILED, reddening the mandatory
+# `tooling-tests` gate component. Same class as the Linux-host-only bug mkuname fixes,
+# and the same `rm -f` first: several dirs below `ln -sf` the real `id` into place, and
+# writing through that symlink would clobber the host's /usr/bin/id.
+#
+# <other-uid> answers a USER OPERAND (`id -u nobody` / `id -g nobody`), which the
+# privilege-drop target resolution asks for: a shim that answered its OWN uid there
+# would let a root case "resolve" root as the unprivileged probe identity — the exact
+# false verification the drop exists to prevent. Omitted => the operand form FAILS
+# (that box has no such account), which is the honest answer for a case that offers
+# no unprivileged identity.
 mkid() {
   rm -f "$1/id"
   cat >"$1/id" <<EOF
 #!/usr/bin/env bash
+other='${3:-}'
 case "\${1:-}" in
-  -u) echo $2 ;;
+  -u|-g)
+    if [ -n "\${2:-}" ]; then
+      [ -n "\$other" ] || exit 1        # no such account on this box
+      echo "\$other"
+    else
+      echo $2
+    fi ;;
   -un|-nu) echo cqlite-test-user ;;
   *)  echo $2 ;;
 esac
@@ -1058,6 +1079,240 @@ if [ "$darwin_rc" -eq 0 ] \
 else
   bad "perf section: Darwin no-op mishandled (rc=$darwin_rc, dir='$(ls -A "$darwin_d")', tripwire='$darwin_mutating')"
   printf '%s\n' "$darwin_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4f-ii. AN INHERITED `PERF_SECTION_OK=1` MAY NOT STEER THE SECTION (issue #3249
+#        review). The gate was read as `${PERF_SECTION_OK:-0}` with no initialisation
+#        before the platform/library checks, so an ambient export carried a macOS host
+#        straight into the LINUX-ONLY implementation and called helper functions that
+#        were never sourced. Same env-inheritance class as the CQLITE_PERF_SYSCTL_DIR
+#        seam steering a privileged write. Asserted on BOTH pre-conditions the guard
+#        chain has: the wrong platform, and a checkout with no perf-capability.sh.
+darwin_inherit_out=$(PERF_SECTION_OK=1 PATH="$darwin_dir:$perfbin:$tmp:$PATH" \
+  HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$darwin_d" CQLITE_PERF_TEST_PRIV_DIR="$darwin_dir" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+darwin_inherit_rc=$?
+if [ "$darwin_inherit_rc" -eq 0 ] \
+   && printf '%s' "$darwin_inherit_out" | grep -q 'nothing to configure on macos' \
+   && [ -z "$(ls -A "$darwin_d")" ] \
+   && ! printf '%s' "$darwin_inherit_out" | grep -q 'runtime now: perf_event_paranoid' \
+   && ! printf '%s' "$darwin_inherit_out" | grep -q 'perf capability VERIFIED' \
+   && ! printf '%s' "$darwin_inherit_out" | grep -qi 'command not found'; then
+  ok "perf section: an INHERITED PERF_SECTION_OK=1 cannot drag a Darwin run into the Linux-only implementation"
+else
+  bad "perf section: an inherited PERF_SECTION_OK=1 steered the section (rc=$darwin_inherit_rc)"
+  printf '%s\n' "$darwin_inherit_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+nolib_root="$tmp/perf-root-nolib"; mkdir -p "$nolib_root/scripts/lib"
+cp "$BOOTSTRAP" "$nolib_root/scripts/bootstrap-agent-machine.sh"
+cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$nolib_root/scripts/lib/gate-notify.sh" 2>/dev/null || true
+nolib_d="$tmp/perf-nolib.d"; mkdir -p "$nolib_d"
+nolib_out=$(PERF_SECTION_OK=1 PATH="$checkapply_shims:$perfbin:$tmp:$PATH" \
+  HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$nolib_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$nolib_root/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+nolib_rc=$?
+if [ "$nolib_rc" -eq 0 ] \
+   && printf '%s' "$nolib_out" | grep -q 'perf-capability.sh missing from this checkout' \
+   && [ -z "$(ls -A "$nolib_d")" ] \
+   && ! printf '%s' "$nolib_out" | grep -q 'runtime now: perf_event_paranoid' \
+   && ! printf '%s' "$nolib_out" | grep -q 'perf capability VERIFIED' \
+   && ! printf '%s' "$nolib_out" | grep -qi 'command not found'; then
+  ok "perf section: an INHERITED PERF_SECTION_OK=1 cannot enter the implementation with no perf-capability.sh in the checkout"
+else
+  bad "perf section: an inherited PERF_SECTION_OK=1 entered the section without its library (rc=$nolib_rc)"
+  printf '%s\n' "$nolib_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# --- 5. THE FUNCTIONAL RESULT IS SUBORDINATE TO /proc, AND TO IDENTITY --------
+# 5a. A SUCCESSFUL perf stat while /proc says paranoid-4. Reporting the functional
+#     result as the overall verdict let a run print a `paranoid-*` diagnosis AND
+#     "VERIFIED" in the same output — contradictory, with the reassuring line winning
+#     the reader's attention. Overall verification now requires BOTH facts; a lone
+#     functional pass is PARTIAL DIAGNOSTIC INFORMATION and /proc governs.
+mkperfshim 8888888
+subord_d="$tmp/perf-subord.d"; mkdir -p "$subord_d"
+bash "$PERFLIB" --drop-in >"$subord_d/99-cqlite-perf.conf"   # current: only /proc disagrees
+subord_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$subord_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+subord_rc=$?
+if [ "$subord_rc" -eq 0 ] \
+   && ! printf '%s' "$subord_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$subord_out" | grep -q 'perf capability NOT verified' \
+   && printf '%s' "$subord_out" | grep -q 'PARTIAL DIAGNOSTIC INFORMATION' \
+   && printf '%s' "$subord_out" | grep -q '/proc is the AUTHORITY here: perf=paranoid-4' \
+   && printf '%s' "$subord_out" | grep -qi 'PERMISSION verdict' \
+   && printf '%s' "$subord_out" | grep -q 'cycles=8888888'; then
+  ok "perf section: a SUCCESSFUL perf stat while /proc says paranoid-4 is never 'VERIFIED' — reported as partial info, /proc governs"
+else
+  bad "perf section: a functional pass overrode a non-ok /proc verdict (rc=$subord_rc)"
+  printf '%s\n' "$subord_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5a-ii. The same rule on the OTHER non-ok token: kptr_restrict != 0 costs kernel
+#        SYMBOLS silently, and `perf stat -C 0 -e cycles` counts perfectly well without
+#        them — so this is the token most likely to be masked by a functional pass.
+kptr_proc="$tmp/perf-proc-kptr"; mkdir -p "$kptr_proc"
+printf -- '-1\n' >"$kptr_proc/perf_event_paranoid"
+printf '1\n'     >"$kptr_proc/kptr_restrict"
+kptr_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$kptr_proc" CQLITE_PERF_SYSCTL_DIR="$subord_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+kptr_rc=$?
+if [ "$kptr_rc" -eq 0 ] \
+   && ! printf '%s' "$kptr_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$kptr_out" | grep -q 'perf capability NOT verified' \
+   && printf '%s' "$kptr_out" | grep -q '/proc is the AUTHORITY here: perf=kptr-restricted' \
+   && printf '%s' "$kptr_out" | grep -q 'kptr_restrict != 0'; then
+  ok "perf section: a SUCCESSFUL perf stat while /proc says kptr-restricted is never 'VERIFIED' (the silent symbol loss still governs)"
+else
+  bad "perf section: a functional pass masked a kptr-restricted verdict (rc=$kptr_rc)"
+  printf '%s\n' "$kptr_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5b. THE PRIVILEGE DIMENSION — the most consequential case in this suite.
+#     perf_event_paranoid restricts UNPRIVILEGED users; ROOT BYPASSES IT. So under
+#     `sudo bash scripts/bootstrap-agent-machine.sh` — a normal provisioning
+#     invocation, and the likeliest one since writing /etc/sysctl.d needs root — a
+#     root `perf stat -C 0 -e cycles` SUCCEEDS on a paranoid=4 box where every
+#     unprivileged agent still gets EACCES. Bootstrap must therefore probe as an
+#     UNPRIVILEGED identity. Here the box offers `setpriv`, /proc is ALREADY ok, and
+#     the drop-in is current: the run must (1) say it dropped privilege, (2) actually
+#     route the collection through setpriv with the resolved uid/gid, and (3) only
+#     THEN report VERIFIED.
+droproot="$tmp/perf-droproot"; mkdir -p "$droproot"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$droproot/$t"
+done
+mkuname "$droproot" Linux
+mkid "$droproot" 0 1000       # we are root; `nobody` resolves to the unprivileged 1000
+droptrip="$tmp/perf-droproot-tripwire.log"; : >"$droptrip"
+# setpriv shim: records the exact drop it was asked for, then execs the collection —
+# so the assertion below proves the PROBE went through it, not merely that a line
+# claiming so was printed.
+cat >"$droproot/setpriv" <<EOF
+#!/usr/bin/env bash
+echo "setpriv \$*" >>"$droptrip"
+while [ \$# -gt 0 ]; do case "\$1" in --*) shift ;; *) break ;; esac; done
+exec "\$@"
+EOF
+printf '#!/usr/bin/env bash\necho "sysctl $*" >>"%s"\nexit 0\n' "$droptrip" >"$droproot/sysctl"
+chmod +x "$droproot/setpriv" "$droproot/sysctl"
+ln -sf "$perfbin/perf" "$droproot/perf"
+mkperfshim 1212121
+drop_proc="$tmp/perf-proc-drop"; mkdir -p "$drop_proc"
+printf -- '-1\n' >"$drop_proc/perf_event_paranoid"
+printf '0\n'     >"$drop_proc/kptr_restrict"
+drop_d="$tmp/perf-drop.d"; mkdir -p "$drop_d"
+bash "$PERFLIB" --drop-in >"$drop_d/99-cqlite-perf.conf"
+drop_out=$(PATH="$droproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$droproot" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+drop_rc=$?
+if [ "$drop_rc" -eq 0 ] \
+   && printf '%s' "$drop_out" | grep -q 'this run is ROOT and root BYPASSES perf_event_paranoid' \
+   && printf '%s' "$drop_out" | grep -q 'DROPS PRIVILEGE (dropped:setpriv:uid=1000)' \
+   && grep -q 'setpriv --reuid=1000 --regid=1000 --clear-groups' "$droptrip" \
+   && printf '%s' "$drop_out" | grep -q 'perf capability VERIFIED .*UNPRIVILEGED perf stat -C 0 -e cycles reports cycles=1212121'; then
+  ok "perf section: a ROOT run DROPS PRIVILEGE for the probe (setpriv, resolved uid/gid) and only then reports VERIFIED"
+else
+  bad "perf section: the root run did not probe as an unprivileged identity (rc=$drop_rc, tripwire='$(cat "$droptrip")')"
+  printf '%s\n' "$drop_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5b-ii. THE FALSE VERIFICATION ITSELF: the same ALREADY-ok box, the same succeeding
+#        perf — but no setpriv/runuser/sudo to drop privilege with. The functional
+#        result then says nothing about an unprivileged process, and reporting it as
+#        "VERIFIED" is exactly the false verification of an unprofileable box. It must
+#        be labelled as NOT evidence, with /proc left as the authority.
+nodroproot="$tmp/perf-nodroproot"; mkdir -p "$nodroproot"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nodroproot/$t"
+done
+mkuname "$nodroproot" Linux
+mkid "$nodroproot" 0 1000     # root, an unprivileged target exists, but no mechanism
+nodroptrip="$tmp/perf-nodroproot-tripwire.log"; : >"$nodroptrip"
+printf '#!/usr/bin/env bash\necho "sysctl $*" >>"%s"\nexit 0\n' "$nodroptrip" >"$nodroproot/sysctl"
+chmod +x "$nodroproot/sysctl"
+ln -sf "$perfbin/perf" "$nodroproot/perf"
+mkperfshim 2323232
+nodrop_out=$(PATH="$nodroproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$nodroproot" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+nodrop_rc=$?
+if [ "$nodrop_rc" -eq 0 ] \
+   && ! printf '%s' "$nodrop_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$nodrop_out" | grep -q 'perf capability NOT verified' \
+   && printf '%s' "$nodrop_out" | grep -q 'ran AS ROOT (root-no-drop-mechanism) and root BYPASSES perf_event_paranoid' \
+   && printf '%s' "$nodrop_out" | grep -q 'NOT evidence that an UNPRIVILEGED process can profile this box' \
+   && printf '%s' "$nodrop_out" | grep -q 'sudo -u <agent-user> perf stat'; then
+  ok "perf section: a ROOT probe with NO way to drop privilege is labelled NOT evidence of unprivileged capability (never 'VERIFIED'), even with /proc ok"
+else
+  bad "perf section: a root-only functional pass was reported as verification (rc=$nodrop_rc)"
+  printf '%s\n' "$nodrop_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5b-iii. ...and with NO unprivileged identity resolvable at all (no `nobody` on the
+#         box, no SUDO_UID), the state is distinct — nothing to probe AS, so nothing
+#         to claim. Root must not fall back to probing as itself and calling it good.
+notarget="$tmp/perf-notarget"; mkdir -p "$notarget"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$notarget/$t"
+done
+mkuname "$notarget" Linux
+mkid "$notarget" 0            # root, and `id -u nobody` FAILS: no unprivileged account
+printf '#!/usr/bin/env bash\nexit 0\n' >"$notarget/sysctl"
+chmod +x "$notarget/sysctl"
+ln -sf "$perfbin/perf" "$notarget/perf"
+ln -sf "$droproot/setpriv" "$notarget/setpriv"   # a mechanism exists; a TARGET does not
+mkperfshim 3434343
+notarget_out=$(PATH="$notarget" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$notarget" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+notarget_rc=$?
+if [ "$notarget_rc" -eq 0 ] \
+   && ! printf '%s' "$notarget_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$notarget_out" | grep -q 'ran AS ROOT (root-no-unprivileged-target)'; then
+  ok "perf section: root with no resolvable unprivileged identity reports that distinctly and claims no verification"
+else
+  bad "perf section: root with no unprivileged target mishandled (rc=$notarget_rc)"
+  printf '%s\n' "$notarget_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5b-iv. SUDO_UID is preferred over `nobody`: under `sudo bootstrap` it names the
+#        account whose profiling capability is actually in question, which is stronger
+#        evidence than an unrelated system account.
+sudouid_out=$(PATH="$droproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  SUDO_UID=1234 SUDO_GID=1235 SUDO_USER=agentuser \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$droproot" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+sudouid_rc=$?
+if [ "$sudouid_rc" -eq 0 ] \
+   && printf '%s' "$sudouid_out" | grep -q 'DROPS PRIVILEGE (dropped:setpriv:uid=1234)' \
+   && grep -q 'setpriv --reuid=1234 --regid=1235 --clear-groups' "$droptrip"; then
+  ok "perf section: under sudo the probe drops to SUDO_UID/SUDO_GID (the account actually in question), not to nobody"
+else
+  bad "perf section: SUDO_UID was not preferred as the probe identity (rc=$sudouid_rc)"
+  printf '%s\n' "$sudouid_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5c. The helper's identity-aware CLI, directly: `--verify-unpriv` must FAIL when the
+#     result cannot be attributed to an unprivileged process, even though the very same
+#     collection succeeded — and must report which state it was in. `--verify` keeps its
+#     narrower contract (this identity, whoever that is), so the two are not confusable.
+mkperfshim 5151515
+vu_self=$(PATH="$perfbin:$tmp:$PATH" bash "$PERFLIB" --verify-unpriv 2>&1); vu_self_rc=$?
+vu_root=$(PATH="$nodroproot" bash "$PERFLIB" --verify-unpriv 2>&1); vu_root_rc=$?
+if [ "$vu_self_rc" -eq 0 ] && printf '%s' "$vu_self" | grep -q 'cycles=5151515 identity=self-unprivileged' \
+   && [ "$vu_root_rc" -ne 0 ] && printf '%s' "$vu_root" | grep -q 'cycles=5151515 identity=root-no-drop-mechanism'; then
+  ok "perf-capability: --verify-unpriv passes only when the result is attributable to an unprivileged identity (and names the state)"
+else
+  bad "perf-capability: --verify-unpriv identity attribution wrong (self rc=$vu_self_rc '$vu_self'; root rc=$vu_root_rc '$vu_root')"
 fi
 
 # 4g. Nothing in this whole suite may have touched the REAL /etc/sysctl.d.

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -867,6 +867,135 @@ else
   printf '%s\n' "$checkapply_out" | sed -n '/Perf profiling/,/^$/p'
 fi
 
+# 4d-iii. THE APPLY COMMAND FAILED, THE CONTROLS TOOK ANYWAY. `sysctl --system` applies
+#         EVERY drop-in on the box, so it can apply OURS correctly and still exit
+#         non-zero because an unrelated pre-existing entry failed (a stale
+#         /etc/sysctl.conf line, a foreign drop-in naming a knob this kernel lacks) —
+#         and one such entry anywhere on a fleet box is enough. Gating the /proc
+#         read-back on that rc left the token STALE and printed "nothing was applied"
+#         about a box that had JUST become profileable: a false verdict, which is the
+#         one thing AC2 exists to prevent. The two facts are independent and must be
+#         reported independently — the command's failure named as the COMMAND's, and the
+#         capability verdict taken from /proc regardless. Here the sysctl shim exits 1
+#         AND updates the fake procfs.
+rcfail_proc="$tmp/perf-proc-rcfail"; mkdir -p "$rcfail_proc"
+printf '4\n' >"$rcfail_proc/perf_event_paranoid"
+printf '1\n' >"$rcfail_proc/kptr_restrict"
+rcfail_shims="$tmp/perf-rcfail-shims"; mkdir -p "$rcfail_shims"
+rcfail_trip="$tmp/perf-rcfail-tripwire.log"; : >"$rcfail_trip"
+cat >"$rcfail_shims/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >>"$rcfail_trip"
+while [ "\${1:-}" = "-n" ]; do shift; done
+exec "\$@"
+EOF
+cat >"$rcfail_shims/sysctl" <<EOF
+#!/usr/bin/env bash
+echo "sysctl \$*" >>"$rcfail_trip"
+case " \$* " in *" --system "*)
+  printf -- '-1\n' >"$rcfail_proc/perf_event_paranoid"
+  printf '0\n'     >"$rcfail_proc/kptr_restrict"
+  echo "sysctl: setting key \"vm.unrelated_stale_entry\": Invalid argument" >&2 ;;
+esac
+exit 1
+EOF
+for t in apt-get apt dnf yum pacman; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$rcfail_shims/$t"
+done
+chmod +x "$rcfail_shims"/*
+rcfail_d="$tmp/perf-rcfail.d"; mkdir -p "$rcfail_d"
+bash "$PERFLIB" --drop-in >"$rcfail_d/99-cqlite-perf.conf"   # already current: only the apply is left
+mkperfshim 6060606
+rcfail_out=$(PATH="$rcfail_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$rcfail_proc" CQLITE_PERF_SYSCTL_DIR="$rcfail_d" CQLITE_PERF_TEST_PRIV_DIR="$rcfail_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+rcfail_rc=$?
+# The read-back verdict must be GOOD (it is what /proc now says), the command failure
+# must be reported DISTINCTLY (naming the exit status and that it applies every
+# drop-in), and the two must not contradict: no "nothing was applied", no "did NOT
+# take", no "NOT in the profileable state" alongside a good read-back. rc still 0.
+if [ "$rcfail_rc" -eq 0 ] \
+   && printf '%s' "$rcfail_out" | grep -q "READ BACK from /proc as profileable: perf_event_paranoid=-1 kptr_restrict=0" \
+   && printf '%s' "$rcfail_out" | grep -q "'sysctl -q --system' exited 1" \
+   && printf '%s' "$rcfail_out" | grep -q 'UNRELATED pre-existing entry' \
+   && ! printf '%s' "$rcfail_out" | grep -q 'nothing was applied' \
+   && ! printf '%s' "$rcfail_out" | grep -q 'the value did NOT take' \
+   && ! printf '%s' "$rcfail_out" | grep -q 'NOT in the profileable state' \
+   && ! printf '%s' "$rcfail_out" | grep -q 'are NOT in effect' \
+   && grep -q 'sysctl -q --system' "$rcfail_trip"; then
+  ok "perf section: a sysctl that FAILS while the controls DO take reports the command failure distinctly and still reads the good verdict back from /proc, rc 0"
+else
+  bad "perf section: a failing sysctl suppressed the /proc read-back or contradicted it (rc=$rcfail_rc)"
+  printf '%s\n' "$rcfail_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# ...and the run must still be honest when BOTH facts are bad: the same failing sysctl
+# with a procfs that does NOT change must name the command failure AND report the
+# controls as not in effect — never a good read-back.
+rcfail2_proc="$tmp/perf-proc-rcfail2"; mkdir -p "$rcfail2_proc"
+printf '4\n' >"$rcfail2_proc/perf_event_paranoid"
+printf '1\n' >"$rcfail2_proc/kptr_restrict"
+rcfail2_shims="$tmp/perf-rcfail2-shims"; mkdir -p "$rcfail2_shims"
+cp "$rcfail_shims/sudo" "$rcfail2_shims/sudo"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$rcfail2_shims/sysctl"
+for t in apt-get apt dnf yum pacman; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$rcfail2_shims/$t"
+done
+chmod +x "$rcfail2_shims"/*
+rcfail2_out=$(PATH="$rcfail2_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$rcfail2_proc" CQLITE_PERF_SYSCTL_DIR="$rcfail_d" CQLITE_PERF_TEST_PRIV_DIR="$rcfail2_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+rcfail2_rc=$?
+if [ "$rcfail2_rc" -eq 0 ] \
+   && printf '%s' "$rcfail2_out" | grep -q "'sysctl -q --system' exited 1" \
+   && printf '%s' "$rcfail2_out" | grep -q 'the controls are NOT in effect' \
+   && ! printf '%s' "$rcfail2_out" | grep -q 'READ BACK from /proc as profileable' \
+   && ! printf '%s' "$rcfail2_out" | grep -q 'reported success'; then
+  ok "perf section: a failing sysctl whose controls did NOT take reports BOTH facts (command exited 1 + controls not in effect), never a good read-back"
+else
+  bad "perf section: the both-bad case mishandled (rc=$rcfail2_rc)"
+  printf '%s\n' "$rcfail2_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4d-iv. CURRENT DROP-IN + NO PRIVILEGE + non-ok runtime: nothing to WRITE (so the
+#        write remedy is not the fix) and no non-interactive privilege to APPLY, which
+#        used to print a diagnosis with NO remedy at all — contradicting every other
+#        unprivileged path in this section. Two boxes, two remedies: a box with no sudo
+#        BINARY needs the root-shell line (a `sudo` line is un-runnable there), a box
+#        whose sudo needs a password needs the same line WITH `sudo` (it works
+#        interactively).
+noapply_d="$tmp/perf-noapply.d"; mkdir -p "$noapply_d"
+bash "$PERFLIB" --drop-in >"$noapply_d/99-cqlite-perf.conf"
+noapply_ref="$tmp/perf-noapply-ref.conf"; cp "$noapply_d/99-cqlite-perf.conf" "$noapply_ref"
+noapply_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$noapply_d" CQLITE_PERF_TEST_PRIV_DIR="$nosudo" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+noapply_rc=$?
+if [ "$noapply_rc" -eq 0 ] \
+   && cmp -s "$noapply_ref" "$noapply_d/99-cqlite-perf.conf" \
+   && printf '%s' "$noapply_out" | grep -q 'drop-in already current' \
+   && printf '%s' "$noapply_out" | grep -q 'NOT in the profileable state' \
+   && printf '%s' "$noapply_out" | grep -q "no 'sudo' on this box — apply it from a ROOT shell:  sysctl -q --system" \
+   && ! printf '%s' "$noapply_out" | grep -q 'sudo sysctl'; then
+  ok "perf section: a current drop-in that cannot be applied (no sudo binary) still prints a RUNNABLE root-shell apply remedy, writes nothing, exits 0"
+else
+  bad "perf section: the current-drop-in/no-privilege branch printed no usable apply remedy (rc=$noapply_rc)"
+  printf '%s\n' "$noapply_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+noapply2_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$noapply_d" CQLITE_PERF_TEST_PRIV_DIR="$pwsudo" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+noapply2_rc=$?
+if [ "$noapply2_rc" -eq 0 ] \
+   && cmp -s "$noapply_ref" "$noapply_d/99-cqlite-perf.conf" \
+   && printf '%s' "$noapply2_out" | grep -q 'NOT in the profileable state' \
+   && printf '%s' "$noapply2_out" | grep -q 'apply the drop-in now:  sudo sysctl -q --system' \
+   && ! printf '%s' "$noapply2_out" | grep -q "no 'sudo' on this box"; then
+  ok "perf section: the same branch on a password-requiring sudo prints the INTERACTIVE 'sudo sysctl -q --system' apply remedy"
+else
+  bad "perf section: the password-sudo current-drop-in branch remedy is wrong (rc=$noapply2_rc)"
+  printf '%s\n' "$noapply2_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
 # 4e. A box with NO `perf` at all must WARN + print the install remedy and STILL exit
 #      0 — bootstrap is the fleet provisioning entry point, so a hard exit here would
 #      break every box without linux-tools. Every other case has perf on PATH, so an

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -241,24 +241,24 @@ fi
 noseam_out=$(env -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_TEST_MODE=1 \
   bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); noseam_rc=$?
 if [ "$noseam_rc" -ne 0 ] \
-   && printf '%s' "$noseam_out" | grep -q 'requires CQLITE_PERF_PROC_DIR INSIDE the declared sandbox' \
-   && printf '%s' "$noseam_out" | grep -q 'requires CQLITE_PERF_SYSCTL_DIR INSIDE the declared sandbox' \
+   && printf '%s' "$noseam_out" | grep -q 'requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR' \
+   && printf '%s' "$noseam_out" | grep -q 'requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR' \
    && printf '%s' "$noseam_out" | grep -q 'NEVER falls back'; then
   ok "perf-capability: test mode with NO path seams REFUSES loudly and names BOTH missing sandbox dirs"
 else
   bad "perf-capability: test mode without seams was allowed to act (rc=$noseam_rc, out='$noseam_out')"
 fi
-# A seam pointing AT production (or anywhere under /etc, /proc, /sys) is refused because it
-# is not inside the sandbox — no forbidden name is consulted — and a RELATIVE path is not a
-# sandbox path either. Each rejection is asserted BY ITS REASON, not merely by a non-zero rc:
-# this guard has a second refusal (a real sudo/sysctl on PATH) that would otherwise satisfy
-# an rc-only check and let a containment regression pass unnoticed.
+# A seam pointing AT production (or anywhere under /etc, /proc, /sys) is the same hole
+# wearing a seam, and a RELATIVE path is not a sandbox either.
+# Each rejection is asserted BY ITS REASON, not merely by a non-zero rc: this guard has a
+# second refusal (a real sudo/sysctl on PATH) that would otherwise satisfy an rc-only
+# check and let a seam-validation regression pass unnoticed.
 guard_rejects_seam() { # guard_rejects_seam <which:PROC|SYSCTL> <proc-seam> <sysctl-seam>
   local out
   out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
           CQLITE_PERF_PROC_DIR="$2" CQLITE_PERF_SYSCTL_DIR="$3" \
           bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1) && return 1
-  printf '%s' "$out" | grep -q "CQLITE_PERF_${1}_DIR INSIDE the declared sandbox"
+  printf '%s' "$out" | grep -q "NON-PRODUCTION CQLITE_PERF_${1}_DIR"
 }
 for badseam in /etc/sysctl.d /etc/sysctl.d/sub /etc /proc /proc/sys/kernel /sys relative/dir ''; do
   guard_rejects_seam SYSCTL "$seamed_proc" "$badseam" || {
@@ -275,70 +275,20 @@ guard_rejects_seam SYSCTL "$seamed_proc" "$symseam" || {
   bad "perf-capability: test mode ACCEPTED a sysctl seam that is a SYMLINK to /etc/sysctl.d"; badseam_fail=1; }
 guard_rejects_seam PROC "$symproc" "$seamed_d" || {
   bad "perf-capability: test mode ACCEPTED a proc seam that is a SYMLINK to /proc/sys/kernel"; badseam_fail=1; }
-# ...and the SPELLING is not the destination. `/tmp/../etc/sysctl.d`, `<symlink-to-/etc>/…`
-# and — the R6-1 escape — `//etc/sysctl.d` (POSIX leaves two leading slashes
-# implementation-defined and `pwd -P` may PRESERVE them, while on Linux `//etc` IS `/etc`)
-# each passed the textual checks of an earlier round. There is no per-spelling check any
-# more: containment refuses all of them, plus every future spelling, for the SAME reason.
-# An UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
+# ...and the SPELLING is not the destination (issue #3249 review R5-1): `/tmp/../etc/sysctl.d`
+# and `<symlink-to-/etc>/sysctl.d` pass every textual test above, and a root `--yes` run
+# resolves BOTH to the production directory. Each escape so far was one more spelling of
+# "somewhere else", so the write-side guard now judges the CANONICAL destination. An
+# UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
 symanc="$tmp/symlinked-ancestor"; rm -f "$symanc"; ln -s /etc "$symanc"
-symout="$tmp/symlink-out-of-sandbox"; rm -f "$symout"; ln -s /tmp "$symout"
 for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d" "$tmp/./nonexistent-sandbox.d" \
-                   "$tmp/no-such-sandbox.d" "//etc/sysctl.d" "//etc/sysctl.d/sub" \
-                   "$symout" "$tmp"; do
+                   "$tmp/no-such-sandbox.d"; do
   guard_rejects_seam SYSCTL "$seamed_proc" "$resolveseam" || {
-    bad "perf-capability: test mode ACCEPTED a sysctl seam that is not strictly inside its sandbox: '$resolveseam'"; badseam_fail=1; }
+    bad "perf-capability: test mode ACCEPTED a sysctl seam that RESOLVES outside its sandbox: '$resolveseam'"; badseam_fail=1; }
 done
-for resolveseam in "$symanc/sysctl.d" "//proc/sys/kernel" "$symout"; do
-  guard_rejects_seam PROC "$resolveseam" "$seamed_d" || {
-    bad "perf-capability: test mode ACCEPTED a proc seam outside its sandbox: '$resolveseam'"; badseam_fail=1; }
-done
-[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam, one that RESOLVES out of the sandbox (.., a symlinked ancestor, a symlink to /tmp), the '//etc' double-slash spelling, a sibling-prefix path and the sandbox ROOT itself — on BOTH sandbox dirs, naming the offending seam"
-# 1c-iii-b. THE CONTAINMENT BOUNDARY AND THE SANDBOX ROOT ITSELF (issue #3249 review
-#           R6-1/R6-2). Containment is only as good as its boundary and its root:
-#             * `/tmp/sandboxevil` must NOT count as inside `/tmp/sandbox` — a plain string
-#               prefix would accept it, which is why the `/` boundary is explicit;
-#             * a path genuinely inside the declared root must still WORK, so the guard is
-#               not vacuously refusing everything (the failure mode a negative-only test
-#               cannot see);
-#             * the ROOT must PROVE itself — unset, relative, `//`-spelled, non-existent, or
-#               an existing directory with no stamp are all refusals NAMING
-#               CQLITE_PERF_TEST_SANDBOX. Without that, `CQLITE_PERF_TEST_SANDBOX=/etc`
-#               would make containment vacuous, and the inversion would have bought nothing.
-sbx="$tmp/sandbox"; mkdir -p "$sbx/inside" "$sbx/inside-proc"; : >"$sbx/.cqlite-perf-sandbox"
-mkdir -p "${sbx}evil"                       # the sibling whose NAME starts with the root's
-nostamp="$tmp/unstamped-root"; mkdir -p "$nostamp/inside"
-guard_with_root() { # guard_with_root <sandbox-root> <proc-seam> <sysctl-seam> -> rc + stderr
-  # $realpriv FIRST on PATH with the same dir declared: the guard's OTHER refusal (a real
-  # sudo/sysctl reachable) must not be what decides these cases.
-  env PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
-    CQLITE_PERF_TEST_SANDBOX="$1" CQLITE_PERF_PROC_DIR="$2" CQLITE_PERF_SYSCTL_DIR="$3" \
-    bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1
-}
-bnd_fail=0
-guard_with_root "$sbx" "$sbx/inside-proc" "$sbx/inside" >/dev/null 2>&1 \
-  || { bad "perf-capability: a seam genuinely INSIDE the declared sandbox was refused (the guard is vacuous)"; bnd_fail=1; }
-bnd_out=$(guard_with_root "$sbx" "$sbx/inside-proc" "${sbx}evil") && bnd_fail=1
-printf '%s' "$bnd_out" | grep -q 'CQLITE_PERF_SYSCTL_DIR INSIDE the declared sandbox' || bnd_fail=1
-[ "$bnd_fail" -eq 0 ] || bad "perf-capability: '${sbx}evil' was treated as inside '$sbx' (prefix match without a / boundary), or a contained seam was refused"
-[ "$bnd_fail" -ne 0 ] || ok "perf-capability: containment is boundary-exact — a seam inside the declared sandbox is ACCEPTED while the sibling '<root>evil' is REFUSED by name"
-root_fail=0
-for badroot in '' relative/sandbox "//$tmp" "$tmp/no-such-root" "$nostamp"; do
-  ro=$(guard_with_root "$badroot" "$sbx/inside-proc" "$sbx/inside") && root_fail=1
-  printf '%s' "$ro" | grep -q 'requires CQLITE_PERF_TEST_SANDBOX' || root_fail=1
-  [ "$root_fail" -eq 0 ] || { bad "perf-capability: sandbox root '$badroot' was accepted (or refused without naming CQLITE_PERF_TEST_SANDBOX)"; break; }
-done
-[ "$root_fail" -ne 0 ] || ok "perf-capability: the sandbox ROOT must prove itself — unset/relative/'//'-spelled/absent/UNSTAMPED are refusals naming CQLITE_PERF_TEST_SANDBOX (so a stray CQLITE_PERF_TEST_SANDBOX=/etc cannot make containment vacuous)"
-# ...and the FORK-FREE read path applies the same containment: a `//`-spelled or
-# out-of-sandbox proc seam reads NOTHING (token `absent`), never the host's real /proc —
-# whose paranoid/kptr values would otherwise show up as ok/paranoid-N/kptr-restricted here.
-read_fail=0
-for badproc in "//proc/sys/kernel" "$symanc/sysctl.d" "/proc/sys/kernel" "${sbx}evil"; do
-  rt=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$sbx" \
-         CQLITE_PERF_PROC_DIR="$badproc" bash "$PERFLIB" --token 2>/dev/null)
-  [ "$rt" = absent ] || { bad "perf-capability: the read path used an out-of-sandbox proc seam '$badproc' (token '$rt', expected 'absent')"; read_fail=1; }
-done
-[ "$read_fail" -ne 0 ] || ok "perf-capability: the fork-free READ path refuses an out-of-sandbox proc seam (including the '//proc' spelling) — token 'absent', the real /proc never read"
+guard_rejects_seam PROC "$symanc/sysctl.d" "$seamed_d" || {
+  bad "perf-capability: test mode ACCEPTED a proc seam with a SYMLINKED ANCESTOR into /etc"; badseam_fail=1; }
+[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam AND one that merely RESOLVES into production (.. or a symlinked ancestor), on BOTH sandbox dirs, naming the offending seam"
 # ...and the write TARGET is re-validated independently of the guard: --drop-in-path may
 # never NAME a production file, because that string is what a root `tee` is pointed at.
 for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d"; do
@@ -597,24 +547,17 @@ if printf '%s\n' "$sp_out" | grep -q "^earlier $sp_hi/10-hardening.conf$" \
 else
   bad "perf-capability: search-path scan wrong: '$sp_out'"
 fi
-# ...and an EXTRA-DIRS entry that is not provably inside the sandbox fails the whole scan
-# CLOSED (rc 1, no output): a test-mode scan may never read the host's real /run or /usr/lib,
-# and a bad entry is an UNKNOWN, not "no competitor". THIS ENTRY POINT IS R6-2: it used the
-# textual validator while the write path canonicalized, so a SYMLINKED ANCESTOR (and the
-# `//etc` spelling) could point a "sandboxed" scan at the host's real configuration. It now
-# goes through the same resolving gate — dirs and the `sysctl.conf` FILE entry alike.
-for spbad in /etc/sysctl.d relative/dir "/tmp/../etc/sysctl.d" "//etc/sysctl.d" \
-             "$symanc/sysctl.d" "$symanc/sysctl.conf" "$symout" "$tmp/../etc/sysctl.d"; do
-  sp_this=0
+# ...and an EXTRA-DIRS entry that is not an absolute non-production path fails the whole
+# scan CLOSED (rc 1, no output): a test-mode scan may never read the host's real /run or
+# /usr/lib, and a bad entry is an UNKNOWN, not "no competitor".
+for spbad in /etc/sysctl.d relative/dir "/tmp/../etc/sysctl.d"; do
   sp_bad_out=$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$sp_hi" \
     CQLITE_PERF_SYSCTL_EXTRA_DIRS="$spbad" \
-    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null) && sp_this=1
-  # No output at all, and in particular NOT ONE host path: this is the "no host file read"
-  # half of the property, so it is asserted rather than inferred from the rc.
-  [ -z "$sp_bad_out" ] || sp_this=1
-  [ "$sp_this" -eq 0 ] || { bad "perf-capability: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry '$spbad' did not fail the scan closed (out='$sp_bad_out')"; sp_bad_fail=1; }
+    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null) && sp_bad_fail=1
+  [ -z "$sp_bad_out" ] || sp_bad_fail=1
+  [ -z "${sp_bad_fail:-}" ] || bad "perf-capability: a production/relative CQLITE_PERF_SYSCTL_EXTRA_DIRS entry '$spbad' did not fail the scan closed"
 done
-[ -n "${sp_bad_fail:-}" ] || ok "perf-capability: an extra search-path entry outside the sandbox — production-shaped, relative, '//etc'-spelled, or reached through a SYMLINKED ANCESTOR (dir or sysctl.conf FILE) — fails the scan CLOSED (rc 1, no output, no host path named)"
+[ -n "${sp_bad_fail:-}" ] || ok "perf-capability: a production-shaped/relative/resolving-into-production extra search-path entry fails the scan CLOSED (rc 1, no output)"
 # ...and an UNREADABLE directory is an UNKNOWN (rc 1), never "no competing file": this
 # diagnostic exists to replace an unknown with a named file, so answering an unknown with
 # the reassuring line would recreate the mystery it was written to end.
@@ -770,62 +713,6 @@ else
     *no-perf-binary*) ok "perf-capability: verify fails with 'no-perf-binary' when perf is absent" ;;
     *) bad "perf-capability: unexpected no-perf verdict: $noperf_out" ;;
   esac
-fi
-
-# 1f. THE GATE IS SINGULAR AND UNSKIPPABLE — a STRUCTURAL audit (issue #3249 review R6-2).
-#     R6-2 was not a wrong check, it was a MISSING one: CQLITE_PERF_SYSCTL_EXTRA_DIRS was a
-#     new seam consumer, and the canonicalizing validation added for the write path simply
-#     never reached it. No behavioural case can catch that class, because the defect is a
-#     path nobody thought to test. So this audit enumerates, FROM THE SOURCE, every function
-#     that dereferences a seam variable and requires each one to route through the
-#     containment family (`perf_capability_sandbox_*` / `perf_capability_path_within`) — with
-#     ONE named, justified allowlist entry. A future entry point that reads a seam without
-#     the gate FAILS here, and joining the allowlist is a visible, reviewable act.
-#
-#     Same shape as the fork-free audit in test_agent_gate_summary.sh: parse the function
-#     bodies (a column-0 `name() {` … column-0 `}`), and treat FINDING NOTHING as a failure,
-#     so a parser that stops matching can never pass this vacuously.
-seam_audit=$(awk \
-  -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX)' \
-  -v gatere='perf_capability_(sandbox_|path_within)' '
-  /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
-    fn = $1; sub(/\(\)$/, "", fn); seam = 0; gate = 0
-    if ($0 ~ seamre) seam = 1
-    if ($0 ~ gatere) gate = 1
-    if ($0 ~ /\}[[:space:]]*$/) { printf "%s %d %d\n", fn, seam, gate; inb = 0 }
-    else inb = 1
-    next
-  }
-  inb && /^\}/ { printf "%s %d %d\n", fn, seam, gate; inb = 0; next }
-  inb {
-    if ($0 ~ seamre) seam = 1
-    if ($0 ~ gatere) gate = 1
-  }
-' "$PERFLIB")
-# The ONLY function allowed to read a seam without the gate, and why: it asks whether a seam
-# was handed to us AT ALL (for the marker-less refusal) and never uses the value as a path.
-# The containment family's own root reader is the gate, so it is named here too.
-seam_audit_allow=' perf_capability_seam_set perf_capability_sandbox_root_into '
-seam_consumers=0; seam_ungated=''
-while read -r fn seam gate; do
-  [ -n "$fn" ] || continue
-  [ "$seam" = 1 ] || continue
-  seam_consumers=$((seam_consumers + 1))
-  case "$seam_audit_allow" in *" $fn "*) continue ;; esac
-  [ "$gate" = 1 ] || seam_ungated="$seam_ungated $fn"
-done <<EOF
-$seam_audit
-EOF
-# 4 is the count at the time of writing (proc_dir_into, sysctl_dir, sysctl_search_path,
-# test_seams_ok) plus the two allowlisted readers; the assert is a FLOOR, so adding a
-# consumer is fine and losing the parse is not.
-if [ "$seam_consumers" -ge 5 ] && [ -z "$seam_ungated" ] \
-   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_sysctl_search_path 1 1$' \
-   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_proc_dir_into 1 1$'; then
-  ok "perf-capability: STRUCTURAL — all $seam_consumers seam-dereferencing functions route through the single containment gate (only the documented presence-check + the root reader are allowlisted), so a new entry point cannot silently skip it"
-else
-  bad "perf-capability: STRUCTURAL audit failed — seam consumers found: $seam_consumers; UNGATED:${seam_ungated:- none}"
-  printf '%s\n' "$seam_audit"
 fi
 
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -30,15 +30,24 @@ PERFLIB="$SCRIPT_DIR/../perf-capability.sh"
 
 PASS=0
 FAIL=0
-# Wall-clock stamp used ONLY to attribute a pre-existing host file (the last case
-# asks "did WE create /etc/sysctl.d/99-cqlite-perf.conf, or was the box already
-# bootstrapped?"). Never a threshold on a measured duration. perf-gate-allow
-SUITE_START=$(date +%s)
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
 
+# sudo_perf_offenders <tripwire-log>: the recorded `sudo` lines belonging to the PERF
+# path (its `-n` availability probe, its `tee`, its `sysctl`) that do NOT carry `-n`.
+# `-n` is what makes bootstrap unpromptable on an unattended worker, so dropping it
+# from PERF_ROOT is a defect every functional assert would still pass. Lines from other
+# bootstrap sections (e.g. the mold `sudo apt-get install`) are out of this issue's scope.
+sudo_perf_offenders() {
+  grep -E '^sudo ' "$1" 2>/dev/null | grep -E '(\btee\b|\bsysctl\b|\btrue\b)' | grep -v '^sudo -n ' || true
+}
+
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-test.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT
+# Reference file for the "did WE create the real /etc/sysctl.d drop-in?" attribution
+# in the final case: a plain `-nt` comparison against a file created NOW, so no
+# `stat -c %Y` (GNU-only) and no wall-clock arithmetic anywhere in this suite.
+suite_ref="$tmp/.suite-start"; : >"$suite_ref"
 
 # Global-state isolation, same posture as test_bootstrap_agent_machine.sh: the
 # bootstrap runs below read/write git config and read board env, and this suite runs
@@ -49,6 +58,31 @@ export GIT_CONFIG_NOSYSTEM=1
 unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
 # A worker shell may export the seams themselves; a test must set exactly what it means.
 unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR
+# The two path seams are INERT unless this marker is set, and the marker itself
+# forbids reaching a real sudo/sysctl (the shim dir is declared per case in
+# CQLITE_PERF_TEST_PRIV_DIR). Cases that must exercise the PRODUCTION defaults run
+# with `env -u CQLITE_PERF_TEST_MODE`.
+export CQLITE_PERF_TEST_MODE=1
+
+# mkuname <dir> <sysname>: a `uname` stub, so the Linux/Darwin branch under test is
+# the one selected by the CASE, not by whatever host runs the suite. Without this the
+# whole suite was silently Linux-host-only: on a Darwin gate host every bootstrap run
+# below would take the "nothing to configure on macos" path and 10 cases would fail.
+# `-r`/`-m` answer too, because bootstrap uses them elsewhere.
+mkuname() {
+  # rm FIRST: several dirs below `ln -sf` the real uname into place, and writing
+  # through that symlink would clobber the host's /usr/bin/uname.
+  rm -f "$1/uname"
+  cat >"$1/uname" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  -r) echo 6.0.0-cqlite-test ;;
+  -m) echo x86_64 ;;
+  *)  echo $2 ;;
+esac
+EOF
+  chmod +x "$1/uname"
+}
 
 # Inert shims for the tools the surrounding bootstrap sections would otherwise
 # reach (network / installs). Only the perf-specific shims below are functional.
@@ -64,6 +98,7 @@ mkshim brew
 mkshim cargo
 mkshim roborev
 mkshim gh
+mkuname "$tmp" Linux   # every bootstrap run below that includes $tmp in PATH is Linux
 host_home="$tmp/host-home"; mkdir -p "$host_home/.cargo"
 
 # --- 1. The shared helper: scripts/perf-capability.sh ------------------------------
@@ -167,10 +202,78 @@ else
   bad "perf-capability: drop-in content is missing a control, the rationale or the posture"
   printf '%s\n' "$dropin"
 fi
-if [ "$(CQLITE_PERF_SYSCTL_DIR=/etc/sysctl.d bash "$PERFLIB" --drop-in-path)" = /etc/sysctl.d/99-cqlite-perf.conf ]; then
-  ok "perf-capability: drop-in path is /etc/sysctl.d/99-cqlite-perf.conf (survives reboot)"
+# 1c-i. The PRODUCTION defaults, asserted with the seams OFF. Every other case here
+#       sets both seams, so a default changed to /tmp/bogus-* would have gone
+#       unnoticed; these two read-only string asserts pin the real literals. They
+#       stay hermetic — nothing is read or written, only the resolved path printed.
+if [ "$(env -u CQLITE_PERF_TEST_MODE -u CQLITE_PERF_SYSCTL_DIR -u CQLITE_PERF_PROC_DIR \
+          bash "$PERFLIB" --drop-in-path)" = /etc/sysctl.d/99-cqlite-perf.conf ]; then
+  ok "perf-capability: the DEFAULT drop-in path is /etc/sysctl.d/99-cqlite-perf.conf (survives reboot)"
 else
-  bad "perf-capability: unexpected drop-in path"
+  bad "perf-capability: unexpected default drop-in path"
+fi
+default_proc=$(env -u CQLITE_PERF_TEST_MODE -u CQLITE_PERF_SYSCTL_DIR -u CQLITE_PERF_PROC_DIR \
+  bash -c '. "$1"; perf_capability_proc_dir' _ "$PERFLIB")
+if [ "$default_proc" = /proc/sys/kernel ]; then
+  ok "perf-capability: the DEFAULT proc dir is /proc/sys/kernel"
+else
+  bad "perf-capability: unexpected default proc dir: '$default_proc'"
+fi
+
+# 1c-ii. The test seams are INERT without the marker, and a PRIVILEGED caller REFUSES
+#        outright. This is the security property: bootstrap pipes the drop-in through
+#        `sudo tee <path>`, so an env-derived destination let one stray export
+#        (CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d) make ROOT write an env-chosen file
+#        while the real drop-in was never installed — and an unparsable sudoers entry
+#        can wedge `sudo` outright. Same for a fake /proc fabricating a verdict.
+seam_no_marker_path=$(env -u CQLITE_PERF_TEST_MODE CQLITE_PERF_SYSCTL_DIR="$tmp/evil-sysctl.d" \
+  bash "$PERFLIB" --drop-in-path)
+if [ "$seam_no_marker_path" = /etc/sysctl.d/99-cqlite-perf.conf ]; then
+  ok "perf-capability: CQLITE_PERF_SYSCTL_DIR is INERT without CQLITE_PERF_TEST_MODE=1 (path stays the hardcoded literal)"
+else
+  bad "perf-capability: a seam without the marker steered the drop-in path to '$seam_no_marker_path'"
+fi
+seam_no_marker_proc=$(env -u CQLITE_PERF_TEST_MODE CQLITE_PERF_PROC_DIR="$perfproc" \
+  bash -c '. "$1"; perf_capability_proc_dir' _ "$PERFLIB")
+if [ "$seam_no_marker_proc" = /proc/sys/kernel ]; then
+  ok "perf-capability: CQLITE_PERF_PROC_DIR is INERT without the marker (no fabricated /proc verdict)"
+else
+  bad "perf-capability: a seam without the marker steered the /proc read to '$seam_no_marker_proc'"
+fi
+guard_out=$(env -u CQLITE_PERF_TEST_MODE CQLITE_PERF_SYSCTL_DIR="$tmp/evil-sysctl.d" \
+  bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); guard_rc=$?
+if [ "$guard_rc" -ne 0 ] && printf '%s' "$guard_out" | grep -qi 'REFUSING'; then
+  ok "perf-capability: env guard REFUSES loudly when a seam is set without the marker"
+else
+  bad "perf-capability: env guard allowed a marker-less seam (rc=$guard_rc, out='$guard_out')"
+fi
+# ...and the marker is itself hermetic: with it set, a REAL sudo/sysctl on PATH is a
+# refusal, so test mode can never reach a real privileged tool.
+realpriv="$tmp/realpriv"; mkdir -p "$realpriv"
+for t in sudo sysctl; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$realpriv/$t"; chmod +x "$realpriv/$t"
+done
+guard2_out=$(PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$tmp/some-other-dir" \
+  bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); guard2_rc=$?
+if [ "$guard2_rc" -ne 0 ] && printf '%s' "$guard2_out" | grep -q 'outside the declared shim dir'; then
+  ok "perf-capability: test mode REFUSES when sudo resolves outside the declared shim dir"
+else
+  bad "perf-capability: test mode accepted an undeclared sudo (rc=$guard2_rc, out='$guard2_out')"
+fi
+# ...and `sysctl` is guarded as strictly as `sudo` (a real `sysctl --system` would
+# reconfigure the HOST kernel, marker or not).
+guard3_out=$(PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$tmp/only-sudo-here" \
+  bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1)
+if printf '%s' "$guard3_out" | grep -q 'sysctl resolves to\|sudo resolves to'; then
+  ok "perf-capability: test mode guards BOTH sudo and sysctl against a real binary"
+else
+  bad "perf-capability: test mode did not name the offending privileged tool: '$guard3_out'"
+fi
+if PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
+     bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>/dev/null; then
+  ok "perf-capability: test mode ACCEPTS a sudo inside the declared shim dir"
+else
+  bad "perf-capability: test mode rejected its own declared shim dir"
 fi
 
 # 1d. The FUNCTIONAL verification is HONOURED, not merely attempted — the #3119
@@ -184,6 +287,24 @@ mkperfshim() { # mkperfshim <csv-count-field>
 echo "perf \$*" >>"\$PERFSHIM_LOG"
 printf '%s\n' '$1,,cycles,100000000,100.00,,'
 exit 0
+EOF
+  chmod +x "$perfbin/perf"
+}
+# mkperfshim_raw <exit-code> <stdout-line>...: the general shim — an EXACT exit code
+# and arbitrary CSV rows (or none). The `perf stat` failure and empty-output paths are
+# the REAL states on an unbootstrapped box (paranoid=4 denies the syscall outright, so
+# perf exits non-zero), and every shim above exits 0 — so without this those two
+# branches were never driven and a mutation making either RETURN SUCCESS survived.
+mkperfshim_raw() {
+  local rc="$1"; shift
+  local data="$perfbin/perf.rows" line
+  : >"$data"
+  for line in "$@"; do printf '%s\n' "$line" >>"$data"; done
+  cat >"$perfbin/perf" <<EOF
+#!/usr/bin/env bash
+echo "perf \$*" >>"\$PERFSHIM_LOG"
+cat "$data"
+exit $rc
 EOF
   chmod +x "$perfbin/perf"
 }
@@ -208,6 +329,89 @@ done
 if [ "$ver_fail" -eq 0 ]; then
   ok "perf-capability: verify requires a NON-ZERO cycle count (0 / <not supported> / <not counted> all FAIL)"
 fi
+# 1d-i. HYBRID PMU (Intel 12th-gen+ P/E cores): perf reports one row per PMU with
+#       QUALIFIED event names (`cpu_core/cycles/`, `cpu_atom/cycles/`), routinely with
+#       `<not supported>` on the sibling that did not run. A parser keyed on a literal
+#       leading `cycles` calls that good collection `no-cycles-row`, i.e. reports a
+#       profileable box as broken. Accept the qualified name and the positive row.
+hybrid_v=$(mkperfshim_raw 0 '<not supported>,,cpu_atom/cycles/,0,100.00,,' '31415926,,cpu_core/cycles/,100000000,100.00,,'
+  PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>&1)
+if [ "$hybrid_v" = "cycles=31415926" ]; then
+  ok "perf-capability: a hybrid-PMU qualified cycle row (cpu_core/cycles/) is accepted, sibling <not supported> ignored"
+else
+  bad "perf-capability: hybrid-PMU rows misparsed: '$hybrid_v'"
+fi
+# ...and the order must not matter (positive row first, unsupported sibling second).
+hybrid2_v=$(mkperfshim_raw 0 '2718281,,cpu_core/cycles/,100000000,100.00,,' '<not supported>,,cpu_atom/cycles/,0,100.00,,'
+  PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>&1)
+if [ "$hybrid2_v" = "cycles=2718281" ]; then
+  ok "perf-capability: a hybrid-PMU positive row is accepted regardless of row order"
+else
+  bad "perf-capability: hybrid-PMU row order changed the verdict: '$hybrid2_v'"
+fi
+# ...while a hybrid box where NO PMU counted is still a failure, not a pass.
+hybrid3_v=$(mkperfshim_raw 0 '<not supported>,,cpu_atom/cycles/,0,100.00,,' '<not counted>,,cpu_core/cycles/,0,100.00,,'
+  PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>&1); hybrid3_rc=$?
+if [ "$hybrid3_rc" -ne 0 ] && printf '%s' "$hybrid3_v" | grep -q 'counter-not-supported'; then
+  ok "perf-capability: a hybrid box where NO PMU counted still FAILS (counter-not-supported)"
+else
+  bad "perf-capability: an all-unsupported hybrid collection was accepted (rc=$hybrid3_rc, '$hybrid3_v')"
+fi
+
+# 1d-ii. `perf stat` EXITING NON-ZERO is the actual paranoid=4 state — the denial this
+#        whole issue is about — and every shim above exits 0, so the branch shipped
+#        untested: a mutation making it print `cycles=1` and return 0 survived. Drive
+#        it with the real help text a denied perf prints.
+mkperfshim_raw 1 'Error:' 'Access to performance monitoring and observability operations is limited.' \
+  'Consider adjusting /proc/sys/kernel/perf_event_paranoid setting to open' >/dev/null
+denied_v=$(PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>&1); denied_rc=$?
+if [ "$denied_rc" -ne 0 ] && printf '%s' "$denied_v" | grep -q '^perf-stat-failed rc=1' \
+   && printf '%s' "$denied_v" | grep -qi 'observability operations is limited'; then
+  ok "perf-capability: a DENIED perf (non-zero exit, 'access limited') fails with perf-stat-failed rc=1 + the text"
+else
+  bad "perf-capability: a non-zero perf exit was not surfaced (rc=$denied_rc, '$denied_v')"
+fi
+# 1d-iii. rc 0 with NO output at all: a masked/absent PMU. Must be no-cycles-row, not
+#         a pass (that branch was equally untested).
+empty_v=$(mkperfshim_raw 0 >/dev/null; PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>&1); empty_rc=$?
+if [ "$empty_rc" -ne 0 ] && printf '%s' "$empty_v" | grep -q 'no-cycles-row'; then
+  ok "perf-capability: rc-0 perf with EMPTY output fails with no-cycles-row"
+else
+  bad "perf-capability: rc-0 perf with empty output was accepted (rc=$empty_rc, '$empty_v')"
+fi
+# 1d-iv. An OVERSIZED/malformed count must fail CLOSED and SILENTLY: `[ 999…9 -le 0 ]`
+#        returns 2 (neither true nor false), so an unvalidated operand fell through to
+#        the VERIFIED return while leaking "integer expression expected" to stderr.
+mkperfshim 99999999999999999999999
+big_out=$(PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>/dev/null); big_rc=$?
+big_err=$(PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>&1 >/dev/null)
+if [ "$big_rc" -ne 0 ] && printf '%s' "$big_out" | grep -q 'unparseable-count=' && [ -z "$big_err" ]; then
+  ok "perf-capability: an oversized cycle count fails CLOSED as unparseable-count, with no stderr leak"
+else
+  bad "perf-capability: oversized count mishandled (rc=$big_rc, out='$big_out', err='$big_err')"
+fi
+mkperfshim '12x'
+mal_out=$(PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>/dev/null); mal_rc=$?
+mal_err=$(PATH="$perfbin:$PATH" bash "$PERFLIB" --verify 2>&1 >/dev/null)
+if [ "$mal_rc" -ne 0 ] && printf '%s' "$mal_out" | grep -q 'unparseable-count=12x' && [ -z "$mal_err" ]; then
+  ok "perf-capability: a malformed cycle count fails CLOSED as unparseable-count, with no stderr leak"
+else
+  bad "perf-capability: malformed count mishandled (rc=$mal_rc, out='$mal_out', err='$mal_err')"
+fi
+# 1d-v. The idempotency byte-compare must not depend on `diff`: without diffutils
+#       `diff -q` exits 127, which reads as "different" — so every --yes run re-wrote
+#       the file AND then falsely reported it could not write it.
+nodiff="$tmp/nodiff-bin"; mkdir -p "$nodiff"
+for t in bash cat; do s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nodiff/$t"; done
+nodiff_dir="$tmp/nodiff-sysctl.d"; mkdir -p "$nodiff_dir"
+bash "$PERFLIB" --drop-in >"$nodiff_dir/99-cqlite-perf.conf"
+if PATH="$nodiff" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$nodiff_dir" \
+     bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB" 2>/dev/null; then
+  ok "perf-capability: the idempotency compare works with NO 'diff' binary on PATH"
+else
+  bad "perf-capability: the idempotency compare needs diffutils (a box without it re-writes forever)"
+fi
+
 # ...and it must actually run the per-CPU collection the doctrine mandates.
 if grep -q 'stat .*-C 0' "$PERFSHIM_LOG" && grep -q '\-e cycles' "$PERFSHIM_LOG"; then
   ok "perf-capability: verify runs 'perf stat -C 0 -e cycles' (per-CPU, as doctrine requires)"
@@ -258,7 +462,7 @@ printf '1\n' >"$perf_proc/kptr_restrict"
 mkperfroot "$tmp/perf-root-check"
 mkperfshim 999999
 check_out=$(PATH="$perfshims:$perfbin:$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$perf_sysctl_d" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$perf_sysctl_d" CQLITE_PERF_TEST_PRIV_DIR="$perfshims" \
   bash "$tmp/perf-root-check/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
 check_rc=$?
 if printf '%s' "$check_out" | grep -q 'Perf profiling capability'; then
@@ -276,14 +480,34 @@ else
   bad "perf section: default run mutated state (rc=$check_rc, dir='$(ls -A "$perf_sysctl_d")', tripwire below)"
   cat "$perftrip"
 fi
-# It must instead PRINT the exact remedy — including the reboot-persistent file and
-# the apply — plus the AC5 posture and the BPF caveat (#3217).
-if printf '%s' "$check_out" | grep -q 'perf-capability.sh --drop-in | sudo tee .*99-cqlite-perf.conf' \
-   && printf '%s' "$check_out" | grep -q 're-run with --yes'; then
-  ok "perf section: prints the exact drop-in remedy line instead of running it"
+# Whatever it DID invoke must be non-interactive: every recorded sudo line begins
+# `sudo -n `, so no code path can sit on a password prompt on an unattended worker.
+check_bare_sudo=$(sudo_perf_offenders "$perftrip")
+if grep -q '^sudo -n true$' "$perftrip" && [ -z "$check_bare_sudo" ]; then
+  ok "perf section: the default run's sudo probe carries -n (never interactive)"
 else
-  bad "perf section: no exact remedy line printed"
+  bad "perf section: a sudo invocation without -n was recorded (or the probe never ran): $(cat "$perftrip")"
+fi
+# It must instead PRINT the exact remedy, and the remedy must WRITE **AND APPLY**: a
+# write-only line leaves the operator with a reboot-persistent file and an
+# unprofileable box until reboot — the very failure the functional verification
+# exists to prevent, on the path most people take (no --yes). Plus the AC5 posture
+# and the BPF caveat (#3217).
+if printf '%s' "$check_out" | grep -q 'perf-capability.sh --drop-in | sudo tee .*99-cqlite-perf.conf >/dev/null && sudo sysctl -q --system' \
+   && printf '%s' "$check_out" | grep -q 're-run with --yes'; then
+  ok "perf section: prints the complete WRITE-AND-APPLY remedy line instead of running it"
+else
+  bad "perf section: the printed remedy is missing the apply (or absent)"
   printf '%s\n' "$check_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# The PRE-state line is asserted SPECIFICALLY (not just "a line somewhere mentions
+# paranoid-4"): it is the diagnosis an operator reads first, and a later warn line
+# carrying the same token would otherwise satisfy a loose grep.
+if printf '%s\n' "$check_out" | grep -q 'runtime now: perf_event_paranoid=4 kptr_restrict=1 .*gate stamps perf=paranoid-4'; then
+  ok "perf section: the pre-state line reports the ACTUAL /proc values and the token the gate will stamp"
+else
+  bad "perf section: the pre-state line is wrong or missing"
+  printf '%s\n' "$check_out" | grep 'runtime now' || true
 fi
 if printf '%s' "$check_out" | grep -qi 'BPF collectors .* require sudo' \
    && printf '%s' "$check_out" | grep -qi 'never apply it to a shared or multi-tenant host'; then
@@ -340,7 +564,7 @@ mkperfroot "$tmp/perf-root-yes"
 mkperfshim 7777777
 yes_home="$tmp/perf-yes-home"; mkdir -p "$yes_home/.cargo"
 yes_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
 yes_rc=$?
 if [ "$yes_rc" -eq 0 ]; then
@@ -361,6 +585,15 @@ else
   bad "perf section: --yes did not use sudo tee + sysctl --system"
   cat "$yestrip"
 fi
+# ...and EVERY privileged invocation carried `-n`: an unattended worker must never be
+# able to sit on a password prompt, so `PERF_ROOT=(sudo)` (no -n) is a defect even
+# though every functional assert above would still pass.
+yes_bare_sudo=$(sudo_perf_offenders "$yestrip")
+if [ -z "$yes_bare_sudo" ] && grep -q '^sudo -n tee ' "$yestrip" && grep -q '^sudo -n sysctl ' "$yestrip"; then
+  ok "perf section: every --yes privileged call went through 'sudo -n' (write AND apply, never interactive)"
+else
+  bad "perf section: a privileged call did not carry sudo -n: $(cat "$yestrip")"
+fi
 # ORDER: the apply must precede the read-back verdict, and the functional verify
 # must come last (it is the verdict on the whole section).
 yes_perf_block=$(printf '%s\n' "$yes_out" | sed -n '/Perf profiling capability/,/^$/p')
@@ -377,7 +610,7 @@ fi
 # Idempotency: a SECOND --yes run must write nothing (byte-compare no-op).
 : >"$yestrip"
 yes2_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
 if printf '%s' "$yes2_out" | grep -q 'drop-in already current' \
    && ! grep -q 'tee .*99-cqlite-perf.conf' "$yestrip"; then
@@ -393,7 +626,7 @@ fi
 #      to AC2: without it, "the check exists" would pass while the box is unusable.
 mkperfshim '<not supported>'
 unsup_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
 unsup_rc=$?
 if printf '%s' "$unsup_out" | grep -q 'perf capability NOT verified' \
@@ -407,7 +640,7 @@ fi
 # 4b. Zero cycles is the virtualised-PMU case — same verdict.
 mkperfshim 0
 zero_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
 if printf '%s' "$zero_out" | grep -q 'perf capability NOT verified' \
    && ! printf '%s' "$zero_out" | grep -q 'perf capability VERIFIED'; then
@@ -416,33 +649,233 @@ else
   bad "perf section: a zero cycle count was accepted as verified"
   printf '%s\n' "$zero_out" | sed -n '/Perf profiling/,/^$/p'
 fi
-# 4c. A box with NO sudo at all: warn + the exact remedy, no write, still exit 0.
+# 4c. A box with NO sudo BINARY: warn + a remedy that actually works there, no write,
+#      still exit 0. The generic `... | sudo tee` line is USELESS on this box, so the
+#      case asserts the root-shell remedy AND the absence of the sudo one — the two
+#      `sudo -n` failure modes (no binary vs needs a password) are different boxes.
 nosudo="$tmp/perf-nosudo"; mkdir -p "$nosudo"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp uname id \
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp id \
          diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
   s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nosudo/$t"
 done
+mkuname "$nosudo" Linux
 ln -sf "$perfbin/perf" "$nosudo/perf"
 mkperfshim 5555555
 nosudo_sysctl="$tmp/perf-nosudo.d"; mkdir -p "$nosudo_sysctl"
 nosudo_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$nosudo_sysctl" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$nosudo_sysctl" CQLITE_PERF_TEST_PRIV_DIR="$nosudo" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
 nosudo_rc=$?
 if [ "$nosudo_rc" -eq 0 ] && [ -z "$(ls -A "$nosudo_sysctl")" ] \
-   && printf '%s' "$nosudo_out" | grep -q 'no non-interactive root' \
-   && printf '%s' "$nosudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf'; then
-  ok "perf section: no-sudo box warns with the exact remedy, writes nothing, exits 0"
+   && printf '%s' "$nosudo_out" | grep -q "no 'sudo' binary on this box" \
+   && printf '%s' "$nosudo_out" | grep -q 'ROOT shell:.*--drop-in > .*99-cqlite-perf.conf && sysctl -q --system' \
+   && ! printf '%s' "$nosudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf'; then
+  ok "perf section: a box with no sudo BINARY warns + prints the root-shell remedy (never a useless 'sudo tee'), writes nothing, exits 0"
 else
   bad "perf section: no-sudo box mishandled (rc=$nosudo_rc, dir='$(ls -A "$nosudo_sysctl")')"
   printf '%s\n' "$nosudo_out" | sed -n '/Perf profiling/,/^$/p'
 fi
-# 4d. Nothing in this whole suite may have touched the REAL /etc/sysctl.d.
+
+# 4c-ii. A box WITH sudo whose `sudo -n` fails (a password is required) is a DIFFERENT
+#        box: the `sudo tee` line does work there, interactively. Bootstrap must say so
+#        and must still never prompt.
+pwsudo="$tmp/perf-pwsudo"; mkdir -p "$pwsudo"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp id \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$pwsudo/$t"
+done
+mkuname "$pwsudo" Linux
+ln -sf "$perfbin/perf" "$pwsudo/perf"
+pwtrip="$tmp/perf-pwsudo-tripwire.log"; : >"$pwtrip"
+cat >"$pwsudo/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >>"$pwtrip"
+exit 1
+EOF
+chmod +x "$pwsudo/sudo"
+pwsudo_sysctl="$tmp/perf-pwsudo.d"; mkdir -p "$pwsudo_sysctl"
+pwsudo_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$pwsudo_sysctl" CQLITE_PERF_TEST_PRIV_DIR="$pwsudo" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+pwsudo_rc=$?
+if [ "$pwsudo_rc" -eq 0 ] && [ -z "$(ls -A "$pwsudo_sysctl")" ] \
+   && printf '%s' "$pwsudo_out" | grep -q 'sudo needs a password' \
+   && printf '%s' "$pwsudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf.*&& sudo sysctl -q --system' \
+   && ! printf '%s' "$pwsudo_out" | grep -q "no 'sudo' binary"; then
+  ok "perf section: a password-requiring sudo is diagnosed distinctly (not 'no sudo binary') with the interactive remedy, writes nothing, exits 0"
+else
+  bad "perf section: password-requiring sudo mishandled (rc=$pwsudo_rc, dir='$(ls -A "$pwsudo_sysctl")')"
+  printf '%s\n' "$pwsudo_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# Whatever it invoked, it must have been non-interactive: EVERY recorded sudo line
+# begins `sudo -n `, so no code path can sit on a password prompt on a worker.
+pw_bad_sudo=$(sudo_perf_offenders "$pwtrip")
+if grep -q '^sudo -n true$' "$pwtrip" && [ -z "$pw_bad_sudo" ]; then
+  ok "perf section: every sudo invocation carries -n (never interactive)"
+else
+  bad "perf section: a sudo invocation without -n was recorded (or none at all): $(cat "$pwtrip")"
+fi
+
+# 4d. THE SILENT REVERT — the real-world trap this whole issue exists to fix, and so
+#      the path that must be best-tested. `sysctl` exits 0 while the value does NOT
+#      take (container, read-only /proc, a later-sorting drop-in or /etc/sysctl.conf
+#      winning), so the verdict may never come from the apply's return code. Here the
+#      sysctl shim succeeds but does NOT touch the fake procfs, and perf is DENIED
+#      (non-zero, as a real paranoid-4 box denies it): bootstrap must warn "did NOT
+#      take", must NOT claim a READ BACK, and must NOT claim VERIFIED — while still
+#      exiting 0. Trusting sysctl's rc keeps every other case green.
+revert_proc="$tmp/perf-proc-revert"; mkdir -p "$revert_proc"
+printf '4\n' >"$revert_proc/perf_event_paranoid"
+printf '1\n' >"$revert_proc/kptr_restrict"
+revert_shims="$tmp/perf-revert-shims"; mkdir -p "$revert_shims"
+revert_trip="$tmp/perf-revert-tripwire.log"; : >"$revert_trip"
+cat >"$revert_shims/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >>"$revert_trip"
+while [ "\${1:-}" = "-n" ]; do shift; done
+exec "\$@"
+EOF
+cat >"$revert_shims/sysctl" <<EOF
+#!/usr/bin/env bash
+echo "sysctl \$*" >>"$revert_trip"
+exit 0
+EOF
+for t in apt-get apt dnf yum pacman; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$revert_shims/$t"
+done
+chmod +x "$revert_shims"/*
+revert_sysctl_d="$tmp/perf-revert.d"; mkdir -p "$revert_sysctl_d"
+mkperfshim_raw 1 'Error:' 'Access to performance monitoring and observability operations is limited.'
+revert_out=$(PATH="$revert_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$revert_sysctl_d" CQLITE_PERF_TEST_PRIV_DIR="$revert_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+revert_rc=$?
+if [ "$revert_rc" -eq 0 ] \
+   && printf '%s' "$revert_out" | grep -q 'the value did NOT take' \
+   && printf '%s' "$revert_out" | grep -q 'perf=paranoid-4' \
+   && ! printf '%s' "$revert_out" | grep -q 'READ BACK from /proc' \
+   && ! printf '%s' "$revert_out" | grep -q 'perf capability VERIFIED' \
+   && grep -q 'sysctl -q --system' "$revert_trip"; then
+  ok "perf section: a sysctl that exits 0 without the value taking is reported as 'did NOT take' from /proc (no READ BACK, no VERIFIED), rc 0"
+else
+  bad "perf section: the silent revert was not caught (rc=$revert_rc)"
+  printf '%s\n' "$revert_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# ...and the diagnostics must name /etc/sysctl.conf, which BOTH `sysctl --system` and
+# systemd-sysctl apply AFTER the sysctl.d drop-ins — so a stale entry there beats our
+# 99- file and is the likeliest cause of exactly this state.
+if printf '%s' "$revert_out" | grep -q '/etc/sysctl.conf' \
+   && printf '%s' "$revert_out" | grep -qi 'applied AFTER the sysctl.d drop-ins'; then
+  ok "perf section: the did-NOT-take diagnostics name /etc/sysctl.conf and its precedence over the drop-ins"
+else
+  bad "perf section: diagnostics omit the /etc/sysctl.conf precedence trap"
+fi
+
+# 4d-ii. CHECK mode with the drop-in already on disk but the runtime NOT profileable:
+#         the apply was only PRINTED, so bootstrap must NOT claim it was applied, and
+#         must still WARN (this branch was previously unreachable — the mismatch
+#         produced no [warn] at all and counted no WARNING).
+checkapply_d="$tmp/perf-checkapply.d"; mkdir -p "$checkapply_d"
+bash "$PERFLIB" --drop-in >"$checkapply_d/99-cqlite-perf.conf"
+checkapply_trip="$tmp/perf-checkapply-tripwire.log"; : >"$checkapply_trip"
+checkapply_shims="$tmp/perf-checkapply-shims"; mkdir -p "$checkapply_shims"
+for t in sudo sysctl tee; do
+  cat >"$checkapply_shims/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$checkapply_trip"
+exit 0
+EOF
+done
+chmod +x "$checkapply_shims"/*
+mkperfshim 4242
+checkapply_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$checkapply_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+checkapply_rc=$?
+checkapply_mutating=$(grep -vE '^sudo -n true$' "$checkapply_trip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
+if [ "$checkapply_rc" -eq 0 ] \
+   && printf '%s' "$checkapply_out" | grep -q 'drop-in already current' \
+   && printf '%s' "$checkapply_out" | grep -q 'has NOT been applied to the running kernel' \
+   && ! printf '%s' "$checkapply_out" | grep -q 'READ BACK from /proc' \
+   && ! printf '%s' "$checkapply_out" | grep -q 'sysctl --system reported success' \
+   && [ -z "$checkapply_mutating" ]; then
+  ok "perf section: check mode with a current drop-in but a non-ok runtime WARNs that it is not applied (and applies nothing)"
+else
+  bad "perf section: check-mode drop-in/runtime mismatch mishandled (rc=$checkapply_rc, tripwire='$checkapply_mutating')"
+  printf '%s\n' "$checkapply_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4e. A box with NO `perf` at all must WARN + print the install remedy and STILL exit
+#      0 — bootstrap is the fleet provisioning entry point, so a hard exit here would
+#      break every box without linux-tools. Every other case has perf on PATH, so an
+#      `exit 1` inserted in this branch previously survived the whole suite.
+noperfbox="$tmp/perf-noperfbox"; mkdir -p "$noperfbox"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp id \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$noperfbox/$t"
+done
+mkuname "$noperfbox" Linux
+cat >"$noperfbox/sudo" <<EOF
+#!/usr/bin/env bash
+while [ "\${1:-}" = "-n" ]; do shift; done
+exec "\$@"
+EOF
+printf '#!/usr/bin/env bash\nexit 0\n' >"$noperfbox/sysctl"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$noperfbox/apt-get"
+chmod +x "$noperfbox/sudo" "$noperfbox/sysctl" "$noperfbox/apt-get"
+noperfbox_d="$tmp/perf-noperfbox.d"; mkdir -p "$noperfbox_d"
+noperfbox_out=$(PATH="$noperfbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$noperfbox_d" CQLITE_PERF_TEST_PRIV_DIR="$noperfbox" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+noperfbox_rc=$?
+if [ "$noperfbox_rc" -eq 0 ] \
+   && printf '%s' "$noperfbox_out" | grep -q 'perf MISSING' \
+   && printf '%s' "$noperfbox_out" | grep -q 'install perf:.*linux-tools' \
+   && ! printf '%s' "$noperfbox_out" | grep -q 'perf capability VERIFIED'; then
+  ok "perf section: a box with no 'perf' binary warns UNVERIFIED + prints the linux-tools remedy and still exits 0"
+else
+  bad "perf section: missing-perf box mishandled (rc=$noperfbox_rc)"
+  printf '%s\n' "$noperfbox_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4f. DARWIN no-op: perf_event_paranoid/kptr_restrict are Linux kernel controls, so on
+#      macOS the section must say so, write nothing, and exit 0. Without a `uname`
+#      stub this whole suite was silently Linux-host-only (a Darwin gate host would
+#      have reddened `tooling-tests` on 10 cases while this path had no assertion).
+darwin_dir="$tmp/perf-darwin-bin"; mkdir -p "$darwin_dir"
+mkuname "$darwin_dir" Darwin
+darwin_d="$tmp/perf-darwin.d"; mkdir -p "$darwin_d"
+darwin_trip="$tmp/perf-darwin-tripwire.log"; : >"$darwin_trip"
+for t in sudo sysctl tee; do
+  cat >"$darwin_dir/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$darwin_trip"
+exit 0
+EOF
+done
+chmod +x "$darwin_dir"/*
+darwin_out=$(PATH="$darwin_dir:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$darwin_d" CQLITE_PERF_TEST_PRIV_DIR="$darwin_dir" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+darwin_rc=$?
+darwin_mutating=$(grep -vE '^sudo -n true$' "$darwin_trip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
+if [ "$darwin_rc" -eq 0 ] \
+   && printf '%s' "$darwin_out" | grep -q 'nothing to configure on macos' \
+   && [ -z "$(ls -A "$darwin_d")" ] && [ -z "$darwin_mutating" ] \
+   && ! printf '%s' "$darwin_out" | grep -q 'perf capability VERIFIED'; then
+  ok "perf section: on Darwin the section is an explicit no-op — no write, no privileged call, rc 0"
+else
+  bad "perf section: Darwin no-op mishandled (rc=$darwin_rc, dir='$(ls -A "$darwin_d")', tripwire='$darwin_mutating')"
+  printf '%s\n' "$darwin_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4g. Nothing in this whole suite may have touched the REAL /etc/sysctl.d.
 if [ ! -e /etc/sysctl.d/99-cqlite-perf.conf ] || [ -n "${CQLITE_PERF_ALLOW_REAL_DROPIN:-}" ]; then
   ok "perf section: the suite never created the real /etc/sysctl.d/99-cqlite-perf.conf"
 else
   # Pre-existing on a bootstrapped box is legitimate; only report if WE made it.
-  if [ "$(stat -c %Y /etc/sysctl.d/99-cqlite-perf.conf 2>/dev/null || echo 0)" -gt "$SUITE_START" ]; then
+  # `-nt` against a file stamped at suite start — no GNU-only `stat -c %Y`.
+  if [ /etc/sysctl.d/99-cqlite-perf.conf -nt "$suite_ref" ]; then
     bad "perf section: the suite wrote the REAL /etc/sysctl.d/99-cqlite-perf.conf"
   else
     ok "perf section: the real drop-in pre-dates this suite (not written by it)"

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -715,6 +715,54 @@ else
   esac
 fi
 
+# 1x. THE HARNESS'S OWN `mktemp` GUARD, OBSERVED FIRING (issue #3249 review R8-3). The
+#     shared lib derives EVERY path from `$tmp`, and these suites run WITHOUT `set -e`
+#     inside the MANDATORY tooling-tests component, sometimes under a root identity — so
+#     an unchecked `tmp=$(mktemp -d …)` was a host-damage defect, not a style nit: with
+#     `tmp` empty the setup lines write /global-gitconfig, /perfbin, /perfshim.log and
+#     /host-home, and `rm -f` /uname and /id. A guard nobody has WATCHED FIRE is not
+#     evidence (a hardcoded `_PERF_STATE="ok"` once survived 118/118 asserts), so BOTH
+#     failure shapes are driven here through a PATH shim — a non-zero `mktemp`, and an
+#     rc-0 `mktemp` that prints an empty path — and the refusal must be named, non-zero,
+#     must never reach the suite body, and must create no root-level path.
+mtg="$tmp/mktemp-guard"; mkdir -p "$mtg/fail-rc" "$mtg/empty-out"
+for t in bash dirname cat sed awk grep printf tr cut sort head tail wc env date chmod mkdir rm ln id uname; do
+  s=$(command -v "$t" 2>/dev/null) || continue
+  ln -sf "$s" "$mtg/fail-rc/$t"; ln -sf "$s" "$mtg/empty-out/$t"
+done
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1'                >"$mtg/fail-rc/mktemp"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "\n"' 'exit 0'  >"$mtg/empty-out/mktemp"
+chmod +x "$mtg/fail-rc/mktemp" "$mtg/empty-out/mktemp"
+printf '%s\n' '. "$1"' 'echo REACHED-SUITE-BODY' >"$mtg/probe.sh"
+# The root-level paths the harness would create with an empty `$tmp`. Compared
+# BEFORE/AFTER rather than asserted absent, so a box that legitimately has one of these
+# names cannot make the case fail for the wrong reason.
+mtg_state() {
+  local p
+  for p in /global-gitconfig /perfbin /perfshim.log /host-home /brew /cargo /gh /roborev /uname /id; do
+    [ -e "$p" ] && printf '%s\n' "$p"
+  done
+  return 0
+}
+mtg_before=$(mtg_state)
+mtg_fail=0
+for variant in fail-rc empty-out; do
+  mtg_out=$(PATH="$mtg/$variant" bash "$mtg/probe.sh" \
+    "$PERF_TEST_LIB_DIR/perf-capability-test-lib.sh" 2>&1); mtg_rc=$?
+  case "$mtg_out" in
+    *'REFUSING TO RUN (reason: unusable-temp-dir)'*) ;;
+    *) bad "perf-lib: a $variant mktemp did not produce the NAMED refusal: '$mtg_out'"; mtg_fail=1 ;;
+  esac
+  [ "$mtg_rc" -ne 0 ] || { bad "perf-lib: a $variant mktemp still exited 0"; mtg_fail=1; }
+  case "$mtg_out" in
+    *REACHED-SUITE-BODY*) bad "perf-lib: a $variant mktemp did not stop the suite body"; mtg_fail=1 ;;
+  esac
+  if [ "$(mtg_state)" != "$mtg_before" ]; then
+    bad "perf-lib: a $variant mktemp let the harness create a ROOT-LEVEL path ($(mtg_state))"; mtg_fail=1
+  fi
+done
+[ "$mtg_fail" -ne 0 ] || ok "perf-capability-test-lib: an unusable 'mktemp -d' (non-zero rc, or rc 0 with an empty path) REFUSES with a named reason, exits non-zero, never reaches the suite body, and creates no root-level path"
+
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.
 perf_test_assert_host_clean
 perf_test_report

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -751,8 +751,7 @@ for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
   s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$rootbox/$t"
 done
 mkuname "$rootbox" Linux
-printf '#!/usr/bin/env bash\ncase "${1:-}" in -u) echo 0 ;; *) echo 0 ;; esac\n' >"$rootbox/id"
-chmod +x "$rootbox/id"
+mkid "$rootbox" 0      # the ONLY case that exercises the already-root branch
 roottrip="$tmp/perf-rootbox-tripwire.log"; : >"$roottrip"
 for t in sudo sysctl; do
   cat >"$rootbox/$t" <<EOF

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -95,6 +95,21 @@ check_token garbage 0 unknown
 check_token '1abc' 0 unknown
 check_token 99999999999999999999999 0 unknown
 check_token -1 '0x0' unknown
+# ...and a value with INTERIOR whitespace must stay malformed. The read used to cut the
+# value at its first space (`${v%%[[:space:]]*}`), so `0 1` became a perfectly
+# capable-looking `0` — an unknown resolving to the GOOD case in the one function the
+# gate's `perf=` token comes from (fail-open audit, #3249 review round 4). Surrounding
+# whitespace is still trimmed, so a normal `-1\n` (or a CRLF file) reads fine.
+check_token '0 1' 0 unknown
+check_token '-1 junk' 0 unknown
+check_token 0 '0 1' unknown
+check_token '  -1  ' 0 ok
+printf -- '-1\r\n' >"$perfproc/perf_event_paranoid"; printf '0\r\n' >"$perfproc/kptr_restrict"
+if [ "$(CQLITE_PERF_PROC_DIR="$perfproc" bash "$PERFLIB" --token)" = ok ]; then
+  ok "perf-capability: a CRLF /proc value still reads as ok (surrounding whitespace trimmed, not truncated)"
+else
+  bad "perf-capability: a CRLF /proc value was misread"
+fi
 # ...and that rejection must be SILENT: this runs inside the gate's summary emit,
 # where a stray stderr line lands in the gate's own output.
 noise=$(printf '1abc\n' >"$perfproc/perf_event_paranoid"; printf '0\n' >"$perfproc/kptr_restrict"
@@ -235,19 +250,32 @@ else
 fi
 # A seam pointing AT production (or anywhere under /etc, /proc, /sys) is the same hole
 # wearing a seam, and a RELATIVE path is not a sandbox either.
-for badseam in /etc/sysctl.d /etc/sysctl.d/sub /etc /proc /proc/sys/kernel /sys relative/dir; do
-  if env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_PROC_DIR="$seamed_proc" CQLITE_PERF_SYSCTL_DIR="$badseam" \
-       bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" >/dev/null 2>&1; then
-    bad "perf-capability: test mode ACCEPTED a production/relative sysctl seam '$badseam'"
-    badseam_fail=1
-  fi
-  if env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$seamed_d" CQLITE_PERF_PROC_DIR="$badseam" \
-       bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" >/dev/null 2>&1; then
-    bad "perf-capability: test mode ACCEPTED a production/relative proc seam '$badseam'"
-    badseam_fail=1
-  fi
+# Each rejection is asserted BY ITS REASON, not merely by a non-zero rc: this guard has a
+# second refusal (a real sudo/sysctl on PATH) that would otherwise satisfy an rc-only
+# check and let a seam-validation regression pass unnoticed.
+guard_rejects_seam() { # guard_rejects_seam <which:PROC|SYSCTL> <proc-seam> <sysctl-seam>
+  local out
+  out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
+          CQLITE_PERF_PROC_DIR="$2" CQLITE_PERF_SYSCTL_DIR="$3" \
+          bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1) && return 1
+  printf '%s' "$out" | grep -q "NON-PRODUCTION CQLITE_PERF_${1}_DIR"
+}
+for badseam in /etc/sysctl.d /etc/sysctl.d/sub /etc /proc /proc/sys/kernel /sys relative/dir ''; do
+  guard_rejects_seam SYSCTL "$seamed_proc" "$badseam" || {
+    bad "perf-capability: test mode did not reject the sysctl seam '$badseam' as non-production"; badseam_fail=1; }
+  guard_rejects_seam PROC "$badseam" "$seamed_d" || {
+    bad "perf-capability: test mode did not reject the proc seam '$badseam' as non-production"; badseam_fail=1; }
 done
-[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects a production-shaped or relative seam (/etc*, /proc*, /sys*, relative) on BOTH sandbox dirs"
+# ...and a seam that is a SYMLINK to production passes every TEXTUAL check while still
+# landing a root `tee` in the real directory, so the seam itself may not be a symlink
+# (fail-open audit, #3249 review round 4).
+symseam="$tmp/symlink-to-production"; rm -f "$symseam"; ln -s /etc/sysctl.d "$symseam"
+symproc="$tmp/symlink-to-proc"; rm -f "$symproc"; ln -s /proc/sys/kernel "$symproc"
+guard_rejects_seam SYSCTL "$seamed_proc" "$symseam" || {
+  bad "perf-capability: test mode ACCEPTED a sysctl seam that is a SYMLINK to /etc/sysctl.d"; badseam_fail=1; }
+guard_rejects_seam PROC "$symproc" "$seamed_d" || {
+  bad "perf-capability: test mode ACCEPTED a proc seam that is a SYMLINK to /proc/sys/kernel"; badseam_fail=1; }
+[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam on BOTH sandbox dirs, naming the offending seam"
 # ...and the refusal reaches the RESOLVERS, not only the guard: an unsandboxed test mode
 # must not be able to name a production path at all (this is what the `tee` would use).
 noseam_path=$(env -u CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_TEST_MODE=1 bash "$PERFLIB" --drop-in-path 2>/dev/null)
@@ -445,6 +473,20 @@ if [ -z "$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$tmp/perf-nocomp.d" \
 else
   bad "perf-capability: an empty sysctl.d dir produced competitor output"
 fi
+# ...and an UNREADABLE directory is an UNKNOWN (rc 1), never "no competing file": this
+# diagnostic exists to replace an unknown with a named file, so answering an unknown with
+# the reassuring line would recreate the mystery it was written to end.
+unreadable_d="$tmp/perf-unreadable.d"; mkdir -p "$unreadable_d"; chmod 000 "$unreadable_d"
+if [ -r "$unreadable_d" ]; then
+  # real root ignores the mode bits; the property under test is unobservable here
+  ok "perf-capability: (skipped under real root) unreadable sysctl.d dir — mode bits do not apply"
+elif CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$unreadable_d" \
+       bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" >/dev/null 2>&1; then
+  bad "perf-capability: an UNREADABLE sysctl.d dir reported success (an unknown became 'no competitor')"
+else
+  ok "perf-capability: an UNREADABLE sysctl.d directory fails the scan (rc 1) instead of claiming no competitor"
+fi
+chmod 755 "$unreadable_d"
 
 # 1e. THE IDENTITY DIMENSION, at the helper level (issue #3249 review R4-1/R4-2). Every
 #     assert here is the same shape: an UNKNOWN or UNVERIFIABLE identity must NOT resolve

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -572,6 +572,36 @@ else
   ok "perf-capability: an UNREADABLE sysctl.d directory fails the scan (rc 1) instead of claiming no competitor"
 fi
 chmod 755 "$unreadable_d"
+# ...and the same rule PER FILE, with the two shapes distinguished (issue #3249 review
+# R8-4). `for f in "$dir"/*.conf` leaves the PATTERN in $f when nothing matches, so one
+# `[ -f ] && [ -r ] || continue` conflated "this directory holds no .conf" (genuinely no
+# competitor) with "this .conf exists but I cannot read it" (an UNKNOWN — and a
+# privileged `sysctl --system` CAN read and apply it). The second must fail the scan.
+unrf_d="$tmp/perf-unreadable-file.d"; mkdir -p "$unrf_d"
+printf 'kernel.perf_event_paranoid = 3\n' >"$unrf_d/10-secret.conf"; chmod 000 "$unrf_d/10-secret.conf"
+noglob_d="$tmp/perf-noglob.d"; mkdir -p "$noglob_d"
+printf 'not a sysctl file\n' >"$noglob_d/README.txt"   # readable dir, glob matches NOTHING
+noglob_out=$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$noglob_d" \
+  bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); noglob_rc=$?
+if [ -r "$unrf_d/10-secret.conf" ]; then
+  # real root ignores the mode bits; the unreadable-FILE half is unobservable here
+  ok "perf-capability: (skipped under real root) unreadable competing .conf — mode bits do not apply"
+else
+  unrf_out=$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$unrf_d" \
+    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); unrf_rc=$?
+  if [ "$unrf_rc" -ne 0 ] && printf '%s\n' "$unrf_out" | grep -q "could not scan .*10-secret.conf" \
+     && ! printf '%s\n' "$unrf_out" | grep -qE '^(earlier|override|last) '; then
+    ok "perf-capability: an EXISTING but UNREADABLE competing .conf fails the scan (rc 1, 'could not scan' naming the file) instead of being silently skipped into a clean bill"
+  else
+    bad "perf-capability: an unreadable competing .conf was skipped silently (rc=$unrf_rc, '$unrf_out')"
+  fi
+fi
+if [ "$noglob_rc" -eq 0 ] && [ -z "$noglob_out" ]; then
+  ok "perf-capability: a readable directory whose *.conf glob matches NOTHING is no competitor (rc 0, no output) — the unmatched glob is not treated as an unreadable file"
+else
+  bad "perf-capability: an unmatched *.conf glob did not scan clean (rc=$noglob_rc, '$noglob_out')"
+fi
+chmod 644 "$unrf_d/10-secret.conf"
 
 # 1e. THE IDENTITY DIMENSION, at the helper level (issue #3249 review R4-1/R4-2). Every
 #     assert here is the same shape: an UNKNOWN or UNVERIFIABLE identity must NOT resolve

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -368,6 +368,205 @@ else
   bad "perf-capability: the idempotency compare needs diffutils (a box without it re-writes forever)"
 fi
 
+# 1d-vi. THE COMPARE IS ACTUALLY BYTE-EXACT (issue #3249 review R4-4). `$( )` strips
+#        EVERY trailing newline from its output, so comparing two command substitutions
+#        judged a file missing its final newline — or carrying extra trailing blank lines
+#        — as CURRENT, and it was never rewritten. That also made a documented claim
+#        ("byte-exact") false. Both variants must be NOT current; the canonical bytes
+#        must still be current, so the fix cannot be "always rewrite".
+dropin_current_is() { # dropin_current_is <dir>  -> rc of perf_capability_dropin_current
+  CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$1" \
+    bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB" 2>/dev/null
+}
+bytes_d="$tmp/perf-bytes.d"; mkdir -p "$bytes_d"
+bytes_f="$bytes_d/99-cqlite-perf.conf"
+bytes_fail=0
+bash "$PERFLIB" --drop-in >"$bytes_f"
+dropin_current_is "$bytes_d" || { bad "perf-capability: the CANONICAL drop-in bytes were judged NOT current"; bytes_fail=1; }
+# variant 1: the final newline stripped (exactly what a `$(...) > file` remedy produces)
+printf '%s' "$(bash "$PERFLIB" --drop-in)" >"$bytes_f"
+if dropin_current_is "$bytes_d"; then
+  bad "perf-capability: a drop-in MISSING its final newline was judged current (the compare is not byte-exact)"
+  bytes_fail=1
+fi
+# variant 2: an extra trailing blank line (an editor, or a doubled remedy paste)
+bash "$PERFLIB" --drop-in >"$bytes_f"; printf '\n' >>"$bytes_f"
+if dropin_current_is "$bytes_d"; then
+  bad "perf-capability: a drop-in with an EXTRA trailing blank line was judged current"
+  bytes_fail=1
+fi
+# variant 3: same bytes, one line's trailing whitespace added — content, not just newlines
+bash "$PERFLIB" --drop-in | sed 's/^kernel.kptr_restrict = 0$/kernel.kptr_restrict = 0 /' >"$bytes_f"
+if dropin_current_is "$bytes_d"; then
+  bad "perf-capability: a drop-in with altered trailing whitespace on a value line was judged current"
+  bytes_fail=1
+fi
+[ "$bytes_fail" -ne 0 ] || ok "perf-capability: the idempotency compare is BYTE-exact — a missing final newline, an extra blank line and altered trailing whitespace are all NOT current"
+
+# 1d-vii. THE '99-' PREFIX IS LOAD-BEARING, and the drop-in says so in its own bytes.
+#         This box ships /etc/sysctl.d/10-kernel-hardening.conf with
+#         `kernel.kptr_restrict = 1`; our file only wins because "99-…" sorts after
+#         "10-…". A future tidy-up to `cqlite-perf.conf` would silently hand kptr_restrict
+#         back to the hardening drop-in at the next boot — the "silent revert" three
+#         measurement reports recorded without ever naming a cause.
+if printf '%s\n' "$dropin" | grep -q '99-' \
+   && printf '%s\n' "$dropin" | grep -qi 'DO NOT RENAME' \
+   && printf '%s\n' "$dropin" | grep -q '10-kernel-hardening.conf'; then
+  ok "perf-capability: the drop-in header states that the '99-' prefix is load-bearing and NAMES 10-kernel-hardening.conf"
+else
+  bad "perf-capability: the drop-in header does not explain the 99- ordering / name the competing hardening file"
+fi
+
+# 1d-viii. NAME THE COMPETITOR. perf_capability_competing_files must find every OTHER
+#          file in the sysctl.d dir that sets perf_event_paranoid/kptr_restrict, and rank
+#          it by BASENAME order: one sorting AFTER ours is an actual override (applied
+#          last, wins); one sorting before is harmless. Unrelated knobs and our own file
+#          are not competitors.
+comp_d="$tmp/perf-competing.d"; mkdir -p "$comp_d"
+bash "$PERFLIB" --drop-in >"$comp_d/99-cqlite-perf.conf"
+printf '# stock ubuntu hardening\nkernel.kptr_restrict = 1\n' >"$comp_d/10-kernel-hardening.conf"
+printf 'kernel.perf_event_paranoid = 3\n'                     >"$comp_d/99-zzz-late.conf"
+printf 'vm.swappiness = 1\n'                                  >"$comp_d/50-unrelated.conf"
+printf '#kernel.kptr_restrict = 1\n'                          >"$comp_d/20-commented.conf"
+comp_out=$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$comp_d" \
+  bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1)
+if printf '%s\n' "$comp_out" | grep -q "^earlier $comp_d/10-kernel-hardening.conf$" \
+   && printf '%s\n' "$comp_out" | grep -q "^override $comp_d/99-zzz-late.conf$" \
+   && ! printf '%s\n' "$comp_out" | grep -q '50-unrelated' \
+   && ! printf '%s\n' "$comp_out" | grep -q '20-commented' \
+   && ! printf '%s\n' "$comp_out" | grep -q '99-cqlite-perf.conf'; then
+  ok "perf-capability: competing sysctl files are found and ranked (10-kernel-hardening=earlier, 99-zzz-late=override; unrelated/commented/own file ignored)"
+else
+  bad "perf-capability: competing-file detection wrong: '$comp_out'"
+fi
+if [ -z "$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$tmp/perf-nocomp.d" \
+             bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null)" ]; then
+  ok "perf-capability: a missing/empty sysctl.d directory yields no competitors (and no error output)"
+else
+  bad "perf-capability: an empty sysctl.d dir produced competitor output"
+fi
+
+# 1e. THE IDENTITY DIMENSION, at the helper level (issue #3249 review R4-1/R4-2). Every
+#     assert here is the same shape: an UNKNOWN or UNVERIFIABLE identity must NOT resolve
+#     to the reassuring answer.
+idbox="$tmp/perf-idbox"; mkdir -p "$idbox"
+for t in bash cat awk printf tr cut sort head tail wc env command timeout; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$idbox/$t"
+done
+mkperfshim 7171717
+ln -sf "$perfbin/perf" "$idbox/perf"
+# 1e-i. `id -u` UNAVAILABLE. The old `$(id -u 2>/dev/null || echo 1000)` invented an
+#       unprivileged answer, so a ROOT run set PERF_UNPRIV_EVIDENCE=1 and printed a false
+#       VERIFIED — the R3-1 defect reintroduced through the detector meant to prevent it.
+noid_out=$(PATH="$idbox" bash "$PERFLIB" --verify-unpriv 2>&1); noid_rc=$?
+if [ "$noid_rc" -ne 0 ] && printf '%s' "$noid_out" | grep -q 'identity=identity-unknown' \
+   && ! printf '%s' "$noid_out" | grep -q 'self-unprivileged'; then
+  ok "perf-capability: with NO usable 'id' the identity is 'identity-unknown' and --verify-unpriv FAILS (never assumed unprivileged)"
+else
+  bad "perf-capability: a missing 'id' was treated as unprivileged (rc=$noid_rc, '$noid_out')"
+fi
+# ...and the same for an `id` that EXISTS but fails, or prints something unparseable.
+mkdir -p "$tmp/perf-idbad" && cp -a "$idbox"/. "$tmp/perf-idbad"/
+printf '#!/usr/bin/env bash\nexit 7\n' >"$tmp/perf-idbad/id"; chmod +x "$tmp/perf-idbad/id"
+mkdir -p "$tmp/perf-idjunk" && cp -a "$idbox"/. "$tmp/perf-idjunk"/
+printf '#!/usr/bin/env bash\necho "uid=0(root) gid=0(root)"\n' >"$tmp/perf-idjunk/id"; chmod +x "$tmp/perf-idjunk/id"
+idbad_out=$(PATH="$tmp/perf-idbad" bash "$PERFLIB" --verify-unpriv 2>&1); idbad_rc=$?
+idjunk_out=$(PATH="$tmp/perf-idjunk" bash "$PERFLIB" --verify-unpriv 2>&1); idjunk_rc=$?
+if [ "$idbad_rc" -ne 0 ] && printf '%s' "$idbad_out" | grep -q 'identity=identity-unknown' \
+   && [ "$idjunk_rc" -ne 0 ] && printf '%s' "$idjunk_out" | grep -q 'identity=identity-unknown'; then
+  ok "perf-capability: an 'id -u' that FAILS or prints unparseable output is 'identity-unknown', not unprivileged"
+else
+  bad "perf-capability: a broken 'id -u' was accepted (fail rc=$idbad_rc '$idbad_out'; junk rc=$idjunk_rc '$idjunk_out')"
+fi
+# 1e-ii. AN INCONSISTENT SUDO_USER MAY NOT BE TRUSTED. SUDO_UID and SUDO_USER are
+#        independent env strings: with `SUDO_UID=1000 SUDO_USER=root` and no setpriv, a
+#        name-based `runuser -u root` / `sudo -u root` would run the probe AS ROOT while
+#        the state claimed a successful drop. The name must be dropped and the VALIDATED
+#        NUMERIC uid used instead (sudo's documented `#<uid>` form).
+mkdir -p "$tmp/perf-idroot" && cp -a "$idbox"/. "$tmp/perf-idroot"/
+cat >"$tmp/perf-idroot/id" <<'EOF'
+#!/usr/bin/env bash
+# root shell; `root` resolves to uid/gid 0, `agentuser` to 1000/1000, nothing else exists
+case "${1:-}" in
+  -u) if [ -n "${2:-}" ]; then case "$2" in root) echo 0 ;; agentuser) echo 1000 ;; *) exit 1 ;; esac
+      else echo 0; fi ;;
+  -g) if [ -n "${2:-}" ]; then case "$2" in root) echo 0 ;; agentuser) echo 1000 ;; *) exit 1 ;; esac
+      else echo 0; fi ;;
+  *) echo 0 ;;
+esac
+EOF
+chmod +x "$tmp/perf-idroot/id"
+idroot_argv="$tmp/perf-idroot-argv.log"
+# sudo/runuser shims: record the FULL argv (so the assertions can prove WHICH identity the
+# probe was actually asked to run as), then strip their own options and exec the rest.
+for t in sudo runuser; do
+  cat >"$tmp/perf-idroot/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$idroot_argv"
+while [ "\${1:-}" = -n ]; do shift; done
+[ "\${1:-}" = -u ] && shift 2
+[ "\${1:-}" = -- ] && shift
+exec "\$@"
+EOF
+  chmod +x "$tmp/perf-idroot/$t"
+done
+: >"$idroot_argv"
+stale_out=$(PATH="$tmp/perf-idroot" SUDO_UID=1000 SUDO_GID=1000 SUDO_USER=root \
+  bash "$PERFLIB" --verify-unpriv 2>&1); stale_rc=$?
+if [ "$stale_rc" -eq 0 ] \
+   && printf '%s' "$stale_out" | grep -q 'identity=dropped:sudo:uid=1000' \
+   && grep -q '^sudo -n -u #1000 -- perf stat' "$idroot_argv" \
+   && ! grep -q 'runuser' "$idroot_argv" \
+   && ! grep -q -- '-u root' "$idroot_argv"; then
+  ok "perf-capability: SUDO_USER=root with SUDO_UID=1000 is REJECTED as a name — the drop uses the validated numeric uid (sudo -u '#1000'), never 'runuser -u root'"
+else
+  bad "perf-capability: a stale SUDO_USER steered the drop (rc=$stale_rc, state='$stale_out', argv='$(cat "$idroot_argv")')"
+fi
+# ...while a CONSISTENT SUDO_USER (passwd says it IS that uid/gid) is still usable, so
+# the fix is a validation rather than a blanket refusal that would lose `runuser`.
+: >"$idroot_argv"
+good_out=$(PATH="$tmp/perf-idroot" SUDO_UID=1000 SUDO_GID=1000 SUDO_USER=agentuser \
+  bash "$PERFLIB" --verify-unpriv 2>&1); good_rc=$?
+if [ "$good_rc" -eq 0 ] && printf '%s' "$good_out" | grep -q 'identity=dropped:runuser:agentuser' \
+   && grep -q '^runuser -u agentuser -- perf stat' "$idroot_argv"; then
+  ok "perf-capability: a SUDO_USER whose passwd uid/gid MATCH the validated numerics is still used for 'runuser -u <name>'"
+else
+  bad "perf-capability: a consistent SUDO_USER was not usable (rc=$good_rc, '$good_out', argv='$(cat "$idroot_argv")')"
+fi
+# ...and a name that is not shell-token safe can never enter the word-split prefix.
+: >"$idroot_argv"
+inj_out=$(PATH="$tmp/perf-idroot" SUDO_UID=1000 SUDO_GID=1000 SUDO_USER='agent user; touch /tmp/pwn' \
+  bash "$PERFLIB" --verify-unpriv 2>&1)
+if printf '%s' "$inj_out" | grep -q 'identity=dropped:sudo:uid=1000' \
+   && ! grep -q 'agent user' "$idroot_argv" && [ ! -e /tmp/pwn ]; then
+  ok "perf-capability: a SUDO_USER containing shell metacharacters/whitespace never reaches the command prefix"
+else
+  bad "perf-capability: an unsafe SUDO_USER reached the prefix ('$inj_out', argv='$(cat "$idroot_argv")')"
+fi
+# 1e-iii. A NEGATIVE or oversized SUDO_UID is not an identity either (`[ -1 -gt 0 ]` is
+#         false, but a negative uid slipping into `setpriv --reuid=-1` would be worse than
+#         a refusal), and with no `nobody` on the box the state must be
+#         root-no-unprivileged-target — never a probe as root labelled a drop.
+mkdir -p "$tmp/perf-idnotarget" && cp -a "$tmp/perf-idroot"/. "$tmp/perf-idnotarget"/
+cat >"$tmp/perf-idnotarget/id" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -u|-g) if [ -n "${2:-}" ]; then exit 1; else echo 0; fi ;;   # no account resolves
+  *) echo 0 ;;
+esac
+EOF
+chmod +x "$tmp/perf-idnotarget/id"
+notgt_fail=0
+for badsudo in -1 0 abc 99999999999999999999999 ''; do
+  bs_out=$(PATH="$tmp/perf-idnotarget" SUDO_UID="$badsudo" SUDO_GID=1000 SUDO_USER=agentuser \
+    bash "$PERFLIB" --verify-unpriv 2>&1); bs_rc=$?
+  if [ "$bs_rc" -eq 0 ] || ! printf '%s' "$bs_out" | grep -q 'identity=root-no-unprivileged-target'; then
+    bad "perf-capability: SUDO_UID='$badsudo' did not fall through to root-no-unprivileged-target (rc=$bs_rc, '$bs_out')"
+    notgt_fail=1
+  fi
+done
+[ "$notgt_fail" -ne 0 ] || ok "perf-capability: a negative/zero/malformed/oversized/empty SUDO_UID is no identity — root with no 'nobody' reports root-no-unprivileged-target and FAILS"
+
 # ...and it must actually run the per-CPU collection the doctrine mandates.
 if grep -q 'stat .*-C 0' "$PERFSHIM_LOG" && grep -q '\-e cycles' "$PERFSHIM_LOG"; then
   ok "perf-capability: verify runs 'perf stat -C 0 -e cycles' (per-CPU, as doctrine requires)"

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
-# Regression test for the PERF PROFILING CAPABILITY path (issue #3249):
-# scripts/perf-capability.sh (the shared helper) plus the bootstrap section that
-# installs and VERIFIES /etc/sysctl.d/99-cqlite-perf.conf.
+# Regression test for the PERF PROFILING CAPABILITY HELPER (issue #3249):
+# scripts/perf-capability.sh — the free /proc token, the canonical
+# /etc/sysctl.d/99-cqlite-perf.conf bytes, the byte-exact idempotency compare, the
+# test-mode env guard, the functional `perf stat` verdict and the privilege-drop
+# identity resolution.
+#
+# The BOOTSTRAP-side integration cases (install + apply + read-back + verdict, across
+# root/no-sudo/Darwin/missing-perf boxes) live in the sibling
+# scripts/tests/test_perf_capability_bootstrap.sh; the shared harness (identity/platform
+# stubs, perf shims, host-safety asserts) lives in
+# scripts/tests/lib/perf-capability-test-lib.sh. Both are wired into the gate's
+# `tooling-tests` component.
 #
 # WHY THIS EXISTS. Agent/worker images ship kernel.perf_event_paranoid = 4 — ALL
 # unprivileged perf use denied — and set it in no sysctl file, so a box is
@@ -9,152 +18,31 @@
 # lost to that, largely because the denial's help text ("access limited") reads
 # like a CAPABILITY verdict when it is a PERMISSION verdict.
 #
-# WHAT IT ASSERTS, beyond "the code is there": that the FUNCTIONAL verification is
-# HONOURED. `perf stat` exits 0 while printing `<not supported>`/`<not counted>`,
-# and a virtualised PMU can report a flat 0 — so an rc-only check is precisely the
-# false green being fixed, and every negative case here drives a shimmed perf that
-# EXITS 0 with an unusable counter.
+# WHAT IT ASSERTS, beyond "the code is there": that no path can reach a
+# CAPABLE/VERIFIED verdict from an UNVALIDATED input. Every "unknown" — an unreadable
+# /proc value, an unparseable cycle count, an unusable `id -u`, an inconsistent
+# SUDO_USER, a missing test-mode sandbox — must resolve AWAY from the reassuring answer.
 #
-# HOST SAFETY. Nothing here touches the real /etc/sysctl.d or /proc: two test-only
-# env seams stand in (CQLITE_PERF_PROC_DIR, CQLITE_PERF_SYSCTL_DIR) and every
-# privileged/mutating tool (sudo, sysctl, tee, the package managers) is a recording
-# PATH shim. The final case asserts that mutation-freedom directly.
+# HOST SAFETY. Nothing here touches the real /etc/sysctl.d or /proc: the test-only env
+# seams stand in and every privileged/mutating tool is a recording PATH shim. The final
+# case asserts that mutation-freedom directly.
 #
 # Run standalone:   bash scripts/tests/test_perf_capability.sh
 # Or via the gate:  scripts/agent-gate.sh runs it in the `tooling-tests` component.
 set -uo pipefail
 
-SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-BOOTSTRAP="$SCRIPT_DIR/../bootstrap-agent-machine.sh"
-PERFLIB="$SCRIPT_DIR/../perf-capability.sh"
-
-PASS=0
-FAIL=0
-ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
-bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
-
-# sudo_perf_offenders <tripwire-log>: the recorded `sudo` lines belonging to the PERF
-# path (its `-n` availability probe, its `tee`, its `sysctl`) that do NOT carry `-n`.
-# `-n` is what makes bootstrap unpromptable on an unattended worker, so dropping it
-# from PERF_ROOT is a defect every functional assert would still pass. Lines from other
-# bootstrap sections (e.g. the mold `sudo apt-get install`) are out of this issue's scope.
-sudo_perf_offenders() {
-  grep -E '^sudo ' "$1" 2>/dev/null | grep -E '(\btee\b|\bsysctl\b|\btrue\b)' | grep -v '^sudo -n ' || true
-}
-
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-test.XXXXXX")
-trap 'rm -rf "$tmp"' EXIT
-# Reference file for the "did WE create the real /etc/sysctl.d drop-in?" attribution
-# in the final case: a plain `-nt` comparison against a file created NOW, so no
-# `stat -c %Y` (GNU-only) and no wall-clock arithmetic anywhere in this suite.
-suite_ref="$tmp/.suite-start"; : >"$suite_ref"
-
-# Global-state isolation, same posture as test_bootstrap_agent_machine.sh: the
-# bootstrap runs below read/write git config and read board env, and this suite runs
-# inside `tooling-tests` on the very box hosting a live delivery session.
-export GIT_CONFIG_GLOBAL="$tmp/global-gitconfig"
-export GIT_CONFIG_NOSYSTEM=1
-: >"$GIT_CONFIG_GLOBAL"
-unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
-# A worker shell may export the seams themselves; a test must set exactly what it means.
-unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR
-# ...and so may a `sudo bash scripts/tests/...` invocation export SUDO_UID/GID/USER,
-# which the privilege-drop target resolution reads. A case that means to exercise that
-# path sets them itself; inheriting them would make the suite's verdict depend on how
-# it was launched (the same env-inheritance class as PERF_SECTION_OK).
-unset SUDO_UID SUDO_GID SUDO_USER
-# The section under test must never be steered by an ambient export either: bootstrap
-# initialises PERF_SECTION_OK itself, and this suite proves it (case 4h).
-unset PERF_SECTION_OK
-# The two path seams are INERT unless this marker is set, and the marker itself
-# forbids reaching a real sudo/sysctl (the shim dir is declared per case in
-# CQLITE_PERF_TEST_PRIV_DIR). Cases that must exercise the PRODUCTION defaults run
-# with `env -u CQLITE_PERF_TEST_MODE`.
-export CQLITE_PERF_TEST_MODE=1
-
-# mkuname <dir> <sysname>: a `uname` stub, so the Linux/Darwin branch under test is
-# the one selected by the CASE, not by whatever host runs the suite. Without this the
-# whole suite was silently Linux-host-only: on a Darwin gate host every bootstrap run
-# below would take the "nothing to configure on macos" path and 10 cases would fail.
-# `-r`/`-m` answer too, because bootstrap uses them elsewhere.
-mkuname() {
-  # rm FIRST: several dirs below `ln -sf` the real uname into place, and writing
-  # through that symlink would clobber the host's /usr/bin/uname.
-  rm -f "$1/uname"
-  cat >"$1/uname" <<EOF
-#!/usr/bin/env bash
-case "\${1:-}" in
-  -r) echo 6.0.0-cqlite-test ;;
-  -m) echo x86_64 ;;
-  *)  echo $2 ;;
-esac
-EOF
-  chmod +x "$1/uname"
-}
-
-# mkid <dir> <self-uid> [<other-uid>]: an `id` stub, so the ROOT / NON-ROOT branch
-# under test is the one selected by the CASE, not by whatever UID runs the suite.
-# Without this the suite was silently NON-ROOT-runner-only: nearly every case asserts
-# the unprivileged behaviour (a `sudo -n true` probe, a `sudo -n tee`, a printed `sudo`
-# remedy), so running the whole thing as root — a container, a CI image, anyone's
-# `sudo bash` — took the root branch and FAILED, reddening the mandatory
-# `tooling-tests` gate component. Same class as the Linux-host-only bug mkuname fixes,
-# and the same `rm -f` first: several dirs below `ln -sf` the real `id` into place, and
-# writing through that symlink would clobber the host's /usr/bin/id.
-#
-# <other-uid> answers a USER OPERAND (`id -u nobody` / `id -g nobody`), which the
-# privilege-drop target resolution asks for: a shim that answered its OWN uid there
-# would let a root case "resolve" root as the unprivileged probe identity — the exact
-# false verification the drop exists to prevent. Omitted => the operand form FAILS
-# (that box has no such account), which is the honest answer for a case that offers
-# no unprivileged identity.
-mkid() {
-  rm -f "$1/id"
-  cat >"$1/id" <<EOF
-#!/usr/bin/env bash
-other='${3:-}'
-case "\${1:-}" in
-  -u|-g)
-    if [ -n "\${2:-}" ]; then
-      [ -n "\$other" ] || exit 1        # no such account on this box
-      echo "\$other"
-    else
-      echo $2
-    fi ;;
-  -un|-nu) echo cqlite-test-user ;;
-  *)  echo $2 ;;
-esac
-EOF
-  chmod +x "$1/id"
-}
-
-# Inert shims for the tools the surrounding bootstrap sections would otherwise
-# reach (network / installs). Only the perf-specific shims below are functional.
-mkshim() {
-  local name="$1"
-  cat >"$tmp/$name" <<EOF
-#!/usr/bin/env bash
-exit 0
-EOF
-  chmod +x "$tmp/$name"
-}
-mkshim brew
-mkshim cargo
-mkshim roborev
-mkshim gh
-mkuname "$tmp" Linux   # every bootstrap run below that includes $tmp in PATH is Linux
-mkid "$tmp" 1000       # ...and is a NON-ROOT runner, whatever UID runs the suite
-host_home="$tmp/host-home"; mkdir -p "$host_home/.cargo"
+# shellcheck source=scripts/tests/lib/perf-capability-test-lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/lib/perf-capability-test-lib.sh"
 
 # --- 1. The shared helper: scripts/perf-capability.sh ------------------------------
 # Agent images ship kernel.perf_event_paranoid = 4 (all unprivileged perf DENIED)
 # and set it in no sysctl file, so a box is profileable only by accident and
-# reverts on reboot. Bootstrap now installs /etc/sysctl.d/99-cqlite-perf.conf and
-# — the part that matters — VERIFIES the result instead of assuming it.
+# reverts on reboot. Bootstrap installs /etc/sysctl.d/99-cqlite-perf.conf and — the
+# part that matters — VERIFIES the result instead of assuming it.
 #
-# Cases below cover the helper contract, then the two bootstrap modes, and are
-# written so NOTHING touches the host: two test-only env seams stand in for the
-# real paths (CQLITE_PERF_PROC_DIR for /proc/sys/kernel, CQLITE_PERF_SYSCTL_DIR for
+# Cases below cover the helper's whole contract and are written so NOTHING touches
+# the host: two test-only env seams stand in for the real paths
+# (CQLITE_PERF_PROC_DIR for /proc/sys/kernel, CQLITE_PERF_SYSCTL_DIR for
 # /etc/sysctl.d) and every privileged/mutating tool is a recording PATH shim. The
 # real /etc/sysctl.d is never opened by this suite.
 if bash -n "$PERFLIB" 2>/dev/null; then
@@ -293,12 +181,17 @@ else
   bad "perf-capability: env guard allowed a marker-less seam (rc=$guard_rc, out='$guard_out')"
 fi
 # ...and the marker is itself hermetic: with it set, a REAL sudo/sysctl on PATH is a
-# refusal, so test mode can never reach a real privileged tool.
+# refusal, so test mode can never reach a real privileged tool. Every case below supplies
+# BOTH sandbox seams, because under the marker they are MANDATORY (1c-iii) — the tool
+# check is what each of these is about, and an unsandboxed run would never reach it.
 realpriv="$tmp/realpriv"; mkdir -p "$realpriv"
 for t in sudo sysctl; do
   printf '#!/usr/bin/env bash\nexit 0\n' >"$realpriv/$t"; chmod +x "$realpriv/$t"
 done
+seamed_proc="$tmp/seamed-proc"; mkdir -p "$seamed_proc"
+seamed_d="$tmp/seamed-sysctl.d"; mkdir -p "$seamed_d"
 guard2_out=$(PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$tmp/some-other-dir" \
+  CQLITE_PERF_PROC_DIR="$seamed_proc" CQLITE_PERF_SYSCTL_DIR="$seamed_d" \
   bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); guard2_rc=$?
 if [ "$guard2_rc" -ne 0 ] && printf '%s' "$guard2_out" | grep -q 'outside the declared shim dir'; then
   ok "perf-capability: test mode REFUSES when sudo resolves outside the declared shim dir"
@@ -308,6 +201,7 @@ fi
 # ...and `sysctl` is guarded as strictly as `sudo` (a real `sysctl --system` would
 # reconfigure the HOST kernel, marker or not).
 guard3_out=$(PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$tmp/only-sudo-here" \
+  CQLITE_PERF_PROC_DIR="$seamed_proc" CQLITE_PERF_SYSCTL_DIR="$seamed_d" \
   bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1)
 if printf '%s' "$guard3_out" | grep -q 'sysctl resolves to\|sudo resolves to'; then
   ok "perf-capability: test mode guards BOTH sudo and sysctl against a real binary"
@@ -315,45 +209,62 @@ else
   bad "perf-capability: test mode did not name the offending privileged tool: '$guard3_out'"
 fi
 if PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
+     CQLITE_PERF_PROC_DIR="$seamed_proc" CQLITE_PERF_SYSCTL_DIR="$seamed_d" \
      bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>/dev/null; then
   ok "perf-capability: test mode ACCEPTS a sudo inside the declared shim dir"
 else
   bad "perf-capability: test mode rejected its own declared shim dir"
 fi
 
+# 1c-iii. TEST MODE HAS NO PRODUCTION FALLBACK (issue #3249 review R4-3). With the
+#         marker set and a path seam MISSING, the resolvers used to fall back to the REAL
+#         /etc/sysctl.d and /proc/sys/kernel — so a test-mode run could pass the env
+#         guard (sudo/sysctl absent, or present as declared shims) and a later root
+#         `--yes` run would `tee` the host's real drop-in. "Hermetic" may not depend on a
+#         variable happening to be set: an absent or production-shaped seam is a loud
+#         refusal, and the path/proc resolvers refuse with it.
+noseam_out=$(env -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_TEST_MODE=1 \
+  bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); noseam_rc=$?
+if [ "$noseam_rc" -ne 0 ] \
+   && printf '%s' "$noseam_out" | grep -q 'requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR' \
+   && printf '%s' "$noseam_out" | grep -q 'requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR' \
+   && printf '%s' "$noseam_out" | grep -q 'NEVER falls back'; then
+  ok "perf-capability: test mode with NO path seams REFUSES loudly and names BOTH missing sandbox dirs"
+else
+  bad "perf-capability: test mode without seams was allowed to act (rc=$noseam_rc, out='$noseam_out')"
+fi
+# A seam pointing AT production (or anywhere under /etc, /proc, /sys) is the same hole
+# wearing a seam, and a RELATIVE path is not a sandbox either.
+for badseam in /etc/sysctl.d /etc/sysctl.d/sub /etc /proc /proc/sys/kernel /sys relative/dir; do
+  if env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_PROC_DIR="$seamed_proc" CQLITE_PERF_SYSCTL_DIR="$badseam" \
+       bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" >/dev/null 2>&1; then
+    bad "perf-capability: test mode ACCEPTED a production/relative sysctl seam '$badseam'"
+    badseam_fail=1
+  fi
+  if env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$seamed_d" CQLITE_PERF_PROC_DIR="$badseam" \
+       bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" >/dev/null 2>&1; then
+    bad "perf-capability: test mode ACCEPTED a production/relative proc seam '$badseam'"
+    badseam_fail=1
+  fi
+done
+[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects a production-shaped or relative seam (/etc*, /proc*, /sys*, relative) on BOTH sandbox dirs"
+# ...and the refusal reaches the RESOLVERS, not only the guard: an unsandboxed test mode
+# must not be able to name a production path at all (this is what the `tee` would use).
+noseam_path=$(env -u CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_TEST_MODE=1 bash "$PERFLIB" --drop-in-path 2>/dev/null)
+noseam_path_rc=$?
+noseam_tok=$(env -u CQLITE_PERF_PROC_DIR CQLITE_PERF_TEST_MODE=1 bash "$PERFLIB" --token 2>/dev/null)
+if [ "$noseam_path_rc" -ne 0 ] && [ -z "$noseam_path" ] && [ "$noseam_tok" = absent ]; then
+  ok "perf-capability: unsandboxed test mode resolves NO drop-in path (rc 1, empty) and reads NO /proc (token 'absent')"
+else
+  bad "perf-capability: unsandboxed test mode still resolved production paths (path rc=$noseam_path_rc '$noseam_path', token '$noseam_tok')"
+fi
+
 # 1d. The FUNCTIONAL verification is HONOURED, not merely attempted — the #3119
 #      lesson (test_bootstrap_agent_machine.sh case 10) applied to this issue. `perf stat` exits 0 while
 #      printing `<not supported>` / `<not counted>`, and a virtualised PMU can
 #      report a flat 0, so an rc-only check is exactly the false green being fixed.
-perfbin="$tmp/perfbin"; mkdir -p "$perfbin"
-mkperfshim() { # mkperfshim <csv-count-field>
-  cat >"$perfbin/perf" <<EOF
-#!/usr/bin/env bash
-echo "perf \$*" >>"\$PERFSHIM_LOG"
-printf '%s\n' '$1,,cycles,100000000,100.00,,'
-exit 0
-EOF
-  chmod +x "$perfbin/perf"
-}
-# mkperfshim_raw <exit-code> <stdout-line>...: the general shim — an EXACT exit code
-# and arbitrary CSV rows (or none). The `perf stat` failure and empty-output paths are
-# the REAL states on an unbootstrapped box (paranoid=4 denies the syscall outright, so
-# perf exits non-zero), and every shim above exits 0 — so without this those two
-# branches were never driven and a mutation making either RETURN SUCCESS survived.
-mkperfshim_raw() {
-  local rc="$1"; shift
-  local data="$perfbin/perf.rows" line
-  : >"$data"
-  for line in "$@"; do printf '%s\n' "$line" >>"$data"; done
-  cat >"$perfbin/perf" <<EOF
-#!/usr/bin/env bash
-echo "perf \$*" >>"\$PERFSHIM_LOG"
-cat "$data"
-exit $rc
-EOF
-  chmod +x "$perfbin/perf"
-}
-export PERFSHIM_LOG="$tmp/perfshim.log"; : >"$PERFSHIM_LOG"
+#      `mkperfshim` / `mkperfshim_raw` / `$perfbin` / `$PERFSHIM_LOG` come from
+#      scripts/tests/lib/perf-capability-test-lib.sh (both suites drive the same shims).
 verify_verdict() { # verify_verdict <csv-count-field> -> "<rc> <stdout>"
   mkperfshim "$1"
   local out rc
@@ -478,856 +389,6 @@ else
   esac
 fi
 
-# --- 2. Bootstrap perf section: the DEFAULT (no --yes) run mutates NOTHING ----
-# Tripwire shims for every privileged/mutating tool the write path could use, so
-# "wrote nothing" is PROVEN rather than assumed. `perf` may be invoked (the
-# verification is read-only and is the point of the section); `sudo`, `sysctl` and
-# `tee` may not.
-perfshims="$tmp/perf-shims"; mkdir -p "$perfshims"
-perftrip="$tmp/perf-tripwire.log"; : >"$perftrip"
-for t in sudo sysctl tee; do
-  cat >"$perfshims/$t" <<EOF
-#!/usr/bin/env bash
-echo "$t \$*" >>"$perftrip"
-exit 0
-EOF
-  chmod +x "$perfshims/$t"
-done
-mkperfroot() { # mkperfroot <dir>: a throwaway REPO_ROOT bootstrap can resolve
-  local dir="$1"
-  mkdir -p "$dir/scripts/lib"
-  cp "$BOOTSTRAP" "$dir/scripts/bootstrap-agent-machine.sh"
-  cp "$PERFLIB" "$dir/scripts/perf-capability.sh"
-  cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$dir/scripts/lib/gate-notify.sh" 2>/dev/null || true
-}
-perf_sysctl_d="$tmp/perf-sysctl.d"; mkdir -p "$perf_sysctl_d"
-perf_proc="$tmp/perf-proc"; mkdir -p "$perf_proc"
-printf '4\n' >"$perf_proc/perf_event_paranoid"
-printf '1\n' >"$perf_proc/kptr_restrict"
-mkperfroot "$tmp/perf-root-check"
-mkperfshim 999999
-check_out=$(PATH="$perfshims:$perfbin:$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$perf_sysctl_d" CQLITE_PERF_TEST_PRIV_DIR="$perfshims" \
-  bash "$tmp/perf-root-check/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-check_rc=$?
-if printf '%s' "$check_out" | grep -q 'Perf profiling capability'; then
-  ok "perf section: present in the bootstrap run"
-else
-  bad "perf section: MISSING from the bootstrap run"
-fi
-# The ONLY tolerated privileged invocation is the non-mutating `sudo -n true`
-# availability probe (bootstrap must know whether to print a sudo remedy at all);
-# anything else — a `tee`, a `sysctl`, or any other sudo command — is a mutation.
-perf_mutating=$(grep -vE '^sudo -n true$' "$perftrip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
-if [ "$check_rc" -eq 0 ] && [ -z "$(ls -A "$perf_sysctl_d")" ] && [ -z "$perf_mutating" ]; then
-  ok "perf section: default (no --yes) run wrote NO drop-in and invoked no privileged/mutating command"
-else
-  bad "perf section: default run mutated state (rc=$check_rc, dir='$(ls -A "$perf_sysctl_d")', tripwire below)"
-  cat "$perftrip"
-fi
-# Whatever it DID invoke must be non-interactive: every recorded sudo line begins
-# `sudo -n `, so no code path can sit on a password prompt on an unattended worker.
-check_bare_sudo=$(sudo_perf_offenders "$perftrip")
-if grep -q '^sudo -n true$' "$perftrip" && [ -z "$check_bare_sudo" ]; then
-  ok "perf section: the default run's sudo probe carries -n (never interactive)"
-else
-  bad "perf section: a sudo invocation without -n was recorded (or the probe never ran): $(cat "$perftrip")"
-fi
-# It must instead PRINT the exact remedy, and the remedy must WRITE **AND APPLY**: a
-# write-only line leaves the operator with a reboot-persistent file and an
-# unprofileable box until reboot — the very failure the functional verification
-# exists to prevent, on the path most people take (no --yes). Plus the AC5 posture
-# and the BPF caveat (#3217).
-if printf '%s' "$check_out" | grep -q 'perf-capability.sh --drop-in | sudo tee .*99-cqlite-perf.conf >/dev/null && sudo sysctl -q --system' \
-   && printf '%s' "$check_out" | grep -q 're-run with --yes'; then
-  ok "perf section: prints the complete WRITE-AND-APPLY remedy line instead of running it"
-else
-  bad "perf section: the printed remedy is missing the apply (or absent)"
-  printf '%s\n' "$check_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-# The PRE-state line is asserted SPECIFICALLY (not just "a line somewhere mentions
-# paranoid-4"): it is the diagnosis an operator reads first, and a later warn line
-# carrying the same token would otherwise satisfy a loose grep.
-if printf '%s\n' "$check_out" | grep -q 'runtime now: perf_event_paranoid=4 kptr_restrict=1 .*gate stamps perf=paranoid-4'; then
-  ok "perf section: the pre-state line reports the ACTUAL /proc values and the token the gate will stamp"
-else
-  bad "perf section: the pre-state line is wrong or missing"
-  printf '%s\n' "$check_out" | grep 'runtime now' || true
-fi
-if printf '%s' "$check_out" | grep -qi 'BPF collectors .* require sudo' \
-   && printf '%s' "$check_out" | grep -qi 'never apply it to a shared or multi-tenant host'; then
-  ok "perf section: states the BPF-still-needs-sudo caveat and the single-tenant posture"
-else
-  bad "perf section: missing the BPF caveat or the security posture"
-fi
-# A blocked box must be DIAGNOSED as a permission verdict, not a capability one.
-if printf '%s' "$check_out" | grep -q 'perf=paranoid-4' \
-   && printf '%s' "$check_out" | grep -qi 'PERMISSION verdict'; then
-  ok "perf section: paranoid-4 is reported as a PERMISSION verdict with the gate's token"
-else
-  bad "perf section: a blocked box was not diagnosed as a permission verdict"
-  printf '%s\n' "$check_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# --- 3. Bootstrap perf section under --yes: write -> READ BACK -> verify ------
-# The privileged shims here are FUNCTIONAL, not inert: `sudo` records and execs,
-# `sysctl --system` records and (like the kernel would) updates the fake procfs, so
-# the read-back has something real to read. Order is asserted, because a read-back
-# that runs BEFORE the apply proves nothing.
-yesshims="$tmp/perf-yes-shims"; mkdir -p "$yesshims"
-yestrip="$tmp/perf-yes-tripwire.log"; : >"$yestrip"
-cat >"$yesshims/sudo" <<EOF
-#!/usr/bin/env bash
-echo "sudo \$*" >>"$yestrip"
-while [ "\${1:-}" = "-n" ]; do shift; done
-exec "\$@"
-EOF
-cat >"$yesshims/sysctl" <<EOF
-#!/usr/bin/env bash
-echo "sysctl \$*" >>"$yestrip"
-case " \$* " in *" --system "*)
-  printf -- '-1\n' >"$tmp/perf-proc-yes/perf_event_paranoid"
-  printf '0\n'     >"$tmp/perf-proc-yes/kptr_restrict" ;;
-esac
-exit 0
-EOF
-# apt-get/apt: --yes would otherwise reach the real package manager via the mold
-# section. Record-only, so this suite can never install anything on the host.
-for t in apt-get apt dnf yum pacman; do
-  cat >"$yesshims/$t" <<EOF
-#!/usr/bin/env bash
-echo "$t \$*" >>"$yestrip"
-exit 0
-EOF
-done
-chmod +x "$yesshims"/*
-proc_yes="$tmp/perf-proc-yes"; mkdir -p "$proc_yes"
-printf '4\n' >"$proc_yes/perf_event_paranoid"
-printf '1\n' >"$proc_yes/kptr_restrict"
-sysctl_yes="$tmp/perf-sysctl-yes.d"; mkdir -p "$sysctl_yes"
-mkperfroot "$tmp/perf-root-yes"
-mkperfshim 7777777
-yes_home="$tmp/perf-yes-home"; mkdir -p "$yes_home/.cargo"
-yes_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-yes_rc=$?
-if [ "$yes_rc" -eq 0 ]; then
-  ok "perf section: --yes run exits 0"
-else
-  bad "perf section: --yes run exited non-zero (rc=$yes_rc)"
-fi
-if [ -f "$sysctl_yes/99-cqlite-perf.conf" ] \
-   && diff -q <(bash "$PERFLIB" --drop-in) "$sysctl_yes/99-cqlite-perf.conf" >/dev/null 2>&1; then
-  ok "perf section: --yes wrote the drop-in with EXACTLY the canonical bytes"
-else
-  bad "perf section: --yes did not write the canonical drop-in"
-  ls -l "$sysctl_yes" 2>&1 | head -3
-fi
-if grep -q 'tee .*99-cqlite-perf.conf' "$yestrip" && grep -q 'sysctl -q --system' "$yestrip"; then
-  ok "perf section: --yes wrote through sudo tee and applied with 'sysctl --system'"
-else
-  bad "perf section: --yes did not use sudo tee + sysctl --system"
-  cat "$yestrip"
-fi
-# ...and EVERY privileged invocation carried `-n`: an unattended worker must never be
-# able to sit on a password prompt, so `PERF_ROOT=(sudo)` (no -n) is a defect even
-# though every functional assert above would still pass.
-yes_bare_sudo=$(sudo_perf_offenders "$yestrip")
-if [ -z "$yes_bare_sudo" ] && grep -q '^sudo -n tee ' "$yestrip" && grep -q '^sudo -n sysctl ' "$yestrip"; then
-  ok "perf section: every --yes privileged call went through 'sudo -n' (write AND apply, never interactive)"
-else
-  bad "perf section: a privileged call did not carry sudo -n: $(cat "$yestrip")"
-fi
-# ORDER: the apply must precede the read-back verdict, and the functional verify
-# must come last (it is the verdict on the whole section).
-yes_perf_block=$(printf '%s\n' "$yes_out" | sed -n '/Perf profiling capability/,/^$/p')
-n_wrote=$(printf '%s\n' "$yes_perf_block" | grep -n 'wrote .*99-cqlite-perf.conf' | head -1 | cut -d: -f1)
-n_read=$(printf '%s\n' "$yes_perf_block" | grep -n 'READ BACK from /proc' | head -1 | cut -d: -f1)
-n_verify=$(printf '%s\n' "$yes_perf_block" | grep -n 'perf capability VERIFIED' | head -1 | cut -d: -f1)
-if [ -n "$n_wrote" ] && [ -n "$n_read" ] && [ -n "$n_verify" ] \
-   && [ "$n_wrote" -lt "$n_read" ] && [ "$n_read" -lt "$n_verify" ]; then
-  ok "perf section: order is write -> read-back from /proc -> functional verify"
-else
-  bad "perf section: wrong order (wrote=$n_wrote read-back=$n_read verify=$n_verify)"
-  printf '%s\n' "$yes_perf_block"
-fi
-# Idempotency: a SECOND --yes run must write nothing (byte-compare no-op).
-: >"$yestrip"
-yes2_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-if printf '%s' "$yes2_out" | grep -q 'drop-in already current' \
-   && ! grep -q 'tee .*99-cqlite-perf.conf' "$yestrip"; then
-  ok "perf section: a second --yes run is an idempotent no-op (no re-write)"
-else
-  bad "perf section: second --yes run re-wrote the drop-in"
-  printf '%s\n' "$yes2_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# --- 4. The verification VERDICT is honoured, and no-sudo degrades gracefully --
-# 4a. A perf that exits 0 but reports an unusable counter must produce a WARN and
-#      must NEVER be reported as verified. This is the #3119-style mutation (test_bootstrap_agent_machine.sh case 10) applied
-#      to AC2: without it, "the check exists" would pass while the box is unusable.
-mkperfshim '<not supported>'
-unsup_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-unsup_rc=$?
-if printf '%s' "$unsup_out" | grep -q 'perf capability NOT verified' \
-   && ! printf '%s' "$unsup_out" | grep -q 'perf capability VERIFIED' \
-   && [ "$unsup_rc" -eq 0 ]; then
-  ok "perf section: an rc-0 perf with an unusable counter WARNs (never 'verified'), run still exits 0"
-else
-  bad "perf section: unusable counter was not surfaced (rc=$unsup_rc)"
-  printf '%s\n' "$unsup_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-# 4b. Zero cycles is the virtualised-PMU case — same verdict.
-mkperfshim 0
-zero_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-if printf '%s' "$zero_out" | grep -q 'perf capability NOT verified' \
-   && ! printf '%s' "$zero_out" | grep -q 'perf capability VERIFIED'; then
-  ok "perf section: a zero cycle count WARNs (never 'verified')"
-else
-  bad "perf section: a zero cycle count was accepted as verified"
-  printf '%s\n' "$zero_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-# 4c. A box with NO sudo BINARY: warn + a remedy that actually works there, no write,
-#      still exit 0. The generic `... | sudo tee` line is USELESS on this box, so the
-#      case asserts the root-shell remedy AND the absence of the sudo one — the two
-#      `sudo -n` failure modes (no binary vs needs a password) are different boxes.
-nosudo="$tmp/perf-nosudo"; mkdir -p "$nosudo"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
-         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nosudo/$t"
-done
-mkuname "$nosudo" Linux
-mkid "$nosudo" 1000    # non-root, whatever UID runs the suite
-ln -sf "$perfbin/perf" "$nosudo/perf"
-mkperfshim 5555555
-nosudo_sysctl="$tmp/perf-nosudo.d"; mkdir -p "$nosudo_sysctl"
-nosudo_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$nosudo_sysctl" CQLITE_PERF_TEST_PRIV_DIR="$nosudo" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-nosudo_rc=$?
-if [ "$nosudo_rc" -eq 0 ] && [ -z "$(ls -A "$nosudo_sysctl")" ] \
-   && printf '%s' "$nosudo_out" | grep -q "no 'sudo' binary on this box" \
-   && printf '%s' "$nosudo_out" | grep -q 'ROOT shell:.*--drop-in > .*99-cqlite-perf.conf && sysctl -q --system' \
-   && ! printf '%s' "$nosudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf'; then
-  ok "perf section: a box with no sudo BINARY warns + prints the root-shell remedy (never a useless 'sudo tee'), writes nothing, exits 0"
-else
-  bad "perf section: no-sudo box mishandled (rc=$nosudo_rc, dir='$(ls -A "$nosudo_sysctl")')"
-  printf '%s\n' "$nosudo_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 4c-ii. A box WITH sudo whose `sudo -n` fails (a password is required) is a DIFFERENT
-#        box: the `sudo tee` line does work there, interactively. Bootstrap must say so
-#        and must still never prompt.
-pwsudo="$tmp/perf-pwsudo"; mkdir -p "$pwsudo"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
-         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$pwsudo/$t"
-done
-mkuname "$pwsudo" Linux
-mkid "$pwsudo" 1000    # non-root, whatever UID runs the suite
-ln -sf "$perfbin/perf" "$pwsudo/perf"
-pwtrip="$tmp/perf-pwsudo-tripwire.log"; : >"$pwtrip"
-cat >"$pwsudo/sudo" <<EOF
-#!/usr/bin/env bash
-echo "sudo \$*" >>"$pwtrip"
-exit 1
-EOF
-chmod +x "$pwsudo/sudo"
-pwsudo_sysctl="$tmp/perf-pwsudo.d"; mkdir -p "$pwsudo_sysctl"
-pwsudo_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$pwsudo_sysctl" CQLITE_PERF_TEST_PRIV_DIR="$pwsudo" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-pwsudo_rc=$?
-if [ "$pwsudo_rc" -eq 0 ] && [ -z "$(ls -A "$pwsudo_sysctl")" ] \
-   && printf '%s' "$pwsudo_out" | grep -q 'sudo needs a password' \
-   && printf '%s' "$pwsudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf.*&& sudo sysctl -q --system' \
-   && ! printf '%s' "$pwsudo_out" | grep -q "no 'sudo' binary"; then
-  ok "perf section: a password-requiring sudo is diagnosed distinctly (not 'no sudo binary') with the interactive remedy, writes nothing, exits 0"
-else
-  bad "perf section: password-requiring sudo mishandled (rc=$pwsudo_rc, dir='$(ls -A "$pwsudo_sysctl")')"
-  printf '%s\n' "$pwsudo_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-# Whatever it invoked, it must have been non-interactive: EVERY recorded sudo line
-# begins `sudo -n `, so no code path can sit on a password prompt on a worker.
-pw_bad_sudo=$(sudo_perf_offenders "$pwtrip")
-if grep -q '^sudo -n true$' "$pwtrip" && [ -z "$pw_bad_sudo" ]; then
-  ok "perf section: every sudo invocation carries -n (never interactive)"
-else
-  bad "perf section: a sudo invocation without -n was recorded (or none at all): $(cat "$pwtrip")"
-fi
-
-# 4c-iii. ALREADY ROOT: the printed remedy must carry NO `sudo` prefix — many root
-#         images have no sudo installed at all, so a hardcoded `sudo tee` line is
-#         un-runnable exactly where it is printed. Check mode, so nothing is written.
-rootbox="$tmp/perf-rootbox"; mkdir -p "$rootbox"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
-         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$rootbox/$t"
-done
-mkuname "$rootbox" Linux
-mkid "$rootbox" 0      # the ONLY case that exercises the already-root branch
-roottrip="$tmp/perf-rootbox-tripwire.log"; : >"$roottrip"
-for t in sudo sysctl; do
-  cat >"$rootbox/$t" <<EOF
-#!/usr/bin/env bash
-echo "$t \$*" >>"$roottrip"
-exit 0
-EOF
-  chmod +x "$rootbox/$t"
-done
-ln -sf "$perfbin/perf" "$rootbox/perf"
-mkperfshim 3333333
-rootbox_d="$tmp/perf-rootbox.d"; mkdir -p "$rootbox_d"
-rootbox_out=$(PATH="$rootbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$rootbox_d" CQLITE_PERF_TEST_PRIV_DIR="$rootbox" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-rootbox_rc=$?
-rootbox_remedy=$(printf '%s\n' "$rootbox_out" | grep 'write + apply the drop-in' || true)
-if [ "$rootbox_rc" -eq 0 ] && [ -z "$(ls -A "$rootbox_d")" ] \
-   && printf '%s' "$rootbox_remedy" | grep -q '| tee .*99-cqlite-perf.conf >/dev/null && sysctl -q --system' \
-   && ! printf '%s' "$rootbox_remedy" | grep -q 'sudo'; then
-  ok "perf section: when ALREADY ROOT the printed write+apply remedy carries no 'sudo' prefix"
-else
-  bad "perf section: root-box remedy line wrong (rc=$rootbox_rc, line='$rootbox_remedy')"
-fi
-
-# 4d. THE SILENT REVERT — the real-world trap this whole issue exists to fix, and so
-#      the path that must be best-tested. `sysctl` exits 0 while the value does NOT
-#      take (container, read-only /proc, a later-sorting drop-in or /etc/sysctl.conf
-#      winning), so the verdict may never come from the apply's return code. Here the
-#      sysctl shim succeeds but does NOT touch the fake procfs, and perf is DENIED
-#      (non-zero, as a real paranoid-4 box denies it): bootstrap must warn "did NOT
-#      take", must NOT claim a READ BACK, and must NOT claim VERIFIED — while still
-#      exiting 0. Trusting sysctl's rc keeps every other case green.
-revert_proc="$tmp/perf-proc-revert"; mkdir -p "$revert_proc"
-printf '4\n' >"$revert_proc/perf_event_paranoid"
-printf '1\n' >"$revert_proc/kptr_restrict"
-revert_shims="$tmp/perf-revert-shims"; mkdir -p "$revert_shims"
-revert_trip="$tmp/perf-revert-tripwire.log"; : >"$revert_trip"
-cat >"$revert_shims/sudo" <<EOF
-#!/usr/bin/env bash
-echo "sudo \$*" >>"$revert_trip"
-while [ "\${1:-}" = "-n" ]; do shift; done
-exec "\$@"
-EOF
-cat >"$revert_shims/sysctl" <<EOF
-#!/usr/bin/env bash
-echo "sysctl \$*" >>"$revert_trip"
-exit 0
-EOF
-for t in apt-get apt dnf yum pacman; do
-  printf '#!/usr/bin/env bash\nexit 0\n' >"$revert_shims/$t"
-done
-chmod +x "$revert_shims"/*
-revert_sysctl_d="$tmp/perf-revert.d"; mkdir -p "$revert_sysctl_d"
-mkperfshim_raw 1 'Error:' 'Access to performance monitoring and observability operations is limited.'
-revert_out=$(PATH="$revert_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$revert_sysctl_d" CQLITE_PERF_TEST_PRIV_DIR="$revert_shims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-revert_rc=$?
-if [ "$revert_rc" -eq 0 ] \
-   && printf '%s' "$revert_out" | grep -q 'the value did NOT take' \
-   && printf '%s' "$revert_out" | grep -q 'perf=paranoid-4' \
-   && ! printf '%s' "$revert_out" | grep -q 'READ BACK from /proc' \
-   && ! printf '%s' "$revert_out" | grep -q 'perf capability VERIFIED' \
-   && grep -q 'sysctl -q --system' "$revert_trip"; then
-  ok "perf section: a sysctl that exits 0 without the value taking is reported as 'did NOT take' from /proc (no READ BACK, no VERIFIED), rc 0"
-else
-  bad "perf section: the silent revert was not caught (rc=$revert_rc)"
-  printf '%s\n' "$revert_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-# ...and the diagnostics must name /etc/sysctl.conf, which BOTH `sysctl --system` and
-# systemd-sysctl apply AFTER the sysctl.d drop-ins — so a stale entry there beats our
-# 99- file and is the likeliest cause of exactly this state.
-if printf '%s' "$revert_out" | grep -q '/etc/sysctl.conf' \
-   && printf '%s' "$revert_out" | grep -qi 'applied AFTER the sysctl.d drop-ins'; then
-  ok "perf section: the did-NOT-take diagnostics name /etc/sysctl.conf and its precedence over the drop-ins"
-else
-  bad "perf section: diagnostics omit the /etc/sysctl.conf precedence trap"
-fi
-
-# 4d-ii. CHECK mode with the drop-in already on disk but the runtime NOT profileable:
-#         the apply was only PRINTED, so bootstrap must NOT claim it was applied, and
-#         must still WARN (this branch was previously unreachable — the mismatch
-#         produced no [warn] at all and counted no WARNING).
-checkapply_d="$tmp/perf-checkapply.d"; mkdir -p "$checkapply_d"
-bash "$PERFLIB" --drop-in >"$checkapply_d/99-cqlite-perf.conf"
-checkapply_trip="$tmp/perf-checkapply-tripwire.log"; : >"$checkapply_trip"
-checkapply_shims="$tmp/perf-checkapply-shims"; mkdir -p "$checkapply_shims"
-for t in sudo sysctl tee; do
-  cat >"$checkapply_shims/$t" <<EOF
-#!/usr/bin/env bash
-echo "$t \$*" >>"$checkapply_trip"
-exit 0
-EOF
-done
-chmod +x "$checkapply_shims"/*
-mkperfshim 4242
-checkapply_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$checkapply_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-checkapply_rc=$?
-checkapply_mutating=$(grep -vE '^sudo -n true$' "$checkapply_trip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
-if [ "$checkapply_rc" -eq 0 ] \
-   && printf '%s' "$checkapply_out" | grep -q 'drop-in already current' \
-   && printf '%s' "$checkapply_out" | grep -q 'has NOT been applied to the running kernel' \
-   && ! printf '%s' "$checkapply_out" | grep -q 'READ BACK from /proc' \
-   && ! printf '%s' "$checkapply_out" | grep -q 'sysctl --system reported success' \
-   && [ -z "$checkapply_mutating" ]; then
-  ok "perf section: check mode with a current drop-in but a non-ok runtime WARNs that it is not applied (and applies nothing)"
-else
-  bad "perf section: check-mode drop-in/runtime mismatch mishandled (rc=$checkapply_rc, tripwire='$checkapply_mutating')"
-  printf '%s\n' "$checkapply_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 4d-iii. THE APPLY COMMAND FAILED, THE CONTROLS TOOK ANYWAY. `sysctl --system` applies
-#         EVERY drop-in on the box, so it can apply OURS correctly and still exit
-#         non-zero because an unrelated pre-existing entry failed (a stale
-#         /etc/sysctl.conf line, a foreign drop-in naming a knob this kernel lacks) —
-#         and one such entry anywhere on a fleet box is enough. Gating the /proc
-#         read-back on that rc left the token STALE and printed "nothing was applied"
-#         about a box that had JUST become profileable: a false verdict, which is the
-#         one thing AC2 exists to prevent. The two facts are independent and must be
-#         reported independently — the command's failure named as the COMMAND's, and the
-#         capability verdict taken from /proc regardless. Here the sysctl shim exits 1
-#         AND updates the fake procfs.
-rcfail_proc="$tmp/perf-proc-rcfail"; mkdir -p "$rcfail_proc"
-printf '4\n' >"$rcfail_proc/perf_event_paranoid"
-printf '1\n' >"$rcfail_proc/kptr_restrict"
-rcfail_shims="$tmp/perf-rcfail-shims"; mkdir -p "$rcfail_shims"
-rcfail_trip="$tmp/perf-rcfail-tripwire.log"; : >"$rcfail_trip"
-cat >"$rcfail_shims/sudo" <<EOF
-#!/usr/bin/env bash
-echo "sudo \$*" >>"$rcfail_trip"
-while [ "\${1:-}" = "-n" ]; do shift; done
-exec "\$@"
-EOF
-cat >"$rcfail_shims/sysctl" <<EOF
-#!/usr/bin/env bash
-echo "sysctl \$*" >>"$rcfail_trip"
-case " \$* " in *" --system "*)
-  printf -- '-1\n' >"$rcfail_proc/perf_event_paranoid"
-  printf '0\n'     >"$rcfail_proc/kptr_restrict"
-  echo "sysctl: setting key \"vm.unrelated_stale_entry\": Invalid argument" >&2 ;;
-esac
-exit 1
-EOF
-for t in apt-get apt dnf yum pacman; do
-  printf '#!/usr/bin/env bash\nexit 0\n' >"$rcfail_shims/$t"
-done
-chmod +x "$rcfail_shims"/*
-rcfail_d="$tmp/perf-rcfail.d"; mkdir -p "$rcfail_d"
-bash "$PERFLIB" --drop-in >"$rcfail_d/99-cqlite-perf.conf"   # already current: only the apply is left
-mkperfshim 6060606
-rcfail_out=$(PATH="$rcfail_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$rcfail_proc" CQLITE_PERF_SYSCTL_DIR="$rcfail_d" CQLITE_PERF_TEST_PRIV_DIR="$rcfail_shims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-rcfail_rc=$?
-# The read-back verdict must be GOOD (it is what /proc now says), the command failure
-# must be reported DISTINCTLY (naming the exit status and that it applies every
-# drop-in), and the two must not contradict: no "nothing was applied", no "did NOT
-# take", no "NOT in the profileable state" alongside a good read-back. rc still 0.
-if [ "$rcfail_rc" -eq 0 ] \
-   && printf '%s' "$rcfail_out" | grep -q "READ BACK from /proc as profileable: perf_event_paranoid=-1 kptr_restrict=0" \
-   && printf '%s' "$rcfail_out" | grep -q "'sysctl -q --system' exited 1" \
-   && printf '%s' "$rcfail_out" | grep -q 'UNRELATED pre-existing entry' \
-   && ! printf '%s' "$rcfail_out" | grep -q 'nothing was applied' \
-   && ! printf '%s' "$rcfail_out" | grep -q 'the value did NOT take' \
-   && ! printf '%s' "$rcfail_out" | grep -q 'NOT in the profileable state' \
-   && ! printf '%s' "$rcfail_out" | grep -q 'are NOT in effect' \
-   && grep -q 'sysctl -q --system' "$rcfail_trip"; then
-  ok "perf section: a sysctl that FAILS while the controls DO take reports the command failure distinctly and still reads the good verdict back from /proc, rc 0"
-else
-  bad "perf section: a failing sysctl suppressed the /proc read-back or contradicted it (rc=$rcfail_rc)"
-  printf '%s\n' "$rcfail_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-# ...and the run must still be honest when BOTH facts are bad: the same failing sysctl
-# with a procfs that does NOT change must name the command failure AND report the
-# controls as not in effect — never a good read-back.
-rcfail2_proc="$tmp/perf-proc-rcfail2"; mkdir -p "$rcfail2_proc"
-printf '4\n' >"$rcfail2_proc/perf_event_paranoid"
-printf '1\n' >"$rcfail2_proc/kptr_restrict"
-rcfail2_shims="$tmp/perf-rcfail2-shims"; mkdir -p "$rcfail2_shims"
-cp "$rcfail_shims/sudo" "$rcfail2_shims/sudo"
-printf '#!/usr/bin/env bash\nexit 1\n' >"$rcfail2_shims/sysctl"
-for t in apt-get apt dnf yum pacman; do
-  printf '#!/usr/bin/env bash\nexit 0\n' >"$rcfail2_shims/$t"
-done
-chmod +x "$rcfail2_shims"/*
-rcfail2_out=$(PATH="$rcfail2_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$rcfail2_proc" CQLITE_PERF_SYSCTL_DIR="$rcfail_d" CQLITE_PERF_TEST_PRIV_DIR="$rcfail2_shims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-rcfail2_rc=$?
-if [ "$rcfail2_rc" -eq 0 ] \
-   && printf '%s' "$rcfail2_out" | grep -q "'sysctl -q --system' exited 1" \
-   && printf '%s' "$rcfail2_out" | grep -q 'the controls are NOT in effect' \
-   && ! printf '%s' "$rcfail2_out" | grep -q 'READ BACK from /proc as profileable' \
-   && ! printf '%s' "$rcfail2_out" | grep -q 'reported success'; then
-  ok "perf section: a failing sysctl whose controls did NOT take reports BOTH facts (command exited 1 + controls not in effect), never a good read-back"
-else
-  bad "perf section: the both-bad case mishandled (rc=$rcfail2_rc)"
-  printf '%s\n' "$rcfail2_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 4d-iv. CURRENT DROP-IN + NO PRIVILEGE + non-ok runtime: nothing to WRITE (so the
-#        write remedy is not the fix) and no non-interactive privilege to APPLY, which
-#        used to print a diagnosis with NO remedy at all — contradicting every other
-#        unprivileged path in this section. Two boxes, two remedies: a box with no sudo
-#        BINARY needs the root-shell line (a `sudo` line is un-runnable there), a box
-#        whose sudo needs a password needs the same line WITH `sudo` (it works
-#        interactively).
-noapply_d="$tmp/perf-noapply.d"; mkdir -p "$noapply_d"
-bash "$PERFLIB" --drop-in >"$noapply_d/99-cqlite-perf.conf"
-noapply_ref="$tmp/perf-noapply-ref.conf"; cp "$noapply_d/99-cqlite-perf.conf" "$noapply_ref"
-noapply_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$noapply_d" CQLITE_PERF_TEST_PRIV_DIR="$nosudo" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-noapply_rc=$?
-if [ "$noapply_rc" -eq 0 ] \
-   && cmp -s "$noapply_ref" "$noapply_d/99-cqlite-perf.conf" \
-   && printf '%s' "$noapply_out" | grep -q 'drop-in already current' \
-   && printf '%s' "$noapply_out" | grep -q 'NOT in the profileable state' \
-   && printf '%s' "$noapply_out" | grep -q "no 'sudo' on this box — apply it from a ROOT shell:  sysctl -q --system" \
-   && ! printf '%s' "$noapply_out" | grep -q 'sudo sysctl'; then
-  ok "perf section: a current drop-in that cannot be applied (no sudo binary) still prints a RUNNABLE root-shell apply remedy, writes nothing, exits 0"
-else
-  bad "perf section: the current-drop-in/no-privilege branch printed no usable apply remedy (rc=$noapply_rc)"
-  printf '%s\n' "$noapply_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-noapply2_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$noapply_d" CQLITE_PERF_TEST_PRIV_DIR="$pwsudo" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-noapply2_rc=$?
-if [ "$noapply2_rc" -eq 0 ] \
-   && cmp -s "$noapply_ref" "$noapply_d/99-cqlite-perf.conf" \
-   && printf '%s' "$noapply2_out" | grep -q 'NOT in the profileable state' \
-   && printf '%s' "$noapply2_out" | grep -q 'apply the drop-in now:  sudo sysctl -q --system' \
-   && ! printf '%s' "$noapply2_out" | grep -q "no 'sudo' on this box"; then
-  ok "perf section: the same branch on a password-requiring sudo prints the INTERACTIVE 'sudo sysctl -q --system' apply remedy"
-else
-  bad "perf section: the password-sudo current-drop-in branch remedy is wrong (rc=$noapply2_rc)"
-  printf '%s\n' "$noapply2_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 4e. A box with NO `perf` at all must WARN + print the install remedy and STILL exit
-#      0 — bootstrap is the fleet provisioning entry point, so a hard exit here would
-#      break every box without linux-tools. Every other case has perf on PATH, so an
-#      `exit 1` inserted in this branch previously survived the whole suite.
-noperfbox="$tmp/perf-noperfbox"; mkdir -p "$noperfbox"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
-         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$noperfbox/$t"
-done
-mkuname "$noperfbox" Linux
-mkid "$noperfbox" 1000    # non-root, whatever UID runs the suite
-cat >"$noperfbox/sudo" <<EOF
-#!/usr/bin/env bash
-while [ "\${1:-}" = "-n" ]; do shift; done
-exec "\$@"
-EOF
-printf '#!/usr/bin/env bash\nexit 0\n' >"$noperfbox/sysctl"
-printf '#!/usr/bin/env bash\nexit 0\n' >"$noperfbox/apt-get"
-chmod +x "$noperfbox/sudo" "$noperfbox/sysctl" "$noperfbox/apt-get"
-noperfbox_d="$tmp/perf-noperfbox.d"; mkdir -p "$noperfbox_d"
-noperfbox_out=$(PATH="$noperfbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$noperfbox_d" CQLITE_PERF_TEST_PRIV_DIR="$noperfbox" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-noperfbox_rc=$?
-if [ "$noperfbox_rc" -eq 0 ] \
-   && printf '%s' "$noperfbox_out" | grep -q 'perf MISSING' \
-   && printf '%s' "$noperfbox_out" | grep -q 'install perf:.*linux-tools' \
-   && ! printf '%s' "$noperfbox_out" | grep -q 'perf capability VERIFIED'; then
-  ok "perf section: a box with no 'perf' binary warns UNVERIFIED + prints the linux-tools remedy and still exits 0"
-else
-  bad "perf section: missing-perf box mishandled (rc=$noperfbox_rc)"
-  printf '%s\n' "$noperfbox_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 4f. DARWIN no-op: perf_event_paranoid/kptr_restrict are Linux kernel controls, so on
-#      macOS the section must say so, write nothing, and exit 0. Without a `uname`
-#      stub this whole suite was silently Linux-host-only (a Darwin gate host would
-#      have reddened `tooling-tests` on 10 cases while this path had no assertion).
-darwin_dir="$tmp/perf-darwin-bin"; mkdir -p "$darwin_dir"
-mkuname "$darwin_dir" Darwin
-darwin_d="$tmp/perf-darwin.d"; mkdir -p "$darwin_d"
-darwin_trip="$tmp/perf-darwin-tripwire.log"; : >"$darwin_trip"
-for t in sudo sysctl tee; do
-  cat >"$darwin_dir/$t" <<EOF
-#!/usr/bin/env bash
-echo "$t \$*" >>"$darwin_trip"
-exit 0
-EOF
-done
-chmod +x "$darwin_dir"/*
-darwin_out=$(PATH="$darwin_dir:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$darwin_d" CQLITE_PERF_TEST_PRIV_DIR="$darwin_dir" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-darwin_rc=$?
-darwin_mutating=$(grep -vE '^sudo -n true$' "$darwin_trip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
-if [ "$darwin_rc" -eq 0 ] \
-   && printf '%s' "$darwin_out" | grep -q 'nothing to configure on macos' \
-   && [ -z "$(ls -A "$darwin_d")" ] && [ -z "$darwin_mutating" ] \
-   && ! printf '%s' "$darwin_out" | grep -q 'perf capability VERIFIED'; then
-  ok "perf section: on Darwin the section is an explicit no-op — no write, no privileged call, rc 0"
-else
-  bad "perf section: Darwin no-op mishandled (rc=$darwin_rc, dir='$(ls -A "$darwin_d")', tripwire='$darwin_mutating')"
-  printf '%s\n' "$darwin_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 4f-ii. AN INHERITED `PERF_SECTION_OK=1` MAY NOT STEER THE SECTION (issue #3249
-#        review). The gate was read as `${PERF_SECTION_OK:-0}` with no initialisation
-#        before the platform/library checks, so an ambient export carried a macOS host
-#        straight into the LINUX-ONLY implementation and called helper functions that
-#        were never sourced. Same env-inheritance class as the CQLITE_PERF_SYSCTL_DIR
-#        seam steering a privileged write. Asserted on BOTH pre-conditions the guard
-#        chain has: the wrong platform, and a checkout with no perf-capability.sh.
-darwin_inherit_out=$(PERF_SECTION_OK=1 PATH="$darwin_dir:$perfbin:$tmp:$PATH" \
-  HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$darwin_d" CQLITE_PERF_TEST_PRIV_DIR="$darwin_dir" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-darwin_inherit_rc=$?
-if [ "$darwin_inherit_rc" -eq 0 ] \
-   && printf '%s' "$darwin_inherit_out" | grep -q 'nothing to configure on macos' \
-   && [ -z "$(ls -A "$darwin_d")" ] \
-   && ! printf '%s' "$darwin_inherit_out" | grep -q 'runtime now: perf_event_paranoid' \
-   && ! printf '%s' "$darwin_inherit_out" | grep -q 'perf capability VERIFIED' \
-   && ! printf '%s' "$darwin_inherit_out" | grep -qi 'command not found'; then
-  ok "perf section: an INHERITED PERF_SECTION_OK=1 cannot drag a Darwin run into the Linux-only implementation"
-else
-  bad "perf section: an inherited PERF_SECTION_OK=1 steered the section (rc=$darwin_inherit_rc)"
-  printf '%s\n' "$darwin_inherit_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-nolib_root="$tmp/perf-root-nolib"; mkdir -p "$nolib_root/scripts/lib"
-cp "$BOOTSTRAP" "$nolib_root/scripts/bootstrap-agent-machine.sh"
-cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$nolib_root/scripts/lib/gate-notify.sh" 2>/dev/null || true
-nolib_d="$tmp/perf-nolib.d"; mkdir -p "$nolib_d"
-nolib_out=$(PERF_SECTION_OK=1 PATH="$checkapply_shims:$perfbin:$tmp:$PATH" \
-  HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$nolib_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
-  bash "$nolib_root/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
-nolib_rc=$?
-if [ "$nolib_rc" -eq 0 ] \
-   && printf '%s' "$nolib_out" | grep -q 'perf-capability.sh missing from this checkout' \
-   && [ -z "$(ls -A "$nolib_d")" ] \
-   && ! printf '%s' "$nolib_out" | grep -q 'runtime now: perf_event_paranoid' \
-   && ! printf '%s' "$nolib_out" | grep -q 'perf capability VERIFIED' \
-   && ! printf '%s' "$nolib_out" | grep -qi 'command not found'; then
-  ok "perf section: an INHERITED PERF_SECTION_OK=1 cannot enter the implementation with no perf-capability.sh in the checkout"
-else
-  bad "perf section: an inherited PERF_SECTION_OK=1 entered the section without its library (rc=$nolib_rc)"
-  printf '%s\n' "$nolib_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# --- 5. THE FUNCTIONAL RESULT IS SUBORDINATE TO /proc, AND TO IDENTITY --------
-# 5a. A SUCCESSFUL perf stat while /proc says paranoid-4. Reporting the functional
-#     result as the overall verdict let a run print a `paranoid-*` diagnosis AND
-#     "VERIFIED" in the same output — contradictory, with the reassuring line winning
-#     the reader's attention. Overall verification now requires BOTH facts; a lone
-#     functional pass is PARTIAL DIAGNOSTIC INFORMATION and /proc governs.
-mkperfshim 8888888
-subord_d="$tmp/perf-subord.d"; mkdir -p "$subord_d"
-bash "$PERFLIB" --drop-in >"$subord_d/99-cqlite-perf.conf"   # current: only /proc disagrees
-subord_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$subord_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-subord_rc=$?
-if [ "$subord_rc" -eq 0 ] \
-   && ! printf '%s' "$subord_out" | grep -q 'perf capability VERIFIED' \
-   && printf '%s' "$subord_out" | grep -q 'perf capability NOT verified' \
-   && printf '%s' "$subord_out" | grep -q 'PARTIAL DIAGNOSTIC INFORMATION' \
-   && printf '%s' "$subord_out" | grep -q '/proc is the AUTHORITY here: perf=paranoid-4' \
-   && printf '%s' "$subord_out" | grep -qi 'PERMISSION verdict' \
-   && printf '%s' "$subord_out" | grep -q 'cycles=8888888'; then
-  ok "perf section: a SUCCESSFUL perf stat while /proc says paranoid-4 is never 'VERIFIED' — reported as partial info, /proc governs"
-else
-  bad "perf section: a functional pass overrode a non-ok /proc verdict (rc=$subord_rc)"
-  printf '%s\n' "$subord_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 5a-ii. The same rule on the OTHER non-ok token: kptr_restrict != 0 costs kernel
-#        SYMBOLS silently, and `perf stat -C 0 -e cycles` counts perfectly well without
-#        them — so this is the token most likely to be masked by a functional pass.
-kptr_proc="$tmp/perf-proc-kptr"; mkdir -p "$kptr_proc"
-printf -- '-1\n' >"$kptr_proc/perf_event_paranoid"
-printf '1\n'     >"$kptr_proc/kptr_restrict"
-kptr_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$kptr_proc" CQLITE_PERF_SYSCTL_DIR="$subord_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-kptr_rc=$?
-if [ "$kptr_rc" -eq 0 ] \
-   && ! printf '%s' "$kptr_out" | grep -q 'perf capability VERIFIED' \
-   && printf '%s' "$kptr_out" | grep -q 'perf capability NOT verified' \
-   && printf '%s' "$kptr_out" | grep -q '/proc is the AUTHORITY here: perf=kptr-restricted' \
-   && printf '%s' "$kptr_out" | grep -q 'kptr_restrict != 0'; then
-  ok "perf section: a SUCCESSFUL perf stat while /proc says kptr-restricted is never 'VERIFIED' (the silent symbol loss still governs)"
-else
-  bad "perf section: a functional pass masked a kptr-restricted verdict (rc=$kptr_rc)"
-  printf '%s\n' "$kptr_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 5b. THE PRIVILEGE DIMENSION — the most consequential case in this suite.
-#     perf_event_paranoid restricts UNPRIVILEGED users; ROOT BYPASSES IT. So under
-#     `sudo bash scripts/bootstrap-agent-machine.sh` — a normal provisioning
-#     invocation, and the likeliest one since writing /etc/sysctl.d needs root — a
-#     root `perf stat -C 0 -e cycles` SUCCEEDS on a paranoid=4 box where every
-#     unprivileged agent still gets EACCES. Bootstrap must therefore probe as an
-#     UNPRIVILEGED identity. Here the box offers `setpriv`, /proc is ALREADY ok, and
-#     the drop-in is current: the run must (1) say it dropped privilege, (2) actually
-#     route the collection through setpriv with the resolved uid/gid, and (3) only
-#     THEN report VERIFIED.
-droproot="$tmp/perf-droproot"; mkdir -p "$droproot"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
-         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$droproot/$t"
-done
-mkuname "$droproot" Linux
-mkid "$droproot" 0 1000       # we are root; `nobody` resolves to the unprivileged 1000
-droptrip="$tmp/perf-droproot-tripwire.log"; : >"$droptrip"
-# setpriv shim: records the exact drop it was asked for, then execs the collection —
-# so the assertion below proves the PROBE went through it, not merely that a line
-# claiming so was printed.
-cat >"$droproot/setpriv" <<EOF
-#!/usr/bin/env bash
-echo "setpriv \$*" >>"$droptrip"
-while [ \$# -gt 0 ]; do case "\$1" in --*) shift ;; *) break ;; esac; done
-exec "\$@"
-EOF
-printf '#!/usr/bin/env bash\necho "sysctl $*" >>"%s"\nexit 0\n' "$droptrip" >"$droproot/sysctl"
-chmod +x "$droproot/setpriv" "$droproot/sysctl"
-ln -sf "$perfbin/perf" "$droproot/perf"
-mkperfshim 1212121
-drop_proc="$tmp/perf-proc-drop"; mkdir -p "$drop_proc"
-printf -- '-1\n' >"$drop_proc/perf_event_paranoid"
-printf '0\n'     >"$drop_proc/kptr_restrict"
-drop_d="$tmp/perf-drop.d"; mkdir -p "$drop_d"
-bash "$PERFLIB" --drop-in >"$drop_d/99-cqlite-perf.conf"
-drop_out=$(PATH="$droproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$droproot" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-drop_rc=$?
-if [ "$drop_rc" -eq 0 ] \
-   && printf '%s' "$drop_out" | grep -q 'this run is ROOT and root BYPASSES perf_event_paranoid' \
-   && printf '%s' "$drop_out" | grep -q 'DROPS PRIVILEGE (dropped:setpriv:uid=1000)' \
-   && grep -q 'setpriv --reuid=1000 --regid=1000 --clear-groups' "$droptrip" \
-   && printf '%s' "$drop_out" | grep -q 'perf capability VERIFIED .*UNPRIVILEGED perf stat -C 0 -e cycles reports cycles=1212121'; then
-  ok "perf section: a ROOT run DROPS PRIVILEGE for the probe (setpriv, resolved uid/gid) and only then reports VERIFIED"
-else
-  bad "perf section: the root run did not probe as an unprivileged identity (rc=$drop_rc, tripwire='$(cat "$droptrip")')"
-  printf '%s\n' "$drop_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 5b-ii. THE FALSE VERIFICATION ITSELF: the same ALREADY-ok box, the same succeeding
-#        perf — but no setpriv/runuser/sudo to drop privilege with. The functional
-#        result then says nothing about an unprivileged process, and reporting it as
-#        "VERIFIED" is exactly the false verification of an unprofileable box. It must
-#        be labelled as NOT evidence, with /proc left as the authority.
-nodroproot="$tmp/perf-nodroproot"; mkdir -p "$nodroproot"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
-         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nodroproot/$t"
-done
-mkuname "$nodroproot" Linux
-mkid "$nodroproot" 0 1000     # root, an unprivileged target exists, but no mechanism
-nodroptrip="$tmp/perf-nodroproot-tripwire.log"; : >"$nodroptrip"
-printf '#!/usr/bin/env bash\necho "sysctl $*" >>"%s"\nexit 0\n' "$nodroptrip" >"$nodroproot/sysctl"
-chmod +x "$nodroproot/sysctl"
-ln -sf "$perfbin/perf" "$nodroproot/perf"
-mkperfshim 2323232
-nodrop_out=$(PATH="$nodroproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$nodroproot" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-nodrop_rc=$?
-if [ "$nodrop_rc" -eq 0 ] \
-   && ! printf '%s' "$nodrop_out" | grep -q 'perf capability VERIFIED' \
-   && printf '%s' "$nodrop_out" | grep -q 'perf capability NOT verified' \
-   && printf '%s' "$nodrop_out" | grep -q 'ran AS ROOT (root-no-drop-mechanism) and root BYPASSES perf_event_paranoid' \
-   && printf '%s' "$nodrop_out" | grep -q 'NOT evidence that an UNPRIVILEGED process can profile this box' \
-   && printf '%s' "$nodrop_out" | grep -q 'sudo -u <agent-user> perf stat'; then
-  ok "perf section: a ROOT probe with NO way to drop privilege is labelled NOT evidence of unprivileged capability (never 'VERIFIED'), even with /proc ok"
-else
-  bad "perf section: a root-only functional pass was reported as verification (rc=$nodrop_rc)"
-  printf '%s\n' "$nodrop_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 5b-iii. ...and with NO unprivileged identity resolvable at all (no `nobody` on the
-#         box, no SUDO_UID), the state is distinct — nothing to probe AS, so nothing
-#         to claim. Root must not fall back to probing as itself and calling it good.
-notarget="$tmp/perf-notarget"; mkdir -p "$notarget"
-for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
-         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$notarget/$t"
-done
-mkuname "$notarget" Linux
-mkid "$notarget" 0            # root, and `id -u nobody` FAILS: no unprivileged account
-printf '#!/usr/bin/env bash\nexit 0\n' >"$notarget/sysctl"
-chmod +x "$notarget/sysctl"
-ln -sf "$perfbin/perf" "$notarget/perf"
-ln -sf "$droproot/setpriv" "$notarget/setpriv"   # a mechanism exists; a TARGET does not
-mkperfshim 3434343
-notarget_out=$(PATH="$notarget" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$notarget" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-notarget_rc=$?
-if [ "$notarget_rc" -eq 0 ] \
-   && ! printf '%s' "$notarget_out" | grep -q 'perf capability VERIFIED' \
-   && printf '%s' "$notarget_out" | grep -q 'ran AS ROOT (root-no-unprivileged-target)'; then
-  ok "perf section: root with no resolvable unprivileged identity reports that distinctly and claims no verification"
-else
-  bad "perf section: root with no unprivileged target mishandled (rc=$notarget_rc)"
-  printf '%s\n' "$notarget_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 5b-iv. SUDO_UID is preferred over `nobody`: under `sudo bootstrap` it names the
-#        account whose profiling capability is actually in question, which is stronger
-#        evidence than an unrelated system account.
-sudouid_out=$(PATH="$droproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
-  SUDO_UID=1234 SUDO_GID=1235 SUDO_USER=agentuser \
-  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$droproot" \
-  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-sudouid_rc=$?
-if [ "$sudouid_rc" -eq 0 ] \
-   && printf '%s' "$sudouid_out" | grep -q 'DROPS PRIVILEGE (dropped:setpriv:uid=1234)' \
-   && grep -q 'setpriv --reuid=1234 --regid=1235 --clear-groups' "$droptrip"; then
-  ok "perf section: under sudo the probe drops to SUDO_UID/SUDO_GID (the account actually in question), not to nobody"
-else
-  bad "perf section: SUDO_UID was not preferred as the probe identity (rc=$sudouid_rc)"
-  printf '%s\n' "$sudouid_out" | sed -n '/Perf profiling/,/^$/p'
-fi
-
-# 5c. The helper's identity-aware CLI, directly: `--verify-unpriv` must FAIL when the
-#     result cannot be attributed to an unprivileged process, even though the very same
-#     collection succeeded — and must report which state it was in. `--verify` keeps its
-#     narrower contract (this identity, whoever that is), so the two are not confusable.
-mkperfshim 5151515
-vu_self=$(PATH="$perfbin:$tmp:$PATH" bash "$PERFLIB" --verify-unpriv 2>&1); vu_self_rc=$?
-vu_root=$(PATH="$nodroproot" bash "$PERFLIB" --verify-unpriv 2>&1); vu_root_rc=$?
-if [ "$vu_self_rc" -eq 0 ] && printf '%s' "$vu_self" | grep -q 'cycles=5151515 identity=self-unprivileged' \
-   && [ "$vu_root_rc" -ne 0 ] && printf '%s' "$vu_root" | grep -q 'cycles=5151515 identity=root-no-drop-mechanism'; then
-  ok "perf-capability: --verify-unpriv passes only when the result is attributable to an unprivileged identity (and names the state)"
-else
-  bad "perf-capability: --verify-unpriv identity attribution wrong (self rc=$vu_self_rc '$vu_self'; root rc=$vu_root_rc '$vu_root')"
-fi
-
-# 4g. Nothing in this whole suite may have touched the REAL /etc/sysctl.d.
-if [ ! -e /etc/sysctl.d/99-cqlite-perf.conf ] || [ -n "${CQLITE_PERF_ALLOW_REAL_DROPIN:-}" ]; then
-  ok "perf section: the suite never created the real /etc/sysctl.d/99-cqlite-perf.conf"
-else
-  # Pre-existing on a bootstrapped box is legitimate; only report if WE made it.
-  # `-nt` against a file stamped at suite start — no GNU-only `stat -c %Y`.
-  if [ /etc/sysctl.d/99-cqlite-perf.conf -nt "$suite_ref" ]; then
-    bad "perf section: the suite wrote the REAL /etc/sysctl.d/99-cqlite-perf.conf"
-  else
-    ok "perf section: the real drop-in pre-dates this suite (not written by it)"
-  fi
-fi
-
-echo
-echo "PASS=$PASS FAIL=$FAIL"
-[ "$FAIL" -eq 0 ]
+# Nothing in this suite may have touched the REAL /etc/sysctl.d.
+perf_test_assert_host_clean
+perf_test_report

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -869,6 +869,164 @@ else
   bad "perf-capability: --verify-unpriv identity attribution wrong (self rc=$vu_self_rc '$vu_self'; root rc=$vu_root_rc '$vu_root')"
 fi
 
+# --- 6. TEST MODE IS HERMETIC BY ENFORCEMENT, NOT BY CONVENTION ---------------
+# 6a. TEST MODE + ROOT IDENTITY + NO SEAMS MUST REFUSE AND WRITE NOTHING (issue #3249
+#     review R4-3). The seams used to FALL BACK to the production directories under the
+#     marker, so this exact combination — marker set, sudo/sysctl present as declared
+#     shims, seams forgotten — passed the env guard, and a root `--yes` run then piped the
+#     drop-in through a bare `tee` into the REAL /etc/sysctl.d. That is a test run mutating
+#     the host, and it contradicted the hermetic-test-mode claim outright.
+#
+#     The `tee`/`sudo`/`sysctl` here are RECORDING shims: if the refusal regresses, the
+#     attempted production write is captured in the tripwire (and the suite's host-clean
+#     assert catches an actual write). The case asserts all three: the section refuses, it
+#     names the misconfiguration, and NOTHING privileged ran.
+noseambox="$tmp/perf-noseambox"; mkdir -p "$noseambox"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$noseambox/$t"
+done
+mkuname "$noseambox" Linux
+mkid "$noseambox" 0 1000        # ROOT: the identity that can actually write /etc/sysctl.d
+ln -sf "$perfbin/perf" "$noseambox/perf"
+noseam_trip="$tmp/perf-noseam-tripwire.log"; : >"$noseam_trip"
+for t in sudo sysctl tee setpriv; do
+  cat >"$noseambox/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$noseam_trip"
+exit 0
+EOF
+  chmod +x "$noseambox/$t"
+done
+mkperfshim 9191919
+noseam_out=$(env -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR \
+  PATH="$noseambox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$noseambox" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+noseam_rc=$?
+noseam_mutating=$(grep -E '^(sudo|sysctl|tee) ' "$noseam_trip" | head -5)
+if [ "$noseam_rc" -eq 0 ] \
+   && printf '%s' "$noseam_out" | grep -q 'perf capability SKIPPED' \
+   && printf '%s' "$noseam_out" | grep -q 'REFUSING' \
+   && [ -z "$noseam_mutating" ] \
+   && ! printf '%s' "$noseam_out" | grep -q 'wrote /etc/sysctl.d' \
+   && ! printf '%s' "$noseam_out" | grep -q 'perf capability VERIFIED' \
+   && [ ! -e /etc/sysctl.d/99-cqlite-perf.conf ]; then
+  ok "perf section: test mode + ROOT + NO seams REFUSES to act — no privileged command, no production write, no verdict, rc 0"
+else
+  bad "perf section: unsandboxed test mode was allowed to act as root (rc=$noseam_rc, tripwire='$noseam_mutating')"
+  printf '%s\n' "$noseam_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 6b. A drop-in that differs ONLY in its trailing newline must be REWRITTEN (R4-4). The
+#     `$( )` compare judged it current, so the box kept a non-canonical file forever while
+#     bootstrap reported "already current" — and the byte-exactness claim was false. Here
+#     the file has no final newline: the run must NOT say "already current", must write
+#     through `tee`, and the file must end byte-identical to the canonical bytes.
+nlfix_d="$tmp/perf-nlfix.d"; mkdir -p "$nlfix_d"
+printf '%s' "$(bash "$PERFLIB" --drop-in)" >"$nlfix_d/99-cqlite-perf.conf"   # final newline stripped
+: >"$yestrip"
+mkperfshim 8181818
+nlfix_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$nlfix_d" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+nlfix_rc=$?
+if [ "$nlfix_rc" -eq 0 ] \
+   && ! printf '%s' "$nlfix_out" | grep -q 'drop-in already current' \
+   && grep -q 'tee .*99-cqlite-perf.conf' "$yestrip" \
+   && cmp -s <(bash "$PERFLIB" --drop-in) "$nlfix_d/99-cqlite-perf.conf"; then
+  ok "perf section: a drop-in MISSING its final newline is judged NOT current and REWRITTEN to the canonical bytes"
+else
+  bad "perf section: a non-canonical drop-in was left in place (rc=$nlfix_rc, tripwire='$(cat "$yestrip")')"
+  printf '%s\n' "$nlfix_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# ...and the same for an EXTRA trailing blank line, which is what an editor leaves behind.
+printf '\n' >>"$nlfix_d/99-cqlite-perf.conf"
+: >"$yestrip"
+nlfix2_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$nlfix_d" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+if ! printf '%s' "$nlfix2_out" | grep -q 'drop-in already current' \
+   && grep -q 'tee .*99-cqlite-perf.conf' "$yestrip" \
+   && cmp -s <(bash "$PERFLIB" --drop-in) "$nlfix_d/99-cqlite-perf.conf"; then
+  ok "perf section: a drop-in with an EXTRA trailing blank line is judged NOT current and REWRITTEN"
+else
+  bad "perf section: an extra-blank-line drop-in was reported current"
+  printf '%s\n' "$nlfix2_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# --- 7. THE DIAGNOSTICS NAME THE FILE THAT IS FIGHTING US --------------------
+# 7a. `kernel.kptr_restrict = 1` in the stock Ubuntu drop-in
+#     /etc/sysctl.d/10-kernel-hardening.conf is the CONCRETE MECHANISM behind the "it
+#     silently reverts" note in three separate measurement reports (ws0-3217:214,
+#     ws3-3029:63, ws0-cassandra-baseline-2026-07-27:847), none of which identified a
+#     cause. A non-ok read-back must therefore name the competing FILES, and rank them:
+#     one sorting AFTER our 99- drop-in actually overrides us; one sorting before does not
+#     (which is exactly why the 99- prefix is load-bearing).
+compbox_d="$tmp/perf-compbox.d"; mkdir -p "$compbox_d"
+bash "$PERFLIB" --drop-in >"$compbox_d/99-cqlite-perf.conf"
+printf '# stock ubuntu hardening\nkernel.kptr_restrict = 1\n' >"$compbox_d/10-kernel-hardening.conf"
+printf 'kernel.perf_event_paranoid = 3\n'                     >"$compbox_d/99-zzz-late.conf"
+printf 'vm.swappiness = 1\n'                                  >"$compbox_d/50-unrelated.conf"
+mkperfshim 4141414
+comp_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$compbox_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+comp_rc=$?
+if [ "$comp_rc" -eq 0 ] \
+   && printf '%s' "$comp_out" | grep -q "OVERRIDE: $compbox_d/99-zzz-late.conf" \
+   && printf '%s' "$comp_out" | grep -q 'sorts AFTER 99-cqlite-perf.conf' \
+   && printf '%s' "$comp_out" | grep -q "competing file: $compbox_d/10-kernel-hardening.conf" \
+   && printf '%s' "$comp_out" | grep -q "99-' prefix is load-bearing" \
+   && ! printf '%s' "$comp_out" | grep -q '50-unrelated'; then
+  ok "perf section: a non-ok read-back NAMES the competing sysctl.d files, flags the later-sorting one as an actual OVERRIDE, and says why the 99- prefix is load-bearing"
+else
+  bad "perf section: the diagnostics did not name the competing file (rc=$comp_rc)"
+  printf '%s\n' "$comp_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# 7b. ...and with no competitor at all it says so, rather than leaving the reader to
+#      wonder whether the scan ran (an absent diagnosis reads like an absent check).
+nocomp_d="$tmp/perf-nocompbox.d"; mkdir -p "$nocomp_d"
+bash "$PERFLIB" --drop-in >"$nocomp_d/99-cqlite-perf.conf"
+nocomp_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$nocomp_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+if printf '%s' "$nocomp_out" | grep -q 'no other file in the sysctl.d directory sets perf_event_paranoid/kptr_restrict' \
+   && ! printf '%s' "$nocomp_out" | grep -q 'OVERRIDE:'; then
+  ok "perf section: with no competing file the scan says so explicitly (a silent scan is indistinguishable from no scan)"
+else
+  bad "perf section: the no-competitor case printed no scan result"
+  printf '%s\n' "$nocomp_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 7c. AN UNKNOWN IDENTITY IS REPORTED AS UNKNOWN (R4-1, bootstrap side). With `id`
+#     unusable the run cannot claim the probe was unprivileged — and must not claim it ran
+#     as root either. /proc is ok and perf succeeds here, so the ONLY thing standing between
+#     this run and a false "VERIFIED" is the identity check.
+idlessbox="$tmp/perf-idlessbox"; mkdir -p "$idlessbox"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$idlessbox/$t"
+done
+mkuname "$idlessbox" Linux
+# NO `id` shim at all: `have id` fails, so every identity question is unanswerable.
+printf '#!/usr/bin/env bash\nexit 0\n' >"$idlessbox/sysctl"; chmod +x "$idlessbox/sysctl"
+ln -sf "$perfbin/perf" "$idlessbox/perf"
+mkperfshim 5252525
+idless_out=$(PATH="$idlessbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$idlessbox" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+idless_rc=$?
+if [ "$idless_rc" -eq 0 ] \
+   && ! printf '%s' "$idless_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$idless_out" | grep -q 'perf capability NOT verified' \
+   && printf '%s' "$idless_out" | grep -q "identity of this process could NOT be determined" \
+   && ! printf '%s' "$idless_out" | grep -q 'the probe ran AS ROOT'; then
+  ok "perf section: with 'id' unusable the run reports the identity as UNKNOWN and claims no verification (and does not assert it ran as root either)"
+else
+  bad "perf section: an unknown identity was resolved to a capability claim (rc=$idless_rc)"
+  printf '%s\n' "$idless_out" | sed -n '/Perf profiling/,/^$/p'
+fi
 
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.
 perf_test_assert_host_clean

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -1,0 +1,875 @@
+#!/usr/bin/env bash
+# Regression test for the PERF PROFILING CAPABILITY BOOTSTRAP SECTION (issue #3249):
+# the part of scripts/bootstrap-agent-machine.sh that installs
+# /etc/sysctl.d/99-cqlite-perf.conf, applies it, READS THE RESULT BACK out of /proc, and
+# only then reports a verdict — across the boxes a fleet actually has (no sudo binary,
+# sudo needing a password, already root, no perf, Darwin, a container whose sysctl
+# silently does nothing).
+#
+# The HELPER's own unit contract lives in the sibling
+# scripts/tests/test_perf_capability.sh; the shared harness (identity/platform stubs,
+# perf shims, host-safety asserts) lives in
+# scripts/tests/lib/perf-capability-test-lib.sh. Both are wired into the gate's
+# `tooling-tests` component.
+#
+# WHAT IT ASSERTS, beyond "the code is there": that the FUNCTIONAL verification is
+# HONOURED and that NO run can print an unqualified "VERIFIED" it has not earned.
+# `perf stat` exits 0 while printing `<not supported>`/`<not counted>`, a virtualised
+# PMU reports a flat 0, `sysctl` exits 0 while the value does not take, and ROOT
+# BYPASSES perf_event_paranoid entirely — so every negative case here drives one of
+# those states and requires the run to say so, while still exiting 0 (bootstrap is the
+# fleet provisioning entry point and may never hard-fail a box).
+#
+# HOST SAFETY. Nothing here touches the real /etc/sysctl.d or /proc: the test-only env
+# seams stand in (and since review R4-3 test mode REFUSES to fall back to a production
+# directory) and every privileged/mutating tool is a recording PATH shim. The final case
+# asserts that mutation-freedom directly.
+#
+# Run standalone:   bash scripts/tests/test_perf_capability_bootstrap.sh
+# Or via the gate:  scripts/agent-gate.sh runs it in the `tooling-tests` component.
+set -uo pipefail
+
+# shellcheck source=scripts/tests/lib/perf-capability-test-lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/lib/perf-capability-test-lib.sh"
+
+# --- 2. Bootstrap perf section: the DEFAULT (no --yes) run mutates NOTHING ----
+# Tripwire shims for every privileged/mutating tool the write path could use, so
+# "wrote nothing" is PROVEN rather than assumed. `perf` may be invoked (the
+# verification is read-only and is the point of the section); `sudo`, `sysctl` and
+# `tee` may not.
+perfshims="$tmp/perf-shims"; mkdir -p "$perfshims"
+perftrip="$tmp/perf-tripwire.log"; : >"$perftrip"
+for t in sudo sysctl tee; do
+  cat >"$perfshims/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$perftrip"
+exit 0
+EOF
+  chmod +x "$perfshims/$t"
+done
+mkperfroot() { # mkperfroot <dir>: a throwaway REPO_ROOT bootstrap can resolve
+  local dir="$1"
+  mkdir -p "$dir/scripts/lib"
+  cp "$BOOTSTRAP" "$dir/scripts/bootstrap-agent-machine.sh"
+  cp "$PERFLIB" "$dir/scripts/perf-capability.sh"
+  cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$dir/scripts/lib/gate-notify.sh" 2>/dev/null || true
+}
+perf_sysctl_d="$tmp/perf-sysctl.d"; mkdir -p "$perf_sysctl_d"
+perf_proc="$tmp/perf-proc"; mkdir -p "$perf_proc"
+printf '4\n' >"$perf_proc/perf_event_paranoid"
+printf '1\n' >"$perf_proc/kptr_restrict"
+mkperfroot "$tmp/perf-root-check"
+mkperfshim 999999
+check_out=$(PATH="$perfshims:$perfbin:$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$perf_sysctl_d" CQLITE_PERF_TEST_PRIV_DIR="$perfshims" \
+  bash "$tmp/perf-root-check/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+check_rc=$?
+if printf '%s' "$check_out" | grep -q 'Perf profiling capability'; then
+  ok "perf section: present in the bootstrap run"
+else
+  bad "perf section: MISSING from the bootstrap run"
+fi
+# The ONLY tolerated privileged invocation is the non-mutating `sudo -n true`
+# availability probe (bootstrap must know whether to print a sudo remedy at all);
+# anything else — a `tee`, a `sysctl`, or any other sudo command — is a mutation.
+perf_mutating=$(grep -vE '^sudo -n true$' "$perftrip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
+if [ "$check_rc" -eq 0 ] && [ -z "$(ls -A "$perf_sysctl_d")" ] && [ -z "$perf_mutating" ]; then
+  ok "perf section: default (no --yes) run wrote NO drop-in and invoked no privileged/mutating command"
+else
+  bad "perf section: default run mutated state (rc=$check_rc, dir='$(ls -A "$perf_sysctl_d")', tripwire below)"
+  cat "$perftrip"
+fi
+# Whatever it DID invoke must be non-interactive: every recorded sudo line begins
+# `sudo -n `, so no code path can sit on a password prompt on an unattended worker.
+check_bare_sudo=$(sudo_perf_offenders "$perftrip")
+if grep -q '^sudo -n true$' "$perftrip" && [ -z "$check_bare_sudo" ]; then
+  ok "perf section: the default run's sudo probe carries -n (never interactive)"
+else
+  bad "perf section: a sudo invocation without -n was recorded (or the probe never ran): $(cat "$perftrip")"
+fi
+# It must instead PRINT the exact remedy, and the remedy must WRITE **AND APPLY**: a
+# write-only line leaves the operator with a reboot-persistent file and an
+# unprofileable box until reboot — the very failure the functional verification
+# exists to prevent, on the path most people take (no --yes). Plus the AC5 posture
+# and the BPF caveat (#3217).
+if printf '%s' "$check_out" | grep -q 'perf-capability.sh --drop-in | sudo tee .*99-cqlite-perf.conf >/dev/null && sudo sysctl -q --system' \
+   && printf '%s' "$check_out" | grep -q 're-run with --yes'; then
+  ok "perf section: prints the complete WRITE-AND-APPLY remedy line instead of running it"
+else
+  bad "perf section: the printed remedy is missing the apply (or absent)"
+  printf '%s\n' "$check_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# The PRE-state line is asserted SPECIFICALLY (not just "a line somewhere mentions
+# paranoid-4"): it is the diagnosis an operator reads first, and a later warn line
+# carrying the same token would otherwise satisfy a loose grep.
+if printf '%s\n' "$check_out" | grep -q 'runtime now: perf_event_paranoid=4 kptr_restrict=1 .*gate stamps perf=paranoid-4'; then
+  ok "perf section: the pre-state line reports the ACTUAL /proc values and the token the gate will stamp"
+else
+  bad "perf section: the pre-state line is wrong or missing"
+  printf '%s\n' "$check_out" | grep 'runtime now' || true
+fi
+if printf '%s' "$check_out" | grep -qi 'BPF collectors .* require sudo' \
+   && printf '%s' "$check_out" | grep -qi 'never apply it to a shared or multi-tenant host'; then
+  ok "perf section: states the BPF-still-needs-sudo caveat and the single-tenant posture"
+else
+  bad "perf section: missing the BPF caveat or the security posture"
+fi
+# A blocked box must be DIAGNOSED as a permission verdict, not a capability one.
+if printf '%s' "$check_out" | grep -q 'perf=paranoid-4' \
+   && printf '%s' "$check_out" | grep -qi 'PERMISSION verdict'; then
+  ok "perf section: paranoid-4 is reported as a PERMISSION verdict with the gate's token"
+else
+  bad "perf section: a blocked box was not diagnosed as a permission verdict"
+  printf '%s\n' "$check_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# --- 3. Bootstrap perf section under --yes: write -> READ BACK -> verify ------
+# The privileged shims here are FUNCTIONAL, not inert: `sudo` records and execs,
+# `sysctl --system` records and (like the kernel would) updates the fake procfs, so
+# the read-back has something real to read. Order is asserted, because a read-back
+# that runs BEFORE the apply proves nothing.
+yesshims="$tmp/perf-yes-shims"; mkdir -p "$yesshims"
+yestrip="$tmp/perf-yes-tripwire.log"; : >"$yestrip"
+cat >"$yesshims/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >>"$yestrip"
+while [ "\${1:-}" = "-n" ]; do shift; done
+exec "\$@"
+EOF
+cat >"$yesshims/sysctl" <<EOF
+#!/usr/bin/env bash
+echo "sysctl \$*" >>"$yestrip"
+case " \$* " in *" --system "*)
+  printf -- '-1\n' >"$tmp/perf-proc-yes/perf_event_paranoid"
+  printf '0\n'     >"$tmp/perf-proc-yes/kptr_restrict" ;;
+esac
+exit 0
+EOF
+# apt-get/apt: --yes would otherwise reach the real package manager via the mold
+# section. Record-only, so this suite can never install anything on the host.
+for t in apt-get apt dnf yum pacman; do
+  cat >"$yesshims/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$yestrip"
+exit 0
+EOF
+done
+chmod +x "$yesshims"/*
+proc_yes="$tmp/perf-proc-yes"; mkdir -p "$proc_yes"
+printf '4\n' >"$proc_yes/perf_event_paranoid"
+printf '1\n' >"$proc_yes/kptr_restrict"
+sysctl_yes="$tmp/perf-sysctl-yes.d"; mkdir -p "$sysctl_yes"
+mkperfroot "$tmp/perf-root-yes"
+mkperfshim 7777777
+yes_home="$tmp/perf-yes-home"; mkdir -p "$yes_home/.cargo"
+yes_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+yes_rc=$?
+if [ "$yes_rc" -eq 0 ]; then
+  ok "perf section: --yes run exits 0"
+else
+  bad "perf section: --yes run exited non-zero (rc=$yes_rc)"
+fi
+if [ -f "$sysctl_yes/99-cqlite-perf.conf" ] \
+   && diff -q <(bash "$PERFLIB" --drop-in) "$sysctl_yes/99-cqlite-perf.conf" >/dev/null 2>&1; then
+  ok "perf section: --yes wrote the drop-in with EXACTLY the canonical bytes"
+else
+  bad "perf section: --yes did not write the canonical drop-in"
+  ls -l "$sysctl_yes" 2>&1 | head -3
+fi
+if grep -q 'tee .*99-cqlite-perf.conf' "$yestrip" && grep -q 'sysctl -q --system' "$yestrip"; then
+  ok "perf section: --yes wrote through sudo tee and applied with 'sysctl --system'"
+else
+  bad "perf section: --yes did not use sudo tee + sysctl --system"
+  cat "$yestrip"
+fi
+# ...and EVERY privileged invocation carried `-n`: an unattended worker must never be
+# able to sit on a password prompt, so `PERF_ROOT=(sudo)` (no -n) is a defect even
+# though every functional assert above would still pass.
+yes_bare_sudo=$(sudo_perf_offenders "$yestrip")
+if [ -z "$yes_bare_sudo" ] && grep -q '^sudo -n tee ' "$yestrip" && grep -q '^sudo -n sysctl ' "$yestrip"; then
+  ok "perf section: every --yes privileged call went through 'sudo -n' (write AND apply, never interactive)"
+else
+  bad "perf section: a privileged call did not carry sudo -n: $(cat "$yestrip")"
+fi
+# ORDER: the apply must precede the read-back verdict, and the functional verify
+# must come last (it is the verdict on the whole section).
+yes_perf_block=$(printf '%s\n' "$yes_out" | sed -n '/Perf profiling capability/,/^$/p')
+n_wrote=$(printf '%s\n' "$yes_perf_block" | grep -n 'wrote .*99-cqlite-perf.conf' | head -1 | cut -d: -f1)
+n_read=$(printf '%s\n' "$yes_perf_block" | grep -n 'READ BACK from /proc' | head -1 | cut -d: -f1)
+n_verify=$(printf '%s\n' "$yes_perf_block" | grep -n 'perf capability VERIFIED' | head -1 | cut -d: -f1)
+if [ -n "$n_wrote" ] && [ -n "$n_read" ] && [ -n "$n_verify" ] \
+   && [ "$n_wrote" -lt "$n_read" ] && [ "$n_read" -lt "$n_verify" ]; then
+  ok "perf section: order is write -> read-back from /proc -> functional verify"
+else
+  bad "perf section: wrong order (wrote=$n_wrote read-back=$n_read verify=$n_verify)"
+  printf '%s\n' "$yes_perf_block"
+fi
+# Idempotency: a SECOND --yes run must write nothing (byte-compare no-op).
+: >"$yestrip"
+yes2_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+if printf '%s' "$yes2_out" | grep -q 'drop-in already current' \
+   && ! grep -q 'tee .*99-cqlite-perf.conf' "$yestrip"; then
+  ok "perf section: a second --yes run is an idempotent no-op (no re-write)"
+else
+  bad "perf section: second --yes run re-wrote the drop-in"
+  printf '%s\n' "$yes2_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# --- 4. The verification VERDICT is honoured, and no-sudo degrades gracefully --
+# 4a. A perf that exits 0 but reports an unusable counter must produce a WARN and
+#      must NEVER be reported as verified. This is the #3119-style mutation (test_bootstrap_agent_machine.sh case 10) applied
+#      to AC2: without it, "the check exists" would pass while the box is unusable.
+mkperfshim '<not supported>'
+unsup_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+unsup_rc=$?
+if printf '%s' "$unsup_out" | grep -q 'perf capability NOT verified' \
+   && ! printf '%s' "$unsup_out" | grep -q 'perf capability VERIFIED' \
+   && [ "$unsup_rc" -eq 0 ]; then
+  ok "perf section: an rc-0 perf with an unusable counter WARNs (never 'verified'), run still exits 0"
+else
+  bad "perf section: unusable counter was not surfaced (rc=$unsup_rc)"
+  printf '%s\n' "$unsup_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# 4b. Zero cycles is the virtualised-PMU case — same verdict.
+mkperfshim 0
+zero_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+if printf '%s' "$zero_out" | grep -q 'perf capability NOT verified' \
+   && ! printf '%s' "$zero_out" | grep -q 'perf capability VERIFIED'; then
+  ok "perf section: a zero cycle count WARNs (never 'verified')"
+else
+  bad "perf section: a zero cycle count was accepted as verified"
+  printf '%s\n' "$zero_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# 4c. A box with NO sudo BINARY: warn + a remedy that actually works there, no write,
+#      still exit 0. The generic `... | sudo tee` line is USELESS on this box, so the
+#      case asserts the root-shell remedy AND the absence of the sudo one — the two
+#      `sudo -n` failure modes (no binary vs needs a password) are different boxes.
+nosudo="$tmp/perf-nosudo"; mkdir -p "$nosudo"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nosudo/$t"
+done
+mkuname "$nosudo" Linux
+mkid "$nosudo" 1000    # non-root, whatever UID runs the suite
+ln -sf "$perfbin/perf" "$nosudo/perf"
+mkperfshim 5555555
+nosudo_sysctl="$tmp/perf-nosudo.d"; mkdir -p "$nosudo_sysctl"
+nosudo_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$nosudo_sysctl" CQLITE_PERF_TEST_PRIV_DIR="$nosudo" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+nosudo_rc=$?
+if [ "$nosudo_rc" -eq 0 ] && [ -z "$(ls -A "$nosudo_sysctl")" ] \
+   && printf '%s' "$nosudo_out" | grep -q "no 'sudo' binary on this box" \
+   && printf '%s' "$nosudo_out" | grep -q 'ROOT shell:.*--drop-in > .*99-cqlite-perf.conf && sysctl -q --system' \
+   && ! printf '%s' "$nosudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf'; then
+  ok "perf section: a box with no sudo BINARY warns + prints the root-shell remedy (never a useless 'sudo tee'), writes nothing, exits 0"
+else
+  bad "perf section: no-sudo box mishandled (rc=$nosudo_rc, dir='$(ls -A "$nosudo_sysctl")')"
+  printf '%s\n' "$nosudo_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4c-ii. A box WITH sudo whose `sudo -n` fails (a password is required) is a DIFFERENT
+#        box: the `sudo tee` line does work there, interactively. Bootstrap must say so
+#        and must still never prompt.
+pwsudo="$tmp/perf-pwsudo"; mkdir -p "$pwsudo"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$pwsudo/$t"
+done
+mkuname "$pwsudo" Linux
+mkid "$pwsudo" 1000    # non-root, whatever UID runs the suite
+ln -sf "$perfbin/perf" "$pwsudo/perf"
+pwtrip="$tmp/perf-pwsudo-tripwire.log"; : >"$pwtrip"
+cat >"$pwsudo/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >>"$pwtrip"
+exit 1
+EOF
+chmod +x "$pwsudo/sudo"
+pwsudo_sysctl="$tmp/perf-pwsudo.d"; mkdir -p "$pwsudo_sysctl"
+pwsudo_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$pwsudo_sysctl" CQLITE_PERF_TEST_PRIV_DIR="$pwsudo" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+pwsudo_rc=$?
+if [ "$pwsudo_rc" -eq 0 ] && [ -z "$(ls -A "$pwsudo_sysctl")" ] \
+   && printf '%s' "$pwsudo_out" | grep -q 'sudo needs a password' \
+   && printf '%s' "$pwsudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf.*&& sudo sysctl -q --system' \
+   && ! printf '%s' "$pwsudo_out" | grep -q "no 'sudo' binary"; then
+  ok "perf section: a password-requiring sudo is diagnosed distinctly (not 'no sudo binary') with the interactive remedy, writes nothing, exits 0"
+else
+  bad "perf section: password-requiring sudo mishandled (rc=$pwsudo_rc, dir='$(ls -A "$pwsudo_sysctl")')"
+  printf '%s\n' "$pwsudo_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# Whatever it invoked, it must have been non-interactive: EVERY recorded sudo line
+# begins `sudo -n `, so no code path can sit on a password prompt on a worker.
+pw_bad_sudo=$(sudo_perf_offenders "$pwtrip")
+if grep -q '^sudo -n true$' "$pwtrip" && [ -z "$pw_bad_sudo" ]; then
+  ok "perf section: every sudo invocation carries -n (never interactive)"
+else
+  bad "perf section: a sudo invocation without -n was recorded (or none at all): $(cat "$pwtrip")"
+fi
+
+# 4c-iii. ALREADY ROOT: the printed remedy must carry NO `sudo` prefix — many root
+#         images have no sudo installed at all, so a hardcoded `sudo tee` line is
+#         un-runnable exactly where it is printed. Check mode, so nothing is written.
+rootbox="$tmp/perf-rootbox"; mkdir -p "$rootbox"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$rootbox/$t"
+done
+mkuname "$rootbox" Linux
+mkid "$rootbox" 0      # the ONLY case that exercises the already-root branch
+roottrip="$tmp/perf-rootbox-tripwire.log"; : >"$roottrip"
+for t in sudo sysctl; do
+  cat >"$rootbox/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$roottrip"
+exit 0
+EOF
+  chmod +x "$rootbox/$t"
+done
+ln -sf "$perfbin/perf" "$rootbox/perf"
+mkperfshim 3333333
+rootbox_d="$tmp/perf-rootbox.d"; mkdir -p "$rootbox_d"
+rootbox_out=$(PATH="$rootbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$rootbox_d" CQLITE_PERF_TEST_PRIV_DIR="$rootbox" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+rootbox_rc=$?
+rootbox_remedy=$(printf '%s\n' "$rootbox_out" | grep 'write + apply the drop-in' || true)
+if [ "$rootbox_rc" -eq 0 ] && [ -z "$(ls -A "$rootbox_d")" ] \
+   && printf '%s' "$rootbox_remedy" | grep -q '| tee .*99-cqlite-perf.conf >/dev/null && sysctl -q --system' \
+   && ! printf '%s' "$rootbox_remedy" | grep -q 'sudo'; then
+  ok "perf section: when ALREADY ROOT the printed write+apply remedy carries no 'sudo' prefix"
+else
+  bad "perf section: root-box remedy line wrong (rc=$rootbox_rc, line='$rootbox_remedy')"
+fi
+
+# 4d. THE SILENT REVERT — the real-world trap this whole issue exists to fix, and so
+#      the path that must be best-tested. `sysctl` exits 0 while the value does NOT
+#      take (container, read-only /proc, a later-sorting drop-in or /etc/sysctl.conf
+#      winning), so the verdict may never come from the apply's return code. Here the
+#      sysctl shim succeeds but does NOT touch the fake procfs, and perf is DENIED
+#      (non-zero, as a real paranoid-4 box denies it): bootstrap must warn "did NOT
+#      take", must NOT claim a READ BACK, and must NOT claim VERIFIED — while still
+#      exiting 0. Trusting sysctl's rc keeps every other case green.
+revert_proc="$tmp/perf-proc-revert"; mkdir -p "$revert_proc"
+printf '4\n' >"$revert_proc/perf_event_paranoid"
+printf '1\n' >"$revert_proc/kptr_restrict"
+revert_shims="$tmp/perf-revert-shims"; mkdir -p "$revert_shims"
+revert_trip="$tmp/perf-revert-tripwire.log"; : >"$revert_trip"
+cat >"$revert_shims/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >>"$revert_trip"
+while [ "\${1:-}" = "-n" ]; do shift; done
+exec "\$@"
+EOF
+cat >"$revert_shims/sysctl" <<EOF
+#!/usr/bin/env bash
+echo "sysctl \$*" >>"$revert_trip"
+exit 0
+EOF
+for t in apt-get apt dnf yum pacman; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$revert_shims/$t"
+done
+chmod +x "$revert_shims"/*
+revert_sysctl_d="$tmp/perf-revert.d"; mkdir -p "$revert_sysctl_d"
+mkperfshim_raw 1 'Error:' 'Access to performance monitoring and observability operations is limited.'
+revert_out=$(PATH="$revert_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$revert_sysctl_d" CQLITE_PERF_TEST_PRIV_DIR="$revert_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+revert_rc=$?
+if [ "$revert_rc" -eq 0 ] \
+   && printf '%s' "$revert_out" | grep -q 'the value did NOT take' \
+   && printf '%s' "$revert_out" | grep -q 'perf=paranoid-4' \
+   && ! printf '%s' "$revert_out" | grep -q 'READ BACK from /proc' \
+   && ! printf '%s' "$revert_out" | grep -q 'perf capability VERIFIED' \
+   && grep -q 'sysctl -q --system' "$revert_trip"; then
+  ok "perf section: a sysctl that exits 0 without the value taking is reported as 'did NOT take' from /proc (no READ BACK, no VERIFIED), rc 0"
+else
+  bad "perf section: the silent revert was not caught (rc=$revert_rc)"
+  printf '%s\n' "$revert_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# ...and the diagnostics must name /etc/sysctl.conf, which BOTH `sysctl --system` and
+# systemd-sysctl apply AFTER the sysctl.d drop-ins — so a stale entry there beats our
+# 99- file and is the likeliest cause of exactly this state.
+if printf '%s' "$revert_out" | grep -q '/etc/sysctl.conf' \
+   && printf '%s' "$revert_out" | grep -qi 'applied AFTER the sysctl.d drop-ins'; then
+  ok "perf section: the did-NOT-take diagnostics name /etc/sysctl.conf and its precedence over the drop-ins"
+else
+  bad "perf section: diagnostics omit the /etc/sysctl.conf precedence trap"
+fi
+
+# 4d-ii. CHECK mode with the drop-in already on disk but the runtime NOT profileable:
+#         the apply was only PRINTED, so bootstrap must NOT claim it was applied, and
+#         must still WARN (this branch was previously unreachable — the mismatch
+#         produced no [warn] at all and counted no WARNING).
+checkapply_d="$tmp/perf-checkapply.d"; mkdir -p "$checkapply_d"
+bash "$PERFLIB" --drop-in >"$checkapply_d/99-cqlite-perf.conf"
+checkapply_trip="$tmp/perf-checkapply-tripwire.log"; : >"$checkapply_trip"
+checkapply_shims="$tmp/perf-checkapply-shims"; mkdir -p "$checkapply_shims"
+for t in sudo sysctl tee; do
+  cat >"$checkapply_shims/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$checkapply_trip"
+exit 0
+EOF
+done
+chmod +x "$checkapply_shims"/*
+mkperfshim 4242
+checkapply_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$checkapply_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+checkapply_rc=$?
+checkapply_mutating=$(grep -vE '^sudo -n true$' "$checkapply_trip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
+if [ "$checkapply_rc" -eq 0 ] \
+   && printf '%s' "$checkapply_out" | grep -q 'drop-in already current' \
+   && printf '%s' "$checkapply_out" | grep -q 'has NOT been applied to the running kernel' \
+   && ! printf '%s' "$checkapply_out" | grep -q 'READ BACK from /proc' \
+   && ! printf '%s' "$checkapply_out" | grep -q 'sysctl --system reported success' \
+   && [ -z "$checkapply_mutating" ]; then
+  ok "perf section: check mode with a current drop-in but a non-ok runtime WARNs that it is not applied (and applies nothing)"
+else
+  bad "perf section: check-mode drop-in/runtime mismatch mishandled (rc=$checkapply_rc, tripwire='$checkapply_mutating')"
+  printf '%s\n' "$checkapply_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4d-iii. THE APPLY COMMAND FAILED, THE CONTROLS TOOK ANYWAY. `sysctl --system` applies
+#         EVERY drop-in on the box, so it can apply OURS correctly and still exit
+#         non-zero because an unrelated pre-existing entry failed (a stale
+#         /etc/sysctl.conf line, a foreign drop-in naming a knob this kernel lacks) —
+#         and one such entry anywhere on a fleet box is enough. Gating the /proc
+#         read-back on that rc left the token STALE and printed "nothing was applied"
+#         about a box that had JUST become profileable: a false verdict, which is the
+#         one thing AC2 exists to prevent. The two facts are independent and must be
+#         reported independently — the command's failure named as the COMMAND's, and the
+#         capability verdict taken from /proc regardless. Here the sysctl shim exits 1
+#         AND updates the fake procfs.
+rcfail_proc="$tmp/perf-proc-rcfail"; mkdir -p "$rcfail_proc"
+printf '4\n' >"$rcfail_proc/perf_event_paranoid"
+printf '1\n' >"$rcfail_proc/kptr_restrict"
+rcfail_shims="$tmp/perf-rcfail-shims"; mkdir -p "$rcfail_shims"
+rcfail_trip="$tmp/perf-rcfail-tripwire.log"; : >"$rcfail_trip"
+cat >"$rcfail_shims/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >>"$rcfail_trip"
+while [ "\${1:-}" = "-n" ]; do shift; done
+exec "\$@"
+EOF
+cat >"$rcfail_shims/sysctl" <<EOF
+#!/usr/bin/env bash
+echo "sysctl \$*" >>"$rcfail_trip"
+case " \$* " in *" --system "*)
+  printf -- '-1\n' >"$rcfail_proc/perf_event_paranoid"
+  printf '0\n'     >"$rcfail_proc/kptr_restrict"
+  echo "sysctl: setting key \"vm.unrelated_stale_entry\": Invalid argument" >&2 ;;
+esac
+exit 1
+EOF
+for t in apt-get apt dnf yum pacman; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$rcfail_shims/$t"
+done
+chmod +x "$rcfail_shims"/*
+rcfail_d="$tmp/perf-rcfail.d"; mkdir -p "$rcfail_d"
+bash "$PERFLIB" --drop-in >"$rcfail_d/99-cqlite-perf.conf"   # already current: only the apply is left
+mkperfshim 6060606
+rcfail_out=$(PATH="$rcfail_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$rcfail_proc" CQLITE_PERF_SYSCTL_DIR="$rcfail_d" CQLITE_PERF_TEST_PRIV_DIR="$rcfail_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+rcfail_rc=$?
+# The read-back verdict must be GOOD (it is what /proc now says), the command failure
+# must be reported DISTINCTLY (naming the exit status and that it applies every
+# drop-in), and the two must not contradict: no "nothing was applied", no "did NOT
+# take", no "NOT in the profileable state" alongside a good read-back. rc still 0.
+if [ "$rcfail_rc" -eq 0 ] \
+   && printf '%s' "$rcfail_out" | grep -q "READ BACK from /proc as profileable: perf_event_paranoid=-1 kptr_restrict=0" \
+   && printf '%s' "$rcfail_out" | grep -q "'sysctl -q --system' exited 1" \
+   && printf '%s' "$rcfail_out" | grep -q 'UNRELATED pre-existing entry' \
+   && ! printf '%s' "$rcfail_out" | grep -q 'nothing was applied' \
+   && ! printf '%s' "$rcfail_out" | grep -q 'the value did NOT take' \
+   && ! printf '%s' "$rcfail_out" | grep -q 'NOT in the profileable state' \
+   && ! printf '%s' "$rcfail_out" | grep -q 'are NOT in effect' \
+   && grep -q 'sysctl -q --system' "$rcfail_trip"; then
+  ok "perf section: a sysctl that FAILS while the controls DO take reports the command failure distinctly and still reads the good verdict back from /proc, rc 0"
+else
+  bad "perf section: a failing sysctl suppressed the /proc read-back or contradicted it (rc=$rcfail_rc)"
+  printf '%s\n' "$rcfail_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+# ...and the run must still be honest when BOTH facts are bad: the same failing sysctl
+# with a procfs that does NOT change must name the command failure AND report the
+# controls as not in effect — never a good read-back.
+rcfail2_proc="$tmp/perf-proc-rcfail2"; mkdir -p "$rcfail2_proc"
+printf '4\n' >"$rcfail2_proc/perf_event_paranoid"
+printf '1\n' >"$rcfail2_proc/kptr_restrict"
+rcfail2_shims="$tmp/perf-rcfail2-shims"; mkdir -p "$rcfail2_shims"
+cp "$rcfail_shims/sudo" "$rcfail2_shims/sudo"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$rcfail2_shims/sysctl"
+for t in apt-get apt dnf yum pacman; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$rcfail2_shims/$t"
+done
+chmod +x "$rcfail2_shims"/*
+rcfail2_out=$(PATH="$rcfail2_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$rcfail2_proc" CQLITE_PERF_SYSCTL_DIR="$rcfail_d" CQLITE_PERF_TEST_PRIV_DIR="$rcfail2_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+rcfail2_rc=$?
+if [ "$rcfail2_rc" -eq 0 ] \
+   && printf '%s' "$rcfail2_out" | grep -q "'sysctl -q --system' exited 1" \
+   && printf '%s' "$rcfail2_out" | grep -q 'the controls are NOT in effect' \
+   && ! printf '%s' "$rcfail2_out" | grep -q 'READ BACK from /proc as profileable' \
+   && ! printf '%s' "$rcfail2_out" | grep -q 'reported success'; then
+  ok "perf section: a failing sysctl whose controls did NOT take reports BOTH facts (command exited 1 + controls not in effect), never a good read-back"
+else
+  bad "perf section: the both-bad case mishandled (rc=$rcfail2_rc)"
+  printf '%s\n' "$rcfail2_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4d-iv. CURRENT DROP-IN + NO PRIVILEGE + non-ok runtime: nothing to WRITE (so the
+#        write remedy is not the fix) and no non-interactive privilege to APPLY, which
+#        used to print a diagnosis with NO remedy at all — contradicting every other
+#        unprivileged path in this section. Two boxes, two remedies: a box with no sudo
+#        BINARY needs the root-shell line (a `sudo` line is un-runnable there), a box
+#        whose sudo needs a password needs the same line WITH `sudo` (it works
+#        interactively).
+noapply_d="$tmp/perf-noapply.d"; mkdir -p "$noapply_d"
+bash "$PERFLIB" --drop-in >"$noapply_d/99-cqlite-perf.conf"
+noapply_ref="$tmp/perf-noapply-ref.conf"; cp "$noapply_d/99-cqlite-perf.conf" "$noapply_ref"
+noapply_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$noapply_d" CQLITE_PERF_TEST_PRIV_DIR="$nosudo" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+noapply_rc=$?
+if [ "$noapply_rc" -eq 0 ] \
+   && cmp -s "$noapply_ref" "$noapply_d/99-cqlite-perf.conf" \
+   && printf '%s' "$noapply_out" | grep -q 'drop-in already current' \
+   && printf '%s' "$noapply_out" | grep -q 'NOT in the profileable state' \
+   && printf '%s' "$noapply_out" | grep -q "no 'sudo' on this box — apply it from a ROOT shell:  sysctl -q --system" \
+   && ! printf '%s' "$noapply_out" | grep -q 'sudo sysctl'; then
+  ok "perf section: a current drop-in that cannot be applied (no sudo binary) still prints a RUNNABLE root-shell apply remedy, writes nothing, exits 0"
+else
+  bad "perf section: the current-drop-in/no-privilege branch printed no usable apply remedy (rc=$noapply_rc)"
+  printf '%s\n' "$noapply_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+noapply2_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$perf_proc" CQLITE_PERF_SYSCTL_DIR="$noapply_d" CQLITE_PERF_TEST_PRIV_DIR="$pwsudo" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+noapply2_rc=$?
+if [ "$noapply2_rc" -eq 0 ] \
+   && cmp -s "$noapply_ref" "$noapply_d/99-cqlite-perf.conf" \
+   && printf '%s' "$noapply2_out" | grep -q 'NOT in the profileable state' \
+   && printf '%s' "$noapply2_out" | grep -q 'apply the drop-in now:  sudo sysctl -q --system' \
+   && ! printf '%s' "$noapply2_out" | grep -q "no 'sudo' on this box"; then
+  ok "perf section: the same branch on a password-requiring sudo prints the INTERACTIVE 'sudo sysctl -q --system' apply remedy"
+else
+  bad "perf section: the password-sudo current-drop-in branch remedy is wrong (rc=$noapply2_rc)"
+  printf '%s\n' "$noapply2_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4e. A box with NO `perf` at all must WARN + print the install remedy and STILL exit
+#      0 — bootstrap is the fleet provisioning entry point, so a hard exit here would
+#      break every box without linux-tools. Every other case has perf on PATH, so an
+#      `exit 1` inserted in this branch previously survived the whole suite.
+noperfbox="$tmp/perf-noperfbox"; mkdir -p "$noperfbox"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$noperfbox/$t"
+done
+mkuname "$noperfbox" Linux
+mkid "$noperfbox" 1000    # non-root, whatever UID runs the suite
+cat >"$noperfbox/sudo" <<EOF
+#!/usr/bin/env bash
+while [ "\${1:-}" = "-n" ]; do shift; done
+exec "\$@"
+EOF
+printf '#!/usr/bin/env bash\nexit 0\n' >"$noperfbox/sysctl"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$noperfbox/apt-get"
+chmod +x "$noperfbox/sudo" "$noperfbox/sysctl" "$noperfbox/apt-get"
+noperfbox_d="$tmp/perf-noperfbox.d"; mkdir -p "$noperfbox_d"
+noperfbox_out=$(PATH="$noperfbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$noperfbox_d" CQLITE_PERF_TEST_PRIV_DIR="$noperfbox" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+noperfbox_rc=$?
+if [ "$noperfbox_rc" -eq 0 ] \
+   && printf '%s' "$noperfbox_out" | grep -q 'perf MISSING' \
+   && printf '%s' "$noperfbox_out" | grep -q 'install perf:.*linux-tools' \
+   && ! printf '%s' "$noperfbox_out" | grep -q 'perf capability VERIFIED'; then
+  ok "perf section: a box with no 'perf' binary warns UNVERIFIED + prints the linux-tools remedy and still exits 0"
+else
+  bad "perf section: missing-perf box mishandled (rc=$noperfbox_rc)"
+  printf '%s\n' "$noperfbox_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4f. DARWIN no-op: perf_event_paranoid/kptr_restrict are Linux kernel controls, so on
+#      macOS the section must say so, write nothing, and exit 0. Without a `uname`
+#      stub this whole suite was silently Linux-host-only (a Darwin gate host would
+#      have reddened `tooling-tests` on 10 cases while this path had no assertion).
+darwin_dir="$tmp/perf-darwin-bin"; mkdir -p "$darwin_dir"
+mkuname "$darwin_dir" Darwin
+darwin_d="$tmp/perf-darwin.d"; mkdir -p "$darwin_d"
+darwin_trip="$tmp/perf-darwin-tripwire.log"; : >"$darwin_trip"
+for t in sudo sysctl tee; do
+  cat >"$darwin_dir/$t" <<EOF
+#!/usr/bin/env bash
+echo "$t \$*" >>"$darwin_trip"
+exit 0
+EOF
+done
+chmod +x "$darwin_dir"/*
+darwin_out=$(PATH="$darwin_dir:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$darwin_d" CQLITE_PERF_TEST_PRIV_DIR="$darwin_dir" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+darwin_rc=$?
+darwin_mutating=$(grep -vE '^sudo -n true$' "$darwin_trip" | grep -E '^(sudo|sysctl|tee) ' | head -5)
+if [ "$darwin_rc" -eq 0 ] \
+   && printf '%s' "$darwin_out" | grep -q 'nothing to configure on macos' \
+   && [ -z "$(ls -A "$darwin_d")" ] && [ -z "$darwin_mutating" ] \
+   && ! printf '%s' "$darwin_out" | grep -q 'perf capability VERIFIED'; then
+  ok "perf section: on Darwin the section is an explicit no-op — no write, no privileged call, rc 0"
+else
+  bad "perf section: Darwin no-op mishandled (rc=$darwin_rc, dir='$(ls -A "$darwin_d")', tripwire='$darwin_mutating')"
+  printf '%s\n' "$darwin_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 4f-ii. AN INHERITED `PERF_SECTION_OK=1` MAY NOT STEER THE SECTION (issue #3249
+#        review). The gate was read as `${PERF_SECTION_OK:-0}` with no initialisation
+#        before the platform/library checks, so an ambient export carried a macOS host
+#        straight into the LINUX-ONLY implementation and called helper functions that
+#        were never sourced. Same env-inheritance class as the CQLITE_PERF_SYSCTL_DIR
+#        seam steering a privileged write. Asserted on BOTH pre-conditions the guard
+#        chain has: the wrong platform, and a checkout with no perf-capability.sh.
+darwin_inherit_out=$(PERF_SECTION_OK=1 PATH="$darwin_dir:$perfbin:$tmp:$PATH" \
+  HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$darwin_d" CQLITE_PERF_TEST_PRIV_DIR="$darwin_dir" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+darwin_inherit_rc=$?
+if [ "$darwin_inherit_rc" -eq 0 ] \
+   && printf '%s' "$darwin_inherit_out" | grep -q 'nothing to configure on macos' \
+   && [ -z "$(ls -A "$darwin_d")" ] \
+   && ! printf '%s' "$darwin_inherit_out" | grep -q 'runtime now: perf_event_paranoid' \
+   && ! printf '%s' "$darwin_inherit_out" | grep -q 'perf capability VERIFIED' \
+   && ! printf '%s' "$darwin_inherit_out" | grep -qi 'command not found'; then
+  ok "perf section: an INHERITED PERF_SECTION_OK=1 cannot drag a Darwin run into the Linux-only implementation"
+else
+  bad "perf section: an inherited PERF_SECTION_OK=1 steered the section (rc=$darwin_inherit_rc)"
+  printf '%s\n' "$darwin_inherit_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+nolib_root="$tmp/perf-root-nolib"; mkdir -p "$nolib_root/scripts/lib"
+cp "$BOOTSTRAP" "$nolib_root/scripts/bootstrap-agent-machine.sh"
+cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$nolib_root/scripts/lib/gate-notify.sh" 2>/dev/null || true
+nolib_d="$tmp/perf-nolib.d"; mkdir -p "$nolib_d"
+nolib_out=$(PERF_SECTION_OK=1 PATH="$checkapply_shims:$perfbin:$tmp:$PATH" \
+  HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$nolib_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$nolib_root/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+nolib_rc=$?
+if [ "$nolib_rc" -eq 0 ] \
+   && printf '%s' "$nolib_out" | grep -q 'perf-capability.sh missing from this checkout' \
+   && [ -z "$(ls -A "$nolib_d")" ] \
+   && ! printf '%s' "$nolib_out" | grep -q 'runtime now: perf_event_paranoid' \
+   && ! printf '%s' "$nolib_out" | grep -q 'perf capability VERIFIED' \
+   && ! printf '%s' "$nolib_out" | grep -qi 'command not found'; then
+  ok "perf section: an INHERITED PERF_SECTION_OK=1 cannot enter the implementation with no perf-capability.sh in the checkout"
+else
+  bad "perf section: an inherited PERF_SECTION_OK=1 entered the section without its library (rc=$nolib_rc)"
+  printf '%s\n' "$nolib_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# --- 5. THE FUNCTIONAL RESULT IS SUBORDINATE TO /proc, AND TO IDENTITY --------
+# 5a. A SUCCESSFUL perf stat while /proc says paranoid-4. Reporting the functional
+#     result as the overall verdict let a run print a `paranoid-*` diagnosis AND
+#     "VERIFIED" in the same output — contradictory, with the reassuring line winning
+#     the reader's attention. Overall verification now requires BOTH facts; a lone
+#     functional pass is PARTIAL DIAGNOSTIC INFORMATION and /proc governs.
+mkperfshim 8888888
+subord_d="$tmp/perf-subord.d"; mkdir -p "$subord_d"
+bash "$PERFLIB" --drop-in >"$subord_d/99-cqlite-perf.conf"   # current: only /proc disagrees
+subord_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$subord_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+subord_rc=$?
+if [ "$subord_rc" -eq 0 ] \
+   && ! printf '%s' "$subord_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$subord_out" | grep -q 'perf capability NOT verified' \
+   && printf '%s' "$subord_out" | grep -q 'PARTIAL DIAGNOSTIC INFORMATION' \
+   && printf '%s' "$subord_out" | grep -q '/proc is the AUTHORITY here: perf=paranoid-4' \
+   && printf '%s' "$subord_out" | grep -qi 'PERMISSION verdict' \
+   && printf '%s' "$subord_out" | grep -q 'cycles=8888888'; then
+  ok "perf section: a SUCCESSFUL perf stat while /proc says paranoid-4 is never 'VERIFIED' — reported as partial info, /proc governs"
+else
+  bad "perf section: a functional pass overrode a non-ok /proc verdict (rc=$subord_rc)"
+  printf '%s\n' "$subord_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5a-ii. The same rule on the OTHER non-ok token: kptr_restrict != 0 costs kernel
+#        SYMBOLS silently, and `perf stat -C 0 -e cycles` counts perfectly well without
+#        them — so this is the token most likely to be masked by a functional pass.
+kptr_proc="$tmp/perf-proc-kptr"; mkdir -p "$kptr_proc"
+printf -- '-1\n' >"$kptr_proc/perf_event_paranoid"
+printf '1\n'     >"$kptr_proc/kptr_restrict"
+kptr_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$kptr_proc" CQLITE_PERF_SYSCTL_DIR="$subord_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+kptr_rc=$?
+if [ "$kptr_rc" -eq 0 ] \
+   && ! printf '%s' "$kptr_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$kptr_out" | grep -q 'perf capability NOT verified' \
+   && printf '%s' "$kptr_out" | grep -q '/proc is the AUTHORITY here: perf=kptr-restricted' \
+   && printf '%s' "$kptr_out" | grep -q 'kptr_restrict != 0'; then
+  ok "perf section: a SUCCESSFUL perf stat while /proc says kptr-restricted is never 'VERIFIED' (the silent symbol loss still governs)"
+else
+  bad "perf section: a functional pass masked a kptr-restricted verdict (rc=$kptr_rc)"
+  printf '%s\n' "$kptr_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5b. THE PRIVILEGE DIMENSION — the most consequential case in this suite.
+#     perf_event_paranoid restricts UNPRIVILEGED users; ROOT BYPASSES IT. So under
+#     `sudo bash scripts/bootstrap-agent-machine.sh` — a normal provisioning
+#     invocation, and the likeliest one since writing /etc/sysctl.d needs root — a
+#     root `perf stat -C 0 -e cycles` SUCCEEDS on a paranoid=4 box where every
+#     unprivileged agent still gets EACCES. Bootstrap must therefore probe as an
+#     UNPRIVILEGED identity. Here the box offers `setpriv`, /proc is ALREADY ok, and
+#     the drop-in is current: the run must (1) say it dropped privilege, (2) actually
+#     route the collection through setpriv with the resolved uid/gid, and (3) only
+#     THEN report VERIFIED.
+droproot="$tmp/perf-droproot"; mkdir -p "$droproot"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$droproot/$t"
+done
+mkuname "$droproot" Linux
+mkid "$droproot" 0 1000       # we are root; `nobody` resolves to the unprivileged 1000
+droptrip="$tmp/perf-droproot-tripwire.log"; : >"$droptrip"
+# setpriv shim: records the exact drop it was asked for, then execs the collection —
+# so the assertion below proves the PROBE went through it, not merely that a line
+# claiming so was printed.
+cat >"$droproot/setpriv" <<EOF
+#!/usr/bin/env bash
+echo "setpriv \$*" >>"$droptrip"
+while [ \$# -gt 0 ]; do case "\$1" in --*) shift ;; *) break ;; esac; done
+exec "\$@"
+EOF
+printf '#!/usr/bin/env bash\necho "sysctl $*" >>"%s"\nexit 0\n' "$droptrip" >"$droproot/sysctl"
+chmod +x "$droproot/setpriv" "$droproot/sysctl"
+ln -sf "$perfbin/perf" "$droproot/perf"
+mkperfshim 1212121
+drop_proc="$tmp/perf-proc-drop"; mkdir -p "$drop_proc"
+printf -- '-1\n' >"$drop_proc/perf_event_paranoid"
+printf '0\n'     >"$drop_proc/kptr_restrict"
+drop_d="$tmp/perf-drop.d"; mkdir -p "$drop_d"
+bash "$PERFLIB" --drop-in >"$drop_d/99-cqlite-perf.conf"
+drop_out=$(PATH="$droproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$droproot" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+drop_rc=$?
+if [ "$drop_rc" -eq 0 ] \
+   && printf '%s' "$drop_out" | grep -q 'this run is ROOT and root BYPASSES perf_event_paranoid' \
+   && printf '%s' "$drop_out" | grep -q 'DROPS PRIVILEGE (dropped:setpriv:uid=1000)' \
+   && grep -q 'setpriv --reuid=1000 --regid=1000 --clear-groups' "$droptrip" \
+   && printf '%s' "$drop_out" | grep -q 'perf capability VERIFIED .*UNPRIVILEGED perf stat -C 0 -e cycles reports cycles=1212121'; then
+  ok "perf section: a ROOT run DROPS PRIVILEGE for the probe (setpriv, resolved uid/gid) and only then reports VERIFIED"
+else
+  bad "perf section: the root run did not probe as an unprivileged identity (rc=$drop_rc, tripwire='$(cat "$droptrip")')"
+  printf '%s\n' "$drop_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5b-ii. THE FALSE VERIFICATION ITSELF: the same ALREADY-ok box, the same succeeding
+#        perf — but no setpriv/runuser/sudo to drop privilege with. The functional
+#        result then says nothing about an unprivileged process, and reporting it as
+#        "VERIFIED" is exactly the false verification of an unprofileable box. It must
+#        be labelled as NOT evidence, with /proc left as the authority.
+nodroproot="$tmp/perf-nodroproot"; mkdir -p "$nodroproot"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$nodroproot/$t"
+done
+mkuname "$nodroproot" Linux
+mkid "$nodroproot" 0 1000     # root, an unprivileged target exists, but no mechanism
+nodroptrip="$tmp/perf-nodroproot-tripwire.log"; : >"$nodroptrip"
+printf '#!/usr/bin/env bash\necho "sysctl $*" >>"%s"\nexit 0\n' "$nodroptrip" >"$nodroproot/sysctl"
+chmod +x "$nodroproot/sysctl"
+ln -sf "$perfbin/perf" "$nodroproot/perf"
+mkperfshim 2323232
+nodrop_out=$(PATH="$nodroproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$nodroproot" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+nodrop_rc=$?
+if [ "$nodrop_rc" -eq 0 ] \
+   && ! printf '%s' "$nodrop_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$nodrop_out" | grep -q 'perf capability NOT verified' \
+   && printf '%s' "$nodrop_out" | grep -q 'ran AS ROOT (root-no-drop-mechanism) and root BYPASSES perf_event_paranoid' \
+   && printf '%s' "$nodrop_out" | grep -q 'NOT evidence that an UNPRIVILEGED process can profile this box' \
+   && printf '%s' "$nodrop_out" | grep -q 'sudo -u <agent-user> perf stat'; then
+  ok "perf section: a ROOT probe with NO way to drop privilege is labelled NOT evidence of unprivileged capability (never 'VERIFIED'), even with /proc ok"
+else
+  bad "perf section: a root-only functional pass was reported as verification (rc=$nodrop_rc)"
+  printf '%s\n' "$nodrop_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5b-iii. ...and with NO unprivileged identity resolvable at all (no `nobody` on the
+#         box, no SUDO_UID), the state is distinct — nothing to probe AS, so nothing
+#         to claim. Root must not fall back to probing as itself and calling it good.
+notarget="$tmp/perf-notarget"; mkdir -p "$notarget"
+for t in bash cat sed awk grep printf tr cut sort head tail wc env date mktemp \
+         diff timeout dirname basename ls rm mv cp mkdir touch git python3 hostname stat find tee; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$notarget/$t"
+done
+mkuname "$notarget" Linux
+mkid "$notarget" 0            # root, and `id -u nobody` FAILS: no unprivileged account
+printf '#!/usr/bin/env bash\nexit 0\n' >"$notarget/sysctl"
+chmod +x "$notarget/sysctl"
+ln -sf "$perfbin/perf" "$notarget/perf"
+ln -sf "$droproot/setpriv" "$notarget/setpriv"   # a mechanism exists; a TARGET does not
+mkperfshim 3434343
+notarget_out=$(PATH="$notarget" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$notarget" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+notarget_rc=$?
+if [ "$notarget_rc" -eq 0 ] \
+   && ! printf '%s' "$notarget_out" | grep -q 'perf capability VERIFIED' \
+   && printf '%s' "$notarget_out" | grep -q 'ran AS ROOT (root-no-unprivileged-target)'; then
+  ok "perf section: root with no resolvable unprivileged identity reports that distinctly and claims no verification"
+else
+  bad "perf section: root with no unprivileged target mishandled (rc=$notarget_rc)"
+  printf '%s\n' "$notarget_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5b-iv. SUDO_UID is preferred over `nobody`: under `sudo bootstrap` it names the
+#        account whose profiling capability is actually in question, which is stronger
+#        evidence than an unrelated system account.
+sudouid_out=$(PATH="$droproot" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  SUDO_UID=1234 SUDO_GID=1235 SUDO_USER=agentuser \
+  CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$drop_d" CQLITE_PERF_TEST_PRIV_DIR="$droproot" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+sudouid_rc=$?
+if [ "$sudouid_rc" -eq 0 ] \
+   && printf '%s' "$sudouid_out" | grep -q 'DROPS PRIVILEGE (dropped:setpriv:uid=1234)' \
+   && grep -q 'setpriv --reuid=1234 --regid=1235 --clear-groups' "$droptrip"; then
+  ok "perf section: under sudo the probe drops to SUDO_UID/SUDO_GID (the account actually in question), not to nobody"
+else
+  bad "perf section: SUDO_UID was not preferred as the probe identity (rc=$sudouid_rc)"
+  printf '%s\n' "$sudouid_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 5c. The helper's identity-aware CLI, directly: `--verify-unpriv` must FAIL when the
+#     result cannot be attributed to an unprivileged process, even though the very same
+#     collection succeeded — and must report which state it was in. `--verify` keeps its
+#     narrower contract (this identity, whoever that is), so the two are not confusable.
+mkperfshim 5151515
+vu_self=$(PATH="$perfbin:$tmp:$PATH" bash "$PERFLIB" --verify-unpriv 2>&1); vu_self_rc=$?
+vu_root=$(PATH="$nodroproot" bash "$PERFLIB" --verify-unpriv 2>&1); vu_root_rc=$?
+if [ "$vu_self_rc" -eq 0 ] && printf '%s' "$vu_self" | grep -q 'cycles=5151515 identity=self-unprivileged' \
+   && [ "$vu_root_rc" -ne 0 ] && printf '%s' "$vu_root" | grep -q 'cycles=5151515 identity=root-no-drop-mechanism'; then
+  ok "perf-capability: --verify-unpriv passes only when the result is attributable to an unprivileged identity (and names the state)"
+else
+  bad "perf-capability: --verify-unpriv identity attribution wrong (self rc=$vu_self_rc '$vu_self'; root rc=$vu_root_rc '$vu_root')"
+fi
+
+
+# Nothing in this suite may have touched the REAL /etc/sysctl.d.
+perf_test_assert_host_clean
+perf_test_report

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -898,12 +898,23 @@ exit 0
 EOF
   chmod +x "$noseambox/$t"
 done
+#     HERMETICITY IS "THIS RUN CHANGED NOTHING", NOT "THAT FILE HAS NEVER EXISTED" (issue
+#     #3249 review R5-2). This case used to assert `[ ! -e /etc/sysctl.d/99-cqlite-perf.conf ]`
+#     absolutely — which would red the MANDATORY `tooling-tests` component on every host this
+#     change had successfully bootstrapped, i.e. on exactly the machines where the feature
+#     worked. The tripwire (no mutating command invoked at all) plus a BEFORE/AFTER
+#     content-and-metadata comparison of the real path prove the same property without
+#     depending on the feature never having been used.
 mkperfshim 9191919
+noseam_before="$tmp/perf-noseam-real-before"
+perf_test_real_dropin_state >"$noseam_before" 2>/dev/null
 noseam_out=$(env -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR \
   PATH="$noseambox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
   CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$noseambox" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
 noseam_rc=$?
+noseam_after="$tmp/perf-noseam-real-after"
+perf_test_real_dropin_state >"$noseam_after" 2>/dev/null
 noseam_mutating=$(grep -E '^(sudo|sysctl|tee) ' "$noseam_trip" | head -5)
 if [ "$noseam_rc" -eq 0 ] \
    && printf '%s' "$noseam_out" | grep -q 'perf capability SKIPPED' \
@@ -911,11 +922,60 @@ if [ "$noseam_rc" -eq 0 ] \
    && [ -z "$noseam_mutating" ] \
    && ! printf '%s' "$noseam_out" | grep -q 'wrote /etc/sysctl.d' \
    && ! printf '%s' "$noseam_out" | grep -q 'perf capability VERIFIED' \
-   && [ ! -e /etc/sysctl.d/99-cqlite-perf.conf ]; then
-  ok "perf section: test mode + ROOT + NO seams REFUSES to act — no privileged command, no production write, no verdict, rc 0"
+   && cmp -s "$noseam_before" "$noseam_after"; then
+  ok "perf section: test mode + ROOT + NO seams REFUSES to act — no privileged command, no verdict, rc 0, and the real drop-in is byte/metadata-unchanged"
 else
-  bad "perf section: unsandboxed test mode was allowed to act as root (rc=$noseam_rc, tripwire='$noseam_mutating')"
+  bad "perf section: unsandboxed test mode was allowed to act as root (rc=$noseam_rc, tripwire='$noseam_mutating', real-dropin-changed=$(cmp -s "$noseam_before" "$noseam_after" || echo yes))"
   printf '%s\n' "$noseam_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 6a-ii. A SEAM THAT *RESOLVES* INTO PRODUCTION IS THE SAME HOLE (issue #3249 review R5-1).
+#        `/tmp/../etc/sysctl.d` and `<symlinked ancestor>/sysctl.d` pass every TEXTUAL
+#        non-production check while a root `--yes` run resolves them to the REAL directory
+#        and overwrites the host's drop-in. Both must refuse, invoke nothing privileged, and
+#        leave the real file untouched — asserted the same before/after way as 6a. A
+#        relative seam is covered by the helper suite's guard loop.
+symanc="$tmp/perf-symlinked-ancestor"; rm -f "$symanc"; ln -s /etc "$symanc"
+resolve_fail=0
+for badseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d"; do
+  : >"$noseam_trip"
+  rs_before="$tmp/perf-resolve-before"; perf_test_real_dropin_state >"$rs_before" 2>/dev/null
+  rs_out=$(env PATH="$noseambox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+    CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$noseambox" \
+    CQLITE_PERF_PROC_DIR="$drop_proc" CQLITE_PERF_SYSCTL_DIR="$badseam" \
+    bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+  rs_rc=$?
+  rs_after="$tmp/perf-resolve-after"; perf_test_real_dropin_state >"$rs_after" 2>/dev/null
+  rs_mutating=$(grep -E '^(sudo|sysctl|tee) ' "$noseam_trip" | head -5)
+  if [ "$rs_rc" -eq 0 ] \
+     && printf '%s' "$rs_out" | grep -q 'perf capability SKIPPED' \
+     && printf '%s' "$rs_out" | grep -q 'REFUSING' \
+     && [ -z "$rs_mutating" ] \
+     && cmp -s "$rs_before" "$rs_after"; then
+    :
+  else
+    bad "perf section: a seam RESOLVING into production ('$badseam') was accepted (rc=$rs_rc, tripwire='$rs_mutating')"
+    resolve_fail=1
+  fi
+done
+[ "$resolve_fail" -ne 0 ] || ok "perf section: a sysctl seam that RESOLVES into /etc/sysctl.d (via .. or a symlinked ancestor) is REFUSED as root — nothing privileged ran and the real drop-in is unchanged"
+
+# 6c. THE HOST-MUTATION COMPARATOR MUST BE SENSITIVE. 6a/6a-ii assert "nothing changed" by
+#     comparing before/after states, so a comparator that could not SEE a write would make
+#     both cases vacuous. Point it at a file the suite may legitimately write and prove a
+#     write is detected — the same assertion shape, driven the other way.
+sens_f="$tmp/perf-comparator-target.conf"
+sens_absent="$tmp/perf-sens-absent"; perf_test_real_dropin_state "$sens_f" >"$sens_absent"
+bash "$PERFLIB" --drop-in >"$sens_f"
+sens_created="$tmp/perf-sens-created"; perf_test_real_dropin_state "$sens_f" >"$sens_created"
+printf '# tampered\n' >>"$sens_f"
+sens_changed="$tmp/perf-sens-changed"; perf_test_real_dropin_state "$sens_f" >"$sens_changed"
+if grep -q '^absent$' "$sens_absent" \
+   && ! cmp -s "$sens_absent" "$sens_created" \
+   && ! cmp -s "$sens_created" "$sens_changed"; then
+  ok "perf section: the before/after host-mutation comparator DETECTS both a create and a content change (so 6a's 'changed nothing' is not vacuous)"
+else
+  bad "perf section: the host-mutation comparator cannot see a write — 6a's hermeticity assertion would be vacuous"
 fi
 
 # 6b. A drop-in that differs ONLY in its trailing newline must be REWRITTEN (R4-4). The
@@ -991,12 +1051,50 @@ bash "$PERFLIB" --drop-in >"$nocomp_d/99-cqlite-perf.conf"
 nocomp_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
   CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$nocomp_d" CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
-if printf '%s' "$nocomp_out" | grep -q 'no other file in the sysctl.d directory sets perf_event_paranoid/kptr_restrict' \
+if printf '%s' "$nocomp_out" | grep -q "no other file on the 'sysctl --system' search path" \
+   && printf '%s' "$nocomp_out" | grep -q '/run/sysctl.d' \
    && ! printf '%s' "$nocomp_out" | grep -q 'OVERRIDE:'; then
-  ok "perf section: with no competing file the scan says so explicitly (a silent scan is indistinguishable from no scan)"
+  ok "perf section: with no competing file the scan says so explicitly AND names the whole search path it covered (a silent scan is indistinguishable from no scan)"
 else
   bad "perf section: the no-competitor case printed no scan result"
   printf '%s\n' "$nocomp_out" | sed -n '/Perf profiling/,/^$/p'
+fi
+
+# 7b-ii. THE SCAN COVERS THE WHOLE `sysctl --system` SEARCH PATH (issue #3249 review R5-4).
+#        Scanning only /etc/sysctl.d meant a later-sorting file in /run/sysctl.d or
+#        /usr/lib/sysctl.d silently overrode our drop-in while bootstrap reported NO
+#        competitor — the same "reverts and nobody knows why" mystery this diagnostic exists
+#        to end. Fixtures live in TWO lower-precedence stand-in directories plus an
+#        /etc/sysctl.conf stand-in, and include a SHADOWING pair: the same basename exists in
+#        the higher-precedence dir, so `sysctl --system` ignores the lower copy entirely and
+#        naming it would point at a file that is not in effect.
+multi_hi="$tmp/perf-multi-hi.d"; mkdir -p "$multi_hi"
+multi_run="$tmp/perf-multi-run.d"; mkdir -p "$multi_run"
+multi_lib="$tmp/perf-multi-lib.d"; mkdir -p "$multi_lib"
+multi_conf_d="$tmp/perf-multi-conf"; mkdir -p "$multi_conf_d"
+bash "$PERFLIB" --drop-in >"$multi_hi/99-cqlite-perf.conf"
+printf 'kernel.kptr_restrict = 1\n'          >"$multi_hi/50-shadow.conf"   # masks the copy below
+printf 'kernel.perf_event_paranoid = 3\n'    >"$multi_run/50-shadow.conf"  # IGNORED by sysctl
+printf 'kernel.perf_event_paranoid = 3\n'    >"$multi_run/99-zzz-run.conf" # later-sorting: WINS
+printf 'kernel/kptr_restrict = 1\n'          >"$multi_lib/95-usrlib.conf"  # slash spelling
+printf 'kernel.perf_event_paranoid = 2\n'    >"$multi_conf_d/sysctl.conf"  # applied LAST of all
+multi_out=$(PATH="$checkapply_shims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$revert_proc" CQLITE_PERF_SYSCTL_DIR="$multi_hi" \
+  CQLITE_PERF_SYSCTL_EXTRA_DIRS="$multi_run:$multi_lib:$multi_conf_d/sysctl.conf" \
+  CQLITE_PERF_TEST_PRIV_DIR="$checkapply_shims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1)
+multi_rc=$?
+if [ "$multi_rc" -eq 0 ] \
+   && printf '%s' "$multi_out" | grep -q "OVERRIDE: $multi_run/99-zzz-run.conf" \
+   && printf '%s' "$multi_out" | grep -q "OVERRIDE: $multi_conf_d/sysctl.conf" \
+   && printf '%s' "$multi_out" | grep -q 'applied AFTER every sysctl.d drop-in' \
+   && printf '%s' "$multi_out" | grep -q "competing file: $multi_hi/50-shadow.conf" \
+   && printf '%s' "$multi_out" | grep -q "competing file: $multi_lib/95-usrlib.conf" \
+   && ! printf '%s' "$multi_out" | grep -q "$multi_run/50-shadow.conf"; then
+  ok "perf section: the competitor scan covers every search-path directory (a later-sorting /run file is an OVERRIDE, /etc/sysctl.conf is flagged as applied-last, and a SHADOWED same-basename copy is not named)"
+else
+  bad "perf section: the multi-directory search-path scan is wrong (rc=$multi_rc)"
+  printf '%s\n' "$multi_out" | sed -n '/Perf profiling/,/^$/p'
 fi
 
 # 7c. AN UNKNOWN IDENTITY IS REPORTED AS UNKNOWN (R4-1, bootstrap side). With `id`

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -384,8 +384,14 @@ accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked perf=
   (a global `RUSTFLAGS` is suppressing the wired flags — don't export one on a worker)
   · `present-unconfigured` (installed but not wired — re-run bootstrap) · `absent`.
 - **`perf`** (issue #3249, **Linux only**) — *can this box be profiled at all?* A free
-  read of `/proc/sys/kernel/{perf_event_paranoid,kptr_restrict}` (no `perf` exec, no
-  subprocess — the gate pays nothing for it). States: `perf=ok` (unprivileged per-CPU
+  read of `/proc/sys/kernel/{perf_event_paranoid,kptr_restrict}` through shell builtins.
+  **Free is an enforced cost, not a slogan**: the emit-time path runs **zero external
+  processes and zero command substitutions** (a `$( )` forks a subshell, so a value read
+  back through one would not be free — hence the token comes back through a
+  caller-named variable), and the helper is sourced **once per gate run**, not per
+  summary. `test_agent_gate_summary.sh` case `perf-free` kills any regression: it counts
+  the substitutions statically and re-runs the extracted path with an unresolvable
+  `PATH` under xtrace subshell counting. States: `perf=ok` (unprivileged per-CPU
   profiling **and** kernel symbols available) · `paranoid-<N>` (`perf_event_paranoid`
   = N ≥ 1 forbids **CPU-wide** events, so the `perf stat -C <cpu>` the measurement
   doctrine mandates is **denied** — a *permission* verdict, not a missing capability;

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -369,11 +369,11 @@ block (full **and** `--lite`) carries a machine-checkable line:
 accelerators: sccache=on nextest=on lanes=on
 ```
 
-On **Linux** the line additionally carries a `mold=` token (byte-identical / no token
-on macOS):
+On **Linux** the line additionally carries a `mold=` token and a `perf=` token
+(byte-identical / no tokens on macOS — both are Linux-only):
 
 ```
-accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked
+accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked perf=ok
 ```
 
 - **`sccache`** — cross-worktree compile cache (~25.6% faster fresh builds).
@@ -383,6 +383,21 @@ accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked
   `~/.cargo/config.toml` managed block. States: `mold=linked` (wired) · `overridden`
   (a global `RUSTFLAGS` is suppressing the wired flags — don't export one on a worker)
   · `present-unconfigured` (installed but not wired — re-run bootstrap) · `absent`.
+- **`perf`** (issue #3249, **Linux only**) — *can this box be profiled at all?* A free
+  read of `/proc/sys/kernel/{perf_event_paranoid,kptr_restrict}` (no `perf` exec, no
+  subprocess — the gate pays nothing for it). States: `perf=ok` (unprivileged per-CPU
+  profiling **and** kernel symbols available) · `paranoid-<N>` (`perf_event_paranoid`
+  = N ≥ 1 forbids **CPU-wide** events, so the `perf stat -C <cpu>` the measurement
+  doctrine mandates is **denied** — a *permission* verdict, not a missing capability;
+  agent images ship `4`, which on Debian/Ubuntu kernels denies perf entirely) ·
+  `kptr-restricted` (paranoid is fine but `kptr_restrict != 0`, so kernel frames
+  resolve to bare addresses — a silent attribution loss) · `absent` (the `/proc`
+  controls are not present, e.g. a container — tune the host) · `unknown` (present but
+  unparseable; never guessed). Anything but `ok` on a box you intend to measure means
+  **re-run `bash scripts/bootstrap-agent-machine.sh --yes`**, which installs
+  `/etc/sysctl.d/99-cqlite-perf.conf` and then *verifies* it by running
+  `perf stat -C 0 -e cycles`. Rationale + security posture:
+  `docs/development/fleet-runbook.md`.
 
 State values: **`on`** (detected & used) · **`absent`** (missing → the gate prints a
 loud `WARN:` on STDERR with the one-line install command) · **`off`** (intentionally


### PR DESCRIPTION
Closes #3249

## Problem

Agent/worker boxes ship with `kernel.perf_event_paranoid = 4` — above even Ubuntu's patched ceiling of 3 ("disallow all perf event use by unprivileged users") — and it is set **nowhere** in `/etc/sysctl.conf` or `/etc/sysctl.d/`. Every profiling run therefore starts from a hard EACCES denial whose help text reads like a *capability* verdict but is a *permission* verdict. Two consecutive measurement issues (#3217, #3096) ended with a large unattributed residual, and this setting had to be cleared by hand on a live box before we could even determine which of the two blockers was operative.

The probe that motivated this found the state sharper than filed: this box's **runtime** value is already `-1` (residue from the #3224 hand-probe) but there is still **no `/etc/sysctl.d/` drop-in** — so the fleet was profileable only *by accident*, on the one box someone had touched, and reverts on reboot or reprovision. Three independent reports already document these two sysctls silently reverting (`ws0-3217-report.md:214`, `ws3-3029-report.md:63`, `ws0-cassandra-baseline-2026-07-27.md:847`), and one checked-in script *hardcodes* a "both SILENTLY REVERT on this box" warning. Agents had been hand-working around this in triplicate for at least three measurement cycles.

## What this does

- **`scripts/perf-capability.sh` (new)** — the single shared helper this repo lacked. Recon found no perf-capability probe anywhere in `scripts/`, and notably **no `#3096` rig exists in-tree at all** (it is referenced only in prose across reports and specs); the sole prior art was `ws0_assert_sysctl()` buried in an archived artifact directory. Exposes a free `/proc` capability read, a functional `perf stat -C 0` verification, and the canonical drop-in bytes.
- **`scripts/bootstrap-agent-machine.sh`** — new `Perf profiling capability` section (placed after mold, the other Linux machine-capability provisioner, sharing its probe-first/fail-safe posture). Installs `/etc/sysctl.d/99-cqlite-perf.conf` idempotently, applies it, **reads the value back from `/proc/sys`** (never trusts the write's rc), then runs AC2's functional verification. This is the first `/etc/*` write in bootstrap; it degrades to a `warn` plus a printed remedy on a no-sudo / no-perf / non-Linux / container box and never exits non-zero, preserving the script's "informational, always exit 0" contract.
- **`scripts/agent-gate.sh`** — a `perf=` token in the `accelerators:` line. Deliberately a **free `/proc` read** (fork-free `read -r v < "$f"`, no `perf` exec, no `sudo`, no subprocess): the gate answers "is this box *configured* profileable", while the ~100ms functional `perf stat` stays in bootstrap. The gate does not pretend to answer "does the vPMU have the counters" — that is #3224, and genuinely hardware.

## Acceptance criteria

| AC | Status |
|---|---|
| 1. `/etc/sysctl.d/` drop-in, applied idempotently, surviving reboot | ✅ whole managed file, byte-compared in-shell |
| 2. Bootstrap **verifies** — `perf stat -C 0 -e cycles` exits 0 **and** non-zero count | ✅ and the negative cases are tested, not assumed |
| 3. Result reported in bootstrap output **and** the gate's `accelerators:` line | ✅ visible in this PR's own lite summary: `… mold=absent perf=ok` |
| 4. Documented in `fleet-runbook.md` incl. `-1`-not-`1` rationale + BPF-needs-sudo note | ✅ |
| 5. Security posture: single-tenant only, never shared/multi-tenant | ✅ in the runbook **and** the drop-in's own header |

### Why `-1` and not `1`
`perf_event_paranoid` is cumulative and higher is more restrictive; **`>= 1` disallows CPU event access**, which is exactly what the mandated CPU-wide `perf stat -C` needs. `0` is the bare minimum; `-1` additionally lifts the `perf_event_mlock_kb` limit, avoiding `perf record` ring-buffer surprises. `kptr_restrict = 0` is a separate control for kernel *symbol* resolution — without it kernel frames render as unresolved addresses, a **silent attribution loss rather than an error**. A permissive `perf_event_paranoid` does **not** gate the `bpf()` syscall, so bcc/bpftrace collectors still require `sudo` (the #3217 finding); this PR does not change that.

## Review — 3 streams, 10 blockers, all fixed

Review-first per #2086: `rust-reviewer`-equivalent shell/privilege review + a mutation-tested test-quality review + roborev, all on the lite-green diff **before** any full gate.

**roborev round 1 (`RESULT: FAIL`, 2 findings)** — verifiably genuine: `reviewed-sha: 11f72ca..fc4758e`, `prompt-content: PASS (5/5 code census paths present)`, tokens `input=96250 cached=73984 output=6620` vs the ~18.7k/0/53 vacuous signature; all eight anti-vacuity assertions PASS.
1. The non-`--yes` printed remedy wrote the drop-in but **omitted `sysctl --system`** — copy-pasting it left the box unprofileable until reboot. Upgraded to blocker: that is verbatim the failure AC2 exists to prevent, on the path most operators take.
2. Hybrid-PMU CPUs report qualified event names (`cpu_core/cycles/`), misread as `no-cycles-row`. Fails *safe* (spurious warn, never a false ok) but a check that cries wolf destroys its own signal — and our Sapphire Rapids fleet box could never have surfaced it.

**Shell + privilege review (2 blockers)**
3. **The test-only `CQLITE_PERF_SYSCTL_DIR` seam steered a *privileged* `sudo tee`.** `CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d` + `--yes` made root write an env-chosen file while reporting `[ok] wrote …`. Damningly, the test suite already `unset` both seams with the comment "A worker shell may export the seams themselves" — the code judged a stray export plausible and defended the tests but not the privileged path. Now: privileged destination is a hardcoded `/etc/sysctl.d` literal; seams are inert without `CQLITE_PERF_TEST_MODE=1`, and that marker **refuses to run against a reachable real `sudo`/`sysctl`**.
4. `[ "$count" -le 0 ]` **failed open**: `[` returns **2** (not 1) on a malformed operand, so an over-wide digit string fell through to `return 0` — false VERIFIED, plus leaked stderr. Commit `fc4758e` had fixed this exact class one commit earlier in a sibling function and missed the one whose entire job is not failing open.
5. *(upgraded from the reviewer's nit)* Doc mirrors + the **normative** `openspec/specs/agent-fleet-runtime/spec.md` described the accelerators line as an exhaustive token list without `perf=`. Per CLAUDE.md's same-change doctrine rule, all four surfaces updated (2 new SHALL requirements + 10 scenarios), mirroring the mold token's #2859 precedent.

**Test-quality review — MUTATION TESTED (5 blockers).** 28 mutants, 17 killed / 11 survived. It confirmed the headline property was genuinely load-bearing (rc-only `verify` → 7 failures; the `fc4758e` guard properly pinned; relaxing `ACCEL_LINE_RE`'s `perf=` alternation to `.*` → killed), but five decisive guards would have shipped green:
6. **The `/proc` read-back was never proven honoured** — trusting `sysctl`'s rc kept the suite 25/25 green while bootstrap printed "applied and READ BACK from /proc" on a box still reporting `4`. The "did NOT take" warn had **zero** coverage. Silent revert is the documented trap this issue exists to close, and it was the least-tested path.
7. **The gate's `perf=` token was never checked against a real `/proc` read** — hardcoding `"ok"` survived 118/118, because every case set the override seam. A gate stamping `perf=ok` on a paranoid-4 box is precisely what AC3 exists to prevent.
8. **`perf stat` exiting non-zero was untested — and that IS the real `paranoid=4` EACCES state**, i.e. the condition this issue is about.
9. The perf-binary-absent branch was uncovered; `exit 1` there survived, and would break every box without `linux-tools`.
10. The suite was silently Linux-host-only — forcing the non-Linux branch produced 10 failures, so a Darwin gate host would red `tooling-tests`.

Plus ~14 nits, all fixed — including a real footgun: **`/etc/sysctl.conf` is applied *after* `sysctl.d` drop-ins and therefore beats our `99-` file**, so a stale entry there would silently defeat this change; diagnostics now grep it and the runbook documents the precedence. Also added Debian/Ubuntu's `>= 3` ladder level, which is what explains why the observed `4` denies everything.

**Fix-round verification: 13 mutants re-applied, each now FAILS a test** (hardcoded gate state → 2 fails; read-back trusting rc → 2; `perf` rc≠0 returning success → 2; `exit 1` after perf-MISSING → 1; seam honoured without marker → 1; `PERF_ROOT=(sudo)` → 1; unvalidated count → 3; literal `^cycles` → 3; Darwin branch disabled → 1; …). A fix without a killing test is not done.

## Verification

- `--lite` **PASS** at `f9da66c`, `tree-integrity: PASS`, `accelerators: … mold=absent perf=ok`
- `test_perf_capability.sh` **PASS=51 FAIL=0** (was 25)
- `test_agent_gate_summary.sh` **123 passed, 0 failed** (was 118)
- `test_bootstrap_agent_machine.sh` **PASS=80 FAIL=0** (regression check)
- `--only tooling-tests` → **PASS (359s)** — proves the new suite is really in the component chain, not merely written
- Hermeticity: the host's real `/etc/sysctl.d` and `/proc` are never touched; asserted directly by the suite's final case

The **full gate of record has not yet run** — it runs once, immediately pre-merge, in `flow-closer`.

## Follow-up (not in scope)
`scripts/bootstrap-agent-machine.sh` is 1196 lines and was already over the ~800 source target before this issue; a split by responsibility is a genuine #1116 candidate.