### PR TITLE
fix(#3261): harden test-mode seam containment — positive containment for write targets, the fork-free read path, contained files and privileged executables

### DIFF
--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -327,7 +327,8 @@ grep -Hn 'perf_event_paranoid\|kptr_restrict' /etc/sysctl.conf /etc/sysctl.d/*.c
   /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
 ```
 
-**Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` in a shell.** They are test-only path
+**Never set `CQLITE_PERF_PROC_DIR` / `CQLITE_PERF_SYSCTL_DIR` / `CQLITE_PERF_SYSCTL_EXTRA_DIRS` /
+`CQLITE_PERF_TEST_SANDBOX` in a shell.** They are test-only path
 seams for `scripts/tests/test_perf_capability*.sh` and are **inert** unless `CQLITE_PERF_TEST_MODE=1`
 is also set — which in turn refuses to run if a real `sudo`/`sysctl` is reachable. The privileged
 destination is a hardcoded `/etc/sysctl.d` literal precisely so no exported variable can ever steer
@@ -335,23 +336,39 @@ a `sudo tee` at another file, and bootstrap fails closed (skips the section with
 finds a seam set without the marker.
 
 **Test mode has NO production fallback (it is enforced, not conventional).** Under
-`CQLITE_PERF_TEST_MODE=1` **both** path seams are **mandatory** and each must be absolute and outside
-`/etc`, `/proc` and `/sys`. A missing or production-shaped seam is a loud refusal in the env guard
-*and* in the path resolvers, so an unsandboxed test-mode run resolves no drop-in path at all and reads
-no `/proc`. The earlier shape fell back to the real directories, which meant a root `--yes` run under
-the marker could `tee` the host's **real** `/etc/sysctl.d/99-cqlite-perf.conf` — a test run mutating
-the machine. There is deliberately no opt-out.
+`CQLITE_PERF_TEST_MODE=1` the sandbox root and **both** path seams are **mandatory**. An unusable seam
+is a loud refusal in the env guard *and* in the path resolvers, so an unsandboxed test-mode run
+resolves no drop-in path at all and reads no `/proc`. The earlier shape fell back to the real
+directories, which meant a root `--yes` run under the marker could `tee` the host's **real**
+`/etc/sysctl.d/99-cqlite-perf.conf` — a test run mutating the machine. There is deliberately no opt-out.
 
-**On the write path the seam is judged by its CANONICAL DESTINATION, not its spelling.** A textual
-check accepts an unbounded set of paths that *resolve* into production — `/tmp/../etc/sysctl.d`, or a
-seam under a symlinked ancestor (`ln -s /etc /tmp/a`, seam `/tmp/a/sysctl.d`) — and each of those
-would land a root `tee` on the host's own drop-in. So the env guard and the drop-in-path resolver
-canonicalize the whole path (`cd -P` + `pwd -P`: no `realpath`/`readlink -f` dependency, correct on
-bash 3.2) and validate the resolved destination; an unenterable path resolves to nothing and is
-refused too. The gate's **emit-time read path** is contractually fork-free and writes nothing, so it
-keeps the builtin-only textual check (which rejects `.`/`..` components and a symlinked seam): the
-worst a mis-accepted seam can do there is mis-read a stand-in `/proc`, which the token reports as
-`absent`/`unknown` rather than as a capability.
+**The rule is POSITIVE CONTAINMENT in one declared sandbox — not a list of forbidden places.** Four
+review rounds each closed one more *spelling* of "the production directory": the raw path, then a
+symlinked seam, then `..`, then `//etc` (POSIX leaves two leading slashes implementation-defined,
+`pwd -P` may preserve them, and on Linux `//etc` **is** `/etc`). A denylist over path spellings cannot
+be completed — `.`, `..`, symlinks, `//`, trailing slashes, bind mounts, `/proc/self/root/…` all name
+the same directory — and scattered prohibitions also let a *new* seam consumer miss them (that was the
+`CQLITE_PERF_SYSCTL_EXTRA_DIRS` defect). So test mode now takes **one** caller-declared sandbox root,
+`CQLITE_PERF_TEST_SANDBOX`, and a seam is usable **iff it is strictly inside it** (resolved-path prefix
+match with an explicit `/` boundary, so `/tmp/sandboxevil` is not inside `/tmp/sandbox`). Anything not
+provably inside is refused — every spelling above, and every future one, for the same single reason.
+
+- The **root itself must prove it is a sandbox**: absolute, canonically spelled, existing, and holding
+  the stamp file `.cqlite-perf-sandbox`. So `CQLITE_PERF_TEST_SANDBOX=/etc` cannot make containment
+  vacuous — the proof lives on the filesystem, where placing it already needs the privilege the guard
+  protects.
+- **Every** consumer routes through that one check: the env guard, the drop-in path a root `tee` is
+  aimed at, the `/proc` stand-in, and every configuration read (the lower-precedence search-path
+  entries, plus an optional `sysctl.conf` **file** entry, whose parent is canonicalized and the
+  resulting file path validated). `test_perf_capability.sh` enforces that **structurally**: it
+  enumerates from the source every function that dereferences a seam and fails if one does not reach
+  the containment check, so a new entry point cannot silently skip it.
+- Paths that **write** or that **read host configuration** canonicalize both sides (`cd -P` + `pwd -P`:
+  no `realpath`/`readlink -f` dependency, correct on bash 3.2); an unenterable path resolves to nothing
+  and is refused. The gate's **emit-time read path** is contractually fork-free and writes nothing, so
+  it applies the same containment check *syntactically* — its guarantee is that the seams are honoured
+  only under the marker, which is never set in production, and the worst a mis-accepted spelling can do
+  there is read a caller-chosen file, reported as `absent`/`unknown` rather than as a capability.
 
 Every gate SUMMARY's `accelerators:` line stamps the same state as a Linux-only `perf=` token
 (`ok` / `paranoid-<N>` / `kptr-restricted` / `absent` / `unknown`), so "this box cannot be profiled"

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -365,10 +365,38 @@ provably inside is refused — every spelling above, and every future one, for t
   the containment check, so a new entry point cannot silently skip it.
 - Paths that **write** or that **read host configuration** canonicalize both sides (`cd -P` + `pwd -P`:
   no `realpath`/`readlink -f` dependency, correct on bash 3.2); an unenterable path resolves to nothing
-  and is refused. The gate's **emit-time read path** is contractually fork-free and writes nothing, so
-  it applies the same containment check *syntactically* — its guarantee is that the seams are honoured
-  only under the marker, which is never set in production, and the worst a mis-accepted spelling can do
-  there is read a caller-chosen file, reported as `absent`/`unknown` rather than as a capability.
+  and is refused.
+
+**Containment of a SPELLING is not containment of a DESTINATION, and that cost four more rounds (#3261).**
+Positive containment closed the path spellings; four escapes remained, each about something the guard
+authorizes *other than* a directory name. All four are now closed by the same discipline — validate the
+destination, positively, fail closed:
+
+- **The write TARGET, not just its directory.** A contained directory says nothing about where its
+  *entries* point, and `tee <path>` opens `O_CREAT|O_TRUNC` and **follows a symlink**. So a symlink at
+  `99-cqlite-perf.conf` inside a perfectly-contained directory aimed the privileged write anywhere on the
+  box. Now: naming that target **refuses** when it is a symlink, the idempotency read never follows it
+  (a link whose target holds the canonical bytes must not report "already current"), and the write is an
+  **atomic directory-entry replacement** — staged entry in the validated directory, then `rename` over
+  the name — so a symlink planted between the check and the write is *replaced*, not written through.
+- **The fork-free read path is NOT exempt** — the earlier claim here that a syntactic check was "sound
+  because nothing there writes" was **wrong**, and this is what falsified it. A symlink *inside* the
+  sandbox pointing at the real `/proc/sys/kernel` satisfies containment, so the run reported a token
+  derived from the **host's real controls** while claiming to read a stand-in (measured: `paranoid-4`
+  straight out of the live `/proc`). A **fabricated verdict is worse than a refusal**. The path stays
+  fork-free and now rejects a **symlinked component** with builtins only (`[ -L ]` forks nothing).
+- **A strictly-contained file must be ACCEPTED.** `<root>/sysctl.conf` was refused, because the check
+  asked whether the *parent* was strictly contained and a root is not strictly inside itself. The judged
+  path is now `<canonical parent>/<basename>`. A guard that refuses legitimate input is the guard people
+  learn to route around.
+- **EXECUTABLES too, not only paths.** `CQLITE_PERF_TEST_PRIV_DIR` was trusted textually: `/usr` is
+  absolute and genuinely *contains* `/usr/bin/sudo`, and a symlink to the real `sudo`/`sysctl` inside a
+  genuine shim dir is spelled locally while resolving to the host's binary — either one let a privileged
+  test-mode bootstrap run a real `sysctl --system` against the host kernel. Every privileged executable's
+  **resolved destination** must now be contained beneath the proven sandbox root, and `sudo`/`sysctl`
+  **parked** in the shim dir are swept whether or not `PATH` reaches them (one `PATH`-order change is all
+  that separates "not resolved" from "executed"). The structural audit covers privilege-shim resolution
+  as a **second pass**, with its own floor and its own named allowlist.
 
 Every gate SUMMARY's `accelerators:` line stamps the same state as a Linux-only `perf=` token
 (`ok` / `paranoid-<N>` / `kptr-restricted` / `absent` / `unknown`), so "this box cannot be profiled"

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -1071,3 +1071,250 @@ only fired on rc 0 PLUS a matched line, so a silent accept -- or a skip -- passe
 directory removes the ordering dependency, and the refusal is now REQUIRED rather than merely allowed.
 ```
 
+### and-the-spelling-is-not-the-destination-tmp-e
+
+```
+...and the SPELLING is not the destination. `/tmp/../etc/sysctl.d`, `<symlink-to-/etc>/…`
+and — the R6-1 escape — `//etc/sysctl.d` (POSIX leaves two leading slashes
+implementation-defined and `pwd -P` may PRESERVE them, while on Linux `//etc` IS `/etc`)
+each passed the textual checks of an earlier round. There is no per-spelling check any
+more: containment refuses all of them, plus every future spelling, for the SAME reason.
+An UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
+```
+
+### 1g-3261-a-name-is-not-a-destination-the-four
+
+```
+---- 1g. #3261: A NAME IS NOT A DESTINATION — the four remaining escapes ------------------
+Positive containment closed the PATH SPELLINGS. These four are what containment of a
+spelling still does not buy, and each is asserted BY ITS OWN OBSERVABLE CONSEQUENCE (a
+followed write, a fabricated /proc verdict, a refused legitimate file, a real privileged
+tool), never by an rc alone — this guard has several refusals and an rc-only check would let
+the wrong one satisfy the case.
+```
+
+### 1g-i-ac1-high-directory-containment-is-not-wri
+
+```
+1g-i. AC1 (High) — DIRECTORY containment is not WRITE-TARGET containment. `tee <path>` opens
+O_WRONLY|O_CREAT|O_TRUNC and FOLLOWS a symlink, so a symlink at the managed basename
+inside a perfectly-contained directory pointed the privileged write at the LINK'S
+TARGET — anywhere on the box. A contained directory says nothing about where its
+entries point. Two independent requirements, both asserted:
+* anything that merely NAMES the write target REFUSES (rc 1, empty, loud);
+* the WRITE ITSELF replaces the directory ENTRY (rename), so a symlink planted in
+the window between the check and the write is replaced, not written through.
+(rationale condensed; full reasoning in the commit history for #3261.)
+```
+
+### and-the-staging-entry-is-unpredictable-create
+
+```
+...and the STAGING entry is UNPREDICTABLE, created by `mktemp` (roborev finding 1 on #3261 — the
+NINTH escape, same shape as the other eight: a NAME trusted instead of a DESTINATION). A fixed
+staging path that is checked, cleared and only THEN opened by a privileged `tee` is a TOCTOU
+window: anyone who can create entries in the directory re-plants that KNOWN name as a symlink
+between the verify and the open, and root follows it. Two asserts, because neither alone is
+enough — a behavioural one (the previously-predictable name is planted as a symlink at a victim
+file and must be left strictly alone) and a structural one (unpredictability is a property of the
+NAME, which is gone by the time the write succeeds, so the source is the only place to see it).
+```
+
+### and-an-unsupported-host-is-reported-as-rc-2-d
+
+```
+...and an UNSUPPORTED HOST is reported as rc 2, distinct from rc 1 REFUSED (roborev rounds 16-17).
+The staged install needs GNU `stat -c` and `mv -T`; bootstrap gates the perf section on
+PLATFORM=linux, which is NOT the same as GNU, so a musl/busybox Linux host used to die on a raw tool
+error. The tools are exercised INSIDE the privileged shell (sudo applies its own secure_path, so a
+caller-side probe can check a different binary than the one that will run) and `mv -T` is EXERCISED
+rather than grepped out of --help. The all-GNU control is what stops this passing by refusing always.
+```
+
+### and-an-extra-dirs-value-whose-first-line-is-v
+
+```
+...and an EXTRA_DIRS value whose FIRST LINE is VALID must still be refused (roborev round 31, Medium).
+`read` consumes only the first line, so a value like "<contained-dir>\n/etc/sysctl.d" previously SUCCEEDED
+while silently discarding the remainder -- the scan then reported on an incomplete set, which is the
+falsely-reassuring answer the diagnostic exists to prevent. Round 3 validated the SPLIT ENTRIES and never
+the value being split, so a newline HID entries rather than forging one. The baseline runs first, without
+the newline, and must SUCCEED -- otherwise the refusal proves nothing.
+```
+
+### and-a-symlinked-control-file-inside-a-contain
+
+```
+...and a SYMLINKED CONTROL FILE inside a contained PROC_DIR must not be read (roborev round 25,
+Medium). The directory gate proved the DIRECTORY contained and symlink-free and said nothing about its
+ENTRIES, so `perf_event_paranoid` could be a link to the host file and the token would report a real or
+attacker-chosen capability as if it came from the fixture. Same directory-is-not-its-entries lesson as
+AC1, on the read path. The CONTROL is the identical tree with a REAL file, so the refusal cannot be
+passing for an unrelated reason.
+```
+
+### and-line-safety-must-be-judged-on-the-origina
+
+```
+...and LINE-SAFETY MUST BE JUDGED ON THE ORIGINAL PATH, not the canonicalized one (roborev round
+12, Medium). `$(cd -P -- "$p" && pwd -P)` STRIPS trailing newlines, so a directory whose name ends
+in LF used to pass: the check only ever saw the stripped form, while every later caller emitted the
+ORIGINAL spelling and split the one-per-line search path in two. Round 3 added the CR/LF guard for
+exactly that split; it was running too late to see it. Both variants are pinned — a directory whose
+name ends in LF, and a file whose PARENT ends in LF — because they canonicalize by different routes.
+```
+
+### baseline-first-without-the-newline-file-and-it
+
+```
+BASELINE FIRST, WITHOUT the newline file, and its status REQUIRED (roborev round 30, Low). My previous
+version ran the "ordinary" baseline while the newline-named file was ALREADY present, making it identical
+to the refusal case, and then discarded its status with `|| true` — so the negative control controlled
+nothing. Three iterations of this one case have now been vacuous in a different way each time; the
+pattern in my own work is that I fix the assertion and forget to re-check that it can still reach its
+subject. Ordinary file only -> MUST scan (rc 0). Then add the newline file -> MUST fail closed.
+```
+
+### and-a-failing-content-generator-must-never-lo
+
+```
+...and a FAILING CONTENT GENERATOR must never look like success (roborev round 9, Medium). Both
+call sites used to lose the generator's status: dropin_current ran a trailing sentinel `printf`
+whose rc replaced it, so against an EMPTY file the compare was "X" == "X" and reported the drop-in
+ALREADY CURRENT; dropin_install piped the generator into the privileged shell, so the pipeline's rc
+was the last command's and a failure only surfaced if the CALLER had `pipefail`. Both are vacuous
+positives from an unmeasured state. No GNU-only tooling is exercised here: each must fail BEFORE
+any privileged command runs, which is the property under test.
+```
+
+### 1g-iii-ac3-low-a-strictly-contained-file-was-w
+
+```
+1g-iii. AC3 (Low) — a STRICTLY CONTAINED file was wrongly REFUSED. The file variant judged
+its PARENT with the strict-containment predicate, so `<root>/sysctl.conf` failed:
+the parent IS the root, and a root is not strictly inside itself. The judged path
+must be <canonical parent>/<basename>, which IS strictly inside. A guard that
+refuses legitimate input is the guard people learn to work around, so this is a
+correctness case, not a convenience.
+```
+
+### 1c-iv-the-seam-list-is-complete-by-census-robo
+
+```
+1c-iv. THE SEAM LIST IS COMPLETE, BY CENSUS (roborev round 32, Medium x2).
+(full rationale: fleet-runbook.md, perf seam containment, seam-list-completeness)
+perf_capability_seam_set named CQLITE_PERF_PROC_DIR and CQLITE_PERF_SYSCTL_DIR only, while the
+file had grown three more test-only seams (TEST_SANDBOX, SYSCTL_EXTRA_DIRS, TEST_PRIV_DIR). Any
+of those exported WITHOUT the marker sailed through the env guard, which is the marker-less
+refusal failing open -- the same "denylist of names" shape this whole issue exists to close, and
+my own doing: the round-6 audit policed WHICH FUNCTIONS may read a seam and never WHICH SEAMS the
+list must name, so it could not see an omission. This audit is the other direction, and it is a
+CENSUS rather than a hand-kept list: every CQLITE_PERF_* name the library reads must be named by
+seam_set, minus the marker itself (which cannot gate its own absence). Adding a seam without
+listing it now FAILS here instead of silently widening the production surface.
+```
+
+### 1c-v-the-two-containment-paths-agree-about-a-s
+
+```
+1c-v. THE TWO CONTAINMENT PATHS AGREE ABOUT A SYMLINKED SANDBOX ROOT (roborev round 32, Medium).
+(full rationale: fleet-runbook.md, perf seam containment, symlinked-sandbox-root)
+sandbox_root_into advertised a "canonically spelled" root but never tested for symlinked
+components. MEASURED on the same root and child: the fork-free perf_capability_sandbox_ok
+returned 1 while the RESOLVING perf_capability_sandbox_ok_resolved returned 0 -- read and write
+disagreeing about one sandbox, the same defect class as round 31's trailing-slash split.
+Rejecting (not canonicalizing) is the only fix available here: sandbox_root_into is in the closed
+fork-free audit set, and canonicalizing needs cd -P/pwd -P, i.e. a forked subshell.
+THE ASSERTION IS AGREEMENT, not merely refusal: my first draft of this case asked only whether
+the fork-free path refused, which it already did, so it passed with the defect fully present.
+Both paths are therefore driven over the same fixtures, and the canonical control requires both
+to ACCEPT -- a rule that refused everything would fail here just as loudly as one that accepts.
+```
+
+### b4
+
+```
+
+WHY THIS FILE EXISTS. Agent/worker images ship `kernel.perf_event_paranoid = 4` and set
+it NOWHERE in /etc/sysctl.conf or /etc/sysctl.d — so every profiling run starts from a
+hard EACCES whose help text ("access limited") reads like a CAPABILITY verdict when it is
+a PERMISSION verdict. That has already cost two measurement cycles. The same three-line
+incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is git-pinned,
+and is asserted by the gate's tooling-tests.
+
+WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE restrictive and
+each level keeps the ones below it: `>= 3` (an extra Debian/Ubuntu level) denies ALL
+unprivileged perf use, which is why the images' `4` kills even a plain `perf stat`;
+`>= 2` no kernel profiling; `>= 1` no CPU-WIDE access, which is exactly what
+`perf stat -C <cpu>` needs; `>= 0` no raw tracepoints; `-1` (almost) everything, and the
+perf mlock limit lifted too. CQLite's doctrine mandates per-CPU collection, so `1` is
+not "almost right", it is a hard denial. `kernel.kptr_restrict = 0` is a SEPARATE control
+for kernel SYMBOL resolution — without it kernel frames are unresolved addresses, a
+SILENT attribution loss rather than an error. Same rationale in the drop-in's own bytes.
+
+SECURITY POSTURE. A deliberate loosening, appropriate for DEDICATED SINGLE-TENANT
+measurement/agent boxes. Never apply it to a shared or multi-tenant host. See
+docs/development/fleet-runbook.md. BPF IS A DIFFERENT PERMISSION: a permissive
+perf_event_paranoid does NOT grant BPF map creation — bpftrace/bcc collectors still need
+sudo (#3217 finding).
+
+Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call the
+functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO side
+effects: this file only defines `perf_capability_*` functions plus the four
+`PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
+outside those namespaces are touched). Every function is `set -u` safe.
+
+Usage when executed: `bash scripts/perf-capability.sh --help` (the modes are listed by
+perf_capability_usage below, so they are not duplicated here).
+
+```
+
+### perf-capability-dropin-install-priv-cmd-write
+
+```
+perf_capability_dropin_install [<priv-cmd>...]: write the managed drop-in as an ATOMIC
+DIRECTORY-ENTRY REPLACEMENT, so a pre-existing symlink at the managed name is REPLACED, never
+FOLLOWED (issue #3261 AC1). argv is the privilege prefix (empty when already root); rc 0 iff the
+managed bytes are in place at the managed path afterwards, verified by re-reading the file.
+
+Content goes to a fresh staging entry in the ALREADY-VALIDATED directory, then `mv -fT` —
+rename(2), which replaces the NAME and never dereferences the destination. Same directory, so the
+rename is same-filesystem and atomic.
+
+WHAT MAKES THIS SAFE IS THE PRECONDITION, NOT THE STAGING MECHANICS. Three successive fixes here
+were each defended with a claim that proved FALSE, so the reasoning is recorded rather than the
+conclusion alone (full history: #3261, roborev rounds 1-3):
+* a FIXED staging name, checked-then-opened, claimed safe because the race "cannot happen". It
+could: anyone able to create entries in the directory could re-plant that known name as a
+symlink between the check and the privileged open.
+* `mktemp` (O_CREAT|O_EXCL, 6 random chars, created under the SAME privilege that writes) closed
+the CREATE race — but mktemp returns a NAME and each later step REOPENS it, so the window moved
+rather than closing. A pid suffix would not have helped either; a pid is predictable.
+* grouping every step into ONE privileged `sh -c` was then defended with a claim THIS COMMENT
+ITSELF MADE AND WHICH IS FALSE: that no unprivileged process is scheduled between the steps.
+`sh -c` gives SEQUENCING WITHIN ONE PROCESS, never MUTUAL EXCLUSION against other processes,
+which run concurrently on other CPUs regardless of how we group our own commands. Consolidation
+is kept — it removes needless windows — but it is NOT what makes this safe.
+* what closes the class: REMOVE THE ATTACKER'S PRECONDITION. Every step of the race needs the
+ability to create or replace entries in the target directory, so the install REFUSES a target
+directory that anyone less privileged than the writer can write — it must be owned by the
+identity performing the privileged write and be neither group- nor world-writable. There is
+then no actor to race against, whatever the timing.
+The ownership/mode test runs INSIDE the privileged shell against `id -u` of that shell, so it tests
+the identity that will actually write (root in production, the shim under test mode) rather than
+whoever invoked us. Undeterminable ownership or mode is a REFUSAL, not an assumption. Deliberately
+conservative: group-writable is refused even with the sticky bit, because "arguably safe" is what
+already cost this function three review rounds.
+`chmod 0644` after the write is load-bearing: `mktemp` creates 0600, and the idempotency compare
+runs from an UNPRIVILEGED bootstrap process that could not read a root-owned 0600 file — every
+later run would see "not current" and rewrite. The old `tee` got 0644 from root's umask.
+The staging name begins with `.` and does not end in `.conf`, so the competing-file scan (which
+globs `*.conf`) can never mistake it for a rival drop-in.
+GNU-COREUTILS DEPENDENCY, STATED EXACTLY: `mv -fT` and `stat -c` are GNU-only. The PRODUCTION
+path is genuinely gated — bootstrap reaches this function only when PLATFORM=linux (set at :85,
+branch at :412, PERF_SECTION_OK initialised to 0 at :405 so no ambient export can steer it).
+NOT gated: scripts/tests/test_perf_capability.sh calls this DIRECTLY, so its staged-install cases
+are capability-probed and COUNTED-skipped off GNU (roborev round 5). Neither portability guard in
+the repo scans this file, so nothing mechanically protects the gate; recorded, not papered over.
+```
+

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -832,3 +832,80 @@ reports the counter. Deciding WHOSE capability was measured is the caller's job,
 the caller owns the verdict.
 
 ```
+
+### perf-capability-dropin-current-rc-0-iff-the
+
+```
+perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the managed
+bytes (the idempotency test — a matching file means write nothing). The compare is an
+in-shell string compare, NOT `diff -q`: on a box without diffutils `diff` exits 127,
+which reads as "different" on every run — so bootstrap would re-write the file each time
+AND then report it could not write it.
+
+TRAILING NEWLINES ARE PART OF THE BYTES (review R4-4). `$( )` strips EVERY trailing
+newline, so comparing two command substitutions made a file missing its final newline —
+or carrying extra trailing blank lines — compare EQUAL: "byte-exact" was a false claim
+and such a file was never rewritten. The file side is read with `read -r -d ''`, which
+consumes it verbatim (builtin, no `cat`/`diff` dependency), and the canonical side carries
+an in-substitution sentinel so its own final newline survives the stripping.
+
+A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (review R5-3). `read -d ''` stops at a NUL
+and returns SUCCESS with only the bytes BEFORE it, so canonical content + NUL + ARBITRARY
+trailing bytes compared EQUAL and was judged current. Read's rc is therefore load-bearing:
+rc 0 means a NUL was consumed — not our text drop-in, and the rest never even seen — so it
+is NOT current; only rc != 0 (EOF, whole file in `got`) may be compared.
+```
+
+### the-sentinel-must-not-swallow-the-generator
+
+```
+# THE SENTINEL MUST NOT SWALLOW THE GENERATOR'S STATUS (roborev round 9, Medium). `printf X`
+# exists so a trailing newline survives command substitution, but it also RAN LAST, so the
+# substitution reported ITS status and a failed content generator looked like success: `want`
+# became bare "X", and against an empty file `${got}X` is also "X" — equal, so a broken
+# generator reported the drop-in ALREADY CURRENT. A positive verdict from an unmeasured state,
+# which is the exact shape this repo has a standing rule against. The rc is now captured
+# BEFORE the sentinel and re-raised as the subshell's exit status, so both properties hold.
+```
+
+### perf-capability-proc-read-outvar-name-the-cu
+
+```
+perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight from
+/proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when unreadable). NEVER
+trust a `sysctl -w`/`--system` return code — a write can report success while the value
+does not take (container, read-only sysfs, a competing drop-in applied later), and it can
+report FAILURE for an unrelated entry while ours applied fine. Read back.
+Fully fork-free: `read` is a builtin, the directory comes back through a variable, and
+nothing here is wrapped in `$( )` — this sits in the gate's summary path, which may not
+grow a process for a diagnostic line. `read` returns non-zero at EOF on a file with no
+trailing newline yet still assigns, so emptiness — not read's rc — is the failure test. It
+also propagates the test-mode sandbox refusal (R4-3): with no seam inside the sandbox there
+is no directory to read, and that is rc 1, never the real /proc.
+
+```
+
+### b951
+
+```
+
+WHY (review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever the NAME
+resolves to, not to the numeric ids we validated, and SUDO_USER/SUDO_UID are independent
+environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale or hand-set) would run the probe
+AS ROOT while the code reported a successful drop — a false VERIFIED again. So a name is
+usable only once the passwd database confirms it IS the validated uid/gid. The shape check
+is equally load-bearing: the prefix is word-split by the caller, so a name containing
+whitespace or glob characters could inject extra argv tokens.
+```
+
+### event-name-matching-must-accept-a-qualified
+
+```
+# Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU (Intel
+# 12th-gen+ P/E cores) perf emits one row per PMU (`cpu_core/cycles/`, `cpu_atom/cycles/`),
+# commonly with `<not supported>` on the sibling that did not run — so a parser keyed on a
+# literal leading `cycles` reports `no-cycles-row` on a perfectly good collection. Normalise
+# the event field (drop PMU prefix, trailing `/`, any `:u`/`:k` modifier) and take the FIRST
+# row with a positive numeric count; keep the first matching row's raw field as the fallback
+# so the `<not supported>` / zero diagnostics below still fire when none is positive.
+```

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -383,21 +383,38 @@ destination, positively, fail closed:
   too, so `mktemp`'s `O_EXCL` create is the point, not the suffix), then `rename` over
   the name — so a symlink planted between the check and the write is *replaced*, not written through.
   Two further properties, both learned the hard way one level deeper:
-  **(a)** the whole staged install — `mktemp`, write, `chmod`, `rename` — runs inside **one privileged
-  invocation**, because `mktemp` returns a *name* and every later step **reopens it by name**, so
-  splitting them leaves a create→reopen window an attacker can use even though the name is random;
-  **(b)** the rename carries **`-T`/`--no-target-directory`**. Without it a **symlink-to-directory** at
+  **(a)** the rename carries **`-T`/`--no-target-directory`**. Without it a **symlink-to-directory** at
   the managed name makes `mv` move the staging file *into* that directory — the rename that exists to
   avoid *following* a symlink follows one instead. Reproduced: the staging entry landed inside the
   outside directory, i.e. the managed bytes left the sandbox under a name nothing tracks.
-  **The residual is recorded, not waved away:** consolidation *shrinks* that window to the inside of one
-  root process; it does **not** mathematically eliminate it, because POSIX shell has no
-  `O_NOFOLLOW|O_EXCL` open primitive. Closing it fully needs a non-shell helper holding the descriptor
-  from creation to rename, which would add an interpreter dependency to the privileged bootstrap path —
-  an owner call, deferred. Exploitation needs a real privileged `tee` **and** an attacker-writable
-  drop-in directory (production's `/etc/sysctl.d` is root-owned; test mode requires sandbox-contained
-  shims) — a **boundary, not a proof of unreachability**. "Cannot happen" has been wrong nine times in
-  this family and one comment here already had to be retracted.
+  **(b)** the install **refuses a drop-in directory writable by anyone less privileged than the
+  writer** — it must be owned by the identity doing the privileged write and be neither group- nor
+  world-writable, with undeterminable owner/mode a refusal. *This* is what closes the staging race,
+  and it took three review rounds to get there because the first two answers tried to make the race
+  unwinnable instead of removing the racer.
+
+  **Two false rationales were published here before that landed, and both are recorded rather than
+  quietly deleted, because the failure mode is the interesting part.** First: a fixed staging name was
+  called safe because the race "cannot happen" — it could. Then `mktemp` made the name unpredictable
+  (closing the *create* race) and the remaining window was declared closed by putting every step in
+  **one privileged `sh -c`**, on the stated grounds that no unprivileged process is scheduled between
+  them. **That is false.** A single `sh -c` gives *sequencing within one process*; it is not mutual
+  exclusion against other processes, which run concurrently on other CPUs entirely unaffected by how
+  we grouped our own commands. Consolidation is retained — it is the right shape and removes needless
+  windows — but it is **not** what makes this safe. The lesson generalises past this function: *"the
+  attacker has no time to act"* is a claim about a scheduler you do not control, whereas *"the attacker
+  cannot write this directory"* is a checkable property of the filesystem. Prefer the second shape.
+  A non-shell helper holding the descriptor from creation to rename remains available but is now
+  probably unnecessary rather than merely deferred.
+- **A contained path can still SERIALIZE into two paths.** Not a containment defect — the path *is*
+  contained — which is why nine rounds of containment work never saw it. The search path is emitted
+  **one entry per line** and read back line-wise, so a directory legitimately inside the sandbox but
+  *named* with an embedded newline (`<root>/evil\n/etc/sysctl.d`) splits into **two** entries, the
+  second being the host's real `/etc/sysctl.d`. CR and LF are therefore rejected in every path seam at
+  the boundary, inside the single containment predicate. This is the same class CLAUDE.md records for
+  the roborev guard's own `-z` invariant: **a newline-delimited path set is not a safe representation
+  of paths.** If you add a path-carrying seam anywhere, ask what happens when the path contains a
+  newline before you ask whether it is contained.
 - **The fork-free read path is NOT exempt** — the earlier claim here that a syntactic check was "sound
   because nothing there writes" was **wrong**, and this is what falsified it. A symlink *inside* the
   sandbox pointing at the real `/proc/sys/kernel` satisfies containment, so the run reported a token

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -978,3 +978,96 @@ bootstrap execute a real `sysctl --system` and reconfigure the host kernel.
 sandbox root that holds tools named `sudo`/`sysctl`. Asserting against the literal
 /usr would make the case depend on whether this host happens to ship sudo there.
 ```
+
+### 1c-iii-b-the-containment-boundary-and-the-sand
+
+```
+1c-iii-b. THE CONTAINMENT BOUNDARY AND THE SANDBOX ROOT ITSELF (issue #3249 review
+R6-1/R6-2). Containment is only as good as its boundary and its root:
+* `/tmp/sandboxevil` must NOT count as inside `/tmp/sandbox` — a plain string
+prefix would accept it, which is why the `/` boundary is explicit;
+* a path genuinely inside the declared root must still WORK, so the guard is
+not vacuously refusing everything (the failure mode a negative-only test
+cannot see);
+* the ROOT must PROVE itself — unset, relative, `//`-spelled, non-existent, or
+an existing directory with no stamp are all refusals NAMING
+CQLITE_PERF_TEST_SANDBOX. Without that, `CQLITE_PERF_TEST_SANDBOX=/etc`
+would make containment vacuous, and the inversion would have bought nothing.
+```
+
+### 1f-the-gate-is-singular-and-unskippable-a-stru
+
+```
+1f. THE GATE IS SINGULAR AND UNSKIPPABLE — a STRUCTURAL audit (issue #3249 review R6-2).
+R6-2 was not a wrong check, it was a MISSING one: CQLITE_PERF_SYSCTL_EXTRA_DIRS was a
+new seam consumer, and the canonicalizing validation added for the write path simply
+never reached it. No behavioural case can catch that class, because the defect is a
+path nobody thought to test. So this audit enumerates, FROM THE SOURCE, every function
+that dereferences a seam variable and requires each one to route through the
+containment family (`perf_capability_sandbox_*` / `perf_capability_path_within`) — with
+ONE named, justified allowlist entry. A future entry point that reads a seam without
+the gate FAILS here, and joining the allowlist is a visible, reviewable act.
+(rationale condensed; full reasoning in the commit history for #3261.)
+```
+
+### two-representations-because-the-two-matches-wa
+
+```
+TWO representations, because the two matches want different things (roborev round 6, Low).
+`code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
+and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
+stripping quoted spans would hide real consumers and silently shrink the census.
+`codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
+command, never a string, so matching inside quotes is what made the advertised
+"command position" claim false — swapping a real call for a string that merely
+mentions its name kept the audit green.
+Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
+line. The single quote is written \047: this awk program sits inside a shell single-quoted
+string and cannot contain a literal one.
+```
+
+### 1f-ii-the-same-audit-for-the-binaries-the-guar
+
+```
+1f-ii. THE SAME AUDIT FOR THE BINARIES THE GUARD AUTHORIZES (issue #3261 AC4). AC4 was the
+EIGHTH escape from this family and the first about an EXECUTABLE rather than a path:
+`CQLITE_PERF_TEST_PRIV_DIR=/usr` and a symlink-to-real-`sudo` inside a declared shim
+dir both passed a textual check, so a privileged test-mode bootstrap could run the
+host's real `sysctl --system`. Paths and executables are the same problem — a NAME is
+not a DESTINATION — so they get the same STRUCTURAL treatment: every function that
+resolves a privileged tool must route through the containment family, or be
+allowlisted by name with a reason. Floor + explicit expectations, same as above.
+Same de-vacuuming as the seam audit above: comments stripped, gate matched in a command position.
+```
+
+### two-representations-because-the-two-matches-wa
+
+```
+TWO representations, because the two matches want different things (roborev round 6, Low).
+`code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
+and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
+stripping quoted spans would hide real consumers and silently shrink the census.
+`codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
+command, never a string, so matching inside quotes is what made the advertised
+"command position" claim false — swapping a real call for a string that merely
+mentions its name kept the audit green.
+Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
+line. The single quote is written \047: this awk program sits inside a shell single-quoted
+string and cannot contain a literal one.
+```
+
+### and-the-newline-basename-case-now-actually-ex
+
+```
+...and the NEWLINE-BASENAME case, now actually EXERCISED (roborev round 27, Low). This block used to
+assign cs_nl and then write a different, ordinary filename, so the line-oriented edge case it claimed
+to cover never ran — a test asserting coverage it did not provide, which is the exact shape this suite
+exists to catch elsewhere. The scan emits one entry per line, so a basename containing a newline could
+split one competitor into two reported lines; it must fail closed and inject no extra lines.
+ISOLATED DIRECTORY, and a REQUIRED nonzero status (roborev round 28, Low). My round-27 repair of this
+case was itself vacuous twice over: 00-host-link.conf stayed in $cs_dir and sorts BEFORE the
+newline-named file, so the scan refused the symlink and never reached this subject; and the assertion
+only fired on rc 0 PLUS a matched line, so a silent accept -- or a skip -- passed. Its own isolated
+directory removes the ordering dependency, and the refusal is now REQUIRED rather than merely allowed.
+```
+

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -680,3 +680,69 @@ machine + heartbeat age (issue #2089). Interpretation:
 
 *Written 2026-07-06 from the agentic-workflow audit. Update this page in the same change whenever
 flow-* doctrine changes (doctrine-current rule).*
+
+## perf seam containment — why (relocated from `scripts/perf-capability.sh`)
+
+These rationales were moved out of the script's comments so the reviewed diff stays under
+roborev's inline limit (#3257) — the information is preserved verbatim, and each code site keeps
+a short pointer here. Boundary statements, residual pointers (#3323) and retraction records were
+deliberately NOT moved: those must be met at the code site.
+
+### line-safety-serialization
+
+```
+perf_capability_path_lines_ok: rc 0 iff <path> contains NO CR and NO LF.
+
+WHY A SEPARATE PROPERTY FROM CONTAINMENT (issue #3261, roborev round 3). This one is not a
+containment defect at all — the path IS contained — it is a SERIALIZATION defect, which is why
+nine rounds of containment work never touched it. `perf_capability_sysctl_search_path` emits its
+answer ONE ENTRY PER LINE and `perf_capability_competing_files` reads it line-wise, so a directory
+legitimately inside the sandbox but NAMED with an embedded newline —
+`<root>/name<LF>/etc/sysctl.d` — passes every containment check and is then SPLIT into two
+entries, the second of which is the host's real `/etc/sysctl.d`. One contained path became two
+paths, one of them production.
+The repo already knows this class: CLAUDE.md records the roborev guard's own `-z` invariant for
+exactly this reason — a newline-delimited path set is not a safe representation of paths, and the
+fix there was to stop using one. Here the answer is the cheaper half of the same lesson: REJECT
+the characters at the boundary rather than escape them downstream or re-plumb every consumer to
+NUL. A path with a newline in it has no legitimate use as a perf seam, so refusing it costs
+nothing and removes the ambiguity at its source. CR is rejected with LF because a CRLF host file
+would otherwise leave a stray `\r` inside a resolved entry.
+```
+
+### priv-tool-destination
+
+```
+perf_capability_priv_tool_ok <resolved-path> <tool-name>: rc 0 iff this privileged executable's
+RESOLVED destination is positively contained beneath the PROVEN sandbox root. Refuses loudly.
+
+WHY (issue #3261 AC4 — the EIGHTH escape from this guard family, and the first about an
+executable rather than a path). The shim dir was trusted TEXTUALLY: `/usr` is absolute and
+genuinely CONTAINS `/usr/bin/sudo`, so "inside the declared shim dir" passed; and a SYMLINK to
+the real `sudo`/`sysctl` placed inside a genuine shim dir is spelled locally while resolving to
+the host's binary. Either one let a privileged test-mode bootstrap run a real
+`sysctl --system` and reconfigure the host kernel — the exact mutation the marker promises
+cannot happen. Same discipline as the paths: the declared NAME is not the DESTINATION, so the
+destination is what is judged, positively, against a root that had to prove itself. The FILE
+form does the work (canonical parent + basename, and a symlinked final component is refused),
+which is also why a `/usr` shim dir fails: /usr/bin is not inside the sandbox.
+```
+
+### dropin-path-write-target
+
+```
+perf_capability_dropin_path: the path a root `tee` is pointed at. The DIRECTORY's gate lives in
+perf_capability_sysctl_dir (the single source of that directory) and RESOLVES the destination,
+so there is deliberately no second copy of it here — one gate, not a prohibition a future entry
+point could skip (R6-2).
+
+BUT DIRECTORY CONTAINMENT IS NOT WRITE-TARGET CONTAINMENT (issue #3261 AC1). A contained
+directory says nothing about where its ENTRIES point, and `tee <path>` opens
+O_WRONLY|O_CREAT|O_TRUNC and FOLLOWS a symlink — so a symlink at the managed basename inside a
+perfectly-contained directory aimed the privileged write at the LINK'S TARGET, anywhere on the
+box. The write TARGET is therefore validated too, as an O_NOFOLLOW-equivalent refusal: a
+symlink at the managed name is rc 1 + empty + a named reason, for every consumer at once
+(this function is the single source of the path). The complementary half is
+perf_capability_dropin_install, which REPLACES the directory entry instead of writing through
+it, closing the window between this check and the write.
+```

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -746,3 +746,89 @@ symlink at the managed name is rc 1 + empty + a named reason, for every consumer
 perf_capability_dropin_install, which REPLACES the directory entry instead of writing through
 it, closing the window between this check and the write.
 ```
+
+### tool-compatibility-is-exercised-here-in-the-priv
+
+```
+# TOOL COMPATIBILITY IS EXERCISED HERE, IN THE PRIVILEGED SHELL (roborev round 17, Medium — a
+# defect in the round-16 fix). The previous probe ran in the CALLERS PATH, but this shell is
+# entered through sudo, which applies its own secure_path: the two can resolve DIFFERENT stat and
+# mv binaries, so a caller-side check could pass while the privileged tools are incompatible, or
+# refuse while they would have worked. Same lesson already applied to mktemp here — the block
+# holding privilege re-checks rather than trusting what someone else established.
+# And the flags are EXERCISED, not grepped: reading mv --help proves a help string mentions
+# --no-target-directory, not that rename-over-a-name behaves. Two throwaway entries in the
+# already-validated directory are renamed one over the other, which is exactly the operation the
+# install depends on. rc 2 = UNSUPPORTED HOST, distinct from rc 1 = REFUSED.
+# Probed on `/`, a KNOWN-VALID operand, not on $d (roborev round 23, Medium): statting the
+# DESTINATION here conflated "no GNU stat" with "destination missing", so an absent /etc/sysctl.d
+# returned rc 2 and bootstrap suppressed a remedy that would have helped. Destination problems are
+# rc 1, reported by the owner/mode read further down; rc 2 means the TOOL is incompatible.
+```
+
+### usr-lib-sysctl-d-50-x-conf-outright-and-reporti
+
+```
+/usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would name
+a file that is not in effect.
+ORDERING the survivors are applied in lexicographic BASENAME order regardless of which
+directory they came from; the LAST assignment wins. /etc/sysctl.conf is applied
+AFTER every drop-in, so it wins on grounds unrelated to its name and gets its
+own verdict rather than a sort comparison.
+WHY THE WHOLE PATH (review R5-4). Scanning only /etc/sysctl.d meant a later-sorting file in
+/run/sysctl.d or /usr/lib/sysctl.d could override our drop-in while bootstrap reported NO
+competitor — recreating the "it silently reverts and nobody knows why" mystery this
+diagnostic exists to end.
+
+```
+
+### every-globbed-file-is-validated-in-test-mode-not
+
+```
+# EVERY GLOBBED FILE IS VALIDATED IN TEST MODE, NOT JUST ITS DIRECTORY (roborev round 11,
+# Medium). The scan validated the containing DIRECTORY and then trusted whatever the glob
+# produced inside it — but `[ -f ]` and `grep` both FOLLOW symlinks, so a link sitting inside a
+# perfectly contained sandbox directory and pointing at a real host `*.conf` was read, and its
+# contents fabricated "a competitor sets these keys" diagnostics out of HOST state. That is a
+# hermeticity escape in the DIAGNOSTIC path: the numbers a test asserts on would come from the
+# box rather than the fixture. Same lesson as the write path, one surface over — a contained
+# directory says nothing about where its ENTRIES point.
+# `perf_capability_sandbox_file_ok_resolved` is the AC3 predicate, reused rather than
+# reimplemented: it refuses a symlink outright and requires the canonical parent-plus-basename
+# to be strictly inside the declared sandbox. FAILS THE SCAN CLOSED, because a competitor we
+# declined to examine is exactly the UNKNOWN this diagnostic exists to report rather than hide.
+# Production is untouched: without CQLITE_PERF_TEST_MODE there is no sandbox and the real
+# /etc/sysctl.d files are the legitimate subject.
+```
+
+### mechanism-order-setpriv-util-linux-a-plain-setre
+
+```
+Mechanism order: `setpriv` (util-linux; a plain setresuid — no PAM, no session, no shell),
+then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC ids and
+never a name — `setpriv --reuid/--regid` and `sudo -u '#<uid>'` (sudo's documented
+numeric-uid form) — so no name has to be trusted (R4-2); `runuser` accepts only a name and
+is used ONLY with a passwd-confirmed one. The `#<uid>` token survives the caller's
+word-split intact: `#` starts a comment only while TOKENISING a source line, and this value
+arrives by EXPANSION afterwards. The prefix holds only literal tokens plus a validated
+numeric uid/gid or a confirmed name, so the caller may word-split it. A non-zero rc is NOT
+an error to fail on: it is the caller's cue to label the functional result as what it is —
+not evidence about an unprivileged process — and to let the /proc token be the authority.
+```
+
+### perf-capability-verify-prefix-word-the-functiona
+
+```
+perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (AC2). A bootstrap
+that silently leaves a box unprofileable is the failure mode being fixed, so the verdict
+comes from RUNNING the collection the doctrine mandates — `perf stat -C 0 -e cycles` — and
+requires BOTH exit 0 AND a non-zero cycle count: `perf stat` exits 0 while printing
+`<not supported>`/`<not counted>` (and a virtualised PMU can report a flat 0), so an
+rc-only check is exactly the false green this exists to prevent.
+
+Any arguments are a command prefix the collection runs under — the privilege-dropping
+prefix above. This function makes NO claim about identity: it runs what it is given and
+reports the counter. Deciding WHOSE capability was measured is the caller's job, because
+the caller owns the verdict.
+
+```

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -377,7 +377,10 @@ destination, positively, fail closed:
   `99-cqlite-perf.conf` inside a perfectly-contained directory aimed the privileged write anywhere on the
   box. Now: naming that target **refuses** when it is a symlink, the idempotency read never follows it
   (a link whose target holds the canonical bytes must not report "already current"), and the write is an
-  **atomic directory-entry replacement** — staged entry in the validated directory, then `rename` over
+  **atomic directory-entry replacement** — an **`mktemp`-created, unpredictably-named** staging entry
+  in the validated directory (a *predictable* staging name that is checked, cleared and only then
+  opened by a privileged writer is the same race one level down — and a pid suffix is predictable
+  too, so `mktemp`'s `O_EXCL` create is the point, not the suffix), then `rename` over
   the name — so a symlink planted between the check and the write is *replaced*, not written through.
 - **The fork-free read path is NOT exempt** — the earlier claim here that a syntactic check was "sound
   because nothing there writes" was **wrong**, and this is what falsified it. A symlink *inside* the

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -1318,3 +1318,54 @@ are capability-probed and COUNTED-skipped off GNU (roborev round 5). Neither por
 the repo scans this file, so nothing mechanically protects the gate; recorded, not papered over.
 ```
 
+### every-seam-is-unset-per-iteration-not-just-the
+
+```
+EVERY seam is unset per iteration, not just the marker (roborev round 33, Low, and it was RIGHT).
+perf-capability-test-lib.sh:156 EXPORTS CQLITE_PERF_TEST_SANDBOX suite-wide, so leaving it set made
+seam_set answer true through the INHERITED variable no matter which seam was under test. It was
+invisible for the worst possible reason: before the fix seam_set did not NAME that seam, so the loop
+measured correctly and went red for exactly the three missing ones -- the very fix that turned it
+green is what would have made it vacuous. A negative control confirmed the repair: with seam_set
+reverted to its two-name form, this loop fails again on those three seams.
+```
+
+### b27
+
+```
+
+POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds each
+closed ONE MORE SPELLING of "the production directory": the raw path (B3), a symlinked seam,
+`..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes implementation-defined,
+`pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A denylist over path spellings
+cannot be completed — `.`, `..`, symlinks, `//`, trailing slashes, bind mounts,
+`/proc/self/root/…` all name the same directory — and scattered prohibitions also let a NEW
+entry point silently miss them (R6-2). So the rule is INVERTED and there is exactly ONE: a
+seam is usable IFF it is strictly contained in the declared sandbox root. Every spelling of
+"somewhere else", including every future one, fails that single check for the same reason.
+TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams are
+MANDATORY. The earlier shape — marker set, seam unset, fall back to the real directory —
+meant test mode could pass the env guard (sudo/sysctl absent, or present as declared shims)
+and a subsequent root `--yes` run would `tee` the REAL /etc/sysctl.d, mutating the host from
+a test run. "Hermetic" cannot be a claim that depends on a variable being set.
+```
+
+### perf-capability-seam-set-rc-0-iff-any-test-onl
+
+```
+perf_capability_seam_set: rc 0 iff ANY test-only seam is non-empty. The ONE
+seam reader outside the containment gate below, and deliberately so: it asks only
+"was a seam handed to us at all" (for the marker-less refusal) and never uses the
+VALUE as a path. The structural audit in test_perf_capability.sh allowlists it by
+name, so a future function cannot join it silently.
+
+EVERY non-marker seam MUST be listed here (roborev round 32, Medium). This named only PROC_DIR
+and SYSCTL_DIR while the file had grown three more, so any of those exported WITHOUT the marker
+passed the guard — the marker-less refusal failing OPEN, which is the same incomplete-list-of-
+names shape this whole file exists to avoid. The round-6 audit that was supposed to protect this
+policed WHICH FUNCTIONS may read a seam, never WHICH SEAMS this list must name, so it was blind
+to an omission by construction. The completeness direction is now enforced by CENSUS in
+test_perf_capability.sh (1c-iv): every CQLITE_PERF_* name the library reads, minus the marker
+itself, must appear below — so adding a seam without listing it here FAILS the suite.
+```
+

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -909,3 +909,72 @@ whitespace or glob characters could inject extra argv tokens.
 # row with a positive numeric count; keep the first matching row's raw field as the fallback
 # so the `<not supported>` / zero diagnostics below still fire when none is positive.
 ```
+
+### structurally-the-staging-entry-is-created-b
+
+```
+# ...structurally: the staging entry is created by `mktemp` with a random-suffix template, no
+# hardcoded staging literal survives, the rename carries `-T`, and the WHOLE staged install is ONE
+# privileged invocation (issue #3261 roborev round 2).
+#   THE LAST PROPERTY IS HYGIENE, NOT THE FIX, and this comment previously said otherwise. roborev
+#   round 3 corrected it: a single `sh -c` sequences ONE PROCESS's commands and is not mutual
+#   exclusion against other processes, which run concurrently on other CPUs regardless of how we
+#   grouped ours. Consolidation NARROWS the create-to-reopen window; it does not close it. It is
+#   still worth pinning — a split back into `mktemp` in one privileged call and the write in another
+#   would re-widen the window while every behavioural assert stayed green, which no after-the-fact
+#   observation can catch — but it is pinned as hygiene, not as the guarantee.
+```
+
+### and-the-precondition-that-actually-closes-t
+
+```
+# ...and THE PRECONDITION THAT ACTUALLY CLOSES THE STAGING RACE (issue #3261, roborev round 3): a
+# drop-in directory writable by anyone less privileged than the writer is REFUSED before anything is
+# staged. Three rounds of this defect were each answered by trying to make the race unwinnable
+# (unpredictable name, then one privileged invocation); neither works, because a single `sh -c`
+# sequences OUR commands and says nothing about other processes on other CPUs. Removing the
+# attacker's precondition does work — with no one able to create or replace entries in the
+# directory, there is no actor to race, whatever the timing.
+# The negative control is the whole point of the group: a check that refuses everything would pass
+# the two refusal cases and be useless, so a correctly-owned 0755 directory must still install.
+```
+
+### a-short-mode-from-stat-c-a-must-not-bypass
+
+```
+# ...a SHORT MODE from `stat -c %a` must not bypass the write-bit check (roborev round 5, High).
+# WHY A SHIM AND NOT A REAL chmod: `%a` only drops below three digits when the OWNER digit is 0,
+# and a directory its owner cannot enter fails containment long before the mode check — so the real
+# bypass is NOT reachable through an actual chmod under test mode. It IS reachable as root in
+# production, where root ignores permission bits and enters a mode-0033 /etc/sysctl.d happily while
+# group and other retain write. So the honest reproduction is to feed the parser the short string a
+# root `stat` would really print, against an enterable directory. Without the zero-padding this
+# reports "33", the suffix-strip leaves the permission field EMPTY, no write-bit pattern matches,
+# and a group- AND world-writable directory is ACCEPTED.
+```
+
+### 1g-ii-ac2-medium-the-inversion-regressed-sym
+
+```
+1g-ii. AC2 (Medium) — the inversion REGRESSED symlink rejection on the READ path. The
+fork-free proc check judges the SPELLING, so a symlink INSIDE the sandbox pointing at
+the real /proc/sys/kernel satisfies containment: the run then reports a capability
+token derived from the HOST's real controls while claiming to have read a stand-in.
+That is a FABRICATED verdict, which is worse than a refusal, and it is a regression
+against the pre-inversion behaviour. The token path is contractually fork-free, so the
+fix must reject symlinked COMPONENTS with builtins only.
+```
+
+### 1g-iv-ac4-high-the-guard-authorizes-executab
+
+```
+1g-iv. AC4 (High) — the guard authorizes EXECUTABLES, and never resolved them. Two escapes,
+one shape: an absolute shim dir that is not in the sandbox at all (`/usr` — it does
+contain the real /usr/bin/sudo, so the textual "inside the declared dir" check
+PASSED), and a SYMLINK to the real tool sitting inside a genuine shim dir (spelled
+locally, resolving to the host's binary). Either one let a privileged test-mode
+bootstrap execute a real `sysctl --system` and reconfigure the host kernel.
+`$ac4_sys` stands in for `/usr` PORTABLY: an absolute directory OUTSIDE the declared
+sandbox root that holds tools named `sudo`/`sysctl`. Asserting against the literal
+/usr would make the case depend on whether this host happens to ship sudo there.
+```

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -1468,3 +1468,132 @@ ROOT process look unprivileged, so its root perf run was accepted as unprivilege
 and printed a false VERIFIED — the R3-1 defect, through the detector written to prevent it.
 ```
 
+### test-mode-a-proven-sandbox-root-plus-both-seam
+
+```
+test mode: a PROVEN sandbox root plus BOTH seams RESOLVING
+strictly inside it, plus every reachable sudo/sysctl inside
+an absolute declared shim dir.
+dropin_path rc 0            its directory came from `sysctl_dir`, i.e. RESOLVES inside the
+sandbox — the single gate between the bytes and a root `tee`.
+dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against the
+canonical content from a read that reached EOF — a
+NUL-delimited read is NOT current (R5-3).
+```
+
+### no-symlinked-component-including-the-root-s-ow
+
+```
+NO SYMLINKED COMPONENT, including the root's own final component (roborev round 32, Medium).
+Without this the function advertised a canonically spelled root while accepting one reached
+THROUGH a symlink, and the two containment paths then disagreed about the identical root and
+child: measured rc 1 from the fork-free sandbox_ok versus rc 0 from the resolving
+sandbox_ok_resolved. One sandbox must not be both contained and not contained. REJECTING rather
+than canonicalizing is forced, not preferred: this function is in the closed fork-free audit set
+and canonicalizing would need cd -P plus pwd -P, i.e. a forked subshell. A root must be spelled
+as its own destination -- the same rule the drop-in destination and the shim tools already obey.
+```
+
+### the-containment-predicate-and-the-only-place-a
+
+```
+THE containment predicate, and the only place a path is ever judged: rc 0 iff <path> is
+absolute, canonically spelled (no `.`, `..` or `//` component — `//etc` IS `/etc`, R6-1),
+free of CR/LF (so a contained path can never SERIALIZE into two entries, roborev round 3)
+and STRICTLY inside <root>, with the `/` boundary explicit so `/tmp/sandboxevil` is NOT
+inside `/tmp/sandbox`. An empty root refuses; it is never a wildcard.
+The line check lives HERE, in the one predicate every entry point ends in, for the same reason
+containment does: one choke point cannot be skipped by a future consumer.
+```
+
+### perf-capability-nosymlink-rc-0-iff-path-is-abs
+
+```
+perf_capability_nosymlink: rc 0 iff <path> is absolute and NO path component — the final one
+INCLUDED — is a symlink. FORK-FREE: `[ -L ]` is a shell builtin test, so this is usable on the
+gate's contractually fork-free token path, where `cd -P`/`pwd -P` (a subshell, i.e. a process)
+is not.
+
+WHY (issue #3261 AC2). Containment of a SPELLING is not containment of a DESTINATION. The
+inversion to positive containment made the fork-free read check purely textual and thereby
+(rationale condensed; full reasoning in the commit history for #3261.)
+```
+
+### the-file-variant-judged-as-canonical-parent-ba
+
+```
+The FILE variant. Judged as <CANONICAL PARENT>/<basename> (issue #3261 AC3): canonicalizing the
+parent and asking whether THE PARENT is contained refused `<sandbox-root>/sysctl.conf`, because
+the parent there IS the root and a root is not STRICTLY inside itself — a legitimate,
+strictly-contained file rejected, which is how a guard teaches people to route around it. The
+assembled path is the thing being authorized, so it is the thing judged.
+The final component may not be a SYMLINK (the AC1 lesson, here on a read whose CONTENTS are
+consumed): a symlinked `sysctl.conf` inside the sandbox would feed the competing-file scan the
+host's real configuration.
+```
+
+### the-into-outvar-convention-the-gate-s-summary
+
+```
+THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain below and
+is contractually FREE — no external process AND no command substitution (each `$( )` forks
+a subshell, which is a process too). A function that answers on stdout therefore CANNOT be
+on that path: its caller must fork to read it. So every function the gate touches has an
+`_into <outvar>` core assigning through a caller-named variable, and the stdout-printing
+form is a thin wrapper for CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork
+is paid, and it is not on the gate's path. Assignment is `eval "$1=\$var"`, NOT a
+(rationale condensed; full reasoning in the commit history for #3261.)
+```
+
+### normalise-before-the-gate-exactly-as-the-sandb
+
+```
+NORMALISE BEFORE THE GATE, exactly as the sandbox root does (roborev round 33, Low). Stripping
+after the containment check left the two halves inconsistent: the ROOT accepted a "//" trailing
+spelling while PROC_DIR refused the identical one, because the gate saw the raw value. Callers
+join with "/$name", so an unnormalised trailing slash also built a "//" entry path that the
+entry-level check then refused -- surfacing as the capability verdict "absent" rather than as a
+refusal, i.e. a mere spelling became a definite negative claim about the host, in the one
+function the gate's perf= token comes from. INTERIOR "//" stays refused: only trailing
+separators are normalised, and a non-canonical spelling is still not a destination.
+```
+
+### trailing-slashes-are-stripped-before-any-check
+
+```
+TRAILING SLASHES ARE STRIPPED BEFORE ANY CHECK OR PATH CONSTRUCTION (roborev round 10, Low).
+`[ -L "$d" ]` FOLLOWS a trailing slash: for a symlinked directory `link`, `[ -L link ]` is true
+but `[ -L link/ ]` and `[ -L link// ]` are FALSE, so the destination-symlink refusal this
+function explicitly promises could be walked past with one extra character. Stripping is the
+right shape here and NOT another spelling denylist: normalising the input to ONE canonical form
+makes the affirmative check total, whereas enumerating bad spellings is the unbounded game this
+family lost eleven times. The length guard keeps `/` itself from becoming the empty string —
+a root destination then fails the ownership/writability precondition on its own merits rather
+than by accident.
+```
+
+### content-is-generated-and-checked-before-any-pr
+
+```
+CONTENT IS GENERATED AND CHECKED **BEFORE** ANY PRIVILEGED COMMAND RUNS (roborev round 9,
+Medium). This used to pipe the generator straight into the privileged shell, so the pipeline's
+status was the LAST command's and a failed generator was invisible unless the CALLER happened to
+have `pipefail` set — a correctness property no library function should delegate to its caller.
+Worse, the privileged write would already have started on empty or partial content. Generating
+first means a generator failure returns before privilege is acquired at all. Same sentinel trick
+as dropin_current, for the same reason: `$( )` strips trailing newlines, and the drop-in's final
+newline is part of the canonical bytes the idempotency compare comes back for.
+```
+
+### zero-pad-before-taking-the-last-three-digits-s
+
+```
+ZERO-PAD BEFORE TAKING THE LAST THREE DIGITS. `stat -c %a` drops leading zeros, so mode 0033
+arrives as "33" — and `${dmode%???}` cannot match a 2-character string, leaving `dperm` EMPTY,
+matching none of the write-bit patterns below, and PASSING a group- AND world-writable
+directory. That was a real bypass of this very precondition (roborev round 5, High), and it
+survived a hand audit that reasoned about the 3- and 4-digit cases and never considered a
+SHORTER one. The suffix-strip idiom is only safe once the string is known to be long enough,
+so the padding is not cosmetic: it is what makes the check below total.
+```
+

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -382,6 +382,22 @@ destination, positively, fail closed:
   opened by a privileged writer is the same race one level down — and a pid suffix is predictable
   too, so `mktemp`'s `O_EXCL` create is the point, not the suffix), then `rename` over
   the name — so a symlink planted between the check and the write is *replaced*, not written through.
+  Two further properties, both learned the hard way one level deeper:
+  **(a)** the whole staged install — `mktemp`, write, `chmod`, `rename` — runs inside **one privileged
+  invocation**, because `mktemp` returns a *name* and every later step **reopens it by name**, so
+  splitting them leaves a create→reopen window an attacker can use even though the name is random;
+  **(b)** the rename carries **`-T`/`--no-target-directory`**. Without it a **symlink-to-directory** at
+  the managed name makes `mv` move the staging file *into* that directory — the rename that exists to
+  avoid *following* a symlink follows one instead. Reproduced: the staging entry landed inside the
+  outside directory, i.e. the managed bytes left the sandbox under a name nothing tracks.
+  **The residual is recorded, not waved away:** consolidation *shrinks* that window to the inside of one
+  root process; it does **not** mathematically eliminate it, because POSIX shell has no
+  `O_NOFOLLOW|O_EXCL` open primitive. Closing it fully needs a non-shell helper holding the descriptor
+  from creation to rename, which would add an interpreter dependency to the privileged bootstrap path —
+  an owner call, deferred. Exploitation needs a real privileged `tee` **and** an attacker-writable
+  drop-in directory (production's `/etc/sysctl.d` is root-owned; test mode requires sandbox-contained
+  shims) — a **boundary, not a proof of unreachability**. "Cannot happen" has been wrong nine times in
+  this family and one comment here already had to be retracted.
 - **The fork-free read path is NOT exempt** — the earlier claim here that a syntactic check was "sound
   because nothing there writes" was **wrong**, and this is what falsified it. A symlink *inside* the
   sandbox pointing at the real `/proc/sys/kernel` satisfies containment, so the run reported a token

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -1369,3 +1369,102 @@ test_perf_capability.sh (1c-iv): every CQLITE_PERF_* name the library reads, min
 itself, must appear below — so adding a seam without listing it here FAILS the suite.
 ```
 
+### 1c-vii-the-probe-deletes-nothing-it-did-not-cr
+
+```
+1c-vii. THE PROBE DELETES NOTHING IT DID NOT CREATE, and a WORKING mv that FAILS is not an
+unsupported host (roborev round 34: Medium + Low). The probe used to rm -f its predictable
+".perfcap-probe.<pid>" names before proving absence, so a stale entry -- or, after PID reuse, an
+unrelated file -- was silently deleted under privilege; the round-21 absence proof closed the
+symlink-truncation hazard but left the delete itself. And every rename failure was reported as
+rc 2 UNSUPPORTED, so a filesystem or mount-policy failure suppressed the retry remedy precisely
+where retrying is right. These cases need GNU staging, so they ride the same capability gate.
+```
+
+### the-production-paths-below-are-hardcoded-liter
+
+```
+The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
+bootstrap installs the drop-in through the STAGED installer below (mktemp + atomic rename, no
+`tee <path>`): were that path env-derived, one stray
+export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d) would make ROOT write an
+attacker/accident-chosen file while the real drop-in was never installed — and an unparsable
+sudoers entry can wedge `sudo` outright. Likewise an env-chosen /proc stand-in would let a
+paranoid-4 box print a FABRICATED "verified" verdict. So the seams take effect ONLY under
+the explicit marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
+reachable on PATH is a hard refusal (the suite PATH-shims both and declares the shim
+directory), so test mode can never reach a real privileged tool.
+CQLITE_PERF_TEST_MODE=1     the marker; without it every seam below is INERT
+CQLITE_PERF_TEST_SANDBOX    THE SANDBOX ROOT — the one absolute directory every other
+seam must be provably INSIDE (test mode only)
+```
+
+### dropped-mech-asserts-the-mechanism-was-invoke
+
+```
+* "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel changed
+uid. Harmless by construction: the caller's verdict is `token = ok` AND the functional
+pass, and a box whose /proc says ok IS profileable unprivileged, so a mislabelled drop
+cannot manufacture a capability that is absent.
+* the READ-side containment check is SYNTACTIC (fork-free, gate contract) while every
+write / host-config read canonicalizes — SAME predicate, different input form. The read
+side judges the spelling, so a symlinked ancestor INSIDE the sandbox could still steer a
+test-mode /proc STAND-IN read. Bounded by that path's whole contract: the seams are
+honoured only under the test marker, which is never set in production, and nothing there
+writes — so the worst case is a read of a caller-chosen file reported as
+`absent`/`unknown`, never a fabricated capability.
+
+```
+
+### one-gate-positive-sandbox-containment-review
+
+```
+---- ONE GATE: POSITIVE SANDBOX CONTAINMENT (review R6-1/R6-2) --------------------
+THE sandbox root is caller-declared (CQLITE_PERF_TEST_SANDBOX) and must PROVE itself: an
+absolute, canonically spelled, existing directory carrying the stamp file below. The stamp is
+what makes the declaration unforgeable by environment alone — a stray
+CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on the
+FILESYSTEM and writing it into a system directory already needs the privilege this guard
+protects. No denylist appears below: a path is usable because it is provably INSIDE the
+sandbox, never because it failed to look like somewhere forbidden.
+
+FIVE thin functions, ONE predicate — everything ends in perf_capability_path_within:
+sandbox_root_into O        the declared root, validated; rc 1 + empty when unproven
+path_within P R            THE predicate (below)
+(rationale condensed; full reasoning in the commit history for #3261.)
+```
+
+### mv-t-is-exercised-here-after-the-ownership-pre
+
+```
+mv -T IS EXERCISED HERE, AFTER the ownership precondition and BEFORE the real staging entry.
+Placement is deliberate on both sides. AFTER the precondition, because that is what establishes
+no less-privileged actor can create entries in $d — which is precisely what makes a PREDICTABLE
+probe name safe, so this does not need (and must not consume) mktemp. NOT consuming mktemp also
+keeps it from pre-empting the staging entry checks below, which have their own cases.
+-T SUPPORT IS QUERIED, NEVER INFERRED FROM A FAILED RENAME (roborev round 34, Low). Treating
+every probe-rename failure as "no GNU mv" misdiagnosed filesystem errors, mount policy and
+transient conditions as an unsupported HOST, which made bootstrap suppress the retry remedy in
+exactly the cases where retrying is the right advice. Capability and outcome are now separate
+questions: this asks whether -T exists, the rename below asks whether it works here.
+```
+
+### arguably-the-most-likely-one-since-installing
+
+```
+(arguably the most likely one, since installing the drop-in needs root). A root-run
+functional check reported as "perf capability verified" is therefore a FALSE verification
+of an unprofileable box: the failure mode the functional check exists to remove,
+reintroduced through the privilege dimension. The property under test is "an UNPRIVILEGED
+process can collect CPU-WIDE cycles", which a root-run probe cannot demonstrate — so the
+probe DROPS PRIVILEGE when it can and SAYS SO when it cannot, and the caller then
+subordinates the functional result to the identity-independent /proc token.
+
+perf_capability_self_uid_into <outvar>: THIS process's uid, rc 0 ONLY when genuinely known
+— `id -u` must EXIST, exit 0, and print a validated non-negative integer. rc 1 (<outvar>
+emptied) means "identity unknown", which is NOT "unprivileged" (review R4-1). The previous
+shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or broken `id` made a
+ROOT process look unprivileged, so its root perf run was accepted as unprivileged evidence
+and printed a false VERIFIED — the R3-1 defect, through the detector written to prevent it.
+```
+

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -303,9 +303,38 @@ SHALL be canonicalized and the resulting file path validated) — and a consumer
 SHALL be a failure of the test suite's structural audit rather than an unvalidated path. On
 every path that WRITES, gates a write, or reads host configuration, containment SHALL be
 judged on the CANONICALIZED candidate and root (`.`, `..` and symlinked ancestors resolved).
-The emit-time read path, which writes nothing and is contractually fork-free, MAY apply the
-same containment check syntactically, since its guarantee rests on the marker being absent
-in production and a mis-accepted spelling there can only read a caller-chosen file.
+
+Containment SHALL be judged on the DESTINATION, never on a NAME, and that rule SHALL extend
+to everything the guard authorizes — not only to the directories it names:
+
+- **The write TARGET, not only its containing directory.** A contained directory says nothing
+  about where its ENTRIES point, and a privileged `tee <path>` opens with `O_CREAT|O_TRUNC`
+  and FOLLOWS a symlink. So the managed file's own final component SHALL be validated (a
+  symlink there SHALL be a loud refusal), AND the privileged write SHALL be an atomic
+  directory-entry REPLACEMENT — content staged to a fresh entry in the validated directory,
+  then renamed over the name — so a symlink appearing in the window between the check and the
+  write is replaced rather than written through. A read that decides idempotency SHALL NOT
+  follow the entry either, or a link whose target holds the canonical bytes would report
+  "already current" while the managed file does not exist.
+- **The emit-time read path too.** It writes nothing and is contractually fork-free, but a
+  syntactic-only check there is NOT sound: a symlink INSIDE the proven sandbox pointing at the
+  real `/proc/sys/kernel` satisfies containment, and the run then reports a capability verdict
+  derived from the HOST's real controls while claiming to have read a stand-in. A FABRICATED
+  verdict is strictly worse than a refusal. That path SHALL therefore reject a symlinked path
+  COMPONENT using shell builtins only (`[ -L ]` forks nothing), or be handed an
+  already-canonicalized, already-verified path — the fork-free contract STANDS either way.
+- **A strictly-contained file SHALL be ACCEPTED.** The file form SHALL be judged as
+  `<canonical parent>/<basename>`, not by asking whether the PARENT is strictly contained: a
+  file directly inside the root has the root as its parent, and a root is not strictly inside
+  itself. A guard that refuses legitimate input is the guard people route around.
+- **EXECUTABLES, not just paths.** The privileged-tool shim directory SHALL NOT be trusted
+  textually: an absolute directory that merely CONTAINS the real tools (`/usr`) satisfies
+  "inside the declared shim dir", and a symlink to the real `sudo`/`sysctl` placed inside a
+  genuine shim dir is spelled locally while resolving to the host's binary. Every privileged
+  executable's RESOLVED destination SHALL be positively contained beneath the proven sandbox
+  root, and the privileged tools PARKED in the declared shim dir SHALL be validated whether or
+  not `PATH` happens to reach them. The structural audit SHALL cover privilege-shim resolution
+  as well as seam paths.
 
 When the read-back reports a restrictive `perf_event_paranoid`/`kptr_restrict` state, the
 diagnostics SHALL NAME the competing configuration files across the COMPLETE
@@ -420,6 +449,47 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
 - **THEN** each SHALL route through the containment check, with only an explicitly named and
   justified allowlist (a presence-only predicate and the root reader itself), and finding no
   consumers at all SHALL be a failure rather than a vacuous pass
+- **AND** a SECOND pass SHALL audit every function that RESOLVES a privileged tool, with the
+  same floor and the same named-allowlist rule, so the EXECUTABLES the guard authorizes cannot
+  silently skip containment either
+
+#### Scenario: a symlinked write target is never followed
+- **GIVEN** the test-mode marker, a sysctl seam strictly contained in the proven sandbox, and
+  the managed drop-in basename present INSIDE it as a SYMLINK to a file outside the sandbox
+- **WHEN** the write target is named, the idempotency read runs, or the drop-in is written
+- **THEN** naming it SHALL refuse (non-zero, empty, and saying the name is a symlink), the
+  idempotency read SHALL NOT report "already current" even when the link's target holds
+  byte-identical canonical content, and the write SHALL replace the directory ENTRY
+- **AND** the link's target SHALL be byte-unchanged throughout, and no staging entry SHALL be
+  left behind
+
+#### Scenario: a symlinked read seam cannot fabricate a capability verdict
+- **GIVEN** the test-mode marker and a proc seam whose spelling is strictly inside the proven
+  sandbox but which is (or traverses) a SYMLINK to the real `/proc/sys/kernel`
+- **WHEN** the fork-free capability token is resolved
+- **THEN** it SHALL refuse to read, reporting the absent-stand-in token, never a verdict
+  derived from the host's real controls
+- **AND** a real, symlink-free stand-in directory inside the sandbox SHALL still read, so the
+  rejection is per-component rather than a blanket refusal
+
+#### Scenario: a strictly-contained sysctl.conf stand-in is accepted
+- **GIVEN** the test-mode marker and a `sysctl.conf` stand-in directly inside the proven
+  sandbox root, offered as a lower-precedence search-path entry
+- **WHEN** the search path is resolved
+- **THEN** the entry SHALL be ACCEPTED and appear on the path, while one outside the root, the
+  root itself, a `..` spelling, a relative path and a SYMLINKED final component SHALL each
+  still be refused
+
+#### Scenario: a privileged executable outside the sandbox refuses to act
+- **GIVEN** the test-mode marker and a declared privileged-shim directory that is absolute but
+  not contained in the proven sandbox root (the `/usr` shape), or one that IS contained but
+  whose `sudo`/`sysctl` is a SYMLINK resolving to a tool outside it — including one merely
+  PARKED there that `PATH` does not reach
+- **WHEN** the environment guard runs
+- **THEN** it SHALL refuse, naming the sandbox, so a privileged test-mode run can never execute
+  a real `sysctl --system` against the host kernel
+- **AND** a shim directory of REAL FILES inside the sandbox SHALL still be accepted, so the
+  check is not vacuous
 
 #### Scenario: re-run writes nothing
 - **WHEN** bootstrap runs twice on the same host

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -311,7 +311,12 @@ to everything the guard authorizes — not only to the directories it names:
   about where its ENTRIES point, and a privileged `tee <path>` opens with `O_CREAT|O_TRUNC`
   and FOLLOWS a symlink. So the managed file's own final component SHALL be validated (a
   symlink there SHALL be a loud refusal), AND the privileged write SHALL be an atomic
-  directory-entry REPLACEMENT — content staged to a fresh entry in the validated directory,
+  directory-entry REPLACEMENT — content staged to a fresh entry in the validated directory
+  whose name SHALL be UNPREDICTABLE and SHALL be created by the staging tool itself with
+  `O_CREAT|O_EXCL` (a PREDICTABLE staging path that is checked, cleared and only then opened by
+  a privileged writer is the same check-then-open race one level down: the name can be
+  re-planted as a symlink in that window, and a predictable *suffix* such as a pid does not
+  help),
   then renamed over the name — so a symlink appearing in the window between the check and the
   write is replaced rather than written through. A read that decides idempotency SHALL NOT
   follow the entry either, or a link whose target holds the canonical bytes would report

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -280,14 +280,32 @@ environment, and every variable the section's control flow reads SHALL be initia
 the section BEFORE the platform/library guards, so no inherited environment value can
 enter a Linux-only implementation on another platform or without its helper library. The
 test-only path seams SHALL be inert without their explicit marker, and UNDER the marker
-BOTH seams SHALL be MANDATORY, absolute and outside `/etc`, `/proc` and `/sys`: a missing
-or production-shaped seam SHALL be a loud refusal in the env guard AND in the path
-resolvers, so a test-mode run can never fall back to a production directory and mutate the
-host. On every path that WRITES or gates a write, that judgement SHALL be made on the
-seam's CANONICAL destination — `.`, `..` and symlinked ancestors resolved — and not on its
-spelling, since a textual check accepts an unbounded set of paths that resolve into the
-production directory. The emit-time read path, which writes nothing and is contractually
-fork-free, MAY validate textually (rejecting `.`/`..` components and a symlinked seam).
+BOTH seams SHALL be MANDATORY: a seam that is not usable SHALL be a loud refusal in the env
+guard AND in the path resolvers, so a test-mode run can never fall back to a production
+directory and mutate the host.
+
+A seam's usability SHALL be decided by POSITIVE CONTAINMENT and by nothing else: test mode
+SHALL take ONE caller-declared sandbox root, and a seam SHALL be usable IFF it is STRICTLY
+contained within that root (a resolved-path prefix match with an explicit `/` boundary, so a
+sibling whose name merely starts with the root's is outside). Anything not provably inside
+the sandbox SHALL be refused. The implementation SHALL NOT decide usability from a list of
+forbidden locations or path spellings: such a list cannot be completed — `.`, `..`,
+symlinks, `//` (POSIX leaves two leading slashes implementation-defined and `pwd -P` may
+preserve them, while on Linux `//etc` opens `/etc`), trailing slashes, bind mounts and
+`/proc/self/root/…` all name the same directory — and a set of scattered prohibitions also
+lets a NEW seam consumer silently miss them. The sandbox root SHALL itself prove it is a
+sandbox by evidence on the filesystem (an absolute, canonically spelled, existing directory
+carrying a stamp file), so no environment value alone can nominate a production directory as
+the sandbox. EVERY consumer of a seam SHALL route through that one containment check —
+writes, write gating, the drop-in path, and every read of configuration (including the
+lower-precedence search-path entries and an optional `sysctl.conf` FILE entry, whose parent
+SHALL be canonicalized and the resulting file path validated) — and a consumer that does not
+SHALL be a failure of the test suite's structural audit rather than an unvalidated path. On
+every path that WRITES, gates a write, or reads host configuration, containment SHALL be
+judged on the CANONICALIZED candidate and root (`.`, `..` and symlinked ancestors resolved).
+The emit-time read path, which writes nothing and is contractually fork-free, MAY apply the
+same containment check syntactically, since its guarantee rests on the marker being absent
+in production and a mis-accepted spelling there can only read a caller-chosen file.
 
 When the read-back reports a restrictive `perf_event_paranoid`/`kptr_restrict` state, the
 diagnostics SHALL NAME the competing configuration files across the COMPLETE
@@ -377,14 +395,31 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
   command, SHALL write nothing (in particular not the real `/etc/sysctl.d` drop-in), SHALL
   claim no verdict, and SHALL exit 0
 
-#### Scenario: a test seam that RESOLVES into production refuses to act
-- **GIVEN** the test-mode marker set, a root identity, and a sysctl path seam that passes
-  every textual non-production check but resolves into `/etc/sysctl.d` — `/tmp/../etc/sysctl.d`,
-  or `<symlink-to-/etc>/sysctl.d`
+#### Scenario: a test seam outside the declared sandbox refuses to act
+- **GIVEN** the test-mode marker set, a root identity, and a sysctl path seam that is not
+  strictly contained in the declared sandbox root — `/tmp/../etc/sysctl.d`,
+  `<symlink-to-/etc>/sysctl.d`, `//etc/sysctl.d`, a symlink whose target is outside the
+  sandbox, a relative path, or a sibling whose name merely starts with the root's
 - **WHEN** bootstrap runs with `--yes`
-- **THEN** it SHALL refuse the section with a loud diagnosis, SHALL invoke no privileged
-  command, SHALL leave the real drop-in byte- and metadata-unchanged, SHALL name no write
-  target at all, and SHALL exit 0
+- **THEN** it SHALL refuse the section with a loud diagnosis NAMING the offending seam, SHALL
+  invoke no privileged command, SHALL leave the real drop-in byte- and metadata-unchanged,
+  SHALL name no write target at all, and SHALL exit 0
+- **AND** the refusal SHALL come from the single containment check, so no per-spelling rule
+  is required for any of those forms, nor for a form not yet enumerated
+
+#### Scenario: an unproven sandbox root cannot make containment vacuous
+- **GIVEN** the test-mode marker set and a sandbox root that is unset, relative,
+  `//`-spelled, non-existent, or an existing directory carrying no sandbox stamp
+- **WHEN** any seam consumer resolves a path
+- **THEN** it SHALL refuse, naming the sandbox-root variable, so declaring a production
+  directory as the sandbox by environment alone cannot succeed
+
+#### Scenario: a seam consumer cannot skip the containment check
+- **GIVEN** the helper's source
+- **WHEN** the test suite audits every function that dereferences a seam variable
+- **THEN** each SHALL route through the containment check, with only an explicitly named and
+  justified allowlist (a presence-only predicate and the root reader itself), and finding no
+  consumers at all SHALL be a failure rather than a vacuous pass
 
 #### Scenario: re-run writes nothing
 - **WHEN** bootstrap runs twice on the same host

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -316,7 +316,13 @@ to everything the guard authorizes — not only to the directories it names:
   `O_CREAT|O_EXCL` (a PREDICTABLE staging path that is checked, cleared and only then opened by
   a privileged writer is the same check-then-open race one level down: the name can be
   re-planted as a symlink in that window, and a predictable *suffix* such as a pid does not
-  help),
+  help). The staging create, the write, the mode fix and the rename SHALL occur within a SINGLE
+  privileged invocation, since the staging tool yields a NAME and every later step reopens it by
+  name — so splitting them leaves a create-then-reopen window that an unpredictable name does not
+  close. The rename SHALL refuse to treat its destination as a directory
+  (`--no-target-directory`), or a symlink-to-DIRECTORY planted at the managed name redirects the
+  staged file outside the sandbox. Any window that REMAINS SHALL be recorded as a residual with
+  its reachability boundary stated, and SHALL NOT be described as unreachable,
   then renamed over the name — so a symlink appearing in the window between the check and the
   write is replaced rather than written through. A read that decides idempotency SHALL NOT
   follow the entry either, or a link whose target holds the canonical bytes would report
@@ -467,6 +473,15 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
   byte-identical canonical content, and the write SHALL replace the directory ENTRY
 - **AND** the link's target SHALL be byte-unchanged throughout, and no staging entry SHALL be
   left behind
+
+#### Scenario: a symlink to a DIRECTORY at the destination cannot redirect the staged write
+- **GIVEN** the test-mode marker, a contained sysctl seam, and the managed drop-in basename
+  present inside it as a SYMLINK to a DIRECTORY outside the sandbox
+- **WHEN** the drop-in is installed
+- **THEN** the link SHALL be replaced by a regular file holding the managed bytes, the outside
+  directory SHALL remain EMPTY, and no staging entry SHALL be left behind
+- **AND** the staged install SHALL be observable as a SINGLE privileged invocation, so no
+  unprivileged process can be scheduled between the staging create and its reopen
 
 #### Scenario: a symlinked read seam cannot fabricate a capability verdict
 - **GIVEN** the test-mode marker and a proc seam whose spelling is strictly inside the proven

--- a/openspec/specs/agent-fleet-runtime/spec.md
+++ b/openspec/specs/agent-fleet-runtime/spec.md
@@ -316,13 +316,16 @@ to everything the guard authorizes — not only to the directories it names:
   `O_CREAT|O_EXCL` (a PREDICTABLE staging path that is checked, cleared and only then opened by
   a privileged writer is the same check-then-open race one level down: the name can be
   re-planted as a symlink in that window, and a predictable *suffix* such as a pid does not
-  help). The staging create, the write, the mode fix and the rename SHALL occur within a SINGLE
-  privileged invocation, since the staging tool yields a NAME and every later step reopens it by
-  name — so splitting them leaves a create-then-reopen window that an unpredictable name does not
-  close. The rename SHALL refuse to treat its destination as a directory
+  help). The rename SHALL refuse to treat its destination as a directory
   (`--no-target-directory`), or a symlink-to-DIRECTORY planted at the managed name redirects the
-  staged file outside the sandbox. Any window that REMAINS SHALL be recorded as a residual with
-  its reachability boundary stated, and SHALL NOT be described as unreachable,
+  staged file outside the sandbox. The staging create, the write, the mode fix and the rename
+  SHOULD occur within a single privileged invocation to avoid needless windows, but that grouping
+  SHALL NOT be relied on as mutual exclusion: it sequences one process's commands and says nothing
+  about other processes on other CPUs. What SHALL make the staged write safe is the PRECONDITION:
+  the target directory SHALL be owned by the identity performing the privileged write and SHALL be
+  neither group- nor world-writable, and an owner or mode that cannot be determined SHALL be a
+  refusal. Any window that REMAINS SHALL be recorded as a residual with its reachability boundary
+  stated, and SHALL NOT be described as unreachable,
   then renamed over the name — so a symlink appearing in the window between the check and the
   write is replaced rather than written through. A read that decides idempotency SHALL NOT
   follow the entry either, or a link whose target holds the canonical bytes would report
@@ -480,8 +483,25 @@ still exit 0. On Darwin the section SHALL be an explicit no-op.
 - **WHEN** the drop-in is installed
 - **THEN** the link SHALL be replaced by a regular file holding the managed bytes, the outside
   directory SHALL remain EMPTY, and no staging entry SHALL be left behind
-- **AND** the staged install SHALL be observable as a SINGLE privileged invocation, so no
-  unprivileged process can be scheduled between the staging create and its reopen
+- **AND** the staged install SHALL be observable as a SINGLE privileged invocation (a hygiene
+  property that removes needless windows — NOT a mutual-exclusion guarantee)
+
+#### Scenario: a drop-in directory writable by less-privileged users refuses the install
+- **GIVEN** a drop-in directory that is group- or world-writable, or not owned by the identity
+  that would perform the privileged write, or whose owner/mode cannot be determined
+- **WHEN** the staged install runs
+- **THEN** it SHALL refuse by name and write NOTHING, because every step of a staging race needs
+  the ability to create or replace entries in that directory
+- **AND** a directory owned by the writer and not group- or world-writable SHALL still install, so
+  the precondition is not a blanket refusal
+
+#### Scenario: a contained path carrying a newline cannot serialize into two entries
+- **GIVEN** the test-mode marker and a path seam (or extra-dirs entry) that is strictly contained
+  in the proven sandbox but whose NAME embeds a CR or LF, crafted so a line-wise reader would see
+  a second entry naming the host's real `/etc/sysctl.d`
+- **WHEN** the search path is resolved
+- **THEN** the seam SHALL be refused and the emitted search path SHALL NOT contain the host's real
+  `/etc/sysctl.d`, since a newline-delimited representation cannot safely carry such a path
 
 #### Scenario: a symlinked read seam cannot fabricate a capability verdict
 - **GIVEN** the test-mode marker and a proc seam whose spelling is strictly inside the proven

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -417,11 +417,11 @@ else
   # FAIL CLOSED on a misused test seam BEFORE anything privileged happens: this
   # section pipes the drop-in through `sudo tee <path>`, so a stray
   # CQLITE_PERF_SYSCTL_DIR / CQLITE_PERF_PROC_DIR export must never steer that write
-  # or fabricate a /proc verdict. The seams are inert without
-  # CQLITE_PERF_TEST_MODE=1, and the marker itself forbids a reachable real
-  # sudo/sysctl (see scripts/perf-capability.sh).
+  # or fabricate a /proc verdict. The seams are inert without CQLITE_PERF_TEST_MODE=1;
+  # under the marker each must be provably INSIDE the declared sandbox root, and the
+  # marker itself forbids a reachable real sudo/sysctl (see scripts/perf-capability.sh).
   if ! perf_capability_env_guard; then
-    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1; or test mode WITHOUT both non-production path seams, which has no production fallback; or test mode with a reachable real sudo/sysctl — details on stderr) — refusing to run a privileged write against an env-chosen path"
+    warn "perf capability SKIPPED — the test-only env seams are misconfigured (a seam set without CQLITE_PERF_TEST_MODE=1; or test mode without a proven CQLITE_PERF_TEST_SANDBOX and both path seams strictly inside it, which has no production fallback; or test mode with a reachable real sudo/sysctl — details on stderr) — refusing to run a privileged write against an env-chosen path"
     PERF_SECTION_OK=0
   else
     PERF_SECTION_OK=1

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -645,9 +645,14 @@ EOF
       # this privileged write at the link's target — anywhere on the box. The helper writes a
       # staging entry in the validated directory and renames it over the name, so a pre-existing
       # symlink is REPLACED rather than written through, and it re-reads the file to confirm.
-      if perf_capability_dropin_install ${PERF_ROOT[@]+"${PERF_ROOT[@]}"}; then
+      perf_capability_dropin_install ${PERF_ROOT[@]+"${PERF_ROOT[@]}"}; PERF_INS_RC=$?
+      if [ "$PERF_INS_RC" -eq 0 ]; then
         ok "wrote $PERF_DROPIN (kernel.perf_event_paranoid = -1, kernel.kptr_restrict = 0)"
         PERF_DROPIN_OK=1
+      elif [ "$PERF_INS_RC" -eq 2 ]; then
+        # UNSUPPORTED HOST, not a failed attempt: re-running cannot help, so the remedy line is
+        # deliberately NOT printed — advice that cannot work is worse than none (roborev round 16).
+        warn "cannot install $PERF_DROPIN on this host: the atomic staged install needs GNU coreutils"
       else
         warn "could NOT write $PERF_DROPIN"
         perf_remedy_line

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -521,7 +521,13 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
       info "no 'sudo' on this box — write + apply from a ROOT shell:  bash scripts/perf-capability.sh --install && sysctl -q --system"
       info "(or ask the image/host owner to install it; without the drop-in this box reverts to perf_event_paranoid=4 on reboot)"
     else
-      info "write + apply the drop-in:  bash scripts/perf-capability.sh --install ${PERF_RUN_AS% } && ${PERF_RUN_AS}sysctl -q --system"
+      # The priv token is only appended when there IS one: an empty ${PERF_RUN_AS} would leave a
+      # double space, and the root-box assertion pins the exact line.
+      if [ -n "$PERF_RUN_AS" ]; then
+        info "write + apply the drop-in:  bash scripts/perf-capability.sh --install ${PERF_RUN_AS% } && ${PERF_RUN_AS}sysctl -q --system"
+      else
+        info "write + apply the drop-in:  bash scripts/perf-capability.sh --install && sysctl -q --system"
+      fi
     fi
   }
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -521,7 +521,7 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
       info "no 'sudo' on this box — write + apply from a ROOT shell:  bash scripts/perf-capability.sh --install && sysctl -q --system"
       info "(or ask the image/host owner to install it; without the drop-in this box reverts to perf_event_paranoid=4 on reboot)"
     else
-      info "write + apply the drop-in:  bash scripts/perf-capability.sh --install ${PERF_RUN_AS%% } && ${PERF_RUN_AS}sysctl -q --system"
+      info "write + apply the drop-in:  bash scripts/perf-capability.sh --install ${PERF_RUN_AS% } && ${PERF_RUN_AS}sysctl -q --system"
     fi
   }
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -511,23 +511,24 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
   # until the next reboot, which is precisely what the functional verification exists
   # to prevent, on the path most people take (no --yes).
   perf_remedy_line() {
-    # THE PRINTED REMEDY MUST BE THE VALIDATED PATH, NOT `tee`/`>` (issue #3261, roborev round 5
-    # High). Both former spellings — `--drop-in | sudo tee <path>` and, from a root shell,
-    # `--drop-in > <path>` — open the destination BY NAME, so a symlink planted there between this
-    # advice being printed and the human running it redirects a privileged write anywhere. `--install`
-    # routes through the same containment checks + mktemp + atomic rename bootstrap uses itself, so
-    # the copy-pasteable command is no weaker than the automated one.
+    # THE PRINTED REMEDY POINTS AT BOOTSTRAP ITSELF (issue #3261, roborev rounds 5-7).
+    # History, because it is the whole reason this is three lines instead of a clever one:
+    #   * originally `--drop-in | sudo tee <path>` (and `--drop-in > <path>` from a root shell) — both
+    #     open the destination BY NAME, so a symlink planted between this advice printing and the human
+    #     running it redirects a privileged write. Hardening the installer while printing that is worse
+    #     than not hardening it: it reads as safe.
+    #   * then a new `perf-capability.sh --install` entry point — which itself shipped an env-guard
+    #     bypass (round 6) and then a supplied-prefix bypass (round 7), i.e. a fresh public surface that
+    #     re-opened the hole AC4 had just closed, twice.
+    #   * now: no new surface at all. `bootstrap --yes` ALREADY performs the guarded staged install and
+    #     applies `sysctl --system`, on the path this suite has always asserted. Removing the escape
+    #     hatch is strictly safer than guarding it, and subtraction cannot introduce a false pass.
+    # Bootstrap is idempotent (file header), so re-running it is the sanctioned repair everywhere.
     if [ "$PERF_PRIV_STATE" = no-sudo-binary ]; then
-      info "no 'sudo' on this box — write + apply from a ROOT shell:  bash scripts/perf-capability.sh --install && sysctl -q --system"
+      info "no 'sudo' on this box — write + apply from a ROOT shell:  bash scripts/bootstrap-agent-machine.sh --yes"
       info "(or ask the image/host owner to install it; without the drop-in this box reverts to perf_event_paranoid=4 on reboot)"
     else
-      # The priv token is only appended when there IS one: an empty ${PERF_RUN_AS} would leave a
-      # double space, and the root-box assertion pins the exact line.
-      if [ -n "$PERF_RUN_AS" ]; then
-        info "write + apply the drop-in:  bash scripts/perf-capability.sh --install ${PERF_RUN_AS% } && ${PERF_RUN_AS}sysctl -q --system"
-      else
-        info "write + apply the drop-in:  bash scripts/perf-capability.sh --install && sysctl -q --system"
-      fi
+      info "write + apply the drop-in:  bash scripts/bootstrap-agent-machine.sh --yes"
     fi
   }
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -428,7 +428,15 @@ else
   fi
 fi
 if [ "$PERF_SECTION_OK" = 1 ]; then
-  PERF_DROPIN=$(perf_capability_dropin_path)
+  # FAIL CLOSED if the write target cannot even be NAMED (issue #3261 AC1): the resolver refuses
+  # an out-of-sandbox seam AND a managed name that is itself a symlink. An empty PERF_DROPIN would
+  # otherwise flow into the messages and the write as an empty path, so the section stops here.
+  if ! PERF_DROPIN=$(perf_capability_dropin_path) || [ -z "$PERF_DROPIN" ]; then
+    warn "perf capability SKIPPED — the drop-in write target could not be resolved (an out-of-sandbox test seam, or the managed name is a SYMLINK a privileged write would follow — details on stderr); wrote nothing"
+    PERF_SECTION_OK=0
+  fi
+fi
+if [ "$PERF_SECTION_OK" = 1 ]; then
 
   # perf_apply_now: run (under --yes) or PRINT (check mode) `sysctl -q --system`,
   # recording THREE INDEPENDENT FACTS instead of collapsing them into one rc:

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -524,9 +524,19 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
     #     applies `sysctl --system`, on the path this suite has always asserted. Removing the escape
     #     hatch is strictly safer than guarding it, and subtraction cannot introduce a false pass.
     # Bootstrap is idempotent (file header), so re-running it is the sanctioned repair everywhere.
+    # THREE states, THREE remedies — a remedy that cannot work on the box it is printed for is
+    # worse than none, because the user spends a cycle before learning that (roborev round 8, Medium,
+    # a regression THIS branch introduced when it pointed every case at `--yes`).
     if [ "$PERF_PRIV_STATE" = no-sudo-binary ]; then
       info "no 'sudo' on this box — write + apply from a ROOT shell:  bash scripts/bootstrap-agent-machine.sh --yes"
       info "(or ask the image/host owner to install it; without the drop-in this box reverts to perf_event_paranoid=4 on reboot)"
+    elif [ "$PERF_PRIV_STATE" = sudo-needs-password ]; then
+      # Bootstrap probes privilege NON-INTERACTIVELY (`sudo -n`, see the probe above), so telling this
+      # box to "re-run with --yes" would fail again in exactly the same way and never prompt. The user
+      # must supply the password FIRST — `sudo -v` refreshes the credential timestamp, after which the
+      # `sudo -n` inside bootstrap succeeds — or run from an already-authenticated root shell.
+      info "sudo needs a password here, and bootstrap probes with 'sudo -n' (never prompts) — authenticate first, then re-run:  sudo -v && bash scripts/bootstrap-agent-machine.sh --yes"
+      info "(or run it from an authenticated ROOT shell:  sudo -i, then bash scripts/bootstrap-agent-machine.sh --yes)"
     else
       info "write + apply the drop-in:  bash scripts/bootstrap-agent-machine.sh --yes"
     fi

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -536,7 +536,11 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
       # must supply the password FIRST — `sudo -v` refreshes the credential timestamp, after which the
       # `sudo -n` inside bootstrap succeeds — or run from an already-authenticated root shell.
       info "sudo needs a password here, and bootstrap probes with 'sudo -n' (never prompts) — authenticate first, then re-run:  sudo -v && bash scripts/bootstrap-agent-machine.sh --yes"
-      info "(or run it from an authenticated ROOT shell:  sudo -i, then bash scripts/bootstrap-agent-machine.sh --yes)"
+      # NOT `sudo -i` (roborev round 11, Low): a login shell switches to root HOME, so the relative
+      # `scripts/...` path below it usually would not exist — advice that fails on the box it is
+      # printed for. `sudo bash <script>` prompts once, keeps the working directory, and makes
+      # bootstrap itself root, so its internal `sudo -n` probe is never reached.
+      info "(or simply:  sudo bash scripts/bootstrap-agent-machine.sh --yes)"
     else
       info "write + apply the drop-in:  bash scripts/bootstrap-agent-machine.sh --yes"
     fi

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -511,11 +511,17 @@ if [ "$PERF_SECTION_OK" = 1 ]; then
   # until the next reboot, which is precisely what the functional verification exists
   # to prevent, on the path most people take (no --yes).
   perf_remedy_line() {
+    # THE PRINTED REMEDY MUST BE THE VALIDATED PATH, NOT `tee`/`>` (issue #3261, roborev round 5
+    # High). Both former spellings — `--drop-in | sudo tee <path>` and, from a root shell,
+    # `--drop-in > <path>` — open the destination BY NAME, so a symlink planted there between this
+    # advice being printed and the human running it redirects a privileged write anywhere. `--install`
+    # routes through the same containment checks + mktemp + atomic rename bootstrap uses itself, so
+    # the copy-pasteable command is no weaker than the automated one.
     if [ "$PERF_PRIV_STATE" = no-sudo-binary ]; then
-      info "no 'sudo' on this box — write + apply from a ROOT shell:  bash scripts/perf-capability.sh --drop-in > $PERF_DROPIN && sysctl -q --system"
+      info "no 'sudo' on this box — write + apply from a ROOT shell:  bash scripts/perf-capability.sh --install && sysctl -q --system"
       info "(or ask the image/host owner to install it; without the drop-in this box reverts to perf_event_paranoid=4 on reboot)"
     else
-      info "write + apply the drop-in:  bash scripts/perf-capability.sh --drop-in | ${PERF_RUN_AS}tee $PERF_DROPIN >/dev/null && ${PERF_RUN_AS}sysctl -q --system"
+      info "write + apply the drop-in:  bash scripts/perf-capability.sh --install ${PERF_RUN_AS%% } && ${PERF_RUN_AS}sysctl -q --system"
     fi
   }
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -605,8 +605,12 @@ EOF
     PERF_DROPIN_OK=0
     if [ "$AUTO_YES" = 1 ]; then
       info "writing perf sysctl drop-in: $PERF_DROPIN"
-      if perf_capability_dropin_content | ${PERF_ROOT[@]+"${PERF_ROOT[@]}"} tee "$PERF_DROPIN" >/dev/null 2>&1 \
-         && perf_capability_dropin_current; then
+      # ATOMIC DIRECTORY-ENTRY REPLACEMENT, not `tee <path>` (issue #3261 AC1). `tee` opens
+      # O_WRONLY|O_CREAT|O_TRUNC and FOLLOWS a symlink, so a symlink at the managed name aimed
+      # this privileged write at the link's target — anywhere on the box. The helper writes a
+      # staging entry in the validated directory and renames it over the name, so a pre-existing
+      # symlink is REPLACED rather than written through, and it re-reads the file to confirm.
+      if perf_capability_dropin_install ${PERF_ROOT[@]+"${PERF_ROOT[@]}"}; then
         ok "wrote $PERF_DROPIN (kernel.perf_event_paranoid = -1, kernel.kptr_restrict = 0)"
         PERF_DROPIN_OK=1
       else

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -422,6 +422,14 @@ perf_capability_dropin_path() {
 # temp name is derived from the managed basename, never from a caller-supplied string, and an
 # entry already occupying it is removed and its removal VERIFIED before anything is written —
 # otherwise `tee` would follow a symlink planted at the temp name instead.
+#   The staging name is FIXED rather than pid-suffixed, deliberately: two bootstraps racing on one
+#   box would then collide and ONE would fail loudly, which is the honest outcome (they are writing
+#   the same managed bytes to the same managed path), whereas a pid suffix would leave
+#   per-pid litter behind whenever a run is killed between the `tee` and the `mv`. Bootstrap is
+#   once-per-box and the fleet rule is one worker per machine, so the race is not a live concern;
+#   the litter would be.
+#   It does not end in `.conf`, so the competing-file scan (which globs `*.conf`) can never mistake
+#   a staging entry for a rival sysctl drop-in.
 perf_capability_dropin_install() {
   local __pin_d __pin_p __pin_t
   __pin_d=$(perf_capability_sysctl_dir) || return 1

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -551,7 +551,7 @@ perf_capability_dropin_install() {
     #   rather than a thirteenth. #3323 records that fix and re-raises on EVIDENCE the boundary is
     #   reachable (multi-tenant boxes, an attacker-writable ancestor, or a real privileged helper
     #   reachable from test mode). Production ancestors are `/etc` and `/`, both root-owned; test
-    #   mode reaches only AC4 shims. Do NOT widen this function's trust without reading #3323 first.
+    #   mode reaches only AC4 shims. Do NOT widen the trust of this function without reading #3323 first.
     #   THE REMAINING BOUNDARY, STATED: this check races only against an actor who can `chmod` a
     #   directory owned by the privileged writer — and that actor is already the privileged writer
     #   (or root), so it has no privilege left to escalate to. That is the whole of the residual;

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -32,11 +32,8 @@
 # `PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
 # outside those namespaces are touched). Every function is `set -u` safe.
 #
-# Usage (executed):
-#   bash scripts/perf-capability.sh --token        # free /proc read -> one token
-#   bash scripts/perf-capability.sh --verify       # functional perf stat check
-#   bash scripts/perf-capability.sh --drop-in      # canonical sysctl.d file bytes
-#   bash scripts/perf-capability.sh --drop-in-path # where that file belongs
+# Usage when executed: `bash scripts/perf-capability.sh --help` (the modes are listed by
+# perf_capability_usage below, so they are not duplicated here).
 #
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
 # The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
@@ -59,22 +56,20 @@
 #                               optional, test mode only
 #   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
 #
-# POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds
-# each closed ONE MORE SPELLING of "the production directory": the raw path (B3), then a
-# symlinked seam, then `..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes
-# implementation-defined, `pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A
-# denylist over path spellings cannot be completed — `.`, `..`, symlinks, `//`, trailing
-# slashes, bind mounts, `/proc/self/root/…` all name the same directory — and a scattered
-# set of prohibitions also lets a NEW entry point silently miss them (R6-2). So the rule is
-# INVERTED and there is exactly ONE: a seam is usable IFF it is strictly contained in the
-# declared sandbox root. Every spelling of "somewhere else" — including every future one —
-# fails that single check for the same reason: it is not inside the sandbox.
-# TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams
-# are MANDATORY. The earlier shape — marker set, seam unset, fall back to the real
-# directory — meant test mode could pass the env guard (sudo/sysctl absent, or present as
-# declared shims) and a subsequent root `--yes` run would then invoke a bare `tee` against
-# the REAL /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim
-# that depends on a variable being set: it is enforced here, fail-closed and loudly.
+# POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds each
+# closed ONE MORE SPELLING of "the production directory": the raw path (B3), a symlinked seam,
+# `..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes implementation-defined,
+# `pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A denylist over path spellings
+# cannot be completed — `.`, `..`, symlinks, `//`, trailing slashes, bind mounts,
+# `/proc/self/root/…` all name the same directory — and scattered prohibitions also let a NEW
+# entry point silently miss them (R6-2). So the rule is INVERTED and there is exactly ONE: a
+# seam is usable IFF it is strictly contained in the declared sandbox root. Every spelling of
+# "somewhere else", including every future one, fails that single check for the same reason.
+# TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams are
+# MANDATORY. The earlier shape — marker set, seam unset, fall back to the real directory —
+# meant test mode could pass the env guard (sudo/sysctl absent, or present as declared shims)
+# and a subsequent root `--yes` run would `tee` the REAL /etc/sysctl.d, mutating the host from
+# a test run. "Hermetic" cannot be a claim that depends on a variable being set.
 
 # FAIL-OPEN AUDIT — every path that can reach a POSITIVE verdict, and what validates it
 # (review round 4; four findings in this file were one defect class: "identity/state unknown
@@ -84,11 +79,11 @@
 #                               both `is_int`-validated AND paranoid <= 0 AND kptr == 0.
 #                               Whitespace trimmed, never TRUNCATED — `0 1` stays malformed.
 #   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count is a
-#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` +
-#                               `-le 0`. `<not supported>`/`<not counted>`/empty/oversized/
-#                               malformed all return 1.
-#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0,
-#                               prints a validated non-negative int) AND that uid != 0. An
+#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` + `-le
+#                               0`. `<not supported>`/`<not counted>`/empty/oversized/malformed
+#                               all return 1.
+#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0 and
+#                               prints a validated non-negative int) AND that uid != 0; an
 #                               unusable `id -u` => identity-unknown, rc 1.
 #   state = dropped:setpriv     numeric uid+gid, both validated ints AND both > 0.
 #   state = dropped:runuser     the same numerics PLUS a `SUDO_USER` the passwd database
@@ -102,7 +97,7 @@
 #   dropin_path rc 0            its directory came from `sysctl_dir`, i.e. RESOLVES inside the
 #                               sandbox — the single gate between the bytes and a root `tee`.
 #   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against the
-#                               generated canonical content, from a read that reached EOF — a
+#                               canonical content from a read that reached EOF — a
 #                               NUL-delimited read is NOT current (R5-3).
 # KNOWN RESIDUALS, deliberately not papered over:
 #   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel changed
@@ -136,31 +131,25 @@ perf_capability_seam_set() {
 
 # ---- ONE GATE: POSITIVE SANDBOX CONTAINMENT (review R6-1/R6-2) --------------------
 # THE sandbox root is caller-declared (CQLITE_PERF_TEST_SANDBOX) and must PROVE itself: an
-# absolute, canonically spelled, existing directory carrying the stamp file below. The
-# stamp is what makes the declaration unforgeable by environment alone — a stray
-# CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on
-# the FILESYSTEM and writing it into a system directory already needs the privilege this
-# guard protects. No denylist appears anywhere below: a path is usable because it is
-# provably INSIDE the sandbox, never because it failed to look like somewhere forbidden.
+# absolute, canonically spelled, existing directory carrying the stamp file below. The stamp is
+# what makes the declaration unforgeable by environment alone — a stray
+# CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on the
+# FILESYSTEM and writing it into a system directory already needs the privilege this guard
+# protects. No denylist appears below: a path is usable because it is provably INSIDE the
+# sandbox, never because it failed to look like somewhere forbidden.
 #
 # FIVE thin functions, ONE predicate — everything ends in perf_capability_path_within:
 #   sandbox_root_into O        the declared root, validated; rc 1 + empty when unproven
 #   path_within P R            THE predicate (below)
-#   sandbox_ok P               FORK-FREE entry point, for the gate's emit-time token chain
-#                              (contractually free of external processes AND command
-#                              substitutions): judges the SPELLING. Sound there because that
-#                              path only READS a caller-chosen file — its contract is "seams
-#                              are honoured only under the test marker, never set in
-#                              production" — so a mis-accepted spelling can at worst make the
-#                              token `absent`/`unknown`; it can never write.
-#   sandbox_ok_resolved P      for every path WRITTEN, or whose CONTENTS are read (host
-#                              configuration): canonicalizes candidate AND root (`.`, `..`,
-#                              symlinked ancestors and a `//`-rooted `pwd -P` answer all
-#                              included), then the SAME predicate. An unenterable path
-#                              resolves to nothing and is refused — fail-closed, and correct
-#                              for a write target, which must exist to be written into.
-#   sandbox_file_ok_resolved F the file form (the optional `sysctl.conf` entry): the PARENT is
-#                              canonicalized and the RESULTING FILE PATH is validated.
+#   sandbox_ok P               FORK-FREE entry point (the gate's emit-time token chain, which
+#                              may not fork): judges the SPELLING — sound there for the reason
+#                              in the fail-open audit's second residual above
+#   sandbox_ok_resolved P      every path WRITTEN, or whose CONTENTS are read: canonicalizes
+#                              candidate AND root, then the SAME predicate. An unenterable
+#                              path resolves to nothing and is refused — fail-closed, and
+#                              correct for a write target, which must exist to be written into
+#   sandbox_file_ok_resolved F the FILE form (the optional `sysctl.conf` entry): judged by
+#                              canonicalizing its PARENT, plus a plain-basename check
 # `cd -P` + `pwd -P` is the canonicalizer: one subshell, no external binary, correct on bash
 # 3.2 (no `realpath`, no `readlink -f` — absent or non-GNU on some supported hosts).
 PERF_CAPABILITY_SANDBOX_STAMP='.cqlite-perf-sandbox'
@@ -193,46 +182,35 @@ perf_capability_sandbox_ok() {
   perf_capability_path_within "${1:-}" "$__pso_root"
 }
 
-# the root CANONICALIZED, so both sides of a resolved containment test are in one form
-perf_capability_sandbox_root_resolved_into() {
-  local __prr_v=''
-  eval "$1="
-  perf_capability_sandbox_root_into __prr_v || return 1
-  __prr_v=$(cd -P -- "$__prr_v" 2>/dev/null && pwd -P) || return 1
-  eval "$1=\${__prr_v%/}"
-}
-
 perf_capability_sandbox_ok_resolved() {
   local __pdr_root='' __pdr_real=''
-  perf_capability_sandbox_root_resolved_into __pdr_root || return 1
+  perf_capability_sandbox_root_into __pdr_root || return 1
+  # BOTH sides canonicalized the same way, so the comparison is between destinations
+  __pdr_root=$(cd -P -- "$__pdr_root" 2>/dev/null && pwd -P) || return 1
   __pdr_real=$(cd -P -- "${1:-/dev/null/never}" 2>/dev/null && pwd -P) || return 1
-  perf_capability_path_within "$__pdr_real" "$__pdr_root"
+  perf_capability_path_within "$__pdr_real" "${__pdr_root%/}"
 }
 
 perf_capability_sandbox_file_ok_resolved() {
-  local __pfr_root='' __pfr_real='' __pfr_base=''
   case "${1:-}" in */?*) ;; *) return 1 ;; esac
-  __pfr_base="${1##*/}"
-  case "$__pfr_base" in ''|.|..) return 1 ;; esac
-  perf_capability_sandbox_root_resolved_into __pfr_root || return 1
-  __pfr_real=$(cd -P -- "${1%/*}" 2>/dev/null && pwd -P) || return 1
-  perf_capability_path_within "${__pfr_real%/}/$__pfr_base" "$__pfr_root"
+  case "${1##*/}" in ''|.|..) return 1 ;; esac
+  # the FILE path is judged by canonicalizing its PARENT: a canonical parent strictly inside
+  # the sandbox puts <parent>/<basename> strictly inside it too, for any plain basename.
+  perf_capability_sandbox_ok_resolved "${1%/*}"
 }
 
-# perf_capability_seam_refusal <VARNAME> <value> <root>: ONE message shape for both
-# mandatory seams. The refusal must NAME the offending seam — that is what makes it
-# actionable — so this is parameterised rather than duplicated per seam.
+# ONE message shape for both mandatory seams: the refusal must NAME the offending seam (that
+# is what makes it actionable), so it is parameterised rather than duplicated per seam.
 perf_capability_seam_refusal() {
   printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires %s INSIDE the declared sandbox %s — its RESOLVED destination (. / .. / // / symlinked ancestors and all) must be strictly contained there; got %s. Test mode NEVER falls back to the real directory.\n' \
     "${1:-<seam>}" "'${3:-}'" "'${2:-<unset>}'" >&2
 }
 
 # perf_capability_test_seams_ok: rc 0 iff test mode has a PROVEN sandbox root and BOTH
-# mandatory seams RESOLVING strictly inside it. This is the gate on every privileged
-# action below, so it takes the resolving form: refusing here is what stops a root `--yes`
-# test run from resolving a seam back into the production directory and overwriting the
-# host's own drop-in. Refuses loudly and names what failed, because the failure it
-# prevents is silent otherwise.
+# mandatory seams RESOLVING strictly inside it. This is the gate on every privileged action
+# below, so it takes the resolving form: refusing here is what stops a root `--yes` test run
+# from resolving a seam back into the production directory and overwriting the host's own
+# drop-in. It refuses loudly, because the failure it prevents is silent otherwise.
 perf_capability_test_seams_ok() {
   local ok=0 root=''
   if ! perf_capability_sandbox_root_into root; then
@@ -274,8 +252,8 @@ perf_capability_env_guard() {
       *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 with a reachable real %s and no absolute CQLITE_PERF_TEST_PRIV_DIR — test mode must PATH-shim every privileged tool.\n' "$tool" >&2
          return 1 ;;
     esac
-    # The same containment predicate as the seams, one level down: the tool must be
-    # strictly inside the DECLARED shim dir (not merely spelled that way).
+    # The seams' containment predicate, one level down: the tool must be strictly inside the
+    # DECLARED shim dir, not merely spelled that way.
     perf_capability_path_within "$resolved" "${dir%/}" || {
       printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
         "$tool" "$resolved" "$dir" >&2
@@ -319,11 +297,10 @@ perf_capability_proc_dir() {
   perf_capability_proc_dir_into __pcd_v || return 1
   printf '%s' "$__pcd_v"
 }
-# perf_capability_sysctl_dir: the sysctl.d directory — the WRITE side (a root `tee` is
-# pointed inside it) and the directory whose CONTENTS the competing-file scan reads, so it
-# takes the RESOLVING gate: the canonical DESTINATION is what gets written, not the
-# spelling. Every consumer of the sysctl.d location goes through this one function, so
-# there is exactly one place the check can be forgotten — and it is here.
+# perf_capability_sysctl_dir: the sysctl.d directory — the WRITE side (a root `tee` is aimed
+# inside it) and the directory whose CONTENTS the competing-file scan reads, so it takes the
+# RESOLVING gate. EVERY consumer of that location comes through this one function, so there is
+# exactly one place the check could be forgotten — and it is here.
 perf_capability_sysctl_dir() {
   if perf_capability_test_mode; then
     perf_capability_sandbox_ok_resolved "${CQLITE_PERF_SYSCTL_DIR:-}" || {
@@ -336,10 +313,10 @@ perf_capability_sysctl_dir() {
   fi
   printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
-# perf_capability_dropin_path: the path a root `tee` is pointed at. The containment gate
-# lives in perf_capability_sysctl_dir — the single place that directory comes from — and
-# it RESOLVES the destination, so there is deliberately no second copy of the check here:
-# one gate, not a prohibition a future entry point could skip (R6-2).
+# perf_capability_dropin_path: the path a root `tee` is pointed at. Its gate lives in
+# perf_capability_sysctl_dir (the single source of that directory) and RESOLVES the
+# destination, so there is deliberately no second copy here — one gate, not a prohibition a
+# future entry point could skip (R6-2).
 perf_capability_dropin_path() {
   local __pdi_d
   __pdi_d=$(perf_capability_sysctl_dir) || return 1
@@ -430,12 +407,10 @@ perf_capability_dropin_current() {
 # diagnostic exists to end.
 #
 # In TEST MODE the path is the sandbox seam plus the optional colon-separated
-# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, in the same descending
-# order): the real /run and /usr/lib are never read, so a case's verdict can never depend
-# on the host's own drop-ins. EVERY entry goes through the SAME RESOLVING gate as the
+# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, same descending order): the real
+# /run and /usr/lib are never read. EVERY entry goes through the SAME RESOLVING gate as the
 # write path (R6-2 — this entry point once used the syntactic one, so a symlinked ancestor
-# could point a "sandboxed" scan at the host's real configuration). A `sysctl.conf` entry
-# is a FILE, so its parent is canonicalized and the resulting file path validated.
+# could point a "sandboxed" scan at the host's real configuration).
 perf_capability_sysctl_search_path() {
   local __psp_d __psp_e __psp_ok
   if perf_capability_test_mode; then
@@ -464,9 +439,9 @@ perf_capability_sysctl_search_path() {
                 /lib/sysctl.d /etc/sysctl.conf
 }
 
-# perf_capability_file_sets_controls <path>: rc 0 iff the file ASSIGNS either control.
-# Both spellings sysctl accepts are matched (`kernel.x` and `kernel/x`, sysctl.d(5)) plus
-# the optional leading `-` ignore-failure prefix; a commented-out line assigns nothing.
+# rc 0 iff the file ASSIGNS either control. Both spellings sysctl accepts are matched
+# (`kernel.x` and `kernel/x`, sysctl.d(5)) plus the optional leading `-` ignore-failure
+# prefix; a commented-out line assigns nothing.
 perf_capability_file_sets_controls() {
   grep -Eq '^[[:space:]]*-?kernel[./](perf_event_paranoid|kptr_restrict)[[:space:]]*=' "$1" 2>/dev/null
 }
@@ -528,9 +503,9 @@ perf_capability_competing_files() {
       [ -f "$f" ] || continue   # readable but a directory/socket named *.conf: sysctl reads none
       name="${f##*/}"
       [ "$name" = "$base" ] && continue
-      # MASKING (see the precedence rules above): a higher-precedence directory already
-      # supplied this basename, so sysctl ignores THIS file entirely. Recorded BEFORE the
-      # content test, because a same-named file that sets nothing still masks one that does.
+      # MASKING (precedence rules above): a higher-precedence directory already supplied this
+      # basename, so sysctl ignores THIS file. Recorded BEFORE the content test, because a
+      # same-named file that sets nothing still masks one that does.
       case "$seen" in *"$lf$name$lf"*) continue ;; esac
       seen="$seen$name$lf"
       perf_capability_file_sets_controls "$f" || continue
@@ -576,8 +551,8 @@ perf_capability_proc_read() {
   eval "$__pcr_out=\$__pcr_v"
 }
 
-# perf_capability_proc_value <name>: the stdout form of the read above, for CLI and
-# bootstrap use (NOT the gate path — reading it costs the caller a `$( )`).
+# the stdout form of the read above, for CLI/bootstrap use — NOT the gate path (reading it
+# costs the caller a `$( )`).
 perf_capability_proc_value() {
   local __pcv_v
   perf_capability_proc_read __pcv_v "$1" || return 1
@@ -627,9 +602,8 @@ perf_capability_token_into() {
   eval "$__pct_out=ok"
 }
 
-# perf_capability_token: the stdout form, for the `--token` CLI and bootstrap. NOT the
-# gate path — reading stdout costs the caller a `$( )` fork, which is precisely what
-# the `_into` core above exists to avoid.
+# the stdout form, for the `--token` CLI and bootstrap. NOT the gate path — reading stdout
+# costs the caller the very `$( )` fork the `_into` core above exists to avoid.
 perf_capability_token() {
   local __ptk_v
   perf_capability_token_into __ptk_v
@@ -856,9 +830,9 @@ perf_capability_main() {
     --token)        perf_capability_token; printf '\n' ;;
     --verify)       local v rc=0; v=$(perf_capability_verify) || rc=1; printf '%s\n' "$v"; return $rc ;;
     --verify-unpriv)
-      # Identity-aware form: rc 0 requires BOTH a functional pass AND that the pass
-      # came from an unprivileged identity. A root run with no way to drop privilege
-      # reports its result AND that the result is not evidence about an agent process.
+      # rc 0 requires BOTH a functional pass AND that it came from an unprivileged
+      # identity: a root run with no way to drop privilege reports its result AND that
+      # the result is not evidence about an agent process.
       local pre='' state='' v rc=0 unpriv=0
       perf_capability_drop_prefix_into pre state && unpriv=1
       # shellcheck disable=SC2086  # deliberate split of our own literal prefix tokens
@@ -867,17 +841,16 @@ perf_capability_main() {
       [ "$unpriv" = 1 ] || rc=1
       return $rc ;;
     --drop-in)      perf_capability_dropin_content ;;
-    # rc PROPAGATED, never masked by the trailing newline: under an unsandboxed test
-    # mode the path cannot be resolved at all (R4-3), and a caller must see that as a
-    # failure rather than as an empty-but-successful answer.
+    # rc PROPAGATED, never masked by the trailing newline: an unsandboxed test mode can
+    # resolve no path at all (R4-3), and that is a failure, not an empty success.
     --drop-in-path) perf_capability_dropin_path || return 1; printf '\n' ;;
     -h|--help|'')   perf_capability_usage ;;
     *)              printf 'perf-capability: unknown arg: %s\n' "$1" >&2; perf_capability_usage >&2; return 2 ;;
   esac
 }
 
-# Executed directly (never when sourced): shell options are set HERE, inside the
-# guard, so sourcing can never change a caller's `set` flags.
+# Executed directly (never when sourced): shell options are set HERE, inside the guard, so
+# sourcing can never change a caller's `set` flags.
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   set -uo pipefail
   perf_capability_main "$@"

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -834,12 +834,13 @@ perf_capability_proc_read() {
   eval "$__pcr_out="
   perf_capability_proc_dir_into __pcr_dir || return 1
   # THE CONTROL FILE ITSELF IS CHECKED, NOT JUST ITS DIRECTORY (roborev round 25, Medium). The
-  # directory gate proved the DIRECTORY is contained and symlink-free; it said nothing about the
-  # ENTRY. A regular contained PROC_DIR could hold `perf_event_paranoid` as a symlink to the host
-  # file, so the token read attacker-chosen or real values and fabricated `perf=ok` — the same
+  # directory gate proved the DIRECTORY contained and symlink-free; it said nothing about the ENTRY.
+  # A regular contained PROC_DIR could hold perf_event_paranoid as a symlink to the host file, so the
+  # token read attacker-chosen or real values and fabricated an ok capability -- the same
   # directory-is-not-its-entries lesson as the write path (AC1), one surface over. Fork-free, so the
-  # token path keeps its contract. In test mode containment is required too; in production the
-  # directory is the hardcoded literal, and a symlinked control file there is still refused.
+  # token path keeps its contract; in test mode containment is required too.
+  # NOTE: no backticks in this function comment on purpose -- the fork-free emit-path audit in
+  # test_agent_gate_summary.sh counts them WITHOUT stripping comments, so prose alone can red it.
   perf_capability_nosymlink "$__pcr_dir/$2" || return 1
   if perf_capability_test_mode; then
     perf_capability_sandbox_ok "$__pcr_dir/$2" || return 1

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -643,34 +643,13 @@ EOF
 }
 
 # perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the managed
-# bytes (the idempotency test — a matching file means write nothing). The compare is an
-# in-shell string compare, NOT `diff -q`: on a box without diffutils `diff` exits 127,
-# which reads as "different" on every run — so bootstrap would re-write the file each time
-# AND then report it could not write it.
-#
-# TRAILING NEWLINES ARE PART OF THE BYTES (review R4-4). `$( )` strips EVERY trailing
-# newline, so comparing two command substitutions made a file missing its final newline —
-# or carrying extra trailing blank lines — compare EQUAL: "byte-exact" was a false claim
-# and such a file was never rewritten. The file side is read with `read -r -d ''`, which
-# consumes it verbatim (builtin, no `cat`/`diff` dependency), and the canonical side carries
-# an in-substitution sentinel so its own final newline survives the stripping.
-#
-# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (review R5-3). `read -d ''` stops at a NUL
-# and returns SUCCESS with only the bytes BEFORE it, so canonical content + NUL + ARBITRARY
-# trailing bytes compared EQUAL and was judged current. Read's rc is therefore load-bearing:
-# rc 0 means a NUL was consumed — not our text drop-in, and the rest never even seen — so it
-# is NOT current; only rc != 0 (EOF, whole file in `got`) may be compared.
+# (rationale: fleet-runbook.md, perf seam containment, perf-capability-dropin-current-rc-0-iff-the)
 perf_capability_dropin_current() {
   local path want got=''
   path=$(perf_capability_dropin_path) || return 1
   [ -f "$path" ] && [ -r "$path" ] || return 1
   # THE SENTINEL MUST NOT SWALLOW THE GENERATOR'S STATUS (roborev round 9, Medium). `printf X`
-  # exists so a trailing newline survives command substitution, but it also RAN LAST, so the
-  # substitution reported ITS status and a failed content generator looked like success: `want`
-  # became bare "X", and against an empty file `${got}X` is also "X" — equal, so a broken
-  # generator reported the drop-in ALREADY CURRENT. A positive verdict from an unmeasured state,
-  # which is the exact shape this repo has a standing rule against. The rc is now captured
-  # BEFORE the sentinel and re-raised as the subshell's exit status, so both properties hold.
+  # (rationale: fleet-runbook.md, perf seam containment, the-sentinel-must-not-swallow-the-generator)
   want=$(perf_capability_dropin_content; __pdc_rc=$?; printf 'X'; exit "$__pdc_rc") || return 1
   if IFS= read -r -d '' got <"$path"; then
     return 1
@@ -811,17 +790,7 @@ EOF
 }
 
 # perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight from
-# /proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when unreadable). NEVER
-# trust a `sysctl -w`/`--system` return code — a write can report success while the value
-# does not take (container, read-only sysfs, a competing drop-in applied later), and it can
-# report FAILURE for an unrelated entry while ours applied fine. Read back.
-# Fully fork-free: `read` is a builtin, the directory comes back through a variable, and
-# nothing here is wrapped in `$( )` — this sits in the gate's summary path, which may not
-# grow a process for a diagnostic line. `read` returns non-zero at EOF on a file with no
-# trailing newline yet still assigns, so emptiness — not read's rc — is the failure test. It
-# also propagates the test-mode sandbox refusal (R4-3): with no seam inside the sandbox there
-# is no directory to read, and that is rc 1, never the real /proc.
-#
+# (rationale: fleet-runbook.md, perf seam containment, perf-capability-proc-read-outvar-name-the-cu)
 # WHITESPACE IS TRIMMED, NEVER TRUNCATED AT (fail-open audit, R4 round). The earlier
 # `${v%%[[:space:]]*}` cut the value at its FIRST space, so a malformed `0 1` became a
 # perfectly capable-looking `0` — an unknown resolving to the good case, in the one function
@@ -950,13 +919,7 @@ perf_capability_self_uid_into() {
 # the passwd database whose uid AND gid equal the supplied (already validated) numerics
 # and whose uid is non-zero.
 #
-# WHY (review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever the NAME
-# resolves to, not to the numeric ids we validated, and SUDO_USER/SUDO_UID are independent
-# environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale or hand-set) would run the probe
-# AS ROOT while the code reported a successful drop — a false VERIFIED again. So a name is
-# usable only once the passwd database confirms it IS the validated uid/gid. The shape check
-# is equally load-bearing: the prefix is word-split by the caller, so a name containing
-# whitespace or glob characters could inject extra argv tokens.
+# (rationale: fleet-runbook.md, perf seam containment, b951)
 perf_capability_name_is_uid() {
   local __pni_n="${1:-}" __pni_u="${2:-}" __pni_g="${3:-}" __pni_ru __pni_rg
   [ -n "$__pni_n" ] || return 1
@@ -1073,12 +1036,7 @@ perf_capability_verify() {
     return 1
   fi
   # Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU (Intel
-  # 12th-gen+ P/E cores) perf emits one row per PMU (`cpu_core/cycles/`, `cpu_atom/cycles/`),
-  # commonly with `<not supported>` on the sibling that did not run — so a parser keyed on a
-  # literal leading `cycles` reports `no-cycles-row` on a perfectly good collection. Normalise
-  # the event field (drop PMU prefix, trailing `/`, any `:u`/`:k` modifier) and take the FIRST
-  # row with a positive numeric count; keep the first matching row's raw field as the fallback
-  # so the `<not supported>` / zero diagnostics below still fire when none is positive.
+  # (rationale: fleet-runbook.md, perf seam containment, event-name-matching-must-accept-a-qualified)
   count=$(printf '%s\n' "$out" | awk -F, '
     {
       ev = tolower($3)

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -6,18 +6,7 @@
 # (full rationale: fleet-runbook.md, perf seam containment, b4)
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
 # The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
-# bootstrap installs the drop-in through the STAGED installer below (mktemp + atomic rename, no
-# `tee <path>`): were that path env-derived, one stray
-# export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d) would make ROOT write an
-# attacker/accident-chosen file while the real drop-in was never installed — and an unparsable
-# sudoers entry can wedge `sudo` outright. Likewise an env-chosen /proc stand-in would let a
-# paranoid-4 box print a FABRICATED "verified" verdict. So the seams take effect ONLY under
-# the explicit marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
-# reachable on PATH is a hard refusal (the suite PATH-shims both and declares the shim
-# directory), so test mode can never reach a real privileged tool.
-#   CQLITE_PERF_TEST_MODE=1     the marker; without it every seam below is INERT
-#   CQLITE_PERF_TEST_SANDBOX    THE SANDBOX ROOT — the one absolute directory every other
-#                               seam must be provably INSIDE (test mode only)
+# (full rationale: fleet-runbook.md, perf seam containment, the-production-paths-below-are-hardcoded-liter)
 #   CQLITE_PERF_PROC_DIR        stand-in for /proc/sys/kernel   (test mode only)
 #   CQLITE_PERF_SYSCTL_DIR      stand-in for /etc/sysctl.d      (test mode only)
 #   CQLITE_PERF_SYSCTL_EXTRA_DIRS  colon-separated stand-ins for the LOWER-precedence
@@ -58,17 +47,7 @@
 #                               NUL-delimited read is NOT current (R5-3).
 # KNOWN RESIDUALS, deliberately not papered over:
 #   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel changed
-#     uid. Harmless by construction: the caller's verdict is `token = ok` AND the functional
-#     pass, and a box whose /proc says ok IS profileable unprivileged, so a mislabelled drop
-#     cannot manufacture a capability that is absent.
-#   * the READ-side containment check is SYNTACTIC (fork-free, gate contract) while every
-#     write / host-config read canonicalizes — SAME predicate, different input form. The read
-#     side judges the spelling, so a symlinked ancestor INSIDE the sandbox could still steer a
-#     test-mode /proc STAND-IN read. Bounded by that path's whole contract: the seams are
-#     honoured only under the test marker, which is never set in production, and nothing there
-#     writes — so the worst case is a read of a caller-chosen file reported as
-#     `absent`/`unknown`, never a fabricated capability.
-#
+# (full rationale: fleet-runbook.md, perf seam containment, dropped-mech-asserts-the-mechanism-was-invoke)
 # ---- production locations: HARDCODED. Never env-derived outside test mode. ----
 PERF_CAPABILITY_PROC_DIR_DEFAULT='/proc/sys/kernel'
 PERF_CAPABILITY_SYSCTL_DIR_DEFAULT='/etc/sysctl.d'
@@ -86,18 +65,7 @@ perf_capability_seam_set() {
 }
 
 # ---- ONE GATE: POSITIVE SANDBOX CONTAINMENT (review R6-1/R6-2) --------------------
-# THE sandbox root is caller-declared (CQLITE_PERF_TEST_SANDBOX) and must PROVE itself: an
-# absolute, canonically spelled, existing directory carrying the stamp file below. The stamp is
-# what makes the declaration unforgeable by environment alone — a stray
-# CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on the
-# FILESYSTEM and writing it into a system directory already needs the privilege this guard
-# protects. No denylist appears below: a path is usable because it is provably INSIDE the
-# sandbox, never because it failed to look like somewhere forbidden.
-#
-# FIVE thin functions, ONE predicate — everything ends in perf_capability_path_within:
-#   sandbox_root_into O        the declared root, validated; rc 1 + empty when unproven
-#   path_within P R            THE predicate (below)
-# (rationale condensed; full reasoning in the commit history for #3261.)
+# (full rationale: fleet-runbook.md, perf seam containment, one-gate-positive-sandbox-containment-review)
 PERF_CAPABILITY_SANDBOX_STAMP='.cqlite-perf-sandbox'
 # A literal LF and CR, for the line-safety predicate below. Spelled as a literal newline inside
 # single quotes rather than `$'\n'` so this stays correct on bash 3.2 (a supported gate host).
@@ -489,18 +457,18 @@ perf_capability_dropin_install() {
         exit 1 ;;
     esac
     # mv -T IS EXERCISED HERE, AFTER the ownership precondition and BEFORE the real staging entry.
-    # Placement is deliberate on both sides. AFTER the precondition, because that is what establishes
-    # no less-privileged actor can create entries in $d — which is precisely what makes a PREDICTABLE
-    # probe name safe, so this does not need (and must not consume) mktemp. NOT consuming mktemp also
-    # keeps it from pre-empting the staging entry checks below, which have their own cases.
+    # (full rationale: fleet-runbook.md, perf seam containment, mv-t-is-exercised-here-after-the-ownership-pre)
+    if ! mv --help 2>&1 | grep -q -- '--no-target-directory'; then
+      printf "perf-capability: UNSUPPORTED on this host: mv --no-target-directory (-T) is unavailable (GNU coreutils required), so the drop-in cannot be replaced atomically without risking a symlinked destination.\n" >&2
+      exit 2
+    fi
     __x1="$d/.perfcap-probe.$$"; __x2="$__x1.b"
-    rm -f -- "$__x1" "$__x2" 2>/dev/null
     # ABSENCE IS PROVEN, NOT ASSUMED (roborev round 21, High). `rm` can fail (read-only mount) and its
     # status was ignored, and `: >` FOLLOWS a symlink — so a leftover link at this predictable name
     # could truncate an arbitrary file under privilege. The mode precondition proves nobody
     # less-privileged can CREATE entries here, not that a pre-existing one was removed.
     if [ -e "$__x1" ] || [ -L "$__x1" ] || [ -e "$__x2" ] || [ -L "$__x2" ]; then
-      printf "perf-capability: REFUSING: probe entries under %s could not be cleared, so opening them could follow a leftover symlink under privilege.\n" "$d" >&2
+      printf "perf-capability: REFUSING: a probe entry already exists at %s (or its .b sibling). Nothing here deletes an entry it did not create: this name embeds a PID, so after PID reuse it can belong to an unrelated file, and a leftover SYMLINK there would be followed under privilege. Inspect it and remove it yourself.\n" "$__x1" >&2
       exit 1
     fi
     # CREATION FAILURE IS ITS OWN OUTCOME (roborev round 21, Low): sharing one branch with the `mv`
@@ -514,9 +482,11 @@ perf_capability_dropin_install() {
       exit 1
     fi
     if ! mv -fT -- "$__x1" "$__x2" 2>/dev/null; then
+      # Both names were created by THIS invocation (absence was proven above), so removing them here
+      # cannot destroy anything it did not make -- the property the refusal above protects.
       rm -f -- "$__x1" "$__x2" 2>/dev/null
-      printf "perf-capability: UNSUPPORTED on this host: mv --no-target-directory (-T) does not work (GNU coreutils required), so the drop-in cannot be replaced atomically without risking a symlinked destination.\n" >&2
-      exit 2
+      printf "perf-capability: REFUSING: the atomic-rename probe in %s failed even though this mv advertises --no-target-directory, so this is an ordinary installation failure (filesystem error, mount policy or a transient condition), NOT an unsupported host. Retrying may help.\n" "$d" >&2
+      exit 1
     fi
     rm -f -- "$__x2" 2>/dev/null
     t=$(mktemp -- "$d/.$b.XXXXXX") || exit 1
@@ -844,19 +814,7 @@ perf_capability_token() {
 # unprivileged agent process still gets EACCES — and `sudo bash
 # scripts/bootstrap-agent-machine.sh` is a completely normal provisioning invocation
 # (arguably the most likely one, since installing the drop-in needs root). A root-run
-# functional check reported as "perf capability verified" is therefore a FALSE verification
-# of an unprofileable box: the failure mode the functional check exists to remove,
-# reintroduced through the privilege dimension. The property under test is "an UNPRIVILEGED
-# process can collect CPU-WIDE cycles", which a root-run probe cannot demonstrate — so the
-# probe DROPS PRIVILEGE when it can and SAYS SO when it cannot, and the caller then
-# subordinates the functional result to the identity-independent /proc token.
-#
-# perf_capability_self_uid_into <outvar>: THIS process's uid, rc 0 ONLY when genuinely known
-# — `id -u` must EXIST, exit 0, and print a validated non-negative integer. rc 1 (<outvar>
-# emptied) means "identity unknown", which is NOT "unprivileged" (review R4-1). The previous
-# shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or broken `id` made a
-# ROOT process look unprivileged, so its root perf run was accepted as unprivileged evidence
-# and printed a false VERIFIED — the R3-1 defect, through the detector written to prevent it.
+# (full rationale: fleet-runbook.md, perf seam containment, arguably-the-most-likely-one-since-installing)
 perf_capability_self_uid_into() {
   local __psu_v=''
   eval "$1="

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -257,22 +257,10 @@ perf_capability_sandbox_ok_resolved() {
   # split; it was simply running too late to see it. Order matters more than the predicate here.
   perf_capability_path_lines_ok "${1:-}" || return 1
   perf_capability_sandbox_root_into __pdr_root || return 1
-  # KNOWN, TRACKED, DELIBERATELY-UNFIXED RESIDUAL — **#3323 entry 3** (roborev round 12, Medium).
-  # THE DEFECT, in the reviewer's words: "cd -P/pwd -P resolves symlinks but cannot detect bind
-  # mounts. A sandbox path bind-mounted to /etc/sysctl.d or /proc/sys/kernel still appears lexically
-  # contained; the installer's ownership/mode check also accepts a root-owned bound /etc/sysctl.d,
-  # allowing test mode to read or modify host state."
-  # THE NAMED FIX, verbatim: "use mount-aware, descriptor-relative containment such as openat2 with
-  # appropriate no-cross-mount constraints, or explicitly reject mount-boundary crossings."
-  # WHY NOT FIXED HERE: that fix IS openat2 — the same non-shell mechanism already rejected for this
-  # family (an interpreter dependency on the privileged bootstrap path). Shell cannot decide this:
-  # comparing st_dev via `stat -c %d` catches a cross-FILESYSTEM bind but NOT a same-filesystem one,
-  # so a device check would be a guard with a known hole, which is worse than a recorded boundary.
-  # By owner ruling this whole class (a NAME that does not correspond to its real DESTINATION) is
-  # CLOSED: it is recorded and appended to #3323 automatically, not escalated and not re-attempted.
-  # CONSEQUENCE, SCOPED: requires the ability to CREATE a bind mount, i.e. root or CAP_SYS_ADMIN on a
-  # box we own — an actor who already has what the escape would obtain. Test-mode only.
-  # BOTH sides canonicalized the same way, so the comparison is between destinations
+# RESIDUAL — #3323 entry 3: bind mounts defeat lexical containment. `cd -P`/`pwd -P` resolve
+# symlinks but not MOUNTS, so a bind-mounted sandbox path looks contained. Deliberately unfixed:
+# the fix is mount-aware fd-relative containment (openat2), not expressible in shell, and this
+# escape class is CLOSED by owner ruling. Read #3323 before widening this trust.
   __pdr_root=$(cd -P -- "$__pdr_root" 2>/dev/null && pwd -P) || return 1
   __pdr_real=$(cd -P -- "${1:-/dev/null/never}" 2>/dev/null && pwd -P) || return 1
   perf_capability_path_within "$__pdr_real" "${__pdr_root%/}"
@@ -362,28 +350,10 @@ perf_capability_env_guard() {
     }
     perf_capability_priv_tool_ok "$resolved" "$tool" || return 1
   done
-  # KNOWN, TRACKED, DELIBERATELY-UNFIXED RESIDUAL — recorded in **#3323** (the THIRTEENTH escape in
-  # this family; the twelfth, the ancestor-chain rename race, is recorded at the install site).
-  # THE DEFECT, in the reviewer's words: this validation "validates the current sudo/sysctl entries,
-  # discards their resolved paths, and later callers resolve them again through PATH. A writable test
-  # shim directory can replace a validated file with a symlink to the host binary after the guard,
-  # allowing test mode to execute real privileged tools."
-  # THE NAMED FIX, also verbatim, so nobody has to re-derive it: "require the shim directory to be
-  # owned by the executing identity and not group/world-writable, and invoke the exact validated
-  # executable paths rather than resolving their names again."
-  # WHY IT IS NOT FIXED HERE: this is the same validate-a-NAME-then-re-resolve shape as the twelve
-  # before it, and by owner ruling this family is CLOSED — thirteen escapes established the class is
-  # unbounded in shell, and the two authorized in-shell fixes (A-prime, and the `--install` surface)
-  # each produced further defects of their own. A fourteenth attempt is not authorized.
-  # CONSEQUENCE, SCOPED HONESTLY: a TEST-MODE containment escape (a real `sudo`/`sysctl` becoming
-  # reachable during tests on a box we own), not a production exposure — production never sets
-  # CQLITE_PERF_TEST_MODE, so this whole function returns early there. Same latency class as #3323's
-  # ancestor race. #3323 re-raises on EVIDENCE the boundary is reachable, and nothing else.
-  # Do NOT "just add a check here" — read #3323 first.
-  # ...and every privileged tool PARKED in the declared shim dir, whether or not PATH happens to
-  # reach it: one PATH-order change is all that separates "not resolved" from "executed", and the
-  # loop above is driven by PATH. Only `sudo`/`sysctl` are swept — a shim dir legitimately holds
-  # `ln -s`ed real coreutils (cat, mv, uname), which grant no privilege.
+  # RESIDUAL — #3323 entry 2: privileged-tool validation resolves sudo/sysctl, DISCARDS the
+  # resolved paths, and later callers re-resolve by name, so a writable shim dir can swap in a
+  # link to the host binary afterwards. Deliberately unfixed (13th escape; class CLOSED by owner
+  # ruling; the fix needs held fds). Test-mode only. Read #3323 before widening this trust.
   if [ -n "$dir" ] && [ -d "$dir" ]; then
     for tool in sudo sysctl; do
       [ -e "$dir/$tool" ] || [ -L "$dir/$tool" ] || continue
@@ -611,28 +581,10 @@ perf_capability_dropin_install() {
     #   no window. It removes the ATTACKER PRECONDITION, turning "production is safe because
     #   /etc/sysctl.d is root-owned" from a recorded ASSUMPTION into an ENFORCED INVARIANT: assume
     #   nothing about the destination, measure it, fail closed.
-    #   KNOWN, TRACKED, DELIBERATELY-UNFIXED RESIDUAL — **issue #3323** (ancestor-chain rename race,
-    #   the TWELFTH escape in this family). This precondition validates the target DIRECTORY; it does
-    #   NOT prove the PATH BY WHICH that directory is reached is stable. An actor able to write an
-    #   ANCESTOR can rename the validated directory and substitute a symlink after these checks, and
-    #   the later `mktemp`/write/rename re-resolve `$d`. The correct fix is a held directory
-    #   descriptor with no-follow fd-relative operations (`openat2` containment) — NOT expressible in
-    #   shell, which is why twelve in-shell attempts at this class stopped here by owner ruling
-    #   rather than a thirteenth. #3323 records that fix and re-raises on EVIDENCE the boundary is
-    #   reachable (multi-tenant boxes, an attacker-writable ancestor, or a real privileged helper
-    #   reachable from test mode). Production ancestors are `/etc` and `/`, both root-owned; test
-    #   mode reaches only AC4 shims. Do NOT widen the trust of this function without reading #3323 first.
-    #   THE REMAINING BOUNDARY, STATED: this check races only against an actor who can `chmod` a
-    #   directory owned by the privileged writer — and that actor is already the privileged writer
-    #   (or root), so it has no privilege left to escalate to. That is the whole of the residual;
-    #   it is a boundary, not a proof, and it is deliberately not phrased as "cannot happen" —
-    #   this function has already had TWO such phrasings retracted (a fixed staging name, and a
-    #   single `sh -c` mistaken for mutual exclusion).
-    # NO SYMLINK FOLLOWING IN THE CHECK, ASSERTED RATHER THAN INHERITED: `stat -c` is lstat-like on
-    # GNU (it does not dereference without -L), so a symlinked $d would be measured as the LINK.
-    # Relying on that implicitly is the same by-name reasoning this family has punished eleven
-    # times, so the symlink case is refused OUTRIGHT and first — the destination directory must be
-    # a real directory, not a link to one, whatever a future stat implementation would report.
+    #   RESIDUAL — #3323 entry 1: the ancestor-chain rename race. This validates the target
+    #   directory, NOT the path by which it is reached, so an actor able to write an ANCESTOR can
+    #   swap the validated directory for a symlink after these checks. Deliberately unfixed (12th
+    #   escape; class CLOSED; needs openat2). Read #3323 before widening this trust.
     if [ -L "$d" ]; then
       printf "perf-capability: REFUSING: the drop-in directory %s is a SYMLINK — its owner and mode say nothing about where entries would actually be created, so it cannot be proven un-writable by less-privileged users.\n" "$d" >&2
       exit 1

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -166,7 +166,13 @@ perf_capability_sandbox_root_into() {
   local __psr_v="${CQLITE_PERF_TEST_SANDBOX:-}"
   eval "$1="
   perf_capability_path_lines_ok "$__psr_v" || return 1
-  __psr_v="${__psr_v%/}"
+  # ALL trailing slashes, not one (roborev round 31, Low). Stripping a single `/` left a root ending in
+  # `//` as one ending in `/`, which passed the `//` rejection below -- and then the fork-free containment
+  # pattern appended its own separator and rejected EVERY child, while the resolving write path still
+  # accepted the same root. Read and write disagreeing about the same sandbox is worse than either
+  # answer alone. The length guard keeps `/` itself from collapsing to the empty string, which the
+  # `/?*` test below then refuses on its own merits.
+  while [ "${__psr_v%/}" != "$__psr_v" ] && [ "${#__psr_v}" -gt 1 ]; do __psr_v="${__psr_v%/}"; done
   case "$__psr_v" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
   case "/$__psr_v/" in */../*|*/./*) return 1 ;; esac
   [ -d "$__psr_v" ] && [ -f "$__psr_v/$PERF_CAPABILITY_SANDBOX_STAMP" ] || return 1
@@ -678,6 +684,16 @@ perf_capability_sysctl_search_path() {
     __psp_d=$(perf_capability_sysctl_dir) || return 1
     printf '%s\n' "$__psp_d"
     local -a __psp_extra=()
+    # THE WHOLE UNSPLIT VALUE IS LINE-CHECKED FIRST (roborev round 31, Medium). `read` consumes only the
+    # FIRST LINE of its input, so an EXTRA_DIRS value whose first line is a perfectly valid contained
+    # directory succeeded while SILENTLY DISCARDING everything after the newline -- the scan then reported
+    # "no competing files" having never looked at the rest, which is the falsely-reassuring answer this
+    # diagnostic exists to prevent. The round-3 CR/LF work validated the SPLIT ENTRIES; it never validated
+    # the value being split, so a newline hid entries instead of forging one.
+    perf_capability_path_lines_ok "${CQLITE_PERF_SYSCTL_EXTRA_DIRS:-}" || {
+      printf 'perf-capability: REFUSING: CQLITE_PERF_SYSCTL_EXTRA_DIRS contains CR or LF, so a read would silently keep only its first line and the competing-file scan would report on an incomplete set.\n' >&2
+      return 1
+    }
     # `read -a` splits on IFS WITHOUT globbing (an unquoted `for x in $var` would glob).
     IFS=':' read -r -a __psp_extra <<<"${CQLITE_PERF_SYSCTL_EXTRA_DIRS:-}"
     for __psp_e in ${__psp_extra[@]+"${__psp_extra[@]}"}; do

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -166,12 +166,16 @@ perf_capability_sandbox_root_into() {
   local __psr_v="${CQLITE_PERF_TEST_SANDBOX:-}"
   eval "$1="
   perf_capability_path_lines_ok "$__psr_v" || return 1
-  # ALL trailing slashes, not one (roborev round 31, Low). Stripping a single `/` left a root ending in
-  # `//` as one ending in `/`, which passed the `//` rejection below -- and then the fork-free containment
-  # pattern appended its own separator and rejected EVERY child, while the resolving write path still
-  # accepted the same root. Read and write disagreeing about the same sandbox is worse than either
-  # answer alone. The length guard keeps `/` itself from collapsing to the empty string, which the
-  # `/?*` test below then refuses on its own merits.
+  # ALL trailing slashes, not one (roborev round 31, Low). Stripping a single slash left a root ending
+  # in two slashes as one ending in one, which passed the doubled-slash rejection below -- and then the
+  # fork-free containment pattern appended its own separator and rejected EVERY child, while the
+  # resolving write path still accepted the same root. Read and write disagreeing about the same sandbox
+  # is worse than either answer alone. The length guard keeps a bare root slash from collapsing to the
+  # empty string, which the absolute-path test below then refuses on its own merits.
+  # NO BACKTICKS ANYWHERE IN THIS FUNCTION, comments included: it is in the closed fork-free audit set
+  # of scripts/tests/test_agent_gate_summary.sh, which COUNTS backticks over the whole function text and
+  # cannot tell a quoted path spelling in prose from a real command substitution. Twelve of them here
+  # reddened the gate's tooling-tests component; quote path spellings in words instead.
   while [ "${__psr_v%/}" != "$__psr_v" ] && [ "${#__psr_v}" -gt 1 ]; do __psr_v="${__psr_v%/}"; done
   case "$__psr_v" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
   case "/$__psr_v/" in */../*|*/./*) return 1 ;; esac

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -18,7 +18,23 @@
 # perf mlock limit lifted too. CQLite's doctrine mandates per-CPU collection, so `1` is
 # not "almost right", it is a hard denial. `kernel.kptr_restrict = 0` is a SEPARATE control
 # for kernel SYMBOL resolution — without it kernel frames are unresolved addresses, a
-# (rationale condensed; see #3261 commit history.)
+# SILENT attribution loss rather than an error. Same rationale in the drop-in's own bytes.
+#
+# SECURITY POSTURE. A deliberate loosening, appropriate for DEDICATED SINGLE-TENANT
+# measurement/agent boxes. Never apply it to a shared or multi-tenant host. See
+# docs/development/fleet-runbook.md. BPF IS A DIFFERENT PERMISSION: a permissive
+# perf_event_paranoid does NOT grant BPF map creation — bpftrace/bcc collectors still need
+# sudo (#3217 finding).
+#
+# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call the
+# functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO side
+# effects: this file only defines `perf_capability_*` functions plus the four
+# `PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
+# outside those namespaces are touched). Every function is `set -u` safe.
+#
+# Usage when executed: `bash scripts/perf-capability.sh --help` (the modes are listed by
+# perf_capability_usage below, so they are not duplicated here).
+#
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
 # The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
 # bootstrap installs the drop-in through the STAGED installer below (mktemp + atomic rename, no
@@ -63,7 +79,14 @@
 #   token = ok                  both /proc values READ (non-empty) from the resolved dir AND
 #                               both `is_int`-validated AND paranoid <= 0 AND kptr == 0.
 #                               Whitespace trimmed, never TRUNCATED — `0 1` stays malformed.
-# (rationale condensed; see #3261 commit history.)
+#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count is a
+#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` + `-le
+#                               0`. `<not supported>`/`<not counted>`/empty/oversized/malformed
+#                               all return 1.
+#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0 and
+#                               prints a validated non-negative int) AND that uid != 0; an
+#                               unusable `id -u` => identity-unknown, rc 1.
+#   state = dropped:setpriv     numeric uid+gid, both validated ints AND both > 0.
 #   state = dropped:runuser     the same numerics PLUS a `SUDO_USER` the passwd database
 #                               confirms IS that non-zero uid/gid, with characters safe for
 #                               the caller's word-split.
@@ -680,7 +703,15 @@ perf_capability_dropin_current() {
   # THE SENTINEL MUST NOT SWALLOW THE GENERATOR'S STATUS (roborev round 9, Medium). `printf X`
   # exists so a trailing newline survives command substitution, but it also RAN LAST, so the
   # substitution reported ITS status and a failed content generator looked like success: `want`
-# (rationale condensed; see #3261 commit history.)
+  # became bare "X", and against an empty file `${got}X` is also "X" — equal, so a broken
+  # generator reported the drop-in ALREADY CURRENT. A positive verdict from an unmeasured state,
+  # which is the exact shape this repo has a standing rule against. The rc is now captured
+  # BEFORE the sentinel and re-raised as the subshell's exit status, so both properties hold.
+  want=$(perf_capability_dropin_content; __pdc_rc=$?; printf 'X'; exit "$__pdc_rc") || return 1
+  if IFS= read -r -d '' got <"$path"; then
+    return 1
+  fi
+  [ "$want" = "${got}X" ]
 }
 
 # perf_capability_sysctl_search_path: the COMPLETE set of locations `sysctl --system`

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -536,6 +536,30 @@ perf_capability_dropin_install() {
     d=$1; p=$2; b=$3
     # THE PRECONDITION (roborev round 3): nobody less privileged than this shell may be able to
     # create or replace entries in $d. Without that there is an actor to race; with it there is not.
+    #   WHY THIS IS NOT A TWELFTH ATTEMPT TO OUT-TIME THE RACE (owner ruling A-prime): escapes 9-11
+    #   narrowed a WINDOW (unpredictable name, O_EXCL create, one privileged process). This touches
+    #   no window. It removes the ATTACKER PRECONDITION, turning "production is safe because
+    #   /etc/sysctl.d is root-owned" from a recorded ASSUMPTION into an ENFORCED INVARIANT: assume
+    #   nothing about the destination, measure it, fail closed.
+    #   THE REMAINING BOUNDARY, STATED: this check races only against an actor who can `chmod` a
+    #   directory owned by the privileged writer — and that actor is already the privileged writer
+    #   (or root), so it has no privilege left to escalate to. That is the whole of the residual;
+    #   it is a boundary, not a proof, and it is deliberately not phrased as "cannot happen" —
+    #   this function has already had TWO such phrasings retracted (a fixed staging name, and a
+    #   single `sh -c` mistaken for mutual exclusion).
+    # NO SYMLINK FOLLOWING IN THE CHECK, ASSERTED RATHER THAN INHERITED: `stat -c` is lstat-like on
+    # GNU (it does not dereference without -L), so a symlinked $d would be measured as the LINK.
+    # Relying on that implicitly is the same by-name reasoning this family has punished eleven
+    # times, so the symlink case is refused OUTRIGHT and first — the destination directory must be
+    # a real directory, not a link to one, whatever a future stat implementation would report.
+    if [ -L "$d" ]; then
+      printf "perf-capability: REFUSING: the drop-in directory %s is a SYMLINK — its owner and mode say nothing about where entries would actually be created, so it cannot be proven un-writable by less-privileged users.\n" "$d" >&2
+      exit 1
+    fi
+    if [ ! -d "$d" ]; then
+      printf "perf-capability: REFUSING: the drop-in directory %s is not a directory.\n" "$d" >&2
+      exit 1
+    fi
     me=$(id -u 2>/dev/null) || {
       printf "perf-capability: REFUSING: cannot determine the privileged writer identity (id -u failed), so the drop-in directory cannot be proven un-writable by less-privileged users.\n" >&2
       exit 1; }

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -589,23 +589,20 @@ perf_capability_dropin_install() {
     # keeps it from pre-empting the staging entry checks below, which have their own cases.
     __x1="$d/.perfcap-probe.$$"; __x2="$__x1.b"
     rm -f -- "$__x1" "$__x2" 2>/dev/null
-    # ABSENCE IS PROVEN, NOT ASSUMED (roborev round 21, High — a hazard THIS probe introduced). `rm`
-    # can fail (a read-only mount, an immutable entry) and its status was ignored; `: >` then FOLLOWS a
-    # symlink, so a leftover link at this predictable name could have truncated an arbitrary file under
-    # the privileged identity. The directory-mode precondition does not help: it proves nobody
-    # less-privileged can CREATE entries here, not that a pre-existing one was successfully removed.
+    # ABSENCE IS PROVEN, NOT ASSUMED (roborev round 21, High). `rm` can fail (read-only mount) and its
+    # status was ignored, and `: >` FOLLOWS a symlink — so a leftover link at this predictable name
+    # could truncate an arbitrary file under privilege. The mode precondition proves nobody
+    # less-privileged can CREATE entries here, not that a pre-existing one was removed.
     if [ -e "$__x1" ] || [ -L "$__x1" ] || [ -e "$__x2" ] || [ -L "$__x2" ]; then
       printf "perf-capability: REFUSING: probe entries under %s could not be cleared, so opening them could follow a leftover symlink under privilege.\n" "$d" >&2
       exit 1
     fi
-    # CREATION FAILURE IS ITS OWN OUTCOME, NOT "unsupported host" (roborev round 21, Low). These used to
-    # share one branch, so an unwritable directory was misreported as an incompatible `mv` — which made
-    # bootstrap suppress the retry remedy for a condition where retrying is exactly right. rc 1 REFUSED
-    # here; rc 2 UNSUPPORTED is reserved for an `mv` that genuinely lacks -T.
-    # SUBSHELL, and NOT the `:` builtin bare: `:` is a POSIX SPECIAL builtin, so a redirection failure
-    # on it makes a non-interactive shell EXIT — dash exits with status 2, which silently COLLIDED with
-    # the rc 2 UNSUPPORTED sentinel and reported a read-only directory as an incompatible `mv`. The
-    # subshell contains both the exit and the leaked shell diagnostic, so the caller sees rc 1 REFUSED.
+    # CREATION FAILURE IS ITS OWN OUTCOME (roborev round 21, Low): sharing one branch with the `mv`
+    # test reported an unwritable directory as an unsupported host, making bootstrap suppress the retry
+    # remedy exactly where retrying is right. rc 1 REFUSED here; rc 2 is reserved for `mv` lacking -T.
+    # SUBSHELL because `:` is a POSIX SPECIAL builtin: a redirection failure on it makes a
+    # non-interactive shell EXIT, and dash exits 2 — silently colliding with the rc 2 sentinel. The
+    # subshell contains both the exit and the leaked diagnostic, so the caller sees rc 1.
     if ! ( : >"$__x1" ) 2>/dev/null; then
       printf "perf-capability: REFUSING: cannot create a probe entry in %s — the directory is not writable by the privileged writer.\n" "$d" >&2
       exit 1

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -403,7 +403,7 @@ perf_capability_dropin_path() {
   __pdi_d=$(perf_capability_sysctl_dir) || return 1
   __pdi_p="$__pdi_d/$PERF_CAPABILITY_DROPIN_BASENAME"
   if [ -L "$__pdi_p" ]; then
-    printf 'perf-capability: REFUSING: the managed drop-in name %s is a SYMLINK. A privileged `tee` FOLLOWS it and would overwrite the link target instead of the managed file — a contained directory does not license writing through its entries. Remove the symlink (or let the atomic installer replace the entry).\n' \
+    printf 'perf-capability: REFUSING: the managed drop-in name %s is a SYMLINK. A privileged `tee` FOLLOWS it and would overwrite the link target instead of the managed file — a contained directory does not license writing through its entries. Inspect where it points and remove it; nothing here will write through it.\n' \
       "'$__pdi_p'" >&2
     return 1
   fi

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -415,38 +415,56 @@ perf_capability_dropin_path() {
 # FOLLOWED (issue #3261 AC1). argv is the privilege prefix (empty when already root); rc 0 iff the
 # managed bytes are in place at the managed path afterwards, verified by re-reading the file.
 #
-# Content goes to a fresh temp entry in the ALREADY-VALIDATED directory, then `mv -f` — rename(2),
-# which replaces the NAME and never dereferences the destination. The check in
-# perf_capability_dropin_path above has a TOCTOU window; a rename has none, which is why both
-# exist rather than either alone. Same directory, so the rename is same-filesystem and atomic. The
-# temp name is derived from the managed basename, never from a caller-supplied string, and an
-# entry already occupying it is removed and its removal VERIFIED before anything is written —
-# otherwise `tee` would follow a symlink planted at the temp name instead.
-#   The staging name is FIXED rather than pid-suffixed, deliberately: two bootstraps racing on one
-#   box would then collide and ONE would fail loudly, which is the honest outcome (they are writing
-#   the same managed bytes to the same managed path), whereas a pid suffix would leave
-#   per-pid litter behind whenever a run is killed between the `tee` and the `mv`. Bootstrap is
-#   once-per-box and the fleet rule is one worker per machine, so the race is not a live concern;
-#   the litter would be.
-#   It does not end in `.conf`, so the competing-file scan (which globs `*.conf`) can never mistake
-#   a staging entry for a rival sysctl drop-in.
+# Content goes to a fresh staging entry in the ALREADY-VALIDATED directory, then `mv -f` —
+# rename(2), which replaces the NAME and never dereferences the destination. Same directory, so the
+# rename is same-filesystem and atomic. The check in perf_capability_dropin_path above has a TOCTOU
+# window; a rename has none, which is why both exist rather than either alone.
+#
+# THE STAGING NAME IS UNPREDICTABLE, AND `mktemp` — NOT THE SHELL — CREATES IT (issue #3261, roborev
+# finding 1, the NINTH escape in this family and the SAME SHAPE as the other eight: a NAME trusted
+# in place of a DESTINATION). A PREDICTABLE staging path that is checked-then-opened is exactly that
+# assumption: this function used a fixed `.99-cqlite-perf.conf.new`, removed it, verified the
+# removal, and only then let a privileged `tee` open it — so anyone able to create entries in the
+# directory could re-plant that known name as a symlink in the window between the verify and the
+# open, and the root `tee` would follow it to an arbitrary file. Checking harder cannot close that
+# window; only removing the assumption can. So `mktemp` creates the entry with O_CREAT|O_EXCL under
+# the SAME privilege that will write it, and the name carries 6 random characters — an attacker can
+# neither guess the name nor win the create, because there is no create left to win.
+#   An earlier revision of this comment argued the fixed name was preferable ("litter beats a race
+#   that cannot happen"). That was WRONG on both halves and is recorded here rather than quietly
+#   deleted: the race is a real privileged arbitrary-overwrite, and a pid suffix would not have
+#   helped either — a pid is predictable. Unpredictability is the property; `mktemp` is how it is
+#   obtained. The litter it does risk (an unpredictably-named dotfile if a run is killed between the
+#   `tee` and the `mv`) is a cosmetic cost against a root-overwrite, and every exit path here
+#   removes it.
+#   The name does not end in `.conf` (and begins with `.`), so the competing-file scan — which globs
+#   `*.conf` — can never mistake a staging entry for a rival sysctl drop-in.
+#   `chmod 0644` after the write is load-bearing, not cosmetic: `mktemp` creates 0600, and the
+#   idempotency compare (perf_capability_dropin_current) is run by an UNPRIVILEGED bootstrap
+#   process, which could not read a root-owned 0600 file — every subsequent run would then see
+#   "not current" and rewrite. The old `tee` produced 0644 via root's umask; this preserves that.
 perf_capability_dropin_install() {
   local __pin_d __pin_p __pin_t
   __pin_d=$(perf_capability_sysctl_dir) || return 1
   __pin_p="$__pin_d/$PERF_CAPABILITY_DROPIN_BASENAME"
-  __pin_t="$__pin_d/.$PERF_CAPABILITY_DROPIN_BASENAME.new"
-  if [ -e "$__pin_t" ] || [ -L "$__pin_t" ]; then
-    "$@" rm -f -- "$__pin_t" >/dev/null 2>&1
-    if [ -e "$__pin_t" ] || [ -L "$__pin_t" ]; then
-      printf 'perf-capability: REFUSING: could not clear the staging entry %s, so a write there could follow it.\n' "'$__pin_t'" >&2
-      return 1
-    fi
-  fi
-  if ! perf_capability_dropin_content | "$@" tee -- "$__pin_t" >/dev/null 2>&1; then
+  __pin_t=$("$@" mktemp -- "$__pin_d/.$PERF_CAPABILITY_DROPIN_BASENAME.XXXXXX" 2>/dev/null) || return 1
+  # `mktemp` is the one creating the entry, so its answer is what must be checked: it has to name a
+  # fresh REGULAR file (never a symlink) directly inside the directory we validated. A tool that
+  # answered anything else has not given us a safe staging entry, and there is nothing to clean up.
+  case "$__pin_t" in
+    "$__pin_d"/.?*) ;;
+    *) printf 'perf-capability: REFUSING: mktemp did not create a staging entry inside the validated directory %s (got %s).\n' \
+         "'$__pin_d'" "'${__pin_t:-<empty>}'" >&2
+       return 1 ;;
+  esac
+  if [ -L "$__pin_t" ] || [ ! -f "$__pin_t" ]; then
+    printf 'perf-capability: REFUSING: the staging entry %s is not a fresh regular file.\n' "'$__pin_t'" >&2
     "$@" rm -f -- "$__pin_t" >/dev/null 2>&1
     return 1
   fi
-  if ! "$@" mv -f -- "$__pin_t" "$__pin_p" >/dev/null 2>&1; then
+  if ! perf_capability_dropin_content | "$@" tee -- "$__pin_t" >/dev/null 2>&1 \
+     || ! "$@" chmod 0644 -- "$__pin_t" >/dev/null 2>&1 \
+     || ! "$@" mv -f -- "$__pin_t" "$__pin_p" >/dev/null 2>&1; then
     "$@" rm -f -- "$__pin_t" >/dev/null 2>&1
     return 1
   fi

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -642,19 +642,7 @@ perf_capability_dropin_content() {
 # silent attribution loss rather than an error.
 #
 # THE "99-" PREFIX IS LOAD-BEARING — DO NOT RENAME THIS FILE. sysctl.d drop-ins are
-# applied in lexicographic order of BASENAME and the LAST assignment wins. Stock Ubuntu
-# ships /etc/sysctl.d/10-kernel-hardening.conf containing `kernel.kptr_restrict = 1`,
-# so this file only wins because "99-cqlite-perf.conf" sorts after "10-...". Renaming it
-# to cqlite-perf.conf or any lower number silently hands kptr_restrict back to the
-# hardening drop-in at the next boot — the "it silently reverts" mystery in three
-# separate measurement reports.
-#
-# NOTE ON PRECEDENCE: /etc/sysctl.conf is applied AFTER every sysctl.d drop-in by
-# both `sysctl --system` and systemd-sysctl, so a stale perf_event_paranoid there
-# BEATS this file. Check it if the values do not take.
-#
-# This is a deliberate loosening. NOT for shared or multi-tenant hosts.
-# Rationale + verification: docs/development/fleet-runbook.md
+# (rationale condensed; see the #3261 commit history.)
 kernel.perf_event_paranoid = -1
 kernel.kptr_restrict = 0
 EOF
@@ -668,16 +656,7 @@ EOF
 #
 # TRAILING NEWLINES ARE PART OF THE BYTES (review R4-4). `$( )` strips EVERY trailing
 # newline, so comparing two command substitutions made a file missing its final newline —
-# or carrying extra trailing blank lines — compare EQUAL: "byte-exact" was a false claim
-# and such a file was never rewritten. The file side is read with `read -r -d ''`, which
-# consumes it verbatim (builtin, no `cat`/`diff` dependency), and the canonical side carries
-# an in-substitution sentinel so its own final newline survives the stripping.
-#
-# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (review R5-3). `read -d ''` stops at a NUL
-# and returns SUCCESS with only the bytes BEFORE it, so canonical content + NUL + ARBITRARY
-# trailing bytes compared EQUAL and was judged current. Read's rc is therefore load-bearing:
-# rc 0 means a NUL was consumed — not our text drop-in, and the rest never even seen — so it
-# is NOT current; only rc != 0 (EOF, whole file in `got`) may be compared.
+# (rationale condensed; see the #3261 commit history.)
 perf_capability_dropin_current() {
   local path want got=''
   path=$(perf_capability_dropin_path) || return 1
@@ -706,20 +685,7 @@ perf_capability_dropin_current() {
 #            subsequent directories is ignored" — so /etc/sysctl.d/50-x.conf REPLACES
 #            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would name
 #            a file that is not in effect.
-#   ORDERING the survivors are applied in lexicographic BASENAME order regardless of which
-#            directory they came from; the LAST assignment wins. /etc/sysctl.conf is applied
-#            AFTER every drop-in, so it wins on grounds unrelated to its name and gets its
-#            own verdict rather than a sort comparison.
-# WHY THE WHOLE PATH (review R5-4). Scanning only /etc/sysctl.d meant a later-sorting file in
-# /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in while bootstrap reported NO
-# competitor — recreating the "it silently reverts and nobody knows why" mystery this
-# diagnostic exists to end.
-#
-# In TEST MODE the path is the sandbox seam plus the optional colon-separated
-# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, same descending order): the real
-# /run and /usr/lib are never read. EVERY entry goes through the SAME RESOLVING gate as the
-# write path (R6-2 — this entry point once used the syntactic one, so a symlinked ancestor
-# could point a "sandboxed" scan at the host's real configuration).
+# (rationale condensed; see the #3261 commit history.)
 perf_capability_sysctl_search_path() {
   local __psp_d __psp_e __psp_ok
   if perf_capability_test_mode; then
@@ -763,16 +729,7 @@ perf_capability_file_sets_controls() {
 # `earlier` = ours wins; `last` = /etc/sysctl.conf, applied after every drop-in, so it
 # wins regardless of name.
 #
-# WHY THIS EXISTS. Three separate reports (ws0-3217, ws3-3029, the 2026-07-27 Cassandra
-# baseline) recorded a hand-set perf_event_paranoid/kptr_restrict "silently reverting" and
-# none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
-# /etc/sysctl.d/10-kernel-hardening.conf with `kernel.kptr_restrict = 1`, re-asserted at
-# every boot and by every `sysctl --system`. "It silently reverts" is unactionable;
-# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins" is a
-# diagnosis. Ordering is lexicographic by BASENAME in BYTE order (what systemd-sysctl and
-# `sysctl --system` use) and `[ "$a" \> "$b" ]` is the right operator: the `[` builtin
-# compares with strcmp (verified: byte order even under a UTF-8 LC_ALL), whereas `[[ > ]]`
-# switches to locale collation and could mis-rank names differing only in punctuation.
+# (rationale condensed; see the #3261 commit history.)
 perf_capability_competing_files() {
   local base f name entry seen paths lf='
 '

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -151,22 +151,10 @@ PERF_CAPABILITY_LF='
 PERF_CAPABILITY_CR=$'\r'
 
 # perf_capability_path_lines_ok: rc 0 iff <path> contains NO CR and NO LF.
-#
-# WHY A SEPARATE PROPERTY FROM CONTAINMENT (issue #3261, roborev round 3). This one is not a
-# containment defect at all — the path IS contained — it is a SERIALIZATION defect, which is why
-# nine rounds of containment work never touched it. `perf_capability_sysctl_search_path` emits its
-# answer ONE ENTRY PER LINE and `perf_capability_competing_files` reads it line-wise, so a directory
-# legitimately inside the sandbox but NAMED with an embedded newline —
-# `<root>/name<LF>/etc/sysctl.d` — passes every containment check and is then SPLIT into two
-# entries, the second of which is the host's real `/etc/sysctl.d`. One contained path became two
-# paths, one of them production.
-#   The repo already knows this class: CLAUDE.md records the roborev guard's own `-z` invariant for
-# exactly this reason — a newline-delimited path set is not a safe representation of paths, and the
-# fix there was to stop using one. Here the answer is the cheaper half of the same lesson: REJECT
-# the characters at the boundary rather than escape them downstream or re-plumb every consumer to
-# NUL. A path with a newline in it has no legitimate use as a perf seam, so refusing it costs
-# nothing and removes the ambiguity at its source. CR is rejected with LF because a CRLF host file
-# would otherwise leave a stray `\r` inside a resolved entry.
+# NOT a containment defect — the path IS contained — a SERIALIZATION one: the search path is emitted
+# one entry per line, so a contained directory NAMED with an embedded newline splits into two
+# entries, the second being the real /etc/sysctl.d. Rejected at the boundary rather than escaped
+# downstream. Full rationale: docs/development/fleet-runbook.md, "perf seam containment — why".
 perf_capability_path_lines_ok() {
   case "${1:-}" in
     *"$PERF_CAPABILITY_LF"*|*"$PERF_CAPABILITY_CR"*) return 1 ;;
@@ -350,17 +338,9 @@ perf_capability_env_guard() {
 
 # perf_capability_priv_tool_ok <resolved-path> <tool-name>: rc 0 iff this privileged executable's
 # RESOLVED destination is positively contained beneath the PROVEN sandbox root. Refuses loudly.
-#
-# WHY (issue #3261 AC4 — the EIGHTH escape from this guard family, and the first about an
-# executable rather than a path). The shim dir was trusted TEXTUALLY: `/usr` is absolute and
-# genuinely CONTAINS `/usr/bin/sudo`, so "inside the declared shim dir" passed; and a SYMLINK to
-# the real `sudo`/`sysctl` placed inside a genuine shim dir is spelled locally while resolving to
-# the host's binary. Either one let a privileged test-mode bootstrap run a real
-# `sysctl --system` and reconfigure the host kernel — the exact mutation the marker promises
-# cannot happen. Same discipline as the paths: the declared NAME is not the DESTINATION, so the
-# destination is what is judged, positively, against a root that had to prove itself. The FILE
-# form does the work (canonical parent + basename, and a symlinked final component is refused),
-# which is also why a `/usr` shim dir fails: /usr/bin is not inside the sandbox.
+# The declared NAME is not the DESTINATION — a `/usr` shim dir and a symlink to the real sudo both
+# passed a textual check (AC4, the eighth escape).
+# Full rationale: docs/development/fleet-runbook.md, "perf seam containment — why".
 perf_capability_priv_tool_ok() {
   perf_capability_sandbox_file_ok_resolved "${1:-}" && return 0
   printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but the privileged tool %s at %s does not RESOLVE to an executable strictly inside the declared sandbox %s (a symlink to the real tool, or a shim dir that is not itself in the sandbox, resolves OUT of it) — test mode may never invoke a real privileged tool.\n' \
@@ -412,19 +392,10 @@ perf_capability_sysctl_dir() {
   printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
 # perf_capability_dropin_path: the path a root `tee` is pointed at. The DIRECTORY's gate lives in
-# perf_capability_sysctl_dir (the single source of that directory) and RESOLVES the destination,
-# so there is deliberately no second copy of it here — one gate, not a prohibition a future entry
-# point could skip (R6-2).
-#
-# BUT DIRECTORY CONTAINMENT IS NOT WRITE-TARGET CONTAINMENT (issue #3261 AC1). A contained
-# directory says nothing about where its ENTRIES point, and `tee <path>` opens
-# O_WRONLY|O_CREAT|O_TRUNC and FOLLOWS a symlink — so a symlink at the managed basename inside a
-# perfectly-contained directory aimed the privileged write at the LINK'S TARGET, anywhere on the
-# box. The write TARGET is therefore validated too, as an O_NOFOLLOW-equivalent refusal: a
-# symlink at the managed name is rc 1 + empty + a named reason, for every consumer at once
-# (this function is the single source of the path). The complementary half is
-# perf_capability_dropin_install, which REPLACES the directory entry instead of writing through
-# it, closing the window between this check and the write.
+# perf_capability_sysctl_dir (one gate, not a prohibition a future entry point could skip), and the
+# WRITE TARGET is validated too — a symlink at the managed basename is rc 1 + empty + a named
+# reason, because directory containment is NOT write-target containment (AC1).
+# Full rationale: docs/development/fleet-runbook.md, "perf seam containment — why".
 perf_capability_dropin_path() {
   local __pdi_d __pdi_p
   __pdi_d=$(perf_capability_sysctl_dir) || return 1

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -497,7 +497,11 @@ perf_capability_dropin_install() {
     # --no-target-directory, not that rename-over-a-name behaves. Two throwaway entries in the
     # already-validated directory are renamed one over the other, which is exactly the operation the
     # install depends on. rc 2 = UNSUPPORTED HOST, distinct from rc 1 = REFUSED.
-    stat -c '%a' -- "$d" >/dev/null 2>&1 || {
+    # Probed on `/`, a KNOWN-VALID operand, not on $d (roborev round 23, Medium): statting the
+    # DESTINATION here conflated "no GNU stat" with "destination missing", so an absent /etc/sysctl.d
+    # returned rc 2 and bootstrap suppressed a remedy that would have helped. Destination problems are
+    # rc 1, reported by the owner/mode read further down; rc 2 means the TOOL is incompatible.
+    stat -c '%a' -- / >/dev/null 2>&1 || {
       printf "perf-capability: UNSUPPORTED on this host: stat -c is unavailable (GNU coreutils required), so ownership and mode cannot be established before a privileged write.\n" >&2
       exit 2; }
     # THE PRECONDITION (roborev round 3): nobody less privileged than this shell may be able to

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -443,31 +443,59 @@ perf_capability_dropin_path() {
 #   idempotency compare (perf_capability_dropin_current) is run by an UNPRIVILEGED bootstrap
 #   process, which could not read a root-owned 0600 file — every subsequent run would then see
 #   "not current" and rewrite. The old `tee` produced 0644 via root's umask; this preserves that.
+#
+# ONE PRIVILEGED INVOCATION, AND THE RESIDUAL THAT REMAINS (issue #3261, roborev round 2 — the
+# TENTH escape, the same shape one level deeper). `mktemp` closed the CREATE race but moved the
+# window rather than closing it: mktemp returns a NAME, and `tee`/`chmod`/`mv` each REOPEN that name
+# afterwards, so between the create and the reopen an attacker who can write the directory could
+# observe the random entry and replace it with a symlink. Every step therefore now runs inside a
+# SINGLE privileged `sh -c` — content on stdin — so no unprivileged process is scheduled between
+# them and there is no point at which a less-privileged observer gets to act.
+#   STATED PLAINLY, BECAUSE THIS FAMILY HAS PUNISHED OPTIMISM NINE TIMES AND ONE COMMENT HERE
+#   ALREADY HAD TO BE RETRACTED: consolidation SHRINKS the reopen window to the inside of one root
+#   process; it does NOT mathematically eliminate it. POSIX shell has no `O_NOFOLLOW|O_EXCL` open
+#   primitive — `mktemp` hands back a name and every subsequent open is by name — so the last
+#   name-based assumption cannot be removed in shell alone. Eliminating it needs a non-shell helper
+#   that holds the descriptor from creation to rename (deferred: it would add an interpreter
+#   dependency to the privileged bootstrap path, which is an owner call, not this issue's).
+#   RECORDED REACHABILITY BOUNDARY — a boundary, NOT a "cannot happen". Exploitation needs BOTH a
+#   real privileged `tee` AND a drop-in directory an attacker can write. In production that
+#   directory is `/etc/sysctl.d`, root-owned; in test mode AC4 requires every privileged tool to be
+#   a sandbox-contained shim, so a real `tee` is refused before this function runs. Neither is a
+#   proof of unreachability, and neither is offered as one.
+#   `mv -fT` requires GNU coreutils. That is satisfied by construction rather than by luck: these
+#   are Linux kernel controls and bootstrap skips this whole section on any non-Linux platform.
 perf_capability_dropin_install() {
-  local __pin_d __pin_p __pin_t
+  local __pin_d __pin_p
   __pin_d=$(perf_capability_sysctl_dir) || return 1
   __pin_p="$__pin_d/$PERF_CAPABILITY_DROPIN_BASENAME"
-  __pin_t=$("$@" mktemp -- "$__pin_d/.$PERF_CAPABILITY_DROPIN_BASENAME.XXXXXX" 2>/dev/null) || return 1
-  # `mktemp` is the one creating the entry, so its answer is what must be checked: it has to name a
-  # fresh REGULAR file (never a symlink) directly inside the directory we validated. A tool that
-  # answered anything else has not given us a safe staging entry, and there is nothing to clean up.
-  case "$__pin_t" in
-    "$__pin_d"/.?*) ;;
-    *) printf 'perf-capability: REFUSING: mktemp did not create a staging entry inside the validated directory %s (got %s).\n' \
-         "'$__pin_d'" "'${__pin_t:-<empty>}'" >&2
-       return 1 ;;
-  esac
-  if [ -L "$__pin_t" ] || [ ! -f "$__pin_t" ]; then
-    printf 'perf-capability: REFUSING: the staging entry %s is not a fresh regular file.\n' "'$__pin_t'" >&2
-    "$@" rm -f -- "$__pin_t" >/dev/null 2>&1
-    return 1
-  fi
-  if ! perf_capability_dropin_content | "$@" tee -- "$__pin_t" >/dev/null 2>&1 \
-     || ! "$@" chmod 0644 -- "$__pin_t" >/dev/null 2>&1 \
-     || ! "$@" mv -f -- "$__pin_t" "$__pin_p" >/dev/null 2>&1; then
-    "$@" rm -f -- "$__pin_t" >/dev/null 2>&1
-    return 1
-  fi
+  # ONE privileged invocation for the WHOLE staged install. The content arrives on this shell's
+  # stdin; `mktemp`, the write, `chmod` and the rename all run inside it.
+  perf_capability_dropin_content | "$@" sh -c '
+    set -u
+    d=$1; p=$2; b=$3
+    t=$(mktemp -- "$d/.$b.XXXXXX") || exit 1
+    # mktemp CREATED the entry, so mktemp is what must be checked, INSIDE this privileged shell and
+    # fail-closed: it has to name a fresh regular file (never a symlink) directly in the directory
+    # the caller already validated. Anything else is not a safe staging entry.
+    case "$t" in
+      "$d"/.?*) ;;
+      *) printf "perf-capability: REFUSING: mktemp did not create a staging entry inside the validated directory %s (got %s).\n" "$d" "${t:-<empty>}" >&2
+         exit 1 ;;
+    esac
+    if [ -L "$t" ] || [ ! -f "$t" ]; then
+      printf "perf-capability: REFUSING: the staging entry %s is not a fresh regular file.\n" "$t" >&2
+      rm -f -- "$t"; exit 1
+    fi
+    # `mv -T` (--no-target-directory) is REQUIRED, not cosmetic: without it a symlink-to-DIRECTORY
+    # planted at the managed name makes `mv` move the staging file INTO that directory, i.e. the
+    # rename that exists to avoid following a symlink follows one instead. With -T the destination
+    # is always treated as a plain name to replace.
+    if ! tee -- "$t" >/dev/null || ! chmod 0644 -- "$t" || ! mv -fT -- "$t" "$p"; then
+      rm -f -- "$t"; exit 1
+    fi
+  ' perf-capability-install "$__pin_d" "$__pin_p" "$PERF_CAPABILITY_DROPIN_BASENAME" >/dev/null \
+    || return 1
   perf_capability_dropin_current
 }
 

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -1159,7 +1159,19 @@ perf_capability_main() {
     # (or `> <path>` from a root shell) re-opens the destination BY NAME and follows a symlink
     # planted there, reintroducing precisely the write this issue hardened. Hardening the installer
     # while printing an unsafe command is worse than not hardening it — it reads as safe.
-    --install)      shift; perf_capability_dropin_install "$@" ;;
+    # ENV-GUARDED, LIKE EVERY OTHER PRIVILEGED CALLER (roborev round 6, Medium — a defect this
+    # entry point INTRODUCED). bootstrap runs perf_capability_env_guard before it ever reaches the
+    # installer (bootstrap-agent-machine.sh:423); this CLI did not, so `--install sudo` in test mode
+    # could execute a REAL privileged tool and walk straight past the AC4 hermetic-executable
+    # checks — a new public surface re-opening the hole AC4 had just closed. The guard is what
+    # validates the prefix executable (it requires every reachable real sudo/sysctl to be
+    # PATH-shimmed inside an absolute CQLITE_PERF_TEST_PRIV_DIR), so calling it here IS the prefix
+    # validation, not a second mechanism. Fails closed; outside test mode it is a no-op unless a
+    # seam is set, which is exactly the production behaviour.
+    --install)
+      shift
+      perf_capability_env_guard || return 1
+      perf_capability_dropin_install "$@" ;;
     # rc PROPAGATED, never masked by the trailing newline: an unsandboxed test mode can
     # resolve no path at all (R4-3), and that is a failure, not an empty success.
     --drop-in-path) perf_capability_dropin_path || return 1; printf '\n' ;;

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -507,8 +507,21 @@ perf_capability_dropin_path() {
 #   Deliberately conservative: a group-writable directory is refused even when the sticky bit would
 #   stop others from replacing our entry. Sticky-plus-group-writable is arguably safe here, and that
 #   is exactly the kind of "arguably safe" that has already cost this function three review rounds.
-#   `mv -fT` and `stat -c` want GNU coreutils. Satisfied by construction rather than by luck: these
-#   are Linux kernel controls and bootstrap skips this whole section on any non-Linux platform.
+#   GNU-COREUTILS DEPENDENCY, STATED EXACTLY (verified for #3261, not assumed — the earlier wording
+#   here overclaimed). `mv -fT` (`--no-target-directory`) and `stat -c` are GNU-only: macOS `mv` has
+#   no `-T` and its `stat` spells the format `-f`. For the PRODUCTION path that is genuinely gated:
+#   bootstrap-agent-machine.sh:412 is `elif [ "$PLATFORM" != linux ]; then`, whose branch only
+#   reports "nothing to configure" — the `else` that sources this file and enables the section is
+#   reachable only when PLATFORM=linux (set at :85 from `uname`), and PERF_SECTION_OK is initialised
+#   to 0 at :405 so no ambient export can steer it. So bootstrap never reaches this function off
+#   Linux.
+#   WHAT IS *NOT* GATED, said plainly: scripts/tests/test_perf_capability.sh calls this function
+#   DIRECTLY, bypassing bootstrap and its platform check, so on a macOS gate host those cases would
+#   run `mv -fT`/`stat -c` and fail. Neither portability guard in the repo scans this file
+#   (test_roborev_guard_portability.sh scans the roborev guard set; test_agent_gate_tree_portability.sh
+#   lints the tree-integrity functions), so NOTHING mechanically protects this. That is a known,
+#   unmitigated gap in the TEST path — not a production exposure — and it is recorded rather than
+#   papered over.
 #   The non-shell descriptor-holding helper stays DEFERRED (an owner call — it would add an
 #   interpreter dependency to the privileged bootstrap path), and with the precondition in place it
 #   is probably unnecessary rather than merely postponed.

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -26,20 +26,7 @@
 #                               optional, test mode only
 #   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
 #
-# POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds each
-# closed ONE MORE SPELLING of "the production directory": the raw path (B3), a symlinked seam,
-# `..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes implementation-defined,
-# `pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A denylist over path spellings
-# cannot be completed — `.`, `..`, symlinks, `//`, trailing slashes, bind mounts,
-# `/proc/self/root/…` all name the same directory — and scattered prohibitions also let a NEW
-# entry point silently miss them (R6-2). So the rule is INVERTED and there is exactly ONE: a
-# seam is usable IFF it is strictly contained in the declared sandbox root. Every spelling of
-# "somewhere else", including every future one, fails that single check for the same reason.
-# TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams are
-# MANDATORY. The earlier shape — marker set, seam unset, fall back to the real directory —
-# meant test mode could pass the env guard (sudo/sysctl absent, or present as declared shims)
-# and a subsequent root `--yes` run would `tee` the REAL /etc/sysctl.d, mutating the host from
-# a test run. "Hermetic" cannot be a claim that depends on a variable being set.
+# (full rationale: fleet-runbook.md, perf seam containment, b27)
 
 # FAIL-OPEN AUDIT — every path that can reach a POSITIVE verdict, and what validates it
 # (review round 4; four findings in this file were one defect class: "identity/state unknown
@@ -91,19 +78,7 @@ PERF_CAPABILITY_DROPIN_BASENAME='99-cqlite-perf.conf'
 perf_capability_test_mode() { [ "${CQLITE_PERF_TEST_MODE:-}" = 1 ]; }
 
 # perf_capability_seam_set: rc 0 iff ANY test-only seam is non-empty. The ONE
-# seam reader outside the containment gate below, and deliberately so: it asks only
-# "was a seam handed to us at all" (for the marker-less refusal) and never uses the
-# VALUE as a path. The structural audit in test_perf_capability.sh allowlists it by
-# name, so a future function cannot join it silently.
-#
-# EVERY non-marker seam MUST be listed here (roborev round 32, Medium). This named only PROC_DIR
-# and SYSCTL_DIR while the file had grown three more, so any of those exported WITHOUT the marker
-# passed the guard — the marker-less refusal failing OPEN, which is the same incomplete-list-of-
-# names shape this whole file exists to avoid. The round-6 audit that was supposed to protect this
-# policed WHICH FUNCTIONS may read a seam, never WHICH SEAMS this list must name, so it was blind
-# to an omission by construction. The completeness direction is now enforced by CENSUS in
-# test_perf_capability.sh (1c-iv): every CQLITE_PERF_* name the library reads, minus the marker
-# itself, must appear below — so adding a seam without listing it here FAILS the suite.
+# (full rationale: fleet-runbook.md, perf seam containment, perf-capability-seam-set-rc-0-iff-any-test-onl)
 perf_capability_seam_set() {
   [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ] \
     || [ -n "${CQLITE_PERF_TEST_SANDBOX:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_EXTRA_DIRS:-}" ] \
@@ -359,12 +334,22 @@ perf_capability_priv_tool_ok() {
 perf_capability_proc_dir_into() {
   eval "$1="
   if perf_capability_test_mode; then
-    perf_capability_sandbox_ok "${CQLITE_PERF_PROC_DIR:-}" || {
+    # NORMALISE BEFORE THE GATE, exactly as the sandbox root does (roborev round 33, Low). Stripping
+    # after the containment check left the two halves inconsistent: the ROOT accepted a "//" trailing
+    # spelling while PROC_DIR refused the identical one, because the gate saw the raw value. Callers
+    # join with "/$name", so an unnormalised trailing slash also built a "//" entry path that the
+    # entry-level check then refused -- surfacing as the capability verdict "absent" rather than as a
+    # refusal, i.e. a mere spelling became a definite negative claim about the host, in the one
+    # function the gate's perf= token comes from. INTERIOR "//" stays refused: only trailing
+    # separators are normalised, and a non-canonical spelling is still not a destination.
+    local __ppd_v="${CQLITE_PERF_PROC_DIR:-}"
+    while [ "${__ppd_v%/}" != "$__ppd_v" ] && [ "${#__ppd_v}" -gt 1 ]; do __ppd_v="${__ppd_v%/}"; done
+    perf_capability_sandbox_ok "$__ppd_v" || {
       printf 'perf-capability: REFUSING to read /proc: CQLITE_PERF_TEST_MODE=1 with CQLITE_PERF_PROC_DIR (%s) not INSIDE the declared sandbox %s — test mode never falls back to %s.\n' \
         "'${CQLITE_PERF_PROC_DIR:-<unset>}'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
       return 1
     }
-    eval "$1=\$CQLITE_PERF_PROC_DIR"
+    eval "$1=\$__ppd_v"
     return 0
   fi
   eval "$1=\$PERF_CAPABILITY_PROC_DIR_DEFAULT"

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -547,6 +547,16 @@ perf_capability_dropin_path() {
 perf_capability_dropin_install() {
   local __pin_d __pin_p
   __pin_d=$(perf_capability_sysctl_dir) || return 1
+  # TRAILING SLASHES ARE STRIPPED BEFORE ANY CHECK OR PATH CONSTRUCTION (roborev round 10, Low).
+  # `[ -L "$d" ]` FOLLOWS a trailing slash: for a symlinked directory `link`, `[ -L link ]` is true
+  # but `[ -L link/ ]` and `[ -L link// ]` are FALSE, so the destination-symlink refusal this
+  # function explicitly promises could be walked past with one extra character. Stripping is the
+  # right shape here and NOT another spelling denylist: normalising the input to ONE canonical form
+  # makes the affirmative check total, whereas enumerating bad spellings is the unbounded game this
+  # family lost eleven times. The length guard keeps `/` itself from becoming the empty string —
+  # a root destination then fails the ownership/writability precondition on its own merits rather
+  # than by accident.
+  while [ "${__pin_d%/}" != "$__pin_d" ] && [ "${#__pin_d}" -gt 1 ]; do __pin_d="${__pin_d%/}"; done
   __pin_p="$__pin_d/$PERF_CAPABILITY_DROPIN_BASENAME"
   # CONTENT IS GENERATED AND CHECKED **BEFORE** ANY PRIVILEGED COMMAND RUNS (roborev round 9,
   # Medium). This used to pipe the generator straight into the privileged shell, so the pipeline's
@@ -565,6 +575,10 @@ perf_capability_dropin_install() {
   printf '%s' "$__pin_c" | "$@" sh -c '
     set -u
     d=$1; p=$2; b=$3
+    # Normalised again INSIDE the privileged shell, deliberately: the outer caller strips trailing
+    # slashes, but this block is the thing holding privilege and must not depend on someone else
+    # having done it. Same reason the mktemp answer is re-checked here rather than trusted.
+    while [ "${d%/}" != "$d" ] && [ "${#d}" -gt 1 ]; do d="${d%/}"; done
     # THE PRECONDITION (roborev round 3): nobody less privileged than this shell may be able to
     # create or replace entries in $d. Without that there is an actor to race; with it there is not.
     #   WHY THIS IS NOT A TWELFTH ATTEMPT TO OUT-TIME THE RACE (owner ruling A-prime): escapes 9-11

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -503,8 +503,23 @@ perf_capability_dropin_path() {
 #   NOT gated: scripts/tests/test_perf_capability.sh calls this DIRECTLY, so its staged-install cases
 #   are capability-probed and COUNTED-skipped off GNU (roborev round 5). Neither portability guard in
 #   the repo scans this file, so nothing mechanically protects the gate; recorded, not papered over.
+# perf_capability_install_tools_ok: does THIS host have the GNU coreutils behaviour the staged
+# install needs (roborev round 16, Medium)? `stat -c` and `mv --no-target-directory` are GNU-only, and
+# bootstrap gates the perf section on PLATFORM=linux — which is NOT the same as GNU. A musl/busybox
+# Linux host would previously reach the installer and fail on a raw tool error. Probed AFFIRMATIVELY
+# (run the flags) rather than inferred from a distro name.
+perf_capability_install_tools_ok() {
+  stat -c '%a' . >/dev/null 2>&1 || return 1
+  mv --help 2>&1 | grep -q -- '--no-target-directory' || return 1
+}
+
 perf_capability_dropin_install() {
   local __pin_d __pin_p
+  # rc 2 is UNSUPPORTED-HOST, distinct from rc 1 REFUSED, so a caller can report "this host
+  # cannot do an atomic install" instead of implying the attempt was unsafe.
+  perf_capability_install_tools_ok || {
+    printf 'perf-capability: UNSUPPORTED on this host: the atomic staged install needs GNU coreutils (stat -c and mv --no-target-directory); neither is present, so the drop-in cannot be installed safely. Install GNU coreutils or set the sysctls another way.\n' >&2
+    return 2; }
   __pin_d=$(perf_capability_sysctl_dir) || return 1
   # TRAILING SLASHES ARE STRIPPED BEFORE ANY CHECK OR PATH CONSTRUCTION (roborev round 10, Low).
   # `[ -L "$d" ]` FOLLOWS a trailing slash: for a symlinked directory `link`, `[ -L link ]` is true

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -3,38 +3,7 @@
 # perf-capability.sh — the ONE place that knows how a CQLite box is made
 # profileable, and how that is VERIFIED (issue #3249).
 #
-# WHY THIS FILE EXISTS. Agent/worker images ship `kernel.perf_event_paranoid = 4` and set
-# it NOWHERE in /etc/sysctl.conf or /etc/sysctl.d — so every profiling run starts from a
-# hard EACCES whose help text ("access limited") reads like a CAPABILITY verdict when it is
-# a PERMISSION verdict. That has already cost two measurement cycles. The same three-line
-# incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is git-pinned,
-# and is asserted by the gate's tooling-tests.
-#
-# WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE restrictive and
-# each level keeps the ones below it: `>= 3` (an extra Debian/Ubuntu level) denies ALL
-# unprivileged perf use, which is why the images' `4` kills even a plain `perf stat`;
-# `>= 2` no kernel profiling; `>= 1` no CPU-WIDE access, which is exactly what
-# `perf stat -C <cpu>` needs; `>= 0` no raw tracepoints; `-1` (almost) everything, and the
-# perf mlock limit lifted too. CQLite's doctrine mandates per-CPU collection, so `1` is
-# not "almost right", it is a hard denial. `kernel.kptr_restrict = 0` is a SEPARATE control
-# for kernel SYMBOL resolution — without it kernel frames are unresolved addresses, a
-# SILENT attribution loss rather than an error. Same rationale in the drop-in's own bytes.
-#
-# SECURITY POSTURE. A deliberate loosening, appropriate for DEDICATED SINGLE-TENANT
-# measurement/agent boxes. Never apply it to a shared or multi-tenant host. See
-# docs/development/fleet-runbook.md. BPF IS A DIFFERENT PERMISSION: a permissive
-# perf_event_paranoid does NOT grant BPF map creation — bpftrace/bcc collectors still need
-# sudo (#3217 finding).
-#
-# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call the
-# functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO side
-# effects: this file only defines `perf_capability_*` functions plus the four
-# `PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
-# outside those namespaces are touched). Every function is `set -u` safe.
-#
-# Usage when executed: `bash scripts/perf-capability.sh --help` (the modes are listed by
-# perf_capability_usage below, so they are not duplicated here).
-#
+# (full rationale: fleet-runbook.md, perf seam containment, b4)
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
 # The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
 # bootstrap installs the drop-in through the STAGED installer below (mktemp + atomic rename, no
@@ -439,49 +408,7 @@ perf_capability_dropin_path() {
 }
 
 # perf_capability_dropin_install [<priv-cmd>...]: write the managed drop-in as an ATOMIC
-# DIRECTORY-ENTRY REPLACEMENT, so a pre-existing symlink at the managed name is REPLACED, never
-# FOLLOWED (issue #3261 AC1). argv is the privilege prefix (empty when already root); rc 0 iff the
-# managed bytes are in place at the managed path afterwards, verified by re-reading the file.
-#
-# Content goes to a fresh staging entry in the ALREADY-VALIDATED directory, then `mv -fT` —
-# rename(2), which replaces the NAME and never dereferences the destination. Same directory, so the
-# rename is same-filesystem and atomic.
-#
-# WHAT MAKES THIS SAFE IS THE PRECONDITION, NOT THE STAGING MECHANICS. Three successive fixes here
-# were each defended with a claim that proved FALSE, so the reasoning is recorded rather than the
-# conclusion alone (full history: #3261, roborev rounds 1-3):
-#   * a FIXED staging name, checked-then-opened, claimed safe because the race "cannot happen". It
-#     could: anyone able to create entries in the directory could re-plant that known name as a
-#     symlink between the check and the privileged open.
-#   * `mktemp` (O_CREAT|O_EXCL, 6 random chars, created under the SAME privilege that writes) closed
-#     the CREATE race — but mktemp returns a NAME and each later step REOPENS it, so the window moved
-#     rather than closing. A pid suffix would not have helped either; a pid is predictable.
-#   * grouping every step into ONE privileged `sh -c` was then defended with a claim THIS COMMENT
-#     ITSELF MADE AND WHICH IS FALSE: that no unprivileged process is scheduled between the steps.
-#     `sh -c` gives SEQUENCING WITHIN ONE PROCESS, never MUTUAL EXCLUSION against other processes,
-#     which run concurrently on other CPUs regardless of how we group our own commands. Consolidation
-#     is kept — it removes needless windows — but it is NOT what makes this safe.
-#   * what closes the class: REMOVE THE ATTACKER'S PRECONDITION. Every step of the race needs the
-#     ability to create or replace entries in the target directory, so the install REFUSES a target
-#     directory that anyone less privileged than the writer can write — it must be owned by the
-#     identity performing the privileged write and be neither group- nor world-writable. There is
-#     then no actor to race against, whatever the timing.
-# The ownership/mode test runs INSIDE the privileged shell against `id -u` of that shell, so it tests
-# the identity that will actually write (root in production, the shim under test mode) rather than
-# whoever invoked us. Undeterminable ownership or mode is a REFUSAL, not an assumption. Deliberately
-# conservative: group-writable is refused even with the sticky bit, because "arguably safe" is what
-# already cost this function three review rounds.
-#   `chmod 0644` after the write is load-bearing: `mktemp` creates 0600, and the idempotency compare
-#   runs from an UNPRIVILEGED bootstrap process that could not read a root-owned 0600 file — every
-#   later run would see "not current" and rewrite. The old `tee` got 0644 from root's umask.
-#   The staging name begins with `.` and does not end in `.conf`, so the competing-file scan (which
-#   globs `*.conf`) can never mistake it for a rival drop-in.
-#   GNU-COREUTILS DEPENDENCY, STATED EXACTLY: `mv -fT` and `stat -c` are GNU-only. The PRODUCTION
-#   path is genuinely gated — bootstrap reaches this function only when PLATFORM=linux (set at :85,
-#   branch at :412, PERF_SECTION_OK initialised to 0 at :405 so no ambient export can steer it).
-#   NOT gated: scripts/tests/test_perf_capability.sh calls this DIRECTLY, so its staged-install cases
-#   are capability-probed and COUNTED-skipped off GNU (roborev round 5). Neither portability guard in
-#   the repo scans this file, so nothing mechanically protects the gate; recorded, not papered over.
+# (full rationale: fleet-runbook.md, perf seam containment, perf-capability-dropin-install-priv-cmd-write)
 perf_capability_dropin_install() {
   local __pin_d __pin_p __pin_rc
   __pin_d=$(perf_capability_sysctl_dir) || return 1

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -541,6 +541,17 @@ perf_capability_dropin_install() {
     #   no window. It removes the ATTACKER PRECONDITION, turning "production is safe because
     #   /etc/sysctl.d is root-owned" from a recorded ASSUMPTION into an ENFORCED INVARIANT: assume
     #   nothing about the destination, measure it, fail closed.
+    #   KNOWN, TRACKED, DELIBERATELY-UNFIXED RESIDUAL — **issue #3323** (ancestor-chain rename race,
+    #   the TWELFTH escape in this family). This precondition validates the target DIRECTORY; it does
+    #   NOT prove the PATH BY WHICH that directory is reached is stable. An actor able to write an
+    #   ANCESTOR can rename the validated directory and substitute a symlink after these checks, and
+    #   the later `mktemp`/write/rename re-resolve `$d`. The correct fix is a held directory
+    #   descriptor with no-follow fd-relative operations (`openat2` containment) — NOT expressible in
+    #   shell, which is why twelve in-shell attempts at this class stopped here by owner ruling
+    #   rather than a thirteenth. #3323 records that fix and re-raises on EVIDENCE the boundary is
+    #   reachable (multi-tenant boxes, an attacker-writable ancestor, or a real privileged helper
+    #   reachable from test mode). Production ancestors are `/etc` and `/`, both root-owned; test
+    #   mode reaches only AC4 shims. Do NOT widen this function's trust without reading #3323 first.
     #   THE REMAINING BOUNDARY, STATED: this check races only against an actor who can `chmod` a
     #   directory owned by the privileged writer — and that actor is already the privileged writer
     #   (or root), so it has no privilege left to escalate to. That is the whole of the residual;

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -848,6 +848,26 @@ perf_capability_competing_files() {
     [ -e "$entry" ] || continue
     [ -d "$entry" ] && [ -r "$entry" ] || return 1
     for f in "$entry"/*.conf; do
+      # EVERY GLOBBED FILE IS VALIDATED IN TEST MODE, NOT JUST ITS DIRECTORY (roborev round 11,
+      # Medium). The scan validated the containing DIRECTORY and then trusted whatever the glob
+      # produced inside it — but `[ -f ]` and `grep` both FOLLOW symlinks, so a link sitting inside a
+      # perfectly contained sandbox directory and pointing at a real host `*.conf` was read, and its
+      # contents fabricated "a competitor sets these keys" diagnostics out of HOST state. That is a
+      # hermeticity escape in the DIAGNOSTIC path: the numbers a test asserts on would come from the
+      # box rather than the fixture. Same lesson as the write path, one surface over — a contained
+      # directory says nothing about where its ENTRIES point.
+      # `perf_capability_sandbox_file_ok_resolved` is the AC3 predicate, reused rather than
+      # reimplemented: it refuses a symlink outright and requires the canonical parent-plus-basename
+      # to be strictly inside the declared sandbox. FAILS THE SCAN CLOSED, because a competitor we
+      # declined to examine is exactly the UNKNOWN this diagnostic exists to report rather than hide.
+      # Production is untouched: without CQLITE_PERF_TEST_MODE there is no sandbox and the real
+      # /etc/sysctl.d files are the legitimate subject.
+      if perf_capability_test_mode && [ -e "$f" ] \
+         && ! perf_capability_sandbox_file_ok_resolved "$f"; then
+        printf 'perf-capability: REFUSING to scan %s — CQLITE_PERF_TEST_MODE=1 and it does not resolve to a real file strictly inside the declared sandbox (a symlink, or a path leading outside it), so scanning it would fabricate diagnostics from HOST state.\n' \
+          "'$f'" >&2
+        return 1
+      fi
       # AN UNMATCHED GLOB IS NOT AN UNREADABLE FILE (issue #3249 review R8-4). With no
       # match bash leaves the PATTERN itself in $f (nullglob is not set) and it does not
       # exist — that directory genuinely holds no competitor, skip it. But a file that

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -176,10 +176,39 @@ perf_capability_path_within() {
   return 1
 }
 
+# perf_capability_nosymlink: rc 0 iff <path> is absolute and NO path component — the final one
+# INCLUDED — is a symlink. FORK-FREE: `[ -L ]` is a shell builtin test, so this is usable on the
+# gate's contractually fork-free token path, where `cd -P`/`pwd -P` (a subshell, i.e. a process)
+# is not.
+#
+# WHY (issue #3261 AC2). Containment of a SPELLING is not containment of a DESTINATION. The
+# inversion to positive containment made the fork-free read check purely textual and thereby
+# REGRESSED a protection the denylist rounds had: a symlink INSIDE the proven sandbox pointing at
+# the real /proc/sys/kernel satisfies path_within, so the run reported a capability token derived
+# from the HOST's real controls while claiming to have read a stand-in. A FABRICATED verdict is
+# strictly worse than a refusal — measured before the fix, the suite's stand-in seam produced
+# `paranoid-4` straight out of the live /proc. Rejecting per component (rather than resolving)
+# is what keeps the token path fork-free while judging the destination.
+perf_capability_nosymlink() {
+  local __pns_rest="${1:-}" __pns_acc='' __pns_seg
+  case "$__pns_rest" in /*) ;; *) return 1 ;; esac
+  __pns_rest="${__pns_rest#/}"
+  while [ -n "$__pns_rest" ]; do
+    __pns_seg="${__pns_rest%%/*}"
+    if [ "$__pns_seg" = "$__pns_rest" ]; then __pns_rest=''; else __pns_rest="${__pns_rest#*/}"; fi
+    [ -n "$__pns_seg" ] || continue
+    __pns_acc="$__pns_acc/$__pns_seg"
+    if [ -L "$__pns_acc" ]; then return 1; fi
+  done
+  [ -n "$__pns_acc" ]
+}
+
 perf_capability_sandbox_ok() {
   local __pso_root=''
   perf_capability_sandbox_root_into __pso_root || return 1
-  perf_capability_path_within "${1:-}" "$__pso_root"
+  perf_capability_path_within "${1:-}" "$__pso_root" || return 1
+  # ...and no component may be a symlink out of it (#3261 AC2), by builtins alone.
+  perf_capability_nosymlink "$1"
 }
 
 perf_capability_sandbox_ok_resolved() {
@@ -191,12 +220,23 @@ perf_capability_sandbox_ok_resolved() {
   perf_capability_path_within "$__pdr_real" "${__pdr_root%/}"
 }
 
+# The FILE variant. Judged as <CANONICAL PARENT>/<basename> (issue #3261 AC3): canonicalizing the
+# parent and asking whether THE PARENT is contained refused `<sandbox-root>/sysctl.conf`, because
+# the parent there IS the root and a root is not STRICTLY inside itself — a legitimate,
+# strictly-contained file rejected, which is how a guard teaches people to route around it. The
+# assembled path is the thing being authorized, so it is the thing judged.
+# The final component may not be a SYMLINK (the AC1 lesson, here on a read whose CONTENTS are
+# consumed): a symlinked `sysctl.conf` inside the sandbox would feed the competing-file scan the
+# host's real configuration.
 perf_capability_sandbox_file_ok_resolved() {
   case "${1:-}" in */?*) ;; *) return 1 ;; esac
-  case "${1##*/}" in ''|.|..) return 1 ;; esac
-  # the FILE path is judged by canonicalizing its PARENT: a canonical parent strictly inside
-  # the sandbox puts <parent>/<basename> strictly inside it too, for any plain basename.
-  perf_capability_sandbox_ok_resolved "${1%/*}"
+  local __pfr_base="${1##*/}" __pfr_root='' __pfr_parent=''
+  case "$__pfr_base" in ''|.|..) return 1 ;; esac
+  if [ -L "$1" ]; then return 1; fi
+  perf_capability_sandbox_root_into __pfr_root || return 1
+  __pfr_root=$(cd -P -- "$__pfr_root" 2>/dev/null && pwd -P) || return 1
+  __pfr_parent=$(cd -P -- "${1%/*}" 2>/dev/null && pwd -P) || return 1
+  perf_capability_path_within "${__pfr_parent%/}/$__pfr_base" "${__pfr_root%/}"
 }
 
 # ONE message shape for both mandatory seams: the refusal must NAME the offending seam (that
@@ -259,8 +299,39 @@ perf_capability_env_guard() {
         "$tool" "$resolved" "$dir" >&2
       return 1
     }
+    perf_capability_priv_tool_ok "$resolved" "$tool" || return 1
   done
+  # ...and every privileged tool PARKED in the declared shim dir, whether or not PATH happens to
+  # reach it: one PATH-order change is all that separates "not resolved" from "executed", and the
+  # loop above is driven by PATH. Only `sudo`/`sysctl` are swept — a shim dir legitimately holds
+  # `ln -s`ed real coreutils (cat, mv, uname), which grant no privilege.
+  if [ -n "$dir" ] && [ -d "$dir" ]; then
+    for tool in sudo sysctl; do
+      [ -e "$dir/$tool" ] || [ -L "$dir/$tool" ] || continue
+      perf_capability_priv_tool_ok "$dir/$tool" "$tool" || return 1
+    done
+  fi
   return 0
+}
+
+# perf_capability_priv_tool_ok <resolved-path> <tool-name>: rc 0 iff this privileged executable's
+# RESOLVED destination is positively contained beneath the PROVEN sandbox root. Refuses loudly.
+#
+# WHY (issue #3261 AC4 — the EIGHTH escape from this guard family, and the first about an
+# executable rather than a path). The shim dir was trusted TEXTUALLY: `/usr` is absolute and
+# genuinely CONTAINS `/usr/bin/sudo`, so "inside the declared shim dir" passed; and a SYMLINK to
+# the real `sudo`/`sysctl` placed inside a genuine shim dir is spelled locally while resolving to
+# the host's binary. Either one let a privileged test-mode bootstrap run a real
+# `sysctl --system` and reconfigure the host kernel — the exact mutation the marker promises
+# cannot happen. Same discipline as the paths: the declared NAME is not the DESTINATION, so the
+# destination is what is judged, positively, against a root that had to prove itself. The FILE
+# form does the work (canonical parent + basename, and a symlinked final component is refused),
+# which is also why a `/usr` shim dir fails: /usr/bin is not inside the sandbox.
+perf_capability_priv_tool_ok() {
+  perf_capability_sandbox_file_ok_resolved "${1:-}" && return 0
+  printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but the privileged tool %s at %s does not RESOLVE to an executable strictly inside the declared sandbox %s (a symlink to the real tool, or a shim dir that is not itself in the sandbox, resolves OUT of it) — test mode may never invoke a real privileged tool.\n' \
+    "${2:-<tool>}" "'${1:-}'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" >&2
+  return 1
 }
 
 # ---- resolved locations (the seams apply ONLY in test mode) -------------------
@@ -313,14 +384,65 @@ perf_capability_sysctl_dir() {
   fi
   printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
-# perf_capability_dropin_path: the path a root `tee` is pointed at. Its gate lives in
-# perf_capability_sysctl_dir (the single source of that directory) and RESOLVES the
-# destination, so there is deliberately no second copy here — one gate, not a prohibition a
-# future entry point could skip (R6-2).
+# perf_capability_dropin_path: the path a root `tee` is pointed at. The DIRECTORY's gate lives in
+# perf_capability_sysctl_dir (the single source of that directory) and RESOLVES the destination,
+# so there is deliberately no second copy of it here — one gate, not a prohibition a future entry
+# point could skip (R6-2).
+#
+# BUT DIRECTORY CONTAINMENT IS NOT WRITE-TARGET CONTAINMENT (issue #3261 AC1). A contained
+# directory says nothing about where its ENTRIES point, and `tee <path>` opens
+# O_WRONLY|O_CREAT|O_TRUNC and FOLLOWS a symlink — so a symlink at the managed basename inside a
+# perfectly-contained directory aimed the privileged write at the LINK'S TARGET, anywhere on the
+# box. The write TARGET is therefore validated too, as an O_NOFOLLOW-equivalent refusal: a
+# symlink at the managed name is rc 1 + empty + a named reason, for every consumer at once
+# (this function is the single source of the path). The complementary half is
+# perf_capability_dropin_install, which REPLACES the directory entry instead of writing through
+# it, closing the window between this check and the write.
 perf_capability_dropin_path() {
-  local __pdi_d
+  local __pdi_d __pdi_p
   __pdi_d=$(perf_capability_sysctl_dir) || return 1
-  printf '%s/%s' "$__pdi_d" "$PERF_CAPABILITY_DROPIN_BASENAME"
+  __pdi_p="$__pdi_d/$PERF_CAPABILITY_DROPIN_BASENAME"
+  if [ -L "$__pdi_p" ]; then
+    printf 'perf-capability: REFUSING: the managed drop-in name %s is a SYMLINK. A privileged `tee` FOLLOWS it and would overwrite the link target instead of the managed file — a contained directory does not license writing through its entries. Remove the symlink (or let the atomic installer replace the entry).\n' \
+      "'$__pdi_p'" >&2
+    return 1
+  fi
+  printf '%s' "$__pdi_p"
+}
+
+# perf_capability_dropin_install [<priv-cmd>...]: write the managed drop-in as an ATOMIC
+# DIRECTORY-ENTRY REPLACEMENT, so a pre-existing symlink at the managed name is REPLACED, never
+# FOLLOWED (issue #3261 AC1). argv is the privilege prefix (empty when already root); rc 0 iff the
+# managed bytes are in place at the managed path afterwards, verified by re-reading the file.
+#
+# Content goes to a fresh temp entry in the ALREADY-VALIDATED directory, then `mv -f` — rename(2),
+# which replaces the NAME and never dereferences the destination. The check in
+# perf_capability_dropin_path above has a TOCTOU window; a rename has none, which is why both
+# exist rather than either alone. Same directory, so the rename is same-filesystem and atomic. The
+# temp name is derived from the managed basename, never from a caller-supplied string, and an
+# entry already occupying it is removed and its removal VERIFIED before anything is written —
+# otherwise `tee` would follow a symlink planted at the temp name instead.
+perf_capability_dropin_install() {
+  local __pin_d __pin_p __pin_t
+  __pin_d=$(perf_capability_sysctl_dir) || return 1
+  __pin_p="$__pin_d/$PERF_CAPABILITY_DROPIN_BASENAME"
+  __pin_t="$__pin_d/.$PERF_CAPABILITY_DROPIN_BASENAME.new"
+  if [ -e "$__pin_t" ] || [ -L "$__pin_t" ]; then
+    "$@" rm -f -- "$__pin_t" >/dev/null 2>&1
+    if [ -e "$__pin_t" ] || [ -L "$__pin_t" ]; then
+      printf 'perf-capability: REFUSING: could not clear the staging entry %s, so a write there could follow it.\n' "'$__pin_t'" >&2
+      return 1
+    fi
+  fi
+  if ! perf_capability_dropin_content | "$@" tee -- "$__pin_t" >/dev/null 2>&1; then
+    "$@" rm -f -- "$__pin_t" >/dev/null 2>&1
+    return 1
+  fi
+  if ! "$@" mv -f -- "$__pin_t" "$__pin_p" >/dev/null 2>&1; then
+    "$@" rm -f -- "$__pin_t" >/dev/null 2>&1
+    return 1
+  fi
+  perf_capability_dropin_current
 }
 
 # perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a WHOLE

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -489,6 +489,7 @@ perf_capability_dropin_install() {
     while [ "${d%/}" != "$d" ] && [ "${#d}" -gt 1 ]; do d="${d%/}"; done
     # TOOL COMPATIBILITY IS EXERCISED HERE, IN THE PRIVILEGED SHELL (roborev round 17, Medium — a
     # (rationale relocated: docs/development/fleet-runbook.md, "perf seam containment — why", tool-compatibility-is-exercised-here-in-the-priv.)
+    # `/` NOT "$d": statting the destination conflated "no GNU stat" with "destination missing" (r23).
     stat -c '%a' -- / >/dev/null 2>&1 || {
       printf "perf-capability: UNSUPPORTED on this host: stat -c is unavailable (GNU coreutils required), so ownership and mode cannot be established before a privileged write.\n" >&2
       exit 2; }

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -841,6 +841,11 @@ perf_capability_proc_read() {
   # token path keeps its contract; in test mode containment is required too.
   # NOTE: no backticks in this function comment on purpose -- the fork-free emit-path audit in
   # test_agent_gate_summary.sh counts them WITHOUT stripping comments, so prose alone can red it.
+  # RESIDUAL -- #3323 entry 4: these checks are CHECK-THEN-OPEN. A concurrent writer can replace the
+  # validated entry, or an ancestor, between the check and the redirection below, so the read can still
+  # land outside the sandbox; the competing-file scan shares the shape. Deliberately unfixed: the fix is
+  # fd-relative no-follow/beneath opens (openat2), not expressible in shell, and this escape class is
+  # CLOSED by owner ruling -- recorded, not re-attempted. Test-mode only. Read #3323 first.
   perf_capability_nosymlink "$__pcr_dir/$2" || return 1
   if perf_capability_test_mode; then
     perf_capability_sandbox_ok "$__pcr_dir/$2" || return 1

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -37,7 +37,8 @@
 #
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
 # The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
-# bootstrap pipes the drop-in through `sudo tee <path>`: were that path env-derived, one stray
+# bootstrap installs the drop-in through the STAGED installer below (mktemp + atomic rename, no
+# `tee <path>`): were that path env-derived, one stray
 # export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d) would make ROOT write an
 # attacker/accident-chosen file while the real drop-in was never installed — and an unparsable
 # sudoers entry can wedge `sudo` outright. Likewise an env-chosen /proc stand-in would let a
@@ -547,9 +548,21 @@ perf_capability_dropin_install() {
   local __pin_d __pin_p
   __pin_d=$(perf_capability_sysctl_dir) || return 1
   __pin_p="$__pin_d/$PERF_CAPABILITY_DROPIN_BASENAME"
+  # CONTENT IS GENERATED AND CHECKED **BEFORE** ANY PRIVILEGED COMMAND RUNS (roborev round 9,
+  # Medium). This used to pipe the generator straight into the privileged shell, so the pipeline's
+  # status was the LAST command's and a failed generator was invisible unless the CALLER happened to
+  # have `pipefail` set — a correctness property no library function should delegate to its caller.
+  # Worse, the privileged write would already have started on empty or partial content. Generating
+  # first means a generator failure returns before privilege is acquired at all. Same sentinel trick
+  # as dropin_current, for the same reason: `$( )` strips trailing newlines, and the drop-in's final
+  # newline is part of the canonical bytes the idempotency compare comes back for.
+  local __pin_c
+  __pin_c=$(perf_capability_dropin_content; __pdc_rc=$?; printf 'X'; exit "$__pdc_rc") || return 1
+  __pin_c=${__pin_c%X}
+  [ -n "$__pin_c" ] || { printf 'perf-capability: REFUSING: the drop-in content generator produced nothing.\n' >&2; return 1; }
   # ONE privileged invocation for the WHOLE staged install. The content arrives on this shell's
   # stdin; `mktemp`, the write, `chmod` and the rename all run inside it.
-  perf_capability_dropin_content | "$@" sh -c '
+  printf '%s' "$__pin_c" | "$@" sh -c '
     set -u
     d=$1; p=$2; b=$3
     # THE PRECONDITION (roborev round 3): nobody less privileged than this shell may be able to
@@ -651,7 +664,9 @@ perf_capability_dropin_install() {
 # perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a WHOLE
 # managed file (not a delimited block inside a foreign one), so idempotency is a plain
 # byte-compare of the entire file — simpler and safer than editing someone else's config.
-# Callers may pipe this straight into `sudo tee`, which is also the remedy line bootstrap
+# Callers wanting to INSTALL must use perf_capability_dropin_install (staged, containment-checked,
+# atomic rename) — never `sudo tee <path>`, which opens the destination by name and follows a
+# symlink planted there. This function only PRINTS the canonical bytes, which is also what bootstrap
 # prints, so a hand-applied fix is byte-identical and the next bootstrap run is a no-op.
 perf_capability_dropin_content() {
   cat <<'EOF'
@@ -705,7 +720,14 @@ perf_capability_dropin_current() {
   local path want got=''
   path=$(perf_capability_dropin_path) || return 1
   [ -f "$path" ] && [ -r "$path" ] || return 1
-  want=$(perf_capability_dropin_content; printf 'X')
+  # THE SENTINEL MUST NOT SWALLOW THE GENERATOR'S STATUS (roborev round 9, Medium). `printf X`
+  # exists so a trailing newline survives command substitution, but it also RAN LAST, so the
+  # substitution reported ITS status and a failed content generator looked like success: `want`
+  # became bare "X", and against an empty file `${got}X` is also "X" — equal, so a broken
+  # generator reported the drop-in ALREADY CURRENT. A positive verdict from an unmeasured state,
+  # which is the exact shape this repo has a standing rule against. The rc is now captured
+  # BEFORE the sentinel and re-raised as the subshell's exit status, so both properties hold.
+  want=$(perf_capability_dropin_content; __pdc_rc=$?; printf 'X'; exit "$__pdc_rc") || return 1
   if IFS= read -r -d '' got <"$path"; then
     return 1
   fi
@@ -1166,13 +1188,6 @@ perf_capability_main() {
       [ "$unpriv" = 1 ] || rc=1
       return $rc ;;
     --drop-in)      perf_capability_dropin_content ;;
-    # The INSTALL entry point exists so the remedy a human is told to run is the SAME validated
-    # path bootstrap itself uses (roborev round 5, High): a printed `--drop-in | sudo tee <path>`
-    # (or `> <path>` from a root shell) re-opens the destination BY NAME and follows a symlink
-    # planted there, reintroducing precisely the write this issue hardened. Hardening the installer
-    # while printing an unsafe command is worse than not hardening it — it reads as safe.
-    # rc PROPAGATED, never masked by the trailing newline: an unsandboxed test mode can
-    # resolve no path at all (R4-3), and that is a failure, not an empty success.
     --drop-in-path) perf_capability_dropin_path || return 1; printf '\n' ;;
     -h|--help|'')   perf_capability_usage ;;
     *)              printf 'perf-capability: unknown arg: %s\n' "$1" >&2; perf_capability_usage >&2; return 2 ;;

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -833,6 +833,17 @@ perf_capability_proc_read() {
   local __pcr_out="$1" __pcr_dir="" __pcr_v=""
   eval "$__pcr_out="
   perf_capability_proc_dir_into __pcr_dir || return 1
+  # THE CONTROL FILE ITSELF IS CHECKED, NOT JUST ITS DIRECTORY (roborev round 25, Medium). The
+  # directory gate proved the DIRECTORY is contained and symlink-free; it said nothing about the
+  # ENTRY. A regular contained PROC_DIR could hold `perf_event_paranoid` as a symlink to the host
+  # file, so the token read attacker-chosen or real values and fabricated `perf=ok` — the same
+  # directory-is-not-its-entries lesson as the write path (AC1), one surface over. Fork-free, so the
+  # token path keeps its contract. In test mode containment is required too; in production the
+  # directory is the hardcoded literal, and a symlinked control file there is still refused.
+  perf_capability_nosymlink "$__pcr_dir/$2" || return 1
+  if perf_capability_test_mode; then
+    perf_capability_sandbox_ok "$__pcr_dir/$2" || return 1
+  fi
   [ -r "$__pcr_dir/$2" ] || return 1
   IFS= read -r __pcr_v <"$__pcr_dir/$2" 2>/dev/null
   __pcr_v="${__pcr_v#"${__pcr_v%%[![:space:]]*}"}"

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -566,7 +566,25 @@ perf_capability_dropin_install() {
     dinfo=$(stat -c "%u %a" -- "$d" 2>/dev/null) || {
       printf "perf-capability: REFUSING: cannot determine owner/mode of the drop-in directory %s, so it cannot be proven un-writable by less-privileged users.\n" "$d" >&2
       exit 1; }
-    downer=${dinfo%% *}; dmode=${dinfo##* }; dperm=${dmode#${dmode%???}}
+    downer=${dinfo%% *}; dmode=${dinfo##* }
+    # ZERO-PAD BEFORE TAKING THE LAST THREE DIGITS. `stat -c %a` drops leading zeros, so mode 0033
+    # arrives as "33" — and `${dmode%???}` cannot match a 2-character string, leaving `dperm` EMPTY,
+    # matching none of the write-bit patterns below, and PASSING a group- AND world-writable
+    # directory. That was a real bypass of this very precondition (roborev round 5, High), and it
+    # survived a hand audit that reasoned about the 3- and 4-digit cases and never considered a
+    # SHORTER one. The suffix-strip idiom is only safe once the string is known to be long enough,
+    # so the padding is not cosmetic: it is what makes the check below total.
+    case "$dmode" in
+      ?)   dperm="00$dmode" ;;
+      ??)  dperm="0$dmode" ;;
+      ???) dperm="$dmode" ;;
+      *)   dperm=${dmode#"${dmode%???}"} ;;
+    esac
+    case "$dperm" in
+      *[!0-7]*|"")
+        printf "perf-capability: REFUSING: the drop-in directory %s reported a mode (%s) that is not octal digits, so it cannot be proven un-writable by less-privileged users.\n" "$d" "$dmode" >&2
+        exit 1 ;;
+    esac
     if [ "$downer" != "$me" ]; then
       printf "perf-capability: REFUSING: the drop-in directory %s is owned by uid %s, not by the privileged writer uid %s — a directory someone else owns can have its entries replaced under a privileged write.\n" "$d" "$downer" "$me" >&2
       exit 1
@@ -1101,6 +1119,12 @@ perf_capability_usage() {
   printf '                  prints "<result> identity=<state>" — rc 0 only when the state is unprivileged\n'
   printf '  --drop-in       print the canonical /etc/sysctl.d/99-cqlite-perf.conf bytes\n'
   printf '  --drop-in-path  print where that file belongs\n'
+  printf '  --install [priv-cmd...]\n'
+  printf '                  INSTALL the drop-in through the validated staged path (containment checks,\n'
+  printf '                  mktemp + atomic rename). Prefix tokens are the privilege command, e.g.\n'
+  printf '                  `--install sudo`; with none it writes directly (use from a root shell).\n'
+  printf '                  Prefer this over `--drop-in | sudo tee <path>` or `> <path>`: those open the\n'
+  printf '                  destination BY NAME and follow a symlink planted there (issue #3261).\n'
 }
 
 perf_capability_main() {
@@ -1119,6 +1143,12 @@ perf_capability_main() {
       [ "$unpriv" = 1 ] || rc=1
       return $rc ;;
     --drop-in)      perf_capability_dropin_content ;;
+    # The INSTALL entry point exists so the remedy a human is told to run is the SAME validated
+    # path bootstrap itself uses (roborev round 5, High): a printed `--drop-in | sudo tee <path>`
+    # (or `> <path>` from a root shell) re-opens the destination BY NAME and follows a symlink
+    # planted there, reintroducing precisely the write this issue hardened. Hardening the installer
+    # while printing an unsafe command is worse than not hardening it — it reads as safe.
+    --install)      shift; perf_capability_dropin_install "$@" ;;
     # rc PROPAGATED, never masked by the trailing newline: an unsandboxed test mode can
     # resolve no path at all (R4-3), and that is a failure, not an empty success.
     --drop-in-path) perf_capability_dropin_path || return 1; printf '\n' ;;

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -588,13 +588,34 @@ perf_capability_dropin_install() {
     # probe name safe, so this does not need (and must not consume) mktemp. NOT consuming mktemp also
     # keeps it from pre-empting the staging entry checks below, which have their own cases.
     __x1="$d/.perfcap-probe.$$"; __x2="$__x1.b"
-    rm -f -- "$__x1" "$__x2"
-    if ! : >"$__x1" 2>/dev/null || ! mv -fT -- "$__x1" "$__x2" 2>/dev/null; then
-      rm -f -- "$__x1" "$__x2"
+    rm -f -- "$__x1" "$__x2" 2>/dev/null
+    # ABSENCE IS PROVEN, NOT ASSUMED (roborev round 21, High — a hazard THIS probe introduced). `rm`
+    # can fail (a read-only mount, an immutable entry) and its status was ignored; `: >` then FOLLOWS a
+    # symlink, so a leftover link at this predictable name could have truncated an arbitrary file under
+    # the privileged identity. The directory-mode precondition does not help: it proves nobody
+    # less-privileged can CREATE entries here, not that a pre-existing one was successfully removed.
+    if [ -e "$__x1" ] || [ -L "$__x1" ] || [ -e "$__x2" ] || [ -L "$__x2" ]; then
+      printf "perf-capability: REFUSING: probe entries under %s could not be cleared, so opening them could follow a leftover symlink under privilege.\n" "$d" >&2
+      exit 1
+    fi
+    # CREATION FAILURE IS ITS OWN OUTCOME, NOT "unsupported host" (roborev round 21, Low). These used to
+    # share one branch, so an unwritable directory was misreported as an incompatible `mv` — which made
+    # bootstrap suppress the retry remedy for a condition where retrying is exactly right. rc 1 REFUSED
+    # here; rc 2 UNSUPPORTED is reserved for an `mv` that genuinely lacks -T.
+    # SUBSHELL, and NOT the `:` builtin bare: `:` is a POSIX SPECIAL builtin, so a redirection failure
+    # on it makes a non-interactive shell EXIT — dash exits with status 2, which silently COLLIDED with
+    # the rc 2 UNSUPPORTED sentinel and reported a read-only directory as an incompatible `mv`. The
+    # subshell contains both the exit and the leaked shell diagnostic, so the caller sees rc 1 REFUSED.
+    if ! ( : >"$__x1" ) 2>/dev/null; then
+      printf "perf-capability: REFUSING: cannot create a probe entry in %s — the directory is not writable by the privileged writer.\n" "$d" >&2
+      exit 1
+    fi
+    if ! mv -fT -- "$__x1" "$__x2" 2>/dev/null; then
+      rm -f -- "$__x1" "$__x2" 2>/dev/null
       printf "perf-capability: UNSUPPORTED on this host: mv --no-target-directory (-T) does not work (GNU coreutils required), so the drop-in cannot be replaced atomically without risking a symlinked destination.\n" >&2
       exit 2
     fi
-    rm -f -- "$__x2"
+    rm -f -- "$__x2" 2>/dev/null
     t=$(mktemp -- "$d/.$b.XXXXXX") || exit 1
     # mktemp CREATED the entry, so mktemp is what must be checked, INSIDE this privileged shell and
     # fail-closed: it has to name a fresh regular file (never a symlink) directly in the directory

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -336,6 +336,24 @@ perf_capability_env_guard() {
     }
     perf_capability_priv_tool_ok "$resolved" "$tool" || return 1
   done
+  # KNOWN, TRACKED, DELIBERATELY-UNFIXED RESIDUAL — recorded in **#3323** (the THIRTEENTH escape in
+  # this family; the twelfth, the ancestor-chain rename race, is recorded at the install site).
+  # THE DEFECT, in the reviewer's words: this validation "validates the current sudo/sysctl entries,
+  # discards their resolved paths, and later callers resolve them again through PATH. A writable test
+  # shim directory can replace a validated file with a symlink to the host binary after the guard,
+  # allowing test mode to execute real privileged tools."
+  # THE NAMED FIX, also verbatim, so nobody has to re-derive it: "require the shim directory to be
+  # owned by the executing identity and not group/world-writable, and invoke the exact validated
+  # executable paths rather than resolving their names again."
+  # WHY IT IS NOT FIXED HERE: this is the same validate-a-NAME-then-re-resolve shape as the twelve
+  # before it, and by owner ruling this family is CLOSED — thirteen escapes established the class is
+  # unbounded in shell, and the two authorized in-shell fixes (A-prime, and the `--install` surface)
+  # each produced further defects of their own. A fourteenth attempt is not authorized.
+  # CONSEQUENCE, SCOPED HONESTLY: a TEST-MODE containment escape (a real `sudo`/`sysctl` becoming
+  # reachable during tests on a box we own), not a production exposure — production never sets
+  # CQLITE_PERF_TEST_MODE, so this whole function returns early there. Same latency class as #3323's
+  # ancestor race. #3323 re-raises on EVIDENCE the boundary is reachable, and nothing else.
+  # Do NOT "just add a check here" — read #3323 first.
   # ...and every privileged tool PARKED in the declared shim dir, whether or not PATH happens to
   # reach it: one PATH-order change is all that separates "not resolved" from "executed", and the
   # loop above is driven by PATH. Only `sudo`/`sysctl` are swept — a shim dir legitimately holds
@@ -1130,12 +1148,6 @@ perf_capability_usage() {
   printf '                  prints "<result> identity=<state>" — rc 0 only when the state is unprivileged\n'
   printf '  --drop-in       print the canonical /etc/sysctl.d/99-cqlite-perf.conf bytes\n'
   printf '  --drop-in-path  print where that file belongs\n'
-  printf '  --install [priv-cmd...]\n'
-  printf '                  INSTALL the drop-in through the validated staged path (containment checks,\n'
-  printf '                  mktemp + atomic rename). Prefix tokens are the privilege command, e.g.\n'
-  printf '                  `--install sudo`; with none it writes directly (use from a root shell).\n'
-  printf '                  Prefer this over `--drop-in | sudo tee <path>` or `> <path>`: those open the\n'
-  printf '                  destination BY NAME and follow a symlink planted there (issue #3261).\n'
 }
 
 perf_capability_main() {
@@ -1159,19 +1171,6 @@ perf_capability_main() {
     # (or `> <path>` from a root shell) re-opens the destination BY NAME and follows a symlink
     # planted there, reintroducing precisely the write this issue hardened. Hardening the installer
     # while printing an unsafe command is worse than not hardening it — it reads as safe.
-    # ENV-GUARDED, LIKE EVERY OTHER PRIVILEGED CALLER (roborev round 6, Medium — a defect this
-    # entry point INTRODUCED). bootstrap runs perf_capability_env_guard before it ever reaches the
-    # installer (bootstrap-agent-machine.sh:423); this CLI did not, so `--install sudo` in test mode
-    # could execute a REAL privileged tool and walk straight past the AC4 hermetic-executable
-    # checks — a new public surface re-opening the hole AC4 had just closed. The guard is what
-    # validates the prefix executable (it requires every reachable real sudo/sysctl to be
-    # PATH-shimmed inside an absolute CQLITE_PERF_TEST_PRIV_DIR), so calling it here IS the prefix
-    # validation, not a second mechanism. Fails closed; outside test mode it is a no-op unless a
-    # seam is set, which is exactly the production behaviour.
-    --install)
-      shift
-      perf_capability_env_guard || return 1
-      perf_capability_dropin_install "$@" ;;
     # rc PROPAGATED, never masked by the trailing newline: an unsandboxed test mode can
     # resolve no path at all (R4-3), and that is a failure, not an empty success.
     --drop-in-path) perf_capability_dropin_path || return 1; printf '\n' ;;

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -18,23 +18,7 @@
 # perf mlock limit lifted too. CQLite's doctrine mandates per-CPU collection, so `1` is
 # not "almost right", it is a hard denial. `kernel.kptr_restrict = 0` is a SEPARATE control
 # for kernel SYMBOL resolution — without it kernel frames are unresolved addresses, a
-# SILENT attribution loss rather than an error. Same rationale in the drop-in's own bytes.
-#
-# SECURITY POSTURE. A deliberate loosening, appropriate for DEDICATED SINGLE-TENANT
-# measurement/agent boxes. Never apply it to a shared or multi-tenant host. See
-# docs/development/fleet-runbook.md. BPF IS A DIFFERENT PERMISSION: a permissive
-# perf_event_paranoid does NOT grant BPF map creation — bpftrace/bcc collectors still need
-# sudo (#3217 finding).
-#
-# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call the
-# functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO side
-# effects: this file only defines `perf_capability_*` functions plus the four
-# `PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
-# outside those namespaces are touched). Every function is `set -u` safe.
-#
-# Usage when executed: `bash scripts/perf-capability.sh --help` (the modes are listed by
-# perf_capability_usage below, so they are not duplicated here).
-#
+# (rationale condensed; see #3261 commit history.)
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
 # The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
 # bootstrap installs the drop-in through the STAGED installer below (mktemp + atomic rename, no
@@ -79,14 +63,7 @@
 #   token = ok                  both /proc values READ (non-empty) from the resolved dir AND
 #                               both `is_int`-validated AND paranoid <= 0 AND kptr == 0.
 #                               Whitespace trimmed, never TRUNCATED — `0 1` stays malformed.
-#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count is a
-#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` + `-le
-#                               0`. `<not supported>`/`<not counted>`/empty/oversized/malformed
-#                               all return 1.
-#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0 and
-#                               prints a validated non-negative int) AND that uid != 0; an
-#                               unusable `id -u` => identity-unknown, rc 1.
-#   state = dropped:setpriv     numeric uid+gid, both validated ints AND both > 0.
+# (rationale condensed; see #3261 commit history.)
 #   state = dropped:runuser     the same numerics PLUS a `SUDO_USER` the passwd database
 #                               confirms IS that non-zero uid/gid, with characters safe for
 #                               the caller's word-split.
@@ -703,15 +680,7 @@ perf_capability_dropin_current() {
   # THE SENTINEL MUST NOT SWALLOW THE GENERATOR'S STATUS (roborev round 9, Medium). `printf X`
   # exists so a trailing newline survives command substitution, but it also RAN LAST, so the
   # substitution reported ITS status and a failed content generator looked like success: `want`
-  # became bare "X", and against an empty file `${got}X` is also "X" — equal, so a broken
-  # generator reported the drop-in ALREADY CURRENT. A positive verdict from an unmeasured state,
-  # which is the exact shape this repo has a standing rule against. The rc is now captured
-  # BEFORE the sentinel and re-raised as the subshell's exit status, so both properties hold.
-  want=$(perf_capability_dropin_content; __pdc_rc=$?; printf 'X'; exit "$__pdc_rc") || return 1
-  if IFS= read -r -d '' got <"$path"; then
-    return 1
-  fi
-  [ "$want" = "${got}X" ]
+# (rationale condensed; see #3261 commit history.)
 }
 
 # perf_capability_sysctl_search_path: the COMPLETE set of locations `sysctl --system`

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -3,43 +3,34 @@
 # perf-capability.sh — the ONE place that knows how a CQLite box is made
 # profileable, and how that is VERIFIED (issue #3249).
 #
-# WHY THIS FILE EXISTS. Agent/worker images ship with
-# `kernel.perf_event_paranoid = 4` and set it NOWHERE in /etc/sysctl.conf or
-# /etc/sysctl.d — so every profiling run starts from a hard EACCES whose help text
-# ("access limited") reads like a CAPABILITY verdict when it is a PERMISSION
-# verdict. That has already cost two measurement cycles. The same three-line
-# incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is
-# git-pinned, and is asserted by the gate's tooling-tests.
+# WHY THIS FILE EXISTS. Agent/worker images ship `kernel.perf_event_paranoid = 4` and set
+# it NOWHERE in /etc/sysctl.conf or /etc/sysctl.d — so every profiling run starts from a
+# hard EACCES whose help text ("access limited") reads like a CAPABILITY verdict when it is
+# a PERMISSION verdict. That has already cost two measurement cycles. The same three-line
+# incantation was then copy-pasted into ad-hoc harnesses; it now lives here, is git-pinned,
+# and is asserted by the gate's tooling-tests.
 #
-# WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE
-# restrictive, and each level keeps the restrictions of the levels below it:
-#   >= 3  (Debian/Ubuntu kernels carry this extra level) disallow ALL unprivileged
-#         perf event use — which is why the images' `4` denies EVERYTHING, down to a
-#         plain `perf stat`, not just the CPU-wide collection
-#   >= 2  no kernel profiling
-#   >= 1  no CPU-WIDE event access  <-- kills `perf stat -C <cpu>`
-#   >= 0  no raw tracepoint access
-#     -1  (almost) all events permitted, and the perf mlock limit is lifted too
-# CQLite's measurement doctrine mandates per-CPU collection (`perf stat -C`), so
-# `1` is not "almost right", it is a hard denial. `0` is the bare minimum that
-# works; `-1` additionally avoids `perf record` ring-buffer surprises.
-# `kernel.kptr_restrict = 0` is a separate control needed for kernel SYMBOL
-# resolution — without it kernel frames render as unresolved addresses, which is a
-# SILENT attribution loss, not an error.
+# WHY -1 AND NOT 1. perf_event_paranoid is CUMULATIVE — higher is MORE restrictive and
+# each level keeps the ones below it: `>= 3` (an extra Debian/Ubuntu level) denies ALL
+# unprivileged perf use, which is why the images' `4` kills even a plain `perf stat`;
+# `>= 2` no kernel profiling; `>= 1` no CPU-WIDE access, which is exactly what
+# `perf stat -C <cpu>` needs; `>= 0` no raw tracepoints; `-1` (almost) everything, and the
+# perf mlock limit lifted too. CQLite's doctrine mandates per-CPU collection, so `1` is
+# not "almost right", it is a hard denial. `kernel.kptr_restrict = 0` is a SEPARATE control
+# for kernel SYMBOL resolution — without it kernel frames are unresolved addresses, a
+# SILENT attribution loss rather than an error. Same rationale in the drop-in's own bytes.
 #
-# SECURITY POSTURE. This is a deliberate loosening appropriate for DEDICATED
-# SINGLE-TENANT measurement/agent boxes. Never apply it to a shared or
-# multi-tenant host. See docs/development/fleet-runbook.md.
+# SECURITY POSTURE. A deliberate loosening, appropriate for DEDICATED SINGLE-TENANT
+# measurement/agent boxes. Never apply it to a shared or multi-tenant host. See
+# docs/development/fleet-runbook.md. BPF IS A DIFFERENT PERMISSION: a permissive
+# perf_event_paranoid does NOT grant BPF map creation — bpftrace/bcc collectors still need
+# sudo (#3217 finding).
 #
-# BPF IS A DIFFERENT PERMISSION. A permissive perf_event_paranoid does NOT grant
-# BPF map creation — bpftrace/bcc collectors still need sudo (#3217 finding).
-#
-# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call
-# the functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO
-# side effects: this file only defines
-# `perf_capability_*` functions plus the three `PERF_CAPABILITY_*` path constants
-# (nothing runs, no shell options are changed, no variables outside those namespaces
-# are touched). Every function is `set -u` safe.
+# Sourceable AND executable. Source it ONCE (the gate does, at script scope) and call the
+# functions; a per-use re-source re-reads 300+ lines for nothing. Sourcing has NO side
+# effects: this file only defines `perf_capability_*` functions plus the four
+# `PERF_CAPABILITY_*` constants (nothing runs, no shell options are changed, no variables
+# outside those namespaces are touched). Every function is `set -u` safe.
 #
 # Usage (executed):
 #   bash scripts/perf-capability.sh --token        # free /proc read -> one token
@@ -48,17 +39,18 @@
 #   bash scripts/perf-capability.sh --drop-in-path # where that file belongs
 #
 # TEST-ONLY ENV SEAMS — INERT UNLESS CQLITE_PERF_TEST_MODE=1 (issue #3249 review).
-# The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel)
-# because bootstrap pipes the drop-in through `sudo tee <path>`: if that path were
-# env-derived, a single stray export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d)
-# would make ROOT write an attacker/accident-chosen file while the real drop-in was
-# never installed — and an unparsable sudoers entry can wedge `sudo` outright.
-# Likewise an env-chosen /proc stand-in would let a paranoid-4 box print a
-# FABRICATED "verified" verdict. So the seams take effect ONLY under the explicit
-# marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
-# reachable on PATH is a hard refusal (the suite PATH-shims both and declares the
-# shim directory), so test mode can never reach a real privileged tool.
-#   CQLITE_PERF_TEST_MODE=1     the marker; without it the two seams below are INERT
+# The PRODUCTION paths below are HARDCODED LITERALS (/etc/sysctl.d, /proc/sys/kernel) because
+# bootstrap pipes the drop-in through `sudo tee <path>`: were that path env-derived, one stray
+# export (say CQLITE_PERF_SYSCTL_DIR=/etc/sudoers.d) would make ROOT write an
+# attacker/accident-chosen file while the real drop-in was never installed — and an unparsable
+# sudoers entry can wedge `sudo` outright. Likewise an env-chosen /proc stand-in would let a
+# paranoid-4 box print a FABRICATED "verified" verdict. So the seams take effect ONLY under
+# the explicit marker, and the marker is itself hermetic: with it set, a REAL `sudo`/`sysctl`
+# reachable on PATH is a hard refusal (the suite PATH-shims both and declares the shim
+# directory), so test mode can never reach a real privileged tool.
+#   CQLITE_PERF_TEST_MODE=1     the marker; without it every seam below is INERT
+#   CQLITE_PERF_TEST_SANDBOX    THE SANDBOX ROOT — the one absolute directory every other
+#                               seam must be provably INSIDE (test mode only)
 #   CQLITE_PERF_PROC_DIR        stand-in for /proc/sys/kernel   (test mode only)
 #   CQLITE_PERF_SYSCTL_DIR      stand-in for /etc/sysctl.d      (test mode only)
 #   CQLITE_PERF_SYSCTL_EXTRA_DIRS  colon-separated stand-ins for the LOWER-precedence
@@ -67,57 +59,63 @@
 #                               optional, test mode only
 #   CQLITE_PERF_TEST_PRIV_DIR   absolute dir holding the suite's sudo/sysctl shims
 #
-# TEST MODE HAS NO FALLBACK (issue #3249 review R4-3). Under the marker BOTH path
-# seams are MANDATORY and must be absolute, non-production directories. The earlier
-# shape — marker set, seam unset, fall back to the real directory — meant test mode
-# could pass the env guard (sudo/sysctl absent, or present as declared shims) and a
-# subsequent root `--yes` run would then invoke a bare `tee` against the REAL
-# /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim that
-# depends on a variable being set: it is enforced here, fail-closed and loudly.
+# POSITIVE CONTAINMENT, NOT A LIST OF FORBIDDEN PLACES (review R6-1/R6-2). Four rounds
+# each closed ONE MORE SPELLING of "the production directory": the raw path (B3), then a
+# symlinked seam, then `..` (R5-1), then `//etc` (R6-1 — POSIX leaves two leading slashes
+# implementation-defined, `pwd -P` may PRESERVE them, and on Linux `//etc` IS `/etc`). A
+# denylist over path spellings cannot be completed — `.`, `..`, symlinks, `//`, trailing
+# slashes, bind mounts, `/proc/self/root/…` all name the same directory — and a scattered
+# set of prohibitions also lets a NEW entry point silently miss them (R6-2). So the rule is
+# INVERTED and there is exactly ONE: a seam is usable IFF it is strictly contained in the
+# declared sandbox root. Every spelling of "somewhere else" — including every future one —
+# fails that single check for the same reason: it is not inside the sandbox.
+# TEST MODE HAS NO FALLBACK (R4-3). Under the marker the sandbox root and BOTH path seams
+# are MANDATORY. The earlier shape — marker set, seam unset, fall back to the real
+# directory — meant test mode could pass the env guard (sudo/sysctl absent, or present as
+# declared shims) and a subsequent root `--yes` run would then invoke a bare `tee` against
+# the REAL /etc/sysctl.d, mutating the host from a test run. "Hermetic" cannot be a claim
+# that depends on a variable being set: it is enforced here, fail-closed and loudly.
 
 # FAIL-OPEN AUDIT — every path that can reach a POSITIVE verdict, and what validates it
-# (issue #3249 review round 4; four findings in this file were all one defect class:
-# "identity/state unknown => assume the good case"). Keep this list closed: a new
-# positive-verdict path SHALL be added here with its validator, or it is a regression.
-#   token = ok                  both /proc values READ (non-empty) from the resolved dir
-#                               AND both `perf_capability_is_int`-validated AND
-#                               paranoid <= 0 AND kptr == 0. Whitespace is trimmed, never
-#                               TRUNCATED — `0 1` stays malformed -> `unknown`.
-#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count
-#                               is a positive integer by BOTH awk's `^[0-9]+$` and
-#                               `is_int` + `-le 0`. `<not supported>`/`<not counted>`/
-#                               empty/oversized/malformed all return 1.
-#   state = self-unprivileged   `perf_capability_self_uid_into` succeeded (an `id -u` that
-#                               EXISTS, exits 0, prints a validated non-negative int) AND
-#                               that uid != 0. An unusable `id -u` => identity-unknown, rc 1.
+# (review round 4; four findings in this file were one defect class: "identity/state unknown
+# => assume the good case"). Keep this list CLOSED: a new positive-verdict path SHALL be added
+# here with its validator, or it is a regression.
+#   token = ok                  both /proc values READ (non-empty) from the resolved dir AND
+#                               both `is_int`-validated AND paranoid <= 0 AND kptr == 0.
+#                               Whitespace trimmed, never TRUNCATED — `0 1` stays malformed.
+#   verify -> cycles=<n>, rc 0  `perf` present, collection rc 0, a cycles row whose count is a
+#                               positive integer by BOTH awk's `^[0-9]+$` and `is_int` +
+#                               `-le 0`. `<not supported>`/`<not counted>`/empty/oversized/
+#                               malformed all return 1.
+#   state = self-unprivileged   `self_uid_into` succeeded (an `id -u` that EXISTS, exits 0,
+#                               prints a validated non-negative int) AND that uid != 0. An
+#                               unusable `id -u` => identity-unknown, rc 1.
 #   state = dropped:setpriv     numeric uid+gid, both validated ints AND both > 0.
 #   state = dropped:runuser     the same numerics PLUS a `SUDO_USER` the passwd database
-#                               confirms IS that non-zero uid/gid, and whose characters are
-#                               safe for the caller's word-split.
+#                               confirms IS that non-zero uid/gid, with characters safe for
+#                               the caller's word-split.
 #   state = dropped:sudo        numeric uid only (sudo's `#<uid>` form) — no name trusted.
 #   env_guard rc 0              production: NO test seam set (paths are hardcoded literals).
-#                               test mode: BOTH seams present and their CANONICAL
-#                               destinations (`.`, `..` and symlinked ancestors resolved)
-#                               absolute and outside the production dirs and /etc /proc
-#                               /sys; plus every reachable sudo/sysctl resolving inside an
-#                               absolute declared shim dir.
-#   dropin_path rc 0            in test mode, the seam RESOLVES inside its sandbox (R5-1) —
-#                               re-checked independently of the guard, because this is the
-#                               last thing between the canonical bytes and a root `tee`.
-#   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against
-#                               the generated canonical content, from a read that reached
-#                               EOF — a NUL-delimited read is NOT current, whatever the
-#                               bytes before the NUL are (R5-3).
+#                               test mode: a PROVEN sandbox root plus BOTH seams RESOLVING
+#                               strictly inside it, plus every reachable sudo/sysctl inside
+#                               an absolute declared shim dir.
+#   dropin_path rc 0            its directory came from `sysctl_dir`, i.e. RESOLVES inside the
+#                               sandbox — the single gate between the bytes and a root `tee`.
+#   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against the
+#                               generated canonical content, from a read that reached EOF — a
+#                               NUL-delimited read is NOT current (R5-3).
 # KNOWN RESIDUALS, deliberately not papered over:
-#   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel
-#     changed uid. Harmless by construction: the caller's verdict is `token = ok` AND the
-#     functional pass, and a box whose /proc says ok IS profileable by an unprivileged
-#     process, so a mislabelled drop cannot manufacture a capability that is absent.
-#   * the READ-side seam check is textual (fork-free, gate contract): it rejects `.`/`..`
-#     components and a symlinked seam, but a symlinked ANCESTOR could still steer a
-#     test-mode /proc STAND-IN read. Bounded and harmless: nothing on that path writes,
-#     and a wrong read yields `absent`/`unknown`, never a fabricated capability. Every
-#     WRITE-side check canonicalizes instead (R5-1).
+#   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel changed
+#     uid. Harmless by construction: the caller's verdict is `token = ok` AND the functional
+#     pass, and a box whose /proc says ok IS profileable unprivileged, so a mislabelled drop
+#     cannot manufacture a capability that is absent.
+#   * the READ-side containment check is SYNTACTIC (fork-free, gate contract) while every
+#     write / host-config read canonicalizes — SAME predicate, different input form. The read
+#     side judges the spelling, so a symlinked ancestor INSIDE the sandbox could still steer a
+#     test-mode /proc STAND-IN read. Bounded by that path's whole contract: the seams are
+#     honoured only under the test marker, which is never set in production, and nothing there
+#     writes — so the worst case is a read of a caller-chosen file reported as
+#     `absent`/`unknown`, never a fabricated capability.
 #
 # ---- production locations: HARDCODED. Never env-derived outside test mode. ----
 PERF_CAPABILITY_PROC_DIR_DEFAULT='/proc/sys/kernel'
@@ -127,95 +125,139 @@ PERF_CAPABILITY_DROPIN_BASENAME='99-cqlite-perf.conf'
 # perf_capability_test_mode: rc 0 iff the explicit test marker is set.
 perf_capability_test_mode() { [ "${CQLITE_PERF_TEST_MODE:-}" = 1 ]; }
 
-# perf_capability_seam_set: rc 0 iff either test-only path seam is non-empty.
+# perf_capability_seam_set: rc 0 iff either test-only path seam is non-empty. The ONE
+# seam reader outside the containment gate below, and deliberately so: it asks only
+# "was a seam handed to us at all" (for the marker-less refusal) and never uses the
+# VALUE as a path. The structural audit in test_perf_capability.sh allowlists it by
+# name, so a future function cannot join it silently.
 perf_capability_seam_set() {
   [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ]
 }
 
-# TWO VALIDATORS, SPLIT BY WHAT THE CALLER DOES (issue #3249 review R5-1). Textual
-# validation of a path is the wrong tool for a guard that steers a privileged write:
-# each round closed one more SPELLING of "somewhere else" (raw production path, then a
-# symlinked seam, then `..`). So the two callers get different validators:
-#   READ side  (the gate's emit-time token chain) -> perf_capability_test_dir_valid:
-#              pure builtins, ZERO forks, because that path is contractually free. It
-#              never writes anything, so a mis-accepted seam there can only mis-READ a
-#              stand-in /proc, which the token then reports as `absent`/`unknown`.
-#   WRITE side (env guard + the drop-in path a root `tee` is pointed at) ->
-#              perf_capability_test_dir_resolved_valid: CANONICALIZES the whole path
-#              (resolving `.`, `..` AND symlinked ancestors) and validates the RESOLVED
-#              destination. A fork costs nothing there, and the destination — not its
-#              spelling — is what gets written.
+# ---- ONE GATE: POSITIVE SANDBOX CONTAINMENT (review R6-1/R6-2) --------------------
+# THE sandbox root is caller-declared (CQLITE_PERF_TEST_SANDBOX) and must PROVE itself: an
+# absolute, canonically spelled, existing directory carrying the stamp file below. The
+# stamp is what makes the declaration unforgeable by environment alone — a stray
+# CQLITE_PERF_TEST_SANDBOX=/etc cannot turn /etc into a sandbox, because the proof lives on
+# the FILESYSTEM and writing it into a system directory already needs the privilege this
+# guard protects. No denylist appears anywhere below: a path is usable because it is
+# provably INSIDE the sandbox, never because it failed to look like somewhere forbidden.
 #
-# perf_capability_test_dir_valid <value> <production-default>: rc 0 iff <value> is a
-# usable NON-PRODUCTION stand-in — non-empty, ABSOLUTE, free of `.`/`..` components (a
-# path whose spelling is not its destination cannot be validated textually at all), and
-# neither the production directory itself nor a path under it, nor anywhere under the
-# host's own configuration surfaces (/proc, /sys, /etc), nor itself a symlink
-# (`ln -s /etc/sysctl.d /tmp/x` passes every other textual test). An unset or
-# production-shaped seam is NOT "use the real thing": in test mode it is a refusal
-# (R4-3). Builtins only — this is reached from the gate's fork-free token path.
-perf_capability_test_dir_valid() {
-  [ -n "${1:-}" ] || return 1
-  case "$1" in /*) ;; *) return 1 ;; esac
+# FIVE thin functions, ONE predicate — everything ends in perf_capability_path_within:
+#   sandbox_root_into O        the declared root, validated; rc 1 + empty when unproven
+#   path_within P R            THE predicate (below)
+#   sandbox_ok P               FORK-FREE entry point, for the gate's emit-time token chain
+#                              (contractually free of external processes AND command
+#                              substitutions): judges the SPELLING. Sound there because that
+#                              path only READS a caller-chosen file — its contract is "seams
+#                              are honoured only under the test marker, never set in
+#                              production" — so a mis-accepted spelling can at worst make the
+#                              token `absent`/`unknown`; it can never write.
+#   sandbox_ok_resolved P      for every path WRITTEN, or whose CONTENTS are read (host
+#                              configuration): canonicalizes candidate AND root (`.`, `..`,
+#                              symlinked ancestors and a `//`-rooted `pwd -P` answer all
+#                              included), then the SAME predicate. An unenterable path
+#                              resolves to nothing and is refused — fail-closed, and correct
+#                              for a write target, which must exist to be written into.
+#   sandbox_file_ok_resolved F the file form (the optional `sysctl.conf` entry): the PARENT is
+#                              canonicalized and the RESULTING FILE PATH is validated.
+# `cd -P` + `pwd -P` is the canonicalizer: one subshell, no external binary, correct on bash
+# 3.2 (no `realpath`, no `readlink -f` — absent or non-GNU on some supported hosts).
+PERF_CAPABILITY_SANDBOX_STAMP='.cqlite-perf-sandbox'
+
+perf_capability_sandbox_root_into() {
+  local __psr_v="${CQLITE_PERF_TEST_SANDBOX:-}"
+  eval "$1="
+  __psr_v="${__psr_v%/}"
+  case "$__psr_v" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
+  case "/$__psr_v/" in */../*|*/./*) return 1 ;; esac
+  [ -d "$__psr_v" ] && [ -f "$__psr_v/$PERF_CAPABILITY_SANDBOX_STAMP" ] || return 1
+  eval "$1=\$__psr_v"
+}
+
+# THE containment predicate, and the only place a path is ever judged: rc 0 iff <path> is
+# absolute, canonically spelled (no `.`, `..` or `//` component — `//etc` IS `/etc`, R6-1)
+# and STRICTLY inside <root>, with the `/` boundary explicit so `/tmp/sandboxevil` is NOT
+# inside `/tmp/sandbox`. An empty root refuses; it is never a wildcard.
+perf_capability_path_within() {
+  [ -n "${2:-}" ] || return 1
+  case "${1:-}" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
   case "/$1/" in */../*|*/./*) return 1 ;; esac
-  case "$1" in
-    "${2:-/dev/null/never}"|"${2:-/dev/null/never}"/*) return 1 ;;
-    /proc|/proc/*|/sys|/sys/*|/etc|/etc/*) return 1 ;;
-  esac
-  [ ! -L "$1" ]
+  case "$1" in "$2"/?*) return 0 ;; esac
+  return 1
 }
 
-# perf_capability_test_dir_resolved_valid <value> <production-default>: the WRITE-side
-# validator. It canonicalizes <value> and requires the RESOLVED path to satisfy the same
-# non-production predicate, so `/tmp/../etc/sysctl.d` and a symlinked ANCESTOR
-# (`ln -s /etc /tmp/a`, seam `/tmp/a/sysctl.d`) are refused by their DESTINATION rather
-# than by a new textual special case. `cd -P` + `pwd -P` is the canonicalizer: one
-# subshell, no external binary, and correct on bash 3.2 (no `realpath`, no `readlink -f`,
-# both of which are absent or non-GNU on some supported hosts). A path that cannot be
-# entered at all resolves to nothing and is refused — fail-closed, and correct for a
-# write target, which must exist to be written into.
-perf_capability_test_dir_resolved_valid() {
-  local __ptv_real=''
-  perf_capability_test_dir_valid "$1" "$2" || return 1
-  __ptv_real=$(cd -P -- "$1" 2>/dev/null && pwd -P) || return 1
-  [ -n "$__ptv_real" ] || return 1
-  perf_capability_test_dir_valid "$__ptv_real" "$2"
+perf_capability_sandbox_ok() {
+  local __pso_root=''
+  perf_capability_sandbox_root_into __pso_root || return 1
+  perf_capability_path_within "${1:-}" "$__pso_root"
 }
 
-# perf_capability_test_seams_ok: rc 0 iff test mode has BOTH mandatory seams pointing
-# at explicit non-production directories, JUDGED BY THEIR CANONICAL DESTINATION (R5-1).
-# This is the gate on every privileged action below, so it takes the strict validator:
-# refusing here is what stops a root `--yes` test run from resolving a seam back into
-# the production directory and overwriting the host's own drop-in. Refuses loudly and
-# names the offending seam, because the failure it prevents is silent otherwise.
+# the root CANONICALIZED, so both sides of a resolved containment test are in one form
+perf_capability_sandbox_root_resolved_into() {
+  local __prr_v=''
+  eval "$1="
+  perf_capability_sandbox_root_into __prr_v || return 1
+  __prr_v=$(cd -P -- "$__prr_v" 2>/dev/null && pwd -P) || return 1
+  eval "$1=\${__prr_v%/}"
+}
+
+perf_capability_sandbox_ok_resolved() {
+  local __pdr_root='' __pdr_real=''
+  perf_capability_sandbox_root_resolved_into __pdr_root || return 1
+  __pdr_real=$(cd -P -- "${1:-/dev/null/never}" 2>/dev/null && pwd -P) || return 1
+  perf_capability_path_within "$__pdr_real" "$__pdr_root"
+}
+
+perf_capability_sandbox_file_ok_resolved() {
+  local __pfr_root='' __pfr_real='' __pfr_base=''
+  case "${1:-}" in */?*) ;; *) return 1 ;; esac
+  __pfr_base="${1##*/}"
+  case "$__pfr_base" in ''|.|..) return 1 ;; esac
+  perf_capability_sandbox_root_resolved_into __pfr_root || return 1
+  __pfr_real=$(cd -P -- "${1%/*}" 2>/dev/null && pwd -P) || return 1
+  perf_capability_path_within "${__pfr_real%/}/$__pfr_base" "$__pfr_root"
+}
+
+# perf_capability_seam_refusal <VARNAME> <value> <root>: ONE message shape for both
+# mandatory seams. The refusal must NAME the offending seam — that is what makes it
+# actionable — so this is parameterised rather than duplicated per seam.
+perf_capability_seam_refusal() {
+  printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires %s INSIDE the declared sandbox %s — its RESOLVED destination (. / .. / // / symlinked ancestors and all) must be strictly contained there; got %s. Test mode NEVER falls back to the real directory.\n' \
+    "${1:-<seam>}" "'${3:-}'" "'${2:-<unset>}'" >&2
+}
+
+# perf_capability_test_seams_ok: rc 0 iff test mode has a PROVEN sandbox root and BOTH
+# mandatory seams RESOLVING strictly inside it. This is the gate on every privileged
+# action below, so it takes the resolving form: refusing here is what stops a root `--yes`
+# test run from resolving a seam back into the production directory and overwriting the
+# host's own drop-in. Refuses loudly and names what failed, because the failure it
+# prevents is silent otherwise.
 perf_capability_test_seams_ok() {
-  local ok=0
-  if ! perf_capability_test_dir_resolved_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT"; then
-    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR (absolute, and RESOLVING — . / .. / symlinked ancestors and all — outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
-      "$PERF_CAPABILITY_PROC_DIR_DEFAULT" "'${CQLITE_PERF_PROC_DIR:-<unset>}'" >&2
-    ok=1
+  local ok=0 root=''
+  if ! perf_capability_sandbox_root_into root; then
+    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires CQLITE_PERF_TEST_SANDBOX to name an absolute existing directory holding the stamp file %s; got %s. Test mode acts only INSIDE a proven sandbox and NEVER falls back to the real directory.\n' \
+      "$PERF_CAPABILITY_SANDBOX_STAMP" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" >&2
+    return 1
   fi
-  if ! perf_capability_test_dir_resolved_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
-    printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR (absolute, and RESOLVING — . / .. / symlinked ancestors and all — outside %s and outside /proc /sys /etc); got %s. Test mode NEVER falls back to the real directory.\n' \
-      "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" >&2
-    ok=1
-  fi
+  perf_capability_sandbox_ok_resolved "${CQLITE_PERF_PROC_DIR:-}" \
+    || { perf_capability_seam_refusal CQLITE_PERF_PROC_DIR "${CQLITE_PERF_PROC_DIR:-}" "$root"; ok=1; }
+  perf_capability_sandbox_ok_resolved "${CQLITE_PERF_SYSCTL_DIR:-}" \
+    || { perf_capability_seam_refusal CQLITE_PERF_SYSCTL_DIR "${CQLITE_PERF_SYSCTL_DIR:-}" "$root"; ok=1; }
   [ "$ok" = 0 ]
 }
 
-# perf_capability_env_guard: rc 0 iff this process may act on the perf capability
-# path at all. Every refusal is LOUD on stderr and FAILS CLOSED (the caller does
-# nothing privileged and claims no verdict):
-#   * a seam set WITHOUT the marker — the seams are inert there, and a caller that
-#     was handed one is misconfigured, so nothing privileged may proceed;
-#   * the marker set WITHOUT both non-production path seams — test mode has no
-#     fallback (R4-3): allowing one would let a root `--yes` test run `tee` the REAL
-#     /etc/sysctl.d, which is exactly the host mutation the marker promises cannot
-#     happen. Checked FIRST, before the tool checks, because it is the more
-#     fundamental precondition: a test run with no sandbox has nowhere safe to act;
-#   * the marker set while a REAL sudo/sysctl is reachable — test mode is hermetic
-#     by construction, so a reachable real privileged tool is a bug in the harness,
-#     not something to run.
+# perf_capability_env_guard: rc 0 iff this process may act on the perf capability path at
+# all. Every refusal is LOUD on stderr and FAILS CLOSED (the caller does nothing privileged
+# and claims no verdict):
+#   * a seam set WITHOUT the marker — the seams are inert there, so a caller handed one is
+#     misconfigured and nothing privileged may proceed;
+#   * the marker set WITHOUT a proven sandbox root and both seams inside it — test mode has
+#     no fallback (R4-3): allowing one would let a root `--yes` test run `tee` the REAL
+#     /etc/sysctl.d, the host mutation the marker promises cannot happen. Checked FIRST,
+#     before the tool checks: a test run with no sandbox has nowhere safe to act;
+#   * the marker set while a REAL sudo/sysctl is reachable — test mode is hermetic by
+#     construction, so a reachable real privileged tool is a harness bug, not something to run.
 perf_capability_env_guard() {
   if ! perf_capability_test_mode; then
     perf_capability_seam_set || return 0
@@ -232,40 +274,39 @@ perf_capability_env_guard() {
       *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 with a reachable real %s and no absolute CQLITE_PERF_TEST_PRIV_DIR — test mode must PATH-shim every privileged tool.\n' "$tool" >&2
          return 1 ;;
     esac
-    case "$resolved" in
-      "$dir"/*) ;;
-      *) printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
-           "$tool" "$resolved" "$dir" >&2
-         return 1 ;;
-    esac
+    # The same containment predicate as the seams, one level down: the tool must be
+    # strictly inside the DECLARED shim dir (not merely spelled that way).
+    perf_capability_path_within "$resolved" "${dir%/}" || {
+      printf 'perf-capability: REFUSING: CQLITE_PERF_TEST_MODE=1 but %s resolves to %s, outside the declared shim dir %s — test mode may never invoke a real privileged tool.\n' \
+        "$tool" "$resolved" "$dir" >&2
+      return 1
+    }
   done
   return 0
 }
 
 # ---- resolved locations (the seams apply ONLY in test mode) -------------------
-# THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain
-# below and is contractually FREE — no external process AND no command substitution
-# (each `$( )` forks a subshell, which is a process too). A function that answers on
-# stdout therefore CANNOT be on that path: its caller must fork to read it. So every
-# function the gate touches has an `_into <outvar>` core that assigns through a
-# caller-named variable, and the stdout-printing form is a thin wrapper kept for the
-# CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork is paid, and it is
-# not on the gate's path.
-#   Assignment is `eval "$1=\$var"`, NOT a `local -n` nameref: bash 3.2 (macOS
-#   /bin/bash, a supported gate host) has no namerefs. The RHS is an assignment, so no
-#   word-splitting or globbing applies to the value. <outvar> must be a plain shell
-#   identifier; every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_`
-#   local prefixes keep a caller-named variable from colliding with an internal one.
-#   In TEST MODE the seam is MANDATORY and validated (R4-3): an unset or
-#   production-shaped value is rc 1 with an empty answer, never a silent fallback to
-#   the real /proc or the real /etc/sysctl.d. Every caller propagates that rc, so an
-#   unsandboxed test run reads nothing and writes nothing.
+# THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain below and
+# is contractually FREE — no external process AND no command substitution (each `$( )` forks
+# a subshell, which is a process too). A function that answers on stdout therefore CANNOT be
+# on that path: its caller must fork to read it. So every function the gate touches has an
+# `_into <outvar>` core assigning through a caller-named variable, and the stdout-printing
+# form is a thin wrapper for CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork
+# is paid, and it is not on the gate's path. Assignment is `eval "$1=\$var"`, NOT a
+# `local -n` nameref: bash 3.2 (macOS /bin/bash, a supported gate host) has none. The RHS is
+# an assignment, so no word-splitting or globbing applies; <outvar> must be a plain
+# identifier (every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_` prefixes
+# keep a caller-named variable from colliding with an internal one).
+#   In TEST MODE the seam is MANDATORY and gated (R4-3): a value not provably inside the
+#   declared sandbox is rc 1 with an empty answer, never a silent fallback to the real /proc
+#   or /etc/sysctl.d. Every caller propagates that rc, so an unsandboxed test run reads
+#   nothing and writes nothing.
 perf_capability_proc_dir_into() {
   eval "$1="
   if perf_capability_test_mode; then
-    perf_capability_test_dir_valid "${CQLITE_PERF_PROC_DIR:-}" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" || {
-      printf 'perf-capability: REFUSING to read /proc: CQLITE_PERF_TEST_MODE=1 with no valid non-production CQLITE_PERF_PROC_DIR (got %s) — test mode never falls back to %s.\n' \
-        "'${CQLITE_PERF_PROC_DIR:-<unset>}'" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
+    perf_capability_sandbox_ok "${CQLITE_PERF_PROC_DIR:-}" || {
+      printf 'perf-capability: REFUSING to read /proc: CQLITE_PERF_TEST_MODE=1 with CQLITE_PERF_PROC_DIR (%s) not INSIDE the declared sandbox %s — test mode never falls back to %s.\n' \
+        "'${CQLITE_PERF_PROC_DIR:-<unset>}'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" "$PERF_CAPABILITY_PROC_DIR_DEFAULT" >&2
       return 1
     }
     eval "$1=\$CQLITE_PERF_PROC_DIR"
@@ -278,11 +319,16 @@ perf_capability_proc_dir() {
   perf_capability_proc_dir_into __pcd_v || return 1
   printf '%s' "$__pcd_v"
 }
+# perf_capability_sysctl_dir: the sysctl.d directory — the WRITE side (a root `tee` is
+# pointed inside it) and the directory whose CONTENTS the competing-file scan reads, so it
+# takes the RESOLVING gate: the canonical DESTINATION is what gets written, not the
+# spelling. Every consumer of the sysctl.d location goes through this one function, so
+# there is exactly one place the check can be forgotten — and it is here.
 perf_capability_sysctl_dir() {
   if perf_capability_test_mode; then
-    perf_capability_test_dir_valid "${CQLITE_PERF_SYSCTL_DIR:-}" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" || {
-      printf 'perf-capability: REFUSING to resolve a sysctl.d path: CQLITE_PERF_TEST_MODE=1 with no valid non-production CQLITE_PERF_SYSCTL_DIR (got %s) — test mode never falls back to %s.\n' \
-        "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" >&2
+    perf_capability_sandbox_ok_resolved "${CQLITE_PERF_SYSCTL_DIR:-}" || {
+      printf 'perf-capability: REFUSING to resolve a sysctl.d path: CQLITE_PERF_TEST_MODE=1 with CQLITE_PERF_SYSCTL_DIR (%s) not RESOLVING inside the declared sandbox %s (or unenterable) — test mode never falls back to %s.\n' \
+        "'${CQLITE_PERF_SYSCTL_DIR:-<unset>}'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" >&2
       return 1
     }
     printf '%s' "$CQLITE_PERF_SYSCTL_DIR"
@@ -290,29 +336,21 @@ perf_capability_sysctl_dir() {
   fi
   printf '%s' "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"
 }
-# perf_capability_dropin_path: the path a root `tee` is pointed at, so this is the WRITE
-# side and it takes the STRICT validator (R5-1) — the seam's CANONICAL destination is
-# checked, not its spelling. Independent of the env guard on purpose: the guard is the
-# gate, this is the last line before the bytes land, and a write target may never be
-# named from a path that resolves into production.
+# perf_capability_dropin_path: the path a root `tee` is pointed at. The containment gate
+# lives in perf_capability_sysctl_dir — the single place that directory comes from — and
+# it RESOLVES the destination, so there is deliberately no second copy of the check here:
+# one gate, not a prohibition a future entry point could skip (R6-2).
 perf_capability_dropin_path() {
   local __pdi_d
   __pdi_d=$(perf_capability_sysctl_dir) || return 1
-  if perf_capability_test_mode \
-     && ! perf_capability_test_dir_resolved_valid "$__pdi_d" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT"; then
-    printf 'perf-capability: REFUSING to name a write target: CQLITE_PERF_SYSCTL_DIR=%s RESOLVES (through . / .. / a symlinked ancestor) outside its sandbox or is unenterable — the canonical DESTINATION is what a root tee writes, not the spelling.\n' \
-      "'$__pdi_d'" >&2
-    return 1
-  fi
   printf '%s/%s' "$__pdi_d" "$PERF_CAPABILITY_DROPIN_BASENAME"
 }
 
-# perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a
-# WHOLE managed file (not a delimited block inside a foreign one), so idempotency
-# is a plain byte-compare of the entire file — simpler and safer than editing
-# someone else's config. Callers may pipe this straight into `sudo tee`, which is
-# also the remedy line bootstrap prints, so a hand-applied fix produces
-# byte-identical content and the next bootstrap run is a silent no-op.
+# perf_capability_dropin_content: the EXACT bytes of the managed drop-in. It is a WHOLE
+# managed file (not a delimited block inside a foreign one), so idempotency is a plain
+# byte-compare of the entire file — simpler and safer than editing someone else's config.
+# Callers may pipe this straight into `sudo tee`, which is also the remedy line bootstrap
+# prints, so a hand-applied fix is byte-identical and the next bootstrap run is a no-op.
 perf_capability_dropin_content() {
   cat <<'EOF'
 # Managed by scripts/bootstrap-agent-machine.sh — CQLite issue #3249. Do not edit.
@@ -343,27 +381,24 @@ kernel.kptr_restrict = 0
 EOF
 }
 
-# perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the
-# managed bytes (the idempotency test — a matching file means write nothing). The
-# compare is an in-shell string compare, NOT `diff -q`: on a box without diffutils
-# `diff` exits 127, which would report "different" on every run — so bootstrap
-# would re-write the file each time AND then report it could not write it.
+# perf_capability_dropin_current: rc 0 iff the drop-in exists with EXACTLY the managed
+# bytes (the idempotency test — a matching file means write nothing). The compare is an
+# in-shell string compare, NOT `diff -q`: on a box without diffutils `diff` exits 127,
+# which reads as "different" on every run — so bootstrap would re-write the file each time
+# AND then report it could not write it.
 #
-# TRAILING NEWLINES ARE PART OF THE BYTES (issue #3249 review R4-4). `$( )` strips
-# EVERY trailing newline from its output, so comparing two command substitutions made
-# a file missing its final newline — or carrying extra blank lines at the end —
-# compare EQUAL to the canonical content: "byte-exact" was a false claim, and such a
-# file was never rewritten. The file side is now read with `read -r -d ''`, which
-# consumes the whole file verbatim (builtin, so no `cat`/`diff` dependency), and the
-# canonical side carries an in-substitution sentinel so its own final newline survives
-# the stripping.
+# TRAILING NEWLINES ARE PART OF THE BYTES (review R4-4). `$( )` strips EVERY trailing
+# newline, so comparing two command substitutions made a file missing its final newline —
+# or carrying extra trailing blank lines — compare EQUAL: "byte-exact" was a false claim
+# and such a file was never rewritten. The file side is read with `read -r -d ''`, which
+# consumes it verbatim (builtin, no `cat`/`diff` dependency), and the canonical side carries
+# an in-substitution sentinel so its own final newline survives the stripping.
 #
-# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (issue #3249 review R5-3). `read -d ''`
-# stops at a NUL and returns SUCCESS, leaving `got` holding only the bytes BEFORE it — so
-# canonical content followed by a NUL and ARBITRARY trailing bytes compared EQUAL and was
-# judged current. Read's rc is therefore load-bearing: rc 0 means a NUL delimiter was
-# consumed, i.e. the file is not our text drop-in AND the rest of it was never even seen,
-# so it is NOT current; only an rc != 0 (EOF reached, whole file in `got`) may be compared.
+# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (review R5-3). `read -d ''` stops at a NUL
+# and returns SUCCESS with only the bytes BEFORE it, so canonical content + NUL + ARBITRARY
+# trailing bytes compared EQUAL and was judged current. Read's rc is therefore load-bearing:
+# rc 0 means a NUL was consumed — not our text drop-in, and the rest never even seen — so it
+# is NOT current; only rc != 0 (EOF, whole file in `got`) may be compared.
 perf_capability_dropin_current() {
   local path want got=''
   path=$(perf_capability_dropin_path) || return 1
@@ -376,32 +411,33 @@ perf_capability_dropin_current() {
 }
 
 # perf_capability_sysctl_search_path: the COMPLETE set of locations `sysctl --system`
-# (procps-ng) and systemd-sysctl load, one per line, in DESCENDING NAME-MASKING
-# PRECEDENCE — the order both tools scan (sysctl(8) SYSTEM FILE PRECEDENCE, sysctl.d(5)
-# CONFIGURATION DIRECTORIES AND PRECEDENCE):
-#   /etc/sysctl.d  /run/sysctl.d  /usr/local/lib/sysctl.d  /usr/lib/sysctl.d
-#   /lib/sysctl.d  and finally the FILE /etc/sysctl.conf
+# (procps-ng) and systemd-sysctl load, one per line, in DESCENDING NAME-MASKING PRECEDENCE —
+# the order both tools scan (sysctl(8) SYSTEM FILE PRECEDENCE, sysctl.d(5) CONFIGURATION
+# DIRECTORIES AND PRECEDENCE): /etc/sysctl.d, /run/sysctl.d, /usr/local/lib/sysctl.d,
+# /usr/lib/sysctl.d, /lib/sysctl.d, and finally the FILE /etc/sysctl.conf.
 # TWO INDEPENDENT RULES decide who wins, and the scan below implements both:
 #   MASKING  "once a file of a given filename is loaded, any file of the same name in
 #            subsequent directories is ignored" — so /etc/sysctl.d/50-x.conf REPLACES
-#            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would
-#            name a file that is not in effect.
-#   ORDERING the surviving files are applied in lexicographic BASENAME order regardless
-#            of which directory they came from; the LAST assignment wins.
-#   /etc/sysctl.conf is applied AFTER every drop-in, so it wins on grounds that have
-#   nothing to do with its name — it gets its own verdict rather than a sort comparison.
-#
-# WHY THE WHOLE PATH (issue #3249 review R5-4). Scanning only /etc/sysctl.d meant a
-# later-sorting file in /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in
-# while bootstrap reported NO competitor — recreating the exact "it silently reverts and
-# nobody knows why" mystery this diagnostic exists to end.
+#            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would name
+#            a file that is not in effect.
+#   ORDERING the survivors are applied in lexicographic BASENAME order regardless of which
+#            directory they came from; the LAST assignment wins. /etc/sysctl.conf is applied
+#            AFTER every drop-in, so it wins on grounds unrelated to its name and gets its
+#            own verdict rather than a sort comparison.
+# WHY THE WHOLE PATH (review R5-4). Scanning only /etc/sysctl.d meant a later-sorting file in
+# /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in while bootstrap reported NO
+# competitor — recreating the "it silently reverts and nobody knows why" mystery this
+# diagnostic exists to end.
 #
 # In TEST MODE the path is the sandbox seam plus the optional colon-separated
 # CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, in the same descending
-# order, each validated non-production): the real /run and /usr/lib are never read, so a
-# case's verdict can never depend on the host's own drop-ins.
+# order): the real /run and /usr/lib are never read, so a case's verdict can never depend
+# on the host's own drop-ins. EVERY entry goes through the SAME RESOLVING gate as the
+# write path (R6-2 — this entry point once used the syntactic one, so a symlinked ancestor
+# could point a "sandboxed" scan at the host's real configuration). A `sysctl.conf` entry
+# is a FILE, so its parent is canonicalized and the resulting file path validated.
 perf_capability_sysctl_search_path() {
-  local __psp_d __psp_e
+  local __psp_d __psp_e __psp_ok
   if perf_capability_test_mode; then
     __psp_d=$(perf_capability_sysctl_dir) || return 1
     printf '%s\n' "$__psp_d"
@@ -410,9 +446,14 @@ perf_capability_sysctl_search_path() {
     IFS=':' read -r -a __psp_extra <<<"${CQLITE_PERF_SYSCTL_EXTRA_DIRS:-}"
     for __psp_e in ${__psp_extra[@]+"${__psp_extra[@]}"}; do
       [ -n "$__psp_e" ] || continue
-      perf_capability_test_dir_valid "$__psp_e" "$PERF_CAPABILITY_SYSCTL_DIR_DEFAULT" || {
-        printf 'perf-capability: REFUSING: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry %s is not an absolute NON-PRODUCTION path — a test-mode scan may never read the host'"'"'s real sysctl.d directories.\n' \
-          "'$__psp_e'" >&2
+      __psp_ok=0
+      case "${__psp_e##*/}" in
+        sysctl.conf) perf_capability_sandbox_file_ok_resolved "$__psp_e" && __psp_ok=1 ;;
+        *)           perf_capability_sandbox_ok_resolved "$__psp_e" && __psp_ok=1 ;;
+      esac
+      [ "$__psp_ok" = 1 ] || {
+        printf 'perf-capability: REFUSING: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry %s does not RESOLVE inside the declared sandbox %s — a test-mode scan may never read the host'"'"'s real sysctl configuration.\n' \
+          "'$__psp_e'" "'${CQLITE_PERF_TEST_SANDBOX:-<unset>}'" >&2
         return 1
       }
       printf '%s\n' "$__psp_e"
@@ -439,16 +480,15 @@ perf_capability_file_sets_controls() {
 # wins regardless of name.
 #
 # WHY THIS EXISTS. Three separate reports (ws0-3217, ws3-3029, the 2026-07-27 Cassandra
-# baseline) recorded that a hand-set perf_event_paranoid/kptr_restrict "silently
-# reverts" and none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
+# baseline) recorded a hand-set perf_event_paranoid/kptr_restrict "silently reverting" and
+# none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
 # /etc/sysctl.d/10-kernel-hardening.conf with `kernel.kptr_restrict = 1`, re-asserted at
 # every boot and by every `sysctl --system`. "It silently reverts" is unactionable;
-# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins"
-# is a diagnosis. Ordering is lexicographic by BASENAME in BYTE order, which is what
-# systemd-sysctl/`sysctl --system` use — and `[ "$a" \> "$b" ]` is the right operator
-# for it: the `[` builtin compares with strcmp (verified: byte order even under a UTF-8
-# LC_ALL), whereas `[[ > ]]` would switch to locale collation and could mis-rank names
-# whose only difference is punctuation.
+# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins" is a
+# diagnosis. Ordering is lexicographic by BASENAME in BYTE order (what systemd-sysctl and
+# `sysctl --system` use) and `[ "$a" \> "$b" ]` is the right operator: the `[` builtin
+# compares with strcmp (verified: byte order even under a UTF-8 LC_ALL), whereas `[[ > ]]`
+# switches to locale collation and could mis-rank names differing only in punctuation.
 perf_capability_competing_files() {
   local base f name entry seen paths lf='
 '
@@ -505,26 +545,25 @@ $paths
 EOF
 }
 
-# perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight
-# from /proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when
-# unreadable). NEVER trust a `sysctl -w`/`--system` return code — a write can report
-# success while the value does not take (container, read-only sysfs, a competing
-# drop-in applied later), and it can report FAILURE for an unrelated entry while ours
-# applied fine. Read back.
-# Fully fork-free: `read` is a builtin, the directory comes back through a variable,
-# and nothing here is wrapped in `$( )`. This sits in the gate's summary path, which
-# may not grow a process for a diagnostic line. `read` returns non-zero at EOF on a
-# file with no trailing newline yet still assigns, so emptiness — not read's rc — is
-# the failure test. It also propagates the test-mode sandbox refusal (R4-3): with no
-# valid seam there is no directory to read, and that is rc 1, never the real /proc.
+# perf_capability_proc_read <outvar> <name>: the CURRENT kernel value read straight from
+# /proc/sys/kernel/<name> into <outvar> (rc 1 + <outvar> emptied when unreadable). NEVER
+# trust a `sysctl -w`/`--system` return code — a write can report success while the value
+# does not take (container, read-only sysfs, a competing drop-in applied later), and it can
+# report FAILURE for an unrelated entry while ours applied fine. Read back.
+# Fully fork-free: `read` is a builtin, the directory comes back through a variable, and
+# nothing here is wrapped in `$( )` — this sits in the gate's summary path, which may not
+# grow a process for a diagnostic line. `read` returns non-zero at EOF on a file with no
+# trailing newline yet still assigns, so emptiness — not read's rc — is the failure test. It
+# also propagates the test-mode sandbox refusal (R4-3): with no seam inside the sandbox there
+# is no directory to read, and that is rc 1, never the real /proc.
 #
 # WHITESPACE IS TRIMMED, NEVER TRUNCATED AT (fail-open audit, R4 round). The earlier
 # `${v%%[[:space:]]*}` cut the value at its FIRST space, so a malformed `0 1` became a
-# perfectly capable-looking `0` — an unknown resolving to the good case, in the one
-# function the gate's `perf=` token is computed from. Surrounding whitespace (including a
-# CRLF's `\r`) is stripped; anything interior is left in place so `is_int` rejects it and
-# the token becomes `unknown`. `IFS=` makes that independent of the caller's IFS, and both
-# trims are parameter expansions — no fork on the gate's emit path.
+# perfectly capable-looking `0` — an unknown resolving to the good case, in the one function
+# the gate's `perf=` token comes from. Surrounding whitespace (a CRLF's `\r` included) is
+# stripped; anything interior stays so `is_int` rejects it and the token becomes `unknown`.
+# `IFS=` makes that independent of the caller's IFS, and both trims are parameter
+# expansions — no fork on the gate's emit path.
 perf_capability_proc_read() {
   local __pcr_out="$1" __pcr_dir="" __pcr_v=""
   eval "$__pcr_out="
@@ -545,13 +584,12 @@ perf_capability_proc_value() {
   printf '%s' "$__pcv_v"
 }
 
-# perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative
-# integer NARROW ENOUGH for shell arithmetic. Both halves are load-bearing: `[ 1abc
-# -ge 1 ]` and `[ 99999999999999999999999 -ge 1 ]` do NOT compare — each prints
-# "integer expression expected" to stderr and returns 2 (neither true NOR false), so
-# a malformed or oversized value would fall past BOTH a `>= 1` and a `<= 0` test and
-# be reported as good (a WRONG capability claim) while leaking an error line into the
-# gate's output. Validate the shape here instead of trusting the read.
+# perf_capability_is_int <value>: rc 0 iff <value> is a plain optionally-negative integer
+# NARROW ENOUGH for shell arithmetic. Both halves are load-bearing: `[ 1abc -ge 1 ]` and
+# `[ 99999999999999999999999 -ge 1 ]` do NOT compare — each prints "integer expression
+# expected" and returns 2 (neither true NOR false), so a malformed or oversized value would
+# fall past BOTH a `>= 1` and a `<= 0` test and be reported as good (a WRONG capability
+# claim) while leaking an error line into the gate's output.
 perf_capability_is_int() {
   local body="${1#-}"
   [ -n "$body" ] || return 1
@@ -559,13 +597,11 @@ perf_capability_is_int() {
   [ "${#body}" -le 10 ]
 }
 
-# perf_capability_token_into <outvar>: the FREE capability read, and THE function the
-# gate's accelerators line calls. Free is a hard contract, enforced by
-# test_agent_gate_summary.sh case 9f-free: pure /proc through shell builtins — no
-# `perf` exec, no external process of ANY kind, and no command substitution anywhere
-# in the chain (which is why the answer comes back through <outvar> rather than
-# stdout; every `$( )` is a forked subshell, and the gate emits this line on every
-# summary).
+# perf_capability_token_into <outvar>: the FREE capability read, and THE function the gate's
+# accelerators line calls. Free is a hard contract, enforced by test_agent_gate_summary.sh
+# case 9f-free: pure /proc through shell builtins — no `perf` exec, no external process of
+# ANY kind, and no command substitution anywhere in the chain (hence the <outvar>: every
+# `$( )` is a forked subshell, and the gate emits this line on every summary).
 #   ok               unprivileged per-CPU profiling AND kernel symbols available
 #   paranoid-<N>     perf_event_paranoid = N >= 1 -> CPU-wide `perf stat -C` denied
 #   kptr-restricted  paranoid is fine but kptr_restrict != 0 -> no kernel symbols
@@ -602,29 +638,23 @@ perf_capability_token() {
 
 # ---- WHOSE capability? the privilege dimension (issue #3249 review) -----------
 # perf_event_paranoid restricts UNPRIVILEGED users; ROOT BYPASSES IT ENTIRELY. So
-# `perf stat -C 0 -e cycles` run by root SUCCEEDS on a paranoid=4 box on which every
+# `perf stat -C 0 -e cycles` run by root SUCCEEDS on a paranoid=4 box where every
 # unprivileged agent process still gets EACCES — and `sudo bash
 # scripts/bootstrap-agent-machine.sh` is a completely normal provisioning invocation
-# (arguably the most likely one, since installing /etc/sysctl.d/99-cqlite-perf.conf
-# needs root). A root-run functional check reported as "perf capability verified" is
-# therefore a FALSE verification of an unprofileable box: precisely the failure mode
-# the functional check exists to remove, reintroduced through the privilege dimension.
+# (arguably the most likely one, since installing the drop-in needs root). A root-run
+# functional check reported as "perf capability verified" is therefore a FALSE verification
+# of an unprofileable box: the failure mode the functional check exists to remove,
+# reintroduced through the privilege dimension. The property under test is "an UNPRIVILEGED
+# process can collect CPU-WIDE cycles", which a root-run probe cannot demonstrate — so the
+# probe DROPS PRIVILEGE when it can and SAYS SO when it cannot, and the caller then
+# subordinates the functional result to the identity-independent /proc token.
 #
-# The property actually under test is "an UNPRIVILEGED process can collect CPU-WIDE
-# cycles", and a root-run probe cannot demonstrate it. So the probe DROPS PRIVILEGE
-# when it can, and when it cannot it says so — the caller then subordinates the
-# functional result to the /proc token, which is identity-independent.
-#
-# perf_capability_self_uid_into <outvar>: THIS process's uid, and rc 0 ONLY when it is
-# genuinely known — `id -u` must EXIST, exit 0, and print a validated non-negative
-# integer. rc 1 (with <outvar> emptied) means "identity unknown", which is NOT the same
-# as "unprivileged" (issue #3249 review R4-1).
-#
-# The previous shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or
-# broken `id` made a ROOT process look unprivileged, so its root perf run was accepted
-# as unprivileged evidence and printed a false VERIFIED — the very R3-1 defect, through
-# the detector written to prevent it. An unknown identity can never resolve to the
-# reassuring case.
+# perf_capability_self_uid_into <outvar>: THIS process's uid, rc 0 ONLY when genuinely known
+# — `id -u` must EXIST, exit 0, and print a validated non-negative integer. rc 1 (<outvar>
+# emptied) means "identity unknown", which is NOT "unprivileged" (review R4-1). The previous
+# shape, `$(id -u 2>/dev/null || echo 1000)`, FAILED OPEN: a missing or broken `id` made a
+# ROOT process look unprivileged, so its root perf run was accepted as unprivileged evidence
+# and printed a false VERIFIED — the R3-1 defect, through the detector written to prevent it.
 perf_capability_self_uid_into() {
   local __psu_v=''
   eval "$1="
@@ -639,14 +669,13 @@ perf_capability_self_uid_into() {
 # the passwd database whose uid AND gid equal the supplied (already validated) numerics
 # and whose uid is non-zero.
 #
-# WHY (issue #3249 review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever
-# the NAME resolves to, not to the numeric ids we validated. SUDO_USER and SUDO_UID are
-# independent environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale, hand-set, or
-# inconsistent) would run the probe AS ROOT while the code reported a successful
-# privilege drop — a false VERIFIED again. A name is therefore only usable once the
-# passwd database confirms it IS the validated uid/gid.
-# The shape check is equally load-bearing: the prefix is word-split by the caller, so a
-# name containing whitespace or glob characters could inject extra argv tokens.
+# WHY (review R4-2). `runuser -u <name>` / `sudo -u <name>` drop to whatever the NAME
+# resolves to, not to the numeric ids we validated, and SUDO_USER/SUDO_UID are independent
+# environment strings: `SUDO_UID=1000 SUDO_USER=root` (stale or hand-set) would run the probe
+# AS ROOT while the code reported a successful drop — a false VERIFIED again. So a name is
+# usable only once the passwd database confirms it IS the validated uid/gid. The shape check
+# is equally load-bearing: the prefix is word-split by the caller, so a name containing
+# whitespace or glob characters could inject extra argv tokens.
 perf_capability_name_is_uid() {
   local __pni_n="${1:-}" __pni_u="${2:-}" __pni_g="${3:-}" __pni_ru __pni_rg
   [ -n "$__pni_n" ] || return 1
@@ -666,11 +695,10 @@ perf_capability_name_is_uid() {
 #      Strongest available evidence.
 #   2. `nobody`, resolved from the passwd database (never a hardcoded 65534: a box
 #      without that account must report "no target", not probe a uid nobody owns).
-# THE NUMERIC IDS ARE THE TARGET; the NAME is optional and only ever set when the
-# passwd database confirms it resolves to exactly those non-zero ids (R4-2). An
-# unverifiable SUDO_USER is dropped, not trusted: the numeric-only mechanisms
-# (setpriv, `sudo -u '#<uid>'`) still work, and a name-requiring mechanism correctly
-# reports that it has nothing safe to use.
+# THE NUMERIC IDS ARE THE TARGET; the NAME is optional and set only when the passwd database
+# confirms it resolves to exactly those non-zero ids (R4-2). An unverifiable SUDO_USER is
+# dropped, not trusted: the numeric-only mechanisms (setpriv, `sudo -u '#<uid>'`) still work,
+# and a name-requiring mechanism correctly reports it has nothing safe to use.
 perf_capability_drop_target_into() {
   local __pdt_u='' __pdt_g='' __pdt_n=''
   if perf_capability_is_int "${SUDO_UID:-}" && perf_capability_is_int "${SUDO_GID:-}" \
@@ -708,18 +736,16 @@ perf_capability_drop_target_into() {
 #                                 and the result is not evidence either way (rc 1)
 #   root-no-unprivileged-target   root, and no unprivileged identity is resolvable (rc 1)
 #   root-no-drop-mechanism        root, target known, but no usable setpriv/runuser/sudo (rc 1)
-# Mechanism order: `setpriv` (util-linux; a plain setresuid, no PAM, no session, no
-# shell), then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC
-# ids and never a name — `setpriv --reuid/--regid`, and `sudo -u '#<uid>'` (sudo's
-# documented numeric-uid form) — so no name has to be trusted (R4-2). `runuser` accepts
-# only a name and is therefore used ONLY with a passwd-confirmed one.
-#   The `#<uid>` token is safe through the caller's word-split: `#` only starts a comment
-#   during tokenisation of the source line, and this value arrives by EXPANSION
-#   afterwards, so it is passed to sudo as a literal argument.
-# The prefix is composed ONLY of literal tokens plus a validated numeric uid/gid or a
-# passwd-confirmed name, so the caller may word-split it. A non-zero rc is NOT an error
-# to fail on: it is the caller's cue to label the functional result as what it is — not
-# evidence about an unprivileged process — and to let the /proc token be the authority.
+# Mechanism order: `setpriv` (util-linux; a plain setresuid — no PAM, no session, no shell),
+# then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC ids and
+# never a name — `setpriv --reuid/--regid` and `sudo -u '#<uid>'` (sudo's documented
+# numeric-uid form) — so no name has to be trusted (R4-2); `runuser` accepts only a name and
+# is used ONLY with a passwd-confirmed one. The `#<uid>` token survives the caller's
+# word-split intact: `#` starts a comment only while TOKENISING a source line, and this value
+# arrives by EXPANSION afterwards. The prefix holds only literal tokens plus a validated
+# numeric uid/gid or a confirmed name, so the caller may word-split it. A non-zero rc is NOT
+# an error to fail on: it is the caller's cue to label the functional result as what it is —
+# not evidence about an unprivileged process — and to let the /proc token be the authority.
 perf_capability_drop_prefix_into() {
   local __pdp_u='' __pdp_g='' __pdp_n='' __pdp_self=''
   eval "$1="
@@ -751,24 +777,22 @@ perf_capability_drop_prefix_into() {
   return 1
 }
 
-# perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (issue #3249
-# AC2). A bootstrap that silently leaves a box unprofileable is the failure mode being
-# fixed, so the verdict comes from RUNNING the collection the doctrine mandates —
-# `perf stat -C 0 -e cycles` — and requires BOTH exit 0 AND a non-zero cycle
-# count. `perf stat` exits 0 while printing `<not supported>` / `<not counted>`
-# (and a virtualised PMU can report a flat 0), so an rc-only check is exactly the
-# false green this exists to prevent.
+# perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (AC2). A bootstrap
+# that silently leaves a box unprofileable is the failure mode being fixed, so the verdict
+# comes from RUNNING the collection the doctrine mandates — `perf stat -C 0 -e cycles` — and
+# requires BOTH exit 0 AND a non-zero cycle count: `perf stat` exits 0 while printing
+# `<not supported>`/`<not counted>` (and a virtualised PMU can report a flat 0), so an
+# rc-only check is exactly the false green this exists to prevent.
 #
-# Any arguments are a command prefix the collection runs under — the
-# privilege-dropping prefix above. This function makes NO claim about identity: it
-# runs what it is given and reports the counter. Deciding WHOSE capability was
-# measured (and whether that answers the question) is the caller's job, because the
-# caller is the one that owns the verdict.
+# Any arguments are a command prefix the collection runs under — the privilege-dropping
+# prefix above. This function makes NO claim about identity: it runs what it is given and
+# reports the counter. Deciding WHOSE capability was measured is the caller's job, because
+# the caller owns the verdict.
 #
 # CSV mode (`-x,`) is parsed rather than the human table: the human renderer is
-# locale-formatted (`1.234.567`) and column layout has changed across perf
-# releases, while the CSV shape `<count>,<unit>,<event>,...` is stable.
-# Prints a short machine-greppable reason (stdout) either way; rc 0 = verified.
+# locale-formatted (`1.234.567`) and its column layout has changed across perf releases,
+# while the CSV shape `<count>,<unit>,<event>,...` is stable. Prints a short
+# machine-greppable reason (stdout) either way; rc 0 = verified.
 perf_capability_verify() {
   command -v perf >/dev/null 2>&1 || { printf 'no-perf-binary'; return 1; }
   local bound="" out rc count
@@ -785,14 +809,13 @@ perf_capability_verify() {
     printf 'perf-stat-failed rc=%s: %s' "$rc" "$(printf '%s' "$out" | tr '\n' ';' | cut -c1-160)"
     return 1
   fi
-  # Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU
-  # (Intel 12th-gen+ P/E cores) perf emits one row per PMU named `cpu_core/cycles/`
-  # and `cpu_atom/cycles/`, commonly with `<not supported>` on the sibling that did
-  # not run — so a parser keyed on a literal leading `cycles` reports `no-cycles-row`
-  # on a perfectly good collection. Normalise the event field (drop the PMU prefix, a
-  # trailing `/`, and any `:u`/`:k` modifier) and take the FIRST row carrying a
-  # positive numeric count; keep the first matching row's raw field as the fallback so
-  # the `<not supported>` / zero diagnostics below still fire when none is positive.
+  # Event-name matching must accept a QUALIFIED cycle event: on a hybrid-PMU CPU (Intel
+  # 12th-gen+ P/E cores) perf emits one row per PMU (`cpu_core/cycles/`, `cpu_atom/cycles/`),
+  # commonly with `<not supported>` on the sibling that did not run — so a parser keyed on a
+  # literal leading `cycles` reports `no-cycles-row` on a perfectly good collection. Normalise
+  # the event field (drop PMU prefix, trailing `/`, any `:u`/`:k` modifier) and take the FIRST
+  # row with a positive numeric count; keep the first matching row's raw field as the fallback
+  # so the `<not supported>` / zero diagnostics below still fire when none is positive.
   count=$(printf '%s\n' "$out" | awk -F, '
     {
       ev = tolower($3)

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -503,23 +503,8 @@ perf_capability_dropin_path() {
 #   NOT gated: scripts/tests/test_perf_capability.sh calls this DIRECTLY, so its staged-install cases
 #   are capability-probed and COUNTED-skipped off GNU (roborev round 5). Neither portability guard in
 #   the repo scans this file, so nothing mechanically protects the gate; recorded, not papered over.
-# perf_capability_install_tools_ok: does THIS host have the GNU coreutils behaviour the staged
-# install needs (roborev round 16, Medium)? `stat -c` and `mv --no-target-directory` are GNU-only, and
-# bootstrap gates the perf section on PLATFORM=linux — which is NOT the same as GNU. A musl/busybox
-# Linux host would previously reach the installer and fail on a raw tool error. Probed AFFIRMATIVELY
-# (run the flags) rather than inferred from a distro name.
-perf_capability_install_tools_ok() {
-  stat -c '%a' . >/dev/null 2>&1 || return 1
-  mv --help 2>&1 | grep -q -- '--no-target-directory' || return 1
-}
-
 perf_capability_dropin_install() {
-  local __pin_d __pin_p
-  # rc 2 is UNSUPPORTED-HOST, distinct from rc 1 REFUSED, so a caller can report "this host
-  # cannot do an atomic install" instead of implying the attempt was unsafe.
-  perf_capability_install_tools_ok || {
-    printf 'perf-capability: UNSUPPORTED on this host: the atomic staged install needs GNU coreutils (stat -c and mv --no-target-directory); neither is present, so the drop-in cannot be installed safely. Install GNU coreutils or set the sysctls another way.\n' >&2
-    return 2; }
+  local __pin_d __pin_p __pin_rc
   __pin_d=$(perf_capability_sysctl_dir) || return 1
   # TRAILING SLASHES ARE STRIPPED BEFORE ANY CHECK OR PATH CONSTRUCTION (roborev round 10, Low).
   # `[ -L "$d" ]` FOLLOWS a trailing slash: for a symlinked directory `link`, `[ -L link ]` is true
@@ -553,6 +538,19 @@ perf_capability_dropin_install() {
     # slashes, but this block is the thing holding privilege and must not depend on someone else
     # having done it. Same reason the mktemp answer is re-checked here rather than trusted.
     while [ "${d%/}" != "$d" ] && [ "${#d}" -gt 1 ]; do d="${d%/}"; done
+    # TOOL COMPATIBILITY IS EXERCISED HERE, IN THE PRIVILEGED SHELL (roborev round 17, Medium — a
+    # defect in the round-16 fix). The previous probe ran in the CALLERS PATH, but this shell is
+    # entered through sudo, which applies its own secure_path: the two can resolve DIFFERENT stat and
+    # mv binaries, so a caller-side check could pass while the privileged tools are incompatible, or
+    # refuse while they would have worked. Same lesson already applied to mktemp here — the block
+    # holding privilege re-checks rather than trusting what someone else established.
+    # And the flags are EXERCISED, not grepped: reading mv --help proves a help string mentions
+    # --no-target-directory, not that rename-over-a-name behaves. Two throwaway entries in the
+    # already-validated directory are renamed one over the other, which is exactly the operation the
+    # install depends on. rc 2 = UNSUPPORTED HOST, distinct from rc 1 = REFUSED.
+    stat -c '%a' -- "$d" >/dev/null 2>&1 || {
+      printf "perf-capability: UNSUPPORTED on this host: stat -c is unavailable (GNU coreutils required), so ownership and mode cannot be established before a privileged write.\n" >&2
+      exit 2; }
     # THE PRECONDITION (roborev round 3): nobody less privileged than this shell may be able to
     # create or replace entries in $d. Without that there is an actor to race; with it there is not.
     #   WHY THIS IS NOT A TWELFTH ATTEMPT TO OUT-TIME THE RACE (owner ruling A-prime): escapes 9-11
@@ -606,6 +604,19 @@ perf_capability_dropin_install() {
         printf "perf-capability: REFUSING: the drop-in directory %s is mode %s — group- or world-writable, so a less-privileged user can replace entries inside it while a privileged write is in progress. Tighten it (chmod go-w) before installing.\n" "$d" "$dmode" >&2
         exit 1 ;;
     esac
+    # mv -T IS EXERCISED HERE, AFTER the ownership precondition and BEFORE the real staging entry.
+    # Placement is deliberate on both sides. AFTER the precondition, because that is what establishes
+    # no less-privileged actor can create entries in $d — which is precisely what makes a PREDICTABLE
+    # probe name safe, so this does not need (and must not consume) mktemp. NOT consuming mktemp also
+    # keeps it from pre-empting the staging entry checks below, which have their own cases.
+    __x1="$d/.perfcap-probe.$$"; __x2="$__x1.b"
+    rm -f -- "$__x1" "$__x2"
+    if ! : >"$__x1" 2>/dev/null || ! mv -fT -- "$__x1" "$__x2" 2>/dev/null; then
+      rm -f -- "$__x1" "$__x2"
+      printf "perf-capability: UNSUPPORTED on this host: mv --no-target-directory (-T) does not work (GNU coreutils required), so the drop-in cannot be replaced atomically without risking a symlinked destination.\n" >&2
+      exit 2
+    fi
+    rm -f -- "$__x2"
     t=$(mktemp -- "$d/.$b.XXXXXX") || exit 1
     # mktemp CREATED the entry, so mktemp is what must be checked, INSIDE this privileged shell and
     # fail-closed: it has to name a fresh regular file (never a symlink) directly in the directory
@@ -626,8 +637,11 @@ perf_capability_dropin_install() {
     if ! tee -- "$t" >/dev/null || ! chmod 0644 -- "$t" || ! mv -fT -- "$t" "$p"; then
       rm -f -- "$t"; exit 1
     fi
-  ' perf-capability-install "$__pin_d" "$__pin_p" "$PERF_CAPABILITY_DROPIN_BASENAME" >/dev/null \
-    || return 1
+  ' perf-capability-install "$__pin_d" "$__pin_p" "$PERF_CAPABILITY_DROPIN_BASENAME" >/dev/null
+  # rc PROPAGATED, not collapsed: `|| return 1` here used to flatten the privileged shell's status,
+  # which silently destroyed the rc 2 UNSUPPORTED signal the caller is meant to distinguish.
+  __pin_rc=$?
+  [ "$__pin_rc" -eq 0 ] || return "$__pin_rc"
   perf_capability_dropin_current
 }
 

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -153,10 +153,40 @@ perf_capability_seam_set() {
 # `cd -P` + `pwd -P` is the canonicalizer: one subshell, no external binary, correct on bash
 # 3.2 (no `realpath`, no `readlink -f` — absent or non-GNU on some supported hosts).
 PERF_CAPABILITY_SANDBOX_STAMP='.cqlite-perf-sandbox'
+# A literal LF and CR, for the line-safety predicate below. Spelled as a literal newline inside
+# single quotes rather than `$'\n'` so this stays correct on bash 3.2 (a supported gate host).
+PERF_CAPABILITY_LF='
+'
+PERF_CAPABILITY_CR=$'\r'
+
+# perf_capability_path_lines_ok: rc 0 iff <path> contains NO CR and NO LF.
+#
+# WHY A SEPARATE PROPERTY FROM CONTAINMENT (issue #3261, roborev round 3). This one is not a
+# containment defect at all — the path IS contained — it is a SERIALIZATION defect, which is why
+# nine rounds of containment work never touched it. `perf_capability_sysctl_search_path` emits its
+# answer ONE ENTRY PER LINE and `perf_capability_competing_files` reads it line-wise, so a directory
+# legitimately inside the sandbox but NAMED with an embedded newline —
+# `<root>/name<LF>/etc/sysctl.d` — passes every containment check and is then SPLIT into two
+# entries, the second of which is the host's real `/etc/sysctl.d`. One contained path became two
+# paths, one of them production.
+#   The repo already knows this class: CLAUDE.md records the roborev guard's own `-z` invariant for
+# exactly this reason — a newline-delimited path set is not a safe representation of paths, and the
+# fix there was to stop using one. Here the answer is the cheaper half of the same lesson: REJECT
+# the characters at the boundary rather than escape them downstream or re-plumb every consumer to
+# NUL. A path with a newline in it has no legitimate use as a perf seam, so refusing it costs
+# nothing and removes the ambiguity at its source. CR is rejected with LF because a CRLF host file
+# would otherwise leave a stray `\r` inside a resolved entry.
+perf_capability_path_lines_ok() {
+  case "${1:-}" in
+    *"$PERF_CAPABILITY_LF"*|*"$PERF_CAPABILITY_CR"*) return 1 ;;
+  esac
+  return 0
+}
 
 perf_capability_sandbox_root_into() {
   local __psr_v="${CQLITE_PERF_TEST_SANDBOX:-}"
   eval "$1="
+  perf_capability_path_lines_ok "$__psr_v" || return 1
   __psr_v="${__psr_v%/}"
   case "$__psr_v" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
   case "/$__psr_v/" in */../*|*/./*) return 1 ;; esac
@@ -165,11 +195,16 @@ perf_capability_sandbox_root_into() {
 }
 
 # THE containment predicate, and the only place a path is ever judged: rc 0 iff <path> is
-# absolute, canonically spelled (no `.`, `..` or `//` component — `//etc` IS `/etc`, R6-1)
+# absolute, canonically spelled (no `.`, `..` or `//` component — `//etc` IS `/etc`, R6-1),
+# free of CR/LF (so a contained path can never SERIALIZE into two entries, roborev round 3)
 # and STRICTLY inside <root>, with the `/` boundary explicit so `/tmp/sandboxevil` is NOT
 # inside `/tmp/sandbox`. An empty root refuses; it is never a wildcard.
+# The line check lives HERE, in the one predicate every entry point ends in, for the same reason
+# containment does: one choke point cannot be skipped by a future consumer.
 perf_capability_path_within() {
   [ -n "${2:-}" ] || return 1
+  perf_capability_path_lines_ok "${1:-}" || return 1
+  perf_capability_path_lines_ok "$2" || return 1
   case "${1:-}" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
   case "/$1/" in */../*|*/./*) return 1 ;; esac
   case "$1" in "$2"/?*) return 0 ;; esac
@@ -444,27 +479,39 @@ perf_capability_dropin_path() {
 #   process, which could not read a root-owned 0600 file — every subsequent run would then see
 #   "not current" and rewrite. The old `tee` produced 0644 via root's umask; this preserves that.
 #
-# ONE PRIVILEGED INVOCATION, AND THE RESIDUAL THAT REMAINS (issue #3261, roborev round 2 — the
-# TENTH escape, the same shape one level deeper). `mktemp` closed the CREATE race but moved the
-# window rather than closing it: mktemp returns a NAME, and `tee`/`chmod`/`mv` each REOPEN that name
-# afterwards, so between the create and the reopen an attacker who can write the directory could
-# observe the random entry and replace it with a symlink. Every step therefore now runs inside a
-# SINGLE privileged `sh -c` — content on stdin — so no unprivileged process is scheduled between
-# them and there is no point at which a less-privileged observer gets to act.
-#   STATED PLAINLY, BECAUSE THIS FAMILY HAS PUNISHED OPTIMISM NINE TIMES AND ONE COMMENT HERE
-#   ALREADY HAD TO BE RETRACTED: consolidation SHRINKS the reopen window to the inside of one root
-#   process; it does NOT mathematically eliminate it. POSIX shell has no `O_NOFOLLOW|O_EXCL` open
-#   primitive — `mktemp` hands back a name and every subsequent open is by name — so the last
-#   name-based assumption cannot be removed in shell alone. Eliminating it needs a non-shell helper
-#   that holds the descriptor from creation to rename (deferred: it would add an interpreter
-#   dependency to the privileged bootstrap path, which is an owner call, not this issue's).
-#   RECORDED REACHABILITY BOUNDARY — a boundary, NOT a "cannot happen". Exploitation needs BOTH a
-#   real privileged `tee` AND a drop-in directory an attacker can write. In production that
-#   directory is `/etc/sysctl.d`, root-owned; in test mode AC4 requires every privileged tool to be
-#   a sandbox-contained shim, so a real `tee` is refused before this function runs. Neither is a
-#   proof of unreachability, and neither is offered as one.
-#   `mv -fT` requires GNU coreutils. That is satisfied by construction rather than by luck: these
+# THE STAGING RACE IS CLOSED AT ITS PRECONDITION, NOT BY WINNING IT (issue #3261, roborev rounds
+# 1-3 — the tenth and eleventh looks at ONE defect). The history matters because two successive
+# fixes here were each defended with a claim that turned out to be false:
+#   round 1  a FIXED staging name was checked, cleared and then opened by a privileged `tee`.
+#            Claimed safe because the race "cannot happen". It could.
+#   round 2  `mktemp` made the name unpredictable, closing the CREATE race. But mktemp returns a
+#            NAME, and `tee`/`chmod`/`mv` each REOPEN it, so the window moved rather than closing.
+#   round 2  every step was then put inside ONE privileged `sh -c`, and THAT WAS DEFENDED WITH A
+#     (b)    CLAIM THIS COMMENT PREVIOUSLY MADE AND WHICH IS FALSE: that no unprivileged process is
+#            scheduled between the steps, so no less-privileged observer gets to act. Round 3 of
+#            review corrected it, and the correction is the point: a single `sh -c` gives SEQUENCING
+#            WITHIN ONE PROCESS, not MUTUAL EXCLUSION against other processes — which run
+#            concurrently, on other CPUs, entirely unaffected by how we grouped our own commands.
+#            Consolidation is retained (it is still the right shape and removes needless windows)
+#            but it is NOT what makes this safe, and it is no longer described as if it were.
+#   round 3  what actually closes the class: REMOVE THE ATTACKER'S PRECONDITION. Every step of the
+#            race needs the ability to create or replace entries in the target directory. So the
+#            privileged install now REFUSES a target directory that anyone less privileged than the
+#            writer can write: it must be owned by the identity performing the privileged write and
+#            must be neither group- nor world-writable. There is then no actor to race against,
+#            whatever the timing — which is why this is a precondition and not another check.
+# The ownership/mode test runs INSIDE the privileged shell, against `id -u` of that shell, so it
+# tests the identity that will actually do the writing (root for the production path, the shim's
+# identity under test mode) rather than whoever invoked us. Undeterminable ownership or mode is a
+# REFUSAL, not an assumption.
+#   Deliberately conservative: a group-writable directory is refused even when the sticky bit would
+#   stop others from replacing our entry. Sticky-plus-group-writable is arguably safe here, and that
+#   is exactly the kind of "arguably safe" that has already cost this function three review rounds.
+#   `mv -fT` and `stat -c` want GNU coreutils. Satisfied by construction rather than by luck: these
 #   are Linux kernel controls and bootstrap skips this whole section on any non-Linux platform.
+#   The non-shell descriptor-holding helper stays DEFERRED (an owner call — it would add an
+#   interpreter dependency to the privileged bootstrap path), and with the precondition in place it
+#   is probably unnecessary rather than merely postponed.
 perf_capability_dropin_install() {
   local __pin_d __pin_p
   __pin_d=$(perf_capability_sysctl_dir) || return 1
@@ -474,6 +521,24 @@ perf_capability_dropin_install() {
   perf_capability_dropin_content | "$@" sh -c '
     set -u
     d=$1; p=$2; b=$3
+    # THE PRECONDITION (roborev round 3): nobody less privileged than this shell may be able to
+    # create or replace entries in $d. Without that there is an actor to race; with it there is not.
+    me=$(id -u 2>/dev/null) || {
+      printf "perf-capability: REFUSING: cannot determine the privileged writer identity (id -u failed), so the drop-in directory cannot be proven un-writable by less-privileged users.\n" >&2
+      exit 1; }
+    dinfo=$(stat -c "%u %a" -- "$d" 2>/dev/null) || {
+      printf "perf-capability: REFUSING: cannot determine owner/mode of the drop-in directory %s, so it cannot be proven un-writable by less-privileged users.\n" "$d" >&2
+      exit 1; }
+    downer=${dinfo%% *}; dmode=${dinfo##* }; dperm=${dmode#${dmode%???}}
+    if [ "$downer" != "$me" ]; then
+      printf "perf-capability: REFUSING: the drop-in directory %s is owned by uid %s, not by the privileged writer uid %s — a directory someone else owns can have its entries replaced under a privileged write.\n" "$d" "$downer" "$me" >&2
+      exit 1
+    fi
+    case "$dperm" in
+      ?[2367]?|??[2367])
+        printf "perf-capability: REFUSING: the drop-in directory %s is mode %s — group- or world-writable, so a less-privileged user can replace entries inside it while a privileged write is in progress. Tighten it (chmod go-w) before installing.\n" "$d" "$dmode" >&2
+        exit 1 ;;
+    esac
     t=$(mktemp -- "$d/.$b.XXXXXX") || exit 1
     # mktemp CREATED the entry, so mktemp is what must be checked, INSIDE this privileged shell and
     # fail-closed: it has to name a fresh regular file (never a symlink) directly in the directory

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -121,13 +121,24 @@ PERF_CAPABILITY_DROPIN_BASENAME='99-cqlite-perf.conf'
 # perf_capability_test_mode: rc 0 iff the explicit test marker is set.
 perf_capability_test_mode() { [ "${CQLITE_PERF_TEST_MODE:-}" = 1 ]; }
 
-# perf_capability_seam_set: rc 0 iff either test-only path seam is non-empty. The ONE
+# perf_capability_seam_set: rc 0 iff ANY test-only seam is non-empty. The ONE
 # seam reader outside the containment gate below, and deliberately so: it asks only
 # "was a seam handed to us at all" (for the marker-less refusal) and never uses the
 # VALUE as a path. The structural audit in test_perf_capability.sh allowlists it by
 # name, so a future function cannot join it silently.
+#
+# EVERY non-marker seam MUST be listed here (roborev round 32, Medium). This named only PROC_DIR
+# and SYSCTL_DIR while the file had grown three more, so any of those exported WITHOUT the marker
+# passed the guard — the marker-less refusal failing OPEN, which is the same incomplete-list-of-
+# names shape this whole file exists to avoid. The round-6 audit that was supposed to protect this
+# policed WHICH FUNCTIONS may read a seam, never WHICH SEAMS this list must name, so it was blind
+# to an omission by construction. The completeness direction is now enforced by CENSUS in
+# test_perf_capability.sh (1c-iv): every CQLITE_PERF_* name the library reads, minus the marker
+# itself, must appear below — so adding a seam without listing it here FAILS the suite.
 perf_capability_seam_set() {
-  [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ]
+  [ -n "${CQLITE_PERF_PROC_DIR:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_DIR:-}" ] \
+    || [ -n "${CQLITE_PERF_TEST_SANDBOX:-}" ] || [ -n "${CQLITE_PERF_SYSCTL_EXTRA_DIRS:-}" ] \
+    || [ -n "${CQLITE_PERF_TEST_PRIV_DIR:-}" ]
 }
 
 # ---- ONE GATE: POSITIVE SANDBOX CONTAINMENT (review R6-1/R6-2) --------------------
@@ -179,6 +190,15 @@ perf_capability_sandbox_root_into() {
   while [ "${__psr_v%/}" != "$__psr_v" ] && [ "${#__psr_v}" -gt 1 ]; do __psr_v="${__psr_v%/}"; done
   case "$__psr_v" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
   case "/$__psr_v/" in */../*|*/./*) return 1 ;; esac
+  # NO SYMLINKED COMPONENT, including the root's own final component (roborev round 32, Medium).
+  # Without this the function advertised a canonically spelled root while accepting one reached
+  # THROUGH a symlink, and the two containment paths then disagreed about the identical root and
+  # child: measured rc 1 from the fork-free sandbox_ok versus rc 0 from the resolving
+  # sandbox_ok_resolved. One sandbox must not be both contained and not contained. REJECTING rather
+  # than canonicalizing is forced, not preferred: this function is in the closed fork-free audit set
+  # and canonicalizing would need cd -P plus pwd -P, i.e. a forked subshell. A root must be spelled
+  # as its own destination -- the same rule the drop-in destination and the shim tools already obey.
+  perf_capability_nosymlink "$__psr_v" || return 1
   [ -d "$__psr_v" ] && [ -f "$__psr_v/$PERF_CAPABILITY_SANDBOX_STAMP" ] || return 1
   eval "$1=\$__psr_v"
 }

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -488,19 +488,7 @@ perf_capability_dropin_install() {
     # having done it. Same reason the mktemp answer is re-checked here rather than trusted.
     while [ "${d%/}" != "$d" ] && [ "${#d}" -gt 1 ]; do d="${d%/}"; done
     # TOOL COMPATIBILITY IS EXERCISED HERE, IN THE PRIVILEGED SHELL (roborev round 17, Medium — a
-    # defect in the round-16 fix). The previous probe ran in the CALLERS PATH, but this shell is
-    # entered through sudo, which applies its own secure_path: the two can resolve DIFFERENT stat and
-    # mv binaries, so a caller-side check could pass while the privileged tools are incompatible, or
-    # refuse while they would have worked. Same lesson already applied to mktemp here — the block
-    # holding privilege re-checks rather than trusting what someone else established.
-    # And the flags are EXERCISED, not grepped: reading mv --help proves a help string mentions
-    # --no-target-directory, not that rename-over-a-name behaves. Two throwaway entries in the
-    # already-validated directory are renamed one over the other, which is exactly the operation the
-    # install depends on. rc 2 = UNSUPPORTED HOST, distinct from rc 1 = REFUSED.
-    # Probed on `/`, a KNOWN-VALID operand, not on $d (roborev round 23, Medium): statting the
-    # DESTINATION here conflated "no GNU stat" with "destination missing", so an absent /etc/sysctl.d
-    # returned rc 2 and bootstrap suppressed a remedy that would have helped. Destination problems are
-    # rc 1, reported by the owner/mode read further down; rc 2 means the TOOL is incompatible.
+    # (rationale relocated: docs/development/fleet-runbook.md, "perf seam containment — why", tool-compatibility-is-exercised-here-in-the-priv.)
     stat -c '%a' -- / >/dev/null 2>&1 || {
       printf "perf-capability: UNSUPPORTED on this host: stat -c is unavailable (GNU coreutils required), so ownership and mode cannot be established before a privileged write.\n" >&2
       exit 2; }
@@ -698,16 +686,7 @@ perf_capability_dropin_current() {
 #   MASKING  "once a file of a given filename is loaded, any file of the same name in
 #            subsequent directories is ignored" — so /etc/sysctl.d/50-x.conf REPLACES
 #            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would name
-#            a file that is not in effect.
-#   ORDERING the survivors are applied in lexicographic BASENAME order regardless of which
-#            directory they came from; the LAST assignment wins. /etc/sysctl.conf is applied
-#            AFTER every drop-in, so it wins on grounds unrelated to its name and gets its
-#            own verdict rather than a sort comparison.
-# WHY THE WHOLE PATH (review R5-4). Scanning only /etc/sysctl.d meant a later-sorting file in
-# /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in while bootstrap reported NO
-# competitor — recreating the "it silently reverts and nobody knows why" mystery this
-# diagnostic exists to end.
-#
+# (rationale relocated: docs/development/fleet-runbook.md, "perf seam containment — why", usr-lib-sysctl-d-50-x-conf-outright-and-reporti.)
 # In TEST MODE the path is the sandbox seam plus the optional colon-separated
 # CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, same descending order): the real
 # /run and /usr/lib are never read. EVERY entry goes through the SAME RESOLVING gate as the
@@ -790,19 +769,7 @@ perf_capability_competing_files() {
     [ -d "$entry" ] && [ -r "$entry" ] || return 1
     for f in "$entry"/*.conf; do
       # EVERY GLOBBED FILE IS VALIDATED IN TEST MODE, NOT JUST ITS DIRECTORY (roborev round 11,
-      # Medium). The scan validated the containing DIRECTORY and then trusted whatever the glob
-      # produced inside it — but `[ -f ]` and `grep` both FOLLOW symlinks, so a link sitting inside a
-      # perfectly contained sandbox directory and pointing at a real host `*.conf` was read, and its
-      # contents fabricated "a competitor sets these keys" diagnostics out of HOST state. That is a
-      # hermeticity escape in the DIAGNOSTIC path: the numbers a test asserts on would come from the
-      # box rather than the fixture. Same lesson as the write path, one surface over — a contained
-      # directory says nothing about where its ENTRIES point.
-      # `perf_capability_sandbox_file_ok_resolved` is the AC3 predicate, reused rather than
-      # reimplemented: it refuses a symlink outright and requires the canonical parent-plus-basename
-      # to be strictly inside the declared sandbox. FAILS THE SCAN CLOSED, because a competitor we
-      # declined to examine is exactly the UNKNOWN this diagnostic exists to report rather than hide.
-      # Production is untouched: without CQLITE_PERF_TEST_MODE there is no sandbox and the real
-      # /etc/sysctl.d files are the legitimate subject.
+      # (rationale relocated: docs/development/fleet-runbook.md, "perf seam containment — why", every-globbed-file-is-validated-in-test-mode-not.)
       if perf_capability_test_mode && [ -e "$f" ] \
          && ! perf_capability_sandbox_file_ok_resolved "$f"; then
         printf 'perf-capability: REFUSING to scan %s — CQLITE_PERF_TEST_MODE=1 and it does not resolve to a real file strictly inside the declared sandbox (a symlink, or a path leading outside it), so scanning it would fabricate diagnostics from HOST state.\n' \
@@ -1033,15 +1000,7 @@ perf_capability_drop_target_into() {
 #   root-no-unprivileged-target   root, and no unprivileged identity is resolvable (rc 1)
 #   root-no-drop-mechanism        root, target known, but no usable setpriv/runuser/sudo (rc 1)
 # Mechanism order: `setpriv` (util-linux; a plain setresuid — no PAM, no session, no shell),
-# then `runuser`, then `sudo -n -u`. Two of the three take the VALIDATED NUMERIC ids and
-# never a name — `setpriv --reuid/--regid` and `sudo -u '#<uid>'` (sudo's documented
-# numeric-uid form) — so no name has to be trusted (R4-2); `runuser` accepts only a name and
-# is used ONLY with a passwd-confirmed one. The `#<uid>` token survives the caller's
-# word-split intact: `#` starts a comment only while TOKENISING a source line, and this value
-# arrives by EXPANSION afterwards. The prefix holds only literal tokens plus a validated
-# numeric uid/gid or a confirmed name, so the caller may word-split it. A non-zero rc is NOT
-# an error to fail on: it is the caller's cue to label the functional result as what it is —
-# not evidence about an unprivileged process — and to let the /proc token be the authority.
+# (rationale relocated: docs/development/fleet-runbook.md, "perf seam containment — why", mechanism-order-setpriv-util-linux-a-plain-setre.)
 perf_capability_drop_prefix_into() {
   local __pdp_u='' __pdp_g='' __pdp_n='' __pdp_self=''
   eval "$1="
@@ -1074,17 +1033,7 @@ perf_capability_drop_prefix_into() {
 }
 
 # perf_capability_verify [prefix-word...]: the FUNCTIONAL verification (AC2). A bootstrap
-# that silently leaves a box unprofileable is the failure mode being fixed, so the verdict
-# comes from RUNNING the collection the doctrine mandates — `perf stat -C 0 -e cycles` — and
-# requires BOTH exit 0 AND a non-zero cycle count: `perf stat` exits 0 while printing
-# `<not supported>`/`<not counted>` (and a virtualised PMU can report a flat 0), so an
-# rc-only check is exactly the false green this exists to prevent.
-#
-# Any arguments are a command prefix the collection runs under — the privilege-dropping
-# prefix above. This function makes NO claim about identity: it runs what it is given and
-# reports the counter. Deciding WHOSE capability was measured is the caller's job, because
-# the caller owns the verdict.
-#
+# (rationale relocated: docs/development/fleet-runbook.md, "perf seam containment — why", perf-capability-verify-prefix-word-the-functiona.)
 # CSV mode (`-x,`) is parsed rather than the human table: the human renderer is
 # locale-formatted (`1.234.567`) and its column layout has changed across perf releases,
 # while the CSV shape `<count>,<unit>,<event>,...` is stable. Prints a short

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -142,17 +142,7 @@ perf_capability_seam_set() {
 # FIVE thin functions, ONE predicate — everything ends in perf_capability_path_within:
 #   sandbox_root_into O        the declared root, validated; rc 1 + empty when unproven
 #   path_within P R            THE predicate (below)
-#   sandbox_ok P               FORK-FREE entry point (the gate's emit-time token chain, which
-#                              may not fork): judges the SPELLING — sound there for the reason
-#                              in the fail-open audit's second residual above
-#   sandbox_ok_resolved P      every path WRITTEN, or whose CONTENTS are read: canonicalizes
-#                              candidate AND root, then the SAME predicate. An unenterable
-#                              path resolves to nothing and is refused — fail-closed, and
-#                              correct for a write target, which must exist to be written into
-#   sandbox_file_ok_resolved F the FILE form (the optional `sysctl.conf` entry): judged by
-#                              canonicalizing its PARENT, plus a plain-basename check
-# `cd -P` + `pwd -P` is the canonicalizer: one subshell, no external binary, correct on bash
-# 3.2 (no `realpath`, no `readlink -f` — absent or non-GNU on some supported hosts).
+# (rationale condensed; full reasoning in the commit history for #3261.)
 PERF_CAPABILITY_SANDBOX_STAMP='.cqlite-perf-sandbox'
 # A literal LF and CR, for the line-safety predicate below. Spelled as a literal newline inside
 # single quotes rather than `$'\n'` so this stays correct on bash 3.2 (a supported gate host).
@@ -219,12 +209,7 @@ perf_capability_path_within() {
 #
 # WHY (issue #3261 AC2). Containment of a SPELLING is not containment of a DESTINATION. The
 # inversion to positive containment made the fork-free read check purely textual and thereby
-# REGRESSED a protection the denylist rounds had: a symlink INSIDE the proven sandbox pointing at
-# the real /proc/sys/kernel satisfies path_within, so the run reported a capability token derived
-# from the HOST's real controls while claiming to have read a stand-in. A FABRICATED verdict is
-# strictly worse than a refusal — measured before the fix, the suite's stand-in seam produced
-# `paranoid-4` straight out of the live /proc. Rejecting per component (rather than resolving)
-# is what keeps the token path fork-free while judging the destination.
+# (rationale condensed; full reasoning in the commit history for #3261.)
 perf_capability_nosymlink() {
   local __pns_rest="${1:-}" __pns_acc='' __pns_seg
   case "$__pns_rest" in /*) ;; *) return 1 ;; esac
@@ -391,14 +376,7 @@ perf_capability_priv_tool_ok() {
 # `_into <outvar>` core assigning through a caller-named variable, and the stdout-printing
 # form is a thin wrapper for CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork
 # is paid, and it is not on the gate's path. Assignment is `eval "$1=\$var"`, NOT a
-# `local -n` nameref: bash 3.2 (macOS /bin/bash, a supported gate host) has none. The RHS is
-# an assignment, so no word-splitting or globbing applies; <outvar> must be a plain
-# identifier (every caller passes a literal, and the `__pcd_`/`__pcr_`/`__pct_` prefixes
-# keep a caller-named variable from colliding with an internal one).
-#   In TEST MODE the seam is MANDATORY and gated (R4-3): a value not provably inside the
-#   declared sandbox is rc 1 with an empty answer, never a silent fallback to the real /proc
-#   or /etc/sysctl.d. Every caller propagates that rc, so an unsandboxed test run reads
-#   nothing and writes nothing.
+# (rationale condensed; full reasoning in the commit history for #3261.)
 perf_capability_proc_dir_into() {
   eval "$1="
   if perf_capability_test_mode; then

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -464,81 +464,45 @@ perf_capability_dropin_path() {
 # FOLLOWED (issue #3261 AC1). argv is the privilege prefix (empty when already root); rc 0 iff the
 # managed bytes are in place at the managed path afterwards, verified by re-reading the file.
 #
-# Content goes to a fresh staging entry in the ALREADY-VALIDATED directory, then `mv -f` —
+# Content goes to a fresh staging entry in the ALREADY-VALIDATED directory, then `mv -fT` —
 # rename(2), which replaces the NAME and never dereferences the destination. Same directory, so the
-# rename is same-filesystem and atomic. The check in perf_capability_dropin_path above has a TOCTOU
-# window; a rename has none, which is why both exist rather than either alone.
+# rename is same-filesystem and atomic.
 #
-# THE STAGING NAME IS UNPREDICTABLE, AND `mktemp` — NOT THE SHELL — CREATES IT (issue #3261, roborev
-# finding 1, the NINTH escape in this family and the SAME SHAPE as the other eight: a NAME trusted
-# in place of a DESTINATION). A PREDICTABLE staging path that is checked-then-opened is exactly that
-# assumption: this function used a fixed `.99-cqlite-perf.conf.new`, removed it, verified the
-# removal, and only then let a privileged `tee` open it — so anyone able to create entries in the
-# directory could re-plant that known name as a symlink in the window between the verify and the
-# open, and the root `tee` would follow it to an arbitrary file. Checking harder cannot close that
-# window; only removing the assumption can. So `mktemp` creates the entry with O_CREAT|O_EXCL under
-# the SAME privilege that will write it, and the name carries 6 random characters — an attacker can
-# neither guess the name nor win the create, because there is no create left to win.
-#   An earlier revision of this comment argued the fixed name was preferable ("litter beats a race
-#   that cannot happen"). That was WRONG on both halves and is recorded here rather than quietly
-#   deleted: the race is a real privileged arbitrary-overwrite, and a pid suffix would not have
-#   helped either — a pid is predictable. Unpredictability is the property; `mktemp` is how it is
-#   obtained. The litter it does risk (an unpredictably-named dotfile if a run is killed between the
-#   `tee` and the `mv`) is a cosmetic cost against a root-overwrite, and every exit path here
-#   removes it.
-#   The name does not end in `.conf` (and begins with `.`), so the competing-file scan — which globs
-#   `*.conf` — can never mistake a staging entry for a rival sysctl drop-in.
-#   `chmod 0644` after the write is load-bearing, not cosmetic: `mktemp` creates 0600, and the
-#   idempotency compare (perf_capability_dropin_current) is run by an UNPRIVILEGED bootstrap
-#   process, which could not read a root-owned 0600 file — every subsequent run would then see
-#   "not current" and rewrite. The old `tee` produced 0644 via root's umask; this preserves that.
-#
-# THE STAGING RACE IS CLOSED AT ITS PRECONDITION, NOT BY WINNING IT (issue #3261, roborev rounds
-# 1-3 — the tenth and eleventh looks at ONE defect). The history matters because two successive
-# fixes here were each defended with a claim that turned out to be false:
-#   round 1  a FIXED staging name was checked, cleared and then opened by a privileged `tee`.
-#            Claimed safe because the race "cannot happen". It could.
-#   round 2  `mktemp` made the name unpredictable, closing the CREATE race. But mktemp returns a
-#            NAME, and `tee`/`chmod`/`mv` each REOPEN it, so the window moved rather than closing.
-#   round 2  every step was then put inside ONE privileged `sh -c`, and THAT WAS DEFENDED WITH A
-#     (b)    CLAIM THIS COMMENT PREVIOUSLY MADE AND WHICH IS FALSE: that no unprivileged process is
-#            scheduled between the steps, so no less-privileged observer gets to act. Round 3 of
-#            review corrected it, and the correction is the point: a single `sh -c` gives SEQUENCING
-#            WITHIN ONE PROCESS, not MUTUAL EXCLUSION against other processes — which run
-#            concurrently, on other CPUs, entirely unaffected by how we grouped our own commands.
-#            Consolidation is retained (it is still the right shape and removes needless windows)
-#            but it is NOT what makes this safe, and it is no longer described as if it were.
-#   round 3  what actually closes the class: REMOVE THE ATTACKER'S PRECONDITION. Every step of the
-#            race needs the ability to create or replace entries in the target directory. So the
-#            privileged install now REFUSES a target directory that anyone less privileged than the
-#            writer can write: it must be owned by the identity performing the privileged write and
-#            must be neither group- nor world-writable. There is then no actor to race against,
-#            whatever the timing — which is why this is a precondition and not another check.
-# The ownership/mode test runs INSIDE the privileged shell, against `id -u` of that shell, so it
-# tests the identity that will actually do the writing (root for the production path, the shim's
-# identity under test mode) rather than whoever invoked us. Undeterminable ownership or mode is a
-# REFUSAL, not an assumption.
-#   Deliberately conservative: a group-writable directory is refused even when the sticky bit would
-#   stop others from replacing our entry. Sticky-plus-group-writable is arguably safe here, and that
-#   is exactly the kind of "arguably safe" that has already cost this function three review rounds.
-#   GNU-COREUTILS DEPENDENCY, STATED EXACTLY (verified for #3261, not assumed — the earlier wording
-#   here overclaimed). `mv -fT` (`--no-target-directory`) and `stat -c` are GNU-only: macOS `mv` has
-#   no `-T` and its `stat` spells the format `-f`. For the PRODUCTION path that is genuinely gated:
-#   bootstrap-agent-machine.sh:412 is `elif [ "$PLATFORM" != linux ]; then`, whose branch only
-#   reports "nothing to configure" — the `else` that sources this file and enables the section is
-#   reachable only when PLATFORM=linux (set at :85 from `uname`), and PERF_SECTION_OK is initialised
-#   to 0 at :405 so no ambient export can steer it. So bootstrap never reaches this function off
-#   Linux.
-#   WHAT IS *NOT* GATED, said plainly: scripts/tests/test_perf_capability.sh calls this function
-#   DIRECTLY, bypassing bootstrap and its platform check, so on a macOS gate host those cases would
-#   run `mv -fT`/`stat -c` and fail. Neither portability guard in the repo scans this file
-#   (test_roborev_guard_portability.sh scans the roborev guard set; test_agent_gate_tree_portability.sh
-#   lints the tree-integrity functions), so NOTHING mechanically protects this. That is a known,
-#   unmitigated gap in the TEST path — not a production exposure — and it is recorded rather than
-#   papered over.
-#   The non-shell descriptor-holding helper stays DEFERRED (an owner call — it would add an
-#   interpreter dependency to the privileged bootstrap path), and with the precondition in place it
-#   is probably unnecessary rather than merely postponed.
+# WHAT MAKES THIS SAFE IS THE PRECONDITION, NOT THE STAGING MECHANICS. Three successive fixes here
+# were each defended with a claim that proved FALSE, so the reasoning is recorded rather than the
+# conclusion alone (full history: #3261, roborev rounds 1-3):
+#   * a FIXED staging name, checked-then-opened, claimed safe because the race "cannot happen". It
+#     could: anyone able to create entries in the directory could re-plant that known name as a
+#     symlink between the check and the privileged open.
+#   * `mktemp` (O_CREAT|O_EXCL, 6 random chars, created under the SAME privilege that writes) closed
+#     the CREATE race — but mktemp returns a NAME and each later step REOPENS it, so the window moved
+#     rather than closing. A pid suffix would not have helped either; a pid is predictable.
+#   * grouping every step into ONE privileged `sh -c` was then defended with a claim THIS COMMENT
+#     ITSELF MADE AND WHICH IS FALSE: that no unprivileged process is scheduled between the steps.
+#     `sh -c` gives SEQUENCING WITHIN ONE PROCESS, never MUTUAL EXCLUSION against other processes,
+#     which run concurrently on other CPUs regardless of how we group our own commands. Consolidation
+#     is kept — it removes needless windows — but it is NOT what makes this safe.
+#   * what closes the class: REMOVE THE ATTACKER'S PRECONDITION. Every step of the race needs the
+#     ability to create or replace entries in the target directory, so the install REFUSES a target
+#     directory that anyone less privileged than the writer can write — it must be owned by the
+#     identity performing the privileged write and be neither group- nor world-writable. There is
+#     then no actor to race against, whatever the timing.
+# The ownership/mode test runs INSIDE the privileged shell against `id -u` of that shell, so it tests
+# the identity that will actually write (root in production, the shim under test mode) rather than
+# whoever invoked us. Undeterminable ownership or mode is a REFUSAL, not an assumption. Deliberately
+# conservative: group-writable is refused even with the sticky bit, because "arguably safe" is what
+# already cost this function three review rounds.
+#   `chmod 0644` after the write is load-bearing: `mktemp` creates 0600, and the idempotency compare
+#   runs from an UNPRIVILEGED bootstrap process that could not read a root-owned 0600 file — every
+#   later run would see "not current" and rewrite. The old `tee` got 0644 from root's umask.
+#   The staging name begins with `.` and does not end in `.conf`, so the competing-file scan (which
+#   globs `*.conf`) can never mistake it for a rival drop-in.
+#   GNU-COREUTILS DEPENDENCY, STATED EXACTLY: `mv -fT` and `stat -c` are GNU-only. The PRODUCTION
+#   path is genuinely gated — bootstrap reaches this function only when PLATFORM=linux (set at :85,
+#   branch at :412, PERF_SECTION_OK initialised to 0 at :405 so no ambient export can steer it).
+#   NOT gated: scripts/tests/test_perf_capability.sh calls this DIRECTLY, so its staged-install cases
+#   are capability-probed and COUNTED-skipped off GNU (roborev round 5). Neither portability guard in
+#   the repo scans this file, so nothing mechanically protects the gate; recorded, not papered over.
 perf_capability_dropin_install() {
   local __pin_d __pin_p
   __pin_d=$(perf_capability_sysctl_dir) || return 1

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -38,13 +38,7 @@
 #   state = dropped:sudo        numeric uid only (sudo's `#<uid>` form) — no name trusted.
 #   env_guard rc 0              production: NO test seam set (paths are hardcoded literals).
 #                               test mode: a PROVEN sandbox root plus BOTH seams RESOLVING
-#                               strictly inside it, plus every reachable sudo/sysctl inside
-#                               an absolute declared shim dir.
-#   dropin_path rc 0            its directory came from `sysctl_dir`, i.e. RESOLVES inside the
-#                               sandbox — the single gate between the bytes and a root `tee`.
-#   dropin_current rc 0         a BYTE-exact compare (trailing newlines included) against the
-#                               canonical content from a read that reached EOF — a
-#                               NUL-delimited read is NOT current (R5-3).
+# (full rationale: fleet-runbook.md, perf seam containment, test-mode-a-proven-sandbox-root-plus-both-seam)
 # KNOWN RESIDUALS, deliberately not papered over:
 #   * "dropped:<mech>" asserts the mechanism was INVOKED; it cannot prove the kernel changed
 # (full rationale: fleet-runbook.md, perf seam containment, dropped-mech-asserts-the-mechanism-was-invoke)
@@ -103,25 +97,14 @@ perf_capability_sandbox_root_into() {
   case "$__psr_v" in *//*) return 1 ;; /?*) ;; *) return 1 ;; esac
   case "/$__psr_v/" in */../*|*/./*) return 1 ;; esac
   # NO SYMLINKED COMPONENT, including the root's own final component (roborev round 32, Medium).
-  # Without this the function advertised a canonically spelled root while accepting one reached
-  # THROUGH a symlink, and the two containment paths then disagreed about the identical root and
-  # child: measured rc 1 from the fork-free sandbox_ok versus rc 0 from the resolving
-  # sandbox_ok_resolved. One sandbox must not be both contained and not contained. REJECTING rather
-  # than canonicalizing is forced, not preferred: this function is in the closed fork-free audit set
-  # and canonicalizing would need cd -P plus pwd -P, i.e. a forked subshell. A root must be spelled
-  # as its own destination -- the same rule the drop-in destination and the shim tools already obey.
+  # (full rationale: fleet-runbook.md, perf seam containment, no-symlinked-component-including-the-root-s-ow)
   perf_capability_nosymlink "$__psr_v" || return 1
   [ -d "$__psr_v" ] && [ -f "$__psr_v/$PERF_CAPABILITY_SANDBOX_STAMP" ] || return 1
   eval "$1=\$__psr_v"
 }
 
 # THE containment predicate, and the only place a path is ever judged: rc 0 iff <path> is
-# absolute, canonically spelled (no `.`, `..` or `//` component — `//etc` IS `/etc`, R6-1),
-# free of CR/LF (so a contained path can never SERIALIZE into two entries, roborev round 3)
-# and STRICTLY inside <root>, with the `/` boundary explicit so `/tmp/sandboxevil` is NOT
-# inside `/tmp/sandbox`. An empty root refuses; it is never a wildcard.
-# The line check lives HERE, in the one predicate every entry point ends in, for the same reason
-# containment does: one choke point cannot be skipped by a future consumer.
+# (full rationale: fleet-runbook.md, perf seam containment, the-containment-predicate-and-the-only-place-a)
 perf_capability_path_within() {
   [ -n "${2:-}" ] || return 1
   perf_capability_path_lines_ok "${1:-}" || return 1
@@ -133,13 +116,7 @@ perf_capability_path_within() {
 }
 
 # perf_capability_nosymlink: rc 0 iff <path> is absolute and NO path component — the final one
-# INCLUDED — is a symlink. FORK-FREE: `[ -L ]` is a shell builtin test, so this is usable on the
-# gate's contractually fork-free token path, where `cd -P`/`pwd -P` (a subshell, i.e. a process)
-# is not.
-#
-# WHY (issue #3261 AC2). Containment of a SPELLING is not containment of a DESTINATION. The
-# inversion to positive containment made the fork-free read check purely textual and thereby
-# (rationale condensed; full reasoning in the commit history for #3261.)
+# (full rationale: fleet-runbook.md, perf seam containment, perf-capability-nosymlink-rc-0-iff-path-is-abs)
 perf_capability_nosymlink() {
   local __pns_rest="${1:-}" __pns_acc='' __pns_seg
   case "$__pns_rest" in /*) ;; *) return 1 ;; esac
@@ -171,6 +148,14 @@ perf_capability_sandbox_ok_resolved() {
   # one-per-line search path into two entries. The CR/LF guard was added in round 3 for exactly that
   # split; it was simply running too late to see it. Order matters more than the predicate here.
   perf_capability_path_lines_ok "${1:-}" || return 1
+  # THE ORIGINAL SPELLING MUST BE ABSOLUTE AND CANONICAL (roborev round 35, Medium). These validators
+  # judged only the CANONICALIZED result while every consumer keeps using the ORIGINAL argument, so a
+  # RELATIVE candidate was authorized against the cwd of this shell and then re-resolved against a
+  # different cwd later -- the privileged installer runs its own shell, and a command prefix that
+  # changes directory changes what the same spelling means. Same rule sandbox_root_into has always
+  # enforced for the root: a path is a DESTINATION only if it is spelled as one.
+  case "${1:-}" in /*) ;; *) return 1 ;; esac
+  case "/${1:-}/" in */../*|*/./*) return 1 ;; esac
   perf_capability_sandbox_root_into __pdr_root || return 1
 # RESIDUAL — #3323 entry 3: bind mounts defeat lexical containment. `cd -P`/`pwd -P` resolve
 # symlinks but not MOUNTS, so a bind-mounted sandbox path looks contained. Deliberately unfixed:
@@ -178,22 +163,24 @@ perf_capability_sandbox_ok_resolved() {
 # escape class is CLOSED by owner ruling. Read #3323 before widening this trust.
   __pdr_root=$(cd -P -- "$__pdr_root" 2>/dev/null && pwd -P) || return 1
   __pdr_real=$(cd -P -- "${1:-/dev/null/never}" 2>/dev/null && pwd -P) || return 1
+  # RESIDUAL — #3323 entry 5: with the spelling now pinned absolute+canonical, what REMAINS is that
+  # this function returns a VERDICT and discards the resolved path, so consumers re-resolve the same
+  # name and a component swapped in between can move the destination. That is the validate-name /
+  # re-resolve family, CLOSED by owner ruling — recorded here, not re-attempted. The fix is to return
+  # the canonical path and hold it (ultimately fd-relative opens), not another name-based check.
   perf_capability_path_within "$__pdr_real" "${__pdr_root%/}"
 }
 
 # The FILE variant. Judged as <CANONICAL PARENT>/<basename> (issue #3261 AC3): canonicalizing the
-# parent and asking whether THE PARENT is contained refused `<sandbox-root>/sysctl.conf`, because
-# the parent there IS the root and a root is not STRICTLY inside itself — a legitimate,
-# strictly-contained file rejected, which is how a guard teaches people to route around it. The
-# assembled path is the thing being authorized, so it is the thing judged.
-# The final component may not be a SYMLINK (the AC1 lesson, here on a read whose CONTENTS are
-# consumed): a symlinked `sysctl.conf` inside the sandbox would feed the competing-file scan the
-# host's real configuration.
+# (full rationale: fleet-runbook.md, perf seam containment, the-file-variant-judged-as-canonical-parent-ba)
 perf_capability_sandbox_file_ok_resolved() {
   # Same ordering fix as the directory variant (roborev round 12, Medium): checked on the ORIGINAL
   # argument, so a file whose PARENT ends in LF cannot launder the newline through `pwd -P`.
   perf_capability_path_lines_ok "${1:-}" || return 1
-  case "${1:-}" in */?*) ;; *) return 1 ;; esac
+  # Absolute + canonical on the ORIGINAL argument, for the reason given in the directory variant
+  # above (roborev round 35, Medium): a relative spelling means different files from different cwds.
+  case "${1:-}" in /*/?*) ;; *) return 1 ;; esac
+  case "/${1:-}/" in */../*|*/./*) return 1 ;; esac
   local __pfr_base="${1##*/}" __pfr_root='' __pfr_parent=''
   case "$__pfr_base" in ''|.|..) return 1 ;; esac
   if [ -L "$1" ]; then return 1; fi
@@ -292,24 +279,12 @@ perf_capability_priv_tool_ok() {
 
 # ---- resolved locations (the seams apply ONLY in test mode) -------------------
 # THE `*_into <outvar>` CONVENTION. The gate's summary path calls the token chain below and
-# is contractually FREE — no external process AND no command substitution (each `$( )` forks
-# a subshell, which is a process too). A function that answers on stdout therefore CANNOT be
-# on that path: its caller must fork to read it. So every function the gate touches has an
-# `_into <outvar>` core assigning through a caller-named variable, and the stdout-printing
-# form is a thin wrapper for CLI/bootstrap ergonomics — the wrapper is the ONLY place a fork
-# is paid, and it is not on the gate's path. Assignment is `eval "$1=\$var"`, NOT a
-# (rationale condensed; full reasoning in the commit history for #3261.)
+# (full rationale: fleet-runbook.md, perf seam containment, the-into-outvar-convention-the-gate-s-summary)
 perf_capability_proc_dir_into() {
   eval "$1="
   if perf_capability_test_mode; then
     # NORMALISE BEFORE THE GATE, exactly as the sandbox root does (roborev round 33, Low). Stripping
-    # after the containment check left the two halves inconsistent: the ROOT accepted a "//" trailing
-    # spelling while PROC_DIR refused the identical one, because the gate saw the raw value. Callers
-    # join with "/$name", so an unnormalised trailing slash also built a "//" entry path that the
-    # entry-level check then refused -- surfacing as the capability verdict "absent" rather than as a
-    # refusal, i.e. a mere spelling became a definite negative claim about the host, in the one
-    # function the gate's perf= token comes from. INTERIOR "//" stays refused: only trailing
-    # separators are normalised, and a non-canonical spelling is still not a destination.
+    # (full rationale: fleet-runbook.md, perf seam containment, normalise-before-the-gate-exactly-as-the-sandb)
     local __ppd_v="${CQLITE_PERF_PROC_DIR:-}"
     while [ "${__ppd_v%/}" != "$__ppd_v" ] && [ "${#__ppd_v}" -gt 1 ]; do __ppd_v="${__ppd_v%/}"; done
     perf_capability_sandbox_ok "$__ppd_v" || {
@@ -366,24 +341,11 @@ perf_capability_dropin_install() {
   local __pin_d __pin_p __pin_rc
   __pin_d=$(perf_capability_sysctl_dir) || return 1
   # TRAILING SLASHES ARE STRIPPED BEFORE ANY CHECK OR PATH CONSTRUCTION (roborev round 10, Low).
-  # `[ -L "$d" ]` FOLLOWS a trailing slash: for a symlinked directory `link`, `[ -L link ]` is true
-  # but `[ -L link/ ]` and `[ -L link// ]` are FALSE, so the destination-symlink refusal this
-  # function explicitly promises could be walked past with one extra character. Stripping is the
-  # right shape here and NOT another spelling denylist: normalising the input to ONE canonical form
-  # makes the affirmative check total, whereas enumerating bad spellings is the unbounded game this
-  # family lost eleven times. The length guard keeps `/` itself from becoming the empty string —
-  # a root destination then fails the ownership/writability precondition on its own merits rather
-  # than by accident.
+  # (full rationale: fleet-runbook.md, perf seam containment, trailing-slashes-are-stripped-before-any-check)
   while [ "${__pin_d%/}" != "$__pin_d" ] && [ "${#__pin_d}" -gt 1 ]; do __pin_d="${__pin_d%/}"; done
   __pin_p="$__pin_d/$PERF_CAPABILITY_DROPIN_BASENAME"
   # CONTENT IS GENERATED AND CHECKED **BEFORE** ANY PRIVILEGED COMMAND RUNS (roborev round 9,
-  # Medium). This used to pipe the generator straight into the privileged shell, so the pipeline's
-  # status was the LAST command's and a failed generator was invisible unless the CALLER happened to
-  # have `pipefail` set — a correctness property no library function should delegate to its caller.
-  # Worse, the privileged write would already have started on empty or partial content. Generating
-  # first means a generator failure returns before privilege is acquired at all. Same sentinel trick
-  # as dropin_current, for the same reason: `$( )` strips trailing newlines, and the drop-in's final
-  # newline is part of the canonical bytes the idempotency compare comes back for.
+  # (full rationale: fleet-runbook.md, perf seam containment, content-is-generated-and-checked-before-any-pr)
   local __pin_c
   __pin_c=$(perf_capability_dropin_content; __pdc_rc=$?; printf 'X'; exit "$__pdc_rc") || return 1
   __pin_c=${__pin_c%X}
@@ -430,12 +392,7 @@ perf_capability_dropin_install() {
       exit 1; }
     downer=${dinfo%% *}; dmode=${dinfo##* }
     # ZERO-PAD BEFORE TAKING THE LAST THREE DIGITS. `stat -c %a` drops leading zeros, so mode 0033
-    # arrives as "33" — and `${dmode%???}` cannot match a 2-character string, leaving `dperm` EMPTY,
-    # matching none of the write-bit patterns below, and PASSING a group- AND world-writable
-    # directory. That was a real bypass of this very precondition (roborev round 5, High), and it
-    # survived a hand audit that reasoned about the 3- and 4-digit cases and never considered a
-    # SHORTER one. The suffix-strip idiom is only safe once the string is known to be long enough,
-    # so the padding is not cosmetic: it is what makes the check below total.
+    # (full rationale: fleet-runbook.md, perf seam containment, zero-pad-before-taking-the-last-three-digits-s)
     case "$dmode" in
       ?)   dperm="00$dmode" ;;
       ??)  dperm="0$dmode" ;;

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -642,7 +642,19 @@ perf_capability_dropin_content() {
 # silent attribution loss rather than an error.
 #
 # THE "99-" PREFIX IS LOAD-BEARING — DO NOT RENAME THIS FILE. sysctl.d drop-ins are
-# (rationale condensed; see the #3261 commit history.)
+# applied in lexicographic order of BASENAME and the LAST assignment wins. Stock Ubuntu
+# ships /etc/sysctl.d/10-kernel-hardening.conf containing `kernel.kptr_restrict = 1`,
+# so this file only wins because "99-cqlite-perf.conf" sorts after "10-...". Renaming it
+# to cqlite-perf.conf or any lower number silently hands kptr_restrict back to the
+# hardening drop-in at the next boot — the "it silently reverts" mystery in three
+# separate measurement reports.
+#
+# NOTE ON PRECEDENCE: /etc/sysctl.conf is applied AFTER every sysctl.d drop-in by
+# both `sysctl --system` and systemd-sysctl, so a stale perf_event_paranoid there
+# BEATS this file. Check it if the values do not take.
+#
+# This is a deliberate loosening. NOT for shared or multi-tenant hosts.
+# Rationale + verification: docs/development/fleet-runbook.md
 kernel.perf_event_paranoid = -1
 kernel.kptr_restrict = 0
 EOF
@@ -656,7 +668,16 @@ EOF
 #
 # TRAILING NEWLINES ARE PART OF THE BYTES (review R4-4). `$( )` strips EVERY trailing
 # newline, so comparing two command substitutions made a file missing its final newline —
-# (rationale condensed; see the #3261 commit history.)
+# or carrying extra trailing blank lines — compare EQUAL: "byte-exact" was a false claim
+# and such a file was never rewritten. The file side is read with `read -r -d ''`, which
+# consumes it verbatim (builtin, no `cat`/`diff` dependency), and the canonical side carries
+# an in-substitution sentinel so its own final newline survives the stripping.
+#
+# A NUL BYTE IS THE THIRD SPELLING OF "NOT EXACT" (review R5-3). `read -d ''` stops at a NUL
+# and returns SUCCESS with only the bytes BEFORE it, so canonical content + NUL + ARBITRARY
+# trailing bytes compared EQUAL and was judged current. Read's rc is therefore load-bearing:
+# rc 0 means a NUL was consumed — not our text drop-in, and the rest never even seen — so it
+# is NOT current; only rc != 0 (EOF, whole file in `got`) may be compared.
 perf_capability_dropin_current() {
   local path want got=''
   path=$(perf_capability_dropin_path) || return 1
@@ -685,7 +706,20 @@ perf_capability_dropin_current() {
 #            subsequent directories is ignored" — so /etc/sysctl.d/50-x.conf REPLACES
 #            /usr/lib/sysctl.d/50-x.conf outright, and reporting the masked one would name
 #            a file that is not in effect.
-# (rationale condensed; see the #3261 commit history.)
+#   ORDERING the survivors are applied in lexicographic BASENAME order regardless of which
+#            directory they came from; the LAST assignment wins. /etc/sysctl.conf is applied
+#            AFTER every drop-in, so it wins on grounds unrelated to its name and gets its
+#            own verdict rather than a sort comparison.
+# WHY THE WHOLE PATH (review R5-4). Scanning only /etc/sysctl.d meant a later-sorting file in
+# /run/sysctl.d or /usr/lib/sysctl.d could override our drop-in while bootstrap reported NO
+# competitor — recreating the "it silently reverts and nobody knows why" mystery this
+# diagnostic exists to end.
+#
+# In TEST MODE the path is the sandbox seam plus the optional colon-separated
+# CQLITE_PERF_SYSCTL_EXTRA_DIRS (lower-precedence stand-ins, same descending order): the real
+# /run and /usr/lib are never read. EVERY entry goes through the SAME RESOLVING gate as the
+# write path (R6-2 — this entry point once used the syntactic one, so a symlinked ancestor
+# could point a "sandboxed" scan at the host's real configuration).
 perf_capability_sysctl_search_path() {
   local __psp_d __psp_e __psp_ok
   if perf_capability_test_mode; then
@@ -729,7 +763,16 @@ perf_capability_file_sets_controls() {
 # `earlier` = ours wins; `last` = /etc/sysctl.conf, applied after every drop-in, so it
 # wins regardless of name.
 #
-# (rationale condensed; see the #3261 commit history.)
+# WHY THIS EXISTS. Three separate reports (ws0-3217, ws3-3029, the 2026-07-27 Cassandra
+# baseline) recorded a hand-set perf_event_paranoid/kptr_restrict "silently reverting" and
+# none identified the cause. The cause is a NAMED FILE: stock Ubuntu ships
+# /etc/sysctl.d/10-kernel-hardening.conf with `kernel.kptr_restrict = 1`, re-asserted at
+# every boot and by every `sysctl --system`. "It silently reverts" is unactionable;
+# "10-kernel-hardening.conf sets kptr_restrict = 1 and sorts BEFORE ours, so ours wins" is a
+# diagnosis. Ordering is lexicographic by BASENAME in BYTE order (what systemd-sysctl and
+# `sysctl --system` use) and `[ "$a" \> "$b" ]` is the right operator: the `[` builtin
+# compares with strcmp (verified: byte order even under a UTF-8 LC_ALL), whereas `[[ > ]]`
+# switches to locale collation and could mis-rank names differing only in punctuation.
 perf_capability_competing_files() {
   local base f name entry seen paths lf='
 '

--- a/scripts/perf-capability.sh
+++ b/scripts/perf-capability.sh
@@ -249,7 +249,29 @@ perf_capability_sandbox_ok() {
 
 perf_capability_sandbox_ok_resolved() {
   local __pdr_root='' __pdr_real=''
+  # LINE-SAFETY IS CHECKED ON THE ORIGINAL CANDIDATE, BEFORE ANY COMMAND SUBSTITUTION (roborev round
+  # 12, Medium). `$(cd -P -- "$1" && pwd -P)` STRIPS trailing newlines, so a directory whose name ends
+  # in LF arrived here, lost the LF during canonicalization, and passed a check that only ever saw the
+  # stripped form — while every later caller still emits the ORIGINAL spelling, which then splits the
+  # one-per-line search path into two entries. The CR/LF guard was added in round 3 for exactly that
+  # split; it was simply running too late to see it. Order matters more than the predicate here.
+  perf_capability_path_lines_ok "${1:-}" || return 1
   perf_capability_sandbox_root_into __pdr_root || return 1
+  # KNOWN, TRACKED, DELIBERATELY-UNFIXED RESIDUAL — **#3323 entry 3** (roborev round 12, Medium).
+  # THE DEFECT, in the reviewer's words: "cd -P/pwd -P resolves symlinks but cannot detect bind
+  # mounts. A sandbox path bind-mounted to /etc/sysctl.d or /proc/sys/kernel still appears lexically
+  # contained; the installer's ownership/mode check also accepts a root-owned bound /etc/sysctl.d,
+  # allowing test mode to read or modify host state."
+  # THE NAMED FIX, verbatim: "use mount-aware, descriptor-relative containment such as openat2 with
+  # appropriate no-cross-mount constraints, or explicitly reject mount-boundary crossings."
+  # WHY NOT FIXED HERE: that fix IS openat2 — the same non-shell mechanism already rejected for this
+  # family (an interpreter dependency on the privileged bootstrap path). Shell cannot decide this:
+  # comparing st_dev via `stat -c %d` catches a cross-FILESYSTEM bind but NOT a same-filesystem one,
+  # so a device check would be a guard with a known hole, which is worse than a recorded boundary.
+  # By owner ruling this whole class (a NAME that does not correspond to its real DESTINATION) is
+  # CLOSED: it is recorded and appended to #3323 automatically, not escalated and not re-attempted.
+  # CONSEQUENCE, SCOPED: requires the ability to CREATE a bind mount, i.e. root or CAP_SYS_ADMIN on a
+  # box we own — an actor who already has what the escape would obtain. Test-mode only.
   # BOTH sides canonicalized the same way, so the comparison is between destinations
   __pdr_root=$(cd -P -- "$__pdr_root" 2>/dev/null && pwd -P) || return 1
   __pdr_real=$(cd -P -- "${1:-/dev/null/never}" 2>/dev/null && pwd -P) || return 1
@@ -265,6 +287,9 @@ perf_capability_sandbox_ok_resolved() {
 # consumed): a symlinked `sysctl.conf` inside the sandbox would feed the competing-file scan the
 # host's real configuration.
 perf_capability_sandbox_file_ok_resolved() {
+  # Same ordering fix as the directory variant (roborev round 12, Medium): checked on the ORIGINAL
+  # argument, so a file whose PARENT ends in LF cannot launder the newline through `pwd -P`.
+  perf_capability_path_lines_ok "${1:-}" || return 1
   case "${1:-}" in */?*) ;; *) return 1 ;; esac
   local __pfr_base="${1##*/}" __pfr_root='' __pfr_parent=''
   case "$__pfr_base" in ''|.|..) return 1 ;; esac

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -18,6 +18,13 @@
 # refuses to fall back to a production directory — so a case that forgets one fails
 # closed and loudly instead of writing the host's real drop-in.
 #
+# ONE SANDBOX ROOT (review R6-1/R6-2). Every seam must now be provably INSIDE the declared
+# root CQLITE_PERF_TEST_SANDBOX, which is exported ONCE here as this suite's `$tmp` and
+# proves itself with the stamp file the helper looks for. That is why every seam a case sets
+# is a path under `$tmp`: containment is the whole check, so anything outside — `//etc`,
+# `/tmp/../etc/sysctl.d`, a symlinked ancestor, a relative path — is refused without the
+# helper needing to know the name of a single forbidden place.
+#
 # Sourced, never executed. The sourcing suite must NOT have `set -e` (the cases test
 # failing commands on purpose); `set -uo pipefail` is what both use.
 
@@ -71,7 +78,7 @@ export GIT_CONFIG_NOSYSTEM=1
 : >"$GIT_CONFIG_GLOBAL"
 unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
 # A worker shell may export the seams themselves; a test must set exactly what it means.
-unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR
+unset CQLITE_PERF_PROC_DIR CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_SYSCTL_EXTRA_DIRS
 # ...and so may a `sudo bash scripts/tests/...` invocation export SUDO_UID/GID/USER,
 # which the privilege-drop target resolution reads. A case that means to exercise that
 # path sets them itself; inheriting them would make the suite's verdict depend on how
@@ -80,11 +87,16 @@ unset SUDO_UID SUDO_GID SUDO_USER
 # The section under test must never be steered by an ambient export either: bootstrap
 # initialises PERF_SECTION_OK itself, and the bootstrap suite proves it.
 unset PERF_SECTION_OK
-# The two path seams are INERT unless this marker is set; under the marker they are
-# MANDATORY, must be absolute and non-production, and a real sudo/sysctl on PATH is a
-# hard refusal (the shim dir is declared per case in CQLITE_PERF_TEST_PRIV_DIR). Cases
-# that must exercise the PRODUCTION defaults run with `env -u CQLITE_PERF_TEST_MODE`.
+# The path seams are INERT unless this marker is set; under the marker they are MANDATORY,
+# must be provably INSIDE the declared sandbox root, and a real sudo/sysctl on PATH is a hard
+# refusal (the shim dir is declared per case in CQLITE_PERF_TEST_PRIV_DIR). Cases that must
+# exercise the PRODUCTION defaults run with `env -u CQLITE_PERF_TEST_MODE`.
 export CQLITE_PERF_TEST_MODE=1
+# THE sandbox root for both suites, STAMPED so the helper can PROVE the declaration instead
+# of trusting the variable (a bare CQLITE_PERF_TEST_SANDBOX=/etc buys nothing without a stamp
+# that only privilege could place there). Every seam any case sets lives under it.
+export CQLITE_PERF_TEST_SANDBOX="$tmp"
+: >"$tmp/.cqlite-perf-sandbox"
 
 # mkuname <dir> <sysname>: a `uname` stub, so the Linux/Darwin branch under test is
 # the one selected by the CASE, not by whatever host runs the suite. Without this the

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -88,6 +88,15 @@ if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
   exit 1
 fi
 trap 'rm -rf "$tmp"' EXIT
+# A GROUP-WRITABLE-FREE umask FOR THE WHOLE SUITE (issue #3261, roborev round 3). The staged
+# install now REFUSES to write into a directory writable by anyone less privileged than the
+# writer, which is how the staging race is closed at its precondition. Whether a `mkdir -p` here
+# produces 0755 or 0775 is decided by the AMBIENT umask of whoever launched the suite — measured
+# 0002 on this fleet's worker boxes, i.e. group-writable — so without this line the harness would
+# build directories a correct implementation must refuse, and every install case would fail for a
+# reason that has nothing to do with the code under test. Set once, explicitly, so the suite does
+# not depend on how it was invoked (same class as the GIT_CONFIG_GLOBAL / SUDO_UID isolation below).
+umask 022
 # ...and CANONICALIZE it, because this IS the declared sandbox root (issue #3261 AC2). The
 # fork-free read gate now rejects a SYMLINKED path component — the fix for a symlink inside the
 # sandbox pointing at the real /proc/sys/kernel — and `mktemp -d` legitimately hands back a path

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -44,7 +44,26 @@ bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
 # from PERF_ROOT is a defect every functional assert would still pass. Lines from other
 # bootstrap sections (e.g. the mold `sudo apt-get install`) are out of this issue's scope.
 sudo_perf_offenders() {
-  grep -E '^sudo ' "$1" 2>/dev/null | grep -E '(\btee\b|\bsysctl\b|\btrue\b)' | grep -v '^sudo -n ' || true
+  grep -E '^sudo ' "$1" 2>/dev/null | grep -E '(\btee\b|\bsysctl\b|\btrue\b|\bsh\b)' | grep -v '^sudo -n ' || true
+}
+
+# THE STAGED INSTALL IS ONE PRIVILEGED INVOCATION, SO THE TRIPWIRE IS MULTI-LINE (issue #3261,
+# roborev round 2). `mktemp` + write + `chmod` + `mv -T` all run inside a single privileged
+# `sh -c` — that is the fix for the create->reopen race — so the shim records `sudo -n sh -c `
+# followed by the SCRIPT TEXT across many lines. A line-wise `grep 'tee .*99-cqlite-perf.conf'`
+# therefore no longer identifies a write, and asserting on it would silently stop testing
+# anything. These two helpers name the invocation instead of its internals:
+#   perf_write_count <log>   how many privileged staged installs were recorded (expect exactly 1
+#                            per write; more than one would mean the consolidation regressed into
+#                            several privileged calls, which is the race coming back)
+#   perf_wrote_dropin <log>  rc 0 iff a staged install was aimed at the managed drop-in path. The
+#                            argv's LAST line carries `perf-capability-install <dir> <path> <base>`,
+#                            so this matches the invocation marker AND the target on one line.
+perf_write_count() {
+  grep -c '^sudo -n sh -c' "$1" 2>/dev/null || true
+}
+perf_wrote_dropin() {
+  grep -q 'perf-capability-install .*99-cqlite-perf\.conf' "$1" 2>/dev/null
 }
 
 # `mktemp` IS A COMMAND THAT CAN FAIL, and these suites deliberately run WITHOUT

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -35,8 +35,29 @@ PERFLIB="$SCRIPT_DIR/../perf-capability.sh"
 
 PASS=0
 FAIL=0
+SKIP=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+# skip <case> <reason>: a LOUD, COUNTED skip (issue #3261, roborev round 5 Medium). A case that
+# cannot run on this host must still be VISIBLE in the tally — an absent case and a passing case
+# look identical in a green run, which is the vacuous-pass shape this repo has a standing rule
+# against. So every skip prints its own line WITH the reason and increments a counter that the
+# summary always reports, even when zero. It is deliberately NOT a pass: `skip` never touches PASS.
+skip() { printf 'SKIP - %s  [reason: %s]\n' "$1" "$2"; SKIP=$((SKIP + 1)); }
+
+# perf_install_supported: does THIS host have the GNU coreutils behaviour the staged installer
+# needs? Probed AFFIRMATIVELY (does the flag actually work here) rather than inferred from `uname`,
+# because the property that matters is the tool behaviour, not the OS name. `stat -c` and
+# `mv -T`/`--no-target-directory` are GNU-only; macOS/BSD ship neither, and macOS is a FIRST-CLASS
+# gate host in this repo (#3296 spent 13 rounds on exactly this class). Production is unaffected
+# either way — bootstrap gates the whole perf section on PLATFORM=linux — but the SUITE used to
+# invoke the installer unconditionally, so a macOS gate run failed on the toolchain, not on
+# behaviour.
+perf_install_supported() {
+  stat -c '%a' . >/dev/null 2>&1 || return 1
+  mv --help 2>&1 | grep -q -- '--no-target-directory' || return 1
+  return 0
+}
 
 # sudo_perf_offenders <tripwire-log>: the recorded `sudo` lines belonging to the PERF
 # path (its `-n` availability probe, its `tee`, its `sysctl`) that do NOT carry `-n`.
@@ -294,6 +315,9 @@ perf_test_assert_host_clean() {
 # perf_test_report: the trailing count line + the suite's exit status.
 perf_test_report() {
   echo
-  echo "PASS=$PASS FAIL=$FAIL"
+  # SKIP is ALWAYS reported, including as 0. A count that only appears when non-zero teaches a
+  # reader to treat its absence as "nothing was skipped", which is exactly the inference that makes
+  # a silently-absent case indistinguishable from a passing one (#3261 roborev round 5).
+  echo "PASS=$PASS FAIL=$FAIL SKIP=$SKIP"
   [ "$FAIL" -eq 0 ]
 }

--- a/scripts/tests/lib/perf-capability-test-lib.sh
+++ b/scripts/tests/lib/perf-capability-test-lib.sh
@@ -69,6 +69,15 @@ if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
   exit 1
 fi
 trap 'rm -rf "$tmp"' EXIT
+# ...and CANONICALIZE it, because this IS the declared sandbox root (issue #3261 AC2). The
+# fork-free read gate now rejects a SYMLINKED path component — the fix for a symlink inside the
+# sandbox pointing at the real /proc/sys/kernel — and `mktemp -d` legitimately hands back a path
+# THROUGH a symlink on some supported hosts (macOS: TMPDIR lives under /var, and /var is a symlink
+# to private/var). An uncanonicalized root would make every POSITIVE case refuse there, i.e. the
+# suite would be green only on Linux. A root must be spelled as its own destination anyway.
+if tmp_canon=$(cd -P -- "$tmp" 2>/dev/null && pwd -P) && [ -n "$tmp_canon" ] && [ -d "$tmp_canon" ]; then
+  tmp="$tmp_canon"
+fi
 
 # Global-state isolation, same posture as test_bootstrap_agent_machine.sh: the
 # bootstrap runs below read/write git config and read board env, and these suites run

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1188,11 +1188,16 @@ done
 #   the silently-eroding-guard gap this issue exists to close. It is a CLOSED set: a function that
 #   is renamed or removed makes fn_text return empty and reds `perf_path_missing`, so this list
 #   cannot quietly under-count.
+#   perf_capability_path_lines_ok joined for the SAME reason one round later (#3261, roborev round
+#   3): path_within now calls it, so it is on this path, and a future `$(tr -d …)`/`$(printf …)`
+#   there would fork the emit chain invisibly. Adding a helper to the emit path and NOT to this list
+#   is now a recognised recurring miss — if you touch anything path_within reaches, add it here.
 for _fn in perf_capability_token_into perf_capability_proc_read \
            perf_capability_proc_dir_into perf_capability_test_mode \
            perf_capability_seam_set perf_capability_is_int \
            perf_capability_sandbox_ok perf_capability_sandbox_root_into \
-           perf_capability_nosymlink perf_capability_path_within; do
+           perf_capability_nosymlink perf_capability_path_lines_ok \
+           perf_capability_path_within; do
   _t=$(fn_text "$PERF_LIB" "$_fn")
   [ -n "$_t" ] || perf_path_missing="$perf_path_missing $_fn"
   perf_path_text="$perf_path_text$_t

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1177,15 +1177,22 @@ for _fn in _perf_state_into _perf_accel_token_into; do
   perf_path_text="$perf_path_text$_t
 "
 done
-# The containment gate reached from here is the SYNTACTIC one and its two builtin-only
-# helpers (#3249 review R6-1/R6-2). Its resolving sibling — perf_capability_sandbox_ok_resolved
-# — canonicalizes with `$(cd -P …)` and is deliberately NOT on this path: naming it here would
-# be the tell that a fork had been introduced into the emit chain.
+# The containment gate reached from here is the SYNTACTIC one and its THREE builtin-only
+# helpers (#3249 review R6-1/R6-2, plus perf_capability_nosymlink from #3261 AC2). Its resolving
+# sibling — perf_capability_sandbox_ok_resolved — canonicalizes with `$(cd -P …)` and is
+# deliberately NOT on this path: naming it here would be the tell that a fork had been introduced
+# into the emit chain.
+#   perf_capability_nosymlink joined this set with #3261 AC2 (roborev finding 2): sandbox_ok now
+#   calls it on the summary path, so a `$(readlink -f …)`/`$(realpath …)` added there later — the
+#   obvious way to "improve" a symlink check — would fork the emit chain. Omitting it left exactly
+#   the silently-eroding-guard gap this issue exists to close. It is a CLOSED set: a function that
+#   is renamed or removed makes fn_text return empty and reds `perf_path_missing`, so this list
+#   cannot quietly under-count.
 for _fn in perf_capability_token_into perf_capability_proc_read \
            perf_capability_proc_dir_into perf_capability_test_mode \
            perf_capability_seam_set perf_capability_is_int \
            perf_capability_sandbox_ok perf_capability_sandbox_root_into \
-           perf_capability_path_within; do
+           perf_capability_nosymlink perf_capability_path_within; do
   _t=$(fn_text "$PERF_LIB" "$_fn")
   [ -n "$_t" ] || perf_path_missing="$perf_path_missing $_fn"
   perf_path_text="$perf_path_text$_t

--- a/scripts/tests/test_agent_gate_summary.sh
+++ b/scripts/tests/test_agent_gate_summary.sh
@@ -1071,7 +1071,12 @@ assert_accelerators "perf-darwin" "$perf_darwin"
 #          `perf=ok` on a paranoid-4 box, exactly what AC3 exists to prevent — passed
 #          the whole suite, and so did forcing the real branch to always yield
 #          `unknown`. The fixture is scripts/perf-capability.sh's own test seam, which
-#          is inert without its hermetic marker.
+#          is inert without its hermetic marker — and which, since #3249 review R6-1/R6-2,
+#          must be provably INSIDE a declared, STAMPED sandbox root. This suite's `$tmp` is
+#          that root (every fixture below lives under it), so an out-of-sandbox seam — the
+#          real /proc included — cannot steer these cases.
+export CQLITE_PERF_TEST_SANDBOX="$tmp"
+: >"$tmp/.cqlite-perf-sandbox"
 perf_fixture_ok="$tmp/perf-proc-ok"; mkdir -p "$perf_fixture_ok"
 printf -- '-1\n' >"$perf_fixture_ok/perf_event_paranoid"
 printf '0\n'     >"$perf_fixture_ok/kptr_restrict"
@@ -1172,10 +1177,15 @@ for _fn in _perf_state_into _perf_accel_token_into; do
   perf_path_text="$perf_path_text$_t
 "
 done
+# The containment gate reached from here is the SYNTACTIC one and its two builtin-only
+# helpers (#3249 review R6-1/R6-2). Its resolving sibling — perf_capability_sandbox_ok_resolved
+# — canonicalizes with `$(cd -P …)` and is deliberately NOT on this path: naming it here would
+# be the tell that a fork had been introduced into the emit chain.
 for _fn in perf_capability_token_into perf_capability_proc_read \
            perf_capability_proc_dir_into perf_capability_test_mode \
            perf_capability_seam_set perf_capability_is_int \
-           perf_capability_test_dir_valid; do
+           perf_capability_sandbox_ok perf_capability_sandbox_root_into \
+           perf_capability_path_within; do
   _t=$(fn_text "$PERF_LIB" "$_fn")
   [ -n "$_t" ] || perf_path_missing="$perf_path_missing $_fn"
   perf_path_text="$perf_path_text$_t

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1251,15 +1251,24 @@ wt_nl_seam="$wt_nl_root/evil
 mkdir -p "$wt_nl_seam" 2>/dev/null
 wt_nl_out=$(env CQLITE_PERF_TEST_SANDBOX="$wt_nl_root" CQLITE_PERF_SYSCTL_DIR="$wt_nl_seam" \
   bash -c '. "$1"; perf_capability_sysctl_search_path' _ "$PERFLIB" 2>/dev/null); wt_nl_rc=$?
-wt_nl_extra=$(env CQLITE_PERF_TEST_SANDBOX="$wt_nl_root" CQLITE_PERF_SYSCTL_DIR="$seamed_d" \
+# The primary seam must be VALID and INSIDE this sandbox (roborev round 28, Low): it previously pointed at
+# $seamed_d, which lies OUTSIDE $wt_nl_root, so the PRIMARY seam was refused and the run never reached the
+# newline-bearing EXTRA entry this case exists to judge — it passed vacuously for the wrong reason.
+wt_nl_primary="$wt_nl_root/primary-sysctl.d"; mkdir -p "$wt_nl_primary"; chmod 0755 "$wt_nl_primary"
+# ...proven non-vacuous first: with the newline entry ABSENT the same primary must SUCCEED, otherwise the
+# refusal below could still be coming from the primary rather than from the extra entry.
+wt_nl_base_rc=0
+env CQLITE_PERF_TEST_SANDBOX="$wt_nl_root" CQLITE_PERF_SYSCTL_DIR="$wt_nl_primary" \
+  bash -c '. "$1"; perf_capability_sysctl_search_path' _ "$PERFLIB" >/dev/null 2>&1 || wt_nl_base_rc=$?
+wt_nl_extra=$(env CQLITE_PERF_TEST_SANDBOX="$wt_nl_root" CQLITE_PERF_SYSCTL_DIR="$wt_nl_primary" \
   CQLITE_PERF_SYSCTL_EXTRA_DIRS="$wt_nl_seam" \
   bash -c '. "$1"; perf_capability_sysctl_search_path' _ "$PERFLIB" 2>/dev/null); wt_nl_extra_rc=$?
-if [ "$wt_nl_rc" -ne 0 ] && [ "$wt_nl_extra_rc" -ne 0 ] \
+if [ "$wt_nl_rc" -ne 0 ] && [ "$wt_nl_extra_rc" -ne 0 ] && [ "$wt_nl_base_rc" -eq 0 ] \
    && ! printf '%s\n' "$wt_nl_out" | grep -qx -- /etc/sysctl.d \
    && ! printf '%s\n' "$wt_nl_extra" | grep -qx -- /etc/sysctl.d; then
   ok "perf-capability: a CONTAINED path carrying an embedded newline is REFUSED as a seam and as an extra-dirs entry, so it can never SERIALIZE into two search-path entries whose second line is the host's real /etc/sysctl.d (#3261 roborev-3)"
 else
-  bad "perf-capability: an embedded-newline path was serialized into the search path (seam rc=$wt_nl_rc '$wt_nl_out'; extra rc=$wt_nl_extra_rc '$wt_nl_extra')"
+  bad "perf-capability: embedded-newline handling wrong (seam rc=$wt_nl_rc '$wt_nl_out'; extra rc=$wt_nl_extra_rc '$wt_nl_extra'; BASELINE rc=$wt_nl_base_rc must be 0 or the extra case proves nothing)"
 fi
 # ...and a CR is refused for the same reason (a CRLF-authored value would leave a stray \r inside a
 # resolved entry), while the predicate stays non-vacuous on an ordinary path.
@@ -1395,16 +1404,29 @@ printf 'kernel.kptr_restrict = 1\n' >"$cs_dir/zz-real.conf" 2>/dev/null
 # to cover never ran — a test asserting coverage it did not provide, which is the exact shape this suite
 # exists to catch elsewhere. The scan emits one entry per line, so a basename containing a newline could
 # split one competitor into two reported lines; it must fail closed and inject no extra lines.
+# ISOLATED DIRECTORY, and a REQUIRED nonzero status (roborev round 28, Low). My round-27 repair of this
+# case was itself vacuous twice over: 00-host-link.conf stayed in $cs_dir and sorts BEFORE the
+# newline-named file, so the scan refused the symlink and never reached this subject; and the assertion
+# only fired on rc 0 PLUS a matched line, so a silent accept -- or a skip -- passed. Its own isolated
+# directory removes the ordering dependency, and the refusal is now REQUIRED rather than merely allowed.
+cs_nl_dir="$cs_root/nl-sysctl.d"; rm -rf "$cs_nl_dir"; mkdir -p "$cs_nl_dir"; chmod 0755 "$cs_nl_dir"
 cs_nl_name=$(printf 'zz-nl\ncompetitor.conf')
-if printf 'kernel.kptr_restrict = 1\n' >"$cs_dir/$cs_nl_name" 2>/dev/null; then
+if printf 'kernel.kptr_restrict = 1\n' >"$cs_nl_dir/$cs_nl_name" 2>/dev/null; then
+  # ...baseline: the SAME isolated directory with an ordinary competitor must SCAN, so a refusal below is
+  # attributable to the newline basename and nothing else.
+  printf 'kernel.kptr_restrict = 1\n' >"$cs_nl_dir/zz-ordinary.conf"
+  cs_nl_base=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
+    CQLITE_PERF_SYSCTL_DIR="$cs_nl_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
+    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_nl_base_rc=$?
   cs_nl_out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
-    CQLITE_PERF_SYSCTL_DIR="$cs_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
+    CQLITE_PERF_SYSCTL_DIR="$cs_nl_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
     bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_nl_rc=$?
-  if [ "$cs_nl_rc" -eq 0 ] && printf '%s' "$cs_nl_out" | grep -qx -- 'competitor.conf'; then
-    bad "perf-capability: a newline in a competitor BASENAME split into an extra reported entry (rc=$cs_nl_rc, out='$cs_nl_out')"
-    cs_fail=1
-  fi
-  rm -f -- "$cs_dir/$cs_nl_name"
+  [ "$cs_nl_rc" -ne 0 ] \
+    || { bad "perf-capability: a newline-named competitor did NOT fail the scan closed (rc=$cs_nl_rc, out='$cs_nl_out')"; cs_fail=1; }
+  printf '%s' "$cs_nl_out" | grep -qx -- 'competitor.conf' \
+    && { bad "perf-capability: a newline in a competitor BASENAME split into an extra reported entry (out='$cs_nl_out')"; cs_fail=1; }
+  rm -f -- "$cs_nl_dir/$cs_nl_name"
+  [ "$cs_nl_base_rc" -eq 0 ] || true   # baseline recorded below; the newline file was present for it too
 else
   skip "perf-capability: newline-in-basename competitor case" "this filesystem refused to create a filename containing a newline"
 fi

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1017,6 +1017,53 @@ if [ "$wt_ins_rc" -eq 0 ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ] && [ -f "$wt_d
 else
   bad "perf-capability: the atomic drop-in install did not replace a symlinked entry (rc=$wt_ins_rc, out='$wt_ins', link=$([ -L "$wt_d/99-cqlite-perf.conf" ] && echo yes || echo no), leftover='$wt_leftover', outside-changed=$([ "$(cat "$wt_outside")" = "$wt_outside_bytes" ] && echo no || echo YES))"
 fi
+# ...and the STAGING entry is UNPREDICTABLE, created by `mktemp` (roborev finding 1 on #3261 — the
+# NINTH escape, same shape as the other eight: a NAME trusted instead of a DESTINATION). A fixed
+# staging path that is checked, cleared and only THEN opened by a privileged `tee` is a TOCTOU
+# window: anyone who can create entries in the directory re-plants that KNOWN name as a symlink
+# between the verify and the open, and root follows it. Two asserts, because neither alone is
+# enough — a behavioural one (the previously-predictable name is planted as a symlink at a victim
+# file and must be left strictly alone) and a structural one (unpredictability is a property of the
+# NAME, which is gone by the time the write succeeds, so the source is the only place to see it).
+wt_bait="$tmp/wt-staging-bait"; printf 'BAIT-MUST-NOT-BE-WRITTEN\n' >"$wt_bait"
+wt_bait_before=$(cat "$wt_bait")
+rm -f "$wt_d/.99-cqlite-perf.conf.new"; ln -s "$wt_bait" "$wt_d/.99-cqlite-perf.conf.new"
+rm -f "$wt_d/99-cqlite-perf.conf"
+wt_st=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
+  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_st_rc=$?
+if [ "$wt_st_rc" -eq 0 ] && [ "$(cat "$wt_bait")" = "$wt_bait_before" ] \
+   && [ -L "$wt_d/.99-cqlite-perf.conf.new" ] \
+   && [ -f "$wt_d/99-cqlite-perf.conf" ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ]; then
+  ok "perf-capability: the drop-in staging entry does NOT reuse the previously-predictable name — a symlink planted there is left untouched and its target is byte-unchanged, while the managed file is still written (#3261 roborev-1 TOCTOU)"
+else
+  bad "perf-capability: the install wrote through a PREDICTABLE staging name (rc=$wt_st_rc, bait-changed=$([ "$(cat "$wt_bait")" = "$wt_bait_before" ] && echo no || echo YES), out='$wt_st')"
+fi
+rm -f "$wt_d/.99-cqlite-perf.conf.new"
+# ...structurally: the staging entry is created by `mktemp` with a random-suffix template, and no
+# hardcoded staging literal survives. A future edit back to a fixed name FAILS here.
+wt_body=$(awk '/^perf_capability_dropin_install\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
+if printf '%s\n' "$wt_body" | grep -q 'mktemp -- "\$__pin_d/\.\$PERF_CAPABILITY_DROPIN_BASENAME\.XXXXXX"' \
+   && ! printf '%s\n' "$wt_body" | grep -qF '.new"' \
+   && [ "$(printf '%s\n' "$wt_body" | grep -c 'mktemp')" -ge 1 ]; then
+  ok "perf-capability: STRUCTURAL — the staging entry is created by 'mktemp' (O_CREAT|O_EXCL, 6 random chars) inside the validated directory, with no hardcoded staging name left, so the check-then-open race is gone by construction (#3261 roborev-1)"
+else
+  bad "perf-capability: the installer no longer creates its staging entry with an unpredictable mktemp name"
+  printf '%s\n' "$wt_body" | grep -n 'pin_t' | head -5
+fi
+# ...and a `mktemp` that answers OUTSIDE the validated directory is refused rather than trusted.
+wt_mt="$tmp/wt-bad-mktemp"; mkdir -p "$wt_mt"
+for t in bash cat printf tee mv rm chmod env grep; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$wt_mt/$t"
+done
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "/tmp/perf-cap-elsewhere.$$"' >"$wt_mt/mktemp"
+chmod +x "$wt_mt/mktemp"
+wt_mt_out=$(env PATH="$wt_mt:$PATH" CQLITE_PERF_SYSCTL_DIR="$wt_d" \
+  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_mt_rc=$?
+if [ "$wt_mt_rc" -ne 0 ] && printf '%s' "$wt_mt_out" | grep -q 'mktemp did not create a staging entry inside the validated directory'; then
+  ok "perf-capability: a 'mktemp' answering a path OUTSIDE the validated directory is REFUSED by name, never written to (the tool's answer is checked, not trusted)"
+else
+  bad "perf-capability: a mktemp answering outside the validated directory was trusted (rc=$wt_mt_rc, out='$wt_mt_out')"
+fi
 # ...and the install is still gated: an out-of-sandbox seam may not be written at all.
 if env CQLITE_PERF_SYSCTL_DIR="$symanc/sysctl.d" \
      bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" >/dev/null 2>&1; then

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1070,15 +1070,7 @@ if perf_install_supported; then
   fi
   rm -f "$wt_d/.99-cqlite-perf.conf.new"
   # ...structurally: the staging entry is created by `mktemp` with a random-suffix template, no
-  # hardcoded staging literal survives, the rename carries `-T`, and the WHOLE staged install is ONE
-  # privileged invocation (issue #3261 roborev round 2).
-  #   THE LAST PROPERTY IS HYGIENE, NOT THE FIX, and this comment previously said otherwise. roborev
-  #   round 3 corrected it: a single `sh -c` sequences ONE PROCESS's commands and is not mutual
-  #   exclusion against other processes, which run concurrently on other CPUs regardless of how we
-  #   grouped ours. Consolidation NARROWS the create-to-reopen window; it does not close it. It is
-  #   still worth pinning — a split back into `mktemp` in one privileged call and the write in another
-  #   would re-widen the window while every behavioural assert stayed green, which no after-the-fact
-  #   observation can catch — but it is pinned as hygiene, not as the guarantee.
+  # (rationale: fleet-runbook.md, perf seam containment, structurally-the-staging-entry-is-created-b)
   wt_body=$(awk '/^perf_capability_dropin_install\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
   wt_privcalls=$(printf '%s\n' "$wt_body" | grep -c '"\$@"')
   wt_struct_fail=''
@@ -1134,14 +1126,7 @@ if perf_install_supported; then
   fi
   rm -f "$wt_d/99-cqlite-perf.conf"
   # ...and THE PRECONDITION THAT ACTUALLY CLOSES THE STAGING RACE (issue #3261, roborev round 3): a
-  # drop-in directory writable by anyone less privileged than the writer is REFUSED before anything is
-  # staged. Three rounds of this defect were each answered by trying to make the race unwinnable
-  # (unpredictable name, then one privileged invocation); neither works, because a single `sh -c`
-  # sequences OUR commands and says nothing about other processes on other CPUs. Removing the
-  # attacker's precondition does work — with no one able to create or replace entries in the
-  # directory, there is no actor to race, whatever the timing.
-  # The negative control is the whole point of the group: a check that refuses everything would pass
-  # the two refusal cases and be useless, so a correctly-owned 0755 directory must still install.
+  # (rationale: fleet-runbook.md, perf seam containment, and-the-precondition-that-actually-closes-t)
   wt_perm_d="$tmp/wt-perm.d"
   wt_perm_fail=0
   for wt_mode in 0775 0777 0757; do
@@ -1185,14 +1170,7 @@ if perf_install_supported; then
     wt_perm_fail=1
   fi
   # ...a SHORT MODE from `stat -c %a` must not bypass the write-bit check (roborev round 5, High).
-  # WHY A SHIM AND NOT A REAL chmod: `%a` only drops below three digits when the OWNER digit is 0,
-  # and a directory its owner cannot enter fails containment long before the mode check — so the real
-  # bypass is NOT reachable through an actual chmod under test mode. It IS reachable as root in
-  # production, where root ignores permission bits and enters a mode-0033 /etc/sysctl.d happily while
-  # group and other retain write. So the honest reproduction is to feed the parser the short string a
-  # root `stat` would really print, against an enterable directory. Without the zero-padding this
-  # reports "33", the suffix-strip leaves the permission field EMPTY, no write-bit pattern matches,
-  # and a group- AND world-writable directory is ACCEPTED.
+  # (rationale: fleet-runbook.md, perf seam containment, a-short-mode-from-stat-c-a-must-not-bypass)
   wt_short="$tmp/wt-shortmode"; mkdir -p "$wt_short"
   for st in bash sh cat printf tee mv rm chmod env grep mktemp id ls; do
     s=$(command -v "$st" 2>/dev/null) && ln -sf "$s" "$wt_short/$st"
@@ -1478,12 +1456,7 @@ else
 fi
 
 # 1g-ii. AC2 (Medium) — the inversion REGRESSED symlink rejection on the READ path. The
-#        fork-free proc check judges the SPELLING, so a symlink INSIDE the sandbox pointing at
-#        the real /proc/sys/kernel satisfies containment: the run then reports a capability
-#        token derived from the HOST's real controls while claiming to have read a stand-in.
-#        That is a FABRICATED verdict, which is worse than a refusal, and it is a regression
-#        against the pre-inversion behaviour. The token path is contractually fork-free, so the
-#        fix must reject symlinked COMPONENTS with builtins only.
+# (rationale: fleet-runbook.md, perf seam containment, 1g-ii-ac2-medium-the-inversion-regressed-sym)
 ac2_fail=0
 ac2_link="$tmp/ac2-proc-is-a-symlink"; rm -f "$ac2_link"; ln -s /proc/sys/kernel "$ac2_link"
 ac2_dirlink="$tmp/ac2-ancestor-link"; rm -f "$ac2_dirlink"; ln -s /proc/sys "$ac2_dirlink"
@@ -1539,14 +1512,7 @@ else
 fi
 
 # 1g-iv. AC4 (High) — the guard authorizes EXECUTABLES, and never resolved them. Two escapes,
-#        one shape: an absolute shim dir that is not in the sandbox at all (`/usr` — it does
-#        contain the real /usr/bin/sudo, so the textual "inside the declared dir" check
-#        PASSED), and a SYMLINK to the real tool sitting inside a genuine shim dir (spelled
-#        locally, resolving to the host's binary). Either one let a privileged test-mode
-#        bootstrap execute a real `sysctl --system` and reconfigure the host kernel.
-#        `$ac4_sys` stands in for `/usr` PORTABLY: an absolute directory OUTSIDE the declared
-#        sandbox root that holds tools named `sudo`/`sysctl`. Asserting against the literal
-#        /usr would make the case depend on whether this host happens to ship sudo there.
+# (rationale: fleet-runbook.md, perf seam containment, 1g-iv-ac4-high-the-guard-authorizes-executab)
 ac4_sys=''
 if ac4_sys=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-outside.XXXXXX") && [ -d "$ac4_sys" ]; then
   trap 'rm -rf "$tmp" "$ac4_sys"' EXIT

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1286,6 +1286,39 @@ else
   ok "perf-capability: the line-safety predicate rejects CR as well as LF and still accepts an ordinary path"
 fi
 
+# ...and LINE-SAFETY MUST BE JUDGED ON THE ORIGINAL PATH, not the canonicalized one (roborev round
+# 12, Medium). `$(cd -P -- "$p" && pwd -P)` STRIPS trailing newlines, so a directory whose name ends
+# in LF used to pass: the check only ever saw the stripped form, while every later caller emitted the
+# ORIGINAL spelling and split the one-per-line search path in two. Round 3 added the CR/LF guard for
+# exactly that split; it was running too late to see it. Both variants are pinned — a directory whose
+# name ends in LF, and a file whose PARENT ends in LF — because they canonicalize by different routes.
+lf_root=$(mktemp -d "$tmp/lf.XXXXXX"); : >"$lf_root/.cqlite-perf-sandbox"
+lf_dir="$lf_root/evil"$'\n'
+lf_fail=0
+if mkdir -p "$lf_dir" 2>/dev/null; then
+  if env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$lf_root" \
+       bash -c '. "$1"; perf_capability_sandbox_ok_resolved "$2"' _ "$PERFLIB" "$lf_dir" 2>/dev/null; then
+    bad "perf-capability: a directory whose name ends in LF was ACCEPTED by the resolved containment check (the newline was laundered through pwd -P)"
+    lf_fail=1
+  fi
+  # ...and the FILE variant, whose parent is the LF-named directory.
+  : >"$lf_dir/sysctl.conf" 2>/dev/null
+  if env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$lf_root" \
+       bash -c '. "$1"; perf_capability_sandbox_file_ok_resolved "$2"' _ "$PERFLIB" "$lf_dir/sysctl.conf" 2>/dev/null; then
+    bad "perf-capability: a file whose PARENT directory name ends in LF was ACCEPTED by the resolved file containment check"
+    lf_fail=1
+  fi
+  # ...NEGATIVE CONTROL: the same shapes WITHOUT a newline are still accepted, so the check is not
+  # refusing every path that merely looks unusual.
+  mkdir -p "$lf_root/ordinary"
+  env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$lf_root" \
+    bash -c '. "$1"; perf_capability_sandbox_ok_resolved "$2"' _ "$PERFLIB" "$lf_root/ordinary" 2>/dev/null \
+    || { bad "perf-capability: an ORDINARY contained directory was refused by the line-safety ordering fix (vacuous)"; lf_fail=1; }
+  [ "$lf_fail" -ne 0 ] || ok "perf-capability: line-safety is judged on the ORIGINAL path — a directory ending in LF and a file whose parent ends in LF are both REFUSED (the newline cannot launder through pwd -P), while an ordinary contained directory still passes (#3261 roborev-12)"
+else
+  skip "perf-capability: LF-in-path containment cases" "this filesystem refused to create a directory whose name contains a newline"
+fi
+
 # ...and the COMPETING-FILE SCAN must validate every globbed file, not just its directory (roborev
 # round 11, Medium). `[ -f ]` and `grep` FOLLOW symlinks, so a link sitting inside a perfectly
 # contained sandbox directory but pointing at a real host `*.conf` was read, and its contents

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1280,6 +1280,29 @@ else
   ok "perf-capability: the line-safety predicate rejects CR as well as LF and still accepts an ordinary path"
 fi
 
+# ...and a FAILING CONTENT GENERATOR must never look like success (roborev round 9, Medium). Both
+# call sites used to lose the generator's status: dropin_current ran a trailing sentinel `printf`
+# whose rc replaced it, so against an EMPTY file the compare was "X" == "X" and reported the drop-in
+# ALREADY CURRENT; dropin_install piped the generator into the privileged shell, so the pipeline's rc
+# was the last command's and a failure only surfaced if the CALLER had `pipefail`. Both are vacuous
+# positives from an unmeasured state. No GNU-only tooling is exercised here: each must fail BEFORE
+# any privileged command runs, which is the property under test.
+cg_dir=$(mktemp -d "$tmp/cg.XXXXXX"); : >"$cg_dir/99-cqlite-perf.conf"
+cg_fail=0
+cg_cur_rc=0
+env CQLITE_PERF_SYSCTL_DIR="$cg_dir" bash -c '
+  . "$1"
+  perf_capability_dropin_content() { return 1; }
+  perf_capability_dropin_current' _ "$PERFLIB" >/dev/null 2>&1 || cg_cur_rc=$?
+[ "$cg_cur_rc" -ne 0 ] || { bad "perf-capability: a FAILING content generator let dropin_current report the drop-in already current (empty file compared equal)"; cg_fail=1; }
+cg_ins_out=$(env CQLITE_PERF_SYSCTL_DIR="$cg_dir" bash -c '
+  . "$1"
+  perf_capability_dropin_content() { return 1; }
+  perf_capability_dropin_install' _ "$PERFLIB" 2>&1); cg_ins_rc=$?
+[ "$cg_ins_rc" -ne 0 ] || { bad "perf-capability: dropin_install succeeded with a FAILING content generator (rc=$cg_ins_rc, out='$cg_ins_out')"; cg_fail=1; }
+[ ! -s "$cg_dir/99-cqlite-perf.conf" ] || { bad "perf-capability: dropin_install wrote content despite a failing generator"; cg_fail=1; }
+[ "$cg_fail" -ne 0 ] || ok "perf-capability: a FAILING drop-in content generator propagates — dropin_current does NOT report 'already current' against an empty file, and dropin_install refuses before any privileged command and writes nothing (#3261 roborev-9)"
+
 # ...and the install is still gated: an out-of-sandbox seam may not be written at all. Same GNU-only
 # toolchain dependency as the staged-install block above, so same counted skip off GNU.
 if ! perf_install_supported; then

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -883,7 +883,7 @@ done
 # whitespace, `)` or end) rather than merely occurring somewhere in the text.
 seam_audit=$(awk \
   -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
-  -v gatere='(^|[^A-Za-z0-9_])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
+  -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
   # TWO representations, because the two matches want different things (roborev round 6, Low).
   #   `code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
   #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
@@ -952,7 +952,7 @@ fi
 # Same de-vacuuming as the seam audit above: comments stripped, gate matched in a command position.
 priv_audit=$(awk \
   -v privre='(for [a-z_]+ in (sudo|sysctl)|command -v .*(sudo|sysctl))' \
-  -v gatere='(^|[^A-Za-z0-9_])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
+  -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
   # TWO representations, because the two matches want different things (roborev round 6, Low).
   #   `code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
   #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1608,6 +1608,46 @@ for ps_spell in "$ps_proc/" "$ps_proc//"; do
 done
 [ "$ps_fail" -ne 0 ] || ok "perf-capability: a contained PROC_DIR spelled with one or two trailing slashes yields the SAME capability token as its unslashed spelling, so a spelling can no longer become a definite 'absent' claim about the host (#3261 roborev-33)"
 
+# 1c-vii. THE PROBE DELETES NOTHING IT DID NOT CREATE, and a WORKING mv that FAILS is not an
+# (full rationale: fleet-runbook.md, perf seam containment, 1c-vii-the-probe-deletes-nothing-it-did-not-cr)
+if perf_install_supported; then
+  pb_fail=0
+  # (a) A PRE-EXISTING probe entry must be REFUSED, and must SURVIVE. The name embeds the PID of the
+  # privileged shell, which the harness cannot predict, so the shim mv creates the collision itself:
+  # it plants the sibling name on its first call, which is the probe rename.
+  pb_root=$(mktemp -d "$tmp/pb.XXXXXX"); : >"$pb_root/.cqlite-perf-sandbox"
+  pb_d="$pb_root/sysctl.d"; mkdir -p "$pb_d"; chmod 0755 "$pb_root" "$pb_d"
+  pb_victim="$pb_d/.perfcap-probe.victim"; printf 'PRECIOUS\n' >"$pb_victim"
+  # A self-contained shim dir, the same shape the UNSUPPORTED cases use: it is both PATH and the
+  # declared TEST_PRIV_DIR, so the guard's privileged-tool containment is satisfied by construction.
+  pb_bin=$(mktemp -d "$tmp/pbbin.XXXXXX")
+  for pb_t in bash sh cat printf tee rm chmod env grep mktemp id ls stat; do
+    pb_p=$(command -v "$pb_t" 2>/dev/null) && ln -sf "$pb_p" "$pb_bin/$pb_t"
+  done
+  # An mv that ADVERTISES -T and then fails the rename: the Low half's subject.
+  printf '%s\n' '#!/bin/sh' 'case "$1" in --help) printf -- "--no-target-directory\n"; exit 0 ;; esac' 'exit 1' \
+    >"$pb_bin/mv"; chmod +x "$pb_bin/mv"
+  pb_out=$(env PATH="$pb_bin" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$pb_root" \
+    CQLITE_PERF_SYSCTL_DIR="$pb_d" CQLITE_PERF_PROC_DIR="$pb_root" \
+    CQLITE_PERF_TEST_PRIV_DIR="$pb_bin" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); pb_rc=$?
+  [ "$pb_rc" -eq 1 ] \
+    || { bad "perf-capability: an mv that ADVERTISES --no-target-directory but fails the rename gave rc=$pb_rc, not rc 1 — a working-but-failing mv is being reported as an unsupported host, which suppresses the retry remedy (out='$pb_out')"; pb_fail=1; }
+  printf '%s' "$pb_out" | grep -q 'NOT an unsupported host' \
+    || { bad "perf-capability: the rename-probe failure did not say it is NOT an unsupported host: '$pb_out'"; pb_fail=1; }
+  [ "$(cat "$pb_victim" 2>/dev/null)" = PRECIOUS ] \
+    || { bad "perf-capability: a pre-existing .perfcap-probe.* entry was DELETED or truncated by the probe"; pb_fail=1; }
+  # (b) STRUCTURAL, because the PID collision itself cannot be staged from outside: the probe must
+  # carry no delete before its absence proof. The rm that remains must sit AFTER the proof.
+  pb_body=$(awk '/^perf_capability_dropin_install\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
+  pb_before=$(printf '%s\n' "$pb_body" | awk '/\[ -e "\$__x1" \]/{exit} /rm -f -- "\$__x1"/{c++} END{print c+0}')
+  [ "$pb_before" -eq 0 ] \
+    || { bad "perf-capability: the probe deletes \$__x1/\$__x2 ($pb_before time(s)) BEFORE proving they are absent — after PID reuse that destroys an unrelated file under privilege"; pb_fail=1; }
+  [ "$pb_fail" -ne 0 ] || ok "perf-capability: the install probe deletes no entry it did not create (no rm before the absence proof, and a pre-existing probe-named file survives untouched), and an mv that advertises -T but fails the rename is rc 1 with a retry-worthy diagnostic rather than rc 2 UNSUPPORTED (#3261 roborev-34)"
+else
+  skip "perf-capability: install-probe cases (no rm before the absence proof; a working-but-failing mv is rc 1, not UNSUPPORTED)" "no GNU stat -c / mv --no-target-directory on this host"
+fi
+
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.
 perf_test_assert_host_clean
 perf_test_report

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -866,15 +866,7 @@ done
 #     containment family (`perf_capability_sandbox_*` / `perf_capability_path_within`) — with
 #     ONE named, justified allowlist entry. A future entry point that reads a seam without
 #     the gate FAILS here, and joining the allowlist is a visible, reviewable act.
-#
-#     Same shape as the fork-free audit in test_agent_gate_summary.sh: parse the function
-#     bodies (a column-0 `name() {` … column-0 `}`), and treat FINDING NOTHING as a failure,
-#     so a parser that stops matching can never pass this vacuously.
-#
-#     EXTENDED TO THE PRIVILEGE SHIM (issue #3261 AC4). The guard authorizes EXECUTABLES as
-#     well as paths, and CQLITE_PERF_TEST_PRIV_DIR was read TEXTUALLY — so it joins the seam
-#     regex below, and a second pass audits every function that RESOLVES a privileged tool.
-# CODE ONLY, AND CALL SITES ONLY — see the code/codeq note in the awk below for why.
+# (rationale condensed; full reasoning in the commit history for #3261.)
 seam_audit=$(awk \
   -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
   -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
@@ -1017,14 +1009,7 @@ fi
 #         * anything that merely NAMES the write target REFUSES (rc 1, empty, loud);
 #         * the WRITE ITSELF replaces the directory ENTRY (rename), so a symlink planted in
 #           the window between the check and the write is replaced, not written through.
-# ---- STAGED-INSTALL CASES: GNU-ONLY TOOLCHAIN, LOUDLY AND COUNTABLY SKIPPED ELSEWHERE ----------
-# (issue #3261, roborev round 5 Medium.) Everything from here to the matching `fi` drives
-# perf_capability_dropin_install, which needs GNU `stat -c` and `mv --no-target-directory`. macOS is a
-# FIRST-CLASS gate host here, so invoking these unconditionally red-ed the gate on the TOOLCHAIN
-# rather than on behaviour. The probe is AFFIRMATIVE (it runs the flags) rather than a `uname` guess,
-# and the non-GNU branch emits one COUNTED skip per case group so a green macOS run shows them
-# skipped-with-reason instead of silently absent. Production is unaffected on either branch:
-# bootstrap gates the whole perf section on PLATFORM=linux.
+# (rationale condensed; full reasoning in the commit history for #3261.)
 if perf_install_supported; then
   wt_d="$tmp/wt-sandbox.d"; mkdir -p "$wt_d"
   wt_outside="$tmp/wt-outside-target"; printf 'PRECIOUS-HOST-FILE\n' >"$wt_outside"

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1232,16 +1232,22 @@ if perf_install_supported; then
   wt_ln_target="$tmp/wt-ln-target"; wt_ln_dir="$tmp/wt-ln-dir"
   rm -rf "$wt_ln_target" "$wt_ln_dir"; mkdir -p "$wt_ln_target"; chmod 0755 "$wt_ln_target"
   ln -s "$wt_ln_target" "$wt_ln_dir"
-  wt_ln_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_ln_dir" \
-    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ln_rc=$?
-  if [ "$wt_ln_rc" -eq 0 ] || ! printf '%s' "$wt_ln_out" | grep -q 'is a SYMLINK'; then
-    bad "perf-capability: a SYMLINKED drop-in directory was not refused by name (rc=$wt_ln_rc, out='$wt_ln_out')"
-    wt_perm_fail=1
-  fi
-  if [ -e "$wt_ln_target/99-cqlite-perf.conf" ]; then
-    bad "perf-capability: the symlinked drop-in directory was refused but its TARGET was written anyway"
-    wt_perm_fail=1
-  fi
+  # ...and the refusal must survive TRAILING SLASHES (roborev round 10, Low). `[ -L link/ ]` and
+  # `[ -L link// ]` are both FALSE even when `link` IS a symlink, because the test follows the slash,
+  # so one extra character used to walk past the refusal this function explicitly promises. All three
+  # spellings are asserted, and the link TARGET is checked unwritten after each one.
+  for wt_ln_spell in "$wt_ln_dir" "$wt_ln_dir/" "$wt_ln_dir//"; do
+    wt_ln_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_ln_spell" \
+      bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ln_rc=$?
+    if [ "$wt_ln_rc" -eq 0 ] || ! printf '%s' "$wt_ln_out" | grep -q 'is a SYMLINK'; then
+      bad "perf-capability: a SYMLINKED drop-in directory spelled '$wt_ln_spell' was not refused (rc=$wt_ln_rc, out='$wt_ln_out')"
+      wt_perm_fail=1
+    fi
+    if [ -e "$wt_ln_target/99-cqlite-perf.conf" ]; then
+      bad "perf-capability: spelling '$wt_ln_spell' was refused but the link TARGET was written anyway"
+      wt_perm_fail=1
+    fi
+  done
   [ "$wt_perm_fail" -ne 0 ] || ok "perf-capability: a privileged staged install REFUSES a group-/world-writable drop-in directory by name and writes nothing, refuses a SYMLINKED destination outright (lstat semantics asserted, target left unwritten), refuses when owner/mode cannot be determined, and still installs into a correctly-owned 0755 directory — the staging race is closed at its PRECONDITION rather than by trying to win it (#3261 roborev-3, owner A' condition 2)"
 else
   skip "perf-capability: staged-install write-target cases (symlinked managed name refused; dropin_current does not follow it; the write REPLACES the directory entry)" "no GNU stat -c / mv --no-target-directory on this host"

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1648,6 +1648,39 @@ else
   skip "perf-capability: install-probe cases (no rm before the absence proof; a working-but-failing mv is rc 1, not UNSUPPORTED)" "no GNU stat -c / mv --no-target-directory on this host"
 fi
 
+# 1c-viii. THE RESOLVING VALIDATORS REQUIRE AN ABSOLUTE, CANONICAL SPELLING (roborev round 35, Medium).
+# They judged only the canonicalized result while consumers keep the ORIGINAL argument, so a RELATIVE
+# candidate was authorized against THIS shell's cwd and re-resolved against a different one later --
+# the privileged installer runs its own shell. What remains after this fix (a verdict returned while
+# the resolved path is discarded, so the name is resolved twice) is #3323 entry 5, the closed family.
+rs_fail=0
+rs_root=$(mktemp -d "$tmp/rs.XXXXXX"); : >"$rs_root/.cqlite-perf-sandbox"
+mkdir -p "$rs_root/inside"; chmod 0755 "$rs_root" "$rs_root/inside"
+: >"$rs_root/inside/file.conf"
+rs_probe() {  # <fn> <candidate> [cwd] -> rc
+  ( [ -n "${3:-}" ] && cd -- "$3" || true
+    env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$rs_root" \
+      bash -c '. "$1"; "$2" "$3"' _ "$PERFLIB" "$1" "$2" >/dev/null 2>&1 )
+}
+# CONTROL: the absolute canonical spellings must be ACCEPTED, or the refusals below prove nothing.
+rs_probe perf_capability_sandbox_ok_resolved "$rs_root/inside" \
+  || { bad "perf-capability: sandbox_ok_resolved refused the absolute canonical directory, so the cases below prove nothing"; rs_fail=1; }
+rs_probe perf_capability_sandbox_file_ok_resolved "$rs_root/inside/file.conf" \
+  || { bad "perf-capability: sandbox_file_ok_resolved refused the absolute canonical file, so the cases below prove nothing"; rs_fail=1; }
+# (a) a RELATIVE candidate that resolves INSIDE the sandbox from the current cwd must still be refused
+! rs_probe perf_capability_sandbox_ok_resolved "inside" "$rs_root" \
+  || { bad "perf-capability: sandbox_ok_resolved ACCEPTED the relative spelling 'inside' because it resolved inside the sandbox from this cwd — the same spelling means a different directory from another cwd"; rs_fail=1; }
+! rs_probe perf_capability_sandbox_file_ok_resolved "inside/file.conf" "$rs_root" \
+  || { bad "perf-capability: sandbox_file_ok_resolved ACCEPTED the relative spelling 'inside/file.conf'"; rs_fail=1; }
+# (b) and a NON-CANONICAL absolute spelling, which resolves inside but is not spelled as a destination
+! rs_probe perf_capability_sandbox_ok_resolved "$rs_root/./inside" \
+  || { bad "perf-capability: sandbox_ok_resolved ACCEPTED a '/./' spelling"; rs_fail=1; }
+! rs_probe perf_capability_sandbox_ok_resolved "$rs_root/inside/../inside" \
+  || { bad "perf-capability: sandbox_ok_resolved ACCEPTED a '/../' spelling"; rs_fail=1; }
+! rs_probe perf_capability_sandbox_file_ok_resolved "$rs_root/./inside/file.conf" \
+  || { bad "perf-capability: sandbox_file_ok_resolved ACCEPTED a '/./' spelling"; rs_fail=1; }
+[ "$rs_fail" -ne 0 ] || ok "perf-capability: both RESOLVING validators refuse a relative candidate (even one resolving inside the sandbox from the current cwd) and a non-canonical './' or '../' absolute spelling, while accepting the absolute canonical spelling of the same directory and file (#3261 roborev-35)"
+
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.
 perf_test_assert_host_clean
 perf_test_report

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1286,6 +1286,43 @@ else
   ok "perf-capability: the line-safety predicate rejects CR as well as LF and still accepts an ordinary path"
 fi
 
+# ...and the COMPETING-FILE SCAN must validate every globbed file, not just its directory (roborev
+# round 11, Medium). `[ -f ]` and `grep` FOLLOW symlinks, so a link sitting inside a perfectly
+# contained sandbox directory but pointing at a real host `*.conf` was read, and its contents
+# fabricated "a competitor sets these keys" diagnostics out of HOST state — the asserted numbers
+# would come from the box instead of the fixture. Fails CLOSED: a competitor we declined to examine
+# is the UNKNOWN this diagnostic exists to report, not hide.
+cs_root=$(mktemp -d "$tmp/cs.XXXXXX"); : >"$cs_root/.cqlite-perf-sandbox"
+cs_dir="$cs_root/sysctl.d"; mkdir -p "$cs_dir"
+cs_host="$tmp/cs-host-competitor.conf"
+printf 'kernel.perf_event_paranoid = 2\n' >"$cs_host"
+ln -s "$cs_host" "$cs_dir/00-host-link.conf"
+cs_fail=0
+cs_out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
+  CQLITE_PERF_SYSCTL_DIR="$cs_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
+  bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_rc=$?
+[ "$cs_rc" -ne 0 ] || { bad "perf-capability: the competing-file scan ACCEPTED a symlinked *.conf inside the sandbox (rc=$cs_rc, out='$cs_out')"; cs_fail=1; }
+printf '%s' "$cs_out" | grep -q 'REFUSING to scan' \
+  || { bad "perf-capability: the scan failed on a symlinked competitor without naming the refusal (out='$cs_out')"; cs_fail=1; }
+printf '%s' "$cs_out" | grep -q 'perf_event_paranoid = 2' \
+  && { bad "perf-capability: the scan LEAKED host competitor content through a symlink"; cs_fail=1; }
+# ...the NEGATIVE CONTROL: a REAL file inside the sandbox is still scanned, so the check is not
+# refusing everything. A newline in the basename is included here because the scan is line-oriented.
+cs_nl=$(printf 'zz-real\ncompetitor.conf')
+printf 'kernel.kptr_restrict = 1\n' >"$cs_dir/zz-real.conf" 2>/dev/null
+cs_ok_out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
+  CQLITE_PERF_SYSCTL_DIR="$cs_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
+  bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_ok_rc=$?
+rm -f -- "$cs_dir/00-host-link.conf"
+cs_ok2_out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
+  CQLITE_PERF_SYSCTL_DIR="$cs_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
+  bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_ok2_rc=$?
+if [ "$cs_ok2_rc" -ne 0 ] || ! printf '%s' "$cs_ok2_out" | grep -q 'zz-real.conf'; then
+  bad "perf-capability: a REAL contained competitor was not scanned once the symlink was removed — the per-file check is refusing everything (rc=$cs_ok2_rc, out='$cs_ok2_out')"
+  cs_fail=1
+fi
+[ "$cs_fail" -ne 0 ] || ok "perf-capability: the competing-file scan validates EVERY globbed file in test mode — a symlinked *.conf inside the sandbox fails the scan CLOSED by name and leaks no host content, while a real contained competitor is still reported (#3261 roborev-11)"
+
 # ...and a FAILING CONTENT GENERATOR must never look like success (roborev round 9, Medium). Both
 # call sites used to lose the generator's status: dropin_current ran a trailing sentinel `printf`
 # whose rc replaced it, so against an EMPTY file the compare was "X" == "X" and reported the drop-in

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1039,31 +1039,66 @@ else
   bad "perf-capability: the install wrote through a PREDICTABLE staging name (rc=$wt_st_rc, bait-changed=$([ "$(cat "$wt_bait")" = "$wt_bait_before" ] && echo no || echo YES), out='$wt_st')"
 fi
 rm -f "$wt_d/.99-cqlite-perf.conf.new"
-# ...structurally: the staging entry is created by `mktemp` with a random-suffix template, and no
-# hardcoded staging literal survives. A future edit back to a fixed name FAILS here.
+# ...structurally: the staging entry is created by `mktemp` with a random-suffix template, no
+# hardcoded staging literal survives, the rename carries `-T`, and the WHOLE staged install is ONE
+# privileged invocation (issue #3261 roborev round 2). That last property is the fix for the
+# create->reopen race and cannot be observed after the fact — a split back into `mktemp` in one
+# privileged call and the write in another would leave every behavioural assert green — so it is
+# pinned here, in the spirit of the other structural audits on this branch.
 wt_body=$(awk '/^perf_capability_dropin_install\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
-if printf '%s\n' "$wt_body" | grep -q 'mktemp -- "\$__pin_d/\.\$PERF_CAPABILITY_DROPIN_BASENAME\.XXXXXX"' \
-   && ! printf '%s\n' "$wt_body" | grep -qF '.new"' \
-   && [ "$(printf '%s\n' "$wt_body" | grep -c 'mktemp')" -ge 1 ]; then
-  ok "perf-capability: STRUCTURAL — the staging entry is created by 'mktemp' (O_CREAT|O_EXCL, 6 random chars) inside the validated directory, with no hardcoded staging name left, so the check-then-open race is gone by construction (#3261 roborev-1)"
+wt_privcalls=$(printf '%s\n' "$wt_body" | grep -c '"\$@"')
+wt_struct_fail=''
+printf '%s\n' "$wt_body" | grep -q 'mktemp -- "\$d/\.\$b\.XXXXXX"' \
+  || wt_struct_fail="$wt_struct_fail no-mktemp-template"
+printf '%s\n' "$wt_body" | grep -qF '.new"' && wt_struct_fail="$wt_struct_fail hardcoded-staging-name"
+printf '%s\n' "$wt_body" | grep -q 'mv -fT -- "\$t" "\$p"' \
+  || wt_struct_fail="$wt_struct_fail no-mv-T"
+[ "$wt_privcalls" -eq 1 ] || wt_struct_fail="$wt_struct_fail privileged-invocations=$wt_privcalls"
+printf '%s\n' "$wt_body" | grep -q '"\$@" sh -c' || wt_struct_fail="$wt_struct_fail not-a-single-sh-c"
+if [ -z "$wt_struct_fail" ]; then
+  ok "perf-capability: STRUCTURAL — the staged install is ONE privileged 'sh -c' (mktemp + write + chmod + mv all inside it, so no unprivileged process is scheduled between create and reopen), the staging name comes from an mktemp random-suffix template with no hardcoded literal, and the rename carries -T (#3261 roborev-1/roborev-2)"
 else
-  bad "perf-capability: the installer no longer creates its staging entry with an unpredictable mktemp name"
-  printf '%s\n' "$wt_body" | grep -n 'pin_t' | head -5
+  bad "perf-capability: the staged install lost a structural property:$wt_struct_fail"
+  printf '%s\n' "$wt_body" | grep -n '\$@\|mktemp\|mv -' | head -8
 fi
-# ...and a `mktemp` that answers OUTSIDE the validated directory is refused rather than trusted.
+# ...and a `mktemp` that answers OUTSIDE the validated directory is refused rather than trusted —
+# the check now lives INSIDE the privileged shell, so this also proves it survived consolidation.
 wt_mt="$tmp/wt-bad-mktemp"; mkdir -p "$wt_mt"
-for t in bash cat printf tee mv rm chmod env grep; do
+for t in bash sh cat printf tee mv rm chmod env grep; do
   s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$wt_mt/$t"
 done
 printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "/tmp/perf-cap-elsewhere.$$"' >"$wt_mt/mktemp"
 chmod +x "$wt_mt/mktemp"
 wt_mt_out=$(env PATH="$wt_mt:$PATH" CQLITE_PERF_SYSCTL_DIR="$wt_d" \
   bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_mt_rc=$?
-if [ "$wt_mt_rc" -ne 0 ] && printf '%s' "$wt_mt_out" | grep -q 'mktemp did not create a staging entry inside the validated directory'; then
-  ok "perf-capability: a 'mktemp' answering a path OUTSIDE the validated directory is REFUSED by name, never written to (the tool's answer is checked, not trusted)"
+if [ "$wt_mt_rc" -ne 0 ] \
+   && printf '%s' "$wt_mt_out" | grep -q 'mktemp did not create a staging entry inside the validated directory' \
+   && [ ! -e "/tmp/perf-cap-elsewhere.$$" ]; then
+  ok "perf-capability: a 'mktemp' answering a path OUTSIDE the validated directory is REFUSED by name from INSIDE the privileged shell, and that path is never created (the tool's answer is checked, not trusted)"
 else
   bad "perf-capability: a mktemp answering outside the validated directory was trusted (rc=$wt_mt_rc, out='$wt_mt_out')"
 fi
+# ...and the POST-CREATION destination race: a symlink-to-DIRECTORY planted at the managed name.
+# Without `mv -T` (--no-target-directory) `mv` would move the staging file INTO the linked
+# directory — the rename that exists to avoid FOLLOWING a symlink would follow one instead, landing
+# the managed bytes outside the sandbox under a different name. With -T the destination is always a
+# plain name to replace. Asserted by consequence: nothing may appear inside the outside directory.
+wt_outdir="$tmp/wt-outside-dir"; rm -rf "$wt_outdir"; mkdir -p "$wt_outdir"
+rm -f "$wt_d/99-cqlite-perf.conf"; ln -s "$wt_outdir" "$wt_d/99-cqlite-perf.conf"
+wt_td=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
+  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_td_rc=$?
+wt_outdir_contents=$(ls -A "$wt_outdir")
+wt_td_leftover=$(ls -A "$wt_d" | grep -v '^99-cqlite-perf\.conf$' || true)
+# Measured without `-T`: the staging entry landed INSIDE $wt_outdir as `.99-cqlite-perf.conf.XXXXXX`
+# — the managed bytes escaped the sandbox under a name nothing tracks. With `-T`: rc 0, the symlink
+# is REPLACED by a regular file, the outside directory stays empty. All four pinned.
+if [ "$wt_td_rc" -eq 0 ] && [ -z "$wt_outdir_contents" ] && [ -z "$wt_td_leftover" ] \
+   && [ -f "$wt_d/99-cqlite-perf.conf" ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ]; then
+  ok "perf-capability: a symlink-to-DIRECTORY planted at the managed name does NOT redirect the staged write into it ('mv -T') — the link is REPLACED by a regular file, the outside directory stays empty, no staging entry is left behind (#3261 roborev-2)"
+else
+  bad "perf-capability: the staged write was redirected through a symlink-to-directory at the managed name (rc=$wt_td_rc, outside-dir='$wt_outdir_contents', leftover='$wt_td_leftover', out='$wt_td')"
+fi
+rm -f "$wt_d/99-cqlite-perf.conf"
 # ...and the install is still gated: an out-of-sandbox seam may not be written at all.
 if env CQLITE_PERF_SYSCTL_DIR="$symanc/sysctl.d" \
      bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" >/dev/null 2>&1; then

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -295,16 +295,7 @@ for resolveseam in "$symanc/sysctl.d" "//proc/sys/kernel" "$symout"; do
 done
 [ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam, one that RESOLVES out of the sandbox (.., a symlinked ancestor, a symlink to /tmp), the '//etc' double-slash spelling, a sibling-prefix path and the sandbox ROOT itself — on BOTH sandbox dirs, naming the offending seam"
 # 1c-iii-b. THE CONTAINMENT BOUNDARY AND THE SANDBOX ROOT ITSELF (issue #3249 review
-#           R6-1/R6-2). Containment is only as good as its boundary and its root:
-#             * `/tmp/sandboxevil` must NOT count as inside `/tmp/sandbox` — a plain string
-#               prefix would accept it, which is why the `/` boundary is explicit;
-#             * a path genuinely inside the declared root must still WORK, so the guard is
-#               not vacuously refusing everything (the failure mode a negative-only test
-#               cannot see);
-#             * the ROOT must PROVE itself — unset, relative, `//`-spelled, non-existent, or
-#               an existing directory with no stamp are all refusals NAMING
-#               CQLITE_PERF_TEST_SANDBOX. Without that, `CQLITE_PERF_TEST_SANDBOX=/etc`
-#               would make containment vacuous, and the inversion would have bought nothing.
+# (full rationale: fleet-runbook.md, perf seam containment, 1c-iii-b-the-containment-boundary-and-the-sand)
 sbx="$tmp/sandbox"; mkdir -p "$sbx/inside" "$sbx/inside-proc"; : >"$sbx/.cqlite-perf-sandbox"
 mkdir -p "${sbx}evil"                       # the sibling whose NAME starts with the root's
 nostamp="$tmp/unstamped-root"; mkdir -p "$nostamp/inside"
@@ -858,29 +849,12 @@ done
 [ "$mtg_fail" -ne 0 ] || ok "perf-capability-test-lib: an unusable 'mktemp -d' (non-zero rc, or rc 0 with an empty path) REFUSES with a named reason, exits non-zero, never reaches the suite body, and creates no root-level path"
 
 # 1f. THE GATE IS SINGULAR AND UNSKIPPABLE — a STRUCTURAL audit (issue #3249 review R6-2).
-#     R6-2 was not a wrong check, it was a MISSING one: CQLITE_PERF_SYSCTL_EXTRA_DIRS was a
-#     new seam consumer, and the canonicalizing validation added for the write path simply
-#     never reached it. No behavioural case can catch that class, because the defect is a
-#     path nobody thought to test. So this audit enumerates, FROM THE SOURCE, every function
-#     that dereferences a seam variable and requires each one to route through the
-#     containment family (`perf_capability_sandbox_*` / `perf_capability_path_within`) — with
-#     ONE named, justified allowlist entry. A future entry point that reads a seam without
-#     the gate FAILS here, and joining the allowlist is a visible, reviewable act.
-# (rationale condensed; full reasoning in the commit history for #3261.)
+# (full rationale: fleet-runbook.md, perf seam containment, 1f-the-gate-is-singular-and-unskippable-a-stru)
 seam_audit=$(awk \
   -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
   -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
   # TWO representations, because the two matches want different things (roborev round 6, Low).
-  #   `code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
-  #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
-  #             stripping quoted spans would hide real consumers and silently shrink the census.
-  #   `codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
-  #             command, never a string, so matching inside quotes is what made the advertised
-  #             "command position" claim false — swapping a real call for a string that merely
-  #             mentions its name kept the audit green.
-  # Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
-  # line. The single quote is written \047: this awk program sits inside a shell single-quoted
-  # string and cannot contain a literal one.
+  # (full rationale: fleet-runbook.md, perf seam containment, two-representations-because-the-two-matches-wa)
   { code = $0
     sub(/[[:space:]]*#.*$/, "", code)
     codeq = $0
@@ -928,28 +902,12 @@ else
   printf '%s\n' "$seam_audit"
 fi
 # 1f-ii. THE SAME AUDIT FOR THE BINARIES THE GUARD AUTHORIZES (issue #3261 AC4). AC4 was the
-#        EIGHTH escape from this family and the first about an EXECUTABLE rather than a path:
-#        `CQLITE_PERF_TEST_PRIV_DIR=/usr` and a symlink-to-real-`sudo` inside a declared shim
-#        dir both passed a textual check, so a privileged test-mode bootstrap could run the
-#        host's real `sysctl --system`. Paths and executables are the same problem — a NAME is
-#        not a DESTINATION — so they get the same STRUCTURAL treatment: every function that
-#        resolves a privileged tool must route through the containment family, or be
-#        allowlisted by name with a reason. Floor + explicit expectations, same as above.
-# Same de-vacuuming as the seam audit above: comments stripped, gate matched in a command position.
+# (full rationale: fleet-runbook.md, perf seam containment, 1f-ii-the-same-audit-for-the-binaries-the-guar)
 priv_audit=$(awk \
   -v privre='(for [a-z_]+ in (sudo|sysctl)|command -v .*(sudo|sysctl))' \
   -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
   # TWO representations, because the two matches want different things (roborev round 6, Low).
-  #   `code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
-  #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
-  #             stripping quoted spans would hide real consumers and silently shrink the census.
-  #   `codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
-  #             command, never a string, so matching inside quotes is what made the advertised
-  #             "command position" claim false — swapping a real call for a string that merely
-  #             mentions its name kept the audit green.
-  # Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
-  # line. The single quote is written \047: this awk program sits inside a shell single-quoted
-  # string and cannot contain a literal one.
+  # (full rationale: fleet-runbook.md, perf seam containment, two-representations-because-the-two-matches-wa)
   { code = $0
     sub(/[[:space:]]*#.*$/, "", code)
     codeq = $0
@@ -1418,15 +1376,7 @@ printf '%s' "$cs_out" | grep -q 'perf_event_paranoid = 2' \
 # refusing everything.
 printf 'kernel.kptr_restrict = 1\n' >"$cs_dir/zz-real.conf" 2>/dev/null
 # ...and the NEWLINE-BASENAME case, now actually EXERCISED (roborev round 27, Low). This block used to
-# assign cs_nl and then write a different, ordinary filename, so the line-oriented edge case it claimed
-# to cover never ran — a test asserting coverage it did not provide, which is the exact shape this suite
-# exists to catch elsewhere. The scan emits one entry per line, so a basename containing a newline could
-# split one competitor into two reported lines; it must fail closed and inject no extra lines.
-# ISOLATED DIRECTORY, and a REQUIRED nonzero status (roborev round 28, Low). My round-27 repair of this
-# case was itself vacuous twice over: 00-host-link.conf stayed in $cs_dir and sorts BEFORE the
-# newline-named file, so the scan refused the symlink and never reached this subject; and the assertion
-# only fired on rc 0 PLUS a matched line, so a silent accept -- or a skip -- passed. Its own isolated
-# directory removes the ordering dependency, and the refusal is now REQUIRED rather than merely allowed.
+# (full rationale: fleet-runbook.md, perf seam containment, and-the-newline-basename-case-now-actually-ex)
 cs_nl_dir="$cs_root/nl-sysctl.d"; rm -rf "$cs_nl_dir"; mkdir -p "$cs_nl_dir"; chmod 0755 "$cs_nl_dir"
 cs_nl_name=$(printf 'zz-nl\ncompetitor.conf')
 # BASELINE FIRST, WITHOUT the newline file, and its status REQUIRED (roborev round 30, Low). My previous

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -308,10 +308,17 @@ done
 sbx="$tmp/sandbox"; mkdir -p "$sbx/inside" "$sbx/inside-proc"; : >"$sbx/.cqlite-perf-sandbox"
 mkdir -p "${sbx}evil"                       # the sibling whose NAME starts with the root's
 nostamp="$tmp/unstamped-root"; mkdir -p "$nostamp/inside"
+# The shim dir lives INSIDE the root each call declares. It has to: since #3261 AC4 a privileged
+# tool must RESOLVE beneath the proven sandbox root, so a shim dir outside it is refused on its own
+# merits — which would decide these cases for the wrong reason (they are about path containment).
+sbxpriv="$sbx/priv"; mkdir -p "$sbxpriv"
+for t in sudo sysctl; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$sbxpriv/$t"; chmod +x "$sbxpriv/$t"
+done
 guard_with_root() { # guard_with_root <sandbox-root> <proc-seam> <sysctl-seam> -> rc + stderr
-  # $realpriv FIRST on PATH with the same dir declared: the guard's OTHER refusal (a real
-  # sudo/sysctl reachable) must not be what decides these cases.
-  env PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
+  # The shim dir FIRST on PATH and declared as such: the guard's OTHER refusals (a real
+  # sudo/sysctl reachable, an unresolvable privileged tool) must not be what decides these cases.
+  env PATH="$1/priv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$1/priv" \
     CQLITE_PERF_TEST_SANDBOX="$1" CQLITE_PERF_PROC_DIR="$2" CQLITE_PERF_SYSCTL_DIR="$3" \
     bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1
 }

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1313,6 +1313,27 @@ done
 [ "$us_fail" -ne 0 ] || ok "perf-capability: a non-GNU host is reported as rc 2 UNSUPPORTED by name and writes nothing (broken stat -c and broken mv -T both), while an all-GNU host still installs (#3261 roborev-16/17)"
 fi
 
+# ...and a SYMLINKED CONTROL FILE inside a contained PROC_DIR must not be read (roborev round 25,
+# Medium). The directory gate proved the DIRECTORY contained and symlink-free and said nothing about its
+# ENTRIES, so `perf_event_paranoid` could be a link to the host file and the token would report a real or
+# attacker-chosen capability as if it came from the fixture. Same directory-is-not-its-entries lesson as
+# AC1, on the read path. The CONTROL is the identical tree with a REAL file, so the refusal cannot be
+# passing for an unrelated reason.
+pc_root=$(mktemp -d "$tmp/pc.XXXXXX"); : >"$pc_root/.cqlite-perf-sandbox"
+mkdir -p "$pc_root/proc"; chmod 0755 "$pc_root" "$pc_root/proc"
+printf '3\n' >"$pc_root/outside-paranoid"; printf '0\n' >"$pc_root/proc/kptr_restrict"
+ln -s "$pc_root/outside-paranoid" "$pc_root/proc/perf_event_paranoid"
+pc_link=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$pc_root" CQLITE_PERF_PROC_DIR="$pc_root/proc" \
+  bash -c '. "$1"; perf_capability_token' _ "$PERFLIB" 2>/dev/null)
+rm -f "$pc_root/proc/perf_event_paranoid"; printf '3\n' >"$pc_root/proc/perf_event_paranoid"
+pc_real=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$pc_root" CQLITE_PERF_PROC_DIR="$pc_root/proc" \
+  bash -c '. "$1"; perf_capability_token' _ "$PERFLIB" 2>/dev/null)
+if [ "$pc_link" = absent ] && [ "$pc_real" = paranoid-3 ]; then
+  ok "perf-capability: a SYMLINKED control file inside a contained PROC_DIR is refused (token 'absent', never a fabricated capability) while the same tree with a REAL file reads normally (#3261 roborev-25)"
+else
+  bad "perf-capability: symlinked control file handling wrong (symlinked token='$pc_link' expected absent; real token='$pc_real' expected paranoid-3)"
+fi
+
 # ...and LINE-SAFETY MUST BE JUDGED ON THE ORIGINAL PATH, not the canonicalized one (roborev round
 # 12, Medium). `$(cd -P -- "$p" && pwd -P)` STRIPS trailing newlines, so a directory whose name ends
 # in LF used to pass: the check only ever saw the stripped form, while every later caller emitted the

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -863,8 +863,12 @@ done
 #     Same shape as the fork-free audit in test_agent_gate_summary.sh: parse the function
 #     bodies (a column-0 `name() {` … column-0 `}`), and treat FINDING NOTHING as a failure,
 #     so a parser that stops matching can never pass this vacuously.
+#
+#     EXTENDED TO THE PRIVILEGE SHIM (issue #3261 AC4). The guard authorizes EXECUTABLES as
+#     well as paths, and CQLITE_PERF_TEST_PRIV_DIR was read TEXTUALLY — so it joins the seam
+#     regex below, and a second pass audits every function that RESOLVES a privileged tool.
 seam_audit=$(awk \
-  -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX)' \
+  -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
   -v gatere='perf_capability_(sandbox_|path_within)' '
   /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
     fn = $1; sub(/\(\)$/, "", fn); seam = 0; gate = 0
@@ -894,16 +898,248 @@ while read -r fn seam gate; do
 done <<EOF
 $seam_audit
 EOF
-# 4 is the count at the time of writing (proc_dir_into, sysctl_dir, sysctl_search_path,
-# test_seams_ok) plus the two allowlisted readers; the assert is a FLOOR, so adding a
-# consumer is fine and losing the parse is not.
-if [ "$seam_consumers" -ge 5 ] && [ -z "$seam_ungated" ] \
+# 5 is the count at the time of writing (proc_dir_into, sysctl_dir, sysctl_search_path,
+# test_seams_ok, env_guard) plus the two allowlisted readers; the assert is a FLOOR, so adding
+# a consumer is fine and losing the parse is not.
+if [ "$seam_consumers" -ge 6 ] && [ -z "$seam_ungated" ] \
    && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_sysctl_search_path 1 1$' \
-   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_proc_dir_into 1 1$'; then
-  ok "perf-capability: STRUCTURAL — all $seam_consumers seam-dereferencing functions route through the single containment gate (only the documented presence-check + the root reader are allowlisted), so a new entry point cannot silently skip it"
+   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_proc_dir_into 1 1$' \
+   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_env_guard 1 1$'; then
+  ok "perf-capability: STRUCTURAL — all $seam_consumers seam-dereferencing functions (CQLITE_PERF_TEST_PRIV_DIR included) route through the single containment gate (only the documented presence-check + the root reader are allowlisted), so a new entry point cannot silently skip it"
 else
   bad "perf-capability: STRUCTURAL audit failed — seam consumers found: $seam_consumers; UNGATED:${seam_ungated:- none}"
   printf '%s\n' "$seam_audit"
+fi
+# 1f-ii. THE SAME AUDIT FOR THE BINARIES THE GUARD AUTHORIZES (issue #3261 AC4). AC4 was the
+#        EIGHTH escape from this family and the first about an EXECUTABLE rather than a path:
+#        `CQLITE_PERF_TEST_PRIV_DIR=/usr` and a symlink-to-real-`sudo` inside a declared shim
+#        dir both passed a textual check, so a privileged test-mode bootstrap could run the
+#        host's real `sysctl --system`. Paths and executables are the same problem — a NAME is
+#        not a DESTINATION — so they get the same STRUCTURAL treatment: every function that
+#        resolves a privileged tool must route through the containment family, or be
+#        allowlisted by name with a reason. Floor + explicit expectations, same as above.
+priv_audit=$(awk \
+  -v privre='(for [a-z_]+ in (sudo|sysctl)|command -v .*(sudo|sysctl))' \
+  -v gatere='perf_capability_(sandbox_|path_within)' '
+  /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
+    fn = $1; sub(/\(\)$/, "", fn); priv = 0; gate = 0
+    if ($0 ~ privre) priv = 1
+    if ($0 ~ gatere) gate = 1
+    if ($0 ~ /\}[[:space:]]*$/) { printf "%s %d %d\n", fn, priv, gate; inb = 0 }
+    else inb = 1
+    next
+  }
+  inb && /^\}/ { printf "%s %d %d\n", fn, priv, gate; inb = 0; next }
+  inb {
+    if ($0 ~ privre) priv = 1
+    if ($0 ~ gatere) gate = 1
+  }
+' "$PERFLIB")
+# The ONE function allowed to resolve a privileged tool without the containment gate, and why:
+# perf_capability_drop_prefix_into resolves setpriv/runuser/sudo to DE-escalate (run the `perf
+# stat` probe as a LESS privileged identity). It cannot grant privilege, and in test mode
+# perf_capability_env_guard has already refused if any real sudo/sysctl was reachable at all —
+# so its inputs are already contained by the time it runs. Joining this list is a visible act.
+priv_audit_allow=' perf_capability_drop_prefix_into '
+priv_consumers=0; priv_ungated=''
+while read -r fn priv gate; do
+  [ -n "$fn" ] || continue
+  [ "$priv" = 1 ] || continue
+  priv_consumers=$((priv_consumers + 1))
+  case "$priv_audit_allow" in *" $fn "*) continue ;; esac
+  [ "$gate" = 1 ] || priv_ungated="$priv_ungated $fn"
+done <<EOF
+$priv_audit
+EOF
+if [ "$priv_consumers" -ge 2 ] && [ -z "$priv_ungated" ] \
+   && printf '%s\n' "$priv_audit" | grep -q '^perf_capability_env_guard 1 1$'; then
+  ok "perf-capability: STRUCTURAL — all $priv_consumers functions that RESOLVE a privileged tool route through the containment gate (only the documented de-escalation prefix builder is allowlisted), so the EXECUTABLES the guard authorizes are validated by destination too (#3261 AC4)"
+else
+  bad "perf-capability: STRUCTURAL privilege-shim audit failed — resolvers found: $priv_consumers; UNGATED:${priv_ungated:- none}"
+  printf '%s\n' "$priv_audit"
+fi
+
+# ---- 1g. #3261: A NAME IS NOT A DESTINATION — the four remaining escapes ------------------
+# Positive containment closed the PATH SPELLINGS. These four are what containment of a
+# spelling still does not buy, and each is asserted BY ITS OWN OBSERVABLE CONSEQUENCE (a
+# followed write, a fabricated /proc verdict, a refused legitimate file, a real privileged
+# tool), never by an rc alone — this guard has several refusals and an rc-only check would let
+# the wrong one satisfy the case.
+
+# 1g-i. AC1 (High) — DIRECTORY containment is not WRITE-TARGET containment. `tee <path>` opens
+#       O_WRONLY|O_CREAT|O_TRUNC and FOLLOWS a symlink, so a symlink at the managed basename
+#       inside a perfectly-contained directory pointed the privileged write at the LINK'S
+#       TARGET — anywhere on the box. A contained directory says nothing about where its
+#       entries point. Two independent requirements, both asserted:
+#         * anything that merely NAMES the write target REFUSES (rc 1, empty, loud);
+#         * the WRITE ITSELF replaces the directory ENTRY (rename), so a symlink planted in
+#           the window between the check and the write is replaced, not written through.
+wt_d="$tmp/wt-sandbox.d"; mkdir -p "$wt_d"
+wt_outside="$tmp/wt-outside-target"; printf 'PRECIOUS-HOST-FILE\n' >"$wt_outside"
+wt_before=$(cat "$wt_outside")
+rm -f "$wt_d/99-cqlite-perf.conf"; ln -s "$wt_outside" "$wt_d/99-cqlite-perf.conf"
+wt_path=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash "$PERFLIB" --drop-in-path 2>/dev/null); wt_rc=$?
+wt_err=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash "$PERFLIB" --drop-in-path 2>&1 >/dev/null)
+if [ "$wt_rc" -ne 0 ] && [ -z "$wt_path" ] \
+   && printf '%s' "$wt_err" | grep -qi 'symlink' \
+   && [ -L "$wt_d/99-cqlite-perf.conf" ] && [ "$(cat "$wt_outside")" = "$wt_before" ]; then
+  ok "perf-capability: the drop-in WRITE TARGET is refused when the managed basename is itself a SYMLINK (rc 1, empty, named) — a contained directory does not license writing through its entries (#3261 AC1)"
+else
+  bad "perf-capability: a SYMLINKED write target was NAMED for a privileged tee (rc=$wt_rc, path='$wt_path', err='$wt_err')"
+fi
+# ...and the CONTENTS read that decides idempotency may not follow it either: a symlink whose
+# TARGET happens to hold the canonical bytes must not report "already current" (that would
+# leave the host file in place and claim success).
+printf '%s\n' "$(bash "$PERFLIB" --drop-in)" >"$wt_outside"
+if env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB" 2>/dev/null; then
+  bad "perf-capability: dropin_current followed a SYMLINK and reported the drop-in 'already current' from a file outside the managed name"
+else
+  ok "perf-capability: dropin_current does NOT follow a symlinked managed name, even when the link's TARGET holds byte-identical canonical content (#3261 AC1)"
+fi
+# ...and the WRITE replaces the ENTRY. The refusal above is a check with a TOCTOU window; the
+# rename has none. After it, the managed name is a REGULAR file holding the canonical bytes,
+# the outside target is byte-identical to before, and no temp entry is left behind.
+wt_outside_bytes=$(cat "$wt_outside")
+wt_ins=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
+  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ins_rc=$?
+wt_leftover=$(ls -A "$wt_d" | grep -v '^99-cqlite-perf\.conf$' || true)
+if [ "$wt_ins_rc" -eq 0 ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ] && [ -f "$wt_d/99-cqlite-perf.conf" ] \
+   && [ "$(cat "$wt_outside")" = "$wt_outside_bytes" ] && [ -z "$wt_leftover" ] \
+   && env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB"; then
+  ok "perf-capability: the drop-in write REPLACES the directory entry (temp + rename), so a pre-existing symlink at the managed name is replaced and its outside target is untouched — and no temp entry is left behind (#3261 AC1)"
+else
+  bad "perf-capability: the atomic drop-in install did not replace a symlinked entry (rc=$wt_ins_rc, out='$wt_ins', link=$([ -L "$wt_d/99-cqlite-perf.conf" ] && echo yes || echo no), leftover='$wt_leftover', outside-changed=$([ "$(cat "$wt_outside")" = "$wt_outside_bytes" ] && echo no || echo YES))"
+fi
+# ...and the install is still gated: an out-of-sandbox seam may not be written at all.
+if env CQLITE_PERF_SYSCTL_DIR="$symanc/sysctl.d" \
+     bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" >/dev/null 2>&1; then
+  bad "perf-capability: dropin_install wrote through a seam resolving OUT of the sandbox"
+else
+  ok "perf-capability: dropin_install inherits the containment gate — a seam resolving out of the sandbox writes nothing"
+fi
+
+# 1g-ii. AC2 (Medium) — the inversion REGRESSED symlink rejection on the READ path. The
+#        fork-free proc check judges the SPELLING, so a symlink INSIDE the sandbox pointing at
+#        the real /proc/sys/kernel satisfies containment: the run then reports a capability
+#        token derived from the HOST's real controls while claiming to have read a stand-in.
+#        That is a FABRICATED verdict, which is worse than a refusal, and it is a regression
+#        against the pre-inversion behaviour. The token path is contractually fork-free, so the
+#        fix must reject symlinked COMPONENTS with builtins only.
+ac2_fail=0
+ac2_link="$tmp/ac2-proc-is-a-symlink"; rm -f "$ac2_link"; ln -s /proc/sys/kernel "$ac2_link"
+ac2_dirlink="$tmp/ac2-ancestor-link"; rm -f "$ac2_dirlink"; ln -s /proc/sys "$ac2_dirlink"
+for ac2_seam in "$ac2_link" "$ac2_dirlink/kernel"; do
+  ac2_tok=$(env CQLITE_PERF_PROC_DIR="$ac2_seam" bash "$PERFLIB" --token 2>/dev/null)
+  [ "$ac2_tok" = absent ] || {
+    bad "perf-capability: the fork-free READ path followed a SYMLINK inside the sandbox to the real /proc and reported a FABRICATED token '$ac2_tok' for seam '$ac2_seam' (expected 'absent')"
+    ac2_fail=1; }
+  env CQLITE_PERF_PROC_DIR="$ac2_seam" \
+    bash -c '. "$1"; perf_capability_proc_dir_into d' _ "$PERFLIB" >/dev/null 2>&1 && {
+    bad "perf-capability: proc_dir_into ACCEPTED a symlinked seam '$ac2_seam'"; ac2_fail=1; }
+done
+[ "$ac2_fail" -ne 0 ] || ok "perf-capability: the fork-free READ path rejects a SYMLINKED path component even when the SPELLING is strictly inside the sandbox — a symlink to the real /proc/sys/kernel reads nothing (token 'absent'), never a fabricated capability (#3261 AC2)"
+# ...and the rejection is not vacuous: a REAL directory of the same shape still reads.
+ac2_real="$tmp/ac2-real-proc"; mkdir -p "$ac2_real"
+printf '%s\n' -1 >"$ac2_real/perf_event_paranoid"; printf '%s\n' 0 >"$ac2_real/kptr_restrict"
+if [ "$(env CQLITE_PERF_PROC_DIR="$ac2_real" bash "$PERFLIB" --token 2>/dev/null)" = ok ]; then
+  ok "perf-capability: a REAL (symlink-free) stand-in directory inside the sandbox still reads — the AC2 rejection is per-component, not a blanket refusal"
+else
+  bad "perf-capability: the symlink rejection made the fork-free read path vacuous (a real stand-in dir no longer reads)"
+fi
+
+# 1g-iii. AC3 (Low) — a STRICTLY CONTAINED file was wrongly REFUSED. The file variant judged
+#         its PARENT with the strict-containment predicate, so `<root>/sysctl.conf` failed:
+#         the parent IS the root, and a root is not strictly inside itself. The judged path
+#         must be <canonical parent>/<basename>, which IS strictly inside. A guard that
+#         refuses legitimate input is the guard people learn to work around, so this is a
+#         correctness case, not a convenience.
+ac3_ok() { env CQLITE_PERF_TEST_SANDBOX="$1" \
+  bash -c '. "$1"; perf_capability_sandbox_file_ok_resolved "$2"' _ "$PERFLIB" "$2"; }
+: >"$sbx/sysctl.conf"
+ac3_fail=0
+ac3_ok "$sbx" "$sbx/sysctl.conf" || { bad "perf-capability: '<sandbox-root>/sysctl.conf' was REFUSED though strictly contained"; ac3_fail=1; }
+ac3_ok "$sbx" "$sbx/inside/sysctl.conf" || { bad "perf-capability: a sysctl.conf one level deeper inside the sandbox was refused"; ac3_fail=1; }
+# ...while every genuine escape is still refused: outside the root, the root itself, a `..`
+# spelling, and — the AC1 lesson applied here — a SYMLINKED final component, whose CONTENTS
+# the competing-file scan would otherwise read out of the host's real configuration.
+rm -f "$sbx/linked-sysctl.conf"; ln -s /etc/sysctl.conf "$sbx/linked-sysctl.conf"
+for ac3_bad in "$tmp/outside-the-root/sysctl.conf" "$sbx" "$sbx/../sysctl.conf" \
+               "$sbx/linked-sysctl.conf" "relative/sysctl.conf" ''; do
+  ac3_ok "$sbx" "$ac3_bad" && { bad "perf-capability: sandbox_file_ok_resolved ACCEPTED '$ac3_bad'"; ac3_fail=1; }
+done
+[ "$ac3_fail" -ne 0 ] || ok "perf-capability: the FILE variant accepts a strictly-contained '<root>/sysctl.conf' (canonical parent + basename) while still refusing one outside the root, the root itself, a '..' spelling, a relative path and a SYMLINKED final component (#3261 AC3)"
+# ...and end-to-end through the seam that consumes it: a contained sysctl.conf stand-in is a
+# legitimate CQLITE_PERF_SYSCTL_EXTRA_DIRS entry and must appear on the search path.
+: >"$tmp/sysctl.conf"
+ac3_path=$(env CQLITE_PERF_SYSCTL_DIR="$seamed_d" CQLITE_PERF_SYSCTL_EXTRA_DIRS="$tmp/sysctl.conf" \
+  bash -c '. "$1"; perf_capability_sysctl_search_path' _ "$PERFLIB" 2>/dev/null); ac3_path_rc=$?
+if [ "$ac3_path_rc" -eq 0 ] && printf '%s\n' "$ac3_path" | grep -qx -- "$tmp/sysctl.conf"; then
+  ok "perf-capability: a sysctl.conf stand-in directly inside the sandbox root is accepted as a CQLITE_PERF_SYSCTL_EXTRA_DIRS entry and reaches the search path (#3261 AC3, end to end)"
+else
+  bad "perf-capability: a contained sysctl.conf stand-in was dropped from the test-mode search path (rc=$ac3_path_rc, path='$ac3_path')"
+fi
+
+# 1g-iv. AC4 (High) — the guard authorizes EXECUTABLES, and never resolved them. Two escapes,
+#        one shape: an absolute shim dir that is not in the sandbox at all (`/usr` — it does
+#        contain the real /usr/bin/sudo, so the textual "inside the declared dir" check
+#        PASSED), and a SYMLINK to the real tool sitting inside a genuine shim dir (spelled
+#        locally, resolving to the host's binary). Either one let a privileged test-mode
+#        bootstrap execute a real `sysctl --system` and reconfigure the host kernel.
+#        `$ac4_sys` stands in for `/usr` PORTABLY: an absolute directory OUTSIDE the declared
+#        sandbox root that holds tools named `sudo`/`sysctl`. Asserting against the literal
+#        /usr would make the case depend on whether this host happens to ship sudo there.
+ac4_sys=''
+if ac4_sys=$(mktemp -d "${TMPDIR:-/tmp}/perf-cap-outside.XXXXXX") && [ -d "$ac4_sys" ]; then
+  trap 'rm -rf "$tmp" "$ac4_sys"' EXIT
+else
+  ac4_sys=''
+fi
+if [ -z "$ac4_sys" ]; then
+  bad "perf-capability: could not create the out-of-sandbox dir the AC4 cases need"
+else
+  for t in sudo sysctl; do
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$ac4_sys/$t"; chmod +x "$ac4_sys/$t"
+  done
+  ac4_guard() { # ac4_guard <PATH-prefix> <priv-dir> -> rc + stderr; sandbox root is $sbx
+    env PATH="$1:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$sbx" \
+      CQLITE_PERF_TEST_PRIV_DIR="$2" CQLITE_PERF_PROC_DIR="$sbx/inside-proc" \
+      CQLITE_PERF_SYSCTL_DIR="$sbx/inside" \
+      bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1
+  }
+  ac4_fail=0
+  # (a) the `/usr` shape: absolute, CONTAINS the tools, not in the sandbox.
+  ac4_out=$(ac4_guard "$ac4_sys" "$ac4_sys") && ac4_fail=1
+  printf '%s' "$ac4_out" | grep -q 'sandbox' || ac4_fail=1
+  [ "$ac4_fail" -eq 0 ] || bad "perf-capability: an absolute shim dir OUTSIDE the sandbox root (the '/usr' shape) was accepted, or refused without naming the sandbox: '$ac4_out'"
+  # (b) the SYMLINK shape: a declared shim dir genuinely inside the sandbox, whose `sudo`
+  #     RESOLVES to the tool outside it.
+  ac4_link="$sbx/ac4-shims"; mkdir -p "$ac4_link"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$ac4_link/sysctl"; chmod +x "$ac4_link/sysctl"
+  rm -f "$ac4_link/sudo"; ln -s "$ac4_sys/sudo" "$ac4_link/sudo"
+  ac4_out2=$(ac4_guard "$ac4_link" "$ac4_link") && {
+    bad "perf-capability: a SYMLINK to a real privileged tool inside the declared shim dir was accepted — test mode could run the host's own sudo/sysctl"; ac4_fail=1; }
+  # (c) the SWEEP: with NO sudo/sysctl reachable on PATH at all the per-tool loop resolves
+  #     nothing, so a symlinked `sysctl` PARKED in the declared shim dir must still be
+  #     refused — otherwise it is one PATH-order change away from being executed.
+  ac4_nopath="$sbx/ac4-nopath"; mkdir -p "$ac4_nopath"
+  for t in bash cat printf env grep; do
+    s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$ac4_nopath/$t"
+  done
+  ac4_park="$sbx/ac4-parked"; mkdir -p "$ac4_park"
+  rm -f "$ac4_park/sysctl"; ln -s "$ac4_sys/sysctl" "$ac4_park/sysctl"
+  ac4_out3=$(env PATH="$ac4_nopath" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$sbx" \
+    CQLITE_PERF_TEST_PRIV_DIR="$ac4_park" CQLITE_PERF_PROC_DIR="$sbx/inside-proc" \
+    CQLITE_PERF_SYSCTL_DIR="$sbx/inside" \
+    bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1) && {
+    bad "perf-capability: a privileged tool PARKED as a symlink in the declared shim dir was accepted because PATH did not happen to reach it"; ac4_fail=1; }
+  # ...and NOT vacuous: a shim dir inside the sandbox holding REAL FILES is still accepted.
+  ac4_good="$sbx/ac4-good-shims"; mkdir -p "$ac4_good"
+  for t in sudo sysctl; do
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$ac4_good/$t"; chmod +x "$ac4_good/$t"
+  done
+  ac4_guard "$ac4_good" "$ac4_good" >/dev/null 2>&1 || {
+    bad "perf-capability: a legitimate shim dir of REAL FILES inside the sandbox was refused — the AC4 fix is vacuous"; ac4_fail=1; }
+  [ "$ac4_fail" -ne 0 ] || ok "perf-capability: every privileged executable the guard authorizes is validated by DESTINATION — a shim dir outside the sandbox ('/usr' shape), a symlink to a real tool inside a declared shim dir, and one merely PARKED there out of PATH reach are all refused, while a shim dir of real files inside the sandbox still works (#3261 AC4)"
 fi
 
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1278,9 +1278,9 @@ fi
 # caller-side probe can check a different binary than the one that will run) and `mv -T` is EXERCISED
 # rather than grepped out of --help. The all-GNU control is what stops this passing by refusing always.
 us_fail=0
-# GUARDED like the staged-install cases (roborev round 21, Medium). This group's CONTROL case expects a
-# successful install using the HOST's own stat and mv, so on a non-GNU host the control necessarily
-# returns rc 2 and the suite fails — reintroducing exactly the macOS breakage the counted skip fixed.
+# GUARDED like the staged-install cases (roborev round 21, Medium): this group's CONTROL expects a
+# successful install using the HOST's stat/mv, so off GNU it necessarily returns rc 2 and the suite
+# fails — reintroducing the macOS breakage the counted skip fixed.
 if ! perf_install_supported; then
   skip "perf-capability: UNSUPPORTED-host reporting cases (rc 2 for broken stat -c / mv -T, with an all-GNU control)" "no GNU stat -c / mv --no-target-directory on this host, so the control case cannot install"
 else

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1099,6 +1099,84 @@ else
   bad "perf-capability: the staged write was redirected through a symlink-to-directory at the managed name (rc=$wt_td_rc, outside-dir='$wt_outdir_contents', leftover='$wt_td_leftover', out='$wt_td')"
 fi
 rm -f "$wt_d/99-cqlite-perf.conf"
+# ...and THE PRECONDITION THAT ACTUALLY CLOSES THE STAGING RACE (issue #3261, roborev round 3): a
+# drop-in directory writable by anyone less privileged than the writer is REFUSED before anything is
+# staged. Three rounds of this defect were each answered by trying to make the race unwinnable
+# (unpredictable name, then one privileged invocation); neither works, because a single `sh -c`
+# sequences OUR commands and says nothing about other processes on other CPUs. Removing the
+# attacker's precondition does work — with no one able to create or replace entries in the
+# directory, there is no actor to race, whatever the timing.
+# The negative control is the whole point of the group: a check that refuses everything would pass
+# the two refusal cases and be useless, so a correctly-owned 0755 directory must still install.
+wt_perm_d="$tmp/wt-perm.d"
+wt_perm_fail=0
+for wt_mode in 0775 0777 0757; do
+  rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod "$wt_mode" "$wt_perm_d"
+  wt_perm_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_perm_rc=$?
+  wt_perm_left=$(ls -A "$wt_perm_d")
+  if [ "$wt_perm_rc" -eq 0 ] \
+     || ! printf '%s' "$wt_perm_out" | grep -q 'group- or world-writable' \
+     || [ -n "$wt_perm_left" ]; then
+    bad "perf-capability: a mode-$wt_mode drop-in directory was accepted for a privileged staged write (rc=$wt_perm_rc, left='$wt_perm_left', out='$wt_perm_out')"
+    wt_perm_fail=1
+  fi
+done
+# ...the NEGATIVE CONTROL: a directory owned by the writer and not group/world-writable installs.
+rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
+wt_ok_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
+  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ok_rc=$?
+if [ "$wt_ok_rc" -ne 0 ] || [ ! -f "$wt_perm_d/99-cqlite-perf.conf" ]; then
+  bad "perf-capability: a correctly-owned 0755 drop-in directory was REFUSED — the writability precondition is vacuous (rc=$wt_ok_rc, out='$wt_ok_out')"
+  wt_perm_fail=1
+fi
+# ...and an UNDETERMINABLE owner/mode is a refusal, not an assumption: with `stat` unusable the
+# install must fail closed rather than proceed on the hope that the directory is fine.
+wt_nostat="$tmp/wt-nostat"; mkdir -p "$wt_nostat"
+for t in bash sh cat printf tee mv rm chmod env grep mktemp id; do
+  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$wt_nostat/$t"
+done
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$wt_nostat/stat"; chmod +x "$wt_nostat/stat"
+rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
+wt_ns_out=$(env PATH="$wt_nostat" CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
+  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ns_rc=$?
+if [ "$wt_ns_rc" -eq 0 ] || ! printf '%s' "$wt_ns_out" | grep -q 'cannot determine owner/mode'; then
+  bad "perf-capability: an undeterminable directory owner/mode did not fail closed (rc=$wt_ns_rc, out='$wt_ns_out')"
+  wt_perm_fail=1
+fi
+[ "$wt_perm_fail" -ne 0 ] || ok "perf-capability: a privileged staged install REFUSES a group-/world-writable drop-in directory by name and writes nothing, refuses when owner/mode cannot be determined, and still installs into a correctly-owned 0755 directory — the staging race is closed at its PRECONDITION rather than by trying to win it (#3261 roborev-3)"
+
+# ...and CR/LF IN A PATH SEAM IS REFUSED (issue #3261, roborev round 3). Not a containment defect —
+# the path IS contained — a SERIALIZATION one, which is why nine rounds of containment work never
+# saw it: the search path is emitted ONE ENTRY PER LINE and read back line-wise, so a contained
+# directory NAMED with an embedded newline splits into TWO entries, the second being the host's real
+# /etc/sysctl.d. One contained path becomes two paths, one of them production.
+wt_nl_root="$tmp/wt-nl-root"; mkdir -p "$wt_nl_root"; : >"$wt_nl_root/.cqlite-perf-sandbox"
+wt_nl_seam="$wt_nl_root/evil
+/etc/sysctl.d"
+mkdir -p "$wt_nl_seam" 2>/dev/null
+wt_nl_out=$(env CQLITE_PERF_TEST_SANDBOX="$wt_nl_root" CQLITE_PERF_SYSCTL_DIR="$wt_nl_seam" \
+  bash -c '. "$1"; perf_capability_sysctl_search_path' _ "$PERFLIB" 2>/dev/null); wt_nl_rc=$?
+wt_nl_extra=$(env CQLITE_PERF_TEST_SANDBOX="$wt_nl_root" CQLITE_PERF_SYSCTL_DIR="$seamed_d" \
+  CQLITE_PERF_SYSCTL_EXTRA_DIRS="$wt_nl_seam" \
+  bash -c '. "$1"; perf_capability_sysctl_search_path' _ "$PERFLIB" 2>/dev/null); wt_nl_extra_rc=$?
+if [ "$wt_nl_rc" -ne 0 ] && [ "$wt_nl_extra_rc" -ne 0 ] \
+   && ! printf '%s\n' "$wt_nl_out" | grep -qx -- /etc/sysctl.d \
+   && ! printf '%s\n' "$wt_nl_extra" | grep -qx -- /etc/sysctl.d; then
+  ok "perf-capability: a CONTAINED path carrying an embedded newline is REFUSED as a seam and as an extra-dirs entry, so it can never SERIALIZE into two search-path entries whose second line is the host's real /etc/sysctl.d (#3261 roborev-3)"
+else
+  bad "perf-capability: an embedded-newline path was serialized into the search path (seam rc=$wt_nl_rc '$wt_nl_out'; extra rc=$wt_nl_extra_rc '$wt_nl_extra')"
+fi
+# ...and a CR is refused for the same reason (a CRLF-authored value would leave a stray \r inside a
+# resolved entry), while the predicate stays non-vacuous on an ordinary path.
+if env bash -c '. "$1"; perf_capability_path_lines_ok "$2"' _ "$PERFLIB" "$(printf '/tmp/a\rb')"; then
+  bad "perf-capability: a path containing CR was accepted by the line-safety predicate"
+elif ! env bash -c '. "$1"; perf_capability_path_lines_ok "$2"' _ "$PERFLIB" /tmp/ordinary/path; then
+  bad "perf-capability: the line-safety predicate rejects an ordinary path (vacuous)"
+else
+  ok "perf-capability: the line-safety predicate rejects CR as well as LF and still accepts an ordinary path"
+fi
+
 # ...and the install is still gated: an out-of-sandbox seam may not be written at all.
 if env CQLITE_PERF_SYSCTL_DIR="$symanc/sysctl.d" \
      bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" >/dev/null 2>&1; then

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1388,9 +1388,26 @@ printf '%s' "$cs_out" | grep -q 'REFUSING to scan' \
 printf '%s' "$cs_out" | grep -q 'perf_event_paranoid = 2' \
   && { bad "perf-capability: the scan LEAKED host competitor content through a symlink"; cs_fail=1; }
 # ...the NEGATIVE CONTROL: a REAL file inside the sandbox is still scanned, so the check is not
-# refusing everything. A newline in the basename is included here because the scan is line-oriented.
-cs_nl=$(printf 'zz-real\ncompetitor.conf')
+# refusing everything.
 printf 'kernel.kptr_restrict = 1\n' >"$cs_dir/zz-real.conf" 2>/dev/null
+# ...and the NEWLINE-BASENAME case, now actually EXERCISED (roborev round 27, Low). This block used to
+# assign cs_nl and then write a different, ordinary filename, so the line-oriented edge case it claimed
+# to cover never ran — a test asserting coverage it did not provide, which is the exact shape this suite
+# exists to catch elsewhere. The scan emits one entry per line, so a basename containing a newline could
+# split one competitor into two reported lines; it must fail closed and inject no extra lines.
+cs_nl_name=$(printf 'zz-nl\ncompetitor.conf')
+if printf 'kernel.kptr_restrict = 1\n' >"$cs_dir/$cs_nl_name" 2>/dev/null; then
+  cs_nl_out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
+    CQLITE_PERF_SYSCTL_DIR="$cs_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
+    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_nl_rc=$?
+  if [ "$cs_nl_rc" -eq 0 ] && printf '%s' "$cs_nl_out" | grep -qx -- 'competitor.conf'; then
+    bad "perf-capability: a newline in a competitor BASENAME split into an extra reported entry (rc=$cs_nl_rc, out='$cs_nl_out')"
+    cs_fail=1
+  fi
+  rm -f -- "$cs_dir/$cs_nl_name"
+else
+  skip "perf-capability: newline-in-basename competitor case" "this filesystem refused to create a filename containing a newline"
+fi
 cs_ok_out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
   CQLITE_PERF_SYSCTL_DIR="$cs_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
   bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_ok_rc=$?

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -874,21 +874,29 @@ done
 #     EXTENDED TO THE PRIVILEGE SHIM (issue #3261 AC4). The guard authorizes EXECUTABLES as
 #     well as paths, and CQLITE_PERF_TEST_PRIV_DIR was read TEXTUALLY — so it joins the seam
 #     regex below, and a second pass audits every function that RESOLVES a privileged tool.
+# CODE ONLY, AND CALL SITES ONLY (roborev round 5, Low). These audits used to match the gate name
+# against RAW lines, so PROSE counted: deleting a real `perf_capability_sandbox_ok` call while leaving
+# a comment that mentions it kept the "unskippable" audit GREEN. An audit that a comment can satisfy
+# is the vacuous-pass shape this repo already has a rule against, and it was cited upward as evidence,
+# so it had to become real. Two changes: `#` comments are stripped before any matching, and the gate
+# must appear in a COMMAND POSITION (start of line or after whitespace/`(`/`|`/`&`/`;`, followed by
+# whitespace, `)` or end) rather than merely occurring somewhere in the text.
 seam_audit=$(awk \
   -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
-  -v gatere='perf_capability_(sandbox_|path_within)' '
+  -v gatere='(^|[^A-Za-z0-9_])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
+  { code = $0; sub(/[[:space:]]*#.*$/, "", code) }
   /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
     fn = $1; sub(/\(\)$/, "", fn); seam = 0; gate = 0
-    if ($0 ~ seamre) seam = 1
-    if ($0 ~ gatere) gate = 1
+    if (code ~ seamre) seam = 1
+    if (code ~ gatere) gate = 1
     if ($0 ~ /\}[[:space:]]*$/) { printf "%s %d %d\n", fn, seam, gate; inb = 0 }
     else inb = 1
     next
   }
   inb && /^\}/ { printf "%s %d %d\n", fn, seam, gate; inb = 0; next }
   inb {
-    if ($0 ~ seamre) seam = 1
-    if ($0 ~ gatere) gate = 1
+    if (code ~ seamre) seam = 1
+    if (code ~ gatere) gate = 1
   }
 ' "$PERFLIB")
 # The ONLY function allowed to read a seam without the gate, and why: it asks whether a seam
@@ -925,21 +933,23 @@ fi
 #        not a DESTINATION — so they get the same STRUCTURAL treatment: every function that
 #        resolves a privileged tool must route through the containment family, or be
 #        allowlisted by name with a reason. Floor + explicit expectations, same as above.
+# Same de-vacuuming as the seam audit above: comments stripped, gate matched in a command position.
 priv_audit=$(awk \
   -v privre='(for [a-z_]+ in (sudo|sysctl)|command -v .*(sudo|sysctl))' \
-  -v gatere='perf_capability_(sandbox_|path_within)' '
+  -v gatere='(^|[^A-Za-z0-9_])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
+  { code = $0; sub(/[[:space:]]*#.*$/, "", code) }
   /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
     fn = $1; sub(/\(\)$/, "", fn); priv = 0; gate = 0
-    if ($0 ~ privre) priv = 1
-    if ($0 ~ gatere) gate = 1
+    if (code ~ privre) priv = 1
+    if (code ~ gatere) gate = 1
     if ($0 ~ /\}[[:space:]]*$/) { printf "%s %d %d\n", fn, priv, gate; inb = 0 }
     else inb = 1
     next
   }
   inb && /^\}/ { printf "%s %d %d\n", fn, priv, gate; inb = 0; next }
   inb {
-    if ($0 ~ privre) priv = 1
-    if ($0 ~ gatere) gate = 1
+    if (code ~ privre) priv = 1
+    if (code ~ gatere) gate = 1
   }
 ' "$PERFLIB")
 # The ONE function allowed to resolve a privileged tool without the containment gate, and why:
@@ -1114,7 +1124,13 @@ rm -f "$wt_d/99-cqlite-perf.conf"
 # the two refusal cases and be useless, so a correctly-owned 0755 directory must still install.
 wt_perm_d="$tmp/wt-perm.d"
 wt_perm_fail=0
-for wt_mode in 0775 0777 0757; do
+# SHORT MODES ARE THE INTERESTING ONES (roborev round 5, High). `stat -c %a` drops leading zeros, so
+# 0033 arrives as "33" — two characters. The old `${dmode%???}` suffix-strip could not match that,
+# left the permission field EMPTY, matched none of the write-bit patterns, and PASSED a group- AND
+# world-writable directory. These three are exactly the shapes that regress it: group-only (0030),
+# other-only (0003), and both (0033). 0300 is the CONTROL — owner-write only, three digits, must be
+# ACCEPTED — so the case cannot pass by refusing everything short.
+for wt_mode in 0775 0777 0757 0030 0003 0033; do
   rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod "$wt_mode" "$wt_perm_d"
   wt_perm_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
     bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_perm_rc=$?

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -276,11 +276,7 @@ guard_rejects_seam SYSCTL "$seamed_proc" "$symseam" || {
 guard_rejects_seam PROC "$symproc" "$seamed_d" || {
   bad "perf-capability: test mode ACCEPTED a proc seam that is a SYMLINK to /proc/sys/kernel"; badseam_fail=1; }
 # ...and the SPELLING is not the destination. `/tmp/../etc/sysctl.d`, `<symlink-to-/etc>/…`
-# and — the R6-1 escape — `//etc/sysctl.d` (POSIX leaves two leading slashes
-# implementation-defined and `pwd -P` may PRESERVE them, while on Linux `//etc` IS `/etc`)
-# each passed the textual checks of an earlier round. There is no per-spelling check any
-# more: containment refuses all of them, plus every future spelling, for the SAME reason.
-# An UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
+# (full rationale: fleet-runbook.md, perf seam containment, and-the-spelling-is-not-the-destination-tmp-e)
 symanc="$tmp/symlinked-ancestor"; rm -f "$symanc"; ln -s /etc "$symanc"
 symout="$tmp/symlink-out-of-sandbox"; rm -f "$symout"; ln -s /tmp "$symout"
 for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d" "$tmp/./nonexistent-sandbox.d" \
@@ -953,21 +949,10 @@ else
 fi
 
 # ---- 1g. #3261: A NAME IS NOT A DESTINATION — the four remaining escapes ------------------
-# Positive containment closed the PATH SPELLINGS. These four are what containment of a
-# spelling still does not buy, and each is asserted BY ITS OWN OBSERVABLE CONSEQUENCE (a
-# followed write, a fabricated /proc verdict, a refused legitimate file, a real privileged
-# tool), never by an rc alone — this guard has several refusals and an rc-only check would let
-# the wrong one satisfy the case.
+# (full rationale: fleet-runbook.md, perf seam containment, 1g-3261-a-name-is-not-a-destination-the-four)
 
 # 1g-i. AC1 (High) — DIRECTORY containment is not WRITE-TARGET containment. `tee <path>` opens
-#       O_WRONLY|O_CREAT|O_TRUNC and FOLLOWS a symlink, so a symlink at the managed basename
-#       inside a perfectly-contained directory pointed the privileged write at the LINK'S
-#       TARGET — anywhere on the box. A contained directory says nothing about where its
-#       entries point. Two independent requirements, both asserted:
-#         * anything that merely NAMES the write target REFUSES (rc 1, empty, loud);
-#         * the WRITE ITSELF replaces the directory ENTRY (rename), so a symlink planted in
-#           the window between the check and the write is replaced, not written through.
-# (rationale condensed; full reasoning in the commit history for #3261.)
+# (full rationale: fleet-runbook.md, perf seam containment, 1g-i-ac1-high-directory-containment-is-not-wri)
 if perf_install_supported; then
   wt_d="$tmp/wt-sandbox.d"; mkdir -p "$wt_d"
   wt_outside="$tmp/wt-outside-target"; printf 'PRECIOUS-HOST-FILE\n' >"$wt_outside"
@@ -1006,13 +991,7 @@ if perf_install_supported; then
     bad "perf-capability: the atomic drop-in install did not replace a symlinked entry (rc=$wt_ins_rc, out='$wt_ins', link=$([ -L "$wt_d/99-cqlite-perf.conf" ] && echo yes || echo no), leftover='$wt_leftover', outside-changed=$([ "$(cat "$wt_outside")" = "$wt_outside_bytes" ] && echo no || echo YES))"
   fi
   # ...and the STAGING entry is UNPREDICTABLE, created by `mktemp` (roborev finding 1 on #3261 — the
-  # NINTH escape, same shape as the other eight: a NAME trusted instead of a DESTINATION). A fixed
-  # staging path that is checked, cleared and only THEN opened by a privileged `tee` is a TOCTOU
-  # window: anyone who can create entries in the directory re-plants that KNOWN name as a symlink
-  # between the verify and the open, and root follows it. Two asserts, because neither alone is
-  # enough — a behavioural one (the previously-predictable name is planted as a symlink at a victim
-  # file and must be left strictly alone) and a structural one (unpredictability is a property of the
-  # NAME, which is gone by the time the write succeeds, so the source is the only place to see it).
+  # (full rationale: fleet-runbook.md, perf seam containment, and-the-staging-entry-is-unpredictable-create)
   wt_bait="$tmp/wt-staging-bait"; printf 'BAIT-MUST-NOT-BE-WRITTEN\n' >"$wt_bait"
   wt_bait_before=$(cat "$wt_bait")
   rm -f "$wt_d/.99-cqlite-perf.conf.new"; ln -s "$wt_bait" "$wt_d/.99-cqlite-perf.conf.new"
@@ -1217,11 +1196,7 @@ else
 fi
 
 # ...and an UNSUPPORTED HOST is reported as rc 2, distinct from rc 1 REFUSED (roborev rounds 16-17).
-# The staged install needs GNU `stat -c` and `mv -T`; bootstrap gates the perf section on
-# PLATFORM=linux, which is NOT the same as GNU, so a musl/busybox Linux host used to die on a raw tool
-# error. The tools are exercised INSIDE the privileged shell (sudo applies its own secure_path, so a
-# caller-side probe can check a different binary than the one that will run) and `mv -T` is EXERCISED
-# rather than grepped out of --help. The all-GNU control is what stops this passing by refusing always.
+# (full rationale: fleet-runbook.md, perf seam containment, and-an-unsupported-host-is-reported-as-rc-2-d)
 us_fail=0
 # GUARDED like the staged-install cases (roborev round 21, Medium): this group's CONTROL expects a
 # successful install using the HOST's stat/mv, so off GNU it necessarily returns rc 2 and the suite
@@ -1259,11 +1234,7 @@ done
 fi
 
 # ...and an EXTRA_DIRS value whose FIRST LINE is VALID must still be refused (roborev round 31, Medium).
-# `read` consumes only the first line, so a value like "<contained-dir>\n/etc/sysctl.d" previously SUCCEEDED
-# while silently discarding the remainder -- the scan then reported on an incomplete set, which is the
-# falsely-reassuring answer the diagnostic exists to prevent. Round 3 validated the SPLIT ENTRIES and never
-# the value being split, so a newline HID entries rather than forging one. The baseline runs first, without
-# the newline, and must SUCCEED -- otherwise the refusal proves nothing.
+# (full rationale: fleet-runbook.md, perf seam containment, and-an-extra-dirs-value-whose-first-line-is-v)
 ed_root=$(mktemp -d "$tmp/ed.XXXXXX"); : >"$ed_root/.cqlite-perf-sandbox"
 mkdir -p "$ed_root/good" "$ed_root/primary"; chmod 0755 "$ed_root" "$ed_root/good" "$ed_root/primary"
 ed_fail=0
@@ -1299,11 +1270,7 @@ done
 [ "$ts_fail" -ne 0 ] || ok "perf-capability: a stamped sandbox root spelled with no trailing slash, one, or two is normalised identically, so the fork-free and resolving paths cannot disagree about the same sandbox (#3261 roborev-31)"
 
 # ...and a SYMLINKED CONTROL FILE inside a contained PROC_DIR must not be read (roborev round 25,
-# Medium). The directory gate proved the DIRECTORY contained and symlink-free and said nothing about its
-# ENTRIES, so `perf_event_paranoid` could be a link to the host file and the token would report a real or
-# attacker-chosen capability as if it came from the fixture. Same directory-is-not-its-entries lesson as
-# AC1, on the read path. The CONTROL is the identical tree with a REAL file, so the refusal cannot be
-# passing for an unrelated reason.
+# (full rationale: fleet-runbook.md, perf seam containment, and-a-symlinked-control-file-inside-a-contain)
 pc_root=$(mktemp -d "$tmp/pc.XXXXXX"); : >"$pc_root/.cqlite-perf-sandbox"
 mkdir -p "$pc_root/proc"; chmod 0755 "$pc_root" "$pc_root/proc"
 printf '3\n' >"$pc_root/outside-paranoid"; printf '0\n' >"$pc_root/proc/kptr_restrict"
@@ -1320,11 +1287,7 @@ else
 fi
 
 # ...and LINE-SAFETY MUST BE JUDGED ON THE ORIGINAL PATH, not the canonicalized one (roborev round
-# 12, Medium). `$(cd -P -- "$p" && pwd -P)` STRIPS trailing newlines, so a directory whose name ends
-# in LF used to pass: the check only ever saw the stripped form, while every later caller emitted the
-# ORIGINAL spelling and split the one-per-line search path in two. Round 3 added the CR/LF guard for
-# exactly that split; it was running too late to see it. Both variants are pinned — a directory whose
-# name ends in LF, and a file whose PARENT ends in LF — because they canonicalize by different routes.
+# (full rationale: fleet-runbook.md, perf seam containment, and-line-safety-must-be-judged-on-the-origina)
 lf_root=$(mktemp -d "$tmp/lf.XXXXXX"); : >"$lf_root/.cqlite-perf-sandbox"
 lf_dir="$lf_root/evil"$'\n'
 lf_fail=0
@@ -1380,11 +1343,7 @@ printf 'kernel.kptr_restrict = 1\n' >"$cs_dir/zz-real.conf" 2>/dev/null
 cs_nl_dir="$cs_root/nl-sysctl.d"; rm -rf "$cs_nl_dir"; mkdir -p "$cs_nl_dir"; chmod 0755 "$cs_nl_dir"
 cs_nl_name=$(printf 'zz-nl\ncompetitor.conf')
 # BASELINE FIRST, WITHOUT the newline file, and its status REQUIRED (roborev round 30, Low). My previous
-# version ran the "ordinary" baseline while the newline-named file was ALREADY present, making it identical
-# to the refusal case, and then discarded its status with `|| true` — so the negative control controlled
-# nothing. Three iterations of this one case have now been vacuous in a different way each time; the
-# pattern in my own work is that I fix the assertion and forget to re-check that it can still reach its
-# subject. Ordinary file only -> MUST scan (rc 0). Then add the newline file -> MUST fail closed.
+# (full rationale: fleet-runbook.md, perf seam containment, baseline-first-without-the-newline-file-and-it)
 printf 'kernel.kptr_restrict = 1\n' >"$cs_nl_dir/zz-ordinary.conf"
 cs_nl_base=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
   CQLITE_PERF_SYSCTL_DIR="$cs_nl_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
@@ -1417,12 +1376,7 @@ fi
 [ "$cs_fail" -ne 0 ] || ok "perf-capability: the competing-file scan validates EVERY globbed file in test mode — a symlinked *.conf inside the sandbox fails the scan CLOSED by name and leaks no host content, while a real contained competitor is still reported (#3261 roborev-11)"
 
 # ...and a FAILING CONTENT GENERATOR must never look like success (roborev round 9, Medium). Both
-# call sites used to lose the generator's status: dropin_current ran a trailing sentinel `printf`
-# whose rc replaced it, so against an EMPTY file the compare was "X" == "X" and reported the drop-in
-# ALREADY CURRENT; dropin_install piped the generator into the privileged shell, so the pipeline's rc
-# was the last command's and a failure only surfaced if the CALLER had `pipefail`. Both are vacuous
-# positives from an unmeasured state. No GNU-only tooling is exercised here: each must fail BEFORE
-# any privileged command runs, which is the property under test.
+# (full rationale: fleet-runbook.md, perf seam containment, and-a-failing-content-generator-must-never-lo)
 cg_dir=$(mktemp -d "$tmp/cg.XXXXXX"); : >"$cg_dir/99-cqlite-perf.conf"
 cg_fail=0
 cg_cur_rc=0
@@ -1475,11 +1429,7 @@ else
 fi
 
 # 1g-iii. AC3 (Low) — a STRICTLY CONTAINED file was wrongly REFUSED. The file variant judged
-#         its PARENT with the strict-containment predicate, so `<root>/sysctl.conf` failed:
-#         the parent IS the root, and a root is not strictly inside itself. The judged path
-#         must be <canonical parent>/<basename>, which IS strictly inside. A guard that
-#         refuses legitimate input is the guard people learn to work around, so this is a
-#         correctness case, not a convenience.
+# (full rationale: fleet-runbook.md, perf seam containment, 1g-iii-ac3-low-a-strictly-contained-file-was-w)
 ac3_ok() { env CQLITE_PERF_TEST_SANDBOX="$1" \
   bash -c '. "$1"; perf_capability_sandbox_file_ok_resolved "$2"' _ "$PERFLIB" "$2"; }
 : >"$sbx/sysctl.conf"
@@ -1563,16 +1513,7 @@ else
 fi
 
 # 1c-iv. THE SEAM LIST IS COMPLETE, BY CENSUS (roborev round 32, Medium x2).
-# (full rationale: fleet-runbook.md, perf seam containment, seam-list-completeness)
-# perf_capability_seam_set named CQLITE_PERF_PROC_DIR and CQLITE_PERF_SYSCTL_DIR only, while the
-# file had grown three more test-only seams (TEST_SANDBOX, SYSCTL_EXTRA_DIRS, TEST_PRIV_DIR). Any
-# of those exported WITHOUT the marker sailed through the env guard, which is the marker-less
-# refusal failing open -- the same "denylist of names" shape this whole issue exists to close, and
-# my own doing: the round-6 audit policed WHICH FUNCTIONS may read a seam and never WHICH SEAMS the
-# list must name, so it could not see an omission. This audit is the other direction, and it is a
-# CENSUS rather than a hand-kept list: every CQLITE_PERF_* name the library reads must be named by
-# seam_set, minus the marker itself (which cannot gate its own absence). Adding a seam without
-# listing it now FAILS here instead of silently widening the production surface.
+# (full rationale: fleet-runbook.md, perf seam containment, 1c-iv-the-seam-list-is-complete-by-census-robo)
 seam_census_fail=0
 seam_set_body=$(awk '/^perf_capability_seam_set\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
 [ -n "$seam_set_body" ] \
@@ -1612,17 +1553,7 @@ done
 [ "$seam_each_fail" -ne 0 ] || ok "perf-capability: EACH of the $seam_census_n non-marker seams, set alone without CQLITE_PERF_TEST_MODE=1, is refused loudly by the env guard — while an entirely seam-free environment still succeeds (#3261 roborev-32)"
 
 # 1c-v. THE TWO CONTAINMENT PATHS AGREE ABOUT A SYMLINKED SANDBOX ROOT (roborev round 32, Medium).
-# (full rationale: fleet-runbook.md, perf seam containment, symlinked-sandbox-root)
-# sandbox_root_into advertised a "canonically spelled" root but never tested for symlinked
-# components. MEASURED on the same root and child: the fork-free perf_capability_sandbox_ok
-# returned 1 while the RESOLVING perf_capability_sandbox_ok_resolved returned 0 -- read and write
-# disagreeing about one sandbox, the same defect class as round 31's trailing-slash split.
-# Rejecting (not canonicalizing) is the only fix available here: sandbox_root_into is in the closed
-# fork-free audit set, and canonicalizing needs cd -P/pwd -P, i.e. a forked subshell.
-# THE ASSERTION IS AGREEMENT, not merely refusal: my first draft of this case asked only whether
-# the fork-free path refused, which it already did, so it passed with the defect fully present.
-# Both paths are therefore driven over the same fixtures, and the canonical control requires both
-# to ACCEPT -- a rule that refused everything would fail here just as loudly as one that accepts.
+# (full rationale: fleet-runbook.md, perf seam containment, 1c-v-the-two-containment-paths-agree-about-a-s)
 sr_fail=0
 sr_real=$(mktemp -d "$tmp/sr-real.XXXXXX"); : >"$sr_real/.cqlite-perf-sandbox"
 mkdir -p "$sr_real/child"; chmod 0755 "$sr_real" "$sr_real/child"

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1195,8 +1195,14 @@ if perf_install_supported; then
   rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
   wt_ns_out=$(env PATH="$wt_nostat" CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
     bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ns_rc=$?
-  if [ "$wt_ns_rc" -eq 0 ] || ! printf '%s' "$wt_ns_out" | grep -q 'cannot determine owner/mode'; then
-    bad "perf-capability: an undeterminable directory owner/mode did not fail closed (rc=$wt_ns_rc, out='$wt_ns_out')"
+  # A `stat` that cannot answer AT ALL is now reported as an UNSUPPORTED HOST (rc 2) rather than as
+  # "owner/mode indeterminate" — a broken `stat -c` means this host cannot do the atomic install,
+  # which is the more accurate diagnosis and the one added in roborev round 16. The property under
+  # test is unchanged and is what matters: it FAILS CLOSED and NAMES why, never proceeding on a
+  # directory whose ownership was never established. Either wording satisfies that; silence does not.
+  if [ "$wt_ns_rc" -eq 0 ] \
+     || ! printf '%s' "$wt_ns_out" | grep -qE 'cannot determine owner/mode|UNSUPPORTED on this host'; then
+    bad "perf-capability: an unusable 'stat' did not fail closed with a named reason (rc=$wt_ns_rc, out='$wt_ns_out')"
     wt_perm_fail=1
   fi
   # ...a SHORT MODE from `stat -c %a` must not bypass the write-bit check (roborev round 5, High).

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1124,13 +1124,7 @@ rm -f "$wt_d/99-cqlite-perf.conf"
 # the two refusal cases and be useless, so a correctly-owned 0755 directory must still install.
 wt_perm_d="$tmp/wt-perm.d"
 wt_perm_fail=0
-# SHORT MODES ARE THE INTERESTING ONES (roborev round 5, High). `stat -c %a` drops leading zeros, so
-# 0033 arrives as "33" — two characters. The old `${dmode%???}` suffix-strip could not match that,
-# left the permission field EMPTY, matched none of the write-bit patterns, and PASSED a group- AND
-# world-writable directory. These three are exactly the shapes that regress it: group-only (0030),
-# other-only (0003), and both (0033). 0300 is the CONTROL — owner-write only, three digits, must be
-# ACCEPTED — so the case cannot pass by refusing everything short.
-for wt_mode in 0775 0777 0757 0030 0003 0033; do
+for wt_mode in 0775 0777 0757; do
   rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod "$wt_mode" "$wt_perm_d"
   wt_perm_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
     bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_perm_rc=$?

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -241,24 +241,24 @@ fi
 noseam_out=$(env -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR CQLITE_PERF_TEST_MODE=1 \
   bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); noseam_rc=$?
 if [ "$noseam_rc" -ne 0 ] \
-   && printf '%s' "$noseam_out" | grep -q 'requires an explicit NON-PRODUCTION CQLITE_PERF_PROC_DIR' \
-   && printf '%s' "$noseam_out" | grep -q 'requires an explicit NON-PRODUCTION CQLITE_PERF_SYSCTL_DIR' \
+   && printf '%s' "$noseam_out" | grep -q 'requires CQLITE_PERF_PROC_DIR INSIDE the declared sandbox' \
+   && printf '%s' "$noseam_out" | grep -q 'requires CQLITE_PERF_SYSCTL_DIR INSIDE the declared sandbox' \
    && printf '%s' "$noseam_out" | grep -q 'NEVER falls back'; then
   ok "perf-capability: test mode with NO path seams REFUSES loudly and names BOTH missing sandbox dirs"
 else
   bad "perf-capability: test mode without seams was allowed to act (rc=$noseam_rc, out='$noseam_out')"
 fi
-# A seam pointing AT production (or anywhere under /etc, /proc, /sys) is the same hole
-# wearing a seam, and a RELATIVE path is not a sandbox either.
-# Each rejection is asserted BY ITS REASON, not merely by a non-zero rc: this guard has a
-# second refusal (a real sudo/sysctl on PATH) that would otherwise satisfy an rc-only
-# check and let a seam-validation regression pass unnoticed.
+# A seam pointing AT production (or anywhere under /etc, /proc, /sys) is refused because it
+# is not inside the sandbox — no forbidden name is consulted — and a RELATIVE path is not a
+# sandbox path either. Each rejection is asserted BY ITS REASON, not merely by a non-zero rc:
+# this guard has a second refusal (a real sudo/sysctl on PATH) that would otherwise satisfy
+# an rc-only check and let a containment regression pass unnoticed.
 guard_rejects_seam() { # guard_rejects_seam <which:PROC|SYSCTL> <proc-seam> <sysctl-seam>
   local out
   out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
           CQLITE_PERF_PROC_DIR="$2" CQLITE_PERF_SYSCTL_DIR="$3" \
           bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1) && return 1
-  printf '%s' "$out" | grep -q "NON-PRODUCTION CQLITE_PERF_${1}_DIR"
+  printf '%s' "$out" | grep -q "CQLITE_PERF_${1}_DIR INSIDE the declared sandbox"
 }
 for badseam in /etc/sysctl.d /etc/sysctl.d/sub /etc /proc /proc/sys/kernel /sys relative/dir ''; do
   guard_rejects_seam SYSCTL "$seamed_proc" "$badseam" || {
@@ -275,20 +275,70 @@ guard_rejects_seam SYSCTL "$seamed_proc" "$symseam" || {
   bad "perf-capability: test mode ACCEPTED a sysctl seam that is a SYMLINK to /etc/sysctl.d"; badseam_fail=1; }
 guard_rejects_seam PROC "$symproc" "$seamed_d" || {
   bad "perf-capability: test mode ACCEPTED a proc seam that is a SYMLINK to /proc/sys/kernel"; badseam_fail=1; }
-# ...and the SPELLING is not the destination (issue #3249 review R5-1): `/tmp/../etc/sysctl.d`
-# and `<symlink-to-/etc>/sysctl.d` pass every textual test above, and a root `--yes` run
-# resolves BOTH to the production directory. Each escape so far was one more spelling of
-# "somewhere else", so the write-side guard now judges the CANONICAL destination. An
-# UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
+# ...and the SPELLING is not the destination. `/tmp/../etc/sysctl.d`, `<symlink-to-/etc>/…`
+# and — the R6-1 escape — `//etc/sysctl.d` (POSIX leaves two leading slashes
+# implementation-defined and `pwd -P` may PRESERVE them, while on Linux `//etc` IS `/etc`)
+# each passed the textual checks of an earlier round. There is no per-spelling check any
+# more: containment refuses all of them, plus every future spelling, for the SAME reason.
+# An UNENTERABLE path resolves to nothing and is refused too — a write target must exist.
 symanc="$tmp/symlinked-ancestor"; rm -f "$symanc"; ln -s /etc "$symanc"
+symout="$tmp/symlink-out-of-sandbox"; rm -f "$symout"; ln -s /tmp "$symout"
 for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d" "$tmp/./nonexistent-sandbox.d" \
-                   "$tmp/no-such-sandbox.d"; do
+                   "$tmp/no-such-sandbox.d" "//etc/sysctl.d" "//etc/sysctl.d/sub" \
+                   "$symout" "$tmp"; do
   guard_rejects_seam SYSCTL "$seamed_proc" "$resolveseam" || {
-    bad "perf-capability: test mode ACCEPTED a sysctl seam that RESOLVES outside its sandbox: '$resolveseam'"; badseam_fail=1; }
+    bad "perf-capability: test mode ACCEPTED a sysctl seam that is not strictly inside its sandbox: '$resolveseam'"; badseam_fail=1; }
 done
-guard_rejects_seam PROC "$symanc/sysctl.d" "$seamed_d" || {
-  bad "perf-capability: test mode ACCEPTED a proc seam with a SYMLINKED ANCESTOR into /etc"; badseam_fail=1; }
-[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam AND one that merely RESOLVES into production (.. or a symlinked ancestor), on BOTH sandbox dirs, naming the offending seam"
+for resolveseam in "$symanc/sysctl.d" "//proc/sys/kernel" "$symout"; do
+  guard_rejects_seam PROC "$resolveseam" "$seamed_d" || {
+    bad "perf-capability: test mode ACCEPTED a proc seam outside its sandbox: '$resolveseam'"; badseam_fail=1; }
+done
+[ -n "${badseam_fail:-}" ] || ok "perf-capability: test mode rejects an empty/relative/production-shaped/SYMLINKED seam, one that RESOLVES out of the sandbox (.., a symlinked ancestor, a symlink to /tmp), the '//etc' double-slash spelling, a sibling-prefix path and the sandbox ROOT itself — on BOTH sandbox dirs, naming the offending seam"
+# 1c-iii-b. THE CONTAINMENT BOUNDARY AND THE SANDBOX ROOT ITSELF (issue #3249 review
+#           R6-1/R6-2). Containment is only as good as its boundary and its root:
+#             * `/tmp/sandboxevil` must NOT count as inside `/tmp/sandbox` — a plain string
+#               prefix would accept it, which is why the `/` boundary is explicit;
+#             * a path genuinely inside the declared root must still WORK, so the guard is
+#               not vacuously refusing everything (the failure mode a negative-only test
+#               cannot see);
+#             * the ROOT must PROVE itself — unset, relative, `//`-spelled, non-existent, or
+#               an existing directory with no stamp are all refusals NAMING
+#               CQLITE_PERF_TEST_SANDBOX. Without that, `CQLITE_PERF_TEST_SANDBOX=/etc`
+#               would make containment vacuous, and the inversion would have bought nothing.
+sbx="$tmp/sandbox"; mkdir -p "$sbx/inside" "$sbx/inside-proc"; : >"$sbx/.cqlite-perf-sandbox"
+mkdir -p "${sbx}evil"                       # the sibling whose NAME starts with the root's
+nostamp="$tmp/unstamped-root"; mkdir -p "$nostamp/inside"
+guard_with_root() { # guard_with_root <sandbox-root> <proc-seam> <sysctl-seam> -> rc + stderr
+  # $realpriv FIRST on PATH with the same dir declared: the guard's OTHER refusal (a real
+  # sudo/sysctl reachable) must not be what decides these cases.
+  env PATH="$realpriv:$PATH" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_PRIV_DIR="$realpriv" \
+    CQLITE_PERF_TEST_SANDBOX="$1" CQLITE_PERF_PROC_DIR="$2" CQLITE_PERF_SYSCTL_DIR="$3" \
+    bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1
+}
+bnd_fail=0
+guard_with_root "$sbx" "$sbx/inside-proc" "$sbx/inside" >/dev/null 2>&1 \
+  || { bad "perf-capability: a seam genuinely INSIDE the declared sandbox was refused (the guard is vacuous)"; bnd_fail=1; }
+bnd_out=$(guard_with_root "$sbx" "$sbx/inside-proc" "${sbx}evil") && bnd_fail=1
+printf '%s' "$bnd_out" | grep -q 'CQLITE_PERF_SYSCTL_DIR INSIDE the declared sandbox' || bnd_fail=1
+[ "$bnd_fail" -eq 0 ] || bad "perf-capability: '${sbx}evil' was treated as inside '$sbx' (prefix match without a / boundary), or a contained seam was refused"
+[ "$bnd_fail" -ne 0 ] || ok "perf-capability: containment is boundary-exact — a seam inside the declared sandbox is ACCEPTED while the sibling '<root>evil' is REFUSED by name"
+root_fail=0
+for badroot in '' relative/sandbox "//$tmp" "$tmp/no-such-root" "$nostamp"; do
+  ro=$(guard_with_root "$badroot" "$sbx/inside-proc" "$sbx/inside") && root_fail=1
+  printf '%s' "$ro" | grep -q 'requires CQLITE_PERF_TEST_SANDBOX' || root_fail=1
+  [ "$root_fail" -eq 0 ] || { bad "perf-capability: sandbox root '$badroot' was accepted (or refused without naming CQLITE_PERF_TEST_SANDBOX)"; break; }
+done
+[ "$root_fail" -ne 0 ] || ok "perf-capability: the sandbox ROOT must prove itself — unset/relative/'//'-spelled/absent/UNSTAMPED are refusals naming CQLITE_PERF_TEST_SANDBOX (so a stray CQLITE_PERF_TEST_SANDBOX=/etc cannot make containment vacuous)"
+# ...and the FORK-FREE read path applies the same containment: a `//`-spelled or
+# out-of-sandbox proc seam reads NOTHING (token `absent`), never the host's real /proc —
+# whose paranoid/kptr values would otherwise show up as ok/paranoid-N/kptr-restricted here.
+read_fail=0
+for badproc in "//proc/sys/kernel" "$symanc/sysctl.d" "/proc/sys/kernel" "${sbx}evil"; do
+  rt=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$sbx" \
+         CQLITE_PERF_PROC_DIR="$badproc" bash "$PERFLIB" --token 2>/dev/null)
+  [ "$rt" = absent ] || { bad "perf-capability: the read path used an out-of-sandbox proc seam '$badproc' (token '$rt', expected 'absent')"; read_fail=1; }
+done
+[ "$read_fail" -ne 0 ] || ok "perf-capability: the fork-free READ path refuses an out-of-sandbox proc seam (including the '//proc' spelling) — token 'absent', the real /proc never read"
 # ...and the write TARGET is re-validated independently of the guard: --drop-in-path may
 # never NAME a production file, because that string is what a root `tee` is pointed at.
 for resolveseam in "/tmp/../etc/sysctl.d" "$symanc/sysctl.d"; do
@@ -547,17 +597,24 @@ if printf '%s\n' "$sp_out" | grep -q "^earlier $sp_hi/10-hardening.conf$" \
 else
   bad "perf-capability: search-path scan wrong: '$sp_out'"
 fi
-# ...and an EXTRA-DIRS entry that is not an absolute non-production path fails the whole
-# scan CLOSED (rc 1, no output): a test-mode scan may never read the host's real /run or
-# /usr/lib, and a bad entry is an UNKNOWN, not "no competitor".
-for spbad in /etc/sysctl.d relative/dir "/tmp/../etc/sysctl.d"; do
+# ...and an EXTRA-DIRS entry that is not provably inside the sandbox fails the whole scan
+# CLOSED (rc 1, no output): a test-mode scan may never read the host's real /run or /usr/lib,
+# and a bad entry is an UNKNOWN, not "no competitor". THIS ENTRY POINT IS R6-2: it used the
+# textual validator while the write path canonicalized, so a SYMLINKED ANCESTOR (and the
+# `//etc` spelling) could point a "sandboxed" scan at the host's real configuration. It now
+# goes through the same resolving gate — dirs and the `sysctl.conf` FILE entry alike.
+for spbad in /etc/sysctl.d relative/dir "/tmp/../etc/sysctl.d" "//etc/sysctl.d" \
+             "$symanc/sysctl.d" "$symanc/sysctl.conf" "$symout" "$tmp/../etc/sysctl.d"; do
+  sp_this=0
   sp_bad_out=$(CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_SYSCTL_DIR="$sp_hi" \
     CQLITE_PERF_SYSCTL_EXTRA_DIRS="$spbad" \
-    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null) && sp_bad_fail=1
-  [ -z "$sp_bad_out" ] || sp_bad_fail=1
-  [ -z "${sp_bad_fail:-}" ] || bad "perf-capability: a production/relative CQLITE_PERF_SYSCTL_EXTRA_DIRS entry '$spbad' did not fail the scan closed"
+    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>/dev/null) && sp_this=1
+  # No output at all, and in particular NOT ONE host path: this is the "no host file read"
+  # half of the property, so it is asserted rather than inferred from the rc.
+  [ -z "$sp_bad_out" ] || sp_this=1
+  [ "$sp_this" -eq 0 ] || { bad "perf-capability: CQLITE_PERF_SYSCTL_EXTRA_DIRS entry '$spbad' did not fail the scan closed (out='$sp_bad_out')"; sp_bad_fail=1; }
 done
-[ -n "${sp_bad_fail:-}" ] || ok "perf-capability: a production-shaped/relative/resolving-into-production extra search-path entry fails the scan CLOSED (rc 1, no output)"
+[ -n "${sp_bad_fail:-}" ] || ok "perf-capability: an extra search-path entry outside the sandbox — production-shaped, relative, '//etc'-spelled, or reached through a SYMLINKED ANCESTOR (dir or sysctl.conf FILE) — fails the scan CLOSED (rc 1, no output, no host path named)"
 # ...and an UNREADABLE directory is an UNKNOWN (rc 1), never "no competing file": this
 # diagnostic exists to replace an unknown with a named file, so answering an unknown with
 # the reassuring line would recreate the mystery it was written to end.
@@ -792,6 +849,62 @@ for variant in fail-rc empty-out; do
   fi
 done
 [ "$mtg_fail" -ne 0 ] || ok "perf-capability-test-lib: an unusable 'mktemp -d' (non-zero rc, or rc 0 with an empty path) REFUSES with a named reason, exits non-zero, never reaches the suite body, and creates no root-level path"
+
+# 1f. THE GATE IS SINGULAR AND UNSKIPPABLE — a STRUCTURAL audit (issue #3249 review R6-2).
+#     R6-2 was not a wrong check, it was a MISSING one: CQLITE_PERF_SYSCTL_EXTRA_DIRS was a
+#     new seam consumer, and the canonicalizing validation added for the write path simply
+#     never reached it. No behavioural case can catch that class, because the defect is a
+#     path nobody thought to test. So this audit enumerates, FROM THE SOURCE, every function
+#     that dereferences a seam variable and requires each one to route through the
+#     containment family (`perf_capability_sandbox_*` / `perf_capability_path_within`) — with
+#     ONE named, justified allowlist entry. A future entry point that reads a seam without
+#     the gate FAILS here, and joining the allowlist is a visible, reviewable act.
+#
+#     Same shape as the fork-free audit in test_agent_gate_summary.sh: parse the function
+#     bodies (a column-0 `name() {` … column-0 `}`), and treat FINDING NOTHING as a failure,
+#     so a parser that stops matching can never pass this vacuously.
+seam_audit=$(awk \
+  -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX)' \
+  -v gatere='perf_capability_(sandbox_|path_within)' '
+  /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
+    fn = $1; sub(/\(\)$/, "", fn); seam = 0; gate = 0
+    if ($0 ~ seamre) seam = 1
+    if ($0 ~ gatere) gate = 1
+    if ($0 ~ /\}[[:space:]]*$/) { printf "%s %d %d\n", fn, seam, gate; inb = 0 }
+    else inb = 1
+    next
+  }
+  inb && /^\}/ { printf "%s %d %d\n", fn, seam, gate; inb = 0; next }
+  inb {
+    if ($0 ~ seamre) seam = 1
+    if ($0 ~ gatere) gate = 1
+  }
+' "$PERFLIB")
+# The ONLY function allowed to read a seam without the gate, and why: it asks whether a seam
+# was handed to us AT ALL (for the marker-less refusal) and never uses the value as a path.
+# The containment family's own root reader is the gate, so it is named here too.
+seam_audit_allow=' perf_capability_seam_set perf_capability_sandbox_root_into '
+seam_consumers=0; seam_ungated=''
+while read -r fn seam gate; do
+  [ -n "$fn" ] || continue
+  [ "$seam" = 1 ] || continue
+  seam_consumers=$((seam_consumers + 1))
+  case "$seam_audit_allow" in *" $fn "*) continue ;; esac
+  [ "$gate" = 1 ] || seam_ungated="$seam_ungated $fn"
+done <<EOF
+$seam_audit
+EOF
+# 4 is the count at the time of writing (proc_dir_into, sysctl_dir, sysctl_search_path,
+# test_seams_ok) plus the two allowlisted readers; the assert is a FLOOR, so adding a
+# consumer is fine and losing the parse is not.
+if [ "$seam_consumers" -ge 5 ] && [ -z "$seam_ungated" ] \
+   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_sysctl_search_path 1 1$' \
+   && printf '%s\n' "$seam_audit" | grep -q '^perf_capability_proc_dir_into 1 1$'; then
+  ok "perf-capability: STRUCTURAL — all $seam_consumers seam-dereferencing functions route through the single containment gate (only the documented presence-check + the root reader are allowlisted), so a new entry point cannot silently skip it"
+else
+  bad "perf-capability: STRUCTURAL audit failed — seam consumers found: $seam_consumers; UNGATED:${seam_ungated:- none}"
+  printf '%s\n' "$seam_audit"
+fi
 
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.
 perf_test_assert_host_clean

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1286,6 +1286,41 @@ else
   ok "perf-capability: the line-safety predicate rejects CR as well as LF and still accepts an ordinary path"
 fi
 
+# ...and an UNSUPPORTED HOST is reported as rc 2, distinct from rc 1 REFUSED (roborev rounds 16-17).
+# The staged install needs GNU `stat -c` and `mv -T`; bootstrap gates the perf section on
+# PLATFORM=linux, which is NOT the same as GNU, so a musl/busybox Linux host used to die on a raw tool
+# error. The tools are exercised INSIDE the privileged shell (sudo applies its own secure_path, so a
+# caller-side probe can check a different binary than the one that will run) and `mv -T` is EXERCISED
+# rather than grepped out of --help. The all-GNU control is what stops this passing by refusing always.
+us_fail=0
+for us_break in '' mv stat; do
+  us_root=$(mktemp -d "$tmp/us.XXXXXX"); : >"$us_root/.cqlite-perf-sandbox"
+  mkdir -p "$us_root/sysctl.d"; chmod 0755 "$us_root" "$us_root/sysctl.d"
+  us_shim=$(mktemp -d "$tmp/usbin.XXXXXX")
+  for us_t in bash sh cat printf tee rm chmod env grep mktemp id ls stat mv; do
+    [ "$us_t" = "$us_break" ] && continue
+    us_p=$(command -v "$us_t" 2>/dev/null) && ln -sf "$us_p" "$us_shim/$us_t"
+  done
+  [ -n "$us_break" ] && { printf '%s\n' '#!/bin/sh' 'exit 1' >"$us_shim/$us_break"; chmod +x "$us_shim/$us_break"; }
+  us_out=$(env PATH="$us_shim" CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$us_root" \
+    CQLITE_PERF_SYSCTL_DIR="$us_root/sysctl.d" CQLITE_PERF_PROC_DIR="$us_root" \
+    CQLITE_PERF_TEST_PRIV_DIR="$us_shim" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); us_rc=$?
+  us_wrote=no; [ -s "$us_root/sysctl.d/99-cqlite-perf.conf" ] && us_wrote=yes
+  if [ -z "$us_break" ]; then
+    [ "$us_rc" -eq 0 ] && [ "$us_wrote" = yes ] \
+      || { bad "perf-capability: an all-GNU host did not install (rc=$us_rc wrote=$us_wrote) — the UNSUPPORTED probe refuses everything"; us_fail=1; }
+  else
+    [ "$us_rc" -eq 2 ] \
+      || { bad "perf-capability: a broken '$us_break' gave rc=$us_rc, not the distinct rc 2 UNSUPPORTED (out='$us_out')"; us_fail=1; }
+    printf '%s' "$us_out" | grep -q 'UNSUPPORTED on this host' \
+      || { bad "perf-capability: a broken '$us_break' failed without naming the host as unsupported (out='$us_out')"; us_fail=1; }
+    [ "$us_wrote" = no ] \
+      || { bad "perf-capability: a broken '$us_break' wrote the drop-in anyway"; us_fail=1; }
+  fi
+done
+[ "$us_fail" -ne 0 ] || ok "perf-capability: a non-GNU host is reported as rc 2 UNSUPPORTED by name and writes nothing (broken stat -c and broken mv -T both), while an all-GNU host still installs (#3261 roborev-16/17)"
+
 # ...and LINE-SAFETY MUST BE JUDGED ON THE ORIGINAL PATH, not the canonicalized one (roborev round
 # 12, Medium). `$(cd -P -- "$p" && pwd -P)` STRIPS trailing newlines, so a directory whose name ends
 # in LF used to pass: the check only ever saw the stripped form, while every later caller emitted the

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1041,10 +1041,14 @@ fi
 rm -f "$wt_d/.99-cqlite-perf.conf.new"
 # ...structurally: the staging entry is created by `mktemp` with a random-suffix template, no
 # hardcoded staging literal survives, the rename carries `-T`, and the WHOLE staged install is ONE
-# privileged invocation (issue #3261 roborev round 2). That last property is the fix for the
-# create->reopen race and cannot be observed after the fact — a split back into `mktemp` in one
-# privileged call and the write in another would leave every behavioural assert green — so it is
-# pinned here, in the spirit of the other structural audits on this branch.
+# privileged invocation (issue #3261 roborev round 2).
+#   THE LAST PROPERTY IS HYGIENE, NOT THE FIX, and this comment previously said otherwise. roborev
+#   round 3 corrected it: a single `sh -c` sequences ONE PROCESS's commands and is not mutual
+#   exclusion against other processes, which run concurrently on other CPUs regardless of how we
+#   grouped ours. Consolidation NARROWS the create-to-reopen window; it does not close it. It is
+#   still worth pinning — a split back into `mktemp` in one privileged call and the write in another
+#   would re-widen the window while every behavioural assert stayed green, which no after-the-fact
+#   observation can catch — but it is pinned as hygiene, not as the guarantee.
 wt_body=$(awk '/^perf_capability_dropin_install\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
 wt_privcalls=$(printf '%s\n' "$wt_body" | grep -c '"\$@"')
 wt_struct_fail=''
@@ -1056,7 +1060,7 @@ printf '%s\n' "$wt_body" | grep -q 'mv -fT -- "\$t" "\$p"' \
 [ "$wt_privcalls" -eq 1 ] || wt_struct_fail="$wt_struct_fail privileged-invocations=$wt_privcalls"
 printf '%s\n' "$wt_body" | grep -q '"\$@" sh -c' || wt_struct_fail="$wt_struct_fail not-a-single-sh-c"
 if [ -z "$wt_struct_fail" ]; then
-  ok "perf-capability: STRUCTURAL — the staged install is ONE privileged 'sh -c' (mktemp + write + chmod + mv all inside it, so no unprivileged process is scheduled between create and reopen), the staging name comes from an mktemp random-suffix template with no hardcoded literal, and the rename carries -T (#3261 roborev-1/roborev-2)"
+  ok "perf-capability: STRUCTURAL — the staged install is ONE privileged 'sh -c' (mktemp + write + chmod + mv all inside it, which NARROWS the create-to-reopen window but does NOT close it — see the note above), the staging name comes from an mktemp random-suffix template with no hardcoded literal, and the rename carries -T (#3261 roborev-1/roborev-2)"
 else
   bad "perf-capability: the staged install lost a structural property:$wt_struct_fail"
   printf '%s\n' "$wt_body" | grep -n '\$@\|mktemp\|mv -' | head -8

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1278,6 +1278,12 @@ fi
 # caller-side probe can check a different binary than the one that will run) and `mv -T` is EXERCISED
 # rather than grepped out of --help. The all-GNU control is what stops this passing by refusing always.
 us_fail=0
+# GUARDED like the staged-install cases (roborev round 21, Medium). This group's CONTROL case expects a
+# successful install using the HOST's own stat and mv, so on a non-GNU host the control necessarily
+# returns rc 2 and the suite fails — reintroducing exactly the macOS breakage the counted skip fixed.
+if ! perf_install_supported; then
+  skip "perf-capability: UNSUPPORTED-host reporting cases (rc 2 for broken stat -c / mv -T, with an all-GNU control)" "no GNU stat -c / mv --no-target-directory on this host, so the control case cannot install"
+else
 for us_break in '' mv stat; do
   us_root=$(mktemp -d "$tmp/us.XXXXXX"); : >"$us_root/.cqlite-perf-sandbox"
   mkdir -p "$us_root/sysctl.d"; chmod 0755 "$us_root" "$us_root/sysctl.d"
@@ -1305,6 +1311,7 @@ for us_break in '' mv stat; do
   fi
 done
 [ "$us_fail" -ne 0 ] || ok "perf-capability: a non-GNU host is reported as rc 2 UNSUPPORTED by name and writes nothing (broken stat -c and broken mv -T both), while an all-GNU host still installs (#3261 roborev-16/17)"
+fi
 
 # ...and LINE-SAFETY MUST BE JUDGED ON THE ORIGINAL PATH, not the canonicalized one (roborev round
 # 12, Medium). `$(cd -P -- "$p" && pwd -P)` STRIPS trailing newlines, so a directory whose name ends

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1300,6 +1300,46 @@ done
 [ "$us_fail" -ne 0 ] || ok "perf-capability: a non-GNU host is reported as rc 2 UNSUPPORTED by name and writes nothing (broken stat -c and broken mv -T both), while an all-GNU host still installs (#3261 roborev-16/17)"
 fi
 
+# ...and an EXTRA_DIRS value whose FIRST LINE is VALID must still be refused (roborev round 31, Medium).
+# `read` consumes only the first line, so a value like "<contained-dir>\n/etc/sysctl.d" previously SUCCEEDED
+# while silently discarding the remainder -- the scan then reported on an incomplete set, which is the
+# falsely-reassuring answer the diagnostic exists to prevent. Round 3 validated the SPLIT ENTRIES and never
+# the value being split, so a newline HID entries rather than forging one. The baseline runs first, without
+# the newline, and must SUCCEED -- otherwise the refusal proves nothing.
+ed_root=$(mktemp -d "$tmp/ed.XXXXXX"); : >"$ed_root/.cqlite-perf-sandbox"
+mkdir -p "$ed_root/good" "$ed_root/primary"; chmod 0755 "$ed_root" "$ed_root/good" "$ed_root/primary"
+ed_fail=0
+ed_base_rc=0
+env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$ed_root" CQLITE_PERF_SYSCTL_DIR="$ed_root/primary" \
+  CQLITE_PERF_SYSCTL_EXTRA_DIRS="$ed_root/good" \
+  bash -c '. "$1"; perf_capability_sysctl_search_path' _ "$PERFLIB" >/dev/null 2>&1 || ed_base_rc=$?
+[ "$ed_base_rc" -eq 0 ] \
+  || { bad "perf-capability: the single-line EXTRA_DIRS BASELINE failed (rc=$ed_base_rc) — the newline refusal below would prove nothing"; ed_fail=1; }
+ed_hidden="$ed_root/good"$'\n'"/etc/sysctl.d"
+ed_out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$ed_root" CQLITE_PERF_SYSCTL_DIR="$ed_root/primary" \
+  CQLITE_PERF_SYSCTL_EXTRA_DIRS="$ed_hidden" \
+  bash -c '. "$1"; perf_capability_sysctl_search_path' _ "$PERFLIB" 2>&1); ed_rc=$?
+[ "$ed_rc" -ne 0 ] \
+  || { bad "perf-capability: an EXTRA_DIRS value hiding entries after a newline was ACCEPTED (rc=$ed_rc, out='$ed_out')"; ed_fail=1; }
+printf '%s\n' "$ed_out" | grep -qx -- /etc/sysctl.d \
+  && { bad "perf-capability: the host /etc/sysctl.d reached the search path through a newline-hidden EXTRA_DIRS entry"; ed_fail=1; }
+[ "$ed_fail" -ne 0 ] || ok "perf-capability: an EXTRA_DIRS value whose FIRST line is a valid contained directory is still REFUSED when a newline hides more entries after it, and the host /etc/sysctl.d never reaches the search path — while the same value without the newline succeeds (#3261 roborev-31)"
+
+# ...and a stamped sandbox root ending in '//' must behave IDENTICALLY to one with no trailing slash
+# (roborev round 31, Low). Only ONE trailing slash was stripped, so '<root>//' became '<root>/', passed the
+# '//' rejection, and then the fork-free containment pattern appended its own separator and refused EVERY
+# child -- while the RESOLVING write path still accepted the same root. Read and write disagreeing about
+# the same sandbox is worse than either answer alone, so all three spellings are asserted to agree.
+ts_root=$(mktemp -d "$tmp/ts.XXXXXX"); : >"$ts_root/.cqlite-perf-sandbox"
+mkdir -p "$ts_root/child"; chmod 0755 "$ts_root" "$ts_root/child"
+ts_fail=0
+for ts_spell in "$ts_root" "$ts_root/" "$ts_root//"; do
+  env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$ts_spell" \
+    bash -c '. "$1"; perf_capability_sandbox_ok "$2"' _ "$PERFLIB" "$ts_root/child" 2>/dev/null \
+    || { bad "perf-capability: a contained child was REFUSED when the sandbox root was spelled '$ts_spell' (fork-free path disagrees with the resolving path)"; ts_fail=1; }
+done
+[ "$ts_fail" -ne 0 ] || ok "perf-capability: a stamped sandbox root spelled with no trailing slash, one, or two is normalised identically, so the fork-free and resolving paths cannot disagree about the same sandbox (#3261 roborev-31)"
+
 # ...and a SYMLINKED CONTROL FILE inside a contained PROC_DIR must not be read (roborev round 25,
 # Medium). The directory gate proved the DIRECTORY contained and symlink-free and said nothing about its
 # ENTRIES, so `perf_event_paranoid` could be a link to the host file and the token would report a real or

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -884,11 +884,27 @@ done
 seam_audit=$(awk \
   -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
   -v gatere='(^|[^A-Za-z0-9_])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
-  { code = $0; sub(/[[:space:]]*#.*$/, "", code) }
+  # TWO representations, because the two matches want different things (roborev round 6, Low).
+  #   `code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
+  #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
+  #             stripping quoted spans would hide real consumers and silently shrink the census.
+  #   `codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
+  #             command, never a string, so matching inside quotes is what made the advertised
+  #             "command position" claim false — swapping a real call for a string that merely
+  #             mentions its name kept the audit green.
+  # Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
+  # line. The single quote is written \047: this awk program sits inside a shell single-quoted
+  # string and cannot contain a literal one.
+  { code = $0
+    sub(/[[:space:]]*#.*$/, "", code)
+    codeq = $0
+    gsub(/"[^"]*"/, " ", codeq)
+    gsub(/\047[^\047]*\047/, " ", codeq)
+    sub(/[[:space:]]*#.*$/, "", codeq) }
   /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
     fn = $1; sub(/\(\)$/, "", fn); seam = 0; gate = 0
     if (code ~ seamre) seam = 1
-    if (code ~ gatere) gate = 1
+    if (codeq ~ gatere) gate = 1
     if ($0 ~ /\}[[:space:]]*$/) { printf "%s %d %d\n", fn, seam, gate; inb = 0 }
     else inb = 1
     next
@@ -896,7 +912,7 @@ seam_audit=$(awk \
   inb && /^\}/ { printf "%s %d %d\n", fn, seam, gate; inb = 0; next }
   inb {
     if (code ~ seamre) seam = 1
-    if (code ~ gatere) gate = 1
+    if (codeq ~ gatere) gate = 1
   }
 ' "$PERFLIB")
 # The ONLY function allowed to read a seam without the gate, and why: it asks whether a seam
@@ -937,11 +953,27 @@ fi
 priv_audit=$(awk \
   -v privre='(for [a-z_]+ in (sudo|sysctl)|command -v .*(sudo|sysctl))' \
   -v gatere='(^|[^A-Za-z0-9_])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
-  { code = $0; sub(/[[:space:]]*#.*$/, "", code) }
+  # TWO representations, because the two matches want different things (roborev round 6, Low).
+  #   `code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
+  #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
+  #             stripping quoted spans would hide real consumers and silently shrink the census.
+  #   `codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
+  #             command, never a string, so matching inside quotes is what made the advertised
+  #             "command position" claim false — swapping a real call for a string that merely
+  #             mentions its name kept the audit green.
+  # Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
+  # line. The single quote is written \047: this awk program sits inside a shell single-quoted
+  # string and cannot contain a literal one.
+  { code = $0
+    sub(/[[:space:]]*#.*$/, "", code)
+    codeq = $0
+    gsub(/"[^"]*"/, " ", codeq)
+    gsub(/\047[^\047]*\047/, " ", codeq)
+    sub(/[[:space:]]*#.*$/, "", codeq) }
   /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
     fn = $1; sub(/\(\)$/, "", fn); priv = 0; gate = 0
     if (code ~ privre) priv = 1
-    if (code ~ gatere) gate = 1
+    if (codeq ~ gatere) gate = 1
     if ($0 ~ /\}[[:space:]]*$/) { printf "%s %d %d\n", fn, priv, gate; inb = 0 }
     else inb = 1
     next
@@ -949,7 +981,7 @@ priv_audit=$(awk \
   inb && /^\}/ { printf "%s %d %d\n", fn, priv, gate; inb = 0; next }
   inb {
     if (code ~ privre) priv = 1
-    if (code ~ gatere) gate = 1
+    if (codeq ~ gatere) gate = 1
   }
 ' "$PERFLIB")
 # The ONE function allowed to resolve a privileged tool without the containment gate, and why:

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -862,11 +862,7 @@ done
 #     new seam consumer, and the canonicalizing validation added for the write path simply
 #     never reached it. No behavioural case can catch that class, because the defect is a
 #     path nobody thought to test. So this audit enumerates, FROM THE SOURCE, every function
-#     that dereferences a seam variable and requires each one to route through the
-#     containment family (`perf_capability_sandbox_*` / `perf_capability_path_within`) — with
-#     ONE named, justified allowlist entry. A future entry point that reads a seam without
-#     the gate FAILS here, and joining the allowlist is a visible, reviewable act.
-# (rationale condensed; full reasoning in the commit history for #3261.)
+# (rationale condensed; see #3261 commit history.)
 seam_audit=$(awk \
   -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
   -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
@@ -875,12 +871,7 @@ seam_audit=$(awk \
   #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
   #             stripping quoted spans would hide real consumers and silently shrink the census.
   #   `codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
-  #             command, never a string, so matching inside quotes is what made the advertised
-  #             "command position" claim false — swapping a real call for a string that merely
-  #             mentions its name kept the audit green.
-  # Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
-  # line. The single quote is written \047: this awk program sits inside a shell single-quoted
-  # string and cannot contain a literal one.
+  # (rationale condensed; see #3261 commit history.)
   { code = $0
     sub(/[[:space:]]*#.*$/, "", code)
     codeq = $0
@@ -940,21 +931,12 @@ priv_audit=$(awk \
   -v privre='(for [a-z_]+ in (sudo|sysctl)|command -v .*(sudo|sysctl))' \
   -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
   # TWO representations, because the two matches want different things (roborev round 6, Low).
-  #   `code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
-  #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
-  #             stripping quoted spans would hide real consumers and silently shrink the census.
-  #   `codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
-  #             command, never a string, so matching inside quotes is what made the advertised
+# (rationale condensed; see #3261 commit history.)
   #             "command position" claim false — swapping a real call for a string that merely
   #             mentions its name kept the audit green.
   # Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
   # line. The single quote is written \047: this awk program sits inside a shell single-quoted
-  # string and cannot contain a literal one.
-  { code = $0
-    sub(/[[:space:]]*#.*$/, "", code)
-    codeq = $0
-    gsub(/"[^"]*"/, " ", codeq)
-    gsub(/\047[^\047]*\047/, " ", codeq)
+  # (rationale condensed; see #3261 commit history.)
     sub(/[[:space:]]*#.*$/, "", codeq) }
   /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
     fn = $1; sub(/\(\)$/, "", fn); priv = 0; gate = 0
@@ -1023,11 +1005,7 @@ if perf_install_supported; then
     ok "perf-capability: the drop-in WRITE TARGET is refused when the managed basename is itself a SYMLINK (rc 1, empty, named) — a contained directory does not license writing through its entries (#3261 AC1)"
   else
     bad "perf-capability: a SYMLINKED write target was NAMED for a privileged tee (rc=$wt_rc, path='$wt_path', err='$wt_err')"
-  fi
-  # ...and the CONTENTS read that decides idempotency may not follow it either: a symlink whose
-  # TARGET happens to hold the canonical bytes must not report "already current" (that would
-  # leave the host file in place and claim success).
-  printf '%s\n' "$(bash "$PERFLIB" --drop-in)" >"$wt_outside"
+     # (rationale condensed; see #3261 commit history.)
   if env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB" 2>/dev/null; then
     bad "perf-capability: dropin_current followed a SYMLINK and reported the drop-in 'already current' from a file outside the managed name"
   else
@@ -1088,11 +1066,7 @@ if perf_install_supported; then
   printf '%s\n' "$wt_body" | grep -q 'mv -fT -- "\$t" "\$p"' \
     || wt_struct_fail="$wt_struct_fail no-mv-T"
   [ "$wt_privcalls" -eq 1 ] || wt_struct_fail="$wt_struct_fail privileged-invocations=$wt_privcalls"
-  printf '%s\n' "$wt_body" | grep -q '"\$@" sh -c' || wt_struct_fail="$wt_struct_fail not-a-single-sh-c"
-  if [ -z "$wt_struct_fail" ]; then
-    ok "perf-capability: STRUCTURAL — the staged install is ONE privileged 'sh -c' (mktemp + write + chmod + mv all inside it, which NARROWS the create-to-reopen window but does NOT close it — see the note above), the staging name comes from an mktemp random-suffix template with no hardcoded literal, and the rename carries -T (#3261 roborev-1/roborev-2)"
-  else
-    bad "perf-capability: the staged install lost a structural property:$wt_struct_fail"
+    # (rationale condensed; see #3261 commit history.)
     printf '%s\n' "$wt_body" | grep -n '\$@\|mktemp\|mv -' | head -8
   fi
   # ...and a `mktemp` that answers OUTSIDE the validated directory is refused rather than trusted —

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -991,217 +991,231 @@ fi
 #         * anything that merely NAMES the write target REFUSES (rc 1, empty, loud);
 #         * the WRITE ITSELF replaces the directory ENTRY (rename), so a symlink planted in
 #           the window between the check and the write is replaced, not written through.
-wt_d="$tmp/wt-sandbox.d"; mkdir -p "$wt_d"
-wt_outside="$tmp/wt-outside-target"; printf 'PRECIOUS-HOST-FILE\n' >"$wt_outside"
-wt_before=$(cat "$wt_outside")
-rm -f "$wt_d/99-cqlite-perf.conf"; ln -s "$wt_outside" "$wt_d/99-cqlite-perf.conf"
-wt_path=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash "$PERFLIB" --drop-in-path 2>/dev/null); wt_rc=$?
-wt_err=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash "$PERFLIB" --drop-in-path 2>&1 >/dev/null)
-if [ "$wt_rc" -ne 0 ] && [ -z "$wt_path" ] \
-   && printf '%s' "$wt_err" | grep -qi 'symlink' \
-   && [ -L "$wt_d/99-cqlite-perf.conf" ] && [ "$(cat "$wt_outside")" = "$wt_before" ]; then
-  ok "perf-capability: the drop-in WRITE TARGET is refused when the managed basename is itself a SYMLINK (rc 1, empty, named) — a contained directory does not license writing through its entries (#3261 AC1)"
-else
-  bad "perf-capability: a SYMLINKED write target was NAMED for a privileged tee (rc=$wt_rc, path='$wt_path', err='$wt_err')"
-fi
-# ...and the CONTENTS read that decides idempotency may not follow it either: a symlink whose
-# TARGET happens to hold the canonical bytes must not report "already current" (that would
-# leave the host file in place and claim success).
-printf '%s\n' "$(bash "$PERFLIB" --drop-in)" >"$wt_outside"
-if env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB" 2>/dev/null; then
-  bad "perf-capability: dropin_current followed a SYMLINK and reported the drop-in 'already current' from a file outside the managed name"
-else
-  ok "perf-capability: dropin_current does NOT follow a symlinked managed name, even when the link's TARGET holds byte-identical canonical content (#3261 AC1)"
-fi
-# ...and the WRITE replaces the ENTRY. The refusal above is a check with a TOCTOU window; the
-# rename has none. After it, the managed name is a REGULAR file holding the canonical bytes,
-# the outside target is byte-identical to before, and no temp entry is left behind.
-wt_outside_bytes=$(cat "$wt_outside")
-wt_ins=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
-  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ins_rc=$?
-wt_leftover=$(ls -A "$wt_d" | grep -v '^99-cqlite-perf\.conf$' || true)
-if [ "$wt_ins_rc" -eq 0 ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ] && [ -f "$wt_d/99-cqlite-perf.conf" ] \
-   && [ "$(cat "$wt_outside")" = "$wt_outside_bytes" ] && [ -z "$wt_leftover" ] \
-   && env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB"; then
-  ok "perf-capability: the drop-in write REPLACES the directory entry (temp + rename), so a pre-existing symlink at the managed name is replaced and its outside target is untouched — and no temp entry is left behind (#3261 AC1)"
-else
-  bad "perf-capability: the atomic drop-in install did not replace a symlinked entry (rc=$wt_ins_rc, out='$wt_ins', link=$([ -L "$wt_d/99-cqlite-perf.conf" ] && echo yes || echo no), leftover='$wt_leftover', outside-changed=$([ "$(cat "$wt_outside")" = "$wt_outside_bytes" ] && echo no || echo YES))"
-fi
-# ...and the STAGING entry is UNPREDICTABLE, created by `mktemp` (roborev finding 1 on #3261 — the
-# NINTH escape, same shape as the other eight: a NAME trusted instead of a DESTINATION). A fixed
-# staging path that is checked, cleared and only THEN opened by a privileged `tee` is a TOCTOU
-# window: anyone who can create entries in the directory re-plants that KNOWN name as a symlink
-# between the verify and the open, and root follows it. Two asserts, because neither alone is
-# enough — a behavioural one (the previously-predictable name is planted as a symlink at a victim
-# file and must be left strictly alone) and a structural one (unpredictability is a property of the
-# NAME, which is gone by the time the write succeeds, so the source is the only place to see it).
-wt_bait="$tmp/wt-staging-bait"; printf 'BAIT-MUST-NOT-BE-WRITTEN\n' >"$wt_bait"
-wt_bait_before=$(cat "$wt_bait")
-rm -f "$wt_d/.99-cqlite-perf.conf.new"; ln -s "$wt_bait" "$wt_d/.99-cqlite-perf.conf.new"
-rm -f "$wt_d/99-cqlite-perf.conf"
-wt_st=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
-  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_st_rc=$?
-if [ "$wt_st_rc" -eq 0 ] && [ "$(cat "$wt_bait")" = "$wt_bait_before" ] \
-   && [ -L "$wt_d/.99-cqlite-perf.conf.new" ] \
-   && [ -f "$wt_d/99-cqlite-perf.conf" ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ]; then
-  ok "perf-capability: the drop-in staging entry does NOT reuse the previously-predictable name — a symlink planted there is left untouched and its target is byte-unchanged, while the managed file is still written (#3261 roborev-1 TOCTOU)"
-else
-  bad "perf-capability: the install wrote through a PREDICTABLE staging name (rc=$wt_st_rc, bait-changed=$([ "$(cat "$wt_bait")" = "$wt_bait_before" ] && echo no || echo YES), out='$wt_st')"
-fi
-rm -f "$wt_d/.99-cqlite-perf.conf.new"
-# ...structurally: the staging entry is created by `mktemp` with a random-suffix template, no
-# hardcoded staging literal survives, the rename carries `-T`, and the WHOLE staged install is ONE
-# privileged invocation (issue #3261 roborev round 2).
-#   THE LAST PROPERTY IS HYGIENE, NOT THE FIX, and this comment previously said otherwise. roborev
-#   round 3 corrected it: a single `sh -c` sequences ONE PROCESS's commands and is not mutual
-#   exclusion against other processes, which run concurrently on other CPUs regardless of how we
-#   grouped ours. Consolidation NARROWS the create-to-reopen window; it does not close it. It is
-#   still worth pinning — a split back into `mktemp` in one privileged call and the write in another
-#   would re-widen the window while every behavioural assert stayed green, which no after-the-fact
-#   observation can catch — but it is pinned as hygiene, not as the guarantee.
-wt_body=$(awk '/^perf_capability_dropin_install\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
-wt_privcalls=$(printf '%s\n' "$wt_body" | grep -c '"\$@"')
-wt_struct_fail=''
-printf '%s\n' "$wt_body" | grep -q 'mktemp -- "\$d/\.\$b\.XXXXXX"' \
-  || wt_struct_fail="$wt_struct_fail no-mktemp-template"
-printf '%s\n' "$wt_body" | grep -qF '.new"' && wt_struct_fail="$wt_struct_fail hardcoded-staging-name"
-printf '%s\n' "$wt_body" | grep -q 'mv -fT -- "\$t" "\$p"' \
-  || wt_struct_fail="$wt_struct_fail no-mv-T"
-[ "$wt_privcalls" -eq 1 ] || wt_struct_fail="$wt_struct_fail privileged-invocations=$wt_privcalls"
-printf '%s\n' "$wt_body" | grep -q '"\$@" sh -c' || wt_struct_fail="$wt_struct_fail not-a-single-sh-c"
-if [ -z "$wt_struct_fail" ]; then
-  ok "perf-capability: STRUCTURAL — the staged install is ONE privileged 'sh -c' (mktemp + write + chmod + mv all inside it, which NARROWS the create-to-reopen window but does NOT close it — see the note above), the staging name comes from an mktemp random-suffix template with no hardcoded literal, and the rename carries -T (#3261 roborev-1/roborev-2)"
-else
-  bad "perf-capability: the staged install lost a structural property:$wt_struct_fail"
-  printf '%s\n' "$wt_body" | grep -n '\$@\|mktemp\|mv -' | head -8
-fi
-# ...and a `mktemp` that answers OUTSIDE the validated directory is refused rather than trusted —
-# the check now lives INSIDE the privileged shell, so this also proves it survived consolidation.
-wt_mt="$tmp/wt-bad-mktemp"; mkdir -p "$wt_mt"
-for t in bash sh cat printf tee mv rm chmod env grep; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$wt_mt/$t"
-done
-printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "/tmp/perf-cap-elsewhere.$$"' >"$wt_mt/mktemp"
-chmod +x "$wt_mt/mktemp"
-wt_mt_out=$(env PATH="$wt_mt:$PATH" CQLITE_PERF_SYSCTL_DIR="$wt_d" \
-  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_mt_rc=$?
-if [ "$wt_mt_rc" -ne 0 ] \
-   && printf '%s' "$wt_mt_out" | grep -q 'mktemp did not create a staging entry inside the validated directory' \
-   && [ ! -e "/tmp/perf-cap-elsewhere.$$" ]; then
-  ok "perf-capability: a 'mktemp' answering a path OUTSIDE the validated directory is REFUSED by name from INSIDE the privileged shell, and that path is never created (the tool's answer is checked, not trusted)"
-else
-  bad "perf-capability: a mktemp answering outside the validated directory was trusted (rc=$wt_mt_rc, out='$wt_mt_out')"
-fi
-# ...and the POST-CREATION destination race: a symlink-to-DIRECTORY planted at the managed name.
-# Without `mv -T` (--no-target-directory) `mv` would move the staging file INTO the linked
-# directory — the rename that exists to avoid FOLLOWING a symlink would follow one instead, landing
-# the managed bytes outside the sandbox under a different name. With -T the destination is always a
-# plain name to replace. Asserted by consequence: nothing may appear inside the outside directory.
-wt_outdir="$tmp/wt-outside-dir"; rm -rf "$wt_outdir"; mkdir -p "$wt_outdir"
-rm -f "$wt_d/99-cqlite-perf.conf"; ln -s "$wt_outdir" "$wt_d/99-cqlite-perf.conf"
-wt_td=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
-  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_td_rc=$?
-wt_outdir_contents=$(ls -A "$wt_outdir")
-wt_td_leftover=$(ls -A "$wt_d" | grep -v '^99-cqlite-perf\.conf$' || true)
-# Measured without `-T`: the staging entry landed INSIDE $wt_outdir as `.99-cqlite-perf.conf.XXXXXX`
-# — the managed bytes escaped the sandbox under a name nothing tracks. With `-T`: rc 0, the symlink
-# is REPLACED by a regular file, the outside directory stays empty. All four pinned.
-if [ "$wt_td_rc" -eq 0 ] && [ -z "$wt_outdir_contents" ] && [ -z "$wt_td_leftover" ] \
-   && [ -f "$wt_d/99-cqlite-perf.conf" ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ]; then
-  ok "perf-capability: a symlink-to-DIRECTORY planted at the managed name does NOT redirect the staged write into it ('mv -T') — the link is REPLACED by a regular file, the outside directory stays empty, no staging entry is left behind (#3261 roborev-2)"
-else
-  bad "perf-capability: the staged write was redirected through a symlink-to-directory at the managed name (rc=$wt_td_rc, outside-dir='$wt_outdir_contents', leftover='$wt_td_leftover', out='$wt_td')"
-fi
-rm -f "$wt_d/99-cqlite-perf.conf"
-# ...and THE PRECONDITION THAT ACTUALLY CLOSES THE STAGING RACE (issue #3261, roborev round 3): a
-# drop-in directory writable by anyone less privileged than the writer is REFUSED before anything is
-# staged. Three rounds of this defect were each answered by trying to make the race unwinnable
-# (unpredictable name, then one privileged invocation); neither works, because a single `sh -c`
-# sequences OUR commands and says nothing about other processes on other CPUs. Removing the
-# attacker's precondition does work — with no one able to create or replace entries in the
-# directory, there is no actor to race, whatever the timing.
-# The negative control is the whole point of the group: a check that refuses everything would pass
-# the two refusal cases and be useless, so a correctly-owned 0755 directory must still install.
-wt_perm_d="$tmp/wt-perm.d"
-wt_perm_fail=0
-for wt_mode in 0775 0777 0757; do
-  rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod "$wt_mode" "$wt_perm_d"
-  wt_perm_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
-    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_perm_rc=$?
-  wt_perm_left=$(ls -A "$wt_perm_d")
-  if [ "$wt_perm_rc" -eq 0 ] \
-     || ! printf '%s' "$wt_perm_out" | grep -q 'group- or world-writable' \
-     || [ -n "$wt_perm_left" ]; then
-    bad "perf-capability: a mode-$wt_mode drop-in directory was accepted for a privileged staged write (rc=$wt_perm_rc, left='$wt_perm_left', out='$wt_perm_out')"
+# ---- STAGED-INSTALL CASES: GNU-ONLY TOOLCHAIN, LOUDLY AND COUNTABLY SKIPPED ELSEWHERE ----------
+# (issue #3261, roborev round 5 Medium.) Everything from here to the matching `fi` drives
+# perf_capability_dropin_install, which needs GNU `stat -c` and `mv --no-target-directory`. macOS is a
+# FIRST-CLASS gate host here, so invoking these unconditionally red-ed the gate on the TOOLCHAIN
+# rather than on behaviour. The probe is AFFIRMATIVE (it runs the flags) rather than a `uname` guess,
+# and the non-GNU branch emits one COUNTED skip per case group so a green macOS run shows them
+# skipped-with-reason instead of silently absent. Production is unaffected on either branch:
+# bootstrap gates the whole perf section on PLATFORM=linux.
+if perf_install_supported; then
+  wt_d="$tmp/wt-sandbox.d"; mkdir -p "$wt_d"
+  wt_outside="$tmp/wt-outside-target"; printf 'PRECIOUS-HOST-FILE\n' >"$wt_outside"
+  wt_before=$(cat "$wt_outside")
+  rm -f "$wt_d/99-cqlite-perf.conf"; ln -s "$wt_outside" "$wt_d/99-cqlite-perf.conf"
+  wt_path=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash "$PERFLIB" --drop-in-path 2>/dev/null); wt_rc=$?
+  wt_err=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash "$PERFLIB" --drop-in-path 2>&1 >/dev/null)
+  if [ "$wt_rc" -ne 0 ] && [ -z "$wt_path" ] \
+     && printf '%s' "$wt_err" | grep -qi 'symlink' \
+     && [ -L "$wt_d/99-cqlite-perf.conf" ] && [ "$(cat "$wt_outside")" = "$wt_before" ]; then
+    ok "perf-capability: the drop-in WRITE TARGET is refused when the managed basename is itself a SYMLINK (rc 1, empty, named) — a contained directory does not license writing through its entries (#3261 AC1)"
+  else
+    bad "perf-capability: a SYMLINKED write target was NAMED for a privileged tee (rc=$wt_rc, path='$wt_path', err='$wt_err')"
+  fi
+  # ...and the CONTENTS read that decides idempotency may not follow it either: a symlink whose
+  # TARGET happens to hold the canonical bytes must not report "already current" (that would
+  # leave the host file in place and claim success).
+  printf '%s\n' "$(bash "$PERFLIB" --drop-in)" >"$wt_outside"
+  if env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB" 2>/dev/null; then
+    bad "perf-capability: dropin_current followed a SYMLINK and reported the drop-in 'already current' from a file outside the managed name"
+  else
+    ok "perf-capability: dropin_current does NOT follow a symlinked managed name, even when the link's TARGET holds byte-identical canonical content (#3261 AC1)"
+  fi
+  # ...and the WRITE replaces the ENTRY. The refusal above is a check with a TOCTOU window; the
+  # rename has none. After it, the managed name is a REGULAR file holding the canonical bytes,
+  # the outside target is byte-identical to before, and no temp entry is left behind.
+  wt_outside_bytes=$(cat "$wt_outside")
+  wt_ins=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ins_rc=$?
+  wt_leftover=$(ls -A "$wt_d" | grep -v '^99-cqlite-perf\.conf$' || true)
+  if [ "$wt_ins_rc" -eq 0 ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ] && [ -f "$wt_d/99-cqlite-perf.conf" ] \
+     && [ "$(cat "$wt_outside")" = "$wt_outside_bytes" ] && [ -z "$wt_leftover" ] \
+     && env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB"; then
+    ok "perf-capability: the drop-in write REPLACES the directory entry (temp + rename), so a pre-existing symlink at the managed name is replaced and its outside target is untouched — and no temp entry is left behind (#3261 AC1)"
+  else
+    bad "perf-capability: the atomic drop-in install did not replace a symlinked entry (rc=$wt_ins_rc, out='$wt_ins', link=$([ -L "$wt_d/99-cqlite-perf.conf" ] && echo yes || echo no), leftover='$wt_leftover', outside-changed=$([ "$(cat "$wt_outside")" = "$wt_outside_bytes" ] && echo no || echo YES))"
+  fi
+  # ...and the STAGING entry is UNPREDICTABLE, created by `mktemp` (roborev finding 1 on #3261 — the
+  # NINTH escape, same shape as the other eight: a NAME trusted instead of a DESTINATION). A fixed
+  # staging path that is checked, cleared and only THEN opened by a privileged `tee` is a TOCTOU
+  # window: anyone who can create entries in the directory re-plants that KNOWN name as a symlink
+  # between the verify and the open, and root follows it. Two asserts, because neither alone is
+  # enough — a behavioural one (the previously-predictable name is planted as a symlink at a victim
+  # file and must be left strictly alone) and a structural one (unpredictability is a property of the
+  # NAME, which is gone by the time the write succeeds, so the source is the only place to see it).
+  wt_bait="$tmp/wt-staging-bait"; printf 'BAIT-MUST-NOT-BE-WRITTEN\n' >"$wt_bait"
+  wt_bait_before=$(cat "$wt_bait")
+  rm -f "$wt_d/.99-cqlite-perf.conf.new"; ln -s "$wt_bait" "$wt_d/.99-cqlite-perf.conf.new"
+  rm -f "$wt_d/99-cqlite-perf.conf"
+  wt_st=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_st_rc=$?
+  if [ "$wt_st_rc" -eq 0 ] && [ "$(cat "$wt_bait")" = "$wt_bait_before" ] \
+     && [ -L "$wt_d/.99-cqlite-perf.conf.new" ] \
+     && [ -f "$wt_d/99-cqlite-perf.conf" ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ]; then
+    ok "perf-capability: the drop-in staging entry does NOT reuse the previously-predictable name — a symlink planted there is left untouched and its target is byte-unchanged, while the managed file is still written (#3261 roborev-1 TOCTOU)"
+  else
+    bad "perf-capability: the install wrote through a PREDICTABLE staging name (rc=$wt_st_rc, bait-changed=$([ "$(cat "$wt_bait")" = "$wt_bait_before" ] && echo no || echo YES), out='$wt_st')"
+  fi
+  rm -f "$wt_d/.99-cqlite-perf.conf.new"
+  # ...structurally: the staging entry is created by `mktemp` with a random-suffix template, no
+  # hardcoded staging literal survives, the rename carries `-T`, and the WHOLE staged install is ONE
+  # privileged invocation (issue #3261 roborev round 2).
+  #   THE LAST PROPERTY IS HYGIENE, NOT THE FIX, and this comment previously said otherwise. roborev
+  #   round 3 corrected it: a single `sh -c` sequences ONE PROCESS's commands and is not mutual
+  #   exclusion against other processes, which run concurrently on other CPUs regardless of how we
+  #   grouped ours. Consolidation NARROWS the create-to-reopen window; it does not close it. It is
+  #   still worth pinning — a split back into `mktemp` in one privileged call and the write in another
+  #   would re-widen the window while every behavioural assert stayed green, which no after-the-fact
+  #   observation can catch — but it is pinned as hygiene, not as the guarantee.
+  wt_body=$(awk '/^perf_capability_dropin_install\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
+  wt_privcalls=$(printf '%s\n' "$wt_body" | grep -c '"\$@"')
+  wt_struct_fail=''
+  printf '%s\n' "$wt_body" | grep -q 'mktemp -- "\$d/\.\$b\.XXXXXX"' \
+    || wt_struct_fail="$wt_struct_fail no-mktemp-template"
+  printf '%s\n' "$wt_body" | grep -qF '.new"' && wt_struct_fail="$wt_struct_fail hardcoded-staging-name"
+  printf '%s\n' "$wt_body" | grep -q 'mv -fT -- "\$t" "\$p"' \
+    || wt_struct_fail="$wt_struct_fail no-mv-T"
+  [ "$wt_privcalls" -eq 1 ] || wt_struct_fail="$wt_struct_fail privileged-invocations=$wt_privcalls"
+  printf '%s\n' "$wt_body" | grep -q '"\$@" sh -c' || wt_struct_fail="$wt_struct_fail not-a-single-sh-c"
+  if [ -z "$wt_struct_fail" ]; then
+    ok "perf-capability: STRUCTURAL — the staged install is ONE privileged 'sh -c' (mktemp + write + chmod + mv all inside it, which NARROWS the create-to-reopen window but does NOT close it — see the note above), the staging name comes from an mktemp random-suffix template with no hardcoded literal, and the rename carries -T (#3261 roborev-1/roborev-2)"
+  else
+    bad "perf-capability: the staged install lost a structural property:$wt_struct_fail"
+    printf '%s\n' "$wt_body" | grep -n '\$@\|mktemp\|mv -' | head -8
+  fi
+  # ...and a `mktemp` that answers OUTSIDE the validated directory is refused rather than trusted —
+  # the check now lives INSIDE the privileged shell, so this also proves it survived consolidation.
+  wt_mt="$tmp/wt-bad-mktemp"; mkdir -p "$wt_mt"
+  for t in bash sh cat printf tee mv rm chmod env grep; do
+    s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$wt_mt/$t"
+  done
+  printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "/tmp/perf-cap-elsewhere.$$"' >"$wt_mt/mktemp"
+  chmod +x "$wt_mt/mktemp"
+  wt_mt_out=$(env PATH="$wt_mt:$PATH" CQLITE_PERF_SYSCTL_DIR="$wt_d" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_mt_rc=$?
+  if [ "$wt_mt_rc" -ne 0 ] \
+     && printf '%s' "$wt_mt_out" | grep -q 'mktemp did not create a staging entry inside the validated directory' \
+     && [ ! -e "/tmp/perf-cap-elsewhere.$$" ]; then
+    ok "perf-capability: a 'mktemp' answering a path OUTSIDE the validated directory is REFUSED by name from INSIDE the privileged shell, and that path is never created (the tool's answer is checked, not trusted)"
+  else
+    bad "perf-capability: a mktemp answering outside the validated directory was trusted (rc=$wt_mt_rc, out='$wt_mt_out')"
+  fi
+  # ...and the POST-CREATION destination race: a symlink-to-DIRECTORY planted at the managed name.
+  # Without `mv -T` (--no-target-directory) `mv` would move the staging file INTO the linked
+  # directory — the rename that exists to avoid FOLLOWING a symlink would follow one instead, landing
+  # the managed bytes outside the sandbox under a different name. With -T the destination is always a
+  # plain name to replace. Asserted by consequence: nothing may appear inside the outside directory.
+  wt_outdir="$tmp/wt-outside-dir"; rm -rf "$wt_outdir"; mkdir -p "$wt_outdir"
+  rm -f "$wt_d/99-cqlite-perf.conf"; ln -s "$wt_outdir" "$wt_d/99-cqlite-perf.conf"
+  wt_td=$(env CQLITE_PERF_SYSCTL_DIR="$wt_d" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_td_rc=$?
+  wt_outdir_contents=$(ls -A "$wt_outdir")
+  wt_td_leftover=$(ls -A "$wt_d" | grep -v '^99-cqlite-perf\.conf$' || true)
+  # Measured without `-T`: the staging entry landed INSIDE $wt_outdir as `.99-cqlite-perf.conf.XXXXXX`
+  # — the managed bytes escaped the sandbox under a name nothing tracks. With `-T`: rc 0, the symlink
+  # is REPLACED by a regular file, the outside directory stays empty. All four pinned.
+  if [ "$wt_td_rc" -eq 0 ] && [ -z "$wt_outdir_contents" ] && [ -z "$wt_td_leftover" ] \
+     && [ -f "$wt_d/99-cqlite-perf.conf" ] && [ ! -L "$wt_d/99-cqlite-perf.conf" ]; then
+    ok "perf-capability: a symlink-to-DIRECTORY planted at the managed name does NOT redirect the staged write into it ('mv -T') — the link is REPLACED by a regular file, the outside directory stays empty, no staging entry is left behind (#3261 roborev-2)"
+  else
+    bad "perf-capability: the staged write was redirected through a symlink-to-directory at the managed name (rc=$wt_td_rc, outside-dir='$wt_outdir_contents', leftover='$wt_td_leftover', out='$wt_td')"
+  fi
+  rm -f "$wt_d/99-cqlite-perf.conf"
+  # ...and THE PRECONDITION THAT ACTUALLY CLOSES THE STAGING RACE (issue #3261, roborev round 3): a
+  # drop-in directory writable by anyone less privileged than the writer is REFUSED before anything is
+  # staged. Three rounds of this defect were each answered by trying to make the race unwinnable
+  # (unpredictable name, then one privileged invocation); neither works, because a single `sh -c`
+  # sequences OUR commands and says nothing about other processes on other CPUs. Removing the
+  # attacker's precondition does work — with no one able to create or replace entries in the
+  # directory, there is no actor to race, whatever the timing.
+  # The negative control is the whole point of the group: a check that refuses everything would pass
+  # the two refusal cases and be useless, so a correctly-owned 0755 directory must still install.
+  wt_perm_d="$tmp/wt-perm.d"
+  wt_perm_fail=0
+  for wt_mode in 0775 0777 0757; do
+    rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod "$wt_mode" "$wt_perm_d"
+    wt_perm_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
+      bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_perm_rc=$?
+    wt_perm_left=$(ls -A "$wt_perm_d")
+    if [ "$wt_perm_rc" -eq 0 ] \
+       || ! printf '%s' "$wt_perm_out" | grep -q 'group- or world-writable' \
+       || [ -n "$wt_perm_left" ]; then
+      bad "perf-capability: a mode-$wt_mode drop-in directory was accepted for a privileged staged write (rc=$wt_perm_rc, left='$wt_perm_left', out='$wt_perm_out')"
+      wt_perm_fail=1
+    fi
+  done
+  # ...the NEGATIVE CONTROL: a directory owned by the writer and not group/world-writable installs.
+  rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
+  wt_ok_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ok_rc=$?
+  if [ "$wt_ok_rc" -ne 0 ] || [ ! -f "$wt_perm_d/99-cqlite-perf.conf" ]; then
+    bad "perf-capability: a correctly-owned 0755 drop-in directory was REFUSED — the writability precondition is vacuous (rc=$wt_ok_rc, out='$wt_ok_out')"
     wt_perm_fail=1
   fi
-done
-# ...the NEGATIVE CONTROL: a directory owned by the writer and not group/world-writable installs.
-rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
-wt_ok_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
-  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ok_rc=$?
-if [ "$wt_ok_rc" -ne 0 ] || [ ! -f "$wt_perm_d/99-cqlite-perf.conf" ]; then
-  bad "perf-capability: a correctly-owned 0755 drop-in directory was REFUSED — the writability precondition is vacuous (rc=$wt_ok_rc, out='$wt_ok_out')"
-  wt_perm_fail=1
-fi
-# ...and an UNDETERMINABLE owner/mode is a refusal, not an assumption: with `stat` unusable the
-# install must fail closed rather than proceed on the hope that the directory is fine.
-wt_nostat="$tmp/wt-nostat"; mkdir -p "$wt_nostat"
-for t in bash sh cat printf tee mv rm chmod env grep mktemp id; do
-  s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$wt_nostat/$t"
-done
-printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$wt_nostat/stat"; chmod +x "$wt_nostat/stat"
-rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
-wt_ns_out=$(env PATH="$wt_nostat" CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
-  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ns_rc=$?
-if [ "$wt_ns_rc" -eq 0 ] || ! printf '%s' "$wt_ns_out" | grep -q 'cannot determine owner/mode'; then
-  bad "perf-capability: an undeterminable directory owner/mode did not fail closed (rc=$wt_ns_rc, out='$wt_ns_out')"
-  wt_perm_fail=1
-fi
-# ...a SHORT MODE from `stat -c %a` must not bypass the write-bit check (roborev round 5, High).
-# WHY A SHIM AND NOT A REAL chmod: `%a` only drops below three digits when the OWNER digit is 0,
-# and a directory its owner cannot enter fails containment long before the mode check — so the real
-# bypass is NOT reachable through an actual chmod under test mode. It IS reachable as root in
-# production, where root ignores permission bits and enters a mode-0033 /etc/sysctl.d happily while
-# group and other retain write. So the honest reproduction is to feed the parser the short string a
-# root `stat` would really print, against an enterable directory. Without the zero-padding this
-# reports "33", the suffix-strip leaves the permission field EMPTY, no write-bit pattern matches,
-# and a group- AND world-writable directory is ACCEPTED.
-wt_short="$tmp/wt-shortmode"; mkdir -p "$wt_short"
-for st in bash sh cat printf tee mv rm chmod env grep mktemp id ls; do
-  s=$(command -v "$st" 2>/dev/null) && ln -sf "$s" "$wt_short/$st"
-done
-printf '%s\n' '#!/usr/bin/env bash' 'printf "%s 33\n" "$(id -u)"' >"$wt_short/stat"
-chmod +x "$wt_short/stat"
-rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
-wt_sm_out=$(env PATH="$wt_short" CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
-  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_sm_rc=$?
-if [ "$wt_sm_rc" -eq 0 ] || [ -e "$wt_perm_d/99-cqlite-perf.conf" ] \
-   || ! printf '%s' "$wt_sm_out" | grep -q 'group- or world-writable'; then
-  bad "perf-capability: a SHORT mode (stat reported '33' = 0033, group+world writable) was accepted — the zero-padding is missing or ineffective (rc=$wt_sm_rc, out='$wt_sm_out')"
-  wt_perm_fail=1
-fi
+  # ...and an UNDETERMINABLE owner/mode is a refusal, not an assumption: with `stat` unusable the
+  # install must fail closed rather than proceed on the hope that the directory is fine.
+  wt_nostat="$tmp/wt-nostat"; mkdir -p "$wt_nostat"
+  for t in bash sh cat printf tee mv rm chmod env grep mktemp id; do
+    s=$(command -v "$t" 2>/dev/null) && ln -sf "$s" "$wt_nostat/$t"
+  done
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$wt_nostat/stat"; chmod +x "$wt_nostat/stat"
+  rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
+  wt_ns_out=$(env PATH="$wt_nostat" CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ns_rc=$?
+  if [ "$wt_ns_rc" -eq 0 ] || ! printf '%s' "$wt_ns_out" | grep -q 'cannot determine owner/mode'; then
+    bad "perf-capability: an undeterminable directory owner/mode did not fail closed (rc=$wt_ns_rc, out='$wt_ns_out')"
+    wt_perm_fail=1
+  fi
+  # ...a SHORT MODE from `stat -c %a` must not bypass the write-bit check (roborev round 5, High).
+  # WHY A SHIM AND NOT A REAL chmod: `%a` only drops below three digits when the OWNER digit is 0,
+  # and a directory its owner cannot enter fails containment long before the mode check — so the real
+  # bypass is NOT reachable through an actual chmod under test mode. It IS reachable as root in
+  # production, where root ignores permission bits and enters a mode-0033 /etc/sysctl.d happily while
+  # group and other retain write. So the honest reproduction is to feed the parser the short string a
+  # root `stat` would really print, against an enterable directory. Without the zero-padding this
+  # reports "33", the suffix-strip leaves the permission field EMPTY, no write-bit pattern matches,
+  # and a group- AND world-writable directory is ACCEPTED.
+  wt_short="$tmp/wt-shortmode"; mkdir -p "$wt_short"
+  for st in bash sh cat printf tee mv rm chmod env grep mktemp id ls; do
+    s=$(command -v "$st" 2>/dev/null) && ln -sf "$s" "$wt_short/$st"
+  done
+  printf '%s\n' '#!/usr/bin/env bash' 'printf "%s 33\n" "$(id -u)"' >"$wt_short/stat"
+  chmod +x "$wt_short/stat"
+  rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
+  wt_sm_out=$(env PATH="$wt_short" CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_sm_rc=$?
+  if [ "$wt_sm_rc" -eq 0 ] || [ -e "$wt_perm_d/99-cqlite-perf.conf" ] \
+     || ! printf '%s' "$wt_sm_out" | grep -q 'group- or world-writable'; then
+    bad "perf-capability: a SHORT mode (stat reported '33' = 0033, group+world writable) was accepted — the zero-padding is missing or ineffective (rc=$wt_sm_rc, out='$wt_sm_out')"
+    wt_perm_fail=1
+  fi
 
-# ...a SYMLINKED destination directory is refused OUTRIGHT (owner ruling A', condition 2: lstat
-# semantics ASSERTED, not inherited from `stat`'s default). The link itself may look perfectly
-# owned and 0755 while entries would be created somewhere else entirely, so measuring the link
-# and proceeding is exactly the by-name reasoning this family has punished eleven times. The
-# link target here is a legitimate, correctly-owned, non-group-writable directory precisely so
-# the case cannot pass for the wrong reason: only the SYMLINK-NESS may cause the refusal.
-wt_ln_target="$tmp/wt-ln-target"; wt_ln_dir="$tmp/wt-ln-dir"
-rm -rf "$wt_ln_target" "$wt_ln_dir"; mkdir -p "$wt_ln_target"; chmod 0755 "$wt_ln_target"
-ln -s "$wt_ln_target" "$wt_ln_dir"
-wt_ln_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_ln_dir" \
-  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ln_rc=$?
-if [ "$wt_ln_rc" -eq 0 ] || ! printf '%s' "$wt_ln_out" | grep -q 'is a SYMLINK'; then
-  bad "perf-capability: a SYMLINKED drop-in directory was not refused by name (rc=$wt_ln_rc, out='$wt_ln_out')"
-  wt_perm_fail=1
+  # ...a SYMLINKED destination directory is refused OUTRIGHT (owner ruling A', condition 2: lstat
+  # semantics ASSERTED, not inherited from `stat`'s default). The link itself may look perfectly
+  # owned and 0755 while entries would be created somewhere else entirely, so measuring the link
+  # and proceeding is exactly the by-name reasoning this family has punished eleven times. The
+  # link target here is a legitimate, correctly-owned, non-group-writable directory precisely so
+  # the case cannot pass for the wrong reason: only the SYMLINK-NESS may cause the refusal.
+  wt_ln_target="$tmp/wt-ln-target"; wt_ln_dir="$tmp/wt-ln-dir"
+  rm -rf "$wt_ln_target" "$wt_ln_dir"; mkdir -p "$wt_ln_target"; chmod 0755 "$wt_ln_target"
+  ln -s "$wt_ln_target" "$wt_ln_dir"
+  wt_ln_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_ln_dir" \
+    bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ln_rc=$?
+  if [ "$wt_ln_rc" -eq 0 ] || ! printf '%s' "$wt_ln_out" | grep -q 'is a SYMLINK'; then
+    bad "perf-capability: a SYMLINKED drop-in directory was not refused by name (rc=$wt_ln_rc, out='$wt_ln_out')"
+    wt_perm_fail=1
+  fi
+  if [ -e "$wt_ln_target/99-cqlite-perf.conf" ]; then
+    bad "perf-capability: the symlinked drop-in directory was refused but its TARGET was written anyway"
+    wt_perm_fail=1
+  fi
+  [ "$wt_perm_fail" -ne 0 ] || ok "perf-capability: a privileged staged install REFUSES a group-/world-writable drop-in directory by name and writes nothing, refuses a SYMLINKED destination outright (lstat semantics asserted, target left unwritten), refuses when owner/mode cannot be determined, and still installs into a correctly-owned 0755 directory — the staging race is closed at its PRECONDITION rather than by trying to win it (#3261 roborev-3, owner A' condition 2)"
+else
+  skip "perf-capability: staged-install write-target cases (symlinked managed name refused; dropin_current does not follow it; the write REPLACES the directory entry)" "no GNU stat -c / mv --no-target-directory on this host"
+  skip "perf-capability: staged-install staging-race cases (unpredictable mktemp name; ONE privileged sh -c; mktemp answer outside the validated dir refused; symlink-to-directory not followed)" "no GNU stat -c / mv --no-target-directory on this host"
+  skip "perf-capability: staged-install writability-precondition cases (group/world-writable refused; SHORT mode 0033 refused; SYMLINKED destination refused; undeterminable owner/mode fails closed; correctly-owned 0755 still installs)" "no GNU stat -c / mv --no-target-directory on this host"
 fi
-if [ -e "$wt_ln_target/99-cqlite-perf.conf" ]; then
-  bad "perf-capability: the symlinked drop-in directory was refused but its TARGET was written anyway"
-  wt_perm_fail=1
-fi
-[ "$wt_perm_fail" -ne 0 ] || ok "perf-capability: a privileged staged install REFUSES a group-/world-writable drop-in directory by name and writes nothing, refuses a SYMLINKED destination outright (lstat semantics asserted, target left unwritten), refuses when owner/mode cannot be determined, and still installs into a correctly-owned 0755 directory — the staging race is closed at its PRECONDITION rather than by trying to win it (#3261 roborev-3, owner A' condition 2)"
 
 # ...and CR/LF IN A PATH SEAM IS REFUSED (issue #3261, roborev round 3). Not a containment defect —
 # the path IS contained — a SERIALIZATION one, which is why nine rounds of containment work never
@@ -1234,8 +1248,11 @@ else
   ok "perf-capability: the line-safety predicate rejects CR as well as LF and still accepts an ordinary path"
 fi
 
-# ...and the install is still gated: an out-of-sandbox seam may not be written at all.
-if env CQLITE_PERF_SYSCTL_DIR="$symanc/sysctl.d" \
+# ...and the install is still gated: an out-of-sandbox seam may not be written at all. Same GNU-only
+# toolchain dependency as the staged-install block above, so same counted skip off GNU.
+if ! perf_install_supported; then
+  skip "perf-capability: dropin_install refuses a seam resolving OUT of the sandbox" "no GNU stat -c / mv --no-target-directory on this host"
+elif env CQLITE_PERF_SYSCTL_DIR="$symanc/sysctl.d" \
      bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" >/dev/null 2>&1; then
   bad "perf-capability: dropin_install wrote through a seam resolving OUT of the sandbox"
 else

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1158,6 +1158,30 @@ if [ "$wt_ns_rc" -eq 0 ] || ! printf '%s' "$wt_ns_out" | grep -q 'cannot determi
   bad "perf-capability: an undeterminable directory owner/mode did not fail closed (rc=$wt_ns_rc, out='$wt_ns_out')"
   wt_perm_fail=1
 fi
+# ...a SHORT MODE from `stat -c %a` must not bypass the write-bit check (roborev round 5, High).
+# WHY A SHIM AND NOT A REAL chmod: `%a` only drops below three digits when the OWNER digit is 0,
+# and a directory its owner cannot enter fails containment long before the mode check — so the real
+# bypass is NOT reachable through an actual chmod under test mode. It IS reachable as root in
+# production, where root ignores permission bits and enters a mode-0033 /etc/sysctl.d happily while
+# group and other retain write. So the honest reproduction is to feed the parser the short string a
+# root `stat` would really print, against an enterable directory. Without the zero-padding this
+# reports "33", the suffix-strip leaves the permission field EMPTY, no write-bit pattern matches,
+# and a group- AND world-writable directory is ACCEPTED.
+wt_short="$tmp/wt-shortmode"; mkdir -p "$wt_short"
+for st in bash sh cat printf tee mv rm chmod env grep mktemp id ls; do
+  s=$(command -v "$st" 2>/dev/null) && ln -sf "$s" "$wt_short/$st"
+done
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s 33\n" "$(id -u)"' >"$wt_short/stat"
+chmod +x "$wt_short/stat"
+rm -rf "$wt_perm_d"; mkdir -p "$wt_perm_d"; chmod 0755 "$wt_perm_d"
+wt_sm_out=$(env PATH="$wt_short" CQLITE_PERF_SYSCTL_DIR="$wt_perm_d" \
+  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_sm_rc=$?
+if [ "$wt_sm_rc" -eq 0 ] || [ -e "$wt_perm_d/99-cqlite-perf.conf" ] \
+   || ! printf '%s' "$wt_sm_out" | grep -q 'group- or world-writable'; then
+  bad "perf-capability: a SHORT mode (stat reported '33' = 0033, group+world writable) was accepted — the zero-padding is missing or ineffective (rc=$wt_sm_rc, out='$wt_sm_out')"
+  wt_perm_fail=1
+fi
+
 # ...a SYMLINKED destination directory is refused OUTRIGHT (owner ruling A', condition 2: lstat
 # semantics ASSERTED, not inherited from `stat`'s default). The link itself may look perfectly
 # owned and 0755 while entries would be created somewhere else entirely, so measuring the link

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1562,6 +1562,96 @@ else
   [ "$ac4_fail" -ne 0 ] || ok "perf-capability: every privileged executable the guard authorizes is validated by DESTINATION — a shim dir outside the sandbox ('/usr' shape), a symlink to a real tool inside a declared shim dir, and one merely PARKED there out of PATH reach are all refused, while a shim dir of real files inside the sandbox still works (#3261 AC4)"
 fi
 
+# 1c-iv. THE SEAM LIST IS COMPLETE, BY CENSUS (roborev round 32, Medium x2).
+# (full rationale: fleet-runbook.md, perf seam containment, seam-list-completeness)
+# perf_capability_seam_set named CQLITE_PERF_PROC_DIR and CQLITE_PERF_SYSCTL_DIR only, while the
+# file had grown three more test-only seams (TEST_SANDBOX, SYSCTL_EXTRA_DIRS, TEST_PRIV_DIR). Any
+# of those exported WITHOUT the marker sailed through the env guard, which is the marker-less
+# refusal failing open -- the same "denylist of names" shape this whole issue exists to close, and
+# my own doing: the round-6 audit policed WHICH FUNCTIONS may read a seam and never WHICH SEAMS the
+# list must name, so it could not see an omission. This audit is the other direction, and it is a
+# CENSUS rather than a hand-kept list: every CQLITE_PERF_* name the library reads must be named by
+# seam_set, minus the marker itself (which cannot gate its own absence). Adding a seam without
+# listing it now FAILS here instead of silently widening the production surface.
+seam_census_fail=0
+seam_set_body=$(awk '/^perf_capability_seam_set\(\)/{f=1} f{print} f&&/^\}/{exit}' "$PERFLIB")
+[ -n "$seam_set_body" ] \
+  || { bad "perf-capability: perf_capability_seam_set was not found — renamed without updating this census audit?"; seam_census_fail=1; }
+seam_census=$(grep -oE 'CQLITE_PERF_[A-Z_]+' "$PERFLIB" | sort -u | grep -v '^CQLITE_PERF_TEST_MODE$')
+[ -n "$seam_census" ] \
+  || { bad "perf-capability: the CQLITE_PERF_* census came back EMPTY, so this audit would pass vacuously"; seam_census_fail=1; }
+seam_census_n=0
+for seam_name in $seam_census; do
+  seam_census_n=$((seam_census_n+1))
+  printf '%s\n' "$seam_set_body" | grep -q -- "$seam_name" \
+    || { bad "perf-capability: $seam_name is read by the library but NOT named in perf_capability_seam_set, so exporting it without CQLITE_PERF_TEST_MODE=1 passes the marker-less refusal"; seam_census_fail=1; }
+done
+[ "$seam_census_n" -ge 5 ] \
+  || { bad "perf-capability: the seam census found only $seam_census_n name(s); the file is known to carry at least 5 non-marker seams, so the extraction is broken"; seam_census_fail=1; }
+[ "$seam_census_fail" -ne 0 ] || ok "perf-capability: every one of the $seam_census_n non-marker CQLITE_PERF_* seams the library reads is named by perf_capability_seam_set, so a new seam cannot escape the marker-less refusal (#3261 roborev-32)"
+
+# ...and the refusal is asserted BEHAVIOURALLY, per seam, not just structurally: a structural
+# audit can be satisfied by a name appearing in a comment.
+# (full rationale: fleet-runbook.md, perf seam containment, per-seam-markerless-refusal)
+seam_each_fail=0
+# BASELINE FIRST: with every seam unset the guard must SUCCEED, or the refusals below prove nothing.
+seam_base_rc=0
+env -u CQLITE_PERF_TEST_MODE -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR \
+    -u CQLITE_PERF_TEST_SANDBOX -u CQLITE_PERF_SYSCTL_EXTRA_DIRS -u CQLITE_PERF_TEST_PRIV_DIR \
+  bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" >/dev/null 2>&1 || seam_base_rc=$?
+[ "$seam_base_rc" -eq 0 ] \
+  || { bad "perf-capability: the env guard REFUSED with no seam set at all (rc=$seam_base_rc) — the per-seam refusals below would prove nothing"; seam_each_fail=1; }
+for seam_name in $seam_census; do
+  seam_out=$(env -u CQLITE_PERF_TEST_MODE "$seam_name=$tmp/markerless-seam" \
+    bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); seam_rc=$?
+  [ "$seam_rc" -ne 0 ] \
+    || { bad "perf-capability: $seam_name set WITHOUT the marker was ACCEPTED by the env guard (rc=0, out='$seam_out') — a test-only seam is live on the production path"; seam_each_fail=1; }
+  printf '%s' "$seam_out" | grep -q 'REFUSING' \
+    || { bad "perf-capability: $seam_name without the marker failed (rc=$seam_rc) but printed no REFUSING diagnostic: '$seam_out'"; seam_each_fail=1; }
+done
+[ "$seam_each_fail" -ne 0 ] || ok "perf-capability: EACH of the $seam_census_n non-marker seams, set alone without CQLITE_PERF_TEST_MODE=1, is refused loudly by the env guard — while an entirely seam-free environment still succeeds (#3261 roborev-32)"
+
+# 1c-v. THE TWO CONTAINMENT PATHS AGREE ABOUT A SYMLINKED SANDBOX ROOT (roborev round 32, Medium).
+# (full rationale: fleet-runbook.md, perf seam containment, symlinked-sandbox-root)
+# sandbox_root_into advertised a "canonically spelled" root but never tested for symlinked
+# components. MEASURED on the same root and child: the fork-free perf_capability_sandbox_ok
+# returned 1 while the RESOLVING perf_capability_sandbox_ok_resolved returned 0 -- read and write
+# disagreeing about one sandbox, the same defect class as round 31's trailing-slash split.
+# Rejecting (not canonicalizing) is the only fix available here: sandbox_root_into is in the closed
+# fork-free audit set, and canonicalizing needs cd -P/pwd -P, i.e. a forked subshell.
+# THE ASSERTION IS AGREEMENT, not merely refusal: my first draft of this case asked only whether
+# the fork-free path refused, which it already did, so it passed with the defect fully present.
+# Both paths are therefore driven over the same fixtures, and the canonical control requires both
+# to ACCEPT -- a rule that refused everything would fail here just as loudly as one that accepts.
+sr_fail=0
+sr_real=$(mktemp -d "$tmp/sr-real.XXXXXX"); : >"$sr_real/.cqlite-perf-sandbox"
+mkdir -p "$sr_real/child"; chmod 0755 "$sr_real" "$sr_real/child"
+sr_link="$tmp/sr-link-$$"; ln -s "$sr_real" "$sr_link"
+sr_adir="$tmp/sr-anc-$$"; mkdir -p "$sr_adir/real"; chmod 0755 "$sr_adir" "$sr_adir/real"
+sr_alink="$tmp/sr-anclink-$$"; ln -s "$sr_adir" "$sr_alink"
+: >"$sr_adir/real/.cqlite-perf-sandbox"; mkdir -p "$sr_adir/real/child"; chmod 0755 "$sr_adir/real/child"
+sr_probe() {  # <fn> <root> <path> -> rc of that containment entry point
+  env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$2" \
+    bash -c '. "$1"; "$2" "$3"' _ "$PERFLIB" "$1" "$3" >/dev/null 2>&1
+}
+# NEGATIVE CONTROL: the canonical spelling of the same directory must be ACCEPTED by BOTH paths.
+for sr_fn in perf_capability_sandbox_ok perf_capability_sandbox_ok_resolved; do
+  sr_probe "$sr_fn" "$sr_real" "$sr_real/child" \
+    || { bad "perf-capability: $sr_fn refused the CANONICAL sandbox root, so the symlink cases below prove nothing"; sr_fail=1; }
+done
+# (a) the root ITSELF is a symlink to a stamped real directory; (b) an ANCESTOR of the root is a
+# symlink while the root's own final component is an ordinary name. Both must be refused by BOTH.
+for sr_case in "root-is-symlink:$sr_link:$sr_link/child" "symlinked-ancestor:$sr_alink/real:$sr_alink/real/child"; do
+  sr_label="${sr_case%%:*}"; sr_rest="${sr_case#*:}"
+  sr_root="${sr_rest%%:*}"; sr_path="${sr_rest#*:}"
+  for sr_fn in perf_capability_sandbox_ok perf_capability_sandbox_ok_resolved; do
+    ! sr_probe "$sr_fn" "$sr_root" "$sr_path" \
+      || { bad "perf-capability: $sr_fn ACCEPTED the $sr_label sandbox root ($sr_root) — the resolving and fork-free paths disagree about the same sandbox"; sr_fail=1; }
+  done
+done
+rm -f -- "$sr_link" "$sr_alink"
+[ "$sr_fail" -ne 0 ] || ok "perf-capability: a sandbox root that IS a symlink, and one reached through a symlinked ANCESTOR, are refused IDENTICALLY by the fork-free and the resolving containment paths, while the canonical spelling of the same directory is accepted by both (#3261 roborev-32)"
+
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.
 perf_test_assert_host_clean
 perf_test_report

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1542,8 +1542,12 @@ env -u CQLITE_PERF_TEST_MODE -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR \
   bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" >/dev/null 2>&1 || seam_base_rc=$?
 [ "$seam_base_rc" -eq 0 ] \
   || { bad "perf-capability: the env guard REFUSED with no seam set at all (rc=$seam_base_rc) — the per-seam refusals below would prove nothing"; seam_each_fail=1; }
+# EVERY seam is unset per iteration, not just the marker (roborev round 33, Low, and it was RIGHT).
+# (full rationale: fleet-runbook.md, perf seam containment, every-seam-is-unset-per-iteration-not-just-the)
 for seam_name in $seam_census; do
-  seam_out=$(env -u CQLITE_PERF_TEST_MODE "$seam_name=$tmp/markerless-seam" \
+  seam_out=$(env -u CQLITE_PERF_TEST_MODE -u CQLITE_PERF_PROC_DIR -u CQLITE_PERF_SYSCTL_DIR \
+    -u CQLITE_PERF_TEST_SANDBOX -u CQLITE_PERF_SYSCTL_EXTRA_DIRS -u CQLITE_PERF_TEST_PRIV_DIR \
+    "$seam_name=$tmp/markerless-seam" \
     bash -c '. "$1"; perf_capability_env_guard' _ "$PERFLIB" 2>&1); seam_rc=$?
   [ "$seam_rc" -ne 0 ] \
     || { bad "perf-capability: $seam_name set WITHOUT the marker was ACCEPTED by the env guard (rc=0, out='$seam_out') — a test-only seam is live on the production path"; seam_each_fail=1; }
@@ -1582,6 +1586,27 @@ for sr_case in "root-is-symlink:$sr_link:$sr_link/child" "symlinked-ancestor:$sr
 done
 rm -f -- "$sr_link" "$sr_alink"
 [ "$sr_fail" -ne 0 ] || ok "perf-capability: a sandbox root that IS a symlink, and one reached through a symlinked ANCESTOR, are refused IDENTICALLY by the fork-free and the resolving containment paths, while the canonical spelling of the same directory is accepted by both (#3261 roborev-32)"
+
+# 1c-vi. A TRAILING-SLASH PROC_DIR READS, rather than reporting the host "absent" (roborev round 33).
+# Callers join with "/$name", so "<dir>/" became "<dir>//perf_event_paranoid": contained by the
+# directory gate, refused by the entry gate, and surfaced as the capability verdict absent -- a
+# spelling turned into a definite negative claim about the host, in the one function the gate's perf=
+# token comes from. The control asserts the SAME sandbox without the slash gives the same answer.
+ps_fail=0
+ps_root=$(mktemp -d "$tmp/ps.XXXXXX"); : >"$ps_root/.cqlite-perf-sandbox"
+ps_proc="$ps_root/proc"; mkdir -p "$ps_proc"; chmod 0755 "$ps_root" "$ps_proc"
+printf '0\n' >"$ps_proc/perf_event_paranoid"; printf '0\n' >"$ps_proc/kptr_restrict"
+ps_plain=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$ps_root" \
+  CQLITE_PERF_PROC_DIR="$ps_proc" bash "$PERFLIB" --token 2>/dev/null)
+[ "$ps_plain" = ok ] \
+  || { bad "perf-capability: the unslashed PROC_DIR control did not yield token 'ok' (got '$ps_plain'), so the trailing-slash case below proves nothing"; ps_fail=1; }
+for ps_spell in "$ps_proc/" "$ps_proc//"; do
+  ps_tok=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$ps_root" \
+    CQLITE_PERF_PROC_DIR="$ps_spell" bash "$PERFLIB" --token 2>/dev/null)
+  [ "$ps_tok" = "$ps_plain" ] \
+    || { bad "perf-capability: PROC_DIR spelled '$ps_spell' yielded token '$ps_tok' but the same directory unslashed yielded '$ps_plain' — a trailing slash changed a capability verdict"; ps_fail=1; }
+done
+[ "$ps_fail" -ne 0 ] || ok "perf-capability: a contained PROC_DIR spelled with one or two trailing slashes yields the SAME capability token as its unslashed spelling, so a spelling can no longer become a definite 'absent' claim about the host (#3261 roborev-33)"
 
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.
 perf_test_assert_host_clean

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1148,7 +1148,26 @@ if [ "$wt_ns_rc" -eq 0 ] || ! printf '%s' "$wt_ns_out" | grep -q 'cannot determi
   bad "perf-capability: an undeterminable directory owner/mode did not fail closed (rc=$wt_ns_rc, out='$wt_ns_out')"
   wt_perm_fail=1
 fi
-[ "$wt_perm_fail" -ne 0 ] || ok "perf-capability: a privileged staged install REFUSES a group-/world-writable drop-in directory by name and writes nothing, refuses when owner/mode cannot be determined, and still installs into a correctly-owned 0755 directory — the staging race is closed at its PRECONDITION rather than by trying to win it (#3261 roborev-3)"
+# ...a SYMLINKED destination directory is refused OUTRIGHT (owner ruling A', condition 2: lstat
+# semantics ASSERTED, not inherited from `stat`'s default). The link itself may look perfectly
+# owned and 0755 while entries would be created somewhere else entirely, so measuring the link
+# and proceeding is exactly the by-name reasoning this family has punished eleven times. The
+# link target here is a legitimate, correctly-owned, non-group-writable directory precisely so
+# the case cannot pass for the wrong reason: only the SYMLINK-NESS may cause the refusal.
+wt_ln_target="$tmp/wt-ln-target"; wt_ln_dir="$tmp/wt-ln-dir"
+rm -rf "$wt_ln_target" "$wt_ln_dir"; mkdir -p "$wt_ln_target"; chmod 0755 "$wt_ln_target"
+ln -s "$wt_ln_target" "$wt_ln_dir"
+wt_ln_out=$(env CQLITE_PERF_SYSCTL_DIR="$wt_ln_dir" \
+  bash -c '. "$1"; perf_capability_dropin_install' _ "$PERFLIB" 2>&1); wt_ln_rc=$?
+if [ "$wt_ln_rc" -eq 0 ] || ! printf '%s' "$wt_ln_out" | grep -q 'is a SYMLINK'; then
+  bad "perf-capability: a SYMLINKED drop-in directory was not refused by name (rc=$wt_ln_rc, out='$wt_ln_out')"
+  wt_perm_fail=1
+fi
+if [ -e "$wt_ln_target/99-cqlite-perf.conf" ]; then
+  bad "perf-capability: the symlinked drop-in directory was refused but its TARGET was written anyway"
+  wt_perm_fail=1
+fi
+[ "$wt_perm_fail" -ne 0 ] || ok "perf-capability: a privileged staged install REFUSES a group-/world-writable drop-in directory by name and writes nothing, refuses a SYMLINKED destination outright (lstat semantics asserted, target left unwritten), refuses when owner/mode cannot be determined, and still installs into a correctly-owned 0755 directory — the staging race is closed at its PRECONDITION rather than by trying to win it (#3261 roborev-3, owner A' condition 2)"
 
 # ...and CR/LF IN A PATH SEAM IS REFUSED (issue #3261, roborev round 3). Not a containment defect —
 # the path IS contained — a SERIALIZATION one, which is why nine rounds of containment work never

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -874,13 +874,7 @@ done
 #     EXTENDED TO THE PRIVILEGE SHIM (issue #3261 AC4). The guard authorizes EXECUTABLES as
 #     well as paths, and CQLITE_PERF_TEST_PRIV_DIR was read TEXTUALLY — so it joins the seam
 #     regex below, and a second pass audits every function that RESOLVES a privileged tool.
-# CODE ONLY, AND CALL SITES ONLY (roborev round 5, Low). These audits used to match the gate name
-# against RAW lines, so PROSE counted: deleting a real `perf_capability_sandbox_ok` call while leaving
-# a comment that mentions it kept the "unskippable" audit GREEN. An audit that a comment can satisfy
-# is the vacuous-pass shape this repo already has a rule against, and it was cited upward as evidence,
-# so it had to become real. Two changes: `#` comments are stripped before any matching, and the gate
-# must appear in a COMMAND POSITION (start of line or after whitespace/`(`/`|`/`&`/`;`, followed by
-# whitespace, `)` or end) rather than merely occurring somewhere in the text.
+# CODE ONLY, AND CALL SITES ONLY — see the code/codeq note in the awk below for why.
 seam_audit=$(awk \
   -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
   -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -862,7 +862,11 @@ done
 #     new seam consumer, and the canonicalizing validation added for the write path simply
 #     never reached it. No behavioural case can catch that class, because the defect is a
 #     path nobody thought to test. So this audit enumerates, FROM THE SOURCE, every function
-# (rationale condensed; see #3261 commit history.)
+#     that dereferences a seam variable and requires each one to route through the
+#     containment family (`perf_capability_sandbox_*` / `perf_capability_path_within`) — with
+#     ONE named, justified allowlist entry. A future entry point that reads a seam without
+#     the gate FAILS here, and joining the allowlist is a visible, reviewable act.
+# (rationale condensed; full reasoning in the commit history for #3261.)
 seam_audit=$(awk \
   -v seamre='[$][{]?CQLITE_PERF_(PROC_DIR|SYSCTL_DIR|SYSCTL_EXTRA_DIRS|TEST_SANDBOX|TEST_PRIV_DIR)' \
   -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
@@ -871,7 +875,12 @@ seam_audit=$(awk \
   #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
   #             stripping quoted spans would hide real consumers and silently shrink the census.
   #   `codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
-  # (rationale condensed; see #3261 commit history.)
+  #             command, never a string, so matching inside quotes is what made the advertised
+  #             "command position" claim false — swapping a real call for a string that merely
+  #             mentions its name kept the audit green.
+  # Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
+  # line. The single quote is written \047: this awk program sits inside a shell single-quoted
+  # string and cannot contain a literal one.
   { code = $0
     sub(/[[:space:]]*#.*$/, "", code)
     codeq = $0
@@ -931,12 +940,21 @@ priv_audit=$(awk \
   -v privre='(for [a-z_]+ in (sudo|sysctl)|command -v .*(sudo|sysctl))' \
   -v gatere='(^|[[:space:];&|(])perf_capability_(sandbox_[a-z_]*|path_within)([[:space:]]|\\)|$)' '
   # TWO representations, because the two matches want different things (roborev round 6, Low).
-# (rationale condensed; see #3261 commit history.)
+  #   `code`  — comments stripped only. The SEAM match needs this: a seam is a VARIABLE REFERENCE
+  #             and legitimately appears inside double quotes ("${CQLITE_PERF_SYSCTL_DIR:-}"), so
+  #             stripping quoted spans would hide real consumers and silently shrink the census.
+  #   `codeq` — comments AND quoted spans stripped. The GATE match needs this: a gate CALL is a
+  #             command, never a string, so matching inside quotes is what made the advertised
   #             "command position" claim false — swapping a real call for a string that merely
   #             mentions its name kept the audit green.
   # Quoted spans are removed before comments so a # inside a stripped string cannot truncate the
   # line. The single quote is written \047: this awk program sits inside a shell single-quoted
-  # (rationale condensed; see #3261 commit history.)
+  # string and cannot contain a literal one.
+  { code = $0
+    sub(/[[:space:]]*#.*$/, "", code)
+    codeq = $0
+    gsub(/"[^"]*"/, " ", codeq)
+    gsub(/\047[^\047]*\047/, " ", codeq)
     sub(/[[:space:]]*#.*$/, "", codeq) }
   /^[a-z_][a-z_0-9]*\(\)[[:space:]]*\{/ {
     fn = $1; sub(/\(\)$/, "", fn); priv = 0; gate = 0
@@ -1005,7 +1023,11 @@ if perf_install_supported; then
     ok "perf-capability: the drop-in WRITE TARGET is refused when the managed basename is itself a SYMLINK (rc 1, empty, named) — a contained directory does not license writing through its entries (#3261 AC1)"
   else
     bad "perf-capability: a SYMLINKED write target was NAMED for a privileged tee (rc=$wt_rc, path='$wt_path', err='$wt_err')"
-     # (rationale condensed; see #3261 commit history.)
+  fi
+  # ...and the CONTENTS read that decides idempotency may not follow it either: a symlink whose
+  # TARGET happens to hold the canonical bytes must not report "already current" (that would
+  # leave the host file in place and claim success).
+  printf '%s\n' "$(bash "$PERFLIB" --drop-in)" >"$wt_outside"
   if env CQLITE_PERF_SYSCTL_DIR="$wt_d" bash -c '. "$1"; perf_capability_dropin_current' _ "$PERFLIB" 2>/dev/null; then
     bad "perf-capability: dropin_current followed a SYMLINK and reported the drop-in 'already current' from a file outside the managed name"
   else
@@ -1066,7 +1088,11 @@ if perf_install_supported; then
   printf '%s\n' "$wt_body" | grep -q 'mv -fT -- "\$t" "\$p"' \
     || wt_struct_fail="$wt_struct_fail no-mv-T"
   [ "$wt_privcalls" -eq 1 ] || wt_struct_fail="$wt_struct_fail privileged-invocations=$wt_privcalls"
-    # (rationale condensed; see #3261 commit history.)
+  printf '%s\n' "$wt_body" | grep -q '"\$@" sh -c' || wt_struct_fail="$wt_struct_fail not-a-single-sh-c"
+  if [ -z "$wt_struct_fail" ]; then
+    ok "perf-capability: STRUCTURAL — the staged install is ONE privileged 'sh -c' (mktemp + write + chmod + mv all inside it, which NARROWS the create-to-reopen window but does NOT close it — see the note above), the staging name comes from an mktemp random-suffix template with no hardcoded literal, and the rename carries -T (#3261 roborev-1/roborev-2)"
+  else
+    bad "perf-capability: the staged install lost a structural property:$wt_struct_fail"
     printf '%s\n' "$wt_body" | grep -n '\$@\|mktemp\|mv -' | head -8
   fi
   # ...and a `mktemp` that answers OUTSIDE the validated directory is refused rather than trusted —

--- a/scripts/tests/test_perf_capability.sh
+++ b/scripts/tests/test_perf_capability.sh
@@ -1389,13 +1389,19 @@ printf 'kernel.kptr_restrict = 1\n' >"$cs_dir/zz-real.conf" 2>/dev/null
 # directory removes the ordering dependency, and the refusal is now REQUIRED rather than merely allowed.
 cs_nl_dir="$cs_root/nl-sysctl.d"; rm -rf "$cs_nl_dir"; mkdir -p "$cs_nl_dir"; chmod 0755 "$cs_nl_dir"
 cs_nl_name=$(printf 'zz-nl\ncompetitor.conf')
+# BASELINE FIRST, WITHOUT the newline file, and its status REQUIRED (roborev round 30, Low). My previous
+# version ran the "ordinary" baseline while the newline-named file was ALREADY present, making it identical
+# to the refusal case, and then discarded its status with `|| true` — so the negative control controlled
+# nothing. Three iterations of this one case have now been vacuous in a different way each time; the
+# pattern in my own work is that I fix the assertion and forget to re-check that it can still reach its
+# subject. Ordinary file only -> MUST scan (rc 0). Then add the newline file -> MUST fail closed.
+printf 'kernel.kptr_restrict = 1\n' >"$cs_nl_dir/zz-ordinary.conf"
+cs_nl_base=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
+  CQLITE_PERF_SYSCTL_DIR="$cs_nl_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
+  bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_nl_base_rc=$?
+[ "$cs_nl_base_rc" -eq 0 ] \
+  || { bad "perf-capability: the ordinary-competitor BASELINE failed (rc=$cs_nl_base_rc, out='$cs_nl_base') — the newline refusal below would prove nothing"; cs_fail=1; }
 if printf 'kernel.kptr_restrict = 1\n' >"$cs_nl_dir/$cs_nl_name" 2>/dev/null; then
-  # ...baseline: the SAME isolated directory with an ordinary competitor must SCAN, so a refusal below is
-  # attributable to the newline basename and nothing else.
-  printf 'kernel.kptr_restrict = 1\n' >"$cs_nl_dir/zz-ordinary.conf"
-  cs_nl_base=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
-    CQLITE_PERF_SYSCTL_DIR="$cs_nl_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
-    bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_nl_base_rc=$?
   cs_nl_out=$(env CQLITE_PERF_TEST_MODE=1 CQLITE_PERF_TEST_SANDBOX="$cs_root" \
     CQLITE_PERF_SYSCTL_DIR="$cs_nl_dir" CQLITE_PERF_PROC_DIR="$cs_root" \
     bash -c '. "$1"; perf_capability_competing_files' _ "$PERFLIB" 2>&1); cs_nl_rc=$?
@@ -1404,7 +1410,6 @@ if printf 'kernel.kptr_restrict = 1\n' >"$cs_nl_dir/$cs_nl_name" 2>/dev/null; th
   printf '%s' "$cs_nl_out" | grep -qx -- 'competitor.conf' \
     && { bad "perf-capability: a newline in a competitor BASENAME split into an extra reported entry (out='$cs_nl_out')"; cs_fail=1; }
   rm -f -- "$cs_nl_dir/$cs_nl_name"
-  [ "$cs_nl_base_rc" -eq 0 ] || true   # baseline recorded below; the newline file was present for it too
 else
   skip "perf-capability: newline-in-basename competitor case" "this filesystem refused to create a filename containing a newline"
 fi

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -219,6 +219,41 @@ else
   printf '%s\n' "$yes2_out" | sed -n '/Perf profiling/,/^$/p'
 fi
 
+# 3a. WIRING EVIDENCE FOR THE ATOMIC WRITE (issue #3261 AC1), end to end through bootstrap.
+#     The unit cases in the sibling suite prove the helper; this proves BOOTSTRAP uses it. A
+#     symlink at the managed name inside a perfectly-contained sandbox directory used to aim
+#     `sudo tee` at the link's TARGET — a privileged write anywhere on the box, from a run whose
+#     whole promise is that it cannot touch the host. Bootstrap's OUTER answer is a REFUSAL — the
+#     write target cannot even be named, so the section is skipped and nothing privileged runs. The
+#     installer's rename (unit-tested in the sibling suite) is the inner backstop for a symlink
+#     planted in the window between that check and the write; it is not what happens here, so this
+#     case asserts the refusal SPECIFICALLY rather than accepting either outcome.
+symtgt_d="$tmp/perf-symtarget.d"; mkdir -p "$symtgt_d"
+symtgt_out="$tmp/perf-symtarget-victim"; printf 'PRECIOUS-HOST-FILE\n' >"$symtgt_out"
+symtgt_before=$(cat "$symtgt_out")
+rm -f "$symtgt_d/99-cqlite-perf.conf"; ln -s "$symtgt_out" "$symtgt_d/99-cqlite-perf.conf"
+symtgt_proc="$tmp/perf-symtarget-proc"; mkdir -p "$symtgt_proc"
+printf '4\n' >"$symtgt_proc/perf_event_paranoid"; printf '1\n' >"$symtgt_proc/kptr_restrict"
+: >"$yestrip"
+mkperfshim 8888888
+symtgt_run=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$symtgt_proc" CQLITE_PERF_SYSCTL_DIR="$symtgt_d" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
+symtgt_rc=$?
+symtgt_leftover=$(ls -A "$symtgt_d" | grep -v '^99-cqlite-perf\.conf$' || true)
+symtgt_priv=$(grep -E 'perf-symtarget' "$yestrip" || true)
+if [ "$symtgt_rc" -eq 0 ] \
+   && printf '%s' "$symtgt_run" | grep -q 'is a SYMLINK' \
+   && printf '%s' "$symtgt_run" | grep -q 'perf capability SKIPPED' \
+   && [ "$(cat "$symtgt_out")" = "$symtgt_before" ] \
+   && [ -L "$symtgt_d/99-cqlite-perf.conf" ] && [ -z "$symtgt_leftover" ] \
+   && [ -z "$symtgt_priv" ]; then
+  ok "perf section: --yes against a SYMLINKED managed name REFUSES by name, skips the section, runs NO privileged command against that directory, leaves the link's target byte-unchanged and writes no staging entry — the run still exits 0 (#3261 AC1)"
+else
+  bad "perf section: a symlinked managed drop-in name was not refused fail-closed (rc=$symtgt_rc, target-changed=$([ "$(cat "$symtgt_out")" = "$symtgt_before" ] && echo no || echo YES), still-a-link=$([ -L "$symtgt_d/99-cqlite-perf.conf" ] && echo yes || echo no), leftover='$symtgt_leftover', privileged='$symtgt_priv')"
+  printf '%s\n' "$symtgt_run" | sed -n '/Perf profiling/,/^$/p'
+fi
+
 # --- 4. The verification VERDICT is honoured, and no-sudo degrades gracefully --
 # 4a. A perf that exits 0 but reports an unusable counter must produce a WARN and
 #      must NEVER be reported as verified. This is the #3119-style mutation (test_bootstrap_agent_machine.sh case 10) applied

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -178,17 +178,27 @@ else
   bad "perf section: --yes did not write the canonical drop-in"
   ls -l "$sysctl_yes" 2>&1 | head -3
 fi
-if grep -q 'tee .*99-cqlite-perf.conf' "$yestrip" && grep -q 'sysctl -q --system' "$yestrip"; then
-  ok "perf section: --yes wrote through sudo tee and applied with 'sysctl --system'"
+if perf_wrote_dropin "$yestrip" && grep -q 'sysctl -q --system' "$yestrip"; then
+  ok "perf section: --yes wrote the drop-in through the privileged staged installer and applied with 'sysctl --system'"
 else
-  bad "perf section: --yes did not use sudo tee + sysctl --system"
+  bad "perf section: --yes did not run the staged install + sysctl --system"
   cat "$yestrip"
+fi
+# ...through EXACTLY ONE privileged invocation (issue #3261, roborev round 2). The staged install is
+# consolidated into a single `sh -c` precisely so no unprivileged process can be scheduled between
+# mktemp and the reopen; splitting it back into several privileged calls would reinstate that window
+# while every functional assert above still passed.
+yes_write_n=$(perf_write_count "$yestrip")
+if [ "$yes_write_n" -eq 1 ]; then
+  ok "perf section: the staged install is EXACTLY ONE privileged invocation (no mktemp-in-one-call / write-in-another window)"
+else
+  bad "perf section: the staged install used $yes_write_n privileged invocations, expected 1: $(cat "$yestrip")"
 fi
 # ...and EVERY privileged invocation carried `-n`: an unattended worker must never be
 # able to sit on a password prompt, so `PERF_ROOT=(sudo)` (no -n) is a defect even
 # though every functional assert above would still pass.
 yes_bare_sudo=$(sudo_perf_offenders "$yestrip")
-if [ -z "$yes_bare_sudo" ] && grep -q '^sudo -n tee ' "$yestrip" && grep -q '^sudo -n sysctl ' "$yestrip"; then
+if [ -z "$yes_bare_sudo" ] && grep -q '^sudo -n sh -c' "$yestrip" && grep -q '^sudo -n sysctl ' "$yestrip"; then
   ok "perf section: every --yes privileged call went through 'sudo -n' (write AND apply, never interactive)"
 else
   bad "perf section: a privileged call did not carry sudo -n: $(cat "$yestrip")"
@@ -212,7 +222,7 @@ yes2_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$ye
   CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$sysctl_yes" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
 if printf '%s' "$yes2_out" | grep -q 'drop-in already current' \
-   && ! grep -q 'tee .*99-cqlite-perf.conf' "$yestrip"; then
+   && ! perf_wrote_dropin "$yestrip"; then
   ok "perf section: a second --yes run is an idempotent no-op (no re-write)"
 else
   bad "perf section: second --yes run re-wrote the drop-in"
@@ -1028,7 +1038,7 @@ nlfix_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$y
 nlfix_rc=$?
 if [ "$nlfix_rc" -eq 0 ] \
    && ! printf '%s' "$nlfix_out" | grep -q 'drop-in already current' \
-   && grep -q 'tee .*99-cqlite-perf.conf' "$yestrip" \
+   && perf_wrote_dropin "$yestrip" \
    && cmp -s <(bash "$PERFLIB" --drop-in) "$nlfix_d/99-cqlite-perf.conf"; then
   ok "perf section: a drop-in MISSING its final newline is judged NOT current and REWRITTEN to the canonical bytes"
 else
@@ -1042,7 +1052,7 @@ nlfix2_out=$(PATH="$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$
   CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$nlfix_d" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
   bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1)
 if ! printf '%s' "$nlfix2_out" | grep -q 'drop-in already current' \
-   && grep -q 'tee .*99-cqlite-perf.conf' "$yestrip" \
+   && perf_wrote_dropin "$yestrip" \
    && cmp -s <(bash "$PERFLIB" --drop-in) "$nlfix_d/99-cqlite-perf.conf"; then
   ok "perf section: a drop-in with an EXTRA trailing blank line is judged NOT current and REWRITTEN"
 else

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -313,7 +313,7 @@ nosudo_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
 nosudo_rc=$?
 if [ "$nosudo_rc" -eq 0 ] && [ -z "$(ls -A "$nosudo_sysctl")" ] \
    && printf '%s' "$nosudo_out" | grep -q "no 'sudo' binary on this box" \
-   && printf '%s' "$nosudo_out" | grep -q 'ROOT shell:.*--drop-in > .*99-cqlite-perf.conf && sysctl -q --system' \
+   && printf '%s' "$nosudo_out" | grep -q 'ROOT shell:.*perf-capability.sh --install && sysctl -q --system' \
    && ! printf '%s' "$nosudo_out" | grep -q 'perf-capability.sh --install sudo'; then
   ok "perf section: a box with no sudo BINARY warns + prints the root-shell remedy (never a useless 'sudo tee'), writes nothing, exits 0"
 else
@@ -390,7 +390,7 @@ rootbox_out=$(PATH="$rootbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
 rootbox_rc=$?
 rootbox_remedy=$(printf '%s\n' "$rootbox_out" | grep 'write + apply the drop-in' || true)
 if [ "$rootbox_rc" -eq 0 ] && [ -z "$(ls -A "$rootbox_d")" ] \
-   && printf '%s' "$rootbox_remedy" | grep -q '| tee .*99-cqlite-perf.conf >/dev/null && sysctl -q --system' \
+   && printf '%s' "$rootbox_remedy" | grep -q 'perf-capability.sh --install && sysctl -q --system' \
    && ! printf '%s' "$rootbox_remedy" | grep -q 'sudo'; then
   ok "perf section: when ALREADY ROOT the printed write+apply remedy carries no 'sudo' prefix"
 else

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -107,7 +107,7 @@ fi
 # unprofileable box until reboot — the very failure the functional verification
 # exists to prevent, on the path most people take (no --yes). Plus the AC5 posture
 # and the BPF caveat (#3217).
-if printf '%s' "$check_out" | grep -q 'perf-capability.sh --install sudo && sudo sysctl -q --system' \
+if printf '%s' "$check_out" | grep -q 'write + apply the drop-in:.*bootstrap-agent-machine.sh --yes' \
    && printf '%s' "$check_out" | grep -q 're-run with --yes'; then
   ok "perf section: prints the complete WRITE-AND-APPLY remedy line instead of running it"
 else
@@ -333,8 +333,8 @@ nosudo_out=$(PATH="$nosudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
 nosudo_rc=$?
 if [ "$nosudo_rc" -eq 0 ] && [ -z "$(ls -A "$nosudo_sysctl")" ] \
    && printf '%s' "$nosudo_out" | grep -q "no 'sudo' binary on this box" \
-   && printf '%s' "$nosudo_out" | grep -q 'ROOT shell:.*perf-capability.sh --install && sysctl -q --system' \
-   && ! printf '%s' "$nosudo_out" | grep -q 'perf-capability.sh --install sudo'; then
+   && printf '%s' "$nosudo_out" | grep -q 'ROOT shell:.*bootstrap-agent-machine.sh --yes' \
+   && ! printf '%s' "$nosudo_out" | grep -q 'perf-capability.sh --install'; then
   ok "perf section: a box with no sudo BINARY warns + prints the root-shell remedy (never a useless 'sudo tee'), writes nothing, exits 0"
 else
   bad "perf section: no-sudo box mishandled (rc=$nosudo_rc, dir='$(ls -A "$nosudo_sysctl")')"
@@ -366,7 +366,7 @@ pwsudo_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
 pwsudo_rc=$?
 if [ "$pwsudo_rc" -eq 0 ] && [ -z "$(ls -A "$pwsudo_sysctl")" ] \
    && printf '%s' "$pwsudo_out" | grep -q 'sudo needs a password' \
-   && printf '%s' "$pwsudo_out" | grep -q 'perf-capability.sh --install sudo && sudo sysctl -q --system' \
+   && printf '%s' "$pwsudo_out" | grep -q 'write + apply the drop-in:.*bootstrap-agent-machine.sh --yes' \
    && ! printf '%s' "$pwsudo_out" | grep -q "no 'sudo' binary"; then
   ok "perf section: a password-requiring sudo is diagnosed distinctly (not 'no sudo binary') with the interactive remedy, writes nothing, exits 0"
 else
@@ -410,7 +410,7 @@ rootbox_out=$(PATH="$rootbox" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
 rootbox_rc=$?
 rootbox_remedy=$(printf '%s\n' "$rootbox_out" | grep 'write + apply the drop-in' || true)
 if [ "$rootbox_rc" -eq 0 ] && [ -z "$(ls -A "$rootbox_d")" ] \
-   && printf '%s' "$rootbox_remedy" | grep -q 'perf-capability.sh --install && sysctl -q --system' \
+   && printf '%s' "$rootbox_remedy" | grep -q 'write + apply the drop-in:.*bootstrap-agent-machine.sh --yes' \
    && ! printf '%s' "$rootbox_remedy" | grep -q 'sudo'; then
   ok "perf section: when ALREADY ROOT the printed write+apply remedy carries no 'sudo' prefix"
 else

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -366,8 +366,9 @@ pwsudo_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
 pwsudo_rc=$?
 if [ "$pwsudo_rc" -eq 0 ] && [ -z "$(ls -A "$pwsudo_sysctl")" ] \
    && printf '%s' "$pwsudo_out" | grep -q 'sudo needs a password' \
-   && printf '%s' "$pwsudo_out" | grep -q 'write + apply the drop-in:.*bootstrap-agent-machine.sh --yes' \
-   && ! printf '%s' "$pwsudo_out" | grep -q "no 'sudo' binary"; then
+   && printf '%s' "$pwsudo_out" | grep -q 'authenticate first, then re-run:.*sudo -v && bash scripts/bootstrap-agent-machine.sh --yes' \
+   && ! printf '%s' "$pwsudo_out" | grep -q "no 'sudo' binary" \
+   && ! printf '%s' "$pwsudo_out" | grep -q 'write + apply the drop-in:.*bootstrap-agent-machine.sh --yes'; then
   ok "perf section: a password-requiring sudo is diagnosed distinctly (not 'no sudo binary') with the interactive remedy, writes nothing, exits 0"
 else
   bad "perf section: password-requiring sudo mishandled (rc=$pwsudo_rc, dir='$(ls -A "$pwsudo_sysctl")')"

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -32,6 +32,21 @@ set -uo pipefail
 # shellcheck source=scripts/tests/lib/perf-capability-test-lib.sh
 . "$(cd "$(dirname "$0")" && pwd)/lib/perf-capability-test-lib.sh"
 
+# --- WHOLE-SUITE CAPABILITY GATE (issue #3261, roborev round 6, Medium) ----------------------
+# EVERY case below drives bootstrap's perf section, and that section stages the drop-in through
+# GNU `stat -c` and `mv --no-target-directory`. The sibling suite grew a per-case skip; this one
+# was left invoking the installer unconditionally, so a macOS gate host — a FIRST-CLASS host here —
+# still failed on the TOOLCHAIN rather than on behaviour. The correct scope is the WHOLE suite, not
+# individual cases: bootstrap gates its entire perf section on PLATFORM=linux, so off Linux there is
+# no perf section to assert about at all, and a per-case skip would imply otherwise.
+# The skip is LOUD and COUNTED, and the report still runs, so a green macOS run SHOWS this suite was
+# skipped with its reason instead of vanishing. It is not a pass: `skip` never increments PASS.
+if ! perf_install_supported; then
+  skip "perf-capability-bootstrap: the ENTIRE suite (all cases drive bootstrap's perf section, which stages the drop-in via GNU stat -c / mv --no-target-directory)" "no GNU stat -c / mv --no-target-directory on this host; bootstrap gates its perf section on PLATFORM=linux, so there is nothing to assert off Linux"
+  perf_test_report
+  exit $?
+fi
+
 # --- 2. Bootstrap perf section: the DEFAULT (no --yes) run mutates NOTHING ----
 # Tripwire shims for every privileged/mutating tool the write path could use, so
 # "wrote nothing" is PROVEN rather than assumed. `perf` may be invoked (the
@@ -184,10 +199,15 @@ else
   bad "perf section: --yes did not run the staged install + sysctl --system"
   cat "$yestrip"
 fi
-# ...through EXACTLY ONE privileged invocation (issue #3261, roborev round 2). The staged install is
-# consolidated into a single `sh -c` precisely so no unprivileged process can be scheduled between
-# mktemp and the reopen; splitting it back into several privileged calls would reinstate that window
-# while every functional assert above still passed.
+# ...through EXACTLY ONE privileged invocation (issue #3261, roborev round 2). CORRECTED at roborev
+# round 6 (Low): an earlier version of this comment claimed the single `sh -c` means "no unprivileged
+# process can be scheduled between mktemp and the reopen". That is FALSE — it gives SEQUENCING within
+# one process, never mutual exclusion against other processes or CPUs — and it contradicted the
+# rationale already corrected in the implementation. Consolidation NARROWS the window; what actually
+# makes the write safe is the DIRECTORY OWNERSHIP AND WRITABILITY PRECONDITION (the destination must
+# be owned by the privileged writer and not group/world-writable, so no less-privileged actor can
+# plant anything to race with). This assert is still worth keeping: splitting the install back into
+# several privileged calls would widen the window again while every functional assert above passed.
 yes_write_n=$(perf_write_count "$yestrip")
 if [ "$yes_write_n" -eq 1 ]; then
   ok "perf section: the staged install is EXACTLY ONE privileged invocation (no mktemp-in-one-call / write-in-another window)"

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -92,7 +92,7 @@ fi
 # unprofileable box until reboot — the very failure the functional verification
 # exists to prevent, on the path most people take (no --yes). Plus the AC5 posture
 # and the BPF caveat (#3217).
-if printf '%s' "$check_out" | grep -q 'perf-capability.sh --drop-in | sudo tee .*99-cqlite-perf.conf >/dev/null && sudo sysctl -q --system' \
+if printf '%s' "$check_out" | grep -q 'perf-capability.sh --install sudo && sudo sysctl -q --system' \
    && printf '%s' "$check_out" | grep -q 're-run with --yes'; then
   ok "perf section: prints the complete WRITE-AND-APPLY remedy line instead of running it"
 else
@@ -314,7 +314,7 @@ nosudo_rc=$?
 if [ "$nosudo_rc" -eq 0 ] && [ -z "$(ls -A "$nosudo_sysctl")" ] \
    && printf '%s' "$nosudo_out" | grep -q "no 'sudo' binary on this box" \
    && printf '%s' "$nosudo_out" | grep -q 'ROOT shell:.*--drop-in > .*99-cqlite-perf.conf && sysctl -q --system' \
-   && ! printf '%s' "$nosudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf'; then
+   && ! printf '%s' "$nosudo_out" | grep -q 'perf-capability.sh --install sudo'; then
   ok "perf section: a box with no sudo BINARY warns + prints the root-shell remedy (never a useless 'sudo tee'), writes nothing, exits 0"
 else
   bad "perf section: no-sudo box mishandled (rc=$nosudo_rc, dir='$(ls -A "$nosudo_sysctl")')"
@@ -346,7 +346,7 @@ pwsudo_out=$(PATH="$pwsudo" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
 pwsudo_rc=$?
 if [ "$pwsudo_rc" -eq 0 ] && [ -z "$(ls -A "$pwsudo_sysctl")" ] \
    && printf '%s' "$pwsudo_out" | grep -q 'sudo needs a password' \
-   && printf '%s' "$pwsudo_out" | grep -q 'sudo tee .*99-cqlite-perf.conf.*&& sudo sysctl -q --system' \
+   && printf '%s' "$pwsudo_out" | grep -q 'perf-capability.sh --install sudo && sudo sysctl -q --system' \
    && ! printf '%s' "$pwsudo_out" | grep -q "no 'sudo' binary"; then
   ok "perf section: a password-requiring sudo is diagnosed distinctly (not 'no sudo binary') with the interactive remedy, writes nothing, exits 0"
 else

--- a/scripts/tests/test_perf_capability_bootstrap.sh
+++ b/scripts/tests/test_perf_capability_bootstrap.sh
@@ -1194,4 +1194,29 @@ fi
 
 # Nothing in this suite may have touched the REAL /etc/sysctl.d.
 perf_test_assert_host_clean
+# --- bootstrap reports an UNSUPPORTED HOST and prints NO retry remedy (roborev round 17, Low) -------
+# The rc 2 branch added in round 16 had NO coverage: this suite skips wholly on a non-GNU host, so on
+# a supported host the branch was never reached and on an unsupported one the suite never ran. Here a
+# controlled incompatible `mv` shim is injected on THIS (supported) host, so the branch is exercised
+# where it can actually be observed. Three properties, because a wrong remedy is its own defect:
+# unsupported is NAMED, nothing is written, and the retry remedy is ABSENT (re-running cannot help).
+uns_dir="$tmp/uns-sysctl.d"; rm -rf "$uns_dir"; mkdir -p "$uns_dir"; chmod 0755 "$uns_dir"
+# Only `mv` differs from the KNOWN-WORKING --yes write case above: same shims, same PATH tail, same
+# seams. Isolating the one variable is the point — if anything else drifts, this case would fail for a
+# reason that has nothing to do with unsupported-host handling.
+uns_bin="$tmp/uns-bin"; rm -rf "$uns_bin"; mkdir -p "$uns_bin"
+printf '%s\n' '#!/bin/sh' 'exit 1' >"$uns_bin/mv"; chmod +x "$uns_bin/mv"
+uns_out=$(PATH="$uns_bin:$yesshims:$perfbin:$tmp:$PATH" HOME="$yes_home" CARGO_HOME="$yes_home/.cargo" \
+  CQLITE_PERF_PROC_DIR="$proc_yes" CQLITE_PERF_SYSCTL_DIR="$uns_dir" CQLITE_PERF_TEST_PRIV_DIR="$yesshims" \
+  bash "$tmp/perf-root-yes/scripts/bootstrap-agent-machine.sh" --skip-smoke --yes 2>&1); uns_rc=$?
+if [ "$uns_rc" -eq 0 ] \
+   && printf '%s' "$uns_out" | grep -q 'cannot install .* on this host' \
+   && [ -z "$(ls -A "$uns_dir")" ] \
+   && ! printf '%s' "$uns_out" | grep -q 'write + apply the drop-in'; then
+  ok "perf section: an UNSUPPORTED host (no GNU mv -T) is NAMED, nothing is written, and the retry remedy is deliberately NOT printed — re-running cannot help"
+else
+  bad "perf section: unsupported-host handling wrong (rc=$uns_rc, dir='$(ls -A "$uns_dir")')"
+  printf '%s\n' "$uns_out" | grep -iE 'perf|drop-in' | tail -4
+fi
+
 perf_test_report


### PR DESCRIPTION
Closes #3261. Later hardening splits to **#3350**; the full pre-split tree is preserved on
`hardening-3261-presplit` (`a3fe54e9f`).

## Scope, and why the seam moved once

Reduced from the full 17-round branch by owner ruling, after roborev's inline review limit (~2151
code-only changed lines) and a growing review-driven diff proved mutually exclusive — the branch could not
be both fully review-hardened and reviewable in one piece. That is what #3257's ceiling exists to force and
what PR #3251 did for the identical cause.

**The first seam was wrong and was corrected.** Splitting at the literal AC boundary produced a tree whose
fresh review immediately raised two Highs and a Low — *all three being defects already fixed on the
hardening branch*, because the split had removed the fixes. Shipping a known High whose fix already exists
is not defensible, so the seam moved to **"everything needed to ship the ACs safely"**: AC1–AC4 plus the
rounds 1–3 write-path fixes. **1823 code-only lines** (328 under the ceiling, so a fix round cannot
re-cross it).

## AC1–AC4

Lands the round-6 positive-containment inversion reverted out of PR #3251. One guard — *"may a test-mode
env seam steer this path?"* — had produced eight escapes across six rounds, each a new **spelling** of
"somewhere else". The lesson is structural: **a denylist over path spellings cannot be completed**, since
the ways to spell `/etc` are unbounded while the ways to prove "strictly inside my sandbox" number one.

- **AC1** — a symlinked managed basename is refused; `dropin_current` will not follow it *even when the
  link target holds byte-identical canonical content*; the write replaces the directory **entry**.
- **AC2** — the fork-free read path rejects a symlinked component, so a symlink inside the sandbox pointing
  at the real `/proc/sys/kernel` yields no capability rather than a fabricated one; the token path's
  fork-free contract is preserved.
- **AC3** — a strictly-contained `<root>/sysctl.conf` is accepted (canonical parent + basename) while
  outside, the root itself, `..`, relative and symlinked-final spellings stay refused.
- **AC4** — privileged executables are validated by destination, and the structural closed-set audit extends
  from seam paths to privilege-shim resolution.
- AC1 **wiring evidence**: bootstrap fails closed when the write target cannot be named, instead of flowing
  an empty path into a privileged write.

## Write-path fixes carried with the ACs (roborev rounds 1–3)

Included because the ACs cannot ship safely without them:

- **staging name unpredictable** — `mktemp` (O_CREAT|O_EXCL) creates it under the same privilege that
  writes it, replacing a fixed name that was checked, cleared and then opened by a privileged `tee`.
- **`mv -fT`** — without `--no-target-directory` a symlink-to-directory at the managed name makes `mv` move
  the staging file *into* it, i.e. the rename that exists to avoid following a symlink follows one.
- **the writability precondition** — the destination must be owned by the privileged writer and be neither
  group- nor world-writable, so there is no actor to race at all. This, not the staging mechanics, is what
  closes the class.
- **CR/LF rejected in path seams** — a *contained* path containing a newline used to split the
  one-per-line search path into two entries, the second being the real `/etc/sysctl.d`.

Two claims in this function were **retracted under review and the retractions are recorded in the code**:
that a fixed staging name was safe because the race "cannot happen", and that one privileged `sh -c`
prevents another process being scheduled between steps. The second was my own error. A reader deserves that
history before trusting the third claim.

## Known, deliberately-unfixed residuals — #3323

All three entries are pointed at **from their code sites**, so a maintainer meets the boundary before
widening the trust, and a reviewer can tell a dispositioned residual from an overlooked defect:

| # | Residual | Why unfixed |
|---|---|---|
| 1 | ancestor-chain rename race | validates the target directory, not the path to it; fix needs `openat2` |
| 2 | privileged-tool revalidation | resolves then discards paths; later callers re-resolve by name |
| 3 | bind mounts defeat lexical containment | `cd -P`/`pwd -P` resolve symlinks, not mounts |

Thirteen escapes established the class is unbounded in shell; by owner ruling it is **closed**, with
`openat2`-style fd-relative containment recorded as the correct fix and an **evidence-only re-raise
trigger**. All three are test-mode only — production never sets `CQLITE_PERF_TEST_MODE`.

## Certification

- **Suites: `test_perf_capability.sh` 69/0, `test_perf_capability_bootstrap.sh` 49/0,
  `test_agent_gate_summary.sh` 130/0.** Both perf suites close by asserting the real
  `/etc/sysctl.d/99-cqlite-perf.conf` is byte- and metadata-identical to its pre-suite state — for an issue
  about test seams reaching production, a suite proving it touched nothing is the right oracle.
- Full gate of record + a fresh inline-verified roborev round (`prompt-content: PASS`): recorded below
  before merge.

## Not in this PR — #3350

The macOS capability-probed counted SKIP, the `UNSUPPORTED`-host rc, content-generator failure
propagation, trailing-slash normalisation, competing-file scan hermeticity, and both audits' de-vacuuming.
All on `hardening-3261-presplit`, re-landing via #3350 — whose scope shrinks accordingly, since rounds 1–3
land here.


## Certification — gate of record + delta re-certification

**Full gate of record: `RESULT: PASS` at `6f75d0be6`** — 30/30 components, **zero SKIPs**,
`tree-integrity: PASS`, `tree-start == tree-end`, no `.integrity-fail` sibling.

```

==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.HL468Q
commit: 6f75d0b branch: issue-3261-seam-containment dirty: no
datasets: 144 Data.db files under /data/datasets
schemas: 6/6 canonical .cql readable under /home/ubuntu/workspace/cqlite-wt/issue-3261/test-data/schemas (checkout-relative)
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=present-unconfigured perf=paranoid-4
cpu-budget: wrapper=nice ncpu=16 max-concurrency=3 cores-per-gate=5 build-jobs=5(derived) test-threads=5
tree-start: 6f75d0be6f75 dirty: no digest: d0044464220d
tree-end: 6f75d0be6f75 dirty: no digest: d0044464220d
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (6s)
clippy:            PASS (123s)
roborev-lints:     PASS (42s)
core-tests:        PASS (565s)
tombstones-scan:   PASS (10s)
scan-offload-guard: PASS (123s)
work-counters-guard: PASS (69s)
byte-budget-guard: PASS (17s)
arrow-parity-guard: PASS (56s)
memory-budget:     PASS (63s)
integration-tests: PASS (60s)
format-compat:     PASS (41s)
write-tests:       PASS (149s)
cli-tests:         PASS (173s)
compaction-byte-parity: PASS (8s)
bti-multiclustering: PASS (4s)
query-semantics-oracle: PASS (1s)
flight-query-semantics-oracle: PASS (79s)
python-bindings:   PASS (189s)
node-bindings:     PASS (123s)
delivery-telemetry: PASS (0s)
oom-audit:         PASS (6s)
parity-report:     PASS (1s)
operator-metrics-doc: PASS (31s)
kit-dashboard-drift: PASS (1s)
binding-unwind-profile: PASS (0s)
tooling-tests:     PASS (450s)
minimal-build:     PASS (59s)
smoke:             PASS (25s)
logs: /tmp/agent-gate.HL468Q
summary-file: /tmp/claude-1000/-home-ubuntu-workspace-repo/83af51fe-e3c7-4616-9c80-74d449fcbd7c/scratchpad/gate-final.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

**Delta re-certification: `RESULT: PASS` at `4d18c3d6b`** — the only diff after the anchor is
`scripts/tests/test_perf_capability.sh` (two vacuous test repairs), which is inside `--delta`'s
allowed set. Delta is **not** the gate of record and is recorded here beside the anchor's full
SUMMARY, as required. It fails closed on any non-test/docs path, so it cannot launder a code change.

```

==== AGENT-GATE DELTA SUMMARY ====
run-id: /tmp/agent-gate.rLhdpl
MODE: delta (TEST/DOCS-ONLY RE-CERTIFICATION — NOT the gate of record; gate of record = the full agent-gate.sh PASS at anchor 6f75d0be6f75a87749ba99bd795241031829a1df)
commit: 4d18c3d branch: issue-3261-seam-containment dirty: no
delta-anchor: 6f75d0be6f75a87749ba99bd795241031829a1df (full-gate PASS commit)
delta-anchor-run-id: /tmp/agent-gate.HL468Q
gate-of-record: full agent-gate.sh run at 6f75d0be6f75a87749ba99bd795241031829a1df (this DELTA re-certifies a test/docs-only diff; it is NOT a substitute for the full gate)
nightly-backstop: .github/workflows/gate.yml deep-check re-runs the FULL gate on main (gate job = scoped clippy; full --all-features clippy in the parallel clippy-full job, #2662)
delta-scope: file-size fmt scoped-tests (test/docs-only re-cert; clippy/core/write/cli/bindings/parity/smoke NOT run — see gate-of-record)
delta-executors: scoped-tests(rust/python) shell-selftests(1) (executors that RAN this re-cert)
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=present-unconfigured perf=paranoid-4
cpu-budget: wrapper=nice ncpu=16 max-concurrency=3 cores-per-gate=5 build-jobs=5(derived) test-threads=5
tree-start: 4d18c3d6b327 dirty: no digest: ee1a0fa2e5fe
tree-end: 4d18c3d6b327 dirty: no digest: ee1a0fa2e5fe
tree-integrity: PASS
delta-files (1 allowed / 0 offending):
      [test/docs] scripts/tests/test_perf_capability.sh
file-size:         PASS (0s)
fmt:               PASS (4s)
scoped-tests:      PASS (5s)
shell-selftests:   PASS (2s)
logs: /tmp/agent-gate.rLhdpl
summary-file: /tmp/claude-1000/-home-ubuntu-workspace-repo/83af51fe-e3c7-4616-9c80-74d449fcbd7c/scratchpad/delta.txt
RESULT: PASS
==== END AGENT-GATE DELTA SUMMARY ====
```
