### PR TITLE
fix(#1458): dataset guards fail closed on a present-but-empty corpus (Python + Node strict fixtures)

### DIFF
--- a/bindings/node/__test__/dataset-guard.test.js
+++ b/bindings/node/__test__/dataset-guard.test.js
@@ -1,0 +1,93 @@
+/**
+ * Tests for the dataset-availability guard itself (issue #1458).
+ *
+ * The guard IS the fail-loudly mechanism for missing SSTable fixtures, so it
+ * needs its own coverage: a present-but-EMPTY sstables directory (the exact
+ * shape of the original #773 failure) must FAIL the suite under strict mode,
+ * never silently `describe.skip`.
+ *
+ * These tests drive the REAL `setup.js` in a child `jest` process — they never
+ * reimplement the directory walk — because a test that reimplements the logic
+ * it asserts on is invariant to the bug (#3042).
+ */
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SETUP_JS = path.join(__dirname, 'setup.js');
+const PACKAGE_DIR = path.dirname(__dirname);
+
+/**
+ * Locate the jest CLI entry point. jest's own module resolver refuses
+ * `require.resolve('jest/bin/jest.js')` (package `exports` map), so resolve the
+ * conventional install locations directly -- the same path package.json's
+ * `test` script uses. Missing => throw (fail loudly), never skip.
+ *
+ * @returns {string}
+ */
+function resolveJestBin() {
+  const candidates = [
+    path.join(PACKAGE_DIR, 'node_modules', 'jest', 'bin', 'jest.js'),
+    path.join(PACKAGE_DIR, '..', '..', 'node_modules', 'jest', 'bin', 'jest.js'),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error(`jest CLI not found; looked in:\n  ${candidates.join('\n  ')}`);
+}
+
+/**
+ * Run a child jest process whose ONLY setup file is the real setup.js, against
+ * a datasets root that exists but holds zero *-Data.db files.
+ *
+ * @param {{strict: boolean}} opts
+ * @returns {{status: number, stdout: string, stderr: string}}
+ */
+function runChildJest({ strict }) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-dataset-guard-'));
+  // Present-but-empty corpus: sstables/test_basic/ exists, no *-Data.db anywhere.
+  fs.mkdirSync(path.join(tmp, 'datasets', 'sstables', 'test_basic'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmp, 'noop.test.js'),
+    "test('noop', () => { expect(global.DATASETS_AVAILABLE).toBe(false); });\n"
+  );
+
+  const config = JSON.stringify({
+    testEnvironment: 'node',
+    rootDir: tmp,
+    testMatch: ['**/*.test.js'],
+    setupFilesAfterEnv: [SETUP_JS],
+  });
+
+  const env = { ...process.env, CQLITE_DATASETS_ROOT: path.join(tmp, 'datasets') };
+  delete env.CQLITE_REQUIRE_FIXTURES;
+  delete env.CQLITE_PARITY_REQUIRE_DATASETS;
+  // Jest sets these for its own workers; leaking them into a nested run confuses it.
+  delete env.JEST_WORKER_ID;
+  if (strict) env.CQLITE_REQUIRE_FIXTURES = '1';
+
+  const result = spawnSync(process.execPath, [resolveJestBin(), '--config', config, '--ci'], {
+    env,
+    encoding: 'utf8',
+    cwd: tmp,
+  });
+  return { status: result.status, stdout: result.stdout || '', stderr: result.stderr || '' };
+}
+
+describe('dataset guard (issue #1458)', () => {
+  test('strict mode fails the suite on a present-but-empty datasets dir', () => {
+    const { status, stdout, stderr } = runChildJest({ strict: true });
+    const output = `${stdout}${stderr}`;
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/-Data\.db/);
+  }, 120000);
+
+  test('non-strict mode still passes (skips) on a present-but-empty datasets dir', () => {
+    const { status, stdout, stderr } = runChildJest({ strict: false });
+    if (status !== 0) {
+      throw new Error(`expected exit 0, got ${status}\n${stdout}${stderr}`);
+    }
+    expect(status).toBe(0);
+  }, 120000);
+});

--- a/bindings/node/__test__/dataset-guard.test.js
+++ b/bindings/node/__test__/dataset-guard.test.js
@@ -16,6 +16,8 @@ const os = require('os');
 const path = require('path');
 
 const SETUP_JS = path.join(__dirname, 'setup.js');
