### PR TITLE
fix(#3393): refuse an implausible boundary product instead of OOM-killing the worker

### DIFF
--- a/scripts/perf/ws0_boundary_observations.py
+++ b/scripts/perf/ws0_boundary_observations.py
@@ -97,7 +97,7 @@ from ws0_corpus_bytes import (
     SESSION_CORPUS_PIN,
     boundary_observations_path,
 )
-from ws0_validate import Invalid, positive_int
+from ws0_validate import MAX_COUNT, Invalid, positive_int
 
 # The BARE SCAN's token in a boundary label. The driver's rep loop treats the bare scan as a PEER of
 # the flight arms (`_ARM_LIST=(scan $ARMS)`) and labels its boundary with this literal, so the
@@ -120,10 +120,33 @@ REQUIRED_OBSERVATION_FIELDS = (
 )
 
 
-# The largest boundary product `expected_boundary_labels` will build (#3393). The published sweep is
-# 25 points x 3 reps; 100k is ~three orders of magnitude above any real configuration, so this can
-# only fire on a caller defect — never on a legitimately large session.
-MAX_EXPECTED_BOUNDARIES = 100_000
+# The driver's `--temp` and `--arm` vocabularies are CLOSED (`ws0-baseline.sh`: `warm|cold|both` and
+# `bypass|merge|both`), so the widest matrix any accepted invocation can ask for is 2 temperatures x
+# (the bare scan + 2 flight arms). These are the bounds the cap below is DERIVED from — never a
+# second opinion about how large a session may be.
+MAX_TEMPS = 2
+MAX_ARMS = 1 + 2
+
+# The largest boundary product `expected_boundary_labels` will build (#3393), DERIVED from the
+# largest product the rig ACCEPTS: the full matrix at `ws0_validate.MAX_COUNT` reps = 2 x 3 x 100,000
+# = 600,000 labels.
+#
+# It is derived rather than picked because a cap BELOW the accepted maximum refuses a configuration
+# the driver and the reporter both validate as fine — and refuses it at REPORT time, after the
+# measurement has already run, so a legitimate session becomes unreportable having burned its whole
+# cost. That is the same wrong-cause refusal `boundary_label`'s docstring warns about, and a first
+# cut of this guard shipped it: a flat 100,000 rejected `--reps 100000`, which `positive_int` accepts.
+# Deriving from `MAX_COUNT` also means a future change to the accepted bound moves both together
+# instead of silently re-introducing the gap. `TEMPS_ALLOWED`/`ARMS_ALLOWED` live in `ws0_report.py`,
+# which imports THIS module, so these two cannot import them back without a cycle;
+# `test_ws0_boundary_record_completeness.sh` reads both sides and FAILS on a mismatch instead — the
+# same way `lib-args.sh`'s MAX_COUNT is pinned against `ws0_validate.MAX_COUNT`.
+#
+# The derived cap keeps the whole of the OOM protection it exists for. MEASURED at the accepted
+# maximum: 600,000 labels cost 41 MB as the list and 139 MB peak RSS across all three resident
+# copies (the list, the JSON-string list over it, and the joined string) — three orders of magnitude
+# under the 20-28 GB that triggered the kills, while a caller defect producing billions still refuses.
+MAX_EXPECTED_BOUNDARIES = MAX_TEMPS * MAX_ARMS * MAX_COUNT
 
 
 def boundary_label(temp: str, rep: int, arm: str) -> str:
@@ -151,25 +174,33 @@ def expected_boundary_labels(temps: list[str], arms: list[str], reps: int) -> li
     a list, and a caller then materializes a second list of JSON strings over it plus the joined
     string — roughly three resident copies. On 2026-08-27/28 that reached 20-28 GB RSS and the kernel
     issued 14 global OOM kills across two 30 GB workers, wedging sshd (a box that cannot fork cannot
-    accept an ssh session) and silently killing five sibling lane sessions. The measurement rig's
-    real configurations are small: the published S=1..6 sweep is 25 points x 3 reps.
+    accept an ssh session) and silently killing five sibling lane sessions.
 
