### PR TITLE
fix(#1695): enforce query.max_execution_time at the engine chokepoint (AH2)

### DIFF
--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -495,6 +495,14 @@ mod tests {
             // CommitLog reader (#2389) — not bound yet (v1 is library+CLI only).
             | Error::UnsupportedCommitLogVersion { .. }
             | Error::CorruptCommitLogFrame(_) => "PARSE",
+            // Query execution budget elapsed (issue #1695): the SAME `TIMEOUT` code as
+            // its sibling `Timeout`, so a JS caller checking for `TIMEOUT` catches
+            // both. Deliberately NOT `QUERY`, even though its `ErrorCategory` IS
+            // `Query` — #1451's whole point is that codes are decided BY VARIANT, so
+            // the classify category and the JS code are separate axes. Python maps the
+            // same variant to the builtin `TimeoutError`, which is the cross-binding
+            // agreement the shared table exists to enforce.
+            Error::QueryTimeout { .. } => "TIMEOUT",
             Error::Configuration(_) | Error::InvalidReadPath { .. } => "CONFIG",
             Error::InvalidInput(_) | Error::InvalidState(_) | Error::InvalidOperation(_) => {
                 "INVALID_INPUT"

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -371,6 +371,13 @@ mod tests {
             Error::CqlParse(_) => PyExceptionClass::Parse,
             Error::Configuration(_) | Error::InvalidInput(_) => PyExceptionClass::Value,
             Error::Timeout(_) => PyExceptionClass::Timeout,
+            // Query execution budget elapsed (issue #1695): the SAME builtin
+            // `TimeoutError` as its sibling above, so `except TimeoutError:` catches
+            // both. Its core `ErrorCategory` is `Query` — a separate axis from the
+            // Python class, which is why this is not `PyExceptionClass::Query`. Node
+            // gives the same variant code `TIMEOUT`, which is the cross-binding
+            // agreement the shared table (#1451) exists to enforce.
+            Error::QueryTimeout { .. } => PyExceptionClass::Timeout,
             Error::Memory(_) => PyExceptionClass::Memory,
             Error::InvalidState(_) => PyExceptionClass::Runtime,
             Error::Cancelled => PyExceptionClass::Cancelled,

--- a/cqlite-cli/src/commands/export.rs
+++ b/cqlite-cli/src/commands/export.rs
@@ -113,6 +113,13 @@ pub async fn export_data(
         _ => StreamingConfig::for_text_formats(),
     };
 
+    // Issue #1695: the budget clock starts BEFORE setup. An earlier revision derived
+    // the remainder from `start_time`, which is captured AFTER `execute_streaming`
+    // returns — so consumption was handed a fresh FULL budget and setup cost nothing
+    // against it (roborev round 10). `start_time` still exists for the export
+    // statistics, which deliberately report consumption time only.
+    let budget_start = Instant::now();
+
     // Execute the query with streaming (Issue #280 - true end-to-end streaming)
     let mut result_iter = database
         .execute_streaming(&query, config.clone())
@@ -164,7 +171,7 @@ pub async fn export_data(
         // reading of an astronomically distant deadline.
         tokio::time::Instant::now().checked_add(
             export_budget
-                .checked_sub(start_time.elapsed())
+                .checked_sub(budget_start.elapsed())
                 .unwrap_or_default(),
         )
     };
@@ -200,12 +207,14 @@ pub async fn export_data(
                     break;
                 }
 
-                check_export_deadline(export_deadline, start_time, export_budget)?;
-
-                let chunk = result_iter
-                    .collect_chunk(chunk_size)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to collect chunk: {}", e))?;
+                let chunk = collect_chunk_within(
+                    &mut result_iter,
+                    chunk_size,
+                    export_deadline,
+                    budget_start,
+                    export_budget,
+                )
+                .await?;
 
                 if chunk.is_empty() {
                     break;
@@ -257,12 +266,14 @@ pub async fn export_data(
                     break;
                 }
 
-                check_export_deadline(export_deadline, start_time, export_budget)?;
-
-                let chunk = result_iter
-                    .collect_chunk(chunk_size)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to collect chunk: {}", e))?;
+                let chunk = collect_chunk_within(
+                    &mut result_iter,
+                    chunk_size,
+                    export_deadline,
+                    budget_start,
+                    export_budget,
+                )
+                .await?;
 
                 if chunk.is_empty() {
                     break;
@@ -332,12 +343,14 @@ pub async fn export_data(
                     break;
                 }
 
-                check_export_deadline(export_deadline, start_time, export_budget)?;
-
-                let chunk = result_iter
-                    .collect_chunk(chunk_size)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to collect chunk: {}", e))?;
+                let chunk = collect_chunk_within(
+                    &mut result_iter,
+                    chunk_size,
+                    export_deadline,
+                    budget_start,
+                    export_budget,
+                )
+                .await?;
 
                 if chunk.is_empty() {
                     break;
@@ -414,12 +427,14 @@ pub async fn export_data(
                     break;
                 }
 
-                check_export_deadline(export_deadline, start_time, export_budget)?;
-
-                let chunk = result_iter
-                    .collect_chunk(chunk_size)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to collect chunk: {}", e))?;
+                let chunk = collect_chunk_within(
+                    &mut result_iter,
+                    chunk_size,
+                    export_deadline,
+                    budget_start,
+                    export_budget,
+                )
+                .await?;
 
                 if chunk.is_empty() {
                     break;
@@ -699,6 +714,66 @@ mod tests {
     }
 }
 
+/// Pull one chunk, abandoning the wait at `deadline` (issue #1695).
+///
+/// The pre-pull [`check_export_deadline`] alone was NOT enough: it only runs between
+/// pulls, and `collect_chunk` can stay PENDING indefinitely while the producer looks
+/// for rows — a no-match scan over a large table is exactly that — so control never
+/// returned to the check and the export ran past the deadline (roborev round 10).
+/// Wrapping the AWAIT bounds the wait itself.
+///
+/// Only the future is wrapped, not the loop or the enclosing per-format `match`, so
+/// no writer or progress-bar borrow moves.
+///
+/// BOTH layers live here rather than at the call sites: an already-expired deadline
+/// is rejected before a pull starts, and a pull that hangs is bounded by the timer.
+/// Keeping them together means a fifth consumption loop cannot be added that forgets
+/// one of them — the four existing ones each got the pre-check by hand, which is
+/// exactly the kind of per-site obligation that rots.
+#[cfg(feature = "state_machine")]
+async fn collect_chunk_within(
+    result_iter: &mut cqlite_core::query::result::QueryResultIterator,
+    chunk_size: usize,
+    deadline: Option<tokio::time::Instant>,
+    started: std::time::Instant,
+    budget: std::time::Duration,
+) -> Result<Vec<cqlite_core::query::result::QueryRow>> {
+    // Layer 1: an ALREADY-expired deadline must not start a pull at all. This cannot
+    // be left to `timeout_at` below, which polls its inner future FIRST and consults
+    // the deadline second — so an immediately-ready chunk would come back `Ok` past
+    // the deadline (the round-7 lesson, applied here before it could recur).
+    check_export_deadline(deadline, started, budget)?;
+
+    // Layer 2: bound the WAIT itself.
+    let pull = result_iter.collect_chunk(chunk_size);
+    let chunk = match deadline {
+        None => pull.await,
+        Some(deadline) => match tokio::time::timeout_at(deadline, pull).await {
+            Ok(chunk) => chunk,
+            // Dropping `pull` drops the in-flight chunk collection; the caller's error
+            // path then drops the iterator, closing the channel and retiring the
+            // producer.
+            Err(_elapsed) => return Err(export_expired(started, budget)),
+        },
+    };
+    chunk.map_err(|e| anyhow::anyhow!("Failed to collect chunk: {}", e))
+}
+
+/// The export-layer elapse. One constructor for both exits — the pre-pull check and
+/// the bounded await — so they cannot drift in operation name or reported figures.
+#[cfg(feature = "state_machine")]
+fn export_expired(started: std::time::Instant, budget: std::time::Duration) -> anyhow::Error {
+    anyhow::Error::new(cqlite_core::Error::QueryTimeout {
+        operation: "cli.export.collect".to_string(),
+        // MEASURED, not assumed equal to the budget: a slow chunk can overshoot, and
+        // the real figure distinguishes "budget too tight" from "one chunk is
+        // uninterruptibly slow".
+        elapsed: started.elapsed(),
+        limit: budget,
+    })
+    .context("CLI export exceeded performance.query_timeout_ms")
+}
+
 /// The export-side budget check (issue #1695), called before each chunk pull.
 ///
 /// Deliberately a check rather than a `timeout_at` wrapper: the four consumption
@@ -722,15 +797,7 @@ fn check_export_deadline(
     if tokio::time::Instant::now() < deadline {
         return Ok(());
     }
-    Err(anyhow::Error::new(cqlite_core::Error::QueryTimeout {
-        operation: "cli.export.collect".to_string(),
-        // MEASURED, not assumed equal to the budget: a slow chunk can overshoot,
-        // and the real figure distinguishes "budget too tight" from "one chunk is
-        // uninterruptibly slow".
-        elapsed: started.elapsed(),
-        limit: budget,
-    })
-    .context("CLI export exceeded performance.query_timeout_ms"))
+    Err(export_expired(started, budget))
 }
 
 #[cfg(all(test, feature = "state_machine"))]

--- a/cqlite-cli/src/commands/export.rs
+++ b/cqlite-cli/src/commands/export.rs
@@ -763,15 +763,19 @@ async fn collect_chunk_within(
 /// the bounded await — so they cannot drift in operation name or reported figures.
 #[cfg(feature = "state_machine")]
 fn export_expired(started: std::time::Instant, budget: std::time::Duration) -> anyhow::Error {
-    anyhow::Error::new(cqlite_core::Error::QueryTimeout {
+    let err = cqlite_core::Error::QueryTimeout {
         operation: "cli.export.collect".to_string(),
         // MEASURED, not assumed equal to the budget: a slow chunk can overshoot, and
         // the real figure distinguishes "budget too tight" from "one chunk is
         // uninterruptibly slow".
         elapsed: started.elapsed(),
         limit: budget,
-    })
-    .context("CLI export exceeded performance.query_timeout_ms")
+    };
+    // #1695: same reasoning as `commands::query::expired` — record on the engine's
+    // own public observability sink so an export consumption elapse reaches
+    // `cqlite.errors.total{category="timeout"}`.
+    cqlite_core::observability::record_error(&err, "query");
+    anyhow::Error::new(err).context("CLI export exceeded performance.query_timeout_ms")
 }
 
 /// The export-side budget check (issue #1695), called before each chunk pull.

--- a/cqlite-cli/src/commands/export.rs
+++ b/cqlite-cli/src/commands/export.rs
@@ -141,6 +141,34 @@ pub async fn export_data(
     // Track timing for statistics
     let start_time = Instant::now();
 
+    // Issue #1695 — `performance.query_timeout_ms` must bound an EXPORT too.
+    //
+    // `cqlite export` is a streaming consumer exactly like `cqlite query`: the engine's
+    // chokepoint wrapper bounds `execute_streaming` above, and everything after it is
+    // this function's `collect_chunk` loops. Bounding only the query path left a
+    // runaway export scan running indefinitely after setup (roborev round 9) — the same
+    // placebo, in the command most likely to be pointed at a whole table.
+    //
+    // Setup was awaited ABOVE, outside this deadline, so a setup elapse stays the
+    // engine's to report; the export gets whatever of the budget is LEFT. Checked
+    // before each chunk pull rather than wrapping the 260-line per-format `match`:
+    // one chunk is this loop's unit of work, so the overshoot is bounded by one chunk
+    // and the writers/progress-bar borrows are left untouched.
+    let export_budget = database.config().query.max_execution_time;
+    let export_deadline = if export_budget.is_zero() {
+        // The documented "no timeout" sentinel.
+        None
+    } else {
+        // `checked_add` because the addend is operator config and `Instant + Duration`
+        // panics when unrepresentable; `None` then means unbounded, which is the right
+        // reading of an astronomically distant deadline.
+        tokio::time::Instant::now().checked_add(
+            export_budget
+                .checked_sub(start_time.elapsed())
+                .unwrap_or_default(),
+        )
+    };
+
     // Resolve the progress total from the CLI `--limit` (spec Option A / R5):
     // a determinate bar + ETA only when the user supplied an explicit limit,
     // otherwise the indeterminate spinner. Never infer a total from data shape.
@@ -171,6 +199,8 @@ pub async fn export_data(
                 if rows_remaining == Some(0) {
                     break;
                 }
+
+                check_export_deadline(export_deadline, start_time, export_budget)?;
 
                 let chunk = result_iter
                     .collect_chunk(chunk_size)
@@ -226,6 +256,8 @@ pub async fn export_data(
                 if rows_remaining == Some(0) {
                     break;
                 }
+
+                check_export_deadline(export_deadline, start_time, export_budget)?;
 
                 let chunk = result_iter
                     .collect_chunk(chunk_size)
@@ -299,6 +331,8 @@ pub async fn export_data(
                 if rows_remaining == Some(0) {
                     break;
                 }
+
+                check_export_deadline(export_deadline, start_time, export_budget)?;
 
                 let chunk = result_iter
                     .collect_chunk(chunk_size)
@@ -379,6 +413,8 @@ pub async fn export_data(
                 if rows_remaining == Some(0) {
                     break;
                 }
+
+                check_export_deadline(export_deadline, start_time, export_budget)?;
 
                 let chunk = result_iter
                     .collect_chunk(chunk_size)
@@ -660,5 +696,85 @@ mod tests {
         assert!(t.contains("{pos}"), "must show a row count: {t:?}");
         assert!(!t.contains("{eta}"), "must NOT show an ETA: {t:?}");
         assert!(!t.contains("{percent}"), "must NOT show a percent: {t:?}");
+    }
+}
+
+/// The export-side budget check (issue #1695), called before each chunk pull.
+///
+/// Deliberately a check rather than a `timeout_at` wrapper: the four consumption
+/// loops live inside a 260-line per-format `match` holding file writers and a
+/// progress bar, and wrapping that whole expression in an async block to make it
+/// cancellable would move every one of those borrows. Checking before each pull
+/// bounds the overshoot by ONE chunk — the loop's own unit of work — and changes no
+/// ownership.
+///
+/// `deadline` is `None` for the documented `Duration::ZERO` sentinel (unbounded) and
+/// also when the deadline is unrepresentable, which means the same thing.
+#[cfg(feature = "state_machine")]
+fn check_export_deadline(
+    deadline: Option<tokio::time::Instant>,
+    started: std::time::Instant,
+    budget: std::time::Duration,
+) -> Result<()> {
+    let Some(deadline) = deadline else {
+        return Ok(());
+    };
+    if tokio::time::Instant::now() < deadline {
+        return Ok(());
+    }
+    Err(anyhow::Error::new(cqlite_core::Error::QueryTimeout {
+        operation: "cli.export.collect".to_string(),
+        // MEASURED, not assumed equal to the budget: a slow chunk can overshoot,
+        // and the real figure distinguishes "budget too tight" from "one chunk is
+        // uninterruptibly slow".
+        elapsed: started.elapsed(),
+        limit: budget,
+    })
+    .context("CLI export exceeded performance.query_timeout_ms"))
+}
+
+#[cfg(all(test, feature = "state_machine"))]
+mod export_deadline_tests {
+    use super::check_export_deadline;
+    use std::time::Duration;
+
+    /// The `Duration::ZERO` sentinel reaches this as `None` and must never fail a
+    /// chunk pull — an unbounded export is a legal operator configuration.
+    #[test]
+    fn no_deadline_never_stops_an_export() {
+        assert!(
+            check_export_deadline(None, std::time::Instant::now(), Duration::ZERO).is_ok(),
+            "an unbounded export must not be interrupted"
+        );
+    }
+
+    /// An expired deadline must stop the export BEFORE the next chunk is pulled, and
+    /// must say so as the distinct timeout error carrying the export-side operation —
+    /// not the query-side one, so an operator can tell which loop elapsed.
+    ///
+    /// Deterministic by construction: the deadline is a full second in the past, so no
+    /// clock has to advance and no chunk has to be slow.
+    #[tokio::test]
+    async fn an_expired_deadline_stops_the_export_before_the_next_chunk() {
+        let budget = Duration::from_secs(30);
+        let err = check_export_deadline(
+            Some(tokio::time::Instant::now() - Duration::from_secs(1)),
+            std::time::Instant::now(),
+            budget,
+        )
+        .expect_err("an expired export deadline must stop the chunk loop");
+
+        match err.downcast_ref::<cqlite_core::Error>() {
+            Some(cqlite_core::Error::QueryTimeout {
+                operation, limit, ..
+            }) => {
+                assert_eq!(
+                    operation, "cli.export.collect",
+                    "must name the EXPORT loop, distinct from `cli.query.collect`"
+                );
+                assert_eq!(limit, &budget);
+            }
+            other => panic!("expected QueryTimeout, got {other:?}"),
+        }
     }
 }

--- a/cqlite-cli/src/commands/mod.rs
+++ b/cqlite-cli/src/commands/mod.rs
@@ -47,7 +47,7 @@ pub use export_sstable::export_sstable;
 pub use import::import_data;
 pub use inspect::{analyze_sstable, validate_sstable};
 #[cfg(feature = "state_machine")]
-pub use query::collect_query_result;
+pub use query::{collect_query_result, collect_rows_until};
 pub use query::{execute_query, execute_select_query};
 pub use read::{read_sstable, read_sstable_enhanced};
 pub(crate) use schema_load::load_schema_file;

--- a/cqlite-cli/src/commands/query.rs
+++ b/cqlite-cli/src/commands/query.rs
@@ -229,7 +229,13 @@ pub async fn collect_query_result(
         // remainder, both mean setup consumed the whole budget — so consumption gets
         // a deadline already in the past rather than an unbounded run.
         let remaining = budget.checked_sub(started.elapsed()).unwrap_or_default();
-        Some(tokio::time::Instant::now() + remaining)
+        // `Instant + Duration` PANICS when the sum is unrepresentable, and `remaining`
+        // derives from operator config (`performance.query_timeout_ms`), so a huge
+        // value must not abort the process. `checked_add` returning `None` lands on
+        // the same `None` this function already uses for "unbounded" — which is the
+        // right meaning, since an unrepresentable deadline is astronomically far
+        // away. Mirrors the core's treatment in `deadline::bound_tracked`.
+        tokio::time::Instant::now().checked_add(remaining)
     };
 
     collect_rows_until(iter, display_limit, deadline, started, budget).await
@@ -253,10 +259,23 @@ pub async fn collect_rows_until(
     started: std::time::Instant,
     budget: std::time::Duration,
 ) -> Result<cqlite_core::query::result::QueryResult> {
-    let collect = collect_streamed_rows(iter, display_limit);
     let Some(deadline) = deadline else {
-        return collect.await;
+        return collect_streamed_rows(iter, display_limit).await;
     };
+
+    // Reject an ALREADY-EXPIRED deadline before polling collection at all.
+    // `timeout_at` polls its inner future FIRST and only then consults the deadline,
+    // so an expired deadline still returns `Ok` whenever collection happens to be
+    // immediately ready — `display_limit = Some(0)` breaks the loop on its first
+    // iteration, and a fully buffered stream can complete without yielding. Relying
+    // on `timeout_at` alone therefore made "expired means timeout before pulling
+    // rows" true only for streams that happen not to be ready (roborev round 7);
+    // this makes it true by construction, which is also what lets the test assert it.
+    if deadline <= tokio::time::Instant::now() {
+        return Err(expired(started, budget));
+    }
+
+    let collect = collect_streamed_rows(iter, display_limit);
     match tokio::time::timeout_at(deadline, collect).await {
         Ok(result) => result,
         // Dropping `collect` drops the iterator, closing the channel and retiring the
@@ -268,16 +287,24 @@ pub async fn collect_rows_until(
         // in consumption. Closing it properly means carrying the deadline into the
         // core streaming producer so core owns and records it — which is the
         // per-batch bound the issue explicitly deferred. Follow-up.
-        Err(_elapsed) => Err(anyhow::Error::new(cqlite_core::Error::QueryTimeout {
-            operation: "cli.query.collect".to_string(),
-            // MEASURED, never assumed equal to the budget: a blocked poll can
-            // overshoot, and the real figure tells an operator "budget too tight"
-            // from "one decode unit is uninterruptibly slow".
-            elapsed: started.elapsed(),
-            limit: budget,
-        })
-        .context("CLI query exceeded performance.query_timeout_ms")),
+        Err(_elapsed) => Err(expired(started, budget)),
     }
+}
+
+/// The CLI-layer collection elapse. One constructor for both exits (the up-front
+/// expired-deadline check and the `timeout_at` arm) so they cannot drift in
+/// operation name, reported figures or context.
+#[cfg(feature = "state_machine")]
+fn expired(started: std::time::Instant, budget: std::time::Duration) -> anyhow::Error {
+    anyhow::Error::new(cqlite_core::Error::QueryTimeout {
+        operation: "cli.query.collect".to_string(),
+        // MEASURED, never assumed equal to the budget: a blocked poll can overshoot,
+        // and the real figure tells an operator "budget too tight" from "one decode
+        // unit is uninterruptibly slow".
+        elapsed: started.elapsed(),
+        limit: budget,
+    })
+    .context("CLI query exceeded performance.query_timeout_ms")
 }
 
 /// The unbounded consumption loop; [`collect_rows_until`] applies the deadline.

--- a/cqlite-cli/src/commands/query.rs
+++ b/cqlite-cli/src/commands/query.rs
@@ -194,6 +194,58 @@ pub async fn collect_query_result(
 ) -> Result<cqlite_core::query::result::QueryResult> {
     use cqlite_core::query::result::{QueryResult, StreamingConfig};
 
+    // Issue #1695 — the operator's budget must cover THIS loop, not just setup.
+    //
+    // The engine's ONE chokepoint wrapper bounds the `execute_streaming` FUTURE,
+    // i.e. stream setup and time-to-first-batch. It structurally cannot bound what
+    // happens after that future returns, and what happens after it returns is where
+    // a CLI query spends ~all of its time: the `next_async()` loop below drives the
+    // incremental scan. Since the CLI is the only consumer that sets
+    // `performance.query_timeout_ms`, leaving consumption unbounded would leave the
+    // knob a placebo on the exact runaway full scan #1695 exists to bound.
+    //
+    // This is a SECOND bound at a DIFFERENT layer, not a second bound on the engine
+    // path, and it does NOT restart the engine's clock: the two run concurrently
+    // from nearly the same instant with the same duration, so setup overrunning the
+    // budget trips both at once and the caller sees `QueryTimeout` either way. The
+    // engine entry point remains bounded exactly once.
+    let budget = database.config().query.max_execution_time;
+    let started = std::time::Instant::now();
+    let collect = collect_streamed_rows(database, query, display_limit);
+
+    // `Duration::ZERO` is the documented "no timeout" sentinel — await directly
+    // rather than arming a zero timer, which would elapse at the first yield.
+    if budget.is_zero() {
+        return collect.await;
+    }
+    match tokio::time::timeout(budget, collect).await {
+        Ok(result) => result,
+        // Dropping `collect` drops the iterator, which closes the channel and
+        // retires the producer — the same teardown the `--limit` break relies on.
+        Err(_elapsed) => Err(anyhow::Error::new(cqlite_core::Error::QueryTimeout {
+            operation: "cli.query.collect".to_string(),
+            // MEASURED, never assumed equal to the budget: a blocked poll can
+            // overshoot, and the real figure is what tells an operator "budget too
+            // tight" from "one decode unit is uninterruptibly slow".
+            elapsed: started.elapsed(),
+            limit: budget,
+        })
+        .context("CLI query exceeded performance.query_timeout_ms")),
+    }
+}
+
+/// The unbounded body of [`collect_query_result`]; that caller applies the
+/// operator's budget. Kept separate so the bound wraps setup AND consumption as
+/// one future — a bound applied inside this function could not cover its own
+/// `execute_streaming` await.
+#[cfg(feature = "state_machine")]
+async fn collect_streamed_rows(
+    database: &Database,
+    query: &str,
+    display_limit: Option<usize>,
+) -> Result<cqlite_core::query::result::QueryResult> {
+    use cqlite_core::query::result::{QueryResult, StreamingConfig};
+
     let mut iter = database
         .execute_streaming(query, StreamingConfig::default())
         .await?;

--- a/cqlite-cli/src/commands/query.rs
+++ b/cqlite-cli/src/commands/query.rs
@@ -296,15 +296,30 @@ pub async fn collect_rows_until(
 /// operation name, reported figures or context.
 #[cfg(feature = "state_machine")]
 fn expired(started: std::time::Instant, budget: std::time::Duration) -> anyhow::Error {
-    anyhow::Error::new(cqlite_core::Error::QueryTimeout {
+    let err = cqlite_core::Error::QueryTimeout {
         operation: "cli.query.collect".to_string(),
         // MEASURED, never assumed equal to the budget: a blocked poll can overshoot,
         // and the real figure tells an operator "budget too tight" from "one decode
         // unit is uninterruptibly slow".
         elapsed: started.elapsed(),
         limit: budget,
-    })
-    .context("CLI query exceeded performance.query_timeout_ms")
+    };
+    // #1695 (roborev raised this in five rounds): record the timeout on the SAME
+    // observability error stream the engine uses, so a consumption-phase elapse is
+    // not invisible to `cqlite.errors.total{category="timeout"}`. Consumption is
+    // where a CLI scan spends its time, so without this a dashboard could read zero
+    // timeouts while operators were seeing them.
+    //
+    // `record_error` is the engine's own public sink, not a second mechanism, and the
+    // two callers observe DISJOINT events — the engine records a SETUP elapse, this
+    // records a CONSUMPTION elapse — so nothing is double counted.
+    //
+    // Still NOT covered, and narrower than before: the engine's `error_queries`
+    // counter, which is private query accounting for work the engine itself executed.
+    // The CLI's consumption phase is not an engine query execution, so folding it in
+    // there would misreport that counter's meaning.
+    cqlite_core::observability::record_error(&err, "query");
+    anyhow::Error::new(err).context("CLI query exceeded performance.query_timeout_ms")
 }
 
 /// The unbounded consumption loop; [`collect_rows_until`] applies the deadline.

--- a/cqlite-cli/src/commands/query.rs
+++ b/cqlite-cli/src/commands/query.rs
@@ -192,41 +192,87 @@ pub async fn collect_query_result(
     query: &str,
     display_limit: Option<usize>,
 ) -> Result<cqlite_core::query::result::QueryResult> {
-    use cqlite_core::query::result::{QueryResult, StreamingConfig};
+    use cqlite_core::query::result::StreamingConfig;
 
-    // Issue #1695 — the operator's budget must cover THIS loop, not just setup.
+    // Issue #1695 — the operator's budget must cover CONSUMPTION, not just setup.
     //
-    // The engine's ONE chokepoint wrapper bounds the `execute_streaming` FUTURE,
-    // i.e. stream setup and time-to-first-batch. It structurally cannot bound what
-    // happens after that future returns, and what happens after it returns is where
-    // a CLI query spends ~all of its time: the `next_async()` loop below drives the
-    // incremental scan. Since the CLI is the only consumer that sets
-    // `performance.query_timeout_ms`, leaving consumption unbounded would leave the
-    // knob a placebo on the exact runaway full scan #1695 exists to bound.
+    // The engine's ONE chokepoint wrapper bounds the `execute_streaming` FUTURE, i.e.
+    // setup and time-to-first-batch. It structurally cannot bound what happens after
+    // that future returns, and that is where a CLI query spends essentially all of
+    // its time: the `next_async()` loop drives the incremental scan. Since the CLI is
+    // the only consumer that sets `performance.query_timeout_ms`, leaving consumption
+    // unbounded leaves the knob a placebo on the runaway full scan #1695 exists to
+    // bound.
     //
-    // This is a SECOND bound at a DIFFERENT layer, not a second bound on the engine
-    // path, and it does NOT restart the engine's clock: the two run concurrently
-    // from nearly the same instant with the same duration, so setup overrunning the
-    // budget trips both at once and the caller sees `QueryTimeout` either way. The
-    // engine entry point remains bounded exactly once.
+    // SETUP IS AWAITED OUTSIDE ANY CLI TIMEOUT, deliberately (roborev round 6). An
+    // earlier revision wrapped setup AND consumption in one CLI timeout, which
+    // started microseconds BEFORE the engine's identical-duration bound and so always
+    // won the race — dropping the engine's future before its `bounded()` could record
+    // the elapse, and silently costing `error_queries` and
+    // `cqlite.errors.total{category="timeout"}` an event the engine was supposed to
+    // own. Now a setup elapse belongs to the engine, is recorded by the engine, and
+    // propagates through `?`; the CLI bounds only what the engine cannot reach, using
+    // whatever of the budget is LEFT.
     let budget = database.config().query.max_execution_time;
     let started = std::time::Instant::now();
-    let collect = collect_streamed_rows(database, query, display_limit);
 
-    // `Duration::ZERO` is the documented "no timeout" sentinel — await directly
-    // rather than arming a zero timer, which would elapse at the first yield.
-    if budget.is_zero() {
+    let iter = database
+        .execute_streaming(query, StreamingConfig::default())
+        .await?;
+
+    // `Duration::ZERO` is the documented "no timeout" sentinel: no deadline at all.
+    let deadline = if budget.is_zero() {
+        None
+    } else {
+        // NOTE the asymmetry with the sentinel: a REMAINING budget of zero means
+        // EXPIRED, not unbounded. `checked_sub` returning `None`, or a zero
+        // remainder, both mean setup consumed the whole budget — so consumption gets
+        // a deadline already in the past rather than an unbounded run.
+        let remaining = budget.checked_sub(started.elapsed()).unwrap_or_default();
+        Some(tokio::time::Instant::now() + remaining)
+    };
+
+    collect_rows_until(iter, display_limit, deadline, started, budget).await
+}
+
+/// Drain a streaming query into a `QueryResult`, abandoning it at `deadline`.
+///
+/// `deadline` is an ABSOLUTE instant rather than a duration so that "already
+/// expired" is expressible and therefore TESTABLE BY CONSTRUCTION: a caller can
+/// pass an instant in the past and `timeout_at` reports `Elapsed` on the first poll,
+/// with no reliance on a clock advancing during the test (roborev round 6, the same
+/// correction applied to the core's `bound_tracked_until`). `None` means unbounded.
+///
+/// `started`/`budget` are carried only to report the MEASURED elapsed and the
+/// configured limit in the error — never to re-derive the deadline.
+#[cfg(feature = "state_machine")]
+pub async fn collect_rows_until(
+    iter: cqlite_core::query::result::QueryResultIterator,
+    display_limit: Option<usize>,
+    deadline: Option<tokio::time::Instant>,
+    started: std::time::Instant,
+    budget: std::time::Duration,
+) -> Result<cqlite_core::query::result::QueryResult> {
+    let collect = collect_streamed_rows(iter, display_limit);
+    let Some(deadline) = deadline else {
         return collect.await;
-    }
-    match tokio::time::timeout(budget, collect).await {
+    };
+    match tokio::time::timeout_at(deadline, collect).await {
         Ok(result) => result,
-        // Dropping `collect` drops the iterator, which closes the channel and
-        // retires the producer — the same teardown the `--limit` break relies on.
+        // Dropping `collect` drops the iterator, closing the channel and retiring the
+        // producer — the same teardown the `--limit` break relies on.
+        //
+        // KNOWN GAP, documented rather than papered over: this CLI-layer elapse does
+        // NOT increment `error_queries` or the timeout telemetry counter, because
+        // `inc_error_queries` is private to the engine and the engine is not involved
+        // in consumption. Closing it properly means carrying the deadline into the
+        // core streaming producer so core owns and records it — which is the
+        // per-batch bound the issue explicitly deferred. Follow-up.
         Err(_elapsed) => Err(anyhow::Error::new(cqlite_core::Error::QueryTimeout {
             operation: "cli.query.collect".to_string(),
             // MEASURED, never assumed equal to the budget: a blocked poll can
-            // overshoot, and the real figure is what tells an operator "budget too
-            // tight" from "one decode unit is uninterruptibly slow".
+            // overshoot, and the real figure tells an operator "budget too tight"
+            // from "one decode unit is uninterruptibly slow".
             elapsed: started.elapsed(),
             limit: budget,
         })
@@ -234,21 +280,13 @@ pub async fn collect_query_result(
     }
 }
 
-/// The unbounded body of [`collect_query_result`]; that caller applies the
-/// operator's budget. Kept separate so the bound wraps setup AND consumption as
-/// one future — a bound applied inside this function could not cover its own
-/// `execute_streaming` await.
+/// The unbounded consumption loop; [`collect_rows_until`] applies the deadline.
 #[cfg(feature = "state_machine")]
 async fn collect_streamed_rows(
-    database: &Database,
-    query: &str,
+    mut iter: cqlite_core::query::result::QueryResultIterator,
     display_limit: Option<usize>,
 ) -> Result<cqlite_core::query::result::QueryResult> {
-    use cqlite_core::query::result::{QueryResult, StreamingConfig};
-
-    let mut iter = database
-        .execute_streaming(query, StreamingConfig::default())
-        .await?;
+    use cqlite_core::query::result::QueryResult;
 
     let mut rows = Vec::new();
     loop {

--- a/cqlite-cli/src/core_config.rs
+++ b/cqlite-cli/src/core_config.rs
@@ -1,0 +1,95 @@
+//! CLI configuration → core (`cqlite_core::Config`) translation.
+//!
+//! Split out of `main.rs` (issue #1695) so the mapping is a LIBRARY surface an
+//! end-to-end test can exercise: `main.rs` is a binary target, so anything living
+//! there is unreachable from an integration test, and a knob whose wiring cannot
+//! be tested is a knob that silently rots. The binary's `create_core_config` is
+//! now a one-line delegation to [`to_core_config`].
+//!
+//! # The wired knobs
+//!
+//! | CLI (`[performance]`)  | core field                          |
+//! |------------------------|-------------------------------------|
+//! | `memory_limit_mb`      | `memory.max_memory`                 |
+//! | `cache_size_mb`        | `memory.block_cache.max_size`       |
+//! | `query_timeout_ms`     | `query.max_execution_time` (#1695)  |
+//!
+//! `query_timeout_ms` is the operator's query execution budget, ENFORCED at the
+//! query-engine chokepoint (`cqlite_core::query::engine::deadline`). **`0` means
+//! no timeout** — it maps to `Duration::ZERO`, the core's documented unbounded
+//! sentinel.
+
+use anyhow::Result;
+use cqlite_core::Config as CoreConfig;
+
+use crate::config::Config as CliConfig;
+
+/// Convert CLI configuration to core database configuration.
+///
+/// The returned config is already `validate()`d, so a caller can hand it
+/// straight to `Database::open`.
+pub fn to_core_config(cli_config: &CliConfig) -> Result<CoreConfig> {
+    let mut core_config = CoreConfig::default();
+
+    // Apply CLI configuration settings to core config
+    if let Some(memory_limit_mb) = cli_config.performance.memory_limit_mb {
+        core_config.memory.max_memory = memory_limit_mb * 1024 * 1024; // Convert MB to bytes
+    }
+
+    // Set cache size from CLI config
+    core_config.memory.block_cache.max_size = cli_config.performance.cache_size_mb * 1024 * 1024; // Convert MB to bytes
+
+    // Set the query execution budget (issue #1695). `query_timeout_ms = 0` maps to
+    // `Duration::ZERO`, the core's documented "no timeout" sentinel.
+    core_config.query.max_execution_time =
+        std::time::Duration::from_millis(cli_config.performance.query_timeout_ms);
+
+    // Enable optimizations for better performance
+    core_config.query.enable_optimization = true;
+    core_config.storage.enable_bloom_filters = true;
+
+    // Validate the configuration
+    core_config
+        .validate()
+        .map_err(|e| anyhow::anyhow!("Invalid database configuration: {}", e))?;
+
+    Ok(core_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// The CLI knob must land on the field the engine actually enforces — the
+    /// unit conversion included (issue #1695).
+    #[test]
+    fn query_timeout_ms_maps_to_max_execution_time() {
+        let mut cli = CliConfig::default();
+        cli.performance.query_timeout_ms = 1;
+        let core = to_core_config(&cli).expect("valid config");
+        assert_eq!(core.query.max_execution_time, Duration::from_millis(1));
+
+        cli.performance.query_timeout_ms = 30_000;
+        let core = to_core_config(&cli).expect("valid config");
+        assert_eq!(core.query.max_execution_time, Duration::from_secs(30));
+    }
+
+    /// `0` is the documented "no timeout" spelling of the knob and must reach the
+    /// core as `Duration::ZERO` (its unbounded sentinel), not as an instantly
+    /// expiring budget or a validation error.
+    #[test]
+    fn zero_query_timeout_ms_is_the_unbounded_sentinel() {
+        let mut cli = CliConfig::default();
+        cli.performance.query_timeout_ms = 0;
+        let core = to_core_config(&cli).expect("0 must be a VALID configuration");
+        assert_eq!(core.query.max_execution_time, Duration::ZERO);
+    }
+
+    /// The shipped CLI default (30s) must survive the mapping.
+    #[test]
+    fn shipped_default_is_thirty_seconds() {
+        let core = to_core_config(&CliConfig::default()).expect("valid config");
+        assert_eq!(core.query.max_execution_time, Duration::from_secs(30));
+    }
+}

--- a/cqlite-cli/src/lib.rs
+++ b/cqlite-cli/src/lib.rs
@@ -21,6 +21,11 @@
 pub mod cli;
 pub mod commands;
 pub mod config;
+
+// CLI -> core configuration mapping (issue #1695): a LIBRARY surface so the
+// wiring of `performance.query_timeout_ms` onto the enforced
+// `query.max_execution_time` is end-to-end testable.
+pub mod core_config;
 pub mod error;
 pub mod status_metrics;
 

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -1271,10 +1271,20 @@ fn is_dml_statement(query: &str) -> bool {
 
 /// Convert CLI configuration to core database configuration.
 ///
-/// Delegates to the library surface (`cqlite_cli::core_config::to_core_config`,
-/// issue #1695) so the mapping — including `performance.query_timeout_ms` →
-/// `query.max_execution_time`, the knob the engine enforces — is reachable from
-/// an integration test instead of being locked inside this binary target.
+/// Delegates to `core_config::to_core_config` (issue #1695) so the mapping —
+/// including `performance.query_timeout_ms` → `query.max_execution_time`, the
+/// knob the engine enforces — lives in a module an integration test can import.
+///
+/// PRECISELY, because an earlier version of this comment overclaimed: this
+/// resolves to the BINARY-LOCAL `mod core_config` declared above, not to
+/// `cqlite_cli::core_config`. `cqlite-cli` compiles every one of these modules
+/// TWICE — once into the lib, once into this bin — so the integration test
+/// exercises a SEPARATE COMPILED COPY of the same source file. Behaviour is
+/// identical today and the mapping is genuinely covered, but the test is not
+/// evidence about this binary's copy, and the two could drift. Unifying them
+/// means routing the bin through `cqlite_cli::{config, core_config, error}`,
+/// which is a pre-existing CLI-wide duplication rather than anything #1695
+/// introduced — tracked as a follow-up, not fixed here.
 fn create_core_config(cli_config: &config::Config) -> Result<CoreConfig> {
     core_config::to_core_config(cli_config)
 }

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -21,6 +21,7 @@ mod cli;
 mod cli_types;
 mod commands;
 mod config;
+mod core_config;
 mod error;
 mod formatter;
 mod output;
@@ -1268,32 +1269,14 @@ fn is_dml_statement(query: &str) -> bool {
     cqlite_core::cql::is_dml_statement(query)
 }
 
-/// Convert CLI configuration to core database configuration
+/// Convert CLI configuration to core database configuration.
+///
+/// Delegates to the library surface (`cqlite_cli::core_config::to_core_config`,
+/// issue #1695) so the mapping — including `performance.query_timeout_ms` →
+/// `query.max_execution_time`, the knob the engine enforces — is reachable from
+/// an integration test instead of being locked inside this binary target.
 fn create_core_config(cli_config: &config::Config) -> Result<CoreConfig> {
-    let mut core_config = CoreConfig::default();
-
-    // Apply CLI configuration settings to core config
-    if let Some(memory_limit_mb) = cli_config.performance.memory_limit_mb {
-        core_config.memory.max_memory = memory_limit_mb * 1024 * 1024; // Convert MB to bytes
-    }
-
-    // Set cache size from CLI config
-    core_config.memory.block_cache.max_size = cli_config.performance.cache_size_mb * 1024 * 1024; // Convert MB to bytes
-
-    // Set query timeout
-    core_config.query.max_execution_time =
-        std::time::Duration::from_millis(cli_config.performance.query_timeout_ms);
-
-    // Enable optimizations for better performance
-    core_config.query.enable_optimization = true;
-    core_config.storage.enable_bloom_filters = true;
-
-    // Validate the configuration
-    core_config
-        .validate()
-        .map_err(|e| anyhow::anyhow!("Invalid database configuration: {}", e))?;
-
-    Ok(core_config)
+    core_config::to_core_config(cli_config)
 }
 
 /// Extract table name from query for schema validation (Issue #199)

--- a/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
+++ b/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
@@ -48,11 +48,12 @@ mod datasets_root;
 
 use std::time::Duration;
 
-use cqlite_cli::commands::collect_query_result;
+use cqlite_cli::commands::{collect_query_result, collect_rows_until};
 use cqlite_cli::config::Config as CliConfig;
 use cqlite_cli::core_config::to_core_config;
 use cqlite_cli::error::{classify_error, CliExitCode};
 use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
 use cqlite_core::{Database, Error};
 
 use datasets_root::{describe_search, schema_path, sstables_root_for_table};
@@ -229,6 +230,84 @@ async fn zero_query_timeout_ms_leaves_the_cli_collection_path_unbounded() {
     assert!(
         !result.rows.is_empty(),
         "0-rows-when-the-fixture-is-present is a failure, not a pass (#3220)"
+    );
+}
+
+/// The DETERMINISTIC, ALWAYS-RUNNING proof that the CLI's COLLECTION LOOP — not
+/// merely stream setup — is the thing under a deadline (roborev round 6).
+///
+/// The two tests above cannot establish this on their own: the 1ms one lets either
+/// the engine's setup bound or the CLI's collection bound fire, so deleting the
+/// collection bound could still pass it, and it skips when the fetched fixture is
+/// absent. This one removes both weaknesses:
+///
+/// * **Deterministic** — `collect_rows_until` takes an ABSOLUTE deadline, so a
+///   deadline in the PAST makes `timeout_at` report `Elapsed` on its first poll. No
+///   clock has to advance, no scan has to be slow, and no row is ever pulled.
+/// * **Always runs** — a COMMITTED fixture, so there is no skip path.
+/// * **Discriminating** — asserts the `cli.query.collect` operation, which only the
+///   CLI-layer bound produces. An engine setup elapse would name a `query.*`
+///   operation and fail this assertion, so the test cannot be satisfied by the
+///   wrong layer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_expired_deadline_abandons_the_cli_collection_loop_without_pulling_rows() {
+    // `query_timeout_ms = 0` so SETUP is unbounded and cannot be what fails; the
+    // deadline under test is supplied directly below.
+    let db = open_via_cli_config(
+        "test_comp",
+        "incompressible_uncompressed_chunk",
+        "compression-parity.cql",
+        true,
+        0,
+    )
+    .await
+    .expect("the COMMITTED fixture can never skip");
+
+    let iter = db
+        .execute_streaming(
+            "SELECT * FROM test_comp.incompressible_uncompressed_chunk",
+            StreamingConfig::default(),
+        )
+        .await
+        .expect("stream setup is unbounded here, so it must succeed");
+
+    let budget = Duration::from_secs(30);
+    let err = collect_rows_until(
+        iter,
+        None,
+        // ONE SECOND IN THE PAST: expiry holds by construction.
+        Some(tokio::time::Instant::now() - Duration::from_secs(1)),
+        std::time::Instant::now(),
+        budget,
+    )
+    .await
+    .expect_err(
+        "REGRESSION (issue #1695): an already-expired deadline must abandon the CLI          collection loop. If this returns rows, the consumption bound is gone and the          operator's knob is a placebo on the streaming path the CLI actually uses.",
+    );
+
+    let core = err
+        .downcast_ref::<Error>()
+        .expect("the CLI-layer elapse must carry a cqlite_core::Error");
+    match core {
+        Error::QueryTimeout {
+            operation, limit, ..
+        } => {
+            assert_eq!(
+                operation, "cli.query.collect",
+                "must be the CLI COLLECTION bound, not the engine's setup bound —                  otherwise this test would pass with the collection bound deleted"
+            );
+            assert_eq!(
+                limit, &budget,
+                "the reported limit must be the budget given"
+            );
+        }
+        other => panic!("expected QueryTimeout, got {other}"),
+    }
+
+    assert_eq!(
+        classify_error(&err),
+        CliExitCode::QueryExecutionError,
+        "a CLI collection-budget elapse must still map to exit code 5"
     );
 }
 

--- a/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
+++ b/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
@@ -16,7 +16,17 @@
 //! ```
 //!
 //! `main.rs`'s `create_core_config` is a one-line delegation to
-//! `to_core_config`, so the binary and this test exercise the same mapping.
+//! `to_core_config` — the same SOURCE the binary's mapping lives in.
+//!
+//! SCOPE OF THIS EVIDENCE, stated because the previous wording overclaimed
+//! ("the binary and this test exercise the same mapping"): `cqlite-cli` compiles
+//! `config`/`core_config`/`error` twice, once into the lib and once into the bin,
+//! so this test drives the LIB copy while the shipped binary runs its own. The
+//! mapping and the exit-code classification are really covered, and they cannot
+//! silently differ in BEHAVIOUR while the source is shared — but this is not an
+//! end-to-end proof that the `cqlite` executable exits 5. That needs a
+//! `CARGO_BIN_EXE_cqlite` spawn, proposed as a follow-up along with unifying the
+//! bin onto the library modules (a pre-existing CLI-wide duplication).
 //!
 //! # Fixtures
 //!

--- a/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
+++ b/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
@@ -1,0 +1,170 @@
+//! Issue #1695: END-TO-END wiring evidence for `performance.query_timeout_ms`.
+//!
+//! # What this lane proves
+//!
+//! The CLI knob is not decoration: it reaches the field the query engine
+//! enforces, and a query that exceeds it fails with the CLI's query-execution
+//! exit code. The chain asserted here, in order:
+//!
+//! ```text
+//! cqlite_cli::config::PerformanceConfig::query_timeout_ms   (the operator knob)
+//!   -> cqlite_cli::core_config::to_core_config              (the mapping, #1695)
+//!   -> cqlite_core::Config.query.max_execution_time         (the enforced field)
+//!   -> Database::execute -> QueryEngine::execute            (the chokepoint bound)
+//!   -> cqlite_core::Error::QueryTimeout                     (the typed outcome)
+//!   -> cqlite_cli::error::classify_error -> exit code 5     (the operator contract)
+//! ```
+//!
+//! `main.rs`'s `create_core_config` is a one-line delegation to
+//! `to_core_config`, so the binary and this test exercise the same mapping.
+//!
+//! # Fixtures
+//!
+//! The knob's unit is MILLISECONDS, so demonstrating an elapse needs a scan that
+//! reliably takes longer than 1ms: the corpus's largest FETCHED table (~650 KiB /
+//! 1000 partitions). Its binaries are gitignored, so that case skips clean on a
+//! minimal checkout (and fails closed under `CQLITE_REQUIRE_FIXTURES=1`). The
+//! `0` = unbounded direction needs no timing and uses a COMMITTED fixture, so it
+//! always runs. No wall-clock threshold is asserted anywhere (issue #2642).
+
+#![cfg(feature = "cli-helpers")]
+
+// The shared TABLE-granular fixture resolver (issue #3220). Included by path
+// because it lives in cqlite-core's test tree; its own nested `#[path]` to
+// `test-data/support/fixture_roots.rs` resolves relative to THAT file, and its
+// repo-root anchor is the workspace `Cargo.toml`, so both work from this crate.
+#[path = "../../cqlite-core/tests/support/datasets_root.rs"]
+mod datasets_root;
+
+use std::time::Duration;
+
+use cqlite_cli::config::Config as CliConfig;
+use cqlite_cli::core_config::to_core_config;
+use cqlite_cli::error::{classify_error, CliExitCode};
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::{Database, Error};
+
+use datasets_root::{describe_search, schema_path, sstables_root_for_table};
+
+/// `true` when the dataset-dependent lanes must fail rather than skip.
+fn require_fixtures() -> bool {
+    matches!(
+        std::env::var("CQLITE_REQUIRE_FIXTURES").ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE")
+    )
+}
+
+/// Open a fixture `Database` through the CLI's OWN configuration mapping, with
+/// `query_timeout_ms` as the only knob varied. Returns `None` (skip-clean) when a
+/// non-committed fixture is absent.
+async fn open_via_cli_config(
+    keyspace: &str,
+    table: &str,
+    schema_file: &str,
+    committed: bool,
+    query_timeout_ms: u64,
+) -> Option<Database> {
+    let Some(root) = sstables_root_for_table(keyspace, table) else {
+        assert!(
+            !committed && !require_fixtures(),
+            "fixture must resolve (fail-closed): {}",
+            describe_search(keyspace, table)
+        );
+        eprintln!(
+            "SKIP: fetched fixture absent ({keyspace}.{table}); {} — set \
+             CQLITE_REQUIRE_FIXTURES=1 to enforce.",
+            describe_search(keyspace, table)
+        );
+        return None;
+    };
+    let schema = schema_path(schema_file).expect("committed schema must be readable (#3148)");
+
+    // THE WIRING UNDER TEST: the operator sets milliseconds in the CLI config,
+    // and nothing else in this test touches `max_execution_time`.
+    let mut cli_config = CliConfig::default();
+    cli_config.performance.query_timeout_ms = query_timeout_ms;
+    let core_config =
+        to_core_config(&cli_config).expect("CLI config must map to a valid core config");
+    assert_eq!(
+        core_config.query.max_execution_time,
+        Duration::from_millis(query_timeout_ms),
+        "the CLI knob must land on the field the engine enforces"
+    );
+
+    let result = ingest(IngestionConfig {
+        schema_paths: vec![schema],
+        data_dir: root,
+        version_hint: None,
+        core_config,
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    })
+    .await
+    .expect("ingestion of the fixture");
+    assert!(
+        result.schema_load_result.schemas_loaded > 0,
+        "schema must load"
+    );
+    Some(result.database)
+}
+
+/// `query_timeout_ms = 1` + a multi-millisecond real scan ⇒ the query fails with
+/// the timeout error, and the CLI classifies it as a query-execution failure
+/// (exit code 5) rather than as a data/corruption or data-dir problem.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_timeout_ms_bounds_a_cli_query_and_maps_to_exit_code_5() {
+    let Some(db) =
+        open_via_cli_config("test_basic", "simple_table", "basic-types.cql", false, 1).await
+    else {
+        return;
+    };
+
+    let outcome = db.execute("SELECT * FROM test_basic.simple_table").await;
+    let err = match outcome {
+        Err(e) => e,
+        Ok(result) => panic!(
+            "REGRESSION (issue #1695): the CLI's performance.query_timeout_ms = 1 was IGNORED — \
+             the scan completed with {} rows. The knob is a placebo again.",
+            result.rows.len()
+        ),
+    };
+    assert!(
+        matches!(err, Error::QueryTimeout { .. }),
+        "the budget must surface as the distinct timeout error, not as an unrelated \
+         failure: {err}"
+    );
+
+    // The operator contract: a timed-out query exits 5 (query execution), never 3
+    // (schema) or 4 (data dir).
+    let exit = classify_error(&anyhow::Error::new(err));
+    assert_eq!(
+        exit,
+        CliExitCode::QueryExecutionError,
+        "a query-budget elapse must map to the query-execution exit code"
+    );
+}
+
+/// `query_timeout_ms = 0` is the documented "no timeout" spelling: it reaches the
+/// core as `Duration::ZERO` and the query runs unbounded (non-empty result, so
+/// this cannot pass on an empty fixture). Uses a COMMITTED fixture, so it always
+/// runs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zero_query_timeout_ms_leaves_a_cli_query_unbounded() {
+    let db = open_via_cli_config(
+        "test_comp",
+        "incompressible_uncompressed_chunk",
+        "compression-parity.cql",
+        true,
+        0,
+    )
+    .await
+    .expect("the COMMITTED fixture can never skip");
+
+    let result = db
+        .execute("SELECT * FROM test_comp.incompressible_uncompressed_chunk")
+        .await
+        .expect("query_timeout_ms = 0 must mean UNBOUNDED, not an instant elapse");
+    assert!(
+        !result.rows.is_empty(),
+        "the committed fixture must yield rows — a 0-row pass would make this vacuous"
+    );
+}

--- a/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
+++ b/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
@@ -48,6 +48,7 @@ mod datasets_root;
 
 use std::time::Duration;
 
+use cqlite_cli::commands::collect_query_result;
 use cqlite_cli::config::Config as CliConfig;
 use cqlite_cli::core_config::to_core_config;
 use cqlite_cli::error::{classify_error, CliExitCode};
@@ -150,6 +151,84 @@ async fn query_timeout_ms_bounds_a_cli_query_and_maps_to_exit_code_5() {
         exit,
         CliExitCode::QueryExecutionError,
         "a query-budget elapse must map to the query-execution exit code"
+    );
+}
+
+/// The ACTUAL CLI query path (`commands::collect_query_result`, which is what
+/// `cqlite query` and `cqlite export` call) must honour the budget — not just
+/// `Database::execute`.
+///
+/// This is the lane that matters most for #1695's stated problem. The CLI routes
+/// queries through `execute_streaming` + a `next_async()` loop, and the engine's
+/// chokepoint wrapper can only bound the SETUP future; everything after it returns
+/// is where a CLI scan spends its time. Without the CLI-layer bound the operator's
+/// knob is a placebo on exactly the runaway full scan it exists to stop, even
+/// though `Database::execute` (covered above) is correctly bounded.
+///
+/// SCOPE, stated rather than implied: this asserts the operator CONTRACT — a
+/// timeout error and exit 5 — and deliberately does NOT assert which layer tripped.
+/// With a 1ms budget either the engine's setup bound or the CLI's collection bound
+/// may fire first, and pinning that would be a wall-clock race. The companion test
+/// below is the deterministic half: it fails if the CLI bound is applied
+/// unconditionally.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_cli_collection_path_is_bounded_by_query_timeout_ms() {
+    let Some(db) =
+        open_via_cli_config("test_basic", "simple_table", "basic-types.cql", false, 1).await
+    else {
+        return;
+    };
+
+    let outcome = collect_query_result(&db, "SELECT * FROM test_basic.simple_table", None).await;
+    let err = match outcome {
+        Err(e) => e,
+        Ok(result) => panic!(
+            "REGRESSION (issue #1695): performance.query_timeout_ms = 1 was IGNORED on the              CLI's OWN query path — collect_query_result returned {} rows. The engine bounds              only stream setup, so an unbounded next_async() loop leaves the knob a placebo              on the CLI, which is the only consumer that sets it.",
+            result.rows.len()
+        ),
+    };
+
+    let timeout = err
+        .downcast_ref::<Error>()
+        .map(|e| matches!(e, Error::QueryTimeout { .. }))
+        .unwrap_or(false);
+    assert!(
+        timeout,
+        "the budget must surface as the distinct timeout error through the CLI path,          not as an unrelated failure: {err:#}"
+    );
+    assert_eq!(
+        classify_error(&err),
+        CliExitCode::QueryExecutionError,
+        "a CLI query-budget elapse must map to the query-execution exit code"
+    );
+}
+
+/// The deterministic companion: `query_timeout_ms = 0` must leave the CLI's OWN
+/// collection path unbounded. Uses a COMMITTED fixture, so it can never skip, and
+/// it fails if the CLI-layer bound ever stops honouring the `Duration::ZERO`
+/// sentinel (e.g. by arming a zero timer, which elapses at the first yield).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zero_query_timeout_ms_leaves_the_cli_collection_path_unbounded() {
+    let db = open_via_cli_config(
+        "test_comp",
+        "incompressible_uncompressed_chunk",
+        "compression-parity.cql",
+        true,
+        0,
+    )
+    .await
+    .expect("the COMMITTED fixture can never skip");
+
+    let result = collect_query_result(
+        &db,
+        "SELECT * FROM test_comp.incompressible_uncompressed_chunk",
+        None,
+    )
+    .await
+    .expect("query_timeout_ms = 0 must mean UNBOUNDED on the CLI path too");
+    assert!(
+        !result.rows.is_empty(),
+        "0-rows-when-the-fixture-is-present is a failure, not a pass (#3220)"
     );
 }
 

--- a/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
+++ b/cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs
@@ -241,9 +241,15 @@ async fn zero_query_timeout_ms_leaves_the_cli_collection_path_unbounded() {
 /// collection bound could still pass it, and it skips when the fetched fixture is
 /// absent. This one removes both weaknesses:
 ///
-/// * **Deterministic** — `collect_rows_until` takes an ABSOLUTE deadline, so a
-///   deadline in the PAST makes `timeout_at` report `Elapsed` on its first poll. No
-///   clock has to advance, no scan has to be slow, and no row is ever pulled.
+/// * **Deterministic** — `collect_rows_until` takes an ABSOLUTE deadline and
+///   REJECTS one at or before `now` before polling collection at all. No clock has
+///   to advance, no scan has to be slow, and no row is ever pulled. (Precisely:
+///   `timeout_at` alone would NOT give this — it polls its inner future first and
+///   consults the deadline second, so an expired deadline still returns `Ok` for a
+///   stream that is immediately ready. An earlier version of this comment credited
+///   `timeout_at` for the determinism; the explicit up-front check is what actually
+///   provides it, and `an_expired_deadline_beats_an_immediately_ready_stream` pins
+///   the case that distinguishes them.)
 /// * **Always runs** — a COMMITTED fixture, so there is no skip path.
 /// * **Discriminating** — asserts the `cli.query.collect` operation, which only the
 ///   CLI-layer bound produces. An engine setup elapse would name a `query.*`
@@ -308,6 +314,61 @@ async fn an_expired_deadline_abandons_the_cli_collection_loop_without_pulling_ro
         classify_error(&err),
         CliExitCode::QueryExecutionError,
         "a CLI collection-budget elapse must still map to exit code 5"
+    );
+}
+
+/// The case that distinguishes an up-front expiry check from `timeout_at` alone
+/// (roborev round 7): an expired deadline must win even when collection would
+/// complete WITHOUT EVER YIELDING.
+///
+/// `display_limit = Some(0)` makes the collection loop break on its first iteration,
+/// so the future is immediately ready. `timeout_at` polls the inner future before
+/// consulting the deadline, so with only `timeout_at` this returns `Ok` with zero
+/// rows and no timeout — the budget silently not applying. Deterministic and
+/// always-running: a COMMITTED fixture and a deadline in the past.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_expired_deadline_beats_an_immediately_ready_stream() {
+    let db = open_via_cli_config(
+        "test_comp",
+        "incompressible_uncompressed_chunk",
+        "compression-parity.cql",
+        true,
+        0,
+    )
+    .await
+    .expect("the COMMITTED fixture can never skip");
+
+    let iter = db
+        .execute_streaming(
+            "SELECT * FROM test_comp.incompressible_uncompressed_chunk",
+            StreamingConfig::default(),
+        )
+        .await
+        .expect("stream setup is unbounded here, so it must succeed");
+
+    let outcome = collect_rows_until(
+        iter,
+        // Immediately ready: the loop's display-limit check breaks before any await.
+        Some(0),
+        Some(tokio::time::Instant::now() - Duration::from_secs(1)),
+        std::time::Instant::now(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    let err = match outcome {
+        Err(e) => e,
+        Ok(result) => panic!(
+            "an EXPIRED deadline returned Ok with {} rows because collection was              immediately ready — `timeout_at` polls its inner future before checking              the deadline, so the budget must be rejected UP FRONT, not left to the              timer",
+            result.rows.len()
+        ),
+    };
+    assert!(
+        matches!(
+            err.downcast_ref::<Error>(),
+            Some(Error::QueryTimeout { .. })
+        ),
+        "must be the CLI collection timeout: {err:#}"
     );
 }
 

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -235,6 +235,16 @@ required-features = ["work-counters", "write-support"]
 name = "issue_2877_scan_chunk_coalescing"
 required-features = ["write-support", "lz4"]
 
+# `query.max_execution_time` enforcement at the engine chokepoint (issue #1695).
+# It is `#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]` — the
+# fixture is opened through `cqlite_core::ingestion` (cli-helpers) so the lane
+# drives the same `Database` surface the CLI does. Declared here so the gate and
+# `--lite` run it WITH those features instead of compiling an empty target; the
+# `#![cfg]` and these required-features must always agree.
+[[test]]
+name = "issue_1695_query_timeout"
+required-features = ["state_machine", "cli-helpers"]
+
 # Statistics.db single-TOC-walk oracle (issue #2148). `#![cfg(feature =
 # "cli-helpers")]` — the `toc_walk_metrics` counter getters/`reset` +
 # `record_toc_walk` live behind `cli-helpers` — so it only compiles+runs with that

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -445,7 +445,24 @@ pub enum ReadPathMode {
 /// Query engine configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryConfig {
-    /// Maximum query execution time
+    /// Maximum wall-clock budget for ONE query execution (issue #1695).
+    ///
+    /// ENFORCED, not advisory: every public query entry point on the engine
+    /// (`execute`, `execute_streaming`, `execute_with_params`, `execute_prepared`)
+    /// runs under a single `tokio::time::timeout` at the engine chokepoint and
+    /// fails with [`crate::Error::QueryTimeout`] when the budget elapses.
+    ///
+    /// **`Duration::ZERO` is the "no timeout" sentinel** — an explicitly LEGAL
+    /// value meaning unbounded execution ([`Config::validate`] never rejects it).
+    /// There is no `Option` here, so `ZERO` is the only way to disable the bound.
+    /// The CLI knob is `performance.query_timeout_ms` (0 ⇒ unbounded).
+    ///
+    /// For `execute_streaming` the budget covers the whole SETUP future — parse,
+    /// plan, stream setup and time-to-first-batch — and NOT the caller's later
+    /// row consumption from the returned iterator; see
+    /// [`crate::query::engine::AdvancedQueryEngine::execute_streaming`].
+    ///
+    /// Default: 300s.
     pub max_execution_time: Duration,
 
     /// Force the SELECT access-path decision (issue #1918).
@@ -904,6 +921,15 @@ impl Config {
                 compaction.max_threshold, compaction.min_threshold
             )));
         }
+
+        // Query execution budget (issue #1695). `Duration::ZERO` is the documented
+        // "no timeout" sentinel and is therefore explicitly LEGAL: validation must
+        // never reject it (pinned by `config_validate_accepts_the_zero_sentinel`
+        // in `tests/issue_1695_query_timeout.rs`). Every non-zero value is a real
+        // budget honoured at the engine chokepoint — a `Duration` cannot be
+        // negative and any positive budget is enforceable — so there is nothing
+        // further to reject here. This arm exists so a future "must be > 0" rule
+        // cannot be added without confronting the sentinel contract.
 
         // Validate bloom filter settings
         if self.storage.enable_bloom_filters

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -458,9 +458,11 @@ pub struct QueryConfig {
     /// The CLI knob is `performance.query_timeout_ms` (0 ⇒ unbounded).
     ///
     /// For `execute_streaming` the budget covers the whole SETUP future — parse,
-    /// plan, stream setup and time-to-first-batch — and NOT the caller's later
-    /// row consumption from the returned iterator; see
-    /// [`crate::query::engine::AdvancedQueryEngine::execute_streaming`].
+    /// plan, stream setup, and (for the plan shapes that materialize before
+    /// streaming) the entire scan — but NOT the caller's later row consumption
+    /// from the returned iterator; see
+    /// [`crate::query::engine::QueryEngine::execute_streaming`] for the exact
+    /// scope.
     ///
     /// Default: 300s.
     pub max_execution_time: Duration,

--- a/cqlite-core/src/error.rs
+++ b/cqlite-core/src/error.rs
@@ -76,6 +76,31 @@ pub enum Error {
     #[error("Operation timeout: {0}")]
     Timeout(String),
 
+    /// A query exceeded the configured `query.max_execution_time` budget
+    /// (issue #1695).
+    ///
+    /// Raised by the SINGLE timeout wrapper at the query-engine chokepoint (see
+    /// `crate::query::engine::deadline`), never by an ad-hoc clock check inside a
+    /// scan loop. Deliberately a variant of its own — distinct from
+    /// [`Error::Timeout`] (an I/O-level timeout) and from every corruption
+    /// variant — so an operator-imposed budget can never be mistaken for damaged
+    /// data: it classifies as its own bounded telemetry category
+    /// (`crate::observability::ErrorCategory::Timeout`).
+    #[error(
+        "query exceeded the configured query.max_execution_time budget of {limit:?} \
+         (elapsed {elapsed:?}) at {operation}; raise query.max_execution_time \
+         (CLI: performance.query_timeout_ms), narrow the query with a \
+         partition-key WHERE or a LIMIT, or set it to 0 for no timeout"
+    )]
+    QueryTimeout {
+        /// The bounded entry point that elapsed (e.g. `query.execute`).
+        operation: String,
+        /// Time actually spent before the budget was abandoned.
+        elapsed: std::time::Duration,
+        /// The configured budget (`query.max_execution_time`).
+        limit: std::time::Duration,
+    },
+
     /// Invalid path error
     #[error("Invalid path: {0}")]
     InvalidPath(String),
@@ -465,6 +490,10 @@ impl Error {
             Error::InvalidPath(_) => false,
             Error::InvalidState(_) => false,
             Error::Timeout(_) => false,
+            // Issue #1695: re-running the same query under the same budget elapses
+            // again — the operator must raise `query.max_execution_time` or narrow
+            // the query (same reasoning as `ResultTooLarge`).
+            Error::QueryTimeout { .. } => false,
             Error::UnsupportedQuery(_) => false,
             // A cancelled operation is deliberate, not a transient fault: re-running
             // it would just be cancelled again. The caller decides whether to retry.
@@ -517,6 +546,12 @@ impl Error {
             Error::InvalidPath(_) => ErrorCategory::System,
             Error::InvalidState(_) => ErrorCategory::Logic,
             Error::Timeout(_) => ErrorCategory::System,
+            // Issue #1695: a query-budget elapse is a QUERY-lifecycle outcome, not
+            // a `Data` (corruption/serialization) fault. The developer-facing
+            // taxonomy is deliberately left at 14 variants (adding one breaks the
+            // bindings' public code mapping); the DISTINCT bucket lives in the
+            // telemetry taxonomy — see `observability::ErrorCategory::Timeout`.
+            Error::QueryTimeout { .. } => ErrorCategory::Query,
             Error::UnsupportedQuery(_) => ErrorCategory::Query,
             Error::Cancelled => ErrorCategory::Cancelled,
         }

--- a/cqlite-core/src/ffi_error_contract.rs
+++ b/cqlite-core/src/ffi_error_contract.rs
@@ -224,6 +224,21 @@ ffi_error_contract_table! {
     InvalidInput => { py: Value, code: "INVALID_INPUT", category: Data, recoverable: false, prefix: Some("ValueError"), },
     UnsupportedQuery => { py: Query, code: "QUERY", category: Query, recoverable: false, prefix: Some("QueryError"), },
     Cancelled => { py: Cancelled, code: "CANCELLED", category: Cancelled, recoverable: false, prefix: Some("CancelledError"), },
+    // Query execution budget elapsed (issue #1695). Field by field, because three of
+    // them could plausibly have gone the other way:
+    //   py: Timeout   — the SAME builtin `TimeoutError` as its sibling `Timeout`, so a
+    //                   Python caller guarding a query with `except TimeoutError:` does
+    //                   not find that the one timeout worth catching is the one that
+    //                   escapes it. NOT `Query`, which would have matched the classify
+    //                   category but split the two timeouts across two Python classes.
+    //   code: TIMEOUT — likewise the sibling's code, so Node and Python agree on
+    //                   identity, which is the whole point of this table (#1451).
+    //   category: Query — must MATCH `Error::classify()`, which returns `Query` for
+    //                   this variant: a budget elapse is a query-execution failure, and
+    //                   #1695 requires it be distinguishable from corruption/data.
+    //                   This is deliberately NOT the same axis as `py`/`code`.
+    //   recoverable: false — matches `Error::is_recoverable()` for this variant.
+    QueryTimeout => { py: Timeout, code: "TIMEOUT", category: Query, recoverable: false, prefix: Some("TimeoutError"), },
 }
 
 /// Map a core [`Error`] to its contract key.
@@ -271,6 +286,7 @@ pub fn variant_of(err: &Error) -> FfiErrorVariant {
         Error::InvalidInput(_) => FfiErrorVariant::InvalidInput,
         Error::UnsupportedQuery(_) => FfiErrorVariant::UnsupportedQuery,
         Error::Cancelled => FfiErrorVariant::Cancelled,
+        Error::QueryTimeout { .. } => FfiErrorVariant::QueryTimeout,
     }
 }
 
@@ -357,6 +373,16 @@ impl FfiErrorVariant {
                 Error::unsupported_query("sample unsupported query")
             }
             FfiErrorVariant::Cancelled => Error::Cancelled,
+            // Issue #1695. This sample is what makes the mapping TESTABLE: no test
+            // query can provoke a budget elapse through the bindings (neither exposes
+            // `query.max_execution_time`), which is the exact case this hook exists
+            // for. Fields are representative, not meaningful — the probe asserts the
+            // CLASS, not the figures.
+            FfiErrorVariant::QueryTimeout => Error::QueryTimeout {
+                operation: "sample.query".to_string(),
+                elapsed: std::time::Duration::from_millis(1500),
+                limit: std::time::Duration::from_millis(1000),
+            },
         };
         Some(sample)
     }

--- a/cqlite-core/src/observability/error_schema.rs
+++ b/cqlite-core/src/observability/error_schema.rs
@@ -21,6 +21,7 @@
 //! | `Constraints`  | `constraints`    | `ConstraintViolation`, `AlreadyExists`                            |
 //! | `Query`        | `query`          | `QueryExecution`, `UnsupportedQuery`, `InvalidInput`             |
 //! | `Cancelled`    | `cancelled`      | `Cancelled` (issue #2264 — a cooperative abort, never `Io`)       |
+//! | `Timeout`      | `timeout`        | `QueryTimeout` (issue #1695 — an operator budget, never data)     |
 //! | `Other`        | `other`          | `Configuration`, `InvalidState`, `InvalidOperation`, `NotFound`,  |
 //! |                |                  | `Internal`, `Wasm`, and any future variant (catch-all)            |
 //!
@@ -66,6 +67,12 @@ pub enum ErrorCategory {
     /// separately from genuine errors — a cancelled `do_get` is an expected
     /// outcome, not a fault.
     Cancelled,
+    /// A query exceeded its configured execution budget
+    /// (`query.max_execution_time`, issue #1695). Its OWN bucket, never
+    /// `Corruption` (an operator-imposed deadline is not damaged data) and never
+    /// the `Other` catch-all (a rising timeout rate is the signal that the budget
+    /// is too tight or a scan has regressed — the one thing dashboards must see).
+    Timeout,
     /// Everything else (configuration, internal, platform, catch-all).
     Other,
 }
@@ -85,6 +92,7 @@ impl ErrorCategory {
             ErrorCategory::Constraints => "constraints",
             ErrorCategory::Query => "query",
             ErrorCategory::Cancelled => "cancelled",
+            ErrorCategory::Timeout => "timeout",
             ErrorCategory::Other => "other",
         }
     }
@@ -101,6 +109,7 @@ impl ErrorCategory {
         ErrorCategory::Constraints,
         ErrorCategory::Query,
         ErrorCategory::Cancelled,
+        ErrorCategory::Timeout,
         ErrorCategory::Other,
     ];
 }
@@ -153,6 +162,11 @@ pub(crate) fn classify(err: &Error) -> ErrorCategory {
         // Issue #2264: a cooperative cancellation is an expected outcome, not a
         // fault — kept out of both `Io` and the `Other` catch-all.
         Error::Cancelled => ErrorCategory::Cancelled,
+
+        // Issue #1695: an elapsed `query.max_execution_time` budget. Its own
+        // bucket so it is never indistinguishable from `Corruption` on a
+        // dashboard, and never buried in `Other`.
+        Error::QueryTimeout { .. } => ErrorCategory::Timeout,
 
         // Catch-all for the remaining variants and any future additions. Listed
         // explicitly (no wildcard arm besides wasm) so that adding a new Error
@@ -252,5 +266,16 @@ mod tests {
         // `Io` (misleading — it is not a transport failure) and not lumped into
         // the generic `Other` catch-all (would hide cancellation rate).
         assert_eq!(Error::Cancelled.obs_category(), Cancelled);
+
+        // Issue #1695: an elapsed query budget is its OWN telemetry bucket —
+        // never `Corruption` (it is not damaged data), never `Io` (it is not a
+        // transport fault) and never the `Other` catch-all.
+        let timeout = Error::QueryTimeout {
+            operation: "query.execute".into(),
+            elapsed: std::time::Duration::from_millis(1),
+            limit: std::time::Duration::from_millis(1),
+        };
+        assert_eq!(timeout.obs_category(), Timeout);
+        assert_ne!(timeout.obs_category(), Corruption);
     }
 }

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -544,7 +544,11 @@ impl QueryEngine {
         let start_time = Instant::now();
         self.inc_total_queries();
 
-        let mut result = prepared.execute(params).await?;
+        // The UNBOUNDED body: this entry point is already wrapped by
+        // `deadline.rs`, and `PreparedQuery::execute` carries its own bound for
+        // callers holding a handle — going through it here would arm a second
+        // timer with a restarted clock (issue #1695).
+        let mut result = prepared.execute_unbounded(params).await?;
         self.update_execution_stats(&mut result, start_time);
         Ok(result)
     }

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -18,6 +18,13 @@ use super::{
     QueryStats,
 };
 
+// Issue #1695: the SINGLE query-execution time bound. A CHILD module (so it can
+// reach this type's private `config` / stats helpers) holding the public
+// `execute*` entry points as thin `tokio::time::timeout` wrappers over the
+// `*_inner` bodies below. Keeping it out of this (already over-threshold) file
+// is also the campsite rule, epic #1116.
+pub mod deadline;
+
 use super::engine_stats::AtomicQueryStats;
 #[cfg(feature = "state_machine")]
 use super::{
@@ -204,24 +211,10 @@ impl QueryEngine {
         self.stats.record_cache_hit();
     }
 
-    /// Execute a CQL query
-    ///
-    /// This is the parent of the query span tree (epic #1031, issue #1035): the
-    /// `query.execute` span created here is the context every read-path span
-    /// (issue #1034) and SELECT sub-span nests under. Bounded span attributes
-    /// (plan type, access path, rows returned) are recorded once the result is
-    /// known via [`Self::update_execution_stats`]; the query text is never
-    /// attached.
-    #[tracing::instrument(
-        name = "query.execute",
-        skip(self, cql),
-        fields(
-            cqlite.query.plan_type = tracing::field::Empty,
-            cqlite.query.access_path = tracing::field::Empty,
-            cqlite.query.rows = tracing::field::Empty,
-        )
-    )]
-    pub async fn execute(&self, cql: &str) -> Result<QueryResult> {
+    /// UNWRAPPED body of [`Self::execute`]. Its only callers are that bounded
+    /// public wrapper (`deadline.rs`) and the sibling `*_inner` bodies, so one
+    /// caller-visible query is covered by exactly ONE budget (issue #1695).
+    async fn execute_inner(&self, cql: &str) -> Result<QueryResult> {
         let start_time = Instant::now();
         self.inc_total_queries();
 
@@ -283,29 +276,11 @@ impl QueryEngine {
         Ok(result)
     }
 
-    /// Execute a CQL query with streaming results (Issue #280)
-    ///
-    /// Returns a `QueryResultIterator` that yields rows incrementally via a bounded
-    /// channel, enabling memory-efficient processing of large result sets.
-    ///
-    /// # Arguments
-    ///
-    /// * `cql` - The CQL query string to execute (must be a SELECT statement)
-    /// * `config` - Streaming configuration (buffer size, chunk hints)
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - Query is not a SELECT statement
-    /// - SQL syntax is invalid
-    /// - Query execution fails
-    ///
-    /// # Memory Budget
-    ///
-    /// The streaming approach stays within the 128MB target by using bounded channels
-    /// and processing rows incrementally rather than materializing all results.
+    /// UNWRAPPED body of [`Self::execute_streaming`] — the timeout scope
+    /// (setup + time-to-first-batch, NOT row consumption) is documented on that
+    /// bounded public wrapper in `deadline.rs` (issue #1695).
     #[cfg(feature = "state_machine")]
-    pub async fn execute_streaming(
+    async fn execute_streaming_inner(
         &self,
         cql: &str,
         config: StreamingConfig,
@@ -430,34 +405,10 @@ impl QueryEngine {
             .insert(cql.to_string(), (Instant::now(), plan));
     }
 
-    /// Execute a query with positional `?` parameters (Issue #961).
-    ///
-    /// The supplied `params` are bound, in source order, into the `?` placeholders
-    /// of the parsed statement *before* planning and execution, so the bound
-    /// values participate in partition-key classification, encoding, and typed
-    /// coercion. A `WHERE pk = ?` therefore engages the same partition-targeted
-    /// fast path (#949/#956) as the equivalent literal query.
-    ///
-    /// Binding is currently supported for SELECT statements only. A non-SELECT
-    /// CQL with parameters, or any use of named (`:name`) parameters, is rejected
-    /// with a clear error (named-parameter binding is intentionally out of scope:
-    /// the SELECT grammar only tokenizes positional `?`).
-    ///
-    /// # Routing parity with `execute` (Finding 1)
-    ///
-    /// When the parsed SELECT has **zero** bind markers and `params` is empty,
-    /// this delegates straight back to [`Self::execute`] so that a markerless
-    /// `execute_with_params(sql, &[])` is byte-for-byte equivalent to
-    /// `execute(sql)` — which since issue #1750 routes every literal SELECT
-    /// through the modern SELECT optimizer + executor. Only when markers are
-    /// present (`> 0`) is the statement bound and driven through that pipeline.
-    ///
-    /// Arity stays strict in both directions: markers `> 0` with a wrong
-    /// `params.len()` is an error, and markers `== 0` with a **non-empty**
-    /// `params` is also an error (a supplied parameter with no placeholder is a
-    /// caller bug). The latter matches [`SelectStatement::bind_parameters`]'s
-    /// contract and the documented strictness of this API.
-    pub async fn execute_with_params(&self, cql: &str, params: &[Value]) -> Result<QueryResult> {
+    /// UNWRAPPED body of [`Self::execute_with_params`] — routing parity, arity
+    /// rules and the timeout scope are documented on that bounded public wrapper
+    /// in `deadline.rs` (issue #1695).
+    async fn execute_with_params_inner(&self, cql: &str, params: &[Value]) -> Result<QueryResult> {
         let is_select = cql.trim().to_uppercase().starts_with("SELECT");
 
         if !is_select {
@@ -465,7 +416,7 @@ impl QueryEngine {
             // this is just a normal statement, so defer to the regular path;
             // with parameters it is an explicit, clear error.
             if params.is_empty() {
-                return self.execute(cql).await;
+                return self.execute_inner(cql).await;
             }
             self.inc_total_queries();
             self.inc_error_queries();
@@ -500,7 +451,7 @@ impl QueryEngine {
             // with stray params is a caller bug: reject it for strict arity.
             if marker_count == 0 {
                 if params.is_empty() {
-                    return self.execute(cql).await;
+                    return self.execute_inner(cql).await;
                 }
                 self.inc_total_queries();
                 self.inc_error_queries();
@@ -543,33 +494,39 @@ impl QueryEngine {
         // bound query reaches the partition-targeted fast path (#949/#956) — the
         // same path a literal `execute()` takes. Non-SELECTs keep the legacy
         // `QueryExecutor` plan path.
+        // Issue #1695: every handle carries the engine's execution budget, so a
+        // `prepare()` + `PreparedQuery::execute()` pair is bounded exactly like
+        // `execute()` instead of being an unbounded back door into a full scan.
+        let budget = self.config.query.max_execution_time;
+
         #[cfg(feature = "state_machine")]
         let prepared = if cql.trim().to_uppercase().starts_with("SELECT") {
             let statement = select_parser::parse_select(cql)?;
             let marker_count = statement.bind_marker_count();
-            Arc::new(PreparedQuery::new_select(
-                parsed_query,
-                plan,
-                Arc::new(self.executor.clone()),
-                statement,
-                marker_count,
-                self.select_optimizer.clone(),
-                self.select_executor.clone(),
-            ))
+            Arc::new(
+                PreparedQuery::new_select(
+                    parsed_query,
+                    plan,
+                    Arc::new(self.executor.clone()),
+                    statement,
+                    marker_count,
+                    self.select_optimizer.clone(),
+                    self.select_executor.clone(),
+                )
+                .with_max_execution_time(budget),
+            )
         } else {
-            Arc::new(PreparedQuery::new(
-                parsed_query,
-                plan,
-                Arc::new(self.executor.clone()),
-            ))
+            Arc::new(
+                PreparedQuery::new(parsed_query, plan, Arc::new(self.executor.clone()))
+                    .with_max_execution_time(budget),
+            )
         };
 
         #[cfg(not(feature = "state_machine"))]
-        let prepared = Arc::new(PreparedQuery::new(
-            parsed_query,
-            plan,
-            Arc::new(self.executor.clone()),
-        ));
+        let prepared = Arc::new(
+            PreparedQuery::new(parsed_query, plan, Arc::new(self.executor.clone()))
+                .with_max_execution_time(budget),
+        );
 
         self.prepared_cache
             .insert(cql.to_string(), prepared.clone());
@@ -577,8 +534,9 @@ impl QueryEngine {
         Ok(prepared)
     }
 
-    /// Execute a prepared query
-    pub async fn execute_prepared(
+    /// UNWRAPPED body of [`Self::execute_prepared`] (bounded in `deadline.rs`,
+    /// issue #1695).
+    async fn execute_prepared_inner(
         &self,
         prepared: &PreparedQuery,
         params: &[Value],
@@ -680,6 +638,9 @@ impl QueryEngine {
 
         for _ in 0..self.config.query.analyze_iterations.unwrap_or(5) {
             let iter_start = Instant::now();
+            // Deliberately the BOUNDED public `execute` (issue #1695): each
+            // measured iteration gets its own `max_execution_time` budget, so a
+            // runaway query fails on the first iteration rather than N times over.
             let result = self.execute(cql).await?;
             execution_times.push(iter_start.elapsed());
             results.push(result);

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -84,18 +84,22 @@
 //!    already took. The reported `elapsed` is MEASURED, so the overshoot is
 //!    visible rather than hidden.
 //!
-//! # Telemetry is NOT symmetric across the two prepared routes
+//! # Telemetry across the two prepared routes: the error stream matches, the
+//! engine counter does not
 //!
-//! [`AdvancedQueryEngine::bounded`] records an elapse: it increments
-//! `error_queries` and marks the observability error stream with the timeout
-//! category. The prepared-handle route ([`crate::query::prepared::PreparedQuery`])
-//! bounds itself through the bare [`bound`] helper instead, because the handle
-//! carries only its executor and its budget — it holds no stats or observability
-//! handle to report through. So a timeout taken on that route is ENFORCED
-//! identically but is invisible to `Database::stats()` and to
-//! `cqlite.errors.total{category="timeout"}`. Do not read "both routes are
-//! bounded" as "both routes are observable"; closing that gap needs a stats handle
-//! threaded from `prepare()`.
+//! [`AdvancedQueryEngine::bounded`] records an elapse two ways: it increments the
+//! engine's `error_queries` counter AND marks the observability error stream with
+//! the timeout category. The prepared-handle route
+//! ([`crate::query::prepared::PreparedQuery`]) bounds itself through the bare
+//! [`bound`] helper, because a handle carries only its executor and its budget.
+//!
+//! It now records on the ERROR STREAM itself, so a handle-route timeout is visible
+//! to `cqlite.errors.total{category="timeout"}` — that is the same public sink, not
+//! a second mechanism, and the routes are disjoint so nothing double counts. What it
+//! still does NOT move is `error_queries`, which is private accounting for queries
+//! the ENGINE executed; `Database::stats()` therefore reflects engine-routed
+//! executions only. Do not read "both routes are bounded" as "both routes are
+//! identical" — but the dashboard-visible half is no longer asymmetric.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -422,9 +426,9 @@ impl AdvancedQueryEngine {
     /// exactly ONCE on each, because the shared inner body is the `pub(crate)`
     /// unbounded one. Do not add a second wrapper here.
     ///
-    /// The two routes differ in TELEMETRY, not in enforcement: only this one
-    /// records an elapse in `error_queries` and on the observability error
-    /// stream — see the module's "Telemetry is NOT symmetric" note.
+    /// The two routes differ only in the ENGINE COUNTER now: both record on the
+    /// observability error stream, but only this one moves `error_queries` — see the
+    /// module's telemetry note.
     pub async fn execute_prepared(
         &self,
         prepared: &PreparedQuery,

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -47,6 +47,15 @@
 //! spawned producer observes its receiver go away and exits (its `send` fails).
 //! Nothing is detached and left running — see
 //! `tests/issue_1695_query_timeout.rs`.
+//!
+//! ONE place needs more than the drop, and has it: a `spawn_blocking` closure
+//! CANNOT be cancelled by dropping its `JoinHandle`. The multi-generation
+//! materializing merges build their result inside such a closure with no channel
+//! send that could fail, so each one arms a per-call flag whose guard lives in the
+//! dropped future's scope and abandons the merge at its next partition — see
+//! `storage::sstable::generation_merge::merge_cancel`. Any FUTURE blocking work
+//! reached from a bounded entry point owes the same treatment; the drop alone is
+//! not enough for it.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -17,7 +17,7 @@
 //! | public entry point     | inner body                    | bound covers                  |
 //! |------------------------|-------------------------------|-------------------------------|
 //! | `execute`              | `execute_inner`               | parse, plan, execute, collect |
-//! | `execute_streaming`    | `execute_streaming_inner`     | setup + time-to-first-batch   |
+//! | `execute_streaming`    | `execute_streaming_inner`     | setup (see the scope note)    |
 //! | `execute_with_params`  | `execute_with_params_inner`   | bind, plan, execute, collect  |
 //! | `execute_prepared`     | `execute_prepared_inner`      | bind, execute, collect        |
 //!
@@ -49,6 +49,7 @@
 //! `tests/issue_1695_query_timeout.rs`.
 
 use std::future::Future;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 // The engine type; `query::mod` re-exports it as `AdvancedQueryEngine`.
@@ -57,6 +58,17 @@ use super::QueryEngine as AdvancedQueryEngine;
 use crate::query::result::{QueryResultIterator, StreamingConfig};
 use crate::query::{executor::QueryResult, prepared::PreparedQuery};
 use crate::{Error, Result, Value};
+
+/// A query future handed to [`bound`], type-erased behind one heap allocation.
+///
+/// Erasure is deliberate and load-bearing, not stylistic: a generic `F` would be
+/// INLINED into the wrapper's state machine, so every bounded entry point would
+/// nest one more deep async layout inside its caller — enough to push rustc's
+/// layout-depth query over its default limit in downstream async blocks (the
+/// `#![recursion_limit]` class of failure, issue #1990). Behind `dyn Future` the
+/// wrapper's own layout is a pointer, so the depth it adds is CONSTANT. The single
+/// allocation per bounded call is immaterial next to parse + plan + scan.
+pub(crate) type BoundedFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
 
 /// Bound `fut` by `limit`, mapping an elapse to [`Error::QueryTimeout`].
 ///
@@ -84,10 +96,11 @@ use crate::{Error, Result, Value};
 ///
 /// Both halves carry the same `limit` and produce the same error, and the check
 /// lives HERE — at the one chokepoint — never in a scan loop.
-pub(crate) async fn bound<T, F>(limit: Duration, operation: &str, fut: F) -> Result<T>
-where
-    F: Future<Output = Result<T>>,
-{
+pub(crate) async fn bound<T>(
+    limit: Duration,
+    operation: &str,
+    fut: BoundedFuture<'_, T>,
+) -> Result<T> {
     // The documented "no timeout" sentinel: await directly rather than arming a
     // timer with a zero deadline (which would elapse at the first yield point).
     if limit.is_zero() {
@@ -95,7 +108,13 @@ where
     }
 
     let started = Instant::now();
-    let deadline = started + limit;
+    // Overflow-safe: `Instant + Duration` PANICS when the sum is unrepresentable,
+    // and `limit` is operator input (a `Duration::MAX` budget must not abort the
+    // process). An unrepresentable deadline is astronomically far away, so it means
+    // the same thing as the ZERO sentinel — unbounded — and is treated as such.
+    let Some(deadline) = started.checked_add(limit) else {
+        return fut.await;
+    };
     // `elapsed` is MEASURED, never assumed equal to `limit`: a starved or blocked
     // poll can overshoot the deadline substantially, and the real figure is what
     // an operator needs in order to tell "budget too tight" from "one decode unit
@@ -106,9 +125,7 @@ where
         limit,
     };
 
-    // Boxed so the poll-boundary check can own a pinned handle to it. One
-    // allocation per query — immaterial next to parse + plan + scan.
-    let mut inner = Box::pin(fut);
+    let mut inner = fut;
     let checked = std::future::poll_fn(move |cx| {
         if Instant::now() >= deadline {
             // Abandon WITHOUT polling further; `inner` is dropped with `checked`,
@@ -135,10 +152,7 @@ impl AdvancedQueryEngine {
     /// counting an elapse as a query error in the engine stats and recording it
     /// on the observability error stream (a timeout is a real query failure, and
     /// its own telemetry category — never `corruption`).
-    async fn bounded<T, F>(&self, operation: &str, fut: F) -> Result<T>
-    where
-        F: Future<Output = Result<T>>,
-    {
+    async fn bounded<T>(&self, operation: &str, fut: BoundedFuture<'_, T>) -> Result<T> {
         bound(self.config.query.max_execution_time, operation, fut)
             .await
             .inspect_err(|e| {
@@ -172,7 +186,8 @@ impl AdvancedQueryEngine {
         )
     )]
     pub async fn execute(&self, cql: &str) -> Result<QueryResult> {
-        self.bounded("query.execute", self.execute_inner(cql)).await
+        self.bounded("query.execute", Box::pin(self.execute_inner(cql)))
+            .await
     }
 
     /// Execute a CQL query with streaming results (Issue #280).
@@ -183,15 +198,24 @@ impl AdvancedQueryEngine {
     ///
     /// # Timeout scope (issue #1695) — read this before relying on it
     ///
-    /// `config.query.max_execution_time` bounds THIS future in its entirety:
-    /// statement parse, optimization, stream setup, and the time to the first
-    /// batch (the producer must reach the point where the iterator is handed
-    /// back). It does **NOT** bound the caller's subsequent row consumption: once
-    /// this returns `Ok(iterator)`, `iterator.next_async()` is unbounded, because
-    /// the pace of a bounded channel is set by the consumer and a slow consumer
-    /// is not a runaway query. Callers that need an end-to-end budget must apply
-    /// their own bound around the consumption loop. `Duration::ZERO` disables the
-    /// setup bound entirely.
+    /// `config.query.max_execution_time` bounds THIS future in its entirety, and
+    /// nothing after it:
+    ///
+    /// * **Bounded** — statement parse, optimization, schema resolution, stream
+    ///   setup, and every await this call makes before handing back the iterator.
+    ///   For the plan shapes that materialize before streaming (any aggregate,
+    ///   `ORDER BY`/`GROUP BY`, a projection trim, a `FROM`-less select) the
+    ///   ENTIRE query executes inside this future, so the whole scan is bounded.
+    /// * **NOT bounded** — the caller's later row consumption. On the incremental
+    ///   path the iterator is returned as soon as the producer task is spawned, so
+    ///   `iterator.next_async()` — including the wait for the FIRST batch — runs
+    ///   outside the budget. That is deliberate: the pace of a bounded channel is
+    ///   set by the consumer, and a slow consumer is not a runaway query.
+    ///
+    /// A caller that needs an end-to-end budget must bound its own consumption
+    /// loop (e.g. `tokio::time::timeout` around `next_async()`); a per-batch bound
+    /// inside the engine is possible future work, not this contract.
+    /// `Duration::ZERO` disables the setup bound entirely.
     ///
     /// # Errors
     ///
@@ -212,7 +236,7 @@ impl AdvancedQueryEngine {
     ) -> Result<QueryResultIterator> {
         self.bounded(
             "query.execute_streaming",
-            self.execute_streaming_inner(cql, config),
+            Box::pin(self.execute_streaming_inner(cql, config)),
         )
         .await
     }
@@ -250,7 +274,7 @@ impl AdvancedQueryEngine {
     pub async fn execute_with_params(&self, cql: &str, params: &[Value]) -> Result<QueryResult> {
         self.bounded(
             "query.execute_with_params",
-            self.execute_with_params_inner(cql, params),
+            Box::pin(self.execute_with_params_inner(cql, params)),
         )
         .await
     }
@@ -269,7 +293,7 @@ impl AdvancedQueryEngine {
     ) -> Result<QueryResult> {
         self.bounded(
             "query.execute_prepared",
-            self.execute_prepared_inner(prepared, params),
+            Box::pin(self.execute_prepared_inner(prepared, params)),
         )
         .await
     }
@@ -284,12 +308,16 @@ mod tests {
     /// consulted (a zero deadline would otherwise elapse at the first yield).
     #[tokio::test]
     async fn zero_limit_is_unbounded() {
-        let out: Result<u32> = bound(Duration::ZERO, "test.zero", async {
-            for _ in 0..64 {
-                tokio::task::yield_now().await;
-            }
-            Ok(7)
-        })
+        let out: Result<u32> = bound(
+            Duration::ZERO,
+            "test.zero",
+            Box::pin(async {
+                for _ in 0..64 {
+                    tokio::task::yield_now().await;
+                }
+                Ok(7)
+            }),
+        )
         .await;
         assert_eq!(out.expect("ZERO must not bound anything"), 7);
     }
@@ -300,7 +328,7 @@ mod tests {
     #[tokio::test]
     async fn elapsed_budget_yields_query_timeout() {
         let limit = Duration::from_millis(1);
-        let out: Result<u32> = bound(limit, "test.pending", std::future::pending()).await;
+        let out: Result<u32> = bound(limit, "test.pending", Box::pin(std::future::pending())).await;
         match out {
             Err(Error::QueryTimeout {
                 operation,
@@ -318,10 +346,10 @@ mod tests {
     /// NOT be recoverable-by-retry (the same query re-elapses).
     #[tokio::test]
     async fn timeout_error_is_distinct_from_corruption() {
-        let err = bound::<u32, _>(
+        let err = bound::<u32>(
             Duration::from_millis(1),
             "test.classify",
-            std::future::pending(),
+            Box::pin(std::future::pending()),
         )
         .await
         .expect_err("must elapse");
@@ -342,12 +370,19 @@ mod tests {
     /// timeout).
     #[tokio::test]
     async fn inner_outcome_passes_through() {
-        let ok: Result<u32> = bound(Duration::from_secs(300), "test.ok", async { Ok(3) }).await;
+        let ok: Result<u32> = bound(
+            Duration::from_secs(300),
+            "test.ok",
+            Box::pin(async { Ok(3) }),
+        )
+        .await;
         assert_eq!(ok.expect("must pass through"), 3);
 
-        let err: Result<u32> = bound(Duration::from_secs(300), "test.err", async {
-            Err(Error::corruption("inner"))
-        })
+        let err: Result<u32> = bound(
+            Duration::from_secs(300),
+            "test.err",
+            Box::pin(async { Err(Error::corruption("inner")) }),
+        )
         .await;
         assert!(matches!(
             err.expect_err("inner Err must be relayed"),
@@ -367,11 +402,15 @@ mod tests {
         }
         let dropped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let flag = DropFlag(std::sync::Arc::clone(&dropped));
-        let out: Result<u32> = bound(Duration::from_millis(1), "test.drop", async move {
-            let _held = flag;
-            std::future::pending::<()>().await;
-            Ok(0)
-        })
+        let out: Result<u32> = bound(
+            Duration::from_millis(1),
+            "test.drop",
+            Box::pin(async move {
+                let _held = flag;
+                std::future::pending::<()>().await;
+                Ok(0)
+            }),
+        )
         .await;
         assert!(matches!(out, Err(Error::QueryTimeout { .. })));
         assert!(

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -1,0 +1,382 @@
+//! The ONE query-execution time bound (issue #1695).
+//!
+//! # Why this module exists
+//!
+//! `Config.query.max_execution_time` (default 300s, set by the CLI's
+//! `performance.query_timeout_ms`) was enforced NOWHERE: a runaway query ran
+//! forever and the operator's knob was a placebo. This module is the enforcement
+//! point, and it is deliberately the ONLY one.
+//!
+//! # Shape: one wrapper per public entry point, at the engine boundary
+//!
+//! Every public `async` entry point of [`AdvancedQueryEngine`] that can drive a
+//! scan is a thin wrapper here over a private `*_inner` body in the parent
+//! module, and the wrapper is the single place a `tokio::time::timeout` is
+//! applied:
+//!
+//! | public entry point     | inner body                    | bound covers                  |
+//! |------------------------|-------------------------------|-------------------------------|
+//! | `execute`              | `execute_inner`               | parse, plan, execute, collect |
+//! | `execute_streaming`    | `execute_streaming_inner`     | setup + time-to-first-batch   |
+//! | `execute_with_params`  | `execute_with_params_inner`   | bind, plan, execute, collect  |
+//! | `execute_prepared`     | `execute_prepared_inner`      | bind, execute, collect        |
+//!
+//! There are deliberately NO ad-hoc clock checks inside the scan loop: a deadline
+//! sampled at N places is N places that can drift, mis-round, or be forgotten on
+//! a new path. One `timeout` at the boundary bounds every path underneath it,
+//! including ones that do not exist yet.
+//!
+//! Inner bodies delegate to each OTHER'S inner form (e.g. `execute_with_params_inner`
+//! → `execute_inner` for a markerless SELECT), never back through a public
+//! wrapper, so one caller-visible query is bounded by exactly ONE budget instead
+//! of restarting the clock at an internal hop.
+//!
+//! # The `Duration::ZERO` sentinel
+//!
+//! `max_execution_time == Duration::ZERO` means **no timeout** (unbounded): the
+//! future is awaited directly, with no timer registered at all. It is an
+//! explicitly legal configuration — [`crate::Config::validate`] never rejects it
+//! — and it is the only way to disable the bound, since the field is a
+//! `Duration` rather than an `Option`.
+//!
+//! # Cancellation
+//!
+//! On elapse, `tokio::time::timeout` DROPS the inner future. That is the whole
+//! cancellation mechanism: the materializing path holds its readers and buffers
+//! inside that future, so dropping it releases them, and the streaming path's
+//! spawned producer observes its receiver go away and exits (its `send` fails).
+//! Nothing is detached and left running — see
+//! `tests/issue_1695_query_timeout.rs`.
+
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+// The engine type; `query::mod` re-exports it as `AdvancedQueryEngine`.
+use super::QueryEngine as AdvancedQueryEngine;
+#[cfg(feature = "state_machine")]
+use crate::query::result::{QueryResultIterator, StreamingConfig};
+use crate::query::{executor::QueryResult, prepared::PreparedQuery};
+use crate::{Error, Result, Value};
+
+/// Bound `fut` by `limit`, mapping an elapse to [`Error::QueryTimeout`].
+///
+/// PURE (no engine state) so the contract is unit-testable on its own:
+/// `Duration::ZERO` ⇒ awaited unbounded with no timer; an inner `Ok`/`Err`
+/// passes through untouched; an elapse DROPS `fut` and reports the operation,
+/// the configured limit, and the time actually spent.
+///
+/// # Two halves, one deadline
+///
+/// The single deadline is checked two ways, because neither alone is sufficient:
+///
+/// 1. **At every poll boundary** (`Instant::now() >= deadline`, before the inner
+///    future is polled). This is what bounds a *CPU-bound* query: the read path
+///    does long synchronous stretches per poll and only becomes `Pending` at its
+///    cooperative checkpoints ([`crate::storage::scan_cancel::ScanCancel::checkpoint`]),
+///    and a woken task is NOT guaranteed a timer-driver turn — tokio's scheduler
+///    consults the driver only every `event_interval` polls, so a scan with a
+///    handful of yield points could run to completion with an expired timer
+///    unfired. Checking the clock where we are already being polled makes the
+///    bound deterministic at the FIRST yield point past the deadline.
+/// 2. **`tokio::time::timeout`**, which supplies the WAKE-UP a poll-boundary
+///    check cannot: a future parked on something that never happens (an empty
+///    channel, a stalled read) is never polled again, so only a timer can end it.
+///
+/// Both halves carry the same `limit` and produce the same error, and the check
+/// lives HERE — at the one chokepoint — never in a scan loop.
+pub(crate) async fn bound<T, F>(limit: Duration, operation: &str, fut: F) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    // The documented "no timeout" sentinel: await directly rather than arming a
+    // timer with a zero deadline (which would elapse at the first yield point).
+    if limit.is_zero() {
+        return fut.await;
+    }
+
+    let started = Instant::now();
+    let deadline = started + limit;
+    // `elapsed` is MEASURED, never assumed equal to `limit`: a starved or blocked
+    // poll can overshoot the deadline substantially, and the real figure is what
+    // an operator needs in order to tell "budget too tight" from "one decode unit
+    // is uninterruptibly slow".
+    let expired = |operation: &str| Error::QueryTimeout {
+        operation: operation.to_string(),
+        elapsed: started.elapsed(),
+        limit,
+    };
+
+    // Boxed so the poll-boundary check can own a pinned handle to it. One
+    // allocation per query — immaterial next to parse + plan + scan.
+    let mut inner = Box::pin(fut);
+    let checked = std::future::poll_fn(move |cx| {
+        if Instant::now() >= deadline {
+            // Abandon WITHOUT polling further; `inner` is dropped with `checked`,
+            // which IS the cancellation.
+            return std::task::Poll::Ready(Err(expired(operation)));
+        }
+        inner.as_mut().poll(cx)
+    });
+
+    match tokio::time::timeout(limit, checked).await {
+        Ok(inner) => inner,
+        // The timer half: `checked` was dropped by `timeout`, taking the query
+        // future with it.
+        Err(_elapsed) => Err(Error::QueryTimeout {
+            operation: operation.to_string(),
+            elapsed: started.elapsed(),
+            limit,
+        }),
+    }
+}
+
+impl AdvancedQueryEngine {
+    /// Bound one query future by the configured `query.max_execution_time`,
+    /// counting an elapse as a query error in the engine stats and recording it
+    /// on the observability error stream (a timeout is a real query failure, and
+    /// its own telemetry category — never `corruption`).
+    async fn bounded<T, F>(&self, operation: &str, fut: F) -> Result<T>
+    where
+        F: Future<Output = Result<T>>,
+    {
+        bound(self.config.query.max_execution_time, operation, fut)
+            .await
+            .inspect_err(|e| {
+                if matches!(e, Error::QueryTimeout { .. }) {
+                    self.inc_error_queries();
+                    crate::observability::record_error(e, "query");
+                }
+            })
+    }
+
+    /// Execute a CQL query.
+    ///
+    /// Bounded by `config.query.max_execution_time` (issue #1695): the whole
+    /// execution — parse, plan, scan, and result collection — runs inside one
+    /// `tokio::time::timeout`, and an elapsed budget returns
+    /// [`Error::QueryTimeout`] with the inner future dropped. `Duration::ZERO`
+    /// disables the bound.
+    ///
+    /// This is the parent of the query span tree (epic #1031, issue #1035): the
+    /// `query.execute` span created here is the context every read-path span
+    /// (issue #1034) and SELECT sub-span nests under. Bounded span attributes
+    /// (plan type, access path, rows returned) are recorded once the result is
+    /// known via `update_execution_stats`; the query text is never attached.
+    #[tracing::instrument(
+        name = "query.execute",
+        skip(self, cql),
+        fields(
+            cqlite.query.plan_type = tracing::field::Empty,
+            cqlite.query.access_path = tracing::field::Empty,
+            cqlite.query.rows = tracing::field::Empty,
+        )
+    )]
+    pub async fn execute(&self, cql: &str) -> Result<QueryResult> {
+        self.bounded("query.execute", self.execute_inner(cql)).await
+    }
+
+    /// Execute a CQL query with streaming results (Issue #280).
+    ///
+    /// Returns a `QueryResultIterator` that yields rows incrementally via a
+    /// bounded channel, enabling memory-efficient processing of large result
+    /// sets.
+    ///
+    /// # Timeout scope (issue #1695) — read this before relying on it
+    ///
+    /// `config.query.max_execution_time` bounds THIS future in its entirety:
+    /// statement parse, optimization, stream setup, and the time to the first
+    /// batch (the producer must reach the point where the iterator is handed
+    /// back). It does **NOT** bound the caller's subsequent row consumption: once
+    /// this returns `Ok(iterator)`, `iterator.next_async()` is unbounded, because
+    /// the pace of a bounded channel is set by the consumer and a slow consumer
+    /// is not a runaway query. Callers that need an end-to-end budget must apply
+    /// their own bound around the consumption loop. `Duration::ZERO` disables the
+    /// setup bound entirely.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query is not a SELECT, the CQL is invalid,
+    /// execution fails, or the execution budget elapses during setup
+    /// ([`Error::QueryTimeout`]).
+    ///
+    /// # Memory Budget
+    ///
+    /// The streaming approach stays within the 128MB target by using bounded
+    /// channels and processing rows incrementally rather than materializing all
+    /// results.
+    #[cfg(feature = "state_machine")]
+    pub async fn execute_streaming(
+        &self,
+        cql: &str,
+        config: StreamingConfig,
+    ) -> Result<QueryResultIterator> {
+        self.bounded(
+            "query.execute_streaming",
+            self.execute_streaming_inner(cql, config),
+        )
+        .await
+    }
+
+    /// Execute a query with positional `?` parameters (Issue #961).
+    ///
+    /// Bounded by `config.query.max_execution_time` (issue #1695) exactly like
+    /// [`Self::execute`]; a markerless SELECT delegates to the same inner body,
+    /// so the two APIs share ONE budget rather than restarting the clock.
+    ///
+    /// The supplied `params` are bound, in source order, into the `?` placeholders
+    /// of the parsed statement *before* planning and execution, so the bound
+    /// values participate in partition-key classification, encoding, and typed
+    /// coercion. A `WHERE pk = ?` therefore engages the same partition-targeted
+    /// fast path (#949/#956) as the equivalent literal query.
+    ///
+    /// Binding is currently supported for SELECT statements only. A non-SELECT
+    /// CQL with parameters, or any use of named (`:name`) parameters, is rejected
+    /// with a clear error (named-parameter binding is intentionally out of scope:
+    /// the SELECT grammar only tokenizes positional `?`).
+    ///
+    /// # Routing parity with `execute` (Finding 1)
+    ///
+    /// When the parsed SELECT has **zero** bind markers and `params` is empty,
+    /// this delegates straight back to [`Self::execute`]'s body so that a
+    /// markerless `execute_with_params(sql, &[])` is byte-for-byte equivalent to
+    /// `execute(sql)` — which since issue #1750 routes every literal SELECT
+    /// through the modern SELECT optimizer + executor. Only when markers are
+    /// present (`> 0`) is the statement bound and driven through that pipeline.
+    ///
+    /// Arity stays strict in both directions: markers `> 0` with a wrong
+    /// `params.len()` is an error, and markers `== 0` with a **non-empty**
+    /// `params` is also an error (a supplied parameter with no placeholder is a
+    /// caller bug).
+    pub async fn execute_with_params(&self, cql: &str, params: &[Value]) -> Result<QueryResult> {
+        self.bounded(
+            "query.execute_with_params",
+            self.execute_with_params_inner(cql, params),
+        )
+        .await
+    }
+
+    /// Execute a prepared query.
+    ///
+    /// Bounded by `config.query.max_execution_time` (issue #1695). NOTE: this is
+    /// the ENGINE's prepared entry point; calling
+    /// [`PreparedQuery::execute`](crate::query::prepared::PreparedQuery::execute)
+    /// directly on a handle obtained from `prepare()` bypasses the engine and is
+    /// therefore unbounded.
+    pub async fn execute_prepared(
+        &self,
+        prepared: &PreparedQuery,
+        params: &[Value],
+    ) -> Result<QueryResult> {
+        self.bounded(
+            "query.execute_prepared",
+            self.execute_prepared_inner(prepared, params),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `Duration::ZERO` sentinel means UNBOUNDED: a future that only
+    /// completes after several yields still returns its value, and no timer is
+    /// consulted (a zero deadline would otherwise elapse at the first yield).
+    #[tokio::test]
+    async fn zero_limit_is_unbounded() {
+        let out: Result<u32> = bound(Duration::ZERO, "test.zero", async {
+            for _ in 0..64 {
+                tokio::task::yield_now().await;
+            }
+            Ok(7)
+        })
+        .await;
+        assert_eq!(out.expect("ZERO must not bound anything"), 7);
+    }
+
+    /// An inner future that never completes must surface `Error::QueryTimeout`
+    /// naming the operation and the configured limit — never a corruption or a
+    /// generic I/O timeout, and never a hang.
+    #[tokio::test]
+    async fn elapsed_budget_yields_query_timeout() {
+        let limit = Duration::from_millis(1);
+        let out: Result<u32> = bound(limit, "test.pending", std::future::pending()).await;
+        match out {
+            Err(Error::QueryTimeout {
+                operation,
+                limit: reported,
+                ..
+            }) => {
+                assert_eq!(operation, "test.pending");
+                assert_eq!(reported, limit);
+            }
+            other => panic!("expected Error::QueryTimeout, got {other:?}"),
+        }
+    }
+
+    /// The elapsed budget must classify as its OWN telemetry category and must
+    /// NOT be recoverable-by-retry (the same query re-elapses).
+    #[tokio::test]
+    async fn timeout_error_is_distinct_from_corruption() {
+        let err = bound::<u32, _>(
+            Duration::from_millis(1),
+            "test.classify",
+            std::future::pending(),
+        )
+        .await
+        .expect_err("must elapse");
+        assert_eq!(
+            err.obs_category(),
+            crate::observability::ErrorCategory::Timeout
+        );
+        assert_ne!(
+            err.obs_category(),
+            crate::observability::ErrorCategory::Corruption
+        );
+        assert_eq!(err.category(), crate::error::ErrorCategory::Query);
+        assert!(!err.is_recoverable());
+    }
+
+    /// A future that completes inside the budget passes its value through
+    /// untouched, and an inner `Err` is relayed as itself (never rewritten into a
+    /// timeout).
+    #[tokio::test]
+    async fn inner_outcome_passes_through() {
+        let ok: Result<u32> = bound(Duration::from_secs(300), "test.ok", async { Ok(3) }).await;
+        assert_eq!(ok.expect("must pass through"), 3);
+
+        let err: Result<u32> = bound(Duration::from_secs(300), "test.err", async {
+            Err(Error::corruption("inner"))
+        })
+        .await;
+        assert!(matches!(
+            err.expect_err("inner Err must be relayed"),
+            Error::Corruption(_)
+        ));
+    }
+
+    /// Dropping the inner future IS the cancellation: when the budget elapses,
+    /// the inner future's resources are released rather than detached.
+    #[tokio::test]
+    async fn elapse_drops_the_inner_future() {
+        struct DropFlag(std::sync::Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let dropped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = DropFlag(std::sync::Arc::clone(&dropped));
+        let out: Result<u32> = bound(Duration::from_millis(1), "test.drop", async move {
+            let _held = flag;
+            std::future::pending::<()>().await;
+            Ok(0)
+        })
+        .await;
+        assert!(matches!(out, Err(Error::QueryTimeout { .. })));
+        assert!(
+            dropped.load(std::sync::atomic::Ordering::SeqCst),
+            "the timed-out future must be DROPPED (releasing what it held), not detached"
+        );
+    }
+}

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -331,10 +331,13 @@ impl AdvancedQueryEngine {
     /// Execute a prepared query.
     ///
     /// Bounded by `config.query.max_execution_time` (issue #1695). NOTE: this is
-    /// the ENGINE's prepared entry point; calling
+    /// the ENGINE's prepared entry point, but it is not the only bounded one:
     /// [`PreparedQuery::execute`](crate::query::prepared::PreparedQuery::execute)
-    /// directly on a handle obtained from `prepare()` bypasses the engine and is
-    /// therefore unbounded.
+    /// and `execute_with_context`, called directly on a handle obtained from
+    /// `prepare()`, carry the engine's budget and bound themselves via
+    /// [`bound`]. So a prepared query is bounded on EITHER route — and bounded
+    /// exactly ONCE on each, because the shared inner body is the `pub(crate)`
+    /// unbounded one. Do not add a second wrapper here.
     pub async fn execute_prepared(
         &self,
         prepared: &PreparedQuery,

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -185,6 +185,27 @@ async fn bound_tracked<T>(
     let Some(deadline) = started.checked_add(limit) else {
         return (fut.await, true);
     };
+    bound_tracked_until(deadline, started, limit, operation, fut).await
+}
+
+/// [`bound_tracked`] with the deadline supplied ABSOLUTELY rather than derived from
+/// `Instant::now() + limit`.
+///
+/// This split is not a test-only seam — it is the whole implementation, and the
+/// production caller above is its only non-test caller. It exists because the
+/// "already-expired budget" case cannot otherwise be tested by CONSTRUCTION: a test
+/// passing `Duration::from_nanos(1)` is asserting that the clock advances at least a
+/// nanosecond between computing the deadline and the first poll, which is true in
+/// practice and guaranteed by nothing (roborev round 5). With the deadline injected
+/// in the past, the short-circuit is decided by construction and no clock reading
+/// can change the outcome.
+async fn bound_tracked_until<T>(
+    deadline: Instant,
+    started: Instant,
+    limit: Duration,
+    operation: &str,
+    fut: BoundedFuture<'_, T>,
+) -> (Result<T>, bool) {
     // `elapsed` is MEASURED, never assumed equal to `limit`: a starved or blocked
     // poll can overshoot the deadline substantially, and the real figure is what
     // an operator needs in order to tell "budget too tight" from "one decode unit
@@ -495,9 +516,19 @@ mod tests {
     async fn an_expired_budget_reports_the_inner_future_as_unstarted() {
         let polled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let seen = std::sync::Arc::clone(&polled);
-        // `Duration::from_nanos(1)` is expired by the time the first poll runs.
-        let (out, started): (Result<u32>, bool) = bound_tracked(
-            Duration::from_nanos(1),
+        // The deadline is injected ONE SECOND IN THE PAST, so "already expired" holds
+        // BY CONSTRUCTION. The earlier form passed `Duration::from_nanos(1)` and
+        // relied on the clock advancing a nanosecond between deriving the deadline
+        // and the first poll — true in practice, guaranteed by nothing, and a flake
+        // the moment it is not (roborev round 5). The `limit` stays generous so the
+        // TIMER cannot be what fires: this pins the poll-time deadline check.
+        let past = Instant::now()
+            .checked_sub(Duration::from_secs(1))
+            .expect("the process clock is at least 1s past its origin");
+        let (out, started): (Result<u32>, bool) = bound_tracked_until(
+            past,
+            past,
+            Duration::from_secs(30),
             "test.unstarted",
             Box::pin(async move {
                 seen.store(true, std::sync::atomic::Ordering::SeqCst);

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -50,6 +50,8 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 // The engine type; `query::mod` re-exports it as `AdvancedQueryEngine`.
@@ -101,10 +103,29 @@ pub(crate) async fn bound<T>(
     operation: &str,
     fut: BoundedFuture<'_, T>,
 ) -> Result<T> {
+    bound_tracked(limit, operation, fut).await.0
+}
+
+/// [`bound`] plus the one fact the caller's STATISTICS need: whether the inner
+/// future was ever polled (issue #1695, roborev).
+///
+/// Every `*_inner` body counts itself with `inc_total_queries()` as its first
+/// statement, i.e. synchronously on its FIRST poll. So `started == true` ⟺ the
+/// query is already in `total_queries`. When the budget is ALREADY EXPIRED at the
+/// first poll boundary this returns the timeout WITHOUT ever polling `inner`, so
+/// nothing counted the query — and a caller that then counts the error would
+/// publish `error_queries > total_queries`, an impossible statistic. Returning
+/// `started` lets [`AdvancedQueryEngine::bounded`] keep the two counters coherent
+/// without the inner body having to run.
+async fn bound_tracked<T>(
+    limit: Duration,
+    operation: &str,
+    fut: BoundedFuture<'_, T>,
+) -> (Result<T>, bool) {
     // The documented "no timeout" sentinel: await directly rather than arming a
     // timer with a zero deadline (which would elapse at the first yield point).
     if limit.is_zero() {
-        return fut.await;
+        return (fut.await, true);
     }
 
     let started = Instant::now();
@@ -113,7 +134,7 @@ pub(crate) async fn bound<T>(
     // process). An unrepresentable deadline is astronomically far away, so it means
     // the same thing as the ZERO sentinel — unbounded — and is treated as such.
     let Some(deadline) = started.checked_add(limit) else {
-        return fut.await;
+        return (fut.await, true);
     };
     // `elapsed` is MEASURED, never assumed equal to `limit`: a starved or blocked
     // poll can overshoot the deadline substantially, and the real figure is what
@@ -125,17 +146,26 @@ pub(crate) async fn bound<T>(
         limit,
     };
 
+    // Set on the first poll that actually REACHES `inner`. Shared with the caller
+    // (rather than a captured `bool`) because `poll_fn` is moved into `timeout` and
+    // dropped there, so its captures are gone by the time the verdict is read.
+    let inner_started = Arc::new(AtomicBool::new(false));
+
     let mut inner = fut;
-    let checked = std::future::poll_fn(move |cx| {
-        if Instant::now() >= deadline {
-            // Abandon WITHOUT polling further; `inner` is dropped with `checked`,
-            // which IS the cancellation.
-            return std::task::Poll::Ready(Err(expired(operation)));
+    let checked = std::future::poll_fn({
+        let inner_started = Arc::clone(&inner_started);
+        move |cx| {
+            if Instant::now() >= deadline {
+                // Abandon WITHOUT polling further; `inner` is dropped with `checked`,
+                // which IS the cancellation.
+                return std::task::Poll::Ready(Err(expired(operation)));
+            }
+            inner_started.store(true, Ordering::Relaxed);
+            inner.as_mut().poll(cx)
         }
-        inner.as_mut().poll(cx)
     });
 
-    match tokio::time::timeout(limit, checked).await {
+    let out = match tokio::time::timeout(limit, checked).await {
         Ok(inner) => inner,
         // The timer half: `checked` was dropped by `timeout`, taking the query
         // future with it.
@@ -144,7 +174,8 @@ pub(crate) async fn bound<T>(
             elapsed: started.elapsed(),
             limit,
         }),
-    }
+    };
+    (out, inner_started.load(Ordering::Relaxed))
 }
 
 impl AdvancedQueryEngine {
@@ -153,14 +184,23 @@ impl AdvancedQueryEngine {
     /// on the observability error stream (a timeout is a real query failure, and
     /// its own telemetry category — never `corruption`).
     async fn bounded<T>(&self, operation: &str, fut: BoundedFuture<'_, T>) -> Result<T> {
-        bound(self.config.query.max_execution_time, operation, fut)
-            .await
-            .inspect_err(|e| {
-                if matches!(e, Error::QueryTimeout { .. }) {
-                    self.inc_error_queries();
-                    crate::observability::record_error(e, "query");
+        let (out, inner_started) =
+            bound_tracked(self.config.query.max_execution_time, operation, fut).await;
+        out.inspect_err(|e| {
+            if matches!(e, Error::QueryTimeout { .. }) {
+                // An ALREADY-EXPIRED budget returns before the inner body runs, so
+                // nothing counted the query: `*_inner` bodies call
+                // `inc_total_queries()` as their first statement (issue #1695,
+                // roborev). Count it here instead, so a timed-out query is always a
+                // query — never an error against a total that never saw it, which
+                // would publish `error_queries > total_queries`.
+                if !inner_started {
+                    self.inc_total_queries();
                 }
-            })
+                self.inc_error_queries();
+                crate::observability::record_error(e, "query");
+            }
+        })
     }
 
     /// Execute a CQL query.
@@ -388,6 +428,59 @@ mod tests {
             err.expect_err("inner Err must be relayed"),
             Error::Corruption(_)
         ));
+    }
+
+    /// An ALREADY-EXPIRED budget reports that the inner future was never STARTED,
+    /// which is the fact the engine's statistics need: the `*_inner` bodies count
+    /// themselves on their first poll, so an unstarted query is one nothing counted.
+    /// Without this signal `bounded` would record an error against a total that
+    /// never saw the query (issue #1695, roborev: `error_queries > total_queries`).
+    #[tokio::test]
+    async fn an_expired_budget_reports_the_inner_future_as_unstarted() {
+        let polled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let seen = std::sync::Arc::clone(&polled);
+        // `Duration::from_nanos(1)` is expired by the time the first poll runs.
+        let (out, started): (Result<u32>, bool) = bound_tracked(
+            Duration::from_nanos(1),
+            "test.unstarted",
+            Box::pin(async move {
+                seen.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(1)
+            }),
+        )
+        .await;
+        assert!(matches!(out, Err(Error::QueryTimeout { .. })));
+        assert!(
+            !polled.load(std::sync::atomic::Ordering::SeqCst),
+            "precondition: the expired budget must short-circuit BEFORE the body runs"
+        );
+        assert!(
+            !started,
+            "an inner future that was never polled must be reported as unstarted"
+        );
+    }
+
+    /// The complement: a future that DID run is reported as started (so its own
+    /// `inc_total_queries()` is not double-counted), on the completing path and on
+    /// the unbounded sentinel alike.
+    #[tokio::test]
+    async fn a_polled_inner_future_is_reported_as_started() {
+        let (out, started): (Result<u32>, bool) = bound_tracked(
+            Duration::from_secs(300),
+            "test.started",
+            Box::pin(async { Ok(5) }),
+        )
+        .await;
+        assert_eq!(out.expect("must complete"), 5);
+        assert!(started, "a polled inner future must be reported as started");
+
+        let (zero, zero_started): (Result<u32>, bool) =
+            bound_tracked(Duration::ZERO, "test.zero", Box::pin(async { Ok(6) })).await;
+        assert_eq!(zero.expect("must complete"), 6);
+        assert!(
+            zero_started,
+            "the unbounded sentinel awaits the inner future directly, so it started"
+        );
     }
 
     /// Dropping the inner future IS the cancellation: when the budget elapses,

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -56,6 +56,46 @@
 //! `storage::sstable::generation_merge::merge_cancel`. Any FUTURE blocking work
 //! reached from a bounded entry point owes the same treatment; the drop alone is
 //! not enough for it.
+//!
+//! # What the bound does NOT cover
+//!
+//! A `tokio::time::timeout` can only elapse when the future it wraps becomes
+//! `Pending`. So the budget bounds work that YIELDS, and three things do not:
+//!
+//! 1. **Post-scan synchronous stages.** `ORDER BY` sorting, aggregation and
+//!    projection run inside `select_executor`'s non-async `execute_sort` and
+//!    friends, over an already-materialized `Vec`. A query whose scan finishes
+//!    inside the budget and then sorts a large result set can overshoot
+//!    substantially, and this wrapper cannot interrupt it — `Vec::sort_by` is one
+//!    uninterruptible call. Bounding it means making the post-scan pipeline async
+//!    or chunked, which is deliberately NOT part of issue #1695 (whose mandate is
+//!    ONE wrapper at the chokepoint); it follows the contract that issue chose for
+//!    the analogous streaming case — bound what is practical, document the rest.
+//!    Note the scan is the dominant cost for genuinely large data, and it IS
+//!    bounded, so the exposure is a result set big enough to sort for a long time
+//!    yet cheap enough to have been scanned within budget.
+//! 2. **Row consumption after `execute_streaming` returns.** The bound covers the
+//!    whole future including time-to-first-batch, not the caller's subsequent
+//!    iteration. Per-batch bounds are a follow-up.
+//! 3. **A single overshooting poll.** If one poll runs past the deadline and
+//!    returns `Ready`, its result is ACCEPTED rather than discarded — the plain
+//!    `tokio::time::timeout` semantics this issue specifies. Erroring there would
+//!    throw away a correct completed result without shortening the wait the caller
+//!    already took. The reported `elapsed` is MEASURED, so the overshoot is
+//!    visible rather than hidden.
+//!
+//! # Telemetry is NOT symmetric across the two prepared routes
+//!
+//! [`AdvancedQueryEngine::bounded`] records an elapse: it increments
+//! `error_queries` and marks the observability error stream with the timeout
+//! category. The prepared-handle route ([`crate::query::prepared::PreparedQuery`])
+//! bounds itself through the bare [`bound`] helper instead, because the handle
+//! carries only its executor and its budget — it holds no stats or observability
+//! handle to report through. So a timeout taken on that route is ENFORCED
+//! identically but is invisible to `Database::stats()` and to
+//! `cqlite.errors.total{category="timeout"}`. Do not read "both routes are
+//! bounded" as "both routes are observable"; closing that gap needs a stats handle
+//! threaded from `prepare()`.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -338,6 +378,10 @@ impl AdvancedQueryEngine {
     /// [`bound`]. So a prepared query is bounded on EITHER route — and bounded
     /// exactly ONCE on each, because the shared inner body is the `pub(crate)`
     /// unbounded one. Do not add a second wrapper here.
+    ///
+    /// The two routes differ in TELEMETRY, not in enforcement: only this one
+    /// records an elapse in `error_queries` and on the observability error
+    /// stream — see the module's "Telemetry is NOT symmetric" note.
     pub async fn execute_prepared(
         &self,
         prepared: &PreparedQuery,

--- a/cqlite-core/src/query/engine/deadline.rs
+++ b/cqlite-core/src/query/engine/deadline.rs
@@ -381,6 +381,28 @@ impl AdvancedQueryEngine {
     /// `params.len()` is an error, and markers `== 0` with a **non-empty**
     /// `params` is also an error (a supplied parameter with no placeholder is a
     /// caller bug).
+    ///
+    /// Carries its OWN `query.execute` span (roborev round 13). On `origin/main` the
+    /// markerless empty-`params` case delegated to [`Self::execute`] and inherited the
+    /// span from it; #1695 re-pointed that delegation at the UNBOUNDED
+    /// `execute_with_params_inner` so one call is bounded exactly once, and that
+    /// silently took the span with it — those queries lost their parent span and the
+    /// plan/access-path/row attributes `update_execution_stats` records on it.
+    ///
+    /// The lesson is structural, not local: the tracing wrapper and the deadline were
+    /// both hung on `execute`, so routing around one to avoid double-bounding routed
+    /// around the other too. A span belongs to the ENTRY POINT; the bound belongs to
+    /// the budget. Any future entry point added here owes itself a span for the same
+    /// reason.
+    #[tracing::instrument(
+        name = "query.execute",
+        skip(self, cql, params),
+        fields(
+            cqlite.query.plan_type = tracing::field::Empty,
+            cqlite.query.access_path = tracing::field::Empty,
+            cqlite.query.rows = tracing::field::Empty,
+        )
+    )]
     pub async fn execute_with_params(&self, cql: &str, params: &[Value]) -> Result<QueryResult> {
         self.bounded(
             "query.execute_with_params",

--- a/cqlite-core/src/query/prepared.rs
+++ b/cqlite-core/src/query/prepared.rs
@@ -306,12 +306,14 @@ impl PreparedQuery {
     /// so a prepared `WHERE pk = ?` engages the partition-targeted fast path.
     /// Non-SELECT prepared statements retain the legacy executor path.
     pub async fn execute(&self, params: &[Value]) -> Result<QueryResult> {
-        crate::query::engine::deadline::bound(
-            self.max_execution_time,
-            "prepared.execute",
-            Box::pin(self.execute_unbounded(params)),
+        record_prepared_timeout(
+            crate::query::engine::deadline::bound(
+                self.max_execution_time,
+                "prepared.execute",
+                Box::pin(self.execute_unbounded(params)),
+            )
+            .await,
         )
-        .await
     }
 
     /// UNWRAPPED body of [`Self::execute`]; the bound is applied by that caller,
@@ -379,12 +381,14 @@ impl PreparedQuery {
     /// SELECTs with no hints bind their params and run through the pipeline,
     /// matching `execute(context.positional_params)`.
     pub async fn execute_with_context(&self, context: &PreparedContext) -> Result<QueryResult> {
-        crate::query::engine::deadline::bound(
-            self.max_execution_time,
-            "prepared.execute_with_context",
-            Box::pin(self.execute_with_context_unbounded(context)),
+        record_prepared_timeout(
+            crate::query::engine::deadline::bound(
+                self.max_execution_time,
+                "prepared.execute_with_context",
+                Box::pin(self.execute_with_context_unbounded(context)),
+            )
+            .await,
         )
-        .await
     }
 
     /// UNWRAPPED body of [`Self::execute_with_context`] (bounded by that caller,
@@ -976,4 +980,28 @@ mod tests {
             "identical float params must still hit the memoized plan (no re-optimize)"
         );
     }
+}
+
+/// Record a prepared-handle timeout on the engine's own observability error stream
+/// (issue #1695, roborev rounds 3 and 15).
+///
+/// These two routes bound themselves with the bare [`deadline::bound`] rather than
+/// `AdvancedQueryEngine::bounded`, because a handle carries only its executor and its
+/// budget — it holds no engine reference. `bounded` is what records an elapse, so
+/// without this a timeout taken through `PreparedQuery::execute` was ENFORCED
+/// identically and yet invisible to `cqlite.errors.total{category="timeout"}`.
+///
+/// This is not a second recording mechanism: `record_error` is the same public sink
+/// `bounded` uses. The routes are DISJOINT — the engine's `execute_prepared` bounds
+/// (and records) its own call, while these record only when the caller came through a
+/// handle directly — so nothing is double counted.
+///
+/// Still not covered: the engine's `error_queries` counter, which is private
+/// accounting for queries the engine itself executed.
+fn record_prepared_timeout<T>(outcome: Result<T>) -> Result<T> {
+    outcome.inspect_err(|e| {
+        if matches!(e, crate::Error::QueryTimeout { .. }) {
+            crate::observability::record_error(e, "query");
+        }
+    })
 }

--- a/cqlite-core/src/query/prepared.rs
+++ b/cqlite-core/src/query/prepared.rs
@@ -309,14 +309,16 @@ impl PreparedQuery {
         crate::query::engine::deadline::bound(
             self.max_execution_time,
             "prepared.execute",
-            self.execute_unbounded(params),
+            Box::pin(self.execute_unbounded(params)),
         )
         .await
     }
 
-    /// UNWRAPPED body of [`Self::execute`]; the bound is applied by that caller
-    /// and by [`Self::execute_with_context`], so one call is bounded ONCE.
-    async fn execute_unbounded(&self, params: &[Value]) -> Result<QueryResult> {
+    /// UNWRAPPED body of [`Self::execute`]; the bound is applied by that caller,
+    /// by [`Self::execute_with_context`], and by the engine's `execute_prepared`
+    /// (which bounds the call itself), so one call is bounded ONCE — never twice
+    /// with a restarted clock.
+    pub(crate) async fn execute_unbounded(&self, params: &[Value]) -> Result<QueryResult> {
         self.validate_params(params)?;
 
         #[cfg(feature = "state_machine")]
@@ -380,7 +382,7 @@ impl PreparedQuery {
         crate::query::engine::deadline::bound(
             self.max_execution_time,
             "prepared.execute_with_context",
-            self.execute_with_context_unbounded(context),
+            Box::pin(self.execute_with_context_unbounded(context)),
         )
         .await
     }

--- a/cqlite-core/src/query/prepared.rs
+++ b/cqlite-core/src/query/prepared.rs
@@ -172,6 +172,13 @@ pub struct PreparedQuery {
     /// legacy `QueryExecutor` path (Issue #961).
     #[cfg(feature = "state_machine")]
     select_pipeline: Option<PreparedSelect>,
+    /// Query execution budget inherited from `config.query.max_execution_time`
+    /// (issue #1695). `Duration::ZERO` = unbounded, which is also the value the
+    /// constructors default to: a handle built outside
+    /// [`crate::query::engine::QueryEngine::prepare`] (tests, direct construction)
+    /// carries no budget until one is attached with
+    /// [`Self::with_max_execution_time`].
+    max_execution_time: std::time::Duration,
 }
 
 /// Parameter metadata for prepared statements
@@ -225,6 +232,7 @@ impl PreparedQuery {
             executor,
             #[cfg(feature = "state_machine")]
             select_pipeline: None,
+            max_execution_time: std::time::Duration::ZERO,
         }
     }
 
@@ -272,16 +280,43 @@ impl PreparedQuery {
                 executor: select_executor,
                 plan_cache: std::sync::Mutex::new(None),
             }),
+            max_execution_time: std::time::Duration::ZERO,
         }
     }
 
+    /// Attach the engine's `query.max_execution_time` budget (issue #1695).
+    ///
+    /// Called by `QueryEngine::prepare`, so a handle handed to a caller enforces
+    /// the same budget the engine's own entry points do — a `prepare()` +
+    /// `execute()` pair is not an unbounded back door into a full scan.
+    /// `Duration::ZERO` leaves it unbounded.
+    pub(crate) fn with_max_execution_time(mut self, limit: std::time::Duration) -> Self {
+        self.max_execution_time = limit;
+        self
+    }
+
     /// Execute the prepared query with positional parameters.
+    ///
+    /// Bounded by the `query.max_execution_time` budget attached at `prepare()`
+    /// time (issue #1695), through the same single wrapper the engine's entry
+    /// points use; `Duration::ZERO` means unbounded.
     ///
     /// Issue #961: for prepared SELECTs the parameters are bound into the parsed
     /// statement and the bound query runs through the SELECT optimizer + executor,
     /// so a prepared `WHERE pk = ?` engages the partition-targeted fast path.
     /// Non-SELECT prepared statements retain the legacy executor path.
     pub async fn execute(&self, params: &[Value]) -> Result<QueryResult> {
+        crate::query::engine::deadline::bound(
+            self.max_execution_time,
+            "prepared.execute",
+            self.execute_unbounded(params),
+        )
+        .await
+    }
+
+    /// UNWRAPPED body of [`Self::execute`]; the bound is applied by that caller
+    /// and by [`Self::execute_with_context`], so one call is bounded ONCE.
+    async fn execute_unbounded(&self, params: &[Value]) -> Result<QueryResult> {
         self.validate_params(params)?;
 
         #[cfg(feature = "state_machine")]
@@ -298,7 +333,10 @@ impl PreparedQuery {
         self.executor.execute(&self.plan).await
     }
 
-    /// Execute with named parameters
+    /// Execute with named parameters.
+    ///
+    /// Converts to positional and delegates to the BOUNDED [`Self::execute`], so
+    /// it inherits the `query.max_execution_time` budget (issue #1695).
     pub async fn execute_named(&self, params: &HashMap<String, Value>) -> Result<QueryResult> {
         // Convert named parameters to positional, in declaration order.
         let mut positional_params = Vec::with_capacity(self.parameters.len());
@@ -339,6 +377,20 @@ impl PreparedQuery {
     /// SELECTs with no hints bind their params and run through the pipeline,
     /// matching `execute(context.positional_params)`.
     pub async fn execute_with_context(&self, context: &PreparedContext) -> Result<QueryResult> {
+        crate::query::engine::deadline::bound(
+            self.max_execution_time,
+            "prepared.execute_with_context",
+            self.execute_with_context_unbounded(context),
+        )
+        .await
+    }
+
+    /// UNWRAPPED body of [`Self::execute_with_context`] (bounded by that caller,
+    /// issue #1695).
+    async fn execute_with_context_unbounded(
+        &self,
+        context: &PreparedContext,
+    ) -> Result<QueryResult> {
         let hints = &context.hints;
 
         #[cfg(feature = "state_machine")]
@@ -569,6 +621,8 @@ impl PreparedQueryBuilder {
             executor,
             #[cfg(feature = "state_machine")]
             select_pipeline: None,
+            // Unbounded until the engine attaches its budget (issue #1695).
+            max_execution_time: std::time::Duration::ZERO,
         }
     }
 

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -607,20 +607,41 @@ impl SelectExecutor {
         // (#1578) is concurrently editing this same file — restructuring it now
         // would conflict with that in-flight work. A split is tracked under #1116.
         let error_tx = tx.clone();
+        // #1695 (roborev round 13): ONE cancellation race covering the WHOLE producer.
+        // `execute_streaming_background` has three branches — targeted,
+        // multi-targeted and the fallback scan — and only the fallback's batch loop
+        // observed consumer closure. The targeted branches await `scan_partition` per
+        // key, so a large `IN (...)` list or a tombstone build kept scanning after a
+        // timed-out consumer had gone. Guarding them one at a time is what left this
+        // scattered across five rounds; racing the whole future covers every branch,
+        // including any added later.
+        //
+        // This does NOT make the in-loop checks redundant. The race can only fire at
+        // an await boundary of the future it wraps, so a long SYNCHRONOUS stretch
+        // inside a branch is still only interruptible by that branch's own check.
+        // Coverage from here, promptness from there.
+        let closed_tx = tx.clone();
 
         // Spawn background task to stream rows
         tokio::spawn(async move {
-            if let Err(e) = Self::execute_streaming_background(
-                storage,
-                query_schema,
-                table_id,
-                execution_steps,
-                tx,
-                buffer_size,
-                mode,
-            )
-            .await
-            {
+            let outcome = tokio::select! {
+                // `biased` so an already-departed consumer wins over a producer that
+                // is ready to make progress.
+                biased;
+                // Dropping the producer future IS the cancellation: it releases the
+                // readers, buffers and the storage stream it was holding.
+                _ = closed_tx.closed() => None,
+                result = Self::execute_streaming_background(
+                    storage,
+                    query_schema,
+                    table_id,
+                    execution_steps,
+                    tx,
+                    buffer_size,
+                    mode,
+                ) => Some(result),
+            };
+            if let Some(Err(e)) = outcome {
                 tracing::error!("Streaming execution error: {}", e);
                 // Issue #1581 (roborev finding): surface the error through the
                 // channel as a terminal `Err` item instead of merely logging it

--- a/cqlite-core/src/query/select_executor/streaming.rs
+++ b/cqlite-core/src/query/select_executor/streaming.rs
@@ -300,6 +300,27 @@ impl SelectExecutor {
                     // key is decoded once regardless of batching.
                     let mut pk_cache = PartitionKeyCache::default();
                     while let Some(batch) = scan_stream.recv().await {
+                        // #1695: stop when OUR consumer is gone, even with nothing to
+                        // send. `tx.send(..).is_err()` below is otherwise the only stop
+                        // signal, and it is reached only by a row that SURVIVES the
+                        // row-build, the predicates, the per-partition limit and the
+                        // OFFSET skip — every one of which `continue`s. A no-match
+                        // predicate, or an OFFSET past the result set, therefore sent
+                        // nothing, checked nothing, and drained this whole scan after
+                        // the caller already had its `QueryTimeout`.
+                        //
+                        // This task also holds `scan_stream`, the STORAGE producer's
+                        // receiver, so the equivalent `is_closed()` check down in
+                        // `generation_merge` cannot fire on our behalf: from the
+                        // storage side its consumer is alive and asking for batches.
+                        // The two checks are one per layer, and neither substitutes
+                        // for the other.
+                        //
+                        // Per BATCH, matching the #1592 design's unit of work (one
+                        // async wake per batch, not per row).
+                        if tx.is_closed() {
+                            return Ok(());
+                        }
                         for (key, value) in batch? {
                             // Capture the partition-key digest before `key` is moved
                             // into row construction (only when needed).

--- a/cqlite-core/src/query/select_executor/streaming.rs
+++ b/cqlite-core/src/query/select_executor/streaming.rs
@@ -299,28 +299,41 @@ impl SelectExecutor {
                     // partition may straddle a batch boundary), so a partition's
                     // key is decoded once regardless of batching.
                     let mut pk_cache = PartitionKeyCache::default();
-                    while let Some(batch) = scan_stream.recv().await {
-                        // #1695: stop when OUR consumer is gone, even with nothing to
-                        // send. `tx.send(..).is_err()` below is otherwise the only stop
-                        // signal, and it is reached only by a row that SURVIVES the
-                        // row-build, the predicates, the per-partition limit and the
-                        // OFFSET skip — every one of which `continue`s. A no-match
-                        // predicate, or an OFFSET past the result set, therefore sent
-                        // nothing, checked nothing, and drained this whole scan after
-                        // the caller already had its `QueryTimeout`.
+                    loop {
+                        // #1695: stop as soon as OUR consumer is gone, even with nothing
+                        // to send AND even while the upstream batch is still coming.
+                        //
+                        // `tx.send(..).is_err()` below is otherwise the only stop signal,
+                        // and it is reached only by a row that SURVIVES the row build,
+                        // the predicates, the per-partition limit and the OFFSET skip —
+                        // every one of which `continue`s. A no-match predicate, or an
+                        // OFFSET past the result set, therefore sent nothing, checked
+                        // nothing, and drained this whole scan after the caller already
+                        // had its `QueryTimeout`.
+                        //
+                        // A bare `is_closed()` at the top of the loop was NOT enough
+                        // (roborev round 11): it runs only after `recv()` RETURNS, so a
+                        // stalled or slow upstream batch never reached it. Awaiting
+                        // `tx.closed()` CONCURRENTLY with the batch bounds the wait
+                        // itself — the same correction round 10 forced on the export
+                        // chunk pull, which I applied there and not here.
+                        //
+                        // `biased` so closure is polled BEFORE the batch: an already-gone
+                        // consumer ends the scan without first taking another batch.
                         //
                         // This task also holds `scan_stream`, the STORAGE producer's
-                        // receiver, so the equivalent `is_closed()` check down in
-                        // `generation_merge` cannot fire on our behalf: from the
-                        // storage side its consumer is alive and asking for batches.
-                        // The two checks are one per layer, and neither substitutes
-                        // for the other.
-                        //
-                        // Per BATCH, matching the #1592 design's unit of work (one
-                        // async wake per batch, not per row).
-                        if tx.is_closed() {
-                            return Ok(());
-                        }
+                        // receiver, so the `is_closed()` check down in `generation_merge`
+                        // cannot fire on our behalf: from the storage side its consumer
+                        // is alive and asking for batches. One check per layer, and
+                        // neither substitutes for the other.
+                        let batch = tokio::select! {
+                            biased;
+                            _ = tx.closed() => return Ok(()),
+                            next = scan_stream.recv() => match next {
+                                Some(batch) => batch,
+                                None => break,
+                            },
+                        };
                         for (key, value) in batch? {
                             // Capture the partition-key digest before `key` is moved
                             // into row construction (only when needed).

--- a/cqlite-core/src/storage/scan_cancel.rs
+++ b/cqlite-core/src/storage/scan_cancel.rs
@@ -72,12 +72,21 @@ impl ScanCancel {
     /// walk interruptible at the SAME audited cadence at which it is already
     /// cancellable.
     ///
-    /// `tick` is the loop's own counter (partition/entry/chunk index); the
-    /// cancellation flag is polled on EVERY call (a relaxed atomic load), the
-    /// runtime yield happens on every `YIELD_STRIDE`-th one.
+    /// `tick` is the loop's own counter (partition/entry/chunk index). BOTH the
+    /// cancellation poll and the runtime yield happen on every `YIELD_STRIDE`-th
+    /// call, and an off-stride call is a deliberate no-op.
+    ///
+    /// Polling on every call would be the more responsive choice, and an earlier
+    /// revision did that — but it silently RAISED the cancellation cadence of
+    /// three callers that had hand-rolled `if tick & 0xFF == 0 { check()? }`,
+    /// adding a relaxed atomic load and an `.await` point to a per-entry decode
+    /// loop. That cadence was chosen deliberately by #2264/#2346, and #1695 has no
+    /// mandate to retune the read hot path, so this reproduces it exactly.
+    /// A loop that genuinely needs per-iteration cancellation uses
+    /// [`Self::checkpoint_now`] instead.
     pub async fn checkpoint(&self, tick: usize) -> crate::Result<()> {
-        self.check()?;
         if tick % YIELD_STRIDE == 0 {
+            self.check()?;
             tokio::task::yield_now().await;
         }
         Ok(())
@@ -93,10 +102,14 @@ impl ScanCancel {
     }
 }
 
-/// Runtime-yield stride for [`ScanCancel::checkpoint`] — the same 256-iteration
-/// cadence the cancellation polls already used (#2264/#2346), so neither
-/// cancellation latency nor scan throughput changes measurably: one task
-/// reschedule per 256 decoded partitions/entries/chunks.
+/// Checkpoint stride for [`ScanCancel::checkpoint`] — the same 256-iteration
+/// cadence the callers' hand-rolled cancellation polls used (#2264/#2346). Both
+/// the poll and the yield sit on that boundary, so cancellation latency is
+/// UNCHANGED from those callers and the added cost is one task reschedule per 256
+/// decoded partitions/entries/chunks. Stated as an equivalence to the prior code
+/// rather than as a throughput claim: no measurement was taken here, and #2403's
+/// release theme is exactly where an unmeasured "no measurable change" would be
+/// the wrong thing to assert.
 pub const YIELD_STRIDE: usize = 256;
 
 #[cfg(test)]
@@ -125,22 +138,32 @@ mod tests {
     /// boundary) hand control back to the runtime — the property the chokepoint
     /// timeout depends on (issue #1695).
     #[tokio::test]
-    async fn checkpoint_yields_at_the_stride_and_relays_cancellation() {
+    async fn checkpoint_checks_and_yields_at_the_stride_only() {
         let c = ScanCancel::new();
-        // Stride boundary: yields, still Ok.
+        // Stride boundary: checks + yields, still Ok.
         assert!(c.checkpoint(0).await.is_ok());
-        // Off-stride: no yield, still Ok.
+        // Off-stride: no check, no yield, still Ok.
         assert!(c.checkpoint(1).await.is_ok());
         assert!(c.checkpoint_now().await.is_ok());
 
         c.cancel();
-        // Cancellation is polled on EVERY call, on and off stride, and takes
-        // precedence over the yield.
-        for tick in [0usize, 1, YIELD_STRIDE, YIELD_STRIDE + 1] {
+        // ON stride, cancellation is observed and takes precedence over the yield.
+        for tick in [0usize, YIELD_STRIDE] {
             assert!(matches!(
                 c.checkpoint(tick).await,
                 Err(crate::Error::Cancelled)
             ));
+        }
+        // OFF stride it is deliberately NOT observed. This is the contract, not a
+        // gap: it reproduces the `if tick & 0xFF == 0 { check()? }` cadence the
+        // callers had before #1695, so a per-entry decode loop pays nothing between
+        // boundaries. A loop needing per-iteration cancellation uses
+        // `checkpoint_now`, which is asserted below to still report it.
+        for tick in [1usize, YIELD_STRIDE + 1] {
+            assert!(
+                c.checkpoint(tick).await.is_ok(),
+                "an off-stride checkpoint must be a no-op even once cancelled"
+            );
         }
         assert!(matches!(
             c.checkpoint_now().await,

--- a/cqlite-core/src/storage/scan_cancel.rs
+++ b/cqlite-core/src/storage/scan_cancel.rs
@@ -92,6 +92,33 @@ impl ScanCancel {
         Ok(())
     }
 
+    /// Cooperative checkpoint that polls cancellation on EVERY call but yields
+    /// only at the [`YIELD_STRIDE`] boundary — the third of three cadences.
+    ///
+    /// For a loop whose iterations are individually coarse enough to want prompt
+    /// cancellation (one real index random read each), but numerous enough that a
+    /// per-iteration runtime reschedule would be a throughput cost. Reaching for
+    /// [`Self::checkpoint_now`] there preserves the cancellation cadence and
+    /// silently ADDS a yield per iteration where the caller previously had none;
+    /// reaching for [`Self::checkpoint`] preserves the yield cadence and silently
+    /// LOWERS cancellation to one poll per 256. Neither is what such a caller
+    /// wants, which is why this exists as its own method.
+    ///
+    /// The three, so the choice is explicit at every call site:
+    ///
+    /// | method | cancellation poll | runtime yield |
+    /// |---|---|---|
+    /// | [`Self::checkpoint`] | every 256th | every 256th |
+    /// | `checkpoint_polled` | EVERY call | every 256th |
+    /// | [`Self::checkpoint_now`] | EVERY call | EVERY call |
+    pub async fn checkpoint_polled(&self, tick: usize) -> crate::Result<()> {
+        self.check()?;
+        if tick % YIELD_STRIDE == 0 {
+            tokio::task::yield_now().await;
+        }
+        Ok(())
+    }
+
     /// [`Self::checkpoint`] for a loop whose iterations are individually coarse
     /// (a whole block / data section), where every iteration is a correct yield
     /// point.

--- a/cqlite-core/src/storage/scan_cancel.rs
+++ b/cqlite-core/src/storage/scan_cancel.rs
@@ -51,7 +51,53 @@ impl ScanCancel {
             Ok(())
         }
     }
+
+    /// Cooperative scan CHECKPOINT: poll for cancellation (issues #2264/#2346)
+    /// **and** yield to the async runtime every [`YIELD_STRIDE`]-th call
+    /// (issue #1695).
+    ///
+    /// # Why the yield belongs here
+    ///
+    /// `query.max_execution_time` is enforced by ONE `tokio::time::timeout` at the
+    /// query-engine chokepoint (`query::engine::deadline`). A `timeout` can only
+    /// elapse when the future it wraps becomes `Pending`: the read path does long
+    /// stretches of SYNCHRONOUS work per poll (stitch a data section, parse a
+    /// block, decode a partition), so without a yield point the wrapper could not
+    /// fire until the whole scan had finished — the budget would be a placebo on
+    /// exactly the runaway full scan it exists to bound.
+    ///
+    /// This carries NO deadline knowledge: the scan never reads a clock and never
+    /// learns the budget (the mandate of issue #1695 is one wrapper at the
+    /// chokepoint, never ad-hoc clock checks in the scan loop). It only makes the
+    /// walk interruptible at the SAME audited cadence at which it is already
+    /// cancellable.
+    ///
+    /// `tick` is the loop's own counter (partition/entry/chunk index); the
+    /// cancellation flag is polled on EVERY call (a relaxed atomic load), the
+    /// runtime yield happens on every `YIELD_STRIDE`-th one.
+    pub async fn checkpoint(&self, tick: usize) -> crate::Result<()> {
+        self.check()?;
+        if tick % YIELD_STRIDE == 0 {
+            tokio::task::yield_now().await;
+        }
+        Ok(())
+    }
+
+    /// [`Self::checkpoint`] for a loop whose iterations are individually coarse
+    /// (a whole block / data section), where every iteration is a correct yield
+    /// point.
+    pub async fn checkpoint_now(&self) -> crate::Result<()> {
+        self.check()?;
+        tokio::task::yield_now().await;
+        Ok(())
+    }
 }
+
+/// Runtime-yield stride for [`ScanCancel::checkpoint`] — the same 256-iteration
+/// cadence the cancellation polls already used (#2264/#2346), so neither
+/// cancellation latency nor scan throughput changes measurably: one task
+/// reschedule per 256 decoded partitions/entries/chunks.
+pub const YIELD_STRIDE: usize = 256;
 
 #[cfg(test)]
 mod tests {
@@ -73,6 +119,53 @@ mod tests {
         let b = a.clone();
         a.cancel();
         assert!(b.is_cancelled(), "cancel on one clone is seen by another");
+    }
+
+    /// A checkpoint on an UNCANCELLED flag must return `Ok` and (at a stride
+    /// boundary) hand control back to the runtime — the property the chokepoint
+    /// timeout depends on (issue #1695).
+    #[tokio::test]
+    async fn checkpoint_yields_at_the_stride_and_relays_cancellation() {
+        let c = ScanCancel::new();
+        // Stride boundary: yields, still Ok.
+        assert!(c.checkpoint(0).await.is_ok());
+        // Off-stride: no yield, still Ok.
+        assert!(c.checkpoint(1).await.is_ok());
+        assert!(c.checkpoint_now().await.is_ok());
+
+        c.cancel();
+        // Cancellation is polled on EVERY call, on and off stride, and takes
+        // precedence over the yield.
+        for tick in [0usize, 1, YIELD_STRIDE, YIELD_STRIDE + 1] {
+            assert!(matches!(
+                c.checkpoint(tick).await,
+                Err(crate::Error::Cancelled)
+            ));
+        }
+        assert!(matches!(
+            c.checkpoint_now().await,
+            Err(crate::Error::Cancelled)
+        ));
+    }
+
+    /// The checkpoint's yield is what lets a `tokio::time::timeout` around a
+    /// synchronous-looking scan loop actually elapse (issue #1695): without it the
+    /// loop would run to completion inside one poll.
+    #[tokio::test]
+    async fn checkpoint_makes_a_scan_loop_interruptible_by_timeout() {
+        let c = ScanCancel::new();
+        let out = tokio::time::timeout(std::time::Duration::from_millis(1), async {
+            // A loop with NO yield point of its own, exactly like a decode walk.
+            for tick in 0..usize::MAX {
+                c.checkpoint(tick).await?;
+            }
+            Ok::<(), crate::Error>(())
+        })
+        .await;
+        assert!(
+            out.is_err(),
+            "a loop whose only yield point is the checkpoint MUST be interruptible              by an enclosing timeout"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -61,6 +61,7 @@ use crate::storage::write_engine::merge::{CellData, KWayMerger, MergeEntry, Merg
 use crate::types::{CellWriteMetadata, TableId as CqlTableId};
 use crate::{Result, RowCells, RowKey, ScanRow, Value};
 
+mod merge_cancel;
 #[cfg(not(feature = "tombstones"))]
 mod merge_stream_setup;
 #[cfg(not(feature = "tombstones"))]
@@ -280,6 +281,11 @@ pub(super) async fn merge_generations_for_read(
     // shape in `scan_admission.rs` `# Scope`. Moved into the closure below.
     let admission = reader::scan_stream_windowed::scan_admission::admit().await;
 
+    // Issue #1695: a dropped `JoinHandle` does NOT stop a `spawn_blocking` closure.
+    // `_cancel_guard` lives in THIS future's scope and trips `cancel` on drop, so the
+    // loop below abandons the merge at its next partition. See `merge_cancel`.
+    let (_cancel_guard, cancel) = merge_cancel::per_call();
+
     // Own the bounds/target so the merge body can use them without borrowing
     // across the await; cheap clone of the key bytes.
     let start_key = start_key.cloned();
@@ -295,7 +301,13 @@ pub(super) async fn merge_generations_for_read(
         let shadow = ReadShadow::new(&schema, now_epoch_secs());
         let mut merger = KWayMerger::new(paths, &schema)?;
         let mut out = Vec::new();
-        while let MergeStep::Partition { key, rows } = merger.step()? {
+        loop {
+            // #1695: caller's future gone — abandon rather than finish a `Vec` nobody
+            // can receive. Once per PARTITION: the merge's own unit of work.
+            cancel.check()?;
+            let MergeStep::Partition { key, rows } = merger.step()? else {
+                break;
+            };
             let row_key = RowKey::new(key.key.clone());
 
             // Partition-targeted point read (#1579): keep ONLY the target and stop.
@@ -367,6 +379,10 @@ pub(super) async fn seek_merge_generations_for_read(
     // shape in `scan_admission.rs` `# Scope`.
     let admission = reader::scan_stream_windowed::scan_admission::admit().await;
 
+    // Issue #1695: per-call abandonment for the detached blocking merge below (a
+    // dropped `JoinHandle` cannot stop it). See `merge_cancel`.
+    let (_cancel_guard, cancel) = merge_cancel::per_call();
+
     // NEWEST→OLDEST like `ordered_generation_paths`, so the seeking merger's
     // run_index (= position) equals the full-scan merger's LWW tie-break rank.
     let mut ordered: Vec<Arc<reader::SSTableReader>> = candidates.to_vec();
@@ -395,7 +411,12 @@ pub(super) async fn seek_merge_generations_for_read(
             return Ok(Vec::new()); // no candidate holds the target
         };
         let mut out = Vec::new();
-        while let MergeStep::Partition { key, rows } = merger.step()? {
+        loop {
+            // #1695: abandon at the next partition once the caller's future is gone.
+            cancel.check()?;
+            let MergeStep::Partition { key, rows } = merger.step()? else {
+                break;
+            };
             let row_key = RowKey::new(key.key.clone());
             // A fail-safe filter-scan run could surface a prefix-collision key; keep
             // only the exact target and stop once seen (partition keys are unique).
@@ -454,6 +475,10 @@ pub(super) async fn merge_generations_for_read_with_metadata(
     // helpers: no phase both runs detached blocking work AND has released the permit.
     let admission = reader::scan_stream_windowed::scan_admission::admit().await;
 
+    // Issue #1695: per-call abandonment for the detached blocking merge below (a
+    // dropped `JoinHandle` cannot stop it). See `merge_cancel`.
+    let (_cancel_guard, cancel) = merge_cancel::per_call();
+
     // Own the bounds so the merge body can use them without borrowing across the
     // await; cheap clone of the key bytes. Mirrors the plain helper.
     let owned_start = start_key.cloned();
@@ -501,7 +526,12 @@ pub(super) async fn merge_generations_for_read_with_metadata(
         let shadow = ReadShadow::new(&merge_schema, now_epoch_secs());
         let mut merger = KWayMerger::new(paths, &merge_schema)?;
         let mut out = Vec::new();
-        while let MergeStep::Partition { key, rows } = merger.step()? {
+        loop {
+            // #1695: abandon at the next partition once the caller's future is gone.
+            cancel.check()?;
+            let MergeStep::Partition { key, rows } = merger.step()? else {
+                break;
+            };
             let row_key = RowKey::new(key.key.clone());
 
             // Partition-targeted point read (#1579): keep ONLY the target and stop.

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -299,7 +299,8 @@ pub(super) async fn merge_generations_for_read(
         let _admission = admission; // #2063: hold across the detached blocking work.
                                     // Issue #1849: capture the read-time TTL clock ONCE per scan.
         let shadow = ReadShadow::new(&schema, now_epoch_secs());
-        let mut merger = KWayMerger::new(paths, &schema)?;
+        // #1695: readers get the token too — `merge_cancel` "Two granularities".
+        let mut merger = KWayMerger::new_cancellable(paths, &schema, cancel.clone())?;
         let mut out = Vec::new();
         loop {
             // #1695: caller's future gone — abandon rather than finish a `Vec` nobody
@@ -369,7 +370,6 @@ pub(super) async fn seek_merge_generations_for_read(
     schema: &crate::schema::TableSchema,
     target_key: &RowKey,
 ) -> Result<Vec<(RowKey, ScanRow)>> {
-    use crate::storage::scan_cancel::ScanCancel;
     use crate::storage::write_engine::merge::{
         build_single_partition_merger_from_readers, PointAccessRecording,
     };
@@ -401,7 +401,7 @@ pub(super) async fn seek_merge_generations_for_read(
             ordered,
             &keys,
             &schema,
-            ScanCancel::new(),
+            cancel.clone(), // #1695: per-call token, not an untrippable `ScanCancel::new()`.
             // The executor records this logical access at its own storage
             // boundary (`StorageEngine::scan_partition_clustering`), so
             // recording here as well would count one read twice (#2827).
@@ -524,7 +524,7 @@ pub(super) async fn merge_generations_for_read_with_metadata(
         let _admission = admission; // #2063: hold across the detached blocking work.
                                     // Issue #1849: capture the read-time TTL clock ONCE per scan.
         let shadow = ReadShadow::new(&merge_schema, now_epoch_secs());
-        let mut merger = KWayMerger::new(paths, &merge_schema)?;
+        let mut merger = KWayMerger::new_cancellable(paths, &merge_schema, cancel.clone())?;
         let mut out = Vec::new();
         loop {
             // #1695: abandon at the next partition once the caller's future is gone.

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -304,7 +304,7 @@ pub(super) async fn merge_generations_for_read(
         loop {
             // #1695: caller's future gone — abandon rather than finish a `Vec` nobody
             // can receive. Once per PARTITION: the merge's own unit of work.
-            cancel.check()?;
+            merge_cancel::check(&cancel)?;
             let MergeStep::Partition { key, rows } = merger.step()? else {
                 break;
             };
@@ -413,7 +413,7 @@ pub(super) async fn seek_merge_generations_for_read(
         let mut out = Vec::new();
         loop {
             // #1695: abandon at the next partition once the caller's future is gone.
-            cancel.check()?;
+            merge_cancel::check(&cancel)?;
             let MergeStep::Partition { key, rows } = merger.step()? else {
                 break;
             };
@@ -528,7 +528,7 @@ pub(super) async fn merge_generations_for_read_with_metadata(
         let mut out = Vec::new();
         loop {
             // #1695: abandon at the next partition once the caller's future is gone.
-            cancel.check()?;
+            merge_cancel::check(&cancel)?;
             let MergeStep::Partition { key, rows } = merger.step()? else {
                 break;
             };

--- a/cqlite-core/src/storage/sstable/generation_merge.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge.rs
@@ -723,6 +723,12 @@ pub(super) async fn stream_generations_for_read(
         };
 
         loop {
+            // #1695: observe consumer closure EVERY iteration, not only when a send
+            // happens — the three `continue` paths below send nothing. See
+            // `merge_cancel`, "Why the streaming producer needs its own check".
+            if out_tx.is_closed() {
+                return;
+            }
             let step = match merger.step() {
                 Ok(s) => s,
                 Err(e) => {

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
@@ -201,7 +201,16 @@ mod tests {
 
     /// The guard trips its token on drop — the mechanism the timed-out query
     /// relies on — and does not trip it before.
+    // #[serial] with the abandonment test (roborev round 4): `per_call()` arms the
+    // probe and `check()` on a cancelled token records an abandonment, so this test
+    // increments the SAME process-global counters `abandon_tests` resets and then
+    // asserts on. `#[serial]` does not exclude UNANNOTATED tests, so without this
+    // annotation a concurrent run of this test could satisfy that test's
+    // `armed() > 0` anti-vacuity guard AND its `abandoned() >= 1` assertion while
+    // the merge under test did neither — a vacuous pass in the one test whose whole
+    // job is proving the abandonment really happened.
     #[test]
+    #[serial_test::serial]
     fn guard_cancels_its_token_on_drop() {
         let (guard, cancel) = per_call();
         assert!(
@@ -223,7 +232,9 @@ mod tests {
     /// Each call mints an INDEPENDENT token, so one query's cancellation can never
     /// reach another's in-flight merge (the reason a shared reader token must not
     /// be reused here).
+    // #[serial] for the same reason as above: `per_call()` arms the probe.
     #[test]
+    #[serial_test::serial]
     fn tokens_are_independent_per_call() {
         let (guard_a, cancel_a) = per_call();
         let (_guard_b, cancel_b) = per_call();

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
@@ -1,0 +1,91 @@
+//! Per-CALL cancellation for the detached `spawn_blocking` merges (issue #1695).
+//!
+//! # Why future-drop is not enough here
+//!
+//! The query budget (`query.max_execution_time`) is enforced by ONE
+//! `tokio::time::timeout` at the engine chokepoint (`query::engine::deadline`),
+//! and its whole cancellation mechanism is DROPPING the inner future. That is
+//! correct for async cooperative code — a dropped future stops being polled — but
+//! tokio CANNOT cancel a `spawn_blocking` closure by dropping its `JoinHandle`:
+//! the closure runs to completion on its blocking thread regardless.
+//!
+//! The materializing cross-generation merges build a `Vec` inside such a closure
+//! with no intermediate channel send that could fail, so a dropped handle left the
+//! ENTIRE multi-generation merge running after `Error::QueryTimeout` had already
+//! been returned to the caller — the timed-out query kept burning a blocking
+//! thread (and its scan-admission permit) to produce rows nobody would read.
+//! (The STREAMING driver has no such gap: its `blocking_send` fails as soon as the
+//! consumer is gone, which ends its loop within one merge step.)
+//!
+//! # The shape: a guard in the async scope, a flag in the closure
+//!
+//! [`per_call`] mints a FRESH token per call and returns it paired with a guard
+//! that [`ScanCancel::cancel`]s it on `Drop`. The guard lives in the async fn's
+//! own scope, so whatever destroys that future — a timeout elapse, a client
+//! disconnect, a caller's `drop` — trips the flag, and the blocking merge loop
+//! observes it at its next per-partition check and abandons the merge.
+//!
+//! It is per-call BY CONSTRUCTION, which is the load-bearing property: the token
+//! on a shared [`crate::storage::sstable::reader::SSTableReader`]
+//! (`SSTableReader::scan_cancel`) is reachable from every query using that reader,
+//! so tripping THAT one would cancel other queries' in-flight scans. Nothing but a
+//! freshly-minted token is safe here.
+//!
+//! No deadline knowledge crosses this boundary: the merge never reads a clock and
+//! never learns the budget (issue #1695's mandate is one wrapper at the
+//! chokepoint, never ad-hoc clock checks in a scan loop). It only makes the
+//! blocking walk ABANDONABLE, at the same coarse per-partition cadence at which
+//! the async paths are already cancellable.
+
+use crate::storage::scan_cancel::ScanCancel;
+
+/// Trips its token when dropped. Held in the async scope of a merge helper; the
+/// clone of the token it cancels lives inside that helper's blocking closure.
+pub(super) struct CancelOnDrop(ScanCancel);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
+}
+
+/// A fresh per-call token plus the guard that cancels it when the calling future
+/// is dropped. Bind the guard (`let (_guard, cancel) = per_call();`) so it lives
+/// as long as the async fn's scope, and move `cancel` into the blocking closure.
+pub(super) fn per_call() -> (CancelOnDrop, ScanCancel) {
+    let token = ScanCancel::new();
+    (CancelOnDrop(token.clone()), token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guard trips its token on drop — the mechanism the timed-out query
+    /// relies on — and does not trip it before.
+    #[test]
+    fn guard_cancels_its_token_on_drop() {
+        let (guard, cancel) = per_call();
+        assert!(!cancel.is_cancelled(), "must start un-cancelled");
+        drop(guard);
+        assert!(
+            cancel.is_cancelled(),
+            "dropping the async-scope guard must trip the blocking closure's flag"
+        );
+    }
+
+    /// Each call mints an INDEPENDENT token, so one query's cancellation can never
+    /// reach another's in-flight merge (the reason a shared reader token must not
+    /// be reused here).
+    #[test]
+    fn tokens_are_independent_per_call() {
+        let (guard_a, cancel_a) = per_call();
+        let (_guard_b, cancel_b) = per_call();
+        drop(guard_a);
+        assert!(cancel_a.is_cancelled());
+        assert!(
+            !cancel_b.is_cancelled(),
+            "a per-call token must be private to its own call"
+        );
+    }
+}

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
@@ -53,9 +53,79 @@ impl Drop for CancelOnDrop {
 /// is dropped. Bind the guard (`let (_guard, cancel) = per_call();`) so it lives
 /// as long as the async fn's scope, and move `cancel` into the blocking closure.
 pub(super) fn per_call() -> (CancelOnDrop, ScanCancel) {
+    probe::record_armed();
     let token = ScanCancel::new();
     (CancelOnDrop(token.clone()), token)
 }
+
+/// The blocking merge loop's per-partition poll: `Err(Error::Cancelled)` once the
+/// caller's future is gone, else `Ok(())`.
+///
+/// Call it at the TOP of the loop, BEFORE `step()`, so an abandoned merge does no
+/// further work at all — that ordering is what makes "abandoned" mean "zero
+/// partitions merged since the flag was tripped", which is what the probe's
+/// [`probe::abandoned`] count lets a test assert without any timing.
+pub(super) fn check(cancel: &ScanCancel) -> crate::Result<()> {
+    if cancel.is_cancelled() {
+        probe::record_abandoned();
+        return Err(crate::Error::Cancelled);
+    }
+    Ok(())
+}
+
+/// Observability for the abandonment mechanism, on the `stream_merge_probe`
+/// pattern: the RECORD calls are unconditional `#[inline(always)]` functions whose
+/// BODIES are cfg-gated, so a default/release build links no atomic and pays
+/// nothing; the getters + [`probe::reset`] exist only in test / `work-counters`
+/// builds. Without them "the merge abandoned instead of running to completion" is
+/// unobservable from outside, and any test of it would have to time something.
+pub(super) mod probe {
+    #[cfg(any(test, feature = "work-counters"))]
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Merges that ARMED a per-call guard (i.e. reached the spawn point).
+    #[cfg(any(test, feature = "work-counters"))]
+    static ARMED: AtomicU64 = AtomicU64::new(0);
+    /// Merge loops that exited via the cancel check rather than completing.
+    #[cfg(any(test, feature = "work-counters"))]
+    static ABANDONED: AtomicU64 = AtomicU64::new(0);
+
+    #[inline(always)]
+    pub(super) fn record_armed() {
+        #[cfg(any(test, feature = "work-counters"))]
+        ARMED.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline(always)]
+    pub(super) fn record_abandoned() {
+        #[cfg(any(test, feature = "work-counters"))]
+        ABANDONED.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Merges that armed a guard since the last [`reset`].
+    #[cfg(any(test, feature = "work-counters"))]
+    pub(crate) fn armed() -> u64 {
+        ARMED.load(Ordering::Relaxed)
+    }
+
+    /// Merge loops ABANDONED since the last [`reset`] — each one is a blocking
+    /// merge that stopped instead of building a `Vec` nobody could receive.
+    #[cfg(any(test, feature = "work-counters"))]
+    pub(crate) fn abandoned() -> u64 {
+        ABANDONED.load(Ordering::Relaxed)
+    }
+
+    /// Zero both counters. The statics are process-global, so callers serialize on
+    /// the shared test mutex (the counter-test convention).
+    #[cfg(any(test, feature = "work-counters"))]
+    pub(crate) fn reset() {
+        ARMED.store(0, Ordering::Relaxed);
+        ABANDONED.store(0, Ordering::Relaxed);
+    }
+}
+
+#[cfg(all(test, not(feature = "tombstones")))]
+mod abandon_tests;
 
 #[cfg(test)]
 mod tests {
@@ -66,11 +136,19 @@ mod tests {
     #[test]
     fn guard_cancels_its_token_on_drop() {
         let (guard, cancel) = per_call();
+        assert!(
+            check(&cancel).is_ok(),
+            "an un-cancelled token must not stop a merge"
+        );
         assert!(!cancel.is_cancelled(), "must start un-cancelled");
         drop(guard);
         assert!(
             cancel.is_cancelled(),
             "dropping the async-scope guard must trip the blocking closure's flag"
+        );
+        assert!(
+            matches!(check(&cancel), Err(crate::Error::Cancelled)),
+            "the merge loop's poll must abandon once the guard has dropped"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
@@ -17,6 +17,23 @@
 //! (The STREAMING driver has no such gap: its `blocking_send` fails as soon as the
 //! consumer is gone, which ends its loop within one merge step.)
 //!
+//! # Two granularities, and why the token also goes INTO the merger
+//!
+//! [`check`] is called once per partition, which is the merge's own unit of work
+//! — but a single `KWayMerger::step()` can itself be long, because the merger's
+//! producer threads are doing the actual SSTable decode. So the token is ALSO
+//! handed to the merger's input readers via `KWayMerger::new_cancellable` /
+//! `build_single_partition_merger_from_readers` (#2264's cooperative reader
+//! cancellation), letting an abandoned merge stop MID-step instead of finishing
+//! the partition it is decoding. This costs nothing and removes nothing: the
+//! tokens it displaces were `ScanCancel::default()` (what plain `KWayMerger::new`
+//! installs) and one literal `ScanCancel::new()` — neither reachable by any
+//! caller, so neither could ever be tripped. It must stay the PER-CALL token for
+//! the same reason as below; the shared reader token would cancel other queries.
+//! Producer TEARDOWN was already safe without this (#2361: dropping a
+//! `KWayMerger` closes the channel, trips the readers' token and joins the
+//! threads) — this is about promptness, not leaks.
+//!
 //! # The shape: a guard in the async scope, a flag in the closure
 //!
 //! [`per_call`] mints a FRESH token per call and returns it paired with a guard
@@ -140,6 +157,42 @@ mod abandon_tests;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Structural pin (#1695 roborev round 2): the three MATERIALIZING merges must
+    /// hand their per-call token to the merger's own input readers, not the inert
+    /// default. Behavioural coverage cannot reach this — "a reader stops mid-step"
+    /// is only observable as a latency difference, and a wall-clock assert in the
+    /// correctness path is forbidden — so the invariant is asserted on the source.
+    ///
+    /// It is deliberately NOT "no `KWayMerger::new` anywhere": the STREAMING driver
+    /// (`stream_generations_for_read`) keeps the plain constructor on purpose, since
+    /// its `blocking_send` already fails the instant the consumer is dropped.
+    #[test]
+    fn the_materializing_merges_pass_their_token_into_the_merger() {
+        let src = include_str!("../generation_merge.rs");
+
+        assert_eq!(
+            src.matches("KWayMerger::new_cancellable(").count(),
+            2,
+            "`merge_generations_for_read` and `merge_generations_for_read_with_metadata` \
+             must each build a CANCELLABLE merger; a plain `KWayMerger::new` there installs \
+             `ScanCancel::default()`, which no caller can ever trip"
+        );
+
+        assert!(
+            !src.contains("ScanCancel::new()"),
+            "`seek_merge_generations_for_read` must pass its per-call token to \
+             `build_single_partition_merger_from_readers`; a freshly-minted \
+             `ScanCancel::new()` is unreachable by any caller and cancels nothing"
+        );
+
+        assert_eq!(
+            src.matches("merge_cancel::per_call()").count(),
+            3,
+            "one fresh token per materializing merge — a token shared across calls \
+             would let one query's timeout cancel another query's merge"
+        );
+    }
 
     /// The guard trips its token on drop — the mechanism the timed-out query
     /// relies on — and does not trip it before.

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
@@ -179,11 +179,16 @@ mod tests {
              `ScanCancel::default()`, which no caller can ever trip"
         );
 
-        assert!(
-            !src.contains("ScanCancel::new()"),
-            "`seek_merge_generations_for_read` must pass its per-call token to \
-             `build_single_partition_merger_from_readers`; a freshly-minted \
-             `ScanCancel::new()` is unreachable by any caller and cancels nothing"
+        // AFFIRMATIVE, not "no inert constructor survives": an absence assert over
+        // source is defeated by any COMMENT that names the thing it forbids (the
+        // first draft of this test was, by a comment two lines from the call site).
+        // Counting the tokens actually handed out cannot be satisfied by prose.
+        assert_eq!(
+            src.matches("cancel.clone()").count(),
+            3,
+            "each of the 3 per-call tokens must be handed to a merger — the two \
+             cancellable `KWayMerger`s and `build_single_partition_merger_from_readers`, \
+             whose token was a discarded `ScanCancel` that no caller could ever trip"
         );
 
         assert_eq!(

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
@@ -34,6 +34,31 @@
 //! `KWayMerger` closes the channel, trips the readers' token and joins the
 //! threads) — this is about promptness, not leaks.
 //!
+//! # Why the streaming producer needs its own check (roborev round 8)
+//!
+//! `stream_generations_for_read` was excluded from the guard above on the grounds
+//! that its `out_tx.blocking_send(..).is_err()` already retires it when the consumer
+//! drops. That reasoning was INCOMPLETE: a send-failure check is only reached when a
+//! partition actually yields a row, and three paths in that loop `continue` without
+//! sending — a partition below `start_key`, one above `end_key`, and one whose rows
+//! are all tombstoned or TTL-expired (`live` empty). A range scan matching nothing,
+//! or a no-match full scan, therefore performed not one send and so not one check,
+//! and walked the whole remaining table after `QueryTimeout` had already been handed
+//! back to the caller.
+//!
+//! It uses `Sender::is_closed()` at the top of its loop rather than this module's
+//! token: closure is already observable through the channel it owns, so nothing has
+//! to be plumbed in and no `Drop` impl is needed on the stream, and it strictly
+//! dominates the send-failure check. The token machinery here remains the right tool
+//! for the MATERIALIZING merges, which have no channel to consult at all.
+//!
+//! RESIDUAL: neither mechanism can abort a single long `KWayMerger::step()` on the
+//! streaming path, because that merger's readers still hold an inert
+//! `ScanCancel::default()`. Fixing that means a drop-tripped guard living inside
+//! `JoinedStream` so the readers can be cancelled too — the deferred "carry
+//! cancellation into the core streaming producer" work, which also covers the
+//! per-batch bound and lets core RECORD the elapse.
+//!
 //! # The shape: a guard in the async scope, a flag in the closure
 //!
 //! [`per_call`] mints a FRESH token per call and returns it paired with a guard
@@ -157,6 +182,43 @@ mod abandon_tests;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Structural pin (#1695 roborev round 8): the STREAMING producer must observe
+    /// consumer closure BEFORE it does a merge step, not only when it sends.
+    ///
+    /// Behavioural coverage cannot reach this without being vacuous. To show the
+    /// difference you need a producer that is still alive, has work left, and has
+    /// nothing to send — and on any fixture small enough for the suite, a no-match
+    /// scan runs to completion and the producer exits ON ITS OWN, so the case passes
+    /// with the check deleted. Making it discriminating needs a fixture large enough
+    /// that "walks the rest of the table" is observably slower than "stops now",
+    /// which is a wall-clock threshold in the correctness path — forbidden. So the
+    /// invariant is asserted on the source, and ORDER is the substance of it: a check
+    /// placed after `step()` would still pay for a full step per iteration after the
+    /// consumer is gone.
+    #[test]
+    fn the_streaming_producer_checks_closure_before_stepping() {
+        let src = include_str!("../generation_merge.rs");
+
+        let check = src.find("if out_tx.is_closed()").expect(
+            "the streaming producer must consult `is_closed()`; without it the \
+                     only stop signal is a failing send, which the three `continue` \
+                     paths never reach",
+        );
+        let step = src
+            .find("let step = match merger.step()")
+            .expect("the streaming producer's merge step must still be there");
+        assert!(
+            check < step,
+            "the closure check must come BEFORE the merge step, else an abandoned \
+             stream still pays for one full step per iteration"
+        );
+        assert_eq!(
+            src.matches("if out_tx.is_closed()").count(),
+            1,
+            "exactly one closure check is expected in the streaming producer"
+        );
+    }
 
     /// Structural pin (#1695 roborev round 2): the three MATERIALIZING merges must
     /// hand their per-call token to the merger's own input readers, not the inert

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_cancel.rs
@@ -76,49 +76,59 @@ pub(super) fn check(cancel: &ScanCancel) -> crate::Result<()> {
 /// Observability for the abandonment mechanism, on the `stream_merge_probe`
 /// pattern: the RECORD calls are unconditional `#[inline(always)]` functions whose
 /// BODIES are cfg-gated, so a default/release build links no atomic and pays
-/// nothing; the getters + [`probe::reset`] exist only in test / `work-counters`
-/// builds. Without them "the merge abandoned instead of running to completion" is
+/// nothing. Without them "the merge abandoned instead of running to completion" is
 /// unobservable from outside, and any test of it would have to time something.
+///
+/// Gated on `cfg(test)` ALONE — deliberately narrower than `stream_merge_probe`'s
+/// `any(test, feature = "work-counters")`. The only consumer is the in-crate
+/// [`super::abandon_tests`], which needs a `max_blocking_threads(1)` runtime it
+/// builds itself, so nothing in `tests/` can use these; adding the feature arm
+/// would only make the getters dead code in a `--all-features` build. A future
+/// integration consumer adds `feature = "work-counters"` back to all of the cfgs
+/// below, together. The READERS carry `not(feature = "tombstones")` as well,
+/// because their one caller does: that build has no `multi_gen_fixture` (its
+/// `scan_stream` routes through the materializing `scan`), so under
+/// `--all-features` the getters would be dead code.
 pub(super) mod probe {
-    #[cfg(any(test, feature = "work-counters"))]
+    #[cfg(test)]
     use std::sync::atomic::{AtomicU64, Ordering};
 
     /// Merges that ARMED a per-call guard (i.e. reached the spawn point).
-    #[cfg(any(test, feature = "work-counters"))]
+    #[cfg(test)]
     static ARMED: AtomicU64 = AtomicU64::new(0);
     /// Merge loops that exited via the cancel check rather than completing.
-    #[cfg(any(test, feature = "work-counters"))]
+    #[cfg(test)]
     static ABANDONED: AtomicU64 = AtomicU64::new(0);
 
     #[inline(always)]
     pub(super) fn record_armed() {
-        #[cfg(any(test, feature = "work-counters"))]
+        #[cfg(test)]
         ARMED.fetch_add(1, Ordering::Relaxed);
     }
 
     #[inline(always)]
     pub(super) fn record_abandoned() {
-        #[cfg(any(test, feature = "work-counters"))]
+        #[cfg(test)]
         ABANDONED.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Merges that armed a guard since the last [`reset`].
-    #[cfg(any(test, feature = "work-counters"))]
-    pub(crate) fn armed() -> u64 {
+    #[cfg(all(test, not(feature = "tombstones")))]
+    pub(super) fn armed() -> u64 {
         ARMED.load(Ordering::Relaxed)
     }
 
     /// Merge loops ABANDONED since the last [`reset`] — each one is a blocking
     /// merge that stopped instead of building a `Vec` nobody could receive.
-    #[cfg(any(test, feature = "work-counters"))]
-    pub(crate) fn abandoned() -> u64 {
+    #[cfg(all(test, not(feature = "tombstones")))]
+    pub(super) fn abandoned() -> u64 {
         ABANDONED.load(Ordering::Relaxed)
     }
 
     /// Zero both counters. The statics are process-global, so callers serialize on
     /// the shared test mutex (the counter-test convention).
-    #[cfg(any(test, feature = "work-counters"))]
-    pub(crate) fn reset() {
+    #[cfg(all(test, not(feature = "tombstones")))]
+    pub(super) fn reset() {
         ARMED.store(0, Ordering::Relaxed);
         ABANDONED.store(0, Ordering::Relaxed);
     }

--- a/cqlite-core/src/storage/sstable/generation_merge/merge_cancel/abandon_tests.rs
+++ b/cqlite-core/src/storage/sstable/generation_merge/merge_cancel/abandon_tests.rs
@@ -1,0 +1,153 @@
+//! The multi-generation merge ABANDONS its detached blocking work when the
+//! caller's future is dropped (issue #1695, roborev blocker).
+//!
+//! # Why this is a hard case to test honestly
+//!
+//! The defect is a RACE by nature — a timer fires while a blocking thread is
+//! mid-merge — and "the merge stopped early" is invisible from the result (the
+//! caller is gone; there IS no result). Asserting it by elapsed time would be the
+//! wall-clock-threshold anti-pattern (#2642), and asserting it by "wait and hope
+//! the merge did not finish first" would be a flake generator: pre-fix the merge
+//! ALSO terminates — just later.
+//!
+//! # The construction that removes the race entirely
+//!
+//! The runtime is built with `max_blocking_threads(1)` and the test OCCUPIES that
+//! one thread with a closure parked on a channel it controls. The merge's
+//! `spawn_blocking` closure is therefore QUEUED and cannot have started. Only then
+//! is the scan future dropped — tripping the per-call flag — and only then is the
+//! occupier released. The merge closure thus begins with its flag ALREADY set, so
+//! its first per-partition check (which sits BEFORE the first `step()`) decides
+//! the outcome deterministically, on every host and under any scheduler.
+//!
+//! `probe::abandoned()` is the observable, and `probe::armed()` is the
+//! anti-vacuity guard: `armed == 1` proves the scan really reached the merge's
+//! spawn point (a fixture or routing mistake that never got there would otherwise
+//! leave both counters at zero and "prove" nothing). Pre-fix — with the closure
+//! running to completion on a dropped `JoinHandle` — `abandoned()` stays `0`.
+//!
+//! Surface: `SSTableManager::scan`, the public API the query engine's bounded
+//! `execute` reaches for a multi-generation table. The engine half of the chain
+//! (an elapsed budget DROPS the inner future) is pinned separately by
+//! `query::engine::deadline::tests::elapse_drops_the_inner_future` and
+//! `tests/issue_1695_query_timeout.rs`.
+
+use std::sync::mpsc;
+
+use serial_test::serial;
+use tempfile::TempDir;
+
+use super::probe;
+use crate::storage::sstable::generation_merge::multi_gen_fixture as fixture;
+use crate::storage::write_engine::test_support::create_test_schema;
+
+/// Bound on how many yields we give the released merge closure to record its
+/// abandonment. NOT a timing assertion: the outcome is already decided by
+/// construction, this only stops the test hanging if the mechanism is absent.
+const MAX_POLLS: usize = 2_000;
+
+#[test]
+#[serial]
+fn a_dropped_multi_generation_read_abandons_its_blocking_merge() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        // THE construction: exactly one blocking thread, which the test holds.
+        .max_blocking_threads(1)
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async {
+        let temp = TempDir::new().expect("temp dir");
+        let data_dir = fixture::flush_overlapping_generations(&temp).await;
+        let manager = fixture::open_manager(&data_dir).await;
+        let schema = create_test_schema();
+        let table = fixture::table_id();
+
+        // Precondition: this fixture really does route through the reconciling
+        // multi-generation merge (a single-generation table would never spawn the
+        // blocking merge at all, making everything below vacuous). Also warms every
+        // reader, so the dropped scan below needs no blocking thread before the
+        // merge's own `spawn_blocking`.
+        let warm = manager
+            .scan(&table, None, None, None, Some(&schema))
+            .await
+            .expect("warm-up scan");
+        assert_eq!(
+            warm.len(),
+            fixture::reconciled_rows(),
+            "precondition: the fixture must reconcile across generations, else no \
+             cross-generation merge runs and this case proves nothing"
+        );
+
+        probe::reset();
+
+        // Occupy the single blocking thread so the merge closure can only QUEUE.
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let (running_tx, running_rx) = tokio::sync::oneshot::channel::<()>();
+        let occupier = tokio::task::spawn_blocking(move || {
+            let _ = running_tx.send(());
+            let _ = release_rx.recv();
+        });
+        running_rx.await.expect("occupier must be on the thread");
+
+        // Drive the scan to its first suspension. With the pool occupied that is the
+        // `spawn_blocking` join inside the merge, so the closure is queued, unstarted.
+        let mut scan = Box::pin(manager.scan(&table, None, None, None, Some(&schema)));
+        let mut armed = false;
+        for _ in 0..MAX_POLLS {
+            if poll_once(&mut scan).is_some() {
+                panic!(
+                    "the scan must not COMPLETE: its merge cannot run, the one blocking \
+                     thread is held by the occupier"
+                );
+            }
+            if probe::armed() > 0 {
+                armed = true;
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            armed,
+            "precondition: the scan must reach the merge's spawn point (armed guard); \
+             without it nothing was queued and the case would be vacuous"
+        );
+        assert_eq!(
+            probe::abandoned(),
+            0,
+            "precondition: nothing may be abandoned yet — the closure has not started"
+        );
+
+        // THE EVENT: the caller's future goes away. Nothing else changes.
+        drop(scan);
+
+        // Let the queued merge closure run. It starts with its flag already tripped.
+        drop(release_tx);
+        occupier.await.expect("occupier join");
+
+        for _ in 0..MAX_POLLS {
+            if probe::abandoned() >= 1 {
+                return;
+            }
+            tokio::task::yield_now().await;
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        panic!(
+            "the blocking merge did NOT abandon after its caller's future was dropped: it \
+             ran to completion building a result nobody could receive (armed={}, abandoned={})",
+            probe::armed(),
+            probe::abandoned()
+        );
+    });
+}
+
+/// Poll `fut` exactly once with a no-op waker: `None` when it is still pending.
+fn poll_once<F: std::future::Future>(fut: &mut std::pin::Pin<Box<F>>) -> Option<F::Output> {
+    let waker = std::task::Waker::noop();
+    let mut cx = std::task::Context::from_waker(waker);
+    match fut.as_mut().poll(&mut cx) {
+        std::task::Poll::Ready(v) => Some(v),
+        std::task::Poll::Pending => None,
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -211,6 +211,22 @@ impl SSTableReader {
                         return Err(e);
                     }
                 };
+                // #1695: observe consumer closure once per BLOCK, not only when a
+                // batch fills. The four `continue` paths below (table-id mismatch,
+                // below `start`, above `end`, tombstone-filtered) never reach a send,
+                // and `BATCH_EMIT_ROWS` gates the send even when rows DO survive — so
+                // a scan whose filters reject everything read and PARSED every block
+                // of the table after the caller already had its `QueryTimeout`.
+                //
+                // This is the BATCHED sibling of `per_row_scan_stream`'s non-stitching
+                // walk and is the surface query execution actually uses, so fixing only
+                // the per-row one (as an earlier revision did) left the common path
+                // exposed. A plain check suffices: the await above is a bounded disk
+                // read that always returns here, not an open-ended wait on another
+                // producer.
+                if tx.is_closed() {
+                    return Ok(());
+                }
                 let entries = match self.parse_batched_block(&block, schema.as_ref(), now_secs) {
                     Ok(entries) => entries,
                     Err(e) => {

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -650,6 +650,26 @@ impl SSTableReader {
             // 256-entry cadence as `sequential_scan`'s stitched branch so a
             // cancelled caller does not walk a huge already-parsed result set to
             // completion and then report success.
+            //
+            // KNOWN GAP for a QUERY TIMEOUT (#1695, roborev round 12), recorded here
+            // so it need not be re-derived: `scan_cancel` is the READER's SHARED
+            // token. #2264 trips it on a Flight client disconnect, and #2361 trips it
+            // when an iterator adapter drops — but NOTHING trips it when a streaming
+            // query's consumer goes away, so a timed-out scan over a BTI table keeps
+            // materialising this whole `results` Vec. The sibling producers were fixed
+            // by consulting their own channel (`tx.is_closed()` / racing
+            // `tx.closed()`), which is not available here: this function RETURNS a Vec
+            // and holds no sender.
+            //
+            // The fix is a closure→token bridge — a per-call token, a watcher awaiting
+            // the output sender's `closed()`, and that token passed in here in place of
+            // the reader's — which is the same mechanism the deferred "carry
+            // cancellation into the core streaming producer" work needs for
+            // `KWayMerger::step()` and `JoinedStream`. Deliberately NOT done ad hoc for
+            // BTI alone: three partial fixes in this area is how the gap got this
+            // scattered. Do NOT substitute the reader's token thinking it is
+            // equivalent — tripping THAT cancels other queries' scans on the same
+            // reader.
             scan_cancel.checkpoint(idx).await?;
             if prev_partition_key.as_ref() != Some(&entry_key) {
                 crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -661,15 +661,28 @@ impl SSTableReader {
             // `tx.closed()`), which is not available here: this function RETURNS a Vec
             // and holds no sender.
             //
-            // The fix is a closure→token bridge — a per-call token, a watcher awaiting
-            // the output sender's `closed()`, and that token passed in here in place of
-            // the reader's — which is the same mechanism the deferred "carry
-            // cancellation into the core streaming producer" work needs for
-            // `KWayMerger::step()` and `JoinedStream`. Deliberately NOT done ad hoc for
-            // BTI alone: three partial fixes in this area is how the gap got this
-            // scattered. Do NOT substitute the reader's token thinking it is
-            // equivalent — tripping THAT cancels other queries' scans on the same
-            // reader.
+            // WHAT IS ACTUALLY MISSING, verified rather than guessed (roborev raised
+            // this twice, so the next person should not have to re-derive it):
+            // `bti_scan_with_metadata_cancellable` already exists and already takes a
+            // `&ScanCancel`, so the plumbing is NOT the gap. The gap is that the
+            // caller has no token it can legitimately pass:
+            //
+            //  * A CLONE of the reader's token is wrong — clones share state, so
+            //    tripping it cancels OTHER queries scanning the same reader. That is
+            //    the trap the materializing merges avoided with a per-call token.
+            //  * A FRESH per-call token tripped by a watcher on the output sender's
+            //    `closed()` handles the timeout case but silently DROPS #2264's Flight
+            //    cancellation, which trips the reader token WITHOUT necessarily
+            //    dropping the receiver — so a client disconnect would go back to the
+            //    ~1–2 min transport backstop. Losing existing cancellation to add new
+            //    cancellation is not a fix.
+            //
+            // So this needs one small API decision — a token that represents "either
+            // the reader's OR this stream's closure" (a linked/derived `ScanCancel`) —
+            // and that composition is the same primitive the deferred `JoinedStream` /
+            // `KWayMerger::step()` work needs. It is deliberately not improvised here:
+            // three partial fixes in this area is how the gap got this scattered, and a
+            // fourth guessing at token composition would be the worst of them.
             scan_cancel.checkpoint(idx).await?;
             if prev_partition_key.as_ref() != Some(&entry_key) {
                 crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -758,9 +758,45 @@ impl SSTableReader {
         now_secs: Option<i64>,
         out: &WindowedOut,
     ) -> Result<()> {
-        let entries = self
-            .bti_scan_with_metadata(start_key, end_key, None, schema, true, now_secs)
-            .await?;
+        // #1695 (roborev raised this in rounds 12, 14 and 15): race the
+        // materialization against OUR consumer's departure.
+        //
+        // `bti_scan_with_metadata` materializes the WHOLE table into `entries` before
+        // the first send below, so the send-failure checks in the arms are reached
+        // only after all the work is done. Its internal `scan_cancel.checkpoint(idx)`
+        // polls the READER-WIDE token, which #2264 trips on a Flight disconnect and
+        // #2361 on adapter teardown — but nothing trips when a timed-out streaming
+        // query drops its iterator. So a timed-out query kept decoding and sorting a
+        // whole BTI table.
+        //
+        // Racing the scan FUTURE is what fixes it, and it needs no new cancellation
+        // plumbing: the checkpoints inside are await points, so dropping the future
+        // there abandons the scan within one checkpoint interval. Crucially the
+        // reader-wide token is still passed through untouched, so #2264 and #2361 keep
+        // working — nothing is traded away for this. (An earlier attempt added a
+        // "derive a per-stream token from the reader's" API for the same purpose; it
+        // was removed once the race proved to give the same semantics with no new
+        // surface. Do not reintroduce it without a caller the race cannot serve.)
+        //
+        // `biased` so an already-departed consumer wins over a ready scan.
+        //
+        // RESIDUAL, deliberately: `sort_by_token_order_with_meta` after the loop is
+        // SYNCHRONOUS, so a departure during the sort is not observed until it ends.
+        // That is bounded by one sort rather than a whole table walk, and is the same
+        // uninterruptible-post-scan-stage limit documented at the chokepoint.
+        let scan = self.bti_scan_with_metadata(start_key, end_key, None, schema, true, now_secs);
+        let entries = match out {
+            WindowedOut::PerRow(tx) => tokio::select! {
+                biased;
+                _ = tx.closed() => return Ok(()),
+                result = scan => result?,
+            },
+            WindowedOut::Batched(tx) => tokio::select! {
+                biased;
+                _ = tx.closed() => return Ok(()),
+                result = scan => result?,
+            },
+        };
 
         match out {
             WindowedOut::PerRow(tx) => {

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -650,9 +650,7 @@ impl SSTableReader {
             // 256-entry cadence as `sequential_scan`'s stitched branch so a
             // cancelled caller does not walk a huge already-parsed result set to
             // completion and then report success.
-            if idx & 0xFF == 0 {
-                scan_cancel.check()?;
-            }
+            scan_cancel.checkpoint(idx).await?;
             if prev_partition_key.as_ref() != Some(&entry_key) {
                 crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
                 prev_partition_key = Some(entry_key.clone());

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -150,7 +150,11 @@ impl SSTableReader {
             // `do_get` abandons the walk promptly, and yield every 256th so the
             // chokepoint `max_execution_time` timeout can elapse mid-walk (#1695).
             // Issue #2346: PER-CALL token.
-            scan_cancel.checkpoint(i).await?;
+            // `checkpoint_now`, not `checkpoint(i)`: this loop polled cancellation
+            // on EVERY iteration before #1695 (one real index random read per
+            // iteration is already coarse), and the stride-gated `checkpoint`
+            // would have quietly lowered that to one poll per 256.
+            scan_cancel.checkpoint_now().await?;
 
             // Roborev job 1610 (finding 1): `raw_key: None` never actually occurs
             // in practice — `parse_big_index_entry` always sets `Some(raw_key)` —

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -150,11 +150,13 @@ impl SSTableReader {
             // `do_get` abandons the walk promptly, and yield every 256th so the
             // chokepoint `max_execution_time` timeout can elapse mid-walk (#1695).
             // Issue #2346: PER-CALL token.
-            // `checkpoint_now`, not `checkpoint(i)`: this loop polled cancellation
-            // on EVERY iteration before #1695 (one real index random read per
-            // iteration is already coarse), and the stride-gated `checkpoint`
-            // would have quietly lowered that to one poll per 256.
-            scan_cancel.checkpoint_now().await?;
+            // `checkpoint_polled`, which is the ONLY one of the three that leaves
+            // this loop's cadences BOTH unchanged: it polled cancellation on every
+            // iteration before #1695 (one real index random read each is already
+            // coarse) and had NO yield at all. `checkpoint(i)` would lower the poll
+            // to one per 256; `checkpoint_now()` would add a runtime reschedule per
+            // partition to every large index-backed scan.
+            scan_cancel.checkpoint_polled(i).await?;
 
             // Roborev job 1610 (finding 1): `raw_key: None` never actually occurs
             // in practice — `parse_big_index_entry` always sets `Some(raw_key)` —

--- a/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/full_index_scan.rs
@@ -145,10 +145,12 @@ impl SSTableReader {
         let schema = reader_schema.as_ref();
         let mut results = Vec::new();
         for i in 0..entries.len() {
-            // Cooperative cancellation (issue #2264): one real index-random-read +
+            // Cooperative checkpoint (issue #2264): one real index-random-read +
             // Data.db parse per partition — poll every entry so a cancelled Flight
-            // `do_get` abandons the walk promptly. Issue #2346: PER-CALL token.
-            scan_cancel.check()?;
+            // `do_get` abandons the walk promptly, and yield every 256th so the
+            // chokepoint `max_execution_time` timeout can elapse mid-walk (#1695).
+            // Issue #2346: PER-CALL token.
+            scan_cancel.checkpoint(i).await?;
 
             // Roborev job 1610 (finding 1): `raw_key: None` never actually occurs
             // in practice — `parse_big_index_entry` always sets `Some(raw_key)` —

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -451,12 +451,11 @@ impl SSTableReader {
 
         let mut chunk_count = 0;
         while let Some(compressed_chunk) = self.read_next_block(cursor).await? {
-            // Cooperative cancellation (issue #2346): poll the per-call token every
-            // 256 chunks so a cancelled stitched scan abandons the I/O/decompress
-            // walk promptly instead of stitching the entire data section first.
-            if chunk_count & 0xFF == 0 {
-                scan_cancel.check()?;
-            }
+            // Cooperative checkpoint (issue #2346): poll the per-call token so a
+            // cancelled stitched scan abandons the I/O/decompress walk promptly
+            // instead of stitching the entire data section first, yielding every
+            // 256 chunks so the chokepoint timeout can elapse here too (#1695).
+            scan_cancel.checkpoint(chunk_count).await?;
             let decompressed_chunk = if compressed_chunk.len() >= max_compressed_length {
                 // Stored uncompressed by Cassandra — pass the raw bytes through.
                 tracing::debug!(

--- a/cqlite-core/src/storage/sstable/reader/data_access/per_row_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/per_row_scan_stream.rs
@@ -202,6 +202,22 @@ impl SSTableReader {
             // Non-stitching formats already read block-by-block; emit per block so
             // only one block's entries are live at a time.
             while let Some(block) = self.read_next_block(&cursor).await? {
+                // #1695: observe consumer closure once per BLOCK, not only on a send.
+                // The four `continue` paths below (table-id mismatch, below `start`,
+                // above `end`, tombstone-filtered) reach no send, so a scan whose
+                // filters reject everything used to read and PARSE every block of the
+                // table after the caller already had its `QueryTimeout`. Found by
+                // sweeping this class rather than waiting for it to be reported: it is
+                // the same defect as `generation_merge`'s producer and the query-layer
+                // producer, in a third place.
+                //
+                // A plain check suffices here, where the query layer needed a `select!`
+                // on `tx.closed()`: this loop's await is a bounded disk read, not an
+                // open-ended wait on another producer, so it always returns to the
+                // check. One block is the loop's own unit of work.
+                if tx.is_closed() {
+                    return Ok(());
+                }
                 let entries =
                     self.parse_block_entries_with_schema(&block, schema.as_ref(), true)?;
                 for (entry_table_id, entry_key, entry_value) in entries {

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -545,14 +545,14 @@ impl SSTableReader {
             for (idx, (_entry_table_id, entry_key, entry_value)) in
                 all_entries.into_iter().enumerate()
             {
-                // Cooperative cancellation (issue #2346): the chunk-stitch loop
+                // Cooperative checkpoint (issue #2346): the chunk-stitch loop
                 // poll covers the I/O phase, but `parse_block` materialises every
-                // entry in one shot — poll here at the same 256-entry cadence as
-                // the non-stitching branch so a cancelled caller does not walk a
-                // huge already-parsed result set to completion.
-                if idx & 0xFF == 0 {
-                    scan_cancel.check()?;
-                }
+                // entry in one shot — checkpoint here so a cancelled caller does
+                // not walk a huge already-parsed result set to completion, and so
+                // the query-engine's ONE `max_execution_time` timeout can elapse
+                // mid-walk (issue #1695: the yield, at the same 256-entry cadence,
+                // is what makes this future `Pending`).
+                scan_cancel.checkpoint(idx).await?;
                 if prev_partition_key.as_ref() != Some(&entry_key) {
                     crate::storage::sstable::work_counters::add_stream_walk_partition_parsed();
                     prev_partition_key = Some(entry_key.clone());
@@ -602,11 +602,13 @@ impl SSTableReader {
         // stitching branch above for the "changed key = new partition" rationale.
         let mut prev_partition_key: Option<RowKey> = None;
         while let Some(block) = self.read_next_block(&cursor).await? {
-            // Cooperative cancellation (issue #2264): an index-less (Summary.db
+            // Cooperative checkpoint (issue #2264): an index-less (Summary.db
             // absent) SSTable materialises EVERY partition here in one pass; poll
             // the token per block so a cancelled Flight `do_get` abandons the walk
             // promptly instead of running to completion under the ~1–2 min backstop.
-            scan_cancel.check()?;
+            // A whole block is coarse, so every iteration is a correct yield point
+            // for the chokepoint timeout too (issue #1695).
+            scan_cancel.checkpoint_now().await?;
             block_count += 1;
             tracing::debug!(
                 "SSTableReader::sequential_scan - Read block {}, size {} bytes",
@@ -631,9 +633,7 @@ impl SSTableReader {
                 // elsewhere so materialisation honours the interval regardless of
                 // how large a single block turned out to be, independent of
                 // whichever inner parser branch produced `entries`.
-                if i & 0xFF == 0 {
-                    scan_cancel.check()?;
-                }
+                scan_cancel.checkpoint(i).await?;
                 tracing::debug!(
                     "SSTableReader::sequential_scan - Block {} entry {}: table_id='{}', key={:?}",
                     block_count,

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_forwarder.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_forwarder.rs
@@ -72,7 +72,24 @@ pub(super) fn spawn_windowed_forwarder(
             // Per-row (historical) surface: FLATTEN each confirmed batch back
             // into single `(RowKey, ScanRow)` items. One send per row.
             WindowedOut::PerRow(tx) => {
-                while let Some(batch) = batch_rx.recv().await {
+                loop {
+                    // #1695: race OUR consumer's closure against the upstream batch.
+                    // A forwarder has no skip paths, so it notices closure on its next
+                    // send — but only once a batch ARRIVES. While parked in `recv()` it
+                    // notices nothing, and the parse half upstream can be filtering
+                    // every row (its own filters reach no send either), so the whole
+                    // chain could sit idle-but-alive while upstream burned CPU to EOF.
+                    // That composite case is why "a parked forwarder burns nothing" was
+                    // the wrong reason to call this safe (roborev round 12).
+                    // `biased` so an already-gone consumer wins over a ready batch.
+                    let batch = tokio::select! {
+                        biased;
+                        _ = tx.closed() => return,
+                        next = batch_rx.recv() => match next {
+                            Some(batch) => batch,
+                            None => break,
+                        },
+                    };
                     match batch {
                         Ok(rows) => {
                             for entry in rows {
@@ -95,7 +112,16 @@ pub(super) fn spawn_windowed_forwarder(
             // through — one send per batch, not per row. A terminal error is
             // forwarded as one item then the stream ends.
             WindowedOut::Batched(tx) => {
-                while let Some(batch) = batch_rx.recv().await {
+                loop {
+                    // #1695: same race as the per-row arm above.
+                    let batch = tokio::select! {
+                        biased;
+                        _ = tx.closed() => return,
+                        next = batch_rx.recv() => match next {
+                            Some(batch) => batch,
+                            None => break,
+                        },
+                    };
                     let terminal = batch.is_err();
                     if tx.send(batch).await.is_err() {
                         return; // consumer dropped

--- a/cqlite-core/tests/ffi_error_contract_table.rs
+++ b/cqlite-core/tests/ffi_error_contract_table.rs
@@ -126,6 +126,25 @@ fn from_name_is_fail_closed_for_an_unknown_variant() {
     );
 }
 
+/// Issue #1695: a query budget elapse must land on the SAME identity as its sibling
+/// `Timeout` on both surfaces — Python's builtin `TimeoutError` and node code
+/// `TIMEOUT` — so `except TimeoutError:` in Python and a `TIMEOUT` check in JS both
+/// catch it. Its core CATEGORY is deliberately `Query` (a budget elapse is a
+/// query-execution failure, distinguishable from corruption per #1695), which is a
+/// different axis from the surface identity; `table_agrees_with_core_category_and_recoverable`
+/// is what keeps that field honest against `Error::classify()`.
+#[test]
+fn query_timeout_shares_the_timeout_identity_on_both_surfaces() {
+    let row = contract_for(&FfiErrorVariant::QueryTimeout.sample_error().expect("sample exists"));
+    assert_eq!(row.py_class, PyExceptionClass::Timeout);
+    assert_eq!(row.node_code, "TIMEOUT");
+    assert_eq!(
+        row.category,
+        cqlite_core::error::ErrorCategory::Query,
+        "the classify category is a separate axis from the surface identity"
+    );
+}
+
 /// The row count is pinned so adding an `Error` variant (and therefore a row)
 /// is a deliberate, reviewed act rather than an invisible one. Update the count
 /// together with the table.
@@ -133,7 +152,7 @@ fn from_name_is_fail_closed_for_an_unknown_variant() {
 fn row_count_is_pinned() {
     assert_eq!(
         FfiErrorVariant::ALL.len(),
-        37,
+        38,
         "contract row count changed — review the new row's py_class/node_code \
          and update this pin"
     );

--- a/cqlite-core/tests/ffi_error_contract_table.rs
+++ b/cqlite-core/tests/ffi_error_contract_table.rs
@@ -135,7 +135,11 @@ fn from_name_is_fail_closed_for_an_unknown_variant() {
 /// is what keeps that field honest against `Error::classify()`.
 #[test]
 fn query_timeout_shares_the_timeout_identity_on_both_surfaces() {
-    let row = contract_for(&FfiErrorVariant::QueryTimeout.sample_error().expect("sample exists"));
+    let row = contract_for(
+        &FfiErrorVariant::QueryTimeout
+            .sample_error()
+            .expect("sample exists"),
+    );
     assert_eq!(row.py_class, PyExceptionClass::Timeout);
     assert_eq!(row.node_code, "TIMEOUT");
     assert_eq!(

--- a/cqlite-core/tests/issue_1695_query_timeout.rs
+++ b/cqlite-core/tests/issue_1695_query_timeout.rs
@@ -602,3 +602,33 @@ async fn await_tasks_back_to(baseline: usize, phase: &str) {
         alive_tasks() - baseline
     );
 }
+
+/// Structural pin (#1695 roborev round 11): the query-layer streaming producer must
+/// await consumer closure CONCURRENTLY with the next batch, not check it after the
+/// batch arrives.
+///
+/// Rounds 8–11 all found the same class of hole — a cancellation check placed
+/// BETWEEN awaits does not bound the await itself — so this pins the shape rather
+/// than one instance of it. A behavioural test would need a producer that stalls
+/// mid-batch on demand, which is a timing construction, and the property is
+/// structural anyway: `recv()` must not be awaited alone.
+#[test]
+fn the_query_layer_producer_awaits_closure_concurrently_with_the_batch() {
+    let src = include_str!("../src/query/select_executor/streaming.rs");
+
+    assert!(
+        src.contains("_ = tx.closed() => return Ok(()),"),
+        "the batch wait must race consumer closure; without it a stalled upstream \
+         batch leaves a timed-out scan running"
+    );
+    assert!(
+        src.contains("biased;"),
+        "closure must be polled BEFORE the batch, so an already-gone consumer ends \
+         the scan without taking one more batch"
+    );
+    assert!(
+        !src.contains("while let Some(batch) = scan_stream.recv().await"),
+        "`recv()` must not be awaited on its own — that is the shape this pin exists \
+         to prevent returning"
+    );
+}

--- a/cqlite-core/tests/issue_1695_query_timeout.rs
+++ b/cqlite-core/tests/issue_1695_query_timeout.rs
@@ -375,13 +375,42 @@ fn config_validate_accepts_the_zero_sentinel() {
 /// the execute-then-stream paths an aggregate takes — the whole scan. A 1ms
 /// budget over the large fixture must therefore fail the call itself.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn streaming_budget_covers_the_setup_future() {
+async fn streaming_budget_covers_setup_for_a_materializing_plan() {
     let db = open_committed_db(EXPIRED_BUDGET).await;
     let outcome = db
         .execute_streaming(
             &streaming_scan_query(&COMMITTED),
             StreamingConfig::default(),
         )
+        .await;
+    assert_timed_out(outcome, "query.execute_streaming", EXPIRED_BUDGET, |_| {
+        "an iterator".to_string()
+    });
+}
+
+/// The same bound on the INCREMENTAL plan shape — the common one — which the case
+/// above does not reach (roborev round 17).
+///
+/// `streaming_scan_query` is `SELECT COUNT(*)`: an aggregate, so the whole query
+/// executes inside the bounded future and the case above cannot distinguish "setup is
+/// bounded" from "everything is bounded". A plain `SELECT *` returns its iterator as
+/// soon as the producer is spawned, so this pins the part of the contract that
+/// actually applies to an ordinary scan: SETUP is bounded.
+///
+/// It deliberately does NOT assert anything about row consumption AFTER the iterator
+/// is returned, because by documented contract that is NOT bounded here — see
+/// `deadline`'s "What the bound does NOT cover". Consumption is bounded one layer up,
+/// in the CLI, and pinned there by
+/// `cqlite-cli/tests/issue_1695_cli_query_timeout_wiring.rs`
+/// (`the_cli_collection_path_is_bounded_by_query_timeout_ms` and the deterministic
+/// `an_expired_deadline_abandons_the_cli_collection_loop_without_pulling_rows`).
+/// If a future change bounds core-side consumption too, this comment is the place that
+/// has to change with it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_budget_covers_setup_for_an_incremental_plan() {
+    let db = open_committed_db(EXPIRED_BUDGET).await;
+    let outcome = db
+        .execute_streaming(&scan_query(&COMMITTED), StreamingConfig::default())
         .await;
     assert_timed_out(outcome, "query.execute_streaming", EXPIRED_BUDGET, |_| {
         "an iterator".to_string()

--- a/cqlite-core/tests/issue_1695_query_timeout.rs
+++ b/cqlite-core/tests/issue_1695_query_timeout.rs
@@ -433,8 +433,19 @@ async fn dropping_a_streaming_iterator_retires_its_producer() {
     let db = open_committed_db(Duration::ZERO).await;
     let baseline = alive_tasks();
 
+    // A ONE-row channel buffer, deliberately: with the default 1024-row buffer the
+    // producer can push this fixture's whole result set and EXIT before the check
+    // below, making "a producer is alive" a race. With `buffer_size = 1` and a
+    // fixture of many rows, taking one row leaves the producer parked on a full
+    // channel — so it is still alive by construction, not by timing.
     let mut iter = db
-        .execute_streaming(&scan_query(&COMMITTED), StreamingConfig::default())
+        .execute_streaming(
+            &scan_query(&COMMITTED),
+            StreamingConfig {
+                buffer_size: 1,
+                ..StreamingConfig::default()
+            },
+        )
         .await
         .expect("unbounded streaming setup");
     let first = iter.next_async().await;
@@ -445,7 +456,8 @@ async fn dropping_a_streaming_iterator_retires_its_producer() {
     );
     assert!(
         alive_tasks() > baseline,
-        "precondition: a live producer task must exist while the iterator is held"
+        "precondition: a live producer task must exist while the iterator is held \
+         (it is parked on the 1-row channel with rows left to send)"
     );
 
     drop(iter);

--- a/cqlite-core/tests/issue_1695_query_timeout.rs
+++ b/cqlite-core/tests/issue_1695_query_timeout.rs
@@ -1,0 +1,512 @@
+//! Issue #1695 (AH2, epic #1685 "config honesty"): `query.max_execution_time` is
+//! ENFORCED at the query-engine chokepoint.
+//!
+//! # The defect
+//!
+//! `Config.query.max_execution_time` (default 300s) is set by the CLI's
+//! `performance.query_timeout_ms` and, before this change, enforced NOWHERE. A
+//! runaway query ran to completion however long it took; the operator's knob was
+//! a placebo. The fix is ONE `tokio::time::timeout` per public engine entry point
+//! (`cqlite-core/src/query/engine/deadline.rs`) — never ad-hoc clock checks in
+//! the scan loop.
+//!
+//! # What each case pins
+//!
+//! * `budget_of_one_millisecond_times_out_a_large_scan` — THE RED CASE. With a
+//!   1ms budget a real large-fixture full scan must return
+//!   `Error::QueryTimeout`. On unenforced code it returns `Ok(rows)`.
+//! * `default_budget_leaves_a_normal_query_unaffected` — the shipped 300s default
+//!   changes nothing (and returns a NON-EMPTY result, so the case cannot pass
+//!   vacuously on an empty fixture).
+//! * `zero_sentinel_means_unbounded` — `Duration::ZERO` is "no timeout", NOT a
+//!   zero deadline that trips instantly; it returns the same rows as the default.
+//! * `config_validate_accepts_the_zero_sentinel` — the sentinel is explicitly
+//!   LEGAL to `Config::validate`.
+//! * `streaming_budget_covers_the_setup_future` — the streaming surface is
+//!   bounded for the work done INSIDE `execute_streaming` (documented contract).
+//! * `timed_out_streaming_query_leaves_no_live_producer` /
+//!   `dropping_a_streaming_iterator_retires_its_producer` — cancellation is
+//!   clean: nothing is left running after the timed-out future is dropped.
+//! * `timeout_error_is_not_a_corruption` — the timeout is a DISTINCT variant with
+//!   a distinct telemetry category, so an operator budget can never read as
+//!   damaged data.
+//!
+//! # Fixture discipline
+//!
+//! The scan fixture is resolved per TABLE via the shared, table-granular resolver
+//! (issue #3220) and its binaries are GIT-COMMITTED, so it is `must_run`:
+//! fail-closed unconditionally, never a silent SKIP. No wall-clock threshold is
+//! ever asserted (issue #2642) — the assertions are on the RESULT (a timeout
+//! error vs rows), never on how long anything took.
+
+// `cli-helpers` gates `cqlite_core::ingestion`, the surface this lane uses to open
+// the fixture as a real `Database` — the same object the CLI builds. Mirrored by
+// `required-features` in cqlite-core/Cargo.toml so the gate runs it WITH the
+// feature rather than compiling an empty target.
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+// `#[path]` because this file IS the integration target's crate root.
+#[path = "support/datasets_root.rs"]
+mod datasets_root;
+
+use std::path::Path;
+use std::time::Duration;
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::{Config, Database, Error};
+
+use datasets_root::{describe_search, schema_path, sstables_root_for_table};
+
+/// A real Cassandra 5.0 fixture to full-scan.
+struct ScanFixture {
+    keyspace: &'static str,
+    table: &'static str,
+    schema: &'static str,
+    /// `true` when the SSTable BINARIES are git-committed, so an unresolvable
+    /// fixture is a harness defect and the case is fail-closed (issue #3220).
+    committed: bool,
+}
+
+/// The largest GIT-COMMITTED single-table fixture (~260 KiB `Data.db` of
+/// high-entropy BLOB rows). Present in every checkout, so every case that only
+/// needs "a real scan" uses it and is `must_run`.
+const COMMITTED: ScanFixture = ScanFixture {
+    keyspace: "test_comp",
+    table: "incompressible_uncompressed_chunk",
+    schema: "compression-parity.cql",
+    committed: true,
+};
+
+/// The largest FETCHED fixture (~650 KiB / 1000 partitions of mixed CQL types):
+/// the only corpus table whose full scan is reliably MULTI-millisecond, so it is
+/// the one that can demonstrate the AC's literal `1ms` budget interrupting a scan
+/// ALREADY IN PROGRESS. Its binaries are gitignored (only the JSONL sidecar is
+/// committed), so this case skips clean on a minimal checkout — and fails closed
+/// under `CQLITE_REQUIRE_FIXTURES=1`, the same contract the sibling dataset lanes
+/// use. Fetch: `bash test-data/scripts/fetch-datasets.sh`.
+const FETCHED_LARGE: ScanFixture = ScanFixture {
+    keyspace: "test_basic",
+    table: "simple_table",
+    schema: "basic-types.cql",
+    committed: false,
+};
+
+/// A budget that is ALREADY EXPIRED by the time the query future is first polled,
+/// so enforcement is observable on ANY host and ANY fixture size: the bound trips
+/// at the read path's first cooperative checkpoint
+/// (`ScanCancel::checkpoint`) rather than depending on how long a scan happens to
+/// take. Distinct from `Duration::ZERO`, which is the "no timeout" sentinel.
+const EXPIRED_BUDGET: Duration = Duration::from_nanos(1);
+
+/// Full-table scan over a fixture — the runaway query shape the knob bounds.
+fn scan_query(f: &ScanFixture) -> String {
+    format!("SELECT * FROM {}.{}", f.keyspace, f.table)
+}
+
+/// An aggregate over the same fixture. The streaming surface routes any
+/// aggregate through its execute-then-stream path, so the WHOLE scan runs inside
+/// the `execute_streaming` future — which is exactly the future the documented
+/// streaming bound covers.
+fn streaming_scan_query(f: &ScanFixture) -> String {
+    format!("SELECT COUNT(*) FROM {}.{}", f.keyspace, f.table)
+}
+
+/// `true` when the dataset-dependent lanes must fail rather than skip.
+fn require_fixtures() -> bool {
+    matches!(
+        std::env::var("CQLITE_REQUIRE_FIXTURES").ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE")
+    )
+}
+
+/// Open a `Database` over `f` with `max_execution_time` set to `budget`.
+///
+/// PER-CASE fail-closed (issue #3220): a `committed` fixture MUST resolve — its
+/// binaries are in git, so absence is a harness defect, never a legitimate skip.
+/// A fetched fixture returns `None` (skip-clean) unless `CQLITE_REQUIRE_FIXTURES=1`.
+async fn open_db(f: &ScanFixture, budget: Duration) -> Option<Database> {
+    let root = match sstables_root_for_table(f.keyspace, f.table) {
+        Some(root) => root,
+        None => {
+            assert!(
+                !f.committed && !require_fixtures(),
+                "fixture must resolve (fail-closed): {}",
+                describe_search(f.keyspace, f.table)
+            );
+            eprintln!(
+                "SKIP: fetched fixture absent ({}.{}); {} — set CQLITE_REQUIRE_FIXTURES=1 to enforce.",
+                f.keyspace,
+                f.table,
+                describe_search(f.keyspace, f.table)
+            );
+            return None;
+        }
+    };
+    let schema = schema_path(f.schema)
+        .unwrap_or_else(|| panic!("committed schema {} must be readable (#3148)", f.schema));
+    Some(open_db_at(f, &root, &schema, budget).await)
+}
+
+/// The `committed` opener, which cannot skip.
+async fn open_committed_db(budget: Duration) -> Database {
+    open_db(&COMMITTED, budget)
+        .await
+        .expect("the COMMITTED fixture can never skip")
+}
+
+async fn open_db_at(f: &ScanFixture, root: &Path, schema: &Path, budget: Duration) -> Database {
+    let mut core_config = Config::default();
+    core_config.query.max_execution_time = budget;
+    core_config
+        .validate()
+        .expect("a max_execution_time budget must be a VALID configuration");
+    let cfg = IngestionConfig {
+        schema_paths: vec![schema.to_path_buf()],
+        data_dir: root.to_path_buf(),
+        version_hint: None,
+        core_config,
+        table_directory_filter: Some(format!("/{}/", f.keyspace)),
+    };
+    let result = ingest(cfg).await.expect("ingestion of the fixture");
+    assert!(
+        result.schema_load_result.schemas_loaded > 0,
+        "the committed schema must load, else the scan would decode schemaless"
+    );
+    result.database
+}
+
+/// Assert `outcome` is the timeout error for `entry_point` under `limit`.
+fn assert_timed_out<T>(
+    outcome: cqlite_core::Result<T>,
+    entry_point: &str,
+    limit: Duration,
+    rows_of: impl FnOnce(T) -> String,
+) {
+    match outcome {
+        Err(Error::QueryTimeout {
+            operation,
+            limit: reported,
+            ..
+        }) => {
+            assert_eq!(
+                reported, limit,
+                "the reported limit must be the CONFIGURED budget"
+            );
+            assert_eq!(
+                operation, entry_point,
+                "the error must name the bounded entry point"
+            );
+        }
+        Err(other) => panic!(
+            "expected Error::QueryTimeout from {entry_point} under a {limit:?} budget, got a \
+             DIFFERENT error (the budget must not surface as an unrelated failure): {other}"
+        ),
+        Ok(value) => panic!(
+            "REGRESSION (issue #1695): a {limit:?} max_execution_time budget was IGNORED by \
+             {entry_point} — the query ran to completion ({}). `query.max_execution_time` is a \
+             placebo again; the chokepoint wrapper in query/engine/deadline.rs is gone.",
+            rows_of(value)
+        ),
+    }
+}
+
+/// THE RED CASE (AC1), literal form: `max_execution_time = 1ms` + a large-scan
+/// fixture ⇒ the timeout `Err`.
+///
+/// Uses the corpus's largest FETCHED table (~650 KiB / 1000 partitions), whose
+/// unbounded full scan measures multiple milliseconds — so the 1ms budget elapses
+/// while the scan is ALREADY IN PROGRESS, at one of the read path's cooperative
+/// checkpoints. Pre-fix (no wrapper at the chokepoint) this returned `Ok(1000
+/// rows)`.
+///
+/// Skip-clean when the fetched corpus is absent; the always-present proof of the
+/// same property is `expired_budget_times_out_a_committed_scan` below.
+/// Asserts on the OUTCOME only — never on elapsed wall clock (issue #2642).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn budget_of_one_millisecond_times_out_a_large_scan() {
+    let limit = Duration::from_millis(1);
+    let Some(db) = open_db(&FETCHED_LARGE, limit).await else {
+        return;
+    };
+    let outcome = db.execute(&scan_query(&FETCHED_LARGE)).await;
+    assert_timed_out(outcome, "query.execute", limit, |r| {
+        format!("{} rows", r.rows.len())
+    });
+}
+
+/// AC1, HOST-INDEPENDENT form: an already-expired budget over the COMMITTED
+/// fixture. `must_run` (fail-closed) and deterministic everywhere — the bound
+/// trips at the read path's first cooperative checkpoint rather than depending on
+/// how long a particular machine takes to decode a particular fixture. This is
+/// the case that guarantees the knob is never a placebo, even on a minimal
+/// checkout where the multi-millisecond fetched fixture is unavailable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expired_budget_times_out_a_committed_scan() {
+    let db = open_committed_db(EXPIRED_BUDGET).await;
+    let outcome = db.execute(&scan_query(&COMMITTED)).await;
+    assert_timed_out(outcome, "query.execute", EXPIRED_BUDGET, |r| {
+        format!("{} rows", r.rows.len())
+    });
+}
+
+/// The same bound must hold on the OTHER public entry points, so the knob is not
+/// a placebo on three of four paths: `execute_with_params` (markerless and bound)
+/// and `execute_prepared`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn every_public_entry_point_is_bounded() {
+    let db = open_committed_db(EXPIRED_BUDGET).await;
+    let query = scan_query(&COMMITTED);
+
+    // Markerless: delegates to `execute`'s INNER body, so it reports the
+    // entry point it was CALLED on, under one shared budget.
+    let markerless = db.execute_with_params(&query, &[]).await;
+    assert_timed_out(
+        markerless,
+        "query.execute_with_params",
+        EXPIRED_BUDGET,
+        |r| format!("{} rows", r.rows.len()),
+    );
+
+    // With a bind marker: the bound SELECT pipeline.
+    let bound = db
+        .execute_with_params(
+            &format!(
+                "SELECT * FROM {}.{} WHERE pk = ?",
+                COMMITTED.keyspace, COMMITTED.table
+            ),
+            &[cqlite_core::Value::Integer(1)],
+        )
+        .await;
+    assert_timed_out(bound, "query.execute_with_params", EXPIRED_BUDGET, |r| {
+        format!("{} rows", r.rows.len())
+    });
+}
+
+/// AC2 (first half): the shipped 300s default changes nothing for a normal query.
+/// Anti-empty-pass: the result must be NON-EMPTY, so the case cannot pass on an
+/// empty fixture.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn default_budget_leaves_a_normal_query_unaffected() {
+    assert_eq!(
+        Config::default().query.max_execution_time,
+        Duration::from_secs(300),
+        "the shipped default budget is 300s"
+    );
+    let db = open_committed_db(Config::default().query.max_execution_time).await;
+    let result = db
+        .execute(&scan_query(&COMMITTED))
+        .await
+        .expect("the default 300s budget must not interfere with a normal query");
+    assert!(
+        !result.rows.is_empty(),
+        "the committed fixture must yield rows — a 0-row pass would make every other \
+         case here vacuous (dataset doctrine)"
+    );
+}
+
+/// AC2 (second half): `Duration::ZERO` is the documented "no timeout" sentinel —
+/// unbounded execution, NOT a zero deadline that trips at the first yield. It
+/// must return the same rows the default budget does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zero_sentinel_means_unbounded() {
+    let bounded = open_committed_db(Config::default().query.max_execution_time).await;
+    let expected = bounded
+        .execute(&scan_query(&COMMITTED))
+        .await
+        .expect("default budget query")
+        .rows
+        .len();
+    assert!(expected > 0, "fixture must yield rows");
+
+    let unbounded = open_committed_db(Duration::ZERO).await;
+    let rows = unbounded
+        .execute(&scan_query(&COMMITTED))
+        .await
+        .expect(
+            "Duration::ZERO is the NO-TIMEOUT sentinel: it must run unbounded, not \
+             elapse instantly",
+        )
+        .rows
+        .len();
+    assert_eq!(
+        rows, expected,
+        "the ZERO sentinel must return the same result as a generous budget"
+    );
+}
+
+/// AC2: the sentinel is explicitly LEGAL configuration — `Config::validate` must
+/// never reject it (nor any ordinary budget).
+#[test]
+fn config_validate_accepts_the_zero_sentinel() {
+    let mut config = Config::default();
+    config.query.max_execution_time = Duration::ZERO;
+    config
+        .validate()
+        .expect("Duration::ZERO is the documented no-timeout sentinel and must validate");
+
+    for budget in [
+        Duration::from_millis(1),
+        Duration::from_secs(300),
+        Duration::from_secs(86_400),
+    ] {
+        config.query.max_execution_time = budget;
+        config
+            .validate()
+            .unwrap_or_else(|e| panic!("budget {budget:?} must validate, got {e}"));
+    }
+}
+
+/// The streaming surface is bounded too (issue #1695 item 2). The documented
+/// scope is the `execute_streaming` FUTURE: parse, plan, stream setup, and — on
+/// the execute-then-stream paths an aggregate takes — the whole scan. A 1ms
+/// budget over the large fixture must therefore fail the call itself.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn streaming_budget_covers_the_setup_future() {
+    let db = open_committed_db(EXPIRED_BUDGET).await;
+    let outcome = db
+        .execute_streaming(
+            &streaming_scan_query(&COMMITTED),
+            StreamingConfig::default(),
+        )
+        .await;
+    assert_timed_out(outcome, "query.execute_streaming", EXPIRED_BUDGET, |_| {
+        "an iterator".to_string()
+    });
+}
+
+/// AC3: cancellation is clean. After the timed-out streaming future is dropped,
+/// no producer task is left alive, and the engine is still usable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn timed_out_streaming_query_leaves_no_live_producer() {
+    let db = open_committed_db(EXPIRED_BUDGET).await;
+    let baseline = alive_tasks();
+
+    let outcome = db
+        .execute_streaming(
+            &streaming_scan_query(&COMMITTED),
+            StreamingConfig::default(),
+        )
+        .await;
+    assert!(
+        matches!(outcome, Err(Error::QueryTimeout { .. })),
+        "precondition: the streaming call must have timed out"
+    );
+    drop(outcome);
+
+    await_tasks_back_to(baseline, "post-timeout").await;
+
+    // The engine is still USABLE after the cancellation: the timed-out future
+    // released everything it held (readers, buffers, registry locks), so a second
+    // query reaches the same clean typed outcome instead of hanging or failing
+    // with a poisoned-lock / already-borrowed error.
+    let again = db
+        .execute_streaming(
+            &streaming_scan_query(&COMMITTED),
+            StreamingConfig::default(),
+        )
+        .await;
+    assert!(
+        matches!(again, Err(Error::QueryTimeout { .. })),
+        "after a cancelled query the engine must still work (same clean timeout, not a \
+         hang or a poisoned-state error): {:?}",
+        again.err()
+    );
+}
+
+/// The complementary half of drop-safety, with NO timing dependence: a streaming
+/// producer that is definitely running (the consumer has taken a row) exits when
+/// its iterator is dropped. This is the mechanism the timeout relies on — the
+/// timed-out future's drop closes the receiver.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_a_streaming_iterator_retires_its_producer() {
+    // Unbounded, so this case tests the DROP mechanism alone.
+    let db = open_committed_db(Duration::ZERO).await;
+    let baseline = alive_tasks();
+
+    let mut iter = db
+        .execute_streaming(&scan_query(&COMMITTED), StreamingConfig::default())
+        .await
+        .expect("unbounded streaming setup");
+    let first = iter.next_async().await;
+    assert!(
+        matches!(first, Some(Ok(_))),
+        "the fixture must yield at least one streamed row, else the producer was \
+         never running and this case would be vacuous: {first:?}"
+    );
+    assert!(
+        alive_tasks() > baseline,
+        "precondition: a live producer task must exist while the iterator is held"
+    );
+
+    drop(iter);
+    await_tasks_back_to(baseline, "post-drop").await;
+}
+
+/// The timeout must be distinguishable from corruption at every layer a consumer
+/// switches on (issue #1695: "do NOT let the timeout error be indistinguishable
+/// from corruption").
+#[test]
+fn timeout_error_is_not_a_corruption() {
+    let err = Error::QueryTimeout {
+        operation: "query.execute".into(),
+        elapsed: Duration::from_millis(2),
+        limit: Duration::from_millis(1),
+    };
+    assert_eq!(
+        err.obs_category(),
+        cqlite_core::observability::ErrorCategory::Timeout,
+        "the telemetry taxonomy must give the budget elapse its own bucket"
+    );
+    assert_ne!(
+        err.obs_category(),
+        cqlite_core::observability::ErrorCategory::Corruption
+    );
+    assert_ne!(
+        err.category(),
+        cqlite_core::error::ErrorCategory::Data,
+        "a budget elapse is never a DATA fault"
+    );
+    assert!(
+        !err.is_recoverable(),
+        "retrying the same query under the same budget elapses again"
+    );
+    let text = err.to_string();
+    for expected in ["max_execution_time", "query_timeout_ms", "LIMIT"] {
+        assert!(
+            text.contains(expected),
+            "the operator-facing message must name the remedy {expected:?}: {text}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task-liveness helpers (no wall-clock assertions — issue #2642)
+// ---------------------------------------------------------------------------
+
+/// Tasks alive on THIS test's own runtime (each `#[tokio::test]` builds its own),
+/// so the count is isolated from every other test.
+fn alive_tasks() -> usize {
+    tokio::runtime::Handle::current()
+        .metrics()
+        .num_alive_tasks()
+}
+
+/// Wait — with a bounded number of polls, never a wall-clock threshold — for the
+/// alive-task count to come back to `baseline`. A producer that never exits is a
+/// LEAK and fails the case; the loop bound only stops the test hanging forever.
+async fn await_tasks_back_to(baseline: usize, phase: &str) {
+    const MAX_POLLS: usize = 2_000;
+    for _ in 0..MAX_POLLS {
+        if alive_tasks() <= baseline {
+            return;
+        }
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    panic!(
+        "LEAK ({phase}): {} task(s) still alive after {MAX_POLLS} polls (baseline {baseline}) — \
+         a producer did not exit when its receiver was dropped, so cancellation is not clean",
+        alive_tasks() - baseline
+    );
+}

--- a/cqlite-core/tests/issue_1695_query_timeout.rs
+++ b/cqlite-core/tests/issue_1695_query_timeout.rs
@@ -30,6 +30,10 @@
 //! * `timeout_error_is_not_a_corruption` — the timeout is a DISTINCT variant with
 //!   a distinct telemetry category, so an operator budget can never read as
 //!   damaged data.
+//! * `an_expired_budget_keeps_error_queries_within_total_queries` /
+//!   `a_completed_query_is_counted_exactly_once` — the engine statistics stay
+//!   COHERENT under the bound: a timed-out query is counted as a query AND as an
+//!   error, never as an error against a total that never saw it.
 //!
 //! # Fixture discipline
 //!
@@ -462,6 +466,73 @@ async fn dropping_a_streaming_iterator_retires_its_producer() {
 
     drop(iter);
     await_tasks_back_to(baseline, "post-drop").await;
+}
+
+/// Roborev blocker: the engine's own statistics must stay COHERENT under the
+/// bound. An already-expired budget returns before the inner body runs, and the
+/// inner body is what calls `inc_total_queries()` — so counting only the error
+/// published `error_queries > total_queries`, a state no sequence of queries can
+/// legitimately produce and one an operator dashboard reads as corruption of the
+/// counters themselves.
+///
+/// Structural, not timed: the assertion is on the counter DELTAS of one query
+/// whose budget is expired before its first poll, so it decides identically on
+/// every host.
+#[tokio::test]
+async fn an_expired_budget_keeps_error_queries_within_total_queries() {
+    let db = open_committed_db(EXPIRED_BUDGET).await;
+    let before = query_stats(&db).await;
+    assert_eq!(
+        (before.total_queries, before.error_queries),
+        (0, 0),
+        "precondition: a freshly opened database has run no queries"
+    );
+
+    let outcome = db.execute(&scan_query(&COMMITTED)).await;
+    assert_timed_out(outcome, "query.execute", EXPIRED_BUDGET, |r| {
+        format!("{} rows", r.rows.len())
+    });
+
+    let after = query_stats(&db).await;
+    assert!(
+        after.error_queries <= after.total_queries,
+        "IMPOSSIBLE STATISTICS: {} error(s) against {} total quer(ies) — a timed-out query          must be counted as a query, not only as an error",
+        after.error_queries,
+        after.total_queries
+    );
+    assert_eq!(
+        (after.total_queries, after.error_queries),
+        (1, 1),
+        "the timed-out query must be counted exactly once as a query and once as an error"
+    );
+}
+
+/// The same coherence must hold when the inner body DID run and counted itself:
+/// the wrapper must not double-count the total. A normal (unbounded) query gives
+/// the complementary delta — one total, no error.
+#[tokio::test]
+async fn a_completed_query_is_counted_exactly_once() {
+    let db = open_committed_db(Duration::ZERO).await;
+    let rows = db
+        .execute(&scan_query(&COMMITTED))
+        .await
+        .expect("unbounded query must succeed");
+    assert!(
+        !rows.rows.is_empty(),
+        "anti-vacuity: the fixture must return rows"
+    );
+    let stats = query_stats(&db).await;
+    assert_eq!(
+        (stats.total_queries, stats.error_queries),
+        (1, 0),
+        "a query that ran must be counted ONCE, with no error"
+    );
+}
+
+/// The query-engine counters as the public `Database::stats()` surface reports
+/// them.
+async fn query_stats(db: &cqlite_core::Database) -> cqlite_core::query::QueryStats {
+    db.stats().await.expect("database stats").query_stats
 }
 
 /// The timeout must be distinguishable from corruption at every layer a consumer

--- a/cqlite-core/tests/issue_1695_query_timeout.rs
+++ b/cqlite-core/tests/issue_1695_query_timeout.rs
@@ -268,6 +268,15 @@ async fn every_public_entry_point_is_bounded() {
         |r| format!("{} rows", r.rows.len()),
     );
 
+    // A handle from `prepare()` carries the engine's budget too (issue #1695):
+    // `Database::prepare` hands back a `PreparedQuery` whose own `execute` would
+    // otherwise be an unbounded back door into the same full scan.
+    let prepared = db.prepare(&query).await.expect("prepare the scan");
+    let via_handle = prepared.execute(&[]).await;
+    assert_timed_out(via_handle, "prepared.execute", EXPIRED_BUDGET, |r| {
+        format!("{} rows", r.rows.len())
+    });
+
     // With a bind marker: the bound SELECT pipeline.
     let bound = db
         .execute_with_params(


### PR DESCRIPTION
Closes #1695.

## What this does

`query.max_execution_time` was a configured-but-dead knob: on `origin/main` it appears only as a field
declaration, a default and a test setter, with no `tokio::time::timeout` anywhere under
`cqlite-core/src/query/`, and `Error::QueryTimeout` did not exist so the variant was unconstructible.
This wires it with **ONE** `tokio::time::timeout` at the engine chokepoint, per the issue's DECIDED approach.

- New `cqlite-core/src/query/engine/deadline.rs` holds every **bounded** public entry point — `execute`,
  `execute_streaming`, `execute_with_params`, `execute_prepared`. `engine.rs` keeps only the unbounded
  `*_inner` bodies and `execute_unbounded` is `pub(crate)`, so each of the 7 entry points is bounded
  **exactly once**.
- New `Error::QueryTimeout` with its own `classify()` category (never `corruption`); the CLI maps it to
  **exit code 5**. Both bindings' exhaustive-variant audits updated.
- Cooperative `ScanCancel` checkpoints in the scan path, so the single engine-level timeout can fire
  against otherwise non-yielding scan work. **No ad-hoc clock reads were added in the scan loop** — the
  issue's `Do NOT` clause. `scan_cancel.rs` contains no clock reads outside its own tests.
- Per-call `merge_cancel` abandonment for the three materializing `spawn_blocking` merges, since tokio
  cannot cancel a `spawn_blocking` closure by dropping its `JoinHandle`.
- **The CLI bounds its own consumption loops** — both `commands::collect_query_result` (`cqlite query`)
  and the four `collect_chunk` loops in `commands::export` (`cqlite export`). This is not decoration:
  without it the feature does not work where it is configured; see §2.

### Two delegated calls (the issue body left these to the implementer)

1. **`Duration::ZERO` means "no timeout"** — `bound` short-circuits `is_zero()` and awaits with no timer
   rather than handing zero to `timeout()`, which would fire instantly. Documented, validated in
   `Config::validate()`, pinned by `zero_limit_is_unbounded`.
2. **The bound covers the whole `execute`/`execute_streaming` future including time-to-first-batch.**
   Post-return row consumption is not bounded; documented, with per-batch bounds as a follow-up.

## ⚠️ Three things a reviewer should look at before merging

### 1. ⚠️ BEHAVIOR CHANGE: the CLI's real default budget is 30s, not 300s

**This is a behavior change with a regression path, stated in those words at the lead's instruction so
nobody discovers it from a broken scan.**

| | Before this PR | After this PR |
|---|---|---|
| A CLI query taking 45s | **succeeds** | **fails** with `Error::QueryTimeout`, **exit code 5** |
| `performance.query_timeout_ms` | set to `30000` by default, **enforced nowhere** | enforced |
| Escape hatch | n/a | **`query_timeout_ms = 0`** = unbounded (documented sentinel) |

Anyone running a CLI query or `cqlite export` that legitimately takes longer than 30 seconds must raise
`performance.query_timeout_ms` or set it to `0`. This belongs in release notes.


`origin/main` already ships `PerformanceConfig::query_timeout_ms = 30000` and already maps it to a
`Duration` — enforced nowhere. Enforcing the knob makes CLI queries bounded at **30s**, so a legitimate
45s CLI scan that used to succeed now returns `QueryTimeout` (exit 5). Escape hatch:
`query_timeout_ms = 0`.

AC2's "default 300s unchanged" refers to the **core** `QueryConfig` default, which is unchanged; the CLI
ships a 10x tighter value of its own. Both cannot hold — you cannot enforce a knob and also leave its
behaviour unchanged, and enforcement is the decided intent.

**Status of this decision: RULED AND CLOSED.** Raised as `DI1695-F1`; the coordination lead ruled it a
product call belonging to the OWNER. The owner ruled on 2026-08-28
([issuecomment-5448884756](https://github.com/pmcfadin/cqlite/issues/1695#issuecomment-5448884756)):
**KEEP 30s — option (a) confirmed, ship it.** The CLI default is the value the CLI has documented all
along, and honouring an operator's stated budget is the least-surprising reading of "stop being a
placebo". Nothing in the implementation changed as a result; the two conditions the owner attached are
the behaviour-change table above and the AC2 scoping paragraph below, both of which this body carries.

### 2. The CLI's query path needed a second bound, at a second layer — the riskiest part of this PR

Roborev round 5 found that the feature did not actually work where it is configured. The CLI routes
queries through `execute_streaming` and then drives the scan in a `next_async()` loop
(`commands/query.rs`; `export.rs` likewise). The engine's chokepoint wrapper bounds the
`execute_streaming` FUTURE — setup and time-to-first-batch — and structurally cannot bound what
happens after that future returns, which is where a CLI query spends essentially all of its time.
Since the CLI is the **only** consumer that sets `performance.query_timeout_ms`, #1695's stated
problem was left standing for the caller it was written about, while `Database::execute` — which every
one of my tests used — was correctly bounded.

`collect_query_result` now bounds consumption. Setup is deliberately awaited **outside** the CLI
timeout so a setup elapse belongs to, and is recorded by, the engine; the CLI applies only the
REMAINING budget to consumption. The engine entry point is still bounded exactly once.

**Flagging this as the highest-risk part of the diff rather than presenting it as settled.** It is new
surface added late, and rounds 6 and 7 both found real defects in it — a race that swallowed the
engine's telemetry, and an expired deadline that did not apply to an immediately-ready stream. Both
are fixed and pinned, but the honest summary is that this is where the review kept finding things.
Bounding per-batch inside the core iterator would fix it for every consumer and is the better shape;
the issue explicitly deferred per-batch bounds, so this takes the local fix at the layer that owns the
loop.

### 2b. What the bound still does NOT cover, and a finding raised in three consecutive rounds

`ORDER BY` sorting, aggregation and projection run inside `select_executor`'s **non-async**
`execute_sort` over an already-materialized `Vec`. A `tokio::time::timeout` can only elapse when its
future goes `Pending`, so a query whose scan finishes inside the budget and then sorts a large result
set can overshoot, uninterrupted. `Vec::sort_by` is one uninterruptible call.

Resolved as documented scope on the issue body's own precedent for the analogous streaming case:
*"pick the simpler contract: bound the whole `execute` future … document that streamed row consumption
afterwards is not bounded, and note per-batch bounds as a possible follow-up."*

**Roborev raised this same line in rounds 2, 3 and 6** — three consecutive rounds, with a different
and progressively better argument each time. My position did not change and is documented in code
under "What the bound does NOT cover". Recording the recurrence count explicitly so the reviewer's
persistence is visible and the call is easy to overturn: if you want post-scan stages bounded, say so
and it becomes its own issue.

### 3. A pinned contract changed: an off-stride `ScanCancel::checkpoint` is now a no-op

An earlier revision of this branch had `checkpoint(tick)` poll the cancellation flag on **every** call.
Three callers had hand-rolled `if tick & 0xFF == 0 { check()? }`, so that silently **raised** their
cancellation cadence and added a relaxed atomic load plus an `.await` point to a per-entry decode loop.
That cadence was chosen deliberately by #2264/#2346 and #1695 has no mandate to retune the read hot path,
so both the poll and the yield now sit on the stride boundary, reproducing the prior cadence exactly.

`full_index_scan.rs` polled on **every** iteration before this branch (one real index random read per
iteration is already coarse), so it uses `checkpoint_now` — a blanket stride-gate would have regressed
that site. Two different prior cadences existed; that is why all four call sites had to be read.

The stride doc no longer claims "neither cancellation latency nor scan throughput changes measurably" —
no measurement was taken, and #2403's release theme is exactly where an unmeasured no-change claim is the
wrong thing to assert. It now states the checkable thing: equivalence to the code it replaced.

## Verification

- **Gate of record**: the full `AGENT-GATE SUMMARY` is posted as a PR comment by `flow-closer`.
- **`file-size`**: run with the sanctioned `CQLITE_ALLOW_FILE_GROWTH=1`. **Disclosed explicitly, because
  that opt-out prints a plain `PASS` with no marker in the SUMMARY** (unlike #2078's
  `missing-fixtures: OPT-OUT`) — that gap is filed as #3402.
  **Corrected 2026-08-28 against the gate's own diagnostic, then RECOMPUTED after the rebase onto `origin/main` at HEAD `f376f1d9`.** An earlier
  revision of this section understated the growth (it was written several rounds back and said "nothing
  was newly pushed over threshold", which is not true at this HEAD). The actual list, verbatim from the
  `file-size` component:

  | file | before → after | limit | newly over? |
  |---|---|---|---|
  | `cqlite-cli/src/commands/export.rs` | 664 → 851 | 800 | **yes** |
  | `cqlite-core/src/storage/sstable/reader/data_access/bti.rs` | 760 → 827 | 800 | **yes** |
  | `cqlite-core/src/storage/sstable/generation_merge.rs` | 770 → 806 | 800 | **yes** |
  | `cqlite-core/src/query/prepared.rs` | 923 → 1007 | 800 | no (already over) |
  | `cqlite-core/src/error.rs` | 878 → 913 | 800 | no (already over) |
  | `cqlite-core/src/config.rs` | 924 → 952 | 800 | no (already over) |
  | `cqlite-core/src/query/select_executor/mod.rs` | 2552 → 2573 | 800 | no (already over) |

  Rationale, unchanged for the already-over files: an `Error` variant cannot be added without touching
  the taxonomy, nor a sentinel documented/validated without touching config, and splitting a 1007-line
  `prepared.rs` or the error taxonomy inside a P1 timeout fix is out of scope (#1116).
  The three **newly-over** files are the later review rounds' work: `export.rs` +187 is the CLI
  consumption bound (round 5's finding that the feature did not work where it is configured),
  `bti.rs` +67 is the BTI scan-cancel-on-consumer-departure fix, `generation_merge.rs` +36 is the
  `is_closed()` correctness guard (round 8). Each is a correctness fix landed in the file that owns the
  behaviour; extracting three new modules across two crates while closing a P1 is the textbook
  out-of-scope split. **Recorded as a debt, not waved away** — noted on #1116 with these three names so
  the campsite work is trackable rather than implicit.
  **Campsite credit**: `engine.rs` 1371→1336 (extracted `deadline.rs`) and `cqlite-cli/src/main.rs`
  1425→1418 (extracted `core_config.rs`) both shrank.
  *(`config.rs`'s baseline moved 1133→924 in the rebase because #1697 split that file on `main`; this
  PR's own delta there is +28 either way. Every other row is unchanged by the rebase — re-measured,
  not assumed.)*
- **roborev**: eleven rounds via `scripts/flow/roborev-review.sh --agent codex --model gpt-5.6-sol`.
  All were genuine (0.8M–3.3M input tokens, 0.7M–3.1M cached, vs the ~18.7k/0 vacuous baseline; every
  integrity key PASS including `prompt-content` at full census).
  **`prompt-content: FAIL` on the later rounds is #3312, not a vacuous review.** #3312 (closed) is
  "prompt-content FALSE-FAILs every large-diff review — roborev delivers the diff by snapshot PATH, and
  the check only reads inline headers", and CLAUDE.md records the same accepted cost: a snapshot-delivered
  diff and a review that received nothing are identical to the machine. Corroborated two ways rather than
  assumed: token accounting (1.97M–3.18M input / 1.82M–3.00M cached, against a ~18.7k/0 vacuous baseline),
  and the findings themselves — round 16 named `bindings/python/src/error.rs:364` and
  `bindings/node/src/error.rs:476`, file:lines that exist only in this diff. No waiver was sought or
  needed.
  **Round 10 is recorded as ABORTED, not passed**: its `sha-assert` FAILED because `origin/main` moved
  mid-review (`2bde26a7c` → `835fb2276`), so its reviewed range no longer matched `origin/main...HEAD`.
  Its two findings were acted on — they concern code this branch added and are base-independent — but an
  unverifiable range is not a review, so the branch was rebased onto the new main and re-reviewed
  against a verified range. Only the re-run counts.
- **`rust-reviewer`**: `0 blockers, 4 nits` on the cancellation delta, confirming the token swap is
  sound. **The nit bodies were never delivered** across two requests — recorded rather than invented; see
  the follow-up.

### roborev findings and their disposition

| Round | Finding | Disposition |
|---|---|---|
| 1 | detached `spawn_blocking` merge survives the timeout | **fixed** — per-call `merge_cancel` |
| 1 | `error_queries` could exceed `total_queries` | **fixed** — `bound_tracked` |
| 1 | admission permit leaked | **declined** — misreading; the permit is deliberately moved into the closure (#2063) so it is held until detached work terminates |
| 2 | a `Ready` result past the deadline is accepted | **declined** — `tokio::time::timeout`'s specified semantics; erroring would discard a correct completed result without shortening the wait already taken |
| 2 | token not passed into the merger's own readers | **fixed** |
| 2 | stale "prepared execute is unbounded" doc | **fixed** |
| 3 | post-scan stages unbounded (High) | **documented scope** — §2b |
| 3 | prepared-route timeouts absent from telemetry | **documented** |
| 3 | checkpoint cadence raised / unmeasured claim | **fixed** — §3 |
| 4 | python `QueryTimeout` fell through to `CqliteError` while a comment claimed otherwise | **fixed** — mapped to builtin `PyTimeoutError`, deviating from the suggested `QueryError`; **but see the unverifiable-mapping caveat below** |
| 4 | `checkpoint_now` added a per-partition yield (my round-3 regression) | **fixed** — third cadence method `checkpoint_polled` |
| 4 | `#[serial]` did not exclude sibling tests that arm the same global probe | **fixed** — real vacuity hole; siblings serialised |
| 4 | `main.rs` uses a binary-local `core_config`, not the lib surface the test drives | **claims corrected**, unification deferred — pre-existing CLI-wide duplication |
| 5 | the CLI's streaming path was unbounded after setup | **fixed** — §2 |
| 5 | expired-budget test assumed the clock advanced | **fixed** — absolute deadline via `bound_tracked_until` |
| 6 | the CLI bound raced the engine's and swallowed its telemetry | **fixed** — setup now awaited outside the CLI timeout |
| 6 | the positive CLI test could pass with the bound deleted | **fixed** — deterministic, discriminating, always-running replacement |
| 6 | post-scan stages unbounded (repeat of 3) | **documented scope** — §2b |
| 7 | `timeout_at` polls before checking, so an expired deadline missed an immediately-ready stream | **fixed** — expired deadline rejected up front; RED-verified |
| 7 | `Instant + Duration` could panic on operator config | **fixed** — `checked_add`, `None` means unbounded |
| 8 | the streaming producer only checked closure when SENDING, so a no-match scan ran on | **fixed** — `Sender::is_closed()` at the top of the loop |
| 9 | a SECOND producer one layer up (query executor) had the same hole, and holds the storage receiver so the layer-below check cannot help it | **fixed** — `tx.is_closed()` per batch |
| 9 | `cqlite export` was still entirely unbounded | **fixed** — see below |
| 9 | CLI consumption timeouts absent from telemetry (3rd raise) | **deferred with reason** — see the caveat below |
| 10 | checking before a chunk pull does not bound a pull that stays PENDING | **fixed** — the await itself is now wrapped |
| 10 | export's budget clock started AFTER setup, granting consumption a fresh full budget | **fixed** — separate `budget_start` before setup |
| 11 | the query-layer closure check ran only AFTER `recv()` returned, so a stalled batch left a timed-out scan running | **fixed** — `biased` select racing `tx.closed()` |
| 11 | CLI consumption timeouts absent from telemetry (4th raise) | **deferred with reason** — see the caveat above |
| — | a THIRD unfixed instance of the same class, in `per_row_scan_stream` | **found by my own sweep, not reported** — see below |
| 12 | `batched_scan_stream` (the surface query execution actually uses) had the same hole; my sweep missed the file | **fixed** |
| 12 | the windowed forwarder, which my sweep had declared SAFE, is exposed compositionally | **fixed** — both arms race `tx.closed()` |
| 12 | BTI materializes the whole table under a shared token nothing trips on stream drop | **deferred** — see the BTI decision note below |
| 13 | the targeted / multi-targeted branches never observed closure (large `IN`, tombstone builds) | **fixed** — ONE race at the spawn covers all branches |
| 13 | markerless `execute_with_params` lost its `query.execute` span | **fixed** — span restored on the entry point |
| 14 | BTI (2nd raise) | **deferred, with the decision now stated** |
| 14 | CLI consumption telemetry (5th raise) | **FIXED — my objection was wrong; see above** |
| 15 | BTI (3rd raise) | **FIXED** — the scan future is now raced against consumer departure |
| 15 | prepared-handle timeouts absent from the error stream | **FIXED** — same disjointness argument as the CLI |
| — | `QueryTimeout` had no row in main's new authoritative FFI error table | **found by the rebase** — registered, and it closed the "reviewed not tested" caveat |

Rounds 5–7 were largely reviewing the fixes from rounds 4–6, which is why the count did not fall
monotonically. The concentration is in the CLI-layer bound (§2), as noted.

Two corrections to roborev's framing, both verified before acting:

- On the merger token: the displaced tokens were `ScanCancel::default()` (what plain `KWayMerger::new`
  installs — `new` IS `new_cancellable` with that default, identical other params) and one literal
  `ScanCancel::new()`. Neither was reachable by any caller, so the change **removes no existing
  cancellation**. It stays the per-call token, never the shared `SSTableReader::scan_cancel`, which would
  cancel other queries' scans.
- roborev said that gap left "detached blocking work and its permit alive". It did not: #2361 already
  closes the channel, trips the readers' token and joins the threads on merger drop, so **AC3 held before
  that fix**. The gain is promptness — an abandoned merge now stops mid-`step()` instead of finishing the
  partition it was decoding — not a leak. The PR does not claim otherwise.

And one correction to MY OWN reasoning, which a reviewer will otherwise hit in the commit history.

In round 1 I excluded `stream_generations_for_read` from the cancel guard, arguing its
`out_tx.blocking_send(..).is_err()` already retires it when the consumer drops. **That was incomplete,
and round 8 caught it.** A send-failure check is only reached when a partition actually yields a row,
and three paths in that loop `continue` without sending — a partition below `start_key`, one above
`end_key`, and one whose rows are all tombstoned or TTL-expired. So a range scan matching nothing, or a
no-match full scan, performed not one send and therefore not one check, and walked the whole remaining
table after `QueryTimeout` had been handed back. Fixed with `Sender::is_closed()` at the top of the
loop, which needs nothing plumbed in and strictly dominates the send check. The earlier reasoning was
right about the common case and wrong about the case that matters.

### CLI consumption timeouts DO reach telemetry — and how I got this wrong for five rounds

Roborev raised this in five separate rounds. I declined it each time, on the grounds that exposing a
"record a timeout someone else detected" entry point would create a second recording path competing with
the engine's. That objection was wrong, and I never checked its premise: `observability::record_error` is
**already `pub`**, and it is the very sink `AdvancedQueryEngine::bounded` uses. There was no second
mechanism and no new API — one sink, two callers, observing DISJOINT events (the engine records a SETUP
elapse; the CLI records a CONSUMPTION elapse), so nothing double counts.

Both `cli.query.collect` and `cli.export.collect` now record, so a consumption elapse reaches
`cqlite.errors.total{category="timeout"}`. Since consumption is where a CLI scan spends its time, this is
the difference between dashboards reflecting operator-visible timeouts and reading zero while operators
see them.

Recording the process failure alongside the fix: I had a plausible-sounding architectural objection and
repeated it across five rounds without testing it. Reviewer persistence was the signal, and I treated it
as noise.

**The narrower residual, stated precisely:** the engine's `error_queries` counter still does not move for
a consumption elapse. That counter is private accounting for work the ENGINE executed, and the CLI's
consumption phase is not an engine query execution — folding it in would misreport the counter's meaning.
`Database::stats()` therefore reports setup elapses only.

### The cancellation class: what it was, and how my own sweep of it fell short

Rounds 8–13 all reported ONE class: a producer whose only stop signal is a failing send, in a loop that
can do real work WITHOUT sending. After round 11 I generalized the test — *can this loop do work without
reaching a send?* — and swept every producer I could enumerate. The sweep found a real unreported
instance, and also produced one wrong verdict and missed one file. Corrected table:

| Producer | Skip paths | Outcome |
|---|---|---|
| `generation_merge` streaming producer | 3 (range ×2, all-tombstoned partition) | fixed, round 8 |
| query-layer `select_executor::streaming` fallback | 4 (row build, predicates, per-partition limit, OFFSET) | fixed, rounds 9 + 11 |
| its targeted / multi-targeted branches | large `IN`, tombstone builds | fixed, round 13 — ONE race at the spawn |
| `per_row_scan_stream` non-stitching | 4 (table-id, range ×2, tombstone) | **found by my sweep** |
| `batched_scan_stream` non-stitching | 4, plus `BATCH_EMIT_ROWS` gating the send | **MISSED by my sweep** — round 12 |
| `scan_stream_forwarder` (both arms) | none | **I wrongly called this SAFE** — round 12 |
| `scan_stream_windowed` | none — every row joins a batch and is sent | safe |
| BTI `bti_scan_with_metadata` | 3 (range ×2, tombstone) | **deferred** — decision below |

Four things worth taking from this rather than just the fixes:

**The enumeration was the weak link, not the predicate.** I listed producers by grepping
`spawn_blocking|tokio::spawn` per directory. `batched_scan_stream.rs` is `#[path]`-included so it never
appeared — and it is the surface query execution actually uses.

**Per-stage reasoning cannot see a whole-chain property.** I cleared the forwarder because a stage parked
in `recv().await` burns nothing. True in isolation; irrelevant compositionally — upstream's filters reach
no send either, so under a no-match scan nothing anywhere sends and the chain idles while upstream burns
to EOF.

**Guarding branch-by-branch is what spread this over five rounds.** Round 13's fix is one race at the
spawn covering every branch of the producer, present and future. It does not replace the in-loop checks:
a race fires only at an await boundary of the future it wraps, so a long synchronous stretch is still only
interruptible by that branch's own check. Coverage from the spawn, promptness from the loops.

**Granularity differs per site, with the reason at each site.** A bounded disk read always returns to a
plain `is_closed()`; an open-ended wait on another producer needs `select!` on `tx.closed()`.

### Cancel-safety of the five new `select!` arms — verified, because a lost batch would be silent wrong output

This diff adds `select!` to producer paths in five places. A future that is NOT cancel-safe, dropped
mid-poll by a `select!`, can consume a message and lose it — which here would mean **rows silently missing
from a query result**, the worst failure class in this repo and one no cancellation test would catch. I did
not check this when writing the code; it is verified now, with the evidence rather than an assurance:

| arm | future | why it is cancel-safe |
|---|---|---|
| `select_executor::streaming` | `scan_stream.recv()` → `JoinedStream::recv()` (`BatchedScanStream` = `JoinedStream<Vec<…>>`) | #3106 made it so deliberately and documented the reasoning inline: the inner `rx.recv().await` is tokio's cancel-safe recv; `&mut JoinHandle` is awaited without taking ownership so "a cancellation here drops only this borrow"; and there is "no `.await` between observing the outcome and recording it" |
| `scan_stream_forwarder`, per-row arm | `batch_rx.recv()` (tokio `mpsc`) | tokio documents `Receiver::recv()` as cancel-safe — no message is lost if the future is dropped before completion |
| `scan_stream_forwarder`, batched arm | same | same |
| `bti::stream_bti_scan` | the `bti_scan_with_metadata` future | dropping it IS the intended cancellation; it returns a `Vec` by value, so there is no partially-consumed channel state to lose |
| `select_executor::execute_streaming` spawn | the whole producer future | same — dropping releases readers, buffers and the storage stream |

`tx.closed()` is cancel-safe by nature. So no arm can drop a consumed-but-undelivered item.

### The BTI deferral, stated as a decision rather than a difficulty

Roborev raised BTI twice, so here is what I verified rather than guessed:
`bti_scan_with_metadata_cancellable` **already exists and already takes a `&ScanCancel`** — plumbing is
not the gap. The gap is that the caller has no token it may legitimately pass:

* a **clone** of the reader's token cancels OTHER queries scanning that reader (clones share state) — the
  trap the materializing merges avoided with a per-call token;
* a **fresh per-call** token tripped by a watcher on the sender's `closed()` handles the timeout but
  silently DROPS #2264's Flight cancellation, which trips the reader token *without* necessarily dropping
  the receiver — sending client disconnects back to the ~1–2 min transport backstop.

Losing existing cancellation to add new cancellation is not a fix. What is needed is one small API
decision — a token meaning "either the reader's OR this stream's closure" — and that composition is the
same primitive the deferred `JoinedStream` / `KWayMerger::step()` work needs. Not improvised at round 14
in a 30-file diff: three partial fixes here is how the gap got scattered, and a fourth guessing at token
composition would be the worst of them.

Consequence, plainly: on a **BTI (`da`) table**, a timed-out streaming query's detached producer keeps
materializing and sorting until its scan completes. It terminates and nothing leaks — but it burns CPU and
memory for an abandoned request. Every non-BTI producer in the read path now observes closure.

### The bindings' error identity now lives in main's authoritative FFI table

This changed under the branch, for the better. Main's #1451 landed "one authoritative FFI error table —
Python and Node stop disagreeing on error identity", replacing the per-binding exhaustive-variant audits
my earlier commits had edited. Rebasing conflicted, and the right resolution was to drop my approach and
re-implement on main's:

```
QueryTimeout => { py: Timeout, code: "TIMEOUT", category: Query,
                  recoverable: false, prefix: Some("TimeoutError") }
```

`py: Timeout` and `code: "TIMEOUT"` put a budget elapse on the SAME identity as its sibling `Timeout` on
both surfaces, so `except TimeoutError:` in Python and a `TIMEOUT` check in JS both catch it — the
cross-binding agreement #1451 exists to enforce, and it vindicates the earlier choice of `PyTimeoutError`
over the suggested `QueryError`. `category: Query` is a deliberately different axis: a budget elapse is a
query-execution failure, distinguishable from corruption per #1695.

Three of main's guards did real work, which is worth recording as an argument for that style of guard:

* `variant_of` is exhaustive, so **the build failed** until the variant had a row — the registration could
  not be forgotten.
* `table_agrees_with_core_category_and_recoverable` **passed**, independently confirming `category: Query`
  and `recoverable: false` match `Error::classify()` and `is_recoverable()` — the cross-table
  contradiction I was worried about, checked by machine rather than by my reading.
* `row_count_is_pinned` **failed 37 → 38** exactly as designed, forcing the new row's identity to be a
  reviewed act rather than an invisible one.

**This also retracts a caveat this PR carried earlier.** I had reported the python mapping as "reviewed,
not tested", because `cargo test -p cqlite-py` cannot link libpython and the binding exposes no way to
provoke a timeout. Main's `FfiErrorVariant::sample_error()` exists for exactly that class ("a variant that
no test query can provoke (`Timeout`, `Memory`, …)"), and `cqlite-core/tests/ffi_error_contract_table.rs`
DOES run under cargo test. With a sample added the mapping is genuinely exercised, and
`query_timeout_shares_the_timeout_identity_on_both_surfaces` pins it. The follow-up asking to make
`cqlite-py`'s Rust tests executable still stands on its own merits, but it is no longer what stands
between this mapping and coverage.

### Known gap: prepared-handle timeouts are invisible to telemetry

`PreparedQuery` carries only its executor and its budget — no stats or observability handle — so a
timeout taken via `PreparedQuery::execute` is **enforced** identically but never increments
`error_queries` or `cqlite.errors.total{category="timeout"}`. Worth stating plainly rather than
softening: #1695 comes from a platform-observability audit, and this ships an observability blind spot on
a public route. Closing it needs a stats handle threaded from `prepare()` into a struct already over the
file-size threshold, so it is a follow-up. Documented at the chokepoint; my earlier doc saying "bounded
on either route" was corrected, since only one route is observable.

### Tests

`cqlite-core/tests/issue_1695_query_timeout.rs` (+604) covers all four ACs, the CLI exit-code-5 wiring
and the `ZERO` sentinel. Fixture roots resolve per-table via `sstables_root_for_table` with per-case
fail-closed assertions for committed fixtures — no suite-wide `assert!(ran > 0)` (#3220). No wall-clock
threshold asserts in the correctness path:

- `a_dropped_multi_generation_read_abandons_its_blocking_merge` removes the race **by construction**: a
  `max_blocking_threads(1)` runtime whose sole blocking thread the test occupies, the future dropped while
  the merge closure is still *queued*, then released — so the closure starts with the flag already
  tripped. Anti-vacuity guard asserts `armed() == 1` before `abandoned() >= 1`. RED-verified: with the
  loop check neutered it fails `armed=1, abandoned=0`.
- `an_expired_budget_keeps_error_queries_within_total_queries` and
  `a_completed_query_is_counted_exactly_once` assert public `Database::stats()` deltas and guard **both**
  directions. RED-verified: pre-fix reports "1 error(s) against 0 total quer(ies)".
- `the_materializing_merges_pass_their_token_into_the_merger` is a structural pin, because "a reader stops
  mid-step" is only observable as a latency difference and a wall-clock assert in the correctness path is
  forbidden. It counts tokens actually handed out rather than asserting the **absence** of the inert
  constructor — the first draft did the latter and was defeated by a comment naming that constructor two
  lines from the call site.
- `checkpoint_checks_and_yields_at_the_stride_only` pins the changed cadence contract, including that an
  off-stride checkpoint is a no-op even once cancelled, and says why that is the contract.

## Follow-ups (proposed as `DI1695-F1`, none merge-blocking)

1. The CLI 30s-vs-300s default decision (§1) — the one item that wants a call before the next release.
2. **A composable `ScanCancel` — "either the reader's token OR this stream's closure"** — then use it
   for the three places that need exactly that primitive:
   (a) **BTI** `bti_scan_with_metadata_cancellable` (see the decision note above; the function and its
   token parameter already exist, only the token to pass is missing);
   (b) a **drop-tripped guard inside `JoinedStream`**, which has no `Drop` impl today so dropping
   detaches its producer;
   (c) cancellation **inside a single long `KWayMerger::step()`** on the streaming path, whose readers
   still hold an inert `ScanCancel::default()`.
   This is one primitive and three call sites, not three separate projects. It is shared streaming
   machinery Flight also uses, which is why it was not improvised late in a diff whose last six review
   rounds were spent on newly added surface.
3. **Carry the deadline itself into the core streaming producer** (the per-batch bound the issue
   deferred), which would additionally let CORE own consumption timeouts rather than the CLI, and move
   the engine's `error_queries` counter with them.
4. Bounding post-scan stages — interruptible/chunked `ORDER BY`, aggregation, projection (§2b; roborev
   raised it three times).
5. Prepared-handle `error_queries` — **narrower than when first listed**. The error-stream half was
   fixed during round 15: `PreparedQuery::execute` / `execute_with_context` now record a timeout on the
   engine's own public sink, so those routes ARE visible to
   `cqlite.errors.total{category="timeout"}`. What remains is only the engine's `error_queries` counter,
   which is private accounting for queries the engine itself executed, and moving it is part of (3).
6. Unify `cqlite-cli`'s binary onto the library modules (`config`/`core_config`/`error`), and add a
   `CARGO_BIN_EXE_cqlite` spawn test asserting exit code 5 end to end. Today the binary compiles its
   own copy of every module, so the exit-code evidence sits at the library-copy level.
7. **Expose `query.max_execution_time` on the Python binding**, which currently has no way to set it, so
   a Python caller cannot bound a query at all — and, separately, make `cqlite-py`'s Rust `#[test]`s
   executable (they never link libpython today, so that whole file's assertions are inert).
   **Correction to an earlier draft of this list:** these are NO LONGER what stands between the
   `PyTimeoutError` mapping and coverage — main's `sample_error()` plus
   `cqlite-core/tests/ffi_error_contract_table.rs` test it today. Both items still stand on their own
   merits (a Python user cannot set the budget; a file of inert tests reads as coverage it does not
   provide), but not as blockers for that mapping.
8. Four `rust-reviewer` nits on the cancellation delta whose bodies were never delivered; re-run a
   review on the merged code to recover them. Recorded as unretrievable rather than guessed at.
9. Two gate `file-size` diagnostic gaps — **filed, per the lead's ruling on `DI1695-F1`**: #3401 (FAIL
   writes no diagnostic log, so the offending file must be recomputed by hand) and #3402
   (`CQLITE_ALLOW_FILE_GROWTH=1` leaves no marker in the SUMMARY, unlike #2078's `OPT-OUT` precedent).
   Both checked against existing issues before filing, and left unlabelled for priority.



