### PR TITLE
fix(#3250): a docs/ path prefix no longer short-circuits pr-gate-core to green

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -84,9 +84,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Names only, NUL-safe path handling, base..head three-dot compare so
-          # only files the PR actually changed are considered.
-          git diff --name-only "${BASE_SHA}...${HEAD_SHA}" > changed-files.txt
+          # Names only, base..head three-dot compare so only files the PR
+          # actually changed are considered.
+          #
+          # `core.quotePath=false` (issue #3250) is load-bearing: git C-QUOTES a
+          # path containing non-ASCII bytes by default, and this repo tracks
+          # non-ASCII and space-bearing prose paths under docs/. The classifier
+          # now decides on the EXTENSION, so a quoted `"docs/\303\251.md"` would
+          # be read as extension `md"` — an accident of spelling. Raw paths make
+          # the verdict come from the real extension instead. `-z` is
+          # deliberately NOT used: it would change the classifier's
+          # newline-delimited stdin contract.
+          git -c core.quotePath=false diff --name-only "${BASE_SHA}...${HEAD_SHA}" > changed-files.txt
 
           echo "Changed files:"
           sed 's/^/  - /' changed-files.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,16 +112,25 @@ cat /tmp/gate-summary.txt   # the SUMMARY block is the ONLY gate text an agent r
   a **just-launched or still-queued** gate as its gate of record — a verdict that does not exist.
   Anchor every poll (agents, skills, docs, helper scripts) on `PASS|FAIL`; a sentinel-only summary
   means "still running, died, or queued", never certified.
-- **A markdown/docs-only diff cannot change the compiled binary — so a test failure in its full gate
+- **A GENUINELY PROSE diff cannot change the compiled binary — so a test failure in its full gate
   is BY DEFINITION pre-existing on `main` or a flake, and the correct response is CITE-AND-WAIVE
-  (#3042).** If your diff touches no compiled input (no `src`, no `Cargo.*`, no build script, no
-  workflow, no test-data), it cannot have caused a test to fail. (Read "docs-only" here the same way
-  roborev doctrine does — a **code-free census**, not a `docs/` path prefix: a PR carrying
-  `docs/reports/*-artifacts/` harness executables ships real programs, so this waiver does not apply to
-  it.) **NEVER patch source to turn such a
+  (#3042).** The waiver's precondition is that the diff touches no compiled input (no `src`, no
+  `Cargo.*`, no build script, no workflow, no test-data). **That qualifier is a path-shape test, and a
+  path shape is not evidence — DON'T JUDGE IT, RUN IT (#3250):**
+  ```bash
+  git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh   # exit 0 = prose
+  ```
+  A non-zero exit means the waiver does not apply, full stop. **The falsifying case is not
+  hypothetical**: this repository ships measurement harnesses under `docs/reports/*-artifacts/` **by
+  convention**, so a #3222-shaped diff contains `src/main.rs` **and** `Cargo.toml` under
+  `docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/` — it satisfies "no `src`, no `Cargo.*`"
+  **textually** while being false **materially**, and an agent correctly following the old wording
+  waives a red that is genuinely theirs. (Read "docs-only" here the same way roborev doctrine does — a
+  **code-free census**, never a `docs/` path prefix; the classifier above is the gate-side spelling of
+  the same idea, and `scripts/tests/test_classify_docs_only.sh` pins it.) **NEVER patch source to turn such a
   gate green** — that is a real change smuggled in under a docs diff, certified by nothing, and it
-  masks the actual main-red. Instead: (1) confirm the diff really is non-compiling-input
-  (`git diff --stat origin/main...HEAD`); (2) identify the failure as a known main-red issue or a
+  masks the actual main-red. Instead: (1) confirm the diff really is non-compiling-input, with the
+  classifier above rather than by eye; (2) identify the failure as a known main-red issue or a
   known flake — reproduce it on a clean `origin/main` checkout if it is not already filed, and FILE it
   if it is not; (3) record the waiver in the PR body naming the failing component and the issue number
   it belongs to. A waiver with no cited issue is not a waiver — it is an unexplained red. Conversely,

--- a/openspec/changes/narrow-docs-only-classifier/design.md
+++ b/openspec/changes/narrow-docs-only-classifier/design.md
@@ -1,0 +1,412 @@
+# Design: narrow the docs-only correctness-gate classifier (issue #3250)
+
+## Context
+
+`scripts/ci/classify-docs-only.sh` decides whether `pr-gate-core` — the compute half of the `required`
+branch-protection check — runs at all. It returns docs-only for any path under `docs/`, extension-blind.
+Since this repository ships measurement harnesses under `docs/reports/*-artifacts/` by convention, three
+merged PRs (#3222, #3081, #3216) reported `required` green in 13–16 seconds having compiled and tested
+nothing. #2910's tier aggregation was checked and does **not** mitigate it: `flight-ci.yml:148` leaves
+`docs/**` deliberately unmandated, so the one registered tier emits not-applicable success.
+
+This is the same bug **class** as #3229 — a path glob that swallows executables under `docs/` — in the
+**correctness gate** rather than the reviewer. #3229 merged first, deliberately, so that the docs-scoped
+artifact declaration exists in exactly one place before a second consumer appears.
+
+Two constraints from #3229's post-mortem govern this design and are treated as given:
+
+- **Fix the BOUNDARY, not the sites.** #3229 burned three review rounds patching one path-normalisation
+  consumer at a time. Here: ONE decision point, pinned structurally.
+- **A symmetric mirror of a production constant is not a test.** A test that copies the constant shares any
+  defect in it, so both sides agree and the suite is green while broken — #3042's blindness in shell.
+
+---
+
+## D1 — the decision point: one function, an affirmative allowlist, a closed grammar
+
+`is_docs_file()` keeps its existing shape and its sensitive-directory escape
+(`.github/`, `scripts/`, `test-data/` ⇒ `full`). The blanket `docs/*) return 0` arm is replaced by a
+**single dispatch**:
+
+```
+is_docs_file(path):
+  1. sensitive dirs (.github/ scripts/ test-data/)              -> full     [unchanged]
+  2. path is not a raw repo-relative spelling (begins with `"`)  -> full     [new, D5]
+  3. path is under docs/  -> return docs_path_is_documentation(path)         [the ONE dispatch]
+  4. global allowlist: *.md|*.markdown | images | LICENSE*|NOTICE* -> docs   [unchanged]
+  5. otherwise                                                   -> full    [unchanged]
+```
+
+`docs_path_is_documentation()` is the **only** place a path under `docs/` is classified, and it classifies
+by **layer**, each layer an affirmative match:
+
+| layer | rule | source of the rule |
+|---|---|---|
+| **L1 prose / image / legal** | `.md`, `.markdown`; `.png .jpg .jpeg .gif .svg .webp .ico`; `LICENSE*`, `NOTICE*` — at any depth | the classifier's **own** path semantics, unchanged from today |
+| **L2 inert report artifact** | extension in the *inert* bucket of the imported `CODE_FREE_ARTIFACT_EXTENSIONS` — at any depth under `docs/` | **imported** (#3229), bucketed here (D3b) |
+| **L3 code-bearing artifact** | extension in the *code-bearing* bucket **AND** `roborev_path_in_artifact_dir(path)` | **imported** (#3229), scoped by directory (D3a) |
+| **fail-closed** | anything else: unknown extension, **no** extension, unassigned imported extension | AC1 |
+
+Ordering is presentational only: the layers are a disjunction over disjoint extension sets, so permuting
+them cannot change an answer. That is stated because #3229's own endpoint fold had to make the same claim.
+
+**Why a function rather than more `case` arms.** The defect is not that one arm is wrong; it is that a
+verdict is reachable from a *path shape* instead of from a *named class*. Adding arms leaves the next
+`docs/`-shaped arm one edit away. A single dispatch makes "classify a `docs/` path" a thing with one
+address, which is what the structural assert can then pin (D6).
+
+**Closed grammar, not "absence of a bad signal".** `docs_path_is_documentation` returns docs-only only from
+an L1/L2/L3 match. There is no `else return 0`, no "not obviously code ⇒ prose". This is #3229's
+affirmative-measurement rule applied at the leaf: a positive verdict requires a positive match.
+
+### Alternatives rejected
+
+- **Add an executable-extension deny-list under `docs/`** (`case docs/*.sh|docs/*.py|…) return 1`). This is
+  the "patch the sites" shape, and it is **fail-OPEN**: the next extension someone commits under `docs/`
+  (`.rb`, `.jq`, `.mjs`, a Dockerfile) is documentation by default. AC1 mandates fail-closed on an
+  unrecognized extension, which a deny-list cannot deliver.
+- **Consult the git executable bit**, as #3229's census does for extensionless paths. Rejected on evidence,
+  see D3d.
+- **Drop `docs/` from the classifier entirely** so `docs/x.md` falls through to the global `*.md` arm. This
+  loses L2/L3 (report artifacts) and would force the full gate on every WS0 report PR — a direct AC2
+  violation, and the standing 14-minute cost the issue forbids.
+
+---
+
+## D2 — AC5: DIRECT IMPORT, not the drift-check substitute. The evidence.
+
+AC5 requires importing #3229's artifact declaration and never restating it; if a shared constant is
+*genuinely not expressible* across `scripts/ci/` and `scripts/flow/`, the required substitute is a
+mechanical check that FAILs when the two lists disagree, with a greppable reason. **Import is expressible.**
+Measured, not assumed:
+
+1. **The declaring file is designed to be sourced and says so.** `scripts/flow/roborev-review-oracles.sh`'s
+   header reads *"SOURCED, never executed"*, and the declaration's own comment reads: *"THE SINGLE
+   DECLARATION: it is imported, never redeclared (`scripts/ci/classify-docs-only.sh` will import it —
+   issue #3250)."* This change is the import #3229 provisioned for.
+2. **Sourcing has no side effects.** Probed under `set -euo pipefail`: exit 0, **zero bytes** on stdout and
+   stderr, shell option string unchanged (`ehuBc` → `ehuBc`), no environment variable required, 11 function
+   definitions and the constants defined. The file contains **no** `set`/`shopt` line, so it cannot mutate
+   the caller's options — which matters because the classifier runs under `set -euo pipefail`.
+3. **The path exists in CI.** `pr-gate.yml`'s only checkout is `actions/checkout@v5` with `fetch-depth: 0`
+   — the whole repository, so `scripts/flow/roborev-review-oracles.sh` is present in the `pr-gate-core`
+   workspace. The classifier is also run from the repo root by the gate's `tooling-tests` component and
+   standalone by developers.
+4. **The directory matcher comes with it.** `roborev_path_in_artifact_dir` is a pure function over its
+   argument plus `CODE_FREE_ARTIFACT_DIR_GLOBS`; it needs none of the wrapper's state. Verified in the
+   probe: `docs/reports/ws0-3217-artifacts/harness/common.sh` ⇒ inside;
+   `docs/observability/grafana/dashboards/cqlite-overview.json` ⇒ outside. Re-implementing it would be the
+   redeclaration AC5 forbids, one level up — and its component-wise matching is load-bearing (a bash `case`
+   glob crosses `/`, git's `:(glob)` `*` does not).
+5. **`CODE_FREE_ARTIFACT_DIR_GLOBS` is an array, and that is why it must be imported rather than copied.**
+   Its values contain `*`; iterating an unquoted string form pathname-expands them against `$PWD`, which
+   silently degrades the classification to "the directories that happen to exist in this checkout". The
+   declaration documents this as a measured hazard. A copy would have to re-earn that.
+
+**So the design takes (a) direct sourcing.** Hermeticity is preserved: the import is a local file read, no
+network, no cargo, no toolchain, and the self-test stays pure shell.
+
+**The failure direction is closed, because an import can fail.** The classifier verifies **after** sourcing
+that the file existed, sourced successfully, and that `CODE_FREE_ARTIFACT_EXTENSIONS` is non-empty and
+`CODE_FREE_ARTIFACT_DIR_GLOBS` has ≥1 element. Any failure ⇒ **every** path under `docs/` classifies `full`
+and the classifier prints a named reason. It never degrades to L1-only-and-carry-on, because that would be
+a *more permissive* gate produced by an infra fault — the shape #3229 named as "an unmeasurable input
+reaching a permissive branch".
+
+**The import is resolved relative to the script's own location**
+(`$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../flow/roborev-review-oracles.sh`), never relative to
+`$PWD`. Two reasons: the classifier is invoked from varying working directories, and location-relative
+resolution is what makes the mutation test of D6 possible — a temp tree with a mutated declaration must be
+able to change the verdict.
+
+**AC5's drift-check substitute is still delivered, aimed at where drift can now occur.** With the list
+imported, the list cannot drift. What *can* drift is the **bucketing**: #3229 may add an extension to
+`CODE_FREE_ARTIFACT_EXTENSIONS`, and this classifier must decide whether the new extension is inert or
+code-bearing. So the self-test asserts the buckets **partition the imported set exactly** — union equals
+the imported set, buckets pairwise disjoint — and an extension in neither FAILs with a greppable reason
+naming the extension and this issue. That is a mechanical disagreement check, and it fails **closed**: an
+unassigned extension also classifies `full` at runtime.
+
+---
+
+## D3 — the subtlety: are #3229's answer set and this classifier's the same?
+
+**No, and conflating them would be the next drift.** They ask different questions:
+
+- **#3229 asks:** *is this path CODE for the purpose of REVIEW?* — i.e. must a reviewer see it. Cost of
+  getting it wrong toward "artifact": lost review coverage. Toward "code": tokens.
+- **#3250 asks:** *does this path require the CORRECTNESS GATE?* — i.e. must fmt/clippy/build/tests/oracle
+  and the policy checks run. Cost toward "docs": a merged, never-compiled change. Toward "code": ~14 minutes.
+
+They **share exactly one sub-answer**: *what counts as committed run output beside a report*. That is
+precisely what `CODE_FREE_ARTIFACT_EXTENSIONS` × `CODE_FREE_ARTIFACT_DIR_GLOBS` denotes, and it is the only
+thing imported. Everything else is this classifier's own path semantics. Stated as a table, because the
+owner's constraint is that the boundary be *stated*, not left implicit:
+
+| element | shared mechanism (imported) | this classifier's own semantics |
+|---|---|---|
+| the artifact extension set | ✅ `CODE_FREE_ARTIFACT_EXTENSIONS` | — |
+| the artifact directory globs + matcher | ✅ `CODE_FREE_ARTIFACT_DIR_GLOBS`, `roborev_path_in_artifact_dir` | — |
+| inert vs code-bearing bucketing of that set | — | ✅ D3b, derived from CLAUDE.md's asymmetry rule |
+| prose extensions | — | ✅ `.md`/`.markdown` only (D3e) |
+| images + `LICENSE*`/`NOTICE*` | — | ✅ unchanged, repo-wide (D3c) |
+| extensionless paths | ❌ deliberately **not** adopted | ✅ unconditional `full` (D3d) |
+| sensitive-dir escape (`.github/`, `scripts/`, `test-data/`) | — | ✅ unchanged; roborev has no analogue |
+
+### D3a — where the answer sets legitimately COINCIDE
+
+For every executable/config-as-code extension the repo ships under `docs/` — `.sh .py .bt .c .rs .toml
+.cql .yml .yaml` — both subsystems answer **code**: none of them is in
+`CODE_FREE_ARTIFACT_EXTENSIONS`. And both fail closed toward "code". So importing the artifact set is
+**safe for the gate**: it is a set of things the reviewer-side already judged non-code, and the gate's
+question is a *stricter* one on the same material.
+
+### D3b — where they legitimately DIFFER: directory scoping applies to code-bearing formats only
+
+CLAUDE.md already rules on this, and the rule is doctrine rather than a preference: *"exclusion of
+code-bearing formats MUST be scoped by directory, never by extension alone"*, because *"an extension
+describes a FORMAT; a directory records an INTENT"* — and the falsifying case is
+`docs/observability/grafana/dashboards/cqlite-overview.json`, which the **full agent gate's own
+`kit-dashboard-drift` component guards**. A classifier that calls that file documentation tells the gate to
+skip on a file the gate itself treats as correctness-bearing.
+
+The asymmetry is also **scoped** by doctrine: it holds for *inert dumps*, where a mistake costs only noise.
+Applied here:
+
+- **inert bucket** (`txt jsonl log err csv gz pdf jfr mmd tex diff`) — docs-only **anywhere** under
+  `docs/`. Nothing in `pr-gate-core` reads a run dump, and no gate component treats one as a contract.
+- **code-bearing bucket** (`json html`) — docs-only **only inside** an artifact directory.
+- **`png svg`** — answered by L1 (the pre-existing image layer) and therefore assigned to neither bucket;
+  see D3c.
+
+Measured against the tracked tree, which is what makes this concrete rather than theoretical: of **808**
+tracked `docs/` files carrying an imported artifact extension, **803 lie inside the four artifact
+directories** and **5 do not**. Each of the 5 is assigned deliberately:
+
+| path | verdict | why |
+|---|---|---|
+| `docs/observability/grafana/dashboards/cqlite-overview.json` | **full** | functional config; guarded by the gate's own `kit-dashboard-drift` |
+| `docs/reports/delivery-telemetry.schema.json` | **full** | the schema governing the delivery ledger |
+| `docs/reports/delivery-telemetry.jsonl` | **docs-only** | inert append-only ledger; the per-delivery telemetry PR keeps its seconds-long green |
+| `docs/sstables-definitive-guide/pandoc-header.tex` | **docs-only** | inert typesetting fragment |
+| `docs/sstables-definitive-guide/statistics-db-annotated-dump.txt` | **docs-only** | inert dump |
+
+The `delivery-telemetry.jsonl` row is why the buckets exist at all. A purely directory-scoped rule — the
+straightforward "mirror #3229 exactly" design — would force the ~14-minute core on **every**
+`flow-finalize` telemetry PR, one per delivery cycle, for a one-line append no gate step reads. That is a
+recurring cost with no correctness return, and it is exactly the over-narrowing AC2 forbids. Note this is a
+case where **#3229's answer is `code` and the gate's is `docs`, and both are right**: a ledger line's
+provenance is worth a reviewer's eye and is not worth a compiler's.
+
+### D3c — `.svg` and `.png`: an untouched layer, and a recorded divergence
+
+The classifier's existing image allowlist (`.png .jpg .jpeg .gif .svg .webp .ico`, repo-wide) is
+**unchanged by this change**, and it answers `docs/img/x.svg` before the artifact layers are consulted.
+#3229 classifies `.svg` as code-bearing and directory-scopes it. Both are correct for their own question:
+roborev's concern is a script embedded in an SVG reaching a *reviewer*, whereas **no `pr-gate-core` step
+reads an image of any kind**. Narrowing `.svg` here would (i) contradict AC2's explicit listing of `.svg`
+and `.png` as still-short-circuiting, (ii) alter the classifier's behaviour for `.svg` **outside** `docs/`
+as well, and (iii) buy **zero** files: the measurement above shows no tracked `.svg` under `docs/` outside
+the four artifact directories. So the divergence is recorded rather than harmonised, and `.svg`/`.png` are
+assigned to the third bucket ("answered by L1") so the partition assert still covers the imported set.
+
+`.jpg`/`.gif`/`.webp`/`.ico` are **not** in the imported set at all, which is exactly why L1 must remain
+authoritative for paths under `docs/`: without it, `docs/img/photo.jpg` would fail closed to `full` and a
+prose PR carrying a photo would pay the full core. That is a real trap in the "let the artifact layers
+decide everything under `docs/`" design, and it is why the layers are a disjunction with L1 inside it.
+
+### D3d — the executable bit is deliberately NOT adopted
+
+#3229 classifies an **extensionless** path under a prose prefix as non-code iff git records it
+non-executable at **both** endpoints of the review range. This classifier does **not** adopt that rule, and
+the reason is not tidiness:
+
+1. **AC1 mandates the opposite**: extensionless under `docs/` ⇒ `full`, unconditionally.
+2. **The classifier's input carries no mode.** Its contract is a newline-delimited path list on stdin
+   (`git diff --name-only` in `pr-gate.yml`). Adopting the mode rule would mean the classifier running
+   `git ls-tree` itself — turning a pure, hermetic, self-testable function into one that needs a repository
+   and two resolvable refs, with #3229's own tri-valued "unmeasurable" hazard imported along with it.
+3. **A mode flip must not decide gating.** `chmod -x` does not turn a program into prose (#3229 round-13
+   found exactly that defect on its own rule), and here the consequence would be an ungated merge.
+4. **The cost is zero.** All **3** tracked extensionless files under `docs/` are mode 100755 harness
+   binaries (`ws0-readbw`, `ws0-stream`, `offcputime-bigmap`) — every one of which *should* force the full
+   path. There is no tracked extensionless prose file under `docs/` to penalise.
+
+So: shared mechanism = the artifact intersection. **Not** shared = the exec-bit rule, the prose extension
+set, the image/legal layer, and the sensitive-dir escape.
+
+### D3e — the prose set is NOT imported
+
+#3229's `CODE_FREE_EXTENSIONS` is `md markdown mdx txt rst adoc`. Importing it as the gate's global prose
+layer was considered and rejected: it applies **repo-wide**, so `.txt`/`.rst` would become docs-only
+outside `docs/` too — and a `.txt` outside `docs/` can be a golden fixture whose edit genuinely changes a
+test's outcome. That would open a **new** hole in a change whose purpose is to close one. `.txt` is reached
+under `docs/` via L2 instead, which is where AC2 wants it and nowhere else.
+
+---
+
+## D4 — the roborev v0.61.2 pin: what is inherited, and what is not
+
+Stated precisely, because conflating the shared mechanism with this classifier's own semantics is the drift
+the owner named:
+
+- **NOT inherited:** the pin's *subject*. `roborev v0.61.2 git.FormatExcludeArgs` describes how roborev
+  turns a configured pattern into git pathspecs (interior-`/` ⇒ root-anchored verbatim; slash-less ⇒
+  `**/`-prefixed recursive; trailing slash inverts the anchoring; two pathspecs per pattern). **This
+  classifier feeds no pathspec to roborev, reads no `.roborev.toml`, and depends on none of those
+  semantics.** Its own matching is `roborev_path_in_artifact_dir`'s component-wise walk, which is
+  deterministic bash over a committed array.
+- **INHERITED:** the pin's *consequence for the declaration's content*. The declaration exists to agree
+  with `.roborev.toml`, whose correctness was established against v0.61.2. If a roborev upgrade changes
+  `FormatExcludeArgs`, `.roborev.toml` may be re-derived and the declaration may move with it — and the
+  declaration now moves **the correctness gate** as well as the reviewer. So the re-verify-on-upgrade
+  obligation gains a clause: after any roborev upgrade, re-verify that the artifact extension/directory
+  declaration still means what the **gate** needs, and re-run `test_classify_docs_only.sh`, whose bucket
+  partition assert is the mechanical half of that check.
+- **A second consumer changes the declaration's status.** Before this change, editing
+  `CODE_FREE_ARTIFACT_EXTENSIONS` affected review coverage. After it, the same edit can change which PRs
+  skip the correctness gate. That is recorded at the classifier's import site and in the spec, because it
+  is the kind of coupling that is obvious for one release and invisible afterwards.
+
+---
+
+## D5 — the raw-path boundary (#3229's six-blocker lesson, applied once)
+
+`pr-gate.yml` produces the changed-file list with `git diff --name-only`, which **C-quotes** any path
+containing non-ASCII or control bytes (`core.quotePath` defaults on). This repository tracks 40
+space-bearing paths under `docs/` and prose files with em dashes in their names. Consequences today, and
+under the new design:
+
+- A quoted path like `"docs/\303\251.md"` has apparent extension `md"`. Under the old blanket `docs/*` it
+  did not even match (the spelling begins with `"`), so it already forced `full` — no regression, but no
+  correctness either: the verdict came from an accident of spelling.
+- Under the new design the extension is what decides, so an accidental read of `md"` — or worse, a future
+  reader "fixing" the quoting by stripping quotes and re-splitting — is the exact class of defect that cost
+  #3229 six blockers across six different consumers.
+
+So the boundary is fixed **once**, in both directions:
+
+1. `pr-gate.yml` computes the list with `git -c core.quotePath=false diff --name-only`, so a legitimately
+   non-ASCII prose path arrives **raw** and is classified on its real extension. (`-z` is *not* used: it
+   would change the classifier's stdin contract from newline- to NUL-delimited, a larger and unnecessary
+   change. `core.quotePath=false` is the minimal fix for the actual failure mode.)
+2. The classifier **fail-closes** on any path spelling it cannot read as raw — one beginning with `"` — with
+   a named reason. Control characters (a literal newline in a path) are still quoted by git even with
+   `quotePath=false`, and remain unrepresentable in a newline-delimited stream; that residual is closed by
+   fail-closing rather than by pretending it cannot happen.
+
+Nothing else about `pr-gate.yml` changes: no trigger filter, no step-gating change, no `required` change.
+The suite's existing Ruby contract assertion continues to pin all of that.
+
+---
+
+## D6 — pinning the boundary: structural asserts and a real mutation
+
+Behavioural cases only cover shapes someone already thought of, so the suite gains asserts about the
+classifier's **structure** and about the **real declaration**:
+
+1. **No second decision site.** No `case` arm anywhere in the classifier may return docs-only for a
+   `docs/`-prefixed pattern; the only `docs/` mention outside the dispatch is the dispatch's own guard. A
+   reintroduced `docs/*) return 0` FAILs.
+2. **No literal copy of the imported lists.** The classifier's source must not contain the artifact
+   extension list nor any of the four directory globs as literals. This is the AC5 assert that bites if
+   someone "simplifies" the import away.
+3. **A mutation of the REAL declaration changes the verdict.** The test copies the classifier and the
+   *real* `roborev-review-oracles.sh` into a temp tree, mutates the copy's declaration (adds a synthetic
+   extension; removes a directory glob), and asserts the classifier's verdict follows. If the classifier
+   ignored the declaration — the symmetric-mirror failure — the verdicts would not move and the test FAILs.
+   This is why the import is location-relative (D2).
+4. **The buckets partition the imported set** exactly, read from the real declaration, never from a mirror.
+5. **The verdicts themselves** stay behavioural, in the existing `assert_docs_only`/`assert_full` style, so
+   the suite reads as one thing.
+
+The suite is **additive**: existing asserts and the Ruby workflow-contract block are preserved, so it
+rebases cleanly over #3296, which is editing the *sibling* suite `test_roborev_review_guard.sh` — a
+different file. Should the two lanes ever touch the same lines, the standing instruction is to raise
+`coord:needs-attention` rather than race.
+
+---
+
+## D7 — AC7: the backfill ruling is the OWNER'S. Recommendation and the evidence.
+
+AC7 asks for a **recorded decision** about the three already-merged, never-gated PRs (#3081/#3026,
+#3216/#3100, #3222/#3217): a retroactive core-gate run over that harness code, or explicit acceptance with
+the reason. Silence fails; either decision passes. **This change does not decide it** — it records what the
+owner rules, with the reason.
+
+**The evidence that bounds the exposure, verified rather than asserted:**
+
+1. **The docs-hosted crate is not a workspace member.** `cargo metadata --no-deps` lists 16 packages;
+   `docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness` is **not** among them, and the root
+   `[workspace] members` list does not reach under `docs/`. So `cargo fmt --all`, `cargo clippy -p
+   cqlite-core`, `cargo build -p cqlite-core --all-features` and the lib tests would **not have compiled or
+   formatted a single byte of it** even had they run.
+2. **None of the other skipped steps reads any path in those diffs.** Workflow-policy validation reads
+   `.github/workflows/**`; dataset-pin agreement, release-version agreement, the Dockerfile Rust-pin
+   lockstep, `Cargo.lock` freshness and the #2644 oracle read workspace manifests, `test-data/**` and
+   `cqlite-core`. A `docs/`-only diff touches none of them.
+3. **Therefore a retroactive `pr-gate-core` run over those three merge commits is equivalent to running it
+   on `main` at those commits** — it would report on `main`'s health, not on the harnesses. And `main` has
+   been re-certified nightly since by `gate.yml`'s full-gate deep check.
+4. **#3229's own AC7 ruling already covers the same three PRs, and its reasoning transfers.** Owner,
+   2026-08-03: *accept as-is, no retroactive pass*, on the grounds that every affected file is a measurement
+   harness that ships nowhere, is imported by nothing, and *"does not run in CI or the agent gate"* — the
+   gate-side claim, stated in that ruling. Its named condition also transfers verbatim: the ruling changes
+   the moment any of that harness code is **promoted** into a shipped path (a gate component, a CI step, an
+   imported module), at which point it inherits the obligations of the surface it joins.
+
+**Recommendation: accept as-is, no retroactive core-gate run** — one ruling covering both #3229 AC7 and
+#3250 AC7 — with the promotion condition recorded. **Safe default if the owner prefers not to rule:** run
+`pr-gate-core`'s step set once against `main` at the newest of the three merge commits and record the
+result, which is cheap, harmless, and honest about proving only `main`'s health at that point. Either way
+the ruling and its reason are recorded in this change before it is done; the requirement is satisfied by
+the record, not by a particular verdict.
+
+---
+
+## D8 — AC6: doctrine, in the same change
+
+CLAUDE.md's #3042 paragraph currently reasons from "a markdown/docs-only diff cannot change the compiled
+binary" with the qualifying test "no `src`, no `Cargo.*`, no build script, no workflow, no test-data". A
+#3222-shaped diff **contains** `src/main.rs` and `Cargo.toml` under
+`docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/`, so the qualifier is satisfied *textually* while
+being false *materially*. The narrowing:
+
+- names the `docs/reports/*-artifacts/` convention explicitly, as the reason a `docs/` path prefix is not
+  evidence of non-compiled input;
+- scopes the waiver to a **genuinely prose** diff, and makes `scripts/ci/classify-docs-only.sh` the
+  mechanical test of that — an agent can now *run* the question rather than judge it, which is the same
+  move CLAUDE.md already makes for the roborev census ("a code-free census, never a `docs/` path prefix");
+- keeps everything else about CITE-AND-WAIVE intact: the waiver still requires a cited issue, and the
+  "compiled input in the diff ⇒ the waiver is void" clause is unchanged.
+
+**Website half.** `CITE-AND-WAIVE` appears in `CLAUDE.md` and **nowhere on the site** today (verified by
+grep across `website/` and `docs/`). The gate doctrine page
+`website/src/content/docs/agents-developing/gate-contract.md` is the correct home — it already owns "what a
+green `required` covers", the component list, and the `--delta` test/docs-only re-certification section — so
+the narrowed rule is added there, with a cross-reference from `roborev-findings.md`'s existing code-free
+census definition so the review-side and gate-side definitions of "docs-only" cannot drift apart again.
+**Publication is accepted by grepping the served page for a distinctive new phrase**, never by HTTP 200; a
+`0` count means not-yet-published (the CDN has been observed serving stale content for ~3 minutes after a
+successful deploy) and is re-checked, never banked.
+
+---
+
+## D9 — what this change deliberately does not do
+
+- It does not model roborev's exclusion set (#3283) or its compiled-in built-ins (#3278). It consumes a
+  committed declaration; it predicts nothing, so it cannot false-PASS about anything.
+- It does not touch `.roborev.toml`. A pattern added there without a matching declaration edit remains
+  #3229's known, accepted gap; this change's partition assert now makes the *declaration* side of that
+  mirror louder, which is a side benefit and not a claim to have closed #3283.
+- It does not relocate a harness, filter the workflow trigger, touch the tier registry, or widen the gate
+  for prose.
+
+## Follow-ups (named, not fixed here)
+
+- **A `pr-gate-core` step that covers docs-hosted harness crates.** Nothing compiles
+  `docs/reports/*-artifacts/**/Cargo.toml` today; the fix in this change makes such a PR *pay* the core, but
+  the core still does not build the harness. Whether it should is a separate scope question (and D7's
+  promotion condition is the doctrine hook for it).
+- **`.github/ci-gating-tiers.yml` has one registered tier.** Out of scope here (#2910 works as designed),
+  but the measurement in this change's proposal is the concrete record of what that buys on a `docs/` PR.

--- a/openspec/changes/narrow-docs-only-classifier/design.md
+++ b/openspec/changes/narrow-docs-only-classifier/design.md
@@ -13,6 +13,17 @@ This is the same bug **class** as #3229 — a path glob that swallows executable
 **correctness gate** rather than the reviewer. #3229 merged first, deliberately, so that the docs-scoped
 artifact declaration exists in exactly one place before a second consumer appears.
 
+**Owner rulings at Seam 1 (2026-08-04), in force and not re-litigated below:**
+
+- **D2(a)** — directory-scope the code-bearing formats (`json`, `html`). Where AC3's literal text and
+  CLAUDE.md's *"an extension describes a FORMAT; a directory records an INTENT"* rule disagree, the
+  doctrine wins; AC3's negative case (prose + artifacts still short-circuits) is delivered against the
+  **inert** extensions instead. See D3b.
+- **D3(a)** — add `core.quotePath=false` to `pr-gate.yml`'s existing `git diff --name-only` in the
+  `Classify docs-only diff` step; do **not** switch to `-z`. See D5.
+- **AC7 / D1(a)** — no retroactive core-gate run; one ruling covers #3229 AC7 and #3250 AC7. Recorded
+  verbatim with its evidence in **D7.RULING**.
+
 Two constraints from #3229's post-mortem govern this design and are treated as given:
 
 - **Fix the BOUNDARY, not the sites.** #3229 burned three review rounds patching one path-normalisation
@@ -320,6 +331,24 @@ classifier's **structure** and about the **real declaration**:
 5. **The verdicts themselves** stay behavioural, in the existing `assert_docs_only`/`assert_full` style, so
    the suite reads as one thing.
 
+**D6a — how the declaration-mutation scenario is delivered, and why it is two-sided.** The scenario as
+written ("a synthetic inert extension added [upstream] ⇒ `docs-only`") cannot hold together with AC1's
+fail-closed rule, because an imported extension this classifier has **not** bucketed must classify `full`
+(otherwise a new upstream extension would become documentation by default — the fail-OPEN shape AC1
+forbids). Both properties are therefore delivered, as three measured sub-cases against a temp tree holding
+a copy of the classifier beside a copy of the **real** declaration:
+
+| mutation | path | verdict | proves |
+|---|---|---|---|
+| `txt` **removed** from the declaration | `docs/reports/ws0-3217-artifacts/results/run.txt` | `docs-only` → **`full`** | the verdict follows the declaration's content |
+| one directory glob **removed** | `docs/round-artifacts/soak/report.html` | `docs-only` → **`full`** | the verdict follows the declared globs, through the imported matcher |
+| synthetic `zzz` added **upstream only** | `.../out.zzz` | stays **`full`**, and the partition assert FAILs naming `zzz` + `#3250` | AC1's fail-closed rule for an unbucketed imported extension |
+| synthetic `zzz` added **upstream AND bucketed here** | `.../out.zzz` | `full` → **`docs-only`** | the scenario's letter: a declared+assigned extension is documentation |
+| synthetic `zzz` **bucketed here only** | `.../out.zzz` | stays **`full`** | the DECLARATION is authoritative — a classifier carrying its own hardcoded list would answer `docs-only` here and fail |
+
+The last row is the discriminator that makes this a test of the *import* rather than a mirror of the
+constant: a hardcoded classifier passes rows 1–4 by accident and fails row 5 by construction.
+
 The suite is **additive**: existing asserts and the Ruby workflow-contract block are preserved, so it
 rebases cleanly over #3296, which is editing the *sibling* suite `test_roborev_review_guard.sh` — a
 different file. Should the two lanes ever touch the same lines, the standing instruction is to raise
@@ -362,6 +391,41 @@ result, which is cheap, harmless, and honest about proving only `main`'s health 
 the ruling and its reason are recorded in this change before it is done; the requirement is satisfied by
 the record, not by a particular verdict.
 
+### D7.RULING — the owner's decision, as given
+
+> **Ruling: NO retroactive core-gate run over PRs #3081 (issue #3026), #3216 (issue #3100) and
+> #3222 (issue #3217). Accept as-is.**
+>
+> - **Date / authority:** 2026-08-04, owner decision taken at Seam 1 of this change (issue #3250).
+> - **Scope:** ONE ruling covers **both** #3229 AC7 (the review side) and #3250 AC7 (the gate side) —
+>   the same three PRs, asked from two directions, answered once.
+> - **Reason:** every affected file is a measurement harness that ships nowhere and is imported by
+>   nothing, so a retroactive run would report on `main`'s health rather than on the harnesses. The
+>   exposure is bounded by the evidence below, and `main` has been re-certified nightly since by
+>   `gate.yml`'s full-gate deep check.
+> - **Condition of change, verbatim:** *the exemption ends the moment harness code is promoted into a
+>   shipped path.* At that moment it inherits the obligations of the surface it joins (a gate
+>   component, a CI step, an imported module), and the question is re-opened for that code.
+
+**Bounding evidence, re-verified in this change rather than inherited as prose:**
+
+1. **The docs-hosted crate is not a workspace member.** `cargo metadata --no-deps --format-version 1`
+   run at this change's HEAD lists **16 packages** — `cassandra-parity`, `cqlite`, `cqlite-cli`,
+   `cqlite-core`, `cqlite-examples`, `cqlite-flight`, `cqlite-integration-tests`, `cqlite-node`,
+   `cqlite-py`, `cqlite-validator`, `flight-loadgen`, `format-compatibility-tests`, `format-validator`,
+   `memory-safety-runner`, `sstabledump-validator`, `xtask` — and **none** of their manifest paths lies
+   under `docs/`. `docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness` is **absent** from the
+   package set, so `cargo fmt --all`, `cargo clippy -p cqlite-core`,
+   `cargo build -p cqlite-core --all-features` and the lib tests would not have compiled, formatted or
+   linted a single byte of it even had the core run.
+2. **No skipped `pr-gate-core` step reads any path in those three diffs.** Workflow-policy validation
+   reads `.github/workflows/**`; dataset-pin agreement, release-version agreement, the Dockerfile
+   Rust-pin lockstep, `Cargo.lock` freshness and the #2644 oracle read workspace manifests,
+   `test-data/**` and `cqlite-core`. The measured diffs are 188 / 269 / 197 paths (D10), of which
+   **exactly one** (`process_improvements.md`, in #3081) is outside `docs/` and it is prose.
+3. **Therefore a retroactive run is equivalent to running the core on `main` at those commits** — which
+   is the substance of the ruling, not an excuse appended to it.
+
 ---
 
 ## D8 — AC6: doctrine, in the same change
@@ -391,6 +455,60 @@ census definition so the review-side and gate-side definitions of "docs-only" ca
 successful deploy) and is re-checked, never banked.
 
 ---
+
+## D10 — AC4: the recorded demonstration on the real merged-PR shapes
+
+Evidence, **not** a gate assertion: the input is a historical API response, so asserting it would either
+pin a network call or commit a fixture that ages. No fixture is committed and no gate assertion depends on
+the network. Replayed 2026-08-05 at this change's HEAD.
+
+**How it was obtained and replayed** (per PR `<N>` ∈ {3222, 3081, 3216}):
+
+```bash
+for page in 1 2 3; do
+  gh api "repos/pmcfadin/cqlite/pulls/<N>/files?per_page=100&page=$page" --jq '.[].filename'
+done > pr-<N>.txt                                   # every page, so nothing is silently truncated
+bash scripts/ci/classify-docs-only.sh < pr-<N>.txt   # amended  (POST)
+git show origin/main:scripts/ci/classify-docs-only.sh > pre.sh
+bash pre.sh                       < pr-<N>.txt       # pre-change (PRE)
+# per-path census: each path fed alone, so the offending set is measured, not inferred
+```
+
+| PR | paths | PRE verdict | POST verdict | offending | first offending path |
+|---|---|---|---|---|---|
+| **#3222** (issue #3217) | **188** | `docs-only` / **exit 0** | `full` / **exit 1** | **35** | `docs/reports/ws0-3217-artifacts/harness/classify-offcpu.py` |
+| **#3081** (issue #3026) | **269** | `docs-only` / **exit 0** | `full` / **exit 1** | **30** | `docs/reports/ws0-3026-artifacts/ws0-corpus/.gen-p200000-pl375x6-ba96x3-bb96x16-cl2x10.yaml` |
+| **#3216** (issue #3100) | **197** | `docs-only` / **exit 0** | `full` / **exit 1** | **1** | `docs/reports/ws0-3100-artifacts/ws0-h2h/schemas/ws0-events.cql` |
+
+**The verdict CHANGED on every one of the three**, which is the point of recording the PRE column: the
+`full` is attributable to this change and not to an unexplained difference in the input.
+
+**The prose-only replay — the fast path is intact on real data.** The same lists with the offending paths
+removed:
+
+| PR | remaining paths | verdict |
+|---|---|---|
+| #3222 | **153** | `docs-only` / **exit 0** |
+| #3081 | **239** | `docs-only` / **exit 0** |
+| #3216 | **196** | `docs-only` / **exit 0** |
+
+**What the offending sets are made of** (measured per path, so a false positive would show up here as
+prose or as an inert artifact — none does):
+
+- **#3222 — 35 paths: 17 `.sh`, 15 `.py`, 2 `.bt`, 1 extensionless** (`partB-run/offcputime-bigmap`).
+  **The count reconciles with the issue's "34" rather than contradicting it:** 34 is the
+  extension-bearing executable count (17+15+2); the 35th is the extensionless harness binary, which AC1
+  forces to `full` unconditionally and without a mode lookup. The measured number is recorded as
+  measured.
+- **#3081 — 30 paths: 13 `.sh`, 6 `.py`, 3 `.c`, 2 extensionless (`ws0-readbw`, `ws0-stream`), 2 `.yaml`,
+  1 `.toml`, 1 `.rs`, 1 `.cql`, 1 `.bt`.** The `.toml` + `.rs` pair is
+  `ws0-cqlite/scan-harness/Cargo.toml` and `.../src/main.rs` — the docs-hosted crate that is the
+  falsifying case for the old CITE-AND-WAIVE qualifier (D8).
+- **#3216 — 1 path: 1 `.cql`** (a schema-as-created fixture). One path is enough: a set is `full` when
+  ANY member is, so #3216's 13-second green rested on a single unclassified file.
+
+**One path in the three diffs is outside `docs/`**: `process_improvements.md` (#3081), prose, classified
+documentation by the pre-existing global `*.md` arm, unchanged by this change.
 
 ## D9 — what this change deliberately does not do
 

--- a/openspec/changes/narrow-docs-only-classifier/design.md
+++ b/openspec/changes/narrow-docs-only-classifier/design.md
@@ -510,6 +510,35 @@ prose or as an inert artifact — none does):
 **One path in the three diffs is outside `docs/`**: `process_improvements.md` (#3081), prose, classified
 documentation by the pre-existing global `*.md` arm, unchanged by this change.
 
+### D10a — the whole tracked `docs/` tree, classified (the "no prose moved" claim, measured)
+
+The spec requires that this change move **no** tracked prose or image file from the fast path to the full
+path. That is measurable, so it is measured rather than asserted. Every tracked path under `docs/` was fed
+to the amended classifier and the offending set extracted path by path
+(`git -c core.quotePath=false ls-files 'docs/*'`, then repeatedly classify-and-remove the named offender):
+
+| | count |
+|---|---|
+| tracked files under `docs/` | **1277** |
+| still `docs-only` (fast path) | **1184** |
+| now forcing the full path | **93** |
+
+The 93 by extension: **43 `.sh`, 27 `.py`, 4 `.yml`, 4 `.c`, 3 extensionless, 3 `.yaml`, 3 `.bt`, 2 `.json`,
+2 `.cql`, 1 `.toml`, 1 `.rs`**. **Zero prose files. Zero images.** Every one is executable code or
+functional configuration; the notable non-harness members are the observability kit
+(`docs/observability/docker-compose.yml`, `prometheus/prometheus.yml`, the two Grafana `provisioning/*.yml`
+files, `otel-collector/config.yaml`) and the two `.json` falsifying cases named in D3b
+(`grafana/dashboards/cqlite-overview.json`, guarded by the gate's own `kit-dashboard-drift` component, and
+`reports/delivery-telemetry.schema.json`).
+
+**A live confirmation of the raw-path boundary, found while running this census.** The first attempt used
+`git ls-files 'docs/*'` **without** `core.quotePath=false`, and the classifier stopped on
+`"docs/research/CQLite Writes (M5) \342\200\224 Analysis & Recommended Paths.md"` with
+`is not a raw repo-relative path (C-quoted spelling) -> FULL PATH (fail-closed, #3250)`. That is exactly
+D5's failure mode reproducing on a real tracked path — quoted, it would otherwise have been read as
+extension `md"` — and exactly why `pr-gate.yml` now passes `core.quotePath=false`. The boundary
+fail-closed and named its cause instead of guessing.
+
 ## D9 — what this change deliberately does not do
 
 - It does not model roborev's exclusion set (#3283) or its compiled-in built-ins (#3278). It consumes a

--- a/openspec/changes/narrow-docs-only-classifier/proposal.md
+++ b/openspec/changes/narrow-docs-only-classifier/proposal.md
@@ -1,0 +1,168 @@
+# Proposal: Narrow `classify-docs-only.sh`'s `docs/` prefix so executables under `docs/` cannot skip the correctness gate (issue #3250)
+
+**Milestone:** maintenance (CI merge-gating semantics / agent-team automation) · **Priority:** P1 ·
+**Routing:** design-driven — this decides **which PRs are allowed to bypass the correctness gate**, both
+error directions carry real cost (under-narrow ⇒ the hole stays open; over-narrow ⇒ every report PR pays a
+~14-minute gate), it must consume a sibling subsystem's declaration without re-drifting from it, and it
+amends doctrine (#3042 CITE-AND-WAIVE). No external oracle exists; the fix is a gate contract plus
+doctrine. · **Issue:** #3250 ·
+**Related:** **#3229** (the sibling defect on the *reviewer* side, merged — it declares the artifact
+constants this change imports), #2645 / epic #2636 (introduced the docs-only short-circuit), #2910 (the
+`required` tier aggregator — measured NOT to mitigate this), #3042 (the CITE-AND-WAIVE doctrine this
+narrows), #3283 (the deferred exclusion-set guard), #3278 (roborev's compiled-in deny-list), #3217 /
+PR #3222, #3026 / PR #3081, #3100 / PR #3216 (the three merged, never-gated harness PRs).
+
+## Why
+
+`scripts/ci/classify-docs-only.sh:46` returns docs-only for **any** path under `docs/` on the strength of
+the path prefix alone:
+
+```bash
+case "$path" in
+  docs/*) return 0 ;;      # extension-blind; bash `case` `*` crosses `/`
+```
+
+Its **only** consumer is `.github/workflows/pr-gate.yml:95`, and **every** correctness step in
+`pr-gate-core` is guarded by `if: steps.classify.outputs.docs_only != 'true'` — workflow-policy
+validation, dataset-pin agreement, release-version agreement, the Flight Dockerfile Rust-pin lockstep,
+Rust setup, `Cargo.lock` freshness, `cargo fmt`, `cqlite-core` clippy `-D warnings`, the all-feature
+build, the fast lib tests, and the #2644 query-semantics oracle. Skipping them does not skip the *check*:
+`pr-gate-core` still concludes `success`, and `required` — the sole branch-protection context — is
+satisfied. So a PR whose whole diff is under `docs/` reports green having compiled and tested nothing.
+
+That is correct for prose. It is **wrong for code**, and this repository ships code under `docs/` **by
+convention**: WS0-style measurement harnesses live in `docs/reports/*-artifacts/`, a convention the owner
+has ruled stays. Currently tracked under `docs/`: 43 `.sh`, 27 `.py`, 4 `.yml`, 4 `.c`, 3 `.yaml`,
+3 `.bt`, 2 `.cql`, 1 `.toml`, 1 `.rs`, and **3 extensionless mode-100755 harness binaries** — plus a
+compilable Cargo crate (`docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/` with `Cargo.toml` +
+`src/main.rs`). The classifier calls every one of them documentation.
+
+**It has already happened three times.** `pr-gate-core` concluded SUCCESS in **16 s** (PR #3222, 188
+files, 0 outside `docs/`, 34 executables), **14 s** (PR #3081) and **13 s** (PR #3216), against a
+~14-minute baseline for a real code PR (PR #3239: 13m 56s; PR #3236: 14m 20s).
+
+**#2910's tier aggregation does not mitigate it** — measured, not assumed. The registry holds exactly one
+tier (`flight`), and `flight-ci.yml:148` leaves `docs/**` *deliberately unmandated*, so the tier emits its
+explicit not-applicable success and `required` is satisfied. Every other PR-triggered workflow is
+`exempt:`. This change starts from **no safety net**.
+
+**And the failure mode is not only mechanical.** CLAUDE.md's #3042 CITE-AND-WAIVE rule tells an agent that
+a "docs-only" diff "cannot change the compiled binary", qualified by "no `src`, no `Cargo.*`". A #3222-shaped
+diff contains **both** — under `docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/`. So an agent
+correctly following documented doctrine reaches the same wrong conclusion and waives a real red as
+"pre-existing by definition". Fixing the classifier without fixing the doctrine leaves the human failure
+path intact.
+
+## What Changes
+
+1. **The `docs/` prefix stops being a verdict (AC1).** `is_docs_file()` gains no new `case` arm; instead
+   the blanket `docs/*) return 0` is replaced by a **single dispatch** to one new function that is the
+   *only* place a path under `docs/` is classified. It returns docs-only ONLY on an **affirmative** match
+   against a named allowlist layer, and `full` for everything else — including every extensionless path
+   and every unrecognized extension under `docs/`. `.sh`/`.py`/`.bt`/`.c`/`.rs`/`.toml`/`.cql`/`.yml`/
+   `.yaml` under `docs/` therefore force the full gate, as does a docs-hosted Cargo crate.
+2. **#3229's artifact declaration is IMPORTED, never restated (AC5).** The classifier sources
+   `scripts/flow/roborev-review-oracles.sh` and consumes `CODE_FREE_ARTIFACT_EXTENSIONS` and
+   `CODE_FREE_ARTIFACT_DIR_GLOBS` (plus its component-wise directory matcher
+   `roborev_path_in_artifact_dir`) from the single declaration that file already advertises as
+   *"THE SINGLE DECLARATION: it is imported, never redeclared (`scripts/ci/classify-docs-only.sh` will
+   import it — issue #3250)"*. Direct import is chosen over AC5's drift-check substitute because it is
+   **measurably expressible** (evidence in `design.md` D2). A missing, unsourceable, or empty declaration
+   is a **fail-closed `full`**, never a silent fallback.
+3. **Code-bearing artifact formats are scoped by DIRECTORY, inert dumps are not.** This is where the gate's
+   question and #3229's question legitimately diverge, and the divergence is derived from CLAUDE.md's own
+   asymmetry rule rather than invented: an inert dump (`.txt`, `.log`, `.jsonl`, …) is docs-only anywhere
+   under `docs/`, while a **code-bearing** format (`.json`, `.html`) is docs-only only INSIDE an
+   artifact-bearing directory — because such a file can be functional configuration under any path. The two
+   live proofs are `docs/observability/grafana/dashboards/cqlite-overview.json` (guarded by the full gate's
+   own `kit-dashboard-drift` component) and `docs/reports/delivery-telemetry.schema.json`. Measured cost of
+   the scoping: of 808 tracked artifact-extension files under `docs/`, **803 are inside the four artifact
+   directories and stay fast; 5 are outside**, and the design assigns each of the 5 deliberately.
+4. **One canonical decision point, pinned by a mutation-tested structural assert.** #3229 spent three
+   review rounds patching one path-normalisation consumer at a time; the lesson is applied here up front.
+   The self-test asserts structurally that no second `docs/`-deciding site exists, that the classifier
+   holds **no literal copy** of the imported lists, and — by mutating the *real* declaration in a temp tree
+   — that the classifier's verdict actually follows it. A symmetric mirror of the constant would be
+   invariant to a shared defect (#3042's blindness in shell) and is therefore forbidden.
+5. **A closed verdict grammar for the imported set.** Every extension in
+   `CODE_FREE_ARTIFACT_EXTENSIONS` is assigned to exactly one bucket (inert / code-bearing /
+   answered-by-the-image-layer). An upstream extension assigned to none FAILs the self-test with a
+   **greppable reason** — AC5's "mechanical check that FAILs when the two lists disagree", applied where
+   drift can actually occur now that the list itself is imported.
+6. **The changed-file list is fed to the classifier RAW.** `pr-gate.yml` computes it with
+   `git -c core.quotePath=false diff --name-only`, and the classifier **fail-closes any path spelling it
+   cannot read as a raw repo-relative path** (a C-quoted spelling, i.e. one beginning with `"`). This
+   repository tracks 40 space-bearing and several non-ASCII paths under `docs/`; classifying
+   `"docs/\303\251.md"` on the extension `md"` is exactly the normalisation defect that cost #3229 six
+   blockers. Both directions are specified: unreadable ⇒ `full`, and legitimate non-ASCII prose is
+   classified on its real extension.
+7. **Regression tests in the existing style (AC3).** `scripts/tests/test_classify_docs_only.sh` keeps its
+   23 asserts and its Ruby workflow-contract assertion and gains additive cases: `.sh`/`.py`/`.bt` under
+   `docs/reports/*-artifacts/`; the docs-hosted `Cargo.toml` + `src/main.rs`; ONE executable hidden among
+   many prose files in both orders (the real #3222 shape); the extensionless 100755 harness binaries; the
+   two functional-config `.json` files; and negatives proving prose + inert artifacts still short-circuit.
+8. **Recorded demonstration on the real shapes (AC4).** The **real 188-path PR #3222 file list** (from
+   `gh api repos/pmcfadin/cqlite/pulls/3222/files`) replayed through the new classifier must yield `full`,
+   and a prose-only WS0 diff must yield `docs-only`. Recorded as evidence in the PR and a committed
+   artifact — not asserted as a test, since the input is a historical API response.
+9. **Doctrine in the same change (AC6).** CLAUDE.md's #3042 CITE-AND-WAIVE paragraph is narrowed so it no
+   longer implies everything under `docs/` is non-compiled input: the `docs/reports/*-artifacts/`
+   convention is named explicitly, the waiver is scoped to a **genuinely prose** diff, and the classifier
+   is named as the mechanical test of that. The matching published page
+   (`website/src/content/docs/agents-developing/gate-contract.md`, which today carries the gate contract
+   but **no** CITE-AND-WAIVE text at all) gains the rule, cross-referenced from `roborev-findings.md`'s
+   existing code-free-census definition so the two doctrines cannot drift. Publication is accepted by
+   **grepping the served page for a distinctive new phrase**, never by HTTP 200.
+10. **The backfill ruling is recorded (AC7).** The decision is the owner's; the change records it with its
+    reason. `design.md` D7 states the recommendation and the evidence that bounds the exposure — the
+    docs-hosted `scan-harness` crate is **not a workspace member** (verified via `cargo metadata`), so no
+    `pr-gate-core` step reads any path in those three diffs.
+
+## Non-goals
+
+- **Not relocating the measurement harnesses out of `docs/reports/*-artifacts/`.** Owner-ruled: the
+  convention stays. No move is proposed and none is smuggled in as tidying.
+- **Not touching `.roborev.toml`, #3229's wrapper, its census, or its vacuity/SHA traps.** This change is a
+  pure *consumer* of #3229's declaration. It adds no pattern, removes none, and changes no roborev behaviour.
+- **Not adding `paths:`/`paths-ignore:` to `pr-gate.yml`'s trigger.** A filtered required check never
+  reports and would block every affected PR forever (`pr-gate.yml:71-78`). The always-emit classifier
+  design is correct and is not what is being fixed.
+- **Not changing the `required` tier registry or promoting tiers (#2910).** That mechanism works as
+  designed; it simply does not cover this hole.
+- **Not widening the gate for prose PRs.** A `.md`/image/`LICENSE`/report-artifact PR keeps its
+  seconds-long green (AC2). Measured: the change moves **0** tracked prose or image file to the full path.
+- **Not changing the classifier's own image/legal allowlist.** `.png`/`.jpg`/`.jpeg`/`.gif`/`.svg`/
+  `.webp`/`.ico` and `LICENSE*`/`NOTICE*` keep their existing repo-wide behaviour; the divergence from
+  roborev's directory-scoped `.svg` is legitimate and is recorded rather than silently harmonised
+  (`design.md` D3c).
+- **Not predicting roborev's exclusion set** (#3283) or modelling its compiled-in deny-list (#3278). This
+  change consumes a declaration; it models nothing.
+- **No Rust code, no library surface, no on-disk format work.** Nothing touches `cqlite-core`, the
+  bindings, the CLI, the no-heuristics decode path, or the <128MB memory budget.
+
+## Impact
+
+- **Gate script:** `scripts/ci/classify-docs-only.sh` — the blanket `docs/*` arm replaced by one dispatch
+  to a single new classifier function; a fail-closed import of #3229's declaration; a raw-path guard.
+- **Workflow:** `.github/workflows/pr-gate.yml` — the `Classify docs-only diff` step computes the
+  changed-file list with `-c core.quotePath=false`. No trigger change, no step-gating change, no
+  `required` change.
+- **Tests:** `scripts/tests/test_classify_docs_only.sh` — additive cases plus the structural/mutation
+  asserts. It runs in the full gate's `tooling-tests` component (`scripts/agent-gate.sh:5519`). Additive
+  by construction, so it rebases cleanly over #3296's concurrent edits to the *sibling* suite
+  (`test_roborev_review_guard.sh` — a different file).
+- **Doctrine surfaces:** `CLAUDE.md` (#3042 CITE-AND-WAIVE paragraph),
+  `website/src/content/docs/agents-developing/gate-contract.md`, and a cross-reference in
+  `website/src/content/docs/agents-developing/roborev-findings.md`.
+- **Cross-subsystem coupling, stated so it is not rediscovered:** `scripts/ci/` now depends on a
+  declaration in `scripts/flow/`. The declaration's *content* is pinned to **roborev v0.61.2** because it
+  mirrors `.roborev.toml`, whose pattern semantics were recovered from that binary. The
+  **re-verify-on-upgrade obligation is inherited** — and its scope is stated precisely in `design.md` D4:
+  a roborev upgrade can move the declaration, and the declaration now moves the **gate**.
+- **CI cost:** unchanged for prose PRs (0 tracked prose/image files newly forced to `full`). A PR whose
+  whole diff is one of the 5 measured outside-glob artifact files pays the ~14-minute core; 3 of the 5 are
+  correctness-bearing and *should*, and the 2 inert ones are deliberately kept fast (D3b).
+- **No-heuristics mandate (#28):** unaffected — that mandate governs on-disk type/format inference in the
+  SSTable read path. Nothing here infers anything; the classification is an allowlist over committed path
+  names, and the exec-bit heuristic roborev uses is deliberately **not** adopted (D3d).
+- **Public binding surfaces (Python/Node/CLI), memory budget:** untouched.

--- a/openspec/changes/narrow-docs-only-classifier/specs/docs-only-gate-classification/spec.md
+++ b/openspec/changes/narrow-docs-only-classifier/specs/docs-only-gate-classification/spec.md
@@ -1,0 +1,544 @@
+# docs-only-gate-classification — delta for narrow-docs-only-classifier (issue #3250)
+
+**Architecture note (read this first).** `scripts/ci/classify-docs-only.sh` decides whether `pr-gate-core`
+— the compute half of the `required` branch-protection check — runs at all. It classified **every** path
+under `docs/` as documentation on the path prefix alone, so a PR whose whole diff is under `docs/` reported
+`required` green having compiled and tested nothing. This repository ships measurement harnesses under
+`docs/reports/*-artifacts/` **by convention** (owner-ruled: the convention stays), so that is not a corner
+case: `pr-gate-core` concluded SUCCESS in **16 s** (PR #3222), **14 s** (PR #3081) and **13 s** (PR #3216)
+against a ~14-minute baseline. #2910's tier aggregation was measured and does **not** mitigate it
+(`flight-ci.yml:148` leaves `docs/**` deliberately unmandated ⇒ not-applicable success).
+
+This delta makes the `docs/` prefix stop being a verdict. A path under `docs/` is documentation only on an
+**affirmative** match against a named allowlist layer; everything else — every unrecognized extension and
+every extensionless path — forces the full gate. The artifact declaration that says what a report artifact
+*is* is **imported from #3229's single declaration, never restated**, and this delta states explicitly
+which parts of that subsystem are shared mechanism and which are this classifier's own path semantics.
+
+**Acceptance-criterion → requirement map** (issue #3250's numbered ACs):
+
+| AC | Requirement(s) |
+|----|----------------|
+| 1 — executables under `docs/` are NOT docs-only, fail-closed on an unrecognized extension | ADDED *A path under `docs/` is documentation only on an affirmative allowlist match* |
+| 2 — genuine prose / report-artifact-only PRs still short-circuit | ADDED *Prose, images, legal text and inert report artifacts under `docs/` still short-circuit* |
+| 3 — regression tests in the existing style | ADDED *A hermetic self-test pins the classification behaviourally and the boundary structurally* |
+| 4 — demonstrated on the real PR #3222 188-path list and a prose-only WS0 diff, recorded not asserted | ADDED *The behaviour is demonstrated on the real merged-PR shapes and recorded* |
+| 5 — #3229's artifact declaration imported, never redeclared, or a mechanical disagreement check | ADDED *The artifact declaration is imported from its single declaration and its use fails closed* |
+| 6 — CLAUDE.md #3042 CITE-AND-WAIVE narrowed + matching website page, publish verified by served content | ADDED *Doctrine scopes the CITE-AND-WAIVE waiver to a genuinely prose diff* |
+| 7 — backfill ruling recorded for #3081/#3026, #3216/#3100, #3222/#3217 | ADDED *The backfill ruling for the three merged, never-gated PRs is recorded* |
+| — (boundary constraint, owner) | ADDED *One canonical decision point classifies a `docs/` path* |
+| — (boundary constraint, owner) | ADDED *The classifier reads raw repo-relative paths and fail-closes on any other spelling* |
+
+**Scope note — what is shared mechanism and what is this classifier's own.** Conflating the two is the next
+drift, so it is stated in the requirements rather than left to a reader. **Shared and imported:** the
+docs-scoped artifact extension set, the artifact-bearing directory globs, and the component-wise directory
+matcher. **This classifier's own:** the prose extension set, the image/legal allowlist, the
+sensitive-directory escape, the inert-vs-code-bearing bucketing of the imported extensions, and the
+treatment of extensionless paths — where this classifier deliberately does **not** adopt #3229's
+executable-bit rule.
+
+## ADDED Requirements
+
+### Requirement: A path under `docs/` is documentation only on an affirmative allowlist match
+
+`scripts/ci/classify-docs-only.sh` SHALL NOT classify a path as documentation on the strength of a `docs/`
+path prefix. A path under `docs/` SHALL be classified documentation ONLY when it affirmatively matches a
+named allowlist layer, and SHALL otherwise force the full path (verdict `full`, exit 1). There SHALL be no
+permissive default anywhere in the `docs/` classification: a positive verdict requires a positive match, so
+every unmeasured, unrecognized or unassigned case inherits `full`.
+
+Specifically, under `docs/` the classifier SHALL force the full path for **every** executable and
+config-as-code extension the repository ships there — at minimum `.sh`, `.py`, `.bt`, `.c`, `.rs`, `.toml`,
+`.cql`, `.yml`, `.yaml` — for **any unrecognized extension**, and for **any path with no extension at all**.
+
+The extensionless rule SHALL be unconditional and SHALL NOT consult git's executable bit, even though the
+sibling subsystem (#3229) does. Four reasons, each of which SHALL remain true of the implementation: the
+classifier's input is a path list carrying no mode information; consulting a mode would require the
+classifier to read a repository and two resolvable refs, destroying its purity and importing an
+"unmeasurable mode" failure mode; a `chmod -x` must not be able to move a program into the documentation
+class, because here the consequence is an ungated merge; and the measured cost is zero — all three tracked
+extensionless files under `docs/` are mode 100755 harness binaries, and no tracked extensionless prose file
+exists under `docs/`.
+
+A changed set SHALL be classified `full` when **any** of its paths is non-documentation, independent of that
+path's position in the set, and the classifier SHALL retain its existing fail-closed treatment of an
+empty/ambiguous changed set. The sensitive-directory escape (`.github/`, `scripts/`, `test-data/` force the
+full path regardless of extension) SHALL be retained unchanged.
+
+#### Scenario: An executable under a report artifact directory forces the full gate
+- **GIVEN** a changed set consisting of `docs/reports/ws0-3217-artifacts/harness/common.sh`
+- **WHEN** the classifier runs
+- **THEN** the verdict is `full` and the exit status is 1
+- **AND** the same holds for `docs/reports/ws0-3026-artifacts/ws0-h2h/cas-scan.py` and for
+  `docs/reports/ws0-3026-artifacts/ws0-corpus/trace-scan.bt`, each on its own
+
+#### Scenario: A docs-hosted Cargo crate forces the full gate
+- **GIVEN** a changed set of `docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/Cargo.toml` and
+  `docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/src/main.rs`
+- **WHEN** the classifier runs
+- **THEN** the verdict is `full` and the exit status is 1
+- **AND** each of the two paths alone also yields `full`, so neither the manifest nor the source depends on
+  the other being present to be caught
+
+#### Scenario: One executable hidden among many prose files is caught, in either order
+- **GIVEN** a changed set of 20 `*.md` files under `docs/reports/ws0-3217-artifacts/` with
+  `docs/reports/ws0-3217-artifacts/harness/emit-point.py` as the **last** entry
+- **WHEN** the classifier runs
+- **THEN** the verdict is `full` and the exit status is 1
+- **AND** the same set with the `.py` as the **first** entry also yields `full`, so the verdict is
+  order-independent — this is the real PR #3222 shape, where 34 executables sat among 154 prose paths
+
+#### Scenario: An extensionless path under `docs/` forces the full gate without consulting its mode
+- **GIVEN** a changed set of `docs/reports/ws0-3026-artifacts/ws0-results/ws0-readbw`
+- **WHEN** the classifier runs
+- **THEN** the verdict is `full` and the exit status is 1
+- **AND** the verdict is unchanged when the same path is not executable in the checkout, and the classifier
+  invokes no git command, so the result cannot depend on a repository, a ref, or a mode lookup
+
+#### Scenario: An unrecognized extension under `docs/` fails closed
+- **GIVEN** changed sets of `docs/tools/run.rb`, `docs/tools/query.jq` and `docs/tools/build.mjs`
+- **WHEN** the classifier runs on each
+- **THEN** every verdict is `full` and every exit status is 1
+- **AND** no deny-list of executable extensions appears anywhere in the classifier, so an extension nobody
+  anticipated is documentation-by-default in neither direction
+
+#### Scenario: The sensitive-directory escape is unchanged
+- **GIVEN** changed sets of `.github/README.md`, `scripts/notes.md`, `test-data/README.md` and
+  `docs/ok.md` + `.github/CONTRIBUTING.md`
+- **WHEN** the classifier runs on each
+- **THEN** every verdict is `full`, exactly as before this change
+
+### Requirement: Prose, images, legal text and inert report artifacts under `docs/` still short-circuit
+
+The classifier SHALL keep returning documentation (verdict `docs-only`, exit 0) for a changed set consisting
+only of prose, images, legal text, and report artifacts, so the ~14-minute correctness core does not become
+the standing cost of a documentation or WS0 **report** PR that carries no code.
+
+Under `docs/`, documentation SHALL comprise exactly three layers, disjoint by extension so their order
+cannot change any answer:
+
+1. **Prose, images and legal text at any depth** — `.md` and `.markdown`; the classifier's existing image
+   allowlist `.png .jpg .jpeg .gif .svg .webp .ico`; and `LICENSE`/`LICENSE.*`/`NOTICE`/`NOTICE.*`. This
+   layer is the classifier's **own** path semantics and SHALL be unchanged by this change, including its
+   behaviour outside `docs/`.
+2. **Inert report artifacts at any depth under `docs/`** — the inert bucket of the imported artifact
+   extension set (at minimum `txt jsonl log err csv gz pdf jfr mmd tex diff`).
+3. **Code-bearing report artifacts inside an artifact-bearing directory only** — see the directory-scoping
+   requirement below.
+
+The prose extension set SHALL NOT be imported from #3229. Its `CODE_FREE_EXTENSIONS`
+(`md markdown mdx txt rst adoc`) applies repo-wide, and a `.txt` outside `docs/` can be a golden test
+fixture whose edit genuinely changes a test outcome — so importing it as a global prose layer would open a
+new gate hole in the change that closes this one. `.txt` reaches documentation status under `docs/` through
+layer 2 and nowhere else.
+
+This change SHALL move **no** tracked prose or image file from the fast path to the full path. That is a
+measurable property of the tracked tree, not an aspiration.
+
+#### Scenario: A prose, image and legal changed set short-circuits
+- **GIVEN** a changed set of `docs/development/dev-cookbook.md`, `docs/img/diagram.png`, `docs/img/x.svg`,
+  `README.md`, `CHANGELOG.markdown` and `LICENSE`
+- **WHEN** the classifier runs
+- **THEN** the verdict is `docs-only` and the exit status is 0
+- **AND** every one of these assertions passed before this change too, so the fast path for prose is
+  demonstrably preserved rather than re-derived
+
+#### Scenario: A WS0 report PR carrying only prose and inert artifacts short-circuits
+- **GIVEN** a changed set of `docs/reports/ws0-3217-artifacts/README.md`,
+  `docs/reports/ws0-3217-artifacts/results/run.txt`, `.../results/points.jsonl`,
+  `.../results/summary.csv`, `.../results/driver.log`, `.../results/driver.err`,
+  `.../results/curve.png` and `.../results/profile.json`
+- **WHEN** the classifier runs
+- **THEN** the verdict is `docs-only` and the exit status is 0 — a genuine report PR keeps its
+  seconds-long green
+
+#### Scenario: Inert artifact extensions are documentation anywhere under `docs/`
+- **GIVEN** changed sets of `docs/reports/delivery-telemetry.jsonl`,
+  `docs/sstables-definitive-guide/pandoc-header.tex` and
+  `docs/sstables-definitive-guide/statistics-db-annotated-dump.txt`, none of which lies inside an
+  artifact-bearing directory
+- **WHEN** the classifier runs on each
+- **THEN** every verdict is `docs-only` and every exit status is 0
+- **AND** the delivery-ledger case is the reason the inert bucket exists: a purely directory-scoped rule
+  would force the ~14-minute core on every `flow-finalize` telemetry PR — one per delivery cycle — for a
+  one-line append that no gate step reads
+
+#### Scenario: A photo extension outside the imported artifact set is still documentation
+- **GIVEN** a changed set of `docs/img/photo.jpg`, `docs/img/anim.gif` and `docs/img/favicon.ico`
+- **WHEN** the classifier runs
+- **THEN** the verdict is `docs-only` and the exit status is 0 — none of these extensions is in the imported
+  artifact set, so the image layer must remain authoritative for paths under `docs/`, and a prose PR
+  carrying a photo does not fail closed
+
+#### Scenario: A prose file living next to an executable does not rescue the set
+- **GIVEN** a changed set of `docs/reports/ws0-3217-artifacts/README.md` and
+  `docs/reports/ws0-3217-artifacts/harness/parse-runqlat.py`
+- **WHEN** the classifier runs
+- **THEN** the verdict is `full` and the exit status is 1
+
+### Requirement: Code-bearing artifact formats under `docs/` are documentation only inside an artifact-bearing directory
+
+The classifier SHALL treat a **code-bearing** artifact format (at minimum `.json` and `.html`) as
+documentation ONLY when the path lies strictly beneath one of the imported artifact-bearing directory globs,
+and SHALL otherwise force the full path. Scoping such a format by extension alone across all of `docs/`
+SHALL NOT be used, and this is a correctness requirement rather than a preference: an extension describes a
+FORMAT, whereas a directory records an INTENT, and a code-bearing file can be functional configuration
+under any path.
+
+The two falsifying cases SHALL both force the full path:
+`docs/observability/grafana/dashboards/cqlite-overview.json`, which the full agent gate's own
+`kit-dashboard-drift` component guards — so the repository already treats it as correctness-bearing — and
+`docs/reports/delivery-telemetry.schema.json`, the schema governing the delivery ledger.
+
+The directory test SHALL be the imported component-wise matcher, NOT a bash `case` glob: a `case` pattern's
+`*` crosses `/`, so `docs/reports/*-artifacts/*` would also match `docs/reports/a/b-artifacts/x`, which
+git's `:(glob)` `*` does not. The classifier SHALL agree with the pathspec the sibling subsystem actually
+configures rather than approximate it.
+
+#### Scenario: Functional configuration under `docs/` forces the full gate
+- **GIVEN** a changed set of `docs/observability/grafana/dashboards/cqlite-overview.json`
+- **WHEN** the classifier runs
+- **THEN** the verdict is `full` and the exit status is 1
+- **AND** the same holds for `docs/reports/delivery-telemetry.schema.json` alone, and for a set pairing
+  either file with any number of `*.md` files
+
+#### Scenario: The same extension inside an artifact directory short-circuits
+- **GIVEN** changed sets of `docs/reports/ws0-3217-artifacts/results/profile.json`,
+  `docs/round-artifacts/soak/report.html` and
+  `docs/sstables-definitive-guide/diagrams/partition-layout.svg`
+- **WHEN** the classifier runs on each
+- **THEN** every verdict is `docs-only` and every exit status is 0 — the fast path for genuine report
+  artifacts is intact, so the directory scoping narrows the hole without widening the gate for reports
+
+#### Scenario: The directory test does not let a glob cross a path separator
+- **GIVEN** a changed set of `docs/reports/a/b-artifacts/x.json`, which a `case` glob
+  `docs/reports/*-artifacts/*` would match but git's `:(glob)` `*` would not
+- **WHEN** the classifier runs
+- **THEN** the verdict is `full` and the exit status is 1
+- **AND** `docs/reports/ws0-3217-artifacts/x.json` — a genuine single-component match — yields `docs-only`,
+  so the assertion distinguishes the matcher's semantics rather than merely observing a `full`
+
+#### Scenario: A nested artifact directory is matched where the configured glob says it is
+- **GIVEN** changed sets of `docs/observability/jfr-reports/run.html` (matching the `docs/**/jfr-reports`
+  glob at depth) and `docs/round-artifacts/2026-08/deep/nested/out.json`
+- **WHEN** the classifier runs on each
+- **THEN** every verdict is `docs-only`, because `**` matches zero or more path components and a match is
+  "strictly beneath" the directory
+
+### Requirement: The artifact declaration is imported from its single declaration and its use fails closed
+
+The classifier SHALL obtain the docs-scoped artifact extension set, the artifact-bearing directory globs,
+and the directory matcher by **importing** the single declaration in
+`scripts/flow/roborev-review-oracles.sh` (`CODE_FREE_ARTIFACT_EXTENSIONS`,
+`CODE_FREE_ARTIFACT_DIR_GLOBS`, `roborev_path_in_artifact_dir`), and SHALL NOT restate any of them. The
+classifier's source SHALL contain no literal copy of the extension list and no literal copy of any directory
+glob.
+
+The import SHALL be resolved **relative to the classifier's own location**, never relative to the working
+directory, so it is correct from any cwd and so the declaration can be mutated in a temporary tree to prove
+the classifier actually follows it.
+
+The import SHALL fail closed. When the declaring file is absent or fails to source, or when
+`CODE_FREE_ARTIFACT_EXTENSIONS` is empty or `CODE_FREE_ARTIFACT_DIR_GLOBS` has no elements after sourcing,
+the classifier SHALL classify **every** path under `docs/` as `full` and SHALL print a named reason. It
+SHALL NOT degrade to a prose-only allowlist and continue, because that would make an infra fault produce a
+*more permissive* gate.
+
+Every extension in the imported set SHALL be assigned to exactly one bucket — **inert** (documentation at
+any depth under `docs/`), **code-bearing** (documentation only inside an artifact directory), or
+**answered-by-the-image-layer** (`png`, `svg`, which the classifier's own image allowlist decides first and
+which this change does not alter). The buckets SHALL partition the imported set exactly: their union equals
+it and they are pairwise disjoint. An imported extension assigned to no bucket SHALL classify `full` at
+runtime AND SHALL fail the self-test with a greppable reason naming the extension and issue #3250. This is
+the mechanical disagreement check AC5 requires, aimed at the bucketing — the only place drift remains
+possible once the list itself is imported.
+
+The coupling this import creates SHALL be recorded at the import site and honoured on upgrade. Its scope is
+exact: this classifier depends on the declaration's **content**, and NOT on `roborev v0.61.2`'s
+`git.FormatExcludeArgs` pathspec semantics — it feeds no pathspec to roborev and reads no `.roborev.toml`.
+What it inherits is the consequence: the declaration mirrors `.roborev.toml`, whose correctness was
+established against that pinned version, so after any roborev upgrade the declaration may move — and it now
+moves the **correctness gate** as well as the reviewer. The re-verify-on-upgrade obligation SHALL therefore
+be recorded as covering the gate, with the bucket-partition assert as its mechanical half.
+
+#### Scenario: The classifier holds no second copy of the imported declaration
+- **GIVEN** the classifier's source
+- **WHEN** it is searched for the imported artifact extension list and for each of the four directory globs
+  as literal text
+- **THEN** none is found, and the only reference to them is through the imported names
+
+#### Scenario: A mutation of the real declaration moves the classifier's verdict
+- **GIVEN** a temporary tree holding a copy of the classifier and a copy of the **real**
+  `scripts/flow/roborev-review-oracles.sh` whose declaration is mutated — a synthetic inert extension added,
+  and one directory glob removed
+- **WHEN** the classifier in that tree is run on a path bearing the synthetic extension inside an artifact
+  directory, and on a code-bearing artifact under the removed glob
+- **THEN** the first yields `docs-only` and the second yields `full`, both **changed** from their verdicts
+  against the unmutated declaration
+- **AND** a classifier carrying its own hardcoded copy of the lists would return the unchanged verdicts and
+  therefore fail this scenario — which is what makes it a test of the import rather than a mirror of the
+  constant
+
+#### Scenario: A missing or empty declaration fails closed
+- **GIVEN** a temporary tree in which the declaring file is absent, and a second in which it defines
+  `CODE_FREE_ARTIFACT_EXTENSIONS=""` and an empty `CODE_FREE_ARTIFACT_DIR_GLOBS`
+- **WHEN** the classifier is run in each on `docs/reports/ws0-3217-artifacts/results/run.txt` — a path that
+  is `docs-only` under the real declaration
+- **THEN** both yield `full` with exit status 1 and a printed reason naming the absent or empty declaration
+- **AND** neither yields `docs-only` for any path under `docs/`, so no infra fault can loosen the gate
+
+#### Scenario: The buckets partition the imported set exactly
+- **GIVEN** the imported `CODE_FREE_ARTIFACT_EXTENSIONS`, read from the real declaration and not from a
+  fixture copy
+- **WHEN** the self-test compares it against the union of the classifier's inert, code-bearing and
+  image-layer buckets
+- **THEN** the union equals the imported set, the buckets are pairwise disjoint, and the assertion passes
+- **AND** when a synthetic extension is added to the declaration in a temporary tree, the self-test FAILs
+  with a message naming that extension and issue #3250, and the classifier classifies a path bearing it as
+  `full`
+
+#### Scenario: Sourcing the declaration has no side effects on the classifier
+- **GIVEN** the classifier running under `set -euo pipefail`
+- **WHEN** it sources the declaration
+- **THEN** nothing is written to stdout or stderr by the sourcing itself, the shell option set is unchanged,
+  no environment variable is required, and the classifier's own stdout remains exactly the one-word verdict
+
+### Requirement: One canonical decision point classifies a `docs/` path
+
+The classification of a path under `docs/` SHALL happen at exactly ONE place in the classifier — a single
+named function reached by a single dispatch from `is_docs_file()`. `is_docs_file()` SHALL contain no `case`
+arm that returns documentation for a `docs/`-prefixed pattern, and no second site anywhere in the file SHALL
+decide a `docs/` path's class. This is a structural requirement, not a stylistic one: the sibling change
+(#3229) spent three review rounds patching one path-normalisation consumer at a time before fixing the
+boundary, and a per-`case`-arm fix here leaves the next `docs/`-shaped arm one edit away.
+
+The self-test SHALL pin this structurally, and the structural assert SHALL be mutation-tested: a
+reintroduced blanket `docs/*) return 0` arm, or a second `docs/` decision site, SHALL make the self-test
+FAIL.
+
+#### Scenario: A reintroduced blanket prefix arm fails the self-test
+- **GIVEN** a temporary copy of the classifier with `docs/*) return 0 ;;` reintroduced into `is_docs_file()`
+- **WHEN** the self-test's structural assertion runs against that copy
+- **THEN** it FAILs with a message naming the offending arm
+- **AND** the unmodified classifier passes the same assertion, so the assert is proven to bite rather than
+  merely to exist
+
+#### Scenario: A second decision site fails the self-test
+- **GIVEN** a temporary copy of the classifier in which a second function also returns documentation for a
+  path under `docs/`
+- **WHEN** the self-test's structural assertion runs against that copy
+- **THEN** it FAILs, naming the second site
+
+#### Scenario: The classifier's external contract is unchanged
+- **GIVEN** the classifier
+- **WHEN** it is run on any changed set
+- **THEN** it still reads a newline-delimited path list on stdin, still prints exactly one word
+  (`docs-only` or `full`) to stdout with the human-readable reason on stderr, still exits 0 for
+  documentation and 1 for the full path, and still forces the full path on an empty or blank-only set
+
+### Requirement: The classifier reads raw repo-relative paths and fail-closes on any other spelling
+
+The changed-file list SHALL reach the classifier as **raw** repo-relative paths.
+`.github/workflows/pr-gate.yml` SHALL compute it with path quoting disabled
+(`git -c core.quotePath=false diff --name-only`), so a legitimately non-ASCII prose path is classified on
+its real extension rather than on an artefact of its spelling. The repository tracks space-bearing and
+non-ASCII paths under `docs/` today, so this is a live case rather than a hypothetical one.
+
+The classifier SHALL fail closed on any path spelling it cannot read as a raw repo-relative path — in
+particular a C-quoted spelling, recognisable by a leading `"` — classifying it `full` with a named reason.
+A path containing a control character remains unrepresentable in a newline-delimited stream and is closed by
+this rule rather than by assuming it cannot occur.
+
+This is the sibling change's lesson applied once rather than six times: #3229 produced six review blockers
+that were all path-normalisation defects in a different consumer each, including a census that read
+`docs/é notes.md` as extension `md"`. Path interpretation SHALL therefore have exactly one boundary in this
+classifier.
+
+#### Scenario: A space-bearing path is classified on its real extension
+- **GIVEN** a changed set containing `docs/research/CQLite Writes (M5) — notes.md` and a second containing
+  `docs/reports/ws0-3217-artifacts/harness/run all.sh`
+- **WHEN** the classifier runs on each
+- **THEN** the first yields `docs-only` and the second yields `full`, so a space neither smuggles code
+  through nor penalises prose
+
+#### Scenario: A C-quoted spelling fails closed
+- **GIVEN** a changed set containing the literal spelling `"docs/\303\251-notes.md"`, quotes included
+- **WHEN** the classifier runs
+- **THEN** the verdict is `full` with exit status 1 and a reason naming the unreadable spelling
+- **AND** the same path in raw form (`docs/é-notes.md`) yields `docs-only`, proving the quoted case fails on
+  the spelling rather than on the extension
+
+#### Scenario: The workflow feeds unquoted paths
+- **GIVEN** `.github/workflows/pr-gate.yml`
+- **WHEN** its `Classify docs-only diff` step is inspected
+- **THEN** the changed-file list is produced with `core.quotePath=false`, and the step is otherwise
+  unchanged: no `paths`/`paths-ignore` filter on the trigger, the classify step carries no `if:`, every
+  heavy step is still gated `!= 'true'`, a docs-only branch step still exists so the required status always
+  reports, and the `required` job still runs with `if: always()`, still depends on the core job, and still
+  aggregates the sibling tiers
+
+### Requirement: A hermetic self-test pins the classification behaviourally and the boundary structurally
+
+`scripts/tests/test_classify_docs_only.sh` SHALL cover the new behaviour in its existing style — pure
+shell, no cargo, Docker, datasets or network, `assert_docs_only`/`assert_full` helpers, one line per case —
+and SHALL retain every existing assertion and its Ruby-based `pr-gate.yml` contract assertion. The additions
+SHALL be **additive**, so the suite rebases cleanly over concurrent work on the sibling suite
+`scripts/tests/test_roborev_review_guard.sh`.
+
+Coverage SHALL include, at minimum: `.sh`, `.py` and `.bt` executables under `docs/reports/*-artifacts/`;
+the docs-hosted `Cargo.toml` and `src/main.rs`; an extensionless mode-100755 harness path; one executable
+hidden among many prose files in both first and last position; the two functional-config `.json` files
+forcing `full`; the same extensions inside an artifact directory short-circuiting; an unrecognized extension
+under `docs/` failing closed; and the negative cases proving prose plus inert `.json`/`.txt` artifacts still
+short-circuit.
+
+The suite SHALL NOT mirror the imported declaration. Where it needs the artifact extension set it SHALL read
+the **real** declaration, and it SHALL additionally carry the structural and mutation assertions required
+above (no literal copy of the lists; no second `docs/` decision site; a mutated declaration moves the
+verdict; the buckets partition the imported set). A symmetric copy of a production constant is not a test:
+it shares any defect in the original, so both sides agree and the suite is green while the gate is broken.
+
+The suite SHALL continue to run in the full gate's `tooling-tests` component, so a regression FAILs the gate
+of record rather than surfacing on a later PR.
+
+#### Scenario: The suite fails when the classifier regresses to the prefix verdict
+- **GIVEN** a classifier reverted to the blanket `docs/*) return 0`
+- **WHEN** `bash scripts/tests/test_classify_docs_only.sh` runs
+- **THEN** it exits non-zero, and the failing assertions include both a behavioural case (an executable
+  under `docs/` reported `docs-only`) and the structural case (the reintroduced arm)
+
+#### Scenario: Every pre-existing assertion still passes
+- **GIVEN** the amended suite
+- **WHEN** it runs against the amended classifier
+- **THEN** the 23 assertions that existed before this change all pass unchanged, and the reported
+  `FAIL` count is 0
+
+#### Scenario: The suite is wired into the gate
+- **GIVEN** `scripts/agent-gate.sh`
+- **WHEN** the `tooling-tests` component runs
+- **THEN** it executes `scripts/tests/test_classify_docs_only.sh`, and a failure of that script FAILs the
+  component and therefore the full gate
+
+#### Scenario: The suite is hermetic
+- **GIVEN** a machine with no datasets root exported, no network, and no cargo invocation permitted
+- **WHEN** the suite runs
+- **THEN** it completes and reports its PASS/FAIL counts, using only shell built-ins, `git` reads of the
+  local checkout, and the optional Ruby workflow assertion which skips with an `info` line when Ruby is
+  absent
+
+### Requirement: The behaviour is demonstrated on the real merged-PR shapes and recorded
+
+The change SHALL record a demonstration against the **real** file lists of the merged, never-gated PRs
+rather than only against synthetic fixtures. The 188-path changed-file list of **PR #3222**, obtained from
+`gh api repos/pmcfadin/cqlite/pulls/3222/files` (both pages), replayed through the amended classifier SHALL
+yield `full`; a prose-only WS0 diff — the same PR's paths with its 34 executables removed — SHALL yield
+`docs-only`. The same replay SHALL be recorded for PR #3081 and PR #3216.
+
+This SHALL be recorded evidence, not a test assertion: the input is a historical API response, so making it
+a gate assertion would either pin a network call or commit a 188-path fixture that ages. The record SHALL
+name the verdict, the exit status, the path count, and the count of paths responsible for the `full`
+verdict, so a reader can tell the demonstration ran from the numbers rather than from a claim that it did.
+
+#### Scenario: The real PR #3222 changed set is classified `full`
+- **GIVEN** the 188 paths of PR #3222, every one under `docs/`, of which 34 are executables or
+  config-as-code
+- **WHEN** they are fed to the amended classifier
+- **THEN** the verdict is `full` with exit status 1, and the recorded evidence names the first offending
+  path and the count of offending paths
+- **AND** the pre-change classifier is recorded as having returned `docs-only` on the same input, so the
+  demonstration shows a changed verdict rather than an unexplained one
+
+#### Scenario: A prose-only WS0 diff is still classified `docs-only`
+- **GIVEN** the same PR #3222 path list with its 34 executable and config-as-code paths removed
+- **WHEN** it is fed to the amended classifier
+- **THEN** the verdict is `docs-only` with exit status 0, demonstrating on real data that the narrowing did
+  not cost report PRs their fast path
+
+#### Scenario: The demonstration is recorded, not asserted
+- **GIVEN** the change's artifacts
+- **WHEN** they are inspected for the demonstration
+- **THEN** the verdicts, counts and commands are recorded in the change and in the PR body, and no gate
+  assertion depends on a network call or on a committed copy of the API response
+
+### Requirement: Doctrine scopes the CITE-AND-WAIVE waiver to a genuinely prose diff
+
+CLAUDE.md's #3042 CITE-AND-WAIVE paragraph SHALL be narrowed so it no longer implies that everything under
+`docs/` is non-compiled input. It SHALL name the `docs/reports/*-artifacts/` measurement-harness convention
+explicitly, SHALL scope the waiver to a diff that is **genuinely prose**, and SHALL name
+`scripts/ci/classify-docs-only.sh` as the mechanical test of that — so an agent can run the question instead
+of judging it. The falsifying case SHALL be named: a #3222-shaped diff contains `src/main.rs` and
+`Cargo.toml` under `docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/`, so the existing qualifier
+("no `src`, no `Cargo.*`") is satisfied textually while being false materially, and an agent correctly
+following the old text waives a red that is genuinely theirs.
+
+Everything else about the rule SHALL be retained: a waiver still requires a cited issue, and the clause
+voiding the waiver when any compiled input is in the diff SHALL be unchanged.
+
+The matching published doctrine SHALL be updated in the same change. `CITE-AND-WAIVE` currently appears
+nowhere on the site, so the rule SHALL be added to the gate doctrine page
+(`website/src/content/docs/agents-developing/gate-contract.md`, which already owns the gate contract and the
+`--delta` test/docs-only re-certification section) and SHALL be cross-referenced from
+`roborev-findings.md`'s existing code-free-census definition, so the review-side and gate-side definitions
+of "docs-only" cannot drift apart again.
+
+Publication SHALL be accepted by the **new content being served** — grepping the served page for a
+distinctive phrase the change introduces — and SHALL NOT be accepted on an HTTP 200 or a green deploy. A
+zero count SHALL be reported as not-yet-published and re-checked, never banked as done.
+
+#### Scenario: The narrowed rule names the convention and the mechanical test
+- **GIVEN** the amended CLAUDE.md paragraph
+- **WHEN** it is read
+- **THEN** it names `docs/reports/*-artifacts/`, scopes the waiver to a genuinely prose diff, names
+  `scripts/ci/classify-docs-only.sh` as the test, retains the cited-issue requirement, and retains the
+  compiled-input-voids-the-waiver clause
+
+#### Scenario: The published page carries the same rule
+- **GIVEN** `website/src/content/docs/agents-developing/gate-contract.md` after the change
+- **WHEN** it is read
+- **THEN** it states the narrowed waiver rule, and `roborev-findings.md` cross-references it so the two
+  definitions of "docs-only" are linked rather than independently maintained
+
+#### Scenario: Publication is verified by served content
+- **GIVEN** the deployed site after the change merges
+- **WHEN** `curl -sS https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/ | grep -c '<the new
+  phrase>'` is run
+- **THEN** the count is non-zero and that is recorded as the acceptance evidence
+- **AND** a zero count is reported as not-yet-published and re-checked after a wait, and an HTTP 200 alone
+  is never accepted as evidence
+
+### Requirement: The backfill ruling for the three merged, never-gated PRs is recorded
+
+The change SHALL record the owner's ruling, **with its reason**, on the three already-merged, never-gated
+PRs — #3081 (issue #3026), #3216 (issue #3100) and #3222 (issue #3217): either a retroactive run of the
+core gate's step set over that harness code, or explicit acceptance as-is with the reason stated. A decision
+either way satisfies this requirement; **silence is the only failing outcome**. The ruling SHALL be
+coordinated with #3229's AC7, which asks the same question about the same three PRs from the review side, so
+one ruling covers both.
+
+The record SHALL carry the evidence that bounds the exposure, so a future reader can tell the decision was
+informed rather than assumed: `docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness` is **not** a
+workspace member (verified via `cargo metadata --no-deps`, 16 packages, none under `docs/`), so no
+`pr-gate-core` step would have compiled, formatted or linted it even had the gate run; and none of the other
+skipped steps reads any path in those diffs, which makes a retroactive run equivalent to running the core on
+`main` at those commits.
+
+The record SHALL also carry the ruling's **condition of change**: any of that harness code being promoted
+into a shipped path — a gate component, a CI step, an imported module — ends the exemption, because at that
+moment it inherits the obligations of the surface it joins.
+
+#### Scenario: An acceptance-as-is ruling is recorded with its reason
+- **GIVEN** the owner rules to accept the three PRs as-is
+- **WHEN** the change is inspected
+- **THEN** the ruling, its date, its reason and its condition of change are recorded in the change, and the
+  bounding evidence (non-membership in the workspace; no skipped step reads those paths) is recorded with it
+
+#### Scenario: A retroactive-run ruling is recorded with its outcome
+- **GIVEN** the owner instead rules for a retroactive run of the core gate's step set
+- **WHEN** the change is inspected
+- **THEN** the commands run, the commit each was run against, and the result of each are recorded, together
+  with the statement of what the run does and does not establish
+
+#### Scenario: Silence on the backfill question fails the change
+- **GIVEN** a change in which neither ruling is recorded
+- **WHEN** the requirement is audited
+- **THEN** it is unmet — the requirement is satisfied by the record, never by the absence of a complaint

--- a/openspec/changes/narrow-docs-only-classifier/tasks.md
+++ b/openspec/changes/narrow-docs-only-classifier/tasks.md
@@ -9,8 +9,10 @@
 > boundary with mutation-tested structural asserts; narrow the #3042 CITE-AND-WAIVE doctrine in the same
 > change. AC→requirement map is at the top of `specs/docs-only-gate-classification/spec.md`.
 >
-> **AC7 needs the owner.** The recommendation and its evidence are in `design.md` D7 (accept as-is, one
-> ruling covering #3229 AC7 and #3250 AC7, with the promotion condition). Do not decide it in-band.
+> **AC7 is RULED (owner, 2026-08-04, Seam 1): accept as-is, no retroactive core-gate run** — one ruling
+> covering #3229 AC7 and #3250 AC7, with the promotion condition. Task 8 is therefore the RECORDING only;
+> the ruling as given, its date, reason, bounding evidence and condition of change are in `design.md`
+> D7.RULING. Do not re-ask it.
 
 ## 1. Import #3229's artifact declaration, fail-closed (surface: `scripts/ci/classify-docs-only.sh`)
 - [ ] Source `scripts/flow/roborev-review-oracles.sh` resolved **relative to the classifier's own

--- a/openspec/changes/narrow-docs-only-classifier/tasks.md
+++ b/openspec/changes/narrow-docs-only-classifier/tasks.md
@@ -1,0 +1,163 @@
+# Tasks: narrow-docs-only-classifier (issue #3250)
+
+> Design decided in `design.md`. In one line: replace `classify-docs-only.sh`'s blanket `docs/*) return 0`
+> with a SINGLE dispatch to one classifier function that returns documentation only on an affirmative
+> allowlist match (prose/image/legal · inert imported artifact anywhere under `docs/` · code-bearing
+> imported artifact inside an artifact-bearing directory), fail-closed on everything else including all
+> extensionless paths; **import** #3229's `CODE_FREE_ARTIFACT_EXTENSIONS` /
+> `CODE_FREE_ARTIFACT_DIR_GLOBS` / `roborev_path_in_artifact_dir` rather than restating them; pin the
+> boundary with mutation-tested structural asserts; narrow the #3042 CITE-AND-WAIVE doctrine in the same
+> change. AC→requirement map is at the top of `specs/docs-only-gate-classification/spec.md`.
+>
+> **AC7 needs the owner.** The recommendation and its evidence are in `design.md` D7 (accept as-is, one
+> ruling covering #3229 AC7 and #3250 AC7, with the promotion condition). Do not decide it in-band.
+
+## 1. Import #3229's artifact declaration, fail-closed (surface: `scripts/ci/classify-docs-only.sh`)
+- [ ] Source `scripts/flow/roborev-review-oracles.sh` resolved **relative to the classifier's own
+      location** (`${BASH_SOURCE[0]}`), never `$PWD`. Location-relative resolution is what makes task 5's
+      mutation test possible.
+- [ ] After sourcing, verify the declaration is usable: file present, source succeeded,
+      `CODE_FREE_ARTIFACT_EXTENSIONS` non-empty, `CODE_FREE_ARTIFACT_DIR_GLOBS` has ≥1 element. On any
+      failure, classify **every** path under `docs/` as `full` and print a named reason. Never degrade to
+      "prose-only allowlist and carry on" — an infra fault must not loosen the gate.
+- [ ] Record the coupling at the import site: this classifier now depends on the declaration's CONTENT
+      (not on roborev v0.61.2's `FormatExcludeArgs` pathspec semantics — it feeds roborev no pathspec and
+      reads no `.roborev.toml`), and an edit to the declaration now moves the CORRECTNESS GATE as well as
+      the reviewer. State the re-verify-on-upgrade obligation in those terms (`design.md` D4).
+- [ ] Do NOT copy the extension list or any directory glob as a literal, and do NOT reimplement the
+      directory matcher — `roborev_path_in_artifact_dir`'s component-wise walk is load-bearing (a bash
+      `case` glob crosses `/`; git's `:(glob)` `*` does not).
+
+## 2. One canonical decision point (surface: `scripts/ci/classify-docs-only.sh`, `is_docs_file()`)
+- [ ] Delete the blanket `docs/*) return 0 ;;` arm. Replace it with a single dispatch to one new function
+      that is the ONLY place a path under `docs/` is classified. Keep the sensitive-directory escape
+      (`.github/`, `scripts/`, `test-data/`) and the global `*.md`/image/`LICENSE*` arms unchanged for
+      paths outside `docs/`.
+- [ ] Implement the three affirmative layers inside that function, disjoint by extension so their order
+      cannot change an answer: L1 prose/image/legal at any depth (the classifier's OWN semantics,
+      unchanged, including `.jpg`/`.gif`/`.webp`/`.ico` which are NOT in the imported set); L2 the inert
+      bucket at any depth under `docs/`; L3 the code-bearing bucket **only** where
+      `roborev_path_in_artifact_dir` says the path is inside an artifact directory.
+- [ ] Declare the buckets: inert = `txt jsonl log err csv gz pdf jfr mmd tex diff`; code-bearing =
+      `json html`; image-layer = `png svg` (assigned to neither behavioural bucket because L1 answers them
+      first, and this change does not alter the image layer — `design.md` D3c). At runtime, an imported
+      extension in NO bucket classifies `full`.
+- [ ] Closed grammar: no `else return 0`, no "not obviously code ⇒ prose". Every documentation verdict
+      comes from a positive match.
+- [ ] Do NOT consult git's executable bit for extensionless paths (`design.md` D3d): the input carries no
+      mode, a mode read would need a repository and two refs, `chmod -x` must not move a program into the
+      documentation class, and all 3 tracked extensionless files under `docs/` are 100755 harnesses.
+
+## 3. Raw-path boundary (surfaces: `scripts/ci/classify-docs-only.sh`, `.github/workflows/pr-gate.yml`)
+- [ ] Classifier: fail closed (`full`, named reason) on any path spelling that is not a raw repo-relative
+      path — in particular one beginning with `"` (git's C-quoted form). One boundary, one place.
+- [ ] `pr-gate.yml` `Classify docs-only diff` step: compute the changed-file list with
+      `git -c core.quotePath=false diff --name-only "${BASE_SHA}...${HEAD_SHA}"`. Do NOT switch to `-z`
+      (that would change the classifier's newline-delimited stdin contract). Change nothing else: no
+      trigger filter, no `if:` on the classify step, no change to the `!= 'true'` heavy-step gates, no
+      change to `required`.
+
+## 4. Behavioural regression cases (surface: `scripts/tests/test_classify_docs_only.sh`)
+- [ ] Additive only — keep all 23 existing asserts and the Ruby `pr-gate.yml` contract block, so the suite
+      rebases cleanly over #3296's concurrent edits to the SIBLING suite
+      (`test_roborev_review_guard.sh` — a different file). If the two lanes ever touch the same lines,
+      raise `coord:needs-attention` rather than racing.
+- [ ] `assert_full` cases: `.sh`, `.py`, `.bt` under `docs/reports/*-artifacts/`; the docs-hosted
+      `Cargo.toml` and `src/main.rs` (each alone and together); an extensionless harness path
+      (`docs/reports/ws0-3026-artifacts/ws0-results/ws0-readbw`); one executable LAST among 20 prose files
+      and the same set with it FIRST (order-independence — the real #3222 shape); unrecognized extensions
+      under `docs/` (`.rb`, `.jq`, `.mjs`); `docs/observability/grafana/dashboards/cqlite-overview.json`;
+      `docs/reports/delivery-telemetry.schema.json`; `docs/reports/a/b-artifacts/x.json` (the `case`-glob
+      separator-crossing case); a C-quoted spelling.
+- [ ] `assert_docs_only` cases: prose + image + legal; a WS0 report set (`README.md` + `.txt` `.jsonl`
+      `.csv` `.log` `.err` `.png` `.json` under an artifact dir); inert extensions OUTSIDE an artifact dir
+      (`docs/reports/delivery-telemetry.jsonl`, `docs/sstables-definitive-guide/pandoc-header.tex`,
+      `.../statistics-db-annotated-dump.txt`); `docs/img/photo.jpg`, `.gif`, `.ico`;
+      `docs/reports/ws0-3217-artifacts/x.json` and `docs/observability/jfr-reports/run.html` and
+      `docs/round-artifacts/2026-08/deep/nested/out.json` (nested/`**` matches); a raw non-ASCII `.md`; a
+      space-bearing `.md`.
+- [ ] Negative-control pair: `docs/reports/ws0-3217-artifacts/README.md` + `.../harness/parse-runqlat.py`
+      ⇒ `full`, proving a prose sibling does not rescue the set.
+
+## 5. Structural + mutation asserts (surface: `scripts/tests/test_classify_docs_only.sh`)
+- [ ] Assert the classifier source contains **no** literal copy of the imported extension list and **no**
+      literal copy of any of the four directory globs.
+- [ ] Assert `is_docs_file()` has no `case` arm returning documentation for a `docs/`-prefixed pattern, and
+      that no second site in the file decides a `docs/` path's class. **Mutation-test the assert**: a temp
+      copy with `docs/*) return 0 ;;` reintroduced must FAIL it, and a temp copy with a second deciding
+      function must FAIL it, while the real file passes.
+- [ ] Mutation-test the IMPORT: temp tree with a copy of the classifier + a copy of the **real**
+      `roborev-review-oracles.sh` whose declaration is mutated (synthetic inert extension added, one
+      directory glob removed); assert the classifier's verdicts MOVE accordingly. A classifier with its own
+      hardcoded lists fails this.
+- [ ] Assert the bucket partition against the **real** declaration (union equals
+      `CODE_FREE_ARTIFACT_EXTENSIONS`, buckets pairwise disjoint). A synthetic extension added upstream must
+      FAIL with a greppable message naming the extension and `#3250`. Never mirror the list into a fixture —
+      a symmetric mirror shares the defect and greens while broken (#3042's blindness in shell).
+- [ ] Assert the fail-closed import: temp tree with the declaring file absent, and one with an empty
+      declaration ⇒ `full` for a path that is `docs-only` under the real declaration, with a named reason.
+- [ ] Confirm the suite stays hermetic (pure shell + local `git` reads + optional Ruby) and still runs in
+      the gate's `tooling-tests` component (`scripts/agent-gate.sh`).
+
+## 6. Recorded demonstration on the real shapes (AC4 — evidence, not asserts)
+- [ ] Fetch PR #3222's real 188-path list (`gh api repos/pmcfadin/cqlite/pulls/3222/files`, both pages);
+      replay through the amended classifier ⇒ expect `full` / exit 1. Record the verdict, exit status, path
+      count, offending-path count and first offending path.
+- [ ] Replay the same list with the 34 executable/config-as-code paths removed ⇒ expect `docs-only` /
+      exit 0. Record it.
+- [ ] Repeat the replay for PR #3081 and PR #3216 and record the verdicts.
+- [ ] Record the pre-change verdict on the same #3222 input (`docs-only`) so the demonstration shows a
+      CHANGED verdict. Put the numbers in the PR body and the change; add no network-dependent gate
+      assertion and commit no 188-path fixture.
+
+## 7. Doctrine, in the same change (AC6)
+- [ ] `CLAUDE.md`: narrow the #3042 CITE-AND-WAIVE paragraph — name the `docs/reports/*-artifacts/`
+      convention, scope the waiver to a genuinely prose diff, name `scripts/ci/classify-docs-only.sh` as
+      the mechanical test, name the falsifying case (`scan-harness`'s `Cargo.toml` + `src/main.rs` satisfy
+      the old qualifier textually while being false materially). Retain the cited-issue requirement and the
+      compiled-input-voids-the-waiver clause.
+- [ ] `website/src/content/docs/agents-developing/gate-contract.md`: add the narrowed rule (CITE-AND-WAIVE
+      appears nowhere on the site today — verified by grep). Cross-reference it from
+      `roborev-findings.md`'s existing code-free-census definition so the review-side and gate-side
+      "docs-only" definitions are linked, not independently maintained.
+- [ ] Verify publication by **served content**:
+      `curl -sS https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/ | grep -c '<new phrase>'`
+      must be non-zero. A `0` is not-yet-published — wait and re-check (the CDN has served stale content for
+      ~3 minutes after a successful deploy). Never accept HTTP 200 or a green deploy as evidence.
+
+## 8. AC7 — the backfill ruling (OWNER decision; do not decide in-band)
+- [ ] Ask the owner, carrying `design.md` D7's recommendation (accept as-is; one ruling covering #3229 AC7
+      and #3250 AC7) and its evidence: `scan-harness` is not a workspace member (`cargo metadata
+      --no-deps`, 16 packages, none under `docs/`), and no skipped `pr-gate-core` step reads any path in
+      those three diffs — so a retroactive run is equivalent to running the core on `main`.
+- [ ] Record the ruling, its date, its reason, its bounding evidence and its condition of change (promotion
+      of harness code into a shipped path ends the exemption) in `design.md` D7 and the PR body. Silence is
+      the only failing outcome.
+
+## 9. Verification, review, gate, merge
+- [ ] `bash scripts/tests/test_classify_docs_only.sh` green standalone; `FAIL=0`.
+- [ ] `--lite` each fix round, summary-file redirect:
+      `AGENT_GATE_SUMMARY_FILE=/tmp/gate-lite-3250.txt bash scripts/agent-gate.sh --lite > lite.log 2>&1
+      < /dev/null`, then read only `/tmp/gate-lite-3250.txt`. Poll on `RESULT: (PASS|FAIL)` —
+      `INCOMPLETE` is a liveness sentinel, not a verdict — and check `tree-integrity:`.
+- [ ] `bash scripts/agent-gate.sh --only tooling-tests` for the fast targeted signal on the suite.
+- [ ] Review-first: `rust-reviewer` is N/A (no Rust); run roborev on the lite-green, PUSHED diff via the
+      ONLY sanctioned form —
+      `bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol --repo /home/ubuntu/workspace/cqlite-wt/issue-3250 --base origin/main`
+      — retaining only the `==== ROBOREV REVIEW SUMMARY ====` block. Any non-PASS terminal `RESULT`
+      (including `NOTHING-TO-REVIEW`) is a failed round. This diff carries shell + workflow code, so it is
+      NOT code-free and MUST be roborev-certified. Raise `default_max_prompt_size` in
+      `~/.roborev/config.toml` and restart the daemon before the closer's pass (#3257); carry
+      `prompt-content:` verbatim in the closer's packet; never slice the base.
+- [ ] Each roborev blocker: fix → `--lite` re-cert → re-review. Nits batch into ONE linked follow-up issue
+      at merge time.
+- [ ] Open the PR. Rebase over #3296 if it has merged; confirm the test additions are still additive.
+- [ ] Hand the endgame to `flow-closer`: the ONE full gate of record
+      (`AGENT_GATE_SUMMARY_FILE=/tmp/gate-3250.txt bash scripts/agent-gate.sh > gate.log 2>&1 < /dev/null`,
+      then read only the summary file — never `gate.log`), then **C** (`spec-auditor` against
+      `openspec/changes/narrow-docs-only-classifier/specs/**`), then the final roborev pass, then
+      `scripts/flow/premerge-assert.sh <pr> <certified-sha>`, then
+      `gh pr merge --auto --squash --delete-branch`. Note the CITE-AND-WAIVE waiver does NOT apply to this
+      PR's own gate: the diff touches workflow and script inputs, so any failure is presumed ours.
+- [ ] `flow-finalize`: archive the change, stamp delivery telemetry via a `telemetry-<N>` worktree PR (never
+      a direct push to `main`), remove the worktree/branch, close the issue with a traceable comment.

--- a/openspec/changes/narrow-docs-only-classifier/tasks.md
+++ b/openspec/changes/narrow-docs-only-classifier/tasks.md
@@ -15,134 +15,138 @@
 > D7.RULING. Do not re-ask it.
 
 ## 1. Import #3229's artifact declaration, fail-closed (surface: `scripts/ci/classify-docs-only.sh`)
-- [ ] Source `scripts/flow/roborev-review-oracles.sh` resolved **relative to the classifier's own
+- [x] Source `scripts/flow/roborev-review-oracles.sh` resolved **relative to the classifier's own
       location** (`${BASH_SOURCE[0]}`), never `$PWD`. Location-relative resolution is what makes task 5's
       mutation test possible.
-- [ ] After sourcing, verify the declaration is usable: file present, source succeeded,
+- [x] After sourcing, verify the declaration is usable: file present, source succeeded,
       `CODE_FREE_ARTIFACT_EXTENSIONS` non-empty, `CODE_FREE_ARTIFACT_DIR_GLOBS` has ≥1 element. On any
       failure, classify **every** path under `docs/` as `full` and print a named reason. Never degrade to
       "prose-only allowlist and carry on" — an infra fault must not loosen the gate.
-- [ ] Record the coupling at the import site: this classifier now depends on the declaration's CONTENT
+- [x] Record the coupling at the import site: this classifier now depends on the declaration's CONTENT
       (not on roborev v0.61.2's `FormatExcludeArgs` pathspec semantics — it feeds roborev no pathspec and
       reads no `.roborev.toml`), and an edit to the declaration now moves the CORRECTNESS GATE as well as
       the reviewer. State the re-verify-on-upgrade obligation in those terms (`design.md` D4).
-- [ ] Do NOT copy the extension list or any directory glob as a literal, and do NOT reimplement the
+- [x] Do NOT copy the extension list or any directory glob as a literal, and do NOT reimplement the
       directory matcher — `roborev_path_in_artifact_dir`'s component-wise walk is load-bearing (a bash
       `case` glob crosses `/`; git's `:(glob)` `*` does not).
 
 ## 2. One canonical decision point (surface: `scripts/ci/classify-docs-only.sh`, `is_docs_file()`)
-- [ ] Delete the blanket `docs/*) return 0 ;;` arm. Replace it with a single dispatch to one new function
+- [x] Delete the blanket `docs/*) return 0 ;;` arm. Replace it with a single dispatch to one new function
       that is the ONLY place a path under `docs/` is classified. Keep the sensitive-directory escape
       (`.github/`, `scripts/`, `test-data/`) and the global `*.md`/image/`LICENSE*` arms unchanged for
       paths outside `docs/`.
-- [ ] Implement the three affirmative layers inside that function, disjoint by extension so their order
+- [x] Implement the three affirmative layers inside that function, disjoint by extension so their order
       cannot change an answer: L1 prose/image/legal at any depth (the classifier's OWN semantics,
       unchanged, including `.jpg`/`.gif`/`.webp`/`.ico` which are NOT in the imported set); L2 the inert
       bucket at any depth under `docs/`; L3 the code-bearing bucket **only** where
       `roborev_path_in_artifact_dir` says the path is inside an artifact directory.
-- [ ] Declare the buckets: inert = `txt jsonl log err csv gz pdf jfr mmd tex diff`; code-bearing =
+- [x] Declare the buckets: inert = `txt jsonl log err csv gz pdf jfr mmd tex diff`; code-bearing =
       `json html`; image-layer = `png svg` (assigned to neither behavioural bucket because L1 answers them
       first, and this change does not alter the image layer — `design.md` D3c). At runtime, an imported
       extension in NO bucket classifies `full`.
-- [ ] Closed grammar: no `else return 0`, no "not obviously code ⇒ prose". Every documentation verdict
+- [x] Closed grammar: no `else return 0`, no "not obviously code ⇒ prose". Every documentation verdict
       comes from a positive match.
-- [ ] Do NOT consult git's executable bit for extensionless paths (`design.md` D3d): the input carries no
+- [x] Do NOT consult git's executable bit for extensionless paths (`design.md` D3d): the input carries no
       mode, a mode read would need a repository and two refs, `chmod -x` must not move a program into the
       documentation class, and all 3 tracked extensionless files under `docs/` are 100755 harnesses.
 
 ## 3. Raw-path boundary (surfaces: `scripts/ci/classify-docs-only.sh`, `.github/workflows/pr-gate.yml`)
-- [ ] Classifier: fail closed (`full`, named reason) on any path spelling that is not a raw repo-relative
+- [x] Classifier: fail closed (`full`, named reason) on any path spelling that is not a raw repo-relative
       path — in particular one beginning with `"` (git's C-quoted form). One boundary, one place.
-- [ ] `pr-gate.yml` `Classify docs-only diff` step: compute the changed-file list with
+- [x] `pr-gate.yml` `Classify docs-only diff` step: compute the changed-file list with
       `git -c core.quotePath=false diff --name-only "${BASE_SHA}...${HEAD_SHA}"`. Do NOT switch to `-z`
       (that would change the classifier's newline-delimited stdin contract). Change nothing else: no
       trigger filter, no `if:` on the classify step, no change to the `!= 'true'` heavy-step gates, no
       change to `required`.
 
 ## 4. Behavioural regression cases (surface: `scripts/tests/test_classify_docs_only.sh`)
-- [ ] Additive only — keep all 23 existing asserts and the Ruby `pr-gate.yml` contract block, so the suite
+- [x] Additive only — keep all 23 existing asserts and the Ruby `pr-gate.yml` contract block, so the suite
       rebases cleanly over #3296's concurrent edits to the SIBLING suite
       (`test_roborev_review_guard.sh` — a different file). If the two lanes ever touch the same lines,
       raise `coord:needs-attention` rather than racing.
-- [ ] `assert_full` cases: `.sh`, `.py`, `.bt` under `docs/reports/*-artifacts/`; the docs-hosted
+- [x] `assert_full` cases: `.sh`, `.py`, `.bt` under `docs/reports/*-artifacts/`; the docs-hosted
       `Cargo.toml` and `src/main.rs` (each alone and together); an extensionless harness path
       (`docs/reports/ws0-3026-artifacts/ws0-results/ws0-readbw`); one executable LAST among 20 prose files
       and the same set with it FIRST (order-independence — the real #3222 shape); unrecognized extensions
       under `docs/` (`.rb`, `.jq`, `.mjs`); `docs/observability/grafana/dashboards/cqlite-overview.json`;
       `docs/reports/delivery-telemetry.schema.json`; `docs/reports/a/b-artifacts/x.json` (the `case`-glob
       separator-crossing case); a C-quoted spelling.
-- [ ] `assert_docs_only` cases: prose + image + legal; a WS0 report set (`README.md` + `.txt` `.jsonl`
+- [x] `assert_docs_only` cases: prose + image + legal; a WS0 report set (`README.md` + `.txt` `.jsonl`
       `.csv` `.log` `.err` `.png` `.json` under an artifact dir); inert extensions OUTSIDE an artifact dir
       (`docs/reports/delivery-telemetry.jsonl`, `docs/sstables-definitive-guide/pandoc-header.tex`,
       `.../statistics-db-annotated-dump.txt`); `docs/img/photo.jpg`, `.gif`, `.ico`;
       `docs/reports/ws0-3217-artifacts/x.json` and `docs/observability/jfr-reports/run.html` and
       `docs/round-artifacts/2026-08/deep/nested/out.json` (nested/`**` matches); a raw non-ASCII `.md`; a
       space-bearing `.md`.
-- [ ] Negative-control pair: `docs/reports/ws0-3217-artifacts/README.md` + `.../harness/parse-runqlat.py`
+- [x] Negative-control pair: `docs/reports/ws0-3217-artifacts/README.md` + `.../harness/parse-runqlat.py`
       ⇒ `full`, proving a prose sibling does not rescue the set.
 
 ## 5. Structural + mutation asserts (surface: `scripts/tests/test_classify_docs_only.sh`)
-- [ ] Assert the classifier source contains **no** literal copy of the imported extension list and **no**
+- [x] Assert the classifier source contains **no** literal copy of the imported extension list and **no**
       literal copy of any of the four directory globs.
-- [ ] Assert `is_docs_file()` has no `case` arm returning documentation for a `docs/`-prefixed pattern, and
+- [x] Assert `is_docs_file()` has no `case` arm returning documentation for a `docs/`-prefixed pattern, and
       that no second site in the file decides a `docs/` path's class. **Mutation-test the assert**: a temp
       copy with `docs/*) return 0 ;;` reintroduced must FAIL it, and a temp copy with a second deciding
       function must FAIL it, while the real file passes.
-- [ ] Mutation-test the IMPORT: temp tree with a copy of the classifier + a copy of the **real**
+- [x] Mutation-test the IMPORT: temp tree with a copy of the classifier + a copy of the **real**
       `roborev-review-oracles.sh` whose declaration is mutated (synthetic inert extension added, one
       directory glob removed); assert the classifier's verdicts MOVE accordingly. A classifier with its own
       hardcoded lists fails this.
-- [ ] Assert the bucket partition against the **real** declaration (union equals
+- [x] Assert the bucket partition against the **real** declaration (union equals
       `CODE_FREE_ARTIFACT_EXTENSIONS`, buckets pairwise disjoint). A synthetic extension added upstream must
       FAIL with a greppable message naming the extension and `#3250`. Never mirror the list into a fixture —
       a symmetric mirror shares the defect and greens while broken (#3042's blindness in shell).
-- [ ] Assert the fail-closed import: temp tree with the declaring file absent, and one with an empty
+- [x] Assert the fail-closed import: temp tree with the declaring file absent, and one with an empty
       declaration ⇒ `full` for a path that is `docs-only` under the real declaration, with a named reason.
-- [ ] Confirm the suite stays hermetic (pure shell + local `git` reads + optional Ruby) and still runs in
+- [x] Confirm the suite stays hermetic (pure shell + local `git` reads + optional Ruby) and still runs in
       the gate's `tooling-tests` component (`scripts/agent-gate.sh`).
 
 ## 6. Recorded demonstration on the real shapes (AC4 — evidence, not asserts)
-- [ ] Fetch PR #3222's real 188-path list (`gh api repos/pmcfadin/cqlite/pulls/3222/files`, both pages);
+- [x] Fetch PR #3222's real 188-path list (`gh api repos/pmcfadin/cqlite/pulls/3222/files`, both pages);
       replay through the amended classifier ⇒ expect `full` / exit 1. Record the verdict, exit status, path
       count, offending-path count and first offending path.
-- [ ] Replay the same list with the 34 executable/config-as-code paths removed ⇒ expect `docs-only` /
+- [x] Replay the same list with the 34 executable/config-as-code paths removed ⇒ expect `docs-only` /
       exit 0. Record it.
-- [ ] Repeat the replay for PR #3081 and PR #3216 and record the verdicts.
-- [ ] Record the pre-change verdict on the same #3222 input (`docs-only`) so the demonstration shows a
+- [x] Repeat the replay for PR #3081 and PR #3216 and record the verdicts.
+- [x] Record the pre-change verdict on the same #3222 input (`docs-only`) so the demonstration shows a
       CHANGED verdict. Put the numbers in the PR body and the change; add no network-dependent gate
       assertion and commit no 188-path fixture.
 
 ## 7. Doctrine, in the same change (AC6)
-- [ ] `CLAUDE.md`: narrow the #3042 CITE-AND-WAIVE paragraph — name the `docs/reports/*-artifacts/`
+- [x] `CLAUDE.md`: narrow the #3042 CITE-AND-WAIVE paragraph — name the `docs/reports/*-artifacts/`
       convention, scope the waiver to a genuinely prose diff, name `scripts/ci/classify-docs-only.sh` as
       the mechanical test, name the falsifying case (`scan-harness`'s `Cargo.toml` + `src/main.rs` satisfy
       the old qualifier textually while being false materially). Retain the cited-issue requirement and the
       compiled-input-voids-the-waiver clause.
-- [ ] `website/src/content/docs/agents-developing/gate-contract.md`: add the narrowed rule (CITE-AND-WAIVE
+- [x] `website/src/content/docs/agents-developing/gate-contract.md`: add the narrowed rule (CITE-AND-WAIVE
       appears nowhere on the site today — verified by grep). Cross-reference it from
       `roborev-findings.md`'s existing code-free-census definition so the review-side and gate-side
       "docs-only" definitions are linked, not independently maintained.
-- [ ] Verify publication by **served content**:
+- [ ] Verify publication by **served content** (POST-MERGE — the site publishes from `main`):
       `curl -sS https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/ | grep -c '<new phrase>'`
       must be non-zero. A `0` is not-yet-published — wait and re-check (the CDN has served stale content for
       ~3 minutes after a successful deploy). Never accept HTTP 200 or a green deploy as evidence.
 
 ## 8. AC7 — the backfill ruling (OWNER decision; do not decide in-band)
-- [ ] Ask the owner, carrying `design.md` D7's recommendation (accept as-is; one ruling covering #3229 AC7
+- [x] Ask the owner, carrying `design.md` D7's recommendation (accept as-is; one ruling covering #3229 AC7
       and #3250 AC7) and its evidence: `scan-harness` is not a workspace member (`cargo metadata
       --no-deps`, 16 packages, none under `docs/`), and no skipped `pr-gate-core` step reads any path in
       those three diffs — so a retroactive run is equivalent to running the core on `main`.
-- [ ] Record the ruling, its date, its reason, its bounding evidence and its condition of change (promotion
+- [x] Record the ruling, its date, its reason, its bounding evidence and its condition of change (promotion
       of harness code into a shipped path ends the exemption) in `design.md` D7 and the PR body. Silence is
       the only failing outcome.
 
 ## 9. Verification, review, gate, merge
-- [ ] `bash scripts/tests/test_classify_docs_only.sh` green standalone; `FAIL=0`.
-- [ ] `--lite` each fix round, summary-file redirect:
+- [x] `bash scripts/tests/test_classify_docs_only.sh` green standalone: **PASS=92 FAIL=0** (23 pre-existing
+      asserts unchanged; ruby absent locally so the Ruby workflow block reports `info - skipped` — it runs in
+      the gate's `tooling-tests` on a ruby-bearing host).
+- [x] `--lite` each fix round, summary-file redirect: **RESULT: PASS**, `tree-integrity: PASS`, at
+      `9eea5dd` (file-size/fmt/clippy/roborev-lints/scoped-tests all PASS).
       `AGENT_GATE_SUMMARY_FILE=/tmp/gate-lite-3250.txt bash scripts/agent-gate.sh --lite > lite.log 2>&1
       < /dev/null`, then read only `/tmp/gate-lite-3250.txt`. Poll on `RESULT: (PASS|FAIL)` —
       `INCOMPLETE` is a liveness sentinel, not a verdict — and check `tree-integrity:`.
-- [ ] `bash scripts/agent-gate.sh --only tooling-tests` for the fast targeted signal on the suite.
+- [x] `bash scripts/agent-gate.sh --only tooling-tests`: **tooling-tests PASS (458s)**, `RESULT: PARTIAL`
+      (`--only` never counts as the gate of record).
 - [ ] Review-first: `rust-reviewer` is N/A (no Rust); run roborev on the lite-green, PUSHED diff via the
       ONLY sanctioned form —
       `bash scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol --repo /home/ubuntu/workspace/cqlite-wt/issue-3250 --base origin/main`

--- a/scripts/ci/classify-docs-only.sh
+++ b/scripts/ci/classify-docs-only.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Docs-only classifier for the required PR gate (issue #2645, epic #2636).
+# Docs-only classifier for the required PR gate (issue #2645, epic #2636;
+# NARROWED by issue #3250).
 #
 # pr-gate.yml is a REQUIRED status check with no path awareness: a docs- or
 # board-only PR still compiles cqlite-core all-features and runs the read-time
@@ -9,8 +10,8 @@
 # permanently blocking a PR that touches only ignored paths.
 #
 # Contract (pure + hermetic so it is self-testable):
-#   - Reads a newline-delimited changed-file list on STDIN (one repo-relative
-#     path per line; blank lines ignored).
+#   - Reads a newline-delimited changed-file list on STDIN (one RAW
+#     repo-relative path per line; blank lines ignored).
 #   - Exit 0  => DOCS-ONLY: every changed file is in the conservative docs
 #                allowlist. The caller MAY skip the Rust/oracle/heavy steps.
 #   - Exit 1  => FULL PATH REQUIRED (fail-closed): at least one file is NOT in
@@ -27,10 +28,198 @@
 # gate script, or a parity manifest can never smuggle a code-relevant change
 # past the gate.
 #
+# ---------------------------------------------------------------------------
+# ISSUE #3250: A `docs/` PATH PREFIX IS NOT A VERDICT.
+#
+# This script used to answer documentation for ANY path under `docs/`, extension
+# blind. This repository ships measurement harnesses under
+# `docs/reports/<ws>-artifacts/` BY CONVENTION (owner-ruled: the convention
+# stays), so that was not a corner case: three merged PRs reported `required`
+# green in 13-16 s against a ~14-minute baseline, having compiled and tested
+# nothing — one of them carrying a whole Cargo crate (a manifest plus
+# `src/main.rs`) and 34 executables in total.
+#
+# A path under `docs/` is now documentation ONLY on an AFFIRMATIVE match against
+# a named allowlist layer, decided in ONE place (`docs_path_is_documentation`):
+#
+#   L1  prose / image / legal at any depth  — this classifier's OWN semantics,
+#       unchanged by #3250, including its behaviour outside `docs/`.
+#   L2  INERT report artifacts at any depth under `docs/` — the inert bucket of
+#       the IMPORTED artifact extension set.
+#   L3  CODE-BEARING report artifacts (json, html) ONLY inside an
+#       artifact-bearing directory, via the IMPORTED component-wise matcher.
+#   ==> anything else — unrecognized extension, NO extension, an imported
+#       extension this classifier has not bucketed — forces the full path.
+#
+# There is deliberately no `else return 0` and no "not obviously code => prose":
+# a positive verdict requires a positive match, so every unmeasured or
+# unanticipated case inherits `full`. A deny-list of executable extensions was
+# rejected for the opposite reason: it is fail-OPEN, and the next extension
+# somebody commits under `docs/` would be documentation by default.
+#
+# The extensionless rule is UNCONDITIONAL and does NOT consult git's executable
+# bit (the sibling subsystem #3229 does): this script's input carries no mode, a
+# mode read would need a repository and two resolvable refs, a `chmod -x` must
+# not be able to move a program into the documentation class when the
+# consequence is an ungated merge, and the measured cost is zero — every tracked
+# extensionless file under `docs/` is a mode-100755 harness binary.
+# ---------------------------------------------------------------------------
+#
 # The script prints a one-word verdict ("docs-only" / "full") to STDOUT and a
 # human-readable reason to STDERR; callers key off the EXIT CODE.
 
 set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# THE IMPORT (issue #3250, AC5): what counts as committed run output beside a
+# report is declared ONCE, in scripts/flow/roborev-review-oracles.sh (#3229).
+# It is IMPORTED here, never restated — no copy of the extension list, no copy
+# of a directory glob, and no re-implementation of the directory matcher (its
+# component-wise walk is load-bearing: a bash `case` glob crosses `/`, git's
+# `:(glob)` `*` does not, so an approximation would disagree with the pathspec
+# the sibling subsystem actually configures).
+#
+# THE COUPLING THIS CREATES, stated because it is obvious for one release and
+# invisible afterwards: this classifier depends on that declaration's CONTENT.
+# It does NOT depend on roborev v0.61.2's `git.FormatExcludeArgs` pathspec
+# semantics — it feeds roborev no pathspec and reads no `.roborev.toml`. What it
+# inherits is the consequence: the declaration mirrors `.roborev.toml`, whose
+# correctness was established against that pinned version, so a roborev upgrade
+# may move the declaration — and an edit to it now moves THE CORRECTNESS GATE as
+# well as the reviewer's diff. After any roborev upgrade, re-verify that the
+# declaration still means what the GATE needs and re-run
+# scripts/tests/test_classify_docs_only.sh, whose bucket-partition assertion is
+# the mechanical half of that obligation.
+#
+# Resolved relative to THIS SCRIPT'S OWN LOCATION, never `$PWD`: the classifier
+# is invoked from varying working directories, and location-relative resolution
+# is what lets the self-test mutate the declaration in a temporary tree and
+# prove the verdict follows it.
+# ---------------------------------------------------------------------------
+CLASSIFY_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ARTIFACT_DECLARATION="$CLASSIFY_SCRIPT_DIR/../flow/roborev-review-oracles.sh"
+ARTIFACT_DECLARATION_STATUS="unusable"
+ARTIFACT_DECLARATION_DETAIL="import not attempted"
+
+if [ ! -f "$ARTIFACT_DECLARATION" ]; then
+  ARTIFACT_DECLARATION_DETAIL="declaring file absent: $ARTIFACT_DECLARATION"
+# shellcheck source=../flow/roborev-review-oracles.sh
+elif ! source "$ARTIFACT_DECLARATION"; then
+  ARTIFACT_DECLARATION_DETAIL="declaring file failed to source: $ARTIFACT_DECLARATION"
+else
+  _declared_globs=0
+  if [ -n "${CODE_FREE_ARTIFACT_DIR_GLOBS+x}" ]; then
+    _declared_globs=${#CODE_FREE_ARTIFACT_DIR_GLOBS[@]}
+  fi
+  if [ -z "${CODE_FREE_ARTIFACT_EXTENSIONS:-}" ]; then
+    ARTIFACT_DECLARATION_DETAIL="CODE_FREE_ARTIFACT_EXTENSIONS is empty or undefined"
+  elif [ "$_declared_globs" -lt 1 ]; then
+    ARTIFACT_DECLARATION_DETAIL="CODE_FREE_ARTIFACT_DIR_GLOBS has no elements"
+  elif ! declare -F roborev_path_in_artifact_dir >/dev/null 2>&1; then
+    ARTIFACT_DECLARATION_DETAIL="roborev_path_in_artifact_dir is not defined"
+  else
+    ARTIFACT_DECLARATION_STATUS="ok"
+    ARTIFACT_DECLARATION_DETAIL="imported from $ARTIFACT_DECLARATION"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# BUCKETING the imported extension set (issue #3250). The two subsystems ask
+# different questions of the same material — #3229 asks "must a REVIEWER see
+# this?", this script asks "must the CORRECTNESS GATE run?" — so the shared
+# declaration is the answer to one sub-question ("what is committed run output
+# beside a report") and the bucketing below is this classifier's own.
+#
+# Doctrine (CLAUDE.md): "exclusion of code-bearing formats MUST be scoped by
+# directory, never by extension alone", because "an extension describes a
+# FORMAT; a directory records an INTENT". So:
+#
+#   inert       — documentation ANYWHERE under docs/. No pr-gate-core step reads
+#                 a run dump, and no gate component treats one as a contract.
+#                 `jsonl` is the load-bearing member: a purely directory-scoped
+#                 rule would force the ~14-minute core on every flow-finalize
+#                 telemetry PR, one per delivery cycle, for a one-line append.
+#   code-bearing— documentation ONLY inside an artifact-bearing directory. The
+#                 falsifying cases are the Grafana dashboard the gate's own
+#                 kit-dashboard-drift component guards, and the schema governing
+#                 the delivery ledger: both are functional, both live under
+#                 docs/, neither is a report artifact.
+#   image-layer — answered by L1 first (the pre-existing repo-wide image
+#                 allowlist, untouched here); listed so the buckets PARTITION
+#                 the imported set and the self-test can prove it.
+#
+# An imported extension in NO bucket classifies `full` at runtime AND FAILs the
+# self-test naming the extension and issue #3250 — the mechanical disagreement
+# check, aimed at the only place drift remains possible once the list itself is
+# imported.
+# ---------------------------------------------------------------------------
+CLASSIFY_INERT_ARTIFACT_EXTENSIONS="txt jsonl log err csv gz pdf jfr mmd tex diff"
+CLASSIFY_CODE_BEARING_ARTIFACT_EXTENSIONS="json html"
+CLASSIFY_IMAGE_LAYER_ARTIFACT_EXTENSIONS="png svg"
+
+# _ext_in_list <extension> <space-separated list> -> 0 when present.
+_ext_in_list() {
+  local needle="$1" candidate
+  # shellcheck disable=SC2086  # intentional word-split of the space-separated list
+  for candidate in $2; do
+    [ "$candidate" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# docs_path_is_documentation <path-under-docs/> -> 0 when the path is
+# documentation. THE ONLY place a path under `docs/` is classified (#3250): the
+# defect this replaced was not one wrong `case` arm but a verdict reachable from
+# a PATH SHAPE instead of a NAMED CLASS, which left the next `docs/`-shaped arm
+# one edit away. The layers below are a disjunction over DISJOINT extension
+# sets, so permuting them cannot change an answer.
+docs_path_is_documentation() {
+  local path="$1" base ext
+
+  # An unusable import fails CLOSED for EVERY path under docs/ — including
+  # prose. Degrading to "L1 only and carry on" would let an infra fault produce
+  # a MORE PERMISSIVE gate, which is the shape #3229 named as an unmeasurable
+  # input reaching a permissive branch.
+  [ "$ARTIFACT_DECLARATION_STATUS" = "ok" ] || return 1
+
+  base="${path##*/}"
+
+  # L1 — prose / image / legal, at any depth. This classifier's own semantics.
+  case "$base" in
+    *.md | *.markdown) return 0 ;;
+    *.png | *.jpg | *.jpeg | *.gif | *.svg | *.webp | *.ico) return 0 ;;
+    LICENSE | LICENSE.* | NOTICE | NOTICE.*) return 0 ;;
+  esac
+
+  # No extension at all => full, unconditionally, with no mode lookup.
+  case "$base" in
+    *.*) ext="${base##*.}" ;;
+    *) return 1 ;;
+  esac
+
+  # L2 / L3 — a report artifact is one the SINGLE DECLARATION recognises AND
+  # this classifier has bucketed. Both conditions are required, so removing an
+  # extension upstream tightens this gate and adding one leaves it closed until
+  # the extension is bucketed here deliberately.
+  _ext_in_list "$ext" "$CODE_FREE_ARTIFACT_EXTENSIONS" || return 1
+
+  # L2 — inert: documentation anywhere under docs/.
+  if _ext_in_list "$ext" "$CLASSIFY_INERT_ARTIFACT_EXTENSIONS"; then
+    return 0
+  fi
+
+  # L3 — code-bearing: documentation only inside an artifact-bearing directory.
+  if _ext_in_list "$ext" "$CLASSIFY_CODE_BEARING_ARTIFACT_EXTENSIONS"; then
+    if roborev_path_in_artifact_dir "$path"; then
+      return 0
+    fi
+    return 1
+  fi
+
+  # Imported but unbucketed (or an image extension, already answered by L1 and
+  # therefore unreachable here) => fail closed.
+  return 1
+}
 
 # is_docs_file <path> -> 0 if the single path is unambiguously a docs file.
 # Fail-closed: unrecognized => 1 (not docs).
@@ -42,8 +231,25 @@ is_docs_file() {
     .github/* | scripts/* | test-data/*) return 1 ;;
   esac
 
+  # THE RAW-PATH BOUNDARY (issue #3250), fixed once, here. `git diff
+  # --name-only` C-QUOTES a path containing non-ASCII or control bytes, and a
+  # quoted spelling like "docs/\303\251.md" has apparent extension `md"` — so an
+  # extension-based verdict read off it would be an accident of spelling.
+  # pr-gate.yml therefore passes `core.quotePath=false`, and any spelling that
+  # still arrives quoted is not a raw repo-relative path and fails closed. A
+  # path containing a control character stays unrepresentable in a
+  # newline-delimited stream, and is closed by this rule rather than by
+  # assuming it cannot occur.
   case "$path" in
-    docs/*) return 0 ;;
+    '"'*) return 1 ;;
+  esac
+
+  # THE SINGLE DISPATCH: one address for "classify a path under docs/".
+  case "$path" in
+    docs/*) docs_path_is_documentation "$path"; return $? ;;
+  esac
+
+  case "$path" in
     *.md | *.markdown) return 0 ;;
     *.png | *.jpg | *.jpeg | *.gif | *.svg | *.webp | *.ico) return 0 ;;
     LICENSE | LICENSE.* | NOTICE | NOTICE.*) return 0 ;;
@@ -55,6 +261,11 @@ main() {
   local saw_file=0
   local path
   local non_docs=""
+
+  if [ "$ARTIFACT_DECLARATION_STATUS" != "ok" ]; then
+    echo "classify-docs-only: artifact-declaration-unusable ($ARTIFACT_DECLARATION_DETAIL)" \
+      "-> EVERY path under docs/ forces the FULL PATH (fail-closed, #3250)" >&2
+  fi
 
   while IFS= read -r path || [ -n "$path" ]; do
     # Skip blank lines (trailing newline, empty diff output).
@@ -74,7 +285,15 @@ main() {
 
   if [ -n "$non_docs" ]; then
     echo "full"
-    echo "classify-docs-only: non-docs file '$non_docs' -> FULL PATH (fail-closed)" >&2
+    case "$non_docs" in
+      '"'*)
+        echo "classify-docs-only: '$non_docs' is not a raw repo-relative path" \
+          "(C-quoted spelling) -> FULL PATH (fail-closed, #3250)" >&2
+        ;;
+      *)
+        echo "classify-docs-only: non-docs file '$non_docs' -> FULL PATH (fail-closed)" >&2
+        ;;
+    esac
     return 1
   fi
 

--- a/scripts/ci/classify-docs-only.sh
+++ b/scripts/ci/classify-docs-only.sh
@@ -185,10 +185,20 @@ docs_path_is_documentation() {
   base="${path##*/}"
 
   # L1 — prose / image / legal, at any depth. This classifier's own semantics.
+  #
+  # The legal names are an EXACT-NAME plus CLOSED-PROSE-SUFFIX allowlist, never a
+  # `LICENSE.*` wildcard (roborev round 1, High): a wildcard suffix accepts ANY
+  # extension, so `docs/tools/LICENSE.sh` and `docs/observability/NOTICE.json`
+  # would be documentation — the very bypass class this change exists to close,
+  # and a direct contradiction of both the fail-closed rule for unrecognized
+  # extensions and the directory scoping of code-bearing formats. Measured before
+  # tightening: only 3 LICENSE/NOTICE files are tracked repo-wide and all 3 carry
+  # the exact extensionless name, so this regresses nothing real.
   case "$base" in
     *.md | *.markdown) return 0 ;;
     *.png | *.jpg | *.jpeg | *.gif | *.svg | *.webp | *.ico) return 0 ;;
-    LICENSE | LICENSE.* | NOTICE | NOTICE.*) return 0 ;;
+    LICENSE | LICENSE.md | LICENSE.markdown | LICENSE.txt | LICENSE.rst) return 0 ;;
+    NOTICE | NOTICE.md | NOTICE.markdown | NOTICE.txt | NOTICE.rst) return 0 ;;
   esac
 
   # No extension at all => full, unconditionally, with no mode lookup.
@@ -249,10 +259,21 @@ is_docs_file() {
     docs/*) docs_path_is_documentation "$path"; return $? ;;
   esac
 
+  # The global legal arm carries the same exact-name + closed-prose-suffix
+  # allowlist as L1, for the same reason. The `LICENSE.*` wildcard here was
+  # PRE-EXISTING (it long predates issue #3250 and this change did not introduce
+  # it), and it let a root-level `LICENSE.sh` short-circuit the gate. It is fixed
+  # opportunistically because it is the identical one-line defect in the function
+  # this change hardens, and leaving a known gate bypass in place merely because
+  # it predates the change would be indefensible. Deliberately still anchored to
+  # the WHOLE path, exactly as before: making it match a basename would WIDEN the
+  # fast path to nested legal files outside `docs/` (e.g. `bindings/node/LICENSE`,
+  # `full` before and after), which is a loosening this change does not make.
   case "$path" in
     *.md | *.markdown) return 0 ;;
     *.png | *.jpg | *.jpeg | *.gif | *.svg | *.webp | *.ico) return 0 ;;
-    LICENSE | LICENSE.* | NOTICE | NOTICE.*) return 0 ;;
+    LICENSE | LICENSE.md | LICENSE.markdown | LICENSE.txt | LICENSE.rst) return 0 ;;
+    NOTICE | NOTICE.md | NOTICE.markdown | NOTICE.txt | NOTICE.rst) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/tests/test_classify_docs_only.sh
+++ b/scripts/tests/test_classify_docs_only.sh
@@ -89,6 +89,407 @@ assert_full "md under scripts (smuggle)"  $'scripts/notes.md\n'
 assert_full "md under test-data (smuggle)" $'test-data/README.md\n'
 assert_full "docs + smuggled workflow md" $'docs/ok.md\n.github/CONTRIBUTING.md\n'
 
+# ===========================================================================
+# ISSUE #3250 — a `docs/` path prefix is no longer a verdict.
+#
+# The classifier used to answer `docs-only` for ANY path under `docs/`, and this
+# repository ships measurement harnesses under `docs/reports/*-artifacts/` BY
+# CONVENTION, so three merged PRs reported `required` green in 13-16 s having
+# compiled and tested nothing. A path under `docs/` is now documentation ONLY on
+# an affirmative allowlist match, with the artifact declaration IMPORTED from
+# #3229's single declaration (`scripts/flow/roborev-review-oracles.sh`).
+#
+# Everything below is ADDITIVE: every assertion above is unchanged.
+# ===========================================================================
+ORACLES="$REPO_ROOT/scripts/flow/roborev-review-oracles.sh"
+[ -f "$ORACLES" ] || { echo "FATAL: artifact declaration missing: $ORACLES" >&2; exit 1; }
+
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/classify-docs-only-3250.XXXXXX")
+cleanup_3250() { rm -rf "$TMPROOT"; }
+trap cleanup_3250 EXIT
+
+# --- reading the REAL declaration, never a fixture mirror -------------------
+# A symmetric copy of a production constant is not a test: it shares any defect
+# in the original, so both sides agree and the suite is green while the gate is
+# broken (#3042's blindness, in shell). Every assertion that needs the artifact
+# extension set or the directory globs reads them from the declaring FILE.
+decl_extensions() {  # <declaring-file>
+  bash -c 'set -uo pipefail; source "$1" >/dev/null 2>&1 || exit 1
+           printf "%s" "${CODE_FREE_ARTIFACT_EXTENSIONS:-}"' _ "$1"
+}
+decl_globs() {       # <declaring-file> -> one glob per line
+  bash -c 'set -uo pipefail; source "$1" >/dev/null 2>&1 || exit 1
+           printf "%s\n" "${CODE_FREE_ARTIFACT_DIR_GLOBS[@]:-}"' _ "$1"
+}
+
+# assert_full_reason <label> <file-list> <ERE the STDERR reason must match>
+# Fail-closed verdicts must NAME their cause: a `full` with no reason is
+# indistinguishable from a `full` for the wrong reason.
+assert_full_reason() {
+  local label="$1" input="$2" want="$3" out rc errf
+  errf="$TMPROOT/err.$$"
+  out=$(printf '%s' "$input" | bash "$CLASSIFY" 2>"$errf")
+  rc=$?
+  if [ "$rc" -eq 1 ] && [ "$out" = "full" ] && grep -Eq "$want" "$errf"; then
+    ok "$label (full + reason matches /$want/)"
+  else
+    bad "$label (expected exit 1/full + reason /$want/, got exit $rc/'$out' reason: $(tr '\n' ' ' <"$errf"))"
+  fi
+  rm -f "$errf"
+}
+
+echo "== (d) #3250: executables and config-as-code under docs/ force the FULL path =="
+assert_full "harness .sh under an artifact dir" $'docs/reports/ws0-3217-artifacts/harness/common.sh\n'
+assert_full "harness .py under an artifact dir" $'docs/reports/ws0-3026-artifacts/ws0-h2h/cas-scan.py\n'
+assert_full "harness .bt under an artifact dir" $'docs/reports/ws0-3026-artifacts/ws0-corpus/trace-scan.bt\n'
+assert_full "docs-hosted Cargo.toml alone"      $'docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/Cargo.toml\n'
+assert_full "docs-hosted src/main.rs alone"     $'docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/src/main.rs\n'
+assert_full "docs-hosted crate (both files)"    $'docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/Cargo.toml\ndocs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/src/main.rs\n'
+assert_full "extensionless harness (no mode read)" $'docs/reports/ws0-3026-artifacts/ws0-results/ws0-readbw\n'
+assert_full "space-bearing harness .sh"         $'docs/reports/ws0-3217-artifacts/harness/run all.sh\n'
+assert_full "unrecognized extension .rb"        $'docs/tools/run.rb\n'
+assert_full "unrecognized extension .jq"        $'docs/tools/query.jq\n'
+assert_full "unrecognized extension .mjs"       $'docs/tools/build.mjs\n'
+assert_full "grafana dashboard json (functional config)" $'docs/observability/grafana/dashboards/cqlite-overview.json\n'
+assert_full "telemetry schema json"             $'docs/reports/delivery-telemetry.schema.json\n'
+assert_full "dashboard json among prose"        $'docs/a.md\ndocs/observability/grafana/dashboards/cqlite-overview.json\ndocs/b.md\n'
+assert_full "schema json among prose"           $'docs/a.md\ndocs/reports/delivery-telemetry.schema.json\n'
+# A bash `case` glob crosses `/`; git's `:(glob)` `*` does not. The imported
+# component-wise matcher must agree with the pathspec, not approximate it.
+assert_full "separator-crossing pseudo-artifact dir" $'docs/reports/a/b-artifacts/x.json\n'
+# The real PR #3222 shape: 34 executables among 154 prose paths. Order must not
+# decide, so the same set is asserted with the executable last AND first.
+PROSE20=""
+_i=1
+while [ "$_i" -le 20 ]; do
+  PROSE20="${PROSE20}docs/reports/ws0-3217-artifacts/note-${_i}.md"$'\n'
+  _i=$((_i + 1))
+done
+assert_full "one .py LAST among 20 prose files"  "${PROSE20}docs/reports/ws0-3217-artifacts/harness/emit-point.py"$'\n'
+assert_full "one .py FIRST among 20 prose files" $'docs/reports/ws0-3217-artifacts/harness/emit-point.py\n'"${PROSE20}"
+assert_full "prose sibling does not rescue the set" $'docs/reports/ws0-3217-artifacts/README.md\ndocs/reports/ws0-3217-artifacts/harness/parse-runqlat.py\n'
+# The raw-path boundary (one place, #3229's six-blocker lesson applied once).
+assert_full_reason "C-quoted spelling fails closed" $'"docs/\\303\\251-notes.md"\n' 'not a raw repo-relative path'
+
+echo "== (e) #3250: prose, images, legal text and report artifacts still short-circuit =="
+assert_docs_only "prose + image + svg + legal" $'docs/development/dev-cookbook.md\ndocs/img/diagram.png\ndocs/img/x.svg\nREADME.md\nCHANGELOG.markdown\nLICENSE\n'
+assert_docs_only "WS0 report set (prose + inert + json in artifact dir)" $'docs/reports/ws0-3217-artifacts/README.md\ndocs/reports/ws0-3217-artifacts/results/run.txt\ndocs/reports/ws0-3217-artifacts/results/points.jsonl\ndocs/reports/ws0-3217-artifacts/results/summary.csv\ndocs/reports/ws0-3217-artifacts/results/driver.log\ndocs/reports/ws0-3217-artifacts/results/driver.err\ndocs/reports/ws0-3217-artifacts/results/curve.png\ndocs/reports/ws0-3217-artifacts/results/profile.json\n'
+# The inert bucket exists for exactly this row: a purely directory-scoped rule
+# would force the ~14-minute core on every flow-finalize telemetry PR.
+assert_docs_only "delivery telemetry ledger (.jsonl outside an artifact dir)" $'docs/reports/delivery-telemetry.jsonl\n'
+assert_docs_only "pandoc header (.tex outside an artifact dir)" $'docs/sstables-definitive-guide/pandoc-header.tex\n'
+assert_docs_only "annotated dump (.txt outside an artifact dir)" $'docs/sstables-definitive-guide/statistics-db-annotated-dump.txt\n'
+assert_docs_only "photo extensions outside the imported set" $'docs/img/photo.jpg\ndocs/img/anim.gif\ndocs/img/favicon.ico\n'
+assert_docs_only "json inside an artifact dir"  $'docs/reports/ws0-3217-artifacts/x.json\n'
+assert_docs_only "html under a nested jfr-reports glob" $'docs/observability/jfr-reports/run.html\n'
+assert_docs_only "json deep under round-artifacts" $'docs/round-artifacts/2026-08/deep/nested/out.json\n'
+assert_docs_only "html under round-artifacts"   $'docs/round-artifacts/soak/report.html\n'
+assert_docs_only "svg under the diagrams dir"   $'docs/sstables-definitive-guide/diagrams/partition-layout.svg\n'
+assert_docs_only "raw non-ASCII prose path"     $'docs/\303\251-notes.md\n'
+assert_docs_only "space-bearing prose path"     $'docs/research/CQLite Writes (M5) \342\200\224 notes.md\n'
+
+echo "== (f) #3250: ONE canonical decision point for a docs/ path (structural) =="
+# docs_case_arms <file>: one line per `case` ARM whose PATTERN mentions `docs/`,
+# as "<first-line-number>:<arm text, multi-line arms joined>". Joining is what
+# stops a blanket arm hiding by putting `return 0` on its own line.
+docs_case_arms() {
+  awk '
+    function emit() { printf "%d:%s\n", start, body; in_arm = 0; body = "" }
+    /^[[:space:]]*#/ { next }
+    in_arm { body = body " " $0; if ($0 ~ /;;/) emit(); next }
+    {
+      if (index($0, ")") == 0) next
+      pat = $0; sub(/\).*/, "", pat)
+      if (pat !~ /docs\//) next
+      start = NR; body = $0; in_arm = 1
+      if ($0 ~ /;;/) emit()
+    }
+    END { if (in_arm) emit() }
+  ' "$1"
+}
+fn_body_range() {  # <file> <fn-name> -> "<first-line> <last-line>"
+  awk -v fn="$2" '
+    $0 ~ "^"fn"\\(\\)[[:space:]]*\\{" { s = NR; inside = 1; next }
+    inside && /^}/ { print s, NR; inside = 0 }
+  ' "$1"
+}
+# S1: no docs/ arm may reach a verdict itself — it may only dispatch.
+structural_s1_reason() {
+  local f="$1" line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      *docs_path_is_documentation*) continue ;;
+    esac
+    printf 'S1: docs/ case arm at line %s decides a verdict instead of dispatching: %s\n' \
+      "${line%%:*}" "${line#*:}"
+  done < <(docs_case_arms "$f")
+}
+# S2/S3: exactly ONE docs/ arm, inside is_docs_file, and ONE dispatch target.
+structural_s2_reason() {
+  local f="$1" arms n range lo hi ln no defs
+  arms=$(docs_case_arms "$f")
+  n=$(printf '%s\n' "$arms" | grep -c '[^[:space:]]')
+  [ "$n" -eq 1 ] || printf 'S2: expected exactly ONE docs/ case arm (the single dispatch), found %s\n' "$n"
+  range=$(fn_body_range "$f" is_docs_file)
+  if [ -z "$range" ]; then
+    printf 'S2: is_docs_file() not found in %s\n' "$f"
+  else
+    lo=${range%% *}; hi=${range##* }
+    while IFS= read -r ln; do
+      [ -n "$ln" ] || continue
+      no=${ln%%:*}
+      if [ "$no" -lt "$lo" ] || [ "$no" -gt "$hi" ]; then
+        printf 'S2: a SECOND docs/ decision site outside is_docs_file() at line %s: %s\n' "$no" "${ln#*:}"
+      fi
+    done < <(printf '%s\n' "$arms")
+  fi
+  defs=$(grep -cE '^docs_path_is_documentation\(\)[[:space:]]*\{' "$f")
+  [ "$defs" -eq 1 ] || printf 'S3: docs_path_is_documentation() defined %s time(s), expected 1\n' "$defs"
+}
+structural_reason() { structural_s1_reason "$1"; structural_s2_reason "$1"; }
+
+_r=$(structural_reason "$CLASSIFY")
+if [ -z "$_r" ]; then
+  ok "classifier has exactly one docs/ decision point (single dispatch in is_docs_file)"
+else
+  bad "classifier structure (#3250): $(printf '%s' "$_r" | tr '\n' '|')"
+fi
+
+# MUTATION-TESTING THE STRUCTURAL ASSERTS. An assert that cannot fail on the
+# reintroduced defect is not an assert.
+MUT_BLANKET="$TMPROOT/mut-blanket-arm.sh"
+awk '{ print; if (!ins && $0 ~ /^[[:space:]]*docs\/\*\)/) { print "    docs/*) return 0 ;;"; ins = 1 } }' \
+  "$CLASSIFY" >"$MUT_BLANKET"
+if cmp -s "$MUT_BLANKET" "$CLASSIFY"; then
+  bad "mutation 1 (blanket docs/* arm) did not apply — the assertion below would be vacuous"
+else
+  ok "mutation 1 (blanket docs/* arm) applied"
+  [ -n "$(structural_reason "$MUT_BLANKET")" ] \
+    && ok "structural assert FAILs a reintroduced blanket 'docs/*) return 0' arm" \
+    || bad "structural assert did NOT catch a reintroduced blanket 'docs/*) return 0' arm"
+fi
+
+MUT_MULTILINE="$TMPROOT/mut-multiline-arm.sh"
+awk '{ print; if (!ins && $0 ~ /^[[:space:]]*docs\/\*\)/) { print "    docs/legacy/*)"; print "      return 0"; print "      ;;"; ins = 1 } }' \
+  "$CLASSIFY" >"$MUT_MULTILINE"
+if cmp -s "$MUT_MULTILINE" "$CLASSIFY"; then
+  bad "mutation 2 (multi-line docs/ arm) did not apply — the assertion below would be vacuous"
+else
+  ok "mutation 2 (multi-line docs/ arm) applied"
+  [ -n "$(structural_reason "$MUT_MULTILINE")" ] \
+    && ok "structural assert FAILs a MULTI-LINE blanket docs/ arm (return 0 on its own line)" \
+    || bad "structural assert did NOT catch a multi-line blanket docs/ arm"
+fi
+
+MUT_SECOND="$TMPROOT/mut-second-site.sh"
+awk '
+  !ins && /^main\(\)[[:space:]]*\{/ {
+    print "docs_legacy_gate() {"
+    print "  case \"$1\" in"
+    print "    docs/*) docs_path_is_documentation \"$1\"; return $? ;;"
+    print "  esac"
+    print "  return 1"
+    print "}"
+    print ""
+    ins = 1
+  }
+  { print }
+' "$CLASSIFY" >"$MUT_SECOND"
+if cmp -s "$MUT_SECOND" "$CLASSIFY"; then
+  bad "mutation 3 (second decision site) did not apply — the assertions below would be vacuous"
+else
+  ok "mutation 3 (second decision site) applied"
+  [ -n "$(structural_reason "$MUT_SECOND")" ] \
+    && ok "structural assert FAILs a SECOND docs/ decision site" \
+    || bad "structural assert did NOT catch a second docs/ decision site"
+  # The second site DISPATCHES, so S1 cannot see it: this proves the arm-count /
+  # location half (S2) is load-bearing rather than redundant with S1.
+  [ -z "$(structural_s1_reason "$MUT_SECOND")" ] \
+    && ok "second-site mutant is invisible to S1, so S2 is proven load-bearing" \
+    || bad "second-site mutant was caught by S1, so S2 remains unproven"
+fi
+
+echo "== (g) #3250: the artifact declaration is IMPORTED, never restated (AC5) =="
+_exts=$(decl_extensions "$ORACLES")
+if [ -z "$_exts" ]; then
+  bad "could not read CODE_FREE_ARTIFACT_EXTENSIONS from $ORACLES"
+elif grep -Fq "$_exts" "$CLASSIFY"; then
+  bad "classifier holds a LITERAL COPY of the imported artifact extension list (#3250 AC5)"
+else
+  ok "classifier holds no literal copy of the imported artifact extension list"
+fi
+_glob_copies=""
+while IFS= read -r _g; do
+  [ -n "$_g" ] || continue
+  if grep -Fq "$_g" "$CLASSIFY"; then _glob_copies="$_glob_copies $_g"; fi
+done < <(decl_globs "$ORACLES")
+if [ -n "$_glob_copies" ]; then
+  bad "classifier holds a LITERAL COPY of artifact directory glob(s):$_glob_copies (#3250 AC5)"
+else
+  ok "classifier holds no literal copy of any artifact directory glob"
+fi
+
+# The buckets must PARTITION the imported set: an extension #3229 adds upstream
+# must be assigned here deliberately, and an unassigned one fails closed.
+partition_reason() {  # <classifier> <declaring-file>
+  local f="$1" o="$2" imported inert code img all e b n
+  imported=$(decl_extensions "$o")
+  inert=$(sed -n 's/^CLASSIFY_INERT_ARTIFACT_EXTENSIONS="\(.*\)"$/\1/p' "$f")
+  code=$(sed -n 's/^CLASSIFY_CODE_BEARING_ARTIFACT_EXTENSIONS="\(.*\)"$/\1/p' "$f")
+  img=$(sed -n 's/^CLASSIFY_IMAGE_LAYER_ARTIFACT_EXTENSIONS="\(.*\)"$/\1/p' "$f")
+  if [ -z "$imported" ]; then
+    printf 'partition: could not read CODE_FREE_ARTIFACT_EXTENSIONS from %s\n' "$o"
+    return 0
+  fi
+  if [ -z "$inert$code$img" ]; then
+    printf 'partition: could not read the CLASSIFY_*_ARTIFACT_EXTENSIONS buckets from %s\n' "$f"
+    return 0
+  fi
+  all="$inert $code $img"
+  for e in $imported; do
+    n=0
+    for b in $all; do [ "$b" = "$e" ] && n=$((n + 1)); done
+    [ "$n" -eq 1 ] || printf 'partition: imported extension "%s" is in %s bucket(s), expected exactly 1 — assign it in scripts/ci/classify-docs-only.sh (issue #3250)\n' "$e" "$n"
+  done
+  for b in $all; do
+    n=0
+    for e in $imported; do [ "$b" = "$e" ] && n=$((n + 1)); done
+    [ "$n" -eq 1 ] || printf 'partition: bucketed extension "%s" is not in the imported declaration (issue #3250)\n' "$b"
+  done
+}
+_r=$(partition_reason "$CLASSIFY" "$ORACLES")
+if [ -z "$_r" ]; then
+  ok "the inert/code-bearing/image-layer buckets partition the imported extension set exactly"
+else
+  bad "bucket partition (#3250): $(printf '%s' "$_r" | tr '\n' '|')"
+fi
+
+# --- the import, mutated in a temp tree ------------------------------------
+# The classifier resolves its import relative to its OWN location, which is what
+# makes this possible: a copy of the classifier beside a MUTATED copy of the real
+# declaration must return DIFFERENT verdicts. A classifier carrying its own
+# hardcoded lists returns the unchanged verdicts and fails here.
+make_tree() {  # <dir>
+  mkdir -p "$1/scripts/ci" "$1/scripts/flow"
+  cp "$CLASSIFY" "$1/scripts/ci/classify-docs-only.sh"
+  cp "$ORACLES" "$1/scripts/flow/roborev-review-oracles.sh"
+}
+assert_tree() {  # <label> <tree-dir> <file-list> <docs-only|full>
+  local label="$1" d="$2" input="$3" want="$4" out rc wantrc=1
+  [ "$want" = "docs-only" ] && wantrc=0
+  out=$(printf '%s' "$input" | bash "$d/scripts/ci/classify-docs-only.sh" 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq "$wantrc" ] && [ "$out" = "$want" ]; then
+    ok "$label (=> $want)"
+  else
+    bad "$label (expected $wantrc/$want, got $rc/'$out')"
+  fi
+}
+assert_tree_mutated() {  # <label> <tree-dir> <relative-file>
+  if cmp -s "$2/$3" "$REPO_ROOT/$3"; then
+    bad "$1 (mutation did not apply — the assertion below would be vacuous)"
+  else
+    ok "$1 (mutation applied)"
+  fi
+}
+
+TXT_IN_ARTIFACT_DIR=$'docs/reports/ws0-3217-artifacts/results/run.txt\n'
+HTML_IN_ROUND_ARTIFACTS=$'docs/round-artifacts/soak/report.html\n'
+SYNTHETIC_EXT_PATH=$'docs/reports/ws0-3217-artifacts/results/out.zzz\n'
+
+T_BASE="$TMPROOT/t-baseline"; make_tree "$T_BASE"
+assert_tree "baseline tree: inert .txt in an artifact dir" "$T_BASE" "$TXT_IN_ARTIFACT_DIR" docs-only
+assert_tree "baseline tree: .html under round-artifacts"   "$T_BASE" "$HTML_IN_ROUND_ARTIFACTS" docs-only
+assert_tree "baseline tree: synthetic .zzz extension"      "$T_BASE" "$SYNTHETIC_EXT_PATH" full
+
+T_NOTXT="$TMPROOT/t-decl-minus-txt"; make_tree "$T_NOTXT"
+sed -i.bak 's/^CODE_FREE_ARTIFACT_EXTENSIONS="txt /CODE_FREE_ARTIFACT_EXTENSIONS="/' \
+  "$T_NOTXT/scripts/flow/roborev-review-oracles.sh"
+rm -f "$T_NOTXT/scripts/flow/roborev-review-oracles.sh.bak"
+assert_tree_mutated "declaration mutation: 'txt' removed from the imported set" \
+  "$T_NOTXT" scripts/flow/roborev-review-oracles.sh
+assert_tree "declaration without 'txt': .txt verdict MOVES to full" "$T_NOTXT" "$TXT_IN_ARTIFACT_DIR" full
+
+T_NOGLOB="$TMPROOT/t-decl-minus-glob"; make_tree "$T_NOGLOB"
+sed -i.bak "/^  'docs\/round-artifacts'$/d" "$T_NOGLOB/scripts/flow/roborev-review-oracles.sh"
+rm -f "$T_NOGLOB/scripts/flow/roborev-review-oracles.sh.bak"
+assert_tree_mutated "declaration mutation: one directory glob removed" \
+  "$T_NOGLOB" scripts/flow/roborev-review-oracles.sh
+assert_tree "declaration without that glob: .html verdict MOVES to full" "$T_NOGLOB" "$HTML_IN_ROUND_ARTIFACTS" full
+
+# A synthetic extension added UPSTREAM ONLY is unassigned here, so it fails
+# CLOSED at runtime and the partition assert names it.
+T_SYNTH="$TMPROOT/t-decl-plus-synthetic"; make_tree "$T_SYNTH"
+sed -i.bak 's/^CODE_FREE_ARTIFACT_EXTENSIONS="\(.*\)"$/CODE_FREE_ARTIFACT_EXTENSIONS="\1 zzz"/' \
+  "$T_SYNTH/scripts/flow/roborev-review-oracles.sh"
+rm -f "$T_SYNTH/scripts/flow/roborev-review-oracles.sh.bak"
+assert_tree_mutated "declaration mutation: synthetic extension added upstream" \
+  "$T_SYNTH" scripts/flow/roborev-review-oracles.sh
+assert_tree "upstream-only synthetic extension fails CLOSED" "$T_SYNTH" "$SYNTHETIC_EXT_PATH" full
+_r=$(partition_reason "$T_SYNTH/scripts/ci/classify-docs-only.sh" "$T_SYNTH/scripts/flow/roborev-review-oracles.sh")
+if printf '%s' "$_r" | grep -q 'zzz' && printf '%s' "$_r" | grep -q '#3250'; then
+  ok "partition assert FAILs on an unassigned upstream extension, naming it and #3250"
+else
+  bad "partition assert did not name the unassigned extension and #3250 (got: $(printf '%s' "$_r" | tr '\n' '|'))"
+fi
+
+# Assigned on BOTH sides, the verdict moves to docs-only; assigned only in the
+# classifier, it does NOT — which is what proves the DECLARATION is authoritative.
+T_BOTH="$TMPROOT/t-both-sides"; make_tree "$T_BOTH"
+sed -i.bak 's/^CODE_FREE_ARTIFACT_EXTENSIONS="\(.*\)"$/CODE_FREE_ARTIFACT_EXTENSIONS="\1 zzz"/' \
+  "$T_BOTH/scripts/flow/roborev-review-oracles.sh"
+sed -i.bak 's/^CLASSIFY_INERT_ARTIFACT_EXTENSIONS="/CLASSIFY_INERT_ARTIFACT_EXTENSIONS="zzz /' \
+  "$T_BOTH/scripts/ci/classify-docs-only.sh"
+rm -f "$T_BOTH"/scripts/flow/*.bak "$T_BOTH"/scripts/ci/*.bak
+assert_tree_mutated "two-sided mutation: declaration" "$T_BOTH" scripts/flow/roborev-review-oracles.sh
+assert_tree_mutated "two-sided mutation: classifier bucket" "$T_BOTH" scripts/ci/classify-docs-only.sh
+assert_tree "synthetic extension declared AND bucketed: verdict MOVES to docs-only" "$T_BOTH" "$SYNTHETIC_EXT_PATH" docs-only
+
+T_LOCAL="$TMPROOT/t-classifier-only"; make_tree "$T_LOCAL"
+sed -i.bak 's/^CLASSIFY_INERT_ARTIFACT_EXTENSIONS="/CLASSIFY_INERT_ARTIFACT_EXTENSIONS="zzz /' \
+  "$T_LOCAL/scripts/ci/classify-docs-only.sh"
+rm -f "$T_LOCAL"/scripts/ci/*.bak
+assert_tree_mutated "classifier-only mutation: bucket extended" "$T_LOCAL" scripts/ci/classify-docs-only.sh
+assert_tree "bucketed but NOT declared: still full (declaration is authoritative)" "$T_LOCAL" "$SYNTHETIC_EXT_PATH" full
+
+echo "== (h) #3250: an unusable import fails CLOSED, never toward prose =="
+# An infra fault must not produce a MORE PERMISSIVE gate, so even prose under
+# docs/ forces the full path when the declaration cannot be used.
+T_ABSENT="$TMPROOT/t-decl-absent"; make_tree "$T_ABSENT"
+rm -f "$T_ABSENT/scripts/flow/roborev-review-oracles.sh"
+assert_tree "declaration absent: inert .txt forces full" "$T_ABSENT" "$TXT_IN_ARTIFACT_DIR" full
+assert_tree "declaration absent: even prose under docs/ forces full" "$T_ABSENT" $'docs/a.md\n' full
+_out=$(printf '%s' "$TXT_IN_ARTIFACT_DIR" | bash "$T_ABSENT/scripts/ci/classify-docs-only.sh" 2>&1 >/dev/null)
+if printf '%s' "$_out" | grep -Eq 'artifact-declaration-unusable'; then
+  ok "declaration absent: reason names the unusable declaration"
+else
+  bad "declaration absent: no named reason (got: $(printf '%s' "$_out" | tr '\n' '|'))"
+fi
+
+T_EMPTY="$TMPROOT/t-decl-empty"; make_tree "$T_EMPTY"
+{ printf '\n%s\n' 'CODE_FREE_ARTIFACT_EXTENSIONS=""'; printf '%s\n' 'CODE_FREE_ARTIFACT_DIR_GLOBS=()'; } \
+  >>"$T_EMPTY/scripts/flow/roborev-review-oracles.sh"
+assert_tree_mutated "declaration mutation: emptied" "$T_EMPTY" scripts/flow/roborev-review-oracles.sh
+assert_tree "declaration empty: inert .txt forces full" "$T_EMPTY" "$TXT_IN_ARTIFACT_DIR" full
+assert_tree "declaration empty: even prose under docs/ forces full" "$T_EMPTY" $'docs/a.md\n' full
+_out=$(printf '%s' "$TXT_IN_ARTIFACT_DIR" | bash "$T_EMPTY/scripts/ci/classify-docs-only.sh" 2>&1 >/dev/null)
+if printf '%s' "$_out" | grep -Eq 'artifact-declaration-unusable'; then
+  ok "declaration empty: reason names the unusable declaration"
+else
+  bad "declaration empty: no named reason (got: $(printf '%s' "$_out" | tr '\n' '|'))"
+fi
+
+# Sourcing the declaration must not pollute the classifier's contract: STDOUT
+# stays exactly the one-word verdict.
+_lines=$(printf '%s' $'docs/a.md\n' | bash "$CLASSIFY" 2>/dev/null | wc -l | tr -d ' ')
+_lines_full=$(printf '%s' $'docs/tools/run.rb\n' | bash "$CLASSIFY" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$_lines" = "1" ] && [ "$_lines_full" = "1" ]; then
+  ok "STDOUT is exactly the one-word verdict in both branches (import has no side effects)"
+else
+  bad "STDOUT is not a single line (docs-only branch: $_lines, full branch: $_lines_full)"
+fi
+
 echo "== workflow contract: required status ALWAYS reports =="
 if [ -f "$WORKFLOW" ]; then
   # No path filter on the trigger (would stop the required check from firing).
@@ -96,6 +497,17 @@ if [ -f "$WORKFLOW" ]; then
     bad "pr-gate.yml must NOT use paths/paths-ignore (required check must always fire)"
   else
     ok "pr-gate.yml trigger has no paths/paths-ignore filter"
+  fi
+
+  # Issue #3250: the changed-file list must reach the classifier as RAW
+  # repo-relative paths. `git diff --name-only` C-QUOTES a non-ASCII path by
+  # default, so `docs/é-notes.md` would arrive with apparent extension `md"` —
+  # and the classifier now decides on the extension. `-z` is deliberately NOT
+  # used: it would change the classifier's newline-delimited stdin contract.
+  if grep -Eq 'git -c core\.quotePath=false diff --name-only' "$WORKFLOW"; then
+    ok "pr-gate.yml computes the changed-file list with core.quotePath=false (#3250)"
+  else
+    bad "pr-gate.yml must compute the changed-file list with 'git -c core.quotePath=false diff --name-only' (#3250)"
   fi
 
   # The classifier step itself must have no `if:` gate (always runs).
@@ -110,6 +522,9 @@ if [ -f "$WORKFLOW" ]; then
       abort("no classify step") unless classify
       # Always runs (no if:), and heavy steps are gated on its output.
       abort("classify step must not be gated") if classify.key?("if")
+      # Issue #3250: the raw-path boundary, asserted on the classify step itself
+      # (the grep above pins the spelling; this pins WHICH step carries it).
+      abort("classify step must disable path quoting (core.quotePath=false)") unless classify["run"].to_s.include?("core.quotePath=false")
       gated = steps.select { |s| s.is_a?(Hash) && s["if"].to_s.include?("steps.classify.outputs.docs_only") }
       # Heavy steps = everything the docs-only path must SKIP (all gated steps
       # except the docs-only informational summary, which runs on == 'true').

--- a/scripts/tests/test_classify_docs_only.sh
+++ b/scripts/tests/test_classify_docs_only.sh
@@ -194,11 +194,31 @@ echo "== (f) #3250: ONE canonical decision point for a docs/ path (structural) =
 # stops a blanket arm hiding by putting `return 0` on its own line.
 docs_case_arms() {
   awk '
-    function emit() { printf "%d:%s\n", start, body; in_arm = 0; body = "" }
+    function emit() { printf "%d:%s\n", start, substr(body, 1, 200); in_arm = 0; body = "" }
+    # A `case` ARM PATTERN is a `|`-separated list of glob WORDS terminated by
+    # `)`. Requiring every token to be space-free is what keeps a body line such
+    # as `echo "... docs/ ... (fail-closed, #3250)"` — which also carries a `)`
+    # after a `docs/` — from being misread as an arm.
+    function is_arm_pattern(line,   pat, n, i, toks) {
+      if (index(line, ")") == 0) return 0
+      pat = line
+      sub(/\).*/, "", pat)
+      sub(/^[[:space:]]*\(?[[:space:]]*/, "", pat)
+      sub(/[[:space:]]+$/, "", pat)
+      if (pat == "") return 0
+      n = split(pat, toks, /[[:space:]]*\|[[:space:]]*/)
+      for (i = 1; i <= n; i++) {
+        if (toks[i] == "" || toks[i] ~ /[[:space:]]/) return 0
+      }
+      return 1
+    }
     /^[[:space:]]*#/ { next }
+    { if ($0 ~ /(^|[[:space:]])case[[:space:]].*[[:space:]]in[[:space:]]*$/) case_depth++ }
+    { if ($0 ~ /^[[:space:]]*esac([[:space:]]|;|$)/) case_depth-- }
     in_arm { body = body " " $0; if ($0 ~ /;;/) emit(); next }
     {
-      if (index($0, ")") == 0) next
+      if (case_depth <= 0) next
+      if (!is_arm_pattern($0)) next
       pat = $0; sub(/\).*/, "", pat)
       if (pat !~ /docs\//) next
       start = NR; body = $0; in_arm = 1

--- a/scripts/tests/test_classify_docs_only.sh
+++ b/scripts/tests/test_classify_docs_only.sh
@@ -188,6 +188,38 @@ assert_docs_only "svg under the diagrams dir"   $'docs/sstables-definitive-guide
 assert_docs_only "raw non-ASCII prose path"     $'docs/\303\251-notes.md\n'
 assert_docs_only "space-bearing prose path"     $'docs/research/CQLite Writes (M5) \342\200\224 notes.md\n'
 
+echo "== (e2) #3250 roborev r1 (High): a legal NAME must not launder an extension =="
+# `LICENSE.* | NOTICE.*` accepted ANY extension at any depth, so a legal-looking
+# NAME laundered an executable straight through the gate — the same bypass class
+# this change exists to close. Both arms are now exact-name + closed prose suffix.
+assert_full "LICENSE.sh under docs/"            $'docs/tools/LICENSE.sh\n'
+assert_full "NOTICE.json under docs/"           $'docs/observability/NOTICE.json\n'
+assert_full "LICENSE.py under docs/"            $'docs/foo/LICENSE.py\n'
+# An artifact directory must not rescue a code-bearing legal-named file either.
+assert_full "LICENSE.bt inside an artifact dir" $'docs/reports/ws0-3217-artifacts/LICENSE.bt\n'
+# Root level: the identical wildcard was PRE-EXISTING (not introduced by #3250)
+# and is fixed opportunistically in the same hunk.
+assert_full "LICENSE.sh at the repo root"       $'LICENSE.sh\n'
+assert_full "NOTICE.py at the repo root"        $'NOTICE.py\n'
+# ...and the legitimate legal fast path survives the tightening.
+assert_docs_only "exact LICENSE at the root"    $'LICENSE\n'
+assert_docs_only "exact NOTICE at the root"     $'NOTICE\n'
+assert_docs_only "exact LICENSE under docs/"    $'docs/x/LICENSE\n'
+assert_docs_only "exact NOTICE under docs/"     $'docs/x/NOTICE\n'
+assert_docs_only "LICENSE.md"                   $'LICENSE.md\n'
+assert_docs_only "LICENSE.txt"                  $'LICENSE.txt\n'
+assert_docs_only "NOTICE.rst under docs/"       $'docs/x/NOTICE.rst\n'
+# The three legal files this repo actually tracks, read from git rather than
+# assumed, so the "regresses nothing real" claim is measured and not asserted.
+# Two are NESTED, and a nested legal file was `full` BEFORE this change too (the
+# global arm is anchored to the whole path); #3250 does not widen that.
+while IFS= read -r _legal; do
+  case "$_legal" in
+    */*) assert_full     "tracked legal file (nested, unchanged): $_legal" "$_legal"$'\n' ;;
+    *)   assert_docs_only "tracked legal file (root): $_legal"             "$_legal"$'\n' ;;
+  esac
+done < <(git -C "$REPO_ROOT" ls-files | grep -E '(^|/)(LICENSE|NOTICE)([.][^/]*)?$')
+
 echo "== (f) #3250: ONE canonical decision point for a docs/ path (structural) =="
 # docs_case_arms <file>: one line per `case` ARM whose PATTERN mentions `docs/`,
 # as "<first-line-number>:<arm text, multi-line arms joined>". Joining is what

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -352,6 +352,61 @@ gate. Delta re-certification leans on that nightly as the net for anything a
 test/docs round scoped past. `--delta` (like `--lite` and `--only`) is EXEMPT from
 the machine-wide concurrency cap.
 
+## CITE-AND-WAIVE: waiving a red on a genuinely prose diff (#3042, narrowed by #3250)
+
+A **genuinely prose** diff cannot change the compiled binary, so a test failure in
+its full gate is by definition **pre-existing on `main` or a flake**, and the
+correct response is CITE-AND-WAIVE — never a source patch to turn the gate green
+(that is a real change smuggled in under a docs diff, certified by nothing, and it
+masks the actual main-red).
+
+The waiver's precondition is that the diff touches **no compiled input**: no `src`,
+no `Cargo.*`, no build script, no workflow, no test-data. **That qualifier is a
+path-shape test, and a path shape is not evidence. Don't judge it — run it:**
+
+```bash
+git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh
+# exit 0 => docs-only  (the waiver is available)
+# exit 1 => full       (the waiver does NOT apply — the failure is presumed yours)
+```
+
+`scripts/ci/classify-docs-only.sh` is the same classifier that decides whether
+`pr-gate-core` runs at all, so running it here asks the gate's own question rather
+than a paraphrase of it. It answers documentation only on an **affirmative**
+allowlist match — prose/images/legal text, inert report artifacts under `docs/`,
+and code-bearing report formats (`.json`, `.html`) **only inside** an
+artifact-bearing directory — and fails closed on every unrecognized extension and
+on **every** extensionless path. `scripts/tests/test_classify_docs_only.sh` pins
+that behaviour, and it runs inside the full gate's `tooling-tests` component.
+
+**Why the old wording was unsafe, in one concrete case.** This repository ships
+measurement harnesses under `docs/reports/*-artifacts/` **by convention**, so a
+PR-#3222-shaped diff contains `src/main.rs` **and** `Cargo.toml` under
+`docs/reports/ws0-3026-artifacts/ws0-cqlite/scan-harness/`. It satisfies "no
+`src`, no `Cargo.*`" **textually** while being false **materially** — measured, the
+three merged `docs/`-only PRs #3222 / #3081 / #3216 carried 35 / 30 / 1 executable
+or config-as-code paths and reported `required` green in 13–16 s against a
+~14-minute baseline. An agent correctly following the old text would waive a red
+that was genuinely its own.
+
+Everything else about the rule is unchanged:
+
+1. Confirm the diff really is non-compiling input — with the classifier, not by eye.
+2. Identify the failure as a **known** main-red issue or a known flake; reproduce it
+   on a clean `origin/main` checkout if it is not already filed, and FILE it if not.
+3. Record the waiver in the PR body, naming the failing component **and** the issue
+   number it belongs to. **A waiver with no cited issue is not a waiver — it is an
+   unexplained red.**
+
+Conversely, **if ANY compiled input is in the diff the waiver is void**: the failure
+is presumed yours until proven otherwise.
+
+**Same definition, two sides.** This is the gate-side spelling of the review-side
+rule in [roborev findings](/cqlite/agents-developing/roborev-findings/): "docs-only"
+means a **code-free census**, never a `docs/` path prefix. The two definitions are
+cross-referenced deliberately so they cannot drift apart again — #3229 fixed the
+reviewer's copy of this bug and #3250 fixed the gate's.
+
 ## New-machine setup
 
 A fresh machine that will run the gate should first run

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -188,6 +188,16 @@ terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round 
    **directories** — never a blanket `docs/**`). Measured after the narrowing: 71 `docs/` executables reach
    the reviewer, 0 markdown does, and nothing outside `docs/` is newly excluded.
 
+   **The GATE had the same bug, and it is the same definition (#3250).** `scripts/ci/classify-docs-only.sh`
+   — which decides whether `pr-gate-core`, the compute half of `required`, runs at all — classified every
+   path under `docs/` as documentation on the prefix alone, so the same three PRs reported `required` green
+   in 13–16 s having compiled nothing. It now answers only on an affirmative allowlist match and imports
+   this subsystem's artifact declaration (`CODE_FREE_ARTIFACT_EXTENSIONS`, `CODE_FREE_ARTIFACT_DIR_GLOBS`,
+   `roborev_path_in_artifact_dir`) rather than restating it, so the review-side and gate-side definitions of
+   "docs-only" are one fact. The gate-side rule — including how to WAIVE a red on a genuinely prose diff, by
+   RUNNING that classifier instead of judging a path shape — is in
+   [gate contract → CITE-AND-WAIVE](/cqlite/agents-developing/gate-contract/).
+
    **NOTHING PREDICTS THE EXCLUSION SET PRE-ENQUEUE, and that is a deliberate, recorded reduction in
    coverage (#3283).** A `census-exclusion:` key that did — a bash port of roborev's own pathspec
    construction (`git.FormatExcludeArgs`) over a TOML parse of three configuration sources — was built on


### PR DESCRIPTION
Closes #3250.

`scripts/ci/classify-docs-only.sh` classified **every** path under `docs/` as documentation on the strength
of the path prefix alone (`docs/*) return 0`). Because `pr-gate-core` — the compute half of the `required`
branch-protection check — skips every correctness step on a docs-only verdict and still concludes `success`,
a PR consisting only of executables under `docs/reports/*-artifacts/` merged with **zero correctness
gating**. That is not hypothetical: it is the standing outcome for the WS0 harness convention, three times
over (#3081 `pr-gate-core` green in **14s**, #3216 in **13s**, #3222 in **16s**, against a ~14-minute
baseline for a real code PR).

This is the gate-side half of the pair whose review-side half was #3229 (PR #3262).

## What changed

- **`scripts/ci/classify-docs-only.sh`** — the blanket `docs/*) return 0` arm is gone. A single new
  `docs_path_is_documentation()` is now the ONLY place a path under `docs/` is classified, and it returns
  documentation only on an **affirmative allowlist match**, in three extension-disjoint layers: L1
  prose/image/legal at any depth; L2 the **inert** artifact bucket at any depth under `docs/`; L3 the
  **code-bearing** bucket (`json`, `html`) only where the path is inside an artifact-bearing directory.
  Closed grammar — no `else return 0`, no "not obviously code ⇒ prose". Unrecognized extensions and **all**
  extensionless paths fail closed, with no executable-bit lookup.
- **AC5, the anti-drift requirement** — the artifact declaration is **imported** from
  `scripts/flow/roborev-review-oracles.sh` (`CODE_FREE_ARTIFACT_EXTENSIONS`,
  `CODE_FREE_ARTIFACT_DIR_GLOBS`, `roborev_path_in_artifact_dir`), sourced relative to the classifier's own
  location, never `$PWD`. No literal copy of the list, no reimplementation of the directory matcher
  (`roborev_path_in_artifact_dir`'s component-wise walk is load-bearing: a bash `case` glob crosses `/`,
  git's `:(glob)` `*` does not). An unusable import fails **closed** — every path under `docs/` becomes
  `full` with a named reason — never "prose allowlist and carry on".
- **`.github/workflows/pr-gate.yml`** — the changed-file list is computed with `core.quotePath=false` so the
  classifier receives raw paths. One flag, one normalization boundary. No trigger filter, no change to the
  heavy-step gates or to `required`.
- **`scripts/tests/test_classify_docs_only.sh`** — additive: all 23 original asserts retained, now
  **108 asserts, 0 failures**. Includes mutation-tested structural asserts (a reintroduced
  `docs/*) return 0` must FAIL them; a hardcoded list must FAIL the import mutation test) and a bucket
  partition assert against the **real** declaration — never a mirrored copy, since a symmetric mirror
  shares the production defect and greens while broken.
- **Doctrine (AC6)** — CLAUDE.md's #3042 CITE-AND-WAIVE paragraph is narrowed, and the rule is added to
  `website/.../agents-developing/gate-contract.md`, cross-referenced from `roborev-findings.md` so the
  gate-side and review-side "docs-only" definitions are linked rather than independently maintained.

## AC4 — recorded demonstration on the real merged-PR shapes

Evidence, not a gate assertion (the input is a historical API response; asserting it would pin a network
call or commit a fixture that ages). Full method and per-extension breakdown in `design.md` D10.

| PR | paths | PRE verdict | POST verdict | offending | first offending path |
|---|---|---|---|---|---|
| **#3222** (#3217) | 188 | `docs-only` / exit 0 | **`full` / exit 1** | 35 | `docs/reports/ws0-3217-artifacts/harness/classify-offcpu.py` |
| **#3081** (#3026) | 269 | `docs-only` / exit 0 | **`full` / exit 1** | 30 | `.../ws0-corpus/.gen-p200000-…yaml` |
| **#3216** (#3100) | 197 | `docs-only` / exit 0 | **`full` / exit 1** | 1 | `.../ws0-h2h/schemas/ws0-events.cql` |

The PRE column is recorded precisely so the `full` is attributable to **this change** and not to an
unexplained difference in the input. Prose-only replays (offending paths removed) still short-circuit:
#3222 153 paths, #3081 239, #3216 196 — all `docs-only` / exit 0, so **AC2's fast path is intact on real
data**.

**The measured count for #3222 is 35, where the issue says 34.** Recorded as measured, not reconciled away:
34 is the extension-bearing executable count (17 `.sh` + 15 `.py` + 2 `.bt`); the 35th is an extensionless
harness binary (`partB-run/offcputime-bigmap`) that AC1 forces to `full` unconditionally.

**Whole tracked `docs/` tree** (D10a — the "no prose moved" claim, measured rather than asserted): 1277
tracked files → **1184 still fast-pathed, 93 now forcing the full path. Zero prose files. Zero images.**
All 93 are executable code or functional configuration.

## AC7 — the backfill ruling (owner-decided, recorded)

**Ruling: accept the three already-merged PRs as-is; no retroactive core-gate run.** Owner decision at
Seam 1, 2026-08-04, one ruling covering #3229 AC7 and #3250 AC7. Bounding evidence: the docs-hosted
`scan-harness` crate is **not** a workspace member (`cargo metadata --no-deps`, 16 packages, none under
`docs/`), and no skipped `pr-gate-core` step reads any path in those three diffs — so a retroactive run
would be equivalent to running the core on `main`. **Condition of change, verbatim: the exemption ends the
moment harness code is promoted into a shipped path.** Recorded in `design.md` D7.

## Verification

- **`--lite` PASS** @ `8fcc8a1` — `tree-integrity: PASS`, tree digest unchanged start→end. (The full gate of
  record runs ONCE in `flow-closer`, immediately pre-merge.)
- **Self-test standalone: PASS=108 FAIL=0.**
- **roborev round 1: FAIL — 1 finding, Severity High**, fixed and re-reviewed. The finding was a real gate
  bypass: the legal-name arm `LICENSE | LICENSE.* | NOTICE | NOTICE.*` used a **wildcard suffix**, so
  `docs/tools/LICENSE.sh` and `docs/observability/NOTICE.json` classified `docs-only` at any depth —
  defeating AC1 and, for `NOTICE.json`, the D2(a) rule that `.json` is documentation only inside an artifact
  directory. Both arms are now exact names + a closed prose-suffix allowlist
  (`.md`/`.markdown`/`.txt`/`.rst`). **The root-level arm's wildcard was PRE-EXISTING** — it long predates
  this issue and this change did not introduce it; it is fixed opportunistically because it is the identical
  one-line defect in the function this change hardens. Safety of the tightening was measured first: only 3
  LICENSE/NOTICE files are tracked repo-wide and all 3 carry the exact extensionless name, so nothing on the
  real tree moves. The global arm stays anchored to the whole path deliberately — basename-matching it would
  *widen* the fast path to nested legal files outside `docs/`, a loosening this change does not make.

### Two caveats stated rather than left implicit

1. **The suite's Ruby structural workflow assertion SKIPPED locally** (`info - ruby absent`). It did not run
   on the authoring box. It is exercised by the full gate's `tooling-tests` component on a Ruby-bearing
   host; the 108/0 local result does not cover it.
2. **CITE-AND-WAIVE does NOT apply to this PR's own gate.** The diff touches workflow and script inputs, so
   any failure here is presumed ours until proven otherwise — the waiver this PR *documents* is
   categorically unavailable to it.

## Seam 1

Spec approved by the owner 2026-08-04 (`REQ-3250-20260804T215500Z-drive-issue-3250`) with **D1(a)** (no
retroactive run), **D2(a)** (directory-scope the code-bearing formats; AC3's literal text yields to
CLAUDE.md's directory-not-extension rule), and **D3(a)** (`core.quotePath=false` in the classify step).
OpenSpec change: `openspec/changes/narrow-docs-only-classifier/`.