-    So refuse an absurd product rather than try to build it. This is deliberately a REFUSAL and not
-    a silent truncation: a truncated expected set would report every missing boundary as the
-    operator's fault, which is the failure mode `boundary_label`'s own docstring warns about one
-    function above. The cap is far above any real configuration, so it can only fire on a defect.
+    So refuse an absurd product rather than try to build it — but refuse ONLY what the rig would not
+    accept in the first place. The cap is `MAX_EXPECTED_BOUNDARIES`, DERIVED from the widest accepted
+    matrix at `MAX_COUNT` reps, so no configuration the driver validates can be refused here; see
+    that constant for why a hand-picked cap below it is a defect rather than a stricter guard.
+
+    The refusal is `Invalid`, the module's one fail-closed exception, so it lands on `ws0_report.py`'s
+    single `FATAL:` exit path like every other refusal here. A bare `ValueError` would escape that
+    handler and surface as an uncaught traceback — a rig defect wearing the costume of a crash.
+
+    It is deliberately a REFUSAL and not a silent truncation: a truncated expected set would report
+    every missing boundary as the operator's fault, which is the failure mode `boundary_label`'s own
+    docstring warns about one function above.
     """
-    n_arms = 1 + len(arms)
-    product = len(temps) * max(reps, 0) * n_arms
     if reps < 0:
-        raise ValueError(f"expected_boundary_labels: reps must be >= 0, got {reps}")
+        raise Invalid(f"expected_boundary_labels: reps must be >= 0, got {reps}")
+    n_arms = 1 + len(arms)
+    product = len(temps) * reps * n_arms
     if product > MAX_EXPECTED_BOUNDARIES:
-        raise ValueError(
+        raise Invalid(
             "expected_boundary_labels: refusing an implausible boundary product "
-            f"({len(temps)} temps x {reps} reps x {n_arms} arms = {product} labels, "
-            f"cap {MAX_EXPECTED_BOUNDARIES}). A real sweep is orders of magnitude smaller; this "
-            "is a caller defect, not a large session. See #3393 — building it has OOM-killed "
-            "workers and taken sshd down with them."
+            f"({len(temps)} temps x {reps} reps x {n_arms} arms = {product:,} labels, "
+            f"cap {MAX_EXPECTED_BOUNDARIES:,} = {MAX_TEMPS} temps x {MAX_ARMS} arms x "
+            f"{MAX_COUNT:,} reps, the widest matrix the rig ACCEPTS). No configuration the driver "
+            "validates can reach this, so it is a caller defect, not a large session. See #3393 — "
+            "building it has OOM-killed workers and taken sshd down with them."
         )
     return [
         boundary_label(temp, rep, arm)

--- a/scripts/perf/ws0_boundary_observations.py
+++ b/scripts/perf/ws0_boundary_observations.py
@@ -120,6 +120,12 @@ REQUIRED_OBSERVATION_FIELDS = (
 )
 
 
+# The largest boundary product `expected_boundary_labels` will build (#3393). The published sweep is
+# 25 points x 3 reps; 100k is ~three orders of magnitude above any real configuration, so this can
+# only fire on a caller defect — never on a legitimately large session.
+MAX_EXPECTED_BOUNDARIES = 100_000
+
+
 def boundary_label(temp: str, rep: int, arm: str) -> str:
     """The label the driver stamps for the boundary AFTER `arm`'s rep of `temp`.
 
@@ -140,7 +146,31 @@ def expected_boundary_labels(temps: list[str], arms: list[str], reps: int) -> li
     round, so a component replaced between them lands directly on the ratio. The expected set is
     therefore the full product: every temperature, every rep, and the bare scan plus every selected
     flight arm.
