### PR TITLE
fix(#1451): one authoritative FFI error table — Python and Node stop disagreeing on error identity

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -266,7 +266,7 @@ try {
   const result = await db.executeNative('SELECT * FROM keyspace.table');
 } catch (e) {
   // Error code for programmatic handling
-  console.log(`Code: ${e.code}`);        // 'IO', 'SCHEMA', 'QUERY', 'PARSE', etc.
+  console.log(`Code: ${e.code}`);        // 'IO', 'SCHEMA', 'QUERY', 'PARSE', 'TIMEOUT', etc.
 
   // Error category
   console.log(`Category: ${e.category}`); // 'System', 'Schema', 'Query', etc.
@@ -281,16 +281,31 @@ try {
 
 **Error Codes:**
 
+Codes come from the shared FFI error contract (`cqlite_core::ffi_error_contract`),
+keyed by the core error VARIANT — the same table the Python binding reads, so a
+given failure has the same identity in both bindings (issue #1451). A code is
+therefore finer-grained than the `category` it reports (a timeout is `TIMEOUT`
+with category `System`).
+
 | Code | Category | Description | Recoverable |
 |------|----------|-------------|-------------|
-| `IO` | System | File system errors | Yes |
-| `SCHEMA` | Schema | Schema parsing/validation | No |
-| `QUERY` | Query | Query execution failures | No |
-| `PARSE` | Data | CQL syntax errors | No |
-| `CONFIG` | Configuration | Invalid configuration | No |
-| `STORAGE` | Storage | Storage engine errors | No |
+| `IO` | System | File system errors, invalid path | Yes (`IO`) |
+| `SCHEMA` | Schema | Schema parsing/validation, table errors | No |
+| `QUERY` | Query | Query execution failures, result-set budget | No |
+| `PARSE` | Data / Query | CQL syntax errors; corrupt or undecodable data | No |
+| `CONFIG` | Configuration | Invalid configuration or read-path knob | No |
+| `STORAGE` | Storage | Storage engine, index, compaction errors | Yes |
 | `NOT_FOUND` | NotFound | Table/resource not found | No |
-| `INVALID_INPUT` | Logic | Invalid operation (e.g., closed db) | No |
+| `INVALID_INPUT` | Data / Logic | Invalid input, operation, or state (e.g. closed db) | No |
+| `CONCURRENCY` | Concurrency | Lock contention, `write_dir` already locked | Varies |
+| `CONFLICT` | Conflict | Resource already exists | No |
+| `CONSTRAINT` | Constraint | Constraint violation | No |
+| `TRANSACTION` | Transaction | Transaction errors | Yes |
+| `TIMEOUT` | System | Operation exceeded its deadline (never `IO`) | No |
+| `MEMORY` | System | Memory/allocation failure (never `IO`) | Yes |
+| `PLATFORM` | Platform | Platform-specific (WASM) errors | No |
+| `INTERNAL` | Internal | Internal errors | No |
+| `CANCELLED` | Cancelled | Cooperative scan cancellation (never `IO`) | No |
 
 ## Type Conversions
 

--- a/bindings/node/__test__/error.test.js
+++ b/bindings/node/__test__/error.test.js
@@ -51,17 +51,22 @@ describe('Error Mapping Tests (Issue #297)', () => {
     }
   });
 
-  test('Parse error maps to code "PARSE" or "QUERY"', async () => {
+  test('CQL parse error maps to the authoritative code "PARSE"', async () => {
+    // Issue #1451: this assertion used to hedge (`['PARSE','QUERY']`) because
+    // Node derived its code from `category()`, and `CqlParse` is Query-category
+    // — so it reported 'QUERY' while Python raised ParseError for the same core
+    // error. The shared contract table (cqlite_core::ffi_error_contract) now
+    // decides BY VARIANT, so exactly one code is correct here.
     skipIfNoDatasets();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
     });
     try {
-      expect.assertions(1);
+      expect.assertions(2);
       await db.execute('THIS IS NOT VALID SQL!!!');
     } catch (e) {
-      // Parse errors may come as PARSE or QUERY depending on where the error is caught
-      expect(['PARSE', 'QUERY']).toContain(e.code);
+      expect(e.code).toBe('PARSE');
+      expect(e.category).toBe('Query');
     } finally {
       await db.close();
     }

--- a/bindings/node/__test__/error.test.js
+++ b/bindings/node/__test__/error.test.js
@@ -57,6 +57,31 @@ describe('Error Mapping Tests (Issue #297)', () => {
     // — so it reported 'QUERY' while Python raised ParseError for the same core
     // error. The shared contract table (cqlite_core::ffi_error_contract) now
     // decides BY VARIANT, so exactly one code is correct here.
+    //
+    // The statement must actually REACH the CQL parser: a statement whose very
+    // first token is not a known verb is rejected earlier as
+    // `Error::QueryExecution` ("Unsupported query type"), which is genuinely
+    // `QUERY` — see the sibling case below.
+    skipIfNoDatasets();
+    const db = await Database.open(global.testPaths.SSTABLES_DIR, {
+      schema: global.testPaths.SCHEMA_BASIC_TYPES,
+    });
+    try {
+      expect.assertions(3);
+      await db.execute('SELECT * FROM');
+    } catch (e) {
+      expect(e.code).toBe('PARSE');
+      expect(e.category).toBe('Query');
+      expect(e.message).toContain('ParseError:');
+    } finally {
+      await db.close();
+    }
+  });
+
+  test('an unrecognized statement type stays "QUERY", not "PARSE"', async () => {
+    // The other side of the #1451 fix: `PARSE` now means a genuine CQL syntax
+    // failure, so an unsupported STATEMENT TYPE (an `Error::QueryExecution`)
+    // must NOT borrow it.
     skipIfNoDatasets();
     const db = await Database.open(global.testPaths.SSTABLES_DIR, {
       schema: global.testPaths.SCHEMA_BASIC_TYPES,
@@ -65,8 +90,8 @@ describe('Error Mapping Tests (Issue #297)', () => {
       expect.assertions(2);
       await db.execute('THIS IS NOT VALID SQL!!!');
     } catch (e) {
-      expect(e.code).toBe('PARSE');
-      expect(e.category).toBe('Query');
+      expect(e.code).toBe('QUERY');
+      expect(e.message).toContain('QueryError:');
     } finally {
       await db.close();
     }

--- a/bindings/node/__test__/error.test.js
+++ b/bindings/node/__test__/error.test.js
@@ -12,7 +12,7 @@
  * - [x] Test: Error message contains original error text
  */
 
-const { Database } = require('../lib/index.js');
+const { Database, _errorContractProbe } = require('../lib/index.js');
 const { skipIfNoDatasets, getNonexistentPath } = require('./helpers.js');
 
 describe('Error Mapping Tests (Issue #297)', () => {
@@ -148,5 +148,95 @@ describe('Error Mapping Tests (Issue #297)', () => {
       expect(typeof e.isRecoverable).toBe('boolean');
       expect(e.message).toContain('closed');
     }
+  });
+});
+
+/**
+ * The shared FFI error contract (issue #1451).
+ *
+ * `cqlite_core::ffi_error_contract` is the ONE authoritative
+ * variant -> (python class, node code, category, recoverable, prefix) table.
+ * Before it, this binding derived `code` from the core `category()` while the
+ * Python binding matched the `Error` VARIANT, so the same core error had a
+ * different identity in each: `CqlParse` reported 'QUERY' here while Python
+ * raised `ParseError`, and `Timeout`/`Memory` both reported 'IO' while Python
+ * raised `TimeoutError`/`MemoryError`.
+ *
+ * These cases drive the production mapping (`to_napi_error` -> the `\0`-encoded
+ * metadata -> `enhanceError`) for variants no query can provoke, via the
+ * `_errorContractProbe` test-support surface. The Python half lives in
+ * `bindings/python/tests/test_errors.py::TestSharedErrorContract`.
+ */
+describe('Shared FFI error contract (Issue #1451)', () => {
+  // [core Error variant, expected code, expected category, expected
+  //  isRecoverable, expected message prefix]
+  const PINNED_ROWS = [
+    ['CqlParse', 'PARSE', 'Query', false, 'ParseError:'],
+    ['InvalidInput', 'INVALID_INPUT', 'Data', false, 'ValueError:'],
+    ['Timeout', 'TIMEOUT', 'System', false, 'TimeoutError:'],
+    ['Memory', 'MEMORY', 'System', true, 'MemoryError:'],
+    ['Corruption', 'PARSE', 'Data', false, 'ParseError:'],
+    ['Io', 'IO', 'System', true, 'IoError:'],
+    ['Cancelled', 'CANCELLED', 'Cancelled', false, 'CancelledError:'],
+  ];
+
+  test.each(PINNED_ROWS)(
+    '%s maps to code "%s", category "%s"',
+    (variant, code, category, isRecoverable, prefix) => {
+      expect.assertions(5);
+      try {
+        _errorContractProbe(variant);
+      } catch (e) {
+        expect(e.code).toBe(code);
+        expect(e.category).toBe(category);
+        expect(e.isRecoverable).toBe(isRecoverable);
+        expect(e.message.startsWith(prefix)).toBe(true);
+        // The null-byte metadata block is stripped from the human message.
+        expect(e.message).not.toContain('\u0000');
+      }
+    }
+  );
+
+  test('Timeout and Memory no longer collapse into the IO identity', () => {
+    expect.assertions(4);
+    const codes = {};
+    for (const variant of ['Io', 'Timeout', 'Memory']) {
+      try {
+        _errorContractProbe(variant);
+      } catch (e) {
+        codes[variant] = e.code;
+      }
+    }
+    expect(codes.Io).toBe('IO');
+    expect(codes.Timeout).not.toBe(codes.Io);
+    expect(codes.Memory).not.toBe(codes.Io);
+    expect(codes.Timeout).not.toBe(codes.Memory);
+  });
+
+  test('CqlParse is PARSE and specifically not QUERY', () => {
+    expect.assertions(2);
+    try {
+      _errorContractProbe('CqlParse');
+    } catch (e) {
+      expect(e.code).toBe('PARSE');
+      expect(e.code).not.toBe('QUERY');
+    }
+  });
+
+  test('an unknown variant name is fail-closed, never a default row', () => {
+    expect.assertions(2);
+    try {
+      _errorContractProbe('NoSuchVariant');
+    } catch (e) {
+      expect(e.message).toContain('unknown core Error variant');
+      expect(e.code).toBe('INVALID_INPUT');
+    }
+  });
+
+  test('the probe always throws (a silent success would vacuously pass)', () => {
+    // Every case above asserts INSIDE a catch block, so a probe that returned
+    // normally would make them all pass having asserted nothing.
+    expect(() => _errorContractProbe('Timeout')).toThrow();
+    expect(() => _errorContractProbe('NoSuchVariant')).toThrow();
   });
 });

--- a/bindings/node/__test__/error.test.js
+++ b/bindings/node/__test__/error.test.js
@@ -149,7 +149,8 @@ describe('Error Mapping Tests (Issue #297)', () => {
       expect(typeof e.code).toBe('string');
       expect(typeof e.category).toBe('string');
       expect(typeof e.isRecoverable).toBe('boolean');
-      // Parse/Query errors are not recoverable
+      // An unknown statement type is a QueryExecution error (code 'QUERY', not
+      // 'PARSE' — see the dedicated cases above); neither is recoverable.
       expect(e.isRecoverable).toBe(false);
     } finally {
       await db.close();

--- a/bindings/node/__test__/typescript-definitions.test.js
+++ b/bindings/node/__test__/typescript-definitions.test.js
@@ -10,8 +10,47 @@
 
 const fs = require('fs');
 const path = require('path');
+const { _errorContractNodeCodes } = require('../lib/index.js');
 
 const LIB_DTS_PATH = path.join(__dirname, '..', 'lib', 'index.d.ts');
+
+/**
+ * Extract the members of a string-literal union type from `.d.ts` source.
+ *
+ * Deliberately NOT a "read to the first semicolon" parse: union members carry
+ * trailing `//` comments and at least one of those comments itself contains a
+ * `;` (the `TIMEOUT` member's "never 'IO';"). Slicing at the first raw `;`
+ * truncates the union and silently UNDER-reads it — which would make a
+ * containment assert pass vacuously in the dangerous direction. So comments are
+ * stripped line-by-line FIRST, and only then is the declaration sliced at its
+ * terminating semicolon.
+ *
+ * @param {string} dts - Full `.d.ts` source text
+ * @param {string} typeName - e.g. 'ErrorCode'
+ * @returns {string[]} Sorted, deduplicated union members
+ */
+function parseStringUnion(dts, typeName) {
+  const codeOnly = dts
+    .split('\n')
+    .map((line) => {
+      const commentAt = line.indexOf('//');
+      return commentAt === -1 ? line : line.slice(0, commentAt);
+    })
+    .join('\n');
+
+  const declaration = new RegExp(`export\\s+type\\s+${typeName}\\s*=`);
+  const start = codeOnly.search(declaration);
+  if (start === -1) {
+    throw new Error(`type ${typeName} not found in index.d.ts`);
+  }
+  const end = codeOnly.indexOf(';', start);
+  if (end === -1) {
+    throw new Error(`type ${typeName} has no terminating ';' in index.d.ts`);
+  }
+  const body = codeOnly.slice(start, end);
+  const members = (body.match(/'[^']+'/g) || []).map((m) => m.slice(1, -1));
+  return [...new Set(members)].sort();
+}
 
 describe('TypeScript Definitions (Issue #312)', () => {
   let dtsContent;
@@ -243,6 +282,53 @@ describe('TypeScript Definitions (Issue #312)', () => {
 
     test('should include Cancelled error category (issue #2264)', () => {
       expect(dtsContent).toMatch(/type\s+ErrorCategory[\s\S]*?\|\s*['"]Cancelled['"]/);
+    });
+
+    /**
+     * Issue #1451: the `ErrorCode` union and the shared FFI error contract's
+     * `node_code` column are the SAME FACT WRITTEN TWICE, in two languages,
+     * maintained by hand. A new core `Error` variant is forced to get a contract
+     * row (`variant_of` is exhaustive, so it fails to compile) — but nothing
+     * forces this union to gain the row's code, so a new code could ship while
+     * TypeScript consumers are told it cannot occur. These two cases close that
+     * in BOTH directions, taking the authoritative set from the TABLE (via the
+     * `_errorContractNodeCodes` seam) rather than from a hand-written list here,
+     * which would merely be a third copy of the same fact.
+     */
+    describe('ErrorCode union is pinned to the shared contract table (issue #1451)', () => {
+      let tableCodes;
+      let unionCodes;
+
+      beforeAll(() => {
+        tableCodes = [...new Set(_errorContractNodeCodes())].sort();
+        unionCodes = parseStringUnion(dtsContent, 'ErrorCode');
+      });
+
+      test('the parse actually read the union (never a vacuous pass)', () => {
+        // A truncated/empty parse would make the containment assertions below
+        // pass while checking nothing, so the parse is asserted first.
+        expect(Array.isArray(tableCodes)).toBe(true);
+        expect(tableCodes.length).toBeGreaterThan(10);
+        expect(unionCodes.length).toBeGreaterThanOrEqual(tableCodes.length);
+        // Members declared AFTER the `;`-bearing TIMEOUT comment: their presence
+        // proves the parse did not truncate there.
+        expect(unionCodes).toContain('IO');
+        expect(unionCodes).toContain('MEMORY');
+        expect(unionCodes).toContain('CANCELLED');
+      });
+
+      test('every code the contract can emit is declared in the union', () => {
+        const missing = tableCodes.filter((code) => !unionCodes.includes(code));
+        expect(missing).toEqual([]);
+      });
+
+      test('the union declares no code the contract never emits', () => {
+        // `simple_error()` reuses INVALID_INPUT for non-core failures (e.g.
+        // "Database is closed"), which the table also emits, so the two sets are
+        // exactly equal today.
+        const extra = unionCodes.filter((code) => !tableCodes.includes(code));
+        expect(extra).toEqual([]);
+      });
     });
 
     test('CqliteError should extend Error', () => {

--- a/bindings/node/__test__/typescript-definitions.test.js
+++ b/bindings/node/__test__/typescript-definitions.test.js
@@ -10,7 +10,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const { _errorContractNodeCodes } = require('../lib/index.js');
 
 const LIB_DTS_PATH = path.join(__dirname, '..', 'lib', 'index.d.ts');
 
@@ -300,6 +299,12 @@ describe('TypeScript Definitions (Issue #312)', () => {
       let unionCodes;
 
       beforeAll(() => {
+        // Required HERE, not at module scope: only these three cases need the
+        // native addon, and a module-scope require would take the file's ~80
+        // pure-text assertions down with it when the addon is not built. If it
+        // IS missing these cases fail loudly (never skip) — the assert cannot be
+        // performed without the authoritative table.
+        const { _errorContractNodeCodes } = require('../lib/index.js');
         tableCodes = [...new Set(_errorContractNodeCodes())].sort();
         unionCodes = parseStringUnion(dtsContent, 'ErrorCode');
       });

--- a/bindings/node/examples/error-handling.ts
+++ b/bindings/node/examples/error-handling.ts
@@ -63,7 +63,7 @@ async function demonstrateErrorHandling() {
     await db.execute('SELEC * FORM table');
   } catch (e) {
     if (isCqliteError(e)) {
-      console.log(`Error Code: ${e.code}`);           // 'PARSE' or 'QUERY'
+      console.log(`Error Code: ${e.code}`);           // 'PARSE' for a CQL syntax error
       console.log(`Category: ${e.category}`);          // 'Query'
       console.log(`Recoverable: ${e.isRecoverable}`);  // false
       console.log(`Message: ${e.message}`);
@@ -149,7 +149,15 @@ async function demonstrateErrorHandling() {
           break;
 
         case 'PARSE':
-          console.log('Query syntax error - check CQL syntax');
+          console.log('CQL syntax error, or corrupt on-disk data');
+          break;
+
+        case 'TIMEOUT':
+          console.log('Operation exceeded its deadline (issue #1451 - never IO)');
+          break;
+
+        case 'MEMORY':
+          console.log('Memory/allocation failure (issue #1451 - never IO)');
           break;
 
         case 'NOT_FOUND':

--- a/bindings/node/examples/error-handling.ts
+++ b/bindings/node/examples/error-handling.ts
@@ -47,9 +47,9 @@ async function demonstrateErrorHandling() {
   }
 
   // =============================================
-  // Example 2: Invalid SQL syntax
+  // Example 2: Invalid CQL syntax (code 'PARSE')
   // =============================================
-  console.log('\n--- Example 2: Invalid SQL Syntax ---');
+  console.log('\n--- Example 2: Invalid CQL Syntax ---');
 
   const dataDir = process.env.CQLITE_DATA_DIR || 'path/to/sstables';
   const schemaPath = process.env.CQLITE_SCHEMA || 'path/to/schema.cql';
@@ -59,8 +59,11 @@ async function demonstrateErrorHandling() {
   try {
     db = await Database.open(dataDir, { schema: schemaPath });
 
-    // Intentionally malformed SQL
-    await db.execute('SELEC * FORM table');
+    // Intentionally malformed CQL. It must be malformed IN THE GRAMMAR (a
+    // SELECT with no table) so it reaches the parser: a statement whose leading
+    // token is not a known verb (e.g. 'SELEC * FORM table') never reaches the
+    // parser and reports 'QUERY', not 'PARSE' (issue #1451).
+    await db.execute('SELECT * FROM');
   } catch (e) {
     if (isCqliteError(e)) {
       console.log(`Error Code: ${e.code}`);           // 'PARSE' for a CQL syntax error
@@ -195,7 +198,10 @@ async function demonstrateErrorHandling() {
   const testDb = await Database.open(dataDir, { schema: schemaPath });
   try {
     await executeWithErrorHandling(testDb, 'SELECT * FROM test_basic.simple_table LIMIT 1');
+    // 'INVALID QUERY' is an unknown statement TYPE -> code 'QUERY'; only a
+    // statement that reaches the CQL parser yields 'PARSE' (issue #1451).
     await executeWithErrorHandling(testDb, 'INVALID QUERY');
+    await executeWithErrorHandling(testDb, 'SELECT * FROM');
     await executeWithErrorHandling(testDb, 'SELECT * FROM no.such_table');
   } finally {
     await testDb.close();

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -757,8 +757,12 @@ export interface StreamingResult extends AsyncIterable<Row> {
 /**
  * Error codes for CQLite errors.
  *
- * These codes map to the ErrorCategory enum in cqlite-core and can be used
- * for programmatic error handling.
+ * Each code is decided **by core `Error` variant** from the shared FFI error
+ * contract (`cqlite_core::ffi_error_contract`) — the one authoritative table the
+ * Python binding reads too, so the same underlying error has the same identity
+ * in both (issue #1451). Codes are therefore FINER-GRAINED than the
+ * `ErrorCategory` they report: a timeout is `TIMEOUT` with category `'System'`,
+ * and a CQL syntax failure is `PARSE` with category `'Query'`.
  *
  * @example
  * ```typescript
@@ -768,7 +772,10 @@ export interface StreamingResult extends AsyncIterable<Row> {
  *   const err = e as CqliteError;
  *   switch (err.code) {
  *     case 'PARSE':
- *       console.log('SQL syntax error');
+ *       console.log('CQL syntax error');
+ *       break;
+ *     case 'TIMEOUT':
+ *       console.log('the operation exceeded its deadline');
  *       break;
  *     case 'IO':
  *       console.log('I/O error, may be retryable');
@@ -778,18 +785,22 @@ export interface StreamingResult extends AsyncIterable<Row> {
  * ```
  */
 export type ErrorCode =
-  | 'IO'           // System-level I/O errors (file access, memory, timeout)
+  | 'IO'           // I/O errors: file access, invalid path (NOT timeouts or memory)
   | 'SCHEMA'       // Schema-related errors (table not found, invalid schema)
-  | 'QUERY'        // Query execution errors (unsupported queries)
-  | 'PARSE'        // Data/parsing errors (CQL syntax, type conversion)
-  | 'CONFIG'       // Configuration errors
-  | 'STORAGE'      // Storage engine errors
-  | 'CONCURRENCY'  // Concurrency/lock errors
+  | 'QUERY'        // Query execution errors (unsupported query, result-set budget)
+  | 'PARSE'        // A CQL syntax failure, or corrupt/undecodable on-disk data
+  | 'CONFIG'       // Configuration errors (including an invalid read-path knob)
+  | 'STORAGE'      // Storage engine errors (storage, index, compaction)
+  | 'CONCURRENCY'  // Concurrency/lock errors (including a locked write_dir)
   | 'NOT_FOUND'    // Resource not found
   | 'CONFLICT'     // Resource conflicts (already exists)
-  | 'INVALID_INPUT' // Logic errors (invalid operation, invalid state)
+  | 'INVALID_INPUT' // Invalid caller input, invalid operation, or invalid state
   | 'CONSTRAINT'   // Constraint violations
   | 'TRANSACTION'  // Transaction errors
+  | 'TIMEOUT'      // The operation exceeded its deadline (issue #1451 — never 'IO';
+                   // Python raises the builtin TimeoutError for the same error)
+  | 'MEMORY'       // A memory/allocation failure (issue #1451 — never 'IO';
+                   // Python raises the builtin MemoryError for the same error)
   | 'PLATFORM'     // Platform-specific errors (WASM)
   | 'INTERNAL'     // Internal errors
   | 'CANCELLED';   // Cooperative scan cancellation (issue #2264 — never 'IO')

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -764,15 +764,22 @@ export interface StreamingResult extends AsyncIterable<Row> {
  * `ErrorCategory` they report: a timeout is `TIMEOUT` with category `'System'`,
  * and a CQL syntax failure is `PARSE` with category `'Query'`.
  *
+ * Note `PARSE` means the statement REACHED the CQL parser and failed there. A
+ * statement whose leading token is not a known verb (e.g. `'INVALID SQL'`) is
+ * rejected before parsing and reports `QUERY`, not `PARSE`.
+ *
  * @example
  * ```typescript
  * try {
- *   await db.execute('INVALID SQL');
+ *   await db.execute('SELECT * FROM');   // malformed CQL: reaches the parser
  * } catch (e) {
  *   const err = e as CqliteError;
  *   switch (err.code) {
  *     case 'PARSE':
  *       console.log('CQL syntax error');
+ *       break;
+ *     case 'QUERY':
+ *       console.log('unsupported or failed query (e.g. an unknown statement type)');
  *       break;
  *     case 'TIMEOUT':
  *       console.log('the operation exceeded its deadline');

--- a/bindings/node/lib/index.js
+++ b/bindings/node/lib/index.js
@@ -24,7 +24,7 @@
  */
 
 const nativeBinding = require('../index.js');
-const { createWrappedDatabase } = require('./error-wrapper.js');
+const { createWrappedDatabase, enhanceError } = require('./error-wrapper.js');
 
 /**
  * PreparedStatement wraps a native PreparedStatement with type consistency.
@@ -95,8 +95,34 @@ const Database = createWrappedDatabase(nativeBinding.Database, wrapPreparedState
 // Re-export version function
 const { version } = nativeBinding;
 
+/**
+ * Test-support: throw the JS error the shared FFI error contract maps a named
+ * core Rust `Error` variant to (issue #1451).
+ *
+ * Goes through the production native mapping and the same `enhanceError`
+ * wrapper every `Database` method uses, so the thrown error carries the real
+ * `code`/`category`/`isRecoverable`. This is how the test suite reaches variants
+ * no query can provoke (`Timeout`, `Memory`). The Python binding's twin is
+ * `cqlite._raise_mapped_core_error`.
+ *
+ * Not part of the stable public API — the leading underscore marks it internal
+ * test support.
+ *
+ * @private
+ * @param {string} variant - Core `Error` variant identifier, e.g. 'Timeout'
+ * @throws {Error} Always; the mapped error for `variant`.
+ */
+function _errorContractProbe(variant) {
+  try {
+    return nativeBinding.errorContractProbe(variant);
+  } catch (error) {
+    throw enhanceError(error);
+  }
+}
+
 module.exports = {
   Database,
   PreparedStatement,
   version,
+  _errorContractProbe,
 };

--- a/bindings/node/lib/index.js
+++ b/bindings/node/lib/index.js
@@ -120,9 +120,28 @@ function _errorContractProbe(variant) {
   }
 }
 
+/**
+ * Test-support: the distinct `code` values the shared FFI error contract can
+ * emit (issue #1451), sorted and deduplicated.
+ *
+ * The authoritative set comes from the Rust contract table, so the `ErrorCode`
+ * union in `index.d.ts` can be asserted against it instead of against a
+ * hand-written copy (see `__test__/typescript-definitions.test.js`).
+ *
+ * Not part of the stable public API — the leading underscore marks it internal
+ * test support.
+ *
+ * @private
+ * @returns {string[]} Sorted, deduplicated error codes.
+ */
+function _errorContractNodeCodes() {
+  return nativeBinding.errorContractNodeCodes();
+}
+
 module.exports = {
   Database,
   PreparedStatement,
   version,
   _errorContractProbe,
+  _errorContractNodeCodes,
 };

--- a/bindings/node/scripts/generate-loader.mjs
+++ b/bindings/node/scripts/generate-loader.mjs
@@ -34,9 +34,11 @@ const IDENTS = [
   'StreamingResult',
   'WriteStats',
   'version',
-  // Test-support: shared FFI error-contract conformance probe (issue #1451).
-  // `lib/index.js` re-exports it as `_errorContractProbe`.
+  // Test-support: shared FFI error-contract conformance probe + the table's
+  // authoritative code set (issue #1451). `lib/index.js` re-exports them as
+  // `_errorContractProbe` / `_errorContractNodeCodes`.
   'errorContractProbe',
+  'errorContractNodeCodes',
 ]
 
 // Native binary loader template.

--- a/bindings/node/scripts/generate-loader.mjs
+++ b/bindings/node/scripts/generate-loader.mjs
@@ -34,6 +34,9 @@ const IDENTS = [
   'StreamingResult',
   'WriteStats',
   'version',
+  // Test-support: shared FFI error-contract conformance probe (issue #1451).
+  // `lib/index.js` re-exports it as `_errorContractProbe`.
+  'errorContractProbe',
 ]
 
 // Native binary loader template.

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -572,7 +572,9 @@ mod tests {
             assert!(!row.node_code.is_empty());
             let napi_err = to_napi_error(err);
             assert!(
-                napi_err.reason.contains(&format!("\0code={}", row.node_code)),
+                napi_err
+                    .reason
+                    .contains(&format!("\0code={}", row.node_code)),
                 "row {} must encode its code for the JS wrapper",
                 row.variant
             );
@@ -601,11 +603,7 @@ mod tests {
                 "MEMORY",
                 Some("MemoryError"),
             ),
-            (
-                Error::corruption("torn page"),
-                "PARSE",
-                Some("ParseError"),
-            ),
+            (Error::corruption("torn page"), "PARSE", Some("ParseError")),
         ];
 
         for (err, code, prefix) in cases {

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -10,25 +10,36 @@
 //! - `category`: Category name from ErrorCategory (e.g., "System", "Schema")
 //! - `isRecoverable`: Boolean indicating if the error is recoverable
 //!
-//! # Error Code Mapping
+//! # Error Code Mapping — the shared FFI error contract (issue #1451)
 //!
-//! | Rust Category | JS Code | JS Message Prefix |
-//! |---------------|---------|-------------------|
-//! | System | `IO` | `IoError:` |
-//! | Schema | `SCHEMA` | `SchemaError:` |
-//! | Query | `QUERY` | `QueryError:` |
-//! | Data | `PARSE` | `ParseError:` |
-//! | Configuration | `CONFIG` | `ValueError:` |
-//! | Storage | `STORAGE` | (original) |
-//! | NotFound | `NOT_FOUND` | (original) |
-//! | Logic | `INVALID_INPUT` | `RuntimeError:` |
-//! | Concurrency | `CONCURRENCY` | (original) |
-//! | Conflict | `CONFLICT` | (original) |
-//! | Constraint | `CONSTRAINT` | (original) |
-//! | Transaction | `TRANSACTION` | (original) |
-//! | Platform | `PLATFORM` | (original) |
-//! | Internal | `INTERNAL` | (original) |
-//! | Cancelled | `CANCELLED` | `CancelledError:` (issue #2264 — never `IO`) |
+//! `code`/`category`/`isRecoverable`/prefix all come from
+//! `cqlite_core::ffi_error_contract`, the ONE authoritative table that
+//! `bindings/python` reads too, keyed **by `Error` variant**. This binding used
+//! to derive its code from `Error::category()`, which made the same core error
+//! a different thing in each binding: `CqlParse` reported `QUERY` here while
+//! Python raised `ParseError`, and `Timeout`/`Memory` both collapsed into `IO`
+//! while Python raised `TimeoutError`/`MemoryError`.
+//!
+//! | Rust variant | JS code | JS message prefix |
+//! |--------------|---------|-------------------|
+//! | `Io`, `InvalidPath` | `IO` | `IoError:` |
+//! | `Schema`, `Table` | `SCHEMA` | `SchemaError:` |
+//! | `QueryExecution`, `UnsupportedQuery`, `ResultTooLarge`, `ForcedReadPathUnavailable` | `QUERY` | `QueryError:` |
+//! | `CqlParse`, `Corruption`, `Serialization`, `Parse`, `TypeConversion`, `InvalidFormat`, `UnsupportedFormat`, `UnsupportedVersion`, `UnsupportedCommitLogVersion`, `CorruptCommitLogFrame` | `PARSE` | `ParseError:` |
+//! | `Configuration`, `InvalidReadPath` | `CONFIG` | `ValueError:` |
+//! | `InvalidInput` | `INVALID_INPUT` | `ValueError:` |
+//! | `InvalidState`, `InvalidOperation` | `INVALID_INPUT` | `RuntimeError:` |
+//! | `Timeout` | `TIMEOUT` | `TimeoutError:` |
+//! | `Memory` | `MEMORY` | `MemoryError:` |
+//! | `Storage`, `Index`, `Compaction` | `STORAGE` | (original) |
+//! | `NotFound` | `NOT_FOUND` | (original) |
+//! | `Concurrency`, `WriteDirLocked` | `CONCURRENCY` | (original) |
+//! | `AlreadyExists` | `CONFLICT` | (original) |
+//! | `ConstraintViolation` | `CONSTRAINT` | (original) |
+//! | `Transaction` | `TRANSACTION` | (original) |
+//! | `Wasm` | `PLATFORM` | (original) |
+//! | `Internal` | `INTERNAL` | (original) |
+//! | `Cancelled` | `CANCELLED` | `CancelledError:` (issue #2264 — never `IO`) |
 //!
 //! # Example
 //!
@@ -36,8 +47,8 @@
 //! try {
 //!   await db.execute("INVALID SQL");
 //! } catch (e) {
-//!   console.log(e.code);          // "PARSE" or "QUERY"
-//!   console.log(e.category);      // "Query" or "Data"
+//!   console.log(e.code);          // "PARSE" (a CQL syntax failure)
+//!   console.log(e.category);      // "Query"
 //!   console.log(e.isRecoverable); // false
 //!   if (e.code === "PARSE") {
 //!     console.log("SQL syntax error");
@@ -45,7 +56,7 @@
 //! }
 //! ```
 
-use cqlite_core::error::ErrorCategory;
+use cqlite_core::ffi_error_contract::contract_for;
 use cqlite_core::Error;
 
 /// Error metadata extracted from a cqlite_core::Error.
@@ -64,68 +75,28 @@ pub struct ErrorMetadata {
     pub message: String,
 }
 
-/// Convert ErrorCategory to a string code for JavaScript.
+/// Extract error metadata from a `cqlite_core::Error`.
 ///
-/// Maps the 14 ErrorCategory variants to simplified string codes
-/// matching the M4 spec requirements.
-pub fn category_to_code(category: ErrorCategory) -> &'static str {
-    match category {
-        ErrorCategory::System => "IO",
-        ErrorCategory::Data => "PARSE",
-        ErrorCategory::Schema => "SCHEMA",
-        ErrorCategory::Query => "QUERY",
-        ErrorCategory::Configuration => "CONFIG",
-        ErrorCategory::Storage => "STORAGE",
-        ErrorCategory::Concurrency => "CONCURRENCY",
-        ErrorCategory::NotFound => "NOT_FOUND",
-        ErrorCategory::Conflict => "CONFLICT",
-        ErrorCategory::Logic => "INVALID_INPUT",
-        ErrorCategory::Constraint => "CONSTRAINT",
-        ErrorCategory::Transaction => "TRANSACTION",
-        ErrorCategory::Platform => "PLATFORM",
-        ErrorCategory::Internal => "INTERNAL",
-        // Issue #2264: a cooperative cancellation gets its OWN code — it must
-        // never fall through to (or be confused with) `IO`, a genuine
-        // transport/filesystem failure.
-        ErrorCategory::Cancelled => "CANCELLED",
-    }
-}
-
-/// Get the message prefix for an error category.
-fn category_to_prefix(category: ErrorCategory) -> Option<&'static str> {
-    match category {
-        ErrorCategory::System => Some("IoError"),
-        ErrorCategory::Schema => Some("SchemaError"),
-        ErrorCategory::Query => Some("QueryError"),
-        ErrorCategory::Data => Some("ParseError"),
-        ErrorCategory::Configuration => Some("ValueError"),
-        ErrorCategory::Logic => Some("RuntimeError"),
-        ErrorCategory::Cancelled => Some("CancelledError"),
-        // Other categories don't have special prefixes
-        _ => None,
-    }
-}
-
-/// Extract error metadata from a cqlite_core::Error.
-///
-/// This provides all the structured information needed for the JavaScript error.
+/// Every field comes from the error's row in the shared FFI error contract
+/// (`cqlite_core::ffi_error_contract`), looked up **by variant** — never
+/// re-derived from `Error::category()`, which cannot distinguish `CqlParse`
+/// from a generic query failure or a `Timeout` from an I/O failure (issue
+/// #1451). `bindings/python` reads the same row, so the two bindings cannot
+/// drift apart; to change how a variant surfaces, edit the table.
 pub fn extract_metadata(err: &Error) -> ErrorMetadata {
-    let category = err.category();
-    let code = category_to_code(category);
-    let category_name = category.to_string();
-    let is_recoverable = err.is_recoverable();
+    let row = contract_for(err);
     let original_message = err.to_string();
 
-    // Format message with prefix if applicable
-    let message = match category_to_prefix(category) {
+    // Format message with the row's prefix if it has one.
+    let message = match row.message_prefix {
         Some(prefix) => format!("{prefix}: {original_message}"),
         None => original_message,
     };
 
     ErrorMetadata {
-        code,
-        category: category_name,
-        is_recoverable,
+        code: row.node_code,
+        category: row.category.to_string(),
+        is_recoverable: row.recoverable,
         message,
     }
 }
@@ -270,18 +241,7 @@ fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_category_to_code() {
-        assert_eq!(category_to_code(ErrorCategory::System), "IO");
-        assert_eq!(category_to_code(ErrorCategory::Schema), "SCHEMA");
-        assert_eq!(category_to_code(ErrorCategory::Query), "QUERY");
-        assert_eq!(category_to_code(ErrorCategory::Data), "PARSE");
-        assert_eq!(category_to_code(ErrorCategory::Configuration), "CONFIG");
-        assert_eq!(category_to_code(ErrorCategory::Storage), "STORAGE");
-        assert_eq!(category_to_code(ErrorCategory::NotFound), "NOT_FOUND");
-        assert_eq!(category_to_code(ErrorCategory::Logic), "INVALID_INPUT");
-    }
+    use cqlite_core::ffi_error_contract::FfiErrorVariant;
 
     #[test]
     fn test_io_error_metadata() {
@@ -359,16 +319,19 @@ mod tests {
         assert!(napi_err.reason.contains("code=QUERY"));
     }
 
+    /// Issue #1451: a CQL syntax failure is `PARSE`, not the generic `QUERY`
+    /// bucket its Query category used to put it in — matching the Python
+    /// binding, which has always raised `ParseError` for this variant.
     #[test]
     fn test_cql_parse_error_mapping() {
         let rust_err = Error::CqlParse("syntax error at position 42".to_string());
         let napi_err = to_napi_error(rust_err);
 
-        // CqlParse has Query category (not Data), so it gets QueryError prefix
-        assert!(napi_err.reason.contains("QueryError:"));
+        assert!(napi_err.reason.contains("ParseError:"));
         assert!(napi_err.reason.contains("syntax error"));
-        assert!(napi_err.reason.contains("code=QUERY"));
+        assert!(napi_err.reason.contains("code=PARSE"));
         assert!(napi_err.reason.contains("category=Query"));
+        assert!(!napi_err.reason.contains("code=QUERY"));
     }
 
     #[test]
@@ -380,34 +343,43 @@ mod tests {
         assert!(napi_err.reason.contains("code=CONFIG"));
     }
 
+    /// Issue #1451: bad caller input is `INVALID_INPUT`, not the `PARSE` code
+    /// that belongs to a genuine CQL parse failure (Python raises `ValueError`
+    /// for this variant, so the prefix says `ValueError:` too).
     #[test]
     fn test_invalid_input_error_mapping() {
         let rust_err = Error::InvalidInput("bad input".to_string());
         let napi_err = to_napi_error(rust_err);
 
-        // InvalidInput has Data category, which maps to ParseError prefix
-        assert!(napi_err.reason.contains("ParseError:"));
-        assert!(napi_err.reason.contains("code=PARSE"));
+        assert!(napi_err.reason.contains("ValueError:"));
+        assert!(napi_err.reason.contains("code=INVALID_INPUT"));
+        assert!(!napi_err.reason.contains("code=PARSE"));
     }
 
+    /// Issue #1451: a deadline gets its OWN code. It used to collapse into `IO`
+    /// via the System category, while Python raised `TimeoutError`.
     #[test]
     fn test_timeout_error_mapping() {
         let rust_err = Error::Timeout("operation timed out".to_string());
         let napi_err = to_napi_error(rust_err);
 
-        // Timeout has System category
-        assert!(napi_err.reason.contains("IoError:"));
-        assert!(napi_err.reason.contains("code=IO"));
+        assert!(napi_err.reason.contains("TimeoutError:"));
+        assert!(napi_err.reason.contains("code=TIMEOUT"));
+        assert!(napi_err.reason.contains("category=System"));
+        assert!(!napi_err.reason.contains("code=IO"));
     }
 
+    /// Issue #1451: an allocation failure gets its OWN code. It used to collapse
+    /// into `IO` via the System category, while Python raised `MemoryError`.
     #[test]
     fn test_memory_error_mapping() {
         let rust_err = Error::Memory("out of memory".to_string());
         let napi_err = to_napi_error(rust_err);
 
-        // Memory has System category
-        assert!(napi_err.reason.contains("IoError:"));
-        assert!(napi_err.reason.contains("code=IO"));
+        assert!(napi_err.reason.contains("MemoryError:"));
+        assert!(napi_err.reason.contains("code=MEMORY"));
+        assert!(napi_err.reason.contains("category=System"));
+        assert!(!napi_err.reason.contains("code=IO"));
     }
 
     #[test]
@@ -447,7 +419,9 @@ mod tests {
         let rust_err = Error::Corruption("data corrupted".to_string());
         let napi_err = to_napi_error(rust_err);
 
-        // Corruption has Data category, which maps to ParseError
+        // Corruption keeps the Data-shaped `PARSE` code and `ParseError:` prefix
+        // (issue #1451 pins this row: Python has no closer class than the base
+        // CqliteError, and Node has no closer code than PARSE).
         assert!(napi_err.reason.contains("data corrupted"));
         assert!(napi_err.reason.contains("code=PARSE"));
     }
@@ -475,144 +449,171 @@ mod tests {
         assert!(napi_err.reason.contains("isRecoverable=false"));
     }
 
-    /// Compile-time completeness check for error variant mapping.
+    /// The JS code each core variant is EXPECTED to surface as — a hand-written
+    /// restatement of the shared contract's `node_code` column.
     ///
-    /// This test ensures all `cqlite_core::Error` variants are accounted for.
-    /// If a new variant is added to the core Error enum, this will fail to compile.
-    #[test]
-    fn test_error_mapping_completeness() {
-        fn verify_all_variants_documented(err: &Error) {
-            match err {
-                // Explicitly mapped variants with category
-                Error::Io(_) => {
-                    assert_eq!(err.category(), ErrorCategory::System);
-                }
-                Error::Schema(_) => {
-                    assert_eq!(err.category(), ErrorCategory::Schema);
-                }
-                Error::Table(_) => {
-                    assert_eq!(err.category(), ErrorCategory::Schema);
-                }
-                Error::QueryExecution(_) => {
-                    assert_eq!(err.category(), ErrorCategory::Query);
-                }
-                // Byte-bounded result budget (issue #1582): Query category,
-                // maps to the "QUERY" JS code via category().
-                Error::ResultTooLarge { .. } => {
-                    assert_eq!(err.category(), ErrorCategory::Query);
-                }
-                Error::UnsupportedQuery(_) => {
-                    assert_eq!(err.category(), ErrorCategory::Query);
-                }
-                // Issue #1918: read-path forcing knob errors. `InvalidReadPath`
-                // is Configuration-category; the fail-closed `point` error is
-                // Query-category. Both flow through `category()` like the rest.
-                Error::InvalidReadPath { .. } => {
-                    assert_eq!(err.category(), ErrorCategory::Configuration);
-                }
-                Error::ForcedReadPathUnavailable { .. } => {
-                    assert_eq!(err.category(), ErrorCategory::Query);
-                }
-                Error::CqlParse(_) => {
-                    // CqlParse is Query category in cqlite-core
-                    assert_eq!(err.category(), ErrorCategory::Query);
-                }
-                Error::Configuration(_) => {
-                    assert_eq!(err.category(), ErrorCategory::Configuration);
-                }
-                Error::InvalidInput(_) => {
-                    assert_eq!(err.category(), ErrorCategory::Data);
-                }
-                Error::Timeout(_) => {
-                    assert_eq!(err.category(), ErrorCategory::System);
-                }
-                Error::Memory(_) => {
-                    assert_eq!(err.category(), ErrorCategory::System);
-                }
-                Error::InvalidState(_) => {
-                    assert_eq!(err.category(), ErrorCategory::Logic);
-                }
-                // Issue #2264: a cooperative cancellation must classify as
-                // `Cancelled` — NEVER `System` (which `category_to_code` maps
-                // to the misleading "IO" JS code).
-                Error::Cancelled => {
-                    assert_eq!(err.category(), ErrorCategory::Cancelled);
-                    assert_eq!(category_to_code(err.category()), "CANCELLED");
-                }
-
-                // All other variants are handled by category
-                Error::Serialization { .. } => {}
-                Error::Corruption(_) => {}
-                Error::InvalidFormat(_) => {}
-                Error::UnsupportedFormat(_) => {}
-                Error::UnsupportedVersion { .. } => {}
-                // CommitLog reader (#2389) — not bound yet (v1 is library+CLI only),
-                // same Data-category handling as the sibling SSTable-format errors above.
-                Error::UnsupportedCommitLogVersion { .. } => {}
-                Error::CorruptCommitLogFrame(_) => {}
-                Error::InvalidPath(_) => {}
-                Error::TypeConversion(_) => {}
-                Error::Storage(_) => {}
-                Error::Concurrency(_) => {}
-                Error::NotFound(_) => {}
-                Error::AlreadyExists(_) => {}
-                Error::InvalidOperation(_) => {}
-                Error::ConstraintViolation(_) => {}
-                Error::Transaction(_) => {}
-                Error::Index(_) => {}
-                Error::Compaction(_) => {}
-                Error::Internal(_) => {}
-                Error::Parse(_) => {}
-
-                // Write-dir lock conflict — Concurrency category, maps to CONCURRENCY code
-                Error::WriteDirLocked { .. } => {
-                    assert_eq!(err.category(), ErrorCategory::Concurrency);
-                }
-
-                #[cfg(target_arch = "wasm32")]
-                Error::Wasm(_) => {}
+    /// Two guards in one:
+    ///
+    /// 1. **Compile-time completeness.** The match is exhaustive over
+    ///    `cqlite_core::Error`, so adding a variant to the core enum fails to
+    ///    compile here until the JS identity is reviewed.
+    /// 2. **Content.** `test_error_mapping_completeness` asserts the shared
+    ///    table (and the metadata `extract_metadata` actually emits) agrees with
+    ///    this independent statement, so an accidental edit to the table's
+    ///    `node_code` column fails HERE instead of reaching users.
+    ///
+    /// Note the codes are decided BY VARIANT (issue #1451), which is why several
+    /// variants sharing one `ErrorCategory` no longer have to share one code:
+    /// `Timeout`/`Memory`/`Io` are all `System`, and `CqlParse`/`QueryExecution`
+    /// are both `Query`.
+    fn expected_node_code(err: &Error) -> &'static str {
+        match err {
+            Error::Io(_) | Error::InvalidPath(_) => "IO",
+            Error::Schema(_) | Error::Table(_) => "SCHEMA",
+            Error::QueryExecution(_)
+            | Error::UnsupportedQuery(_)
+            // Byte-bounded result budget (issue #1582) and the forced-read-path
+            // fail-closed error (issue #1918) are both query-shaped.
+            | Error::ResultTooLarge { .. }
+            | Error::ForcedReadPathUnavailable { .. } => "QUERY",
+            // A real CQL parse failure — and the data-shaped errors that share
+            // the parse identity because JS has no closer code for them.
+            Error::CqlParse(_)
+            | Error::Corruption(_)
+            | Error::Serialization { .. }
+            | Error::Parse(_)
+            | Error::TypeConversion(_)
+            | Error::InvalidFormat(_)
+            | Error::UnsupportedFormat(_)
+            | Error::UnsupportedVersion { .. }
+            // CommitLog reader (#2389) — not bound yet (v1 is library+CLI only).
+            | Error::UnsupportedCommitLogVersion { .. }
+            | Error::CorruptCommitLogFrame(_) => "PARSE",
+            Error::Configuration(_) | Error::InvalidReadPath { .. } => "CONFIG",
+            Error::InvalidInput(_) | Error::InvalidState(_) | Error::InvalidOperation(_) => {
+                "INVALID_INPUT"
             }
-        }
+            Error::Timeout(_) => "TIMEOUT",
+            Error::Memory(_) => "MEMORY",
+            Error::Storage(_) | Error::Index(_) | Error::Compaction(_) => "STORAGE",
+            Error::NotFound(_) => "NOT_FOUND",
+            Error::Concurrency(_) | Error::WriteDirLocked { .. } => "CONCURRENCY",
+            Error::AlreadyExists(_) => "CONFLICT",
+            Error::ConstraintViolation(_) => "CONSTRAINT",
+            Error::Transaction(_) => "TRANSACTION",
+            Error::Internal(_) => "INTERNAL",
+            // Issue #2264: a cooperative cancellation gets its OWN code — never
+            // the misleading "IO" of a genuine transport/filesystem failure.
+            Error::Cancelled => "CANCELLED",
 
-        // Exercise the exhaustive match
-        let test_errors = vec![
-            Error::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "test")),
-            Error::Schema("test".to_string()),
-            Error::Corruption("test".to_string()),
-            Error::Cancelled,
-        ];
-
-        for err in &test_errors {
-            verify_all_variants_documented(err);
-            // Also verify extract_metadata works
-            let _ = extract_metadata(err);
+            #[cfg(target_arch = "wasm32")]
+            Error::Wasm(_) => "PLATFORM",
         }
     }
 
+    /// Every core variant emits the documented code — in the shared contract AND
+    /// in the metadata this binding actually attaches to the JS error.
     #[test]
-    fn test_all_error_categories_have_codes() {
-        // Verify every ErrorCategory maps to a code
-        let categories = [
-            ErrorCategory::System,
-            ErrorCategory::Data,
-            ErrorCategory::Schema,
-            ErrorCategory::Query,
-            ErrorCategory::Configuration,
-            ErrorCategory::Storage,
-            ErrorCategory::Concurrency,
-            ErrorCategory::NotFound,
-            ErrorCategory::Conflict,
-            ErrorCategory::Logic,
-            ErrorCategory::Constraint,
-            ErrorCategory::Transaction,
-            ErrorCategory::Platform,
-            ErrorCategory::Internal,
-            ErrorCategory::Cancelled,
+    fn test_error_mapping_completeness() {
+        let mut checked = 0usize;
+        for &variant in FfiErrorVariant::ALL {
+            let Some(err) = variant.sample_error() else {
+                // Only `Wasm` lacks a representative value off wasm32.
+                assert_eq!(variant, FfiErrorVariant::Wasm);
+                continue;
+            };
+            let expected = expected_node_code(&err);
+            let row = contract_for(&err);
+            assert_eq!(
+                row.node_code, expected,
+                "shared contract row {} emits {}, this binding documents {}",
+                row.variant, row.node_code, expected
+            );
+
+            let metadata = extract_metadata(&err);
+            assert_eq!(metadata.code, expected, "metadata code for {}", row.variant);
+            assert_eq!(
+                metadata.category,
+                err.category().to_string(),
+                "metadata category for {}",
+                row.variant
+            );
+            assert_eq!(
+                metadata.is_recoverable,
+                err.is_recoverable(),
+                "metadata isRecoverable for {}",
+                row.variant
+            );
+            // The ORIGINAL core message always survives, prefix or not.
+            assert!(
+                metadata.message.contains(&err.to_string()),
+                "metadata message for {} must contain the core message",
+                row.variant
+            );
+            checked += 1;
+        }
+        let expected_checked =
+            FfiErrorVariant::ALL.len() - if cfg!(target_arch = "wasm32") { 0 } else { 1 };
+        assert_eq!(
+            checked, expected_checked,
+            "every contract row except Wasm (off wasm32) must be exercised"
+        );
+    }
+
+    /// Every row emits a non-empty code, and the metadata encoding the JS
+    /// wrapper parses survives for every one of them.
+    #[test]
+    fn test_every_row_encodes_parseable_metadata() {
+        for &variant in FfiErrorVariant::ALL {
+            let Some(err) = variant.sample_error() else {
+                continue;
+            };
+            let row = contract_for(&err);
+            assert!(!row.node_code.is_empty());
+            let napi_err = to_napi_error(err);
+            assert!(
+                napi_err.reason.contains(&format!("\0code={}", row.node_code)),
+                "row {} must encode its code for the JS wrapper",
+                row.variant
+            );
+            assert!(napi_err.reason.contains("\0category="));
+            assert!(napi_err.reason.contains("\0isRecoverable="));
+        }
+    }
+
+    /// The four cross-binding divergences issue #1451 fixes, pinned as a table.
+    #[test]
+    fn test_pinned_contract_rows() {
+        let cases = [
+            (Error::cql_parse("bad syntax"), "PARSE", Some("ParseError")),
+            (
+                Error::invalid_input("bad argument"),
+                "INVALID_INPUT",
+                Some("ValueError"),
+            ),
+            (
+                Error::Timeout("deadline exceeded".to_string()),
+                "TIMEOUT",
+                Some("TimeoutError"),
+            ),
+            (
+                Error::memory("allocation failed"),
+                "MEMORY",
+                Some("MemoryError"),
+            ),
+            (
+                Error::corruption("torn page"),
+                "PARSE",
+                Some("ParseError"),
+            ),
         ];
 
-        for category in categories {
-            let code = category_to_code(category);
-            assert!(!code.is_empty(), "Category {category:?} should have a code");
+        for (err, code, prefix) in cases {
+            let row = contract_for(&err);
+            assert_eq!(row.node_code, code, "node_code for {}", row.variant);
+            assert_eq!(row.message_prefix, prefix, "prefix for {}", row.variant);
+            let metadata = extract_metadata(&err);
+            assert_eq!(metadata.code, code);
         }
     }
 }

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -43,15 +43,21 @@
 //!
 //! # Example
 //!
+//! The statement below is malformed *in the CQL grammar* (a `SELECT` with no
+//! table), so it reaches the parser and fails there — that is what `PARSE`
+//! means. A statement whose leading token is not a known verb (`"INVALID SQL"`)
+//! never reaches the parser: it is rejected earlier as `Error::QueryExecution`
+//! and correctly reports `QUERY`, not `PARSE`.
+//!
 //! ```javascript
 //! try {
-//!   await db.execute("INVALID SQL");
+//!   await db.execute("SELECT * FROM");
 //! } catch (e) {
 //!   console.log(e.code);          // "PARSE" (a CQL syntax failure)
 //!   console.log(e.category);      // "Query"
 //!   console.log(e.isRecoverable); // false
 //!   if (e.code === "PARSE") {
-//!     console.log("SQL syntax error");
+//!     console.log("CQL syntax error");
 //!   }
 //! }
 //! ```

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -59,3 +59,37 @@ use napi_derive::napi;
 pub fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
+
+/// Test-support: throw the JS error the shared FFI error contract maps a named
+/// core `Error` variant to (issue #1451).
+///
+/// `variant` is a core `cqlite_core::Error` variant identifier, verbatim (e.g.
+/// `"CqlParse"`, `"Timeout"`). The probe builds that variant's representative
+/// error and returns it through the PRODUCTION `to_napi_error` path — including
+/// the `\0code=…\0category=…\0isRecoverable=…` encoding `lib/error-wrapper.js`
+/// parses — so the Jest suite can assert `error.code`/`category`/`isRecoverable`
+/// for EVERY variant, including `Timeout` and `Memory`, which no query can
+/// provoke. This is the Node twin of the Python binding's
+/// `_raise_mapped_core_error`, and both read the one shared table, so a
+/// cross-binding divergence fails both suites.
+///
+/// An unrecognized name throws rather than substituting a default row
+/// (fail-closed: a typo'd variant must never look like a passing mapping).
+/// Not part of the stable public API; `lib/index.js` re-exports it as
+/// `_errorContractProbe`.
+///
+/// @param variant - Core `Error` variant identifier
+/// @throws Always: the mapped error for `variant`, or an `INVALID_INPUT` error
+///         if the name is unknown.
+#[napi]
+pub fn error_contract_probe(variant: String) -> napi::Result<()> {
+    match cqlite_core::ffi_error_contract::FfiErrorVariant::from_name(&variant)
+        .and_then(|v| v.sample_error())
+    {
+        Some(err) => Err(error::to_napi_error(err)),
+        None => Err(error::simple_error(format!(
+            "unknown core Error variant '{variant}' (or no representative value \
+             for it on this build target)"
+        ))),
+    }
+}

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -60,6 +60,35 @@ pub fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
+/// The distinct JS error codes the shared FFI error contract can emit
+/// (issue #1451) — i.e. the authoritative `node_code` column of
+/// `cqlite_core::ffi_error_contract`, sorted and deduplicated.
+///
+/// Exists so the `ErrorCode` union in `lib/index.d.ts` can be asserted against
+/// the TABLE rather than against a hand-written list in the test. Without it,
+/// adding a contract row with a new code would ship a code the TypeScript type
+/// surface never declares — a silent type lie, and the "same fact written twice,
+/// maintained by hand" failure mode. The drift assert lives in
+/// `__test__/typescript-definitions.test.js` and fails in BOTH directions.
+///
+/// Every row is reported regardless of build target (e.g. `Wasm`'s `PLATFORM`),
+/// because the union must declare every code the contract can name.
+///
+/// Not part of the stable public API; `lib/index.js` re-exports it as
+/// `_errorContractNodeCodes`.
+///
+/// @returns Sorted, deduplicated list of JS error codes.
+#[napi]
+pub fn error_contract_node_codes() -> Vec<String> {
+    let mut codes: Vec<String> = cqlite_core::ffi_error_contract::FfiErrorVariant::ALL
+        .iter()
+        .map(|variant| variant.row().node_code.to_string())
+        .collect();
+    codes.sort_unstable();
+    codes.dedup();
+    codes
+}
+
 /// Test-support: throw the JS error the shared FFI error contract maps a named
 /// core `Error` variant to (issue #1451).
 ///

--- a/bindings/python/python/cqlite/__init__.py
+++ b/bindings/python/python/cqlite/__init__.py
@@ -9,6 +9,8 @@ from cqlite._cqlite import (
     _decimal_from_parts,
     # Test-support: direct INET rendering path (issue #1453)
     _inet_from_bytes,
+    # Test-support: shared FFI error-contract conformance probe (issue #1451)
+    _raise_mapped_core_error,
     # Exception types
     CqliteError,
     SchemaError,
@@ -50,6 +52,8 @@ __all__ = [
     "_decimal_from_parts",
     # Test-support: direct INET rendering path (issue #1453)
     "_inet_from_bytes",
+    # Test-support: shared FFI error-contract conformance probe (issue #1451)
+    "_raise_mapped_core_error",
     # Exception types
     "CqliteError",
     "SchemaError",

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -1,6 +1,12 @@
 //! Error mapping layer for Python bindings.
 //!
-//! Maps `cqlite_core::Error` variants to Python exceptions.
+//! Maps `cqlite_core::Error` variants to Python exceptions **by reading the
+//! shared FFI error contract** (`cqlite_core::ffi_error_contract`) — the ONE
+//! authoritative variant -> (python class, node code, category, recoverable,
+//! prefix) table that `bindings/node` reads too, so a core error has the same
+//! identity in every binding (issue #1451). This module owns only the
+//! identifier -> concrete PyO3 class step; it never decides WHICH class a
+//! variant gets.
 //!
 //! # Exception Hierarchy
 //!
@@ -16,6 +22,7 @@
 //! └── MemoryError (builtin) - Memory errors
 //! ```
 
+use cqlite_core::ffi_error_contract::{contract_for, PyExceptionClass};
 use pyo3::exceptions::{PyIOError, PyMemoryError, PyRuntimeError, PyTimeoutError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::{create_exception, PyErr};
@@ -57,68 +64,42 @@ pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 /// This function is used instead of `impl From<cqlite_core::Error> for PyErr`
 /// due to Rust's orphan rules (both types are from external crates).
 ///
-/// # Mapping Table
+/// The class is chosen **by variant** from the shared FFI error contract
+/// (`cqlite_core::ffi_error_contract`), never re-derived here — that table is
+/// also what `bindings/node` reads, so the two bindings cannot drift apart
+/// (issue #1451). To change how a variant surfaces, edit the table.
+///
+/// # Mapping Table (from the shared contract)
 ///
 /// | Rust Variant | Python Exception |
 /// |--------------|------------------|
 /// | `Io` | `IOError` (builtin) |
 /// | `Schema`, `Table` | `SchemaError` |
-/// | `QueryExecution`, `UnsupportedQuery` | `QueryError` |
+/// | `QueryExecution`, `ResultTooLarge`, `UnsupportedQuery` | `QueryError` |
 /// | `CqlParse` | `ParseError` |
 /// | `Configuration`, `InvalidInput` | `ValueError` (builtin) |
 /// | `Timeout` | `TimeoutError` (builtin) |
 /// | `Memory` | `MemoryError` (builtin) |
+/// | `InvalidState` | `RuntimeError` (builtin) |
 /// | `Cancelled` | `CancelledError` (issue #2264 — never `IOError`) |
-/// | All others | `CqliteError` (base) |
+/// | All others (incl. `Corruption`) | `CqliteError` (base) |
 pub fn to_py_err(err: cqlite_core::Error) -> PyErr {
     let message = err.to_string();
 
-    match err {
-        // I/O errors -> Python IOError (builtin)
-        cqlite_core::Error::Io(_) => PyIOError::new_err(message),
-
-        // Schema-related errors -> SchemaError
-        cqlite_core::Error::Schema(_) | cqlite_core::Error::Table(_) => {
-            SchemaError::new_err(message)
-        }
-
-        // Query execution errors -> QueryError. `ResultTooLarge` (issue #1582,
-        // byte-bounded result budget) is a query-shaped error whose message
-        // tells the user to add LIMIT or stream, so it maps to QueryError too.
-        cqlite_core::Error::QueryExecution(_)
-        | cqlite_core::Error::ResultTooLarge { .. }
-        | cqlite_core::Error::UnsupportedQuery(_) => QueryError::new_err(message),
-
-        // CQL parsing errors -> ParseError
-        cqlite_core::Error::CqlParse(_) => ParseError::new_err(message),
-
-        // Configuration/input errors -> Python ValueError (builtin)
-        cqlite_core::Error::Configuration(_) | cqlite_core::Error::InvalidInput(_) => {
-            PyValueError::new_err(message)
-        }
-
-        // Timeout errors -> Python TimeoutError (builtin)
-        cqlite_core::Error::Timeout(_) => PyTimeoutError::new_err(message),
-
-        // Memory errors -> Python MemoryError (builtin)
-        cqlite_core::Error::Memory(_) => PyMemoryError::new_err(message),
-
-        // Invalid state errors -> Python RuntimeError (builtin)
-        // This covers cases like using a closed database
-        cqlite_core::Error::InvalidState(_) => PyRuntimeError::new_err(message),
-
-        // Write-dir lock conflict -> CqliteError with clear message
-        // The formatted message already contains the path and advice
-        cqlite_core::Error::WriteDirLocked { .. } => CqliteError::new_err(message),
-
-        // A cooperative cancellation -> dedicated CancelledError (issue #2264),
-        // NOT the base CqliteError (would be indistinguishable from any other
-        // failure) and NEVER IOError (not a transport/filesystem failure).
-        cqlite_core::Error::Cancelled => CancelledError::new_err(message),
-
-        // All other errors -> CqliteError (base exception)
-        // See test_error_mapping_completeness() for the complete list of unmapped variants
-        _ => CqliteError::new_err(message),
+    // ONE lookup in the shared contract; the match below only turns the
+    // class IDENTIFIER into the concrete PyO3 class. It is exhaustive, so a new
+    // `PyExceptionClass` fails to compile until it is wired to a real class.
+    match contract_for(&err).py_class {
+        PyExceptionClass::IoError => PyIOError::new_err(message),
+        PyExceptionClass::ValueError => PyValueError::new_err(message),
+        PyExceptionClass::TimeoutError => PyTimeoutError::new_err(message),
+        PyExceptionClass::MemoryError => PyMemoryError::new_err(message),
+        PyExceptionClass::RuntimeError => PyRuntimeError::new_err(message),
+        PyExceptionClass::CqliteError => CqliteError::new_err(message),
+        PyExceptionClass::SchemaError => SchemaError::new_err(message),
+        PyExceptionClass::QueryError => QueryError::new_err(message),
+        PyExceptionClass::ParseError => ParseError::new_err(message),
+        PyExceptionClass::CancelledError => CancelledError::new_err(message),
     }
 }
 
@@ -136,6 +117,7 @@ pub fn runtime_init_to_py_err(err: std::io::Error) -> PyErr {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cqlite_core::ffi_error_contract::FfiErrorVariant;
     use cqlite_core::Error;
 
     /// Helper to extract error message from PyErr
@@ -345,132 +327,190 @@ mod tests {
         }
     }
 
-    /// Compile-time completeness check for error variant mapping.
+    /// The Python exception class each core variant is EXPECTED to surface as —
+    /// a hand-written restatement of the shared contract's `py_class` column.
     ///
-    /// This test ensures all `cqlite_core::Error` variants are explicitly handled
-    /// in the `to_py_err` function. If a new variant is added to the core Error enum,
-    /// this test will fail to compile, forcing a review of the Python error mapping.
+    /// Two guards in one:
+    ///
+    /// 1. **Compile-time completeness.** The match is exhaustive over
+    ///    `cqlite_core::Error`, so adding a variant to the core enum fails to
+    ///    compile here until the Python identity is reviewed.
+    /// 2. **Content.** `test_error_mapping_completeness` asserts the shared
+    ///    table (and the exception `to_py_err` actually raises) agrees with this
+    ///    independent statement, so an accidental edit to the table's
+    ///    `py_class` column fails HERE instead of reaching users.
     ///
     /// # Error Mapping Table (Complete)
     ///
     /// | Rust Variant | Python Exception | Notes |
     /// |--------------|------------------|-------|
     /// | `Io` | `IOError` (builtin) | I/O operations |
-    /// | `Schema` | `SchemaError` | Schema validation |
-    /// | `Table` | `SchemaError` | Table-related errors |
-    /// | `QueryExecution` | `QueryError` | Query execution |
-    /// | `UnsupportedQuery` | `QueryError` | Unsupported operations |
-    /// | `CqlParse` | `ParseError` | CQL syntax errors |
-    /// | `Configuration` | `ValueError` (builtin) | Config errors |
-    /// | `InvalidInput` | `ValueError` (builtin) | Input validation |
-    /// | `Timeout` | `TimeoutError` (builtin) | Operation timeouts |
-    /// | `Memory` | `MemoryError` (builtin) | Memory allocation |
-    /// | `InvalidState` | `RuntimeError` (builtin) | Invalid state (e.g., closed DB) |
-    /// | `Cancelled` | `CancelledError` | Cooperative abort (issue #2264) — never `IOError` |
-    /// | `Serialization` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Corruption` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `InvalidFormat` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `UnsupportedFormat` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `InvalidPath` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `TypeConversion` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Storage` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Concurrency` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `NotFound` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `AlreadyExists` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `InvalidOperation` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `ConstraintViolation` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Transaction` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Index` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Compaction` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Internal` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Parse` | `CqliteError` (base) | Unmapped - generic error |
-    /// | `Wasm` (wasm32 only) | `CqliteError` (base) | Unmapped - generic error |
+    /// | `Schema`, `Table` | `SchemaError` | Schema/table validation |
+    /// | `QueryExecution`, `ResultTooLarge`, `UnsupportedQuery` | `QueryError` | Query execution |
+    /// | `CqlParse` | `ParseError` | CQL syntax errors (Node code `PARSE`, #1451) |
+    /// | `Configuration`, `InvalidInput` | `ValueError` (builtin) | Config/input validation |
+    /// | `Timeout` | `TimeoutError` (builtin) | Node code `TIMEOUT` (#1451) |
+    /// | `Memory` | `MemoryError` (builtin) | Node code `MEMORY` (#1451) |
+    /// | `InvalidState` | `RuntimeError` (builtin) | Invalid state (e.g. closed DB) |
+    /// | `Cancelled` | `CancelledError` | Cooperative abort (#2264) — never `IOError` |
+    /// | `Corruption`, `Serialization`, `InvalidFormat`, `UnsupportedFormat` | `CqliteError` (base) | No closer Python class |
+    /// | `UnsupportedVersion`, `UnsupportedCommitLogVersion`, `CorruptCommitLogFrame` | `CqliteError` (base) | Format gating |
+    /// | `InvalidReadPath`, `ForcedReadPathUnavailable` | `CqliteError` (base) | Read-path knob (#1918) |
+    /// | `InvalidPath`, `TypeConversion`, `Storage`, `Concurrency`, `NotFound` | `CqliteError` (base) | |
+    /// | `AlreadyExists`, `InvalidOperation`, `ConstraintViolation`, `Transaction` | `CqliteError` (base) | |
+    /// | `Index`, `Compaction`, `Internal`, `Parse`, `WriteDirLocked` | `CqliteError` (base) | |
+    /// | `Wasm` (wasm32 only) | `CqliteError` (base) | |
+    fn expected_py_class(err: &Error) -> PyExceptionClass {
+        match err {
+            // === Explicitly mapped to specific Python exceptions ===
+            Error::Io(_) => PyExceptionClass::IoError,
+            Error::Schema(_) | Error::Table(_) => PyExceptionClass::SchemaError,
+            Error::QueryExecution(_)
+            | Error::ResultTooLarge { .. }
+            | Error::UnsupportedQuery(_) => PyExceptionClass::QueryError,
+            Error::CqlParse(_) => PyExceptionClass::ParseError,
+            Error::Configuration(_) | Error::InvalidInput(_) => PyExceptionClass::ValueError,
+            Error::Timeout(_) => PyExceptionClass::TimeoutError,
+            Error::Memory(_) => PyExceptionClass::MemoryError,
+            Error::InvalidState(_) => PyExceptionClass::RuntimeError,
+            Error::Cancelled => PyExceptionClass::CancelledError,
+
+            // === Variants with no closer Python class: the base exception ===
+            Error::Serialization { .. } => PyExceptionClass::CqliteError,
+            Error::Corruption(_) => PyExceptionClass::CqliteError,
+            Error::InvalidFormat(_) => PyExceptionClass::CqliteError,
+            Error::UnsupportedFormat(_) => PyExceptionClass::CqliteError,
+            Error::UnsupportedVersion { .. } => PyExceptionClass::CqliteError,
+            // CommitLog reader (#2389) — not bound yet (v1 is library+CLI only).
+            Error::UnsupportedCommitLogVersion { .. } => PyExceptionClass::CqliteError,
+            Error::CorruptCommitLogFrame(_) => PyExceptionClass::CqliteError,
+            // Read-path forcing knob errors (#1918).
+            Error::InvalidReadPath { .. } => PyExceptionClass::CqliteError,
+            Error::ForcedReadPathUnavailable { .. } => PyExceptionClass::CqliteError,
+            Error::InvalidPath(_) => PyExceptionClass::CqliteError,
+            Error::TypeConversion(_) => PyExceptionClass::CqliteError,
+            Error::Storage(_) => PyExceptionClass::CqliteError,
+            Error::Concurrency(_) => PyExceptionClass::CqliteError,
+            Error::NotFound(_) => PyExceptionClass::CqliteError,
+            Error::AlreadyExists(_) => PyExceptionClass::CqliteError,
+            Error::InvalidOperation(_) => PyExceptionClass::CqliteError,
+            Error::ConstraintViolation(_) => PyExceptionClass::CqliteError,
+            Error::Transaction(_) => PyExceptionClass::CqliteError,
+            Error::Index(_) => PyExceptionClass::CqliteError,
+            Error::Compaction(_) => PyExceptionClass::CqliteError,
+            Error::Internal(_) => PyExceptionClass::CqliteError,
+            Error::Parse(_) => PyExceptionClass::CqliteError,
+            Error::WriteDirLocked { .. } => PyExceptionClass::CqliteError,
+
+            // Conditional variant (only exists on wasm32)
+            #[cfg(target_arch = "wasm32")]
+            Error::Wasm(_) => PyExceptionClass::CqliteError,
+        }
+    }
+
+    /// Is the exception `to_py_err` produced an instance of `class`?
+    ///
+    /// Exhaustive over `PyExceptionClass`, so a new class in the shared contract
+    /// fails to compile until this check (and `to_py_err`) handles it.
+    fn raised_class_matches(py: Python<'_>, py_err: &PyErr, class: PyExceptionClass) -> bool {
+        match class {
+            PyExceptionClass::IoError => py_err.is_instance_of::<PyIOError>(py),
+            PyExceptionClass::ValueError => py_err.is_instance_of::<PyValueError>(py),
+            PyExceptionClass::TimeoutError => py_err.is_instance_of::<PyTimeoutError>(py),
+            PyExceptionClass::MemoryError => py_err.is_instance_of::<PyMemoryError>(py),
+            PyExceptionClass::RuntimeError => py_err.is_instance_of::<PyRuntimeError>(py),
+            // The base class is only correct if NO subclass matched, otherwise
+            // "maps to CqliteError" would be satisfied by every subclass too.
+            PyExceptionClass::CqliteError => {
+                py_err.is_instance_of::<CqliteError>(py)
+                    && !py_err.is_instance_of::<SchemaError>(py)
+                    && !py_err.is_instance_of::<QueryError>(py)
+                    && !py_err.is_instance_of::<ParseError>(py)
+                    && !py_err.is_instance_of::<CancelledError>(py)
+            }
+            PyExceptionClass::SchemaError => py_err.is_instance_of::<SchemaError>(py),
+            PyExceptionClass::QueryError => py_err.is_instance_of::<QueryError>(py),
+            PyExceptionClass::ParseError => py_err.is_instance_of::<ParseError>(py),
+            PyExceptionClass::CancelledError => py_err.is_instance_of::<CancelledError>(py),
+        }
+    }
+
+    /// Every core variant maps to the documented Python class — in the shared
+    /// contract AND in the exception `to_py_err` actually raises.
     #[test]
     fn test_error_mapping_completeness() {
-        // This function uses an exhaustive match to ensure all Error variants
-        // are accounted for. If a new variant is added to cqlite_core::Error,
-        // this will fail to compile until the match is updated.
-        //
-        // The goal is NOT to test runtime behavior (other tests do that),
-        // but to serve as a compile-time check and documentation.
+        let mut checked = 0usize;
+        for &variant in FfiErrorVariant::ALL {
+            let Some(err) = variant.sample_error() else {
+                // Only `Wasm` lacks a representative value off wasm32.
+                assert_eq!(variant, FfiErrorVariant::Wasm);
+                continue;
+            };
+            let expected = expected_py_class(&err);
+            let row = contract_for(&err);
+            assert_eq!(
+                row.py_class, expected,
+                "shared contract row {} maps to {:?}, this binding documents {:?}",
+                row.variant, row.py_class, expected
+            );
 
-        fn verify_all_variants_documented(err: &Error) {
-            match err {
-                // === Explicitly mapped to specific Python exceptions ===
-                Error::Io(_) => { /* Maps to PyIOError */ }
-                Error::Schema(_) => { /* Maps to SchemaError */ }
-                Error::Table(_) => { /* Maps to SchemaError */ }
-                Error::QueryExecution(_) => { /* Maps to QueryError */ }
-                Error::ResultTooLarge { .. } => { /* Maps to QueryError (issue #1582) */ }
-                Error::UnsupportedQuery(_) => { /* Maps to QueryError */ }
-                // Issue #1918: read-path forcing knob errors fall through to the
-                // base CqliteError like every other query-shaped variant below.
-                Error::InvalidReadPath { .. } => { /* Maps to CqliteError */ }
-                Error::ForcedReadPathUnavailable { .. } => { /* Maps to CqliteError */ }
-                Error::CqlParse(_) => { /* Maps to ParseError */ }
-                Error::Configuration(_) => { /* Maps to PyValueError */ }
-                Error::InvalidInput(_) => { /* Maps to PyValueError */ }
-                Error::Timeout(_) => { /* Maps to PyTimeoutError */ }
-                Error::Memory(_) => { /* Maps to PyMemoryError */ }
-                Error::InvalidState(_) => { /* Maps to PyRuntimeError */ }
-                Error::Cancelled => { /* Maps to CancelledError (issue #2264) — NEVER IOError */ }
-
-                // === Unmapped variants (fall through to base CqliteError) ===
-                Error::Serialization { .. } => { /* Maps to CqliteError */ }
-                Error::Corruption(_) => { /* Maps to CqliteError */ }
-                Error::InvalidFormat(_) => { /* Maps to CqliteError */ }
-                Error::UnsupportedFormat(_) => { /* Maps to CqliteError */ }
-                Error::UnsupportedVersion { .. } => { /* Maps to CqliteError */ }
-                // CommitLog reader (#2389) — not bound yet (v1 is library+CLI only),
-                // same Data-category handling as the sibling SSTable-format errors above.
-                Error::UnsupportedCommitLogVersion { .. } => { /* Maps to CqliteError */ }
-                Error::CorruptCommitLogFrame(_) => { /* Maps to CqliteError */ }
-                Error::InvalidPath(_) => { /* Maps to CqliteError */ }
-                Error::TypeConversion(_) => { /* Maps to CqliteError */ }
-                Error::Storage(_) => { /* Maps to CqliteError */ }
-                Error::Concurrency(_) => { /* Maps to CqliteError */ }
-                Error::NotFound(_) => { /* Maps to CqliteError */ }
-                Error::AlreadyExists(_) => { /* Maps to CqliteError */ }
-                Error::InvalidOperation(_) => { /* Maps to CqliteError */ }
-                Error::ConstraintViolation(_) => { /* Maps to CqliteError */ }
-                Error::Transaction(_) => { /* Maps to CqliteError */ }
-                Error::Index(_) => { /* Maps to CqliteError */ }
-                Error::Compaction(_) => { /* Maps to CqliteError */ }
-                Error::Internal(_) => { /* Maps to CqliteError */ }
-                Error::Parse(_) => { /* Maps to CqliteError */ }
-
-                // Write-dir lock conflict — maps to CqliteError with clear message
-                Error::WriteDirLocked { .. } => { /* Maps to CqliteError */ }
-
-                // Conditional variant (only exists on wasm32)
-                #[cfg(target_arch = "wasm32")]
-                Error::Wasm(_) => { /* Maps to CqliteError */ }
-            }
+            let py_err = to_py_err(err);
+            Python::with_gil(|py| {
+                assert!(
+                    raised_class_matches(py, &py_err, expected),
+                    "{} must raise {}",
+                    row.variant,
+                    expected.as_str()
+                );
+            });
+            checked += 1;
         }
+        let expected_checked =
+            FfiErrorVariant::ALL.len() - if cfg!(target_arch = "wasm32") { 0 } else { 1 };
+        assert_eq!(
+            checked, expected_checked,
+            "every contract row except Wasm (off wasm32) must be exercised"
+        );
+    }
 
-        // Create sample errors to verify the function compiles
-        // (This exercises the exhaustive match at compile time)
-        let test_errors = vec![
-            Error::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "test")),
-            Error::Schema("test".to_string()),
-            Error::Corruption("test".to_string()),
-            Error::InvalidState("test".to_string()),
-            Error::Serialization {
-                message: "test".to_string(),
-                source: None,
-            },
-            Error::Cancelled,
+    /// The four cross-binding divergences issue #1451 fixes, pinned on the
+    /// Python side of the contract.
+    #[test]
+    fn test_pinned_contract_rows() {
+        let cases = [
+            (
+                Error::cql_parse("syntax error"),
+                PyExceptionClass::ParseError,
+                "PARSE",
+            ),
+            (
+                Error::invalid_input("bad input"),
+                PyExceptionClass::ValueError,
+                "INVALID_INPUT",
+            ),
+            (
+                Error::Timeout("timed out".to_string()),
+                PyExceptionClass::TimeoutError,
+                "TIMEOUT",
+            ),
+            (
+                Error::memory("out of memory"),
+                PyExceptionClass::MemoryError,
+                "MEMORY",
+            ),
+            (
+                Error::corruption("data corrupted"),
+                PyExceptionClass::CqliteError,
+                "PARSE",
+            ),
         ];
 
-        for err in &test_errors {
-            verify_all_variants_documented(err);
-        }
-
-        // Additionally verify that the to_py_err function handles all these
-        // (This is a runtime sanity check, but primarily the compile-time check matters)
-        for err in test_errors {
-            let _py_err = to_py_err(err);
-            // If we got here, the mapping didn't panic
+        for (err, py_class, node_code) in cases {
+            let row = contract_for(&err);
+            assert_eq!(row.py_class, py_class, "py_class for {}", row.variant);
+            // Asserted here too: this binding and Node read the SAME row, so a
+            // Node-side code change cannot silently move the Python class.
+            assert_eq!(row.node_code, node_code, "node_code for {}", row.variant);
         }
     }
 

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -90,16 +90,16 @@ pub fn to_py_err(err: cqlite_core::Error) -> PyErr {
     // class IDENTIFIER into the concrete PyO3 class. It is exhaustive, so a new
     // `PyExceptionClass` fails to compile until it is wired to a real class.
     match contract_for(&err).py_class {
-        PyExceptionClass::IoError => PyIOError::new_err(message),
-        PyExceptionClass::ValueError => PyValueError::new_err(message),
-        PyExceptionClass::TimeoutError => PyTimeoutError::new_err(message),
-        PyExceptionClass::MemoryError => PyMemoryError::new_err(message),
-        PyExceptionClass::RuntimeError => PyRuntimeError::new_err(message),
-        PyExceptionClass::CqliteError => CqliteError::new_err(message),
-        PyExceptionClass::SchemaError => SchemaError::new_err(message),
-        PyExceptionClass::QueryError => QueryError::new_err(message),
-        PyExceptionClass::ParseError => ParseError::new_err(message),
-        PyExceptionClass::CancelledError => CancelledError::new_err(message),
+        PyExceptionClass::Io => PyIOError::new_err(message),
+        PyExceptionClass::Value => PyValueError::new_err(message),
+        PyExceptionClass::Timeout => PyTimeoutError::new_err(message),
+        PyExceptionClass::Memory => PyMemoryError::new_err(message),
+        PyExceptionClass::Runtime => PyRuntimeError::new_err(message),
+        PyExceptionClass::Cqlite => CqliteError::new_err(message),
+        PyExceptionClass::Schema => SchemaError::new_err(message),
+        PyExceptionClass::Query => QueryError::new_err(message),
+        PyExceptionClass::Parse => ParseError::new_err(message),
+        PyExceptionClass::Cancelled => CancelledError::new_err(message),
     }
 }
 
@@ -363,48 +363,48 @@ mod tests {
     fn expected_py_class(err: &Error) -> PyExceptionClass {
         match err {
             // === Explicitly mapped to specific Python exceptions ===
-            Error::Io(_) => PyExceptionClass::IoError,
-            Error::Schema(_) | Error::Table(_) => PyExceptionClass::SchemaError,
+            Error::Io(_) => PyExceptionClass::Io,
+            Error::Schema(_) | Error::Table(_) => PyExceptionClass::Schema,
             Error::QueryExecution(_)
             | Error::ResultTooLarge { .. }
-            | Error::UnsupportedQuery(_) => PyExceptionClass::QueryError,
-            Error::CqlParse(_) => PyExceptionClass::ParseError,
-            Error::Configuration(_) | Error::InvalidInput(_) => PyExceptionClass::ValueError,
-            Error::Timeout(_) => PyExceptionClass::TimeoutError,
-            Error::Memory(_) => PyExceptionClass::MemoryError,
-            Error::InvalidState(_) => PyExceptionClass::RuntimeError,
-            Error::Cancelled => PyExceptionClass::CancelledError,
+            | Error::UnsupportedQuery(_) => PyExceptionClass::Query,
+            Error::CqlParse(_) => PyExceptionClass::Parse,
+            Error::Configuration(_) | Error::InvalidInput(_) => PyExceptionClass::Value,
+            Error::Timeout(_) => PyExceptionClass::Timeout,
+            Error::Memory(_) => PyExceptionClass::Memory,
+            Error::InvalidState(_) => PyExceptionClass::Runtime,
+            Error::Cancelled => PyExceptionClass::Cancelled,
 
             // === Variants with no closer Python class: the base exception ===
-            Error::Serialization { .. } => PyExceptionClass::CqliteError,
-            Error::Corruption(_) => PyExceptionClass::CqliteError,
-            Error::InvalidFormat(_) => PyExceptionClass::CqliteError,
-            Error::UnsupportedFormat(_) => PyExceptionClass::CqliteError,
-            Error::UnsupportedVersion { .. } => PyExceptionClass::CqliteError,
+            Error::Serialization { .. } => PyExceptionClass::Cqlite,
+            Error::Corruption(_) => PyExceptionClass::Cqlite,
+            Error::InvalidFormat(_) => PyExceptionClass::Cqlite,
+            Error::UnsupportedFormat(_) => PyExceptionClass::Cqlite,
+            Error::UnsupportedVersion { .. } => PyExceptionClass::Cqlite,
             // CommitLog reader (#2389) — not bound yet (v1 is library+CLI only).
-            Error::UnsupportedCommitLogVersion { .. } => PyExceptionClass::CqliteError,
-            Error::CorruptCommitLogFrame(_) => PyExceptionClass::CqliteError,
+            Error::UnsupportedCommitLogVersion { .. } => PyExceptionClass::Cqlite,
+            Error::CorruptCommitLogFrame(_) => PyExceptionClass::Cqlite,
             // Read-path forcing knob errors (#1918).
-            Error::InvalidReadPath { .. } => PyExceptionClass::CqliteError,
-            Error::ForcedReadPathUnavailable { .. } => PyExceptionClass::CqliteError,
-            Error::InvalidPath(_) => PyExceptionClass::CqliteError,
-            Error::TypeConversion(_) => PyExceptionClass::CqliteError,
-            Error::Storage(_) => PyExceptionClass::CqliteError,
-            Error::Concurrency(_) => PyExceptionClass::CqliteError,
-            Error::NotFound(_) => PyExceptionClass::CqliteError,
-            Error::AlreadyExists(_) => PyExceptionClass::CqliteError,
-            Error::InvalidOperation(_) => PyExceptionClass::CqliteError,
-            Error::ConstraintViolation(_) => PyExceptionClass::CqliteError,
-            Error::Transaction(_) => PyExceptionClass::CqliteError,
-            Error::Index(_) => PyExceptionClass::CqliteError,
-            Error::Compaction(_) => PyExceptionClass::CqliteError,
-            Error::Internal(_) => PyExceptionClass::CqliteError,
-            Error::Parse(_) => PyExceptionClass::CqliteError,
-            Error::WriteDirLocked { .. } => PyExceptionClass::CqliteError,
+            Error::InvalidReadPath { .. } => PyExceptionClass::Cqlite,
+            Error::ForcedReadPathUnavailable { .. } => PyExceptionClass::Cqlite,
+            Error::InvalidPath(_) => PyExceptionClass::Cqlite,
+            Error::TypeConversion(_) => PyExceptionClass::Cqlite,
+            Error::Storage(_) => PyExceptionClass::Cqlite,
+            Error::Concurrency(_) => PyExceptionClass::Cqlite,
+            Error::NotFound(_) => PyExceptionClass::Cqlite,
+            Error::AlreadyExists(_) => PyExceptionClass::Cqlite,
+            Error::InvalidOperation(_) => PyExceptionClass::Cqlite,
+            Error::ConstraintViolation(_) => PyExceptionClass::Cqlite,
+            Error::Transaction(_) => PyExceptionClass::Cqlite,
+            Error::Index(_) => PyExceptionClass::Cqlite,
+            Error::Compaction(_) => PyExceptionClass::Cqlite,
+            Error::Internal(_) => PyExceptionClass::Cqlite,
+            Error::Parse(_) => PyExceptionClass::Cqlite,
+            Error::WriteDirLocked { .. } => PyExceptionClass::Cqlite,
 
             // Conditional variant (only exists on wasm32)
             #[cfg(target_arch = "wasm32")]
-            Error::Wasm(_) => PyExceptionClass::CqliteError,
+            Error::Wasm(_) => PyExceptionClass::Cqlite,
         }
     }
 
@@ -414,24 +414,24 @@ mod tests {
     /// fails to compile until this check (and `to_py_err`) handles it.
     fn raised_class_matches(py: Python<'_>, py_err: &PyErr, class: PyExceptionClass) -> bool {
         match class {
-            PyExceptionClass::IoError => py_err.is_instance_of::<PyIOError>(py),
-            PyExceptionClass::ValueError => py_err.is_instance_of::<PyValueError>(py),
-            PyExceptionClass::TimeoutError => py_err.is_instance_of::<PyTimeoutError>(py),
-            PyExceptionClass::MemoryError => py_err.is_instance_of::<PyMemoryError>(py),
-            PyExceptionClass::RuntimeError => py_err.is_instance_of::<PyRuntimeError>(py),
+            PyExceptionClass::Io => py_err.is_instance_of::<PyIOError>(py),
+            PyExceptionClass::Value => py_err.is_instance_of::<PyValueError>(py),
+            PyExceptionClass::Timeout => py_err.is_instance_of::<PyTimeoutError>(py),
+            PyExceptionClass::Memory => py_err.is_instance_of::<PyMemoryError>(py),
+            PyExceptionClass::Runtime => py_err.is_instance_of::<PyRuntimeError>(py),
             // The base class is only correct if NO subclass matched, otherwise
             // "maps to CqliteError" would be satisfied by every subclass too.
-            PyExceptionClass::CqliteError => {
+            PyExceptionClass::Cqlite => {
                 py_err.is_instance_of::<CqliteError>(py)
                     && !py_err.is_instance_of::<SchemaError>(py)
                     && !py_err.is_instance_of::<QueryError>(py)
                     && !py_err.is_instance_of::<ParseError>(py)
                     && !py_err.is_instance_of::<CancelledError>(py)
             }
-            PyExceptionClass::SchemaError => py_err.is_instance_of::<SchemaError>(py),
-            PyExceptionClass::QueryError => py_err.is_instance_of::<QueryError>(py),
-            PyExceptionClass::ParseError => py_err.is_instance_of::<ParseError>(py),
-            PyExceptionClass::CancelledError => py_err.is_instance_of::<CancelledError>(py),
+            PyExceptionClass::Schema => py_err.is_instance_of::<SchemaError>(py),
+            PyExceptionClass::Query => py_err.is_instance_of::<QueryError>(py),
+            PyExceptionClass::Parse => py_err.is_instance_of::<ParseError>(py),
+            PyExceptionClass::Cancelled => py_err.is_instance_of::<CancelledError>(py),
         }
     }
 
@@ -480,27 +480,27 @@ mod tests {
         let cases = [
             (
                 Error::cql_parse("syntax error"),
-                PyExceptionClass::ParseError,
+                PyExceptionClass::Parse,
                 "PARSE",
             ),
             (
                 Error::invalid_input("bad input"),
-                PyExceptionClass::ValueError,
+                PyExceptionClass::Value,
                 "INVALID_INPUT",
             ),
             (
                 Error::Timeout("timed out".to_string()),
-                PyExceptionClass::TimeoutError,
+                PyExceptionClass::Timeout,
                 "TIMEOUT",
             ),
             (
                 Error::memory("out of memory"),
-                PyExceptionClass::MemoryError,
+                PyExceptionClass::Memory,
                 "MEMORY",
             ),
             (
                 Error::corruption("data corrupted"),
-                PyExceptionClass::CqliteError,
+                PyExceptionClass::Cqlite,
                 "PARSE",
             ),
         ];

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -88,6 +88,34 @@ fn _inet_from_bytes(py: Python<'_>, bytes: Vec<u8>) -> PyResult<PyObject> {
     value::inet_to_py(py, &bytes)
 }
 
+/// Test-support: raise the Python exception the shared FFI error contract maps a
+/// named core `Error` variant to (issue #1451).
+///
+/// `variant` is a core `cqlite_core::Error` variant identifier, verbatim (e.g.
+/// `"CqlParse"`, `"Timeout"`). The probe builds that variant's representative
+/// error and returns it through the PRODUCTION `to_py_err` path, so the pytest
+/// suite can assert the contract's Python identity for EVERY variant — including
+/// `Timeout` and `Memory`, which no test query can provoke. This is the Python
+/// twin of the Node binding's `_errorContractProbe`, and both read the one shared
+/// table, so a cross-binding divergence is a test failure in both suites.
+///
+/// An unrecognized name raises `ValueError` rather than substituting a default
+/// row (fail-closed: a typo'd variant must never look like a passing mapping).
+/// Not part of the stable public API; the leading underscore marks it internal
+/// test support.
+#[pyfunction]
+fn _raise_mapped_core_error(variant: &str) -> PyResult<()> {
+    match cqlite_core::ffi_error_contract::FfiErrorVariant::from_name(variant)
+        .and_then(|v| v.sample_error())
+    {
+        Some(err) => Err(to_py_err(err)),
+        None => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "unknown core Error variant '{variant}' (or no representative value \
+             for it on this build target)"
+        ))),
+    }
+}
+
 /// Python module for CQLite.
 #[pymodule]
 fn _cqlite(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -105,6 +133,10 @@ fn _cqlite(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Test-support: direct INET rendering path for the malformed-inet typed-error
     // test (issue #1453). See the fn doc comment.
     m.add_function(wrap_pyfunction!(_inet_from_bytes, m)?)?;
+
+    // Test-support: shared FFI error-contract conformance probe (issue #1451).
+    // See the fn doc comment.
+    m.add_function(wrap_pyfunction!(_raise_mapped_core_error, m)?)?;
 
     // Register exception types
     error::register_exceptions(m)?;

--- a/bindings/python/tests/test_errors.py
+++ b/bindings/python/tests/test_errors.py
@@ -250,10 +250,21 @@ class TestCqlParseErrorFromRealQuery:
     ``require_test_data`` instead of silently passing.
     """
 
-    def test_invalid_cql_raises_parse_error(self, db):
-        with pytest.raises(cqlite.CqliteError) as excinfo:
+    def test_truncated_cql_raises_parse_error(self, db):
+        """A statement that reaches the CQL parser and fails there is ParseError.
+
+        The statement must actually reach the parser: one whose first token is
+        not a known verb is rejected earlier as a core ``QueryExecution`` error
+        ("Unsupported query type"), which is a ``QueryError`` — asserted
+        separately below so the two identities stay distinguishable.
+        """
+        with pytest.raises(cqlite.ParseError) as excinfo:
+            db.execute("SELECT * FROM")
+        assert not isinstance(excinfo.value, cqlite.QueryError)
+
+    def test_unrecognized_statement_type_raises_query_error(self, db):
+        """The other side of the fix: an unsupported statement type is a
+        ``QueryError``, and must not borrow the parse identity."""
+        with pytest.raises(cqlite.QueryError) as excinfo:
             db.execute("THIS IS NOT VALID CQL!!!")
-        err = excinfo.value
-        assert isinstance(err, (cqlite.ParseError, cqlite.QueryError)), (
-            f"unexpected exception class {type(err).__name__}: {err}"
-        )
+        assert not isinstance(excinfo.value, cqlite.ParseError)

--- a/bindings/python/tests/test_errors.py
+++ b/bindings/python/tests/test_errors.py
@@ -137,3 +137,123 @@ class TestExceptionInAllExports:
         assert "SchemaError" in all_exports
         assert "QueryError" in all_exports
         assert "ParseError" in all_exports
+
+
+class TestSharedErrorContract:
+    """The shared FFI error contract (issue #1451).
+
+    ``cqlite_core::ffi_error_contract`` is the ONE authoritative
+    variant -> (python class, node code, category, recoverable, prefix) table.
+    Before it, Python mapped by ``Error`` variant while Node derived its code
+    from ``category()``, so the same core error had a different identity in each
+    binding. These cases pin the Python half of the pinned rows; the Node half
+    lives in ``bindings/node/__test__/error.test.js``.
+
+    Each case goes through the PRODUCTION ``to_py_err`` path via the
+    ``_raise_mapped_core_error`` probe, which is the only way to reach a variant
+    (``Timeout``, ``Memory``) that no query can provoke.
+    """
+
+    # (core Error variant, expected Python exception class, expected Node code)
+    #
+    # The Node code is asserted in the Node suite; it is named here so the two
+    # halves of the contract are readable in one place.
+    PINNED_ROWS = [
+        ("CqlParse", cqlite.ParseError, "PARSE"),
+        ("InvalidInput", ValueError, "INVALID_INPUT"),
+        ("Timeout", TimeoutError, "TIMEOUT"),
+        ("Memory", MemoryError, "MEMORY"),
+        ("Corruption", cqlite.CqliteError, "PARSE"),
+    ]
+
+    @pytest.mark.parametrize(
+        "variant,expected_class,node_code",
+        PINNED_ROWS,
+        ids=[row[0] for row in PINNED_ROWS],
+    )
+    def test_pinned_row_raises_mapped_class(self, variant, expected_class, node_code):
+        """The core variant surfaces as exactly the contract's Python class."""
+        with pytest.raises(expected_class) as excinfo:
+            cqlite._raise_mapped_core_error(variant)
+        assert isinstance(excinfo.value, expected_class), (
+            f"{variant} (Node code {node_code}) must raise "
+            f"{expected_class.__name__}, got {type(excinfo.value).__name__}"
+        )
+        # The original core message survives the mapping.
+        assert str(excinfo.value)
+
+    def test_corruption_is_the_base_class_not_a_subclass(self):
+        """``Corruption`` maps to the BASE ``CqliteError``.
+
+        ``pytest.raises(CqliteError)`` alone would also pass for any subclass,
+        so the base-class row is only really pinned by excluding them.
+        """
+        with pytest.raises(cqlite.CqliteError) as excinfo:
+            cqlite._raise_mapped_core_error("Corruption")
+        err = excinfo.value
+        assert type(err) is cqlite.CqliteError
+        assert not isinstance(err, (cqlite.SchemaError, cqlite.QueryError, cqlite.ParseError))
+
+    def test_timeout_and_memory_keep_distinct_identities(self):
+        """Issue #1451: these two used to collapse into the I/O identity.
+
+        Python already raised ``TimeoutError``/``MemoryError`` while Node
+        reported ``IO`` for both. Pinned by EXACT class here (note that Python's
+        builtin ``TimeoutError`` is itself an ``OSError`` subclass, so an
+        ``isinstance`` check against ``OSError`` could not tell them apart) so
+        the shared row cannot regress toward the plain I/O identity.
+        """
+        exact = {"Timeout": TimeoutError, "Memory": MemoryError, "Io": OSError}
+        for variant, expected in exact.items():
+            with pytest.raises(Exception) as excinfo:
+                cqlite._raise_mapped_core_error(variant)
+            assert type(excinfo.value) is expected, (
+                f"{variant} must raise exactly {expected.__name__}, "
+                f"got {type(excinfo.value).__name__}"
+            )
+
+    def test_cql_parse_is_parse_error_not_query_error(self):
+        """``CqlParse`` is a ParseError, and specifically not a QueryError."""
+        with pytest.raises(cqlite.ParseError) as excinfo:
+            cqlite._raise_mapped_core_error("CqlParse")
+        assert not isinstance(excinfo.value, cqlite.QueryError)
+
+    def test_unknown_variant_is_fail_closed(self):
+        """An unrecognized variant name raises, never a substituted default."""
+        with pytest.raises(ValueError, match="unknown core Error variant"):
+            cqlite._raise_mapped_core_error("NoSuchVariant")
+
+    def test_every_contract_variant_is_reachable(self):
+        """Every variant named in the pinned rows resolves in the shared table.
+
+        A row renamed in core (or dropped from the table) makes the probe raise
+        ``ValueError`` for a name that is supposed to exist — which the pinned
+        cases above would report as the WRONG exception class rather than as a
+        missing row, so it is asserted explicitly here.
+        """
+        for variant, expected_class, _ in self.PINNED_ROWS:
+            with pytest.raises(Exception) as excinfo:
+                cqlite._raise_mapped_core_error(variant)
+            assert not (
+                isinstance(excinfo.value, ValueError)
+                and "unknown core Error variant" in str(excinfo.value)
+            ), f"contract row '{variant}' is missing from the shared table"
+            assert isinstance(excinfo.value, expected_class)
+
+
+class TestCqlParseErrorFromRealQuery:
+    """End-to-end: a genuinely invalid CQL statement raises ``ParseError``.
+
+    Exercises the wired path (``Database.execute`` -> core -> shared contract ->
+    ``to_py_err``) rather than the probe. Uses the real dataset corpus; a
+    present-but-empty dataset root FAILS LOUDLY under strict fixture mode via
+    ``require_test_data`` instead of silently passing.
+    """
+
+    def test_invalid_cql_raises_parse_error(self, db):
+        with pytest.raises(cqlite.CqliteError) as excinfo:
+            db.execute("THIS IS NOT VALID CQL!!!")
+        err = excinfo.value
+        assert isinstance(err, (cqlite.ParseError, cqlite.QueryError)), (
+            f"unexpected exception class {type(err).__name__}: {err}"
+        )

--- a/cqlite-core/src/ffi_error_contract.rs
+++ b/cqlite-core/src/ffi_error_contract.rs
@@ -53,45 +53,47 @@ use crate::error::{Error, ErrorCategory};
 ///
 /// An *identifier*, not a PyO3 type: `cqlite-core` must not depend on `pyo3`.
 /// The Python binding matches on this enum to pick the concrete class, so a new
-/// member fails that binding's build until it is handled.
+/// member fails that binding's build until it is handled. Members are named
+/// without an `Error` suffix (the enum already says "exception class"); the
+/// Python-visible class name is [`PyExceptionClass::as_str`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PyExceptionClass {
     /// Python builtin `IOError`/`OSError`.
-    IoError,
+    Io,
     /// Python builtin `ValueError`.
-    ValueError,
+    Value,
     /// Python builtin `TimeoutError`.
-    TimeoutError,
+    Timeout,
     /// Python builtin `MemoryError`.
-    MemoryError,
+    Memory,
     /// Python builtin `RuntimeError`.
-    RuntimeError,
+    Runtime,
     /// `cqlite.CqliteError` — the base class of the binding's own hierarchy.
-    CqliteError,
+    Cqlite,
     /// `cqlite.SchemaError` (subclass of `CqliteError`).
-    SchemaError,
+    Schema,
     /// `cqlite.QueryError` (subclass of `CqliteError`).
-    QueryError,
+    Query,
     /// `cqlite.ParseError` (subclass of `CqliteError`).
-    ParseError,
+    Parse,
     /// `cqlite.CancelledError` (subclass of `CqliteError`, issue #2264).
-    CancelledError,
+    Cancelled,
 }
 
 impl PyExceptionClass {
     /// The class name as Python sees it (`"IOError"`, `"ParseError"`, …).
     pub const fn as_str(self) -> &'static str {
         match self {
-            PyExceptionClass::IoError => "IOError",
-            PyExceptionClass::ValueError => "ValueError",
-            PyExceptionClass::TimeoutError => "TimeoutError",
-            PyExceptionClass::MemoryError => "MemoryError",
-            PyExceptionClass::RuntimeError => "RuntimeError",
-            PyExceptionClass::CqliteError => "CqliteError",
-            PyExceptionClass::SchemaError => "SchemaError",
-            PyExceptionClass::QueryError => "QueryError",
-            PyExceptionClass::ParseError => "ParseError",
-            PyExceptionClass::CancelledError => "CancelledError",
+            PyExceptionClass::Io => "IOError",
+            PyExceptionClass::Value => "ValueError",
+            PyExceptionClass::Timeout => "TimeoutError",
+            PyExceptionClass::Memory => "MemoryError",
+            PyExceptionClass::Runtime => "RuntimeError",
+            PyExceptionClass::Cqlite => "CqliteError",
+            PyExceptionClass::Schema => "SchemaError",
+            PyExceptionClass::Query => "QueryError",
+            PyExceptionClass::Parse => "ParseError",
+            PyExceptionClass::Cancelled => "CancelledError",
         }
     }
 }
@@ -181,47 +183,47 @@ macro_rules! ffi_error_contract_table {
 // took the `PARSE` code that belongs to a genuine CQL parse failure.
 // ============================================================================
 ffi_error_contract_table! {
-    Io => { py: IoError, code: "IO", category: System, recoverable: true, prefix: Some("IoError"), },
-    Serialization => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
-    Corruption => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
-    Schema => { py: SchemaError, code: "SCHEMA", category: Schema, recoverable: false, prefix: Some("SchemaError"), },
+    Io => { py: Io, code: "IO", category: System, recoverable: true, prefix: Some("IoError"), },
+    Serialization => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    Corruption => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    Schema => { py: Schema, code: "SCHEMA", category: Schema, recoverable: false, prefix: Some("SchemaError"), },
     // (#1451) real PARSE: a CQL syntax failure, not the generic QUERY bucket.
-    CqlParse => { py: ParseError, code: "PARSE", category: Query, recoverable: false, prefix: Some("ParseError"), },
-    InvalidFormat => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
-    UnsupportedFormat => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
-    UnsupportedVersion => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
-    UnsupportedCommitLogVersion => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
-    CorruptCommitLogFrame => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    CqlParse => { py: Parse, code: "PARSE", category: Query, recoverable: false, prefix: Some("ParseError"), },
+    InvalidFormat => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    UnsupportedFormat => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    UnsupportedVersion => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    UnsupportedCommitLogVersion => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    CorruptCommitLogFrame => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
     // (#1451) dedicated TIMEOUT code: a deadline is not an I/O failure.
-    Timeout => { py: TimeoutError, code: "TIMEOUT", category: System, recoverable: false, prefix: Some("TimeoutError"), },
-    InvalidPath => { py: CqliteError, code: "IO", category: System, recoverable: false, prefix: Some("IoError"), },
-    InvalidState => { py: RuntimeError, code: "INVALID_INPUT", category: Logic, recoverable: false, prefix: Some("RuntimeError"), },
-    QueryExecution => { py: QueryError, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
-    ResultTooLarge => { py: QueryError, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
-    InvalidReadPath => { py: CqliteError, code: "CONFIG", category: Configuration, recoverable: false, prefix: Some("ValueError"), },
-    ForcedReadPathUnavailable => { py: CqliteError, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
-    TypeConversion => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
-    Configuration => { py: ValueError, code: "CONFIG", category: Configuration, recoverable: false, prefix: Some("ValueError"), },
-    Storage => { py: CqliteError, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
+    Timeout => { py: Timeout, code: "TIMEOUT", category: System, recoverable: false, prefix: Some("TimeoutError"), },
+    InvalidPath => { py: Cqlite, code: "IO", category: System, recoverable: false, prefix: Some("IoError"), },
+    InvalidState => { py: Runtime, code: "INVALID_INPUT", category: Logic, recoverable: false, prefix: Some("RuntimeError"), },
+    QueryExecution => { py: Query, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
+    ResultTooLarge => { py: Query, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
+    InvalidReadPath => { py: Cqlite, code: "CONFIG", category: Configuration, recoverable: false, prefix: Some("ValueError"), },
+    ForcedReadPathUnavailable => { py: Cqlite, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
+    TypeConversion => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    Configuration => { py: Value, code: "CONFIG", category: Configuration, recoverable: false, prefix: Some("ValueError"), },
+    Storage => { py: Cqlite, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
     // (#1451) dedicated MEMORY code: an allocation failure is not an I/O failure.
-    Memory => { py: MemoryError, code: "MEMORY", category: System, recoverable: true, prefix: Some("MemoryError"), },
-    Concurrency => { py: CqliteError, code: "CONCURRENCY", category: Concurrency, recoverable: true, prefix: None, },
-    WriteDirLocked => { py: CqliteError, code: "CONCURRENCY", category: Concurrency, recoverable: false, prefix: None, },
-    NotFound => { py: CqliteError, code: "NOT_FOUND", category: NotFound, recoverable: false, prefix: None, },
-    Table => { py: SchemaError, code: "SCHEMA", category: Schema, recoverable: false, prefix: Some("SchemaError"), },
-    AlreadyExists => { py: CqliteError, code: "CONFLICT", category: Conflict, recoverable: false, prefix: None, },
-    InvalidOperation => { py: CqliteError, code: "INVALID_INPUT", category: Logic, recoverable: false, prefix: Some("RuntimeError"), },
-    ConstraintViolation => { py: CqliteError, code: "CONSTRAINT", category: Constraint, recoverable: false, prefix: None, },
-    Transaction => { py: CqliteError, code: "TRANSACTION", category: Transaction, recoverable: true, prefix: None, },
-    Index => { py: CqliteError, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
-    Compaction => { py: CqliteError, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
-    Wasm => { py: CqliteError, code: "PLATFORM", category: Platform, recoverable: false, prefix: None, },
-    Internal => { py: CqliteError, code: "INTERNAL", category: Internal, recoverable: false, prefix: None, },
-    Parse => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    Memory => { py: Memory, code: "MEMORY", category: System, recoverable: true, prefix: Some("MemoryError"), },
+    Concurrency => { py: Cqlite, code: "CONCURRENCY", category: Concurrency, recoverable: true, prefix: None, },
+    WriteDirLocked => { py: Cqlite, code: "CONCURRENCY", category: Concurrency, recoverable: false, prefix: None, },
+    NotFound => { py: Cqlite, code: "NOT_FOUND", category: NotFound, recoverable: false, prefix: None, },
+    Table => { py: Schema, code: "SCHEMA", category: Schema, recoverable: false, prefix: Some("SchemaError"), },
+    AlreadyExists => { py: Cqlite, code: "CONFLICT", category: Conflict, recoverable: false, prefix: None, },
+    InvalidOperation => { py: Cqlite, code: "INVALID_INPUT", category: Logic, recoverable: false, prefix: Some("RuntimeError"), },
+    ConstraintViolation => { py: Cqlite, code: "CONSTRAINT", category: Constraint, recoverable: false, prefix: None, },
+    Transaction => { py: Cqlite, code: "TRANSACTION", category: Transaction, recoverable: true, prefix: None, },
+    Index => { py: Cqlite, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
+    Compaction => { py: Cqlite, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
+    Wasm => { py: Cqlite, code: "PLATFORM", category: Platform, recoverable: false, prefix: None, },
+    Internal => { py: Cqlite, code: "INTERNAL", category: Internal, recoverable: false, prefix: None, },
+    Parse => { py: Cqlite, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
     // (#1451) INVALID_INPUT, not PARSE: bad caller input is not a CQL parse failure.
-    InvalidInput => { py: ValueError, code: "INVALID_INPUT", category: Data, recoverable: false, prefix: Some("ValueError"), },
-    UnsupportedQuery => { py: QueryError, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
-    Cancelled => { py: CancelledError, code: "CANCELLED", category: Cancelled, recoverable: false, prefix: Some("CancelledError"), },
+    InvalidInput => { py: Value, code: "INVALID_INPUT", category: Data, recoverable: false, prefix: Some("ValueError"), },
+    UnsupportedQuery => { py: Query, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
+    Cancelled => { py: Cancelled, code: "CANCELLED", category: Cancelled, recoverable: false, prefix: Some("CancelledError"), },
 }
 
 /// Map a core [`Error`] to its contract key.
@@ -351,7 +353,9 @@ impl FfiErrorVariant {
             FfiErrorVariant::Internal => Error::internal("sample internal failure"),
             FfiErrorVariant::Parse => Error::parse("sample parse failure"),
             FfiErrorVariant::InvalidInput => Error::invalid_input("sample invalid input"),
-            FfiErrorVariant::UnsupportedQuery => Error::unsupported_query("sample unsupported query"),
+            FfiErrorVariant::UnsupportedQuery => {
+                Error::unsupported_query("sample unsupported query")
+            }
             FfiErrorVariant::Cancelled => Error::Cancelled,
         };
         Some(sample)

--- a/cqlite-core/src/ffi_error_contract.rs
+++ b/cqlite-core/src/ffi_error_contract.rs
@@ -1,0 +1,359 @@
+//! The shared FFI error contract (issue #1451).
+//!
+//! **This module is the single source of truth for how a core [`Error`] variant
+//! surfaces in the language bindings.** It is consumed by
+//! `bindings/python/src/error.rs` (`to_py_err`) and
+//! `bindings/node/src/error.rs` (`extract_metadata`), which previously carried
+//! two hand-maintained mappings keyed on *different* things — Python matched the
+//! `Error` **variant**, Node derived its code from [`Error::category`] — so the
+//! same core error had a different identity in each binding (`CqlParse` was
+//! `ParseError` in Python but code `QUERY` in Node; `Timeout`/`Memory` collapsed
+//! into `IO`). Both bindings now read the rows below **by variant**.
+//!
+//! # Relocation
+//!
+//! The contract lives in `cqlite-core` only because the shared FFI crate does
+//! not exist yet. When `cqlite-ffi-common` (issue #1452) lands, this module
+//! moves there verbatim and the bindings re-point their import; nothing else
+//! changes. It is deliberately a top-level module (a sibling of [`crate::error`])
+//! so that move is a file move.
+//!
+//! # No binding dependency may enter this module
+//!
+//! The rows are **inert data**. The Python class is carried as an *identifier*
+//! ([`PyExceptionClass`]), never a PyO3 type, and the Node code as a plain
+//! `&'static str`; `cqlite-core` therefore gains no `pyo3`/`napi` dependency.
+//!
+//! # Column meanings
+//!
+//! | Column | Meaning |
+//! |--------|---------|
+//! | `py_class` | Python exception class the variant is raised as |
+//! | `node_code` | JS `error.code` string |
+//! | `category` | JS `error.category` (mirrors [`Error::category`]) |
+//! | `recoverable` | JS `error.isRecoverable` (mirrors [`Error::is_recoverable`]) |
+//! | `message_prefix` | prefix prepended to the Node message (`"IoError: …"`) |
+//!
+//! `category`/`recoverable` are carried in the row so a binding needs exactly
+//! ONE lookup, and a unit test pins them against [`Error::category`] /
+//! [`Error::is_recoverable`] so the copy can never drift. Core's `category()`
+//! and `is_recoverable()` are untouched by this module and keep their own
+//! meaning for their own callers.
+//!
+//! # Adding an `Error` variant
+//!
+//! [`variant_of`] is an exhaustive match over [`Error`], so a new core variant
+//! **fails to compile** until it is mapped to an [`FfiErrorVariant`]; adding a
+//! new `FfiErrorVariant` requires a row in the table below (the macro generates
+//! the exhaustive `row()` match from it).
+
+use crate::error::{Error, ErrorCategory};
+
+/// Identifier of the Python exception class a core [`Error`] maps to.
+///
+/// An *identifier*, not a PyO3 type: `cqlite-core` must not depend on `pyo3`.
+/// The Python binding matches on this enum to pick the concrete class, so a new
+/// member fails that binding's build until it is handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PyExceptionClass {
+    /// Python builtin `IOError`/`OSError`.
+    IoError,
+    /// Python builtin `ValueError`.
+    ValueError,
+    /// Python builtin `TimeoutError`.
+    TimeoutError,
+    /// Python builtin `MemoryError`.
+    MemoryError,
+    /// Python builtin `RuntimeError`.
+    RuntimeError,
+    /// `cqlite.CqliteError` — the base class of the binding's own hierarchy.
+    CqliteError,
+    /// `cqlite.SchemaError` (subclass of `CqliteError`).
+    SchemaError,
+    /// `cqlite.QueryError` (subclass of `CqliteError`).
+    QueryError,
+    /// `cqlite.ParseError` (subclass of `CqliteError`).
+    ParseError,
+    /// `cqlite.CancelledError` (subclass of `CqliteError`, issue #2264).
+    CancelledError,
+}
+
+impl PyExceptionClass {
+    /// The class name as Python sees it (`"IOError"`, `"ParseError"`, …).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            PyExceptionClass::IoError => "IOError",
+            PyExceptionClass::ValueError => "ValueError",
+            PyExceptionClass::TimeoutError => "TimeoutError",
+            PyExceptionClass::MemoryError => "MemoryError",
+            PyExceptionClass::RuntimeError => "RuntimeError",
+            PyExceptionClass::CqliteError => "CqliteError",
+            PyExceptionClass::SchemaError => "SchemaError",
+            PyExceptionClass::QueryError => "QueryError",
+            PyExceptionClass::ParseError => "ParseError",
+            PyExceptionClass::CancelledError => "CancelledError",
+        }
+    }
+}
+
+/// One row of the shared FFI error contract: the complete binding identity of a
+/// single core [`Error`] variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FfiErrorRow {
+    /// The core [`Error`] variant's identifier (e.g. `"CqlParse"`).
+    pub variant: &'static str,
+    /// Python exception class to raise.
+    pub py_class: PyExceptionClass,
+    /// JavaScript `error.code`.
+    pub node_code: &'static str,
+    /// JavaScript `error.category`.
+    pub category: ErrorCategory,
+    /// JavaScript `error.isRecoverable`.
+    pub recoverable: bool,
+    /// Prefix prepended to the Node message, if any.
+    pub message_prefix: Option<&'static str>,
+}
+
+/// Declare the contract table ONCE, generating the variant enum, the full-row
+/// lookup, the name lookup and the enumeration of every row from it.
+macro_rules! ffi_error_contract_table {
+    ($(
+        $variant:ident => {
+            py: $py:ident,
+            code: $code:literal,
+            category: $cat:ident,
+            recoverable: $rec:literal,
+            prefix: $prefix:expr,
+        }
+    ),+ $(,)?) => {
+        /// One member per core [`Error`] variant, named identically to it.
+        ///
+        /// This is the contract's key. Errors are mapped to it by [`variant_of`],
+        /// which is exhaustive over [`Error`].
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum FfiErrorVariant {
+            $(
+                #[doc = concat!("Contract row for [`Error::", stringify!($variant), "`].")]
+                $variant,
+            )+
+        }
+
+        impl FfiErrorVariant {
+            /// Every contract row's key, in table order.
+            pub const ALL: &'static [FfiErrorVariant] = &[$(FfiErrorVariant::$variant),+];
+
+            /// The contract row for this variant.
+            pub const fn row(self) -> FfiErrorRow {
+                match self {
+                    $(
+                        FfiErrorVariant::$variant => FfiErrorRow {
+                            variant: stringify!($variant),
+                            py_class: PyExceptionClass::$py,
+                            node_code: $code,
+                            category: ErrorCategory::$cat,
+                            recoverable: $rec,
+                            message_prefix: $prefix,
+                        },
+                    )+
+                }
+            }
+
+            /// Resolve a variant by its core [`Error`] identifier.
+            ///
+            /// Returns `None` for an unknown name (fail-closed: a caller must
+            /// never silently fall back to some default row).
+            pub fn from_name(name: &str) -> Option<Self> {
+                match name {
+                    $(stringify!($variant) => Some(FfiErrorVariant::$variant),)+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+// ============================================================================
+// THE TABLE — the single source of truth for both bindings.
+//
+// `code`/`prefix` changes marked (#1451) are the cross-binding divergences this
+// issue fixes: before it, Node derived these from `category()`, so `CqlParse`
+// reported `QUERY`, `Timeout`/`Memory` both reported `IO`, and `InvalidInput`
+// took the `PARSE` code that belongs to a genuine CQL parse failure.
+// ============================================================================
+ffi_error_contract_table! {
+    Io => { py: IoError, code: "IO", category: System, recoverable: true, prefix: Some("IoError"), },
+    Serialization => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    Corruption => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    Schema => { py: SchemaError, code: "SCHEMA", category: Schema, recoverable: false, prefix: Some("SchemaError"), },
+    // (#1451) real PARSE: a CQL syntax failure, not the generic QUERY bucket.
+    CqlParse => { py: ParseError, code: "PARSE", category: Query, recoverable: false, prefix: Some("ParseError"), },
+    InvalidFormat => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    UnsupportedFormat => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    UnsupportedVersion => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    UnsupportedCommitLogVersion => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    CorruptCommitLogFrame => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    // (#1451) dedicated TIMEOUT code: a deadline is not an I/O failure.
+    Timeout => { py: TimeoutError, code: "TIMEOUT", category: System, recoverable: false, prefix: Some("TimeoutError"), },
+    InvalidPath => { py: CqliteError, code: "IO", category: System, recoverable: false, prefix: Some("IoError"), },
+    InvalidState => { py: RuntimeError, code: "INVALID_INPUT", category: Logic, recoverable: false, prefix: Some("RuntimeError"), },
+    QueryExecution => { py: QueryError, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
+    ResultTooLarge => { py: QueryError, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
+    InvalidReadPath => { py: CqliteError, code: "CONFIG", category: Configuration, recoverable: false, prefix: Some("ValueError"), },
+    ForcedReadPathUnavailable => { py: CqliteError, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
+    TypeConversion => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    Configuration => { py: ValueError, code: "CONFIG", category: Configuration, recoverable: false, prefix: Some("ValueError"), },
+    Storage => { py: CqliteError, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
+    // (#1451) dedicated MEMORY code: an allocation failure is not an I/O failure.
+    Memory => { py: MemoryError, code: "MEMORY", category: System, recoverable: true, prefix: Some("MemoryError"), },
+    Concurrency => { py: CqliteError, code: "CONCURRENCY", category: Concurrency, recoverable: true, prefix: None, },
+    WriteDirLocked => { py: CqliteError, code: "CONCURRENCY", category: Concurrency, recoverable: false, prefix: None, },
+    NotFound => { py: CqliteError, code: "NOT_FOUND", category: NotFound, recoverable: false, prefix: None, },
+    Table => { py: SchemaError, code: "SCHEMA", category: Schema, recoverable: false, prefix: Some("SchemaError"), },
+    AlreadyExists => { py: CqliteError, code: "CONFLICT", category: Conflict, recoverable: false, prefix: None, },
+    InvalidOperation => { py: CqliteError, code: "INVALID_INPUT", category: Logic, recoverable: false, prefix: Some("RuntimeError"), },
+    ConstraintViolation => { py: CqliteError, code: "CONSTRAINT", category: Constraint, recoverable: false, prefix: None, },
+    Transaction => { py: CqliteError, code: "TRANSACTION", category: Transaction, recoverable: true, prefix: None, },
+    Index => { py: CqliteError, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
+    Compaction => { py: CqliteError, code: "STORAGE", category: Storage, recoverable: true, prefix: None, },
+    Wasm => { py: CqliteError, code: "PLATFORM", category: Platform, recoverable: false, prefix: None, },
+    Internal => { py: CqliteError, code: "INTERNAL", category: Internal, recoverable: false, prefix: None, },
+    Parse => { py: CqliteError, code: "PARSE", category: Data, recoverable: false, prefix: Some("ParseError"), },
+    // (#1451) INVALID_INPUT, not PARSE: bad caller input is not a CQL parse failure.
+    InvalidInput => { py: ValueError, code: "INVALID_INPUT", category: Data, recoverable: false, prefix: Some("ValueError"), },
+    UnsupportedQuery => { py: QueryError, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
+    Cancelled => { py: CancelledError, code: "CANCELLED", category: Cancelled, recoverable: false, prefix: Some("CancelledError"), },
+}
+
+/// Map a core [`Error`] to its contract key.
+///
+/// **This match is the contract's exhaustiveness guard**: it is exhaustive over
+/// [`Error`], so adding a variant to the core enum fails to compile until the
+/// variant is given an [`FfiErrorVariant`] (and therefore a table row).
+pub fn variant_of(err: &Error) -> FfiErrorVariant {
+    match err {
+        Error::Io(_) => FfiErrorVariant::Io,
+        Error::Serialization { .. } => FfiErrorVariant::Serialization,
+        Error::Corruption(_) => FfiErrorVariant::Corruption,
+        Error::Schema(_) => FfiErrorVariant::Schema,
+        Error::CqlParse(_) => FfiErrorVariant::CqlParse,
+        Error::InvalidFormat(_) => FfiErrorVariant::InvalidFormat,
+        Error::UnsupportedFormat(_) => FfiErrorVariant::UnsupportedFormat,
+        Error::UnsupportedVersion { .. } => FfiErrorVariant::UnsupportedVersion,
+        Error::UnsupportedCommitLogVersion { .. } => FfiErrorVariant::UnsupportedCommitLogVersion,
+        Error::CorruptCommitLogFrame(_) => FfiErrorVariant::CorruptCommitLogFrame,
+        Error::Timeout(_) => FfiErrorVariant::Timeout,
+        Error::InvalidPath(_) => FfiErrorVariant::InvalidPath,
+        Error::InvalidState(_) => FfiErrorVariant::InvalidState,
+        Error::QueryExecution(_) => FfiErrorVariant::QueryExecution,
+        Error::ResultTooLarge { .. } => FfiErrorVariant::ResultTooLarge,
+        Error::InvalidReadPath { .. } => FfiErrorVariant::InvalidReadPath,
+        Error::ForcedReadPathUnavailable { .. } => FfiErrorVariant::ForcedReadPathUnavailable,
+        Error::TypeConversion(_) => FfiErrorVariant::TypeConversion,
+        Error::Configuration(_) => FfiErrorVariant::Configuration,
+        Error::Storage(_) => FfiErrorVariant::Storage,
+        Error::Memory(_) => FfiErrorVariant::Memory,
+        Error::Concurrency(_) => FfiErrorVariant::Concurrency,
+        Error::WriteDirLocked { .. } => FfiErrorVariant::WriteDirLocked,
+        Error::NotFound(_) => FfiErrorVariant::NotFound,
+        Error::Table(_) => FfiErrorVariant::Table,
+        Error::AlreadyExists(_) => FfiErrorVariant::AlreadyExists,
+        Error::InvalidOperation(_) => FfiErrorVariant::InvalidOperation,
+        Error::ConstraintViolation(_) => FfiErrorVariant::ConstraintViolation,
+        Error::Transaction(_) => FfiErrorVariant::Transaction,
+        Error::Index(_) => FfiErrorVariant::Index,
+        Error::Compaction(_) => FfiErrorVariant::Compaction,
+        #[cfg(target_arch = "wasm32")]
+        Error::Wasm(_) => FfiErrorVariant::Wasm,
+        Error::Internal(_) => FfiErrorVariant::Internal,
+        Error::Parse(_) => FfiErrorVariant::Parse,
+        Error::InvalidInput(_) => FfiErrorVariant::InvalidInput,
+        Error::UnsupportedQuery(_) => FfiErrorVariant::UnsupportedQuery,
+        Error::Cancelled => FfiErrorVariant::Cancelled,
+    }
+}
+
+/// The contract row for a core [`Error`] — the ONE lookup a binding performs.
+pub fn contract_for(err: &Error) -> FfiErrorRow {
+    variant_of(err).row()
+}
+
+impl FfiErrorVariant {
+    /// A representative [`Error`] value for this contract row.
+    ///
+    /// Used by the bindings' error-contract conformance probes (and this
+    /// module's tests) to exercise the real mapping path for a variant that no
+    /// test query can provoke (`Timeout`, `Memory`, …). Returns `None` only for
+    /// a variant that does not exist on this build target (`Wasm` off wasm32),
+    /// never as a silent fallback.
+    pub fn sample_error(self) -> Option<Error> {
+        let sample = match self {
+            FfiErrorVariant::Io => Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "sample io failure",
+            )),
+            FfiErrorVariant::Serialization => Error::serialization("sample serialization failure"),
+            FfiErrorVariant::Corruption => Error::corruption("sample corruption"),
+            FfiErrorVariant::Schema => Error::schema("sample schema failure"),
+            FfiErrorVariant::CqlParse => Error::cql_parse("sample CQL syntax failure"),
+            FfiErrorVariant::InvalidFormat => Error::invalid_format("sample invalid format"),
+            FfiErrorVariant::UnsupportedFormat => {
+                Error::unsupported_format("sample unsupported format")
+            }
+            FfiErrorVariant::UnsupportedVersion => Error::UnsupportedVersion {
+                version: "ma".to_string(),
+                floor: "na".to_string(),
+            },
+            FfiErrorVariant::UnsupportedCommitLogVersion => Error::UnsupportedCommitLogVersion {
+                version: 5,
+                floor: 6,
+                ceiling: 8,
+            },
+            FfiErrorVariant::CorruptCommitLogFrame => {
+                Error::CorruptCommitLogFrame("sample corrupt frame".to_string())
+            }
+            FfiErrorVariant::Timeout => Error::Timeout("sample operation timeout".to_string()),
+            FfiErrorVariant::InvalidPath => Error::invalid_path("sample invalid path"),
+            FfiErrorVariant::InvalidState => Error::invalid_state("sample invalid state"),
+            FfiErrorVariant::QueryExecution => Error::query_execution("sample query failure"),
+            FfiErrorVariant::ResultTooLarge => Error::ResultTooLarge {
+                budget_bytes: 1,
+                estimated_bytes: 2,
+                rows: 3,
+            },
+            FfiErrorVariant::InvalidReadPath => Error::invalid_read_path("sample"),
+            FfiErrorVariant::ForcedReadPathUnavailable => {
+                Error::forced_read_path_unavailable("point", "sample reason")
+            }
+            FfiErrorVariant::TypeConversion => Error::type_conversion("sample type conversion"),
+            FfiErrorVariant::Configuration => Error::configuration("sample configuration failure"),
+            FfiErrorVariant::Storage => Error::storage("sample storage failure"),
+            FfiErrorVariant::Memory => Error::memory("sample allocation failure"),
+            FfiErrorVariant::Concurrency => Error::concurrency("sample concurrency failure"),
+            FfiErrorVariant::WriteDirLocked => Error::write_dir_locked("/sample/write/dir"),
+            FfiErrorVariant::NotFound => Error::not_found("sample missing resource"),
+            FfiErrorVariant::Table => Error::Table("sample table failure".to_string()),
+            FfiErrorVariant::AlreadyExists => Error::already_exists("sample existing resource"),
+            FfiErrorVariant::InvalidOperation => {
+                Error::invalid_operation("sample invalid operation")
+            }
+            FfiErrorVariant::ConstraintViolation => {
+                Error::constraint_violation("sample constraint violation")
+            }
+            FfiErrorVariant::Transaction => Error::transaction("sample transaction failure"),
+            FfiErrorVariant::Index => Error::index("sample index failure"),
+            FfiErrorVariant::Compaction => Error::compaction("sample compaction failure"),
+            #[cfg(target_arch = "wasm32")]
+            FfiErrorVariant::Wasm => Error::wasm("sample wasm failure"),
+            // `Error::Wasm` does not exist off wasm32, so no sample can be
+            // constructed. Reported as `None`, never substituted.
+            #[cfg(not(target_arch = "wasm32"))]
+            FfiErrorVariant::Wasm => return None,
+            FfiErrorVariant::Internal => Error::internal("sample internal failure"),
+            FfiErrorVariant::Parse => Error::parse("sample parse failure"),
+            FfiErrorVariant::InvalidInput => Error::invalid_input("sample invalid input"),
+            FfiErrorVariant::UnsupportedQuery => Error::unsupported_query("sample unsupported query"),
+            FfiErrorVariant::Cancelled => Error::Cancelled,
+        };
+        Some(sample)
+    }
+}

--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -13,17 +13,11 @@
 pub mod config;
 pub mod cql;
 pub mod error;
-// The shared FFI error contract (issue #1451): the ONE authoritative
-// variant -> (python class, node code, category, recoverable, prefix) table that
-// `bindings/python` and `bindings/node` both consume, so a core error has the
-// same identity in every binding. Inert data only — no pyo3/napi dependency.
-// Relocates to `cqlite-ffi-common` when issue #1452 lands.
+// The shared FFI error contract both bindings consume (issue #1451; see the module docs).
 pub mod ffi_error_contract;
 pub(crate) mod float_cmp;
 pub mod parser;
-// DISABLED FOR M1: Security and performance modules causing compilation errors
-// pub mod performance;
-// pub mod security; // Security framework for comprehensive protection
+// DISABLED FOR M1 (compilation errors): pub mod performance; pub mod security;
 pub mod types;
 pub mod util;
 pub mod version_hints;

--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -13,6 +13,12 @@
 pub mod config;
 pub mod cql;
 pub mod error;
+// The shared FFI error contract (issue #1451): the ONE authoritative
+// variant -> (python class, node code, category, recoverable, prefix) table that
+// `bindings/python` and `bindings/node` both consume, so a core error has the
+// same identity in every binding. Inert data only — no pyo3/napi dependency.
+// Relocates to `cqlite-ffi-common` when issue #1452 lands.
+pub mod ffi_error_contract;
 pub(crate) mod float_cmp;
 pub mod parser;
 // DISABLED FOR M1: Security and performance modules causing compilation errors

--- a/cqlite-core/tests/ffi_error_contract_table.rs
+++ b/cqlite-core/tests/ffi_error_contract_table.rs
@@ -102,11 +102,13 @@ fn table_agrees_with_core_category_and_recoverable() {
 fn every_row_has_a_nonempty_screaming_snake_node_code() {
     for &v in FfiErrorVariant::ALL {
         let code = v.row().node_code;
-        assert!(!code.is_empty(), "row {} has an empty code", v.row().variant);
         assert!(
-            code
-                .chars()
-                .all(|c| c.is_ascii_uppercase() || c == '_'),
+            !code.is_empty(),
+            "row {} has an empty code",
+            v.row().variant
+        );
+        assert!(
+            code.chars().all(|c| c.is_ascii_uppercase() || c == '_'),
             "node code {code} must be SCREAMING_SNAKE_CASE (it is a JS `error.code`)"
         );
     }
@@ -145,7 +147,7 @@ fn row_of(err: &Error) -> FfiErrorRow {
 fn cql_parse_row_is_parse_error_and_real_parse_code() {
     let row = row_of(&Error::cql_parse("bad syntax"));
     assert_eq!(row.variant, "CqlParse");
-    assert_eq!(row.py_class, PyExceptionClass::ParseError);
+    assert_eq!(row.py_class, PyExceptionClass::Parse);
     // Issue #1451: Node reported "QUERY" here, because it derived the code from
     // category(). `PARSE` is now a real CQL parse failure in BOTH bindings.
     assert_eq!(row.node_code, "PARSE");
@@ -158,7 +160,7 @@ fn cql_parse_row_is_parse_error_and_real_parse_code() {
 fn invalid_input_row_is_value_error_and_not_the_parse_code() {
     let row = row_of(&Error::invalid_input("bad argument"));
     assert_eq!(row.variant, "InvalidInput");
-    assert_eq!(row.py_class, PyExceptionClass::ValueError);
+    assert_eq!(row.py_class, PyExceptionClass::Value);
     // Issue #1451: Node reported "PARSE" (from the Data category), which belongs
     // to a genuine CQL parse failure. Bad caller input is INVALID_INPUT.
     assert_eq!(row.node_code, "INVALID_INPUT");
@@ -170,7 +172,7 @@ fn invalid_input_row_is_value_error_and_not_the_parse_code() {
 fn timeout_row_has_a_dedicated_timeout_code() {
     let row = row_of(&Error::Timeout("deadline exceeded".to_string()));
     assert_eq!(row.variant, "Timeout");
-    assert_eq!(row.py_class, PyExceptionClass::TimeoutError);
+    assert_eq!(row.py_class, PyExceptionClass::Timeout);
     // Issue #1451: Node collapsed Timeout into "IO" via the System category.
     assert_eq!(row.node_code, "TIMEOUT");
     assert_eq!(row.category, ErrorCategory::System);
@@ -182,7 +184,7 @@ fn timeout_row_has_a_dedicated_timeout_code() {
 fn memory_row_has_a_dedicated_memory_code() {
     let row = row_of(&Error::memory("allocation failed"));
     assert_eq!(row.variant, "Memory");
-    assert_eq!(row.py_class, PyExceptionClass::MemoryError);
+    assert_eq!(row.py_class, PyExceptionClass::Memory);
     // Issue #1451: Node collapsed Memory into "IO" via the System category.
     assert_eq!(row.node_code, "MEMORY");
     assert_eq!(row.category, ErrorCategory::System);
@@ -196,7 +198,7 @@ fn corruption_row_stays_on_the_base_python_class() {
     assert_eq!(row.variant, "Corruption");
     // Python has no closer builtin/custom class for corrupt on-disk data, so the
     // base class is authoritative here (issue #1451's divergence table).
-    assert_eq!(row.py_class, PyExceptionClass::CqliteError);
+    assert_eq!(row.py_class, PyExceptionClass::Cqlite);
     assert_eq!(row.node_code, "PARSE");
     assert_eq!(row.category, ErrorCategory::Data);
     assert!(!row.recoverable);
@@ -215,11 +217,11 @@ fn timeout_and_memory_no_longer_share_the_io_identity() {
 
 #[test]
 fn python_class_names_are_the_names_python_sees() {
-    assert_eq!(PyExceptionClass::IoError.as_str(), "IOError");
-    assert_eq!(PyExceptionClass::ParseError.as_str(), "ParseError");
-    assert_eq!(PyExceptionClass::ValueError.as_str(), "ValueError");
-    assert_eq!(PyExceptionClass::TimeoutError.as_str(), "TimeoutError");
-    assert_eq!(PyExceptionClass::MemoryError.as_str(), "MemoryError");
-    assert_eq!(PyExceptionClass::CqliteError.as_str(), "CqliteError");
-    assert_eq!(PyExceptionClass::CancelledError.as_str(), "CancelledError");
+    assert_eq!(PyExceptionClass::Io.as_str(), "IOError");
+    assert_eq!(PyExceptionClass::Parse.as_str(), "ParseError");
+    assert_eq!(PyExceptionClass::Value.as_str(), "ValueError");
+    assert_eq!(PyExceptionClass::Timeout.as_str(), "TimeoutError");
+    assert_eq!(PyExceptionClass::Memory.as_str(), "MemoryError");
+    assert_eq!(PyExceptionClass::Cqlite.as_str(), "CqliteError");
+    assert_eq!(PyExceptionClass::Cancelled.as_str(), "CancelledError");
 }

--- a/cqlite-core/tests/ffi_error_contract_table.rs
+++ b/cqlite-core/tests/ffi_error_contract_table.rs
@@ -1,0 +1,225 @@
+//! Tests for the shared FFI error contract table (issue #1451).
+//!
+//! The table in `cqlite_core::ffi_error_contract` is the single source of truth
+//! for how a core `Error` variant surfaces in `bindings/python` and
+//! `bindings/node`. These tests pin:
+//!
+//! 1. **Completeness** — every contract row has a constructible representative
+//!    error, and `variant_of` maps that error back to the same row (so a row can
+//!    never be orphaned or aliased onto the wrong variant).
+//! 2. **Agreement with core** — the row's `category`/`recoverable` copies match
+//!    `Error::category()` / `Error::is_recoverable()` for every variant, so the
+//!    copy carried for the bindings' single lookup cannot drift.
+//! 3. **The rows issue #1451 pins**, including the four cross-binding
+//!    divergences it fixes.
+//!
+//! Note that a *new* core `Error` variant is caught by the compiler, not here:
+//! `variant_of` is an exhaustive match over `Error`.
+
+use cqlite_core::error::{Error, ErrorCategory};
+use cqlite_core::ffi_error_contract::{
+    contract_for, variant_of, FfiErrorRow, FfiErrorVariant, PyExceptionClass,
+};
+
+/// The representative error for `v`, failing loudly when one is expected but
+/// absent. `None` is legitimate ONLY for `Wasm` off a wasm32 target, where the
+/// core variant does not exist.
+fn require_sample(v: FfiErrorVariant) -> Option<Error> {
+    match v.sample_error() {
+        Some(err) => Some(err),
+        None => {
+            assert_eq!(
+                v,
+                FfiErrorVariant::Wasm,
+                "{:?} has no representative error; only Wasm (off wasm32) may lack one",
+                v
+            );
+            assert!(
+                !cfg!(target_arch = "wasm32"),
+                "Error::Wasm exists on wasm32, so a sample must be constructible"
+            );
+            None
+        }
+    }
+}
+
+#[test]
+fn every_row_round_trips_through_variant_of() {
+    let mut checked = 0usize;
+    for &v in FfiErrorVariant::ALL {
+        let Some(err) = require_sample(v) else {
+            continue;
+        };
+        assert_eq!(
+            variant_of(&err),
+            v,
+            "variant_of({}) must resolve back to its own contract row",
+            v.row().variant
+        );
+        assert_eq!(contract_for(&err), v.row());
+        assert_eq!(
+            FfiErrorVariant::from_name(v.row().variant),
+            Some(v),
+            "row name {} must resolve back to its variant",
+            v.row().variant
+        );
+        checked += 1;
+    }
+    // Off wasm32 exactly one row (Wasm) has no constructible sample.
+    let expected = FfiErrorVariant::ALL.len() - if cfg!(target_arch = "wasm32") { 0 } else { 1 };
+    assert_eq!(
+        checked, expected,
+        "every contract row except Wasm (off wasm32) must be exercised"
+    );
+}
+
+#[test]
+fn table_agrees_with_core_category_and_recoverable() {
+    for &v in FfiErrorVariant::ALL {
+        let Some(err) = require_sample(v) else {
+            continue;
+        };
+        let row = v.row();
+        // The row carries `category`/`recoverable` so a binding needs ONE
+        // lookup. They are copies of core's values, and this pins them: a
+        // DELIBERATE future divergence must edit this test with its reason.
+        assert_eq!(
+            row.category,
+            err.category(),
+            "row {} category must match Error::category()",
+            row.variant
+        );
+        assert_eq!(
+            row.recoverable,
+            err.is_recoverable(),
+            "row {} recoverable must match Error::is_recoverable()",
+            row.variant
+        );
+    }
+}
+
+#[test]
+fn every_row_has_a_nonempty_screaming_snake_node_code() {
+    for &v in FfiErrorVariant::ALL {
+        let code = v.row().node_code;
+        assert!(!code.is_empty(), "row {} has an empty code", v.row().variant);
+        assert!(
+            code
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c == '_'),
+            "node code {code} must be SCREAMING_SNAKE_CASE (it is a JS `error.code`)"
+        );
+    }
+}
+
+#[test]
+fn from_name_is_fail_closed_for_an_unknown_variant() {
+    assert_eq!(FfiErrorVariant::from_name("NoSuchVariant"), None);
+    assert_eq!(FfiErrorVariant::from_name(""), None);
+    // Case-sensitive: the name is the core `Error` identifier, verbatim.
+    assert_eq!(FfiErrorVariant::from_name("timeout"), None);
+    assert_eq!(
+        FfiErrorVariant::from_name("Timeout"),
+        Some(FfiErrorVariant::Timeout)
+    );
+}
+
+/// The row count is pinned so adding an `Error` variant (and therefore a row)
+/// is a deliberate, reviewed act rather than an invisible one. Update the count
+/// together with the table.
+#[test]
+fn row_count_is_pinned() {
+    assert_eq!(
+        FfiErrorVariant::ALL.len(),
+        37,
+        "contract row count changed — review the new row's py_class/node_code \
+         and update this pin"
+    );
+}
+
+fn row_of(err: &Error) -> FfiErrorRow {
+    contract_for(err)
+}
+
+#[test]
+fn cql_parse_row_is_parse_error_and_real_parse_code() {
+    let row = row_of(&Error::cql_parse("bad syntax"));
+    assert_eq!(row.variant, "CqlParse");
+    assert_eq!(row.py_class, PyExceptionClass::ParseError);
+    // Issue #1451: Node reported "QUERY" here, because it derived the code from
+    // category(). `PARSE` is now a real CQL parse failure in BOTH bindings.
+    assert_eq!(row.node_code, "PARSE");
+    assert_eq!(row.category, ErrorCategory::Query);
+    assert!(!row.recoverable);
+    assert_eq!(row.message_prefix, Some("ParseError"));
+}
+
+#[test]
+fn invalid_input_row_is_value_error_and_not_the_parse_code() {
+    let row = row_of(&Error::invalid_input("bad argument"));
+    assert_eq!(row.variant, "InvalidInput");
+    assert_eq!(row.py_class, PyExceptionClass::ValueError);
+    // Issue #1451: Node reported "PARSE" (from the Data category), which belongs
+    // to a genuine CQL parse failure. Bad caller input is INVALID_INPUT.
+    assert_eq!(row.node_code, "INVALID_INPUT");
+    assert_eq!(row.category, ErrorCategory::Data);
+    assert_eq!(row.message_prefix, Some("ValueError"));
+}
+
+#[test]
+fn timeout_row_has_a_dedicated_timeout_code() {
+    let row = row_of(&Error::Timeout("deadline exceeded".to_string()));
+    assert_eq!(row.variant, "Timeout");
+    assert_eq!(row.py_class, PyExceptionClass::TimeoutError);
+    // Issue #1451: Node collapsed Timeout into "IO" via the System category.
+    assert_eq!(row.node_code, "TIMEOUT");
+    assert_eq!(row.category, ErrorCategory::System);
+    assert!(!row.recoverable);
+    assert_eq!(row.message_prefix, Some("TimeoutError"));
+}
+
+#[test]
+fn memory_row_has_a_dedicated_memory_code() {
+    let row = row_of(&Error::memory("allocation failed"));
+    assert_eq!(row.variant, "Memory");
+    assert_eq!(row.py_class, PyExceptionClass::MemoryError);
+    // Issue #1451: Node collapsed Memory into "IO" via the System category.
+    assert_eq!(row.node_code, "MEMORY");
+    assert_eq!(row.category, ErrorCategory::System);
+    assert!(row.recoverable);
+    assert_eq!(row.message_prefix, Some("MemoryError"));
+}
+
+#[test]
+fn corruption_row_stays_on_the_base_python_class() {
+    let row = row_of(&Error::corruption("torn page"));
+    assert_eq!(row.variant, "Corruption");
+    // Python has no closer builtin/custom class for corrupt on-disk data, so the
+    // base class is authoritative here (issue #1451's divergence table).
+    assert_eq!(row.py_class, PyExceptionClass::CqliteError);
+    assert_eq!(row.node_code, "PARSE");
+    assert_eq!(row.category, ErrorCategory::Data);
+    assert!(!row.recoverable);
+}
+
+#[test]
+fn timeout_and_memory_no_longer_share_the_io_identity() {
+    let io = row_of(&Error::Io(std::io::Error::other("disk gone")));
+    let timeout = row_of(&Error::Timeout("deadline exceeded".to_string()));
+    let memory = row_of(&Error::memory("allocation failed"));
+    assert_eq!(io.node_code, "IO");
+    assert_ne!(timeout.node_code, io.node_code);
+    assert_ne!(memory.node_code, io.node_code);
+    assert_ne!(timeout.node_code, memory.node_code);
+}
+
+#[test]
+fn python_class_names_are_the_names_python_sees() {
+    assert_eq!(PyExceptionClass::IoError.as_str(), "IOError");
+    assert_eq!(PyExceptionClass::ParseError.as_str(), "ParseError");
+    assert_eq!(PyExceptionClass::ValueError.as_str(), "ValueError");
+    assert_eq!(PyExceptionClass::TimeoutError.as_str(), "TimeoutError");
+    assert_eq!(PyExceptionClass::MemoryError.as_str(), "MemoryError");
+    assert_eq!(PyExceptionClass::CqliteError.as_str(), "CqliteError");
+    assert_eq!(PyExceptionClass::CancelledError.as_str(), "CancelledError");
+}


### PR DESCRIPTION
Closes #1451.

## What this changes

The same core error had a **different identity in each binding**: Python mapped `cqlite_core::Error` to an exception by **variant**, while Node derived `error.code` from `Error::category()`. So "catch `ParseError` for bad CQL" was true in Python and false in Node (`CqlParse` reported `QUERY`), and `Timeout`/`Memory` — distinct `TimeoutError`/`MemoryError` in Python — both collapsed to `IO` in Node.

Both mappings are now driven by **one authoritative table**, keyed by core `Error` variant:
`cqlite-core/src/ffi_error_contract.rs`. Each row is `(py_class, node_code, category, recoverable, prefix)`.

## Where the table lives, and why (AC step 1)

**#1452 (`cqlite-ffi-common`) has not landed**, so of the two fallbacks the AC sanctions I took **one table in `cqlite-core`**, *not* duplicate-copies-plus-a-drift-test:

- The DoD asks for "**one** authoritative … table; both `to_py_err` and `extract_metadata` consume it". A single table satisfies that literally; two copies satisfy it only by proxy.
- The table is inert data — the Python class travels as an **identifier** (`PyExceptionClass`), never a PyO3 type. **No PyO3/napi dependency enters `cqlite-core`, and `cqlite-core/Cargo.toml` is unchanged.**
- It is a **new file**, not an addition to `cqlite-core/src/error.rs` (already 878 lines, over the ~800 target — growing it would trip the `file-size` ratchet).
- When #1452 lands the module relocates wholesale; nothing has to be de-duplicated first.

Core's `Error` enum, `category()` and `is_recoverable()` are **untouched** — `cqlite-core/src/error.rs` has no diff. The reported `category` stays core-derived; only the `code` is finer-grained, and `table_agrees_with_core_category_and_recoverable` pins that.

## User-visible behavior changes (Node `error.code`)

| Core variant | Before | After |
|---|---|---|
| `CqlParse` | `QUERY` | **`PARSE`** |
| `Timeout` | `IO` | **`TIMEOUT`** |
| `Memory` | `IO` | **`MEMORY`** |
| `InvalidInput` | `PARSE` | **`INVALID_INPUT`** |
| `Corruption` | `PARSE` | `PARSE` (unchanged) |

`ErrorCode` in `bindings/node/lib/index.d.ts` gains `TIMEOUT` and `MEMORY`. Consumers switching on `err.code` for these four variants must update; the codes are strictly more specific than what they replace.

## A correction to the issue's premise, worth recording

The issue points at `bindings/node/__test__/error.test.js:54-64` hedging `expect(['PARSE','QUERY']).toContain(e.code)`. That test was **passing on the `QUERY` branch for a reason unrelated to the mapping**: it provoked `'THIS IS NOT VALID SQL!!!'`, whose unknown first token is rejected *before* the CQL parser as `Error::QueryExecution` — legitimately `QUERY`. It never exercised `CqlParse` at all.

So the RED was demonstrated on a **rewritten** test (`'SELECT * FROM'`, which reaches the parser), not on the original. A sibling test now pins the other direction: an unsupported *statement type* must stay `QUERY` and must not borrow the new `PARSE`. The same misleading example had propagated into the docs, which roborev caught (below).

## Tests

- **Rust** `cqlite-core/tests/ffi_error_contract_table.rs` — every row round-trips through `variant_of`; the table agrees with core `category()`/`is_recoverable()`; every row has a non-empty SCREAMING_SNAKE code; `from_name` is fail-closed on an unknown variant; the row count is pinned; each row the issue names is asserted individually; `Timeout`/`Memory` no longer share `IO`'s identity.
- **Python** `bindings/python/tests/test_errors.py` — table-driven: `CqlParse`→`ParseError`, `Timeout`→`TimeoutError`, `Memory`→`MemoryError`, `InvalidInput`→`ValueError`, `Corruption`→`CqliteError`.
- **Node** `bindings/node/__test__/error.test.js` — hedged assertions replaced with authoritative ones, including **negative** assertions (`CqlParse` is `PARSE` and specifically *not* `QUERY`).
- **Compile-time completeness survives**: `variant_of` is exhaustive over `Error`, so adding a core variant **fails to build** until it gets a table row.
- `Timeout`/`Memory` cannot be provoked by any query, which is exactly where the Node divergence hid. Two conformance probes (`_raise_mapped_core_error`, `_errorContractProbe`) make every row assertable; both route through the **production** `to_py_err`/`to_napi_error` path (including Node's `\0code=…\0category=…\0isRecoverable=…` encoding) so they cannot green while production diverges, and both fail closed on an unrecognized variant name.

## Review

**roborev: 1 finding (Low), fixed in `e5bb70fe1`.** Three doc sites illustrated `PARSE` with `SELEC * FORM table` — an unknown-first-token statement that actually yields `QUERY`, i.e. the docs taught the opposite of the semantic this PR establishes. Fixed rather than deferred as a nit because these are lines this PR itself wrote.

**Lead's own finding, fixed in `b2042584d`.** Nothing pinned the `.d.ts` `ErrorCode` union to the table's `node_code` column: a new variant is forced to get a table row (compile error) and trips the pinned row count, but nothing forced the *type surface* to gain the code — a silent type lie, and the "same fact written twice, maintained by hand" shape. Now closed by a **bidirectional** drift assert that takes the authoritative set from the table via a napi seam (not a third hand-written copy), strips `//` comments *before* slicing the declaration (the `TIMEOUT` member's comment contains a `;`, so a naive first-semicolon parse under-reads the union and passes vacuously), and carries an explicit anti-vacuity case.

**`rust-reviewer` did not deliver a report.** The subagent completed and went idle without returning findings, and re-requests went unanswered. Recorded as **not delivered** rather than implied. Standing in for it, the lead verified directly: `category_to_code` is **deleted outright** (no residual second mapping); zero `unwrap`/`expect`/`panic!`/`unreachable!` introduced anywhere under `cqlite-core/src` or `bindings/*/src`; the `\0` metadata encoding is byte-preserved with identical field order; the table's 17 `node_code`s and the union's 17 members match exactly.

## Follow-up (not in scope here)

`bindings/node/src/error.rs::simple_error` hardcodes `code=INVALID_INPUT\0category=Logic\0isRecoverable=false` — a fourth hand-written copy of a mapping fact. **Pre-existing and untouched by this PR** (the diff only adds a nearby assertion); it serves non-core errors like "Database is closed". Deriving it from the `InvalidInput` row belongs in #1452's consolidation.

## Local certification at `46ca553`

```
==== AGENT-GATE LITE SUMMARY ====
MODE: lite (FAST ITERATION — NOT the gate of record; full agent-gate.sh must PASS once before merge)
commit: 46ca553 branch: issue-1451-shared-authoritative-error-table dirty: no
tree-integrity: PASS
file-size: PASS   fmt: PASS   clippy: PASS   roborev-lints: PASS (44s)   scoped-tests: PASS (129s)
python-tier: PASS (maturin develop && pytest bindings/python/tests -m 'not slow' -q)
RESULT: PASS
==== END AGENT-GATE LITE SUMMARY ====
```

Lite is **not** the gate of record — the full `scripts/agent-gate.sh` runs once in `flow-closer`
before merge. Node, run separately (lite's scope does not cover the JS suites, and the new
`_errorContractNodeCodes` napi seam needs a build first): `npm run build` exit 0, then
**104/104 across `error.test.js` + `typescript-definitions.test.js`**, with the two dataset-backed
cases executing in 149ms/175ms rather than skipping.

### One transient red, explained and filed: #3377

An earlier lite round at this same commit reported `roborev-lints: FAIL` on assertion 741 of
`scripts/tests/test_roborev_review_guard.sh` — "delivery-mode classification is back in the flow
scripts — mixed-delivery". **This PR touches nothing under `scripts/`.** It is a flake, filed as
**#3377** with the measurement table: the same clean detached worktree at this commit gave **1 FAIL
then 3 consecutive PASS (741/0)**, and `origin/main` passes under the same component. The
`mixed-delivery` token genuinely appears on a non-comment line of `scripts/flow/roborev-review.sh:339`
(inside a heredoc, so the assertion's comment-stripping cannot remove it — the raw grep hits on
`origin/main` too), so the check passes only while `$WRAPPER` points at a stripped scratch copy.

Recorded rather than waived: the #3042 docs-only waiver is **void here** (this diff contains `src`),
so this is a cited-flake explanation, not a waiver. `scripts/` was deliberately **not** modified to
turn the component green.
