### PR TITLE
fix(#3384): the flight suite's flake was an unbounded race, not cross-binary residue — bound it structurally

### DIFF
--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -138,3 +138,50 @@ mod tests {
         assert!(!delta.any_merge_work());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Query-row producer completion (issue #3384)
+// ---------------------------------------------------------------------------
+
+/// Producers that have finished decoding, published with RELEASE ordering.
+///
+/// Deliberately NOT a field of [`ReadPathProbe`]: every field there is loaded
+/// `Relaxed`, which is right for counters read after the work is known to be over,
+/// and wrong for this one — its whole job is to TELL you the work is over.
+static QUERY_ROW_PRODUCERS_FINISHED: AtomicU64 = AtomicU64::new(0);
+
+/// Publish that one `QueryRowStream` producer has finished decoding.
+///
+/// Call BEFORE the terminal message is sent, never after (roborev, issue #3384):
+/// a consumer holding the terminal message must be able to conclude that this
+/// producer can no longer publish, or a producer from a PRIOR test case can
+/// increment into a LATER case's freshly-reset counter and the later case will
+/// observe a completion that was never its own.
+pub fn mark_query_row_producer_finished() {
+    QUERY_ROW_PRODUCERS_FINISHED.fetch_add(1, Ordering::Release);
+}
+
+/// `QueryRowStream` producers that have finished decoding since the last
+/// [`reset_query_row_producers_finished`] (issue #3384).
+///
+/// The CAUSAL completion signal for an abandoned walk. A test that instead waits
+/// for a work counter to "stop growing" is sampling another thread's progress: a
+/// producer merely descheduled, or paused between two increments, is
+/// indistinguishable from one that has stopped, so the walk can resume and drain
+/// the table right after the assertion passed.
+///
+/// The `Acquire` load is load-bearing, not decoration. With `Relaxed` on both
+/// sides, observing a non-zero count would establish NO happens-before edge with
+/// the producer's earlier work-counter increments, so a reader could see
+/// "finished" and then read a STALE row count — precisely the guarantee this
+/// signal exists to give (roborev, issue #3384).
+pub fn query_row_producers_finished() -> u64 {
+    QUERY_ROW_PRODUCERS_FINISHED.load(Ordering::Acquire)
+}
+
+/// Zero the completion count. A test that will wait on
+/// [`query_row_producers_finished`] must call this first, while holding whatever
+/// lock serializes producers in its binary.
+pub fn reset_query_row_producers_finished() {
+    QUERY_ROW_PRODUCERS_FINISHED.store(0, Ordering::Release);
+}

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -156,6 +156,33 @@ pub fn query_row_producers_finished() -> u64 {
     QUERY_ROW_PRODUCERS_FINISHED.load(Ordering::Acquire)
 }
 
+/// Detached `BatchedScanStream` tasks that have terminated, published with
+/// RELEASE ordering (issue #3384).
+static BATCHED_SCANS_FINISHED: AtomicU64 = AtomicU64::new(0);
+
+/// Publish that one detached batched-scan task has terminated.
+///
+/// The INNER half of the abandoned-walk completion story. `mark_query_row_producer_finished`
+/// proves the outer query-row thread stopped pulling; this proves the detached task it
+/// dropped without joining has stopped DECODING. Only both together make
+/// `stream_walk_partitions_parsed` final — waiting a fixed interval instead merely
+/// makes the race less likely, which is the defect this issue exists to remove.
+pub fn mark_batched_scan_finished() {
+    BATCHED_SCANS_FINISHED.fetch_add(1, Ordering::Release);
+}
+
+/// Detached batched-scan tasks that have terminated since
+/// [`reset_batched_scans_finished`] (issue #3384). `Acquire`, for the same
+/// happens-before reason as [`query_row_producers_finished`].
+pub fn batched_scans_finished() -> u64 {
+    BATCHED_SCANS_FINISHED.load(Ordering::Acquire)
+}
+
+/// Zero the detached batched-scan completion count (issue #3384).
+pub fn reset_batched_scans_finished() {
+    BATCHED_SCANS_FINISHED.store(0, Ordering::Release);
+}
+
 /// Zero the completion count. A test that will wait on
 /// [`query_row_producers_finished`] must call this first, while holding whatever
 /// lock serializes producers in its binary.

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -36,7 +36,7 @@
 //! must serialize against any sibling test in the same binary that also merges
 //! (one file = one process is the strongest form; a mutex is the minimum).
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
 static MERGERS_BUILT: AtomicU64 = AtomicU64::new(0);
 static RECONCILE_ENTRIES: AtomicU64 = AtomicU64::new(0);
@@ -154,6 +154,50 @@ pub fn mark_query_row_producer_finished() {
 /// signal exists to give (roborev, issue #3384).
 pub fn query_row_producers_finished() -> u64 {
     QUERY_ROW_PRODUCERS_FINISHED.load(Ordering::Acquire)
+}
+
+/// Blocking scan tasks currently running (issue #3384). A GAUGE, not a counter.
+static BLOCKING_SCAN_TASKS_INFLIGHT: AtomicI64 = AtomicI64::new(0);
+
+/// RAII marker for one blocking scan task: increments on construction, decrements on
+/// drop (issue #3384).
+///
+/// The stitching path's parse/feed halves run under `spawn_blocking`, and blocking
+/// tasks are NOT cancellable — dropping their `JoinHandle` DETACHES them. So neither
+/// the outer query-row producer's completion nor the scan future's drop guard proves
+/// decoding has stopped: both can fire while a detached blocking half is still
+/// draining. This gauge is the missing half. A gauge rather than a completion counter
+/// because the number of blocking halves is an implementation detail — a reader waits
+/// for it to reach ZERO instead of knowing how many to expect.
+///
+/// Decrement is a `Drop` impl so an unwinding task still clears its slot; a leaked
+/// increment would hang every future reader.
+pub struct BlockingScanTaskGuard;
+
+impl BlockingScanTaskGuard {
+    /// Register one running blocking scan task.
+    pub fn new() -> Self {
+        BLOCKING_SCAN_TASKS_INFLIGHT.fetch_add(1, Ordering::Release);
+        Self
+    }
+}
+
+impl Default for BlockingScanTaskGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for BlockingScanTaskGuard {
+    fn drop(&mut self) {
+        BLOCKING_SCAN_TASKS_INFLIGHT.fetch_sub(1, Ordering::Release);
+    }
+}
+
+/// Blocking scan tasks still running (issue #3384). ZERO means every detached
+/// blocking half has stopped, so `stream_walk_partitions_parsed` is final.
+pub fn blocking_scan_tasks_inflight() -> i64 {
+    BLOCKING_SCAN_TASKS_INFLIGHT.load(Ordering::Acquire)
 }
 
 /// Times a batched scan took the STITCHING branch (issue #3384).

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -183,14 +183,23 @@ pub(crate) struct BlockingScanTaskGuard(());
 impl BlockingScanTaskGuard {
     /// Register one running blocking scan task. The ONLY way to make one.
     pub(crate) fn new() -> Self {
-        BLOCKING_SCAN_TASKS_INFLIGHT.fetch_add(1, Ordering::Release);
+        // `AcqRel` for the same chaining reason as the decrement below.
+        BLOCKING_SCAN_TASKS_INFLIGHT.fetch_add(1, Ordering::AcqRel);
         Self(())
     }
 }
 
 impl Drop for BlockingScanTaskGuard {
     fn drop(&mut self) {
-        BLOCKING_SCAN_TASKS_INFLIGHT.fetch_sub(1, Ordering::Release);
+        // `AcqRel`, not `Release` (roborev, issue #3384). A reader's `Acquire` load of
+        // ZERO synchronizes-with the FINAL decrement only. With plain `Release` stores
+        // that leaves the EARLIER tasks' work unordered: if the feed half decrements
+        // last, the reader's subsequent (Relaxed) work-counter load is not guaranteed to
+        // observe the parse half's increments — so the "final count" would not be final,
+        // which is the entire property this gauge exists to provide. `AcqRel` makes each
+        // decrement ACQUIRE the ones before it, chaining happens-before through every
+        // task so the last decrement publishes all of their work.
+        BLOCKING_SCAN_TASKS_INFLIGHT.fetch_sub(1, Ordering::AcqRel);
     }
 }
 

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -105,40 +105,6 @@ impl ReadPathProbe {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// A delta must count exactly the work recorded between the two snapshots,
-    /// independent of whatever a sibling test already accumulated.
-    #[test]
-    fn delta_counts_only_work_between_snapshots() {
-        let before = ReadPathProbe::snapshot();
-        record_merger_built();
-        record_reconcile_entry();
-        record_reconcile_entry();
-        record_cell_metadata_map();
-        let delta = ReadPathProbe::snapshot().delta_since(&before);
-        assert!(delta.mergers_built >= 1, "the merger build was recorded");
-        assert!(delta.reconcile_entries >= 2, "both reconciles recorded");
-        assert!(delta.cell_metadata_maps >= 1, "the map alloc was recorded");
-        assert!(delta.any_merge_work());
-    }
-
-    /// A zero delta reports no merge work — the shape the bypass assertion uses.
-    #[test]
-    fn zero_delta_reports_no_merge_work() {
-        let a = ReadPathProbe {
-            mergers_built: 7,
-            reconcile_entries: 9,
-            cell_metadata_maps: 11,
-        };
-        let delta = a.delta_since(&a);
-        assert_eq!(delta, ReadPathProbe::default());
-        assert!(!delta.any_merge_work());
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Query-row producer completion (issue #3384)
 // ---------------------------------------------------------------------------
@@ -184,4 +150,38 @@ pub fn query_row_producers_finished() -> u64 {
 /// lock serializes producers in its binary.
 pub fn reset_query_row_producers_finished() {
     QUERY_ROW_PRODUCERS_FINISHED.store(0, Ordering::Release);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A delta must count exactly the work recorded between the two snapshots,
+    /// independent of whatever a sibling test already accumulated.
+    #[test]
+    fn delta_counts_only_work_between_snapshots() {
+        let before = ReadPathProbe::snapshot();
+        record_merger_built();
+        record_reconcile_entry();
+        record_reconcile_entry();
+        record_cell_metadata_map();
+        let delta = ReadPathProbe::snapshot().delta_since(&before);
+        assert!(delta.mergers_built >= 1, "the merger build was recorded");
+        assert!(delta.reconcile_entries >= 2, "both reconciles recorded");
+        assert!(delta.cell_metadata_maps >= 1, "the map alloc was recorded");
+        assert!(delta.any_merge_work());
+    }
+
+    /// A zero delta reports no merge work — the shape the bypass assertion uses.
+    #[test]
+    fn zero_delta_reports_no_merge_work() {
+        let a = ReadPathProbe {
+            mergers_built: 7,
+            reconcile_entries: 9,
+            cell_metadata_maps: 11,
+        };
+        let delta = a.delta_since(&a);
+        assert_eq!(delta, ReadPathProbe::default());
+        assert!(!delta.any_merge_work());
+    }
 }

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -172,19 +172,19 @@ static BLOCKING_SCAN_TASKS_INFLIGHT: AtomicI64 = AtomicI64::new(0);
 ///
 /// Decrement is a `Drop` impl so an unwinding task still clears its slot; a leaked
 /// increment would hang every future reader.
-pub struct BlockingScanTaskGuard;
+/// The private field is load-bearing (roborev, issue #3384): as a UNIT struct this
+/// was constructible by name, so a caller could make one WITHOUT the increment and
+/// then decrement the gauge below zero on drop — silently breaking every completion
+/// check that reads it. `pub(crate)` for the same reason, narrowed further: nothing
+/// outside this crate needs to register a blocking task, and the observers
+/// ([`blocking_scan_tasks_inflight`]) stay public.
+pub(crate) struct BlockingScanTaskGuard(());
 
 impl BlockingScanTaskGuard {
-    /// Register one running blocking scan task.
-    pub fn new() -> Self {
+    /// Register one running blocking scan task. The ONLY way to make one.
+    pub(crate) fn new() -> Self {
         BLOCKING_SCAN_TASKS_INFLIGHT.fetch_add(1, Ordering::Release);
-        Self
-    }
-}
-
-impl Default for BlockingScanTaskGuard {
-    fn default() -> Self {
-        Self::new()
+        Self(())
     }
 }
 

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -156,6 +156,35 @@ pub fn query_row_producers_finished() -> u64 {
     QUERY_ROW_PRODUCERS_FINISHED.load(Ordering::Acquire)
 }
 
+/// Times a batched scan took the STITCHING branch (issue #3384).
+static BATCHED_SCAN_STITCHING_PATHS: AtomicU64 = AtomicU64::new(0);
+
+/// Record that a batched scan routed to `run_scan_stream_windowed` — the
+/// STITCHING branch (issue #3384).
+///
+/// Exists so a test can AFFIRMATIVELY measure which branch its fixture took, rather
+/// than infer it. The completion signal below covers only the non-stitching loop, and
+/// the obvious proxies for "am I on that loop" are all wrong: absence of
+/// `CompressionInfo.db` does not imply it (roborev), and neither does the fixture being
+/// uncompressed in the colloquial sense — `requires_chunk_stitching()` is
+/// `data_format() == V5CompressedLegacy && is_nb_format()`, and `V5_0Uncompressed` maps
+/// to the FORMER but not the LATTER. Two proxies, two different wrong answers; the
+/// branch itself is the only thing worth asserting on.
+pub fn mark_batched_scan_stitching_path() {
+    BATCHED_SCAN_STITCHING_PATHS.fetch_add(1, Ordering::Release);
+}
+
+/// Batched scans that took the stitching branch since
+/// [`reset_batched_scan_stitching_paths`] (issue #3384).
+pub fn batched_scan_stitching_paths() -> u64 {
+    BATCHED_SCAN_STITCHING_PATHS.load(Ordering::Acquire)
+}
+
+/// Zero the stitching-branch count (issue #3384).
+pub fn reset_batched_scan_stitching_paths() {
+    BATCHED_SCAN_STITCHING_PATHS.store(0, Ordering::Release);
+}
+
 /// Detached `BatchedScanStream` tasks that have terminated, published with
 /// RELEASE ordering (issue #3384).
 static BATCHED_SCANS_FINISHED: AtomicU64 = AtomicU64::new(0);

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -167,6 +167,19 @@ static BATCHED_SCANS_FINISHED: AtomicU64 = AtomicU64::new(0);
 /// dropped without joining has stopped DECODING. Only both together make
 /// `stream_walk_partitions_parsed` final — waiting a fixed interval instead merely
 /// makes the race less likely, which is the defect this issue exists to remove.
+///
+/// # Scope, and it is narrower than "the scan has finished" (roborev, issue #3384)
+///
+/// This is published from a DROP guard on the spawned future, so it covers everything
+/// that decodes INSIDE that future — which is the whole of the block-by-block loop
+/// taken by non-stitching (uncompressed) readers.
+///
+/// It does NOT cover the STITCHING path. `requires_chunk_stitching()` (compressed `nb`)
+/// routes to `run_scan_stream_windowed`, which dispatches `spawn_blocking` parse/feed
+/// tasks; blocking tasks are not cancellable, so they can still be decoding and
+/// advancing `stream_walk_partitions_parsed` when this signal fires. On that path the
+/// signal is PREMATURE and must not be read as finality. Joining those tasks on
+/// cancellation is the real fix and is tracked on #3428.
 pub fn mark_batched_scan_finished() {
     BATCHED_SCANS_FINISHED.fetch_add(1, Ordering::Release);
 }

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -136,6 +136,17 @@ pub fn mark_query_row_producer_finished() {
 /// indistinguishable from one that has stopped, so the walk can resume and drain
 /// the table right after the assertion passed.
 ///
+/// # What it proves, and what it does NOT
+///
+/// It proves the OUTER query-row producer stopped. It does NOT prove the INNER
+/// batched scan task has (roborev, issue #3384): `drive_full_scan_rows` drops
+/// `BatchedScanStream` on its way out and that task is never joined. That trail is
+/// BOUNDED — the inner loop consults its consumer only when a batch fills, so after
+/// the receiver is dropped it decodes at most one more emit batch before its `send`
+/// fails and it returns — so it cannot run away, but a reader wanting a FINAL work
+/// count should let the trail land rather than read the instant this signal moves.
+/// Joining the inner task on shutdown is tracked on #3428.
+///
 /// The `Acquire` load is load-bearing, not decoration. With `Relaxed` on both
 /// sides, observing a non-zero count would establish NO happens-before edge with
 /// the producer's earlier work-counter increments, so a reader could see

--- a/cqlite-core/src/storage/read_path_probe.rs
+++ b/cqlite-core/src/storage/read_path_probe.rs
@@ -166,7 +166,9 @@ static BLOCKING_SCAN_TASKS_INFLIGHT: AtomicI64 = AtomicI64::new(0);
 /// tasks are NOT cancellable — dropping their `JoinHandle` DETACHES them. So neither
 /// the outer query-row producer's completion nor the scan future's drop guard proves
 /// decoding has stopped: both can fire while a detached blocking half is still
-/// draining. This gauge is the missing half. A gauge rather than a completion counter
+/// draining. This gauge is the THIRD and last of the completion signals — the other two
+/// are `query_row_producers_finished` (outer thread) and the scan future's own drop
+/// guard, and neither covers detached blocking work. A gauge rather than a completion counter
 /// because the number of blocking halves is an implementation detail — a reader waits
 /// for it to reach ZERO instead of knowing how many to expect.
 ///
@@ -244,9 +246,9 @@ static BATCHED_SCANS_FINISHED: AtomicU64 = AtomicU64::new(0);
 
 /// Publish that one detached batched-scan task has terminated.
 ///
-/// The INNER half of the abandoned-walk completion story. `mark_query_row_producer_finished`
+/// The SECOND of three abandoned-walk completion signals. `mark_query_row_producer_finished`
 /// proves the outer query-row thread stopped pulling; this proves the detached task it
-/// dropped without joining has stopped DECODING. Only both together make
+/// dropped without joining has stopped DECODING. Only all three together make
 /// `stream_walk_partitions_parsed` final — waiting a fixed interval instead merely
 /// makes the race less likely, which is the defect this issue exists to remove.
 ///

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -18,8 +18,18 @@
 //! now share ONE dispatch, [`SSTableReader::stream_bti_scan`], so a third divergent
 //! copy of this decision cannot drift again (the #1577 class).
 //!
-//! Included via `#[path = "batched_scan_stream.rs"] mod batched_scan_stream;` in
-//! [`super`], so it shares `sequential.rs`'s imports through `use super::*`.
+//! Included via `#[path = "batched_scan_stream.rs"] pub(super) mod batched_scan_stream;`
+//! in [`super`], so it shares `sequential.rs`'s imports through `use super::*`.
+//!
+//! # Why the module is `pub(super)` (issue #3384)
+//!
+//! [`batched_channel_capacity`] is the SINGLE definition of this surface's channel
+//! sizing, and `summary_scan::query_rows` derives its exported read-ahead bound
+//! ([`QUERY_ROWS_MAX_READ_AHEAD`](crate::storage::sstable::reader::QUERY_ROWS_MAX_READ_AHEAD))
+//! from it rather than restating the arithmetic. `pub(super)` is the narrowest
+//! visibility that reaches that sibling; the prose lives here rather than beside
+//! the `mod` declaration because `sequential.rs` is 1319 lines, already over the
+//! campsite threshold (epic #1116), and this file is not.
 
 use super::*;
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -227,6 +227,10 @@ impl SSTableReader {
         }
 
         if self.requires_chunk_stitching() {
+            // Affirmative branch marker (issue #3384): the detached-scan completion
+            // signal does NOT cover this branch's `spawn_blocking` decode, so a test
+            // relying on that signal must be able to measure that it did not land here.
+            crate::storage::read_path_probe::mark_batched_scan_stitching_path();
             // Forward the windowed driver's internal batches straight through — no
             // flatten, no re-batch (issue #1592). Same driver, same order/content
             // as the per-row path; only the output surface differs.

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -71,11 +71,12 @@ impl SSTableReader {
         admission: ScanAdmission,
         now_secs: Option<i64>,
     ) -> BatchedScanStream {
-        // The public channel carries BATCHES; sizing it to
-        // `ceil(buffer_size / BATCH_EMIT_ROWS)` batches keeps the resident-row
-        // budget of this channel comparable to the per-row surface's `buffer_size`
-        // rather than `buffer_size * BATCH_EMIT_ROWS`.
-        let cap = buffer_size.div_ceil(BATCH_EMIT_ROWS).max(1);
+        // The public channel carries BATCHES (see `batched_channel_capacity`,
+        // which is the SINGLE definition of this sizing — the query-row stream's
+        // exported read-ahead bound is derived from the same `const fn`).
+        let cap = crate::storage::sstable::reader::scan_stream_windowed::batched_channel_capacity(
+            buffer_size,
+        );
         let (tx, rx) = mpsc::channel(cap);
         // Read-metric grain (issue #1701): identical rule to the per-row surface —
         // an `Acquire` scan is the top-level read OPERATION and is measured with

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -33,6 +33,15 @@
 
 use super::*;
 
+/// Publishes detached-scan completion on drop — see the spawn site (issue #3384).
+struct ScanTaskDone;
+
+impl Drop for ScanTaskDone {
+    fn drop(&mut self) {
+        crate::storage::read_path_probe::mark_batched_scan_finished();
+    }
+}
+
 /// Batches the public BATCHED-scan channel below holds for a given `buffer_size`.
 ///
 /// Sizing the channel to `ceil(buffer_size / BATCH_EMIT_ROWS)` batches keeps its
@@ -121,6 +130,17 @@ impl SSTableReader {
             ScanAdmission::Exempt => None,
         };
         let task = tokio::spawn(async move {
+            // CAUSAL completion signal for THIS detached task (issue #3384,
+            // roborev). `BatchedScanStream` is dropped without joining its task, so
+            // a consumer that stopped reading cannot otherwise tell "the scan
+            // finished" from "the scan is descheduled between two increments".
+            //
+            // It is a DROP guard, not a statement at the end of the block, because
+            // the common exit here is CANCELLATION, not completion: the query-row
+            // producer owns a `current_thread` runtime and drops it as it returns,
+            // which cancels this future at its next await — so a trailing statement
+            // would never run. Measured: it never fired. Drop runs on both paths.
+            let _done = ScanTaskDone;
             if let Err(e) = self
                 .run_scan_stream_batched(
                     table_id,

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -31,7 +31,7 @@ use super::*;
 ///
 /// A `const fn` with ONE definition because the query-row stream's exported
 /// read-ahead bound
-/// ([`QUERY_ROWS_MAX_READ_AHEAD_ROWS`](crate::storage::sstable::reader::QUERY_ROWS_MAX_READ_AHEAD_ROWS))
+/// ([`QUERY_ROWS_MAX_READ_AHEAD`](crate::storage::sstable::reader::QUERY_ROWS_MAX_READ_AHEAD))
 /// is derived from it. A second copy of this arithmetic could drift from the
 /// channel the constructor actually builds — which is precisely how a documented
 /// read-ahead bound becomes silently wrong (issue #3384).

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -129,18 +129,25 @@ impl SSTableReader {
             )),
             ScanAdmission::Exempt => None,
         };
+
+        // CAUSAL completion signal for THIS detached task (issue #3384, roborev).
+        // `BatchedScanStream` is dropped without joining its task, so a consumer that
+        // stopped reading cannot otherwise tell "the scan finished" from "the scan is
+        // descheduled between two increments".
+        //
+        // A DROP guard, not a statement at the end of the block, because the common exit
+        // here is CANCELLATION, not completion: the query-row producer owns a
+        // `current_thread` runtime and drops it as it returns, cancelling this future at
+        // its next await — a trailing statement would never run. Measured: it never fired.
+        //
+        // Constructed BEFORE `tokio::spawn` and moved in (roborev): a future dropped
+        // before its FIRST POLL — a runtime shut down between spawn and schedule — would
+        // otherwise never construct the guard, so nothing would publish and every waiter
+        // would time out. Owning it outside the async block makes the guard's lifetime
+        // the TASK's, not the body's.
+        let done = ScanTaskDone;
         let task = tokio::spawn(async move {
-            // CAUSAL completion signal for THIS detached task (issue #3384,
-            // roborev). `BatchedScanStream` is dropped without joining its task, so
-            // a consumer that stopped reading cannot otherwise tell "the scan
-            // finished" from "the scan is descheduled between two increments".
-            //
-            // It is a DROP guard, not a statement at the end of the block, because
-            // the common exit here is CANCELLATION, not completion: the query-row
-            // producer owns a `current_thread` runtime and drops it as it returns,
-            // which cancels this future at its next await — so a trailing statement
-            // would never run. Measured: it never fired. Drop runs on both paths.
-            let _done = ScanTaskDone;
+            let _done = done;
             if let Err(e) = self
                 .run_scan_stream_batched(
                     table_id,

--- a/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/batched_scan_stream.rs
@@ -23,6 +23,27 @@
 
 use super::*;
 
+/// Batches the public BATCHED-scan channel below holds for a given `buffer_size`.
+///
+/// Sizing the channel to `ceil(buffer_size / BATCH_EMIT_ROWS)` batches keeps its
+/// resident-row budget comparable to the per-row surface's `buffer_size` rather
+/// than `buffer_size * BATCH_EMIT_ROWS`.
+///
+/// A `const fn` with ONE definition because the query-row stream's exported
+/// read-ahead bound
+/// ([`QUERY_ROWS_MAX_READ_AHEAD_ROWS`](crate::storage::sstable::reader::QUERY_ROWS_MAX_READ_AHEAD_ROWS))
+/// is derived from it. A second copy of this arithmetic could drift from the
+/// channel the constructor actually builds — which is precisely how a documented
+/// read-ahead bound becomes silently wrong (issue #3384).
+pub(crate) const fn batched_channel_capacity(buffer_size: usize) -> usize {
+    let cap = buffer_size.div_ceil(BATCH_EMIT_ROWS);
+    if cap == 0 {
+        1
+    } else {
+        cap
+    }
+}
+
 impl SSTableReader {
     /// Batched streaming scan (issue #1592, Epic F/F2): the additive companion to
     /// [`scan_stream`](Self::scan_stream) whose channel item is a `Vec` BATCH of
@@ -74,9 +95,7 @@ impl SSTableReader {
         // The public channel carries BATCHES (see `batched_channel_capacity`,
         // which is the SINGLE definition of this sizing — the query-row stream's
         // exported read-ahead bound is derived from the same `const fn`).
-        let cap = crate::storage::sstable::reader::scan_stream_windowed::batched_channel_capacity(
-            buffer_size,
-        );
+        let cap = batched_channel_capacity(buffer_size);
         let (tx, rx) = mpsc::channel(cap);
         // Read-metric grain (issue #1701): identical rule to the per-row surface —
         // an `Acquire` scan is the top-level read OPERATION and is measured with

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -106,10 +106,7 @@ pub use point_compaction::SinglePartitionCompaction;
 // Token-range bound pushed into the Summary-guided streaming walk (issue #2413
 // Option A). Re-exported to the crate so the flight warm merge can construct one
 // from its `TokenFilter`.
-pub use summary_scan::{
-    QueryRowBatch, QueryRowStream, ScanTokenBound, QUERY_ROWS_MAX_READ_AHEAD_ROWS,
-    QUERY_ROWS_MAX_RESIDENT_ROWS,
-};
+pub use summary_scan::{QueryRowBatch, QueryRowStream, ScanTokenBound, QUERY_ROWS_MAX_READ_AHEAD};
 
 // Re-export the decompress-work counter so the sibling `scan_stream_windowed`
 // module (outside `data_access`) can increment it on the windowed-scan miss path

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -106,7 +106,10 @@ pub use point_compaction::SinglePartitionCompaction;
 // Token-range bound pushed into the Summary-guided streaming walk (issue #2413
 // Option A). Re-exported to the crate so the flight warm merge can construct one
 // from its `TokenFilter`.
-pub use summary_scan::{QueryRowBatch, QueryRowStream, ScanTokenBound};
+pub use summary_scan::{
+    QueryRowBatch, QueryRowStream, ScanTokenBound, QUERY_ROWS_MAX_READ_AHEAD_ROWS,
+    QUERY_ROWS_MAX_RESIDENT_ROWS,
+};
 
 // Re-export the decompress-work counter so the sibling `scan_stream_windowed`
 // module (outside `data_access`) can increment it on the windowed-scan miss path

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -1313,7 +1313,7 @@ mod tests {
 #[path = "per_row_scan_stream.rs"]
 mod per_row_scan_stream;
 
-// The BATCHED streaming scan (issue #1592), its issue-#3109 BTI dispatch, and the
-// channel-sizing `const fn` #3384's read-ahead bound derives from (epic #1116).
+// The BATCHED streaming scan (`scan_stream_batched`, issue #1592) and its issue-#3109
+// BTI dispatch — split out of this file for the same campsite reason (epic #1116).
 #[path = "batched_scan_stream.rs"]
 pub(super) mod batched_scan_stream;

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -1313,10 +1313,7 @@ mod tests {
 #[path = "per_row_scan_stream.rs"]
 mod per_row_scan_stream;
 
-// The BATCHED streaming scan (`scan_stream_batched`, issue #1592) and its issue-#3109
-// BTI dispatch — split out of this file for the same campsite reason (epic #1116).
-// `pub(super)`: `batched_channel_capacity` is the single definition of this
-// surface's channel sizing, and `summary_scan::query_rows` derives its exported
-// read-ahead bound from it (issue #3384).
+// The BATCHED streaming scan (issue #1592), its issue-#3109 BTI dispatch, and the
+// channel-sizing `const fn` #3384's read-ahead bound derives from (epic #1116).
 #[path = "batched_scan_stream.rs"]
 pub(super) mod batched_scan_stream;

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -1315,5 +1315,8 @@ mod per_row_scan_stream;
 
 // The BATCHED streaming scan (`scan_stream_batched`, issue #1592) and its issue-#3109
 // BTI dispatch — split out of this file for the same campsite reason (epic #1116).
+// `pub(super)`: `batched_channel_capacity` is the single definition of this
+// surface's channel sizing, and `summary_scan::query_rows` derives its exported
+// read-ahead bound from it (issue #3384).
 #[path = "batched_scan_stream.rs"]
-mod batched_scan_stream;
+pub(super) mod batched_scan_stream;

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
@@ -49,6 +49,8 @@ use crate::{Error, Result, RowKey};
 mod compressed_scan_window;
 /// Single-generation, token-scoped, pull-based query ROW stream (issue #3058).
 mod query_rows;
+/// Sizing constants + the derived read-ahead bounds (issue #3384).
+mod query_rows_bounds;
 pub use query_rows::{QueryRowBatch, QueryRowStream, QUERY_ROWS_MAX_READ_AHEAD};
 
 // COMBINED-INTERACTION regression for the #2876 read-intent split x the #2877

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
@@ -49,7 +49,9 @@ use crate::{Error, Result, RowKey};
 mod compressed_scan_window;
 /// Single-generation, token-scoped, pull-based query ROW stream (issue #3058).
 mod query_rows;
-pub use query_rows::{QueryRowBatch, QueryRowStream};
+pub use query_rows::{
+    QueryRowBatch, QueryRowStream, QUERY_ROWS_MAX_READ_AHEAD_ROWS, QUERY_ROWS_MAX_RESIDENT_ROWS,
+};
 
 // COMBINED-INTERACTION regression for the #2876 read-intent split x the #2877
 // coalescing window: every widened read this walk issues must land on the

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/mod.rs
@@ -49,9 +49,7 @@ use crate::{Error, Result, RowKey};
 mod compressed_scan_window;
 /// Single-generation, token-scoped, pull-based query ROW stream (issue #3058).
 mod query_rows;
-pub use query_rows::{
-    QueryRowBatch, QueryRowStream, QUERY_ROWS_MAX_READ_AHEAD_ROWS, QUERY_ROWS_MAX_RESIDENT_ROWS,
-};
+pub use query_rows::{QueryRowBatch, QueryRowStream, QUERY_ROWS_MAX_READ_AHEAD};
 
 // COMBINED-INTERACTION regression for the #2876 read-intent split x the #2877
 // coalescing window: every widened read this walk issues must land on the

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -105,6 +105,9 @@ use super::ScanTokenBound;
 use crate::storage::producer_fault::ProducerFault;
 use crate::storage::scan_cancel::ScanCancel;
 use crate::storage::sstable::reader::scan_stream_windowed::scan_admission::ScanAdmission;
+use crate::storage::sstable::reader::scan_stream_windowed::{
+    batched_channel_capacity, BATCH_EMIT_ROWS, MAX_INFLIGHT_BATCH_ROWS,
+};
 use crate::types::ScanRow;
 use crate::{Error, Result, RowKey};
 
@@ -113,10 +116,63 @@ use crate::{Error, Result, RowKey};
 /// handoff per batch instead of per row.
 const QUERY_ROWS_PER_BATCH: usize = 128;
 
-/// Batches the bounded handoff channel may hold. Resident rows are therefore
-/// bounded by `QUERY_ROWS_PER_BATCH * (QUERY_ROWS_CHANNEL_BATCHES + 1)` plus the
-/// partition currently being decoded — independent of table size.
+/// Batches the bounded handoff channel may hold. Resident rows on this channel
+/// are therefore bounded by [`QUERY_ROWS_MAX_RESIDENT_ROWS`] plus the partition
+/// currently being decoded — independent of table size.
 const QUERY_ROWS_CHANNEL_BATCHES: usize = 4;
+
+/// Rows the query-row handoff channel can hold in flight ahead of a consumer that
+/// has stopped reading — [`QUERY_ROWS_CHANNEL_BATCHES`] channel-resident batches
+/// plus the ONE batch a producer parked in `SyncSender::send` still owns (a
+/// blocked send moves the value only on success). The batch currently being
+/// accumulated is not a further term: once it reaches [`QUERY_ROWS_PER_BATCH`] it
+/// BECOMES the parked send, and a parked producer accumulates no further rows.
+///
+/// This bounds the HANDOFF CHANNEL ALONE. It is NOT the walk's read-ahead: the
+/// producer thread pulls from an inner batched scan stream that has bounded
+/// buffers of its own, so a cancelled or abandoned walk can decode up to
+/// [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] rows — not this many — after its consumer
+/// stops. Use that constant for "how far can an abandoned walk run"; use this one
+/// only when reasoning about the channel itself.
+pub const QUERY_ROWS_MAX_RESIDENT_ROWS: usize =
+    QUERY_ROWS_PER_BATCH * (QUERY_ROWS_CHANNEL_BATCHES + 1);
+
+/// `buffer_size` the full-ring arm ([`drive_full_scan_rows`]) hands to the inner
+/// batched scan stream. Named so [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] is derived
+/// from the SAME value the call site passes, never a restated copy of it.
+const QUERY_ROWS_FULL_SCAN_BUFFER_ROWS: usize = QUERY_ROWS_PER_BATCH * QUERY_ROWS_CHANNEL_BATCHES;
+
+/// Upper bound on the rows a [`QueryRowStream`] producer can decode AHEAD of its
+/// consumer — and therefore on how much work an ABANDONED or CANCELLED walk can
+/// still do after the consumer stops reading. A CONSTANT: it does not scale with
+/// the table, so a walk over a million partitions abandoned after one row decodes
+/// at most this many more rows, not the rest of the table.
+///
+/// Every term is a bounded buffer between the disk and the consumer, on the
+/// full-ring arm ([`drive_full_scan_rows`], the deepest of the two arms):
+///   1. [`QUERY_ROWS_MAX_RESIDENT_ROWS`] — this stream's handoff channel plus the
+///      producer's parked send.
+///   2. The inner batched scan stream's public channel:
+///      [`batched_channel_capacity`] batches of up to
+///      [`BATCH_EMIT_ROWS`] rows.
+///   3. The one inner batch [`drive_full_scan_rows`] has `recv`'d and still owns
+///      while parked handing it on (up to [`BATCH_EMIT_ROWS`] rows).
+///   4. [`MAX_INFLIGHT_BATCH_ROWS`] — the windowed scan's own batching subsystem
+///      (pending batch + bounded batch channel + producer parked in `send`).
+///
+/// # What it does NOT cover
+///
+/// * The ONE partition currently being decoded: the windowed scan materializes a
+///   confirmed partition in `scratch` before batching it, so a table with wide
+///   partitions adds a `max_partition_size` term on top (the pre-existing #1156
+///   term, see [`MAX_INFLIGHT_BATCH_ROWS`]'s docs).
+/// * Anything resident in the CONSUMER downstream of this stream — a Flight
+///   producer's own Arrow batches, for instance, are bounded by that consumer's
+///   own budget, not by this constant.
+pub const QUERY_ROWS_MAX_READ_AHEAD_ROWS: usize = QUERY_ROWS_MAX_RESIDENT_ROWS
+    + batched_channel_capacity(QUERY_ROWS_FULL_SCAN_BUFFER_ROWS) * BATCH_EMIT_ROWS
+    + BATCH_EMIT_ROWS
+    + MAX_INFLIGHT_BATCH_ROWS;
 
 /// One message from a [`QueryRowStream`].
 #[derive(Debug)]
@@ -631,7 +687,7 @@ async fn drive_full_scan_rows(
         None,
         None,
         Some(schema),
-        QUERY_ROWS_PER_BATCH * QUERY_ROWS_CHANNEL_BATCHES,
+        QUERY_ROWS_FULL_SCAN_BUFFER_ROWS,
         ScanAdmission::Exempt,
         Some(now_secs),
     );

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -125,9 +125,10 @@ const QUERY_ROWS_CHANNEL_BATCHES: usize = 4;
 /// Rows the query-row handoff channel can hold in flight ahead of a consumer that
 /// has stopped reading — [`QUERY_ROWS_CHANNEL_BATCHES`] channel-resident batches
 /// plus the ONE batch a producer parked in `SyncSender::send` still owns (a
-/// blocked send moves the value only on success). The batch currently being
-/// accumulated is not a further term: once it reaches [`QUERY_ROWS_PER_BATCH`] it
-/// BECOMES the parked send, and a parked producer accumulates no further rows.
+/// blocked send moves the value only on success), each of at most
+/// [`QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS`] rows. The batch currently being
+/// accumulated is not a further term: once it reaches that size it BECOMES the
+/// parked send, and a parked producer accumulates no further rows.
 ///
 /// Crate-internal (`pub` for its doc links, not re-exported to the crate root):
 /// the bound OUTSIDE callers need is [`QUERY_ROWS_MAX_READ_AHEAD`].
@@ -139,7 +140,27 @@ const QUERY_ROWS_CHANNEL_BATCHES: usize = 4;
 /// stops. Use that constant for "how far can an abandoned walk run"; use this one
 /// only when reasoning about the channel itself.
 pub const QUERY_ROWS_MAX_RESIDENT_ROWS: usize =
-    QUERY_ROWS_PER_BATCH * (QUERY_ROWS_CHANNEL_BATCHES + 1);
+    QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS * (QUERY_ROWS_CHANNEL_BATCHES + 1);
+
+/// The largest batch either arm can put on the handoff channel.
+///
+/// The two arms size their batches DIFFERENTLY, and taking the smaller of the two
+/// is how the exported read-ahead bound came to understate the full-ring arm by
+/// a factor of two (roborev, issue #3384):
+///
+/// * the token-bounded arm accumulates through [`BatchSink`] and emits at
+///   [`QUERY_ROWS_PER_BATCH`] (128) rows;
+/// * the full-ring arm ([`drive_full_scan_rows`]) does NOT re-chunk — `emit_rows`
+///   forwards the inner batched scan stream's batch VERBATIM, and those are capped
+///   at [`BATCH_EMIT_ROWS`] (256).
+///
+/// A bound that must hold on BOTH arms therefore has to use the MAXIMUM, not
+/// either arm's own figure.
+const QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS: usize = if BATCH_EMIT_ROWS > QUERY_ROWS_PER_BATCH {
+    BATCH_EMIT_ROWS
+} else {
+    QUERY_ROWS_PER_BATCH
+};
 
 /// `buffer_size` the full-ring arm ([`drive_full_scan_rows`]) hands to the inner
 /// batched scan stream. Named so [`QUERY_ROWS_MAX_READ_AHEAD`] is derived
@@ -173,6 +194,17 @@ const QUERY_ROWS_FULL_SCAN_BUFFER_ROWS: usize = QUERY_ROWS_PER_BATCH * QUERY_ROW
 /// * Anything resident in the CONSUMER downstream of this stream — a Flight
 ///   producer's own Arrow batches, for instance, are bounded by that consumer's
 ///   own budget, not by this constant.
+/// * **Regions that decode to NO emitted rows.** This is a PRECONDITION, not a
+///   footnote (roborev, issue #3384). The full-ring arm observes cancellation
+///   only BETWEEN batches it receives from the inner scan, because
+///   `scan_stream_batched_admitted` is not handed the child cancel flag and does
+///   not poll one internally. So the bound holds while decoded partitions keep
+///   YIELDING rows — every decoded partition then pushes the channel toward the
+///   parked state in which cancellation is observed. Over a stretch that survives
+///   nothing (all tombstoned, or all TTL-expired at the read clock) the inner scan
+///   emits no batch, the producer never parks, and it can decode past this bound —
+///   in the limit, to the end of the table. Tracked as a real cancellation gap in
+///   the read path, NOT merely a documentation caveat: see issue #3428.
 pub const QUERY_ROWS_MAX_READ_AHEAD: usize = QUERY_ROWS_MAX_RESIDENT_ROWS
     + batched_channel_capacity(QUERY_ROWS_FULL_SCAN_BUFFER_ROWS) * BATCH_EMIT_ROWS
     + BATCH_EMIT_ROWS

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -354,14 +354,14 @@ impl SSTableReader {
                     Ok(Err(e)) => QueryRowMsg::Failed(e),
                     Err(panic) => QueryRowMsg::Failed(panicked_producer_error(panic.as_ref())),
                 };
+                // CAUSAL completion signal (issue #3384), published BEFORE the
+                // terminal message and never after (roborev): a consumer holding
+                // the terminal message must be able to conclude this producer can
+                // no longer publish, or a PRIOR case's producer could increment
+                // into a LATER case's freshly-reset counter. Nothing below decodes.
+                crate::storage::read_path_probe::mark_query_row_producer_finished();
                 // The consumer may already be gone; a failed send is fine.
                 let _ = sender.send(terminal);
-                // CAUSAL completion signal (issue #3384). Incremented LAST, after
-                // the terminal message, so an observer that sees it knows this
-                // producer decoded its final row: "the counter stopped moving" is
-                // a sample of another thread and cannot distinguish stopped from
-                // merely descheduled.
-                crate::storage::sstable::work_counters::add_query_row_producer_finished();
             })
             .map_err(|e| {
                 Error::Storage(format!("query row stream: failed to spawn thread: {e}"))

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -129,21 +129,24 @@ const QUERY_ROWS_CHANNEL_BATCHES: usize = 4;
 /// accumulated is not a further term: once it reaches [`QUERY_ROWS_PER_BATCH`] it
 /// BECOMES the parked send, and a parked producer accumulates no further rows.
 ///
+/// Crate-internal (`pub` for its doc links, not re-exported to the crate root):
+/// the bound OUTSIDE callers need is [`QUERY_ROWS_MAX_READ_AHEAD`].
+///
 /// This bounds the HANDOFF CHANNEL ALONE. It is NOT the walk's read-ahead: the
 /// producer thread pulls from an inner batched scan stream that has bounded
 /// buffers of its own, so a cancelled or abandoned walk can decode up to
-/// [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] rows — not this many — after its consumer
+/// [`QUERY_ROWS_MAX_READ_AHEAD`] rows — not this many — after its consumer
 /// stops. Use that constant for "how far can an abandoned walk run"; use this one
 /// only when reasoning about the channel itself.
 pub const QUERY_ROWS_MAX_RESIDENT_ROWS: usize =
     QUERY_ROWS_PER_BATCH * (QUERY_ROWS_CHANNEL_BATCHES + 1);
 
 /// `buffer_size` the full-ring arm ([`drive_full_scan_rows`]) hands to the inner
-/// batched scan stream. Named so [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] is derived
+/// batched scan stream. Named so [`QUERY_ROWS_MAX_READ_AHEAD`] is derived
 /// from the SAME value the call site passes, never a restated copy of it.
 const QUERY_ROWS_FULL_SCAN_BUFFER_ROWS: usize = QUERY_ROWS_PER_BATCH * QUERY_ROWS_CHANNEL_BATCHES;
 
-/// Upper bound on the rows a [`QueryRowStream`] producer can decode AHEAD of its
+/// Upper bound, IN ROWS, on what a [`QueryRowStream`] producer can decode AHEAD of its
 /// consumer — and therefore on how much work an ABANDONED or CANCELLED walk can
 /// still do after the consumer stops reading. A CONSTANT: it does not scale with
 /// the table, so a walk over a million partitions abandoned after one row decodes
@@ -170,7 +173,7 @@ const QUERY_ROWS_FULL_SCAN_BUFFER_ROWS: usize = QUERY_ROWS_PER_BATCH * QUERY_ROW
 /// * Anything resident in the CONSUMER downstream of this stream — a Flight
 ///   producer's own Arrow batches, for instance, are bounded by that consumer's
 ///   own budget, not by this constant.
-pub const QUERY_ROWS_MAX_READ_AHEAD_ROWS: usize = QUERY_ROWS_MAX_RESIDENT_ROWS
+pub const QUERY_ROWS_MAX_READ_AHEAD: usize = QUERY_ROWS_MAX_RESIDENT_ROWS
     + batched_channel_capacity(QUERY_ROWS_FULL_SCAN_BUFFER_ROWS) * BATCH_EMIT_ROWS
     + BATCH_EMIT_ROWS
     + MAX_INFLIGHT_BATCH_ROWS;

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -101,12 +101,13 @@ use std::sync::Arc;
 
 use super::super::super::SSTableReader;
 use super::super::full_index_stream::FullIndexStreamOutcome;
+use super::super::sequential::batched_scan_stream::batched_channel_capacity;
 use super::ScanTokenBound;
 use crate::storage::producer_fault::ProducerFault;
 use crate::storage::scan_cancel::ScanCancel;
 use crate::storage::sstable::reader::scan_stream_windowed::scan_admission::ScanAdmission;
 use crate::storage::sstable::reader::scan_stream_windowed::{
-    batched_channel_capacity, BATCH_EMIT_ROWS, MAX_INFLIGHT_BATCH_ROWS,
+    BATCH_EMIT_ROWS, MAX_INFLIGHT_BATCH_ROWS,
 };
 use crate::types::ScanRow;
 use crate::{Error, Result, RowKey};

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -101,114 +101,19 @@ use std::sync::Arc;
 
 use super::super::super::SSTableReader;
 use super::super::full_index_stream::FullIndexStreamOutcome;
-use super::super::sequential::batched_scan_stream::batched_channel_capacity;
+use super::query_rows_bounds::{
+    QUERY_ROWS_CHANNEL_BATCHES, QUERY_ROWS_FULL_SCAN_BUFFER_ROWS, QUERY_ROWS_PER_BATCH,
+};
 use super::ScanTokenBound;
 use crate::storage::producer_fault::ProducerFault;
 use crate::storage::scan_cancel::ScanCancel;
 use crate::storage::sstable::reader::scan_stream_windowed::scan_admission::ScanAdmission;
-use crate::storage::sstable::reader::scan_stream_windowed::{
-    BATCH_EMIT_ROWS, MAX_INFLIGHT_BATCH_ROWS,
-};
+// Re-exported so `summary_scan::query_rows::QUERY_ROWS_MAX_READ_AHEAD` keeps
+// resolving after the sizing constants moved to their own file (issue #3384).
+#[allow(unused_imports)]
+pub use super::query_rows_bounds::{QUERY_ROWS_MAX_READ_AHEAD, QUERY_ROWS_MAX_RESIDENT_ROWS};
 use crate::types::ScanRow;
 use crate::{Error, Result, RowKey};
-
-/// Rows accumulated before a batch is handed to the consumer. Matches the
-/// batched scan surface's emit granularity (issue #1592): one cross-thread
-/// handoff per batch instead of per row.
-const QUERY_ROWS_PER_BATCH: usize = 128;
-
-/// Batches the bounded handoff channel may hold. Resident rows on this channel
-/// are therefore bounded by [`QUERY_ROWS_MAX_RESIDENT_ROWS`] plus the partition
-/// currently being decoded — independent of table size.
-const QUERY_ROWS_CHANNEL_BATCHES: usize = 4;
-
-/// Rows the query-row handoff channel can hold in flight ahead of a consumer that
-/// has stopped reading — [`QUERY_ROWS_CHANNEL_BATCHES`] channel-resident batches
-/// plus the ONE batch a producer parked in `SyncSender::send` still owns (a
-/// blocked send moves the value only on success), each of at most
-/// [`QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS`] rows. The batch currently being
-/// accumulated is not a further term: once it reaches that size it BECOMES the
-/// parked send, and a parked producer accumulates no further rows.
-///
-/// Crate-internal (`pub` for its doc links, not re-exported to the crate root):
-/// the bound OUTSIDE callers need is [`QUERY_ROWS_MAX_READ_AHEAD`].
-///
-/// This bounds the HANDOFF CHANNEL ALONE. It is NOT the walk's read-ahead: the
-/// producer thread pulls from an inner batched scan stream that has bounded
-/// buffers of its own, so a cancelled or abandoned walk can decode up to
-/// [`QUERY_ROWS_MAX_READ_AHEAD`] rows — not this many — after its consumer
-/// stops. Use that constant for "how far can an abandoned walk run"; use this one
-/// only when reasoning about the channel itself.
-pub const QUERY_ROWS_MAX_RESIDENT_ROWS: usize =
-    QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS * (QUERY_ROWS_CHANNEL_BATCHES + 1);
-
-/// The largest batch either arm can put on the handoff channel.
-///
-/// The two arms size their batches DIFFERENTLY, and taking the smaller of the two
-/// is how the exported read-ahead bound came to understate the full-ring arm by
-/// a factor of two (roborev, issue #3384):
-///
-/// * the token-bounded arm accumulates through [`BatchSink`] and emits at
-///   [`QUERY_ROWS_PER_BATCH`] (128) rows;
-/// * the full-ring arm ([`drive_full_scan_rows`]) does NOT re-chunk — `emit_rows`
-///   forwards the inner batched scan stream's batch VERBATIM, and those are capped
-///   at [`BATCH_EMIT_ROWS`] (256).
-///
-/// A bound that must hold on BOTH arms therefore has to use the MAXIMUM, not
-/// either arm's own figure.
-const QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS: usize = if BATCH_EMIT_ROWS > QUERY_ROWS_PER_BATCH {
-    BATCH_EMIT_ROWS
-} else {
-    QUERY_ROWS_PER_BATCH
-};
-
-/// `buffer_size` the full-ring arm ([`drive_full_scan_rows`]) hands to the inner
-/// batched scan stream. Named so [`QUERY_ROWS_MAX_READ_AHEAD`] is derived
-/// from the SAME value the call site passes, never a restated copy of it.
-const QUERY_ROWS_FULL_SCAN_BUFFER_ROWS: usize = QUERY_ROWS_PER_BATCH * QUERY_ROWS_CHANNEL_BATCHES;
-
-/// Upper bound, IN ROWS, on what a [`QueryRowStream`] producer can decode AHEAD of its
-/// consumer — and therefore on how much work an ABANDONED or CANCELLED walk can
-/// still do after the consumer stops reading. A CONSTANT: it does not scale with
-/// the table, so a walk over a million partitions abandoned after one row decodes
-/// at most this many more rows, not the rest of the table.
-///
-/// Every term is a bounded buffer between the disk and the consumer, on the
-/// full-ring arm ([`drive_full_scan_rows`], the deepest of the two arms):
-///   1. [`QUERY_ROWS_MAX_RESIDENT_ROWS`] — this stream's handoff channel plus the
-///      producer's parked send.
-///   2. The inner batched scan stream's public channel:
-///      [`batched_channel_capacity`] batches of up to
-///      [`BATCH_EMIT_ROWS`] rows.
-///   3. The one inner batch [`drive_full_scan_rows`] has `recv`'d and still owns
-///      while parked handing it on (up to [`BATCH_EMIT_ROWS`] rows).
-///   4. [`MAX_INFLIGHT_BATCH_ROWS`] — the windowed scan's own batching subsystem
-///      (pending batch + bounded batch channel + producer parked in `send`).
-///
-/// # What it does NOT cover
-///
-/// * The ONE partition currently being decoded: the windowed scan materializes a
-///   confirmed partition in `scratch` before batching it, so a table with wide
-///   partitions adds a `max_partition_size` term on top (the pre-existing #1156
-///   term, see [`MAX_INFLIGHT_BATCH_ROWS`]'s docs).
-/// * Anything resident in the CONSUMER downstream of this stream — a Flight
-///   producer's own Arrow batches, for instance, are bounded by that consumer's
-///   own budget, not by this constant.
-/// * **Regions that decode to NO emitted rows.** This is a PRECONDITION, not a
-///   footnote (roborev, issue #3384). The full-ring arm observes cancellation
-///   only BETWEEN batches it receives from the inner scan, because
-///   `scan_stream_batched_admitted` is not handed the child cancel flag and does
-///   not poll one internally. So the bound holds while decoded partitions keep
-///   YIELDING rows — every decoded partition then pushes the channel toward the
-///   parked state in which cancellation is observed. Over a stretch that survives
-///   nothing (all tombstoned, or all TTL-expired at the read clock) the inner scan
-///   emits no batch, the producer never parks, and it can decode past this bound —
-///   in the limit, to the end of the table. Tracked as a real cancellation gap in
-///   the read path, NOT merely a documentation caveat: see issue #3428.
-pub const QUERY_ROWS_MAX_READ_AHEAD: usize = QUERY_ROWS_MAX_RESIDENT_ROWS
-    + batched_channel_capacity(QUERY_ROWS_FULL_SCAN_BUFFER_ROWS) * BATCH_EMIT_ROWS
-    + BATCH_EMIT_ROWS
-    + MAX_INFLIGHT_BATCH_ROWS;
 
 /// One message from a [`QueryRowStream`].
 #[derive(Debug)]
@@ -451,6 +356,12 @@ impl SSTableReader {
                 };
                 // The consumer may already be gone; a failed send is fine.
                 let _ = sender.send(terminal);
+                // CAUSAL completion signal (issue #3384). Incremented LAST, after
+                // the terminal message, so an observer that sees it knows this
+                // producer decoded its final row: "the counter stopped moving" is
+                // a sample of another thread and cannot distinguish stopped from
+                // merely descheduled.
+                crate::storage::sstable::work_counters::add_query_row_producer_finished();
             })
             .map_err(|e| {
                 Error::Storage(format!("query row stream: failed to spawn thread: {e}"))

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows.rs
@@ -316,6 +316,8 @@ impl SSTableReader {
         // a production build.
         let mut fault =
             crate::storage::producer_fault::ProducerFault::capture_for(|| self.file_path());
+        // One publisher per producer thread; see `CompletionOnce` (issue #3384).
+        let mut done = CompletionOnce::new();
         std::thread::Builder::new()
             .name("cqlite-query-rows".to_string())
             .spawn(move || {
@@ -345,6 +347,7 @@ impl SSTableReader {
                             &bridge,
                             &tx,
                             &mut fault,
+                            &mut done,
                         ))
                     }));
                 // EXACTLY ONE terminal message on every exit path, so the
@@ -359,7 +362,7 @@ impl SSTableReader {
                 // the terminal message must be able to conclude this producer can
                 // no longer publish, or a PRIOR case's producer could increment
                 // into a LATER case's freshly-reset counter. Nothing below decodes.
-                crate::storage::read_path_probe::mark_query_row_producer_finished();
+                done.publish();
                 // The consumer may already be gone; a failed send is fine.
                 let _ = sender.send(terminal);
             })
@@ -473,6 +476,7 @@ async fn drive_query_rows(
     cancel: &CancelBridge,
     tx: &SyncSender<QueryRowMsg>,
     fault: &mut ProducerFault,
+    done: &mut CompletionOnce,
 ) -> Result<()> {
     if token_bound.is_none() {
         return drive_full_scan_rows(reader, schema, now_secs, cancel, tx, fault).await;
@@ -522,8 +526,40 @@ async fn drive_query_rows(
     // Neither walk can serve this reader. Report it as the FIRST and ONLY
     // message, having emitted nothing — enforced, for the same reason.
     assert_nothing_emitted(sink.emitted, "before reporting Unsupported")?;
+    // Publish BEFORE the send: the documented caller drops the stream the moment it
+    // sees `Unsupported`, so this message is terminal in practice even though the
+    // closure still sends `Done` behind it (roborev, issue #3384).
+    done.publish();
     let _ = tx.send(QueryRowMsg::Item(QueryRowBatch::Unsupported));
     Ok(())
+}
+
+/// Publishes producer completion EXACTLY ONCE, and always BEFORE any message a
+/// consumer can act on as terminal (issue #3384, roborev).
+///
+/// The invariant this exists to hold: **no consumer-observable terminal message may
+/// precede the completion publish.** If one does, the consumer can drop the stream,
+/// its test can finish and a LATER test can `reset` the counter, and only then does
+/// the paused producer increment — so the later test observes a completion that was
+/// never its own and reads a non-final work count. That is a false PASS in the exact
+/// test this issue exists to make trustworthy.
+///
+/// Two exit paths publish, hence the idempotence: the `Unsupported` report inside
+/// [`drive_query_rows`], and the producer closure's terminal `Done`/`Failed`. A
+/// producer that takes the first still reaches the second.
+struct CompletionOnce(bool);
+
+impl CompletionOnce {
+    const fn new() -> Self {
+        Self(false)
+    }
+
+    fn publish(&mut self) {
+        if !self.0 {
+            self.0 = true;
+            crate::storage::read_path_probe::mark_query_row_producer_finished();
+        }
+    }
 }
 
 /// Hand ONE batch of rows to the consumer, returning `false` when the consumer

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_bounds.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_bounds.rs
@@ -1,0 +1,125 @@
+//! Sizing constants for [`QueryRowStream`](super::QueryRowStream) and the
+//! read-ahead bounds derived from them (issue #3384).
+//!
+//! Split out of `query_rows.rs` under the campsite rule (epic #1116): the
+//! derivation below is mostly PROSE — four buffer terms, a precondition, and the
+//! record of how the bound was once wrong — and it pushed the driver file over
+//! the 800-line threshold. Keeping it beside the driver would mean either
+//! deleting the reasoning or growing an over-threshold file, and the reasoning is
+//! the part that stops the bound silently going wrong again.
+//!
+//! Everything here is `const`; there is no behaviour in this file.
+
+use super::super::super::scan_stream_windowed::{BATCH_EMIT_ROWS, MAX_INFLIGHT_BATCH_ROWS};
+use super::super::sequential::batched_scan_stream::batched_channel_capacity;
+
+/// Rows accumulated before a batch is handed to the consumer. Matches the
+/// batched scan surface's emit granularity (issue #1592): one cross-thread
+/// handoff per batch instead of per row.
+pub(crate) const QUERY_ROWS_PER_BATCH: usize = 128;
+
+/// Batches the bounded handoff channel may hold. Resident rows on this channel
+/// are therefore bounded by [`QUERY_ROWS_MAX_RESIDENT_ROWS`] plus the partition
+/// currently being decoded — independent of table size.
+pub(crate) const QUERY_ROWS_CHANNEL_BATCHES: usize = 4;
+
+/// Rows the query-row handoff channel can hold in flight ahead of a consumer that
+/// has stopped reading — [`QUERY_ROWS_CHANNEL_BATCHES`] channel-resident batches
+/// plus the ONE batch a producer parked in `SyncSender::send` still owns (a
+/// blocked send moves the value only on success), each of at most
+/// [`QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS`] rows. The batch currently being
+/// accumulated is not a further term: once it reaches that size it BECOMES the
+/// parked send, and a parked producer accumulates no further rows.
+///
+/// Crate-internal (`pub` for its doc links, not re-exported to the crate root):
+/// the bound OUTSIDE callers need is [`QUERY_ROWS_MAX_READ_AHEAD`].
+///
+/// This bounds the HANDOFF CHANNEL ALONE. It is NOT the walk's read-ahead: the
+/// producer thread pulls from an inner batched scan stream that has bounded
+/// buffers of its own, so a cancelled or abandoned walk can decode up to
+/// [`QUERY_ROWS_MAX_READ_AHEAD`] rows — not this many — after its consumer
+/// stops. Use that constant for "how far can an abandoned walk run"; use this one
+/// only when reasoning about the channel itself.
+pub const QUERY_ROWS_MAX_RESIDENT_ROWS: usize =
+    QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS * (QUERY_ROWS_CHANNEL_BATCHES + 1);
+
+/// The largest batch either arm can put on the handoff channel.
+///
+/// The two arms size their batches DIFFERENTLY, and taking the smaller of the two
+/// is how the exported read-ahead bound came to understate the full-ring arm by
+/// a factor of two (roborev, issue #3384):
+///
+/// * the token-bounded arm accumulates through [`BatchSink`] and emits at
+///   [`QUERY_ROWS_PER_BATCH`] (128) rows;
+/// * the full-ring arm ([`drive_full_scan_rows`]) does NOT re-chunk — `emit_rows`
+///   forwards the inner batched scan stream's batch VERBATIM, and those are capped
+///   at [`BATCH_EMIT_ROWS`] (256).
+///
+/// A bound that must hold on BOTH arms therefore has to use the MAXIMUM, not
+/// either arm's own figure.
+pub(crate) const QUERY_ROWS_MAX_HANDOFF_BATCH_ROWS: usize =
+    if BATCH_EMIT_ROWS > QUERY_ROWS_PER_BATCH {
+        BATCH_EMIT_ROWS
+    } else {
+        QUERY_ROWS_PER_BATCH
+    };
+
+/// `buffer_size` the full-ring arm ([`drive_full_scan_rows`]) hands to the inner
+/// batched scan stream. Named so [`QUERY_ROWS_MAX_READ_AHEAD`] is derived
+/// from the SAME value the call site passes, never a restated copy of it.
+pub(crate) const QUERY_ROWS_FULL_SCAN_BUFFER_ROWS: usize =
+    QUERY_ROWS_PER_BATCH * QUERY_ROWS_CHANNEL_BATCHES;
+
+/// Upper bound, IN ROWS, on what a [`QueryRowStream`] producer can decode AHEAD of its
+/// consumer — and therefore on how much work an ABANDONED or CANCELLED walk can
+/// still do after the consumer stops reading. A CONSTANT: it does not scale with
+/// the table, so a walk over a million partitions abandoned after one row decodes
+/// at most this many more rows, not the rest of the table.
+///
+/// Every term is a bounded buffer between the disk and the consumer, on the
+/// full-ring arm ([`drive_full_scan_rows`], the deepest of the two arms):
+///   1. [`QUERY_ROWS_MAX_RESIDENT_ROWS`] — this stream's handoff channel plus the
+///      producer's parked send.
+///   2. The inner batched scan stream's public channel:
+///      [`batched_channel_capacity`] batches of up to
+///      [`BATCH_EMIT_ROWS`] rows.
+///   3. The one inner batch [`drive_full_scan_rows`] has `recv`'d and still owns
+///      while parked handing it on (up to [`BATCH_EMIT_ROWS`] rows).
+///   4. [`MAX_INFLIGHT_BATCH_ROWS`] — the windowed scan's own batching subsystem
+///      (pending batch + bounded batch channel + producer parked in `send`).
+///
+/// # What it does NOT cover
+///
+/// * The ONE partition currently being decoded: the windowed scan materializes a
+///   confirmed partition in `scratch` before batching it, so a table with wide
+///   partitions adds a `max_partition_size` term on top (the pre-existing #1156
+///   term, see [`MAX_INFLIGHT_BATCH_ROWS`]'s docs).
+/// * Anything resident in the CONSUMER downstream of this stream — a Flight
+///   producer's own Arrow batches, for instance, are bounded by that consumer's
+///   own budget, not by this constant.
+/// * **Regions that decode to NO emitted rows.** This is a PRECONDITION, not a
+///   footnote (roborev, issue #3384). The full-ring arm observes cancellation
+///   only BETWEEN batches it receives from the inner scan, because
+///   `scan_stream_batched_admitted` is not handed the child cancel flag and does
+///   not poll one internally. So the bound holds while decoded partitions keep
+///   YIELDING rows — every decoded partition then pushes the channel toward the
+///   parked state in which cancellation is observed. Over a stretch that survives
+///   nothing (all tombstoned, or all TTL-expired at the read clock) the inner scan
+///   emits no batch, the producer never parks, and it can decode past this bound —
+///   in the limit, to the end of the table. Tracked as a real cancellation gap in
+///   the read path, NOT merely a documentation caveat: see issue #3428.
+/// * **Eager materialization inside a single decode step.** The bound counts rows
+///   RESIDENT IN THE PIPELINE'S BOUNDED BUFFERS, and the work probe it is asserted
+///   against (`work_counters::stream_walk_partitions_parsed`) advances as entries
+///   are ITERATED — which is backpressured, hence bounded. It does NOT bound work
+///   done eagerly *inside* one step before any iteration begins (roborev, issue
+///   #3384): `parse_batched_block` materializes a whole block's entries at once,
+///   and for a format whose data section is one block that is the whole table;
+///   `bti_scan_with_metadata` on the `da` path is materializing too. So read this
+///   constant as *"rows that can be handed onward after the consumer leaves"*, not
+///   as *"CPU and memory an abandoned walk can still spend"*. The two coincide on
+///   the incremental block-iteration path and diverge on the materializing ones.
+pub const QUERY_ROWS_MAX_READ_AHEAD: usize = QUERY_ROWS_MAX_RESIDENT_ROWS
+    + batched_channel_capacity(QUERY_ROWS_FULL_SCAN_BUFFER_ROWS) * BATCH_EMIT_ROWS
+    + BATCH_EMIT_ROWS
+    + MAX_INFLIGHT_BATCH_ROWS;

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
@@ -244,3 +244,62 @@ fn the_cancel_bridge_is_one_way() {
         "and is propagated into the child so the walk aborts promptly"
     );
 }
+
+/// The exported read-ahead bounds must stay DERIVED from the buffer sizes that
+/// actually run — never a hand-maintained literal (issue #3384).
+///
+/// This is the regression pin for the whole point of the constants: an integration
+/// test sizes its fixture as a multiple of [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] so
+/// "the abandoned walk stopped early" is structural rather than scheduling luck.
+/// Were a buffer sizing change to leave the constant behind, that test would
+/// silently go back to asserting a coin flip, so each term is pinned here against
+/// the sizing it comes from.
+#[test]
+fn the_exported_read_ahead_bounds_are_derived_from_the_real_buffer_sizes() {
+    assert_eq!(
+        QUERY_ROWS_MAX_RESIDENT_ROWS,
+        QUERY_ROWS_PER_BATCH * (QUERY_ROWS_CHANNEL_BATCHES + 1),
+        "the handoff-channel bound is channel-resident batches + the parked send"
+    );
+    assert_eq!(
+        QUERY_ROWS_FULL_SCAN_BUFFER_ROWS,
+        QUERY_ROWS_PER_BATCH * QUERY_ROWS_CHANNEL_BATCHES,
+        "the full-ring arm's inner buffer_size must stay the value \
+         `drive_full_scan_rows` passes"
+    );
+    assert_eq!(
+        QUERY_ROWS_MAX_READ_AHEAD_ROWS,
+        QUERY_ROWS_MAX_RESIDENT_ROWS
+            + batched_channel_capacity(QUERY_ROWS_FULL_SCAN_BUFFER_ROWS) * BATCH_EMIT_ROWS
+            + BATCH_EMIT_ROWS
+            + MAX_INFLIGHT_BATCH_ROWS,
+        "the walk's read-ahead is the SUM of every bounded buffer between disk \
+         and consumer; see the constant's doc for the four terms"
+    );
+    // The walk's read-ahead STRICTLY exceeds the handoff channel's own bound —
+    // the property that makes using the wrong one of the two a real error rather
+    // than a stylistic one.
+    assert!(
+        QUERY_ROWS_MAX_READ_AHEAD_ROWS > QUERY_ROWS_MAX_RESIDENT_ROWS,
+        "read-ahead {QUERY_ROWS_MAX_READ_AHEAD_ROWS} must exceed the handoff \
+         channel's {QUERY_ROWS_MAX_RESIDENT_ROWS}"
+    );
+}
+
+/// The channel sizing helper the read-ahead bound is derived from is the SAME
+/// definition the batched scan stream's constructor uses, so it must behave like
+/// `ceil` with a floor of one batch — a zero-capacity `mpsc::channel` would panic
+/// at the constructor, and a capacity that over-states the real channel would
+/// over-state the read-ahead bound.
+#[test]
+fn the_batched_channel_capacity_helper_is_ceil_with_a_one_batch_floor() {
+    assert_eq!(batched_channel_capacity(0), 1, "never zero-capacity");
+    assert_eq!(batched_channel_capacity(1), 1);
+    assert_eq!(batched_channel_capacity(BATCH_EMIT_ROWS), 1);
+    assert_eq!(
+        batched_channel_capacity(BATCH_EMIT_ROWS + 1),
+        2,
+        "ceil, not floor"
+    );
+    assert_eq!(batched_channel_capacity(4 * BATCH_EMIT_ROWS), 4);
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
@@ -256,10 +256,23 @@ fn the_cancel_bridge_is_one_way() {
 /// the sizing it comes from.
 #[test]
 fn the_exported_read_ahead_bounds_are_derived_from_the_real_buffer_sizes() {
+    // The batch size here is the MAXIMUM of the two arms', not either arm's own
+    // (roborev, issue #3384): the token-bounded arm re-chunks to
+    // QUERY_ROWS_PER_BATCH, but the full-ring arm forwards the inner stream's
+    // BATCH_EMIT_ROWS-capped batches verbatim, and a bound that must hold on both
+    // has to assume the larger. Using QUERY_ROWS_PER_BATCH here is what made the
+    // exported bound understate the full-ring arm by a factor of two.
+    let max_handoff_batch = BATCH_EMIT_ROWS.max(QUERY_ROWS_PER_BATCH);
     assert_eq!(
         QUERY_ROWS_MAX_RESIDENT_ROWS,
-        QUERY_ROWS_PER_BATCH * (QUERY_ROWS_CHANNEL_BATCHES + 1),
-        "the handoff-channel bound is channel-resident batches + the parked send"
+        max_handoff_batch * (QUERY_ROWS_CHANNEL_BATCHES + 1),
+        "the handoff-channel bound is channel-resident batches + the parked send, \
+         each sized by the LARGER arm's batch"
+    );
+    assert!(
+        max_handoff_batch >= BATCH_EMIT_ROWS,
+        "the full-ring arm forwards BATCH_EMIT_ROWS-sized batches unchanged, so the \
+         handoff term can never be smaller than one of them"
     );
     assert_eq!(
         QUERY_ROWS_FULL_SCAN_BUFFER_ROWS,

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
@@ -8,6 +8,16 @@
 //! `QueryRowStream`'s fields) directly.
 
 use super::*;
+// The sizing constants live in `query_rows_bounds.rs` (issue #3384), not in the
+// parent module, so `use super::*` does not reach them.
+use super::super::query_rows_bounds::{
+    QUERY_ROWS_CHANNEL_BATCHES, QUERY_ROWS_FULL_SCAN_BUFFER_ROWS, QUERY_ROWS_MAX_READ_AHEAD,
+    QUERY_ROWS_MAX_RESIDENT_ROWS, QUERY_ROWS_PER_BATCH,
+};
+use crate::storage::sstable::reader::data_access::sequential::batched_scan_stream::batched_channel_capacity;
+use crate::storage::sstable::reader::scan_stream_windowed::{
+    BATCH_EMIT_ROWS, MAX_INFLIGHT_BATCH_ROWS,
+};
 
 /// Build a `QueryRowStream` around a raw channel so the CONSUMER half of the
 /// #3106 protocol can be asserted in isolation, including the case a real

--- a/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/summary_scan/query_rows_tests.rs
@@ -249,7 +249,7 @@ fn the_cancel_bridge_is_one_way() {
 /// actually run — never a hand-maintained literal (issue #3384).
 ///
 /// This is the regression pin for the whole point of the constants: an integration
-/// test sizes its fixture as a multiple of [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] so
+/// test sizes its fixture as a multiple of [`QUERY_ROWS_MAX_READ_AHEAD`] so
 /// "the abandoned walk stopped early" is structural rather than scheduling luck.
 /// Were a buffer sizing change to leave the constant behind, that test would
 /// silently go back to asserting a coin flip, so each term is pinned here against
@@ -268,7 +268,7 @@ fn the_exported_read_ahead_bounds_are_derived_from_the_real_buffer_sizes() {
          `drive_full_scan_rows` passes"
     );
     assert_eq!(
-        QUERY_ROWS_MAX_READ_AHEAD_ROWS,
+        QUERY_ROWS_MAX_READ_AHEAD,
         QUERY_ROWS_MAX_RESIDENT_ROWS
             + batched_channel_capacity(QUERY_ROWS_FULL_SCAN_BUFFER_ROWS) * BATCH_EMIT_ROWS
             + BATCH_EMIT_ROWS
@@ -280,8 +280,8 @@ fn the_exported_read_ahead_bounds_are_derived_from_the_real_buffer_sizes() {
     // the property that makes using the wrong one of the two a real error rather
     // than a stylistic one.
     assert!(
-        QUERY_ROWS_MAX_READ_AHEAD_ROWS > QUERY_ROWS_MAX_RESIDENT_ROWS,
-        "read-ahead {QUERY_ROWS_MAX_READ_AHEAD_ROWS} must exceed the handoff \
+        QUERY_ROWS_MAX_READ_AHEAD > QUERY_ROWS_MAX_RESIDENT_ROWS,
+        "read-ahead {QUERY_ROWS_MAX_READ_AHEAD} must exceed the handoff \
          channel's {QUERY_ROWS_MAX_RESIDENT_ROWS}"
     );
 }

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -81,7 +81,10 @@ pub use data_access::joined_scan_stream::{
 };
 // Token-range bound pushed into the Summary-guided streaming walk (issue #2413
 // Option A) — used by the flight warm merge to scope a split's scan.
-pub use data_access::{QueryRowBatch, QueryRowStream, ScanTokenBound};
+pub use data_access::{
+    QueryRowBatch, QueryRowStream, ScanTokenBound, QUERY_ROWS_MAX_READ_AHEAD_ROWS,
+    QUERY_ROWS_MAX_RESIDENT_ROWS,
+};
 // Single-partition compaction seek outcome (issue #2207). `not(tombstones)` like
 // the seek path it wraps.
 #[cfg(not(feature = "tombstones"))]

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -81,10 +81,7 @@ pub use data_access::joined_scan_stream::{
 };
 // Token-range bound pushed into the Summary-guided streaming walk (issue #2413
 // Option A) — used by the flight warm merge to scope a split's scan.
-pub use data_access::{
-    QueryRowBatch, QueryRowStream, ScanTokenBound, QUERY_ROWS_MAX_READ_AHEAD_ROWS,
-    QUERY_ROWS_MAX_RESIDENT_ROWS,
-};
+pub use data_access::{QueryRowBatch, QueryRowStream, ScanTokenBound, QUERY_ROWS_MAX_READ_AHEAD};
 // Single-partition compaction seek outcome (issue #2207). `not(tombstones)` like
 // the seek path it wraps.
 #[cfg(not(feature = "tombstones"))]

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -500,12 +500,8 @@ impl SSTableReader {
         let io_failed = Arc::new(AtomicBool::new(false));
         let reader = Arc::clone(&self);
         let task_io_failed = Arc::clone(&io_failed);
-        // Detached-blocking-work marker (issue #3384): a dropped `JoinHandle` DETACHES
-        // a blocking task rather than aborting it, so this guard is how a reader learns
-        // the drain has actually stopped. Constructed BEFORE `spawn_blocking` and MOVED
-        // in (roborev): registering inside the closure would leave a task that is
-        // queued-but-not-yet-started counted as zero, so a reader could see "nothing in
-        // flight" and read the counter before that task decodes its first row.
+        // Detached-blocking-work marker; BEFORE the spawn so a queued task is not
+        // counted as zero. Full rationale on `BlockingScanTaskGuard` (issue #3384).
         let parse_inflight = crate::storage::read_path_probe::BlockingScanTaskGuard::new();
         let parse_task = tokio::task::spawn_blocking(move || {
             let _inflight = parse_inflight;
@@ -637,7 +633,7 @@ impl SSTableReader {
         max_compressed_length: usize,
     ) -> Option<Error> {
         let io_failed_feed = Arc::clone(io_failed);
-        // Registered BEFORE the spawn and moved in — see the parse half (issue #3384).
+        // Registered BEFORE the spawn — see the parse half (issue #3384).
         let feed_inflight = crate::storage::read_path_probe::BlockingScanTaskGuard::new();
         let feed = tokio::task::spawn_blocking(move || -> Option<Error> {
             let _inflight = feed_inflight;

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -286,29 +286,6 @@ const BATCH_CHANNEL_CAP: usize = 2;
 /// change that breaks the bound must update this constant AND keep that test green.
 pub(super) const MAX_INFLIGHT_BATCH_ROWS: usize = (BATCH_CHANNEL_CAP + 2) * BATCH_EMIT_ROWS;
 
-/// Batches the public BATCHED-scan channel
-/// ([`SSTableReader::scan_stream_batched_admitted`](crate::storage::sstable::reader::SSTableReader))
-/// holds for a given `buffer_size`.
-///
-/// Sizing the channel to `ceil(buffer_size / BATCH_EMIT_ROWS)` batches keeps the
-/// resident-row budget of that channel comparable to the per-row surface's
-/// `buffer_size` rather than `buffer_size * BATCH_EMIT_ROWS`.
-///
-/// A `const fn` with ONE definition because the query-row stream's exported
-/// read-ahead bound
-/// ([`QUERY_ROWS_MAX_READ_AHEAD_ROWS`](crate::storage::sstable::reader::QUERY_ROWS_MAX_READ_AHEAD_ROWS))
-/// is derived from it. A second copy of this arithmetic could drift from the
-/// channel the constructor actually builds — which is precisely how a documented
-/// read-ahead bound becomes silently wrong.
-pub(crate) const fn batched_channel_capacity(buffer_size: usize) -> usize {
-    let cap = buffer_size.div_ceil(BATCH_EMIT_ROWS);
-    if cap == 0 {
-        1
-    } else {
-        cap
-    }
-}
-
 /// Which public surface the windowed driver's forwarder adapts its single
 /// internal `Vec`-batched stream to (issue #1592, Epic F/F2).
 ///

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -286,6 +286,29 @@ const BATCH_CHANNEL_CAP: usize = 2;
 /// change that breaks the bound must update this constant AND keep that test green.
 pub(super) const MAX_INFLIGHT_BATCH_ROWS: usize = (BATCH_CHANNEL_CAP + 2) * BATCH_EMIT_ROWS;
 
+/// Batches the public BATCHED-scan channel
+/// ([`SSTableReader::scan_stream_batched_admitted`](crate::storage::sstable::reader::SSTableReader))
+/// holds for a given `buffer_size`.
+///
+/// Sizing the channel to `ceil(buffer_size / BATCH_EMIT_ROWS)` batches keeps the
+/// resident-row budget of that channel comparable to the per-row surface's
+/// `buffer_size` rather than `buffer_size * BATCH_EMIT_ROWS`.
+///
+/// A `const fn` with ONE definition because the query-row stream's exported
+/// read-ahead bound
+/// ([`QUERY_ROWS_MAX_READ_AHEAD_ROWS`](crate::storage::sstable::reader::QUERY_ROWS_MAX_READ_AHEAD_ROWS))
+/// is derived from it. A second copy of this arithmetic could drift from the
+/// channel the constructor actually builds — which is precisely how a documented
+/// read-ahead bound becomes silently wrong.
+pub(crate) const fn batched_channel_capacity(buffer_size: usize) -> usize {
+    let cap = buffer_size.div_ceil(BATCH_EMIT_ROWS);
+    if cap == 0 {
+        1
+    } else {
+        cap
+    }
+}
+
 /// Which public surface the windowed driver's forwarder adapts its single
 /// internal `Vec`-batched stream to (issue #1592, Epic F/F2).
 ///

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -501,6 +501,10 @@ impl SSTableReader {
         let reader = Arc::clone(&self);
         let task_io_failed = Arc::clone(&io_failed);
         let parse_task = tokio::task::spawn_blocking(move || {
+            // Detached-blocking-work marker (issue #3384): a dropped `JoinHandle`
+            // DETACHES this task rather than aborting it, so this guard is how a
+            // reader learns the drain has actually stopped.
+            let _inflight = crate::storage::read_path_probe::BlockingScanTaskGuard::new();
             reader.drain_scan_window_blocking(ctx, raw_rx, batch_tx, task_io_failed)
         });
 
@@ -630,6 +634,8 @@ impl SSTableReader {
     ) -> Option<Error> {
         let io_failed_feed = Arc::clone(io_failed);
         let feed = tokio::task::spawn_blocking(move || -> Option<Error> {
+            // Detached-blocking-work marker (issue #3384) — see the parse half.
+            let _inflight = crate::storage::read_path_probe::BlockingScanTaskGuard::new();
             // Panic/early-exit guard (roborev finding, issue #1593). `raw_tx` is
             // captured (moved) into this closure and drops when the closure
             // returns OR unwinds; the parse half reads a `raw_tx` close with

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -500,11 +500,15 @@ impl SSTableReader {
         let io_failed = Arc::new(AtomicBool::new(false));
         let reader = Arc::clone(&self);
         let task_io_failed = Arc::clone(&io_failed);
+        // Detached-blocking-work marker (issue #3384): a dropped `JoinHandle` DETACHES
+        // a blocking task rather than aborting it, so this guard is how a reader learns
+        // the drain has actually stopped. Constructed BEFORE `spawn_blocking` and MOVED
+        // in (roborev): registering inside the closure would leave a task that is
+        // queued-but-not-yet-started counted as zero, so a reader could see "nothing in
+        // flight" and read the counter before that task decodes its first row.
+        let parse_inflight = crate::storage::read_path_probe::BlockingScanTaskGuard::new();
         let parse_task = tokio::task::spawn_blocking(move || {
-            // Detached-blocking-work marker (issue #3384): a dropped `JoinHandle`
-            // DETACHES this task rather than aborting it, so this guard is how a
-            // reader learns the drain has actually stopped.
-            let _inflight = crate::storage::read_path_probe::BlockingScanTaskGuard::new();
+            let _inflight = parse_inflight;
             reader.drain_scan_window_blocking(ctx, raw_rx, batch_tx, task_io_failed)
         });
 
@@ -633,9 +637,10 @@ impl SSTableReader {
         max_compressed_length: usize,
     ) -> Option<Error> {
         let io_failed_feed = Arc::clone(io_failed);
+        // Registered BEFORE the spawn and moved in — see the parse half (issue #3384).
+        let feed_inflight = crate::storage::read_path_probe::BlockingScanTaskGuard::new();
         let feed = tokio::task::spawn_blocking(move || -> Option<Error> {
-            // Detached-blocking-work marker (issue #3384) — see the parse half.
-            let _inflight = crate::storage::read_path_probe::BlockingScanTaskGuard::new();
+            let _inflight = feed_inflight;
             // Panic/early-exit guard (roborev finding, issue #1593). `raw_tx` is
             // captured (moved) into this closure and drops when the closure
             // returns OR unwinds; the parse half reads a `raw_tx` close with

--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -128,6 +128,7 @@ struct Counters {
     /// partition count regardless of how narrow the split range (or `LIMIT`) is —
     /// the fixed multi-second warm-scan setup this counter exists to make visible.
     stream_walk_partitions_parsed: AtomicU64,
+    query_row_producers_finished: AtomicU64,
     /// Merge ENTRIES decoded from `Data.db` by ANY [`KWayMerger`]-adapter-driven
     /// run (Issue #2096) — full scans, compaction, AND multi-candidate point
     /// reads all share the same [`SSTableRowIteratorAdapter`]/`PathProbe::Seeked`
@@ -165,6 +166,7 @@ impl Counters {
             reverse_peak_block_rows: AtomicU64::new(0),
             data_db_checksum_full_reads: AtomicU64::new(0),
             stream_walk_partitions_parsed: AtomicU64::new(0),
+            query_row_producers_finished: AtomicU64::new(0),
             merge_run_entries_decoded: AtomicU64::new(0),
         }
     }
@@ -220,6 +222,15 @@ impl Counters {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    fn add_query_row_producer_finished(&self) {
+        self.query_row_producers_finished
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn query_row_producers_finished(&self) -> u64 {
+        self.query_row_producers_finished.load(Ordering::Relaxed)
+    }
+
     fn stream_walk_partitions_parsed(&self) -> u64 {
         self.stream_walk_partitions_parsed.load(Ordering::Relaxed)
     }
@@ -272,6 +283,8 @@ impl Counters {
         self.reverse_peak_block_rows.store(0, Ordering::Relaxed);
         self.data_db_checksum_full_reads.store(0, Ordering::Relaxed);
         self.stream_walk_partitions_parsed
+            .store(0, Ordering::Relaxed);
+        self.query_row_producers_finished
             .store(0, Ordering::Relaxed);
         self.merge_run_entries_decoded.store(0, Ordering::Relaxed);
     }
@@ -414,6 +427,25 @@ pub(crate) fn add_stream_walk_partition_parsed() {
 /// `cargo test` (issue #2428). Such assertions use [`stream_walk_scope`]'s
 /// thread-local [`StreamWalkScope`](stream_walk_scope::StreamWalkScope) instead,
 /// which is immune by construction.
+/// One `QueryRowStream` producer thread has TERMINATED (issue #3384).
+///
+/// The causal completion signal for an abandoned walk. A test that instead waits
+/// for [`stream_walk_partitions_parsed`] to "stop growing" is asserting on a
+/// SAMPLE of another thread's progress: a producer that is merely descheduled
+/// looks identical to one that has stopped, so the walk can resume and drain the
+/// table after the assertion passed (roborev, issue #3384). This counter moves
+/// only when the producer closure has actually run to completion, so a reader
+/// that observes it knows the walk's row count is FINAL.
+pub(crate) fn add_query_row_producer_finished() {
+    COUNTERS.add_query_row_producer_finished();
+}
+
+/// Number of `QueryRowStream` producer threads that have terminated since
+/// [`reset`] (issue #3384). See [`add_query_row_producer_finished`].
+pub fn query_row_producers_finished() -> u64 {
+    COUNTERS.query_row_producers_finished()
+}
+
 pub fn stream_walk_partitions_parsed() -> u64 {
     COUNTERS.stream_walk_partitions_parsed()
 }

--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -128,7 +128,6 @@ struct Counters {
     /// partition count regardless of how narrow the split range (or `LIMIT`) is —
     /// the fixed multi-second warm-scan setup this counter exists to make visible.
     stream_walk_partitions_parsed: AtomicU64,
-    query_row_producers_finished: AtomicU64,
     /// Merge ENTRIES decoded from `Data.db` by ANY [`KWayMerger`]-adapter-driven
     /// run (Issue #2096) — full scans, compaction, AND multi-candidate point
     /// reads all share the same [`SSTableRowIteratorAdapter`]/`PathProbe::Seeked`
@@ -166,7 +165,6 @@ impl Counters {
             reverse_peak_block_rows: AtomicU64::new(0),
             data_db_checksum_full_reads: AtomicU64::new(0),
             stream_walk_partitions_parsed: AtomicU64::new(0),
-            query_row_producers_finished: AtomicU64::new(0),
             merge_run_entries_decoded: AtomicU64::new(0),
         }
     }
@@ -222,15 +220,6 @@ impl Counters {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn add_query_row_producer_finished(&self) {
-        self.query_row_producers_finished
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn query_row_producers_finished(&self) -> u64 {
-        self.query_row_producers_finished.load(Ordering::Relaxed)
-    }
-
     fn stream_walk_partitions_parsed(&self) -> u64 {
         self.stream_walk_partitions_parsed.load(Ordering::Relaxed)
     }
@@ -283,8 +272,6 @@ impl Counters {
         self.reverse_peak_block_rows.store(0, Ordering::Relaxed);
         self.data_db_checksum_full_reads.store(0, Ordering::Relaxed);
         self.stream_walk_partitions_parsed
-            .store(0, Ordering::Relaxed);
-        self.query_row_producers_finished
             .store(0, Ordering::Relaxed);
         self.merge_run_entries_decoded.store(0, Ordering::Relaxed);
     }
@@ -427,25 +414,6 @@ pub(crate) fn add_stream_walk_partition_parsed() {
 /// `cargo test` (issue #2428). Such assertions use [`stream_walk_scope`]'s
 /// thread-local [`StreamWalkScope`](stream_walk_scope::StreamWalkScope) instead,
 /// which is immune by construction.
-/// One `QueryRowStream` producer thread has TERMINATED (issue #3384).
-///
-/// The causal completion signal for an abandoned walk. A test that instead waits
-/// for [`stream_walk_partitions_parsed`] to "stop growing" is asserting on a
-/// SAMPLE of another thread's progress: a producer that is merely descheduled
-/// looks identical to one that has stopped, so the walk can resume and drain the
-/// table after the assertion passed (roborev, issue #3384). This counter moves
-/// only when the producer closure has actually run to completion, so a reader
-/// that observes it knows the walk's row count is FINAL.
-pub(crate) fn add_query_row_producer_finished() {
-    COUNTERS.add_query_row_producer_finished();
-}
-
-/// Number of `QueryRowStream` producer threads that have terminated since
-/// [`reset`] (issue #3384). See [`add_query_row_producer_finished`].
-pub fn query_row_producers_finished() -> u64 {
-    COUNTERS.query_row_producers_finished()
-}
-
 pub fn stream_walk_partitions_parsed() -> u64 {
     COUNTERS.stream_walk_partitions_parsed()
 }

--- a/cqlite-flight/src/cli.rs
+++ b/cqlite-flight/src/cli.rs
@@ -224,3 +224,18 @@ pub fn log_startup(
         "cqlite-flight starting"
     );
 }
+
+/// The POST-BIND readiness line (issue #3384).
+///
+/// Distinct from [`log_startup`], which records CONFIGURATION and is necessarily
+/// written before the port is acquired. This one is emitted only once a listener
+/// exists, so its presence is proof the process owns `bound` — the property a
+/// readiness probe needs and that a configuration line cannot supply, since a
+/// process can log its configuration and then die of `EADDRINUSE`.
+///
+/// `bound` is the ADDRESS ACTUALLY BOUND, not the one requested: with
+/// `--listen 127.0.0.1:0` the requested port is 0 and only this line names the
+/// port a client can dial.
+pub fn log_listening(bound: std::net::SocketAddr) {
+    tracing::info!(listening_on = %bound, "cqlite-flight listening on {bound}");
+}

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -2,6 +2,7 @@
 //! data. Runs co-located with a Cassandra node and reads its local SSTables.
 
 use arrow_flight::flight_service_server::FlightServiceServer;
+use tonic::transport::server::TcpIncoming;
 use tonic::transport::Server;
 
 use cqlite_flight::admission::{Admission, AdmissionConfig, WaitBudget};
@@ -100,10 +101,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Graceful shutdown (issue #1473): on ctrl_c / SIGTERM, tonic stops
     // accepting new connections and drains in-flight RPCs rather than tearing
     // every open stream down abruptly.
+    // Bind EXPLICITLY, then announce (issue #3384). `serve_with_shutdown` binds
+    // internally, so every line logged before this point — including
+    // `log_startup`'s configuration record — is written by a process that has not
+    // yet acquired the port and may still fail to. An operator reading the log
+    // could not tell "configured and serving" from "configured, then died of
+    // EADDRINUSE", and a test harness keying readiness on those lines cannot
+    // either: that is the residual roborev found in #3384's readiness fix. The
+    // line below is emitted only AFTER the listener exists, and carries the
+    // ACTUAL bound address, which is the only useful one when `--listen` names
+    // port 0.
+    let listener = tokio::net::TcpListener::bind(listen).await?;
+    let bound = listener.local_addr()?;
+    let incoming = TcpIncoming::from_listener(listener, true, None)
+        .map_err(|e| format!("failed to accept on {bound}: {e}"))?;
+    cli::log_listening(bound);
     Server::builder()
         .max_concurrent_streams(max_concurrent_streams)
         .add_service(FlightServiceServer::new(service))
-        .serve_with_shutdown(listen, shutdown_signal())
+        .serve_with_incoming_shutdown(incoming, shutdown_signal())
         .await?;
     Ok(())
 }

--- a/cqlite-flight/tests/issue_2821_egress_budget_e2e.rs
+++ b/cqlite-flight/tests/issue_2821_egress_budget_e2e.rs
@@ -20,9 +20,8 @@
 //! (#2642). The timeouts below are liveness bounds on process/socket readiness,
 //! not correctness properties.
 
-use std::net::{SocketAddr, TcpListener};
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
 use arrow_flight::decode::FlightRecordBatchStream;
@@ -76,106 +75,30 @@ fn ticket_bytes() -> Vec<u8> {
 }
 
 // ---------------------------------------------------------------------------
-// Server process control (mirrors tests/issue_2825_max_batch_bytes_e2e.rs)
+// Server process control
 // ---------------------------------------------------------------------------
 
-struct ServerProcess {
-    child: Child,
-    addr: SocketAddr,
-    log: PathBuf,
-    _log_dir: tempfile::TempDir,
-}
+// Shared with `tests/issue_2825_max_batch_bytes_e2e.rs` (issue #3384): both files
+// carried the same copy of this helper, and therefore the same readiness defect.
+// See the support module's doc for the readiness contract.
+#[path = "support/flight_server_process.rs"]
+mod flight_server_process;
+use flight_server_process::{ServerProcess, ServerSpec};
 
-impl Drop for ServerProcess {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-impl ServerProcess {
-    fn log(&self) -> String {
-        strip_ansi(&std::fs::read_to_string(&self.log).unwrap_or_default())
-    }
-}
-
-/// Drop CSI escape sequences (`ESC [ <params> <final byte>`) from `s`.
-fn strip_ansi(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '\u{1b}' {
-            out.push(c);
-            continue;
-        }
-        if chars.peek() == Some(&'[') {
-            chars.next();
-        }
-        for c in chars.by_ref() {
-            if ('@'..='~').contains(&c) {
-                break;
-            }
-        }
-    }
-    out
-}
-
-fn free_port() -> u16 {
-    let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
-    let port = l.local_addr().expect("local_addr").port();
-    drop(l);
-    port
-}
-
+/// Start the REAL server binary over `data_dir` with `extra_args` and `env`, with
+/// this file's fixed per-batch payload cap applied.
+///
+/// Both knob env vars are removed from the child's environment first so a stray
+/// value in the developer's environment cannot silently change what is under test.
 fn start_server(data_dir: &Path, extra_args: &[String], env: &[(&str, String)]) -> ServerProcess {
-    let exe = env!("CARGO_BIN_EXE_cqlite-flight");
-    let mut last_log = String::new();
-    for _ in 0..3 {
-        let port = free_port();
-        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-        let log_dir = tempfile::TempDir::new().expect("log dir");
-        let log = log_dir.path().join("server.log");
-        let out = std::fs::File::create(&log).expect("log file");
-        let err = out.try_clone().expect("clone log fd");
-
-        let mut cmd = Command::new(exe);
-        cmd.arg("--data-dir")
-            .arg(data_dir)
-            .arg("--listen")
-            .arg(addr.to_string())
-            .arg("--max-batch-bytes")
-            .arg(BATCH_CAP.to_string())
-            .args(extra_args)
-            .stdout(Stdio::from(out))
-            .stderr(Stdio::from(err));
-        // Start from a clean slate so a stray value in the developer's
-        // environment cannot silently change what is under test.
-        cmd.env_remove(ENV_MAX_BATCH_BYTES);
-        cmd.env_remove(ENV_MAX_INFLIGHT_EGRESS_BYTES);
-        for (k, v) in env {
-            cmd.env(k, v);
-        }
-        let child = cmd.spawn().expect("spawn cqlite-flight");
-        let mut server = ServerProcess {
-            child,
-            addr,
-            log,
-            _log_dir: log_dir,
-        };
-
-        // Liveness wait: poll the socket until the server accepts.
-        for _ in 0..200 {
-            if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(50)).is_ok() {
-                return server;
-            }
-            if let Ok(Some(_)) = server.child.try_wait() {
-                break; // exited early (likely a port collision) — retry
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        last_log = server.log();
-    }
-    panic!("cqlite-flight never became ready; last server log:\n{last_log}");
+    let mut args = vec!["--max-batch-bytes".to_string(), BATCH_CAP.to_string()];
+    args.extend_from_slice(extra_args);
+    flight_server_process::start_server(ServerSpec {
+        data_dir,
+        args: &args,
+        env,
+        env_remove: &[ENV_MAX_BATCH_BYTES, ENV_MAX_INFLIGHT_EGRESS_BYTES],
+    })
 }
 
 /// Stream a real `do_get` and return every decoded batch.

--- a/cqlite-flight/tests/issue_2825_max_batch_bytes_e2e.rs
+++ b/cqlite-flight/tests/issue_2825_max_batch_bytes_e2e.rs
@@ -19,9 +19,8 @@
 //! (#2642). The timeouts below are liveness bounds on process/socket readiness,
 //! not correctness properties.
 
-use std::net::{SocketAddr, TcpListener};
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
 use arrow_flight::decode::FlightRecordBatchStream;
@@ -77,115 +76,26 @@ fn ticket_bytes() -> Vec<u8> {
 // Server process control
 // ---------------------------------------------------------------------------
 
-/// A spawned `cqlite-flight` server process, killed on drop so a failing
-/// assertion can never leak a listener.
-struct ServerProcess {
-    child: Child,
-    addr: SocketAddr,
-    log: PathBuf,
-    // Kept so the log file outlives the process.
-    _log_dir: tempfile::TempDir,
-}
+// Spawning the real binary and WAITING FOR IT CORRECTLY is shared with
+// `tests/issue_2821_egress_budget_e2e.rs` (issue #3384): both files carried the
+// same copy of it, and therefore the same readiness defect. See the support
+// module's doc for the readiness contract.
+#[path = "support/flight_server_process.rs"]
+mod flight_server_process;
+use flight_server_process::{ServerProcess, ServerSpec};
 
-impl Drop for ServerProcess {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-impl ServerProcess {
-    /// Everything the server wrote to stdout+stderr so far (the startup log),
-    /// with the `tracing-subscriber` ANSI styling stripped so the field
-    /// assertions match plain `key=value` text.
-    fn log(&self) -> String {
-        strip_ansi(&std::fs::read_to_string(&self.log).unwrap_or_default())
-    }
-}
-
-/// Drop CSI escape sequences (`ESC [ <params> <final byte>`) from `s`.
-fn strip_ansi(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '\u{1b}' {
-            out.push(c);
-            continue;
-        }
-        // Skip the `[` introducer, then every parameter/intermediate byte up to
-        // and including the final byte in `@..=~` (e.g. the `m` of `ESC[32m`).
-        if chars.peek() == Some(&'[') {
-            chars.next();
-        }
-        for c in chars.by_ref() {
-            if ('@'..='~').contains(&c) {
-                break;
-            }
-        }
-    }
-    out
-}
-
-/// An ephemeral loopback port that is free right now.
-fn free_port() -> u16 {
-    let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
-    let port = l.local_addr().expect("local_addr").port();
-    drop(l);
-    port
-}
-
-/// Start the REAL server binary over `data_dir` with `extra_args` and `env`, and
-/// wait until it accepts connections.
+/// Start the REAL server binary over `data_dir` with `extra_args` and `env`.
 ///
-/// Retries on a port that another process grabbed in the gap between
-/// [`free_port`] and the child's own bind — a startup race, not a correctness
-/// property, so no assertion depends on timing here.
+/// `CQLITE_MAX_BATCH_BYTES` is removed from the child's environment first so a
+/// stray value in the developer's environment cannot silently change what is
+/// under test.
 fn start_server(data_dir: &Path, extra_args: &[String], env: &[(&str, String)]) -> ServerProcess {
-    let exe = env!("CARGO_BIN_EXE_cqlite-flight");
-    let mut last_log = String::new();
-    for _ in 0..3 {
-        let port = free_port();
-        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-        let log_dir = tempfile::TempDir::new().expect("log dir");
-        let log = log_dir.path().join("server.log");
-        let out = std::fs::File::create(&log).expect("log file");
-        let err = out.try_clone().expect("clone log fd");
-
-        let mut cmd = Command::new(exe);
-        cmd.arg("--data-dir")
-            .arg(data_dir)
-            .arg("--listen")
-            .arg(addr.to_string())
-            .args(extra_args)
-            .stdout(Stdio::from(out))
-            .stderr(Stdio::from(err));
-        // Start from a clean slate so a stray CQLITE_MAX_BATCH_BYTES in the
-        // developer's environment cannot silently change what is under test.
-        cmd.env_remove(ENV_MAX_BATCH_BYTES);
-        for (k, v) in env {
-            cmd.env(k, v);
-        }
-        let child = cmd.spawn().expect("spawn cqlite-flight");
-        let mut server = ServerProcess {
-            child,
-            addr,
-            log,
-            _log_dir: log_dir,
-        };
-
-        // Liveness wait: poll the socket until the server accepts.
-        for _ in 0..200 {
-            if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(50)).is_ok() {
-                return server;
-            }
-            if let Ok(Some(_)) = server.child.try_wait() {
-                break; // exited early (likely a port collision) — retry
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        last_log = server.log();
-    }
-    panic!("cqlite-flight never became ready; last server log:\n{last_log}");
+    flight_server_process::start_server(ServerSpec {
+        data_dir,
+        args: extra_args,
+        env,
+        env_remove: &[ENV_MAX_BATCH_BYTES],
+    })
 }
 
 /// Stream a real `do_get` against `addr` and return the row count of each

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -226,6 +226,22 @@ async fn build_generations(batches: Vec<Vec<Mutation>>) -> (tempfile::TempDir, P
 /// Authoritative count of `*-Data.db` generations under the table directory —
 /// the same listing the warm registry's generation probe uses, so a test can
 /// state the source count it is exercising instead of assuming it.
+/// `*-CompressionInfo.db` components under the table dir — zero means every reader
+/// here is uncompressed, hence non-stitching (issue #3384).
+fn count_compression_info(data_dir: &std::path::Path) -> usize {
+    let table_dir = data_dir.join(KS).join(TBL);
+    std::fs::read_dir(&table_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.ends_with("-CompressionInfo.db"))
+        })
+        .count()
+}
+
 fn count_data_dbs(data_dir: &std::path::Path) -> usize {
     let table_dir = data_dir.join(KS).join(TBL);
     std::fs::read_dir(&table_dir)
@@ -511,6 +527,22 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
     cqlite_core::storage::read_path_probe::reset_batched_scans_finished();
     let (_temp, data_dir) = build_generations(vec![rows]).await;
     assert_eq!(count_data_dbs(&data_dir), 1);
+    // ENFORCED precondition for the completion signal below (roborev, issue #3384).
+    // That signal is a drop guard on the scan's spawned future, so it covers a
+    // decode loop that runs INSIDE that future. Only NON-STITCHING readers take that
+    // loop: `requires_chunk_stitching()` (compressed `nb`) instead routes to
+    // `run_scan_stream_windowed`, whose `spawn_blocking` parse/feed tasks are not
+    // cancellable and can still be decoding when the guard fires. The write engine
+    // emits UNCOMPRESSED SSTables, so this fixture takes the covered path — asserted
+    // rather than assumed, so switching the fixture to a compressed one cannot
+    // silently turn the signal premature.
+    assert_eq!(
+        count_compression_info(&data_dir),
+        0,
+        "this fixture must stay UNCOMPRESSED: a compressed reader takes the stitching \
+         path, whose spawn_blocking decode is not covered by the completion signal \
+         this test waits on (issue #3384)"
+    );
 
     let svc = CqliteFlightService::new(data_dir, 1)
         .with_egress_budget(EgressBudget::bytes(CANCEL_EGRESS_CEILING));

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -36,9 +36,13 @@ use tonic::Request;
 
 use cqlite_core::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
 use cqlite_core::storage::read_path_probe::ReadPathProbe;
+use cqlite_core::storage::sstable::reader::{
+    QUERY_ROWS_MAX_READ_AHEAD_ROWS, QUERY_ROWS_MAX_RESIDENT_ROWS,
+};
 use cqlite_core::storage::sstable::work_counters;
 use cqlite_core::storage::write_engine::{
-    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+    CellOperation, ClusteringKey, Durability, Mutation, PartitionKey, TableId, WriteEngine,
+    WriteEngineConfig,
 };
 use cqlite_core::types::Value;
 use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
@@ -46,23 +50,70 @@ use cqlite_flight::bypass::MERGE_PATH_ENV;
 use cqlite_flight::egress_credit::EgressBudget;
 use cqlite_flight::service::CqliteFlightService;
 
-/// Partitions in the mid-stream-cancel fixture. Must be far more than the stream
-/// can hold in flight under [`CANCEL_EGRESS_CEILING`], so "stopped early" and
-/// "drained the table" are distinguishable STRUCTURALLY (by the credit pool)
-/// rather than by scheduling luck.
-const PARTITIONS: usize = 800;
+/// Rows per Arrow batch for the mid-stream-cancel test — one, so the client can
+/// stop after a single row and every downstream term below is counted in rows.
+const CANCEL_BATCH_SIZE: usize = 1;
+
+/// Rows resident DOWNSTREAM of the core producer when the client stops reading —
+/// the slack term of [`CANCEL_DECODE_CEILING`], derived from the mechanism rather
+/// than fitted to an observation.
+///
+/// Two contributions:
+///
+/// * **The Flight egress path**, which is COUNT-bounded independently of bytes:
+///   `do_get`'s channel holds `DO_GET_CHANNEL_CAPACITY` (4) batches with ~2 more
+///   in flight (one counted-but-unsent, one encoder prefetch) and the producer's
+///   own row buffer holds at most one further batch — all at
+///   [`CANCEL_BATCH_SIZE`] rows each, so ~7 rows. (Those constants are
+///   crate-private, hence named in prose and covered generously by the `8 *`
+///   below rather than mirrored as load-bearing literals.)
+/// * **The one core handoff batch** `ScanRowSource` holds as its current row
+///   iterator, which cannot exceed [`QUERY_ROWS_MAX_RESIDENT_ROWS`]. This is the
+///   dominant term.
+const CANCEL_DOWNSTREAM_ROWS: usize = QUERY_ROWS_MAX_RESIDENT_ROWS + 8 * CANCEL_BATCH_SIZE;
+
+/// Rows an ABANDONED fast-arm walk may still decode after the client stops
+/// reading — the structural bound the stop assertion is made against.
+///
+/// It is a CONSTANT, independent of the fixture's size: the producer runs ahead
+/// only as far as the bounded buffers between disk and client allow, then parks
+/// and observes the cancellation. [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] is
+/// cqlite-core's own sum of those buffers on the arm this test runs (a
+/// no-token-bound `do_get` → the full-ring arm), derived there from the sizings
+/// that actually run; [`CANCEL_DOWNSTREAM_ROWS`] adds what is resident on the
+/// Flight side of the handoff.
+///
+/// One row per partition in the fixture, so a row bound is a partition bound.
+const CANCEL_DECODE_CEILING: usize = QUERY_ROWS_MAX_READ_AHEAD_ROWS + CANCEL_DOWNSTREAM_ROWS;
+
+/// Partitions in the mid-stream-cancel fixture: a generous multiple of
+/// [`CANCEL_DECODE_CEILING`], so "the walk stopped" and "the walk drained the
+/// table" are separated by a wide margin that no scheduling outcome can close.
+/// The 800 this once was is BELOW the read-ahead bound — 1.25x of the handoff
+/// channel alone — which is why the old `settled < PARTITIONS` assertion was a
+/// coin flip (issue #3384). Rows are tiny and the fixture builder skips WAL
+/// durability, so the whole fixture costs ~150ms to build.
+const PARTITIONS: usize = 4 * CANCEL_DECODE_CEILING;
 
 /// Per-stream in-flight egress ceiling for the mid-stream-cancel test.
 ///
-/// This is what makes the stop assertion DETERMINISTIC. Without a tight ceiling
-/// the producer is free to race ahead of a client that has stopped reading, and
-/// on a fast/loaded machine it can decode the whole (tiny, one-row-per-partition)
-/// fixture before the cancellation is observed — which is scheduling, not
-/// behaviour, and made an earlier revision of this test flaky under the gate's
-/// parallel load. With the ceiling, only a bounded number of batches can be
-/// buffered ahead of the dropped client, so the walk MUST park and then stop:
-/// the bound below holds by construction. Comfortably above one 1-row batch's
-/// capacity (so no batch is refused) and far below the whole fixture's.
+/// # What this governs — and what it does NOT
+///
+/// It caps the CAPACITY BYTES the server holds on the EGRESS path: Arrow batches
+/// queued in `do_get`'s channel or yielded and not yet dropped. That is entirely
+/// DOWNSTREAM of the read-ahead this test bounds, so it cannot make the stop
+/// assertion deterministic at any value — an earlier revision of this doc claimed
+/// it did ("the bound holds by construction"), and that claim was false: the walk
+/// is driven by `SSTableReader::open_query_row_stream`'s producer thread, which
+/// decodes into its own bounded buffers ahead of the egress path and is metered by
+/// nothing here. With a fixture of 800 one-row partitions the producer's
+/// read-ahead alone could reach the whole table, which is precisely the flake
+/// issue #3384 records. The determinism now comes from
+/// [`CANCEL_DECODE_CEILING`] — a bound on the producer, not on egress.
+///
+/// It is kept because a metered stream is the shape production runs, and because
+/// it does bound the downstream half of [`CANCEL_DOWNSTREAM_ROWS`]. Comfortably
+/// above one 1-row batch's capacity, so no batch is ever refused.
 const CANCEL_EGRESS_CEILING: usize = 64 * 1024;
 
 /// Serializes the process-global probe/env window (see the module doc).
@@ -138,7 +189,12 @@ async fn build_generations(batches: Vec<Vec<Mutation>>) -> (tempfile::TempDir, P
     let temp = tempfile::TempDir::new().expect("tempdir");
     let data_dir = temp.path().join("data");
     let wal_dir = temp.path().join("wal");
-    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema());
+    // `Durability::Disabled` (bulk-load mode): these fixtures are durable after the
+    // `flush` below, which is the only state any test here reads, and skipping the
+    // per-write WAL fsync is what makes the several-thousand-partition
+    // mid-stream-cancel fixture cost ~150ms instead of ~50s.
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema())
+        .with_durability(Durability::Disabled);
     let mut engine = WriteEngine::new(config).expect("engine");
     for batch in batches {
         for m in batch {
@@ -405,11 +461,25 @@ async fn token_pruning_to_one_source_still_selects_the_fast_path() {
 /// arm ran (roborev: asserting only `mergers_built == 0` would pass even if the
 /// fast arm drained the whole table after the client left). The marker is
 /// `work_counters::stream_walk_partitions_parsed()`, which counts partition BODIES
-/// decoded: after the drop it must stop growing AND be below the fixture's
-/// partition count.
+/// decoded.
 ///
-/// The bound is made structural by [`CANCEL_EGRESS_CEILING`] — see its doc for why
-/// a bound without it is scheduling luck rather than behaviour.
+/// # Why the bound is [`CANCEL_DECODE_CEILING`] and not the fixture size
+///
+/// Two assertions, and they say different things:
+///
+/// 1. **The walk STOPPED** — the counter stops growing. This is the causal half.
+/// 2. **It stopped WHERE THE MECHANISM SAYS IT MUST** — the count is at most the
+///    pipeline's bounded read-ahead ([`CANCEL_DECODE_CEILING`]), a constant that
+///    does not scale with the table.
+///
+/// (2) used to read `settled < PARTITIONS` over an 800-partition fixture, which
+/// asserted that the cancellation BEAT the producer — a race outcome, ~25-30% red
+/// in isolation (issue #3384). The producer legitimately reads ahead up to
+/// [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] rows, i.e. THREE TIMES that fixture, so a
+/// full drain was permitted behaviour that the test called a bug. Bounding by the
+/// read-ahead instead keeps the real property (a cancelled walk does O(1) further
+/// work, not O(table)) and makes it a fact about the code rather than about the
+/// scheduler.
 #[tokio::test]
 async fn fast_arm_stream_stops_when_the_client_drops_it() {
     let _guard = PROBE_LOCK.lock().await;
@@ -471,10 +541,30 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
         "the walk never stopped decoding partition bodies after the client dropped \
          the stream (last sample {settled} of {PARTITIONS})"
     );
+    // Observability for the issue-#3384 measurement: under `--nocapture` this
+    // prints the observed read-ahead, so the distribution can be re-measured
+    // (e.g. before tightening the ceiling) without patching the test. Silent in a
+    // normal run; not an assertion.
+    eprintln!(
+        "issue-3384 observed read-ahead: {settled} partition bodies \
+         (ceiling {CANCEL_DECODE_CEILING}, fixture {PARTITIONS})"
+    );
+    // Non-vacuity: the fixture must be far larger than the bound, or "bounded by
+    // the read-ahead" would be trivially true of a full drain. Asserted rather
+    // than assumed, so a future shrink of the fixture (or a growth of the core
+    // read-ahead) cannot quietly make the assertion below meaningless.
     assert!(
-        settled < PARTITIONS as u64,
-        "the abandoned scan must not have drained the whole fixture: decoded \
-         {settled} of {PARTITIONS} partition bodies"
+        PARTITIONS >= 4 * CANCEL_DECODE_CEILING,
+        "fixture drift: {PARTITIONS} partitions is not a wide enough margin over \
+         the decode ceiling {CANCEL_DECODE_CEILING} for the bound to mean anything"
+    );
+    assert!(
+        settled <= CANCEL_DECODE_CEILING as u64,
+        "the abandoned scan decoded MORE than the pipeline's bounded read-ahead \
+         permits: {settled} partition bodies > ceiling {CANCEL_DECODE_CEILING} \
+         (core read-ahead {QUERY_ROWS_MAX_READ_AHEAD_ROWS} + downstream \
+         {CANCEL_DOWNSTREAM_ROWS}), fixture {PARTITIONS}. Either the walk ignored \
+         the cancellation or a buffer grew without the core bound following it"
     );
 }
 

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -97,6 +97,20 @@ const CANCEL_DECODE_CEILING: usize = QUERY_ROWS_MAX_READ_AHEAD + CANCEL_DOWNSTRE
 /// durability, so the whole fixture costs ~150ms to build.
 const PARTITIONS: usize = 4 * CANCEL_DECODE_CEILING;
 
+// Non-vacuity, enforced at COMPILE TIME: the fixture must stay a wide multiple of
+// the decode ceiling, or "the walk stopped within the read-ahead" would be
+// trivially true of a full drain. A runtime `assert!` here could only ever be a
+// tautology (both sides are `const`, and `PARTITIONS` is defined from the
+// ceiling); as a `const` assertion it instead fails the BUILD if a later edit
+// replaces `PARTITIONS` with a literal, or grows the core read-ahead past the
+// margin (issue #3384).
+const _: () = assert!(
+    PARTITIONS >= 4 * CANCEL_DECODE_CEILING,
+    "fixture drift: PARTITIONS must stay >= 4x CANCEL_DECODE_CEILING or the \
+     read-ahead bound in fast_arm_stream_stops_when_the_client_drops_it is \
+     trivially satisfied (issue #3384)"
+);
+
 /// Per-stream in-flight egress ceiling for the mid-stream-cancel test.
 ///
 /// # What this governs — and what it does NOT
@@ -550,15 +564,6 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
     eprintln!(
         "issue-3384 observed read-ahead: {settled} partition bodies \
          (ceiling {CANCEL_DECODE_CEILING}, fixture {PARTITIONS})"
-    );
-    // Non-vacuity: the fixture must be far larger than the bound, or "bounded by
-    // the read-ahead" would be trivially true of a full drain. Asserted rather
-    // than assumed, so a future shrink of the fixture (or a growth of the core
-    // read-ahead) cannot quietly make the assertion below meaningless.
-    assert!(
-        PARTITIONS >= 4 * CANCEL_DECODE_CEILING,
-        "fixture drift: {PARTITIONS} partitions is not a wide enough margin over \
-         the decode ceiling {CANCEL_DECODE_CEILING} for the bound to mean anything"
     );
     assert!(
         settled <= CANCEL_DECODE_CEILING as u64,

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -505,6 +505,9 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
         .map(|i| write(i as i32, 1, "v", 100))
         .collect();
     work_counters::reset();
+    // Reset UNDER `PROBE_LOCK` (held for this whole test): a producer from a
+    // previous case in this binary must not be able to publish into this count.
+    cqlite_core::storage::read_path_probe::reset_query_row_producers_finished();
     let (_temp, data_dir) = build_generations(vec![rows]).await;
     assert_eq!(count_data_dbs(&data_dir), 1);
 
@@ -551,7 +554,7 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
         // The producer runs on its own OS thread, so yielding this task is not
         // enough to let it make progress; sleep briefly instead.
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-        if work_counters::query_row_producers_finished() > 0 {
+        if cqlite_core::storage::read_path_probe::query_row_producers_finished() > 0 {
             stopped = true;
             break;
         }

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -508,6 +508,7 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
     // Reset UNDER `PROBE_LOCK` (held for this whole test): a producer from a
     // previous case in this binary must not be able to publish into this count.
     cqlite_core::storage::read_path_probe::reset_query_row_producers_finished();
+    cqlite_core::storage::read_path_probe::reset_batched_scans_finished();
     let (_temp, data_dir) = build_generations(vec![rows]).await;
     assert_eq!(count_data_dbs(&data_dir), 1);
 
@@ -566,24 +567,32 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
          partition bodies so far)",
         work_counters::stream_walk_partitions_parsed()
     );
-    // The completion signal proves the OUTER query-row producer stopped. It does
-    // NOT prove the INNER batched scan task has (roborev, issue #3384):
-    // `drive_full_scan_rows` drops `BatchedScanStream` on its way out and that task
-    // is never joined. The trail is BOUNDED and cannot run away — the inner loop
-    // consults its consumer only when a batch fills, so once the receiver is dropped
-    // it decodes at most one more `BATCH_EMIT_ROWS` batch before its `send` fails and
-    // it returns — but "bounded" is not "finished", so let that trail land before
-    // reading rather than reading the instant the outer thread exits.
+    // BOTH halves must be observed before the counter is final (roborev, issue
+    // #3384). The signal above proves the OUTER query-row producer stopped pulling;
+    // it does NOT prove the INNER batched scan task has stopped DECODING, because
+    // `drive_full_scan_rows` drops `BatchedScanStream` without joining its task.
     //
-    // MEASURED, not assumed: without this window the observed maximum was 1280; with
-    // it, 2370. The earlier reads were genuinely non-final. Convergence checked too —
-    // a 10x longer window gives 2048, i.e. LOWER, so the spread is run-to-run variance
-    // and not window-dependence. This is a drain window for a bounded amount of work,
-    // never a deadline, and no assertion here compares an elapsed duration to a
-    // threshold (#2642).
-    for _ in 0..200 {
+    // A fixed drain interval was the first attempt and it was WRONG for this issue's
+    // own reason: it makes the race less likely instead of removing it, and a
+    // descheduled or regressed task can still increment after the sample. So wait on
+    // the inner task's own causal completion signal instead. The bound below is a
+    // liveness guard, never a deadline.
+    let mut inner_done = false;
+    for _ in 0..6_000 {
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        if cqlite_core::storage::read_path_probe::batched_scans_finished() > 0 {
+            inner_done = true;
+            break;
+        }
     }
+    assert!(
+        inner_done,
+        "the detached batched scan task never terminated after the client dropped \
+         the stream — the abandoned walk is still decoding (counter at {} of \
+         {PARTITIONS})",
+        work_counters::stream_walk_partitions_parsed()
+    );
+    // Both producers have provably finished, so this is the FINAL count.
     let settled = work_counters::stream_walk_partitions_parsed();
     // Observability for the issue-#3384 measurement: under `--nocapture` this
     // prints the observed read-ahead, so the distribution can be re-measured

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -533,30 +533,39 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
     );
 
     // THE stop assertion, on an observed work marker rather than a timing
-    // threshold: wait for the partition-body count to STABILIZE (two equal
-    // consecutive samples), then require it to be bounded below the fixture.
-    // Stabilization is a convergence check, not a deadline — a walk that keeps
-    // decoding simply never converges and the test says so. `PROBE_LOCK`
-    // serializes this file and one file = one process, so no sibling scan
-    // contributes to the counter.
-    let mut settled = work_counters::stream_walk_partitions_parsed();
-    let mut stable = false;
-    for _ in 0..2_000 {
-        for _ in 0..10 {
-            tokio::task::yield_now().await;
-        }
-        let sample = work_counters::stream_walk_partitions_parsed();
-        if sample == settled {
-            stable = true;
+    // threshold: wait for the producer thread to TERMINATE, then read its final
+    // partition-body count.
+    //
+    // This used to wait for the count to STABILIZE (two equal consecutive
+    // samples). That is a sample of another thread's progress, and a producer
+    // that is merely descheduled — or between two increments — is
+    // indistinguishable from one that has stopped, so a cancellation regression
+    // could pass here and drain the fixture immediately afterwards (roborev,
+    // issue #3384). `query_row_producers_finished` is incremented as the last act
+    // of the producer closure, so observing it makes "the walk stopped" a fact
+    // rather than an inference. The loop bound is a liveness guard, not a
+    // deadline. `PROBE_LOCK` serializes this file and one file = one process, so
+    // no sibling scan contributes to either counter.
+    let mut stopped = false;
+    for _ in 0..6_000 {
+        // The producer runs on its own OS thread, so yielding this task is not
+        // enough to let it make progress; sleep briefly instead.
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        if work_counters::query_row_producers_finished() > 0 {
+            stopped = true;
             break;
         }
-        settled = sample;
     }
     assert!(
-        stable,
-        "the walk never stopped decoding partition bodies after the client dropped \
-         the stream (last sample {settled} of {PARTITIONS})"
+        stopped,
+        "the query-row producer never terminated after the client dropped the \
+         stream — the abandoned walk is still running (decoded {} of {PARTITIONS} \
+         partition bodies so far)",
+        work_counters::stream_walk_partitions_parsed()
     );
+    // Read the counter only AFTER the producer has provably exited, so this is
+    // its FINAL value and not a sample of a thread that might resume.
+    let settled = work_counters::stream_walk_partitions_parsed();
     // Observability for the issue-#3384 measurement: under `--nocapture` this
     // prints the observed read-ahead, so the distribution can be re-measured
     // (e.g. before tightening the ceiling) without patching the test. Silent in a

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -607,24 +607,34 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
         "this fixture is expected on the STITCHING branch; if that changed, the drain \
          window below needs re-justifying (issue #3384)"
     );
-    // CONSEQUENCE, stated rather than glossed: the stitching branch decodes in
-    // `spawn_blocking` parse/feed tasks. Blocking tasks are NOT cancellable, so the two
-    // causal signals above — the outer producer and the scan future's drop guard — do
-    // not prove those tasks have stopped. There is no causal signal for them today;
-    // publishing one from the blocking tasks is the real fix and is tracked on #3428.
+    // CONSEQUENCE: the stitching branch decodes in `spawn_blocking` parse/feed halves,
+    // and blocking tasks are NOT cancellable — dropping their `JoinHandle` DETACHES
+    // them. So the two signals above do not prove decoding stopped; a detached half is
+    // still draining. The FIX for that is the third signal below, not a longer sleep: a
+    // fixed drain only makes the race less likely, which is the defect this whole issue
+    // exists to remove, and roborev flagged it twice before I stopped reaching for it.
     //
-    // What IS true: the tail is BOUNDED. Each blocking task feeds a bounded channel and
-    // stops when its consumer is gone, so it cannot run away — which is why the ceiling
-    // below, built from those same buffer sizes, still holds. The drain lets that
-    // bounded tail land. MEASURED, not tuned: without it the observed max was 1280,
-    // with it 2370, and a 10x longer window gives 2048 — LOWER, so the spread is
-    // run-to-run variance and the window is sufficient rather than merely long. It is a
-    // drain for bounded work, never a deadline, and nothing here compares an elapsed
-    // duration to a threshold (#2642).
-    for _ in 0..200 {
+    // `blocking_scan_tasks_inflight()` is a GAUGE — each blocking half holds an RAII
+    // guard — so waiting for ZERO proves every detached half has stopped, without the
+    // test needing to know how many there are. The bound is a liveness guard, not a
+    // deadline.
+    let mut blocking_done = false;
+    for _ in 0..6_000 {
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        if cqlite_core::storage::read_path_probe::blocking_scan_tasks_inflight() == 0 {
+            blocking_done = true;
+            break;
+        }
     }
-    // Both producers have provably finished, so this is the FINAL count.
+    assert!(
+        blocking_done,
+        "detached blocking scan tasks never stopped after the client dropped the \
+         stream — {} still in flight, counter at {} of {PARTITIONS} (issue #3384)",
+        cqlite_core::storage::read_path_probe::blocking_scan_tasks_inflight(),
+        work_counters::stream_walk_partitions_parsed()
+    );
+    // All THREE producers — outer thread, scan future, detached blocking halves —
+    // have provably stopped, so this is the FINAL count.
     let settled = work_counters::stream_walk_partitions_parsed();
     // Observability for the issue-#3384 measurement: under `--nocapture` this
     // prints the observed read-ahead, so the distribution can be re-measured

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -226,22 +226,6 @@ async fn build_generations(batches: Vec<Vec<Mutation>>) -> (tempfile::TempDir, P
 /// Authoritative count of `*-Data.db` generations under the table directory —
 /// the same listing the warm registry's generation probe uses, so a test can
 /// state the source count it is exercising instead of assuming it.
-/// `*-CompressionInfo.db` components under the table dir — zero means every reader
-/// here is uncompressed, hence non-stitching (issue #3384).
-fn count_compression_info(data_dir: &std::path::Path) -> usize {
-    let table_dir = data_dir.join(KS).join(TBL);
-    std::fs::read_dir(&table_dir)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .filter(|e| {
-            e.file_name()
-                .to_str()
-                .is_some_and(|n| n.ends_with("-CompressionInfo.db"))
-        })
-        .count()
-}
-
 fn count_data_dbs(data_dir: &std::path::Path) -> usize {
     let table_dir = data_dir.join(KS).join(TBL);
     std::fs::read_dir(&table_dir)
@@ -525,25 +509,9 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
     // previous case in this binary must not be able to publish into this count.
     cqlite_core::storage::read_path_probe::reset_query_row_producers_finished();
     cqlite_core::storage::read_path_probe::reset_batched_scans_finished();
+    cqlite_core::storage::read_path_probe::reset_batched_scan_stitching_paths();
     let (_temp, data_dir) = build_generations(vec![rows]).await;
     assert_eq!(count_data_dbs(&data_dir), 1);
-    // ENFORCED precondition for the completion signal below (roborev, issue #3384).
-    // That signal is a drop guard on the scan's spawned future, so it covers a
-    // decode loop that runs INSIDE that future. Only NON-STITCHING readers take that
-    // loop: `requires_chunk_stitching()` (compressed `nb`) instead routes to
-    // `run_scan_stream_windowed`, whose `spawn_blocking` parse/feed tasks are not
-    // cancellable and can still be decoding when the guard fires. The write engine
-    // emits UNCOMPRESSED SSTables, so this fixture takes the covered path — asserted
-    // rather than assumed, so switching the fixture to a compressed one cannot
-    // silently turn the signal premature.
-    assert_eq!(
-        count_compression_info(&data_dir),
-        0,
-        "this fixture must stay UNCOMPRESSED: a compressed reader takes the stitching \
-         path, whose spawn_blocking decode is not covered by the completion signal \
-         this test waits on (issue #3384)"
-    );
-
     let svc = CqliteFlightService::new(data_dir, 1)
         .with_egress_budget(EgressBudget::bytes(CANCEL_EGRESS_CEILING));
     let before = ReadPathProbe::snapshot();
@@ -624,6 +592,38 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
          {PARTITIONS})",
         work_counters::stream_walk_partitions_parsed()
     );
+    // WHICH BRANCH THIS FIXTURE TAKES — measured, and it is NOT what two rounds of
+    // plausible inference concluded (roborev, issue #3384).
+    //
+    // It takes the STITCHING branch. Both proxies were wrong: absence of
+    // `CompressionInfo.db` proves nothing, and so does "the write engine emits
+    // uncompressed SSTables" — `requires_chunk_stitching()` is
+    // `data_format() == V5CompressedLegacy && is_nb_format()`, and this fixture
+    // satisfies BOTH. Asserted here so the reasoning below is pinned to a measurement
+    // rather than to an argument, and so a future format change forces it to be redone.
+    assert_eq!(
+        cqlite_core::storage::read_path_probe::batched_scan_stitching_paths(),
+        1,
+        "this fixture is expected on the STITCHING branch; if that changed, the drain \
+         window below needs re-justifying (issue #3384)"
+    );
+    // CONSEQUENCE, stated rather than glossed: the stitching branch decodes in
+    // `spawn_blocking` parse/feed tasks. Blocking tasks are NOT cancellable, so the two
+    // causal signals above — the outer producer and the scan future's drop guard — do
+    // not prove those tasks have stopped. There is no causal signal for them today;
+    // publishing one from the blocking tasks is the real fix and is tracked on #3428.
+    //
+    // What IS true: the tail is BOUNDED. Each blocking task feeds a bounded channel and
+    // stops when its consumer is gone, so it cannot run away — which is why the ceiling
+    // below, built from those same buffer sizes, still holds. The drain lets that
+    // bounded tail land. MEASURED, not tuned: without it the observed max was 1280,
+    // with it 2370, and a 10x longer window gives 2048 — LOWER, so the spread is
+    // run-to-run variance and the window is sufficient rather than merely long. It is a
+    // drain for bounded work, never a deadline, and nothing here compares an elapsed
+    // duration to a threshold (#2642).
+    for _ in 0..200 {
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
     // Both producers have provably finished, so this is the FINAL count.
     let settled = work_counters::stream_walk_partitions_parsed();
     // Observability for the issue-#3384 measurement: under `--nocapture` this

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -36,9 +36,7 @@ use tonic::Request;
 
 use cqlite_core::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
 use cqlite_core::storage::read_path_probe::ReadPathProbe;
-use cqlite_core::storage::sstable::reader::{
-    QUERY_ROWS_MAX_READ_AHEAD_ROWS, QUERY_ROWS_MAX_RESIDENT_ROWS,
-};
+use cqlite_core::storage::sstable::reader::QUERY_ROWS_MAX_READ_AHEAD;
 use cqlite_core::storage::sstable::work_counters;
 use cqlite_core::storage::write_engine::{
     CellOperation, ClusteringKey, Durability, Mutation, PartitionKey, TableId, WriteEngine,
@@ -68,23 +66,27 @@ const CANCEL_BATCH_SIZE: usize = 1;
 ///   crate-private, hence named in prose and covered generously by the `8 *`
 ///   below rather than mirrored as load-bearing literals.)
 /// * **The one core handoff batch** `ScanRowSource` holds as its current row
-///   iterator, which cannot exceed [`QUERY_ROWS_MAX_RESIDENT_ROWS`]. This is the
-///   dominant term.
-const CANCEL_DOWNSTREAM_ROWS: usize = QUERY_ROWS_MAX_RESIDENT_ROWS + 8 * CANCEL_BATCH_SIZE;
+///   iterator — the dominant term. One batch is by construction no larger than the
+///   whole handoff channel's contents, and that in turn is one term of
+///   [`QUERY_ROWS_MAX_READ_AHEAD`], so a second `QUERY_ROWS_MAX_READ_AHEAD`
+///   generously covers it. Deliberately loose: the exact per-batch row count is
+///   crate-internal to cqlite-core, and a loose bound derived from a published one
+///   beats a tight bound copied out of a private constant.
+const CANCEL_DOWNSTREAM_ROWS: usize = QUERY_ROWS_MAX_READ_AHEAD + 8 * CANCEL_BATCH_SIZE;
 
 /// Rows an ABANDONED fast-arm walk may still decode after the client stops
 /// reading — the structural bound the stop assertion is made against.
 ///
 /// It is a CONSTANT, independent of the fixture's size: the producer runs ahead
 /// only as far as the bounded buffers between disk and client allow, then parks
-/// and observes the cancellation. [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] is
+/// and observes the cancellation. [`QUERY_ROWS_MAX_READ_AHEAD`] is
 /// cqlite-core's own sum of those buffers on the arm this test runs (a
 /// no-token-bound `do_get` → the full-ring arm), derived there from the sizings
 /// that actually run; [`CANCEL_DOWNSTREAM_ROWS`] adds what is resident on the
 /// Flight side of the handoff.
 ///
 /// One row per partition in the fixture, so a row bound is a partition bound.
-const CANCEL_DECODE_CEILING: usize = QUERY_ROWS_MAX_READ_AHEAD_ROWS + CANCEL_DOWNSTREAM_ROWS;
+const CANCEL_DECODE_CEILING: usize = QUERY_ROWS_MAX_READ_AHEAD + CANCEL_DOWNSTREAM_ROWS;
 
 /// Partitions in the mid-stream-cancel fixture: a generous multiple of
 /// [`CANCEL_DECODE_CEILING`], so "the walk stopped" and "the walk drained the
@@ -475,7 +477,7 @@ async fn token_pruning_to_one_source_still_selects_the_fast_path() {
 /// (2) used to read `settled < PARTITIONS` over an 800-partition fixture, which
 /// asserted that the cancellation BEAT the producer — a race outcome, ~25-30% red
 /// in isolation (issue #3384). The producer legitimately reads ahead up to
-/// [`QUERY_ROWS_MAX_READ_AHEAD_ROWS`] rows, i.e. THREE TIMES that fixture, so a
+/// [`QUERY_ROWS_MAX_READ_AHEAD`] rows, i.e. THREE TIMES that fixture, so a
 /// full drain was permitted behaviour that the test called a bug. Bounding by the
 /// read-ahead instead keeps the real property (a cancelled walk does O(1) further
 /// work, not O(table)) and makes it a fact about the code rather than about the
@@ -562,7 +564,7 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
         settled <= CANCEL_DECODE_CEILING as u64,
         "the abandoned scan decoded MORE than the pipeline's bounded read-ahead \
          permits: {settled} partition bodies > ceiling {CANCEL_DECODE_CEILING} \
-         (core read-ahead {QUERY_ROWS_MAX_READ_AHEAD_ROWS} + downstream \
+         (core read-ahead {QUERY_ROWS_MAX_READ_AHEAD} + downstream \
          {CANCEL_DOWNSTREAM_ROWS}), fixture {PARTITIONS}. Either the walk ignored \
          the cancellation or a buffer grew without the core bound following it"
     );

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -545,11 +545,13 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
     // that is merely descheduled — or between two increments — is
     // indistinguishable from one that has stopped, so a cancellation regression
     // could pass here and drain the fixture immediately afterwards (roborev,
-    // issue #3384). `query_row_producers_finished` is incremented as the last act
-    // of the producer closure, so observing it makes "the walk stopped" a fact
-    // rather than an inference. The loop bound is a liveness guard, not a
+    // issue #3384). `query_row_producers_finished` is published BEFORE any
+    // message a consumer can act on as terminal — including
+    // `QueryRowBatch::Unsupported`, whose caller drops the stream immediately — so a
+    // producer cannot publish into a LATER case's freshly-reset counter. Observing it
+    // makes "the outer producer stopped" a fact rather than an inference. The loop bound is a liveness guard, not a
     // deadline. `PROBE_LOCK` serializes this file and one file = one process, so
-    // no sibling scan contributes to either counter.
+    // no sibling scan contributes to any of these counters.
     let mut stopped = false;
     for _ in 0..6_000 {
         // The producer runs on its own OS thread, so yielding this task is not
@@ -567,8 +569,9 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
          partition bodies so far)",
         work_counters::stream_walk_partitions_parsed()
     );
-    // BOTH halves must be observed before the counter is final (roborev, issue
-    // #3384). The signal above proves the OUTER query-row producer stopped pulling;
+    // THREE producers must be observed before the counter is final (roborev, issue
+    // #3384) — this is the second. The signal above proves the OUTER query-row
+    // producer stopped pulling;
     // it does NOT prove the INNER batched scan task has stopped DECODING, because
     // `drive_full_scan_rows` drops `BatchedScanStream` without joining its task.
     //

--- a/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
+++ b/cqlite-flight/tests/issue_3058_bypass_path_taken.rs
@@ -566,8 +566,24 @@ async fn fast_arm_stream_stops_when_the_client_drops_it() {
          partition bodies so far)",
         work_counters::stream_walk_partitions_parsed()
     );
-    // Read the counter only AFTER the producer has provably exited, so this is
-    // its FINAL value and not a sample of a thread that might resume.
+    // The completion signal proves the OUTER query-row producer stopped. It does
+    // NOT prove the INNER batched scan task has (roborev, issue #3384):
+    // `drive_full_scan_rows` drops `BatchedScanStream` on its way out and that task
+    // is never joined. The trail is BOUNDED and cannot run away — the inner loop
+    // consults its consumer only when a batch fills, so once the receiver is dropped
+    // it decodes at most one more `BATCH_EMIT_ROWS` batch before its `send` fails and
+    // it returns — but "bounded" is not "finished", so let that trail land before
+    // reading rather than reading the instant the outer thread exits.
+    //
+    // MEASURED, not assumed: without this window the observed maximum was 1280; with
+    // it, 2370. The earlier reads were genuinely non-final. Convergence checked too —
+    // a 10x longer window gives 2048, i.e. LOWER, so the spread is run-to-run variance
+    // and not window-dependence. This is a drain window for a bounded amount of work,
+    // never a deadline, and no assertion here compares an elapsed duration to a
+    // threshold (#2642).
+    for _ in 0..200 {
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
     let settled = work_counters::stream_walk_partitions_parsed();
     // Observability for the issue-#3384 measurement: under `--nocapture` this
     // prints the observed read-ahead, so the distribution can be re-measured

--- a/cqlite-flight/tests/support/flight_server_process.rs
+++ b/cqlite-flight/tests/support/flight_server_process.rs
@@ -190,6 +190,13 @@ pub fn start_server(spec: ServerSpec<'_>) -> ServerProcess {
         for k in spec.env_remove {
             cmd.env_remove(k);
         }
+        // Pin the child's log filter (roborev, issue #3384). Readiness below waits for
+        // an INFO line the server emits after binding, and the child would otherwise
+        // INHERIT `RUST_LOG` — so a developer or CI runner with `RUST_LOG=warn` would
+        // make a perfectly healthy server never become "ready", and the failure would
+        // look like a hung server rather than a filtered log line. Set before the
+        // caller's env so a test can still override it deliberately.
+        cmd.env("RUST_LOG", "info");
         for (k, v) in spec.env {
             cmd.env(k, v);
         }

--- a/cqlite-flight/tests/support/flight_server_process.rs
+++ b/cqlite-flight/tests/support/flight_server_process.rs
@@ -1,0 +1,225 @@
+//! Spawn-and-wait control for the REAL `cqlite-flight` server binary, shared by
+//! the end-to-end knob-wiring tests (issue #3384).
+//!
+//! `tests/issue_2821_egress_budget_e2e.rs` and
+//! `tests/issue_2825_max_batch_bytes_e2e.rs` each carried a byte-identical copy of
+//! this helper. Both copies had the SAME readiness defect (below), so the fix had
+//! to land twice — the shape issue #1577 exists to stop. One definition now, used
+//! by both binaries.
+//!
+//! # The readiness contract, and the defect it replaces
+//!
+//! [`free_port`] binds `127.0.0.1:0`, reads the port and DROPS the listener; the
+//! child then re-binds it. That is a TOCTOU window by construction: another
+//! process (including a sibling test in the same binary, which runs three of these
+//! in parallel) can take the port in the gap, and our child then dies of
+//! `EADDRINUSE`. The window cannot be closed from here — the server binary takes a
+//! `--listen` address, not an inherited socket — so the collision is retried
+//! instead.
+//!
+//! What matters is that the collision is DETECTED. The previous readiness loop
+//! polled `TcpStream::connect_timeout` FIRST and returned the instant it
+//! succeeded, consulting `child.try_wait()` only after a FAILED connect. So when
+//! our child had died of `EADDRINUSE` while the colliding listener still held the
+//! port, the loop returned a DEAD CHILD paired with a FOREIGN SOCKET: the test
+//! then streamed from someone else's server and asserted against its own dead
+//! child's empty log file — which presents exactly as
+//! `startup log does not record the env-configured ceiling`.
+//!
+//! Readiness therefore now means all three of:
+//!
+//! 1. **Our child is alive** (`try_wait()` is `None`) — checked BEFORE a
+//!    successful connect is accepted, and again after, since a child that loses
+//!    the bind race exits promptly at bind time.
+//! 2. **Our child logged its own startup line**, carrying OUR listen address, into
+//!    OUR private temp-dir log. A foreign server cannot put that there.
+//! 3. **The socket accepts.**
+//!
+//! Residual, stated rather than implied away: between (1) and (3) there remains an
+//! unclosable instant in which a live child could die and a foreign listener take
+//! its place. Distinguishing that would need the peer's process identity, which
+//! loopback TCP does not offer. It is strictly narrower than the window the old
+//! loop returned from as a matter of course.
+//!
+//! No assertion here compares an elapsed duration against a threshold (#2642): the
+//! timeouts are liveness bounds on process/socket readiness, not correctness
+//! properties.
+
+#![allow(dead_code)]
+
+use std::net::{SocketAddr, TcpListener};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+/// The startup line `cqlite_flight::cli::log_startup` emits, and the field
+/// carrying the address it was told to listen on. Together they identify OUR
+/// child's log rather than merely "some server started".
+const STARTUP_LINE: &str = "cqlite-flight starting";
+const LISTEN_FIELD: &str = "listen=";
+
+/// Readiness poll budget: 200 attempts x 50ms socket timeout + 50ms sleep.
+const READY_ATTEMPTS: usize = 200;
+const READY_POLL: Duration = Duration::from_millis(50);
+/// Port-collision retries (see the module doc — the TOCTOU is retried, not closed).
+const BIND_ATTEMPTS: usize = 3;
+
+/// A spawned `cqlite-flight` server process, killed on drop so a failing
+/// assertion can never leak a listener.
+pub struct ServerProcess {
+    child: Child,
+    /// The address this server was told to listen on, and (per the readiness
+    /// contract) the one its own startup log records.
+    pub addr: SocketAddr,
+    log: PathBuf,
+    // Kept so the log file outlives the process.
+    _log_dir: tempfile::TempDir,
+}
+
+impl Drop for ServerProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl ServerProcess {
+    /// Everything the server wrote to stdout+stderr so far (the startup log),
+    /// with the `tracing-subscriber` ANSI styling stripped so the field
+    /// assertions match plain `key=value` text.
+    pub fn log(&self) -> String {
+        strip_ansi(&std::fs::read_to_string(&self.log).unwrap_or_default())
+    }
+
+    /// `Some(status)` once the child has exited, `None` while it is running.
+    fn exited(&mut self) -> Option<std::process::ExitStatus> {
+        self.child.try_wait().ok().flatten()
+    }
+
+    /// Has THIS child written its own startup line for THIS listen address?
+    fn logged_own_startup(&self) -> bool {
+        let log = self.log();
+        log.contains(STARTUP_LINE) && log.contains(&format!("{LISTEN_FIELD}{}", self.addr))
+    }
+}
+
+/// Drop CSI escape sequences (`ESC [ <params> <final byte>`) from `s`.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        // Skip the `[` introducer, then every parameter/intermediate byte up to
+        // and including the final byte in `@..=~` (e.g. the `m` of `ESC[32m`).
+        if chars.peek() == Some(&'[') {
+            chars.next();
+        }
+        for c in chars.by_ref() {
+            if ('@'..='~').contains(&c) {
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// An ephemeral loopback port that is free right now (see the module doc for the
+/// TOCTOU this leaves open and how [`start_server`] detects it).
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let port = l.local_addr().expect("local_addr").port();
+    drop(l);
+    port
+}
+
+/// How to launch the server under test.
+pub struct ServerSpec<'a> {
+    /// `--data-dir`.
+    pub data_dir: &'a Path,
+    /// Arguments appended after `--data-dir`/`--listen`.
+    pub args: &'a [String],
+    /// Environment to SET for the child.
+    pub env: &'a [(&'a str, String)],
+    /// Environment to REMOVE first, so a stray value in the developer's
+    /// environment cannot silently change what is under test.
+    pub env_remove: &'a [&'a str],
+}
+
+/// Start the REAL server binary per `spec` and return once it is ready — which
+/// means our own child is alive, has logged its own startup line for our listen
+/// address, and accepts connections (see the module doc).
+///
+/// Panics with the last child's log if no attempt became ready.
+pub fn start_server(spec: ServerSpec<'_>) -> ServerProcess {
+    let exe = env!("CARGO_BIN_EXE_cqlite-flight");
+    let mut last_log = String::new();
+    for _ in 0..BIND_ATTEMPTS {
+        let port = free_port();
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
+        let log_dir = tempfile::TempDir::new().expect("log dir");
+        let log = log_dir.path().join("server.log");
+        let out = std::fs::File::create(&log).expect("log file");
+        let err = out.try_clone().expect("clone log fd");
+
+        let mut cmd = Command::new(exe);
+        cmd.arg("--data-dir")
+            .arg(spec.data_dir)
+            .arg("--listen")
+            .arg(addr.to_string())
+            .args(spec.args)
+            .stdout(Stdio::from(out))
+            .stderr(Stdio::from(err));
+        for k in spec.env_remove {
+            cmd.env_remove(k);
+        }
+        for (k, v) in spec.env {
+            cmd.env(k, v);
+        }
+        let child = cmd.spawn().expect("spawn cqlite-flight");
+        let server = ServerProcess {
+            child,
+            addr,
+            log,
+            _log_dir: log_dir,
+        };
+
+        match wait_until_ready(server) {
+            Ok(ready) => return ready,
+            // Not ready: our child either exited (a lost bind race) or never came
+            // up within the budget. Either way, retry on a fresh port.
+            Err(log) => last_log = log,
+        }
+    }
+    panic!("cqlite-flight never became ready; last server log:\n{last_log}");
+}
+
+/// The readiness contract of the module doc, applied to ONE spawned child.
+///
+/// Takes the child BY VALUE and hands it back on success, so a not-ready child is
+/// dropped (and killed) here rather than escaping to the caller: `Err` carries only
+/// its log, for the panic message.
+fn wait_until_ready(mut server: ServerProcess) -> Result<ServerProcess, String> {
+    for _ in 0..READY_ATTEMPTS {
+        // (1) OUR child must still be running. Checked FIRST: a child that lost
+        // the bind race is already gone, and accepting a connect in that state is
+        // how the old loop paired a dead child with a foreign socket.
+        if server.exited().is_some() {
+            return Err(server.log());
+        }
+        // (2) OUR child must have logged its own startup line for OUR address,
+        // into OUR private log — a foreign server cannot write there. (3) the
+        // socket must accept. Then (1) again: the child could have exited between
+        // the log check and the connect, leaving a foreign listener behind.
+        if server.logged_own_startup()
+            && std::net::TcpStream::connect_timeout(&server.addr, READY_POLL).is_ok()
+            && server.exited().is_none()
+        {
+            return Ok(server);
+        }
+        std::thread::sleep(READY_POLL);
+    }
+    Err(server.log())
+}

--- a/cqlite-flight/tests/support/flight_server_process.rs
+++ b/cqlite-flight/tests/support/flight_server_process.rs
@@ -35,11 +35,19 @@
 //!    OUR private temp-dir log. A foreign server cannot put that there.
 //! 3. **The socket accepts.**
 //!
-//! Residual, stated rather than implied away: between (1) and (3) there remains an
-//! unclosable instant in which a live child could die and a foreign listener take
-//! its place. Distinguishing that would need the peer's process identity, which
-//! loopback TCP does not offer. It is strictly narrower than the window the old
-//! loop returned from as a matter of course.
+//! The startup line used to be the CONFIGURATION line (`cqlite-flight starting`),
+//! and roborev (issue #3384) showed that was not enough: `log_startup` runs BEFORE
+//! `serve_with_shutdown` binds, so a child could log the expected address, lose the
+//! bind race, still be alive when the probe connected to the FOREIGN listener, pass
+//! the final `try_wait`, and only then exit with `EADDRINUSE`. The server now emits
+//! a separate line AFTER `TcpListener::bind` returns (`cli::log_listening`), and
+//! that is what (2) matches — a line no process that failed to bind can have
+//! written.
+//!
+//! Residual, stated rather than implied away: a child could bind, log, and then die
+//! while a foreign process takes the freed port before (3) connects. That requires a
+//! crash in a window bounded by two adjacent statements, rather than the ordinary
+//! bind race the old loop returned from as a matter of course.
 //!
 //! No assertion here compares an elapsed duration against a threshold (#2642): the
 //! timeouts are liveness bounds on process/socket readiness, not correctness
@@ -55,8 +63,15 @@ use std::time::Duration;
 /// The startup line `cqlite_flight::cli::log_startup` emits, and the field
 /// carrying the address it was told to listen on. Together they identify OUR
 /// child's log rather than merely "some server started".
-const STARTUP_LINE: &str = "cqlite-flight starting";
-const LISTEN_FIELD: &str = "listen=";
+/// The POST-BIND readiness line (`cli::log_listening`, issue #3384).
+///
+/// Deliberately NOT the `cqlite-flight starting` configuration line: that one is
+/// written BEFORE the port is acquired, so a child can log it, lose the bind race
+/// to a sibling, and still be alive when the probe connects to the FOREIGN
+/// listener — which is precisely the residual roborev found in the first version
+/// of this readiness fix. Only a line written after `TcpListener::bind` returned
+/// proves this child owns the port.
+const LISTENING_LINE: &str = "cqlite-flight listening on";
 
 /// Readiness poll budget: 200 attempts x 50ms socket timeout + 50ms sleep.
 const READY_ATTEMPTS: usize = 200;
@@ -99,7 +114,7 @@ impl ServerProcess {
     /// Has THIS child written its own startup line for THIS listen address?
     fn logged_own_startup(&self) -> bool {
         let log = self.log();
-        log.contains(STARTUP_LINE) && log.contains(&format!("{LISTEN_FIELD}{}", self.addr))
+        log.contains(&format!("{LISTENING_LINE} {}", self.addr))
     }
 }
 


### PR DESCRIPTION
Fixes #3384. Also fixes #3383, which is one symptom of it. Spawns #3428 and #3434.

## Both issues' stated mechanisms were wrong, and measuring first changed the fix

#3384 blamed **cumulative cross-binary state**; #3383 blamed **intra-package parallelism**. Both were explicitly hypotheses. Neither survived measurement.

| measurement | result |
|---|---|
| per-binary `pid`/`start`/`end` timeline, 10 whole-package runs | **strictly sequential, zero overlap** — cargo does not run test targets concurrently, so #3383's mechanism does not exist |
| whole package | 3 fail / 9 (33%) |
| the victim test **alone in its own process**, all siblings filtered out | **6 fail / 20 (30%)** |
| `issue_2370_gauge_readback_test` alone | 0 / 20 |
| `issue_2821_egress_budget_e2e` alone | 0 / 20 |
| CPU affinity 16 vs 8 cores | 3/10, 1/10 vs 2/10 — no material change |

The victim fails at the same rate with **nothing else in its process**. The "3/3 PASS standalone" in the issue was a small-sample artifact — at 25% that happens 42% of the time.

## The defect: a bound that was never a bound

The test asserted `settled < PARTITIONS` over an 800-row fixture — that a cancellation *beat* a producer. The fast arm reads ahead through four bounded buffers totalling **3072 rows**, nearly 4x that fixture, so the producer never parked. Every captured failure was the saturated `800 of 800`, 7 of 7: a race with no bound can only finish or be interrupted.

`CANCEL_EGRESS_CEILING`'s doc claimed it made the bound hold "by construction". It did not — it meters Arrow batches *downstream* of the read-ahead.

## The fix

1. **Name the bound**, derived from the sizings that actually run (`QUERY_ROWS_MAX_READ_AHEAD`), with `batched_channel_capacity` as one `const fn` shared by the channel constructor and the bound so the arithmetic cannot drift. Unit tests pin each term.
2. **Assert the property that is true**: the walk **stopped** — proven by three causal signals, not by a counter looking still — and stopped **within the read-ahead**, a constant independent of table size. A `const` assertion keeps the fixture at >= 4x the ceiling, so drift fails the **build**.
3. **Fix a latent readiness TOCTOU** shared by two e2e files: `start_server` returned on the first successful connect, so a child dead of `EADDRINUSE` plus a foreign listener read as "ready". The server now **binds explicitly and announces after**, and readiness keys on that line. Extracted to a shared helper so the fix landed once.

## Three causal signals, because two were not enough

The abandoned walk has three producers and each needed its own proof of termination:

| producer | signal |
|---|---|
| outer query-row thread | `query_row_producers_finished`, published before ANY consumer-observable terminal message |
| the scan's detached future | `ScanTaskDone` drop guard, owned by the task so an unpolled future still publishes |
| stitching path's `spawn_blocking` parse/feed halves | `blocking_scan_tasks_inflight()` gauge; the reader waits for ZERO |

**There is no sleep-based reasoning left in the correctness path.** Every RMW on the gauge is `AcqRel` so each decrement acquires the ones before it — a plain `Release` would leave an earlier task's work unordered against a reader that observes zero, which is exactly the finality the gauge exists to provide.

## Evidence

- **30/30** isolated repeats (was 6/20 red), observed read-ahead **768..1536** against the **6152** ceiling.
- Fixture is 31x larger (800 -> 24608 partitions) and the binary is faster (~4s -> 0.5s).
- Full agent-gate **PASS, 30/30 components** (at `0230ec059`; being re-run at the final head).
- roborev **PASS, 0 findings** at `35352de71` — the head that will actually merge, re-run after the rebase because resolving its conflict produced code no review had seen. Thirteen prior rounds produced **seventeen** genuine findings.

## Review history — where most of the value came from

Three of those findings were **false-PASS windows in the very test this issue exists to make trustworthy**: completion published after a terminal message a caller acts on; a counter read while a detached task was still decoding; a gauge that counted a queued task as zero. Two were concurrency defects in the instrumentation itself — an unsound `Release`/`Acquire` chain, and a guard that could never fire if a future was dropped before its first poll.

Two of my own published claims were **wrong and are corrected on the issue**: that the observed max landing exactly on 1280 confirmed the arithmetic (an artifact of reading too early), and that the fixture takes the non-stitching path (an affirmative probe returned the opposite). Both are the defect this issue is about — a proxy that sounds right is not a measurement.

## What this PR deliberately does NOT do

**`issue_2370_gauge_readback_test` is untouched.** Unreproduced in 40 runs, and the one mechanism I could construct is falsified (`CqliteFlightService::new` uses `Admission::unconstrained()`). A speculative fix would read as "flake reduced" while proving nothing.

**#3428** carries the real structural work: the full-ring inner scan never receives the child cancel flag (an all-tombstoned region can decode to the end of the table); `parse_batched_block`/BTI materialize eagerly; and the blocking halves are never joined on cancellation. No test covers the BTI or stitching cancellation paths — that absence is why these were review findings rather than failures.

**#3434** carries the fleet capacity defect found while gating this: disk exhaustion produces a **fake red**, not a queue.

## Notes for the reviewer

- **No `CQLITE_ALLOW_FILE_GROWTH` anywhere.** Net growth against the merge base is zero for every over-threshold file; the sizing constants moved to `query_rows_bounds.rs` rather than being trimmed, because the prose is the safeguard.
- Commit `e13a6751e` is titled `docs(...)` but carries the `const` drift guard. Mislabelled; content is in the diff.
- Once this lands, #1699's `flight-tests` lane can widen to the whole package. Its descope cited intra-package parallelism, which does not exist.