+
+    FAIL-CLOSED ON AN IMPLAUSIBLE PRODUCT (#3393). Unbounded, this materializes the whole product as
+    a list, and a caller then materializes a second list of JSON strings over it plus the joined
+    string — roughly three resident copies. On 2026-08-27/28 that reached 20-28 GB RSS and the kernel
+    issued 14 global OOM kills across two 30 GB workers, wedging sshd (a box that cannot fork cannot
+    accept an ssh session) and silently killing five sibling lane sessions. The measurement rig's
+    real configurations are small: the published S=1..6 sweep is 25 points x 3 reps.
+
+    So refuse an absurd product rather than try to build it. This is deliberately a REFUSAL and not
+    a silent truncation: a truncated expected set would report every missing boundary as the
+    operator's fault, which is the failure mode `boundary_label`'s own docstring warns about one
+    function above. The cap is far above any real configuration, so it can only fire on a defect.
     """
+    n_arms = 1 + len(arms)
+    product = len(temps) * max(reps, 0) * n_arms
+    if reps < 0:
+        raise ValueError(f"expected_boundary_labels: reps must be >= 0, got {reps}")
+    if product > MAX_EXPECTED_BOUNDARIES:
+        raise ValueError(
+            "expected_boundary_labels: refusing an implausible boundary product "
+            f"({len(temps)} temps x {reps} reps x {n_arms} arms = {product} labels, "
+            f"cap {MAX_EXPECTED_BOUNDARIES}). A real sweep is orders of magnitude smaller; this "
+            "is a caller defect, not a large session. See #3393 — building it has OOM-killed "
+            "workers and taken sshd down with them."
+        )
     return [
         boundary_label(temp, rep, arm)
         for temp in temps

--- a/scripts/tests/test_ws0_boundary_record_completeness.sh
+++ b/scripts/tests/test_ws0_boundary_record_completeness.sh
@@ -429,6 +429,55 @@ else
 fi
 
 # ==========================================================================
+# §26 — `expected_boundary_labels` REFUSES an implausible product (#3393)
+# ==========================================================================
+# Unbounded, this function materializes the whole temps x reps x arms product as a list, and
+# `ws0_pin_boundary_observations` then materializes a SECOND list of JSON strings over it plus the
+# joined string — ~three resident copies. On 2026-08-27/28 that reached 20-28 GB RSS and the kernel
+# issued 14 global OOM kills across two 30 GB workers, wedging sshd (a box that cannot fork cannot
+# accept an ssh session) and silently killing five sibling lane sessions.
+#
+# BOTH DIRECTIONS are pinned, because a cap tested only in its refusing direction is how a guard
+# ships that reds correct input — the failure mode this rig has recorded repeatedly.
+
+labels_probe() {
+  python3 - "$PERF_DIR" "$1" <<'PY' 2>&1
+import sys
+sys.path.insert(0, sys.argv[1])
+from ws0_boundary_observations import expected_boundary_labels
+try:
+    out = expected_boundary_labels(["warm"], ["bypass"], int(sys.argv[2]))
+    print(f"BUILT {len(out)}")
+except ValueError as exc:
+    print(f"REFUSED {exc}")
+PY
+}
+
+real_out="$(labels_probe 3)"
+if [[ "$real_out" == "BUILT 6" ]]; then
+  pass "OBSERVED (#3393, GREEN direction): a real configuration still builds — 1 temp x 3 reps x (scan+bypass) = 6 labels, so the cap cannot red a legitimate sweep"
+else
+  fail "#3393: a real configuration must still build 6 labels (got: $real_out)"
+fi
+
+absurd_out="$(labels_probe 10000000)"
+if [[ "$absurd_out" == REFUSED* ]] \
+   && grep -q 'implausible boundary product' <<<"$absurd_out" \
+   && grep -q '3393' <<<"$absurd_out"; then
+  pass "OBSERVED (#3393, RED direction): an absurd product REFUSES with the count, the cap and the issue named, instead of allocating ~28 GB and being OOM-killed"
+else
+  fail "#3393: an absurd product must refuse, naming the product and the cap (got: $absurd_out)"
+fi
+
+# A REFUSAL, never a truncation: a silently-truncated expected set would report every missing
+# boundary as the operator's fault, which is exactly what `boundary_label`'s docstring warns about.
+if grep -q 'REFUSED' <<<"$absurd_out" && ! grep -q '^BUILT' <<<"$absurd_out"; then
+  pass "OBSERVED (#3393): the oversize path REFUSES rather than truncating, so a short expected set can never be blamed on the operator"
+else
+  fail "#3393: the oversize path must refuse, not truncate (got: $absurd_out)"
+fi
+
+# ==========================================================================
 # A MINIMUM CHECK COUNT, because `set -uo pipefail` carries no `-e`
 # ==========================================================================
 # Without `-e` a block that silently never executes LOWERS the count and registers NO failure, and
@@ -436,7 +485,7 @@ fi
 # and reports SUCCESS. That is the suite-level vacuous green, one level up from the checks.
 #
 # The floor is DERIVED FROM THE OBSERVED COUNT — run, then recorded — never counted off the source.
-MIN_CHECKS=13
+MIN_CHECKS=16
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo
   echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."

--- a/scripts/tests/test_ws0_boundary_record_completeness.sh
+++ b/scripts/tests/test_ws0_boundary_record_completeness.sh
@@ -438,18 +438,27 @@ fi
 # accept an ssh session) and silently killing five sibling lane sessions.
 #
 # BOTH DIRECTIONS are pinned, because a cap tested only in its refusing direction is how a guard
-# ships that reds correct input — the failure mode this rig has recorded repeatedly.
+# ships that reds correct input — the failure mode this rig has recorded repeatedly. The FIRST cut of
+# this guard shipped exactly that: a flat 100,000, which refuses `--reps 100000` even though
+# `positive_int` accepts it up to `MAX_COUNT`. So the green direction is asserted AT THE ACCEPTED
+# MAXIMUM and not merely at a small sweep — a green case below the cap cannot see that gap, which is
+# why the first version passed its own tests.
 
 labels_probe() {
-  python3 - "$PERF_DIR" "$1" <<'PY' 2>&1
+  python3 - "$PERF_DIR" "$1" "${2-warm}" "${3-bypass}" <<'PY' 2>&1
 import sys
 sys.path.insert(0, sys.argv[1])
 from ws0_boundary_observations import expected_boundary_labels
+from ws0_validate import Invalid
+temps = sys.argv[3].split()
+arms = [a for a in sys.argv[4].split() if a]
 try:
-    out = expected_boundary_labels(["warm"], ["bypass"], int(sys.argv[2]))
+    out = expected_boundary_labels(temps, arms, int(sys.argv[2]))
     print(f"BUILT {len(out)}")
-except ValueError as exc:
+except Invalid as exc:
     print(f"REFUSED {exc}")
+except Exception as exc:                      # noqa: BLE001 - the point is to NAME a wrong type
+    print(f"WRONGTYPE {type(exc).__name__}: {exc}")
 PY
 }
 
@@ -458,6 +467,83 @@ if [[ "$real_out" == "BUILT 6" ]]; then
   pass "OBSERVED (#3393, GREEN direction): a real configuration still builds — 1 temp x 3 reps x (scan+bypass) = 6 labels, so the cap cannot red a legitimate sweep"
 else
   fail "#3393: a real configuration must still build 6 labels (got: $real_out)"
+fi
+
+# THE ACCEPTED MAXIMUM, which is the case a flat cap gets wrong. The driver's `--temp`/`--arm`
+# vocabularies are closed (warm|cold, bypass|merge) and `--reps` is accepted up to
+# `ws0_validate.MAX_COUNT`, so the widest product any ACCEPTED invocation can ask for is
+# 2 x (scan+2) x MAX_COUNT. Every one of those must BUILD: refusing here would refuse a session the
+# driver and the reporter both validate as fine, and refuse it at REPORT time, after the measurement
+# has already been paid for.
+accepted_max="$(python3 - "$PERF_DIR" <<'PY' 2>&1
+import sys
+sys.path.insert(0, sys.argv[1])
+from ws0_validate import MAX_COUNT
+print(2 * 3 * MAX_COUNT)
+PY
+)"
+max_out="$(labels_probe "$(python3 -c 'import sys; sys.path.insert(0, sys.argv[1]); from ws0_validate import MAX_COUNT; print(MAX_COUNT)' "$PERF_DIR")" "warm cold" "bypass merge")"
+if [[ "$max_out" == "BUILT $accepted_max" ]]; then
+  pass "OBSERVED (#3393, GREEN direction AT THE ACCEPTED MAXIMUM): the widest matrix the rig accepts — 2 temps x (scan+2 arms) x MAX_COUNT reps = $accepted_max labels — still BUILDS, so no configuration the driver validates can be refused here"
+else
+  fail "#3393: the accepted maximum ($accepted_max labels) must still build (got: ${max_out:0:200})"
+fi
+
+# NON-VACUITY of the case above: the FLAT 100,000 cap this guard first shipped REFUSES that same
+# accepted maximum. Re-enacted by lowering the shipped constant rather than by describing it, so the
+# claim "a flat cap reds accepted input" is measured and not asserted.
+flat_out="$(python3 - "$PERF_DIR" <<'PY' 2>&1
+import sys
+sys.path.insert(0, sys.argv[1])
+import ws0_boundary_observations as m
+from ws0_validate import Invalid, MAX_COUNT
+m.MAX_EXPECTED_BOUNDARIES = 100_000          # the pre-fix flat cap
+try:
+    m.expected_boundary_labels(["warm", "cold"], ["bypass", "merge"], MAX_COUNT)
+    print("BUILT")
+except Invalid:
+    print("REFUSED")
+PY
+)"
+if [[ "$flat_out" == "REFUSED" ]]; then
+  pass "NON-VACUITY (#3393): the pre-fix FLAT 100,000 cap REFUSES the accepted maximum — so the derived cap is load-bearing and the green case above is a real regression guard, not a restatement"
+else
+  fail "#3393: the flat-cap re-enactment must refuse the accepted maximum, or the derived cap proves nothing (got: $flat_out)"
+fi
+
+# THE CAP IS DERIVED, not chosen — asserted by reading BOTH sides, the way `lib-args.sh`'s MAX_COUNT
+# is pinned against `ws0_validate.MAX_COUNT`. `TEMPS_ALLOWED`/`ARMS_ALLOWED` live in `ws0_report.py`,
+# which IMPORTS this module, so the constant cannot import them back without a cycle; this check is
+# what keeps the two spellings honest instead.
+drift_out="$(python3 - "$PERF_DIR" <<'PY' 2>&1
+import sys
+sys.path.insert(0, sys.argv[1])
+from ws0_boundary_observations import MAX_ARMS, MAX_EXPECTED_BOUNDARIES, MAX_TEMPS
+from ws0_report import ARMS_ALLOWED, TEMPS_ALLOWED
+from ws0_validate import MAX_COUNT
+problems = []
+if MAX_TEMPS != len(TEMPS_ALLOWED):
+    problems.append(f"MAX_TEMPS {MAX_TEMPS} != len(TEMPS_ALLOWED) {len(TEMPS_ALLOWED)}")
+if MAX_ARMS != 1 + len(ARMS_ALLOWED):
+    problems.append(f"MAX_ARMS {MAX_ARMS} != 1+len(ARMS_ALLOWED) {1 + len(ARMS_ALLOWED)}")
+if MAX_EXPECTED_BOUNDARIES != MAX_TEMPS * MAX_ARMS * MAX_COUNT:
+    problems.append(f"cap {MAX_EXPECTED_BOUNDARIES} is not MAX_TEMPS*MAX_ARMS*MAX_COUNT")
+print("DERIVED" if not problems else "DRIFT " + "; ".join(problems))
+PY
+)"
+if [[ "$drift_out" == "DERIVED" ]]; then
+  pass "OBSERVED (#3393): the cap is DERIVED from the reporter's own closed vocabularies and MAX_COUNT — MAX_TEMPS == len(TEMPS_ALLOWED), MAX_ARMS == 1+len(ARMS_ALLOWED), cap == their product — so raising the accepted bound cannot silently re-open the gap"
+else
+  fail "#3393: the cap must stay derived from TEMPS_ALLOWED/ARMS_ALLOWED/MAX_COUNT (got: $drift_out)"
+fi
+
+# The RED direction, JUST ABOVE the cap — the tight edge, so the boundary is pinned on both sides and
+# not merely somewhere between 6 and ten million.
+over_out="$(labels_probe "$(python3 -c 'import sys; sys.path.insert(0, sys.argv[1]); from ws0_validate import MAX_COUNT; print(MAX_COUNT + 1)' "$PERF_DIR")" "warm cold" "bypass merge")"
+if [[ "$over_out" == REFUSED* ]] && grep -q 'implausible boundary product' <<<"$over_out"; then
+  pass "OBSERVED (#3393, RED direction at the TIGHT EDGE): one rep ABOVE the accepted maximum REFUSES, so the cap is pinned on both sides"
+else
+  fail "#3393: one rep above the accepted maximum must refuse (got: ${over_out:0:200})"
 fi
 
 absurd_out="$(labels_probe 10000000)"
@@ -477,6 +563,71 @@ else
   fail "#3393: the oversize path must refuse, not truncate (got: $absurd_out)"
 fi
 
+# A NEGATIVE reps is refused too, and as the SAME exception type — the product arithmetic would
+# otherwise read as a harmless 0 and return an EMPTY expected set, i.e. a session that owed nothing.
+neg_out="$(labels_probe -1)"
+if [[ "$neg_out" == REFUSED* ]] && grep -q 'reps must be >= 0' <<<"$neg_out"; then
+  pass "OBSERVED (#3393): a NEGATIVE reps is refused as Invalid rather than yielding an EMPTY expected set (a session that owed no boundaries at all)"
+else
+  fail "#3393: a negative reps must refuse (got: $neg_out)"
+fi
+
+# THE EXCEPTION TYPE IS PART OF THE CONTRACT (#3393). `ws0_report.py` funnels every fail-closed
+# decision through ONE `except Invalid` -> `FATAL:` exit path. A refusal raised as a bare `ValueError`
+# escapes that handler and reaches the operator as an uncaught traceback — a rig defect wearing the
+# costume of a crash. The first cut of this guard raised `ValueError`; `labels_probe` prints
+# `WRONGTYPE` for anything that is not `Invalid`, so all three RED cases above would name it.
+if ! grep -q 'WRONGTYPE' <<<"$absurd_out$over_out$neg_out"; then
+  pass "OBSERVED (#3393): every refusal here is Invalid — the ONE exception ws0_report.py catches — so it lands on the reporter's single FATAL: exit path and never on a traceback"
+else
+  fail "#3393: the refusal must be Invalid, not another exception type (got: ${absurd_out:0:120} / ${over_out:0:120} / ${neg_out:0:120})"
+fi
+
+# NON-VACUITY of the check above: `Invalid` is NOT a `ValueError`, so the pre-fix `raise ValueError`
+# genuinely escaped `except Invalid` — the traceback was real and not a theoretical concern.
+esc_out="$(python3 - "$PERF_DIR" <<'PY' 2>&1
+import sys
+sys.path.insert(0, sys.argv[1])
+from ws0_validate import Invalid
+print("ESCAPES" if not issubclass(Invalid, ValueError) else "CAUGHT")
+PY
+)"
+handler_catches=$(grep -c 'except Invalid as exc:' "$REPORT")
+if [[ "$esc_out" == "ESCAPES" ]] && [ "$handler_catches" -ge 1 ]; then
+  pass "NON-VACUITY (#3393): ws0_report.py catches Invalid and Invalid is NOT a subclass of ValueError — so the pre-fix raise ValueError really did escape the reporter's only handler"
+else
+  fail "#3393: Invalid must not be a ValueError subclass and the reporter must catch Invalid (esc=$esc_out, handlers=$handler_catches)"
+fi
+
+# ...and END-TO-END THROUGH THE SHIPPED REPORTER, because the two checks above are about types and a
+# type assertion cannot show what an operator sees. A manifest at `--reps MAX_COUNT` — a count
+# `positive_int` ACCEPTS — must reach the reporter's normal refusal path: a single `FATAL:` line, NO
+# traceback, and NOT the implausible-product refusal. Pre-fix, the flat cap raised `ValueError` from
+# under `build_report` and this same session produced a traceback instead.
+make_corpus "$TMP/corpus-cap"
+mkdir -p "$TMP/rec-cap"
+(
+  # shellcheck disable=SC2034  # consumed by make_scan_rep via dynamic scope, as in boundary_record_session
+  WS0_SCAN_CORPUS="$TMP/corpus-cap"
+  for r in 1 2; do
+    make_scan_rep "$TMP/rec-cap" warm "$r" ok
+    make_flight_rep "$TMP/rec-cap" warm "$r" ok "$GOOD_FLIGHT"
+  done
+  ws0_pin_session_corpus "$TMP/rec-cap" "$TMP/corpus-cap" \
+    "$(python3 -c 'import sys; sys.path.insert(0, sys.argv[1]); from ws0_validate import MAX_COUNT; print(MAX_COUNT)' "$PERF_DIR")" \
+    warm bypass 1
+)
+cap_out=$(python3 "$REPORT" --dir "$TMP/rec-cap" --corpus "$TMP/corpus-cap" 2>&1)
+cap_rc=$?
+if [ "$cap_rc" -ne 0 ] \
+   && [ "$(grep -c '^FATAL:' <<<"$cap_out")" -eq 1 ] \
+   && ! grep -q 'Traceback' <<<"$cap_out" \
+   && ! grep -q 'implausible boundary product' <<<"$cap_out"; then
+  pass "OBSERVED (#3393, END-TO-END through ws0_report.py): a session declaring the ACCEPTED --reps MAX_COUNT reaches the reporter's normal refusal — exactly one FATAL: line, no traceback, and no implausible-product refusal (rc=$cap_rc)"
+else
+  fail "#3393: an accepted --reps MAX_COUNT session must reach a normal FATAL: refusal with no traceback and no product refusal (rc=$cap_rc, fatals=$(grep -c '^FATAL:' <<<"$cap_out"), traceback=$(grep -c 'Traceback' <<<"$cap_out"), product=$(grep -c 'implausible boundary product' <<<"$cap_out"))"
+fi
+
 # ==========================================================================
 # A MINIMUM CHECK COUNT, because `set -uo pipefail` carries no `-e`
 # ==========================================================================
@@ -485,7 +636,7 @@ fi
 # and reports SUCCESS. That is the suite-level vacuous green, one level up from the checks.
 #
 # The floor is DERIVED FROM THE OBSERVED COUNT — run, then recorded — never counted off the source.
-MIN_CHECKS=16
+MIN_CHECKS=24
 if [ "$checks" -lt "$MIN_CHECKS" ]; then
   echo
   echo "FAIL - only $checks check(s) ran; this suite has at least $MIN_CHECKS."


### PR DESCRIPTION
Refs #3393.

## What was wrong

`expected_boundary_labels` materialized the whole `temps × reps × arms` product as a list, and `ws0_pin_boundary_observations` (`scripts/tests/lib-ws0-fixtures.sh:527`) then materialized a **second** list — one JSON string per label — over that same product, plus the joined string. Roughly three resident copies.

## What it cost, measured rather than inferred

On 2026-08-27/28 this reached **20–28 GB RSS** on 30 GB workers and the kernel issued **14 global OOM kills** across two boxes:

| box | kills | victim RSS |
|---|--:|---|
| box1 | 8 | 20.5–25.9 GB |
| box2 | 6 | 26.9–28.5 GB |
| rig box (no full gate yet) | **0** | — |

Caught live with a 2-second RSS sampler, because `dmesg` records the kill but never the argv and the process dies in ~70 s. Growth was **linear at ~410 MB/s** (2,256 → 8,029 MB across 15 s of samples), which is what identified an accumulating loop rather than one oversized parse.

**Collateral, all confirmed:**
- **sshd wedged on both boxes.** A box that cannot fork cannot accept an ssh session, which presents as TCP-accepted-with-no-banner — easily misread as a broken instance. It was: a healthy box was rebooted and then **terminated** on that misreading before the real cause was known.
- **Five lane sessions silently killed** (#1705 ×2, #1697 ×2, #1699 ×1). A dead tmux session is invisible to any monitor that iterates existing sessions, so each death went unreported until dead-lane detection was added.
- Reached from the gate's `tooling-tests` component via the `test_ws0_*.sh` suite, so **every full gate run risked it** — which is why the distribution above tracks "has run a full gate", not lanes-per-box.

## The fix

Cap the product at **100,000** and **refuse** beyond it, naming the product, the cap and the issue. The published sweep is 25 points × 3 reps, so the cap sits ~three orders of magnitude above any real configuration and can only fire on a caller defect.

**Deliberately a refusal, not a truncation.** A silently-truncated expected set reports every missing boundary as the operator's fault — precisely the failure mode `boundary_label`'s own docstring warns about one function above.

Also rejects a negative `reps` rather than silently yielding an empty product.

**Not converted to a generator**, though that would also fix it: the function returns a list to callers that may take `len()` or iterate twice, and six lanes were running gates against this file at the time. The cap is the minimal change that stops the OOM without touching caller semantics. Streaming remains available as a follow-up under #3393.

## Tests

`scripts/tests/test_ws0_boundary_record_completeness.sh` — 16 checks (floor raised 13 → 16), **both directions pinned**:

- **GREEN:** a real configuration still builds (1 temp × 3 reps × (scan+bypass) = 6 labels), so the cap cannot red a legitimate sweep. A cap tested only in its refusing direction is how a guard ships that reds correct input.
- **RED:** an absurd product refuses with the count, cap and issue named.
- **Refusal not truncation:** the oversize path emits no `BUILT`.

**Negative control run** (safely, just over the cap rather than at 28 GB): unpatched **builds 100,001 labels with no refusal**; patched refuses; fix restored and re-verified.

## What this does not do

It does not identify *which caller* passes an enormous `reps` — the sampler log on box2 has the full argv of each occurrence and that remains open on #3393, along with the observation that the gate's own `oom-audit` component (#2012) could not catch this because it audits Rust while the offending code is Python.


---

## Certification record (closer)

### Gate of record — FULL, `RESULT: PASS` on the certified sha

```
==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.zQZZCk
commit: b327846 branch: fix-3393-ws0-boundary-oom dirty: no
datasets: 144 Data.db files under /data/datasets
schemas: 6/6 canonical .cql readable under /data/lanes/lane-3393/test-data/schemas (checkout-relative)
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked perf=ok
tree-start: b32784653099 dirty: no digest: 369aff8e874b
tree-end: b32784653099 dirty: no digest: 369aff8e874b
tree-integrity: PASS
file-size: PASS  fmt: PASS  clippy: PASS  roborev-lints: PASS  core-tests: PASS
tombstones-scan: PASS  scan-offload-guard: PASS  work-counters-guard: PASS
byte-budget-guard: PASS  arrow-parity-guard: PASS  memory-budget: PASS
integration-tests: PASS  format-compat: PASS  write-tests: PASS  cli-tests: PASS
compaction-byte-parity: PASS  bti-multiclustering: PASS  query-semantics-oracle: PASS
flight-query-semantics-oracle: PASS  python-bindings: PASS  node-bindings: PASS
delivery-telemetry: PASS  oom-audit: PASS  parity-report: PASS
operator-metrics-doc: PASS  kit-dashboard-drift: PASS  binding-unwind-profile: PASS
tooling-tests: PASS (656s)  minimal-build: PASS  smoke: PASS
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

### roborev — CLEAN (round 2, job 11)

```
==== ROBOREV REVIEW SUMMARY ====
reviewed-sha: 5b8ae405806738e63fbba96075b50913f5874e96..b327846530997b02f6d5729877824f7465e9ed86
job: 11   model: gpt-5.6-sol   census: 2 files, +263/-2
tokens: input=528037 cached=455168 output=5260
push-assert: PASS   census-check: PASS   code-free: PASS   job-record: PASS
sha-assert: PASS    review-completed: PASS
prompt-content: PASS (2/2 code census paths present)
vacuity-tier1: PASS  vacuity-tier2: PASS
findings: NONE      roborev-exit: PASS
RESULT: PASS
==== END ROBOREV REVIEW SUMMARY ====
```

Token accounting is in the genuine band (398k–649k in / 314k–554k cached / 5.0k–6.3k out); the vacuous baseline is ~18.7k in / 0 cached / 53 out. No waiver was requested or granted anywhere in this certification.

`--base` was given as the **merge-base** (`5b8ae4058` = `git merge-base origin/main HEAD`) rather than the `origin/main` default, because the wrapper's `sha-assert` compares the job record's range base against `origin/main`'s **tip** while computing its own census from the **merge-base** — so it false-FAILs a correctly-scoped review whenever `main` advances mid-run (it did: #3381/#3411 merged during round 1's gate). The reviewed scope is byte-identical: `git diff --name-only <merge-base>..HEAD` and `origin/main...HEAD` produce the same file list. Escalated to the lead on #3393 for triage.

### Round 1 was not clean — two confirmed defects, both fixed in `b32784653`

1. **BLOCKER — the cap refused input the rig ACCEPTS.** `positive_int` accepts `--reps` to `MAX_COUNT = 100_000` and the `--temp`/`--arm` vocabularies are closed, so the widest accepted matrix is `2 x (scan + 2) x 100_000` = **600,000** boundaries. A flat 100,000 cap refused that, **at report time**, after the measurement had been paid for. The cap is now derived (`MAX_TEMPS * MAX_ARMS * MAX_COUNT`) and pinned against `TEMPS_ALLOWED`/`ARMS_ALLOWED`/`MAX_COUNT` by a drift check (they live in `ws0_report.py`, which imports this module, so importing them back would cycle).
2. **The refusal raised `ValueError`**, which escapes `ws0_report.py`'s sole `except Invalid` → `FATAL:` exit path as an uncaught traceback (`issubclass(Invalid, ValueError)` is `False`, measured). Now raises `Invalid`.

**The OOM protection is intact, measured not assumed**: at the derived cap, 600,000 labels cost 41 MB as the list and **139 MB peak RSS** across all three resident copies — three orders of magnitude under the 20–28 GB that caused the 14 kills, while a caller defect producing billions still refuses.

Coverage 16 → 24 checks, green direction now asserted **at the accepted maximum** (a green case below the cap cannot falsify the cap), with the pre-fix flat cap re-enacted for non-vacuity, the tight edge above the cap, the refusal type, and an end-to-end pass through `ws0_report.py`. Sibling suite `test_ws0_report_guards.sh` 107/107.

### Round 1's gate red was an unrelated known flake, cited not waived

Round 1's full gate FAILed `tooling-tests` on `scripts/tests/test_ws0_cpu_pinning_guards.sh` — a file **byte-identical to `main`** (`0ca3da4de…`, as is `lib-server.sh` at `b0173661f…`) and not in this diff. It is instance N of **#3387**: `awk … | grep -q` under `set -o pipefail`, where `grep -q` exits on the first match and `awk` takes SIGPIPE, so a **successful** match yields a failing pipeline. Measured 0/400 unloaded vs **558/3000 under 16-way CPU load**, all `rc=141`. Recorded on #3387; it did not recur in the gate of record above.

I did **not** waive it and did not patch source to green it: `git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh` exits **1** (`full`), so #3042's cite-and-waive is void for this PR. The clean full-gate PASS above is on the real diff.
