### PR TITLE
feat: /drive-issue command — single-issue driver with coord comms + cron re-checks

### DIFF
--- a/.claude/commands/drive-issue.md
+++ b/.claude/commands/drive-issue.md
@@ -1,0 +1,105 @@
+---
+description: Use when told to drive, run, or own ONE named cqlite issue to done/merged in this session (e.g. "drive issue 3272"), including unattended runs where lead/owner answers arrive asynchronously on the issue thread. Requires an issue number argument.
+---
+
+# /drive-issue <N> — drive one named issue to green and merged, with coord comms + cron re-checks
+
+**Issue:** `$ARGUMENTS` — required, exactly one issue number. No argument, or not a number → say so
+and stop; never guess an issue or fall back to the Ready column.
+
+You are a **flow-lead worker bound to exactly ONE issue**. Your baseline operating rules are
+`.claude/commands/worker.md` — read it and obey ALL of it: context discipline (you orchestrate;
+subagents implement, gate, and review — explicit `model:` on every spawn), worktree isolation
+(never touch the root checkout), the claim protocol (`claim.sh` ref FIRST), the implement loop
+(TDD → `--lite` each round → review-first → PR → `flow-closer` endgame), finalize + telemetry, and
+every hard rule (gate summary-file contract with the `PASS|FAIL` probe, roborev ONLY via
+`scripts/flow/roborev-review.sh --agent … --model …`, merge ONLY via `gh pr merge --auto`, never
+poll your own PR's CI, `CQLITE_DATASETS_ROOT` from the fetch script's printed export, commit early
+and often).
+
+The FOUR deltas below OVERRIDE worker.md wherever they conflict. Everything else: worker.md wins.
+
+## Delta 1 — Issue selection is fixed, not board-picked
+
+You take **issue #$ARGUMENTS only**. Never a second issue, never a substitute.
+
+- Board `Status=Done` or issue closed → report "already done" and stop.
+- `claim.sh claim <N>` returns `CLAIM LOST` → another machine owns it; report the holder and stop.
+  Adoption of a reaped/legacy claim follows ONLY the documented `adopt` procedure (CLAUDE.md) after
+  confirming abandonment — never race a live lane.
+- Board `Status=Backlog` → the issue is deliberately not dispatchable (usually gated on another
+  issue — read its thread). Report why and stop; do not "helpfully" promote it yourself.
+
+## Delta 2 — Comms are github-coord, not manager-signed comments
+
+At session start, run the **`github-coord:github-coord-worker`** skill and announce it on your
+first issue comment. ALL upward communication goes through its protocol on issue #N's thread:
+
+- One request marker per question; `coord:needs-attention` for decisions/questions,
+  `coord:blocked` when you cannot make dependency-safe progress, `coord:follow-up-proposed` for
+  scope you want split out. Those three labels are the ONLY tracker metadata you touch.
+- **Never `AskUserQuestion`.** A prompt in an unattended session is a hang (#2666); the coord
+  request + Delta 3's cron replaces it entirely.
+- The LEAD clears coord labels, never you. You may proceed the moment a response comment
+  **pairing your request ID, strictly newer than your request**, exists — even if the label is
+  still on.
+- Do not decide spec-ambiguous questions alone; resolve from (in order) approved spec, issue
+  acceptance criteria, CLAUDE.md doctrine, repo state — and escalate only what those cannot decide.
+
+## Delta 3 — Waiting = ONE cron re-check, never park-and-exit, never an in-session poll
+
+When you are blocked on a lead/owner response (Seam-1 spec approval, a decision request, a HOLD):
+
+1. Post the coord request (marker + label) with your recommendation and a default.
+2. Record durable state in the worktree: `.drive-issue-state.md` — stage reached, open request ID,
+   PR/branch, timestamp (`date -u`).
+3. **Arm the cron**: `CronList` first — if a job named `drive-issue-<N>` already exists, do NOT
+   create another. Else `CronCreate` name `drive-issue-<N>`, interval ~15 minutes, prompt exactly:
+   `/drive-issue <N>`. The command is resume-safe (Delta 4), so each firing rehydrates, checks for
+   an answer, and either continues the pipeline or goes back to sleep.
+4. Refresh the claim heartbeat (`claim-heartbeat.sh beat <N>`), then **end the turn cleanly**. The
+   cron does the waiting — no `sleep`, no in-session polling loop, no exiting-and-abandoning.
+
+**Cron hygiene (non-negotiable):** exactly one cron per issue, named `drive-issue-<N>`.
+`CronDelete` it the moment you are unblocked, and ALWAYS at merge/finalize/stop/kill — a leaked
+cron re-invokes forever. Deleting the cron is part of "done"; a report that omits it is incomplete.
+
+`resume-dont-ask` label on the issue = standing Seam-1 seal: proceed without asking or waiting.
+
+## Delta 4 — Every invocation is a RESUME first
+
+On start, BEFORE anything else: `git fetch origin`, then check whether this machine already holds
+`refs/claims/issue-<N>` (`claim.sh verify <N>`) or has the issue worktree.
+
+- **Held → resume**: read `.drive-issue-state.md` + the issue thread. If a pairing response newer
+  than your open request exists → `CronDelete drive-issue-<N>`, clear the state marker's open
+  request, and continue the pipeline from the recorded stage. If not → beat the heartbeat, post
+  nothing, end the turn (the cron persists). Never re-ask an unanswered question — one marker, one
+  wait.
+- **Not held → fresh start**: claim per worker.md step 3, then route (oracle-driven → straight to
+  implement; design-driven → `flow-activate` to Seam 1, render the spec INLINE in an issue comment
+  as the approval request, then Delta 3). The spec render and the coord request are **ONE combined
+  comment** — spec + marker + recommendation + default together — never two posts.
+
+All state is durable outside your context (claim ref, worktree commits, issue thread, OpenSpec
+files, state marker, board) — a fresh session must be able to pick up mid-pipeline from those
+alone. If something exists only in your window, write it down before ending the turn.
+
+## The pipeline (worker.md's, restated in one line)
+
+claim → route (Seam 1 if design-driven, via Delta 3) → `flow-implement` (subagent TDD, `--lite`
+each round, rust-reviewer + sanctioned roborev on the lite-green diff BEFORE any full gate) → open
+PR → `flow-closer` endgame (ONE full gate of record → C intent audit → final roborev →
+`premerge-assert` → `gh pr merge --auto --squash --delete-branch`) → `flow-finalize` (archive,
+telemetry PR, worktree/branch/claim cleanup) → `CronDelete` → closing comment on the issue with the
+terminal packet (verdicts + PR + residuals).
+
+## Red flags — STOP and re-read the matching delta
+
+- About to `AskUserQuestion` → Delta 2: coord request + cron.
+- About to `sleep`, loop-poll the thread, or watch your own PR's CI → Delta 3 / worker.md: the
+  cron (or GitHub's `--auto`) does the waiting; end the turn.
+- About to claim a second issue, or substitute a "better" one → Delta 1: one issue, fixed.
+- About to create a cron without `CronList`, or report done with the cron alive → Delta 3 hygiene.
+- Re-posting a question that already has an open marker → Delta 4: one marker, one wait.
+- Editing labels/milestones/assignees beyond the three `coord:*` labels → Delta 2: not yours.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,9 @@ Skills in `.claude/skills/` activate automatically when relevant:
 | `test-data-management` | Test SSTable generation, validation |
 
 **Delivery pipeline skills**: `flow-groom` → `flow-activate` → `flow-implement` → `flow-address` →
-`flow-finalize`, plus `flow-board` (claim board + next thing). See
+`flow-finalize`, plus `flow-board` (claim board + next thing) and **`/drive-issue <N>`** (drive ONE
+named issue to merged: worker persona + `github-coord-worker` comms + a self-rearming cron that
+re-checks the issue for lead answers while blocked). See
 `docs/development/pm-operating-loop.md`. (`start-epic`/`pm-status` are deprecated pointers → flow-*.)
 
 ## Available Subagents


### PR DESCRIPTION
## What

New project command `.claude/commands/drive-issue.md` — `/drive-issue <N>` drives exactly one named issue to green and merged. Designed as a **thin delta on `/worker`** (all baseline rules inherited by reference — context discipline, worktree isolation, claim protocol, implement loop, closer endgame, finalize):

1. **Delta 1 — fixed issue selection**: takes #N only; refuses on no-arg, CLAIM LOST, closed, or Backlog (gated) — never substitutes or self-promotes.
2. **Delta 2 — github-coord comms**: runs `github-coord:github-coord-worker`; all escalation via request markers + the three `coord:*` labels; `AskUserQuestion` forbidden (#2666).
3. **Delta 3 — cron-wait instead of park-and-exit**: when blocked on a lead/owner answer, posts ONE coord request, records durable state (`.drive-issue-state.md`), arms ONE named cron (`drive-issue-<N>`, ~15 min, prompt = `/drive-issue <N>`), ends the turn. Cron hygiene: `CronList` before create, `CronDelete` on unblock and ALWAYS at finalize — deleting the cron is part of "done".
4. **Delta 4 — resume-safe re-entry**: every invocation rehydrates from claim ref + worktree + issue thread + state marker; answered → continue from recorded stage; unanswered → heartbeat and end turn. One marker, one wait — never re-asks.

CLAUDE.md's delivery-pipeline skills line registers the command in the same change (keep-doctrine-current).

## Verification

Comprehension-tested with a fresh-context agent against seven scenarios (no-arg, Seam-1 sequence, cron-fire-unanswered, CLAIM LOST, done-definition, mid-implementation decision, Backlog status): **7/7 answered correctly from the document alone**; the single flagged soft ambiguity (spec render + coord marker = one combined comment) is closed in this diff. Docs/command-only change — no compiled input.

Related: #2666 (park-and-resume), #2665 (claim ref), #2090 (single-issue sessions), github-coord plugin (installed today).