### PR TITLE
fix(#3296): make the roborev review-guard test portable — the gate of record is RED on macOS

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4614,10 +4614,21 @@ run_clippy() {
 # dataset corpus. Both scripts are SKIP-aware (no python3 -> loud SKIP, exit 0),
 # so this component is safe on a stripped runner; any real violation exits non-zero
 # and FAILs the component.
+#   * test_roborev_guard_portability.sh — the #3296 PLATFORM class: the guard test above
+#     is a shell script that runs on macOS worker boxes and Linux CI, and three GNU-only
+#     constructs in its own scaffolding (`sed -i EXPR FILE`, an operand-less `paste -s`,
+#     and a literal-vs-canonical `--repo` compare over macOS's /var -> /private/var
+#     symlink) made it report `failed: 7` on macOS while every hosted Linux lane was
+#     green — i.e. the LOCAL gate of record was red on the whole fleet and no CI signal
+#     could see it. This test keeps that class out structurally (a construct table whose
+#     every pattern carries a positive control) and behaviourally (the guard test's own
+#     helpers, extracted verbatim, exercised under BSD `sed`/`paste` shims), so the
+#     platform difference is caught on ANY platform. Hermetic, ~1s.
 run_roborev_lints_cmd() {
   bash "$REPO_ROOT/scripts/ci/check-workflow-injection.sh" &&
     bash "$REPO_ROOT/scripts/tests/check-no-wallclock-asserts.sh" &&
-    bash "$REPO_ROOT/scripts/tests/test_roborev_review_guard.sh"
+    bash "$REPO_ROOT/scripts/tests/test_roborev_review_guard.sh" &&
+    bash "$REPO_ROOT/scripts/tests/test_roborev_guard_portability.sh"
 }
 
 run_component() { # run_component <name> <cmd...>

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -689,88 +689,37 @@ else
     fi
   done
 
-  # --- AC2, THE CLASS RATHER THAN THE INSTANCES: no mutation call site may DISCARD the
-  # helper's status. `sed_inplace`/`sed_inplace_verified` return non-zero when the edit did not
-  # land, but that is protection only if the caller READS it; a bare statement call leaves
-  # "matched nothing" (and every other unmeasured state) on the permissive path, so the case's
-  # later assertion can be satisfied by the STALE content — the roborev finding on
-  # test_roborev_review_guard.sh's cx29 restore, which read `ok` on cx28's mutation.
+  # --- DELIBERATELY NOT BUILT: a STRUCTURAL rule that every `sed_inplace`/`sed_inplace_verified`
+  # call in the guard test reads the helper's status (owner ruling, #3296 round 6; the #3283
+  # disposition pattern).
   #
-  # AN ALLOW-LIST, NOT A DENY-LIST (#3296 round-5 blocker 3). The first form of this rule
-  # EXCLUDED lines containing `&&`/`||` anywhere, which accepted `true && sed_inplace "$f" "$e"`
-  # and `sed_inplace "$f" "$e"; true || bad` — two forms in which the mutation's status is
-  # DISCARDED under this script's non-errexit execution. That is the very shape this rule exists
-  # to catch, reintroduced inside the rule: unanticipated spellings inheriting the permissive
-  # branch. So the ACCEPTED forms are now ENUMERATED and everything else FAILs, including forms
-  # nobody anticipated:
-  #   (1) directly controlled:      [if|elif|while|until] [!] sed_inplace… ; then|do
-  #   (2) direct failure handler:   sed_inplace… || bad|return|exit
-  # Both are anchored at the start of the logical line, and NEITHER tolerates `;`, `&` or a single
-  # `|` between the call and its terminator — so `if sed_inplace … || true; then` (a condition that
-  # reads the status and then neutralises it) and `… | foo || bad` are NOT accepted either. That
-  # costs a sed expression delimited with `|` a false FAIL; the marker below is its route.
-  # Deciding "is this status consumed?" in general is shell-semantics analysis and is deliberately
-  # OUT OF BOUNDS. A call in an unlisted form reds the gate with a message saying the FORM was not
-  # recognised, and the author rewrites it into an accepted form (or marks the line
-  # `portability-lint-allow`, the repo's visible-in-the-diff escape marker, which scan_hits
-  # honours). False FAILs are acceptable noise here; a false PASS is blindness.
+  # WHAT IT WOULD HAVE CHECKED: that no mutation call site discards the helper's non-zero
+  # "nothing changed" status — the defect behind the round-4 finding, where cx29's restore ignored
+  # it and the case then passed on cx28's stale value.
   #
-  # Reuses scan_hits, so comment-only lines are blanked and a call whose `|| bad …` sits on a
-  # CONTINUATION line is judged on the joined logical line (the deliberate design: line-oriented
-  # matching plus continuation joining, never a shell tokeniser).
-  _ss_call_re='(^|[^[:alnum:]_])sed_inplace(_verified)?[[:space:]]+"'
-  _ss_ok_controlled='^[0-9]+:[[:space:]]*(if|elif|while|until)[[:space:]]+(![[:space:]]*)?sed_inplace(_verified)?[[:space:]]+"[^;&|]*;[[:space:]]*(then|do)([[:space:]]|$)'
-  _ss_ok_handler='^[0-9]+:[[:space:]]*(![[:space:]]*)?sed_inplace(_verified)?[[:space:]]+"[^;&|]*\|\|[[:space:]]*(bad|return|exit)([[:space:]]|$)'
-  sed_status_offenders() { # sed_status_offenders <file> -> "lineno:logical-line" per unaccepted call
-    scan_hits "$_ss_call_re" "$1" \
-      | grep -vE "$_ss_ok_controlled" \
-      | grep -vE "$_ss_ok_handler" \
-      || printf ''
-  }
-  # BOTH DIRECTIONS, and the FALSE-ACCEPTING forms the round-5 review named are PERMANENT
-  # negative controls: the complement of the allow-list is pinned, so a widening cannot regress
-  # unnoticed. `flag` = must be reported, `ok` = must be accepted.
-  _ss_ctl_dir="$tmp/sed-status"
-  mkdir -p "$_ss_ctl_dir"
-  _sq="'"
-  printf '%s\n' "  sed_inplace \"\$f\" ${_sq}s/a/b/${_sq}" >"$_ss_ctl_dir/flag-bare.sh"
-  printf '%s\n' "  true && sed_inplace \"\$f\" \"\$expr\"" >"$_ss_ctl_dir/flag-and-chain.sh"
-  printf '%s\n' "  sed_inplace \"\$f\" \"\$expr\"; true || bad no" >"$_ss_ctl_dir/flag-semicolon-or.sh"
-  printf '%s\n' "  sed_inplace \"\$f\" \"\$expr\" && ok yes" >"$_ss_ctl_dir/flag-and-success.sh"
-  printf '%s\n' "  if sed_inplace \"\$f\" \"\$expr\" || true; then :; fi" >"$_ss_ctl_dir/flag-if-or-true.sh"
-  printf '%s\n' "if sed_inplace \"\$f\" ${_sq}s/a/b/${_sq}; then :; fi" >"$_ss_ctl_dir/ok-if.sh"
-  printf '%s\n' "  sed_inplace \"\$f\" \\" "    ${_sq}s/a/b/${_sq} || bad no" >"$_ss_ctl_dir/ok-or-bad.sh"
-  printf '%s\n' "  elif ! sed_inplace_verified \"\$f\" \"\$expr\" \"\$want\"; then" >"$_ss_ctl_dir/ok-elif-negated.sh"
-  for _ssc in \
-    'flag:bare statement call:flag-bare.sh' \
-    'flag:`true && sed_inplace …` (status discarded — the round-5 finding):flag-and-chain.sh' \
-    'flag:`sed_inplace …; true || bad` (the handler belongs to `true`):flag-semicolon-or.sh' \
-    'flag:`sed_inplace … && ok` (a SUCCESS chain handles no failure):flag-and-success.sh' \
-    'flag:`if sed_inplace … || true; then` (reads the status, then neutralises it):flag-if-or-true.sh' \
-    'ok:`if sed_inplace …; then`:ok-if.sh' \
-    'ok:a line-broken call with `|| bad` on the continuation:ok-or-bad.sh' \
-    'ok:`elif ! sed_inplace_verified …; then`:ok-elif-negated.sh'; do
-    _ss_want="${_ssc%%:*}"
-    _ss_rest="${_ssc#*:}"
-    _ss_why="${_ss_rest%:*}"
-    _ss_file="$_ss_ctl_dir/${_ss_rest##*:}"
-    _ss_got=$(sed_status_offenders "$_ss_file")
-    if [ "$_ss_want" = flag ] && [ -n "$_ss_got" ]; then
-      ok "AC2 control: the status-check allow-list REPORTS $_ss_why"
-    elif [ "$_ss_want" = flag ]; then
-      bad "AC2 control: the status-check allow-list ACCEPTED $_ss_why — the mutation's status is discarded there, so a stale-content pass is possible again"
-    elif [ -z "$_ss_got" ]; then
-      ok "AC2 control: the status-check allow-list accepts $_ss_why"
-    else
-      bad "AC2 control: the status-check allow-list reported an ACCEPTED form ($_ss_why) — it would force callers to hide from it rather than measure"
-    fi
-  done
-  _ss_hits=$(sed_status_offenders "$GUARD")
-  if [ -z "$_ss_hits" ]; then
-    ok 'AC2: every sed_inplace/sed_inplace_verified call in the guard test is in an ACCEPTED status-reading form (no mutation is asserted against without being measured)'
-  else
-    bad "AC2: the guard test has a mutation call in an UNRECOGNISED form (its status may be discarded) at: $(printf '%s' "$_ss_hits" | tr '\n' ' ') — rewrite it as \`if [!] sed_inplace…\` or \`sed_inplace… || bad|return|exit\`"
-  fi
+  # WHY IT IS GONE: it existed for three review rounds and produced a false PASS in every one
+  # (1 -> 2 -> 1 -> 2), each time in code the preceding fix round had just introduced: a
+  # `&&`/`||`-anywhere deny-list accepted `true && sed_inplace …` and `sed_inplace …; true || bad`;
+  # the allow-list that replaced it accepted `if sed_inplace … || true; then`; and it could not see
+  # an unquoted `sed_inplace $file "$expr"` at all. That is not a series of typos, it is the shape
+  # of the task: the rule is a bash ERE approximating SHELL GRAMMAR, and the correctness of a
+  # second implementation of a grammar is knowable only by differential testing against the real
+  # parser — which is out of scope here. CLAUDE.md's #3229 owner ruling applies verbatim: a guard
+  # with known documented false-PASSes is worse than no guard, because it invites reliance it
+  # cannot support, and subtraction cannot introduce a false PASS.
+  #
+  # WHAT PROTECTS THE PROPERTY INSTEAD: the four call sites in the guard test are correct today and
+  # each is verified BEHAVIOURALLY — every one routes a failed mutation to `bad` (proved by making
+  # each expression non-matching and observing the case FAIL at the edit site rather than passing on
+  # stale content), `sed_inplace_verified` requires its three affirmative facts at the edit site
+  # itself, and the AC2 text pins above still assert each case carries its own post-edit
+  # verification. The BSD-shim differential below exercises the helper's fail-closed no-op return
+  # and its mode preservation directly.
+  #
+  # ACCEPTED RESIDUAL, stated plainly and not argued away: a FIFTH call site added later that
+  # discards the status is caught only BEHAVIOURALLY — i.e. only if it happens to break a case —
+  # and nothing here will name it. Per the ruling this is recorded, not tracked as an issue, and is
+  # re-raisable only if it ever bites in practice.
 
   # --- summary_key_order under the paste shim, plus the RED side of the differential.
   printf 'vacuity-tier2: PASS\nroborev-exit: PASS\nfindings: NONE\nlog: /tmp/x\n' >"$tmp/block.txt"

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -669,9 +669,12 @@ else
   # to catch, reintroduced inside the rule: unanticipated spellings inheriting the permissive
   # branch. So the ACCEPTED forms are now ENUMERATED and everything else FAILs, including forms
   # nobody anticipated:
-  #   (1) directly controlled:      [if|elif|while|until] [!] sed_inplace…      (start of line)
-  #   (2) direct failure handler:   sed_inplace… || bad|return|exit              (start of line,
-  #                                 with no `;`/`&` between the call and the `||`)
+  #   (1) directly controlled:      [if|elif|while|until] [!] sed_inplace… ; then|do
+  #   (2) direct failure handler:   sed_inplace… || bad|return|exit
+  # Both are anchored at the start of the logical line, and NEITHER tolerates `;`, `&` or a single
+  # `|` between the call and its terminator — so `if sed_inplace … || true; then` (a condition that
+  # reads the status and then neutralises it) and `… | foo || bad` are NOT accepted either. That
+  # costs a sed expression delimited with `|` a false FAIL; the marker below is its route.
   # Deciding "is this status consumed?" in general is shell-semantics analysis and is deliberately
   # OUT OF BOUNDS. A call in an unlisted form reds the gate with a message saying the FORM was not
   # recognised, and the author rewrites it into an accepted form (or marks the line
@@ -682,8 +685,8 @@ else
   # CONTINUATION line is judged on the joined logical line (the deliberate design: line-oriented
   # matching plus continuation joining, never a shell tokeniser).
   _ss_call_re='(^|[^[:alnum:]_])sed_inplace(_verified)?[[:space:]]+"'
-  _ss_ok_controlled='^[0-9]+:[[:space:]]*(if|elif|while|until)[[:space:]]+(![[:space:]]*)?sed_inplace(_verified)?[[:space:]]+"'
-  _ss_ok_handler='^[0-9]+:[[:space:]]*(![[:space:]]*)?sed_inplace(_verified)?[[:space:]]+"[^;&]*\|\|[[:space:]]*(bad|return|exit)([[:space:]]|$)'
+  _ss_ok_controlled='^[0-9]+:[[:space:]]*(if|elif|while|until)[[:space:]]+(![[:space:]]*)?sed_inplace(_verified)?[[:space:]]+"[^;&|]*;[[:space:]]*(then|do)([[:space:]]|$)'
+  _ss_ok_handler='^[0-9]+:[[:space:]]*(![[:space:]]*)?sed_inplace(_verified)?[[:space:]]+"[^;&|]*\|\|[[:space:]]*(bad|return|exit)([[:space:]]|$)'
   sed_status_offenders() { # sed_status_offenders <file> -> "lineno:logical-line" per unaccepted call
     scan_hits "$_ss_call_re" "$1" \
       | grep -vE "$_ss_ok_controlled" \
@@ -700,6 +703,7 @@ else
   printf '%s\n' "  true && sed_inplace \"\$f\" \"\$expr\"" >"$_ss_ctl_dir/flag-and-chain.sh"
   printf '%s\n' "  sed_inplace \"\$f\" \"\$expr\"; true || bad no" >"$_ss_ctl_dir/flag-semicolon-or.sh"
   printf '%s\n' "  sed_inplace \"\$f\" \"\$expr\" && ok yes" >"$_ss_ctl_dir/flag-and-success.sh"
+  printf '%s\n' "  if sed_inplace \"\$f\" \"\$expr\" || true; then :; fi" >"$_ss_ctl_dir/flag-if-or-true.sh"
   printf '%s\n' "if sed_inplace \"\$f\" ${_sq}s/a/b/${_sq}; then :; fi" >"$_ss_ctl_dir/ok-if.sh"
   printf '%s\n' "  sed_inplace \"\$f\" \\" "    ${_sq}s/a/b/${_sq} || bad no" >"$_ss_ctl_dir/ok-or-bad.sh"
   printf '%s\n' "  elif ! sed_inplace_verified \"\$f\" \"\$expr\" \"\$want\"; then" >"$_ss_ctl_dir/ok-elif-negated.sh"
@@ -708,6 +712,7 @@ else
     'flag:`true && sed_inplace …` (status discarded — the round-5 finding):flag-and-chain.sh' \
     'flag:`sed_inplace …; true || bad` (the handler belongs to `true`):flag-semicolon-or.sh' \
     'flag:`sed_inplace … && ok` (a SUCCESS chain handles no failure):flag-and-success.sh' \
+    'flag:`if sed_inplace … || true; then` (reads the status, then neutralises it):flag-if-or-true.sh' \
     'ok:`if sed_inplace …; then`:ok-if.sh' \
     'ok:a line-broken call with `|| bad` on the continuation:ok-or-bad.sh' \
     'ok:`elif ! sed_inplace_verified …; then`:ok-elif-negated.sh'; do
@@ -914,28 +919,58 @@ else
   #   UNRECOGNISED  everything else -> a counted FAILURE naming what was not recognised
   # An unrecognised state FAILs; it never inherits DEP-SKIP. The classifier is itself controlled
   # below, in all three directions.
+  #
+  # DEP-SKIP IS ONE NAMED CONDITION, NOT A SHAPE (#3296 round-5 blocker 4). The round-4 form
+  # accepted "rc 0 AND some line begins `SKIP -`", so an unrelated earlier skip followed by an
+  # accidental `exit 0` would hide a truncated composition as an allowed dependency skip — a
+  # deny-list wearing an allow-list's clothes. The permissive branch now requires the ONE
+  # supported dependency condition, identified two ways at once:
+  #   * a DEDICATED SENTINEL EXIT CODE (77, the long-standing "skipped" convention), distinct from
+  #     the guard test's own failure exit (1) and from bash's syntax-error exit (2); and
+  #   * the EXACT message line of that condition, read out of the guard test itself (never a
+  #     hand-copied duplicate that could drift): the python3 preflight, the only dependency the
+  #     guard test declines for. If that message cannot be extracted, the recognised cause is
+  #     unidentifiable, which is a FAILURE TO MEASURE and is reported as such — DEP-SKIP then
+  #     has no legitimate route at all rather than a loose one.
+  # A future prologue skip for a DIFFERENT dependency is therefore UNRECOGNISED until it is added
+  # here deliberately (the FAIL message says so) — noise, never blindness.
+  _AC5_SKIP_RC=77
   _ac5_dep='python3: present'
   command -v python3 >/dev/null 2>&1 ||
     _ac5_dep='python3: ABSENT (the guard test SKIPs its structured-payload cases without it)'
+  # The exact expected line, extracted from the guard test's own printf (not duplicated here).
+  _ac5_dep_msg=$(grep -F "printf 'SKIP - no python3:" "$GUARD" | head -1 \
+    | sed -e "s/^[[:space:]]*printf '//" -e "s/\\\\n'[[:space:]]*\$//")
+  case "$_ac5_dep_msg" in
+    'SKIP - no python3:'*) ;;
+    *) _ac5_dep_msg='' ;;
+  esac
+  if [ -n "$_ac5_dep_msg" ]; then
+    ok 'AC5 control: the ONE supported dependency-skip message was extracted from the guard test, so the permissive branch is keyed on a real, current condition'
+  else
+    bad "AC5 control: the guard test's python3 dependency-skip message could not be extracted, so the ONE permissive cause cannot be identified — every early exit will be reported UNRECOGNISED until this contract is updated"
+  fi
   _ac5_out=''; _ac5_rc=0; _ac5_state=''; _ac5_cause=''
   run_ac5_probe() { # run_ac5_probe <script> -> _ac5_out / _ac5_rc / _ac5_state / _ac5_cause
     _ac5_out=$(bash "$1" 2>&1); _ac5_rc=$?
     if printf '%s\n' "$_ac5_out" | grep -qF '==== ROBOREV REVIEW GUARD TEST TALLY'; then
       _ac5_state='MEASURED'
       _ac5_cause='the probe reached the guard test tally epilogue'
-    elif [ "$_ac5_rc" -eq 0 ] && printf '%s\n' "$_ac5_out" | grep -q '^SKIP - '; then
+    elif [ "$_ac5_rc" -eq "$_AC5_SKIP_RC" ] && [ -n "$_ac5_dep_msg" ] &&
+      printf '%s\n' "$_ac5_out" | grep -qxF -- "$_ac5_dep_msg"; then
       # THE ONE PERMISSIVE CAUSE, and the reason it is legitimately permissive, recorded here at
-      # the branch: the guard test may decline to run on a host that lacks a dependency, and it
-      # says so in its OWN idiom — a `SKIP - ` line — and then exits ZERO. Both facts are
-      # required and both are AFFIRMATIVE: the marker identifies the cause as a declared skip
-      # (not an accident), and rc 0 says the probe chose to stop rather than broke. A stripped
-      # runner is a supported host, so this must not red the gate; anything that cannot show
-      # BOTH facts is not this cause and is not permitted to borrow its verdict.
+      # the branch: the guard test may decline to run on a host that lacks python3, the single
+      # dependency it declines for. TWO independent affirmative facts are required — the
+      # dedicated sentinel rc (nothing else in the guard test exits 77) and the EXACT declared
+      # message line (whole-line match, `grep -xF`, against text read from the guard test itself).
+      # A stripped runner is a supported host, so this must not red the gate; anything that cannot
+      # show BOTH facts is not this cause and may not borrow its verdict — including an unrelated
+      # `SKIP -` line followed by an accidental `exit 0`, which is what the round-4 form accepted.
       _ac5_state='DEP-SKIP'
-      _ac5_cause='the probe declined with the guard test SKIP marker and exited zero'
+      _ac5_cause="the probe declined with the sentinel rc $_AC5_SKIP_RC and the exact python3 dependency message"
     elif [ "$_ac5_rc" -eq 0 ]; then
       _ac5_state='UNRECOGNISED'
-      _ac5_cause='it exited ZERO before the tally but printed NO `SKIP - ` marker, so nothing identifies this as a declared dependency skip (a silently truncated prologue looks exactly like this)'
+      _ac5_cause="it exited ZERO before the tally, which is not the sentinel rc $_AC5_SKIP_RC a declared dependency skip must use (a silently truncated prologue, or an unrelated skip followed by a stray \`exit 0\`, looks exactly like this)"
     else
       _ac5_state='UNRECOGNISED'
       _ac5_cause="it exited NON-ZERO (rc $_ac5_rc) before the tally — a syntax error in the composition, a stray \`exit\`, or a prologue that failed; none of those is a dependency skip"
@@ -953,33 +988,38 @@ else
 
   compose_probe "$tmp/mirror/tests/ac5-fail.sh" "bad 'AC5 injected failure'"
   compose_probe "$tmp/mirror/tests/ac5-pass.sh" ":"
-  # CONTROL FIRST: a prologue that short-circuits must be classified NOT-MEASURED, not FAIL.
-  # Without this the skip branch could be dead code and the red-gate hazard would be unfixed.
+  # CONTROL FIRST: the ONE supported dependency condition — the guard test's own python3 message,
+  # verbatim, plus the sentinel rc — must be classified DEP-SKIP, or the permissive branch is dead
+  # code and the red-gate hazard on a stripped runner is unfixed.
   compose_probe "$tmp/mirror/tests/ac5-skip.sh" \
-    "printf 'SKIP - simulated prologue dependency skip\\n'; exit 0"
+    "printf '%s\\n' '$_ac5_dep_msg'; exit $_AC5_SKIP_RC"
   run_ac5_probe "$tmp/mirror/tests/ac5-skip.sh"
   if [ "$_ac5_state" = 'DEP-SKIP' ]; then
-    ok 'AC5 control: a composition that DECLARES a dependency skip (SKIP marker + exit 0) is classified DEP-SKIP, so a stripped runner degrades to a loud SKIP instead of a red gate'
+    ok "AC5 control: the ONE supported dependency skip (sentinel rc $_AC5_SKIP_RC + the exact python3 message) is classified DEP-SKIP, so a stripped runner degrades to a loud SKIP instead of a red gate"
   else
-    bad "AC5 control: a declared dependency skip was classified $_ac5_state ($_ac5_cause) — the one permissive cause cannot be identified, so a legitimate skip on a stripped runner would red the gate"
+    bad "AC5 control: the supported dependency skip was classified $_ac5_state ($_ac5_cause) — the one permissive cause cannot be identified, so a legitimate skip on a stripped runner would red the gate"
   fi
 
   # THE OTHER DIRECTION, AND IT IS THE BLOCKER (#3296): the permissive branch must be reachable
-  # ONLY from that affirmatively identified cause. Three compositions that exit early for reasons
-  # which are NOT a declared skip must each classify UNRECOGNISED — and `ac5_not_measured` routes
-  # UNRECOGNISED to `bad`, so each of these WOULD red the gate. Pre-fix, all three were absorbed
-  # into the same non-failing SKIP as the declared skip above.
+  # ONLY from that affirmatively identified cause, so its COMPLEMENT is pinned case by case —
+  # including the two halves of the signature taken separately, and the round-5 finding (an
+  # unrelated `SKIP -` line plus an accidental `exit 0`, which the previous form accepted).
+  # `ac5_not_measured` routes UNRECOGNISED to `bad`, so every one of these WOULD red the gate.
   for _ac5_u in \
     "syntax:bad 'AC5 injected failure'; fi" \
     "nonzero-exit:exit 1" \
-    "silent-exit-zero:exit 0"; do
+    "silent-exit-zero:exit 0" \
+    "unrelated-skip-line-then-exit-zero:printf 'SKIP - some unrelated earlier skip\\n'; exit 0" \
+    "unrelated-skip-line-then-sentinel-rc:printf 'SKIP - some unrelated earlier skip\\n'; exit $_AC5_SKIP_RC" \
+    "exact-message-without-sentinel-rc:printf '%s\\n' '$_ac5_dep_msg'; exit 0" \
+    "exact-message-as-a-substring-only:printf '%s\\n' 'noise $_ac5_dep_msg noise'; exit $_AC5_SKIP_RC"; do
     _ac5_ulabel="${_ac5_u%%:*}"
     compose_probe "$tmp/mirror/tests/ac5-unrec.sh" "${_ac5_u#*:}"
     run_ac5_probe "$tmp/mirror/tests/ac5-unrec.sh"
     if [ "$_ac5_state" = 'UNRECOGNISED' ]; then
-      ok "AC5 control: an early exit with no declared skip ($_ac5_ulabel, rc $_ac5_rc) is classified UNRECOGNISED, so it is a counted FAILURE and not a skip"
+      ok "AC5 control: an early exit that is not the supported dependency condition ($_ac5_ulabel, rc $_ac5_rc) is classified UNRECOGNISED, so it is a counted FAILURE and not a skip"
     else
-      bad "AC5 control: an early exit with no declared skip ($_ac5_ulabel, rc $_ac5_rc) was classified $_ac5_state — a broken composition, or a broken exit-code contract, would then pass as a skip"
+      bad "AC5 control: an early exit that is not the supported dependency condition ($_ac5_ulabel, rc $_ac5_rc) was classified $_ac5_state — a broken composition, or a broken exit-code contract, would then pass as a skip"
     fi
   done
 

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -59,8 +59,14 @@ FLOW_DIR="$SCRIPT_DIR/../flow"
 
 PASS=0
 FAIL=0
-ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
-bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+# SKIPPED is COUNTED and printed in the tally, never absorbed into PASS. A check that could not
+# run has no verdict to give: reporting it as a pass is the vacuous pass itself, and reporting it
+# as a failure turns a legitimately stripped runner into a red gate (which is #3296's own defect
+# one level down). So it is its own third state, loud in the output and named in the tally.
+SKIPPED=0
+ok()   { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad()  { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+skip() { printf 'SKIP - %s\n' "$1"; SKIPPED=$((SKIPPED + 1)); }
 
 if [ ! -f "$GUARD" ]; then
   printf 'FAIL - the guard test is not at %s — nothing to keep portable\n' "$GUARD"
@@ -601,17 +607,60 @@ else
       awk -v n="$_epi_start" 'NR >= n' "$GUARD"
     } >"$1"
   }
+  # A COMPOSITION IS A LINE-SLICE OF A FOREIGN FILE, so it can be short-circuited by something
+  # that is not the contract under test: a dependency SKIP (the guard test SKIPs its
+  # structured-payload cases when python3 is missing — today at a line BELOW this slice, but a
+  # preflight is exactly the kind of thing that migrates upward), a missing fixture, any early
+  # `exit`. If that happens the probe never reaches the tally epilogue, and classifying it by
+  # rc/text alone would report BOTH probes as contract FAILURES — turning a legitimate skip on a
+  # stripped runner into a red gate, which is #3296's own failure mode reproduced one level down.
+  #
+  # So reaching the tally is measured FIRST and is a precondition for any verdict: no tally means
+  # NOT MEASURED (a loud, counted SKIP naming the dependency state and the probe's last line),
+  # never a pass and never a failure. The classifier is itself controlled below.
+  _ac5_dep='python3: present'
+  command -v python3 >/dev/null 2>&1 ||
+    _ac5_dep='python3: ABSENT (the guard test SKIPs its structured-payload cases without it)'
+  _ac5_out=''; _ac5_rc=0; _ac5_reached=0
+  run_ac5_probe() { # run_ac5_probe <script> -> _ac5_out / _ac5_rc / _ac5_reached
+    _ac5_out=$(bash "$1" 2>&1); _ac5_rc=$?
+    if printf '%s\n' "$_ac5_out" | grep -qF '==== ROBOREV REVIEW GUARD TEST TALLY'; then
+      _ac5_reached=1
+    else
+      _ac5_reached=0
+    fi
+  }
+  ac5_not_measured() { # ac5_not_measured <label>
+    skip "AC5 ($1): the composed probe EXITED BEFORE the guard test's tally epilogue (rc $_ac5_rc; $_ac5_dep; last line: $(printf '%s' "$_ac5_out" | tail -1)) — the prologue short-circuited, so the exit-code contract was NOT MEASURED on this host. Not a pass: rerun where the guard test's prologue dependencies are present."
+  }
+
   compose_probe "$tmp/mirror/tests/ac5-fail.sh" "bad 'AC5 injected failure'"
   compose_probe "$tmp/mirror/tests/ac5-pass.sh" ":"
-  _ac5_out=$(bash "$tmp/mirror/tests/ac5-fail.sh" 2>&1); _ac5_rc=$?
-  if [ "$_ac5_rc" -ne 0 ] && printf '%s\n' "$_ac5_out" | grep -qF 'GUARD-TEST RESULT: FAIL' &&
+  # CONTROL FIRST: a prologue that short-circuits must be classified NOT-MEASURED, not FAIL.
+  # Without this the skip branch could be dead code and the red-gate hazard would be unfixed.
+  compose_probe "$tmp/mirror/tests/ac5-skip.sh" \
+    "printf 'SKIP - simulated prologue dependency skip\\n'; exit 0"
+  run_ac5_probe "$tmp/mirror/tests/ac5-skip.sh"
+  if [ "$_ac5_reached" -eq 0 ]; then
+    ok 'AC5 control: a composition whose prologue short-circuits is detected as NOT MEASURED (it never reaches the tally), so a stripped runner degrades to a loud SKIP instead of a red gate'
+  else
+    bad 'AC5 control: a short-circuited composition was reported as having reached the tally — the not-measured detector cannot fire, so a legitimate dependency skip would be misclassified as a contract failure'
+  fi
+
+  run_ac5_probe "$tmp/mirror/tests/ac5-fail.sh"
+  if [ "$_ac5_reached" -eq 0 ]; then
+    ac5_not_measured 'injected failing case'
+  elif [ "$_ac5_rc" -ne 0 ] && printf '%s\n' "$_ac5_out" | grep -qF 'GUARD-TEST RESULT: FAIL' &&
     printf '%s\n' "$_ac5_out" | grep -qF 'failed: 1'; then
     ok "AC5: a failing case still exits NON-ZERO (rc $_ac5_rc) with GUARD-TEST RESULT: FAIL"
   else
     bad "AC5: the guard test's tally epilogue did not fail closed (rc $_ac5_rc): $(printf '%s' "$_ac5_out" | tail -3 | tr '\n' ' ')"
   fi
-  _ac5_out=$(bash "$tmp/mirror/tests/ac5-pass.sh" 2>&1); _ac5_rc=$?
-  if [ "$_ac5_rc" -eq 0 ] && printf '%s\n' "$_ac5_out" | grep -qF 'GUARD-TEST RESULT: PASS'; then
+
+  run_ac5_probe "$tmp/mirror/tests/ac5-pass.sh"
+  if [ "$_ac5_reached" -eq 0 ]; then
+    ac5_not_measured 'clean control'
+  elif [ "$_ac5_rc" -eq 0 ] && printf '%s\n' "$_ac5_out" | grep -qF 'GUARD-TEST RESULT: PASS'; then
     ok 'AC5 control: with no failing case the same epilogue exits 0 with GUARD-TEST RESULT: PASS'
   else
     bad "AC5 control: the clean composition did not pass (rc $_ac5_rc) — the injected-failure result above would then mean nothing"
@@ -621,7 +670,7 @@ fi
 # The gate must not swallow either script's exit status: `roborev-lints` is where both run in
 # --lite and in the full gate of record.
 if [ ! -f "$GATE" ]; then
-  printf 'SKIP - agent-gate.sh not found; the roborev-lints wiring could not be checked\n'
+  skip 'wiring: agent-gate.sh not found; the roborev-lints wiring could not be checked'
 else
   _lints=$(awk '/^run_roborev_lints_cmd\(\) \{/,/^\}$/' "$GATE")
   if [ -z "$_lints" ]; then
@@ -645,7 +694,12 @@ fi
 # The tally line deliberately does NOT start with `RESULT:` — that token belongs to the agent
 # gate's summary contract and to the roborev wrapper's own block.
 printf '\n==== ROBOREV GUARD PORTABILITY TALLY ====\n'
-printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
+printf 'passed: %d  failed: %d  skipped: %d\n' "$PASS" "$FAIL" "$SKIPPED"
+# A skip does not red the gate — a stripped runner is a supported host — but it is never
+# silent: it is counted above and restated here, naming that coverage was reduced on this run.
+if [ "$SKIPPED" -ne 0 ]; then
+  printf 'NOT MEASURED: %d check(s) SKIPped on this host — see the SKIP lines above for what was not covered\n' "$SKIPPED"
+fi
 if [ "$FAIL" -ne 0 ]; then
   printf 'PORTABILITY RESULT: FAIL\n'
   exit 1

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -864,22 +864,58 @@ else
   # stripped runner into a red gate, which is #3296's own failure mode reproduced one level down.
   #
   # So reaching the tally is measured FIRST and is a precondition for any verdict: no tally means
-  # NOT MEASURED (a loud, counted SKIP naming the dependency state and the probe's last line),
-  # never a pass and never a failure. The classifier is itself controlled below.
+  # the exit-code contract was not measured, and such a run is never reported as a pass.
+  #
+  # CLOSED GRAMMAR (#3296, roborev blocker 2). "Did not reach the tally" is not one state, it is
+  # the WHOLE SPACE of early exits: a dependency skip, a syntax error in the composition, a stray
+  # `exit 1`, a prologue that dies silently. Classifying that space as one non-failing SKIP is the
+  # CLAUDE.md defect in its purest form — a permissive branch keyed on the ABSENCE of a good
+  # signal, so an ACTUALLY BROKEN exit-code contract (or an actually broken composition) reports
+  # the same green as a stripped runner. Measured before this fix: injecting a syntax error into
+  # the ac5-fail probe, and injecting `exit 1`, each produced `skipped: 1` and
+  # `PORTABILITY RESULT: PASS`.
+  #
+  # So the classifier returns ONE of three ENUMERATED states, and only ONE of them is permissive:
+  #   MEASURED      the tally was reached; the rc/text verdict below applies
+  #   DEP-SKIP      the ONE permissive cause, AFFIRMATIVELY identified (see the branch)
+  #   UNRECOGNISED  everything else -> a counted FAILURE naming what was not recognised
+  # An unrecognised state FAILs; it never inherits DEP-SKIP. The classifier is itself controlled
+  # below, in all three directions.
   _ac5_dep='python3: present'
   command -v python3 >/dev/null 2>&1 ||
     _ac5_dep='python3: ABSENT (the guard test SKIPs its structured-payload cases without it)'
-  _ac5_out=''; _ac5_rc=0; _ac5_reached=0
-  run_ac5_probe() { # run_ac5_probe <script> -> _ac5_out / _ac5_rc / _ac5_reached
+  _ac5_out=''; _ac5_rc=0; _ac5_state=''; _ac5_cause=''
+  run_ac5_probe() { # run_ac5_probe <script> -> _ac5_out / _ac5_rc / _ac5_state / _ac5_cause
     _ac5_out=$(bash "$1" 2>&1); _ac5_rc=$?
     if printf '%s\n' "$_ac5_out" | grep -qF '==== ROBOREV REVIEW GUARD TEST TALLY'; then
-      _ac5_reached=1
+      _ac5_state='MEASURED'
+      _ac5_cause='the probe reached the guard test tally epilogue'
+    elif [ "$_ac5_rc" -eq 0 ] && printf '%s\n' "$_ac5_out" | grep -q '^SKIP - '; then
+      # THE ONE PERMISSIVE CAUSE, and the reason it is legitimately permissive, recorded here at
+      # the branch: the guard test may decline to run on a host that lacks a dependency, and it
+      # says so in its OWN idiom — a `SKIP - ` line — and then exits ZERO. Both facts are
+      # required and both are AFFIRMATIVE: the marker identifies the cause as a declared skip
+      # (not an accident), and rc 0 says the probe chose to stop rather than broke. A stripped
+      # runner is a supported host, so this must not red the gate; anything that cannot show
+      # BOTH facts is not this cause and is not permitted to borrow its verdict.
+      _ac5_state='DEP-SKIP'
+      _ac5_cause='the probe declined with the guard test SKIP marker and exited zero'
+    elif [ "$_ac5_rc" -eq 0 ]; then
+      _ac5_state='UNRECOGNISED'
+      _ac5_cause='it exited ZERO before the tally but printed NO `SKIP - ` marker, so nothing identifies this as a declared dependency skip (a silently truncated prologue looks exactly like this)'
     else
-      _ac5_reached=0
+      _ac5_state='UNRECOGNISED'
+      _ac5_cause="it exited NON-ZERO (rc $_ac5_rc) before the tally — a syntax error in the composition, a stray \`exit\`, or a prologue that failed; none of those is a dependency skip"
     fi
   }
+  # The ONLY route to a SKIP: an affirmatively identified DEP-SKIP. Every other non-MEASURED
+  # state is a counted FAILURE whose message names what was not recognised.
   ac5_not_measured() { # ac5_not_measured <label>
-    skip "AC5 ($1): the composed probe EXITED BEFORE the guard test's tally epilogue (rc $_ac5_rc; $_ac5_dep; last line: $(printf '%s' "$_ac5_out" | tail -1)) — the prologue short-circuited, so the exit-code contract was NOT MEASURED on this host. Not a pass: rerun where the guard test's prologue dependencies are present."
+    if [ "$_ac5_state" = 'DEP-SKIP' ]; then
+      skip "AC5 ($1): the composed probe DECLINED before the guard test's tally epilogue (rc $_ac5_rc; $_ac5_dep; last line: $(printf '%s' "$_ac5_out" | tail -1)) — a declared dependency skip, so the exit-code contract was NOT MEASURED on this host. Not a pass: rerun where the guard test's prologue dependencies are present."
+    else
+      bad "AC5 ($1): the composed probe exited before the guard test's tally for an UNRECOGNISED reason — $_ac5_cause (state $_ac5_state; rc $_ac5_rc; $_ac5_dep; last line: $(printf '%s' "$_ac5_out" | tail -1)). An unrecognised early exit is a FAILURE, never a skip: it may BE the broken exit-code contract this case exists to catch."
+    fi
   }
 
   compose_probe "$tmp/mirror/tests/ac5-fail.sh" "bad 'AC5 injected failure'"
@@ -889,14 +925,33 @@ else
   compose_probe "$tmp/mirror/tests/ac5-skip.sh" \
     "printf 'SKIP - simulated prologue dependency skip\\n'; exit 0"
   run_ac5_probe "$tmp/mirror/tests/ac5-skip.sh"
-  if [ "$_ac5_reached" -eq 0 ]; then
-    ok 'AC5 control: a composition whose prologue short-circuits is detected as NOT MEASURED (it never reaches the tally), so a stripped runner degrades to a loud SKIP instead of a red gate'
+  if [ "$_ac5_state" = 'DEP-SKIP' ]; then
+    ok 'AC5 control: a composition that DECLARES a dependency skip (SKIP marker + exit 0) is classified DEP-SKIP, so a stripped runner degrades to a loud SKIP instead of a red gate'
   else
-    bad 'AC5 control: a short-circuited composition was reported as having reached the tally — the not-measured detector cannot fire, so a legitimate dependency skip would be misclassified as a contract failure'
+    bad "AC5 control: a declared dependency skip was classified $_ac5_state ($_ac5_cause) — the one permissive cause cannot be identified, so a legitimate skip on a stripped runner would red the gate"
   fi
 
+  # THE OTHER DIRECTION, AND IT IS THE BLOCKER (#3296): the permissive branch must be reachable
+  # ONLY from that affirmatively identified cause. Three compositions that exit early for reasons
+  # which are NOT a declared skip must each classify UNRECOGNISED — and `ac5_not_measured` routes
+  # UNRECOGNISED to `bad`, so each of these WOULD red the gate. Pre-fix, all three were absorbed
+  # into the same non-failing SKIP as the declared skip above.
+  for _ac5_u in \
+    "syntax:bad 'AC5 injected failure'; fi" \
+    "nonzero-exit:exit 1" \
+    "silent-exit-zero:exit 0"; do
+    _ac5_ulabel="${_ac5_u%%:*}"
+    compose_probe "$tmp/mirror/tests/ac5-unrec.sh" "${_ac5_u#*:}"
+    run_ac5_probe "$tmp/mirror/tests/ac5-unrec.sh"
+    if [ "$_ac5_state" = 'UNRECOGNISED' ]; then
+      ok "AC5 control: an early exit with no declared skip ($_ac5_ulabel, rc $_ac5_rc) is classified UNRECOGNISED, so it is a counted FAILURE and not a skip"
+    else
+      bad "AC5 control: an early exit with no declared skip ($_ac5_ulabel, rc $_ac5_rc) was classified $_ac5_state — a broken composition, or a broken exit-code contract, would then pass as a skip"
+    fi
+  done
+
   run_ac5_probe "$tmp/mirror/tests/ac5-fail.sh"
-  if [ "$_ac5_reached" -eq 0 ]; then
+  if [ "$_ac5_state" != 'MEASURED' ]; then
     ac5_not_measured 'injected failing case'
   elif [ "$_ac5_rc" -ne 0 ] && printf '%s\n' "$_ac5_out" | grep -qF 'GUARD-TEST RESULT: FAIL' &&
     printf '%s\n' "$_ac5_out" | grep -qF 'failed: 1'; then
@@ -906,7 +961,7 @@ else
   fi
 
   run_ac5_probe "$tmp/mirror/tests/ac5-pass.sh"
-  if [ "$_ac5_reached" -eq 0 ]; then
+  if [ "$_ac5_state" != 'MEASURED' ]; then
     ac5_not_measured 'clean control'
   elif [ "$_ac5_rc" -eq 0 ] && printf '%s\n' "$_ac5_out" | grep -qF 'GUARD-TEST RESULT: PASS'; then
     ok 'AC5 control: with no failing case the same epilogue exits 0 with GUARD-TEST RESULT: PASS'

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -198,8 +198,29 @@ RE_SED_INPLACE_CLUSTER='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-[nEralusz
 # rule, the cluster rule and both empty-suffix rules before this fix. `--in-place=SUFFIX` needed
 # no such repair; it is already reached through the option run above, and both of its positions
 # are now pinned by controls below rather than assumed.
-RE_SED_INPLACE_EMPTY_DQ='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-i("")'
-RE_SED_INPLACE_EMPTY_SQ='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-i'"('')"
+#
+# AND THEY REQUIRE A TOKEN BOUNDARY AFTER THE CLOSING QUOTES (#3296 round-9 review, a FALSE
+# POSITIVE in the two rules above). The rules must distinguish two spellings that differ only in
+# what FOLLOWS the quotes, because SHELL QUOTE REMOVAL is what decides which one sed sees:
+#   sed -i''      -> argv is `-i`      : a bare in-place flag. BSD declares -i WITH A REQUIRED
+#                                        argument, so it eats the next token. NON-PORTABLE, flag it.
+#   sed -i''.bak  -> argv is `-i.bak`  : the ATTACHED-SUFFIX form. BOTH seds read this identically,
+#                                        and the cluster rule's own comment above already calls the
+#                                        attached suffix portable (`-Ei.bak` is deliberately not
+#                                        matched). PORTABLE — flagging it reds the gate on correct
+#                                        code, and this lint is GATE-WIRED into roborev-lints, so a
+#                                        false FAIL here recreates #3296 one level down: "a key that
+#                                        reds on correct input is the key agents learn to waive".
+# So a match now requires the quotes to END THE TOKEN: whitespace, a shell metacharacter, or
+# end-of-line. Measured, before -> after, on the two directions: the four attached-suffix forms
+# (`-i''.bak`, `-i"".bak`, either beyond an option run, and at EOL) go from FLAGGED to clean, while
+# all seven bare-empty-suffix forms stay FLAGGED — including the three whose boundary is not a
+# space (`sed -i''` at EOL, `$(sed -i'' f)` closing on `)`, and `sed -i'';`), which is why the
+# boundary set is metacharacters and `$`, not `[[:space:]]` alone. Both directions are pinned by
+# permanent controls below; widening the escape would show up there as a missed positive.
+_TOK_END='([[:space:]]|$|[|;&<>()])'
+RE_SED_INPLACE_EMPTY_DQ='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-i("")'"$_TOK_END"
+RE_SED_INPLACE_EMPTY_SQ='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-i'"('')$_TOK_END"
 # PASTE WITH NO FILE OPERAND, in every spelling that reaches BSD's `if (*argv == NULL) usage();`:
 #   paste -sd,            bundled flags, nothing after them
 #   paste -d ,            the delimiter argument SEPARATED from -d (consumed as the option's
@@ -721,6 +742,29 @@ printf '%s\n' "  sed -e 's/a/b/' -i'' file" >"$tmp/sp-empty-sq.sh" # portability
 assert_flagged "\`sed -e EXPR -i'' file\` (empty SINGLE-quoted suffix beyond the adjacent position)" "$tmp/sp-empty-sq.sh" # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
 printf '%s\n' "  sed -e 's/a/b/' -i\"\" file" >"$tmp/sp-empty-dq.sh"
 assert_flagged '`sed -e EXPR -i"" file` (empty DOUBLE-quoted suffix beyond the adjacent position)' "$tmp/sp-empty-dq.sh" # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
+# (g2) THE OTHER SIDE OF THE SAME TOKEN — a CONCATENATED ATTACHED SUFFIX (#3296 round-9 review
+# false positive). `-i''.bak` and `-i"".bak` survive shell quote removal as `-i.bak`, the attached
+# form BOTH seds read identically, so they are PORTABLE and must NOT be reported. These are
+# PERMANENT negative controls: the rules distinguish the two spellings only by the token boundary
+# after the closing quotes, and nothing but a control keeps that boundary in place. They are
+# deliberately paired with the (g) positives above — a regex change that widens the escape to make
+# these pass would break those, and one that drops the boundary again would break these.
+printf '%s\n' "  sed -i''.bak -e 's/a/b/' file" >"$tmp/sp-attach-sq.sh"
+assert_not_flagged "\`sed -i''.bak …\` (quote removal yields the PORTABLE attached suffix -i.bak)" "$tmp/sp-attach-sq.sh"
+printf '%s\n' "  sed -i\"\".bak -e 's/a/b/' file" >"$tmp/sp-attach-dq.sh"
+assert_not_flagged '`sed -i"".bak …` (quote removal yields the PORTABLE attached suffix -i.bak)' "$tmp/sp-attach-dq.sh"
+printf '%s\n' "  sed -e 's/a/b/' -i''.bak file" >"$tmp/sp-attach-sq2.sh"
+assert_not_flagged "\`sed -e EXPR -i''.bak file\` (portable attached suffix BEYOND an option run — the widened option run must not resurrect the false positive)" "$tmp/sp-attach-sq2.sh"
+printf '%s\n' "  sed -i''.bak" >"$tmp/sp-attach-eol.sh"
+assert_not_flagged "\`sed -i''.bak\` at end-of-line (the boundary set must not treat the suffix as a token end)" "$tmp/sp-attach-eol.sh"
+# And the boundaries that are NOT whitespace must still FLAG the bare empty suffix, or the fix
+# above would have bought its precision by losing coverage at end-of-line, before `)` and before `;`.
+printf '%s\n' "  sed -i''" >"$tmp/sp-empty-eol.sh"
+assert_flagged "a bare \`sed -i''\` at END-OF-LINE (boundary \$)" "$tmp/sp-empty-eol.sh"
+printf '%s\n' "  order=\$(sed -i'' f)" >"$tmp/sp-empty-paren.sh" # portability-lint-allow: deliberate fixture: the bare empty-suffix spelling this control must DETECT
+assert_flagged "a bare \`sed -i''\` inside a command substitution (boundary \`)\`)" "$tmp/sp-empty-paren.sh"
+printf '%s\n' "  sed -i''; echo done" >"$tmp/sp-empty-semi.sh" # portability-lint-allow: deliberate fixture: the bare empty-suffix spelling this control must DETECT
+assert_flagged "a bare \`sed -i''\` terminated by a semicolon (boundary \`;\`)" "$tmp/sp-empty-semi.sh"
 # The widening must not reach past a shell metacharacter here either: an empty-suffix `-i` on the
 # far side of a pipe belongs to a DIFFERENT command.
 printf '%s\n' '  sed '"'"'s/x/y/'"'"' f | grep -i'"''"' foo' >"$tmp/sp-empty-pipe.sh"

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -105,16 +105,37 @@ trap 'rm -rf "$tmp"' EXIT
 #     file operand (bare, separated `-d ARG`, and with input/output/fd redirections); plus
 #     `readlink -f`, `stat -c`, `grep -P`, `date -d`, `sed -z`/`grep -z`, `find -printf`,
 #     `xargs -r`, `base64 -w`, `timeout`, and the bash-4-only constructs.
-#   * WHAT IS AUTHORITATIVE: mechanism (2), the BEHAVIOURAL BSD-shim differential. It EXECUTES
-#     the guard test's own helpers under BSD `sed -i` and BSD `paste` semantics, so it does not
-#     care how a construct is spelled at all.
-#   * WHY THIS SURVIVES WHERE THE DELETED LINT DID NOT: a spelling this table misses is a
-#     BOUNDED FALSE NEGATIVE with a backstop underneath it. The deleted lint had no backstop and
-#     its misses were false PASSES about the property it was the only check for.
+#   * WHAT IS AUTHORITATIVE, AND OVER EXACTLY WHAT CODE: mechanism (2), the BEHAVIOURAL BSD-shim
+#     differential. It does not care how a construct is SPELLED — but it can only speak for the
+#     code it actually EXECUTES, and that is a SHORT, NAMED LIST: the guard test's `sed_inplace`,
+#     `sed_inplace_verified` and `summary_key_order`, extracted verbatim and run under the BSD
+#     `sed -i` / BSD `paste` shims, plus the two bare shim controls. (Sections (3) and (4) also
+#     EXECUTE real guard-test text — the `case-f-invocation-asserts` block, and the prologue +
+#     tally epilogue — but NOT under the shims, so they are not portability coverage.) Everything
+#     else in the scanned files — the whole of the rest of test_roborev_review_guard.sh, all of
+#     scripts/flow/roborev-review*.sh, and roborev-job-facts.py — is covered by the ENUMERATED
+#     SCANNER ALONE.
+#   * SO THE COVERAGE CLAIM IS NARROW, AND THIS IS ITS HONEST FORM (#3296 round-9 finding 2, which
+#     CORRECTS the round-8 wording here — the earlier text called a missed spelling a "BOUNDED
+#     FALSE NEGATIVE with a backstop underneath it" without qualification, and that was WRONG):
+#       - INSIDE the three executed helpers, a missed spelling IS bounded: the behavioural probe
+#         catches the defect whatever the spelling, because it runs the code under BSD semantics.
+#       - ANYWHERE ELSE in the scanned files there is NO backstop. An unenumerated spelling
+#         introduced there — `$SED -i`, an alias, `eval`, a quoted metacharacter inside the option
+#         run — is an UNCOVERED false negative: this file reports the code path clean and nothing
+#         in it will contradict that. See residual 5 below, which states it as a residual rather
+#         than leaving it to be rediscovered.
+#   * WHY THIS STILL SURVIVES WHERE THE DELETED LINT DID NOT — and the difference is NOT "it has a
+#     backstop everywhere", which is the claim just retracted. It is that the deleted lint's misses
+#     were false PASSES about the property it was the SOLE check for, and its false-PASS count GREW
+#     across review rounds (1, 1, 2, 3). This table's misses are false NEGATIVES of a tripwire that
+#     claims only to be a tripwire; its coverage is stated rather than implied; and every fix to it
+#     is additive.
 #   * WHAT A NEWLY-DISCOVERED SPELLING MEANS: add a row and a positive control — a cheap ADDITIVE
 #     fix. It is NOT evidence that the mechanism is broken, and it is not a reason to attempt a
 #     shell tokeniser here (a second implementation of shell grammar, whose correctness is
-#     knowable only by differential testing against the first).
+#     knowable only by differential testing against the first). Extending the differential to one
+#     more real call site is the other additive route, and is how `sed_inplace_verified` got here.
 # The residual it leaves is enumerated in full under "STATED RESIDUAL" below.
 #
 # THIS FILE SCANS ITSELF. It runs inside the macOS-sensitive `roborev-lints` gate component and
@@ -275,8 +296,30 @@ fi
 #      quiet direction — noise here would be worse than a miss, per the negative controls).
 #   4. A construct built by string concatenation or eval (`cmd="sed -"; cmd="$cmd i"`).
 #
-# Each of these is a MISS, never a false green elsewhere; the behavioural shim differential in
-# section (2) is the backstop that catches what the text scan cannot see.
+#   5. THE BACKSTOP DOES NOT COVER THE WHOLE SCANNED SET, AND 1-4 ARE UNCOVERED OUTSIDE IT
+#      (#3296 round-9 finding 2 — this bullet CORRECTS an earlier claim made right here, that the
+#      shim differential "is the backstop that catches what the text scan cannot see", full stop).
+#      It is not, in general. The differential EXECUTES exactly three helpers — `sed_inplace`,
+#      `sed_inplace_verified`, `summary_key_order` — under BSD `sed -i` / BSD `paste` semantics.
+#      For code INSIDE those three, residuals 1-4 are bounded: the probe runs the code and a defect
+#      surfaces as a failing case whatever the spelling. For every OTHER line of the scanned set —
+#      the rest of test_roborev_review_guard.sh, all four scripts/flow/roborev-review* files —
+#      the enumerated scanner is the ONLY mechanism in this file, so a spelling from 1-4 introduced
+#      THERE is an UNCOVERED false negative: the scan reports the code path clean and no probe
+#      contradicts it.
+#      This is a KNOWN REDUCTION IN COVERAGE, accepted and recorded, not argued away. It is NOT
+#      closed by adding "parsing-based validation": a bash re-implementation of shell word
+#      splitting is a second implementation of a grammar, and a second implementation's correctness
+#      is knowable only by differential testing against the original — the failure recorded in
+#      CLAUDE.md for the deleted `census-exclusion:` predictor (which was tested against a MODEL of
+#      Go rather than against Go) and for the deleted status lint further down this file (a
+#      false-PASS count that GREW: 1, 1, 2, 3). The two routes that ARE open are both additive and
+#      cheap: extend the differential to one more real call site (which is how
+#      `sed_inplace_verified` came to be covered), or add the spelling to the table with a positive
+#      control.
+#
+# Residuals 1-4 are MISSES, never false greens about something else. Residual 5 says where those
+# misses have a behavioural backstop underneath them and where they do not.
 # ---------------------------------------------------------------------------
 
 # The scan body: code only. A construct named in a comment (this repo documents the ones it
@@ -901,7 +944,12 @@ extract_fn() { # extract_fn <name> -> the function's source text
   awk -v fn="$1" '$0 ~ "^" fn "\\(\\) \\{" { inside = 1 } inside { print } inside && /^\}$/ { exit }' "$GUARD"
 }
 
-for _fn in sed_inplace summary_key_order; do
+# `sed_inplace_verified` is extracted and exercised too (#3296 round-9): it is the helper the
+# caller contract PREFERS for every mutate-then-assert case, it wraps `sed_inplace`, and running it
+# under the BSD sed shim costs one more name in this list. That widens the behavioural coverage by
+# one real call site — which is the only honest way to widen the backstop claim in the scope
+# statement above.
+for _fn in sed_inplace sed_inplace_verified summary_key_order; do
   _src=$(extract_fn "$_fn")
   if [ -z "$_src" ]; then
     bad "extraction: $_fn is not defined in $(basename "$GUARD") — the portable helper was removed or renamed, so nothing below tests it"
@@ -916,7 +964,8 @@ for _fn in sed_inplace summary_key_order; do
   eval "$_src"
 done
 
-if ! declare -f sed_inplace >/dev/null || ! declare -f summary_key_order >/dev/null; then
+if ! declare -f sed_inplace >/dev/null || ! declare -f sed_inplace_verified >/dev/null ||
+  ! declare -f summary_key_order >/dev/null; then
   bad 'extraction: the guard test helpers are not available — the differential below cannot run'
 else
   # --- sed_inplace, single-line substitution, under BSD -i semantics.
@@ -939,6 +988,39 @@ else
     ok 'sed_inplace: the cx29-shaped two-line replacement lands, with the new line immediately after the header'
   else
     bad "sed_inplace: the multi-line replacement did not land as two lines (line 2 = '$_mp')"
+  fi
+
+  # --- sed_inplace_verified UNDER THE BSD sed SHIM (#3296 round-9): the helper the caller contract
+  # prefers, exercised behaviourally rather than only pinned by text. All three of its affirmative
+  # facts are covered — the edit landed, the wanted post-edit state is PRESENT, and the state it
+  # replaces is GONE — because a helper that returns 0 without checking them would let a case assert
+  # against content the edit never produced.
+  printf 'TIER1="PASS"\n' >"$tmp/ver.txt"
+  if PATH="$SHIM_PATH" sed_inplace_verified "$tmp/ver.txt" \
+    's/^TIER1="PASS"$/TIER1="MEASUREMENT-DID-NOT-HAPPEN"/' \
+    'TIER1="MEASUREMENT-DID-NOT-HAPPEN"' 'TIER1="PASS"' &&
+    grep -qF 'TIER1="MEASUREMENT-DID-NOT-HAPPEN"' "$tmp/ver.txt"; then
+    ok 'sed_inplace_verified: a mutation whose wanted state is present and whose replaced state is gone SUCCEEDS under BSD sed semantics'
+  else
+    bad "sed_inplace_verified: the verified mutation did not land under the BSD shim: $(cat "$tmp/ver.txt")"
+  fi
+  # The edit LANDS but the wanted state is NOT what was asked for: must be non-zero, or "the edit
+  # ran" would be mistaken for "the edit did what I meant".
+  printf 'TIER1="PASS"\n' >"$tmp/ver2.txt"
+  if PATH="$SHIM_PATH" sed_inplace_verified "$tmp/ver2.txt" \
+    's/^TIER1="PASS"$/TIER1="SOMETHING-ELSE"/' 'TIER1="WHAT-THE-CALLER-WANTED"'; then
+    bad 'sed_inplace_verified: an edit that landed but produced a DIFFERENT state returned SUCCESS — the wanted-state check is not enforced under BSD semantics'
+  else
+    ok 'sed_inplace_verified: an edit that lands but does NOT produce the wanted state returns NON-ZERO (the affirmative post-edit fact is enforced, not assumed)'
+  fi
+  # And the must-be-ABSENT direction: the edit landed and the wanted state is present, but the
+  # state that was supposed to be replaced is still in the file.
+  printf 'TIER1="PASS"\nTIER1="PASS"\n' >"$tmp/ver3.txt"
+  if PATH="$SHIM_PATH" sed_inplace_verified "$tmp/ver3.txt" \
+    '1s/^TIER1="PASS"$/TIER1="NEW"/' 'TIER1="NEW"' 'TIER1="PASS"'; then
+    bad 'sed_inplace_verified: a mutation that left the state it was supposed to REPLACE still in the file returned SUCCESS — the must-be-absent fact is not enforced'
+  else
+    ok 'sed_inplace_verified: a mutation that leaves the REPLACED state behind returns NON-ZERO (all three affirmative facts are required, under BSD semantics)'
   fi
 
   # --- AC2 AT THE EDIT SITE: an expression that matches NOTHING must be an ERROR, and the

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -117,7 +117,13 @@ RE_SED_INPLACE='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+(-i|--in-place)([[
 # cluster it consumes the NEXT ARGV entry as the backup suffix — byte for byte the #3296
 # defect, reached by a spelling the bare-`-i` regex never sees. `-i.bak` (an ATTACHED suffix)
 # is portable and deliberately NOT matched: both seds read it the same way.
-RE_SED_INPLACE_CLUSTER='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-[a-zA-Z]+i([[:space:]]|$)'
+#
+# The letters BEFORE the trailing `i` are restricted to the ARGUMENT-FREE sed options
+# (BSD `n E r a l u`, plus GNU's `s` and `z`). A cluster containing an ARGUMENT-TAKING option
+# never reaches an in-place flag at all: in `sed -fi input`, getopt gives `-f` the argument
+# "i" (the script file), so there is no `-i` and flagging it was a false positive. Same for
+# `-ei`, and for BSD's `-I`/`-i`, which take arguments themselves.
+RE_SED_INPLACE_CLUSTER='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-[nEralusz]+i([[:space:]]|$)'
 # PASTE WITH NO FILE OPERAND, in every spelling that reaches BSD's `if (*argv == NULL) usage();`:
 #   paste -sd,            bundled flags, nothing after them
 #   paste -d ,            the delimiter argument SEPARATED from -d (consumed as the option's
@@ -310,12 +316,16 @@ fi
 
 # NEGATIVE CONTROLS for the cluster rule: a cluster that does NOT end in `i`, and an ATTACHED
 # suffix (portable — both seds read `-i.bak` as -i with suffix ".bak"), must not be reported.
+# `-fi`/`-ei` are included because the trailing `i` there is the ARGUMENT of an argument-taking
+# option, not an in-place flag: `sed -fi input` reads its script from a file named "i".
 printf '%s\n' \
   "  sed -n '2p' \"\$f\"" \
   "  sed -E 's/a/b/' \"\$f\"" \
-  "  sed -Ei.bak -e 's/a/b/' \"\$f\"" >"$tmp/cluster-ok.sh"
+  "  sed -Ei.bak -e 's/a/b/' \"\$f\"" \
+  "  sed -fi input" \
+  "  sed -ei 's/a/b/' \"\$f\"" >"$tmp/cluster-ok.sh"
 if [ -z "$(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh")" ]; then
-  ok 'structural control: a non-`i` cluster (-n, -E) and an ATTACHED suffix (-Ei.bak) are not flagged — the rule reds only on the unportable spelling'
+  ok 'structural control: a non-`i` cluster (-n, -E), an ATTACHED suffix (-Ei.bak) and an argument-taking cluster (-fi, -ei, where the i is the OPTION ARGUMENT) are not flagged — the rule reds only on the unportable spelling'
 else
   bad "structural control: the cluster rule false-positives on a portable sed — a lint that reds on correct input is the lint agents learn to waive: $(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh" | tr '\n' ' ')"
 fi
@@ -685,16 +695,47 @@ _cf_block=$(awk '/^# >>> BEGIN case-f-invocation-asserts/,/^# <<< END case-f-inv
 if [ -z "$_cf_block" ] || ! printf '%s\n' "$_cf_block" | grep -q 'work_canon='; then
   bad 'AC3: the case-f-invocation-asserts block could not be extracted from the guard test (markers removed?) — the contract is then untested here'
 else
-  mkdir -p "$tmp/real/work"
-  ln -s "$tmp/real" "$tmp/link"
+  # FIXTURE SETUP IS ITSELF MEASURED. Every command below was previously allowed to fail
+  # silently: a failed `git init`/commit leaves `_canon` EMPTY, and an empty `_canon` still
+  # satisfies `"$work" != "$_canon"`, so the probes would then compare the wrapper's contract
+  # against an empty expected repo path and report success. That is a positive verdict with no
+  # affirmative measurement behind it — the defect this whole file exists to prevent. So the
+  # setup is a fail-closed chain, `_canon` must be non-empty, ABSOLUTE, and actually resolve to
+  # the fixture, and an unestablished fixture is a loud counted SKIP, never a pass.
+  _cf_setup_err=''
   work="$tmp/link/work"
-  git init -q -b main "$work" >/dev/null 2>&1
-  git -C "$work" config user.email t@e && git -C "$work" config user.name t
-  printf 'x\n' >"$work/f.txt"
-  git -C "$work" add f.txt >/dev/null 2>&1
-  git -C "$work" commit -q -m base >/dev/null 2>&1
-  _canon=$(cd "$(git -C "$work" rev-parse --show-toplevel)" && pwd -P)
-  if [ "$work" = "$_canon" ]; then
+  mkdir -p "$tmp/real/work" || _cf_setup_err='mkdir of the fixture dir failed'
+  [ -n "$_cf_setup_err" ] || ln -s "$tmp/real" "$tmp/link" || _cf_setup_err='the symlink that reproduces /var -> /private/var could not be created'
+  [ -n "$_cf_setup_err" ] || git init -q -b main "$work" >/dev/null 2>&1 || _cf_setup_err='git init failed'
+  [ -n "$_cf_setup_err" ] || git -C "$work" config user.email t@e || _cf_setup_err='git config user.email failed'
+  [ -n "$_cf_setup_err" ] || git -C "$work" config user.name t || _cf_setup_err='git config user.name failed'
+  [ -n "$_cf_setup_err" ] || printf 'x\n' >"$work/f.txt" || _cf_setup_err='writing the fixture file failed'
+  [ -n "$_cf_setup_err" ] || git -C "$work" add f.txt >/dev/null 2>&1 || _cf_setup_err='git add failed'
+  [ -n "$_cf_setup_err" ] || git -C "$work" commit -q -m base >/dev/null 2>&1 || _cf_setup_err='git commit failed'
+  _canon=''
+  if [ -z "$_cf_setup_err" ]; then
+    _top=$(git -C "$work" rev-parse --show-toplevel 2>/dev/null) ||
+      _cf_setup_err='git rev-parse --show-toplevel failed'
+    [ -n "$_top" ] || _cf_setup_err='git rev-parse --show-toplevel returned nothing'
+    if [ -z "$_cf_setup_err" ]; then
+      _canon=$(cd "$_top" 2>/dev/null && pwd -P) || _cf_setup_err='canonicalising the fixture path failed'
+    fi
+  fi
+  # The canonical path must be non-empty, absolute, AND the same directory as $work — an
+  # arbitrary non-empty string would satisfy the "differs from $work" control by accident.
+  if [ -z "$_cf_setup_err" ]; then
+    case "$_canon" in
+      /*) ;;
+      *) _cf_setup_err="the canonical path is not absolute: '$_canon'" ;;
+    esac
+  fi
+  if [ -z "$_cf_setup_err" ] && ! [ "$_canon" -ef "$work" ]; then
+    _cf_setup_err="the canonical path '$_canon' is not the same directory as the fixture '$work'"
+  fi
+
+  if [ -n "$_cf_setup_err" ]; then
+    skip "AC3: the case (f) fixture could not be established ($_cf_setup_err) — the canonicalisation contract was NOT MEASURED on this host. Not a pass: the probes below are skipped rather than run against an unestablished fixture."
+  elif [ "$work" = "$_canon" ]; then
     bad 'AC3: the symlinked fixture did not produce a path that differs from its canonical form — the canonicalisation is not actually exercised, so a PASS below would be vacuous'
   else
     ok "AC3 control: the fixture path differs from its canonical form ($work vs $_canon), reproducing the macOS /var -> /private/var split"
@@ -723,15 +764,19 @@ else
     esac
   }
 
-  _tail='--agent codex --model gpt-5.6-sol --wait'
-  probe_case_f sanctioned 'the sanctioned canonical --repo record' accept \
-    "review --branch --base origin/main --repo $_canon $_tail"
-  probe_case_f relative 'a RELATIVE --repo' reject \
-    "review --branch --base origin/main --repo . $_tail"
-  probe_case_f rootco 'a ROOT-CHECKOUT --repo' reject \
-    "review --branch --base origin/main --repo $REPO_ROOT $_tail"
-  probe_case_f norepo 'a --branch review with NO --repo at all' reject \
-    "review --branch --base origin/main $_tail"
+  if [ -n "$_cf_setup_err" ]; then
+    skip 'AC3: the four case (f) contract probes (sanctioned / relative / root-checkout / no --repo) were NOT RUN, because the fixture above could not be established'
+  else
+    _tail='--agent codex --model gpt-5.6-sol --wait'
+    probe_case_f sanctioned 'the sanctioned canonical --repo record' accept \
+      "review --branch --base origin/main --repo $_canon $_tail"
+    probe_case_f relative 'a RELATIVE --repo' reject \
+      "review --branch --base origin/main --repo . $_tail"
+    probe_case_f rootco 'a ROOT-CHECKOUT --repo' reject \
+      "review --branch --base origin/main --repo $REPO_ROOT $_tail"
+    probe_case_f norepo 'a --branch review with NO --repo at all' reject \
+      "review --branch --base origin/main $_tail"
+  fi
 fi
 
 # ===========================================================================

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -127,6 +127,18 @@ RE_SED_INPLACE='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+(-i|--in-place(=[^
 # "i" (the script file), so there is no `-i` and flagging it was a false positive. Same for
 # `-ei`, and for BSD's `-I`/`-i`, which take arguments themselves.
 RE_SED_INPLACE_CLUSTER='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-[nEralusz]+i([[:space:]]|$)'
+# THE EMPTY-SUFFIX SPELLINGS, `-i""` and `-i''`. GNU sed reads an ATTACHED empty suffix as "edit
+# in place, keep no backup"; BSD sed has no such reading (it needs `-i ''` as a separate word, or
+# no `-i` at all), so the GNU-only spelling is a portability defect in its own right.
+#
+# THESE TWO RULES ALSO TAKE THE OPTION RUN (#3296 round-8 finding 2). The first form required
+# `-i""` to sit IMMEDIATELY after `sed`, so `sed -e 's/a/b/' -i'' f` — the same defect one option
+# further along — was invisible to EVERY rule in this table: measured `. . . .` against the bare
+# rule, the cluster rule and both empty-suffix rules before this fix. `--in-place=SUFFIX` needed
+# no such repair; it is already reached through the option run above, and both of its positions
+# are now pinned by controls below rather than assumed.
+RE_SED_INPLACE_EMPTY_DQ='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-i("")'
+RE_SED_INPLACE_EMPTY_SQ='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-i'"('')"
 # PASTE WITH NO FILE OPERAND, in every spelling that reaches BSD's `if (*argv == NULL) usage();`:
 #   paste -sd,            bundled flags, nothing after them
 #   paste -d ,            the delimiter argument SEPARATED from -d (consumed as the option's
@@ -146,10 +158,10 @@ add_construct "$RE_SED_INPLACE" \
 add_construct "$RE_SED_INPLACE_CLUSTER" \
   "a BUNDLED cluster ending in -i (-Ei, -ni, -nEi, …) reaches the SAME BSD argument-consuming -i as a bare -i, so the edit never lands — use sed_inplace" \
   "  sed -Ei 's/a/b/' \"\$f\""
-add_construct '(^|[^[:alnum:]_-])sed[[:space:]]+-i("")' \
+add_construct "$RE_SED_INPLACE_EMPTY_DQ" \
   'the empty-suffix spelling -i"" is GNU-only (BSD needs -i "" or no -i at all) — use sed_inplace' \
   '  sed -i"" -e s/a/b/ f'
-add_construct "(^|[^[:alnum:]_-])sed[[:space:]]+-i('')" \
+add_construct "$RE_SED_INPLACE_EMPTY_SQ" \
   "the empty-suffix spelling -i'' is GNU-only — use sed_inplace" \
   "  sed -i'' -e s/a/b/ f"
 add_construct "$RE_PASTE_NO_OPERAND" \
@@ -383,6 +395,30 @@ assert_flagged '`paste -sd, <"$f"` (redirection with no space)' "$tmp/sp-redir2.
 # (e) the GNU long spelling, absent from BSD sed entirely.
 printf '%s\n' "  sed --in-place -e 's/a/b/' file" >"$tmp/sp-long.sh"
 assert_flagged '`sed --in-place` (GNU long option; BSD sed has no such flag)' "$tmp/sp-long.sh"
+# (f) the long spelling with an ATTACHED `=SUFFIX`, in BOTH positions — adjacent to `sed` and
+# beyond an intervening option. A long-option rule that requires WHITESPACE after the option name
+# sees neither; this table's does not, and both positions are now pinned by measurement instead of
+# left to inspection of the regex (#3296 round-8 finding 2).
+printf '%s\n' "  sed --in-place=.bak -e 's/a/b/' file" >"$tmp/sp-long-eq.sh"
+assert_flagged '`sed --in-place=.bak …` (long option with an ATTACHED suffix, adjacent to sed)' "$tmp/sp-long-eq.sh"
+printf '%s\n' "  sed -e 's/a/b/' --in-place=.bak file" >"$tmp/sp-long-eq2.sh"
+assert_flagged '`sed -e EXPR --in-place=.bak file` (attached-suffix long option BEYOND an intervening option)' "$tmp/sp-long-eq2.sh"
+# (g) the EMPTY-SUFFIX spellings beyond the adjacent position. Before the empty-suffix rules were
+# given the same option-run handling as the bare `-i` rule, these were invisible to EVERY rule in
+# the table — the hole this control now closes and keeps closed.
+printf '%s\n' "  sed -e 's/a/b/' -i'' file" >"$tmp/sp-empty-sq.sh"
+assert_flagged "\`sed -e EXPR -i'' file\` (empty SINGLE-quoted suffix beyond the adjacent position)" "$tmp/sp-empty-sq.sh"
+printf '%s\n' "  sed -e 's/a/b/' -i\"\" file" >"$tmp/sp-empty-dq.sh"
+assert_flagged '`sed -e EXPR -i"" file` (empty DOUBLE-quoted suffix beyond the adjacent position)' "$tmp/sp-empty-dq.sh"
+# The widening must not reach past a shell metacharacter here either: an empty-suffix `-i` on the
+# far side of a pipe belongs to a DIFFERENT command.
+printf '%s\n' '  sed '"'"'s/x/y/'"'"' f | grep -i'"''"' foo' >"$tmp/sp-empty-pipe.sh"
+assert_not_flagged "a \`grep -i''\` AFTER a pipe (the empty-suffix rules stop at the metacharacter too)" "$tmp/sp-empty-pipe.sh"
+# And the same spellings in PROSE stay invisible: this repo documents the constructs it bans, so a
+# comment naming one is not an invocation.
+printf '%s\n' "# prose: sed -e 's/a/b/' -i'' file, and sed --in-place=.bak, are both banned here" \
+  >"$tmp/sp-new-cmt.sh"
+assert_not_flagged 'the new in-place spellings named in a COMMENT (prose about a banned construct is not an invocation)' "$tmp/sp-new-cmt.sh"
 
 # NEGATIVE CONTROLS for the widened option run — this is where widening can go wrong.
 # The first is the important one: an `-i` belonging to a DIFFERENT command after a pipe must

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -98,18 +98,38 @@ SCAN_FILES=(
 CONSTRUCT_RE=(); CONSTRUCT_WHY=(); CONSTRUCT_SAMPLE=()
 add_construct() { CONSTRUCT_RE+=("$1"); CONSTRUCT_WHY+=("$2"); CONSTRUCT_SAMPLE+=("$3"); }
 
-# The two patterns whose controls below name them directly are held in NAMED variables rather
+# The patterns whose controls below name them directly are held in NAMED variables rather
 # than referenced by table INDEX: an index reference silently retargets when a row is inserted
 # above it, which would leave a control asserting about a different rule than it names.
-RE_SED_INPLACE='(^|[^[:alnum:]_-])sed[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-i([[:space:]]|$)'
+#
+# THE OPTION RUN. `-i` does not have to sit next to `sed`: `sed -e 's/a/b/' -i file` reaches the
+# same BSD argument-consuming `-i` (it eats `file` as the backup suffix) while an "adjacent
+# flags only" regex sees nothing. So the rules skip over an arbitrary run of intervening
+# tokens — BUT that run stops dead at a shell metacharacter (| ; & < > ( )), which is what
+# keeps `sed 's/x/y/' f | grep -i foo` from being read as a sed `-i`: the `-i` there belongs to
+# a DIFFERENT command. This is deliberately a LINE-ORIENTED approximation of shell parsing and
+# not a tokeniser; the residual it leaves is stated in full below the table.
+_OPT_RUN='([[:space:]]+[^[:space:]|;&<>()]+)*'
+RE_SED_INPLACE='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+(-i|--in-place)([[:space:]]|$)'
 # BUNDLED CLUSTERS ending in `i` — the hole the bare `-i` rule above leaves open. BSD getopt
 # processes `-Ei` as `-E` then `-i`, and `i` is declared WITH A REQUIRED ARGUMENT (Apple
 # text_cmds sed/main.c: `getopt(argc, argv, "EI:ae:f:i:lnru")`), so with nothing left in the
 # cluster it consumes the NEXT ARGV entry as the backup suffix — byte for byte the #3296
 # defect, reached by a spelling the bare-`-i` regex never sees. `-i.bak` (an ATTACHED suffix)
 # is portable and deliberately NOT matched: both seds read it the same way.
-RE_SED_INPLACE_CLUSTER='(^|[^[:alnum:]_-])sed[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-[a-zA-Z]+i([[:space:]]|$)'
-RE_PASTE_NO_OPERAND='(^|[^[:alnum:]_-])paste([[:space:]]+-[^[:space:]|;)&]+)*[[:space:]]*($|\||\)|;|&)'
+RE_SED_INPLACE_CLUSTER='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-[a-zA-Z]+i([[:space:]]|$)'
+# PASTE WITH NO FILE OPERAND, in every spelling that reaches BSD's `if (*argv == NULL) usage();`:
+#   paste -sd,            bundled flags, nothing after them
+#   paste -d ,            the delimiter argument SEPARATED from -d (consumed as the option's
+#                         argument by getopt, so it is not an operand either)
+#   paste -sd, < input    a REDIRECTION is not an operand — BSD still usage()-errors, and the
+#                         `<` is why the option run above excludes redirection characters
+# The `-d`-with-separated-argument pair is matched as ONE unit, because a regex cannot express
+# "this bare token is the argument of the preceding option" any other way.
+_PASTE_DARG='[[:space:]]+-[a-zA-Z]*d[[:space:]]+[^[:space:]|;)&<]+'
+_PASTE_OPT='[[:space:]]+-[^[:space:]|;)&<]+'
+_PASTE_REDIR='([[:space:]]*<[[:space:]]*[^[:space:]|;)&]+)?'
+RE_PASTE_NO_OPERAND='(^|[^[:alnum:]_-])paste('"$_PASTE_DARG"'|'"$_PASTE_OPT"')*'"$_PASTE_REDIR"'[[:space:]]*($|\||\)|;|&)'
 
 add_construct "$RE_SED_INPLACE" \
   "BSD sed's -i takes a REQUIRED suffix argument, so it eats the EXPRESSION and the edit never lands (#3296 cx28/cx29/cx28b/cx28c) — use the guard test's sed_inplace helper" \
@@ -162,13 +182,68 @@ if [ "${#CONSTRUCT_RE[@]}" -ne "${#CONSTRUCT_WHY[@]}" ] ||
   bad 'structural: the construct table arrays are not the same length — some pattern has no reason or no positive control'
 fi
 
+# ---------------------------------------------------------------------------
+# STATED RESIDUAL (an undocumented hole is worse than no guard, because it invites reliance it
+# cannot support). This scanner is line-oriented ERE matching over backslash-JOINED logical
+# lines. It is deliberately NOT a shell tokeniser: a bash re-implementation of shell word
+# splitting would be a second implementation whose own correctness is only knowable by
+# differential testing against the first, which is the failure mode CLAUDE.md records for the
+# deleted `census-exclusion:` predictor (a false-PASS count that GREW across review rounds).
+# So these spellings are KNOWN NOT COVERED, by choice:
+#
+#   1. A shell metacharacter INSIDE QUOTES within the option run, e.g.
+#        sed -e 's/a|b/c/' -i f
+#      The run stops at the `|` because nothing here knows it is quoted. Un-quoted, the same
+#      `|` really would end the command, and reading it as one is what prevents the
+#      `sed … | grep -i …` false positive — the two cases are indistinguishable line-wise.
+#   2. The command name reached through a VARIABLE or an alias: `$SED -i f`, `"${SED}" -i f`.
+#      (`command sed -i f` and `env sed -i f` ARE caught — the literal name is present.)
+#   3. An operand supplied at RUNTIME: `paste -sd, $files` is flagged when $files is empty and
+#      not otherwise; the scanner cannot know, so it treats a bare word as an operand (the
+#      quiet direction — noise here would be worse than a miss, per the negative controls).
+#   4. A construct built by string concatenation or eval (`cmd="sed -"; cmd="$cmd i"`).
+#
+# Each of these is a MISS, never a false green elsewhere; the behavioural shim differential in
+# section (2) is the backstop that catches what the text scan cannot see.
+# ---------------------------------------------------------------------------
+
 # The scan body: code only. A construct named in a comment (this repo documents the ones it
 # banned) is prose, not an invocation. A line carrying `portability-lint-allow` is exempt —
 # the repo's existing escape-marker convention (`injection-lint-allow`, `perf-gate-allow`) —
 # so a provably-safe or deliberately-BSD-emulating line has a route that is VISIBLE in the
 # diff instead of forcing a rewrite of the lint.
+#
+# CONTINUATION JOINING: `sed \` + newline + `-i file` is ONE command that no line-oriented ERE
+# can see, so logical lines are assembled before matching. The awk below is written to keep the
+# output the SAME LENGTH as the input — a joined logical line is emitted at the position of its
+# FIRST physical line and each consumed continuation becomes a blank — so `grep -n` line numbers
+# still name the real line in the real file. Comment-only and marker-exempt lines are BLANKED
+# rather than deleted for the same reason (deleting them, as the previous form did, shifted
+# every number after them). A comment line is never joined to the next: `#` in shell comments to
+# end of line, so a trailing backslash there continues nothing.
 scan_hits() { # scan_hits <ere> <file>
-  grep -vE '^[[:space:]]*#' "$2" | grep -v 'portability-lint-allow' | grep -nE -- "$1" || true
+  awk '
+    function emit_logical(  i) {
+      if (buf ~ /portability-lint-allow/) print ""; else print buf
+      for (i = 0; i < pending; i++) print ""
+      buf = ""; have = 0; pending = 0
+    }
+    BEGIN { buf = ""; have = 0; pending = 0 }
+    {
+      if (have == 0) {
+        if ($0 ~ /^[[:space:]]*#/) { print ""; next }
+        buf = $0; have = 1; pending = 0
+      } else {
+        line = $0
+        sub(/^[[:space:]]+/, "", line)
+        buf = buf " " line
+        pending = pending + 1
+      }
+      if (buf ~ /\\$/) { sub(/\\$/, "", buf); next }
+      emit_logical()
+    }
+    END { if (have == 1) emit_logical() }
+  ' "$2" | grep -nE -- "$1" || true
 }
 
 for _ci in "${!CONSTRUCT_RE[@]}"; do
@@ -243,6 +318,86 @@ if [ -z "$(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh")" ]; then
   ok 'structural control: a non-`i` cluster (-n, -E) and an ATTACHED suffix (-Ei.bak) are not flagged — the rule reds only on the unportable spelling'
 else
   bad "structural control: the cluster rule false-positives on a portable sed — a lint that reds on correct input is the lint agents learn to waive: $(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh" | tr '\n' ' ')"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTROLS FOR THE SPELLINGS THE ADJACENT-FLAGS-ONLY FORM MISSED (roborev round 2). Each named
+# form gets its OWN control and each is asserted to FIRE — a rule without a control is a rule
+# nobody has tested. Multi-line fixtures are written as separate printf arguments so the
+# continuation-joining path is exercised on real newlines, not on an escaped approximation.
+# The assertion is against the UNION of the table's rules, because "is this flagged by the
+# scan" is the property the guard actually provides.
+# ---------------------------------------------------------------------------
+scan_any() { # scan_any <file> -> hits from ANY rule in the table
+  local _i _h _all=""
+  for _i in "${!CONSTRUCT_RE[@]}"; do
+    _h=$(scan_hits "${CONSTRUCT_RE[$_i]}" "$1")
+    [ -n "$_h" ] && _all="$_all ${_h%%$'\n'*}"
+  done
+  printf '%s' "$_all"
+}
+assert_flagged() { # assert_flagged <label> <file>
+  if [ -n "$(scan_any "$2")" ]; then
+    ok "structural control: $1 is FLAGGED"
+  else
+    bad "structural control: $1 is NOT flagged — the scan has a hole at this spelling, and a guard with a known-but-hidden miss invites reliance it cannot support"
+  fi
+}
+assert_not_flagged() { # assert_not_flagged <label> <file>
+  if [ -z "$(scan_any "$2")" ]; then
+    ok "structural control: $1 is correctly NOT flagged"
+  else
+    bad "structural control: $1 was flagged — a lint that reds on correct input is the lint agents learn to waive:$(scan_any "$2")"
+  fi
+}
+
+# (a) -i AFTER an intervening option argument. BSD eats `file` as the backup suffix.
+printf '%s\n' "  sed -e 's/a/b/' -i file" >"$tmp/sp-optrun.sh"
+assert_flagged '`sed -e EXPR -i file` (-i beyond the adjacent option run)' "$tmp/sp-optrun.sh"
+# (b) a LINE-BROKEN invocation — invisible to any single-line ERE, hence the joiner.
+printf '%s\n' '  sed \' '    -i '"'"'s/a/b/'"'"' file' >"$tmp/sp-break.sh"
+assert_flagged '`sed \` + newline + `-i …` (backslash-continued across lines)' "$tmp/sp-break.sh"
+printf '%s\n' '  sed -e '"'"'s/a/b/'"'"' \' '    -Ei file' >"$tmp/sp-break2.sh"
+assert_flagged 'a line-broken invocation whose continuation carries a BUNDLED -Ei' "$tmp/sp-break2.sh"
+# (c) the delimiter argument SEPARATED from -d, with no operand.
+printf '%s\n' '  order=$(paste -d ,)' >"$tmp/sp-darg.sh"
+assert_flagged '`paste -d ,` (separated delimiter argument, still no file operand)' "$tmp/sp-darg.sh"
+# (d) a REDIRECTION is not an operand — BSD usage()-errors just the same.
+printf '%s\n' '  order=$(paste -sd, < input)' >"$tmp/sp-redir.sh"
+assert_flagged '`paste -sd, < input` (a redirection is not a file operand)' "$tmp/sp-redir.sh"
+printf '%s\n' '  order=$(paste -sd, <"$f")' >"$tmp/sp-redir2.sh"
+assert_flagged '`paste -sd, <"$f"` (redirection with no space)' "$tmp/sp-redir2.sh"
+# (e) the GNU long spelling, absent from BSD sed entirely.
+printf '%s\n' "  sed --in-place -e 's/a/b/' file" >"$tmp/sp-long.sh"
+assert_flagged '`sed --in-place` (GNU long option; BSD sed has no such flag)' "$tmp/sp-long.sh"
+
+# NEGATIVE CONTROLS for the widened option run — this is where widening can go wrong.
+# The first is the important one: an `-i` belonging to a DIFFERENT command after a pipe must
+# not be attributed to the sed, which is why the option run stops at a shell metacharacter.
+printf '%s\n' '  sed '"'"'s/x/y/'"'"' f | grep -i foo' >"$tmp/sp-pipe.sh"
+assert_not_flagged 'a `grep -i` AFTER a pipe (the -i belongs to another command)' "$tmp/sp-pipe.sh"
+printf '%s\n' "  sed -e 's/a/b/' file" >"$tmp/sp-noi.sh"
+assert_not_flagged 'a multi-option sed with NO in-place flag' "$tmp/sp-noi.sh"
+printf '%s\n' '  order=$(paste -d , "$f")' >"$tmp/sp-dargok.sh"
+assert_not_flagged '`paste -d , FILE` (separated delimiter argument WITH an operand)' "$tmp/sp-dargok.sh"
+printf '%s\n' '  grep -q foo \' '    "$f" | sed -n '"'"'1p'"'"'' >"$tmp/sp-breakok.sh"
+assert_not_flagged 'a benign backslash-continued command (joining must not manufacture a hit)' "$tmp/sp-breakok.sh"
+# A comment line ending in a backslash continues NOTHING in shell, so it must not swallow the
+# next line into a joined logical line — otherwise a comment could mask real code below it.
+printf '%s\n' '# sed \' "  echo ok" >"$tmp/sp-cmtbreak.sh"
+assert_not_flagged 'a COMMENT ending in a backslash (it must not join the code line beneath it)' "$tmp/sp-cmtbreak.sh"
+printf '%s\n' '# prose about sed, ending in a backslash \' "  sed -i 's/a/b/' file" \
+  >"$tmp/sp-cmtbreak2.sh"
+assert_flagged 'a REAL `sed -i` on the line beneath a backslash-ended COMMENT (joining it into the comment would MASK it)' "$tmp/sp-cmtbreak2.sh"
+
+# The joiner rewrites the stream, so LINE NUMBERS are asserted rather than assumed: a report
+# naming the wrong line sends the next reader to the wrong place.
+printf '%s\n' '# a comment' '' "  sed -i 's/a/b/' f" '  echo tail' >"$tmp/sp-lineno.sh"
+_ln=$(scan_hits "$RE_SED_INPLACE" "$tmp/sp-lineno.sh")
+if [ "${_ln%%:*}" = 3 ]; then
+  ok 'structural control: a hit is reported at its REAL file line (blanking, not deleting, keeps numbering exact)'
+else
+  bad "structural control: the hit was reported at line '${_ln%%:*}' but lives at line 3 — the scan's line numbers do not name the real file"
 fi
 
 # NEGATIVE CONTROL for the paste pattern, whose ERE is the subtlest of the table: a paste WITH

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -73,7 +73,23 @@ if [ ! -f "$GUARD" ]; then
   exit 1
 fi
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/roborev-portability.XXXXXX")
+# THE TEMP DIRECTORY IS VERIFIED BEFORE ANYTHING USES IT, AND BEFORE THE TRAP (#3296 round-12).
+# An unchecked `mktemp -d` that fails, or that prints nothing, leaves $tmp EMPTY — and then every
+# `"$tmp/x"` below resolves to `/x`. This script does not merely read those paths, it CREATES them
+# unconditionally: `mkdir -p "$tmp/real/work"`, `ln -s "$tmp/real" "$tmp/link"`,
+# `chmod 000 "$tmp/cnr-noread.sh"`, dozens of `>"$tmp/…"` fixtures. On a privileged runner that is
+# root-level file creation, and the files are left behind. It is gate-wired into `roborev-lints`, so
+# it runs on every --lite and every full gate.
+#
+# THE ORDER IS THE POINT, not just the check: installing `trap 'rm -rf "$tmp"' EXIT` while $tmp may
+# be empty arms a recursive delete for a path that is not ours, so the verification must come first.
+# BOTH facts are required — a NON-EMPTY string AND an actual DIRECTORY — because a `mktemp` that
+# emitted a diagnostic on stdout, or a path that vanished, would satisfy the emptiness test alone.
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/roborev-portability.XXXXXX") || tmp=''
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  printf 'FAIL - mktemp -d did not yield a usable temp directory (got: %s) — refusing to run rather than resolving every "$tmp/..." fixture path under /\n' "${tmp:-<empty>}"
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT
 
 # ===========================================================================

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -660,44 +660,77 @@ else
   # land, but that is protection only if the caller READS it; a bare statement call leaves
   # "matched nothing" (and every other unmeasured state) on the permissive path, so the case's
   # later assertion can be satisfied by the STALE content — the roborev finding on
-  # test_roborev_review_guard.sh's cx29 restore, which read `ok` on cx28's mutation. Line-
-  # oriented on purpose (no shell tokeniser here, by design): a call is required to sit in a
-  # CONDITIONAL position, i.e. after `if`/`elif`/`while`/`until` (optionally negated) or joined
-  # with `&&`/`||`. Definitions and prose are excluded, and the rule carries a POSITIVE CONTROL
-  # below so a regex that silently matches nothing cannot pass.
+  # test_roborev_review_guard.sh's cx29 restore, which read `ok` on cx28's mutation.
+  #
+  # AN ALLOW-LIST, NOT A DENY-LIST (#3296 round-5 blocker 3). The first form of this rule
+  # EXCLUDED lines containing `&&`/`||` anywhere, which accepted `true && sed_inplace "$f" "$e"`
+  # and `sed_inplace "$f" "$e"; true || bad` — two forms in which the mutation's status is
+  # DISCARDED under this script's non-errexit execution. That is the very shape this rule exists
+  # to catch, reintroduced inside the rule: unanticipated spellings inheriting the permissive
+  # branch. So the ACCEPTED forms are now ENUMERATED and everything else FAILs, including forms
+  # nobody anticipated:
+  #   (1) directly controlled:      [if|elif|while|until] [!] sed_inplace…      (start of line)
+  #   (2) direct failure handler:   sed_inplace… || bad|return|exit              (start of line,
+  #                                 with no `;`/`&` between the call and the `||`)
+  # Deciding "is this status consumed?" in general is shell-semantics analysis and is deliberately
+  # OUT OF BOUNDS. A call in an unlisted form reds the gate with a message saying the FORM was not
+  # recognised, and the author rewrites it into an accepted form (or marks the line
+  # `portability-lint-allow`, the repo's visible-in-the-diff escape marker, which scan_hits
+  # honours). False FAILs are acceptable noise here; a false PASS is blindness.
+  #
   # Reuses scan_hits, so comment-only lines are blanked and a call whose `|| bad …` sits on a
   # CONTINUATION line is judged on the joined logical line (the deliberate design: line-oriented
   # matching plus continuation joining, never a shell tokeniser).
   _ss_call_re='(^|[^[:alnum:]_])sed_inplace(_verified)?[[:space:]]+"'
-  sed_status_offenders() { # sed_status_offenders <file> -> "lineno:logical-line" per discarding call
+  _ss_ok_controlled='^[0-9]+:[[:space:]]*(if|elif|while|until)[[:space:]]+(![[:space:]]*)?sed_inplace(_verified)?[[:space:]]+"'
+  _ss_ok_handler='^[0-9]+:[[:space:]]*(![[:space:]]*)?sed_inplace(_verified)?[[:space:]]+"[^;&]*\|\|[[:space:]]*(bad|return|exit)([[:space:]]|$)'
+  sed_status_offenders() { # sed_status_offenders <file> -> "lineno:logical-line" per unaccepted call
     scan_hits "$_ss_call_re" "$1" \
-      | grep -vE '^[0-9]+:[[:space:]]*(if|elif|while|until)[[:space:]]+!?[[:space:]]*sed_inplace' \
-      | grep -vE '^[0-9]+:.*(\&\&|\|\|)[[:space:]]*!?[[:space:]]*sed_inplace' \
-      | grep -vE '^[0-9]+:.*sed_inplace(_verified)?[[:space:]].*(\&\&|\|\|)' \
+      | grep -vE "$_ss_ok_controlled" \
+      | grep -vE "$_ss_ok_handler" \
       || printf ''
   }
-  # BOTH DIRECTIONS. The rule must flag the discarding form and must NOT flag the two accepted
-  # status-reading forms, or it would either pass vacuously or force the callers to hide from it.
-  printf '%s\n' '  sed_inplace "$f" '"'"'s/a/b/'"'" >"$tmp/sed-status-violation.sh"
-  printf '%s\n' 'if sed_inplace "$f" '"'"'s/a/b/'"'"'; then :; fi' >"$tmp/sed-status-ok-if.sh"
-  printf '%s\n' '  sed_inplace "$f" \' '    '"'"'s/a/b/'"'"' || bad no' >"$tmp/sed-status-ok-or.sh"
-  if [ -n "$(sed_status_offenders "$tmp/sed-status-violation.sh")" ]; then
-    ok 'AC2 control: the discarded-status rule DETECTS a bare `sed_inplace` statement call (so its clean verdict below is a measurement)'
-  else
-    bad 'AC2 control: the discarded-status rule did not flag a bare `sed_inplace` statement call — every clean verdict from it would be vacuous'
-  fi
-  for _ssok in if:"$tmp/sed-status-ok-if.sh" or:"$tmp/sed-status-ok-or.sh"; do
-    if [ -z "$(sed_status_offenders "${_ssok#*:}")" ]; then
-      ok "AC2 control: the rule accepts a status-READING call (${_ssok%%:*} form)"
+  # BOTH DIRECTIONS, and the FALSE-ACCEPTING forms the round-5 review named are PERMANENT
+  # negative controls: the complement of the allow-list is pinned, so a widening cannot regress
+  # unnoticed. `flag` = must be reported, `ok` = must be accepted.
+  _ss_ctl_dir="$tmp/sed-status"
+  mkdir -p "$_ss_ctl_dir"
+  _sq="'"
+  printf '%s\n' "  sed_inplace \"\$f\" ${_sq}s/a/b/${_sq}" >"$_ss_ctl_dir/flag-bare.sh"
+  printf '%s\n' "  true && sed_inplace \"\$f\" \"\$expr\"" >"$_ss_ctl_dir/flag-and-chain.sh"
+  printf '%s\n' "  sed_inplace \"\$f\" \"\$expr\"; true || bad no" >"$_ss_ctl_dir/flag-semicolon-or.sh"
+  printf '%s\n' "  sed_inplace \"\$f\" \"\$expr\" && ok yes" >"$_ss_ctl_dir/flag-and-success.sh"
+  printf '%s\n' "if sed_inplace \"\$f\" ${_sq}s/a/b/${_sq}; then :; fi" >"$_ss_ctl_dir/ok-if.sh"
+  printf '%s\n' "  sed_inplace \"\$f\" \\" "    ${_sq}s/a/b/${_sq} || bad no" >"$_ss_ctl_dir/ok-or-bad.sh"
+  printf '%s\n' "  elif ! sed_inplace_verified \"\$f\" \"\$expr\" \"\$want\"; then" >"$_ss_ctl_dir/ok-elif-negated.sh"
+  for _ssc in \
+    'flag:bare statement call:flag-bare.sh' \
+    'flag:`true && sed_inplace …` (status discarded — the round-5 finding):flag-and-chain.sh' \
+    'flag:`sed_inplace …; true || bad` (the handler belongs to `true`):flag-semicolon-or.sh' \
+    'flag:`sed_inplace … && ok` (a SUCCESS chain handles no failure):flag-and-success.sh' \
+    'ok:`if sed_inplace …; then`:ok-if.sh' \
+    'ok:a line-broken call with `|| bad` on the continuation:ok-or-bad.sh' \
+    'ok:`elif ! sed_inplace_verified …; then`:ok-elif-negated.sh'; do
+    _ss_want="${_ssc%%:*}"
+    _ss_rest="${_ssc#*:}"
+    _ss_why="${_ss_rest%:*}"
+    _ss_file="$_ss_ctl_dir/${_ss_rest##*:}"
+    _ss_got=$(sed_status_offenders "$_ss_file")
+    if [ "$_ss_want" = flag ] && [ -n "$_ss_got" ]; then
+      ok "AC2 control: the status-check allow-list REPORTS $_ss_why"
+    elif [ "$_ss_want" = flag ]; then
+      bad "AC2 control: the status-check allow-list ACCEPTED $_ss_why — the mutation's status is discarded there, so a stale-content pass is possible again"
+    elif [ -z "$_ss_got" ]; then
+      ok "AC2 control: the status-check allow-list accepts $_ss_why"
     else
-      bad "AC2 control: the rule flagged a status-READING call (${_ssok%%:*} form) — it would force callers to hide from it rather than measure"
+      bad "AC2 control: the status-check allow-list reported an ACCEPTED form ($_ss_why) — it would force callers to hide from it rather than measure"
     fi
   done
   _ss_hits=$(sed_status_offenders "$GUARD")
   if [ -z "$_ss_hits" ]; then
-    ok 'AC2: every sed_inplace/sed_inplace_verified call in the guard test READS the status (no mutation is asserted against without being measured)'
+    ok 'AC2: every sed_inplace/sed_inplace_verified call in the guard test is in an ACCEPTED status-reading form (no mutation is asserted against without being measured)'
   else
-    bad "AC2: the guard test discards a mutation helper's status at: $(printf '%s' "$_ss_hits" | tr '\n' ' ') — an unapplied edit would be asserted against, and the case could pass on stale content"
+    bad "AC2: the guard test has a mutation call in an UNRECOGNISED form (its status may be discarded) at: $(printf '%s' "$_ss_hits" | tr '\n' ' ') — rewrite it as \`if [!] sed_inplace…\` or \`sed_inplace… || bad|return|exit\`"
   fi
 
   # --- summary_key_order under the paste shim, plus the RED side of the differential.

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -638,11 +638,14 @@ else
 
   # --- AC2 IN THE CASES: the four cases must STILL verify the mutation landed. Asserted on
   # the guard test's TEXT, because a helper that is fail-closed today does not keep the CASES
-  # fail-closed tomorrow. These are the three verification forms cx28 / cx29 / cx28b+cx28c use.
+  # fail-closed tomorrow. These are the verification forms cx28 / cx29 / cx28b+cx28c use — each
+  # now names the state that must be PRESENT after the edit and, where an earlier case's
+  # mutation must be gone, the state that must be ABSENT (`sed_inplace_verified`, #3296).
   for _vpair in \
-    "grep -qF 'TIER1=\"MEASUREMENT-DID-NOT-HAPPEN\"'|cx28 verifies its unrecognised-verdict patch landed" \
+    "'    TIER1=\"MEASUREMENT-DID-NOT-HAPPEN\"' '    TIER1=\"PASS\"'|cx28 verifies its unrecognised-verdict patch landed and replaced the valid value" \
     "= '  return 0'|cx29 verifies its early-return patch is the line after the header" \
-    "grep -qF \"TIER1=\\\"\$_np_value\\\"\"|cx28b/cx28c verify their near-prefix patch landed"; do
+    "'    TIER1=\"PASS\"' 'MEASUREMENT-DID-NOT-HAPPEN'|cx29 verifies the cx28 mutation was really restored (present PASS, absent stale value)" \
+    "\"    TIER1=\\\"\$_np_value\\\"\" '    TIER1=\"PASS\"'|cx28b/cx28c verify their near-prefix patch landed and replaced the valid value"; do
     _vtext="${_vpair%%|*}"
     _vwhy="${_vpair#*|}"
     if grep -qF -- "$_vtext" "$GUARD"; then
@@ -651,6 +654,51 @@ else
       bad "AC2: the guard test no longer contains this verification ($_vwhy) — a case that cannot detect an unapplied patch is a regression even when green"
     fi
   done
+
+  # --- AC2, THE CLASS RATHER THAN THE INSTANCES: no mutation call site may DISCARD the
+  # helper's status. `sed_inplace`/`sed_inplace_verified` return non-zero when the edit did not
+  # land, but that is protection only if the caller READS it; a bare statement call leaves
+  # "matched nothing" (and every other unmeasured state) on the permissive path, so the case's
+  # later assertion can be satisfied by the STALE content — the roborev finding on
+  # test_roborev_review_guard.sh's cx29 restore, which read `ok` on cx28's mutation. Line-
+  # oriented on purpose (no shell tokeniser here, by design): a call is required to sit in a
+  # CONDITIONAL position, i.e. after `if`/`elif`/`while`/`until` (optionally negated) or joined
+  # with `&&`/`||`. Definitions and prose are excluded, and the rule carries a POSITIVE CONTROL
+  # below so a regex that silently matches nothing cannot pass.
+  # Reuses scan_hits, so comment-only lines are blanked and a call whose `|| bad …` sits on a
+  # CONTINUATION line is judged on the joined logical line (the deliberate design: line-oriented
+  # matching plus continuation joining, never a shell tokeniser).
+  _ss_call_re='(^|[^[:alnum:]_])sed_inplace(_verified)?[[:space:]]+"'
+  sed_status_offenders() { # sed_status_offenders <file> -> "lineno:logical-line" per discarding call
+    scan_hits "$_ss_call_re" "$1" \
+      | grep -vE '^[0-9]+:[[:space:]]*(if|elif|while|until)[[:space:]]+!?[[:space:]]*sed_inplace' \
+      | grep -vE '^[0-9]+:.*(\&\&|\|\|)[[:space:]]*!?[[:space:]]*sed_inplace' \
+      | grep -vE '^[0-9]+:.*sed_inplace(_verified)?[[:space:]].*(\&\&|\|\|)' \
+      || printf ''
+  }
+  # BOTH DIRECTIONS. The rule must flag the discarding form and must NOT flag the two accepted
+  # status-reading forms, or it would either pass vacuously or force the callers to hide from it.
+  printf '%s\n' '  sed_inplace "$f" '"'"'s/a/b/'"'" >"$tmp/sed-status-violation.sh"
+  printf '%s\n' 'if sed_inplace "$f" '"'"'s/a/b/'"'"'; then :; fi' >"$tmp/sed-status-ok-if.sh"
+  printf '%s\n' '  sed_inplace "$f" \' '    '"'"'s/a/b/'"'"' || bad no' >"$tmp/sed-status-ok-or.sh"
+  if [ -n "$(sed_status_offenders "$tmp/sed-status-violation.sh")" ]; then
+    ok 'AC2 control: the discarded-status rule DETECTS a bare `sed_inplace` statement call (so its clean verdict below is a measurement)'
+  else
+    bad 'AC2 control: the discarded-status rule did not flag a bare `sed_inplace` statement call — every clean verdict from it would be vacuous'
+  fi
+  for _ssok in if:"$tmp/sed-status-ok-if.sh" or:"$tmp/sed-status-ok-or.sh"; do
+    if [ -z "$(sed_status_offenders "${_ssok#*:}")" ]; then
+      ok "AC2 control: the rule accepts a status-READING call (${_ssok%%:*} form)"
+    else
+      bad "AC2 control: the rule flagged a status-READING call (${_ssok%%:*} form) — it would force callers to hide from it rather than measure"
+    fi
+  done
+  _ss_hits=$(sed_status_offenders "$GUARD")
+  if [ -z "$_ss_hits" ]; then
+    ok 'AC2: every sed_inplace/sed_inplace_verified call in the guard test READS the status (no mutation is asserted against without being measured)'
+  else
+    bad "AC2: the guard test discards a mutation helper's status at: $(printf '%s' "$_ss_hits" | tr '\n' ' ') — an unapplied edit would be asserted against, and the case could pass on stale content"
+  fi
 
   # --- summary_key_order under the paste shim, plus the RED side of the differential.
   printf 'vacuity-tier2: PASS\nroborev-exit: PASS\nfindings: NONE\nlog: /tmp/x\n' >"$tmp/block.txt"

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -601,6 +601,40 @@ else
   else
     bad 'sed_inplace: a no-op patch changed the file'
   fi
+  # --- MODE PRESERVATION, BOTH DIRECTIONS (#3296 round-6). The cases in the guard test mutate
+  # COPIES OF EXECUTABLE FLOW SCRIPTS (roborev-review-checks.sh, mode 755). The first form of the
+  # helper ended in `mv scratch original`, and the scratch was created fresh by `>`, so it carried
+  # `0666 & ~umask` — no execute bits under ANY umask: measured `-rwxr-xr-x` -> `-rw-rw-r--` on a
+  # successful edit. An environment-dependent breakage introduced by a portability fix is the very
+  # class this branch closes, so it is pinned here in both directions: a SUCCESSFUL edit and a
+  # FAILED (no-change, non-zero) edit must both leave the file executable. `[ -x ]` is POSIX test,
+  # not a `stat` format flag (those are the GNU-vs-BSD divergence itself).
+  printf '#!/bin/sh\necho alpha\n' >"$tmp/exec-ok.sh"
+  chmod 755 "$tmp/exec-ok.sh"
+  if [ ! -x "$tmp/exec-ok.sh" ]; then
+    bad 'sed_inplace control: the fixture could not be made executable, so mode preservation was NOT MEASURED (a filesystem mounted noexec-ish?)'
+  else
+    if PATH="$SHIM_PATH" sed_inplace "$tmp/exec-ok.sh" 's/alpha/ALPHA/' &&
+      grep -qF 'echo ALPHA' "$tmp/exec-ok.sh"; then
+      if [ -x "$tmp/exec-ok.sh" ]; then
+        ok 'sed_inplace: a SUCCESSFUL edit preserves the executable bit (the original file is truncated and rewritten, never replaced by a fresh umask-moded file)'
+      else
+        bad 'sed_inplace: a successful edit LOST the executable bit — mutating a copied flow script would make it non-executable, which is a new platform/umask-dependent breakage'
+      fi
+    else
+      bad 'sed_inplace: the mode-preservation fixture edit did not land, so the executable-bit contract was NOT MEASURED'
+    fi
+    printf '#!/bin/sh\necho beta\n' >"$tmp/exec-noop.sh"
+    chmod 755 "$tmp/exec-noop.sh"
+    if PATH="$SHIM_PATH" sed_inplace "$tmp/exec-noop.sh" 's/^nothing-matches-this$/x/'; then
+      bad 'sed_inplace: the no-op fixture edit returned SUCCESS, so the FAILED-edit direction of the mode contract was not exercised'
+    elif [ -x "$tmp/exec-noop.sh" ]; then
+      ok 'sed_inplace: a FAILED (no-change, non-zero) edit also preserves the executable bit'
+    else
+      bad 'sed_inplace: a FAILED edit LOST the executable bit — the failure path must leave the file exactly as it was'
+    fi
+  fi
+
   # And no temp spill: the helper must not leave its scratch file behind on the failure path.
   #
   # AFFIRMATIVE MEASUREMENT (CLAUDE.md: "never derive a pass from the ABSENCE of a bad

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -145,11 +145,22 @@ RE_SED_INPLACE_EMPTY_SQ='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+-i'"('')"
 #                         argument by getopt, so it is not an operand either)
 #   paste -sd, < input    a REDIRECTION is not an operand — BSD still usage()-errors, and the
 #                         `<` is why the option run above excludes redirection characters
+#   paste -sd, >out       an OUTPUT redirection is not an operand either
+#   paste -sd, 2>/dev/null   nor is a FILE-DESCRIPTOR redirection
 # The `-d`-with-separated-argument pair is matched as ONE unit, because a regex cannot express
 # "this bare token is the argument of the preceding option" any other way.
 _PASTE_DARG='[[:space:]]+-[a-zA-Z]*d[[:space:]]+[^[:space:]|;)&<]+'
 _PASTE_OPT='[[:space:]]+-[^[:space:]|;)&<]+'
-_PASTE_REDIR='([[:space:]]*<[[:space:]]*[^[:space:]|;)&]+)?'
+# THE REDIRECTION GRAMMAR COVERS ALL THREE DIRECTIONS, AND REPEATS (#3296 round-8 finding 3). The
+# first form recognised ONE OPTIONAL INPUT redirection, so `paste -sd, >output`,
+# `paste -sd, 2>/dev/null`, `paste -sd, >>out 2>&1` and `paste -sd, <in >out` each had NO file
+# operand, diverged on BSD exactly as case (j2) did, and were reported CLEAN (measured: `.` under
+# the old grammar, `X` under this one, for all four). A redirection is: an optional fd number, one
+# of `<` `>` `>>`, an optional `&` (so `2>&1` is one redirection, not a redirection plus a stray
+# operand), and a target; zero or more of them may follow the options. `[0-9]*`/`&?` are what keep
+# the fd forms from being read as operands, which is the whole point of the rule.
+_PASTE_REDIR_ONE='[[:space:]]*[0-9]*(>>|<|>)&?[[:space:]]*[^[:space:]|;)&]+'
+_PASTE_REDIR='('"$_PASTE_REDIR_ONE"')*'
 RE_PASTE_NO_OPERAND='(^|[^[:alnum:]_-])paste('"$_PASTE_DARG"'|'"$_PASTE_OPT"')*'"$_PASTE_REDIR"'[[:space:]]*($|\||\)|;|&)'
 
 add_construct "$RE_SED_INPLACE" \
@@ -392,6 +403,28 @@ printf '%s\n' '  order=$(paste -sd, < input)' >"$tmp/sp-redir.sh"
 assert_flagged '`paste -sd, < input` (a redirection is not a file operand)' "$tmp/sp-redir.sh"
 printf '%s\n' '  order=$(paste -sd, <"$f")' >"$tmp/sp-redir2.sh"
 assert_flagged '`paste -sd, <"$f"` (redirection with no space)' "$tmp/sp-redir2.sh"
+# (d2) OUTPUT and FILE-DESCRIPTOR redirections are not operands either — one control per spelling,
+# because an input-only grammar reported every one of these CLEAN (#3296 round-8 finding 3).
+printf '%s\n' '  paste -sd, >output' >"$tmp/sp-redir-out.sh"
+assert_flagged '`paste -sd, >output` (an OUTPUT redirection is not a file operand)' "$tmp/sp-redir-out.sh"
+printf '%s\n' '  paste -sd, >>output' >"$tmp/sp-redir-app.sh"
+assert_flagged '`paste -sd, >>output` (an APPEND redirection is not a file operand)' "$tmp/sp-redir-app.sh"
+printf '%s\n' '  paste -sd, 2>/dev/null' >"$tmp/sp-redir-fd.sh"
+assert_flagged '`paste -sd, 2>/dev/null` (a FILE-DESCRIPTOR redirection is not a file operand)' "$tmp/sp-redir-fd.sh"
+printf '%s\n' '  paste -sd, >out 2>&1' >"$tmp/sp-redir-both.sh"
+assert_flagged '`paste -sd, >out 2>&1` (a RUN of redirections, one of them an fd duplication)' "$tmp/sp-redir-both.sh"
+printf '%s\n' '  paste -sd, <in >out' >"$tmp/sp-redir-inout.sh"
+assert_flagged '`paste -sd, <in >out` (input AND output redirection, still no operand)' "$tmp/sp-redir-inout.sh"
+printf '%s\n' '  order=$(paste -sd, >"$out")' >"$tmp/sp-redir-subst.sh"
+assert_flagged '`order=$(paste -sd, >"$out")` (output redirection inside a command substitution)' "$tmp/sp-redir-subst.sh"
+# And the NEGATIVE direction for the widened grammar, which is where widening can go wrong: a
+# paste that HAS an operand must stay unflagged even when it also redirects.
+printf '%s\n' '  paste -sd, "$f" >out' >"$tmp/sp-redir-okfile.sh"
+assert_not_flagged '`paste -sd, "$f" >out` (an operand AND a redirection — portable)' "$tmp/sp-redir-okfile.sh"
+printf '%s\n' '  paste -sd, - 2>/dev/null' >"$tmp/sp-redir-okdash.sh"
+assert_not_flagged '`paste -sd, - 2>/dev/null` (the explicit `-` stdin operand plus an fd redirection)' "$tmp/sp-redir-okdash.sh"
+printf '%s\n' '#  paste -sd, >output and paste -sd, 2>/dev/null are both banned' >"$tmp/sp-redir-cmt.sh"
+assert_not_flagged 'the redirection spellings named in a COMMENT (prose, not an invocation)' "$tmp/sp-redir-cmt.sh"
 # (e) the GNU long spelling, absent from BSD sed entirely.
 printf '%s\n' "  sed --in-place -e 's/a/b/' file" >"$tmp/sp-long.sh"
 assert_flagged '`sed --in-place` (GNU long option; BSD sed has no such flag)' "$tmp/sp-long.sh"

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -1170,20 +1170,69 @@ else
   # satisfies `"$work" != "$_canon"`, so the probes would then compare the wrapper's contract
   # against an empty expected repo path and report success. That is a positive verdict with no
   # affirmative measurement behind it — the defect this whole file exists to prevent. So the
-  # setup is a fail-closed chain, `_canon` must be non-empty, ABSOLUTE, and actually resolve to
-  # the fixture, and an unestablished fixture is a loud counted SKIP, never a pass.
+  # setup is a fail-closed chain and `_canon` must be non-empty, ABSOLUTE, and actually resolve
+  # to the fixture.
+  #
+  # MEASURING IT WAS NOT ENOUGH, BECAUSE THE MEASUREMENT'S FAILURE BRANCH WAS A SKIP (#3296
+  # round-9 finding 3, a RE-OCCURRENCE in the same place as the round-3 commit titled "AC3 fixture
+  # setup must be measured"). Every cause — a broken command, a failed write, a canonicalisation
+  # error — became a counted SKIP while the script still exited 0, so a regression in fixture setup
+  # SILENTLY DISABLED all four canonical-path contract probes without failing the gate. CLAUDE.md
+  # is explicit: a SKIP means the check never ran, which IS the vacuous pass itself. Turning a
+  # per-cause measurement into one permissive bucket reproduces the very defect being measured.
+  #
+  # So the two are now DIFFERENT KINDS OF THING and are classified before the chain runs:
+  #   * an ENVIRONMENT LIMITATION — affirmatively identified, by name, by a dedicated CAPABILITY
+  #     PROBE, and only for the two conditions a supported host may legitimately lack: `git`, and
+  #     a filesystem that can create symlinks. That is the ONLY route to `skip`.
+  #   * EVERYTHING ELSE is a FAILURE of this file's own fixture, and goes to `bad`.
+  # A cause nobody enumerated is therefore a red, not a silent skip — noise, never blindness.
+  cf_env_limitation() { # cf_env_limitation <scratch-dir> -> a NAMED limitation on stdout, else nothing
+    if ! command -v git >/dev/null 2>&1; then
+      printf 'git is not installed on this host, and the case (f) fixture is a git repository'
+      return 0
+    fi
+    # `ln -s` needs no existing target, so a dangling link is a sufficient capability probe.
+    if ln -s "$1/cf-symlink-probe-target" "$1/cf-symlink-probe" 2>/dev/null &&
+      [ -L "$1/cf-symlink-probe" ]; then
+      rm -f "$1/cf-symlink-probe"
+      return 0
+    fi
+    printf 'symlinks cannot be created under %s, and the fixture needs one to reproduce the macOS /var -> /private/var split' "$1"
+  }
+  # THE CLASSIFIER IS CONTROLLED IN BOTH DIRECTIONS, because a skip route that can never fire is
+  # dead code, and one that fires on a healthy host would silently disable the probes below.
+  _cf_probe_ok=$(cf_env_limitation "$tmp")
+  if [ -z "$_cf_probe_ok" ]; then
+    ok 'AC3 control: no environment limitation is detected on this host, so the four case (f) contract probes below really RUN (a skip here would be the vacuous pass)'
+  else
+    skip "AC3 control: an environment limitation is present on this host ($_cf_probe_ok), so the case (f) probes cannot run here"
+  fi
+  mkdir -p "$tmp/cf-ro" 2>/dev/null
+  chmod 555 "$tmp/cf-ro" 2>/dev/null
+  if ln -s x "$tmp/cf-ro/writable-check" 2>/dev/null; then
+    rm -f "$tmp/cf-ro/writable-check"
+    skip 'AC3 control: the symlink-capability branch could NOT be provoked — a read-only directory still accepted a symlink (running as root, or a filesystem that ignores mode bits), so that skip route was not measured on this host'
+  elif [ -n "$(cf_env_limitation "$tmp/cf-ro")" ]; then
+    ok 'AC3 control: the symlink-capability probe DETECTS a filesystem that cannot create the link — the one legitimate skip route is reachable and named, not dead code'
+  else
+    bad 'AC3 control: the symlink-capability probe reported NO limitation on a directory where `ln -s` demonstrably fails — the skip route cannot be reached, so a genuine environment limitation would be reported as a fixture FAILURE'
+  fi
+  chmod 755 "$tmp/cf-ro" 2>/dev/null
+
+  _cf_env_limit=$(cf_env_limitation "$tmp")
   _cf_setup_err=''
   work="$tmp/link/work"
-  mkdir -p "$tmp/real/work" || _cf_setup_err='mkdir of the fixture dir failed'
-  [ -n "$_cf_setup_err" ] || ln -s "$tmp/real" "$tmp/link" || _cf_setup_err='the symlink that reproduces /var -> /private/var could not be created'
-  [ -n "$_cf_setup_err" ] || git init -q -b main "$work" >/dev/null 2>&1 || _cf_setup_err='git init failed'
-  [ -n "$_cf_setup_err" ] || git -C "$work" config user.email t@e || _cf_setup_err='git config user.email failed'
-  [ -n "$_cf_setup_err" ] || git -C "$work" config user.name t || _cf_setup_err='git config user.name failed'
-  [ -n "$_cf_setup_err" ] || printf 'x\n' >"$work/f.txt" || _cf_setup_err='writing the fixture file failed'
-  [ -n "$_cf_setup_err" ] || git -C "$work" add f.txt >/dev/null 2>&1 || _cf_setup_err='git add failed'
-  [ -n "$_cf_setup_err" ] || git -C "$work" commit -q -m base >/dev/null 2>&1 || _cf_setup_err='git commit failed'
+  [ -n "$_cf_env_limit" ] || mkdir -p "$tmp/real/work" || _cf_setup_err='mkdir of the fixture dir failed'
+  [ -n "$_cf_env_limit$_cf_setup_err" ] || ln -s "$tmp/real" "$tmp/link" || _cf_setup_err='the symlink that reproduces /var -> /private/var could not be created (the capability probe above says this filesystem CAN make symlinks, so this is a fixture failure, not an environment limitation)'
+  [ -n "$_cf_env_limit$_cf_setup_err" ] || git init -q -b main "$work" >/dev/null 2>&1 || _cf_setup_err='git init failed'
+  [ -n "$_cf_env_limit$_cf_setup_err" ] || git -C "$work" config user.email t@e || _cf_setup_err='git config user.email failed'
+  [ -n "$_cf_env_limit$_cf_setup_err" ] || git -C "$work" config user.name t || _cf_setup_err='git config user.name failed'
+  [ -n "$_cf_env_limit$_cf_setup_err" ] || printf 'x\n' >"$work/f.txt" || _cf_setup_err='writing the fixture file failed'
+  [ -n "$_cf_env_limit$_cf_setup_err" ] || git -C "$work" add f.txt >/dev/null 2>&1 || _cf_setup_err='git add failed'
+  [ -n "$_cf_env_limit$_cf_setup_err" ] || git -C "$work" commit -q -m base >/dev/null 2>&1 || _cf_setup_err='git commit failed'
   _canon=''
-  if [ -z "$_cf_setup_err" ]; then
+  if [ -z "$_cf_env_limit$_cf_setup_err" ]; then
     _top=$(git -C "$work" rev-parse --show-toplevel 2>/dev/null) ||
       _cf_setup_err='git rev-parse --show-toplevel failed'
     [ -n "$_top" ] || _cf_setup_err='git rev-parse --show-toplevel returned nothing'
@@ -1193,18 +1242,20 @@ else
   fi
   # The canonical path must be non-empty, absolute, AND the same directory as $work — an
   # arbitrary non-empty string would satisfy the "differs from $work" control by accident.
-  if [ -z "$_cf_setup_err" ]; then
+  if [ -z "$_cf_env_limit$_cf_setup_err" ]; then
     case "$_canon" in
       /*) ;;
       *) _cf_setup_err="the canonical path is not absolute: '$_canon'" ;;
     esac
   fi
-  if [ -z "$_cf_setup_err" ] && ! [ "$_canon" -ef "$work" ]; then
+  if [ -z "$_cf_env_limit$_cf_setup_err" ] && ! [ "$_canon" -ef "$work" ]; then
     _cf_setup_err="the canonical path '$_canon' is not the same directory as the fixture '$work'"
   fi
 
-  if [ -n "$_cf_setup_err" ]; then
-    skip "AC3: the case (f) fixture could not be established ($_cf_setup_err) — the canonicalisation contract was NOT MEASURED on this host. Not a pass: the probes below are skipped rather than run against an unestablished fixture."
+  if [ -n "$_cf_env_limit" ]; then
+    skip "AC3: the case (f) fixture could not be established because of an affirmatively identified environment limitation ($_cf_env_limit) — the canonicalisation contract was NOT MEASURED on this host. Not a pass: the probes below are skipped rather than run against an unestablished fixture."
+  elif [ -n "$_cf_setup_err" ]; then
+    bad "AC3: the case (f) fixture setup FAILED ($_cf_setup_err). This is a defect in THIS FILE's fixture, not a limitation of the host — the capability probe above found none — so it is a counted FAILURE, never a skip: as a skip it silently disabled all four canonical-path contract probes while the script still exited 0 (#3296 round-9)."
   elif [ "$work" = "$_canon" ]; then
     bad 'AC3: the symlinked fixture did not produce a path that differs from its canonical form — the canonicalisation is not actually exercised, so a PASS below would be vacuous'
   else
@@ -1234,8 +1285,10 @@ else
     esac
   }
 
-  if [ -n "$_cf_setup_err" ]; then
-    skip 'AC3: the four case (f) contract probes (sanctioned / relative / root-checkout / no --repo) were NOT RUN, because the fixture above could not be established'
+  if [ -n "$_cf_env_limit" ]; then
+    skip 'AC3: the four case (f) contract probes (sanctioned / relative / root-checkout / no --repo) were NOT RUN, because of the environment limitation named above'
+  elif [ -n "$_cf_setup_err" ]; then
+    bad 'AC3: the four case (f) contract probes (sanctioned / relative / root-checkout / no --repo) were NOT RUN, because this file’s own fixture setup FAILED — losing all four contract probes is a counted FAILURE, not a skip'
   else
     _tail='--agent codex --model gpt-5.6-sol --wait'
     probe_case_f sanctioned 'the sanctioned canonical --repo record' accept \

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -293,7 +293,72 @@ fi
 # rather than deleted for the same reason (deleting them, as the previous form did, shifted
 # every number after them). A comment line is never joined to the next: `#` in shell comments to
 # end of line, so a trailing backslash there continues nothing.
-scan_hits() { # scan_hits <ere> <file>
+#
+# A SCAN THAT COULD NOT RUN IS NOT A CLEAN SCAN (#3296 round-9 finding 1). The first form ended
+# `awk … | grep -nE -- "$1" || true`, and that `|| true` swallowed EVERY non-zero status, not just
+# grep's "no matches": an unreadable scan target, an `awk` that died, a MALFORMED ERE in the table
+# (grep exits 2) — each produced empty output and was reported as "the roborev code path is free
+# of this construct". That is the purest form of the defect this whole branch is about, one level
+# down: the mechanism that cannot run reports the same green as the mechanism that found nothing.
+#
+# So the two stages are now measured SEPARATELY and only ONE status means "no findings":
+#   * the target must be READABLE before anything is attempted;
+#   * the preprocessing awk's own exit status is captured, with its stderr, and any non-zero is an
+#     ERROR — never an empty result;
+#   * of grep's statuses ONLY 1 means "no matches". 0 means hits; anything else (2 = bad regex or
+#     an I/O error) is an ERROR. `grep -c`-style thinking ("no output means clean") is exactly
+#     what is being removed here.
+# The three states are returned as 0 = hits / 1 = none / 2 = COULD NOT RUN, and state 2 carries a
+# named cause in SCAN_ERR. There is deliberately no fourth, permissive state.
+SCAN_ERR=''
+SCAN_HITS_FILE=''
+scan_hits_to() { # scan_hits_to <ere> <file> -> 0 hits (in $SCAN_HITS_FILE) / 1 none / 2 could-not-run
+  local _re="$1" _f="$2" _pre="$tmp/scan-pre.txt" _serr="$tmp/scan-stderr.txt" _arc _grc
+  SCAN_ERR=''
+  SCAN_HITS_FILE="$tmp/scan-hits.txt"
+  : >"$SCAN_HITS_FILE"
+  if [ ! -f "$_f" ]; then
+    SCAN_ERR="the scan target does not exist: $_f"
+    return 2
+  fi
+  if [ ! -r "$_f" ]; then
+    SCAN_ERR="the scan target exists but is NOT READABLE: $_f"
+    return 2
+  fi
+  scan_preprocess "$_f" >"$_pre" 2>"$_serr"
+  _arc=$?
+  if [ "$_arc" -ne 0 ]; then
+    SCAN_ERR="the preprocessing awk exited $_arc on $_f (stderr: $(tr '\n' ' ' <"$_serr"))"
+    return 2
+  fi
+  grep -nE -- "$_re" "$_pre" >"$SCAN_HITS_FILE" 2>"$_serr"
+  _grc=$?
+  case "$_grc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *)
+      SCAN_ERR="grep exited $_grc — neither 0 (matched) nor 1 (no match), so this is an ERROR, not a clean scan — on $_f with ERE '$_re' (stderr: $(tr '\n' ' ' <"$_serr"))"
+      return 2 ;;
+  esac
+}
+
+# scan_found is what every call site uses. It COUNTS the could-not-run state as a failure itself,
+# right where the cause is known, and still returns 2 so the caller reports NO verdict: an errored
+# scan has no verdict to give, and printing either `ok` or `bad` for it would be a verdict derived
+# from an unmeasured state.
+scan_found() { # scan_found <ere> <file> -> 0 hits / 1 none / 2 could-not-run (already counted)
+  local _rc
+  scan_hits_to "$1" "$2"
+  _rc=$?
+  if [ "$_rc" -eq 2 ]; then
+    bad "structural: the scan itself COULD NOT RUN — $SCAN_ERR. A scan that cannot run has no verdict to give, so this is a counted FAILURE and never a clean scan (#3296 round-9)."
+  fi
+  return "$_rc"
+}
+scan_first_hit() { head -1 "$SCAN_HITS_FILE"; }
+scan_all_hits() { tr '\n' ' ' <"$SCAN_HITS_FILE"; }
+
+scan_preprocess() { # scan_preprocess <file> -> the joined, comment-blanked logical-line stream
   awk '
     function emit_logical(  i) {
       if (buf ~ /portability-lint-allow/) print ""; else print buf
@@ -315,8 +380,105 @@ scan_hits() { # scan_hits <ere> <file>
       emit_logical()
     }
     END { if (have == 1) emit_logical() }
-  ' "$2" | grep -nE -- "$1" || true
+  ' "$1"
 }
+
+# ---------------------------------------------------------------------------
+# CONTROLS FOR THE COULD-NOT-RUN STATE ITSELF. A three-state contract is only protection if state 2
+# is REACHABLE and COUNTED, so each of its four causes is provoked here and required to be
+# classified 2 with a cause that NAMES it — and a clean scan is still required to be state 1, so
+# the fix has not turned every scan into an error. Without these the new branches would be dead
+# code asserted only in prose, which is the same shape as the defect they close.
+# ---------------------------------------------------------------------------
+_cnr="$tmp/cnr-clean.sh"
+printf '%s\n' '  echo portable' >"$_cnr"
+scan_hits_to '(^|[^[:alnum:]_-])stat[[:space:]]+-c' "$_cnr"
+if [ $? -eq 1 ]; then
+  ok 'scan-status control: a readable target with no match is state 1 (NO FINDINGS) — grep exit 1 is still the one status that means clean'
+else
+  bad "scan-status control: a clean scan was NOT classified as state 1 (SCAN_ERR: $SCAN_ERR) — the error handling has made every scan an error"
+fi
+scan_hits_to 'echo' "$_cnr"
+if [ $? -eq 0 ] && [ -s "$SCAN_HITS_FILE" ]; then
+  ok 'scan-status control: a matching target is state 0 with its hits in $SCAN_HITS_FILE'
+else
+  bad "scan-status control: a matching target was not classified as state 0 with hits (SCAN_ERR: $SCAN_ERR)"
+fi
+scan_hits_to 'x' "$tmp/definitely-absent-scan-target.sh"
+_cnr_rc=$?
+case "$_cnr_rc:$SCAN_ERR" in
+  '2:the scan target does not exist'*)
+    ok 'scan-status control: a MISSING scan target is state 2 (could-not-run) with a cause naming it — never an empty, clean-looking result' ;;
+  *)
+    bad "scan-status control: a MISSING scan target was classified rc $_cnr_rc / '$SCAN_ERR' — an absent target must not be reported as a clean scan" ;;
+esac
+printf '%s\n' '  echo x' >"$tmp/cnr-noread.sh"
+chmod 000 "$tmp/cnr-noread.sh" 2>/dev/null
+if [ -r "$tmp/cnr-noread.sh" ]; then
+  # An affirmatively identified environment limitation (running as root, or a filesystem that
+  # ignores mode bits): the file could not be MADE unreadable, so this cause cannot be provoked
+  # here. Named, counted, and never reported as a pass.
+  skip 'scan-status control: the unreadable-target cause was NOT MEASURED — chmod 000 left the file readable (running as root, or a filesystem that ignores mode bits)'
+else
+  scan_hits_to 'x' "$tmp/cnr-noread.sh"
+  _cnr_rc=$?
+  case "$_cnr_rc:$SCAN_ERR" in
+    '2:the scan target exists but is NOT READABLE'*)
+      ok 'scan-status control: an UNREADABLE scan target is state 2 with a cause naming it (the finding-1 case: `awk … | grep … || true` reported this as a CLEAN SCAN)' ;;
+    *)
+      bad "scan-status control: an UNREADABLE scan target was classified rc $_cnr_rc / '$SCAN_ERR' — this is the exact case the swallowed exit status reported clean" ;;
+  esac
+fi
+chmod 644 "$tmp/cnr-noread.sh" 2>/dev/null
+# A MALFORMED ERE makes grep exit 2. Under the old form that was indistinguishable from "no
+# matches", so a typo'd table entry silently certified every file clean, forever.
+scan_hits_to '(' "$_cnr"
+_cnr_rc=$?
+case "$_cnr_rc:$SCAN_ERR" in
+  '2:grep exited '*)
+    ok 'scan-status control: a MALFORMED ERE (grep exit 2) is state 2 with a cause naming grep’s status — only exit 1 is accepted as "no findings"' ;;
+  *)
+    bad "scan-status control: a MALFORMED ERE was classified rc $_cnr_rc / '$SCAN_ERR' — a broken pattern would then certify every scanned file clean" ;;
+esac
+# The PREPROCESSING stage's failure path, provoked by swapping the preprocessor for one that fails
+# and restoring the real text afterwards (`declare -f`, bash 3.2 compatible). Corrupting the real
+# awk program to test this would be untestable-in-place; this exercises the actual branch.
+_real_pre=$(declare -f scan_preprocess)
+if [ -z "$_real_pre" ]; then
+  bad 'scan-status control: scan_preprocess could not be captured, so the awk-failure branch was NOT MEASURED'
+else
+  scan_preprocess() { return 3; }
+  scan_hits_to 'x' "$_cnr"
+  _cnr_rc=$?
+  eval "$_real_pre"
+  case "$_cnr_rc:$SCAN_ERR" in
+    '2:the preprocessing awk exited 3'*)
+      ok 'scan-status control: a FAILING preprocessing stage is state 2 with a cause naming its exit status — an awk that dies no longer yields an empty, clean-looking scan' ;;
+    *)
+      bad "scan-status control: a failing preprocessing stage was classified rc $_cnr_rc / '$SCAN_ERR' — a dead awk would then be reported as a clean scan" ;;
+  esac
+  # And the restore must have worked, or every scan below runs against a stub.
+  scan_hits_to 'echo' "$_cnr"
+  if [ $? -eq 0 ]; then
+    ok 'scan-status control: the real preprocessor was restored after the injection (the scans below run against the real awk)'
+  else
+    bad "scan-status control: the preprocessor was NOT restored (SCAN_ERR: $SCAN_ERR) — every scan below would be running against the failing stub"
+  fi
+fi
+# Finally: state 2 must be COUNTED, not merely returned. Measured on the tally itself, with the
+# counters restored afterwards so this probe does not red the run it is measuring.
+_cnr_p0=$PASS
+_cnr_f0=$FAIL
+scan_found 'x' "$tmp/definitely-absent-scan-target.sh" >/dev/null 2>&1
+_cnr_df=$((FAIL - _cnr_f0))
+_cnr_dp=$((PASS - _cnr_p0))
+PASS=$_cnr_p0
+FAIL=$_cnr_f0
+if [ "$_cnr_df" -eq 1 ] && [ "$_cnr_dp" -eq 0 ]; then
+  ok 'scan-status control: scan_found COUNTS the could-not-run state as a tally FAILURE (1 failure, 0 passes) — it propagates to the gate rather than being swallowed'
+else
+  bad "scan-status control: a could-not-run scan produced $_cnr_df failure(s) / $_cnr_dp pass(es) on the tally — it must be exactly one counted FAILURE"
+fi
 
 for _ci in "${!CONSTRUCT_RE[@]}"; do
   _re="${CONSTRUCT_RE[$_ci]}"
@@ -324,22 +486,30 @@ for _ci in "${!CONSTRUCT_RE[@]}"; do
   # POSITIVE CONTROL FIRST: the pattern must detect its own sample violation. Without this a
   # typo'd regex would report every file clean, forever.
   printf '%s\n' "${CONSTRUCT_SAMPLE[$_ci]}" >"$tmp/sample-$_ci.sh"
-  if [ -n "$(scan_hits "$_re" "$tmp/sample-$_ci.sh")" ]; then
-    ok "structural control: the pattern detects its sample violation (${CONSTRUCT_SAMPLE[$_ci]})"
-  else
-    bad "structural control: the pattern MATCHES NOTHING — it cannot detect '${CONSTRUCT_SAMPLE[$_ci]}', so its clean verdict below is vacuous ($_re)"
-    continue
-  fi
+  scan_found "$_re" "$tmp/sample-$_ci.sh"
+  case $? in
+    0) ok "structural control: the pattern detects its sample violation (${CONSTRUCT_SAMPLE[$_ci]})" ;;
+    1)
+      bad "structural control: the pattern MATCHES NOTHING — it cannot detect '${CONSTRUCT_SAMPLE[$_ci]}', so its clean verdict below is vacuous ($_re)"
+      continue ;;
+    # The could-not-run state is already counted by scan_found; the rule's clean verdict below
+    # would be unmeasured, so the rule is skipped over entirely rather than reported either way.
+    *) continue ;;
+  esac
   _hits=""
+  _scan_broke=0
   for _f in "${SCAN_FILES[@]}"; do
-    if [ ! -f "$_f" ]; then
-      bad "structural: scan target missing: $_f"
-      continue
-    fi
-    _fh=$(scan_hits "$_re" "$_f")
-    [ -n "$_fh" ] && _hits="$_hits $(basename "$_f"):${_fh%%$'\n'*}"
+    scan_found "$_re" "$_f"
+    case $? in
+      0) _hits="$_hits $(basename "$_f"):$(scan_first_hit)" ;;
+      1) ;;
+      *) _scan_broke=1 ;;
+    esac
   done
-  if [ -z "$_hits" ]; then
+  if [ "$_scan_broke" -eq 1 ]; then
+    : # a target could not be scanned: the cause is already a counted FAILURE, and a
+      # "free of this construct" verdict over a partially-scanned set would be vacuous.
+  elif [ -z "$_hits" ]; then
     ok "structural: the roborev code path is free of this construct — $_why"
   else
     bad "structural: GNU-only construct in the roborev code path ($_why):$_hits"
@@ -360,25 +530,37 @@ printf '%s\n' \
 # cluster rule's, and what matters to a reader of this file is that NO in-place spelling
 # escapes the table. Which rule catches which is pinned separately, immediately below.
 _cluster_missed=""
+_cluster_broke=0
 while IFS= read -r _cl; do
   [ -n "$_cl" ] || continue
   printf '%s\n' "$_cl" >"$tmp/cluster-one.sh"
-  if [ -z "$(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-one.sh")" ] &&
-    [ -z "$(scan_hits "$RE_SED_INPLACE" "$tmp/cluster-one.sh")" ]; then
+  # The two rules are consulted with EXPLICIT statuses rather than `! scan_found … && ! scan_found …`:
+  # `!` would fold the could-not-run state (2) in with "no match" (1) and report the spelling as
+  # MISSED — a verdict about a scan that never ran.
+  scan_found "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-one.sh"
+  _c1=$?
+  scan_found "$RE_SED_INPLACE" "$tmp/cluster-one.sh"
+  _c2=$?
+  if [ "$_c1" -eq 2 ] || [ "$_c2" -eq 2 ]; then
+    _cluster_broke=1
+  elif [ "$_c1" -eq 1 ] && [ "$_c2" -eq 1 ]; then
     _cluster_missed="$_cluster_missed [$_cl]"
   fi
 done <"$tmp/cluster-bad.sh"
-if [ -z "$_cluster_missed" ]; then
+if [ "$_cluster_broke" -eq 1 ]; then
+  : # already counted by scan_found; a MISS/no-MISS verdict here would be unmeasured
+elif [ -z "$_cluster_missed" ]; then
   ok 'structural control: every in-place spelling (-Ei, -ni, -nEi, -E -i) is detected by the in-place rules — no bundled form escapes the table'
 else
   bad "structural control: the in-place rules MISS:$_cluster_missed — a scanner with a known hole invites reliance it cannot support"
 fi
 printf '%s\n' "  sed -Ei 's/a/b/' \"\$f\"" >"$tmp/cluster-one.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
-if [ -z "$(scan_hits "$RE_SED_INPLACE" "$tmp/cluster-one.sh")" ]; then
-  ok 'structural control: `sed -Ei` is (still) invisible to the bare -i rule — which is WHY the cluster rule exists, stated as a measurement rather than an assumption'
-else
-  bad 'structural control: the bare -i rule now also matches `sed -Ei`; fold the two rules together rather than keeping a redundant one'
-fi
+scan_found "$RE_SED_INPLACE" "$tmp/cluster-one.sh"
+case $? in
+  1) ok 'structural control: `sed -Ei` is (still) invisible to the bare -i rule — which is WHY the cluster rule exists, stated as a measurement rather than an assumption' ;;
+  0) bad 'structural control: the bare -i rule now also matches `sed -Ei`; fold the two rules together rather than keeping a redundant one' ;;
+  *) : ;; # already counted by scan_found
+esac
 
 # NEGATIVE CONTROLS for the cluster rule: a cluster that does NOT end in `i`, and an ATTACHED
 # suffix (portable — both seds read `-i.bak` as -i with suffix ".bak"), must not be reported.
@@ -390,11 +572,12 @@ printf '%s\n' \
   "  sed -Ei.bak -e 's/a/b/' \"\$f\"" \
   "  sed -fi input" \
   "  sed -ei 's/a/b/' \"\$f\"" >"$tmp/cluster-ok.sh"
-if [ -z "$(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh")" ]; then
-  ok 'structural control: a non-`i` cluster (-n, -E), an ATTACHED suffix (-Ei.bak) and an argument-taking cluster (-fi, -ei, where the i is the OPTION ARGUMENT) are not flagged — the rule reds only on the unportable spelling'
-else
-  bad "structural control: the cluster rule false-positives on a portable sed — a lint that reds on correct input is the lint agents learn to waive: $(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh" | tr '\n' ' ')"
-fi
+scan_found "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh"
+case $? in
+  1) ok 'structural control: a non-`i` cluster (-n, -E), an ATTACHED suffix (-Ei.bak) and an argument-taking cluster (-fi, -ei, where the i is the OPTION ARGUMENT) are not flagged — the rule reds only on the unportable spelling' ;;
+  0) bad "structural control: the cluster rule false-positives on a portable sed — a lint that reds on correct input is the lint agents learn to waive: $(scan_all_hits)" ;;
+  *) : ;; # already counted by scan_found
+esac
 
 # ---------------------------------------------------------------------------
 # CONTROLS FOR THE SPELLINGS THE ADJACENT-FLAGS-ONLY FORM MISSED (roborev round 2). Each named
@@ -404,27 +587,39 @@ fi
 # The assertion is against the UNION of the table's rules, because "is this flagged by the
 # scan" is the property the guard actually provides.
 # ---------------------------------------------------------------------------
-scan_any() { # scan_any <file> -> hits from ANY rule in the table
-  local _i _h _all=""
+# scan_any carries the same three states outward: 0 = some rule hit, 1 = no rule hit, 2 = a scan
+# could not run (already counted by scan_found). It ABORTS on state 2 rather than continuing over
+# the remaining rules, because a "no rule matched" answer assembled from a partially-executed table
+# is exactly the unmeasured-state verdict being removed here.
+_scan_any_hits=''
+scan_any() { # scan_any <file> -> 0 flagged / 1 clean / 2 could-not-run; hits in $_scan_any_hits
+  local _i _any=1
+  _scan_any_hits=''
   for _i in "${!CONSTRUCT_RE[@]}"; do
-    _h=$(scan_hits "${CONSTRUCT_RE[$_i]}" "$1")
-    [ -n "$_h" ] && _all="$_all ${_h%%$'\n'*}"
+    scan_found "${CONSTRUCT_RE[$_i]}" "$1"
+    case $? in
+      0) _any=0; _scan_any_hits="$_scan_any_hits $(scan_first_hit)" ;;
+      1) ;;
+      *) return 2 ;;
+    esac
   done
-  printf '%s' "$_all"
+  return "$_any"
 }
 assert_flagged() { # assert_flagged <label> <file>
-  if [ -n "$(scan_any "$2")" ]; then
-    ok "structural control: $1 is FLAGGED"
-  else
-    bad "structural control: $1 is NOT flagged — the scan has a hole at this spelling, and a guard with a known-but-hidden miss invites reliance it cannot support"
-  fi
+  scan_any "$2"
+  case $? in
+    0) ok "structural control: $1 is FLAGGED" ;;
+    1) bad "structural control: $1 is NOT flagged — the scan has a hole at this spelling, and a guard with a known-but-hidden miss invites reliance it cannot support" ;;
+    *) : ;; # the cause is already a counted FAILURE; there is no verdict to give here
+  esac
 }
 assert_not_flagged() { # assert_not_flagged <label> <file>
-  if [ -z "$(scan_any "$2")" ]; then
-    ok "structural control: $1 is correctly NOT flagged"
-  else
-    bad "structural control: $1 was flagged — a lint that reds on correct input is the lint agents learn to waive:$(scan_any "$2")"
-  fi
+  scan_any "$2"
+  case $? in
+    1) ok "structural control: $1 is correctly NOT flagged" ;;
+    0) bad "structural control: $1 was flagged — a lint that reds on correct input is the lint agents learn to waive:$_scan_any_hits" ;;
+    *) : ;; # the cause is already a counted FAILURE; there is no verdict to give here
+  esac
 }
 
 # (a) -i AFTER an intervening option argument. BSD eats `file` as the backup suffix.
@@ -515,32 +710,40 @@ assert_flagged 'a REAL `sed -i` on the line beneath a backslash-ended COMMENT (j
 # The joiner rewrites the stream, so LINE NUMBERS are asserted rather than assumed: a report
 # naming the wrong line sends the next reader to the wrong place.
 printf '%s\n' '# a comment' '' "  sed -i 's/a/b/' f" '  echo tail' >"$tmp/sp-lineno.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
-_ln=$(scan_hits "$RE_SED_INPLACE" "$tmp/sp-lineno.sh")
-if [ "${_ln%%:*}" = 3 ]; then
-  ok 'structural control: a hit is reported at its REAL file line (blanking, not deleting, keeps numbering exact)'
-else
-  bad "structural control: the hit was reported at line '${_ln%%:*}' but lives at line 3 — the scan's line numbers do not name the real file"
-fi
+scan_found "$RE_SED_INPLACE" "$tmp/sp-lineno.sh"
+case $? in
+  0)
+    _ln=$(scan_first_hit)
+    if [ "${_ln%%:*}" = 3 ]; then
+      ok 'structural control: a hit is reported at its REAL file line (blanking, not deleting, keeps numbering exact)'
+    else
+      bad "structural control: the hit was reported at line '${_ln%%:*}' but lives at line 3 — the scan's line numbers do not name the real file"
+    fi ;;
+  1) bad "structural control: the line-numbering fixture produced NO hit at all, so the scan's line numbering was NOT MEASURED — which is a failure, not a pass" ;;
+  *) : ;; # already counted by scan_found
+esac
 
 # NEGATIVE CONTROL for the paste pattern, whose ERE is the subtlest of the table: a paste WITH
 # an explicit operand is portable and must NOT be reported.
 printf '%s\n' '  order=$(grep -n x f | cut -d: -f2 | paste -sd, -)' >"$tmp/paste-ok.sh"
 printf '%s\n' '  order=$(paste -sd, "$f")' >>"$tmp/paste-ok.sh"
-if [ -z "$(scan_hits "$RE_PASTE_NO_OPERAND" "$tmp/paste-ok.sh")" ]; then
-  ok 'structural control: a paste WITH a file operand (`-` or a path) is not flagged'
-else
-  bad 'structural control: the paste pattern false-positives on a portable paste with an operand — a lint that reds on correct input is the lint agents learn to waive'
-fi
+scan_found "$RE_PASTE_NO_OPERAND" "$tmp/paste-ok.sh"
+case $? in
+  1) ok 'structural control: a paste WITH a file operand (`-` or a path) is not flagged' ;;
+  0) bad "structural control: the paste pattern false-positives on a portable paste with an operand — a lint that reds on correct input is the lint agents learn to waive: $(scan_all_hits)" ;;
+  *) : ;; # already counted by scan_found
+esac
 
 # CONTROL for the escape marker, in BOTH directions: it must exempt the line it is on, and it
 # must not be a blanket switch (the same sample WITHOUT the marker is still detected above).
 printf '%s\n' "  sed -i 's/a/b/' \"\$f\"   # portability-lint-allow: deliberate BSD-emulation control" \
   >"$tmp/allow.sh"
-if [ -z "$(scan_hits "$RE_SED_INPLACE" "$tmp/allow.sh")" ]; then
-  ok 'structural control: a line marked portability-lint-allow is exempt (a visible, per-line escape)'
-else
-  bad 'structural control: the portability-lint-allow marker does not exempt its line'
-fi
+scan_found "$RE_SED_INPLACE" "$tmp/allow.sh"
+case $? in
+  1) ok 'structural control: a line marked portability-lint-allow is exempt (a visible, per-line escape)' ;;
+  0) bad 'structural control: the portability-lint-allow marker does not exempt its line' ;;
+  *) : ;; # already counted by scan_found
+esac
 
 # ---------------------------------------------------------------------------
 # THE SELF-SCAN, AND THE TWO WAYS IT COULD BE VACUOUS (#3296 round-8 finding 1).

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -1,0 +1,533 @@
+#!/usr/bin/env bash
+# PORTABILITY GUARD for the roborev review-guard code path (issue #3296).
+#
+# WHY THIS FILE EXISTS. `scripts/tests/test_roborev_review_guard.sh` gates a merge (it runs
+# inside the gate's `roborev-lints` component, in --lite AND in the full gate of record). At
+# `origin/main` it reported `passed: 553  failed: 7` on macOS and `failed: 0` on Linux: three
+# GNU-vs-BSD utility differences in the TEST's own scaffolding, not in the wrapper it guards.
+# Every hosted CI lane is Linux, so NO hosted signal can see that class — it is found by
+# whoever next tries to certify anything locally, as a failure attributed to THEIR diff.
+#
+# So the regression coverage cannot be "run it on macOS": it must be a DIFFERENTIAL that runs
+# on every platform. Two mechanisms, both here:
+#
+#   (1) STRUCTURAL — the GNU-only constructs that caused #3296 (and their nearest relatives)
+#       cannot be reintroduced into the roborev code path. Each pattern carries a POSITIVE
+#       CONTROL: a sample violation the pattern must DETECT. A scanner whose regex silently
+#       matches nothing is the vacuous pass this repo keeps finding (CLAUDE.md: "never derive a
+#       pass from the ABSENCE of a bad signal"), so every pattern is affirmatively measured.
+#
+#   (2) BEHAVIOURAL under BSD SHIMS — a `sed` that consumes -i's next argument as the backup
+#       suffix (BSD semantics) and a `paste` that usage()-errors with no file operand are put
+#       first on PATH, and the guard test's OWN helpers — extracted VERBATIM from it, never
+#       copied — are exercised against them. Each shim is itself controlled: it must first be
+#       shown to REPRODUCE the reported defect, or the differential below proves nothing.
+#
+# Deliberately TARGETED: it exercises the new helpers and the mutated asserts, NOT all 581
+# guard-test cases under shims (that would double a --lite component's runtime for no extra
+# information — the full-suite run under both shims was recorded once, by hand, on #3296).
+#
+# AUTHORITATIVE SOURCES for the three BSD behaviours emulated here (a CQLite file is never
+# authority for another program's behaviour):
+#   sed -i takes a REQUIRED argument   Apple text_cmds sed/main.c:
+#                                      getopt(argc, argv, "EI:ae:f:i:lnru")   <- the `i:`
+#   paste needs a file operand         Apple text_cmds paste/paste.c + FreeBSD
+#                                      usr.bin/paste/paste.c:
+#                                        argc -= optind; argv += optind;
+#                                        if (*argv == NULL) usage();
+#                                      usage() -> stderr + exit(1), i.e. EMPTY stdout
+#   cut is NOT implicated              FreeBSD usr.bin/cut/cut.c: with no operand it reads
+#                                      stdin (`if (*argv) ... else fcn(stdin, "stdin")`)
+#
+# Run standalone:   bash scripts/tests/test_roborev_guard_portability.sh
+# Or via the gate:  scripts/agent-gate.sh --lite   (roborev-lints component)
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+GUARD="$SCRIPT_DIR/test_roborev_review_guard.sh"
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+FLOW_DIR="$SCRIPT_DIR/../flow"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$GUARD" ]; then
+  printf 'FAIL - the guard test is not at %s — nothing to keep portable\n' "$GUARD"
+  exit 1
+fi
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/roborev-portability.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+# ===========================================================================
+# (1) STRUCTURAL: no GNU-only construct in the roborev code path.
+#
+# The table is EXPLICIT rather than a generic "GNU long option" sweep: a generic sweep
+# false-positives on git/gh (whose long options are portable) and a lint agents learn to
+# waive is worse than no lint. Add an entry when a new divergence is actually found.
+# Comment-only lines are stripped before scanning, so prose ABOUT a construct (including
+# this file's own citations, and the guard test's `sed -i` explanation) is not a violation.
+# ===========================================================================
+SCAN_FILES=(
+  "$GUARD"
+  "$FLOW_DIR/roborev-review.sh"
+  "$FLOW_DIR/roborev-review-checks.sh"
+  "$FLOW_DIR/roborev-review-oracles.sh"
+  "$FLOW_DIR/roborev-job-facts.py"
+)
+
+# Three parallel arrays: the ERE, why it is not portable, and a sample violation the ERE
+# MUST detect (the positive control that keeps the pattern honest).
+CONSTRUCT_RE=(); CONSTRUCT_WHY=(); CONSTRUCT_SAMPLE=()
+add_construct() { CONSTRUCT_RE+=("$1"); CONSTRUCT_WHY+=("$2"); CONSTRUCT_SAMPLE+=("$3"); }
+
+add_construct '(^|[^[:alnum:]_-])sed[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-i([[:space:]]|$)' \
+  "BSD sed's -i takes a REQUIRED suffix argument, so it eats the EXPRESSION and the edit never lands (#3296 cx28/cx29/cx28b/cx28c) — use the guard test's sed_inplace helper" \
+  "  sed -i 's/a/b/' \"\$f\""
+add_construct '(^|[^[:alnum:]_-])sed[[:space:]]+-i("")' \
+  'the empty-suffix spelling -i"" is GNU-only (BSD needs -i "" or no -i at all) — use sed_inplace' \
+  '  sed -i"" -e s/a/b/ f'
+add_construct "(^|[^[:alnum:]_-])sed[[:space:]]+-i('')" \
+  "the empty-suffix spelling -i'' is GNU-only — use sed_inplace" \
+  "  sed -i'' -e s/a/b/ f"
+add_construct '(^|[^[:alnum:]_-])paste([[:space:]]+-[^[:space:]|;)&]+)*[[:space:]]*($|\||\)|;|&)' \
+  'a paste with NO FILE OPERAND is empty output + exit 1 on BSD (it usage()-errors instead of reading stdin) — pass an explicit `-`, or extract with awk (#3296 case (j2))' \
+  '  order=$(grep -n x f | cut -d: -f2 | paste -sd,)'
+add_construct '(^|[^[:alnum:]_-])readlink[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-f' \
+  'readlink -f is absent from older BSD readlink — canonicalise with `cd "$p" && pwd -P` (which is what the wrapper does)' \
+  '  p=$(readlink -f "$x")'
+add_construct '(^|[^[:alnum:]_-])stat[[:space:]]+-c' \
+  'stat -c is GNU-only (BSD spells it stat -f)' \
+  '  n=$(stat -c %s "$f")'
+add_construct '(^|[^[:alnum:]_-])grep[[:space:]]+-[a-zA-Z]*P([[:space:]]|$)' \
+  'grep -P (PCRE) is GNU-only — BSD grep has no -P' \
+  "  grep -P '\\\\d+' f"
+add_construct '(^|[^[:alnum:]_-])date[[:space:]]+(-d[[:space:]]|--date)' \
+  'date -d/--date is GNU-only (BSD date uses -r / -v / -j -f)' \
+  '  t=$(date -d @1700000000)'
+add_construct '(^|[^[:alnum:]_-])(sed|grep)[[:space:]]+-[a-zA-Z]*z([[:space:]]|$)' \
+  'sed -z / grep -z (NUL-delimited records) are GNU-only — read `git … -z` output with a shell read loop or awk RS' \
+  '  grep -z foo f'
+add_construct '\-printf[[:space:]]' \
+  'find -printf is GNU-only — use -exec or -print with a shell loop' \
+  "  find . -printf '%p\\\\n'"
+add_construct '(^|[^[:alnum:]_-])xargs[[:space:]]+(-[a-zA-Z]*r|--)' \
+  'xargs -r (and GNU long options) are not in BSD xargs; BSD already skips an empty input line only with -0' \
+  '  printf "" | xargs -r rm'
+add_construct '(^|[^[:alnum:]_-])base64[[:space:]]+-w' \
+  'base64 -w is GNU-only (BSD/macOS base64 has no wrap flag; use -b or fold)' \
+  '  base64 -w0 <f'
+add_construct '(^|[^[:alnum:]_-])timeout[[:space:]]+[0-9]' \
+  'timeout(1) is NOT installed on stock macOS — guard it with `command -v timeout` or restructure' \
+  '  timeout 30 some-command'
+add_construct '(^|[^[:alnum:]_-])(mapfile|readarray)([[:space:]]|$)|declare[[:space:]]+-A|\$\{[A-Za-z_][A-Za-z_0-9]*,,\}' \
+  'bash 4 only — stock macOS /bin/bash is 3.2, so mapfile/readarray/associative arrays/${v,,} can abort the script outright' \
+  '  mapfile -t arr <f'
+
+if [ "${#CONSTRUCT_RE[@]}" -ne "${#CONSTRUCT_WHY[@]}" ] ||
+  [ "${#CONSTRUCT_RE[@]}" -ne "${#CONSTRUCT_SAMPLE[@]}" ]; then
+  bad 'structural: the construct table arrays are not the same length — some pattern has no reason or no positive control'
+fi
+
+# The scan body: code only. A construct named in a comment (this repo documents the ones it
+# banned) is prose, not an invocation.
+scan_hits() { # scan_hits <ere> <file>
+  grep -vE '^[[:space:]]*#' "$2" | grep -nE -- "$1" || true
+}
+
+for _ci in "${!CONSTRUCT_RE[@]}"; do
+  _re="${CONSTRUCT_RE[$_ci]}"
+  _why="${CONSTRUCT_WHY[$_ci]}"
+  # POSITIVE CONTROL FIRST: the pattern must detect its own sample violation. Without this a
+  # typo'd regex would report every file clean, forever.
+  printf '%s\n' "${CONSTRUCT_SAMPLE[$_ci]}" >"$tmp/sample-$_ci.sh"
+  if [ -n "$(scan_hits "$_re" "$tmp/sample-$_ci.sh")" ]; then
+    ok "structural control: the pattern detects its sample violation (${CONSTRUCT_SAMPLE[$_ci]})"
+  else
+    bad "structural control: the pattern MATCHES NOTHING — it cannot detect '${CONSTRUCT_SAMPLE[$_ci]}', so its clean verdict below is vacuous ($_re)"
+    continue
+  fi
+  _hits=""
+  for _f in "${SCAN_FILES[@]}"; do
+    if [ ! -f "$_f" ]; then
+      bad "structural: scan target missing: $_f"
+      continue
+    fi
+    _fh=$(scan_hits "$_re" "$_f")
+    [ -n "$_fh" ] && _hits="$_hits $(basename "$_f"):${_fh%%$'\n'*}"
+  done
+  if [ -z "$_hits" ]; then
+    ok "structural: the roborev code path is free of this construct — $_why"
+  else
+    bad "structural: GNU-only construct in the roborev code path ($_why):$_hits"
+  fi
+done
+
+# NEGATIVE CONTROL for the paste pattern, whose ERE is the subtlest of the table: a paste WITH
+# an explicit operand is portable and must NOT be reported.
+printf '%s\n' '  order=$(grep -n x f | cut -d: -f2 | paste -sd, -)' >"$tmp/paste-ok.sh"
+printf '%s\n' '  order=$(paste -sd, "$f")' >>"$tmp/paste-ok.sh"
+if [ -z "$(scan_hits "${CONSTRUCT_RE[3]}" "$tmp/paste-ok.sh")" ]; then
+  ok 'structural control: a paste WITH a file operand (`-` or a path) is not flagged'
+else
+  bad 'structural control: the paste pattern false-positives on a portable paste with an operand — a lint that reds on correct input is the lint agents learn to waive'
+fi
+
+# ===========================================================================
+# (2) THE BSD SHIMS, and the controls that prove they reproduce the reported defects.
+# ===========================================================================
+shim="$tmp/shim"
+mkdir -p "$shim"
+REAL_SED=$(command -v sed || printf '')
+REAL_PASTE=$(command -v paste || printf '')
+if [ -z "$REAL_SED" ] || [ -z "$REAL_PASTE" ]; then
+  bad 'shim setup: sed/paste not found on PATH — the differential cannot run (this is a failure to measure, not a measurement)'
+fi
+
+{
+  printf '#!/usr/bin/env bash\n# BSD/macOS sed emulation, -i only (see test_roborev_guard_portability.sh).\n'
+  printf 'REAL_SED=%q\n' "$REAL_SED"
+  cat <<'SHIM_SED'
+set -uo pipefail
+# BSD sed declares -i with a REQUIRED argument, so a SEPARATE `-i` consumes the NEXT argv
+# entry as the backup suffix. Rewriting it to GNU's attached form reproduces exactly that
+# consumption: `sed -i EXPR FILE` becomes suffix=EXPR, script=FILE, no input file — the edit
+# never lands and the exit status is non-zero, which is what macOS does.
+out=()
+while [ $# -gt 0 ]; do
+  if [ "$1" = "-i" ]; then
+    shift
+    suffix="${1-}"
+    [ $# -gt 0 ] && shift
+    out+=("-i$suffix")
+  else
+    out+=("$1")
+    shift
+  fi
+done
+exec "$REAL_SED" "${out[@]}"
+SHIM_SED
+} >"$shim/sed"
+
+{
+  printf '#!/usr/bin/env bash\n# BSD/macOS paste emulation (see test_roborev_guard_portability.sh).\n'
+  printf 'REAL_PASTE=%q\n' "$REAL_PASTE"
+  cat <<'SHIM_PASTE'
+set -uo pipefail
+# getopt(argc, argv, "d:s") then `if (*argv == NULL) usage();` — flags are consumed (with
+# bundling, so `-sd,` is -s plus -d,), and a missing FILE OPERAND is a usage error on stderr
+# with exit 1 and NOTHING on stdout.
+orig=("$@")
+operands=()
+end=0
+while [ $# -gt 0 ]; do
+  a="$1"
+  if [ "$end" -eq 0 ] && [ "$a" = "--" ]; then end=1; shift; continue; fi
+  if [ "$end" -eq 0 ] && [ "${a#-}" != "$a" ] && [ "$a" != "-" ]; then
+    rest="${a#-}"
+    while [ -n "$rest" ]; do
+      c="${rest:0:1}"
+      rest="${rest:1}"
+      case "$c" in
+        d) if [ -n "$rest" ]; then rest=""; else shift; fi ;;
+        *) ;;
+      esac
+    done
+    shift
+    continue
+  fi
+  operands+=("$a")
+  shift
+done
+if [ "${#operands[@]}" -eq 0 ]; then
+  printf 'usage: paste [-s] [-d delimiters] file ...\n' >&2
+  exit 1
+fi
+exec "$REAL_PASTE" "${orig[@]}"
+SHIM_PASTE
+} >"$shim/paste"
+chmod +x "$shim/sed" "$shim/paste"
+
+SHIM_PATH="$shim:$PATH"
+
+# CONTROL A: the sed shim must reproduce the #3296 defect — non-zero exit AND an UNCHANGED
+# file. If it silently worked, every sed_inplace assert below would be vacuous.
+printf 'foo\n' >"$tmp/ctl-sed.txt"
+if PATH="$SHIM_PATH" sed -i 's/foo/bar/' "$tmp/ctl-sed.txt" 2>/dev/null; then
+  bad 'shim control: `sed -i EXPR FILE` SUCCEEDED under the BSD shim — the shim does not emulate BSD, so the differential below would prove nothing'
+elif [ "$(cat "$tmp/ctl-sed.txt")" = foo ]; then
+  ok 'shim control: under BSD -i semantics `sed -i EXPR FILE` fails AND leaves the file unpatched (the #3296 root cause 1, reproduced on this platform)'
+else
+  bad "shim control: the file changed despite the failure: $(cat "$tmp/ctl-sed.txt")"
+fi
+
+# CONTROL B: the paste shim must reproduce case (j2) — empty stdout, non-zero exit.
+_ctl_paste=$(printf 'a\nb\n' | PATH="$SHIM_PATH" paste -sd, 2>/dev/null)
+_ctl_paste_rc=$?
+if [ "$_ctl_paste_rc" -eq 0 ] || [ -n "$_ctl_paste" ]; then
+  bad "shim control: operand-less `paste -sd,` produced '$_ctl_paste' (rc $_ctl_paste_rc) under the BSD shim — the shim does not emulate BSD"
+else
+  ok 'shim control: under BSD semantics an operand-less `paste -sd,` yields EMPTY stdout + non-zero exit (the #3296 root cause 3, reproduced on this platform)'
+fi
+printf 'a\nb\n' >"$tmp/ctl-paste.txt"
+if [ "$(PATH="$SHIM_PATH" paste -sd, "$tmp/ctl-paste.txt" 2>/dev/null)" = 'a,b' ]; then
+  ok 'shim control: the paste shim still passes a legitimate `paste -sd, FILE` through'
+else
+  bad 'shim control: the paste shim broke a legitimate `paste -sd, FILE` — it emulates something other than BSD'
+fi
+
+# ---------------------------------------------------------------------------
+# The helpers under test are EXTRACTED VERBATIM from the guard test, never copied: a copy
+# would drift, and a drifted copy passing here while the real helper is broken is precisely
+# the shape of failure this file exists to remove.
+# ---------------------------------------------------------------------------
+extract_fn() { # extract_fn <name> -> the function's source text
+  awk -v fn="$1" '$0 ~ "^" fn "\\(\\) \\{" { inside = 1 } inside { print } inside && /^\}$/ { exit }' "$GUARD"
+}
+
+for _fn in sed_inplace summary_key_order; do
+  _src=$(extract_fn "$_fn")
+  if [ -z "$_src" ]; then
+    bad "extraction: $_fn is not defined in $(basename "$GUARD") — the portable helper was removed or renamed, so nothing below tests it"
+    continue
+  fi
+  if printf '%s\n' "$_src" | bash -n 2>/dev/null; then
+    ok "extraction: $_fn was read verbatim from the guard test and parses"
+  else
+    bad "extraction: the $_fn text read from the guard test does not parse"
+    continue
+  fi
+  eval "$_src"
+done
+
+if ! declare -f sed_inplace >/dev/null || ! declare -f summary_key_order >/dev/null; then
+  bad 'extraction: the guard test helpers are not available — the differential below cannot run'
+else
+  # --- sed_inplace, single-line substitution, under BSD -i semantics.
+  printf 'alpha\nbeta\n' >"$tmp/one.txt"
+  if PATH="$SHIM_PATH" sed_inplace "$tmp/one.txt" 's/^alpha$/ALPHA/' &&
+    [ "$(cat "$tmp/one.txt")" = "$(printf 'ALPHA\nbeta')" ]; then
+    ok 'sed_inplace: a single-line substitution lands under BSD sed semantics (where `sed -i` would not have)'
+  else
+    bad "sed_inplace: the substitution did not land under the BSD shim: $(cat "$tmp/one.txt")"
+  fi
+
+  # --- sed_inplace, the cx29-shaped MULTI-LINE insert, verified the way cx29 verifies it:
+  # the inserted line must be the line IMMEDIATELY AFTER the function header.
+  printf 'roborev_check_prompt_content() {\n  local x\n}\n' >"$tmp/multi.sh"
+  PATH="$SHIM_PATH" sed_inplace "$tmp/multi.sh" \
+    's/^roborev_check_prompt_content() {$/roborev_check_prompt_content() {\
+  return 0/'
+  _mp=$(grep -A1 '^roborev_check_prompt_content() {$' "$tmp/multi.sh" | sed -n '2p')
+  if [ "$_mp" = '  return 0' ]; then
+    ok 'sed_inplace: the cx29-shaped two-line replacement lands, with the new line immediately after the header'
+  else
+    bad "sed_inplace: the multi-line replacement did not land as two lines (line 2 = '$_mp')"
+  fi
+
+  # --- AC2 AT THE EDIT SITE: an expression that matches NOTHING must be an ERROR, and the
+  # file must be byte-identical. Portability must not have become unconditionality.
+  cp "$tmp/one.txt" "$tmp/one.before"
+  if PATH="$SHIM_PATH" sed_inplace "$tmp/one.txt" 's/^nothing-matches-this$/x/'; then
+    bad 'sed_inplace: a no-op patch returned SUCCESS — a silently unapplied mutation would then be asserted against, which is a probe failing in the direction that looks like success'
+  elif cmp -s "$tmp/one.txt" "$tmp/one.before"; then
+    ok 'sed_inplace: a no-op patch returns NON-ZERO and leaves the file byte-identical (fail-closed preserved)'
+  else
+    bad 'sed_inplace: a no-op patch changed the file'
+  fi
+  # And no temp spill: the helper must not leave its scratch file behind on the failure path.
+  if [ -z "$(find "$tmp" -maxdepth 1 -name '*.sed-inplace.*' 2>/dev/null)" ]; then
+    ok 'sed_inplace: no scratch file is left behind on the no-op path'
+  else
+    bad 'sed_inplace: a .sed-inplace.* scratch file survived the no-op path'
+  fi
+
+  # --- AC2 IN THE CASES: the four cases must STILL verify the mutation landed. Asserted on
+  # the guard test's TEXT, because a helper that is fail-closed today does not keep the CASES
+  # fail-closed tomorrow. These are the three verification forms cx28 / cx29 / cx28b+cx28c use.
+  for _vpair in \
+    "grep -qF 'TIER1=\"MEASUREMENT-DID-NOT-HAPPEN\"'|cx28 verifies its unrecognised-verdict patch landed" \
+    "= '  return 0'|cx29 verifies its early-return patch is the line after the header" \
+    "grep -qF \"TIER1=\\\"\$_np_value\\\"\"|cx28b/cx28c verify their near-prefix patch landed"; do
+    _vtext="${_vpair%%|*}"
+    _vwhy="${_vpair#*|}"
+    if grep -qF -- "$_vtext" "$GUARD"; then
+      ok "AC2: $_vwhy"
+    else
+      bad "AC2: the guard test no longer contains this verification ($_vwhy) — a case that cannot detect an unapplied patch is a regression even when green"
+    fi
+  done
+
+  # --- summary_key_order under the paste shim, plus the RED side of the differential.
+  printf 'vacuity-tier2: PASS\nroborev-exit: PASS\nfindings: NONE\nlog: /tmp/x\n' >"$tmp/block.txt"
+  if [ "$(PATH="$SHIM_PATH" summary_key_order "$tmp/block.txt" 'vacuity-tier2|roborev-exit|log')" \
+    = 'vacuity-tier2,roborev-exit,log' ]; then
+    ok 'summary_key_order: the key order is extracted correctly under BSD paste semantics'
+  else
+    bad "summary_key_order: wrong extraction under the BSD shim: '$(PATH="$SHIM_PATH" summary_key_order "$tmp/block.txt" 'vacuity-tier2|roborev-exit|log')'"
+  fi
+  # The pre-#3296 pipeline, run under the same shim, on the same input: it must come back
+  # EMPTY. This is the control that the fix fixed something — the reported case (j2) symptom
+  # was `unexpected key order: ` with nothing after the colon. The operand-less paste below is
+  # DELIBERATE (it is the defect being reproduced) and is why the structural scan above covers
+  # the roborev code path rather than this file.
+  _old=$(PATH="$SHIM_PATH" bash -c "grep -nE '^(vacuity-tier2|roborev-exit|log):' '$tmp/block.txt' | cut -d: -f2 | paste -sd," 2>/dev/null)
+  if [ -z "$_old" ]; then
+    ok 'differential: the pre-#3296 `grep | cut | paste -sd,` pipeline returns EMPTY under BSD paste — the reported case (j2) symptom, reproduced'
+  else
+    bad "differential: the old pipeline returned '$_old' under the shim, so this platform cannot reproduce case (j2) and the fix is unverified here"
+  fi
+  if printf '%s\n' "$(extract_fn summary_key_order)" | grep -qE '(^|[^[:alnum:]_-])paste([[:space:]]|$)'; then
+    bad 'summary_key_order: it still shells out to paste'
+  else
+    ok 'summary_key_order: the extraction has no paste stage at all'
+  fi
+fi
+
+# ===========================================================================
+# (3) AC3: case (f)'s pinned contract still FAILs when it is VIOLATED.
+#
+# The fix compares the wrapper's CANONICALISED --repo against a canonicalisation computed the
+# same way, instead of the literal fixture path (which differs on macOS, where $TMPDIR is
+# under /var, a symlink to /private/var). The hazard of such a fix is loosening the match
+# until it accepts anything. So the REAL assert block is extracted from the guard test and
+# fed four records: the sanctioned one, and three violations that must each still be caught.
+#
+# The fixture repo is placed UNDER A SYMLINK, which reproduces /var -> /private/var on any
+# platform: `$work` and its canonical form differ, so the canonical-to-canonical comparison is
+# genuinely exercised here rather than trivially satisfied.
+# ===========================================================================
+_cf_block=$(awk '/^# >>> BEGIN case-f-invocation-asserts/,/^# <<< END case-f-invocation-asserts/' "$GUARD")
+if [ -z "$_cf_block" ] || ! printf '%s\n' "$_cf_block" | grep -q 'work_canon='; then
+  bad 'AC3: the case-f-invocation-asserts block could not be extracted from the guard test (markers removed?) — the contract is then untested here'
+else
+  mkdir -p "$tmp/real/work"
+  ln -s "$tmp/real" "$tmp/link"
+  work="$tmp/link/work"
+  git init -q -b main "$work" >/dev/null 2>&1
+  git -C "$work" config user.email t@e && git -C "$work" config user.name t
+  printf 'x\n' >"$work/f.txt"
+  git -C "$work" add f.txt >/dev/null 2>&1
+  git -C "$work" commit -q -m base >/dev/null 2>&1
+  _canon=$(cd "$(git -C "$work" rev-parse --show-toplevel)" && pwd -P)
+  if [ "$work" = "$_canon" ]; then
+    bad 'AC3: the symlinked fixture did not produce a path that differs from its canonical form — the canonicalisation is not actually exercised, so a PASS below would be vacuous'
+  else
+    ok "AC3 control: the fixture path differs from its canonical form ($work vs $_canon), reproducing the macOS /var -> /private/var split"
+  fi
+
+  probe_case_f() { # probe_case_f <label> <expect: accept|reject> <recorded invocation line>
+    local label="$2" expect="$3" line="$4" p0=$PASS f0=$FAIL dp df
+    INVOKED="$tmp/invoked-$1.txt"
+    printf '%s\n' "$line" >"$INVOKED"
+    eval "$_cf_block" >/dev/null 2>&1
+    dp=$((PASS - p0)); df=$((FAIL - f0))
+    PASS=$p0; FAIL=$f0
+    case "$expect" in
+      accept)
+        if [ "$dp" -eq 2 ] && [ "$df" -eq 0 ]; then
+          ok "AC3: $label is ACCEPTED by the real case (f) asserts"
+        else
+          bad "AC3: $label should be accepted but the real asserts reported $df failure(s) / $dp pass(es)"
+        fi ;;
+      reject)
+        if [ "$df" -eq 2 ] && [ "$dp" -eq 0 ]; then
+          ok "AC3: $label is REJECTED by both real case (f) asserts"
+        else
+          bad "AC3: $label was NOT rejected by both asserts ($df failure(s) / $dp pass(es)) — the canonicalisation fix loosened the pinned contract"
+        fi ;;
+    esac
+  }
+
+  _tail='--agent codex --model gpt-5.6-sol --wait'
+  probe_case_f sanctioned 'the sanctioned canonical --repo record' accept \
+    "review --branch --base origin/main --repo $_canon $_tail"
+  probe_case_f relative 'a RELATIVE --repo' reject \
+    "review --branch --base origin/main --repo . $_tail"
+  probe_case_f rootco 'a ROOT-CHECKOUT --repo' reject \
+    "review --branch --base origin/main --repo $REPO_ROOT $_tail"
+  probe_case_f norepo 'a --branch review with NO --repo at all' reject \
+    "review --branch --base origin/main $_tail"
+fi
+
+# ===========================================================================
+# (4) AC5: the #3262 exit-code propagation is NOT weakened — `GUARD-TEST RESULT: FAIL`
+# still exits non-zero. The fail-open that returned 0 on a FAIL verdict is what hid three
+# of the #3296 failures for weeks, and it is the more expensive of the two defects.
+#
+# Exercised on the guard test's OWN prologue + OWN tally epilogue (both read out of the real
+# file), with one injected failing case in between. Composing it rather than re-running all
+# 581 cases keeps this component fast; the text under test is the real text either way.
+# ===========================================================================
+_pro_end=$(grep -nF "trap 'rm -rf \"\$tmp\"' EXIT" "$GUARD" | head -1 | cut -d: -f1)
+_epi_start=$(grep -nF '==== ROBOREV REVIEW GUARD TEST TALLY' "$GUARD" | head -1 | cut -d: -f1)
+if [ -z "$_pro_end" ] || [ -z "$_epi_start" ] || [ "$_epi_start" -le "$_pro_end" ]; then
+  bad "AC5: could not locate the guard test's prologue/tally epilogue (prologue end '$_pro_end', epilogue start '$_epi_start') — the exit-code contract is untested here"
+else
+  # The composition is laid out in a MIRROR of the real tree (scripts/tests + scripts/flow with
+  # a placeholder wrapper), because the guard test's prologue resolves $SCRIPT_DIR from $0 and
+  # exits 1 when ../flow/roborev-review.sh is missing — a composition run from a bare temp dir
+  # would fail for that reason instead of the one under test.
+  mkdir -p "$tmp/mirror/tests" "$tmp/mirror/flow"
+  printf '#!/usr/bin/env bash\n# placeholder: the AC5 composition never invokes the wrapper.\n' \
+    >"$tmp/mirror/flow/roborev-review.sh"
+  compose_probe() { # compose_probe <out> <middle line>
+    {
+      awk -v n="$_pro_end" 'NR <= n' "$GUARD"
+      printf '%s\n' "$2"
+      awk -v n="$_epi_start" 'NR >= n' "$GUARD"
+    } >"$1"
+  }
+  compose_probe "$tmp/mirror/tests/ac5-fail.sh" "bad 'AC5 injected failure'"
+  compose_probe "$tmp/mirror/tests/ac5-pass.sh" ":"
+  _ac5_out=$(bash "$tmp/mirror/tests/ac5-fail.sh" 2>&1); _ac5_rc=$?
+  if [ "$_ac5_rc" -ne 0 ] && printf '%s\n' "$_ac5_out" | grep -qF 'GUARD-TEST RESULT: FAIL' &&
+    printf '%s\n' "$_ac5_out" | grep -qF 'failed: 1'; then
+    ok "AC5: a failing case still exits NON-ZERO (rc $_ac5_rc) with GUARD-TEST RESULT: FAIL"
+  else
+    bad "AC5: the guard test's tally epilogue did not fail closed (rc $_ac5_rc): $(printf '%s' "$_ac5_out" | tail -3 | tr '\n' ' ')"
+  fi
+  _ac5_out=$(bash "$tmp/mirror/tests/ac5-pass.sh" 2>&1); _ac5_rc=$?
+  if [ "$_ac5_rc" -eq 0 ] && printf '%s\n' "$_ac5_out" | grep -qF 'GUARD-TEST RESULT: PASS'; then
+    ok 'AC5 control: with no failing case the same epilogue exits 0 with GUARD-TEST RESULT: PASS'
+  else
+    bad "AC5 control: the clean composition did not pass (rc $_ac5_rc) — the injected-failure result above would then mean nothing"
+  fi
+fi
+
+# The gate must not swallow either script's exit status: `roborev-lints` is where both run in
+# --lite and in the full gate of record.
+if [ ! -f "$GATE" ]; then
+  printf 'SKIP - agent-gate.sh not found; the roborev-lints wiring could not be checked\n'
+else
+  _lints=$(awk '/^run_roborev_lints_cmd\(\) \{/,/^\}$/' "$GATE")
+  if [ -z "$_lints" ]; then
+    bad 'wiring: run_roborev_lints_cmd is not defined in agent-gate.sh — this test may not be gate-run at all'
+  else
+    for _needed in test_roborev_review_guard.sh test_roborev_guard_portability.sh; do
+      if printf '%s\n' "$_lints" | grep -qF "$_needed"; then
+        ok "wiring: roborev-lints runs $_needed"
+      else
+        bad "wiring: roborev-lints does not run $_needed — a regression would not FAIL the fast loop"
+      fi
+    done
+    if printf '%s\n' "$_lints" | grep -qE '\|\|[[:space:]]*(true|:)'; then
+      bad 'wiring: run_roborev_lints_cmd suppresses a non-zero exit (|| true) — that is the #3262 fail-open again, one level up'
+    else
+      ok 'wiring: run_roborev_lints_cmd propagates a non-zero exit (no || true)'
+    fi
+  fi
+fi
+
+# The tally line deliberately does NOT start with `RESULT:` — that token belongs to the agent
+# gate's summary contract and to the roborev wrapper's own block.
+printf '\n==== ROBOREV GUARD PORTABILITY TALLY ====\n'
+printf 'passed: %d  failed: %d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  printf 'PORTABILITY RESULT: FAIL\n'
+  exit 1
+fi
+printf 'PORTABILITY RESULT: PASS\n'

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -85,8 +85,48 @@ trap 'rm -rf "$tmp"' EXIT
 # Comment-only lines are stripped before scanning, so prose ABOUT a construct (including
 # this file's own citations, and the guard test's `sed -i` explanation) is not a violation.
 # ===========================================================================
+#
+# SCOPE OF THIS SCANNER — ENUMERATED, NOT EXHAUSTIVE, AND SAID SO IN CODE (#3296 round-8;
+# CLAUDE.md: "where a signal genuinely SHOULD be permissive, record the reason IN CODE at the
+# branch"). Three consecutive review rounds each produced the same class of finding — "here is
+# another spelling the table does not detect" — and the spelling space of a shell command is
+# UNBOUNDED: `--in-place=`, `-i''`, `-e X -i`, line continuations, `$SED -i`, `eval`, string
+# concatenation. A scanner that implicitly claims completeness therefore generates a finding
+# EVERY round, forever. That non-convergence is exactly why the sibling structural lint on this
+# branch was DELETED by owner ruling (see the "DELIBERATELY NOT BUILT" record further down this
+# file, and CLAUDE.md's #3229 ruling: a guard with known false-PASSes is worse than no guard).
+#
+# So, stated plainly rather than left to be rediscovered:
+#   * WHAT THIS IS: a BEST-EFFORT DRIFT TRIPWIRE over an ENUMERATED set of spellings — the ones
+#     that actually caused #3296 plus their nearest measured relatives. Enumerated today:
+#     `sed -i EXPR`, `sed -i` beyond an option run, bundled clusters ending in `i` (-Ei/-ni/-nEi),
+#     `--in-place` and `--in-place=SUFFIX`, the empty-suffix forms `-i''`/`-i""` (adjacent or
+#     beyond an option run), backslash-continued invocations of all of the above; `paste` with no
+#     file operand (bare, separated `-d ARG`, and with input/output/fd redirections); plus
+#     `readlink -f`, `stat -c`, `grep -P`, `date -d`, `sed -z`/`grep -z`, `find -printf`,
+#     `xargs -r`, `base64 -w`, `timeout`, and the bash-4-only constructs.
+#   * WHAT IS AUTHORITATIVE: mechanism (2), the BEHAVIOURAL BSD-shim differential. It EXECUTES
+#     the guard test's own helpers under BSD `sed -i` and BSD `paste` semantics, so it does not
+#     care how a construct is spelled at all.
+#   * WHY THIS SURVIVES WHERE THE DELETED LINT DID NOT: a spelling this table misses is a
+#     BOUNDED FALSE NEGATIVE with a backstop underneath it. The deleted lint had no backstop and
+#     its misses were false PASSES about the property it was the only check for.
+#   * WHAT A NEWLY-DISCOVERED SPELLING MEANS: add a row and a positive control — a cheap ADDITIVE
+#     fix. It is NOT evidence that the mechanism is broken, and it is not a reason to attempt a
+#     shell tokeniser here (a second implementation of shell grammar, whose correctness is
+#     knowable only by differential testing against the first).
+# The residual it leaves is enumerated in full under "STATED RESIDUAL" below.
+#
+# THIS FILE SCANS ITSELF. It runs inside the macOS-sensitive `roborev-lints` gate component and
+# is mostly shell scaffolding, so a GNU-only construct added HERE would reproduce the exact
+# Linux-green/macOS-red regression the file exists to prevent — and nothing else would see it.
+# The self-scan is not vacuous: this file is NOT blanket-exempt. It deliberately CONTAINS the
+# banned constructs, in two places only — its BSD-emulation fixtures and its positive controls —
+# and each such LINE carries a `portability-lint-allow` marker naming why, so the exemption is
+# visible in the diff and every other line of this file is scanned like any other target.
 SCAN_FILES=(
   "$GUARD"
+  "$SCRIPT_DIR/$(basename "$0")"
   "$FLOW_DIR/roborev-review.sh"
   "$FLOW_DIR/roborev-review-checks.sh"
   "$FLOW_DIR/roborev-review-oracles.sh"
@@ -165,49 +205,49 @@ RE_PASTE_NO_OPERAND='(^|[^[:alnum:]_-])paste('"$_PASTE_DARG"'|'"$_PASTE_OPT"')*'
 
 add_construct "$RE_SED_INPLACE" \
   "BSD sed's -i takes a REQUIRED suffix argument, so it eats the EXPRESSION and the edit never lands (#3296 cx28/cx29/cx28b/cx28c) — use the guard test's sed_inplace helper" \
-  "  sed -i 's/a/b/' \"\$f\""
+  "  sed -i 's/a/b/' \"\$f\"" # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct "$RE_SED_INPLACE_CLUSTER" \
   "a BUNDLED cluster ending in -i (-Ei, -ni, -nEi, …) reaches the SAME BSD argument-consuming -i as a bare -i, so the edit never lands — use sed_inplace" \
-  "  sed -Ei 's/a/b/' \"\$f\""
+  "  sed -Ei 's/a/b/' \"\$f\"" # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct "$RE_SED_INPLACE_EMPTY_DQ" \
   'the empty-suffix spelling -i"" is GNU-only (BSD needs -i "" or no -i at all) — use sed_inplace' \
-  '  sed -i"" -e s/a/b/ f'
+  '  sed -i"" -e s/a/b/ f' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct "$RE_SED_INPLACE_EMPTY_SQ" \
   "the empty-suffix spelling -i'' is GNU-only — use sed_inplace" \
-  "  sed -i'' -e s/a/b/ f"
+  "  sed -i'' -e s/a/b/ f" # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct "$RE_PASTE_NO_OPERAND" \
   'a paste with NO FILE OPERAND is empty output + exit 1 on BSD (it usage()-errors instead of reading stdin) — pass an explicit `-`, or extract with awk (#3296 case (j2))' \
-  '  order=$(grep -n x f | cut -d: -f2 | paste -sd,)'
+  '  order=$(grep -n x f | cut -d: -f2 | paste -sd,)' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])readlink[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-f' \
   'readlink -f is absent from older BSD readlink — canonicalise with `cd "$p" && pwd -P` (which is what the wrapper does)' \
-  '  p=$(readlink -f "$x")'
+  '  p=$(readlink -f "$x")' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])stat[[:space:]]+-c' \
   'stat -c is GNU-only (BSD spells it stat -f)' \
-  '  n=$(stat -c %s "$f")'
+  '  n=$(stat -c %s "$f")' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])grep[[:space:]]+-[a-zA-Z]*P([[:space:]]|$)' \
   'grep -P (PCRE) is GNU-only — BSD grep has no -P' \
-  "  grep -P '\\\\d+' f"
+  "  grep -P '\\\\d+' f" # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])date[[:space:]]+(-d[[:space:]]|--date)' \
   'date -d/--date is GNU-only (BSD date uses -r / -v / -j -f)' \
-  '  t=$(date -d @1700000000)'
+  '  t=$(date -d @1700000000)' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])(sed|grep)[[:space:]]+-[a-zA-Z]*z([[:space:]]|$)' \
   'sed -z / grep -z (NUL-delimited records) are GNU-only — read `git … -z` output with a shell read loop or awk RS' \
-  '  grep -z foo f'
+  '  grep -z foo f' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '\-printf[[:space:]]' \
   'find -printf is GNU-only — use -exec or -print with a shell loop' \
-  "  find . -printf '%p\\\\n'"
+  "  find . -printf '%p\\\\n'" # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])xargs[[:space:]]+(-[a-zA-Z]*r|--)' \
   'xargs -r (and GNU long options) are not in BSD xargs; BSD already skips an empty input line only with -0' \
-  '  printf "" | xargs -r rm'
+  '  printf "" | xargs -r rm' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])base64[[:space:]]+-w' \
   'base64 -w is GNU-only (BSD/macOS base64 has no wrap flag; use -b or fold)' \
-  '  base64 -w0 <f'
+  '  base64 -w0 <f' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])timeout[[:space:]]+[0-9]' \
   'timeout(1) is NOT installed on stock macOS — guard it with `command -v timeout` or restructure' \
-  '  timeout 30 some-command'
+  '  timeout 30 some-command' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 add_construct '(^|[^[:alnum:]_-])(mapfile|readarray)([[:space:]]|$)|declare[[:space:]]+-A|\$\{[A-Za-z_][A-Za-z_0-9]*,,\}' \
   'bash 4 only — stock macOS /bin/bash is 3.2, so mapfile/readarray/associative arrays/${v,,} can abort the script outright' \
-  '  mapfile -t arr <f'
+  '  mapfile -t arr <f' # portability-lint-allow: the SAMPLE VIOLATION this rule must detect (table data, not an invocation)
 
 if [ "${#CONSTRUCT_RE[@]}" -ne "${#CONSTRUCT_WHY[@]}" ] ||
   [ "${#CONSTRUCT_RE[@]}" -ne "${#CONSTRUCT_SAMPLE[@]}" ]; then
@@ -314,7 +354,7 @@ printf '%s\n' \
   "  sed -Ei 's/a/b/' \"\$f\"" \
   "  sed -ni '\$p' \"\$f\"" \
   "  sed -nEi 's/a/b/' \"\$f\"" \
-  "  sed -E -i 's/a/b/' \"\$f\"" >"$tmp/cluster-bad.sh"
+  "  sed -E -i 's/a/b/' \"\$f\"" >"$tmp/cluster-bad.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 # Asserted against the UNION of the two in-place rules, because that union is what the scan
 # actually applies: `-E -i` (separated) is the BARE rule's job and `-Ei` (bundled) is the
 # cluster rule's, and what matters to a reader of this file is that NO in-place spelling
@@ -333,7 +373,7 @@ if [ -z "$_cluster_missed" ]; then
 else
   bad "structural control: the in-place rules MISS:$_cluster_missed — a scanner with a known hole invites reliance it cannot support"
 fi
-printf '%s\n' "  sed -Ei 's/a/b/' \"\$f\"" >"$tmp/cluster-one.sh"
+printf '%s\n' "  sed -Ei 's/a/b/' \"\$f\"" >"$tmp/cluster-one.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 if [ -z "$(scan_hits "$RE_SED_INPLACE" "$tmp/cluster-one.sh")" ]; then
   ok 'structural control: `sed -Ei` is (still) invisible to the bare -i rule — which is WHY the cluster rule exists, stated as a measurement rather than an assumption'
 else
@@ -388,35 +428,35 @@ assert_not_flagged() { # assert_not_flagged <label> <file>
 }
 
 # (a) -i AFTER an intervening option argument. BSD eats `file` as the backup suffix.
-printf '%s\n' "  sed -e 's/a/b/' -i file" >"$tmp/sp-optrun.sh"
-assert_flagged '`sed -e EXPR -i file` (-i beyond the adjacent option run)' "$tmp/sp-optrun.sh"
+printf '%s\n' "  sed -e 's/a/b/' -i file" >"$tmp/sp-optrun.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
+assert_flagged '`sed -e EXPR -i file` (-i beyond the adjacent option run)' "$tmp/sp-optrun.sh" # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
 # (b) a LINE-BROKEN invocation — invisible to any single-line ERE, hence the joiner.
-printf '%s\n' '  sed \' '    -i '"'"'s/a/b/'"'"' file' >"$tmp/sp-break.sh"
+printf '%s\n' '  sed \' '    -i '"'"'s/a/b/'"'"' file' >"$tmp/sp-break.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`sed \` + newline + `-i …` (backslash-continued across lines)' "$tmp/sp-break.sh"
-printf '%s\n' '  sed -e '"'"'s/a/b/'"'"' \' '    -Ei file' >"$tmp/sp-break2.sh"
+printf '%s\n' '  sed -e '"'"'s/a/b/'"'"' \' '    -Ei file' >"$tmp/sp-break2.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged 'a line-broken invocation whose continuation carries a BUNDLED -Ei' "$tmp/sp-break2.sh"
 # (c) the delimiter argument SEPARATED from -d, with no operand.
-printf '%s\n' '  order=$(paste -d ,)' >"$tmp/sp-darg.sh"
+printf '%s\n' '  order=$(paste -d ,)' >"$tmp/sp-darg.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`paste -d ,` (separated delimiter argument, still no file operand)' "$tmp/sp-darg.sh"
 # (d) a REDIRECTION is not an operand — BSD usage()-errors just the same.
-printf '%s\n' '  order=$(paste -sd, < input)' >"$tmp/sp-redir.sh"
+printf '%s\n' '  order=$(paste -sd, < input)' >"$tmp/sp-redir.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`paste -sd, < input` (a redirection is not a file operand)' "$tmp/sp-redir.sh"
-printf '%s\n' '  order=$(paste -sd, <"$f")' >"$tmp/sp-redir2.sh"
+printf '%s\n' '  order=$(paste -sd, <"$f")' >"$tmp/sp-redir2.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`paste -sd, <"$f"` (redirection with no space)' "$tmp/sp-redir2.sh"
 # (d2) OUTPUT and FILE-DESCRIPTOR redirections are not operands either — one control per spelling,
 # because an input-only grammar reported every one of these CLEAN (#3296 round-8 finding 3).
-printf '%s\n' '  paste -sd, >output' >"$tmp/sp-redir-out.sh"
+printf '%s\n' '  paste -sd, >output' >"$tmp/sp-redir-out.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`paste -sd, >output` (an OUTPUT redirection is not a file operand)' "$tmp/sp-redir-out.sh"
-printf '%s\n' '  paste -sd, >>output' >"$tmp/sp-redir-app.sh"
+printf '%s\n' '  paste -sd, >>output' >"$tmp/sp-redir-app.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`paste -sd, >>output` (an APPEND redirection is not a file operand)' "$tmp/sp-redir-app.sh"
-printf '%s\n' '  paste -sd, 2>/dev/null' >"$tmp/sp-redir-fd.sh"
+printf '%s\n' '  paste -sd, 2>/dev/null' >"$tmp/sp-redir-fd.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`paste -sd, 2>/dev/null` (a FILE-DESCRIPTOR redirection is not a file operand)' "$tmp/sp-redir-fd.sh"
-printf '%s\n' '  paste -sd, >out 2>&1' >"$tmp/sp-redir-both.sh"
+printf '%s\n' '  paste -sd, >out 2>&1' >"$tmp/sp-redir-both.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`paste -sd, >out 2>&1` (a RUN of redirections, one of them an fd duplication)' "$tmp/sp-redir-both.sh"
-printf '%s\n' '  paste -sd, <in >out' >"$tmp/sp-redir-inout.sh"
+printf '%s\n' '  paste -sd, <in >out' >"$tmp/sp-redir-inout.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`paste -sd, <in >out` (input AND output redirection, still no operand)' "$tmp/sp-redir-inout.sh"
-printf '%s\n' '  order=$(paste -sd, >"$out")' >"$tmp/sp-redir-subst.sh"
-assert_flagged '`order=$(paste -sd, >"$out")` (output redirection inside a command substitution)' "$tmp/sp-redir-subst.sh"
+printf '%s\n' '  order=$(paste -sd, >"$out")' >"$tmp/sp-redir-subst.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
+assert_flagged '`order=$(paste -sd, >"$out")` (output redirection inside a command substitution)' "$tmp/sp-redir-subst.sh" # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
 # And the NEGATIVE direction for the widened grammar, which is where widening can go wrong: a
 # paste that HAS an operand must stay unflagged even when it also redirects.
 printf '%s\n' '  paste -sd, "$f" >out' >"$tmp/sp-redir-okfile.sh"
@@ -426,23 +466,23 @@ assert_not_flagged '`paste -sd, - 2>/dev/null` (the explicit `-` stdin operand p
 printf '%s\n' '#  paste -sd, >output and paste -sd, 2>/dev/null are both banned' >"$tmp/sp-redir-cmt.sh"
 assert_not_flagged 'the redirection spellings named in a COMMENT (prose, not an invocation)' "$tmp/sp-redir-cmt.sh"
 # (e) the GNU long spelling, absent from BSD sed entirely.
-printf '%s\n' "  sed --in-place -e 's/a/b/' file" >"$tmp/sp-long.sh"
+printf '%s\n' "  sed --in-place -e 's/a/b/' file" >"$tmp/sp-long.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged '`sed --in-place` (GNU long option; BSD sed has no such flag)' "$tmp/sp-long.sh"
 # (f) the long spelling with an ATTACHED `=SUFFIX`, in BOTH positions — adjacent to `sed` and
 # beyond an intervening option. A long-option rule that requires WHITESPACE after the option name
 # sees neither; this table's does not, and both positions are now pinned by measurement instead of
 # left to inspection of the regex (#3296 round-8 finding 2).
-printf '%s\n' "  sed --in-place=.bak -e 's/a/b/' file" >"$tmp/sp-long-eq.sh"
-assert_flagged '`sed --in-place=.bak …` (long option with an ATTACHED suffix, adjacent to sed)' "$tmp/sp-long-eq.sh"
-printf '%s\n' "  sed -e 's/a/b/' --in-place=.bak file" >"$tmp/sp-long-eq2.sh"
-assert_flagged '`sed -e EXPR --in-place=.bak file` (attached-suffix long option BEYOND an intervening option)' "$tmp/sp-long-eq2.sh"
+printf '%s\n' "  sed --in-place=.bak -e 's/a/b/' file" >"$tmp/sp-long-eq.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
+assert_flagged '`sed --in-place=.bak …` (long option with an ATTACHED suffix, adjacent to sed)' "$tmp/sp-long-eq.sh" # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
+printf '%s\n' "  sed -e 's/a/b/' --in-place=.bak file" >"$tmp/sp-long-eq2.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
+assert_flagged '`sed -e EXPR --in-place=.bak file` (attached-suffix long option BEYOND an intervening option)' "$tmp/sp-long-eq2.sh" # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
 # (g) the EMPTY-SUFFIX spellings beyond the adjacent position. Before the empty-suffix rules were
 # given the same option-run handling as the bare `-i` rule, these were invisible to EVERY rule in
 # the table — the hole this control now closes and keeps closed.
-printf '%s\n' "  sed -e 's/a/b/' -i'' file" >"$tmp/sp-empty-sq.sh"
-assert_flagged "\`sed -e EXPR -i'' file\` (empty SINGLE-quoted suffix beyond the adjacent position)" "$tmp/sp-empty-sq.sh"
+printf '%s\n' "  sed -e 's/a/b/' -i'' file" >"$tmp/sp-empty-sq.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
+assert_flagged "\`sed -e EXPR -i'' file\` (empty SINGLE-quoted suffix beyond the adjacent position)" "$tmp/sp-empty-sq.sh" # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
 printf '%s\n' "  sed -e 's/a/b/' -i\"\" file" >"$tmp/sp-empty-dq.sh"
-assert_flagged '`sed -e EXPR -i"" file` (empty DOUBLE-quoted suffix beyond the adjacent position)' "$tmp/sp-empty-dq.sh"
+assert_flagged '`sed -e EXPR -i"" file` (empty DOUBLE-quoted suffix beyond the adjacent position)' "$tmp/sp-empty-dq.sh" # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
 # The widening must not reach past a shell metacharacter here either: an empty-suffix `-i` on the
 # far side of a pipe belongs to a DIFFERENT command.
 printf '%s\n' '  sed '"'"'s/x/y/'"'"' f | grep -i'"''"' foo' >"$tmp/sp-empty-pipe.sh"
@@ -450,7 +490,7 @@ assert_not_flagged "a \`grep -i''\` AFTER a pipe (the empty-suffix rules stop at
 # And the same spellings in PROSE stay invisible: this repo documents the constructs it bans, so a
 # comment naming one is not an invocation.
 printf '%s\n' "# prose: sed -e 's/a/b/' -i'' file, and sed --in-place=.bak, are both banned here" \
-  >"$tmp/sp-new-cmt.sh"
+  >"$tmp/sp-new-cmt.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_not_flagged 'the new in-place spellings named in a COMMENT (prose about a banned construct is not an invocation)' "$tmp/sp-new-cmt.sh"
 
 # NEGATIVE CONTROLS for the widened option run — this is where widening can go wrong.
@@ -469,12 +509,12 @@ assert_not_flagged 'a benign backslash-continued command (joining must not manuf
 printf '%s\n' '# sed \' "  echo ok" >"$tmp/sp-cmtbreak.sh"
 assert_not_flagged 'a COMMENT ending in a backslash (it must not join the code line beneath it)' "$tmp/sp-cmtbreak.sh"
 printf '%s\n' '# prose about sed, ending in a backslash \' "  sed -i 's/a/b/' file" \
-  >"$tmp/sp-cmtbreak2.sh"
+  >"$tmp/sp-cmtbreak2.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 assert_flagged 'a REAL `sed -i` on the line beneath a backslash-ended COMMENT (joining it into the comment would MASK it)' "$tmp/sp-cmtbreak2.sh"
 
 # The joiner rewrites the stream, so LINE NUMBERS are asserted rather than assumed: a report
 # naming the wrong line sends the next reader to the wrong place.
-printf '%s\n' '# a comment' '' "  sed -i 's/a/b/' f" '  echo tail' >"$tmp/sp-lineno.sh"
+printf '%s\n' '# a comment' '' "  sed -i 's/a/b/' f" '  echo tail' >"$tmp/sp-lineno.sh" # portability-lint-allow: deliberate fixture: the unportable spelling this control must DETECT
 _ln=$(scan_hits "$RE_SED_INPLACE" "$tmp/sp-lineno.sh")
 if [ "${_ln%%:*}" = 3 ]; then
   ok 'structural control: a hit is reported at its REAL file line (blanking, not deleting, keeps numbering exact)'
@@ -502,19 +542,54 @@ else
   bad 'structural control: the portability-lint-allow marker does not exempt its line'
 fi
 
+# ---------------------------------------------------------------------------
+# THE SELF-SCAN, AND THE TWO WAYS IT COULD BE VACUOUS (#3296 round-8 finding 1).
+#
+# This file is one of the SCAN_FILES: it runs inside the macOS-sensitive `roborev-lints`
+# component and is mostly shell scaffolding, so a GNU-only construct added HERE would reproduce
+# the exact Linux-green/macOS-red regression it exists to prevent, and nothing else would catch
+# it. But it also DELIBERATELY contains the banned constructs — in its BSD-emulation fixtures and
+# its positive controls — each exempted by a per-line `portability-lint-allow` marker rather than
+# by any blanket rule. A self-scan of a file full of sanctioned violations can go green two ways
+# that have nothing to do with the file being clean, so BOTH are measured here rather than
+# asserted in prose:
+#   (i)  EXEMPT IN EFFECT — this file dropped from SCAN_FILES, or so heavily marked that nothing
+#        in it is scanned any more. Controlled by appending an UNMARKED violation to a COPY of
+#        this file: it must be FLAGGED.
+#   (ii) DECORATIVE MARKERS — if the rules did not in fact match this file's own fixtures, the
+#        green would come from the rules MISSING them, not from the exemption doing its job, and
+#        the markers would be hiding nothing. Controlled by neutralising the marker token in a
+#        copy: the file must then be FLAGGED, i.e. the markers are load-bearing.
+# ---------------------------------------------------------------------------
+_self="$SCRIPT_DIR/$(basename "$0")"
+_self_in_scan=no
+for _sf in "${SCAN_FILES[@]}"; do
+  [ "$_sf" = "$_self" ] && _self_in_scan=yes
+done
+if [ "$_self_in_scan" = yes ]; then
+  ok 'self-scan: this file is one of the SCAN_FILES — a GNU-only construct added to the portability guard itself FAILs the same component it gates'
+else
+  bad 'self-scan: this file is NOT in SCAN_FILES — the guard that runs in the macOS-sensitive roborev-lints component does not check its own scaffolding, which is where #3296 lived'
+fi
+cat "$_self" >"$tmp/self-unmarked.sh"
+printf '%s\n' "  sed -i 's/a/b/' \"\$f\"" >>"$tmp/self-unmarked.sh" # portability-lint-allow: writes an UNMARKED violation into the self-scan copy on purpose
+assert_flagged 'an UNMARKED violation appended to a COPY of this file (so the self-scan is a real scan, not a blanket exemption)' "$tmp/self-unmarked.sh"
+awk '{ gsub(/portability-lint-allow/, "portability-lint-NEUTRALISED"); print }' "$_self" >"$tmp/self-nomarker.sh"
+assert_flagged "this file with its exemption markers NEUTRALISED (proving the markers are load-bearing — the rules really do match this file's own deliberate fixtures)" "$tmp/self-nomarker.sh"
+
 # ===========================================================================
 # (2) THE BSD SHIMS, and the controls that prove they reproduce the reported defects.
 # ===========================================================================
 shim="$tmp/shim"
 mkdir -p "$shim"
 REAL_SED=$(command -v sed || printf '')
-REAL_PASTE=$(command -v paste || printf '')
+REAL_PASTE=$(command -v paste || printf '') # portability-lint-allow: names the binary for the shim; `command -v` does not invoke paste
 if [ -z "$REAL_SED" ] || [ -z "$REAL_PASTE" ]; then
   bad 'shim setup: sed/paste not found on PATH — the differential cannot run (this is a failure to measure, not a measurement)'
 fi
 
 {
-  printf '#!/usr/bin/env bash\n# BSD/macOS sed emulation, -i only (see test_roborev_guard_portability.sh).\n'
+  printf '#!/usr/bin/env bash\n# BSD/macOS sed emulation, -i only (see test_roborev_guard_portability.sh).\n' # portability-lint-allow: prose inside the shim script this printf writes, not an invocation
   printf 'REAL_SED=%q\n' "$REAL_SED"
   cat <<'SHIM_SED'
 set -uo pipefail
@@ -591,16 +666,16 @@ SHIM_PATH="$shim:$PATH"
 # CONTROL A: the sed shim must reproduce the #3296 defect — non-zero exit AND an UNCHANGED
 # file. If it silently worked, every sed_inplace assert below would be vacuous.
 printf 'foo\n' >"$tmp/ctl-sed.txt"
-if PATH="$SHIM_PATH" sed -i 's/foo/bar/' "$tmp/ctl-sed.txt" 2>/dev/null; then
-  bad 'shim control: `sed -i EXPR FILE` SUCCEEDED under the BSD shim — the shim does not emulate BSD, so the differential below would prove nothing'
+if PATH="$SHIM_PATH" sed -i 's/foo/bar/' "$tmp/ctl-sed.txt" 2>/dev/null; then # portability-lint-allow: BSD-shim control: this `sed -i` MUST run, to prove the shim reproduces #3296
+  bad 'shim control: `sed -i EXPR FILE` SUCCEEDED under the BSD shim — the shim does not emulate BSD, so the differential below would prove nothing' # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
 elif [ "$(cat "$tmp/ctl-sed.txt")" = foo ]; then
-  ok 'shim control: under BSD -i semantics `sed -i EXPR FILE` fails AND leaves the file unpatched (the #3296 root cause 1, reproduced on this platform)'
+  ok 'shim control: under BSD -i semantics `sed -i EXPR FILE` fails AND leaves the file unpatched (the #3296 root cause 1, reproduced on this platform)' # portability-lint-allow: the construct is named in this assertion LABEL, not invoked
 else
   bad "shim control: the file changed despite the failure: $(cat "$tmp/ctl-sed.txt")"
 fi
 
 # CONTROL B: the paste shim must reproduce case (j2) — empty stdout, non-zero exit.
-_ctl_paste=$(printf 'a\nb\n' | PATH="$SHIM_PATH" paste -sd, 2>/dev/null)
+_ctl_paste=$(printf 'a\nb\n' | PATH="$SHIM_PATH" paste -sd, 2>/dev/null) # portability-lint-allow: BSD-shim control: the operand-less paste IS the defect being reproduced
 _ctl_paste_rc=$?
 if [ "$_ctl_paste_rc" -eq 0 ] || [ -n "$_ctl_paste" ]; then
   bad "shim control: operand-less `paste -sd,` produced '$_ctl_paste' (rc $_ctl_paste_rc) under the BSD shim — the shim does not emulate BSD"

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -27,6 +27,14 @@
 # guard-test cases under shims (that would double a --lite component's runtime for no extra
 # information — the full-suite run under both shims was recorded once, by hand, on #3296).
 #
+# SAME DOCTRINE, DIFFERENT SCOPE as scripts/tests/test_agent_gate_tree_portability.sh (#2926,
+# after #2914): behavioural BSD shims for the covered paths plus a static lint for the
+# uncovered ones, every lint rule proved discriminating. That file lints the gate's
+# tree-integrity functions; this one lints the roborev review-guard path. macOS is a
+# FIRST-CLASS host here — the gate carries `Darwin) … taskpolicy` branches and declares a
+# /bin/bash 3.2 floor — so this file also avoids bash-4-only constructs and never expands a
+# possibly-empty array under `set -u` (a 3.2 unbound-variable abort).
+#
 # AUTHORITATIVE SOURCES for the three BSD behaviours emulated here (a CQLite file is never
 # authority for another program's behaviour):
 #   sed -i takes a REQUIRED argument   Apple text_cmds sed/main.c:
@@ -133,9 +141,12 @@ if [ "${#CONSTRUCT_RE[@]}" -ne "${#CONSTRUCT_WHY[@]}" ] ||
 fi
 
 # The scan body: code only. A construct named in a comment (this repo documents the ones it
-# banned) is prose, not an invocation.
+# banned) is prose, not an invocation. A line carrying `portability-lint-allow` is exempt —
+# the repo's existing escape-marker convention (`injection-lint-allow`, `perf-gate-allow`) —
+# so a provably-safe or deliberately-BSD-emulating line has a route that is VISIBLE in the
+# diff instead of forcing a rewrite of the lint.
 scan_hits() { # scan_hits <ere> <file>
-  grep -vE '^[[:space:]]*#' "$2" | grep -nE -- "$1" || true
+  grep -vE '^[[:space:]]*#' "$2" | grep -v 'portability-lint-allow' | grep -nE -- "$1" || true
 }
 
 for _ci in "${!CONSTRUCT_RE[@]}"; do
@@ -176,6 +187,16 @@ else
   bad 'structural control: the paste pattern false-positives on a portable paste with an operand — a lint that reds on correct input is the lint agents learn to waive'
 fi
 
+# CONTROL for the escape marker, in BOTH directions: it must exempt the line it is on, and it
+# must not be a blanket switch (the same sample WITHOUT the marker is still detected above).
+printf '%s\n' "  sed -i 's/a/b/' \"\$f\"   # portability-lint-allow: deliberate BSD-emulation control" \
+  >"$tmp/allow.sh"
+if [ -z "$(scan_hits "${CONSTRUCT_RE[0]}" "$tmp/allow.sh")" ]; then
+  ok 'structural control: a line marked portability-lint-allow is exempt (a visible, per-line escape)'
+else
+  bad 'structural control: the portability-lint-allow marker does not exempt its line'
+fi
+
 # ===========================================================================
 # (2) THE BSD SHIMS, and the controls that prove they reproduce the reported defects.
 # ===========================================================================
@@ -192,6 +213,9 @@ fi
   printf 'REAL_SED=%q\n' "$REAL_SED"
   cat <<'SHIM_SED'
 set -uo pipefail
+# A zero-argument call is handled before any array is built: expanding an EMPTY "${arr[@]}"
+# under `set -u` aborts on macOS's /bin/bash 3.2, the floor the gate declares.
+[ $# -eq 0 ] && exec "$REAL_SED"
 # BSD sed declares -i with a REQUIRED argument, so a SEPARATE `-i` consumes the NEXT argv
 # entry as the backup suffix. Rewriting it to GNU's attached form reproduces exactly that
 # consumption: `sed -i EXPR FILE` becomes suffix=EXPR, script=FILE, no input file — the edit
@@ -220,8 +244,14 @@ set -uo pipefail
 # getopt(argc, argv, "d:s") then `if (*argv == NULL) usage();` — flags are consumed (with
 # bundling, so `-sd,` is -s plus -d,), and a missing FILE OPERAND is a usage error on stderr
 # with exit 1 and NOTHING on stdout.
+if [ $# -eq 0 ]; then   # see the sed shim: no empty-array expansion under bash 3.2 + set -u
+  printf 'usage: paste [-s] [-d delimiters] file ...\n' >&2
+  exit 1
+fi
 orig=("$@")
-operands=()
+# A COUNTER, not an array: `${#arr[@]}` on an array that never received an element is not
+# reliably safe under bash 3.2 + set -u either.
+n_operands=0
 end=0
 while [ $# -gt 0 ]; do
   a="$1"
@@ -239,10 +269,10 @@ while [ $# -gt 0 ]; do
     shift
     continue
   fi
-  operands+=("$a")
+  n_operands=$((n_operands + 1))
   shift
 done
-if [ "${#operands[@]}" -eq 0 ]; then
+if [ "$n_operands" -eq 0 ]; then
   printf 'usage: paste [-s] [-d delimiters] file ...\n' >&2
   exit 1
 fi

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -369,10 +369,38 @@ else
     bad 'sed_inplace: a no-op patch changed the file'
   fi
   # And no temp spill: the helper must not leave its scratch file behind on the failure path.
-  if [ -z "$(find "$tmp" -maxdepth 1 -name '*.sed-inplace.*' 2>/dev/null)" ]; then
-    ok 'sed_inplace: no scratch file is left behind on the no-op path'
+  #
+  # AFFIRMATIVE MEASUREMENT (CLAUDE.md: "never derive a pass from the ABSENCE of a bad
+  # signal"). The obvious spelling — `[ -z "$(find … 2>/dev/null)" ]` — reads EMPTY OUTPUT as
+  # "no spill", so an enumeration that never ran (unreadable dir, a `find` that errored, a
+  # mistyped path) reports the same green as a genuinely clean dir. That is the exact vacuous
+  # portability pass this file exists to prevent, one level down. So the enumeration is
+  # (1) first shown to DETECT a planted spill, and (2) then required to EXIT ZERO before its
+  # empty output is allowed to mean anything; its stderr is captured, never discarded.
+  #
+  # `-maxdepth` is deliberately KEPT: it is NOT a GNU extension — FreeBSD/macOS find(1)
+  # documents `-maxdepth n` ("Always true; descend at most n directory levels below the
+  # command line arguments"), and scripts/agent-gate.sh already relies on it fleet-wide.
+  _spill_err="$tmp/spill-find.err"
+  scratch_scan() { find "$tmp" -maxdepth 1 -name '*.sed-inplace.*' 2>"$_spill_err"; }
+
+  _decoy="$tmp/planted.sed-inplace.control"
+  : >"$_decoy"
+  _ctl_spill=$(scratch_scan); _ctl_spill_rc=$?
+  rm -f "$_decoy"
+  if [ "$_ctl_spill_rc" -eq 0 ] && printf '%s\n' "$_ctl_spill" | grep -qF 'planted.sed-inplace.control'; then
+    ok 'sed_inplace control: the scratch-file enumeration detects a PLANTED spill (so its clean verdict below is a measurement, not an empty pipe)'
   else
-    bad 'sed_inplace: a .sed-inplace.* scratch file survived the no-op path'
+    bad "sed_inplace control: the scratch-file enumeration did not find a planted spill (rc $_ctl_spill_rc, stderr: $(tr '\n' ' ' <"$_spill_err")) — every no-spill verdict from it would be vacuous"
+  fi
+
+  _spill=$(scratch_scan); _spill_rc=$?
+  if [ "$_spill_rc" -ne 0 ]; then
+    bad "sed_inplace: the scratch-file enumeration itself FAILED (rc $_spill_rc, stderr: $(tr '\n' ' ' <"$_spill_err")) — a failure to measure is not a measurement, so this is NOT reported as 'no spill'"
+  elif [ -n "$_spill" ]; then
+    bad "sed_inplace: a .sed-inplace.* scratch file survived the no-op path: $(printf '%s' "$_spill" | tr '\n' ' ')"
+  else
+    ok 'sed_inplace: no scratch file is left behind on the no-op path (enumeration exited 0, having first been shown to detect a planted spill)'
   fi
 
   # --- AC2 IN THE CASES: the four cases must STILL verify the mutation landed. Asserted on

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -92,16 +92,32 @@ SCAN_FILES=(
 CONSTRUCT_RE=(); CONSTRUCT_WHY=(); CONSTRUCT_SAMPLE=()
 add_construct() { CONSTRUCT_RE+=("$1"); CONSTRUCT_WHY+=("$2"); CONSTRUCT_SAMPLE+=("$3"); }
 
-add_construct '(^|[^[:alnum:]_-])sed[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-i([[:space:]]|$)' \
+# The two patterns whose controls below name them directly are held in NAMED variables rather
+# than referenced by table INDEX: an index reference silently retargets when a row is inserted
+# above it, which would leave a control asserting about a different rule than it names.
+RE_SED_INPLACE='(^|[^[:alnum:]_-])sed[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-i([[:space:]]|$)'
+# BUNDLED CLUSTERS ending in `i` — the hole the bare `-i` rule above leaves open. BSD getopt
+# processes `-Ei` as `-E` then `-i`, and `i` is declared WITH A REQUIRED ARGUMENT (Apple
+# text_cmds sed/main.c: `getopt(argc, argv, "EI:ae:f:i:lnru")`), so with nothing left in the
+# cluster it consumes the NEXT ARGV entry as the backup suffix — byte for byte the #3296
+# defect, reached by a spelling the bare-`-i` regex never sees. `-i.bak` (an ATTACHED suffix)
+# is portable and deliberately NOT matched: both seds read it the same way.
+RE_SED_INPLACE_CLUSTER='(^|[^[:alnum:]_-])sed[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-[a-zA-Z]+i([[:space:]]|$)'
+RE_PASTE_NO_OPERAND='(^|[^[:alnum:]_-])paste([[:space:]]+-[^[:space:]|;)&]+)*[[:space:]]*($|\||\)|;|&)'
+
+add_construct "$RE_SED_INPLACE" \
   "BSD sed's -i takes a REQUIRED suffix argument, so it eats the EXPRESSION and the edit never lands (#3296 cx28/cx29/cx28b/cx28c) — use the guard test's sed_inplace helper" \
   "  sed -i 's/a/b/' \"\$f\""
+add_construct "$RE_SED_INPLACE_CLUSTER" \
+  "a BUNDLED cluster ending in -i (-Ei, -ni, -nEi, …) reaches the SAME BSD argument-consuming -i as a bare -i, so the edit never lands — use sed_inplace" \
+  "  sed -Ei 's/a/b/' \"\$f\""
 add_construct '(^|[^[:alnum:]_-])sed[[:space:]]+-i("")' \
   'the empty-suffix spelling -i"" is GNU-only (BSD needs -i "" or no -i at all) — use sed_inplace' \
   '  sed -i"" -e s/a/b/ f'
 add_construct "(^|[^[:alnum:]_-])sed[[:space:]]+-i('')" \
   "the empty-suffix spelling -i'' is GNU-only — use sed_inplace" \
   "  sed -i'' -e s/a/b/ f"
-add_construct '(^|[^[:alnum:]_-])paste([[:space:]]+-[^[:space:]|;)&]+)*[[:space:]]*($|\||\)|;|&)' \
+add_construct "$RE_PASTE_NO_OPERAND" \
   'a paste with NO FILE OPERAND is empty output + exit 1 on BSD (it usage()-errors instead of reading stdin) — pass an explicit `-`, or extract with awk (#3296 case (j2))' \
   '  order=$(grep -n x f | cut -d: -f2 | paste -sd,)'
 add_construct '(^|[^[:alnum:]_-])readlink[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-f' \
@@ -177,11 +193,57 @@ for _ci in "${!CONSTRUCT_RE[@]}"; do
   fi
 done
 
+# POSITIVE CONTROLS for the CLUSTER rule beyond its table sample: every bundled spelling that
+# reaches BSD's argument-consuming -i must be detected, not just the one in the table. `-Ei` is
+# the form that evaded the bare-`-i` rule and is therefore asserted against BOTH rules: the old
+# one must MISS it (that is the hole) and the new one must CATCH it.
+printf '%s\n' \
+  "  sed -Ei 's/a/b/' \"\$f\"" \
+  "  sed -ni '\$p' \"\$f\"" \
+  "  sed -nEi 's/a/b/' \"\$f\"" \
+  "  sed -E -i 's/a/b/' \"\$f\"" >"$tmp/cluster-bad.sh"
+# Asserted against the UNION of the two in-place rules, because that union is what the scan
+# actually applies: `-E -i` (separated) is the BARE rule's job and `-Ei` (bundled) is the
+# cluster rule's, and what matters to a reader of this file is that NO in-place spelling
+# escapes the table. Which rule catches which is pinned separately, immediately below.
+_cluster_missed=""
+while IFS= read -r _cl; do
+  [ -n "$_cl" ] || continue
+  printf '%s\n' "$_cl" >"$tmp/cluster-one.sh"
+  if [ -z "$(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-one.sh")" ] &&
+    [ -z "$(scan_hits "$RE_SED_INPLACE" "$tmp/cluster-one.sh")" ]; then
+    _cluster_missed="$_cluster_missed [$_cl]"
+  fi
+done <"$tmp/cluster-bad.sh"
+if [ -z "$_cluster_missed" ]; then
+  ok 'structural control: every in-place spelling (-Ei, -ni, -nEi, -E -i) is detected by the in-place rules — no bundled form escapes the table'
+else
+  bad "structural control: the in-place rules MISS:$_cluster_missed — a scanner with a known hole invites reliance it cannot support"
+fi
+printf '%s\n' "  sed -Ei 's/a/b/' \"\$f\"" >"$tmp/cluster-one.sh"
+if [ -z "$(scan_hits "$RE_SED_INPLACE" "$tmp/cluster-one.sh")" ]; then
+  ok 'structural control: `sed -Ei` is (still) invisible to the bare -i rule — which is WHY the cluster rule exists, stated as a measurement rather than an assumption'
+else
+  bad 'structural control: the bare -i rule now also matches `sed -Ei`; fold the two rules together rather than keeping a redundant one'
+fi
+
+# NEGATIVE CONTROLS for the cluster rule: a cluster that does NOT end in `i`, and an ATTACHED
+# suffix (portable — both seds read `-i.bak` as -i with suffix ".bak"), must not be reported.
+printf '%s\n' \
+  "  sed -n '2p' \"\$f\"" \
+  "  sed -E 's/a/b/' \"\$f\"" \
+  "  sed -Ei.bak -e 's/a/b/' \"\$f\"" >"$tmp/cluster-ok.sh"
+if [ -z "$(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh")" ]; then
+  ok 'structural control: a non-`i` cluster (-n, -E) and an ATTACHED suffix (-Ei.bak) are not flagged — the rule reds only on the unportable spelling'
+else
+  bad "structural control: the cluster rule false-positives on a portable sed — a lint that reds on correct input is the lint agents learn to waive: $(scan_hits "$RE_SED_INPLACE_CLUSTER" "$tmp/cluster-ok.sh" | tr '\n' ' ')"
+fi
+
 # NEGATIVE CONTROL for the paste pattern, whose ERE is the subtlest of the table: a paste WITH
 # an explicit operand is portable and must NOT be reported.
 printf '%s\n' '  order=$(grep -n x f | cut -d: -f2 | paste -sd, -)' >"$tmp/paste-ok.sh"
 printf '%s\n' '  order=$(paste -sd, "$f")' >>"$tmp/paste-ok.sh"
-if [ -z "$(scan_hits "${CONSTRUCT_RE[3]}" "$tmp/paste-ok.sh")" ]; then
+if [ -z "$(scan_hits "$RE_PASTE_NO_OPERAND" "$tmp/paste-ok.sh")" ]; then
   ok 'structural control: a paste WITH a file operand (`-` or a path) is not flagged'
 else
   bad 'structural control: the paste pattern false-positives on a portable paste with an operand — a lint that reds on correct input is the lint agents learn to waive'
@@ -191,7 +253,7 @@ fi
 # must not be a blanket switch (the same sample WITHOUT the marker is still detected above).
 printf '%s\n' "  sed -i 's/a/b/' \"\$f\"   # portability-lint-allow: deliberate BSD-emulation control" \
   >"$tmp/allow.sh"
-if [ -z "$(scan_hits "${CONSTRUCT_RE[0]}" "$tmp/allow.sh")" ]; then
+if [ -z "$(scan_hits "$RE_SED_INPLACE" "$tmp/allow.sh")" ]; then
   ok 'structural control: a line marked portability-lint-allow is exempt (a visible, per-line escape)'
 else
   bad 'structural control: the portability-lint-allow marker does not exempt its line'

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -1313,11 +1313,27 @@ else
   #     a filesystem that can create symlinks. That is the ONLY route to `skip`.
   #   * EVERYTHING ELSE is a FAILURE of this file's own fixture, and goes to `bad`.
   # A cause nobody enumerated is therefore a red, not a silent skip — noise, never blindness.
-  cf_env_limitation() { # cf_env_limitation <scratch-dir> -> a NAMED limitation on stdout, else nothing
-    if ! command -v git >/dev/null 2>&1; then
-      printf 'git is not installed on this host, and the case (f) fixture is a git repository'
-      return 0
-    fi
+  # THE TWO CAUSES ARE SEPARATELY ANSWERABLE PROBES (#3296 round-11). They used to be ONE function
+  # that returned the FIRST limitation it found, git BEFORE symlinks. So on a host without git the
+  # symlink control below asked that composite probe, received the GIT cause, saw a non-empty string
+  # and reported the symlink-skip branch "reachable and named" — having never executed the symlink
+  # probe at all. A control that claims a measurement it did not perform is this branch's entire
+  # subject, so the fix is applied twice over: the probes are SPLIT, so the symlink control can ask
+  # the symlink question directly and a git answer is structurally impossible; AND the control
+  # asserts that the cause it received IDENTIFIES SYMLINK CREATION, so any future refactor that
+  # re-composes them cannot silently satisfy it again. Splitting alone would be undone by such a
+  # refactor; the cause assertion alone would still be reading a composite answer.
+  #
+  # The message text lives in its own function so a control can feed the REAL git cause to the
+  # acceptance test without hand-copying a duplicate that could drift out of step with it.
+  cf_git_limitation_message() {
+    printf 'git is not installed on this host, and the case (f) fixture is a git repository'
+  }
+  cf_git_limitation() { # -> the NAMED git limitation on stdout, else nothing
+    command -v git >/dev/null 2>&1 && return 0
+    cf_git_limitation_message
+  }
+  cf_symlink_limitation() { # cf_symlink_limitation <scratch-dir> -> the NAMED symlink limitation, else nothing
     # `ln -s` needs no existing target, so a dangling link is a sufficient capability probe.
     if ln -s "$1/cf-symlink-probe-target" "$1/cf-symlink-probe" 2>/dev/null &&
       [ -L "$1/cf-symlink-probe" ]; then
@@ -1325,6 +1341,26 @@ else
       return 0
     fi
     printf 'symlinks cannot be created under %s, and the fixture needs one to reproduce the macOS /var -> /private/var split' "$1"
+  }
+  # The composite remains, for the setup chain, which legitimately wants EITHER cause. It is only
+  # the CONTROLS that must not use it.
+  cf_env_limitation() { # cf_env_limitation <scratch-dir> -> the first NAMED limitation, else nothing
+    local _l
+    _l=$(cf_git_limitation)
+    if [ -n "$_l" ]; then
+      printf '%s' "$_l"
+      return 0
+    fi
+    cf_symlink_limitation "$1"
+  }
+  # The acceptance test for "this cause really is about symlinks", used by the control below and
+  # itself controlled in both directions — a test that accepted everything would re-admit the very
+  # defect being fixed, and one that accepted nothing would make the symlink control dead code.
+  cf_cause_is_symlink() { # cf_cause_is_symlink <cause> -> 0 only if it identifies symlink creation
+    case "$1" in
+      'symlinks cannot be created under '*) return 0 ;;
+      *) return 1 ;;
+    esac
   }
   # THE CLASSIFIER IS CONTROLLED IN BOTH DIRECTIONS, because a skip route that can never fire is
   # dead code, and one that fires on a healthy host would silently disable the probes below.
@@ -1334,15 +1370,39 @@ else
   else
     skip "AC3 control: an environment limitation is present on this host ($_cf_probe_ok), so the case (f) probes cannot run here"
   fi
+  # THE FINDING ITSELF, PINNED: the GIT cause must not be able to satisfy the symlink control. Fed
+  # the real git message — read from its function, never a hand-copied duplicate — the acceptance
+  # test must REJECT it. This control is privilege- and platform-independent, so it runs everywhere
+  # the composite probe's ordering could have hidden an unexercised symlink branch.
+  if cf_cause_is_symlink "$(cf_git_limitation_message)"; then
+    bad 'AC3 control: the GIT limitation message SATISFIES the symlink acceptance test — on a host without git the symlink-skip branch would be reported measured while never being exercised (#3296 round-11)'
+  else
+    ok 'AC3 control: the GIT limitation message does NOT satisfy the symlink acceptance test — a git answer can no longer stand in for a symlink measurement'
+  fi
+  # The ACCEPT direction of the same test, provoked from the REAL probe rather than a literal, by
+  # pointing it at a directory that does not exist: `ln -s` cannot succeed there on ANY host, root
+  # included, so the symlink skip route is proved reachable-and-named even where the read-only
+  # directory control below has to skip.
+  _cf_sym_absent=$(cf_symlink_limitation "$tmp/definitely-absent-dir-for-symlink-probe")
+  if cf_cause_is_symlink "$_cf_sym_absent"; then
+    ok 'AC3 control: the SYMLINK probe, asked directly, returns a cause that identifies SYMLINK CREATION when `ln -s` cannot succeed — the acceptance test is discriminating, not blanket-rejecting, and the skip route is reachable on any host'
+  else
+    bad "AC3 control: the symlink probe answered '$_cf_sym_absent' where `ln -s` cannot succeed — it must name symlink creation, or the symlink control can never pass and is dead code"
+  fi
   mkdir -p "$tmp/cf-ro" 2>/dev/null
   chmod 555 "$tmp/cf-ro" 2>/dev/null
   if ln -s x "$tmp/cf-ro/writable-check" 2>/dev/null; then
     rm -f "$tmp/cf-ro/writable-check"
-    skip 'AC3 control: the symlink-capability branch could NOT be provoked — a read-only directory still accepted a symlink (running as root, or a filesystem that ignores mode bits), so that skip route was not measured on this host'
-  elif [ -n "$(cf_env_limitation "$tmp/cf-ro")" ]; then
-    ok 'AC3 control: the symlink-capability probe DETECTS a filesystem that cannot create the link — the one legitimate skip route is reachable and named, not dead code'
+    skip 'AC3 control: the symlink-capability branch could NOT be provoked on a read-only directory — it still accepted a symlink (running as root, or a filesystem that ignores mode bits), so the realistic filesystem case was not measured on this host'
   else
-    bad 'AC3 control: the symlink-capability probe reported NO limitation on a directory where `ln -s` demonstrably fails — the skip route cannot be reached, so a genuine environment limitation would be reported as a fixture FAILURE'
+    _cf_sym_cause=$(cf_symlink_limitation "$tmp/cf-ro")
+    if cf_cause_is_symlink "$_cf_sym_cause"; then
+      ok 'AC3 control: the SYMLINK capability probe — asked DIRECTLY, never through the composite — DETECTS a filesystem that cannot create the link, and its cause identifies SYMLINK CREATION, so an unrelated git answer can no longer satisfy this control'
+    elif [ -z "$_cf_sym_cause" ]; then
+      bad 'AC3 control: the symlink-capability probe reported NO limitation on a directory where `ln -s` demonstrably fails — the skip route cannot be reached, so a genuine environment limitation would be reported as a fixture FAILURE'
+    else
+      bad "AC3 control: the symlink probe answered '$_cf_sym_cause', which does not identify SYMLINK CREATION — a control satisfied by some OTHER cause reports a measurement it never performed (#3296 round-11)"
+    fi
   fi
   chmod 755 "$tmp/cf-ro" 2>/dev/null
 

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -110,7 +110,10 @@ add_construct() { CONSTRUCT_RE+=("$1"); CONSTRUCT_WHY+=("$2"); CONSTRUCT_SAMPLE+
 # a DIFFERENT command. This is deliberately a LINE-ORIENTED approximation of shell parsing and
 # not a tokeniser; the residual it leaves is stated in full below the table.
 _OPT_RUN='([[:space:]]+[^[:space:]|;&<>()]+)*'
-RE_SED_INPLACE='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+(-i|--in-place)([[:space:]]|$)'
+# `--in-place` is matched with an OPTIONAL `=SUFFIX` (#3296 round 8): GNU accepts
+# `--in-place=.bak`, and requiring whitespace after the option name made that spelling — a long
+# option BSD sed does not have AT ALL — invisible to this rule.
+RE_SED_INPLACE='(^|[^[:alnum:]_-])sed'"$_OPT_RUN"'[[:space:]]+(-i|--in-place(=[^[:space:]|;&<>()]*)?)([[:space:]]|$)'
 # BUNDLED CLUSTERS ending in `i` — the hole the bare `-i` rule above leaves open. BSD getopt
 # processes `-Ei` as `-E` then `-i`, and `i` is declared WITH A REQUIRED ARGUMENT (Apple
 # text_cmds sed/main.c: `getopt(argc, argv, "EI:ae:f:i:lnru")`), so with nothing left in the
@@ -729,16 +732,67 @@ else
   else
     bad "summary_key_order: wrong extraction under the BSD shim: '$(PATH="$SHIM_PATH" summary_key_order "$tmp/block.txt" 'vacuity-tier2|roborev-exit|log')'"
   fi
-  # The pre-#3296 pipeline, run under the same shim, on the same input: it must come back
-  # EMPTY. This is the control that the fix fixed something — the reported case (j2) symptom
-  # was `unexpected key order: ` with nothing after the colon. The operand-less paste below is
-  # DELIBERATE (it is the defect being reproduced) and is why the structural scan above covers
-  # the roborev code path rather than this file.
-  _old=$(PATH="$SHIM_PATH" bash -c "grep -nE '^(vacuity-tier2|roborev-exit|log):' '$tmp/block.txt' | cut -d: -f2 | paste -sd," 2>/dev/null)
-  if [ -z "$_old" ]; then
-    ok 'differential: the pre-#3296 `grep | cut | paste -sd,` pipeline returns EMPTY under BSD paste — the reported case (j2) symptom, reproduced'
+  # THE OLD-PIPELINE DIFFERENTIAL — the RED side of the fix, and (with the shim controls above)
+  # the AUTHORITATIVE half of this file, so a control that can pass for the wrong reason here
+  # undermines the whole guard (#3296 round-8 finding 4). The reported case (j2) symptom was
+  # `unexpected key order: ` with nothing after the colon; the operand-less paste below is
+  # DELIBERATE — it IS the defect being reproduced — and carries a per-line lint marker.
+  #
+  # EMPTY OUTPUT ALONE IS NOT PROOF THAT `paste` REFUSED. The previous form captured the
+  # composed pipeline's stdout, DISCARDED ITS EXIT STATUS, and read `[ -z "$_old" ]` as "BSD
+  # paste usage()-errored". But every UNRELATED failure in that pipeline yields the very same
+  # empty string — a mistyped fixture path, a grep that matched nothing, a `cut` missing from
+  # the shimmed PATH, a quoting error in the `bash -c` text — so the control that is supposed to
+  # prove the shim reproduces case (j2) could pass for a reason that has nothing to do with
+  # paste. That is CLAUDE.md's shape verbatim: a positive verdict derived from the ABSENCE of a
+  # bad signal, with every unmeasured state inheriting the permissive branch.
+  #
+  # So THREE affirmative facts are required before emptiness may be ATTRIBUTED to the paste
+  # stage, and the classifier is itself controlled below against a PLANTED upstream failure:
+  #   1. the UPSTREAM `grep | cut` prefix, run alone on the same input under the same PATH,
+  #      produces NON-EMPTY output (paste is therefore demonstrably fed real data);
+  #   2. the full pipeline's STATUS is non-zero — measured with `set -o pipefail` inside the
+  #      probe shell, so a failing paste stage is not masked by the last command's status;
+  #   3. and its stdout is EMPTY, which is the reported case (j2) symptom.
+  # The reason for each rejection is reported, so a red here names which stage misbehaved.
+  _old_why=''
+  old_pipeline_reproduces() { # old_pipeline_reproduces <block-file>; sets _old_why
+    local _bf="$1" _up _up_rc=0 _full _full_rc=0
+    _up=$(PATH="$SHIM_PATH" bash -c 'set -o pipefail; grep -nE "^(vacuity-tier2|roborev-exit|log):" "$1" | cut -d: -f2' _ "$_bf" 2>/dev/null) || _up_rc=$?
+    if [ "$_up_rc" -ne 0 ] || [ -z "$_up" ]; then
+      _old_why="UPSTREAM: the \`grep | cut\` prefix produced nothing on its own (rc $_up_rc, output '$_up'), so an empty full-pipeline result cannot be attributed to paste at all — a failure to measure, not a reproduction"
+      return 1
+    fi
+    _full=$(PATH="$SHIM_PATH" bash -c 'set -o pipefail; grep -nE "^(vacuity-tier2|roborev-exit|log):" "$1" | cut -d: -f2 | paste -sd,' _ "$_bf" 2>/dev/null) || _full_rc=$? # portability-lint-allow: the operand-less paste IS the #3296 defect being reproduced
+    if [ "$_full_rc" -eq 0 ]; then
+      _old_why="STATUS: the pipeline SUCCEEDED (rc 0, output '$_full') — BSD paste semantics were not in force on this run"
+      return 1
+    fi
+    if [ -n "$_full" ]; then
+      _old_why="OUTPUT: the pipeline failed (rc $_full_rc) but still produced '$_full', so its failure is not the empty-stdout symptom of case (j2)"
+      return 1
+    fi
+    _old_why="upstream alone produced '$(printf '%s' "$_up" | tr '\n' ' ')'; the paste stage then failed (rc $_full_rc) with EMPTY stdout"
+    return 0
+  }
+  if old_pipeline_reproduces "$tmp/block.txt"; then
+    ok "differential: the pre-#3296 \`grep | cut | paste\` pipeline FAILS with EMPTY stdout under BSD paste, and the emptiness is ATTRIBUTED to the paste stage rather than assumed — $_old_why (the reported case (j2) symptom, reproduced)"
   else
-    bad "differential: the old pipeline returned '$_old' under the shim, so this platform cannot reproduce case (j2) and the fix is unverified here"
+    bad "differential: case (j2) was NOT reproduced on this platform, so the fix is unverified here — $_old_why"
+  fi
+  # CONTROL, THE DIRECTION THAT WAS BROKEN: a pipeline failure that is NOT paste's must not be
+  # reported as a successful reproduction. Planted as a MISSING INPUT FILE — grep then exits
+  # non-zero with empty output, byte for byte the shape the status-discarding form accepted as
+  # proof that BSD paste had refused.
+  if old_pipeline_reproduces "$tmp/no-such-block-file.txt"; then
+    bad 'differential control: a pipeline whose UPSTREAM failed (missing input file) was reported as a successful BSD-paste reproduction — the control passes for the wrong reason, so the differential proves nothing'
+  else
+    case "$_old_why" in
+      UPSTREAM:*)
+        ok 'differential control: an unrelated pipeline failure (missing input) is REJECTED and attributed to the upstream stages, not to paste — empty output alone is no longer read as proof' ;;
+      *)
+        bad "differential control: the unrelated failure was rejected, but for the wrong reason ($_old_why) — the classifier must identify the upstream stages as the cause" ;;
+    esac
   fi
   if printf '%s\n' "$(extract_fn summary_key_order)" | grep -qE '(^|[^[:alnum:]_-])paste([[:space:]]|$)'; then
     bad 'summary_key_order: it still shells out to paste'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -54,7 +54,16 @@ FAIL=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/roborev-guard-test.XXXXXX")
+# mktemp is verified BEFORE the trap and before any fixture (#3296). Unchecked, a failed or
+# empty-output `mktemp -d` leaves $tmp empty, every `"$tmp/x"` resolves to `/x`, and this file
+# creates those paths unconditionally — root-level file creation on a privileged runner. Arming
+# `rm -rf "$tmp"` on an unverified path is the same hazard, hence the ordering. Non-empty AND a
+# directory: a diagnostic printed on stdout would pass the emptiness test alone.
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/roborev-guard-test.XXXXXX") || tmp=''
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  printf 'FAIL - mktemp -d did not yield a usable temp directory (got: %s) — refusing to run rather than resolving every "$tmp/..." fixture path under /\n' "${tmp:-<empty>}"
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -101,7 +101,28 @@ trap 'rm -rf "$tmp"' EXIT
 # still used as the staging buffer (sed cannot read and write one file at once) and the
 # no-change check still runs BEFORE anything is written back, so the fail-closed contract
 # is unchanged: a no-op patch touches nothing and returns non-zero.
-sed_inplace() { # sed_inplace <file> <sed-expr>  -> non-zero if nothing changed
+# ===========================================================================
+# CALLER CONTRACT — READ THIS BEFORE ADDING A CALL (#3296).
+#
+# EVERY caller MUST check the status of this helper. It returns NON-ZERO when the edit did
+# not land (sed failed, or the expression matched nothing and the file is unchanged), and
+# that return is the ONLY thing standing between a silently unapplied mutation and a case
+# that then asserts against STALE content — a pass for a reason the case is not about. That
+# is not hypothetical: cx29's restore discarded the status once, and with its expression made
+# non-matching the case still reported `ok` on the PREVIOUS case's mutation.
+#
+# So: `if sed_inplace … ; then` / `elif ! sed_inplace_verified … ; then`, or
+# `sed_inplace … || bad "…"`. NEVER a bare statement call, and never a `|| true`.
+#
+# PREFER `sed_inplace_verified` (below) for any mutate-then-assert case: it additionally
+# requires the intended post-edit STATE to be present and, optionally, the state it replaces
+# to be gone, so "the edit ran" cannot be mistaken for "the edit did what I meant".
+#
+# No lint enforces this — the structural rule that tried was DELETED by owner ruling; see the
+# "DELIBERATELY NOT BUILT" record in scripts/tests/test_roborev_guard_portability.sh for why,
+# and for the residual it leaves. This comment is the enforcement.
+# ===========================================================================
+sed_inplace() { # sed_inplace <file> <sed-expr>  -> non-zero if nothing changed; CHECK THE STATUS
   local _f="$1" _expr="$2" _t
   _t="$_f.sed-inplace.$$"
   sed "$_expr" "$_f" >"$_t" || { rm -f "$_t"; return 1; }

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -90,6 +90,28 @@ sed_inplace() { # sed_inplace <file> <sed-expr>  -> non-zero if nothing changed
   mv "$_t" "$_f"
 }
 
+# AFFIRMATIVE MEASUREMENT AT THE EDIT SITE (#3296, CLAUDE.md "a positive verdict requires an
+# AFFIRMATIVE MEASUREMENT"). `sed_inplace`'s non-zero status is only protection if a CALLER
+# READS IT, and a mutate-then-assert case that ignores it inherits the permissive branch for
+# every unmeasured state: sed matched nothing, sed matched a DIFFERENT line, an earlier case's
+# mutation is still in the file. The later assertion is then satisfied by the STALE content the
+# edit never replaced — a pass for a reason the case is not about. (Concretely: the cx29 restore
+# below ignored the status, and with the expression made non-matching cx29's own causal assert
+# `assert_verdict FAIL 1` still read `ok`, on cx28's grammar violation.)
+#
+# So every mutation in this file goes through this wrapper, which requires THREE affirmative
+# facts before the caller may believe its mutation: the edit changed the file, the intended
+# post-edit STATE is present, and (optionally) the state it was supposed to replace is GONE.
+# Anything else is non-zero, and every call site routes non-zero to `bad`. Fixed-string
+# (`grep -F`) comparisons throughout: the states are literal source lines, not patterns.
+sed_inplace_verified() { # sed_inplace_verified <file> <expr> <must-be-present> [<must-be-absent>]
+  local _f="$1" _expr="$2" _want="$3" _gone="${4:-}"
+  sed_inplace "$_f" "$_expr" || return 1
+  grep -qF -- "$_want" "$_f" || return 1
+  if [ -n "$_gone" ] && grep -qF -- "$_gone" "$_f"; then return 1; fi
+  return 0
+}
+
 # PORTABILITY (#3296): the summary block's key ORDER, extracted with one awk.
 # The previous form was `grep -nE '^(k1|k2|k3):' "$OUT" | cut -d: -f2 | paste -sd,`,
 # whose `paste -sd,` carries NO FILE OPERAND. GNU paste reads stdin in that case; BSD
@@ -2017,9 +2039,9 @@ assert_verdict 'case (cx28 control) the UNPATCHED copy reaches PASS' PASS 0
 assert_lacks 'case (cx28 control) and reports no grammar violation' 'verdict-grammar'
 # ONE key, ONE value, outside the grammar. `MEASUREMENT-DID-NOT-HAPPEN` is deliberately not a
 # near-miss of a recognised prefix, so the case pins the ALLOW-LIST rather than a spelling.
-if sed_inplace "$_gm_dir/roborev-review-checks.sh" \
-  's/^    TIER1="PASS"$/    TIER1="MEASUREMENT-DID-NOT-HAPPEN"/' &&
-  grep -qF 'TIER1="MEASUREMENT-DID-NOT-HAPPEN"' "$_gm_dir/roborev-review-checks.sh"; then
+if sed_inplace_verified "$_gm_dir/roborev-review-checks.sh" \
+  's/^    TIER1="PASS"$/    TIER1="MEASUREMENT-DID-NOT-HAPPEN"/' \
+  '    TIER1="MEASUREMENT-DID-NOT-HAPPEN"' '    TIER1="PASS"'; then
   ok 'case (cx28): the unrecognised-verdict patch was really applied to the copy'
   run_wrapper "$work"
   assert_verdict 'case (cx28)' FAIL 1
@@ -2043,20 +2065,32 @@ printf '== case (cx29): a check that never ran cannot ride to PASS on its initia
 # before assigning anything, which is exactly what an aborted helper or a stray `return` in a
 # new branch looks like. cx28's control (the unpatched copy PASSes on this fixture) is the
 # both-directions control for this case too; the patch is verified applied before it is run.
-sed_inplace "$_gm_dir/roborev-review-checks.sh" \
+# VERIFIED, not assumed, in BOTH halves (#3296): the edit must have CHANGED the file (the
+# helper's status, read here rather than discarded) and the `return 0` must be the line
+# IMMEDIATELY AFTER the function header. A sed that matched nothing leaves a copy identical to
+# the control, and this case would then be asserting against an unpatched wrapper — a probe
+# failing in the direction that looks like success.
+_gm_patched=''
+if sed_inplace "$_gm_dir/roborev-review-checks.sh" \
   's/^roborev_check_prompt_content() {$/roborev_check_prompt_content() {\
-  return 0/'
-# VERIFIED, not assumed: the `return 0` must be the line IMMEDIATELY AFTER the function
-# header. A sed that matched nothing leaves a copy identical to the control, and this case
-# would then be asserting against an unpatched wrapper — a probe failing in the
-# direction that looks like success.
-_gm_patched=$(grep -A1 '^roborev_check_prompt_content() {$' "$_gm_dir/roborev-review-checks.sh" \
-  | sed -n '2p')
-if [ "$_gm_patched" = '  return 0' ]; then
-  # Undo cx28's patch so the ONLY grammar-relevant difference is the un-run check.
-  sed_inplace "$_gm_dir/roborev-review-checks.sh" \
-    's/^    TIER1="MEASUREMENT-DID-NOT-HAPPEN"$/    TIER1="PASS"/'
-  ok 'case (cx29): the early-return patch was really applied to the copy'
+  return 0/'; then
+  _gm_patched=$(grep -A1 '^roborev_check_prompt_content() {$' "$_gm_dir/roborev-review-checks.sh" \
+    | sed -n '2p')
+fi
+if [ "$_gm_patched" != '  return 0' ]; then
+  bad "case (cx29): could not patch the copied checks file for an early return (the line after the header reads '$_gm_patched'), so the never-ran-check path was never exercised"
+# Undo cx28's patch so the ONLY grammar-relevant difference is the un-run check. This restore
+# is REQUIRED to succeed and its post-state is MEASURED — `TIER1="PASS"` present AND cx28's
+# invalid value gone. A restore that silently stopped matching leaves the copy carrying cx28's
+# out-of-grammar value, and then cx29's own causal assert (`RESULT: FAIL`, exit 1) is satisfied
+# by cx28's verdict-grammar violation instead of the un-run check this case is about: a
+# stale-value pass, measured as such before this guard existed.
+elif ! sed_inplace_verified "$_gm_dir/roborev-review-checks.sh" \
+  's/^    TIER1="MEASUREMENT-DID-NOT-HAPPEN"$/    TIER1="PASS"/' \
+  '    TIER1="PASS"' 'MEASUREMENT-DID-NOT-HAPPEN'; then
+  bad 'case (cx29): the cx28 TIER1 mutation could not be verifiably restored to PASS on the copy, so a FAIL below would be cx28 grammar violation rather than cx29 never-ran check — the case is NOT MEASURED and must not report a pass'
+else
+  ok 'case (cx29): the early-return patch was really applied to the copy, and the cx28 TIER1 mutation was verified restored to PASS'
   run_wrapper "$work"
   assert_verdict 'case (cx29)' FAIL 1
   assert_says 'case (cx29) the un-run key is named as never having affirmatively passed' "^ERROR: verdict-affirmation: this run reached the PASS branch with a VERDICT-CARRYING key that never affirmatively passed — prompt-content: 'SKIP'\. "
@@ -2064,8 +2098,6 @@ if [ "$_gm_patched" = '  return 0' ]; then
   assert_says 'case (cx29) it points the reader at the wrapper, not the branch under review' 'NOT something to fix in the branch under review'
   assert_says 'case (cx29) the un-run key is visible in the block' '^prompt-content: SKIP$'
   assert_lacks 'case (cx29) and the grammar check does not misreport it as unrecognised' 'verdict-grammar'
-else
-  bad 'case (cx29): could not patch the copied checks file for an early return, so the never-ran-check path was never exercised'
 fi
 WRAPPER="$_gm_real_wrapper"
 
@@ -2109,9 +2141,9 @@ for _np_case in cx28b:PASSthisNeverRan cx28c:PASS-MEASUREMENT-DID-NOT-HAPPEN; do
   # would prove nothing about the mutation.
   run_wrapper "$work"
   assert_verdict "case ($_np_label control) the restored copy reaches PASS" PASS 0
-  if sed_inplace "$_gm_dir/roborev-review-checks.sh" \
-    "s/^    TIER1=\"PASS\"\$/    TIER1=\"$_np_value\"/" &&
-    grep -qF "TIER1=\"$_np_value\"" "$_gm_dir/roborev-review-checks.sh"; then
+  if sed_inplace_verified "$_gm_dir/roborev-review-checks.sh" \
+    "s/^    TIER1=\"PASS\"\$/    TIER1=\"$_np_value\"/" \
+    "    TIER1=\"$_np_value\"" '    TIER1="PASS"'; then
     ok "case ($_np_label): the near-prefix patch was really applied to the copy"
     run_wrapper "$work"
     assert_verdict "case ($_np_label)" FAIL 1

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -58,6 +58,54 @@ tmp=$(mktemp -d "${TMPDIR:-/tmp}/roborev-guard-test.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT
 
 # ---------------------------------------------------------------------------
+# PORTABILITY (#3296): the ONE in-place edit used by every case that mutates a copied
+# flow script. `sed -i EXPR FILE` is GNU-ONLY, and its BSD failure is SILENT-ish:
+# BSD/macOS sed declares -i with a REQUIRED argument (Apple text_cmds sed/main.c:
+# `getopt(argc, argv, "EI:ae:f:i:lnru")` — note the `i:`), so it consumes EXPR as the
+# backup SUFFIX and then reads FILE as the SCRIPT. The edit never lands. That is how
+# four cases (cx28, cx29, cx28b, cx28c) FAILed on macOS at pristine origin/main while
+# passing on Linux — each verifies the mutation landed before asserting against it, so
+# each correctly reported `bad`: the fail-closed design worked, only the portability
+# was wrong.
+#
+# This helper keeps that fail-closed property and adds a SECOND, independent guard at
+# the edit site: it returns NON-ZERO when the file content did not change, so an
+# expression that matches nothing is an error here as well as at each case's own
+# verification. Portability is therefore not a licence to become unconditional — a
+# no-op patch is still detected in both places.
+#
+# Replacement newlines are written as a backslash + a REAL newline (POSIX §sed, valid
+# on every sed) rather than `\n`: current BSD sed does translate `\n` in the RHS
+# (text_cmds sed/compile.c compile_subst: `case 'n': *p = '\n';`), but the POSIX form
+# is vintage-insensitive and costs nothing.
+#
+# Do NOT reintroduce `sed -i` (or any other GNU-only construct) here: the structural
+# assert in scripts/tests/test_roborev_guard_portability.sh forbids it, and that test
+# also exercises this helper under a BSD-semantics `sed` shim.
+sed_inplace() { # sed_inplace <file> <sed-expr>  -> non-zero if nothing changed
+  local _f="$1" _expr="$2" _t
+  _t="$_f.sed-inplace.$$"
+  sed "$_expr" "$_f" >"$_t" || { rm -f "$_t"; return 1; }
+  if cmp -s "$_f" "$_t"; then rm -f "$_t"; return 1; fi
+  mv "$_t" "$_f"
+}
+
+# PORTABILITY (#3296): the summary block's key ORDER, extracted with one awk.
+# The previous form was `grep -nE '^(k1|k2|k3):' "$OUT" | cut -d: -f2 | paste -sd,`,
+# whose `paste -sd,` carries NO FILE OPERAND. GNU paste reads stdin in that case; BSD
+# paste does NOT — Apple text_cmds paste/paste.c and FreeBSD usr.bin/paste/paste.c both
+# do `argc -= optind; argv += optind; if (*argv == NULL) usage();`, and `usage()` prints
+# "usage: paste [-s] [-d delimiters] file ..." to stderr and exit(1). So on macOS the
+# whole command substitution yielded the EMPTY STRING — exactly the reported case (j2)
+# symptom: an empty extraction while the two neighbouring asserts on the same $OUT were
+# green. `cut` is NOT implicated: FreeBSD usr.bin/cut/cut.c reads stdin when given no
+# file operand (`if (*argv) ... else rval = fcn(stdin, "stdin")`).
+# awk needs no join step, so the operand-less pipe stage disappears entirely.
+summary_key_order() { # summary_key_order <file> <extended-regex-of-keys> -> "k1,k2,k3"
+  awk -v keys="$2" '$0 ~ "^(" keys "):" { printf "%s%s", sep, substr($0, 1, index($0, ":") - 1); sep = "," }' "$1"
+}
+
+# ---------------------------------------------------------------------------
 # The stub reviewer: first on PATH, driven entirely by STUB_* env vars, replaying
 # the RECORDED SHAPE of the real binary's payload — notably `token_usage`, which is
 # a JSON-ENCODED STRING (decoded twice) carrying `total_output_tokens`, not a nested
@@ -1969,8 +2017,8 @@ assert_verdict 'case (cx28 control) the UNPATCHED copy reaches PASS' PASS 0
 assert_lacks 'case (cx28 control) and reports no grammar violation' 'verdict-grammar'
 # ONE key, ONE value, outside the grammar. `MEASUREMENT-DID-NOT-HAPPEN` is deliberately not a
 # near-miss of a recognised prefix, so the case pins the ALLOW-LIST rather than a spelling.
-if sed -i 's/^    TIER1="PASS"$/    TIER1="MEASUREMENT-DID-NOT-HAPPEN"/' \
-  "$_gm_dir/roborev-review-checks.sh" &&
+if sed_inplace "$_gm_dir/roborev-review-checks.sh" \
+  's/^    TIER1="PASS"$/    TIER1="MEASUREMENT-DID-NOT-HAPPEN"/' &&
   grep -qF 'TIER1="MEASUREMENT-DID-NOT-HAPPEN"' "$_gm_dir/roborev-review-checks.sh"; then
   ok 'case (cx28): the unrecognised-verdict patch was really applied to the copy'
   run_wrapper "$work"
@@ -1995,8 +2043,9 @@ printf '== case (cx29): a check that never ran cannot ride to PASS on its initia
 # before assigning anything, which is exactly what an aborted helper or a stray `return` in a
 # new branch looks like. cx28's control (the unpatched copy PASSes on this fixture) is the
 # both-directions control for this case too; the patch is verified applied before it is run.
-sed -i 's/^roborev_check_prompt_content() {$/roborev_check_prompt_content() {\n  return 0/' \
-  "$_gm_dir/roborev-review-checks.sh"
+sed_inplace "$_gm_dir/roborev-review-checks.sh" \
+  's/^roborev_check_prompt_content() {$/roborev_check_prompt_content() {\
+  return 0/'
 # VERIFIED, not assumed: the `return 0` must be the line IMMEDIATELY AFTER the function
 # header. A sed that matched nothing leaves a copy identical to the control, and this case
 # would then be asserting against an unpatched wrapper — a probe failing in the
@@ -2005,8 +2054,8 @@ _gm_patched=$(grep -A1 '^roborev_check_prompt_content() {$' "$_gm_dir/roborev-re
   | sed -n '2p')
 if [ "$_gm_patched" = '  return 0' ]; then
   # Undo cx28's patch so the ONLY grammar-relevant difference is the un-run check.
-  sed -i 's/^    TIER1="MEASUREMENT-DID-NOT-HAPPEN"$/    TIER1="PASS"/' \
-    "$_gm_dir/roborev-review-checks.sh"
+  sed_inplace "$_gm_dir/roborev-review-checks.sh" \
+    's/^    TIER1="MEASUREMENT-DID-NOT-HAPPEN"$/    TIER1="PASS"/'
   ok 'case (cx29): the early-return patch was really applied to the copy'
   run_wrapper "$work"
   assert_verdict 'case (cx29)' FAIL 1
@@ -2046,8 +2095,12 @@ for _np_case in cx28b:PASSthisNeverRan cx28c:PASS-MEASUREMENT-DID-NOT-HAPPEN; do
   printf '== case (%s): the near-prefix value %s is UNRECOGNISED, not a PASS ==\n' "$_np_label" "$_np_value"
   reset_stub
   # Restore the copy to the control state, then apply ONLY this mutation.
-  sed -i 's/^roborev_check_prompt_content() {\n  return 0$/roborev_check_prompt_content() {/' \
-    "$_gm_dir/roborev-review-checks.sh"
+  # The restore is the `cp` ALONE, and deliberately so (#3296): the line that used to sit
+  # here tried to undo cx29's insertion with `sed -i 's/^header() {\n  return 0$/header() {/'`
+  # — a TWO-LINE left-hand side, which no sed can match, since sed's pattern space holds one
+  # line at a time. It was therefore a no-op on GNU too, and the wholesale `cp` from the real
+  # checks file was already doing all the restoring. Removed rather than made portable: making
+  # a no-op portable would have been inventing behaviour the suite never had.
   cp "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$_gm_dir/roborev-review-checks.sh"
   work=$(make_fixture "case_$_np_label" pushed)
   STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
@@ -2056,8 +2109,8 @@ for _np_case in cx28b:PASSthisNeverRan cx28c:PASS-MEASUREMENT-DID-NOT-HAPPEN; do
   # would prove nothing about the mutation.
   run_wrapper "$work"
   assert_verdict "case ($_np_label control) the restored copy reaches PASS" PASS 0
-  if sed -i "s/^    TIER1=\"PASS\"\$/    TIER1=\"$_np_value\"/" \
-    "$_gm_dir/roborev-review-checks.sh" &&
+  if sed_inplace "$_gm_dir/roborev-review-checks.sh" \
+    "s/^    TIER1=\"PASS\"\$/    TIER1=\"$_np_value\"/" &&
     grep -qF "TIER1=\"$_np_value\"" "$_gm_dir/roborev-review-checks.sh"; then
     ok "case ($_np_label): the near-prefix patch was really applied to the copy"
     run_wrapper "$work"
@@ -2344,16 +2397,27 @@ assert_says 'case (f) reviewed-sha reports the RANGE' "^reviewed-sha: $(git -C "
 assert_says 'case (f) job printed' '^job: 4656$'
 assert_says 'case (f) log path named' '^log: .+transcript-'
 assert_one_block 'case (f)'
+# PORTABILITY (#3296): compare CANONICAL to CANONICAL, computed by the SAME mechanism the
+# wrapper uses. roborev-review.sh resolves --repo with
+#   REPO=$(git -C "$REPO_ARG" rev-parse --show-toplevel); REPO=$(cd "$REPO" && pwd -P)
+# and records THAT string. On macOS $TMPDIR lives under /var, which is a symlink to
+# /private/var, so the fixture path `$work` and the recorded path differ by that prefix and
+# the literal `--repo $work` match FAILed — with the wrapper behaving perfectly (this is what
+# broke both case (f) asserts at pristine origin/main). The expectation is canonicalised the
+# same way rather than loosened to a substring: the full flag string is still matched with
+# `grep -F`, so a relative --repo, a missing --repo, or a root-checkout --repo still FAILs.
+work_canon=$(cd "$(git -C "$work" rev-parse --show-toplevel)" && pwd -P)
 # The sanctioned invocation form: explicit HEAD sha, explicit ABSOLUTE --repo,
 # --wait, both --agent and --model — and never --branch, never two positionals.
-if grep -qF -- "review --branch --base origin/main --repo $work --agent codex --model gpt-5.6-sol --wait" "$INVOKED"; then
+if grep -qF -- "review --branch --base origin/main --repo $work_canon --agent codex --model gpt-5.6-sol --wait" "$INVOKED"; then
   ok 'case (f): invoked over the census RANGE with an explicit absolute --repo + --wait'
 else
   bad "case (f): unexpected invocation form: $(cat "$INVOKED")"
 fi
 # `--branch` is correct ONLY with an explicit --repo (without it, it resolves against
-# the ROOT checkout); the two-positional range form must never appear.
-if grep -qF -- '--branch' "$INVOKED" && grep -qF -- "--repo $work" "$INVOKED"; then
+# the ROOT checkout); the two-positional range form must never appear. `--repo` is matched
+# with its ABSOLUTE canonical value, so a relative path would not satisfy it.
+if grep -qF -- '--branch' "$INVOKED" && grep -qF -- "--repo $work_canon" "$INVOKED"; then
   ok 'case (f): --branch is paired with an explicit absolute --repo'
 else
   bad "case (f): --branch/--repo pairing missing: $(cat "$INVOKED")"
@@ -2463,10 +2527,16 @@ assert_verdict 'case (j2)' PASS 0
 assert_says 'case (j2) roborev-exit PASS' '^roborev-exit: PASS$'
 assert_says 'case (j2) findings NONE' '^findings: NONE$'
 # Key ORDER is part of the contract: roborev-exit sits between vacuity-tier2 and log.
-if [ "$(grep -nE '^(vacuity-tier2|roborev-exit|log):' "$OUT" | cut -d: -f2 | paste -sd,)" = "vacuity-tier2,roborev-exit,log" ]; then
+# Extracted with `summary_key_order` (one awk) — see its definition for WHY the previous
+# `grep -n | cut | paste -sd,` form returned the EMPTY STRING on macOS (#3296): the
+# operand-less `paste` usage()-errors on BSD instead of reading stdin. An empty extraction
+# still FAILs this compare, so the fix changes a FALSE FAIL into a real measurement; it does
+# not make the assert conditional.
+_j2_key_order=$(summary_key_order "$OUT" 'vacuity-tier2|roborev-exit|log')
+if [ "$_j2_key_order" = "vacuity-tier2,roborev-exit,log" ]; then
   ok 'case (j2): roborev-exit is positioned between vacuity-tier2 and log'
 else
-  bad "case (j2): unexpected key order: $(grep -nE '^(vacuity-tier2|roborev-exit|log):' "$OUT" | cut -d: -f2 | paste -sd,)"
+  bad "case (j2): unexpected key order: $_j2_key_order"
 fi
 
 printf '== case (j3): a pre-invocation failure leaves roborev-exit: SKIP ==\n'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -82,12 +82,32 @@ trap 'rm -rf "$tmp"' EXIT
 # Do NOT reintroduce `sed -i` (or any other GNU-only construct) here: the structural
 # assert in scripts/tests/test_roborev_guard_portability.sh forbids it, and that test
 # also exercises this helper under a BSD-semantics `sed` shim.
+#
+# THE ORIGINAL FILE IS TRUNCATED AND REWRITTEN, NOT REPLACED (#3296 round-6): the first
+# form ended in `mv "$_t" "$_f"`, and the scratch file was created fresh by `>`, so it
+# carried `0666 & ~umask` — i.e. NO execute bits under ANY umask. Every mutation of an
+# executable script (the cases here copy and patch `roborev-review-checks.sh`, mode 755)
+# therefore silently made it non-executable: measured `-rwxr-xr-x` -> `-rw-rw-r--`. That
+# is the same class as the defect this branch exists to fix — an environment-dependent
+# breakage introduced by a portability fix.
+#
+# Writing the transformed bytes back into the ORIGINAL path with `>` avoids the whole
+# question rather than answering it: POSIX redirection opens an EXISTING file with
+# O_TRUNC, and the `mode` argument of open() applies only on CREATION, so the file's
+# permission bits, owner and inode are untouched. No mode is ever queried — deliberately:
+# `stat`'s format flags are themselves GNU-vs-BSD divergent (`stat -c %a` vs `stat -f %Lp`),
+# and `cp`'s no-`-p` destination mode is umask-modified, so both of the obvious repairs
+# would have reintroduced exactly the platform divergence under test. The scratch file is
+# still used as the staging buffer (sed cannot read and write one file at once) and the
+# no-change check still runs BEFORE anything is written back, so the fail-closed contract
+# is unchanged: a no-op patch touches nothing and returns non-zero.
 sed_inplace() { # sed_inplace <file> <sed-expr>  -> non-zero if nothing changed
   local _f="$1" _expr="$2" _t
   _t="$_f.sed-inplace.$$"
   sed "$_expr" "$_f" >"$_t" || { rm -f "$_t"; return 1; }
   if cmp -s "$_f" "$_t"; then rm -f "$_t"; return 1; fi
-  mv "$_t" "$_f"
+  cat "$_t" >"$_f" || { rm -f "$_t"; return 1; }
+  rm -f "$_t"
 }
 
 # AFFIRMATIVE MEASUREMENT AT THE EDIT SITE (#3296, CLAUDE.md "a positive verdict requires an

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -2406,6 +2406,10 @@ assert_one_block 'case (f)'
 # broke both case (f) asserts at pristine origin/main). The expectation is canonicalised the
 # same way rather than loosened to a substring: the full flag string is still matched with
 # `grep -F`, so a relative --repo, a missing --repo, or a root-checkout --repo still FAILs.
+# >>> BEGIN case-f-invocation-asserts (#3296) — this block is EXTRACTED VERBATIM and
+# mutation-tested by scripts/tests/test_roborev_guard_portability.sh, which feeds it a
+# relative, a root-checkout and a missing `--repo` record and requires BOTH asserts to
+# report `bad` for each. Keep the markers; the extractor FAILs closed if they go missing.
 work_canon=$(cd "$(git -C "$work" rev-parse --show-toplevel)" && pwd -P)
 # The sanctioned invocation form: explicit HEAD sha, explicit ABSOLUTE --repo,
 # --wait, both --agent and --model — and never --branch, never two positionals.
@@ -2422,6 +2426,7 @@ if grep -qF -- '--branch' "$INVOKED" && grep -qF -- "--repo $work_canon" "$INVOK
 else
   bad "case (f): --branch/--repo pairing missing: $(cat "$INVOKED")"
 fi
+# <<< END case-f-invocation-asserts (#3296)
 if grep -qE -- 'review [0-9a-f]{7,40} [0-9a-f]{7,40}' "$INVOKED"; then
   bad 'case (f): the two-positional commit-range form was used'
 else


### PR DESCRIPTION
Closes #3296.

`origin/main` FAILed the `roborev-lints` gate component on macOS — 7 cases in
`scripts/tests/test_roborev_review_guard.sh` — so **no local certification was possible on the
(all-macOS) worker fleet**, on any branch, including a markdown-only docs diff. Three root causes,
all in the guard test's own scaffolding, none in the wrapper it guards. Every hosted CI lane is
Linux and was green throughout, so **no hosted signal can see this class**.

## The three root-cause fixes

1. **GNU-only `sed -i EXPR FILE` (4 cases: `cx28`, `cx29`, `cx28b`, `cx28c`).** BSD/macOS `sed`
   declares `-i` with a *required* argument (Apple `text_cmds` `sed/main.c`: `getopt(argc, argv,
   "EI:ae:f:i:lnru")` — note the `i:`), so it eats `EXPR` as the backup suffix and reads `FILE` as
   the script. The edit never lands. Replaced with a `sed_inplace` helper that **returns non-zero
   when the content did not change**, so a no-op patch is caught at the edit site.
2. **`/var` vs `/private/var` (2 cases, `case (f)`).** The assert compared a literal fixture path
   against the **canonicalised** path the wrapper records. Now canonicalised by the *same
   mechanism* the wrapper uses — `roborev-review.sh` does `rev-parse --show-toplevel` then
   `cd "$REPO" && pwd -P` — so the two cannot re-diverge on a future platform. Still a full-string
   `grep -F` match, so a relative, missing, or root-checkout `--repo` still FAILs (AC3).
3. **Operand-less `paste -sd,` (1 case, `case (j2)`).** GNU `paste` reads stdin with no file
   operand; **BSD does not** — Apple `text_cmds` `paste/paste.c` and FreeBSD `usr.bin/paste/paste.c`
   both do `argc -= optind; argv += optind; if (*argv == NULL) usage();`. The whole command
   substitution yielded the empty string, exactly the reported symptom. Replaced with one `awk`.
   `cut` is **not** implicated: FreeBSD `cut.c` reads stdin with no operand. Cause stated in-code
   from primary source (AC4).

A 5th `sed -i` site was **deleted rather than ported**: its left-hand side spanned two lines, which
no `sed` can match (the pattern space holds one line), so it was **a no-op on GNU too** — the
wholesale `cp` on the next line was always doing the restore. Making a no-op portable would have
invented behaviour the suite never had.

### 4th fix, found by review: `sed_inplace` was resetting permission bits

The helper ended in `mv "$_t" "$_f"`, and the scratch file was created fresh by `>`, so it carried
`0666 & ~umask` — **no execute bits under any umask**. Every mutation of an executable script
silently made it non-executable (measured `-rwxr-xr-x` → `-rw-rw-r--`); the cases here patch
`roborev-review-checks.sh`, mode 755. **Same class as the defect this branch exists to fix — an
environment-dependent breakage introduced by a portability fix.**

Fixed by writing the transformed bytes back into the **original path** (`cat "$_t" >"$_f"`), which
**avoids the mode question rather than answering it**: POSIX redirection opens an existing file with
`O_TRUNC`, and `open()`'s mode argument applies only on *creation*, so permissions, owner and inode
are untouched. No mode is ever queried — deliberately, because `stat`'s format flags are themselves
GNU-vs-BSD divergent (`-c %a` vs `-f %Lp`) and `cp` without `-p` gives the destination a
umask-modified mode, so **both obvious repairs would have reintroduced the very divergence under
test**. Both directions are pinned with POSIX `[ -x ]`: the bit survives a successful edit *and* a
failed (no-change) edit.

## New: `scripts/tests/test_roborev_guard_portability.sh` (129 cases, ~1s, hermetic)

The bug is macOS-only but every fix was developed on Linux, so the branch adds a Linux-runnable
BSD-semantics guard, wired into the existing `roborev-lints` component. Two mechanisms:

1. **STRUCTURAL scanner** — the GNU-only constructs cannot be reintroduced into the roborev code
   path. Every pattern carries a positive control, so a regex that silently matches nothing cannot
   pass. **It now scans its own source too**, with `portability-lint-allow` markers on its
   deliberate BSD-emulation fixtures (not a blanket exemption).
2. **BEHAVIOURAL BSD-shim differential** — a `sed` shim with BSD `-i` argument semantics and a
   `paste` shim that usage-errors with no operand go first on `PATH`, and the guard test's **own**
   helpers (extracted verbatim) are executed against them. Each shim must first be shown to
   *reproduce* the reported defect, or the differential proves nothing.

**Scanner scope is stated in code as ENUMERATED, not exhaustive** — see "SCOPE OF THIS SCANNER".
Spelling space is unbounded (`--in-place=`, `-i''`, `-e X -i`, continuations, `$SED -i`, `eval`), so
a scanner implying completeness generates a finding every round forever. The file therefore names
what the differential actually executes, and splits the coverage claim in two: **bounded inside
those helpers, uncovered anywhere else.** An earlier revision of this text claimed a backstop
without qualification; review showed that was overstated and it is now retracted in place, with the
uncovered case recorded as a known reduction in coverage (`STATED RESIDUAL 5`).

## Evidence (this Linux box)

| Check | Result |
|---|---|
| `test_roborev_review_guard.sh` | `passed: 581  failed: 0`, exit 0 — **same count as baseline**, no case dropped to buy green |
| `test_roborev_guard_portability.sh` | `passed: 129  failed: 0  skipped: 0`, exit 0 |
| `--lite` @ `9087d53` | `RESULT: PASS`, `dirty: no`, `tree-integrity: PASS`, `roborev-lints: PASS (31s)` |
| **Gate of record @ `9087d53`** | **`RESULT: PASS`**, `tree-integrity: PASS`, `dirty: no`, all ~30 components |
| **`--delta` @ `e36521c`** (anchor `9087d53`) | **`RESULT: PASS`**, `delta-files: 2 allowed / 0 offending`, `delta-executors: scoped-tests(rust/python) shell-selftests(2)` |
| **roborev round 13 @ `e36521c`** | **`RESULT: PASS`, `findings: NONE`**, `sha-assert: PASS` |
| **AC6** — `--lite` on a single-file markdown diff | `RESULT: PASS`, `roborev-lints: PASS` |
| **AC1 macOS — NATIVE, both PASS** | see below |

### AC1 — native macOS tally (the acceptance bar, satisfied on the target platform)

Run by the coordination lead on **macOS 26.5.2, stock BSD userland**, in a fresh
`git worktree add --detach` at **exactly `9087d53ad24e7177769620f525168f497ba0f9c7`**
(`rev-parse HEAD` verified), untouched by any other lane:

```
==== ROBOREV REVIEW GUARD TEST TALLY ====
passed: 581  failed: 0
GUARD-TEST RESULT: PASS                      EXIT=0

==== ROBOREV GUARD PORTABILITY TALLY ====
passed: 120  failed: 0  skipped: 0
PORTABILITY RESULT: PASS                     EXIT=0
```

`581/0` matches the Linux count exactly — **the 7 macOS failures at `origin/main` are gone and no
case was dropped to buy green.** The second tally is the portability guard's **first-ever native
execution on its target platform**, with `skipped: 0` — every case ran, none skipped. That mattered
because a BSD-emulation guard that had only ever executed under GNU tools is itself a #3296 risk, and
it is gate-wired into `roborev-lints`.

**The round-7 `-maxdepth` High finding is refuted BY PLATFORM MEASUREMENT**, not by argument: both
scratch-file enumeration cases pass natively (including the planted-spill control that proves the
clean verdict is a measurement rather than an empty pipe), and a direct oracle probe on that box
showed stock macOS `find` accepting `-maxdepth 1` and returning 14 entries with no error and no
fallback.

### AC1 + AC6 — native macOS tally at the FINAL SHA `e36521c` (the tally this PR merges on)

Run by the coordination lead on **macOS 26.5.2, stock BSD userland**, in a fresh detached worktree at
**exactly `e36521c7dbc1b67dd59e6a4c93544695972ee602`**:

```
==== ROBOREV REVIEW GUARD TEST TALLY ====
passed: 581  failed: 0
GUARD-TEST RESULT: PASS                      EXIT=0

==== ROBOREV GUARD PORTABILITY TALLY ====
passed: 129  failed: 0  skipped: 0
PORTABILITY RESULT: PASS                     EXIT=0
```

`581/0` is the baseline count unchanged — **the seven macOS failures are eliminated and no case was
dropped to buy green.** `120 → 129` is confirmed all-additions, zero skips, every case executed
natively.

**AC6's macOS half is now MEASURED rather than inferential.** It had been evidenced on Linux with the
macOS half following compositionally; that gap was closed by a direct native run of the gate-wired
component itself on the same Mac at `e36521c`:

```
mode: PARTIAL (--only roborev-lints) - does NOT count as the gate
roborev-lints:     PASS (91s)
tree-integrity: PASS   commit: e36521c   dirty: no
```

`--only` PARTIAL mode counts for nothing as a gate — the Linux gate of record at `9087d53` plus the
`--delta` re-cert remain the certification — but as a *measurement* it turns AC6-macOS from "follows
compositionally" into "observed: the wired component passes on its target platform."

**The earlier tally below binds to `9087d53ad` and is SUPERSEDED.** Three post-anchor polish rounds (below) changed
both test scripts, so per the coordination ruling — *a change touching either test script requires a
fresh `READY-FOR-MACOS-TALLY`* — a **new native tally on `e36521c` is required before merge** and has
been requested. The `9087d53` tally is retained above as the evidence that the seven macOS failures
were eliminated; it is **not** the tally this PR merges on.

## Post-anchor polish rounds (`--delta` re-certified, never a repeat full gate)

The gate of record PASSed at `9087d53`. Three further roborev rounds then found real defects, all
confined to `scripts/tests/*.sh`, so each re-certified with **`--delta`** against that anchor rather
than burning a second full gate (`--delta` fails closed on any non-test/docs path, so a mis-scoped
diff could not have passed vacuously):

| Round | SHA | Finding | Fix |
|---|---|---|---|
| 11 | `956bb0e` | **Medium — FALSE POSITIVE**: `RE_SED_INPLACE_EMPTY_DQ`/`_SQ` lacked a token boundary, flagging `sed -i''.bak` / `sed -i"".bak` | Quote removal decides it: `-i''` → argv `-i` (BSD's `-i` takes a required arg and eats the next token — **non-portable**), while `-i''.bak` → argv `-i.bak` (**the attached-suffix form both seds read identically**). Both rules now require the quotes to END THE TOKEN; 7 negative controls pin the portable spellings. |
| 12 | `1338eba` | **Low**: the AC3 symlink-capability control reported the symlink branch as measured when `git` was absent, because `cf_env_limitation` returned the Git limitation first | Probes split; the symlink control now asserts its cause identifies **symlink creation** specifically, so a Git answer cannot satisfy it. Both directions still pinned. |
| 13 | `e36521c` | **Medium — SAFETY**: `mktemp -d` unchecked. Empty `$tmp` makes every `"$tmp/x"` resolve to `/x`, and these scripts CREATE those paths unconditionally (`mkdir -p`, `ln -s`, `chmod 000`, dozens of `>"$tmp/…"`) — root-level file creation on a privileged runner | Verified non-empty AND a directory **before the trap and before any fixture** (arming `rm -rf "$tmp"` on an unverified path is the same hazard). Controlled: with a failing `mktemp` shim both scripts refuse to run, exit non-zero, and create nothing under `/`. |

**Round 13's fix also repairs the identical defect PRE-EXISTING on `origin/main`** at
`test_roborev_review_guard.sh:57` (same unchecked `mktemp -d`, same `trap 'rm -rf "$tmp"' EXIT`).
That one line is outside this issue's scope and is fixed deliberately and opportunistically, because
it is the same class, it is one line, and the file is already rewritten by ~200 lines here — certifying
a file while knowingly leaving a root-overwrite hazard in it is not defensible. Scope was held to
exactly that line. **Approved by owner ruling** as a safety rider rather than scope drift, with the
deliberate one-line scope extension noted for the record.

**Why round 11's false positive was treated as a blocker rather than batched as a nit:** this lint is
gate-wired into `roborev-lints`, so a false FAIL reds the gate on *correct* code — precisely the
failure mode this issue exists to eliminate. *A key that reds on correct input is the key agents learn
to waive.* Precision in the flagging direction matters here as much as coverage does.

**The guard is not vacuous.** Every mechanism has a measured RED-before:

| Planted defect | Verdict |
|---|---|
| `sed -i 's/foo/bar/' "$1"` / `-Ei` / `-ni` / `-nEi` / `-e EXPR -i file` / line-broken `-i` | `failed: 1`, exit 1 |
| `sed --in-place=.bak …` (new) | `failed: 2`, exit 1 — reported **clean** before |
| `paste -sd,` bare / `< input` / `>output` / `2>/dev/null` (last two new) | `failed: 2`, exit 1 — reported **clean** before |
| unreadable scan target (new) | `failed: 15`, exit 1 — reported a **CLEAN SCAN** before |
| fixture-setup failure, `git commit` planted to fail (new) | `failed: 2`, exit 1 — was `skipped: 2` + **PASS** before, silently disabling all 4 canonical-path probes |
| AC5 composition: injected `exit 1` | `failed: 1`, exit 1 — was `skipped: 1` + **PASS** before |
| AC5 composition: unrelated `SKIP -` line + `exit 0` | `failed: 1`, exit 1 — was classified a legitimate dependency skip before |
| any of the above in a *comment* | `failed: 0`, exit 0 ✅ (no false positive) |

**AC5** (#3262's exit-code propagation) is measured in both directions. A composition that declines
is classified by a **closed grammar** of three enumerated states — `MEASURED` / `DEP-SKIP` /
`UNRECOGNISED` — where `DEP-SKIP` is the *only* permissive state and requires **two** affirmative
signals: the dedicated sentinel `exit 77` **and** the exact whole-line message, *extracted from the
guard test itself* so it cannot drift. Everything else is a counted failure naming the unrecognised
cause. 7 permanent controls pin the complement.

Likewise **AC3 fixture setup**: `skip` is now reachable only from a dedicated capability probe (git
present; a filesystem that can create symlinks), controlled in *both* directions so the skip route
is not dead code. Every other setup failure is a failure.

## roborev

**Round 13 @ `e36521c` — `RESULT: PASS`, `findings: NONE`**, `sha-assert: PASS`, every integrity key
PASS, `prompt-content: PASS (3/3)`, 175.2k input / 122.1k cached.

Thirteen rounds, all genuine (correct range, token accounting far from the 18.7k/0-cached/8s vacuous
signature). Rounds 1–3 by the original worker; the lane was then interrupted by an EC2 fleet kill
and resumed on a replacement machine under an owner-authorised claim adoption, which found that HEAD
had never been reviewed (round 3 was in flight when the machine died, and a commit landed after it).

| Round | SHA | Verdict |
|---|---|---|
| 1 | `6d06f45` | FAIL — 3 findings, fixed |
| 2 | `27b3abc` | FAIL — 1 finding, fixed |
| 3 | `b16dbea` | interrupted mid-run (machine killed) |
| 4 | `8be5a07` | FAIL — 2 findings, fixed |
| 5 | `04e4481` | FAIL — 2 findings (both *inside* round 4's fix), fixed |
| 6 | `e3d90fb` | FAIL — 3 findings, fixed |
| 7 | `3911ac7` | FAIL — 3 findings (2 = the since-deleted lint; 1 refuted, below) |
| 8 | `67468c6` | FAIL — 4 findings, fixed |
| 9 | `c1ad0e3` | **VOID** — `sha-assert: FAIL`, range ≠ `origin/main...HEAD` after main moved; rebased |
| 10 | `9087d53` | PASS — findings: NONE (**this is the gate-of-record anchor**) |
| 11 | `956bb0e` | FAIL — 1 finding (false positive), fixed |
| 12 | `1338eba` | FAIL — 1 finding, fixed |
| **13** | **`e36521c`** | **PASS — findings: NONE** |

Every finding across rounds 4–9 was one recurring class: **a positive verdict inheriting a
permissive branch from an unmeasured state** — the same defect this issue is about, appearing inside
the fix for it, repeatedly. Each is now keyed on an affirmative value rather than the absence of a
bad signal.

### A structural lint was DELETED by owner ruling

The round-4 fix added `sed_status_offenders`, a rule that every `sed_inplace` call site reads the
helper's status. It produced a **false PASS in every subsequent round** (`&&`/`||`-anywhere accepted
`true && sed_inplace …`; the allow-list that replaced it accepted `if sed_inplace … || true; then`;
and it could not see an unquoted `sed_inplace $file "$expr"` **at all**). That is not a series of
typos — it is a bash ERE approximating **shell grammar**, whose correctness is knowable only by
differential testing against a real parser.

Per CLAUDE.md's #3229 ruling (*"a guard with known documented false-PASSes is worse than no guard…
subtraction cannot introduce a false PASS"*), the owner ruled **delete**, with two binding riders,
both landed:
1. a **caller contract** at `sed_inplace` naming the accepted forms and forbidding `|| true`;
2. a **`DELIBERATELY NOT BUILT`** record (the #3283 disposition pattern) stating what it would have
   checked, why it is gone, what protects the property instead, and the **accepted residual: a fifth
   call site that discards the status is caught only behaviourally.** Recorded, not tracked as an
   issue, re-raisable only if it bites in practice.

### One finding refuted, not implemented

Round 7 raised **High**: *"stock macOS `find` does not support `-maxdepth`, so both scratch-file
checks will fail on the target platform."* **Refuted on evidence:** `origin/main`'s
`test_roborev_review_guard.sh:3532` **already** uses `find -maxdepth 1`, and this issue's own macOS
measurement of that very file was `passed: 553  failed: 7` with all 7 failures enumerated as the
`sed -i` / `/private/var` / `paste` cases — had `-maxdepth` been unsupported it would have been an
8th failure. `scripts/agent-gate.sh` also uses it twice and runs fleet-wide on the all-macOS fleet.
The finding did not recur in round 8. `-maxdepth` is kept: a hand-rolled depth-1 traversal is
likelier to be wrong than the flag. **The native macOS tally is being asked to confirm these
specific cases**, which turns a disputed assertion into a platform measurement.

An earlier round's *"parse shell tokens instead of matching lines"* was likewise declined — it is
the second-implementation-of-shell-grammar trap that got the lint above deleted.

## Residuals, stated

- **AC1's macOS half is SATISFIED natively** (above). It could not be observed from the implementing
  box, which is Linux — at pristine `origin/main` the guard test is `581/0` here, so the 7 failures
  are genuinely macOS-only. No macOS tally was pasted that was not observed; the lead ran it.
- **A fifth `sed_inplace` call site discarding its status** is caught only behaviourally (above).
- **An unenumerated GNU-only spelling introduced outside the helpers the differential executes** is
  an uncovered false negative (`STATED RESIDUAL 5`).
- **A separate PRE-EXISTING bug is now #3314** (P2, Backlog): on a `python3`-less `PATH` the guard
  test reports `passed: 422  failed: 77`, exit 1 — **byte-identical on pristine `origin/main`** —
  contradicting `agent-gate.sh`'s own comment claiming the component is SKIP-aware and *"safe on a
  stripped runner"*. Same class as #3296, different root cause; folding it in would have broken
  1:1:1:1.
- The full `AGENT-GATE SUMMARY` (the one gate of record) is run once by `flow-closer` pre-merge and
  recorded below.
