### PR TITLE
docs(#2817): established-engineering research surveys — TPC verdict + footprint/build-path lever slate

### DIFF
--- a/docs/research/throughput-2026-08-arrow-build-path-survey.md
+++ b/docs/research/throughput-2026-08-arrow-build-path-survey.md
@@ -1,0 +1,137 @@
+# Lane 3 — Row→Arrow build cost in production Rust/Arrow systems
+
+**2026-08-04, owner-commissioned research survey (lane 3 of 3).** Synthesis + verdicts:
+`throughput-2026-08-research-synthesis.md`. Claims tagged **[MEASURED]** (published number),
+**[SOURCE]** (read from arrow-rs source/API docs — a fact about the code), or **[FOLKLORE]**
+(repeated, no primary measurement). Our numbers (1.52 µs/row Flight overhead, 313 ns/row IPC
+framing, ~1.2 µs/row unattributed build) treated as ground truth.
+
+## 1. arrow-rs builder economics
+
+- **`finish()` does not retain capacity** — it is `mem::take(&mut self.buffer)`; the builder gets a
+  new empty buffer **[SOURCE]**
+  ([arrow-buffer builder](https://raw.githubusercontent.com/apache/arrow-rs/main/arrow-buffer/src/builder/mod.rs)).
+  This kills the "reuse the builder object across batches" idea **[FOLKLORE]** — builders are
+  reusable after `finish()` ([ARROW-4075](https://issues.apache.org/jira/browse/ARROW-4075)) but
+  reuse buys the struct, not the allocation. Actionable form: **re-apply `with_capacity` every
+  batch** from a known row count + byte estimate.
+- **`BufferBuilder::append()` calls `reserve(1)` per element** **[SOURCE]** — a capacity branch per
+  value; bulk paths (`append_slice`, `append_n`, `Extend`) amortize it. Capacity accessors added so
+  downstreams can measure allocation slack ([#10342](http://www.mail-archive.com/commits@arrow.apache.org/msg63672.html)).
+- **`GenericByteBuilder::with_capacity(item_capacity, data_capacity)`** takes offsets AND value
+  bytes; `append_value` takes `impl AsRef<[u8]>` — **borrowed bytes are accepted; no owned
+  `String`/`Vec<u8>` required**. Panics at i32 offset overflow (2 GB/array) **[SOURCE]**
+  ([docs](https://docs.rs/arrow-array/latest/arrow_array/builder/struct.GenericByteBuilder.html)).
+- **Nested builders are the documented dispatch trap**: `StructBuilder` stores children as
+  `Box<dyn ArrayBuilder>`; `field_builder::<T>(i)` is a **runtime downcast**; `len()` checks only
+  the first child. `List<Struct<…>>` downcasts through `ListBuilder<Box<dyn ArrayBuilder>>`
+  **[SOURCE]** ([docs](https://docs.rs/arrow-array/latest/arrow_array/builder/struct.StructBuilder.html)).
+  Per-cell downcast is the pathological shape.
+- **View builders offer real zero-copy**: `GenericByteViewBuilder::append_block(Buffer)` +
+  `try_append_view(block, offset, len)`; values ≤ ~12 B inlined into the 16-byte view; block growth
+  8 KiB → 2 MiB ([#6136](https://github.com/apache/arrow-rs/pull/6136)) **[SOURCE]**
+  ([docs](https://docs.rs/arrow-array/latest/arrow_array/builder/struct.GenericByteViewBuilder.html)).
+- **StringView payoff**: 20–200% on string-heavy ClickBench; Parquet→`StringViewArray` 287.81 µs vs
+  `StringArray` 345.03 µs (~1.2×) by reusing the source page buffer **[MEASURED]**
+  ([DataFusion blog](https://datafusion.apache.org/blog/2024/09/13/string-view-german-style-strings-part-1/)).
+
+## 2. Row→columnar in the wild
+
+- **`arrow-row` is the opposite direction** (Arrow → comparable byte rows for sort/group)
+  **[SOURCE]** ([docs](https://docs.rs/arrow-row/latest/arrow_row/)). Do not mine it.
+- **`arrow-avro` is the closest published analogue** (row-oriented source → Arrow, in-tree,
+  benchmarked). Design: per-field `Codec` decided once at schema-bind, then decode "column-by-column
+  straight into Arrow builders," explicitly avoiding "deserializ[ing] one record at a time into
+  native Rust values … then build[ing] Arrow arrays from those values" (extra allocations,
+  cache-unfriendly) **[SOURCE]**. Measured against exactly that row-object path (`apache-avro`):
+  **1 M rows 267.21 ms → 27.91 ms = 9.57×**; 10 K rows 2.60 → 0.24 ms = 10.8× **[MEASURED]**
+  ([announcement](https://arrow.apache.org/blog/2025/10/23/introducing-arrow-avro/)). Caveat:
+  bench schema field count undisclosed — per-field normalization is an estimate.
+- **arrow-json / Arroyo**: two-pass tape (simdjson-style); each column decoder gets a position
+  array, processing "in a tight, efficient loop, and only needing to downcast the array a single
+  time." 0.396–5.108 µs/record vs Jackson 0.517–11.73 **[MEASURED]**
+  ([Arroyo](https://www.arroyo.dev/blog/fast-arrow-json-decoding/)); raw-reader rewrite ~2.5× over
+  the `serde_json::Value` intermediate ([#3479](https://github.com/apache/arrow-rs/pull/3479)).
+- **ConnectorX (VLDB 2022)**: >85% of `pandas.read_sql` is client-side (~40% deserialization / ~40%
+  dataframe conversion) **[MEASURED]**; peak memory 4× final frame. Fixes = pre-allocate destination
+  from metadata, stream small batches, write each converted cell directly into its final slot,
+  compile-time type-conversion codegen. String ablation ~doubles the 16-column lineitem load
+  **[MEASURED]** ([paper](https://www.vldb.org/pvldb/vol15/p2994-wang.pdf),
+  [repo](https://github.com/sfu-db/connector-x)).
+- **ADBC Postgres**: binary wire → Arrow "without ever materialising rows in between" **[SOURCE]**
+  ([docs](https://arrow.apache.org/adbc/current/driver/postgresql.html)).
+- **DataFusion's cautionary tale**: `Vec<ScalarValue>` (owned per-value enums — structurally our
+  `Value`) documented as ~16 B/field overhead + heap indirection, degrading with column count
+  **[SOURCE]** ([#1708](https://github.com/apache/datafusion/issues/1708)); doctrine is "prefer
+  Arrow compute kernels over `ScalarValue`."
+
+## 3. Arrow Flight serving costs
+
+- `FlightDataEncoderBuilder` default max flight data size **2 MiB** (size estimate approximate)
+  **[SOURCE]** ([docs](https://docs.rs/arrow-flight/latest/arrow_flight/encode/struct.FlightDataEncoderBuilder.html)).
+- **Splitting is cheap and at our batch size probably a no-op**: `split_batch_for_grpc_response`
+  sums buffer sizes once per input batch and emits zero-copy `batch.slice()`s; a 2 MiB-targeted
+  batch yields `n_batches == 1`, one slice **[SOURCE]**
+  ([encode.rs](https://arrow.apache.org/rust/src/arrow_flight/encode.rs.html)). **This
+  independently explains #3096's measured ZERO on the framing lever — there was no work to
+  remove.** (Iterator-not-Vec micro-opt: [#10126](http://www.mail-archive.com/commits@arrow.apache.org/msg62674.html).)
+- **One `dictionary_tracker` per stream** — dictionaries not re-sent per batch by default
+  **[SOURCE]**. Only bites if emitting `DictionaryArray`s.
+- **The one unavoidable copy is tonic's**: default codec copies `data_body` into its buffer — a
+  memcpy of the whole IPC body; non-contiguous-buffer proposal open, unimplemented **[SOURCE]**
+  ([tonic #1558](https://github.com/hyperium/tonic/issues/1558)). Plausibly a chunk of our
+  313 ns/row framing; not removable from our side.
+- Upstream sizing guidance is row-count-based (DataFusion `batch_size` 8192 + `coalesce_batches`)
+  **[SOURCE]** ([configs](https://datafusion.apache.org/user-guide/configs.html)). Flight itself is
+  not the ceiling: DoGet measured to ~6000 MB/s, ~95% of link bandwidth **[MEASURED]**
+  ([arXiv 2204.03032](https://arxiv.org/abs/2204.03032)).
+
+## 4. Anti-pattern audit
+
+| Anti-pattern | What fast implementations do | Evidence |
+|---|---|---|
+| `match value_enum` per cell | Bind (source type → Arrow type) once per column at schema-bind; monomorphized/codegen appender per column | arrow-avro `Codec`; ConnectorX macro DSL **[SOURCE]** |
+| Downcast `Box<dyn ArrayBuilder>` per cell | Downcast once per column per batch, then a tight loop | arrow-json/Arroyo **[SOURCE]** |
+| Build owned `String`/`Vec<u8>` then append | Append `&str`/`&[u8]` borrowed from source (`append_value: AsRef`), or `append_block` + view for true zero-copy | arrow-rs API; StringView **[MEASURED]** |
+| Row-major outer loop over cells | Column-major inner loop (row-major outer OK *if* per-column appender resolved outside it) | arrow-avro **[SOURCE]** |
+| Grow builders from zero each batch | `with_capacity(rows, est_bytes)` per batch (capacity NOT retained across `finish()`) | arrow-buffer source **[SOURCE]** |
+
+## 5. Realistic expectations — is our 1.2 µs/row 2× or 10× off?
+
+1. **arrow-avro**: 267 ns/row row-object path (~67 ns/field if the 4-field bench shape) →
+   **~1.07 µs/row estimated at 16 columns**. Our 1.2 µs/row lands almost exactly on the measured
+   row-object-materializing path scaled to our width — the single most informative data point here.
+2. **arrow-json/Arroyo**: 0.4–0.6 µs/record for ~5–10 field records *including parsing raw JSON*.
+   We are not parsing and cost 2–3× that.
+3. **ConnectorX**: 16-column lineitem, single stream = **2.6 µs/row for the entire pipeline** (wire
+   read + deserialize + convert + write). Our 1.2 µs/row is under half a full pipeline while doing
+   only the last stage.
+
+**Judgement: ~1.2 µs/row is ~4–10× off achievable (150–400 ns/row for 15–20 mixed columns).** That
+takes total Flight overhead to ~0.5–0.7 µs/row, with IPC framing (313 ns/row) as the floor and
+dominant term.
+
+## Ranked candidates for the `do_get` build path
+
+1. **Resolve type dispatch + builder downcast once per column per batch; build column-major.**
+   2–4× on the ~1.2 µs/row region (confidence medium-high — arrow-avro 9.6×, arrow-json ~2.5×
+   against structurally identical baselines). Pitfalls: nested types keep per-cell downcasts in
+   naive ports; the win is the tight per-column loop, not the tape. Pre-validate: perf self-time in
+   builder vtable thunks / `field_builder` / `Value` match arms (<10% of build region ⇒ mis-aimed);
+   or an afternoon criterion bench building one RecordBatch two ways from a pre-materialized row set.
+2. **Append borrowed bytes; stop materializing owned `String`/`Vec<u8>` for text/blob cells.**
+   1.3–2× on string-heavy schemas, ~0 on all-primitive (confidence medium — ConnectorX ablation
+   ~2×; gain depends on unmeasured var-len fraction). Pitfalls: the aggressive `Utf8View` form
+   **changes the wire schema** — connector/client compatibility is an owner decision; conservative
+   borrowed-`&str` form has no wire impact, try first; `StringBuilder` 2 GB offset panic at large
+   batches. Pre-validate: allocations/row via dhat/counting allocator (≈ var-len column count ⇒
+   confirmed), + var-len bytes/row histogram per table. Digest oracle makes byte-identity free.
+3. **Per-batch `with_capacity` pre-sizing from a running per-column byte EWMA.** 5–15% (confidence
+   medium; listed third because cheap, not big). Pitfall: the folklore "hoist builders and reuse"
+   does nothing (`finish()` = `mem::take`); undersized data_capacity = geometric realloc + memcpy;
+   oversized inflates RSS vs the 128 MB target / B4 budget. Pre-validate: realloc count per builder
+   per batch via capacity accessors; ≤1–2 ⇒ drop this entirely.
+
+**Explicitly do NOT pursue:** further Flight framing tuning (mechanism-explained zero: one size
+sum + single zero-copy slice at 2 MiB; residual is tonic's upstream memcpy) and schema caching
+(emitted once per stream — nothing recomputed).

--- a/docs/research/throughput-2026-08-cache-footprint-survey.md
+++ b/docs/research/throughput-2026-08-cache-footprint-survey.md
@@ -1,0 +1,143 @@
+# Lane 2 — Minimizing per-row memory footprint in analytical engines
+
+**2026-08-04, owner-commissioned research survey (lane 2 of 3).** Synthesis + verdicts:
+`throughput-2026-08-research-synthesis.md`. Claims tagged MEASURED vs FOLKLORE/inference; our own
+numbers (mission doc §0/§6, #3027 (row-decode attribution)) treated as ground truth.
+
+**Bottom line:** our measured 4.75× amplification (~3.3 KB touched per 692.7 B row) and the
+LLC-capacity scaling mechanism are the exact symptom pair the vectorized-execution literature was
+built to fix — and the canonical fix is not "add threads" or "tune allocators": it is **(a) never
+build the intermediate at all, and (b) size the batch so its working set fits a private cache, not
+the shared one.** The measured origin for (b) is MonetDB/X100, not DuckDB folklore.
+
+## 1. Morsel-driven parallelism — and why it is NOT our lever
+
+Leis et al. (SIGMOD 2014) schedules ~100K-tuple morsels for **NUMA locality and load balance**
+(measured >30× average speedup on 32 cores; "morsel size of about 100,000 tuples yields good
+tradeoff") ([paper](https://db.in.tum.de/~leis/papers/morsels.pdf)). A morsel is a *scheduling*
+unit, **not a cache-resident unit** — the paper outsources cache-sized processing to the vector
+engine. Adopters: DuckDB ([discussion #6632](https://github.com/duckdb/duckdb/discussions/6632)),
+Umbra ([SIGMOD 2021](https://db.in.tum.de/~kohn/papers/query-scheduling-sigmod21.pdf)), Velox
+([dbdb.io](https://dbdb.io/db/velox)). Our box is 6 cores on effectively one NUMA node — morsel
+scheduling buys nothing here. Do not spend effort on it.
+
+## 2. Cache-conscious batch sizing — the measured rule
+
+**MEASURED** ([Boncz/Zukowski/Nes, CIDR 2005](https://www.cidrdb.org/cidr2005/papers/P19.pdf),
+§5.1.1 + Fig. 10): X100 default vector 1024; TPC-H Q1 optimum ~1000, "all values between 128 and 8K
+work well"; performance deteriorates "when intermediate results do not fit in the cache anymore"
+(40 B/row × 8K crossing the 320 KB combined L1+L2 of the test box). Order-of-magnitude swing from
+batch sizing alone (~10 s at size 1, ~0.2–0.3 s at 1K, back toward ~1 s at 4M).
+
+**The rule: `batch_rows × bytes_touched_per_row` should fit the PRIVATE L1+L2, not the LLC.**
+
+Engine settings, with provenance:
+- **DuckDB** `STANDARD_VECTOR_SIZE` = 2048 ([docs](https://duckdb.org/docs/current/internals/vector)).
+  FOLKLORE FLAG: the "chosen to fit L1/L2" rationale appears only in secondary blogs; DuckDB's own
+  docs state no cache-fit rationale. The measured justification traces to X100.
+- **Velox**: `preferred_output_batch_rows` = 1024, `preferred_output_batch_bytes` = 10 MB,
+  `max_output_batch_rows` = 10000 — **sizes by BYTES when row size is known**
+  ([configs](https://facebookincubator.github.io/velox/configs.html)). This is the discipline to
+  adopt; we know our row size.
+- **DataFusion**: default `batch_size` 8192, reduced from 65536 with measured TPC-H SF=10 numbers
+  (Q1: 32000→996 ms, 16000→829, 8000→715, 4000→685 — ~1.45× from batch size alone)
+  ([PR #9834](https://github.com/apache/arrow/pull/9834)).
+- **Photon** (§4.1): batches "to bound memory usage and exploit cache locality"
+  ([SIGMOD 2022](https://people.eecs.berkeley.edu/~matei/papers/2022/sigmod_photon.pdf)).
+
+**Applied to CQLite (INFERENCE — verify actual batch size, D2):** at 3.3 KB touched/row, an
+8192-row batch ≈ 27 MB/core working set; ×6 cores = 162 MB vs 54 MiB LLC — 3× oversubscribed.
+Per-core LLC budget 54/6 = 9 MiB permits ~2,700 rows at 3.3 KB/row, or ~13,600 at the 693 B logical
+width. **The amplification factor is what pushes us over the line — which is why footprint levers
+fix scaling AND base cost.**
+
+## 3. Eliminating intermediate materialization
+
+Where our 2,343 B/row of `estimate_value_size` + `into_owned` lives.
+
+- **arrow-rs Parquet** decodes column-at-a-time straight into Arrow arrays, never building rows:
+  amortized type dispatch, sequential access, "avoid many small heap allocations with a single
+  large allocation"; streams in bounded batches; dictionary preservation measured >60× in cases
+  ([Arrow blog 2022](https://arrow.apache.org/blog/2022/12/26/querying-parquet-with-millisecond-latency/)).
+- **arrow-rs late materialization**: `RowSelection`, `ReadPlanBuilder` (one predicate column at a
+  time, tightening selection), `CachedArrayReader` — "the ultimate performance win is not doing I/O
+  or decoding at all"
+  ([Arrow blog 2025](https://arrow.apache.org/blog/2025/12/11/parquet-late-materialization-deep-dive/)).
+- **Velox Lazy Vectors** (§4.2): populate on first use; selective materialization; computation
+  pushdown "without having to materialize an intermediate Vector"
+  ([VLDB 2022](https://www.vldb.org/pvldb/vol15/p3372-pedreira.pdf)).
+- **Photon** (§3.4): columnar-native scan "can skip a possibly expensive column-to-row pivoting
+  step." **The inverse is our situation**: SSTables are row-oriented, so one pivot is mandatory —
+  but we currently pay it TWICE (bytes → owned row → Arrow) where one (bytes → Arrow builders) is
+  required.
+
+**Equivalent restructuring for a row-oriented format:** decode a bounded row window; within it,
+write each cell directly into the per-column Arrow builder as parsed — no per-row `Value` tree ever
+exists. Column-at-a-time *output* with row-at-a-time *input*. Late materialization applies for
+predicate-bearing scans (decode key/predicate columns first, then survivors' projected columns).
+
+## 4. Allocation strategy: arenas, buffer reuse, drop glue
+
+- **Photon buffer pool** (§4.5): transient column batches from an internal MRU pool — "keeps hot
+  memory in use for repeated allocations for each input batch"; per-batch allocation count is fixed
+  once operators are fixed.
+- **Velox Buffers** (§4.2): contiguous, memory-pooled, refcounted, copy-on-write.
+- **MEASURED Rust analogue** ([oxc, Rust Magazine](https://rustmagazine.org/issue-3/javascript-compiler/))
+  — deep enum trees + allocation churn, the closest published shape to ours:
+  - arena for the AST: **~20% improvement** (motivated by profiler showing heavy `drop` time — our
+    exact 949 B/row drop-glue symptom);
+  - boxing enum variants (to 16 B): **~10%**;
+  - `usize`→`u32` span fields: up to 5%.
+- **bumpalo** ([docs](https://docs.rs/bumpalo/latest/bumpalo/)): mass deallocation ≈ pointer reset
+  — collapses drop glue by construction. Caveat: `Drop` is skipped unless `bumpalo::boxed::Box`;
+  resource-owning values need explicit handling.
+
+## 5. SoA vs AoS and enum-heavy `Value` types
+
+- Rust enum size = largest variant + tag; types >128 B trigger `memcpy`; box outsized variants
+  ("more likely a net win if the outsized variant is rare")
+  ([Rust Performance Book](https://nnethercote.github.io/perf-book/type-sizes.html) — guidance, no
+  percentages; the measured numbers are oxc's above).
+- AoS with a tagged union pays max_variant_size per element regardless of stored variant; a
+  `Value`-shaped enum reaches ~48–56 B ([dense enums](https://alic.dev/blog/dense-enums)); at ~12
+  columns that is ~670 B/row of enum scaffolding before payload — nearly doubling a 693 B row.
+- **How engines avoid it: no per-row tagged union at all.** Photon stores column values
+  contiguously with a null byte-vector + position list; type known once per *column vector*, not
+  per *value* (and it tested + rejected the bitmask alternative). Velox: size + type + nullability
+  bitmap per Vector. **The tag moves from per-value to per-column — that is the whole trick.**
+
+## Ranked candidates (confidence stated for magnitude, not direction)
+
+1. **Fuse size accounting into decode; delete the standalone `estimate_value_size` traversal.**
+   Gap: BOTH. Removes up to 1,398 B/row = 42% of touched bytes; expected 15–30% scan path
+   (confidence: high on bytes, medium on wall-clock). Risk LOW — but the v0.13 byte-bounded result
+   budgets must keep identical semantics (encoded vs decoded size definitions must agree first).
+   Pre-validate: stub it to a constant in a throwaway branch; re-run the #3027 profile (<1 h).
+2. **Byte-budgeted batch sizing (adopt Velox's `preferred_output_batch_bytes`).** Gap: 6-core
+   scaling primarily. X100 Fig. 10 + DataFusion PR show 1.4–3× when straddling a boundary — which
+   the 3× oversubscription estimate says we are (confidence medium; near-zero if current batch is
+   already ~1K rows — VERIFY). Risks: per-batch + framing overhead regression (#3096's measured
+   framing zero is adjacent); LLC budget is 54 MiB / concurrent_scans, not /6 (admission
+   interaction). Pre-validate: sweep 256/1K/2K/4K/8K/16K rows; plot rows/s AND LLC-misses/row at 1
+   and 6 cores (~2 h; diagnostic even if nothing changes).
+3. **Decode straight into Arrow builders — retire the owned row on the scan→Flight path.** Gap:
+   BOTH — the structural fix. Eliminates `into_owned` (945 B/row) + most drop glue (949 B/row) ≈
+   58% of touched bytes; composes with #1 to ~99% of measured intermediate traffic. Confidence
+   medium-high on bytes, medium end-to-end (Amdahl). Risk HIGH: read-time reconciliation
+   (tombstones, TTL, multi-SSTable merge) operates on owned rows — either builders accept
+   out-of-order/retracted rows or reconciliation moves upstream. Acceptance gates MUST be the
+   query-semantics oracle + point-vs-full differential (#1918) — the JSONL physical goldens are
+   blind to reconciliation bugs, and a CQLite-written round-trip is invariant to symmetric errors.
+   Pre-validate: prototype ONE fixed-width column on a single-SSTable no-merge path; measure
+   bytes-touched/row vs current (~1 day). Do after #1/#2 reveal remaining headroom.
+4. **Arena-allocate per-batch decode scratch + shrink the `Value` enum** — the partial-credit
+   version of #3. oxc analogue: ~20% (arena, attacking the 949 B/row drop glue) + ~10% (boxing).
+   Confidence medium (someone else's numbers, compiler AST not scan pipeline). Risks: arena
+   lifetimes at API boundaries; bumpalo skipping `Drop`; boxing costs indirection on hot common
+   variants. Pre-validate: (a) `size_of::<Value>()` + per-variant sizes (10 min); (b) synthetic
+   100K-row build-and-drop bench, current allocator vs bumpalo (no engine changes).
+
+**Sequencing:** run #4(a)'s size_of probe and #2's batch sweep FIRST (hours, diagnostic regardless
+of outcome). Then #1 (cheapest real win, best byte-per-effort). Use results to decide #3 vs #4.
+Given #3096 (two levers measured at exactly zero), **a day of measurement before a week of
+refactoring is the pattern our own history endorses.**

--- a/docs/research/throughput-2026-08-research-synthesis.md
+++ b/docs/research/throughput-2026-08-research-synthesis.md
@@ -1,0 +1,116 @@
+# 0.17 throughput — established-engineering survey: SYNTHESIS
+
+**2026-08-04. Owner-commissioned, three parallel research lanes.** The owner's question: *"It sounds
+like we aren't using cores efficiently — one thread per core, no context switches, no cache
+invalidation. Research how these problems have been solved in Rust."* Companion lane reports (full
+citations there; this file carries only the conclusions):
+
+- `throughput-2026-08-tpc-runtime-survey.md` — thread-per-core runtimes (lane 1)
+- `throughput-2026-08-cache-footprint-survey.md` — cache-footprint engine design (lane 2)
+- `throughput-2026-08-arrow-build-path-survey.md` — arrow-rs production build paths (lane 3)
+
+Ground truth throughout = the measured numbers in `docs/architecture/0.17-throughput-mission.md`
+(§0, §6): per-core gap A = 1.52 µs/row (1.2 µs unattributed), scaling gap B = LLC capacity
+contention, bytes touched ≈ 3.3 KB per 692.7 B logical row (#3027 (row-decode attribution)).
+
+---
+
+## 1. Verdicts
+
+### Thread-per-core: NO (mechanism mismatch, with physics)
+
+- Every documented TPC win (Seastar/ScyllaDB, Redpanda, monoio, Enberg ANCS'19) is a
+  coherence/locking/scheduling/syscall win; **none is an LLC-capacity win**, and the public evidence
+  base is network echo benchmarks, not CPU-bound columnar streaming.
+- Our counters already acquit what TPC fixes: blocked time ≤0.07%, zero voluntary parks,
+  instructions/row flat (#3217 (full-box C(N)), #3224 (LLC attribution)).
+- **Pinning cannot partition the LLC**: Ice-Lake-class LLCs are hash-sliced *by address*, not
+  core-owned (Maurice et al., RAID'15). A migrated task refetches through L1/L2, not LLC — and our
+  L1d misses are **flat** while LLC misses triple, which affirmatively acquits work-stealing
+  migration as the gap-B mechanism.
+- The one TPC benefit that transfers — bounding concurrent live working sets — is available from
+  admission control we already ship (`--max-concurrent-scans`), by making it footprint-aware.
+
+### The convergent diagnosis: the owned `Value` row intermediate is BOTH gaps
+
+All three lanes independently land on the same structure. We pay a **double pivot**
+(SSTable bytes → owned `Value` row tree → Arrow builders) where one pivot is required; the
+intermediate is why we touch 4.75× the logical bytes per row. The fat intermediate is
+simultaneously the per-core tax (gap A) and the LLC footprint that stops fitting at 6 cores (gap B)
+— which is why footprint levers are the rare class that moves both.
+
+### The 1.2 µs/row mystery now has a NAMED SUSPECT with an external anchor
+
+arrow-avro (in-tree, benchmarked) measured **exactly our architecture** — "deserialize one record
+at a time into native Rust values, then build Arrow arrays from those values" — at **9.6× slower**
+than its column-first decoder (267 ns/row vs 27.9 ns/row on its bench schema; ~67 ns/field for the
+slow path, estimating **~1.07 µs/row at our column width**). Our unattributed 1.2 µs/row lands
+almost exactly on the measured row-object path scaled to our width. Cross-anchors agree
+(arrow-json/Arroyo 0.4–0.6 µs/record *including* JSON parsing; ConnectorX 2.6 µs/row for an entire
+DB-client pipeline). **Judgement: our build region is ~4–10× off achievable (150–400 ns/row for
+15–20 mixed columns), not 2× off.**
+
+### Retro-validation of #3096's two zeros (mechanism-level, raises rig confidence)
+
+- Flight framing lever = zero because `split_batch_for_grpc_response` at a 2 MiB target computes one
+  size sum and emits a **single zero-copy slice** — there was no work to remove.
+- Schema-cache lever = zero because the encoder emits the schema **once per stream** — nothing was
+  recomputed.
+- The remaining framing cost is tonic's whole-body memcpy (tonic #1558, open upstream) — our
+  measured 313 ns/row IPC framing is near the practical floor from our side.
+
+### The per-core arithmetic now closes
+
+Achievable build (150–400 ns/row) + framing floor (~313 ns/row) ≈ **0.5–0.7 µs/row total Flight
+overhead**, vs today's 1.52. On bare scan's 2.44 µs/row that projects `do_get` ≈ **318–340k rows/s
+per core — above the old 1.3× per-core bar (315,730)**. The per-core target is reachable through
+the build path alone, per external anchors. (Projection, not a measurement — #3248 must confirm the
+cost is where the anchors say it is.)
+
+### Batch-size math (estimate — VERIFY, this is D2/E2's job)
+
+At the 2 MiB Flight target and ~675 B/row wire, a batch ≈ ~3,100 rows; × 3.3 KB touched/row ≈
+**~10 MB working set per in-flight batch region; 6 cores ≈ 61 MB vs a 54 MiB LLC** — right at the
+contention boundary, consistent with the measured miss tripling. X100 (CIDR'05, Fig. 10) is the
+measured precedent that batch sizing alone moves this class by 1.4–3× when straddling a boundary;
+DataFusion re-measured the same (batch 32k→4k: Q1 996→685 ms).
+
+---
+
+## 2. Diagnostics slate (hours each; run BEFORE any lever — #3096 discipline)
+
+| ID | Probe | Cost | Validates/kills | Where |
+|---|---|---|---|---|
+| **D1** | `size_of::<Value>()` + per-variant sizes | 10 min | enum-shrink headroom (L4) | any box |
+| **D2** | Batch-size sweep (rows/s AND LLC-misses/row, S=1 + S=6) | ~2 h | L2 batch sizing; = X100 Fig. 10 on our corpus | metal box (#3299 E2) |
+| **D3** | Stub `estimate_value_size` → constant; re-profile | ~1 h | L1 (42%-of-bytes claim) | any box |
+| **D4** | Allocations/row + reallocs/builder/batch (dhat / counting allocator) | ~2 h | L3b borrowed-bytes; L3c pre-sizing | any box |
+| **D5** | perf self-time: builder vtable thunks / `field_builder` downcasts / `Value` match arms | ~2 h | L3a column-first aim check (<10% ⇒ mis-aimed) | perf-capable box |
+| **E1** | `resctrl`/CMT `llc_occupancy` per scan, S=1 + S=6 | ~1 h | capacity hypothesis directly | metal box (#3299) |
+
+**Pre-registered prediction (for #3248):** D5 finds per-cell dispatch + owned-row
+materialization ≈ 0.8–1.0 µs/row of the 1.2; D4 finds allocations/row ≈ count of var-len columns.
+If NOT, the arrow-avro analogy fails and L3 must not be funded.
+
+## 3. Lever slate (ranked; fund only after the matching diagnostic)
+
+| ID | Lever | Gap | Expected | Risk | Gate |
+|---|---|---|---|---|---|
+| **L1** | Fuse size accounting into decode; delete the standalone `estimate_value_size` walk (1,398 B/row = 42% of touched bytes) | BOTH | 15–30% scan path | LOW — but verify encoded-vs-decoded size semantics for the v0.13 byte budgets first | D3 |
+| **L2** | Byte-budgeted batch sizing (Velox `preferred_output_batch_bytes` model; budget = LLC/concurrent_scans, not LLC/6) | B mostly | 1.4–3× on the scaling loss IF D2 shows a knee | LOW-MED — small batches raise per-batch + framing overhead; interacts with admission | D2/E2 |
+| **L3a** | Column-first build: resolve type dispatch + builder downcast ONCE per column per batch; tight per-column loops; per-batch `with_capacity` (NOT builder-object reuse — `finish()` is `mem::take`, capacity is not retained) | A | 2–4× on the 1.2 µs/row region | MED — nested types (`StructBuilder` re-downcasts per call) are where naive ports lose the win | D5 |
+| **L3b** | Append borrowed bytes for text/blob (`append_value(impl AsRef<[u8]>)`); conservative form only — `Utf8View`/`append_block` changes the WIRE schema (connector compatibility = owner decision) | A | 1.3–2× on string-heavy schemas | MED | D4 |
+| **L3c (full)** | Retire the owned row on the scan→Flight path entirely (decode → builders) | BOTH | ~58% of touched bytes | **HIGH** — reconciliation (tombstones/TTL/merge) operates on owned rows; acceptance gates MUST be the query-semantics oracle + point-vs-full differential (#1918), never the JSONL goldens (symmetric-oracle blind spot) | prototype 1 fixed-width column, single-SSTable, no-merge path first |
+| **L4** | Arena (bumpalo) per-batch scratch + box outsized `Value` variants — partial credit if L3c is too expensive (oxc analogue: ~20% + ~10%) | BOTH | ~20-30% | MED — bumpalo skips `Drop`; hazard for resource-owning variants | D1 + synthetic arena bench |
+| **L5** | Footprint-aware `--max-concurrent-scans` (cap = effective_LLC × safety / bytes_per_scan) | B stability | small on peak, large on overload stability | LOW | E1 |
+
+**Do NOT pursue:** runtime migration (glommio is seeking maintainers; monoio evidence is echo
+benchmarks), further Flight framing tuning (mechanism-explained zero), morsel-driven scheduling
+(a NUMA/load-balance tool; our box is one node — the cache-resident unit is the vector, which is L2).
+
+## 4. Relationship to the mission doc
+
+Slots directly into the two-gap frame (mission §6): L3a/b + L1 are the gap-A program #3248 must
+license; L2 + L5 (+ L3c's byte cuts) are the gap-B program #3288 must license; #3299's E1/E2 arms
+adjudicate the capacity mechanism directly. Nothing here is funded until its diagnostic passes —
+the #3096 lesson, applied in advance.

--- a/docs/research/throughput-2026-08-tpc-runtime-survey.md
+++ b/docs/research/throughput-2026-08-tpc-runtime-survey.md
@@ -1,0 +1,139 @@
+# Lane 1 — Thread-per-core in Rust vs. our measured LLC-capacity ceiling
+
+**2026-08-04, owner-commissioned research survey (lane 1 of 3).** Synthesis + verdicts:
+`throughput-2026-08-research-synthesis.md`. Claims tagged MEASURED vs FOLKLORE; our own numbers
+(mission doc §0/§6) treated as ground truth.
+
+**Bottom line:** every documented win of thread-per-core (TPC) is a *coherence, synchronization,
+scheduling, or OS-interface* win. None of the primary sources claims — or measures — an **LLC
+capacity** win. Our measured signature (LLC-load-misses/row 11.9→38.1 while instructions/row, L1d
+loads/misses, and branch-misses stay flat within 1.3%) is the signature TPC does **not** address.
+Recommendation: against a runtime migration; for two footprint/admission levers plus one
+per-core-path audit.
+
+## 1. Seastar / ScyllaDB / Redpanda — what TPC actually solved
+
+**MEASURED / claimed by authors:**
+- Seastar's rationale names locks ("unscalable programming practices (such as taking locks) can
+  devastate performance on many cores"), atomics, and memory-ordering fences — "dramatically slower
+  than operations that involve only data in a single core's cache"
+  ([Seastar tutorial](https://github.com/scylladb/seastar/blob/master/doc/tutorial.md)). That is
+  **coherence traffic and cache-line bouncing**, not cache capacity.
+- ScyllaDB's 2024 post is qualitative: thread contention, uneven resource distribution, latency
+  spikes; **no cache measurements, no LLC discussion**; the linear-scaling claim is unsourced
+  ([ScyllaDB](https://www.scylladb.com/2024/10/21/why-scylladbs-shard-per-core-architecture-matters/)).
+- Redpanda names context-switch overhead, heavy concurrency control, kernel buffer cache — **no
+  benchmark numbers**
+  ([Redpanda](https://www.redpanda.com/blog/engineering-redpanda-multi-core-hardware);
+  [QCon 2023](https://qconlondon.com/presentation/mar2023/performance-adventures-thread-core-async-redpanda-and-seastar)).
+- The one peer-reviewed measurement: Enberg et al., ANCS'19 — TPC KV store cut tail latency up to
+  71% vs Memcached ([paper](https://penberg.org/papers/tpc-ancs19.pdf)); its own attribution is IRQ
+  affinity, request steering, syscall overhead, NUMA; concedes shared-nothing "can limit system
+  throughput for skewed workloads." No cache counters for its "cache efficiency" aside.
+
+**FOLKLORE:** "TPC improves cache locality" — asserted by Seastar/Datadog/monoio docs, measured by
+none of them. HN practitioner consensus is about *contention*, not capacity
+([HN 38503439](https://news.ycombinator.com/item?id=38503439)).
+
+**Counterpoint:** Seastar *statically and equally divides memory between shards*
+([docs](https://docs.seastar.io/master/split/24.html)). Over a shared read-only mmap'd corpus,
+per-shard partitioning tends to *duplicate* per-shard structures — the wrong direction for a
+capacity-bound workload.
+
+## 2. Rust TPC runtimes — maturity, and what their benchmarks measure
+
+| Runtime | Status | Benchmark shape | Relevance |
+|---|---|---|---|
+| [glommio](https://github.com/DataDog/glommio) | Alive but fragile — open ["Call for maintainers"](https://github.com/DataDog/glommio/issues/707) (Mar 2026) | [Launch post](https://www.datadoghq.com/blog/engineering/introducing-glommio/): zero benchmarks; cites Enberg | Low (io_uring + I/O-bound thesis) |
+| [monoio](https://github.com/bytedance/monoio) | Production at ByteDance ([monolake](https://github.com/cloudwego/monolake) proxies) | [100-byte network echo](https://github.com/monoio-rs/monoio/blob/master/docs/en/benchmark.md): ~2× tokio @4 cores, ~3× @16; *worse* than tokio at 1 core | Low (syscall/IRQ amortization, not decode) |
+| [tokio-uring](https://github.com/tokio-rs/tokio-uring) | Explicitly young, sparse releases | n/a | Low |
+
+**There is no published TPC-vs-tokio benchmark for CPU-bound columnar streaming.** Every headline
+number is a network echo test. Adopting TPC for our shape would be extrapolation, not replication.
+
+## 3. tokio work-stealing's cache cost — and what analytical engines do
+
+- Tokio's scheduler post is about **L1/L2 message-passing latency**, not LLC; the LIFO-slot fix
+  bought chained_spawn 12×, ping_pong 2.3×, Hyper +34% — all message-passing microbenchmarks
+  ([tokio.rs](https://tokio.rs/blog/2019-10-scheduler)).
+- **Mechanism check against our data:** Ice-Lake-class LLCs are shared, non-inclusive, distributed
+  as ~1.5 MiB slices ([WikiChip](https://fuse.wikichip.org/news/4734/intel-launches-3rd-gen-ice-lake-xeon-scalable/)),
+  lines homed to slices by an undocumented **address hash**, not the reading core
+  ([Maurice et al., RAID'15](https://cmaurice.fr/pdf/raid15_maurice.pdf)). A migrated task pays
+  L1d/L2 refill; the line is *still in LLC*. Migration inflates L1/L2 misses, **not** LLC misses.
+  Our L1d loads/misses are flat within 1.3% while LLC misses tripled — **affirmative evidence that
+  work-stealing migration is not our mechanism.**
+- **InfluxDB IOx** uses tokio *for* CPU-bound analytics; its `DedicatedExecutor` protects tail
+  latency/liveness, **not** cache behavior; per-task overhead "~10 nanoseconds range," amortized by
+  vectorizing thousands of rows per task
+  ([InfluxData](https://www.influxdata.com/blog/using-rustlangs-async-tokio-runtime-for-cpu-bound-tasks/)).
+- **DataFusion**: core scaling is a known open problem; `RepartitionExec` round-robin "is not NUMA
+  friendly" — qualitative, no measured cache numbers
+  ([datafusion#7001](https://github.com/apache/datafusion/issues/7001)).
+- **Polars** is rayon ([docs](https://docs.pola.rs/user-guide/misc/multiprocessing/)) — which also
+  work-steals. Analytical engines avoid *fine-grained* stealing by making the unit a batch, not by
+  avoiding stealing.
+- **tokio has no core-pinning API**; `Builder::on_thread_start` + `core_affinity` makes pinning a
+  ~20-line experiment, not a migration
+  ([docs.rs](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html)).
+
+## 4. Adjudication: does TPC help an LLC-*capacity* problem?
+
+**Steelman FOR (the one argument that survives):** run-to-completion bounds simultaneously-live
+working sets to one per core; under tokio, K in-flight scans across W workers make live footprint ≈
+tasks-in-flight × per-scan state. If S=6 has >6 live scans resident, TPC would shrink aggregate
+footprint. This is the morsel-driven insight
+([Leis et al., SIGMOD'14](https://dl.acm.org/doi/10.1145/2588555.2610507)) — achieved *with*
+work-stealing at coarse granularity.
+
+**Steelman AGAINST (stronger, on our hardware):**
+1. **Pinning cannot partition a hash-sliced LLC** ([RAID'15](https://cmaurice.fr/pdf/raid15_maurice.pdf));
+   only Intel CAT/RDT partitions ways ([Intel RDT](https://www.intel.com/content/www/us/en/architecture-and-technology/resource-director-technology.html),
+   [CMU TR](https://www.cs.cmu.edu/~sboucher/tr2017.pdf)) — and CAT redistributes, it does not create.
+2. **Shared-socket caveat**: 54 MiB is the full-socket L3 of the Xeon 8375C behind i4i
+   ([AWS](https://aws.amazon.com/ec2/instance-types/i4i/)); a virtualized slice shares it with
+   co-tenants no runtime can reach. (Our #3224 numbers are from i4i.metal — single-tenant — but
+   production pods on shared slices face this.)
+3. **TPC tends to increase footprint** via per-shard duplication; over a shared read-only mmap,
+   sharing is the asset.
+4. Our counters already acquitted what TPC fixes.
+
+**Verdict: TPC is the wrong-shaped lever for the measured mechanism.** Its one transferable benefit
+— bounding concurrent live working sets — is available from admission control we already ship
+(`--max-concurrent-scans`), at ~0 architectural cost. The mechanism-matched lever for a capacity
+ceiling is the X100/DuckDB one: shrink the per-unit working set
+([MonetDB/X100, CIDR'05](https://www.cidrdb.org/cidr2005/papers/P19.pdf);
+[DuckDB vectors](https://duckdb.org/docs/current/internals/vector);
+[DataFusion configs](https://datafusion.apache.org/user-guide/configs.html)).
+
+## 5. Cheapest falsifiable experiments (adopted into #3299's protocol)
+
+- **E1 — direct occupancy (~1 h, first):** Linux `resctrl` / Intel CMT `llc_occupancy` per
+  monitoring group at S=1 and S=6. Occupancy/scan ~constant and Σ crossing effective LLC at S≈4–6 ⇒
+  capacity confirmed (lever = footprint/admission; TPC dead). Σ well under 54 MiB while misses
+  triple ⇒ capacity hypothesis wrong (suspect prefetcher throttling, TLB, co-tenant eviction).
+- **E2 — footprint sweep at fixed S=6 (~half day, the discriminator):** hold 6 threads, vary
+  per-scan working set ~4× across ~4 points; plot LLC-misses/row AND rows/s vs Σ footprint. Knee
+  near effective LLC ⇒ capacity confirmed and the batch-sizing lever is licensed + sized; flat ⇒
+  the footprint lever is dead before anyone writes it.
+- **E3 — pin / N single-threaded runtimes (~1 day, optional last):** expected null given §4; a
+  citable closure either way. If misses drop materially, migration-driven resident-set duplication
+  was real — and pinning alone captured it without changing runtimes.
+
+## Ranked candidates (max 3)
+
+1. **Right-size the per-scan working set (batch rows + read-ahead/decode buffers) to a stated LLC
+   budget.** Gap: 6-core scaling. Recover roughly half to two-thirds of the 29% marginal loss if E2
+   shows a knee (mechanism confidence high, magnitude medium-low). Validate: E2, reporting rows/s
+   alongside misses/row (tiny-batch overhead is DataFusion-documented).
+2. **Make `--max-concurrent-scans` LLC-footprint-aware** (cap = effective_LLC × safety /
+   bytes_per_scan from E1). Gap: scaling stability under overload; low confidence it raises peak.
+   Honest limit: co-tenant LLC pressure is unobservable — budget must be measured, not computed.
+3. **Audit the do_get path for per-ROW work across the 4 stacked bounded channels.** Gap: per-core
+   base (1.2 µs/row is far too large for tokio's ~10 ns/task amortized overhead — if any hop is
+   per-row rather than per-batch, that is the mispricing). Validate: count channel sends and
+   allocations per 1M rows; sends/row ≫ 4/batch ⇒ fix batching granularity, not the runtime.
+
+**Explicitly NOT recommended:** migrating to glommio/monoio/tokio-uring, or restructuring to
+shared-nothing. Mechanism unmatched; evidence base is echo benchmarks; glommio is seeking
+maintainers; the cheap subset (pinning) is testable in a day as E3 without committing to anything.


### PR DESCRIPTION
## What

Four research docs under `docs/research/` from the owner-commissioned 2026-08-04 survey ("should we go thread-per-core?"), three parallel lanes + synthesis:

- **`throughput-2026-08-research-synthesis.md`** — verdicts: TPC **rejected** (mechanism mismatch with the measured LLC-capacity contention, with physics — hash-sliced LLC cannot be partitioned by pinning; our flat L1d misses already acquit work-stealing migration); convergent diagnosis = the **owned `Value` row intermediate** (double pivot, 3.3 KB touched per 693 B row) drives BOTH gaps; external anchor (arrow-avro's measured 9.57× row-object-vs-column-first) lands our unattributed 1.2 µs/row almost exactly on the measured slow path at our width; diagnostics slate D1–D5/E1–E2 and lever slate L1–L5, every lever gated on its diagnostic (the #3096 (encode levers zero) lesson applied in advance).
- **`throughput-2026-08-tpc-runtime-survey.md`** — Seastar/ScyllaDB/Redpanda/glommio/monoio/tokio evidence review; E1 (resctrl occupancy) / E2 (footprint sweep) / E3 (pinning, expected null) experiment designs — already adopted into #3299's protocol.
- **`throughput-2026-08-cache-footprint-survey.md`** — X100/DuckDB/Velox/Photon/morsel-driven catalog; the measured batch-sizing rule (fit PRIVATE L1+L2); oxc arena/enum-shrink analogues; ranked L1–L4.
- **`throughput-2026-08-arrow-build-path-survey.md`** — arrow-rs builder economics (finish() = mem::take, per-cell downcast trap, borrowed-bytes appends, view builders); arrow-avro/arrow-json/ConnectorX anchors; **mechanism-level retro-explanation of both #3096 zeros** (split_batch at 2 MiB = one zero-copy slice; schema emitted once per stream); achievable build = 150–400 ns/row.

## Verification (docs-only)

Code-free census — not roborev-certifiable by doctrine; substitute is primary-source verification: every performance claim carries its citation inline (papers, arrow-rs source, project docs), MEASURED vs SOURCE vs FOLKLORE tagged per claim, and all CQLite-side numbers are quoted from the mission doc §0/§6 and #3027/#3096/#3217/#3224 as already established. Inferences (batch-size arithmetic, per-field normalization) are flagged as estimates with the verifying diagnostic named.

Related: #2817 (0.17 epic), #3023 (exploration umbrella), #3299 (box ceiling — E1/E2 adopted), #3248 (gap-A profile — predictions pre-registered), #3288 (locality lever).