### PR TITLE
docs(#2817): record #3224's LLC mechanism, the slope-vs-level lever criterion, and a session log

### DIFF
--- a/docs/architecture/0.17-throughput-mission.md
+++ b/docs/architecture/0.17-throughput-mission.md
@@ -1,21 +1,30 @@
 # 0.17 Throughput Mission — tracking & mission document
 
-**Status as of 2026-08-03.** Living document. The board (GitHub Project #1) is the dispatch
+**Status as of 2026-08-04.** Living document. The board (GitHub Project #1) is the dispatch
 authority; this file is the *narrative* — mission, what's measured, what's in flight, and the gaps
 that keep biting. When board and this doc disagree on status, the board wins; open a PR to fix this
 file.
 
 Parent epic: **#2817** (0.17 scan-path throughput program). Exploration umbrella: **#3023**.
 
-> **2026-08-03 headline.** #3058 is merged and measured on one corpus: the shipping path went from
-> **2.73× SLOWER than stock Cassandra to 1.12× FASTER** — a **3.06×** improvement. The correctness
-> gate that blocked measurement is discharged (#3100 ran, #3094/#3095/#3121/#3154/#3140/#3146
-> merged; only #3129 remains). **And then the plan stalled, honestly:** of the three named levers for
-> the remaining gap, **two are now dead** — #3217 acquitted the `do_get` mpsc handoff (measured
-> **zero** parks) and #3096's two Arrow-encode levers **measure at ZERO**. Nothing has moved the
-> throughput number since #3058. The remaining gap is **1.62× → 1.30×** and its cause is
-> **not yet attributed**: 87% of the IPC decay (#3224, measuring now) and 82% of the encode region
-> (#3248) are unexplained. See §0 and §6.
+> **2026-08-04 headline — the mechanism is NAMED, and it tells us which levers can possibly work.**
+> #3224 measured both of #3217's endpoints on an `i4i.metal` where the LLC counters actually program.
+> **The full-box IPC decay is LLC capacity contention:** `LLC-load-misses/row` **triples** (11.94 →
+> 38.08, miss rate 16.1% → 43.2%) while `instructions/row`, `L1-dcache-loads`, `L1d-load-misses` and
+> `branch-misses` are all **flat within 1.3%**. Six cores share one 54 MiB LLC, each gets ~1/6 the
+> effective capacity, and the working set stops fitting. **Unattributed residual fell from ~87% to
+> 32.24%** — and DRAM bandwidth is **NOT** the wall (24.43 of 112.54 GB/s, 21.7% of peak).
+>
+> **The strategic consequence, which supersedes the plan's whole lever list:** a lever that reduces
+> **bytes touched per row / improves locality** moves the **SLOPE**; a lever that reduces
+> **instructions per row at the same footprint** moves the **LEVEL only**. `instructions/row` being
+> flat is the direct evidence. **Every remaining named lever except #3288 is a level lever.**
+>
+> Still true and still the honest part: **throughput has not moved since #3058's 3.06×** (2.73×
+> slower than stock Cassandra → 1.12× faster). Of the three originally named levers, **two are
+> measured dead** — #3217 acquitted the `do_get` mpsc handoff (**zero** parks), #3096's two
+> Arrow-encode levers **measure at ZERO** (merged 2026-08-04 as an honest negative). The gap is
+> **1.62× → 1.30×**, we need **+24.8%**, and it now has a *direction* for the first time. See §0, §6.
 
 ---
 
@@ -48,11 +57,25 @@ On the 1-hardware-thread basis (the valid basis for cycles/row and IPC): merge 7
 234,842 = **3.26×**; bare scan 396,723 → gap **1.69×**; vs Cassandra `SELECT *` 219,486 = **1.07×**.
 
 **Improvement since #3058: 0%.** #3096 measured both of its levers at zero. That is the honest
-number and it is the reason this program feels stalled — it is stalled on *attribution*, not on
+number, and it is why this program felt stalled — it was stalled on *attribution*, not on
 engineering throughput.
 
 **Remaining to target:** 1.3× of bare scan = **315,730 rows/s**. We are at 252,999. **We need
-+24.8%** and we currently cannot name where it comes from.
++24.8%.** As of #3224 we can finally say what *kind* of change can deliver it — a locality /
+bytes-touched-per-row change (§6) — though not yet which specific one.
+
+### The precision bound on every number in this document
+
+**The between-binary noise floor is ~1.4%** (#3096, 2026-08-04). Found by a falsifier the method
+produced against itself: an arm doing **strictly more work per batch measured 1.37% FASTER**. That is
+impossible as work, so it is code layout, not the lever. **A same-binary drift control cannot see
+this** — #3096's same-binary control gave `CTRL−ON sd = 1.29%` and reported nothing.
+
+**Consequence:** every lever A/B in this program compares separately-built binaries, so **any claim
+below ~1.4% must be reported as *within resolution*, not as a value.** No verdict in this document
+moves — `AC1 UNMET` at 16.3% short, the 3.06×, and the ×3.191 LLC-miss ratio are all an order of
+magnitude clear of the floor — but the *precision* of small lever deltas was previously overstated.
+→ #3248 owns the remedy.
 
 ---
 
@@ -76,7 +99,7 @@ basis — this ambiguity has produced two published errors already.
 
 ## 2. Ground truth — the measurement chain
 
-Four measurement runs, each superseding the last on the questions it answers:
+Five measurement runs, each superseding the last on the questions it answers:
 
 | Run | What it established | Report |
 |---|---|---|
@@ -84,6 +107,7 @@ Four measurement runs, each superseding the last on the questions it answers:
 | **#3027** (WS1, CLOSED) | Row decode is **compute-bound** (traffic:cycles 0.44). Traffic in `estimate_value_size` (1,398 B/row), `drop_glue::<QueryRow>` (949), `Value::into_owned` (945). | — |
 | **#3100** (CLOSED 08-02) | **The authoritative numbers in §0.** One corpus, post-#3058 binary, both merge arms, output digest `0x4903ffa446163c4b` **exact**. Plus the first C(N) sweep and the device acquittal. | `docs/reports/ws0-3100-report.md` |
 | **#3217** (CLOSED 08-03) | Full-box C(N) + off-CPU attribution. **Falsified** the compounding-collapse scenario; **acquitted** the `do_get` handoff; isolated the residual to an **IPC decay of unknown cause**. | `docs/reports/ws0-3217-report.md` |
+| **#3224** (In Review 08-04, PR #3286) | **Named the IPC decay: LLC capacity contention.** Re-measured both of #3217's endpoints on `i4i.metal` where `LLC-*` and `cycle_activity.stalls_l3_miss` program. Residual **~87% → 32.24%**. DRAM **not** saturated (21.7% of peak). Established the **slope-vs-level** criterion that re-ranks every remaining lever. | `docs/reports/ws0-3224*` (149 files) |
 
 ### #3100's two acquittals
 
@@ -122,18 +146,22 @@ collapse scenario required. **A perfect handoff fix is worth at most ~1.2–1.4�
 | **#3109** (P1) | **CLOSED.** Real bug: `run_scan_stream_batched` lacked the BTI dispatch that `run_scan_stream`/sequential had. |
 | **#3220 / #3032 / #3131 / #3148** | **CLOSED.** Fixture + harness integrity (multi-component `da` fixture, table-granular fixture resolution, fleet-wide `CQLITE_DATASETS_ROOT`). |
 | **#3249** (P1) | **CLOSED.** Profileable `perf` config on agent boxes. **Caveat: not baked into the golden AMI and not reboot-persistent → #3274.** |
+| **#3234** (P1) | **MERGED 2026-08-04** (PR #3255). Profileable BTI (`da`) perf corpus + `gen-perf-corpus-bti.sh` + a committed Cassandra-written golden + a byte-identical drift control. **Unblocks WS3 (#3029) and WS4 (#3030).** Follow-ups #3267, #3273, #3279. |
+| **#3096** (P1) | **MERGED 2026-08-04** (PR #3254). **An honest negative: both Arrow-encode levers measure at ZERO; neither is retained.** `AC1 UNMET`, 16.3% short → #3248; `R4 UNMET` → #3272. What shipped with value: the `arrow_convert.rs` split (2,596 → 428), the `Field`-identity schema contract, a perturbation-proven digest oracle, the **~1.4% between-binary noise floor** (§0), and **IPC framing priced at 313.0 ns/row**. |
+| **#3229** (P1) | **MERGED 2026-08-04** (PR #3262). Narrowed roborev's `docs/` exclusion so measurement harnesses are reviewed — **the change that made #3224's harness reviewable at all** (its round 8 was the first genuine review of those ten executables). Built-in-exclude modelling removed → #3278; AC2 residual open behind #3260; AC3/AC4 → #3283. |
 | Correctness gate (§10) | **DISCHARGED** except #3129. #3094, #3095, #3106, #3120, #3121, #3124, #3139, #3140, #3146, #3154 all merged. |
 
 ---
 
 ## 4. In flight
 
+**One item, and it is waiting on a person, not on a measurement.**
+
 | Issue | P | State | Note |
 |---|---|---|---|
-| **#3096** | P1 | In Review, PR #3254, `HOLD: merge after #3229` | **AC1 UNMET — both Arrow-encode levers measure at ZERO** (§5), and **lever 4 is now REVERTED WHOLE** (→ #3281). Merging per owner decision 2026-08-03 that a correctly-measured negative satisfies the change (spec R5); throughput re-anchored to #3248. Needs a fresh full gate at the reverted HEAD — the `bbd6797` gate certified a tree that no longer exists. |
-| **#3229** | P1 | In Review, PR #3262 | roborev blind to executable code under `docs/` — `exclude_patterns` omits it at any diff size. Gates #3096's certifying round. Its built-in-exclude modelling subsystem is **removed and deferred to #3278** after four consecutive false-PASS blockers; whether that removal still lets #3096 reach a numeric `prompt-content: PASS` is an open report-back. |
-| **#3234** | P1 | **MERGED** 2026-08-04 (PR #3255) | Profileable BTI (`da`) perf corpus + `gen-perf-corpus-bti.sh`. **Unblocks WS3 (#3029) and WS4 (#3030).** Follow-ups #3267, #3273. |
-| **#3224** | P1 | **In Progress on `i4i.metal`**, 12h box to 2026-08-04T12:44Z | **The #1 open question**: the microarchitectural cause of the IPC decay. First host in the program with working uncore counters. |
+| **#3224** | P1 | In Review, **PR #3286 open and NOT armed** | **The result is complete and certified** (§6): gate of record `RESULT: PASS` **unwaived** with `tree-integrity: PASS` at `e7af9028`, CI `required` green, 29 review findings fixed across rounds 1–7, published figures re-derived **bit-identical** (1,109 leaf values, 13 differ, all 13 newly added keys). **Blocked only on round 8's seven `Medium` findings**, all in guard/validation code written during the session (`ws0schema.py`, `derive.py` validators, `run-all.sh` resume predicate, `penalty-probe.sh` row parser) — none in a measurement path, none touching a published figure. Fix-or-waive is an owner call. **The 67.76%/32.24% attribution exists nowhere but this PR** and both #2817 and #3096 consume it. |
+
+Nothing else in the program is in flight. `In Progress` on the board is **empty**.
 
 ---
 
@@ -197,47 +225,107 @@ The honest state of the four candidate explanations:
 | Candidate | Status |
 |---|---|
 | `do_get` mpsc handoff | **ACQUITTED (#3217).** Zero voluntary parks at every measurement point; ≤1.46 s of 1,963 s blocked time (≤0.07%). The parks that exist are per-chunk/per-128-rows **inside `cqlite-core`**, below Flight. Ordered LAST — it optimises a site measured at ~0 cost. |
-| Arrow encode (#3096) | **Two levers measure ZERO** (§5). The encode region is 82% unattributed — not disproved, **unlocated**. → #3248. |
-| Allocator churn (#3028), `RowColumnResolution` (#3047) | **Never re-priced post-#3058.** Both were measured inside the merge that no longer runs. Do not start until re-baselined. |
-| The scaling discount (~29%) | **Not extra work and not the handoff.** instructions/row is **flat (+0.1%)** from the 1-core to the 6-core peak while cycles/row rises **+34.1%** and IPC falls **−25.4%**. It is a cycles-per-instruction (memory-side) effect. |
+| Arrow encode (#3096) | **Two levers measure ZERO** (§5). The encode region is 82% unattributed — not disproved, **unlocated**. → #3248. **And per #3224 it is a LEVEL lever unless it reduces bytes touched per row** — that is now the question #3248 must answer about it. |
+| Allocator churn (#3028), `RowColumnResolution` (#3047) | **Never re-priced post-#3058** — both were measured inside the merge that no longer runs. **Now doubly discounted:** both reduce instructions/row, and #3224 shows instructions/row is **flat** across the scaling range, so neither can move the slope. Level levers at best. Do not start until re-baselined *and* checked for a footprint effect. |
+| The scaling discount (~29%) | **RESOLVED (#3224): LLC capacity contention.** Not extra work, not the handoff. See below. |
 
-### The one genuinely open question — #3224
+### ANSWERED — #3224: the decay is LLC capacity contention
 
-| point | instr/row | cycles/row | IPC | L1d-miss/row | dTLB-miss/row |
-|---|--:|--:|--:|--:|--:|
-| S=1 N=2 (1-core peak) | 38,343 | 25,200 | **1.52** | 265.4 | 7.6 |
-| S=6 N=16 (6-core peak) | 38,382 | 33,793 | **1.14** | 285.4 | 10.6 |
+#3217 could not name the cause because `LLC-loads`, `LLC-load-misses` and `cache-references` all read
+`<not supported>` or a constant `0` on its virtualized host — the silent-instrument class. #3224
+re-measured **both** endpoints on an `i4i.metal` where those counters program. 3 reps per endpoint,
+**every counter at 100.00% enabled**, ALIGNED convention, medians:
 
-L1d (+7.5% rel.) and dTLB (+40% rel.) together explain only **10–13%** of the +8,593 cycles/row.
-**~87% is unattributed.** `LLC-loads`/`LLC-load-misses` read `<not supported>` on the virtualized
-host, and `cache-references` **programs cleanly and returns a constant 0** — the silent-instrument
-class. LLC / memory-bandwidth saturation is the natural hypothesis and **was not measured**.
+| per row | S=1/N=2 | S=6/N=16 | ratio |
+|---|--:|--:|--:|
+| instructions | 38,856.8 | 38,685.6 | **0.996 — flat** |
+| L1-dcache-loads | 9,157.7 | 9,140.8 | **0.998 — flat** |
+| L1-dcache-load-misses | 586.7 | 578.9 | **0.987 — flat** |
+| branch-misses | 63.05 | 62.95 | **0.998 — flat** |
+| **LLC-load-misses** | **11.94** | **38.08** | **×3.191** |
+| cycles | 31,316.4 | 37,284.9 | ×1.191 |
+| **IPC** | **1.2376** | **1.0384** | **−16.09%** |
 
-**#3217's own conclusion, adopted: the #1 next step is a MEASUREMENT, not a fix.** Both per-row-work
-levers are unfounded with respect to the scaling discount — one costs nothing, the other's relevance
-is unknown. #3224 is running on the first host in this program with working uncore counters (88
-devices; positive control 13.95% vs 61.23% LLC miss rate, differential ≥2× gated in either
-direction). **That single result decides whether any per-row-work lever moves the slope.**
+**The mechanism is named by what does NOT move.** Same instruction stream, private caches untouched,
+and **LLC misses per row triple** — miss rate **16.1% → 43.2%**. Six cores contend for one shared
+**54 MiB** LLC; each gets ~1/6 the effective capacity and the working set stops fitting.
+
+**The residual is now a measured number, not an estimate — 32.24%.** This host programs
+`cycle_activity.stalls_l3_miss`, and because the three `cycle_activity` counters **nest**,
+differencing them *partitions* the delta rather than estimating it:
+
+| bucket | cycles/row | % of Δ |
+|---|--:|--:|
+| **L3-miss stalls (DRAM)** | **+3,821.3** | **67.76%** |
+| L2-miss-but-L3-hit stalls (LLC) | +657.4 | 11.66% |
+| other execution stalls | +1,792.6 | 31.79% |
+| non-stalled cycles | −631.9 | −11.20% |
+| **SUM** | **+5,639.4** | **100.00%** (closure error **+0.000**) |
+
+Δ = **+5,639.4** cycles/row; attributed **+3,821.3 (67.76%)**; **residual +1,818.1 = 32.24%
+UNATTRIBUTED** (#3217 left ~87%). → **#3287** owns splitting the remainder.
+
+**Two independent routes agree, and neither alone would have licensed the claim.** A zero-MLP penalty
+charge (303.1 cyc/miss, measured on this host) accounts for **140.51%** of the delta — impossible,
+and it would have declared the mechanism *fully explained*. Corrected by the **measured** MLP (2.20)
+it lands at 63.84% against the measured 67.76%: **agreement within 5.8%.** This is why modelling was
+the weak link and why the nesting-based partition is the load-bearing result.
+
+### The consequence that re-ranks every lever: SLOPE vs LEVEL
+
+**DRAM bandwidth is NOT the wall — 24.43 GB/s against 112.54 GB/s, 21.7% of peak, ~4.6× headroom**,
+measured at the engine's own 6-core/12-thread NUMA-bound binding. So the verdict is stated
+*conditionally*, because "is it bandwidth-bound?" presupposes a wall that does not exist:
+
+| a lever that… | moves |
+|---|---|
+| reduces **bytes touched per row** / improves locality (LLC footprint) | **the SLOPE** |
+| reduces **instructions per row** at the same footprint | **the LEVEL only** |
+
+**`instructions/row` flat at 0.996 is the direct evidence for the second row.** Read against §7:
+**#3288 (locality / bytes-touched-per-row) is the only named candidate that can move the slope.**
+#3028, #3047, #2897 and the encode levers are level levers unless they are shown to shrink the
+working set — which is a measurement none of them has.
+
+**Caveat on the `4.6×`, stated because it is not re-derived.** Round 7 fixed a defect where the
+bandwidth triad recorded its iteration start *after* releasing its workers, which inflates the
+best-of-N ceiling in the anti-conservative direction. The `ac5/` artefact is stamped `04:03Z`; the fix
+landed `08:13Z`; **it was never regenerated**, and `4.6×` is not among the 1,109 re-derived leaf
+values. The *direction* is known (the true headroom is **≤4.6×**), and the conclusion is robust —
+reaching saturation would take a >4× error — but **quote `21.7% of peak` as provisional until
+re-derived.** → tracked in #3287.
+
+**#3217's open method question is settled.** Its interior-window convention was *sound*: the two
+conventions agree to **0.45%** at its most exposed point. Its 25,200 vs this host's 31,316 cycles/row
+is a **cross-host** difference (+24%), not a convention artefact — so #3217's numbers stand as
+measured on its own host and must not be mixed with these.
 
 ---
 
 ## 7. Open work, ranked
 
-### Blocking everything — attribution before funding
+### The one lever the measurement actually points at
 | Issue | P | Finding |
 |---|---|---|
-| **#3224** | P1 | Microarchitectural cause of the IPC decay. 87% unattributed. **In progress on metal, 12h box.** |
-| **#3272** | P1 | **Harden the WS0 measurement rig before anything is funded on it — 7 open findings.** Every remaining number is a cycles/row attribution on this rig. |
-| **#3248** | P1 | Profile *inside* the 82% unattributed encode region + a bare-scan-vs-`do_get` differential. **Buys a profile, not a patch.** |
+| **#3288** | P1 | **Locality / working-set lever: cut bytes touched per row on the Flight read path.** Per §6 this is the **only** named candidate that can move the SLOPE, and it now has a priced target rather than a guess: the working set must shrink enough to fit ~1/6 of a 54 MiB LLC. **Start here.** |
 
-### Throughput levers — all currently unfounded
+### Attribution still owed before anything else is funded
 | Issue | P | Finding |
 |---|---|---|
-| **#3028** (WS2) | P1 | Allocator churn 19.6%. **RE-PRICE against post-#3058 profile first.** |
-| **#3047** | P2 | Hoist `RowColumnResolution` per-partition → per-scan (17.4% on-CPU). Same re-price caveat. |
+| **#3272** | P1 | **Harden the WS0 measurement rig before anything is funded on it — 7 open findings.** Every remaining number is a cycles/row attribution on this rig, and #3224's 29 fixed findings were all in its guard layer. **Gating.** |
+| **#3287** | P1 | **Split #3224's remaining 32.24% residual** — TMA level-2 + an offcore/prefetch breakdown. Also owns re-deriving the `4.6×` AC5 ceiling under the round-7 barrier fix (§6 caveat). |
+| **#3248** | P1 | Profile *inside* the 82% unattributed encode region + a bare-scan-vs-`do_get` differential. **Buys a profile, not a patch.** Now also owes the slope-vs-level verdict on encode, and owns the ~1.4% noise-floor remedy (§0). |
+| **#3289** | P2 | WS0 harness must derive server core sets from the running SMT topology instead of a hard-coded map — a wrong pinning silently changes every per-core figure. |
+
+### Throughput levers — now explicitly LEVEL levers (see §6)
+| Issue | P | Finding |
+|---|---|---|
+| **#3028** (WS2) | P1 | Allocator churn 19.6%. **RE-PRICE against post-#3058 profile first**, and note it reduces instructions/row, which #3224 measured **flat** — level only unless it shrinks the footprint. |
+| **#3047** | P2 | Hoist `RowColumnResolution` per-partition → per-scan (17.4% on-CPU). Same two caveats. |
 | **#3113** | P1 | Sequential scan issues I/O serially (QD 1.05–1.39 of 32). Not a warm-path lever; #3100 §4 acquitted the device warm. |
-| **(UNFILED)** | — | **Decompress + decode** — the 73%-of-cold-scan CPU ceiling #3068 §6 exposed (~144 MB/s logical, LZ4 + 12M row decodes). The real *cold* lever. Needs its own oracle. **Still unfiled — file it.** |
-| **#2820 / #2828 / #2826 / #2897 / #2917** | P1–P3 | Batch fan-in, chunk-cache retune, and three Arrow-egress items that overlap #3096/#3248. Do not start ahead of #3248. |
+| **#3295** | P2 | **Decompress + decode** — the 73%-of-cold-scan CPU ceiling #3068 §6 exposed (~144 MB/s logical, LZ4 + 12M row decodes). The real *cold* lever; needs its own oracle. **Filed 2026-08-04** after sitting UNFILED through two status cycles. |
+| **#3281** | P2 | `cqlite-flight` double-slices every batch against arrow-flight's 2 MiB default. Requires a **measured** target before any code (the #3096 lever-4 lesson). |
+| **#2820 / #2828 / #2826 / #2897 / #2917** | P1–P3 | Batch fan-in, chunk-cache retune, and three Arrow-egress items that overlap #3248. Do not start ahead of #3248. **#2828's chunk-cache retune is the one of these with a plausible footprint effect** — re-read it against §6. |
 
 ### Correctness — one item left
 | Issue | P | Finding |
@@ -288,6 +376,10 @@ direction). **That single result decides whether any per-row-work lever moves th
 | **Lever 4 is still worth keeping for wire safety** | **NO — REVERTED WHOLE (#3096, 2026-08-04).** Its `wire_partition` mechanism failed three consecutive reviews, each fix inverting the error. One design error: **a reserve is conservative in a target and not in a ceiling**, and one number served both. → #3281 (measure first). |
 | **An over-estimated byte reserve "can only cause extra splitting, which is the safe direction"** | **FALSE for a hard ceiling.** True for a target only. Subtracting an over-estimate from the ceiling **false-rejects legal input**. The claim was in the module doc and cost three review rounds. |
 | **"82% of encode is array build"** | **NOT AN ATTRIBUTION** — a complement with zero per-function data inside it. → #3248. |
+| **The full-box IPC decay is of unknown cause / might be memory-bandwidth saturation** | **RESOLVED, and the bandwidth half is REFUTED (#3224).** It is **LLC capacity contention**: `LLC-load-misses/row` ×3.191 (16.1% → 43.2% miss rate) with instructions, L1d and branch-misses all flat within 1.3%. DRAM runs at **21.7% of measured peak** — there is no bandwidth wall. |
+| **"~87% of the IPC decay is unattributed"** | **SUPERSEDED (#3224): the residual is 32.24%**, measured via nesting `cycle_activity` counters rather than modelled. Do not quote the 87%; → #3287 for the remainder. |
+| **A reduction in instructions/row is a throughput lever at box scale** | **NO — LEVEL ONLY (#3224).** `instructions/row` is **flat (0.996)** from the 1-core to the 6-core peak. Only a change in **bytes touched per row / LLC footprint** moves the slope. This demotes #3028, #3047, #2897 and the encode levers unless they are shown to shrink the working set. |
+| **A same-binary drift control measures the noise floor of a between-binary A/B** | **NO (#3096).** The floor is **~1.4% from code layout alone**; the same-binary control saw `sd = 1.29%` and reported nothing. Falsified by an arm doing strictly more work measuring **1.37% faster**. Any sub-1.4% between-binary claim is *within resolution*, not a value. |
 | **T3 roofline (~1.8M rows/s/core, memory-bandwidth bound)** | **REFUTED** (traffic 1.0–1.9 KB/row vs 4.4 modeled; IPC 2.71–3.07 → instruction-bound). |
 | **T1 = 600k rows/s/core** | **WITHDRAWN — underivable.** Derived from the refuted T3. Not disproved; has no basis. Replaced by §6's measured target. |
 | **"Cut memory traffic" as a win criterion** | **DROPPED.** Report cycles/row and rows/s. Keep the traffic column (it caught T3) but it is inbound-only — a lower bound. |
@@ -327,7 +419,24 @@ direction). **That single result decides whether any per-row-work lever moves th
 11. **`perf_event_paranoid = -1` is for dedicated single-tenant measurement boxes only.** Never a
     shared or multi-tenant host.
 12. **Verify the PMU before measuring on a metered box.** Re-assert `perf_event_paranoid`/
-    `kptr_restrict` before every capture — they silently revert (#3217 method, #3274).
+    `kptr_restrict` before every capture — they silently revert (#3217 method, #3274). Record
+    `pct_running` for every counter and treat anything below 100.00% as multiplexed — #3224's runs
+    were all at 100.00%, which is *why* its ratios are quotable.
+13. **An unmeasurable state must initialise to the value that FAILS.** Never to a sentinel that reads
+    as excellent. #3224's 29 fixed findings were **one class**: a measurement step whose failure was
+    recorded, printed, or structurally representable but **not acted on**. The canonical instance is
+    `MUXMIN` defaulting to `10000`, so an unparseable counter-enabled percentage "passed with more
+    margin than a healthy one." A false PASS costs the doctrine; a false FAIL costs a round.
+14. **State the noise floor before quoting a delta** (§0). ~1.4% between separately-built binaries.
+    A same-binary control does not measure it.
+15. **`date -u` before any claim about a time budget.** A worker on a $10.98/hr metered box computed
+    "~40 min remain" when it had ~4h, stood down, and left ~3h of the box idle. Its own clock was
+    correct — it substituted an estimate for a measurement, and the substitute failed in the
+    permissive direction. Same class as rule 13, in reasoning rather than in code.
+16. **Do not assert a scheduled event happened when you could not observe it.** The same box was
+    reported "past its hard stop" for five consecutive status cycles while it was in fact running and
+    billing, because the probe path was down and the *schedule* was substituted for a measurement.
+    "Cannot verify" is the correct output. Rule 13 applied to operations.
 
 ---
 
@@ -361,10 +470,12 @@ trustworthy.
 ## 11. The one-line status
 
 **#3058 shipped a real 3.06× and put the shipping path 1.12× ahead of stock Cassandra; the
-correctness gate is discharged; and the remaining 1.62× → 1.30× is blocked on ATTRIBUTION, not
-engineering — two of three named levers are measured dead, 87% of the IPC decay (#3224, running on
-metal now) and 82% of the encode region (#3248) are unexplained, and #3272 must harden the rig
-before any of it is priced.**
+correctness gate is discharged; throughput has not moved since, with two of three named levers
+measured dead — but #3224 has now NAMED the full-box mechanism as LLC capacity contention (residual
+~87% → 32.24%, DRAM at only 21.7% of peak), which converts the remaining 1.62× → 1.30× from an
+unattributed gap into a specific requirement: cut BYTES TOUCHED PER ROW (#3288), because
+instructions/row is flat and every other named lever moves the level, not the slope — after #3272
+hardens the rig it all rests on.**
 
 ---
 
@@ -381,3 +492,69 @@ before any of it is priced.**
    review's scope is the false-PASS direction; a false FAIL only costs a round.
 5. **Coverage is not equivalence.** A per-slice review ledger is a *finder*, never a *certifier*;
    only one full-range round with a non-vacuous prompt certifies.
+
+---
+
+## 13. Session log
+
+Newest first. One entry per working session, with the state it left behind and the next step it
+handed forward. This section exists because "what did we already try, and what did it conclude?" was
+being answered from memory across sessions.
+
+### 2026-08-04 (overnight, 4 boxes + 1 `i4i.metal`)
+
+**Four deliveries landed; the program's central question got answered; throughput did not move.**
+
+| merged | issue | conclusion |
+|---|---|---|
+| PR #3251 | **#3249** | Profileable `perf` config persisted on agent boxes. Not in the golden AMI → #3274. |
+| PR #3255 | **#3234** | BTI (`da`) perf corpus + committed Cassandra-written golden + byte-identical drift control. **Unblocks WS3/WS4.** |
+| PR #3262 | **#3229** | roborev's `docs/` exclusion narrowed. **Load-bearing for #3224** — its harness executables had never been reviewed until this landed. |
+| PR #3254 | **#3096** | **Both Arrow-encode levers measure at ZERO; neither retained.** `AC1 UNMET`, 16.3% short → #3248. |
+
+**What we learned, in order of how much it changes the plan:**
+
+1. **The full-box mechanism is LLC capacity contention (#3224).** §6. This is the first mechanistic
+   answer the program has produced, and it re-ranks everything: **#3288 is the only named slope
+   lever**; #3028/#3047/#2897/encode are level levers. Residual ~87% → **32.24%**, measured not
+   modelled. DRAM at **21.7% of peak** — no bandwidth wall.
+2. **Both #3096 levers are zero, measured twice.** Lever 6: **+0.30%, CI [−1,661, +3,125] covering
+   zero**, the second time with the mechanism genuinely live. Lever 4 reverted whole — one design
+   error (*one number served as both a `target` and a `ceiling`*) → #3281.
+3. **The between-binary noise floor is ~1.4%** (§0), which bounds every A/B in the program including
+   #3224's own ratios.
+4. **IPC framing is priced at 313.0 ns/row** — previously attributable to nothing, now a ceiling on
+   what any framing change can buy.
+5. **The dominant defect class of the night was fail-open in an instrument** (rules 13–16). #3224 fixed
+   **29** findings, all one class. Two of them were arithmetic: integer milli-rate rounding making a
+   flat counter read `inf → OK`, and the bandwidth triad recording its iteration start after releasing
+   its workers (which inflated the AC5 ceiling — hence §6's `4.6×` caveat).
+
+**Verified clean, so nobody re-opens them:** every counter in #3224's published result sets ran at
+**100.00% `pct_running`** — zero multiplexing, no nonzero `RC_*` — so the `MUXMIN` fail-open defect
+was **latent and never corrupted a published figure**. The IMC channel sum is validated by byte
+accounting at **measured/expected = 1.008** with far-socket fraction 0.0019.
+
+**Left open, deliberately:**
+
+- **PR #3286 (#3224) is open, certified, and NOT armed** — gate `RESULT: PASS` unwaived at
+  `e7af9028`, CI `required` green, seven round-8 `Medium` findings in guard code outstanding.
+  Fix-or-waive is an owner call. **The 67.76%/32.24% attribution exists nowhere else.**
+- **`4.6×` AC5 headroom is not re-derived** under the round-7 barrier fix (§6 caveat) → #3287.
+- **#3295 filed** for the cold-path decompress+decode ceiling, after two cycles as `(UNFILED)`.
+
+**Next steps, in dependency order:**
+
+1. **#3272 — harden the WS0 rig.** Gating. Every number above is a cycles/row attribution on it, and
+   #3224 proved its guard layer is where the errors live.
+2. **#3288 — the locality / bytes-touched-per-row lever.** The only candidate §6 licenses. It now has
+   a target: shrink the working set enough to fit ~1/6 of a 54 MiB LLC.
+3. **#3287 — split the 32.24% residual** (TMA level-2 + offcore/prefetch) and re-derive the AC5 ceiling.
+4. **#3248 — profile inside the encode complement** and return the slope-vs-level verdict on encode.
+5. Re-read **#2828** (chunk-cache retune) against §6 — of the deferred egress/cache items it is the one
+   with a plausible footprint effect.
+
+### Earlier sessions
+
+Not yet backfilled. §2 (measurement chain), §3 (shipped), §8 (refuted) and §10 (correctness gate)
+carry the substance for everything before 2026-08-04; this log starts here.


### PR DESCRIPTION
Refs #2817. Refs #3224. Refs #3295. Refs #3296.

Single-file markdown diff: `docs/architecture/0.17-throughput-mission.md`, 383 → 560 lines (+225/−48). No code, no `Cargo.lock`, no test-data.

## Why

The tracking doc was **four days and five measurement runs stale** and, more importantly, was missing the single most consequential result the program has produced: **#3224's answer to what the full-box IPC decay actually is**, and the re-ranking of every open lever that answer forces. It still carried "### The one genuinely open question — #3224" as an open question that had in fact been answered and re-derived bit-identically.

## What it records

**§0 — the headline is now the mechanism, not the symptom.** The full-box IPC decay is **LLC capacity contention**: `LLC-load-misses/row` 11.94 → 38.08 (**×3.191**, miss rate 16.1% → 43.2%) while `instructions` (0.996), `L1-dcache-loads` (0.998), `L1-dcache-load-misses` (0.987) and `branch-misses` (0.998) are flat, on six cores sharing one 54 MiB LLC. IPC 1.2376 → 1.0384 (−16.09%).

**§6 — the `cycle_activity` nesting partition, with its residual stated as a number rather than elided.** Δ = +5,639.4 cycles/row; L3-miss stalls +3,821.3 (**67.76%**); L2-miss-but-L3-hit +657.4 (11.66%); other execution stalls +1,792.6 (31.79%); non-stalled −631.9 (−11.20%); closure error +0.000. **Residual +1,818.1 = 32.24% unattributed** — recorded as unattributed, not as attributed-to-the-largest-bucket. #3217 left ~87%, so that row moves to §8 as superseded rather than being quietly overwritten. The MLP corroboration is included because it is the check that makes the number believable: the zero-MLP charge accounts for **140.51%** of Δ (impossible on its face), and correcting by the measured MLP of 2.20 gives 63.84% against the measured 67.76% — **agreement within 5.8%**.

**§6/§7 — the consequence, which is the part that changes what we do next: SLOPE vs LEVEL.** DRAM sits at **24.43 of 112.54 GB/s = 21.7% of peak**, so there is no bandwidth wall and the scaling discount is not a saturation story. A lever that cuts **bytes touched per row / LLC footprint** moves the **slope**; a lever that cuts **instructions per row** moves the **level only** — and instructions/row is measured flat. That single criterion demotes #3028, #3047, #2897 and the encode levers to explicit LEVEL levers, and promotes **#3288** as the one named lever the measurement actually points at. §7 is re-ranked into "the one lever the measurement points at" / "attribution still owed" (#3272 gating, #3287, #3248, #3289) / "throughput levers — now explicitly LEVEL levers".

**The `4.6×` figure is flagged provisional, in the doc, next to the number.** The `ac5/` artefact is stamped `04:03Z`; the round-7 three-phase-barrier fix landed `08:13Z`; **it was never regenerated**, and round 7's own finding predicts this is precisely the number that should have moved. It is quotable only as provisional until re-derived — that is #3287's job.

**§0 — the precision bound on every number in the document.** The ~1.4% between-binary noise floor (#3096), how it was established, and the rule that follows: any claim below it must be reported as *within resolution*, not as a value. Included because the falsifier is the memorable part — an arm doing strictly more work measured **1.37% faster**.

**§8 — four refutations added** rather than deletions: bandwidth saturation refuted, the ~87% residual superseded, instruction-count reduction shown to be level-only, and a same-binary control shown not to measure the between-binary floor (`CTRL−ON sd = 1.29%` cannot see a 1.4% between-binary effect).

**§9 — rules 13–16**, each earned by a specific failure this program made:
- an unmeasurable state must initialise to the value that **FAILS** (the `MUXMIN` → `10000` fail-open);
- state the noise floor **before** quoting a delta;
- `date -u` before any claim about a time budget;
- **do not assert a scheduled event happened when you could not observe it.**

Rule 16 is mine. I reported box 4 as past its 12:44Z hard stop for five consecutive sweeps while it was in fact still running and billing, because the probe path was down and I treated a *scheduled* event as an *observed* one — the same fail-open-on-an-unmeasurable-state defect I had spent the night diagnosing in other people's code. It is in the doc as a rule rather than in a postmortem nobody re-reads.

**§13 — a new session log**, opening with the `2026-08-04 (overnight)` entry: the four merges, five ranked learnings, a "verified clean, so nobody re-opens them" section (all 28 published CSVs at 100.00% `pct_running` — so the `MUXMIN` fail-open was **latent and never corrupted a published figure**; IMC byte-accounting ratio 1.008), a "left open, deliberately" section, and **five dependency-ordered next steps** (#3272 → #3288 → #3287 → #3248 → re-read #2828).

Every figure is taken from PR #3286's body rather than from recollection, and #3295 was **filed before being referenced** so the cross-reference is real. §7's formerly `(UNFILED)` cold-path lever is now #3295.

## Certification — read this before reading the gate result

`--lite` at `0fe049a` returns **`RESULT: FAIL`** on **`roborev-lints`**, with `tree-integrity: PASS`, `file-size: PASS`, `fmt: PASS`, `clippy: PASS`, `scoped-tests: PASS`.

**That failure is pre-existing `main`-red and cannot be caused by this diff, which contains one markdown file.** Proven rather than argued: a pristine `git worktree add --detach origin/main` at `e28576421` produces the **byte-identical** 7-failure set:

```
passed: 553  failed: 7
GUARD-TEST RESULT: FAIL
```

Same seven cases (`cx28`, `cx29`, `cx28b`, `cx28c`, `case (f)` ×2, `case (j2)`). Root-caused and filed as **#3296 (P0)**: GNU-only `sed -i` in `test_roborev_review_guard.sh` (4 cases — BSD sed leaves the mutation unapplied and the cases correctly self-report), `/var` vs `/private/var` canonicalisation in `case (f)` (2 cases), and an empty key-order extraction in `case (j2)` (1 case, least characterised). Bisected: at `9f11eb7cf^` the same script printed `GUARD-TEST RESULT: FAIL` and **exited 0** — three of the seven were latent behind the guard test's own fail-open exit path, which #3262 correctly closed.

**I am not asking for a waiver and this PR should not be the vehicle for one.** #3296 is the fix; the honest state of this branch is that its four other lite components are green and the fifth is red on `main` for reasons in a file this diff does not touch. If the preference is to hold this PR until #3296 lands and then certify cleanly, that is the stricter and better order and I will do it — the doc content does not expire. If the preference is to land the record now, that is a waiver decision and it is the owner's.

No roborev pass: a code-free delta is not roborev-certifiable (#2964 rule 4).
