### PR TITLE
fix(#3369): bootstrap measures git PUSH capability by performing it; verify.run wires credentials and fails closed

### DIFF
--- a/.agent-ami/profile.yaml
+++ b/.agent-ami/profile.yaml
@@ -57,7 +57,7 @@ verify:
   #     printed only when there are zero warnings, which is exactly --strict's condition
   #     — belt and braces on the same fact, from two independent channels.
   # Section 3b now measures git PUSH capability by performing the operation (create +
-  # read back + delete a throwaway refs/claims/smoke-<nonce> ref), not by probing the
+  # read back + delete a throwaway refs/claims/smoke-<commit-sha> ref), not by probing the
   # credential helper: the affected box passed `gh auth status` AND
   # `git ls-remote origin HEAD` and still could not push.
   run: "bash scripts/bootstrap-agent-machine.sh --fix-credentials --strict"

--- a/.agent-ami/profile.yaml
+++ b/.agent-ami/profile.yaml
@@ -42,8 +42,31 @@ env:
   SCCACHE_CACHE_SIZE: "30G"
   CQLITE_DATASETS_ROOT: "{data_mount}/datasets"
 verify:
-  run: "bash scripts/bootstrap-agent-machine.sh"
+  # --fix-credentials --strict (issue #3369). Two independent gaps, both real on a box
+  # launched from the pinned image:
+  #  1. WIRING. The image has a working `gh` but no git credential helper, so the first
+  #     thing a lane does — `scripts/flow/claim.sh claim <N>`, a plain `git push` of a
+  #     claim ref — fails `CLAIM: ERROR reason=auth`. Bare (no flag) the bootstrap can
+  #     only ever WARN about that; it cannot wire it. --fix-credentials runs section
+  #     3b's auto-fix (preferring `gh auth setup-git`) and NOTHING else, so verify stays
+  #     a verification step rather than becoming a toolchain installer — which is what
+  #     --yes would have made it.
+  #  2. FAIL-CLOSED. The script always exits 0 by design (it composes into setup
+  #     scripts), so the expect string below was the ONLY failure signal. --strict makes
+  #     the exit code fail closed too. It adds no NEW strictness: "All checks green." is
+  #     printed only when there are zero warnings, which is exactly --strict's condition
+  #     — belt and braces on the same fact, from two independent channels.
+  # Section 3b now measures git PUSH capability by performing the operation (create +
+  # read back + delete a throwaway refs/claims/smoke-<nonce> ref), not by probing the
+  # credential helper: the affected box passed `gh auth status` AND
+  # `git ls-remote origin HEAD` and still could not push.
+  run: "bash scripts/bootstrap-agent-machine.sh --fix-credentials --strict"
   expect: "All checks green."
 hooks:
+  # Deliberately EMPTY (issue #3369). The credential wiring belongs in verify.run above,
+  # not here: the hook schema is defined by the EXTERNAL agent-ami launcher and nothing
+  # in this repo documents or consumes it, so a command placed here would be a guess at
+  # an external contract — and a wrong guess breaks onboarding fleet-wide. verify.run's
+  # shape is known and already exercised on every launch.
   post_toolchain: []
   pre_verify: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -926,7 +926,7 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   fix the box (`gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes`, which also
   probes board access functionally rather than trusting the `project` scope string). Since #3369 the
   same script MEASURES git push capability by **performing the push** — a throwaway
-  `refs/claims/smoke-<nonce>` create/read-back/delete via `claim.sh smoke` — rather than trusting a
+  `refs/claims/smoke-<commit-sha>` create/read-back/delete via `claim.sh smoke` — rather than trusting a
   credential-helper answer or a green `git ls-remote`, and reports it three-valued
   (`git-push: VERIFIED` / `FAILED` / `UNMEASURED`); an unmeasurable result is UNKNOWN, never `ok`.
   `--fix-credentials` wires the credential path only (no toolchain installs) and `--strict` turns any

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -924,7 +924,13 @@ end-to-end test. Green helper-only unit tests are not sufficient.
   `fatal: could not read Username`, and `claim.sh` now calls that `ERROR reason=auth (NOT
   retryable)` instead of the old misleading `reason=infra (transient — retry)` — do not retry it,
   fix the box (`gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes`, which also
-  probes board access functionally rather than trusting the `project` scope string). The three
+  probes board access functionally rather than trusting the `project` scope string). Since #3369 the
+  same script MEASURES git push capability by **performing the push** — a throwaway
+  `refs/claims/smoke-<nonce>` create/read-back/delete via `claim.sh smoke` — rather than trusting a
+  credential-helper answer or a green `git ls-remote`, and reports it three-valued
+  (`git-push: VERIFIED` / `FAILED` / `UNMEASURED`); an unmeasurable result is UNKNOWN, never `ok`.
+  `--fix-credentials` wires the credential path only (no toolchain installs) and `--strict` turns any
+  warning into exit 1, which is what `.agent-ami/profile.yaml`'s `verify.run` uses. The three
   worker-environment deltas and the messages that identify them: `docs/development/fleet-runbook.md`.
 - **Supervisor-authored machine claim + CI reaper (#2655/#2499)**: liveness is now MECHANISM-driven,
   not prose. `worker-supervisor.sh` stamps `refs/machine-claims/<machine>` (issue+supervisor-PID+ts)

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -41,7 +41,7 @@ without it, it prints the exact command for each gap. It verifies, in order:
 3b. **git PUSH capability** (#3369) — the section above validates *configuration*
    (`git credential fill` never contacts the network); this one performs **the
    operation**, delegating to `scripts/flow/claim.sh smoke` to create, read back and
-   delete a throwaway `refs/claims/smoke-<nonce>` ref. It runs **after** the credential
+   delete a throwaway `refs/claims/smoke-<commit-sha>` ref. It runs **after** the credential
    fix, so it measures the machine as the fix left it. The verdict is **three-valued**
    and prints one greppable line:
 
@@ -57,13 +57,13 @@ without it, it prints the exact command for each gap. It verifies, in order:
    **not** `--skip-smoke` (which skips the final *gate* run).
 
    **Cost:** measuring the operation means performing it — two extra network round trips
-   and a transient `refs/claims/smoke-<nonce>` ref created and deleted on the shared
+   and a transient `refs/claims/smoke-<commit-sha>` ref created and deleted on the shared
    origin, on **every** run of this script. An **observed** cleanup failure FAILS the
    probe (`reason=cleanup-unverified` — the delete exited nonzero, so whether the ref
    survives is unknown), so it can never pass quietly. A run **interrupted before
    cleanup** is the residual: it leaves no verdict at all and can still strand a ref.
    List them with `git ls-remote origin 'refs/claims/smoke-*'` and delete with
-   `git push origin --delete refs/claims/smoke-<nonce>` — always safe.
+   `git push origin --delete refs/claims/smoke-<commit-sha>` — always safe.
 4. **roborev** — installed, and this machine's *configured* agent resolves.
 5. **Datasets** + `CQLITE_DATASETS_ROOT` guidance.
 6. **Health check** — runs the gate's fmt smoke and prints the authoritative

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -9,7 +9,13 @@ place, and `gh`/roborev configured so a local gate run predicts CI.
 ```bash
 bash scripts/bootstrap-agent-machine.sh          # check everything; print any install commands
 bash scripts/bootstrap-agent-machine.sh --yes    # also auto-run brew/cargo installs + dataset fetch
+bash scripts/bootstrap-agent-machine.sh --fix-credentials --strict   # image/launcher preflight (#3369):
+                                                 # wire git push credentials ONLY, and exit 1 on any [warn]
 ```
+
+`--strict` is what the agent-ami profile's `verify.run` uses. Without it the script always
+exits 0 (so it composes into setup scripts) and the ONLY failure signal is the literal
+string `All checks green.` in its stdout — a signal a caller can forget to check.
 
 Idempotent and safe to re-run. macOS + Linux. It **never installs without `--yes`** —
 without it, it prints the exact command for each gap. It verifies, in order:
@@ -28,8 +34,25 @@ without it, it prints the exact command for each gap. It verifies, in order:
    changed. The output names the account it measured. Point it elsewhere with
    `CQLITE_PROJECT_OWNER` / `CQLITE_PROJECT_NUMBER` / `CQLITE_PROJECT_ACCOUNT`.
    It also checks **git push credentials** (#2942) — a *separate* credential path from
-   `gh`. Under `--yes` it configures one, **scoped to the origin host**, and the token
-   value is never written to disk.
+   `gh`. Under `--yes` (or `--fix-credentials`) it configures one, **scoped to the origin
+   host**, and the token value is never written to disk.
+3b. **git PUSH capability** (#3369) — the section above validates *configuration*
+   (`git credential fill` never contacts the network); this one performs **the
+   operation**, delegating to `scripts/flow/claim.sh smoke` to create, read back and
+   delete a throwaway `refs/claims/smoke-<nonce>` ref. It runs **after** the credential
+   fix, so it measures the machine as the fix left it. The verdict is **three-valued**
+   and prints one greppable line:
+
+   | Line | Meaning |
+   |---|---|
+   | `[ok]   git-push: VERIFIED (refs/claims/* create+ls-remote+delete on 'origin')` | affirmatively measured — the claim protocol works here |
+   | `[warn] git-push: FAILED (...)` | the remote refused the push (credentials, or the `refs/claims/*` namespace) |
+   | `[warn] git-push: UNMEASURED (...)` | no remote / unreachable / no `timeout` to bound it / no verdict — capability is **UNKNOWN, not ok** |
+   | `[warn] git-push: OPT-OUT (--skip-push-probe)` | deliberately not measured; still a warning, so it can never buy a green |
+
+   UNMEASURED is a warning on purpose: an unmeasured capability must never inherit the
+   permissive branch. `--skip-push-probe` is for offline boxes and hermetic tests, and is
+   **not** `--skip-smoke` (which skips the final *gate* run).
 4. **roborev** — installed, and this machine's *configured* agent resolves.
 5. **Datasets** + `CQLITE_DATASETS_ROOT` guidance.
 6. **Health check** — runs the gate's fmt smoke and prints the authoritative

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -38,6 +38,15 @@ without it, it prints the exact command for each gap. It verifies, in order:
    host**, and the token value is never written to disk. That check is a *configuration*
    probe (`git credential fill`, which never contacts the network): it proves a helper
    ANSWERS, never that a push would succeed. The push claim belongs to 3b below.
+   The **fallback** repair — the `$GH_TOKEN`-dereferencing helper, used only when
+   `gh auth setup-git` yields no usable credential — is additionally gated on
+   `gh auth status --hostname <push host>` **confirming** that host. The host is read from
+   local git config (`git remote get-url --push`), so a typo, a leftover fork/mirror
+   `pushurl` or a stale `insteadOf` would otherwise configure git to hand a real GitHub
+   token to a host nobody intended, during a preflight the launcher runs automatically.
+   Not confirmed ⇒ the repair is **refused**, one `[warn]` names the host, and `--strict`
+   exits 1. `gh auth setup-git` itself stays unconditional: it makes `gh` the helper, and
+   `gh` decides what it will answer for.
 3b. **git PUSH capability** (#3369) — the section above validates *configuration*
    (`git credential fill` never contacts the network); this one performs **the
    operation**, delegating to `scripts/flow/claim.sh smoke` to create, read back and
@@ -79,6 +88,7 @@ The bootstrap now checks the first two and fails loudly; the third is a hand-typ
 |---|---|---|
 | `fatal: could not read Username for 'https://github.com'` | `gh` is authenticated but **git is not** — they are separate credential paths. `scripts/flow/claim.sh` + `claim-heartbeat.sh` push with plain git on 10+ call sites, so the claim protocol itself does not work. | `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes` (configures an origin-host-scoped helper that dereferences `$GH_TOKEN` at call time). |
 | `git push` fails on a box where `gh auth status` is green **and** `git ls-remote origin HEAD` succeeds | Same shape, one subsystem over: a read is evidence about reachability, not about the write. `claim.sh claim <N>` — the first thing a lane does — is a `git push`, so the box looks healthy and no lane can start (#3369). | `bash scripts/bootstrap-agent-machine.sh --fix-credentials`, then read its `git-push:` line. That check is the direct application of the doctrine sentence below: it PERFORMS the push instead of inferring it. |
+| `git push has NO credentials for <host> and this run REFUSED to configure any` under `--fix-credentials` | The push host was resolved from local git config and `gh auth status --hostname <host>` did not confirm authentication for it, so the run would have configured git to hand `$GH_TOKEN` to that host. Fail-closed by design (#3369). | If the host is right: `gh auth login --hostname <host>`, then re-run. If it is wrong: `git remote set-url --push origin <the intended url>` — check for a leftover fork/mirror `pushurl` or a stale `insteadOf`. |
 | `gh project …` fails for a missing **`read:org`** scope on a token whose scopes DO include `project` | A scope match is evidence about a token, not about the operation. `gh project item-edit` needs `read:org`; the equivalent GraphQL mutation does not. | Widen the token (`gh auth refresh -s read:org`), **or** do board writes through the `updateProjectV2ItemFieldValue` GraphQL mutation — it succeeds with the same token. |
 | `stale info` from a **bare** `git push --force-with-lease`, even when local and remote refs demonstrably match | The bare form leases against a remote-tracking ref your checkout may never have fetched. | Always the explicit CAS form: `git push --force-with-lease=<ref>:<sha>` (what the flow scripts already use). |
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -48,7 +48,7 @@ without it, it prints the exact command for each gap. It verifies, in order:
    | Line | Meaning |
    |---|---|
    | `[ok]   git-push: VERIFIED (refs/claims/* create+ls-remote+delete on 'origin')` | affirmatively measured — the claim protocol works here |
-   | `[warn] git-push: FAILED (...)` | the remote refused the push (credentials, or the `refs/claims/*` namespace) |
+   | `[warn] git-push: FAILED (...)` | the remote refused the operation — credentials, the `refs/claims/*` namespace, or a namespace that accepts the create but **refuses the delete** (unusable for claims: `release` deletes `refs/claims/issue-<N>`, and that case strands a ref, so the line tells you how to list it) |
    | `[warn] git-push: UNMEASURED (...)` | no remote / unreachable / no `timeout` to bound it / no verdict — capability is **UNKNOWN, not ok** |
    | `[warn] git-push: OPT-OUT (--skip-push-probe)` | deliberately not measured; still a warning, so it can never buy a green |
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -35,7 +35,9 @@ without it, it prints the exact command for each gap. It verifies, in order:
    `CQLITE_PROJECT_OWNER` / `CQLITE_PROJECT_NUMBER` / `CQLITE_PROJECT_ACCOUNT`.
    It also checks **git push credentials** (#2942) — a *separate* credential path from
    `gh`. Under `--yes` (or `--fix-credentials`) it configures one, **scoped to the origin
-   host**, and the token value is never written to disk.
+   host**, and the token value is never written to disk. That check is a *configuration*
+   probe (`git credential fill`, which never contacts the network): it proves a helper
+   ANSWERS, never that a push would succeed. The push claim belongs to 3b below.
 3b. **git PUSH capability** (#3369) — the section above validates *configuration*
    (`git credential fill` never contacts the network); this one performs **the
    operation**, delegating to `scripts/flow/claim.sh smoke` to create, read back and
@@ -53,6 +55,13 @@ without it, it prints the exact command for each gap. It verifies, in order:
    UNMEASURED is a warning on purpose: an unmeasured capability must never inherit the
    permissive branch. `--skip-push-probe` is for offline boxes and hermetic tests, and is
    **not** `--skip-smoke` (which skips the final *gate* run).
+
+   **Cost:** measuring the operation means performing it — two extra network round trips
+   and a transient `refs/claims/smoke-<nonce>` ref created and deleted on the shared
+   origin, on **every** run of this script. `claim.sh smoke` only warns if its cleanup
+   delete fails, so an interrupted run can strand one; list them with
+   `git ls-remote origin 'refs/claims/smoke-*'` and delete with
+   `git push origin --delete refs/claims/smoke-<nonce>`.
 4. **roborev** — installed, and this machine's *configured* agent resolves.
 5. **Datasets** + `CQLITE_DATASETS_ROOT` guidance.
 6. **Health check** — runs the gate's fmt smoke and prints the authoritative
@@ -67,6 +76,7 @@ The bootstrap now checks the first two and fails loudly; the third is a hand-typ
 | You see | Real cause | Working form |
 |---|---|---|
 | `fatal: could not read Username for 'https://github.com'` | `gh` is authenticated but **git is not** — they are separate credential paths. `scripts/flow/claim.sh` + `claim-heartbeat.sh` push with plain git on 10+ call sites, so the claim protocol itself does not work. | `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes` (configures an origin-host-scoped helper that dereferences `$GH_TOKEN` at call time). |
+| `git push` fails on a box where `gh auth status` is green **and** `git ls-remote origin HEAD` succeeds | Same shape, one subsystem over: a read is evidence about reachability, not about the write. `claim.sh claim <N>` — the first thing a lane does — is a `git push`, so the box looks healthy and no lane can start (#3369). | `bash scripts/bootstrap-agent-machine.sh --fix-credentials`, then read its `git-push:` line. That check is the direct application of the doctrine sentence below: it PERFORMS the push instead of inferring it. |
 | `gh project …` fails for a missing **`read:org`** scope on a token whose scopes DO include `project` | A scope match is evidence about a token, not about the operation. `gh project item-edit` needs `read:org`; the equivalent GraphQL mutation does not. | Widen the token (`gh auth refresh -s read:org`), **or** do board writes through the `updateProjectV2ItemFieldValue` GraphQL mutation — it succeeds with the same token. |
 | `stale info` from a **bare** `git push --force-with-lease`, even when local and remote refs demonstrably match | The bare form leases against a remote-tracking ref your checkout may never have fetched. | Always the explicit CAS form: `git push --force-with-lease=<ref>:<sha>` (what the flow scripts already use). |
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -39,14 +39,20 @@ without it, it prints the exact command for each gap. It verifies, in order:
    probe (`git credential fill`, which never contacts the network): it proves a helper
    ANSWERS, never that a push would succeed. The push claim belongs to 3b below.
    The **fallback** repair — the `$GH_TOKEN`-dereferencing helper, used only when
-   `gh auth setup-git` yields no usable credential — is additionally gated on
-   `gh auth status --hostname <push host>` **confirming** that host. The host is read from
+   `gh auth setup-git` yields no usable credential — is additionally gated on **token
+   authority for that host**: `gh auth token --hostname <push host>` must return a token
+   **equal to** the `$GH_TOKEN`/`$GITHUB_TOKEN` this run would install. **A successful
+   login for the host is deliberately NOT sufficient** — on a box authenticated to both
+   `github.com` and a GitHub Enterprise host, a login check passes for both and the
+   github.com token would be handed to the enterprise host. The host itself is read from
    local git config (`git remote get-url --push`), so a typo, a leftover fork/mirror
-   `pushurl` or a stale `insteadOf` would otherwise configure git to hand a real GitHub
-   token to a host nobody intended, during a preflight the launcher runs automatically.
-   Not confirmed ⇒ the repair is **refused**, one `[warn]` names the host, and `--strict`
-   exits 1. `gh auth setup-git` itself stays unconditional: it makes `gh` the helper, and
-   `gh` decides what it will answer for.
+   `pushurl` or a stale `insteadOf` would otherwise configure git to hand a real
+   credential to a host nobody intended, during a preflight the launcher runs
+   automatically. Anything other than an exact match — no token for that host, a different
+   token, an unanswerable `gh`, an empty answer — ⇒ the repair is **refused**, one `[warn]`
+   names the host (never a token value), and `--strict` exits 1. `gh auth setup-git` itself
+   stays unconditional: it makes `gh` the helper, and `gh` decides, per host, what it will
+   answer for.
 3b. **git PUSH capability** (#3369) — the section above validates *configuration*
    (`git credential fill` never contacts the network); this one performs **the
    operation**, delegating to `scripts/flow/claim.sh smoke` to create, read back and
@@ -88,7 +94,7 @@ The bootstrap now checks the first two and fails loudly; the third is a hand-typ
 |---|---|---|
 | `fatal: could not read Username for 'https://github.com'` | `gh` is authenticated but **git is not** — they are separate credential paths. `scripts/flow/claim.sh` + `claim-heartbeat.sh` push with plain git on 10+ call sites, so the claim protocol itself does not work. | `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes` (configures an origin-host-scoped helper that dereferences `$GH_TOKEN` at call time). |
 | `git push` fails on a box where `gh auth status` is green **and** `git ls-remote origin HEAD` succeeds | Same shape, one subsystem over: a read is evidence about reachability, not about the write. `claim.sh claim <N>` — the first thing a lane does — is a `git push`, so the box looks healthy and no lane can start (#3369). | `bash scripts/bootstrap-agent-machine.sh --fix-credentials`, then read its `git-push:` line. That check is the direct application of the doctrine sentence below: it PERFORMS the push instead of inferring it. |
-| `git push has NO credentials for <host> and this run REFUSED to configure any` under `--fix-credentials` | The push host was resolved from local git config and `gh auth status --hostname <host>` did not confirm authentication for it, so the run would have configured git to hand `$GH_TOKEN` to that host. Fail-closed by design (#3369). | If the host is right: `gh auth login --hostname <host>`, then re-run. If it is wrong: `git remote set-url --push origin <the intended url>` — check for a leftover fork/mirror `pushurl` or a stale `insteadOf`. |
+| `git push has NO credentials for <host> and this run REFUSED to configure any` under `--fix-credentials` | The push host was resolved from local git config, and `gh auth token --hostname <host>` did not return the token this environment holds — gh has none for that host, or a **different** one (the reachable case: a github.com token on a box that also has a GitHub Enterprise host). A login for the host is not enough; the run would otherwise have configured git to hand `$GH_TOKEN` to a host that token does not belong to. Fail-closed by design (#3369). | If the host is right: `gh auth login --hostname <host>`, then re-run `--fix-credentials` — preferably **without** `$GH_TOKEN` set, so `gh auth setup-git` supplies that host's own token. If it is wrong: `git remote set-url --push origin <the intended url>` — check for a leftover fork/mirror `pushurl` or a stale `insteadOf`. |
 | `gh project …` fails for a missing **`read:org`** scope on a token whose scopes DO include `project` | A scope match is evidence about a token, not about the operation. `gh project item-edit` needs `read:org`; the equivalent GraphQL mutation does not. | Widen the token (`gh auth refresh -s read:org`), **or** do board writes through the `updateProjectV2ItemFieldValue` GraphQL mutation — it succeeds with the same token. |
 | `stale info` from a **bare** `git push --force-with-lease`, even when local and remote refs demonstrably match | The bare form leases against a remote-tracking ref your checkout may never have fetched. | Always the explicit CAS form: `git push --force-with-lease=<ref>:<sha>` (what the flow scripts already use). |
 

--- a/docs/development/agent-machine-setup.md
+++ b/docs/development/agent-machine-setup.md
@@ -48,7 +48,7 @@ without it, it prints the exact command for each gap. It verifies, in order:
    | Line | Meaning |
    |---|---|
    | `[ok]   git-push: VERIFIED (refs/claims/* create+ls-remote+delete on 'origin')` | affirmatively measured — the claim protocol works here |
-   | `[warn] git-push: FAILED (...)` | the remote refused the operation — credentials, the `refs/claims/*` namespace, or a namespace that accepts the create but **refuses the delete** (unusable for claims: `release` deletes `refs/claims/issue-<N>`, and that case strands a ref, so the line tells you how to list it) |
+   | `[warn] git-push: FAILED (...)` | the operation did not complete. For a credential fault the line names it and gives the #2942 remedy; for anything else bootstrap **quotes `claim.sh`'s own verdict verbatim** rather than guessing a cause — including `reason=cleanup-unverified`, where the cleanup delete exited nonzero so delete capability is unproven (`release` deletes `refs/claims/issue-<N>`) and the ref may survive; the quoted line carries the `ls-remote` check |
    | `[warn] git-push: UNMEASURED (...)` | no remote / unreachable / no `timeout` to bound it / no verdict — capability is **UNKNOWN, not ok** |
    | `[warn] git-push: OPT-OUT (--skip-push-probe)` | deliberately not measured; still a warning, so it can never buy a green |
 
@@ -58,10 +58,12 @@ without it, it prints the exact command for each gap. It verifies, in order:
 
    **Cost:** measuring the operation means performing it — two extra network round trips
    and a transient `refs/claims/smoke-<nonce>` ref created and deleted on the shared
-   origin, on **every** run of this script. `claim.sh smoke` only warns if its cleanup
-   delete fails, so an interrupted run can strand one; list them with
-   `git ls-remote origin 'refs/claims/smoke-*'` and delete with
-   `git push origin --delete refs/claims/smoke-<nonce>`.
+   origin, on **every** run of this script. An **observed** cleanup failure FAILS the
+   probe (`reason=cleanup-unverified` — the delete exited nonzero, so whether the ref
+   survives is unknown), so it can never pass quietly. A run **interrupted before
+   cleanup** is the residual: it leaves no verdict at all and can still strand a ref.
+   List them with `git ls-remote origin 'refs/claims/smoke-*'` and delete with
+   `git push origin --delete refs/claims/smoke-<nonce>` — always safe.
 4. **roborev** — installed, and this machine's *configured* agent resolves.
 5. **Datasets** + `CQLITE_DATASETS_ROOT` guidance.
 6. **Health check** — runs the gate's fmt smoke and prints the authoritative

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -51,10 +51,13 @@ bash scripts/flow/claim.sh smoke               # same probe the bootstrap runs (
 
 **Cost and residual of the automatic probe.** Every bootstrap run — laptop runs included — makes two
 extra network round trips and CREATES AND DELETES a transient `refs/claims/smoke-<nonce>` ref on the
-shared origin. `claim.sh smoke` only *warns* if its cleanup delete fails, so an interrupted run can
-strand one. **Deleting a stray `refs/claims/smoke-*` is always safe** — it is a throwaway root commit
-that nothing reads, and it is NOT a claim lock (those are `refs/claims/issue-<N>`, never `smoke-`).
-List and clean them:
+shared origin. A remote that REFUSES the cleanup delete now FAILS the probe
+(`SMOKE-FAIL … reason=delete-rejected` → `git-push: FAILED`, #3369) rather than reporting success with
+a stderr warning — delete capability is required by the claim protocol, since `claim.sh release`
+deletes `refs/claims/issue-<N>`. A ref can still be stranded if a run is KILLED between the create and
+the delete, and by the delete-rejected case itself. **Deleting a stray `refs/claims/smoke-*` is always
+safe** — it is a throwaway root commit that nothing reads, and it is NOT a claim lock (those are
+`refs/claims/issue-<N>`, never `smoke-`). List and clean them:
 
 ```bash
 git ls-remote origin 'refs/claims/smoke-*'

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -31,25 +31,30 @@ issues itself). Other machines run pure **workers**. A lead is a worker with a h
 git clone https://github.com/pmcfadin/cqlite && cd cqlite
 bash scripts/bootstrap-agent-machine.sh        # or manually: sccache, cargo-nextest, bash>=4.3, mold (Linux)
 bash test-data/scripts/fetch-datasets.sh       # real SSTable binaries — REQUIRED; export the line it prints
+gh auth setup-git                              # git push credentials — SEPARATE from gh auth (#2942)
 gh auth status                                  # must include the 'project' scope (board access)
 ```
 
-**git push credentials and the `refs/claims/*` preflight are no longer manual steps (#3369).**
-`bootstrap-agent-machine.sh --fix-credentials` wires the credential path itself (preferring
-`gh auth setup-git`), and every bootstrap run then MEASURES push capability by performing the
-operation — it invokes `claim.sh smoke` and reports one of `git-push: VERIFIED` / `FAILED` /
-`UNMEASURED`. The two commands below are now the **fallback** when you are diagnosing by hand, not
-the primary path:
+**On a LAUNCHER-ONBOARDED box the credential step is already done (#3369)** — the agent-ami
+profile's `verify.run` is `bootstrap-agent-machine.sh --fix-credentials --strict`, which runs
+`gh auth setup-git` itself after the token is injected. It is **wired at onboard, not baked into
+the image**, so a hand-built box still needs the line above; the two paths do not conflict, and
+re-running it is idempotent.
+
+**The `refs/claims/*` preflight is no longer a separate manual step either.** Every bootstrap run
+MEASURES push capability by performing the operation — it invokes `claim.sh smoke` and reports one
+of `git-push: VERIFIED` / `FAILED` / `UNMEASURED`. Run the probe by hand only when diagnosing:
 
 ```bash
-gh auth setup-git                              # fallback: wire git push credentials (SEPARATE from gh auth, #2942)
-bash scripts/flow/claim.sh smoke               # fallback: prove origin accepts refs/claims/* (see below)
+bash scripts/flow/claim.sh smoke               # same probe the bootstrap runs (see below)
 ```
 
 **Cost and residual of the automatic probe.** Every bootstrap run — laptop runs included — makes two
 extra network round trips and CREATES AND DELETES a transient `refs/claims/smoke-<nonce>` ref on the
 shared origin. `claim.sh smoke` only *warns* if its cleanup delete fails, so an interrupted run can
-strand one. List and clean them:
+strand one. **Deleting a stray `refs/claims/smoke-*` is always safe** — it is a throwaway root commit
+that nothing reads, and it is NOT a claim lock (those are `refs/claims/issue-<N>`, never `smoke-`).
+List and clean them:
 
 ```bash
 git ls-remote origin 'refs/claims/smoke-*'
@@ -684,7 +689,7 @@ machine + heartbeat age (issue #2089). Interpretation:
 | Laptop lid closed mid-issue | Nothing. Commits are on the origin branch. Reopen and say `implement <N>` — it resumes from the worktree. |
 | Session feels degraded / bloated | Kill it, start fresh. Board + disk are the state; the new session rehydrates in one board read. |
 | Board unreachable (auth/scope error) | The session STOPS by design (labels are decorative, never a dispatch source). Fix `gh auth refresh -s project` and restart. If the scope is already present and `gh project` still fails for `read:org`, that is the #2942 delta — use the `updateProjectV2ItemFieldValue` GraphQL mutation for board writes, or widen the token with `-s read:org`. |
-| `fatal: could not read Username` on any push | git has no credentials even though `gh` does (#2942). The claim protocol pushes with plain git, so it is fully broken until fixed: `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --yes`. A claim attempt on such a box reports `reason=auth`, not a retryable transient. |
+| `fatal: could not read Username` on any push | git has no credentials even though `gh` does (#2942). The claim protocol pushes with plain git, so it is fully broken until fixed: `gh auth setup-git`, or `bash scripts/bootstrap-agent-machine.sh --fix-credentials`. A claim attempt on such a box reports `reason=auth`, not a retryable transient. **Since #3369 the bootstrap catches this one step earlier**, by performing the push rather than probing the credential helper: the same fault shows there as `git-push: FAILED`. Never wait for a lane to hit it. |
 | Gate seems hung | It's probably queued: look for `waiting for gate slot (N in use)…`. Queued ≠ hung. |
 | Green SUMMARY but parity lines say SKIP | Datasets missing on that machine — `fetch-datasets.sh`, export the root it prints, re-run. Probe an existing root with `fetch-datasets.sh --verify-only` (mutates nothing). The FULL gate FAILs CLOSED here (`missing-fixtures: FAIL-CLOSED (#2078)`) so it can't slip through; `--lite`/`--only` stay lenient. |
 | `missing-schemas: FAIL-CLOSED (#3148)` | Either a committed `test-data/schemas/*.cql` is unreadable (broken checkout — `git restore --source=HEAD -- test-data/schemas`) or `CQLITE_SCHEMAS_ROOT` is set to a **relative** path (export an absolute one, or unset it). Never a corpus-layout problem: the schemas root is checkout-relative. No opt-out exists — do not look for one. |

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -50,7 +50,7 @@ bash scripts/flow/claim.sh smoke               # same probe the bootstrap runs (
 ```
 
 **Cost and residual of the automatic probe.** Every bootstrap run — laptop runs included — makes two
-extra network round trips and CREATES AND DELETES a transient `refs/claims/smoke-<nonce>` ref on the
+extra network round trips and CREATES AND DELETES a transient `refs/claims/smoke-<commit-sha>` ref on the
 shared origin. A cleanup delete that exits nonzero now FAILS the probe
 (`SMOKE-FAIL … reason=cleanup-unverified` → `git-push: FAILED`, #3369) rather than reporting success
 with a stderr warning: delete capability is required by the claim protocol, since `claim.sh release`
@@ -64,7 +64,7 @@ safe** — it is a throwaway root commit that nothing reads, and it is NOT a cla
 
 ```bash
 git ls-remote origin 'refs/claims/smoke-*'
-git push origin --delete refs/claims/smoke-<nonce>
+git push origin --delete refs/claims/smoke-<commit-sha>
 ```
 
 ### Notification channel (ntfy) — one env var, no per-machine binary (#3119)
@@ -144,7 +144,7 @@ again.
 
 **Claim-ref preflight (#2665):** the cross-machine lock is a push to the `refs/claims/*` ref
 namespace on origin — `claim.sh smoke` creates, `ls-remote`s, and deletes a throwaway
-`refs/claims/smoke-<nonce>` ref to confirm the remote permits it (`SMOKE-OK` = good). This is
+`refs/claims/smoke-<commit-sha>` ref to confirm the remote permits it (`SMOKE-OK` = good). This is
 **verified working on github.com/pmcfadin/cqlite** (2026-07-17). Since #3369
 `bootstrap-agent-machine.sh` runs this probe on every invocation (that is its `git-push:` line), so
 you rarely need it by hand; run it directly **when adopting a new remote or host** — a managed Git host that restricts custom ref namespaces would make the whole

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -34,6 +34,8 @@ bash test-data/scripts/fetch-datasets.sh       # real SSTable binaries — REQUI
 gh auth setup-git                              # git push credentials — SEPARATE from gh auth (#2942)
 gh auth status                                  # must include the 'project' scope (board access)
 bash scripts/flow/claim.sh smoke               # preflight: prove origin accepts refs/claims/* (see below)
+                                               #   (bootstrap now runs this probe itself and reports
+                                               #    git-push: VERIFIED / FAILED / UNMEASURED, #3369)
 ```
 
 ### Notification channel (ntfy) — one env var, no per-machine binary (#3119)

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -31,11 +31,29 @@ issues itself). Other machines run pure **workers**. A lead is a worker with a h
 git clone https://github.com/pmcfadin/cqlite && cd cqlite
 bash scripts/bootstrap-agent-machine.sh        # or manually: sccache, cargo-nextest, bash>=4.3, mold (Linux)
 bash test-data/scripts/fetch-datasets.sh       # real SSTable binaries — REQUIRED; export the line it prints
-gh auth setup-git                              # git push credentials — SEPARATE from gh auth (#2942)
 gh auth status                                  # must include the 'project' scope (board access)
-bash scripts/flow/claim.sh smoke               # preflight: prove origin accepts refs/claims/* (see below)
-                                               #   (bootstrap now runs this probe itself and reports
-                                               #    git-push: VERIFIED / FAILED / UNMEASURED, #3369)
+```
+
+**git push credentials and the `refs/claims/*` preflight are no longer manual steps (#3369).**
+`bootstrap-agent-machine.sh --fix-credentials` wires the credential path itself (preferring
+`gh auth setup-git`), and every bootstrap run then MEASURES push capability by performing the
+operation — it invokes `claim.sh smoke` and reports one of `git-push: VERIFIED` / `FAILED` /
+`UNMEASURED`. The two commands below are now the **fallback** when you are diagnosing by hand, not
+the primary path:
+
+```bash
+gh auth setup-git                              # fallback: wire git push credentials (SEPARATE from gh auth, #2942)
+bash scripts/flow/claim.sh smoke               # fallback: prove origin accepts refs/claims/* (see below)
+```
+
+**Cost and residual of the automatic probe.** Every bootstrap run — laptop runs included — makes two
+extra network round trips and CREATES AND DELETES a transient `refs/claims/smoke-<nonce>` ref on the
+shared origin. `claim.sh smoke` only *warns* if its cleanup delete fails, so an interrupted run can
+strand one. List and clean them:
+
+```bash
+git ls-remote origin 'refs/claims/smoke-*'
+git push origin --delete refs/claims/smoke-<nonce>
 ```
 
 ### Notification channel (ntfy) — one env var, no per-machine binary (#3119)
@@ -116,8 +134,9 @@ again.
 **Claim-ref preflight (#2665):** the cross-machine lock is a push to the `refs/claims/*` ref
 namespace on origin — `claim.sh smoke` creates, `ls-remote`s, and deletes a throwaway
 `refs/claims/smoke-<nonce>` ref to confirm the remote permits it (`SMOKE-OK` = good). This is
-**verified working on github.com/pmcfadin/cqlite** (2026-07-17). Run it **once when adopting a new
-remote or host** — a managed Git host that restricts custom ref namespaces would make the whole
+**verified working on github.com/pmcfadin/cqlite** (2026-07-17). Since #3369
+`bootstrap-agent-machine.sh` runs this probe on every invocation (that is its `git-push:` line), so
+you rarely need it by hand; run it directly **when adopting a new remote or host** — a managed Git host that restricts custom ref namespaces would make the whole
 claim mechanism unusable, and that must be caught before the fleet relies on it. **Non-unique
 hostnames:** the claim holder identity is `hostname -s`; on a fleet of cloud images/containers/cloned
 VMs that report the *same* short hostname, export a UNIQUE `CLAIM_MACHINE` per box (else two machines

--- a/docs/development/fleet-runbook.md
+++ b/docs/development/fleet-runbook.md
@@ -51,11 +51,14 @@ bash scripts/flow/claim.sh smoke               # same probe the bootstrap runs (
 
 **Cost and residual of the automatic probe.** Every bootstrap run — laptop runs included — makes two
 extra network round trips and CREATES AND DELETES a transient `refs/claims/smoke-<nonce>` ref on the
-shared origin. A remote that REFUSES the cleanup delete now FAILS the probe
-(`SMOKE-FAIL … reason=delete-rejected` → `git-push: FAILED`, #3369) rather than reporting success with
-a stderr warning — delete capability is required by the claim protocol, since `claim.sh release`
-deletes `refs/claims/issue-<N>`. A ref can still be stranded if a run is KILLED between the create and
-the delete, and by the delete-rejected case itself. **Deleting a stray `refs/claims/smoke-*` is always
+shared origin. A cleanup delete that exits nonzero now FAILS the probe
+(`SMOKE-FAIL … reason=cleanup-unverified` → `git-push: FAILED`, #3369) rather than reporting success
+with a stderr warning: delete capability is required by the claim protocol, since `claim.sh release`
+deletes `refs/claims/issue-<N>`. That verdict deliberately attributes **no cause** — one nonzero exit
+cannot tell a remote's deletion policy from a network drop — so it reports the observation and tells
+you how to check. A ref can still be stranded two ways: by that case (the delete did not succeed, so
+the ref's fate is unknown), and by a run KILLED between the create and the delete, which leaves no
+verdict at all. **Deleting a stray `refs/claims/smoke-*` is always
 safe** — it is a throwaway root commit that nothing reads, and it is NOT a claim lock (those are
 `refs/claims/issue-<N>`, never `smoke-`). List and clean them:
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1452,9 +1452,16 @@ else
       # deleted from is unusable for claims (`release` deletes refs/claims/issue-<N>), and
       # this run has stranded a ref — so it is FAILED, never VERIFIED.
       warn "git-push: FAILED ('$PUSH_PROBE_REMOTE' accepted the refs/claims/* create but REFUSED the delete — unusable for the claim protocol, and a smoke ref is now STRANDED)"
+      # NOT push_probe_fix_advice (#3369 review): that advises 'gh auth setup-git' /
+      # --fix-credentials, and a SUCCESSFUL CREATE already proves authentication worked.
+      # No credential change can move a server-side ref-deletion policy, so the generic
+      # remediation would send the operator to fix something that is not broken — the
+      # same class of defect as a health signal pointing the wrong way, which is the
+      # whole subject of this issue. Two lines, inline, naming the actual remedy.
+      info "cause:  the create AUTHENTICATED fine — this is $PUSH_PROBE_REMOTE's ref-deletion policy, NOT a credential fault"
+      info "fix:    permit deletion of refs/claims/* on $PUSH_PROBE_REMOTE — 'claim.sh release' deletes refs/claims/issue-<N>, so the claim protocol cannot run there until it is allowed"
       info "list strays:  git ls-remote $PUSH_PROBE_REMOTE 'refs/claims/smoke-*'"
       info "delete one:   git push $PUSH_PROBE_REMOTE --delete refs/claims/smoke-<nonce>   (always safe — it is not a claim lock)"
-      push_probe_fix_advice
     elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL.*reason=commit-build'; then
       # A LOCAL failure building the throwaway claim commit: the push never happened,
       # so nothing was learned about push capability.

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1219,6 +1219,11 @@ git_env_token_helper_active() {
 # git_origin_host <url> — host of an http(s) origin ("" for any other form). The
 # path is stripped FIRST so an '@' inside the path can never be mistaken for the
 # user[:password]@ prefix.
+#
+# The userinfo is stripped at the LAST '@', not the first (issue #3369 review). That is
+# where git itself splits an authority, and it matters here because this value is PRINTED:
+# with `#*@`, a URL whose password contains an '@' (e.g. `https://u:p@ss@host/…`) left the
+# tail of the password in the "host" and put a credential fragment into onboarding logs.
 git_origin_host() {
   local url="$1" rest hostport
   case "$url" in
@@ -1227,7 +1232,7 @@ git_origin_host() {
     *) return 0 ;;
   esac
   hostport="${rest%%/*}"
-  printf '%s' "${hostport#*@}"
+  printf '%s' "${hostport##*@}"
 }
 
 # ---- the ONE remote this whole section is about (issue #3369 review) ----
@@ -1526,7 +1531,7 @@ push_probe_fix_advice() {
   # `other`. Three affirmative arms, one per protocol class; nothing falls through into
   # advice written for a different transport.
   if [ "$GIT_ORIGIN_KIND" = ssh ]; then
-    info "fix:    this is an SSH remote ($GIT_ORIGIN_URL) — git authenticates with your SSH KEY, not a credential helper"
+    info "fix:    remote '$PUSH_PROBE_REMOTE' is an SSH remote — git authenticates with your SSH KEY, not a credential helper"
     info "        check the key:  ssh -T git@<host>   and that it is loaded:  ssh-add -l"
     info "        'gh auth setup-git' does NOT apply here — it configures https credentials only"
   elif [ "$GIT_ORIGIN_KIND" = https ]; then
@@ -1535,10 +1540,19 @@ push_probe_fix_advice() {
     info "        if a helper is ALREADY wired, the token may authenticate yet lack WRITE access —"
     info "        check the scopes reported in the 'gh auth + board access' section above (contents:write / repo)"
   else
-    info "fix:    the remote is a '$GIT_ORIGIN_KIND' remote ($GIT_ORIGIN_URL) — neither https nor SSH, so a git"
+    info "fix:    remote '$PUSH_PROBE_REMOTE' is a '$GIT_ORIGIN_KIND' remote — neither https nor SSH, so a git"
     info "        credential helper may not apply at all; check that transport's own access path"
     info "        ('gh auth setup-git' configures https credentials only, and would not affect this remote)"
   fi
+  # THE REMOTE URL IS NEVER PRINTED (issue #3369 review). Both non-https arms used to
+  # print $GIT_ORIGIN_URL verbatim, and a remote URL can carry `https://user:token@host/…`
+  # — while this script's output is persisted in onboarding logs, so those two lines wrote
+  # a live credential into a log file. §3b already treats remote URLs as secret-bearing
+  # (it classifies push stderr rather than echoing it); these sites had diverged from it.
+  # What identifies the subject unambiguously is the remote NAME plus the protocol class,
+  # both of which are printed above; the operator can read the URL locally.
+  info "        (the URL is deliberately NOT printed here — it can embed a credential and this output is logged;"
+  info "         read it locally with:  git -C $REPO_ROOT remote get-url --push $PUSH_PROBE_REMOTE)"
   info "verify by hand:  bash scripts/flow/claim.sh smoke"
 }
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -47,7 +47,7 @@
 #      The token is never written to disk.
 #      It then measures git PUSH CAPABILITY (issue #3369) by performing THE
 #      OPERATION — `scripts/flow/claim.sh smoke` creates, reads back and deletes a
-#      throwaway refs/claims/smoke-<nonce> ref on the origin — because every check
+#      throwaway refs/claims/smoke-<commit-sha> ref on the origin — because every check
 #      before it is evidence about CONFIGURATION, not about the operation: the box
 #      that motivated #3369 passed `gh auth status` AND `git ls-remote origin HEAD`
 #      and still failed every claim push. The verdict is THREE-valued and prints one
@@ -1361,7 +1361,7 @@ fi
 # neither is a read.
 #
 # So the verdict below comes from performing THE OPERATION: create + read back +
-# delete a throwaway `refs/claims/smoke-<nonce>` ref. It DELEGATES to
+# delete a throwaway `refs/claims/smoke-<commit-sha>` ref. It DELEGATES to
 # `scripts/flow/claim.sh smoke`, the repo's existing sanctioned push probe — which
 # pushes the same ref namespace the claim protocol uses, already classifies an auth
 # fault (`reason=auth`) apart from a namespace refusal, and always deletes the ref it
@@ -1387,7 +1387,7 @@ fi
 # means performing it:
 #   - two network round trips beyond the reachability read (the create push and the
 #     cleanup delete), plus one `ls-remote`;
-#   - a TRANSIENT `refs/claims/smoke-<nonce>` ref CREATED AND DELETED on the SHARED
+#   - a TRANSIENT `refs/claims/smoke-<commit-sha>` ref CREATED AND DELETED on the SHARED
 #     origin. claim.sh's cmd_smoke describes itself as a "ONE-TIME preflight ... NOT
 #     part of the hermetic test suite" because it mutates the real remote; invoking it
 #     here makes that mutation routine, which is accepted deliberately: making the
@@ -1400,7 +1400,7 @@ fi
 # the origin — nothing can close that window from inside the probe. So the cleanup
 # commands stay documented:
 #   git ls-remote origin 'refs/claims/smoke-*'
-#   git push origin --delete refs/claims/smoke-<nonce>
+#   git push origin --delete refs/claims/smoke-<commit-sha>
 # PUSH_PROBE_REMOTE is resolved ONCE above §3b — the credential half and this probe MUST
 # address the same remote (see the note there).
 CLAIM_SH="$REPO_ROOT/scripts/flow/claim.sh"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1418,17 +1418,33 @@ else
     push_probe_out=$(cd "$REPO_ROOT" && bounded "$PUSH_PROBE_BOUND" env GIT_TERMINAL_PROMPT=0 \
       GIT_ASKPASS=cqlite-bootstrap-no-askpass SSH_ASKPASS=cqlite-bootstrap-no-askpass \
       bash "$CLAIM_SH" smoke 2>&1) || push_probe_rc=$?
-    if printf '%s\n' "$push_probe_out" | grep -q 'SMOKE-OK'; then
-      # The one affirmative branch: the ref was created on the remote AND read back.
+    # Every match below is ANCHORED on `^CLAIM: ` — claim.sh's `emit` prefix — and the
+    # affirmative branch ALSO requires rc 0 (#3369). Unanchored, the verdict is decided
+    # from a stream that carries claim.sh's own control tokens AND arbitrary payload
+    # (remediation prose, an echoed command, a SMOKE-FAIL message that quotes another
+    # verdict), so a data line could pose as the verdict — the control/data-in-one-channel
+    # hazard CLAUDE.md documents. And a verdict token alone is a TEXT PROXY for a process
+    # status: requiring both means a claim.sh that dies after printing cannot pass.
+    if [ "$push_probe_rc" -eq 0 ] && printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-OK'; then
+      # The one affirmative branch: the ref was created on the remote, read back, AND
+      # deleted — all three, because claim.sh now fails the delete rather than warning.
       ok "git-push: VERIFIED (refs/claims/* create+ls-remote+delete on '$PUSH_PROBE_REMOTE') — the claim protocol can run on this machine"
-    elif printf '%s\n' "$push_probe_out" | grep -q 'SMOKE-FAIL.*reason=auth'; then
+    elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL.*reason=auth'; then
       warn "git-push: FAILED (git cannot AUTHENTICATE the refs/claims/* push to '$PUSH_PROBE_REMOTE' — an authenticated 'gh' does NOT authenticate git)"
       push_probe_fix_advice
-    elif printf '%s\n' "$push_probe_out" | grep -q 'SMOKE-FAIL.*reason=commit-build'; then
+    elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL.*reason=delete-rejected'; then
+      # Create+read-back worked and the DELETE was refused. A namespace that cannot be
+      # deleted from is unusable for claims (`release` deletes refs/claims/issue-<N>), and
+      # this run has stranded a ref — so it is FAILED, never VERIFIED.
+      warn "git-push: FAILED ('$PUSH_PROBE_REMOTE' accepted the refs/claims/* create but REFUSED the delete — unusable for the claim protocol, and a smoke ref is now STRANDED)"
+      info "list strays:  git ls-remote $PUSH_PROBE_REMOTE 'refs/claims/smoke-*'"
+      info "delete one:   git push $PUSH_PROBE_REMOTE --delete refs/claims/smoke-<nonce>   (always safe — it is not a claim lock)"
+      push_probe_fix_advice
+    elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL.*reason=commit-build'; then
       # A LOCAL failure building the throwaway claim commit: the push never happened,
       # so nothing was learned about push capability.
       warn "git-push: UNMEASURED (the throwaway claim commit could not be built locally — the push was never attempted)"
-    elif printf '%s\n' "$push_probe_out" | grep -q 'SMOKE-FAIL'; then
+    elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL'; then
       warn "git-push: FAILED ('$PUSH_PROBE_REMOTE' rejected the refs/claims/* push — does the remote permit that ref namespace?)"
       push_probe_fix_advice
     elif [ "$push_probe_rc" = 124 ] || [ "$push_probe_rc" = 137 ]; then

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -134,9 +134,20 @@ have() { command -v "$1" >/dev/null 2>&1; }
 TIMEOUT_BIN="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
 # bounded <secs> <cmd...> — run <cmd...> under the resolved timeout binary if there is
 # one, else run it directly. Use `env VAR=... cmd` when the call needs env prefixes.
+#
+# --kill-after IS THE BOUND (#3369 review). Plain `timeout <secs>` sends SIGTERM and then
+# WAITS: a child that traps or ignores SIGTERM — git, ssh, a Git Credential Manager, a
+# credential helper — runs on indefinitely, so the advertised bound bounds nothing.
+# Measured: `timeout 3` on a TERM-ignoring child returned after 30s (rc 124); with
+# `--kill-after=2` it returned after 5s (rc 137). This is boot-path code where a hang is
+# the worst outcome, and this change newly routes a NETWORK PUSH through here. 5s is
+# ample grace for a well-behaved child to finish its own cleanup. Both `timeout` and
+# `gtimeout` accept the flag, and the degrade-visibly-when-neither-exists path below is
+# unchanged.
+BOUNDED_KILL_GRACE=5
 bounded() {
   local secs="$1"; shift
-  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" "$secs" "$@"; else "$@"; fi
+  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" --kill-after="$BOUNDED_KILL_GRACE" "$secs" "$@"; else "$@"; fi
 }
 ok()   { printf '  \033[32m[ok]\033[0m   %s\n' "$1"; }
 warn() { printf '  \033[33m[warn]\033[0m %s\n' "$1"; WARNINGS=$((WARNINGS + 1)); }
@@ -1472,6 +1483,9 @@ else
         info "$push_probe_line"
       done
     elif [ "$push_probe_rc" = 124 ] || [ "$push_probe_rc" = 137 ]; then
+      # 124 = SIGTERM'd at the bound; 137 = it ignored SIGTERM and `bounded`'s
+      # --kill-after escalated to SIGKILL. 137 was UNREACHABLE until that flag was added
+      # (#3369 review): the code anticipated an outcome the wrapper could not produce.
       warn "git-push: UNMEASURED (the probe exceeded its ${PUSH_PROBE_BOUND}s bound and was killed — push capability is UNKNOWN, not ok)"
     else
       warn "git-push: UNMEASURED (scripts/flow/claim.sh smoke produced no SMOKE-OK/SMOKE-FAIL verdict, rc=$push_probe_rc — push capability is UNKNOWN, not ok)"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1204,33 +1204,50 @@ elif git_cred_probe "$GIT_ORIGIN_HOST"; then
     info "      fail every push. For unattended workers prefer:  gh auth setup-git"
   fi
 else
-  warn "git push has NO credentials for $GIT_ORIGIN_HOST — an authenticated 'gh' does NOT authenticate git"
-  info "symptom: every push fails with  fatal: could not read Username for 'https://$GIT_ORIGIN_HOST'"
-  info "impact: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — the claim protocol does not work"
-  info "fix:    gh auth setup-git    (preferred; wires gh as git's credential helper)"
-  info "        or re-run with --fix-credentials (or --yes) to configure a helper that reads \$GH_TOKEN at call time"
+  # UNWIRED AS FOUND. Whether that is a WARNING depends on the machine's state when this
+  # section ENDS, not on its state when the section began (issue #3369). The first cut
+  # warned here, before the repair below, and nothing could retract it: with
+  # --fix-credentials the run then REPAIRED the box, the push probe reported VERIFIED,
+  # and the summary still withheld "All checks green." and --strict still exited 1 — so
+  # the AMI onboarder's verify FAILED on exactly the box it had just fixed, which is the
+  # whole scenario #3369 exists for. Every test stayed green while it did.
+  #
+  # So the diagnosis is gathered first, ONE verdict is emitted last, and it reports the
+  # FINAL state. WARNINGS is never decremented: a counter that can go down would let an
+  # unrelated later success cancel a genuine earlier fault. The fix is not to retract a
+  # warning — it is not to emit one until the answer is known.
+  cred_diag() {
+    info "symptom: every push fails with  fatal: could not read Username for 'https://$GIT_ORIGIN_HOST'"
+    info "impact: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — the claim protocol does not work"
+    info "fix:    gh auth setup-git    (preferred; wires gh as git's credential helper)"
+    info "        or re-run with --fix-credentials (or --yes) to configure a helper that reads \$GH_TOKEN at call time"
+  }
   # --fix-credentials wires ONLY this section, leaving every other check read-only
   # (issue #3369): the AMI onboarder's verify step needs the credential path wired
   # after token injection, and turning a VERIFICATION step into a full toolchain
   # installer (which --yes also is) would be a far larger change than that needs.
   if [ "$AUTO_YES" = 1 ] || [ "$FIX_CREDENTIALS" = 1 ]; then
+    info "git push has NO credentials for $GIT_ORIGIN_HOST yet — an authenticated 'gh' does NOT authenticate git; attempting to configure one"
     cred_fixed=0
+    cred_how=""
     # Preferred form: let gh wire itself in. Verified by RE-PROBING — on the box
     # that motivated #2942 the gh credential path was precisely what was not wired,
-    # so "the command exited 0" is not evidence.
+    # so "the command exited 0" is not evidence. Every branch below is likewise
+    # confirmed by a re-probe, never by the repair command's own exit status.
     if have gh && gh auth status >/dev/null 2>&1; then
       info "configuring: gh auth setup-git"
       if gh auth setup-git >/dev/null 2>&1 && git_cred_probe "$GIT_ORIGIN_HOST"; then
-        ok "git credentials configured via 'gh auth setup-git' (no secret written to disk)"
-        cred_fixed=1
+        cred_fixed=1; cred_how="'gh auth setup-git'"
       else
         info "'gh auth setup-git' did not yield a usable credential — falling back to the \$GH_TOKEN helper"
       fi
     fi
     if [ "$cred_fixed" = 0 ]; then
       if [ -z "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]; then
-        warn "cannot auto-configure: neither GH_TOKEN nor GITHUB_TOKEN is set in this environment"
-        info "export GH_TOKEN=<token>, then re-run:  bash scripts/bootstrap-agent-machine.sh --yes"
+        # `info`, not `warn`: the single verdict below owns the warning, so a failed
+        # repair counts ONCE rather than twice.
+        info "cannot auto-configure: neither GH_TOKEN nor GITHUB_TOKEN is set in this environment"
+        info "export GH_TOKEN=<token>, then re-run:  bash scripts/bootstrap-agent-machine.sh --fix-credentials"
       else
         # The value written is a shell snippet that DEREFERENCES $GH_TOKEN when git
         # asks — the token itself never lands on disk, so rotating it needs no
@@ -1250,18 +1267,29 @@ else
         # key we write — a copy scoped to some other host is unrelated and must not
         # suppress this one.
         if git config --global --get-all "$cred_key" 2>/dev/null | grep -qF 'x-access-token'; then
-          warn "a \$GH_TOKEN-style helper is ALREADY configured for $GIT_ORIGIN_HOST yet the probe still fails — check that GH_TOKEN is set, valid and unexpired (not re-adding it)"
+          info "a \$GH_TOKEN-style helper is ALREADY configured for $GIT_ORIGIN_HOST yet the probe still fails — check that GH_TOKEN is set, valid and unexpired (not re-adding it)"
         elif git config --global --add "$cred_key" "$GIT_CRED_HELPER" 2>/dev/null \
            && git_cred_probe "$GIT_ORIGIN_HOST"; then
-          ok "git credentials configured for $GIT_ORIGIN_HOST via a \$GH_TOKEN-dereferencing helper (no secret written to disk)"
-          info "this helper reads \$GH_TOKEN from the ENVIRONMENT — an unattended worker (systemd/cron)"
-          info "started without GH_TOKEN exported will still fail every push; prefer 'gh auth setup-git' there"
+          cred_fixed=1; cred_how="a \$GH_TOKEN-dereferencing helper"
         else
-          warn "could not configure a working git credential helper — fix manually: gh auth setup-git"
+          info "could not configure a working git credential helper"
         fi
       fi
     fi
+    # THE SINGLE VERDICT, on the state the machine is in NOW.
+    if [ "$cred_fixed" = 1 ]; then
+      ok "git credentials WIRED BY THIS RUN via $cred_how for $GIT_ORIGIN_HOST (confirmed by re-probe; no secret written to disk)"
+      if git_env_token_helper_active; then
+        info "this helper reads \$GH_TOKEN from the ENVIRONMENT — an unattended worker (systemd/cron)"
+        info "started without GH_TOKEN exported will still fail every push; prefer 'gh auth setup-git' there"
+      fi
+    else
+      warn "git push has NO credentials for $GIT_ORIGIN_HOST and this run could NOT configure any — an authenticated 'gh' does NOT authenticate git"
+      cred_diag
+    fi
   else
+    warn "git push has NO credentials for $GIT_ORIGIN_HOST — an authenticated 'gh' does NOT authenticate git"
+    cred_diag
     info "(re-run with --fix-credentials to wire credentials only, or --yes to also install)"
   fi
 fi

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1399,12 +1399,33 @@ git_push_probe_stderr_is_auth() {
   return 1
 }
 
-# push_probe_fix_advice — the remediation both non-verified verdicts print.
+# push_probe_fix_advice — the remediation the AUTH verdicts print.
+#
+# PROTOCOL-AWARE, keyed on GIT_ORIGIN_KIND (#3369 review). That value is derived from the
+# REMOTE URL in §3b — authoritative by construction — never from git's error text, so
+# this adds no classification and no new failure cause. It matters because an SSH remote
+# authenticates with a KEY: `gh auth setup-git` wires an https credential helper and
+# cannot affect it, so advising it there sends the operator to fix something that is not
+# even in the path. This change routed SSH origins into the push probe for the first
+# time, which is what made that reachable.
+#
+# The scope line in the https branch STATES A POSSIBILITY rather than detecting one: a
+# token can authenticate perfectly and still lack `contents:write`, which no credential
+# rewiring fixes. We cannot tell that state from here and do not pretend to — the line
+# points at the scope report the board-access section already prints.
 push_probe_fix_advice() {
   info "impact: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — a lane cannot even START"
-  info "fix:    gh auth setup-git    (preferred; wires gh as git's credential helper)"
-  info "        then re-run:  bash scripts/bootstrap-agent-machine.sh --fix-credentials"
-  info "        verify by hand:  bash scripts/flow/claim.sh smoke"
+  if [ "$GIT_ORIGIN_KIND" = ssh ]; then
+    info "fix:    this is an SSH remote ($GIT_ORIGIN_URL) — git authenticates with your SSH KEY, not a credential helper"
+    info "        check the key:  ssh -T git@<host>   and that it is loaded:  ssh-add -l"
+    info "        'gh auth setup-git' does NOT apply here — it configures https credentials only"
+  else
+    info "fix:    gh auth setup-git    (preferred; wires gh as git's credential helper)"
+    info "        then re-run:  bash scripts/bootstrap-agent-machine.sh --fix-credentials"
+    info "        if a helper is ALREADY wired, the token may authenticate yet lack WRITE access —"
+    info "        check the scopes reported in the 'gh auth + board access' section above (contents:write / repo)"
+  fi
+  info "verify by hand:  bash scripts/flow/claim.sh smoke"
 }
 
 hdr "git PUSH capability (issue #3369)"

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1447,28 +1447,27 @@ else
     elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL.*reason=auth'; then
       warn "git-push: FAILED (git cannot AUTHENTICATE the refs/claims/* push to '$PUSH_PROBE_REMOTE' — an authenticated 'gh' does NOT authenticate git)"
       push_probe_fix_advice
-    elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL.*reason=delete-rejected'; then
-      # Create+read-back worked and the DELETE was refused. A namespace that cannot be
-      # deleted from is unusable for claims (`release` deletes refs/claims/issue-<N>), and
-      # this run has stranded a ref — so it is FAILED, never VERIFIED.
-      warn "git-push: FAILED ('$PUSH_PROBE_REMOTE' accepted the refs/claims/* create but REFUSED the delete — unusable for the claim protocol, and a smoke ref is now STRANDED)"
-      # NOT push_probe_fix_advice (#3369 review): that advises 'gh auth setup-git' /
-      # --fix-credentials, and a SUCCESSFUL CREATE already proves authentication worked.
-      # No credential change can move a server-side ref-deletion policy, so the generic
-      # remediation would send the operator to fix something that is not broken — the
-      # same class of defect as a health signal pointing the wrong way, which is the
-      # whole subject of this issue. Two lines, inline, naming the actual remedy.
-      info "cause:  the create AUTHENTICATED fine — this is $PUSH_PROBE_REMOTE's ref-deletion policy, NOT a credential fault"
-      info "fix:    permit deletion of refs/claims/* on $PUSH_PROBE_REMOTE — 'claim.sh release' deletes refs/claims/issue-<N>, so the claim protocol cannot run there until it is allowed"
-      info "list strays:  git ls-remote $PUSH_PROBE_REMOTE 'refs/claims/smoke-*'"
-      info "delete one:   git push $PUSH_PROBE_REMOTE --delete refs/claims/smoke-<nonce>   (always safe — it is not a claim lock)"
     elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL.*reason=commit-build'; then
       # A LOCAL failure building the throwaway claim commit: the push never happened,
       # so nothing was learned about push capability.
       warn "git-push: UNMEASURED (the throwaway claim commit could not be built locally — the push was never attempted)"
     elif printf '%s\n' "$push_probe_out" | grep -q '^CLAIM: SMOKE-FAIL'; then
-      warn "git-push: FAILED ('$PUSH_PROBE_REMOTE' rejected the refs/claims/* push — does the remote permit that ref namespace?)"
-      push_probe_fix_advice
+      # THE CATCH-ALL QUOTES; IT DOES NOT RE-CLASSIFY (#3369 review). It used to re-word
+      # every unrecognised reason code as "rejected the push — does the remote permit that
+      # ref namespace?", which mis-attributed `ls-remote-mismatch` AND discarded the
+      # cleanup detail claim.sh had just been fixed to report: a diagnostic improved in
+      # one file, thrown away by its consumer one file over. Quoting claim.sh's own
+      # verdict line means no reason code — present or FUTURE — can lose detail or be
+      # given a cause bootstrap cannot know, and it is why the specific branches whose
+      # only job was re-wording are gone. Dedicated branches survive ONLY where bootstrap
+      # says something claim.sh cannot: `reason=auth` (the #2942 credential remediation)
+      # and `reason=commit-build` (a LOCAL failure, so UNMEASURED rather than FAILED).
+      # No credential advice here: the cause is unknown, and guessing it wrong is what
+      # sent an operator after `gh auth setup-git` for a fault credentials cannot fix.
+      warn "git-push: FAILED — the claim protocol cannot run on this machine until this is resolved. claim.sh reports:"
+      printf '%s\n' "$push_probe_out" | grep '^CLAIM: SMOKE-FAIL' | while IFS= read -r push_probe_line; do
+        info "$push_probe_line"
+      done
     elif [ "$push_probe_rc" = 124 ] || [ "$push_probe_rc" = 137 ]; then
       warn "git-push: UNMEASURED (the probe exceeded its ${PUSH_PROBE_BOUND}s bound and was killed — push capability is UNKNOWN, not ok)"
     else

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1500,6 +1500,17 @@ elif [ "$PUSH_PROBE_URL_COUNT" -gt 1 ]; then
   # so the machine is never certified on the strength of it.
   warn "git-push: UNMEASURED (remote '$PUSH_PROBE_REMOTE' has $PUSH_PROBE_URL_COUNT push URLs — refusing to run a MUTATING probe against multiple destinations)"
   info "verify by hand against one destination:  CLAIM_REMOTE=<single-url-remote> bash scripts/flow/claim.sh smoke"
+elif [ "$TIMEOUT_KILL_AFTER" != 1 ] && [ -n "$TIMEOUT_BIN" ]; then
+  # IF YOU CANNOT BOUND THE MUTATION, DO NOT MUTATE (#3369 review). `bounded` degrades to
+  # SIGTERM-only when the resolved timeout lacks --kill-after, which keeps the NON-mutating
+  # probes working — but this one performs a real network PUSH, and a SIGTERM-only bound
+  # provably waits forever on a child that ignores SIGTERM (measured: 3s bound, 30s wait).
+  # Hanging the launcher is worse than a red verdict, so the mutation is refused. Note the
+  # fall-through to the probe below therefore requires the AFFIRMATIVE
+  # TIMEOUT_KILL_AFTER=1 — a hard bound is a precondition of pushing, not a nice-to-have.
+  warn "git-push: UNMEASURED (the resolved timeout cannot hard-kill (no --kill-after), so a wedged child could hang this run — refusing to perform a MUTATING push it cannot bound)"
+  info "install GNU coreutils (macOS: brew install coreutils) so the probe can be hard-bounded, then re-run"
+  info "or check by hand where a hang is survivable:  bash scripts/flow/claim.sh smoke"
 elif [ -z "$TIMEOUT_BIN" ]; then
   # Refuse rather than run unbounded: an unbounded network push during boot can wedge
   # the onboarder indefinitely, and reporting `ok` for a probe we declined to run is

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1450,15 +1450,26 @@ git_push_probe_stderr_is_auth() {
 # points at the scope report the board-access section already prints.
 push_probe_fix_advice() {
   info "impact: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — a lane cannot even START"
+  # KEYED ON THE AFFIRMATIVE VALUE, never on `!= ssh` (#3369 review). The first cut said
+  # "not SSH ⇒ give https credential advice", so `file://`, a bare local path and any
+  # custom protocol were handed `gh auth setup-git` — guidance that cannot apply to them.
+  # That is this change's own central rule broken by the change: a permissive branch must
+  # test for the value it means, and GIT_ORIGIN_KIND already computes an explicit
+  # `other`. Three affirmative arms, one per protocol class; nothing falls through into
+  # advice written for a different transport.
   if [ "$GIT_ORIGIN_KIND" = ssh ]; then
     info "fix:    this is an SSH remote ($GIT_ORIGIN_URL) — git authenticates with your SSH KEY, not a credential helper"
     info "        check the key:  ssh -T git@<host>   and that it is loaded:  ssh-add -l"
     info "        'gh auth setup-git' does NOT apply here — it configures https credentials only"
-  else
+  elif [ "$GIT_ORIGIN_KIND" = https ]; then
     info "fix:    gh auth setup-git    (preferred; wires gh as git's credential helper)"
     info "        then re-run:  bash scripts/bootstrap-agent-machine.sh --fix-credentials"
     info "        if a helper is ALREADY wired, the token may authenticate yet lack WRITE access —"
     info "        check the scopes reported in the 'gh auth + board access' section above (contents:write / repo)"
+  else
+    info "fix:    the remote is a '$GIT_ORIGIN_KIND' remote ($GIT_ORIGIN_URL) — neither https nor SSH, so a git"
+    info "        credential helper may not apply at all; check that transport's own access path"
+    info "        ('gh auth setup-git' configures https credentials only, and would not affect this remote)"
   fi
   info "verify by hand:  bash scripts/flow/claim.sh smoke"
 }

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1155,14 +1155,28 @@ git_origin_host() {
   printf '%s' "${hostport#*@}"
 }
 
+# ---- the ONE remote this whole section is about (issue #3369 review) ----
+# Resolved ONCE, and every consumer below — the credential probe, the repair, and the
+# push probe — reads THIS value. The first cut derived credentials from `origin`'s FETCH
+# url while the push probe pushed to `${CLAIM_REMOTE:-origin}`, so with CLAIM_REMOTE set
+# (test_claim_lock.sh drives claim.sh exactly that way) or an `origin` carrying a
+# `pushurl`, the credential half wired and blessed host A while the probe pushed to host
+# B — a verdict about a host that is not the subject, and a second route to blocker 1's
+# symptom (`--fix-credentials --strict` failing on a validly configured box).
+#
+# `get-url --push` is deliberately ONE call for both cases: it returns the `pushurl`
+# when one is configured and falls back to the fetch url when none is. A second host
+# variable is what created the defect, so there is exactly one.
+PUSH_PROBE_REMOTE="${CLAIM_REMOTE:-origin}"   # the remote claim.sh itself will use
+
 hdr "git push credentials (issue #2942)"
-# Classify origin BEFORE probing: only an http(s) remote uses a credential helper.
+# Classify the remote BEFORE probing: only an http(s) remote uses a credential helper.
 # An SSH remote authenticates with a key (a helper is irrelevant), and a local/file
 # remote needs no credential at all — mislabeling either would send an operator
 # after the wrong fix, which is the exact failure mode this whole change exists to end.
 GIT_ORIGIN_URL=""; GIT_ORIGIN_HOST=""; GIT_ORIGIN_KIND=none
 if have git; then
-  GIT_ORIGIN_URL=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
+  GIT_ORIGIN_URL=$(git -C "$REPO_ROOT" remote get-url --push "$PUSH_PROBE_REMOTE" 2>/dev/null || true)
   case "$GIT_ORIGIN_URL" in
     "")                    GIT_ORIGIN_KIND=none ;;
     https://*|http://*)    GIT_ORIGIN_KIND=https; GIT_ORIGIN_HOST=$(git_origin_host "$GIT_ORIGIN_URL") ;;
@@ -1176,17 +1190,17 @@ fi
 if ! have git; then
   warn "git NOT installed — the claim protocol pushes with plain git"
 elif [ "$GIT_ORIGIN_KIND" = none ]; then
-  warn "no 'origin' remote in $REPO_ROOT — cannot check push credentials"
+  warn "no '$PUSH_PROBE_REMOTE' remote in $REPO_ROOT — cannot check push credentials"
 elif [ "$GIT_ORIGIN_KIND" = ssh ]; then
   # SSH (git@host:… / ssh://…): git authenticates with your SSH key, and an https
   # credential helper is irrelevant. Report it and configure nothing.
   # NOT an exemption from the push probe below: an SSH origin is push-probed like any
   # other (the smoke push works over ssh), so a machine with no usable key still gets a
   # FAILED verdict rather than a green "no helper needed" (issue #3369).
-  ok "origin is an SSH remote — git push authenticates via SSH keys, not a credential helper (no helper needed)"
+  ok "'$PUSH_PROBE_REMOTE' is an SSH remote — git push authenticates via SSH keys, not a credential helper (no helper needed)"
   info "verify separately if pushes fail:  ssh -T git@github.com"
 elif [ "$GIT_ORIGIN_KIND" = other ]; then
-  info "origin is a '$GIT_ORIGIN_KIND' remote (neither http(s) nor SSH) — no credential helper applies"
+  info "'$PUSH_PROBE_REMOTE' is a '$GIT_ORIGIN_KIND' remote (neither http(s) nor SSH) — no credential helper applies"
 elif git_cred_probe "$GIT_ORIGIN_HOST"; then
   # Says ONLY what `git credential fill` proved: a configured helper answered. It does
   # NOT say a push would succeed — the previous wording ("git push credentials resolve
@@ -1346,7 +1360,8 @@ fi
 # here (cmd_smoke's hot path is out of scope for #3369). List and clean them with:
 #   git ls-remote origin 'refs/claims/smoke-*'
 #   git push origin --delete refs/claims/smoke-<nonce>
-PUSH_PROBE_REMOTE="${CLAIM_REMOTE:-origin}"   # the remote claim.sh itself will use
+# PUSH_PROBE_REMOTE is resolved ONCE above §3b — the credential half and this probe MUST
+# address the same remote (see the note there).
 CLAIM_SH="$REPO_ROOT/scripts/flow/claim.sh"
 PUSH_PROBE_BOUND=60   # 3 network round trips (push, ls-remote, delete) + slack
 

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1355,9 +1355,12 @@ fi
 #     here makes that mutation routine, which is accepted deliberately: making the
 #     measurement opt-in would restore "a read by default", the exact defect #3369
 #     exists to remove.
-# RESIDUAL: cmd_smoke only WARNS if its cleanup delete fails, so an interrupted or
-# partially-failing run can strand a `refs/claims/smoke-*` ref on the origin. Not fixed
-# here (cmd_smoke's hot path is out of scope for #3369). List and clean them with:
+# RESIDUAL, stated precisely because the two halves differ. An OBSERVED cleanup failure
+# now FAILS the probe (`reason=cleanup-unverified`) instead of passing with a stderr
+# warning, so it cannot pass silently. But a run KILLED between the create and the
+# delete produces NO verdict at all and can still leave a `refs/claims/smoke-*` ref on
+# the origin — nothing can close that window from inside the probe. So the cleanup
+# commands stay documented:
 #   git ls-remote origin 'refs/claims/smoke-*'
 #   git push origin --delete refs/claims/smoke-<nonce>
 # PUSH_PROBE_REMOTE is resolved ONCE above §3b — the credential half and this probe MUST

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1167,6 +1167,30 @@ git_local_helper_configured() {
   git -C "$REPO_ROOT" config --local --get-regexp '^credential\..*helper$' >/dev/null 2>&1
 }
 
+# gh_auth_confirms_host <host> — 0 iff `gh` AFFIRMS that it is authenticated to THAT
+# EXACT host. Used for ONE purpose (issue #3369 review): to gate the fallback repair
+# below, which installs a helper that hands $GH_TOKEN — a real GitHub credential — to
+# whatever host the repair is scoped to.
+#
+# The host is resolved from LOCAL GIT CONFIG (`git remote get-url --push`), so a typo, a
+# leftover fork/mirror pushurl or a stale `insteadOf` names a host nobody intended — and
+# .agent-ami/profile.yaml runs this script with --fix-credentials at every onboard, so the
+# accident path is automatic. An invoker who controls the box is out of the threat model;
+# a MISCONFIGURED REMOTE is not, and by this repo's triage rule ("can be bypassed BY
+# ACCIDENT ⇒ defect") that makes it in scope.
+#
+# `gh` is the AUTHORITY and is asked directly. Nothing here allowlists hosts or pattern-
+# matches the URL: trust inferred from a string is the guessing shape this whole change
+# exists to remove. And the branch is keyed on the AFFIRMATIVE answer — an absent gh, an
+# unbounded-call failure, a network hiccup and a genuine "not logged in" all land on the
+# same NON-confirming side, because an unmeasured confirmation is not a confirmation.
+gh_auth_confirms_host() {
+  local host="$1"
+  [ -n "$host" ] || return 1
+  have gh || return 1
+  bounded 20 gh auth status --hostname "$host" >/dev/null 2>&1
+}
+
 # git_env_token_helper_active — 0 iff a configured helper (any scope, any host key) is
 # an ENV-DEREFERENCING one. Used to attach the "$GH_TOKEN must be exported" caveat to
 # an otherwise-green verdict. Both markers must appear in the SAME line (--get-regexp
@@ -1282,6 +1306,10 @@ else
     info "git push has NO credentials for $GIT_ORIGIN_HOST yet — an authenticated 'gh' does NOT authenticate git; attempting to configure one"
     cred_fixed=0
     cred_how=""
+    # Set only by the refusal branch below, so the ONE verdict can name what happened
+    # without a second warning. It is a state of the FINAL machine (no credential was
+    # configured, deliberately), which is what this section reports.
+    cred_refused_host=0
     # Preferred form: let gh wire itself in. Verified by RE-PROBING — on the box
     # that motivated #2942 the gh credential path was precisely what was not wired,
     # so "the command exited 0" is not evidence. Every branch below is likewise
@@ -1300,6 +1328,17 @@ else
         # repair counts ONCE rather than twice.
         info "cannot auto-configure: neither GH_TOKEN nor GITHUB_TOKEN is set in this environment"
         info "export GH_TOKEN=<token>, then re-run:  bash scripts/bootstrap-agent-machine.sh --fix-credentials"
+      elif ! gh_auth_confirms_host "$GIT_ORIGIN_HOST"; then
+        # AFFIRMATIVE CONFIRMATION OR NO REPAIR (issue #3369 review). The fallback below
+        # would configure git to hand $GH_TOKEN to $GIT_ORIGIN_HOST, and the push probe in
+        # §3b-push then performs a real push to it — all from a host resolved out of local
+        # git config, which a typo, a leftover fork/mirror pushurl or a stale `insteadOf`
+        # can point anywhere. So the repair is gated on `gh` CONFIRMING authentication for
+        # that exact host, and refuses otherwise. `gh auth setup-git` above stays
+        # unconditional: it makes gh the helper and gh decides what it answers for; the
+        # dangerous path is specifically dereferencing the RAW token for an arbitrary host.
+        cred_refused_host=1
+        info "REFUSING to configure a \$GH_TOKEN-dereferencing helper for $GIT_ORIGIN_HOST: 'gh auth status --hostname $GIT_ORIGIN_HOST' did not confirm authentication for that host"
       else
         # The value written is a shell snippet that DEREFERENCES $GH_TOKEN when git
         # asks — the token itself never lands on disk, so rotating it needs no
@@ -1335,6 +1374,21 @@ else
         info "this helper reads \$GH_TOKEN from the ENVIRONMENT — an unattended worker (systemd/cron)"
         info "started without GH_TOKEN exported will still fail every push; prefer 'gh auth setup-git' there"
       fi
+    elif [ "$cred_refused_host" = 1 ]; then
+      # A DISTINCT verdict, not a second one: exactly one warning is still emitted, and it
+      # reports the final state (no credential configured) together with WHY, because the
+      # remedy differs completely from the generic "could not configure any" case below —
+      # there the operator supplies a credential; here the operator first decides whether
+      # that host should be receiving a GitHub token at all.
+      #
+      # The HOST is named; the push URL deliberately is NOT. A remote URL can embed a
+      # credential (claim.sh classifies push stderr for exactly that reason and never
+      # prints it), so echoing it here would trade one leak for another.
+      warn "git push has NO credentials for $GIT_ORIGIN_HOST and this run REFUSED to configure any: 'gh' does not report authentication for that host, so a token will NOT be configured for it"
+      info "why: the fallback helper hands \$GH_TOKEN — a real GitHub credential — to whichever host it is scoped to, and this host came from LOCAL GIT CONFIG ('git remote get-url --push $PUSH_PROBE_REMOTE'), which a typo, a leftover fork/mirror pushurl or a stale 'insteadOf' can point anywhere"
+      info "fix (host is correct):   gh auth login --hostname $GIT_ORIGIN_HOST    then re-run with --fix-credentials"
+      info "fix (host is WRONG):     git -C $REPO_ROOT remote set-url --push $PUSH_PROBE_REMOTE <the intended url>"
+      info "impact until then: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — the claim protocol does not work"
     else
       warn "git push has NO credentials for $GIT_ORIGIN_HOST and this run could NOT configure any — an authenticated 'gh' does NOT authenticate git"
       cred_diag

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1167,28 +1167,41 @@ git_local_helper_configured() {
   git -C "$REPO_ROOT" config --local --get-regexp '^credential\..*helper$' >/dev/null 2>&1
 }
 
-# gh_auth_confirms_host <host> — 0 iff `gh` AFFIRMS that it is authenticated to THAT
-# EXACT host. Used for ONE purpose (issue #3369 review): to gate the fallback repair
-# below, which installs a helper that hands $GH_TOKEN — a real GitHub credential — to
-# whatever host the repair is scoped to.
+# gh_token_is_authoritative_for_host <host> — 0 iff the ENVIRONMENT token this script
+# would install ($GH_TOKEN, else $GITHUB_TOKEN) is the very token `gh` holds FOR THAT
+# EXACT HOST. Gates the fallback repair below, which configures git to hand that token to
+# whatever host the helper is scoped to (issue #3369 review).
 #
-# The host is resolved from LOCAL GIT CONFIG (`git remote get-url --push`), so a typo, a
+# The host comes from LOCAL GIT CONFIG (`git remote get-url --push`), so a typo, a
 # leftover fork/mirror pushurl or a stale `insteadOf` names a host nobody intended — and
 # .agent-ami/profile.yaml runs this script with --fix-credentials at every onboard, so the
 # accident path is automatic. An invoker who controls the box is out of the threat model;
 # a MISCONFIGURED REMOTE is not, and by this repo's triage rule ("can be bypassed BY
 # ACCIDENT ⇒ defect") that makes it in scope.
 #
-# `gh` is the AUTHORITY and is asked directly. Nothing here allowlists hosts or pattern-
-# matches the URL: trust inferred from a string is the guessing shape this whole change
-# exists to remove. And the branch is keyed on the AFFIRMATIVE answer — an absent gh, an
-# unbounded-call failure, a network hiccup and a genuine "not logged in" all land on the
-# same NON-confirming side, because an unmeasured confirmation is not a confirmation.
-gh_auth_confirms_host() {
-  local host="$1"
+# THE PREDICATE IS TOKEN AUTHORITY, NOT A LOGIN. The first cut asked
+# `gh auth status --hostname <host>`, which answers "does gh hold SOME credential for that
+# host?" — a different fact from "is THIS token the credential for that host?". On a box
+# authenticated to both github.com and a GitHub Enterprise host, with `origin` on the
+# enterprise host, that check PASSES and the repair then hands the github.com token to the
+# enterprise host: a proxy standing in for the property, the same shape as every other
+# defect in this change. So `gh` is asked for the host's OWN token and it must MATCH.
+#
+# `gh` is the AUTHORITY and is asked directly. Nothing here allowlists hosts, and nothing
+# infers enterprise-ness (or anything else) from the hostname string. The branch is keyed
+# on the AFFIRMATIVE answer — an absent gh, a bounded-call failure, no token for that
+# host, an empty answer and a genuine mismatch all land on the same NON-confirming side,
+# because an unmeasured authority is not an authority. Neither value is ever printed,
+# logged or compared through a file: both stay in local shell variables.
+gh_token_is_authoritative_for_host() {
+  local host="$1" env_tok gh_tok
   [ -n "$host" ] || return 1
   have gh || return 1
-  bounded 20 gh auth status --hostname "$host" >/dev/null 2>&1
+  env_tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  [ -n "$env_tok" ] || return 1
+  gh_tok=$(bounded 20 gh auth token --hostname "$host" 2>/dev/null) || return 1
+  [ -n "$gh_tok" ] || return 1
+  [ "$gh_tok" = "$env_tok" ]
 }
 
 # git_env_token_helper_active — 0 iff a configured helper (any scope, any host key) is
@@ -1328,17 +1341,18 @@ else
         # repair counts ONCE rather than twice.
         info "cannot auto-configure: neither GH_TOKEN nor GITHUB_TOKEN is set in this environment"
         info "export GH_TOKEN=<token>, then re-run:  bash scripts/bootstrap-agent-machine.sh --fix-credentials"
-      elif ! gh_auth_confirms_host "$GIT_ORIGIN_HOST"; then
-        # AFFIRMATIVE CONFIRMATION OR NO REPAIR (issue #3369 review). The fallback below
-        # would configure git to hand $GH_TOKEN to $GIT_ORIGIN_HOST, and the push probe in
-        # §3b-push then performs a real push to it — all from a host resolved out of local
-        # git config, which a typo, a leftover fork/mirror pushurl or a stale `insteadOf`
-        # can point anywhere. So the repair is gated on `gh` CONFIRMING authentication for
-        # that exact host, and refuses otherwise. `gh auth setup-git` above stays
-        # unconditional: it makes gh the helper and gh decides what it answers for; the
-        # dangerous path is specifically dereferencing the RAW token for an arbitrary host.
+      elif ! gh_token_is_authoritative_for_host "$GIT_ORIGIN_HOST"; then
+        # AFFIRMATIVE AUTHORITY OR NO REPAIR (issue #3369 review). The fallback below
+        # would configure git to hand the ENVIRONMENT token to $GIT_ORIGIN_HOST, and the
+        # push probe in §3b-push then performs a real push to it — all from a host
+        # resolved out of local git config, which a typo, a leftover fork/mirror pushurl
+        # or a stale `insteadOf` can point anywhere. So the repair is gated on that token
+        # being the one `gh` holds FOR THAT HOST, and refuses otherwise.
+        # `gh auth setup-git` above stays unconditional: it makes gh the helper and gh
+        # decides what it answers for, per host. The dangerous path is specifically
+        # dereferencing a RAW token for a host that token does not belong to.
         cred_refused_host=1
-        info "REFUSING to configure a \$GH_TOKEN-dereferencing helper for $GIT_ORIGIN_HOST: 'gh auth status --hostname $GIT_ORIGIN_HOST' did not confirm authentication for that host"
+        info "REFUSING to configure a \$GH_TOKEN-dereferencing helper for $GIT_ORIGIN_HOST: 'gh auth token --hostname $GIT_ORIGIN_HOST' did not return the token this environment holds (gh may hold none for that host, or a DIFFERENT one — e.g. a github.com token on a box that also has a GitHub Enterprise host)"
       else
         # The value written is a shell snippet that DEREFERENCES $GH_TOKEN when git
         # asks — the token itself never lands on disk, so rotating it needs no
@@ -1384,9 +1398,9 @@ else
       # The HOST is named; the push URL deliberately is NOT. A remote URL can embed a
       # credential (claim.sh classifies push stderr for exactly that reason and never
       # prints it), so echoing it here would trade one leak for another.
-      warn "git push has NO credentials for $GIT_ORIGIN_HOST and this run REFUSED to configure any: 'gh' does not report authentication for that host, so a token will NOT be configured for it"
-      info "why: the fallback helper hands \$GH_TOKEN — a real GitHub credential — to whichever host it is scoped to, and this host came from LOCAL GIT CONFIG ('git remote get-url --push $PUSH_PROBE_REMOTE'), which a typo, a leftover fork/mirror pushurl or a stale 'insteadOf' can point anywhere"
-      info "fix (host is correct):   gh auth login --hostname $GIT_ORIGIN_HOST    then re-run with --fix-credentials"
+      warn "git push has NO credentials for $GIT_ORIGIN_HOST and this run REFUSED to configure any: \$GH_TOKEN is not the token 'gh' holds for that host, so a token will NOT be configured for it"
+      info "why: the fallback helper hands that token — a real credential — to whichever host it is scoped to, and this host came from LOCAL GIT CONFIG ('git remote get-url --push $PUSH_PROBE_REMOTE'), which a typo, a leftover fork/mirror pushurl or a stale 'insteadOf' can point anywhere. A login for the host is NOT enough: on a box authenticated to both github.com and a GitHub Enterprise host, the token for one must not be handed to the other"
+      info "fix (host is correct):   gh auth login --hostname $GIT_ORIGIN_HOST    then re-run with --fix-credentials (preferably WITHOUT \$GH_TOKEN set, so 'gh auth setup-git' supplies that host's own token)"
       info "fix (host is WRONG):     git -C $REPO_ROOT remote set-url --push $PUSH_PROBE_REMOTE <the intended url>"
       info "impact until then: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — the claim protocol does not work"
     else

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -41,10 +41,19 @@
 #   3b. git push CREDENTIALS (issue #2942) — separate from `gh` auth. The claim
 #      protocol (scripts/flow/claim.sh, claim-heartbeat.sh) pushes with plain git
 #      on 10+ call sites, so an authenticated gh with an unauthenticated git means
-#      the cross-machine lock does not work. Under --yes this configures a
-#      credential path scoped to the origin host, preferring `gh auth setup-git`,
-#      else a helper that dereferences $GH_TOKEN at call time. The token is never
-#      written to disk.
+#      the cross-machine lock does not work. Under --yes (or --fix-credentials) this
+#      configures a credential path scoped to the origin host, preferring
+#      `gh auth setup-git`, else a helper that dereferences $GH_TOKEN at call time.
+#      The token is never written to disk.
+#      It then measures git PUSH CAPABILITY (issue #3369) by performing THE
+#      OPERATION — `scripts/flow/claim.sh smoke` creates, reads back and deletes a
+#      throwaway refs/claims/smoke-<nonce> ref on the origin — because every check
+#      before it is evidence about CONFIGURATION, not about the operation: the box
+#      that motivated #3369 passed `gh auth status` AND `git ls-remote origin HEAD`
+#      and still failed every claim push. The verdict is THREE-valued and prints one
+#      greppable `git-push:` line — VERIFIED (affirmatively measured), FAILED, or
+#      UNMEASURED (no remote/unreachable/no bound available). UNMEASURED is a [warn],
+#      never an [ok]: an unmeasured capability must not inherit the permissive branch.
 #   4. roborev installed and its LOCAL config resolves — roborev follows THIS
 #      machine's configured agent (commonly codex via .roborev.toml); we warn
 #      only if the local config is broken, never prescribe an agent.
@@ -55,7 +64,25 @@
 # Usage:
 #   bash scripts/bootstrap-agent-machine.sh            # check + print install cmds
 #   bash scripts/bootstrap-agent-machine.sh --yes      # also auto-run installs + git credentials
-#   bash scripts/bootstrap-agent-machine.sh --skip-smoke   # skip the final gate run
+#   bash scripts/bootstrap-agent-machine.sh --fix-credentials  # wire git push credentials ONLY
+#                                                      #   (section 3b's auto-fix, the same
+#                                                      #   `gh auth setup-git`-preferring path
+#                                                      #   --yes uses); every other check stays
+#                                                      #   read-only — no toolchain installs.
+#   bash scripts/bootstrap-agent-machine.sh --strict   # exit 1 when there is any [warn]
+#                                                      #   (default stays exit 0 so this script
+#                                                      #   still composes into setup scripts)
+#   bash scripts/bootstrap-agent-machine.sh --skip-push-probe  # skip ONLY section 3b's push
+#                                                      #   probe (the refs/claims/* smoke push).
+#                                                      #   Loud + non-passing: it emits
+#                                                      #   `git-push: OPT-OUT` as a [warn], so it
+#                                                      #   withholds "All checks green." and can
+#                                                      #   never buy a vacuous green. For offline
+#                                                      #   boxes and hermetic self-tests.
+#   bash scripts/bootstrap-agent-machine.sh --skip-smoke   # skip the final GATE run (section 6).
+#                                                      #   DISTINCT from --skip-push-probe: this
+#                                                      #   one is about the gate fmt smoke, that
+#                                                      #   one about the git push probe.
 #   bash scripts/bootstrap-agent-machine.sh --help
 set -uo pipefail
 
@@ -64,10 +91,19 @@ GATE="$REPO_ROOT/scripts/agent-gate.sh"
 
 AUTO_YES=0
 SKIP_SMOKE=0
+# --skip-push-probe is deliberately NOT spelled --skip-smoke-push or folded into
+# --skip-smoke: --skip-smoke skips the GATE fmt run in section 6 and has nothing to do
+# with git. Two different subjects, two different flags (issue #3369).
+SKIP_PUSH_PROBE=0
+FIX_CREDENTIALS=0
+STRICT=0
 for arg in "$@"; do
   case "$arg" in
     --yes|-y) AUTO_YES=1 ;;
     --skip-smoke) SKIP_SMOKE=1 ;;
+    --skip-push-probe) SKIP_PUSH_PROBE=1 ;;
+    --fix-credentials) FIX_CREDENTIALS=1 ;;
+    --strict) STRICT=1 ;;
     -h|--help)
       # Print the whole leading comment block, bounded by the FIRST `set -` line
       # rather than a hardcoded line number: a fixed `2,45p` silently truncates the
@@ -1144,6 +1180,9 @@ elif [ "$GIT_ORIGIN_KIND" = none ]; then
 elif [ "$GIT_ORIGIN_KIND" = ssh ]; then
   # SSH (git@host:… / ssh://…): git authenticates with your SSH key, and an https
   # credential helper is irrelevant. Report it and configure nothing.
+  # NOT an exemption from the push probe below: an SSH origin is push-probed like any
+  # other (the smoke push works over ssh), so a machine with no usable key still gets a
+  # FAILED verdict rather than a green "no helper needed" (issue #3369).
   ok "origin is an SSH remote — git push authenticates via SSH keys, not a credential helper (no helper needed)"
   info "verify separately if pushes fail:  ssh -T git@github.com"
 elif [ "$GIT_ORIGIN_KIND" = other ]; then
@@ -1164,8 +1203,12 @@ else
   info "symptom: every push fails with  fatal: could not read Username for 'https://$GIT_ORIGIN_HOST'"
   info "impact: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — the claim protocol does not work"
   info "fix:    gh auth setup-git    (preferred; wires gh as git's credential helper)"
-  info "        or re-run with --yes to configure a helper that reads \$GH_TOKEN at call time"
-  if [ "$AUTO_YES" = 1 ]; then
+  info "        or re-run with --fix-credentials (or --yes) to configure a helper that reads \$GH_TOKEN at call time"
+  # --fix-credentials wires ONLY this section, leaving every other check read-only
+  # (issue #3369): the AMI onboarder's verify step needs the credential path wired
+  # after token injection, and turning a VERIFICATION step into a full toolchain
+  # installer (which --yes also is) would be a far larger change than that needs.
+  if [ "$AUTO_YES" = 1 ] || [ "$FIX_CREDENTIALS" = 1 ]; then
     cred_fixed=0
     # Preferred form: let gh wire itself in. Verified by RE-PROBING — on the box
     # that motivated #2942 the gh credential path was precisely what was not wired,
@@ -1214,7 +1257,135 @@ else
       fi
     fi
   else
-    info "(re-run with --yes to auto-configure)"
+    info "(re-run with --fix-credentials to wire credentials only, or --yes to also install)"
+  fi
+fi
+# ---- 3b-push. git PUSH CAPABILITY — measured, not inferred (issue #3369) ----
+# Everything above this line validates CONFIGURATION. `git credential fill` runs the
+# configured helper chain and answers "would git find a credential for this host?"
+# without ever contacting the network and without pushing anything; the section's own
+# comment says so. That is not the property the fleet depends on. A token with no
+# `contents:write`, an expired or unrotated token, an SSO authorization never granted,
+# and a host that refuses the `refs/claims/*` namespace ALL pass every check above and
+# still fail the very first thing a lane does — `bash scripts/flow/claim.sh claim <N>`,
+# a plain `git push` of a claim ref. That is the defect this exists for: the affected
+# box passed `gh auth status` AND `git ls-remote origin HEAD` and therefore LOOKED
+# healthy, so the preflight certified a machine on which no lane could start.
+# Generalized in docs/development/agent-machine-setup.md: "A scope match is evidence
+# about a token, not about the operation." Neither is a credential-helper answer, and
+# neither is a read.
+#
+# So the verdict below comes from performing THE OPERATION: create + read back +
+# delete a throwaway `refs/claims/smoke-<nonce>` ref. It DELEGATES to
+# `scripts/flow/claim.sh smoke`, the repo's existing sanctioned push probe — which
+# pushes the same ref namespace the claim protocol uses, already classifies an auth
+# fault (`reason=auth`) apart from a namespace refusal, and always deletes the ref it
+# created. `git push --dry-run` is deliberately NOT used: it stops short of the ref
+# update, which is the part the server decides, so it is one more piece of evidence
+# about configuration. It runs AFTER the auto-fix above, so what gets measured is the
+# machine as the fix left it.
+#
+# THREE-VALUED, NEVER TWO. A positive verdict requires an AFFIRMATIVE measurement, so
+# the `ok` branch is keyed on the smoke ref having really been created and read back —
+# never on the absence of a failure signal. Anything unmeasurable (no remote, an
+# unreachable remote, no claim.sh in this checkout, no `timeout`/`gtimeout` to bound
+# the network calls, the bound firing) is UNMEASURED, which is a [warn]: an unmeasured
+# push capability must not inherit the permissive branch, and "All checks green." must
+# not be printed for a machine whose claim protocol was never exercised.
+#
+# Hang safety: the whole probe runs under `bounded`, with GIT_TERMINAL_PROMPT=0 and a
+# deliberately nonexistent askpass, so neither a credential prompt nor a wedged remote
+# can stall a boot.
+PUSH_PROBE_REMOTE="${CLAIM_REMOTE:-origin}"   # the remote claim.sh itself will use
+CLAIM_SH="$REPO_ROOT/scripts/flow/claim.sh"
+PUSH_PROBE_BOUND=60   # 3 network round trips (push, ls-remote, delete) + slack
+
+# git_push_probe_stderr_is_auth <text> — mirrors git_stderr_is_auth in
+# scripts/flow/claim.sh (keep the two in sync). Used for ONE purpose: when the
+# reachability precheck fails, tell a CREDENTIAL refusal (FAILED — actionable, names
+# the fix) from an unreachable remote (UNMEASURED — nothing was learned about push).
+# Deliberately conservative: anything unrecognized stays UNMEASURED rather than being
+# asserted as a credential fault. The classified text is NEVER printed — a remote URL
+# can carry an embedded token, which is why claim.sh never echoes git's stderr either.
+git_push_probe_stderr_is_auth() {
+  case "$1" in
+    *"could not read Username"*      | *"could not read Password"*        | \
+    *"Authentication failed"*        | *"authentication failed"*          | \
+    *"terminal prompts disabled"*    | *"Invalid username or token"*      | \
+    *"Invalid username or password"* | *"Permission denied (publickey)"*  | \
+    *"Permission to "*" denied"*     | *"Write access to repository not granted"* | \
+    *"Support for password authentication was removed"* | *"401 Unauthorized"*)
+      return 0 ;;
+  esac
+  return 1
+}
+
+# push_probe_fix_advice — the remediation both non-verified verdicts print.
+push_probe_fix_advice() {
+  info "impact: scripts/flow/claim.sh + claim-heartbeat.sh push on 10+ call sites — a lane cannot even START"
+  info "fix:    gh auth setup-git    (preferred; wires gh as git's credential helper)"
+  info "        then re-run:  bash scripts/bootstrap-agent-machine.sh --fix-credentials"
+  info "        verify by hand:  bash scripts/flow/claim.sh smoke"
+}
+
+hdr "git PUSH capability (issue #3369)"
+if [ "$SKIP_PUSH_PROBE" = 1 ]; then
+  # Loud and NON-PASSING by construction: an opt-out that returned `ok` would be a
+  # switch for buying a vacuous green, which is the whole failure mode above.
+  warn "git-push: OPT-OUT (--skip-push-probe) — push capability was NOT measured on this machine"
+  info "this run cannot certify that the claim protocol works here; drop the flag to measure it"
+elif ! have git; then
+  warn "git-push: UNMEASURED (git is not installed — nothing to probe with)"
+elif [ ! -f "$CLAIM_SH" ]; then
+  warn "git-push: UNMEASURED (no scripts/flow/claim.sh under $REPO_ROOT — the sanctioned push probe is not in this checkout)"
+elif ! git -C "$REPO_ROOT" remote get-url "$PUSH_PROBE_REMOTE" >/dev/null 2>&1; then
+  warn "git-push: UNMEASURED (no '$PUSH_PROBE_REMOTE' remote in $REPO_ROOT — nothing to push to)"
+elif [ -z "$TIMEOUT_BIN" ]; then
+  # Refuse rather than run unbounded: an unbounded network push during boot can wedge
+  # the onboarder indefinitely, and reporting `ok` for a probe we declined to run is
+  # exactly the permissive-unknown branch this section rejects.
+  warn "git-push: UNMEASURED (no timeout/gtimeout on PATH — refusing to run an UNBOUNDED network push during bootstrap)"
+  info "install GNU coreutils so the probe can be bounded (macOS: brew install coreutils), then re-run"
+else
+  # Reachability precheck. Its ONLY job is to separate "the remote is unreachable, so
+  # nothing was measured" from "the remote refused you" — it is NEVER a success
+  # signal, because a passing read is precisely what made the broken box look healthy.
+  push_probe_ls_err=""
+  push_probe_ls_rc=0
+  push_probe_ls_err=$(bounded "$PUSH_PROBE_BOUND" env GIT_TERMINAL_PROMPT=0 \
+    GIT_ASKPASS=cqlite-bootstrap-no-askpass SSH_ASKPASS=cqlite-bootstrap-no-askpass \
+    git -C "$REPO_ROOT" ls-remote "$PUSH_PROBE_REMOTE" 2>&1 >/dev/null) || push_probe_ls_rc=$?
+  if [ "$push_probe_ls_rc" -ne 0 ] && git_push_probe_stderr_is_auth "$push_probe_ls_err"; then
+    warn "git-push: FAILED (git cannot AUTHENTICATE to '$PUSH_PROBE_REMOTE' — an authenticated 'gh' does NOT authenticate git)"
+    push_probe_fix_advice
+  elif [ "$push_probe_ls_rc" -ne 0 ]; then
+    warn "git-push: UNMEASURED (cannot reach '$PUSH_PROBE_REMOTE' — no network, or the remote does not exist; push capability is UNKNOWN, not ok)"
+    info "re-run once the remote is reachable, or verify by hand:  bash scripts/flow/claim.sh smoke"
+  else
+    # THE OPERATION. Run from REPO_ROOT because claim.sh drives the git repo at $PWD.
+    push_probe_out=""
+    push_probe_rc=0
+    push_probe_out=$(cd "$REPO_ROOT" && bounded "$PUSH_PROBE_BOUND" env GIT_TERMINAL_PROMPT=0 \
+      GIT_ASKPASS=cqlite-bootstrap-no-askpass SSH_ASKPASS=cqlite-bootstrap-no-askpass \
+      bash "$CLAIM_SH" smoke 2>&1) || push_probe_rc=$?
+    if printf '%s\n' "$push_probe_out" | grep -q 'SMOKE-OK'; then
+      # The one affirmative branch: the ref was created on the remote AND read back.
+      ok "git-push: VERIFIED (refs/claims/* create+ls-remote+delete on '$PUSH_PROBE_REMOTE') — the claim protocol can run on this machine"
+    elif printf '%s\n' "$push_probe_out" | grep -q 'SMOKE-FAIL.*reason=auth'; then
+      warn "git-push: FAILED (git cannot AUTHENTICATE the refs/claims/* push to '$PUSH_PROBE_REMOTE' — an authenticated 'gh' does NOT authenticate git)"
+      push_probe_fix_advice
+    elif printf '%s\n' "$push_probe_out" | grep -q 'SMOKE-FAIL.*reason=commit-build'; then
+      # A LOCAL failure building the throwaway claim commit: the push never happened,
+      # so nothing was learned about push capability.
+      warn "git-push: UNMEASURED (the throwaway claim commit could not be built locally — the push was never attempted)"
+    elif printf '%s\n' "$push_probe_out" | grep -q 'SMOKE-FAIL'; then
+      warn "git-push: FAILED ('$PUSH_PROBE_REMOTE' rejected the refs/claims/* push — does the remote permit that ref namespace?)"
+      push_probe_fix_advice
+    elif [ "$push_probe_rc" = 124 ] || [ "$push_probe_rc" = 137 ]; then
+      warn "git-push: UNMEASURED (the probe exceeded its ${PUSH_PROBE_BOUND}s bound and was killed — push capability is UNKNOWN, not ok)"
+    else
+      warn "git-push: UNMEASURED (scripts/flow/claim.sh smoke produced no SMOKE-OK/SMOKE-FAIL verdict, rc=$push_probe_rc — push capability is UNKNOWN, not ok)"
+    fi
   fi
 fi
 
@@ -1420,5 +1591,16 @@ else
   printf '  \033[33m%d warning(s).\033[0m Address the [warn] lines above (or re-run with --yes to auto-install).\n' "$WARNINGS"
 fi
 info "Full doctrine: docs/development/agent-machine-setup.md"
-# Informational bootstrap: always exit 0 so it composes into setup scripts.
+# Informational bootstrap: DEFAULT is always exit 0 so it composes into setup scripts.
+# That contract is preserved deliberately (issue #3369) — callers rely on it.
+#
+# --strict is the opt-in fail-closed signal for a machine PREFLIGHT (the agent-ami
+# profile's verify.run uses it). Before it existed, the ONLY fail-closed signal was
+# the presence of the literal string "All checks green." in stdout, so any caller that
+# forgot to string-match — or matched it loosely — onboarded a broken box while this
+# script exited 0. An exit code cannot be forgotten by accident.
+if [ "$STRICT" = 1 ] && [ "$WARNINGS" -ne 0 ]; then
+  info "--strict: exiting 1 ($WARNINGS warning(s)) — this machine is NOT certified ready"
+  exit 1
+fi
 exit 0

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -131,7 +131,28 @@ have() { command -v "$1" >/dev/null 2>&1; }
 # the one where two of the three hang scenarios live (a locked osxkeychain, a Git
 # Credential Manager browser flow). Resolve both, and degrade visibly (unbounded) only
 # when neither exists.
-TIMEOUT_BIN="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
+# Resolution PROBES the candidate rather than trusting it (#3369 review). --kill-after is
+# a GNU coreutils flag: BusyBox and older implementations REJECT it, and a non-GNU
+# `timeout` earlier on PATH than a GNU `gtimeout` would be selected by a
+# first-match-wins lookup. A selected binary that rejects the flag makes EVERY bounded
+# call fail — board access, credential probe, push probe — so --strict would then reject
+# a perfectly healthy machine: the bound-hardening would have inverted this change's
+# purpose. So each candidate is tried WITH the flag; a candidate that supports it wins
+# even if it is second, and a candidate that does not is still usable with the bound
+# degraded to SIGTERM-only (the pre-hardening behaviour, and far better than every
+# bounded call failing). The probe asks about BEHAVIOUR; nothing here sniffs a vendor.
+TIMEOUT_BIN=""
+TIMEOUT_KILL_AFTER=0
+for _tb_name in timeout gtimeout; do
+  _tb_path="$(command -v "$_tb_name" 2>/dev/null || true)"
+  [ -n "$_tb_path" ] || continue
+  if "$_tb_path" --kill-after=1 1 true >/dev/null 2>&1; then
+    TIMEOUT_BIN="$_tb_path"; TIMEOUT_KILL_AFTER=1; break
+  fi
+  # Usable, but without the escalation. Keep it as the fallback and keep looking.
+  [ -n "$TIMEOUT_BIN" ] || TIMEOUT_BIN="$_tb_path"
+done
+unset _tb_name _tb_path
 # bounded <secs> <cmd...> — run <cmd...> under the resolved timeout binary if there is
 # one, else run it directly. Use `env VAR=... cmd` when the call needs env prefixes.
 #
@@ -147,7 +168,13 @@ TIMEOUT_BIN="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null
 BOUNDED_KILL_GRACE=5
 bounded() {
   local secs="$1"; shift
-  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" --kill-after="$BOUNDED_KILL_GRACE" "$secs" "$@"; else "$@"; fi
+  if [ -n "$TIMEOUT_BIN" ] && [ "$TIMEOUT_KILL_AFTER" = 1 ]; then
+    "$TIMEOUT_BIN" --kill-after="$BOUNDED_KILL_GRACE" "$secs" "$@"
+  elif [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" "$secs" "$@"
+  else
+    "$@"
+  fi
 }
 ok()   { printf '  \033[32m[ok]\033[0m   %s\n' "$1"; }
 warn() { printf '  \033[33m[warn]\033[0m %s\n' "$1"; WARNINGS=$((WARNINGS + 1)); }
@@ -1377,6 +1404,14 @@ fi
 # PUSH_PROBE_REMOTE is resolved ONCE above §3b — the credential half and this probe MUST
 # address the same remote (see the note there).
 CLAIM_SH="$REPO_ROOT/scripts/flow/claim.sh"
+# How many destinations `git push $PUSH_PROBE_REMOTE` would write to. `--all` is what
+# distinguishes "the first push URL" (what the classification above reads) from "every
+# push URL" (what a push actually hits).
+PUSH_PROBE_URL_COUNT=0
+if have git; then
+  PUSH_PROBE_URL_COUNT=$(git -C "$REPO_ROOT" remote get-url --push --all "$PUSH_PROBE_REMOTE" 2>/dev/null | grep -c . || true)
+  PUSH_PROBE_URL_COUNT=${PUSH_PROBE_URL_COUNT:-0}
+fi
 PUSH_PROBE_BOUND=60   # 3 network round trips (push, ls-remote, delete) + slack
 
 # git_push_probe_stderr_is_auth <text> — mirrors git_stderr_is_auth in
@@ -1429,6 +1464,10 @@ push_probe_fix_advice() {
 }
 
 hdr "git PUSH capability (issue #3369)"
+if [ -n "$TIMEOUT_BIN" ] && [ "$TIMEOUT_KILL_AFTER" = 0 ]; then
+  info "note: $TIMEOUT_BIN does not accept --kill-after, so every bound here degrades to SIGTERM-only —"
+  info "      a child that ignores SIGTERM can still outlive its bound. Install GNU coreutils for the hard bound."
+fi
 if [ "$SKIP_PUSH_PROBE" = 1 ]; then
   # Loud and NON-PASSING by construction: an opt-out that returned `ok` would be a
   # switch for buying a vacuous green, which is the whole failure mode above.
@@ -1440,6 +1479,16 @@ elif [ ! -f "$CLAIM_SH" ]; then
   warn "git-push: UNMEASURED (no scripts/flow/claim.sh under $REPO_ROOT — the sanctioned push probe is not in this checkout)"
 elif ! git -C "$REPO_ROOT" remote get-url "$PUSH_PROBE_REMOTE" >/dev/null 2>&1; then
   warn "git-push: UNMEASURED (no '$PUSH_PROBE_REMOTE' remote in $REPO_ROOT — nothing to push to)"
+elif [ "$PUSH_PROBE_URL_COUNT" -gt 1 ]; then
+  # A remote may carry SEVERAL pushurls, and `git push <remote>` pushes to EVERY one, so
+  # the probe would mutate N destinations while `get-url --push` describes only the first
+  # (#3369 review). It could create the ref on A, fail on B, and return having cleaned
+  # neither — an uninterpretable result from a MUTATING measurement. This change's own
+  # discipline says do not run a measurement you cannot interpret, so it refuses instead
+  # of enumerating destinations or growing per-destination credential logic. UNMEASURED,
+  # so the machine is never certified on the strength of it.
+  warn "git-push: UNMEASURED (remote '$PUSH_PROBE_REMOTE' has $PUSH_PROBE_URL_COUNT push URLs — refusing to run a MUTATING probe against multiple destinations)"
+  info "verify by hand against one destination:  CLAIM_REMOTE=<single-url-remote> bash scripts/flow/claim.sh smoke"
 elif [ -z "$TIMEOUT_BIN" ]; then
   # Refuse rather than run unbounded: an unbounded network push during boot can wedge
   # the onboarder indefinitely, and reporting `ok` for a probe we declined to run is

--- a/scripts/bootstrap-agent-machine.sh
+++ b/scripts/bootstrap-agent-machine.sh
@@ -1188,7 +1188,12 @@ elif [ "$GIT_ORIGIN_KIND" = ssh ]; then
 elif [ "$GIT_ORIGIN_KIND" = other ]; then
   info "origin is a '$GIT_ORIGIN_KIND' remote (neither http(s) nor SSH) — no credential helper applies"
 elif git_cred_probe "$GIT_ORIGIN_HOST"; then
-  ok "git push credentials resolve for $GIT_ORIGIN_HOST (a helper answers with a non-empty secret)"
+  # Says ONLY what `git credential fill` proved: a configured helper answered. It does
+  # NOT say a push would succeed — the previous wording ("git push credentials resolve
+  # for <host>") claimed push resolution on the strength of a configuration probe that
+  # never contacts the network, which is the #3369 overclaim in one sentence. The push
+  # claim belongs to the push probe below, and only to it.
+  ok "a git credential helper ANSWERS for $GIT_ORIGIN_HOST with a non-empty secret (configuration only — push capability is measured in the next section)"
   if git_local_helper_configured && ! git_global_helper_configured; then
     info "note: the helper is configured at REPO-LOCAL scope only — a fresh clone or a"
     info "      new checkout on this box will NOT inherit it. Re-run with --yes to add a global one."
@@ -1296,6 +1301,23 @@ fi
 # Hang safety: the whole probe runs under `bounded`, with GIT_TERMINAL_PROMPT=0 and a
 # deliberately nonexistent askpass, so neither a credential prompt nor a wedged remote
 # can stall a boot.
+#
+# THE COST, STATED OUT LOUD, because it is paid on EVERY invocation of this script —
+# a developer laptop run included, not just an image launch. Measuring the operation
+# means performing it:
+#   - two network round trips beyond the reachability read (the create push and the
+#     cleanup delete), plus one `ls-remote`;
+#   - a TRANSIENT `refs/claims/smoke-<nonce>` ref CREATED AND DELETED on the SHARED
+#     origin. claim.sh's cmd_smoke describes itself as a "ONE-TIME preflight ... NOT
+#     part of the hermetic test suite" because it mutates the real remote; invoking it
+#     here makes that mutation routine, which is accepted deliberately: making the
+#     measurement opt-in would restore "a read by default", the exact defect #3369
+#     exists to remove.
+# RESIDUAL: cmd_smoke only WARNS if its cleanup delete fails, so an interrupted or
+# partially-failing run can strand a `refs/claims/smoke-*` ref on the origin. Not fixed
+# here (cmd_smoke's hot path is out of scope for #3369). List and clean them with:
+#   git ls-remote origin 'refs/claims/smoke-*'
+#   git push origin --delete refs/claims/smoke-<nonce>
 PUSH_PROBE_REMOTE="${CLAIM_REMOTE:-origin}"   # the remote claim.sh itself will use
 CLAIM_SH="$REPO_ROOT/scripts/flow/claim.sh"
 PUSH_PROBE_BOUND=60   # 3 network round trips (push, ls-remote, delete) + slack

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -1109,9 +1109,11 @@ cmd_status() {
 # `refs/claims/smoke-<nonce>` ref). Some managed Git hosts restrict custom ref
 # namespaces; if this fails, the whole claim mechanism is unusable on that remote
 # and MUST be caught before the fleet relies on it. ALL THREE steps are part of the
-# verdict (#3369): a remote that accepts the create and refuses the DELETE is equally
-# unusable, because `release` deletes refs/claims/issue-<N> — that is
-# `reason=delete-rejected`, never a SMOKE-OK with a stderr warning. NOT part of the hermetic test
+# verdict (#3369): a cleanup delete that does not succeed leaves delete capability
+# UNPROVEN, and `release` deletes refs/claims/issue-<N> — that is
+# `reason=cleanup-unverified`, never a SMOKE-OK with a stderr warning. The reason code
+# names the OBSERVATION (a nonzero exit); it attributes no cause, because one exit status
+# cannot tell a deletion policy from a network drop. NOT part of the hermetic test
 # suite — it mutates the REAL origin. (Verified on github.com/pmcfadin/cqlite
 # 2026-07-17: refs/claims/* is pushable.)
 cmd_smoke() {
@@ -1160,10 +1162,19 @@ cmd_smoke() {
   fi
   if [ "$delete_ok" = 0 ]; then
     # DELETE CAPABILITY IS REQUIRED BY THE CLAIM PROTOCOL, not a tidiness nicety:
-    # `claim.sh release` deletes refs/claims/issue-<N>, and the reaper depends on it. A
-    # namespace that accepts a create and refuses a delete is BROKEN for claims, so this
-    # is a FAIL, not a warning — and it names the ref it stranded.
-    emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=delete-rejected (create + ls-remote worked, but $REMOTE REFUSED the delete — 'claim.sh release' deletes refs/claims/issue-<N>, so this namespace is unusable for claims; the throwaway ref is STRANDED: remove it with 'git push $REMOTE --delete $ref')"
+    # `claim.sh release` deletes refs/claims/issue-<N>, and the reaper depends on it. So a
+    # cleanup delete that did not succeed is a FAIL, never a SMOKE-OK with a stderr note.
+    #
+    # BUT THE REASON CODE STATES THE OBSERVATION, NOT A CAUSE (#3369 review). The first
+    # cut called this `delete-rejected` and blamed the remote's ref-deletion policy — a
+    # definite causal verdict inferred from ONE bit (a nonzero exit), which a transient
+    # network drop or a post-readback auth failure produces identically. That is the
+    # affirmative-measurement violation this whole change exists to remove, committed by
+    # the change itself. Distinguishing the causes would mean re-deriving them from git's
+    # stderr text, which is the same guessing shape one level down. So: what is KNOWN is
+    # that the delete exited nonzero, and therefore that delete capability is UNPROVEN
+    # and the ref's existence UNKNOWN. Nothing else is claimed.
+    emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=cleanup-unverified (the cleanup delete exited NONZERO — no cause is attributed. Whether $ref still exists on $REMOTE is UNKNOWN: check with 'git ls-remote $REMOTE $ref' and remove it with 'git push $REMOTE --delete $ref' if present. Delete capability is therefore UNPROVEN, and 'claim.sh release' deletes refs/claims/issue-<N>, so this namespace is NOT confirmed usable for claims.)"
     return 1
   fi
   emit "SMOKE-OK remote=$REMOTE namespace=refs/claims/* (create + ls-remote + delete verified)"

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -1145,7 +1145,17 @@ cmd_smoke() {
   local delete_ok=1
   git push "$REMOTE" --delete "$ref" >/dev/null 2>&1 || delete_ok=0
   if [ "$seen" != "$sha" ]; then
-    emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=ls-remote-mismatch seen=${seen:-<none>} expected=$sha"
+    # The readback failed — but the cleanup delete was already attempted above, and if
+    # that ALSO failed, returning here used to suppress it entirely: the operator got a
+    # mismatch verdict with no hint that a ref might be sitting on the shared origin
+    # (#3369 review). Same reason code, one appended field — not a fourth variant.
+    # Deliberately "UNKNOWN" rather than "STRANDED": the readback says the ref is not
+    # there and the delete says it could not be removed, so the two signals disagree and
+    # neither may be asserted. That is the same three-valued discipline this whole probe
+    # is built on.
+    local mismatch_extra=""
+    [ "$delete_ok" = 0 ] && mismatch_extra=" cleanup-delete=FAILED (whether $ref exists on $REMOTE is UNKNOWN — check 'git ls-remote $REMOTE $ref' and remove it with 'git push $REMOTE --delete $ref' if present)"
+    emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=ls-remote-mismatch seen=${seen:-<none>} expected=$sha$mismatch_extra"
     return 1
   fi
   if [ "$delete_ok" = 0 ]; then

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -1076,7 +1076,7 @@ cmd_status() {
     sha="$(printf '%s' "$line" | awk '{print $1}')"
     ref="$(printf '%s' "$line" | awk '{print $2}')"
     # Only issue claim refs are rendered — skip stray refs under refs/claims/*
-    # that are NOT issue claims (e.g. a leftover `refs/claims/smoke-<nonce>` from
+    # that are NOT issue claims (e.g. a leftover `refs/claims/smoke-<commit-sha>` from
     # an interrupted preflight), so they never masquerade as an issue row.
     case "$ref" in
       refs/claims/issue-*) : ;;
@@ -1106,7 +1106,7 @@ cmd_status() {
 # ---------------------------------------------------------------------------
 # cmd_smoke — ONE-TIME preflight for a new remote/host: prove that origin accepts
 # a push to the `refs/claims/*` namespace (create + ls-remote + delete a throwaway
-# `refs/claims/smoke-<nonce>` ref). Some managed Git hosts restrict custom ref
+# `refs/claims/smoke-<commit-sha>` ref). Some managed Git hosts restrict custom ref
 # namespaces; if this fails, the whole claim mechanism is unusable on that remote
 # and MUST be caught before the fleet relies on it. ALL THREE steps are part of the
 # verdict (#3369): a cleanup delete that does not succeed leaves delete capability
@@ -1117,11 +1117,25 @@ cmd_status() {
 # suite — it mutates the REAL origin. (Verified on github.com/pmcfadin/cqlite
 # 2026-07-17: refs/claims/* is pushable.)
 cmd_smoke() {
-  local nonce ref sha seen
-  nonce="$$-${RANDOM}-$(date -u +%s)"
-  ref="refs/claims/smoke-${nonce}"
-  note "smoke preflight: does $REMOTE accept a push to refs/claims/* ? (ref=$ref)"
+  local ref sha seen
+  # THE REF NAME IS DERIVED FROM THE COMMIT SHA, never from an ad-hoc nonce (#3369
+  # review). It used to be `$$-${RANDOM}-$(date -u +%s)`: a pid, ONE 15-bit $RANDOM and a
+  # second-resolution timestamp. Bash seeds $RANDOM from pid+time, so on identically
+  # provisioned machines booting simultaneously — literally this issue's subject, a fleet
+  # launched from ONE AMI — all three components are CORRELATED rather than independent.
+  # Since every bootstrap now runs this probe against the SHARED origin, a collision
+  # presents as a spurious push rejection => `git-push: FAILED` => `--strict` refusing a
+  # healthy box, the same failure class as this issue's earlier blockers.
+  #
+  # `build_claim_commit` is already called here and its message carries machine + pid +
+  # TWO $RANDOMs + timestamp, so the commit object is content-addressed over strictly
+  # more entropy than the old nonce had — and two runs that differ in any of those fields
+  # cannot share a sha. The `refs/claims/smoke-` PREFIX is load-bearing (the docs, the
+  # `git ls-remote origin 'refs/claims/smoke-*'` cleanup command, and cmd_status's
+  # "never an issue claim" skip all key on it) and is kept.
   sha="$(build_claim_commit "smoke" "smoke")" || { emit "SMOKE-FAIL remote=$REMOTE reason=commit-build"; return 1; }
+  ref="refs/claims/smoke-${sha}"
+  note "smoke preflight: does $REMOTE accept a push to refs/claims/* ? (ref=$ref)"
   local smoke_err
   if ! smoke_err="$(git push "$REMOTE" "${sha}:${ref}" 2>&1 >/dev/null)"; then
     # An unauthenticated git is the #1 reason this preflight fails on a fresh box,

--- a/scripts/flow/claim.sh
+++ b/scripts/flow/claim.sh
@@ -1108,7 +1108,10 @@ cmd_status() {
 # a push to the `refs/claims/*` namespace (create + ls-remote + delete a throwaway
 # `refs/claims/smoke-<nonce>` ref). Some managed Git hosts restrict custom ref
 # namespaces; if this fails, the whole claim mechanism is unusable on that remote
-# and MUST be caught before the fleet relies on it. NOT part of the hermetic test
+# and MUST be caught before the fleet relies on it. ALL THREE steps are part of the
+# verdict (#3369): a remote that accepts the create and refuses the DELETE is equally
+# unusable, because `release` deletes refs/claims/issue-<N> — that is
+# `reason=delete-rejected`, never a SMOKE-OK with a stderr warning. NOT part of the hermetic test
 # suite — it mutates the REAL origin. (Verified on github.com/pmcfadin/cqlite
 # 2026-07-17: refs/claims/* is pushable.)
 cmd_smoke() {
@@ -1132,14 +1135,29 @@ cmd_smoke() {
   # `|| true`: an ls-remote failure here must NOT abort before the cleanup delete
   # below (a stranded smoke ref is the worst outcome). A "" seen → SMOKE-FAIL.
   seen="$(git ls-remote "$REMOTE" "$ref" 2>/dev/null | awk '{print $1}' | head -1 || true)"
-  # Always clean up the throwaway ref, whatever the ls-remote said.
-  git push "$REMOTE" --delete "$ref" >/dev/null 2>&1 || note "WARNING: could not delete $ref on $REMOTE — remove it manually"
-  if [ "$seen" = "$sha" ]; then
-    emit "SMOKE-OK remote=$REMOTE namespace=refs/claims/* (create + ls-remote + delete verified)"
-    return 0
+  # Always clean up the throwaway ref, whatever the ls-remote said — and RECORD whether
+  # the cleanup worked. It used to be `|| note "WARNING: ..."`, after which SMOKE-OK was
+  # emitted UNCONDITIONALLY with the text "(create + ls-remote + delete verified)" — a
+  # verdict claiming more than it measured (#3369). Two costs: a caller (bootstrap's
+  # push-capability probe) read SMOKE-OK as proof of the whole cycle and passed a machine
+  # that had just STRANDED a ref on the shared origin; and the diagnosis was a `note` on
+  # stderr, invisible to any caller capturing the verdict.
+  local delete_ok=1
+  git push "$REMOTE" --delete "$ref" >/dev/null 2>&1 || delete_ok=0
+  if [ "$seen" != "$sha" ]; then
+    emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=ls-remote-mismatch seen=${seen:-<none>} expected=$sha"
+    return 1
   fi
-  emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=ls-remote-mismatch seen=${seen:-<none>} expected=$sha"
-  return 1
+  if [ "$delete_ok" = 0 ]; then
+    # DELETE CAPABILITY IS REQUIRED BY THE CLAIM PROTOCOL, not a tidiness nicety:
+    # `claim.sh release` deletes refs/claims/issue-<N>, and the reaper depends on it. A
+    # namespace that accepts a create and refuses a delete is BROKEN for claims, so this
+    # is a FAIL, not a warning — and it names the ref it stranded.
+    emit "SMOKE-FAIL remote=$REMOTE ref=$ref reason=delete-rejected (create + ls-remote worked, but $REMOTE REFUSED the delete — 'claim.sh release' deletes refs/claims/issue-<N>, so this namespace is unusable for claims; the throwaway ref is STRANDED: remove it with 'git push $REMOTE --delete $ref')"
+    return 1
+  fi
+  emit "SMOKE-OK remote=$REMOTE namespace=refs/claims/* (create + ls-remote + delete verified)"
+  return 0
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -174,8 +174,25 @@ count_begin() {
 # fast and offline during these mold cases, which run bootstrap under the full PATH
 # with CARGO_HOME pointed at a throwaway dir (a real `cargo --version` there would
 # trigger a multi-minute rustup toolchain provision into the empty CARGO_HOME).
+# GH_STUB_TOKEN_BODY — every `gh` stub must answer `gh auth token --hostname github.com`
+# with the ENVIRONMENT token, because that is what real gh does: GH_TOKEN/GITHUB_TOKEN take
+# precedence for github.com, and gh reports per-host tokens for anything else. §3b's
+# fallback repair is gated on that answer MATCHING the token it would install (#3369 FIX L),
+# so a stub that stays silent makes every --yes fallback case REFUSE — a test artifact
+# rather than behaviour. Any other host correctly gets gh's "no token" failure.
+GH_STUB_TOKEN_BODY='if [ "$1" = auth ] && [ "$2" = token ]; then
+  want=""; shift 2
+  while [ $# -gt 0 ]; do [ "$1" = --hostname ] && { want="$2"; shift; }; shift; done
+  case "${want:-github.com}" in
+    github.com) echo "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ;;
+    *) echo "no oauth token found for $want" >&2; exit 1 ;;
+  esac
+  exit 0
+fi'
+
 stub_net() {
-  mk_stub "$1" gh 'exit 0'
+  mk_stub "$1" gh "$GH_STUB_TOKEN_BODY
+exit 0"
   mk_stub "$1" roborev 'exit 0'
   mk_stub "$1" cargo '[ "$1" = --version ] && echo "cargo 1.88.0"; exit 0'
 }
@@ -534,7 +551,9 @@ fi
 sb7b=$(mktemp -d "$tmp/cred7b.XXXXXX"); stub7b="$tmp/stub7b"
 mk_hermetic_bin "$stub7b"
 gh7b_log="$tmp/gh7b.log"; : >"$gh7b_log"
-mk_stub "$stub7b" gh "echo \"\$*\" >>\"$gh7b_log\"; exit 0"   # setup-git succeeds but wires nothing
+mk_stub "$stub7b" gh "echo \"\$*\" >>\"$gh7b_log\"
+$GH_STUB_TOKEN_BODY
+exit 0"   # setup-git succeeds but wires nothing; `auth token` answers as real gh does
 repo7b="$tmp/repo7b"; mk_fake_repo "$repo7b" "https://github.com/pmcfadin/cqlite.git"
 gc7b="$sb7b/gitconfig"
 out7b=$(PATH="$stub7b" HOME="$sb7b" CARGO_HOME="$sb7b/.cargo" GIT_CONFIG_GLOBAL="$gc7b" \
@@ -778,7 +797,8 @@ fi
 #     is a real footgun (git consults each entry in order).
 sb7e=$(mktemp -d "$tmp/cred7e.XXXXXX"); stub7e="$tmp/stub7e"
 mk_hermetic_bin "$stub7e"
-mk_stub "$stub7e" gh 'exit 0'   # setup-git is a no-op -> the fallback helper is used
+mk_stub "$stub7e" gh "$GH_STUB_TOKEN_BODY
+exit 0"   # setup-git is a no-op -> the fallback helper is used
 repo7e="$tmp/repo7e"; mk_fake_repo "$repo7e" "https://github.com/pmcfadin/cqlite.git"
 gc7e="$sb7e/gitconfig"
 for _ in 1 2; do
@@ -879,6 +899,16 @@ case "\$1" in
       echo "github.com"
       echo "  ✓ Logged in to github.com account tester (GH_TOKEN)"
       echo "  - Token scopes: 'gist', 'project', 'read:org', 'repo', 'workflow'"
+    elif [ "\$2" = token ]; then
+      # As real gh: the environment token IS github.com's token, and any other host has
+      # none here (#3369 FIX L gates the fallback repair on this answer).
+      want=""; shift 2
+      while [ \$# -gt 0 ]; do [ "\$1" = --hostname ] && { want="\$2"; shift; }; shift; done
+      case "\${want:-github.com}" in
+        github.com) echo "\${GH_TOKEN:-\${GITHUB_TOKEN:-}}" ;;
+        *) echo "no oauth token found for \$want" >&2; exit 1 ;;
+      esac
+      exit 0
     elif [ "\$2" = setup-git ]; then
       $setup
     fi

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -699,6 +699,15 @@ fi
 #     would skip it on the one platform whose hang scenarios (locked osxkeychain, a GCM
 #     browser flow) motivated the bound, leaving it uncovered exactly where it matters.
 TIMEOUT_BIN_TEST="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
+# A watchdog for a fixture that IGNORES SIGTERM must be able to escalate to SIGKILL, so
+# it is resolved by the SAME behavioural probe the bootstrap uses (`--kill-after=1 1
+# true`) rather than assumed — a plain `timeout` aimed at a TERM-ignoring child waits
+# FOREVER, and `tooling-tests` is a full-gate component, where a hang is worse than a
+# failure because nothing reports it (#3369 review).
+TIMEOUT_KILL_TEST=""
+if [ -n "$TIMEOUT_BIN_TEST" ] && "$TIMEOUT_BIN_TEST" --kill-after=1 1 true >/dev/null 2>&1; then
+  TIMEOUT_KILL_TEST="$TIMEOUT_BIN_TEST"
+fi
 if [ -n "$TIMEOUT_BIN_TEST" ]; then
   sb7h=$(mktemp -d "$tmp/cred7h.XXXXXX"); stub7h="$tmp/stub7h"
   mk_hermetic_bin "$stub7h"
@@ -1256,7 +1265,7 @@ fi
 #   the bound is production behaviour and must not be shrunk to suit a test. Its own
 #   outer ceiling is the negative control: WITHOUT --kill-after the bootstrap never
 #   returns, the ceiling fires, and rc is 124.
-if [ -n "$TIMEOUT_BIN_TEST" ]; then
+if [ -n "$TIMEOUT_KILL_TEST" ]; then
   bare7pm="$tmp/bare7pm.git"; mk_push_bare "$bare7pm"
   repo7pm="$tmp/repo7pm"; mk_push_repo "$repo7pm" "file://$bare7pm"
   printf '#!/usr/bin/env bash\ntrap "" TERM\nsleep 300\n' >"$repo7pm/scripts/flow/claim.sh"
@@ -1265,13 +1274,15 @@ if [ -n "$TIMEOUT_BIN_TEST" ]; then
   gc7pm="$tmp/gc7pm"; : >"$gc7pm"
   hang_start=$(date +%s)
   hang_rc=0
-  hang_out=$("$TIMEOUT_BIN_TEST" 150 env PATH="$bin7pm:$PATH" HOME="$repo7pm/.home" \
+  hang_out=$("$TIMEOUT_KILL_TEST" --kill-after=5 150 env PATH="$bin7pm:$PATH" HOME="$repo7pm/.home" \
     CARGO_HOME="$repo7pm/.home/.cargo" GIT_CONFIG_GLOBAL="$gc7pm" GIT_CONFIG_NOSYSTEM=1 \
     CLAIM_MACHINE=push-probe-test CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t' \
     CQLITE_PROJECT_OWNER=pmcfadin CQLITE_PROJECT_NUMBER=1 \
     bash "$repo7pm/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1) || hang_rc=$?
   hang_elapsed=$(( $(date +%s) - hang_start ))
-  if [ "$hang_rc" -ne 124 ] && printf '%s' "$hang_out" | grep -q '\[warn\].*git-push: UNMEASURED.*exceeded its 60s bound and was killed' \
+  # rc 124 OR 137 both mean the OUTER ceiling fired (137 = the watchdog had to SIGKILL
+  # bootstrap itself), i.e. the inner bound failed to bound. Either is a failure here.
+  if [ "$hang_rc" -ne 124 ] && [ "$hang_rc" -ne 137 ] && printf '%s' "$hang_out" | grep -q '\[warn\].*git-push: UNMEASURED.*exceeded its 60s bound and was killed' \
      && [ "$hang_elapsed" -lt 120 ]; then
     ok "push: a SIGTERM-ignoring probe child is KILLED at the bound + grace — bootstrap still completes (${hang_elapsed}s) and reports UNMEASURED"
   else
@@ -1279,7 +1290,10 @@ if [ -n "$TIMEOUT_BIN_TEST" ]; then
     push_verdict "$hang_out"
   fi
 else
-  echo "skip - push: bound-escalation guard needs timeout/gtimeout (neither on this host)"
+  # Deliberately SKIP rather than run unbounded: this fixture ignores SIGTERM, so without
+  # a hard-kill-capable watchdog the case could hang the gate forever. A skip that says
+  # so is honest; a case that can hang is not.
+  echo "skip - push: bound-escalation guard needs a timeout/gtimeout accepting --kill-after (its fixture ignores SIGTERM)"
 fi
 
 # 7p-n. SSH REMOTES GET SSH ADVICE (#3369 review). `gh auth setup-git` configures an

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1241,6 +1241,45 @@ else
   push_plain "$out7pl2" | grep -E 'credential|remote' | head -5
 fi
 
+# 7p-m. THE BOUND MUST ACTUALLY BOUND (#3369 review). `timeout <secs>` sends SIGTERM and
+#   then waits, so a child that traps or ignores it runs on forever and the advertised
+#   60s bound bounds nothing — in BOOT-PATH code, where a hang is the worst outcome.
+#   `bounded` now passes --kill-after, which also makes the probe's rc=137 branch
+#   reachable for the first time (it previously anticipated an outcome the wrapper could
+#   not produce). The stand-in for a TERM-ignoring git/ssh/credential-manager is a
+#   claim.sh that traps TERM: it is `bounded`'s DIRECT child (env execs it), which is the
+#   process timeout signals.
+#
+#   COST: this case necessarily waits out the real 60s bound plus the 5s grace (~65s) —
+#   the bound is production behaviour and must not be shrunk to suit a test. Its own
+#   outer ceiling is the negative control: WITHOUT --kill-after the bootstrap never
+#   returns, the ceiling fires, and rc is 124.
+if [ -n "$TIMEOUT_BIN_TEST" ]; then
+  bare7pm="$tmp/bare7pm.git"; mk_push_bare "$bare7pm"
+  repo7pm="$tmp/repo7pm"; mk_push_repo "$repo7pm" "file://$bare7pm"
+  printf '#!/usr/bin/env bash\ntrap "" TERM\nsleep 300\n' >"$repo7pm/scripts/flow/claim.sh"
+  chmod +x "$repo7pm/scripts/flow/claim.sh"
+  bin7pm="$tmp/bin7pm"; mk_push_bin "$bin7pm"
+  gc7pm="$tmp/gc7pm"; : >"$gc7pm"
+  hang_start=$(date +%s)
+  hang_rc=0
+  hang_out=$("$TIMEOUT_BIN_TEST" 150 env PATH="$bin7pm:$PATH" HOME="$repo7pm/.home" \
+    CARGO_HOME="$repo7pm/.home/.cargo" GIT_CONFIG_GLOBAL="$gc7pm" GIT_CONFIG_NOSYSTEM=1 \
+    CLAIM_MACHINE=push-probe-test CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t' \
+    CQLITE_PROJECT_OWNER=pmcfadin CQLITE_PROJECT_NUMBER=1 \
+    bash "$repo7pm/scripts/bootstrap-agent-machine.sh" --skip-smoke 2>&1) || hang_rc=$?
+  hang_elapsed=$(( $(date +%s) - hang_start ))
+  if [ "$hang_rc" -ne 124 ] && printf '%s' "$hang_out" | grep -q '\[warn\].*git-push: UNMEASURED.*exceeded its 60s bound and was killed' \
+     && [ "$hang_elapsed" -lt 120 ]; then
+    ok "push: a SIGTERM-ignoring probe child is KILLED at the bound + grace — bootstrap still completes (${hang_elapsed}s) and reports UNMEASURED"
+  else
+    bad "push: the bound did not bound a TERM-ignoring child (rc=$hang_rc elapsed=${hang_elapsed}s)"
+    push_verdict "$hang_out"
+  fi
+else
+  echo "skip - push: bound-escalation guard needs timeout/gtimeout (neither on this host)"
+fi
+
 # 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH
 #   directions. They are two channels for ONE fact: the green string is printed iff
 #   WARNINGS is 0, and --strict exits 0 iff WARNINGS is 0. A reviewer proposed keying

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -882,11 +882,19 @@ run_push() {
   push_out=$(PATH="$bin:$PATH" HOME="$repo/.home" CARGO_HOME="$repo/.home/.cargo" \
     GIT_CONFIG_GLOBAL="$gc" GIT_CONFIG_NOSYSTEM=1 CLAIM_MACHINE=push-probe-test \
     CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t' \
+    CQLITE_PROJECT_OWNER=pmcfadin CQLITE_PROJECT_NUMBER=1 \
     bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke "$@" 2>&1) || push_rc=$?
 }
-push_warns()  { printf '%s' "$1" | grep -cF '[warn]'; }
+# ANSI colour is stripped with a printf-built ESC, not a `\x1b` escape: BSD sed (the
+# fleet's macOS hosts) does not understand \x1b and would silently match nothing.
+PUSH_ESC=$(printf '\033')
+push_plain()  { printf '%s' "$1" | sed "s/${PUSH_ESC}\[[0-9;]*m//g"; }
+# Count only real warn LINES. `grep -cF '[warn]'` also matched the summary's
+# "Address the [warn] lines above", making every count one too high — and the counts
+# below are the whole basis of the delta assertion.
+push_warns()  { push_plain "$1" | grep -cE '^[[:space:]]+\[warn\] '; }
 push_green()  { printf '%s' "$1" | grep -qF 'All checks green.'; }
-push_verdict(){ printf '%s' "$1" | grep -F 'git-push:' | sed 's/\x1b\[[0-9;]*m//g'; }
+push_verdict(){ push_plain "$1" | grep -F 'git-push:'; }
 
 # 7p-a/d. THE POSITIVE CONTROL and the OPT-OUT, measured as a pair against ONE sandbox
 #   whose only variable is the flag. Run the opt-out FIRST so its warning count
@@ -1012,6 +1020,29 @@ if printf '%s' "$out7pc2" | grep -q "\[warn\].*git-push: UNMEASURED.*no 'origin'
 else
   bad "push: missing origin was not reported as UNMEASURED"
   push_verdict "$out7pc2"
+fi
+
+# 7p-c3. THE MUTATION THIS BLOCK EXISTS FOR. The probe delegates to claim.sh, so the
+#   permissive branch must be keyed on the AFFIRMATIVE `SMOKE-OK`, never on the ABSENCE
+#   of `SMOKE-FAIL`: a probe that produced NO verdict at all (killed, or a claim.sh
+#   whose output contract moved) would otherwise be read as success. Verified as a real
+#   mutation: rewriting the branch to `! grep SMOKE-FAIL` leaves every OTHER case in
+#   this block green, and only this one reds. The remote here is a bare repo that
+#   ACCEPTS pushes, so reachability is not what is being measured — the verdict is.
+repo7pc3="$tmp/repo7pc3"; bare7pc3="$tmp/bare7pc3.git"
+mk_push_bare "$bare7pc3"
+mk_push_repo "$repo7pc3" "file://$bare7pc3"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$repo7pc3/scripts/flow/claim.sh"   # mute: no verdict
+chmod +x "$repo7pc3/scripts/flow/claim.sh"
+bin7pc3="$tmp/bin7pc3"; mk_push_bin "$bin7pc3"
+gc7pc3="$tmp/gc7pc3"; : >"$gc7pc3"
+run_push "$repo7pc3" "$bin7pc3" "$gc7pc3"; out7pc3=$push_out
+if printf '%s' "$out7pc3" | grep -q '\[warn\].*git-push: UNMEASURED.*no SMOKE-OK/SMOKE-FAIL verdict' \
+   && ! printf '%s' "$out7pc3" | grep -q '\[ok\].*git-push'; then
+  ok "push: a probe that returns NO verdict is UNMEASURED — success is keyed on SMOKE-OK, not on the absence of failure"
+else
+  bad "push: a verdict-less probe was not reported UNMEASURED (the permissive branch is keyed on '!= failed')"
+  push_verdict "$out7pc3"
 fi
 
 # 7p-e. ORDERING: the probe must run AFTER section 3b's credential fix, so what it

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -58,7 +58,7 @@ export GIT_CONFIG_NOSYSTEM=1
 
 # --- REAL-ORIGIN isolation for the push probe (issue #3369) ----------------
 # Section 3b now MEASURES push capability by actually pushing a throwaway
-# refs/claims/smoke-<nonce> ref (scripts/flow/claim.sh smoke). Every case that runs
+# refs/claims/smoke-<commit-sha> ref (scripts/flow/claim.sh smoke). Every case that runs
 # "$BOOTSTRAP" IN PLACE therefore has the real checkout as REPO_ROOT and the real
 # github.com origin as its remote — with this box's real credentials. Those runs pass
 # --skip-push-probe so this suite can NEVER mutate the real origin; the probe's own
@@ -827,7 +827,7 @@ fi
 # motivated #3369 passed every one of them while every `git push` failed, so the
 # launcher's preflight certified a machine on which no lane could start. These cases
 # pin the probe that performs THE OPERATION (create + read back + delete a throwaway
-# refs/claims/smoke-<nonce> ref, via scripts/flow/claim.sh smoke) and — just as
+# refs/claims/smoke-<commit-sha> ref, via scripts/flow/claim.sh smoke) and — just as
 # importantly — pin that an UNKNOWN answer is never reported green.
 #
 # Hermetic in three layers, because a push probe that escaped the sandbox would mutate

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1031,7 +1031,7 @@ fi
 # passed only because the advice branched on `!= ssh` and swept `other` into the https
 # arm, i.e. the test asserted a property it never exercised (#3369 review). The genuine
 # https path is 7p-q below.
-if printf '%s' "$out7pb" | grep -q "remote is a 'other' remote" \
+if printf '%s' "$out7pb" | grep -q "remote 'origin' is a 'other' remote" \
    && printf '%s' "$out7pb" | grep -q 'credential helper may not apply' \
    && ! push_plain "$out7pb" | grep -E '^ *fix:' | grep -q 'gh auth setup-git'; then
   ok "push: a file:// remote's auth-shaped failure gets protocol-neutral advice, NOT https credential advice"
@@ -1381,6 +1381,55 @@ else
   push_plain "$out7pn" | grep -E 'git-push|fix:|ssh' | head -5
 fi
 
+# 7p-s. NOTHING PRINTED MAY CARRY A CREDENTIAL FROM THE REMOTE URL (#3369 review). A
+#   remote URL can be `https://user:token@host/…` or `ssh://user:token@host/…`, and this
+#   script's output is persisted in ONBOARDING LOGS — so the two advice lines that printed
+#   $GIT_ORIGIN_URL verbatim wrote a live credential into a log file. Both sub-cases below
+#   put a distinctive secret in the URL and assert it never appears in the output, which is
+#   the property; the structural guard in 7p-i covers the sites nobody has written yet.
+URL_SECRET='ghp_URLembeddedSECRET3369URLembeddedSEC'
+
+#   (i) An SSH remote whose URL embeds a secret. The `ssh` stub supplies an auth-shaped
+#   failure (as in 7p-n) so the advice branch — the code under test — is really reached.
+repo7ps="$tmp/repo7ps"; mk_push_repo "$repo7ps" "ssh://cq:$URL_SECRET@push-probe.invalid/owner/repo.git"
+bin7ps="$tmp/bin7ps"; mk_push_bin "$bin7ps"
+mk_stub "$bin7ps" ssh 'echo "git@push-probe.invalid: Permission denied (publickey)." >&2; exit 255'
+gc7ps="$tmp/gc7ps"; : >"$gc7ps"
+run_push "$repo7ps" "$bin7ps" "$gc7ps"; out7ps=$push_out
+# Guard the guard: without the FAILED verdict + SSH advice the run never reached the lines
+# under test, and "the secret is absent" would be true for the wrong reason.
+if printf '%s' "$out7ps" | grep -q '\[warn\].*git-push: FAILED' \
+   && printf '%s' "$out7ps" | grep -q 'authenticates with your SSH KEY'; then
+  ok "push: (precondition) 7p-s(i) reaches the FAILED verdict and the SSH advice branch"
+else
+  bad "push: 7p-s(i) precondition FAILED — the advice branch was not reached, the secret assert would be vacuous"
+  push_plain "$out7ps" | grep -E 'git-push|fix:' | head -4
+fi
+if ! printf '%s' "$out7ps" | grep -qF "$URL_SECRET" \
+   && printf '%s' "$out7ps" | grep -q "remote 'origin' is an SSH remote" \
+   && printf '%s' "$out7ps" | grep -q 'remote get-url --push origin'; then
+  ok "push: a credential embedded in an SSH remote URL is NEVER printed — the advice names the remote and where to read the URL locally"
+else
+  bad "push: the remote URL (and its embedded secret) reached the output"
+  push_plain "$out7ps" | grep -E 'fix:|URL' | head -4
+fi
+
+#   (ii) An https remote whose PASSWORD contains an '@'. The host is printed on many lines,
+#   so parsing the userinfo at the FIRST '@' left the tail of the password inside the
+#   "host" and logged a credential fragment. git splits an authority at the LAST '@'.
+repo7ps2="$tmp/repo7ps2"; mk_push_repo "$repo7ps2" "https://cq:p@${URL_SECRET}@push-probe.invalid/cqlite.git"
+bin7ps2="$tmp/bin7ps2"; mk_push_bin "$bin7ps2"
+gc7ps2="$tmp/gc7ps2"; : >"$gc7ps2"
+run_push "$repo7ps2" "$bin7ps2" "$gc7ps2"; out7ps2=$push_out
+if printf '%s' "$out7ps2" | grep -q 'git push has NO credentials for push-probe.invalid' \
+   && ! printf '%s' "$out7ps2" | grep -qF "$URL_SECRET" \
+   && ! printf '%s' "$out7ps2" | grep -q '@push-probe.invalid'; then
+  ok "push: a password containing '@' does not leak into the printed host (userinfo is split at the LAST '@')"
+else
+  bad "push: the parsed host carried a credential fragment"
+  push_plain "$out7ps2" | grep -E 'push-probe' | head -4
+fi
+
 # 7p-o. A `timeout` THAT REJECTS --kill-after MUST NOT BREAK EVERY BOUND (#3369 review).
 #   --kill-after is GNU coreutils; BusyBox and older implementations reject it, and a
 #   non-GNU `timeout` earlier on PATH than a GNU `gtimeout` would win a first-match-wins
@@ -1456,7 +1505,7 @@ run_push "$repo7pq" "$bin7pq" "$gc7pq" --fix-credentials --strict; out7pq=$push_
 # Guard the guard: if the classification were not https, this case would be testing the
 # same `other` path as 7p-b and its assertion would be vacuous again.
 if printf '%s' "$out7pq" | grep -q 'push-probe.invalid' \
-   && ! printf '%s' "$out7pq" | grep -q "remote is a 'other' remote"; then
+   && ! printf '%s' "$out7pq" | grep -q "is a 'other' remote"; then
   ok "push: (precondition) 7p-q's remote really is classified https"
 else
   bad "push: 7p-q precondition FAILED — not an https classification, the advice assertion below is vacuous"
@@ -1722,6 +1771,18 @@ if [ -z "$lone_tstub" ]; then
 else
   bad "push: a case stubs one timeout candidate; the production loop can escape to the other:"
   printf '%s\n' "$lone_tstub"
+fi
+# Same shape, fourth instance, and this one guards the SCRIPT rather than the suite: no
+# line the bootstrap EMITS may pass the raw remote URL, which can embed a credential while
+# this output is persisted in onboarding logs (#3369 review). Behavioural cases (7p-s)
+# cover the two sites that did; this covers the next one somebody adds. The classification
+# uses of $GIT_ORIGIN_URL in section 3b are untouched — it is only PRINTING that is banned.
+urlprint=$(grep -nE '^[[:space:]]*(info|warn|ok|note|hdr)[[:space:]].*\$GIT_ORIGIN_URL' "$BOOTSTRAP" || true)
+if [ -z "$urlprint" ]; then
+  ok "push: no emitted line prints the raw remote URL (it can embed a credential, and this output is logged)"
+else
+  bad "push: an emitted line prints \$GIT_ORIGIN_URL — print the remote NAME + protocol + parsed host instead:"
+  printf '%s\n' "$urlprint"
 fi
 unguarded=$(grep -n 'bash "\$BOOTSTRAP" --skip-smoke' "$TEST_SELF" | grep -v -- '--skip-push-probe' || true)
 if [ -z "$unguarded" ]; then

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1133,6 +1133,49 @@ else
   echo "skip - push: AC1+AC3 exit-0 assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
 fi
 
+# 7p-k. DELETE REJECTION (#3369 blocker 2). `cmd_smoke` used to emit SMOKE-OK — text and
+#   all: "(create + ls-remote + delete verified)" — after only a stderr `note` when the
+#   cleanup delete failed. Bootstrap then reported VERIFIED and passed --strict on a
+#   machine that had just stranded a ref on the shared origin: a verdict claiming more
+#   than it measured, the same shape as the §3b wording defect one layer down.
+bare7pk="$tmp/bare7pk.git"
+mk_push_bare "$bare7pk" 'zero=0000000000000000000000000000000000000000
+while read -r old new ref; do
+  if [ "$new" = "$zero" ]; then echo "deletion of $ref denied by policy" >&2; exit 1; fi
+done
+exit 0'
+repo7pk="$tmp/repo7pk"; mk_push_repo "$repo7pk" "file://$bare7pk"
+bin7pk="$tmp/bin7pk"; mk_push_bin "$bin7pk"
+gc7pk="$tmp/gc7pk"; : >"$gc7pk"
+run_push "$repo7pk" "$bin7pk" "$gc7pk" --strict; out7pk=$push_out; rc7pk=$push_rc
+if printf '%s' "$out7pk" | grep -q '\[warn\].*git-push: FAILED.*REFUSED the delete' \
+   && ! printf '%s' "$out7pk" | grep -q 'git-push: VERIFIED' \
+   && ! push_green "$out7pk" && [ "$rc7pk" -ne 0 ]; then
+  ok "push: a remote that accepts create but REFUSES delete is FAILED, never VERIFIED (green withheld, --strict exits $rc7pk)"
+else
+  bad "push: delete rejection was reported as success (rc=$rc7pk)"
+  push_verdict "$out7pk"
+fi
+if printf '%s' "$out7pk" | grep -q "git ls-remote .* 'refs/claims/smoke-\*'"; then
+  ok "push: the delete-rejected verdict tells the operator how to list the ref it stranded"
+else
+  bad "push: delete-rejected verdict gave no stray-ref cleanup guidance"
+fi
+# The verdict must come from claim.sh's ANCHORED verdict line AND its exit status, not
+# from a substring anywhere in the captured stream. A claim.sh that prints the token in
+# prose (or on stderr) and then FAILS must not pass.
+printf '#!/usr/bin/env bash\necho "hint: a healthy run prints CLAIM: SMOKE-OK here" >&2\nexit 1\n' \
+  >"$repo7pk/scripts/flow/claim.sh"
+chmod +x "$repo7pk/scripts/flow/claim.sh"
+run_push "$repo7pk" "$bin7pk" "$gc7pk"; out7pk2=$push_out
+if printf '%s' "$out7pk2" | grep -q '\[warn\].*git-push: UNMEASURED' \
+   && ! printf '%s' "$out7pk2" | grep -q '\[ok\].*git-push'; then
+  ok "push: the SMOKE-OK token in unanchored prose (plus a nonzero exit) does NOT satisfy the probe"
+else
+  bad "push: a prose mention of SMOKE-OK was accepted as the verdict"
+  push_verdict "$out7pk2"
+fi
+
 # 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH
 #   directions. They are two channels for ONE fact: the green string is printed iff
 #   WARNINGS is 0, and --strict exits 0 iff WARNINGS is 0. A reviewer proposed keying

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1442,47 +1442,70 @@ else
   push_plain "$out7pq" | grep -E 'git-push|fix:|scopes' | head -5
 fi
 
-# 7p-r. THE FALLBACK REPAIR IS GATED ON AN AFFIRMATIVE gh CONFIRMATION OF THE PUSH HOST
-#   (#3369 review). §3b resolves the host from LOCAL GIT CONFIG (`git remote get-url
-#   --push`), then under --fix-credentials installs a helper that dereferences $GH_TOKEN
-#   FOR THAT HOST, and §3b-push immediately performs a real push to it. Nothing confirmed
-#   the host was one `gh` is authenticated to — so a typo, a leftover fork/mirror pushurl
-#   or a stale `insteadOf` handed a real GitHub token to an unintended host, during a probe
-#   .agent-ami/profile.yaml runs AUTOMATICALLY at every onboard. An invoker who controls the
-#   box is out of the threat model; a MISCONFIGURED REMOTE is reachable BY ACCIDENT, which
-#   this repo's triage rule makes a defect.
+# 7p-r. THE FALLBACK REPAIR IS GATED ON THE ENVIRONMENT TOKEN BEING AUTHORITATIVE FOR THE
+#   PUSH HOST (#3369 review, twice). §3b resolves the host from LOCAL GIT CONFIG (`git
+#   remote get-url --push`), then under --fix-credentials installs a helper that
+#   dereferences $GH_TOKEN FOR THAT HOST, and §3b-push immediately performs a real push to
+#   it — all during a preflight .agent-ami/profile.yaml runs AUTOMATICALLY at every onboard.
+#   A typo, a leftover fork/mirror pushurl or a stale `insteadOf` therefore handed a real
+#   credential to an unintended host. An invoker who controls the box is out of the threat
+#   model; a MISCONFIGURED REMOTE is reachable BY ACCIDENT, which this repo's triage rule
+#   makes a defect.
 #
-#   MEASURED AS A PAIR against one sandbox shape whose ONLY variable is what the gh stub
-#   confirms — without the positive control, "no helper was written" would also be
-#   satisfied by a repair that stopped working altogether.
+#   THE PREDICATE IS TOKEN AUTHORITY, NOT A LOGIN — and this case is built to falsify the
+#   weaker one. The first fix asked `gh auth status --hostname <host>`, which answers "does
+#   gh hold SOME credential for that host?". The sandbox below is the box where those two
+#   facts diverge: gh is authenticated to BOTH github.com and the push host (so the
+#   status check PASSES for both) while the push host's own token is a DIFFERENT value from
+#   $GH_TOKEN — exactly a github.com token on a machine that also has a GitHub Enterprise
+#   host. The preconditions assert that divergence rather than assuming it.
+#
+#   MEASURED AS A PAIR against one sandbox shape whose ONLY variable is which token gh
+#   reports for the push host — without the positive control, "no helper was written"
+#   would also be satisfied by a repair that stopped working altogether.
 #   Both stubs' `gh auth setup-git` installs ONLY the url.<local>.insteadOf rewrite and NO
 #   credential helper, which is what routes the run into the FALLBACK (the branch under
 #   test) while keeping the push itself offline on a local bare repo.
 
-# mk_push_gh_hostaware <dir> <host-gh-confirms> <setup-git-body> — like mk_push_gh, but
-# `gh auth status --hostname H` succeeds ONLY for <host-gh-confirms> and otherwise fails
-# the way the real gh does (stderr + exit 1). A bare `gh auth status` still succeeds, so
-# section 3 and the setup-git branch behave exactly as in every other 7p case.
-mk_push_gh_hostaware() {
-  local dir="$1" confirmed="$2" setup="${3:-:}"
+# mk_push_gh_tokenhost <dir> <host> <token-gh-holds-for-that-host> <setup-git-body> — like
+# mk_push_gh, but modelling a TWO-HOST box:
+#   `gh auth status`              succeeds, listing github.com AND <host>
+#   `gh auth status --hostname H` succeeds for BOTH of them (the insufficient predicate)
+#   `gh auth token --hostname H`  prints $GH_TOKEN for github.com, <token…> for <host>,
+#                                 and fails the way real gh does for anything else
+mk_push_gh_tokenhost() {
+  local dir="$1" host="$2" tok="$3" setup="${4:-:}"
   cat >"$dir/gh" <<EOF
 #!/usr/bin/env bash
+host_arg() {   # the value of --hostname in "\$@", or ""
+  while [ \$# -gt 0 ]; do
+    [ "\$1" = --hostname ] && { printf '%s' "\$2"; return 0; }
+    shift
+  done
+}
 case "\$1" in
   auth)
     if [ "\$2" = status ]; then
-      want=""
-      shift 2
-      while [ \$# -gt 0 ]; do
-        [ "\$1" = --hostname ] && { want="\$2"; shift; }
-        shift
-      done
-      if [ -n "\$want" ] && [ "\$want" != "$confirmed" ]; then
-        echo "You are not logged into any accounts on \$want" >&2
-        exit 1
-      fi
+      shift 2; want="\$(host_arg "\$@")"
+      case "\$want" in
+        ""|github.com|$host) : ;;
+        *) echo "You are not logged into any accounts on \$want" >&2; exit 1 ;;
+      esac
       echo "github.com"
       echo "  ✓ Logged in to github.com account tester (GH_TOKEN)"
       echo "  - Token scopes: 'gist', 'project', 'read:org', 'repo', 'workflow'"
+      echo "$host"
+      echo "  ✓ Logged in to $host account tester (keyring)"
+      echo "  - Token scopes: 'repo', 'workflow'"
+      exit 0
+    elif [ "\$2" = token ]; then
+      shift 2; want="\$(host_arg "\$@")"
+      case "\$want" in
+        ""|github.com) printf '%s\\n' "\${GH_TOKEN:-}" ;;
+        $host)         printf '%s\\n' '$tok' ;;
+        *) echo "no oauth token found for \$want" >&2; exit 1 ;;
+      esac
+      exit 0
     elif [ "\$2" = setup-git ]; then
       $setup
     fi
@@ -1499,22 +1522,26 @@ EOF
 # Saved and restored so no later case inherits it.
 gh_tok_was_set=${GH_TOKEN+1}; gh_tok_saved="${GH_TOKEN-}"
 export GH_TOKEN="$FAKE_TOKEN"
+ENTERPRISE_TOKEN='ghp_ENTERPRISEtoken3369ENTERPRISEtoken33'
 
-# (i) NEGATIVE: gh confirms github.com only, while the push host is push-probe.invalid.
+# (i) NEGATIVE: gh is logged in to the push host, but that host's token is NOT $GH_TOKEN.
 bare7pr="$tmp/bare7pr.git"; mk_push_bare "$bare7pr"
 repo7pr="$tmp/repo7pr"; mk_push_repo "$repo7pr" "https://push-probe.invalid/cqlite.git"
 bin7pr="$tmp/bin7pr"; mk_push_bin "$bin7pr"
-mk_push_gh_hostaware "$bin7pr" github.com \
+mk_push_gh_tokenhost "$bin7pr" push-probe.invalid "$ENTERPRISE_TOKEN" \
   "git config --global \"url.file://$bare7pr/.insteadOf\" 'https://push-probe.invalid/cqlite.git'"
 gc7pr="$tmp/gc7pr"; : >"$gc7pr"
-# Guard the guard, BOTH directions: the stub must refuse the push host and still satisfy a
-# bare `gh auth status` — otherwise the run would stop for an unrelated reason and the
-# assertions below would be vacuous.
-if ! PATH="$bin7pr:$PATH" gh auth status --hostname push-probe.invalid >/dev/null 2>&1 \
-   && PATH="$bin7pr:$PATH" gh auth status >/dev/null 2>&1; then
-  ok "push: (precondition) the gh stub refuses --hostname push-probe.invalid yet is authenticated overall"
+# Guard the guard, and it is the whole point of the case: the WEAKER predicate must PASS
+# here (gh really is logged in to the push host) while the token for that host DIFFERS
+# from $GH_TOKEN. Without this, the assertions below could be satisfied by a stub that
+# simply refuses everything.
+pr_status_ok=0; PATH="$bin7pr:$PATH" gh auth status --hostname push-probe.invalid >/dev/null 2>&1 && pr_status_ok=1
+pr_tok_host=$(PATH="$bin7pr:$PATH" gh auth token --hostname push-probe.invalid 2>/dev/null)
+pr_tok_gh=$(PATH="$bin7pr:$PATH" gh auth token --hostname github.com 2>/dev/null)
+if [ "$pr_status_ok" -eq 1 ] && [ "$pr_tok_host" = "$ENTERPRISE_TOKEN" ] && [ "$pr_tok_gh" = "$FAKE_TOKEN" ]; then
+  ok "push: (precondition) the two-host gh stub CONFIRMS a login for the push host while holding a DIFFERENT token for it"
 else
-  bad "push: 7p-r precondition FAILED — the hostname-aware gh stub does not discriminate"
+  bad "push: 7p-r precondition FAILED — stub does not model the two-host box (status=$pr_status_ok host-token-differs=$([ "$pr_tok_host" != "$FAKE_TOKEN" ] && echo yes || echo no))"
 fi
 run_push "$repo7pr" "$bin7pr" "$gc7pr" --fix-credentials --strict; out7pr=$push_out; rc7pr=$push_rc
 helper7pr=$(git config --file "$gc7pr" --get-all 'credential.https://push-probe.invalid.helper' 2>/dev/null | wc -l | tr -d ' ')
@@ -1522,10 +1549,17 @@ tokleak7pr=$(grep -cF "$FAKE_TOKEN" "$gc7pr" 2>/dev/null || true)
 if [ "${helper7pr:-0}" -eq 0 ] && [ "${tokleak7pr:-0}" -eq 0 ] \
    && printf '%s' "$out7pr" | grep -q '\[warn\].*push-probe.invalid.*REFUSED to configure any' \
    && ! push_green "$out7pr" && [ "$rc7pr" -ne 0 ]; then
-  ok "push: an unconfirmed push host gets NO \$GH_TOKEN helper — the refusal warns, green is withheld, --strict exits $rc7pr"
+  ok "push: a token that is NOT authoritative for the push host is NOT configured for it — the refusal warns, green is withheld, --strict exits $rc7pr"
 else
-  bad "push: a token helper was configured for a host gh does not confirm (helpers=${helper7pr:-0} rc=$rc7pr)"
+  bad "push: a foreign token was configured for the push host (helpers=${helper7pr:-0} rc=$rc7pr)"
   push_plain "$out7pr" | grep -E 'credential|REFUS|git-push' | head -6
+fi
+# Neither token may appear anywhere in the output: the comparison is in-process, and the
+# diagnosis names the HOST, never a secret.
+if ! printf '%s' "$out7pr" | grep -qF "$FAKE_TOKEN" && ! printf '%s' "$out7pr" | grep -qF "$ENTERPRISE_TOKEN"; then
+  ok "push: the authority check prints NEITHER token — the refusal names only the host"
+else
+  bad "push: a token value leaked into the bootstrap output"
 fi
 # ONE verdict, as everywhere else in §3b: the refusal must not also emit the generic
 # "could not configure any" warning, or a single fault would be counted twice.
@@ -1541,12 +1575,12 @@ else
   echo "skip - push: one-warning assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
 fi
 
-# (ii) POSITIVE CONTROL: the SAME sandbox, the SAME fallback path, the ONLY change being
-#      that gh confirms push-probe.invalid — the repair must still happen exactly as before.
+# (ii) POSITIVE CONTROL: the SAME sandbox and the SAME fallback path, the ONLY change being
+#      that gh reports $GH_TOKEN as the push host's own token — the repair must still happen.
 bare7pr2="$tmp/bare7pr2.git"; mk_push_bare "$bare7pr2"
 repo7pr2="$tmp/repo7pr2"; mk_push_repo "$repo7pr2" "https://push-probe.invalid/cqlite.git"
 bin7pr2="$tmp/bin7pr2"; mk_push_bin "$bin7pr2"
-mk_push_gh_hostaware "$bin7pr2" push-probe.invalid \
+mk_push_gh_tokenhost "$bin7pr2" push-probe.invalid "$FAKE_TOKEN" \
   "git config --global \"url.file://$bare7pr2/.insteadOf\" 'https://push-probe.invalid/cqlite.git'"
 gc7pr2="$tmp/gc7pr2"; : >"$gc7pr2"
 run_push "$repo7pr2" "$bin7pr2" "$gc7pr2" --fix-credentials --strict; out7pr2=$push_out; rc7pr2=$push_rc
@@ -1555,9 +1589,9 @@ if [ "${helper7pr2:-0}" -ge 1 ] \
    && printf '%s' "$out7pr2" | grep -q '\[ok\].*git credentials WIRED BY THIS RUN.*push-probe.invalid' \
    && printf '%s' "$out7pr2" | grep -q '\[ok\].*git-push: VERIFIED' \
    && ! printf '%s' "$out7pr2" | grep -q 'REFUSED to configure any'; then
-  ok "push: (positive control) a gh-CONFIRMED host is repaired exactly as before — helper written, credentials WIRED, push VERIFIED"
+  ok "push: (positive control) the AUTHORITATIVE token is repaired exactly as before — helper written, credentials WIRED, push VERIFIED"
 else
-  bad "push: the confirmation gate broke the repair on a confirmed host (helpers=${helper7pr2:-0} rc=$rc7pr2)"
+  bad "push: the authority gate broke the repair on its own host (helpers=${helper7pr2:-0} rc=$rc7pr2)"
   push_plain "$out7pr2" | grep -E 'credential|git-push' | head -6
 fi
 

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -969,13 +969,18 @@ else
   bad "push: credential-shaped rejection not reported as FAILED (rc=$rc7pb, green=$(push_green "$out7pb" && echo yes || echo no))"
   push_verdict "$out7pb"
 fi
-if printf '%s' "$out7pb" | grep -q 'gh auth setup-git' \
-   && printf '%s' "$out7pb" | grep -q -- '--fix-credentials' \
-   && printf '%s' "$out7pb" | grep -q 'contents:write'; then
-  ok "push: an HTTPS auth failure prints the credential remediation AND the write-scope possibility"
+# THIS CASE'S REMOTE IS `file://`, so its subject is the NON-https advice. The assertion
+# used to claim "HTTPS auth failure" while driving exactly this file:// remote — it
+# passed only because the advice branched on `!= ssh` and swept `other` into the https
+# arm, i.e. the test asserted a property it never exercised (#3369 review). The genuine
+# https path is 7p-q below.
+if printf '%s' "$out7pb" | grep -q "remote is a 'other' remote" \
+   && printf '%s' "$out7pb" | grep -q 'credential helper may not apply' \
+   && ! push_plain "$out7pb" | grep -E '^ *fix:' | grep -q 'gh auth setup-git'; then
+  ok "push: a file:// remote's auth-shaped failure gets protocol-neutral advice, NOT https credential advice"
 else
-  bad "push: https FAILED verdict printed no remediation / omitted the scope line"
-  push_plain "$out7pb" | grep -E 'fix:|scopes' | head -4
+  bad "push: a non-https remote was given https credential advice"
+  push_plain "$out7pb" | grep -E 'fix:|remote is a' | head -4
 fi
 
 # 7p-b2. PUSH FAILS, namespace-shaped: a rejection git's stderr does NOT identify as a
@@ -1373,6 +1378,38 @@ if printf '%s' "$out7pp" | grep -q '\[warn\].*git-push: UNMEASURED.*2 push URLs'
 else
   bad "push: multi-destination remote was probed anyway (refs created=$refs7pp rc=$rc7pp)"
   push_verdict "$out7pp"
+fi
+
+# 7p-q. THE GENUINE HTTPS PATH (#3369 review) — the case 7p-b only claimed to be. The
+#   origin really is `https://…` at classification time, so GIT_ORIGIN_KIND is `https`;
+#   the `gh auth setup-git` stub then installs the url.<local>.insteadOf rewrite (as in
+#   7p-e/7p-j), so the push lands on a local bare repo whose pre-receive speaks the
+#   credential signature claim.sh classifies as auth. Offline, no server, no real host —
+#   and the advice under test is the one an https box would actually see.
+bare7pq="$tmp/bare7pq.git"; mk_push_bare "$bare7pq" 'echo "Authentication failed" >&2; exit 1'
+repo7pq="$tmp/repo7pq"; mk_push_repo "$repo7pq" "https://push-probe.invalid/cqlite.git"
+bin7pq="$tmp/bin7pq"
+mk_push_bin "$bin7pq" "git config --global --add 'credential.https://push-probe.invalid.helper' '!f(){ test \"\$1\" = get || exit 0; echo username=gh-stub; echo password=wired; };f'
+      git config --global \"url.file://$bare7pq/.insteadOf\" 'https://push-probe.invalid/cqlite.git'"
+gc7pq="$tmp/gc7pq"; : >"$gc7pq"
+run_push "$repo7pq" "$bin7pq" "$gc7pq" --fix-credentials --strict; out7pq=$push_out; rc7pq=$push_rc
+# Guard the guard: if the classification were not https, this case would be testing the
+# same `other` path as 7p-b and its assertion would be vacuous again.
+if printf '%s' "$out7pq" | grep -q 'push-probe.invalid' \
+   && ! printf '%s' "$out7pq" | grep -q "remote is a 'other' remote"; then
+  ok "push: (precondition) 7p-q's remote really is classified https"
+else
+  bad "push: 7p-q precondition FAILED — not an https classification, the advice assertion below is vacuous"
+fi
+if printf '%s' "$out7pq" | grep -q '\[warn\].*git-push: FAILED.*AUTHENTICATE' \
+   && printf '%s' "$out7pq" | grep -q 'gh auth setup-git' \
+   && printf '%s' "$out7pq" | grep -q -- '--fix-credentials' \
+   && printf '%s' "$out7pq" | grep -q 'contents:write' \
+   && [ "$rc7pq" -ne 0 ]; then
+  ok "push: a real HTTPS auth failure prints the credential remediation AND the write-scope possibility"
+else
+  bad "push: https auth failure printed no remediation / omitted the scope line (rc=$rc7pq)"
+  push_plain "$out7pq" | grep -E 'git-push|fix:|scopes' | head -5
 fi
 
 # 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1100,6 +1100,39 @@ else
   [ -s "$trip7pf" ] && cat "$trip7pf"
 fi
 
+# 7p-j. THE AC1+AC3 END-TO-END CASE — the one whose absence let a defect through with
+#   102 tests green. A fresh UNWIRED box (no credential helper, exactly the pinned-AMI
+#   state) + `--fix-credentials --strict` must end at exit 0 AND print
+#   "All checks green.". The first implementation warned about the missing helper BEFORE
+#   repairing it and could not retract that warning, so verify.run FAILED on a box it had
+#   just successfully repaired — AC1 and AC3 both defeated, invisibly. The §3b verdict is
+#   now emitted once, after the repair, on the FINAL state.
+bare7pj="$tmp/bare7pj.git"; mk_push_bare "$bare7pj"
+repo7pj="$tmp/repo7pj"; mk_push_repo "$repo7pj" "https://push-probe.invalid/cqlite.git"
+bin7pj="$tmp/bin7pj"
+mk_push_bin "$bin7pj" "git config --global --add 'credential.https://push-probe.invalid.helper' '!f(){ test \"\$1\" = get || exit 0; echo username=gh-stub; echo password=wired-by-setup-git; };f'
+      git config --global \"url.file://$bare7pj/.insteadOf\" 'https://push-probe.invalid/cqlite.git'"
+gc7pj="$tmp/gc7pj"; : >"$gc7pj"   # UNWIRED: no helper, no rewrite, as the image ships
+run_push "$repo7pj" "$bin7pj" "$gc7pj" --fix-credentials --strict; out7pj=$push_out; rc7pj=$push_rc
+if printf '%s' "$out7pj" | grep -q '\[ok\].*git credentials WIRED BY THIS RUN' \
+   && ! printf '%s' "$out7pj" | grep -q '\[warn\].*git push has NO credentials' \
+   && printf '%s' "$out7pj" | grep -q '\[ok\].*git-push: VERIFIED'; then
+  ok "push: an unwired box repaired by --fix-credentials reports ONE [ok] verdict — no pre-repair warning survives the repair"
+else
+  bad "push: the repaired box still carries a credential WARNING (verify.run would fail on a box it just fixed)"
+  push_plain "$out7pj" | grep -E 'credential|git-push' | head -6
+fi
+if [ "$base_warns" -eq 1 ]; then
+  if [ "$rc7pj" -eq 0 ] && push_green "$out7pj" && [ "$(push_warns "$out7pj")" -eq 0 ]; then
+    ok "push: AC1+AC3 end to end — unwired box + --fix-credentials --strict => exit 0 AND 'All checks green.'"
+  else
+    bad "push: repaired box did not certify (rc=$rc7pj warns=$(push_warns "$out7pj") green=$(push_green "$out7pj" && echo yes || echo no))"
+    push_plain "$out7pj" | grep -E '\[warn\]' | head -5
+  fi
+else
+  echo "skip - push: AC1+AC3 exit-0 assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
+fi
+
 # 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH
 #   directions. They are two channels for ONE fact: the green string is printed iff
 #   WARNINGS is 0, and --strict exits 0 iff WARNINGS is 0. A reviewer proposed keying

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1442,6 +1442,127 @@ else
   push_plain "$out7pq" | grep -E 'git-push|fix:|scopes' | head -5
 fi
 
+# 7p-r. THE FALLBACK REPAIR IS GATED ON AN AFFIRMATIVE gh CONFIRMATION OF THE PUSH HOST
+#   (#3369 review). §3b resolves the host from LOCAL GIT CONFIG (`git remote get-url
+#   --push`), then under --fix-credentials installs a helper that dereferences $GH_TOKEN
+#   FOR THAT HOST, and §3b-push immediately performs a real push to it. Nothing confirmed
+#   the host was one `gh` is authenticated to — so a typo, a leftover fork/mirror pushurl
+#   or a stale `insteadOf` handed a real GitHub token to an unintended host, during a probe
+#   .agent-ami/profile.yaml runs AUTOMATICALLY at every onboard. An invoker who controls the
+#   box is out of the threat model; a MISCONFIGURED REMOTE is reachable BY ACCIDENT, which
+#   this repo's triage rule makes a defect.
+#
+#   MEASURED AS A PAIR against one sandbox shape whose ONLY variable is what the gh stub
+#   confirms — without the positive control, "no helper was written" would also be
+#   satisfied by a repair that stopped working altogether.
+#   Both stubs' `gh auth setup-git` installs ONLY the url.<local>.insteadOf rewrite and NO
+#   credential helper, which is what routes the run into the FALLBACK (the branch under
+#   test) while keeping the push itself offline on a local bare repo.
+
+# mk_push_gh_hostaware <dir> <host-gh-confirms> <setup-git-body> — like mk_push_gh, but
+# `gh auth status --hostname H` succeeds ONLY for <host-gh-confirms> and otherwise fails
+# the way the real gh does (stderr + exit 1). A bare `gh auth status` still succeeds, so
+# section 3 and the setup-git branch behave exactly as in every other 7p case.
+mk_push_gh_hostaware() {
+  local dir="$1" confirmed="$2" setup="${3:-:}"
+  cat >"$dir/gh" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+  auth)
+    if [ "\$2" = status ]; then
+      want=""
+      shift 2
+      while [ \$# -gt 0 ]; do
+        [ "\$1" = --hostname ] && { want="\$2"; shift; }
+        shift
+      done
+      if [ -n "\$want" ] && [ "\$want" != "$confirmed" ]; then
+        echo "You are not logged into any accounts on \$want" >&2
+        exit 1
+      fi
+      echo "github.com"
+      echo "  ✓ Logged in to github.com account tester (GH_TOKEN)"
+      echo "  - Token scopes: 'gist', 'project', 'read:org', 'repo', 'workflow'"
+    elif [ "\$2" = setup-git ]; then
+      $setup
+    fi
+    exit 0 ;;
+  project) echo '{"id":"PVT_stub"}'; exit 0 ;;
+  api)     echo '{"data":{"node":{"id":"PVT_stub"}}}'; exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$dir/gh"
+}
+
+# The fallback needs a token in the environment or it never reaches the gated branch.
+# Saved and restored so no later case inherits it.
+gh_tok_was_set=${GH_TOKEN+1}; gh_tok_saved="${GH_TOKEN-}"
+export GH_TOKEN="$FAKE_TOKEN"
+
+# (i) NEGATIVE: gh confirms github.com only, while the push host is push-probe.invalid.
+bare7pr="$tmp/bare7pr.git"; mk_push_bare "$bare7pr"
+repo7pr="$tmp/repo7pr"; mk_push_repo "$repo7pr" "https://push-probe.invalid/cqlite.git"
+bin7pr="$tmp/bin7pr"; mk_push_bin "$bin7pr"
+mk_push_gh_hostaware "$bin7pr" github.com \
+  "git config --global \"url.file://$bare7pr/.insteadOf\" 'https://push-probe.invalid/cqlite.git'"
+gc7pr="$tmp/gc7pr"; : >"$gc7pr"
+# Guard the guard, BOTH directions: the stub must refuse the push host and still satisfy a
+# bare `gh auth status` — otherwise the run would stop for an unrelated reason and the
+# assertions below would be vacuous.
+if ! PATH="$bin7pr:$PATH" gh auth status --hostname push-probe.invalid >/dev/null 2>&1 \
+   && PATH="$bin7pr:$PATH" gh auth status >/dev/null 2>&1; then
+  ok "push: (precondition) the gh stub refuses --hostname push-probe.invalid yet is authenticated overall"
+else
+  bad "push: 7p-r precondition FAILED — the hostname-aware gh stub does not discriminate"
+fi
+run_push "$repo7pr" "$bin7pr" "$gc7pr" --fix-credentials --strict; out7pr=$push_out; rc7pr=$push_rc
+helper7pr=$(git config --file "$gc7pr" --get-all 'credential.https://push-probe.invalid.helper' 2>/dev/null | wc -l | tr -d ' ')
+tokleak7pr=$(grep -cF "$FAKE_TOKEN" "$gc7pr" 2>/dev/null || true)
+if [ "${helper7pr:-0}" -eq 0 ] && [ "${tokleak7pr:-0}" -eq 0 ] \
+   && printf '%s' "$out7pr" | grep -q '\[warn\].*push-probe.invalid.*REFUSED to configure any' \
+   && ! push_green "$out7pr" && [ "$rc7pr" -ne 0 ]; then
+  ok "push: an unconfirmed push host gets NO \$GH_TOKEN helper — the refusal warns, green is withheld, --strict exits $rc7pr"
+else
+  bad "push: a token helper was configured for a host gh does not confirm (helpers=${helper7pr:-0} rc=$rc7pr)"
+  push_plain "$out7pr" | grep -E 'credential|REFUS|git-push' | head -6
+fi
+# ONE verdict, as everywhere else in §3b: the refusal must not also emit the generic
+# "could not configure any" warning, or a single fault would be counted twice.
+if [ "$base_warns" -eq 1 ]; then
+  if [ "$(push_warns "$out7pr")" -eq 1 ] \
+     && ! printf '%s' "$out7pr" | grep -q 'could NOT configure any'; then
+    ok "push: the refusal is exactly ONE warning and names the host, not a generic second verdict"
+  else
+    bad "push: refusal emitted $(push_warns "$out7pr") warnings (expected 1)"
+    push_plain "$out7pr" | grep -E '^[[:space:]]+\[warn\] ' | head -4
+  fi
+else
+  echo "skip - push: one-warning assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
+fi
+
+# (ii) POSITIVE CONTROL: the SAME sandbox, the SAME fallback path, the ONLY change being
+#      that gh confirms push-probe.invalid — the repair must still happen exactly as before.
+bare7pr2="$tmp/bare7pr2.git"; mk_push_bare "$bare7pr2"
+repo7pr2="$tmp/repo7pr2"; mk_push_repo "$repo7pr2" "https://push-probe.invalid/cqlite.git"
+bin7pr2="$tmp/bin7pr2"; mk_push_bin "$bin7pr2"
+mk_push_gh_hostaware "$bin7pr2" push-probe.invalid \
+  "git config --global \"url.file://$bare7pr2/.insteadOf\" 'https://push-probe.invalid/cqlite.git'"
+gc7pr2="$tmp/gc7pr2"; : >"$gc7pr2"
+run_push "$repo7pr2" "$bin7pr2" "$gc7pr2" --fix-credentials --strict; out7pr2=$push_out; rc7pr2=$push_rc
+helper7pr2=$(git config --file "$gc7pr2" --get-all 'credential.https://push-probe.invalid.helper' 2>/dev/null | grep -cF 'x-access-token' || true)
+if [ "${helper7pr2:-0}" -ge 1 ] \
+   && printf '%s' "$out7pr2" | grep -q '\[ok\].*git credentials WIRED BY THIS RUN.*push-probe.invalid' \
+   && printf '%s' "$out7pr2" | grep -q '\[ok\].*git-push: VERIFIED' \
+   && ! printf '%s' "$out7pr2" | grep -q 'REFUSED to configure any'; then
+  ok "push: (positive control) a gh-CONFIRMED host is repaired exactly as before — helper written, credentials WIRED, push VERIFIED"
+else
+  bad "push: the confirmation gate broke the repair on a confirmed host (helpers=${helper7pr2:-0} rc=$rc7pr2)"
+  push_plain "$out7pr2" | grep -E 'credential|git-push' | head -6
+fi
+
+if [ -n "${gh_tok_was_set:-}" ]; then export GH_TOKEN="$gh_tok_saved"; else unset GH_TOKEN; fi
+
 # 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH
 #   directions. They are two channels for ONE fact: the green string is printed iff
 #   WARNINGS is 0, and --strict exits 0 iff WARNINGS is 0. A reviewer proposed keying

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1100,6 +1100,53 @@ else
   [ -s "$trip7pf" ] && cat "$trip7pf"
 fi
 
+# 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH
+#   directions. They are two channels for ONE fact: the green string is printed iff
+#   WARNINGS is 0, and --strict exits 0 iff WARNINGS is 0. A reviewer proposed keying
+#   --strict on a narrower "blocking faults only" counter; that would have made a box
+#   with an ADVISORY warning exit 0 from --strict while the unchanged `expect` string
+#   still failed the same run — two channels disagreeing, which is worse than either
+#   alone. This case exists so the next person to have that idea trips a test.
+#
+#   The advisory run below is what gives the case teeth: a machine whose push probe
+#   VERIFIES but which carries an unrelated advisory warning (no Data.db fixtures).
+#   Under a blocking-only --strict it would exit 0 while withholding green.
+repo7pg="$tmp/repo7pg"; mk_push_repo "$repo7pg" "file://$bare7pa"
+rm -f "$repo7pg/test-data/datasets/sstables/ks/tbl/nb-1-big-Data.db"   # one ADVISORY warn
+bin7pg="$tmp/bin7pg"; mk_push_bin "$bin7pg"
+gc7pg="$tmp/gc7pg"; : >"$gc7pg"
+run_push "$repo7pg" "$bin7pg" "$gc7pg" --strict; out7pg=$push_out; rc7pg=$push_rc
+if printf '%s' "$out7pg" | grep -q '\[ok\].*git-push: VERIFIED' \
+   && printf '%s' "$out7pg" | grep -q 'no \*-Data.db files found' \
+   && ! push_green "$out7pg" && [ "$rc7pg" -ne 0 ]; then
+  ok "push: an ADVISORY warning withholds green AND fails --strict, even with push VERIFIED (--strict is not blocking-only)"
+else
+  bad "push: advisory-warning run diverged (rc=$rc7pg, green=$(push_green "$out7pg" && echo yes || echo no))"
+  push_verdict "$out7pg"
+fi
+
+divergence=0; green_runs=0; nongreen_runs=0
+check_divergence() {   # <label> <output> <rc-of-a---strict-run>
+  if push_green "$2"; then
+    green_runs=$((green_runs + 1))
+    [ "$3" -eq 0 ] || { divergence=1; echo "   divergence: $1 printed 'All checks green.' but --strict exited $3"; }
+  else
+    nongreen_runs=$((nongreen_runs + 1))
+    [ "$3" -ne 0 ] || { divergence=1; echo "   divergence: $1 withheld 'All checks green.' but --strict exited 0"; }
+  fi
+}
+check_divergence 7p-a "$out7pa" "$rc7pa"    # verified, clean   -> expect green + 0
+check_divergence 7p-d "$out7pd" "$rc7pd"    # opt-out           -> expect no green + nonzero
+check_divergence 7p-b "$out7pb" "$rc7pb"    # push FAILED       -> expect no green + nonzero
+check_divergence 7p-g "$out7pg" "$rc7pg"    # advisory warning  -> expect no green + nonzero
+if [ "$divergence" -eq 0 ] && [ "$green_runs" -ge 1 ] && [ "$nongreen_runs" -ge 1 ]; then
+  ok "push: --strict's exit code and 'All checks green.' agree in BOTH directions ($green_runs green, $nongreen_runs non-green runs)"
+elif [ "$divergence" -ne 0 ]; then
+  bad "push: --strict and the 'All checks green.' string DIVERGED (see the divergence lines above)"
+else
+  echo "skip - push: divergence check needs both directions (green=$green_runs nongreen=$nongreen_runs on this host)"
+fi
+
 # 7p-h. FLAG HYGIENE. --skip-push-probe and --skip-smoke are different subjects (the
 #   git push probe vs the gate fmt run) and the name similarity is a live hazard, so
 #   both must be documented and each must skip only its own thing. 7p-a ran with

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1305,6 +1305,62 @@ else
   push_plain "$out7pn" | grep -E 'git-push|fix:|ssh' | head -5
 fi
 
+# 7p-o. A `timeout` THAT REJECTS --kill-after MUST NOT BREAK EVERY BOUND (#3369 review).
+#   --kill-after is GNU coreutils; BusyBox and older implementations reject it, and a
+#   non-GNU `timeout` earlier on PATH than a GNU `gtimeout` would win a first-match-wins
+#   lookup. If the selected binary rejects the flag, EVERY bounded call fails — board
+#   probe, credential probe, push probe — and --strict then rejects a healthy machine.
+#   The stub rejects the flag and otherwise delegates to the real binary, so this
+#   measures the SELECTION logic, not a crippled timeout.
+if [ -n "$TIMEOUT_BIN_TEST" ]; then
+  bare7po="$tmp/bare7po.git"; mk_push_bare "$bare7po"
+  repo7po="$tmp/repo7po"; mk_push_repo "$repo7po" "file://$bare7po"
+  bin7po="$tmp/bin7po"; mk_push_bin "$bin7po"
+  mk_stub "$bin7po" timeout 'for a in "$@"; do case "$a" in --kill-after*)
+      echo "timeout: unrecognized option '"'"'$a'"'"'" >&2; exit 125 ;;
+    esac; done
+exec '"$TIMEOUT_BIN_TEST"' "$@"'
+  gc7po="$tmp/gc7po"; : >"$gc7po"
+  run_push "$repo7po" "$bin7po" "$gc7po" --strict; out7po=$push_out; rc7po=$push_rc
+  # The property is that BOUNDED CALLS STILL WORK and the degradation is stated — not
+  # that the whole run stays green. A flag-rejecting timeout also makes the notify
+  # self-test SKIP, which is PRE-EXISTING behaviour (that check has required
+  # --kill-after since before this change), so asserting rc=0 here would be asserting
+  # something about an unrelated section.
+  if printf '%s' "$out7po" | grep -q '\[ok\].*git-push: VERIFIED' \
+     && printf '%s' "$out7po" | grep -q 'does not accept --kill-after' \
+     && ! printf '%s' "$out7po" | grep -q '\[warn\].*git-push'; then
+    ok "push: a timeout that rejects --kill-after still bounds (SIGTERM-only) — the probe VERIFIES and the degradation is STATED"
+  else
+    bad "push: a flag-rejecting timeout broke the bounded calls (rc=$rc7po)"
+    push_plain "$out7po" | grep -E 'git-push|kill-after' | head -4
+  fi
+else
+  echo "skip - push: --kill-after fallback case needs a real timeout/gtimeout to delegate to"
+fi
+
+# 7p-p. A REMOTE WITH SEVERAL PUSH URLs (#3369 review). `git push <remote>` writes to
+#   EVERY configured pushurl while `get-url --push` names only the first, so the probe
+#   would mutate N destinations and could create the ref on A, fail on B and clean
+#   neither. It refuses instead: UNMEASURED, nothing pushed anywhere, green withheld.
+bare7pp1="$tmp/bare7pp1.git"; mk_push_bare "$bare7pp1"
+bare7pp2="$tmp/bare7pp2.git"; mk_push_bare "$bare7pp2"
+repo7pp="$tmp/repo7pp"; mk_push_repo "$repo7pp" "file://$bare7pp1"
+git -C "$repo7pp" remote set-url --add --push origin "file://$bare7pp1" >/dev/null 2>&1
+git -C "$repo7pp" remote set-url --add --push origin "file://$bare7pp2" >/dev/null 2>&1
+bin7pp="$tmp/bin7pp"; mk_push_bin "$bin7pp"
+gc7pp="$tmp/gc7pp"; : >"$gc7pp"
+run_push "$repo7pp" "$bin7pp" "$gc7pp" --strict; out7pp=$push_out; rc7pp=$push_rc
+refs7pp=$(( $(git ls-remote "$bare7pp1" 'refs/claims/*' 2>/dev/null | wc -l) + $(git ls-remote "$bare7pp2" 'refs/claims/*' 2>/dev/null | wc -l) ))
+if printf '%s' "$out7pp" | grep -q '\[warn\].*git-push: UNMEASURED.*2 push URLs' \
+   && ! printf '%s' "$out7pp" | grep -q '\[ok\].*git-push' \
+   && [ "$refs7pp" -eq 0 ] && ! push_green "$out7pp" && [ "$rc7pp" -ne 0 ]; then
+  ok "push: a multi-push-URL remote is UNMEASURED and NOTHING is pushed to either destination (green withheld)"
+else
+  bad "push: multi-destination remote was probed anyway (refs created=$refs7pp rc=$rc7pp)"
+  push_verdict "$out7pp"
+fi
+
 # 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH
 #   directions. They are two channels for ONE fact: the green string is printed iff
 #   WARNINGS is 0, and --strict exits 0 iff WARNINGS is 0. A reviewer proposed keying

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1176,6 +1176,51 @@ else
   push_verdict "$out7pk2"
 fi
 
+# 7p-l. ONE REMOTE, RESOLVED ONCE (#3369 review). The credential half used to read
+#   `origin`'s FETCH url while the push probe pushed to `${CLAIM_REMOTE:-origin}` and
+#   honoured any `pushurl` — so the run could wire and bless host A while pushing to host
+#   B. Both divergences are covered: a non-origin CLAIM_REMOTE, and an origin whose
+#   pushurl differs from its fetch url.
+#
+#   (i) CLAIM_REMOTE names a different remote. `origin` here is a local bare repo that
+#   needs no credential at all; if the credential half still read `origin`, it would emit
+#   the "'other' remote — no credential helper applies" line and never repair anything,
+#   and the push to `upstream` would then be unwired.
+bare7pl="$tmp/bare7pl.git"; mk_push_bare "$bare7pl"
+repo7pl="$tmp/repo7pl"; mk_push_repo "$repo7pl" "file://$tmp/decoy7pl.git"
+git -C "$repo7pl" remote add upstream "https://push-probe.invalid/cqlite.git" >/dev/null 2>&1
+bin7pl="$tmp/bin7pl"
+mk_push_bin "$bin7pl" "git config --global --add 'credential.https://push-probe.invalid.helper' '!f(){ test \"\$1\" = get || exit 0; echo username=gh-stub; echo password=wired; };f'
+      git config --global \"url.file://$bare7pl/.insteadOf\" 'https://push-probe.invalid/cqlite.git'"
+gc7pl="$tmp/gc7pl"; : >"$gc7pl"
+export CLAIM_REMOTE=upstream      # unset immediately after: it must not leak into later cases
+run_push "$repo7pl" "$bin7pl" "$gc7pl" --fix-credentials --strict; out7pl=$push_out; rc7pl=$push_rc
+unset CLAIM_REMOTE
+if printf '%s' "$out7pl" | grep -q '\[ok\].*git credentials WIRED BY THIS RUN.*push-probe.invalid' \
+   && printf '%s' "$out7pl" | grep -q "\[ok\].*git-push: VERIFIED.*'upstream'" \
+   && ! printf '%s' "$out7pl" | grep -q "no credential helper applies"; then
+  ok "push: with CLAIM_REMOTE set, the credential half and the push probe address the SAME remote"
+else
+  bad "push: credential half and push probe addressed different remotes (rc=$rc7pl)"
+  push_plain "$out7pl" | grep -E 'credential|git-push|remote' | head -6
+fi
+
+#   (ii) `origin` with a pushurl that differs from its fetch url. `git push` honours the
+#   pushurl, so the credential subject is the PUSH host — reading the fetch url would
+#   classify this as a local 'other' remote needing no helper at all.
+repo7pl2="$tmp/repo7pl2"; mk_push_repo "$repo7pl2" "file://$tmp/decoy7pl2.git"
+git -C "$repo7pl2" remote set-url --push origin "https://push-probe.invalid/cqlite.git" >/dev/null 2>&1
+bin7pl2="$tmp/bin7pl2"; mk_push_bin "$bin7pl2"
+gc7pl2="$tmp/gc7pl2"; : >"$gc7pl2"
+run_push "$repo7pl2" "$bin7pl2" "$gc7pl2"; out7pl2=$push_out
+if printf '%s' "$out7pl2" | grep -q '\[warn\].*git push has NO credentials for push-probe.invalid' \
+   && ! printf '%s' "$out7pl2" | grep -q "no credential helper applies"; then
+  ok "push: an origin with a differing pushurl is judged on its PUSH host, not its fetch host"
+else
+  bad "push: pushurl was ignored — the credential verdict is about the wrong host"
+  push_plain "$out7pl2" | grep -E 'credential|remote' | head -5
+fi
+
 # 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH
 #   directions. They are two channels for ONE fact: the green string is printed iff
 #   WARNINGS is 0, and --strict exits 0 iff WARNINGS is 0. A reviewer proposed keying

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1349,7 +1349,7 @@ exec '"$TIMEOUT_BIN_TEST"' "$@"'
   if printf '%s' "$out7po" | grep -q '\[ok\].*git-push: VERIFIED' \
      && printf '%s' "$out7po" | grep -q 'does not accept --kill-after' \
      && ! printf '%s' "$out7po" | grep -q '\[warn\].*git-push'; then
-    ok "push: a timeout that rejects --kill-after still bounds (SIGTERM-only) — the probe VERIFIES and the degradation is STATED"
+    ok "push: a timeout that rejects --kill-after is still SELECTED and USED — probes keep working and the SIGTERM-only degradation is STATED"
   else
     bad "push: a flag-rejecting timeout broke the bounded calls (rc=$rc7po)"
     push_plain "$out7po" | grep -E 'git-push|kill-after' | head -4

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1341,17 +1341,20 @@ if [ -n "$TIMEOUT_BIN_TEST" ]; then
 exec '"$TIMEOUT_BIN_TEST"' "$@"'
   gc7po="$tmp/gc7po"; : >"$gc7po"
   run_push "$repo7po" "$bin7po" "$gc7po" --strict; out7po=$push_out; rc7po=$push_rc
-  # The property is that BOUNDED CALLS STILL WORK and the degradation is stated — not
-  # that the whole run stays green. A flag-rejecting timeout also makes the notify
-  # self-test SKIP, which is PRE-EXISTING behaviour (that check has required
-  # --kill-after since before this change), so asserting rc=0 here would be asserting
-  # something about an unrelated section.
-  if printf '%s' "$out7po" | grep -q '\[ok\].*git-push: VERIFIED' \
-     && printf '%s' "$out7po" | grep -q 'does not accept --kill-after' \
-     && ! printf '%s' "$out7po" | grep -q '\[warn\].*git-push'; then
-    ok "push: a timeout that rejects --kill-after is still SELECTED and USED — probes keep working and the SIGTERM-only degradation is STATED"
+  # TWO properties, and the second is the one that matters most. (1) The flag-rejecting
+  # binary is still SELECTED and USED, so the non-mutating probes keep working and the
+  # degradation is STATED — without that, every bounded call would fail and --strict would
+  # reject a healthy machine. (2) The MUTATING push is REFUSED, because a SIGTERM-only
+  # bound provably does not bound a child that ignores SIGTERM and hanging the launcher is
+  # worse than a red verdict. Nothing is pushed, green is withheld, --strict exits nonzero.
+  refs7po=$(git ls-remote "$bare7po" 'refs/claims/*' 2>/dev/null | wc -l | tr -d ' ')
+  if printf '%s' "$out7po" | grep -q 'does not accept --kill-after' \
+     && printf '%s' "$out7po" | grep -q '\[warn\].*git-push: UNMEASURED.*cannot hard-kill' \
+     && ! printf '%s' "$out7po" | grep -q '\[ok\].*git-push' \
+     && [ "${refs7po:-0}" -eq 0 ] && ! push_green "$out7po" && [ "$rc7po" -ne 0 ]; then
+    ok "push: a timeout that cannot hard-kill is still used for other probes, but the MUTATING push is REFUSED — nothing pushed, green withheld, --strict exits $rc7po"
   else
-    bad "push: a flag-rejecting timeout broke the bounded calls (rc=$rc7po)"
+    bad "push: a mutating push ran under a bound that cannot hard-kill (rc=$rc7po refs=${refs7po:-0})"
     push_plain "$out7po" | grep -E 'git-push|kill-after' | head -4
   fi
 else

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1161,6 +1161,18 @@ if printf '%s' "$out7pk" | grep -q "git ls-remote .* 'refs/claims/smoke-\*'"; th
 else
   bad "push: delete-rejected verdict gave no stray-ref cleanup guidance"
 fi
+# The advice must be ACTIONABLE for THIS fault: a successful create already proved
+# authentication, so recommending 'gh auth setup-git' / --fix-credentials would send the
+# operator to fix something that is not broken (#3369 review). It must name the
+# ref-deletion policy instead.
+if ! printf '%s' "$out7pk" | grep -q 'gh auth setup-git' \
+   && ! printf '%s' "$out7pk" | grep -q -- '--fix-credentials' \
+   && printf '%s' "$out7pk" | grep -q 'ref-deletion policy, NOT a credential fault'; then
+  ok "push: delete rejection advises the ref-deletion policy, NOT credentials (the create already authenticated)"
+else
+  bad "push: delete rejection gave credential advice that cannot fix a deletion policy"
+  push_plain "$out7pk" | grep -E 'cause|fix|setup-git' | head -4
+fi
 # The verdict must come from claim.sh's ANCHORED verdict line AND its exit status, not
 # from a substring anywhere in the captured stream. A claim.sh that prints the token in
 # prose (or on stderr) and then FAILS must not pass.

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -961,10 +961,12 @@ else
   push_verdict "$out7pb"
 fi
 if printf '%s' "$out7pb" | grep -q 'gh auth setup-git' \
-   && printf '%s' "$out7pb" | grep -q -- '--fix-credentials'; then
-  ok "push: the FAILED verdict prints the remediation (gh auth setup-git / --fix-credentials)"
+   && printf '%s' "$out7pb" | grep -q -- '--fix-credentials' \
+   && printf '%s' "$out7pb" | grep -q 'contents:write'; then
+  ok "push: an HTTPS auth failure prints the credential remediation AND the write-scope possibility"
 else
-  bad "push: FAILED verdict printed no remediation"
+  bad "push: https FAILED verdict printed no remediation / omitted the scope line"
+  push_plain "$out7pb" | grep -E 'fix:|scopes' | head -4
 fi
 
 # 7p-b2. PUSH FAILS, namespace-shaped: a rejection git's stderr does NOT identify as a
@@ -1278,6 +1280,29 @@ if [ -n "$TIMEOUT_BIN_TEST" ]; then
   fi
 else
   echo "skip - push: bound-escalation guard needs timeout/gtimeout (neither on this host)"
+fi
+
+# 7p-n. SSH REMOTES GET SSH ADVICE (#3369 review). `gh auth setup-git` configures an
+#   HTTPS credential helper and cannot affect key-based auth, so printing it for an SSH
+#   remote sends the operator to fix something that is not in the path — the same
+#   wrong-remedy class as the delete-path advice two rounds ago. It is newly reachable
+#   because this change routes SSH origins into the push probe instead of exempting them.
+#   The branch is keyed on GIT_ORIGIN_KIND (derived from the remote URL, authoritative by
+#   construction), NOT on git's error text: no cause is being classified here.
+#   An `ssh` stub supplies the auth-shaped failure, so nothing contacts a real host.
+repo7pn="$tmp/repo7pn"; mk_push_repo "$repo7pn" "git@push-probe.invalid:owner/repo.git"
+bin7pn="$tmp/bin7pn"; mk_push_bin "$bin7pn"
+mk_stub "$bin7pn" ssh 'echo "git@push-probe.invalid: Permission denied (publickey)." >&2; exit 255'
+gc7pn="$tmp/gc7pn"; : >"$gc7pn"
+run_push "$repo7pn" "$bin7pn" "$gc7pn"; out7pn=$push_out
+if printf '%s' "$out7pn" | grep -q '\[warn\].*git-push: FAILED' \
+   && printf '%s' "$out7pn" | grep -q 'authenticates with your SSH KEY' \
+   && printf '%s' "$out7pn" | grep -q 'ssh-add -l' \
+   && ! push_plain "$out7pn" | grep -E '^ *fix:|^ *  *then re-run' | grep -q 'gh auth setup-git'; then
+  ok "push: an SSH remote's push failure advises SSH keys, NOT 'gh auth setup-git' (which cannot affect key auth)"
+else
+  bad "push: SSH push failure got https credential advice"
+  push_plain "$out7pn" | grep -E 'git-push|fix:|ssh' | head -5
 fi
 
 # 7p-g. `--strict` AND "All checks green." MUST NOT DIVERGE — asserted in BOTH

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -1169,6 +1169,28 @@ else
   bad "push: the two skip flags are not independent"
 fi
 
+# 7p-i. STRUCTURAL GUARD: no case in this suite may point the push probe at a REAL
+#   remote. Behavioural cases only cover the shapes someone already thought of; this
+#   one covers the case NOBODY HAS WRITTEN YET. The probe pushes for real, so a case
+#   that gave a claim.sh-bearing sandbox a github.com origin — or a whole-checkout run
+#   that forgot --skip-push-probe — would mutate the shared origin from a unit test.
+TEST_SELF="$SCRIPT_DIR/$(basename "$0")"
+bad_remote=$(grep -n 'mk_push_repo "\$repo' "$TEST_SELF" \
+  | grep -vE 'file://|push-probe\.invalid|mk_push_repo "\$repo[a-z0-9]*" ""' || true)
+if [ -z "$bad_remote" ]; then
+  ok "push: every claim.sh-bearing sandbox points at a local file:// repo, an empty remote, or push-probe.invalid"
+else
+  bad "push: a sandbox that can PUSH is pointed at a non-local remote:"
+  printf '%s\n' "$bad_remote"
+fi
+unguarded=$(grep -n 'bash "\$BOOTSTRAP" --skip-smoke' "$TEST_SELF" | grep -v -- '--skip-push-probe' || true)
+if [ -z "$unguarded" ]; then
+  ok "push: every run against the REAL checkout passes --skip-push-probe (the suite cannot reach the real origin)"
+else
+  bad "push: a real-checkout run would probe the REAL origin:"
+  printf '%s\n' "$unguarded"
+fi
+
 # --- 8. Board check is a FUNCTIONAL, READ-ONLY probe (issue #2942) ----------
 # The false OK this exists to prevent: a token whose scopes INCLUDE `project` while
 # `gh project` still fails for a missing `read:org`, and the equivalent

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -698,16 +698,43 @@ fi
 #     where GNU coreutils installs `gtimeout` — keying this case off `timeout` alone
 #     would skip it on the one platform whose hang scenarios (locked osxkeychain, a GCM
 #     browser flow) motivated the bound, leaving it uncovered exactly where it matters.
-TIMEOUT_BIN_TEST="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
-# A watchdog for a fixture that IGNORES SIGTERM must be able to escalate to SIGKILL, so
-# it is resolved by the SAME behavioural probe the bootstrap uses (`--kill-after=1 1
-# true`) rather than assumed — a plain `timeout` aimed at a TERM-ignoring child waits
-# FOREVER, and `tooling-tests` is a full-gate component, where a hang is worse than a
-# failure because nothing reports it (#3369 review).
+# MIRRORS PRODUCTION'S CANDIDATE LOOP (#3369 review). Two values, two meanings:
+#   TIMEOUT_BIN_TEST  — the FIRST present candidate (what 7h/7hm need: "is there one?")
+#   TIMEOUT_KILL_TEST — the first present candidate that ACCEPTS --kill-after, which may
+#                       be the SECOND one. A watchdog for a fixture that IGNORES SIGTERM
+#                       must be able to escalate to SIGKILL: a plain `timeout` aimed at
+#                       such a child waits FOREVER, and `tooling-tests` is a full-gate
+#                       component where a hang is worse than a failure (nothing reports
+#                       it). Resolved by the SAME behavioural probe the bootstrap uses.
+# Checking only the FIRST candidate is how the 7p-o portability defect hid: the harness
+# and the code under test disagreed about which binary was in play.
+TIMEOUT_BIN_TEST=""
 TIMEOUT_KILL_TEST=""
-if [ -n "$TIMEOUT_BIN_TEST" ] && "$TIMEOUT_BIN_TEST" --kill-after=1 1 true >/dev/null 2>&1; then
-  TIMEOUT_KILL_TEST="$TIMEOUT_BIN_TEST"
-fi
+for _tbt_name in timeout gtimeout; do
+  _tbt_path="$(command -v "$_tbt_name" 2>/dev/null || true)"
+  [ -n "$_tbt_path" ] || continue
+  [ -n "$TIMEOUT_BIN_TEST" ] || TIMEOUT_BIN_TEST="$_tbt_path"
+  if [ -z "$TIMEOUT_KILL_TEST" ] && "$_tbt_path" --kill-after=1 1 true >/dev/null 2>&1; then
+    TIMEOUT_KILL_TEST="$_tbt_path"
+  fi
+done
+unset _tbt_name _tbt_path
+
+# mk_no_killafter_timeouts <dir> — stub EVERY timeout candidate the production loop tries
+# (`timeout` THEN `gtimeout`) so it cannot escape past the stub to a real binary further
+# along PATH. Stubbing only `timeout` made 7p-o pass on this Linux box (no gtimeout) and
+# FAIL on stock macOS, where GNU coreutils installs `gtimeout` — a supported fleet
+# platform, per bounded()'s own comment. Each stub rejects --kill-after and otherwise
+# delegates to the real binary, so what is measured is the SELECTION logic.
+mk_no_killafter_timeouts() {
+  local dir="$1" real="$2" name
+  for name in timeout gtimeout; do
+    mk_stub "$dir" "$name" 'for a in "$@"; do case "$a" in --kill-after*)
+      echo "'"$name"': unrecognized option '"'"'$a'"'"'" >&2; exit 125 ;;
+    esac; done
+exec '"$real"' "$@"'
+  done
+}
 if [ -n "$TIMEOUT_BIN_TEST" ]; then
   sb7h=$(mktemp -d "$tmp/cred7h.XXXXXX"); stub7h="$tmp/stub7h"
   mk_hermetic_bin "$stub7h"
@@ -1329,16 +1356,16 @@ fi
 #   non-GNU `timeout` earlier on PATH than a GNU `gtimeout` would win a first-match-wins
 #   lookup. If the selected binary rejects the flag, EVERY bounded call fails — board
 #   probe, credential probe, push probe — and --strict then rejects a healthy machine.
-#   The stub rejects the flag and otherwise delegates to the real binary, so this
-#   measures the SELECTION logic, not a crippled timeout.
+#   The stubs reject the flag and otherwise delegate to the real binary, so this measures
+#   the SELECTION logic, not a crippled timeout. BOTH candidates are stubbed: stubbing
+#   only `timeout` left the loop free to select a real `gtimeout` further along PATH, so
+#   the probe ran, no UNMEASURED appeared, and the case FAILED on stock macOS — green
+#   here (Linux, no gtimeout) and red on a supported platform (#3369 review).
 if [ -n "$TIMEOUT_BIN_TEST" ]; then
   bare7po="$tmp/bare7po.git"; mk_push_bare "$bare7po"
   repo7po="$tmp/repo7po"; mk_push_repo "$repo7po" "file://$bare7po"
   bin7po="$tmp/bin7po"; mk_push_bin "$bin7po"
-  mk_stub "$bin7po" timeout 'for a in "$@"; do case "$a" in --kill-after*)
-      echo "timeout: unrecognized option '"'"'$a'"'"'" >&2; exit 125 ;;
-    esac; done
-exec '"$TIMEOUT_BIN_TEST"' "$@"'
+  mk_no_killafter_timeouts "$bin7po" "$TIMEOUT_BIN_TEST"
   gc7po="$tmp/gc7po"; : >"$gc7po"
   run_push "$repo7po" "$bin7po" "$gc7po" --strict; out7po=$push_out; rc7po=$push_rc
   # TWO properties, and the second is the one that matters most. (1) The flag-rejecting
@@ -1497,6 +1524,19 @@ if [ -z "$bad_remote" ]; then
 else
   bad "push: a sandbox that can PUSH is pointed at a non-local remote:"
   printf '%s\n' "$bad_remote"
+fi
+# Same shape, third instance: a case that stubs ONE timeout candidate leaves the
+# production loop free to select a real one further along PATH. That is what made 7p-o
+# pass here and fail on stock macOS, and it is invisible on any host lacking the OTHER
+# candidate — so it is asserted structurally, not behaviourally. The needle is built by
+# concatenation so this guard cannot match its own source line.
+tstub_needle='mk_stub'' "[^"]*" timeout'
+lone_tstub=$(grep -nE "$tstub_needle" "$TEST_SELF" || true)
+if [ -z "$lone_tstub" ]; then
+  ok "push: no case stubs a single timeout candidate — use mk_no_killafter_timeouts (stubs timeout AND gtimeout)"
+else
+  bad "push: a case stubs one timeout candidate; the production loop can escape to the other:"
+  printf '%s\n' "$lone_tstub"
 fi
 unguarded=$(grep -n 'bash "\$BOOTSTRAP" --skip-smoke' "$TEST_SELF" | grep -v -- '--skip-push-probe' || true)
 if [ -z "$unguarded" ]; then

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -56,6 +56,17 @@ export GIT_CONFIG_GLOBAL="$tmp/global-gitconfig"
 export GIT_CONFIG_NOSYSTEM=1
 : >"$GIT_CONFIG_GLOBAL"
 
+# --- REAL-ORIGIN isolation for the push probe (issue #3369) ----------------
+# Section 3b now MEASURES push capability by actually pushing a throwaway
+# refs/claims/smoke-<nonce> ref (scripts/flow/claim.sh smoke). Every case that runs
+# "$BOOTSTRAP" IN PLACE therefore has the real checkout as REPO_ROOT and the real
+# github.com origin as its remote — with this box's real credentials. Those runs pass
+# --skip-push-probe so this suite can NEVER mutate the real origin; the probe's own
+# behaviour is covered hermetically in block 7p below, against sandbox remotes only.
+# Cases that run a COPY of bootstrap in a fake repo are safe without the flag: the
+# probe short-circuits to UNMEASURED when the copy's tree has no scripts/flow/claim.sh
+# (mk_fake_repo only installs it on explicit request), so no network call is made.
+
 # --- BOARD env isolation (issue #2942) -------------------------------------
 # The board section reads CQLITE_PROJECT_{OWNER,NUMBER,ACCOUNT} and PROJECT_TITLE from
 # the environment, and a worker shell commonly EXPORTS them (the fleet exports
@@ -65,19 +76,22 @@ export GIT_CONFIG_NOSYSTEM=1
 unset CQLITE_PROJECT_NUMBER CQLITE_PROJECT_OWNER CQLITE_PROJECT_ACCOUNT PROJECT_TITLE
 
 mkshim() {
-  # mkshim <name>: a fake tool that records "install"/"add" invocations and is
-  # otherwise a harmless no-op (version/status queries succeed emptily).
-  local name="$1"
-  cat >"$tmp/$name" <<EOF
+  # mkshim <name> [dir] [log]: a fake tool that records "install"/"add" invocations
+  # and is otherwise a harmless no-op (version/status queries succeed emptily).
+  # dir/log default to the shared sandbox + tripwire; a case that needs its OWN
+  # install tripwire (7p-f, issue #3369) passes its own and leaves the shared shims
+  # every later case depends on untouched.
+  local name="$1" dir="${2:-$tmp}" log="${3:-$tripwire}"
+  cat >"$dir/$name" <<EOF
 #!/usr/bin/env bash
 for a in "\$@"; do
   case "\$a" in
-    install|add) echo "$name \$*" >>"$tripwire" ;;
+    install|add) echo "$name \$*" >>"$log" ;;
   esac
 done
 exit 0
 EOF
-  chmod +x "$tmp/$name"
+  chmod +x "$dir/$name"
 }
 mkshim brew
 mkshim cargo
@@ -91,7 +105,7 @@ host_home="$tmp/host-home"; mkdir -p "$host_home/.cargo"
 
 # Run with the shims FIRST on PATH, default mode (no --yes), skipping the smoke.
 run_out=$(PATH="$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1); run_rc=$?
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1); run_rc=$?
 
 if [ "$run_rc" -eq 0 ]; then
   ok "default (no --yes) run exits 0"
@@ -122,7 +136,7 @@ done
 # Reset the tripwire so the no-install assertion below reflects ONLY this run.
 : >"$tripwire"
 guard_out=$(PATH="$tmp:/usr/bin:/bin" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$guard_out" | grep -Eq "install sccache:|sccache MISSING"; then
   ok "missing accelerator prints install guidance (does not auto-install)"
 else
@@ -193,7 +207,7 @@ stub_net "$stubA"
 mk_stub "$stubA" mold '[ "$1" = --version ] && echo "mold 2.4.0"; exit 0'
 mk_stub "$stubA" cc 'exit 0'
 outA=$(PATH="$stubA:$PATH" HOME="$sbA" CARGO_HOME="$sbA/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 cfgA="$sbA/.cargo/config.toml"
 if printf '%s' "$outA" | grep -q "Link accelerator: mold"; then
   ok "mold: Linux run emits the mold section"
@@ -221,7 +235,7 @@ fi
 #     identical to the first run.
 firstA=$(cat "$cfgA")
 PATH="$stubA:$PATH" HOME="$sbA" CARGO_HOME="$sbA/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 secondA=$(cat "$cfgA")
 if [ "$(count_begin "$cfgA")" = 1 ] && [ "$firstA" = "$secondA" ]; then
   ok "mold: re-run idempotent (exactly one block, file byte-identical)"
@@ -234,7 +248,7 @@ sbC=$(mktemp -d "$tmp/moldC.XXXXXX"); mkdir -p "$sbC/.cargo"
 cfgC="$sbC/.cargo/config.toml"
 printf '[build]\njobs = 7\n\n[net]\nretry = 9\n' >"$cfgC"
 PATH="$stubA:$PATH" HOME="$sbC" CARGO_HOME="$sbC/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 if grep -qx 'jobs = 7' "$cfgC" && grep -qx 'retry = 9' "$cfgC" \
    && grep -qx '\[build\]' "$cfgC" && grep -qx '\[net\]' "$cfgC" \
    && grep -q '^# BEGIN cqlite-mold' "$cfgC"; then
@@ -246,7 +260,7 @@ fi
 # Idempotent even with user content present.
 firstC=$(cat "$cfgC")
 PATH="$stubA:$PATH" HOME="$sbC" CARGO_HOME="$sbC/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 if [ "$firstC" = "$(cat "$cfgC")" ] && [ "$(count_begin "$cfgC")" = 1 ]; then
   ok "mold: re-run with user content stays byte-identical (one block)"
 else
@@ -261,7 +275,7 @@ mk_stub "$stubD" mold 'exit 0'
 mk_stub "$stubD" cc 'exit 1'
 mk_stub "$stubD" clang 'exit 1'
 outD=$(PATH="$stubD:$PATH" HOME="$sbD" CARGO_HOME="$sbD/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outD" | grep -q "link probe FAILED" \
    && [ ! -f "$sbD/.cargo/config.toml" ]; then
   ok "mold: failed link probe warns and writes no linker config"
@@ -278,7 +292,7 @@ mk_stub "$stubE" mold 'exit 0'
 mk_stub "$stubE" cc 'exit 1'
 mk_stub "$stubE" clang 'exit 0'
 PATH="$stubE:$PATH" HOME="$sbE" CARGO_HOME="$sbE/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 cfgE="$sbE/.cargo/config.toml"
 if [ -f "$cfgE" ] && [ "$(grep -c '^linker = "clang"' "$cfgE")" = 2 ]; then
   ok "mold: clang-only probe writes linker = \"clang\" for both triples"
@@ -294,7 +308,7 @@ stub_net "$stubF"
 mk_stub "$stubF" mold '[ "$1" = --version ] && echo "mold 2.4.0"; exit 0'
 mk_stub "$stubF" cc 'exit 0'
 outF=$(PATH="$stubF:$PATH" HOME="$sbF" CARGO_HOME="$sbF/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if ! printf '%s' "$outF" | grep -q "Link accelerator: mold" \
    && [ ! -f "$sbF/.cargo/config.toml" ]; then
   ok "mold: Darwin performs no mold detection/config (no-op)"
@@ -311,7 +325,7 @@ mk_hermetic_bin "$stubG"
 tripG="$stubG/tripwire.log"; : >"$tripG"
 mk_stub "$stubG" apt-get "echo \"apt-get \$*\" >>\"$tripG\"; exit 0"
 outG=$(PATH="$stubG" HOME="$sbG" CARGO_HOME="$sbG/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outG" | grep -q "mold MISSING" \
    && printf '%s' "$outG" | grep -q "install mold:.*apt-get install -y mold" \
    && [ ! -s "$tripG" ] \
@@ -327,7 +341,7 @@ fi
 sbH=$(mktemp -d "$tmp/moldH.XXXXXX"); stubH="$tmp/stubH"
 mk_hermetic_bin "$stubH"
 outH=$(PATH="$stubH" HOME="$sbH" CARGO_HOME="$sbH/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outH" | grep -q "no supported package manager" \
    && [ ! -f "$sbH/.cargo/config.toml" ]; then
   ok "mold: missing + no package manager warns and writes no config"
@@ -342,7 +356,7 @@ fi
 sbJ=$(mktemp -d "$tmp/moldJ.XXXXXX"); mkdir -p "$sbJ/.cargo"
 printf '[net]\nretry = 4\n' >"$sbJ/.cargo/config"
 PATH="$stubA:$PATH" HOME="$sbJ" CARGO_HOME="$sbJ/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 if grep -q '^# BEGIN cqlite-mold' "$sbJ/.cargo/config" \
    && grep -qx 'retry = 4' "$sbJ/.cargo/config" \
    && [ ! -f "$sbJ/.cargo/config.toml" ]; then
@@ -361,7 +375,7 @@ cfgK="$sbK/.cargo/config.toml"
 printf '[target.x86_64-unknown-linux-gnu]\nrustflags = ["-C", "target-cpu=native"]\n' >"$cfgK"
 beforeK=$(cat "$cfgK")
 outK=$(PATH="$stubA:$PATH" HOME="$sbK" CARGO_HOME="$sbK/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outK" | grep -q "existing \[target" \
    && [ "$beforeK" = "$(cat "$cfgK")" ] \
    && ! grep -q '^# BEGIN cqlite-mold' "$cfgK"; then
@@ -378,7 +392,7 @@ printf '[net]\nretry = 1\n' >"$sbL/.cargo/config"
 printf '[net]\nretry = 2\n' >"$sbL/.cargo/config.toml"
 tomlL_before=$(cat "$sbL/.cargo/config.toml")
 PATH="$stubA:$PATH" HOME="$sbL" CARGO_HOME="$sbL/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke >/dev/null 2>&1
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe >/dev/null 2>&1
 if grep -q '^# BEGIN cqlite-mold' "$sbL/.cargo/config" \
    && ! grep -q '^# BEGIN cqlite-mold' "$sbL/.cargo/config.toml" \
    && [ "$tomlL_before" = "$(cat "$sbL/.cargo/config.toml")" ]; then
@@ -395,7 +409,7 @@ cfgM="$sbM/.cargo/config.toml"
 printf '[build]\nrustflags = ["-C", "target-cpu=native"]\n' >"$cfgM"
 beforeM=$(cat "$cfgM")
 outM=$(PATH="$stubA:$PATH" HOME="$sbM" CARGO_HOME="$sbM/.cargo" \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$outM" | grep -q "existing \[build\] rustflags" \
    && [ "$beforeM" = "$(cat "$cfgM")" ] \
    && ! grep -q '^# BEGIN cqlite-mold' "$cfgM"; then
@@ -461,12 +475,22 @@ fi
 # helper. The copy makes BASH_SOURCE-derived REPO_ROOT resolve to <dir>, so the
 # credential probe reads THIS remote/config, never the real checkout's — and the
 # --yes dataset fetch is a fast no-op (no test-data/scripts/fetch-datasets.sh here).
+# A THIRD argument, `with-claim`, additionally installs scripts/flow/claim.sh — the
+# push-capability probe (issue #3369) delegates to it, and short-circuits to UNMEASURED
+# without ever touching the network when it is absent. That default is what keeps every
+# pre-existing case above from pushing to the real origin: they are unchanged, and their
+# copies have no claim.sh, so no case acquires a network call by inheritance.
 mk_fake_repo() {
-  local dir="$1" url="$2"
+  local dir="$1" url="$2" claim="${3:-}"
   mkdir -p "$dir/scripts"
   cp "$BOOTSTRAP" "$dir/scripts/bootstrap-agent-machine.sh"
+  if [ "$claim" = with-claim ]; then
+    mkdir -p "$dir/scripts/flow"
+    cp "$SCRIPT_DIR/../flow/claim.sh" "$dir/scripts/flow/claim.sh"
+  fi
   git -c init.defaultBranch=main init -q "$dir" >/dev/null 2>&1
-  git -C "$dir" remote add origin "$url" >/dev/null 2>&1
+  [ -n "$url" ] && git -C "$dir" remote add origin "$url" >/dev/null 2>&1
+  return 0
 }
 
 FAKE_TOKEN='ghp_FAKEtoken2942FAKEtoken2942FAKEtoken'
@@ -759,6 +783,312 @@ if printf '%s' "$out7i" | grep -q 'REPO-LOCAL scope only'; then
 else
   bad "cred: repo-local-scope note missed a host-scoped local helper"
   printf '%s\n' "$out7i" | grep -i -A3 "git push credentials"
+fi
+
+# --- 7p. git PUSH capability is MEASURED, not inferred (issue #3369) --------
+# Block 7 covers the CONFIGURATION probe (`git credential fill`). That probe, plus
+# `gh auth status` and `git ls-remote origin HEAD`, are all READS — and the box that
+# motivated #3369 passed every one of them while every `git push` failed, so the
+# launcher's preflight certified a machine on which no lane could start. These cases
+# pin the probe that performs THE OPERATION (create + read back + delete a throwaway
+# refs/claims/smoke-<nonce> ref, via scripts/flow/claim.sh smoke) and — just as
+# importantly — pin that an UNKNOWN answer is never reported green.
+#
+# Hermetic in three layers, because a push probe that escaped the sandbox would mutate
+# the REAL origin:
+#   1. every case runs a COPY of bootstrap in a throwaway repo, so REPO_ROOT is never
+#      this checkout;
+#   2. every origin is either a local `file://` bare repo or `push-probe.invalid` — the
+#      RFC 2606 guaranteed-unresolvable TLD — never a reachable public remote;
+#   3. every whole-checkout run elsewhere in this suite passes --skip-push-probe.
+
+# mk_push_repo <dir> <origin-url|""> — a throwaway checkout that reports ZERO warnings
+# except the ones a case deliberately provokes. Getting to zero matters: "All checks
+# green." is printed only when WARNINGS is 0, so it is the oracle for BOTH "the probe
+# verified" and "the probe withheld green"; a sandbox warning for unrelated reasons
+# would make every green assertion here vacuous. (The precondition below MEASURES that
+# rather than assuming it.)
+mk_push_repo() {
+  local dir="$1" url="$2"
+  mk_fake_repo "$dir" "$url" with-claim
+  mkdir -p "$dir/scripts/lib" "$dir/test-data/datasets/sstables/ks/tbl" "$dir/.home/.cargo"
+  cp "$SCRIPT_DIR/../lib/gate-notify.sh" "$dir/scripts/lib/gate-notify.sh"
+  cp "$SCRIPT_DIR/../perf-capability.sh" "$dir/scripts/perf-capability.sh"
+  : >"$dir/test-data/datasets/sstables/ks/tbl/nb-1-big-Data.db"
+}
+
+# mk_push_bare <dir> [pre-receive-body] — a local bare repo that accepts pushes. With a
+# body, its pre-receive hook decides the push's fate OFFLINE, which is how the FAILED
+# verdicts below are produced deterministically and without a network.
+mk_push_bare() {
+  local dir="$1" hook="${2:-}"
+  git -c init.defaultBranch=main init -q --bare "$dir" >/dev/null 2>&1
+  if [ -n "$hook" ]; then
+    mkdir -p "$dir/hooks"
+    printf '#!/usr/bin/env bash\n%s\n' "$hook" >"$dir/hooks/pre-receive"
+    chmod +x "$dir/hooks/pre-receive"
+  fi
+}
+
+# mk_push_gh <dir> [setup-git-body] — a gh stub that satisfies the auth + board
+# sections (so neither contributes a warning) and runs <setup-git-body> on
+# `gh auth setup-git`.
+mk_push_gh() {
+  local dir="$1" setup="${2:-:}"
+  cat >"$dir/gh" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+  auth)
+    if [ "\$2" = status ]; then
+      echo "github.com"
+      echo "  ✓ Logged in to github.com account tester (GH_TOKEN)"
+      echo "  - Token scopes: 'gist', 'project', 'read:org', 'repo', 'workflow'"
+    elif [ "\$2" = setup-git ]; then
+      $setup
+    fi
+    exit 0 ;;
+  project) echo '{"id":"PVT_stub"}'; exit 0 ;;
+  api)     echo '{"data":{"node":{"id":"PVT_stub"}}}'; exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$dir/gh"
+}
+
+# mk_push_bin <dir> [setup-git-body] — PATH stubs that keep every OTHER section quiet.
+# `uname` reports Darwin so the Linux-only mold + perf sections (whose verdicts depend
+# on the HOST's kernel settings) cannot leak host state into these cases.
+mk_push_bin() {
+  local dir="$1" setup="${2:-:}"
+  mkdir -p "$dir"
+  mk_stub "$dir" uname 'echo Darwin'
+  mk_stub "$dir" sccache 'exit 0'
+  mk_stub "$dir" cargo-nextest 'exit 0'
+  mk_stub "$dir" cargo 'exit 0'
+  mk_stub "$dir" roborev 'exit 0'
+  mk_push_gh "$dir" "$setup"
+}
+
+# run_push <repo> <bin> <gitconfig> [bootstrap args...] — sets push_out and push_rc in
+# the CALLER's shell. Deliberately NOT `out=$(run_push …)`: a command substitution runs
+# the function in a subshell, so push_rc would be discarded — and the EXIT CODE is half
+# of what these cases assert (--strict). Never --yes: nothing here may install. Always
+# --skip-smoke: the gate fmt run is a different subject (and minutes long).
+push_rc=0
+push_out=""
+run_push() {
+  local repo="$1" bin="$2" gc="$3"; shift 3
+  push_rc=0
+  push_out=$(PATH="$bin:$PATH" HOME="$repo/.home" CARGO_HOME="$repo/.home/.cargo" \
+    GIT_CONFIG_GLOBAL="$gc" GIT_CONFIG_NOSYSTEM=1 CLAIM_MACHINE=push-probe-test \
+    CODEX_NOTIFY_WEBHOOK='https://ntfy.example.com/t' \
+    bash "$repo/scripts/bootstrap-agent-machine.sh" --skip-smoke "$@" 2>&1) || push_rc=$?
+}
+push_warns()  { printf '%s' "$1" | grep -cF '[warn]'; }
+push_green()  { printf '%s' "$1" | grep -qF 'All checks green.'; }
+push_verdict(){ printf '%s' "$1" | grep -F 'git-push:' | sed 's/\x1b\[[0-9;]*m//g'; }
+
+# 7p-a/d. THE POSITIVE CONTROL and the OPT-OUT, measured as a pair against ONE sandbox
+#   whose only variable is the flag. Run the opt-out FIRST so its warning count
+#   establishes what the sandbox costs before the probe is even considered.
+bare7pa="$tmp/bare7pa.git"; mk_push_bare "$bare7pa"
+repo7pa="$tmp/repo7pa"; mk_push_repo "$repo7pa" "file://$bare7pa"
+bin7pa="$tmp/bin7pa"; mk_push_bin "$bin7pa"
+gc7pa="$tmp/gc7pa"; : >"$gc7pa"
+run_push "$repo7pa" "$bin7pa" "$gc7pa" --skip-push-probe --strict; out7pd=$push_out; rc7pd=$push_rc
+run_push "$repo7pa" "$bin7pa" "$gc7pa" --strict; out7pa=$push_out; rc7pa=$push_rc
+base_warns=$(push_warns "$out7pd"); probe_warns=$(push_warns "$out7pa")
+
+if printf '%s' "$out7pa" | grep -q '\[ok\].*git-push: VERIFIED' \
+   && printf '%s' "$out7pa" | grep -q 'refs/claims/\*'; then
+  ok "push: a REAL push (create+ls-remote+delete on a local bare repo) is reported VERIFIED as [ok]"
+else
+  bad "push: the probe could not report VERIFIED even against a bare repo that accepts pushes"
+  push_verdict "$out7pa"
+fi
+# The delta is host-independent: the ONLY difference between the two runs is the flag.
+if [ "$probe_warns" -eq $((base_warns - 1)) ]; then
+  ok "push: a VERIFIED probe adds no warning, and --skip-push-probe adds exactly one"
+else
+  bad "push: warning delta wrong (opt-out=$base_warns verified=$probe_warns)"
+fi
+if printf '%s' "$out7pd" | grep -q '\[warn\].*git-push: OPT-OUT (--skip-push-probe)'; then
+  ok "push: --skip-push-probe emits a LOUD [warn] OPT-OUT line (it cannot buy a silent pass)"
+else
+  bad "push: --skip-push-probe was silent or reported ok"
+  push_verdict "$out7pd"
+fi
+if [ "$rc7pd" -ne 0 ] && ! push_green "$out7pd"; then
+  ok "push: --skip-push-probe WITHHOLDS 'All checks green.' and fails --strict (rc=$rc7pd)"
+else
+  bad "push: the opt-out bought a green/zero-exit run (rc=$rc7pd)"
+fi
+# Absolute-green assertions need the sandbox to be otherwise-warning-free. MEASURE that
+# (baseline = exactly the one OPT-OUT warning) instead of assuming it: an exotic host
+# that warns for its own reasons must not produce a mystery red here.
+if [ "$base_warns" -eq 1 ]; then
+  if push_green "$out7pa" && [ "$rc7pa" -eq 0 ]; then
+    ok "push: VERIFIED yields 'All checks green.' and --strict exits 0 (zero warnings)"
+  else
+    bad "push: a verified machine did not go green / --strict did not exit 0 (rc=$rc7pa)"
+    push_verdict "$out7pa"
+  fi
+else
+  echo "skip - push: absolute-green assertions need an otherwise-clean sandbox (baseline=$base_warns warnings)"
+  printf '%s' "$out7pd" | grep -F '[warn]' | sed 's/\x1b\[[0-9;]*m//g' | head -5
+fi
+
+# 7p-b. PUSH FAILS, credential-shaped. The bare repo's pre-receive hook speaks the
+#   signature claim.sh classifies as auth, so this needs no network and no real token.
+bare7pb="$tmp/bare7pb.git"; mk_push_bare "$bare7pb" 'echo "Authentication failed" >&2; exit 1'
+repo7pb="$tmp/repo7pb"; mk_push_repo "$repo7pb" "file://$bare7pb"
+bin7pb="$tmp/bin7pb"; mk_push_bin "$bin7pb"
+gc7pb="$tmp/gc7pb"; : >"$gc7pb"
+run_push "$repo7pb" "$bin7pb" "$gc7pb" --strict; out7pb=$push_out; rc7pb=$push_rc
+if printf '%s' "$out7pb" | grep -q '\[warn\].*git-push: FAILED.*AUTHENTICATE' \
+   && ! push_green "$out7pb" && [ "$rc7pb" -ne 0 ]; then
+  ok "push: a rejected push is a [warn] FAILED naming authentication, green withheld, --strict exits $rc7pb"
+else
+  bad "push: credential-shaped rejection not reported as FAILED (rc=$rc7pb, green=$(push_green "$out7pb" && echo yes || echo no))"
+  push_verdict "$out7pb"
+fi
+if printf '%s' "$out7pb" | grep -q 'gh auth setup-git' \
+   && printf '%s' "$out7pb" | grep -q -- '--fix-credentials'; then
+  ok "push: the FAILED verdict prints the remediation (gh auth setup-git / --fix-credentials)"
+else
+  bad "push: FAILED verdict printed no remediation"
+fi
+
+# 7p-b2. PUSH FAILS, namespace-shaped: a rejection git's stderr does NOT identify as a
+#   credential fault must not be mislabelled as one — and the DEFAULT (no --strict) run
+#   must still exit 0, which is the composability contract this script has always had.
+bare7pb2="$tmp/bare7pb2.git"; mk_push_bare "$bare7pb2" 'echo "denied by ref policy" >&2; exit 1'
+repo7pb2="$tmp/repo7pb2"; mk_push_repo "$repo7pb2" "file://$bare7pb2"
+bin7pb2="$tmp/bin7pb2"; mk_push_bin "$bin7pb2"
+gc7pb2="$tmp/gc7pb2"; : >"$gc7pb2"
+run_push "$repo7pb2" "$bin7pb2" "$gc7pb2"; out7pb2=$push_out; rc7pb2=$push_rc
+if printf '%s' "$out7pb2" | grep -q '\[warn\].*git-push: FAILED.*ref namespace' \
+   && ! printf '%s' "$out7pb2" | grep -q 'git-push: FAILED.*AUTHENTICATE'; then
+  ok "push: a non-credential rejection is reported as a namespace refusal, not as an auth fault"
+else
+  bad "push: namespace rejection misclassified"
+  push_verdict "$out7pb2"
+fi
+if [ "$rc7pb2" -eq 0 ] && ! push_green "$out7pb2"; then
+  ok "push: WITHOUT --strict the script still exits 0 despite warnings (contract preserved)"
+else
+  bad "push: default exit contract broken (rc=$rc7pb2)"
+fi
+
+# 7p-c. THE MOST IMPORTANT CASE: an UNKNOWN answer must not inherit the permissive
+#   branch. The remote does not exist, so NOTHING was learned about push capability —
+#   the verdict must be UNMEASURED, a [warn], and must never be an [ok].
+repo7pc="$tmp/repo7pc"; mk_push_repo "$repo7pc" "file://$tmp/no-such-bare.git"
+bin7pc="$tmp/bin7pc"; mk_push_bin "$bin7pc"
+gc7pc="$tmp/gc7pc"; : >"$gc7pc"
+run_push "$repo7pc" "$bin7pc" "$gc7pc"; out7pc=$push_out; rc7pc=$push_rc
+if printf '%s' "$out7pc" | grep -q '\[warn\].*git-push: UNMEASURED' \
+   && printf '%s' "$out7pc" | grep -q 'git-push: UNMEASURED.*UNKNOWN, not ok'; then
+  ok "push: an unreachable remote is UNMEASURED, and the text names it as UNKNOWN"
+else
+  bad "push: unreachable remote did not produce the UNMEASURED verdict"
+  push_verdict "$out7pc"
+fi
+if ! printf '%s' "$out7pc" | grep -q '\[ok\].*git-push' && ! push_green "$out7pc"; then
+  ok "push: an UNMEASURED probe is NEVER [ok] and NEVER green (affirmative-measurement rule)"
+else
+  bad "push: an unmeasured push capability took the permissive branch"
+  push_verdict "$out7pc"
+fi
+
+# 7p-c2. The other unmeasurable shape: no origin remote at all.
+repo7pc2="$tmp/repo7pc2"; mk_push_repo "$repo7pc2" ""
+bin7pc2="$tmp/bin7pc2"; mk_push_bin "$bin7pc2"
+gc7pc2="$tmp/gc7pc2"; : >"$gc7pc2"
+run_push "$repo7pc2" "$bin7pc2" "$gc7pc2"; out7pc2=$push_out
+if printf '%s' "$out7pc2" | grep -q "\[warn\].*git-push: UNMEASURED.*no 'origin' remote" \
+   && ! printf '%s' "$out7pc2" | grep -q '\[ok\].*git-push'; then
+  ok "push: no origin remote -> UNMEASURED [warn], never [ok]"
+else
+  bad "push: missing origin was not reported as UNMEASURED"
+  push_verdict "$out7pc2"
+fi
+
+# 7p-e. ORDERING: the probe must run AFTER section 3b's credential fix, so what it
+#   measures is the machine as the fix LEFT it. Asserted as a SEQUENCE, not as
+#   co-presence: the `gh auth setup-git` stub is what makes the push reachable at all
+#   (it installs the url.<local>.insteadOf rewrite), so a probe running BEFORE the fix
+#   cannot possibly report VERIFIED — and the negative twin below proves it does not.
+#   The origin is `push-probe.invalid` (RFC 2606: guaranteed not to resolve), so the
+#   unwired run fails offline instead of reaching a real host.
+bare7pe="$tmp/bare7pe.git"; order7pe="$tmp/order7pe.log"; : >"$order7pe"
+mk_push_bare "$bare7pe" "echo PUSH >>\"$order7pe\"; exit 0"
+repo7pe="$tmp/repo7pe"; mk_push_repo "$repo7pe" "https://push-probe.invalid/cqlite.git"
+bin7pe="$tmp/bin7pe"
+mk_push_bin "$bin7pe" "echo SETUP-GIT >>\"$order7pe\"
+      git config --global --add 'credential.https://push-probe.invalid.helper' '!f(){ test \"\$1\" = get || exit 0; echo username=gh-stub; echo password=wired-by-setup-git; };f'
+      git config --global \"url.file://$bare7pe/.insteadOf\" 'https://push-probe.invalid/cqlite.git'"
+# Negative twin FIRST: without --fix-credentials nothing wires the machine, so the
+# probe must NOT report VERIFIED. Without this, "VERIFIED after the fix" would not
+# distinguish a probe that ran after the fix from one that always passes.
+gc7pe1="$tmp/gc7pe1"; : >"$gc7pe1"
+run_push "$repo7pe" "$bin7pe" "$gc7pe1"; out7pe1=$push_out
+twin_log=$(tr '\n' ' ' <"$order7pe")
+if ! printf '%s' "$out7pe1" | grep -q 'git-push: VERIFIED' && [ -z "${twin_log// /}" ]; then
+  ok "push: (negative twin) with no credential fix the probe never reaches the remote and never VERIFIES"
+else
+  bad "push: the unwired machine reported VERIFIED (log=[$twin_log])"
+  push_verdict "$out7pe1"
+fi
+: >"$order7pe"; gc7pe2="$tmp/gc7pe2"; : >"$gc7pe2"
+run_push "$repo7pe" "$bin7pe" "$gc7pe2" --fix-credentials; out7pe2=$push_out
+order_seq=$(sed 's/[^A-Z-]//g' "$order7pe" | tr '\n' ' ' | tr -s ' ')
+if printf '%s' "$out7pe2" | grep -q '\[ok\].*git-push: VERIFIED' \
+   && printf '%s\n' "$order_seq" | grep -q '^SETUP-GIT PUSH'; then
+  ok "push: the probe runs AFTER the credential fix — observed order [$order_seq], verdict VERIFIED"
+else
+  bad "push: fix/probe ordering not established (order=[$order_seq])"
+  push_verdict "$out7pe2"
+fi
+
+# 7p-f. --fix-credentials is NARROW: it wires credentials and installs NOTHING. Turning
+#   the launcher's VERIFY step into a full toolchain installer (which reusing --yes
+#   would have done) is a far larger change to an external contract than #3369 needs,
+#   so the install tripwire must stay empty.
+trip7pf="$tmp/tripwire7pf.log"; : >"$trip7pf"
+bin7pf="$tmp/bin7pf"
+mk_push_bin "$bin7pf" "git config --global --add 'credential.https://push-probe.invalid.helper' '!f(){ test \"\$1\" = get || exit 0; echo username=gh-stub; echo password=wired-by-setup-git; };f'"
+for shim in brew cargo roborev; do mkshim "$shim" "$bin7pf" "$trip7pf"; done
+repo7pf="$tmp/repo7pf"; mk_push_repo "$repo7pf" "https://push-probe.invalid/cqlite.git"
+gc7pf="$tmp/gc7pf"; : >"$gc7pf"
+run_push "$repo7pf" "$bin7pf" "$gc7pf" --fix-credentials; out7pf=$push_out
+if grep -qF 'push-probe.invalid' "$gc7pf" 2>/dev/null && [ ! -s "$trip7pf" ]; then
+  ok "push: --fix-credentials wires the credential helper and installs NOTHING (tripwire empty)"
+else
+  bad "push: --fix-credentials was not narrow (helper=$(grep -c . "$gc7pf" 2>/dev/null) tripwire=$(wc -l <"$trip7pf" 2>/dev/null))"
+  [ -s "$trip7pf" ] && cat "$trip7pf"
+fi
+
+# 7p-h. FLAG HYGIENE. --skip-push-probe and --skip-smoke are different subjects (the
+#   git push probe vs the gate fmt run) and the name similarity is a live hazard, so
+#   both must be documented and each must skip only its own thing. 7p-a ran with
+#   --skip-smoke ALONE and still probed; 7p-d ran with BOTH and skipped only the probe.
+push_help=$(bash "$BOOTSTRAP" --help 2>&1)
+if printf '%s' "$push_help" | grep -q -- '--skip-push-probe' \
+   && printf '%s' "$push_help" | grep -q -- '--skip-smoke' \
+   && printf '%s' "$push_help" | grep -q -- '--fix-credentials' \
+   && printf '%s' "$push_help" | grep -q -- '--strict'; then
+  ok "push: --help documents --skip-push-probe, --skip-smoke, --fix-credentials and --strict"
+else
+  bad "push: --help does not document the new flags"
+fi
+if printf '%s' "$out7pa" | grep -q 'git-push: VERIFIED' \
+   && printf '%s' "$out7pa" | grep -q 'skipped (--skip-smoke)' \
+   && printf '%s' "$out7pd" | grep -q 'git-push: OPT-OUT' \
+   && printf '%s' "$out7pd" | grep -q 'skipped (--skip-smoke)'; then
+  ok "push: --skip-smoke skips only the gate run; --skip-push-probe skips only the push probe"
+else
+  bad "push: the two skip flags are not independent"
 fi
 
 # --- 8. Board check is a FUNCTIONAL, READ-ONLY probe (issue #2942) ----------
@@ -1184,7 +1514,7 @@ fi
 # reported value must name the HOST only.
 redact_out=$(PATH="$tmp:$PATH" HOME="$host_home" CARGO_HOME="$host_home/.cargo" \
   CODEX_NOTIFY_WEBHOOK='https://alice:s3cr3t-token@ntfy.example.com/private-topic' \
-  bash "$BOOTSTRAP" --skip-smoke 2>&1)
+  bash "$BOOTSTRAP" --skip-smoke --skip-push-probe 2>&1)
 if printf '%s' "$redact_out" | grep -q 'notify target configured' \
    && ! printf '%s' "$redact_out" | grep -qE 's3cr3t-token|alice:'; then
   ok "notify: URL userinfo is redacted from the reported target"

--- a/scripts/tests/test_bootstrap_agent_machine.sh
+++ b/scripts/tests/test_bootstrap_agent_machine.sh
@@ -975,11 +975,16 @@ repo7pb2="$tmp/repo7pb2"; mk_push_repo "$repo7pb2" "file://$bare7pb2"
 bin7pb2="$tmp/bin7pb2"; mk_push_bin "$bin7pb2"
 gc7pb2="$tmp/gc7pb2"; : >"$gc7pb2"
 run_push "$repo7pb2" "$bin7pb2" "$gc7pb2"; out7pb2=$push_out; rc7pb2=$push_rc
-if printf '%s' "$out7pb2" | grep -q '\[warn\].*git-push: FAILED.*ref namespace' \
+# The catch-all QUOTES claim.sh's verdict rather than re-wording it (#3369 review): a
+# re-worded catch-all mis-attributed every unrecognised reason code and discarded detail
+# claim.sh had just been fixed to report. So the assertion is that the ORIGINAL verdict
+# line survives into bootstrap's output, and that bootstrap adds no cause of its own.
+if printf '%s' "$out7pb2" | grep -q '\[warn\].*git-push: FAILED' \
+   && push_plain "$out7pb2" | grep -q '^ *CLAIM: SMOKE-FAIL.*reason=push-rejected' \
    && ! printf '%s' "$out7pb2" | grep -q 'git-push: FAILED.*AUTHENTICATE'; then
-  ok "push: a non-credential rejection is reported as a namespace refusal, not as an auth fault"
+  ok "push: an unrecognised SMOKE-FAIL is QUOTED verbatim (reason survives; no auth mis-attribution)"
 else
-  bad "push: namespace rejection misclassified"
+  bad "push: catch-all re-classified instead of quoting"
   push_verdict "$out7pb2"
 fi
 if [ "$rc7pb2" -eq 0 ] && ! push_green "$out7pb2"; then
@@ -1133,7 +1138,7 @@ else
   echo "skip - push: AC1+AC3 exit-0 assertion needs an otherwise-clean sandbox (baseline=$base_warns warnings)"
 fi
 
-# 7p-k. DELETE REJECTION (#3369 blocker 2). `cmd_smoke` used to emit SMOKE-OK — text and
+# 7p-k. AN UNSUCCESSFUL CLEANUP DELETE (#3369 blocker 2). `cmd_smoke` used to emit SMOKE-OK — text and
 #   all: "(create + ls-remote + delete verified)" — after only a stderr `note` when the
 #   cleanup delete failed. Bootstrap then reported VERIFIED and passed --strict on a
 #   machine that had just stranded a ref on the shared origin: a verdict claiming more
@@ -1148,30 +1153,33 @@ repo7pk="$tmp/repo7pk"; mk_push_repo "$repo7pk" "file://$bare7pk"
 bin7pk="$tmp/bin7pk"; mk_push_bin "$bin7pk"
 gc7pk="$tmp/gc7pk"; : >"$gc7pk"
 run_push "$repo7pk" "$bin7pk" "$gc7pk" --strict; out7pk=$push_out; rc7pk=$push_rc
-if printf '%s' "$out7pk" | grep -q '\[warn\].*git-push: FAILED.*REFUSED the delete' \
+if printf '%s' "$out7pk" | grep -q '\[warn\].*git-push: FAILED' \
+   && push_plain "$out7pk" | grep -q 'reason=cleanup-unverified' \
    && ! printf '%s' "$out7pk" | grep -q 'git-push: VERIFIED' \
    && ! push_green "$out7pk" && [ "$rc7pk" -ne 0 ]; then
-  ok "push: a remote that accepts create but REFUSES delete is FAILED, never VERIFIED (green withheld, --strict exits $rc7pk)"
+  ok "push: an unsuccessful cleanup delete is FAILED, never VERIFIED (green withheld, --strict exits $rc7pk)"
 else
-  bad "push: delete rejection was reported as success (rc=$rc7pk)"
+  bad "push: delete failure was reported as success (rc=$rc7pk)"
   push_verdict "$out7pk"
 fi
-if printf '%s' "$out7pk" | grep -q "git ls-remote .* 'refs/claims/smoke-\*'"; then
-  ok "push: the delete-rejected verdict tells the operator how to list the ref it stranded"
+if push_plain "$out7pk" | grep -q "git ls-remote .* refs/claims/smoke-"; then
+  ok "push: the quoted verdict reaches the operator with the ls-remote check for the possibly-stranded ref"
 else
-  bad "push: delete-rejected verdict gave no stray-ref cleanup guidance"
+  bad "push: cleanup-unverified verdict lost its stray-ref guidance in transit"
+  push_plain "$out7pk" | grep -E 'CLAIM:|git-push' | head -3
 fi
-# The advice must be ACTIONABLE for THIS fault: a successful create already proved
-# authentication, so recommending 'gh auth setup-git' / --fix-credentials would send the
-# operator to fix something that is not broken (#3369 review). It must name the
-# ref-deletion policy instead.
+# NO CAUSE MAY BE ATTRIBUTED (#3369 review). One nonzero exit cannot tell a deletion
+# policy from a network drop from a post-readback auth failure, so neither claim.sh nor
+# bootstrap may name one — and in particular bootstrap must not fall back to credential
+# advice, which was the wrong-remedy defect one round earlier.
 if ! printf '%s' "$out7pk" | grep -q 'gh auth setup-git' \
    && ! printf '%s' "$out7pk" | grep -q -- '--fix-credentials' \
-   && printf '%s' "$out7pk" | grep -q 'ref-deletion policy, NOT a credential fault'; then
-  ok "push: delete rejection advises the ref-deletion policy, NOT credentials (the create already authenticated)"
+   && ! printf '%s' "$out7pk" | grep -qi 'ref-deletion policy' \
+   && push_plain "$out7pk" | grep -q 'no cause is attributed'; then
+  ok "push: a failed cleanup attributes NO cause and gives no credential advice — it reports the observation"
 else
-  bad "push: delete rejection gave credential advice that cannot fix a deletion policy"
-  push_plain "$out7pk" | grep -E 'cause|fix|setup-git' | head -4
+  bad "push: an unsupportable cause (or credential advice) was attached to a failed cleanup"
+  push_plain "$out7pk" | grep -E 'CLAIM:|cause|setup-git' | head -4
 fi
 # The verdict must come from claim.sh's ANCHORED verdict line AND its exit status, not
 # from a substring anywhere in the captured stream. A claim.sh that prints the token in

--- a/scripts/tests/test_claim_lock.sh
+++ b/scripts/tests/test_claim_lock.sh
@@ -665,7 +665,7 @@ else
 $outSmokeAuth"
 fi
 
-# (g) smoke on a remote that ACCEPTS the create and REFUSES the delete (#3369). It used
+# (g) smoke on a remote that ACCEPTS the create and refuses the delete (#3369). It used
 # to emit SMOKE-OK — whose own text says "delete verified" — after a stderr-only warning,
 # so a caller could not tell a clean cycle from a stranded ref. Delete capability is
 # REQUIRED: `release` deletes refs/claims/issue-<N>, so such a namespace is unusable.
@@ -682,12 +682,18 @@ HOOK
 chmod +x "$DELORIGIN/hooks/pre-receive"
 rc=0; outSmokeDel=$( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE="$DELORIGIN" bash "$CLAIM" smoke 2>/dev/null ) || rc=$?
 strayDel=$(gg -C "$A" ls-remote "$DELORIGIN" 'refs/claims/smoke-*' | wc -l | tr -d ' ')
+# The reason code states the OBSERVATION (a nonzero cleanup exit) and attributes NO
+# cause: one exit status cannot distinguish this remote's deletion policy from a network
+# drop or a post-readback auth failure, and naming one would be the affirmative-
+# measurement violation this whole change exists to remove (#3369 review).
 if [ "$rc" -ne 0 ] && printf '%s\n' "$outSmokeDel" | grep -q 'SMOKE-FAIL' \
-   && printf '%s\n' "$outSmokeDel" | grep -q 'reason=delete-rejected' \
+   && printf '%s\n' "$outSmokeDel" | grep -q 'reason=cleanup-unverified' \
+   && printf '%s\n' "$outSmokeDel" | grep -q 'no cause is attributed' \
+   && printf '%s\n' "$outSmokeDel" | grep -q 'UNPROVEN' \
    && ! printf '%s\n' "$outSmokeDel" | grep -q 'SMOKE-OK'; then
-  ok "(g) smoke on a delete-refusing remote → SMOKE-FAIL reason=delete-rejected, never SMOKE-OK (stray refs on that remote: $strayDel)"
+  ok "(g) smoke whose cleanup delete fails → SMOKE-FAIL reason=cleanup-unverified, no cause attributed, never SMOKE-OK (refs left on that remote: $strayDel)"
 else
-  bad "(g) expected SMOKE-FAIL reason=delete-rejected; got rc=$rc
+  bad "(g) expected SMOKE-FAIL reason=cleanup-unverified attributing no cause; got rc=$rc
 $outSmokeDel"
 fi
 # Positive control: the SAME probe against the ordinary origin still succeeds, so (g) is

--- a/scripts/tests/test_claim_lock.sh
+++ b/scripts/tests/test_claim_lock.sh
@@ -705,6 +705,65 @@ else
 $outSmokeOk"
 fi
 
+# (h) readback failure AND delete failure at once (#3369 review). The mismatch branch
+# returned before reporting the delete result, so the ONE path that can leave a ref on the
+# shared origin said nothing about it. Reproduced honestly: a post-receive hook removes
+# whatever was just pushed, so the readback finds nothing AND the delete then fails
+# ("remote ref does not exist"). The verdict must keep reason=ls-remote-mismatch (no new
+# variant) and carry the cleanup-delete failure with the ls-remote check.
+GHOSTORIGIN="$T/ghost.git"
+gg init --bare -q "$GHOSTORIGIN"
+# post-receive removes what the create just wrote -> the readback finds nothing;
+# pre-receive refuses deletions (all-zeros new sha) -> the cleanup delete also fails.
+# Both halves are needed: deleting an already-absent ref is a no-op SUCCESS for
+# receive-pack, so the post-receive alone leaves delete_ok=1 (measured).
+cat >"$GHOSTORIGIN/hooks/post-receive" <<'HOOK'
+#!/usr/bin/env bash
+while read -r old new ref; do git update-ref -d "$ref" 2>/dev/null || true; done
+exit 0
+HOOK
+cat >"$GHOSTORIGIN/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+zero=0000000000000000000000000000000000000000
+while read -r old new ref; do
+  if [ "$new" = "$zero" ]; then echo "deletion of $ref denied by policy" >&2; exit 1; fi
+done
+exit 0
+HOOK
+chmod +x "$GHOSTORIGIN/hooks/post-receive" "$GHOSTORIGIN/hooks/pre-receive"
+rc=0; outGhost=$( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE="$GHOSTORIGIN" bash "$CLAIM" smoke 2>/dev/null ) || rc=$?
+if [ "$rc" -ne 0 ] && printf '%s\n' "$outGhost" | grep -q 'reason=ls-remote-mismatch' \
+   && printf '%s\n' "$outGhost" | grep -q 'cleanup-delete=FAILED' \
+   && printf '%s\n' "$outGhost" | grep -q 'git ls-remote' \
+   && ! printf '%s\n' "$outGhost" | grep -q 'SMOKE-OK'; then
+  ok "(h) readback mismatch + failed cleanup → one verdict naming BOTH, with the ls-remote check"
+else
+  bad "(h) expected reason=ls-remote-mismatch carrying cleanup-delete=FAILED; got rc=$rc
+$outGhost"
+fi
+# Control: a readback mismatch whose cleanup SUCCEEDS must NOT claim a cleanup failure,
+# or the field above would be noise rather than a signal. Same ghost remote, but the hook
+# deletes only on a CREATE (new != zeros), so the probe's own delete still succeeds.
+CLEANORIGIN="$T/ghost-clean.git"
+gg init --bare -q "$CLEANORIGIN"
+cat >"$CLEANORIGIN/hooks/post-receive" <<'HOOK'
+#!/usr/bin/env bash
+zero=0000000000000000000000000000000000000000
+while read -r old new ref; do
+  [ "$new" = "$zero" ] || git update-ref -d "$ref" 2>/dev/null || true
+done
+exit 0
+HOOK
+chmod +x "$CLEANORIGIN/hooks/post-receive"
+rc=0; outGhost2=$( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE="$CLEANORIGIN" bash "$CLAIM" smoke 2>/dev/null ) || rc=$?
+if [ "$rc" -ne 0 ] && printf '%s\n' "$outGhost2" | grep -q 'reason=ls-remote-mismatch' \
+   && ! printf '%s\n' "$outGhost2" | grep -q 'cleanup-delete=FAILED'; then
+  ok "(h) control: a mismatch whose cleanup SUCCEEDED reports no cleanup failure"
+else
+  bad "(h) control: cleanup-delete=FAILED reported on a successful cleanup; rc=$rc
+$outGhost2"
+fi
+
 # ===========================================================================
 echo
 echo "==== CLAIM-LOCK TEST SUMMARY: PASS=$PASS FAIL=$FAIL ===="

--- a/scripts/tests/test_claim_lock.sh
+++ b/scripts/tests/test_claim_lock.sh
@@ -770,6 +770,37 @@ else
 $outGhost2"
 fi
 
+# (i) THE SMOKE REF NAME IS CONTENT-ADDRESSED, NOT AN AD-HOC NONCE (#3369 review).
+# It used to be `$$-${RANDOM}-$(date -u +%s)`. Bash seeds $RANDOM from pid+time, so on
+# identically provisioned machines booting simultaneously — a fleet launched from ONE AMI,
+# this issue's own subject — pid, $RANDOM and a second-resolution timestamp are correlated
+# rather than independent, and two boxes can pick the SAME name against the shared origin:
+# a spurious push rejection, `git-push: FAILED`, and `--strict` refusing a healthy box.
+# No race is provoked here (a passing race proves nothing); the PROPERTY is asserted —
+# distinct names across runs, each one the sha of THIS run's claim commit, which is unique
+# to its machine+pid+two-$RANDOMs+timestamp message.
+strayI_before=$(gg -C "$A" ls-remote origin 'refs/claims/smoke-*' | wc -l | tr -d ' ')
+rcI1=0; outI1=$( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" smoke 2>&1 ) || rcI1=$?
+rcI2=0; outI2=$( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" smoke 2>&1 ) || rcI2=$?
+strayI_after=$(gg -C "$A" ls-remote origin 'refs/claims/smoke-*' | wc -l | tr -d ' ')
+# The name is announced in the probe's own note line, which is where an operator chasing a
+# stranded ref reads it — so that is what is parsed, not an internal variable.
+refI1=$(printf '%s\n' "$outI1" | grep -oE 'refs/claims/smoke-[0-9a-f]{40}' | head -1)
+refI2=$(printf '%s\n' "$outI2" | grep -oE 'refs/claims/smoke-[0-9a-f]{40}' | head -1)
+# Guard the guard: a 40-hex suffix could be hex-shaped by accident. It must be the OBJECT
+# NAME of this run's smoke claim commit, which is the whole content-addressed claim.
+objI1=$(gg -C "$A" cat-file commit "${refI1##*-}" 2>/dev/null | grep -c 'claim issue=smoke' || true)
+if [ "$rcI1" -eq 0 ] && [ "$rcI2" -eq 0 ] \
+   && printf '%s\n' "$outI1" | grep -q 'SMOKE-OK' && printf '%s\n' "$outI2" | grep -q 'SMOKE-OK' \
+   && [ -n "$refI1" ] && [ -n "$refI2" ] && [ "$refI1" != "$refI2" ] \
+   && [ "${objI1:-0}" -ge 1 ] && [ "$strayI_after" = "$strayI_before" ]; then
+  ok "(i) two smoke runs on ONE origin use DISTINCT content-addressed refs (each = its own claim commit's sha), both SMOKE-OK, no strays left"
+else
+  bad "(i) smoke ref names are not distinct/content-addressed: rc=$rcI1/$rcI2 ref1=$refI1 ref2=$refI2 commit-match=${objI1:-0} strays $strayI_before -> $strayI_after
+$outI1
+$outI2"
+fi
+
 # ===========================================================================
 echo
 echo "==== CLAIM-LOCK TEST SUMMARY: PASS=$PASS FAIL=$FAIL ===="

--- a/scripts/tests/test_claim_lock.sh
+++ b/scripts/tests/test_claim_lock.sh
@@ -665,6 +665,46 @@ else
 $outSmokeAuth"
 fi
 
+# (g) smoke on a remote that ACCEPTS the create and REFUSES the delete (#3369). It used
+# to emit SMOKE-OK — whose own text says "delete verified" — after a stderr-only warning,
+# so a caller could not tell a clean cycle from a stranded ref. Delete capability is
+# REQUIRED: `release` deletes refs/claims/issue-<N>, so such a namespace is unusable.
+DELORIGIN="$T/deleteproof.git"
+gg init --bare -q "$DELORIGIN"
+cat >"$DELORIGIN/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+zero=0000000000000000000000000000000000000000
+while read -r old new ref; do
+  if [ "$new" = "$zero" ]; then echo "deletion of $ref denied by policy" >&2; exit 1; fi
+done
+exit 0
+HOOK
+chmod +x "$DELORIGIN/hooks/pre-receive"
+rc=0; outSmokeDel=$( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE="$DELORIGIN" bash "$CLAIM" smoke 2>/dev/null ) || rc=$?
+strayDel=$(gg -C "$A" ls-remote "$DELORIGIN" 'refs/claims/smoke-*' | wc -l | tr -d ' ')
+if [ "$rc" -ne 0 ] && printf '%s\n' "$outSmokeDel" | grep -q 'SMOKE-FAIL' \
+   && printf '%s\n' "$outSmokeDel" | grep -q 'reason=delete-rejected' \
+   && ! printf '%s\n' "$outSmokeDel" | grep -q 'SMOKE-OK'; then
+  ok "(g) smoke on a delete-refusing remote → SMOKE-FAIL reason=delete-rejected, never SMOKE-OK (stray refs on that remote: $strayDel)"
+else
+  bad "(g) expected SMOKE-FAIL reason=delete-rejected; got rc=$rc
+$outSmokeDel"
+fi
+# Positive control: the SAME probe against the ordinary origin still succeeds, so (g) is
+# measuring the delete refusal and not a broken probe.
+# Count NEW strays only: TEST 19 above deliberately leaves a `refs/claims/smoke-stray`
+# on origin, so an absolute count of 0 is the wrong oracle — the property is that THIS
+# probe adds none.
+strayBefore=$(gg -C "$A" ls-remote origin 'refs/claims/smoke-*' | wc -l | tr -d ' ')
+rc=0; outSmokeOk=$( cd "$A" && CLAIM_MACHINE=machineA CLAIM_REMOTE=origin bash "$CLAIM" smoke 2>/dev/null ) || rc=$?
+strayAfter=$(gg -C "$A" ls-remote origin 'refs/claims/smoke-*' | wc -l | tr -d ' ')
+if [ "$rc" -eq 0 ] && printf '%s\n' "$outSmokeOk" | grep -q 'SMOKE-OK' && [ "$strayAfter" = "$strayBefore" ]; then
+  ok "(g) positive control: a normal remote still yields SMOKE-OK and leaves NO new stray ref"
+else
+  bad "(g) positive control failed: rc=$rc strays $strayBefore -> $strayAfter
+$outSmokeOk"
+fi
+
 # ===========================================================================
 echo
 echo "==== CLAIM-LOCK TEST SUMMARY: PASS=$PASS FAIL=$FAIL ===="


### PR DESCRIPTION
Closes #3369.

## What was wrong

A worker box launched from the pinned agent-ami image has a working `gh` but **no git credential helper**, so the first thing a lane does — `scripts/flow/claim.sh claim <N>`, a plain `git push` of a claim ref — fails `CLAIM: ERROR reason=auth`. The box passes every read-side probe first (`gh auth status` green, `git ls-remote origin HEAD` succeeds), so it looks healthy right up to the moment it burns a lane start.

Two independent in-repo defects let that through. Both are in the path the launcher actually executes.

### 1. The preflight measured configuration and reported it as capability

`scripts/bootstrap-agent-machine.sh` §3b probed credentials with `git credential fill` and asserted a non-empty `password=`. Its own header comment says what it does: "without contacting the network and without pushing anything". It then printed:

```
[ok]   git push credentials resolve for github.com (a helper answers with a non-empty secret)
```

That sentence claims **push resolution** on the strength of a probe that never pushes. A token lacking `contents:write`, or a host rejecting the `refs/claims/*` namespace, passes it. This is #3369's AC3 defect living in this repository, and it is the generalized form of a sentence already in `docs/development/agent-machine-setup.md:47` — *"A scope match is evidence about a token, not about the operation."*

### 2. The verify step could not fix what it recommended

`.agent-ami/profile.yaml`'s `verify.run` invoked the bootstrap with **no flags**. §3b's auto-fix — which prefers `gh auth setup-git` — only runs under `--yes`. So the onboarder's own verification step was structurally incapable of wiring the credential path it told the operator to wire. This gap is not mentioned in the issue; it was found while mapping the surface.

## What changed

**A real push-capability probe (new §3b-push).** It measures the operation by performing it, delegating to the existing sanctioned probe `claim.sh smoke` — create + read back + delete a throwaway `refs/claims/smoke-<nonce>` ref. It is **three-valued**, and that is the load-bearing property:

| verdict | condition | severity |
|---|---|---|
| `git-push: VERIFIED` | `SMOKE-OK` — affirmatively measured | `ok` |
| `git-push: FAILED` | push rejected / git cannot authenticate | `warn` + remediation |
| `git-push: UNMEASURED` | no git, no remote, unreachable remote, no `timeout` binary, claim commit unbuildable | `warn` — **not** `ok` |
| `git-push: OPT-OUT` | `--skip-push-probe` | `warn` — visible, never silent |

The permissive branch keys on the affirmative `SMOKE-OK`, never on the absence of a bad signal. An unmeasured push capability is **unknown, not ok** — per CLAUDE.md, *"where an oracle is the SOLE evidence for a claim and could not be consulted the verdict is NON-PASSING and its text names what was unverifiable."* The probe refuses to run at all rather than run unbounded when no `timeout`/`gtimeout` exists.

**`--fix-credentials`** runs §3b's auto-fix (preferring `gh auth setup-git`) and nothing else, so verify stays a verification step instead of becoming a toolchain installer — which reusing `--yes` would have made it.

**`--strict`** exits nonzero when warnings > 0. The script's documented default `exit 0` is preserved (it composes into setup scripts). Before this, the bootstrap **always exited 0**, so the sole fail-closed signal was the literal string `All checks green.` on stdout — a **text proxy standing in for a status**, where any change to the message silently disables the guard. Both channels now carry the verdict, and a test pins them as complementary in both directions so they cannot drift apart.

**`verify.run` becomes `bash scripts/bootstrap-agent-machine.sh --fix-credentials --strict`.**

`hooks.pre_verify` / `hooks.post_toolchain` are deliberately left empty: their schema is defined by the **external** launcher and nothing in this repo documents or consumes it, so a command placed there would be a guess at an external contract, and a wrong guess breaks onboarding fleet-wide. `verify.run`'s shape is known and already exercised on every launch.

## The conditional — please read this before concluding anything about a fresh box

**This change makes the preflight fail closed IF the launcher reads it. Whether it does is unverified, and is tracked in #3470.**

The box that produced #3369 reported `onboarded (skip-verify)` — its profile's own `verify.run` never ran. On the one box where we have evidence, the launcher did not consult the verify step at all. If that is the general behaviour, the work in this PR ships as **a guard with an empty subject set — green because nothing consults it**. #3470 leads with that question precisely because it is the precondition for this PR's value, not a nice-to-have alongside it.

Nothing here establishes that a fresh box now fails loudly. It establishes that the verify step now emits a truthful, fail-closed verdict on both available channels.

## A measurement that cuts both ways

All three live fleet boxes currently return `credential.https://github.com.helper` from `git config --global --get-regexp credential`. The fleet is **green** on the exact property this issue says the image gets wrong.

That is confirmation, not refutation: they are green only because they were **repaired by hand** today (`gh auth setup-git` / `bootstrap --yes`, after `claim.sh` failed `reason=auth` on a box whose `gh auth` was green). A fresh box from the pinned AMI remains the untested case. **Any probe run against a working fleet reports fine — which is precisely why this defect survived.** The property was *restored*, not *held*.

## Behaviour change worth knowing

The push probe **performs a real push on every bootstrap invocation**, including a developer's laptop run: two network round trips plus a transient `refs/claims/smoke-<nonce>` ref created and deleted on the shared origin. `cmd_smoke` was written as a one-time preflight that "mutates the REAL origin", so this is a deliberate widening — measuring the operation is the whole point of AC3, and making it opt-in would recreate the read-probe-by-default defect this PR exists to remove.

Residual: `cmd_smoke` only *warns* if its cleanup delete fails, so a stranded ref is possible. List them with `git ls-remote origin 'refs/claims/smoke-*'`. Not fixed here (out of scope, in `claim.sh`'s hot file); documented in `docs/development/fleet-runbook.md`.

## Gate of record — PASS

Run on box1 (not this lane's box), run-id `/tmp/agent-gate.TJkKYO`:

```
commit:          b677a16   branch: HEAD   dirty: no
tree-start:      b677a16b9afd  dirty: no  digest: d4076cd9fb99
tree-end:        b677a16b9afd  dirty: no  digest: d4076cd9fb99
tree-integrity:  PASS
tooling-tests:   PASS (839s)
RESULT:          PASS
```

31/31 components, `nonpass=0`. `tree-start == tree-end` on identical digests, so the tree was stable for the whole run. `commit:` re-checked against origin and still this PR's head, so the PASS is current rather than historical. GitHub's `required` is independently SUCCESS at this head. `perf=paranoid-4` / `mold=absent` are expected off box3 and advisory for a gate.

**`tooling-tests` at 839s was the longest single component of any gate on the fleet that day** — and that is the component that covers this diff. The suite that proves the fix grew from **80 → 126 asserts (+58%)** in `test_bootstrap_agent_machine.sh` and **31 → 36** in `test_claim_lock.sh`. Fourteen minutes of the certification is this change's own test coverage running.

## Acceptance criteria

| AC | Status |
|---|---|
| **1** — a box can `git push` with no manual step | **Met**, via AC1's second stated option ("have the onboarder run `gh auth setup-git` after auth injection"): `verify.run --fix-credentials`. Baking into the **image** is the first option and is deferred to #3470 item 4. |
| **2** — verified from a box booted from the image | **PENDING POST-MERGE EVIDENCE — not claimed.** The profile is read from the **default branch** at onboard time, so this change is its own subject and cannot certify itself. CLAUDE.md records the general rule and the handling: plan the demonstration for after the merge. The fleet owner runs it and records the transcript on #3369 before it closes. |
| **3** — preflight fails closed on **push** capability, not read capability | **Met in-repo**, on both channels (exit code + expect string), *subject to the conditional above*. |
| **4** — `onboarded (skip-verify)` fixed or made loud | **Not met in-repo, and not fixable here.** `skip-verify` appears **nowhere** in this repository (0 hits, docs included); it is emitted entirely by external tooling. Tracked as #3470 item 3, leading that issue. |

## Verification

- **Baseline, clean `origin/main` worktree on this box**: `scripts/tests/test_bootstrap_agent_machine.sh` → `PASS=80 FAIL=0`. Anything red after this change is ours, not pre-existing.
- **Before-evidence**, same clean tree: the §3b `[ok]` overclaim quoted above, 3 advisory warnings (mold, perf ×2), `All checks green.` printed 0 times, exit 0.
- `tooling-tests` component covers the extended suite (`scripts/agent-gate.sh` → `test_bootstrap_agent_machine.sh`). Note `tooling-tests` is **not** in `LITE_COMPONENTS`, so it was run directly every round in addition to `--lite`.

### Test results

| suite | baseline (`origin/main` @ `1ccc66680`) | this branch |
|---|---|---|
| `scripts/tests/test_bootstrap_agent_machine.sh` | `PASS=80 FAIL=0` | `PASS=126 FAIL=0` |
| `scripts/tests/test_claim_lock.sh` | `PASS=31 FAIL=0` | `PASS=36 FAIL=0` |

Both baselines were measured on a **separate clean `origin/main` worktree**, so any red is attributable to this branch and not to pre-existing state. **No pre-existing case name was removed or renamed in either suite** — the added coverage is additive, not a swap. (Checked explicitly, because a case that stops asserting what it used to assert is a silent coverage loss that a rising pass-count hides.)

### Gate coverage of this diff — stated plainly

There is **no shell linter in the gate** (no shellcheck component; shellcheck is not installed on the worker boxes either). Of the gate's 33 components, this diff's only substantive subject is **`tooling-tests`**, which runs both suites above. Everything else is Rust and unaffected, and `roborev-lints` has no subject here (no workflow files). So a green full gate should **not** be read as broad verification of this change — the extended suites plus the roborev rounds are the real coverage. Flagged as an observation, not fixed here (out of scope for #3369).

### Review history — eleven roborev rounds, nineteen blockers

Every round was a genuine, correctly-scoped range review: `sha-assert: PASS`, `prompt-content: PASS` on every code census path, token accounting 301k–1054k input against a ~18.7k vacuous baseline.

| round | job | head | findings |
|---|---|---|---|
| 1 | 96 | `c00095ed4` | 2 |
| 2 | 98 | `0eccdcc4e` | 3 |
| 3 | 100 | `c7b1a811d` | 3 |
| 4 | 102 | `bfef97d7a` | 2 |
| 5 | 104 | `85df355e2` | 2 |
| 6 | 106 | `9ab25521e` | 2 |
| 7 | 107 | `2fc4a6302` | 3 — one fixed, two batched to #3474 |
| 8 | 109 | `87fdd2552` | 2 — 1 fixed, 1 batched |
| 9 | 110 | `461d9c4cb` | 2 — both fixed, one **High** |
| 10 | 112 | `68af9aaaf` | 4 — 3 fixed, 1 batched |
| 11 | 113 | `49144d3c2` | 2 — 1 fixed (docs), 1 already batched |

**Round 11 is the review of record.** The only commit after it is docs-only, and `*.md` is in the repo root's `.roborev.toml` `exclude_patterns`, so roborev never receives markdown. Proven rather than asserted — the non-markdown diff against `origin/main` hashes identically at round 11's head and at HEAD:

```
round-11 head non-md sha256: 971ec2d3d79ffca0b73eaa10772abb015e513aa244eb35a87c1652a64324037d
current  HEAD non-md sha256: 971ec2d3d79ffca0b73eaa10772abb015e513aa244eb35a87c1652a64324037d
```

A twelfth round could not have seen anything new.

**One High-severity finding, worth reading in full.** Round 9 found that `verify.run --fix-credentials` installed a `$GH_TOKEN`-dereferencing helper for the effective push host **without confirming `gh` was authenticated to that host** — and the probe then pushed to it. It was a consequence of an earlier fix in this same PR that resolved the host from `git remote get-url --push`, making the token-installing host **local-git-config-controlled**, while `verify.run` made the path automatic at onboard. A hostile invoker is out of the threat model, but a typo'd `pushurl`, a leftover fork remote or a stale `insteadOf` reaches it **by accident**, and this repo's triage rule puts the accident path in scope.

The first fix for it was **also wrong, and roborev caught that too**: gating on `gh auth status --hostname` confirms *`gh` holds some credential for that host*, which is a different fact from *this token is the credential for that host*. On a box authenticated to both `github.com` and an enterprise host, with `origin` on the enterprise host, that check passes and the github.com token is handed over. The predicate is now **token authority**: `gh auth token --hostname <host>` must **equal** the environment token, else the repair is refused. No allowlists, and nothing infers anything from the hostname string.

Note what that sequence is: the surrounding code *already* scoped the helper per-host, with a comment explaining that an unscoped helper "offers the GitHub token to EVERY https host git talks to". A correct mitigation was silently invalidated when a later change made its input attacker-or-accident-controlled.

**The four worth knowing about beyond this PR:**

1. **The change defeated its own purpose while every test passed.** The "no credentials" `warn` fired *before* the `--fix-credentials` repair and was never cleared, so `verify.run` exited 1 and withheld `All checks green.` **on a box it had just successfully repaired** — AC1 and AC3 both dead, with 102 tests green, because no case asserted the end-to-end path. The verdict is now decided once from the final state and **confirmed by a re-probe**, not by trusting the repair command's exit status.
2. **`SMOKE-OK` claimed `(create + ls-remote + delete verified)` when the delete had failed** — the same overclaim shape §3b was fixing, one layer down, with the cleanup warning captured into a variable so nobody saw it.
3. **`bounded`'s advertised 60s bound bounded nothing.** Plain `timeout` sends SIGTERM and waits; a TERM-ignoring child (git, ssh, a credential helper) ran on indefinitely — and the probe's own `rc=137` branch was **unreachable**, code anticipating an outcome the wrapper could not produce. Measured: `timeout 3` on a TERM-ignoring child returned after 30s; with `--kill-after=2`, 5s.
4. **A test asserted "HTTPS advice" while driving a `file://` remote** — it passed by accident and never exercised the https path. Asking for a *uniform* no-unexercised-assertion check then found a **second** mislabeled case. A mislabeled test is a habit, not an incident.

**Two findings were taken as diagnoses while their prescriptions were rejected**, and the reasoning is recorded because it shaped the design:

- roborev proposed distinguishing delete-failure causes (policy / auth / unreachable) by parsing stderr, and later three auth-fault classes the same way. Both were declined: deriving a cause from error text is the guessing-from-strings shape this repo's no-heuristics doctrine exists to prevent, and each new classification had been producing the next round's finding. Instead the code **reports the observation and attributes nothing** (`reason=cleanup-unverified`), and keys remediation on `GIT_ORIGIN_KIND`, which is derived from the remote URL and correct by construction.
- roborev proposed a dedicated branch per reason code. Declined: the catch-all now **quotes `claim.sh`'s verdict verbatim** instead of re-wording it, so no reason code — present or future — can lose detail or be given a cause bootstrap cannot know. Verdict branches went **5 → 4** and have held there since.

**Process note, recorded honestly:** seven rounds was substantially a triage failure on my side, not reviewer noise. Every finding was real; none were false positives. But project doctrine batches *nits* into one follow-up at merge time and never lets them trigger a re-verify round, and I classified all thirteen as blockers — which guarantees the rounds do not end. The last two rounds were spent on genuine but principled items (a test that could hang the gate; an `!= bad` branch where the rule is `= good`); the exotic-config items that remain are batched, not blocking.

**Batched, not dropped:** the two residual findings are filed as **#3474** with a stated reason each — both fail closed (the box is not certified) rather than producing a false green, which is what makes batching defensible rather than convenient. #3474 also records an observation with no other home: **the gate cannot lint shell at all**, so every one of the fourteen blockers in this ~1400-line bash diff was found by roborev or by hand, never by the gate.

**Linked issues**
- **#3470** — the external agent-ami launcher question. Leads with whether the launcher honours `verify.run` at all, because that is the **precondition** for this PR's fail-closed signals being read rather than a third improvement alongside the others.
- **#3474** — batched nits from these rounds.

