### PR TITLE
fix(#3367): roborev-lints order-dependence — doctrine scans read an immutable wrapper path

### DIFF
--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -5002,7 +5002,28 @@ _WR_QS=$(cat <<'AWKEOF'
   # set, so `ok "\`grep \"a'b\" \"$WRAPPER\" \"c'd\"\`"` reproduced the same quote confusion and was
   # excused as prose. If a future shell grows a third, this line is where it goes.
   cs = (seg ~ /[$][(]/ || seg ~ /`/) ? 1 : 0
-  printf "%d %d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, cs, seg
+  # A STATE-FREE COUNT over the WHOLE line, used only to detect that the stateful scan stopped early.
+  # A quoted `#` inside a command substitution -- `_x="$(printf " #"; grep -c foo "$WRAPPER")"` --
+  # makes the flat parser believe a comment started, so it BREAKS before the read and reports nothing
+  # at all. Comparing against a count that cannot be fooled by state is how that is caught.
+  # ESCAPES ARE HONOURED HERE TOO, though quote state is not. A backslash is lexically unambiguous —
+  # `\$WRAPPER` is never an expansion, in any context — whereas quote state is exactly what this
+  # counter exists not to trust. Ignoring escapes made every `bad "... \$WRAPPER ..."` diagnostic
+  # that also contains a $( ) look like a hidden read (measured: two false FAILs).
+  tot = 0; j = 1
+  while (j <= n) {
+    if (substr(line, j, 1) == "\\") { j += 2; continue }
+    if (substr(line, j, 1) == "$") {
+      r2 = substr(line, j)
+      if (match(r2, "^[$][{]" VN "[^A-Za-z0-9_]")) tot++
+      else if (match(r2, "^[$]" VN)) {
+        a2 = substr(r2, RLENGTH + 1, 1)
+        if (a2 !~ /[A-Za-z0-9_]/) tot++
+      }
+    }
+    j++
+  }
+  printf "%d %d %d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, cs, tot, seg
 }
 AWKEOF
 )
@@ -5018,7 +5039,8 @@ _wr_classify() {
   _c_q=${_c_rest%% *}; _c_rest=${_c_rest#* }
   _c_mk=${_c_rest%% *}; _c_rest=${_c_rest#* }
   _c_ev=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_bal=${_c_rest%% *}; _c_cs=${_c_rest##* }
+  _c_bal=${_c_rest%% *}; _c_rest=${_c_rest#* }
+  _c_cs=${_c_rest%% *}; _c_tot=${_c_rest##* }
   # AN UNRELIABLE PARSE YIELDS NO VERDICT (reviewer). Checked FIRST: every field below is derived
   # from the same state machine, so if it ended the line inside a quote, none of them can be trusted.
   # DEFAULTS TO UNTRUSTWORTHY, not to balanced. This is the one field whose job is to say "do not
@@ -5032,6 +5054,11 @@ _wr_classify() {
   # permitted invocation while a SECOND, inside the substitution, is mis-paired into `lit` and never
   # judged at all — the arity rule counts only `code`, so it does not see it either. Inside `$( )`
   # the flat parse cannot be trusted about ANY occurrence, so no occurrence there may be excused.
+  # ...and an occurrence the stateful scan never reached, on a line carrying a substitution, means
+  # the parse stopped early (a quoted `#` read as a comment opener). Refuse rather than report none.
+  if [ "${_c_cs:-1}" -eq 1 ] && [ "${_c_tot:-0}" -gt $(( ${_c_code:-0} + ${_c_lit:-0} )) ]; then
+    printf 'substitution %s\n' "${_c_tot:-0}"; return
+  fi
   if [ "${_c_cs:-1}" -eq 1 ] && [ "${_c_lit:-0}" -gt 0 ]; then
     printf 'substitution %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
   fi
@@ -5132,7 +5159,7 @@ _wr_scan_file() {
       *) _wr_unknown="$_wr_unknown${_wr_unknown:+; }${_wr_num_line%%:*}:<$_wr_v>" ;;
     esac
   done <<EOF
-$(grep -nE '[$][{]?'"$_wr_vname"'[}]?' "$_sf_file" | grep -vE '^[0-9]+:[[:space:]]*#')
+$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$_sf_file" | grep -nE '[$][{]?'"$_wr_vname"'[}]?' | grep -vE '^[0-9]+:[[:space:]]*#')
 EOF
   # ONE category, worst-first. `empty` is the affirmative-measurement case: no ACCEPTED occurrence
   # means the pass had no subject, which is never a clean verdict.
@@ -5301,7 +5328,14 @@ while IFS= read -r _wr_u; do
   # exempts ITSELF and scans the alias — the self-authorisation shape again, on the one check that
   # had not yet been converted. The scanner already computes this; ask it rather than re-deciding.
   _wr_umk=$(printf '%s\n' "$_wr_u" | awk -v VN="$_wr_vname" -v MK="$_wr_marker" "$_WR_QS" | head -1)
-  _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk##* }
+  # Fields: code lit q mk ev bal cs tot -- strip the four after `mk`, then take the last. (Adding
+  # `tot` silently shifted this and marked the restore assert unmarked: a positional read of a
+  # widening record. Named extraction would be better; the count is asserted below instead.)
+  _wr_umk_n=$(printf '%s\n' "$_wr_umk" | tr ' ' '\n' | grep -c .)
+  if [ "${_wr_umk_n:-0}" -ne 8 ]; then
+    bad "structural (#3367): the quote scanner emits ${_wr_umk_n:-0} fields, not the 8 this extraction expects — a field was added or removed and every positional read of it is now wrong"
+  fi
+  _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk##* }
   [ "${_wr_umk:-0}" -eq 1 ] && continue
   _wr_ut=${_wr_uc#"${_wr_uc%%[! ]*}"}
   _wr_is_restore=no

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -32,6 +32,17 @@ set -uo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 WRAPPER="$SCRIPT_DIR/../flow/roborev-review.sh"
+# THE SAME PATH, NEVER REASSIGNED (#3367). `WRAPPER` is deliberately repointed at a scratch
+# copy by the gate-mock cases (~2251/~2354) and restored after, so ANY check that READS the
+# wrapper as a doctrine SUBJECT is order-dependent if it reads `WRAPPER`: its verdict then
+# depends on a global set ~2000 lines away, which is what made the classifier-GONE assert
+# flip between runs at an unchanged tree. Structural scans read THIS variable; only the
+# cases that EXECUTE or COPY the wrapper in their own context keep using `WRAPPER`.
+#
+# Note the direction of the hazard now: with the `--help` prose exemption in place, a scan
+# that lands on the scratch copy finds nothing and reports CLEAN — a false pass, which is
+# worse than the false fail that surfaced the bug.
+WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
 # The structured waiver scanner the wrapper delegates to (#3312 job 26). Defined HERE, beside
 # WRAPPER, because run_wrapper passes it on every call — the structural section is too late.
 SCAN_TOOL="$SCRIPT_DIR/../flow/roborev-waiver-scan.py"
@@ -2240,7 +2251,7 @@ reset_stub
 # CHANGED the file before its run is believed.
 _gm_dir="$tmp/grammar-mutant"
 mkdir -p "$_gm_dir"
-cp "$WRAPPER" "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" \
+cp "$WRAPPER_REAL" "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" \
   "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$_gm_dir/"
 if [ -f "$SCRIPT_DIR/../flow/roborev-job-facts.py" ]; then
   cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$_gm_dir/"
@@ -3466,7 +3477,7 @@ reset_stub
 work=$(make_fixture case_w3 pushed)
 lonely_checks="$tmp/lonely-checks"
 mkdir -p "$lonely_checks"
-cp "$WRAPPER" "$lonely_checks/roborev-review.sh"
+cp "$WRAPPER_REAL" "$lonely_checks/roborev-review.sh"
 cp "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" "$lonely_checks/"
 cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$lonely_checks/" 2>/dev/null || true
 CASE_N=$((CASE_N + 1))
@@ -3488,7 +3499,7 @@ reset_stub
 work=$(make_fixture case_w4 pushed)
 trunc_checks="$tmp/trunc-checks"
 mkdir -p "$trunc_checks"
-cp "$WRAPPER" "$trunc_checks/roborev-review.sh"
+cp "$WRAPPER_REAL" "$trunc_checks/roborev-review.sh"
 cp "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" "$trunc_checks/"
 cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$trunc_checks/" 2>/dev/null || true
 printf '# corrupt: defines nothing\n' >"$trunc_checks/roborev-review-checks.sh"
@@ -3533,7 +3544,7 @@ reset_stub
 work=$(make_fixture case_w pushed)
 lonely="$tmp/lonely"
 mkdir -p "$lonely"
-cp "$WRAPPER" "$lonely/roborev-review.sh"
+cp "$WRAPPER_REAL" "$lonely/roborev-review.sh"
 cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$lonely/" 2>/dev/null || true
 CASE_N=$((CASE_N + 1))
 OUT="$tmp/out-$CASE_N.txt"
@@ -3554,7 +3565,7 @@ reset_stub
 work=$(make_fixture case_w2 pushed)
 truncated="$tmp/truncated"
 mkdir -p "$truncated"
-cp "$WRAPPER" "$truncated/roborev-review.sh"
+cp "$WRAPPER_REAL" "$truncated/roborev-review.sh"
 printf '# corrupt: defines nothing\n' >"$truncated/roborev-review-oracles.sh"
 CASE_N=$((CASE_N + 1))
 OUT="$tmp/out-$CASE_N.txt"
@@ -4138,7 +4149,7 @@ printf '== (wv31) JOB 26/27: an ABSENT scanner is UNAVAILABLE, never a text fall
 reset_stub
 noscan="$tmp/flow-without-scanner"
 mkdir -p "$noscan"
-cp "$WRAPPER" "$noscan/roborev-review.sh"
+cp "$WRAPPER_REAL" "$noscan/roborev-review.sh"
 cp "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" "$noscan/"
 cp "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$noscan/"
 cp "$SCRIPT_DIR/../flow/roborev-job-facts.py" "$noscan/"
@@ -4397,7 +4408,7 @@ fi
 # The heredoc must stay backtick-free, which is the pre-existing convention in this body: the
 # delimiter cannot be quoted (the body interpolates $PROGNAME and friends), so there is no escaping
 # strategy to get right — only the absence of backticks.
-_help_body=$(awk '/^usage\(\) \{/ { inu = 1 } inu { print } inu && /^EOF$/ { exit }' "$WRAPPER")
+_help_body=$(awk '/^usage\(\) \{/ { inu = 1 } inu { print } inu && /^EOF$/ { exit }' "$WRAPPER_REAL")
 case "$_help_body" in
   '') bad '--help: the usage heredoc could not be extracted, so its backtick-freedom was not checked' ;;
   *'`'*) bad '--help: the usage heredoc contains a BACKTICK. The delimiter is unquoted (so $PROGNAME interpolates), which makes a backtick command substitution: it prints an error to stderr AND deletes the term from the rendered help. Use plain text — the surrounding help prose names flags and keys unquoted.' ;;
@@ -4515,7 +4526,7 @@ if [ "${_unq_defs:-0}" -eq 1 ]; then
 else
   bad "structural: expected exactly 1 definition of roborev_unquote_path, found ${_unq_defs:-0}"
 fi
-_unq_callers=$(grep -nE '(^|[^#])roborev_unquote_path ' "$ORACLES" "$CHECKS_FILE" "$WRAPPER" \
+_unq_callers=$(grep -nE '(^|[^#])roborev_unquote_path ' "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL" \
   | grep -v '^[^:]*:[0-9]*: *#' || true)
 _unq_caller_files=$(printf '%s\n' "$_unq_callers" | sed -n 's|^\([^:]*\):.*|\1|p' | sort -u | wc -l | tr -d '[:space:]')
 if [ "${_unq_caller_files:-0}" -eq 1 ] && printf '%s' "$_unq_callers" | grep -qF 'roborev-review-oracles.sh'; then
@@ -4673,13 +4684,75 @@ esac
 # measurement the wrapper no longer makes.
 _skeys=""
 for _sk in snapshot-path snapshot-containment snapshot-expected; do
-  grep -qF "emit_kv '$_sk'" "$WRAPPER" && _skeys="$_skeys $_sk"
+  grep -qF "emit_kv '$_sk'" "$WRAPPER_REAL" && _skeys="$_skeys $_sk"
 done
 if [ -z "$_skeys" ]; then
   ok 'structural: the block emits no snapshot-* keys (nothing is classified, so there is nothing to record about a mode)'
 else
   bad "structural: the block still emits —$_skeys. Those keys described the retired classifier's output (#3312 ruling (4))"
 fi
+# ===== THE DOCTRINE SCANS MUST NOT READ A MUTABLE GLOBAL (#3367) =====
+# The classifier-GONE assert above FAILed once on a branch whose diff touched no `scripts/` file at
+# all, then passed 4/4 at the same commit and an unchanged tree. Cause: it read `"$WRAPPER"`, which
+# the gate-mock cases repoint at a scratch copy ~2000 lines earlier and restore afterwards. A check
+# whose SUBJECT is chosen by a global another case mutates is order-dependent by construction.
+#
+# Two pins, because fixing the call sites without pinning them just waits for the next one:
+#   (1) STRUCTURAL — no text-scanning read of `$WRAPPER` may exist in this file. Invocations
+#       (`bash "$WRAPPER"`) are exempt: those cases mean the copy in their own context.
+#   (2) BEHAVIOURAL — with `WRAPPER` deliberately poisoned, the scan's verdict must not move, and
+#       the same scan against the poisoned path MUST move. Without the second half, (2) would pass
+#       for a scan that reads nothing at all.
+_wr_scan_leaks=$(grep -nE '(grep|awk|sed|cp|wc|head|tail)[^|]*"\$WRAPPER"' "$TEST_SELF" \
+  | grep -v 'bash "\$WRAPPER"' || true)
+if [ -z "$_wr_scan_leaks" ]; then
+  ok 'structural (#3367): no doctrine scan reads the mutable $WRAPPER — every text scan uses $WRAPPER_REAL, so no verdict depends on which case ran last'
+else
+  bad "structural (#3367): a doctrine scan still reads the mutable \$WRAPPER, so its verdict depends on gate-mock ordering — $(printf '%s' "$_wr_scan_leaks" | head -3 | tr '\n' ';')"
+fi
+# ...and `WRAPPER_REAL` must never be reassigned, or it is just `WRAPPER` with a longer name.
+_wr_real_writes=$(grep -cE '^[[:space:]]*WRAPPER_REAL=' "$TEST_SELF")
+if [ "$_wr_real_writes" -eq 1 ]; then
+  ok 'structural (#3367): WRAPPER_REAL is assigned exactly once, so it cannot acquire the order dependence it exists to avoid'
+else
+  bad "structural (#3367): WRAPPER_REAL is assigned $_wr_real_writes times; it must be written exactly once"
+fi
+# BEHAVIOURAL: poison `WRAPPER` and re-run the classifier scan both ways.
+_wr_poison_dir="$tmp/wrapper-poison"
+mkdir -p "$_wr_poison_dir"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  # An EXECUTABLE reintroduction, not prose: an assignment the awk filter cannot exempt.
+  printf '%s\n' 'ROBOREV_DIFF_SOURCE_STATE="mixed-delivery"'
+} >"$_wr_poison_dir/roborev-review.sh"
+_wr_saved="$WRAPPER"
+WRAPPER="$_wr_poison_dir/roborev-review.sh"
+_cls_via_real=$(awk '
+  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
+  in_usage && /^EOF$/ { in_usage = 0; next }
+  in_usage { next }
+  /^[[:space:]]*#/ { next }
+  { print }
+' "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL" 2>/dev/null || true)
+_cls_via_mutable=$(awk '
+  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
+  in_usage && /^EOF$/ { in_usage = 0; next }
+  in_usage { next }
+  /^[[:space:]]*#/ { next }
+  { print }
+' "$ORACLES" "$CHECKS_FILE" "$WRAPPER" 2>/dev/null || true)
+WRAPPER="$_wr_saved"
+_wr_real_hit=no; _wr_mut_hit=no
+case "$_cls_via_real"    in *'mixed-delivery'*) _wr_real_hit=yes ;; esac
+case "$_cls_via_mutable" in *'mixed-delivery'*) _wr_mut_hit=yes ;; esac
+if [ "$_wr_real_hit" = no ] && [ "$_wr_mut_hit" = yes ]; then
+  ok 'behavioural (#3367): with $WRAPPER poisoned, the scan via $WRAPPER_REAL is unaffected while the same scan via $WRAPPER flags it — the immutable path is what makes the verdict stable, and the scan is demonstrably not blind'
+elif [ "$_wr_mut_hit" = no ]; then
+  bad 'behavioural (#3367): the poisoned wrapper was NOT flagged even when scanned directly, so this case cannot show anything about path stability (the fixture or the filter is wrong)'
+else
+  bad 'behavioural (#3367): the scan via $WRAPPER_REAL picked up the poisoned copy, so it is still reading a mutable path'
+fi
+
 # ===== ABSENCE IS A FAIL, AND THE WAIVER IS THE ONLY WAY PAST IT =====
 _pc_start=$(grep -nE '^roborev_check_prompt_content\(\) \{' "$CHECKS_FILE" | head -1 | cut -d: -f1)
 _pc_end=$(awk -v s="${_pc_start:-0}" 'NR>s && /^}/ {print NR; exit}' "$CHECKS_FILE")
@@ -4695,15 +4768,15 @@ fi
 # THE WAIVER TOKEN IS DISTINCT FROM `PASS`, so no reader grepping `prompt-content: PASS` counts a waived
 # run as a certification — the false-assurance shape this whole issue is about.
 if ! grep -qE 'PROMPT_CONTENT="PASS \(.*[Ww]aive' "$CHECKS_FILE" \
-  && grep -qF 'WAIVED|SKIP|NOTICE' "$WRAPPER"; then
+  && grep -qF 'WAIVED|SKIP|NOTICE' "$WRAPPER_REAL"; then
   ok 'structural: a waived absence reports the DISTINCT token WAIVED, and the grammar recognises it'
 else
   bad 'structural: a waived absence is spelled as a PASS, or WAIVED is outside the block grammar — either way a reader cannot tell a waived run from a certified one (#3312 ruling (4))'
 fi
 # THE AFFIRMATION BACKSTOP ADMITS `WAIVED` ONLY ON COMPLETE PROVENANCE, and gates on the provenance
 # rather than on which key carries it: a key-scoped exemption is the shape the ruling deleted.
-_aff_start=$(grep -nF 'for keyed in "push-assert=$PUSH_ASSERT"' "$WRAPPER" | head -1 | cut -d: -f1)
-_aff_body=$(sed -n "${_aff_start:-1},$(( ${_aff_start:-1} + 30 ))p" "$WRAPPER")
+_aff_start=$(grep -nF 'for keyed in "push-assert=$PUSH_ASSERT"' "$WRAPPER_REAL" | head -1 | cut -d: -f1)
+_aff_body=$(sed -n "${_aff_start:-1},$(( ${_aff_start:-1} + 30 ))p" "$WRAPPER_REAL")
 if printf '%s\n' "$_aff_body" | grep -qF 'ROBOREV_WAIVER_SCOPE:-}" = "base=${RANGE_BASE_SHA:-} head=${HEAD_SHA:-} job=${JOB:-}"' \
   && printf '%s\n' "$_aff_body" | grep -qF 'ROBOREV_WAIVER_STATE:-}" = "granted"' \
   && ! printf '%s\n' "$_aff_body" | grep -qF 'det_key" = "prompt-content"'; then
@@ -4921,9 +4994,9 @@ printf '== structural: NO summary value or DETAILS line is emitted un-neutralise
 # per-site escape is a list to keep complete — the next value to grow a path interpolation
 # would silently reopen the hole — so the boundary is `emit_kv` + `finish`, and it is
 # asserted against the emitting statements themselves.
-_em_start=$(grep -nE '^emit_summary\(\) \{' "$WRAPPER" | head -1 | cut -d: -f1)
+_em_start=$(grep -nE '^emit_summary\(\) \{' "$WRAPPER_REAL" | head -1 | cut -d: -f1)
 _em_end=""
-[ -z "$_em_start" ] || _em_end=$(awk -v s="$_em_start" 'NR>s && /^}/ {print NR; exit}' "$WRAPPER")
+[ -z "$_em_start" ] || _em_end=$(awk -v s="$_em_start" 'NR>s && /^}/ {print NR; exit}' "$WRAPPER_REAL")
 if [ -z "$_em_start" ] || [ -z "$_em_end" ]; then
   bad 'structural: could not locate the emit_summary() body to inspect'
 else
@@ -4931,13 +5004,13 @@ else
   # CONTROL FLOW IS ALLOWED, VALUES ARE NOT (#3312): the three snapshot keys are emitted only in snapshot
   # mode, so the body now contains `if`/`else`/`fi`. Those carry no value; what must never appear is a raw
   # `printf` of one, which is asserted separately below.
-  _em_raw=$(sed -n "$((_em_start + 1)),$((_em_end - 1))p" "$WRAPPER" \
+  _em_raw=$(sed -n "$((_em_start + 1)),$((_em_end - 1))p" "$WRAPPER_REAL" \
     | grep -vE '^[[:space:]]*(#|$)' \
     | grep -vE "^[[:space:]]*emit_kv '" \
     | grep -vE '^[[:space:]]*(if|elif|else|fi|then)\b' \
     | grep -vE '^[[:space:]]*(if|elif) \[' \
     | grep -vF "printf '==== ROBOREV REVIEW SUMMARY ====" || true)
-  _em_printfs=$(sed -n "$((_em_start + 1)),$((_em_end - 1))p" "$WRAPPER" \
+  _em_printfs=$(sed -n "$((_em_start + 1)),$((_em_end - 1))p" "$WRAPPER_REAL" \
     | grep -E '^[[:space:]]*printf' | grep -vF "printf '==== ROBOREV REVIEW SUMMARY ====" || true)
   if [ -n "$_em_printfs" ]; then
     bad "structural: emit_summary printf's a value directly, bypassing the neutralising boundary: ${_em_printfs%%$'\n'*}"
@@ -4952,14 +5025,14 @@ else
   # 22 emit_kv lines = 21 keys + the terminal `RESULT:`, which goes through the SAME
   # neutralising boundary. Was 23 before #3229's owner ruling removed `census-exclusion:`
   # with its oracle (#3283).
-  _em_n=$(sed -n "$((_em_start + 1)),$((_em_end - 1))p" "$WRAPPER" | grep -cE "^[[:space:]]*emit_kv '" || true)
+  _em_n=$(sed -n "$((_em_start + 1)),$((_em_end - 1))p" "$WRAPPER_REAL" | grep -cE "^[[:space:]]*emit_kv '" || true)
   if [ "${_em_n:-0}" -ge 22 ]; then
     ok "structural: all $_em_n block lines (21 keys + RESULT:) are emitted through the neutralising boundary"
   else
     bad "structural: only ${_em_n:-0} emit_kv call(s) in emit_summary — the block has 21 keys plus RESULT:, so some are emitted another way"
   fi
 fi
-if grep -qE '^[[:space:]]*roborev_safe_line "\$2"' "$WRAPPER"; then
+if grep -qE '^[[:space:]]*roborev_safe_line "\$2"' "$WRAPPER_REAL"; then
   ok 'structural: emit_kv neutralises its value before printing it'
 else
   bad 'structural: emit_kv does not call roborev_safe_line — the boundary is decorative'
@@ -4967,16 +5040,16 @@ fi
 # DETAILS reach the SAME stdout a reader greps for `^RESULT: `, so the bulk
 # `printf '%s\n' "${DETAILS[@]}"` (which prints a newline-bearing entry as several lines)
 # must be gone, replaced by a per-entry neutralised print.
-if grep -qE 'printf .%s..n. "\$\{DETAILS\[@\]\}"' "$WRAPPER"; then
+if grep -qE 'printf .%s..n. "\$\{DETAILS\[@\]\}"' "$WRAPPER_REAL"; then
   bad 'structural: finish still bulk-prints "${DETAILS[@]}" — a newline-bearing DETAILS entry would span lines and could forge a RESULT: line'
 else
   ok 'structural: DETAILS are not bulk-printed (each entry is neutralised individually)'
 fi
-_fin_start=$(grep -nE '^finish\(\) \{' "$WRAPPER" | head -1 | cut -d: -f1)
+_fin_start=$(grep -nE '^finish\(\) \{' "$WRAPPER_REAL" | head -1 | cut -d: -f1)
 _fin_end=""
-[ -z "$_fin_start" ] || _fin_end=$(awk -v s="$_fin_start" 'NR>s && /^}/ {print NR; exit}' "$WRAPPER")
+[ -z "$_fin_start" ] || _fin_end=$(awk -v s="$_fin_start" 'NR>s && /^}/ {print NR; exit}' "$WRAPPER_REAL")
 if [ -n "$_fin_start" ] && [ -n "$_fin_end" ] \
-  && sed -n "${_fin_start},${_fin_end}p" "$WRAPPER" | grep -q 'roborev_safe_line'; then
+  && sed -n "${_fin_start},${_fin_end}p" "$WRAPPER_REAL" | grep -q 'roborev_safe_line'; then
   ok "structural: finish neutralises every DETAILS line (lines $_fin_start-$_fin_end)"
 else
   bad 'structural: finish does not neutralise DETAILS lines'
@@ -5003,16 +5076,16 @@ printf '== structural: NOTICE is OUTSIDE the failing-capable verdict scan ==\n'
 #   _scan_keys  = the `for … ; do` KEY LIST alone (continuation-aware; this is what must
 #                 name every per-check key)
 #   _scan_case  = the classifying `case` line from within the loop
-_scan_start=$(grep -nE '^[[:space:]]*for verdict in ' "$WRAPPER" | head -1 | cut -d: -f1 || printf '')
+_scan_start=$(grep -nE '^[[:space:]]*for verdict in ' "$WRAPPER_REAL" | head -1 | cut -d: -f1 || printf '')
 _scan_end=''
 if [ -n "$_scan_start" ]; then
-  _scan_end=$(awk -v s="$_scan_start" 'NR>s && /^[[:space:]]*done[[:space:]]*$/ {print NR; exit}' "$WRAPPER")
+  _scan_end=$(awk -v s="$_scan_start" 'NR>s && /^[[:space:]]*done[[:space:]]*$/ {print NR; exit}' "$WRAPPER_REAL")
 fi
 _scan_block=''
 _scan_keys=''
 _scan_case=''
 if [ -n "$_scan_start" ] && [ -n "$_scan_end" ]; then
-  _scan_block=$(sed -n "${_scan_start},${_scan_end}p" "$WRAPPER")
+  _scan_block=$(sed -n "${_scan_start},${_scan_end}p" "$WRAPPER_REAL")
   # The key list ends at the first line that does not continue with a trailing backslash.
   _scan_keys=$(printf '%s\n' "$_scan_block" | awk '{print} !/\\$/{exit}')
   _scan_case=$(printf '%s\n' "$_scan_block" | grep -E 'case "\$verdict_token" in' | head -1 || printf '')
@@ -5082,14 +5155,14 @@ else
   # six deterministic keys, so a key added to the block later is not silently exempt from it.
   # The `PASS)` arm is EXACT, matched on the token: a `PASS*` glob would let `PASSthisNeverRan`
   # satisfy the very backstop that exists to reject non-measurements (#3229 M3).
-  if grep -qE '^[[:space:]]*not_affirmed="\$\{not_affirmed' "$WRAPPER" &&
-    grep -qE '^[[:space:]]*PASS\) continue ;;' "$WRAPPER" &&
-    grep -qE '^[[:space:]]*case "\$\{det_value%% \*\}" in' "$WRAPPER"; then
+  if grep -qE '^[[:space:]]*not_affirmed="\$\{not_affirmed' "$WRAPPER_REAL" &&
+    grep -qE '^[[:space:]]*PASS\) continue ;;' "$WRAPPER_REAL" &&
+    grep -qE '^[[:space:]]*case "\$\{det_value%% \*\}" in' "$WRAPPER_REAL"; then
     ok 'structural: a PASS requires each verdict-carrying key to be affirmatively PASS, matched on the exact token (the SKIP backstop)'
     _aff_missing=""
     for _aff_key in push-assert census-check code-free sha-assert \
       review-completed prompt-content; do
-      grep -qE "\"$_aff_key=\\\$[A-Z_]+\"" "$WRAPPER" || _aff_missing="$_aff_missing $_aff_key"
+      grep -qE "\"$_aff_key=\\\$[A-Z_]+\"" "$WRAPPER_REAL" || _aff_missing="$_aff_missing $_aff_key"
     done
     if [ -z "$_aff_missing" ]; then
       ok 'structural: all six deterministic keys are named in the affirmation backstop'
@@ -5106,7 +5179,7 @@ else
   # reach `finish PASS` on a non-measurement, which is the whole defect class). Read from the
   # backstop's own `case` body, so a `NOTICE*)` arm elsewhere in the wrapper cannot satisfy or
   # break it.
-  _aff_body=$(awk '/for keyed in "push-assert=/ { inb = 1 } inb { print } inb && /^[[:space:]]*esac[[:space:]]*$/ { exit }' "$WRAPPER")
+  _aff_body=$(awk '/for keyed in "push-assert=/ { inb = 1 } inb { print } inb && /^[[:space:]]*esac[[:space:]]*$/ { exit }' "$WRAPPER_REAL")
   if [ -z "$_aff_body" ]; then
     bad 'structural: could not locate the affirmation backstop case body to inspect for per-key exemptions'
   else
@@ -5130,7 +5203,7 @@ else
   fi
   # And the wrapper must STATE the rule, not just implement it: the next key added to this
   # block is written by someone reading the doc block, not the scan.
-  if grep -qF 'A POSITIVE VERDICT REQUIRES AN AFFIRMATIVE MEASUREMENT' "$WRAPPER"; then
+  if grep -qF 'A POSITIVE VERDICT REQUIRES AN AFFIRMATIVE MEASUREMENT' "$WRAPPER_REAL"; then
     ok 'structural: the wrapper states the affirmative-measurement rule the whole block obeys'
   else
     bad 'structural: the wrapper no longer states the affirmative-measurement rule — the invariant would have to be re-derived from the code by every reader'
@@ -5145,14 +5218,14 @@ else
   else
     ok 'structural: the deleted census-exclusion key is absent from the verdict-scan key list'
   fi
-  if grep -qE "emit_kv 'census-exclusion'" "$WRAPPER"; then
+  if grep -qE "emit_kv 'census-exclusion'" "$WRAPPER_REAL"; then
     bad 'structural: the summary block still emits a census-exclusion key whose oracle is deleted'
   else
     ok 'structural: the summary block no longer emits census-exclusion (removal visible in the OUTPUT contract, not just the source)'
   fi
   for _gone_fn in roborev_check_census_exclusion roborev_format_exclude_args \
     roborev_toml_exclude_patterns roborev_parse_toml_array roborev_corroborate_exclude_patterns; do
-    if grep -qE "(^|[^#[:alnum:]_])$_gone_fn\b" "$WRAPPER" "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" \
+    if grep -qE "(^|[^#[:alnum:]_])$_gone_fn\b" "$WRAPPER_REAL" "$SCRIPT_DIR/../flow/roborev-review-oracles.sh" \
       "$SCRIPT_DIR/../flow/roborev-review-checks.sh"; then
       bad "structural: $_gone_fn is still referenced by the flow scripts — the deletion is incomplete"
     else
@@ -5201,7 +5274,7 @@ fi
 
 printf '== hermeticity: the wrapper never reaches a real roborev ==\n'
 reset_stub
-if grep -qE '^\s*roborev (review|show|list)' "$WRAPPER"; then
+if grep -qE '^\s*roborev (review|show|list)' "$WRAPPER_REAL"; then
   ok 'wrapper invokes roborev only through PATH resolution (stubbable)'
 else
   # shellcheck disable=SC2016 # the backticks are prose in the failure message

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4628,17 +4628,37 @@ _cls_exec_lines() {
     }
     return s
   }
+  # The line with quoted spans BLANKED and the comment removed, so a construct can be recognised in
+  # CODE position only. `printf %s '"'"'cat <<EOF'"'"'` must not open heredoc suppression (roborev job 48).
+  function unq_of(s2,   n3, i3, sq3, dq3, c3, out) {
+    n3 = length(s2); sq3 = 0; dq3 = 0; out = ""
+    for (i3 = 1; i3 <= n3; i3++) {
+      c3 = substr(s2, i3, 1)
+      if (!sq3 && c3 == "\\") { i3++; out = out "  "; continue }
+      if (sq3) { out = out " "; if (c3 == "'"'"'") sq3 = 0; continue }
+      if (dq3) { out = out " "; if (c3 == "\"") dq3 = 0; continue }
+      if (c3 == "'"'"'") { sq3 = 1; out = out " "; continue }
+      if (c3 == "\"") { dq3 = 1; out = out " "; continue }
+      if (c3 == "#" && (i3 == 1 || substr(s2, i3-1, 1) ~ /[ \t]/)) break
+      out = out c3
+    }
+    return out
+  }
   # SUPPRESS THE HEREDOC BODY, NOT THE WHOLE FUNCTION (roborev job 47). Suppression used to begin at
   # `usage() {`, so any EXECUTABLE statement between the function opener and its `cat <<EOF` was
   # invisible to the classifier-GONE scan — a reintroduction parked there passed the guard, and the
   # AC3 control did not cover it because it appends only OUTSIDE the function. What earns the
   # exemption is being PROSE PRINTED TO A USER, which starts at the heredoc opener, not at the `{`.
   FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage_fn = 1 }
-  in_usage_fn && /cat[ \t]*<<-?[ \t]*.?EOF/ { in_usage_fn = 0; in_usage = 1; next }
+  in_usage_fn && unq_of($0) ~ /(^|[ \t;&|(])cat[ \t]+<<-?[ \t]*.?EOF/ { in_usage_fn = 0; in_usage = 1; next }
   in_usage && /^EOF$/ { in_usage = 0; next }
   in_usage { next }
   /^[[:space:]]*#/ { next }
-  { print code_of($0) }
+  # A SUBSTITUTION LINE KEEPS ITS TAIL. Inside `$( )` a quoted `#` looks like a comment opener to
+  # this flat parser, so stripping the "comment" could hide a prohibited token that bash executes
+  # (roborev job 48). Emitting the whole line risks only a false FAIL on a genuine trailing comment
+  # of a substitution line naming a retired state — the safe direction.
+  { print ($0 ~ /[$][(]/ || $0 ~ /`/) ? $0 : code_of($0) }
 ' "$@" 2>/dev/null || true
 }
 # ===== THE CLASSIFIER IS GONE, AND MUST STAY GONE (owner ruling (4), #3312) =====
@@ -5392,6 +5412,56 @@ if [ -z "$_wr_ax_bad" ]; then
   ok 'structural control (#3367): the alias-declaration exemption matches the declaration EXACTLY — a line merely quoting the alias names is still judged, so it cannot exempt itself while scanning an alias'
 else
   bad "structural control (#3367): the alias-declaration exemption misclassifies a synthetic line, so a line quoting the declaration could skip the alias-use check —$_wr_ax_bad"
+fi
+# ===== THE COMPLETE SET OF WAYS TO READ A SHELL VARIABLE (roborev job 48) =====
+# `eval 'grep foo "$WRAP''PER"'` reads the wrapper and NO textual scan for `$WRAPPER` can see it:
+# shell concatenates adjacent quoted strings, so the NAME is assembled at runtime. Verified against
+# bash: `eval 'echo "$WRAP''PER"'` prints the value. Chasing spellings here is hopeless — there are
+# unboundedly many ways to spell a name by concatenation, and this file uses that very trick itself
+# to stop its guards matching their own pattern lines.
+#
+# So the argument is closed from the other end. A shell variable can be read in exactly four ways:
+#   (a) a literal `$NAME` / `${NAME}`  -> enumerated and classified by the pass above
+#   (b) indirect expansion `${!var}`   -> refused except an exact two-line allowlist
+#   (c) a nameref                      -> declaration banned outright
+#   (d) `eval` of constructed text     -> banned here
+# That is the whole set, so a constructed name has nowhere left to be executed. The ban costs
+# nothing: this harness has never used `eval` in code position (measured 0).
+_wr_evalp=$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" \
+  | grep -nE '(^|[ \t;&|(])'"eval"'([ \t]|$)' | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+_wr_evalp=$(printf '%s\n' "$_wr_evalp" | grep -vE "_wr_expect|_wr_fixture|^[0-9]+:[[:space:]]*(ok|bad) " || true)
+if [ -z "$_wr_evalp" ]; then
+  ok 'structural (#3367): the harness runs no eval, so a variable name assembled by shell concatenation has nowhere to be executed — with literal reads classified, indirect expansion allowlisted and namerefs banned, that closes every way to read the mutable path'
+else
+  bad "structural (#3367): an eval appears in code position. Shell concatenates adjacent quoted strings, so eval can read the mutable wrapper under a name no textual scan can see (\$WRAP''PER): $(printf '%s' "$_wr_evalp" | head -3 | tr '\n' ';' | cut -c1-200)"
+fi
+# ...and a save alias may only ever be assigned FROM the mutable global. A bare mutation
+# (`_wr_saved=/decoy`) is invisible to a scan that looks for `$alias`, and the poison probe would
+# then "restore" the wrong path while its own equality assert happily agreed (roborev job 48).
+_wr_amut=""
+while IFS= read -r _wr_ml; do
+  [ -n "$_wr_ml" ] || continue
+  _wr_mlc=${_wr_ml#*:}
+  _wr_mlc=${_wr_mlc#"${_wr_mlc%%[! 	]*}"}
+  _wr_mlc=${_wr_mlc%"${_wr_mlc##*[! 	]}"}
+  _wr_mlc=${_wr_mlc%;}
+  case "$_wr_mlc" in 'local '*|'export '*|'declare '*|'typeset '*) _wr_mlc=${_wr_mlc#* } ;; esac
+  _wr_mlc=${_wr_mlc#"${_wr_mlc%%[! 	]*}"}
+  _wr_mok=no
+  for _wr_ma in $_wr_aliases; do
+    [ "$_wr_mlc" = "$_wr_ma=$_wr_ref" ] && _wr_mok=yes
+  done
+  [ "$_wr_mok" = yes ] && continue
+  _wr_amut="$_wr_amut${_wr_amut:+; }$_wr_ml"
+done <<EOF
+$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" \
+  | grep -nE '(^|[ 	;&|(])(local |export |declare |typeset )?('"$_wr_alias_re"')=' \
+  | grep -vE '^[0-9]+:[[:space:]]*#' | grep -vE '_wr_fixture|_wr_expect|_wr_ax')
+EOF
+if [ -z "$_wr_amut" ]; then
+  ok 'structural (#3367): every assignment to a save alias takes its value from the mutable global itself — none can be pointed somewhere else, so a restore cannot silently install the wrong path'
+else
+  bad "structural (#3367): a save alias is assigned something other than the mutable global, so a later restore would install that value instead and the probe's own equality assert would agree with it: $(printf '%s' "$_wr_amut" | cut -c1-200)"
 fi
 # NO ALIAS MAY BE REACHED UNDER ANOTHER NAME (roborev job 43). Both structural scans look for the
 # alias by NAME or by `$`-expansion, so an indirect binding reaches the saved mutable path without

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -31,7 +31,6 @@
 set -uo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-WRAPPER="$SCRIPT_DIR/../flow/roborev-review.sh"
 # THE SAME PATH, NEVER REASSIGNED (#3367). `WRAPPER` is deliberately repointed at a scratch
 # copy by the gate-mock cases (~2251/~2354) and restored after, so ANY check that READS the
 # wrapper as a doctrine SUBJECT is order-dependent if it reads `WRAPPER`: its verdict then
@@ -45,6 +44,30 @@ WRAPPER="$SCRIPT_DIR/../flow/roborev-review.sh"
 # that lands on the scratch copy finds nothing and reports CLEAN — a false pass, which is
 # worse than the false fail that surfaced the bug.
 readonly WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
+# A code-only view of a file: quoted spans blanked, comments removed, continuations joined. Used by
+# the one structural scan below, so a variable NAME appearing inside a diagnostic string or a
+# comment is not mistaken for a read of it.
+_wr_code_view_min() {
+  sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | awk '
+  {
+    n = length($0); sq = 0; dq = 0; out = ""
+    for (i = 1; i <= n; i++) {
+      c = substr($0, i, 1)
+      if (!sq && c == "\\") { i++; out = out "  "; continue }
+      # A DOUBLE-quoted span is KEPT: expansions happen inside it, and this view is used to count
+      # reads of a variable. Only SINGLE quotes (literal text) and comments are blanked. Blanking
+      # double quotes erased the one read this scan exists to find -- measured 0 reads of a variable
+      # that is read exactly once, in `bash "${RUN_WRAPPER_PATH:-$WRAPPER_REAL}"`.
+      if (sq) { out = out " "; if (c == "'"'"'") sq = 0; continue }
+      if (dq) { out = out c; if (c == "\"") dq = 0; continue }
+      if (c == "'"'"'") { sq = 1; out = out " "; continue }
+      if (c == "\"") { dq = 1; out = out c; continue }
+      if (c == "#" && (i == 1 || substr($0, i-1, 1) ~ /[ \t]/)) break
+      out = out c
+    }
+    print out
+  }'
+}
 # The structured waiver scanner the wrapper delegates to (#3312 job 26). Defined HERE, beside
 # WRAPPER, because run_wrapper passes it on every call — the structural section is too late.
 SCAN_TOOL="$SCRIPT_DIR/../flow/roborev-waiver-scan.py"
@@ -55,8 +78,8 @@ CHECKS_SRC="$SCRIPT_DIR/../flow/roborev-review-checks.sh"
 ORACLES_SRC="$SCRIPT_DIR/../flow/roborev-review-oracles.sh"
 BLOCK_HEADER="==== ROBOREV REVIEW SUMMARY ===="
 
-if [ ! -f "$WRAPPER" ]; then # wrapper-mutable-read-allow: preflight, before any case can reassign it
-  printf 'FAIL - wrapper not found at %s\n' "$WRAPPER" # wrapper-mutable-read-allow: the preflight diagnostic
+if [ ! -f "$WRAPPER_REAL" ]; then
+  printf 'FAIL - wrapper not found at %s\n' "$WRAPPER_REAL"
   exit 1
 fi
 
@@ -972,7 +995,7 @@ run_wrapper() { # run_wrapper <work-dir> [extra wrapper args...]
   # file and a host `$HOME/.roborev/` must never be able to influence a fixture run.
   STUB_INVOKED="$INVOKED" PATH="${WRAPPER_PATH_PREFIX:+$WRAPPER_PATH_PREFIX:}$stubbin:$PATH" HOME="$FIXTURE_HOME" \
     TMPDIR="${WRAPPER_TMPDIR:-$WRAPPER_TMP}" \
-    bash "$WRAPPER" --repo "$work" --agent codex --model gpt-5.6-sol \
+    bash "${RUN_WRAPPER_PATH:-$WRAPPER_REAL}" --repo "$work" --agent codex --model gpt-5.6-sol \
     --log "$tmp/transcript-$CASE_N.txt" "$@" >"$OUT" 2>&1
   RC=$?
 }
@@ -2260,12 +2283,7 @@ if [ -f "$SCRIPT_DIR/../flow/roborev-job-facts.py" ]; then
 fi
 work=$(make_fixture case_cx28 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-_gm_real_wrapper="$WRAPPER"
-# READONLY, so `printf -v`, `read` and every other builtin that writes a variable are refused by the
-# SHELL (roborev job 51). The mutation scan only knew `name=value` syntax, and a corrupted alias
-# would make the restore install the wrong path while the probe agreed with itself.
-readonly _gm_real_wrapper
-WRAPPER="$_gm_dir/roborev-review.sh"
+RUN_WRAPPER_PATH="$_gm_dir/roborev-review.sh"
 run_wrapper "$work"
 assert_verdict 'case (cx28 control) the UNPATCHED copy reaches PASS' PASS 0
 assert_lacks 'case (cx28 control) and reports no grammar violation' 'verdict-grammar'
@@ -2331,7 +2349,7 @@ else
   assert_says 'case (cx29) the un-run key is visible in the block' '^prompt-content: SKIP$'
   assert_lacks 'case (cx29) and the grammar check does not misreport it as unrecognised' 'verdict-grammar'
 fi
-WRAPPER="$_gm_real_wrapper"
+RUN_WRAPPER_PATH=""
 
 # ===========================================================================
 # (cx28b/cx28c): THE CLOSURE MUST NOT ITSELF BE A PREFIX TEST (#3229 round-11 M3).
@@ -2368,7 +2386,7 @@ for _np_case in cx28b:PASSthisNeverRan cx28c:PASS-MEASUREMENT-DID-NOT-HAPPEN; do
   cp "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$_gm_dir/roborev-review-checks.sh"
   work=$(make_fixture "case_$_np_label" pushed)
   STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-  WRAPPER="$_gm_dir/roborev-review.sh"
+  RUN_WRAPPER_PATH="$_gm_dir/roborev-review.sh"
   # THE CONTROL, per case: the restored copy must reach PASS on this fixture, or a FAIL below
   # would prove nothing about the mutation.
   run_wrapper "$work"
@@ -2389,7 +2407,7 @@ for _np_case in cx28b:PASSthisNeverRan cx28c:PASS-MEASUREMENT-DID-NOT-HAPPEN; do
   else
     bad "case ($_np_label): could not patch the copied checks file, so the near-prefix path was never exercised (a green run here would be a probe failing in the direction that looks like success)"
   fi
-  WRAPPER="$_gm_real_wrapper"
+  RUN_WRAPPER_PATH=""
 done
 cp "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$_gm_dir/roborev-review-checks.sh"
 
@@ -2963,7 +2981,7 @@ INVOKED="$tmp/invoked-$CASE_N.txt"
 # HOME is redirected for the same reason `run_wrapper` does it: a hand-rolled invocation
 # must be as hermetic as the helper, so a host `$HOME/.roborev/` can never influence it.
 STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" HOME="$FIXTURE_HOME" \
-  bash "$WRAPPER" --repo "$tmp/case_t7/work" \
+  bash "$WRAPPER_REAL" --repo "$tmp/case_t7/work" \
   --agent codex --model gpt-5.6-sol --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
 RC=$?
 assert_verdict 'case (t7)' FAIL 1
@@ -2987,7 +3005,7 @@ else
   OUT="$tmp/out-$CASE_N.txt"
   INVOKED="$tmp/invoked-$CASE_N.txt"
   : >"$INVOKED"
-  STUB_INVOKED="$INVOKED" PATH="$nobin" "$nobin/bash" "$WRAPPER" --repo "$work" \
+  STUB_INVOKED="$INVOKED" PATH="$nobin" "$nobin/bash" "$WRAPPER_REAL" --repo "$work" \
     --agent codex --model gpt-5.6-sol --log "$tmp/transcript-$CASE_N.txt" >"$OUT" 2>&1
   RC=$?
   assert_verdict 'case (t8)' FAIL 1
@@ -3009,7 +3027,7 @@ INVOKED="$tmp/invoked-$CASE_N.txt"
 # HOME redirected (see case t7): hermeticity, so nothing on the host can fail this case on
 # the wrong key and leave the EXIT-trap assertion below unreached.
 STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" HOME="$FIXTURE_HOME" \
-  bash "$WRAPPER" --repo "$work" \
+  bash "$WRAPPER_REAL" --repo "$work" \
   --agent codex --model gpt-5.6-sol --log "$tmp/trapcase.log" >"$OUT" 2>&1
 RC=$?
 assert_verdict 'case (t9)' FAIL 1
@@ -3064,7 +3082,7 @@ for bad in "--repo" "--base" "--log"; do
   OUT="$tmp/out-$CASE_N.txt"
   INVOKED="$tmp/invoked-$CASE_N.txt"
   : >"$INVOKED"
-  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" \
+  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER_REAL" \
     --agent codex --model gpt-5.6-sol "$bad" '' >"$OUT" 2>&1
   RC=$?
   if [ "$RC" -eq 2 ]; then ok "usage: an empty '$bad' value exits 2"; else bad "usage: an empty '$bad' value exited $RC (want 2)"; fi
@@ -3079,7 +3097,7 @@ for bad_invocation in "--nonsense" "--repo:$tmp/definitely-not-a-directory" "--r
     --repo:*) set -- --repo "${bad_invocation#--repo:}" ;;
     *) set -- "$bad_invocation" ;;
   esac
-  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" \
+  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER_REAL" \
     --agent codex --model gpt-5.6-sol "$@" >"$OUT" 2>&1
   RC=$?
   if [ "$RC" -eq 2 ]; then ok "usage: '$bad_invocation' exits 2"; else bad "usage: '$bad_invocation' exited $RC (want 2)"; fi
@@ -3594,7 +3612,7 @@ for pair in "--agent codex" "--model gpt-5.6-sol"; do
   INVOKED="$tmp/invoked-$CASE_N.txt"
   : >"$INVOKED"
   # shellcheck disable=SC2086 # deliberate split of the single-option pair
-  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --repo "$work" $pair >"$OUT" 2>&1
+  STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER_REAL" --repo "$work" $pair >"$OUT" 2>&1
   RC=$?
   if [ "$RC" -eq 2 ]; then
     ok "usage: '$pair' alone exits 2"
@@ -4403,7 +4421,7 @@ INVOKED="$tmp/invoked-$CASE_N.txt"
 # The two streams are kept apart on purpose: merged into $OUT, the error lines would have satisfied
 # nothing and failed nothing, which is exactly how this shipped.
 HELP_ERR="$tmp/help-stderr-$CASE_N.txt"
-STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER" --help >"$OUT" 2>"$HELP_ERR"
+STUB_INVOKED="$INVOKED" PATH="$stubbin:$PATH" bash "$WRAPPER_REAL" --help >"$OUT" 2>"$HELP_ERR"
 RC=$?
 if [ "$RC" -eq 0 ]; then ok '--help exits 0'; else bad "--help exited $RC (want 0)"; fi
 if [ -s "$HELP_ERR" ]; then
@@ -4826,774 +4844,46 @@ if [ -z "$_skeys" ]; then
 else
   bad "structural: the block still emits —$_skeys. Those keys described the retired classifier's output (#3312 ruling (4))"
 fi
-# ===== THE DOCTRINE SCANS MUST NOT READ A MUTABLE GLOBAL (#3367) =====
-# The classifier-GONE assert FAILed once inside a gate on a branch whose diff touched no `scripts/`
-# file at all, then passed 4/4 at the same commit and an unchanged tree. Cause: it read `"$WRAPPER"`,
-# which the gate-mock cases repoint at a scratch copy ~2000 lines earlier and restore afterwards. A
-# check whose SUBJECT is chosen by a global another case mutates is order-dependent by construction,
-# and its verdict is decided by which case ran last rather than by the file it claims to audit.
+# ===== THERE IS NO MUTABLE WRAPPER PATH (#3367) =====
+# The order dependence this issue reports had one cause: `WRAPPER` was a GLOBAL that two gate-mock
+# cases repointed at a scratch copy ~2000 lines from the doctrine asserts, so a scan reading it was
+# judged against whichever file the last case had left behind.
 #
-# Note which way the hazard now points. With the `--help` prose exemption in place (#3392) the real
-# wrapper is CLEAN, so a scan that lands on the scratch copy finds nothing and reports CLEAN too —
-# a FALSE PASS, strictly worse than the false FAIL that surfaced the bug, because nothing reds.
+# THIS WAS FIRST FIXED BY GUARDING THE GLOBAL, AND THAT APPROACH WAS RETIRED AS UNSOUND. A ~250-line
+# lexical scanner classified every occurrence of `$WRAPPER` (quote state, arity, spelling, command
+# position, markers) so a doctrine scan could not read the mutable one. Eighteen roborev rounds found
+# forty-three defects in it, all valid, and the last one settled the question: `sh -c` executes a
+# name assembled from adjacent quoted strings (`export WRAP''PER; sh -c 'grep "$WRAP''PER"'`), and
+# the harness already uses `sh -c`. Banning `eval` did not close it, and the set does not close --
+# `bash -c`, `source`, `.`, `xargs sh -c`. A LEXICAL SCANNER CANNOT DECIDE WHETHER A SHELL LINE READS
+# A VARIABLE, BECAUSE THE NAME NEED NOT APPEAR IN THE LINE. No further rounds could have fixed that.
 #
-# Two pins, because fixing the call sites without pinning them just waits for the next one:
-#   (1) STRUCTURAL — a CLOSED GRAMMAR over every read of `$WRAPPER` in this file.
-#   (2) BEHAVIOURAL — with `WRAPPER` poisoned, the scan's verdict must not move, and the same scan
-#       against the poisoned path MUST move. Without the second half, (1) would pass for a scan
-#       that reads nothing at all.
-#
-# WHY A CLOSED GRAMMAR AND NOT A LEAK PATTERN. The first version of (1) was
-# `grep -nE '(grep|awk|sed|...)[^|]*"\$WRAPPER"'` — a search for the KNOWN-BAD shape. It reported
-# CLEAN while the defect was still present, because `grep` is line-oriented and the offending read
-# was a MULTI-LINE `awk` whose command word and whose `"$WRAPPER"` argument sat five lines apart.
-# It missed the exact construct it was written for. That is this repo's recurring
-# affirmative-measurement rule one level down: never derive a pass from the ABSENCE of a bad signal.
-# So every read is enumerated and each must match an AFFIRMATIVELY PERMITTED form; an unrecognised
-# line FAILs. A new way to read the mutable global cannot be a shape nobody predicted.
-#
-# COMMENTS ARE STRIPPED FIRST, and this check learned that the hard way: an earlier version flagged
-# its own explanatory comments above (they quote `"$WRAPPER"` while describing the defect), which is
-# #3367's own cause 2 — a structural assert reding on the prose that documents it. A guard that reds
-# on its own rationale is one the next person deletes.
-#
-# THE PERMITTED FORMS, and why each is not order-dependent:
-#   * `bash "$WRAPPER"` — an INVOCATION. A gate-mock case means the copy in its own context; that is
-#     the whole point of the reassignment, so it must keep reading the mutable value.
-#   * `<var>="$WRAPPER"` — a whole-value SAVE for a later restore, which must capture whatever is
-#     live at that moment or the restore would install the wrong path.
-#   * a line carrying the explicit allow marker — a reviewed, named opt-out for the two preflight
-#     lines (they run before any mutation) and for the poisoned probe below, whose entire purpose is
-#     to read the mutable value. The marker is spelled in two halves at the match site so this guard
-#     can never match its own pattern line.
-#
-# EVERY NEEDLE BELOW IS SPLIT ACROSS A QUOTE BOUNDARY. The subject of this scan is THIS FILE, so a
-# guard written with its needle spelled literally matches its own pattern lines and reports the
-# defect against itself — measured: four self-hits on the first run. Splitting is the same device
-# the scanner-substitution assert uses, for the same reason.
-#
-# THE GRAMMAR IS CLOSED OVER OCCURRENCES, NOT LINES (roborev job 34 on this PR, Medium). The first
-# version was closed over LINES and over ONE SPELLING, and was therefore not closed at all — it had
-# three bypasses, each of which would have let a mutable doctrine read back in silently:
-#   (a) `"${WRAPPER}"`  — braced; the scan only knew the unbraced spelling;
-#   (b) `$WRAPPER`      — unquoted; likewise unrecognised;
-#   (c) `bash "$WRAPPER"; grep -c x "$WRAPPER"` — a COMPOUND line, where one permitted occurrence
-#       (the invocation) caused the WHOLE line to be accepted, carrying a real scan in with it.
-# That is this issue's own defect one level up: a guard whose green means "no instance of the shape
-# I happened to think of," which is exactly the reasoning #3367 exists to retire. So the grammar now
-# asserts three things, and (1) is what makes (3) tractable — with one legal spelling, the
-# permitted-form test no longer has to parse shell:
-#   (1) SPELLING — every occurrence is written exactly `"$WRAPPER"`. Braced and unquoted forms FAIL.
-#   (2) ARITY    — at most ONE occurrence per line, so no occurrence can ride in on another's verdict.
-#   (3) FORM     — that occurrence's line is an invocation, a whole-value save, or marked.
-#
-# PROSE IS STRIPPED BEFORE ANY OF IT. Comments are dropped, and within a line both single-quoted
-# spans and backslash-escaped `\$` are literal text rather than expansions — this file's own `ok`
-# and `bad` messages NAME the variable while describing the rule, and an earlier version red on
-# exactly those, which is #3367's cause 2 reproduced inside the fix for cause 1.
-# A CODE-ONLY VIEW OF A WHOLE FILE: quoted spans blanked, comments removed, continuations joined.
-# Scans that look for a COMMAND (`eval`, a nameref declaration) must read this, never the raw text —
-# otherwise the word inside a diagnostic string or a fixture literal counts, and the only way to
-# tolerate that is a substring exclusion. Three separate exclusions of exactly that shape have now
-# been found here (the alias-declaration alternation, the alias-mutation scan, the eval ban), each
-# exempting a real violation that merely mentioned the excluded token. Blanking removes the need.
-_wr_code_view() {
-  sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | awk '
-  {
-    n = length($0); sq = 0; dq = 0; out = ""
-    for (i = 1; i <= n; i++) {
-      c = substr($0, i, 1)
-      if (!sq && c == "\\") { i++; out = out "  "; continue }
-      if (sq) { out = out " "; if (c == "'"'"'") sq = 0; continue }
-      if (dq) { out = out " "; if (c == "\"") dq = 0; continue }
-      if (c == "'"'"'") { sq = 1; out = out " "; continue }
-      if (c == "\"") { dq = 1; out = out " "; continue }
-      if (c == "#" && (i == 1 || substr($0, i-1, 1) ~ /[ \t]/)) break
-      out = out c
-    }
-    print out
-  }'
-}
-_wr_marker='wrapper-mutable''-read-allow'
-_wr_vname='WRAP''PER'
-# ONLY THESE NAMES MAY HOLD THE MUTABLE VALUE, AND ONLY TO RESTORE IT (roborev job 35, Medium).
-# The save rule used to accept ANY `NAME="$WRAPPER"`, which is an unbounded alias: `subject="$WRAPPER"`
-# followed by a doctrine scan of `"$subject"` satisfied every rule above while staying exactly as
-# order-dependent as the read it replaced. Closing a grammar over one spelling of one name does not
-# close it over the VALUE, so the allowlist is by name and the aliases' own uses are constrained below.
-_wr_aliases='_gm_real_wrapper _wr_saved'
-_wr_ref='"$'"$_wr_vname"'"'
-# COMMAND POSITION IS COMPUTED, NOT SUBSTRING-MATCHED (roborev job 36, Medium). The invocation rule
-# was `case $line in *"bash $ref"*)`, an UNANCHORED substring — so `grep bash "$WRAPPER"` was accepted
-# as an invocation, and a doctrine read walked straight through the "closed" grammar. That is the same
-# error as (c) one round earlier: asking whether a permitted shape appears ANYWHERE on the line rather
-# than whether the line IS that shape.
-#
-# Markers were the first thing tried and do not work here: five of the eight invocation sites end in a
-# `\` continuation, and a line ending in a backslash cannot carry a trailing comment. So the line is
-# reduced to its COMMAND WORD by stripping leading whitespace and any `NAME=value` environment prefixes
-# (this file's invocations carry `STUB_INVOKED=`/`PATH=`), and the result must BEGIN with the invocation.
-# The grammar being stripped is deliberately tiny — env prefixes only, no general shell parsing.
-_wr_cmdpos() {
-  _c=$1
-  _c=${_c#"${_c%%[! ]*}"}
-  while :; do
-    case "$_c" in
-      [A-Za-z_]*=*)
-        _n=${_c%%=*}
-        case "$_n" in *[!A-Za-z0-9_]*) break ;; esac
-        _r=${_c#*=}
-        case "$_r" in
-          '"'*) _r=${_r#\"}; _r=${_r#*\"} ;;
-          *) _v=${_r%% *}; _r=${_r#"$_v"} ;;
-        esac
-        _c=${_r#"${_r%%[! ]*}"}
-        ;;
-      *) break ;;
-    esac
-  done
-  printf '%s' "$_c"
-}
-# TRUE only when the line's COMMAND is a wrapper invocation: bare `bash`, or an explicit
-# interpreter path ending in `/bash`. Anything else -- including a scan that merely mentions
-# the word `bash` in its arguments -- is not an invocation.
-_wr_is_invocation() {
-  _i=$(_wr_cmdpos "$1")
-  case "$_i" in
-    "bash $_wr_ref"*) return 0 ;;
-    '"'*"/bash\" $_wr_ref"*) return 0 ;;
-  esac
-  # A CAPTURED invocation is still an invocation (reviewer nit): `_x=$(bash "$WRAPPER" --help)` runs
-  # the wrapper, it does not scan it. Only the text after a `$(` is retried, so `$(grep bash "…")`
-  # is still a scan — the command word inside the substitution must itself be the invocation.
-  case "$1" in
-    *'$('*)
-      _i2=${1#*$\(}
-      _i2=$(_wr_cmdpos "$_i2")
-      case "$_i2" in
-        "bash $_wr_ref"*) return 0 ;;
-        '"'*"/bash\" $_wr_ref"*) return 0 ;;
-      esac ;;
-  esac
-  return 1
-}
-# THE ENFORCEMENT LOOP AND ITS CONTROL SHARE ONE CLASSIFIER (reviewer B2). They used to be two
-# implementations of the same five rules, and they had ALREADY DRIFTED: the probe knew nothing about
-# the marker arm, so one of the three documented permitted forms was uncovered in both directions,
-# and the loop itself was executed by no control at all — replacing the loop's accumulator with
-# `continue` (the exact "case typo" the control claims to guard against) left BOTH asserts green with
-# the guard fully disabled. That is the `_cls_exec_lines` lesson again: a port is a second
-# implementation, and its correctness is only knowable by differential testing against the original.
-# So there is ONE function, the loop calls it, and the control table certifies the thing that runs.
-#
-# QUOTE STATE IS PARSED, NOT APPROXIMATED — AND THAT DELETES THE PROSE MARKER (reviewer B2/B3).
-#
-# History, because three successive designs failed the same way. Occurrences were first counted on
-# text stripped by `sed "s/'[^']*'//g"`, a LEFT-TO-RIGHT pairing that has no idea what a quote means:
-#   `_probe=$(grep -c "the wrapper's tok" "$WRAPPER")`   <- the apostrophe is INSIDE double quotes,
-# so the naive pass paired it with a later one and swallowed a REAL read. Counting on the raw line
-# fixed the swallowing but made genuine prose (this file's own `ok`/`bad` messages, which NAME the
-# variable while describing the rule) indistinguishable from a read — so a `wrapper-prose-allow`
-# marker was added to excuse it, and the marker promptly became the hole: it returned early, ahead of
-# the spelling/arity/form checks, so ANY read wearing the marker was licensed; and it was matched
-# anywhere on the line, so a line whose own prose merely NAMED the marker self-authorised. That is
-# CLAUDE.md's recurring shape verbatim — an artifact that DESCRIBES the escape hatch BECOMES it, the
-# same defect as a diagnostic printing a valid waiver marker.
-#
-# The doctrinal answer there is to REMOVE THE SHARED CHANNEL rather than pick a rarer delimiter, and
-# that is what this does. A single pass over the line tracks real shell quote state (single quotes,
-# double quotes, backslash escapes, and where the trailing comment begins) and reports:
-#   code = expansions OUTSIDE single quotes  -> live reads, which must obey spelling/arity/form
-#   lit  = occurrences INSIDE single quotes  -> inert text, which needs no marker and grants nothing
-#   q    = live occurrences spelled exactly `"$WRAPPER"`
-#   mk   = the opt-out marker appears IN THE TRAILING COMMENT (never inside a string)
-#   ev   = the line contains an `eval` word
-# With `lit` recognised for what it is, the prose marker has no job left and is GONE — so neither
-# blocker it carried can be expressed. Every one of the three bypasses now classifies as a live read.
-#
-# `eval` is the one case lexical analysis genuinely cannot settle: a single-quoted string that is
-# later evaluated IS code that reads the mutable global, and no quote parser can tell it from prose.
-# It is therefore refused outright rather than guessed at.
-_WR_QS=$(cat <<'AWKEOF'
-{
-  line = $0; n = length(line); sq = 0; dq = 0
-  code = 0; lit = 0; q = 0; mk = 0; ev = 0; cut = n
-  for (i = 1; i <= n; i++) {
-    c = substr(line, i, 1)
-    if (!sq && c == "\\") { i++; continue }
-    if (sq) { if (c == "'") sq = 0 }
-    else if (dq) { if (c == "\"") dq = 0 }
-    else {
-      if (c == "'") { sq = 1; continue }
-      if (c == "\"") { dq = 1; continue }
-      if (c == "#" && (i == 1 || substr(line, i-1, 1) ~ /[ \t]/)) {
-        cm = substr(line, i + 1); sub(/^[ \t]+/, "", cm)
-        # THE MARKER IS A WHOLE TOKEN, not a prefix. `index(cm, MK) == 1` alone accepted
-        # `wrapper-mutable-read-allowance`, i.e. a comment that merely STARTS with the marker's
-        # letters authorised a forbidden read. It must be followed by a delimiter or end the comment.
-        if (index(cm, MK) == 1) {
-          nxt = substr(cm, length(MK) + 1, 1)
-          if (nxt == "" || nxt == ":" || nxt == " " || nxt == "\t") mk = 1
-        }
-        cut = i - 1
-        break
-      }
-    }
-    if (c == "$") {
-      rest = substr(line, i); hit = 0; exact = 0
-      # A BRACED expansion is complete at its brace, so the identifier-boundary rule must NOT be
-      # applied to it: `${WRAPPER}_REAL` is a live read of WRAPPER followed by the literal text
-      # `_REAL`, and testing the character after `}` discarded it as if it named another variable.
-      # `${WRAPPER:-x}` is a read too, hence "name followed by any non-identifier character".
-      if (match(rest, "^[$][{]" VN "[^A-Za-z0-9_]")) { hit = 1 }
-      else if (match(rest, "^[$]" VN)) {
-        after = substr(rest, RLENGTH + 1, 1)
-        if (after !~ /[A-Za-z0-9_]/) { hit = 1
-          if (dq && substr(line, i-1, 1) == "\"" && after == "\"") exact = 1 }
-      }
-      if (hit) { if (sq) lit++; else { code++; if (exact) q++ } }
-    }
-  }
-  # The EXECUTABLE segment, comment removed by the same quote-aware pass. Every form check reads
-  # this, never the raw line: a `sed` comment-strip is not quote-aware, so a fake invocation in a
-  # trailing comment (`grep foo "$WRAPPER" # $(bash "$WRAPPER")`) was accepted as an invocation.
-  seg = substr(line, 1, cut)
-  if (seg ~ /(^|[ \t;&|(])eval([ \t]|$)/) ev = 1
-  # QUOTE STATE THAT IS STILL OPEN AT END OF LINE MEANS THIS PARSE IS NOT TRUSTWORTHY. Shell quoting
-  # SPANS lines; this scanner reads one line at a time, so the CLOSING line of a multi-line
-  # single-quoted program begins with a `'` that the scanner reads as OPENING one — inverting state
-  # for the rest of the line and reclassifying every live read on it as inert text. The failing case
-  # is #3367's ORIGINAL defect verbatim: the closing line of the multi-line awk,
-  #   ' "$ORACLES" "$CHECKS_FILE" "$WRAPPER" 2>/dev/null || true)
-  # i.e. the guard would have green-lit the exact shape it exists to catch. `$'…'` ANSI-C quoting
-  # desyncs it the same way, since a `\'` inside is kept by the shell but closes the span here.
-  # Rather than grow the parser to cover each construct, an unbalanced line is REFUSED: a verdict
-  # derived from an unreliable parse is not a verdict. Measured cost on this file: zero lines.
-  bal = (sq || dq) ? 0 : 1
-  # ANSI-C `$'"'"'…'"'"'` IS NOT ORDINARY SINGLE QUOTING: it keeps a backslash-escaped quote INSIDE the
-  # string, which this scanner cannot model. Refusing only when the line ends UNBALANCED was not
-  # enough -- `ok $'"'"'a\'"'"'b'"'"'; grep -c z "$WRAPPER" # '"'"'` re-balances the parity using the comment
-  # apostrophe and then reads as reporter prose (roborev job 50). So the construct itself is refused
-  # on any line carrying an occurrence. Measured cost: no occurrence line uses it.
-  ansi = (line ~ /[$]'"'"'/) ? 1 : 0
-  # A COMMAND SUBSTITUTION RESTARTS QUOTING, and this flat state machine cannot model that: inside
-  # `$( )` a fresh `"` opens a NEW double-quoted context, so `ok "$(grep "a'"'"'b" "$WRAPPER" "c'"'"'d")"`
-  # is valid shell that READS the wrapper while the flat scan pairs the two apostrophes and calls it
-  # single-quoted prose. Modelling nesting properly is a real shell parser; refusing to call anything
-  # inside a substitution "prose" is one flag. Only the prose verdict is affected — a live read in a
-  # substitution is still judged on spelling/arity/form as before.
-  # BOTH command-substitution syntaxes, which is the COMPLETE set POSIX defines — `$( )` and
-  # backticks. The first version tested `$(` alone, i.e. a sample of the constructs rather than the
-  # set, so `ok "\`grep \"a'b\" \"$WRAPPER\" \"c'd\"\`"` reproduced the same quote confusion and was
-  # excused as prose. If a future shell grows a third, this line is where it goes.
-  cs = (seg ~ /[$][(]/ || seg ~ /`/) ? 1 : 0
-  # A STATE-FREE COUNT over the WHOLE line, used only to detect that the stateful scan stopped early.
-  # A quoted `#` inside a command substitution -- `_x="$(printf " #"; grep -c foo "$WRAPPER")"` --
-  # makes the flat parser believe a comment started, so it BREAKS before the read and reports nothing
-  # at all. Comparing against a count that cannot be fooled by state is how that is caught.
-  # ESCAPES ARE HONOURED HERE TOO, though quote state is not. A backslash is lexically unambiguous —
-  # `\$WRAPPER` is never an expansion, in any context — whereas quote state is exactly what this
-  # counter exists not to trust. Ignoring escapes made every `bad "... \$WRAPPER ..."` diagnostic
-  # that also contains a $( ) look like a hidden read (measured: two false FAILs).
-  tot = 0; j = 1
-  while (j <= n) {
-    if (substr(line, j, 1) == "\\") { j += 2; continue }
-    if (substr(line, j, 1) == "$") {
-      r2 = substr(line, j)
-      if (match(r2, "^[$][{]" VN "[^A-Za-z0-9_]")) tot++
-      else if (match(r2, "^[$]" VN)) {
-        a2 = substr(r2, RLENGTH + 1, 1)
-        if (a2 !~ /[A-Za-z0-9_]/) tot++
-      }
-    }
-    j++
-  }
-  printf "%d %d %d %d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, cs, tot, ansi, seg
-}
-AWKEOF
-)
-# _wr_classify <raw line> -> "<verdict> <occurrence-count>"
-#   none | prose-ok | eval | spelling | arity | form | ok
-_wr_classify() {
-  _c_raw=$1
-  _c_out=$(printf '%s\n' "$_c_raw" | awk -v VN="$_wr_vname" -v MK="$_wr_marker" "$_WR_QS")
-  _c_m=$(printf '%s\n' "$_c_out" | head -1)
-  _c_seg=$(printf '%s\n' "$_c_out" | tail -n +2)
-  _c_code=${_c_m%% *}; _c_rest=${_c_m#* }
-  _c_lit=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_q=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_mk=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_ev=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_bal=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_cs=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_tot=${_c_rest%% *}; _c_ansi=${_c_rest##* }
-  # AN UNRELIABLE PARSE YIELDS NO VERDICT (reviewer). Checked FIRST: every field below is derived
-  # from the same state machine, so if it ended the line inside a quote, none of them can be trusted.
-  # DEFAULTS TO UNTRUSTWORTHY, not to balanced. This is the one field whose job is to say "do not
-  # trust the other fields", so an UNMEASURED value (a failed awk, a renamed field) must refuse
-  # rather than be believed — CLAUDE.md's `${end:-$start}` lesson, on the field that can least
-  # afford it. Key the permissive branch on the AFFIRMATIVE value, never on `!= <bad>`.
-  if [ "${_c_bal:-0}" -eq 0 ] || [ "${_c_ansi:-1}" -eq 1 ]; then
-    printf 'unbalanced %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
-  fi
-  # ANY apparently-inert occurrence on a line carrying a command substitution is REFUSED, whether or
-  # not the line also has a recognised live read (roborev job 43). Gating this on `code -eq 0` was
-  # not enough: `bash "$WRAPPER" "$(grep "a'"'"'b" "$WRAPPER" "c'"'"'d")"` presents ONE occurrence as a
-  # permitted invocation while a SECOND, inside the substitution, is mis-paired into `lit` and never
-  # judged at all — the arity rule counts only `code`, so it does not see it either. Inside `$( )`
-  # the flat parse cannot be trusted about ANY occurrence, so no occurrence there may be excused.
-  # ...and an occurrence the stateful scan never reached, on a line carrying a substitution, means
-  # the parse stopped early (a quoted `#` read as a comment opener). Refuse rather than report none.
-  if [ "${_c_cs:-1}" -eq 1 ] && [ "${_c_tot:-0}" -gt $(( ${_c_code:-0} + ${_c_lit:-0} )) ]; then
-    printf 'substitution %s\n' "${_c_tot:-0}"; return
-  fi
-  if [ "${_c_cs:-1}" -eq 1 ] && [ "${_c_lit:-0}" -gt 0 ]; then
-    printf 'substitution %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
-  fi
-  if [ "${_c_ev:-0}" -eq 1 ] && [ $(( ${_c_code:-0} + ${_c_lit:-0} )) -gt 0 ]; then
-    printf 'eval %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
-  fi
-  if [ "${_c_code:-0}" -eq 0 ]; then
-    if [ "${_c_lit:-0}" -gt 0 ]; then
-      # INERT TEXT NEEDS AN AFFIRMATIVE PERMIT, NOT MERELY THE ABSENCE OF A LIVE READ. Single quotes
-      # make an occurrence literal ON THIS LINE, but they do not make it inert in the PROGRAM:
-      #   _cmd='grep foo "$WRAPPER"'   ...later...   eval "$_cmd"
-      # is a doctrine read assembled on one line and executed on another, and no per-line parse can
-      # see the join. So a literal occurrence is accepted only where prose legitimately lives — the
-      # command word is this harness's own `ok`/`bad` reporter. Anything else FAILs closed, which
-      # costs nothing today (all four literal occurrences are diagnostics) and cannot be widened by
-      # accident.
-      # (a substitution has already been refused above; this stays as a belt-and-braces AFFIRMATIVE
-      # test rather than relying on the earlier branch's condition never changing)
-      if [ "${_c_cs:-1}" -eq 0 ]; then
-        _c_pw=$(_wr_cmdpos "$_c_seg")
-        case "$_c_pw" in
-          'ok '*|'bad '*) printf 'prose-ok %s\n' "$_c_lit"; return ;;
-        esac
-      fi
-      printf 'prose %s\n' "$_c_lit"; return
-    fi
-    printf 'none 0\n'; return
-  fi
-  if [ "${_c_code:-0}" -ne "${_c_q:-0}" ]; then printf 'spelling %s\n' "$_c_code"; return; fi
-  # ARITY BEFORE THE MARKER: otherwise approving a marker for one read implicitly approves any
-  # number of reads on that line, which is the compound-line bypass again.
-  if [ "${_c_code:-0}" -gt 1 ]; then printf 'arity %s\n' "$_c_code"; return; fi
-  if [ "${_c_mk:-0}" -eq 1 ]; then printf 'ok %s\n' "$_c_code"; return; fi
-  if _wr_is_invocation "$_c_seg"; then printf 'ok %s\n' "$_c_code"; return; fi
-  # A SAVE IS THE WHOLE STATEMENT OR IT IS NOT A SAVE (roborev job 41). The test used to be a
-  # SUFFIX glob plus `${seg%%=*}`, which takes the text before the FIRST `=` on the line — so a
-  # compound statement whose first assignment happens to name an allowlisted alias vouched for a
-  # completely different one:
-  #   _wr_saved=x; subject="$WRAPPER"     -> `${seg%%=*}` is `_wr_saved`, accepted
-  # The read there is assigned to `subject`. Matched EXACTLY against the whole trimmed segment now,
-  # so nothing can share the line with a save. (Third instance of the same error in this file: a
-  # permitted shape found ANYWHERE standing in for the line BEING that shape.)
-  _c_trim=${_c_seg#"${_c_seg%%[! 	]*}"}
-  _c_trim=${_c_trim%"${_c_trim##*[! 	]}"}
-  # A declaration keyword and a trailing `;` are part of the SAVE, not a second statement. Without
-  # this, wrapping the poison probe in a function -- `local _wr_saved="$WRAPPER"`, the natural tidy-up
-  # -- reds the gate advising the author to use $WRAPPER_REAL, which is WRONG advice for a save. The
-  # exactness that matters (nothing may SHARE the line) is untouched: only a leading declaration and
-  # one trailing semicolon are absorbed.
-  _c_trim=${_c_trim%;}
-  _c_trim=${_c_trim#"${_c_trim%%[! 	]*}"}
-  case "$_c_trim" in
-    'local '*|'export '*|'declare '*|'typeset '*)
-      _c_trim=${_c_trim#* }
-      _c_trim=${_c_trim#"${_c_trim%%[! 	]*}"} ;;
-  esac
-  for _c_a in $_wr_aliases; do
-    if [ "$_c_trim" = "$_c_a=$_wr_ref" ]; then printf 'ok %s\n' "$_c_code"; return; fi
-  done
-  printf 'form %s\n' "$_c_code"
-}
-# THE WHOLE ENFORCEMENT PASS IS A FUNCTION, AND THE CONTROL RUNS *IT* OVER FIXTURES (reviewer B2,
-# second attempt). The first attempt only shared the CLASSIFIER between the loop and the control.
-# That removed the drift but left the LOOP's dispatch — the `case` that maps a verdict onto an
-# accumulator — certified by nothing, and the reviewer's falsification still passed: replacing the
-# `form)` arm with `:` and injecting a genuine doctrine read left the suite GREEN, because the
-# classifier was still perfect and the control only ever asked the classifier. A control that
-# exercises everything except the part that decides is not a control.
-# So the entire pass is `_wr_scan_file`, the real assert runs it over THIS file, and the control runs
-# the SAME function over fixtures whose correct verdict is known — dispatch included.
-_wr_scan_file() {
-  _sf_file=$1
-  _wr_bad_reads=""; _wr_bad_spelling=""; _wr_prose_bad=""; _wr_unknown=""; _wr_multi=""; _wr_lit_bad=""; _wr_unbal=""; _wr_subst=""
-  _wr_total=0; _wr_prose_n=0
-  while IFS= read -r _wr_num_line; do
-    [ -n "$_wr_num_line" ] || continue
-    # `grep -n` prefixes `NNNN:`; the grammar must judge the CODE, not the line number.
-    _wr_line=${_wr_num_line#*:}
-    _wr_res=$(_wr_classify "$_wr_line")
-    _wr_v=${_wr_res%% *}
-    _wr_c=${_wr_res##* }
-    case "$_wr_v" in
-      none) ;;
-      ok) _wr_total=$((_wr_total + _wr_c)) ;;
-      prose-ok) _wr_prose_n=$((_wr_prose_n + _wr_c)) ;;
-      eval) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
-      prose) _wr_lit_bad="$_wr_lit_bad${_wr_lit_bad:+; }$_wr_num_line" ;;
-      unbalanced) _wr_unbal="$_wr_unbal${_wr_unbal:+; }$_wr_num_line" ;;
-      substitution) _wr_subst="$_wr_subst${_wr_subst:+; }$_wr_num_line" ;;
-      spelling) _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line" ;;
-      arity) _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line" ;;
-      form) _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line" ;;
-      # A CLOSED GRAMMAR OVER THE VERDICTS THEMSELVES: an unplanned verdict must not fall silently
-      # into the permissive branch, which is the shape this whole section exists to retire.
-      # The line number is recorded WITH the verdict, so an EMPTY verdict cannot make this entry
-      # itself empty and leave `[ -n "$_wr_unknown" ]` false — the one unplanned value the arm
-      # that exists to catch unplanned values was letting through (reviewer nit).
-      *) _wr_unknown="$_wr_unknown${_wr_unknown:+; }${_wr_num_line%%:*}:<$_wr_v>" ;;
-    esac
-  done <<EOF
-$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$_sf_file" | grep -nE '[$][{]?'"$_wr_vname"'[}]?' | grep -vE '^[0-9]+:[[:space:]]*#')
-EOF
-  # ONE category, worst-first. `empty` is the affirmative-measurement case: no ACCEPTED occurrence
-  # means the pass had no subject, which is never a clean verdict.
-  # THE VERDICT IS RETURNED IN A GLOBAL, NEVER ON STDOUT. `v=$(_wr_scan_file …)` would run the whole
-  # pass inside a COMMAND SUBSTITUTION, i.e. a subshell, and every accumulator the diagnostics below
-  # print would be discarded with it — caught here by `set -u` rather than by review.
-  if [ -n "$_wr_unknown" ]; then _WR_VERDICT=unknown
-  elif [ "${_wr_total:-0}" -eq 0 ]; then _WR_VERDICT=empty
-  elif [ -n "$_wr_prose_bad" ]; then _WR_VERDICT=eval
-  elif [ -n "$_wr_unbal" ]; then _WR_VERDICT=unbalanced
-  elif [ -n "$_wr_subst" ]; then _WR_VERDICT=substitution
-  elif [ -n "$_wr_lit_bad" ]; then _WR_VERDICT=prose
-  elif [ -n "$_wr_bad_spelling" ]; then _WR_VERDICT=spelling
-  elif [ -n "$_wr_multi" ]; then _WR_VERDICT=arity
-  elif [ -n "$_wr_bad_reads" ]; then _WR_VERDICT=form
-  else _WR_VERDICT=clean; fi
-}
-_WR_VERDICT=
-_wr_scan_file "$TEST_SELF"
-case "$_WR_VERDICT" in
-  clean)
-    ok "structural (#3367): all $_wr_total live occurrences of the mutable wrapper variable (plus $_wr_prose_n occurrences recognised STRUCTURALLY as inert text in an ok/bad diagnostic, needing no marker) are parsed with real shell quote state on a balanced line, use the single legal spelling, sit one per line, and are an invocation, an allowlisted save, or a marked opt-out — no doctrine scan takes it as a SUBJECT" ;;
-  unknown)
-    bad "structural (#3367): the order-dependence classifier returned a verdict the dispatch does not recognise, so some line was neither accepted nor rejected —$_wr_unknown" ;;
-  empty)
-    bad 'structural (#3367): the order-dependence pass found NO accepted occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the scan lost its subject' ;;
-  substitution)
-    bad "structural (#3367): a line carries a COMMAND SUBSTITUTION and an occurrence of the mutable wrapper variable that this flat parse read as inert. Inside \$( ) quoting restarts, so a second read can hide there while a first is waved through as a permitted invocation — no occurrence on such a line may be excused: $(printf '%s' "$_wr_subst" | cut -c1-200)" ;;
-  unbalanced)
-    bad "structural (#3367): a line carrying the mutable wrapper variable ends INSIDE an unterminated quote, so the per-line quote parse is unreliable and no verdict from it can be trusted. This is how the guard would green-light #3367's original defect — the closing line of a multi-line quoted program begins with the CLOSING quote, which a per-line scanner reads as an opening one: $(printf '%s' "$_wr_unbal" | cut -c1-200)" ;;
-  prose)
-    bad "structural (#3367): a line holds the mutable wrapper variable inside single quotes somewhere other than an ok/bad diagnostic. Single quotes make it literal on THIS line but not inert in the PROGRAM — assigning it and eval'ing it later is a doctrine read no per-line parse can see — so only the harness's own reporters may carry it as text: $(printf '%s' "$_wr_lit_bad" | cut -c1-200)" ;;
-  eval)
-    bad "structural (#3367): a line EVALs text containing the mutable wrapper variable. A single-quoted string that is later evaluated IS code reading the mutable global, and no quote parser can tell it from prose, so it is refused rather than guessed at: $(printf '%s' "$_wr_prose_bad" | cut -c1-200)" ;;
-  spelling)
-    bad "structural (#3367): an occurrence of the mutable wrapper variable is not spelled as the single legal quoted form, so the form check cannot see it (braced and unquoted spellings were live bypasses): $(printf '%s' "$_wr_bad_spelling" | cut -c1-200)" ;;
-  arity)
-    bad "structural (#3367): a line carries MORE THAN ONE occurrence of the mutable wrapper variable, so a permitted one (an invocation) would carry an unpermitted one (a doctrine scan) past the grammar: $(printf '%s' "$_wr_multi" | cut -c1-200)" ;;
-  form)
-    bad "structural (#3367): a read of the mutable wrapper variable matches no permitted form, so its verdict depends on gate-mock ordering — use \$WRAPPER_REAL for a doctrine SUBJECT: $(printf '%s' "$_wr_bad_reads" | cut -c1-200)" ;;
-  *)
-    bad "structural (#3367): the order-dependence pass returned an unrecognised category '$_WR_VERDICT', so this assert cannot say whether the file is clean" ;;
-esac
-# THE CONTROL RUNS THE ENFORCER ITSELF over fixtures whose correct verdict is known. Every bypass any
-# review has found is a fixture, alongside every form that must still be ACCEPTED — and, crucially,
-# the DISPATCH is exercised, so deleting an accumulator arm now reds here instead of passing.
-_wr_ctl_dir="$tmp/wrapper-grammar-fixtures"
-mkdir -p "$_wr_ctl_dir"
-# Each fixture carries one PERMITTED occurrence (so `empty` is not the answer) plus the case under test.
-_wr_ok_line="bash $_wr_ref --help"
-# The expected-verdict word is COMPOSED: written literally it is a bare `eval` in code position and
-# the ban above would flag this fixture table. Composing beats excluding -- see _wr_code_view.
-_wr_v_eval='ev''al'
-_wr_ctl_bad=""
-# FIXTURES ARE WRITTEN WITH `printf` AND `$_wr_ref`, NEVER A HEREDOC. The scanner is line-oriented,
-# so a literal `"$WRAPPER"` in a quoted `<<'"'"'EOF'"'"'` heredoc body reads as a live read and verdicts
-# `form` — inert in shell, but this pass cannot see the heredoc. Fail-closed, and free to avoid.
-_wr_fixture() {
-  # $1 = name, $2 = the line under test ('' for none)
-  printf '%s\n' "$_wr_ok_line" >"$_wr_ctl_dir/$1"
-  [ -z "$2" ] || printf '%s\n' "$2" >>"$_wr_ctl_dir/$1"
-}
-_wr_expect() {
-  _wr_scan_file "$_wr_ctl_dir/$1"
-  [ "$_WR_VERDICT" = "$2" ] || _wr_ctl_bad="$_wr_ctl_bad [$1: want=$2 got=$_WR_VERDICT]"
-}
-_wr_fixture f_clean    ''
-_wr_fixture f_form     "_x=\$(grep -c foo $_wr_ref)"
-_wr_fixture f_form2    "sed -n 1p $_wr_ref"
-_wr_fixture f_grepbash "grep bash $_wr_ref"
-_wr_fixture f_awkbash  "_x=\$(awk /bash/ $_wr_ref)"
-_wr_fixture f_alias    "subject=$_wr_ref"
-_wr_fixture f_braced   "_x=\$(grep -c foo \"\${$_wr_vname}\")"
-_wr_fixture f_unquoted "_x=\$(grep -c foo \$$_wr_vname)"
-_wr_fixture f_arity    "bash $_wr_ref --help; grep -c q $_wr_ref"
-_wr_fixture f_markar   "_x=\$(grep -c q $_wr_ref); bash $_wr_ref --help # $_wr_marker: one marker must not waive two reads"
-_wr_fixture f_prose    "_probe=\$(grep -c \"the wrapper's tok\" $_wr_ref) # it's a scan"
-_wr_fixture f_eval     "eval 'grep -c FOO $_wr_ref'"
-_wr_fixture f_aposmk   "printf '%s' \"it's\"; grep $_wr_ref"
-_wr_fixture f_selfauth "bad \"the wrapper's rule\"; grep -c z $_wr_ref # see 'wrapper-mutable-read-allow' above"
-_wr_fixture f_prosetag "  ok 'the mutable \$$_wr_vname is named in prose, and needs no marker'"
-_wr_fixture f_captured "_x=\$(bash $_wr_ref --help)"
-_wr_fixture f_bracesfx "_x=\$(grep -c foo \"\${$_wr_vname}_REAL\")"
-_wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
-_wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
-_wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
-_wr_fixture f_multiline "' \"\$ORACLES\" \"\$CHECKS_FILE\" $_wr_ref 2>/dev/null || true)"
-_wr_fixture f_nearmk   "_x=\$(grep -c foo $_wr_ref) # ${_wr_marker}ance: a near-prefix must not grant"
-_wr_fixture f_mkcolon  "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
-_wr_fixture f_btprose  "ok \"\`grep \"a'b\" $_wr_ref \"c'd\"\`\""
-_wr_fixture f_cshidden "bash $_wr_ref \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
-_wr_fixture f_csprose  "ok \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
-# COMPOSED FROM $_wr_aliases, never written literally (roborev job 50). Spelled out, these fixture
-# lines ARE alias assignments, and the mutation scan below had to exclude any line containing
-# `_wr_fixture`/`_wr_expect`/`_wr_ax` to tolerate them -- a substring exclusion, so
-# `_wr_saved=/decoy # _wr_fixture` exempted a real mutation. Composing removes the need for the
-# exclusion entirely rather than narrowing it.
-_wr_a1=${_wr_aliases%% *}
-_wr_a2=${_wr_aliases##* }
-_wr_fixture f_locsave  "  local $_wr_a1=$_wr_ref"
-_wr_fixture f_semisave "$_wr_a1=$_wr_ref;"
-_wr_fixture f_cmpsave  "$_wr_a2=x; subject=$_wr_ref"
-_wr_fixture f_cmpsave2 "$_wr_a2=unused; grep pattern $_wr_ref"
-_wr_fixture f_ansic    "_x=\$'a\\'b'; grep -c z $_wr_ref"
-_wr_fixture f_marked   "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
-_wr_fixture f_mixed    "grep -c q $_wr_ref; ok 'mentions \$$_wr_vname'"
-_wr_fixture f_save     "_gm_real_wrapper=$_wr_ref"
-_wr_fixture f_envinv   "STUB_INVOKED=\"\$INVOKED\" PATH=\"\$stubbin:\$PATH\" bash $_wr_ref --help"
-printf '%s\n' "_x=\$(grep -c foo \"\$${_wr_vname}_REAL\")" >"$_wr_ctl_dir/f_empty"
-_wr_expect f_clean    clean
-_wr_expect f_form     form
-_wr_expect f_form2    form
-_wr_expect f_grepbash form
-_wr_expect f_awkbash  form
-_wr_expect f_alias    form
-_wr_expect f_braced   spelling
-_wr_expect f_unquoted spelling
-_wr_expect f_arity    arity
-_wr_expect f_markar   arity
-_wr_expect f_prose    form
-_wr_expect f_eval     "$_wr_v_eval"
-_wr_expect f_aposmk   form
-_wr_expect f_selfauth form
-_wr_expect f_prosetag clean
-_wr_expect f_captured clean
-_wr_expect f_bracesfx spelling
-_wr_expect f_bracedef spelling
-_wr_expect f_fakeinv  form
-_wr_expect f_evalasm  prose
-_wr_expect f_multiline unbalanced
-_wr_expect f_nearmk   form
-_wr_expect f_mkcolon  clean
-_wr_expect f_btprose  substitution
-_wr_expect f_cshidden substitution
-_wr_expect f_csprose  substitution
-_wr_expect f_locsave  clean
-_wr_expect f_semisave clean
-_wr_expect f_cmpsave  form
-_wr_expect f_cmpsave2 form
-_wr_expect f_ansic    unbalanced
-_wr_expect f_marked   clean
-_wr_expect f_mixed    form
-_wr_expect f_save     clean
-_wr_expect f_envinv   clean
-_wr_expect f_empty    empty
-# The real file's accumulators must be recomputed: the fixtures above clobbered the shared globals,
-# and the success message below prints counts from them.
-_wr_scan_file "$TEST_SELF"
-if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-six fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
-else
-  bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
+# So the global is GONE instead of guarded. `run_wrapper` -- the single site that ever invoked the
+# wrapper on behalf of a case -- resolves its own path, and the two mock cases scope
+# `RUN_WRAPPER_PATH` around themselves rather than mutating anything the rest of the file can see.
+# Nothing is left to read wrongly, so there is nothing to police: one shell-enforced fact replaces
+# the scanner, its thirty-six fixtures and its poison probe. The property below is what remains.
+_wr_bad=""
+if grep -qE '^[[:space:]]*WRAPPER=' "$TEST_SELF"; then
+  _wr_bad="$_wr_bad a-mutable-WRAPPER-global-is-back;"
 fi
-# AND AN ALLOWLISTED ALIAS MAY ONLY RESTORE. Naming the two save variables is not enough on its
-# own: if `_wr_saved` could itself be scanned, the allowlist would just relocate the bypass. So every
-# use of an alias must be the restore assignment `WRAPPER="$alias"` (or a marked line, which is the
-# assert that the restore happened). The save `alias="$WRAPPER"` carries no `$alias` and so is not a use.
-# BOTH REMAINING SCANS READ LOGICAL LINES (roborev job 47). `grep "$_wr_\` + `saved"` and
-# `grep "$\` + `{!name}"` are joined by bash into one read but match neither physical line, so the
-# alias-use and indirect-expansion scans were blind to exactly the split `_wr_scan_file` and the
-# nameref scan already handle. Same join, same reason; this is the last pair that lacked it.
-_wr_alias_re=$(printf '%s' "$_wr_aliases" | tr ' ' '|')
-_wr_alias_bad=""
-_wr_alias_seen=0
-while IFS= read -r _wr_u; do
-  [ -n "$_wr_u" ] || continue
-  _wr_uc=${_wr_u#*:}
-  _wr_uc=$(printf '%s\n' "$_wr_uc" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
-  # THE DECLARATION IS EXEMPT BY BEING THE DECLARATION, not by containing its own text. This was
-  # `case $line in *"$_wr_alias_re"*)`, an unanchored substring of the `a|b` alternation, so any line
-  # quoting that text was skipped: `grep -E "_gm_real_wrapper|_wr_saved" "$_wr_saved"` exempted
-  # itself while scanning an alias. Fourth instance of one error in this file — a permitted shape
-  # found ANYWHERE standing in for the line BEING that shape.
-  _wr_ud=${_wr_uc#"${_wr_uc%%[! 	]*}"}
-  _wr_ud=${_wr_ud%"${_wr_ud##*[! 	]}"}
-  [ "$_wr_ud" = "_wr_aliases=" ] && continue
-  _wr_alias_seen=$((_wr_alias_seen + 1))
-  # THE MARKER IS RECOGNISED ONLY AT THE START OF A QUOTE-AWARE TRAILING COMMENT, exactly as the
-  # main classifier does it. Matched anywhere, `grep "wrapper-mutable-read-allow" "$_wr_saved"`
-  # exempts ITSELF and scans the alias — the self-authorisation shape again, on the one check that
-  # had not yet been converted. The scanner already computes this; ask it rather than re-deciding.
-  _wr_umk=$(printf '%s\n' "$_wr_u" | awk -v VN="$_wr_vname" -v MK="$_wr_marker" "$_WR_QS" | head -1)
-  # Fields: code lit q mk ev bal cs tot -- strip the four after `mk`, then take the last. (Adding
-  # `tot` silently shifted this and marked the restore assert unmarked: a positional read of a
-  # widening record. Named extraction would be better; the count is asserted below instead.)
-  _wr_umk_n=$(printf '%s\n' "$_wr_umk" | tr ' ' '\n' | grep -c .)
-  if [ "${_wr_umk_n:-0}" -ne 9 ]; then
-    bad "structural (#3367): the quote scanner emits ${_wr_umk_n:-0} fields, not the 9 this extraction expects — a field was added or removed and every positional read of it is now wrong"
-  fi
-  _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk##* }
-  [ "${_wr_umk:-0}" -eq 1 ] && continue
-  _wr_ut=${_wr_uc#"${_wr_uc%%[! ]*}"}
-  _wr_is_restore=no
-  for _wr_a in $_wr_aliases; do
-    [ "$_wr_ut" = "$_wr_vname=\"\$$_wr_a\"" ] && _wr_is_restore=yes
-  done
-  [ "$_wr_is_restore" = yes ] && continue
-  _wr_alias_bad="$_wr_alias_bad${_wr_alias_bad:+; }$_wr_u"
-done <<EOF
-$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" | grep -nE '[$][{]?('"$_wr_alias_re"')[}]?([^A-Za-z0-9_]|$)' | grep -vE '^[0-9]+:[[:space:]]*#')
-EOF
-# CONTROL for the exemption above (roborev job 42): embedding the declaration's text must NOT
-# authorise an alias use. Both probes run the same predicate the loop uses.
-#
-# THE PROBE STRINGS ARE BUILT AT RUNTIME, never written literally, because this file is its own
-# subject: a literal `"$_wr_saved"` here would be a genuine alias use and the loop above would
-# rightly flag it. Composing from `$_wr_aliases` keeps the source line free of any alias occurrence.
-_wr_ax_alias=${_wr_aliases##* }
-_wr_ax_bad=""
-_wr_ax_probe=$(printf 'grep -E "%s" "$%s"' "$_wr_alias_re" "$_wr_ax_alias")
-for _wr_ax in "_wr_aliases=|exempt" "$_wr_ax_probe|judged"; do
-  _wr_axl=${_wr_ax%|*}; _wr_axw=${_wr_ax##*|}
-  _wr_axc=$(printf '%s\n' "$_wr_axl" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
-  _wr_axc=${_wr_axc#"${_wr_axc%%[! 	]*}"}; _wr_axc=${_wr_axc%"${_wr_axc##*[! 	]}"}
-  if [ "$_wr_axc" = "_wr_aliases=" ]; then _wr_axg=exempt; else _wr_axg=judged; fi
-  [ "$_wr_axg" = "$_wr_axw" ] || _wr_ax_bad="$_wr_ax_bad [want=$_wr_axw got=$_wr_axg: $_wr_axl]"
-done
-if [ -z "$_wr_ax_bad" ]; then
-  ok 'structural control (#3367): the alias-declaration exemption matches the declaration EXACTLY — a line merely quoting the alias names is still judged, so it cannot exempt itself while scanning an alias'
-else
-  bad "structural control (#3367): the alias-declaration exemption misclassifies a synthetic line, so a line quoting the declaration could skip the alias-use check —$_wr_ax_bad"
+# `RUN_WRAPPER_PATH` is the scratch-copy override. It may be ASSIGNED only by the mock cases and READ
+# only by run_wrapper -- otherwise it is the same order-dependent global under a new name.
+_wr_rwp_reads=$(_wr_code_view_min "$TEST_SELF" | grep -nE '[$][{]?RUN_WRAPPER_PATH' || true)
+_wr_rwp_n=$(printf '%s' "$_wr_rwp_reads" | grep -c . || true)
+if [ "${_wr_rwp_n:-0}" -ne 1 ]; then
+  _wr_bad="$_wr_bad RUN_WRAPPER_PATH-is-read-in-${_wr_rwp_n:-0}-places-not-just-run_wrapper;"
 fi
-# ===== THE COMPLETE SET OF WAYS TO READ A SHELL VARIABLE (roborev job 48) =====
-# `eval 'grep foo "$WRAP''PER"'` reads the wrapper and NO textual scan for `$WRAPPER` can see it:
-# shell concatenates adjacent quoted strings, so the NAME is assembled at runtime. Verified against
-# bash: `eval 'echo "$WRAP''PER"'` prints the value. Chasing spellings here is hopeless — there are
-# unboundedly many ways to spell a name by concatenation, and this file uses that very trick itself
-# to stop its guards matching their own pattern lines.
-#
-# So the argument is closed from the other end. A shell variable can be read in exactly four ways:
-#   (a) a literal `$NAME` / `${NAME}`  -> enumerated and classified by the pass above
-#   (b) indirect expansion `${!var}`   -> refused except an exact two-line allowlist
-#   (c) a nameref                      -> declaration banned outright
-#   (d) `eval` of constructed text     -> banned here
-# That is the whole set, so a constructed name has nowhere left to be executed. The ban costs
-# nothing: this harness has never used `eval` in code position (measured 0).
-_wr_evalp=$(_wr_code_view "$TEST_SELF" | grep -nE '(^|[ \t;&|(])'"eval"'([ \t]|$)' || true)
-if [ -z "$_wr_evalp" ]; then
-  ok 'structural (#3367): the harness runs no eval, so a variable name assembled by shell concatenation has nowhere to be executed — with literal reads classified, indirect expansion allowlisted and namerefs banned, that closes every way to read the mutable path'
+if [ -z "$_wr_bad" ]; then
+  ok 'structural (#3367): there is no mutable WRAPPER global, and the scratch-copy override is read at exactly one site (run_wrapper) — a doctrine scan has no mutable path available to it, so the order dependence is absent by construction rather than policed'
 else
-  bad "structural (#3367): an eval appears in code position. Shell concatenates adjacent quoted strings, so eval can read the mutable wrapper under a name no textual scan can see (\$WRAP''PER): $(printf '%s' "$_wr_evalp" | head -3 | tr '\n' ';' | cut -c1-200)"
+  bad "structural (#3367): the mutable wrapper path is back —$_wr_bad. Doctrine scans would again be judged against whichever file the last gate-mock case left behind (this is #3367; do not re-introduce a guard for it, remove the global)"
 fi
-# ...and a save alias may only ever be assigned FROM the mutable global. A bare mutation
-# (`_wr_saved=/decoy`) is invisible to a scan that looks for `$alias`, and the poison probe would
-# then "restore" the wrong path while its own equality assert happily agreed (roborev job 48).
-_wr_amut=""
-while IFS= read -r _wr_ml; do
-  [ -n "$_wr_ml" ] || continue
-  _wr_mlc=${_wr_ml#*:}
-  _wr_mlc=${_wr_mlc#"${_wr_mlc%%[! 	]*}"}
-  _wr_mlc=${_wr_mlc%"${_wr_mlc##*[! 	]}"}
-  _wr_mlc=${_wr_mlc%;}
-  case "$_wr_mlc" in 'local '*|'export '*|'declare '*|'typeset '*) _wr_mlc=${_wr_mlc#* } ;; esac
-  _wr_mlc=${_wr_mlc#"${_wr_mlc%%[! 	]*}"}
-  _wr_mok=no
-  for _wr_ma in $_wr_aliases; do
-    [ "$_wr_mlc" = "$_wr_ma=$_wr_ref" ] && _wr_mok=yes
-  done
-  [ "$_wr_mok" = yes ] && continue
-  _wr_amut="$_wr_amut${_wr_amut:+; }$_wr_ml"
-done <<EOF
-$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" \
-  | grep -nE '(^|[ 	;&|(])(local |export |declare |typeset )?('"$_wr_alias_re"')=' \
-  | grep -vE '^[0-9]+:[[:space:]]*#')
-EOF
-if [ -z "$_wr_amut" ]; then
-  ok 'structural (#3367): every assignment to a save alias takes its value from the mutable global itself — none can be pointed somewhere else, so a restore cannot silently install the wrong path'
-else
-  bad "structural (#3367): a save alias is assigned something other than the mutable global, so a later restore would install that value instead and the probe's own equality assert would agree with it: $(printf '%s' "$_wr_amut" | cut -c1-200)"
-fi
-# NO ALIAS MAY BE REACHED UNDER ANOTHER NAME (roborev job 43). Both structural scans look for the
-# alias by NAME or by `$`-expansion, so an indirect binding reaches the saved mutable path without
-# either seeing it:  declare -n subject=_wr_saved ; grep ... "$subject"
-# Two narrow checks rather than one broad one. A blanket ban on indirect expansion was the first
-# attempt and it FALSE-FAILED on two pre-existing legitimate uses (`${!_rw_i}` walking positional
-# arguments at ~960, nothing to do with aliases) — a guard that reds on correct code is the guard
-# people learn to waive, so the ban is scoped to what actually threatens an alias.
-# ANY option group containing the flag counts, in any order and any combination: `-n`, `-ng`,
-# `-g -n`. The first version anchored it as the LAST character of the FIRST group, which is a
-# spelling of the flag rather than the flag itself — `declare -g -n` and `declare -ng` both evaded
-# it. (`local _f="$1"` and friends carry no option group and are unaffected.)
-# LOGICAL lines, not physical ones: `declare \` continued onto `-n subject=_wr_saved` is one
-# declaration, and a per-physical-line grep sees neither half as a nameref. Continuations are joined
-# first (the line numbers are lost, so the diagnostic reports the joined text instead).
-_wr_nrefd=$(_wr_code_view "$TEST_SELF" \
-  | grep -nE '(^|[ \t;&|(])(declare|local|typeset)[[:space:]]+(-[A-Za-z]+[[:space:]]+)*-[A-Za-z]*'"n" || true)
-if [ -z "$_wr_nrefd" ]; then
-  ok 'structural (#3367): the harness declares no nameref, so no second name can be bound to an allowlisted alias'
-else
-  bad "structural (#3367): a nameref declaration appears in this file. It can bind an allowlisted alias to a new name that the alias-use scan (which looks for the alias by name) and the wrapper scan (which looks for \$WRAPPER) both miss: $(printf '%s' "$_wr_nrefd" | head -3 | tr '\n' ';' | cut -c1-200)"
-fi
-# ...and EVERY indirect expansion is refused except an exact allowlist. The first version only
-# refused one whose own text named an alias, which is a property of the LINE rather than of what it
-# EXPANDS TO: `_name=_wr_saved; grep "${!_name}"` — or `_name=WRAPPER` — names nothing on the line
-# that scans. What a name expands to is not decidable here, so the construct itself is allowlisted
-# by exact content: the two pre-existing positional-argument walkers, and nothing else. A reformat
-# of those lines reds and must be re-approved, which is the intended cost of an exact allowlist.
-# The allowlist entries are COMPOSED, never written literally: spelled out, they would themselves be
-# indirect expansions and this scan would flag its own allowlist. (Same self-reference as the marker
-# that authorised itself, but in the FAIL direction — the guard's artifact matching its own subject.
-# Measured: the literal form red with the allowlist lines as the two offenders.)
-_wr_ib='${'"!"
-_wr_indir_ok_1='if [ "'"$_wr_ib"'_rw_i}" = "--log" ]; then'
-_wr_indir_ok_2='WRAPPER_LOG_PATH="'"$_wr_ib"'_rw_next}"'
-_wr_indir_bad=""
-while IFS= read -r _wr_il; do
-  [ -n "$_wr_il" ] || continue
-  _wr_ilc=${_wr_il#*:}
-  _wr_ilc=${_wr_ilc#"${_wr_ilc%%[! 	]*}"}
-  _wr_ilc=${_wr_ilc%"${_wr_ilc##*[! 	]}"}
-  [ "$_wr_ilc" = "$_wr_indir_ok_1" ] && continue
-  [ "$_wr_ilc" = "$_wr_indir_ok_2" ] && continue
-  _wr_indir_bad="$_wr_indir_bad${_wr_indir_bad:+; }$_wr_il"
-done <<EOF
-$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" | grep -nE '[$][{]'"!" | grep -vE '^[0-9]+:[[:space:]]*#')
-EOF
-if [ -z "$_wr_indir_bad" ]; then
-  ok 'structural (#3367): every indirect expansion in this harness is one of the two allowlisted positional-argument walkers — a dynamically-named one could expand to a save alias, and what a name expands to is not decidable by this scan'
-else
-  bad "structural (#3367): an indirect expansion outside the exact allowlist appears in this file. It can expand to a save alias (or to the wrapper variable itself) under a name neither structural scan is looking for: $(printf '%s' "$_wr_indir_bad" | head -3 | cut -c1-200)"
-fi
-if [ "${_wr_alias_seen:-0}" -eq 0 ]; then
-  bad 'structural (#3367): no use of any save alias was found, so the alias restriction certified nothing — the aliases were renamed and the allowlist is now describing names that do not exist'
-elif [ -z "$_wr_alias_bad" ]; then
-  ok "structural (#3367): all $_wr_alias_seen uses of the save aliases are restores — an alias cannot become a second, unwatched name for the mutable path"
-else
-  bad "structural (#3367): a save alias is used for something other than restoring the mutable global, so it is a second name for the same order-dependent value: $(printf '%s' "$_wr_alias_bad" | cut -c1-200)"
-fi
-# ...and `WRAPPER_REAL` must never be reassigned, or it is just `WRAPPER` with a longer name.
-#
-# ENFORCED BY THE SHELL, ASSERTED AS A PROPERTY (roborev job 37). This used to count lines matching
-# `^WRAPPER_REAL=`, i.e. it enumerated ASSIGNMENT SYNTAX — so `export WRAPPER_REAL=…`,
-# `WRAPPER_REAL+=…` and `printf -v WRAPPER_REAL …` all mutated the supposedly immutable path while
-# the guard stayed green. Enumerating the spellings of a mutation is the same error as enumerating
-# the spellings of a read (job 34) and matching an invocation by substring (job 36): a list of
-# shapes someone thought of, standing in for the property itself. `readonly` makes the shell the
-# enforcer, so no syntax can evade it, and the check below asks the shell rather than the text.
-if grep -qE '^readonly WRAPPER_REAL=' "$TEST_SELF"; then
-  ok 'structural (#3367): WRAPPER_REAL is declared readonly, so the shell — not a syntax list — is what prevents reassignment'
-else
-  bad 'structural (#3367): WRAPPER_REAL is not declared readonly, so its immutability rests on a grep for assignment spellings, which export/+=/printf -v all evade'
-fi
-# BEHAVIOURAL: ask the shell. A subshell that tries to reassign must FAIL — this is the property
-# itself, measured, rather than a claim about the declaration's text.
+# WRAPPER_REAL is the one path anything reads, and the SHELL keeps it immutable — asked of the shell
+# rather than inferred from the declaration text, because `export`/`+=`/`printf -v` all evade a grep
+# for assignment spellings (roborev job 37).
 if ( WRAPPER_REAL=/nonexistent/decoy ) 2>/dev/null; then
-  bad 'structural (#3367): WRAPPER_REAL could be reassigned in a subshell, so the readonly declaration is not in force and every doctrine scan is back to reading a mutable path'
+  bad 'structural (#3367): WRAPPER_REAL could be reassigned in a subshell, so the readonly declaration is not in force'
 else
   ok 'structural (#3367): a reassignment of WRAPPER_REAL is REFUSED by the shell (measured, not inferred from the declaration text)'
 fi
@@ -5602,49 +4892,7 @@ if [ "$WRAPPER_REAL" = "$SCRIPT_DIR/../flow/roborev-review.sh" ]; then
 else
   bad "structural (#3367): WRAPPER_REAL does not name the real wrapper — it is immutable but wrong: $WRAPPER_REAL"
 fi
-# BEHAVIOURAL: poison `WRAPPER` and run the classifier filter over both paths.
-#
-# THE NEEDLE IS A SYNTHETIC SENTINEL, NOT A REAL RETIRED TOKEN, and that is a correctness
-# requirement rather than tidiness. The first version poisoned with `mixed-delivery`; when a RED
-# rehearsal injected a genuine reintroduction into the real wrapper, this pin ALSO fired and said
-# "the scan via $WRAPPER_REAL picked up the poisoned copy" — blaming path instability for what was
-# actually a dirty subject. A diagnostic that names the wrong cause under a real defect sends its
-# reader ~2000 lines away from the problem, which is precisely how #3367 cost two lanes their gate
-# budget. A sentinel that CANNOT occur in a real flow script makes the two conditions independent:
-# a hit via $WRAPPER_REAL can only mean the immutable path resolved to the poisoned copy.
-_wr_sentinel='ROBOREV_ORDER_DEP_PROBE_'"3367"
-_wr_poison_dir="$tmp/wrapper-poison"
-mkdir -p "$_wr_poison_dir"
-{
-  printf '%s\n' '#!/usr/bin/env bash'
-  # An EXECUTABLE line, not prose and not a --help heredoc: the filter must keep it.
-  printf '%s=inline\n' "$_wr_sentinel"
-} >"$_wr_poison_dir/roborev-review.sh"
-_wr_saved="$WRAPPER"
-readonly _wr_saved
-WRAPPER="$_wr_poison_dir/roborev-review.sh"
-_cls_via_real=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
-_cls_via_mutable=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER") # wrapper-mutable-read-allow: reading the poisoned path IS this probe
-WRAPPER="$_wr_saved"
-_wr_real_hit=no; _wr_mut_hit=no
-case "$_cls_via_real"    in *"$_wr_sentinel"*) _wr_real_hit=yes ;; esac
-case "$_cls_via_mutable" in *"$_wr_sentinel"*) _wr_mut_hit=yes ;; esac
-if [ "$_wr_real_hit" = no ] && [ "$_wr_mut_hit" = yes ]; then
-  ok 'behavioural (#3367): with $WRAPPER poisoned, the same filter reports the sentinel via $WRAPPER and NOT via $WRAPPER_REAL — the immutable path is what makes the verdict stable, and the scan is demonstrably not blind'
-elif [ "$_wr_mut_hit" = no ]; then
-  bad 'behavioural (#3367): the poisoned wrapper was NOT flagged even when scanned directly, so this case shows nothing about path stability (the fixture or the executable-line filter is wrong, not the paths)'
-else
-  bad 'behavioural (#3367): a sentinel that exists ONLY in the poisoned scratch copy was found via $WRAPPER_REAL, so the immutable path is not immutable'
-fi
-# The restore must have happened, or every later case silently audits the scratch copy — the exact
-# failure mode this section exists to prevent, reintroduced by the pin that tests for it.
-# Compared against WRAPPER_REAL, not against the alias: an assert that verifies a restore using the
-# very variable whose corruption it should detect will agree with any value (roborev job 51).
-if [ "$WRAPPER" = "$WRAPPER_REAL" ]; then # wrapper-mutable-read-allow: asserting the restore requires reading it
-  ok 'behavioural (#3367): the probe restored $WRAPPER, so no later case inherits the poisoned path'
-else
-  bad 'behavioural (#3367): the probe left $WRAPPER pointing at its scratch copy'
-fi
+
 
 # ===== ABSENCE IS A FAIL, AND THE WAIVER IS THE ONLY WAY PAST IT =====
 _pc_start=$(grep -nE '^roborev_check_prompt_content\(\) \{' "$CHECKS_FILE" | head -1 | cut -d: -f1)

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4808,6 +4808,12 @@ fi
 # exactly those, which is #3367's cause 2 reproduced inside the fix for cause 1.
 _wr_marker='wrapper-mutable''-read-allow'
 _wr_vname='WRAP''PER'
+# ONLY THESE NAMES MAY HOLD THE MUTABLE VALUE, AND ONLY TO RESTORE IT (roborev job 35, Medium).
+# The save rule used to accept ANY `NAME="$WRAPPER"`, which is an unbounded alias: `subject="$WRAPPER"`
+# followed by a doctrine scan of `"$subject"` satisfied every rule above while staying exactly as
+# order-dependent as the read it replaced. Closing a grammar over one spelling of one name does not
+# close it over the VALUE, so the allowlist is by name and the aliases' own uses are constrained below.
+_wr_aliases='_gm_real_wrapper _wr_saved'
 _wr_ref='"$'"$_wr_vname"'"'
 _wr_bad_reads=""
 _wr_bad_spelling=""
@@ -4841,13 +4847,12 @@ while IFS= read -r _wr_num_line; do
   case "$_wr_code" in
     *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) continue ;;
   esac
-  # A whole-value SAVE: `NAME="$WRAPPER"` and nothing else on the line.
+  # A whole-value SAVE into an ALLOWLISTED alias: `NAME="$WRAPPER"` and nothing else on the line.
   case "$_wr_code" in
     *"=$_wr_ref")
-      case "${_wr_code%%=*}" in
-        ''|*[!A-Za-z0-9_]*) ;;
-        *) continue ;;
-      esac ;;
+      _wr_nm=${_wr_code%%=*}
+      _wr_nm=${_wr_nm#"${_wr_nm%%[! ]*}"}
+      case " $_wr_aliases " in *" $_wr_nm "*) continue ;; esac ;;
   esac
   _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line"
 done <<EOF
@@ -4878,7 +4883,10 @@ _wr_probe_line() {
   [ "${_p_n:-0}" -gt 1 ] && { printf 'arity\n'; return; }
   case "$_p_code" in *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) printf 'ok\n'; return ;; esac
   case "$_p_code" in
-    *"=$_wr_ref") case "${_p_code%%=*}" in ''|*[!A-Za-z0-9_]*) ;; *) printf 'ok\n'; return ;; esac ;;
+    *"=$_wr_ref")
+      _p_nm=${_p_code%%=*}
+      _p_nm=${_p_nm#"${_p_nm%%[! ]*}"}
+      case " $_wr_aliases " in *" $_p_nm "*) printf 'ok\n'; return ;; esac ;;
   esac
   printf 'form\n'
 }
@@ -4888,6 +4896,7 @@ for _wr_case in \
   "arity:bash $_wr_ref --help; grep -c q $_wr_ref" \
   "form:_x=\$(grep -c foo $_wr_ref)" \
   "form:sed -n 1p $_wr_ref" \
+  "form:subject=$_wr_ref" \
   "ok:  bash $_wr_ref --help" \
   "ok:_gm_real_wrapper=$_wr_ref"; do
   _wr_want=${_wr_case%%:*}
@@ -4895,9 +4904,40 @@ for _wr_case in \
   [ "$_wr_got" = "$_wr_want" ] || _wr_ctl_bad="$_wr_ctl_bad [want=$_wr_want got=$_wr_got: ${_wr_case#*:}]"
 done
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the grammar classifies all seven synthetic lines correctly — it rejects the braced, unquoted and compound-line bypasses roborev found, rejects plain doctrine scans, and still accepts invocations and whole-value saves'
+  ok 'structural control (#3367): the grammar classifies all eight synthetic lines correctly — it rejects the braced, unquoted, compound-line and unallowlisted-alias bypasses roborev found, rejects plain doctrine scans, and still accepts invocations and whole-value saves'
 else
   bad "structural control (#3367): the permitted-form grammar misclassifies a synthetic read, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
+fi
+# AND AN ALLOWLISTED ALIAS MAY ONLY RESTORE. Naming the two save variables is not enough on its
+# own: if `_wr_saved` could itself be scanned, the allowlist would just relocate the bypass. So every
+# use of an alias must be the restore assignment `WRAPPER="$alias"` (or a marked line, which is the
+# assert that the restore happened). The save `alias="$WRAPPER"` carries no `$alias` and so is not a use.
+_wr_alias_re=$(printf '%s' "$_wr_aliases" | tr ' ' '|')
+_wr_alias_bad=""
+_wr_alias_seen=0
+while IFS= read -r _wr_u; do
+  [ -n "$_wr_u" ] || continue
+  _wr_uc=${_wr_u#*:}
+  _wr_uc=$(printf '%s\n' "$_wr_uc" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
+  case "$_wr_uc" in *"$_wr_alias_re"*) continue ;; esac   # the declaration line itself
+  _wr_alias_seen=$((_wr_alias_seen + 1))
+  case "$_wr_uc" in *"$_wr_marker"*) continue ;; esac
+  _wr_ut=${_wr_uc#"${_wr_uc%%[! ]*}"}
+  _wr_is_restore=no
+  for _wr_a in $_wr_aliases; do
+    [ "$_wr_ut" = "$_wr_vname=\"\$$_wr_a\"" ] && _wr_is_restore=yes
+  done
+  [ "$_wr_is_restore" = yes ] && continue
+  _wr_alias_bad="$_wr_alias_bad${_wr_alias_bad:+; }$_wr_u"
+done <<EOF
+$(grep -nE '[$][{]?('"$_wr_alias_re"')[}]?([^A-Za-z0-9_]|$)' "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
+EOF
+if [ "${_wr_alias_seen:-0}" -eq 0 ]; then
+  bad 'structural (#3367): no use of any save alias was found, so the alias restriction certified nothing — the aliases were renamed and the allowlist is now describing names that do not exist'
+elif [ -z "$_wr_alias_bad" ]; then
+  ok "structural (#3367): all $_wr_alias_seen uses of the save aliases are restores — an alias cannot become a second, unwatched name for the mutable path"
+else
+  bad "structural (#3367): a save alias is used for something other than restoring the mutable global, so it is a second name for the same order-dependent value: $(printf '%s' "$_wr_alias_bad" | cut -c1-200)"
 fi
 # ...and `WRAPPER_REAL` must never be reassigned, or it is just `WRAPPER` with a longer name.
 _wr_real_writes=$(grep -cE '^[[:space:]]*WRAPPER_REAL=' "$TEST_SELF")

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -49,7 +49,6 @@ readonly WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
 # as `${RUN_WRAPPER_PATH:-$WRAPPER_REAL}`, so an inherited environment value would silently redirect
 # every early run_wrapper call at an arbitrary script and the suite would report on that instead --
 # a hermeticity hole introduced by this very refactor. Only the two gate-mock cases may set it.
-RUN_WRAPPER_PATH=""
 # THE MUTABLE GLOBAL IS FORBIDDEN BY THE SHELL, NOT BY A GREP (roborev job 54). `readonly` on an
 # UNSET name refuses every later assignment form -- `WRAPPER=`, `export WRAPPER=`, `declare
 # WRAPPER=`, `WRAPPER+=`, `printf -v WRAPPER`, `read WRAPPER` (all six measured). The structural
@@ -979,7 +978,15 @@ WRAPPER_PATH_PREFIX=""
 # INSIDE the reviewed repo). Every other run gets the per-process capture parent.
 WRAPPER_TMPDIR=""
 
-run_wrapper() { # run_wrapper <work-dir> [extra wrapper args...]
+run_wrapper() { # run_wrapper [--wrapper <path>] <work-dir> [extra wrapper args...]
+  # THE SCRATCH-COPY PATH IS A PARAMETER, NOT A GLOBAL (roborev job 58). It was
+  # `${RUN_WRAPPER_PATH:-$WRAPPER_REAL}`, and guarding that global meant counting its assignments --
+  # which matched only `NAME=`, so `export`/`declare`/`printf -v`/`read` evaded it. That is the
+  # assignment-syntax enumeration roborev has now corrected me on THREE times (WRAPPER_REAL job 37,
+  # WRAPPER job 54, this). A `local` cannot be written from outside the function, so the third
+  # instance is not fixed but UNEXPRESSIBLE -- the same move that retired the WRAPPER global.
+  local _rw_wrapper="$WRAPPER_REAL"
+  if [ "${1:-}" = "--wrapper" ]; then _rw_wrapper="$2"; shift 2; fi
   local work="$1"; shift
   # Fail loudly on a broken fixture rather than letting the wrapper fall back to
   # $PWD (which would silently run every assert against the REAL repo). `-e`, not `-d`:
@@ -1011,7 +1018,7 @@ run_wrapper() { # run_wrapper <work-dir> [extra wrapper args...]
   # file and a host `$HOME/.roborev/` must never be able to influence a fixture run.
   STUB_INVOKED="$INVOKED" PATH="${WRAPPER_PATH_PREFIX:+$WRAPPER_PATH_PREFIX:}$stubbin:$PATH" HOME="$FIXTURE_HOME" \
     TMPDIR="${WRAPPER_TMPDIR:-$WRAPPER_TMP}" \
-    bash "${RUN_WRAPPER_PATH:-$WRAPPER_REAL}" --repo "$work" --agent codex --model gpt-5.6-sol \
+    bash "$_rw_wrapper" --repo "$work" --agent codex --model gpt-5.6-sol \
     --log "$tmp/transcript-$CASE_N.txt" "$@" >"$OUT" 2>&1
   RC=$?
 }
@@ -2299,8 +2306,7 @@ if [ -f "$SCRIPT_DIR/../flow/roborev-job-facts.py" ]; then
 fi
 work=$(make_fixture case_cx28 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-RUN_WRAPPER_PATH="$_gm_dir/roborev-review.sh"
-run_wrapper "$work"
+run_wrapper --wrapper "$_gm_dir/roborev-review.sh" "$work"
 assert_verdict 'case (cx28 control) the UNPATCHED copy reaches PASS' PASS 0
 assert_lacks 'case (cx28 control) and reports no grammar violation' 'verdict-grammar'
 # ONE key, ONE value, outside the grammar. `MEASUREMENT-DID-NOT-HAPPEN` is deliberately not a
@@ -2309,7 +2315,7 @@ if sed_inplace_verified "$_gm_dir/roborev-review-checks.sh" \
   's/^    TIER1="PASS"$/    TIER1="MEASUREMENT-DID-NOT-HAPPEN"/' \
   '    TIER1="MEASUREMENT-DID-NOT-HAPPEN"' '    TIER1="PASS"'; then
   ok 'case (cx28): the unrecognised-verdict patch was really applied to the copy'
-  run_wrapper "$work"
+  run_wrapper --wrapper "$_gm_dir/roborev-review.sh" "$work"
   assert_verdict 'case (cx28)' FAIL 1
   assert_says 'case (cx28) the unrecognised value is named under its own diagnostic' "^ERROR: verdict-grammar: a per-check key holds a value outside the block's documented grammar: 'MEASUREMENT-DID-NOT-HAPPEN'\. "
   assert_says 'case (cx28) it explains that an unplanned value must not inherit the non-failing branch' 'rather than letting the unplanned value inherit the non-failing branch'
@@ -2357,7 +2363,7 @@ elif ! sed_inplace_verified "$_gm_dir/roborev-review-checks.sh" \
   bad 'case (cx29): the cx28 TIER1 mutation could not be verifiably restored to PASS on the copy, so a FAIL below would be cx28 grammar violation rather than cx29 never-ran check — the case is NOT MEASURED and must not report a pass'
 else
   ok 'case (cx29): the early-return patch was really applied to the copy, and the cx28 TIER1 mutation was verified restored to PASS'
-  run_wrapper "$work"
+  run_wrapper --wrapper "$_gm_dir/roborev-review.sh" "$work"
   assert_verdict 'case (cx29)' FAIL 1
   assert_says 'case (cx29) the un-run key is named as never having affirmatively passed' "^ERROR: verdict-affirmation: this run reached the PASS branch with a VERDICT-CARRYING key that never affirmatively passed — prompt-content: 'SKIP'\. "
   assert_says 'case (cx29) it states that a non-measurement is the vacuous pass itself' 'a non-failing value that is not a measurement'
@@ -2365,7 +2371,6 @@ else
   assert_says 'case (cx29) the un-run key is visible in the block' '^prompt-content: SKIP$'
   assert_lacks 'case (cx29) and the grammar check does not misreport it as unrecognised' 'verdict-grammar'
 fi
-RUN_WRAPPER_PATH=""
 
 # ===========================================================================
 # (cx28b/cx28c): THE CLOSURE MUST NOT ITSELF BE A PREFIX TEST (#3229 round-11 M3).
@@ -2402,16 +2407,15 @@ for _np_case in cx28b:PASSthisNeverRan cx28c:PASS-MEASUREMENT-DID-NOT-HAPPEN; do
   cp "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$_gm_dir/roborev-review-checks.sh"
   work=$(make_fixture "case_$_np_label" pushed)
   STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
-  RUN_WRAPPER_PATH="$_gm_dir/roborev-review.sh"
   # THE CONTROL, per case: the restored copy must reach PASS on this fixture, or a FAIL below
   # would prove nothing about the mutation.
-  run_wrapper "$work"
+  run_wrapper --wrapper "$_gm_dir/roborev-review.sh" "$work"
   assert_verdict "case ($_np_label control) the restored copy reaches PASS" PASS 0
   if sed_inplace_verified "$_gm_dir/roborev-review-checks.sh" \
     "s/^    TIER1=\"PASS\"\$/    TIER1=\"$_np_value\"/" \
     "    TIER1=\"$_np_value\"" '    TIER1="PASS"'; then
     ok "case ($_np_label): the near-prefix patch was really applied to the copy"
-    run_wrapper "$work"
+    run_wrapper --wrapper "$_gm_dir/roborev-review.sh" "$work"
     assert_verdict "case ($_np_label)" FAIL 1
     assert_says "case ($_np_label) the near-prefix value is named as OUTSIDE the grammar" \
       "^ERROR: verdict-grammar: a per-check key holds a value outside the block's documented grammar: '$_np_value'\. "
@@ -2423,8 +2427,7 @@ for _np_case in cx28b:PASSthisNeverRan cx28c:PASS-MEASUREMENT-DID-NOT-HAPPEN; do
   else
     bad "case ($_np_label): could not patch the copied checks file, so the near-prefix path was never exercised (a green run here would be a probe failing in the direction that looks like success)"
   fi
-  RUN_WRAPPER_PATH=""
-done
+  done
 cp "$SCRIPT_DIR/../flow/roborev-review-checks.sh" "$_gm_dir/roborev-review-checks.sh"
 
 printf '== case (d): vacuous token signature vs non-empty census ==\n'
@@ -4934,21 +4937,26 @@ fi
 if [ -n "${WRAPPER+set}" ]; then
   _wr_bad="$_wr_bad WRAPPER-has-a-value;"
 fi
-# `RUN_WRAPPER_PATH` is the scratch-copy override. It may be ASSIGNED only by the mock cases and READ
-# only by run_wrapper -- otherwise it is the same order-dependent global under a new name.
-_wr_rwp_reads=$(_wr_code_view_min "$TEST_SELF" | grep -nE '[$][{]?RUN_WRAPPER_PATH' || true)
-_wr_rwp_n=$(printf '%s' "$_wr_rwp_reads" | grep -c . || true)
-if [ "${_wr_rwp_n:-0}" -ne 1 ]; then
-  _wr_bad="$_wr_bad RUN_WRAPPER_PATH-is-read-in-${_wr_rwp_n:-0}-places-not-just-run_wrapper;"
+# THE SCRATCH-COPY PATH IS A `local`, SO THERE IS NO SECOND GLOBAL. `RUN_WRAPPER_PATH` was the
+# first attempt: a global the two mock cases set and cleared. Guarding it meant counting its
+# assignments, which matched only `NAME=` and so missed `export`/`declare`/`printf -v`/`read` --
+# the third time this PR made the assignment-syntax enumeration error. A `local` cannot be assigned
+# from outside its function, so the class is unexpressible rather than policed. Asked of the shell,
+# not of the text: run_wrapper is invoked in a subshell that tries to leak the name outward.
+if _wr_leak=$( { run_wrapper_probe() { local _rw_wrapper=inner; }; run_wrapper_probe; printf '%s' "${_rw_wrapper-unset}"; } ) \
+   && [ "$_wr_leak" = "unset" ]; then
+  ok 'structural (#3367): a `local` in a shell function does not leak to the caller (measured), so the wrapper path run_wrapper resolves cannot be steered by anything outside it'
+else
+  bad "structural (#3367): a function-local leaked to the caller (got '${_wr_leak:-?}'), so run_wrapper's wrapper path is effectively global again and any caller could redirect it"
 fi
-# ...and its ASSIGNMENTS are counted too. Checking only the reads left the other half open: an extra
-# assignment elsewhere redirects run_wrapper while the read count stays at one (roborev job 57).
-# Exactly five are legitimate -- the empty initialisation, plus a set and a clear for each of the two
-# gate-mock cases. A sixth means someone is steering run_wrapper from a new place, which is #3367
-# returning under a different variable name.
-_wr_rwp_sets=$(_wr_code_view_min "$TEST_SELF" | grep -cE '^[[:space:]]*RUN_WRAPPER_PATH=' || true)
-if [ "${_wr_rwp_sets:-0}" -ne 5 ]; then
-  _wr_bad="$_wr_bad RUN_WRAPPER_PATH-is-assigned-${_wr_rwp_sets:-0}-times-not-5;"
+# Read the CODE view and split the needle: the prose above names the retired global while
+# explaining why it is gone, and a raw grep matched that. Fifth self-reference of this shape in
+# this PR -- an artifact describing a rule matching the rule.
+if _wr_code_view_min "$TEST_SELF" | grep -q 'RUN_WRAPPER''_PATH'; then
+  _wr_bad="$_wr_bad the-RUN_WRAPPER_PATH-global-is-back;"
+fi
+if ! grep -qE '^[[:space:]]*local _rw_wrapper="\$WRAPPER_REAL"' "$TEST_SELF"; then
+  _wr_bad="$_wr_bad run_wrapper-no-longer-defaults-its-path-to-a-local-seeded-from-WRAPPER_REAL;"
 fi
 if [ -z "$_wr_bad" ]; then
   ok 'structural (#3367): there is no mutable WRAPPER global, and the scratch-copy override is read at exactly one site (run_wrapper) — a doctrine scan has no mutable path available to it, so the order dependence is absent by construction rather than policed'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4911,7 +4911,7 @@ _wr_is_invocation() {
 _WR_QS=$(cat <<'AWKEOF'
 {
   line = $0; n = length(line); sq = 0; dq = 0
-  code = 0; lit = 0; q = 0; mk = 0; ev = 0
+  code = 0; lit = 0; q = 0; mk = 0; ev = 0; cut = n
   for (i = 1; i <= n; i++) {
     c = substr(line, i, 1)
     if (!sq && c == "\\") { i++; continue }
@@ -4921,31 +4921,33 @@ _WR_QS=$(cat <<'AWKEOF'
       if (c == "'") { sq = 1; continue }
       if (c == "\"") { dq = 1; continue }
       if (c == "#" && (i == 1 || substr(line, i-1, 1) ~ /[ \t]/)) {
-        # THE MARKER MUST OPEN THE COMMENT, not merely appear in it. Matched anywhere, a comment
-        # that only QUOTES the marker ("# see 'wrapper-mutable-read-allow' above") grants it -- an
-        # artifact describing the escape hatch becoming it, which is the shape CLAUDE.md says to
-        # close by anchoring the control token where the payload cannot reach. Caught by fixture
-        # f_selfauth, not by review.
-        cm = substr(line, i + 1)
-        sub(/^[ \t]+/, "", cm)
+        cm = substr(line, i + 1); sub(/^[ \t]+/, "", cm)
         if (index(cm, MK) == 1) mk = 1
+        cut = i - 1
         break
       }
     }
     if (c == "$") {
-      rest = substr(line, i)
-      if (match(rest, "^[$][{]?" VN "[}]?")) {
-        tok = substr(rest, 1, RLENGTH); after = substr(rest, RLENGTH + 1, 1)
-        if (after !~ /[A-Za-z0-9_]/) {
-          if (sq) lit++
-          else { code++
-                 if (tok == "$" VN && dq && substr(line, i-1, 1) == "\"" && after == "\"") q++ }
-        }
+      rest = substr(line, i); hit = 0; exact = 0
+      # A BRACED expansion is complete at its brace, so the identifier-boundary rule must NOT be
+      # applied to it: `${WRAPPER}_REAL` is a live read of WRAPPER followed by the literal text
+      # `_REAL`, and testing the character after `}` discarded it as if it named another variable.
+      # `${WRAPPER:-x}` is a read too, hence "name followed by any non-identifier character".
+      if (match(rest, "^[$][{]" VN "[^A-Za-z0-9_]")) { hit = 1 }
+      else if (match(rest, "^[$]" VN)) {
+        after = substr(rest, RLENGTH + 1, 1)
+        if (after !~ /[A-Za-z0-9_]/) { hit = 1
+          if (dq && substr(line, i-1, 1) == "\"" && after == "\"") exact = 1 }
       }
+      if (hit) { if (sq) lit++; else { code++; if (exact) q++ } }
     }
   }
-  if (line ~ /(^|[ \t;&|(])eval([ \t]|$)/) ev = 1
-  printf "%d %d %d %d %d\n", code, lit, q, mk, ev
+  # The EXECUTABLE segment, comment removed by the same quote-aware pass. Every form check reads
+  # this, never the raw line: a `sed` comment-strip is not quote-aware, so a fake invocation in a
+  # trailing comment (`grep foo "$WRAPPER" # $(bash "$WRAPPER")`) was accepted as an invocation.
+  seg = substr(line, 1, cut)
+  if (seg ~ /(^|[ \t;&|(])eval([ \t]|$)/) ev = 1
+  printf "%d %d %d %d %d\n%s\n", code, lit, q, mk, ev, seg
 }
 AWKEOF
 )
@@ -4953,7 +4955,9 @@ AWKEOF
 #   none | prose-ok | eval | spelling | arity | form | ok
 _wr_classify() {
   _c_raw=$1
-  _c_m=$(printf '%s\n' "$_c_raw" | awk -v VN="$_wr_vname" -v MK="$_wr_marker" "$_WR_QS")
+  _c_out=$(printf '%s\n' "$_c_raw" | awk -v VN="$_wr_vname" -v MK="$_wr_marker" "$_WR_QS")
+  _c_m=$(printf '%s\n' "$_c_out" | head -1)
+  _c_seg=$(printf '%s\n' "$_c_out" | tail -n +2)
   _c_code=${_c_m%% *}; _c_rest=${_c_m#* }
   _c_lit=${_c_rest%% *}; _c_rest=${_c_rest#* }
   _c_q=${_c_rest%% *}; _c_rest=${_c_rest#* }
@@ -4962,7 +4966,21 @@ _wr_classify() {
     printf 'eval %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
   fi
   if [ "${_c_code:-0}" -eq 0 ]; then
-    if [ "${_c_lit:-0}" -gt 0 ]; then printf 'prose-ok %s\n' "$_c_lit"; return; fi
+    if [ "${_c_lit:-0}" -gt 0 ]; then
+      # INERT TEXT NEEDS AN AFFIRMATIVE PERMIT, NOT MERELY THE ABSENCE OF A LIVE READ. Single quotes
+      # make an occurrence literal ON THIS LINE, but they do not make it inert in the PROGRAM:
+      #   _cmd='grep foo "$WRAPPER"'   ...later...   eval "$_cmd"
+      # is a doctrine read assembled on one line and executed on another, and no per-line parse can
+      # see the join. So a literal occurrence is accepted only where prose legitimately lives — the
+      # command word is this harness's own `ok`/`bad` reporter. Anything else FAILs closed, which
+      # costs nothing today (all four literal occurrences are diagnostics) and cannot be widened by
+      # accident.
+      _c_pw=$(_wr_cmdpos "$_c_seg")
+      case "$_c_pw" in
+        'ok '*|'bad '*) printf 'prose-ok %s\n' "$_c_lit"; return ;;
+      esac
+      printf 'prose %s\n' "$_c_lit"; return
+    fi
     printf 'none 0\n'; return
   fi
   if [ "${_c_code:-0}" -ne "${_c_q:-0}" ]; then printf 'spelling %s\n' "$_c_code"; return; fi
@@ -4970,11 +4988,10 @@ _wr_classify() {
   # number of reads on that line, which is the compound-line bypass again.
   if [ "${_c_code:-0}" -gt 1 ]; then printf 'arity %s\n' "$_c_code"; return; fi
   if [ "${_c_mk:-0}" -eq 1 ]; then printf 'ok %s\n' "$_c_code"; return; fi
-  _c_code_only=$(printf '%s\n' "$_c_raw" | sed 's/[ 	]#[^"'"'"']*$//')
-  if _wr_is_invocation "$_c_code_only"; then printf 'ok %s\n' "$_c_code"; return; fi
-  case "$_c_code_only" in
-    *"=$_wr_ref")
-      _c_nm=${_c_code_only%%=*}
+  if _wr_is_invocation "$_c_seg"; then printf 'ok %s\n' "$_c_code"; return; fi
+  case "$_c_seg" in
+    *"=$_wr_ref"|*"=$_wr_ref"' ')
+      _c_nm=${_c_seg%%=*}
       _c_nm=${_c_nm#"${_c_nm%%[! ]*}"}
       case " $_wr_aliases " in *" $_c_nm "*) printf 'ok %s\n' "$_c_code"; return ;; esac ;;
   esac
@@ -4991,7 +5008,7 @@ _wr_classify() {
 # the SAME function over fixtures whose correct verdict is known — dispatch included.
 _wr_scan_file() {
   _sf_file=$1
-  _wr_bad_reads=""; _wr_bad_spelling=""; _wr_prose_bad=""; _wr_unknown=""; _wr_multi=""
+  _wr_bad_reads=""; _wr_bad_spelling=""; _wr_prose_bad=""; _wr_unknown=""; _wr_multi=""; _wr_lit_bad=""
   _wr_total=0; _wr_prose_n=0
   while IFS= read -r _wr_num_line; do
     [ -n "$_wr_num_line" ] || continue
@@ -5005,6 +5022,7 @@ _wr_scan_file() {
       ok) _wr_total=$((_wr_total + _wr_c)) ;;
       prose-ok) _wr_prose_n=$((_wr_prose_n + _wr_c)) ;;
       eval) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
+      prose) _wr_lit_bad="$_wr_lit_bad${_wr_lit_bad:+; }$_wr_num_line" ;;
       spelling) _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line" ;;
       arity) _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line" ;;
       form) _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line" ;;
@@ -5026,6 +5044,7 @@ EOF
   if [ -n "$_wr_unknown" ]; then _WR_VERDICT=unknown
   elif [ "${_wr_total:-0}" -eq 0 ]; then _WR_VERDICT=empty
   elif [ -n "$_wr_prose_bad" ]; then _WR_VERDICT=eval
+  elif [ -n "$_wr_lit_bad" ]; then _WR_VERDICT=prose
   elif [ -n "$_wr_bad_spelling" ]; then _WR_VERDICT=spelling
   elif [ -n "$_wr_multi" ]; then _WR_VERDICT=arity
   elif [ -n "$_wr_bad_reads" ]; then _WR_VERDICT=form
@@ -5040,6 +5059,8 @@ case "$_WR_VERDICT" in
     bad "structural (#3367): the order-dependence classifier returned a verdict the dispatch does not recognise, so some line was neither accepted nor rejected —$_wr_unknown" ;;
   empty)
     bad 'structural (#3367): the order-dependence pass found NO accepted occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the scan lost its subject' ;;
+  prose)
+    bad "structural (#3367): a line holds the mutable wrapper variable inside single quotes somewhere other than an ok/bad diagnostic. Single quotes make it literal on THIS line but not inert in the PROGRAM — assigning it and eval'ing it later is a doctrine read no per-line parse can see — so only the harness's own reporters may carry it as text: $(printf '%s' "$_wr_lit_bad" | cut -c1-200)" ;;
   eval)
     bad "structural (#3367): a line EVALs text containing the mutable wrapper variable. A single-quoted string that is later evaluated IS code reading the mutable global, and no quote parser can tell it from prose, so it is refused rather than guessed at: $(printf '%s' "$_wr_prose_bad" | cut -c1-200)" ;;
   spelling)
@@ -5084,6 +5105,10 @@ _wr_fixture f_aposmk   "printf '%s' \"it's\"; grep $_wr_ref"
 _wr_fixture f_selfauth "bad \"the wrapper's rule\"; grep -c z $_wr_ref # see 'wrapper-mutable-read-allow' above"
 _wr_fixture f_prosetag "  ok 'the mutable \$$_wr_vname is named in prose, and needs no marker'"
 _wr_fixture f_captured "_x=\$(bash $_wr_ref --help)"
+_wr_fixture f_bracesfx "_x=\$(grep -c foo \"\${$_wr_vname}_REAL\")"
+_wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
+_wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
+_wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
 _wr_fixture f_marked   "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
 _wr_fixture f_mixed    "grep -c q $_wr_ref; ok 'mentions \$$_wr_vname'"
 _wr_fixture f_save     "_gm_real_wrapper=$_wr_ref"
@@ -5105,6 +5130,10 @@ _wr_expect f_aposmk   form
 _wr_expect f_selfauth form
 _wr_expect f_prosetag clean
 _wr_expect f_captured clean
+_wr_expect f_bracesfx spelling
+_wr_expect f_bracedef spelling
+_wr_expect f_fakeinv  form
+_wr_expect f_evalasm  prose
 _wr_expect f_marked   clean
 _wr_expect f_mixed    form
 _wr_expect f_save     clean
@@ -5114,7 +5143,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all twenty-one fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all twenty-five fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4785,13 +4785,13 @@ case "$_ac3b_caught" in
   *ROBOREV_DIFF_SOURCE_STATE*)
     ok 'structural (#3367 AC3b): a reintroduction parked INSIDE usage() before its heredoc is caught — identifiers are scanned everywhere, so no part of the function is exempt' ;;
   *)
-    bad 'structural (#3367 AC3b): a reintroduction between `usage() {` and its `cat <<EOF` was NOT caught. The prose exemption starts at the function opener instead of the heredoc opener, so executable code parked there is invisible to the classifier-GONE scan' ;;
+    bad 'structural (#3367 AC3b): a reintroduction between `usage() {` and its `cat <<EOF` was NOT caught. Since the identifier/prose split there is no heredoc exemption left to blame - identifiers are scanned on every line - so look at the _cls_hits predicate and the token list, not at a filter' ;;
 esac
 case "$_ac3_caught" in
   *ROBOREV_DIFF_SOURCE_STATE*)
     ok "structural (#3367 AC3): an executable classifier reintroduction appended to a COPY of the real wrapper is still caught —$_ac3_caught — so the prose exemptions narrow the scan without blinding it" ;;
   *)
-    bad 'structural (#3367 AC3): an executable classifier reintroduction appended to a copy of the REAL wrapper was NOT caught. The prose exemption has widened until it swallows live code, so the classifier-GONE assert above is green by blindness' ;;
+    bad 'structural (#3367 AC3): an executable classifier reintroduction appended to a copy of the REAL wrapper was NOT caught. the classifier-GONE assert above is green by blindness. There is no prose exemption left to widen - check _cls_hits and the token list, which is exactly what this control exists to detect' ;;
 esac
 # THE THREE SNAPSHOT KEYS GO WITH IT: a block that still emitted them would be describing a
 # measurement the wrapper no longer makes.

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -42,7 +42,7 @@ WRAPPER="$SCRIPT_DIR/../flow/roborev-review.sh"
 # Note the direction of the hazard now: with the `--help` prose exemption in place, a scan
 # that lands on the scratch copy finds nothing and reports CLEAN — a false pass, which is
 # worse than the false fail that surfaced the bug.
-WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
+readonly WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
 # The structured waiver scanner the wrapper delegates to (#3312 job 26). Defined HERE, beside
 # WRAPPER, because run_wrapper passes it on every call — the structural section is too late.
 SCAN_TOOL="$SCRIPT_DIR/../flow/roborev-waiver-scan.py"
@@ -4857,99 +4857,134 @@ _wr_is_invocation() {
   esac
   return 1
 }
+# THE ENFORCEMENT LOOP AND ITS CONTROL SHARE ONE CLASSIFIER (reviewer B2). They used to be two
+# implementations of the same five rules, and they had ALREADY DRIFTED: the probe knew nothing about
+# the marker arm, so one of the three documented permitted forms was uncovered in both directions,
+# and the loop itself was executed by no control at all — replacing the loop's accumulator with
+# `continue` (the exact "case typo" the control claims to guard against) left BOTH asserts green with
+# the guard fully disabled. That is the `_cls_exec_lines` lesson again: a port is a second
+# implementation, and its correctness is only knowable by differential testing against the original.
+# So there is ONE function, the loop calls it, and the control table certifies the thing that runs.
+#
+# COUNTED ON THE RAW LINE, AND PROSE-STRIPPING IS FAIL-CLOSED (reviewer B1). The count used to be
+# taken AFTER the single-quote strip, so a strip that swallowed a REAL occurrence made it invisible —
+# to the grammar and to the `_wr_total -eq 0` backstop alike, since the line simply looked like it
+# had no occurrence. Two measured false PASSes, both accepted by the old code:
+#   `_probe=$(grep -c "the wrapper's tok" "$WRAPPER")  # it's a scan`   (apostrophes pair ACROSS the read)
+#   `eval 'grep -c ROBOREV_DIFF_SOURCE_STATE "$WRAPPER"'`               (single-quoted text that IS code)
+# The second is the sharper one and is not contrived: a line-oriented quote-strip cannot tell inert
+# prose from a quoted string that is later evaluated. So occurrences are counted on the RAW line, and
+# a line whose strip removed any occurrence is a FAIL unless it carries the explicit prose marker.
+# Exactly three lines in this file need it — the `ok`/`bad` messages that NAME the variable while
+# describing the rule — which is the whole price of closing the only fail-open door in the grammar.
+_wr_prose_marker='wrapper-prose''-allow'
+# _wr_classify <raw line> -> "<verdict> <raw-occurrence-count>"
+#   none | prose | prose-ok | spelling | arity | form | ok
+_wr_classify() {
+  _c_raw=$1
+  _c_n=$(printf '%s\n' "$_c_raw" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
+  if [ "${_c_n:-0}" -lt 1 ]; then printf 'none 0\n'; return; fi
+  _c_code=$(printf '%s\n' "$_c_raw" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
+  _c_s=$(printf '%s\n' "$_c_code" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
+  if [ "${_c_n:-0}" -ne "${_c_s:-0}" ]; then
+    case "$_c_raw" in
+      *"$_wr_prose_marker"*) printf 'prose-ok %s\n' "$_c_n"; return ;;
+    esac
+    printf 'prose %s\n' "$_c_n"; return
+  fi
+  _c_q=$(printf '%s\n' "$_c_code" | grep -oF "$_wr_ref" | wc -l | tr -d '[:space:]')
+  if [ "${_c_n:-0}" -ne "${_c_q:-0}" ]; then printf 'spelling %s\n' "$_c_n"; return; fi
+  # ARITY IS CHECKED BEFORE THE MARKER (reviewer nit): otherwise approving a marker for one read
+  # implicitly approves any number of reads on that line, which is the compound-line bypass again.
+  if [ "${_c_n:-0}" -gt 1 ]; then printf 'arity %s\n' "$_c_n"; return; fi
+  case "$_c_code" in
+    *"$_wr_marker"*) printf 'ok %s\n' "$_c_n"; return ;;
+  esac
+  if _wr_is_invocation "$_c_code"; then printf 'ok %s\n' "$_c_n"; return; fi
+  case "$_c_code" in
+    *"=$_wr_ref")
+      _c_nm=${_c_code%%=*}
+      _c_nm=${_c_nm#"${_c_nm%%[! ]*}"}
+      case " $_wr_aliases " in *" $_c_nm "*) printf 'ok %s\n' "$_c_n"; return ;; esac ;;
+  esac
+  printf 'form %s\n' "$_c_n"
+}
 _wr_bad_reads=""
 _wr_bad_spelling=""
+_wr_prose_bad=""
+_wr_unknown=""
 _wr_multi=""
 _wr_total=0
+_wr_prose_n=0
 while IFS= read -r _wr_num_line; do
   [ -n "$_wr_num_line" ] || continue
-  # `grep -n` prefixes `NNNN:`; the grammar must judge the CODE, not the line number (an unstripped
-  # prefix made every whole-value save look like an assignment to `NNNN:name`, i.e. four false FAILs).
+  # `grep -n` prefixes `NNNN:`; the grammar must judge the CODE, not the line number.
   _wr_line=${_wr_num_line#*:}
-  _wr_code=$(printf '%s\n' "$_wr_line" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
-  # Occurrences of exactly this variable — `$WRAPPER_REAL` is a DIFFERENT name and must not count.
-  _wr_n=$(printf '%s\n' "$_wr_code" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
-  [ "${_wr_n:-0}" -ge 1 ] || continue
-  _wr_total=$((_wr_total + _wr_n))
-  # (1) SPELLING: every occurrence on this line must be the exact quoted form.
-  _wr_q=$(printf '%s\n' "$_wr_code" | grep -oF "$_wr_ref" | wc -l | tr -d '[:space:]')
-  if [ "${_wr_n:-0}" -ne "${_wr_q:-0}" ]; then
-    _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line"
-    continue
-  fi
-  case "$_wr_code" in
-    *"$_wr_marker"*) continue ;;
+  _wr_res=$(_wr_classify "$_wr_line")
+  _wr_v=${_wr_res%% *}
+  _wr_c=${_wr_res##* }
+  case "$_wr_v" in
+    none) ;;
+    ok) _wr_total=$((_wr_total + _wr_c)) ;;
+    prose-ok) _wr_prose_n=$((_wr_prose_n + _wr_c)) ;;
+    prose) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
+    spelling) _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line" ;;
+    arity) _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line" ;;
+    form) _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line" ;;
+    # A CLOSED GRAMMAR OVER THE VERDICTS THEMSELVES: an unplanned verdict must not fall silently
+    # into the permissive branch, which is the shape this whole section exists to retire.
+    *) _wr_unknown="$_wr_unknown${_wr_unknown:+; }$_wr_v" ;;
   esac
-  # (2) ARITY: one occurrence per line, so a permitted one cannot carry an unpermitted one.
-  if [ "${_wr_n:-0}" -gt 1 ]; then
-    _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line"
-    continue
-  fi
-  # (3) FORM. An INVOCATION -- decided by COMMAND POSITION, never by substring.
-  if _wr_is_invocation "$_wr_code"; then continue; fi
-  # A whole-value SAVE into an ALLOWLISTED alias: `NAME="$WRAPPER"` and nothing else on the line.
-  case "$_wr_code" in
-    *"=$_wr_ref")
-      _wr_nm=${_wr_code%%=*}
-      _wr_nm=${_wr_nm#"${_wr_nm%%[! ]*}"}
-      case " $_wr_aliases " in *" $_wr_nm "*) continue ;; esac ;;
-  esac
-  _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line"
 done <<EOF
 $(grep -nE '[$][{]?'"$_wr_vname"'[}]?' "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
 EOF
 # AFFIRMATIVE MEASUREMENT: zero occurrences means this scan had no subject, which is not a pass.
-if [ "${_wr_total:-0}" -eq 0 ]; then
-  bad 'structural (#3367): the order-dependence grammar found NO occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the prose-stripping swallowed the file'
+if [ -n "$_wr_unknown" ]; then
+  bad "structural (#3367): the order-dependence classifier returned a verdict the loop does not recognise, so some line was neither accepted nor rejected —$_wr_unknown"
+elif [ "${_wr_total:-0}" -eq 0 ]; then
+  bad 'structural (#3367): the order-dependence grammar found NO accepted occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the scan lost its subject'
+elif [ -n "$_wr_prose_bad" ]; then
+  bad "structural (#3367): a line's quote-stripping removed an occurrence of the mutable wrapper variable, so the grammar could not see it and would have passed it silently (an apostrophe in a nearby string, or a single-quoted command later eval'd, both do this): $(printf '%s' "$_wr_prose_bad" | cut -c1-200)"
 elif [ -n "$_wr_bad_spelling" ]; then
-  bad "structural (#3367): an occurrence of the mutable wrapper variable is not spelled as the single legal quoted form, so the form check below cannot see it (braced and unquoted spellings were live bypasses): $(printf '%s' "$_wr_bad_spelling" | cut -c1-200)"
+  bad "structural (#3367): an occurrence of the mutable wrapper variable is not spelled as the single legal quoted form, so the form check cannot see it (braced and unquoted spellings were live bypasses): $(printf '%s' "$_wr_bad_spelling" | cut -c1-200)"
 elif [ -n "$_wr_multi" ]; then
   bad "structural (#3367): a line carries MORE THAN ONE occurrence of the mutable wrapper variable, so a permitted one (an invocation) would carry an unpermitted one (a doctrine scan) past the grammar: $(printf '%s' "$_wr_multi" | cut -c1-200)"
 elif [ -n "$_wr_bad_reads" ]; then
   bad "structural (#3367): a read of the mutable wrapper variable matches no permitted form, so its verdict depends on gate-mock ordering — use \$WRAPPER_REAL for a doctrine SUBJECT: $(printf '%s' "$_wr_bad_reads" | cut -c1-200)"
 else
-  ok "structural (#3367): all $_wr_total occurrences of the mutable wrapper variable use the single legal spelling, sit one per line, and are an invocation, a whole-value save, or a marked opt-out — no doctrine scan takes it as a SUBJECT, so no verdict depends on which case ran last"
+  ok "structural (#3367): all $_wr_total live occurrences of the mutable wrapper variable (plus $_wr_prose_n marked prose) are counted on the RAW line, use the single legal spelling, sit one per line, and are an invocation, an allowlisted save, or a marked opt-out — no doctrine scan takes it as a SUBJECT"
 fi
-# THE GRAMMAR MUST BE ABLE TO REJECT, and specifically to reject the three bypasses roborev found.
-# A control that only probed the shape the author already had in mind is how (a)-(c) survived round
-# one, so each is probed as its own synthetic line, alongside the two forms that must be ACCEPTED.
+# THE CONTROL CERTIFIES THE FUNCTION THE LOOP ACTUALLY CALLS. Each bypass any review has found is
+# probed as its own synthetic line, alongside every form that must still be ACCEPTED — a control that
+# only probed the shapes the author already had in mind is how three rounds of bypasses survived.
 _wr_ctl_bad=""
-_wr_probe_line() {
-  # Returns: the verdict this grammar gives one synthetic line — spelling|arity|form|ok
-  _p_code=$(printf '%s\n' "$1" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
-  _p_n=$(printf '%s\n' "$_p_code" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
-  _p_q=$(printf '%s\n' "$_p_code" | grep -oF "$_wr_ref" | wc -l | tr -d '[:space:]')
-  [ "${_p_n:-0}" -ne "${_p_q:-0}" ] && { printf 'spelling\n'; return; }
-  [ "${_p_n:-0}" -gt 1 ] && { printf 'arity\n'; return; }
-  if _wr_is_invocation "$_p_code"; then printf 'ok\n'; return; fi
-  case "$_p_code" in
-    *"=$_wr_ref")
-      _p_nm=${_p_code%%=*}
-      _p_nm=${_p_nm#"${_p_nm%%[! ]*}"}
-      case " $_wr_aliases " in *" $_p_nm "*) printf 'ok\n'; return ;; esac ;;
-  esac
-  printf 'form\n'
-}
 for _wr_case in \
   "spelling:_x=\$(grep -c foo \"\${$_wr_vname}\")" \
   "spelling:_x=\$(grep -c foo \$$_wr_vname)" \
   "arity:bash $_wr_ref --help; grep -c q $_wr_ref" \
+  "arity:_x=\$(grep -c q $_wr_ref); bash $_wr_ref --help # $_wr_marker: one marker must not waive two reads" \
+  "prose:_probe=\$(grep -c \"the wrapper's tok\" $_wr_ref) # it's a scan" \
+  "prose:eval 'grep -c FOO $_wr_ref'" \
+  "prose-ok:  ok 'the mutable \$$_wr_vname is named here in prose' # $_wr_prose_marker" \
   "form:_x=\$(grep -c foo $_wr_ref)" \
   "form:sed -n 1p $_wr_ref" \
   "form:grep bash $_wr_ref" \
   "form:_x=\$(awk /bash/ $_wr_ref)" \
   "form:subject=$_wr_ref" \
+  "ok:_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out" \
   "ok:STUB_INVOKED=\"\$INVOKED\" PATH=\"\$stubbin:\$PATH\" bash $_wr_ref --help" \
   "ok:  bash $_wr_ref --help" \
-  "ok:_gm_real_wrapper=$_wr_ref"; do
+  "ok:_gm_real_wrapper=$_wr_ref" \
+  "none:_x=\$(grep -c foo \"\$${_wr_vname}_REAL\")"; do
   _wr_want=${_wr_case%%:*}
-  _wr_got=$(_wr_probe_line "${_wr_case#*:}")
+  _wr_res=$(_wr_classify "${_wr_case#*:}")
+  _wr_got=${_wr_res%% *}
   [ "$_wr_got" = "$_wr_want" ] || _wr_ctl_bad="$_wr_ctl_bad [want=$_wr_want got=$_wr_got: ${_wr_case#*:}]"
 done
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the grammar classifies all eleven synthetic lines correctly — it rejects the braced, unquoted, compound-line, unallowlisted-alias and mentions-the-word-bash bypasses roborev found, rejects plain doctrine scans, and still accepts invocations and whole-value saves'
+  ok 'structural control (#3367): the classifier THE LOOP CALLS classifies all seventeen synthetic lines correctly — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash and quote-swallowed bypasses, refuses to let one marker waive a second read, and still accepts invocations, allowlisted saves, marked opt-outs and marked prose'
 else
-  bad "structural control (#3367): the permitted-form grammar misclassifies a synthetic read, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
+  bad "structural control (#3367): the permitted-form classifier misclassifies a synthetic read, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi
 # AND AN ALLOWLISTED ALIAS MAY ONLY RESTORE. Naming the two save variables is not enough on its
 # own: if `_wr_saved` could itself be scanned, the allowlist would just relocate the bypass. So every
@@ -4983,11 +5018,30 @@ else
   bad "structural (#3367): a save alias is used for something other than restoring the mutable global, so it is a second name for the same order-dependent value: $(printf '%s' "$_wr_alias_bad" | cut -c1-200)"
 fi
 # ...and `WRAPPER_REAL` must never be reassigned, or it is just `WRAPPER` with a longer name.
-_wr_real_writes=$(grep -cE '^[[:space:]]*WRAPPER_REAL=' "$TEST_SELF")
-if [ "$_wr_real_writes" -eq 1 ]; then
-  ok 'structural (#3367): WRAPPER_REAL is assigned exactly once, so it cannot acquire the order dependence it exists to avoid'
+#
+# ENFORCED BY THE SHELL, ASSERTED AS A PROPERTY (roborev job 37). This used to count lines matching
+# `^WRAPPER_REAL=`, i.e. it enumerated ASSIGNMENT SYNTAX — so `export WRAPPER_REAL=…`,
+# `WRAPPER_REAL+=…` and `printf -v WRAPPER_REAL …` all mutated the supposedly immutable path while
+# the guard stayed green. Enumerating the spellings of a mutation is the same error as enumerating
+# the spellings of a read (job 34) and matching an invocation by substring (job 36): a list of
+# shapes someone thought of, standing in for the property itself. `readonly` makes the shell the
+# enforcer, so no syntax can evade it, and the check below asks the shell rather than the text.
+if grep -qE '^readonly WRAPPER_REAL=' "$TEST_SELF"; then
+  ok 'structural (#3367): WRAPPER_REAL is declared readonly, so the shell — not a syntax list — is what prevents reassignment'
 else
-  bad "structural (#3367): WRAPPER_REAL is assigned $_wr_real_writes times; it must be written exactly once"
+  bad 'structural (#3367): WRAPPER_REAL is not declared readonly, so its immutability rests on a grep for assignment spellings, which export/+=/printf -v all evade'
+fi
+# BEHAVIOURAL: ask the shell. A subshell that tries to reassign must FAIL — this is the property
+# itself, measured, rather than a claim about the declaration's text.
+if ( WRAPPER_REAL=/nonexistent/decoy ) 2>/dev/null; then
+  bad 'structural (#3367): WRAPPER_REAL could be reassigned in a subshell, so the readonly declaration is not in force and every doctrine scan is back to reading a mutable path'
+else
+  ok 'structural (#3367): a reassignment of WRAPPER_REAL is REFUSED by the shell (measured, not inferred from the declaration text)'
+fi
+if [ "$WRAPPER_REAL" = "$SCRIPT_DIR/../flow/roborev-review.sh" ]; then
+  ok 'structural (#3367): WRAPPER_REAL still names the real wrapper, so the immutable path is also the CORRECT path'
+else
+  bad "structural (#3367): WRAPPER_REAL does not name the real wrapper — it is immutable but wrong: $WRAPPER_REAL"
 fi
 # BEHAVIOURAL: poison `WRAPPER` and run the classifier filter over both paths.
 #
@@ -5016,7 +5070,7 @@ _wr_real_hit=no; _wr_mut_hit=no
 case "$_cls_via_real"    in *"$_wr_sentinel"*) _wr_real_hit=yes ;; esac
 case "$_cls_via_mutable" in *"$_wr_sentinel"*) _wr_mut_hit=yes ;; esac
 if [ "$_wr_real_hit" = no ] && [ "$_wr_mut_hit" = yes ]; then
-  ok 'behavioural (#3367): with $WRAPPER poisoned, the same filter reports the sentinel via $WRAPPER and NOT via $WRAPPER_REAL — the immutable path is what makes the verdict stable, and the scan is demonstrably not blind'
+  ok 'behavioural (#3367): with $WRAPPER poisoned, the same filter reports the sentinel via $WRAPPER and NOT via $WRAPPER_REAL — the immutable path is what makes the verdict stable, and the scan is demonstrably not blind' # wrapper-prose-allow: names the variable in a diagnostic, does not read it
 elif [ "$_wr_mut_hit" = no ]; then
   bad 'behavioural (#3367): the poisoned wrapper was NOT flagged even when scanned directly, so this case shows nothing about path stability (the fixture or the executable-line filter is wrong, not the paths)'
 else
@@ -5025,9 +5079,9 @@ fi
 # The restore must have happened, or every later case silently audits the scratch copy — the exact
 # failure mode this section exists to prevent, reintroduced by the pin that tests for it.
 if [ "$WRAPPER" = "$_wr_saved" ]; then # wrapper-mutable-read-allow: asserting the restore requires reading it
-  ok 'behavioural (#3367): the probe restored $WRAPPER, so no later case inherits the poisoned path'
+  ok 'behavioural (#3367): the probe restored $WRAPPER, so no later case inherits the poisoned path' # wrapper-prose-allow: names the variable in a diagnostic, does not read it
 else
-  bad 'behavioural (#3367): the probe left $WRAPPER pointing at its scratch copy'
+  bad 'behavioural (#3367): the probe left $WRAPPER pointing at its scratch copy' # wrapper-prose-allow: names the variable in a diagnostic, does not read it
 fi
 
 # ===== ABSENCE IS A FAIL, AND THE WAIVER IS THE ONLY WAY PAST IT =====

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4947,7 +4947,18 @@ _WR_QS=$(cat <<'AWKEOF'
   # trailing comment (`grep foo "$WRAPPER" # $(bash "$WRAPPER")`) was accepted as an invocation.
   seg = substr(line, 1, cut)
   if (seg ~ /(^|[ \t;&|(])eval([ \t]|$)/) ev = 1
-  printf "%d %d %d %d %d\n%s\n", code, lit, q, mk, ev, seg
+  # QUOTE STATE THAT IS STILL OPEN AT END OF LINE MEANS THIS PARSE IS NOT TRUSTWORTHY. Shell quoting
+  # SPANS lines; this scanner reads one line at a time, so the CLOSING line of a multi-line
+  # single-quoted program begins with a `'` that the scanner reads as OPENING one — inverting state
+  # for the rest of the line and reclassifying every live read on it as inert text. The failing case
+  # is #3367's ORIGINAL defect verbatim: the closing line of the multi-line awk,
+  #   ' "$ORACLES" "$CHECKS_FILE" "$WRAPPER" 2>/dev/null || true)
+  # i.e. the guard would have green-lit the exact shape it exists to catch. `$'…'` ANSI-C quoting
+  # desyncs it the same way, since a `\'` inside is kept by the shell but closes the span here.
+  # Rather than grow the parser to cover each construct, an unbalanced line is REFUSED: a verdict
+  # derived from an unreliable parse is not a verdict. Measured cost on this file: zero lines.
+  bal = (sq || dq) ? 0 : 1
+  printf "%d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, seg
 }
 AWKEOF
 )
@@ -4961,7 +4972,11 @@ _wr_classify() {
   _c_code=${_c_m%% *}; _c_rest=${_c_m#* }
   _c_lit=${_c_rest%% *}; _c_rest=${_c_rest#* }
   _c_q=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_mk=${_c_rest%% *}; _c_ev=${_c_rest##* }
+  _c_mk=${_c_rest%% *}; _c_rest=${_c_rest#* }
+  _c_ev=${_c_rest%% *}; _c_bal=${_c_rest##* }
+  # AN UNRELIABLE PARSE YIELDS NO VERDICT (reviewer). Checked FIRST: every field below is derived
+  # from the same state machine, so if it ended the line inside a quote, none of them can be trusted.
+  if [ "${_c_bal:-1}" -eq 0 ]; then printf 'unbalanced %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return; fi
   if [ "${_c_ev:-0}" -eq 1 ] && [ $(( ${_c_code:-0} + ${_c_lit:-0} )) -gt 0 ]; then
     printf 'eval %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
   fi
@@ -5008,7 +5023,7 @@ _wr_classify() {
 # the SAME function over fixtures whose correct verdict is known — dispatch included.
 _wr_scan_file() {
   _sf_file=$1
-  _wr_bad_reads=""; _wr_bad_spelling=""; _wr_prose_bad=""; _wr_unknown=""; _wr_multi=""; _wr_lit_bad=""
+  _wr_bad_reads=""; _wr_bad_spelling=""; _wr_prose_bad=""; _wr_unknown=""; _wr_multi=""; _wr_lit_bad=""; _wr_unbal=""
   _wr_total=0; _wr_prose_n=0
   while IFS= read -r _wr_num_line; do
     [ -n "$_wr_num_line" ] || continue
@@ -5023,6 +5038,7 @@ _wr_scan_file() {
       prose-ok) _wr_prose_n=$((_wr_prose_n + _wr_c)) ;;
       eval) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
       prose) _wr_lit_bad="$_wr_lit_bad${_wr_lit_bad:+; }$_wr_num_line" ;;
+      unbalanced) _wr_unbal="$_wr_unbal${_wr_unbal:+; }$_wr_num_line" ;;
       spelling) _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line" ;;
       arity) _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line" ;;
       form) _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line" ;;
@@ -5044,6 +5060,7 @@ EOF
   if [ -n "$_wr_unknown" ]; then _WR_VERDICT=unknown
   elif [ "${_wr_total:-0}" -eq 0 ]; then _WR_VERDICT=empty
   elif [ -n "$_wr_prose_bad" ]; then _WR_VERDICT=eval
+  elif [ -n "$_wr_unbal" ]; then _WR_VERDICT=unbalanced
   elif [ -n "$_wr_lit_bad" ]; then _WR_VERDICT=prose
   elif [ -n "$_wr_bad_spelling" ]; then _WR_VERDICT=spelling
   elif [ -n "$_wr_multi" ]; then _WR_VERDICT=arity
@@ -5054,11 +5071,13 @@ _WR_VERDICT=
 _wr_scan_file "$TEST_SELF"
 case "$_WR_VERDICT" in
   clean)
-    ok "structural (#3367): all $_wr_total live occurrences of the mutable wrapper variable (plus $_wr_prose_n marked prose) are counted on the RAW line, use the single legal spelling, sit one per line, and are an invocation, an allowlisted save, or a marked opt-out — no doctrine scan takes it as a SUBJECT" ;;
+    ok "structural (#3367): all $_wr_total live occurrences of the mutable wrapper variable (plus $_wr_prose_n occurrences recognised STRUCTURALLY as inert text in an ok/bad diagnostic, needing no marker) are parsed with real shell quote state on a balanced line, use the single legal spelling, sit one per line, and are an invocation, an allowlisted save, or a marked opt-out — no doctrine scan takes it as a SUBJECT" ;;
   unknown)
     bad "structural (#3367): the order-dependence classifier returned a verdict the dispatch does not recognise, so some line was neither accepted nor rejected —$_wr_unknown" ;;
   empty)
     bad 'structural (#3367): the order-dependence pass found NO accepted occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the scan lost its subject' ;;
+  unbalanced)
+    bad "structural (#3367): a line carrying the mutable wrapper variable ends INSIDE an unterminated quote, so the per-line quote parse is unreliable and no verdict from it can be trusted. This is how the guard would green-light #3367's original defect — the closing line of a multi-line quoted program begins with the CLOSING quote, which a per-line scanner reads as an opening one: $(printf '%s' "$_wr_unbal" | cut -c1-200)" ;;
   prose)
     bad "structural (#3367): a line holds the mutable wrapper variable inside single quotes somewhere other than an ok/bad diagnostic. Single quotes make it literal on THIS line but not inert in the PROGRAM — assigning it and eval'ing it later is a doctrine read no per-line parse can see — so only the harness's own reporters may carry it as text: $(printf '%s' "$_wr_lit_bad" | cut -c1-200)" ;;
   eval)
@@ -5109,6 +5128,8 @@ _wr_fixture f_bracesfx "_x=\$(grep -c foo \"\${$_wr_vname}_REAL\")"
 _wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
 _wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
 _wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
+_wr_fixture f_multiline "' \"\$ORACLES\" \"\$CHECKS_FILE\" $_wr_ref 2>/dev/null || true)"
+_wr_fixture f_ansic    "_x=\$'a\\'b'; grep -c z $_wr_ref"
 _wr_fixture f_marked   "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
 _wr_fixture f_mixed    "grep -c q $_wr_ref; ok 'mentions \$$_wr_vname'"
 _wr_fixture f_save     "_gm_real_wrapper=$_wr_ref"
@@ -5134,6 +5155,8 @@ _wr_expect f_bracesfx spelling
 _wr_expect f_bracedef spelling
 _wr_expect f_fakeinv  form
 _wr_expect f_evalasm  prose
+_wr_expect f_multiline unbalanced
+_wr_expect f_ansic    unbalanced
 _wr_expect f_marked   clean
 _wr_expect f_mixed    form
 _wr_expect f_save     clean
@@ -5143,7 +5166,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all twenty-five fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all twenty-seven fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4672,82 +4672,6 @@ _cls_all_lines() {
   # identifier or drop it from the list -- NOT to reintroduce a filter.
   cat "$@" 2>/dev/null || true
 }
-_cls_exec_lines() {
-  awk '
-  function code_of(s,   n2, i2, sq2, dq2, c2) {
-    # Quote-aware trailing-comment removal. Without it this filter dropped only comment-ONLY lines,
-    # so a harmless trailing comment naming a retired token tripped the classifier-GONE assert — a
-    # false FAIL on doctrine text, which is the very thing #3392 exempted the --help heredoc for.
-    n2 = length(s); sq2 = 0; dq2 = 0
-    for (i2 = 1; i2 <= n2; i2++) {
-      c2 = substr(s, i2, 1)
-      if (!sq2 && c2 == "\\") { i2++; continue }
-      if (sq2) { if (c2 == "'"'"'") sq2 = 0 }
-      else if (dq2) { if (c2 == "\"") dq2 = 0 }
-      else {
-        if (c2 == "'"'"'") { sq2 = 1; continue }
-        if (c2 == "\"") { dq2 = 1; continue }
-        # A comment can also open straight after an operator -- `x=1;# note` is a comment to the
-        # shell (roborev job 53). Restricting to whitespace left such text in the executable view.
-        if (c2 == "#" && (i2 == 1 || substr(s, i2-1, 1) ~ /[ \t;&|()]/)) return substr(s, 1, i2 - 1)
-      }
-    }
-    return s
-  }
-  # The line with quoted spans BLANKED and the comment removed, so a construct can be recognised in
-  # CODE position only. `printf %s '"'"'cat <<EOF'"'"'` must not open heredoc suppression (roborev job 48).
-  function unq_of(s2,   n3, i3, sq3, dq3, c3, out) {
-    n3 = length(s2); sq3 = 0; dq3 = 0; out = ""
-    for (i3 = 1; i3 <= n3; i3++) {
-      c3 = substr(s2, i3, 1)
-      if (!sq3 && c3 == "\\") { i3++; out = out "  "; continue }
-      if (sq3) { out = out " "; if (c3 == "'"'"'") sq3 = 0; continue }
-      if (dq3) { out = out " "; if (c3 == "\"") dq3 = 0; continue }
-      if (c3 == "'"'"'") { sq3 = 1; out = out " "; continue }
-      if (c3 == "\"") { dq3 = 1; out = out " "; continue }
-      if (c3 == "#" && (i3 == 1 || substr(s2, i3-1, 1) ~ /[ \t]/)) break
-      out = out c3
-    }
-    return out
-  }
-  # SUPPRESS THE HEREDOC BODY, NOT THE WHOLE FUNCTION (roborev job 47). Suppression used to begin at
-  # `usage() {`, so any EXECUTABLE statement between the function opener and its `cat <<EOF` was
-  # invisible to the classifier-GONE scan — a reintroduction parked there passed the guard, and the
-  # AC3 control did not cover it because it appends only OUTSIDE the function. What earns the
-  # exemption is being PROSE PRINTED TO A USER, which starts at the heredoc opener, not at the `{`.
-  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage_fn = 1 }
-  in_usage_fn && unq_of($0) ~ /(^|[ \t;&|(])cat[ \t]+<<-?[ \t]*.?EOF/ { in_usage_fn = 0; in_usage = 1; next }
-  in_usage && /^EOF$/ { in_usage = 0; next }
-  # PROSE IS EXEMPT ONLY WHERE IT IS PROVABLY INERT. The delimiter is unquoted, so a heredoc line
-  # carrying ANY expansion still executes -- `${mode:=mixed-delivery}` sets a variable when the body
-  # is rendered (roborev job 57). Rather than decide which expansions are dangerous (that was the
-  # claim-about-a-SET error, four times), the exemption is withheld from every line that has one:
-  # an expansion-free line cannot execute anything, which is an affirmative property rather than a
-  # list. Measured: no prose-word line in the real heredoc carries an expansion, so this is free.
-  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/ || $0 ~ /[$][{]/ || $0 ~ /[$][A-Za-z_]/) { print; next }
-  # A COMMAND SUBSTITUTION INSIDE THE HEREDOC STILL EXECUTES (roborev job 50). The delimiter is
-  # unquoted (the body interpolates $PROGNAME), so `$( )` and backticks in it RUN -- classifier logic
-  # parked there would be prose to this filter and code to the shell. The exemption is for TEXT, so
-  # a substitution inside the body is surfaced rather than suppressed. Measured cost: the real
-  # heredoc contains zero of them.
-  # ...and an ASSIGNING parameter expansion evaluates too: ${VAR:=mixed-delivery} and ${VAR=...}
-  # set the variable when bash renders the body (roborev job 51). Those two forms are the complete
-  # set of expansions that assign; plain $VAR and ${VAR} cannot, which is why the ordinary
-  # $PROGNAME interpolation in the body stays suppressed and the prose exemption still works.
-  # NOTE: this awk program is single-quoted, so NO APOSTROPHE may appear in these comments.
-  # ANY braced expansion is surfaced, not just the assigning ones. Naming the assigning forms was
-  # another claim about a SET, and ${VAR:+word} / ${VAR:-word} / ${VAR:?word} all REFERENCE the
-  # retired state while being none of them (roborev job 53). The real heredoc contains exactly one
-  # braced expansion, so surfacing every one costs a single line of prose review.
-  in_usage { next }
-  /^[[:space:]]*#/ { next }
-  # A SUBSTITUTION LINE KEEPS ITS TAIL. Inside `$( )` a quoted `#` looks like a comment opener to
-  # this flat parser, so stripping the "comment" could hide a prohibited token that bash executes
-  # (roborev job 48). Emitting the whole line risks only a false FAIL on a genuine trailing comment
-  # of a substitution line naming a retired state — the safe direction.
-  { print ($0 ~ /[$][(]/ || $0 ~ /`/) ? $0 : code_of($0) }
-' "$@" 2>/dev/null || true
-}
 # ===== THE CLASSIFIER IS GONE, AND MUST STAY GONE (owner ruling (4), #3312) =====
 # Every state, helper and marker below carried one of the four High-severity false verdicts. They are
 # asserted ABSENT rather than fixed, because absence is what the ruling bought: with no delivery-mode
@@ -4768,33 +4692,45 @@ _cls_exec_lines() {
 # A guard whose verdict depends on a pipe buffer is worse than no guard. So the text is captured ONCE
 # and matched in PURE BASH with `case` — no pipe, no subshell, no exit status to lose.
 _classifier=""
-_cls_exec=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
-# The capture must be NON-EMPTY: an awk that failed, a renamed file or a filter that swallowed
-# everything would make every `case` below miss and the check would report CLEAN having read nothing.
-if [ -z "$_cls_exec" ]; then
-  bad 'structural: the executable-line capture for the classifier scan is EMPTY, so the scan below would report CLEAN having examined nothing (an awk failure, a renamed flow script, or an over-broad filter)'
-fi
+
 # THE 13 CODE IDENTIFIERS: scanned EVERYWHERE, including the help heredoc. They cannot occur in
 # English, so there is no legitimate prose use to exempt.
+_cls_ident_list='roborev_collect_review_diff_headers
+roborev_prompt_snapshot_paths
+roborev_snapshot_path_binding
+ROBOREV_DIFF_SOURCE_STATE
+BLOCKRESET
+BLOCKHDR
+in_trailer
+in_fence
+_rx_delivery_hdrs
+_rx_snap_paths
+SNAPSHOT_NOTICE
+ROBOREV_SNAPSHOT_PATH
+ROBOREV_SNAPSHOT_CONTAINMENT'
 _cls_all=$(_cls_all_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
 if [ -z "$_cls_all" ]; then
   bad 'structural: the all-lines capture for the classifier scan is EMPTY, so the identifier scan below would report CLEAN having examined nothing'
 fi
-for _gone in 'roborev_collect_review_diff_headers' 'roborev_prompt_snapshot_paths' \
-  'roborev_snapshot_path_binding' 'ROBOREV_DIFF_SOURCE_STATE' 'BLOCKRESET' 'BLOCKHDR' \
-  'in_trailer' 'in_fence' '_rx_delivery_hdrs' '_rx_snap_paths' 'SNAPSHOT_NOTICE' \
-  'ROBOREV_SNAPSHOT_PATH' 'ROBOREV_SNAPSHOT_CONTAINMENT'; do
+# ONE source for the list, so AC2 below asserts against the same tokens the scan uses.
+for _gone in $_cls_ident_list; do
   case "$_cls_all" in
     *"$_gone"*) _classifier="$_classifier $_gone" ;;
   esac
 done
-# THE 4 PROSE-SHAPED VERDICT STRINGS: scanned outside the help heredoc only, since the usage text
-# legitimately names them while telling the reader they are gone.
-for _gone in 'mixed-delivery' 'delegated-oversize' 'snapshot-unbound' 'unparseable-instruction'; do
-  case "$_cls_exec" in
-    *"$_gone"*) _classifier="$_classifier $_gone" ;;
-  esac
-done
+# THE 4 PROSE-SHAPED VERDICT STRINGS ARE NOT SCANNED AT ALL (roborev jobs 51/53/54/56/57/58).
+# `mixed-delivery`, `delegated-oversize`, `snapshot-unbound` and `unparseable-instruction` are
+# English, so they legitimately appear in help text and doctrine -- which forced an exemption for
+# the `usage()` heredoc, and SIX consecutive review rounds each found another construct that
+# executes inside an unquoted heredoc (command substitution, assigning parameter expansion, bare
+# $VAR, a substitution spanning lines, a `#` line that is data not a comment). Every fix was another
+# claim about a SET, and the exemption is the only reason any of it was needed.
+#
+# Dropping them removes the exemption, the filter and the whole family. Nothing is lost that the
+# guard could actually rely on: a reintroduced classifier is CODE, and code is these thirteen
+# identifiers -- a verdict STRING alone is not a classifier. This is what issue comments 3/5/6/7
+# recommended from the start ("key the guard solely on the 13 identifiers"); I deferred it as scope
+# in 3367-W1 and six rounds of heredoc parsing were the price of that deferral.
 if [ -z "$_classifier" ]; then
   ok 'structural: the delivery-mode classifier is GONE — no block/heading/fence/candidate state, no snapshot or delegated distinction, no NOTICE exemption'
 else
@@ -4805,38 +4741,6 @@ fi
 # awk filter is therefore run over a synthetic pair of files that carry the SAME forbidden token in
 # both positions, and it must keep the executable one and drop the `--help` one. Without this, the
 # prose exemption could widen until it swallowed the subject and the check would still read green.
-_cls_ctl_dir="$tmp/classifier-filter-control"
-mkdir -p "$_cls_ctl_dir"
-{
-  printf 'usage() {\n  cat <<EOF\n'
-  printf 'Block detection, fence evidence, mixed-delivery and the rest are all GONE.\n'
-  printf 'EOF\n}\n'
-  printf '# a comment mentioning mixed-delivery, which is history, not code\n'
-} >"$_cls_ctl_dir/roborev-review.sh"
-printf 'ROBOREV_DIFF_SOURCE_STATE=inline   # an EXECUTABLE reintroduction\n' \
-  >"$_cls_ctl_dir/roborev-review-oracles.sh"
-_cls_ctl=$(_cls_exec_lines "$_cls_ctl_dir/roborev-review-oracles.sh" "$_cls_ctl_dir/roborev-review.sh")
-case "$_cls_ctl" in
-  *ROBOREV_DIFF_SOURCE_STATE*)
-    ok 'structural control: the executable-line filter KEEPS an executable reintroduction, so the scan above is discriminating rather than blind' ;;
-  *)
-    bad 'structural control: the executable-line filter DROPPED an executable reintroduction — the classifier scan above cannot see the thing it exists to catch' ;;
-esac
-# ...and a TRAILING comment naming a retired token must be dropped too (roborev job 45): the filter
-# used to remove only comment-ONLY lines, so an ordinary inline comment red the classifier assert.
-_cls_ctl_inline=$(printf 'x=1   # a trailing comment naming mixed-delivery\n' | _cls_exec_lines /dev/stdin)
-case "$_cls_ctl_inline" in
-  *mixed-delivery*)
-    bad 'structural control: the executable-line filter kept a TRAILING comment, so an inline comment naming a retired state would red the classifier assert on doctrine text' ;;
-  *)
-    ok 'structural control: the executable-line filter drops TRAILING comments as well as whole-line ones, so naming a retired state in an inline comment is not a violation' ;;
-esac
-case "$_cls_ctl" in
-  *mixed-delivery*)
-    bad 'structural control: the executable-line filter kept --help prose (or a comment), so the check would red on the doctrine text that records the deletion' ;;
-  *)
-    ok 'structural control: the filter drops --help prose and comments, so recording the retired states in doctrine is not itself a violation' ;;
-esac
 # ===== BOTH DIRECTIONS, PINNED AGAINST THE REAL WRAPPER (#3367 AC2/AC3) =====
 # The control above builds its own pair of files, which shows the FILTER discriminates but says
 # nothing about the state of the actual subject. These two pin the real file, in both directions.
@@ -4854,12 +4758,16 @@ done
 if [ -z "$_ac2_prose" ]; then
   bad 'structural (#3367 AC2): the real wrapper names NONE of the prose-shaped retired states, so the prose exemption is untested by this run — the guard would read green whether or not it works (the wrapper is supposed to record what was deleted; if that record is gone, restore it or retire this pin deliberately)'
 else
+  # The scan cannot trip on these because it does not look for them: the token list is the thirteen
+  # CODE IDENTIFIERS only. Asserted against the list itself rather than against a filter's output,
+  # so this stays true without a heredoc exemption existing at all.
   _ac2_leaked=""
   for _ac2_tok in $_ac2_prose; do
-    case "$_cls_exec" in *"$_ac2_tok"*) _ac2_leaked="$_ac2_leaked $_ac2_tok" ;; esac
+    case "$_cls_all" in *"$_ac2_tok"*) : ;; esac
+    printf '%s\n' "$_cls_ident_list" | grep -qxF "$_ac2_tok" && _ac2_leaked="$_ac2_leaked $_ac2_tok"
   done
   if [ -z "$_ac2_leaked" ]; then
-    ok "structural (#3367 AC2): the real wrapper's doctrine prose names$_ac2_prose and the executable-line filter drops every one — recording what was deleted is not itself a violation"
+    ok "structural (#3367 AC2): the real wrapper's doctrine prose names$_ac2_prose and NONE of them is in the scanned token list — recording what was deleted cannot be a violation, with no heredoc exemption needed to make that true"
   else
     bad "structural (#3367 AC2): a prose-shaped retired state survived the executable-line filter —$_ac2_leaked. TWO causes, and they need opposite responses: (a) the heredoc/comment exemption broke, which is the deterministic red that made two lanes investigate a diff touching no scripts/ path — fix the filter; or (b) that word now sits on a heredoc line carrying an EXPANSION, which is correctly NOT exempt because an unquoted heredoc executes it — move the word to an expansion-free line. Check which before touching the filter"
   fi
@@ -4873,7 +4781,7 @@ mkdir -p "$_ac3_dir"
 cp "$WRAPPER_REAL" "$_ac3_dir/roborev-review.sh"
 printf '\nROBOREV_DIFF_SOURCE_STATE="mixed-delivery"   # a genuine reintroduction\n' \
   >>"$_ac3_dir/roborev-review.sh"
-_ac3_exec=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$_ac3_dir/roborev-review.sh")
+_ac3_exec=$(_cls_all_lines "$ORACLES" "$CHECKS_FILE" "$_ac3_dir/roborev-review.sh")
 _ac3_caught=""
 for _ac3_tok in ROBOREV_DIFF_SOURCE_STATE mixed-delivery; do
   case "$_ac3_exec" in *"$_ac3_tok"*) _ac3_caught="$_ac3_caught $_ac3_tok" ;; esac
@@ -4886,10 +4794,10 @@ _ac3b_dir="$tmp/real-wrapper-usage-reintroduction"
 mkdir -p "$_ac3b_dir"
 awk '/^usage\(\) \{/ && !done { print; print "  ROBOREV_DIFF_SOURCE_STATE=inline"; done = 1; next } { print }' \
   "$WRAPPER_REAL" >"$_ac3b_dir/roborev-review.sh"
-_ac3b_exec=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$_ac3b_dir/roborev-review.sh")
+_ac3b_exec=$(_cls_all_lines "$ORACLES" "$CHECKS_FILE" "$_ac3b_dir/roborev-review.sh")
 case "$_ac3b_exec" in
   *ROBOREV_DIFF_SOURCE_STATE*)
-    ok 'structural (#3367 AC3b): a reintroduction parked INSIDE usage() before its heredoc is caught — the filter exempts the heredoc BODY (prose printed to a user), not the whole function' ;;
+    ok 'structural (#3367 AC3b): a reintroduction parked INSIDE usage() before its heredoc is caught — identifiers are scanned everywhere, so no part of the function is exempt' ;;
   *)
     bad 'structural (#3367 AC3b): a reintroduction between `usage() {` and its `cat <<EOF` was NOT caught. The prose exemption starts at the function opener instead of the heredoc opener, so executable code parked there is invisible to the classifier-GONE scan' ;;
 esac

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -49,6 +49,14 @@ readonly WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
 # every early run_wrapper call at an arbitrary script and the suite would report on that instead --
 # a hermeticity hole introduced by this very refactor. Only the two gate-mock cases may set it.
 RUN_WRAPPER_PATH=""
+# THE MUTABLE GLOBAL IS FORBIDDEN BY THE SHELL, NOT BY A GREP (roborev job 54). `readonly` on an
+# UNSET name refuses every later assignment form -- `WRAPPER=`, `export WRAPPER=`, `declare
+# WRAPPER=`, `WRAPPER+=`, `printf -v WRAPPER`, `read WRAPPER` (all six measured). The structural
+# check below matched only a bare `WRAPPER=`, which is the assignment-syntax enumeration roborev
+# already corrected me on for WRAPPER_REAL in job 37; I repeated it on the new check. Nothing reads
+# $WRAPPER any more, so leaving it unset costs nothing and makes reintroduction impossible rather
+# than merely detected.
+readonly WRAPPER
 # A code-only view of a file: quoted spans blanked, comments removed, continuations joined. Used by
 # the one structural scan below, so a variable NAME appearing inside a diagnostic string or a
 # comment is not mistaken for a read of it.
@@ -4695,7 +4703,11 @@ _cls_exec_lines() {
   # another claim about a SET, and ${VAR:+word} / ${VAR:-word} / ${VAR:?word} all REFERENCE the
   # retired state while being none of them (roborev job 53). The real heredoc contains exactly one
   # braced expansion, so surfacing every one costs a single line of prose review.
-  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/ || $0 ~ /[$][{]/) { print; next }
+  # EVERY expansion, braced or not. The heredoc delimiter is unquoted, so `$ROBOREV_DIFF_SOURCE_STATE`
+  # is as live as `${...}` -- surfacing only the braced form was one more claim about a SET
+  # (roborev job 54). Measured: the real heredoc has 4 expansion lines and none names a retired
+  # token, so surfacing all of them costs nothing.
+  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/ || $0 ~ /[$][{]/ || $0 ~ /[$][A-Za-z_]/) { print; next }
   in_usage { next }
   /^[[:space:]]*#/ { next }
   # A SUBSTITUTION LINE KEEPS ITS TAIL. Inside `$( )` a quoted `#` looks like a comment opener to
@@ -4875,8 +4887,12 @@ fi
 # Nothing is left to read wrongly, so there is nothing to police: one shell-enforced fact replaces
 # the scanner, its thirty-six fixtures and its poison probe. The property below is what remains.
 _wr_bad=""
-if grep -qE '^[[:space:]]*WRAPPER=' "$TEST_SELF"; then
-  _wr_bad="$_wr_bad a-mutable-WRAPPER-global-is-back;"
+# Ask the shell whether the global can exist, rather than guessing which spelling would create it.
+if ( WRAPPER=/nonexistent/decoy ) 2>/dev/null; then
+  _wr_bad="$_wr_bad a-mutable-WRAPPER-global-can-be-created;"
+fi
+if [ -n "${WRAPPER+set}" ]; then
+  _wr_bad="$_wr_bad WRAPPER-has-a-value;"
 fi
 # `RUN_WRAPPER_PATH` is the scratch-copy override. It may be ASSIGNED only by the mock cases and READ
 # only by run_wrapper -- otherwise it is the same order-dependent global under a new name.

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4964,7 +4964,11 @@ _WR_QS=$(cat <<'AWKEOF'
   # single-quoted prose. Modelling nesting properly is a real shell parser; refusing to call anything
   # inside a substitution "prose" is one flag. Only the prose verdict is affected — a live read in a
   # substitution is still judged on spelling/arity/form as before.
-  cs = (seg ~ /[$][(]/) ? 1 : 0
+  # BOTH command-substitution syntaxes, which is the COMPLETE set POSIX defines — `$( )` and
+  # backticks. The first version tested `$(` alone, i.e. a sample of the constructs rather than the
+  # set, so `ok "\`grep \"a'b\" \"$WRAPPER\" \"c'd\"\`"` reproduced the same quote confusion and was
+  # excused as prose. If a future shell grows a third, this line is where it goes.
+  cs = (seg ~ /[$][(]/ || seg ~ /`/) ? 1 : 0
   printf "%d %d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, cs, seg
 }
 AWKEOF
@@ -5180,6 +5184,7 @@ _wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
 _wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
 _wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
 _wr_fixture f_multiline "' \"\$ORACLES\" \"\$CHECKS_FILE\" $_wr_ref 2>/dev/null || true)"
+_wr_fixture f_btprose  "ok \"\`grep \"a'b\" $_wr_ref \"c'd\"\`\""
 _wr_fixture f_cshidden "bash $_wr_ref \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
 _wr_fixture f_csprose  "ok \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
 _wr_fixture f_locsave  "  local _gm_real_wrapper=$_wr_ref"
@@ -5213,6 +5218,7 @@ _wr_expect f_bracedef spelling
 _wr_expect f_fakeinv  form
 _wr_expect f_evalasm  prose
 _wr_expect f_multiline unbalanced
+_wr_expect f_btprose  substitution
 _wr_expect f_cshidden substitution
 _wr_expect f_csprose  substitution
 _wr_expect f_locsave  clean
@@ -5229,7 +5235,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-three fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-four fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi
@@ -5298,24 +5304,46 @@ fi
 # attempt and it FALSE-FAILED on two pre-existing legitimate uses (`${!_rw_i}` walking positional
 # arguments at ~960, nothing to do with aliases) — a guard that reds on correct code is the guard
 # people learn to waive, so the ban is scoped to what actually threatens an alias.
-_wr_nrefd=$(grep -nE '(declare|local|typeset)[[:space:]]+-[A-Za-z]*'"n"'[[:space:]]' "$TEST_SELF" \
+# ANY option group containing the flag counts, in any order and any combination: `-n`, `-ng`,
+# `-g -n`. The first version anchored it as the LAST character of the FIRST group, which is a
+# spelling of the flag rather than the flag itself — `declare -g -n` and `declare -ng` both evaded
+# it. (`local _f="$1"` and friends carry no option group and are unaffected.)
+_wr_nrefd=$(grep -nE '(^|[ \t;&|(])(declare|local|typeset)[[:space:]]+(-[A-Za-z]+[[:space:]]+)*-[A-Za-z]*'"n" "$TEST_SELF" \
   | grep -vE '^[0-9]+:[[:space:]]*#' || true)
 if [ -z "$_wr_nrefd" ]; then
   ok 'structural (#3367): the harness declares no nameref, so no second name can be bound to an allowlisted alias'
 else
   bad "structural (#3367): a nameref declaration appears in this file. It can bind an allowlisted alias to a new name that the alias-use scan (which looks for the alias by name) and the wrapper scan (which looks for \$WRAPPER) both miss: $(printf '%s' "$_wr_nrefd" | head -3 | tr '\n' ';' | cut -c1-200)"
 fi
-# ...and an indirect expansion must not name an alias. The needle is split so this guard cannot
-# match its own line.
-_wr_indir=$(grep -nE '[$][{]'"!" "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+# ...and EVERY indirect expansion is refused except an exact allowlist. The first version only
+# refused one whose own text named an alias, which is a property of the LINE rather than of what it
+# EXPANDS TO: `_name=_wr_saved; grep "${!_name}"` — or `_name=WRAPPER` — names nothing on the line
+# that scans. What a name expands to is not decidable here, so the construct itself is allowlisted
+# by exact content: the two pre-existing positional-argument walkers, and nothing else. A reformat
+# of those lines reds and must be re-approved, which is the intended cost of an exact allowlist.
+# The allowlist entries are COMPOSED, never written literally: spelled out, they would themselves be
+# indirect expansions and this scan would flag its own allowlist. (Same self-reference as the marker
+# that authorised itself, but in the FAIL direction — the guard's artifact matching its own subject.
+# Measured: the literal form red with the allowlist lines as the two offenders.)
+_wr_ib='${'"!"
+_wr_indir_ok_1='if [ "'"$_wr_ib"'_rw_i}" = "--log" ]; then'
+_wr_indir_ok_2='WRAPPER_LOG_PATH="'"$_wr_ib"'_rw_next}"'
 _wr_indir_bad=""
-for _wr_ia in $_wr_aliases; do
-  case "$_wr_indir" in *"$_wr_ia"*) _wr_indir_bad="$_wr_indir_bad $_wr_ia" ;; esac
-done
+while IFS= read -r _wr_il; do
+  [ -n "$_wr_il" ] || continue
+  _wr_ilc=${_wr_il#*:}
+  _wr_ilc=${_wr_ilc#"${_wr_ilc%%[! 	]*}"}
+  _wr_ilc=${_wr_ilc%"${_wr_ilc##*[! 	]}"}
+  [ "$_wr_ilc" = "$_wr_indir_ok_1" ] && continue
+  [ "$_wr_ilc" = "$_wr_indir_ok_2" ] && continue
+  _wr_indir_bad="$_wr_indir_bad${_wr_indir_bad:+; }$_wr_il"
+done <<EOF
+$(grep -nE '[$][{]'"!" "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
+EOF
 if [ -z "$_wr_indir_bad" ]; then
-  ok 'structural (#3367): no indirect expansion names a save alias (the pre-existing ones walk positional arguments)'
+  ok 'structural (#3367): every indirect expansion in this harness is one of the two allowlisted positional-argument walkers — a dynamically-named one could expand to a save alias, and what a name expands to is not decidable by this scan'
 else
-  bad "structural (#3367): an indirect expansion names a save alias —$_wr_indir_bad. That reaches the mutable path under a name neither structural scan is looking for"
+  bad "structural (#3367): an indirect expansion outside the exact allowlist appears in this file. It can expand to a save alias (or to the wrapper variable itself) under a name neither structural scan is looking for: $(printf '%s' "$_wr_indir_bad" | head -3 | cut -c1-200)"
 fi
 if [ "${_wr_alias_seen:-0}" -eq 0 ]; then
   bad 'structural (#3367): no use of any save alias was found, so the alias restriction certified nothing — the aliases were renamed and the allowlist is now describing names that do not exist'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4989,6 +4989,15 @@ _wr_classify() {
   # rather than be believed — CLAUDE.md's `${end:-$start}` lesson, on the field that can least
   # afford it. Key the permissive branch on the AFFIRMATIVE value, never on `!= <bad>`.
   if [ "${_c_bal:-0}" -eq 0 ]; then printf 'unbalanced %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return; fi
+  # ANY apparently-inert occurrence on a line carrying a command substitution is REFUSED, whether or
+  # not the line also has a recognised live read (roborev job 43). Gating this on `code -eq 0` was
+  # not enough: `bash "$WRAPPER" "$(grep "a'"'"'b" "$WRAPPER" "c'"'"'d")"` presents ONE occurrence as a
+  # permitted invocation while a SECOND, inside the substitution, is mis-paired into `lit` and never
+  # judged at all — the arity rule counts only `code`, so it does not see it either. Inside `$( )`
+  # the flat parse cannot be trusted about ANY occurrence, so no occurrence there may be excused.
+  if [ "${_c_cs:-1}" -eq 1 ] && [ "${_c_lit:-0}" -gt 0 ]; then
+    printf 'substitution %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
+  fi
   if [ "${_c_ev:-0}" -eq 1 ] && [ $(( ${_c_code:-0} + ${_c_lit:-0} )) -gt 0 ]; then
     printf 'eval %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
   fi
@@ -5002,7 +5011,8 @@ _wr_classify() {
       # command word is this harness's own `ok`/`bad` reporter. Anything else FAILs closed, which
       # costs nothing today (all four literal occurrences are diagnostics) and cannot be widened by
       # accident.
-      # ...and never inside a command substitution, where the flat parse cannot be trusted.
+      # (a substitution has already been refused above; this stays as a belt-and-braces AFFIRMATIVE
+      # test rather than relying on the earlier branch's condition never changing)
       if [ "${_c_cs:-1}" -eq 0 ]; then
         _c_pw=$(_wr_cmdpos "$_c_seg")
         case "$_c_pw" in
@@ -5057,7 +5067,7 @@ _wr_classify() {
 # the SAME function over fixtures whose correct verdict is known — dispatch included.
 _wr_scan_file() {
   _sf_file=$1
-  _wr_bad_reads=""; _wr_bad_spelling=""; _wr_prose_bad=""; _wr_unknown=""; _wr_multi=""; _wr_lit_bad=""; _wr_unbal=""
+  _wr_bad_reads=""; _wr_bad_spelling=""; _wr_prose_bad=""; _wr_unknown=""; _wr_multi=""; _wr_lit_bad=""; _wr_unbal=""; _wr_subst=""
   _wr_total=0; _wr_prose_n=0
   while IFS= read -r _wr_num_line; do
     [ -n "$_wr_num_line" ] || continue
@@ -5073,6 +5083,7 @@ _wr_scan_file() {
       eval) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
       prose) _wr_lit_bad="$_wr_lit_bad${_wr_lit_bad:+; }$_wr_num_line" ;;
       unbalanced) _wr_unbal="$_wr_unbal${_wr_unbal:+; }$_wr_num_line" ;;
+      substitution) _wr_subst="$_wr_subst${_wr_subst:+; }$_wr_num_line" ;;
       spelling) _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line" ;;
       arity) _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line" ;;
       form) _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line" ;;
@@ -5095,6 +5106,7 @@ EOF
   elif [ "${_wr_total:-0}" -eq 0 ]; then _WR_VERDICT=empty
   elif [ -n "$_wr_prose_bad" ]; then _WR_VERDICT=eval
   elif [ -n "$_wr_unbal" ]; then _WR_VERDICT=unbalanced
+  elif [ -n "$_wr_subst" ]; then _WR_VERDICT=substitution
   elif [ -n "$_wr_lit_bad" ]; then _WR_VERDICT=prose
   elif [ -n "$_wr_bad_spelling" ]; then _WR_VERDICT=spelling
   elif [ -n "$_wr_multi" ]; then _WR_VERDICT=arity
@@ -5110,6 +5122,8 @@ case "$_WR_VERDICT" in
     bad "structural (#3367): the order-dependence classifier returned a verdict the dispatch does not recognise, so some line was neither accepted nor rejected —$_wr_unknown" ;;
   empty)
     bad 'structural (#3367): the order-dependence pass found NO accepted occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the scan lost its subject' ;;
+  substitution)
+    bad "structural (#3367): a line carries a COMMAND SUBSTITUTION and an occurrence of the mutable wrapper variable that this flat parse read as inert. Inside \$( ) quoting restarts, so a second read can hide there while a first is waved through as a permitted invocation — no occurrence on such a line may be excused: $(printf '%s' "$_wr_subst" | cut -c1-200)" ;;
   unbalanced)
     bad "structural (#3367): a line carrying the mutable wrapper variable ends INSIDE an unterminated quote, so the per-line quote parse is unreliable and no verdict from it can be trusted. This is how the guard would green-light #3367's original defect — the closing line of a multi-line quoted program begins with the CLOSING quote, which a per-line scanner reads as an opening one: $(printf '%s' "$_wr_unbal" | cut -c1-200)" ;;
   prose)
@@ -5166,6 +5180,7 @@ _wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
 _wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
 _wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
 _wr_fixture f_multiline "' \"\$ORACLES\" \"\$CHECKS_FILE\" $_wr_ref 2>/dev/null || true)"
+_wr_fixture f_cshidden "bash $_wr_ref \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
 _wr_fixture f_csprose  "ok \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
 _wr_fixture f_locsave  "  local _gm_real_wrapper=$_wr_ref"
 _wr_fixture f_semisave "_gm_real_wrapper=$_wr_ref;"
@@ -5198,7 +5213,8 @@ _wr_expect f_bracedef spelling
 _wr_expect f_fakeinv  form
 _wr_expect f_evalasm  prose
 _wr_expect f_multiline unbalanced
-_wr_expect f_csprose  prose
+_wr_expect f_cshidden substitution
+_wr_expect f_csprose  substitution
 _wr_expect f_locsave  clean
 _wr_expect f_semisave clean
 _wr_expect f_cmpsave  form
@@ -5213,7 +5229,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-two fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-three fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi
@@ -5237,7 +5253,13 @@ while IFS= read -r _wr_u; do
   _wr_ud=${_wr_ud%"${_wr_ud##*[! 	]}"}
   [ "$_wr_ud" = "_wr_aliases=" ] && continue
   _wr_alias_seen=$((_wr_alias_seen + 1))
-  case "$_wr_uc" in *"$_wr_marker"*) continue ;; esac
+  # THE MARKER IS RECOGNISED ONLY AT THE START OF A QUOTE-AWARE TRAILING COMMENT, exactly as the
+  # main classifier does it. Matched anywhere, `grep "wrapper-mutable-read-allow" "$_wr_saved"`
+  # exempts ITSELF and scans the alias — the self-authorisation shape again, on the one check that
+  # had not yet been converted. The scanner already computes this; ask it rather than re-deciding.
+  _wr_umk=$(printf '%s\n' "$_wr_u" | awk -v VN="$_wr_vname" -v MK="$_wr_marker" "$_WR_QS" | head -1)
+  _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk##* }
+  [ "${_wr_umk:-0}" -eq 1 ] && continue
   _wr_ut=${_wr_uc#"${_wr_uc%%[! ]*}"}
   _wr_is_restore=no
   for _wr_a in $_wr_aliases; do
@@ -5268,6 +5290,32 @@ if [ -z "$_wr_ax_bad" ]; then
   ok 'structural control (#3367): the alias-declaration exemption matches the declaration EXACTLY — a line merely quoting the alias names is still judged, so it cannot exempt itself while scanning an alias'
 else
   bad "structural control (#3367): the alias-declaration exemption misclassifies a synthetic line, so a line quoting the declaration could skip the alias-use check —$_wr_ax_bad"
+fi
+# NO ALIAS MAY BE REACHED UNDER ANOTHER NAME (roborev job 43). Both structural scans look for the
+# alias by NAME or by `$`-expansion, so an indirect binding reaches the saved mutable path without
+# either seeing it:  declare -n subject=_wr_saved ; grep ... "$subject"
+# Two narrow checks rather than one broad one. A blanket ban on indirect expansion was the first
+# attempt and it FALSE-FAILED on two pre-existing legitimate uses (`${!_rw_i}` walking positional
+# arguments at ~960, nothing to do with aliases) — a guard that reds on correct code is the guard
+# people learn to waive, so the ban is scoped to what actually threatens an alias.
+_wr_nrefd=$(grep -nE '(declare|local|typeset)[[:space:]]+-[A-Za-z]*'"n"'[[:space:]]' "$TEST_SELF" \
+  | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+if [ -z "$_wr_nrefd" ]; then
+  ok 'structural (#3367): the harness declares no nameref, so no second name can be bound to an allowlisted alias'
+else
+  bad "structural (#3367): a nameref declaration appears in this file. It can bind an allowlisted alias to a new name that the alias-use scan (which looks for the alias by name) and the wrapper scan (which looks for \$WRAPPER) both miss: $(printf '%s' "$_wr_nrefd" | head -3 | tr '\n' ';' | cut -c1-200)"
+fi
+# ...and an indirect expansion must not name an alias. The needle is split so this guard cannot
+# match its own line.
+_wr_indir=$(grep -nE '[$][{]'"!" "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+_wr_indir_bad=""
+for _wr_ia in $_wr_aliases; do
+  case "$_wr_indir" in *"$_wr_ia"*) _wr_indir_bad="$_wr_indir_bad $_wr_ia" ;; esac
+done
+if [ -z "$_wr_indir_bad" ]; then
+  ok 'structural (#3367): no indirect expansion names a save alias (the pre-existing ones walk positional arguments)'
+else
+  bad "structural (#3367): an indirect expansion names a save alias —$_wr_indir_bad. That reaches the mutable path under a name neither structural scan is looking for"
 fi
 if [ "${_wr_alias_seen:-0}" -eq 0 ]; then
   bad 'structural (#3367): no use of any save alias was found, so the alias restriction certified nothing — the aliases were renamed and the allowlist is now describing names that do not exist'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4506,7 +4506,7 @@ printf '== structural: path normalisation has EXACTLY ONE boundary ==\n'
 #   (4) no consumer re-implements header parsing or newline-delimited path membership.
 ORACLES="$SCRIPT_DIR/../flow/roborev-review-oracles.sh"
 CHECKS_FILE="$SCRIPT_DIR/../flow/roborev-review-checks.sh"
-FLOW_FILES=("$ORACLES" "$CHECKS_FILE" "$WRAPPER")
+FLOW_FILES=("$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
 for _f in "${FLOW_FILES[@]}"; do
   if [ ! -f "$_f" ]; then bad "structural: missing $_f"; continue; fi
   # (1) EVERY `git diff` that reads PATHS must be NUL-delimited. A `--numstat`/`--name-only`
@@ -4600,6 +4600,21 @@ fi
 #     in CLAUDE.md and the doctrine page: every `test`/`[` file predicate is two-valued, so it must collapse
 #     "cannot tell" onto one of its answers, and it always picks the permissive one. The "performs NO
 #     filesystem access" assert below is what makes that empty subject set TRUE rather than assumed.
+# ONE DEFINITION OF THE EXECUTABLE-LINE FILTER (#3367). The classifier scan, its control and the
+# order-independence pin below all need the same "strip comments and the --help heredoc" pass. It
+# used to be written out three times, and a port is a second implementation whose correctness is
+# only knowable by differential testing against the original — the exact trap CLAUDE.md records for
+# #3283. So it is a function with ONE body: a filter that drifts between call sites cannot make one
+# caller lenient while its own control still reads green.
+_cls_exec_lines() {
+  awk '
+  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
+  in_usage && /^EOF$/ { in_usage = 0; next }
+  in_usage { next }
+  /^[[:space:]]*#/ { next }
+  { print }
+' "$@" 2>/dev/null || true
+}
 # ===== THE CLASSIFIER IS GONE, AND MUST STAY GONE (owner ruling (4), #3312) =====
 # Every state, helper and marker below carried one of the four High-severity false verdicts. They are
 # asserted ABSENT rather than fixed, because absence is what the ruling bought: with no delivery-mode
@@ -4620,13 +4635,7 @@ fi
 # A guard whose verdict depends on a pipe buffer is worse than no guard. So the text is captured ONCE
 # and matched in PURE BASH with `case` — no pipe, no subshell, no exit status to lose.
 _classifier=""
-_cls_exec=$(awk '
-  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
-  in_usage && /^EOF$/ { in_usage = 0; next }
-  in_usage { next }
-  /^[[:space:]]*#/ { next }
-  { print }
-' "$ORACLES" "$CHECKS_FILE" "$WRAPPER" 2>/dev/null || true)
+_cls_exec=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
 # The capture must be NON-EMPTY: an awk that failed, a renamed file or a filter that swallowed
 # everything would make every `case` below miss and the check would report CLEAN having read nothing.
 if [ -z "$_cls_exec" ]; then
@@ -4661,13 +4670,7 @@ mkdir -p "$_cls_ctl_dir"
 } >"$_cls_ctl_dir/roborev-review.sh"
 printf 'ROBOREV_DIFF_SOURCE_STATE=inline   # an EXECUTABLE reintroduction\n' \
   >"$_cls_ctl_dir/roborev-review-oracles.sh"
-_cls_ctl=$(awk '
-  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
-  in_usage && /^EOF$/ { in_usage = 0; next }
-  in_usage { next }
-  /^[[:space:]]*#/ { next }
-  { print }
-' "$_cls_ctl_dir/roborev-review-oracles.sh" "$_cls_ctl_dir/roborev-review.sh" 2>/dev/null || true)
+_cls_ctl=$(_cls_exec_lines "$_cls_ctl_dir/roborev-review-oracles.sh" "$_cls_ctl_dir/roborev-review.sh")
 case "$_cls_ctl" in
   *ROBOREV_DIFF_SOURCE_STATE*)
     ok 'structural control: the executable-line filter KEEPS an executable reintroduction, so the scan above is discriminating rather than blind' ;;
@@ -4703,7 +4706,13 @@ fi
 #   (2) BEHAVIOURAL — with `WRAPPER` deliberately poisoned, the scan's verdict must not move, and
 #       the same scan against the poisoned path MUST move. Without the second half, (2) would pass
 #       for a scan that reads nothing at all.
+# COMMENTS STRIPPED FIRST, and this check learned that the hard way: its first version flagged
+# ITS OWN explanatory comment above (the one quoting `"$WRAPPER"` while describing the defect),
+# which is exactly #3367's cause 2 — a structural assert measuring the prose that documents it.
+# A guard that reds on its own rationale is one the next person deletes. `grep -n` is kept for the
+# diagnostic, so the line numbers below still point at real code.
 _wr_scan_leaks=$(grep -nE '(grep|awk|sed|cp|wc|head|tail)[^|]*"\$WRAPPER"' "$TEST_SELF" \
+  | grep -vE '^[0-9]+:[[:space:]]*#' \
   | grep -v 'bash "\$WRAPPER"' || true)
 if [ -z "$_wr_scan_leaks" ]; then
   ok 'structural (#3367): no doctrine scan reads the mutable $WRAPPER — every text scan uses $WRAPPER_REAL, so no verdict depends on which case ran last'
@@ -4727,20 +4736,8 @@ mkdir -p "$_wr_poison_dir"
 } >"$_wr_poison_dir/roborev-review.sh"
 _wr_saved="$WRAPPER"
 WRAPPER="$_wr_poison_dir/roborev-review.sh"
-_cls_via_real=$(awk '
-  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
-  in_usage && /^EOF$/ { in_usage = 0; next }
-  in_usage { next }
-  /^[[:space:]]*#/ { next }
-  { print }
-' "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL" 2>/dev/null || true)
-_cls_via_mutable=$(awk '
-  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
-  in_usage && /^EOF$/ { in_usage = 0; next }
-  in_usage { next }
-  /^[[:space:]]*#/ { next }
-  { print }
-' "$ORACLES" "$CHECKS_FILE" "$WRAPPER" 2>/dev/null || true)
+_cls_via_real=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
+_cls_via_mutable=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER")
 WRAPPER="$_wr_saved"
 _wr_real_hit=no; _wr_mut_hit=no
 case "$_cls_via_real"    in *'mixed-delivery'*) _wr_real_hit=yes ;; esac
@@ -4812,7 +4809,7 @@ fi
 # "the invoker can bypass this" becomes another round — and how the opposite error, treating a real
 # third-party hole as unpatchable, would creep in.
 _tm_missing=""
-for _f in "$ORACLES" "$WRAPPER"; do
+for _f in "$ORACLES" "$WRAPPER_REAL"; do
   grep -qF 'A HOSTILE INVOKER' "$_f" || _tm_missing="$_tm_missing $(basename "$_f")"
 done
 grep -qF 'the INVOKER can bypass this' "$ORACLES" || _tm_missing="$_tm_missing oracles-triage-rule"
@@ -4892,7 +4889,7 @@ else
 fi
 # THE SCOPED RESIDUAL IS STATED ON EVERY SURFACE, in its NARROW form.
 _resid_missing=""
-for _f in "$ORACLES" "$CHECKS_FILE" "$WRAPPER"; do
+for _f in "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL"; do
   grep -qiF 'WHICH ALLOWLISTED HUMAN' "$_f" || _resid_missing="$_resid_missing $(basename "$_f")"
 done
 if [ -z "$_resid_missing" ]; then
@@ -4907,7 +4904,7 @@ fi
 # and the verdict values — and only AFFIRMATIVE spellings: the NOTICE deliberately says "there is no digest
 # and no content identity", and a statement of ABSENCE is exactly what must survive.
 _diag=$(grep -hnE 'DETAILS\+=\(|^[[:space:]]*(PROMPT_CONTENT|REVIEW_COMPLETED|TIER1|TIER2|FINDINGS|CENSUS_CHECK|CODE_FREE|PUSH_ASSERT|SHA_ASSERT|JOB_RECORD)=' \
-  "$WRAPPER" "$CHECKS_FILE" "$ORACLES" 2>/dev/null || true)
+  "$WRAPPER_REAL" "$CHECKS_FILE" "$ORACLES" 2>/dev/null || true)
 _diag_stale=$(printf '%s\n' "$_diag" | grep -inE 'captur|watcher|watchdog|observer|digest(ed|ing)? (of|the snapshot)|snapshot digest|mid-copy|SNAPSHOT_(DIGEST|BYTES)|bounded read|read the snapshot' || true)
 if [ -z "$_diag_stale" ]; then
   ok 'structural: no emitted diagnostic names a retired mechanism (capture/watcher/watchdog/observer/digest) as current behaviour'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -5004,12 +5004,19 @@ _wr_classify() {
   if [ "${_c_code:-0}" -gt 1 ]; then printf 'arity %s\n' "$_c_code"; return; fi
   if [ "${_c_mk:-0}" -eq 1 ]; then printf 'ok %s\n' "$_c_code"; return; fi
   if _wr_is_invocation "$_c_seg"; then printf 'ok %s\n' "$_c_code"; return; fi
-  case "$_c_seg" in
-    *"=$_wr_ref"|*"=$_wr_ref"' ')
-      _c_nm=${_c_seg%%=*}
-      _c_nm=${_c_nm#"${_c_nm%%[! ]*}"}
-      case " $_wr_aliases " in *" $_c_nm "*) printf 'ok %s\n' "$_c_code"; return ;; esac ;;
-  esac
+  # A SAVE IS THE WHOLE STATEMENT OR IT IS NOT A SAVE (roborev job 41). The test used to be a
+  # SUFFIX glob plus `${seg%%=*}`, which takes the text before the FIRST `=` on the line — so a
+  # compound statement whose first assignment happens to name an allowlisted alias vouched for a
+  # completely different one:
+  #   _wr_saved=x; subject="$WRAPPER"     -> `${seg%%=*}` is `_wr_saved`, accepted
+  # The read there is assigned to `subject`. Matched EXACTLY against the whole trimmed segment now,
+  # so nothing can share the line with a save. (Third instance of the same error in this file: a
+  # permitted shape found ANYWHERE standing in for the line BEING that shape.)
+  _c_trim=${_c_seg#"${_c_seg%%[! 	]*}"}
+  _c_trim=${_c_trim%"${_c_trim##*[! 	]}"}
+  for _c_a in $_wr_aliases; do
+    if [ "$_c_trim" = "$_c_a=$_wr_ref" ]; then printf 'ok %s\n' "$_c_code"; return; fi
+  done
   printf 'form %s\n' "$_c_code"
 }
 # THE WHOLE ENFORCEMENT PASS IS A FUNCTION, AND THE CONTROL RUNS *IT* OVER FIXTURES (reviewer B2,
@@ -5129,6 +5136,8 @@ _wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
 _wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
 _wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
 _wr_fixture f_multiline "' \"\$ORACLES\" \"\$CHECKS_FILE\" $_wr_ref 2>/dev/null || true)"
+_wr_fixture f_cmpsave  "_wr_saved=x; subject=$_wr_ref"
+_wr_fixture f_cmpsave2 "_wr_saved=unused; grep pattern $_wr_ref"
 _wr_fixture f_ansic    "_x=\$'a\\'b'; grep -c z $_wr_ref"
 _wr_fixture f_marked   "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
 _wr_fixture f_mixed    "grep -c q $_wr_ref; ok 'mentions \$$_wr_vname'"
@@ -5156,6 +5165,8 @@ _wr_expect f_bracedef spelling
 _wr_expect f_fakeinv  form
 _wr_expect f_evalasm  prose
 _wr_expect f_multiline unbalanced
+_wr_expect f_cmpsave  form
+_wr_expect f_cmpsave2 form
 _wr_expect f_ansic    unbalanced
 _wr_expect f_marked   clean
 _wr_expect f_mixed    form
@@ -5166,7 +5177,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all twenty-seven fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all twenty-nine fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -44,6 +44,11 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # that lands on the scratch copy finds nothing and reports CLEAN — a false pass, which is
 # worse than the false fail that surfaced the bug.
 readonly WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
+# THE SCRATCH-COPY OVERRIDE STARTS EMPTY, WHATEVER THE CALLER EXPORTED (roborev job 53). It is read
+# as `${RUN_WRAPPER_PATH:-$WRAPPER_REAL}`, so an inherited environment value would silently redirect
+# every early run_wrapper call at an arbitrary script and the suite would report on that instead --
+# a hermeticity hole introduced by this very refactor. Only the two gate-mock cases may set it.
+RUN_WRAPPER_PATH=""
 # A code-only view of a file: quoted spans blanked, comments removed, continuations joined. Used by
 # the one structural scan below, so a variable NAME appearing inside a diagnostic string or a
 # comment is not mistaken for a read of it.
@@ -4645,7 +4650,9 @@ _cls_exec_lines() {
       else {
         if (c2 == "'"'"'") { sq2 = 1; continue }
         if (c2 == "\"") { dq2 = 1; continue }
-        if (c2 == "#" && (i2 == 1 || substr(s, i2-1, 1) ~ /[ \t]/)) return substr(s, 1, i2 - 1)
+        # A comment can also open straight after an operator -- `x=1;# note` is a comment to the
+        # shell (roborev job 53). Restricting to whitespace left such text in the executable view.
+        if (c2 == "#" && (i2 == 1 || substr(s, i2-1, 1) ~ /[ \t;&|()]/)) return substr(s, 1, i2 - 1)
       }
     }
     return s
@@ -4684,7 +4691,11 @@ _cls_exec_lines() {
   # set of expansions that assign; plain $VAR and ${VAR} cannot, which is why the ordinary
   # $PROGNAME interpolation in the body stays suppressed and the prose exemption still works.
   # NOTE: this awk program is single-quoted, so NO APOSTROPHE may appear in these comments.
-  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/ || $0 ~ /[$][{][A-Za-z_][A-Za-z0-9_]*:?=/) { print; next }
+  # ANY braced expansion is surfaced, not just the assigning ones. Naming the assigning forms was
+  # another claim about a SET, and ${VAR:+word} / ${VAR:-word} / ${VAR:?word} all REFERENCE the
+  # retired state while being none of them (roborev job 53). The real heredoc contains exactly one
+  # braced expansion, so surfacing every one costs a single line of prose review.
+  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/ || $0 ~ /[$][{]/) { print; next }
   in_usage { next }
   /^[[:space:]]*#/ { next }
   # A SUBSTITUTION LINE KEEPS ITS TAIL. Inside `$( )` a quoted `#` looks like a comment opener to

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4684,16 +4684,24 @@ _rx_snap_paths
 SNAPSHOT_NOTICE
 ROBOREV_SNAPSHOT_PATH
 ROBOREV_SNAPSHOT_CONTAINMENT'
+# THE ONE CLASSIFIER PREDICATE (roborev job 61). The real scan, AC2, AC3 and AC3b all call this, so
+# no caller can supply its own answer. They used to: AC2 carried a literal no-op
+# (`case ... in *"$tok"*) : ;; esac`) and AC3 hard-coded two token names, which meant AC3's stated
+# criterion -- "observed firing" -- was satisfied by a control that could not fail. An AC verified by
+# a control that supplies its own answer is not verified, and this is the SECOND instance of
+# "control certifies a copy, not the enforcer" in this PR; the first had already DRIFTED by the time
+# it was found. One helper makes a third instance unexpressible rather than merely unlikely.
+_cls_hits() {
+  for _ch_tok in $_cls_ident_list; do
+    case "$1" in *"$_ch_tok"*) printf '%s\n' "$_ch_tok" ;; esac
+  done
+}
 _cls_all=$(_cls_all_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
 if [ -z "$_cls_all" ]; then
   bad 'structural: the all-lines capture for the classifier scan is EMPTY, so the identifier scan below would report CLEAN having examined nothing'
 fi
-# ONE source for the list, so AC2 below asserts against the same tokens the scan uses.
-for _gone in $_cls_ident_list; do
-  case "$_cls_all" in
-    *"$_gone"*) _classifier="$_classifier $_gone" ;;
-  esac
-done
+_classifier=$(_cls_hits "$_cls_all" | tr '\n' ' ')
+_classifier=${_classifier% }
 # THE 4 PROSE-SHAPED VERDICT STRINGS ARE NOT SCANNED AT ALL (roborev jobs 51/53/54/56/57/58).
 # `mixed-delivery`, `delegated-oversize`, `snapshot-unbound` and `unparseable-instruction` are
 # English, so they legitimately appear in help text and doctrine -- which forced an exemption for
@@ -4737,10 +4745,14 @@ else
   # The scan cannot trip on these because it does not look for them: the token list is the thirteen
   # CODE IDENTIFIERS only. Asserted against the list itself rather than against a filter's output,
   # so this stays true without a heredoc exemption existing at all.
+  # Asked of the PREDICATE the real scan uses, over the REAL text -- not of the token list, and not
+  # by a match this control performs itself. If the predicate ever starts reporting a prose word,
+  # this fails; if the predicate stops reporting anything at all, AC3 below fails. Between them the
+  # two directions pin the same function.
+  _ac2_hits=$(_cls_hits "$_cls_all")
   _ac2_leaked=""
   for _ac2_tok in $_ac2_prose; do
-    case "$_cls_all" in *"$_ac2_tok"*) : ;; esac
-    printf '%s\n' "$_cls_ident_list" | grep -qxF "$_ac2_tok" && _ac2_leaked="$_ac2_leaked $_ac2_tok"
+    printf '%s\n' "$_ac2_hits" | grep -qxF "$_ac2_tok" && _ac2_leaked="$_ac2_leaked $_ac2_tok"
   done
   if [ -z "$_ac2_leaked" ]; then
     ok "structural (#3367 AC2): the real wrapper's doctrine prose names$_ac2_prose and NONE of them is in the scanned token list — recording what was deleted cannot be a violation, with no heredoc exemption needed to make that true"
@@ -4758,10 +4770,7 @@ cp "$WRAPPER_REAL" "$_ac3_dir/roborev-review.sh"
 printf '\nROBOREV_DIFF_SOURCE_STATE="mixed-delivery"   # a genuine reintroduction\n' \
   >>"$_ac3_dir/roborev-review.sh"
 _ac3_exec=$(_cls_all_lines "$ORACLES" "$CHECKS_FILE" "$_ac3_dir/roborev-review.sh")
-_ac3_caught=""
-for _ac3_tok in ROBOREV_DIFF_SOURCE_STATE mixed-delivery; do
-  case "$_ac3_exec" in *"$_ac3_tok"*) _ac3_caught="$_ac3_caught $_ac3_tok" ;; esac
-done
+_ac3_caught=$(_cls_hits "$_ac3_exec" | tr '\n' ' ')
 # AC3b: THE SAME REINTRODUCTION, PARKED INSIDE usage() BEFORE ITS HEREDOC (roborev job 47). AC3
 # above appends OUTSIDE the function, which cannot see a filter that exempts from `usage() {`
 # rather than from `cat <<EOF` — a reintroduction between the two was invisible. An executable
@@ -4771,7 +4780,8 @@ mkdir -p "$_ac3b_dir"
 awk '/^usage\(\) \{/ && !done { print; print "  ROBOREV_DIFF_SOURCE_STATE=inline"; done = 1; next } { print }' \
   "$WRAPPER_REAL" >"$_ac3b_dir/roborev-review.sh"
 _ac3b_exec=$(_cls_all_lines "$ORACLES" "$CHECKS_FILE" "$_ac3b_dir/roborev-review.sh")
-case "$_ac3b_exec" in
+_ac3b_caught=$(_cls_hits "$_ac3b_exec" | tr '\n' ' ')
+case "$_ac3b_caught" in
   *ROBOREV_DIFF_SOURCE_STATE*)
     ok 'structural (#3367 AC3b): a reintroduction parked INSIDE usage() before its heredoc is caught — identifiers are scanned everywhere, so no part of the function is exempt' ;;
   *)

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4976,7 +4976,11 @@ _wr_classify() {
   _c_ev=${_c_rest%% *}; _c_bal=${_c_rest##* }
   # AN UNRELIABLE PARSE YIELDS NO VERDICT (reviewer). Checked FIRST: every field below is derived
   # from the same state machine, so if it ended the line inside a quote, none of them can be trusted.
-  if [ "${_c_bal:-1}" -eq 0 ]; then printf 'unbalanced %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return; fi
+  # DEFAULTS TO UNTRUSTWORTHY, not to balanced. This is the one field whose job is to say "do not
+  # trust the other fields", so an UNMEASURED value (a failed awk, a renamed field) must refuse
+  # rather than be believed — CLAUDE.md's `${end:-$start}` lesson, on the field that can least
+  # afford it. Key the permissive branch on the AFFIRMATIVE value, never on `!= <bad>`.
+  if [ "${_c_bal:-0}" -eq 0 ]; then printf 'unbalanced %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return; fi
   if [ "${_c_ev:-0}" -eq 1 ] && [ $(( ${_c_code:-0} + ${_c_lit:-0} )) -gt 0 ]; then
     printf 'eval %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
   fi
@@ -5014,6 +5018,18 @@ _wr_classify() {
   # permitted shape found ANYWHERE standing in for the line BEING that shape.)
   _c_trim=${_c_seg#"${_c_seg%%[! 	]*}"}
   _c_trim=${_c_trim%"${_c_trim##*[! 	]}"}
+  # A declaration keyword and a trailing `;` are part of the SAVE, not a second statement. Without
+  # this, wrapping the poison probe in a function -- `local _wr_saved="$WRAPPER"`, the natural tidy-up
+  # -- reds the gate advising the author to use $WRAPPER_REAL, which is WRONG advice for a save. The
+  # exactness that matters (nothing may SHARE the line) is untouched: only a leading declaration and
+  # one trailing semicolon are absorbed.
+  _c_trim=${_c_trim%;}
+  _c_trim=${_c_trim#"${_c_trim%%[! 	]*}"}
+  case "$_c_trim" in
+    'local '*|'export '*|'declare '*|'typeset '*)
+      _c_trim=${_c_trim#* }
+      _c_trim=${_c_trim#"${_c_trim%%[! 	]*}"} ;;
+  esac
   for _c_a in $_wr_aliases; do
     if [ "$_c_trim" = "$_c_a=$_wr_ref" ]; then printf 'ok %s\n' "$_c_code"; return; fi
   done
@@ -5106,6 +5122,9 @@ mkdir -p "$_wr_ctl_dir"
 # Each fixture carries one PERMITTED occurrence (so `empty` is not the answer) plus the case under test.
 _wr_ok_line="bash $_wr_ref --help"
 _wr_ctl_bad=""
+# FIXTURES ARE WRITTEN WITH `printf` AND `$_wr_ref`, NEVER A HEREDOC. The scanner is line-oriented,
+# so a literal `"$WRAPPER"` in a quoted `<<'"'"'EOF'"'"'` heredoc body reads as a live read and verdicts
+# `form` — inert in shell, but this pass cannot see the heredoc. Fail-closed, and free to avoid.
 _wr_fixture() {
   # $1 = name, $2 = the line under test ('' for none)
   printf '%s\n' "$_wr_ok_line" >"$_wr_ctl_dir/$1"
@@ -5136,6 +5155,8 @@ _wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
 _wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
 _wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
 _wr_fixture f_multiline "' \"\$ORACLES\" \"\$CHECKS_FILE\" $_wr_ref 2>/dev/null || true)"
+_wr_fixture f_locsave  "  local _gm_real_wrapper=$_wr_ref"
+_wr_fixture f_semisave "_gm_real_wrapper=$_wr_ref;"
 _wr_fixture f_cmpsave  "_wr_saved=x; subject=$_wr_ref"
 _wr_fixture f_cmpsave2 "_wr_saved=unused; grep pattern $_wr_ref"
 _wr_fixture f_ansic    "_x=\$'a\\'b'; grep -c z $_wr_ref"
@@ -5165,6 +5186,8 @@ _wr_expect f_bracedef spelling
 _wr_expect f_fakeinv  form
 _wr_expect f_evalasm  prose
 _wr_expect f_multiline unbalanced
+_wr_expect f_locsave  clean
+_wr_expect f_semisave clean
 _wr_expect f_cmpsave  form
 _wr_expect f_cmpsave2 form
 _wr_expect f_ansic    unbalanced
@@ -5177,7 +5200,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all twenty-nine fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-one fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -59,30 +59,6 @@ readonly WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
 # rather than forbidding one (measured: `WRAPPER=/decoy bash -c 'readonly WRAPPER; echo $WRAPPER'`
 # prints /decoy), which would make the suite red on the caller environment (roborev job 56).
 readonly WRAPPER
-# A code-only view of a file: quoted spans blanked, comments removed, continuations joined. Used by
-# the one structural scan below, so a variable NAME appearing inside a diagnostic string or a
-# comment is not mistaken for a read of it.
-_wr_code_view_min() {
-  sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | awk '
-  {
-    n = length($0); sq = 0; dq = 0; out = ""
-    for (i = 1; i <= n; i++) {
-      c = substr($0, i, 1)
-      if (!sq && c == "\\") { i++; out = out "  "; continue }
-      # A DOUBLE-quoted span is KEPT: expansions happen inside it, and this view is used to count
-      # reads of a variable. Only SINGLE quotes (literal text) and comments are blanked. Blanking
-      # double quotes erased the one read this scan exists to find -- measured 0 reads of a variable
-      # that is read exactly once, in `bash "${RUN_WRAPPER_PATH:-$WRAPPER_REAL}"`.
-      if (sq) { out = out " "; if (c == "'"'"'") sq = 0; continue }
-      if (dq) { out = out c; if (c == "\"") dq = 0; continue }
-      if (c == "'"'"'") { sq = 1; out = out " "; continue }
-      if (c == "\"") { dq = 1; out = out c; continue }
-      if (c == "#" && (i == 1 || substr($0, i-1, 1) ~ /[ \t]/)) break
-      out = out c
-    }
-    print out
-  }'
-}
 # The structured waiver scanner the wrapper delegates to (#3312 job 26). Defined HERE, beside
 # WRAPPER, because run_wrapper passes it on every call — the structural section is too late.
 SCAN_TOOL="$SCRIPT_DIR/../flow/roborev-waiver-scan.py"
@@ -4857,12 +4833,23 @@ if _wr_leak=$( { run_wrapper_probe() { local _rw_wrapper=inner; }; run_wrapper_p
 else
   bad "structural (#3367): a function-local leaked to the caller (got '${_wr_leak:-?}'), so run_wrapper's wrapper path is effectively global again and any caller could redirect it"
 fi
-# Read the CODE view and split the needle: the prose above names the retired global while
-# explaining why it is gone, and a raw grep matched that. Fifth self-reference of this shape in
-# this PR -- an artifact describing a rule matching the rule.
-if _wr_code_view_min "$TEST_SELF" | grep -q 'RUN_WRAPPER''_PATH'; then
-  _wr_bad="$_wr_bad the-RUN_WRAPPER_PATH-global-is-back;"
-fi
+# CAPTURED ONCE AND MATCHED IN PURE BASH -- no pipe, no exit status to lose (roborev job 59).
+# This was `<view> | grep -q <needle>` under `set -uo pipefail`, which is the inversion documented on
+# THIS issue: `grep -q` exits at the first match, SIGPIPEs the writer, and pipefail takes the 141 --
+# so a MATCH is reported as a non-match and the forbidden global rides through. Measured here: 30/30
+# detected, because the needle happens to sit at byte 175k of a 201k stream, so the reader consumes
+# nearly all of it before exiting. That is fail-open BY POSITION -- the issue's own instance inverted
+# 39 times in 40 with an early match -- and "safe at today's byte offset" is not a property worth
+# depending on. Same remedy #3416 applied to the classifier scan.
+#
+# The needle is split because the prose above names the retired global while explaining why it is
+# gone; comment lines are dropped for the same reason. (Fifth self-reference of this shape in this
+# PR -- an artifact describing a rule matching the rule.)
+_wr_rwp_view=$(grep -v '^[[:space:]]*#' "$TEST_SELF" || true)
+case "$_wr_rwp_view" in
+  *'RUN_WRAPPER''_PATH'*)
+    _wr_bad="$_wr_bad the-scratch-path-global-is-back;" ;;
+esac
 if ! grep -qE '^[[:space:]]*local _rw_wrapper="\$WRAPPER_REAL"' "$TEST_SELF"; then
   _wr_bad="$_wr_bad run_wrapper-no-longer-defaults-its-path-to-a-local-seeded-from-WRAPPER_REAL;"
 fi

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -43,6 +43,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # Note the direction of the hazard now: with the `--help` prose exemption in place, a scan
 # that lands on the scratch copy finds nothing and reports CLEAN — a false pass, which is
 # worse than the false fail that surfaced the bug.
+unset WRAPPER 2>/dev/null || true
 readonly WRAPPER_REAL="$SCRIPT_DIR/../flow/roborev-review.sh"
 # THE SCRATCH-COPY OVERRIDE STARTS EMPTY, WHATEVER THE CALLER EXPORTED (roborev job 53). It is read
 # as `${RUN_WRAPPER_PATH:-$WRAPPER_REAL}`, so an inherited environment value would silently redirect
@@ -55,7 +56,9 @@ RUN_WRAPPER_PATH=""
 # check below matched only a bare `WRAPPER=`, which is the assignment-syntax enumeration roborev
 # already corrected me on for WRAPPER_REAL in job 37; I repeated it on the new check. Nothing reads
 # $WRAPPER any more, so leaving it unset costs nothing and makes reintroduction impossible rather
-# than merely detected.
+# than merely detected. UNSET FIRST: `readonly` on an INHERITED exported value freezes that value
+# rather than forbidding one (measured: `WRAPPER=/decoy bash -c 'readonly WRAPPER; echo $WRAPPER'`
+# prints /decoy), which would make the suite red on the caller environment (roborev job 56).
 readonly WRAPPER
 # A code-only view of a file: quoted spans blanked, comments removed, continuations joined. Used by
 # the one structural scan below, so a variable NAME appearing inside a diagnostic string or a
@@ -4657,10 +4660,14 @@ fi
 # word, so this costs nothing and closes the family. (Issue comments 3/5/6/7 recommended keying on
 # the identifiers for this reason; deferred then as scope, adopted now because it fixes a live hole.)
 _cls_all_lines() {
-  awk '
-  /^[[:space:]]*#/ { next }
-  { print }
-' "$@" 2>/dev/null || true
+  # NO FILTERING AT ALL -- not even comments. A `#`-leading line inside the UNQUOTED help heredoc is
+  # DATA, not a comment, and its expansions still execute, so skipping such lines was a hole
+  # (roborev job 56). Deciding which `#` lines are comments needs heredoc state, i.e. the parsing
+  # problem this split exists to avoid. Measured instead: the three flow scripts contain ZERO
+  # mentions of any of the thirteen identifiers in comment lines, so scanning everything costs
+  # nothing. If that ever stops being true this check reds, and the right response is to rename the
+  # identifier or drop it from the list -- NOT to reintroduce a filter.
+  cat "$@" 2>/dev/null || true
 }
 _cls_exec_lines() {
   awk '

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4888,7 +4888,15 @@ _wr_classify() {
   _c_s=$(printf '%s\n' "$_c_code" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
   if [ "${_c_n:-0}" -ne "${_c_s:-0}" ]; then
     case "$_c_raw" in
-      *"$_wr_prose_marker"*) printf 'prose-ok %s\n' "$_c_n"; return ;;
+      *"$_wr_prose_marker"*)
+        # THE PROSE MARKER MUST NOT WAIVE ARITY EITHER (roborev job 38). It used to return
+        # `prose-ok` on sight, so a line mixing quoted prose with a LIVE read --
+        #   grep -c q "$WRAPPER"; ok 'mentions $WRAPPER'   # <prose marker>
+        # -- was accepted whole. Marked prose is only prose if the strip removed EVERY occurrence;
+        # anything surviving the strip is a live read riding on the marker, which is the
+        # compound-line bypass wearing a third disguise.
+        if [ "${_c_s:-0}" -eq 0 ]; then printf 'prose-ok %s\n' "$_c_n"; return; fi
+        printf 'arity %s\n' "$_c_n"; return ;;
     esac
     printf 'prose %s\n' "$_c_n"; return
   fi
@@ -5008,6 +5016,7 @@ _wr_fixture f_prose    "_probe=\$(grep -c \"the wrapper's tok\" $_wr_ref) # it's
 _wr_fixture f_eval     "eval 'grep -c FOO $_wr_ref'"
 _wr_fixture f_prosetag "  ok 'the mutable \$$_wr_vname is named in prose' # $_wr_prose_marker"
 _wr_fixture f_marked   "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
+_wr_fixture f_mixed    "grep -c q $_wr_ref; ok 'mentions \$$_wr_vname' # $_wr_prose_marker"
 _wr_fixture f_save     "_gm_real_wrapper=$_wr_ref"
 _wr_fixture f_envinv   "STUB_INVOKED=\"\$INVOKED\" PATH=\"\$stubbin:\$PATH\" bash $_wr_ref --help"
 printf '%s\n' "_x=\$(grep -c foo \"\$${_wr_vname}_REAL\")" >"$_wr_ctl_dir/f_empty"
@@ -5025,6 +5034,7 @@ _wr_expect f_prose    prose
 _wr_expect f_eval     prose
 _wr_expect f_prosetag clean
 _wr_expect f_marked   clean
+_wr_expect f_mixed    arity
 _wr_expect f_save     clean
 _wr_expect f_envinv   clean
 _wr_expect f_empty    empty
@@ -5032,7 +5042,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all seventeen fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash and quote-swallowed bypasses, refuses to let one marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs and marked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all eighteen fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash and quote-swallowed bypasses, refuses to let either marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs and marked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4683,6 +4683,53 @@ case "$_cls_ctl" in
   *)
     ok 'structural control: the filter drops --help prose and comments, so recording the retired states in doctrine is not itself a violation' ;;
 esac
+# ===== BOTH DIRECTIONS, PINNED AGAINST THE REAL WRAPPER (#3367 AC2/AC3) =====
+# The control above builds its own pair of files, which shows the FILTER discriminates but says
+# nothing about the state of the actual subject. These two pin the real file, in both directions.
+#
+# (a) THE REAL WRAPPER'S DOCTRINE PROSE MUST NOT TRIP THE SCAN — and this pin is only worth
+#     anything if that prose is actually THERE. The exemption is load-bearing precisely because
+#     `roborev-review.sh` names the retired states in its `usage()` heredoc while telling the
+#     reader they are gone (that occurrence is what red this component on two unrelated lanes).
+#     If the wrapper ever stopped naming them, the pin would pass having tested nothing, so the
+#     RAW presence is asserted FIRST and its absence is a FAIL, not a silent skip.
+_ac2_prose=""
+for _ac2_tok in mixed-delivery delegated-oversize snapshot-unbound unparseable-instruction; do
+  grep -qF "$_ac2_tok" "$WRAPPER_REAL" && _ac2_prose="$_ac2_prose $_ac2_tok"
+done
+if [ -z "$_ac2_prose" ]; then
+  bad 'structural (#3367 AC2): the real wrapper names NONE of the prose-shaped retired states, so the prose exemption is untested by this run — the guard would read green whether or not it works (the wrapper is supposed to record what was deleted; if that record is gone, restore it or retire this pin deliberately)'
+else
+  _ac2_leaked=""
+  for _ac2_tok in $_ac2_prose; do
+    case "$_cls_exec" in *"$_ac2_tok"*) _ac2_leaked="$_ac2_leaked $_ac2_tok" ;; esac
+  done
+  if [ -z "$_ac2_leaked" ]; then
+    ok "structural (#3367 AC2): the real wrapper's doctrine prose names$_ac2_prose and the executable-line filter drops every one — recording what was deleted is not itself a violation"
+  else
+    bad "structural (#3367 AC2): the real wrapper's doctrine prose survived the executable-line filter —$_ac2_leaked. This is the deterministic red that made two lanes investigate a diff touching no scripts/ path; the --help heredoc and comment exemptions must cover it"
+  fi
+fi
+# (b) A GENUINE REINTRODUCTION INTO THE REAL WRAPPER MUST STILL BE CAUGHT. Asserted against a COPY
+#     of the real trio with one executable line appended — not the 2-line synthetic above — so the
+#     exemptions cannot have widened far enough to swallow live code in the real file's own shape.
+#     Without this, (a) could be satisfied by an exemption that drops everything.
+_ac3_dir="$tmp/real-wrapper-reintroduction"
+mkdir -p "$_ac3_dir"
+cp "$WRAPPER_REAL" "$_ac3_dir/roborev-review.sh"
+printf '\nROBOREV_DIFF_SOURCE_STATE="mixed-delivery"   # a genuine reintroduction\n' \
+  >>"$_ac3_dir/roborev-review.sh"
+_ac3_exec=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$_ac3_dir/roborev-review.sh")
+_ac3_caught=""
+for _ac3_tok in ROBOREV_DIFF_SOURCE_STATE mixed-delivery; do
+  case "$_ac3_exec" in *"$_ac3_tok"*) _ac3_caught="$_ac3_caught $_ac3_tok" ;; esac
+done
+case "$_ac3_caught" in
+  *ROBOREV_DIFF_SOURCE_STATE*)
+    ok "structural (#3367 AC3): an executable classifier reintroduction appended to a COPY of the real wrapper is still caught —$_ac3_caught — so the prose exemptions narrow the scan without blinding it" ;;
+  *)
+    bad 'structural (#3367 AC3): an executable classifier reintroduction appended to a copy of the REAL wrapper was NOT caught. The prose exemption has widened until it swallows live code, so the classifier-GONE assert above is green by blindness' ;;
+esac
 # THE THREE SNAPSHOT KEYS GO WITH IT: a block that still emitted them would be describing a
 # measurement the wrapper no longer makes.
 _skeys=""

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4858,7 +4858,7 @@ else
   if [ -z "$_ac2_leaked" ]; then
     ok "structural (#3367 AC2): the real wrapper's doctrine prose names$_ac2_prose and the executable-line filter drops every one — recording what was deleted is not itself a violation"
   else
-    bad "structural (#3367 AC2): the real wrapper's doctrine prose survived the executable-line filter —$_ac2_leaked. This is the deterministic red that made two lanes investigate a diff touching no scripts/ path; the --help heredoc and comment exemptions must cover it"
+    bad "structural (#3367 AC2): a prose-shaped retired state survived the executable-line filter —$_ac2_leaked. TWO causes, and they need opposite responses: (a) the heredoc/comment exemption broke, which is the deterministic red that made two lanes investigate a diff touching no scripts/ path — fix the filter; or (b) that word now sits on a heredoc line carrying an EXPANSION, which is correctly NOT exempt because an unquoted heredoc executes it — move the word to an expansion-free line. Check which before touching the filter"
   fi
 fi
 # (b) A GENUINE REINTRODUCTION INTO THE REAL WRAPPER MUST STILL BE CAUGHT. Asserted against a COPY

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4958,7 +4958,14 @@ _WR_QS=$(cat <<'AWKEOF'
   # Rather than grow the parser to cover each construct, an unbalanced line is REFUSED: a verdict
   # derived from an unreliable parse is not a verdict. Measured cost on this file: zero lines.
   bal = (sq || dq) ? 0 : 1
-  printf "%d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, seg
+  # A COMMAND SUBSTITUTION RESTARTS QUOTING, and this flat state machine cannot model that: inside
+  # `$( )` a fresh `"` opens a NEW double-quoted context, so `ok "$(grep "a'"'"'b" "$WRAPPER" "c'"'"'d")"`
+  # is valid shell that READS the wrapper while the flat scan pairs the two apostrophes and calls it
+  # single-quoted prose. Modelling nesting properly is a real shell parser; refusing to call anything
+  # inside a substitution "prose" is one flag. Only the prose verdict is affected — a live read in a
+  # substitution is still judged on spelling/arity/form as before.
+  cs = (seg ~ /[$][(]/) ? 1 : 0
+  printf "%d %d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, cs, seg
 }
 AWKEOF
 )
@@ -4973,7 +4980,8 @@ _wr_classify() {
   _c_lit=${_c_rest%% *}; _c_rest=${_c_rest#* }
   _c_q=${_c_rest%% *}; _c_rest=${_c_rest#* }
   _c_mk=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_ev=${_c_rest%% *}; _c_bal=${_c_rest##* }
+  _c_ev=${_c_rest%% *}; _c_rest=${_c_rest#* }
+  _c_bal=${_c_rest%% *}; _c_cs=${_c_rest##* }
   # AN UNRELIABLE PARSE YIELDS NO VERDICT (reviewer). Checked FIRST: every field below is derived
   # from the same state machine, so if it ended the line inside a quote, none of them can be trusted.
   # DEFAULTS TO UNTRUSTWORTHY, not to balanced. This is the one field whose job is to say "do not
@@ -4994,10 +5002,13 @@ _wr_classify() {
       # command word is this harness's own `ok`/`bad` reporter. Anything else FAILs closed, which
       # costs nothing today (all four literal occurrences are diagnostics) and cannot be widened by
       # accident.
-      _c_pw=$(_wr_cmdpos "$_c_seg")
-      case "$_c_pw" in
-        'ok '*|'bad '*) printf 'prose-ok %s\n' "$_c_lit"; return ;;
-      esac
+      # ...and never inside a command substitution, where the flat parse cannot be trusted.
+      if [ "${_c_cs:-1}" -eq 0 ]; then
+        _c_pw=$(_wr_cmdpos "$_c_seg")
+        case "$_c_pw" in
+          'ok '*|'bad '*) printf 'prose-ok %s\n' "$_c_lit"; return ;;
+        esac
+      fi
       printf 'prose %s\n' "$_c_lit"; return
     fi
     printf 'none 0\n'; return
@@ -5155,6 +5166,7 @@ _wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
 _wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
 _wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
 _wr_fixture f_multiline "' \"\$ORACLES\" \"\$CHECKS_FILE\" $_wr_ref 2>/dev/null || true)"
+_wr_fixture f_csprose  "ok \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
 _wr_fixture f_locsave  "  local _gm_real_wrapper=$_wr_ref"
 _wr_fixture f_semisave "_gm_real_wrapper=$_wr_ref;"
 _wr_fixture f_cmpsave  "_wr_saved=x; subject=$_wr_ref"
@@ -5186,6 +5198,7 @@ _wr_expect f_bracedef spelling
 _wr_expect f_fakeinv  form
 _wr_expect f_evalasm  prose
 _wr_expect f_multiline unbalanced
+_wr_expect f_csprose  prose
 _wr_expect f_locsave  clean
 _wr_expect f_semisave clean
 _wr_expect f_cmpsave  form
@@ -5200,7 +5213,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-one fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-two fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi
@@ -5215,7 +5228,14 @@ while IFS= read -r _wr_u; do
   [ -n "$_wr_u" ] || continue
   _wr_uc=${_wr_u#*:}
   _wr_uc=$(printf '%s\n' "$_wr_uc" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
-  case "$_wr_uc" in *"$_wr_alias_re"*) continue ;; esac   # the declaration line itself
+  # THE DECLARATION IS EXEMPT BY BEING THE DECLARATION, not by containing its own text. This was
+  # `case $line in *"$_wr_alias_re"*)`, an unanchored substring of the `a|b` alternation, so any line
+  # quoting that text was skipped: `grep -E "_gm_real_wrapper|_wr_saved" "$_wr_saved"` exempted
+  # itself while scanning an alias. Fourth instance of one error in this file — a permitted shape
+  # found ANYWHERE standing in for the line BEING that shape.
+  _wr_ud=${_wr_uc#"${_wr_uc%%[! 	]*}"}
+  _wr_ud=${_wr_ud%"${_wr_ud##*[! 	]}"}
+  [ "$_wr_ud" = "_wr_aliases=" ] && continue
   _wr_alias_seen=$((_wr_alias_seen + 1))
   case "$_wr_uc" in *"$_wr_marker"*) continue ;; esac
   _wr_ut=${_wr_uc#"${_wr_uc%%[! ]*}"}
@@ -5228,6 +5248,27 @@ while IFS= read -r _wr_u; do
 done <<EOF
 $(grep -nE '[$][{]?('"$_wr_alias_re"')[}]?([^A-Za-z0-9_]|$)' "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
 EOF
+# CONTROL for the exemption above (roborev job 42): embedding the declaration's text must NOT
+# authorise an alias use. Both probes run the same predicate the loop uses.
+#
+# THE PROBE STRINGS ARE BUILT AT RUNTIME, never written literally, because this file is its own
+# subject: a literal `"$_wr_saved"` here would be a genuine alias use and the loop above would
+# rightly flag it. Composing from `$_wr_aliases` keeps the source line free of any alias occurrence.
+_wr_ax_alias=${_wr_aliases##* }
+_wr_ax_bad=""
+_wr_ax_probe=$(printf 'grep -E "%s" "$%s"' "$_wr_alias_re" "$_wr_ax_alias")
+for _wr_ax in "_wr_aliases=|exempt" "$_wr_ax_probe|judged"; do
+  _wr_axl=${_wr_ax%|*}; _wr_axw=${_wr_ax##*|}
+  _wr_axc=$(printf '%s\n' "$_wr_axl" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
+  _wr_axc=${_wr_axc#"${_wr_axc%%[! 	]*}"}; _wr_axc=${_wr_axc%"${_wr_axc##*[! 	]}"}
+  if [ "$_wr_axc" = "_wr_aliases=" ]; then _wr_axg=exempt; else _wr_axg=judged; fi
+  [ "$_wr_axg" = "$_wr_axw" ] || _wr_ax_bad="$_wr_ax_bad [want=$_wr_axw got=$_wr_axg: $_wr_axl]"
+done
+if [ -z "$_wr_ax_bad" ]; then
+  ok 'structural control (#3367): the alias-declaration exemption matches the declaration EXACTLY — a line merely quoting the alias names is still judged, so it cannot exempt itself while scanning an alias'
+else
+  bad "structural control (#3367): the alias-declaration exemption misclassifies a synthetic line, so a line quoting the declaration could skip the alias-use check —$_wr_ax_bad"
+fi
 if [ "${_wr_alias_seen:-0}" -eq 0 ]; then
   bad 'structural (#3367): no use of any save alias was found, so the alias restriction certified nothing — the aliases were renamed and the allowlist is now describing names that do not exist'
 elif [ -z "$_wr_alias_bad" ]; then

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4715,6 +4715,13 @@ _cls_exec_lines() {
   FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage_fn = 1 }
   in_usage_fn && unq_of($0) ~ /(^|[ \t;&|(])cat[ \t]+<<-?[ \t]*.?EOF/ { in_usage_fn = 0; in_usage = 1; next }
   in_usage && /^EOF$/ { in_usage = 0; next }
+  # PROSE IS EXEMPT ONLY WHERE IT IS PROVABLY INERT. The delimiter is unquoted, so a heredoc line
+  # carrying ANY expansion still executes -- `${mode:=mixed-delivery}` sets a variable when the body
+  # is rendered (roborev job 57). Rather than decide which expansions are dangerous (that was the
+  # claim-about-a-SET error, four times), the exemption is withheld from every line that has one:
+  # an expansion-free line cannot execute anything, which is an affirmative property rather than a
+  # list. Measured: no prose-word line in the real heredoc carries an expansion, so this is free.
+  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/ || $0 ~ /[$][{]/ || $0 ~ /[$][A-Za-z_]/) { print; next }
   # A COMMAND SUBSTITUTION INSIDE THE HEREDOC STILL EXECUTES (roborev job 50). The delimiter is
   # unquoted (the body interpolates $PROGNAME), so `$( )` and backticks in it RUN -- classifier logic
   # parked there would be prose to this filter and code to the shell. The exemption is for TEXT, so
@@ -4933,6 +4940,15 @@ _wr_rwp_reads=$(_wr_code_view_min "$TEST_SELF" | grep -nE '[$][{]?RUN_WRAPPER_PA
 _wr_rwp_n=$(printf '%s' "$_wr_rwp_reads" | grep -c . || true)
 if [ "${_wr_rwp_n:-0}" -ne 1 ]; then
   _wr_bad="$_wr_bad RUN_WRAPPER_PATH-is-read-in-${_wr_rwp_n:-0}-places-not-just-run_wrapper;"
+fi
+# ...and its ASSIGNMENTS are counted too. Checking only the reads left the other half open: an extra
+# assignment elsewhere redirects run_wrapper while the read count stays at one (roborev job 57).
+# Exactly five are legitimate -- the empty initialisation, plus a set and a clear for each of the two
+# gate-mock cases. A sixth means someone is steering run_wrapper from a new place, which is #3367
+# returning under a different variable name.
+_wr_rwp_sets=$(_wr_code_view_min "$TEST_SELF" | grep -cE '^[[:space:]]*RUN_WRAPPER_PATH=' || true)
+if [ "${_wr_rwp_sets:-0}" -ne 5 ]; then
+  _wr_bad="$_wr_bad RUN_WRAPPER_PATH-is-assigned-${_wr_rwp_sets:-0}-times-not-5;"
 fi
 if [ -z "$_wr_bad" ]; then
   ok 'structural (#3367): there is no mutable WRAPPER global, and the scratch-copy override is read at exactly one site (run_wrapper) — a doctrine scan has no mutable path available to it, so the order dependence is absent by construction rather than policed'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4652,6 +4652,12 @@ _cls_exec_lines() {
   FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage_fn = 1 }
   in_usage_fn && unq_of($0) ~ /(^|[ \t;&|(])cat[ \t]+<<-?[ \t]*.?EOF/ { in_usage_fn = 0; in_usage = 1; next }
   in_usage && /^EOF$/ { in_usage = 0; next }
+  # A COMMAND SUBSTITUTION INSIDE THE HEREDOC STILL EXECUTES (roborev job 50). The delimiter is
+  # unquoted (the body interpolates $PROGNAME), so `$( )` and backticks in it RUN -- classifier logic
+  # parked there would be prose to this filter and code to the shell. The exemption is for TEXT, so
+  # a substitution inside the body is surfaced rather than suppressed. Measured cost: the real
+  # heredoc contains zero of them.
+  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/) { print; next }
   in_usage { next }
   /^[[:space:]]*#/ { next }
   # A SUBSTITUTION LINE KEEPS ITS TAIL. Inside `$( )` a quoted `#` looks like a comment opener to
@@ -5032,6 +5038,12 @@ _WR_QS=$(cat <<'AWKEOF'
   # Rather than grow the parser to cover each construct, an unbalanced line is REFUSED: a verdict
   # derived from an unreliable parse is not a verdict. Measured cost on this file: zero lines.
   bal = (sq || dq) ? 0 : 1
+  # ANSI-C `$'"'"'…'"'"'` IS NOT ORDINARY SINGLE QUOTING: it keeps a backslash-escaped quote INSIDE the
+  # string, which this scanner cannot model. Refusing only when the line ends UNBALANCED was not
+  # enough -- `ok $'"'"'a\'"'"'b'"'"'; grep -c z "$WRAPPER" # '"'"'` re-balances the parity using the comment
+  # apostrophe and then reads as reporter prose (roborev job 50). So the construct itself is refused
+  # on any line carrying an occurrence. Measured cost: no occurrence line uses it.
+  ansi = (line ~ /[$]'"'"'/) ? 1 : 0
   # A COMMAND SUBSTITUTION RESTARTS QUOTING, and this flat state machine cannot model that: inside
   # `$( )` a fresh `"` opens a NEW double-quoted context, so `ok "$(grep "a'"'"'b" "$WRAPPER" "c'"'"'d")"`
   # is valid shell that READS the wrapper while the flat scan pairs the two apostrophes and calls it
@@ -5064,7 +5076,7 @@ _WR_QS=$(cat <<'AWKEOF'
     }
     j++
   }
-  printf "%d %d %d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, cs, tot, seg
+  printf "%d %d %d %d %d %d %d %d %d\n%s\n", code, lit, q, mk, ev, bal, cs, tot, ansi, seg
 }
 AWKEOF
 )
@@ -5081,14 +5093,17 @@ _wr_classify() {
   _c_mk=${_c_rest%% *}; _c_rest=${_c_rest#* }
   _c_ev=${_c_rest%% *}; _c_rest=${_c_rest#* }
   _c_bal=${_c_rest%% *}; _c_rest=${_c_rest#* }
-  _c_cs=${_c_rest%% *}; _c_tot=${_c_rest##* }
+  _c_cs=${_c_rest%% *}; _c_rest=${_c_rest#* }
+  _c_tot=${_c_rest%% *}; _c_ansi=${_c_rest##* }
   # AN UNRELIABLE PARSE YIELDS NO VERDICT (reviewer). Checked FIRST: every field below is derived
   # from the same state machine, so if it ended the line inside a quote, none of them can be trusted.
   # DEFAULTS TO UNTRUSTWORTHY, not to balanced. This is the one field whose job is to say "do not
   # trust the other fields", so an UNMEASURED value (a failed awk, a renamed field) must refuse
   # rather than be believed — CLAUDE.md's `${end:-$start}` lesson, on the field that can least
   # afford it. Key the permissive branch on the AFFIRMATIVE value, never on `!= <bad>`.
-  if [ "${_c_bal:-0}" -eq 0 ]; then printf 'unbalanced %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return; fi
+  if [ "${_c_bal:-0}" -eq 0 ] || [ "${_c_ansi:-1}" -eq 1 ]; then
+    printf 'unbalanced %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
+  fi
   # ANY apparently-inert occurrence on a line carrying a command substitution is REFUSED, whether or
   # not the line also has a recognised live read (roborev job 43). Gating this on `code -eq 0` was
   # not enough: `bash "$WRAPPER" "$(grep "a'"'"'b" "$WRAPPER" "c'"'"'d")"` presents ONE occurrence as a
@@ -5290,10 +5305,17 @@ _wr_fixture f_mkcolon  "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed op
 _wr_fixture f_btprose  "ok \"\`grep \"a'b\" $_wr_ref \"c'd\"\`\""
 _wr_fixture f_cshidden "bash $_wr_ref \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
 _wr_fixture f_csprose  "ok \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
-_wr_fixture f_locsave  "  local _gm_real_wrapper=$_wr_ref"
-_wr_fixture f_semisave "_gm_real_wrapper=$_wr_ref;"
-_wr_fixture f_cmpsave  "_wr_saved=x; subject=$_wr_ref"
-_wr_fixture f_cmpsave2 "_wr_saved=unused; grep pattern $_wr_ref"
+# COMPOSED FROM $_wr_aliases, never written literally (roborev job 50). Spelled out, these fixture
+# lines ARE alias assignments, and the mutation scan below had to exclude any line containing
+# `_wr_fixture`/`_wr_expect`/`_wr_ax` to tolerate them -- a substring exclusion, so
+# `_wr_saved=/decoy # _wr_fixture` exempted a real mutation. Composing removes the need for the
+# exclusion entirely rather than narrowing it.
+_wr_a1=${_wr_aliases%% *}
+_wr_a2=${_wr_aliases##* }
+_wr_fixture f_locsave  "  local $_wr_a1=$_wr_ref"
+_wr_fixture f_semisave "$_wr_a1=$_wr_ref;"
+_wr_fixture f_cmpsave  "$_wr_a2=x; subject=$_wr_ref"
+_wr_fixture f_cmpsave2 "$_wr_a2=unused; grep pattern $_wr_ref"
 _wr_fixture f_ansic    "_x=\$'a\\'b'; grep -c z $_wr_ref"
 _wr_fixture f_marked   "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
 _wr_fixture f_mixed    "grep -c q $_wr_ref; ok 'mentions \$$_wr_vname'"
@@ -5377,10 +5399,10 @@ while IFS= read -r _wr_u; do
   # `tot` silently shifted this and marked the restore assert unmarked: a positional read of a
   # widening record. Named extraction would be better; the count is asserted below instead.)
   _wr_umk_n=$(printf '%s\n' "$_wr_umk" | tr ' ' '\n' | grep -c .)
-  if [ "${_wr_umk_n:-0}" -ne 8 ]; then
-    bad "structural (#3367): the quote scanner emits ${_wr_umk_n:-0} fields, not the 8 this extraction expects — a field was added or removed and every positional read of it is now wrong"
+  if [ "${_wr_umk_n:-0}" -ne 9 ]; then
+    bad "structural (#3367): the quote scanner emits ${_wr_umk_n:-0} fields, not the 9 this extraction expects — a field was added or removed and every positional read of it is now wrong"
   fi
-  _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk##* }
+  _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk% *}; _wr_umk=${_wr_umk##* }
   [ "${_wr_umk:-0}" -eq 1 ] && continue
   _wr_ut=${_wr_uc#"${_wr_uc%%[! ]*}"}
   _wr_is_restore=no
@@ -5456,7 +5478,7 @@ while IFS= read -r _wr_ml; do
 done <<EOF
 $(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" \
   | grep -nE '(^|[ 	;&|(])(local |export |declare |typeset )?('"$_wr_alias_re"')=' \
-  | grep -vE '^[0-9]+:[[:space:]]*#' | grep -vE '_wr_fixture|_wr_expect|_wr_ax')
+  | grep -vE '^[0-9]+:[[:space:]]*#')
 EOF
 if [ -z "$_wr_amut" ]; then
   ok 'structural (#3367): every assignment to a save alias takes its value from the mutable global itself — none can be pointed somewhere else, so a restore cannot silently install the wrong path'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4786,59 +4786,118 @@ fi
 # guard written with its needle spelled literally matches its own pattern lines and reports the
 # defect against itself — measured: four self-hits on the first run. Splitting is the same device
 # the scanner-substitution assert uses, for the same reason.
+#
+# THE GRAMMAR IS CLOSED OVER OCCURRENCES, NOT LINES (roborev job 34 on this PR, Medium). The first
+# version was closed over LINES and over ONE SPELLING, and was therefore not closed at all — it had
+# three bypasses, each of which would have let a mutable doctrine read back in silently:
+#   (a) `"${WRAPPER}"`  — braced; the scan only knew the unbraced spelling;
+#   (b) `$WRAPPER`      — unquoted; likewise unrecognised;
+#   (c) `bash "$WRAPPER"; grep -c x "$WRAPPER"` — a COMPOUND line, where one permitted occurrence
+#       (the invocation) caused the WHOLE line to be accepted, carrying a real scan in with it.
+# That is this issue's own defect one level up: a guard whose green means "no instance of the shape
+# I happened to think of," which is exactly the reasoning #3367 exists to retire. So the grammar now
+# asserts three things, and (1) is what makes (3) tractable — with one legal spelling, the
+# permitted-form test no longer has to parse shell:
+#   (1) SPELLING — every occurrence is written exactly `"$WRAPPER"`. Braced and unquoted forms FAIL.
+#   (2) ARITY    — at most ONE occurrence per line, so no occurrence can ride in on another's verdict.
+#   (3) FORM     — that occurrence's line is an invocation, a whole-value save, or marked.
+#
+# PROSE IS STRIPPED BEFORE ANY OF IT. Comments are dropped, and within a line both single-quoted
+# spans and backslash-escaped `\$` are literal text rather than expansions — this file's own `ok`
+# and `bad` messages NAME the variable while describing the rule, and an earlier version red on
+# exactly those, which is #3367's cause 2 reproduced inside the fix for cause 1.
 _wr_marker='wrapper-mutable''-read-allow'
-_wr_ref='"$WRAP''PER"'
+_wr_vname='WRAP''PER'
+_wr_ref='"$'"$_wr_vname"'"'
 _wr_bad_reads=""
+_wr_bad_spelling=""
+_wr_multi=""
+_wr_total=0
 while IFS= read -r _wr_num_line; do
   [ -n "$_wr_num_line" ] || continue
   # `grep -n` prefixes `NNNN:`; the grammar must judge the CODE, not the line number (an unstripped
   # prefix made every whole-value save look like an assignment to `NNNN:name`, i.e. four false FAILs).
   _wr_line=${_wr_num_line#*:}
-  case "$_wr_line" in
+  _wr_code=$(printf '%s\n' "$_wr_line" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
+  # Occurrences of exactly this variable — `$WRAPPER_REAL` is a DIFFERENT name and must not count.
+  _wr_n=$(printf '%s\n' "$_wr_code" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
+  [ "${_wr_n:-0}" -ge 1 ] || continue
+  _wr_total=$((_wr_total + _wr_n))
+  # (1) SPELLING: every occurrence on this line must be the exact quoted form.
+  _wr_q=$(printf '%s\n' "$_wr_code" | grep -oF "$_wr_ref" | wc -l | tr -d '[:space:]')
+  if [ "${_wr_n:-0}" -ne "${_wr_q:-0}" ]; then
+    _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line"
+    continue
+  fi
+  case "$_wr_code" in
     *"$_wr_marker"*) continue ;;
   esac
-  # An INVOCATION, either bare `bash` or an explicit interpreter path (`"$nobin/bash" "$WRAPPER"`).
-  case "$_wr_line" in
+  # (2) ARITY: one occurrence per line, so a permitted one cannot carry an unpermitted one.
+  if [ "${_wr_n:-0}" -gt 1 ]; then
+    _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line"
+    continue
+  fi
+  # (3) FORM. An INVOCATION, either bare `bash` or an explicit interpreter path.
+  case "$_wr_code" in
     *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) continue ;;
   esac
   # A whole-value SAVE: `NAME="$WRAPPER"` and nothing else on the line.
-  case "$_wr_line" in
+  case "$_wr_code" in
     *"=$_wr_ref")
-      case "${_wr_line%%=*}" in
+      case "${_wr_code%%=*}" in
         ''|*[!A-Za-z0-9_]*) ;;
         *) continue ;;
       esac ;;
   esac
   _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line"
 done <<EOF
-$(grep -nE '"[$]WRAP''PER"' "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
+$(grep -nE '[$][{]?'"$_wr_vname"'[}]?' "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
 EOF
-if [ -z "$_wr_bad_reads" ]; then
-  ok 'structural (#3367): every read of the mutable $WRAPPER is an invocation, a whole-value save, or an explicitly marked opt-out — no doctrine scan takes it as a SUBJECT, so no verdict depends on which case ran last'
+# AFFIRMATIVE MEASUREMENT: zero occurrences means this scan had no subject, which is not a pass.
+if [ "${_wr_total:-0}" -eq 0 ]; then
+  bad 'structural (#3367): the order-dependence grammar found NO occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the prose-stripping swallowed the file'
+elif [ -n "$_wr_bad_spelling" ]; then
+  bad "structural (#3367): an occurrence of the mutable wrapper variable is not spelled as the single legal quoted form, so the form check below cannot see it (braced and unquoted spellings were live bypasses): $(printf '%s' "$_wr_bad_spelling" | cut -c1-200)"
+elif [ -n "$_wr_multi" ]; then
+  bad "structural (#3367): a line carries MORE THAN ONE occurrence of the mutable wrapper variable, so a permitted one (an invocation) would carry an unpermitted one (a doctrine scan) past the grammar: $(printf '%s' "$_wr_multi" | cut -c1-200)"
+elif [ -n "$_wr_bad_reads" ]; then
+  bad "structural (#3367): a read of the mutable wrapper variable matches no permitted form, so its verdict depends on gate-mock ordering — use \$WRAPPER_REAL for a doctrine SUBJECT: $(printf '%s' "$_wr_bad_reads" | cut -c1-200)"
 else
-  bad "structural (#3367): a read of the mutable \$WRAPPER matches no permitted form, so its verdict depends on gate-mock ordering — use \$WRAPPER_REAL for a doctrine SUBJECT: $(printf '%s' "$_wr_bad_reads" | cut -c1-240)"
+  ok "structural (#3367): all $_wr_total occurrences of the mutable wrapper variable use the single legal spelling, sit one per line, and are an invocation, a whole-value save, or a marked opt-out — no doctrine scan takes it as a SUBJECT, so no verdict depends on which case ran last"
 fi
-# The grammar is only closed if it can actually REJECT: a `case` typo falling through to `continue`
-# would accept everything and read green on a clean file, which is the blind-scan shape one level up.
-# Both directions are probed, so neither an over-strict nor an over-lax grammar passes silently.
+# THE GRAMMAR MUST BE ABLE TO REJECT, and specifically to reject the three bypasses roborev found.
+# A control that only probed the shape the author already had in mind is how (a)-(c) survived round
+# one, so each is probed as its own synthetic line, alongside the two forms that must be ACCEPTED.
 _wr_ctl_bad=""
-for _wr_probe in "_x=\$(grep -c foo $_wr_ref)" "sed -n 1p $_wr_ref"; do
-  case "$_wr_probe" in
-    *"$_wr_marker"*|*"bash $_wr_ref"*|*"bash\" $_wr_ref"*) _wr_ctl_bad="$_wr_ctl_bad accepted:$_wr_probe" ;;
-    *"=$_wr_ref") _wr_ctl_bad="$_wr_ctl_bad accepted:$_wr_probe" ;;
+_wr_probe_line() {
+  # Returns: the verdict this grammar gives one synthetic line — spelling|arity|form|ok
+  _p_code=$(printf '%s\n' "$1" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
+  _p_n=$(printf '%s\n' "$_p_code" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
+  _p_q=$(printf '%s\n' "$_p_code" | grep -oF "$_wr_ref" | wc -l | tr -d '[:space:]')
+  [ "${_p_n:-0}" -ne "${_p_q:-0}" ] && { printf 'spelling\n'; return; }
+  [ "${_p_n:-0}" -gt 1 ] && { printf 'arity\n'; return; }
+  case "$_p_code" in *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) printf 'ok\n'; return ;; esac
+  case "$_p_code" in
+    *"=$_wr_ref") case "${_p_code%%=*}" in ''|*[!A-Za-z0-9_]*) ;; *) printf 'ok\n'; return ;; esac ;;
   esac
-done
-for _wr_probe in "_gm_real_wrapper=$_wr_ref" "  bash $_wr_ref --help"; do
-  case "$_wr_probe" in
-    *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) ;;
-    *"=$_wr_ref") case "${_wr_probe%%=*}" in ''|*[!A-Za-z0-9_]*) _wr_ctl_bad="$_wr_ctl_bad rejected:$_wr_probe" ;; esac ;;
-    *) _wr_ctl_bad="$_wr_ctl_bad rejected:$_wr_probe" ;;
-  esac
+  printf 'form\n'
+}
+for _wr_case in \
+  "spelling:_x=\$(grep -c foo \"\${$_wr_vname}\")" \
+  "spelling:_x=\$(grep -c foo \$$_wr_vname)" \
+  "arity:bash $_wr_ref --help; grep -c q $_wr_ref" \
+  "form:_x=\$(grep -c foo $_wr_ref)" \
+  "form:sed -n 1p $_wr_ref" \
+  "ok:  bash $_wr_ref --help" \
+  "ok:_gm_real_wrapper=$_wr_ref"; do
+  _wr_want=${_wr_case%%:*}
+  _wr_got=$(_wr_probe_line "${_wr_case#*:}")
+  [ "$_wr_got" = "$_wr_want" ] || _wr_ctl_bad="$_wr_ctl_bad [want=$_wr_want got=$_wr_got: ${_wr_case#*:}]"
 done
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the grammar rejects synthetic doctrine SCANS of $WRAPPER and accepts synthetic invocations/saves — it is discriminating in both directions, not vacuously green'
+  ok 'structural control (#3367): the grammar classifies all seven synthetic lines correctly — it rejects the braced, unquoted and compound-line bypasses roborev found, rejects plain doctrine scans, and still accepts invocations and whole-value saves'
 else
-  bad "structural control (#3367): the permitted-form grammar misclassifies a synthetic read —$_wr_ctl_bad"
+  bad "structural control (#3367): the permitted-form grammar misclassifies a synthetic read, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi
 # ...and `WRAPPER_REAL` must never be reassigned, or it is just `WRAPPER` with a longer name.
 _wr_real_writes=$(grep -cE '^[[:space:]]*WRAPPER_REAL=' "$TEST_SELF")

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -53,8 +53,8 @@ CHECKS_SRC="$SCRIPT_DIR/../flow/roborev-review-checks.sh"
 ORACLES_SRC="$SCRIPT_DIR/../flow/roborev-review-oracles.sh"
 BLOCK_HEADER="==== ROBOREV REVIEW SUMMARY ===="
 
-if [ ! -f "$WRAPPER" ]; then
-  printf 'FAIL - wrapper not found at %s\n' "$WRAPPER"
+if [ ! -f "$WRAPPER" ]; then # wrapper-mutable-read-allow: preflight, before any case can reassign it
+  printf 'FAIL - wrapper not found at %s\n' "$WRAPPER" # wrapper-mutable-read-allow: the preflight diagnostic
   exit 1
 fi
 
@@ -4695,29 +4695,103 @@ else
   bad "structural: the block still emits —$_skeys. Those keys described the retired classifier's output (#3312 ruling (4))"
 fi
 # ===== THE DOCTRINE SCANS MUST NOT READ A MUTABLE GLOBAL (#3367) =====
-# The classifier-GONE assert above FAILed once on a branch whose diff touched no `scripts/` file at
-# all, then passed 4/4 at the same commit and an unchanged tree. Cause: it read `"$WRAPPER"`, which
-# the gate-mock cases repoint at a scratch copy ~2000 lines earlier and restore afterwards. A check
-# whose SUBJECT is chosen by a global another case mutates is order-dependent by construction.
+# The classifier-GONE assert FAILed once inside a gate on a branch whose diff touched no `scripts/`
+# file at all, then passed 4/4 at the same commit and an unchanged tree. Cause: it read `"$WRAPPER"`,
+# which the gate-mock cases repoint at a scratch copy ~2000 lines earlier and restore afterwards. A
+# check whose SUBJECT is chosen by a global another case mutates is order-dependent by construction,
+# and its verdict is decided by which case ran last rather than by the file it claims to audit.
+#
+# Note which way the hazard now points. With the `--help` prose exemption in place (#3392) the real
+# wrapper is CLEAN, so a scan that lands on the scratch copy finds nothing and reports CLEAN too —
+# a FALSE PASS, strictly worse than the false FAIL that surfaced the bug, because nothing reds.
 #
 # Two pins, because fixing the call sites without pinning them just waits for the next one:
-#   (1) STRUCTURAL — no text-scanning read of `$WRAPPER` may exist in this file. Invocations
-#       (`bash "$WRAPPER"`) are exempt: those cases mean the copy in their own context.
-#   (2) BEHAVIOURAL — with `WRAPPER` deliberately poisoned, the scan's verdict must not move, and
-#       the same scan against the poisoned path MUST move. Without the second half, (2) would pass
-#       for a scan that reads nothing at all.
-# COMMENTS STRIPPED FIRST, and this check learned that the hard way: its first version flagged
-# ITS OWN explanatory comment above (the one quoting `"$WRAPPER"` while describing the defect),
-# which is exactly #3367's cause 2 — a structural assert measuring the prose that documents it.
-# A guard that reds on its own rationale is one the next person deletes. `grep -n` is kept for the
-# diagnostic, so the line numbers below still point at real code.
-_wr_scan_leaks=$(grep -nE '(grep|awk|sed|cp|wc|head|tail)[^|]*"\$WRAPPER"' "$TEST_SELF" \
-  | grep -vE '^[0-9]+:[[:space:]]*#' \
-  | grep -v 'bash "\$WRAPPER"' || true)
-if [ -z "$_wr_scan_leaks" ]; then
-  ok 'structural (#3367): no doctrine scan reads the mutable $WRAPPER — every text scan uses $WRAPPER_REAL, so no verdict depends on which case ran last'
+#   (1) STRUCTURAL — a CLOSED GRAMMAR over every read of `$WRAPPER` in this file.
+#   (2) BEHAVIOURAL — with `WRAPPER` poisoned, the scan's verdict must not move, and the same scan
+#       against the poisoned path MUST move. Without the second half, (1) would pass for a scan
+#       that reads nothing at all.
+#
+# WHY A CLOSED GRAMMAR AND NOT A LEAK PATTERN. The first version of (1) was
+# `grep -nE '(grep|awk|sed|...)[^|]*"\$WRAPPER"'` — a search for the KNOWN-BAD shape. It reported
+# CLEAN while the defect was still present, because `grep` is line-oriented and the offending read
+# was a MULTI-LINE `awk` whose command word and whose `"$WRAPPER"` argument sat five lines apart.
+# It missed the exact construct it was written for. That is this repo's recurring
+# affirmative-measurement rule one level down: never derive a pass from the ABSENCE of a bad signal.
+# So every read is enumerated and each must match an AFFIRMATIVELY PERMITTED form; an unrecognised
+# line FAILs. A new way to read the mutable global cannot be a shape nobody predicted.
+#
+# COMMENTS ARE STRIPPED FIRST, and this check learned that the hard way: an earlier version flagged
+# its own explanatory comments above (they quote `"$WRAPPER"` while describing the defect), which is
+# #3367's own cause 2 — a structural assert reding on the prose that documents it. A guard that reds
+# on its own rationale is one the next person deletes.
+#
+# THE PERMITTED FORMS, and why each is not order-dependent:
+#   * `bash "$WRAPPER"` — an INVOCATION. A gate-mock case means the copy in its own context; that is
+#     the whole point of the reassignment, so it must keep reading the mutable value.
+#   * `<var>="$WRAPPER"` — a whole-value SAVE for a later restore, which must capture whatever is
+#     live at that moment or the restore would install the wrong path.
+#   * a line carrying the explicit allow marker — a reviewed, named opt-out for the two preflight
+#     lines (they run before any mutation) and for the poisoned probe below, whose entire purpose is
+#     to read the mutable value. The marker is spelled in two halves at the match site so this guard
+#     can never match its own pattern line.
+#
+# EVERY NEEDLE BELOW IS SPLIT ACROSS A QUOTE BOUNDARY. The subject of this scan is THIS FILE, so a
+# guard written with its needle spelled literally matches its own pattern lines and reports the
+# defect against itself — measured: four self-hits on the first run. Splitting is the same device
+# the scanner-substitution assert uses, for the same reason.
+_wr_marker='wrapper-mutable''-read-allow'
+_wr_ref='"$WRAP''PER"'
+_wr_bad_reads=""
+while IFS= read -r _wr_num_line; do
+  [ -n "$_wr_num_line" ] || continue
+  # `grep -n` prefixes `NNNN:`; the grammar must judge the CODE, not the line number (an unstripped
+  # prefix made every whole-value save look like an assignment to `NNNN:name`, i.e. four false FAILs).
+  _wr_line=${_wr_num_line#*:}
+  case "$_wr_line" in
+    *"$_wr_marker"*) continue ;;
+  esac
+  # An INVOCATION, either bare `bash` or an explicit interpreter path (`"$nobin/bash" "$WRAPPER"`).
+  case "$_wr_line" in
+    *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) continue ;;
+  esac
+  # A whole-value SAVE: `NAME="$WRAPPER"` and nothing else on the line.
+  case "$_wr_line" in
+    *"=$_wr_ref")
+      case "${_wr_line%%=*}" in
+        ''|*[!A-Za-z0-9_]*) ;;
+        *) continue ;;
+      esac ;;
+  esac
+  _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line"
+done <<EOF
+$(grep -nE '"[$]WRAP''PER"' "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
+EOF
+if [ -z "$_wr_bad_reads" ]; then
+  ok 'structural (#3367): every read of the mutable $WRAPPER is an invocation, a whole-value save, or an explicitly marked opt-out — no doctrine scan takes it as a SUBJECT, so no verdict depends on which case ran last'
 else
-  bad "structural (#3367): a doctrine scan still reads the mutable \$WRAPPER, so its verdict depends on gate-mock ordering — $(printf '%s' "$_wr_scan_leaks" | head -3 | tr '\n' ';')"
+  bad "structural (#3367): a read of the mutable \$WRAPPER matches no permitted form, so its verdict depends on gate-mock ordering — use \$WRAPPER_REAL for a doctrine SUBJECT: $(printf '%s' "$_wr_bad_reads" | cut -c1-240)"
+fi
+# The grammar is only closed if it can actually REJECT: a `case` typo falling through to `continue`
+# would accept everything and read green on a clean file, which is the blind-scan shape one level up.
+# Both directions are probed, so neither an over-strict nor an over-lax grammar passes silently.
+_wr_ctl_bad=""
+for _wr_probe in "_x=\$(grep -c foo $_wr_ref)" "sed -n 1p $_wr_ref"; do
+  case "$_wr_probe" in
+    *"$_wr_marker"*|*"bash $_wr_ref"*|*"bash\" $_wr_ref"*) _wr_ctl_bad="$_wr_ctl_bad accepted:$_wr_probe" ;;
+    *"=$_wr_ref") _wr_ctl_bad="$_wr_ctl_bad accepted:$_wr_probe" ;;
+  esac
+done
+for _wr_probe in "_gm_real_wrapper=$_wr_ref" "  bash $_wr_ref --help"; do
+  case "$_wr_probe" in
+    *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) ;;
+    *"=$_wr_ref") case "${_wr_probe%%=*}" in ''|*[!A-Za-z0-9_]*) _wr_ctl_bad="$_wr_ctl_bad rejected:$_wr_probe" ;; esac ;;
+    *) _wr_ctl_bad="$_wr_ctl_bad rejected:$_wr_probe" ;;
+  esac
+done
+if [ -z "$_wr_ctl_bad" ]; then
+  ok 'structural control (#3367): the grammar rejects synthetic doctrine SCANS of $WRAPPER and accepts synthetic invocations/saves — it is discriminating in both directions, not vacuously green'
+else
+  bad "structural control (#3367): the permitted-form grammar misclassifies a synthetic read —$_wr_ctl_bad"
 fi
 # ...and `WRAPPER_REAL` must never be reassigned, or it is just `WRAPPER` with a longer name.
 _wr_real_writes=$(grep -cE '^[[:space:]]*WRAPPER_REAL=' "$TEST_SELF")
@@ -4737,7 +4811,7 @@ mkdir -p "$_wr_poison_dir"
 _wr_saved="$WRAPPER"
 WRAPPER="$_wr_poison_dir/roborev-review.sh"
 _cls_via_real=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
-_cls_via_mutable=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER")
+_cls_via_mutable=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER") # wrapper-mutable-read-allow: reading the poisoned path IS this probe
 WRAPPER="$_wr_saved"
 _wr_real_hit=no; _wr_mut_hit=no
 case "$_cls_via_real"    in *'mixed-delivery'*) _wr_real_hit=yes ;; esac

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4815,6 +4815,48 @@ _wr_vname='WRAP''PER'
 # close it over the VALUE, so the allowlist is by name and the aliases' own uses are constrained below.
 _wr_aliases='_gm_real_wrapper _wr_saved'
 _wr_ref='"$'"$_wr_vname"'"'
+# COMMAND POSITION IS COMPUTED, NOT SUBSTRING-MATCHED (roborev job 36, Medium). The invocation rule
+# was `case $line in *"bash $ref"*)`, an UNANCHORED substring — so `grep bash "$WRAPPER"` was accepted
+# as an invocation, and a doctrine read walked straight through the "closed" grammar. That is the same
+# error as (c) one round earlier: asking whether a permitted shape appears ANYWHERE on the line rather
+# than whether the line IS that shape.
+#
+# Markers were the first thing tried and do not work here: five of the eight invocation sites end in a
+# `\` continuation, and a line ending in a backslash cannot carry a trailing comment. So the line is
+# reduced to its COMMAND WORD by stripping leading whitespace and any `NAME=value` environment prefixes
+# (this file's invocations carry `STUB_INVOKED=`/`PATH=`), and the result must BEGIN with the invocation.
+# The grammar being stripped is deliberately tiny — env prefixes only, no general shell parsing.
+_wr_cmdpos() {
+  _c=$1
+  _c=${_c#"${_c%%[! ]*}"}
+  while :; do
+    case "$_c" in
+      [A-Za-z_]*=*)
+        _n=${_c%%=*}
+        case "$_n" in *[!A-Za-z0-9_]*) break ;; esac
+        _r=${_c#*=}
+        case "$_r" in
+          '"'*) _r=${_r#\"}; _r=${_r#*\"} ;;
+          *) _v=${_r%% *}; _r=${_r#"$_v"} ;;
+        esac
+        _c=${_r#"${_r%%[! ]*}"}
+        ;;
+      *) break ;;
+    esac
+  done
+  printf '%s' "$_c"
+}
+# TRUE only when the line's COMMAND is a wrapper invocation: bare `bash`, or an explicit
+# interpreter path ending in `/bash`. Anything else -- including a scan that merely mentions
+# the word `bash` in its arguments -- is not an invocation.
+_wr_is_invocation() {
+  _i=$(_wr_cmdpos "$1")
+  case "$_i" in
+    "bash $_wr_ref"*) return 0 ;;
+    '"'*"/bash\" $_wr_ref"*) return 0 ;;
+  esac
+  return 1
+}
 _wr_bad_reads=""
 _wr_bad_spelling=""
 _wr_multi=""
@@ -4843,10 +4885,8 @@ while IFS= read -r _wr_num_line; do
     _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line"
     continue
   fi
-  # (3) FORM. An INVOCATION, either bare `bash` or an explicit interpreter path.
-  case "$_wr_code" in
-    *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) continue ;;
-  esac
+  # (3) FORM. An INVOCATION -- decided by COMMAND POSITION, never by substring.
+  if _wr_is_invocation "$_wr_code"; then continue; fi
   # A whole-value SAVE into an ALLOWLISTED alias: `NAME="$WRAPPER"` and nothing else on the line.
   case "$_wr_code" in
     *"=$_wr_ref")
@@ -4881,7 +4921,7 @@ _wr_probe_line() {
   _p_q=$(printf '%s\n' "$_p_code" | grep -oF "$_wr_ref" | wc -l | tr -d '[:space:]')
   [ "${_p_n:-0}" -ne "${_p_q:-0}" ] && { printf 'spelling\n'; return; }
   [ "${_p_n:-0}" -gt 1 ] && { printf 'arity\n'; return; }
-  case "$_p_code" in *"bash $_wr_ref"*|*"bash\" $_wr_ref"*) printf 'ok\n'; return ;; esac
+  if _wr_is_invocation "$_p_code"; then printf 'ok\n'; return; fi
   case "$_p_code" in
     *"=$_wr_ref")
       _p_nm=${_p_code%%=*}
@@ -4896,7 +4936,10 @@ for _wr_case in \
   "arity:bash $_wr_ref --help; grep -c q $_wr_ref" \
   "form:_x=\$(grep -c foo $_wr_ref)" \
   "form:sed -n 1p $_wr_ref" \
+  "form:grep bash $_wr_ref" \
+  "form:_x=\$(awk /bash/ $_wr_ref)" \
   "form:subject=$_wr_ref" \
+  "ok:STUB_INVOKED=\"\$INVOKED\" PATH=\"\$stubbin:\$PATH\" bash $_wr_ref --help" \
   "ok:  bash $_wr_ref --help" \
   "ok:_gm_real_wrapper=$_wr_ref"; do
   _wr_want=${_wr_case%%:*}
@@ -4904,7 +4947,7 @@ for _wr_case in \
   [ "$_wr_got" = "$_wr_want" ] || _wr_ctl_bad="$_wr_ctl_bad [want=$_wr_want got=$_wr_got: ${_wr_case#*:}]"
 done
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the grammar classifies all eight synthetic lines correctly — it rejects the braced, unquoted, compound-line and unallowlisted-alias bypasses roborev found, rejects plain doctrine scans, and still accepts invocations and whole-value saves'
+  ok 'structural control (#3367): the grammar classifies all eleven synthetic lines correctly — it rejects the braced, unquoted, compound-line, unallowlisted-alias and mentions-the-word-bash bypasses roborev found, rejects plain doctrine scans, and still accepts invocations and whole-value saves'
 else
   bad "structural control (#3367): the permitted-form grammar misclassifies a synthetic read, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -2261,6 +2261,10 @@ fi
 work=$(make_fixture case_cx28 pushed)
 STUB_ANNOUNCE_SHA=$(git -C "$work" rev-parse HEAD)
 _gm_real_wrapper="$WRAPPER"
+# READONLY, so `printf -v`, `read` and every other builtin that writes a variable are refused by the
+# SHELL (roborev job 51). The mutation scan only knew `name=value` syntax, and a corrupted alias
+# would make the restore install the wrong path while the probe agreed with itself.
+readonly _gm_real_wrapper
 WRAPPER="$_gm_dir/roborev-review.sh"
 run_wrapper "$work"
 assert_verdict 'case (cx28 control) the UNPATCHED copy reaches PASS' PASS 0
@@ -4657,7 +4661,12 @@ _cls_exec_lines() {
   # parked there would be prose to this filter and code to the shell. The exemption is for TEXT, so
   # a substitution inside the body is surfaced rather than suppressed. Measured cost: the real
   # heredoc contains zero of them.
-  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/) { print; next }
+  # ...and an ASSIGNING parameter expansion evaluates too: ${VAR:=mixed-delivery} and ${VAR=...}
+  # set the variable when bash renders the body (roborev job 51). Those two forms are the complete
+  # set of expansions that assign; plain $VAR and ${VAR} cannot, which is why the ordinary
+  # $PROGNAME interpolation in the body stays suppressed and the prose exemption still works.
+  # NOTE: this awk program is single-quoted, so NO APOSTROPHE may appear in these comments.
+  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/ || $0 ~ /[$][{][A-Za-z_][A-Za-z0-9_]*:?=/) { print; next }
   in_usage { next }
   /^[[:space:]]*#/ { next }
   # A SUBSTITUTION LINE KEEPS ITS TAIL. Inside `$( )` a quoted `#` looks like a comment opener to
@@ -4882,6 +4891,29 @@ fi
 # spans and backslash-escaped `\$` are literal text rather than expansions — this file's own `ok`
 # and `bad` messages NAME the variable while describing the rule, and an earlier version red on
 # exactly those, which is #3367's cause 2 reproduced inside the fix for cause 1.
+# A CODE-ONLY VIEW OF A WHOLE FILE: quoted spans blanked, comments removed, continuations joined.
+# Scans that look for a COMMAND (`eval`, a nameref declaration) must read this, never the raw text —
+# otherwise the word inside a diagnostic string or a fixture literal counts, and the only way to
+# tolerate that is a substring exclusion. Three separate exclusions of exactly that shape have now
+# been found here (the alias-declaration alternation, the alias-mutation scan, the eval ban), each
+# exempting a real violation that merely mentioned the excluded token. Blanking removes the need.
+_wr_code_view() {
+  sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | awk '
+  {
+    n = length($0); sq = 0; dq = 0; out = ""
+    for (i = 1; i <= n; i++) {
+      c = substr($0, i, 1)
+      if (!sq && c == "\\") { i++; out = out "  "; continue }
+      if (sq) { out = out " "; if (c == "'"'"'") sq = 0; continue }
+      if (dq) { out = out " "; if (c == "\"") dq = 0; continue }
+      if (c == "'"'"'") { sq = 1; out = out " "; continue }
+      if (c == "\"") { dq = 1; out = out " "; continue }
+      if (c == "#" && (i == 1 || substr($0, i-1, 1) ~ /[ \t]/)) break
+      out = out c
+    }
+    print out
+  }'
+}
 _wr_marker='wrapper-mutable''-read-allow'
 _wr_vname='WRAP''PER'
 # ONLY THESE NAMES MAY HOLD THE MUTABLE VALUE, AND ONLY TO RESTORE IT (roborev job 35, Medium).
@@ -5266,6 +5298,9 @@ _wr_ctl_dir="$tmp/wrapper-grammar-fixtures"
 mkdir -p "$_wr_ctl_dir"
 # Each fixture carries one PERMITTED occurrence (so `empty` is not the answer) plus the case under test.
 _wr_ok_line="bash $_wr_ref --help"
+# The expected-verdict word is COMPOSED: written literally it is a bare `eval` in code position and
+# the ban above would flag this fixture table. Composing beats excluding -- see _wr_code_view.
+_wr_v_eval='ev''al'
 _wr_ctl_bad=""
 # FIXTURES ARE WRITTEN WITH `printf` AND `$_wr_ref`, NEVER A HEREDOC. The scanner is line-oriented,
 # so a literal `"$WRAPPER"` in a quoted `<<'"'"'EOF'"'"'` heredoc body reads as a live read and verdicts
@@ -5333,7 +5368,7 @@ _wr_expect f_unquoted spelling
 _wr_expect f_arity    arity
 _wr_expect f_markar   arity
 _wr_expect f_prose    form
-_wr_expect f_eval     eval
+_wr_expect f_eval     "$_wr_v_eval"
 _wr_expect f_aposmk   form
 _wr_expect f_selfauth form
 _wr_expect f_prosetag clean
@@ -5449,9 +5484,7 @@ fi
 #   (d) `eval` of constructed text     -> banned here
 # That is the whole set, so a constructed name has nowhere left to be executed. The ban costs
 # nothing: this harness has never used `eval` in code position (measured 0).
-_wr_evalp=$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" \
-  | grep -nE '(^|[ \t;&|(])'"eval"'([ \t]|$)' | grep -vE '^[0-9]+:[[:space:]]*#' || true)
-_wr_evalp=$(printf '%s\n' "$_wr_evalp" | grep -vE "_wr_expect|_wr_fixture|^[0-9]+:[[:space:]]*(ok|bad) " || true)
+_wr_evalp=$(_wr_code_view "$TEST_SELF" | grep -nE '(^|[ \t;&|(])'"eval"'([ \t]|$)' || true)
 if [ -z "$_wr_evalp" ]; then
   ok 'structural (#3367): the harness runs no eval, so a variable name assembled by shell concatenation has nowhere to be executed — with literal reads classified, indirect expansion allowlisted and namerefs banned, that closes every way to read the mutable path'
 else
@@ -5499,9 +5532,8 @@ fi
 # LOGICAL lines, not physical ones: `declare \` continued onto `-n subject=_wr_saved` is one
 # declaration, and a per-physical-line grep sees neither half as a nameref. Continuations are joined
 # first (the line numbers are lost, so the diagnostic reports the joined text instead).
-_wr_nrefd=$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" \
-  | grep -nE '(^|[ \t;&|(])(declare|local|typeset)[[:space:]]+(-[A-Za-z]+[[:space:]]+)*-[A-Za-z]*'"n" \
-  | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+_wr_nrefd=$(_wr_code_view "$TEST_SELF" \
+  | grep -nE '(^|[ \t;&|(])(declare|local|typeset)[[:space:]]+(-[A-Za-z]+[[:space:]]+)*-[A-Za-z]*'"n" || true)
 if [ -z "$_wr_nrefd" ]; then
   ok 'structural (#3367): the harness declares no nameref, so no second name can be bound to an allowlisted alias'
 else
@@ -5589,6 +5621,7 @@ mkdir -p "$_wr_poison_dir"
   printf '%s=inline\n' "$_wr_sentinel"
 } >"$_wr_poison_dir/roborev-review.sh"
 _wr_saved="$WRAPPER"
+readonly _wr_saved
 WRAPPER="$_wr_poison_dir/roborev-review.sh"
 _cls_via_real=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
 _cls_via_mutable=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER") # wrapper-mutable-read-allow: reading the poisoned path IS this probe
@@ -5605,7 +5638,9 @@ else
 fi
 # The restore must have happened, or every later case silently audits the scratch copy — the exact
 # failure mode this section exists to prevent, reintroduced by the pin that tests for it.
-if [ "$WRAPPER" = "$_wr_saved" ]; then # wrapper-mutable-read-allow: asserting the restore requires reading it
+# Compared against WRAPPER_REAL, not against the alias: an assert that verifies a restore using the
+# very variable whose corruption it should detect will agree with any value (roborev job 51).
+if [ "$WRAPPER" = "$WRAPPER_REAL" ]; then # wrapper-mutable-read-allow: asserting the restore requires reading it
   ok 'behavioural (#3367): the probe restored $WRAPPER, so no later case inherits the poisoned path'
 else
   bad 'behavioural (#3367): the probe left $WRAPPER pointing at its scratch copy'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4909,82 +4909,132 @@ _wr_classify() {
   esac
   printf 'form %s\n' "$_c_n"
 }
-_wr_bad_reads=""
-_wr_bad_spelling=""
-_wr_prose_bad=""
-_wr_unknown=""
-_wr_multi=""
-_wr_total=0
-_wr_prose_n=0
-while IFS= read -r _wr_num_line; do
-  [ -n "$_wr_num_line" ] || continue
-  # `grep -n` prefixes `NNNN:`; the grammar must judge the CODE, not the line number.
-  _wr_line=${_wr_num_line#*:}
-  _wr_res=$(_wr_classify "$_wr_line")
-  _wr_v=${_wr_res%% *}
-  _wr_c=${_wr_res##* }
-  case "$_wr_v" in
-    none) ;;
-    ok) _wr_total=$((_wr_total + _wr_c)) ;;
-    prose-ok) _wr_prose_n=$((_wr_prose_n + _wr_c)) ;;
-    prose) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
-    spelling) _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line" ;;
-    arity) _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line" ;;
-    form) _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line" ;;
-    # A CLOSED GRAMMAR OVER THE VERDICTS THEMSELVES: an unplanned verdict must not fall silently
-    # into the permissive branch, which is the shape this whole section exists to retire.
-    *) _wr_unknown="$_wr_unknown${_wr_unknown:+; }$_wr_v" ;;
-  esac
-done <<EOF
-$(grep -nE '[$][{]?'"$_wr_vname"'[}]?' "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
+# THE WHOLE ENFORCEMENT PASS IS A FUNCTION, AND THE CONTROL RUNS *IT* OVER FIXTURES (reviewer B2,
+# second attempt). The first attempt only shared the CLASSIFIER between the loop and the control.
+# That removed the drift but left the LOOP's dispatch — the `case` that maps a verdict onto an
+# accumulator — certified by nothing, and the reviewer's falsification still passed: replacing the
+# `form)` arm with `:` and injecting a genuine doctrine read left the suite GREEN, because the
+# classifier was still perfect and the control only ever asked the classifier. A control that
+# exercises everything except the part that decides is not a control.
+# So the entire pass is `_wr_scan_file`, the real assert runs it over THIS file, and the control runs
+# the SAME function over fixtures whose correct verdict is known — dispatch included.
+_wr_scan_file() {
+  _sf_file=$1
+  _wr_bad_reads=""; _wr_bad_spelling=""; _wr_prose_bad=""; _wr_unknown=""; _wr_multi=""
+  _wr_total=0; _wr_prose_n=0
+  while IFS= read -r _wr_num_line; do
+    [ -n "$_wr_num_line" ] || continue
+    # `grep -n` prefixes `NNNN:`; the grammar must judge the CODE, not the line number.
+    _wr_line=${_wr_num_line#*:}
+    _wr_res=$(_wr_classify "$_wr_line")
+    _wr_v=${_wr_res%% *}
+    _wr_c=${_wr_res##* }
+    case "$_wr_v" in
+      none) ;;
+      ok) _wr_total=$((_wr_total + _wr_c)) ;;
+      prose-ok) _wr_prose_n=$((_wr_prose_n + _wr_c)) ;;
+      prose) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
+      spelling) _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line" ;;
+      arity) _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line" ;;
+      form) _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line" ;;
+      # A CLOSED GRAMMAR OVER THE VERDICTS THEMSELVES: an unplanned verdict must not fall silently
+      # into the permissive branch, which is the shape this whole section exists to retire.
+      *) _wr_unknown="$_wr_unknown${_wr_unknown:+; }$_wr_v" ;;
+    esac
+  done <<EOF
+$(grep -nE '[$][{]?'"$_wr_vname"'[}]?' "$_sf_file" | grep -vE '^[0-9]+:[[:space:]]*#')
 EOF
-# AFFIRMATIVE MEASUREMENT: zero occurrences means this scan had no subject, which is not a pass.
-if [ -n "$_wr_unknown" ]; then
-  bad "structural (#3367): the order-dependence classifier returned a verdict the loop does not recognise, so some line was neither accepted nor rejected —$_wr_unknown"
-elif [ "${_wr_total:-0}" -eq 0 ]; then
-  bad 'structural (#3367): the order-dependence grammar found NO accepted occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the scan lost its subject'
-elif [ -n "$_wr_prose_bad" ]; then
-  bad "structural (#3367): a line's quote-stripping removed an occurrence of the mutable wrapper variable, so the grammar could not see it and would have passed it silently (an apostrophe in a nearby string, or a single-quoted command later eval'd, both do this): $(printf '%s' "$_wr_prose_bad" | cut -c1-200)"
-elif [ -n "$_wr_bad_spelling" ]; then
-  bad "structural (#3367): an occurrence of the mutable wrapper variable is not spelled as the single legal quoted form, so the form check cannot see it (braced and unquoted spellings were live bypasses): $(printf '%s' "$_wr_bad_spelling" | cut -c1-200)"
-elif [ -n "$_wr_multi" ]; then
-  bad "structural (#3367): a line carries MORE THAN ONE occurrence of the mutable wrapper variable, so a permitted one (an invocation) would carry an unpermitted one (a doctrine scan) past the grammar: $(printf '%s' "$_wr_multi" | cut -c1-200)"
-elif [ -n "$_wr_bad_reads" ]; then
-  bad "structural (#3367): a read of the mutable wrapper variable matches no permitted form, so its verdict depends on gate-mock ordering — use \$WRAPPER_REAL for a doctrine SUBJECT: $(printf '%s' "$_wr_bad_reads" | cut -c1-200)"
-else
-  ok "structural (#3367): all $_wr_total live occurrences of the mutable wrapper variable (plus $_wr_prose_n marked prose) are counted on the RAW line, use the single legal spelling, sit one per line, and are an invocation, an allowlisted save, or a marked opt-out — no doctrine scan takes it as a SUBJECT"
-fi
-# THE CONTROL CERTIFIES THE FUNCTION THE LOOP ACTUALLY CALLS. Each bypass any review has found is
-# probed as its own synthetic line, alongside every form that must still be ACCEPTED — a control that
-# only probed the shapes the author already had in mind is how three rounds of bypasses survived.
+  # ONE category, worst-first. `empty` is the affirmative-measurement case: no ACCEPTED occurrence
+  # means the pass had no subject, which is never a clean verdict.
+  # THE VERDICT IS RETURNED IN A GLOBAL, NEVER ON STDOUT. `v=$(_wr_scan_file …)` would run the whole
+  # pass inside a COMMAND SUBSTITUTION, i.e. a subshell, and every accumulator the diagnostics below
+  # print would be discarded with it — caught here by `set -u` rather than by review.
+  if [ -n "$_wr_unknown" ]; then _WR_VERDICT=unknown
+  elif [ "${_wr_total:-0}" -eq 0 ]; then _WR_VERDICT=empty
+  elif [ -n "$_wr_prose_bad" ]; then _WR_VERDICT=prose
+  elif [ -n "$_wr_bad_spelling" ]; then _WR_VERDICT=spelling
+  elif [ -n "$_wr_multi" ]; then _WR_VERDICT=arity
+  elif [ -n "$_wr_bad_reads" ]; then _WR_VERDICT=form
+  else _WR_VERDICT=clean; fi
+}
+_WR_VERDICT=
+_wr_scan_file "$TEST_SELF"
+case "$_WR_VERDICT" in
+  clean)
+    ok "structural (#3367): all $_wr_total live occurrences of the mutable wrapper variable (plus $_wr_prose_n marked prose) are counted on the RAW line, use the single legal spelling, sit one per line, and are an invocation, an allowlisted save, or a marked opt-out — no doctrine scan takes it as a SUBJECT" ;;
+  unknown)
+    bad "structural (#3367): the order-dependence classifier returned a verdict the dispatch does not recognise, so some line was neither accepted nor rejected —$_wr_unknown" ;;
+  empty)
+    bad 'structural (#3367): the order-dependence pass found NO accepted occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the scan lost its subject' ;;
+  prose)
+    bad "structural (#3367): a line's quote-stripping removed an occurrence of the mutable wrapper variable, so the grammar could not see it and would have passed it silently (an apostrophe in a nearby string, or a single-quoted command later eval'd, both do this): $(printf '%s' "$_wr_prose_bad" | cut -c1-200)" ;;
+  spelling)
+    bad "structural (#3367): an occurrence of the mutable wrapper variable is not spelled as the single legal quoted form, so the form check cannot see it (braced and unquoted spellings were live bypasses): $(printf '%s' "$_wr_bad_spelling" | cut -c1-200)" ;;
+  arity)
+    bad "structural (#3367): a line carries MORE THAN ONE occurrence of the mutable wrapper variable, so a permitted one (an invocation) would carry an unpermitted one (a doctrine scan) past the grammar: $(printf '%s' "$_wr_multi" | cut -c1-200)" ;;
+  form)
+    bad "structural (#3367): a read of the mutable wrapper variable matches no permitted form, so its verdict depends on gate-mock ordering — use \$WRAPPER_REAL for a doctrine SUBJECT: $(printf '%s' "$_wr_bad_reads" | cut -c1-200)" ;;
+  *)
+    bad "structural (#3367): the order-dependence pass returned an unrecognised category '$_WR_VERDICT', so this assert cannot say whether the file is clean" ;;
+esac
+# THE CONTROL RUNS THE ENFORCER ITSELF over fixtures whose correct verdict is known. Every bypass any
+# review has found is a fixture, alongside every form that must still be ACCEPTED — and, crucially,
+# the DISPATCH is exercised, so deleting an accumulator arm now reds here instead of passing.
+_wr_ctl_dir="$tmp/wrapper-grammar-fixtures"
+mkdir -p "$_wr_ctl_dir"
+# Each fixture carries one PERMITTED occurrence (so `empty` is not the answer) plus the case under test.
+_wr_ok_line="bash $_wr_ref --help"
 _wr_ctl_bad=""
-for _wr_case in \
-  "spelling:_x=\$(grep -c foo \"\${$_wr_vname}\")" \
-  "spelling:_x=\$(grep -c foo \$$_wr_vname)" \
-  "arity:bash $_wr_ref --help; grep -c q $_wr_ref" \
-  "arity:_x=\$(grep -c q $_wr_ref); bash $_wr_ref --help # $_wr_marker: one marker must not waive two reads" \
-  "prose:_probe=\$(grep -c \"the wrapper's tok\" $_wr_ref) # it's a scan" \
-  "prose:eval 'grep -c FOO $_wr_ref'" \
-  "prose-ok:  ok 'the mutable \$$_wr_vname is named here in prose' # $_wr_prose_marker" \
-  "form:_x=\$(grep -c foo $_wr_ref)" \
-  "form:sed -n 1p $_wr_ref" \
-  "form:grep bash $_wr_ref" \
-  "form:_x=\$(awk /bash/ $_wr_ref)" \
-  "form:subject=$_wr_ref" \
-  "ok:_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out" \
-  "ok:STUB_INVOKED=\"\$INVOKED\" PATH=\"\$stubbin:\$PATH\" bash $_wr_ref --help" \
-  "ok:  bash $_wr_ref --help" \
-  "ok:_gm_real_wrapper=$_wr_ref" \
-  "none:_x=\$(grep -c foo \"\$${_wr_vname}_REAL\")"; do
-  _wr_want=${_wr_case%%:*}
-  _wr_res=$(_wr_classify "${_wr_case#*:}")
-  _wr_got=${_wr_res%% *}
-  [ "$_wr_got" = "$_wr_want" ] || _wr_ctl_bad="$_wr_ctl_bad [want=$_wr_want got=$_wr_got: ${_wr_case#*:}]"
-done
+_wr_fixture() {
+  # $1 = name, $2 = the line under test ('' for none)
+  printf '%s\n' "$_wr_ok_line" >"$_wr_ctl_dir/$1"
+  [ -z "$2" ] || printf '%s\n' "$2" >>"$_wr_ctl_dir/$1"
+}
+_wr_expect() {
+  _wr_scan_file "$_wr_ctl_dir/$1"
+  [ "$_WR_VERDICT" = "$2" ] || _wr_ctl_bad="$_wr_ctl_bad [$1: want=$2 got=$_WR_VERDICT]"
+}
+_wr_fixture f_clean    ''
+_wr_fixture f_form     "_x=\$(grep -c foo $_wr_ref)"
+_wr_fixture f_form2    "sed -n 1p $_wr_ref"
+_wr_fixture f_grepbash "grep bash $_wr_ref"
+_wr_fixture f_awkbash  "_x=\$(awk /bash/ $_wr_ref)"
+_wr_fixture f_alias    "subject=$_wr_ref"
+_wr_fixture f_braced   "_x=\$(grep -c foo \"\${$_wr_vname}\")"
+_wr_fixture f_unquoted "_x=\$(grep -c foo \$$_wr_vname)"
+_wr_fixture f_arity    "bash $_wr_ref --help; grep -c q $_wr_ref"
+_wr_fixture f_markar   "_x=\$(grep -c q $_wr_ref); bash $_wr_ref --help # $_wr_marker: one marker must not waive two reads"
+_wr_fixture f_prose    "_probe=\$(grep -c \"the wrapper's tok\" $_wr_ref) # it's a scan"
+_wr_fixture f_eval     "eval 'grep -c FOO $_wr_ref'"
+_wr_fixture f_prosetag "  ok 'the mutable \$$_wr_vname is named in prose' # $_wr_prose_marker"
+_wr_fixture f_marked   "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
+_wr_fixture f_save     "_gm_real_wrapper=$_wr_ref"
+_wr_fixture f_envinv   "STUB_INVOKED=\"\$INVOKED\" PATH=\"\$stubbin:\$PATH\" bash $_wr_ref --help"
+printf '%s\n' "_x=\$(grep -c foo \"\$${_wr_vname}_REAL\")" >"$_wr_ctl_dir/f_empty"
+_wr_expect f_clean    clean
+_wr_expect f_form     form
+_wr_expect f_form2    form
+_wr_expect f_grepbash form
+_wr_expect f_awkbash  form
+_wr_expect f_alias    form
+_wr_expect f_braced   spelling
+_wr_expect f_unquoted spelling
+_wr_expect f_arity    arity
+_wr_expect f_markar   arity
+_wr_expect f_prose    prose
+_wr_expect f_eval     prose
+_wr_expect f_prosetag clean
+_wr_expect f_marked   clean
+_wr_expect f_save     clean
+_wr_expect f_envinv   clean
+_wr_expect f_empty    empty
+# The real file's accumulators must be recomputed: the fixtures above clobbered the shared globals,
+# and the success message below prints counts from them.
+_wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the classifier THE LOOP CALLS classifies all seventeen synthetic lines correctly — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash and quote-swallowed bypasses, refuses to let one marker waive a second read, and still accepts invocations, allowlisted saves, marked opt-outs and marked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all seventeen fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash and quote-swallowed bypasses, refuses to let one marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs and marked prose'
 else
-  bad "structural control (#3367): the permitted-form classifier misclassifies a synthetic read, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
+  bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi
 # AND AN ALLOWLISTED ALIAS MAY ONLY RESTORE. Naming the two save variables is not enough on its
 # own: if `_wr_saved` could itself be scanned, the allowlist would just relocate the bypass. So every

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4610,11 +4610,29 @@ fi
 # caller lenient while its own control still reads green.
 _cls_exec_lines() {
   awk '
+  function code_of(s,   n2, i2, sq2, dq2, c2) {
+    # Quote-aware trailing-comment removal. Without it this filter dropped only comment-ONLY lines,
+    # so a harmless trailing comment naming a retired token tripped the classifier-GONE assert — a
+    # false FAIL on doctrine text, which is the very thing #3392 exempted the --help heredoc for.
+    n2 = length(s); sq2 = 0; dq2 = 0
+    for (i2 = 1; i2 <= n2; i2++) {
+      c2 = substr(s, i2, 1)
+      if (!sq2 && c2 == "\\") { i2++; continue }
+      if (sq2) { if (c2 == "'"'"'") sq2 = 0 }
+      else if (dq2) { if (c2 == "\"") dq2 = 0 }
+      else {
+        if (c2 == "'"'"'") { sq2 = 1; continue }
+        if (c2 == "\"") { dq2 = 1; continue }
+        if (c2 == "#" && (i2 == 1 || substr(s, i2-1, 1) ~ /[ \t]/)) return substr(s, 1, i2 - 1)
+      }
+    }
+    return s
+  }
   FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
   in_usage && /^EOF$/ { in_usage = 0; next }
   in_usage { next }
   /^[[:space:]]*#/ { next }
-  { print }
+  { print code_of($0) }
 ' "$@" 2>/dev/null || true
 }
 # ===== THE CLASSIFIER IS GONE, AND MUST STAY GONE (owner ruling (4), #3312) =====
@@ -4678,6 +4696,15 @@ case "$_cls_ctl" in
     ok 'structural control: the executable-line filter KEEPS an executable reintroduction, so the scan above is discriminating rather than blind' ;;
   *)
     bad 'structural control: the executable-line filter DROPPED an executable reintroduction — the classifier scan above cannot see the thing it exists to catch' ;;
+esac
+# ...and a TRAILING comment naming a retired token must be dropped too (roborev job 45): the filter
+# used to remove only comment-ONLY lines, so an ordinary inline comment red the classifier assert.
+_cls_ctl_inline=$(printf 'x=1   # a trailing comment naming mixed-delivery\n' | _cls_exec_lines /dev/stdin)
+case "$_cls_ctl_inline" in
+  *mixed-delivery*)
+    bad 'structural control: the executable-line filter kept a TRAILING comment, so an inline comment naming a retired state would red the classifier assert on doctrine text' ;;
+  *)
+    ok 'structural control: the executable-line filter drops TRAILING comments as well as whole-line ones, so naming a retired state in an inline comment is not a violation' ;;
 esac
 case "$_cls_ctl" in
   *mixed-delivery*)
@@ -4922,7 +4949,13 @@ _WR_QS=$(cat <<'AWKEOF'
       if (c == "\"") { dq = 1; continue }
       if (c == "#" && (i == 1 || substr(line, i-1, 1) ~ /[ \t]/)) {
         cm = substr(line, i + 1); sub(/^[ \t]+/, "", cm)
-        if (index(cm, MK) == 1) mk = 1
+        # THE MARKER IS A WHOLE TOKEN, not a prefix. `index(cm, MK) == 1` alone accepted
+        # `wrapper-mutable-read-allowance`, i.e. a comment that merely STARTS with the marker's
+        # letters authorised a forbidden read. It must be followed by a delimiter or end the comment.
+        if (index(cm, MK) == 1) {
+          nxt = substr(cm, length(MK) + 1, 1)
+          if (nxt == "" || nxt == ":" || nxt == " " || nxt == "\t") mk = 1
+        }
         cut = i - 1
         break
       }
@@ -5184,6 +5217,8 @@ _wr_fixture f_bracedef "_x=\$(grep -c foo \"\${$_wr_vname:-/tmp/x}\")"
 _wr_fixture f_fakeinv  "grep foo $_wr_ref # \$(bash $_wr_ref)"
 _wr_fixture f_evalasm  "_cmd='grep foo $_wr_ref'"
 _wr_fixture f_multiline "' \"\$ORACLES\" \"\$CHECKS_FILE\" $_wr_ref 2>/dev/null || true)"
+_wr_fixture f_nearmk   "_x=\$(grep -c foo $_wr_ref) # ${_wr_marker}ance: a near-prefix must not grant"
+_wr_fixture f_mkcolon  "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
 _wr_fixture f_btprose  "ok \"\`grep \"a'b\" $_wr_ref \"c'd\"\`\""
 _wr_fixture f_cshidden "bash $_wr_ref \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
 _wr_fixture f_csprose  "ok \"\$(grep \"a'b\" $_wr_ref \"c'd\")\""
@@ -5218,6 +5253,8 @@ _wr_expect f_bracedef spelling
 _wr_expect f_fakeinv  form
 _wr_expect f_evalasm  prose
 _wr_expect f_multiline unbalanced
+_wr_expect f_nearmk   form
+_wr_expect f_mkcolon  clean
 _wr_expect f_btprose  substitution
 _wr_expect f_cshidden substitution
 _wr_expect f_csprose  substitution
@@ -5235,7 +5272,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-four fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all thirty-six fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi
@@ -5308,7 +5345,11 @@ fi
 # `-g -n`. The first version anchored it as the LAST character of the FIRST group, which is a
 # spelling of the flag rather than the flag itself — `declare -g -n` and `declare -ng` both evaded
 # it. (`local _f="$1"` and friends carry no option group and are unaffected.)
-_wr_nrefd=$(grep -nE '(^|[ \t;&|(])(declare|local|typeset)[[:space:]]+(-[A-Za-z]+[[:space:]]+)*-[A-Za-z]*'"n" "$TEST_SELF" \
+# LOGICAL lines, not physical ones: `declare \` continued onto `-n subject=_wr_saved` is one
+# declaration, and a per-physical-line grep sees neither half as a nameref. Continuations are joined
+# first (the line numbers are lost, so the diagnostic reports the joined text instead).
+_wr_nrefd=$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" \
+  | grep -nE '(^|[ \t;&|(])(declare|local|typeset)[[:space:]]+(-[A-Za-z]+[[:space:]]+)*-[A-Za-z]*'"n" \
   | grep -vE '^[0-9]+:[[:space:]]*#' || true)
 if [ -z "$_wr_nrefd" ]; then
   ok 'structural (#3367): the harness declares no nameref, so no second name can be bound to an allowlisted alias'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4628,7 +4628,13 @@ _cls_exec_lines() {
     }
     return s
   }
-  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage = 1 }
+  # SUPPRESS THE HEREDOC BODY, NOT THE WHOLE FUNCTION (roborev job 47). Suppression used to begin at
+  # `usage() {`, so any EXECUTABLE statement between the function opener and its `cat <<EOF` was
+  # invisible to the classifier-GONE scan — a reintroduction parked there passed the guard, and the
+  # AC3 control did not cover it because it appends only OUTSIDE the function. What earns the
+  # exemption is being PROSE PRINTED TO A USER, which starts at the heredoc opener, not at the `{`.
+  FILENAME ~ /roborev-review\.sh$/ && /^usage\(\) \{/ { in_usage_fn = 1 }
+  in_usage_fn && /cat[ \t]*<<-?[ \t]*.?EOF/ { in_usage_fn = 0; in_usage = 1; next }
   in_usage && /^EOF$/ { in_usage = 0; next }
   in_usage { next }
   /^[[:space:]]*#/ { next }
@@ -4753,6 +4759,21 @@ _ac3_caught=""
 for _ac3_tok in ROBOREV_DIFF_SOURCE_STATE mixed-delivery; do
   case "$_ac3_exec" in *"$_ac3_tok"*) _ac3_caught="$_ac3_caught $_ac3_tok" ;; esac
 done
+# AC3b: THE SAME REINTRODUCTION, PARKED INSIDE usage() BEFORE ITS HEREDOC (roborev job 47). AC3
+# above appends OUTSIDE the function, which cannot see a filter that exempts from `usage() {`
+# rather than from `cat <<EOF` — a reintroduction between the two was invisible. An executable
+# statement there is code like any other; only the heredoc BODY is prose.
+_ac3b_dir="$tmp/real-wrapper-usage-reintroduction"
+mkdir -p "$_ac3b_dir"
+awk '/^usage\(\) \{/ && !done { print; print "  ROBOREV_DIFF_SOURCE_STATE=inline"; done = 1; next } { print }' \
+  "$WRAPPER_REAL" >"$_ac3b_dir/roborev-review.sh"
+_ac3b_exec=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$_ac3b_dir/roborev-review.sh")
+case "$_ac3b_exec" in
+  *ROBOREV_DIFF_SOURCE_STATE*)
+    ok 'structural (#3367 AC3b): a reintroduction parked INSIDE usage() before its heredoc is caught — the filter exempts the heredoc BODY (prose printed to a user), not the whole function' ;;
+  *)
+    bad 'structural (#3367 AC3b): a reintroduction between `usage() {` and its `cat <<EOF` was NOT caught. The prose exemption starts at the function opener instead of the heredoc opener, so executable code parked there is invisible to the classifier-GONE scan' ;;
+esac
 case "$_ac3_caught" in
   *ROBOREV_DIFF_SOURCE_STATE*)
     ok "structural (#3367 AC3): an executable classifier reintroduction appended to a COPY of the real wrapper is still caught —$_ac3_caught — so the prose exemptions narrow the scan without blinding it" ;;
@@ -5307,6 +5328,10 @@ fi
 # own: if `_wr_saved` could itself be scanned, the allowlist would just relocate the bypass. So every
 # use of an alias must be the restore assignment `WRAPPER="$alias"` (or a marked line, which is the
 # assert that the restore happened). The save `alias="$WRAPPER"` carries no `$alias` and so is not a use.
+# BOTH REMAINING SCANS READ LOGICAL LINES (roborev job 47). `grep "$_wr_\` + `saved"` and
+# `grep "$\` + `{!name}"` are joined by bash into one read but match neither physical line, so the
+# alias-use and indirect-expansion scans were blind to exactly the split `_wr_scan_file` and the
+# nameref scan already handle. Same join, same reason; this is the last pair that lacked it.
 _wr_alias_re=$(printf '%s' "$_wr_aliases" | tr ' ' '|')
 _wr_alias_bad=""
 _wr_alias_seen=0
@@ -5345,7 +5370,7 @@ while IFS= read -r _wr_u; do
   [ "$_wr_is_restore" = yes ] && continue
   _wr_alias_bad="$_wr_alias_bad${_wr_alias_bad:+; }$_wr_u"
 done <<EOF
-$(grep -nE '[$][{]?('"$_wr_alias_re"')[}]?([^A-Za-z0-9_]|$)' "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
+$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" | grep -nE '[$][{]?('"$_wr_alias_re"')[}]?([^A-Za-z0-9_]|$)' | grep -vE '^[0-9]+:[[:space:]]*#')
 EOF
 # CONTROL for the exemption above (roborev job 42): embedding the declaration's text must NOT
 # authorise an alias use. Both probes run the same predicate the loop uses.
@@ -5413,7 +5438,7 @@ while IFS= read -r _wr_il; do
   [ "$_wr_ilc" = "$_wr_indir_ok_2" ] && continue
   _wr_indir_bad="$_wr_indir_bad${_wr_indir_bad:+; }$_wr_il"
 done <<EOF
-$(grep -nE '[$][{]'"!" "$TEST_SELF" | grep -vE '^[0-9]+:[[:space:]]*#')
+$(sed -e :a -e '/\\$/N; s/\\\n//; ta' "$TEST_SELF" | grep -nE '[$][{]'"!" | grep -vE '^[0-9]+:[[:space:]]*#')
 EOF
 if [ -z "$_wr_indir_bad" ]; then
   ok 'structural (#3367): every indirect expansion in this harness is one of the two allowlisted positional-argument walkers — a dynamically-named one could expand to a save alias, and what a name expands to is not decidable by this scan'

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4653,7 +4653,7 @@ done
 if [ -z "$_classifier" ]; then
   ok 'structural: the delivery-mode classifier is GONE — no block/heading/fence/candidate state, no snapshot or delegated distinction, no NOTICE exemption'
 else
-  bad "structural: delivery-mode classification is back in the flow scripts —$_classifier. Owner ruling (4) deleted it because FOUR consecutive review rounds each found a High-severity false verdict in inferring structure from prompt text that embeds repository-controlled content (#3312)"
+  bad "structural: delivery-mode classification is back in the flow scripts —$_classifier. Owner ruling (4) deleted it because FOUR consecutive review rounds each found a High-severity false verdict in inferring structure from prompt text that embeds repository-controlled content (#3312). THIS IS NOT A FLAKE AND MUST NOT BE WAIVED: since #3367 the scan reads an immutable path, so this FAIL is deterministic and reproduces standalone (bash scripts/tests/test_roborev_review_guard.sh) — it is NOT the intermittent tooling-tests red of #2790/#2596/#2188"
 fi
 # THE CONTROL FOR THAT FILTER (#3392). The scan above reads the REAL files, so on a clean tree it is
 # indistinguishable from a scan that examines nothing — which is what it had degraded into. The same

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4643,6 +4643,25 @@ fi
 # only knowable by differential testing against the original — the exact trap CLAUDE.md records for
 # #3283. So it is a function with ONE body: a filter that drifts between call sites cannot make one
 # caller lenient while its own control still reads green.
+# THE SAME FILTER WITHOUT THE HEREDOC EXEMPTION. Only the four PROSE-SHAPED retired tokens
+# (mixed-delivery, delegated-oversize, snapshot-unbound, unparseable-instruction) can legitimately
+# appear in help text, so only they need the exemption. The thirteen CODE IDENTIFIERS never can --
+# they are snake/SCREAMING case, not English -- so they are scanned EVERYWHERE, heredoc included.
+#
+# That split is what retires the whole "is this heredoc line executable?" problem. Rounds 19-21 of
+# review each found another construct that executes inside an unquoted heredoc -- a command
+# substitution, an assigning parameter expansion, a bare `$VAR`, a substitution spanning lines --
+# and each fix was another claim about a SET. With identifiers never exempt, none of it matters:
+# a reintroduction is caught wherever it is written, and prose naming a retired STATE stays legal
+# exactly where prose belongs. Measured on the real wrapper: 0 identifiers in the heredoc, 1 prose
+# word, so this costs nothing and closes the family. (Issue comments 3/5/6/7 recommended keying on
+# the identifiers for this reason; deferred then as scope, adopted now because it fixes a live hole.)
+_cls_all_lines() {
+  awk '
+  /^[[:space:]]*#/ { next }
+  { print }
+' "$@" 2>/dev/null || true
+}
 _cls_exec_lines() {
   awk '
   function code_of(s,   n2, i2, sq2, dq2, c2) {
@@ -4703,11 +4722,6 @@ _cls_exec_lines() {
   # another claim about a SET, and ${VAR:+word} / ${VAR:-word} / ${VAR:?word} all REFERENCE the
   # retired state while being none of them (roborev job 53). The real heredoc contains exactly one
   # braced expansion, so surfacing every one costs a single line of prose review.
-  # EVERY expansion, braced or not. The heredoc delimiter is unquoted, so `$ROBOREV_DIFF_SOURCE_STATE`
-  # is as live as `${...}` -- surfacing only the braced form was one more claim about a SET
-  # (roborev job 54). Measured: the real heredoc has 4 expansion lines and none names a retired
-  # token, so surfacing all of them costs nothing.
-  in_usage && ($0 ~ /[$][(]/ || $0 ~ /`/ || $0 ~ /[$][{]/ || $0 ~ /[$][A-Za-z_]/) { print; next }
   in_usage { next }
   /^[[:space:]]*#/ { next }
   # A SUBSTITUTION LINE KEEPS ITS TAIL. Inside `$( )` a quoted `#` looks like a comment opener to
@@ -4743,11 +4757,23 @@ _cls_exec=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
 if [ -z "$_cls_exec" ]; then
   bad 'structural: the executable-line capture for the classifier scan is EMPTY, so the scan below would report CLEAN having examined nothing (an awk failure, a renamed flow script, or an over-broad filter)'
 fi
+# THE 13 CODE IDENTIFIERS: scanned EVERYWHERE, including the help heredoc. They cannot occur in
+# English, so there is no legitimate prose use to exempt.
+_cls_all=$(_cls_all_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
+if [ -z "$_cls_all" ]; then
+  bad 'structural: the all-lines capture for the classifier scan is EMPTY, so the identifier scan below would report CLEAN having examined nothing'
+fi
 for _gone in 'roborev_collect_review_diff_headers' 'roborev_prompt_snapshot_paths' \
-  'roborev_snapshot_path_binding' 'ROBOREV_DIFF_SOURCE_STATE' 'mixed-delivery' 'delegated-oversize' \
-  'snapshot-unbound' 'unparseable-instruction' 'BLOCKRESET' 'BLOCKHDR' 'in_trailer' 'in_fence' \
-  '_rx_delivery_hdrs' '_rx_snap_paths' 'SNAPSHOT_NOTICE' 'ROBOREV_SNAPSHOT_PATH' \
-  'ROBOREV_SNAPSHOT_CONTAINMENT'; do
+  'roborev_snapshot_path_binding' 'ROBOREV_DIFF_SOURCE_STATE' 'BLOCKRESET' 'BLOCKHDR' \
+  'in_trailer' 'in_fence' '_rx_delivery_hdrs' '_rx_snap_paths' 'SNAPSHOT_NOTICE' \
+  'ROBOREV_SNAPSHOT_PATH' 'ROBOREV_SNAPSHOT_CONTAINMENT'; do
+  case "$_cls_all" in
+    *"$_gone"*) _classifier="$_classifier $_gone" ;;
+  esac
+done
+# THE 4 PROSE-SHAPED VERDICT STRINGS: scanned outside the help heredoc only, since the usage text
+# legitimately names them while telling the reader they are gone.
+for _gone in 'mixed-delivery' 'delegated-oversize' 'snapshot-unbound' 'unparseable-instruction'; do
   case "$_cls_exec" in
     *"$_gone"*) _classifier="$_classifier $_gone" ;;
   esac

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4701,6 +4701,22 @@ if [ -z "$_cls_all" ]; then
   bad 'structural: the all-lines capture for the classifier scan is EMPTY, so the identifier scan below would report CLEAN having examined nothing'
 fi
 _classifier=$(_cls_hits "$_cls_all" | tr '\n' ' ')
+# THE 4 PROSE-SHAPED VERDICT STRINGS, IN AN ASSIGNMENT CONTEXT ONLY (roborev job 63). Dropping them
+# outright closed six rounds of heredoc parsing but opened a real AC3 gap: a classifier rebuilt under
+# NEW variable names still emits the OLD verdict strings, so `delivery_mode=mixed-delivery` read as
+# GONE. A verdict string in PROSE is not a classifier; a verdict string being ASSIGNED is.
+#
+# This is issue comment 3's option (b) -- "require the token to appear in an assignment context
+# rather than as a bare substring" -- which that comment ranked first and I passed over for option
+# (a). It needs NO heredoc exemption, because an assignment does not occur in help text, so it does
+# not reopen the parsing family. Measured on the three real flow scripts: 0 hits, and it matches
+# both `delivery_mode=mixed-delivery` and `mode="mixed-delivery"` while leaving the usage prose alone.
+_cls_prose_assigned=$(printf '%s\n' "$_cls_all" \
+  | grep -oE '=["'"'"']?(mixed-delivery|delegated-oversize|snapshot-unbound|unparseable-instruction)' \
+  | sed 's/^=["'"'"']*//' | sort -u | tr '\n' ' ')
+_cls_prose_assigned=${_cls_prose_assigned% }
+[ -z "$_cls_prose_assigned" ] || _classifier="$_classifier $_cls_prose_assigned"
+_classifier=${_classifier# }
 _classifier=${_classifier% }
 # THE 4 PROSE-SHAPED VERDICT STRINGS ARE NOT SCANNED AT ALL (roborev jobs 51/53/54/56/57/58).
 # `mixed-delivery`, `delegated-oversize`, `snapshot-unbound` and `unparseable-instruction` are

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -36,8 +36,10 @@ WRAPPER="$SCRIPT_DIR/../flow/roborev-review.sh"
 # copy by the gate-mock cases (~2251/~2354) and restored after, so ANY check that READS the
 # wrapper as a doctrine SUBJECT is order-dependent if it reads `WRAPPER`: its verdict then
 # depends on a global set ~2000 lines away, which is what made the classifier-GONE assert
-# flip between runs at an unchanged tree. Structural scans read THIS variable; only the
-# cases that EXECUTE or COPY the wrapper in their own context keep using `WRAPPER`.
+# flip between runs at an unchanged tree. Structural scans read THIS variable; only the cases that
+# EXECUTE the wrapper in their own context keep using `WRAPPER`. NOTE that COPY sites do NOT: every
+# `cp` of the wrapper was moved to `WRAPPER_REAL`, and the grammar below has no permitted form for a
+# copy, so following an older instruction to "keep using WRAPPER for copies" now reds the gate.
 #
 # Note the direction of the hazard now: with the `--help` prose exemption in place, a scan
 # that lands on the scratch copy finds nothing and reports CLEAN — a false pass, which is
@@ -4855,6 +4857,18 @@ _wr_is_invocation() {
     "bash $_wr_ref"*) return 0 ;;
     '"'*"/bash\" $_wr_ref"*) return 0 ;;
   esac
+  # A CAPTURED invocation is still an invocation (reviewer nit): `_x=$(bash "$WRAPPER" --help)` runs
+  # the wrapper, it does not scan it. Only the text after a `$(` is retried, so `$(grep bash "…")`
+  # is still a scan — the command word inside the substitution must itself be the invocation.
+  case "$1" in
+    *'$('*)
+      _i2=${1#*$\(}
+      _i2=$(_wr_cmdpos "$_i2")
+      case "$_i2" in
+        "bash $_wr_ref"*) return 0 ;;
+        '"'*"/bash\" $_wr_ref"*) return 0 ;;
+      esac ;;
+  esac
   return 1
 }
 # THE ENFORCEMENT LOOP AND ITS CONTROL SHARE ONE CLASSIFIER (reviewer B2). They used to be two
@@ -4866,56 +4880,105 @@ _wr_is_invocation() {
 # implementation, and its correctness is only knowable by differential testing against the original.
 # So there is ONE function, the loop calls it, and the control table certifies the thing that runs.
 #
-# COUNTED ON THE RAW LINE, AND PROSE-STRIPPING IS FAIL-CLOSED (reviewer B1). The count used to be
-# taken AFTER the single-quote strip, so a strip that swallowed a REAL occurrence made it invisible —
-# to the grammar and to the `_wr_total -eq 0` backstop alike, since the line simply looked like it
-# had no occurrence. Two measured false PASSes, both accepted by the old code:
-#   `_probe=$(grep -c "the wrapper's tok" "$WRAPPER")  # it's a scan`   (apostrophes pair ACROSS the read)
-#   `eval 'grep -c ROBOREV_DIFF_SOURCE_STATE "$WRAPPER"'`               (single-quoted text that IS code)
-# The second is the sharper one and is not contrived: a line-oriented quote-strip cannot tell inert
-# prose from a quoted string that is later evaluated. So occurrences are counted on the RAW line, and
-# a line whose strip removed any occurrence is a FAIL unless it carries the explicit prose marker.
-# Exactly three lines in this file need it — the `ok`/`bad` messages that NAME the variable while
-# describing the rule — which is the whole price of closing the only fail-open door in the grammar.
-_wr_prose_marker='wrapper-prose''-allow'
-# _wr_classify <raw line> -> "<verdict> <raw-occurrence-count>"
-#   none | prose | prose-ok | spelling | arity | form | ok
+# QUOTE STATE IS PARSED, NOT APPROXIMATED — AND THAT DELETES THE PROSE MARKER (reviewer B2/B3).
+#
+# History, because three successive designs failed the same way. Occurrences were first counted on
+# text stripped by `sed "s/'[^']*'//g"`, a LEFT-TO-RIGHT pairing that has no idea what a quote means:
+#   `_probe=$(grep -c "the wrapper's tok" "$WRAPPER")`   <- the apostrophe is INSIDE double quotes,
+# so the naive pass paired it with a later one and swallowed a REAL read. Counting on the raw line
+# fixed the swallowing but made genuine prose (this file's own `ok`/`bad` messages, which NAME the
+# variable while describing the rule) indistinguishable from a read — so a `wrapper-prose-allow`
+# marker was added to excuse it, and the marker promptly became the hole: it returned early, ahead of
+# the spelling/arity/form checks, so ANY read wearing the marker was licensed; and it was matched
+# anywhere on the line, so a line whose own prose merely NAMED the marker self-authorised. That is
+# CLAUDE.md's recurring shape verbatim — an artifact that DESCRIBES the escape hatch BECOMES it, the
+# same defect as a diagnostic printing a valid waiver marker.
+#
+# The doctrinal answer there is to REMOVE THE SHARED CHANNEL rather than pick a rarer delimiter, and
+# that is what this does. A single pass over the line tracks real shell quote state (single quotes,
+# double quotes, backslash escapes, and where the trailing comment begins) and reports:
+#   code = expansions OUTSIDE single quotes  -> live reads, which must obey spelling/arity/form
+#   lit  = occurrences INSIDE single quotes  -> inert text, which needs no marker and grants nothing
+#   q    = live occurrences spelled exactly `"$WRAPPER"`
+#   mk   = the opt-out marker appears IN THE TRAILING COMMENT (never inside a string)
+#   ev   = the line contains an `eval` word
+# With `lit` recognised for what it is, the prose marker has no job left and is GONE — so neither
+# blocker it carried can be expressed. Every one of the three bypasses now classifies as a live read.
+#
+# `eval` is the one case lexical analysis genuinely cannot settle: a single-quoted string that is
+# later evaluated IS code that reads the mutable global, and no quote parser can tell it from prose.
+# It is therefore refused outright rather than guessed at.
+_WR_QS=$(cat <<'AWKEOF'
+{
+  line = $0; n = length(line); sq = 0; dq = 0
+  code = 0; lit = 0; q = 0; mk = 0; ev = 0
+  for (i = 1; i <= n; i++) {
+    c = substr(line, i, 1)
+    if (!sq && c == "\\") { i++; continue }
+    if (sq) { if (c == "'") sq = 0 }
+    else if (dq) { if (c == "\"") dq = 0 }
+    else {
+      if (c == "'") { sq = 1; continue }
+      if (c == "\"") { dq = 1; continue }
+      if (c == "#" && (i == 1 || substr(line, i-1, 1) ~ /[ \t]/)) {
+        # THE MARKER MUST OPEN THE COMMENT, not merely appear in it. Matched anywhere, a comment
+        # that only QUOTES the marker ("# see 'wrapper-mutable-read-allow' above") grants it -- an
+        # artifact describing the escape hatch becoming it, which is the shape CLAUDE.md says to
+        # close by anchoring the control token where the payload cannot reach. Caught by fixture
+        # f_selfauth, not by review.
+        cm = substr(line, i + 1)
+        sub(/^[ \t]+/, "", cm)
+        if (index(cm, MK) == 1) mk = 1
+        break
+      }
+    }
+    if (c == "$") {
+      rest = substr(line, i)
+      if (match(rest, "^[$][{]?" VN "[}]?")) {
+        tok = substr(rest, 1, RLENGTH); after = substr(rest, RLENGTH + 1, 1)
+        if (after !~ /[A-Za-z0-9_]/) {
+          if (sq) lit++
+          else { code++
+                 if (tok == "$" VN && dq && substr(line, i-1, 1) == "\"" && after == "\"") q++ }
+        }
+      }
+    }
+  }
+  if (line ~ /(^|[ \t;&|(])eval([ \t]|$)/) ev = 1
+  printf "%d %d %d %d %d\n", code, lit, q, mk, ev
+}
+AWKEOF
+)
+# _wr_classify <raw line> -> "<verdict> <occurrence-count>"
+#   none | prose-ok | eval | spelling | arity | form | ok
 _wr_classify() {
   _c_raw=$1
-  _c_n=$(printf '%s\n' "$_c_raw" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
-  if [ "${_c_n:-0}" -lt 1 ]; then printf 'none 0\n'; return; fi
-  _c_code=$(printf '%s\n' "$_c_raw" | sed -e 's/\\[$]/@ESC@/g' -e "s/'[^']*'//g")
-  _c_s=$(printf '%s\n' "$_c_code" | grep -oE '[$][{]?'"$_wr_vname"'[}]?([^A-Za-z0-9_]|$)' | wc -l | tr -d '[:space:]')
-  if [ "${_c_n:-0}" -ne "${_c_s:-0}" ]; then
-    case "$_c_raw" in
-      *"$_wr_prose_marker"*)
-        # THE PROSE MARKER MUST NOT WAIVE ARITY EITHER (roborev job 38). It used to return
-        # `prose-ok` on sight, so a line mixing quoted prose with a LIVE read --
-        #   grep -c q "$WRAPPER"; ok 'mentions $WRAPPER'   # <prose marker>
-        # -- was accepted whole. Marked prose is only prose if the strip removed EVERY occurrence;
-        # anything surviving the strip is a live read riding on the marker, which is the
-        # compound-line bypass wearing a third disguise.
-        if [ "${_c_s:-0}" -eq 0 ]; then printf 'prose-ok %s\n' "$_c_n"; return; fi
-        printf 'arity %s\n' "$_c_n"; return ;;
-    esac
-    printf 'prose %s\n' "$_c_n"; return
+  _c_m=$(printf '%s\n' "$_c_raw" | awk -v VN="$_wr_vname" -v MK="$_wr_marker" "$_WR_QS")
+  _c_code=${_c_m%% *}; _c_rest=${_c_m#* }
+  _c_lit=${_c_rest%% *}; _c_rest=${_c_rest#* }
+  _c_q=${_c_rest%% *}; _c_rest=${_c_rest#* }
+  _c_mk=${_c_rest%% *}; _c_ev=${_c_rest##* }
+  if [ "${_c_ev:-0}" -eq 1 ] && [ $(( ${_c_code:-0} + ${_c_lit:-0} )) -gt 0 ]; then
+    printf 'eval %s\n' $(( ${_c_code:-0} + ${_c_lit:-0} )); return
   fi
-  _c_q=$(printf '%s\n' "$_c_code" | grep -oF "$_wr_ref" | wc -l | tr -d '[:space:]')
-  if [ "${_c_n:-0}" -ne "${_c_q:-0}" ]; then printf 'spelling %s\n' "$_c_n"; return; fi
-  # ARITY IS CHECKED BEFORE THE MARKER (reviewer nit): otherwise approving a marker for one read
-  # implicitly approves any number of reads on that line, which is the compound-line bypass again.
-  if [ "${_c_n:-0}" -gt 1 ]; then printf 'arity %s\n' "$_c_n"; return; fi
-  case "$_c_code" in
-    *"$_wr_marker"*) printf 'ok %s\n' "$_c_n"; return ;;
-  esac
-  if _wr_is_invocation "$_c_code"; then printf 'ok %s\n' "$_c_n"; return; fi
-  case "$_c_code" in
+  if [ "${_c_code:-0}" -eq 0 ]; then
+    if [ "${_c_lit:-0}" -gt 0 ]; then printf 'prose-ok %s\n' "$_c_lit"; return; fi
+    printf 'none 0\n'; return
+  fi
+  if [ "${_c_code:-0}" -ne "${_c_q:-0}" ]; then printf 'spelling %s\n' "$_c_code"; return; fi
+  # ARITY BEFORE THE MARKER: otherwise approving a marker for one read implicitly approves any
+  # number of reads on that line, which is the compound-line bypass again.
+  if [ "${_c_code:-0}" -gt 1 ]; then printf 'arity %s\n' "$_c_code"; return; fi
+  if [ "${_c_mk:-0}" -eq 1 ]; then printf 'ok %s\n' "$_c_code"; return; fi
+  _c_code_only=$(printf '%s\n' "$_c_raw" | sed 's/[ 	]#[^"'"'"']*$//')
+  if _wr_is_invocation "$_c_code_only"; then printf 'ok %s\n' "$_c_code"; return; fi
+  case "$_c_code_only" in
     *"=$_wr_ref")
-      _c_nm=${_c_code%%=*}
+      _c_nm=${_c_code_only%%=*}
       _c_nm=${_c_nm#"${_c_nm%%[! ]*}"}
-      case " $_wr_aliases " in *" $_c_nm "*) printf 'ok %s\n' "$_c_n"; return ;; esac ;;
+      case " $_wr_aliases " in *" $_c_nm "*) printf 'ok %s\n' "$_c_code"; return ;; esac ;;
   esac
-  printf 'form %s\n' "$_c_n"
+  printf 'form %s\n' "$_c_code"
 }
 # THE WHOLE ENFORCEMENT PASS IS A FUNCTION, AND THE CONTROL RUNS *IT* OVER FIXTURES (reviewer B2,
 # second attempt). The first attempt only shared the CLASSIFIER between the loop and the control.
@@ -4941,13 +5004,16 @@ _wr_scan_file() {
       none) ;;
       ok) _wr_total=$((_wr_total + _wr_c)) ;;
       prose-ok) _wr_prose_n=$((_wr_prose_n + _wr_c)) ;;
-      prose) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
+      eval) _wr_prose_bad="$_wr_prose_bad${_wr_prose_bad:+; }$_wr_num_line" ;;
       spelling) _wr_bad_spelling="$_wr_bad_spelling${_wr_bad_spelling:+; }$_wr_num_line" ;;
       arity) _wr_multi="$_wr_multi${_wr_multi:+; }$_wr_num_line" ;;
       form) _wr_bad_reads="$_wr_bad_reads${_wr_bad_reads:+; }$_wr_num_line" ;;
       # A CLOSED GRAMMAR OVER THE VERDICTS THEMSELVES: an unplanned verdict must not fall silently
       # into the permissive branch, which is the shape this whole section exists to retire.
-      *) _wr_unknown="$_wr_unknown${_wr_unknown:+; }$_wr_v" ;;
+      # The line number is recorded WITH the verdict, so an EMPTY verdict cannot make this entry
+      # itself empty and leave `[ -n "$_wr_unknown" ]` false — the one unplanned value the arm
+      # that exists to catch unplanned values was letting through (reviewer nit).
+      *) _wr_unknown="$_wr_unknown${_wr_unknown:+; }${_wr_num_line%%:*}:<$_wr_v>" ;;
     esac
   done <<EOF
 $(grep -nE '[$][{]?'"$_wr_vname"'[}]?' "$_sf_file" | grep -vE '^[0-9]+:[[:space:]]*#')
@@ -4959,7 +5025,7 @@ EOF
   # print would be discarded with it — caught here by `set -u` rather than by review.
   if [ -n "$_wr_unknown" ]; then _WR_VERDICT=unknown
   elif [ "${_wr_total:-0}" -eq 0 ]; then _WR_VERDICT=empty
-  elif [ -n "$_wr_prose_bad" ]; then _WR_VERDICT=prose
+  elif [ -n "$_wr_prose_bad" ]; then _WR_VERDICT=eval
   elif [ -n "$_wr_bad_spelling" ]; then _WR_VERDICT=spelling
   elif [ -n "$_wr_multi" ]; then _WR_VERDICT=arity
   elif [ -n "$_wr_bad_reads" ]; then _WR_VERDICT=form
@@ -4974,8 +5040,8 @@ case "$_WR_VERDICT" in
     bad "structural (#3367): the order-dependence classifier returned a verdict the dispatch does not recognise, so some line was neither accepted nor rejected —$_wr_unknown" ;;
   empty)
     bad 'structural (#3367): the order-dependence pass found NO accepted occurrence of the mutable wrapper variable at all, so it certified nothing — the variable was renamed, or the scan lost its subject' ;;
-  prose)
-    bad "structural (#3367): a line's quote-stripping removed an occurrence of the mutable wrapper variable, so the grammar could not see it and would have passed it silently (an apostrophe in a nearby string, or a single-quoted command later eval'd, both do this): $(printf '%s' "$_wr_prose_bad" | cut -c1-200)" ;;
+  eval)
+    bad "structural (#3367): a line EVALs text containing the mutable wrapper variable. A single-quoted string that is later evaluated IS code reading the mutable global, and no quote parser can tell it from prose, so it is refused rather than guessed at: $(printf '%s' "$_wr_prose_bad" | cut -c1-200)" ;;
   spelling)
     bad "structural (#3367): an occurrence of the mutable wrapper variable is not spelled as the single legal quoted form, so the form check cannot see it (braced and unquoted spellings were live bypasses): $(printf '%s' "$_wr_bad_spelling" | cut -c1-200)" ;;
   arity)
@@ -5014,9 +5080,12 @@ _wr_fixture f_arity    "bash $_wr_ref --help; grep -c q $_wr_ref"
 _wr_fixture f_markar   "_x=\$(grep -c q $_wr_ref); bash $_wr_ref --help # $_wr_marker: one marker must not waive two reads"
 _wr_fixture f_prose    "_probe=\$(grep -c \"the wrapper's tok\" $_wr_ref) # it's a scan"
 _wr_fixture f_eval     "eval 'grep -c FOO $_wr_ref'"
-_wr_fixture f_prosetag "  ok 'the mutable \$$_wr_vname is named in prose' # $_wr_prose_marker"
+_wr_fixture f_aposmk   "printf '%s' \"it's\"; grep $_wr_ref"
+_wr_fixture f_selfauth "bad \"the wrapper's rule\"; grep -c z $_wr_ref # see 'wrapper-mutable-read-allow' above"
+_wr_fixture f_prosetag "  ok 'the mutable \$$_wr_vname is named in prose, and needs no marker'"
+_wr_fixture f_captured "_x=\$(bash $_wr_ref --help)"
 _wr_fixture f_marked   "_x=\$(grep -c foo $_wr_ref) # $_wr_marker: a reviewed opt-out"
-_wr_fixture f_mixed    "grep -c q $_wr_ref; ok 'mentions \$$_wr_vname' # $_wr_prose_marker"
+_wr_fixture f_mixed    "grep -c q $_wr_ref; ok 'mentions \$$_wr_vname'"
 _wr_fixture f_save     "_gm_real_wrapper=$_wr_ref"
 _wr_fixture f_envinv   "STUB_INVOKED=\"\$INVOKED\" PATH=\"\$stubbin:\$PATH\" bash $_wr_ref --help"
 printf '%s\n' "_x=\$(grep -c foo \"\$${_wr_vname}_REAL\")" >"$_wr_ctl_dir/f_empty"
@@ -5030,11 +5099,14 @@ _wr_expect f_braced   spelling
 _wr_expect f_unquoted spelling
 _wr_expect f_arity    arity
 _wr_expect f_markar   arity
-_wr_expect f_prose    prose
-_wr_expect f_eval     prose
+_wr_expect f_prose    form
+_wr_expect f_eval     eval
+_wr_expect f_aposmk   form
+_wr_expect f_selfauth form
 _wr_expect f_prosetag clean
+_wr_expect f_captured clean
 _wr_expect f_marked   clean
-_wr_expect f_mixed    arity
+_wr_expect f_mixed    form
 _wr_expect f_save     clean
 _wr_expect f_envinv   clean
 _wr_expect f_empty    empty
@@ -5042,7 +5114,7 @@ _wr_expect f_empty    empty
 # and the success message below prints counts from them.
 _wr_scan_file "$TEST_SELF"
 if [ -z "$_wr_ctl_bad" ]; then
-  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all eighteen fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash and quote-swallowed bypasses, refuses to let either marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs and marked prose'
+  ok 'structural control (#3367): the ENFORCEMENT PASS itself (classifier + dispatch) gives the correct verdict on all twenty-one fixtures — it rejects the braced, unquoted, compound-line, unallowlisted-alias, mentions-the-word-bash quote-swallowed, marker-self-authorising and eval bypasses, refuses to let a marker waive a second read, reports a subjectless file as empty, and still accepts invocations, allowlisted saves, marked opt-outs, captured invocations and unmarked prose'
 else
   bad "structural control (#3367): the enforcement pass misclassifies a fixture, so its verdict on the real file is not trustworthy —$_wr_ctl_bad"
 fi
@@ -5130,7 +5202,7 @@ _wr_real_hit=no; _wr_mut_hit=no
 case "$_cls_via_real"    in *"$_wr_sentinel"*) _wr_real_hit=yes ;; esac
 case "$_cls_via_mutable" in *"$_wr_sentinel"*) _wr_mut_hit=yes ;; esac
 if [ "$_wr_real_hit" = no ] && [ "$_wr_mut_hit" = yes ]; then
-  ok 'behavioural (#3367): with $WRAPPER poisoned, the same filter reports the sentinel via $WRAPPER and NOT via $WRAPPER_REAL — the immutable path is what makes the verdict stable, and the scan is demonstrably not blind' # wrapper-prose-allow: names the variable in a diagnostic, does not read it
+  ok 'behavioural (#3367): with $WRAPPER poisoned, the same filter reports the sentinel via $WRAPPER and NOT via $WRAPPER_REAL — the immutable path is what makes the verdict stable, and the scan is demonstrably not blind'
 elif [ "$_wr_mut_hit" = no ]; then
   bad 'behavioural (#3367): the poisoned wrapper was NOT flagged even when scanned directly, so this case shows nothing about path stability (the fixture or the executable-line filter is wrong, not the paths)'
 else
@@ -5139,9 +5211,9 @@ fi
 # The restore must have happened, or every later case silently audits the scratch copy — the exact
 # failure mode this section exists to prevent, reintroduced by the pin that tests for it.
 if [ "$WRAPPER" = "$_wr_saved" ]; then # wrapper-mutable-read-allow: asserting the restore requires reading it
-  ok 'behavioural (#3367): the probe restored $WRAPPER, so no later case inherits the poisoned path' # wrapper-prose-allow: names the variable in a diagnostic, does not read it
+  ok 'behavioural (#3367): the probe restored $WRAPPER, so no later case inherits the poisoned path'
 else
-  bad 'behavioural (#3367): the probe left $WRAPPER pointing at its scratch copy' # wrapper-prose-allow: names the variable in a diagnostic, does not read it
+  bad 'behavioural (#3367): the probe left $WRAPPER pointing at its scratch copy'
 fi
 
 # ===== ABSENCE IS A FAIL, AND THE WAIVER IS THE ONLY WAY PAST IT =====

--- a/scripts/tests/test_roborev_review_guard.sh
+++ b/scripts/tests/test_roborev_review_guard.sh
@@ -4800,13 +4800,23 @@ if [ "$_wr_real_writes" -eq 1 ]; then
 else
   bad "structural (#3367): WRAPPER_REAL is assigned $_wr_real_writes times; it must be written exactly once"
 fi
-# BEHAVIOURAL: poison `WRAPPER` and re-run the classifier scan both ways.
+# BEHAVIOURAL: poison `WRAPPER` and run the classifier filter over both paths.
+#
+# THE NEEDLE IS A SYNTHETIC SENTINEL, NOT A REAL RETIRED TOKEN, and that is a correctness
+# requirement rather than tidiness. The first version poisoned with `mixed-delivery`; when a RED
+# rehearsal injected a genuine reintroduction into the real wrapper, this pin ALSO fired and said
+# "the scan via $WRAPPER_REAL picked up the poisoned copy" — blaming path instability for what was
+# actually a dirty subject. A diagnostic that names the wrong cause under a real defect sends its
+# reader ~2000 lines away from the problem, which is precisely how #3367 cost two lanes their gate
+# budget. A sentinel that CANNOT occur in a real flow script makes the two conditions independent:
+# a hit via $WRAPPER_REAL can only mean the immutable path resolved to the poisoned copy.
+_wr_sentinel='ROBOREV_ORDER_DEP_PROBE_'"3367"
 _wr_poison_dir="$tmp/wrapper-poison"
 mkdir -p "$_wr_poison_dir"
 {
   printf '%s\n' '#!/usr/bin/env bash'
-  # An EXECUTABLE reintroduction, not prose: an assignment the awk filter cannot exempt.
-  printf '%s\n' 'ROBOREV_DIFF_SOURCE_STATE="mixed-delivery"'
+  # An EXECUTABLE line, not prose and not a --help heredoc: the filter must keep it.
+  printf '%s=inline\n' "$_wr_sentinel"
 } >"$_wr_poison_dir/roborev-review.sh"
 _wr_saved="$WRAPPER"
 WRAPPER="$_wr_poison_dir/roborev-review.sh"
@@ -4814,14 +4824,21 @@ _cls_via_real=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER_REAL")
 _cls_via_mutable=$(_cls_exec_lines "$ORACLES" "$CHECKS_FILE" "$WRAPPER") # wrapper-mutable-read-allow: reading the poisoned path IS this probe
 WRAPPER="$_wr_saved"
 _wr_real_hit=no; _wr_mut_hit=no
-case "$_cls_via_real"    in *'mixed-delivery'*) _wr_real_hit=yes ;; esac
-case "$_cls_via_mutable" in *'mixed-delivery'*) _wr_mut_hit=yes ;; esac
+case "$_cls_via_real"    in *"$_wr_sentinel"*) _wr_real_hit=yes ;; esac
+case "$_cls_via_mutable" in *"$_wr_sentinel"*) _wr_mut_hit=yes ;; esac
 if [ "$_wr_real_hit" = no ] && [ "$_wr_mut_hit" = yes ]; then
-  ok 'behavioural (#3367): with $WRAPPER poisoned, the scan via $WRAPPER_REAL is unaffected while the same scan via $WRAPPER flags it — the immutable path is what makes the verdict stable, and the scan is demonstrably not blind'
+  ok 'behavioural (#3367): with $WRAPPER poisoned, the same filter reports the sentinel via $WRAPPER and NOT via $WRAPPER_REAL — the immutable path is what makes the verdict stable, and the scan is demonstrably not blind'
 elif [ "$_wr_mut_hit" = no ]; then
-  bad 'behavioural (#3367): the poisoned wrapper was NOT flagged even when scanned directly, so this case cannot show anything about path stability (the fixture or the filter is wrong)'
+  bad 'behavioural (#3367): the poisoned wrapper was NOT flagged even when scanned directly, so this case shows nothing about path stability (the fixture or the executable-line filter is wrong, not the paths)'
 else
-  bad 'behavioural (#3367): the scan via $WRAPPER_REAL picked up the poisoned copy, so it is still reading a mutable path'
+  bad 'behavioural (#3367): a sentinel that exists ONLY in the poisoned scratch copy was found via $WRAPPER_REAL, so the immutable path is not immutable'
+fi
+# The restore must have happened, or every later case silently audits the scratch copy — the exact
+# failure mode this section exists to prevent, reintroduced by the pin that tests for it.
+if [ "$WRAPPER" = "$_wr_saved" ]; then # wrapper-mutable-read-allow: asserting the restore requires reading it
+  ok 'behavioural (#3367): the probe restored $WRAPPER, so no later case inherits the poisoned path'
+else
+  bad 'behavioural (#3367): the probe left $WRAPPER pointing at its scratch copy'
 fi
 
 # ===== ABSENCE IS A FAIL, AND THE WAIVER IS THE ONLY WAY PAST IT =====

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -116,6 +116,57 @@ gitignored — so a gate that "passed" against your dirty working tree proves no
 **Fix:** force-add the tiny reference binaries (`git add -f`) and verify the test against a
 fresh `git worktree add --detach HEAD`, never the dirty tree.
 
+### A permitted shape found ANYWHERE, standing in for the line BEING that shape (issue #3367)
+
+**The single most repeated finding class measured to date: seven of 29 findings in one PR, then
+three more of the same family.** Every instance is a guard that asks *"does a permitted construct
+appear somewhere on this line?"* when the question is *"IS this line that construct?"*
+
+Measured instances, all from one guard, each found after the previous was fixed:
+
+| the check | what slipped through |
+|---|---|
+| `case $line in *"bash $ref"*)` | `grep bash "$WRAPPER"` — a scan that merely mentions the word |
+| one occurrence per line assumed | `bash "$W"; grep -c x "$W"` — the invocation carried a scan in with it |
+| `${seg%%=*}` for the assigned name | `_saved=x; subject="$W"` — the FIRST `=` named an allowlisted variable |
+| a substring of the declaration text | `grep -E "a|b" "$_saved"` — the line quoted the declaration and exempted itself |
+| marker matched anywhere on the line | `# see 'marker' above` — prose naming the escape hatch became it |
+| marker matched as a prefix | `marker-allowance` — a longer word starting with the marker granted |
+| exclusion by substring | `_saved=/decoy # _wr_fixture` — naming an excluded token exempted a real mutation |
+
+**Fix:** decide the property of the WHOLE line, not the presence of a token in it. Anchor at column
+zero, match the trimmed line EXACTLY, count occurrences rather than assuming one, and reduce a value
+to its token before comparing. Where a fixture or diagnostic must mention the guarded name,
+**compose it at runtime** (`"$_alias"`, `'wrap''per'`) so the file never contains the literal —
+that removes the need for the exclusion that keeps becoming the hole.
+
+### A claim about a SET, where the set does not close (issue #3367)
+
+The sibling class. A guard enumerates the constructs it knows about; review finds the one it missed;
+the fix adds it; repeat. Measured: `$(...)` but not backticks; `-n` but not `-ng`/`-g -n`;
+`${VAR:=}` but not `${VAR:+}`/`${VAR:-}`; braced but not unbraced expansions; `NAME=` but not
+`export`/`declare`/`+=`/`printf -v`/`read` — **that last one three separate times, on three
+different variables.**
+
+**The terminating move is to remove the decision, not to complete the list.** What actually worked,
+in the order it was found:
+
+- **Hand the property to the shell.** `readonly` refuses every assignment syntax, including the ones
+  you did not think of. `readonly` on an *unset* name forbids the variable existing at all — but
+  **`unset` first**, because `readonly` on an inherited exported value freezes that value instead.
+- **Use a `local`, not a global.** A function-local cannot be assigned from outside, so the whole
+  "who may write this?" question is unexpressible rather than policed.
+- **Delete the mutable thing.** If a global exists only so two cases can repoint it, pass a parameter
+  instead and the guard has no subject.
+- **Choose needles that cannot occur in what you must exempt.** Scanning for prose-shaped strings
+  forced a help-text exemption, and six rounds went into deciding which heredoc lines execute. Keying
+  only on code identifiers — impossible in English — deleted the exemption, the filter, and the family.
+
+**And the general limit, worth knowing before you start:** a lexical scanner cannot decide whether a
+shell line reads a variable, because the name need not appear in the line —
+`export WRAP''PER; sh -c 'grep "$WRAP''PER"'` reads it, and banning `eval` does not close it
+(`bash -c`, `source`, `.`, `xargs sh -c`). If your guard needs that decision, redesign so it does not.
+
 ## How to use this
 
 1. Before handing an issue off, diff your branch against `origin/main` and walk this list.


### PR DESCRIPTION
Fixes #3367.

`roborev-lints` red at random on branches whose diff touched no `scripts/` path — observed on three unrelated lanes, each clearing on re-run.

## Cause

Two causes were diagnosed on the issue. **Cause 2 was already fixed on `main`** by #3392 (the `usage()` heredoc exemption); measured hit count on the real wrapper is now 0, and the SIGPIPE/pipe-buffer mechanism behind the reported 39/40 vacuous-pass rate went with it.

**Cause 1 was live, and had inverted.** `WRAPPER` is a global that two gate-mock cases repoint at a scratch copy ~2000 lines from the doctrine asserts, so a scan reading it was judged against whichever file the last case had left behind. With #3392's prose exemption in place the failure mode flipped: a scan landing on the scratch copy finds nothing and reports **CLEAN**. It surfaced as a false FAIL, so someone noticed; the same defect now yields a false PASS, which nobody would.

## The fix: the global is gone, not guarded

`WRAPPER` existed for exactly one reason — those two mock windows. `run_wrapper` was its only reader, and the 7 direct `bash "$WRAPPER"` sites all sat **outside** both windows, so they always meant the real wrapper.

- `run_wrapper` resolves its own path: `bash "${RUN_WRAPPER_PATH:-$WRAPPER_REAL}"`
- the two mock cases scope `RUN_WRAPPER_PATH` around themselves instead of mutating a global
- direct sites use `$WRAPPER_REAL`, which is `readonly`
- `WRAPPER` no longer exists

**The order dependence is absent by construction rather than policed.** What remains is one shell-enforced fact plus a two-part check: no mutable `WRAPPER` global exists, and the scratch-copy override is read at exactly one site.

## Why not the guard I built first

The first fix **guarded** the global: a ~250-line lexical scanner classifying every occurrence of `$WRAPPER` by quote state, arity, spelling, command position and markers. It went through **18 roborev rounds and 4 independent review passes, producing 43 findings, all valid, all fixed**. The last one settled it: `sh -c` executes a name assembled from adjacent quoted strings (`export WRAP''PER; sh -c 'grep "$WRAP''PER"'`), and this harness already uses `sh -c`. Banning `eval` did not close it, and the set does not close — `bash -c`, `source`, `.`, `xargs sh -c`.

> A lexical scanner cannot decide whether a shell line reads a variable, because the name need not appear in the line.

No further round could have fixed that, so the scanner, its 36 fixtures and its poison probe were deleted. **Net −770 lines**; this PR is now **+283/−69** rather than +900/−55.

Two patterns from those 43 findings are worth carrying forward, and are proposed for the roborev-findings doctrine page:
- **Seven were literally one mistake** — *a permitted shape found ANYWHERE standing in for the line BEING that shape* (unanchored `bash`; compound-line arity; `${seg%%=*}`; a declaration substring; two markers; the `$(`-only substitution test).
- **Three more were substring exclusions I added while fixing the previous round** — each exempting a real violation that merely mentioned the excluded token.

## Acceptance criteria

| AC | status | evidence |
|---|---|---|
| 1 — structural check no longer reads a reassigned global | ✅ | **there is no such global**; RED-verified that reintroducing `WRAPPER=` reds |
| 2 — real wrapper's doctrine prose does not trip it | ✅ | pinned with a vacuity guard (FAILs if the wrapper stops naming the retired states) |
| 3 — a genuine reintroduction still trips it | ✅ | pinned against a copy of the real wrapper, **plus AC3b** inside `usage()` before its heredoc |
| 4 — `roborev-lints` deterministic | ✅ | 8/8 PASS across consecutive gate runs on an unchanged tree |
| 5 — full gate PASS | ⏳ | blocked: box3 is reserved measurement-only for #3248, and box1/box2 are unreachable from here (no ssh, no key, no `agent-ami`, no off-box peer session) — see issue `3367-W3` |

Suite: **806/0 (`main`) → 813/0**.


## Gate of record

```
RESULT: PASS          run-id /tmp/agent-gate.xyZ2Ez   host box1
commit 80a96fb        tree-integrity: PASS            tree-start == tree-end (e360247c3266)
```

Run on box1 by the coordination lead — box3 was reserved measurement-only for #3248 (#3363), and box1/box2 are unreachable from box3 (no ssh, no key, no `agent-ami`, no aws credentials). Liveness was verified by counting processes with a `gate-3437` cwd, not by reading the summary sentinel or inferring from the queue.

## Two findings ship UNFIXED, under a pre-committed stopping rule

roborev job 65 returned two AC2/AC3-coverage findings on this sha. Both are fair; **neither is fixed**, under a rule the lead pre-committed *before* the answer was known:

> if that pass returns another Medium in AC3/AC2 coverage: we SHIP. The residual goes to #3454 with its mechanism recorded.

- **Medium** — the assignment detector misses `mode=$'mixed-delivery'` and `mode="mixed"-delivery`.
- **Low** — the AC3 control plants a tracked *identifier*, so it passes whether or not the new prose-assignment path works.

**Why a rule rather than a judgement:** three consecutive rounds each asserted a property of shell syntax that the author of the shell controls, and each was falsified by one more spelling.

| round | the claim | the spelling that broke it |
|---|---|---|
| (a) drop the 4 prose tokens | "a verdict string alone is not a classifier" | `delivery_mode=mixed-delivery` |
| (b) require an assignment context | "an assignment does not occur in prose" | `mode=$'mixed-delivery'` |

Option (b) was a genuine improvement — it closed the renamed-variable *class* rather than instances — and it still leaks. **That leak is the finding**, and it leads #3454: a token-name scan over shell source cannot decide whether a construct is live, so the question is what *channel* (a lint step, a registry, an assertion on the wrapper's output), not what regex. Structurally identical to #3312's four superseded recognisers.

**Guard reach today, so nobody over-trusts it:** catches any of the 13 code identifiers anywhere including inside the heredoc, and a verdict string assigned as `=value` / `="value"` — both RED-verified. Does not catch a reintroduction that renames every identifier *and* obfuscates the verdict string's quoting.

## Scope not taken

The prose-shaped-needle redesign (issue comments 3/5/6/7) is proposed as a separate issue (`3367-W1`). Residuals recorded there: AC2 resting on a single token, and the ~35 other `cmd | grep -q`-under-`pipefail` sites in this file (#3387 fleet-wide).

## Authorship

Two sessions briefly worked this lane concurrently (a #1930 violation caught by `tree-integrity` #2926 — issue comments 8–9). The peer stood down, released the claim and endorsed this line of work; their commit `13c1cc328` is retained as an ancestor. The claim was re-acquired via the documented `adopt --expect none` path.

