### PR TITLE
docs(#2817): lever 4 is reverted whole, not retained for wire safety

### DIFF
--- a/docs/architecture/0.17-throughput-mission.md
+++ b/docs/architecture/0.17-throughput-mission.md
@@ -130,9 +130,9 @@ collapse scenario required. **A perfect handoff fix is worth at most ~1.2–1.4�
 
 | Issue | P | State | Note |
 |---|---|---|---|
-| **#3096** | P1 | In Review, PR #3254, `HOLD: merge after #3229` | **AC1 UNMET — both Arrow-encode levers measure at ZERO** (§5). Merging per owner decision 2026-08-03 that a correctly-measured negative satisfies the change (spec R5); throughput re-anchored to #3248. |
-| **#3229** | P1 | In Review, PR #3262 | roborev blind to executable code under `docs/` — `exclude_patterns` omits it at any diff size. Gates #3096's certifying round. |
-| **#3234** | P1 | In Review, PR #3255 | Profileable BTI (`da`) perf corpus + `gen-perf-corpus-bti.sh`. Prerequisite for WS3 (#3029) and WS4 (#3030). Gate PASS, C PASS, awaiting final roborev. |
+| **#3096** | P1 | In Review, PR #3254, `HOLD: merge after #3229` | **AC1 UNMET — both Arrow-encode levers measure at ZERO** (§5), and **lever 4 is now REVERTED WHOLE** (→ #3281). Merging per owner decision 2026-08-03 that a correctly-measured negative satisfies the change (spec R5); throughput re-anchored to #3248. Needs a fresh full gate at the reverted HEAD — the `bbd6797` gate certified a tree that no longer exists. |
+| **#3229** | P1 | In Review, PR #3262 | roborev blind to executable code under `docs/` — `exclude_patterns` omits it at any diff size. Gates #3096's certifying round. Its built-in-exclude modelling subsystem is **removed and deferred to #3278** after four consecutive false-PASS blockers; whether that removal still lets #3096 reach a numeric `prompt-content: PASS` is an open report-back. |
+| **#3234** | P1 | **MERGED** 2026-08-04 (PR #3255) | Profileable BTI (`da`) perf corpus + `gen-perf-corpus-bti.sh`. **Unblocks WS3 (#3029) and WS4 (#3030).** Follow-ups #3267, #3273. |
 | **#3224** | P1 | **In Progress on `i4i.metal`**, 12h box to 2026-08-04T12:44Z | **The #1 open question**: the microarchitectural cause of the IPC decay. First host in the program with working uncore counters. |
 
 ---
@@ -166,7 +166,22 @@ order, control in every run, all three binary md5s recorded):
    positively measured region is IPC framing (313.0 ns/row). #3248 exists to profile inside the
    complement **before** any array-build lever is funded.
 
-**Lever 4 is retained for WIRE SAFETY, not throughput.** Lever 6 is retained as correct-and-cheap.
+**Lever 4 is REVERTED WHOLE — it is not retained for wire safety either** (lead ruling
+2026-08-04). Its only remaining justification was the `wire_partition` byte-partitioner, and that
+mechanism **failed three consecutive reviews, each fix inverting the error**: guard under-measured →
+partitioner under-budgeted (false-accept) → partitioner over-budgeted and subtracted the
+over-estimate from the **hard ceiling**, rejecting rows whose serialized message fits (false-reject
+on legal input). One design error, not three bugs — *a reserve is conservative in a **target** and
+not in a **ceiling***, and one number was used for both roles. The revert returns `do_get` to
+arrow-flight's default 2 MiB target: a configuration that was shipping and was never reported
+broken. The residual double-slicing inefficiency and the pre-existing 4 MiB gRPC exposure are
+deferred to **#3281**, which requires a *measured* target before any code. **Lever 6 is retained as
+correct-and-cheap.**
+
+What #3096 ships is the durable part: the `arrow_convert.rs` split (2,596 → 428, verified
+behavior-neutral item-by-item), the `Field`-identity schema contract, the IPC-framing attribution
+(**313.0 ns/row** — now the ceiling on what any framing change can buy), and the honest negative
+result.
 
 ---
 
@@ -235,7 +250,7 @@ direction). **That single result decides whether any per-row-work lever moves th
 | Issue | P | Finding |
 |---|---|---|
 | **#3253** | P1 | roborev's token-accounting vacuity tier is **INVALID** — token bands are not a vacuity oracle in either direction. `prompt-content` is the only deterministic one. |
-| **#3229** | P1 | roborev blind to executable code under `docs/`. **In review.** |
+| **#3229** | P1 | roborev blind to executable code under `docs/`. **In review**; built-in modelling removed → **#3278**. |
 | **#3157** | — | roborev returns a vacuous "No issues found" once the diff spills past the prompt ceiling (#3257 mechanism). |
 | **#3226** | P1 | bcc `offcputime`'s silent 10,240-key truncation + the measurement-doctrine harness. |
 | **#3274** | P2 | #3249's perf sysctls are **not in the golden AMI and not reboot-persistent** — found on the metal box at `perf_event_paranoid=4`. |
@@ -246,7 +261,7 @@ direction). **That single result decides whether any per-row-work lever moves th
 ### Exploration workstreams
 | Issue | P | State |
 |---|---|---|
