### PR TITLE
docs(#3393): record the OOM diagnostic order — check dmesg before condemning a box (AC4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -915,7 +915,19 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   reap predicate (exit 0 = reap, 1 = keep, 2 = no ref): reap ONLY on age > threshold (4h) AND no open
   PR AND (pid-dead, when the claim is local — a foreign machine's PID is unknowable). It KEEPS on a
   fresh ref, an open PR, a live local PID, or an unparseable age; a `gh`/network hiccup in the
-  open-PR probe assumes an open PR (keeps). The `project-board-sync` 30-min cron runs a `reap-claims`
+  open-PR probe assumes an open PR (keeps).
+  **`should-reap` is a REAP GATE, not a liveness monitor, and the difference cost three lanes
+  (#3393)**: it consults the PID only AFTER age > 4h, so a worker the kernel OOM-killed a minute ago
+  is indistinguishable from a healthy one for four hours — and even then the answer is an exit code
+  nobody watches. Nothing reported three silent lane deaths, each of which left a clean worktree, a
+  held claim and an open PR. **There is no committed tool for this yet** (#3393 AC3 is open, blocked
+  on a claim-ref layout decision: `refs/machine-claims/<machine>` is per-MACHINE, so on a multi-lane
+  box a surviving lane's stamp overwrites a dead sibling's PID and the dead lane becomes
+  unobservable). Until it lands, a suspected dead lane is diagnosed BY HAND, and the order matters —
+  `docs/development/fleet-runbook.md` records it, starting with `dmesg` for an OOM kill *before*
+  concluding a box is broken, because reading that symptom as a broken instance already cost one
+  healthy machine.
+  The `project-board-sync` 30-min cron runs a `reap-claims`
   job that applies this predicate server-side and flips a freed board item back to Ready with a
   traceable comment. **`PROJECTS_TOKEN` absence now FAILS the workflow loudly (`::error::`)** — a
   persistent red run is the alert, replacing the old silent green `::notice::` no-op. The scheduled

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -668,6 +668,40 @@ machine + heartbeat age (issue #2089). Interpretation:
 | Green SUMMARY but parity lines say SKIP | Datasets missing on that machine — `fetch-datasets.sh`, export the root it prints, re-run. Probe an existing root with `fetch-datasets.sh --verify-only` (mutates nothing). The FULL gate FAILs CLOSED here (`missing-fixtures: FAIL-CLOSED (#2078)`) so it can't slip through; `--lite`/`--only` stay lenient. |
 | `missing-schemas: FAIL-CLOSED (#3148)` | Either a committed `test-data/schemas/*.cql` is unreadable (broken checkout — `git restore --source=HEAD -- test-data/schemas`) or `CQLITE_SCHEMAS_ROOT` is set to a **relative** path (export an absolute one, or unset it). Never a corpus-layout problem: the schemas root is checkout-relative. No opt-out exists — do not look for one. |
 | Two machines want the same issue | Impossible past the claim: the second claim-ref push is rejected server-side (non-fast-forward on the fixed-name ref, #2665); the loser sees `CLAIM LOST` and picks the next Ready item. |
+| **SSH accepts TCP but sends no banner** (from inside the VPC) | **Check `dmesg` for an OOM kill BEFORE concluding the instance is broken** — see the diagnostic order below. This is a memory symptom far more often than a broken box, and a soft reboot may be silently ignored. |
+| A lane vanished — worktree clean, claim held, nothing reported | There is **no committed tool for this yet** (#3393 AC3, open). By hand: `bash scripts/flow/claim-heartbeat.sh list-claims` for the owning machine and PID, then `kill -0 <pid>` **on that box** — a PID is only checkable where it runs. `should-reap` will not tell you: it consults the PID only after the claim is >4h old, so a lane killed a minute ago is indistinguishable from a healthy one for four hours. |
+
+
+### Diagnostic order when a box stops answering (#3393)
+
+Recorded because getting this order wrong cost a healthy machine. On 2026-08-27/28 the kernel
+issued **10 global OOM kills** across two `c7i.4xlarge` workers, every victim a `python3` holding
+**20–28 GB** on a 30 GB box. Under memory exhaustion `sshd` cannot fork a session, so the box
+presents as *"TCP connects, no banner"* — which reads exactly like a broken instance. It was read
+that way: a **healthy box was terminated**, losing a measurement lane's 43 minutes and one
+unpushed commit. The signal that would have prevented it was one command nobody ran.
+
+So, in this order:
+
+1. **`dmesg | grep -i "out of memory"`** (or `journalctl -k | grep -i oom`). An OOM kill names the
+   victim, its RSS and its cgroup — `task_memcg=…/tmux-spawn-<uuid>.scope` identifies a **lane**
+   rather than a system service. This is step 1 because it is cheap, non-destructive, and
+   disambiguates the most likely cause.
+2. **`bash scripts/flow/claim-heartbeat.sh list-claims`**, then `kill -0 <pid>` on the owning box
+   for each claim it lists. A claim whose PID is gone is a lane that died; if that issue still has
+   an **open PR** it is an orphaned endgame (#2499) — adopt it, never reap it. This step is manual
+   because no committed tool reports it yet (#3393 AC3).
+3. **`df -h`** — a full disk is the other resource-exhaustion story that surfaces as a confusing
+   failure (#3379), and it is equally cheap to rule out.
+4. **Only then** treat the instance as broken. Note that a soft `reboot-instances` may be
+   **silently ignored** on a memory-exhausted box (observed: console stayed at the original boot,
+   CPU never dipped); a hard stop/start was required.
+
+Two standing lessons from the same incident. **Memory exhaustion is invisible to any monitor that
+iterates existing sessions** — a dead tmux session cannot report itself, so nothing noticed three
+silent lane deaths (`lane-1705` twice, `lane-1697` once), each leaving a clean worktree, a held
+claim and an open PR. And **lane density is the dial**: 4 lanes per box produced OOM kills and
+wedges on *both* boxes, while the 1-lane rig box recorded **zero** and never wedged.
 
 ---
 


### PR DESCRIPTION
Closes part of #3393 — **AC4 only**. See the scope note below for why AC3 is not here.

## What this does

Records the diagnostic order for a box that stops answering, because getting it wrong already cost a healthy machine.

On 2026-08-27/28 the kernel issued **10 global OOM kills** across two `c7i.4xlarge` workers, every victim a `python3` holding **20–28 GB** on a 30 GB box. Under memory exhaustion `sshd` cannot fork a session, so the box presents as *"TCP connects, no banner"* — indistinguishable from a broken instance, and read that way: a **healthy box was terminated**, losing a measurement lane's 43 minutes and one unpushed commit. The signal that would have prevented it was one command nobody ran.

**`docs/development/fleet-runbook.md`** — two Recovery-scenarios rows (the no-banner symptom; the silently-vanished lane) and a *Diagnostic order when a box stops answering* section:

1. `dmesg | grep -i "out of memory"` **first** — cheap, non-destructive, and it disambiguates the likeliest cause. The `task_memcg=…/tmux-spawn-<uuid>.scope` field identifies a *lane* rather than a system service.
2. The claim refs by hand (`list-claims`, then `kill -0 <pid>` **on the owning box** — a PID is only checkable where it runs). A dead PID whose issue still has an open PR is an orphaned endgame (#2499): adopt it, never reap it.
3. `df -h` — the other resource-exhaustion story that surfaces as a confusing failure (#3379), equally cheap to rule out.
4. **Only then** treat the instance as broken — noting that a soft `reboot-instances` may be **silently ignored** on a memory-exhausted box (observed: console stayed at the original boot, CPU never dipped); a hard stop/start was required.

Plus the two standing lessons: memory exhaustion is invisible to any monitor that iterates existing sessions (a dead tmux session cannot report itself — which is why nothing noticed three lane deaths, each leaving a clean worktree, a held claim and an open PR), and **lane density is the dial** — 4 lanes/box produced OOM kills and wedges on *both* boxes while the 1-lane rig box recorded **zero**.

**`CLAUDE.md`** — states why `should-reap` is a reap *gate* and not a liveness monitor, that no committed tool covers this yet, and where the diagnostic order lives.

## Scope: AC4 only, and why

**AC3 (committed tooling that reports a dead lane) is NOT in this change**, and the runbook says so explicitly rather than leaving a reader to infer that no tool means no problem.

A complete implementation exists and is preserved on **`issue-3393-oom-loud-dead-lanes`** (`c9897104`): a `claim-heartbeat.sh dead-lanes` subcommand, 95 regression tests, 20 commits, **17 roborev rounds with ~30 findings fixed**. It cannot clear review as scoped, for a structural reason:

`refs/machine-claims/<machine>` is **one ref per machine** (#2655, premised on "one worker per machine" #1930), but the boxes in this issue ran **four lanes each** — and the ref is force-updated every supervisor iteration. So after one lane dies, a surviving sibling's next stamp overwrites the dead PID, and the tool cannot observe the very scenario AC3 exists to catch. Two of this issue's three silent deaths were on one host.

The fix is lane-scoped claim refs, which changes a namespace shared with `should-reap` and the `project-board-sync` reaper, and collides with the #1930 invariant the fleet was already violating — either that invariant holds and 4-lane boxes are the bug, or the layout must follow reality. Those are different fixes and it is an owner decision, so it is not taken here. A follow-up issue carries it, with the branch preserved so none of the work is lost.

## Certification

**Docs-only**, verified by running the classifier rather than judging the paths:

```
$ git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh
docs-only
classify-docs-only: all changed files are docs -> short-circuit to green
exit 0
```

Per doctrine a code-free diff **cannot be roborev-certified**, and this PR records **no** roborev verdict. The sanctioned substitute is primary-source verification, done against the shipped source rather than from memory:

| Claim in the docs | Verified against |
|---|---|
| `should-reap` consults the PID only *after* the age gate | `claim-heartbeat.sh` `cmd_should_reap`: the `age -le threshold` early return precedes the `kill -0` check by 16 lines |
| The threshold is 4h | `DEFAULT_REAP_THRESHOLD_SECS=14400` (`claim-heartbeat.sh:120`) |
| `list-claims` reports machine/issue/PID | `claim-heartbeat.sh:339` prints `MACHINE ISSUE PID TS AGE`; run live, returns `no claims found on origin` |
| #3379 is the disk-full sibling | `gh issue view 3379` — *"agent-gate: a disk-full (ENOSPC) run reports component 'FAIL' indistinguishably from a test failure"* |

Incident facts (kill counts, RSS range, the terminated box, the three lane deaths, lane density) are quoted from #3393's own body, which the owner recorded from `dmesg` and the console at the time.


---

## Gate of record — FULL, `RESULT: PASS`

```
==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.iIbQNH
commit: bd8b103 branch: issue-3393-oom-diagnostic-order dirty: no
datasets: 144 Data.db files under /data/datasets
schemas: 6/6 canonical .cql readable (checkout-relative)
accelerators: sccache=on nextest=on lanes=on sccache-health=ok mold=linked perf=ok
tree-start: bd8b103d128f dirty: no digest: c6a718880edb
tree-end:   bd8b103d128f dirty: no digest: c6a718880edb
tree-integrity: PASS
file-size / fmt / clippy / roborev-lints / core-tests / tombstones-scan /
scan-offload-guard / work-counters-guard / byte-budget-guard / arrow-parity-guard /
memory-budget / integration-tests / format-compat / write-tests / cli-tests /
compaction-byte-parity / bti-multiclustering / query-semantics-oracle /
flight-query-semantics-oracle / python-bindings / node-bindings /
delivery-telemetry / oom-audit / parity-report / operator-metrics-doc /
kit-dashboard-drift / binding-unwind-profile / tooling-tests / minimal-build / smoke
   ... all 30 components PASS
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

All 30 components green on the certified sha, `tree-integrity: PASS`, `dirty: no`. **No waiver of any kind was used** — the #3042 cite-and-waive path was available for this docs-only diff and was not needed, because nothing failed.

`scripts/flow/premerge-assert.sh 3429 bd8b103d128fd8ab2d5de42d727a01e8517dd2b6` → `PREMERGE: OK`, and a fresh re-read of PR and issue comments found no `HOLD:` order (the one string match on #3393 is my own earlier comment quoting the token while reporting its absence).

## Follow-up

AC3 is tracked in **#3430**, which states the blocking decision (lane-scoped claim refs vs. enforcing the one-worker-per-machine invariant) with both options and the evidence for each, and carries forward the reusable findings from the 17 review rounds so they survive even if the implementation is rewritten. The branch `issue-3393-oom-loud-dead-lanes` @ `c9897104` is preserved unmerged.

#3393 stays **open** on AC1 and AC3.
