### PR TITLE
chore: plain-Claude default sessions (drop flow-lead default agent + startup board hook)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "agent": "flow-lead",
   "env": {
     "ISSUE_GATE_TEST_CMD": "scripts/agent-gate.sh --lite",
     "ISSUE_GATE_COVERAGE_CMD": "",
@@ -58,16 +57,6 @@
   },
   "includeCoAuthoredBy": false,
   "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'flow-lead: before anything else, orient \u2014 run the flow-board skill to render the CQLite Delivery claim board (open issues by Status + claims) and surface the single furthest-along item waiting on the owner (a green PR to merge, a spec to approve), or a claim-aware pick-list. Do not wait for a prompt.'"
-          }
-        ]
-      }
-    ],
     "TaskCompleted": [
       {
         "hooks": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -622,7 +622,7 @@ A feature is done only when its public surface exercises it — a named surface 
 end-to-end test. Green helper-only unit tests are not sufficient.
 
 ### Delivery pipeline (flow-lead)
-- **`flow-lead`** orchestrates (the repo's default agent; `claude --agent flow-lead`) — it spawns
+- **`flow-lead`** orchestrates (opt-in: `claude --agent flow-lead`; plain sessions are default Claude) — it spawns
   and sequences the specialists + roborev + the gate, and writes no production code. Verbs:
   `flow-groom` → `flow-activate` (**Seam 1**: owner approves spec + design) → `flow-implement` (the
   implement loop above) → `flow-address` → `flow-finalize`; `flow-board` = status + the single next


### PR DESCRIPTION
## What

Owner decision 2026-08-04: a bare `claude` session in this repo should be **plain Claude Code**, not auto-flow-lead.

- `.claude/settings.json`: remove `\"agent\": \"flow-lead\"` (the default-agent persona) and the `SessionStart` hook (the "orient from the board, do not wait for a prompt" nudge). **Everything else unchanged**: env, all 42 permission rules, `includeCoAuthoredBy`, and the `TaskCompleted` issue-gate hook.
- `CLAUDE.md`: the one doctrine line that called flow-lead "the repo's default agent" now reads opt-in (`claude --agent flow-lead`) — kept current in the same change per convention.

## Fleet impact: none

`scripts/local/worker-supervisor.sh:292` launches workers with `--agent flow-lead` **explicitly** and hands them the `/worker` skill directly — neither removed setting is load-bearing for unattended workers. Attended lead sessions remain one flag away.

## Verification

`jq -e` validates the edited settings.json; post-edit checks confirm `agent` absent, `hooks` contains only `TaskCompleted` (command intact), and `permissions.allow` still has 42 rules. Config + docs only — no compiled input in the diff.