### PR TITLE
fix(#3358): apply a query's token bound on a BTI (`da`) reader, which dropped it

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
@@ -110,6 +110,52 @@ impl ScanTokenBound {
     }
 }
 
+/// The token range applied to a walk whose signature does not take one.
+///
+/// [`SSTableReader::stream_all_partitions_for_query`] pushes its
+/// [`ScanTokenBound`] into the Summary-guided walk, which skips an out-of-range
+/// partition body rather than decoding it. Its full-ring fallback routes take no
+/// bound, so this gate applies the range to their emit instead. Correctness is
+/// then a property of the call rather than of which route the reader chose, which
+/// matters most for a BTI (`da`) reader: it fails the Summary-guided gate on every
+/// call, so the fallback is its only route (issue #3358).
+///
+/// The verdict is computed once per partition, not once per row. A token is a
+/// property of the partition key, and a walk emits a partition's rows
+/// consecutively, so a per-row hash would charge every row for an answer that
+/// changes at a partition boundary.
+struct TokenGate {
+    bound: Option<ScanTokenBound>,
+    /// The key `admits` below was computed for.
+    last: Option<std::sync::Arc<[u8]>>,
+    admits: bool,
+}
+
+impl TokenGate {
+    fn new(bound: Option<ScanTokenBound>) -> Self {
+        // `admits` starts true so an unbounded walk answers without touching
+        // `last` at all.
+        Self {
+            bound,
+            last: None,
+            admits: true,
+        }
+    }
+
+    /// Whether this row's partition is inside the range.
+    fn admits(&mut self, key: &std::sync::Arc<[u8]>) -> bool {
+        let Some(bound) = self.bound else {
+            return true;
+        };
+        if self.last.as_ref().is_none_or(|last| last != key) {
+            let token = crate::util::cassandra_murmur3::cassandra_murmur3_token(key);
+            self.admits = bound.contains(token);
+            self.last = Some(key.clone());
+        }
+        self.admits
+    }
+}
+
 impl SSTableReader {
     /// The `Index.db` path SIBLING of this reader's CURRENT `Data.db` path (issue
     /// #2412 §C, #2383-aware). Derived from [`Self::file_path`] (the ArcSwap that a
@@ -586,8 +632,20 @@ impl SSTableReader {
                  compaction stream (issue #2412)."
             );
         }
-        // Full-ring fallback (no usable summary/index): the downstream token filter
-        // still bounds the result set, so correctness holds without pushdown.
+        // Full-ring fallback: the routes below take no `token_bound` in their
+        // signatures, so the range is applied to their emit instead of being
+        // dropped (issue #3358). A BTI (`da`) reader reaches this fallback on
+        // EVERY call — `bti_partitions_db.is_some()` fails the gate above — so
+        // before this it was not a fallback for that format but the only route,
+        // and `stream_all_partitions_for_query(.., Some(bound), ..)` returned the
+        // whole ring. An `nb` generation holding the same rows returned exactly
+        // the range, which `issue_2412_wraparound_scan.rs` pins with
+        // `assert_eq!`, so the two formats disagreed about what the parameter
+        // means.
+        //
+        // The gate is applied here, once, rather than inside each route: it is
+        // the boundary the caller's range was handed to, and the two routes below
+        // reach three different walk implementations between them.
         //
         // QUERY-ARM caller-schema fidelity (issue #3097): the summary-guided walk
         // above honours the caller's authoritative `schema`, but this fallback
@@ -608,6 +666,13 @@ impl SSTableReader {
         // `stream_all_partitions_for_compaction`, whose stitch/BTI decode already
         // honours the passed `schema` (`schema.cloned().or_else(...)`), so no
         // divergence is introduced there.
+        let mut gate = TokenGate::new(token_bound);
+        let mut emit = move |row: super::super::compaction_row::CompactionRow| {
+            if !gate.admits(&row.key.0) {
+                return Ok(ControlFlow::Continue(()));
+            }
+            emit(row)
+        };
         if self.requires_chunk_stitching() || self.bti_partitions_db.is_some() {
             return self
                 .stream_all_partitions_for_compaction(schema, scan_cancel, emit)
@@ -680,5 +745,66 @@ mod tests {
             !wrap.can_stop_past(i64::MAX),
             "a wraparound range never early-stops a forward walk"
         );
+    }
+
+    /// The gate's own tests. The end-to-end pin, over a Cassandra-written BTI
+    /// generation through `stream_all_partitions_for_query`, is
+    /// `tests/issue_3358_bti_query_token_bound.rs`; these cover the parts that
+    /// file cannot isolate.
+    mod token_gate {
+        use super::super::{ScanTokenBound, TokenGate};
+        use crate::util::cassandra_murmur3::cassandra_murmur3_token;
+        use std::sync::Arc;
+
+        fn key(bytes: &[u8]) -> Arc<[u8]> {
+            Arc::from(bytes.to_vec().into_boxed_slice())
+        }
+
+        #[test]
+        fn no_bound_admits_every_key() {
+            let mut gate = TokenGate::new(None);
+            for bytes in [&b"a"[..], b"b", b"a"] {
+                assert!(gate.admits(&key(bytes)));
+            }
+        }
+
+        #[test]
+        fn a_bound_admits_its_own_partition_only() {
+            let inside = key(b"inside");
+            let outside = key(b"outside");
+            let token = cassandra_murmur3_token(&inside);
+            let bound = ScanTokenBound {
+                start_excl: token - 1,
+                end_incl: token,
+                wraparound: false,
+            };
+            assert!(
+                !bound.contains(cassandra_murmur3_token(&outside)),
+                "the two keys must fall either side of the bound, or this case \
+                 cannot discriminate"
+            );
+            let mut gate = TokenGate::new(Some(bound));
+            assert!(gate.admits(&inside));
+            assert!(!gate.admits(&outside));
+        }
+
+        /// The memo holds one key's verdict, so it must be recomputed the moment
+        /// the key changes — including when the walk returns to a key it has seen.
+        #[test]
+        fn the_memo_follows_the_partition_boundary() {
+            let inside = key(b"inside");
+            let outside = key(b"outside");
+            let token = cassandra_murmur3_token(&inside);
+            let mut gate = TokenGate::new(Some(ScanTokenBound {
+                start_excl: token - 1,
+                end_incl: token,
+                wraparound: false,
+            }));
+            let verdicts: Vec<bool> = [&inside, &inside, &outside, &outside, &inside]
+                .into_iter()
+                .map(|k| gate.admits(k))
+                .collect();
+            assert_eq!(verdicts, vec![true, true, false, false, true]);
+        }
     }
 }

--- a/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
+++ b/cqlite-core/tests/issue_3358_bti_query_token_bound.rs
@@ -1,0 +1,339 @@
+//! Issue #3358: `stream_all_partitions_for_query` must narrow to its
+//! `token_bound` on a BTI (`da`) reader, as it already does on an `nb` one.
+//!
+//! `ScanTokenBound::contains` is called in one place, the Summary-guided walk in
+//! `summary_scan/mod.rs`, and `stream_all_partitions_for_query` gates that walk on
+//! `self.index_reader.is_some() && self.bti_partitions_db.is_none() &&
+//! summary_usable`. Every BTI generation has a `Partitions.db`, so the second term
+//! is false for every `da` reader on every call: the "full-ring fallback" below the
+//! gate is not a fallback for that format but its only route. Both routes there
+//! (`stream_all_partitions_for_compaction` and `stream_all_partitions_cancellable`)
+//! take no bound in their signatures, so the caller's range was accepted and
+//! dropped, with no error and no WARN, and the call returned the whole ring.
+//!
+//! The asymmetry is what makes this a defect rather than a documented pushdown
+//! hint. `issue_2412_wraparound_scan.rs` drives the SAME public surface over an
+//! `nb` generation and pins its narrowing with `assert_eq!`: "a non-wraparound
+//! range must emit exactly its one contiguous segment". So one parameter meant two
+//! different things depending on the file format underneath, and a consumer that
+//! splits a scan by token range read every row once per split.
+//!
+//! Why no existing test caught it: every token-bound test builds its generation
+//! with `WriteEngine`, which writes `Summary.db`/`Index.db` and never a BTI
+//! generation. This test reads a COMMITTED, Cassandra-5.0.2-written `da` fixture
+//! instead, so the route under test is the one a Cassandra 5 node's files take.
+//!
+//! # Oracle
+//!
+//! The expected partitions are derived, never assumed. `test_da`'s
+//! `wide_multiclustering_small` fixture is 600 rows over 5 single-`int`-PK
+//! partitions, and its committed `sstabledump -l` golden records both numbers; the
+//! golden is re-read here, so a regenerated corpus fails loudly rather than
+//! quietly weakening the assertions. Each bound's expected set is then computed
+//! from `cassandra_murmur3_token` over the fixture's actual keys, and every case
+//! asserts that the bound genuinely excludes at least one partition — otherwise
+//! "the whole ring" and "the range" would be the same answer and the test could
+//! not discriminate.
+//!
+//! Requires the gitignored `Data.db` binaries; SKIPs (never passes with zero rows)
+//! when absent. `CQLITE_DATASETS_ROOT` is honored first, else the in-repo
+//! `test-data/datasets` corpus is used.
+
+#![cfg(feature = "state_machine")]
+
+use std::collections::BTreeMap;
+use std::ops::ControlFlow;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{parse_cql_schema, TableSchema};
+use cqlite_core::storage::scan_cancel::ScanCancel;
+use cqlite_core::storage::sstable::reader::{SSTableReader, ScanTokenBound};
+use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
+use cqlite_core::Config;
+
+const KEYSPACE: &str = "test_da";
+const TABLE: &str = "wide_multiclustering_small";
+const SSTABLE_PREFIX: &str = "da-1-bti";
+
+/// Repo root = the parent of this crate's manifest dir (`<repo>/cqlite-core`).
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cqlite-core has a parent repo dir")
+        .to_path_buf()
+}
+
+/// The `<table>-<cfid>` generation dir, requiring a real `Data.db` so a JSONL-only
+/// checkout SKIPs rather than passing with zero rows.
+fn fixture_dir() -> Option<PathBuf> {
+    let roots = std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .into_iter()
+        .chain(std::iter::once(repo_root().join("test-data/datasets")));
+    for root in roots {
+        let keyspace_dir = root.join("sstables").join(KEYSPACE);
+        let Ok(entries) = std::fs::read_dir(&keyspace_dir) else {
+            continue;
+        };
+        let mut candidates: Vec<PathBuf> = entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(&format!("{TABLE}-")))
+            })
+            .collect();
+        candidates.sort();
+        if let Some(dir) = candidates
+            .into_iter()
+            .find(|p| p.join(format!("{SSTABLE_PREFIX}-Data.db")).is_file())
+        {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+/// The DDL of the fixture, as `test-data/schemas/wide-multiclustering-small-bti.cql`
+/// declares it. A single `int` partition key, so a partition is labelled here by
+/// the 4-byte big-endian value its raw key holds.
+fn schema() -> TableSchema {
+    let cql = format!(
+        "CREATE TABLE {KEYSPACE}.{TABLE} (\
+             pk int, bucket text, seq int, payload text, \
+             PRIMARY KEY (pk, bucket, seq));"
+    );
+    parse_cql_schema(&cql).expect("parse the fixture schema")
+}
+
+/// Rows per partition, as Cassandra's own `sstabledump -l` recorded them.
+///
+/// The oracle is a dump of Cassandra-written bytes, never CQLite output (#3042).
+/// One line of the golden is one PARTITION and each `"type":"row"` within it one
+/// row, so the two are counted separately: a range that emits the right partitions
+/// with the wrong row counts is still wrong.
+fn golden_rows_by_pk(dir: &Path) -> BTreeMap<i32, usize> {
+    let golden = dir.join(format!("{SSTABLE_PREFIX}-Data.db.jsonl"));
+    let text = std::fs::read_to_string(&golden)
+        .unwrap_or_else(|e| panic!("read golden {}: {e}", golden.display()));
+    let mut by_pk = BTreeMap::new();
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        // `"key":["3"]` — one component, the `int` PK rendered as decimal text.
+        let marker = "\"key\":[\"";
+        let start = line
+            .find(marker)
+            .unwrap_or_else(|| panic!("golden line carries a partition key: {line}"))
+            + marker.len();
+        let end = start
+            + line[start..]
+                .find('"')
+                .unwrap_or_else(|| panic!("golden partition key is quoted: {line}"));
+        let pk: i32 = line[start..end].parse().unwrap_or_else(|e| {
+            panic!("golden partition key {} is an int: {e}", &line[start..end])
+        });
+        let rows = line.matches("\"type\":\"row\"").count();
+        assert!(rows > 0, "golden partition {pk} must hold at least one row");
+        assert!(
+            by_pk.insert(pk, rows).is_none(),
+            "golden must record partition {pk} once"
+        );
+    }
+    assert!(
+        by_pk.len() > 2,
+        "the fixture needs three or more partitions for a range to exclude one; \
+         the golden records {}",
+        by_pk.len()
+    );
+    by_pk
+}
+
+async fn open_reader(data_db: &Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+    let reader = SSTableReader::open(data_db, &config, platform)
+        .await
+        .expect("open the BTI SSTable reader");
+    assert!(
+        reader.is_bti(),
+        "fixture {} must open as a BTI (`da`) reader, else the dropped bound is \
+         never exercised",
+        data_db.display()
+    );
+    reader
+}
+
+/// Drive `stream_all_partitions_for_query` and count the rows it emits per
+/// partition key.
+///
+/// This is the public surface a consumer that splits a scan by token range calls
+/// (`write_engine::merge::from_readers::drive_query_stream` reaches it through
+/// `KWayMerger::new_from_readers`), and the same one
+/// `issue_2412_wraparound_scan.rs` drives for an `nb` generation.
+async fn emitted_rows_by_pk(
+    reader: &SSTableReader,
+    token_bound: Option<ScanTokenBound>,
+) -> BTreeMap<i32, usize> {
+    let schema = schema();
+    let cancel = ScanCancel::default();
+    let mut by_pk: BTreeMap<i32, usize> = BTreeMap::new();
+    reader
+        .stream_all_partitions_for_query(Some(&schema), &cancel, token_bound, |row| {
+            let key_bytes: &[u8] = &row.key.0;
+            let pk = i32::from_be_bytes(key_bytes.try_into().expect("4-byte int PK"));
+            *by_pk.entry(pk).or_default() += 1;
+            Ok(ControlFlow::Continue(()))
+        })
+        .await
+        .expect("stream_all_partitions_for_query");
+    by_pk
+}
+
+/// The fixture, as the golden describes it.
+struct Fixture {
+    data_db: PathBuf,
+    /// `(partition key, rows)` in ascending token order, which is the order the
+    /// ring is divided in and so the order a range is chosen from.
+    ring: Vec<(i32, usize)>,
+    /// The same counts keyed by partition, for comparing against a whole scan.
+    golden: BTreeMap<i32, usize>,
+}
+
+/// The fixture's partitions in ring order, with the golden's row count each.
+///
+/// Returns `None` when the `Data.db` binaries are absent, which is the SKIP.
+fn fixture() -> Option<Fixture> {
+    let dir = fixture_dir()?;
+    let golden = golden_rows_by_pk(&dir);
+    let mut by_token: Vec<(i32, i64, usize)> = golden
+        .iter()
+        .map(|(&pk, &rows)| (pk, cassandra_murmur3_token(&pk.to_be_bytes()), rows))
+        .collect();
+    by_token.sort_by_key(|(_, token, _)| *token);
+    let ring: Vec<(i32, usize)> = by_token.iter().map(|(pk, _, rows)| (*pk, *rows)).collect();
+    Some(Fixture {
+        data_db: dir.join(format!("{SSTABLE_PREFIX}-Data.db")),
+        ring,
+        golden,
+    })
+}
+
+fn token_of(pk: i32) -> i64 {
+    cassandra_murmur3_token(&pk.to_be_bytes())
+}
+
+/// Control: the surface reads the whole fixture when no range is given, so a
+/// narrowed answer below is a narrowing rather than a failure to read.
+#[test]
+fn unbounded_scan_matches_the_golden() {
+    let Some(Fixture {
+        data_db, golden, ..
+    }) = fixture()
+    else {
+        eprintln!("SKIP: {KEYSPACE}.{TABLE} Data.db is absent (gitignored corpus)");
+        return;
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let reader = rt.block_on(open_reader(&data_db));
+    let got = rt.block_on(emitted_rows_by_pk(&reader, None));
+    assert_eq!(
+        got, golden,
+        "an unbounded scan must emit every partition of the fixture, with the row \
+         counts Cassandra's own dump records"
+    );
+}
+
+/// THE pin: a non-wraparound range must emit exactly its one contiguous segment,
+/// which is what the `nb` surface already guarantees.
+///
+/// Before the fix this returned all five partitions and all 600 rows for any
+/// range, so N consumers splitting the ring between them each read the whole
+/// table.
+#[test]
+fn non_wraparound_range_emits_only_its_segment() {
+    let Some(Fixture { data_db, ring, .. }) = fixture() else {
+        eprintln!("SKIP: {KEYSPACE}.{TABLE} Data.db is absent (gitignored corpus)");
+        return;
+    };
+    // A mid-ring segment: every partition above the lowest and below the highest.
+    // The two it excludes are what makes the case discriminating.
+    let last = ring.len() - 1;
+    let start_excl = token_of(ring[0].0);
+    let end_incl = token_of(ring[last - 1].0);
+    assert!(
+        start_excl < end_incl,
+        "a non-wraparound pair must have start < end; got {start_excl} and {end_incl}"
+    );
+    let expected: BTreeMap<i32, usize> = ring[1..last].iter().copied().collect();
+    assert!(
+        !expected.is_empty() && expected.len() < ring.len(),
+        "the range must hold something and exclude something, else it cannot \
+         discriminate a narrowed scan from a full one"
+    );
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let reader = rt.block_on(open_reader(&data_db));
+    let bound = ScanTokenBound {
+        start_excl,
+        end_incl,
+        wraparound: false,
+    };
+    let got = rt.block_on(emitted_rows_by_pk(&reader, Some(bound)));
+
+    assert_eq!(
+        got,
+        expected,
+        "a non-wraparound range over a BTI (`da`) generation must emit exactly its \
+         one contiguous segment ({} of {} partitions), as the `nb` surface does \
+         (issue_2412_wraparound_scan.rs). Emitting all {} means the bound reached \
+         the full-ring fallback and was dropped there",
+        expected.len(),
+        ring.len(),
+        ring.len()
+    );
+}
+
+/// The wraparound arm: both segments, and nothing between them.
+///
+/// `can_stop_past` refuses to early-stop on a wraparound range, so this also pins
+/// that the fix takes no early exit it is not entitled to.
+#[test]
+fn wraparound_range_emits_both_segments_and_nothing_between() {
+    let Some(Fixture { data_db, ring, .. }) = fixture() else {
+        eprintln!("SKIP: {KEYSPACE}.{TABLE} Data.db is absent (gitignored corpus)");
+        return;
+    };
+    // `(highest-but-one, MAX] ∪ [MIN, lowest]`: the highest partition and the
+    // lowest one, with everything between them excluded.
+    let last = ring.len() - 1;
+    let start_excl = token_of(ring[last - 1].0);
+    let end_incl = token_of(ring[0].0);
+    assert!(
+        start_excl > end_incl,
+        "a wraparound pair must have start > end; got {start_excl} and {end_incl}"
+    );
+    let expected: BTreeMap<i32, usize> = [ring[0], ring[last]].into_iter().collect();
+    assert!(
+        expected.len() == 2 && ring.len() > 3,
+        "both segments must hold a partition, and at least one partition must lie \
+         between them"
+    );
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let reader = rt.block_on(open_reader(&data_db));
+    let bound = ScanTokenBound {
+        start_excl,
+        end_incl,
+        wraparound: true,
+    };
+    let got = rt.block_on(emitted_rows_by_pk(&reader, Some(bound)));
+
+    assert_eq!(
+        got, expected,
+        "a wraparound range must emit the partitions of BOTH segments and none of \
+         those between them"
+    );
+}


### PR DESCRIPTION
## Adoption certification record — #3358, per the owner's 2026-08-30 ruling

This PR is @michaelsembwever's. A fleet lane adopted it for certification only, per the owner's ruling on this thread: *"certify then merge … Authorship stays with @michaelsembwever; the lane adds nothing but certification."* **No commit of theirs was rewritten, rebased, amended or squashed, and none could have been — `maintainerCanModify: false` on `thelastpickle:fix/bti-query-token-bound`.** The head is exactly as they pushed it.

---

## ⚠️ READ THIS BEFORE GREPPING `RESULT: PASS` BELOW — two gates ran, on two DIFFERENT trees

There are two `AGENT-GATE SUMMARY` blocks in this body and **they certify different artifacts.** Getting this wrong is not hypothetical: another lane tonight came within one step of merging #3616 on a peer's verdict because a run directory looked plausible and only the `run-id:` line exposed it.

| | Gate A | Gate B |
|---|---|---|
| `tree-start` | `4bc6b913a6af` | **`45e52a62d92d`** |
| What that tree is | **the PR head** | **`origin/main` + this diff** — *NOT the PR head* |
| Verdict | **none — killed before its terminal emit** (one component FAILed) | **PASS** |
| What it certifies | this diff against its 8-day-old base | this diff against the main it will actually join |

**Gate B's `tree-start` is NOT `4bc6b913a`.** It is a local merge commit that exists only to be measured. If you are looking for "a green gate on the PR head", it does not exist and this body does not claim one.

**And there is only ONE pasteable `AGENT-GATE SUMMARY` block below, not two.** Gate A never reached its terminal emit — see the section below for exactly what it did and did not produce. Its evidence is real and component-level; it is not a certified verdict, and this body does not dress it as one.

### Why the head assert and the gate tree are deliberately DIFFERENT trees

The pre-merge assert run before arming auto-merge is, and stays:

```
scripts/flow/premerge-assert.sh 3362 4bc6b913a6afc63d2fe7f234152da9b03ea03a89
```

That asserts **the PR head has not moved since certification** — its job is to stop a push landing between certification and merge. It is deliberately pinned to the **PR head**, `4bc6b913a`.

Gate B ran on a **different** tree, `45e52a62d`, on purpose. The two are answering different questions and conflating them is how a stale certification gets merged:

- **`premerge-assert` asks:** *is the thing GitHub will merge still the thing I reviewed?* That question is about the **head**, so it must be pinned to the head.
- **Gate B asks:** *does the tree that RESULTS from merging behave correctly?* A squash-merge composes this diff with **current** `main`, not with the base it was written against. This PR sat 8 days; its base is `2bde26a7c` (2026-08-22) while main is 10+ commits further on. So a gate on the head alone certifies a tree that **will never exist after the merge**.

Keeping both is the point: the head assert pins *identity*, the merge-result gate pins *behaviour*. Neither substitutes for the other, and this body records both rather than presenting the convenient one.

---

## Gate A — the PR head. NO TERMINAL VERDICT; one component FAILed, and that failure is not this diff

### What Gate A actually produced — stated before the evidence, because the distinction matters

Gate A was **killed by a box-wide OOM before it could emit a verdict.** Its summary file therefore holds the launch sentinel, which CLAUDE.md is explicit is *not* a verdict:

```
run-id: /tmp/agent-gate.tuU5Zj
tree-start: 4bc6b913a6af dirty: no
RESULT: INCOMPLETE (gate did not finish)
```

The kill was **not this lane's doing and not this diff's**. `dmesg` on the runner:

```
[Sun Aug 30 23:43:09 2026] oom-kill:constraint=CONSTRAINT_NONE, ..., global_oom,
   task_memcg=.../tmux-spawn-3b040d37-....scope, task=python3, pid=1098679
[Sun Aug 30 23:43:09 2026] Out of memory: Killed process 1098679 (python3)
   anon-rss:24675212kB
```

A **peer** process at 24.7 GB on a 30 GB box triggered a **global** OOM; Gate A was collateral, dying in `[tooling-tests]` near the end of its run.

So, precisely:

- ❌ There is **no `RESULT: FAIL`** for the PR head, and none is claimed anywhere in this body.
- ✅ There **is** component-level evidence, quoted below: `>>> [core-tests] FAIL (809s)`, with every other component Gate A reached reporting PASS.

**Nothing in the merge decision rests on this half.** The PR does not merge *because* the head is red; it merges because the landing artifact (Gate B) is green. Re-running Gate A would re-roll a known flake for the non-load-bearing half of the record, so the honest partial is recorded instead of a manufactured one.

### The component-level failure, and why it is not this diff

Sole failing test:

```
FAIL [6.517s] (4633/5147) cqlite-core::issue_2370_concurrent_merge_thread_budget
              concurrent_merges_bound_aggregate_threads_to_o_c_m
Summary [27.313s] 4648/5147 tests run: 4647 passed, 1 failed, 42 skipped

C=2 concurrent merges over M=3 inputs each added 30 OS threads over baseline
(peak=32, baseline=2); O(C·M) bound is 24 (= 3·M·C + 6). A delta scaling with
num_cpus (num_cpus=16) means a producer built a multi-threaded runtime.
```

**This was NOT waived under the #3042 prose rule.** That waiver is void the moment a diff touches compiled input, and this diff touches `summary_scan/mod.rs`. The failure was presumed the diff's and investigated until four orthogonal reasons showed it is not:

1. **Wrong code path.** The test drives `merger.merge(&mut writer)` — the compaction/merge path. The changed method is `stream_all_partitions_for_query`, the QUERY arm; compaction never routes through it (it calls `stream_all_partitions_for_compaction` directly). The diff cannot reach the code under test.
2. **Wrong quantity.** The assert bounds a peak **OS-thread count**. The diff adds a per-partition token memo — it creates no threads and no runtime.
3. **Wrong magnitude — the identity argument.** The test's own message names the defect's signature as *"a delta scaling with `num_cpus`"*, which at `num_cpus=16` is `C·M·num_cpus ≈ 96`. The observed delta is **30 against a bound of 24**: a 6-thread overshoot. A 30 is not a small 96; it is a different phenomenon — threshold tightness under load, not runtime amplification.
4. **It is a known, already-filed flake on this exact test**: #3514 (*"reds 2/3 standalone at moderate load"*), #3385 (*"reds by exactly one thread under load, passes 3/3 standalone"*), #3438 (*"apply #3385's reap confirmation to the concurrent test"*).

**And the fix is already on main — it is only absent from this PR's base:**

```
$ git merge-base --is-ancestor 5e08db201 HEAD          # fix(#3514) reap-confirmed acceptance
  exit 1   → NOT in this PR
$ git merge-base --is-ancestor 5e08db201 origin/main
  exit 0   → IS on main

PR base 2bde26a7c : 2026-08-22 09:11
fix 5e08db201     : 2026-08-30 10:58   (8 days later)
```

That is the whole explanation, and it is what motivated Gate B.

### That attribution is now DEMONSTRATED, not argued — Gate B ran the same test and it passed

The four reasons above are a disproof by reasoning. Gate B supplies the experiment, and it is the
single most load-bearing line in this record:

```
PASS [   5.671s] (5266/5280) cqlite-core::issue_2370_concurrent_merge_thread_budget
                             concurrent_merges_bound_aggregate_threads_to_o_c_m
     Summary [  54.021s] 5280 tests run: 5280 passed, 42 skipped
```

**Same test, same diff, same machine, same load — the only variable changed is the base.** It fails
against the PR's 8-day-old base and passes against current `main`, which carries the fix
`5e08db201`. If the failure were the diff's, changing the base could not have cleared it.

(Note the denominator moves, `4648` → `5280`: the landing tree carries the tests `main` has gained
since this PR was branched, which is itself part of why the head-only gate certifies the wrong
artifact.)

---

## Format-source adjudication vs the pinned `cassandra-5.0.8` tag — PASS

Read through the tag ref, never a working tree. Pin resolves to `bc1db9ce043cc13a1b2fe9d3f4e2c7ad7e552021`. A CQLite `file:line` is not format authority, so all three properties are cited to Cassandra source.

**(a) The token is `normalize(hash3_x64_128(key, pos, remaining, seed=0)[0])`** over the whole partition-key buffer, first of the two 64-bit words, `Long.MIN_VALUE → Long.MAX_VALUE` (`Murmur3Partitioner.getToken`/`getHash`/`normalize`). Matched by the `cassandra_murmur3_token` the new gate calls. The patch hashes `row.key.0` — the same partition-key bytes the summary-guided route hashes — so one parameter now means one thing on both routes, which is the property the issue said was broken.

**(b) A range is left-exclusive, right-inclusive.** `Range.contains` is `point > left && right >= point` non-wrapping, `point > left || right >= point` wrapping. `ScanTokenBound::contains` is those two expressions verbatim.

**(c) `start == end` ⇒ FULL ring, and Cassandra says so structurally.** `isWrapAround` is `left.compareTo(right) >= 0` — **`>=`** — so equal endpoints are classified as wrapping, and the wrapping branch then admits every point. This was expected to be a CQLite house rule (`#2228`); it is not, it is a consequence of Cassandra's own code.

---

## Independent RED/GREEN — the fix was not taken on trust

A test that silently skipped is also green, so both sides were run rather than reading the branch's CI.

**GREEN** on the PR head, with `--nocapture` to prove the cases *executed*:

```
running 3 tests
test non_wraparound_range_emits_only_its_segment ... ok
test wraparound_range_emits_both_segments_and_nothing_between ... ok
test unbounded_scan_matches_the_golden ... ok
test result: ok. 3 passed; 0 failed
```
No `SKIP:` line — all three ran.

**RED** in a throwaway detached worktree at the merge-base with only the test file copied in (fix absent, confirmed by `grep -c TokenGate` → `0`; a separate worktree so no gate's `tree-integrity` could be voided):

```
non_wraparound_range_emits_only_its_segment ... FAILED
  left: {0: 20, 1: 80, 2: 20, 3: 80, 4: 400}
 right: {0: 20, 2: 20, 4: 400}
wraparound_range_emits_both_segments_and_nothing_between ... FAILED
  left: {0: 20, 1: 80, 2: 20, 3: 80, 4: 400}
 right: {1: 80, 3: 80}
test result: FAILED. 1 passed; 2 failed
```

The reported figures reproduced to the digit from a clean baseline. The defect is real, the test discriminates, the fix closes it, and the third case passing on both sides confirms a narrowing rather than a failure to read.

---

## roborev — PASS, `findings: NONE`

Reviewed range base is pinned to the **immutable merge-base sha**, not `origin/main`. First round failed `sha-assert` legitimately because main advanced *during* the review (`2bde26a7c` → `d6fe6d39b`), so the enqueue and the assert resolved the moving ref differently. Nothing to do with the diff.

Gate B's delta vs `main` is **byte-identical** to the reviewed diff (+467/−2, same two files), so the review covers the landing tree as well as the head.


```
==== ROBOREV REVIEW SUMMARY ====
repo: /data/lanes/lane-3358
branch: issue-3358-token-bound-bti-adopt
base: 2bde26a7cf3a0a43b33b6cbfef4510781d434351
head-sha: 4bc6b913a6afc63d2fe7f234152da9b03ea03a89
reviewed-sha: 2bde26a7cf3a0a43b33b6cbfef4510781d434351..4bc6b913a6afc63d2fe7f234152da9b03ea03a89
job: 250
model: gpt-5.6-sol
census: 2 files, +467/-2
tokens: input=628685 cached=468480 output=3565
push-assert: PASS
census-check: PASS
code-free: PASS
job-record: PASS
sha-assert: PASS
review-completed: PASS
prompt-content: PASS (2/2 code census paths present)
vacuity-tier1: PASS
vacuity-tier2: PASS
findings: NONE
roborev-exit: PASS
log: /tmp/claude-1000/-data-lanes-lane-3358/96f0bd12-e553-4983-8f81-536636b095b2/scratchpad/roborev-r2.log
RESULT: PASS
```

The token accounting is the anti-vacuity tell and it is in the genuine range (`input=628685 cached=468480`), against a vacuous baseline of ~18.7k input / 0 cached. `prompt-content: PASS (2/2 code census paths present)` confirms the reviewer actually received both changed files.

---

## Gate B — the LANDING artifact (`origin/main` + this diff). The gate of record for this merge

This is the run the merge decision rests on. Tree: a local, **never-pushed** merge of the PR head into current `main` (a pushed branch would read as a competing PR).

**Currency re-verified at gate launch**, because `main` moved during the lane's downtime:

```
$ git rev-parse origin/main                              -> e53628ef7
$ git merge-base --is-ancestor origin/main HEAD          -> YES
$ git log --oneline HEAD..origin/main                    -> (empty)
$ git diff --numstat origin/main...HEAD
  128  2  cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
  339  0  cqlite-core/tests/issue_3358_bti_query_token_bound.rs
```

The merge result already contained the current tip, and its delta vs `main` is still exactly `+467/−2` over the same two files — byte-identical to the roborev-reviewed diff, so no further review round is owed.

```
==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.FtXE7E
commit: 45e52a6 branch: cert-3358-merge-result dirty: no
datasets: 144 Data.db files under /data/datasets
schemas: 6/6 canonical .cql readable under /tmp/claude-1000/-data-lanes-lane-3358/96f0bd12-e553-4983-8f81-536636b095b2/scratchpad/merge-result/test-data/schemas (checkout-relative)
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.5.tar.gz DATASET_SHA256: 414195074f6df446a7381aad051af84158e9a021a6e2cd21cbc6c3ad0be1ba16 
accelerators: sccache=on nextest=on lanes=on sccache-health=warn mold=absent perf=paranoid-4
cpu-budget: wrapper=nice ncpu=16 max-concurrency=1 cores-per-gate=16 build-jobs=16(derived) test-threads=16
tree-start: 45e52a62d92d dirty: no digest: a9a595978614
tree-end: 45e52a62d92d dirty: no digest: a9a595978614
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (6s)
clippy:            PASS (5438s)
roborev-lints:     PASS (53s)
core-tests:        PASS (1310s)
tombstones-scan:   PASS (388s)
scan-offload-guard: PASS (386s)
work-counters-guard: PASS (257s)
byte-budget-guard: PASS (14s)
arrow-parity-guard: PASS (469s)
memory-budget:     PASS (3593s)
integration-tests: PASS (285s)
format-compat:     PASS (217s)
write-tests:       PASS (332s)
cli-tests:         PASS (947s)
compaction-byte-parity: PASS (10s)
bti-multiclustering: PASS (3s)
query-semantics-oracle: PASS (1s)
flight-query-semantics-oracle: PASS (491s)
flight-tests:      PASS (2236s)
legacy-heuristics: PASS (3248s)
feature-iso-parquet: PASS (2127s)
feature-iso-delta-scan: PASS (1476s)
python-bindings:   PASS (1851s)
node-bindings:     PASS (1466s)
binding-rust-tests: PASS (2467s)
delivery-telemetry: PASS (0s)
oom-audit:         PASS (18s)
parity-report:     PASS (484s)
operator-metrics-doc: PASS (139s)
kit-dashboard-drift: PASS (2s)
binding-unwind-profile: PASS (0s)
pub-surface:       PASS (0s)
tooling-tests:     PASS (1234s)
minimal-build:     PASS (308s)
smoke:             PASS (1773s)
node-bindings-leak-lane: RAN (#1465 exception-path/abandoned-iterator leak budgets executed inside #3522's whole-suite npm test; AFFIRMED from that run's own jest JSON report — every named budget test present and passed)
logs: /tmp/agent-gate.FtXE7E
summary-file: /tmp/claude-1000/-data-lanes-lane-3358/90c8373c-78a0-499b-b987-74ca88c5ecd9/scratchpad/gate3-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

**Read the `tree-start:` line above: it is `45e52a62d92d`, NOT the PR head `4bc6b913a`.** That is the intended and disclosed property of this record, explained in the table at the top.

### `file-size`: passed via an acknowledged ratchet, not a suppressed check

`summary_scan/mod.rs` goes 686 → 812 against an 800-line campsite threshold, so the run carries `CQLITE_ALLOW_FILE_GROWTH=1`:

```
>>> [file-size] 1 over-threshold file(s) grew; ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1:
      summary_scan/mod.rs: 686 -> 812 (limit 800)
```

Three things this is **not**: it is not the #3042 prose waiver (void here — the diff touches compiled input, so `classify-docs-only.sh` returns non-zero); it is not a source edit to turn a gate green (not one line of the diff was touched); and it suppresses **no correctness component**. It acknowledges a **hygiene ratchet** on an external contribution whose head cannot be amended (`maintainerCanModify: false`). CLAUDE.md sanctions the acknowledgement provided a note links #1116 — filed as **#3635**, with the gate output, a concrete ~180-line pure-move split proposal, and an acceptance criterion of *"passes `file-size` without the env var"*.

---

## Pre-merge assert — pinned to the head, not to the gated tree

```
scripts/flow/premerge-assert.sh 3362 4bc6b913a6afc63d2fe7f234152da9b03ea03a89
```

---

## Follow-ups filed (none block this merge)

| Issue | | Why it is a follow-up and not a fix here |
|---|---|---|
| **#3633** | P3 — empty-key token | Real but not triggerable through any public surface reachable by this diff. Carries an explicit **"do not fix `cassandra_murmur3.rs:531`"** note: that assert is on `cassandra_murmur3_x64_128` (the RAW hash), where `h1 = 0` for empty input is the *correct* murmur3 value. Nothing currently pins the divergent *token*. |
| **#3634** | P3 — wraparound flag | Same bar: observation, not a triggerable defect. |
| **#3635** | P3 — split `summary_scan/mod.rs` | The `file-size` ratchet above. |
| **#3220 hardening** | opened as a **PR**, in-session, immediately after this merges | Per the owner's tightening: *open it, don't merely file it.* The new test's three SKIP guards must fail **closed** — the fixture is committed source (`git ls-files` lists it, `git check-ignore` does not match), so the module doc's "gitignored" premise is factually wrong and a skip would leave a green suite certifying nothing. Patch is pre-staged and anchor-asserted; it targets a file that only exists on `main` once this lands. |

---

*Certification by a fleet lane on behalf of the maintainers. The change itself, and all authorship, is @michaelsembwever's.*


---

<details><summary><b>Original PR description by @michaelsembwever</b> (unmodified)</summary>

Apply a query's `ScanTokenBound` on a BTI (`da`) reader, which dropped it.

## Related Issue
- Closes #3358

## Changes Made

`stream_all_partitions_for_query` accepted a `ScanTokenBound` and dropped it for every BTI generation, returning the whole ring with no error and no WARN.  The gate above its "full-ring fallback" is

```rust
if self.index_reader.is_some() && self.bti_partitions_db.is_none() && summary_usable {
```

and a `da` generation always has a `Partitions.db`, so the fallback is that format's only route.  Neither route below the gate takes a bound in its signature.  An `nb` generation holding the same rows narrowed exactly, which `tests/issue_2412_wraparound_scan.rs` pins with `assert_eq!`, so one parameter meant two things depending on the format underneath.

- `TokenGate` applies the range to the emit both fallback routes pass through, so the narrowing is a property of the call rather than of the route the reader chose.
- The verdict is computed once per partition, not once per row: a token is a property of the partition key, and a walk emits a partition's rows consecutively.
- `tests/issue_3358_bti_query_token_bound.rs` is the end-to-end pin, over the committed Cassandra-5.0.2-written `test_da.wide_multiclustering_small` fixture.
- The fallback's comment now records why the region is not a fallback for `da` files, so the next reader does not re-derive it.

No upstream line is deleted and no signature changes.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

### Component(s) Affected
- [x] cqlite-core
- [x] SSTable Reader
- [x] Tests

## Testing

### Test Environment
- OS: macOS 15 (Darwin 25.6.0)
- Rust version: 1.97.1 (`rust-toolchain.toml`)
- Test data: `test-data/datasets/sstables/test_da/wide_multiclustering_small-47f6a3008f6911f1bc0f8df8badcc262`, 600 rows over 5 partitions, written by Cassandra 5.0.2, with its `sstabledump -l` golden.  DDL: `test-data/schemas/wide-multiclustering-small-bti.cql`.

### Tests Run
- [x] Unit tests (`cargo test`)
- [x] Integration tests
- Local pre-merge mode used: `cargo fmt -p cqlite-core`, `RUSTFLAGS="-D warnings" cargo clippy -p cqlite-core --all-targets --all-features`, `env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core --no-fail-fast`

### Test Results

The new test on `main`, without the fix, keyed by partition with its row count:

```
running 3 tests
test unbounded_scan_matches_the_golden ... ok
test non_wraparound_range_emits_only_its_segment ... FAILED
test wraparound_range_emits_both_segments_and_nothing_between ... FAILED

---- non_wraparound_range_emits_only_its_segment ----
  left: {0: 20, 1: 80, 2: 20, 3: 80, 4: 400}
 right: {0: 20, 2: 20, 4: 400}

---- wraparound_range_emits_both_segments_and_nothing_between ----
  left: {0: 20, 1: 80, 2: 20, 3: 80, 4: 400}
 right: {1: 80, 3: 80}
```

and with it:

```
running 3 tests
test wraparound_range_emits_both_segments_and_nothing_between ... ok
test unbounded_scan_matches_the_golden ... ok
test non_wraparound_range_emits_only_its_segment ... ok

test result: ok. 3 passed; 0 failed
```

`cargo test -p cqlite-core --no-fail-fast` leaves the same 21 test targets failing with and without this change; every one of them opens a gitignored corpus this checkout does not hold.  The three `TokenGate` unit tests and the three cases above are the additions.

## Public Surface & Wiring Evidence

- [x] This PR adds/changes feature or performance behavior
- [x] **Call-chain evidence**
- [x] **End-to-end test from the public surface**
- [x] No new public API is a stub
- [x] If a fallback path exists, the e2e test distinguishes the NEW path from the fallback

**Public surface(s) exercised:** `SSTableReader::stream_all_partitions_for_query`, the same surface `tests/issue_2412_wraparound_scan.rs` drives; a merge consumer reaches it through `KWayMerger::new_from_readers(readers, schema, cancel, token_bound)` → `write_engine::merge::from_readers::drive_query_stream`.

**Call chain (public surface → new code):**

```
SSTableReader::stream_all_partitions_for_query(Some(schema), cancel, Some(bound), emit)
  → summary_scan/mod.rs: the Summary-guided gate, which a `da` reader always fails
  → the full-ring fallback: TokenGate::new(token_bound), wrapping `emit`
  → stream_all_partitions_for_compaction  (BTI or chunk-stitching)
    or stream_all_partitions_cancellable  (the rest)
```

The fallback *is* the path under test here, so there is no separate fast path to distinguish.  What the test distinguishes is narrowing from failing to read: the third case drives the same route unbounded and asserts every partition and every row against Cassandra's own dump, so a narrowed answer in the other two cases cannot be a reader that stopped working.  `open_reader` also asserts `reader.is_bti()`, so an `nb` fixture cannot silently satisfy the test through the already-correct route.

## Cassandra Compatibility
- [x] Maintains compatibility with existing Cassandra versions

A Cassandra 5 (`da`) file now honours a token range as a Cassandra 4 (`nb`) file already did.  Nothing changes for a caller passing `None`: `TokenGate::admits` returns `true` without hashing a key.

## Performance Impact
- [x] Performance improvement (include benchmark results)

Fewer rows leave the reader, and the rows a range excludes are no longer converted downstream.  Measured on our own equivalent of this gate, applied at the merge producer over one 203.7 MB `da` generation of 1,102,576 rows: the CPU time of a split fell 43%, 16.14 s to 9.14 s, and peak resident memory held at 35 to 39 MB where seven token ranges had previously reached 716 MB, out-of-range rows having queued in the merge before the consumer discarded them.

The read itself is unchanged.  These routes drain the data section sequentially with no partition-index seek, so a range still reads the whole file; two follow-up issues cover that, an early stop on a non-wraparound range (#3359) and a `Partitions.db`-driven range scan (#3360).

## Documentation
- [x] Code is self-documenting with clear variable names and comments
- [x] I have commented my code, particularly in hard-to-understand areas

The module doc already claimed the property this restores, that "out-of-range partition bodies are never read/decoded"; the fallback's comment now says what the fallback does with the range and why it is a `da` reader's only route.

## Additional Notes

Two placements were tried.  Filtering in `write_engine::merge::from_readers::drive_query_stream` fixes the merge consumer and leaves every other caller of the reader holding a dropped bound.  This PR takes the other: at the reader, so the parameter means the same thing for every consumer and both formats.


</details>
