### PR TITLE
fix(#3310): --verify-only REPORTS SIGKILL-orphaned tracked fixtures (never repairs) + pin the guard on required

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -149,6 +149,24 @@ jobs:
           "flight dockerfile rust-pin"
           -- bash scripts/ci/check-dockerfile-rust-pin.sh
 
+      # Corpus-safety guard for the DESTRUCTIVE dataset fetch (issues #2878 /
+      # #3245 / #3310). It ran only in the local agent gate and the nightly deep
+      # check, so `required` did not pin it on a PR that edits
+      # test-data/scripts/fetch-datasets.sh — the one file whose regressions
+      # `rm -rf` an operator's checkout. Enrolled HERE, in the required gate's own
+      # compute job, rather than in ci.yml's `flow-tooling-tests` (that job is
+      # `ci:broad`-label-gated AND ci.yml is a registry `exempt:` workflow, so it
+      # can never gate a merge) and rather than as a new tier in
+      # .github/ci-gating-tiers.yml (a whole new always-emitting context, plus the
+      # base-ref property that a registry entry cannot certify itself). Hermetic:
+      # no network, no dataset, ~10s.
+      - name: Dataset-fetch tracked-fixture guard (#2878/#3245/#3310)
+        if: steps.classify.outputs.docs_only != 'true'
+        run: >-
+          bash scripts/ci/ci-timing-summary.sh measure
+          "dataset fetch tracked-fixture guard"
+          -- bash scripts/tests/test_fetch_datasets_tracked_guard.sh
+
       - name: Setup Rust
         if: steps.classify.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-rust-ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,10 @@ guarantees, and on a fleet box it is often a machine-local root (e.g. `/data/dat
 `$PWD/test-data/datasets`. The printed line beats any root remembered from this file. The script
 rejects every unrecognized argument (exit 2) because its default path is destructive
 (`rm -rf` on the dataset root); `--verify-only` probes a root without mutating anything, `--help`
-lists the flags.
+lists the flags. `--verify-only` also **reports** (never repairs) git-tracked fixtures a
+SIGKILLed fetch left deleted: it names them, prints the exact `git restore` one-liner and exits
+non-zero — distinct from the generic "does not hold a usable dataset corpus", and distinct again
+from `NO SUBJECT` (out-of-repo root) and `COULD NOT MEASURE` (census untakeable) (#3310).
 
 **`CQLITE_DATASETS_ROOT` alone is sufficient on every layout (#3131/#3148)** — the corpus root needs
 no `schemas` sibling. The CQL schema fixtures (`test-data/schemas`, 23 committed files incl.

--- a/scripts/tests/test_fetch_datasets_tracked_guard.sh
+++ b/scripts/tests/test_fetch_datasets_tracked_guard.sh
@@ -2344,6 +2344,139 @@ else
   bad "3310-worktree-newline: the advertised command did not repair it: '$R42_CMD'"
 fi
 
+# === Case 43: a FLAGGED path that is PRESENT is simply present (#3310 r3 B1) ===
+# skip-worktree / assume-unchanged hide a path's state from git's STATUS
+# machinery; they do not stop the direct `-e`/`-L` test this probe performs. So a
+# flagged path that demonstrably EXISTS has a determinable state and must not
+# make the probe fail — the first cut refused every flagged path, which turned the
+# primary diagnostic red on an intact checkout that merely carries one.
+flagged_present_case() {
+  local label="$1" dir="$2" flag="$3" rel="goldens/simple_table-Data.db.jsonl"
+  make_repo "$dir"
+  make_usable_corpus "$dir/test-data/datasets"
+  git -C "$dir" update-index "$flag" -- "test-data/datasets/$rel"
+  if [ -f "$dir/test-data/datasets/$rel" ]; then
+    ok "$label: the flagged fixture is present on disk (precondition)"
+  else
+    bad "$label: fixture missing before the probe; case is vacuous"
+  fi
+  run_verify "$dir" "$dir/test-data/datasets"
+  if [ "$RC" -eq 0 ]; then
+    ok "$label: an intact checkout carrying a flagged fixture still verifies (exit 0)"
+  else
+    bad "$label: false failure on a PRESENT flagged fixture (exit $RC); output: $OUT"
+  fi
+  case "$OUT" in
+    *"$PROBE_UNMEASURED_MARKER"*) bad "$label: called a present path unmeasurable; output: $OUT" ;;
+    *) ok "$label: no unmeasurable verdict for a path it can see" ;;
+  esac
+  case "$OUT" in
+    *"Tracked-fixture probe (#3310): OK"*) ok "$label: reports the clean verdict" ;;
+    *) bad "$label: no clean verdict; output: $OUT" ;;
+  esac
+}
+flagged_present_case "3310-flagged-present-skip" "$T/case43a-repo" --skip-worktree
+flagged_present_case "3310-flagged-present-assume" "$T/case43b-repo" --assume-unchanged
+
+# === Case 44: rename classification must not depend on ambient config (r3 B2) ==
+# `diff.renames=false` makes a staged rename report as `D` + `A`, so a probe that
+# relies on the DEFAULT being on emits a false missing-fixture error and
+# advertises a repair that REVERSES intentional work. The invocation must pass
+# rename detection explicitly.
+R44="$T/case44-repo"
+make_repo "$R44"
+make_usable_corpus "$R44/test-data/datasets"
+git -C "$R44" config diff.renames false
+git -C "$R44" mv "test-data/datasets/goldens/simple_table-Data.db.jsonl" \
+                 "test-data/datasets/goldens/renamed-Data.db.jsonl"
+if [ "$(git -C "$R44" config --get diff.renames)" = "false" ] \
+   && [ -f "$R44/test-data/datasets/goldens/renamed-Data.db.jsonl" ]; then
+  ok "3310-rename-config: staged rename in place with diff.renames=false (precondition)"
+else
+  bad "3310-rename-config: could not set up the staged rename; case is vacuous"
+fi
+run_verify "$R44" "$R44/test-data/datasets"
+if [ "$RC" -eq 0 ]; then
+  ok "3310-rename-config: a staged rename is not a missing fixture (exit 0)"
+else
+  bad "3310-rename-config: false missing-fixture report under diff.renames=false (exit $RC); output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_MISSING_MARKER"*) bad "3310-rename-config: reported the renamed-away path as missing; output: $OUT" ;;
+  *) ok "3310-rename-config: no missing-fixture claim for a renamed path" ;;
+esac
+case "$OUT" in
+  *"restore"*"simple_table-Data.db.jsonl"*)
+    bad "3310-rename-config: advertised a repair that would REVERSE the rename; output: $OUT" ;;
+  *) ok "3310-rename-config: advertises no rename-reversing repair" ;;
+esac
+
+# === Case 45: an unresolvable HEAD is UNMEASURABLE, not empty (r3 B3) =========
+# A failing `rev-parse --verify HEAD` does not prove an unborn branch: a corrupt
+# ref fails the same way. Treating both as "no commits" skips the staged-deletion
+# census entirely and can still reach a CLEAN verdict for a state never measured.
+# The corruption here is content-only (no chmod), and it leaves the repository
+# otherwise usable — `rev-parse --show-toplevel` and `ls-files` still work — so
+# the probe really does reach the HEAD decision.
+R45="$T/case45-repo"
+make_repo "$R45"
+make_usable_corpus "$R45/test-data/datasets"
+R45_BRANCH="$(git -C "$R45" symbolic-ref -q HEAD)"
+git -C "$R45" pack-refs --all >/dev/null 2>&1 || true
+rm -f "$R45/.git/packed-refs"
+mkdir -p "$R45/.git/$(dirname "${R45_BRANCH#refs/}" | sed 's|^|refs/|')" 2>/dev/null || true
+printf 'corrupt-not-a-sha\n' >"$R45/.git/$R45_BRANCH"
+if ! git -C "$R45" rev-parse --verify -q HEAD >/dev/null 2>&1 \
+   && git -C "$R45" rev-parse --show-toplevel >/dev/null 2>&1; then
+  ok "3310-head-corrupt: HEAD is unresolvable while the repo still works (precondition)"
+else
+  bad "3310-head-corrupt: could not create the unresolvable-HEAD state; case is vacuous"
+fi
+run_verify "$R45" "$R45/test-data/datasets"
+if [ "$RC" -ne 0 ]; then
+  ok "3310-head-corrupt: an unresolvable HEAD does not yield a clean run (exit $RC)"
+else
+  bad "3310-head-corrupt: reported success without measuring staged deletions; output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_UNMEASURED_MARKER"*) ok "3310-head-corrupt: reports COULD NOT MEASURE" ;;
+  *) bad "3310-head-corrupt: no unmeasurable verdict; output: $OUT" ;;
+esac
+case "$OUT" in
+  *"Tracked-fixture probe (#3310): OK"*)
+    bad "3310-head-corrupt: printed a clean tracked-fixture verdict; output: $OUT" ;;
+  *) ok "3310-head-corrupt: no clean verdict" ;;
+esac
+
+# === Case 46: a genuinely UNBORN branch is still measurable and clean =========
+# The other side of case 45: the discriminator must not over-fire. A repo with
+# staged fixtures and no commit yet cannot HAVE a deletion relative to HEAD, so
+# the probe must verify normally rather than refusing.
+R46="$T/case46-repo"
+mkdir -p "$R46/test-data/datasets/goldens"
+git -C "$R46" init -q
+git -C "$R46" config user.email test@example.com
+git -C "$R46" config user.name "Test"
+printf 'unborn fixture\n' >"$R46/test-data/datasets/goldens/unborn-Data.db.jsonl"
+git -C "$R46" add -f -- "test-data/datasets/goldens/unborn-Data.db.jsonl"
+make_usable_corpus "$R46/test-data/datasets"
+if ! git -C "$R46" rev-parse --verify -q HEAD >/dev/null 2>&1 \
+   && [ -n "$(git -C "$R46" ls-files -- test-data/datasets)" ]; then
+  ok "3310-head-unborn: unborn HEAD with staged fixtures (precondition)"
+else
+  bad "3310-head-unborn: could not create the unborn state; case is vacuous"
+fi
+run_verify "$R46" "$R46/test-data/datasets"
+if [ "$RC" -eq 0 ]; then
+  ok "3310-head-unborn: an unborn branch verifies normally (exit 0)"
+else
+  bad "3310-head-unborn: false failure on an unborn branch (exit $RC); output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_UNMEASURED_MARKER"*) bad "3310-head-unborn: refused a measurable unborn repo; output: $OUT" ;;
+  *) ok "3310-head-unborn: no unmeasurable verdict" ;;
+esac
+
 # --- summary -----------------------------------------------------------------
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/test_fetch_datasets_tracked_guard.sh
+++ b/scripts/tests/test_fetch_datasets_tracked_guard.sh
@@ -2122,7 +2122,10 @@ make_usable_corpus "$R38/test-data/datasets"
 rm -f "$R38/test-data/datasets/goldens/simple_table-Data.db.jsonl" \
       "$R38/test-data/datasets/goldens/spaced name-Data.db.jsonl"
 run_verify "$R38" "$R38/test-data/datasets"
-R38_CMD="$(printf '%s\n' "$OUT" | grep -E "git -C .* restore --worktree --" | head -1)"
+# The printed line carries this script's `ERROR:   ` prefix; the COMMAND is what
+# follows it, and that is what an operator copies. Strip the prefix, then run the
+# remainder VERBATIM — anything less would not test the advertised text.
+R38_CMD="$(printf '%s\n' "$OUT" | grep -E "git -C .* restore --worktree --" | head -1 | sed 's/^ERROR:[[:space:]]*//')"
 if [ -n "$R38_CMD" ]; then
   ok "3310-scoped-repair: a --worktree repair line was printed"
 else
@@ -2174,7 +2177,7 @@ if [ "$RC" -ne 0 ]; then
 else
   bad "3310-staged-delete: exited 0; output: $OUT"
 fi
-R39_CMD="$(printf '%s\n' "$OUT" | grep -E "git -C .* restore --staged --worktree --" | head -1)"
+R39_CMD="$(printf '%s\n' "$OUT" | grep -E "git -C .* restore --staged --worktree --" | head -1 | sed 's/^ERROR:[[:space:]]*//')"
 if [ -n "$R39_CMD" ]; then
   ok "3310-staged-delete: a --staged --worktree repair line was printed"
 else

--- a/scripts/tests/test_fetch_datasets_tracked_guard.sh
+++ b/scripts/tests/test_fetch_datasets_tracked_guard.sh
@@ -1827,10 +1827,32 @@ case "$OUT" in
   *) bad "3310-report: does not name '$R32_DELETED_B'; output: $OUT" ;;
 esac
 case "$OUT" in
-  *"git -C "*"restore"*"--worktree"*"test-data/datasets"*)
-    ok "3310-report: prints the exact one-line repair command" ;;
-  *) bad "3310-report: no copy-pasteable repair command; output: $OUT" ;;
+  *"git -C "*"restore"*"--worktree"*"test-data/datasets/$R32_DELETED_A"*)
+    ok "3310-report: prints a one-line repair command naming the deleted PATH" ;;
+  *) bad "3310-report: no copy-pasteable path-scoped repair command; output: $OUT" ;;
 esac
+# The repair must be SCOPED TO THE DELETED PATHS. A subtree-wide
+# `git restore --worktree -- test-data/datasets` reverts every unrelated local
+# change under the root — and --verify-only returns BEFORE the destructive path's
+# refuse_modified_tracked_dataset_files, so nothing here has ruled such a
+# modification out. Advertising that line as "EXACTLY this command" would make
+# this change a new instance of the data loss #2878/#3245 exist to prevent.
+R32_SUBTREE_WIDE=0
+while IFS= read -r line; do
+  case "$line" in
+    *"git -C "*" restore "*)
+      case "$line" in
+        *"-- test-data/datasets" | *"-- 'test-data/datasets'" | *"-- test-data/datasets ") R32_SUBTREE_WIDE=1 ;;
+      esac ;;
+  esac
+done <<EOF
+$OUT
+EOF
+if [ "$R32_SUBTREE_WIDE" -eq 0 ]; then
+  ok "3310-report: no subtree-wide restore is advertised (the repair cannot revert unrelated work)"
+else
+  bad "3310-report: advertised a subtree-wide 'restore -- test-data/datasets'; output: $OUT"
+fi
 # Textually DISTINCT from the generic unusable-root diagnostic: an agent must be
 # able to tell "your fixtures are missing, here is the repair" from "this root has
 # no corpus". The corpus here is fine, so the unusable message would be a lie.
@@ -1854,11 +1876,16 @@ if [ "$R32_STATUS_BEFORE" = "$R32_STATUS_AFTER" ]; then
 else
   bad "3310-report: git status changed: '$R32_STATUS_BEFORE' -> '$R32_STATUS_AFTER'"
 fi
-if [ ! -e "$R32_ROOT/$R32_DELETED_A" ] && [ ! -e "$R32_ROOT/$R32_DELETED_B" ]; then
-  ok "3310-report: the deleted fixtures are STILL deleted (it reported, it did not repair)"
-else
-  bad "3310-report: --verify-only restored a file; it must never mutate the tree"
-fi
+# DIRECT existence assertion, deliberately INDEPENDENT of the census above: the
+# headline guarantee is "reports, never repairs", and it must survive any future
+# refactor of census_of. Asserted per file so a partial restore cannot hide.
+for rel in "$R32_DELETED_A" "$R32_DELETED_B"; do
+  if [ ! -e "$R32_ROOT/$rel" ]; then
+    ok "3310-report: '$rel' is STILL deleted (it reported, it did not repair)"
+  else
+    bad "3310-report: --verify-only RESTORED '$rel'; it must never mutate the tree"
+  fi
+done
 
 # === Case 32b: the SAME report when the corpus content is ALSO absent =========
 # The reported motivation: with the corpus gone too, the pre-#3310 probe answered
@@ -2031,6 +2058,170 @@ if [ "$R36_CENSUS_BEFORE" = "$R36_CENSUS_AFTER" ]; then
 else
   bad "3310-unmeasurable: the root changed across a report-only probe"
 fi
+
+# === Case 37: a DELETED fixture carrying skip-worktree must not read clean ====
+# roborev #3310 blocker 2. `git status` SUPPRESSES worktree reporting for
+# skip-worktree ('S') and assume-unchanged (lowercase tag) index entries, so a
+# probe that infers presence from "no deletion entries appeared" reports every
+# file present while the file is genuinely gone. Presence must be established
+# AFFIRMATIVELY (stat each indexed path) — and where an index flag makes the
+# state undeterminable, the answer is COULD NOT MEASURE, never a clean verdict.
+# The destructive path already refuses these flags; this probe must not be weaker
+# than the code sitting above it.
+#
+# probe_flagged_case <label> <case-dir> <git update-index flag>
+probe_flagged_case() {
+  local label="$1" dir="$2" flag="$3" rel="goldens/simple_table-Data.db.jsonl"
+  make_repo "$dir"
+  make_usable_corpus "$dir/test-data/datasets"
+  git -C "$dir" update-index "$flag" -- "test-data/datasets/$rel"
+  rm -f "$dir/test-data/datasets/$rel"
+  # Precondition: git really is blind to the deletion (else the case is vacuous).
+  if [ -z "$(git -C "$dir" status --porcelain -- "test-data/datasets/$rel")" ]; then
+    ok "$label: git status is BLIND to the deletion (the flag really hides it)"
+  else
+    bad "$label: git status still reports the deletion; case is vacuous"
+  fi
+  run_verify "$dir" "$dir/test-data/datasets"
+  if [ "$RC" -ne 0 ]; then
+    ok "$label: does not report a clean root (exit $RC)"
+  else
+    bad "$label: reported the root usable with a hidden tracked fixture DELETED; output: $OUT"
+  fi
+  case "$OUT" in
+    *"Tracked-fixture probe (#3310): OK"*)
+      bad "$label: printed a CLEAN tracked-fixture verdict about a file it cannot see; output: $OUT" ;;
+    *) ok "$label: no clean tracked-fixture verdict" ;;
+  esac
+  case "$OUT" in
+    *"$PROBE_MISSING_MARKER"* | *"$PROBE_UNMEASURED_MARKER"*)
+      ok "$label: reports it as missing or explicitly unmeasurable" ;;
+    *) bad "$label: neither reported nor declared unmeasurable; output: $OUT" ;;
+  esac
+  case "$OUT" in
+    *"$rel"*) ok "$label: names the affected path" ;;
+    *) bad "$label: does not name '$rel'; output: $OUT" ;;
+  esac
+  if [ ! -e "$dir/test-data/datasets/$rel" ]; then
+    ok "$label: still repaired nothing"
+  else
+    bad "$label: the probe restored the file"
+  fi
+}
+probe_flagged_case "3310-skip-worktree" "$T/case37-repo" --skip-worktree
+probe_flagged_case "3310-assume-unchanged" "$T/case37b-repo" --assume-unchanged
+
+# === Case 38: the repair is SCOPED, and every path in it is shell-quoted ======
+# roborev #3310 blocker 1, positive control: two deletions, one space-bearing.
+# The printed command must name both paths (so it actually repairs both) and must
+# round-trip through a shell — an unquoted `spaced name-...` would silently become
+# two pathspecs, neither of which exists.
+R38="$T/case38-repo"
+make_repo "$R38"
+make_usable_corpus "$R38/test-data/datasets"
+rm -f "$R38/test-data/datasets/goldens/simple_table-Data.db.jsonl" \
+      "$R38/test-data/datasets/goldens/spaced name-Data.db.jsonl"
+run_verify "$R38" "$R38/test-data/datasets"
+R38_CMD="$(printf '%s\n' "$OUT" | grep -E "git -C .* restore --worktree --" | head -1)"
+if [ -n "$R38_CMD" ]; then
+  ok "3310-scoped-repair: a --worktree repair line was printed"
+else
+  bad "3310-scoped-repair: no --worktree repair line; output: $OUT"
+fi
+case "$R38_CMD" in
+  *"goldens/simple_table-Data.db.jsonl"*) ok "3310-scoped-repair: the command names the first deleted path" ;;
+  *) bad "3310-scoped-repair: first path absent from the command: '$R38_CMD'" ;;
+esac
+case "$R38_CMD" in
+  *"goldens/spaced name-Data.db.jsonl"* | *"goldens/spaced\\ name-Data.db.jsonl"*)
+    ok "3310-scoped-repair: the command names the SPACE-bearing deleted path" ;;
+  *) bad "3310-scoped-repair: space-bearing path absent from the command: '$R38_CMD'" ;;
+esac
+case "$R38_CMD" in
+  *"-- test-data/datasets" | *"-- 'test-data/datasets'")
+    bad "3310-scoped-repair: the command is subtree-wide, not path-scoped: '$R38_CMD'" ;;
+  *) ok "3310-scoped-repair: the command is not subtree-wide" ;;
+esac
+# The advertised line must WORK: run it verbatim and require both files back.
+( cd "$R38" && eval "$R38_CMD" ) >/dev/null 2>&1
+if [ -f "$R38/test-data/datasets/goldens/simple_table-Data.db.jsonl" ] \
+   && [ -f "$R38/test-data/datasets/goldens/spaced name-Data.db.jsonl" ]; then
+  ok "3310-scoped-repair: pasting the advertised command verbatim restores BOTH files"
+else
+  bad "3310-scoped-repair: the advertised command did not repair the deletions: '$R38_CMD'"
+fi
+# ...and it must not have touched the tracked fixtures it was not asked about.
+if [ -z "$(git -C "$R38" status --porcelain 2>&1)" ]; then
+  ok "3310-scoped-repair: the checkout is clean after the advertised repair"
+else
+  bad "3310-scoped-repair: the repair left the checkout dirty: $(git -C "$R38" status --porcelain | head -3)"
+fi
+
+# === Case 39: a STAGED deletion needs a DIFFERENT repair command ==============
+# `git rm --cached` removes the index entry, so `git restore --worktree` has
+# nothing to rebuild from and silently no-ops; only `--staged --worktree` works.
+# Lumping this class in with worktree deletions would advertise a command that
+# does not repair it.
+R39="$T/case39-repo"
+make_repo "$R39"
+make_usable_corpus "$R39/test-data/datasets"
+R39_REL="goldens/simple_table-Data.db.jsonl"
+git -C "$R39" rm -q --cached "test-data/datasets/$R39_REL" >/dev/null
+rm -f "$R39/test-data/datasets/$R39_REL"
+run_verify "$R39" "$R39/test-data/datasets"
+if [ "$RC" -ne 0 ]; then
+  ok "3310-staged-delete: reports the staged+worktree deletion (exit $RC)"
+else
+  bad "3310-staged-delete: exited 0; output: $OUT"
+fi
+R39_CMD="$(printf '%s\n' "$OUT" | grep -E "git -C .* restore --staged --worktree --" | head -1)"
+if [ -n "$R39_CMD" ]; then
+  ok "3310-staged-delete: a --staged --worktree repair line was printed"
+else
+  bad "3310-staged-delete: no staged-class repair line; output: $OUT"
+fi
+case "$R39_CMD" in
+  *"$R39_REL"*) ok "3310-staged-delete: the staged-class command names the path" ;;
+  *) bad "3310-staged-delete: path absent from the staged-class command: '$R39_CMD'" ;;
+esac
+case "$R39_CMD" in
+  *"-- test-data/datasets" | *"-- 'test-data/datasets'")
+    bad "3310-staged-delete: the staged-class command is subtree-wide: '$R39_CMD'" ;;
+  *) ok "3310-staged-delete: the staged-class command is not subtree-wide" ;;
+esac
+if [ ! -e "$R39/test-data/datasets/$R39_REL" ]; then
+  ok "3310-staged-delete: still repaired nothing"
+else
+  bad "3310-staged-delete: the probe restored the staged-deleted file"
+fi
+( cd "$R39" && eval "$R39_CMD" ) >/dev/null 2>&1
+if [ -f "$R39/test-data/datasets/$R39_REL" ]; then
+  ok "3310-staged-delete: pasting the advertised command verbatim restores the file"
+else
+  bad "3310-staged-delete: the advertised staged-class command did not repair it: '$R39_CMD'"
+fi
+
+# === Case 39b: a staged deletion whose CONTENT IS STILL ON DISK is not missing =
+# The boundary of the probe's subject: nothing is absent, so it must not claim a
+# missing fixture — but it must not stay silent about a measured signal either.
+R39B="$T/case39b-repo"
+make_repo "$R39B"
+make_usable_corpus "$R39B/test-data/datasets"
+git -C "$R39B" rm -q --cached "test-data/datasets/$R39_REL" >/dev/null
+run_verify "$R39B" "$R39B/test-data/datasets"
+if [ "$RC" -eq 0 ]; then
+  ok "3310-staged-present: content on disk is not a missing fixture (exit 0)"
+else
+  bad "3310-staged-present: false positive on a staged deletion whose content is present (exit $RC); output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_MISSING_MARKER"*) bad "3310-staged-present: called a present file missing; output: $OUT" ;;
+  *) ok "3310-staged-present: no missing-fixture claim" ;;
+esac
+case "$OUT" in
+  *"STAGED DELETION"*) ok "3310-staged-present: still reports the measured staged deletion as a NOTE" ;;
+  *) bad "3310-staged-present: silently dropped a measured signal; output: $OUT" ;;
+esac
 
 # --- summary -----------------------------------------------------------------
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"

--- a/scripts/tests/test_fetch_datasets_tracked_guard.sh
+++ b/scripts/tests/test_fetch_datasets_tracked_guard.sh
@@ -202,12 +202,15 @@ IGN
 # script with curl stubbed and CI explicitly unset unless an override is passed.
 # A dataset-root of "-" leaves CQLITE_DATASETS_ROOT UNSET so the script's
 # documented relative default (test-data/datasets) is exercised. Set
-# FETCH_PAYLOAD/FETCH_PAYLOAD_SHA to serve a different archive.
+# FETCH_PAYLOAD/FETCH_PAYLOAD_SHA to serve a different archive, and FETCH_ARGS to
+# pass SCRIPT arguments (issue #3310 drives the same real script through
+# `--verify-only`; every other case passes none).
 # Sets $OUT (combined output) and $RC.
 FETCH_PAYLOAD=""
 FETCH_PAYLOAD_SHA=""
 FETCH_BIN=""
 FETCH_TMPDIR=""
+FETCH_ARGS=()
 run_fetch() {
   local cwd="$1" root="$2"
   shift 2
@@ -223,19 +226,22 @@ run_fetch() {
     # FETCH_TMPDIR overrides it for the cases that probe a hostile TMPDIR.
     export TMPDIR="${FETCH_TMPDIR:-$T}"
     export STUB_CURL_PAYLOAD="$payload"
+    # `${arr[@]+"${arr[@]}"}` — an EMPTY array expands to nothing under `set -u`
+    # on every bash this suite runs on (bash 3.2 included), which a bare
+    # `"${arr[@]}"` does not.
     if [ "$root" = "-" ]; then
       env -u CQLITE_DATASETS_ROOT "$@" \
         DATASET_TAG="fake-tag" \
         DATASET_ASSET="$ASSET" \
         DATASET_SHA256="$sha" \
-        bash "$FETCH" 2>&1
+        bash "$FETCH" ${FETCH_ARGS[@]+"${FETCH_ARGS[@]}"} 2>&1
     else
       env "$@" \
         CQLITE_DATASETS_ROOT="$root" \
         DATASET_TAG="fake-tag" \
         DATASET_ASSET="$ASSET" \
         DATASET_SHA256="$sha" \
-        bash "$FETCH" 2>&1
+        bash "$FETCH" ${FETCH_ARGS[@]+"${FETCH_ARGS[@]}"} 2>&1
     fi
   )
   RC=$?
@@ -1718,6 +1724,313 @@ else
   bad "no-tracked-fixtures: false refusal on a clean in-repo root (exit $RC); output: $OUT"
 fi
 assert_archive_extracted "$R31/test-data/datasets" "no-tracked-fixtures"
+
+# =============================================================================
+# Issue #3310 — `--verify-only` must REPORT SIGKILL-orphaned tracked fixtures.
+#
+# The #2878 crash-safe restore covers EXIT/INT/TERM/HUP; SIGKILL outruns all of
+# them and leaves tracked fixtures DELETED on disk with the index still recording
+# them. Recovery exists, but only in the DESTRUCTIVE path's `missing-only`
+# pre-flight — and `--verify-only` returns before it. So the first diagnostic an
+# agent reaches for used to answer "root unusable" (or, with the corpus intact,
+# a clean green) for a checkout whose git-tracked fixtures are gone.
+#
+# The contract these cases pin: `--verify-only` REPORTS, never repairs. It names
+# the missing tracked file(s), prints the exact one-line repair command, exits
+# non-zero, and mutates NOTHING — the deleted files stay deleted.
+# =============================================================================
+
+# make_usable_corpus <root> — the minimal CONTENT has_required_content() demands,
+# so `--verify-only` can reach a VERIFIED verdict. Everything it writes is either
+# .gitignore'd by make_repo's .gitignore (*.db, metadata.yml, sstables/) or lives
+# under sstables/, so a repo built by make_repo stays `git status`-clean.
+make_usable_corpus() {
+  local root="$1" c
+  mkdir -p "$root/sstables/test_basic/simple_table-aaaa" "$root/$WIDE_DIR" \
+    || { echo "FAIL - could not create the synthetic corpus under $root"; exit 1; }
+  printf 'synthetic: true\n' >"$root/metadata.yml"
+  printf '{"synthetic":"wide golden"}\n' >"$root/$WIDE_DIR/nb-2-big-Data.db.jsonl"
+  for c in nb-2-big-Data.db nb-2-big-Index.db nb-2-big-Digest.crc32 nb-2-big-CompressionInfo.db; do
+    printf 'wide %s\n' "$c" >"$root/$WIDE_DIR/$c"
+  done
+  for c in nb-1-big-Data.db nb-1-big-Index.db nb-1-big-Summary.db nb-1-big-Statistics.db; do
+    printf 'basic %s\n' "$c" >"$root/sstables/test_basic/simple_table-aaaa/$c"
+  done
+}
+
+# mtime_of / census_of — a NO-WRITES oracle for a report-only probe. The census is
+# every path under the root with its type, mtime and content hash, NUL-walked and
+# sorted, so a rewritten file (same size, same name) is caught as surely as a
+# created or deleted one. Assertion (b) of #3310 compares it across the run.
+mtime_of() { stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null || printf '?\n'; }
+census_of() {
+  local root="$1" p
+  if [ ! -d "$root" ]; then printf 'ABSENT\t%s\n' "$root"; return 0; fi
+  ( cd "$root" && find . -print0 | LC_ALL=C sort -z ) | while IFS= read -r -d '' p; do
+    if [ -L "$root/$p" ]; then
+      printf '%s\tsymlink\n' "$p"
+    elif [ -f "$root/$p" ]; then
+      printf '%s\tfile\t%s\t%s\n' "$p" "$(mtime_of "$root/$p")" "$(sha256_of "$root/$p")"
+    else
+      printf '%s\tdir\n' "$p"
+    fi
+  done
+}
+
+# run_verify <cwd> <dataset-root> [env...] — the same real script, `--verify-only`.
+run_verify() {
+  FETCH_ARGS=(--verify-only)
+  run_fetch "$@"
+  FETCH_ARGS=()
+}
+
+# The three verdict markers the probe may print. Kept in one place so a case can
+# assert BOTH that the right one appeared and that the others did not.
+PROBE_MISSING_MARKER="TRACKED FIXTURES MISSING"
+PROBE_UNMEASURED_MARKER="TRACKED-FIXTURE PROBE COULD NOT MEASURE"
+PROBE_NOSUBJECT_MARKER="NO SUBJECT"
+UNUSABLE_MARKER="does not hold a usable dataset corpus"
+
+# === Case 32: --verify-only NAMES the orphaned fixtures and REPAIRS NOTHING ====
+R32="$T/case32-repo"
+make_repo "$R32"
+R32_ROOT="$R32/test-data/datasets"
+make_usable_corpus "$R32_ROOT"
+# Exactly what a SIGKILL mid-`rm -rf` leaves: tracked fixtures gone from disk, the
+# index unchanged. One of the two carries a SPACE — this repo tracks 40
+# space-bearing paths, and a probe that splits on whitespace would drop or mangle
+# it (git's `-z` output is the only reason it survives).
+R32_DELETED_A="goldens/simple_table-Data.db.jsonl"
+R32_DELETED_B="goldens/spaced name-Data.db.jsonl"
+rm -f "$R32_ROOT/$R32_DELETED_A" "$R32_ROOT/$R32_DELETED_B"
+R32_CENSUS_BEFORE="$(census_of "$R32_ROOT")"
+R32_STATUS_BEFORE="$(git -C "$R32" status --porcelain 2>&1)"
+run_verify "$R32" "$R32_ROOT"
+R32_CENSUS_AFTER="$(census_of "$R32_ROOT")"
+R32_STATUS_AFTER="$(git -C "$R32" status --porcelain 2>&1)"
+
+if [ "$RC" -ne 0 ]; then
+  ok "3310-report: --verify-only exits non-zero on orphaned tracked fixtures (exit $RC)"
+else
+  bad "3310-report: --verify-only exited 0 with tracked fixtures DELETED; output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_MISSING_MARKER"*) ok "3310-report: names the condition ('$PROBE_MISSING_MARKER')" ;;
+  *) bad "3310-report: missing the '$PROBE_MISSING_MARKER' marker; output: $OUT" ;;
+esac
+case "$OUT" in
+  *"$R32_DELETED_A"*) ok "3310-report: names the missing tracked file" ;;
+  *) bad "3310-report: does not name '$R32_DELETED_A'; output: $OUT" ;;
+esac
+case "$OUT" in
+  *"$R32_DELETED_B"*) ok "3310-report: names the SPACE-bearing missing tracked file intact" ;;
+  *) bad "3310-report: does not name '$R32_DELETED_B'; output: $OUT" ;;
+esac
+case "$OUT" in
+  *"git -C "*"restore"*"--worktree"*"test-data/datasets"*)
+    ok "3310-report: prints the exact one-line repair command" ;;
+  *) bad "3310-report: no copy-pasteable repair command; output: $OUT" ;;
+esac
+# Textually DISTINCT from the generic unusable-root diagnostic: an agent must be
+# able to tell "your fixtures are missing, here is the repair" from "this root has
+# no corpus". The corpus here is fine, so the unusable message would be a lie.
+case "$OUT" in
+  *"$UNUSABLE_MARKER"*) bad "3310-report: reported the generic root-unusable message instead; output: $OUT" ;;
+  *) ok "3310-report: diagnostic is distinct from the generic '$UNUSABLE_MARKER'" ;;
+esac
+case "$OUT" in
+  *"Dataset root VERIFIED"*) bad "3310-report: still reported the root VERIFIED; output: $OUT" ;;
+  *) ok "3310-report: does not report the root VERIFIED while fixtures are orphaned" ;;
+esac
+# --- (b) REPORT-ONLY: the run must have written nothing at all ----------------
+if [ "$R32_CENSUS_BEFORE" = "$R32_CENSUS_AFTER" ]; then
+  ok "3310-report: the dataset root is byte-for-byte unchanged (no writes, no repair)"
+else
+  bad "3310-report: the root CHANGED across a report-only probe:"
+  diff <(printf '%s\n' "$R32_CENSUS_BEFORE") <(printf '%s\n' "$R32_CENSUS_AFTER") | head -10
+fi
+if [ "$R32_STATUS_BEFORE" = "$R32_STATUS_AFTER" ]; then
+  ok "3310-report: git status --porcelain is unchanged (the index was not touched)"
+else
+  bad "3310-report: git status changed: '$R32_STATUS_BEFORE' -> '$R32_STATUS_AFTER'"
+fi
+if [ ! -e "$R32_ROOT/$R32_DELETED_A" ] && [ ! -e "$R32_ROOT/$R32_DELETED_B" ]; then
+  ok "3310-report: the deleted fixtures are STILL deleted (it reported, it did not repair)"
+else
+  bad "3310-report: --verify-only restored a file; it must never mutate the tree"
+fi
+
+# === Case 32b: the SAME report when the corpus content is ALSO absent =========
+# The reported motivation: with the corpus gone too, the pre-#3310 probe answered
+# only "root unusable", which sends an agent to re-fetch instead of to the
+# one-line restore. The fixture diagnosis must come FIRST and must still appear.
+R32B="$T/case32b-repo"
+make_repo "$R32B"
+rm -f "$R32B/test-data/datasets/$R32_DELETED_A"
+run_verify "$R32B" "$R32B/test-data/datasets"
+if [ "$RC" -ne 0 ]; then
+  ok "3310-report-no-corpus: still exits non-zero (exit $RC)"
+else
+  bad "3310-report-no-corpus: exited 0; output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_MISSING_MARKER"*"$R32_DELETED_A"*)
+    ok "3310-report-no-corpus: reports the missing tracked fixture, not just 'root unusable'" ;;
+  *) bad "3310-report-no-corpus: no tracked-fixture diagnosis; output: $OUT" ;;
+esac
+if [ -f "$R32B/test-data/datasets/${TRACKED_RELATIVE[0]}" ]; then
+  ok "3310-report-no-corpus: the surviving tracked fixtures were left alone"
+else
+  bad "3310-report-no-corpus: a surviving tracked fixture disappeared"
+fi
+
+# === Case 32c: NON-VACUITY — with the probe disabled the defect returns =======
+# The mutant is the pre-#3310 script: `--verify-only` skips the probe entirely.
+# With a usable corpus and tracked fixtures deleted it must report a GREEN
+# VERIFIED root — the misleading answer this issue exists to remove.
+MUTANT_NO_PROBE="$T/fetch-datasets-mutant-no-verify-probe.sh"
+sed 's/^  report_orphaned_tracked_fixtures || exit 1$/  : mutant-no-verify-probe/' \
+  "$FETCH" >"$MUTANT_NO_PROBE"
+if grep -q ': mutant-no-verify-probe' "$MUTANT_NO_PROBE"; then
+  ok "non-vacuity: built a verify-probe-disabled mutant"
+  R32C="$T/case32c-repo"
+  make_repo "$R32C"
+  make_usable_corpus "$R32C/test-data/datasets"
+  rm -f "$R32C/test-data/datasets/$R32_DELETED_A"
+  FETCH_SAVED="$FETCH"
+  FETCH="$MUTANT_NO_PROBE"
+  run_verify "$R32C" "$R32C/test-data/datasets"
+  FETCH="$FETCH_SAVED"
+  if [ "$RC" -eq 0 ]; then
+    ok "non-vacuity: mutant reports the root usable (exit 0) with a tracked fixture DELETED"
+  else
+    bad "non-vacuity: mutant did not reproduce the misleading green (exit $RC); output: $OUT"
+  fi
+  case "$OUT" in
+    *"$R32_DELETED_A"*) bad "non-vacuity: mutant named the missing file — the assert is vacuous" ;;
+    *) ok "non-vacuity: mutant never names the orphaned fixture (the pre-#3310 blind spot)" ;;
+  esac
+else
+  bad "non-vacuity: could not build the verify-probe-disabled mutant (call site renamed?)"
+fi
+
+# === Case 33: NO SUBJECT — an out-of-repo root has no tracked files at all =====
+# The fleet layout (/data/datasets). Nothing there is tracked by construction, so
+# the probe must NOT fire — and must not print a vacuous "0 of 0 clean" verdict
+# either: a probe with no subject has no clean verdict to give.
+if [ "$SANDBOX_IN_REPO" = 1 ]; then
+  printf 'INFO - skipping the out-of-repo probe case (sandbox is inside a checkout)\n'
+else
+  R33_ROOT="$T/case33-outside/test-data/datasets"
+  make_usable_corpus "$R33_ROOT"
+  run_verify "$T/case33-outside" "$R33_ROOT"
+  if [ "$RC" -eq 0 ]; then
+    ok "3310-no-subject-outside: an out-of-repo root still verifies clean (exit 0)"
+  else
+    bad "3310-no-subject-outside: false failure on an out-of-repo root (exit $RC); output: $OUT"
+  fi
+  case "$OUT" in
+    *"$PROBE_MISSING_MARKER"*) bad "3310-no-subject-outside: the probe fired with no subject; output: $OUT" ;;
+    *) ok "3310-no-subject-outside: the probe does not fire" ;;
+  esac
+  case "$OUT" in
+    *"$PROBE_NOSUBJECT_MARKER"*) ok "3310-no-subject-outside: says it had NO SUBJECT rather than claiming a clean census" ;;
+    *) bad "3310-no-subject-outside: no no-subject statement; output: $OUT" ;;
+  esac
+  case "$OUT" in
+    *"all 0 git-tracked"*) bad "3310-no-subject-outside: printed a vacuous 0/0 clean verdict; output: $OUT" ;;
+    *) ok "3310-no-subject-outside: no vacuous 0/0 clean count" ;;
+  esac
+fi
+
+# === Case 34: NO SUBJECT — an IN-repo root that tracks nothing ================
+# The other no-subject shape: inside a work tree, but the index holds no path
+# under the root (case 31's repo, probed instead of fetched).
+R34="$T/case34-repo"
+mkdir -p "$R34"
+git -C "$R34" init -q
+git -C "$R34" config user.email test@example.com
+git -C "$R34" config user.name "Test"
+printf 'placeholder\n' >"$R34/README.md"
+git -C "$R34" add README.md
+git -C "$R34" commit -qm "repo with no tracked dataset fixtures"
+make_usable_corpus "$R34/test-data/datasets"
+run_verify "$R34" "$R34/test-data/datasets"
+if [ "$RC" -eq 0 ]; then
+  ok "3310-no-subject-in-repo: an in-repo root tracking nothing verifies clean (exit 0)"
+else
+  bad "3310-no-subject-in-repo: false failure (exit $RC); output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_NOSUBJECT_MARKER"*) ok "3310-no-subject-in-repo: reports NO SUBJECT, not a clean census of nothing" ;;
+  *) bad "3310-no-subject-in-repo: no no-subject statement; output: $OUT" ;;
+esac
+case "$OUT" in
+  *"all 0 git-tracked"*) bad "3310-no-subject-in-repo: printed a vacuous 0/0 clean verdict; output: $OUT" ;;
+  *) ok "3310-no-subject-in-repo: no vacuous 0/0 clean count" ;;
+esac
+
+# === Case 35: POSITIVE CONTROL — every tracked fixture present ================
+# An affirmative measurement, not the absence of a bad signal: the probe must say
+# how many tracked files it found and that all of them are on disk.
+R35="$T/case35-repo"
+make_repo "$R35"
+make_usable_corpus "$R35/test-data/datasets"
+run_verify "$R35" "$R35/test-data/datasets"
+if [ "$RC" -eq 0 ]; then
+  ok "3310-positive: an intact checkout verifies clean (exit 0)"
+else
+  bad "3310-positive: false failure on an intact checkout (exit $RC); output: $OUT"
+fi
+case "$OUT" in
+  *"all ${#TRACKED_RELATIVE[@]} git-tracked file(s)"*)
+    ok "3310-positive: reports the measured count (${#TRACKED_RELATIVE[@]}) as present" ;;
+  *) bad "3310-positive: no affirmative count in the verdict; output: $OUT" ;;
+esac
+case "$OUT" in
+  *"Dataset root VERIFIED"*) ok "3310-positive: the probe does not block the normal VERIFIED report" ;;
+  *) bad "3310-positive: the usual verify-only output disappeared; output: $OUT" ;;
+esac
+
+# === Case 36: UNMEASURABLE — an in-checkout root whose census cannot be taken ==
+# A positive verdict requires an AFFIRMATIVE measurement. With git unusable and
+# the root inside a checkout, "no missing fixtures" is unknown, not true — the
+# unmeasured state must NOT inherit the permissive branch.
+GITBIN="$T/bin-broken-git"
+mkdir -p "$GITBIN" || { echo "FAIL - could not create $GITBIN"; exit 1; }
+cp "$BIN/curl" "$GITBIN/curl"
+cat >"$GITBIN/git" <<'MOCK'
+#!/usr/bin/env bash
+echo "git: simulated failure (issue #3310 unmeasurable-census case)" >&2
+exit 1
+MOCK
+chmod +x "$GITBIN/git"
+R36="$T/case36-repo"
+make_repo "$R36"
+make_usable_corpus "$R36/test-data/datasets"
+R36_CENSUS_BEFORE="$(census_of "$R36/test-data/datasets")"
+FETCH_BIN="$GITBIN"
+run_verify "$R36" "$R36/test-data/datasets"
+FETCH_BIN=""
+R36_CENSUS_AFTER="$(census_of "$R36/test-data/datasets")"
+if [ "$RC" -ne 0 ]; then
+  ok "3310-unmeasurable: an untakeable census exits non-zero (exit $RC)"
+else
+  bad "3310-unmeasurable: an unmeasured census took the permissive branch (exit 0); output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_UNMEASURED_MARKER"*) ok "3310-unmeasurable: says the census could not be taken" ;;
+  *) bad "3310-unmeasurable: no could-not-measure statement; output: $OUT" ;;
+esac
+case "$OUT" in
+  *"Dataset root VERIFIED"*) bad "3310-unmeasurable: reported VERIFIED without the measurement; output: $OUT" ;;
+  *) ok "3310-unmeasurable: no VERIFIED verdict without the measurement" ;;
+esac
+if [ "$R36_CENSUS_BEFORE" = "$R36_CENSUS_AFTER" ]; then
+  ok "3310-unmeasurable: still mutated nothing"
+else
+  bad "3310-unmeasurable: the root changed across a report-only probe"
+fi
 
 # --- summary -----------------------------------------------------------------
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"

--- a/scripts/tests/test_fetch_datasets_tracked_guard.sh
+++ b/scripts/tests/test_fetch_datasets_tracked_guard.sh
@@ -2226,6 +2226,124 @@ case "$OUT" in
   *) bad "3310-staged-present: silently dropped a measured signal; output: $OUT" ;;
 esac
 
+# === Case 40: STAGED deletions of AWKWARDLY-NAMED paths (#3310 roborev r2) =====
+# The staged-deletion scan is the one path-reading step of the probe that did not
+# consume git's NUL-delimited output directly: it read the porcelain helper's
+# newline-JOINED return value. Measured facts that set the scope of these cases:
+#   * `git status --porcelain -z` emits paths VERBATIM — `-z` disables the
+#     C-quoting that plain porcelain applies to space-bearing and non-ASCII paths.
+#     So the space/non-ASCII cases below pass on the newline-joined reader too;
+#     they are REGRESSION PINS for the quoting class, not reproductions.
+#   * a path containing a NEWLINE is a genuine defect on that reader: the record
+#     splits, the probe reports a truncated path, and the "EXACTLY this command"
+#     repair then names a file that does not exist. That case is the red one.
+# All three are kept: the pins are what stop a future edit from reintroducing
+# C-quoted parsing, which is invisible until someone tracks such a path.
+#
+# stage_delete_case <label> <dir> <rel-under-datasets> <expect-missing:1|0>
+#   Adds a tracked fixture at <rel>, stage-deletes it (git rm --cached), and
+#   removes it from disk when a missing report is expected. Asserts the report,
+#   the EXACT path in both the listing and the repair command, and that pasting
+#   the advertised command verbatim really restores the file.
+stage_delete_case() {
+  local label="$1" dir="$2" rel="$3" expect_missing="$4" cmd
+  make_repo "$dir"
+  make_usable_corpus "$dir/test-data/datasets"
+  mkdir -p "$dir/test-data/datasets/$(dirname "$rel")"
+  printf 'awkwardly named tracked fixture\n' >"$dir/test-data/datasets/$rel"
+  git -C "$dir" add -f -- "test-data/datasets/$rel"
+  git -C "$dir" commit -qm "add awkward fixture"
+  git -C "$dir" rm -q --cached -- "test-data/datasets/$rel" >/dev/null
+  if [ "$expect_missing" = 1 ]; then
+    rm -f "$dir/test-data/datasets/$rel"
+  fi
+  run_verify "$dir" "$dir/test-data/datasets"
+
+  if [ "$expect_missing" != 1 ]; then
+    # The false-ABSENT direction: the content is still on disk, so a probe that
+    # mis-parses the path would call a present file missing.
+    if [ "$RC" -eq 0 ]; then
+      ok "$label: content on disk is not reported missing (exit 0)"
+    else
+      bad "$label: false 'missing' on a staged deletion whose content is present (exit $RC); output: $OUT"
+    fi
+    case "$OUT" in
+      *"$PROBE_MISSING_MARKER"*) bad "$label: called a present file missing; output: $OUT" ;;
+      *) ok "$label: no missing-fixture claim" ;;
+    esac
+    case "$OUT" in
+      *"STAGED DELETION"*) ok "$label: still reports the measured staged deletion as a NOTE" ;;
+      *) bad "$label: silently dropped the measured staged deletion; output: $OUT" ;;
+    esac
+    return 0
+  fi
+
+  if [ "$RC" -ne 0 ]; then
+    ok "$label: reports the staged deletion (exit $RC)"
+  else
+    bad "$label: exited 0 with the fixture gone; output: $OUT"
+  fi
+  # The EXACT path must appear — a truncated or quoted spelling must not pass.
+  case "$OUT" in
+    *"test-data/datasets/$rel"*) ok "$label: the report names the exact path" ;;
+    *) bad "$label: the exact path is absent (truncated or re-quoted?); output: $OUT" ;;
+  esac
+  cmd="$(printf '%s\n' "$OUT" | grep -E "git -C .* restore --staged --worktree --" | head -1 | sed 's/^ERROR:[[:space:]]*//')"
+  if [ -n "$cmd" ]; then
+    ok "$label: a --staged --worktree repair line was printed"
+  else
+    bad "$label: no staged-class repair line; output: $OUT"
+  fi
+  if [ ! -e "$dir/test-data/datasets/$rel" ]; then
+    ok "$label: repaired nothing itself"
+  else
+    bad "$label: the probe restored the file"
+  fi
+  # The decisive assertion: the ADVERTISED command, pasted verbatim, must repair.
+  # A mangled path here fails loudly instead of silently no-op'ing, because the
+  # file's return is what is checked — not the command's exit status.
+  ( cd "$dir" && eval "$cmd" ) >/dev/null 2>&1
+  if [ -f "$dir/test-data/datasets/$rel" ]; then
+    ok "$label: pasting the advertised command verbatim restores the file"
+  else
+    bad "$label: the advertised command did not repair it: '$cmd'"
+  fi
+}
+
+stage_delete_case "3310-staged-space" "$T/case40a-repo" "goldens/staged spaced-Data.db.jsonl" 1
+stage_delete_case "3310-staged-utf8"  "$T/case40b-repo" "goldens/é-café-Data.db.jsonl" 1
+stage_delete_case "3310-staged-newline" "$T/case40c-repo" "$(printf 'goldens/line\nbreak-Data.db.jsonl')" 1
+
+# === Case 41: the false-ABSENT direction for the same awkward names ===========
+stage_delete_case "3310-staged-space-present" "$T/case41a-repo" "goldens/present spaced-Data.db.jsonl" 0
+stage_delete_case "3310-staged-utf8-present"  "$T/case41b-repo" "goldens/présent-Data.db.jsonl" 0
+
+# === Case 42: a WORKTREE deletion of the same awkward names ===================
+# The index-census half already reads `ls-files -z` NUL-delimited, so this is a
+# regression pin on the half that was correct — the two halves must not diverge.
+R42="$T/case42-repo"
+make_repo "$R42"
+make_usable_corpus "$R42/test-data/datasets"
+R42_NL="$(printf 'goldens/worktree line\nbreak-Data.db.jsonl')"
+mkdir -p "$R42/test-data/datasets/goldens"
+printf 'x\n' >"$R42/test-data/datasets/$R42_NL"
+git -C "$R42" add -f -- "test-data/datasets/$R42_NL"
+git -C "$R42" commit -qm "add newline-bearing fixture"
+rm -f "$R42/test-data/datasets/$R42_NL"
+run_verify "$R42" "$R42/test-data/datasets"
+if [ "$RC" -ne 0 ]; then
+  ok "3310-worktree-newline: reports the worktree deletion of a newline-bearing path (exit $RC)"
+else
+  bad "3310-worktree-newline: exited 0 with the fixture gone; output: $OUT"
+fi
+R42_CMD="$(printf '%s\n' "$OUT" | grep -E "git -C .* restore --worktree --" | head -1 | sed 's/^ERROR:[[:space:]]*//')"
+( cd "$R42" && eval "$R42_CMD" ) >/dev/null 2>&1
+if [ -f "$R42/test-data/datasets/$R42_NL" ]; then
+  ok "3310-worktree-newline: the advertised command restores a newline-bearing path"
+else
+  bad "3310-worktree-newline: the advertised command did not repair it: '$R42_CMD'"
+fi
+
 # --- summary -----------------------------------------------------------------
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/test_fetch_datasets_tracked_guard.sh
+++ b/scripts/tests/test_fetch_datasets_tracked_guard.sh
@@ -2477,6 +2477,150 @@ case "$OUT" in
   *) ok "3310-head-unborn: no unmeasurable verdict" ;;
 esac
 
+# =============================================================================
+# Issue #3310 round 4 — UNCLASSIFIABLE GIT STATE IS DECLARED, NOT CLASSIFIED.
+#
+# Two states defeat the probe's subtree-scoped census, each in a way that would
+# produce a CONFIDENT WRONG REPAIR rather than a wrong verdict:
+#   * a staged rename whose destination leaves the dataset subtree — the census
+#     pathspec hides the destination, so rename detection cannot fire and the old
+#     path looks deleted; the advertised repair would REVERSE intentional work;
+#   * an unmerged (conflict) entry — `ls-files` lists it once per stage, and
+#     `git restore --worktree` cannot rebuild a conflicted path at all, so the
+#     promised repair simply fails.
+# Rather than model each, the probe detects MARKERS of unclassifiable state and
+# emits its existing COULD NOT MEASURE verdict, with NO repair command. An honest
+# unmeasurable beats a confident wrong repair.
+# =============================================================================
+
+# assert_no_repair_advertised <label> — the whole point of the rule: when the
+# probe cannot classify, it must not print a command for anyone to paste.
+assert_no_repair_advertised() {
+  local label="$1" n
+  n="$(printf '%s\n' "$OUT" | grep -cE "git -C .* restore " || true)"
+  if [ "$n" -eq 0 ]; then
+    ok "$label: advertises NO repair command"
+  else
+    bad "$label: advertised $n repair command(s) for a state it cannot classify; output: $OUT"
+  fi
+}
+
+# === Case 47: a staged rename OUT of the dataset subtree ======================
+R47="$T/case47-repo"
+make_repo "$R47"
+make_usable_corpus "$R47/test-data/datasets"
+mkdir -p "$R47/relocated"
+git -C "$R47" mv "test-data/datasets/goldens/simple_table-Data.db.jsonl" \
+                 "relocated/simple_table-Data.db.jsonl"
+if [ -f "$R47/relocated/simple_table-Data.db.jsonl" ] \
+   && [ ! -e "$R47/test-data/datasets/goldens/simple_table-Data.db.jsonl" ]; then
+  ok "3310-rename-out: fixture staged-renamed outside the dataset subtree (precondition)"
+else
+  bad "3310-rename-out: could not stage the boundary-crossing rename; case is vacuous"
+fi
+run_verify "$R47" "$R47/test-data/datasets"
+case "$OUT" in
+  *"$PROBE_MISSING_MARKER"*)
+    bad "3310-rename-out: called an intentionally relocated fixture MISSING; output: $OUT" ;;
+  *) ok "3310-rename-out: no false missing-fixture report" ;;
+esac
+assert_no_repair_advertised "3310-rename-out"
+case "$OUT" in
+  *"$PROBE_UNMEASURED_MARKER"*) ok "3310-rename-out: declares the state unclassifiable" ;;
+  *) bad "3310-rename-out: no COULD NOT MEASURE verdict; output: $OUT" ;;
+esac
+if [ "$RC" -ne 0 ]; then
+  ok "3310-rename-out: an unclassifiable state is not a clean run (exit $RC)"
+else
+  bad "3310-rename-out: exited 0 on a state it cannot classify; output: $OUT"
+fi
+if [ -f "$R47/relocated/simple_table-Data.db.jsonl" ]; then
+  ok "3310-rename-out: the relocated file is untouched"
+else
+  bad "3310-rename-out: the probe disturbed the renamed file"
+fi
+
+# === Case 48/49: an ABSENT unmerged path — declared, deduplicated, no repair ===
+# Built from a REAL merge conflict (the case-16 idiom), then deleted from disk:
+# `ls-files` lists it once per stage, so a probe that classifies it as an ordinary
+# worktree deletion both duplicates it and promises a repair that cannot work.
+R48="$T/case48-repo"
+make_repo "$R48"
+make_usable_corpus "$R48/test-data/datasets"
+R48_REL="test-data/datasets/goldens/simple_table-Data.db.jsonl"
+R48_BASE="$(git -C "$R48" rev-parse --abbrev-ref HEAD)"
+git -C "$R48" checkout -q -b conflicting-48
+printf 'branch side\n' >"$R48/$R48_REL"
+git -C "$R48" add -f "$R48_REL"
+git -C "$R48" commit -qm "branch side"
+git -C "$R48" checkout -q "$R48_BASE"
+printf 'base side\n' >"$R48/$R48_REL"
+git -C "$R48" add -f "$R48_REL"
+git -C "$R48" commit -qm "base side"
+git -C "$R48" merge -q conflicting-48 >/dev/null 2>&1 || true
+R48_STAGES="$(git -C "$R48" ls-files -u -- "$R48_REL" | wc -l | tr -d ' ')"
+rm -f "$R48/$R48_REL"
+if [ "$R48_STAGES" -gt 1 ] && [ ! -e "$R48/$R48_REL" ]; then
+  ok "3310-unmerged-absent: $R48_STAGES stage entries for an ABSENT path (precondition)"
+else
+  bad "3310-unmerged-absent: could not build the unmerged+absent fixture ($R48_STAGES stages); case is vacuous"
+fi
+run_verify "$R48" "$R48/test-data/datasets"
+case "$OUT" in
+  *"$PROBE_UNMEASURED_MARKER"*) ok "3310-unmerged-absent: declares COULD NOT MEASURE" ;;
+  *) bad "3310-unmerged-absent: no unmeasurable verdict; output: $OUT" ;;
+esac
+assert_no_repair_advertised "3310-unmerged-absent"
+if [ "$RC" -ne 0 ]; then
+  ok "3310-unmerged-absent: does not report a clean run (exit $RC)"
+else
+  bad "3310-unmerged-absent: exited 0 mid-conflict; output: $OUT"
+fi
+# Case 49 (dedup): the path is listed once per STAGE by git; the report must name
+# it exactly once however the verdict was reached.
+R48_MENTIONS="$(printf '%s\n' "$OUT" | grep -o "goldens/simple_table-Data.db.jsonl" | wc -l | tr -d ' ')"
+if [ "$R48_MENTIONS" -eq 1 ]; then
+  ok "3310-unmerged-dedup: the multi-stage path is named exactly once"
+else
+  bad "3310-unmerged-dedup: named $R48_MENTIONS times (stage duplication leaked); output: $OUT"
+fi
+
+# === Case 50: the pre-check must NOT trip on a healthy checkout ===============
+# The false-positive direction. Last round's flagged-present regression showed how
+# easily an over-broad guard reds a good root, and a guard that reds on correct
+# input is the guard people disable.
+R50="$T/case50-repo"
+make_repo "$R50"
+make_usable_corpus "$R50/test-data/datasets"
+run_verify "$R50" "$R50/test-data/datasets"
+if [ "$RC" -eq 0 ]; then
+  ok "3310-precheck-healthy: a healthy checkout still verifies (exit 0)"
+else
+  bad "3310-precheck-healthy: the pre-check reds a good root (exit $RC); output: $OUT"
+fi
+case "$OUT" in
+  *"$PROBE_UNMEASURED_MARKER"*) bad "3310-precheck-healthy: the pre-check tripped on a healthy checkout; output: $OUT" ;;
+  *) ok "3310-precheck-healthy: the pre-check does not trip" ;;
+esac
+case "$OUT" in
+  *"Tracked-fixture probe (#3310): OK"*) ok "3310-precheck-healthy: the clean verdict is still reached" ;;
+  *) bad "3310-precheck-healthy: no clean verdict; output: $OUT" ;;
+esac
+# ...and a rename that stays INSIDE the subtree is classifiable, so it must not
+# trip the boundary marker either (the pre-check is about the BOUNDARY, not about
+# renames as such — case 44 already pins the diff.renames=false half).
+R50B="$T/case50b-repo"
+make_repo "$R50B"
+make_usable_corpus "$R50B/test-data/datasets"
+git -C "$R50B" mv "test-data/datasets/goldens/simple_table-Data.db.jsonl" \
+                  "test-data/datasets/goldens/renamed-inside-Data.db.jsonl"
+run_verify "$R50B" "$R50B/test-data/datasets"
+if [ "$RC" -eq 0 ]; then
+  ok "3310-precheck-inside-rename: a rename INSIDE the subtree stays classifiable (exit 0)"
+else
+  bad "3310-precheck-inside-rename: false unmeasurable on an in-subtree rename (exit $RC); output: $OUT"
+fi
+
 # --- summary -----------------------------------------------------------------
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -1256,6 +1256,195 @@ resolve_tracked_subtree_readonly() {
   return 0
 }
 
+# True when a repo-relative path lies at or under the captured subtree. Compared
+# COMPONENT-WISE (the trailing slash), so `test-data/datasets-old` is not read as
+# inside `test-data/datasets` — the same rule as path_relative_inside.
+path_under_tracked_rel() {
+  case "$1" in
+    "${TRACKED_GUARD_REL}" | "${TRACKED_GUARD_REL}"/*) return 0 ;;
+  esac
+  return 1
+}
+
+# Order-preserving de-duplication of a path list into DEDUPED_PATHS (issue #3310
+# roborev round 4). `git ls-files` reports an UNMERGED path once per stage, so a
+# report built from it can name the same file three times. O(n²) is deliberate:
+# the input is the DELETED/unmerged set, and a portable, obviously-correct loop
+# beats a `sort -zu` pipeline whose NUL support is not universal on macOS.
+DEDUPED_PATHS=()
+dedupe_paths() {
+  local candidate existing seen
+  DEDUPED_PATHS=()
+  for candidate in "$@"; do
+    seen=0
+    for existing in ${DEDUPED_PATHS[@]+"${DEDUPED_PATHS[@]}"}; do
+      if [ "${existing}" = "${candidate}" ]; then
+        seen=1
+        break
+      fi
+    done
+    if [ "${seen}" = 0 ]; then
+      DEDUPED_PATHS+=( "${candidate}" )
+    fi
+  done
+}
+
+# Classify HEAD once, for every consumer of a staged (HEAD-vs-index) diff.
+#   0  HEAD resolves — staged diffs are meaningful
+#   1  CONFIRMED unborn — no commit exists, so no path can be deleted or renamed
+#      RELATIVE TO HEAD; a measured emptiness, not a skipped measurement
+#   2  COULD NOT MEASURE (reason in TRACKED_PROBE_REASON)
+#
+# A failing `rev-parse --verify HEAD` proves nothing on its own: a corrupt ref
+# fails identically to an unborn branch (roborev round 3). Unborn is therefore
+# CONFIRMED — HEAD is a symref to a branch AND that branch does not exist, which
+# `show-ref --verify` reports with exit status exactly 1 ("ref not found"); a
+# corrupt ref exits 128 and an unparseable HEAD fails `symbolic-ref` outright.
+# Exit codes verified against git 2.43 in all three states, not assumed.
+classify_head_state() {
+  local head_ref="" show_ref_rc=0
+  TRACKED_PROBE_REASON=""
+  if guard_git -C "${TRACKED_GUARD_REPO}" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+    return 0
+  fi
+  if head_ref="$(guard_git -C "${TRACKED_GUARD_REPO}" symbolic-ref -q HEAD 2>/dev/null)" \
+    && [ -n "${head_ref}" ]; then
+    guard_git -C "${TRACKED_GUARD_REPO}" show-ref --verify -q -- "${head_ref}" >/dev/null 2>&1 \
+      || show_ref_rc=$?
+  else
+    show_ref_rc=-1
+  fi
+  if [ "${show_ref_rc}" = 1 ]; then
+    return 1
+  fi
+  TRACKED_PROBE_REASON="HEAD in '${TRACKED_GUARD_REPO}' does not resolve and is NOT a confirmed unborn branch (symbolic-ref gave '${head_ref:-<none>}', show-ref status ${show_ref_rc}) — a corrupt or unreadable ref fails exactly like an unborn one, so staged changes cannot be ruled out"
+  return 2
+}
+
+# ---------------------------------------------------------------------------
+# UNCLASSIFIABLE GIT STATE: DECLARE, DO NOT CLASSIFY (issue #3310, roborev r4).
+#
+# Two states defeat the subtree-scoped census in the same way — not by producing a
+# wrong VERDICT, but by producing a CONFIDENT WRONG REPAIR:
+#   * a staged rename whose destination leaves the dataset subtree. The census
+#     pathspec hides the destination, so rename detection cannot fire and the old
+#     path looks deleted; the advertised "EXACTLY this command" would REVERSE
+#     intentional work.
+#   * an unmerged (conflict) index entry. `git restore --worktree` cannot rebuild a
+#     conflicted path — there is no single stage to restore from — so the promised
+#     repair simply fails, and `ls-files` lists the path once per stage.
+#
+# Modelling each state is how a probe accumulates confident wrong answers, so this
+# instead detects MARKERS of unclassifiable state and hands the verdict to the
+# existing COULD NOT MEASURE path, which prints NO repair command. An honest
+# unmeasurable beats a confident wrong repair.
+#
+# AFFIRMATIVE BY CONSTRUCTION: the clean branch is reached only after both marker
+# scans have RUN and reported nothing. Neither scan's failure is permitted to look
+# like "no marker" — a scan that cannot run returns 2, which is also COULD NOT
+# MEASURE. Nothing here infers classifiability from the absence of trouble.
+#
+#   0  measured: no unclassifiable-state marker under the subtree
+#   1  a marker was found (reason in TRACKED_PROBE_REASON)
+#   2  the pre-check itself could not run (reason in TRACKED_PROBE_REASON)
+# ---------------------------------------------------------------------------
+detect_unclassifiable_git_state() {
+  local scratch record path old new head_rc=0 shown
+  local -a unmerged=()
+  TRACKED_PROBE_REASON=""
+
+  # MARKER 1 — unmerged index entries under the subtree. Index-only, so it needs
+  # no HEAD and runs unconditionally. `-z` (unlike the destructive path's
+  # `ls-files -u` read at the top of this file, which is newline-framed): the
+  # records here are turned into report text, so they must be exact.
+  if ! scratch="$(mktemp "${TRACKED_GUARD_STATE_DIR}/cqlite-probe-unmerged.XXXXXX")"; then
+    TRACKED_PROBE_REASON="could not create a scratch file for the unmerged-entry scan"
+    return 2
+  fi
+  if ! guard_git -C "${TRACKED_GUARD_REPO}" ls-files -u -z -- ":(literal)${TRACKED_GUARD_REL}" >"${scratch}"; then
+    rm -f "${scratch}"
+    TRACKED_PROBE_REASON="'git ls-files -u' failed for '${TRACKED_GUARD_REL}' in '${TRACKED_GUARD_REPO}', so unmerged (conflicted) entries cannot be ruled out"
+    return 2
+  fi
+  # Records are "<mode> <sha> <stage>\t<path>"; the path follows the TAB.
+  while IFS= read -r -d '' record; do
+    case "${record}" in
+      *"$(printf '\t')"*) unmerged+=( "${record#*$'\t'}" ) ;;
+      *)
+        rm -f "${scratch}"
+        TRACKED_PROBE_REASON="unparseable 'git ls-files -u -z' record '${record}' for '${TRACKED_GUARD_REL}'"
+        return 2
+        ;;
+    esac
+  done <"${scratch}"
+  rm -f "${scratch}"
+  if [ "${#unmerged[@]}" -gt 0 ]; then
+    dedupe_paths "${unmerged[@]}"
+    shown="${#DEDUPED_PATHS[@]}"
+    [ "${shown}" -le 5 ] || shown=5
+    TRACKED_PROBE_REASON="${#DEDUPED_PATHS[@]} path(s) under '${TRACKED_GUARD_REL}' have UNMERGED (conflicted) index entries: $(printf '%s; ' "${DEDUPED_PATHS[@]:0:shown}")— a conflicted path has no single stage to restore from, so whether it is present, lost, or mid-resolution cannot be classified and 'git restore --worktree' could not repair it. Resolve or abort the merge first"
+    return 1
+  fi
+
+  # MARKER 2 — a staged rename CROSSING the subtree boundary. Detected on a
+  # WHOLE-REPO staged diff (no pathspec): restricting it to the subtree is exactly
+  # what hides the destination and defeats rename detection, so the marker scan
+  # must look wider than the census does.
+  classify_head_state || head_rc=$?
+  case "${head_rc}" in
+    0) ;;
+    1) return 0 ;;  # unborn: no staged rename can exist relative to a HEAD that does not exist
+    *) return 2 ;;  # TRACKED_PROBE_REASON already set
+  esac
+
+  if ! scratch="$(mktemp "${TRACKED_GUARD_STATE_DIR}/cqlite-probe-renames.XXXXXX")"; then
+    TRACKED_PROBE_REASON="could not create a scratch file for the boundary-rename scan"
+    return 2
+  fi
+  if ! guard_git -C "${TRACKED_GUARD_REPO}" --no-optional-locks diff --cached --name-status \
+    --find-renames -z >"${scratch}"; then
+    rm -f "${scratch}"
+    TRACKED_PROBE_REASON="'git diff --cached --name-status' failed in '${TRACKED_GUARD_REPO}', so a rename crossing the '${TRACKED_GUARD_REL}' boundary cannot be ruled out"
+    return 2
+  fi
+  # `--name-status -z` frames a plain change as "<status>\0<path>\0" and a
+  # rename/copy as "R<score>\0<old>\0<new>\0". A truncated record means the framing
+  # is not what is being parsed — refusing to guess is mandatory here.
+  while IFS= read -r -d '' record; do
+    case "${record}" in
+      R* | C*)
+        if ! IFS= read -r -d '' old || ! IFS= read -r -d '' new; then
+          rm -f "${scratch}"
+          TRACKED_PROBE_REASON="truncated 'git diff --cached --name-status -z' rename record '${record}' in '${TRACKED_GUARD_REPO}'"
+          return 2
+        fi
+        if path_under_tracked_rel "${old}" && ! path_under_tracked_rel "${new}"; then
+          rm -f "${scratch}"
+          TRACKED_PROBE_REASON="a staged RENAME moves '${old}' out of '${TRACKED_GUARD_REL}' to '${new}' — the census is scoped to '${TRACKED_GUARD_REL}', so within that scope the old path is indistinguishable from a deleted fixture, and a repair advertised for it would REVERSE the rename"
+          return 1
+        fi
+        if path_under_tracked_rel "${new}" && ! path_under_tracked_rel "${old}"; then
+          rm -f "${scratch}"
+          TRACKED_PROBE_REASON="a staged RENAME moves '${old}' into '${TRACKED_GUARD_REL}' as '${new}' — the census is scoped to '${TRACKED_GUARD_REL}', so the two halves of that rename cannot be related to each other within this scope"
+          return 1
+        fi
+        ;;
+      *)
+        if ! IFS= read -r -d '' path; then
+          rm -f "${scratch}"
+          TRACKED_PROBE_REASON="truncated 'git diff --cached --name-status -z' record '${record}' in '${TRACKED_GUARD_REPO}'"
+          return 2
+        fi
+        ;;
+    esac
+  done <"${scratch}"
+  rm -f "${scratch}"
+
+  # Both scans RAN and reported nothing. That — not the absence of an error — is
+  # what licenses the classifying census below.
+  return 0
+}
+
 # The COULD-NOT-MEASURE verdict, textually distinct from both the missing-fixture
 # report and guarantee_usable_root's "does not hold a usable dataset corpus".
 report_unmeasurable_tracked_census() {
@@ -1292,7 +1481,7 @@ print_scoped_repair_command() {
 # census could not be taken), 0 otherwise. Writes only outside the dataset root.
 report_orphaned_tracked_fixtures() {
   local resolve_rc=0 dataset_abs census_file tracked_count=0
-  local record tag path staged_file staged_present=0 shown=0 head_ref show_ref_rc
+  local record tag path staged_file staged_present=0 shown=0 precheck_rc head_rc
   local -a flagged_absent=() worktree_deleted=() staged_deleted=()
 
   resolve_tracked_subtree_readonly || resolve_rc=$?
@@ -1321,6 +1510,16 @@ report_orphaned_tracked_fixtures() {
     return 1
   fi
 
+  # (0) BEFORE classifying anything: refuse to classify a state this probe does not
+  # model (issue #3310, roborev round 4). Both outcomes route to the same
+  # COULD NOT MEASURE verdict, which prints NO repair command.
+  precheck_rc=0
+  detect_unclassifiable_git_state || precheck_rc=$?
+  if [ "${precheck_rc}" != 0 ]; then
+    report_unmeasurable_tracked_census "${TRACKED_PROBE_REASON}"
+    return 1
+  fi
+
   # (1) The INDEX census, WITH each entry's index flags, and an AFFIRMATIVE
   # per-path existence test (issue #3310, roborev blocker 2).
   #
@@ -1336,10 +1535,15 @@ report_orphaned_tracked_fixtures() {
     report_unmeasurable_tracked_census "could not create a scratch file for the tracked-file census"
     return 1
   fi
-  if ! guard_git -C "${TRACKED_GUARD_REPO}" ls-files -v -z -- ":(literal)${TRACKED_GUARD_REL}" >"${census_file}"; then
-    rm -f "${census_file}"
-    report_unmeasurable_tracked_census "'git ls-files -v' failed for '${TRACKED_GUARD_REL}' in '${TRACKED_GUARD_REPO}'"
-    return 1
+  # `--deduplicate` (git >= 2.31) so a path in a merge conflict is not counted once
+  # per stage; older git lacks the option, so retry without it and let the
+  # dedupe_paths pass below cover the difference.
+  if ! guard_git -C "${TRACKED_GUARD_REPO}" ls-files -v -z --deduplicate -- ":(literal)${TRACKED_GUARD_REL}" >"${census_file}" 2>/dev/null; then
+    if ! guard_git -C "${TRACKED_GUARD_REPO}" ls-files -v -z -- ":(literal)${TRACKED_GUARD_REL}" >"${census_file}"; then
+      rm -f "${census_file}"
+      report_unmeasurable_tracked_census "'git ls-files -v' failed for '${TRACKED_GUARD_REL}' in '${TRACKED_GUARD_REPO}'"
+      return 1
+    fi
   fi
   # NUL-delimited (`-z`) throughout: this repo tracks 40 space-bearing paths, and a
   # whitespace-split census would silently miscount or mangle them. Records are
@@ -1403,32 +1607,16 @@ report_orphaned_tracked_fixtures() {
   # staged rename report as `D` — a false missing-fixture error whose advertised
   # repair would REVERSE the rename. A correctness property may not depend on
   # ambient configuration.
-  if ! guard_git -C "${TRACKED_GUARD_REPO}" rev-parse --verify -q HEAD >/dev/null 2>&1; then
-    # HEAD did not resolve. That is NOT proof of an unborn branch — a corrupt or
-    # unreadable ref fails identically — and skipping the census on an unproven
-    # assumption is how a clean verdict gets issued for a state never measured
-    # (roborev round 3). So CONFIRM unborn positively, and route everything else to
-    # COULD NOT MEASURE:
-    #   unborn  ⇔  HEAD is a symref to a branch (symbolic-ref succeeds) AND that
-    #              branch does not exist (`show-ref --verify` exits exactly 1,
-    #              git's "ref not found"; a corrupt ref exits 128, and an
-    #              unparseable HEAD fails symbolic-ref outright).
-    # Verified against git 2.43 rather than assumed, in all three states.
-    head_ref=""
-    show_ref_rc=0
-    if head_ref="$(guard_git -C "${TRACKED_GUARD_REPO}" symbolic-ref -q HEAD 2>/dev/null)" \
-      && [ -n "${head_ref}" ]; then
-      guard_git -C "${TRACKED_GUARD_REPO}" show-ref --verify -q -- "${head_ref}" >/dev/null 2>&1 \
-        || show_ref_rc=$?
-    else
-      show_ref_rc=-1
-    fi
-    if [ "${show_ref_rc}" != 1 ]; then
-      report_unmeasurable_tracked_census "HEAD in '${TRACKED_GUARD_REPO}' does not resolve and is NOT a confirmed unborn branch (symbolic-ref gave '${head_ref:-<none>}', show-ref status ${show_ref_rc}) — a corrupt or unreadable ref fails exactly like an unborn one, so staged deletions cannot be ruled out"
-      return 1
-    fi
-    # CONFIRMED unborn: no commit exists, so no path can be deleted RELATIVE TO
-    # HEAD. This is a measured emptiness, not a skipped measurement.
+  head_rc=0
+  classify_head_state || head_rc=$?
+  if [ "${head_rc}" = 2 ]; then
+    report_unmeasurable_tracked_census "${TRACKED_PROBE_REASON}"
+    return 1
+  fi
+  if [ "${head_rc}" = 1 ]; then
+    # CONFIRMED unborn (classify_head_state proves it rather than inferring it from
+    # a failed rev-parse): no commit exists, so no path can be deleted RELATIVE TO
+    # HEAD. A measured emptiness, not a skipped measurement.
     :
   else
     if ! staged_file="$(mktemp "${TRACKED_GUARD_STATE_DIR}/cqlite-probe-staged.XXXXXX")"; then
@@ -1449,6 +1637,19 @@ report_orphaned_tracked_fixtures() {
       fi
     done <"${staged_file}"
     rm -f "${staged_file}"
+  fi
+
+  # Defensive de-duplication of both report arrays (roborev round 4). The
+  # `--deduplicate` census above covers the stage-duplication case on git >= 2.31;
+  # this covers the fallback, and makes "named exactly once" a property of the
+  # REPORT rather than of a git version.
+  if [ "${#worktree_deleted[@]}" -gt 0 ]; then
+    dedupe_paths "${worktree_deleted[@]}"
+    worktree_deleted=( ${DEDUPED_PATHS[@]+"${DEDUPED_PATHS[@]}"} )
+  fi
+  if [ "${#staged_deleted[@]}" -gt 0 ]; then
+    dedupe_paths "${staged_deleted[@]}"
+    staged_deleted=( ${DEDUPED_PATHS[@]+"${DEDUPED_PATHS[@]}"} )
   fi
 
   if [ "${#worktree_deleted[@]}" -gt 0 ] || [ "${#staged_deleted[@]}" -gt 0 ]; then

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -1264,12 +1264,36 @@ report_unmeasurable_tracked_census() {
   echo "ERROR: cannot report this root usable. Nothing was created, deleted or restored." >&2
 }
 
+# Print an `ERROR:   git -C <repo> restore <flags> -- <p1> <p2> …` line naming
+# EXACTLY the paths passed to it (issue #3310, roborev blocker 1).
+#
+# The first cut advertised `restore --worktree -- <the whole dataset subtree>`.
+# That is a DESTRUCTIVE one-liner: it reverts every local change under the root,
+# and `--verify-only` returns BEFORE refuse_modified_tracked_dataset_files, so at
+# this point nothing has ruled such a change out — the very silent-revert loss
+# #3245 exists to prevent, re-advertised by the tool that reports it.
+#
+# Every path is %q-quoted (this repo tracks 40 space-bearing paths; an unquoted
+# `spaced name-Data.db.jsonl` becomes two pathspecs, neither of which exists), and
+# the list is NEVER truncated: an elided path would leave the operator with a
+# command that repairs only part of the damage, and the temptation to "fix" that by
+# widening the pathspec back to the subtree is exactly the defect above.
+print_scoped_repair_command() {
+  local flags="$1" line path
+  shift
+  line="ERROR:   git -C $(printf '%q' "${TRACKED_GUARD_REPO}") restore ${flags} --"
+  for path in "$@"; do
+    line="${line} $(printf '%q' "${path}")"
+  done
+  printf '%s\n' "${line}" >&2
+}
+
 # The probe itself. Returns 1 when it must fail the run (fixtures missing, or the
 # census could not be taken), 0 otherwise. Writes only outside the dataset root.
 report_orphaned_tracked_fixtures() {
-  local resolve_rc=0 dataset_abs census_file tracked_count=0 rel_path
-  local scan_rc=0 entries record xy path staged_deletion=0 repair_flags shown=0
-  local -a deleted=()
+  local resolve_rc=0 dataset_abs census_file tracked_count=0
+  local record tag path scan_rc=0 entries xy staged_present=0 shown=0
+  local -a flagged=() worktree_deleted=() staged_deleted=()
 
   resolve_tracked_subtree_readonly || resolve_rc=$?
   case "${resolve_rc}" in
@@ -1286,8 +1310,8 @@ report_orphaned_tracked_fixtures() {
       ;;
   esac
 
-  # The status scan needs a scratch file, and --verify-only must not write inside
-  # the root it is probing — resolve_guard_state_dir PROVES a location outside it.
+  # The census needs a scratch file, and --verify-only must not write inside the
+  # root it is probing — resolve_guard_state_dir PROVES a location outside it.
   if ! dataset_abs="$(physical_path "${DATASET_ROOT}")"; then
     report_unmeasurable_tracked_census "could not resolve a physical path for '${DATASET_ROOT}'"
     return 1
@@ -1297,31 +1321,65 @@ report_orphaned_tracked_fixtures() {
     return 1
   fi
 
-  # (1) The INDEX census — how many tracked files the subtree is supposed to hold.
-  # Used ONLY to distinguish "no subject" from "all present"; it deliberately does
-  # NOT gate the status scan below, because `git ls-files` reads the index and so
-  # reports 0 precisely when every tracked path is staged-deleted — the state of
-  # maximum risk (the #3245 review blocker, in a new place).
+  # (1) The INDEX census, WITH each entry's index flags, and an AFFIRMATIVE
+  # per-path existence test (issue #3310, roborev blocker 2).
+  #
+  # Presence is established by STATTING each indexed path, never inferred from a
+  # count plus the ABSENCE of deletion entries in the status scan: git deliberately
+  # suppresses worktree-change reporting for skip-worktree (tag `S`) and
+  # assume-unchanged (any lowercase tag) entries, so such a file can be genuinely
+  # gone while every status oracle reports clean. Deriving a positive verdict from
+  # the absence of a bad signal is the shape CLAUDE.md flags; `ls-files -v` is the
+  # same oracle capture_tracked_dataset_files already uses against these flags, so
+  # this probe is not weaker than the code sitting above it.
   if ! census_file="$(mktemp "${TRACKED_GUARD_STATE_DIR}/cqlite-probe-census.XXXXXX")"; then
     report_unmeasurable_tracked_census "could not create a scratch file for the tracked-file census"
     return 1
   fi
-  if ! guard_git -C "${TRACKED_GUARD_REPO}" ls-files -z -- ":(literal)${TRACKED_GUARD_REL}" >"${census_file}"; then
+  if ! guard_git -C "${TRACKED_GUARD_REPO}" ls-files -v -z -- ":(literal)${TRACKED_GUARD_REL}" >"${census_file}"; then
     rm -f "${census_file}"
-    report_unmeasurable_tracked_census "'git ls-files' failed for '${TRACKED_GUARD_REL}' in '${TRACKED_GUARD_REPO}'"
+    report_unmeasurable_tracked_census "'git ls-files -v' failed for '${TRACKED_GUARD_REL}' in '${TRACKED_GUARD_REPO}'"
     return 1
   fi
   # NUL-delimited (`-z`) throughout: this repo tracks 40 space-bearing paths, and a
-  # whitespace-split census would silently miscount or mangle them.
-  while IFS= read -r -d '' rel_path; do
+  # whitespace-split census would silently miscount or mangle them. Records are
+  # "<tag> <path>"; the tag is a single character, so the path starts at offset 2.
+  while IFS= read -r -d '' record; do
+    tag="${record%% *}"
+    path="${record#* }"
     tracked_count=$((tracked_count + 1))
+    case "${tag}" in
+      S | [a-z])
+        # Sparse-excluded or assume-unchanged: on-disk absence is INTENTIONAL for a
+        # sparse checkout and invisible to every status oracle otherwise, and
+        # `git restore` cannot rebuild a sparse-excluded path — so its state is
+        # genuinely undeterminable here. Undeterminable is COULD NOT MEASURE, never
+        # a clean verdict (and never a fabricated "missing" either).
+        flagged+=( "${path}" )
+        continue
+        ;;
+    esac
+    # `-L` as well as `-e`: a tracked symlink whose target is absent is still
+    # PRESENT as a checked-out path, and calling it a missing fixture would be a
+    # false positive.
+    if [ ! -e "${TRACKED_GUARD_REPO}/${path}" ] && [ ! -L "${TRACKED_GUARD_REPO}/${path}" ]; then
+      worktree_deleted+=( "${path}" )
+    fi
   done <"${census_file}"
   rm -f "${census_file}"
 
-  # (2) The authority: the same porcelain oracle the #3245 guards use. Its `-z`
-  # git read is what makes space-bearing paths safe; its OUTPUT is one "XY <path>"
-  # per line, which is the helper's established contract (shared with
-  # refuse_modified_tracked_dataset_files and verify_tracked_status_clean_or_fail).
+  if [ "${#flagged[@]}" -gt 0 ]; then
+    shown="${#flagged[@]}"
+    [ "${shown}" -le 5 ] || shown=5
+    report_unmeasurable_tracked_census "${#flagged[@]} tracked path(s) under '${TRACKED_GUARD_REL}' carry index flags that hide their worktree state from git — SKIP-WORKTREE / sparse-checkout excluded (tag 'S') or ASSUME-UNCHANGED (lowercase tag): $(printf '%s; ' "${flagged[@]:0:shown}")— whether they are present on disk cannot be established, and 'git restore' could not rebuild a sparse-excluded one. Clear the flags (git update-index --no-skip-worktree --no-assume-unchanged), unsparse the path (git sparse-checkout), or point CQLITE_DATASETS_ROOT outside the affected area"
+    return 1
+  fi
+
+  # (2) STAGED deletions — the class the index walk above structurally cannot see:
+  # `git rm --cached` removes the index entry, so `ls-files` never lists the path.
+  # The porcelain oracle the #3245 guards use DOES report it (`D `), and it is the
+  # same helper rather than a second mechanism. Its output is one "XY <path>" per
+  # line, the helper's established contract.
   entries="$(tracked_dataset_dirty_entries)" || scan_rc=$?
   case "${scan_rc}" in
     0 | 2) ;;
@@ -1336,51 +1394,59 @@ report_orphaned_tracked_fixtures() {
       [ -n "${record}" ] || continue
       xy="${record:0:2}"
       path="${record:3}"
+      # X == 'D' is a staged deletion. A worktree-only deletion (' D', 'MD', 'RD',
+      # 'AD') is already covered by the index walk above — the path is still in the
+      # index — so taking it from here too would double-report it.
       case "${xy}" in
-        # Either half of the status pair reporting a deletion: ' D' (deleted in the
-        # worktree, the SIGKILL shape), 'D ' (staged deletion), 'DD'/'AD'/'MD'/'RD'.
-        D? | ?D) deleted+=( "${path}" ) ;;
+        D?) ;;
         *) continue ;;
       esac
-      case "${xy}" in
-        D?) staged_deletion=1 ;;
-      esac
+      if [ ! -e "${TRACKED_GUARD_REPO}/${path}" ] && [ ! -L "${TRACKED_GUARD_REPO}/${path}" ]; then
+        staged_deleted+=( "${path}" )
+      else
+        staged_present=$((staged_present + 1))
+      fi
     done <<EOF
 ${entries}
 EOF
   fi
 
-  if [ "${#deleted[@]}" -gt 0 ]; then
-    # `git restore --worktree` rebuilds a worktree deletion from the index; a
-    # STAGED deletion has no index entry left, so that spelling would silently do
-    # nothing and `--staged` is required. The printed line is chosen by
-    # MEASUREMENT rather than printing the broader form unconditionally, which
-    # would revert unrelated staged work under the same path.
-    repair_flags="--worktree"
-    [ "${staged_deletion}" = 1 ] && repair_flags="--staged --worktree"
-
-    echo "ERROR: TRACKED FIXTURES MISSING under '${TRACKED_GUARD_REL}' (issue #3310): ${#deleted[@]} git-tracked" >&2
+  if [ "${#worktree_deleted[@]}" -gt 0 ] || [ "${#staged_deleted[@]}" -gt 0 ]; then
+    shown=$(( ${#worktree_deleted[@]} + ${#staged_deleted[@]} ))
+    echo "ERROR: TRACKED FIXTURES MISSING under '${TRACKED_GUARD_REL}' (issue #3310): ${shown} git-tracked" >&2
     echo "ERROR: file(s) recorded in git are DELETED on disk. This is NOT the 'does not hold a" >&2
     echo "ERROR: usable dataset corpus' condition — the fetched corpus may be perfectly fine." >&2
     echo "ERROR: A fetch killed with SIGKILL outruns the #2878 EXIT/INT/TERM/HUP restore and" >&2
     echo "ERROR: leaves exactly this state." >&2
-    echo "ERROR: missing tracked file(s):" >&2
-    for path in "${deleted[@]}"; do
-      shown=$((shown + 1))
-      [ "${shown}" -le 20 ] || break
-      echo "ERROR:   ${path}" >&2
-    done
-    if [ "${#deleted[@]}" -gt 20 ]; then
-      echo "ERROR:   … and $(( ${#deleted[@]} - 20 )) more" >&2
-    fi
     echo "ERROR: --verify-only REPORTS ONLY (issue #3310): nothing was created, deleted or" >&2
-    echo "ERROR: restored. Repair with EXACTLY this command:" >&2
-    # %q for the same reason as guarantee_usable_root's remedy line: a path holding
-    # a space or a shell metacharacter must still paste as a working command.
-    # shellcheck disable=SC2059  # %q is the point; the values are arguments, not the format
-    printf 'ERROR:   git -C %q restore %s -- %q\n' \
-      "${TRACKED_GUARD_REPO}" "${repair_flags}" "${TRACKED_GUARD_REL}" >&2
+    echo "ERROR: restored. Repair with EXACTLY the command(s) below — each names only the" >&2
+    echo "ERROR: paths that are actually missing, so nothing else in your tree is touched." >&2
+    if [ "${#worktree_deleted[@]}" -gt 0 ]; then
+      echo "ERROR: ${#worktree_deleted[@]} deleted from the WORKTREE (still in the index):" >&2
+      for path in "${worktree_deleted[@]}"; do
+        echo "ERROR:   ${path}" >&2
+      done
+      print_scoped_repair_command "--worktree" "${worktree_deleted[@]}"
+    fi
+    if [ "${#staged_deleted[@]}" -gt 0 ]; then
+      # A staged deletion has NO index entry left, so `restore --worktree` alone has
+      # nothing to rebuild from and silently no-ops; `--staged` puts the HEAD entry
+      # back first. Emitted as its OWN command so the worktree class is not widened
+      # to `--staged` (which would also unstage unrelated intentional removals).
+      echo "ERROR: ${#staged_deleted[@]} deleted from the INDEX and the worktree (staged deletion):" >&2
+      for path in "${staged_deleted[@]}"; do
+        echo "ERROR:   ${path}" >&2
+      done
+      print_scoped_repair_command "--staged --worktree" "${staged_deleted[@]}"
+    fi
     return 1
+  fi
+
+  # A measured signal is never dropped silently: a staged deletion whose content is
+  # still on disk is NOT a missing fixture (nothing is absent), but it is the state
+  # in which a fetch would lose that content for good (#3245), so it is reported.
+  if [ "${staged_present}" -gt 0 ]; then
+    echo "NOTE: ${staged_present} tracked path(s) under '${TRACKED_GUARD_REL}' carry a STAGED DELETION but their content is still on disk — nothing is missing, but a fetch would delete content the index can no longer rebuild (#3245)"
   fi
 
   if [ "${tracked_count}" -eq 0 ]; then
@@ -1388,7 +1454,7 @@ EOF
     return 0
   fi
 
-  echo "Tracked-fixture probe (#3310): OK — all ${tracked_count} git-tracked file(s) under '${TRACKED_GUARD_REL}' are present on disk"
+  echo "Tracked-fixture probe (#3310): OK — all ${tracked_count} git-tracked file(s) under '${TRACKED_GUARD_REL}' are present on disk (each stat'ed individually)"
   return 0
 }
 

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -1292,8 +1292,8 @@ print_scoped_repair_command() {
 # census could not be taken), 0 otherwise. Writes only outside the dataset root.
 report_orphaned_tracked_fixtures() {
   local resolve_rc=0 dataset_abs census_file tracked_count=0
-  local record tag path staged_file staged_present=0 shown=0
-  local -a flagged=() worktree_deleted=() staged_deleted=()
+  local record tag path staged_file staged_present=0 shown=0 head_ref show_ref_rc
+  local -a flagged_absent=() worktree_deleted=() staged_deleted=()
 
   resolve_tracked_subtree_readonly || resolve_rc=$?
   case "${resolve_rc}" in
@@ -1348,30 +1348,38 @@ report_orphaned_tracked_fixtures() {
     tag="${record%% *}"
     path="${record#* }"
     tracked_count=$((tracked_count + 1))
-    case "${tag}" in
-      S | [a-z])
-        # Sparse-excluded or assume-unchanged: on-disk absence is INTENTIONAL for a
-        # sparse checkout and invisible to every status oracle otherwise, and
-        # `git restore` cannot rebuild a sparse-excluded path — so its state is
-        # genuinely undeterminable here. Undeterminable is COULD NOT MEASURE, never
-        # a clean verdict (and never a fabricated "missing" either).
-        flagged+=( "${path}" )
-        continue
-        ;;
-    esac
+    # PRESENCE IS TESTED FIRST, index flags second (roborev round 3). skip-worktree
+    # and assume-unchanged hide a path from git's STATUS machinery; they do not
+    # stop this direct filesystem test, so a flagged path that demonstrably EXISTS
+    # has a determinable state and is simply PRESENT. Refusing on the flag alone
+    # turned --verify-only red on an intact checkout that merely carries one.
+    #
     # `-L` as well as `-e`: a tracked symlink whose target is absent is still
     # PRESENT as a checked-out path, and calling it a missing fixture would be a
     # false positive.
-    if [ ! -e "${TRACKED_GUARD_REPO}/${path}" ] && [ ! -L "${TRACKED_GUARD_REPO}/${path}" ]; then
-      worktree_deleted+=( "${path}" )
+    if [ -e "${TRACKED_GUARD_REPO}/${path}" ] || [ -L "${TRACKED_GUARD_REPO}/${path}" ]; then
+      continue
     fi
+    case "${tag}" in
+      S | [a-z])
+        # ABSENT *and* flagged is the genuinely ambiguous case: for a sparse
+        # checkout the absence is INTENTIONAL, for a lost fixture it is damage, and
+        # git reports neither — nor could `git restore` rebuild a sparse-excluded
+        # path. Undeterminable is COULD NOT MEASURE, never a clean verdict, and
+        # never a fabricated "missing" either.
+        flagged_absent+=( "${path}" )
+        ;;
+      *)
+        worktree_deleted+=( "${path}" )
+        ;;
+    esac
   done <"${census_file}"
   rm -f "${census_file}"
 
-  if [ "${#flagged[@]}" -gt 0 ]; then
-    shown="${#flagged[@]}"
+  if [ "${#flagged_absent[@]}" -gt 0 ]; then
+    shown="${#flagged_absent[@]}"
     [ "${shown}" -le 5 ] || shown=5
-    report_unmeasurable_tracked_census "${#flagged[@]} tracked path(s) under '${TRACKED_GUARD_REL}' carry index flags that hide their worktree state from git — SKIP-WORKTREE / sparse-checkout excluded (tag 'S') or ASSUME-UNCHANGED (lowercase tag): $(printf '%s; ' "${flagged[@]:0:shown}")— whether they are present on disk cannot be established, and 'git restore' could not rebuild a sparse-excluded one. Clear the flags (git update-index --no-skip-worktree --no-assume-unchanged), unsparse the path (git sparse-checkout), or point CQLITE_DATASETS_ROOT outside the affected area"
+    report_unmeasurable_tracked_census "${#flagged_absent[@]} tracked path(s) under '${TRACKED_GUARD_REL}' are ABSENT on disk AND carry index flags that hide their worktree state from git — SKIP-WORKTREE / sparse-checkout excluded (tag 'S') or ASSUME-UNCHANGED (lowercase tag): $(printf '%s; ' "${flagged_absent[@]:0:shown}")— so whether they are legitimately excluded from this checkout or LOST cannot be established, and 'git restore' could not rebuild a sparse-excluded one either. Clear the flags (git update-index --no-skip-worktree --no-assume-unchanged), unsparse the path (git sparse-checkout), or point CQLITE_DATASETS_ROOT outside the affected area"
     return 1
   fi
 
@@ -1390,12 +1398,37 @@ report_orphaned_tracked_fixtures() {
   # anywhere between git and the emitted command.
   #
   # `--diff-filter=D` over HEAD..index is exactly the porcelain `D ` class, and
-  # rename detection stays ON (the default): a staged rename reports `R`, so the
-  # old path is not mistaken for a lost fixture.
+  # `--find-renames` is passed EXPLICITLY (roborev round 3): rename detection is
+  # only the default, so `diff.renames=false` in a repo or user config would make a
+  # staged rename report as `D` — a false missing-fixture error whose advertised
+  # repair would REVERSE the rename. A correctness property may not depend on
+  # ambient configuration.
   if ! guard_git -C "${TRACKED_GUARD_REPO}" rev-parse --verify -q HEAD >/dev/null 2>&1; then
-    # An UNBORN HEAD cannot have a deletion relative to HEAD — an affirmative
-    # reason to skip, not an unmeasured assumption. (`git diff --cached` would
-    # fail outright here, which must not read as "no staged deletions".)
+    # HEAD did not resolve. That is NOT proof of an unborn branch — a corrupt or
+    # unreadable ref fails identically — and skipping the census on an unproven
+    # assumption is how a clean verdict gets issued for a state never measured
+    # (roborev round 3). So CONFIRM unborn positively, and route everything else to
+    # COULD NOT MEASURE:
+    #   unborn  ⇔  HEAD is a symref to a branch (symbolic-ref succeeds) AND that
+    #              branch does not exist (`show-ref --verify` exits exactly 1,
+    #              git's "ref not found"; a corrupt ref exits 128, and an
+    #              unparseable HEAD fails symbolic-ref outright).
+    # Verified against git 2.43 rather than assumed, in all three states.
+    head_ref=""
+    show_ref_rc=0
+    if head_ref="$(guard_git -C "${TRACKED_GUARD_REPO}" symbolic-ref -q HEAD 2>/dev/null)" \
+      && [ -n "${head_ref}" ]; then
+      guard_git -C "${TRACKED_GUARD_REPO}" show-ref --verify -q -- "${head_ref}" >/dev/null 2>&1 \
+        || show_ref_rc=$?
+    else
+      show_ref_rc=-1
+    fi
+    if [ "${show_ref_rc}" != 1 ]; then
+      report_unmeasurable_tracked_census "HEAD in '${TRACKED_GUARD_REPO}' does not resolve and is NOT a confirmed unborn branch (symbolic-ref gave '${head_ref:-<none>}', show-ref status ${show_ref_rc}) — a corrupt or unreadable ref fails exactly like an unborn one, so staged deletions cannot be ruled out"
+      return 1
+    fi
+    # CONFIRMED unborn: no commit exists, so no path can be deleted RELATIVE TO
+    # HEAD. This is a measured emptiness, not a skipped measurement.
     :
   else
     if ! staged_file="$(mktemp "${TRACKED_GUARD_STATE_DIR}/cqlite-probe-staged.XXXXXX")"; then
@@ -1403,7 +1436,7 @@ report_orphaned_tracked_fixtures() {
       return 1
     fi
     if ! guard_git -C "${TRACKED_GUARD_REPO}" --no-optional-locks diff --cached --name-only \
-      --diff-filter=D -z -- ":(literal)${TRACKED_GUARD_REL}" >"${staged_file}"; then
+      --find-renames --diff-filter=D -z -- ":(literal)${TRACKED_GUARD_REL}" >"${staged_file}"; then
       rm -f "${staged_file}"
       report_unmeasurable_tracked_census "'git diff --cached --diff-filter=D' failed for '${TRACKED_GUARD_REL}' in '${TRACKED_GUARD_REPO}', so staged deletions cannot be ruled out"
       return 1

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -1168,6 +1168,230 @@ guarantee_usable_root() {
   echo "NOTE: checkout-relative — not fetched here and not a sibling of this root (#3148)."
 }
 
+# ---------------------------------------------------------------------------
+# --verify-only tracked-fixture probe (issue #3310) — REPORT ONLY, NEVER REPAIR.
+#
+# The #2878 crash-safe restore covers EXIT/INT/TERM/HUP. SIGKILL outruns all of
+# them, so a killed fetch can leave git-tracked fixtures DELETED on disk with the
+# index still recording them. Recovery does exist — the DESTRUCTIVE path's
+# `restore_tracked_dataset_files missing-only` pre-flight — but `--verify-only`
+# exits above it, so the documented "is my root usable?" probe answered either a
+# clean green (corpus intact, fixtures gone) or the generic "does not hold a usable
+# dataset corpus" (corpus gone too), and neither names the actual damage or its
+# one-line repair. The first diagnostic an agent reaches for therefore misled.
+#
+# DESIGN DECISION, recorded in #3310 and enforced here structurally: this probe
+# REPORTS, it does not repair. `--verify-only` promises to mutate nothing (#3131
+# blocker B2), and a probe that quietly fixed the tree would be a second,
+# unannounced destructive-adjacent path in the one mode operators trust to be
+# inert. It therefore names the files, prints the exact repair command, and exits
+# non-zero; the repair is the operator's (or the next real fetch's) to run.
+# ---------------------------------------------------------------------------
+
+# Locate the (repository, subtree) pair a tracked census would apply to, using the
+# SAME git plumbing as capture_tracked_dataset_files but with NONE of its
+# refusals: every refuse_* there is a statement about a `rm -rf` that this mode
+# never performs, and printing "refusing to replace ..." from a read-only probe
+# would be false. Sets TRACKED_GUARD_REPO/TRACKED_GUARD_REL on success.
+#
+#   0  in-repo — REPO/REL are valid
+#   1  provably OUTSIDE any git work tree; the probe has NO SUBJECT
+#   2  COULD NOT MEASURE; the reason is in TRACKED_PROBE_REASON
+#
+# The reason travels in a GLOBAL rather than on stdout because this function
+# PUBLISHES globals: `reason="$(resolve_tracked_subtree_readonly)"` would run it in
+# a subshell, and TRACKED_GUARD_REPO/REL would be discarded with it — an empty REL
+# then makes the `:(literal)` pathspec match the WHOLE repository, so the probe
+# would census (and report on) every tracked file in the checkout.
+#
+# The `1` verdict is an affirmative proof (git says there is no work tree, or —
+# when git is absent — no ancestor carries a `.git`), never a fallback for an
+# unanswered question: that distinction is the whole point of the `2` verdict.
+TRACKED_PROBE_REASON=""
+resolve_tracked_subtree_readonly() {
+  local dataset_abs probe repo_root repo_root_phys rel
+  TRACKED_PROBE_REASON=""
+  TRACKED_GUARD_REPO=""
+  TRACKED_GUARD_REL=""
+
+  if ! dataset_abs="$(physical_path "${DATASET_ROOT}")"; then
+    TRACKED_PROBE_REASON="could not resolve a physical path for '${DATASET_ROOT}'"
+    return 2
+  fi
+
+  if ! command -v git >/dev/null 2>&1; then
+    if ancestor_has_git_dir "${dataset_abs}"; then
+      TRACKED_PROBE_REASON="git is not installed, but '${dataset_abs}' is inside a git checkout, so its tracked files cannot be enumerated"
+      return 2
+    fi
+    return 1
+  fi
+
+  probe="$(nearest_existing_dir "${dataset_abs}")"
+  if ! repo_root="$(guard_git -C "${probe}" rev-parse --show-toplevel 2>/dev/null)" || [ -z "${repo_root}" ]; then
+    if ancestor_has_git_dir "${dataset_abs}"; then
+      TRACKED_PROBE_REASON="'${dataset_abs}' looks like it is inside a git checkout, but 'git -C ${probe} rev-parse --show-toplevel' reported no work tree"
+      return 2
+    fi
+    return 1
+  fi
+
+  if ! repo_root_phys="$(physical_path "${repo_root}")"; then
+    TRACKED_PROBE_REASON="could not resolve a physical path for the enclosing repository '${repo_root}'"
+    return 2
+  fi
+
+  if ! rel="$(path_relative_inside "${repo_root_phys}" "${dataset_abs}")"; then
+    TRACKED_PROBE_REASON="could not decide whether '${dataset_abs}' is inside the git work tree at '${repo_root_phys}' (probed from '${probe}')"
+    return 2
+  fi
+
+  if [ "${rel}" = "." ]; then
+    TRACKED_PROBE_REASON="'${dataset_abs}' IS the root of the git work tree at '${repo_root_phys}', so a tracked census there would cover the whole repository rather than a fixture subtree"
+    return 2
+  fi
+
+  TRACKED_GUARD_REPO="${repo_root_phys}"
+  TRACKED_GUARD_REL="${rel}"
+  return 0
+}
+
+# The COULD-NOT-MEASURE verdict, textually distinct from both the missing-fixture
+# report and guarantee_usable_root's "does not hold a usable dataset corpus".
+report_unmeasurable_tracked_census() {
+  echo "ERROR: TRACKED-FIXTURE PROBE COULD NOT MEASURE '${DATASET_ROOT}' (issue #3310): $1" >&2
+  echo "ERROR: an unmeasured tracked-fixture census is NOT a clean one, so --verify-only" >&2
+  echo "ERROR: cannot report this root usable. Nothing was created, deleted or restored." >&2
+}
+
+# The probe itself. Returns 1 when it must fail the run (fixtures missing, or the
+# census could not be taken), 0 otherwise. Writes only outside the dataset root.
+report_orphaned_tracked_fixtures() {
+  local resolve_rc=0 dataset_abs census_file tracked_count=0 rel_path
+  local scan_rc=0 entries record xy path staged_deletion=0 repair_flags shown=0
+  local -a deleted=()
+
+  resolve_tracked_subtree_readonly || resolve_rc=$?
+  case "${resolve_rc}" in
+    0) ;;
+    1)
+      # No subject — and said as such. A "0 of 0 clean" verdict here would be a
+      # positive claim about a census that has no subject to take (#3310).
+      echo "Tracked-fixture probe (#3310): NO SUBJECT — '${DATASET_ROOT}' lies outside any git work tree, so no git-tracked fixture can be missing from it"
+      return 0
+      ;;
+    *)
+      report_unmeasurable_tracked_census "${TRACKED_PROBE_REASON}"
+      return 1
+      ;;
+  esac
+
+  # The status scan needs a scratch file, and --verify-only must not write inside
+  # the root it is probing — resolve_guard_state_dir PROVES a location outside it.
+  if ! dataset_abs="$(physical_path "${DATASET_ROOT}")"; then
+    report_unmeasurable_tracked_census "could not resolve a physical path for '${DATASET_ROOT}'"
+    return 1
+  fi
+  if ! TRACKED_GUARD_STATE_DIR="$(resolve_guard_state_dir "${dataset_abs}")"; then
+    report_unmeasurable_tracked_census "no writable temporary directory (of TMPDIR, /tmp, HOME) could be PROVEN to lie outside '${dataset_abs}', so the census could not be taken without writing inside the root this probe promises not to touch"
+    return 1
+  fi
+
+  # (1) The INDEX census — how many tracked files the subtree is supposed to hold.
+  # Used ONLY to distinguish "no subject" from "all present"; it deliberately does
+  # NOT gate the status scan below, because `git ls-files` reads the index and so
+  # reports 0 precisely when every tracked path is staged-deleted — the state of
+  # maximum risk (the #3245 review blocker, in a new place).
+  if ! census_file="$(mktemp "${TRACKED_GUARD_STATE_DIR}/cqlite-probe-census.XXXXXX")"; then
+    report_unmeasurable_tracked_census "could not create a scratch file for the tracked-file census"
+    return 1
+  fi
+  if ! guard_git -C "${TRACKED_GUARD_REPO}" ls-files -z -- ":(literal)${TRACKED_GUARD_REL}" >"${census_file}"; then
+    rm -f "${census_file}"
+    report_unmeasurable_tracked_census "'git ls-files' failed for '${TRACKED_GUARD_REL}' in '${TRACKED_GUARD_REPO}'"
+    return 1
+  fi
+  # NUL-delimited (`-z`) throughout: this repo tracks 40 space-bearing paths, and a
+  # whitespace-split census would silently miscount or mangle them.
+  while IFS= read -r -d '' rel_path; do
+    tracked_count=$((tracked_count + 1))
+  done <"${census_file}"
+  rm -f "${census_file}"
+
+  # (2) The authority: the same porcelain oracle the #3245 guards use. Its `-z`
+  # git read is what makes space-bearing paths safe; its OUTPUT is one "XY <path>"
+  # per line, which is the helper's established contract (shared with
+  # refuse_modified_tracked_dataset_files and verify_tracked_status_clean_or_fail).
+  entries="$(tracked_dataset_dirty_entries)" || scan_rc=$?
+  case "${scan_rc}" in
+    0 | 2) ;;
+    *)
+      report_unmeasurable_tracked_census "${entries}"
+      return 1
+      ;;
+  esac
+
+  if [ "${scan_rc}" = 2 ]; then
+    while IFS= read -r record; do
+      [ -n "${record}" ] || continue
+      xy="${record:0:2}"
+      path="${record:3}"
+      case "${xy}" in
+        # Either half of the status pair reporting a deletion: ' D' (deleted in the
+        # worktree, the SIGKILL shape), 'D ' (staged deletion), 'DD'/'AD'/'MD'/'RD'.
+        D? | ?D) deleted+=( "${path}" ) ;;
+        *) continue ;;
+      esac
+      case "${xy}" in
+        D?) staged_deletion=1 ;;
+      esac
+    done <<EOF
+${entries}
+EOF
+  fi
+
+  if [ "${#deleted[@]}" -gt 0 ]; then
+    # `git restore --worktree` rebuilds a worktree deletion from the index; a
+    # STAGED deletion has no index entry left, so that spelling would silently do
+    # nothing and `--staged` is required. The printed line is chosen by
+    # MEASUREMENT rather than printing the broader form unconditionally, which
+    # would revert unrelated staged work under the same path.
+    repair_flags="--worktree"
+    [ "${staged_deletion}" = 1 ] && repair_flags="--staged --worktree"
+
+    echo "ERROR: TRACKED FIXTURES MISSING under '${TRACKED_GUARD_REL}' (issue #3310): ${#deleted[@]} git-tracked" >&2
+    echo "ERROR: file(s) recorded in git are DELETED on disk. This is NOT the 'does not hold a" >&2
+    echo "ERROR: usable dataset corpus' condition — the fetched corpus may be perfectly fine." >&2
+    echo "ERROR: A fetch killed with SIGKILL outruns the #2878 EXIT/INT/TERM/HUP restore and" >&2
+    echo "ERROR: leaves exactly this state." >&2
+    echo "ERROR: missing tracked file(s):" >&2
+    for path in "${deleted[@]}"; do
+      shown=$((shown + 1))
+      [ "${shown}" -le 20 ] || break
+      echo "ERROR:   ${path}" >&2
+    done
+    if [ "${#deleted[@]}" -gt 20 ]; then
+      echo "ERROR:   … and $(( ${#deleted[@]} - 20 )) more" >&2
+    fi
+    echo "ERROR: --verify-only REPORTS ONLY (issue #3310): nothing was created, deleted or" >&2
+    echo "ERROR: restored. Repair with EXACTLY this command:" >&2
+    # %q for the same reason as guarantee_usable_root's remedy line: a path holding
+    # a space or a shell metacharacter must still paste as a working command.
+    # shellcheck disable=SC2059  # %q is the point; the values are arguments, not the format
+    printf 'ERROR:   git -C %q restore %s -- %q\n' \
+      "${TRACKED_GUARD_REPO}" "${repair_flags}" "${TRACKED_GUARD_REL}" >&2
+    return 1
+  fi
+
+  if [ "${tracked_count}" -eq 0 ]; then
+    echo "Tracked-fixture probe (#3310): NO SUBJECT — the git work tree at '${TRACKED_GUARD_REPO}' tracks no file under '${TRACKED_GUARD_REL}', so none can be missing"
+    return 0
+  fi
+
+  echo "Tracked-fixture probe (#3310): OK — all ${tracked_count} git-tracked file(s) under '${TRACKED_GUARD_REL}' are present on disk"
+  return 0
+}
+
 # --verify-only (issue #3131): report whether the resolved root is usable and print the
 # guaranteed export line, WITHOUT downloading, extracting, removing or re-pinning
 # anything. Two reasons this exists rather than being a pure internal:
@@ -1181,6 +1405,11 @@ guarantee_usable_root() {
 # script, before any filesystem work; canonicalize_dataset_root honors VERIFY_ONLY by
 # never creating the parent directory.
 if [ "${VERIFY_ONLY}" = 1 ]; then
+  # BEFORE guarantee_usable_root, deliberately (issue #3310): with the corpus also
+  # gone, the content check would exit first and answer "root unusable", sending an
+  # operator to a re-fetch instead of to the one-line restore. The more specific
+  # diagnosis has to be the one that speaks.
+  report_orphaned_tracked_fixtures || exit 1
   guarantee_usable_root "verify-only (no download, no extraction)"
   exit 0
 fi

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -1292,7 +1292,7 @@ print_scoped_repair_command() {
 # census could not be taken), 0 otherwise. Writes only outside the dataset root.
 report_orphaned_tracked_fixtures() {
   local resolve_rc=0 dataset_abs census_file tracked_count=0
-  local record tag path scan_rc=0 entries xy staged_present=0 shown=0
+  local record tag path staged_file staged_present=0 shown=0
   local -a flagged=() worktree_deleted=() staged_deleted=()
 
   resolve_tracked_subtree_readonly || resolve_rc=$?
@@ -1377,38 +1377,45 @@ report_orphaned_tracked_fixtures() {
 
   # (2) STAGED deletions — the class the index walk above structurally cannot see:
   # `git rm --cached` removes the index entry, so `ls-files` never lists the path.
-  # The porcelain oracle the #3245 guards use DOES report it (`D `), and it is the
-  # same helper rather than a second mechanism. Its output is one "XY <path>" per
-  # line, the helper's established contract.
-  entries="$(tracked_dataset_dirty_entries)" || scan_rc=$?
-  case "${scan_rc}" in
-    0 | 2) ;;
-    *)
-      report_unmeasurable_tracked_census "${entries}"
+  #
+  # Read NUL-delimited, DIRECTLY from git (issue #3310, roborev round 2). The
+  # earlier cut consumed tracked_dataset_dirty_entries, whose git read IS `-z`
+  # (so, measured: space-bearing and non-ASCII paths arrive verbatim — `-z`
+  # disables porcelain's C-quoting) but whose RETURN VALUE is newline-JOINED. That
+  # framing is sound for its own callers, which only count entries and `head -3`
+  # them, and unsound here: a path containing a NEWLINE splits into two records, so
+  # the probe reports a TRUNCATED path and then advertises an "EXACTLY this
+  # command" repair naming a file that does not exist. Every path-reading git
+  # command in this function is therefore `-z`, end to end, with no line framing
+  # anywhere between git and the emitted command.
+  #
+  # `--diff-filter=D` over HEAD..index is exactly the porcelain `D ` class, and
+  # rename detection stays ON (the default): a staged rename reports `R`, so the
+  # old path is not mistaken for a lost fixture.
+  if ! guard_git -C "${TRACKED_GUARD_REPO}" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+    # An UNBORN HEAD cannot have a deletion relative to HEAD — an affirmative
+    # reason to skip, not an unmeasured assumption. (`git diff --cached` would
+    # fail outright here, which must not read as "no staged deletions".)
+    :
+  else
+    if ! staged_file="$(mktemp "${TRACKED_GUARD_STATE_DIR}/cqlite-probe-staged.XXXXXX")"; then
+      report_unmeasurable_tracked_census "could not create a scratch file for the staged-deletion scan"
       return 1
-      ;;
-  esac
-
-  if [ "${scan_rc}" = 2 ]; then
-    while IFS= read -r record; do
-      [ -n "${record}" ] || continue
-      xy="${record:0:2}"
-      path="${record:3}"
-      # X == 'D' is a staged deletion. A worktree-only deletion (' D', 'MD', 'RD',
-      # 'AD') is already covered by the index walk above — the path is still in the
-      # index — so taking it from here too would double-report it.
-      case "${xy}" in
-        D?) ;;
-        *) continue ;;
-      esac
+    fi
+    if ! guard_git -C "${TRACKED_GUARD_REPO}" --no-optional-locks diff --cached --name-only \
+      --diff-filter=D -z -- ":(literal)${TRACKED_GUARD_REL}" >"${staged_file}"; then
+      rm -f "${staged_file}"
+      report_unmeasurable_tracked_census "'git diff --cached --diff-filter=D' failed for '${TRACKED_GUARD_REL}' in '${TRACKED_GUARD_REPO}', so staged deletions cannot be ruled out"
+      return 1
+    fi
+    while IFS= read -r -d '' path; do
       if [ ! -e "${TRACKED_GUARD_REPO}/${path}" ] && [ ! -L "${TRACKED_GUARD_REPO}/${path}" ]; then
         staged_deleted+=( "${path}" )
       else
         staged_present=$((staged_present + 1))
       fi
-    done <<EOF
-${entries}
-EOF
+    done <"${staged_file}"
+    rm -f "${staged_file}"
   fi
 
   if [ "${#worktree_deleted[@]}" -gt 0 ] || [ "${#staged_deleted[@]}" -gt 0 ]; then

--- a/website/src/content/docs/agents-developing/test-data.md
+++ b/website/src/content/docs/agents-developing/test-data.md
@@ -51,6 +51,16 @@ unrecognized argument is rejected with exit 2**, deliberately: the script's defa
 destructive (`rm -rf` on the dataset root), so a typo like `-verify-only` must never
 silently select it.
 
+It also **reports** git-tracked fixtures that are missing from the root (issue #3310). A fetch
+killed with `SIGKILL` outruns the crash-safe restore and leaves tracked fixtures deleted while
+the index still records them; `--verify-only` names each one, prints the exact
+`git -C <repo> restore --worktree -- <path>` repair, and exits non-zero — a diagnostic
+deliberately distinct from the generic "does not hold a usable dataset corpus". It **reports,
+it never repairs**: the mode's promise to mutate nothing is absolute. A root outside any git
+work tree (the usual `/data/datasets` layout) has no tracked files, so the probe says it had
+`NO SUBJECT` rather than claiming a clean census of nothing; a census it could not take is
+reported as `COULD NOT MEASURE`, never as "nothing missing".
+
 ## Dataset pins
 
 The fetch script uses these defaults (override with environment variables):


### PR DESCRIPTION
Closes #3310.

## What this does

`test-data/scripts/fetch-datasets.sh --verify-only` is the documented non-destructive "is my root
usable?" probe. A fetch killed with `SIGKILL` outruns the #2878 EXIT/INT/TERM/HUP restore and leaves
git-tracked fixtures deleted while the index still records them; recovery existed only in the
DESTRUCTIVE path's pre-flight, which `--verify-only` returns before. So the first diagnostic an agent
reached for answered "root unusable" (or, with the corpus intact, a clean green) for a checkout whose
tracked fixtures were gone.

**AC1** — `--verify-only` now **REPORTS, never repairs**: it names each missing tracked fixture, prints a
**path-scoped** repair command (worktree vs staged deletions get separate, correct commands, each path
`printf '%q'`-quoted), exits non-zero, and mutates nothing. Three distinct verdicts, so an unmeasurable
state can never read as clean: missing / `NO SUBJECT` (root outside any git work tree) /
`COULD NOT MEASURE`.

**AC2** — `scripts/tests/test_fetch_datasets_tracked_guard.sh` is now pinned by `required`. The step was
added to **`pr-gate-core`**, the job `required` does `needs:` on — deliberately NOT to
`ci.yml flow-tooling-tests` (that job is `ci:broad`-label-gated AND `ci.yml` is a registry `exempt:`
workflow, so it can never gate a merge) and NOT as a new tier (no new always-emitting context; a
registry entry also cannot certify itself). No new `pull_request` workflow, so the #2910 unenrolled-
workflow hazard does not apply.

**AC3** — deliberately NOT claimed here. `required` evaluates the aggregator and registry from the PR's
**BASE** ref, so this enrollment cannot certify itself. It verifies on the first PR merged after this
one. Stated residual, not a green check.

## Certification

- **Full gate of record**: run by `flow-closer`; its `AGENT-GATE SUMMARY` is the verdict of record and is
  recorded below by the closer.
- **`--lite` re-cert every fix round** (6 rounds), each with the summary-file redirect. Final:
  `RESULT: PASS` at `2d177e1`, `tree-integrity: PASS`, clean tree.
- **Guard test**: 352 assertions, 0 failed.
- **TDD red-first verified independently at EVERY round**, each in a throwaway `git worktree --detach` at
  the test-only commit with the script unchanged: 14, 21, 2, 12, 6 assertions red respectively. Assertions
  pin the *harm*, not the symptom — e.g. "advertised a repair that would REVERSE the rename", "reported
  success without measuring staged deletions", "named 6 times (stage duplication leaked)".
- The no-writes oracle is a full census (type + mtime + sha256 per path, NUL-walked), so a `--verify-only`
  that *repaired* would fail it; a direct "still absent" assertion backs it independently.

## roborev — NOT clean, and deliberately so

Five sanctioned rounds (`scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol --repo <wt>
--base origin/main`). Findings ran **2 → 1 → 3 → 2 → 1**, each round's findings living in the previous
round's fix — the #3229 non-converging-curve pattern. Nine blockers were fixed across rounds 1-4.

The **final round (job 16, `2d177e1`) is `RESULT: FAIL` with 1 Medium finding**, deferred by explicit
lead grant, not waived and not called clean:

- **`diff.renameLimit`** can make git skip exhaustive rename detection, exit 0, and emit a
  deletion+addition instead of a rename — so a boundary-crossing rename bypasses the new pre-check and is
  misreported as missing, with a repair that reverses intentional work. Filed as **#3331** with the state
  named and red-first ACs.

That deferral is the **pre-registered mechanical exit** the lead granted in response to
`REQ-3310-20260806T021634Z` (issue comment 5199807177): ONE bounded round, and any further
*classification* defect defers to a follow-up naming the state rather than a further fix round. Round 5's
finding is exactly that class, so it deferred mechanically — no round 6, no re-escalation.

Round-5 wrapper integrity keys all PASS: `sha-assert`, `push-assert`, `census-check`, `code-free`,
`job-record`, `prompt-content: PASS (3/3)`, `vacuity-tier1/2`; 152k input / 123k cached tokens (genuine
review range, far from the ~18.7k/0-cached vacuous baseline).

## The granted design decision (round 4)

Rather than keep classifying git states it could not model, the probe now **declares** them:
`detect_unclassifiable_git_state()` detects *markers* of unclassifiable state (unmerged index entries via
`ls-files -u -z`; a staged rename candidate crossing the pathspec boundary) and routes to
`COULD NOT MEASURE` with **no repair command**. It is **affirmative by construction** — contract is
`0` measured-clean / `1` marker-found / `2` pre-check-could-not-run, every failure path returns `2`, and
the caller routes ANY non-zero to the unmeasurable verdict, so the clean branch is reachable only after
both probes *succeeded*. An unborn HEAD returns clean with a stated justification (no staged rename can
exist relative to a HEAD that does not exist) — a measured emptiness, not a skipped measurement.

## Follow-ups

- **#3331** — the deferred `diff.renameLimit` classification defect (real; exotic trigger).
- **#3332** — batched NITs: complete the marker-absence assertions; make the destructive path's
  pre-existing `ls-files -u` NUL-delimited.

Both need grooming (priority + board status) — a worker touches only `coord:*` labels.

## Doctrine kept current in-change

`CLAUDE.md` and `website/src/content/docs/agents-developing/test-data.md` both document the new behavior
and explicitly state "reports, never repairs" plus the `NO SUBJECT` / `COULD NOT MEASURE` distinction.


---

## Endgame verdicts of record (flow-closer)

### Full agent gate — THE gate of record (one run, `2d177e1`)

<details><summary><code>RESULT: PASS</code> — 30/30 components, <code>tree-integrity: PASS</code></summary>

```

==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.Com2UY
commit: 2d177e1 branch: issue-3310-verify-only-tracked-report dirty: no
datasets: 144 Data.db files under /data/datasets
schemas: 6/6 canonical .cql readable under /home/ubuntu/workspace/cqlite-wt/issue-3310/test-data/schemas (checkout-relative)
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=absent perf=paranoid-4
cpu-budget: wrapper=nice ncpu=16 max-concurrency=3 cores-per-gate=5 build-jobs=5(derived) test-threads=5
tree-start: 2d177e1a4621 dirty: no digest: 8cef488f7b1f
tree-end: 2d177e1a4621 dirty: no digest: 8cef488f7b1f
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (6s)
clippy:            PASS (3s)
roborev-lints:     PASS (46s)
core-tests:        PASS (669s)
tombstones-scan:   PASS (45s)
scan-offload-guard: PASS (161s)
work-counters-guard: PASS (93s)
byte-budget-guard: PASS (16s)
arrow-parity-guard: PASS (74s)
memory-budget:     PASS (558s)
integration-tests: PASS (63s)
format-compat:     PASS (42s)
write-tests:       PASS (155s)
cli-tests:         PASS (171s)
compaction-byte-parity: PASS (7s)
bti-multiclustering: PASS (4s)
query-semantics-oracle: PASS (0s)
flight-query-semantics-oracle: PASS (82s)
python-bindings:   PASS (727s)
node-bindings:     PASS (497s)
delivery-telemetry: PASS (1s)
oom-audit:         PASS (6s)
parity-report:     PASS (18s)
operator-metrics-doc: PASS (32s)
kit-dashboard-drift: PASS (1s)
binding-unwind-profile: PASS (2s)
tooling-tests:     PASS (437s)
minimal-build:     PASS (65s)
smoke:             PASS (137s)
logs: /tmp/agent-gate.Com2UY
summary-file: /tmp/gate-full-3310.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```
</details>

Run-id verified as this closer's own run; `commit: 2d177e1` == the certified head; `dirty: no`;
`tree-start` == `tree-end` (`tree-integrity: PASS`, #2926); no `.integrity-fail.*` sibling; process exit `0`.
Datasets root `/data/datasets` (144 `Data.db`), schemas `6/6` readable — no vacuous/0-row pass.

### Final roborev pass — **NOT clean** (deferred under a granted, bounded exit)

```
==== ROBOREV REVIEW SUMMARY ====
repo: /home/ubuntu/workspace/cqlite-wt/issue-3310
branch: issue-3310-verify-only-tracked-report
base: origin/main
head-sha: 2d177e1a4621178ba15045aadfa27f1aa06dbc44
reviewed-sha: 51e3ac66d3ab062192a3d252e0578762ed04fe4b..2d177e1a4621178ba15045aadfa27f1aa06dbc44
job: 17
model: gpt-5.6-sol
census: 5 files, +1473/-4
tokens: input=76585 cached=48640 output=1822
push-assert: PASS
census-check: PASS
code-free: PASS
job-record: PASS
sha-assert: PASS
review-completed: PASS
prompt-content: PASS (3/3 code census paths present)
vacuity-tier1: PASS
vacuity-tier2: PASS
findings: PRESENT (1)
roborev-exit: FINDINGS (exit 1)
RESULT: FAIL
==== END ROBOREV REVIEW SUMMARY ====
```

**This PR does not record "roborev clean," and does not claim to.** The round returned exactly **one**
finding — Medium, `diff.renameLimit` can make git skip exhaustive rename detection, exit `0`, and emit
deletion+addition instead of a rename, bypassing the new unclassifiable-state pre-check. That is the
*single* finding pre-authorized as deferred by the owner's granted mechanical exit (reply to
`REQ-3310-20260806T021634Z`, [issuecomment-5199807177](https://github.com/pmcfadin/cqlite/issues/3310#issuecomment-5199807177)):
one bounded round, any further *classification* defect defers to a follow-up naming the state. It is
filed as **#3331**. The closer verified the finding is that finding and no other, and that every wrapper
integrity key (`push-assert`, `sha-assert`, `prompt-content`, `job-record`, `code-free`, `vacuity-tier1/2`)
is `PASS` — a failure there would have blocked the merge independently of the finding.

Review scope verified genuine, not vacuous: `reviewed-sha` base `51e3ac6` == `origin/main`, head
`2d177e1` == branch HEAD (a real range, not the T1 worktree/base-equal or T2 empty-tree signature);
76.6k input / 48.6k cached tokens is in the genuine-review band, far above the 18.7k/0-cached vacuous baseline.

### Pre-merge guards

- `scripts/flow/premerge-assert.sh 3333 2d177e1a…` → `PREMERGE: OK` (PR open, `headRefOid` == certified SHA).
- Fresh `HOLD:` re-read of PR + issue comments → no `HOLD: merge after #N` order outstanding.
