### PR TITLE
fix(#3392): sha-assert compares the reviewed range against the MERGE-BASE, not origin/main's tip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,7 +423,15 @@ implement (TDD) → --lite each fix round (summary-file redirect)
   the job-id carrier: for a range review it names only the BASE, so an unavailable record FAILs rather
   than falling back to prose that verifies nothing. A range that does not match, a SINGLE-COMMIT record
   (even one equal to HEAD), or a base-equal scope **aborts the round** — base-equality is the signature of
-  the worktree bug. **(3)** `"contains no code changes to review"` on a
+  the worktree bug. **The expected RANGE BASE is the MERGE-BASE, never the base ref's TIP (#3392)**:
+  `<base>...HEAD` *is* `merge-base(<base>, HEAD)..HEAD`, so an assert that expected the tip FAILED
+  DETERMINISTICALLY on a CORRECT review of any branch whose `main` had advanced past its branch point —
+  i.e. almost every branch not just rebased. It was misdiagnosed as a race **twice** (the falsifying
+  control: `origin/main` recorded before AND after a failing round, unmoved). The tip is still read, for
+  the T1 root-checkout signature alone, and the block now prints an informational
+  `assert-base: <merge-base> (merge-base of <base> and HEAD; <base> tip <sha>)` so the two can never be
+  confused in a pasted block. The absence waiver's `base=` field is bound to that same merge-base —
+  copy it from `assert-base:`, not from `base:`. **(3)** `"contains no code changes to review"` on a
   NON-EMPTY diff is a **HARD FAIL**, never a pass. **(4)** A docs-only (code-free) diff **cannot be
   roborev-certified at all** — and "docs-only" means a **CODE-FREE CENSUS as the wrapper classifies it,
   NEVER a `docs/` path prefix** (#3229). The mechanism, stated correctly: **roborev drops exactly what

--- a/openspec/specs/roborev-review-guard/spec.md
+++ b/openspec/specs/roborev-review-guard/spec.md
@@ -62,11 +62,29 @@ The census SHALL be partitioned into a CODE subset and a non-code subset by the 
 changed), while `code-free:` is decided by the non-code count equalling the total and `prompt-content:` is
 asserted over the CODE subset alone.
 
+The census range's BASE SHALL be the **MERGE-BASE** of the base ref and HEAD, resolved ONCE and reused:
+`<base>...HEAD` is by definition `merge-base(<base>, HEAD)..HEAD`, so the base ref's TIP is NOT the base of
+the range under review and SHALL NOT be used as one. The wrapper SHALL carry the two as SEPARATE named
+values — the range base (used by the census, by `sha-assert:` and by the absence-waiver scope) and the base
+ref's tip (used only where the tip itself is the subject, i.e. the ROOT-checkout signature in
+`sha-assert:`) — and the census diff SHALL be pinned to the resolved range base, so one read of a moving
+mirror ref cannot leave the census measuring one range while the assert expects another.
+
 An unmeasurable census SHALL fail closed and SHALL be DISTINGUISHABLE from an empty one:
-`FAIL (base '<ref>' unresolvable)` when the base ref does not resolve to a commit, and
-`FAIL (git diff failed)` when the diff command itself exits non-zero. Neither SHALL be aliased to
-`FAIL (empty census)` / `NOTHING-TO-REVIEW`, because "we could not tell" is not "there is nothing to
-review". The wrapper SHALL NOT fetch on the caller's behalf to repair an unresolvable base.
+`FAIL (base '<ref>' unresolvable)` when the base ref does not resolve to a commit,
+`FAIL (no merge-base between '<ref>' and HEAD)` when the two have no common ancestor,
+`FAIL (merge-base of '<ref>' and HEAD unusable)` when the merge-base command succeeds without yielding
+exactly one 40-hex sha, and `FAIL (git diff failed)` when the diff command itself exits non-zero. None
+SHALL be aliased to `FAIL (empty census)` / `NOTHING-TO-REVIEW`, because "we could not tell" is not "there
+is nothing to review". An unresolvable merge-base SHALL NOT be degraded to the base ref's tip or to an
+empty value — a permissive branch here SHALL be keyed on the AFFIRMATIVE value (one 40-hex sha), never on
+the absence of a non-zero exit. The wrapper SHALL NOT fetch on the caller's behalf to repair an
+unresolvable base.
+
+#### Scenario: An unresolvable merge-base fails closed before anything is enqueued
+- **GIVEN** a repository whose base ref and HEAD have NO common ancestor (unrelated histories)
+- **WHEN** the wrapper computes the census
+- **THEN** `census-check:` reads `FAIL (no merge-base between '<ref>' and HEAD)`, the message states that this is explicitly NOT `NOTHING-TO-REVIEW` and that the base is deliberately not degraded to the tip, no review is enqueued, and the terminal `RESULT:` is `FAIL`
 
 #### Scenario: An unresolvable base ref fails closed rather than reporting nothing to review
 - **GIVEN** a clone whose `origin/main` mirror ref does not resolve (a narrow fetch refspec that has never fetched it)
@@ -576,7 +594,10 @@ census base.
 
 The value set SHALL be:
 
-- `PASS` — range head == branch HEAD AND range base == the resolved base sha.
+- `PASS` — range head == branch HEAD AND range base == the resolved RANGE BASE, i.e. the MERGE-BASE of
+  the base ref and HEAD. It SHALL NOT be the base ref's TIP: the reviewed range is merge-base-relative, so
+  comparing its base endpoint against the tip made a CORRECT review FAIL deterministically for every branch
+  whose base ref had advanced since the branch point (issue #3392).
 - `FAIL (reviewed range does not match <base>...HEAD)` — either endpoint disagrees, with the message
   naming WHICH: a range BASE of git's empty-tree hash SHALL be named as the signature of the
   non-sanctioned two-positional form, and a range HEAD short of branch HEAD SHALL be named as a reviewed
@@ -587,8 +608,11 @@ The value set SHALL be:
   passes every path check while the earlier changes go unreviewed. The sanctioned invocation always
   records a range, so a single sha means something else ran.
 - `FAIL (reviewed-sha does not match head-sha)` — a single-commit record that is not branch HEAD;
-  attributed when it equals the base ref (the signature of `--branch` resolved against the ROOT checkout)
-  and otherwise named as matching neither endpoint.
+  attributed when it equals the base ref's TIP (the signature of `--branch` resolved against the ROOT
+  checkout, which enqueues that tip), attributed distinctly when it equals the MERGE-BASE (the branch point
+  itself, so every commit under review is a descendant of it), and otherwise named as matching neither
+  endpoint. Both equalities SHALL FAIL, and the message SHALL name WHICH one matched — when the branch is
+  not behind its base the two are the same commit and the message SHALL say so.
 - `FAIL (job record unavailable — reviewed range unverifiable)` — no `git_ref` after the bounded read.
   This SHALL FAIL rather than fall back to prose: for a RANGE review the stdout announcement names only
   the range BASE, so it cannot establish that branch HEAD was reviewed at all, and a fallback to it would
@@ -605,7 +629,7 @@ case-normalised before matching, both fields validated before use, and when seve
 present the LAST one SHALL be the effective enqueue with the multiplicity recorded as a NOTICE.
 
 #### Scenario: A matching range satisfies the assert
-- **WHEN** the job record's `git_ref` is `<base40>..<head40>` whose head equals branch HEAD and whose base equals the resolved base sha
+- **WHEN** the job record's `git_ref` is `<base40>..<head40>` whose head equals branch HEAD and whose base equals the resolved range base (the merge-base of the base ref and HEAD)
 - **THEN** `sha-assert:` reads `PASS` and `reviewed-sha:` reports the full `<base40>..<head40>` range beside `head-sha:`
 
 #### Scenario: A range whose endpoints do not match the census range fails closed
@@ -622,6 +646,16 @@ present the LAST one SHALL be the effective enqueue with the multiplicity record
 - **GIVEN** a worktree branch whose HEAD differs from its base `origin/main`
 - **WHEN** the job record reports the base ref as the reviewed commit
 - **THEN** the wrapper exits non-zero with `RESULT: FAIL`, and the message states that the reviewed sha equals the base ref, that NO branch change was reviewed, and that base-equality is the signature of a `--branch` review resolved against the ROOT checkout
+
+#### Scenario: A correct review of a branch whose base ref has advanced PASSes
+- **GIVEN** a branch whose HEAD is unchanged while its base ref has advanced past the branch point, so `merge-base(<base>, HEAD)` and `rev-parse <base>` are DIFFERENT commits
+- **WHEN** the job record's `git_ref` is `<merge-base>..<branch HEAD>` — the range roborev actually reviews
+- **THEN** `sha-assert:` reads `PASS`, `assert-base:` names the merge-base with the base ref's tip beside it, and the terminal `RESULT:` is `PASS`
+
+#### Scenario: With the base ref advanced, a tip-anchored range and a stale head still FAIL
+- **GIVEN** the same branch, whose base ref has advanced past the branch point
+- **WHEN** the job record's `git_ref` anchors the range at the base ref's TIP, or at git's empty tree, or reports a head short of the branch tip, or is a single sha equal to the tip or to the merge-base
+- **THEN** `sha-assert:` FAILs in every one of those cases with the endpoint-naming diagnostics, so the merge-base comparison is not a loosening of what the assert catches
 
 #### Scenario: An unavailable job record fails closed rather than falling back to the announcement
 - **GIVEN** a job whose record still carries no `git_ref` after the bounded read
@@ -827,12 +861,16 @@ reading `PASS` beside a `RESULT: FAIL` and cannot attribute the failure.
 The wrapper SHALL emit a single compact `==== ROBOREV REVIEW SUMMARY ====` block on every **VERDICT**
 exit path — a pass, any failed check, or an empty census — carrying one field per line, in a FIXED
 order that is part of the contract, under the greppable keys: `repo:`, `branch:`, `base:`, `head-sha:`,
-`reviewed-sha:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`,
-`job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`,
+`reviewed-sha:`, `assert-base:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`,
+`code-free:`, `job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`,
 `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:`, `log:`, and a terminal
-`RESULT: PASS|FAIL|NOTHING-TO-REVIEW` — **TWENTY-TWO keys in all**, counting the terminal `RESULT:`. Each
+`RESULT: PASS|FAIL|NOTHING-TO-REVIEW` — **TWENTY-THREE keys in all**, counting the terminal `RESULT:`. Each
 SHALL appear EXACTLY ONCE, and `code-free:` SHALL sit immediately after `census-check:`, mirroring its
 pre-enqueue evaluation order.
