### PR TITLE
docs(#3249): four named durable lessons from #3249 (seam-vs-assertion, closed-set audit, full-range review, closer freshness)

### DIFF
--- a/docs/development/pm-operating-loop.md
+++ b/docs/development/pm-operating-loop.md
@@ -61,6 +61,10 @@ ORDER: k                # queue rank when several are Ready at once
    GitHub owns the CI-green wait** (#2667), and returns only a terminal packet. Any src change after the
    full gate INVALIDATES it — the closer re-runs the gate if a fix or rebase postdates it.
    No worker CI busy-wait (`ScheduleWakeup`-polling a PR's own CI is prohibited).
+   **Re-read the issue LIVE immediately before spawning the closer** (owner, 2026-08-03) — not from the
+   last status tick. A manager order can land between a poll and the spawn (it has), and the closer is
+   the one irreversible step in the pipeline, so it is the one step that must never run on stale
+   instructions. See `process_improvements.md` (2026-08-03 / #3249, entry 4).
 6. **Finalize follows the merge.** The merge event triggers `flow-finalize` (archive any OpenSpec change,
    **stamp the telemetry ledger** with the roborev blocker/nit split, remove the worktree, delete the origin
    claim branch + clear the heartbeat, close the issue with a traceable comment). Board → Done (built-in).
@@ -219,6 +223,14 @@ worktree (the manager never rebases someone else's branch).
   excludes non-code paths from the diff it builds. Any non-PASS terminal `RESULT`, `NOTHING-TO-REVIEW`
   included, is a failed round and a blocked merge — never "roborev clean". See CLAUDE.md +
   `docs/development/agent-machine-setup.md`.
+- **Coverage is not equivalence — a per-slice review ledger is an audit trail, never a certification**
+  (owner, 2026-08-03). The only certifying review artifact is ONE genuine full-range `<base>...HEAD`
+  round with `prompt-content: PASS`; never slice the base to get a green. On a non-PASS round, raise
+  roborev's `default_max_prompt_size` (#3257/#3263) and re-run the FULL range — past the assembled-prompt
+  ceiling roborev spills the diff to a file the sandbox cannot read, so the model answers "No issues
+  found" having read zero lines, a vacuous PASS textually identical to a real one. On #3249 a complete
+  per-slice ledger over a `+4216` diff still missed 4 findings (1 High, 2 Medium) that the full range
+  found. See `process_improvements.md` (2026-08-03 / #3249, entry 3).
 - Every GitHub write gets a short traceable comment.
 
 ## Field round validation (separate from the agent gate, issue #2399)

--- a/process_improvements.md
+++ b/process_improvements.md
@@ -920,4 +920,69 @@ issues have landed). Keep entries short so a future reader can re-run the measur
 - **A subagent that pushes back on a lead's instruction can be right — leave room for it.**
   The lead diagnosed a superseded gate block and ordered the closer to discard its triage;
   the closer refused, and its evidence (the `../schemas` sibling) was the actual root cause.
+
+## 2026-08-03 — #3249 (persist a profileable perf configuration on agent boxes): lessons
+
+Four named entries from #3249 / PR #3251 (squash `a93c3f0`). Entries 3 and 4 are **owner
+standing rules for the whole fleet** (owner, 2026-08-03), not observations; they are
+cross-referenced from `docs/development/pm-operating-loop.md`.
+
+### 1. A test-only seam on the value under test can replace the assertion
+
+The owner's framing, which this issue proved on itself **twice**. When a test sets a seam that
+overrides the very value under test, the suite goes green whether or not the production path
+works — the seam, not the code, is supplying the answer. Concretely: hardcoding
+`_PERF_STATE="ok"` in `scripts/agent-gate.sh` **survived all 118 tests**, because every case set
+`AGENT_GATE_TEST_PERF_STATE`; and the `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` seams
+meant no test ever exercised the production default paths, so repointing them at
+`/tmp/bogus-*` also survived.
+
+**Rule: any test-only seam on the value under test requires at least one non-seam case that
+derives the expectation from the real source and asserts the specific value — never a member of
+a regex alternation. Otherwise the seam has replaced the assertion.**
+
+Sharper corollary found on #3249: a case can unset the *obvious* seam and still be seam-driven
+through a *second* one — `9f-real` unset the gate's token seam but still set the library's
+fixture-directory seam. So "no seam set" must be verified against the full list of seams the
+code actually reads, **enumerated from source rather than remembered**.
+
+### 2. A targeted audit finds what adversarial review rounds do not
+
+Seven roborev/reviewer rounds on #3249 produced **29 findings**. A single *closed-set audit* —
+enumerate every path that can reach a "capable/verified" verdict, then prove each is reachable
+only from validated input — found **three more in one pass**, including one in the gate token's
+own parse (`proc_read` truncated at the first whitespace, so `0 1` read as a capable `0`).
+
+**Rule: for a property of the form "X must never be reported unless Y," enumerate the closed set
+of paths that can report X and justify each, rather than waiting for reviewers to find them one
+at a time. Reviewers chase findings; an audit forces every member of a set to justify itself.**
+
+Record the audit as a durable artifact (a file header or doc), not merely as the fixed lines —
+otherwise the next change re-opens the set with nothing to check it against.
+
+### 3. Coverage is not equivalence: a per-slice review ledger is an audit trail, never a certification
+
+**Fleet rule (owner, 2026-08-03).** On #3249 every line of a `+4216` diff sat inside some
+verified review slice, and the per-slice ledger was complete — yet a single full-range round
+then surfaced **4 findings (one High, two Medium) that no sliced round produced**. A reviewer
+holding the whole change reasons across boundaries a slice cannot see; slice coverage is not
+equivalent to reviewing the change.
+
+**Rule: the only certifying review artifact is one genuine full-range `<base>...HEAD` round with
+`prompt-content: PASS`. Never slice the base to get a green; if a round is non-PASS, raise
+`default_max_prompt_size` (see #3257 / #3263) and re-run the full range.**
+
+Mechanism, so the rule is understandable rather than ritual: past an assembled-prompt byte
+ceiling (default 204,800) roborev **spills the diff to a file** instead of discarding it, and on
+a sandboxed box every read of that file fails — so the model answers "No issues found" having
+read zero lines. That vacuous PASS is textually identical to a real one.
+
+### 4. Re-read the issue immediately before spawning `flow-closer`
+
+**Fleet doctrine (owner, 2026-08-03).** A fleet order landed between a status poll and a closer
+spawn, and the closer was briefed with an instruction that order had countermanded. Nothing was
+armed, but `flow-closer` is the one irreversible step in the pipeline (full gate → final review
+→ merge), so it is the one step that must never run on stale instructions.
+
+**Rule: re-read the issue live at closer-spawn time, not on the last status tick.**
   An instruction to destroy evidence deserves resistance.


### PR DESCRIPTION
Refs #3249 (perf_event_paranoid=4 blocks profiling on agent boxes; PR #3251, squash `a93c3f0`)

The three (now four) durable artifacts the owner asked for "at finalize" on #3249. Docs-only.

## What this records and why

`process_improvements.md` gains a `## 2026-08-03 — #3249 …: lessons` section in the house style of
the existing dated lesson sections, with each lesson as its own **named** `###` entry:

1. **"A test-only seam on the value under test can replace the assertion."** #3249 proved this on
   itself twice: hardcoding `_PERF_STATE="ok"` survived all 118 tests (every case set
   `AGENT_GATE_TEST_PERF_STATE`), and repointing the `CQLITE_PERF_PROC_DIR`/`CQLITE_PERF_SYSCTL_DIR`
   seams at `/tmp/bogus-*` also survived. Rule: any such seam needs at least one non-seam case
   deriving its expectation from the real source and asserting a specific value (never a regex
   alternation member). Corollary: a case can unset the *obvious* seam and still be seam-driven via a
   second one (`9f-real`), so "no seam set" must be checked against the seams **enumerated from
   source**.
2. **"A targeted audit finds what adversarial review rounds do not."** Seven review rounds produced
   29 findings; one closed-set audit of every path that can report "capable/verified" found three
   more in a single pass, including the token parse truncating at whitespace (`0 1` → capable `0`).
   Rule: for "X must never be reported unless Y," enumerate the closed set and justify each member,
   and record the audit as a durable artifact.
3. **"Coverage is not equivalence: a per-slice review ledger is an audit trail, never a
   certification."** Fleet rule (owner, 2026-08-03). A complete per-slice ledger over a `+4216` diff
   still missed 4 findings (1 High, 2 Medium) that one full-range round found. Rule: the only
   certifying artifact is a genuine full-range `<base>...HEAD` round with `prompt-content: PASS`;
   never slice the base for a green — raise `default_max_prompt_size` (#3257/#3263) and re-run the
   full range. Mechanism included in one line: past the assembled-prompt ceiling (default 204,800)
   roborev spills the diff to a file the sandbox cannot read, so the model answers "No issues found"
   having read zero lines — a vacuous PASS textually identical to a real one.
4. **"Re-read the issue immediately before spawning `flow-closer`."** Fleet doctrine (owner,
   2026-08-03). A fleet order landed between a status poll and a closer spawn and the closer was
   briefed with a countermanded instruction; nothing was armed, but the closer is the pipeline's one
   irreversible step, so it is the one step that must not run on stale instructions.

## Doctrine kept unsplit

Entries 3 and 4 are standing fleet rules, and `docs/development/pm-operating-loop.md` already
enumerates both surfaces they govern (the roborev **Hard rules** bullet and worker-lifecycle step 5,
`flow-closer`). Each is added there as one condensed rule that **cross-references** the
`process_improvements.md` entry rather than duplicating it.

## Verification

- **Docs-only:** `git diff --stat origin/main...HEAD` = `docs/development/pm-operating-loop.md` +12,
  `process_improvements.md` +65. No `.rs`, `.sh`, workflow, or config file touched.
- **`--lite` PASS** on `38d103e` (file-size, fmt, clippy, roborev-lints, scoped-tests;
  `tree-integrity: PASS`).
- **roborev is INAPPLICABLE to this diff and is deliberately NOT recorded as clean.** roborev
  excludes non-code paths from the diff it builds, so for a markdown-only change the constructed diff
  is genuinely empty and any verdict it returns reports an empty input, not a review (CLAUDE.md,
  #2964). No roborev run was attempted.
- **Full-gate note (CLAUDE.md #3042):** a markdown-only diff cannot change the compiled binary, so
  any test failure in a full gate on this branch is by definition pre-existing on `main` or a flake —
  it must be cited and waived (naming the failing component and its issue), never patched away in
  source under a docs diff.

Do **not** auto-merge: per the requesting owner instruction, `--auto` is intentionally NOT armed on
this PR.