### PR TITLE
docs(#2817): commit the 0.17 throughput mission doc with the divisible numbers

### DIFF
--- a/docs/architecture/0.17-throughput-mission.md
+++ b/docs/architecture/0.17-throughput-mission.md
@@ -1,0 +1,366 @@
+# 0.17 Throughput Mission — tracking & mission document
+
+**Status as of 2026-08-03.** Living document. The board (GitHub Project #1) is the dispatch
+authority; this file is the *narrative* — mission, what's measured, what's in flight, and the gaps
+that keep biting. When board and this doc disagree on status, the board wins; open a PR to fix this
+file.
+
+Parent epic: **#2817** (0.17 scan-path throughput program). Exploration umbrella: **#3023**.
+
+> **2026-08-03 headline.** #3058 is merged and measured on one corpus: the shipping path went from
+> **2.73× SLOWER than stock Cassandra to 1.12× FASTER** — a **3.06×** improvement. The correctness
+> gate that blocked measurement is discharged (#3100 ran, #3094/#3095/#3121/#3154/#3140/#3146
+> merged; only #3129 remains). **And then the plan stalled, honestly:** of the three named levers for
+> the remaining gap, **two are now dead** — #3217 acquitted the `do_get` mpsc handoff (measured
+> **zero** parks) and #3096's two Arrow-encode levers **measure at ZERO**. Nothing has moved the
+> throughput number since #3058. The remaining gap is **1.62× → 1.30×** and its cause is
+> **not yet attributed**: 87% of the IPC decay (#3224, measuring now) and 82% of the encode region
+> (#3248) are unexplained. See §0 and §6.
+
+---
+
+## 0. How much have we actually improved?
+
+The only divisible answer comes from **#3100** (PR #3216), where all arms ran on **one
+byte-identical corpus** with a post-#3058 binary. Earlier figures mixed corpora and could not be
+divided; use these.
+
+`c7i.4xlarge`, warm, **1 physical core** (`-c 2,10`), medians of 3, matched pinnings:
+
+| Surface | rows/s / phys core |
+|---|--:|
+| CQLite **bare scan** (our own ceiling) | **410,449** |
+| CQLite **Flight `do_get` — bypass** (post-#3058) | **252,999** |
+| Cassandra `SELECT count(*)` | 328,623 |
+| Cassandra `SELECT *` | 225,771 |
+| CQLite **Flight `do_get` — merge** (pre-#3058) | **82,639** |
+
+**The improvement, stated four ways — all the same measurement:**
+
+| Framing | Before #3058 | After #3058 | Change |
+|---|--:|--:|--:|
+| `do_get` rows/s / phys core | 82,639 | 252,999 | **3.06×** |
+| vs Cassandra `SELECT *` | 0.37× (**2.73× slower**) | **1.12× faster** | crossed the line |
+| Gap to our own bare scan | 4.97× | **1.62×** | closed 3.35× of it |
+| Cycles/row | 72,382 | 22,111 | −69% |
+
+On the 1-hardware-thread basis (the valid basis for cycles/row and IPC): merge 71,974 → bypass
+234,842 = **3.26×**; bare scan 396,723 → gap **1.69×**; vs Cassandra `SELECT *` 219,486 = **1.07×**.
+
+**Improvement since #3058: 0%.** #3096 measured both of its levers at zero. That is the honest
+number and it is the reason this program feels stalled — it is stalled on *attribution*, not on
+engineering throughput.
+
+**Remaining to target:** 1.3× of bare scan = **315,730 rows/s**. We are at 252,999. **We need
++24.8%** and we currently cannot name where it comes from.
+
+---
+
+## 1. The mission, in one sentence
+
+**Make CQLite's Arrow Flight scan (`do_get`) fast enough to be worth deploying, and prove it with
+measurements a skeptic can audit.**
+
+The engine is not the problem. The shipping path is. Everything below serves that one goal.
+
+### The unit
+**rows/s per PHYSICAL core, warm.** The plateau tracks physical cores, not hardware threads. It is
+the only figure that composes across boxes.
+
+### Three byte bases — never write a bare "MB/s"
+This corpus: **logical/uncompressed 692.70 B/row**, **compressed on-disk 195.96 B/row** (LZ4
+3.535×), **Arrow wire ~675 B/row**. They differ by 3.5×. Every throughput figure MUST name its
+basis — this ambiguity has produced two published errors already.
+
+---
+
+## 2. Ground truth — the measurement chain
+
+Four measurement runs, each superseding the last on the questions it answers:
+
+| Run | What it established | Report |
+|---|---|---|
+| **#3026** (WS0, CLOSED) | First head-to-head. Bare scan beats stock Cassandra **1.13–1.24×**. Its `do_get` and Cassandra arms were on **different corpora** — not divisible; superseded by #3100 for any ratio. | `docs/reports/ws0-cassandra-baseline-2026-07-27.md` |
+| **#3027** (WS1, CLOSED) | Row decode is **compute-bound** (traffic:cycles 0.44). Traffic in `estimate_value_size` (1,398 B/row), `drop_glue::<QueryRow>` (949), `Value::into_owned` (945). | — |
+| **#3100** (CLOSED 08-02) | **The authoritative numbers in §0.** One corpus, post-#3058 binary, both merge arms, output digest `0x4903ffa446163c4b` **exact**. Plus the first C(N) sweep and the device acquittal. | `docs/reports/ws0-3100-report.md` |
+| **#3217** (CLOSED 08-03) | Full-box C(N) + off-CPU attribution. **Falsified** the compounding-collapse scenario; **acquitted** the `do_get` handoff; isolated the residual to an **IPC decay of unknown cause**. | `docs/reports/ws0-3217-report.md` |
+
+### #3100's two acquittals
+
+- **Concurrency, one core:** aggregate peaks at **N=2 (1.16×)** then declines (246,940 → 287,441 →
+  236,734 at N=16); per-scan p50 grows 16 s → 270 s. Handoff/drain-bound, not scan-bound.
+- **The device:** cold `rareq-sz` 1.4–3.5 KB but the block-size histogram is **dominated by
+  128–256 KB reads at both N=1 and N=16**; `%util` *falls* 14% → 3% as N rises. 16 streams do not
+  create 16× more tiny requests. **The N>2 ceiling is CPU/handoff-bound, not disk.**
+
+### #3217's full-box result — the collapse scenario is dead
+
+Marginal efficiency against the best a single physical core achieves (252,420 rows/s at N=2):
+
+| S (physical cores) | best aggregate rows/s | marginal efficiency |
+|---:|---:|---:|
+| 1 | 252,420 | 1.000 |
+| 2 | 440,677 | 0.873 |
+| 4 | 818,747 | 0.811 |
+| 6 | **1,076,917** | **0.711** |
+
+Six cores retain **71%** at **96.7% server utilisation**. The loss is ~29%, not the 60–75% the
+collapse scenario required. **A perfect handoff fix is worth at most ~1.2–1.4× at box level, not
+2.5–4×.**
+
+---
+
+## 3. What has SHIPPED
+
+| Item | Result |
+|---|---|
+| **#3058** (P0) — `do_get` ran k-way merge/reconciliation unconditionally even on ONE SSTable | **MERGED. The program's one real win: 3.06×** (§0). Non-vacuity: `reconcile_entries`/`cell_metadata_maps` = literal 0 on 4M rows, byte-identical digest. |
+| **#3100** (P1) | **CLOSED.** The authoritative head-to-head + C(N) + device acquittal (§2). |
+| **#3217** (P1) | **CLOSED.** Full-box curve; handoff acquitted; residual isolated to IPC decay. |
+| **#3068** (P0) | **CLOSED — hypothesis falsified before any code.** Cold `rareq-sz` **93.8 KB, not 4.4 KB**; 87% of reads ≥64 KB. Kill criterion fired correctly; no lever built. |
+| **#3026 / #3027 / #1406** | **CLOSED.** Ground truth, row-decode attribution, compressed-write fail-closed guard. |
+| **#3109** (P1) | **CLOSED.** Real bug: `run_scan_stream_batched` lacked the BTI dispatch that `run_scan_stream`/sequential had. |
+| **#3220 / #3032 / #3131 / #3148** | **CLOSED.** Fixture + harness integrity (multi-component `da` fixture, table-granular fixture resolution, fleet-wide `CQLITE_DATASETS_ROOT`). |
+| **#3249** (P1) | **CLOSED.** Profileable `perf` config on agent boxes. **Caveat: not baked into the golden AMI and not reboot-persistent → #3274.** |
+| Correctness gate (§10) | **DISCHARGED** except #3129. #3094, #3095, #3106, #3120, #3121, #3124, #3139, #3140, #3146, #3154 all merged. |
+
+---
+
+## 4. In flight
+
+| Issue | P | State | Note |
+|---|---|---|---|
+| **#3096** | P1 | In Review, PR #3254, `HOLD: merge after #3229` | **AC1 UNMET — both Arrow-encode levers measure at ZERO** (§5). Merging per owner decision 2026-08-03 that a correctly-measured negative satisfies the change (spec R5); throughput re-anchored to #3248. |
+| **#3229** | P1 | In Review, PR #3262 | roborev blind to executable code under `docs/` — `exclude_patterns` omits it at any diff size. Gates #3096's certifying round. |
+| **#3234** | P1 | In Review, PR #3255 | Profileable BTI (`da`) perf corpus + `gen-perf-corpus-bti.sh`. Prerequisite for WS3 (#3029) and WS4 (#3030). Gate PASS, C PASS, awaiting final roborev. |
+| **#3224** | P1 | **In Progress on `i4i.metal`**, 12h box to 2026-08-04T12:44Z | **The #1 open question**: the microarchitectural cause of the IPC decay. First host in the program with working uncore counters. |
+
+---
+
+## 5. #3096 — read this before funding any encode lever
+
+#3096 was the plan's headline remaining lever: Arrow encode measured at **59% of cycles / 675 B/row
+copied**, against 15–20% assumed. Its final measurement (8 rounds × 3 arms, interleaved, rotated
+order, control in every run, all three binary md5s recorded):
+
+| arm | rows/s (median) | spread |
+|---|--:|--:|
+| BASE | 232,245 | 5.1% |
+| lever 4 only (batch/flight-data framing) | 232,691 | 9.8% |
+| lever 4 (corrected target) | 230,321 | 5.5% |
+
+- **Lever 4: −72 rows/s (−0.03%), 4/8 rounds positive. ZERO.**
+- **Lever 6 (Arrow schema cache): ZERO.** Paired within-round attribution −320.1 rows/s, 5/10 rounds
+  positive.
+- Ratio vs same-session bare scan **1.553×** against a 1.3× target of 275,223 → **16.3% short**.
+
+**Two things here are more valuable than the levers would have been:**
+
+1. **An earlier measurement recorded lever 4 at +2.3% / +4,817 rows/s. It did not reproduce and is
+   superseded** — it was measured at a 4 MiB flight-data target the PR removes as a wire hazard. A
+   `−137 cycles/row` movement with rows/s unmoved is **not** a win; spec R1 makes that shape a FAIL
+   (the #2877 pattern). *#3248's body still quotes the superseded `+2.0%` / `1.560× → 1.529×` /
+   "15.0% short" figures — those predate the final re-measurement. Use the table above.*
+2. **"82% is array build" is a COMPLEMENT, NOT AN ATTRIBUTION.** It is `1,746 − 313 = 1,432.9
+   ns/row`, labeled from the call graph with **zero per-function data inside it**. The only
+   positively measured region is IPC framing (313.0 ns/row). #3248 exists to profile inside the
+   complement **before** any array-build lever is funded.
+
+**Lever 4 is retained for WIRE SAFETY, not throughput.** Lever 6 is retained as correct-and-cheap.
+
+---
+
+## 6. THE TARGET, and why we cannot currently reach it
+
+**Flight `do_get` within ~1.3× of our own bare scan = ~315,730 rows/s per physical core, warm.**
+Derived from the measured intra-CQLite gap, not a model.
+
+**Current: 1.62× (252,999). Short by 24.8%.**
+
+The honest state of the four candidate explanations:
+
+| Candidate | Status |
+|---|---|
+| `do_get` mpsc handoff | **ACQUITTED (#3217).** Zero voluntary parks at every measurement point; ≤1.46 s of 1,963 s blocked time (≤0.07%). The parks that exist are per-chunk/per-128-rows **inside `cqlite-core`**, below Flight. Ordered LAST — it optimises a site measured at ~0 cost. |
+| Arrow encode (#3096) | **Two levers measure ZERO** (§5). The encode region is 82% unattributed — not disproved, **unlocated**. → #3248. |
+| Allocator churn (#3028), `RowColumnResolution` (#3047) | **Never re-priced post-#3058.** Both were measured inside the merge that no longer runs. Do not start until re-baselined. |
+| The scaling discount (~29%) | **Not extra work and not the handoff.** instructions/row is **flat (+0.1%)** from the 1-core to the 6-core peak while cycles/row rises **+34.1%** and IPC falls **−25.4%**. It is a cycles-per-instruction (memory-side) effect. |
+
+### The one genuinely open question — #3224
+
+| point | instr/row | cycles/row | IPC | L1d-miss/row | dTLB-miss/row |
+|---|--:|--:|--:|--:|--:|
+| S=1 N=2 (1-core peak) | 38,343 | 25,200 | **1.52** | 265.4 | 7.6 |
+| S=6 N=16 (6-core peak) | 38,382 | 33,793 | **1.14** | 285.4 | 10.6 |
+
+L1d (+7.5% rel.) and dTLB (+40% rel.) together explain only **10–13%** of the +8,593 cycles/row.
+**~87% is unattributed.** `LLC-loads`/`LLC-load-misses` read `<not supported>` on the virtualized
+host, and `cache-references` **programs cleanly and returns a constant 0** — the silent-instrument
+class. LLC / memory-bandwidth saturation is the natural hypothesis and **was not measured**.
+
+**#3217's own conclusion, adopted: the #1 next step is a MEASUREMENT, not a fix.** Both per-row-work
+levers are unfounded with respect to the scaling discount — one costs nothing, the other's relevance
+is unknown. #3224 is running on the first host in this program with working uncore counters (88
+devices; positive control 13.95% vs 61.23% LLC miss rate, differential ≥2× gated in either
+direction). **That single result decides whether any per-row-work lever moves the slope.**
+
+---
+
+## 7. Open work, ranked
+
+### Blocking everything — attribution before funding
+| Issue | P | Finding |
+|---|---|---|
+| **#3224** | P1 | Microarchitectural cause of the IPC decay. 87% unattributed. **In progress on metal, 12h box.** |
+| **#3272** | P1 | **Harden the WS0 measurement rig before anything is funded on it — 7 open findings.** Every remaining number is a cycles/row attribution on this rig. |
+| **#3248** | P1 | Profile *inside* the 82% unattributed encode region + a bare-scan-vs-`do_get` differential. **Buys a profile, not a patch.** |
+
+### Throughput levers — all currently unfounded
+| Issue | P | Finding |
+|---|---|---|
+| **#3028** (WS2) | P1 | Allocator churn 19.6%. **RE-PRICE against post-#3058 profile first.** |
+| **#3047** | P2 | Hoist `RowColumnResolution` per-partition → per-scan (17.4% on-CPU). Same re-price caveat. |
+| **#3113** | P1 | Sequential scan issues I/O serially (QD 1.05–1.39 of 32). Not a warm-path lever; #3100 §4 acquitted the device warm. |
+| **(UNFILED)** | — | **Decompress + decode** — the 73%-of-cold-scan CPU ceiling #3068 §6 exposed (~144 MB/s logical, LZ4 + 12M row decodes). The real *cold* lever. Needs its own oracle. **Still unfiled — file it.** |
+| **#2820 / #2828 / #2826 / #2897 / #2917** | P1–P3 | Batch fan-in, chunk-cache retune, and three Arrow-egress items that overlap #3096/#3248. Do not start ahead of #3248. |
+
+### Correctness — one item left
+| Issue | P | Finding |
+|---|---|---|
+| **#3129** | P1 | Multi-generation merge resurrects a partition-deleted row as a phantom; single-gen vs multi-gen disagree on the same bytes. |
+| **#3149** | P2 | Discarded `JoinHandle` on the delta-scan path — silent short delta export (Family A remnant, not gating). |
+| **#2988** | P2 | Multi-generation SELECT still drives the buffered `KWayMerger` — the case #3058's fast path must not regress. |
+
+### Measurement integrity — protects every verdict
+| Issue | P | Finding |
+|---|---|---|
+| **#3253** | P1 | roborev's token-accounting vacuity tier is **INVALID** — token bands are not a vacuity oracle in either direction. `prompt-content` is the only deterministic one. |
+| **#3229** | P1 | roborev blind to executable code under `docs/`. **In review.** |
+| **#3157** | — | roborev returns a vacuous "No issues found" once the diff spills past the prompt ceiling (#3257 mechanism). |
+| **#3226** | P1 | bcc `offcputime`'s silent 10,240-key truncation + the measurement-doctrine harness. |
+| **#3274** | P2 | #3249's perf sysctls are **not in the golden AMI and not reboot-persistent** — found on the metal box at `perf_event_paranoid=4`. |
+| **#3275** | P2 | `worker-supervisor.sh` treats an unrecognized argument as "start working" — `--help` claims an issue and spawns a worker. |
+| **#3104** | P2 | `CQLITE_DATASETS_ROOT` doctrine trap → gate skips dataset tests. |
+| **#3048** | P3 | `row_build` bench variance 7–26% — cannot resolve a sub-10% change. |
+
+### Exploration workstreams
+| Issue | P | State |
+|---|---|---|
+| **#3029** (WS3) | P1 | BTI (`da`) read profile. Structural analysis merged (PR #3235); corpus arrives with #3234. |
+| **#3030** (WS4) | P2 | Wide-row (≥4 KB) profile. Corpus built on #3068's box. |
+| **#3031** (WS5) | P2 | **PARK.** Both axes gone: Cassandra is also QD-1; CQLite mmaps. Keep the honest-denominator discipline; do not implement. |
+| **#2818** | P1 | i4i cold-vs-warm `samply` profile. **Adopted onto the same metal instance as #3224 — do not launch a second metal box.** |
+| **#2827** | P2 | Keyed access-distribution probe (gates a decoded-partition cache). |
+
+### Adjacent bugs surfaced by the program
+| Issue | P | Finding |
+|---|---|---|
+| **#3101** | P1 | `cqlite info`/`read-sstable` allocate ~1.0× Data.db (8.5 GiB RSS on 8.2 GiB file); OOMs before emitting a row. **Query path is CLEAN** (23 MiB). Violates the <128 MB target on a shipped command. |
+| **#3060** | P2 | `cqlite-flight` may never exit when signalled mid-stream — ~176% CPU spin. |
+| **#3061** | P3 | Streaming scan 1,017 MiB peak RSS, Data.db mapped twice. Likely an RSS-measurement question. |
+| **#2866** | — | **Origin issue** — the ~20 MB/s single-`DoGet` benchmark that started the program. Reframe/close against §0. |
+| **#3145 / #3151 / #3158 / #3102 / #3105 / #3040** | P1–P3 | uuid/timeuuid rendering, unasserted row-tombstone decision, batched nits, and the mmap-plane comment cleanup. |
+
+---
+
+## 8. Refuted / retired — do not re-derive these
+
+| Claim | Status |
+|---|---|
+| **The per-core handoff discount compounds across cores (2.5–4× box-level lever)** | **FALSIFIED (#3217).** 71% marginal efficiency at 6 cores / 96.7% util. Worth ≤1.2–1.4×. |
+| **The `do_get` mpsc handoff is the bottleneck** | **ACQUITTED (#3217).** Measured **zero** voluntary parks; ≤0.07% of blocked time. "The mpsc handoff" was never one thing — the bypass path stacks **four** bounded channels, and the one the issue named is not the one that parks. |
+| **Arrow batch/flight-data framing (lever 4) and schema caching (lever 6) are throughput levers** | **MEASURE AT ZERO (#3096).** Lever 4 −0.03%; lever 6 −320 rows/s paired. An earlier +2.3% **did not reproduce** and is superseded. |
+| **"82% of encode is array build"** | **NOT AN ATTRIBUTION** — a complement with zero per-function data inside it. → #3248. |
+| **T3 roofline (~1.8M rows/s/core, memory-bandwidth bound)** | **REFUTED** (traffic 1.0–1.9 KB/row vs 4.4 modeled; IPC 2.71–3.07 → instruction-bound). |
+| **T1 = 600k rows/s/core** | **WITHDRAWN — underivable.** Derived from the refuted T3. Not disproved; has no basis. Replaced by §6's measured target. |
+| **"Cut memory traffic" as a win criterion** | **DROPPED.** Report cycles/row and rows/s. Keep the traffic column (it caught T3) but it is inbound-only — a lower bound. |
+| **The scan reads 4.4 KB page-at-a-time (#2876 premise)** | **Wrong plane.** The 4.4 KB regime lives on `point_source` (`MADV_RANDOM`), a **point-read** path, not the scan. |
+| **The 4 MiB scan window never becomes a large I/O (#3068)** | **FALSIFIED.** Cold `rareq-sz` 93.8 KB; 87% of reads ≥64 KB. Confirmed at scale by #3100 §4 (128–256 KB dominant at every N). |
+| **"Forcing mmap is 40% slower" (#2818 Arm 2)** | **VOID for the read scan.** mmap is the DEFAULT; that test measured a different knob. |
+| **1.18× read-path headline** | **WITHDRAWN** — the one mismatched-pinning ratio. Matched pairs: 1.13–1.24× (#3026), 1.12× (#3100). |
+| **CQLite's own writer can author a compressed-path test corpus** | **NO** — writer emits uncompressed only (#1406). Compressed-path perf work REQUIRES a Cassandra container. |
+
+---
+
+## 9. Standing operating rules (bought with real pain)
+
+1. **Pass conditions are EXTERNAL numbers.** Internal counters are supporting evidence only. A green
+   counter with an unmoved external number is the #2877 failure. Every perf issue carries a
+   pre-registered external prediction and a **kill criterion** — if the number doesn't move, STOP and
+   post the negative. **#3068 and #3096 are both successes by this rule.**
+2. **A measurement that does not reproduce is not a result.** #3096's +2.3% survived one session and
+   died in the next. Interleave arms, rotate order, keep a control in every round, record every
+   binary's md5, and report per-arm dispersion.
+3. **Distinguish an attribution from a complement.** "The other 82%" names a region, not a cost.
+   Never fund a lever inside an unprofiled complement.
+4. **A broken instrument that emits plausible output is the dominant failure mode.** `cache-references`
+   programming cleanly and returning `0`; `offcputime` truncating at 10,240 keys; roborev spilling a
+   diff and reviewing nothing. Every collector needs a **lost-record guard and a positive control**,
+   and the positive control must be **observed failing** on a known-bad host.
+5. **Report cold AND warm as separate numbers, never blended.** ~1.37× cold / ~1.00× warm.
+6. **Name the byte basis on every MB/s** (§1). Name the full fio job shape on every fio number.
+7. **Read the board server-side-filtered** (`--query "status:Ready"`); unfiltered silently truncates
+   on the 900+ item board. `refs/claims/issue-<N>` is the lock; `status:*` labels lag ≤30 min.
+8. **Correctness gates speed.** A `do_get` that errors on a tombstone or phantoms a row is not
+   deployable at any throughput.
+9. **Run measurements contained** — `test-data/scripts/perf-run-contained.sh`. An uncontained cold
+   read on a swapless box DoS'd its own host (#3068 RCA, 75 min lost).
+10. **Reuse the committed corpus generators** — `docs/reports/ws0-3026-artifacts/ws0-corpus/`,
+    `test-data/scripts/gen-perf-corpus-3068.sh`, and (with #3234) `gen-perf-corpus-bti.sh`.
+11. **`perf_event_paranoid = -1` is for dedicated single-tenant measurement boxes only.** Never a
+    shared or multi-tenant host.
+12. **Verify the PMU before measuring on a metered box.** Re-assert `perf_event_paranoid`/
+    `kptr_restrict` before every capture — they silently revert (#3217 method, #3274).
+
+---
+
+## 10. The correctness gate — discharged
+
+Landing #3058 and hardening its fast bypass arm exposed a correctness surface that had to be clean
+before #3100 could mean anything. **That gate is now discharged**; recorded here so the two defect
+*families* are not rediscovered.
+
+**Family A — "dead producer reads as end-of-scan" (silent truncation).** One
+`task dies → sender drops → consumer reads clean EOF → caller gets fewer rows, no error`.
+**MERGED:** #3106 (query-row stream), #3120 (k-way merge adapter — incl. compaction output, silent
+loss on the WRITE path), #3139 (prerequisite 13.5k-line `merge/mod.rs` split), #3124
+(multi-generation scan), #3154 (transient `KWayMerger::new` error returned unreconciled rows under
+`Ok`). **OPEN, not gating:** #3149 (delta-scan path).
+
+**Family B — "deleted row resurfaces as a phantom all-null row."** **MERGED:** #3095 (static-column
+semantics), #3094 (cell tombstone aborting the whole stream), #3121 (row-deleted clustering row +
+live static). **OPEN:** #3129 (multi-gen partition-deleted row).
+
+**Fast-arm holes the #3058 bypass introduced.** **MERGED:** #3140 (fast arm surfaced
+`Value::Tombstone`; Arrow rejected it → `do_get` aborted, zero rows), #3146 (fast arm bypassed the
+read-path row shadow → phantom all-null row, core-vs-Flight divergence).
+
+**#3100 then ran on the correctness-clean binary and reproduced the output digest exactly**
+(`0x4903ffa446163c4b`, 3,999,890 rows / 47,998,680 cells). That is what makes §0's numbers
+trustworthy.
+
+---
+
+## 11. The one-line status
+
+**#3058 shipped a real 3.06× and put the shipping path 1.12× ahead of stock Cassandra; the
+correctness gate is discharged; and the remaining 1.62× → 1.30× is blocked on ATTRIBUTION, not
+engineering — two of three named levers are measured dead, 87% of the IPC decay (#3224, running on
+metal now) and 82% of the encode region (#3248) are unexplained, and #3272 must harden the rig
+before any of it is priced.**
+
+---
+
+## 12. Process lessons queued to `process_improvements.md`
+
+1. **Rebase long-running branches onto `main` periodically.** #3094 ran 6 rounds + 2 owner decision
+   points with no rebase, so all integration cost landed at the end.
+2. **Do not dispatch a large refactor of a file an active claim is editing.** #3139's 13.5k-line
+   split landed under the in-flight #3094 P0 fix on the same file. Lead-scheduling rule.
+3. **A negative result needs the same delivery rigor as a positive one.** #3096 took 12 findings and
+   a re-anchored AC to ship "both levers are zero" *correctly*. Budget for it; the alternative is a
+   fabricated win.
+4. **Pre-commit the disposition before review, and never waive re-review.** A lead's bound on a
+   review's scope is the false-PASS direction; a false FAIL only costs a round.
+5. **Coverage is not equivalence.** A per-slice review ledger is a *finder*, never a *certifier*;
+   only one full-range round with a non-vacuous prompt certifies.


### PR DESCRIPTION
## Summary

`docs/architecture/0.17-throughput-mission.md` — the 0.17 scan-path throughput program's tracking doc — has been **untracked in a working tree since 2026-07-30**, so it was invisible to anyone but the one machine holding it, and its ground-truth section still carried **pre-#3100 cross-corpus ratios**. Those ratios compared an *uncompressed* CQLite corpus against a *compressed* Cassandra baseline; they are not divisible. This commits the doc with every number restated from a **committed** report.

Docs only. No code, no test, no build surface.

## The question it now answers: by how much did we improve?

From `docs/reports/ws0-3100-report.md` — all arms on **one byte-identical corpus**, post-#3058 binary, warm, **1 physical core** (`-c 2,10`), output digest `0x4903ffa446163c4b` reproduced exactly:

| Framing | Before #3058 | After #3058 | Change |
|---|--:|--:|--:|
| `do_get` rows/s / phys core | 82,639 | 252,999 | **3.06×** |
| vs Cassandra `SELECT *` (225,771) | 0.37× (**2.73× slower**) | **1.12× faster** | crossed the line |
| Gap to our own bare scan (410,449) | 4.97× | **1.62×** | closed 3.35× of it |
| Cycles/row | 72,382 | 22,111 | −69% |

The doc's prior figures — 3.32×, and 5.73× → 1.47× — were the cross-corpus ones. The most useful framing is the second row: the shipping path did not just get a ratio, it **crossed from behind stock Cassandra to ahead of it**.

## And the part that matters more: improvement since #3058 is 0%

Two of the three named levers for the remaining gap are now dead, both by correct measurement:

- **#3217 ACQUITTED the `do_get` mpsc handoff** — *zero* voluntary parks at every measurement point, ≤1.46 s of 1,963 s blocked (≤0.07%). It also **FALSIFIED the compounding-collapse scenario**: 71% marginal efficiency at 6 physical cores / 96.7% util, so a perfect handoff fix is worth **≤1.2–1.4× at box level, not 2.5–4×**. Ordered LAST — it optimises a site measured at ~0 cost.
- **#3096's two Arrow-encode levers MEASURE AT ZERO** — lever 4 −0.03% (4/8 rounds positive), lever 6 −320 rows/s paired (5/10 positive).

**One correction this PR records explicitly:** #3096's earlier **+2.3% / +4,817 rows/s did not reproduce** and is superseded — it was measured at a 4 MiB flight-data target the PR removes as a wire hazard. **#3248's body still quotes the derived `+2.0%` / `1.560× → 1.529×` / "15.0% short" figures**, which predate the final re-measurement. Anyone pricing an encode lever off #3248's body today would be pricing off a withdrawn number.

## Where the remaining 24.8% actually is: unattributed

Target = 1.3× of bare scan = **315,730 rows/s**. We are at 252,999.

| point | instr/row | cycles/row | IPC |
|---|--:|--:|--:|
| S=1 N=2 (1-core peak) | 38,343 | 25,200 | **1.52** |
| S=6 N=16 (6-core peak) | 38,382 | 33,793 | **1.14** |

instructions/row is **flat (+0.1%)** while cycles/row rises **+34.1%** — a memory-side CPI effect, not extra work. L1d (+7.5%) and dTLB (+40%) explain only **10–13%** of the +8,593 cycles/row; **~87% is unattributed** because `LLC-*` reads `<not supported>` on the virtualized host and `cache-references` **programs cleanly and returns a constant 0** (the silent-instrument class, appearing in the first probe of the very issue commissioned because of it).

So the doc adopts #3217's own conclusion: **the #1 next step is a MEASUREMENT, not a fix** (#3224, running on bare metal now with 88 uncore devices and an observed-failing positive control). Both per-row-work levers are unfounded *with respect to the scaling discount* — one costs nothing, the other's relevance is unknown.

It also carries #3248's **complement-vs-attribution** correction: "82% is array build" is `1,746 − 313 = 1,432.9 ns/row` from the call graph with **zero per-function data inside it**. Never fund a lever inside an unprofiled complement.

## Also updated

- §10 **correctness gate DISCHARGED** — #3094/#3095/#3106/#3120/#3121/#3124/#3139/#3140/#3146/#3154 merged; only **#3129** (multi-gen partition-deleted phantom) remains. The two defect *families* are recorded so they aren't rediscovered. The prior "STOP after that" order is discharged as of 2026-08-02.
- §7 ranks **attribution before funding**: #3224, #3272 (7 open rig findings), #3248 buy *measurements*; #3028/#3047 carry an explicit **re-price-post-#3058** caveat because both were measured inside the merge that no longer runs.
- New: **#3274** (#3249's perf sysctls aren't in the golden AMI and don't survive reboot — found at `paranoid=4` on the metal box) and **#3275** (`worker-supervisor.sh` treats an unrecognized arg as "start working"; `--help` claims an issue and spawns a worker).
- §8 refuted list gains the acquitted handoff, the falsified collapse, the two zero-measuring levers, and the complement claim.
- Still flagged **UNFILED**: the decompress+decode ceiling (~73% of cold-scan CPU, ~144 MB/s logical) — the real *cold* lever.

## Verification

Docs-only, single added file. `git show --stat` = 1 file, 366 insertions. Every quantitative claim traces to a committed artifact — `docs/reports/ws0-3100-report.md`, `docs/reports/ws0-3217-report.md`, or PR #3254's measurement table — with the one superseded-figure divergence called out above rather than blended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