+`assert-base:` SHALL be INFORMATIONAL — outside the verdict scan and outside the affirmation backstop,
+exactly like `census:`, `tokens:` and `waiver:` — and SHALL state the sha the range assert compared against
+together with the base ref's TIP, so a reader of a pasted block can tell a merge-base from a ref tip
+instead of inferring which one `base:` meant (issue #3392).
 `reviewed-sha:` SHALL carry the reviewed RANGE `<base40>..<head40>` on a normal run (a single sha only
 when the record reports one, and `-` when it is unverifiable), so a reader SHALL NOT expect a bare sha
 there.
@@ -944,7 +982,11 @@ path (exit `0`) is likewise not a verdict and SHALL emit no block.
 
 #### Scenario: The block carries every per-check key in the contracted order
 - **WHEN** a review was enqueued and completed
-- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:` — twenty-two keys in all, each exactly once
+- **THEN** the block carries `repo:`, `branch:`, `base:`, `head-sha:`, `reviewed-sha:`, `assert-base:`, `job:`, `model:`, `census:`, `tokens:`, `push-assert:`, `census-check:`, `code-free:`, `job-record:`, `sha-assert:`, `review-completed:`, `prompt-content:`, `vacuity-tier1:`, `vacuity-tier2:`, `findings:`, `roborev-exit:` and `log:` in that order, ahead of the terminal `RESULT:` — twenty-three keys in all, each exactly once
+
+#### Scenario: The block states which base the range assert compared against
+- **WHEN** a normal run's block is read
+- **THEN** `assert-base:` carries the resolved range base (the merge-base of the base ref and HEAD) together with the base ref's tip, and it is informational — it appears in neither the verdict-grammar scan nor the affirmation backstop, so it can never make a run pass or fail on its own
 
 #### Scenario: An unreached check reads SKIP, never blank
 - **GIVEN** a run that fails at `push-assert:` before the census is classified
@@ -1161,8 +1203,9 @@ key, the exact-token verdict grammar (the value up to its first space, matched e
 SIX-key affirmation backstop and no per-key exemption, and the corrected `prompt-content:` values
 (an unretrievable prompt FAILS; there is no non-failing `UNAVAILABLE` for that key). Where doctrine
 documents the live probe it SHALL state the expectation in the RANGE form — the `reviewed-sha:` range's
-HEAD endpoint equals the worktree HEAD and its base equals the base ref — never as `reviewed-sha`
-equalling the worktree HEAD.
+HEAD endpoint equals the worktree HEAD and its base equals `git merge-base <base> HEAD` (NOT
+`git rev-parse <base>`, which is the ref's tip and equals the merge-base only while the branch is not
+behind — #3392) — never as `reviewed-sha` equalling the worktree HEAD.
 
 **Scenario attribution note (#3229).** The *Both AC6 doctrine surfaces carry all four rules* scenario
 below was authored as *Both **AC4** doctrine surfaces …* under #2964, where the doctrine criterion was
@@ -1207,7 +1250,7 @@ delete it as AC4 residue. The assertion is unchanged; only its criterion number 
 
 #### Scenario: The live-probe expectation is stated in the range form
 - **WHEN** the doctrine page's live worktree probe section is inspected
-- **THEN** it asks the reader to confirm the `reviewed-sha:` RANGE — its HEAD endpoint equal to the worktree branch HEAD and its base equal to the base ref — rather than a `reviewed-sha` equal to the worktree HEAD, which the range value can never satisfy
+- **THEN** it asks the reader to confirm the `reviewed-sha:` RANGE — its HEAD endpoint equal to the worktree branch HEAD and its base equal to `git merge-base <base> HEAD` — rather than a `reviewed-sha` equal to the worktree HEAD, which the range value can never satisfy
 
 #### Scenario: The mechanized-in-lite table lists the new guard
 - **WHEN** the `roborev-findings` page's table of classes mechanized in `--lite` is inspected
@@ -1222,7 +1265,7 @@ A regression check SHALL exercise the wrapper hermetically — using a stub `rob
 replays recorded real outputs, with no network, no live reviewer, no dataset corpus and no cargo — and
 SHALL assert that the wrapper:
 
-(a) FAILs when the reviewed sha equals the base ref, naming the base; (b) FAILs when the reviewed scope
+(a) FAILs when the reviewed sha equals the base ref — its tip and its merge-base with HEAD alike, each named distinctly; (b) FAILs when the reviewed scope
 does not match the census range at either endpoint; (c) FAILs a cleanliness vacuity claim against a
 non-empty code census — INCLUDING one whose sentence sits under a `## Summary` HEADING — and does NOT
 fail a findings-bearing or out-of-summary mention of the same phrase; (d) FAILs the vacuous token
@@ -1306,7 +1349,7 @@ because it is read as coverage. The suite's stub SHALL emit a VALID JSON job rec
 double quotes, so a quote-bearing prompt cannot degrade the record and mask the very comparison the case
 exists to pin.
 
-The check SHALL also pin the block's key ORDER — all twenty-two keys, each appearing EXACTLY ONCE, with
+The check SHALL also pin the block's key ORDER — all twenty-three keys, each appearing EXACTLY ONCE, with
 `code-free:` immediately after `census-check:` — the distinctness of its header from all three
 agent-gate summary headers, the usage-error path emitting no block, and hermeticity itself. It SHALL be
 registered in the agent gate's shell-tooling component set such that it runs in the fast `--lite` loop

--- a/scripts/flow/roborev-review-checks.sh
+++ b/scripts/flow/roborev-review-checks.sh
@@ -180,7 +180,14 @@ roborev_check_prompt_content() {
       # never completed — is reached on a different path and is untouched by it. A `WAIVED` token
       # therefore always means "the census paths were absent and a named human accepted that", never
       # anything else.
-      roborev_absence_waiver_lookup "${BASE_SHA:-}" "${HEAD_SHA:-}" "${JOB:-}"
+      # BOUND TO THE MERGE-BASE, THE SAME BASE `sha-assert` COMPARES AGAINST (#3392). The scope
+      # is the REVIEWED RANGE, and that range is `merge-base..HEAD`; binding it to the base ref's
+      # TIP gave the waiver the identical staleness defect the assert had — a waiver written for a
+      # failing run went spuriously STALE on `--recheck-job` the moment the base ref advanced,
+      # which re-deadlettered the #3312 break-glass exactly when the fleet is busiest. Nothing is
+      # weakened: base AND head AND job are all still required and all still verified, and the
+      # base is now the one sha that actually identifies the reviewed range.
+      roborev_absence_waiver_lookup "${RANGE_BASE_SHA:-}" "${HEAD_SHA:-}" "${JOB:-}"
       WAIVER_REPORT="${ROBOREV_WAIVER_STATE}"
       if [ "$ROBOREV_WAIVER_STATE" = "granted" ]; then
         # A DISTINCT VERDICT TOKEN, deliberately not `PASS (waived …)`: every reader that greps
@@ -209,7 +216,7 @@ roborev_check_prompt_content() {
         # now lives ONLY in `--help`, which the requester has to go and read; nothing printed here can be
         # pasted into a grant. The anchoring and placeholder rules make a pasted block harmless anyway,
         # but this layer means the block never carries a live credential in the first place.
-        DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} CODE census paths appear on NEITHER side of any 'diff --git' header in the prompt actually sent to the reviewer, so nothing establishes that the reviewer received their diffs. The census is authoritative ($CENSUS for ${BASE}...HEAD); a diff that does not carry a file cannot have reviewed it. THE MACHINE CANNOT TELL WHY THEY ARE ABSENT — a diff roborev delivered by snapshot path and a vacuous review that received nothing look IDENTICAL from here, which is the accepted cost of not inferring delivery mode from injectable prompt text. If this absence is legitimate, the review's token accounting is the evidence a human weighs (genuine reviews measured 398k-649k input / 314k-554k cached; the vacuous baseline is ~18.7k input / 0 cached), and the OWNER or the COORDINATION LEAD may waive it for THIS review only (base ${BASE_SHA:-<unknown>}, head ${HEAD_SHA:-<unknown>}, job ${JOB:-<unknown>}) with a dedicated anchored PR-comment line. THE EXACT MARKER FORM IS DELIBERATELY NOT PRINTED HERE — run 'bash scripts/flow/roborev-review.sh --help' for it — because a summary block gets pasted into PR comments as a matter of course, and a block that carried a complete marker would authorize the next run by being quoted. Waiver state for this run: ${WAIVER_REPORT} (a well-formed marker from an author outside the waiver allowlist reports UNAUTHORIZED and does not grant). Absent paths (first 10):")
+        DETAILS+=("ERROR: prompt-content: ${#missing_paths[@]} of the ${#checked_paths[@]} CODE census paths appear on NEITHER side of any 'diff --git' header in the prompt actually sent to the reviewer, so nothing establishes that the reviewer received their diffs. The census is authoritative ($CENSUS for ${BASE}...HEAD); a diff that does not carry a file cannot have reviewed it. THE MACHINE CANNOT TELL WHY THEY ARE ABSENT — a diff roborev delivered by snapshot path and a vacuous review that received nothing look IDENTICAL from here, which is the accepted cost of not inferring delivery mode from injectable prompt text. If this absence is legitimate, the review's token accounting is the evidence a human weighs (genuine reviews measured 398k-649k input / 314k-554k cached; the vacuous baseline is ~18.7k input / 0 cached), and the OWNER or the COORDINATION LEAD may waive it for THIS review only (base ${RANGE_BASE_SHA:-<unknown>} — the merge-base of ${BASE} and HEAD, which is the base of the reviewed range and NOT the tip of ${BASE}, head ${HEAD_SHA:-<unknown>}, job ${JOB:-<unknown>}) with a dedicated anchored PR-comment line. THE EXACT MARKER FORM IS DELIBERATELY NOT PRINTED HERE — run 'bash scripts/flow/roborev-review.sh --help' for it — because a summary block gets pasted into PR comments as a matter of course, and a block that carried a complete marker would authorize the next run by being quoted. Waiver state for this run: ${WAIVER_REPORT} (a well-formed marker from an author outside the waiver allowlist reports UNAUTHORIZED and does not grant). Absent paths (first 10):")
       fi
       printed=0
       for census_path in "${missing_paths[@]}"; do

--- a/scripts/flow/roborev-review-oracles.sh
+++ b/scripts/flow/roborev-review-oracles.sh
@@ -26,8 +26,8 @@
 # turning both checks into no-ops would be the worst regression possible here).
 
 # shellcheck disable=SC2034
-# ^ every variable assigned in this file (PUSH_ASSERT, BASE_SHA, CENSUS_CHECK,
-#   CODE_FREE, census_*) is READ by the sourcing wrapper, which
+# ^ every variable assigned in this file (PUSH_ASSERT, BASE_TIP_SHA, RANGE_BASE_SHA,
+#   CENSUS_CHECK, CODE_FREE, census_*) is READ by the sourcing wrapper, which
 #   shellcheck cannot see when it lints this fragment standalone. Lint the pair with
 #   `shellcheck -x scripts/flow/roborev-review.sh` to resolve them across the
 #   source boundary.
@@ -187,11 +187,12 @@ _rx_dirglob_match() {
 
 # ROBOREV_RANGE_ENDPOINT_REFS: the refs that ARE the census range's endpoints, named once so
 # neither caller nor reader can disagree about what "the range" means. HEAD is the right-hand
-# endpoint; `BASE_SHA` the left. The order is presentational ONLY — the fold below is a
-# DISJUNCTION, so permuting this array cannot change any answer.
+# endpoint; `RANGE_BASE_SHA` — the MERGE-BASE, which is what `<base>...HEAD` actually diffs
+# against, NOT the base ref's tip (#3392) — is the left. The order is presentational ONLY —
+# the fold below is a DISJUNCTION, so permuting this array cannot change any answer.
 roborev_range_endpoint_refs() {
   local ref
-  for ref in HEAD "${BASE_SHA:-}"; do
+  for ref in HEAD "${RANGE_BASE_SHA:-}"; do
     [ -n "$ref" ] && printf '%s\n' "$ref"
   done
 }
@@ -496,7 +497,7 @@ roborev_push_assert() {
   PUSH_ASSERT="PASS"
 }
 
-# roborev_census: sets BASE_SHA, CENSUS, CENSUS_CHECK, CODE_FREE and the
+# roborev_census: sets BASE_TIP_SHA, RANGE_BASE_SHA, CENSUS, CENSUS_CHECK, CODE_FREE and the
 # census_* / census_paths state; calls `finish` on failure or an empty census.
 roborev_census() {
   # --- step 3: the local diff census — THE ORACLE -------------------------------
@@ -505,10 +506,69 @@ roborev_census() {
   # unresolvable base must never be allowed to produce an empty census, which would
   # surface as NOTHING-TO-REVIEW and read as "nothing to look at" rather than "we
   # could not tell". No implicit `git fetch` is performed on the caller's behalf.
-  BASE_SHA=""
-  if ! BASE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "${BASE}^{commit}"); then
+  BASE_TIP_SHA=""
+  RANGE_BASE_SHA=""
+  if ! BASE_TIP_SHA=$(git -C "$REPO" rev-parse --verify --quiet "${BASE}^{commit}"); then
     CENSUS_CHECK="FAIL (base '$BASE' unresolvable)"
     DETAILS+=("ERROR: census: base ref '$BASE' does not resolve to a commit in $REPO, so the census — and therefore every vacuity judgement — would be unfounded. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW: an unresolvable base is 'we cannot tell', never 'there is nothing to review'. If '$BASE' is a remote-tracking ref, this clone may have a narrow fetch refspec or have never fetched it; fetch it yourself (the wrapper never fetches behind your back) and re-run. No review was enqueued.")
+    finish FAIL 1
+  fi
+
+  # ===== THE RANGE BASE IS THE MERGE-BASE, NEVER THE BASE REF'S TIP (#3392) =====
+  # `<base>...HEAD` — the THREE-DOT form the census measures — is
+  # `merge-base(<base>, HEAD)..HEAD`. It is NOT `<base-tip>..HEAD`, and the two differ for
+  # every branch whose `<base>` has advanced since the branch point, i.e. for almost every
+  # branch that has not just been rebased. roborev reviews the same three-dot range and its
+  # job record's `git_ref` therefore carries `<merge-base>..<head>`.
+  #
+  # Before this, ONE name (`BASE_SHA`) held the TIP and was used both as this range's left
+  # endpoint and as `sha-assert`'s expected range base, so the assert compared a
+  # merge-base-relative reviewed range against the tip and FAILED DETERMINISTICALLY on a
+  # CORRECT review — an abort that costs the review's tokens and reads exactly like a vacuous
+  # review. Two different definitions of "base" under one name is the whole defect, so the
+  # name is retired: `RANGE_BASE_SHA` is the base OF THE RANGE UNDER REVIEW (what the census
+  # diffs from, what the assert expects, what the absence waiver is bound to) and
+  # `BASE_TIP_SHA` is the base REF's tip, used only where the tip itself is the subject (the
+  # root-checkout T1 diagnostic in the wrapper).
+  #
+  # RESOLVED FROM `$BASE_TIP_SHA`, NOT FROM `$BASE` AGAIN, and the census diff below is then
+  # pinned to `$RANGE_BASE_SHA`: one read of the moving ref, one range, used by the census,
+  # the assert and the waiver scope. That is what closes the SECOND-ORDER race the deterministic
+  # bug was masking — a mirror ref that advances mid-run can otherwise leave the census
+  # measuring one range while the assert expects another, and each would look correct alone.
+  #
+  # FAIL CLOSED, affirmatively. Unrelated histories (no common ancestor) exit non-zero with no
+  # output; a broken/absent object store can fail in other ways. Either way the range under
+  # review is UNKNOWN, and an unknown range must never degrade to the tip or to an empty value —
+  # the tip is the very thing that produced the defect, and an empty expected base would make
+  # `sha-assert` compare against nothing. So the permissive branch is keyed on the AFFIRMATIVE
+  # value: a single 40-hex sha and nothing else (a multi-line `--all`-style answer, an empty
+  # answer, or anything non-hex is a FAIL, because we could not tell WHICH base was reviewed).
+  # Ordered BEFORE any review is enqueued, like every other census check, so a failure here
+  # costs no review tokens.
+  local mergebase_err="$LOG.mergebase.err"
+  if ! RANGE_BASE_SHA=$(git -C "$REPO" merge-base "$BASE_TIP_SHA" HEAD 2>"$mergebase_err"); then
+    CENSUS_CHECK="FAIL (no merge-base between '$BASE' and HEAD)"
+    DETAILS+=("ERROR: census: 'git merge-base $BASE_TIP_SHA HEAD' failed in $REPO, so the BASE OF THE RANGE UNDER REVIEW is unknown and neither the census ('${BASE}...HEAD' is merge-base..HEAD) nor sha-assert would have anything sound to measure against. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW: an unresolvable merge-base is 'we cannot tell', never 'there is nothing to review'. The usual cause is that '$BASE' and HEAD have NO common ancestor (unrelated histories). It is deliberately NOT degraded to the tip of '$BASE': asserting a merge-base-relative reviewed range against a tip is the defect this resolution exists to fix. No review was enqueued. git said:")
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      DETAILS+=("  $line")
+    done <"$mergebase_err"
+    finish FAIL 1
+  fi
+  # The AFFIRMATIVE form test: `range_base_form` only ever becomes `40-hex` by a positive
+  # measurement (hex-only AND exactly 40 bytes), and the branch below keys on THAT value rather
+  # than on "not one of the bad shapes" — a shape nobody anticipated therefore fails closed.
+  # `*[!0-9a-f]*` catches a NEWLINE too, so a multi-line answer (several merge bases) cannot
+  # slip through as a sha with trailing noise.
+  local range_base_form="unusable"
+  case "$RANGE_BASE_SHA" in
+    *[!0-9a-f]*) ;;
+    ?*) [ "${#RANGE_BASE_SHA}" -eq 40 ] && range_base_form="40-hex" ;;
+  esac
+  if [ "$range_base_form" != "40-hex" ]; then
+    CENSUS_CHECK="FAIL (merge-base of '$BASE' and HEAD unusable)"
+    DETAILS+=("ERROR: census: 'git merge-base $BASE_TIP_SHA HEAD' succeeded but did not yield exactly one 40-hex commit sha, so the base of the range under review is not established. A PASS here would rest on the ABSENCE of a non-zero exit rather than on a measurement, so it fails closed. What git returned, rendered between markers: [$RANGE_BASE_SHA]. No review was enqueued.")
     finish FAIL 1
   fi
 
@@ -548,13 +608,17 @@ roborev_census() {
   # survives intact — which a line-oriented read cannot do at all.
   local numstat_file="$LOG.numstat"
   set +e
-  git -C "$REPO" diff --numstat -z --no-renames "${BASE}...HEAD" \
+  # `"$RANGE_BASE_SHA" HEAD` (two-dot) IS `"${BASE}...HEAD"` (three-dot) BY DEFINITION, with
+  # the moving ref read exactly ONCE — see the merge-base resolution above. Every diagnostic
+  # that says `${BASE}...HEAD` names this same range; the spelling here is pinned, the prose
+  # there is the reader-facing name for it.
+  git -C "$REPO" diff --numstat -z --no-renames "$RANGE_BASE_SHA" HEAD \
     >"$numstat_file" 2>"$numstat_file.err"
   DIFF_RC=$?
   set -e
   if [ "$DIFF_RC" -ne 0 ]; then
     CENSUS_CHECK="FAIL (git diff failed)"
-    DETAILS+=("ERROR: census: 'git diff --numstat -z --no-renames ${BASE}...HEAD' exited $DIFF_RC in $REPO, so the census was never measured. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW — an unmeasurable diff is 'we cannot tell', never 'there is nothing to review'. git said:")
+    DETAILS+=("ERROR: census: 'git diff --numstat -z --no-renames $RANGE_BASE_SHA HEAD' (that is, ${BASE}...HEAD) exited $DIFF_RC in $REPO, so the census was never measured. This is a FAIL, explicitly NOT a NOTHING-TO-REVIEW — an unmeasurable diff is 'we cannot tell', never 'there is nothing to review'. git said:")
     while IFS= read -r line; do
       [ -n "$line" ] || continue
       DETAILS+=("  $line")

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -386,11 +386,12 @@ A worker or a closer may REQUEST one — one comment, including the token accoun
 and may never apply it to its own PR.
 
 IT IS BOUND TO THE WHOLE REVIEW SCOPE, not just the head: base AND head AND job are all
-required and all verified. `base=` is the base OF THE REVIEWED RANGE — the merge-base of
-`--base` and HEAD, which the block prints as `assert-base:` — NOT the tip of the base ref
-(#3392). Copy it from `assert-base:`; the two are the same commit only while the branch is
-not behind its base, and binding to the tip made a waiver go STALE the instant the base ref
-advanced, which is what made this mechanism a dead letter under fleet load. The authorizer's judgment under (d) was about ONE review and
+required and all verified. The base= field is the base OF THE REVIEWED RANGE — the
+merge-base of --base and HEAD, which the block prints under the assert-base: key — and NOT
+the tip of the base ref (#3392). Copy it from the assert-base: line of the failing block,
+never from the base: line; the two name the same commit only while the branch is not behind
+its base, and binding to the tip made a waiver go STALE the instant the base ref advanced,
+which is what made this mechanism a dead letter under fleet load. The authorizer's judgment under (d) was about ONE review and
 its token accounting, so the waiver may not outlive it — a push, a different base or a
 re-run each need a fresh one. A marker missing any field is MALFORMED, never granted.
 

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -873,9 +873,42 @@ if [ -n "$RECHECK_JOB" ]; then
   RECHECK_ACTIVE=1
   : >"$LOG"
 else
+  # ===== THE ENQUEUE IS PINNED TO THE RESOLVED MERGE-BASE, NOT THE SYMBOLIC REF (#3392) =====
+  # `--base` used to receive the SYMBOLIC `$BASE`, so roborev re-resolved the mirror ref ITSELF and
+  # computed its own merge-base. If the ref moved between the census and this call, roborev reviewed a
+  # DIFFERENT range than the census measured — and the only thing that noticed was `sha-assert`, AFTER a
+  # full-price review had been spent. That is the residual second-order race the issue names, and
+  # detecting it later is not the same as not having it.
+  #
+  # Passing the RESOLVED sha makes the range IMMUTABLE across all four consumers — census, enqueue,
+  # assert, waiver scope — so the divergence is UNEXPRESSIBLE rather than caught. The property that makes
+  # this exact rather than approximate: with the merge-base as the base, `base..HEAD` and `base...HEAD`
+  # denote the SAME range (merge-base(merge-base, HEAD) is the merge-base), so pinning it cannot change
+  # what is reviewed — there is no longer a two-dot/three-dot semantics gap for the two sides to disagree
+  # across.
+  #
+  # VERIFIED AGAINST THE REAL BINARY (roborev v0.61.2), not assumed: a raw 40-hex sha is accepted by
+  # `--base` and recorded as the range base. Measured on a throwaway repo whose main had advanced past
+  # the branch point (merge-base d6b806a…, branch head 0b226fa…, main tip 399abca…):
+  #   --base <merge-base sha>  -> "1 commits since d6b806a…", git_ref d6b806a…..0b226fa…, job_type range
+  #   --base origin/main       -> "1 commits since origin/main", git_ref d6b806a…..0b226fa…  (IDENTICAL)
+  # i.e. both forms record the same merge-base-anchored range — which is also the direct measurement
+  # that roborev anchors at the MERGE-BASE and never at the ref tip.
+  #
+  # The block still reports `base: $BASE` — the operator asked for a symbolic ref and the block must not
+  # misreport what was requested — while `assert-base:` carries the resolved sha this call used.
+  #
+  # A STRUCTURAL BACKSTOP, deliberately unreachable through the normal ordering (the census resolves
+  # `RANGE_BASE_SHA` and `finish`es on failure, before this point): an EMPTY value here would be handed to
+  # roborev as no `--base` at all, silently re-enabling its base AUTO-DETECTION and reviewing a range
+  # nothing verified. The point of a backstop is not to depend on an upstream check still being there.
+  if [ -z "${RANGE_BASE_SHA:-}" ]; then
+    DETAILS+=("ERROR: the resolved range base is empty at the enqueue, so the reviewed range would be whatever roborev auto-detected rather than the census range. This is a defect in the wrapper's own ordering (the census resolves it and fails closed before this point), not something to fix in the branch under review. Failing closed; no review was enqueued.")
+    finish FAIL 1
+  fi
   set +e
   roborev review --branch \
-    --base "$BASE" \
+    --base "$RANGE_BASE_SHA" \
     --repo "$REPO" \
     --agent "$AGENT" \
     --model "$MODEL" \

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -82,7 +82,8 @@
 # agent-gate summary headers so neither can ever be pasted as the other:
 #
 #   ==== ROBOREV REVIEW SUMMARY ====
-#   repo: / branch: / base: / head-sha: / reviewed-sha: / job: / model: / census:
+#   repo: / branch: / base: / head-sha: / reviewed-sha: / assert-base: / job: /
+#   model: / census: /
 #   tokens: / push-assert: / census-check: / code-free: / job-record: /
 #   sha-assert: / review-completed: / prompt-content: /
 #   vacuity-tier1: / vacuity-tier2: / findings: / roborev-exit: / log:
@@ -101,6 +102,10 @@
 #   job-record        PASS | PASS (no token accounting in the record) |
 #                     DEGRADED (incomplete after <n> retries: <fields>) | SKIP
 #   sha-assert        PASS | FAIL (...) | SKIP
+#                     Asserts BOTH endpoints of the reviewed range against the CENSUS range,
+#                     whose base is the MERGE-BASE of `<base>` and HEAD — `<base>...HEAD` is
+#                     `merge-base(<base>, HEAD)..HEAD`, never `<base-tip>..HEAD` (#3392). The
+#                     base ref's TIP is still read, for the T1 root-checkout signature alone.
 #   prompt-content    PASS (<k>/<n> code census paths present) |
 #                     FAIL (<k>/<n> code census paths absent from the prompt) |
 #                     FAIL (no code census path was checkable — a 0/0 is never a pass) |
@@ -173,7 +178,10 @@
 # record's git_ref, asserting BOTH endpoints of the reviewed range against the census
 # range), `review-completed` (job status + an allow-list of terminal verdict markers),
 # `prompt-content` (the CODE subset of our census inside the prompt actually sent). Prose matching (`vacuity-tier1`) and token accounting (`vacuity-tier2`)
-# CORROBORATE; tier 1 can only ever raise a NOTICE.
+# CORROBORATE; tier 1 can only ever raise a NOTICE. `base:`, `head-sha:`, `reviewed-sha:`,
+# `assert-base:`, `census:`, `tokens:` and `waiver:` are INFORMATIONAL — they are in neither
+# the verdict-grammar scan nor the affirmation loop (both enumerate the verdict-carrying keys
+# by name), so none of them can make a run pass or fail on its own.
 #
 # EXIT CODES (exactly three outcomes plus a usage code)
 #   0  PASS               — a review demonstrably HAPPENED against branch HEAD with
@@ -377,7 +385,11 @@ A worker or a closer may REQUEST one — one comment, including the token accoun
 and may never apply it to its own PR.
 
 IT IS BOUND TO THE WHOLE REVIEW SCOPE, not just the head: base AND head AND job are all
-required and all verified. The authorizer's judgment under (d) was about ONE review and
+required and all verified. `base=` is the base OF THE REVIEWED RANGE — the merge-base of
+`--base` and HEAD, which the block prints as `assert-base:` — NOT the tip of the base ref
+(#3392). Copy it from `assert-base:`; the two are the same commit only while the branch is
+not behind its base, and binding to the tip made a waiver go STALE the instant the base ref
+advanced, which is what made this mechanism a dead letter under fleet load. The authorizer's judgment under (d) was about ONE review and
 its token accounting, so the waiver may not outlive it — a push, a different base or a
 re-run each need a fresh one. A marker missing any field is MALFORMED, never granted.
 
@@ -458,7 +470,10 @@ a worktree; the gate's hermetic check uses a stub reviewer.
        - head-sha == the worktree branch HEAD (git rev-parse HEAD);
        - sha-assert: PASS;
        - reviewed-sha ENDS IN that same head-sha, and its base endpoint (before '..')
-         == git rev-parse <base> — i.e. the reviewed range IS <base>...HEAD;
+         == git merge-base <base> HEAD — i.e. the reviewed range IS <base>...HEAD.
+         NOT git rev-parse <base>: the tip and the merge-base are the same commit only
+         while the branch is not behind <base> (#3392). assert-base: names the sha the
+         assert used, and the <base> tip beside it, so the two are never confused;
        - reviewed-sha is NOT the base ref alone, and its head endpoint is NOT the base
          sha: either means the review never reached the worktree's own commits, which
          is the root-checkout resolution this probe exists to rule out;
@@ -684,6 +699,16 @@ emit_summary() {
   emit_kv 'base' "$BASE"
   emit_kv 'head-sha' "${HEAD_SHA:--}"
   emit_kv 'reviewed-sha' "$REVIEWED_SHA"
+  # ===== WHICH BASE THE RANGE ASSERT COMPARED AGAINST (#3392) =====
+  # INFORMATIONAL, exactly like `census:`/`tokens:`/`waiver:` — it is NOT in the verdict-grammar
+  # scan and NOT in the affirmation loop (both enumerate the verdict-carrying keys by name), so it
+  # can never make anything pass or fail on its own; `sha-assert:` alone carries that verdict.
+  # It exists because the two candidate bases are INDISTINGUISHABLE in a pasted block otherwise:
+  # a reader comparing `reviewed-sha`'s base endpoint against `base:` has no way to tell a
+  # merge-base from the ref tip, which is exactly the confusion that let the tip-vs-merge-base
+  # defect survive two misdiagnoses. Both shas are printed, always, so their (in)equality is
+  # visible rather than inferred. Placed beside `head-sha:`/`reviewed-sha:`, the other endpoints.
+  emit_kv 'assert-base' "${RANGE_BASE_SHA:--} (merge-base of $BASE and HEAD; $BASE tip ${BASE_TIP_SHA:--})"
   emit_kv 'job' "$JOB"
   emit_kv 'model' "$MODEL_LINE"
   emit_kv 'census' "$CENSUS"
@@ -1078,19 +1103,33 @@ TOK_OUT=$(fact output_tokens)
 # reviewed at all: when the record is unavailable this assert FAILS rather than
 # falling back to a check that verifies nothing. (A single-sha `git_ref` is still
 # accepted, for a roborev build that reports one.)
+#
+# ===== THE EXPECTED RANGE BASE IS `RANGE_BASE_SHA`, THE MERGE-BASE (#3392) =====
+# `<base>...HEAD` is `merge-base(<base>, HEAD)..HEAD`, which is the range the census
+# measures and the range roborev reviews. Comparing the record's base endpoint against
+# the base REF'S TIP instead — as this did — made a CORRECT review FAIL deterministically
+# for every branch whose base had advanced since the branch point, i.e. for almost every
+# branch that had not just been rebased. It was misdiagnosed as a race twice; the
+# controlled measurement (base ref recorded before AND after the review, unmoved, assert
+# failed anyway) is what killed that hypothesis. So the comparison is now like-for-like.
+#
+# `BASE_TIP_SHA` DOES NOT DISAPPEAR, and that is AC2: the single-sha branch below needs
+# the TIP, because the T1 trap it detects is a `--branch` review resolved against the
+# ROOT checkout, which enqueues the base ref's TIP. Each variable is used where its own
+# meaning is the subject, and neither is a stand-in for the other.
 if [ "$announce_ok" -eq 1 ]; then
   case "$JOB_GIT_REF" in
     *..*)
       range_base="${JOB_GIT_REF%%..*}"
       range_head="${JOB_GIT_REF##*..}"
       REVIEWED_SHA="$JOB_GIT_REF"
-      if [ "$range_head" = "$HEAD_SHA" ] && [ "$range_base" = "$BASE_SHA" ]; then
+      if [ "$range_head" = "$HEAD_SHA" ] && [ "$range_base" = "$RANGE_BASE_SHA" ]; then
         SHA_ASSERT="PASS"
       else
         SHA_ASSERT="FAIL (reviewed range does not match ${BASE}...HEAD)"
-        DETAILS+=("ERROR: sha-assert: the reviewed range '$JOB_GIT_REF' does not match the census range: expected base '$BASE_SHA' ($BASE) and head '$HEAD_SHA' (job $JOB).")
-        if [ "$range_base" != "$BASE_SHA" ]; then
-          DETAILS+=("ERROR: sha-assert: the range BASE is '$range_base', not '$BASE_SHA'. An empty-tree base (4b825dc6...) is the signature of the non-sanctioned two-positional commit-range form.")
+        DETAILS+=("ERROR: sha-assert: the reviewed range '$JOB_GIT_REF' does not match the census range: expected base '$RANGE_BASE_SHA' (the merge-base of $BASE and HEAD, which is what '${BASE}...HEAD' diffs from) and head '$HEAD_SHA' (job $JOB).")
+        if [ "$range_base" != "$RANGE_BASE_SHA" ]; then
+          DETAILS+=("ERROR: sha-assert: the range BASE is '$range_base', not '$RANGE_BASE_SHA'. An empty-tree base (4b825dc6...) is the signature of the non-sanctioned two-positional commit-range form. A base equal to the TIP of '$BASE' ($BASE_TIP_SHA) instead of its merge-base with HEAD would mean the review scope was anchored at the ref tip, which is NOT the branch diff — the reviewed range must be merge-base..HEAD.")
         fi
         if [ "$range_head" != "$HEAD_SHA" ]; then
           DETAILS+=("ERROR: sha-assert: the range HEAD is '$range_head', not branch HEAD '$HEAD_SHA' — the reviewed scope stops short of the branch tip.")
@@ -1111,10 +1150,24 @@ if [ "$announce_ok" -eq 1 ]; then
       else
         SHA_ASSERT="FAIL (reviewed-sha does not match head-sha)"
         DETAILS+=("ERROR: sha-assert: the job record's git_ref '$JOB_GIT_REF' does not equal branch HEAD '$HEAD_SHA' (job $JOB).")
-        if [ "$JOB_GIT_REF" = "$BASE_SHA" ]; then
-          DETAILS+=("ERROR: sha-assert: the reviewed sha EQUALS the base ref '$BASE' ($BASE_SHA) — NO branch change was reviewed. That equality is the signature of a '--branch' review resolved against the ROOT checkout instead of this worktree.")
+        # ===== T1, AND WHY THE TIP IS STILL READ HERE (AC2, #3392) =====
+        # A `--branch` review resolved against the ROOT checkout enqueues the base ref's
+        # TIP, so THE TIP is the sha this signature is about — it is not interchangeable
+        # with the merge-base. But the merge-base is the base of the range that SHOULD have
+        # been reviewed, so an equality with EITHER is the same "no branch change was
+        # reviewed" signature and both are reported, naming WHICH one matched. On a freshly
+        # rebased branch they are the same commit and the message says so; when they differ,
+        # which one matched is the diagnostic (tip => the root-checkout resolution;
+        # merge-base => a review anchored at the branch point, still reviewing nothing).
+        # Either way this FAILs — nothing here becomes permissive.
+        if [ "$JOB_GIT_REF" = "$BASE_TIP_SHA" ] && [ "$JOB_GIT_REF" = "$RANGE_BASE_SHA" ]; then
+          DETAILS+=("ERROR: sha-assert: the reviewed sha EQUALS the base ref '$BASE' — which here is BOTH its tip and its merge-base with HEAD ($BASE_TIP_SHA; this branch is not behind '$BASE') — so NO branch change was reviewed. That equality is the signature of a '--branch' review resolved against the ROOT checkout instead of this worktree.")
+        elif [ "$JOB_GIT_REF" = "$BASE_TIP_SHA" ]; then
+          DETAILS+=("ERROR: sha-assert: the reviewed sha EQUALS the TIP of the base ref '$BASE' ($BASE_TIP_SHA) — NO branch change was reviewed. That equality is the signature of a '--branch' review resolved against the ROOT checkout instead of this worktree. (The base of the range that SHOULD have been reviewed is the merge-base, $RANGE_BASE_SHA.)")
+        elif [ "$JOB_GIT_REF" = "$RANGE_BASE_SHA" ]; then
+          DETAILS+=("ERROR: sha-assert: the reviewed sha EQUALS the MERGE-BASE of '$BASE' and HEAD ($RANGE_BASE_SHA) — the branch point itself, so NO branch change was reviewed: every commit under review is a DESCENDANT of it. (The tip of '$BASE' is $BASE_TIP_SHA.)")
         else
-          DETAILS+=("ERROR: sha-assert: the reviewed sha matches NEITHER endpoint (head '$HEAD_SHA', base '$BASE' $BASE_SHA).")
+          DETAILS+=("ERROR: sha-assert: the reviewed sha matches NEITHER endpoint (head '$HEAD_SHA', range base '$RANGE_BASE_SHA' — the merge-base of '$BASE' and HEAD, whose tip is $BASE_TIP_SHA).")
         fi
       fi
       ;;
@@ -1271,7 +1324,7 @@ if [ "$failed" -eq 0 ]; then
       # time a key is added, and the provenance test is the property that actually matters.
       WAIVED)
         if [ -n "${ROBOREV_WAIVER_AUTHOR:-}" ] && [ -n "${ROBOREV_WAIVER_REASON:-}" ] \
-          && [ "${ROBOREV_WAIVER_SCOPE:-}" = "base=${BASE_SHA:-} head=${HEAD_SHA:-} job=${JOB:-}" ] \
+          && [ "${ROBOREV_WAIVER_SCOPE:-}" = "base=${RANGE_BASE_SHA:-} head=${HEAD_SHA:-} job=${JOB:-}" ] \
           && [ "${ROBOREV_WAIVER_STATE:-}" = "granted" ]; then continue; fi
         ;;
     esac

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -373,7 +373,8 @@ re-run inherit a waiver written for a different review, which is the hole the jo
 binding closes.
 
 A recheck INHERITS NOTHING from the original run. sha-assert re-compares the record's
-git_ref against this base and head; the record's own review text becomes the
+git_ref against this base and head — 'this base' being the MERGE-BASE of --base and HEAD,
+the base of the range under review, which the block names under assert-base: (#3392); the record's own review text becomes the
 transcript, so review-completed, both vacuity tiers and findings are re-asserted from
 it (a record with no review text leaves the transcript empty, which fails closed);
 roborev-exit reports SKIP rather than claiming an exit status for a process that did
@@ -483,7 +484,7 @@ a worktree; the gate's hermetic check uses a stub reviewer.
      RESULT is PASS (exit 0) only when the review is also finding-free; a review with
      open findings correctly reports FINDINGS and exits 1 — that is not a probe
      failure, and the scope assertions above are what the probe is for.
-  4. Record the observed head-sha/reviewed-sha/job/census/tokens in the PR body,
+  4. Record the observed head-sha/reviewed-sha/assert-base/job/census/tokens in the PR body,
      and re-run the probe after any roborev version bump.
 EOF
 }

--- a/scripts/flow/roborev-review.sh
+++ b/scripts/flow/roborev-review.sh
@@ -387,7 +387,7 @@ and may never apply it to its own PR.
 
 IT IS BOUND TO THE WHOLE REVIEW SCOPE, not just the head: base AND head AND job are all
 required and all verified. The base= field is the base OF THE REVIEWED RANGE — the
-merge-base of --base and HEAD, which the block prints under the assert-base: key — and NOT
+merge-base of the --base ref and HEAD, which the block prints under the assert-base: key — and NOT
 the tip of the base ref (#3392). Copy it from the assert-base: line of the failing block,
 never from the base: line; the two name the same commit only while the branch is not behind
 its base, and binding to the tip made a waiver go STALE the instant the base ref advanced,

--- a/scripts/tests/test_roborev_guard_portability.sh
+++ b/scripts/tests/test_roborev_guard_portability.sh
@@ -1493,14 +1493,21 @@ else
     bad 'AC3: the four case (f) contract probes (sanctioned / relative / root-checkout / no --repo) were NOT RUN, because this file’s own fixture setup FAILED — losing all four contract probes is a counted FAILURE, not a skip'
   else
     _tail='--agent codex --model gpt-5.6-sol --wait'
+    # A SYNTHETIC 40-hex base (#3392). The wrapper now enqueues the RESOLVED merge-base sha, and the
+    # extracted block therefore matches the base by SHAPE (`--base <40-hex> --repo`). This fixture has
+    # no `origin/main` to compute a real merge-base from — its subject is the `--repo`
+    # canonicalisation — so a shape-conformant literal is what keeps these four probes measuring THAT
+    # contract. A symbolic base here would be rejected by the shape match and all four probes would
+    # report the wrong thing about `--repo`.
+    _cf_base=0123456789abcdef0123456789abcdef01234567
     probe_case_f sanctioned 'the sanctioned canonical --repo record' accept \
-      "review --branch --base origin/main --repo $_canon $_tail"
+      "review --branch --base $_cf_base --repo $_canon $_tail"
     probe_case_f relative 'a RELATIVE --repo' reject \
-      "review --branch --base origin/main --repo . $_tail"
+      "review --branch --base $_cf_base --repo . $_tail"
     probe_case_f rootco 'a ROOT-CHECKOUT --repo' reject \
-      "review --branch --base origin/main --repo $REPO_ROOT $_tail"
+      "review --branch --base $_cf_base --repo $REPO_ROOT $_tail"
     probe_case_f norepo 'a --branch review with NO --repo at all' reject \
-      "review --branch --base origin/main $_tail"
+      "review --branch --base $_cf_base $_tail"
   fi
 fi
 

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -3205,6 +3205,14 @@ assert_says 'case (mb1) reviewed-sha is the merge-base-anchored range' "^reviewe
 assert_says 'case (mb1) assert-base names the MERGE-BASE, with the tip beside it' \
   "^assert-base: $mb_base \(merge-base of origin/main and HEAD; origin/main tip $mb_tip\)\$"
 assert_lacks 'case (mb1) the TIP is not what the assert compared against' "^assert-base: $mb_tip "
+# Key POSITION is part of the block contract (see case (j2)): `assert-base:` sits with the other
+# endpoints, between `reviewed-sha:` and `job:`, where a reader compares them.
+_mb1_key_order=$(summary_key_order "$OUT" 'head-sha|reviewed-sha|assert-base|job')
+if [ "$_mb1_key_order" = "head-sha,reviewed-sha,assert-base,job" ]; then
+  ok 'case (mb1): assert-base is positioned between reviewed-sha and job'
+else
+  bad "case (mb1): unexpected key order: $_mb1_key_order"
+fi
 
 printf '== case (mb2): with the base advanced, a STALE HEAD still FAILs (negative control) ==\n'
 reset_stub

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4374,9 +4374,45 @@ CASE_N=$((CASE_N + 1))
 OUT="$tmp/out-$CASE_N.txt"
 INVOKED="$tmp/invoked-$CASE_N.txt"
 : >"$INVOKED"
-STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --help >"$OUT" 2>&1
+# ===== STDERR IS CAPTURED SEPARATELY, AND MUST BE EMPTY (#3392) =====
+# `usage()` is an UNQUOTED heredoc (`cat <<EOF`) so that $PROGNAME interpolates, which makes a
+# BACKTICK in its body COMMAND SUBSTITUTION. A markdown-style `--base` in the help text therefore
+# (a) printed `--base: command not found` on stderr and (b) SILENTLY DELETED the backticked term
+# from the rendered help. (b) is the damage: the waiver passage is the ONLY sanctioned place an
+# operator learns WHICH sha to copy into a marker — the diagnostics deliberately refuse to print
+# the marker and point here instead — so a corrupted help produces a waiver naming the wrong base,
+# which then reports STALE. This class is INVISIBLE to a source read and to a diff review; only
+# EXECUTING `--help` and looking at stderr finds it.
+# The two streams are kept apart on purpose: merged into $OUT, the error lines would have satisfied
+# nothing and failed nothing, which is exactly how this shipped.
+HELP_ERR="$tmp/help-stderr-$CASE_N.txt"
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --help >"$OUT" 2>"$HELP_ERR"
 RC=$?
 if [ "$RC" -eq 0 ]; then ok '--help exits 0'; else bad "--help exited $RC (want 0)"; fi
+if [ -s "$HELP_ERR" ]; then
+  bad "--help wrote to STDERR, so the usage heredoc is being EXECUTED, not printed — a backtick (command substitution in an unquoted heredoc) also DELETES the backticked term from the rendered text: $(tr '\n' ' ' <"$HELP_ERR")"
+else
+  ok '--help writes NOTHING to stderr — no part of the usage heredoc is executed'
+fi
+# The heredoc must stay backtick-free, which is the pre-existing convention in this body: the
+# delimiter cannot be quoted (the body interpolates $PROGNAME and friends), so there is no escaping
+# strategy to get right — only the absence of backticks.
+_help_body=$(awk '/^usage\(\) \{/ { inu = 1 } inu { print } inu && /^EOF$/ { exit }' "$WRAPPER")
+case "$_help_body" in
+  '') bad '--help: the usage heredoc could not be extracted, so its backtick-freedom was not checked' ;;
+  *'`'*) bad '--help: the usage heredoc contains a BACKTICK. The delimiter is unquoted (so $PROGNAME interpolates), which makes a backtick command substitution: it prints an error to stderr AND deletes the term from the rendered help. Use plain text — the surrounding help prose names flags and keys unquoted.' ;;
+  *) ok '--help: the usage heredoc is backtick-free, so nothing in it can be executed or silently deleted' ;;
+esac
+# THE SEMANTIC HALF, because an empty stderr is not sufficient: the terms an operator has to COPY
+# must actually be PRESENT in the rendered text. A future backtick around a different term would be
+# caught by the two asserts above, but so would a well-meaning rewrite that simply dropped them.
+for _hterm in 'base=' '--base' 'assert-base:'; do
+  if grep -qF -- "$_hterm" "$OUT"; then
+    ok "--help renders the term an operator must copy: $_hterm"
+  else
+    bad "--help does not render '$_hterm' — the waiver passage cannot tell a human which sha to name, and this is what a swallowed backtick looks like"
+  fi
+done
 assert_says '--help states the exit-code contract' '0=PASS, 1=FAIL, 3=NOTHING-TO-REVIEW'
 assert_says '--help names the sanctioned range invocation' 'Sanctioned invocation'
 assert_says '--help marks --branch-without-repo non-sanctioned' "WITHOUT an explicit --repo"

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -747,6 +747,17 @@ make_fixture() { # make_fixture <name> <mode> -> prints work dir
       git_q "$work" add -A
       git_q "$work" commit -q -m 'a file named "foo b/x" beside one named "foo"'
       ;;
+    advanced-base)
+      # TWO branch commits, so `HEAD~1` is a real intermediate commit and the negative control
+      # (a reviewed range that stops short of the branch tip) is a realistic scope rather than a
+      # degenerate empty range. The base ref is advanced AFTER the push, below.
+      printf 'fn helper() {}\n' >>"$work/main.rs"
+      git_q "$work" add main.rs
+      git_q "$work" commit -q -m 'branch commit 1'
+      printf 'fn helper_two() {}\n' >>"$work/main.rs"
+      git_q "$work" add main.rs
+      git_q "$work" commit -q -m 'branch commit 2'
+      ;;
     newline-name)
       # A path with a LITERAL NEWLINE, beside a path equal to its FIRST LINE. That pairing
       # is the whole point: a newline-delimited prompt path set + `grep -Fxq` turns the
@@ -797,6 +808,21 @@ make_fixture() { # make_fixture <name> <mode> -> prints work dir
     no-base)
       git_q "$work" update-ref -d refs/remotes/origin/main
       ;;
+    advanced-base)
+      # ===== THE #3392 FIXTURE: `origin/main` MOVES AHEAD OF THE BRANCH POINT =====
+      # The BRANCH HEAD is left untouched; only the base ref advances, which is the normal state
+      # of every branch older than the last merge to main. After this,
+      #   merge-base(origin/main, HEAD)  !=  rev-parse origin/main
+      # so a `sha-assert` that expects the base ref's TIP fails on a review that is entirely
+      # CORRECT — the deterministic abort this fixture exists to reproduce. The push updates
+      # `refs/remotes/origin/main`, so the mirror ref the wrapper reads really is ahead.
+      git_q "$work" checkout -q main
+      printf 'fn landed_on_main_after_the_branch_point() {}\n' >>"$work/README.md"
+      git_q "$work" add README.md
+      git_q "$work" commit -q -m 'a commit that lands on main after the branch point'
+      git_q "$work" push -q "$remote" main
+      git_q "$work" checkout -q feature
+      ;;
     detached)
       git_q "$work" checkout -q --detach HEAD
       ;;
@@ -845,8 +871,29 @@ assert_tracked_mode() { # assert_tracked_mode <label> <work> <ref> <path> <want-
   fi
 }
 
-# range_ref <work>: the git_ref shape a RANGE review records, "<base40>..<head40>".
-range_ref() { printf '%s..%s' "$(git -C "$1" rev-parse "${2:-origin/main}")" "$(git -C "$1" rev-parse HEAD)"; }
+# range_ref <work> [base-ref]: the git_ref shape a RANGE review records, "<base40>..<head40>".
+# THE BASE ENDPOINT IS THE MERGE-BASE, not `rev-parse <base-ref>` (#3392): roborev reviews
+# `<base>...HEAD`, i.e. `merge-base(<base>, HEAD)..HEAD`, and that is what its job record carries.
+# In a fixture whose base ref has not advanced past the branch point the two are the SAME commit,
+# so the old spelling still passed — it was simply describing the wrong thing, and it would have
+# silently mis-stated the record for any fixture that DOES advance the base (see the `advanced-base`
+# fixture and the `mb*` family).
+range_ref() { printf '%s..%s' "$(git -C "$1" merge-base "${2:-origin/main}" HEAD)" "$(git -C "$1" rev-parse HEAD)"; }
+
+# assert_base_advanced <label> <work>: the FIXTURE-INTEGRITY guard for every case that exists to
+# distinguish the merge-base from the base ref's TIP. If the fixture stopped advancing the base ref
+# the two collapse to one commit and every such case would pass while testing NOTHING — the exact
+# vacuity this suite exists to prevent — so the inequality is asserted explicitly rather than assumed.
+assert_base_advanced() { # assert_base_advanced <label> <work>
+  local tip mb
+  tip=$(git -C "$2" rev-parse origin/main 2>/dev/null || printf '')
+  mb=$(git -C "$2" merge-base origin/main HEAD 2>/dev/null || printf '')
+  if [ -n "$tip" ] && [ -n "$mb" ] && [ "$tip" != "$mb" ]; then
+    ok "$1: fixture is NON-VACUOUS — the origin/main tip ($tip) and the merge-base ($mb) are different commits"
+  else
+    bad "$1: fixture is VACUOUS — origin/main tip '${tip:-<unresolved>}' and merge-base '${mb:-<unresolved>}' are not two different commits, so nothing about the distinction is under test"
+  fi
+}
 
 # The wrapper's own temp directory for fixture runs. It MUST exist: the census's mode probe uses `mktemp`
 # under $TMPDIR, and a missing directory makes that probe fail — which the census correctly reports as an
@@ -1448,7 +1495,10 @@ set -uo pipefail
 # shellcheck disable=SC1090
 . "$1"          # the real oracles file
 REPO="$2"
-BASE_SHA="$3"
+# The range's LEFT endpoint is the MERGE-BASE (`RANGE_BASE_SHA`, #3392), not the base ref's
+# tip: `roborev_range_endpoint_refs` folds over HEAD and that. In this linear fixture the two
+# would coincide anyway; the name is what the oracles actually read.
+RANGE_BASE_SHA="$3"
 for p in both-exec both-plain head-only-exec head-only-plain base-only-exec \
          base-exec-head-plain head-exec-base-plain 'glob[x]*?-exec' absent-everywhere; do
   st=0
@@ -1531,10 +1581,10 @@ cx3i_mut="$tmp/cx3i-oracles.sh"
 for _mut in head base; do
   cp "$ORACLES_SRC" "$cx3i_mut"
   if [ "$_mut" = head ]; then
-    _mut_from='HEAD "${BASE_SHA:-}"'; _mut_to='HEAD'
+    _mut_from='HEAD "${RANGE_BASE_SHA:-}"'; _mut_to='HEAD'
     _mut_lost=base-only-exec; _mut_lost2=base-exec-head-plain; _mut_kept=head-only-exec
   else
-    _mut_from='HEAD "${BASE_SHA:-}"'; _mut_to='"${BASE_SHA:-}"'
+    _mut_from='HEAD "${RANGE_BASE_SHA:-}"'; _mut_to='"${RANGE_BASE_SHA:-}"'
     _mut_lost=head-only-exec; _mut_lost2=head-exec-base-plain; _mut_kept=base-only-exec
   fi
   # Patch the ENDPOINT PRODUCER, which is the single place the range is named — a mutant that
@@ -1681,8 +1731,9 @@ if [ "$cx3j_got" = OK ]; then
 else
   bad "case (cx3j): roborev_path_exec_state's shape reads '$cx3j_got' — an endpoint can be skipped again"
 fi
-# The per-endpoint predicate must stay RANGE-BLIND: if it learns about BASE_SHA it can express
-# a precedence again, which is the ambiguity the split exists to remove.
+# The per-endpoint predicate must stay RANGE-BLIND: if it learns about RANGE_BASE_SHA (or the
+# base ref's tip, BASE_TIP_SHA) it can express a precedence again, which is the ambiguity the
+# split exists to remove.
 cx3j_pred=$(awk '
   /^_roborev_mode_exec_state_at\(\) \{/ { inf = 1 }
   inf { print }
@@ -1691,7 +1742,7 @@ cx3j_pred=$(awk '
 if [ -z "$cx3j_pred" ]; then
   bad 'case (cx3j): _roborev_mode_exec_state_at was not found, so its range-blindness was not checked'
 else
-  if ! printf '%s\n' "$cx3j_pred" | grep -vE '^[[:space:]]*#' | grep -qE 'BASE_SHA|\bHEAD\b'; then
+  if ! printf '%s\n' "$cx3j_pred" | grep -vE '^[[:space:]]*#' | grep -qE 'RANGE_BASE_SHA|BASE_TIP_SHA|\bHEAD\b'; then
     ok 'case (cx3j): the per-endpoint predicate names no endpoint (range-blind, so it cannot encode an ordering)'
   else
     bad 'case (cx3j): _roborev_mode_exec_state_at references a specific endpoint — it can encode a precedence again'
@@ -2828,13 +2879,21 @@ assert_verdict 'case (t5)' FAIL 1
 assert_says 'case (t5) push-assert names the detached HEAD' '^push-assert: FAIL \(detached HEAD\)$'
 assert_never_enqueued 'case (t5)'
 
-printf '== case (t6): a census whose git diff FAILS is not "genuinely empty" ==\n'
+printf '== case (t6): a census whose RANGE cannot be measured is not "genuinely empty" ==\n'
 reset_stub
+# THE CLASS INVARIANT, which is what this case has always been for: "we could not measure the
+# range" must never render as "there is nothing to review". Unrelated histories now abort one step
+# EARLIER than they used to — at the merge-base resolution rather than at the `git diff` (#3392),
+# because the range base is resolved before the diff that uses it — so this asserts the invariant
+# and the pre-enqueue guarantee, while case (mb7) pins the merge-base diagnostic itself. The
+# `git diff failed` arm is retained as a STRUCTURAL backstop for a diff that fails for some other
+# reason (an unreadable object store), exactly like the other unreachable-by-ordering backstops in
+# these files: the point of a backstop is not to depend on an upstream check still being there.
 work=$(make_fixture case_t6 orphan-base)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 run_wrapper "$work" --base unrelated
 assert_verdict 'case (t6)' FAIL 1
-assert_says 'case (t6) the diff failure is named' '^census-check: FAIL \(git diff failed\)$'
+assert_says 'case (t6) the census check is what FAILs' '^census-check: FAIL \('
 assert_says 'case (t6) it is explicitly not NOTHING-TO-REVIEW' 'explicitly NOT a NOTHING-TO-REVIEW'
 assert_lacks 'case (t6) never reports NOTHING-TO-REVIEW' '^RESULT: NOTHING-TO-REVIEW$'
 assert_never_enqueued 'case (t6)'
@@ -3106,6 +3165,153 @@ assert_verdict 'case (x4)' FAIL 1
 assert_says 'case (x4) the single-commit record is refused' '^sha-assert: FAIL \(single-commit record, not the census range\)$'
 assert_says 'case (x4) explains the same-file blind spot' 'when several commits touch the same file'
 
+# =============================================================================================
+# (mb*) THE RANGE BASE IS THE MERGE-BASE, NEVER THE BASE REF'S TIP (issue #3392)
+# =============================================================================================
+# THE DEFECT THESE PIN. The census measures `<base>...HEAD`, which is
+# `merge-base(<base>, HEAD)..HEAD`, and roborev reviews the same range, so its job record's
+# `git_ref` carries the MERGE-BASE as the range base. `sha-assert` compared that against
+# `rev-parse <base>` — the base ref's TIP — so it FAILED DETERMINISTICALLY for every branch
+# whose base had advanced since the branch point, i.e. for almost every branch not just rebased.
+# It was misdiagnosed as a race twice; the controlled measurement (the base ref recorded before
+# AND after a failing review, unmoved) is what killed that hypothesis.
+#
+# WHY EVERY CASE HERE CALLS `assert_base_advanced` FIRST. Under the OLD code these cases would
+# pass just as well in a fixture where the tip and the merge-base coincide — the distinction
+# would be untested and the family would be decoration. The inequality is therefore MEASURED
+# per case, not assumed from the fixture's name.
+#
+# AND WHY THE FAMILY IS SIX CASES, NOT ONE. A guard tested only in its passing direction is how
+# a vacuous green ships: (mb1) is the headline PASS, and (mb2)-(mb6) are the discriminations —
+# a stale head, the T2 empty-tree base, the T1 tip equality, a branch-point equality, and the
+# tip-anchored RANGE the old assert used to demand — every one of which must still FAIL.
+printf '== case (mb1): a CORRECT review of a branch whose base has advanced PASSes ==\n'
+reset_stub
+work=$(make_fixture case_mb1 advanced-base)
+assert_base_advanced 'case (mb1)' "$work"
+mb_tip=$(git -C "$work" rev-parse origin/main)
+mb_base=$(git -C "$work" merge-base origin/main HEAD)
+mb_head=$(git -C "$work" rev-parse HEAD)
+# The record roborev really writes for this branch: the MERGE-BASE, then branch HEAD. The
+# announcement names only the range base, which for a range review is that same merge-base.
+STUB_ANNOUNCE_SHA="$mb_base"
+STUB_GIT_REF="$mb_base..$mb_head"
+run_wrapper "$work"
+assert_verdict 'case (mb1)' PASS 0
+assert_says 'case (mb1) sha-assert PASSes on a correct review of a branch that is behind' '^sha-assert: PASS$'
+assert_says 'case (mb1) reviewed-sha is the merge-base-anchored range' "^reviewed-sha: $mb_base\.\.$mb_head\$"
+# AC3: the block STATES which base the assert compared against, and prints the tip beside it, so a
+# reader of a pasted block can tell the two apart instead of inferring which one `base:` meant.
+assert_says 'case (mb1) assert-base names the MERGE-BASE, with the tip beside it' \
+  "^assert-base: $mb_base \(merge-base of origin/main and HEAD; origin/main tip $mb_tip\)\$"
+assert_lacks 'case (mb1) the TIP is not what the assert compared against' "^assert-base: $mb_tip "
+
+printf '== case (mb2): with the base advanced, a STALE HEAD still FAILs (negative control) ==\n'
+reset_stub
+# THE CONTROL FOR (mb1): same fixture, same advanced base, the ONLY difference being a reviewed
+# range that stops one commit short of the branch tip. If (mb1) passed because the assert stopped
+# checking, this would pass too. It must not.
+work=$(make_fixture case_mb2 advanced-base)
+assert_base_advanced 'case (mb2)' "$work"
+mb_base=$(git -C "$work" merge-base origin/main HEAD)
+mb_head=$(git -C "$work" rev-parse HEAD)
+mb_stale=$(git -C "$work" rev-parse 'HEAD^')
+STUB_ANNOUNCE_SHA="$mb_base"
+STUB_GIT_REF="$mb_base..$mb_stale"
+run_wrapper "$work"
+assert_verdict 'case (mb2)' FAIL 1
+assert_says 'case (mb2) sha-assert still FAILs on a short range' '^sha-assert: FAIL \(reviewed range does not match origin/main\.\.\.HEAD\)$'
+assert_says 'case (mb2) the short HEAD endpoint is named' "the range HEAD is '$mb_stale', not branch HEAD '$mb_head'"
+assert_says 'case (mb2) it says the scope stopped short' 'the reviewed scope stops short of the branch tip'
+
+printf '== case (mb3): with the base advanced, an EMPTY-TREE base still FAILs (T2 pin) ==\n'
+reset_stub
+# T2 is a property of the range base VALUE, so advancing the base ref must not disturb it.
+work=$(make_fixture case_mb3 advanced-base)
+assert_base_advanced 'case (mb3)' "$work"
+mb_base=$(git -C "$work" merge-base origin/main HEAD)
+mb_head=$(git -C "$work" rev-parse HEAD)
+STUB_ANNOUNCE_SHA="$mb_base"
+STUB_GIT_REF="4b825dc642cb6eb9a060e54bf8d69288fbee4904..$mb_head"
+run_wrapper "$work"
+assert_verdict 'case (mb3)' FAIL 1
+assert_says 'case (mb3) the wrong range BASE is named' 'the range BASE is .4b825dc642cb6eb9a060e54bf8d69288fbee4904.'
+assert_says 'case (mb3) the empty-tree signature survives the change' 'empty-tree base \(4b825dc6\.\.\.\) is the signature of the non-sanctioned two-positional'
+assert_says 'case (mb3) the expected base is the merge-base' "not '$mb_base'"
+
+printf '== case (mb4): a single-sha record equal to the TIP still FAILs (T1 pin) ==\n'
+reset_stub
+# AC2, AND THE REASON THE TIP IS STILL READ AT ALL. A `--branch` review resolved against the ROOT
+# checkout enqueues the base ref's TIP — so the tip, not the merge-base, is the sha this signature
+# is about. With the base advanced the two are DIFFERENT commits, which is precisely the fixture in
+# which a merge-base-only implementation would lose the T1 diagnostic.
+work=$(make_fixture case_mb4 advanced-base)
+assert_base_advanced 'case (mb4)' "$work"
+mb_tip=$(git -C "$work" rev-parse origin/main)
+mb_base=$(git -C "$work" merge-base origin/main HEAD)
+STUB_ANNOUNCE_SHA="$mb_tip"
+STUB_GIT_REF="$mb_tip"
+run_wrapper "$work"
+assert_verdict 'case (mb4)' FAIL 1
+assert_says 'case (mb4) sha-assert FAILs' '^sha-assert: FAIL \(reviewed-sha does not match head-sha\)$'
+assert_says 'case (mb4) the TIP equality is named as such' "the reviewed sha EQUALS the TIP of the base ref 'origin/main' \($mb_tip\)"
+assert_says 'case (mb4) the root-checkout resolution is still called out' "signature of a '--branch' review resolved against the ROOT checkout"
+assert_says 'case (mb4) it also names the base the range SHOULD have had' "the merge-base, $mb_base"
+
+printf '== case (mb5): a single-sha record equal to the MERGE-BASE also FAILs ==\n'
+reset_stub
+# The other base-equality: a review anchored at the branch point itself reviewed nothing either,
+# because every commit under review is a DESCENDANT of it. Both equalities FAIL; the diagnostic
+# says WHICH one matched, so an operator can tell a root-checkout resolution from a branch-point one.
+work=$(make_fixture case_mb5 advanced-base)
+assert_base_advanced 'case (mb5)' "$work"
+mb_tip=$(git -C "$work" rev-parse origin/main)
+mb_base=$(git -C "$work" merge-base origin/main HEAD)
+STUB_ANNOUNCE_SHA="$mb_base"
+STUB_GIT_REF="$mb_base"
+run_wrapper "$work"
+assert_verdict 'case (mb5)' FAIL 1
+assert_says 'case (mb5) sha-assert FAILs' '^sha-assert: FAIL \(reviewed-sha does not match head-sha\)$'
+assert_says 'case (mb5) the merge-base equality is named' "the reviewed sha EQUALS the MERGE-BASE of 'origin/main' and HEAD \($mb_base\)"
+assert_says 'case (mb5) it explains why that reviewed nothing' 'the branch point itself, so NO branch change was reviewed'
+assert_says 'case (mb5) the tip is reported beside it' "The tip of 'origin/main' is $mb_tip"
+
+printf '== case (mb6): a RANGE anchored at the base ref TIP FAILs (the old expectation) ==\n'
+reset_stub
+# THE DIRECTION THAT PROVES THE FIX IS NOT A LOOSENING. `<tip>..HEAD` is exactly the range the
+# OLD assert demanded, and it is NOT the branch diff — it subtracts commits that only main has.
+# So the shape the old code required must now FAIL, or "compare against the merge-base" would
+# just mean "accept either".
+work=$(make_fixture case_mb6 advanced-base)
+assert_base_advanced 'case (mb6)' "$work"
+mb_tip=$(git -C "$work" rev-parse origin/main)
+mb_base=$(git -C "$work" merge-base origin/main HEAD)
+mb_head=$(git -C "$work" rev-parse HEAD)
+STUB_ANNOUNCE_SHA="$mb_tip"
+STUB_GIT_REF="$mb_tip..$mb_head"
+run_wrapper "$work"
+assert_verdict 'case (mb6)' FAIL 1
+assert_says 'case (mb6) a tip-anchored range is refused' '^sha-assert: FAIL \(reviewed range does not match origin/main\.\.\.HEAD\)$'
+assert_says 'case (mb6) the expected base is the merge-base' "the range BASE is '$mb_tip', not '$mb_base'"
+assert_says 'case (mb6) the tip-anchor is diagnosed by name' "A base equal to the TIP of 'origin/main' \($mb_tip\)"
+
+printf '== case (mb7): an UNRESOLVABLE merge-base FAILs CLOSED, pre-enqueue ==\n'
+reset_stub
+# AFFIRMATIVE MEASUREMENT. With no common ancestor the base OF THE RANGE is unknown, and an
+# unknown base must never degrade to the tip (the tip is the defect) or to an empty string (which
+# would make the assert compare against nothing). It is a census FAIL, before any review is
+# enqueued, so it costs no review tokens.
+work=$(make_fixture case_mb7 orphan-base)
+STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
+run_wrapper "$work" --base unrelated
+assert_verdict 'case (mb7)' FAIL 1
+assert_says 'case (mb7) the unresolvable merge-base is named' "^census-check: FAIL \(no merge-base between 'unrelated' and HEAD\)\$"
+assert_says 'case (mb7) it is explicitly not NOTHING-TO-REVIEW' 'explicitly NOT a NOTHING-TO-REVIEW'
+assert_says 'case (mb7) it refuses to degrade to the tip' 'deliberately NOT degraded to the tip'
+assert_lacks 'case (mb7) never reports NOTHING-TO-REVIEW' '^RESULT: NOTHING-TO-REVIEW$'
+assert_never_enqueued 'case (mb7)'
+
+
 printf '== case (x5): a MENTIONED path without a diff header does NOT count as covered ==\n'
 reset_stub
 # The substring form of this check was satisfied by any incidental mention — including
@@ -3355,7 +3561,10 @@ done
 # waiver unable to touch any other verdict.
 w_work=$(make_fixture case_w two-code-commits)
 w_head=$(git -C "$w_work" rev-parse HEAD)
-w_base=$(git -C "$w_work" rev-parse origin/main)
+# THE MERGE-BASE, because that is the base of the reviewed range and therefore the base the waiver
+# scope is bound to (#3392). This fixture's base ref has not advanced, so it is the same commit as
+# the tip here — case (mb8) is the one that separates them.
+w_base=$(git -C "$w_work" merge-base origin/main HEAD)
 
 printf '== (wv1) a prompt naming a snapshot path is NOT special: an absent census path FAILs ==\n'
 # The shape that used to produce an exempted NOTICE. There is no snapshot mode any more, so this is
@@ -3375,7 +3584,7 @@ assert_says 'case (wv1) the diagnostic points at --help instead of printing a ma
   'THE EXACT MARKER FORM IS DELIBERATELY NOT PRINTED HERE'
 assert_lacks 'case (wv1) and no part of the marker appears anywhere in the output' 'roborev-waive'
 assert_says 'case (wv1) it names the review scope a waiver would have to bind' \
-  "base $w_base, head $w_head, job 4656"
+  "base $w_base — the merge-base of origin/main and HEAD, which is the base of the reviewed range and NOT the tip of origin/main, head $w_head, job 4656"
 assert_says 'case (wv1) the NONE cause names the SHAPE requirement (job 29)' \
   'the marker must be the SOLE NONBLANK CONTENT of a TOP-LEVEL PR comment'
 assert_says 'case (wv1) and it names the contexts that do not count' \
@@ -4000,6 +4209,46 @@ assert_says 'case (wv33c) neither preformatted context is an authorization' \
 assert_lacks 'case (wv33c) and neither grants' '^prompt-content: WAIVED'
 reset_stub
 
+printf '== case (mb8): the absence WAIVER is bound to the MERGE-BASE, not the base ref tip ==\n'
+# THE SAME STALENESS DEFECT, IN THE WAIVER (#3392). The waiver scope is `base=<sha> head=<sha>
+# job=<id>` and it identifies THE REVIEWED RANGE, whose base is the merge-base. Bound to the base
+# ref's TIP instead, a waiver written for a failing run went spuriously STALE on `--recheck-job`
+# the moment the base ref advanced — re-deadlettering the #3312 break-glass exactly when the fleet
+# is busiest. Nothing is weakened here: base AND head AND job are all still required and verified.
+reset_stub
+mb8_work=$(make_fixture case_mb8 advanced-base)
+assert_base_advanced 'case (mb8)' "$mb8_work"
+mb8_tip=$(git -C "$mb8_work" rev-parse origin/main)
+mb8_base=$(git -C "$mb8_work" merge-base origin/main HEAD)
+mb8_head=$(git -C "$mb8_work" rev-parse HEAD)
+STUB_ANNOUNCE_SHA="$mb8_base"
+STUB_GIT_REF="$mb8_base..$mb8_head"
+STUB_PROMPT="$PROMPT_WITHOUT_PATHS"
+STUB_GH_COMMENTS="\001pmcfadin\nroborev-waive: prompt-content-absent base=$mb8_base head=$mb8_head job=4656 reason=absence checked against the token accounting\n"
+run_wrapper "$mb8_work"
+assert_says 'case (mb8) a marker naming the MERGE-BASE grants' \
+  "^waiver: GRANTED \(author=@pmcfadin base=$mb8_base head=$mb8_head job=4656 reason=absence checked against the token accounting\)\$"
+assert_says 'case (mb8) and the absence verdict is WAIVED, not PASS' '^prompt-content: WAIVED \(2/2 code census paths absent'
+reset_stub
+
+printf '== case (mb8b): a marker naming the STALE base ref TIP does NOT grant ==\n'
+# THE CONTROL. Only the `base=` field differs from (mb8) — it names the base ref's TIP, which is a
+# real commit but NOT the base of the reviewed range — so the marker names a DIFFERENT review and
+# the FAIL stands. This is what makes (mb8) a measurement of the binding rather than of the parser.
+reset_stub
+STUB_ANNOUNCE_SHA="$mb8_base"
+STUB_GIT_REF="$mb8_base..$mb8_head"
+STUB_PROMPT="$PROMPT_WITHOUT_PATHS"
+STUB_GH_COMMENTS="\001pmcfadin\nroborev-waive: prompt-content-absent base=$mb8_tip head=$mb8_head job=4656 reason=bound to the wrong base\n"
+run_wrapper "$mb8_work"
+assert_verdict 'case (mb8b)' FAIL 1
+assert_says 'case (mb8b) the tip-bound marker is STALE' \
+  "^waiver: STALE \(the marker names a different review — base \($mb8_tip != $mb8_base\)"
+assert_lacks 'case (mb8b) and it grants nothing' '^prompt-content: WAIVED'
+assert_says 'case (mb8b) the absence FAIL stands' \
+  '^prompt-content: FAIL \(2/2 code census paths absent from the prompt\)$'
+reset_stub
+
 printf '== the summary header is distinct from every agent-gate header ==\n'
 reset_stub
 work=$(make_fixture case_hdr pushed)
@@ -4235,7 +4484,7 @@ _pc_start=$(grep -nE '^roborev_check_prompt_content\(\) \{' "$CHECKS_FILE" | hea
 _pc_end=$(awk -v s="${_pc_start:-0}" 'NR>s && /^}/ {print NR; exit}' "$CHECKS_FILE")
 _pc_body=$(sed -n "${_pc_start:-1},${_pc_end:-1}p" "$CHECKS_FILE")
 _pc_exec=$(printf '%s\n' "$_pc_body" | grep -v '^[[:space:]]*#')
-if printf '%s\n' "$_pc_exec" | grep -qF 'roborev_absence_waiver_lookup "${BASE_SHA:-}" "${HEAD_SHA:-}" "${JOB:-}"' \
+if printf '%s\n' "$_pc_exec" | grep -qF 'roborev_absence_waiver_lookup "${RANGE_BASE_SHA:-}" "${HEAD_SHA:-}" "${JOB:-}"' \
   && [ "$(printf '%s\n' "$_pc_exec" | grep -cF 'roborev_absence_waiver_lookup')" -eq 1 ] \
   && printf '%s\n' "$_pc_body" | grep -qF 'PROMPT_CONTENT="WAIVED ('; then
   ok 'structural: the waiver is looked up EXACTLY ONCE, inside the absence branch, so it can excuse only that verdict (constraint (c))'
@@ -4254,7 +4503,7 @@ fi
 # rather than on which key carries it: a key-scoped exemption is the shape the ruling deleted.
 _aff_start=$(grep -nF 'for keyed in "push-assert=$PUSH_ASSERT"' "$WRAPPER" | head -1 | cut -d: -f1)
 _aff_body=$(sed -n "${_aff_start:-1},$(( ${_aff_start:-1} + 30 ))p" "$WRAPPER")
-if printf '%s\n' "$_aff_body" | grep -qF 'ROBOREV_WAIVER_SCOPE:-}" = "base=${BASE_SHA:-} head=${HEAD_SHA:-} job=${JOB:-}"' \
+if printf '%s\n' "$_aff_body" | grep -qF 'ROBOREV_WAIVER_SCOPE:-}" = "base=${RANGE_BASE_SHA:-} head=${HEAD_SHA:-} job=${JOB:-}"' \
   && printf '%s\n' "$_aff_body" | grep -qF 'ROBOREV_WAIVER_STATE:-}" = "granted"' \
   && ! printf '%s\n' "$_aff_body" | grep -qF 'det_key" = "prompt-content"'; then
   ok 'structural: WAIVED is admitted only with a complete, sha-matching provenance, and the gate is not key-scoped'
@@ -4671,7 +4920,7 @@ else
     if [ "$_aff_continues" -eq 2 ] &&
       printf '%s\n' "$_aff_body" | grep -qE '^[[:space:]]*PASS\) continue ;;' &&
       printf '%s\n' "$_aff_body" | grep -qF '"${ROBOREV_WAIVER_STATE:-}" = "granted"' &&
-      printf '%s\n' "$_aff_body" | grep -qF '"${ROBOREV_WAIVER_SCOPE:-}" = "base=${BASE_SHA:-} head=${HEAD_SHA:-} job=${JOB:-}"' &&
+      printf '%s\n' "$_aff_body" | grep -qF '"${ROBOREV_WAIVER_SCOPE:-}" = "base=${RANGE_BASE_SHA:-} head=${HEAD_SHA:-} job=${JOB:-}"' &&
       ! printf '%s\n' "$_aff_body" | grep -qF 'det_key" = "prompt-content"'; then
       ok 'structural: the affirmation backstop has the affirmative PASS arm plus exactly the WAIVED admission, gated on the complete scope-matching provenance (base+head+job) and not on the key'
     else

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -275,6 +275,17 @@ record_read_blank() {
 case "$cmd" in
   review)
     printf 'review %s\n' "$*" >>"$STUB_INVOKED"
+    # STUB_ON_REVIEW: a command run AT ENQUEUE TIME, so a case can mutate the fixture DURING the
+    # review — the only way to express a mid-run base-ref move hermetically (#3392). It FAILS LOUDLY
+    # (exit 97, distinct from every verdict path) rather than being swallowed: a hook that silently
+    # did nothing would leave its case asserting a race it never created, which is a probe failing
+    # toward success.
+    if [ -n "${STUB_ON_REVIEW:-}" ]; then
+      sh -c "$STUB_ON_REVIEW" >/dev/null 2>&1 || {
+        printf 'STUB_ON_REVIEW failed: %s\n' "$STUB_ON_REVIEW" >&2
+        exit 97
+      }
+    fi
     if [ -n "${STUB_ANNOUNCE_SHA:-}" ]; then
       printf 'Enqueued job %s for %s\n' "${STUB_JOB:-4600}" "$STUB_ANNOUNCE_SHA"
     fi
@@ -1067,6 +1078,7 @@ export STUB_GH_COMMENTS=''
 export STUB_GH_COMMENTS_JSON=''
 export STUB_GH_COMMENTS_FILE=''
 export STUB_GH_RC=0
+export STUB_ON_REVIEW=''
 reset_stub() {
   STUB_JOB=4656
   STUB_VERDICT=$'No issues found.\nSummary: reviewed the diff; no issues found.'
@@ -1090,6 +1102,7 @@ reset_stub() {
   STUB_GH_COMMENTS_JSON=''
   STUB_GH_COMMENTS_FILE=''
   STUB_GH_RC=0
+  STUB_ON_REVIEW=''
 }
 
 printf '== case (a): enqueued sha == base ref ==\n'
@@ -2627,7 +2640,7 @@ assert_verdict 'case (f)' PASS 0
 for line in 'push-assert: PASS' 'census-check: PASS' 'sha-assert: PASS' 'vacuity-tier1: PASS' 'vacuity-tier2: PASS'; do
   assert_says "case (f) $line" "^$line\$"
 done
-assert_says 'case (f) reviewed-sha reports the RANGE' "^reviewed-sha: $(git -C "$work" rev-parse origin/main)\.\.$head_sha\$"
+assert_says 'case (f) reviewed-sha reports the RANGE' "^reviewed-sha: $(git -C "$work" merge-base origin/main HEAD)\.\.$head_sha\$"
 assert_says 'case (f) job printed' '^job: 4656$'
 assert_says 'case (f) log path named' '^log: .+transcript-'
 assert_one_block 'case (f)'
@@ -2647,8 +2660,18 @@ assert_one_block 'case (f)'
 work_canon=$(cd "$(git -C "$work" rev-parse --show-toplevel)" && pwd -P)
 # The sanctioned invocation form: explicit HEAD sha, explicit ABSOLUTE --repo,
 # --wait, both --agent and --model — and never --branch, never two positionals.
-if grep -qF -- "review --branch --base origin/main --repo $work_canon --agent codex --model gpt-5.6-sol --wait" "$INVOKED"; then
-  ok 'case (f): invoked over the census RANGE with an explicit absolute --repo + --wait'
+# THE BASE IS MATCHED BY SHAPE HERE, AND BY VALUE JUST BELOW (#3392). The enqueue now pins the
+# RESOLVED 40-hex merge-base rather than the symbolic ref, so the census, the enqueue, the assert and
+# the waiver scope all name ONE immutable range. This block is EXTRACTED and mutation-tested by the
+# portability suite against a fixture that has no `origin/main` at all, so it cannot compute the
+# value — it asserts the SHAPE (`--base <40-hex>` immediately followed by `--repo`), which is what
+# makes a symbolic ref, an empty base and a dropped `--repo` all fail here. The VALUE assert (that the
+# sha is THIS fixture's merge-base) is the next assert down, outside the extracted region, where the
+# fixture can compute it. Exactly TWO assert sites live in this block: the portability probes require
+# dp==2 / df==2, so adding a third here would break their arithmetic.
+if grep -qE -- '^review --branch --base [0-9a-f]{40} --repo ' "$INVOKED" \
+  && grep -qF -- "--repo $work_canon --agent codex --model gpt-5.6-sol --wait" "$INVOKED"; then
+  ok 'case (f): invoked over the census RANGE with a 40-hex pinned base and an explicit absolute --repo + --wait'
 else
   bad "case (f): unexpected invocation form: $(cat "$INVOKED")"
 fi
@@ -2661,6 +2684,20 @@ else
   bad "case (f): --branch/--repo pairing missing: $(cat "$INVOKED")"
 fi
 # <<< END case-f-invocation-asserts (#3296)
+# THE VALUE PIN for the base the wrapper enqueued (#3392): it must be the MERGE-BASE of the base ref
+# and HEAD — the base of the range the census measured — and NOT the symbolic ref, whose re-resolution
+# by roborev is what let the enqueued range drift from the measured one between the two steps.
+_cf_pinned_base=$(git -C "$work" merge-base origin/main HEAD)
+if grep -qF -- "--base $_cf_pinned_base " "$INVOKED"; then
+  ok 'case (f): the enqueued base is the RESOLVED merge-base sha, so census/enqueue/assert name one immutable range'
+else
+  bad "case (f): the enqueued base is not the resolved merge-base '$_cf_pinned_base': $(cat "$INVOKED")"
+fi
+if grep -qF -- '--base origin/main' "$INVOKED"; then
+  bad 'case (f): the SYMBOLIC base ref reached the enqueue — roborev would re-resolve it, so the reviewed range could differ from the measured one'
+else
+  ok 'case (f): no symbolic base ref reaches the enqueue'
+fi
 if grep -qE -- 'review [0-9a-f]{7,40} [0-9a-f]{7,40}' "$INVOKED"; then
   bad 'case (f): the two-positional commit-range form was used'
 else
@@ -4216,6 +4253,63 @@ assert_says 'case (wv33c) neither preformatted context is an authorization' \
   '^waiver: NONE \(no waiver comment for this review: the marker must be the SOLE NONBLANK CONTENT'
 assert_lacks 'case (wv33c) and neither grants' '^prompt-content: WAIVED'
 reset_stub
+
+printf '== case (mb9): the ENQUEUED range is IMMUTABLE against a mid-review base-ref move ==\n'
+# THE RESIDUAL SECOND-ORDER RACE, CLOSED BY CONSTRUCTION (roborev round 1, Medium). The wrapper used
+# to pass the SYMBOLIC base ref to `roborev review --base`, so roborev re-resolved the mirror ref
+# ITSELF and computed its own merge-base. A ref move between the census and the enqueue therefore
+# reviewed a DIFFERENT range than the census measured, and the only thing that noticed was
+# `sha-assert` — AFTER a full-price review had been spent. Passing the RESOLVED sha makes the
+# divergence unexpressible instead of merely detectable.
+#
+# WHAT THIS CASE CAN AND CANNOT MEASURE, stated rather than implied. The stub reviewer cannot
+# re-derive a range from `--base` the way the real binary does, so this case does NOT measure
+# roborev's internal resolution (that is measured against the REAL binary, recorded in the wrapper's
+# comment at the enqueue: `--base <sha>` and `--base origin/main` produced the IDENTICAL
+# merge-base-anchored `git_ref` on a repo whose main had advanced). What it DOES measure, hermetically
+# and decisively, is the property the fix rests on: the argument the wrapper hands to the enqueue, and
+# the base its assert later compares against, are BOTH the sha captured by the census and are
+# UNAFFECTED by the ref moving mid-review.
+#
+# THE MOVE IS CHOSEN TO CHANGE THE MERGE-BASE, not just the tip: it force-pushes the feature branch
+# onto main, after which `merge-base(origin/main, HEAD)` is HEAD itself. So a wrapper that passed the
+# symbolic ref would have had roborev resolve a demonstrably different range, and a wrapper that
+# re-read the base after the review would assert against a different sha. Both are asserted against.
+reset_stub
+work=$(make_fixture case_mb9 advanced-base)
+assert_base_advanced 'case (mb9)' "$work"
+mb9_base=$(git -C "$work" merge-base origin/main HEAD)
+mb9_head=$(git -C "$work" rev-parse HEAD)
+STUB_ANNOUNCE_SHA="$mb9_base"
+STUB_GIT_REF="$mb9_base..$mb9_head"
+# Force-push the branch onto the remote's main, then update the mirror ref: the census has already
+# run, so this lands strictly between the census and the assert.
+STUB_ON_REVIEW="git -C '$work' push -q -f origin feature:main && git -C '$work' fetch -q origin"
+run_wrapper "$work"
+STUB_ON_REVIEW=''
+# NON-VACUITY, in the direction that matters: the mid-review move must really have changed what
+# `origin/main` denotes AND what its merge-base with HEAD would now be. If it did not, this case
+# proves nothing about immutability.
+mb9_moved_base=$(git -C "$work" merge-base origin/main HEAD)
+if [ "$mb9_moved_base" != "$mb9_base" ]; then
+  ok "case (mb9): the mid-review move really changed the merge-base ($mb9_base -> $mb9_moved_base), so the pinning is load-bearing here"
+else
+  bad "case (mb9): the mid-review move did NOT change the merge-base (still $mb9_base) — the case cannot distinguish a pinned base from a re-resolved one"
+fi
+assert_verdict 'case (mb9)' PASS 0
+assert_says 'case (mb9) sha-assert still PASSes against the PRE-MOVE range' '^sha-assert: PASS$'
+assert_says 'case (mb9) assert-base still names the census-time merge-base' "^assert-base: $mb9_base "
+assert_lacks 'case (mb9) the post-move merge-base is not what the assert used' "^assert-base: $mb9_moved_base "
+if grep -qF -- "--base $mb9_base " "$INVOKED"; then
+  ok 'case (mb9): the enqueue carried the census-time merge-base SHA, so the ref move could not change the reviewed range'
+else
+  bad "case (mb9): the enqueue did not carry the census-time merge-base '$mb9_base': $(cat "$INVOKED")"
+fi
+if grep -qF -- '--base origin/main' "$INVOKED"; then
+  bad 'case (mb9): the SYMBOLIC base ref reached the enqueue, so roborev would have re-resolved it AFTER the move — the race is still open'
+else
+  ok 'case (mb9): no symbolic base ref reaches the enqueue'
+fi
 
 printf '== case (mb8): the absence WAIVER is bound to the MERGE-BASE, not the base ref tip ==\n'
 # THE SAME STALENESS DEFECT, IN THE WAIVER (#3392). The waiver scope is `base=<sha> head=<sha>

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4328,6 +4328,11 @@ STUB_GIT_REF="$mb8_base..$mb8_head"
 STUB_PROMPT="$PROMPT_WITHOUT_PATHS"
 STUB_GH_COMMENTS="\001pmcfadin\nroborev-waive: prompt-content-absent base=$mb8_base head=$mb8_head job=4656 reason=absence checked against the token accounting\n"
 run_wrapper "$mb8_work"
+# THE TERMINAL VERDICT, not just the two waiver lines (roborev round 1, Low). Without it a regression
+# in the waiver-ADMISSION path — the affirmation backstop refusing a `WAIVED` whose provenance it can
+# no longer match — would leave this case green while the waiver was unusable in practice: the two
+# asserts below only prove the waiver was FOUND and RECORDED, never that it let the run reach a pass.
+assert_verdict 'case (mb8)' PASS 0
 assert_says 'case (mb8) a marker naming the MERGE-BASE grants' \
   "^waiver: GRANTED \(author=@pmcfadin base=$mb8_base head=$mb8_head job=4656 reason=absence checked against the token accounting\)\$"
 assert_says 'case (mb8) and the absence verdict is WAIVED, not PASS' '^prompt-content: WAIVED \(1/1 code census paths absent'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4558,23 +4558,81 @@ fi
 # asserted ABSENT rather than fixed, because absence is what the ruling bought: with no delivery-mode
 # inference there is nothing left for a fifth round to find wrong. A reintroduction is a design
 # regression, not a refactor, and it reds here.
+# EXECUTABLE LINES ONLY, AND THE FILTER IS THE WHOLE DIFFICULTY (#3392). A comment that RECORDS what
+# was deleted — and why it may not come back — is the durable artifact of this ruling, so scanning
+# prose would make the history itself a violation. `--help` PROSE is prose for exactly the same
+# reason and was NOT being exempted: the usage heredoc names the retired states while telling the
+# reader they are gone, which this check would read as a reintroduction.
+#
+# AND THE OLD PREDICATE WAS FAIL-OPEN, NON-DETERMINISTICALLY (found here, #3392). It was
+# `grep -hv ... | grep -qF "$needle"`, and under this file's `pipefail` the DOWNSTREAM `grep -q`
+# exits at its FIRST match, which SIGPIPEs the upstream grep, so the PIPELINE status became 141 —
+# non-zero — and a real violation was recorded as CLEAN. Whether it did so depended on whether the
+# upstream had finished writing, i.e. on the BYTE OFFSET of the match: adding an unrelated comment
+# block to the wrapper flipped this very check from clean to violated with no change to its subject.
+# A guard whose verdict depends on a pipe buffer is worse than no guard. So the text is captured ONCE
+# and matched in PURE BASH with `case` — no pipe, no subshell, no exit status to lose.
 _classifier=""
+_cls_exec=$(awk '
+  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
+  in_usage && /^EOF$/ { in_usage = 0; next }
+  in_usage { next }
+  /^[[:space:]]*#/ { next }
+  { print }
+' "$ORACLES" "$CHECKS_FILE" "$WRAPPER" 2>/dev/null || true)
+# The capture must be NON-EMPTY: an awk that failed, a renamed file or a filter that swallowed
+# everything would make every `case` below miss and the check would report CLEAN having read nothing.
+if [ -z "$_cls_exec" ]; then
+  bad 'structural: the executable-line capture for the classifier scan is EMPTY, so the scan below would report CLEAN having examined nothing (an awk failure, a renamed flow script, or an over-broad filter)'
+fi
 for _gone in 'roborev_collect_review_diff_headers' 'roborev_prompt_snapshot_paths' \
   'roborev_snapshot_path_binding' 'ROBOREV_DIFF_SOURCE_STATE' 'mixed-delivery' 'delegated-oversize' \
   'snapshot-unbound' 'unparseable-instruction' 'BLOCKRESET' 'BLOCKHDR' 'in_trailer' 'in_fence' \
   '_rx_delivery_hdrs' '_rx_snap_paths' 'SNAPSHOT_NOTICE' 'ROBOREV_SNAPSHOT_PATH' \
   'ROBOREV_SNAPSHOT_CONTAINMENT'; do
-  # EXECUTABLE LINES ONLY: a comment that RECORDS what was deleted (and why it may not come back) is
-  # the durable artifact of this ruling, so scanning prose would make the history itself a violation.
-  if grep -hv '^[[:space:]]*#' "$ORACLES" "$CHECKS_FILE" "$WRAPPER" 2>/dev/null | grep -qF "$_gone"; then
-    _classifier="$_classifier $_gone"
-  fi
+  case "$_cls_exec" in
+    *"$_gone"*) _classifier="$_classifier $_gone" ;;
+  esac
 done
 if [ -z "$_classifier" ]; then
   ok 'structural: the delivery-mode classifier is GONE — no block/heading/fence/candidate state, no snapshot or delegated distinction, no NOTICE exemption'
 else
   bad "structural: delivery-mode classification is back in the flow scripts —$_classifier. Owner ruling (4) deleted it because FOUR consecutive review rounds each found a High-severity false verdict in inferring structure from prompt text that embeds repository-controlled content (#3312)"
 fi
+# THE CONTROL FOR THAT FILTER (#3392). The scan above reads the REAL files, so on a clean tree it is
+# indistinguishable from a scan that examines nothing — which is what it had degraded into. The same
+# awk filter is therefore run over a synthetic pair of files that carry the SAME forbidden token in
+# both positions, and it must keep the executable one and drop the `--help` one. Without this, the
+# prose exemption could widen until it swallowed the subject and the check would still read green.
+_cls_ctl_dir="$tmp/classifier-filter-control"
+mkdir -p "$_cls_ctl_dir"
+{
+  printf 'usage() {\n  cat <<EOF\n'
+  printf 'Block detection, fence evidence, mixed-delivery and the rest are all GONE.\n'
+  printf 'EOF\n}\n'
+  printf '# a comment mentioning mixed-delivery, which is history, not code\n'
+} >"$_cls_ctl_dir/roborev-review.sh"
+printf 'ROBOREV_DIFF_SOURCE_STATE=inline   # an EXECUTABLE reintroduction\n' \
+  >"$_cls_ctl_dir/roborev-review-oracles.sh"
+_cls_ctl=$(awk '
+  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
+  in_usage && /^EOF$/ { in_usage = 0; next }
+  in_usage { next }
+  /^[[:space:]]*#/ { next }
+  { print }
+' "$_cls_ctl_dir/roborev-review-oracles.sh" "$_cls_ctl_dir/roborev-review.sh" 2>/dev/null || true)
+case "$_cls_ctl" in
+  *ROBOREV_DIFF_SOURCE_STATE*)
+    ok 'structural control: the executable-line filter KEEPS an executable reintroduction, so the scan above is discriminating rather than blind' ;;
+  *)
+    bad 'structural control: the executable-line filter DROPPED an executable reintroduction — the classifier scan above cannot see the thing it exists to catch' ;;
+esac
+case "$_cls_ctl" in
+  *mixed-delivery*)
+    bad 'structural control: the executable-line filter kept --help prose (or a comment), so the check would red on the doctrine text that records the deletion' ;;
+  *)
+    ok 'structural control: the filter drops --help prose and comments, so recording the retired states in doctrine is not itself a violation' ;;
+esac
 # THE THREE SNAPSHOT KEYS GO WITH IT: a block that still emitted them would be describing a
 # measurement the wrapper no longer makes.
 _skeys=""

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4228,7 +4228,7 @@ STUB_GH_COMMENTS="\001pmcfadin\nroborev-waive: prompt-content-absent base=$mb8_b
 run_wrapper "$mb8_work"
 assert_says 'case (mb8) a marker naming the MERGE-BASE grants' \
   "^waiver: GRANTED \(author=@pmcfadin base=$mb8_base head=$mb8_head job=4656 reason=absence checked against the token accounting\)\$"
-assert_says 'case (mb8) and the absence verdict is WAIVED, not PASS' '^prompt-content: WAIVED \(2/2 code census paths absent'
+assert_says 'case (mb8) and the absence verdict is WAIVED, not PASS' '^prompt-content: WAIVED \(1/1 code census paths absent'
 reset_stub
 
 printf '== case (mb8b): a marker naming the STALE base ref TIP does NOT grant ==\n'
@@ -4246,7 +4246,7 @@ assert_says 'case (mb8b) the tip-bound marker is STALE' \
   "^waiver: STALE \(the marker names a different review — base \($mb8_tip != $mb8_base\)"
 assert_lacks 'case (mb8b) and it grants nothing' '^prompt-content: WAIVED'
 assert_says 'case (mb8b) the absence FAIL stands' \
-  '^prompt-content: FAIL \(2/2 code census paths absent from the prompt\)$'
+  '^prompt-content: FAIL \(1/1 code census paths absent from the prompt\)$'
 reset_stub
 
 printf '== the summary header is distinct from every agent-gate header ==\n'

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -157,7 +157,13 @@ terminal `RESULT` — `NOTHING-TO-REVIEW` included — is a failed review round 
    is a stronger source than its human-readable prose — the same principle that moved the push assert
    off the local `origin/<branch>` mirror ref onto `git ls-remote`. A range that does not match, a
    **single-commit record even when it equals HEAD**, or a scope that *equals the base ref*, **aborts the
-   round**; base-equality is the signature of the
+   round**. The expected **range base is the MERGE-BASE** of `<base>` and HEAD, never the base ref's
+   **tip** — `<base>...HEAD` *is* `merge-base(<base>, HEAD)..HEAD`, and an assert that expected the tip
+   failed deterministically on a correct review of any branch whose `main` had advanced past its branch
+   point (#3392, misdiagnosed as a race twice). The tip is still read for the root-checkout signature
+   alone, and the block prints an informational
+   `assert-base: <merge-base> (merge-base of <base> and HEAD; <base> tip <sha>)`; the absence waiver's
+   `base=` field binds to that merge-base, so copy it from `assert-base:`. base-equality is the signature of the
    worktree bug below. Also push first — an unpushed implementation commit is itself an empty-diff
    cause, and the wrapper asserts the push and FAILs otherwise. Which fields are asserted is the
    wrapper's business — see its `--help`.
@@ -664,7 +670,9 @@ unreviewed code fleet-wide.
 The hermetic regression check cannot prove the real external binary honours `--repo`. From a real
 `issue-<N>-*` worktree whose commit is pushed, while the root checkout sits on `main`, run the wrapper and
 confirm the summary block's `sha-assert: PASS` beside a **`reviewed-sha:` RANGE** of the form
-`<base40>..<head40>` whose **HEAD endpoint is the worktree branch's HEAD** and whose base is `origin/main`.
+`<base40>..<head40>` whose **HEAD endpoint is the worktree branch's HEAD** and whose base is
+`git merge-base origin/main HEAD` — **not** `git rev-parse origin/main`, which is the ref's tip and equals
+the merge-base only while the branch is not behind (#3392). The block's `assert-base:` key names both.
 Because the sanctioned invocation reviews a range, `reviewed-sha` is **not** a bare sha — do not test it for
 equality with `head-sha`; compare the range's head endpoint. A `reviewed-sha` that is `origin/main` alone
 means the explicit `--repo` did not defeat the root-checkout resolution. It stays out of the gate because


### PR DESCRIPTION
Closes #3392.

## The defect

`sha-assert` asked its question against two different definitions of "base":

- the census measures `git diff --numstat -z --no-renames "${BASE}...HEAD"` — **three-dot**, i.e. `merge-base(BASE, HEAD)..HEAD`;
- `BASE_SHA` was `git rev-parse "${BASE}^{commit}"` — the **TIP** of `origin/main`;
- the assert compared the record's (merge-base-relative) `git_ref` against that tip.

roborev is correct: it reviews `merge-base..HEAD`, which is the true branch diff and exactly what `--base origin/main` means under three-dot semantics. So the assert FAILed **deterministically** for any branch whose `main` had advanced since its merge-base — nearly every branch not freshly rebased. Re-running or waiting could never help.

**Not a race.** The issue was filed on a race diagnosis; the owner's correction disproved it with a controlled measurement (`origin/main` unmoved across the window, assert failing anyway) and ruled out the originally-recommended "pin `BASE_SHA` at launch" — pinning still pins the *tip*, and the mismatch is tip-vs-merge-base.

## The change

`BASE_TIP_SHA` (the ref's tip) and `RANGE_BASE_SHA` (the merge-base) are now separate named values. The merge-base is resolved **once**, in the census, and reused by the census diff, the enqueue, `sha-assert:` and the absence-waiver scope. The tip survives for exactly one purpose: the T1 root-checkout base-equality signature, which genuinely needs it.

Fails closed, with no degradation to the tip: `FAIL (base '<ref>' unresolvable)`, `FAIL (no merge-base between '<ref>' and HEAD)`, `FAIL (merge-base ... unusable)` when the command succeeds without yielding exactly one 40-hex sha, `FAIL (git diff failed)`. No review is enqueued in any of them.

New informational key, deliberately outside **both** the verdict-affirmation loop and the closed verdict-grammar scan (both enumerate explicit variables):

```
assert-base: <merge-base> (merge-base of <base> and HEAD; <base> tip <sha>)
```

`base:` stays symbolic so a pasted block cannot be misread as a stale-base review.

## Acceptance criteria

- **AC1** — moved base, unchanged head ⇒ `sha-assert: PASS`. Case `mb1`, on an `advanced-base` fixture. **Asserted non-vacuous**: `assert_base_advanced` FAILs any fixture where tip == merge-base ("nothing about the distinction is under test").
- **AC2** — stale head still FAILs; T1 base-equality and T2 empty-tree signatures intact, the former still comparing against the **tip**. Cases `mb2`–`mb6`.
- **AC3** — the block states which base was compared, and `--help` + CLAUDE.md + the canonical site + the capability spec all agree.
- **AC4** — moved-base case plus the negative control. `mb2` is the paired discriminator: same fixture, range stops one commit short, present precisely in case `mb1` passed because the assert stopped checking.

## Verification

```
scripts/agent-gate.sh --lite      RESULT: PASS   tree-integrity: PASS   commit 6555a39
test_roborev_review_guard.sh      806 passed, 0 failed
test_roborev_guard_portability.sh 129 passed, 0 failed, 0 skipped
roborev job 45 (codex/gpt-5.6-sol) RESULT: PASS  findings NONE
                                   input 983672 / cached 870400 / output 7219
                                   prompt-content PASS (5/5) · both vacuity tiers PASS
```

Full `agent-gate.sh` (the gate of record) recorded separately below.

## What is NOT evidence here, stated deliberately

**This PR's own roborev rounds are corroboration, never the oracle.** The wrapper is read from the invoking worktree, so these rounds ran the *fixed* script — a green `sha-assert` is equally consistent with a fix that stopped checking. That is #3042's lesson (a CQLite-written + CQLite-read round-trip is invariant to a uniform error) applied to a tooling change rather than a format one. The oracle is the hermetic `mb1`/`mb2` pair.

Two specifics:
- Round 1 (job 40) ran at **one commit of drift** (`assert-base: 33f8adc3e`, tip `b3729b6ae`) and `sha-assert` held — under the old code that round would have voided. Useful corroboration.
- Round 2 (job 45, above) ran **after the rebase**, so merge-base == tip and it could not exercise the moved-base condition at all. Recorded so nobody reads its PASS as a demonstration.

## "A caller could already pass the merge-base" — yes, and that is the argument FOR this change

Verified against unfixed `origin/main`, not assumed: `--base) BASE="$2"` (`:518`) accepts any string, and for `mb = merge-base(HEAD, origin/main)`, `rev-parse(mb) == merge-base(mb, HEAD) == mb`, so `mb..HEAD` and `mb...HEAD` are the same 5 commits. `--base "$(git merge-base HEAD origin/main)"` works today.

**So this PR's value is not "make a correct range possible" — it is "make the safe thing the default, so correctness stops depending on every caller remembering an incantation."** Same argument the repo already makes about `--repo` on `--branch`: the flag existed all along, and its absence still cost vacuous reviews fleet-wide until the wrapper made it mandatory. A guard whose correctness rests on caller discipline has a documented bypass, and every lane is a caller. The workaround also leaves **no evidence** — a reader of a pasted block cannot tell whether the operator remembered — and cannot reach the waiver-scope binding at all.

## Measured cost of the bug (two independent lanes)

- PR #3376 (#1712) rounds 6 and 7, ~1.3M input each.
- PR #3397 (#1701) job 22: **2.27M input / 2.11M cached, `prompt-content: PASS 24/24`, real findings acted on** — discarded solely because the reviewed base was a stale main. It then nearly recurred the same night at 2 more commits of drift. **Two occurrences, one lane, one night, on a 4-lane box: a rate, not a coincidence.** Credit: lane-1701.

**It also unlocks recovery.** A round voided *only* by this bug should be salvageable with `--recheck-job <id>`, which re-decides a stored verdict and enqueues nothing — zero reviewer tokens. Applies only to a round that was *valid and voided*; a findings FAIL re-derives the same FAIL from the record.

## Included beyond the headline fix, and why

1. **Finding 1 (roborev, Medium):** the enqueue is now pinned to the resolved merge-base sha, so census, enqueue, assert and waiver share one immutable range. With the merge-base as the base, two-dot and three-dot coincide — the semantics gap that caused this bug stops existing rather than being papered over.
2. **Finding 2 (roborev, Low):** case `mb8` asserts its terminal verdict, so waiver admission cannot rot behind a green test.
3. **`--help` heredoc blocker (found by executing the tool):** `usage()` is an unquoted heredoc, so newly added markdown backticks ran as command substitution — three stderr errors, and `base=`, `--base`, `assert-base:` **silently deleted from the rendered help**. That text is the only sanctioned source for the waiver marker's base sha, so this change would have re-bound the break-glass and deleted its documentation in one stroke. Now has a permanent regression case asserting `--help` exits 0 with **empty stderr** — which immediately caught a backtick the rebase reintroduced. No static review can see this class; in a diff a backtick reads as markdown emphasis.
4. **The classifier-absence scan was fail-open under `pipefail`.** Not unrelated, though I first thought so: the `mixed-delivery` needle sits at byte 38,949 **inside the `usage()` heredoc**, which survives the `^\s*#` filter because heredoc text is not a comment. Measured on pristine `main`: a **67,528-byte** stream against a **65,536-byte** pipe buffer ⇒ an early `grep -qF` match SIGPIPEs the upstream, the pipeline returns 141, and a real violation is recorded as clean — **1/40 fired, 39/40 silent**. Since this change edits `usage()`, it moves those bytes and can flip that guard's verdict, so it is obliged to fix it. Now captured once and matched in pure bash `case` — no pipe, no status to lose — with `--help` prose exempted for the same reason comments are. The standing measurement is on #3367.

## Doctrine updated in the same change

CLAUDE.md rule 2, the canonical `agents-developing/roborev-findings` page (including its live-worktree probe, which told readers to expect `origin/main` — the exact value the bug asserted), and the `roborev-review-guard` capability spec.

**On the spec being a main spec edited directly:** kept deliberately. `9f11eb7cf` (#3229's *fix* commit) edited this same file the same way, the content is normative `SHALL` language for precisely the contract this change alters, and backing it out would leave the spec describing a tip-based contract the wrapper no longer implements. There is no active `openspec/changes/` dir, so the alternative is inventing a proposal after the fact for a bug fix CLAUDE.md routes away from OpenSpec.

## Known coupling, flagged rather than discovered later

This diff **adds** net text to `usage()`, which grows the 1,992-byte excess over the pipe buffer described above. With item 4 fixed that no longer affects a verdict, but any future edit to these three files perturbs that margin: growth makes the old vacuous PASS more likely, and shrinking back under 65,536 bytes would have made it deterministically red fleet-wide.

## Review provenance, stated accurately

One independent review (roborev codex, jobs 40 and 45) plus my own verification. A `rust-reviewer` subagent was dispatched and **never delivered findings** across ~30 minutes and three requests, so this did not receive a second independent review. Both implementer and reviewer subagents were stopped mid-run — the implementer was rewriting the wrapper underneath a verification, reintroducing a fixed backtick — and the final two commits are the lead's, not the implementer's.
