### PR TITLE
docs(#3393): mirror the should-reap/liveness doctrine onto the website page

### DIFF
--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -332,6 +332,29 @@ comment. Two workflow hardenings ship with it: **`PROJECTS_TOKEN` absence now fa
 10-minute auto-add grace window**, so it no longer races the built-in Auto-add workflow's default-status
 write on a freshly created issue.
 
+**`should-reap` is a REAP GATE, not a liveness monitor — and that gap cost three lanes (#3393).** It
+consults the recorded PID only *after* age > threshold, so a worker the kernel OOM-killed a minute ago is
+indistinguishable from a healthy one for **four hours** — and even then the answer is an exit code nobody is
+watching. On 2026-08-27/28 the kernel issued **10 global OOM kills** across two 30 GB workers (every victim
+a `python3` at 20–28 GB) and three lanes died silently, each leaving a clean worktree, a held claim and an
+open PR. **Memory exhaustion is invisible to any monitor that iterates existing sessions**: a dead tmux
+session cannot report itself.
+
+**There is no committed tool for this yet.** #3430 tracks it, blocked on a layout decision rather than on
+code: `refs/machine-claims/<machine>` is keyed per **MACHINE** and force-updated every supervisor
+iteration, so on a multi-lane box a surviving lane's stamp overwrites a dead sibling's PID — a live sibling
+does not merely hide a dead lane, it **masks** it. Either lane-scoped refs land (which changes what
+`should-reap` and the CI reaper read), or the one-worker-per-machine invariant (#1930) is enforced and
+multi-lane boxes are themselves the defect; #3393's own data supports the latter (4 lanes ⇒ OOM kills and
+wedges on *both* boxes; the 1-lane box ⇒ zero).
+
+Until it lands, a suspected dead lane is diagnosed **by hand, and the order matters** — full procedure in
+`docs/development/fleet-runbook.md`. The one line worth memorising: when a box accepts TCP but sends no SSH
+banner from inside the VPC, **check `dmesg` for an OOM kill before concluding the instance is broken**.
+Reading that symptom as a broken instance already cost one healthy machine (terminated, losing a
+measurement lane's 43 minutes and an unpushed commit), and a soft reboot may be silently ignored on a
+memory-exhausted host.
+
 **Never block on a question (park-and-resume, #2666).** A worker runs unattended, so `AskUserQuestion` (and
 any interactive prompt) is attended-sessions-only. When a worker hits Seam 1 (an unapproved spec) or a
 genuine mid-run owner decision it does not wait — it **parks**: posts ONE structured question comment


### PR DESCRIPTION
Follow-up to #3429, closing a gap in it that I should have caught before merging.

#3429 added the `should-reap`-is-not-a-liveness-monitor doctrine to **CLAUDE.md** and **`docs/development/fleet-runbook.md`**, but not to **`website/src/content/docs/agents-developing/delivery-pipeline.md`** — which carries the same claim/heartbeat/`should-reap` material. The doctrine-current rule is explicit that a workflow change updates CLAUDE.md *and* the website page as part of the change, so #3429 was incomplete on that point.

Added immediately after the existing reap-predicate section it qualifies:

- **`should-reap` is a reap GATE, not a liveness monitor.** It consults the PID only *after* age > threshold, so a worker OOM-killed a minute ago looks healthy for four hours — and even then the answer is an exit code nobody watches.
- **The cost, from #3393:** 10 global OOM kills across two 30 GB workers; three lanes died silently, each leaving a clean worktree, a held claim and an open PR. *Memory exhaustion is invisible to any monitor that iterates existing sessions* — a dead tmux session cannot report itself.
- **No committed tool yet (#3430), and why it's blocked on a decision rather than code:** `refs/machine-claims/<machine>` is per-MACHINE and force-updated every supervisor iteration, so on a multi-lane box a surviving lane's stamp *masks* a dead sibling. Either lane-scoped refs land, or #1930 is enforced and multi-lane boxes are themselves the defect — this issue's own data supports the latter (4 lanes ⇒ OOM on both boxes; 1 lane ⇒ zero).
- **The line worth memorising:** TCP accepted but no SSH banner from inside the VPC ⇒ check `dmesg` for an OOM kill *before* concluding the instance is broken. That misreading already cost a healthy machine, and a soft reboot may be silently ignored on an exhausted host.

## Certification

Docs-only, verified by running the classifier rather than judging paths:

```
$ git diff --name-only origin/main...HEAD | bash scripts/ci/classify-docs-only.sh
docs-only
classify-docs-only: all changed files are docs -> short-circuit to green
exit 0
```

Per doctrine a code-free diff **cannot** be roborev-certified and **no** roborev verdict is recorded here. The substantive claims are the same ones verified against shipped source for #3429: `cmd_should_reap`'s `age -le threshold` early return precedes its `kill -0` check, and `DEFAULT_REAP_THRESHOLD_SECS=14400` (4h).

Full gate to follow on this head; the #3042 cite-and-waive path is available for a prose diff but I do not expect to need it.

---

## Gate of record — FULL, `RESULT: PASS`

```
==== AGENT-GATE SUMMARY ====
run-id: /tmp/agent-gate.XIjd17
commit: 2b55e31 branch: issue-3393-website-doctrine dirty: no
tree-start: 2b55e31956b0 dirty: no
tree-end:   2b55e31956b0 dirty: no
tree-integrity: PASS
   ... all 30 components PASS
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

`premerge-assert.sh 3431 2b55e31956b05905a2506bbe29efa2f078c90c93` → `PREMERGE: OK`; no `HOLD:` order. **No waiver used.**

### Markdown validation (this is an Astro content page)

`node_modules` is absent on this host so the site could not be built offline; validated the inserted block directly instead — frontmatter intact, **0** bare angle brackets outside code spans (the HTML-parsing hazard in a `.md` page), and backticks balanced on every added line. The `<machine>`-style placeholders are inside code spans, matching the surrounding page's existing convention.

### Note: this PR was briefly blocked by a GitHub secondary rate limit

`premerge-assert.sh` **failed closed** on `GraphQL: API rate limit already exceeded`, while the `rate_limit` endpoint reported the GraphQL quota *full* (5000/5000) — the signature of a **secondary** limit, which that endpoint does not report. REST stayed healthy throughout and confirmed the PR head independently.

Recorded because the temptation here is the failure mode: the REST merge endpoint was available and would have worked. It was not used — `PUT /pulls/N/merge` merges *immediately*, bypassing the required-check wait that branch protection exists to enforce, and it is forbidden precisely so that a throttle never becomes the reason a PR lands unchecked. The gate verdict was preserved on disk and the sanctioned path retried until GraphQL recovered.