-| **#3029** (WS3) | P1 | BTI (`da`) read profile. Structural analysis merged (PR #3235); corpus arrives with #3234. |
+| **#3029** (WS3) | P1 | BTI (`da`) read profile. Structural analysis merged (PR #3235); **corpus landed with #3234 — unblocked.** |
 | **#3030** (WS4) | P2 | Wide-row (≥4 KB) profile. Corpus built on #3068's box. |
 | **#3031** (WS5) | P2 | **PARK.** Both axes gone: Cassandra is also QD-1; CQLite mmaps. Keep the honest-denominator discipline; do not implement. |
 | **#2818** | P1 | i4i cold-vs-warm `samply` profile. **Adopted onto the same metal instance as #3224 — do not launch a second metal box.** |
@@ -270,6 +285,8 @@ direction). **That single result decides whether any per-row-work lever moves th
 | **The per-core handoff discount compounds across cores (2.5–4× box-level lever)** | **FALSIFIED (#3217).** 71% marginal efficiency at 6 cores / 96.7% util. Worth ≤1.2–1.4×. |
 | **The `do_get` mpsc handoff is the bottleneck** | **ACQUITTED (#3217).** Measured **zero** voluntary parks; ≤0.07% of blocked time. "The mpsc handoff" was never one thing — the bypass path stacks **four** bounded channels, and the one the issue named is not the one that parks. |
 | **Arrow batch/flight-data framing (lever 4) and schema caching (lever 6) are throughput levers** | **MEASURE AT ZERO (#3096).** Lever 4 −0.03%; lever 6 −320 rows/s paired. An earlier +2.3% **did not reproduce** and is superseded. |
+| **Lever 4 is still worth keeping for wire safety** | **NO — REVERTED WHOLE (#3096, 2026-08-04).** Its `wire_partition` mechanism failed three consecutive reviews, each fix inverting the error. One design error: **a reserve is conservative in a target and not in a ceiling**, and one number served both. → #3281 (measure first). |
+| **An over-estimated byte reserve "can only cause extra splitting, which is the safe direction"** | **FALSE for a hard ceiling.** True for a target only. Subtracting an over-estimate from the ceiling **false-rejects legal input**. The claim was in the module doc and cost three review rounds. |
 | **"82% of encode is array build"** | **NOT AN ATTRIBUTION** — a complement with zero per-function data inside it. → #3248. |
 | **T3 roofline (~1.8M rows/s/core, memory-bandwidth bound)** | **REFUTED** (traffic 1.0–1.9 KB/row vs 4.4 modeled; IPC 2.71–3.07 → instruction-bound). |
 | **T1 = 600k rows/s/core** | **WITHDRAWN — underivable.** Derived from the refuted T3. Not disproved; has no basis. Replaced by §6's measured target. |


### PR DESCRIPTION
## Summary

Corrects a line I landed in #3277 **an hour before ruling against it**. §5 of the mission doc said:

> **Lever 4 is retained for WIRE SAFETY, not throughput.**

As of the lead ruling on [#3096](https://github.com/pmcfadin/cqlite/issues/3096) that is false. Lever 4 and the whole `wire_partition` surface are **reverted**. This is my own stale line, not the worker's — they were told not to touch the mission doc from their branch.

Docs only. No code, no test, no build surface.

## Why the reason is worth recording, not just the outcome

The wire-safety mechanism failed **three consecutive reviews**, and each fix **inverted** the error:

| # | Defect | Fix | Outcome |
|---|---|---|---|
| 1 | guard measured only `data_body`, not the serialized message | `b253bae` | correct; **exposed #2** |
| 2 | partitioner budgeted only the Arrow payload → wide schema rejected by the now-correct guard | `c8c199a` | correct direction; **caused #3** |
| 3 | over-estimate subtracted from the **hard ceiling** → `RowTooWide` for rows whose message **fits** | reverted | — |

That is **one design error, not three bugs**: *a reserve is conservative in a **target** and not in a **ceiling***, and one number served both roles. Under-budget → false-accept; over-budget → **false-reject on legal input**. §8 gains the module doc's own claim — *"a larger reserve can only cause extra splitting, which is the safe direction"* — as refuted, because that sentence is what licensed the third movement.

Lever 4 measured **zero** (−0.03%, 4/8 rounds positive), so the revert costs nothing measurable and returns `do_get` to arrow-flight's default 2 MiB target — **a configuration that was shipping and was never reported broken**, not an untested one. Residual double-slicing and the pre-existing 4 MiB gRPC exposure are deferred to **#3281**, which requires a *measured* target before any code.

## Also refreshed

- **#3234 MERGED** (PR #3255) → **WS3 #3029 unblocked**; the BTI perf corpus landed.
- **#3229**'s built-in-exclude modelling **removed and deferred to #3278** after four consecutive false-PASS blockers — with the open report-back on whether that removal still lets #3096 reach a numeric `prompt-content: PASS`. If it does not, #3096's HOLD needs re-anchoring, and that is flagged rather than assumed.
- **#3096 needs a fresh full gate.** The `bbd6797` gate certified a tree the revert destroys; a revert is not post-gate polish and `--delta` does not reach it.
- Records what #3096 **still ships**, which is the durable part: the `arrow_convert.rs` split (2,596 → 428, verified behavior-neutral item-by-item), the `Field`-identity schema contract, the IPC-framing attribution at **313.0 ns/row** — now the ceiling on what any framing change can buy — and the honest negative result.

## Verification

`git diff --stat` = 1 file, +23/−6. Every claim traces to the #3096 thread (the three movements with their commit SHAs, the 8-round zero measurement) or to PR #3255's merge. No throughput number in the doc changes — this PR corrects a *retention* claim, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