+// Upper bound on a nested jest run (see the spawnSync call for why it matters).
+const CHILD_TIMEOUT_MS = 90000;
 const PACKAGE_DIR = path.dirname(__dirname);
 
 /**
@@ -162,7 +164,28 @@ function runChildJest({ strict, corpus = 'empty' }) {
     env,
     encoding: 'utf8',
     cwd: tmp,
+    // A finite bound is load-bearing, not hygiene: jest's own per-test timeout
+    // cannot interrupt a SYNCHRONOUS spawnSync, so without this a wedged child
+    // stalls the whole test job indefinitely. Kept below the 120s per-test
+    // timeout so a hang surfaces as the explicit throw below.
+    timeout: CHILD_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
+
+  // A timed-out or unstartable child yields status === null, and the strict
+  // cases assert `status !== 0` -- so an unreported hang would MASQUERADE as
+  // the strict-mode failure they are trying to prove. Fail loudly instead.
+  if (result.error) {
+    throw new Error(
+      `child jest did not complete (corpus=${corpus} strict=${strict}): ${result.error.message}`
+    );
+  }
+  if (result.status === null) {
+    throw new Error(
+      `child jest was killed without an exit status (corpus=${corpus} strict=${strict}; ` +
+      `signal=${result.signal}) -- treated as a harness failure, never as a guard verdict`
+    );
+  }
   return { status: result.status, stdout: result.stdout || '', stderr: result.stderr || '' };
 }
 

--- a/bindings/node/__test__/dataset-guard.test.js
+++ b/bindings/node/__test__/dataset-guard.test.js
@@ -70,6 +70,26 @@ const CORPUS_SHAPES = {
     },
     childTest: "test('noop', () => {});\n",
   },
+  // A self-referential symlink inside test_basic. Symlinked keyspace dirs are
+  // followed on purpose, so the walk must terminate on a link pointing at an
+  // ancestor and report an unavailable corpus rather than crashing setup --
+  // which it must never do in NON-strict mode (issue #1458).
+  //
+  // HONESTY NOTE: this case is a behavioral CONTROL, not a red-then-green
+  // regression pin. Measured on Linux, the pre-visited-set walk did not blow
+  // the stack: the kernel's 40-level symlink cap makes statSync() fail ELOOP at
+  // recursion depth ~81, which the broken-symlink `continue` swallows. The
+  // visited-set still earns its place (it drops those ~80 redundant
+  // readdir/stat rounds and re-walks of diamond-linked dirs), and this case
+  // pins the observable contract on every platform.
+  symlinkCycle: {
+    build: (sstables) => {
+      const testBasic = path.join(sstables, 'test_basic');
+      fs.mkdirSync(testBasic, { recursive: true });
+      fs.symlinkSync(sstables, path.join(testBasic, 'loop'), 'dir');
+    },
+    childTest: "test('noop', () => { expect(global.DATASETS_AVAILABLE).toBe(false); });\n",
+  },
 };
 
 /**
@@ -138,5 +158,16 @@ describe('dataset guard (issue #1458)', () => {
     }
     expect(output).toMatch(/test_basic/);
     expect(output).toMatch(/-Data\.db/);
+  }, 120000);
+
+  // The walk follows symlinked dirs, so a link pointing at an ancestor must
+  // terminate quietly (exit 0, corpus unavailable) rather than crash setup.
+  test('a self-referential symlink does not crash the walk (non-strict)', () => {
+    const { status, stdout, stderr } = runChildJest({ strict: false, corpus: 'symlinkCycle' });
+    const output = `${stdout}${stderr}`;
+    if (status !== 0) {
+      throw new Error(`expected exit 0, got ${status}\n${output}`);
+    }
+    expect(output).not.toMatch(/Maximum call stack/);
   }, 120000);
 });

--- a/bindings/node/__test__/dataset-guard.test.js
+++ b/bindings/node/__test__/dataset-guard.test.js
@@ -38,20 +38,53 @@ function resolveJestBin() {
 }
 
 /**
- * Run a child jest process whose ONLY setup file is the real setup.js, against
- * a datasets root that exists but holds zero *-Data.db files.
+ * Corpus shapes a child jest run can be pointed at. Each shape owns both the
+ * on-disk layout AND the child test body, because the body decides what a
+ * non-zero exit is allowed to mean.
  *
- * @param {{strict: boolean}} opts
+ * @type {Record<string, {build: (sstables: string) => void, childTest: string}>}
+ */
+const CORPUS_SHAPES = {
+  // Present-but-empty: sstables/test_basic/ exists, no *-Data.db anywhere.
+  // The body asserts the guard's own verdict, so the non-strict control proves
+  // the run both survived AND saw an unavailable corpus.
+  empty: {
+    build: (sstables) => {
+      fs.mkdirSync(path.join(sstables, 'test_basic'), { recursive: true });
+    },
+    childTest: "test('noop', () => { expect(global.DATASETS_AVAILABLE).toBe(false); });\n",
+  },
+  // test_basic/ present but EMPTY, while a DIFFERENT keyspace holds a
+  // *-Data.db. A corpus-WIDE content check that dropped the test_basic
+  // requirement reports this as available and then enables the
+  // test_basic-dependent suites, which cannot possibly pass (issue #1458).
+  //
+  // The body here is deliberately assertion-FREE: the guard throwing must be
+  // the only possible source of a non-zero exit, otherwise a failing child
+  // assertion would green this test against the very bug it pins.
+  otherKeyspaceOnly: {
+    build: (sstables) => {
+      fs.mkdirSync(path.join(sstables, 'test_basic'), { recursive: true });
+      fs.mkdirSync(path.join(sstables, 'test_collections'), { recursive: true });
+      fs.writeFileSync(path.join(sstables, 'test_collections', 'nb-1-big-Data.db'), '');
+    },
+    childTest: "test('noop', () => {});\n",
+  },
+};
+
+/**
+ * Run a child jest process whose ONLY setup file is the real setup.js, against
+ * a synthesized datasets root of the requested shape.
+ *
+ * @param {{strict: boolean, corpus?: keyof typeof CORPUS_SHAPES}} opts
  * @returns {{status: number, stdout: string, stderr: string}}
  */
