### PR TITLE
test(#1714): AK3 standing mod-reachability guard for cqlite-core/src [HELD — blocked on #3366, do not merge]

### DIFF
--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -207,13 +207,13 @@ fn every_resolution_rule_is_observed_working() {
 
     for (key, rule) in cases {
         assert!(
-            report.enumerated.contains(&key.to_string()),
+            report.enumerated.contains(*key),
             "resolution-rule case `{key}` ({rule}) is not in the census — the case moved or \
              was renamed. Repoint it at a live file; do not delete the case, the rule needs a \
              witness."
         );
         assert!(
-            report.reachable.contains(&key.to_string()),
+            report.reachable.contains(*key),
             "resolution rule NOT working: `{key}` should be reachable via {rule}, but the \
              walker did not reach it. A rule that stopped resolving turns real files into \
              false orphans (and, combined with a wide exception list, hides real ones)."

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -28,13 +28,15 @@
 //! The walker itself lives in `support/mod_reachability.rs` and is crate-agnostic so
 //! #1502 (the `cqlite-cli` mod-wiring guard) can drive it for `src/main.rs`.
 
+#[path = "support/mod_reachability_harness.rs"]
+mod harness;
 #[path = "support/mod_reachability.rs"]
 mod mod_reachability;
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
 
+use harness::{stripped, ScratchCrate};
 use mod_reachability::{analyze, strip_comments_and_strings, ExpectedOrphan, ModuleGraphSpec};
 
 const SRC_DIR: &str = "src";
@@ -286,81 +288,6 @@ pub fn lifetimes<'a>(s: &'a str) -> &'a str { s }
     );
 }
 
-/// rustc DISCARDS a `#!` line at byte offset 0 of a source file, so whatever that line
-/// says is not Rust at all. Parsing it as ordinary code is the false-PASS path this
-/// asserts against: a `#!/usr/bin/env -S tool mod orphan;` first line would otherwise
-/// yield a bogus `mod orphan;` declaration and make an unreachable file look reachable —
-/// the exact silent green this guard exists to prevent (#1714).
-#[test]
-fn shebang_line_at_offset_zero_does_not_declare_a_module() {
-    let tree = ScratchCrate::new("shebang-not-a-decl");
-    tree.write(
-        "src/lib.rs",
-        "#!/usr/bin/env -S tool mod orphan;\npub mod wired;\n",
-    );
-    tree.write("src/wired.rs", "pub fn f() {}\n");
-    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
-
-    let report = tree.analyze();
-    assert_eq!(
-        report.orphans.iter().cloned().collect::<Vec<_>>(),
-        vec!["src/orphan.rs".to_string()],
-        "a `mod orphan;` inside a SHEBANG line (which rustc discards) must NOT make \
-         `orphan.rs` reachable; enumerated={:?} reachable={:?}",
-        report.enumerated,
-        report.reachable
-    );
-    assert!(
-        report.reachable.contains("src/wired.rs"),
-        "a shebang-bearing root must still resolve the real declarations below it"
-    );
-}
-
-/// The other direction of the same fix, and the one that would be catastrophic to get
-/// backwards: `#![...]` at byte offset 0 is a Rust INNER ATTRIBUTE (this crate's own
-/// `lib.rs` opens with one), not a shebang. Blanking it would eat the rest of that line,
-/// so the real `pub mod wired;` sharing it must survive.
-#[test]
-fn inner_attribute_at_offset_zero_is_not_mistaken_for_a_shebang() {
-    let tree = ScratchCrate::new("inner-attr-not-shebang");
-    tree.write("src/lib.rs", "#![allow(dead_code)] pub mod wired;\n");
-    tree.write("src/wired.rs", "pub fn f() {}\n");
-
-    let report = tree.analyze();
-    assert!(
-        report.orphans.is_empty(),
-        "`#![allow(dead_code)]` at offset 0 is an inner attribute, not a shebang — \
-         blanking its line swallowed the real `pub mod wired;`: orphans={:?}",
-        report.orphans
-    );
-    let out = stripped("#![allow(dead_code)] pub mod wired;\n");
-    assert_eq!(
-        out, "#![allow(dead_code)] pub mod wired;\n",
-        "an inner attribute at offset 0 must reach the parser byte-for-byte"
-    );
-}
-
-/// The shebang rule applies at BYTE OFFSET 0 and nowhere else: an implementation that
-/// stripped any line merely *starting* with `#!` would eat this file's real declaration,
-/// which sits on the ordinary `#![...]`-after-a-comment-header line every Rust crate has.
-#[test]
-fn hash_bang_after_offset_zero_is_not_a_shebang() {
-    let tree = ScratchCrate::new("hashbang-not-at-zero");
-    tree.write(
-        "src/lib.rs",
-        "//! Crate docs, line 1.\n//! Line 2.\n//! Line 3.\n\n#![allow(dead_code)] pub mod wired;\n",
-    );
-    tree.write("src/wired.rs", "pub fn f() {}\n");
-
-    let report = tree.analyze();
-    assert!(
-        report.orphans.is_empty(),
-        "a `#!` line that is NOT at byte offset 0 is not a shebang; its declarations must \
-         survive: orphans={:?}",
-        report.orphans
-    );
-}
-
 /// Every resolution rule, exercised against a tree the test controls end to end.
 #[test]
 fn synthetic_tree_exercises_every_resolution_rule() {
@@ -564,8 +491,11 @@ fn symlink_under_src_fails_closed() {
     tree.write("src/lib.rs", "pub mod wired;\n");
     tree.write("src/wired.rs", "pub fn f() {}\n");
     tree.write("outside/hidden_orphan.rs", "pub fn never_compiled() {}\n");
-    symlink(tree.dir.join("outside"), tree.dir.join("src/linked_dir"))
-        .unwrap_or_else(|e| panic!("cannot create directory symlink: {e}"));
+    symlink(
+        tree.dir().join("outside"),
+        tree.dir().join("src/linked_dir"),
+    )
+    .unwrap_or_else(|e| panic!("cannot create directory symlink: {e}"));
     let cause = tree.expect_failure();
     assert!(
         cause.contains("symlink") && cause.contains("linked_dir"),
@@ -578,8 +508,8 @@ fn symlink_under_src_fails_closed() {
     tree.write("src/wired.rs", "pub fn f() {}\n");
     tree.write("outside/target.rs", "pub fn f() {}\n");
     symlink(
-        tree.dir.join("outside/target.rs"),
-        tree.dir.join("src/linked.rs"),
+        tree.dir().join("outside/target.rs"),
+        tree.dir().join("src/linked.rs"),
     )
     .unwrap_or_else(|e| panic!("cannot create file symlink: {e}"));
     let cause = tree.expect_failure();
@@ -1241,10 +1171,6 @@ fn the_non_ascii_identifier_refusal_never_reds_ordinary_rust() {
 // Stripper unit tests (control vs data, at the sanitizer boundary)
 // ---------------------------------------------------------------------------
 
-fn stripped(src: &str) -> String {
-    strip_comments_and_strings(src).unwrap_or_else(|e| panic!("sanitize failed: {e}"))
-}
-
 #[test]
 fn stripper_blanks_every_comment_form() {
     for src in [
@@ -1329,122 +1255,5 @@ fn stripper_fails_closed_on_unterminated_input() {
             strip_comments_and_strings(src).is_err(),
             "unterminated {what} must fail closed rather than yield a guessed parse"
         );
-    }
-}
-
-/// A shebang line is blanked like every other non-Rust span: same byte length, newline
-/// preserved, so byte offsets and reported line numbers stay aligned with the original
-/// source. The both-directions half is asserted too — `#![...]` at offset 0 is an inner
-/// attribute and must reach the parser untouched — plus the fail-closed refusal for the
-/// one shape whose shebang-vs-attribute reading this walker does not model.
-#[test]
-fn stripper_blanks_a_shebang_but_never_an_inner_attribute() {
-    let src = "#!/usr/bin/env cargo\nmod a;\n";
-    let out = stripped(src);
-    assert_eq!(
-        out, "                    \nmod a;\n",
-        "the shebang line must be blanked in place (offsets and newline preserved): {out:?}"
-    );
-    assert_eq!(out.len(), src.len(), "byte offsets must be preserved");
-    assert_eq!(
-        out.matches('\n').count(),
-        src.matches('\n').count(),
-        "line breaks must be preserved so reported line numbers stay correct"
-    );
-
-    for attr in [
-        "#![allow(dead_code)]\nmod a;\n",
-        "#![doc = \"not a shebang\"]\nmod a;\n",
-    ] {
-        // The literal's own value is blanked (it is data), so compare the code skeleton.
-        let out = stripped(attr);
-        assert!(
-            out.starts_with("#![") && out.contains("mod a;"),
-            "`#![...]` at offset 0 is an inner attribute, not a shebang: {attr:?} -> {out:?}"
-        );
-    }
-
-    // `#!` + whitespace/comment + `[` is an inner attribute to rustc (it skips both
-    // before deciding) and a shebang to a naive next-byte test. This walker models
-    // neither reading, so it refuses rather than guessing (FAIL-CLOSED).
-    for src in [
-        "#! [allow(dead_code)]\nmod a;\n",
-        "#!\n[allow(dead_code)]\nmod a;\n",
-        "#!/* c */[allow(dead_code)]\nmod a;\n",
-        "#!// c\n[allow(dead_code)]\nmod a;\n",
-    ] {
-        assert!(
-            strip_comments_and_strings(src).is_err(),
-            "the unmodeled shebang-vs-inner-attribute shape must fail closed: {src:?}"
-        );
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Scratch crate helper
-// ---------------------------------------------------------------------------
-
-static SCRATCH_SEQ: AtomicUsize = AtomicUsize::new(0);
-
-/// A throwaway crate-shaped directory tree under the OS temp dir.
-struct ScratchCrate {
-    dir: PathBuf,
-}
-
-impl ScratchCrate {
-    fn new(label: &str) -> Self {
-        let seq = SCRATCH_SEQ.fetch_add(1, Ordering::SeqCst);
-        let dir = std::env::temp_dir().join(format!(
-            "cqlite-1714-mod-reach-{}-{seq}-{label}",
-            std::process::id()
-        ));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("cannot create {}: {e}", dir.display()));
-        Self { dir }
-    }
-
-    fn write(&self, rel: &str, contents: &str) {
-        let path = self.dir.join(rel);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .unwrap_or_else(|e| panic!("cannot create {}: {e}", parent.display()));
-        }
-        fs::write(&path, contents)
-            .unwrap_or_else(|e| panic!("cannot write {}: {e}", path.display()));
-    }
-
-    fn spec(&self) -> ModuleGraphSpec {
-        ModuleGraphSpec {
-            crate_dir: self.dir.clone(),
-            root_file_rel: "src/lib.rs".to_string(),
-            src_dir_rel: SRC_DIR.to_string(),
-        }
-    }
-
-    fn analyze(&self) -> mod_reachability::Report {
-        analyze(&self.spec()).unwrap_or_else(|cause| {
-            panic!(
-                "walk of scratch crate {} failed: {cause}",
-                self.dir.display()
-            )
-        })
-    }
-
-    /// Assert the walk fails closed and return the cause.
-    fn expect_failure(&self) -> String {
-        match analyze(&self.spec()) {
-            Ok(report) => panic!(
-                "expected a FAIL-CLOSED refusal, got a report (orphans={:?}) — a skip-and-continue \
-                 here IS the vacuous pass",
-                report.orphans
-            ),
-            Err(cause) => cause,
-        }
-    }
-}
-
-impl Drop for ScratchCrate {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.dir);
     }
 }

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -1,0 +1,594 @@
+//! Issue #1714 (AK3): every `cqlite-core/src/**/*.rs` file must be reachable from a
+//! `mod` declaration chain rooted at `lib.rs`.
+//!
+//! # Why this guard exists
+//!
+//! An unreachable file is **never compiled**. `cqlite-core/src/memory_safety_tests.rs`
+//! sat orphaned for months: 1000+ lines of "memory safety tests" that rustc never saw,
+//! so every edit to it was a silent no-op and every one of its assertions was dead
+//! text. Deleting it (PR #2044) fixed that instance; only a standing guard stops the
+//! next one. This is that guard — the issue's own words: "the real deliverable".
+//!
+//! # Anti-vacuity: the guard is OBSERVED to fire, not merely present
+//!
+//! A reachability walker has one catastrophic failure mode — enumerating nothing, or
+//! resolving nothing, and reporting green. So this lane:
+//!
+//! * asserts a **census floor** (a collapsed enumeration FAILs, never passes);
+//! * asserts a **named positive case per resolution rule**, so each rule is seen working
+//!   against the live tree;
+//! * **demonstrates the detector on a synthetic tree** (a throwaway crate with one
+//!   deliberate orphan), so the detector's teeth are proven independently of the live
+//!   tree's state — it keeps working after #1715 and #3364 empty the exception list;
+//! * proves `mod` mentions inside comments/strings are **data, not declarations**
+//!   (CLAUDE.md #3312), the false-PASS path a raw-text scan would take;
+//! * asserts the exception list **per entry**, fail-closed in BOTH directions (issue
+//!   #3220: a suite-wide aggregate cannot see one case skipping behind its siblings).
+//!
+//! The walker itself lives in `support/mod_reachability.rs` and is crate-agnostic so
+//! #1502 (the `cqlite-cli` mod-wiring guard) can drive it for `src/main.rs`.
+
+#[path = "support/mod_reachability.rs"]
+mod mod_reachability;
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use mod_reachability::{analyze, strip_comments_and_strings, ExpectedOrphan, ModuleGraphSpec};
+
+const SRC_DIR: &str = "src";
+
+/// Files known to be unreachable, each with the issue that owns removing it.
+///
+/// This list is **fail-closed both ways** (see [`exception_list_is_fail_closed`]): an
+/// entry whose file is gone FAILs, and an entry whose file became reachable FAILs. So
+/// #1715 and #3364 cannot land their deletions without deleting their entry here, and
+/// the list cannot silently accumulate stale excuses.
+const EXPECTED_ORPHANS: &[ExpectedOrphan] = &[
+    ExpectedOrphan {
+        path: "schema/cql_generator.rs",
+        issue: "#1715",
+        reason: "AK4 owns deleting this 856-LOC orphan; #1714 must not delete it here",
+    },
+    ExpectedOrphan {
+        path: "storage/sstable/header_fix_functions.rs",
+        issue: "#3364",
+        reason: "#3364 owns deleting this 102-LOC orphan; #1714 must not delete it here",
+    },
+];
+
+/// A collapsed census is the vacuous-pass failure mode, so the floor is asserted rather
+/// than assumed. There were 481 `.rs` files under `cqlite-core/src` when this landed;
+/// the floor is deliberately slack enough to survive ordinary refactoring.
+const CENSUS_FLOOR: usize = 300;
+
+fn core_spec() -> ModuleGraphSpec {
+    ModuleGraphSpec {
+        crate_dir: PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        root_file_rel: "src/lib.rs".to_string(),
+        src_dir_rel: SRC_DIR.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The live lane
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cqlite_core_src_has_no_unknown_orphan_modules() {
+    let spec = core_spec();
+    let report = match analyze(&spec) {
+        Ok(report) => report,
+        Err(cause) => panic!(
+            "mod-reachability walk of `cqlite-core/src` could not complete: {cause}\n\
+             This is a FAIL-CLOSED refusal, not a pass: the walker met a construct it does \
+             not model, so it cannot certify that every file is compiled. Either teach the \
+             walker that construct (tests/support/mod_reachability.rs) or remove it."
+        ),
+    };
+
+    assert!(
+        report.enumerated.len() >= CENSUS_FLOOR,
+        "census collapsed: enumerated only {} `.rs` file(s) under `{}` (floor {CENSUS_FLOOR}).\n\
+         A walker that enumerates (almost) nothing reports green while checking nothing — the \
+         vacuous pass this guard exists to prevent. Fix the enumeration, do not lower the floor.",
+        report.enumerated.len(),
+        SRC_DIR
+    );
+    assert!(
+        report.mod_decls_resolved >= CENSUS_FLOOR,
+        "only {} `mod` declaration(s) resolved from `src/lib.rs` — the module graph did not \
+         actually get walked, so every file would look orphaned (or, with an over-broad \
+         exception list, every file would look fine). Vacuous either way.",
+        report.mod_decls_resolved
+    );
+
+    let unexpected = report.unexpected_orphans(EXPECTED_ORPHANS, SRC_DIR);
+    assert!(
+        unexpected.is_empty(),
+        "unreachable file(s) under `cqlite-core/src` — no `mod` chain from `lib.rs` reaches \
+         them, so rustc NEVER COMPILES them and every edit to them is a silent no-op \
+         (tests inside them never run):\n  {}\n\n\
+         Two legitimate remedies:\n  \
+         1. wire it in — add the `mod <name>;` declaration that makes it part of the crate;\n  \
+         2. delete it — an uncompiled file is not code, it is text.\n\
+         If it is deliberate dead code pending a tracked deletion, add an entry to \
+         EXPECTED_ORPHANS in this file citing THAT issue (#1714 AK3).",
+        unexpected.join("\n  ")
+    );
+}
+
+#[test]
+fn exception_list_is_fail_closed() {
+    let spec = core_spec();
+    let report = analyze(&spec).unwrap_or_else(|cause| panic!("walk failed: {cause}"));
+
+    // Per ENTRY, never a suite-wide aggregate (#3220): an aggregate cannot see one
+    // entry going stale behind its siblings.
+    for expected in EXPECTED_ORPHANS {
+        let key = format!("{SRC_DIR}/{}", expected.path);
+        let abs = spec.crate_dir.join(&key);
+        assert!(
+            abs.is_file(),
+            "stale exception: `{key}` (owner {}) no longer exists.\n\
+             Remedy: the file was deleted — remove this exception entry from EXPECTED_ORPHANS.",
+            expected.issue
+        );
+        assert!(
+            report.orphans.contains(&key),
+            "stale exception: `{key}` (owner {}) is now REACHABLE from `lib.rs`.\n\
+             Remedy: this file is wired in — remove this exception entry from EXPECTED_ORPHANS.\n\
+             Reason recorded when the entry was added: {}",
+            expected.issue,
+            expected.reason
+        );
+    }
+}
+
+/// One named live-tree case per resolution rule, so every rule is OBSERVED working.
+/// If a rule silently stopped resolving, the live lane above would report a flood of
+/// false orphans — but only after someone had already been told "everything is fine"
+/// by a walker that quietly resolved nothing. These cases pin the rules directly.
+#[test]
+fn every_resolution_rule_is_observed_working() {
+    let spec = core_spec();
+    let report = analyze(&spec).unwrap_or_else(|cause| panic!("walk failed: {cause}"));
+
+    let cases: &[(&str, &str)] = &[
+        // `mod name;` in lib.rs -> `name.rs`
+        (
+            "src/config.rs",
+            "plain `pub mod config;` in lib.rs -> config.rs",
+        ),
+        // `mod name;` in lib.rs -> `name/mod.rs`
+        (
+            "src/storage/mod.rs",
+            "`pub mod storage;` in lib.rs -> storage/mod.rs",
+        ),
+        // `mod name;` in `foo.rs` -> `foo/name.rs` (a non-mod.rs file owns `foo/`)
+        (
+            "src/types/comparator.rs",
+            "`pub mod comparator;` in types.rs -> types/comparator.rs",
+        ),
+        // cfg-gated modules are REACHABLE (issue #1714 AC-3) — no feature evaluation.
+        (
+            "src/types/comparator_test.rs",
+            "`#[cfg(test)] mod comparator_test;` in types.rs is reachable despite the cfg",
+        ),
+        // `#[path = "…"]` is relative to the directory of the DECLARING FILE.
+        (
+            "src/observability/otel_tests.rs",
+            "`#[path = \"otel_tests.rs\"]` in observability/otel.rs",
+        ),
+        (
+            "src/export/arrow_size_render.rs",
+            "`#[path = \"arrow_size_render.rs\"]` in export/arrow_size.rs",
+        ),
+        (
+            "src/query/select_executor/row_build_alloc_budget_test.rs",
+            "`#[path = \"row_build_alloc_budget_test.rs\"]` in query/select_executor/row_build.rs",
+        ),
+        (
+            "src/storage/sstable/reader/scan_stream_windowed_guard.rs",
+            "`#[path = \"scan_stream_windowed_guard.rs\"]` in reader/scan_stream_windowed.rs",
+        ),
+    ];
+
+    for (key, rule) in cases {
+        assert!(
+            report.enumerated.contains(&key.to_string()),
+            "resolution-rule case `{key}` ({rule}) is not in the census — the case moved or \
+             was renamed. Repoint it at a live file; do not delete the case, the rule needs a \
+             witness."
+        );
+        assert!(
+            report.reachable.contains(&key.to_string()),
+            "resolution rule NOT working: `{key}` should be reachable via {rule}, but the \
+             walker did not reach it. A rule that stopped resolving turns real files into \
+             false orphans (and, combined with a wide exception list, hides real ones)."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detector demonstration on synthetic trees (the mechanized TDD requirement)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn detector_reports_exactly_the_unreachable_file() {
+    let tree = ScratchCrate::new("detects-orphan");
+    tree.write("src/lib.rs", "pub mod wired;\n");
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+    let report = tree.analyze();
+    assert_eq!(
+        report.orphans.iter().cloned().collect::<Vec<_>>(),
+        vec!["src/orphan.rs".to_string()],
+        "the detector must report EXACTLY the unreachable file; enumerated={:?} reachable={:?}",
+        report.enumerated,
+        report.reachable
+    );
+    assert_eq!(
+        report.enumerated.len(),
+        3,
+        "census must see all three files"
+    );
+}
+
+/// A `mod` mention inside a comment or a literal is DATA, not a declaration
+/// (CLAUDE.md #3312). Scanning raw text would make this orphan look reachable — a
+/// false PASS, the worst outcome for a hygiene guard. Live instance of the hazard:
+/// `src/storage/write_engine/merge/mod.rs` mentions `cql_generator` in a doc comment.
+#[test]
+fn mod_mentions_in_comments_and_literals_are_data_not_declarations() {
+    let tree = ScratchCrate::new("data-not-control");
+    tree.write(
+        "src/lib.rs",
+        r####"
+//! Doc comment mentioning `mod orphan;` — data.
+// Line comment: mod orphan;
+/* block comment: mod orphan;
+   /* nested: mod orphan; */
+   still a comment: mod orphan; */
+/** outer doc block: mod orphan; */
+pub mod wired;
+
+pub const A: &str = "mod orphan;";
+pub const B: &str = r"mod orphan;";
+pub const C: &str = r#"raw with quote " and mod orphan;"#;
+pub const D: &str = r##"deeper "# raw and mod orphan;"##;
+pub const E: &str = "escaped quote \" then mod orphan;";
+pub const F: &[u8] = b"byte string mod orphan;";
+pub const G: char = '\'';
+pub fn lifetimes<'a>(s: &'a str) -> &'a str { s }
+"####,
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+    let report = tree.analyze();
+    assert_eq!(
+        report.orphans.iter().cloned().collect::<Vec<_>>(),
+        vec!["src/orphan.rs".to_string()],
+        "a `mod orphan;` inside a comment or a literal must NOT make `orphan.rs` reachable"
+    );
+}
+
+/// Every resolution rule, exercised against a tree the test controls end to end.
+#[test]
+fn synthetic_tree_exercises_every_resolution_rule() {
+    let tree = ScratchCrate::new("all-rules");
+    tree.write(
+        "src/lib.rs",
+        r#"
+pub mod flat;                       // -> src/flat.rs
+pub mod nested;                     // -> src/nested/mod.rs
+pub(crate) mod vis_crate;           // visibility prefixes are accepted
+pub(in crate::nested) mod vis_in;
+#[cfg(test)]
+mod cfg_gated;                      // cfg-gated is REACHABLE (AC-3)
+#[cfg(feature = "nope")]
+mod cfg_feature_gated;
+#[cfg_attr(test, allow(dead_code))]
+mod cfg_attr_gated;
+#[path = "redirected_by_path.rs"]
+mod aliased;                        // #[path] is relative to lib.rs's directory
+pub mod inline_host;
+"#,
+    );
+    tree.write("src/flat.rs", "pub mod child;\n"); // -> src/flat/child.rs
+    tree.write("src/flat/child.rs", "pub fn f() {}\n");
+    // A mod-rs file (`mod.rs`): a `#[path]` mod inside an inline block resolves under
+    // `<dir-of-mod.rs>/<inline names>/`, with NO file-stem component.
+    tree.write(
+        "src/nested/mod.rs",
+        r#"
+pub mod leaf;
+pub mod inner2 {
+    #[path = "deep_alias.rs"]
+    mod aliased;
+}
+"#,
+    );
+    tree.write("src/nested/inner2/deep_alias.rs", "pub fn f() {}\n");
+    tree.write("src/nested/leaf.rs", "pub fn f() {}\n");
+    tree.write("src/vis_crate.rs", "pub fn f() {}\n");
+    tree.write("src/vis_in.rs", "pub fn f() {}\n");
+    tree.write("src/cfg_gated.rs", "pub fn f() {}\n");
+    tree.write("src/cfg_feature_gated.rs", "pub fn f() {}\n");
+    tree.write("src/cfg_attr_gated.rs", "pub fn f() {}\n");
+    tree.write("src/redirected_by_path.rs", "pub fn f() {}\n");
+    // A non-mod-rs file (`inline_host.rs`): an inline block contributes no file of its
+    // own, and both a plain `mod` and a `#[path]` mod inside it resolve under
+    // `<dir>/<stem>/<inline names>/` — the stem component is what distinguishes this
+    // from the mod-rs case above (Rust Reference, "Modules / The path attribute").
+    tree.write(
+        "src/inline_host.rs",
+        r#"
+pub mod inner {
+    pub mod deep;
+    #[path = "path_in_inline.rs"]
+    mod aliased_inner;
+}
+pub fn f() {}
+"#,
+    );
+    tree.write("src/inline_host/inner/deep.rs", "pub fn f() {}\n");
+    tree.write("src/inline_host/inner/path_in_inline.rs", "pub fn f() {}\n");
+
+    let report = tree.analyze();
+    assert!(
+        report.orphans.is_empty(),
+        "every file in this tree is wired in, yet the walker reported orphans: {:?}",
+        report.orphans
+    );
+    assert_eq!(
+        report.enumerated.len(),
+        report.reachable.len(),
+        "census and reachable set must coincide for a fully-wired tree"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed: unmodeled constructs are errors, never skips
+// ---------------------------------------------------------------------------
+
+#[test]
+fn include_macro_fails_closed() {
+    let tree = ScratchCrate::new("include-macro");
+    tree.write(
+        "src/lib.rs",
+        "pub mod wired;\ninclude!(\"generated.rs\");\n",
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/generated.rs", "pub fn f() {}\n");
+    let cause = tree.expect_failure();
+    assert!(
+        cause.contains("include!"),
+        "an `include!` must fail closed naming itself; got: {cause}"
+    );
+}
+
+#[test]
+fn unresolvable_mod_declaration_fails_closed() {
+    let tree = ScratchCrate::new("unresolvable-mod");
+    tree.write("src/lib.rs", "pub mod ghost;\n");
+    let cause = tree.expect_failure();
+    assert!(
+        cause.contains("src/ghost.rs") && cause.contains("src/ghost/mod.rs"),
+        "an unresolvable `mod` must name both candidates; got: {cause}"
+    );
+}
+
+#[test]
+fn path_attr_on_inline_mod_fails_closed() {
+    let tree = ScratchCrate::new("path-on-inline");
+    tree.write(
+        "src/lib.rs",
+        "#[path = \"elsewhere\"]\npub mod inline_block { pub fn f() {} }\n",
+    );
+    let cause = tree.expect_failure();
+    assert!(
+        cause.contains("INLINE"),
+        "`#[path]` on an inline mod block must fail closed; got: {cause}"
+    );
+}
+
+#[test]
+fn cfg_attr_path_redirect_fails_closed() {
+    let tree = ScratchCrate::new("cfg-attr-path");
+    tree.write(
+        "src/lib.rs",
+        "#[cfg_attr(test, path = \"other.rs\")]\nmod thing;\n",
+    );
+    tree.write("src/thing.rs", "pub fn f() {}\n");
+    tree.write("src/other.rs", "pub fn f() {}\n");
+    let cause = tree.expect_failure();
+    assert!(
+        cause.contains("cfg_attr"),
+        "a conditional `#[cfg_attr(…, path = …)]` redirect must fail closed; got: {cause}"
+    );
+}
+
+#[test]
+fn missing_path_target_fails_closed() {
+    let tree = ScratchCrate::new("missing-path-target");
+    tree.write("src/lib.rs", "#[path = \"nope.rs\"]\nmod aliased;\n");
+    let cause = tree.expect_failure();
+    assert!(
+        cause.contains("nope.rs") && cause.contains("does not exist"),
+        "a `#[path]` pointing at a missing file must fail closed; got: {cause}"
+    );
+}
+
+#[test]
+fn empty_source_tree_fails_closed_rather_than_passing() {
+    let tree = ScratchCrate::new("no-src-dir");
+    // Deliberately no `src/` at all.
+    let cause = tree.expect_failure();
+    assert!(
+        cause.contains("source directory"),
+        "a missing source directory must fail closed (a zero census is the vacuous pass); \
+         got: {cause}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Stripper unit tests (control vs data, at the sanitizer boundary)
+// ---------------------------------------------------------------------------
+
+fn stripped(src: &str) -> String {
+    strip_comments_and_strings(src).unwrap_or_else(|e| panic!("sanitize failed: {e}"))
+}
+
+#[test]
+fn stripper_blanks_every_comment_form() {
+    for src in [
+        "// mod x;\nlet a = 1;\n",
+        "/// mod x;\nlet a = 1;\n",
+        "//! mod x;\nlet a = 1;\n",
+        "/* mod x; */let a = 1;\n",
+        "/* outer /* nested mod x; */ still outer mod x; */let a = 1;\n",
+        "/** doc block mod x; */let a = 1;\n",
+    ] {
+        let out = stripped(src);
+        assert!(
+            !out.contains("mod x"),
+            "comment content survived the stripper: input {src:?} -> {out:?}"
+        );
+        assert!(
+            out.contains("let a = 1;"),
+            "the stripper ate real code: input {src:?} -> {out:?}"
+        );
+        assert_eq!(
+            out.len(),
+            src.len(),
+            "the stripper must preserve byte offsets so diagnostics stay accurate"
+        );
+        assert_eq!(
+            out.matches('\n').count(),
+            src.matches('\n').count(),
+            "the stripper must preserve line breaks so reported line numbers are correct"
+        );
+    }
+}
+
+#[test]
+fn stripper_blanks_every_literal_form() {
+    for src in [
+        "let s = \"mod x;\";\n",
+        "let s = \"escaped \\\" then mod x;\";\n",
+        "let s = r\"mod x;\";\n",
+        "let s = r#\"quote \" and mod x;\"#;\n",
+        "let s = r##\"deeper \"# and mod x;\"##;\n",
+        "let s = b\"mod x;\";\n",
+        "let s = br#\"mod x;\"#;\n",
+    ] {
+        let out = stripped(src);
+        assert!(
+            !out.contains("mod x"),
+            "literal content survived the stripper: input {src:?} -> {out:?}"
+        );
+        assert_eq!(out.len(), src.len(), "byte offsets must be preserved");
+    }
+}
+
+#[test]
+fn stripper_keeps_lifetimes_and_char_literals_apart() {
+    let src = "fn f<'a>(c: char) -> &'a str { let q = '\\''; let z = 'x'; \"s\" }\n";
+    let out = stripped(src);
+    assert!(
+        out.contains("fn f<'a>") && out.contains("&'a str"),
+        "lifetimes must survive (mistaking one for a char literal would swallow real code): {out:?}"
+    );
+    assert_eq!(out.len(), src.len(), "byte offsets must be preserved");
+    assert!(
+        !out.contains('"'),
+        "string literals must be blanked: {out:?}"
+    );
+}
+
+#[test]
+fn stripper_fails_closed_on_unterminated_input() {
+    for (src, what) in [
+        ("/* never closed\n", "block comment"),
+        ("let s = \"never closed\n", "string literal"),
+        ("let s = r#\"never closed\n", "raw string literal"),
+    ] {
+        assert!(
+            strip_comments_and_strings(src).is_err(),
+            "unterminated {what} must fail closed rather than yield a guessed parse"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scratch crate helper
+// ---------------------------------------------------------------------------
+
+static SCRATCH_SEQ: AtomicUsize = AtomicUsize::new(0);
+
+/// A throwaway crate-shaped directory tree under the OS temp dir.
+struct ScratchCrate {
+    dir: PathBuf,
+}
+
+impl ScratchCrate {
+    fn new(label: &str) -> Self {
+        let seq = SCRATCH_SEQ.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-1714-mod-reach-{}-{seq}-{label}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("cannot create {}: {e}", dir.display()));
+        Self { dir }
+    }
+
+    fn write(&self, rel: &str, contents: &str) {
+        let path = self.dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .unwrap_or_else(|e| panic!("cannot create {}: {e}", parent.display()));
+        }
+        fs::write(&path, contents)
+            .unwrap_or_else(|e| panic!("cannot write {}: {e}", path.display()));
+    }
+
+    fn spec(&self) -> ModuleGraphSpec {
+        ModuleGraphSpec {
+            crate_dir: self.dir.clone(),
+            root_file_rel: "src/lib.rs".to_string(),
+            src_dir_rel: SRC_DIR.to_string(),
+        }
+    }
+
+    fn analyze(&self) -> mod_reachability::Report {
+        analyze(&self.spec()).unwrap_or_else(|cause| {
+            panic!(
+                "walk of scratch crate {} failed: {cause}",
+                self.dir.display()
+            )
+        })
+    }
+
+    /// Assert the walk fails closed and return the cause.
+    fn expect_failure(&self) -> String {
+        match analyze(&self.spec()) {
+            Ok(report) => panic!(
+                "expected a FAIL-CLOSED refusal, got a report (orphans={:?}) — a skip-and-continue \
+                 here IS the vacuous pass",
+                report.orphans
+            ),
+            Err(cause) => cause,
+        }
+    }
+}
+
+impl Drop for ScratchCrate {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -768,6 +768,128 @@ fn unrecognized_literal_prefix_fails_closed() {
     }
 }
 
+/// **The identifier-family half of the same boundary.** Rust identifiers are
+/// `XID_Start XID_Continue*`, so `macro_rules! café { () => { mod orphan; } }` is a real
+/// macro definition — and this walker's lexer is deliberately ASCII-only. Scanning past
+/// the `é` lexes the macro name as `caf`, leaves the rest to the ordinary scan, fails to
+/// recognize the macro context, and counts the `mod orphan;` in the macro body as a real
+/// declaration: the walker's critical FALSE PASS, arrived at with no unrecognized prefix
+/// anywhere in sight.
+///
+/// The fix is the same one the prefix family got — refuse, never skip — because the
+/// alternative is shipping Unicode XID tables, i.e. a second implementation of rustc's
+/// lexer, which is what produced this walker's review history. Both positions are pinned:
+/// a non-ASCII character where an identifier could START, and one where the identifier
+/// just scanned could CONTINUE.
+#[test]
+fn non_ascii_identifiers_fail_closed_rather_than_hiding_a_macro_context() {
+    for (label, snippet, shown, position) in [
+        // THE case: without the refusal this walk reports zero orphans.
+        (
+            "unicode-macro-definition",
+            "macro_rules! café { () => { mod orphan; } }\npub mod wired;\n",
+            "é",
+            "CONTINUE",
+        ),
+        (
+            "unicode-macro-invocation",
+            "pub fn f() { café!(mod orphan;); }\npub mod wired;\n",
+            "é",
+            "CONTINUE",
+        ),
+        // An ordinary Unicode identifier: legal Rust this walker refuses to read rather
+        // than half-read. A loud refusal is the doctrine; a silent half-parse is not.
+        (
+            "unicode-identifier-continue",
+            "pub fn f() { let café = 1; let _ = café; }\npub mod wired;\n",
+            "é",
+            "CONTINUE",
+        ),
+        // XID_Start itself non-ASCII, so the very first byte of the identifier is the
+        // refusal point — the START position, reached from the sanitizer's scan loop.
+        (
+            "unicode-identifier-start",
+            "pub fn f() { let _ = Übersicht; }\npub mod wired;\n",
+            "Ü",
+            "START",
+        ),
+        (
+            "non-latin-identifier-start",
+            "pub fn 模块() {}\npub mod wired;\n",
+            "模",
+            "START",
+        ),
+    ] {
+        let tree = ScratchCrate::new(&format!("non-ascii-{label}"));
+        tree.write("src/lib.rs", snippet);
+        tree.write("src/wired.rs", "pub fn f() {}\n");
+        tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+        let cause = tree.expect_failure();
+        assert!(
+            cause.contains("NON-ASCII character"),
+            "case `{label}`: a non-ASCII identifier byte must fail CLOSED as a non-ASCII \
+             refusal — scanning past it is the silent false PASS; got: {cause}"
+        );
+        assert!(
+            cause.contains(shown),
+            "case `{label}`: the refusal must NAME the offending character (`{shown}`); \
+             got: {cause}"
+        );
+        assert!(
+            cause.contains(position),
+            "case `{label}`: the refusal must say which identifier position it refused \
+             ({position}); got: {cause}"
+        );
+        assert!(
+            cause.contains("ASCII-only"),
+            "case `{label}`: the refusal must state that the ASCII-only identifier rules \
+              are deliberate, so the reader does not \"fix\" them by widening a byte range; \
+             got: {cause}"
+        );
+        assert!(
+            cause.contains("src/lib.rs") && cause.contains("line 1"),
+            "case `{label}`: the refusal must name the file and line; got: {cause}"
+        );
+        assert!(
+            cause.contains("#1714"),
+            "case `{label}`: the refusal must point at the issue that owns the lexer; \
+             got: {cause}"
+        );
+    }
+}
+
+/// The refusal must not fire on a non-ASCII character that is DATA. Comments and string
+/// literals are where non-ASCII actually lives in this repository (456 of the ~540 files
+/// measured below contain some), and the sanitizer blanks them before the identifier scan
+/// can reach a byte inside one — so every one of those files must walk cleanly. A refusal
+/// branch that reds on ordinary prose is the branch someone deletes.
+#[test]
+fn non_ascii_in_comments_and_literals_is_data_not_an_identifier() {
+    let tree = ScratchCrate::new("non-ascii-data");
+    tree.write(
+        "src/lib.rs",
+        "// café — mod orphan;\n\
+         /// Übersicht: mod orphan;\n\
+         /* 模块 mod orphan; */\n\
+         pub fn f() -> &'static str { \"café mod orphan;\" }\n\
+         pub fn g() -> &'static str { r#\"Übersicht mod orphan;\"# }\n\
+         pub fn h() -> char { '模' }\n\
+         pub mod wired;\n",
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+    let report = tree.analyze();
+    assert_eq!(
+        report.orphans.iter().cloned().collect::<Vec<_>>(),
+        vec!["src/orphan.rs".to_string()],
+        "non-ASCII inside comments and literals is DATA: it must neither red the walk nor \
+         hide the orphan; reachable={:?}",
+        report.reachable
+    );
+}
+
 /// A raw identifier is legal in a `mod` declaration, and the `r#` is **not** part of the
 /// name: `mod r#type;` declares a module whose file is `type.rs`. Failing closed here
 /// would be a real false FAIL the moment someone writes `mod r#try;`, so the resolution
@@ -881,24 +1003,31 @@ pub fn g<'a>(r#match: &'a str) -> &'a str { r#match }
     );
 }
 
-/// The anti-vacuity complement to [`unrecognized_literal_prefix_fails_closed`]: a
-/// refusal branch that reds on ORDINARY Rust is the branch someone deletes, and deleting
-/// it re-opens the whole false-PASS family. So the lexer is measured against every real
-/// `.rs` file in the two crates it serves — `cqlite-core/src` (this guard's subject) and
-/// `cqlite-cli/src` (#1502's subject, which will drive the same walker) — and must refuse
-/// none of them.
+// ---------------------------------------------------------------------------
+// Real-corpus anti-vacuity measurement
+// ---------------------------------------------------------------------------
+
+/// Every real `.rs` file in the two crates this walker serves — `cqlite-core/src` (its
+/// subject) and `cqlite-cli/src` (#1502's subject, which will drive the same walker).
 ///
-/// Measured when this landed: 1400 `.rs` files across the whole workspace produced
-/// exactly one refusal, and that one is correct (a rust-script file whose shebang makes
-/// `#\!` an invalid Rust escape, outside any crate's `src`).
-#[test]
-fn the_prefix_refusal_never_reds_ordinary_rust() {
+/// Nothing here is allowed to swallow a filesystem error. `read_dir`'s iterator yields a
+/// `Result` PER ENTRY, and the idiomatic-looking `entries.flatten()` DISCARDS the `Err`
+/// arm: a directory whose entries fail to stat would silently shrink the census while the
+/// count floor below still passed — a vacuous pass in the very measurement that exists to
+/// prove the refusals are not over-broad. Same for `Path::is_dir()`, which answers `false`
+/// on an IO error, so the entry's `file_type()` is asked instead and its error propagated.
+fn real_rust_corpus() -> Vec<PathBuf> {
     fn collect(dir: &PathBuf, out: &mut Vec<PathBuf>) {
         let entries =
             fs::read_dir(dir).unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()));
-        for entry in entries.flatten() {
+        for entry in entries {
+            let entry =
+                entry.unwrap_or_else(|e| panic!("cannot read an entry of {}: {e}", dir.display()));
             let path = entry.path();
-            if path.is_dir() {
+            let file_type = entry
+                .file_type()
+                .unwrap_or_else(|e| panic!("cannot stat {}: {e}", path.display()));
+            if file_type.is_dir() {
                 collect(&path, out);
             } else if path.extension().map(|e| e == "rs").unwrap_or(false) {
                 out.push(path);
@@ -926,21 +1055,110 @@ fn the_prefix_refusal_never_reds_ordinary_rust() {
         "only {} files probed — the census collapsed, so this test proved nothing",
         files.len()
     );
+    files
+}
 
+/// Read a corpus file, refusing to guess at an unreadable one.
+fn read_corpus_file(path: &PathBuf) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// The anti-vacuity complement to [`unrecognized_literal_prefix_fails_closed`]: a
+/// refusal branch that reds on ORDINARY Rust is the branch someone deletes, and deleting
+/// it re-opens the whole false-PASS family. So the lexer is measured against every real
+/// `.rs` file in the two crates it serves and must refuse none of them.
+///
+/// Measured when this landed: 1400 `.rs` files across the whole workspace produced
+/// exactly one refusal, and that one is correct (a rust-script file whose shebang makes
+/// `#!` an invalid Rust escape, outside any crate's `src`).
+#[test]
+fn the_prefix_refusal_never_reds_ordinary_rust() {
+    let files = real_rust_corpus();
     let mut refusals = Vec::new();
     for file in &files {
-        let text = fs::read_to_string(file)
-            .unwrap_or_else(|e| panic!("cannot read {}: {e}", file.display()));
-        if let Err(cause) = mod_reachability::sanitize(&text) {
+        if let Err(cause) = mod_reachability::sanitize(&read_corpus_file(file)) {
             refusals.push(format!("{}: {cause}", file.display()));
         }
     }
     assert!(
         refusals.is_empty(),
-        "the lexer refused {} real Rust file(s); an over-broad refusal is the branch \
+        "the lexer refused {} of {} real Rust file(s); an over-broad refusal is the branch \
          someone deletes:\n{}",
         refusals.len(),
+        files.len(),
         refusals.join("\n")
+    );
+}
+
+/// The same measurement for the NON-ASCII identifier refusal, which needs its own case
+/// because non-ASCII is *common* in this repository's real code — em dashes and accented
+/// words in comments, doc comments and string literals — while being *rare* in the one
+/// position the refusal covers. If the refusal fired on data, this guard would red on
+/// hundreds of ordinary files and be deleted within a week.
+///
+/// Three properties, so a pass cannot be vacuous:
+/// 1. a large majority of the corpus genuinely CONTAINS non-ASCII bytes (asserted, not
+///    assumed — otherwise the probe would be measuring ASCII files and proving nothing);
+/// 2. no such file is refused;
+/// 3. each one's SANITIZED text is pure ASCII and the same byte length as the input, i.e.
+///    every non-ASCII byte went through the blanking path rather than past the scan. That
+///    is the invariant `parse_mod_decls`, `find_mod_token` and `ident_token` rely on when
+///    they apply ASCII-only identifier rules to sanitized text.
+#[test]
+fn the_non_ascii_identifier_refusal_never_reds_ordinary_rust() {
+    let files = real_rust_corpus();
+    let mut with_non_ascii = 0usize;
+    let mut refusals = Vec::new();
+    let mut leaked = Vec::new();
+
+    for file in &files {
+        let text = read_corpus_file(file);
+        if text.is_ascii() {
+            continue;
+        }
+        with_non_ascii += 1;
+        match mod_reachability::sanitize(&text) {
+            Err(cause) => refusals.push(format!("{}: {cause}", file.display())),
+            Ok(sanitized) => {
+                if !sanitized.text.is_ascii() || sanitized.text.len() != text.len() {
+                    leaked.push(file.display().to_string());
+                }
+            }
+        }
+    }
+
+    // Property 1: the hazard is actually present in the corpus.
+    assert!(
+        with_non_ascii >= 100,
+        "only {with_non_ascii} of {} corpus files contain non-ASCII bytes — the probe is \
+         measuring ASCII files and proves nothing about the non-ASCII refusal",
+        files.len()
+    );
+    // Property 2: it never fires on them.
+    assert!(
+        refusals.is_empty(),
+        "the non-ASCII refusal fired on {} of {with_non_ascii} real Rust file(s) that carry \
+         non-ASCII text; a refusal that reds ordinary prose is the branch someone deletes, \
+         so this is a DESIGN problem, not a file to fix:\n{}",
+        refusals.len(),
+        refusals.join("\n")
+    );
+    // Property 3: every one of those bytes was blanked, offsets preserved.
+    assert!(
+        leaked.is_empty(),
+        "{} file(s) sanitized to text that is not pure ASCII (or changed byte length), so a \
+         non-ASCII byte reached code position unrefused — the downstream parsers' \
+         ASCII-only identifier rules would split an identifier around it:\n{}",
+        leaked.len(),
+        leaked.join("\n")
+    );
+
+    // The measurement itself, so a reader of the test output sees what was covered rather
+    // than trusting the assertions' silence.
+    eprintln!(
+        "non-ASCII refusal census: {} real .rs files scanned, {with_non_ascii} carried \
+         non-ASCII bytes, 0 refusals",
+        files.len()
     );
 }
 

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -32,7 +32,7 @@
 mod mod_reachability;
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use mod_reachability::{analyze, strip_comments_and_strings, ExpectedOrphan, ModuleGraphSpec};
@@ -1092,7 +1092,7 @@ pub fn g<'a>(r#match: &'a str) -> &'a str { r#match }
 /// prove the refusals are not over-broad. Same for `Path::is_dir()`, which answers `false`
 /// on an IO error, so the entry's `file_type()` is asked instead and its error propagated.
 fn real_rust_corpus() -> Vec<PathBuf> {
-    fn collect(dir: &PathBuf, out: &mut Vec<PathBuf>) {
+    fn collect(dir: &Path, out: &mut Vec<PathBuf>) {
         let entries =
             fs::read_dir(dir).unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()));
         for entry in entries {
@@ -1134,7 +1134,7 @@ fn real_rust_corpus() -> Vec<PathBuf> {
 }
 
 /// Read a corpus file, refusing to guess at an unreadable one.
-fn read_corpus_file(path: &PathBuf) -> String {
+fn read_corpus_file(path: &Path) -> String {
     fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
 }
 

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -881,6 +881,69 @@ pub fn g<'a>(r#match: &'a str) -> &'a str { r#match }
     );
 }
 
+/// The anti-vacuity complement to [`unrecognized_literal_prefix_fails_closed`]: a
+/// refusal branch that reds on ORDINARY Rust is the branch someone deletes, and deleting
+/// it re-opens the whole false-PASS family. So the lexer is measured against every real
+/// `.rs` file in the two crates it serves — `cqlite-core/src` (this guard's subject) and
+/// `cqlite-cli/src` (#1502's subject, which will drive the same walker) — and must refuse
+/// none of them.
+///
+/// Measured when this landed: 1400 `.rs` files across the whole workspace produced
+/// exactly one refusal, and that one is correct (a rust-script file whose shebang makes
+/// `#\!` an invalid Rust escape, outside any crate's `src`).
+#[test]
+fn the_prefix_refusal_never_reds_ordinary_rust() {
+    fn collect(dir: &PathBuf, out: &mut Vec<PathBuf>) {
+        let entries =
+            fs::read_dir(dir).unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()));
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect(&path, out);
+            } else if path.extension().map(|e| e == "rs").unwrap_or(false) {
+                out.push(path);
+            }
+        }
+    }
+
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cqlite-core has a parent workspace directory")
+        .to_path_buf();
+    let mut files = Vec::new();
+    for crate_src in ["cqlite-core/src", "cqlite-cli/src"] {
+        let dir = workspace.join(crate_src);
+        assert!(
+            dir.is_dir(),
+            "`{}` must exist — a probe with no subject measures nothing (FAIL-CLOSED)",
+            dir.display()
+        );
+        collect(&dir, &mut files);
+    }
+    // A collapsed census is the vacuous pass; there were 481 + 60 files when this landed.
+    assert!(
+        files.len() >= 300,
+        "only {} files probed — the census collapsed, so this test proved nothing",
+        files.len()
+    );
+
+    let mut refusals = Vec::new();
+    for file in &files {
+        let text = fs::read_to_string(file)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", file.display()));
+        if let Err(cause) = mod_reachability::sanitize(&text) {
+            refusals.push(format!("{}: {cause}", file.display()));
+        }
+    }
+    assert!(
+        refusals.is_empty(),
+        "the lexer refused {} real Rust file(s); an over-broad refusal is the branch \
+         someone deletes:\n{}",
+        refusals.len(),
+        refusals.join("\n")
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Stripper unit tests (control vs data, at the sanitizer boundary)
 // ---------------------------------------------------------------------------

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -433,6 +433,46 @@ fn missing_path_target_fails_closed() {
     );
 }
 
+/// A `#[path]` value is read out of the sanitizer's literal side table, so the string
+/// scanner must reproduce the value BYTE-EXACTLY. Decoding unescaped bytes one at a time
+/// (`byte as char`) turns the two UTF-8 bytes of `ó` into two Latin-1 characters, and the
+/// mojibake resolves to nothing. That fails *closed* (an unresolvable path errors), so it
+/// is a false FAIL rather than a false PASS — but CLAUDE.md records a six-defect
+/// path-normalisation family born of exactly this byte-vs-char confusion.
+#[test]
+fn non_ascii_path_attribute_values_survive_the_sanitizer() {
+    // (a) the character written literally in the source.
+    let tree = ScratchCrate::new("non-ascii-path-literal");
+    tree.write("src/lib.rs", "#[path = \"módulo_ñ.rs\"]\nmod aliased;\n");
+    tree.write("src/módulo_ñ.rs", "pub fn f() {}\n");
+    let report = tree.analyze();
+    assert!(
+        report.reachable.contains("src/módulo_ñ.rs"),
+        "a non-ASCII `#[path]` value must resolve to its file; reachable={:?}",
+        report.reachable
+    );
+    assert!(
+        report.orphans.is_empty(),
+        "no file in this tree is unreachable, yet orphans={:?}",
+        report.orphans
+    );
+
+    // (b) the same character written as a `\u{…}` escape — escape handling must keep
+    //     working alongside the raw-byte accumulation.
+    let tree = ScratchCrate::new("non-ascii-path-escape");
+    tree.write(
+        "src/lib.rs",
+        "#[path = \"m\\u{f3}dulo_\\u{f1}.rs\"]\nmod aliased;\n",
+    );
+    tree.write("src/módulo_ñ.rs", "pub fn f() {}\n");
+    let report = tree.analyze();
+    assert!(
+        report.reachable.contains("src/módulo_ñ.rs"),
+        "a `\\u{{…}}`-escaped `#[path]` value must resolve to the same file; reachable={:?}",
+        report.reachable
+    );
+}
+
 /// A symlink under `src/` is a hole in the census. `DirEntry::file_type().is_dir()` is
 /// FALSE for a symlink that points at a directory, so the whole subtree behind it would
 /// be walked past in silence and every orphan inside it would pass undetected — a silent

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -433,6 +433,100 @@ fn missing_path_target_fails_closed() {
     );
 }
 
+/// A `mod` token inside a macro's token tree is neither control nor data the walker can
+/// read: rustc decides what the macro expands to, and this walker does not expand macros.
+/// Counting it as a real declaration makes an unreachable file look reachable — the exact
+/// false-PASS class this guard exists to prevent (same shape as the commented-out
+/// `mod` that hid `parser/collection_udt_tests.rs`). So it fails CLOSED, naming the macro.
+#[test]
+fn mod_declaration_inside_a_macro_fails_closed() {
+    for (label, lib_rs, needle) in [
+        (
+            "macro-rules-body",
+            "pub mod wired;\nmacro_rules! make_it { () => { mod orphan; }; }\n",
+            "make_it",
+        ),
+        (
+            "macro-invocation-paren",
+            "pub mod wired;\npub const S: &str = stringify!(mod orphan;);\n",
+            "stringify!",
+        ),
+        (
+            "macro-invocation-brace",
+            "pub mod wired;\ncfg_if::cfg_if! { mod orphan; }\n",
+            "cfg_if!",
+        ),
+        (
+            "macro-invocation-bracket",
+            "pub mod wired;\npub const S: &str = stringify![mod orphan;];\n",
+            "stringify!",
+        ),
+        (
+            "macro-rules-metavariable",
+            "pub mod wired;\nmacro_rules! decl { ($n:ident) => { mod $n; }; }\n",
+            "decl",
+        ),
+    ] {
+        let tree = ScratchCrate::new(label);
+        tree.write("src/lib.rs", lib_rs);
+        tree.write("src/wired.rs", "pub fn f() {}\n");
+        tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+        let cause = tree.expect_failure();
+        assert!(
+            cause.contains("macro") && cause.contains(needle),
+            "case `{label}`: a `mod` inside a macro token tree must fail closed naming the \
+             macro (`{needle}`); got: {cause}"
+        );
+    }
+}
+
+/// The other half, and it is the half that keeps the guard alive: an over-broad macro
+/// rule that reds on EVERY macro is the rule someone deletes. Ordinary macros — a
+/// `macro_rules!` definition with no `mod` in it, `format!`, `vec![]`, and a `!=` that
+/// merely looks like an invocation — must leave the walk untouched, and the orphan
+/// underneath must still be found.
+#[test]
+fn an_ordinary_macro_does_not_trip_the_mod_in_macro_guard() {
+    let tree = ScratchCrate::new("macro-without-mod");
+    tree.write(
+        "src/lib.rs",
+        r####"
+macro_rules! shout {
+    ($x:expr) => {{
+        let modified = format!("{}!", $x);
+        modified
+    }};
+}
+macro_rules! braces_and_brackets {
+    () => {
+        vec![1usize, 2, 3]
+    };
+}
+pub mod wired;
+pub fn f() -> String { shout!("hi") }
+pub fn g() -> Vec<usize> { braces_and_brackets!() }
+pub fn h(a: usize, b: usize) -> bool { a != b }
+pub fn i() { assert!(matches!(Some(1u8), Some(_))); }
+"####,
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+    let report = tree.analyze();
+    assert_eq!(
+        report.orphans.iter().cloned().collect::<Vec<_>>(),
+        vec!["src/orphan.rs".to_string()],
+        "ordinary macros must neither fail the walk nor hide the orphan; enumerated={:?} \
+         reachable={:?}",
+        report.enumerated,
+        report.reachable
+    );
+    assert!(
+        report.reachable.contains("src/wired.rs"),
+        "a macro-bearing root must still resolve its real `mod` declarations"
+    );
+}
+
 #[test]
 fn empty_source_tree_fails_closed_rather_than_passing() {
     let tree = ScratchCrate::new("no-src-dir");

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -56,6 +56,16 @@ const EXPECTED_ORPHANS: &[ExpectedOrphan] = &[
         issue: "#3364",
         reason: "#3364 owns deleting this 102-LOC orphan; #1714 must not delete it here",
     },
+    // Found BY THIS GUARD on its first run over the live tree, and not by the hand
+    // census that preceded it: `parser/mod.rs:115` carries a COMMENTED-OUT
+    // `// pub mod collection_udt_tests;`, which a raw `mod <stem>` grep counts as a
+    // wiring. Stripping comments before parsing is what exposes it — the guard's first
+    // real catch, and the reason the control-vs-data requirement is not academic.
+    ExpectedOrphan {
+        path: "parser/collection_udt_tests.rs",
+        issue: "#3365",
+        reason: "#3365 owns deleting/wiring this 374-LOC orphan; #1714 must not decide it here",
+    },
 ];
 
 /// A collapsed census is the vacuous-pass failure mode, so the floor is asserted rather

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -286,6 +286,81 @@ pub fn lifetimes<'a>(s: &'a str) -> &'a str { s }
     );
 }
 
+/// rustc DISCARDS a `#!` line at byte offset 0 of a source file, so whatever that line
+/// says is not Rust at all. Parsing it as ordinary code is the false-PASS path this
+/// asserts against: a `#!/usr/bin/env -S tool mod orphan;` first line would otherwise
+/// yield a bogus `mod orphan;` declaration and make an unreachable file look reachable —
+/// the exact silent green this guard exists to prevent (#1714).
+#[test]
+fn shebang_line_at_offset_zero_does_not_declare_a_module() {
+    let tree = ScratchCrate::new("shebang-not-a-decl");
+    tree.write(
+        "src/lib.rs",
+        "#!/usr/bin/env -S tool mod orphan;\npub mod wired;\n",
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+    let report = tree.analyze();
+    assert_eq!(
+        report.orphans.iter().cloned().collect::<Vec<_>>(),
+        vec!["src/orphan.rs".to_string()],
+        "a `mod orphan;` inside a SHEBANG line (which rustc discards) must NOT make \
+         `orphan.rs` reachable; enumerated={:?} reachable={:?}",
+        report.enumerated,
+        report.reachable
+    );
+    assert!(
+        report.reachable.contains("src/wired.rs"),
+        "a shebang-bearing root must still resolve the real declarations below it"
+    );
+}
+
+/// The other direction of the same fix, and the one that would be catastrophic to get
+/// backwards: `#![...]` at byte offset 0 is a Rust INNER ATTRIBUTE (this crate's own
+/// `lib.rs` opens with one), not a shebang. Blanking it would eat the rest of that line,
+/// so the real `pub mod wired;` sharing it must survive.
+#[test]
+fn inner_attribute_at_offset_zero_is_not_mistaken_for_a_shebang() {
+    let tree = ScratchCrate::new("inner-attr-not-shebang");
+    tree.write("src/lib.rs", "#![allow(dead_code)] pub mod wired;\n");
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+
+    let report = tree.analyze();
+    assert!(
+        report.orphans.is_empty(),
+        "`#![allow(dead_code)]` at offset 0 is an inner attribute, not a shebang — \
+         blanking its line swallowed the real `pub mod wired;`: orphans={:?}",
+        report.orphans
+    );
+    let out = stripped("#![allow(dead_code)] pub mod wired;\n");
+    assert_eq!(
+        out, "#![allow(dead_code)] pub mod wired;\n",
+        "an inner attribute at offset 0 must reach the parser byte-for-byte"
+    );
+}
+
+/// The shebang rule applies at BYTE OFFSET 0 and nowhere else: an implementation that
+/// stripped any line merely *starting* with `#!` would eat this file's real declaration,
+/// which sits on the ordinary `#![...]`-after-a-comment-header line every Rust crate has.
+#[test]
+fn hash_bang_after_offset_zero_is_not_a_shebang() {
+    let tree = ScratchCrate::new("hashbang-not-at-zero");
+    tree.write(
+        "src/lib.rs",
+        "//! Crate docs, line 1.\n//! Line 2.\n//! Line 3.\n\n#![allow(dead_code)] pub mod wired;\n",
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+
+    let report = tree.analyze();
+    assert!(
+        report.orphans.is_empty(),
+        "a `#!` line that is NOT at byte offset 0 is not a shebang; its declarations must \
+         survive: orphans={:?}",
+        report.orphans
+    );
+}
+
 /// Every resolution rule, exercised against a tree the test controls end to end.
 #[test]
 fn synthetic_tree_exercises_every_resolution_rule() {
@@ -1253,6 +1328,54 @@ fn stripper_fails_closed_on_unterminated_input() {
         assert!(
             strip_comments_and_strings(src).is_err(),
             "unterminated {what} must fail closed rather than yield a guessed parse"
+        );
+    }
+}
+
+/// A shebang line is blanked like every other non-Rust span: same byte length, newline
+/// preserved, so byte offsets and reported line numbers stay aligned with the original
+/// source. The both-directions half is asserted too — `#![...]` at offset 0 is an inner
+/// attribute and must reach the parser untouched — plus the fail-closed refusal for the
+/// one shape whose shebang-vs-attribute reading this walker does not model.
+#[test]
+fn stripper_blanks_a_shebang_but_never_an_inner_attribute() {
+    let src = "#!/usr/bin/env cargo\nmod a;\n";
+    let out = stripped(src);
+    assert_eq!(
+        out, "                    \nmod a;\n",
+        "the shebang line must be blanked in place (offsets and newline preserved): {out:?}"
+    );
+    assert_eq!(out.len(), src.len(), "byte offsets must be preserved");
+    assert_eq!(
+        out.matches('\n').count(),
+        src.matches('\n').count(),
+        "line breaks must be preserved so reported line numbers stay correct"
+    );
+
+    for attr in [
+        "#![allow(dead_code)]\nmod a;\n",
+        "#![doc = \"not a shebang\"]\nmod a;\n",
+    ] {
+        // The literal's own value is blanked (it is data), so compare the code skeleton.
+        let out = stripped(attr);
+        assert!(
+            out.starts_with("#![") && out.contains("mod a;"),
+            "`#![...]` at offset 0 is an inner attribute, not a shebang: {attr:?} -> {out:?}"
+        );
+    }
+
+    // `#!` + whitespace/comment + `[` is an inner attribute to rustc (it skips both
+    // before deciding) and a shebang to a naive next-byte test. This walker models
+    // neither reading, so it refuses rather than guessing (FAIL-CLOSED).
+    for src in [
+        "#! [allow(dead_code)]\nmod a;\n",
+        "#!\n[allow(dead_code)]\nmod a;\n",
+        "#!/* c */[allow(dead_code)]\nmod a;\n",
+        "#!// c\n[allow(dead_code)]\nmod a;\n",
+    ] {
+        assert!(
+            strip_comments_and_strings(src).is_err(),
+            "the unmodeled shebang-vs-inner-attribute shape must fail closed: {src:?}"
         );
     }
 }

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -433,6 +433,47 @@ fn missing_path_target_fails_closed() {
     );
 }
 
+/// A symlink under `src/` is a hole in the census. `DirEntry::file_type().is_dir()` is
+/// FALSE for a symlink that points at a directory, so the whole subtree behind it would
+/// be walked past in silence and every orphan inside it would pass undetected — a silent
+/// census omission is a vacuous pass. Following it instead would need canonical-path
+/// boundary and cycle checks to buy nothing (there are no symlinks under
+/// `cqlite-core/src`), so the walker refuses.
+#[test]
+#[cfg(unix)]
+fn symlink_under_src_fails_closed() {
+    use std::os::unix::fs::symlink;
+
+    // (a) a symlinked DIRECTORY: `is_dir()` is false, so the subtree is skipped.
+    let tree = ScratchCrate::new("symlink-dir");
+    tree.write("src/lib.rs", "pub mod wired;\n");
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("outside/hidden_orphan.rs", "pub fn never_compiled() {}\n");
+    symlink(tree.dir.join("outside"), tree.dir.join("src/linked_dir"))
+        .unwrap_or_else(|e| panic!("cannot create directory symlink: {e}"));
+    let cause = tree.expect_failure();
+    assert!(
+        cause.contains("symlink") && cause.contains("linked_dir"),
+        "a symlinked DIRECTORY under `src/` must fail closed naming the path; got: {cause}"
+    );
+
+    // (b) a symlinked `.rs` FILE, which could name a file outside the crate entirely.
+    let tree = ScratchCrate::new("symlink-file");
+    tree.write("src/lib.rs", "pub mod wired;\n");
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("outside/target.rs", "pub fn f() {}\n");
+    symlink(
+        tree.dir.join("outside/target.rs"),
+        tree.dir.join("src/linked.rs"),
+    )
+    .unwrap_or_else(|e| panic!("cannot create file symlink: {e}"));
+    let cause = tree.expect_failure();
+    assert!(
+        cause.contains("symlink") && cause.contains("linked.rs"),
+        "a symlinked `.rs` FILE under `src/` must fail closed naming the path; got: {cause}"
+    );
+}
+
 /// A `mod` token inside a macro's token tree is neither control nor data the walker can
 /// read: rustc decides what the macro expands to, and this walker does not expand macros.
 /// Counting it as a real declaration makes an unreachable file look reachable — the exact

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -435,6 +435,48 @@ fn missing_path_target_fails_closed() {
     );
 }
 
+/// Rust permits an ABSOLUTE `#[path]` value, and rustc resolves it as an absolute path —
+/// against the filesystem root, not against the declaring file's directory. Prepending the
+/// declaring module's directory to it and normalizing the result as if it were relative
+/// re-points the declaration at an entirely different, IN-CRATE file: `#[path =
+/// "/abs/target.rs"]` in `src/lib.rs` becomes `src/abs/target.rs`, so a same-named in-crate
+/// orphan is marked reachable while rustc compiles something outside the crate. That is a
+/// FALSE PASS — an orphan reported as wired — which is why the walker refuses instead.
+///
+/// Both spellings are covered: POSIX (`/…`) and the Windows forms (`\…`, `C:\…`, `C:/…`),
+/// since `normalize_key` unifies `\` to `/` and would otherwise fold a drive-letter or UNC
+/// value into an in-crate key on any platform.
+#[test]
+fn absolute_path_attribute_value_fails_closed() {
+    // (source spelling of the literal, the value it decodes to). A Windows path must
+    // double its backslashes in Rust source — `"\abs"` is an invalid escape rustc rejects
+    // too, and the sanitizer refuses it one layer earlier.
+    for (spelling, value) in [
+        ("/abs/target.rs", "/abs/target.rs"),
+        ("\\\\abs\\\\target.rs", "\\abs\\target.rs"),
+        ("C:\\\\abs\\\\target.rs", "C:\\abs\\target.rs"),
+        ("C:/abs/target.rs", "C:/abs/target.rs"),
+    ] {
+        let tree = ScratchCrate::new("absolute-path-attr");
+        tree.write(
+            "src/lib.rs",
+            &format!("#[path = \"{spelling}\"]\nmod aliased;\npub mod wired;\n"),
+        );
+        tree.write("src/wired.rs", "pub fn f() {}\n");
+        // The file a "prepend the module directory and normalize" reading would land on.
+        // It is a real orphan: rustc, reading the value as absolute, never compiles it.
+        tree.write("src/abs/target.rs", "pub fn never_compiled() {}\n");
+        tree.write("src/C/abs/target.rs", "pub fn never_compiled() {}\n");
+
+        let cause = tree.expect_failure();
+        assert!(
+            cause.contains(value) && cause.contains("src/lib.rs:2") && cause.contains("absolute"),
+            "the refusal must name the file, the line and the absolute value verbatim; \
+             got: {cause}"
+        );
+    }
+}
+
 /// A `#[path]` value is read out of the sanitizer's literal side table, so the string
 /// scanner must reproduce the value BYTE-EXACTLY. Decoding unescaped bytes one at a time
 /// (`byte as char`) turns the two UTF-8 bytes of `ó` into two Latin-1 characters, and the

--- a/cqlite-core/tests/issue_1714_mod_reachability.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability.rs
@@ -621,6 +621,267 @@ fn empty_source_tree_fails_closed_rather_than_passing() {
 }
 
 // ---------------------------------------------------------------------------
+// The literal/identifier prefix family (issue #1714, roborev rounds 1-2)
+// ---------------------------------------------------------------------------
+
+/// Every Rust literal form, one case each, with `mod orphan;` **inside** the literal.
+///
+/// This is the family test, not a set of special cases. Five review findings on this
+/// walker were all the same shape: prefix recognition lived in three parsers, each
+/// knowing a different subset of Rust's prefixes, so an unrecognized prefix fell through
+/// to ordinary scanning and the `mod orphan;` inside it was counted as a real
+/// declaration — a silent FALSE PASS. `cr#"…"#` (raw C-string) was the last one found;
+/// its exact adversarial case is pinned below, because the embedded `"` is the point: a
+/// scanner that terminates the literal at the first quote lands squarely in `mod orphan;`.
+#[test]
+fn every_literal_prefix_form_is_data_not_a_declaration() {
+    for (label, literal) in [
+        ("string", r####""mod orphan;""####),
+        (
+            "string-escaped-quote",
+            r####""escaped \" then mod orphan;""####,
+        ),
+        ("raw", r####"r"mod orphan;""####),
+        ("raw-hash", r####"r#"quote " and mod orphan;"#"####),
+        ("raw-hash2", r####"r##"deeper "# and mod orphan;"##"####),
+        ("byte-string", r####"b"mod orphan;""####),
+        ("byte-raw", r####"br"mod orphan;""####),
+        ("byte-raw-hash", r####"br#"quote " and mod orphan;"#"####),
+        ("cstring", r####"c"mod orphan;""####),
+        ("cstring-raw", r####"cr"mod orphan;""####),
+        // The roborev round-2 finding, verbatim: embedded quotes inside a hashed raw
+        // C-string. A naive scanner terminates at the first `"` and reads the rest as code.
+        (
+            "cstring-raw-hash",
+            r####"cr#"left " mod orphan; " right"#"####,
+        ),
+        (
+            "cstring-raw-hash2",
+            r####"cr##"deeper "# and mod orphan;"##"####,
+        ),
+        // A char literal cannot hold `mod orphan;`, so the byte-char cases pin the other
+        // way a mis-lex hurts: a quote inside `b'…'`/`'…'` that is mistaken for the start
+        // of a string literal shifts every later quote pairing, which drops the following
+        // string's `mod orphan;` into code position.
+        ("byte-char-quote", r####"(b'"', "mod orphan;")"####),
+        ("char-quote", r####"('"', "mod orphan;")"####),
+        ("char-escaped-quote", r####"('\'', "mod orphan;")"####),
+    ] {
+        let tree = ScratchCrate::new(&format!("literal-{label}"));
+        tree.write(
+            "src/lib.rs",
+            &format!("pub mod wired;\npub fn f() {{ let _ = {literal}; }}\n"),
+        );
+        tree.write("src/wired.rs", "pub fn f() {}\n");
+        tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+        let report = tree.analyze();
+        assert_eq!(
+            report.orphans.iter().cloned().collect::<Vec<_>>(),
+            vec!["src/orphan.rs".to_string()],
+            "case `{label}` ({literal}): a `mod orphan;` inside a literal is DATA — it must \
+             not make `orphan.rs` look reachable; reachable={:?}",
+            report.reachable
+        );
+        assert!(
+            report.reachable.contains("src/wired.rs"),
+            "case `{label}` ({literal}): the literal must not swallow the real `mod wired;` \
+             that follows it; reachable={:?}",
+            report.reachable
+        );
+    }
+}
+
+/// **The test that keeps the family closed.** An identifier-ish token glued to `"`, `'`
+/// or `#` that the lexer's `PREFIXES` table does not know must be an `Err` naming the
+/// file, line and token — never a fall-through to ordinary scanning.
+///
+/// Rust reserves every such sequence (edition-2021 reserved prefixes) precisely so new
+/// literal forms can be added; `c"…"` and `cr#"…"#` themselves arrived that way in Rust
+/// 1.77. Without this branch, the *next* prefix silently disables the guard, which is how
+/// this walker got two findings of the same shape in consecutive review rounds. With it,
+/// the walk stops and a human adds one table row.
+#[test]
+fn unrecognized_literal_prefix_fails_closed() {
+    for (label, snippet, token) in [
+        // A hypothetical future string prefix (`f"…"`, `k#"…"#`) — the real threat model.
+        (
+            "future-string-prefix",
+            "pub fn f() { let _ = f\"mod orphan;\"; }\npub mod wired;\n",
+            "f\"",
+        ),
+        (
+            "future-hash-prefix",
+            "pub fn f() { let _ = k#\"mod orphan;\"#; }\npub mod wired;\n",
+            "k#",
+        ),
+        // `b#`/`c#` are NOT raw-string prefixes (`br#`/`cr#` are) — a one-character slip
+        // that must refuse rather than scan on.
+        (
+            "byte-hash-is-not-a-raw-prefix",
+            "pub fn f() { let _ = b#\"mod orphan;\"#; }\npub mod wired;\n",
+            "b#",
+        ),
+        (
+            "cstring-hash-is-not-a-raw-prefix",
+            "pub fn f() { let _ = c#\"mod orphan;\"#; }\npub mod wired;\n",
+            "c#",
+        ),
+        // `r##foo` is neither a raw string (no `\"`) nor a raw identifier (two hashes).
+        (
+            "double-hash-raw-identifier",
+            "pub fn f() { let _ = r##orphan; }\npub mod wired;\n",
+            "r#",
+        ),
+        // A future char-like prefix.
+        (
+            "future-char-prefix",
+            "pub fn f() { let _ = q'x'; }\npub mod wired;\n",
+            "q'",
+        ),
+    ] {
+        let tree = ScratchCrate::new(&format!("prefix-{label}"));
+        tree.write("src/lib.rs", snippet);
+        tree.write("src/wired.rs", "pub fn f() {}\n");
+        tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+        let cause = tree.expect_failure();
+        assert!(
+            cause.contains("unrecognized literal/identifier prefix"),
+            "case `{label}`: an unrecognized prefix must fail CLOSED as a prefix refusal \
+             (a fall-through to ordinary scanning is the silent false PASS); got: {cause}"
+        );
+        assert!(
+            cause.contains(token),
+            "case `{label}`: the refusal must NAME the offending token (`{token}`) so a \
+             human can add the table row; got: {cause}"
+        );
+        assert!(
+            cause.contains("src/lib.rs") && cause.contains("line 1"),
+            "case `{label}`: the refusal must name the file and line; got: {cause}"
+        );
+        assert!(
+            cause.contains("#1714"),
+            "case `{label}`: the refusal must point at the issue that owns the table; \
+             got: {cause}"
+        );
+    }
+}
+
+/// A raw identifier is legal in a `mod` declaration, and the `r#` is **not** part of the
+/// name: `mod r#type;` declares a module whose file is `type.rs`. Failing closed here
+/// would be a real false FAIL the moment someone writes `mod r#try;`, so the resolution
+/// is pinned in both flavors (`name.rs` and `name/mod.rs`).
+#[test]
+fn raw_identifier_module_declarations_resolve() {
+    let tree = ScratchCrate::new("raw-ident-mod");
+    tree.write(
+        "src/lib.rs",
+        "pub mod r#type;\npub mod r#try;\npub mod wired;\n",
+    );
+    tree.write("src/type.rs", "pub fn f() {}\n");
+    tree.write("src/try/mod.rs", "pub fn f() {}\n");
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+    let report = tree.analyze();
+    for expected in ["src/type.rs", "src/try/mod.rs", "src/wired.rs"] {
+        assert!(
+            report.reachable.contains(expected),
+            "`mod r#…;` must resolve with the `r#` stripped: `{expected}` missing from {:?}",
+            report.reachable
+        );
+    }
+    assert_eq!(
+        report.orphans.iter().cloned().collect::<Vec<_>>(),
+        vec!["src/orphan.rs".to_string()],
+        "raw-identifier modules must not disturb orphan detection"
+    );
+}
+
+/// A macro may be *named* with a raw identifier, in both definition and invocation
+/// position. If the walker does not consume `r#name` atomically it never recognizes the
+/// macro at all, parses its token tree as ordinary Rust, and counts the `mod orphan;`
+/// inside it as a real declaration — the roborev round-2 finding.
+#[test]
+fn raw_identifier_named_macros_reach_the_mod_in_macro_guard() {
+    for (label, lib_rs, needle) in [
+        (
+            "raw-macro-rules-definition",
+            "pub mod wired;\nmacro_rules! r#make { () => { mod orphan; }; }\n",
+            "r#make",
+        ),
+        (
+            "raw-macro-invocation-paren",
+            "pub mod wired;\npub const S: &str = r#make!(mod orphan;);\n",
+            "r#make!",
+        ),
+        (
+            "raw-macro-invocation-brace",
+            "pub mod wired;\nouter::r#bar! { mod orphan; }\n",
+            "r#bar!",
+        ),
+        (
+            "raw-macro-invocation-bracket",
+            "pub mod wired;\npub const S: &str = r#make![mod orphan;];\n",
+            "r#make!",
+        ),
+        (
+            "raw-macro-rules-metavariable",
+            "pub mod wired;\nmacro_rules! r#decl { ($n:ident) => { mod $n; }; }\n",
+            "r#decl",
+        ),
+    ] {
+        let tree = ScratchCrate::new(&format!("raw-macro-{label}"));
+        tree.write("src/lib.rs", lib_rs);
+        tree.write("src/wired.rs", "pub fn f() {}\n");
+        tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+        let cause = tree.expect_failure();
+        assert!(
+            cause.contains("macro") && cause.contains(needle),
+            "case `{label}`: a `mod` inside a raw-identifier-named macro's token tree must \
+             fail closed naming the macro (`{needle}`); got: {cause}"
+        );
+    }
+}
+
+/// The other direction for raw identifiers: `r#mod` is an IDENTIFIER, never the keyword,
+/// and an ordinary raw-identifier-named macro with no `mod` in it must leave the walk
+/// alone. An over-broad guard is the guard someone deletes.
+#[test]
+fn raw_identifiers_that_are_not_declarations_do_not_trip_the_guard() {
+    let tree = ScratchCrate::new("raw-ident-benign");
+    tree.write(
+        "src/lib.rs",
+        r####"
+macro_rules! r#fn {
+    ($x:expr) => {{ let r#mod = $x; r#mod }};
+}
+pub mod wired;
+pub struct S { pub r#type: u8, pub r#mod: u8 }
+pub fn f() -> usize { r#fn!(1usize) }
+pub fn g<'a>(r#match: &'a str) -> &'a str { r#match }
+"####,
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+    let report = tree.analyze();
+    assert_eq!(
+        report.orphans.iter().cloned().collect::<Vec<_>>(),
+        vec!["src/orphan.rs".to_string()],
+        "`r#mod` is an identifier, not a declaration, and a benign raw-named macro must \
+         neither fail the walk nor hide the orphan; reachable={:?}",
+        report.reachable
+    );
+    assert!(
+        report.reachable.contains("src/wired.rs"),
+        "a raw-identifier-bearing root must still resolve its real `mod` declarations"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Stripper unit tests (control vs data, at the sanitizer boundary)
 // ---------------------------------------------------------------------------
 
@@ -669,7 +930,13 @@ fn stripper_blanks_every_literal_form() {
         "let s = r#\"quote \" and mod x;\"#;\n",
         "let s = r##\"deeper \"# and mod x;\"##;\n",
         "let s = b\"mod x;\";\n",
+        "let s = br\"mod x;\";\n",
         "let s = br#\"mod x;\"#;\n",
+        "let s = c\"mod x;\";\n",
+        "let s = cr\"mod x;\";\n",
+        "let s = cr#\"quote \" and mod x;\"#;\n",
+        "let s = cr##\"deeper \"# and mod x;\"##;\n",
+        "let s = (b'\"', \"mod x;\");\n",
     ] {
         let out = stripped(src);
         assert!(

--- a/cqlite-core/tests/issue_1714_mod_reachability_shebang.rs
+++ b/cqlite-core/tests/issue_1714_mod_reachability_shebang.rs
@@ -1,0 +1,148 @@
+//! Issue #1714: the SHEBANG half of the `mod`-reachability sanitizer, measured against
+//! rustc's own rule.
+//!
+//! # Why this is its own test file
+//!
+//! rustc DISCARDS a `#!` line at byte offset 0 (`rustc_lexer::strip_shebang`), so those
+//! bytes are not Rust at all — while `#![…]` at offset 0 is an inner attribute and IS
+//! Rust. Both directions are load-bearing and both are dangerous to get wrong:
+//!
+//! * reading a shebang as code invents declarations (`#!/usr/bin/env -S tool mod orphan;`)
+//!   and makes an unreachable file look reachable — the silent FALSE PASS this guard
+//!   exists to prevent;
+//! * reading an inner attribute as a shebang blanks a line of real code, swallowing any
+//!   `pub mod wired;` that shares it.
+//!
+//! rustc's rule is narrow and non-obvious (see `shebang_end`), so these cases are pinned
+//! against **measured rustc behavior** rather than against a reading of the docs, and kept
+//! together where the next reader can see the whole table at once.
+
+#[path = "support/mod_reachability_harness.rs"]
+mod harness;
+#[path = "support/mod_reachability.rs"]
+mod mod_reachability;
+
+use harness::{stripped, ScratchCrate};
+use mod_reachability::strip_comments_and_strings;
+
+/// rustc DISCARDS a `#!` line at byte offset 0 of a source file, so whatever that line
+/// says is not Rust at all. Parsing it as ordinary code is the false-PASS path this
+/// asserts against: a `#!/usr/bin/env -S tool mod orphan;` first line would otherwise
+/// yield a bogus `mod orphan;` declaration and make an unreachable file look reachable —
+/// the exact silent green this guard exists to prevent (#1714).
+#[test]
+fn shebang_line_at_offset_zero_does_not_declare_a_module() {
+    let tree = ScratchCrate::new("shebang-not-a-decl");
+    tree.write(
+        "src/lib.rs",
+        "#!/usr/bin/env -S tool mod orphan;\npub mod wired;\n",
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+    tree.write("src/orphan.rs", "pub fn never_compiled() {}\n");
+
+    let report = tree.analyze();
+    assert_eq!(
+        report.orphans.iter().cloned().collect::<Vec<_>>(),
+        vec!["src/orphan.rs".to_string()],
+        "a `mod orphan;` inside a SHEBANG line (which rustc discards) must NOT make \
+         `orphan.rs` reachable; enumerated={:?} reachable={:?}",
+        report.enumerated,
+        report.reachable
+    );
+    assert!(
+        report.reachable.contains("src/wired.rs"),
+        "a shebang-bearing root must still resolve the real declarations below it"
+    );
+}
+
+/// The other direction of the same fix, and the one that would be catastrophic to get
+/// backwards: `#![...]` at byte offset 0 is a Rust INNER ATTRIBUTE (this crate's own
+/// `lib.rs` opens with one), not a shebang. Blanking it would eat the rest of that line,
+/// so the real `pub mod wired;` sharing it must survive.
+#[test]
+fn inner_attribute_at_offset_zero_is_not_mistaken_for_a_shebang() {
+    let tree = ScratchCrate::new("inner-attr-not-shebang");
+    tree.write("src/lib.rs", "#![allow(dead_code)] pub mod wired;\n");
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+
+    let report = tree.analyze();
+    assert!(
+        report.orphans.is_empty(),
+        "`#![allow(dead_code)]` at offset 0 is an inner attribute, not a shebang — \
+         blanking its line swallowed the real `pub mod wired;`: orphans={:?}",
+        report.orphans
+    );
+    let out = stripped("#![allow(dead_code)] pub mod wired;\n");
+    assert_eq!(
+        out, "#![allow(dead_code)] pub mod wired;\n",
+        "an inner attribute at offset 0 must reach the parser byte-for-byte"
+    );
+}
+
+/// The shebang rule applies at BYTE OFFSET 0 and nowhere else: an implementation that
+/// stripped any line merely *starting* with `#!` would eat this file's real declaration,
+/// which sits on the ordinary `#![...]`-after-a-comment-header line every Rust crate has.
+#[test]
+fn hash_bang_after_offset_zero_is_not_a_shebang() {
+    let tree = ScratchCrate::new("hashbang-not-at-zero");
+    tree.write(
+        "src/lib.rs",
+        "//! Crate docs, line 1.\n//! Line 2.\n//! Line 3.\n\n#![allow(dead_code)] pub mod wired;\n",
+    );
+    tree.write("src/wired.rs", "pub fn f() {}\n");
+
+    let report = tree.analyze();
+    assert!(
+        report.orphans.is_empty(),
+        "a `#!` line that is NOT at byte offset 0 is not a shebang; its declarations must \
+         survive: orphans={:?}",
+        report.orphans
+    );
+}
+/// A shebang line is blanked like every other non-Rust span: same byte length, newline
+/// preserved, so byte offsets and reported line numbers stay aligned with the original
+/// source. The both-directions half is asserted too — `#![...]` at offset 0 is an inner
+/// attribute and must reach the parser untouched — plus the fail-closed refusal for the
+/// one shape whose shebang-vs-attribute reading this walker does not model.
+#[test]
+fn stripper_blanks_a_shebang_but_never_an_inner_attribute() {
+    let src = "#!/usr/bin/env cargo\nmod a;\n";
+    let out = stripped(src);
+    assert_eq!(
+        out, "                    \nmod a;\n",
+        "the shebang line must be blanked in place (offsets and newline preserved): {out:?}"
+    );
+    assert_eq!(out.len(), src.len(), "byte offsets must be preserved");
+    assert_eq!(
+        out.matches('\n').count(),
+        src.matches('\n').count(),
+        "line breaks must be preserved so reported line numbers stay correct"
+    );
+
+    for attr in [
+        "#![allow(dead_code)]\nmod a;\n",
+        "#![doc = \"not a shebang\"]\nmod a;\n",
+    ] {
+        // The literal's own value is blanked (it is data), so compare the code skeleton.
+        let out = stripped(attr);
+        assert!(
+            out.starts_with("#![") && out.contains("mod a;"),
+            "`#![...]` at offset 0 is an inner attribute, not a shebang: {attr:?} -> {out:?}"
+        );
+    }
+
+    // `#!` + whitespace/comment + `[` is an inner attribute to rustc (it skips both
+    // before deciding) and a shebang to a naive next-byte test. This walker models
+    // neither reading, so it refuses rather than guessing (FAIL-CLOSED).
+    for src in [
+        "#! [allow(dead_code)]\nmod a;\n",
+        "#!\n[allow(dead_code)]\nmod a;\n",
+        "#!/* c */[allow(dead_code)]\nmod a;\n",
+        "#!// c\n[allow(dead_code)]\nmod a;\n",
+    ] {
+        assert!(
+            strip_comments_and_strings(src).is_err(),
+            "the unmodeled shebang-vs-inner-attribute shape must fail closed: {src:?}"
+        );
+    }
+}

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -191,6 +191,24 @@ fn enumerate_rs_files(
         let file_type = entry
             .file_type()
             .map_err(|e| format!("cannot stat `{}`: {e} (FAIL-CLOSED)", path.display()))?;
+        // `is_dir()` is FALSE for a symlink pointing at a directory, so the naive form
+        // walks straight past the subtree and every orphan inside it passes undetected.
+        // A silent census omission is the vacuous pass this walker exists to prevent, and
+        // a symlinked `.rs` file could name a target outside the crate entirely. Following
+        // one would need canonical-path boundary and cycle checks to buy nothing (there
+        // are no symlinks under `cqlite-core/src`), so refuse instead of guessing.
+        if file_type.is_symlink() {
+            return Err(format!(
+                "`{}` is a symlink, which this walker does not model: a symlinked directory \
+                 is not reported as a directory, so its whole subtree would be silently \
+                 omitted from the census, and a symlinked `.rs` file may point outside the \
+                 crate (FAIL-CLOSED — see #1714).\n\
+                 Remedy: replace the symlink with a real file or directory, or teach the \
+                 walker to follow it with canonical-path boundary and cycle checks \
+                 (tests/support/mod_reachability.rs).",
+                path.display()
+            ));
+        }
         if file_type.is_dir() {
             enumerate_rs_files(crate_dir, &path, out)?;
         } else if path.extension().map(|e| e == "rs").unwrap_or(false) {

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -33,7 +33,10 @@
 //! before [`parse_mod_decls`] ever sees the text, and the attribute values the parser
 //! genuinely needs (`#[path = "…"]`) are recovered from a **side table** keyed by byte
 //! offset rather than by re-reading the text. Control tokens and caller data therefore
-//! never share a channel.
+//! never share a channel. The same reasoning covers a **shebang**: rustc discards a `#!`
+//! line at byte offset 0, so a `#!/usr/bin/env -S tool mod orphan;` first line is not Rust
+//! and must not be read as a declaration ([`shebang_end`]) — while `#![…]` at offset 0 is
+//! an inner attribute and stays ordinary code, because blanking it would swallow real code.
 //!
 //! # One table for every prefix (issue #1714, roborev rounds 1-2)
 //!
@@ -56,7 +59,9 @@
 //! what a macro expands to), a symlink under the source directory (see
 //! [`enumerate_rs_files`] — a silently-skipped subtree is a census with a hole in it), an
 //! unterminated comment or literal, an unreadable file, an unknown escape, an
-//! unrecognized literal or identifier prefix (see [`lexer`]), a **non-ASCII byte in a
+//! unrecognized literal or identifier prefix (see [`lexer`]), a `#!` at byte offset 0
+//! whose shebang-vs-inner-attribute reading is ambiguous (see [`shebang_end`]), a
+//! **non-ASCII byte in a
 //! position where an identifier could start or continue** (see
 //! [`lexer::refuse_non_ascii`] — Rust permits Unicode identifiers, this lexer's rules are
 //! ASCII-only, and scanning past one could misclassify a macro context), and a
@@ -299,6 +304,16 @@ pub fn sanitize(src: &str) -> Result<Sanitized, String> {
     let mut literals: Vec<Literal> = Vec::new();
     let mut i = 0usize;
 
+    // rustc DISCARDS a `#!` line at byte offset 0 (`rustc_lexer::strip_shebang`), so its
+    // bytes are not Rust at all. Parsing them as code is a false-PASS path: a first line
+    // `#!/usr/bin/env -S tool mod orphan;` would yield a bogus `mod orphan;` and make an
+    // unreachable file look reachable (#1714). Blanked, not deleted, like every other
+    // non-Rust span here, so offsets and line numbers stay aligned with the source.
+    if let Some(end) = shebang_end(b)? {
+        blank(&mut out, 0, end);
+        i = end;
+    }
+
     while i < n {
         let c = b[i];
         if c == b'/' && i + 1 < n && b[i + 1] == b'/' {
@@ -383,6 +398,50 @@ pub fn sanitize(src: &str) -> Result<Sanitized, String> {
         ));
     }
     Ok(Sanitized { text, literals })
+}
+
+/// Length of the shebang line at byte offset 0, or `None` when there is none.
+///
+/// The rule is narrow on purpose, and getting it backwards would be worse than not
+/// having it: `#![...]` at offset 0 is a Rust **inner attribute** (`#![allow(…)]` opens
+/// most crate roots, this one included), and blanking that line would swallow any real
+/// code sharing it. So only `#!` NOT followed by `[` is a shebang, and it is a shebang
+/// only at offset 0 — a `#!` further down the file is ordinary Rust.
+///
+/// rustc decides the `[` question after skipping whitespace **and comments**, so
+/// `#! [allow(…)]` and `#!/* c */[allow(…)]` are inner attributes to rustc while a
+/// next-byte test reads them as shebangs. This walker models neither reading, so it
+/// refuses that shape rather than guessing — the difference between the two readings is
+/// exactly one blanked line of code, i.e. a possible wrong verdict (FAIL-CLOSED, #1714).
+fn shebang_end(b: &[u8]) -> Result<Option<usize>, String> {
+    if b.len() < 2 || b[0] != b'#' || b[1] != b'!' {
+        return Ok(None);
+    }
+    if b.get(2) == Some(&b'[') {
+        return Ok(None); // inner attribute: ordinary Rust.
+    }
+    // Would rustc's whitespace-and-comment skip land on `[`? Anything that could is
+    // refused; a real shebang (`#!/usr/bin/env …`) starts with a non-space, non-comment
+    // byte and is unaffected.
+    let mut t = 2usize;
+    while t < b.len() && b[t].is_ascii_whitespace() {
+        t += 1;
+    }
+    let ambiguous = match (b.get(t), b.get(t + 1)) {
+        (Some(&b'['), _) => Some("whitespace"),
+        (Some(&b'/'), Some(&b'/')) | (Some(&b'/'), Some(&b'*')) => Some("a comment"),
+        _ => None,
+    };
+    if let Some(what) = ambiguous {
+        return Err(format!(
+            "line 1: `#!` at byte offset 0 followed by {what} before the rest of the line.              rustc skips whitespace and comments before deciding, so this may be an inner              attribute (`#![…]`, ordinary Rust) or a shebang (discarded entirely) — and the              two readings differ by one line of code, so guessing could either invent a `mod`              declaration or swallow a real one (FAIL-CLOSED — see #1714).\n\
+             Remedy: write the inner attribute as `#![…]` with no gap, or report this as a              sanitizer gap (tests/support/mod_reachability.rs)."
+        ));
+    }
+    // A shebang ends at (not including) the first newline — matching rustc's
+    // `2 + first_line_len`, so a following line stays ordinary Rust.
+    let end = b.iter().position(|c| *c == b'\n').unwrap_or(b.len());
+    Ok(Some(end))
 }
 
 fn blank(out: &mut [u8], start: usize, end: usize) {

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -35,6 +35,19 @@
 //! offset rather than by re-reading the text. Control tokens and caller data therefore
 //! never share a channel.
 //!
+//! # One table for every prefix (issue #1714, roborev rounds 1-2)
+//!
+//! Five review findings on this walker were **one bug five times**: prefix recognition
+//! lived in three parsers (`sanitize`, `parse_mod_decls`, `find_mod_token`), each knowing
+//! a different subset of Rust's literal and identifier prefixes, and an unrecognized
+//! prefix **fell through to ordinary scanning** — so the `mod orphan;` inside a
+//! `cr#"…"#` raw C-string, or inside `macro_rules! r#make`, was counted as a real
+//! declaration. That knowledge now lives once, in the [`lexer`] module's `PREFIXES`
+//! table, and every caller goes through [`lexer::lex_token`] / [`lexer::ident_token`]. An
+//! identifier-ish token glued to `"`, `'` or `#` that the table does not know is an `Err`
+//! naming file, line and token, so a Rust literal form newer than the table cannot
+//! silently disable the guard.
+//!
 //! # Fail-closed
 //!
 //! Every construct this walker does not model is an `Err`, never a skip: `include!`,
@@ -42,7 +55,8 @@
 //! a macro's token tree (see [`scan_macro_context`] — rustc, not this walker, decides
 //! what a macro expands to), a symlink under the source directory (see
 //! [`enumerate_rs_files`] — a silently-skipped subtree is a census with a hole in it), an
-//! unterminated comment or literal, an unreadable file, an unknown escape, and a
+//! unterminated comment or literal, an unreadable file, an unknown escape, an
+//! unrecognized literal or identifier prefix (see [`lexer`]), and a
 //! `mod name;` that resolves to neither candidate file. A skip is the vacuous pass this
 //! guard exists to prevent.
 

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -825,6 +825,30 @@ fn resolve_mod_file(crate_dir: &Path, parent_key: &str, decl: &ModDecl) -> Resul
     };
 
     if let Some(raw) = &decl.path_attr {
+        // An ABSOLUTE `#[path]` value is legal Rust, and rustc resolves it against the
+        // FILESYSTEM ROOT — not against the declaring file's directory. Joining it onto
+        // `base` and normalizing the result (which folds a leading `/`, and unifies `\` to
+        // `/`, so `C:\x.rs` becomes `C/x.rs`) silently re-points the declaration at a
+        // DIFFERENT, in-crate file: `#[path = "/abs/target.rs"]` in `src/lib.rs` would mark
+        // `src/abs/target.rs` reachable while rustc compiles `/abs/target.rs`. A same-named
+        // in-crate orphan then reads as wired — the FALSE PASS this walker exists to
+        // prevent. The target is also outside the census by construction, so there is
+        // nothing to boundary-check it against; refuse (#1714).
+        if let Some(shape) = absolute_path_shape(raw) {
+            return Err(format!(
+                "{parent_key}:{}: `#[path = \"{raw}\"] mod {}` names an ABSOLUTE path \
+                 ({shape}). rustc resolves it against the filesystem root, so it may point \
+                 outside the crate entirely and cannot be boundary-checked against the \
+                 census; treating it as relative to `{}` would mark a DIFFERENT, in-crate \
+                 file reachable and hide a real orphan (FAIL-CLOSED — see #1714).\n\
+                 Remedy: write the `#[path]` value relative to the declaring file, or teach \
+                 the walker absolute targets with an explicit in-crate boundary check \
+                 (tests/support/mod_reachability.rs).",
+                decl.line,
+                decl.name,
+                dirname(parent_key)
+            ));
+        }
         // The Rust Reference, "Modules / The path attribute":
         //   * a `#[path]` mod at FILE TOP LEVEL resolves relative to the DIRECTORY of the
         //     declaring file (so `#[path = "otel_tests.rs"]` in `observability/otel.rs`
@@ -907,6 +931,28 @@ fn file_stem(key: &str) -> String {
         Some(idx) => base[..idx].to_string(),
         None => base.to_string(),
     }
+}
+
+/// `Some(description)` when `raw` is an ABSOLUTE path value, `None` when it is relative.
+///
+/// Platform-independent on purpose: `Path::is_absolute` answers per-HOST (`C:\x.rs` is
+/// "relative" on Unix), while [`normalize_key`] unifies `\` to `/` on every host — so a
+/// Windows-shaped value would fold into an in-crate key here regardless of where this runs.
+/// All four spellings are therefore recognized directly.
+fn absolute_path_shape(raw: &str) -> Option<&'static str> {
+    let b = raw.as_bytes();
+    match b.first() {
+        Some(b'/') => return Some("POSIX, leading `/`"),
+        // `\x`, and the UNC form `\\server\share\x`.
+        Some(b'\\') => return Some("Windows root-relative or UNC, leading `\\`"),
+        _ => {}
+    }
+    // `C:\x.rs` / `C:/x.rs` — a drive-letter prefix.
+    if b.len() >= 3 && b[0].is_ascii_alphabetic() && b[1] == b':' && (b[2] == b'/' || b[2] == b'\\')
+    {
+        return Some("Windows drive-letter, `X:` prefix");
+    }
+    None
 }
 
 /// Lexically resolve `.` and `..` in a `/`-separated key. Escaping the crate root is an error.

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -58,9 +58,7 @@ use std::collections::{BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use lexer::{
-    ident_token, is_ident_byte, is_ident_start, lex_token, line_of, skip_ws, LexToken,
-};
+use lexer::{ident_token, is_ident_byte, is_ident_start, lex_token, line_of, skip_ws, LexToken};
 
 /// What to analyze. Crate-agnostic on purpose — see the module docs (#1502).
 #[derive(Debug, Clone)]

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -38,10 +38,13 @@
 //! # Fail-closed
 //!
 //! Every construct this walker does not model is an `Err`, never a skip: `include!`,
-//! `#[cfg_attr(…, path = …)]`, a `#[path]` on an inline `mod` block, an unterminated
-//! comment or literal, an unreadable file, an unknown escape, and a `mod name;` that
-//! resolves to neither candidate file. A skip is the vacuous pass this guard exists to
-//! prevent.
+//! `#[cfg_attr(…, path = …)]`, a `#[path]` on an inline `mod` block, a `mod` token inside
+//! a macro's token tree (see [`scan_macro_context`] — rustc, not this walker, decides
+//! what a macro expands to), a symlink under the source directory (see
+//! [`enumerate_rs_files`] — a silently-skipped subtree is a census with a hole in it), an
+//! unterminated comment or literal, an unreadable file, an unknown escape, and a
+//! `mod name;` that resolves to neither candidate file. A skip is the vacuous pass this
+//! guard exists to prevent.
 
 #![allow(dead_code)]
 
@@ -683,6 +686,15 @@ pub fn parse_mod_decls(s: &Sanitized, file_label: &str) -> Result<Vec<ModDecl>, 
                     pending_path = None;
                 }
                 _ => {
+                    // A macro's token tree is neither control nor data this walker can
+                    // read — rustc decides what it expands to. `Some(end)` means the
+                    // tree held no `mod` token and is skipped wholesale; a `mod` inside
+                    // one is an `Err` (see `scan_macro_context`).
+                    if let Some(after_macro) =
+                        scan_macro_context(b, text, word, i, word_start, file_label)?
+                    {
+                        i = after_macro;
+                    }
                     pending_path = None;
                 }
             }
@@ -692,6 +704,108 @@ pub fn parse_mod_decls(s: &Sanitized, file_label: &str) -> Result<Vec<ModDecl>, 
         i += 1;
     }
     Ok(out)
+}
+
+/// If the identifier just consumed opens a **macro context**, return the byte offset one
+/// past its token tree; `None` when it does not open one.
+///
+/// Two shapes are recognized: a definition `macro_rules! name { … }` and an invocation
+/// `name!( … )` / `name![ … ]` / `name!{ … }` (a path-qualified `foo::bar!( … )` arrives
+/// here as its last segment, `bar`).
+///
+/// # Why a `mod` in here is an `Err` and not a declaration
+///
+/// `mod orphan;` inside a macro is **not** a declaration the walker can trust: rustc
+/// decides whether that token tree is ever expanded, how many times, and with what name
+/// (`mod $n;`). Counting it makes an unreachable file look reachable — the same false
+/// PASS a commented-out `mod` produced for `parser/collection_udt_tests.rs`, and the
+/// worst failure mode a hygiene guard has. Expanding macros is out of scope, so this
+/// fails CLOSED instead (module docs, "Fail-closed").
+///
+/// The refusal is scoped to token trees that actually contain a `mod` token: an
+/// over-broad rule that reds on every `format!` is the rule someone deletes, which is
+/// why `an_ordinary_macro_does_not_trip_the_mod_in_macro_guard` pins the other
+/// direction.
+fn scan_macro_context(
+    b: &[u8],
+    text: &str,
+    word: &str,
+    ident_end_at: usize,
+    word_start: usize,
+    file_label: &str,
+) -> Result<Option<usize>, String> {
+    let n = b.len();
+    let mut k = skip_ws(b, ident_end_at);
+    if k >= n || b[k] != b'!' {
+        return Ok(None);
+    }
+    k = skip_ws(b, k + 1);
+
+    // `macro_rules! name { … }` names the macro BETWEEN the `!` and the token tree;
+    // an invocation puts the name before the `!`.
+    let mut macro_name = format!("{word}!");
+    if word == "macro_rules" && k < n && is_ident_start(b[k]) {
+        let name_end = ident_end(b, k);
+        macro_name = format!("macro_rules! {}", &text[k..name_end]);
+        k = skip_ws(b, name_end);
+    }
+
+    // No delimiter after the `!` means this was never a macro invocation — `a != b`
+    // reaches here and must be left to the ordinary scan.
+    let (open, close_byte) = match b.get(k) {
+        Some(b'(') => (b'(', b')'),
+        Some(b'[') => (b'[', b']'),
+        Some(b'{') => (b'{', b'}'),
+        _ => return Ok(None),
+    };
+    let close = matching_bracket(b, k, open, close_byte).ok_or_else(|| {
+        format!(
+            "{file_label}:{}: unbalanced `{}` token tree for `{macro_name}` — the walker \
+             cannot tell where the macro ends, so it cannot know what follows it \
+             (FAIL-CLOSED)",
+            line_of(text, word_start),
+            open as char
+        )
+    })?;
+
+    if let Some(mod_at) = find_mod_token(b, text, k + 1, close) {
+        return Err(format!(
+            "{file_label}:{}: a `mod` declaration appears inside the token tree of \
+             `{macro_name}`. This walker does not expand macros, so it cannot tell whether \
+             that declaration names a real module file, how many times it is expanded, or \
+             what its name expands to — counting it would make an unreachable file look \
+             reachable (FAIL-CLOSED — see #1714).\n\
+             Remedy: declare the module outside the macro, or teach the walker this macro's \
+             expansion (tests/support/mod_reachability.rs).",
+            line_of(text, mod_at)
+        ));
+    }
+    Ok(Some(close + 1))
+}
+
+/// Byte offset of a `mod <ident>` / `mod $meta` token sequence within `[start, end)`, if any.
+///
+/// Token-aware on both sides: `module` and `r#mod` are identifiers, not the keyword.
+fn find_mod_token(b: &[u8], text: &str, start: usize, end: usize) -> Option<usize> {
+    let mut i = start;
+    while i < end {
+        if is_ident_start(b[i]) {
+            let word_end = ident_end(b, i).min(end);
+            // `r#mod` is a raw IDENTIFIER; the `#` before it is the tell.
+            let raw_ident = i > 0 && b[i - 1] == b'#';
+            if !raw_ident && &text[i..word_end] == "mod" {
+                let after = skip_ws(b, word_end);
+                // `mod name;` or a `macro_rules!` metavariable `mod $name;`.
+                if after < end && (is_ident_start(b[after]) || b[after] == b'$') {
+                    return Some(i);
+                }
+            }
+            i = word_end.max(i + 1);
+        } else {
+            i += 1;
+        }
+    }
+    None
 }
 
 /// `Some(value)` when the attribute body is a `path = "…"`; `Err` for unmodeled shapes.

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -373,10 +373,16 @@ fn blank(out: &mut [u8], start: usize, end: usize) {
 }
 
 /// Scan a `"…"` literal starting at the opening quote. Returns `(end, unescaped value)`.
+///
+/// The value is accumulated as **raw bytes** and decoded as UTF-8 once at the end. The
+/// obvious `value.push(byte as char)` decodes UTF-8 one byte at a time, so the two bytes
+/// of `ó` become two Latin-1 characters and `#[path = "módulo.rs"]` resolves to mojibake
+/// that names no file — the byte-vs-char confusion behind CLAUDE.md's six-defect
+/// path-normalisation family.
 fn scan_string(b: &[u8], start: usize) -> Result<(usize, String), String> {
     let n = b.len();
     let mut j = start + 1;
-    let mut value = String::new();
+    let mut value: Vec<u8> = Vec::new();
     while j < n {
         match b[j] {
             b'\\' => {
@@ -411,7 +417,11 @@ fn scan_string(b: &[u8], start: usize) -> Result<(usize, String), String> {
                         let byte = u8::from_str_radix(text, 16).map_err(|_| {
                             format!("malformed `\\x{text}` escape in string literal (FAIL-CLOSED)")
                         })?;
-                        value.push(byte as char);
+                        // `\xNN` names a CODE POINT here, not a raw byte: Rust rejects
+                        // `\x80`+ in a string literal, and this scanner is shared with
+                        // byte strings (`b"\xff"`), where accumulating the raw byte would
+                        // make a legitimate literal invalid UTF-8 and fail the walk closed.
+                        push_char(&mut value, byte as char);
                         j += 4;
                         continue;
                     }
@@ -442,7 +452,7 @@ fn scan_string(b: &[u8], start: usize) -> Result<(usize, String), String> {
                         let ch = char::from_u32(code).ok_or_else(|| {
                             format!("`\\u{{{digits}}}` is not a Unicode scalar (FAIL-CLOSED)")
                         })?;
-                        value.push(ch);
+                        push_char(&mut value, ch);
                         j = k + 1;
                         continue;
                     }
@@ -454,17 +464,33 @@ fn scan_string(b: &[u8], start: usize) -> Result<(usize, String), String> {
                         ))
                     }
                 };
-                value.push(decoded);
+                push_char(&mut value, decoded);
                 j += 2;
             }
-            b'"' => return Ok((j + 1, value)),
+            b'"' => {
+                let decoded = String::from_utf8(value).map_err(|e| {
+                    format!(
+                        "string literal is not valid UTF-8 ({e}) — refusing to guess its \
+                         value (FAIL-CLOSED)"
+                    )
+                })?;
+                return Ok((j + 1, decoded));
+            }
             other => {
-                value.push(other as char);
+                // Raw byte: a multi-byte character arrives here one byte per iteration and
+                // must be reassembled, not transcoded per byte.
+                value.push(other);
                 j += 1;
             }
         }
     }
     Err("unterminated string literal (FAIL-CLOSED)".to_string())
+}
+
+/// Append `ch`'s UTF-8 encoding to a raw-byte literal accumulator.
+fn push_char(out: &mut Vec<u8>, ch: char) {
+    let mut buf = [0u8; 4];
+    out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
 }
 
 /// Scan `r#"…"#` (any hash count). `prefix_end` is the byte after the `r`/`br` ident.

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -1,0 +1,898 @@
+//! Crate-agnostic `mod`-reachability walker (issue #1714, AK3).
+//!
+//! # What this exists to catch
+//!
+//! A `.rs` file under a crate's `src/` that no `mod` declaration chain reaches from
+//! the crate root is **never compiled**. Editing it is a silent no-op: it type-checks
+//! nothing, its tests never run, and `cargo test` stays green while the code rots.
+//! `cqlite-core/src/memory_safety_tests.rs` was exactly that for months before it was
+//! deleted (PR #2044) — and the deletion alone does not stop the next one. This walker
+//! is the standing guard: it enumerates every `src/**/*.rs`, computes the set rustc
+//! actually reaches, and fails on the difference.
+//!
+//! # Reuse by other crates (issue #1502, the CLI mod-wiring guard)
+//!
+//! Nothing here is `cqlite-core`-specific: [`ModuleGraphSpec`] parameterizes the crate
+//! directory, the root file (`src/lib.rs` for a library, `src/main.rs` for a binary)
+//! and the source directory, and the expected-orphan list lives in the *caller's* test.
+//! **Recommendation for #1502**: pull this module into `cqlite-cli/tests/` with
+//! `#[path = "../../cqlite-core/tests/support/mod_reachability.rs"] mod mod_reachability;`
+//! and pass `root_file_rel = "src/main.rs"`. That keeps one implementation and one set
+//! of unit tests. Promotion to a shared `dev-dependency` crate is the cleaner end state
+//! but costs a new workspace member, so it is only worth doing once a third caller
+//! appears. The CLI side is **not** implemented here — it is #1502's scope.
+//!
+//! # Control vs data: sanitize before parsing (CLAUDE.md #3312)
+//!
+//! A `mod foo;` inside a comment, a doc comment, or a string literal is **data**, not
+//! a declaration. Scanning raw text would let a doc example such as the `cql_generator`
+//! mention in `storage/write_engine/merge/mod.rs` make an orphan look reachable — a
+//! **false PASS**, the worst failure mode a hygiene guard has. So [`sanitize`] blanks
+//! every comment (line, block, **nested** block, doc) and every complete literal
+//! (string with escapes, raw string at any hash level, byte string, char literal)
+//! before [`parse_mod_decls`] ever sees the text, and the attribute values the parser
+//! genuinely needs (`#[path = "…"]`) are recovered from a **side table** keyed by byte
+//! offset rather than by re-reading the text. Control tokens and caller data therefore
+//! never share a channel.
+//!
+//! # Fail-closed
+//!
+//! Every construct this walker does not model is an `Err`, never a skip: `include!`,
+//! `#[cfg_attr(…, path = …)]`, a `#[path]` on an inline `mod` block, an unterminated
+//! comment or literal, an unreadable file, an unknown escape, and a `mod name;` that
+//! resolves to neither candidate file. A skip is the vacuous pass this guard exists to
+//! prevent.
+
+#![allow(dead_code)]
+
+use std::collections::{BTreeSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// What to analyze. Crate-agnostic on purpose — see the module docs (#1502).
+#[derive(Debug, Clone)]
+pub struct ModuleGraphSpec {
+    /// Absolute path to the crate directory (the one holding `Cargo.toml`).
+    pub crate_dir: PathBuf,
+    /// Crate-relative root file, e.g. `src/lib.rs` (library) or `src/main.rs` (binary).
+    pub root_file_rel: String,
+    /// Crate-relative source directory whose `*.rs` files must all be reachable.
+    pub src_dir_rel: String,
+}
+
+/// A file that is *known* to be unreachable, with the issue that owns removing it.
+#[derive(Debug, Clone, Copy)]
+pub struct ExpectedOrphan {
+    /// Path relative to [`ModuleGraphSpec::src_dir_rel`], forward slashes.
+    pub path: &'static str,
+    /// The issue that owns deleting (or wiring in) the file.
+    pub issue: &'static str,
+    /// Why the exception exists.
+    pub reason: &'static str,
+}
+
+/// Outcome of a reachability analysis. All keys are crate-relative, `/`-separated.
+#[derive(Debug, Clone)]
+pub struct Report {
+    /// Every `*.rs` file found under the source directory.
+    pub enumerated: BTreeSet<String>,
+    /// Every file rustc reaches from the root, including the root itself.
+    pub reachable: BTreeSet<String>,
+    /// `enumerated - reachable`, with no exceptions applied (the caller applies those).
+    pub orphans: BTreeSet<String>,
+    /// How many module files were parsed while walking (root included).
+    pub modules_parsed: usize,
+    /// How many `mod` declarations were resolved to a file.
+    pub mod_decls_resolved: usize,
+}
+
+impl Report {
+    /// `orphans` minus the expected set — the ones a human must act on.
+    pub fn unexpected_orphans(
+        &self,
+        expected: &[ExpectedOrphan],
+        src_dir_rel: &str,
+    ) -> Vec<String> {
+        let allowed: BTreeSet<String> = expected
+            .iter()
+            .map(|e| join_key(src_dir_rel, e.path))
+            .collect();
+        self.orphans
+            .iter()
+            .filter(|o| !allowed.contains(*o))
+            .cloned()
+            .collect()
+    }
+}
+
+/// Walk the module graph and diff it against the on-disk census.
+///
+/// Returns `Err` with an actionable cause for every unmodeled construct (see module docs).
+pub fn analyze(spec: &ModuleGraphSpec) -> Result<Report, String> {
+    let src_root = spec.crate_dir.join(&spec.src_dir_rel);
+    if !src_root.is_dir() {
+        return Err(format!(
+            "source directory `{}` does not exist or is not a directory — \
+             a walker with no census cannot certify anything (FAIL-CLOSED)",
+            src_root.display()
+        ));
+    }
+
+    let mut enumerated = BTreeSet::new();
+    enumerate_rs_files(&spec.crate_dir, &src_root, &mut enumerated)?;
+
+    let root_key = normalize_key(&spec.root_file_rel)?;
+    if !spec.crate_dir.join(&root_key).is_file() {
+        return Err(format!(
+            "root file `{root_key}` does not exist under `{}` (FAIL-CLOSED)",
+            spec.crate_dir.display()
+        ));
+    }
+
+    let mut reachable: BTreeSet<String> = BTreeSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    queue.push_back(root_key);
+    let mut modules_parsed = 0usize;
+    let mut mod_decls_resolved = 0usize;
+
+    while let Some(key) = queue.pop_front() {
+        if !reachable.insert(key.clone()) {
+            continue;
+        }
+        let abs = spec.crate_dir.join(&key);
+        let text = fs::read_to_string(&abs).map_err(|e| {
+            format!(
+                "unreadable module file `{key}`: {e} — an unreadable file cannot be \
+                 analyzed, so its children are unknown (FAIL-CLOSED)"
+            )
+        })?;
+        modules_parsed += 1;
+        let sanitized = sanitize(&text).map_err(|e| format!("{key}: {e}"))?;
+        let decls = parse_mod_decls(&sanitized, &key)?;
+        for decl in decls {
+            let child = resolve_mod_file(&spec.crate_dir, &key, &decl)?;
+            mod_decls_resolved += 1;
+            queue.push_back(child);
+        }
+    }
+
+    let orphans = enumerated.difference(&reachable).cloned().collect();
+    Ok(Report {
+        enumerated,
+        reachable,
+        orphans,
+        modules_parsed,
+        mod_decls_resolved,
+    })
+}
+
+fn enumerate_rs_files(
+    crate_dir: &Path,
+    dir: &Path,
+    out: &mut BTreeSet<String>,
+) -> Result<(), String> {
+    let entries = fs::read_dir(dir).map_err(|e| {
+        format!(
+            "cannot read directory `{}`: {e} (FAIL-CLOSED)",
+            dir.display()
+        )
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            format!(
+                "cannot read entry in `{}`: {e} (FAIL-CLOSED)",
+                dir.display()
+            )
+        })?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|e| format!("cannot stat `{}`: {e} (FAIL-CLOSED)", path.display()))?;
+        if file_type.is_dir() {
+            enumerate_rs_files(crate_dir, &path, out)?;
+        } else if path.extension().map(|e| e == "rs").unwrap_or(false) {
+            let rel = path.strip_prefix(crate_dir).map_err(|_| {
+                format!(
+                    "`{}` is not under crate dir `{}` (FAIL-CLOSED)",
+                    path.display(),
+                    crate_dir.display()
+                )
+            })?;
+            out.insert(path_to_key(rel));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Sanitizer: comments and literals become blanks; literal values go to a side table.
+// ---------------------------------------------------------------------------
+
+/// A complete literal that was blanked out of the sanitized text.
+#[derive(Debug, Clone)]
+pub struct Literal {
+    /// Byte offset of the literal's first byte in the sanitized text.
+    pub start: usize,
+    /// Byte offset one past the literal's last byte.
+    pub end: usize,
+    /// The literal's unescaped value (empty for char literals).
+    pub value: String,
+}
+
+/// Sanitized source: parseable text plus the literal values the parser may need.
+#[derive(Debug, Clone)]
+pub struct Sanitized {
+    /// Same byte length as the input; comments/literals blanked, newlines preserved.
+    pub text: String,
+    /// Every string/char literal that was blanked, in source order.
+    pub literals: Vec<Literal>,
+}
+
+impl Sanitized {
+    fn literals_in(&self, start: usize, end: usize) -> Vec<&Literal> {
+        self.literals
+            .iter()
+            .filter(|l| l.start >= start && l.end <= end)
+            .collect()
+    }
+}
+
+/// Convenience wrapper used by the stripper unit tests.
+pub fn strip_comments_and_strings(src: &str) -> Result<String, String> {
+    Ok(sanitize(src)?.text)
+}
+
+/// Blank every comment and literal, preserving byte offsets and line breaks.
+pub fn sanitize(src: &str) -> Result<Sanitized, String> {
+    let b = src.as_bytes();
+    let n = b.len();
+    let mut out = b.to_vec();
+    let mut literals: Vec<Literal> = Vec::new();
+    let mut i = 0usize;
+
+    while i < n {
+        let c = b[i];
+        if c == b'/' && i + 1 < n && b[i + 1] == b'/' {
+            let mut j = i + 2;
+            while j < n && b[j] != b'\n' {
+                j += 1;
+            }
+            blank(&mut out, i, j);
+            i = j;
+        } else if c == b'/' && i + 1 < n && b[i + 1] == b'*' {
+            let mut depth = 1usize;
+            let mut j = i + 2;
+            while j < n && depth > 0 {
+                if b[j] == b'/' && j + 1 < n && b[j + 1] == b'*' {
+                    depth += 1;
+                    j += 2;
+                } else if b[j] == b'*' && j + 1 < n && b[j + 1] == b'/' {
+                    depth -= 1;
+                    j += 2;
+                } else {
+                    j += 1;
+                }
+            }
+            if depth > 0 {
+                return Err("unterminated block comment (FAIL-CLOSED)".to_string());
+            }
+            blank(&mut out, i, j);
+            i = j;
+        } else if c == b'"' {
+            let (end, value) = scan_string(b, i)?;
+            blank(&mut out, i, end);
+            literals.push(Literal {
+                start: i,
+                end,
+                value,
+            });
+            i = end;
+        } else if c == b'\'' {
+            match scan_char_or_lifetime(b, i)? {
+                Some(end) => {
+                    blank(&mut out, i, end);
+                    literals.push(Literal {
+                        start: i,
+                        end,
+                        value: String::new(),
+                    });
+                    i = end;
+                }
+                // A lifetime (`'a`): ordinary code, leave it alone.
+                None => i += 1,
+            }
+        } else if is_ident_start(c) {
+            let ident_end = ident_end(b, i);
+            let ident = &src[i..ident_end];
+            let next = b.get(ident_end).copied();
+            // `r"…"` / `r#"…"#` / `br#"…"#` are raw STRINGS; `r#type` is a raw
+            // IDENTIFIER (Rust allows keywords as identifiers that way, and
+            // `cqlite-core` uses `r#type`). They differ only in what follows the
+            // hashes: a `"` for the string, an identifier byte for the identifier.
+            let raw_prefix = matches!(ident, "r" | "br") && is_raw_string_prefix(b, ident_end);
+            let byte_prefix = ident == "b" && next == Some(b'"');
+            if raw_prefix {
+                let (end, value) = scan_raw_string(b, i, ident_end)?;
+                blank(&mut out, i, end);
+                literals.push(Literal {
+                    start: i,
+                    end,
+                    value,
+                });
+                i = end;
+            } else if byte_prefix {
+                let (end, value) = scan_string(b, ident_end)?;
+                blank(&mut out, i, end);
+                literals.push(Literal {
+                    start: i,
+                    end,
+                    value,
+                });
+                i = end;
+            } else {
+                i = ident_end;
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    let text = String::from_utf8(out).map_err(|e| {
+        format!("sanitized text is not valid UTF-8 ({e}) — refusing to parse (FAIL-CLOSED)")
+    })?;
+    Ok(Sanitized { text, literals })
+}
+
+fn blank(out: &mut [u8], start: usize, end: usize) {
+    for byte in &mut out[start..end] {
+        if *byte != b'\n' {
+            *byte = b' ';
+        }
+    }
+}
+
+/// Scan a `"…"` literal starting at the opening quote. Returns `(end, unescaped value)`.
+fn scan_string(b: &[u8], start: usize) -> Result<(usize, String), String> {
+    let n = b.len();
+    let mut j = start + 1;
+    let mut value = String::new();
+    while j < n {
+        match b[j] {
+            b'\\' => {
+                if j + 1 >= n {
+                    return Err("unterminated escape in string literal (FAIL-CLOSED)".to_string());
+                }
+                let esc = b[j + 1];
+                let decoded = match esc {
+                    b'\\' => '\\',
+                    b'"' => '"',
+                    b'\'' => '\'',
+                    b'n' => '\n',
+                    b'r' => '\r',
+                    b't' => '\t',
+                    b'0' => '\0',
+                    b'\n' => {
+                        // Line continuation: skip the newline and following whitespace.
+                        j += 2;
+                        while j < n && (b[j] as char).is_ascii_whitespace() {
+                            j += 1;
+                        }
+                        continue;
+                    }
+                    b'x' => {
+                        // `\xNN` — exactly two hex digits.
+                        let hex = b.get(j + 2..j + 4).ok_or_else(|| {
+                            "truncated `\\x` escape in string literal (FAIL-CLOSED)".to_string()
+                        })?;
+                        let text = std::str::from_utf8(hex).map_err(|_| {
+                            "non-UTF-8 `\\x` escape in string literal (FAIL-CLOSED)".to_string()
+                        })?;
+                        let byte = u8::from_str_radix(text, 16).map_err(|_| {
+                            format!("malformed `\\x{text}` escape in string literal (FAIL-CLOSED)")
+                        })?;
+                        value.push(byte as char);
+                        j += 4;
+                        continue;
+                    }
+                    b'u' => {
+                        // `\u{HEX…}`
+                        if b.get(j + 2) != Some(&b'{') {
+                            return Err("malformed `\\u` escape (expected `{`) in string literal \
+                                 (FAIL-CLOSED)"
+                                .to_string());
+                        }
+                        let mut k = j + 3;
+                        let mut digits = String::new();
+                        while k < n && b[k] != b'}' {
+                            if b[k] != b'_' {
+                                digits.push(b[k] as char);
+                            }
+                            k += 1;
+                        }
+                        if k >= n {
+                            return Err(
+                                "unterminated `\\u{…}` escape in string literal (FAIL-CLOSED)"
+                                    .to_string(),
+                            );
+                        }
+                        let code = u32::from_str_radix(&digits, 16).map_err(|_| {
+                            format!("malformed `\\u{{{digits}}}` escape (FAIL-CLOSED)")
+                        })?;
+                        let ch = char::from_u32(code).ok_or_else(|| {
+                            format!("`\\u{{{digits}}}` is not a Unicode scalar (FAIL-CLOSED)")
+                        })?;
+                        value.push(ch);
+                        j = k + 1;
+                        continue;
+                    }
+                    other => {
+                        return Err(format!(
+                            "unmodeled string escape `\\{}` — this walker does not decode it, \
+                             and guessing could mis-read a `#[path]` value (FAIL-CLOSED)",
+                            other as char
+                        ))
+                    }
+                };
+                value.push(decoded);
+                j += 2;
+            }
+            b'"' => return Ok((j + 1, value)),
+            other => {
+                value.push(other as char);
+                j += 1;
+            }
+        }
+    }
+    Err("unterminated string literal (FAIL-CLOSED)".to_string())
+}
+
+/// Scan `r#"…"#` (any hash count). `prefix_end` is the byte after the `r`/`br` ident.
+fn scan_raw_string(b: &[u8], start: usize, prefix_end: usize) -> Result<(usize, String), String> {
+    let n = b.len();
+    let mut hashes = 0usize;
+    let mut j = prefix_end;
+    while j < n && b[j] == b'#' {
+        hashes += 1;
+        j += 1;
+    }
+    if j >= n || b[j] != b'"' {
+        return Err(format!(
+            "malformed raw string literal at byte {start} (FAIL-CLOSED)"
+        ));
+    }
+    let content_start = j + 1;
+    let mut k = content_start;
+    while k < n {
+        if b[k] == b'"' {
+            let mut closing = 0usize;
+            while closing < hashes && k + 1 + closing < n && b[k + 1 + closing] == b'#' {
+                closing += 1;
+            }
+            if closing == hashes {
+                let value = String::from_utf8_lossy(&b[content_start..k]).into_owned();
+                return Ok((k + 1 + hashes, value));
+            }
+        }
+        k += 1;
+    }
+    Err("unterminated raw string literal (FAIL-CLOSED)".to_string())
+}
+
+/// `Ok(Some(end))` for a char literal, `Ok(None)` for a lifetime.
+fn scan_char_or_lifetime(b: &[u8], start: usize) -> Result<Option<usize>, String> {
+    let n = b.len();
+    if start + 1 >= n {
+        return Ok(None);
+    }
+    if b[start + 1] == b'\\' {
+        let mut j = start + 2;
+        // Escapes may be multi-byte (`\u{1F600}`); scan to the closing quote.
+        while j < n && b[j] != b'\'' {
+            j += 1;
+        }
+        if j >= n {
+            return Err("unterminated char literal (FAIL-CLOSED)".to_string());
+        }
+        return Ok(Some(j + 1));
+    }
+    // One UTF-8 scalar followed by `'` is a char literal; anything else is a lifetime.
+    let mut char_len = 1usize;
+    while start + 1 + char_len < n && (b[start + 1 + char_len] & 0xC0) == 0x80 {
+        char_len += 1;
+    }
+    let close = start + 1 + char_len;
+    if close < n && b[close] == b'\'' {
+        Ok(Some(close + 1))
+    } else {
+        Ok(None)
+    }
+}
+
+/// `true` when the bytes at `after_prefix` (just past an `r`/`br` ident) open a raw
+/// STRING literal: zero or more `#` followed by `"`. `r#type` therefore returns `false`
+/// (that is a raw identifier, not a literal).
+fn is_raw_string_prefix(b: &[u8], after_prefix: usize) -> bool {
+    let mut j = after_prefix;
+    while j < b.len() && b[j] == b'#' {
+        j += 1;
+    }
+    b.get(j) == Some(&b'"')
+}
+
+fn is_ident_start(c: u8) -> bool {
+    c == b'_' || c.is_ascii_alphabetic()
+}
+
+fn is_ident_byte(c: u8) -> bool {
+    c == b'_' || c.is_ascii_alphanumeric()
+}
+
+fn ident_end(b: &[u8], start: usize) -> usize {
+    let mut j = start;
+    while j < b.len() && is_ident_byte(b[j]) {
+        j += 1;
+    }
+    j
+}
+
+// ---------------------------------------------------------------------------
+// Parser: `mod` declarations out of sanitized text.
+// ---------------------------------------------------------------------------
+
+/// One `mod` declaration that names a file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModDecl {
+    pub name: String,
+    /// `Some(value)` when declared with `#[path = "value"]`.
+    pub path_attr: Option<String>,
+    /// Names of the enclosing *inline* `mod` blocks, outermost first.
+    pub inline_prefix: Vec<String>,
+    /// 1-based line of the `mod` keyword, for diagnostics.
+    pub line: usize,
+}
+
+/// Extract every external (`mod name;`) declaration, recursing through inline blocks.
+///
+/// cfg-gated declarations are **kept**: a `#[cfg(test)]`/`#[cfg(feature = …)]` module is
+/// reachable (issue #1714 AC-3). No feature evaluation is attempted, by design.
+pub fn parse_mod_decls(s: &Sanitized, file_label: &str) -> Result<Vec<ModDecl>, String> {
+    let text = &s.text;
+    let b = text.as_bytes();
+    let n = b.len();
+    let mut i = 0usize;
+    let mut depth = 0usize;
+    // (inline mod name, brace depth of its body)
+    let mut inline_stack: Vec<(String, usize)> = Vec::new();
+    let mut pending_path: Option<String> = None;
+    let mut out: Vec<ModDecl> = Vec::new();
+
+    while i < n {
+        let c = b[i];
+        if c.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        if c == b'#' {
+            let mut j = i + 1;
+            if j < n && b[j] == b'!' {
+                j += 1;
+            }
+            if j < n && b[j] == b'[' {
+                let close = matching_bracket(b, j, b'[', b']').ok_or_else(|| {
+                    format!("{file_label}: unbalanced attribute brackets (FAIL-CLOSED)")
+                })?;
+                let inner_start = j + 1;
+                let inner = &text[inner_start..close];
+                if let Some(path) = attr_path_value(s, inner, inner_start, close, file_label)? {
+                    pending_path = Some(path);
+                }
+                i = close + 1;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        if c == b'{' {
+            depth += 1;
+            i += 1;
+            continue;
+        }
+        if c == b'}' {
+            depth = depth.saturating_sub(1);
+            while inline_stack.last().map(|t| t.1 > depth).unwrap_or(false) {
+                inline_stack.pop();
+            }
+            i += 1;
+            continue;
+        }
+        if is_ident_start(c) {
+            let end = ident_end(b, i);
+            let word = &text[i..end];
+            let word_start = i;
+            i = end;
+            match word {
+                "pub" => {
+                    // `pub(crate)`, `pub(super)`, `pub(in path)` — skip the qualifier,
+                    // keep any pending `#[path]` for the item that follows.
+                    let mut k = skip_ws(b, i);
+                    if k < n && b[k] == b'(' {
+                        let close = matching_bracket(b, k, b'(', b')').ok_or_else(|| {
+                            format!("{file_label}: unbalanced visibility parens (FAIL-CLOSED)")
+                        })?;
+                        k = close + 1;
+                    }
+                    i = k;
+                }
+                "mod" => {
+                    let k = skip_ws(b, i);
+                    if k >= n || !is_ident_start(b[k]) {
+                        return Err(format!(
+                            "{file_label}:{}: `mod` not followed by an identifier (FAIL-CLOSED)",
+                            line_of(text, word_start)
+                        ));
+                    }
+                    let name_end = ident_end(b, k);
+                    let name = text[k..name_end].to_string();
+                    let after = skip_ws(b, name_end);
+                    if after < n && b[after] == b';' {
+                        out.push(ModDecl {
+                            name,
+                            path_attr: pending_path.take(),
+                            inline_prefix: inline_stack.iter().map(|t| t.0.clone()).collect(),
+                            line: line_of(text, word_start),
+                        });
+                        i = after + 1;
+                    } else if after < n && b[after] == b'{' {
+                        if pending_path.is_some() {
+                            return Err(format!(
+                                "{file_label}:{}: `#[path]` on an INLINE `mod {name} {{ … }}` \
+                                 changes the directory its children resolve against; this walker \
+                                 does not model it (FAIL-CLOSED — see #1714)",
+                                line_of(text, word_start)
+                            ));
+                        }
+                        depth += 1;
+                        inline_stack.push((name, depth));
+                        i = after + 1;
+                    } else {
+                        return Err(format!(
+                            "{file_label}:{}: `mod {name}` followed by neither `;` nor `{{` \
+                             (FAIL-CLOSED)",
+                            line_of(text, word_start)
+                        ));
+                    }
+                    pending_path = None;
+                }
+                "r" if b.get(i) == Some(&b'#')
+                    && b.get(i + 1).map(|c| is_ident_start(*c)).unwrap_or(false) =>
+                {
+                    // Raw identifier (`r#type`, `r#mod`): an identifier, never a keyword.
+                    i = ident_end(b, i + 1);
+                    pending_path = None;
+                }
+                "include" => {
+                    let k = skip_ws(b, i);
+                    if k < n && b[k] == b'!' {
+                        return Err(format!(
+                            "{file_label}:{}: `include!` brings a file into the module graph in a \
+                             way this walker does not model — a file included this way would be \
+                             misreported as an orphan (FAIL-CLOSED — see #1714)",
+                            line_of(text, word_start)
+                        ));
+                    }
+                    pending_path = None;
+                }
+                _ => {
+                    pending_path = None;
+                }
+            }
+            continue;
+        }
+        pending_path = None;
+        i += 1;
+    }
+    Ok(out)
+}
+
+/// `Some(value)` when the attribute body is a `path = "…"`; `Err` for unmodeled shapes.
+fn attr_path_value(
+    s: &Sanitized,
+    inner: &str,
+    inner_start: usize,
+    inner_end: usize,
+    file_label: &str,
+) -> Result<Option<String>, String> {
+    let trimmed = inner.trim_start();
+    if trimmed.starts_with("cfg_attr") && contains_word(inner, "path") {
+        return Err(format!(
+            "{file_label}: `#[cfg_attr(…, path = …)]` conditionally redirects a module file; \
+             this walker does not model it (FAIL-CLOSED — see #1714)"
+        ));
+    }
+    if !trimmed.starts_with("path") {
+        return Ok(None);
+    }
+    let after = trimmed["path".len()..].trim_start();
+    if !after.starts_with('=') {
+        return Ok(None);
+    }
+    let lits = s.literals_in(inner_start, inner_end);
+    if lits.len() != 1 {
+        return Err(format!(
+            "{file_label}: `#[path …]` with {} literal(s) — expected exactly one string value \
+             (FAIL-CLOSED)",
+            lits.len()
+        ));
+    }
+    Ok(Some(lits[0].value.clone()))
+}
+
+fn contains_word(haystack: &str, word: &str) -> bool {
+    let b = haystack.as_bytes();
+    let w = word.as_bytes();
+    let mut i = 0usize;
+    while i + w.len() <= b.len() {
+        if &b[i..i + w.len()] == w {
+            let before_ok = i == 0 || !is_ident_byte(b[i - 1]);
+            let after_ok = i + w.len() == b.len() || !is_ident_byte(b[i + w.len()]);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn skip_ws(b: &[u8], mut i: usize) -> usize {
+    while i < b.len() && b[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+fn matching_bracket(b: &[u8], open_at: usize, open: u8, close: u8) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut i = open_at;
+    while i < b.len() {
+        if b[i] == open {
+            depth += 1;
+        } else if b[i] == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn line_of(text: &str, offset: usize) -> usize {
+    text.as_bytes()[..offset.min(text.len())]
+        .iter()
+        .filter(|c| **c == b'\n')
+        .count()
+        + 1
+}
+
+// ---------------------------------------------------------------------------
+// File resolution (rustc semantics).
+// ---------------------------------------------------------------------------
+
+/// Resolve one `mod` declaration to the crate-relative file it names.
+fn resolve_mod_file(crate_dir: &Path, parent_key: &str, decl: &ModDecl) -> Result<String, String> {
+    let parent_dir = dirname(parent_key);
+    let stem = file_stem(parent_key);
+    // `lib.rs`/`main.rs`/`mod.rs` own their own directory; `foo.rs` owns `foo/`.
+    let module_dir = if matches!(stem.as_str(), "lib" | "main" | "mod") {
+        parent_dir.clone()
+    } else {
+        join_key(&parent_dir, &stem)
+    };
+
+    if let Some(raw) = &decl.path_attr {
+        // The Rust Reference, "Modules / The path attribute":
+        //   * a `#[path]` mod at FILE TOP LEVEL resolves relative to the DIRECTORY of the
+        //     declaring file (so `#[path = "otel_tests.rs"]` in `observability/otel.rs`
+        //     names `observability/otel_tests.rs`, NOT `observability/otel/…`);
+        //   * a `#[path]` mod INSIDE an inline `mod` block resolves relative to the
+        //     module directory (i.e. `<dir>` for a mod-rs file — `lib.rs`/`main.rs`/
+        //     `mod.rs` — and `<dir>/<stem>` for any other file) extended by the names of
+        //     the enclosing inline `mod` blocks.
+        let mut base = if decl.inline_prefix.is_empty() {
+            parent_dir
+        } else {
+            module_dir
+        };
+        for part in &decl.inline_prefix {
+            base = join_key(&base, part);
+        }
+        let key = normalize_key(&join_key(&base, raw))?;
+        if crate_dir.join(&key).is_file() {
+            return Ok(key);
+        }
+        return Err(format!(
+            "{parent_key}:{}: `#[path = \"{raw}\"] mod {}` resolves to `{key}`, which does not \
+             exist (FAIL-CLOSED)",
+            decl.line, decl.name
+        ));
+    }
+
+    let mut base = module_dir;
+    for part in &decl.inline_prefix {
+        base = join_key(&base, part);
+    }
+    let flat = normalize_key(&format!("{base}/{}.rs", decl.name))?;
+    let nested = normalize_key(&format!("{base}/{}/mod.rs", decl.name))?;
+    let flat_exists = crate_dir.join(&flat).is_file();
+    let nested_exists = crate_dir.join(&nested).is_file();
+    match (flat_exists, nested_exists) {
+        (true, false) => Ok(flat),
+        (false, true) => Ok(nested),
+        (true, true) => Err(format!(
+            "{parent_key}:{}: `mod {}` is ambiguous — both `{flat}` and `{nested}` exist \
+             (rustc rejects this too) (FAIL-CLOSED)",
+            decl.line, decl.name
+        )),
+        (false, false) => Err(format!(
+            "{parent_key}:{}: `mod {}` resolves to neither `{flat}` nor `{nested}`, and carries \
+             no `#[path]` attribute — the module graph cannot be walked past this point \
+             (FAIL-CLOSED)",
+            decl.line, decl.name
+        )),
+    }
+}
+
+fn path_to_key(path: &Path) -> String {
+    path.components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn join_key(a: &str, b: &str) -> String {
+    if a.is_empty() {
+        b.to_string()
+    } else if b.is_empty() {
+        a.to_string()
+    } else {
+        format!("{}/{}", a.trim_end_matches('/'), b)
+    }
+}
+
+fn dirname(key: &str) -> String {
+    match key.rfind('/') {
+        Some(idx) => key[..idx].to_string(),
+        None => String::new(),
+    }
+}
+
+fn file_stem(key: &str) -> String {
+    let base = key.rsplit('/').next().unwrap_or(key);
+    match base.rfind('.') {
+        Some(idx) => base[..idx].to_string(),
+        None => base.to_string(),
+    }
+}
+
+/// Lexically resolve `.` and `..` in a `/`-separated key. Escaping the crate root is an error.
+fn normalize_key(key: &str) -> Result<String, String> {
+    let mut parts: Vec<String> = Vec::new();
+    let unified = key.replace('\\', "/");
+    for part in unified.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                if parts.pop().is_none() {
+                    return Err(format!(
+                        "path `{key}` escapes the crate directory — this walker only models \
+                         in-crate module files (FAIL-CLOSED)"
+                    ));
+                }
+            }
+            other => parts.push(other.to_string()),
+        }
+    }
+    Ok(parts.join("/"))
+}

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -56,7 +56,10 @@
 //! what a macro expands to), a symlink under the source directory (see
 //! [`enumerate_rs_files`] — a silently-skipped subtree is a census with a hole in it), an
 //! unterminated comment or literal, an unreadable file, an unknown escape, an
-//! unrecognized literal or identifier prefix (see [`lexer`]), and a
+//! unrecognized literal or identifier prefix (see [`lexer`]), a **non-ASCII byte in a
+//! position where an identifier could start or continue** (see
+//! [`lexer::refuse_non_ascii`] — Rust permits Unicode identifiers, this lexer's rules are
+//! ASCII-only, and scanning past one could misclassify a macro context), and a
 //! `mod name;` that resolves to neither candidate file. A skip is the vacuous pass this
 //! guard exists to prevent.
 
@@ -72,7 +75,10 @@ use std::collections::{BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use lexer::{ident_token, is_ident_byte, is_ident_start, lex_token, line_of, skip_ws, LexToken};
+use lexer::{
+    ident_token, is_ident_byte, is_ident_start, lex_token, line_of, refuse_non_ascii, skip_ws,
+    IdentPos, LexToken,
+};
 
 /// What to analyze. Crate-agnostic on purpose — see the module docs (#1502).
 #[derive(Debug, Clone)]
@@ -343,6 +349,13 @@ pub fn sanitize(src: &str) -> Result<Sanitized, String> {
                 LexToken::Lifetime { end } => i = end,
             }
         } else {
+            // Identifier-family analogue of the unrecognized-prefix refusal above: this
+            // byte is in CODE position (every comment and literal reached so far was
+            // blanked and skipped), and Rust allows a Unicode identifier there — which
+            // this lexer's ASCII-only rules do not model. Refusing, rather than scanning
+            // past, is what stops `macro_rules! café { () => { mod orphan; } }` from
+            // being read as ordinary code (#1714).
+            refuse_non_ascii(b, src, i, IdentPos::Start)?;
             i += 1;
         }
     }
@@ -350,6 +363,25 @@ pub fn sanitize(src: &str) -> Result<Sanitized, String> {
     let text = String::from_utf8(out).map_err(|e| {
         format!("sanitized text is not valid UTF-8 ({e}) — refusing to parse (FAIL-CLOSED)")
     })?;
+    // Backstop for the identifier-family boundary above, and the reason every downstream
+    // parser may rely on ASCII identifier rules: blanking writes ASCII spaces and a
+    // non-ASCII byte in code position is refused, so a SUCCESSFUL sanitize is ASCII-only
+    // by construction. Asserting that invariant beats arguing it — if some future lexer
+    // path lets a non-ASCII byte through in code position, `parse_mod_decls` and
+    // `find_mod_token` would silently split an identifier around it (#1714).
+    if let Some(at) = text.as_bytes().iter().position(|c| !c.is_ascii()) {
+        return Err(format!(
+            "line {}: sanitized text still holds a non-ASCII byte (0x{:02X}) after every \
+             comment and literal was blanked. This lexer's identifier rules are ASCII-only, \
+             so scanning it would split an identifier around that byte and could \
+             misclassify a macro context — the silent FALSE PASS this walker exists to \
+             prevent (FAIL-CLOSED — see #1714).\n\
+             Remedy: report this as a lexer gap — a non-ASCII byte in code position should \
+             already have been refused at the scan (tests/support/mod_reachability.rs).",
+            line_of(&text, at),
+            text.as_bytes()[at]
+        ));
+    }
     Ok(Sanitized { text, literals })
 }
 

--- a/cqlite-core/tests/support/mod_reachability.rs
+++ b/cqlite-core/tests/support/mod_reachability.rs
@@ -48,9 +48,19 @@
 
 #![allow(dead_code)]
 
+// One table-driven place for every Rust literal and identifier prefix (issue #1714): an
+// unrecognized prefix is an `Err`, never a fall-through to ordinary scanning. See the
+// lexer module's docs for why the prefix knowledge cannot live in three parsers again.
+#[path = "mod_reachability_lexer.rs"]
+pub mod lexer;
+
 use std::collections::{BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use lexer::{
+    ident_token, is_ident_byte, is_ident_start, lex_token, line_of, skip_ws, LexToken,
+};
 
 /// What to analyze. Crate-agnostic on purpose — see the module docs (#1502).
 #[derive(Debug, Clone)]
@@ -299,59 +309,26 @@ pub fn sanitize(src: &str) -> Result<Sanitized, String> {
             }
             blank(&mut out, i, j);
             i = j;
-        } else if c == b'"' {
-            let (end, value) = scan_string(b, i)?;
-            blank(&mut out, i, end);
-            literals.push(Literal {
-                start: i,
-                end,
-                value,
-            });
-            i = end;
-        } else if c == b'\'' {
-            match scan_char_or_lifetime(b, i)? {
-                Some(end) => {
+        } else if c == b'"' || c == b'\'' || is_ident_start(c) {
+            // ALL literal/identifier prefix recognition goes through the lexer's table:
+            // strings, raw strings at any hash level, byte and C-string flavors, byte
+            // chars, char-vs-lifetime, and raw identifiers. An identifier-ish token glued
+            // to `"`/`'`/`#` that the table does not know is an `Err` here, so a literal
+            // form newer than the table cannot silently disable the guard (#1714).
+            match lex_token(b, src, i)? {
+                LexToken::Literal { end, value } => {
                     blank(&mut out, i, end);
                     literals.push(Literal {
                         start: i,
                         end,
-                        value: String::new(),
+                        value,
                     });
                     i = end;
                 }
-                // A lifetime (`'a`): ordinary code, leave it alone.
-                None => i += 1,
-            }
-        } else if is_ident_start(c) {
-            let ident_end = ident_end(b, i);
-            let ident = &src[i..ident_end];
-            let next = b.get(ident_end).copied();
-            // `r"…"` / `r#"…"#` / `br#"…"#` are raw STRINGS; `r#type` is a raw
-            // IDENTIFIER (Rust allows keywords as identifiers that way, and
-            // `cqlite-core` uses `r#type`). They differ only in what follows the
-            // hashes: a `"` for the string, an identifier byte for the identifier.
-            let raw_prefix = matches!(ident, "r" | "br") && is_raw_string_prefix(b, ident_end);
-            let byte_prefix = ident == "b" && next == Some(b'"');
-            if raw_prefix {
-                let (end, value) = scan_raw_string(b, i, ident_end)?;
-                blank(&mut out, i, end);
-                literals.push(Literal {
-                    start: i,
-                    end,
-                    value,
-                });
-                i = end;
-            } else if byte_prefix {
-                let (end, value) = scan_string(b, ident_end)?;
-                blank(&mut out, i, end);
-                literals.push(Literal {
-                    start: i,
-                    end,
-                    value,
-                });
-                i = end;
-            } else {
-                i = ident_end;
+                // Ordinary code: identifiers (including `r#type`) and lifetimes/labels
+                // are consumed whole so their bytes cannot be re-read as a prefix.
+                LexToken::Ident(span) => i = span.end,
+                LexToken::Lifetime { end } => i = end,
             }
         } else {
             i += 1;
@@ -370,216 +347,6 @@ fn blank(out: &mut [u8], start: usize, end: usize) {
             *byte = b' ';
         }
     }
-}
-
-/// Scan a `"…"` literal starting at the opening quote. Returns `(end, unescaped value)`.
-///
-/// The value is accumulated as **raw bytes** and decoded as UTF-8 once at the end. The
-/// obvious `value.push(byte as char)` decodes UTF-8 one byte at a time, so the two bytes
-/// of `ó` become two Latin-1 characters and `#[path = "módulo.rs"]` resolves to mojibake
-/// that names no file — the byte-vs-char confusion behind CLAUDE.md's six-defect
-/// path-normalisation family.
-fn scan_string(b: &[u8], start: usize) -> Result<(usize, String), String> {
-    let n = b.len();
-    let mut j = start + 1;
-    let mut value: Vec<u8> = Vec::new();
-    while j < n {
-        match b[j] {
-            b'\\' => {
-                if j + 1 >= n {
-                    return Err("unterminated escape in string literal (FAIL-CLOSED)".to_string());
-                }
-                let esc = b[j + 1];
-                let decoded = match esc {
-                    b'\\' => '\\',
-                    b'"' => '"',
-                    b'\'' => '\'',
-                    b'n' => '\n',
-                    b'r' => '\r',
-                    b't' => '\t',
-                    b'0' => '\0',
-                    b'\n' => {
-                        // Line continuation: skip the newline and following whitespace.
-                        j += 2;
-                        while j < n && (b[j] as char).is_ascii_whitespace() {
-                            j += 1;
-                        }
-                        continue;
-                    }
-                    b'x' => {
-                        // `\xNN` — exactly two hex digits.
-                        let hex = b.get(j + 2..j + 4).ok_or_else(|| {
-                            "truncated `\\x` escape in string literal (FAIL-CLOSED)".to_string()
-                        })?;
-                        let text = std::str::from_utf8(hex).map_err(|_| {
-                            "non-UTF-8 `\\x` escape in string literal (FAIL-CLOSED)".to_string()
-                        })?;
-                        let byte = u8::from_str_radix(text, 16).map_err(|_| {
-                            format!("malformed `\\x{text}` escape in string literal (FAIL-CLOSED)")
-                        })?;
-                        // `\xNN` names a CODE POINT here, not a raw byte: Rust rejects
-                        // `\x80`+ in a string literal, and this scanner is shared with
-                        // byte strings (`b"\xff"`), where accumulating the raw byte would
-                        // make a legitimate literal invalid UTF-8 and fail the walk closed.
-                        push_char(&mut value, byte as char);
-                        j += 4;
-                        continue;
-                    }
-                    b'u' => {
-                        // `\u{HEX…}`
-                        if b.get(j + 2) != Some(&b'{') {
-                            return Err("malformed `\\u` escape (expected `{`) in string literal \
-                                 (FAIL-CLOSED)"
-                                .to_string());
-                        }
-                        let mut k = j + 3;
-                        let mut digits = String::new();
-                        while k < n && b[k] != b'}' {
-                            if b[k] != b'_' {
-                                digits.push(b[k] as char);
-                            }
-                            k += 1;
-                        }
-                        if k >= n {
-                            return Err(
-                                "unterminated `\\u{…}` escape in string literal (FAIL-CLOSED)"
-                                    .to_string(),
-                            );
-                        }
-                        let code = u32::from_str_radix(&digits, 16).map_err(|_| {
-                            format!("malformed `\\u{{{digits}}}` escape (FAIL-CLOSED)")
-                        })?;
-                        let ch = char::from_u32(code).ok_or_else(|| {
-                            format!("`\\u{{{digits}}}` is not a Unicode scalar (FAIL-CLOSED)")
-                        })?;
-                        push_char(&mut value, ch);
-                        j = k + 1;
-                        continue;
-                    }
-                    other => {
-                        return Err(format!(
-                            "unmodeled string escape `\\{}` — this walker does not decode it, \
-                             and guessing could mis-read a `#[path]` value (FAIL-CLOSED)",
-                            other as char
-                        ))
-                    }
-                };
-                push_char(&mut value, decoded);
-                j += 2;
-            }
-            b'"' => {
-                let decoded = String::from_utf8(value).map_err(|e| {
-                    format!(
-                        "string literal is not valid UTF-8 ({e}) — refusing to guess its \
-                         value (FAIL-CLOSED)"
-                    )
-                })?;
-                return Ok((j + 1, decoded));
-            }
-            other => {
-                // Raw byte: a multi-byte character arrives here one byte per iteration and
-                // must be reassembled, not transcoded per byte.
-                value.push(other);
-                j += 1;
-            }
-        }
-    }
-    Err("unterminated string literal (FAIL-CLOSED)".to_string())
-}
-
-/// Append `ch`'s UTF-8 encoding to a raw-byte literal accumulator.
-fn push_char(out: &mut Vec<u8>, ch: char) {
-    let mut buf = [0u8; 4];
-    out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
-}
-
-/// Scan `r#"…"#` (any hash count). `prefix_end` is the byte after the `r`/`br` ident.
-fn scan_raw_string(b: &[u8], start: usize, prefix_end: usize) -> Result<(usize, String), String> {
-    let n = b.len();
-    let mut hashes = 0usize;
-    let mut j = prefix_end;
-    while j < n && b[j] == b'#' {
-        hashes += 1;
-        j += 1;
-    }
-    if j >= n || b[j] != b'"' {
-        return Err(format!(
-            "malformed raw string literal at byte {start} (FAIL-CLOSED)"
-        ));
-    }
-    let content_start = j + 1;
-    let mut k = content_start;
-    while k < n {
-        if b[k] == b'"' {
-            let mut closing = 0usize;
-            while closing < hashes && k + 1 + closing < n && b[k + 1 + closing] == b'#' {
-                closing += 1;
-            }
-            if closing == hashes {
-                let value = String::from_utf8_lossy(&b[content_start..k]).into_owned();
-                return Ok((k + 1 + hashes, value));
-            }
-        }
-        k += 1;
-    }
-    Err("unterminated raw string literal (FAIL-CLOSED)".to_string())
-}
-
-/// `Ok(Some(end))` for a char literal, `Ok(None)` for a lifetime.
-fn scan_char_or_lifetime(b: &[u8], start: usize) -> Result<Option<usize>, String> {
-    let n = b.len();
-    if start + 1 >= n {
-        return Ok(None);
-    }
-    if b[start + 1] == b'\\' {
-        let mut j = start + 2;
-        // Escapes may be multi-byte (`\u{1F600}`); scan to the closing quote.
-        while j < n && b[j] != b'\'' {
-            j += 1;
-        }
-        if j >= n {
-            return Err("unterminated char literal (FAIL-CLOSED)".to_string());
-        }
-        return Ok(Some(j + 1));
-    }
-    // One UTF-8 scalar followed by `'` is a char literal; anything else is a lifetime.
-    let mut char_len = 1usize;
-    while start + 1 + char_len < n && (b[start + 1 + char_len] & 0xC0) == 0x80 {
-        char_len += 1;
-    }
-    let close = start + 1 + char_len;
-    if close < n && b[close] == b'\'' {
-        Ok(Some(close + 1))
-    } else {
-        Ok(None)
-    }
-}
-
-/// `true` when the bytes at `after_prefix` (just past an `r`/`br` ident) open a raw
-/// STRING literal: zero or more `#` followed by `"`. `r#type` therefore returns `false`
-/// (that is a raw identifier, not a literal).
-fn is_raw_string_prefix(b: &[u8], after_prefix: usize) -> bool {
-    let mut j = after_prefix;
-    while j < b.len() && b[j] == b'#' {
-        j += 1;
-    }
-    b.get(j) == Some(&b'"')
-}
-
-fn is_ident_start(c: u8) -> bool {
-    c == b'_' || c.is_ascii_alphabetic()
-}
-
-fn is_ident_byte(c: u8) -> bool {
-    c == b'_' || c.is_ascii_alphanumeric()
-}
-
-fn ident_end(b: &[u8], start: usize) -> usize {
-    let mut j = start;
-    while j < b.len() && is_ident_byte(b[j]) {
-        j += 1;
-    }
-    j
 }
 
 // ---------------------------------------------------------------------------
@@ -653,10 +420,25 @@ pub fn parse_mod_decls(s: &Sanitized, file_label: &str) -> Result<Vec<ModDecl>, 
             continue;
         }
         if is_ident_start(c) {
-            let end = ident_end(b, i);
-            let word = &text[i..end];
+            // One shared lexer consumes the identifier, `r#` included, so a raw
+            // identifier can never be re-read as its `r` + `#` + name pieces (#1714).
+            let tok = ident_token(b, i);
+            let word = &text[tok.name_start..tok.name_end];
             let word_start = i;
-            i = end;
+            i = tok.end;
+            if tok.raw {
+                // A raw identifier is an IDENTIFIER, never a keyword: `r#mod` declares
+                // nothing. But it CAN name a macro (`r#make!(…)`, `foo::r#bar!{…}`), so
+                // it must still reach the fail-closed macro branch — otherwise a `mod`
+                // inside that token tree would be counted as a real declaration (#1714).
+                if let Some(after_macro) =
+                    scan_macro_context(b, text, &format!("r#{word}"), i, word_start, file_label)?
+                {
+                    i = after_macro;
+                }
+                pending_path = None;
+                continue;
+            }
             match word {
                 "pub" => {
                     // `pub(crate)`, `pub(super)`, `pub(in path)` — skip the qualifier,
@@ -678,9 +460,13 @@ pub fn parse_mod_decls(s: &Sanitized, file_label: &str) -> Result<Vec<ModDecl>, 
                             line_of(text, word_start)
                         ));
                     }
-                    let name_end = ident_end(b, k);
-                    let name = text[k..name_end].to_string();
-                    let after = skip_ws(b, name_end);
+                    // `mod r#type;` is legal and declares a module whose file is
+                    // `type.rs`: the `r#` is not part of the name. Lexing the name
+                    // atomically is what makes that resolve instead of failing closed
+                    // on a `mod` "followed by neither `;` nor `{`" (#1714).
+                    let name_tok = ident_token(b, k);
+                    let name = text[name_tok.name_start..name_tok.name_end].to_string();
+                    let after = skip_ws(b, name_tok.end);
                     if after < n && b[after] == b';' {
                         out.push(ModDecl {
                             name,
@@ -708,13 +494,6 @@ pub fn parse_mod_decls(s: &Sanitized, file_label: &str) -> Result<Vec<ModDecl>, 
                             line_of(text, word_start)
                         ));
                     }
-                    pending_path = None;
-                }
-                "r" if b.get(i) == Some(&b'#')
-                    && b.get(i + 1).map(|c| is_ident_start(*c)).unwrap_or(false) =>
-                {
-                    // Raw identifier (`r#type`, `r#mod`): an identifier, never a keyword.
-                    i = ident_end(b, i + 1);
                     pending_path = None;
                 }
                 "include" => {
@@ -789,9 +568,16 @@ fn scan_macro_context(
     // an invocation puts the name before the `!`.
     let mut macro_name = format!("{word}!");
     if word == "macro_rules" && k < n && is_ident_start(b[k]) {
-        let name_end = ident_end(b, k);
-        macro_name = format!("macro_rules! {}", &text[k..name_end]);
-        k = skip_ws(b, name_end);
+        // The name may be a raw identifier (`macro_rules! r#make`); consuming it
+        // atomically is what keeps the definition recognized as a macro instead of
+        // leaving its body to be parsed as ordinary Rust (#1714).
+        let name_tok = ident_token(b, k);
+        macro_name = format!(
+            "macro_rules! {}{}",
+            if name_tok.raw { "r#" } else { "" },
+            &text[name_tok.name_start..name_tok.name_end]
+        );
+        k = skip_ws(b, name_tok.end);
     }
 
     // No delimiter after the `!` means this was never a macro invocation — `a != b`
@@ -834,17 +620,18 @@ fn find_mod_token(b: &[u8], text: &str, start: usize, end: usize) -> Option<usiz
     let mut i = start;
     while i < end {
         if is_ident_start(b[i]) {
-            let word_end = ident_end(b, i).min(end);
-            // `r#mod` is a raw IDENTIFIER; the `#` before it is the tell.
-            let raw_ident = i > 0 && b[i - 1] == b'#';
-            if !raw_ident && &text[i..word_end] == "mod" {
-                let after = skip_ws(b, word_end);
+            let tok = ident_token(b, i);
+            let word_end = tok.name_end.min(end);
+            // `r#mod` is a raw IDENTIFIER, not the keyword — decided by the shared lexer's
+            // `raw` flag rather than by peeking at the previous byte (#1714).
+            if !tok.raw && tok.name_end <= end && &text[tok.name_start..word_end] == "mod" {
+                let after = skip_ws(b, tok.end);
                 // `mod name;` or a `macro_rules!` metavariable `mod $name;`.
                 if after < end && (is_ident_start(b[after]) || b[after] == b'$') {
                     return Some(i);
                 }
             }
-            i = word_end.max(i + 1);
+            i = tok.end.max(i + 1);
         } else {
             i += 1;
         }
@@ -902,13 +689,6 @@ fn contains_word(haystack: &str, word: &str) -> bool {
     false
 }
 
-fn skip_ws(b: &[u8], mut i: usize) -> usize {
-    while i < b.len() && b[i].is_ascii_whitespace() {
-        i += 1;
-    }
-    i
-}
-
 fn matching_bracket(b: &[u8], open_at: usize, open: u8, close: u8) -> Option<usize> {
     let mut depth = 0usize;
     let mut i = open_at;
@@ -924,14 +704,6 @@ fn matching_bracket(b: &[u8], open_at: usize, open: u8, close: u8) -> Option<usi
         i += 1;
     }
     None
-}
-
-fn line_of(text: &str, offset: usize) -> usize {
-    text.as_bytes()[..offset.min(text.len())]
-        .iter()
-        .filter(|c| **c == b'\n')
-        .count()
-        + 1
 }
 
 // ---------------------------------------------------------------------------

--- a/cqlite-core/tests/support/mod_reachability_harness.rs
+++ b/cqlite-core/tests/support/mod_reachability_harness.rs
@@ -1,0 +1,108 @@
+//! Shared test harness for the `mod`-reachability guard (issue #1714).
+//!
+//! Two helpers, used by every `issue_1714_mod_reachability*` integration test:
+//!
+//! * [`ScratchCrate`] — a throwaway crate-shaped directory tree, so the detector's teeth
+//!   are proven against a tree the test controls end to end rather than against the live
+//!   `cqlite-core/src` (whose orphan set changes as #1715 / #3364 / #3365 land);
+//! * [`stripped`] — the sanitizer at its own boundary.
+//!
+//! It lives in `support/` (not inlined in one test file) because each integration test is
+//! its OWN crate: without a shared file, a second test file must copy the harness, and a
+//! copy is where the two drift apart. Every includer declares both modules:
+//!
+//! ```ignore
+//! #[path = "support/mod_reachability.rs"]
+//! mod mod_reachability;
+//! #[path = "support/mod_reachability_harness.rs"]
+//! mod harness;
+//! ```
+
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::mod_reachability::{analyze, strip_comments_and_strings, ModuleGraphSpec, Report};
+
+/// Sanitize `src` and return the blanked text, panicking on a refusal.
+///
+/// Tests that WANT the refusal call [`strip_comments_and_strings`] directly and assert on
+/// the `Err` — a helper that swallowed it would turn a fail-closed refusal into a pass.
+pub fn stripped(src: &str) -> String {
+    strip_comments_and_strings(src).unwrap_or_else(|e| panic!("sanitize failed: {e}"))
+}
+
+const SRC_DIR: &str = "src";
+
+static SCRATCH_SEQ: AtomicUsize = AtomicUsize::new(0);
+
+/// A throwaway crate-shaped directory tree under the OS temp dir.
+pub struct ScratchCrate {
+    dir: PathBuf,
+}
+
+impl ScratchCrate {
+    pub fn new(label: &str) -> Self {
+        let seq = SCRATCH_SEQ.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!(
+            "cqlite-1714-mod-reach-{}-{seq}-{label}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("cannot create {}: {e}", dir.display()));
+        Self { dir }
+    }
+
+    /// The crate directory itself — for the few cases that must build something the
+    /// `write` helper cannot express (a symlink, a directory outside `src`).
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    pub fn write(&self, rel: &str, contents: &str) {
+        let path = self.dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .unwrap_or_else(|e| panic!("cannot create {}: {e}", parent.display()));
+        }
+        fs::write(&path, contents)
+            .unwrap_or_else(|e| panic!("cannot write {}: {e}", path.display()));
+    }
+
+    pub fn spec(&self) -> ModuleGraphSpec {
+        ModuleGraphSpec {
+            crate_dir: self.dir.clone(),
+            root_file_rel: "src/lib.rs".to_string(),
+            src_dir_rel: SRC_DIR.to_string(),
+        }
+    }
+
+    pub fn analyze(&self) -> Report {
+        analyze(&self.spec()).unwrap_or_else(|cause| {
+            panic!(
+                "walk of scratch crate {} failed: {cause}",
+                self.dir.display()
+            )
+        })
+    }
+
+    /// Assert the walk fails closed and return the cause.
+    pub fn expect_failure(&self) -> String {
+        match analyze(&self.spec()) {
+            Ok(report) => panic!(
+                "expected a FAIL-CLOSED refusal, got a report (orphans={:?}) — a skip-and-continue \
+                 here IS the vacuous pass",
+                report.orphans
+            ),
+            Err(cause) => cause,
+        }
+    }
+}
+
+impl Drop for ScratchCrate {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}

--- a/cqlite-core/tests/support/mod_reachability_lexer.rs
+++ b/cqlite-core/tests/support/mod_reachability_lexer.rs
@@ -41,6 +41,22 @@
 //!
 //! A bare `'` is a char literal **or** a lifetime/label (`'a`, `'static`, and the raw
 //! lifetime `'r#fn`); telling them apart is [`scan_char_or_lifetime`]'s job.
+//!
+//! # Fail closed on a NON-ASCII identifier — the same boundary, one family over
+//!
+//! Rust identifiers are `XID_Start XID_Continue*`, so `café`, `Übersicht` and `模块` are
+//! all legal identifiers and `macro_rules! café { () => { mod orphan; } }` is a real macro
+//! definition. This lexer's identifier rules are **deliberately ASCII-only**
+//! ([`is_ident_start`] / [`is_ident_byte`]), because widening them means shipping (or
+//! depending on) Unicode XID tables — a second implementation of rustc's lexer, which is
+//! the mistake that produced this walker's whole review history.
+//!
+//! So the ASCII-only rules keep a **boundary**, not a blind spot: a non-ASCII byte in a
+//! position where an identifier could start or continue is an `Err`
+//! ([`refuse_non_ascii`]), exactly as an unrecognized literal prefix is. Without it the
+//! lexer would return `caf` for `café`, leave `é` to the ordinary scan, fail to recognize
+//! the macro context, and count the `mod orphan;` in the macro body as a real declaration
+//! — the silent FALSE PASS this walker exists to prevent.
 
 #![allow(dead_code)]
 
@@ -234,6 +250,9 @@ pub fn ident_token(b: &[u8], start: usize) -> IdentSpan {
 /// fail-closed branch that keeps the prefix family closed) and for a malformed or
 /// unterminated literal.
 pub fn lex_token(b: &[u8], src: &str, start: usize) -> Result<LexToken, String> {
+    // Identifier-family analogue of the unrecognized-prefix refusal below: a non-ASCII
+    // byte here could START a Unicode identifier this lexer does not model (#1714).
+    refuse_non_ascii(b, src, start, IdentPos::Start)?;
     // The unprefixed rows are looked up in exactly the same table as the prefixed ones,
     // so `"` and `'` cannot drift away from what `PREFIXES` says about them.
     if let Some(follower) = follower_of(b[start]) {
@@ -252,6 +271,10 @@ pub fn lex_token(b: &[u8], src: &str, start: usize) -> Result<LexToken, String> 
         ));
     }
     let id_end = ident_end(b, start);
+    // ...and the CONTINUE position. `ident_end` stops at the first non-ident ASCII byte,
+    // so without this the identifier `café` would lex as `caf` and its macro context
+    // would go unrecognized (#1714).
+    refuse_non_ascii(b, src, id_end, IdentPos::Continue)?;
     let ident = &src[start..id_end];
     let Some(next) = b.get(id_end).copied() else {
         return Ok(LexToken::Ident(ident_token(b, start)));
@@ -317,6 +340,70 @@ fn scan_form(
             Err(unrecognized(src, start, ident, b'#'))
         }
     }
+}
+
+/// Which identifier position a non-ASCII byte was met in. Both are refusals; the
+/// distinction is diagnostic only — it tells the reader whether the character would have
+/// begun an identifier or extended the one just scanned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentPos {
+    /// A byte where an identifier could START (`café`'s `c` position).
+    Start,
+    /// A byte where the identifier just scanned could CONTINUE (`café`'s `é`).
+    Continue,
+}
+
+impl IdentPos {
+    fn describe(self) -> &'static str {
+        match self {
+            IdentPos::Start => "could START a Rust identifier",
+            IdentPos::Continue => "could CONTINUE the identifier just scanned",
+        }
+    }
+}
+
+/// Refuse a non-ASCII byte met where an identifier could start or continue.
+///
+/// **This is the identifier-family analogue of [`unrecognized`]** (the literal-prefix
+/// refusal): the same fail-closed boundary, one lexical family over. See the module docs
+/// for why the identifier rules are ASCII-only and why widening them is the wrong fix.
+///
+/// `Ok(())` for `at` past the end of `b` and for every ASCII byte — non-ASCII text in
+/// comments and literals never reaches here, because the sanitizer blanks and skips those
+/// spans before the scan can reach a byte inside one.
+pub fn refuse_non_ascii(b: &[u8], src: &str, at: usize, pos: IdentPos) -> Result<(), String> {
+    let Some(&byte) = b.get(at) else {
+        return Ok(());
+    };
+    if byte.is_ascii() {
+        return Ok(());
+    }
+    Err(non_ascii_refusal(src, at, byte, pos))
+}
+
+/// `byte` is passed in rather than re-read from `src`, so this cannot index out of bounds
+/// even if a caller ever hands it a `src` that is not `b`'s text.
+fn non_ascii_refusal(src: &str, at: usize, byte: u8, pos: IdentPos) -> String {
+    // The byte is shown as a CHARACTER when the offset is a UTF-8 boundary (it always is
+    // in practice: everything scanned before it was ASCII), and as a raw byte otherwise,
+    // so the diagnostic can never itself mangle the input it is reporting.
+    let shown = match src.get(at..).and_then(|rest| rest.chars().next()) {
+        Some(ch) => format!("`{ch}` (U+{:04X})", ch as u32),
+        None => format!("byte 0x{byte:02X}"),
+    };
+    format!(
+        "line {}: {shown} is a NON-ASCII character in a position that {}. This lexer's \
+         identifier rules are deliberately ASCII-only, while Rust permits Unicode \
+         identifiers (`XID_Start XID_Continue*`), so scanning past it could misclassify a \
+         macro context — `macro_rules! café {{ () => {{ mod orphan; }} }}` would be read as \
+         ordinary code and the `mod orphan;` in its body counted as a real declaration, \
+         the silent FALSE PASS this walker exists to prevent (FAIL-CLOSED — see #1714).\n\
+         Remedy: rename the identifier to ASCII, or teach this lexer real Unicode XID \
+         identifier rules (tests/support/mod_reachability_lexer.rs) — which means Unicode \
+         tables, not a wider byte range.",
+        line_of(src, at),
+        pos.describe()
+    )
 }
 
 fn unrecognized(src: &str, start: usize, ident: &str, follower: u8) -> String {
@@ -545,14 +632,22 @@ pub fn is_raw_string_prefix(b: &[u8], after_prefix: usize) -> bool {
 // Shared byte helpers
 // ---------------------------------------------------------------------------
 
+/// ASCII-only by design — the boundary that makes that sound is [`refuse_non_ascii`],
+/// which refuses (never skips) a non-ASCII byte in this position. See the module docs.
 pub fn is_ident_start(c: u8) -> bool {
     c == b'_' || c.is_ascii_alphabetic()
 }
 
+/// ASCII-only by design; see [`is_ident_start`] and [`refuse_non_ascii`].
 pub fn is_ident_byte(c: u8) -> bool {
     c == b'_' || c.is_ascii_alphanumeric()
 }
 
+/// One past the last identifier byte at `start`.
+///
+/// Stops at the first byte [`is_ident_byte`] rejects, which includes every non-ASCII byte
+/// — so a caller that may see raw source must pair this with [`refuse_non_ascii`] at the
+/// returned offset rather than treat the stop as a token boundary.
 pub fn ident_end(b: &[u8], start: usize) -> usize {
     let mut j = start;
     while j < b.len() && is_ident_byte(b[j]) {

--- a/cqlite-core/tests/support/mod_reachability_lexer.rs
+++ b/cqlite-core/tests/support/mod_reachability_lexer.rs
@@ -1,0 +1,578 @@
+//! Table-driven Rust lexical recognition for the `mod`-reachability walker (issue #1714).
+//!
+//! # Why this is one table and not scattered prefix checks
+//!
+//! The walker's whole value is that it cannot be fooled into calling an unreachable file
+//! reachable. Every false PASS it has ever had came from the same shape: a `mod orphan;`
+//! that lives inside something the lexer did not recognize — a comment, a string, a macro
+//! token tree — and therefore got scanned as ordinary code. Two review rounds produced
+//! five findings of that shape, and the last two (`cr#"…"#` raw C-strings, and raw
+//! identifiers such as `macro_rules! r#make`) were the *same* bug twice: the prefix
+//! recognition lived in three places (`sanitize`, `parse_mod_decls`, `find_mod_token`),
+//! each knowing a different subset of Rust's prefixes, and **an unrecognized prefix fell
+//! through to ordinary scanning**.
+//!
+//! So prefix knowledge lives here, once, in [`PREFIXES`], and every caller goes through
+//! [`lex_token`] / [`ident_token`]. Adding a Rust literal form is a one-row edit.
+//!
+//! # Fail closed on an unrecognized prefix — the load-bearing half
+//!
+//! Rust **reserves** every `ident"…"`, `ident'…'` and `ident#…` sequence (edition 2021
+//! reserved prefixes, RFC 3101), precisely so future literal forms can be added. This
+//! lexer takes the same position: an identifier-ish token immediately followed by `"`,
+//! `'` or `#` that is not in [`PREFIXES`] is an **`Err` naming the file, line and token**
+//! — never a fall-through to ordinary scanning. That converts the entire family from
+//! "silent false PASS" into "loud refusal", so a Rust literal prefix newer than this
+//! table cannot quietly disable the guard: the walk stops and a human adds the row.
+//!
+//! # The complete set as of Rust 2024
+//!
+//! | form | example |
+//! |------|---------|
+//! | string | `"s"` |
+//! | raw string (any hash count) | `r"s"`, `r#"s"#`, `r##"s"##` |
+//! | byte string | `b"s"` |
+//! | raw byte string | `br"s"`, `br#"s"#` |
+//! | C string | `c"s"` |
+//! | raw C string | `cr"s"`, `cr#"s"#` |
+//! | char | `'c'`, `'\''`, `'\u{1F600}'` |
+//! | byte char | `b'c'` |
+//! | raw identifier (legal anywhere an identifier is) | `r#type`, `r#make` |
+//!
+//! A bare `'` is a char literal **or** a lifetime/label (`'a`, `'static`, and the raw
+//! lifetime `'r#fn`); telling them apart is [`scan_char_or_lifetime`]'s job.
+
+#![allow(dead_code)]
+
+// ---------------------------------------------------------------------------
+// The table
+// ---------------------------------------------------------------------------
+
+/// The byte that follows a prefix identifier and decides what it introduces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Follower {
+    /// `"` — a quoted literal starts immediately.
+    Quote,
+    /// `'` — a char-like literal (or, unprefixed, possibly a lifetime).
+    Apostrophe,
+    /// `#` — raw string hashes, or a raw identifier.
+    Hash,
+}
+
+/// How to scan the token a recognized (prefix, follower) pair introduces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Form {
+    /// `"…"` with escapes: string, byte string, C string.
+    Quoted,
+    /// `r"…"` / `r#"…"#` at any hash count, byte or C flavored.
+    RawQuoted,
+    /// `'…'` — unprefixed, so it may instead be a lifetime/label.
+    CharOrLifetime,
+    /// `b'…'` — always a literal; a lifetime cannot carry the `b` prefix.
+    ByteChar,
+    /// `r#` — either a raw string (`r#"…"#`) or a raw identifier (`r#type`).
+    RawQuotedOrRawIdent,
+}
+
+struct PrefixRow {
+    /// The identifier immediately before the follower; `""` for the unprefixed forms.
+    ident: &'static str,
+    follower: Follower,
+    form: Form,
+}
+
+/// Every literal/identifier prefix Rust 2024 defines. **This is the single place prefix
+/// knowledge lives** (see the module docs); anything absent from it fails closed.
+const PREFIXES: &[PrefixRow] = &[
+    // Unprefixed forms.
+    PrefixRow {
+        ident: "",
+        follower: Follower::Quote,
+        form: Form::Quoted,
+    },
+    PrefixRow {
+        ident: "",
+        follower: Follower::Apostrophe,
+        form: Form::CharOrLifetime,
+    },
+    // Byte flavored.
+    PrefixRow {
+        ident: "b",
+        follower: Follower::Quote,
+        form: Form::Quoted,
+    },
+    PrefixRow {
+        ident: "b",
+        follower: Follower::Apostrophe,
+        form: Form::ByteChar,
+    },
+    PrefixRow {
+        ident: "br",
+        follower: Follower::Quote,
+        form: Form::RawQuoted,
+    },
+    PrefixRow {
+        ident: "br",
+        follower: Follower::Hash,
+        form: Form::RawQuoted,
+    },
+    // C-string flavored (Rust 1.77+): `c"…"`, `cr"…"`, `cr#"…"#`.
+    PrefixRow {
+        ident: "c",
+        follower: Follower::Quote,
+        form: Form::Quoted,
+    },
+    PrefixRow {
+        ident: "cr",
+        follower: Follower::Quote,
+        form: Form::RawQuoted,
+    },
+    PrefixRow {
+        ident: "cr",
+        follower: Follower::Hash,
+        form: Form::RawQuoted,
+    },
+    // Plain raw: `r"…"`, and `r#` which is a raw string OR a raw identifier.
+    PrefixRow {
+        ident: "r",
+        follower: Follower::Quote,
+        form: Form::RawQuoted,
+    },
+    PrefixRow {
+        ident: "r",
+        follower: Follower::Hash,
+        form: Form::RawQuotedOrRawIdent,
+    },
+];
+
+fn follower_of(byte: u8) -> Option<Follower> {
+    match byte {
+        b'"' => Some(Follower::Quote),
+        b'\'' => Some(Follower::Apostrophe),
+        b'#' => Some(Follower::Hash),
+        _ => None,
+    }
+}
+
+fn lookup(ident: &str, follower: Follower) -> Option<Form> {
+    PREFIXES
+        .iter()
+        .find(|row| row.ident == ident && row.follower == follower)
+        .map(|row| row.form)
+}
+
+// ---------------------------------------------------------------------------
+// Tokens
+// ---------------------------------------------------------------------------
+
+/// An identifier, with any `r#` consumed **atomically**.
+///
+/// `name_start..name_end` is the identifier *name* — the `r#` is not part of it, which is
+/// why `mod r#type;` declares a module whose file is `type.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IdentSpan {
+    pub start: usize,
+    /// One past the whole token (past `type` in `r#type`).
+    pub end: usize,
+    pub name_start: usize,
+    pub name_end: usize,
+    /// `true` for `r#ident`: an identifier, therefore **never** a keyword.
+    pub raw: bool,
+}
+
+/// What [`lex_token`] found.
+#[derive(Debug, Clone)]
+pub enum LexToken {
+    /// A complete literal spanning `start..end`; `value` is unescaped (empty for chars).
+    Literal { end: usize, value: String },
+    /// An identifier (possibly raw).
+    Ident(IdentSpan),
+    /// A lifetime/label sigil (`'a`, `'static`, `'r#fn`) — ordinary code, one byte wide.
+    Lifetime { end: usize },
+}
+
+/// The identifier token starting at `start`, consuming a leading `r#` atomically.
+///
+/// Infallible by design: this is the form used on **already-sanitized** text, where every
+/// literal has been blanked, so `r#` can only be a raw identifier. A stray `r#` followed
+/// by a non-identifier byte (impossible post-[`sanitize`]-style blanking, which fails
+/// closed on it) degrades to the plain identifier `r`, leaving the `#` to the caller —
+/// never to a silent skip.
+///
+/// [`sanitize`]: crate
+pub fn ident_token(b: &[u8], start: usize) -> IdentSpan {
+    let id_end = ident_end(b, start);
+    if b.get(id_end) == Some(&b'#')
+        && b.get(id_end + 1)
+            .copied()
+            .map(is_ident_start)
+            .unwrap_or(false)
+        && &b[start..id_end] == b"r"
+    {
+        let name_start = id_end + 1;
+        let name_end = ident_end(b, name_start);
+        return IdentSpan {
+            start,
+            end: name_end,
+            name_start,
+            name_end,
+            raw: true,
+        };
+    }
+    IdentSpan {
+        start,
+        end: id_end,
+        name_start: start,
+        name_end: id_end,
+        raw: false,
+    }
+}
+
+/// Lex the token at `start`, which must be an identifier-start byte, `"`, or `'`.
+///
+/// Returns `Err` for an unrecognized prefix (see the module docs — this is the
+/// fail-closed branch that keeps the prefix family closed) and for a malformed or
+/// unterminated literal.
+pub fn lex_token(b: &[u8], src: &str, start: usize) -> Result<LexToken, String> {
+    // The unprefixed rows are looked up in exactly the same table as the prefixed ones,
+    // so `"` and `'` cannot drift away from what `PREFIXES` says about them.
+    if let Some(follower) = follower_of(b[start]) {
+        if follower != Follower::Hash {
+            let form =
+                lookup("", follower).ok_or_else(|| unrecognized(src, start, "", b[start]))?;
+            return scan_form(b, src, start, start, form, "");
+        }
+    }
+    if !is_ident_start(b[start]) {
+        return Err(format!(
+            "line {}: `{}` is not the start of a token this lexer models (FAIL-CLOSED — \
+             see #1714)",
+            line_of(src, start),
+            b[start] as char
+        ));
+    }
+    let id_end = ident_end(b, start);
+    let ident = &src[start..id_end];
+    let Some(next) = b.get(id_end).copied() else {
+        return Ok(LexToken::Ident(ident_token(b, start)));
+    };
+    let Some(follower) = follower_of(next) else {
+        return Ok(LexToken::Ident(ident_token(b, start)));
+    };
+    // An identifier-ish token glued to `"`, `'` or `#` is a PREFIX. If the table does not
+    // know it, refuse: falling through to ordinary scanning would parse the literal's
+    // contents as code, and a `mod orphan;` inside it would be counted as a real
+    // declaration — a silent FALSE PASS, the one failure mode this walker exists to
+    // prevent. Rust itself reserves these sequences for exactly this reason (#1714).
+    let form = lookup(ident, follower).ok_or_else(|| unrecognized(src, start, ident, next))?;
+    scan_form(b, src, start, id_end, form, ident)
+}
+
+fn scan_form(
+    b: &[u8],
+    src: &str,
+    start: usize,
+    prefix_end: usize,
+    form: Form,
+    ident: &str,
+) -> Result<LexToken, String> {
+    match form {
+        Form::Quoted => {
+            let (end, value) = scan_string(b, prefix_end)?;
+            Ok(LexToken::Literal { end, value })
+        }
+        Form::RawQuoted => {
+            let (end, value) = scan_raw_string(b, start, prefix_end)?;
+            Ok(LexToken::Literal { end, value })
+        }
+        Form::CharOrLifetime => match scan_char_or_lifetime(b, prefix_end)? {
+            Some(end) => Ok(LexToken::Literal {
+                end,
+                value: String::new(),
+            }),
+            None => Ok(LexToken::Lifetime { end: start + 1 }),
+        },
+        Form::ByteChar => match scan_char_or_lifetime(b, prefix_end)? {
+            Some(end) => Ok(LexToken::Literal {
+                end,
+                value: String::new(),
+            }),
+            // `b'` cannot introduce a lifetime, so an unclosed one is malformed input,
+            // not code to scan past.
+            None => Err(format!(
+                "line {}: malformed byte-char literal `b'` (FAIL-CLOSED — see #1714)",
+                line_of(src, start)
+            )),
+        },
+        Form::RawQuotedOrRawIdent => {
+            if is_raw_string_prefix(b, prefix_end) {
+                let (end, value) = scan_raw_string(b, start, prefix_end)?;
+                return Ok(LexToken::Literal { end, value });
+            }
+            let span = ident_token(b, start);
+            if span.raw {
+                return Ok(LexToken::Ident(span));
+            }
+            // `r##foo`, `r#1`: neither a raw string nor a raw identifier.
+            Err(unrecognized(src, start, ident, b'#'))
+        }
+    }
+}
+
+fn unrecognized(src: &str, start: usize, ident: &str, follower: u8) -> String {
+    format!(
+        "line {}: `{ident}{}` is an unrecognized literal/identifier prefix. Rust reserves \
+         EVERY `ident\"…\"`, `ident'…'` and `ident#…` sequence, so this is either a literal \
+         form newer than this lexer's table or not Rust at all. Scanning past it as \
+         ordinary code would parse its contents as code — and a `mod orphan;` inside it \
+         would be counted as a real declaration, the silent FALSE PASS this walker exists \
+         to prevent (FAIL-CLOSED — see #1714).\n\
+         Remedy: add the form to `PREFIXES` in tests/support/mod_reachability_lexer.rs.",
+        line_of(src, start),
+        follower as char
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Scanners
+// ---------------------------------------------------------------------------
+
+/// Scan a `"…"` literal starting at the opening quote. Returns `(end, unescaped value)`.
+///
+/// The value is accumulated as **raw bytes** and decoded as UTF-8 once at the end. The
+/// obvious `value.push(byte as char)` decodes UTF-8 one byte at a time, so the two bytes
+/// of `ó` become two Latin-1 characters and `#[path = "módulo.rs"]` resolves to mojibake
+/// that names no file — the byte-vs-char confusion behind CLAUDE.md's six-defect
+/// path-normalisation family.
+pub fn scan_string(b: &[u8], start: usize) -> Result<(usize, String), String> {
+    let n = b.len();
+    let mut j = start + 1;
+    let mut value: Vec<u8> = Vec::new();
+    while j < n {
+        match b[j] {
+            b'\\' => {
+                if j + 1 >= n {
+                    return Err("unterminated escape in string literal (FAIL-CLOSED)".to_string());
+                }
+                let esc = b[j + 1];
+                let decoded = match esc {
+                    b'\\' => '\\',
+                    b'"' => '"',
+                    b'\'' => '\'',
+                    b'n' => '\n',
+                    b'r' => '\r',
+                    b't' => '\t',
+                    b'0' => '\0',
+                    b'\n' => {
+                        // Line continuation: skip the newline and following whitespace.
+                        j += 2;
+                        while j < n && (b[j] as char).is_ascii_whitespace() {
+                            j += 1;
+                        }
+                        continue;
+                    }
+                    b'x' => {
+                        // `\xNN` — exactly two hex digits.
+                        let hex = b.get(j + 2..j + 4).ok_or_else(|| {
+                            "truncated `\\x` escape in string literal (FAIL-CLOSED)".to_string()
+                        })?;
+                        let text = std::str::from_utf8(hex).map_err(|_| {
+                            "non-UTF-8 `\\x` escape in string literal (FAIL-CLOSED)".to_string()
+                        })?;
+                        let byte = u8::from_str_radix(text, 16).map_err(|_| {
+                            format!("malformed `\\x{text}` escape in string literal (FAIL-CLOSED)")
+                        })?;
+                        // `\xNN` names a CODE POINT here, not a raw byte: Rust rejects
+                        // `\x80`+ in a string literal, and this scanner is shared with
+                        // byte strings (`b"\xff"`), where accumulating the raw byte would
+                        // make a legitimate literal invalid UTF-8 and fail the walk closed.
+                        push_char(&mut value, byte as char);
+                        j += 4;
+                        continue;
+                    }
+                    b'u' => {
+                        // `\u{HEX…}`
+                        if b.get(j + 2) != Some(&b'{') {
+                            return Err("malformed `\\u` escape (expected `{`) in string literal \
+                                 (FAIL-CLOSED)"
+                                .to_string());
+                        }
+                        let mut k = j + 3;
+                        let mut digits = String::new();
+                        while k < n && b[k] != b'}' {
+                            if b[k] != b'_' {
+                                digits.push(b[k] as char);
+                            }
+                            k += 1;
+                        }
+                        if k >= n {
+                            return Err(
+                                "unterminated `\\u{…}` escape in string literal (FAIL-CLOSED)"
+                                    .to_string(),
+                            );
+                        }
+                        let code = u32::from_str_radix(&digits, 16).map_err(|_| {
+                            format!("malformed `\\u{{{digits}}}` escape (FAIL-CLOSED)")
+                        })?;
+                        let ch = char::from_u32(code).ok_or_else(|| {
+                            format!("`\\u{{{digits}}}` is not a Unicode scalar (FAIL-CLOSED)")
+                        })?;
+                        push_char(&mut value, ch);
+                        j = k + 1;
+                        continue;
+                    }
+                    other => {
+                        return Err(format!(
+                            "unmodeled string escape `\\{}` — this walker does not decode it, \
+                             and guessing could mis-read a `#[path]` value (FAIL-CLOSED)",
+                            other as char
+                        ))
+                    }
+                };
+                push_char(&mut value, decoded);
+                j += 2;
+            }
+            b'"' => {
+                let decoded = String::from_utf8(value).map_err(|e| {
+                    format!(
+                        "string literal is not valid UTF-8 ({e}) — refusing to guess its \
+                         value (FAIL-CLOSED)"
+                    )
+                })?;
+                return Ok((j + 1, decoded));
+            }
+            other => {
+                // Raw byte: a multi-byte character arrives here one byte per iteration and
+                // must be reassembled, not transcoded per byte.
+                value.push(other);
+                j += 1;
+            }
+        }
+    }
+    Err("unterminated string literal (FAIL-CLOSED)".to_string())
+}
+
+/// Append `ch`'s UTF-8 encoding to a raw-byte literal accumulator.
+fn push_char(out: &mut Vec<u8>, ch: char) {
+    let mut buf = [0u8; 4];
+    out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+}
+
+/// Scan `r#"…"#` at any hash count (also `br`/`cr` flavored). `prefix_end` is the byte
+/// after the prefix identifier; `start` is the prefix's first byte, so the returned span
+/// covers the prefix too.
+///
+/// The closing delimiter is `"` followed by **exactly** the opening hash count, which is
+/// what makes an embedded `"` — the adversarial `cr#"left " mod orphan; " right"#` — part
+/// of the value rather than a premature terminator.
+pub fn scan_raw_string(
+    b: &[u8],
+    start: usize,
+    prefix_end: usize,
+) -> Result<(usize, String), String> {
+    let n = b.len();
+    let mut hashes = 0usize;
+    let mut j = prefix_end;
+    while j < n && b[j] == b'#' {
+        hashes += 1;
+        j += 1;
+    }
+    if j >= n || b[j] != b'"' {
+        return Err(format!(
+            "malformed raw string literal at byte {start} (FAIL-CLOSED)"
+        ));
+    }
+    let content_start = j + 1;
+    let mut k = content_start;
+    while k < n {
+        if b[k] == b'"' {
+            let mut closing = 0usize;
+            while closing < hashes && k + 1 + closing < n && b[k + 1 + closing] == b'#' {
+                closing += 1;
+            }
+            if closing == hashes {
+                let value = String::from_utf8_lossy(&b[content_start..k]).into_owned();
+                return Ok((k + 1 + hashes, value));
+            }
+        }
+        k += 1;
+    }
+    Err("unterminated raw string literal (FAIL-CLOSED)".to_string())
+}
+
+/// `Ok(Some(end))` for a char literal, `Ok(None)` for a lifetime/label.
+pub fn scan_char_or_lifetime(b: &[u8], start: usize) -> Result<Option<usize>, String> {
+    let n = b.len();
+    if start + 1 >= n {
+        return Ok(None);
+    }
+    if b[start + 1] == b'\\' {
+        let mut j = start + 2;
+        // Escapes may be multi-byte (`\u{1F600}`); scan to the closing quote.
+        while j < n && b[j] != b'\'' {
+            j += 1;
+        }
+        if j >= n {
+            return Err("unterminated char literal (FAIL-CLOSED)".to_string());
+        }
+        return Ok(Some(j + 1));
+    }
+    // One UTF-8 scalar followed by `'` is a char literal; anything else is a lifetime.
+    let mut char_len = 1usize;
+    while start + 1 + char_len < n && (b[start + 1 + char_len] & 0xC0) == 0x80 {
+        char_len += 1;
+    }
+    let close = start + 1 + char_len;
+    if close < n && b[close] == b'\'' {
+        Ok(Some(close + 1))
+    } else {
+        Ok(None)
+    }
+}
+
+/// `true` when the bytes at `after_prefix` (just past an `r`/`br`/`cr` ident) open a raw
+/// STRING literal: zero or more `#` followed by `"`. `r#type` therefore returns `false`
+/// (that is a raw identifier, not a literal).
+pub fn is_raw_string_prefix(b: &[u8], after_prefix: usize) -> bool {
+    let mut j = after_prefix;
+    while j < b.len() && b[j] == b'#' {
+        j += 1;
+    }
+    b.get(j) == Some(&b'"')
+}
+
+// ---------------------------------------------------------------------------
+// Shared byte helpers
+// ---------------------------------------------------------------------------
+
+pub fn is_ident_start(c: u8) -> bool {
+    c == b'_' || c.is_ascii_alphabetic()
+}
+
+pub fn is_ident_byte(c: u8) -> bool {
+    c == b'_' || c.is_ascii_alphanumeric()
+}
+
+pub fn ident_end(b: &[u8], start: usize) -> usize {
+    let mut j = start;
+    while j < b.len() && is_ident_byte(b[j]) {
+        j += 1;
+    }
+    j
+}
+
+pub fn skip_ws(b: &[u8], mut i: usize) -> usize {
+    while i < b.len() && b[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+/// 1-based line of `offset` within `text`.
+pub fn line_of(text: &str, offset: usize) -> usize {
+    text.as_bytes()[..offset.min(text.len())]
+        .iter()
+        .filter(|c| **c == b'\n')
+        .count()
+        + 1
+}


### PR DESCRIPTION
Refs #1714. **DO NOT MERGE — held by lead ruling, blocked on #3366.**

> **Status: OPEN, UNARMED, intentionally not merging.** `--auto` is deliberately **not** armed.
> The delivery lead [revised an earlier merge approval and held this PR](https://github.com/pmcfadin/cqlite/issues/1714#issuecomment-5435644930): the hand-written-lexer design is being replaced by **#3366** (reachability derived from rustc's own dep-info), which is sequenced ahead of it. This PR is preserved as the evidence and test corpus for that work, **not** as a merge candidate. It deliberately does **not** say `Closes #1714`.

## What it contains

A standing **mod-reachability guard** for `cqlite-core/src`: every `.rs` file under it must be reachable from a `mod` declaration chain rooted at `lib.rs`. A file with no such chain is **never compiled by rustc under any feature combination**, so edits to it are silent no-ops and tests inside it never run — the failure mode #1714 was filed for, after a dead file misled an auditor into a refuted finding.

| file | lines |
|---|---|
| `cqlite-core/tests/support/mod_reachability.rs` | 977 |
| `cqlite-core/tests/support/mod_reachability_lexer.rs` | 673 |
| `cqlite-core/tests/support/mod_reachability_harness.rs` | 108 |
| `cqlite-core/tests/issue_1714_mod_reachability.rs` | 1301 |
| `cqlite-core/tests/issue_1714_mod_reachability_shebang.rs` | 148 |

**34 tests** (30 + 4). AK3's deletion half was already done: `cqlite-core/src/memory_safety_tests.rs` went out in `fb8330a6a` (PR #2044) before this issue was claimed, so the guard was the entire remaining deliverable.

## Why it is held — six rustc divergences over five roborev rounds

Every false-PASS finding was one class: **our lexer disagreeing with rustc's.** Each was fixed; the class regenerated. Findings per round: **3, 2, 2, 2, 3 — it went up.**

| round | divergence | class |
|---|---|---|
| 1 | `mod` inside a `macro_rules!` body / `stringify!(…)` | false PASS |
| 2 | `cr"…"` / `cr#"…"#` raw C-strings unrecognized | false PASS |
| 2 | raw identifiers (`r#make`) not consumed atomically | false PASS |
| 3 | identifiers ASCII-only; Rust permits Unicode XID | false PASS |
| 4 | `#!` shebang lines not stripped | false PASS |
| 5 | absolute `#[path]` values folded in-crate as relative | **false PASS, in the original walker** |

Round 5 ended the design. It was a silent false PASS in the *core* walker rather than in the refusal work, which falsified the premise the earlier approval rested on ("the residual leans fail-closed"). Per #3283's budget rule — *more than two rounds to converge means it is the wrong design; stop and re-derive, do not patch* — five rounds is the answer. A set difference against rustc's dep-info has **no lexer to diverge**.

The mitigation that did work, worth carrying to #3366 in spirit: close each family by **refusal** rather than emulation — an `Err` naming file, line, token and remedy, never a silent pass. Its limit is that it does not generalize; a shebang is neither a literal prefix nor an identifier.

## Certification status — stated precisely, nothing implied

| stage | status |
|---|---|
| `--lite` | **PASS** at `82c6bb95` (this HEAD) — block below |
| **FULL `agent-gate.sh`** | **NEVER RUN.** No gate of record exists for this branch. |
| roborev | **NEVER CLEAN.** 5 rounds, all `RESULT: FAIL` (3/2/2/2/3 findings). Last at `8f5339c9`. |
| `rust-reviewer` | **NEVER DELIVERED**, two attempts. See residuals. |
| spec-auditor **C** | not run |

Round 5's findings are **partially fixed**: the absolute-`#[path]` false PASS is fixed (`82c6bb95`); the shebang whitespace false-FAIL and the `'\''`/`b'\''` span bug are **left unfixed** on the lead's instruction not to open a round 6 for a diff that will not merge as the durable guard.

## What the guard found: four orphans, one that a hand-census missed

| file | LOC | how it hid | owner |
|---|---|---|---|
| `schema/cql_generator.rs` | 856 | no reference of any kind | #1715 |
| `storage/sstable/header_fix_functions.rs` | 102 | no reference of any kind | #3364 |
| `parser/collection_udt_tests.rs` | 374 | **wired only by a commented-out `mod`** | #3365 |
| `memory_safety_tests.rs` | 482 | already deleted in `fb8330a6a` | #1714 |

The third is the useful one. `cqlite-core/src/parser/mod.rs:115` reads `// pub mod collection_udt_tests; // Commented out due to missing methods` — a grep census counts that as a wiring. **My own careful hand-census cleared the file; the guard caught it.** None of the three live orphans is deleted here; each is owned by its own issue, and the fail-closed exception entries force those PRs to remove their own entry.

## Observed firing, not merely present (#3249)

Each probe run against the **live** tree, then reverted:

| probe | result |
|---|---|
| planted `src/zzz_lead_probe_orphan.rs` | orphan reported by name, both remedies listed |
| removed an exception's target file | `stale exception … remove this exception entry` |
| `macro_rules!` containing `mod zzz_probe_target;` | fail-closed, names the macro |
| symlinked dir `src/zzz_linkdir` | fail-closed, names the path |
| `cr#"left " mod zzz_orphan_target; " right"#` | orphan correctly reported unreachable |
| unrecognized prefix `zz"…"` | fail-closed, remedy names the `PREFIXES` table |
| real 482-line `memory_safety_tests.rs` restored from history | flagged by name — closes AC-2's first half against the real artifact |

Also verified by hand (substituting for the missing review): exception matching is **exact** `BTreeSet` membership, so an entry cannot excuse a sibling path; the walk's `Err` path panics fail-closed; census floors assert on **two** axes (files enumerated *and* declarations resolved); `#[path]` on an inline `mod` is detected and hard-failed rather than mis-resolved. The guard was confirmed to run in the gate of record's scope: `cargo nextest list -p cqlite-core --features cli-helpers` lists its tests.

## Residuals

- **`rust-reviewer` never delivered — twice.** First attempt signalled idle with no findings; a fresh respawn with an explicit `model: opus` (per the lead's condition, not a `SendMessage` resume) was still running with nothing delivered when this PR was opened. **Review-first did not happen on this diff.** Recorded rather than papered over as "clean". Moot for merging since this PR is held, but it must not be read as reviewed. Six of seven subagents this lane signalled idle without a terminal packet; the lead is tracking that as a fleet-level precondition, not a #1714 footnote.
- **#3367** — `roborev-lints` reds at random. It FAILed once here then PASSed 4/4 standalone at the same commit. Not caused by this diff (`git diff --name-only origin/main...HEAD -- scripts/` is empty). Two defects that cancel: a mutable `WRAPPER` global making the assert order-dependent, and underneath it a **deterministic** true-positive where the `#`-prefix filter fails to exclude a continuation line of the wrapper's own doctrine prose. **Fixing the first alone turns the gate permanently red.** `scripts/` deliberately untouched here.
- Roborev's **prescription** for the shebang finding was wrong (verified against `rustc 1.98.0`: `#! [allow(…)]` and `#! /* c */ [allow(…)]` both compile, so rustc skips whitespace *and* comments before testing for `[`). Its diagnoses were reliable across five rounds; its fixes were not. Full table in #3366.
- **AF1 #1502** is still open, so no shared CLI helper existed to reuse. #3366 generalizes to any crate and closes that half.
- No new dependencies; std only.

## Follow-ups filed

**#3364** (delete `header_fix_functions.rs`) · **#3365** (delete-or-wire `collection_udt_tests.rs`) · **#3366** (rustc dep-info oracle — **blocks this PR**) · **#3367** (`roborev-lints` random red). All deliberately **unlabeled**: a worker touches only `coord:*` labels, so P-levels and board Status are the owner's call.

## `--lite` SUMMARY at this HEAD (NOT the gate of record)

```

==== AGENT-GATE LITE SUMMARY ====
run-id: /tmp/agent-gate.ZV1QNA
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 82c6bb9 branch: issue-1714-delete-orphan-memory-safety-tests dirty: no
lite-scope: file-size fmt clippy roborev-lints scoped-tests (full gate NOT run — run it once before merge)
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=absent perf=paranoid-4
cpu-budget: wrapper=nice ncpu=16 max-concurrency=1 cores-per-gate=16 build-jobs=16(derived) test-threads=16
tree-start: 82c6bb956910 dirty: no digest: f5abbb4d1f43
tree-end: 82c6bb956910 dirty: no digest: f5abbb4d1f43
tree-integrity: PASS
file-size:         PASS (0s)
fmt:               PASS (5s)
clippy:            PASS (1s)
roborev-lints:     PASS (40s)
scoped-tests:      PASS (5s)
logs: /tmp/agent-gate.ZV1QNA
summary-file: /tmp/gate-lite-1714-final.txt
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```