-function runChildJest({ strict }) {
+function runChildJest({ strict, corpus = 'empty' }) {
+  const shape = CORPUS_SHAPES[corpus];
+  if (!shape) throw new Error(`unknown corpus shape: ${corpus}`);
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-dataset-guard-'));
-  // Present-but-empty corpus: sstables/test_basic/ exists, no *-Data.db anywhere.
-  fs.mkdirSync(path.join(tmp, 'datasets', 'sstables', 'test_basic'), { recursive: true });
-  fs.writeFileSync(
-    path.join(tmp, 'noop.test.js'),
-    "test('noop', () => { expect(global.DATASETS_AVAILABLE).toBe(false); });\n"
-  );
+  shape.build(path.join(tmp, 'datasets', 'sstables'));
+  fs.writeFileSync(path.join(tmp, 'noop.test.js'), shape.childTest);
 
   const config = JSON.stringify({
     testEnvironment: 'node',
@@ -89,5 +122,21 @@ describe('dataset guard (issue #1458)', () => {
       throw new Error(`expected exit 0, got ${status}\n${stdout}${stderr}`);
     }
     expect(status).toBe(0);
+  }, 120000);
+
+  // Regression: content-awareness was ADDED to the test_basic requirement, not
+  // swapped for it. A *-Data.db under some OTHER keyspace does not make the
+  // test_basic-dependent suites runnable, so it must not report available.
+  test('strict mode fails when test_basic is empty but another keyspace has data', () => {
+    const { status, stdout, stderr } = runChildJest({
+      strict: true,
+      corpus: 'otherKeyspaceOnly',
+    });
+    const output = `${stdout}${stderr}`;
+    if (status === 0) {
+      throw new Error(`expected non-zero exit, got 0\n${output}`);
+    }
+    expect(output).toMatch(/test_basic/);
+    expect(output).toMatch(/-Data\.db/);
   }, 120000);
 });

--- a/bindings/node/__test__/dataset-guard.test.js
+++ b/bindings/node/__test__/dataset-guard.test.js
@@ -10,7 +10,7 @@
  * reimplement the directory walk — because a test that reimplements the logic
  * it asserts on is invariant to the bug (#3042).
  */
-const { spawnSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -70,18 +70,56 @@ const CORPUS_SHAPES = {
     },
     childTest: "test('noop', () => {});\n",
   },
-  // A self-referential symlink inside test_basic. Symlinked keyspace dirs are
-  // followed on purpose, so the walk must terminate on a link pointing at an
-  // ancestor and report an unavailable corpus rather than crashing setup --
-  // which it must never do in NON-strict mode (issue #1458).
+  // A NON-REGULAR entry named `*-Data.db` inside test_basic: a FIFO (falling
+  // back to a directory where mkfifo is unavailable). Name-only matching
+  // reports this as a corpus and enables every dataset-dependent suite, which
+  // then fails on the first read -- the guard must require a REGULAR FILE,
+  // exactly as Python's `Path.is_file()` filter does (issue #1458).
+  //
+  // Body is deliberately assertion-FREE (see otherKeyspaceOnly): the guard
+  // throwing must be the only possible source of a non-zero exit.
+  nonRegularDataDb: {
+    build: (sstables) => {
+      const testBasic = path.join(sstables, 'test_basic');
+      fs.mkdirSync(testBasic, { recursive: true });
+      const fifo = path.join(testBasic, 'nb-1-big-Data.db');
+      try {
+        execFileSync('mkfifo', [fifo]);
+      } catch (err) {
+        // No mkfifo (non-POSIX host): a DIRECTORY named *-Data.db is the other
+        // non-regular shape the is_file() filter must reject.
+        fs.mkdirSync(fifo, { recursive: true });
+      }
+    },
+    childTest: "test('noop', () => {});\n",
+  },
+  // POSITIVE control for the other half of the regular-file rule: a *-Data.db
+  // that is a SYMLINK to a real regular file still counts, because Python's
+  // `Path.is_file()` follows links. Pins rule 2 so a future tightening of the
+  // non-regular rejection above cannot silently drop symlinked fixtures.
+  symlinkedDataFile: {
+    build: (sstables) => {
+      const testBasic = path.join(sstables, 'test_basic');
+      fs.mkdirSync(testBasic, { recursive: true });
+      const payload = path.join(sstables, '..', 'payload.bin');
+      fs.writeFileSync(payload, 'sstable bytes');
+      fs.symlinkSync(payload, path.join(testBasic, 'nb-1-big-Data.db'), 'file');
+    },
+    childTest: "test('noop', () => { expect(global.DATASETS_AVAILABLE).toBe(true); });\n",
+  },
+  // A self-referential symlink inside test_basic. Symlinked DIRECTORIES are not
+  // traversed (matching Python's recursive glob), which is what makes a cycle
+  // structurally unreachable; this case pins that observable contract -- the
+  // link is skipped, the corpus reports unavailable, and setup never crashes in
+  // NON-strict mode (issue #1458).
   //
   // HONESTY NOTE: this case is a behavioral CONTROL, not a red-then-green
-  // regression pin. Measured on Linux, the pre-visited-set walk did not blow
-  // the stack: the kernel's 40-level symlink cap makes statSync() fail ELOOP at
-  // recursion depth ~81, which the broken-symlink `continue` swallows. The
-  // visited-set still earns its place (it drops those ~80 redundant
-  // readdir/stat rounds and re-walks of diamond-linked dirs), and this case
-  // pins the observable contract on every platform.
+  // regression pin -- no shipped version of this walk crashed here. Measured on
+  // Linux, the earlier symlink-following walk did not blow the stack either:
+  // the kernel's 40-level symlink cap makes statSync() fail ELOOP at recursion
+  // depth ~81, which its broken-symlink `continue` swallowed. Now that
+  // directory links are skipped outright there is no cycle machinery left to
+  // exercise, so what this case guards is the contract, on every platform.
   symlinkCycle: {
     build: (sstables) => {
       const testBasic = path.join(sstables, 'test_basic');
@@ -160,8 +198,9 @@ describe('dataset guard (issue #1458)', () => {
     expect(output).toMatch(/-Data\.db/);
   }, 120000);
 
-  // The walk follows symlinked dirs, so a link pointing at an ancestor must
-  // terminate quietly (exit 0, corpus unavailable) rather than crash setup.
+  // Symlinked directories are skipped, so a link pointing at an ancestor is
+  // never entered: the walk terminates quietly (exit 0, corpus unavailable)
+  // rather than crashing setup.
   test('a self-referential symlink does not crash the walk (non-strict)', () => {
     const { status, stdout, stderr } = runChildJest({ strict: false, corpus: 'symlinkCycle' });
     const output = `${stdout}${stderr}`;
@@ -169,5 +208,35 @@ describe('dataset guard (issue #1458)', () => {
       throw new Error(`expected exit 0, got ${status}\n${output}`);
     }
     expect(output).not.toMatch(/Maximum call stack/);
+  }, 120000);
+
+  // Regression (roborev round 3): name-only matching accepted a FIFO/directory
+  // named *-Data.db as a fixture. Only a REGULAR FILE is a corpus, matching
+  // Python's `Path.is_file()` filter.
+  test('strict mode fails when the only *-Data.db entry is not a regular file', () => {
+    const { status, stdout, stderr } = runChildJest({
+      strict: true,
+      corpus: 'nonRegularDataDb',
+    });
+    const output = `${stdout}${stderr}`;
+    if (status === 0) {
+      throw new Error(`expected non-zero exit, got 0\n${output}`);
+    }
+    expect(output).toMatch(/test_basic/);
+    expect(output).toMatch(/-Data\.db/);
+  }, 120000);
+
+  // Positive control for the other half of the same rule: `is_file()` follows
+  // symlinks, so a *-Data.db symlinked to a real regular file still counts.
+  test('a *-Data.db symlinked to a regular file still counts as available', () => {
+    const { status, stdout, stderr } = runChildJest({
+      strict: false,
+      corpus: 'symlinkedDataFile',
+    });
+    const output = `${stdout}${stderr}`;
+    if (status !== 0) {
+      throw new Error(`expected exit 0, got ${status}\n${output}`);
+    }
+    expect(status).toBe(0);
   }, 120000);
 });

--- a/bindings/node/__test__/setup.js
+++ b/bindings/node/__test__/setup.js
@@ -77,8 +77,18 @@ function hasDataDbFile(dir) {
   return false;
 }
 
-// Issue #1458: content-aware, not directory-only.
-const DATASETS_AVAILABLE = fs.existsSync(SSTABLES_DIR) && hasDataDbFile(SSTABLES_DIR);
+// Issue #1458: content-aware AND still test_basic-scoped.
+//
+// BOTH halves are load-bearing, and content-awareness was ADDED to the original
+// `existsSync(SSTABLES_DIR/test_basic)` requirement -- never swapped for it. A
+// corpus-WIDE `hasDataDbFile(SSTABLES_DIR)` accepts a root holding only, say,
+// test_collections/ and then enables EVERY dataset-dependent suite including the
+// test_basic ones that cannot possibly pass: a net WEAKENING of this guard.
+// Asking for content INSIDE test_basic implies the dir exists AND that the
+// corpus is non-empty, so this is strictly stronger than either half alone.
+// Do not "simplify" it back to a corpus-wide check.
+const TEST_BASIC_DIR = path.join(SSTABLES_DIR, 'test_basic');
+const DATASETS_AVAILABLE = fs.existsSync(SSTABLES_DIR) && hasDataDbFile(TEST_BASIC_DIR);
 
 // Strict fixture mode (issue #1230/#1458). Mirrors the Python
 // _require_fixtures_strict() helper: same two env var names, and the same
@@ -127,7 +137,7 @@ if (process.env.DEBUG_TESTS) {
 // describe.skip, which would report a green run over zero real assertions.
 if (REQUIRE_FIXTURES && !DATASETS_AVAILABLE) {
   throw new Error(
-    `No SSTable fixtures found: ${SSTABLES_DIR} is absent or contains 0 *-Data.db files ` +
+    `No SSTable fixtures found: ${TEST_BASIC_DIR} is absent or contains 0 *-Data.db files ` +
     '(CQLITE_REQUIRE_FIXTURES=1 — fetch with bash test-data/scripts/fetch-datasets.sh)'
   );
 }

--- a/bindings/node/__test__/setup.js
+++ b/bindings/node/__test__/setup.js
@@ -39,32 +39,39 @@ const SCHEMA_OA_TEST = path.join(SCHEMAS_DIR, 'oa-test.cql');
 
 /**
  * Recursively check whether `dir` contains at least one `*-Data.db` SSTable
- * binary (issue #1458).
+ * binary FILE (issue #1458).
  *
  * Directory existence alone is NOT evidence of a corpus: a present-but-EMPTY
  * sstables dir is the exact shape of the original #773 failure and used to
  * count as "available", false-greening a broken fixture setup.
  *
- * Symlinked directories ARE followed (a symlinked keyspace dir is a legitimate
- * corpus layout), so the walk must be cycle-safe: `visited` holds the resolved
- * real path of every directory already entered, and a link pointing at an
- * ancestor is skipped instead of recursing until the stack overflows.
+ * Three traversal rules, DELIBERATELY IDENTICAL to those of the Python guard's
+ * `_data_db_files()` in bindings/python/tests/conftest.py, which gets them for
+ * free from a recursive `Path.glob` of `*-Data.db` filtered by `Path.is_file()`:
+ *   1. a symlinked DIRECTORY is NOT traversed (recursion enters real dirs only);
+ *   2. a symlinked FILE whose target is a regular file IS counted (`is_file()`,
+ *      like `statSync`, follows the link);
+ *   3. a FIFO, socket, device node or directory named `*-Data.db` is NOT
+ *      counted -- only a regular file qualifies.
+ *
+ * The two implementations are ONE contract written twice: whoever changes the
+ * rules here must change `_data_db_files()` too, and vice versa.
+ *
+ * Consequence, recorded honestly: a symlinked KEYSPACE DIRECTORY is unsupported
+ * in BOTH languages. No corpus uses that layout (measured: zero symlinks under
+ * the fleet corpus and under the checkout's test-data/datasets), and rule 1
+ * fails in the SAFE direction -- such a root reports zero fixtures, so strict
+ * mode throws the existing loud "0 *-Data.db files" error rather than silently
+ * skipping.
+ *
+ * Rule 1 also makes symlink CYCLES structurally unreachable (only a followed
+ * directory link could close one), so this walk needs no realpath/visited-set
+ * cycle machinery.
  *
  * @param {string} dir
- * @param {Set<string>} [visited] resolved real paths already walked
  * @returns {boolean}
  */
-function hasDataDbFile(dir, visited = new Set()) {
-  let real;
-  try {
-    real = fs.realpathSync(dir);
-  } catch (err) {
-    // A path that cannot be resolved contributes no fixtures (fail closed).
-    return false;
-  }
-  if (visited.has(real)) return false; // cycle or diamond: already covered
-  visited.add(real);
-
+function hasDataDbFile(dir) {
   let entries;
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -74,20 +81,22 @@ function hasDataDbFile(dir, visited = new Set()) {
   }
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
-    let isDirectory = entry.isDirectory();
-    if (entry.isSymbolicLink()) {
-      // withFileTypes does not follow symlinks; a symlinked keyspace dir is
-      // still a legitimate corpus layout.
-      try {
-        isDirectory = fs.statSync(full).isDirectory();
-      } catch (err) {
-        continue; // broken symlink
-      }
-    }
-    if (isDirectory) {
-      if (hasDataDbFile(full, visited)) return true;
+    if (entry.isDirectory()) {
+      // Rule 1: withFileTypes never follows symlinks, so isDirectory() is true
+      // for REAL directories only and a symlinked dir is skipped here.
+      if (hasDataDbFile(full)) return true;
     } else if (entry.name.endsWith('-Data.db')) {
-      return true;
+      // Rule 3: a regular file qualifies immediately.
+      if (entry.isFile()) return true;
+      if (entry.isSymbolicLink()) {
+        // Rule 2: follow the link -- it counts iff the target is a regular
+        // file. A broken link (or one to a FIFO/socket/dir) contributes none.
+        try {
+          if (fs.statSync(full).isFile()) return true;
+        } catch (err) {
+          continue;
+        }
+      }
     }
   }
   return false;

--- a/bindings/node/__test__/setup.js
+++ b/bindings/node/__test__/setup.js
@@ -37,8 +37,54 @@ const SCHEMA_OA_TEST = path.join(SCHEMAS_DIR, 'oa-test.cql');
 // Dataset Availability Detection
 // =============================================================================
 
-const DATASETS_AVAILABLE = fs.existsSync(SSTABLES_DIR) &&
-  fs.existsSync(path.join(SSTABLES_DIR, 'test_basic'));
+/**
+ * Recursively check whether `dir` contains at least one `*-Data.db` SSTable
+ * binary (issue #1458).
+ *
+ * Directory existence alone is NOT evidence of a corpus: a present-but-EMPTY
+ * sstables dir is the exact shape of the original #773 failure and used to
+ * count as "available", false-greening a broken fixture setup.
+ *
+ * @param {string} dir
+ * @returns {boolean}
+ */
+function hasDataDbFile(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    // Unreadable/absent dir contributes no fixtures.
+    return false;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    let isDirectory = entry.isDirectory();
+    if (entry.isSymbolicLink()) {
+      // withFileTypes does not follow symlinks; a symlinked keyspace dir is
+      // still a legitimate corpus layout.
+      try {
+        isDirectory = fs.statSync(full).isDirectory();
+      } catch (err) {
+        continue; // broken symlink
+      }
+    }
+    if (isDirectory) {
+      if (hasDataDbFile(full)) return true;
+    } else if (entry.name.endsWith('-Data.db')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Issue #1458: content-aware, not directory-only.
+const DATASETS_AVAILABLE = fs.existsSync(SSTABLES_DIR) && hasDataDbFile(SSTABLES_DIR);
+
+// Strict fixture mode (issue #1230/#1458). Mirrors the Python
+// _require_fixtures_strict() helper: same two env var names, and the same
+// accepted truthy spellings ('1', 'true'). No other names are recognised.
+const REQUIRE_FIXTURES = ['1', 'true'].includes(process.env.CQLITE_REQUIRE_FIXTURES) ||
+  ['1', 'true'].includes(process.env.CQLITE_PARITY_REQUIRE_DATASETS);
 
 // =============================================================================
 // Slow Test Handling (matching Python conftest.py RUN_SLOW_TESTS pattern)
@@ -63,6 +109,7 @@ global.testPaths = {
 };
 
 global.DATASETS_AVAILABLE = DATASETS_AVAILABLE;
+global.REQUIRE_FIXTURES = REQUIRE_FIXTURES;
 global.SHOULD_RUN_SLOW_TESTS = SHOULD_RUN_SLOW_TESTS;
 
 // Log test configuration (only in verbose mode)
@@ -71,5 +118,16 @@ if (process.env.DEBUG_TESTS) {
   console.log(`  PROJECT_ROOT: ${PROJECT_ROOT}`);
   console.log(`  SSTABLES_DIR: ${SSTABLES_DIR}`);
   console.log(`  DATASETS_AVAILABLE: ${DATASETS_AVAILABLE}`);
+  console.log(`  REQUIRE_FIXTURES: ${REQUIRE_FIXTURES}`);
   console.log(`  SHOULD_RUN_SLOW_TESTS: ${SHOULD_RUN_SLOW_TESTS}`);
+}
+
+// Issue #1458: under strict mode a missing corpus is a hard failure of the
+// WHOLE suite -- throwing here beats leaving DATASETS_AVAILABLE=false for
+// describe.skip, which would report a green run over zero real assertions.
+if (REQUIRE_FIXTURES && !DATASETS_AVAILABLE) {
+  throw new Error(
+    `No SSTable fixtures found: ${SSTABLES_DIR} is absent or contains 0 *-Data.db files ` +
+    '(CQLITE_REQUIRE_FIXTURES=1 — fetch with bash test-data/scripts/fetch-datasets.sh)'
+  );
 }

--- a/bindings/node/__test__/setup.js
+++ b/bindings/node/__test__/setup.js
@@ -45,10 +45,26 @@ const SCHEMA_OA_TEST = path.join(SCHEMAS_DIR, 'oa-test.cql');
  * sstables dir is the exact shape of the original #773 failure and used to
  * count as "available", false-greening a broken fixture setup.
  *
+ * Symlinked directories ARE followed (a symlinked keyspace dir is a legitimate
+ * corpus layout), so the walk must be cycle-safe: `visited` holds the resolved
+ * real path of every directory already entered, and a link pointing at an
+ * ancestor is skipped instead of recursing until the stack overflows.
+ *
  * @param {string} dir
+ * @param {Set<string>} [visited] resolved real paths already walked
  * @returns {boolean}
  */
-function hasDataDbFile(dir) {
+function hasDataDbFile(dir, visited = new Set()) {
+  let real;
+  try {
+    real = fs.realpathSync(dir);
+  } catch (err) {
+    // A path that cannot be resolved contributes no fixtures (fail closed).
+    return false;
+  }
+  if (visited.has(real)) return false; // cycle or diamond: already covered
+  visited.add(real);
+
   let entries;
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -69,7 +85,7 @@ function hasDataDbFile(dir) {
       }
     }
     if (isDirectory) {
-      if (hasDataDbFile(full)) return true;
+      if (hasDataDbFile(full, visited)) return true;
     } else if (entry.name.endsWith('-Data.db')) {
       return true;
     }

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -76,20 +76,51 @@ def _require_fixtures_strict() -> bool:
     ) in ("1", "true")
 
 
-def _count_data_db() -> int:
-    """Number of ``*-Data.db`` SSTable binaries under ``DATASETS`` (issue #1458).
+# Two helpers, deliberately (issue #1458):
+#   _has_data_db()   -- the PREDICATE the guard asks on every dataset-dependent
+#                       test. Short-circuits at the first hit, so it never walks
+#                       the whole corpus (155 *-Data.db over 122 table dirs) to
+#                       answer "is there at least one?". Mirrors the Node
+#                       hasDataDbFile() walk, which short-circuits the same way.
+#   _count_data_db() -- the DIAGNOSTIC / acceptance-criteria counter. O(corpus)
+#                       and deliberately NOT on the hot path.
+# Both apply the same is_file() filter, so they can never disagree.
+
+
+def _data_db_files():
+    """Yield every ``*-Data.db`` FILE under ``DATASETS`` (issue #1458).
 
     A present-but-EMPTY datasets directory is the exact shape of the original
     #773 failure, so directory existence alone is not evidence of a corpus.
-    Returns 0 when ``DATASETS`` does not exist.
+    Yields nothing when ``DATASETS`` does not exist.
 
-    Only FILES count: ``Path.glob`` yields directories too, so an unfiltered
-    count lets a *directory* named e.g. ``placeholder-Data.db`` satisfy strict
+    Only FILES qualify: ``Path.glob`` yields directories too, so an unfiltered
+    match lets a *directory* named e.g. ``placeholder-Data.db`` satisfy strict
     mode with zero actual SSTable binaries.
     """
     if not DATASETS.exists():
-        return 0
-    return sum(1 for p in DATASETS.glob("**/*-Data.db") if p.is_file())
+        return
+    for path in DATASETS.glob("**/*-Data.db"):
+        if path.is_file():
+            yield path
+
+
+def _has_data_db() -> bool:
+    """True when at least one ``*-Data.db`` FILE exists under ``DATASETS``.
+
+    Short-circuits at the first hit — this is the hot-path check used by
+    ``skip_if_no_datasets()``.
+    """
+    return any(True for _ in _data_db_files())
+
+
+def _count_data_db() -> int:
+    """Number of ``*-Data.db`` SSTable binaries under ``DATASETS`` (issue #1458).
+
+    Diagnostic counter: walks the ENTIRE corpus, so it is not used by the guard.
+    Returns 0 when ``DATASETS`` does not exist.
+    """
+    return sum(1 for _ in _data_db_files())
 
 
 def skip_if_no_datasets():
@@ -114,7 +145,7 @@ def skip_if_no_datasets():
             )
         pytest.skip(msg)
 
-    if _count_data_db() == 0:
+    if not _has_data_db():
         msg = f"Datasets dir present but contains 0 *-Data.db files: {DATASETS}"
         if _require_fixtures_strict():
             pytest.fail(

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -82,10 +82,14 @@ def _count_data_db() -> int:
     A present-but-EMPTY datasets directory is the exact shape of the original
     #773 failure, so directory existence alone is not evidence of a corpus.
     Returns 0 when ``DATASETS`` does not exist.
+
+    Only FILES count: ``Path.glob`` yields directories too, so an unfiltered
+    count lets a *directory* named e.g. ``placeholder-Data.db`` satisfy strict
+    mode with zero actual SSTable binaries.
     """
     if not DATASETS.exists():
         return 0
-    return sum(1 for _ in DATASETS.glob("**/*-Data.db"))
+    return sum(1 for p in DATASETS.glob("**/*-Data.db") if p.is_file())
 
 
 def skip_if_no_datasets():

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -76,11 +76,29 @@ def _require_fixtures_strict() -> bool:
     ) in ("1", "true")
 
 
+def _count_data_db() -> int:
+    """Number of ``*-Data.db`` SSTable binaries under ``DATASETS`` (issue #1458).
+
+    A present-but-EMPTY datasets directory is the exact shape of the original
+    #773 failure, so directory existence alone is not evidence of a corpus.
+    Returns 0 when ``DATASETS`` does not exist.
+    """
+    if not DATASETS.exists():
+        return 0
+    return sum(1 for _ in DATASETS.glob("**/*-Data.db"))
+
+
 def skip_if_no_datasets():
-    """Skip (or, under strict mode, FAIL) when the datasets dir is absent.
+    """Skip (or, under strict mode, FAIL) when the dataset corpus is unusable.
 
     Issue #1230: under ``CQLITE_REQUIRE_FIXTURES=1`` (used by CI) a missing
     dataset is a hard failure, never a silent skip.
+
+    Issue #1458: the check is CONTENT-aware, not directory-only — a datasets
+    dir that exists but holds zero ``*-Data.db`` files fails closed under strict
+    mode too, since that false-greens a broken fixture setup exactly like an
+    absent directory does. Local dev without the binaries (neither strict flag
+    set) still skips in both cases.
     """
     if not DATASETS.exists():
         msg = f"Test data not found: {DATASETS}"
@@ -88,6 +106,17 @@ def skip_if_no_datasets():
             pytest.fail(
                 f"{msg} (CQLITE_REQUIRE_FIXTURES=1 — fetch with "
                 "bash test-data/scripts/fetch-datasets.sh)",
+                pytrace=False,
+            )
+        pytest.skip(msg)
+
+    if _count_data_db() == 0:
+        msg = f"Datasets dir present but contains 0 *-Data.db files: {DATASETS}"
+        if _require_fixtures_strict():
+            pytest.fail(
+                "Datasets dir present but contains 0 *-Data.db files "
+                "(CQLITE_REQUIRE_FIXTURES=1 — fetch with "
+                f"test-data/scripts/fetch-datasets.sh): {DATASETS}",
                 pytrace=False,
             )
         pytest.skip(msg)

--- a/bindings/python/tests/test_dataset_guard.py
+++ b/bindings/python/tests/test_dataset_guard.py
@@ -66,3 +66,23 @@ def test_strict_passes_when_data_db_present(tmp_path, monkeypatch):
     assert conftest._count_data_db() == 1
 
     conftest.skip_if_no_datasets()  # must not raise Failed or Skipped
+
+
+def test_strict_fails_when_data_db_is_a_directory(tmp_path, monkeypatch):
+    """A DIRECTORY named ``*-Data.db`` is not an SSTable binary.
+
+    ``Path.glob`` yields directories as well as files, so an unfiltered count
+    lets a placeholder dir satisfy strict mode with zero real fixtures -- the
+    same false-green class this guard exists to close.
+    """
+    datasets = _empty_datasets_dir(tmp_path)
+    (datasets / "test_basic" / "nb-1-big-Data.db").mkdir()
+    monkeypatch.setattr(conftest, "DATASETS", datasets)
+    _strict(monkeypatch)
+
+    assert conftest._count_data_db() == 0
+
+    with pytest.raises(Failed) as excinfo:
+        conftest.skip_if_no_datasets()
+
+    assert "0 *-Data.db" in str(excinfo.value)

--- a/bindings/python/tests/test_dataset_guard.py
+++ b/bindings/python/tests/test_dataset_guard.py
@@ -1,0 +1,68 @@
+"""Tests for the dataset-availability guard itself (issue #1458).
+
+The guard IS the fail-loudly mechanism for missing SSTable fixtures, so it needs
+its own coverage: a present-but-EMPTY datasets directory (the exact shape of the
+original #773 failure) must HARD-FAIL under strict mode, never skip.
+
+These tests drive the REAL ``conftest.skip_if_no_datasets()`` — they never
+reimplement the counting logic — because a test that reimplements the helper it
+asserts on is invariant to the bug (#3042).
+"""
+
+import pytest
+from _pytest.outcomes import Failed, Skipped
+
+import conftest
+
+STRICT_ENV_VARS = ("CQLITE_REQUIRE_FIXTURES", "CQLITE_PARITY_REQUIRE_DATASETS")
+
+
+def _empty_datasets_dir(tmp_path):
+    """A datasets root that exists and has a keyspace dir, but zero *-Data.db."""
+    datasets = tmp_path / "sstables"
+    (datasets / "test_basic").mkdir(parents=True)
+    return datasets
+
+
+def _non_strict(monkeypatch):
+    for var in STRICT_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _strict(monkeypatch):
+    monkeypatch.setenv("CQLITE_REQUIRE_FIXTURES", "1")
+    monkeypatch.delenv("CQLITE_PARITY_REQUIRE_DATASETS", raising=False)
+
+
+def test_strict_fails_on_empty_datasets_dir(tmp_path, monkeypatch):
+    """Strict mode + present-but-empty datasets dir => hard FAIL, not skip."""
+    monkeypatch.setattr(conftest, "DATASETS", _empty_datasets_dir(tmp_path))
+    _strict(monkeypatch)
+
+    assert conftest._count_data_db() == 0
+
+    with pytest.raises(Failed) as excinfo:
+        conftest.skip_if_no_datasets()
+
+    assert "0 *-Data.db" in str(excinfo.value)
+
+
+def test_non_strict_skips_on_empty_datasets_dir(tmp_path, monkeypatch):
+    """Negative control: without the strict flags local dev still SKIPS."""
+    monkeypatch.setattr(conftest, "DATASETS", _empty_datasets_dir(tmp_path))
+    _non_strict(monkeypatch)
+
+    with pytest.raises(Skipped):
+        conftest.skip_if_no_datasets()
+
+
+def test_strict_passes_when_data_db_present(tmp_path, monkeypatch):
+    """Negative control: strict mode + a *-Data.db present => no raise."""
+    datasets = _empty_datasets_dir(tmp_path)
+    (datasets / "test_basic" / "nb-1-big-Data.db").write_bytes(b"")
+    monkeypatch.setattr(conftest, "DATASETS", datasets)
+    _strict(monkeypatch)
+
+    assert conftest._count_data_db() == 1
+
+    conftest.skip_if_no_datasets()  # must not raise Failed or Skipped

--- a/bindings/python/tests/test_dataset_guard.py
+++ b/bindings/python/tests/test_dataset_guard.py
@@ -40,6 +40,7 @@ def test_strict_fails_on_empty_datasets_dir(tmp_path, monkeypatch):
     _strict(monkeypatch)
 
     assert conftest._count_data_db() == 0
+    assert conftest._has_data_db() is False
 
     with pytest.raises(Failed) as excinfo:
         conftest.skip_if_no_datasets()
@@ -64,6 +65,7 @@ def test_strict_passes_when_data_db_present(tmp_path, monkeypatch):
     _strict(monkeypatch)
 
     assert conftest._count_data_db() == 1
+    assert conftest._has_data_db() is True
 
     conftest.skip_if_no_datasets()  # must not raise Failed or Skipped
 
@@ -81,6 +83,7 @@ def test_strict_fails_when_data_db_is_a_directory(tmp_path, monkeypatch):
     _strict(monkeypatch)
 
     assert conftest._count_data_db() == 0
+    assert conftest._has_data_db() is False
 
     with pytest.raises(Failed) as excinfo:
         conftest.skip_if_no_datasets()


### PR DESCRIPTION
Closes #1458.

## What was wrong

Dataset-dependent tests are supposed to fail loudly under strict mode when the SSTable binaries are missing (#1230), so a dropped table or a path regression reds CI instead of passing by skipping. Both guards only checked that the datasets **directory** existed:

- **Python** (`conftest.py`): a `DATASETS` dir that exists but holds zero `*-Data.db` passed the strict guard.
- **Node** (`setup.js`): directory-only *and* no strict mode at all — it just `describe.skip`ped.

A present-but-empty corpus is the exact shape of the original #773 failure, so this false-greened a broken fixture setup.

## What changed (test harness only — no binding source touched)

- `bindings/python/tests/conftest.py` — the guard is content-aware: a present dir holding zero `*-Data.db` **files** now fails closed under strict mode, skips under non-strict.
- `bindings/node/__test__/setup.js` — content-aware **and** strict-capable: under `CQLITE_REQUIRE_FIXTURES` / `CQLITE_PARITY_REQUIRE_DATASETS` it **throws from setup**, failing the whole suite instead of leaving `DATASETS_AVAILABLE=false` for `describe.skip` to report a green run over zero real assertions.
- Two new test files pinning the guards themselves, in both directions.

Non-strict local dev is unchanged: with neither env var set, Python skips and Node skips. A developer without the ~GB of fixtures is never blocked.

### Traversal is ONE contract written twice

Both guards now implement identical rules, and both say so in comments naming the other:

1. a symlinked **directory** is NOT traversed;
2. a symlinked **file** whose target is a regular file IS counted;
3. a FIFO, socket, device node, or **directory** named `*-Data.db` is NOT counted — only a regular file qualifies.

Python gets these free from `Path.glob("**/*-Data.db") + is_file()`; Node's walk was aligned to match. I measured all three on this interpreter rather than trusting the docs. Consequence recorded honestly in both files: a symlinked *keyspace directory* is unsupported in both languages — no corpus uses that layout (zero symlinks measured under the fleet corpus and the checkout's `test-data/datasets`), and it fails in the safe direction (reports zero fixtures ⇒ strict mode throws the loud error).

## TDD evidence — measured, not asserted

Every case was observed RED against the unfixed parent commit and GREEN after, by reconstructing the new tests against a detached worktree of the pre-fix source:

| Case | RED at | GREEN |
|---|---|---|
| Python: strict + empty dir ⇒ `Failed` | `origin/main` (3 failed) | HEAD |
| Python: non-strict + empty dir ⇒ skips | `origin/main` | HEAD |
| Python: strict + `*-Data.db` present ⇒ no raise | `origin/main` | HEAD |
| Python: strict + `*-Data.db` is a **directory** ⇒ `Failed` | `92bb63ba6` — `_count_data_db()` returned **1** for a directory | HEAD |
| Node: strict + empty dir ⇒ non-zero exit | `origin/main` (2 failed) | HEAD |
| Node: non-strict + empty dir ⇒ exit 0 | `origin/main` — `DATASETS_AVAILABLE` was **true** for an empty `test_basic/` | HEAD |
| Node: strict + empty `test_basic` but data in another keyspace ⇒ non-zero | `a730ecca5` (only this case failed) | HEAD |
| Node: only `*-Data.db` entry is a **FIFO** ⇒ non-zero | `538ab236b` (only this case failed) | HEAD |

Final: Python **4 passed**, Node **6 passed**.

Neither test file is invariant to the bug (#3042): the Python tests drive the real `conftest.skip_if_no_datasets()` patching only `DATASETS`, and the Node tests drive the real `setup.js` in a child jest process — never a reimplementation of the walk. The Node harness explicitly `delete`s both strict env vars so a CI box running with `CQLITE_REQUIRE_FIXTURES=1` cannot bleed into the non-strict control case.

**One case is explicitly NOT a red-then-green pin**, and says so in an `HONESTY NOTE` in the code: the self-referential-symlink case. Measured on Linux the pre-fix walk did not blow the stack — the kernel's 40-level symlink cap makes `statSync` fail `ELOOP` at depth ~81, which the broken-symlink `continue` swallowed. So roborev's "unbounded recursion crashes setup" scenario does not reproduce as stated; the case is retained as a behavioral control (symlinked dir skipped, non-strict never crashes) and is labelled as such rather than presented as a regression pin.

## No regression against the real corpus

Tightening a guard is exactly where you break the working case, so this was verified directly rather than assumed. Against `CQLITE_DATASETS_ROOT=/data/datasets` (155 `*-Data.db`, `test_basic/` holding 8), `DATASETS_AVAILABLE` is **true** in both non-strict and `CQLITE_REQUIRE_FIXTURES=1` modes, and the Python suite runs (not skips) — `python-tier: PASS` in the lite summary runs `pytest bindings/python/tests -m 'not slow' -q`.

## Review record — stated precisely

- **roborev: CLEAN** at head `9db4948b7` — job 10, `RESULT: PASS`, `findings: NONE`, `reviewed-sha 2bde26a7c..9db4948b7`, `prompt-content: PASS (4/4)`, tokens 88.9k in / 74.8k cached (genuine range, vs the ~18.7k/0 vacuous baseline). Reached over **four** rounds: 3 findings → 2 → 2 → 0, every round via `scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol --repo <abs> --base origin/main`.
- **`rust-reviewer` produced no retrievable output** across three attempts (the subagent went idle without its report reaching the lead, as did two others this session). It contributed nothing to this review round and is **not** being recorded as a clean pass. The third read was done by the lead directly, line by line, which is what surfaced the efficiency defect below.

### Findings fixed in review rounds

| Round | Finding | Resolution |
|---|---|---|
| 1 | Node content check **replaced** the `test_basic` requirement instead of adding to it — one stray `*-Data.db` anywhere re-enabled every dataset test | Require content **inside** `test_basic`: strictly stronger than either half alone |
| 1 | `Path.glob` yields **directories**, so a dir named `placeholder-Data.db` satisfied strict mode | `is_file()` filter + regression test |
| 1 | Node walk followed directory symlinks with no visited set | Superseded in round 2 — rule 1 makes cycles structurally unreachable |
| 1 (lead) | `_count_data_db()` walked the **entire corpus on every guarded test** (155 files / 122 dirs, hundreds of times per session) to answer "is there ≥1?" | Short-circuiting `_has_data_db()` on the hot path; `_count_data_db()` retained as the diagnostic/AC counter. Both share one `_data_db_files()` generator so they cannot disagree |
| 2 | Python/Node traversal semantics disagreed (symlinks, non-regular files) | Aligned Node to Python's stdlib semantics — a net code **reduction**, deleting the realpath/visited-set machinery, rather than adding a custom cycle-safe walk to both languages for a layout no corpus uses |
| 3 | `spawnSync` had no timeout | See below |
| 3 | Python guard is corpus-wide while Node is `test_basic`-scoped | **Split to #3370** — out of scope, see below |

The `spawnSync` finding was rated Low but is worse than that: jest's per-test timeout cannot interrupt a synchronous spawn, and a timed-out child yields `status === null` while the strict cases assert `status !== 0` — so a hang would have **masqueraded as the strict-mode failure those cases exist to prove**. Now bounded at 90s with an explicit throw on `result.error` or a null status, so a harness failure can never be read as a guard verdict.

## Deliberate scope split

Round 3 correctly observed that Python's guard is corpus-wide: content in `test_collections/` satisfies it for a `test_basic` test. That is real, but it is a **different and larger property** than "an empty corpus must not pass", and fixing it properly means per-call-site fixture declarations across ~16 test files — the documented #3220 "resolve per TABLE, assert per CASE" shape, one language over. Filed as **#3370** rather than absorbed, per 1:1:1:1. Neither language regressed here: Python is strictly stronger than before this PR, just less precise than Node, as it always was.

## Deviations from the issue's prescribed steps

1. The issue had `skip_if_no_datasets()` call `_count_data_db() == 0`. The guard calls a short-circuiting `_has_data_db()` instead (identical observable behavior, O(1) instead of O(corpus) per test); `_count_data_db()` is retained exactly as specified for the acceptance criteria and diagnostics.
2. The issue specified `process.env.CQLITE_REQUIRE_FIXTURES === '1'` for Node. Both `'1'` and `'true'` are accepted, mirroring Python's `_require_fixtures_strict()`, so the same CI env cannot mean strict in one language and non-strict in the other. No other env var names added.

## Verification limits — read before trusting the green

The **Node native module is not built in these worktrees** (`@cqlite/node has no prebuilt binary for linux-x64`), so 22 of 26 node suites fail at `require` time. This is **pre-existing, not from this change** — measured on a clean `origin/main` worktree: main is **23 failed / 3 passed**, this branch **22 failed / 4 passed** (this branch is strictly better; it adds the passing guard suite). The full gate has **no node tier**, so the Node half of this change is evidenced by the guard suite (which does not need the native module) plus a direct `DATASETS_AVAILABLE` probe against the real corpus — *not* by a green full node suite. Stating this explicitly rather than implying broader coverage.

## Definition of done

- [x] Empty `test_basic/` + strict flag ⇒ Python FAILS and Node FAILS, both verified to have passed-by-skip before the change
- [x] Non-strict local dev still skips gracefully
- [x] File-size ratchet respected (`file-size: PASS`)
- [x] No `unwrap()`/`expect()` introduced in library code (no library code touched)
- [x] Full `scripts/agent-gate.sh` PASS — gate of record `RESULT: PASS`, run-id `/tmp/agent-gate.6J4mAv`, `tree-integrity: PASS`, commit `9db4948`; 30 components all PASS, zero SKIP. SUMMARY pasted in a comment below.
