### PR TITLE
fix(#1716): AK5 — label the three unwired tools/ crates; correct the premise that a bare build compiled them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,16 +222,16 @@ tools/           # 7 crates, each with a RECORDED disposition in one of THREE
                  #             name BOTH halves, and the crate must stay a
                  #             workspace member — never `exclude` it.
                  #   A NEW tools/ crate must be classified there or the gate FAILs.
-                 #   A MIXED crate's live half is the UNION of two INDEPENDENT
-                 #   sources, at least one non-empty, both always checked:
-                 #   workspace dependents (DERIVED from `cargo tree --workspace
-                 #   --invert`, so unclaimable falsely) and invoked binaries
-                 #   (RECORDED in MIXED_INVOKED, since invocation is not
-                 #   mechanically checkable, but each is cross-checked against
-                 #   the crate's declared [[bin]]s). The README must NAME every
-                 #   item from both. Granularity is per-CRATE, not per-target:
-                 #   adding an orphaned bin to a WIRED crate passes unchanged —
-                 #   a recorded limitation, not an oversight.
+                 #   That guard is deliberately SMALL: it checks a disposition
+                 #   was RECORDED and LABELED, not that the record is TRUE, and it
+                 #   is per-CRATE (an orphaned bin added to a WIRED crate passes
+                 #   unchanged). It needs no cargo/python3/network. A
+                 #   cargo-derived cross-check that verified truth was built and
+                 #   REMOVED (#1716) — 11 review findings landed in it and none in
+                 #   the list/README part, and its scratch workspaces sat outside
+                 #   the repo so they did not inherit rust-toolchain.toml, making a
+                 #   MANDATORY gate component host-toolchain-dependent. Doing it
+                 #   properly is its own issue under epic #1688.
 fuzz/            # cargo-fuzz crate — own workspace, EXCLUDED from the main one
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,9 +208,31 @@ cqlite-cli/      # Command-line interface
 bindings/python/ # Python bindings (PyO3) — M4 complete
 bindings/node/   # Node.js bindings (napi-rs) — Phase 3 complete
 test-data/       # Real Cassandra 5.0 SSTables for testing
-tools/           # sstabledump-validator, format-validator
+tools/           # 7 crates, each with a RECORDED disposition (#1716), pinned by
+                 #   scripts/tests/test_tools_crate_disposition.sh:
+                 #   CI-wired: cassandra-parity, flight-loadgen,
+                 #     sstabledump-validator, ws0-corpus-gen.
+                 #   UNWIRED manual dev tools (no workflow/script/live doc runs
+                 #     them; each carries a README saying so): cqlite-validator,
+                 #     memory-safety-runner, and format-validator's 4 BINS.
+                 #   format-validator's LIB is WIRED — tests/format-compatibility
+                 #     (the gate's `format-compat` component) path-depends on it —
+                 #     so that crate must stay a workspace member. A NEW tools/
+                 #     crate must be classified in that guard or the gate FAILs.
 fuzz/            # cargo-fuzz crate — own workspace, EXCLUDED from the main one
 ```
+
+**A bare `cargo build` here already builds only the ROOT package — do not "optimize" it with
+`default-members` (#1716).** This workspace has a root package (`cqlite`), and cargo's default for
+`default-members` in that case is **that package alone** ("all members" is the default only for a
+VIRTUAL workspace). Verified: `cargo tree --depth 0` at the root resolves to `cqlite` and nothing
+else. So adding an explicit `default-members` list would **expand** the bare build from 1 package to
+14 — the opposite of the intent, and the trap #1716 was originally written around ("these crates are
+compiled by every workspace build" was false). The `tools/` crates are compiled only by an explicit
+`--workspace`/`--all-targets` (the gate's clippy) or `-p`. Two corollaries: those crates stay fully
+linted under `-D warnings` no matter their disposition; and their own unit tests are run by **no**
+automated lane and never were (no CI job or gate component runs workspace-wide tests) — run them
+with `cargo test -p <name>`.
 
 **Planned (M6)**: `bindings/wasm/`. Full source map (parsers, writers, query engine, bindings
 layout, binding structure trees):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,14 +222,16 @@ tools/           # 7 crates, each with a RECORDED disposition in one of THREE
                  #             name BOTH halves, and the crate must stay a
                  #             workspace member — never `exclude` it.
                  #   A NEW tools/ crate must be classified there or the gate FAILs.
-                 #   A MIXED crate records WHICH half is live, in one of two
-                 #   kinds: `dependency` (a library some workspace package needs
-                 #   — DERIVED from `cargo tree --workspace --invert`, so it
-                 #   cannot be claimed falsely) or `invoked:<bin>` (binaries CI
-                 #   runs — recorded, since invocation is not mechanically
-                 #   checkable, but each target is still cross-checked against
-                 #   the crate's declared [[bin]]s). Both require the README to
-                 #   NAME the live half.
+                 #   A MIXED crate's live half is the UNION of two INDEPENDENT
+                 #   sources, at least one non-empty, both always checked:
+                 #   workspace dependents (DERIVED from `cargo tree --workspace
+                 #   --invert`, so unclaimable falsely) and invoked binaries
+                 #   (RECORDED in MIXED_INVOKED, since invocation is not
+                 #   mechanically checkable, but each is cross-checked against
+                 #   the crate's declared [[bin]]s). The README must NAME every
+                 #   item from both. Granularity is per-CRATE, not per-target:
+                 #   adding an orphaned bin to a WIRED crate passes unchanged —
+                 #   a recorded limitation, not an oversight.
 fuzz/            # cargo-fuzz crate — own workspace, EXCLUDED from the main one
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,17 +208,20 @@ cqlite-cli/      # Command-line interface
 bindings/python/ # Python bindings (PyO3) — M4 complete
 bindings/node/   # Node.js bindings (napi-rs) — Phase 3 complete
 test-data/       # Real Cassandra 5.0 SSTables for testing
-tools/           # 7 crates, each with a RECORDED disposition (#1716), pinned by
-                 #   scripts/tests/test_tools_crate_disposition.sh:
-                 #   CI-wired: cassandra-parity, flight-loadgen,
-                 #     sstabledump-validator, ws0-corpus-gen.
-                 #   UNWIRED manual dev tools (no workflow/script/live doc runs
-                 #     them; each carries a README saying so): cqlite-validator,
-                 #     memory-safety-runner, and format-validator's 4 BINS.
-                 #   format-validator's LIB is WIRED — tests/format-compatibility
-                 #     (the gate's `format-compat` component) path-depends on it —
-                 #     so that crate must stay a workspace member. A NEW tools/
-                 #     crate must be classified in that guard or the gate FAILs.
+tools/           # 7 crates, each with a RECORDED disposition in one of THREE
+                 #   categories, pinned by the gate guard
+                 #   scripts/tests/test_tools_crate_disposition.sh (#1716):
+                 #   WIRED   — cassandra-parity, flight-loadgen,
+                 #             sstabledump-validator, ws0-corpus-gen.
+                 #   UNWIRED — nothing runs them AND nothing depends on them:
+                 #             cqlite-validator, memory-safety-runner. Each needs
+                 #             a README saying it is NOT CI-wired.
+                 #   MIXED   — format-validator: its 4 BINS are orphaned but its
+                 #             LIB is WIRED (tests/format-compatibility = the
+                 #             gate's `format-compat` component). Its README must
+                 #             name BOTH halves, and the crate must stay a
+                 #             workspace member — never `exclude` it.
+                 #   A NEW tools/ crate must be classified there or the gate FAILs.
 fuzz/            # cargo-fuzz crate — own workspace, EXCLUDED from the main one
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,10 @@ tools/           # 7 crates, each with a RECORDED disposition in one of THREE
                  #             name BOTH halves, and the crate must stay a
                  #             workspace member — never `exclude` it.
                  #   A NEW tools/ crate must be classified there or the gate FAILs.
+                 #   The DEPENDENCY half is DERIVED (cargo tree --workspace
+                 #   --invert) and cross-checked both ways, so UNWIRED/MIXED
+                 #   cannot be claimed falsely; only "something RUNS it" is
+                 #   recorded by hand.
 fuzz/            # cargo-fuzz crate — own workspace, EXCLUDED from the main one
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,10 +222,14 @@ tools/           # 7 crates, each with a RECORDED disposition in one of THREE
                  #             name BOTH halves, and the crate must stay a
                  #             workspace member — never `exclude` it.
                  #   A NEW tools/ crate must be classified there or the gate FAILs.
-                 #   The DEPENDENCY half is DERIVED (cargo tree --workspace
-                 #   --invert) and cross-checked both ways, so UNWIRED/MIXED
-                 #   cannot be claimed falsely; only "something RUNS it" is
-                 #   recorded by hand.
+                 #   A MIXED crate records WHICH half is live, in one of two
+                 #   kinds: `dependency` (a library some workspace package needs
+                 #   — DERIVED from `cargo tree --workspace --invert`, so it
+                 #   cannot be claimed falsely) or `invoked:<bin>` (binaries CI
+                 #   runs — recorded, since invocation is not mechanically
+                 #   checkable, but each target is still cross-checked against
+                 #   the crate's declared [[bin]]s). Both require the README to
+                 #   NAME the live half.
 fuzz/            # cargo-fuzz crate — own workspace, EXCLUDED from the main one
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,10 +229,18 @@ VIRTUAL workspace). Verified: `cargo tree --depth 0` at the root resolves to `cq
 else. So adding an explicit `default-members` list would **expand** the bare build from 1 package to
 14 — the opposite of the intent, and the trap #1716 was originally written around ("these crates are
 compiled by every workspace build" was false). The `tools/` crates are compiled only by an explicit
-`--workspace`/`--all-targets` (the gate's clippy) or `-p`. Two corollaries: those crates stay fully
-linted under `-D warnings` no matter their disposition; and their own unit tests are run by **no**
-automated lane and never were (no CI job or gate component runs workspace-wide tests) — run them
-with `cargo test -p <name>`.
+`--workspace`/`--all-targets` (the gate's clippy) or `-p`. So those crates stay fully linted under
+`-D warnings` no matter their disposition.
+
+**Their unit tests, though, run ONLY when your diff touches their package (#1716).** No CI job and
+no gate component runs workspace-wide tests, so an untouched `tools/` crate's tests never execute —
+but `--lite`'s blast-radius maps a touched path to its package and runs that package's `--lib`
+tests. Consequence, found the hard way on #1716: editing only `tools/format-validator/README.md`
+made `--lite` run that crate's tests **for the first time**, and one failed —
+`test_hex_dump_formatting` asserted an unseparated `"48656c6c6f"` against a `hexdump -C`-style
+formatter that emits `48 65 6c 6c 6f`, an expectation that could never hold for any input. **Expect
+latent failures the first time you touch a long-unwired crate**; they are pre-existing, not yours,
+but they are yours to fix because your diff is what runs them.
 
 **Planned (M6)**: `bindings/wasm/`. Full source map (parsers, writers, query engine, bindings
 layout, binding structure trees):

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,48 @@ members = [
 exclude = [
     "fuzz",
 ]
+
+# default-members (issue #1716, epic #1688 finding AK5) — what a BARE `cargo
+# build` / `cargo test` at the workspace root compiles.
+#
+# `members` above globs `tools/*`, and with no `default-members` every bare build
+# compiled all seven tools/ crates. Three of them are invoked by no CI workflow,
+# no script and no doc (census in #1716): `tools/cqlite-validator`,
+# `tools/memory-safety-runner`, and the four BINARIES of
+# `tools/format-validator`. They are manual dev tools — see each crate's README.
+#
+# They stay workspace MEMBERS on purpose; `exclude`-ing them would break three
+# live things:
+#   * `tests/format-compatibility` (package `format-compatibility-tests`, the
+#     full gate's `format-compat` component) path-depends on format-validator's
+#     LIB and uses `format_validator::{format_constants, utils}`. That lib is
+#     wired, so it still builds here as that package's dependency — only its
+#     four unwired bins leave the default set.
+#   * `scripts/tests/test_agent_gate_summary.sh` uses
+#     `tools/format-validator/src/lib.rs` as the fixture for the gate's
+#     path -> package "owners" resolution, which reads `cargo metadata`.
+#   * `xtask/src/oom_audit/scope.rs` asserts on a format-validator path.
+#
+# Nothing is lint-exempted by this: the gate lints with
+# `cargo clippy --workspace --all-targets --all-features`, and `--workspace`
+# overrides default-members, so all three crates stay under `-D warnings`.
+# Build them explicitly with `cargo build -p <name>` (or `--workspace`).
+default-members = [
+    ".",
+    "cqlite-core",
+    "cqlite-cli",
+    "cqlite-flight",
+    "bindings/python",
+    "bindings/node",
+    "tests",
+    "tests/format-compatibility",
+    "examples",
+    "tools/cassandra-parity",
+    "tools/flight-loadgen",
+    "tools/sstabledump-validator",
+    "tools/ws0-corpus-gen",
+    "xtask",
+]
 resolver = "2"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,47 +19,16 @@ exclude = [
     "fuzz",
 ]
 
-# default-members (issue #1716, epic #1688 finding AK5) — what a BARE `cargo
-# build` / `cargo test` at the workspace root compiles.
-#
-# `members` above globs `tools/*`, and with no `default-members` every bare build
-# compiled all seven tools/ crates. Three of them are invoked by no CI workflow,
-# no script and no doc (census in #1716): `tools/cqlite-validator`,
-# `tools/memory-safety-runner`, and the four BINARIES of
-# `tools/format-validator`. They are manual dev tools — see each crate's README.
-#
-# They stay workspace MEMBERS on purpose; `exclude`-ing them would break three
-# live things:
-#   * `tests/format-compatibility` (package `format-compatibility-tests`, the
-#     full gate's `format-compat` component) path-depends on format-validator's
-#     LIB and uses `format_validator::{format_constants, utils}`. That lib is
-#     wired, so it still builds here as that package's dependency — only its
-#     four unwired bins leave the default set.
-#   * `scripts/tests/test_agent_gate_summary.sh` uses
-#     `tools/format-validator/src/lib.rs` as the fixture for the gate's
-#     path -> package "owners" resolution, which reads `cargo metadata`.
-#   * `xtask/src/oom_audit/scope.rs` asserts on a format-validator path.
-#
-# Nothing is lint-exempted by this: the gate lints with
-# `cargo clippy --workspace --all-targets --all-features`, and `--workspace`
-# overrides default-members, so all three crates stay under `-D warnings`.
-# Build them explicitly with `cargo build -p <name>` (or `--workspace`).
-default-members = [
-    ".",
-    "cqlite-core",
-    "cqlite-cli",
-    "cqlite-flight",
-    "bindings/python",
-    "bindings/node",
-    "tests",
-    "tests/format-compatibility",
-    "examples",
-    "tools/cassandra-parity",
-    "tools/flight-loadgen",
-    "tools/sstabledump-validator",
-    "tools/ws0-corpus-gen",
-    "xtask",
-]
+# NOTE (issue #1716, epic #1688 finding AK5): do NOT add `default-members` here
+# expecting it to make a bare root build cheaper — it would do the OPPOSITE.
+# This workspace has a ROOT PACKAGE (`cqlite`, below), and cargo's default for
+# `default-members` in that case is THE ROOT PACKAGE ALONE (it is "all members"
+# only for a VIRTUAL workspace). Verified on this manifest: `cargo tree
+# --depth 0` at the root resolves to `cqlite` and nothing else. So a bare
+# `cargo build` already compiles the narrowest possible set, and spelling out a
+# `default-members` list would EXPAND it from 1 package to 14.
+# The unwired `tools/` crates (see each one's README) are compiled only by an
+# explicit `--workspace` or `-p`, never by a bare build.
 resolver = "2"
 
 [package]

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -210,6 +210,13 @@
 #                      datasets.
 #                      SKIP-aware (loud): SKIPs only when cqlite-core is absent.
 #   tooling-tests      shell-tooling regression tests (fast, no datasets/network):
+#                      scripts/tests/test_tools_crate_disposition.sh (+ its
+#                      selftest) — #1716/AK5: every crate under tools/ must be
+#                      EXPLICITLY classified CI-wired vs unwired manual dev tool,
+#                      and every unwired one must carry a README saying so. Needs
+#                      no python3/cargo, so it ALWAYS runs (never SKIPs). Fails
+#                      closed on an absent/unclassifiable subject; wiredness is
+#                      recorded and diff-reviewed, never grep-inferred.
 #                      scripts/tests/test_agent_gate_summary.sh — proves the
 #                      SUMMARY block survives non-foreground capture (#1175). It
 #                      only drives `agent-gate.sh --emit-summary-selftest`, which
@@ -6928,6 +6935,30 @@ run_tooling_tests() {
   if ! bash "$REPO_ROOT/scripts/tests/test_agent_gate_tree_provenance.sh" >>"$log" 2>&1; then
     status=FAIL
     echo "--- [$name] FAILED (tree-integrity PROVENANCE self-test #2926); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
+  # tools/ crate disposition census (#1716, epic #1688 finding AK5): no
+  # python3/Docker/cargo needed, always runs. Every crate under tools/ must be
+  # EXPLICITLY classified as CI-wired or as an unwired manual dev tool, and every
+  # unwired one must carry a README stating it. The defect it exists for: three
+  # tools/ crates were invoked by no workflow, no script and no doc for months
+  # while reading as live tooling. `members` globs `tools/*`, so a new crate
+  # otherwise joins the workspace with no statement of whether anything runs it,
+  # and a deleted README is invisible. Fails closed on an absent/unclassifiable
+  # subject; wiredness is RECORDED and reviewed in the diff, never grep-inferred
+  # (a grep gets it wrong both ways — see the guard's header). A failure FAILs the
+  # component, mirroring the keyspace-scoping guard.
+  echo ">>> [$name] bash scripts/tests/test_tools_crate_disposition.sh; bash scripts/tests/test_tools_crate_disposition_selftest.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_tools_crate_disposition.sh" >>"$log" 2>&1 ||
+     ! bash "$REPO_ROOT/scripts/tests/test_tools_crate_disposition_selftest.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (tools/ crate disposition census #1716); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -234,7 +234,10 @@
 #                      going to the network; remedy `cargo fetch --locked` is named
 #                      in the failure. Fails CLOSED on an absent or unmeasurable
 #                      subject — including cargo output that is non-empty but no
-#                      longer parseable — and never SKIPs.
+#                      longer parseable — and never SKIPs. SCOPE: CRATE-level, not
+#                      per-target — adding an orphaned bin to an already-WIRED crate
+#                      passes unchanged (a known, recorded limitation; a per-target
+#                      inventory would be its own issue under epic #1688).
 #                      scripts/tests/test_agent_gate_summary.sh — proves the
 #                      SUMMARY block survives non-foreground capture (#1175). It
 #                      only drives `agent-gate.sh --emit-summary-selftest`, which

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -222,8 +222,15 @@
 #                      "something RUNS it" is not mechanically checkable, so it
 #                      stays recorded + diff-reviewed, never grep-inferred.
 #                      Needs cargo (always present in a gate); no python3/Docker.
-#                      Fails CLOSED on an absent or unmeasurable subject; never
-#                      SKIPs.
+#                      Stays inside this component's fast/no-network contract:
+#                      the cargo query carries --locked --offline, so it cannot
+#                      reach the registry and cannot rewrite Cargo.lock (i.e. it
+#                      cannot mutate the tree its own gate is certifying, #2926).
+#                      A COLD cargo cache therefore FAILs it rather than silently
+#                      going to the network; remedy `cargo fetch --locked` is named
+#                      in the failure. Fails CLOSED on an absent or unmeasurable
+#                      subject — including cargo output that is non-empty but no
+#                      longer parseable — and never SKIPs.
 #                      scripts/tests/test_agent_gate_summary.sh — proves the
 #                      SUMMARY block survives non-foreground capture (#1175). It
 #                      only drives `agent-gate.sh --emit-summary-selftest`, which

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -212,8 +212,11 @@
 #   tooling-tests      shell-tooling regression tests (fast, no datasets/network):
 #                      scripts/tests/test_tools_crate_disposition.sh (+ its
 #                      selftest) — #1716/AK5: every crate under tools/ must be
-#                      EXPLICITLY classified CI-wired vs unwired manual dev tool,
-#                      and every unwired one must carry a README saying so. Needs
+#                      EXPLICITLY classified WIRED / UNWIRED / MIXED, and every
+#                      crate carrying orphaned targets must carry a README saying
+#                      so (a MIXED one must ALSO name its live half, or a
+#                      partly-live crate reads as wholly dead — roborev job 75
+#                      caught a two-way split asserting exactly that). Needs
 #                      no python3/cargo, so it ALWAYS runs (never SKIPs). Fails
 #                      closed on an absent/unclassifiable subject; wiredness is
 #                      recorded and diff-reviewed, never grep-inferred.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -217,8 +217,12 @@
 #                      so. TWO HALVES: "something DEPENDS on it" is DERIVED from
 #                      cargo tree --workspace --invert and CROSS-CHECKED (UNWIRED
 #                      must have ZERO workspace dependents, MIXED at least one, and
-#                      a MIXED README must NAME its real dependents), so neither
-#                      category can be asserted falsely in either direction;
+#                      a MIXED README must NAME its live half). A MIXED crate
+#                      records WHICH half is live — `dependency` (derived from
+#                      cargo) or `invoked:<bin>` (recorded, but cross-checked
+#                      against the declared [[bin]]s), because a multi-binary tool
+#                      with one bin wired and one orphaned has NO reverse cargo
+#                      dependency at all; so no category can be asserted falsely;
 #                      "something RUNS it" is not mechanically checkable, so it
 #                      stays recorded + diff-reviewed, never grep-inferred.
 #                      Needs cargo (always present in a gate); no python3/Docker.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -213,31 +213,21 @@
 #                      scripts/tests/test_tools_crate_disposition.sh (+ its
 #                      selftest) — #1716/AK5: every crate under tools/ must be
 #                      EXPLICITLY classified WIRED / UNWIRED / MIXED, and every
-#                      crate carrying orphaned targets must carry a README saying
-#                      so. TWO HALVES: "something DEPENDS on it" is DERIVED from
-#                      cargo tree --workspace --invert and CROSS-CHECKED (UNWIRED
-#                      must have ZERO workspace dependents, MIXED at least one, and
-#                      a MIXED README must NAME its live half). A MIXED crate
-#                      records WHICH half is live — `dependency` (derived from
-#                      cargo) or `invoked:<bin>` (recorded, but cross-checked
-#                      against the declared [[bin]]s), because a multi-binary tool
-#                      with one bin wired and one orphaned has NO reverse cargo
-#                      dependency at all; so no category can be asserted falsely;
-#                      "something RUNS it" is not mechanically checkable, so it
-#                      stays recorded + diff-reviewed, never grep-inferred.
-#                      Needs cargo (always present in a gate); no python3/Docker.
-#                      Stays inside this component's fast/no-network contract:
-#                      the cargo query carries --locked --offline, so it cannot
-#                      reach the registry and cannot rewrite Cargo.lock (i.e. it
-#                      cannot mutate the tree its own gate is certifying, #2926).
-#                      A COLD cargo cache therefore FAILs it rather than silently
-#                      going to the network; remedy `cargo fetch --locked` is named
-#                      in the failure. Fails CLOSED on an absent or unmeasurable
-#                      subject — including cargo output that is non-empty but no
-#                      longer parseable — and never SKIPs. SCOPE: CRATE-level, not
-#                      per-target — adding an orphaned bin to an already-WIRED crate
-#                      passes unchanged (a known, recorded limitation; a per-target
-#                      inventory would be its own issue under epic #1688).
+#                      crate carrying orphaned targets must carry a README that
+#                      STATES it is not CI-wired. Needs NO cargo, python3, Docker
+#                      or network — filesystem and lists only, so it always runs
+#                      and cannot be environment-dependent. Fails CLOSED on an
+#                      absent or unmeasurable subject; never SKIPs.
+#                      SCOPE, deliberately small: it verifies a disposition was
+#                      RECORDED and LABELED, not that the record is TRUE, and it is
+#                      per-CRATE, so an orphaned bin added to a WIRED crate passes
+#                      unchanged. A cargo-derived cross-check that DID verify truth
+#                      was built and removed (#1716): 11 review findings landed in
+#                      it and none in the list/README part, and its self-tests built
+#                      scratch workspaces outside the repo that do not inherit
+#                      rust-toolchain.toml — making a MANDATORY component depend on
+#                      the host toolchain. Verifying truth properly is its own issue
+#                      under epic #1688.
 #                      scripts/tests/test_agent_gate_summary.sh — proves the
 #                      SUMMARY block survives non-foreground capture (#1175). It
 #                      only drives `agent-gate.sh --emit-summary-selftest`, which

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -214,12 +214,16 @@
 #                      selftest) — #1716/AK5: every crate under tools/ must be
 #                      EXPLICITLY classified WIRED / UNWIRED / MIXED, and every
 #                      crate carrying orphaned targets must carry a README saying
-#                      so (a MIXED one must ALSO name its live half, or a
-#                      partly-live crate reads as wholly dead — roborev job 75
-#                      caught a two-way split asserting exactly that). Needs
-#                      no python3/cargo, so it ALWAYS runs (never SKIPs). Fails
-#                      closed on an absent/unclassifiable subject; wiredness is
-#                      recorded and diff-reviewed, never grep-inferred.
+#                      so. TWO HALVES: "something DEPENDS on it" is DERIVED from
+#                      cargo tree --workspace --invert and CROSS-CHECKED (UNWIRED
+#                      must have ZERO workspace dependents, MIXED at least one, and
+#                      a MIXED README must NAME its real dependents), so neither
+#                      category can be asserted falsely in either direction;
+#                      "something RUNS it" is not mechanically checkable, so it
+#                      stays recorded + diff-reviewed, never grep-inferred.
+#                      Needs cargo (always present in a gate); no python3/Docker.
+#                      Fails CLOSED on an absent or unmeasurable subject; never
+#                      SKIPs.
 #                      scripts/tests/test_agent_gate_summary.sh — proves the
 #                      SUMMARY block survives non-foreground capture (#1175). It
 #                      only drives `agent-gate.sh --emit-summary-selftest`, which

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# tools/ crate disposition census (issue #1716, epic #1688 finding AK5).
+#
+# ONE property: every crate under tools/ is EXPLICITLY classified as either
+# CI-wired or an unwired manual dev tool, and every unwired one carries the
+# README label that says so.
+#
+# Why. Finding AK5 was that three tools/ crates were invoked by no workflow, no
+# script and no doc, and nothing said so — so they read as live tooling for
+# months. #1716 labeled them. Without this guard that labeling silently decays:
+# the root manifest's `members` globs `tools/*`, so a NEW crate joins the
+# workspace with no statement of whether anything runs it, and a deleted README
+# is invisible. Both are caught here, at zero cost, with no false positives:
+# the rule is a list, not an inference.
+#
+# Deliberately NOT what this guard does: it does not try to DERIVE wiredness by
+# grepping for invocations. A grep is a proxy that gets both directions wrong —
+# tools/format-validator is referenced twice under scripts/ purely as a PATH
+# FIXTURE (neither reference runs it), and a crate can be wired via a binary
+# name that differs from its package name (tools/ws0-corpus-gen ships
+# `ws0-scan-bench`). A guard whose FAIL an agent learns to waive is worse than
+# no guard (CLAUDE.md), so wiredness is RECORDED here by a human and reviewed in
+# the diff, never guessed.
+#
+# FAILS CLOSED: an unclassifiable or unmeasurable tree is a FAIL, never a pass.
+# Self-test / negative controls: scripts/tests/test_tools_crate_disposition_selftest.sh
+set -uo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# Resolved from this script's OWN location, with no env override: an override is
+# settable by the party the guard constrains (CLAUDE.md #3312 — "the constrained
+# party must not choose its own enforcer"). A self-test needing a different tree
+# copies this script into that tree; it never redirects this variable.
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+
+# --- The recorded disposition. Hard-coded ON PURPOSE: one visible location,
+# --- inside the diff a reviewer already reads. Moving a crate between these two
+# --- lists is a deliberate, reviewable act.
+
+# Invoked by at least one CI workflow or script. No README required by this guard.
+WIRED_TOOLS="cassandra-parity
+flight-loadgen
+sstabledump-validator
+ws0-corpus-gen"
+
+# Invoked by NO workflow, NO script and NO live doc (census: issue #1716).
+# Each MUST carry a README.md carrying the label marker below.
+UNWIRED_TOOLS="cqlite-validator
+format-validator
+memory-safety-runner"
+
+# The marker every unwired tool's README must contain, so the label states the
+# actual fact rather than merely existing as a file.
+LABEL_MARKER="NOT CI-wired"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "ok: $*"; }
+
+[ -d "$ROOT/tools" ] || fail "no tools/ directory under $ROOT — this guard's subject is missing; refusing to pass vacuously"
+
+wired_sorted=$(printf '%s\n' "$WIRED_TOOLS" | grep . | sort -u)
+unwired_sorted=$(printf '%s\n' "$UNWIRED_TOOLS" | grep . | sort -u)
+n_wired=$(printf '%s\n' "$wired_sorted" | grep -c .)
+n_unwired=$(printf '%s\n' "$unwired_sorted" | grep -c .)
+
+# --- affirmative-measurement floor: both recorded lists must be non-empty, or a
+# --- later "every crate is accounted for" loop could be satisfied by an empty
+# --- subject set.
+[ "$n_unwired" -gt 0 ] || fail "the recorded UNWIRED_TOOLS list is empty — this guard would then enforce no label at all; refusing to pass vacuously"
+[ "$n_wired" -gt 0 ]   || fail "the recorded WIRED_TOOLS list is empty — refusing to pass vacuously"
+
+# --- 1. the two lists must be disjoint. A crate in both would satisfy the
+# ---    accounted-for loop below while making its label requirement ambiguous.
+both=$(comm -12 <(printf '%s\n' "$wired_sorted") <(printf '%s\n' "$unwired_sorted"))
+[ -z "$both" ] || fail "crate(s) recorded as BOTH wired and unwired: $(printf '%s ' $both)- a crate has exactly one disposition"
+ok "recorded disposition is self-consistent ($n_wired wired, $n_unwired unwired, disjoint)"
+
+# --- 2. every crate ON DISK under tools/ must appear in exactly one list. This
+# ---    is the half that catches a NEW crate arriving via the `tools/*` members
+# ---    glob with no statement of whether anything runs it. It reads the
+# ---    FILESYSTEM, so a manifest glob that silently failed to match cannot hide
+# ---    one.
+n_disk=0
+for manifest in "$ROOT"/tools/*/Cargo.toml; do
+  [ -f "$manifest" ] || continue
+  n_disk=$((n_disk + 1))
+  crate=$(basename "$(dirname "$manifest")")
+  if printf '%s\n' "$wired_sorted"   | grep -qxF "$crate"; then continue; fi
+  if printf '%s\n' "$unwired_sorted" | grep -qxF "$crate"; then continue; fi
+  fail "tools/$crate exists on disk but is in NEITHER recorded list (issue #1716). Classify it in $SCRIPT_DIR/$(basename "$0"): add it to WIRED_TOOLS if a CI workflow or script invokes it, or to UNWIRED_TOOLS plus a README.md labeling it '$LABEL_MARKER' if it is a manual dev tool."
+done
+[ "$n_disk" -gt 0 ] || fail "found no tools/*/Cargo.toml on disk — the filesystem half of this guard measured nothing; refusing to pass vacuously"
+[ "$n_disk" -eq $((n_wired + n_unwired)) ] || fail "the recorded lists name $((n_wired + n_unwired)) crate(s) but $n_disk exist on disk — a recorded crate was renamed or removed without updating $(basename "$0") (issue #1716)"
+ok "all $n_disk tools/ crate(s) on disk are classified by the recorded disposition"
+
+# --- 3. every recorded crate must actually EXIST. Without this, deleting a crate
+# ---    while leaving it listed would keep the count check above satisfiable by a
+# ---    compensating addition.
+while IFS= read -r crate; do
+  [ -n "$crate" ] || continue
+  [ -f "$ROOT/tools/$crate/Cargo.toml" ] \
+    || fail "tools/$crate is recorded in $(basename "$0") but has no Cargo.toml on disk — remove it from the list if the crate is gone (issue #1716)"
+done <<< "$wired_sorted
+$unwired_sorted"
+ok "every recorded crate exists on disk"
+
+# --- 4. the actual acceptance criterion of #1716: each unwired crate carries a
+# ---    README that SAYS it is not CI-wired. A present-but-silent README does
+# ---    not label anything, so the marker is required, not just the file.
+while IFS= read -r crate; do
+  [ -n "$crate" ] || continue
+  readme="$ROOT/tools/$crate/README.md"
+  [ -f "$readme" ] \
+    || fail "tools/$crate is recorded as unwired but has no README.md — issue #1716 requires each unwired tool be LABELED (what it is, that it is not CI-wired, how to build/run it)"
+  [ -r "$readme" ] \
+    || fail "tools/$crate/README.md is not readable — cannot verify its label; unmeasurable is not a pass"
+  grep -qF "$LABEL_MARKER" "$readme" \
+    || fail "tools/$crate/README.md exists but does not contain the label '$LABEL_MARKER' — the README must STATE that no CI workflow or script invokes this crate, not merely exist (issue #1716)"
+done <<< "$unwired_sorted"
+ok "all $n_unwired unwired crate(s) carry a README.md stating '$LABEL_MARKER'"
+
+echo "PASS: tools/ crate disposition census (#1716)"

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -1,67 +1,59 @@
 #!/usr/bin/env bash
 # tools/ crate disposition census (issue #1716, epic #1688 finding AK5).
 #
-# SCOPE, stated first because a guard that overpromises is worse than a small one.
-# This checks CRATE-level disposition, NOT per-target disposition. Adding an
-# orphaned binary to an already-WIRED crate therefore needs no census update and
-# passes unchanged (roborev job 85). That gap is REAL and is accepted rather than
-# closed: closing it means maintaining a per-target inventory for every [[bin]] of
-# every tools/ crate, checked against each manifest — which is a larger mechanism
-# than the P3 labeling issue that this guard serves, and it would put the
-# disposition of ~12 targets into a hand-maintained list whose drift is exactly the
-# failure mode this guard exists to prevent. Recorded as a known limitation with a
-# pointer to epic #1688; if per-target disposition is wanted, it deserves its own
-# issue rather than a rider on this one.
+# ONE property, at CRATE granularity: every crate under tools/ is EXPLICITLY
+# classified, and every crate carrying unwired targets carries a README that says
+# so.
 #
-# ONE property, at crate granularity: every crate under tools/ is EXPLICITLY
-# classified into one of THREE dispositions, and every crate carrying unwired
-# targets carries the README label that says so:
+#   WIRED   something runs it.
+#   UNWIRED nothing runs it and nothing depends on it.
+#   MIXED   some targets are live and others are orphaned.
 #
-#   WIRED   — something runs it; nothing in it is orphaned.
-#   UNWIRED — nothing runs it, and nothing depends on it either. Needs a label.
-#   MIXED   — some targets are live and others are orphaned. Needs a label that
-#             states BOTH halves, because calling such a crate simply "unwired"
-#             is a FALSE census and invites deleting the live half.
+# Why it exists. AK5 was that three tools/ crates were invoked by no workflow, no
+# script and no doc, and nothing said so — so they read as live tooling for months.
+# #1716 labeled them. Without this guard the labeling silently decays: the root
+# manifest's `members` globs `tools/*`, so a NEW crate joins the workspace with no
+# statement of whether anything runs it, and a deleted README is invisible. Both
+# are caught here, deterministically, with no false positives: the rule is a list.
 #
-# The three-way split exists because a two-way one was wrong (roborev job 75 on
-# #1716): tools/format-validator's four BINARIES are invoked by nothing, while its
-# LIBRARY is a path dependency of tests/format-compatibility — the gate's own
-# `format-compat` component. Filing that crate under a crate-level "unwired" made
-# a mixed-status crate satisfy a mutually-exclusive classification, so the census
-# asserted something untrue about it.
+# ============================ SCOPE, AND WHAT IT IS NOT ======================
+# This is a DOCUMENTATION-COMPLETENESS guard. It verifies that a disposition has
+# been RECORDED and LABELED. It does NOT verify that the recorded disposition is
+# TRUE, and it makes no such claim anywhere.
 #
-# Why. Finding AK5 was that three tools/ crates were invoked by no workflow, no
-# script and no doc, and nothing said so — so they read as live tooling for
-# months. #1716 labeled them. Without this guard that labeling silently decays:
-# the root manifest's `members` globs `tools/*`, so a NEW crate joins the
-# workspace with no statement of whether anything runs it, and a deleted README
-# is invisible. Both are caught here, at zero cost, with no false positives:
-# the rule is a list, not an inference.
+# An earlier version did try to verify truth, by deriving workspace dependents from
+# `cargo tree --workspace --invert` and cross-checking them. That was REMOVED, and
+# the reason is worth recording because it is the more useful lesson:
 #
-# TWO HALVES, and the split matters — one is DERIVED, the other RECORDED:
+#   * Eleven review findings over eight rounds landed in that machinery and NONE in
+#     the list-and-README part below. The derivation was where all the complexity
+#     and all the defects lived.
+#   * It required cargo inside a component documented as fast and network-free, and
+#     its self-tests built scratch workspaces OUTSIDE the repository — which do not
+#     inherit rust-toolchain.toml, so a MANDATORY gate component's behaviour became
+#     dependent on the host's default toolchain (roborev job 86). A flaky mandatory
+#     gate is a fleet-wide liability, and that is a bad trade for a P3 labeling task.
+#   * The property it verified is genuinely valuable, but verifying it properly is a
+#     larger mechanism than this issue warrants. It belongs to epic #1688 as its own
+#     issue, not as a rider here.
 #
-#   "something DEPENDS on it" is MECHANICALLY CHECKABLE from the manifests, so it
-#   is DERIVED (via `cargo tree --workspace --invert`, cargo as its own authority)
-#   and CROSS-CHECKED against the recorded disposition. UNWIRED must have ZERO
-#   workspace dependents and MIXED must have AT LEAST ONE — so neither category
-#   can be asserted falsely, in either direction.
+# Two consequences, stated rather than left to be discovered:
+#   * A MIXED crate's "live half" claim is DOCUMENTED, not verified. The README must
+#     carry the label; nothing here proves which half is live.
+#   * Granularity is per-CRATE. Adding an orphaned binary to an already-WIRED crate
+#     needs no census update and passes unchanged.
+# Both are accepted limitations of a small guard, not oversights. A guard that
+# overpromises is worse than a small one.
 #
-#   "something RUNS it" is NOT mechanically checkable — invocations live in
-#   workflows, scripts and prose — so it is RECORDED by a human and reviewed in
-#   the diff. It is deliberately NOT grep-inferred: a grep for invocations gets
-#   both directions wrong (tools/format-validator is referenced twice under
-#   scripts/ purely as a PATH FIXTURE that runs nothing, and tools/ws0-corpus-gen
-#   is wired via a binary name that differs from its package name), and a guard
-#   whose FAIL an agent learns to waive is worse than no guard (CLAUDE.md).
+# Deliberately NOT grep-inferred: wiredness is RECORDED by a human and reviewed in
+# the diff, never guessed from invocations. A grep for those gets both directions
+# wrong — tools/format-validator is referenced twice under scripts/ purely as a PATH
+# FIXTURE that runs nothing, and tools/ws0-corpus-gen is wired via a binary name
+# that differs from its package name. A guard whose FAIL an agent learns to waive is
+# worse than no guard (CLAUDE.md).
 #
-# This split is the fix for roborev job 78: the MIXED label had been verified by
-# grepping the README for the generic word "WIRED", which a README could satisfy
-# while saying the opposite ("previously WIRED, now entirely NOT CI-wired").
-# Verifying a claim by pattern-matching prose is unbounded — the prose author
-# chooses the wording — so the load-bearing check moved OFF the prose and onto the
-# manifests, and the prose requirement is now to name the crate's ACTUAL,
-# DERIVED dependents rather than any fixed word.
-#
+# Needs NO cargo, NO python3, NO Docker and NO network: filesystem and lists only,
+# so it always runs and cannot be environment-dependent.
 # FAILS CLOSED: an unclassifiable or unmeasurable tree is a FAIL, never a pass.
 # Self-test / negative controls: scripts/tests/test_tools_crate_disposition_selftest.sh
 set -uo pipefail
@@ -73,15 +65,14 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 # copies this script into that tree; it never redirects this variable.
 ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 
-# --- The recorded disposition. Hard-coded ON PURPOSE: one visible location,
-# --- inside the diff a reviewer already reads. Moving a crate between these
-# --- lists is a deliberate, reviewable act.
+# --- The recorded disposition. Hard-coded ON PURPOSE: one visible location, inside
+# --- the diff a reviewer already reads. Moving a crate between these lists is a
+# --- deliberate, reviewable act.
 
 # Invoked by at least one CI workflow or script. No README required by this guard.
-# NOTE the crate-level granularity (see SCOPE above): a crate here may still gain
-# an orphaned binary later without tripping anything. If you know a WIRED crate has
-# acquired an orphaned target, move it to MIXED_TOOLS and label it — the guard will
-# not tell you to.
+# NOTE the crate-level granularity (see SCOPE above): a crate here may later gain an
+# orphaned binary without tripping anything. If you know that has happened, move it
+# to MIXED_TOOLS and label it — the guard will not tell you to.
 WIRED_TOOLS="cassandra-parity
 flight-loadgen
 sstabledump-validator
@@ -92,195 +83,33 @@ ws0-corpus-gen"
 UNWIRED_TOOLS="cqlite-validator
 memory-safety-runner"
 
-# Some targets live, some orphaned. Each MUST carry a README.md containing BOTH
-# LABEL_MARKER (for the orphaned targets) and the names of its DERIVED dependents (the live
-# ones, named below from the DERIVED dependent set), so the label cannot describe
-# the crate as wholly unwired.
-#   format-validator: 4 binaries orphaned; LIBRARY wired into
-#   tests/format-compatibility (gate component `format-compat`), and also used as
-#   a fixture by scripts/tests/test_agent_gate_summary.sh (owners resolution) and
-#   asserted on by xtask/src/oom_audit/scope.rs. NEVER workspace-`exclude` it.
+# Some targets live, some orphaned. Each MUST carry a README.md containing
+# LABEL_MARKER, and that README is where the split is documented.
+#   format-validator: its 4 binaries are orphaned; its LIBRARY is a path dependency
+#   of tests/format-compatibility (the gate's `format-compat` component), and it is
+#   also used as a fixture by scripts/tests/test_agent_gate_summary.sh (owners
+#   resolution) and asserted on by xtask/src/oom_audit/scope.rs. So it must stay a
+#   workspace MEMBER — never `exclude` it, only its bins are dead.
 MIXED_TOOLS="format-validator"
 
-# For each MIXED crate, the binaries CI INVOKES — or `none`. This does NOT replace
-# dependency discovery: workspace dependents are ALWAYS derived for every MIXED
-# crate and always required to be documented. The two are INDEPENDENT, because a
-# crate can have both (roborev job 85), and an earlier version treated them as
-# mutually exclusive — choosing `invoked:` then skipped dependency discovery
-# entirely, letting a README omit real dependents while still passing.
-#
-# So the live half is the UNION of two sources, at least one of which must be
-# non-empty:
-#   DERIVED   workspace dependents, from `cargo tree --workspace --invert`.
-#   RECORDED  invoked binaries, because invocation is not mechanically checkable —
-#             but each recorded target is still cross-checked against the crate's
-#             DECLARED [[bin]] targets, and must be named in the README.
-# Format: <crate>|<bin>[,<bin>...] or <crate>|none. Every MIXED crate must appear.
-MIXED_INVOKED="format-validator|none"
-
+# The marker every README with orphaned targets must contain, so the label states
+# the actual fact rather than merely existing as a file.
 LABEL_MARKER="NOT CI-wired"
-# A MIXED crate's README must additionally name each of its ACTUAL workspace
-# dependents — the package names are DERIVED below, never hard-coded here, so this
-# requirement cannot be satisfied by a generic word (roborev job 78).
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "ok: $*"; }
 
-# The RECORDED invoked-binary list for a MIXED crate, from MIXED_INVOKED. Returns
-# non-zero when the crate has no entry, so an unrecorded MIXED crate fails closed
-# rather than silently defaulting to "no invoked binaries".
-mixed_invoked_targets() {
-  local crate="$1" line
-  line=$(printf '%s\n' "$MIXED_INVOKED" | grep "^$crate|" | head -1)
-  [ -n "$line" ] || return 1
-  printf '%s\n' "${line#*|}"
-}
-
-# The [[bin]] target names declared by tools/<dir>/Cargo.toml. Used to cross-check
-# a RECORDED invoked target against something mechanical: a target CI supposedly
-# runs must at least EXIST. Returns non-zero if the manifest cannot be read (an
-# unreadable manifest is unmeasurable, not "no bins").
-declared_bins() {
-  # Two statements, not one: within a SINGLE `local`, bash creates every name
-  # before assigning them, so a later word referencing an earlier one expands an
-  # UNSET local and dies under `set -u` ("dir: unbound variable"). This only
-  # surfaced in the scratch self-tests, because the real repo's one MIXED crate
-  # takes the `dependency` branch and never calls this function.
-  local dir="$1"
-  local manifest="$ROOT/tools/$dir/Cargo.toml"
-  [ -r "$manifest" ] || return 1
-  awk '
-    /^[[:space:]]*\[\[bin\]\]/ { inbin = 1; next }
-    /^[[:space:]]*\[/            { inbin = 0 }
-    inbin && /^[[:space:]]*name[[:space:]]*=/ {
-      if (match($0, /"[^"]+"/)) print substr($0, RSTART + 1, RLENGTH - 2)
-    }
-  ' "$manifest"
-}
-
-# The PACKAGE name declared by tools/<dir>/Cargo.toml. The recorded lists and the
-# README live under the DIRECTORY name, but cargo is queried by PACKAGE name, and
-# the two are not the same thing — assuming they were made every scratch-tree
-# self-test case report "cargo could not answer". All seven of this repo's tools/
-# crates happen to match, which is exactly why the assumption would have stayed
-# invisible here until someone added one that did not.
-#
-# Takes the FIRST `name =` line in the manifest: that is the `[package]` one, since
-# `[package]` precedes any `[lib]`/`[[bin]]` table that also carries a `name`
-# (tools/cassandra-parity has both). Fails closed if none is found.
-package_name_of() {
-  local dir="$1" name
-  name=$(sed -n 's/^name[[:space:]]*=[[:space:]]*"\([^"]\{1,\}\)".*/\1/p' "$ROOT/tools/$dir/Cargo.toml" 2>/dev/null | head -1)
-  [ -n "$name" ] || return 1
-  printf '%s\n' "$name"
-}
-
-# Workspace packages that DIRECTLY depend on $1 (a PACKAGE name), derived from cargo's own
-# resolution — never a hand-parse of Cargo.toml, and never a grep for prose.
-#
-# `--workspace` is REQUIRED: without it `cargo tree` operates on the DEFAULT
-# member set, which in this workspace is the root package alone (see the
-# `default-members` note in the root Cargo.toml), and every crate would appear to
-# have zero dependents — a silent false negative that would let a MIXED crate be
-# recorded UNWIRED. Measured: `cargo tree --invert format-validator` reports no
-# dependents; adding `--workspace` reports format-compatibility-tests.
-#
-# `--all-features` and `--target all` are equally REQUIRED, and for the same class
-# of reason (roborev job 79): `cargo tree` otherwise resolves only the DEFAULT
-# feature set and the HOST target, so a workspace package depending on a tool crate
-# behind an OPTIONAL FEATURE, or under a `[target.'cfg(...)'.dependencies]` table,
-# is INVISIBLE — and that crate would then be recorded UNWIRED while something
-# really does depend on it. Every narrowing of this query is a way for the census to
-# be wrong in the permissive direction, so the query is widened to everything cargo
-# can see.
-#
-# Direct dependents suffice: if nothing depends on a crate directly, nothing
-# depends on it transitively either.
-#
-# Prints one package name per line (the subject itself excluded). Returns
-# non-zero if cargo could not answer, so the caller can fail CLOSED.
-# FAIL-CLOSED CONTRACT, and the two traps designed out of it.
-#
-# (1) Under `pipefail`, `grep -v` exits 1 when it matches NOTHING — the NORMAL,
-#     EXPECTED result for an UNWIRED crate. Folding cargo's call and the filtering
-#     into ONE pipeline therefore made "cargo could not answer" and "zero
-#     dependents" return the SAME status, collapsing the legitimate case onto the
-#     error branch. That is the two-valued-predicate trap: a probe that cannot tell
-#     "no result" from "could not measure" must collapse them.
-# (2) The obvious patch for (1) — `grep ... || true` — is WORSE, because `|| true`
-#     also swallows grep's exit 2 (a REAL error) and any `sed`/`sort` failure,
-#     converting an UNMEASURABLE dependency graph into "zero dependents". That
-#     inverts the contract: a permissive answer derived from the ABSENCE of a
-#     signal, which is the one shape CLAUDE.md says never to build (roborev job 80).
-#
-# Neither is special-cased. The SHAPE that created the dilemma is gone instead:
-# cargo's status is captured ALONE, and the parse is ONE `awk` stage plus `sort` —
-# NEITHER of which exits non-zero for empty output. So `pipefail` stays armed with
-# no `|| true` anywhere, emptiness is DATA, and a genuine failure in any stage
-# still propagates.
-workspace_dependents() {
-  local crate="$1" out rc parsed
-  # `--locked --offline` keeps this inside the tooling-tests contract (fast, no
-  # network): --offline forbids registry access and --locked refuses to REWRITE
-  # Cargo.lock, so the guard cannot mutate the tree it is inspecting. Neither
-  # changes the ANSWER — resolution comes from Cargo.lock plus the local cache
-  # (verified: identical output with and without both flags). A cold cargo cache
-  # makes this FAIL rather than silently reach the network, which is the correct
-  # direction; the caller's message names the remedy.
-  out=$(cd "$ROOT" && cargo tree --workspace --invert "$crate" --depth 1 \
-          --all-features --target all --locked --offline 2>/dev/null)
-  rc=$?
-  [ "$rc" -eq 0 ] || return 1
-  # cargo always echoes the subject itself as the tree root, so empty output here
-  # means cargo answered nothing at all — a measurement failure, not "no deps".
-  [ -n "$out" ] || return 1
-
-  # Package name = the token immediately preceding " v<digit>", which skips both
-  # the tree glyphs cargo prefixes and the trailing (/path). The SUBJECT itself is
-  # dropped HERE, inside awk, rather than by a downstream `grep -v` — see the
-  # fail-closed note above the function for why that grep had to go entirely.
-  # The parse must PROVE it understood the output before an empty dependent set is
-  # allowed to mean "no dependents" (roborev job 82). cargo ALWAYS prints the
-  # subject as the tree root, so seeing the subject is positive evidence that the
-  # pattern still matches cargo's format; NOT seeing it means the format changed or
-  # the filter silently matched nothing — under which an UNWIRED crate with real
-  # dependents would have passed. awk exits 3 for that case, distinct from a real
-  # awk failure, and both are non-zero so both fail closed.
-  parsed=$(printf '%s\n' "$out" | awk -v self="$crate" '
-    match($0, /[A-Za-z0-9_-]+ v[0-9]/) {
-      name = substr($0, RSTART, RLENGTH)
-      sub(/ v[0-9]$/, "", name)
-      if (name == self) { seen_self = 1; next }
-      print name
-    }
-    END { if (!seen_self) exit 3 }' | sort -u)
-  rc=$?
-  [ "$rc" -eq 0 ] || return 1
-
-  # Reaching here means cargo answered AND the parse succeeded — each validated
-  # above — so success is asserted from those checks, not assumed. An EMPTY result
-  # prints NOTHING, never a blank line (a caller's `[ -n "$deps" ]` would read one
-  # blank line as a single dependent named "").
-  [ -z "$parsed" ] || printf '%s\n' "$parsed"
-  return 0
-}
-
 [ -d "$ROOT/tools" ] || fail "no tools/ directory under $ROOT — this guard's subject is missing; refusing to pass vacuously"
 
-wired_sorted=$(printf '%s\n' "$WIRED_TOOLS" | grep . | sort -u)
-unwired_sorted=$(printf '%s\n' "$UNWIRED_TOOLS" | grep . | sort -u)
-mixed_sorted=$(printf '%s\n' "$MIXED_TOOLS" | grep . | sort -u)
 # `grep -c` exits 1 for a count of ZERO while still PRINTING "0", so its status is
-# deliberately not used as a signal here — the printed count is the datum, and the
-# floors below are what reject zero. count_lines guards the one thing that would
-# otherwise slip through: a value that is not a number at all (a grep that died
-# printing nothing), which would reach `[ "$n" -gt 0 ]` as a bash syntax error
-# rather than as a named cause.
-# RETURNS non-zero rather than calling fail(): fail() ends with `exit`, and an
-# `exit` inside a command substitution leaves only the SUBSHELL — the parent would
-# carry on with an empty value and hit `[ "" -gt 0 ]` as a bash syntax error
-# instead of a named cause. So the status is propagated and checked at each call
-# site with `|| fail`.
+# deliberately not used as a signal — the printed count is the datum, and the floors
+# below are what reject zero. count_lines guards only the thing that would otherwise
+# slip through: a value that is not a number at all, which would reach
+# `[ "$n" -gt 0 ]` as a bash syntax error rather than a named cause.
+#
+# RETURNS non-zero rather than calling fail(): fail() ends in `exit`, and an `exit`
+# inside a command substitution leaves only the SUBSHELL — the parent would carry on
+# with an empty value. So the status is checked at each call site with `|| fail`.
 count_lines() {
   local n
   n=$(printf '%s\n' "$1" | grep -c .)
@@ -289,29 +118,33 @@ count_lines() {
   esac
   printf '%s\n' "$n"
 }
-n_wired=$(count_lines "$wired_sorted")     || fail "cannot count WIRED_TOOLS (grep -c returned no usable number) — unmeasurable is not a pass"
-n_unwired=$(count_lines "$unwired_sorted") || fail "cannot count UNWIRED_TOOLS (grep -c returned no usable number) — unmeasurable is not a pass"
-n_mixed=$(count_lines "$mixed_sorted")     || fail "cannot count MIXED_TOOLS (grep -c returned no usable number) — unmeasurable is not a pass"
-# Crates that carry orphaned targets: UNWIRED (wholly) + MIXED (partly). Both owe
-# a label; only MIXED additionally owes a statement of its live half.
-labelled_sorted=$(printf '%s\n%s\n' "$unwired_sorted" "$mixed_sorted" | grep . | sort -u)
-n_labelled=$(count_lines "$labelled_sorted") || fail "cannot count the label-bearing crate set (grep -c returned no usable number) — unmeasurable is not a pass"
 
-# --- affirmative-measurement floor: the label-bearing set must be non-empty, or
-# --- the label loop below would enforce nothing while still reporting PASS.
+wired_sorted=$(printf '%s\n' "$WIRED_TOOLS" | grep . | sort -u)
+unwired_sorted=$(printf '%s\n' "$UNWIRED_TOOLS" | grep . | sort -u)
+mixed_sorted=$(printf '%s\n' "$MIXED_TOOLS" | grep . | sort -u)
+n_wired=$(count_lines "$wired_sorted")     || fail "cannot count WIRED_TOOLS — unmeasurable is not a pass"
+n_unwired=$(count_lines "$unwired_sorted") || fail "cannot count UNWIRED_TOOLS — unmeasurable is not a pass"
+n_mixed=$(count_lines "$mixed_sorted")     || fail "cannot count MIXED_TOOLS — unmeasurable is not a pass"
+
+# Crates that carry orphaned targets: UNWIRED (wholly) + MIXED (partly). Both owe a
+# README label.
+labelled_sorted=$(printf '%s\n%s\n' "$unwired_sorted" "$mixed_sorted" | grep . | sort -u)
+n_labelled=$(count_lines "$labelled_sorted") || fail "cannot count the label-bearing crate set — unmeasurable is not a pass"
+
+# --- affirmative-measurement floor: the label-bearing set must be non-empty, or the
+# --- label loop below would enforce nothing while still reporting PASS.
 [ "$n_labelled" -gt 0 ] || fail "UNWIRED_TOOLS and MIXED_TOOLS are both empty — this guard would then enforce no label at all; refusing to pass vacuously"
 [ "$n_wired" -gt 0 ]    || fail "the recorded WIRED_TOOLS list is empty — refusing to pass vacuously"
 
 # --- 1. the three lists must be pairwise DISJOINT. A crate in two of them would
 # ---    satisfy the accounted-for loop below while making its label requirement
-# ---    ambiguous — which is the exact defect the third category exists to fix
-# ---    (roborev job 75), so it is asserted rather than assumed.
+# ---    ambiguous.
 #
 # `comm`'s exit status is CHECKED, not discarded. An unchecked `both=$(comm ...)`
-# yields an empty string when comm FAILS, and "empty intersection" is precisely
-# this check's PASS condition — so a comm failure would silently certify the lists
-# as disjoint. Same shape as roborev jobs 78/80: never let a permissive verdict
-# rest on the absence of output that a failure also produces.
+# yields an EMPTY string when comm FAILS, and "empty intersection" is exactly this
+# check's PASS condition — so a comm failure would silently certify the lists as
+# disjoint. Never let a permissive verdict rest on the absence of output that a
+# failure also produces.
 check_disjoint() {
   local a="$1" b="$2" name_a="$3" name_b="$4" both rc
   both=$(comm -12 <(printf '%s\n' "$a") <(printf '%s\n' "$b"))
@@ -355,8 +188,8 @@ $mixed_sorted"
 ok "every recorded crate exists on disk"
 
 # --- 4. the actual acceptance criterion of #1716: every crate carrying orphaned
-# ---    targets carries a README that SAYS so. A present-but-silent README does
-# ---    not label anything, so the marker is required, not just the file.
+# ---    targets carries a README that SAYS so. A present-but-silent README does not
+# ---    label anything, so the marker is required, not just the file.
 while IFS= read -r crate; do
   [ -n "$crate" ] || continue
   readme="$ROOT/tools/$crate/README.md"
@@ -368,84 +201,5 @@ while IFS= read -r crate; do
     || fail "tools/$crate/README.md exists but does not contain '$LABEL_MARKER' — the README must STATE that no CI workflow or script invokes it (or its orphaned targets), not merely exist (issue #1716)"
 done <<< "$labelled_sorted"
 ok "all $n_labelled crate(s) with orphaned targets carry a README.md stating '$LABEL_MARKER'"
-
-# --- 5. CROSS-CHECK the recorded disposition against the MANIFESTS. This is the
-# ---    half that cannot be talked around: "something depends on it" is derived
-# ---    from cargo's own resolution, so UNWIRED cannot be claimed for a crate the
-# ---    workspace depends on, and MIXED cannot be claimed for one it does not.
-while IFS= read -r crate; do
-  [ -n "$crate" ] || continue
-  pkg=$(package_name_of "$crate") \
-    || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
-  deps=$(workspace_dependents "$pkg") \
-    || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed, or its output no longer contains the subject as the tree root) — unmeasurable is not a pass. If the cargo REGISTRY CACHE is cold this guard fails by design rather than reach the network: run \`cargo fetch --locked\` once. If cargo's tree FORMAT changed, fix the parser in $(basename "$0")."
-  if [ -n "$deps" ]; then
-    fail "tools/$crate is recorded UNWIRED (nothing runs it AND nothing depends on it) but these workspace package(s) DEPEND on it: $(printf '%s ' $deps)- that is a FALSE census. Move it to MIXED_TOOLS (and label its README accordingly), because deleting or workspace-excluding it would break them (issue #1716)."
-  fi
-done <<< "$unwired_sorted"
-ok "every UNWIRED crate has zero workspace dependents (derived from cargo, not asserted)"
-
-if [ "$n_mixed" -gt 0 ]; then
-  while IFS= read -r crate; do
-    [ -n "$crate" ] || continue
-    readme="$ROOT/tools/$crate/README.md"
-
-    # --- (a) DERIVED half: dependents are computed for EVERY mixed crate, never
-    # --- skipped on the strength of a recorded invoked list. The two sources are
-    # --- independent and a crate can have both (roborev job 85).
-    pkg=$(package_name_of "$crate") \
-      || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
-    deps=$(workspace_dependents "$pkg") \
-      || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed, or its output no longer contains the subject as the tree root) — unmeasurable is not a pass. If the cargo REGISTRY CACHE is cold this guard fails by design rather than reach the network: run \`cargo fetch --locked\` once. If cargo's tree FORMAT changed, fix the parser in $(basename "$0")."
-    n_dep=0
-    while IFS= read -r dep; do
-      [ -n "$dep" ] || continue
-      grep -qF "$dep" "$readme" \
-        || fail "tools/$crate is MIXED and '$dep' really does depend on it, but its README.md never mentions '$dep'. A mixed crate's label must NAME its live half — otherwise it reads as wholly dead and invites deleting or workspace-excluding the part '$dep' needs (issue #1716)."
-      n_dep=$((n_dep + 1))
-    done <<< "$deps"
-
-    # --- (b) RECORDED half: invoked binaries, cross-checked against declared bins.
-    targets=$(mixed_invoked_targets "$crate") \
-      || fail "tools/$crate is recorded MIXED but has no entry in MIXED_INVOKED — record which of its binaries CI runs as '$crate|<bin>[,<bin>...]', or '$crate|none' if its live half is only a library dependency. Refusing to guess (issue #1716)."
-    n_inv=0
-    if [ "$targets" != none ]; then
-      [ -n "$targets" ] \
-        || fail "tools/$crate has an EMPTY MIXED_INVOKED target list — write '$crate|none' to say so explicitly rather than leaving it blank (issue #1716)."
-      bins=$(declared_bins "$crate") \
-        || fail "cannot read tools/$crate/Cargo.toml to list its [[bin]] targets — unmeasurable is not a pass"
-      old_ifs=$IFS; IFS=','
-      for target in $targets; do
-        IFS=$old_ifs
-        [ -n "$target" ] || fail "tools/$crate has an empty entry in its MIXED_INVOKED list '$targets' (a stray comma?) — refusing to pass on an unparseable record"
-        printf '%s\n' "$bins" | grep -qxF "$target" \
-          || fail "tools/$crate records invoked target '$target' in MIXED_INVOKED, but the crate declares no [[bin]] by that name (declared: $(printf '%s ' $bins)) — a target CI runs must at least exist (issue #1716)."
-        grep -qF "$target" "$readme" \
-          || fail "tools/$crate records invoked target '$target' as part of its live half, but its README.md never mentions '$target' (issue #1716)."
-        n_inv=$((n_inv + 1))
-        IFS=','
-      done
-      IFS=$old_ifs
-      [ "$n_inv" -gt 0 ] \
-        || fail "tools/$crate is recorded MIXED with invoked targets '$targets' but none was checked — refusing to pass vacuously"
-    fi
-
-    # --- (c) the UNION must be non-empty: a MIXED crate with neither a dependent
-    # --- nor an invoked binary has no live half at all, and belongs in UNWIRED.
-    [ "$((n_dep + n_inv))" -gt 0 ] \
-      || fail "tools/$crate is recorded MIXED but has NO live half from either source: no workspace package depends on it, and MIXED_INVOKED records no invoked binary. If nothing runs it and nothing depends on it, it belongs in UNWIRED_TOOLS (issue #1716)."
-    ok "tools/$crate (MIXED) documents its live half: $n_dep derived dependent(s), $n_inv recorded invoked target(s)"
-  done <<< "$mixed_sorted"
-fi
-
-# --- 6. every MIXED_INVOKED entry must name a crate that IS recorded MIXED, so a
-# ---    stale entry cannot sit there implying coverage it does not provide.
-while IFS= read -r entry; do
-  [ -n "$entry" ] || continue
-  entry_crate="${entry%%|*}"
-  printf '%s\n' "$mixed_sorted" | grep -qxF "$entry_crate" \
-    || fail "MIXED_INVOKED has an entry for '$entry_crate', which is not in MIXED_TOOLS — remove the stale entry (issue #1716)"
-done <<< "$(printf '%s\n' "$MIXED_INVOKED" | grep .)"
-ok "every MIXED_INVOKED entry corresponds to a recorded MIXED crate"
 
 echo "PASS: tools/ crate disposition census (#1716)"

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -137,17 +137,27 @@ package_name_of() {
 #
 # Prints one package name per line (the subject itself excluded). Returns
 # non-zero if cargo could not answer, so the caller can fail CLOSED.
-# NOTE the deliberate separation of the two failure modes below. Under
-# `pipefail`, a `grep -v` that matches nothing exits 1, so folding the cargo call
-# and the filtering into ONE pipeline made "cargo could not answer" and "the crate
-# has ZERO dependents" return the SAME status — and zero dependents is the NORMAL,
-# EXPECTED case for an UNWIRED crate. That is the two-valued-predicate trap: a
-# probe that cannot distinguish "no result" from "could not measure" must collapse
-# them, and it collapsed the legitimate case onto the error branch (every UNWIRED
-# crate reported "unmeasurable"). So cargo's exit status is captured ALONE, and the
-# filtering — whose emptiness is meaningful, not an error — is `|| true`.
+# FAIL-CLOSED CONTRACT, and the two traps designed out of it.
+#
+# (1) Under `pipefail`, `grep -v` exits 1 when it matches NOTHING — the NORMAL,
+#     EXPECTED result for an UNWIRED crate. Folding cargo's call and the filtering
+#     into ONE pipeline therefore made "cargo could not answer" and "zero
+#     dependents" return the SAME status, collapsing the legitimate case onto the
+#     error branch. That is the two-valued-predicate trap: a probe that cannot tell
+#     "no result" from "could not measure" must collapse them.
+# (2) The obvious patch for (1) — `grep ... || true` — is WORSE, because `|| true`
+#     also swallows grep's exit 2 (a REAL error) and any `sed`/`sort` failure,
+#     converting an UNMEASURABLE dependency graph into "zero dependents". That
+#     inverts the contract: a permissive answer derived from the ABSENCE of a
+#     signal, which is the one shape CLAUDE.md says never to build (roborev job 80).
+#
+# Neither is special-cased. The SHAPE that created the dilemma is gone instead:
+# cargo's status is captured ALONE, and the parse is ONE `awk` stage plus `sort` —
+# NEITHER of which exits non-zero for empty output. So `pipefail` stays armed with
+# no `|| true` anywhere, emptiness is DATA, and a genuine failure in any stage
+# still propagates.
 workspace_dependents() {
-  local crate="$1" out rc
+  local crate="$1" out rc parsed
   out=$(cd "$ROOT" && cargo tree --workspace --invert "$crate" --depth 1 \
           --all-features --target all 2>/dev/null)
   rc=$?
@@ -155,10 +165,25 @@ workspace_dependents() {
   # cargo always echoes the subject itself as the tree root, so empty output here
   # means cargo answered nothing at all — a measurement failure, not "no deps".
   [ -n "$out" ] || return 1
-  printf '%s\n' "$out" \
-    | sed -n 's/^[^A-Za-z0-9_-]*\([A-Za-z0-9_-]\{1,\}\) v[0-9].*/\1/p' \
-    | { grep -vxF "$crate" || true; } \
-    | sort -u
+
+  # Package name = the token immediately preceding " v<digit>", which skips both
+  # the tree glyphs cargo prefixes and the trailing (/path). The SUBJECT itself is
+  # dropped HERE, inside awk, rather than by a downstream `grep -v` — see the
+  # fail-closed note above the function for why that grep had to go entirely.
+  parsed=$(printf '%s\n' "$out" | awk -v self="$crate" '
+    match($0, /[A-Za-z0-9_-]+ v[0-9]/) {
+      name = substr($0, RSTART, RLENGTH)
+      sub(/ v[0-9]$/, "", name)
+      if (name != self) print name
+    }' | sort -u)
+  rc=$?
+  [ "$rc" -eq 0 ] || return 1
+
+  # Reaching here means cargo answered AND the parse succeeded — each validated
+  # above — so success is asserted from those checks, not assumed. An EMPTY result
+  # prints NOTHING, never a blank line (a caller's `[ -n "$deps" ]` would read one
+  # blank line as a single dependent named "").
+  [ -z "$parsed" ] || printf '%s\n' "$parsed"
   return 0
 }
 

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -123,6 +123,15 @@ package_name_of() {
 # recorded UNWIRED. Measured: `cargo tree --invert format-validator` reports no
 # dependents; adding `--workspace` reports format-compatibility-tests.
 #
+# `--all-features` and `--target all` are equally REQUIRED, and for the same class
+# of reason (roborev job 79): `cargo tree` otherwise resolves only the DEFAULT
+# feature set and the HOST target, so a workspace package depending on a tool crate
+# behind an OPTIONAL FEATURE, or under a `[target.'cfg(...)'.dependencies]` table,
+# is INVISIBLE — and that crate would then be recorded UNWIRED while something
+# really does depend on it. Every narrowing of this query is a way for the census to
+# be wrong in the permissive direction, so the query is widened to everything cargo
+# can see.
+#
 # Direct dependents suffice: if nothing depends on a crate directly, nothing
 # depends on it transitively either.
 #
@@ -139,7 +148,8 @@ package_name_of() {
 # filtering — whose emptiness is meaningful, not an error — is `|| true`.
 workspace_dependents() {
   local crate="$1" out rc
-  out=$(cd "$ROOT" && cargo tree --workspace --invert "$crate" --depth 1 2>/dev/null)
+  out=$(cd "$ROOT" && cargo tree --workspace --invert "$crate" --depth 1 \
+          --all-features --target all 2>/dev/null)
   rc=$?
   [ "$rc" -eq 0 ] || return 1
   # cargo always echoes the subject itself as the tree root, so empty output here

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -86,6 +86,23 @@ memory-safety-runner"
 #   asserted on by xtask/src/oom_audit/scope.rs. NEVER workspace-`exclude` it.
 MIXED_TOOLS="format-validator"
 
+# For each MIXED crate, WHAT its live half is. Two kinds exist because "live" has
+# two sources, and only one of them is derivable (roborev job 83):
+#
+#   dependency      the live half is a LIBRARY some workspace package depends on.
+#                   DERIVED from cargo; the README must name the real dependents.
+#   invoked:a,b,... the live half is BINARIES that CI invokes. Invocation is NOT
+#                   mechanically checkable, so the target names are RECORDED — but
+#                   each is still cross-checked against the crate's DECLARED
+#                   [[bin]] targets, and the README must name each one.
+#
+# The second kind exists because requiring a workspace dependent for every MIXED
+# crate rejected a legitimate shape: a multi-binary tool with one bin wired into CI
+# and another orphaned has NO reverse cargo dependency at all, and the guard would
+# have told its author to record it UNWIRED — which is false.
+# Format: <crate>|<kind>. Every MIXED crate must appear here or the guard FAILs.
+MIXED_LIVE="format-validator|dependency"
+
 # The marker every README with orphaned targets must contain, so the label states
 # the actual fact rather than merely existing as a file.
 LABEL_MARKER="NOT CI-wired"
@@ -95,6 +112,38 @@ LABEL_MARKER="NOT CI-wired"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "ok: $*"; }
+
+# The recorded live-half KIND for a MIXED crate, from MIXED_LIVE. Returns non-zero
+# when the crate has no entry, so an unrecorded MIXED crate fails closed rather
+# than defaulting to either kind.
+mixed_live_kind() {
+  local crate="$1" line
+  line=$(printf '%s\n' "$MIXED_LIVE" | grep "^$crate|" | head -1)
+  [ -n "$line" ] || return 1
+  printf '%s\n' "${line#*|}"
+}
+
+# The [[bin]] target names declared by tools/<dir>/Cargo.toml. Used to cross-check
+# a RECORDED invoked target against something mechanical: a target CI supposedly
+# runs must at least EXIST. Returns non-zero if the manifest cannot be read (an
+# unreadable manifest is unmeasurable, not "no bins").
+declared_bins() {
+  # Two statements, not one: within a SINGLE `local`, bash creates every name
+  # before assigning them, so a later word referencing an earlier one expands an
+  # UNSET local and dies under `set -u` ("dir: unbound variable"). This only
+  # surfaced in the scratch self-tests, because the real repo's one MIXED crate
+  # takes the `dependency` branch and never calls this function.
+  local dir="$1"
+  local manifest="$ROOT/tools/$dir/Cargo.toml"
+  [ -r "$manifest" ] || return 1
+  awk '
+    /^[[:space:]]*\[\[bin\]\]/ { inbin = 1; next }
+    /^[[:space:]]*\[/            { inbin = 0 }
+    inbin && /^[[:space:]]*name[[:space:]]*=/ {
+      if (match($0, /"[^"]+"/)) print substr($0, RSTART + 1, RLENGTH - 2)
+    }
+  ' "$manifest"
+}
 
 # The PACKAGE name declared by tools/<dir>/Cargo.toml. The recorded lists and the
 # README live under the DIRECTORY name, but cargo is queried by PACKAGE name, and
@@ -327,23 +376,67 @@ if [ "$n_mixed" -gt 0 ]; then
   while IFS= read -r crate; do
     [ -n "$crate" ] || continue
     readme="$ROOT/tools/$crate/README.md"
-    pkg=$(package_name_of "$crate") \
-      || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
-    deps=$(workspace_dependents "$pkg") \
-      || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed, or its output no longer contains the subject as the tree root) — unmeasurable is not a pass. If the cargo REGISTRY CACHE is cold this guard fails by design rather than reach the network: run \`cargo fetch --locked\` once. If cargo's tree FORMAT changed, fix the parser in $(basename "$0")."
-    [ -n "$deps" ] \
-      || fail "tools/$crate is recorded MIXED (some targets live, some orphaned) but NO workspace package depends on it — the 'live half' claim is unsupported. If nothing runs it either, it belongs in UNWIRED_TOOLS (issue #1716)."
-    # --- and its README must NAME each real dependent. The required strings are
-    # --- DERIVED above, so this cannot be satisfied by a generic word like
-    # --- "WIRED" that a README could carry while saying the opposite
-    # --- ("previously WIRED, now entirely NOT CI-wired") — roborev job 78.
-    while IFS= read -r dep; do
-      [ -n "$dep" ] || continue
-      grep -qF "$dep" "$readme" \
-        || fail "tools/$crate is recorded MIXED and '$dep' really does depend on it, but its README.md never mentions '$dep'. A mixed crate's label must NAME the live half — otherwise it reads as wholly dead and invites deleting or workspace-excluding the part '$dep' needs (issue #1716)."
-    done <<< "$deps"
-    ok "tools/$crate (MIXED) names its real dependent(s) in the README: $(printf '%s ' $deps)"
+    kind=$(mixed_live_kind "$crate") \
+      || fail "tools/$crate is recorded MIXED but has no entry in MIXED_LIVE — record WHAT its live half is ('$crate|dependency' if a workspace package depends on its library, or '$crate|invoked:<bin>[,<bin>...]' if CI runs some of its binaries). Refusing to guess (issue #1716)."
+    case "$kind" in
+      dependency)
+        # --- DERIVED: cargo must actually report a dependent, and the README must
+        # --- name each one.
+        pkg=$(package_name_of "$crate") \
+          || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
+        deps=$(workspace_dependents "$pkg") \
+          || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed, or its output no longer contains the subject as the tree root) — unmeasurable is not a pass. If the cargo REGISTRY CACHE is cold this guard fails by design rather than reach the network: run \`cargo fetch --locked\` once. If cargo's tree FORMAT changed, fix the parser in $(basename "$0")."
+        [ -n "$deps" ] \
+          || fail "tools/$crate is recorded MIXED via 'dependency' but NO workspace package depends on it. If its live half is instead a BINARY that CI runs, record '$crate|invoked:<bin>' in MIXED_LIVE. If nothing runs it and nothing depends on it, it belongs in UNWIRED_TOOLS (issue #1716)."
+        while IFS= read -r dep; do
+          [ -n "$dep" ] || continue
+          grep -qF "$dep" "$readme" \
+            || fail "tools/$crate is recorded MIXED and '$dep' really does depend on it, but its README.md never mentions '$dep'. A mixed crate's label must NAME the live half — otherwise it reads as wholly dead and invites deleting or workspace-excluding the part '$dep' needs (issue #1716)."
+        done <<< "$deps"
+        ok "tools/$crate (MIXED via dependency) names its real dependent(s) in the README: $(printf '%s ' $deps)"
+        ;;
+      invoked:*)
+        # --- RECORDED, but still cross-checked: a target CI supposedly runs must at
+        # --- least be DECLARED as a [[bin]], and the README must name it. This is
+        # --- the shape that has no reverse cargo dependency at all — a multi-binary
+        # --- tool with one bin wired and another orphaned (roborev job 83).
+        targets="${kind#invoked:}"
+        [ -n "$targets" ] \
+          || fail "tools/$crate is recorded MIXED via 'invoked:' but names no target — record which binaries CI runs, e.g. '$crate|invoked:<bin>' (issue #1716)."
+        bins=$(declared_bins "$crate") \
+          || fail "cannot read tools/$crate/Cargo.toml to list its [[bin]] targets — unmeasurable is not a pass"
+        n_checked=0
+        old_ifs=$IFS; IFS=','
+        for target in $targets; do
+          IFS=$old_ifs
+          [ -n "$target" ] || continue
+          printf '%s\n' "$bins" | grep -qxF "$target" \
+            || fail "tools/$crate records invoked target '$target' in MIXED_LIVE, but the crate declares no [[bin]] by that name (declared: $(printf '%s ' $bins)) — a target CI runs must at least exist (issue #1716)."
+          grep -qF "$target" "$readme" \
+            || fail "tools/$crate records invoked target '$target' as its live half, but its README.md never mentions '$target'. A mixed crate's label must NAME the live half, or the crate reads as wholly dead (issue #1716)."
+          n_checked=$((n_checked + 1))
+          IFS=','
+        done
+        IFS=$old_ifs
+        [ "$n_checked" -gt 0 ] \
+          || fail "tools/$crate is recorded MIXED via 'invoked:$targets' but no target was actually checked — refusing to pass vacuously"
+        ok "tools/$crate (MIXED via $n_checked invoked target(s)) declares and documents each: $targets"
+        ;;
+      *)
+        fail "tools/$crate has an unrecognised MIXED_LIVE kind '$kind' — the only accepted forms are 'dependency' and 'invoked:<bin>[,<bin>...]'. An unrecognised value is refused rather than treated as either (issue #1716)."
+        ;;
+    esac
   done <<< "$mixed_sorted"
 fi
+
+# --- 6. every MIXED_LIVE entry must name a crate that IS recorded MIXED, so a
+# ---    stale entry cannot sit there implying coverage it does not provide.
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  entry_crate="${entry%%|*}"
+  printf '%s\n' "$mixed_sorted" | grep -qxF "$entry_crate" \
+    || fail "MIXED_LIVE has an entry for '$entry_crate', which is not in MIXED_TOOLS — remove the stale entry (issue #1716)"
+done <<< "$(printf '%s\n' "$MIXED_LIVE" | grep .)"
+ok "every MIXED_LIVE entry corresponds to a recorded MIXED crate"
 
 echo "PASS: tools/ crate disposition census (#1716)"

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -158,8 +158,15 @@ package_name_of() {
 # still propagates.
 workspace_dependents() {
   local crate="$1" out rc parsed
+  # `--locked --offline` keeps this inside the tooling-tests contract (fast, no
+  # network): --offline forbids registry access and --locked refuses to REWRITE
+  # Cargo.lock, so the guard cannot mutate the tree it is inspecting. Neither
+  # changes the ANSWER — resolution comes from Cargo.lock plus the local cache
+  # (verified: identical output with and without both flags). A cold cargo cache
+  # makes this FAIL rather than silently reach the network, which is the correct
+  # direction; the caller's message names the remedy.
   out=$(cd "$ROOT" && cargo tree --workspace --invert "$crate" --depth 1 \
-          --all-features --target all 2>/dev/null)
+          --all-features --target all --locked --offline 2>/dev/null)
   rc=$?
   [ "$rc" -eq 0 ] || return 1
   # cargo always echoes the subject itself as the tree root, so empty output here
@@ -170,12 +177,21 @@ workspace_dependents() {
   # the tree glyphs cargo prefixes and the trailing (/path). The SUBJECT itself is
   # dropped HERE, inside awk, rather than by a downstream `grep -v` — see the
   # fail-closed note above the function for why that grep had to go entirely.
+  # The parse must PROVE it understood the output before an empty dependent set is
+  # allowed to mean "no dependents" (roborev job 82). cargo ALWAYS prints the
+  # subject as the tree root, so seeing the subject is positive evidence that the
+  # pattern still matches cargo's format; NOT seeing it means the format changed or
+  # the filter silently matched nothing — under which an UNWIRED crate with real
+  # dependents would have passed. awk exits 3 for that case, distinct from a real
+  # awk failure, and both are non-zero so both fail closed.
   parsed=$(printf '%s\n' "$out" | awk -v self="$crate" '
     match($0, /[A-Za-z0-9_-]+ v[0-9]/) {
       name = substr($0, RSTART, RLENGTH)
       sub(/ v[0-9]$/, "", name)
-      if (name != self) print name
-    }' | sort -u)
+      if (name == self) { seen_self = 1; next }
+      print name
+    }
+    END { if (!seen_self) exit 3 }' | sort -u)
   rc=$?
   [ "$rc" -eq 0 ] || return 1
 
@@ -300,7 +316,7 @@ while IFS= read -r crate; do
   pkg=$(package_name_of "$crate") \
     || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
   deps=$(workspace_dependents "$pkg") \
-    || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed) — unmeasurable is not a pass"
+    || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed, or its output no longer contains the subject as the tree root) — unmeasurable is not a pass. If the cargo REGISTRY CACHE is cold this guard fails by design rather than reach the network: run \`cargo fetch --locked\` once. If cargo's tree FORMAT changed, fix the parser in $(basename "$0")."
   if [ -n "$deps" ]; then
     fail "tools/$crate is recorded UNWIRED (nothing runs it AND nothing depends on it) but these workspace package(s) DEPEND on it: $(printf '%s ' $deps)- that is a FALSE census. Move it to MIXED_TOOLS (and label its README accordingly), because deleting or workspace-excluding it would break them (issue #1716)."
   fi
@@ -314,7 +330,7 @@ if [ "$n_mixed" -gt 0 ]; then
     pkg=$(package_name_of "$crate") \
       || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
     deps=$(workspace_dependents "$pkg") \
-      || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed) — unmeasurable is not a pass"
+      || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed, or its output no longer contains the subject as the tree root) — unmeasurable is not a pass. If the cargo REGISTRY CACHE is cold this guard fails by design rather than reach the network: run \`cargo fetch --locked\` once. If cargo's tree FORMAT changed, fix the parser in $(basename "$0")."
     [ -n "$deps" ] \
       || fail "tools/$crate is recorded MIXED (some targets live, some orphaned) but NO workspace package depends on it — the 'live half' claim is unsupported. If nothing runs it either, it belongs in UNWIRED_TOOLS (issue #1716)."
     # --- and its README must NAME each real dependent. The required strings are

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
 # tools/ crate disposition census (issue #1716, epic #1688 finding AK5).
 #
-# ONE property: every crate under tools/ is EXPLICITLY classified into one of
-# THREE dispositions, and every crate carrying unwired targets carries the README
-# label that says so:
+# SCOPE, stated first because a guard that overpromises is worse than a small one.
+# This checks CRATE-level disposition, NOT per-target disposition. Adding an
+# orphaned binary to an already-WIRED crate therefore needs no census update and
+# passes unchanged (roborev job 85). That gap is REAL and is accepted rather than
+# closed: closing it means maintaining a per-target inventory for every [[bin]] of
+# every tools/ crate, checked against each manifest — which is a larger mechanism
+# than the P3 labeling issue that this guard serves, and it would put the
+# disposition of ~12 targets into a hand-maintained list whose drift is exactly the
+# failure mode this guard exists to prevent. Recorded as a known limitation with a
+# pointer to epic #1688; if per-target disposition is wanted, it deserves its own
+# issue rather than a rider on this one.
+#
+# ONE property, at crate granularity: every crate under tools/ is EXPLICITLY
+# classified into one of THREE dispositions, and every crate carrying unwired
+# targets carries the README label that says so:
 #
 #   WIRED   — something runs it; nothing in it is orphaned.
 #   UNWIRED — nothing runs it, and nothing depends on it either. Needs a label.
@@ -66,6 +78,10 @@ ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 # --- lists is a deliberate, reviewable act.
 
 # Invoked by at least one CI workflow or script. No README required by this guard.
+# NOTE the crate-level granularity (see SCOPE above): a crate here may still gain
+# an orphaned binary later without tripping anything. If you know a WIRED crate has
+# acquired an orphaned target, move it to MIXED_TOOLS and label it — the guard will
+# not tell you to.
 WIRED_TOOLS="cassandra-parity
 flight-loadgen
 sstabledump-validator
@@ -86,25 +102,22 @@ memory-safety-runner"
 #   asserted on by xtask/src/oom_audit/scope.rs. NEVER workspace-`exclude` it.
 MIXED_TOOLS="format-validator"
 
-# For each MIXED crate, WHAT its live half is. Two kinds exist because "live" has
-# two sources, and only one of them is derivable (roborev job 83):
+# For each MIXED crate, the binaries CI INVOKES — or `none`. This does NOT replace
+# dependency discovery: workspace dependents are ALWAYS derived for every MIXED
+# crate and always required to be documented. The two are INDEPENDENT, because a
+# crate can have both (roborev job 85), and an earlier version treated them as
+# mutually exclusive — choosing `invoked:` then skipped dependency discovery
+# entirely, letting a README omit real dependents while still passing.
 #
-#   dependency      the live half is a LIBRARY some workspace package depends on.
-#                   DERIVED from cargo; the README must name the real dependents.
-#   invoked:a,b,... the live half is BINARIES that CI invokes. Invocation is NOT
-#                   mechanically checkable, so the target names are RECORDED — but
-#                   each is still cross-checked against the crate's DECLARED
-#                   [[bin]] targets, and the README must name each one.
-#
-# The second kind exists because requiring a workspace dependent for every MIXED
-# crate rejected a legitimate shape: a multi-binary tool with one bin wired into CI
-# and another orphaned has NO reverse cargo dependency at all, and the guard would
-# have told its author to record it UNWIRED — which is false.
-# Format: <crate>|<kind>. Every MIXED crate must appear here or the guard FAILs.
-MIXED_LIVE="format-validator|dependency"
+# So the live half is the UNION of two sources, at least one of which must be
+# non-empty:
+#   DERIVED   workspace dependents, from `cargo tree --workspace --invert`.
+#   RECORDED  invoked binaries, because invocation is not mechanically checkable —
+#             but each recorded target is still cross-checked against the crate's
+#             DECLARED [[bin]] targets, and must be named in the README.
+# Format: <crate>|<bin>[,<bin>...] or <crate>|none. Every MIXED crate must appear.
+MIXED_INVOKED="format-validator|none"
 
-# The marker every README with orphaned targets must contain, so the label states
-# the actual fact rather than merely existing as a file.
 LABEL_MARKER="NOT CI-wired"
 # A MIXED crate's README must additionally name each of its ACTUAL workspace
 # dependents — the package names are DERIVED below, never hard-coded here, so this
@@ -113,12 +126,12 @@ LABEL_MARKER="NOT CI-wired"
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "ok: $*"; }
 
-# The recorded live-half KIND for a MIXED crate, from MIXED_LIVE. Returns non-zero
-# when the crate has no entry, so an unrecorded MIXED crate fails closed rather
-# than defaulting to either kind.
-mixed_live_kind() {
+# The RECORDED invoked-binary list for a MIXED crate, from MIXED_INVOKED. Returns
+# non-zero when the crate has no entry, so an unrecorded MIXED crate fails closed
+# rather than silently defaulting to "no invoked binaries".
+mixed_invoked_targets() {
   local crate="$1" line
-  line=$(printf '%s\n' "$MIXED_LIVE" | grep "^$crate|" | head -1)
+  line=$(printf '%s\n' "$MIXED_INVOKED" | grep "^$crate|" | head -1)
   [ -n "$line" ] || return 1
   printf '%s\n' "${line#*|}"
 }
@@ -376,67 +389,63 @@ if [ "$n_mixed" -gt 0 ]; then
   while IFS= read -r crate; do
     [ -n "$crate" ] || continue
     readme="$ROOT/tools/$crate/README.md"
-    kind=$(mixed_live_kind "$crate") \
-      || fail "tools/$crate is recorded MIXED but has no entry in MIXED_LIVE — record WHAT its live half is ('$crate|dependency' if a workspace package depends on its library, or '$crate|invoked:<bin>[,<bin>...]' if CI runs some of its binaries). Refusing to guess (issue #1716)."
-    case "$kind" in
-      dependency)
-        # --- DERIVED: cargo must actually report a dependent, and the README must
-        # --- name each one.
-        pkg=$(package_name_of "$crate") \
-          || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
-        deps=$(workspace_dependents "$pkg") \
-          || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed, or its output no longer contains the subject as the tree root) — unmeasurable is not a pass. If the cargo REGISTRY CACHE is cold this guard fails by design rather than reach the network: run \`cargo fetch --locked\` once. If cargo's tree FORMAT changed, fix the parser in $(basename "$0")."
-        [ -n "$deps" ] \
-          || fail "tools/$crate is recorded MIXED via 'dependency' but NO workspace package depends on it. If its live half is instead a BINARY that CI runs, record '$crate|invoked:<bin>' in MIXED_LIVE. If nothing runs it and nothing depends on it, it belongs in UNWIRED_TOOLS (issue #1716)."
-        while IFS= read -r dep; do
-          [ -n "$dep" ] || continue
-          grep -qF "$dep" "$readme" \
-            || fail "tools/$crate is recorded MIXED and '$dep' really does depend on it, but its README.md never mentions '$dep'. A mixed crate's label must NAME the live half — otherwise it reads as wholly dead and invites deleting or workspace-excluding the part '$dep' needs (issue #1716)."
-        done <<< "$deps"
-        ok "tools/$crate (MIXED via dependency) names its real dependent(s) in the README: $(printf '%s ' $deps)"
-        ;;
-      invoked:*)
-        # --- RECORDED, but still cross-checked: a target CI supposedly runs must at
-        # --- least be DECLARED as a [[bin]], and the README must name it. This is
-        # --- the shape that has no reverse cargo dependency at all — a multi-binary
-        # --- tool with one bin wired and another orphaned (roborev job 83).
-        targets="${kind#invoked:}"
-        [ -n "$targets" ] \
-          || fail "tools/$crate is recorded MIXED via 'invoked:' but names no target — record which binaries CI runs, e.g. '$crate|invoked:<bin>' (issue #1716)."
-        bins=$(declared_bins "$crate") \
-          || fail "cannot read tools/$crate/Cargo.toml to list its [[bin]] targets — unmeasurable is not a pass"
-        n_checked=0
-        old_ifs=$IFS; IFS=','
-        for target in $targets; do
-          IFS=$old_ifs
-          [ -n "$target" ] || continue
-          printf '%s\n' "$bins" | grep -qxF "$target" \
-            || fail "tools/$crate records invoked target '$target' in MIXED_LIVE, but the crate declares no [[bin]] by that name (declared: $(printf '%s ' $bins)) — a target CI runs must at least exist (issue #1716)."
-          grep -qF "$target" "$readme" \
-            || fail "tools/$crate records invoked target '$target' as its live half, but its README.md never mentions '$target'. A mixed crate's label must NAME the live half, or the crate reads as wholly dead (issue #1716)."
-          n_checked=$((n_checked + 1))
-          IFS=','
-        done
+
+    # --- (a) DERIVED half: dependents are computed for EVERY mixed crate, never
+    # --- skipped on the strength of a recorded invoked list. The two sources are
+    # --- independent and a crate can have both (roborev job 85).
+    pkg=$(package_name_of "$crate") \
+      || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
+    deps=$(workspace_dependents "$pkg") \
+      || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed, or its output no longer contains the subject as the tree root) — unmeasurable is not a pass. If the cargo REGISTRY CACHE is cold this guard fails by design rather than reach the network: run \`cargo fetch --locked\` once. If cargo's tree FORMAT changed, fix the parser in $(basename "$0")."
+    n_dep=0
+    while IFS= read -r dep; do
+      [ -n "$dep" ] || continue
+      grep -qF "$dep" "$readme" \
+        || fail "tools/$crate is MIXED and '$dep' really does depend on it, but its README.md never mentions '$dep'. A mixed crate's label must NAME its live half — otherwise it reads as wholly dead and invites deleting or workspace-excluding the part '$dep' needs (issue #1716)."
+      n_dep=$((n_dep + 1))
+    done <<< "$deps"
+
+    # --- (b) RECORDED half: invoked binaries, cross-checked against declared bins.
+    targets=$(mixed_invoked_targets "$crate") \
+      || fail "tools/$crate is recorded MIXED but has no entry in MIXED_INVOKED — record which of its binaries CI runs as '$crate|<bin>[,<bin>...]', or '$crate|none' if its live half is only a library dependency. Refusing to guess (issue #1716)."
+    n_inv=0
+    if [ "$targets" != none ]; then
+      [ -n "$targets" ] \
+        || fail "tools/$crate has an EMPTY MIXED_INVOKED target list — write '$crate|none' to say so explicitly rather than leaving it blank (issue #1716)."
+      bins=$(declared_bins "$crate") \
+        || fail "cannot read tools/$crate/Cargo.toml to list its [[bin]] targets — unmeasurable is not a pass"
+      old_ifs=$IFS; IFS=','
+      for target in $targets; do
         IFS=$old_ifs
-        [ "$n_checked" -gt 0 ] \
-          || fail "tools/$crate is recorded MIXED via 'invoked:$targets' but no target was actually checked — refusing to pass vacuously"
-        ok "tools/$crate (MIXED via $n_checked invoked target(s)) declares and documents each: $targets"
-        ;;
-      *)
-        fail "tools/$crate has an unrecognised MIXED_LIVE kind '$kind' — the only accepted forms are 'dependency' and 'invoked:<bin>[,<bin>...]'. An unrecognised value is refused rather than treated as either (issue #1716)."
-        ;;
-    esac
+        [ -n "$target" ] || fail "tools/$crate has an empty entry in its MIXED_INVOKED list '$targets' (a stray comma?) — refusing to pass on an unparseable record"
+        printf '%s\n' "$bins" | grep -qxF "$target" \
+          || fail "tools/$crate records invoked target '$target' in MIXED_INVOKED, but the crate declares no [[bin]] by that name (declared: $(printf '%s ' $bins)) — a target CI runs must at least exist (issue #1716)."
+        grep -qF "$target" "$readme" \
+          || fail "tools/$crate records invoked target '$target' as part of its live half, but its README.md never mentions '$target' (issue #1716)."
+        n_inv=$((n_inv + 1))
+        IFS=','
+      done
+      IFS=$old_ifs
+      [ "$n_inv" -gt 0 ] \
+        || fail "tools/$crate is recorded MIXED with invoked targets '$targets' but none was checked — refusing to pass vacuously"
+    fi
+
+    # --- (c) the UNION must be non-empty: a MIXED crate with neither a dependent
+    # --- nor an invoked binary has no live half at all, and belongs in UNWIRED.
+    [ "$((n_dep + n_inv))" -gt 0 ] \
+      || fail "tools/$crate is recorded MIXED but has NO live half from either source: no workspace package depends on it, and MIXED_INVOKED records no invoked binary. If nothing runs it and nothing depends on it, it belongs in UNWIRED_TOOLS (issue #1716)."
+    ok "tools/$crate (MIXED) documents its live half: $n_dep derived dependent(s), $n_inv recorded invoked target(s)"
   done <<< "$mixed_sorted"
 fi
 
-# --- 6. every MIXED_LIVE entry must name a crate that IS recorded MIXED, so a
+# --- 6. every MIXED_INVOKED entry must name a crate that IS recorded MIXED, so a
 # ---    stale entry cannot sit there implying coverage it does not provide.
 while IFS= read -r entry; do
   [ -n "$entry" ] || continue
   entry_crate="${entry%%|*}"
   printf '%s\n' "$mixed_sorted" | grep -qxF "$entry_crate" \
-    || fail "MIXED_LIVE has an entry for '$entry_crate', which is not in MIXED_TOOLS — remove the stale entry (issue #1716)"
-done <<< "$(printf '%s\n' "$MIXED_LIVE" | grep .)"
-ok "every MIXED_LIVE entry corresponds to a recorded MIXED crate"
+    || fail "MIXED_INVOKED has an entry for '$entry_crate', which is not in MIXED_TOOLS — remove the stale entry (issue #1716)"
+done <<< "$(printf '%s\n' "$MIXED_INVOKED" | grep .)"
+ok "every MIXED_INVOKED entry corresponds to a recorded MIXED crate"
 
 echo "PASS: tools/ crate disposition census (#1716)"

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -26,14 +26,29 @@
 # is invisible. Both are caught here, at zero cost, with no false positives:
 # the rule is a list, not an inference.
 #
-# Deliberately NOT what this guard does: it does not try to DERIVE wiredness by
-# grepping for invocations. A grep is a proxy that gets both directions wrong —
-# tools/format-validator is referenced twice under scripts/ purely as a PATH
-# FIXTURE (neither reference runs it), and a crate can be wired via a binary
-# name that differs from its package name (tools/ws0-corpus-gen ships
-# `ws0-scan-bench`). A guard whose FAIL an agent learns to waive is worse than
-# no guard (CLAUDE.md), so wiredness is RECORDED here by a human and reviewed in
-# the diff, never guessed.
+# TWO HALVES, and the split matters — one is DERIVED, the other RECORDED:
+#
+#   "something DEPENDS on it" is MECHANICALLY CHECKABLE from the manifests, so it
+#   is DERIVED (via `cargo tree --workspace --invert`, cargo as its own authority)
+#   and CROSS-CHECKED against the recorded disposition. UNWIRED must have ZERO
+#   workspace dependents and MIXED must have AT LEAST ONE — so neither category
+#   can be asserted falsely, in either direction.
+#
+#   "something RUNS it" is NOT mechanically checkable — invocations live in
+#   workflows, scripts and prose — so it is RECORDED by a human and reviewed in
+#   the diff. It is deliberately NOT grep-inferred: a grep for invocations gets
+#   both directions wrong (tools/format-validator is referenced twice under
+#   scripts/ purely as a PATH FIXTURE that runs nothing, and tools/ws0-corpus-gen
+#   is wired via a binary name that differs from its package name), and a guard
+#   whose FAIL an agent learns to waive is worse than no guard (CLAUDE.md).
+#
+# This split is the fix for roborev job 78: the MIXED label had been verified by
+# grepping the README for the generic word "WIRED", which a README could satisfy
+# while saying the opposite ("previously WIRED, now entirely NOT CI-wired").
+# Verifying a claim by pattern-matching prose is unbounded — the prose author
+# chooses the wording — so the load-bearing check moved OFF the prose and onto the
+# manifests, and the prose requirement is now to name the crate's ACTUAL,
+# DERIVED dependents rather than any fixed word.
 #
 # FAILS CLOSED: an unclassifiable or unmeasurable tree is a FAIL, never a pass.
 # Self-test / negative controls: scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -62,8 +77,9 @@ UNWIRED_TOOLS="cqlite-validator
 memory-safety-runner"
 
 # Some targets live, some orphaned. Each MUST carry a README.md containing BOTH
-# LABEL_MARKER (for the orphaned targets) and MIXED_WIRED_MARKER (naming the live
-# ones), so the label cannot describe the crate as wholly unwired.
+# LABEL_MARKER (for the orphaned targets) and the names of its DERIVED dependents (the live
+# ones, named below from the DERIVED dependent set), so the label cannot describe
+# the crate as wholly unwired.
 #   format-validator: 4 binaries orphaned; LIBRARY wired into
 #   tests/format-compatibility (gate component `format-compat`), and also used as
 #   a fixture by scripts/tests/test_agent_gate_summary.sh (owners resolution) and
@@ -73,12 +89,68 @@ MIXED_TOOLS="format-validator"
 # The marker every README with orphaned targets must contain, so the label states
 # the actual fact rather than merely existing as a file.
 LABEL_MARKER="NOT CI-wired"
-# Additionally required of a MIXED crate's README: it must name the LIVE half, so
-# a partly-live crate can never be labeled as though it were wholly dead.
-MIXED_WIRED_MARKER="WIRED"
+# A MIXED crate's README must additionally name each of its ACTUAL workspace
+# dependents — the package names are DERIVED below, never hard-coded here, so this
+# requirement cannot be satisfied by a generic word (roborev job 78).
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "ok: $*"; }
+
+# The PACKAGE name declared by tools/<dir>/Cargo.toml. The recorded lists and the
+# README live under the DIRECTORY name, but cargo is queried by PACKAGE name, and
+# the two are not the same thing — assuming they were made every scratch-tree
+# self-test case report "cargo could not answer". All seven of this repo's tools/
+# crates happen to match, which is exactly why the assumption would have stayed
+# invisible here until someone added one that did not.
+#
+# Takes the FIRST `name =` line in the manifest: that is the `[package]` one, since
+# `[package]` precedes any `[lib]`/`[[bin]]` table that also carries a `name`
+# (tools/cassandra-parity has both). Fails closed if none is found.
+package_name_of() {
+  local dir="$1" name
+  name=$(sed -n 's/^name[[:space:]]*=[[:space:]]*"\([^"]\{1,\}\)".*/\1/p' "$ROOT/tools/$dir/Cargo.toml" 2>/dev/null | head -1)
+  [ -n "$name" ] || return 1
+  printf '%s\n' "$name"
+}
+
+# Workspace packages that DIRECTLY depend on $1 (a PACKAGE name), derived from cargo's own
+# resolution — never a hand-parse of Cargo.toml, and never a grep for prose.
+#
+# `--workspace` is REQUIRED: without it `cargo tree` operates on the DEFAULT
+# member set, which in this workspace is the root package alone (see the
+# `default-members` note in the root Cargo.toml), and every crate would appear to
+# have zero dependents — a silent false negative that would let a MIXED crate be
+# recorded UNWIRED. Measured: `cargo tree --invert format-validator` reports no
+# dependents; adding `--workspace` reports format-compatibility-tests.
+#
+# Direct dependents suffice: if nothing depends on a crate directly, nothing
+# depends on it transitively either.
+#
+# Prints one package name per line (the subject itself excluded). Returns
+# non-zero if cargo could not answer, so the caller can fail CLOSED.
+# NOTE the deliberate separation of the two failure modes below. Under
+# `pipefail`, a `grep -v` that matches nothing exits 1, so folding the cargo call
+# and the filtering into ONE pipeline made "cargo could not answer" and "the crate
+# has ZERO dependents" return the SAME status — and zero dependents is the NORMAL,
+# EXPECTED case for an UNWIRED crate. That is the two-valued-predicate trap: a
+# probe that cannot distinguish "no result" from "could not measure" must collapse
+# them, and it collapsed the legitimate case onto the error branch (every UNWIRED
+# crate reported "unmeasurable"). So cargo's exit status is captured ALONE, and the
+# filtering — whose emptiness is meaningful, not an error — is `|| true`.
+workspace_dependents() {
+  local crate="$1" out rc
+  out=$(cd "$ROOT" && cargo tree --workspace --invert "$crate" --depth 1 2>/dev/null)
+  rc=$?
+  [ "$rc" -eq 0 ] || return 1
+  # cargo always echoes the subject itself as the tree root, so empty output here
+  # means cargo answered nothing at all — a measurement failure, not "no deps".
+  [ -n "$out" ] || return 1
+  printf '%s\n' "$out" \
+    | sed -n 's/^[^A-Za-z0-9_-]*\([A-Za-z0-9_-]\{1,\}\) v[0-9].*/\1/p' \
+    | { grep -vxF "$crate" || true; } \
+    | sort -u
+  return 0
+}
 
 [ -d "$ROOT/tools" ] || fail "no tools/ directory under $ROOT — this guard's subject is missing; refusing to pass vacuously"
 
@@ -157,18 +229,43 @@ while IFS= read -r crate; do
 done <<< "$labelled_sorted"
 ok "all $n_labelled crate(s) with orphaned targets carry a README.md stating '$LABEL_MARKER'"
 
-# --- 5. a MIXED crate's README must ALSO name its LIVE half. Without this, a
-# ---    mixed crate's label is indistinguishable from a wholly-unwired one — the
-# ---    false census roborev job 75 caught — and a future reader could delete or
-# ---    workspace-`exclude` a dependency the gate needs.
+# --- 5. CROSS-CHECK the recorded disposition against the MANIFESTS. This is the
+# ---    half that cannot be talked around: "something depends on it" is derived
+# ---    from cargo's own resolution, so UNWIRED cannot be claimed for a crate the
+# ---    workspace depends on, and MIXED cannot be claimed for one it does not.
+while IFS= read -r crate; do
+  [ -n "$crate" ] || continue
+  pkg=$(package_name_of "$crate") \
+    || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
+  deps=$(workspace_dependents "$pkg") \
+    || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed) — unmeasurable is not a pass"
+  if [ -n "$deps" ]; then
+    fail "tools/$crate is recorded UNWIRED (nothing runs it AND nothing depends on it) but these workspace package(s) DEPEND on it: $(printf '%s ' $deps)- that is a FALSE census. Move it to MIXED_TOOLS (and label its README accordingly), because deleting or workspace-excluding it would break them (issue #1716)."
+  fi
+done <<< "$unwired_sorted"
+ok "every UNWIRED crate has zero workspace dependents (derived from cargo, not asserted)"
+
 if [ "$n_mixed" -gt 0 ]; then
   while IFS= read -r crate; do
     [ -n "$crate" ] || continue
     readme="$ROOT/tools/$crate/README.md"
-    grep -qF "$MIXED_WIRED_MARKER" "$readme" \
-      || fail "tools/$crate is recorded MIXED (some targets live, some orphaned) but its README.md never says '$MIXED_WIRED_MARKER' — a mixed crate labeled only '$LABEL_MARKER' reads as wholly dead, which invites deleting or workspace-excluding the half the gate depends on (issue #1716)"
+    pkg=$(package_name_of "$crate") \
+      || fail "cannot read the package name from tools/$crate/Cargo.toml — unmeasurable is not a pass"
+    deps=$(workspace_dependents "$pkg") \
+      || fail "cannot derive workspace dependents of tools/$crate (package '$pkg'; cargo tree --workspace --invert failed) — unmeasurable is not a pass"
+    [ -n "$deps" ] \
+      || fail "tools/$crate is recorded MIXED (some targets live, some orphaned) but NO workspace package depends on it — the 'live half' claim is unsupported. If nothing runs it either, it belongs in UNWIRED_TOOLS (issue #1716)."
+    # --- and its README must NAME each real dependent. The required strings are
+    # --- DERIVED above, so this cannot be satisfied by a generic word like
+    # --- "WIRED" that a README could carry while saying the opposite
+    # --- ("previously WIRED, now entirely NOT CI-wired") — roborev job 78.
+    while IFS= read -r dep; do
+      [ -n "$dep" ] || continue
+      grep -qF "$dep" "$readme" \
+        || fail "tools/$crate is recorded MIXED and '$dep' really does depend on it, but its README.md never mentions '$dep'. A mixed crate's label must NAME the live half — otherwise it reads as wholly dead and invites deleting or workspace-excluding the part '$dep' needs (issue #1716)."
+    done <<< "$deps"
+    ok "tools/$crate (MIXED) names its real dependent(s) in the README: $(printf '%s ' $deps)"
   done <<< "$mixed_sorted"
-  ok "all $n_mixed mixed crate(s) name their live half ('$MIXED_WIRED_MARKER') in the README"
 fi
 
 echo "PASS: tools/ crate disposition census (#1716)"

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
 # tools/ crate disposition census (issue #1716, epic #1688 finding AK5).
 #
-# ONE property: every crate under tools/ is EXPLICITLY classified as either
-# CI-wired or an unwired manual dev tool, and every unwired one carries the
-# README label that says so.
+# ONE property: every crate under tools/ is EXPLICITLY classified into one of
+# THREE dispositions, and every crate carrying unwired targets carries the README
+# label that says so:
+#
+#   WIRED   — something runs it; nothing in it is orphaned.
+#   UNWIRED — nothing runs it, and nothing depends on it either. Needs a label.
+#   MIXED   — some targets are live and others are orphaned. Needs a label that
+#             states BOTH halves, because calling such a crate simply "unwired"
+#             is a FALSE census and invites deleting the live half.
+#
+# The three-way split exists because a two-way one was wrong (roborev job 75 on
+# #1716): tools/format-validator's four BINARIES are invoked by nothing, while its
+# LIBRARY is a path dependency of tests/format-compatibility — the gate's own
+# `format-compat` component. Filing that crate under a crate-level "unwired" made
+# a mixed-status crate satisfy a mutually-exclusive classification, so the census
+# asserted something untrue about it.
 #
 # Why. Finding AK5 was that three tools/ crates were invoked by no workflow, no
 # script and no doc, and nothing said so — so they read as live tooling for
@@ -34,7 +47,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 
 # --- The recorded disposition. Hard-coded ON PURPOSE: one visible location,
-# --- inside the diff a reviewer already reads. Moving a crate between these two
+# --- inside the diff a reviewer already reads. Moving a crate between these
 # --- lists is a deliberate, reviewable act.
 
 # Invoked by at least one CI workflow or script. No README required by this guard.
@@ -43,26 +56,26 @@ flight-loadgen
 sstabledump-validator
 ws0-corpus-gen"
 
-# Invoked by NO workflow, NO script and NO live doc (census: issue #1716).
-# Each MUST carry a README.md carrying the label marker below.
-#
-# "Unwired" here is a statement about what anything RUNS, which is not the same as
-# what anything DEPENDS ON, and tools/format-validator is the case that separates
-# them: nothing invokes any of its four binaries, so it belongs on this list — yet
-# its LIBRARY is a path dependency of tests/format-compatibility (the gate's
-# `format-compat` component). So membership here means "no CI workflow or script
-# runs this crate", never "this crate is unused", and it is emphatically NOT a
-# licence to delete or to workspace-`exclude`: excluding format-validator breaks
-# that gate component, scripts/tests/test_agent_gate_summary.sh (which uses its
-# lib.rs as the owners-resolution fixture) and xtask/src/oom_audit/scope.rs. Each
-# README states its own crate's split.
+# Nothing runs these AND nothing depends on them (census: issue #1716). Each MUST
+# carry a README.md containing LABEL_MARKER.
 UNWIRED_TOOLS="cqlite-validator
-format-validator
 memory-safety-runner"
 
-# The marker every unwired tool's README must contain, so the label states the
-# actual fact rather than merely existing as a file.
+# Some targets live, some orphaned. Each MUST carry a README.md containing BOTH
+# LABEL_MARKER (for the orphaned targets) and MIXED_WIRED_MARKER (naming the live
+# ones), so the label cannot describe the crate as wholly unwired.
+#   format-validator: 4 binaries orphaned; LIBRARY wired into
+#   tests/format-compatibility (gate component `format-compat`), and also used as
+#   a fixture by scripts/tests/test_agent_gate_summary.sh (owners resolution) and
+#   asserted on by xtask/src/oom_audit/scope.rs. NEVER workspace-`exclude` it.
+MIXED_TOOLS="format-validator"
+
+# The marker every README with orphaned targets must contain, so the label states
+# the actual fact rather than merely existing as a file.
 LABEL_MARKER="NOT CI-wired"
+# Additionally required of a MIXED crate's README: it must name the LIVE half, so
+# a partly-live crate can never be labeled as though it were wholly dead.
+MIXED_WIRED_MARKER="WIRED"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "ok: $*"; }
@@ -71,26 +84,38 @@ ok()   { echo "ok: $*"; }
 
 wired_sorted=$(printf '%s\n' "$WIRED_TOOLS" | grep . | sort -u)
 unwired_sorted=$(printf '%s\n' "$UNWIRED_TOOLS" | grep . | sort -u)
+mixed_sorted=$(printf '%s\n' "$MIXED_TOOLS" | grep . | sort -u)
 n_wired=$(printf '%s\n' "$wired_sorted" | grep -c .)
 n_unwired=$(printf '%s\n' "$unwired_sorted" | grep -c .)
+n_mixed=$(printf '%s\n' "$mixed_sorted" | grep -c .)
+# Crates that carry orphaned targets: UNWIRED (wholly) + MIXED (partly). Both owe
+# a label; only MIXED additionally owes a statement of its live half.
+labelled_sorted=$(printf '%s\n%s\n' "$unwired_sorted" "$mixed_sorted" | grep . | sort -u)
+n_labelled=$(printf '%s\n' "$labelled_sorted" | grep -c .)
 
-# --- affirmative-measurement floor: both recorded lists must be non-empty, or a
-# --- later "every crate is accounted for" loop could be satisfied by an empty
-# --- subject set.
-[ "$n_unwired" -gt 0 ] || fail "the recorded UNWIRED_TOOLS list is empty — this guard would then enforce no label at all; refusing to pass vacuously"
-[ "$n_wired" -gt 0 ]   || fail "the recorded WIRED_TOOLS list is empty — refusing to pass vacuously"
+# --- affirmative-measurement floor: the label-bearing set must be non-empty, or
+# --- the label loop below would enforce nothing while still reporting PASS.
+[ "$n_labelled" -gt 0 ] || fail "UNWIRED_TOOLS and MIXED_TOOLS are both empty — this guard would then enforce no label at all; refusing to pass vacuously"
+[ "$n_wired" -gt 0 ]    || fail "the recorded WIRED_TOOLS list is empty — refusing to pass vacuously"
 
-# --- 1. the two lists must be disjoint. A crate in both would satisfy the
-# ---    accounted-for loop below while making its label requirement ambiguous.
-both=$(comm -12 <(printf '%s\n' "$wired_sorted") <(printf '%s\n' "$unwired_sorted"))
-[ -z "$both" ] || fail "crate(s) recorded as BOTH wired and unwired: $(printf '%s ' $both)- a crate has exactly one disposition"
-ok "recorded disposition is self-consistent ($n_wired wired, $n_unwired unwired, disjoint)"
+# --- 1. the three lists must be pairwise DISJOINT. A crate in two of them would
+# ---    satisfy the accounted-for loop below while making its label requirement
+# ---    ambiguous — which is the exact defect the third category exists to fix
+# ---    (roborev job 75), so it is asserted rather than assumed.
+check_disjoint() {
+  local a="$1" b="$2" name_a="$3" name_b="$4" both
+  both=$(comm -12 <(printf '%s\n' "$a") <(printf '%s\n' "$b"))
+  [ -z "$both" ] || fail "crate(s) recorded in BOTH $name_a and $name_b: $(printf '%s ' $both)- a crate has exactly ONE disposition"
+}
+check_disjoint "$wired_sorted"   "$unwired_sorted" WIRED_TOOLS   UNWIRED_TOOLS
+check_disjoint "$wired_sorted"   "$mixed_sorted"   WIRED_TOOLS   MIXED_TOOLS
+check_disjoint "$unwired_sorted" "$mixed_sorted"   UNWIRED_TOOLS MIXED_TOOLS
+ok "recorded disposition is self-consistent ($n_wired wired, $n_unwired unwired, $n_mixed mixed; pairwise disjoint)"
 
-# --- 2. every crate ON DISK under tools/ must appear in exactly one list. This
-# ---    is the half that catches a NEW crate arriving via the `tools/*` members
-# ---    glob with no statement of whether anything runs it. It reads the
-# ---    FILESYSTEM, so a manifest glob that silently failed to match cannot hide
-# ---    one.
+# --- 2. every crate ON DISK under tools/ must appear in exactly one list. This is
+# ---    the half that catches a NEW crate arriving via the `tools/*` members glob
+# ---    with no statement of whether anything runs it. It reads the FILESYSTEM, so
+# ---    a manifest glob that silently failed to match cannot hide one.
 n_disk=0
 for manifest in "$ROOT"/tools/*/Cargo.toml; do
   [ -f "$manifest" ] || continue
@@ -98,10 +123,11 @@ for manifest in "$ROOT"/tools/*/Cargo.toml; do
   crate=$(basename "$(dirname "$manifest")")
   if printf '%s\n' "$wired_sorted"   | grep -qxF "$crate"; then continue; fi
   if printf '%s\n' "$unwired_sorted" | grep -qxF "$crate"; then continue; fi
-  fail "tools/$crate exists on disk but is in NEITHER recorded list (issue #1716). Classify it in $SCRIPT_DIR/$(basename "$0"): add it to WIRED_TOOLS if a CI workflow or script invokes it, or to UNWIRED_TOOLS plus a README.md labeling it '$LABEL_MARKER' if it is a manual dev tool."
+  if printf '%s\n' "$mixed_sorted"   | grep -qxF "$crate"; then continue; fi
+  fail "tools/$crate exists on disk but is in NONE of the three recorded lists (issue #1716). Classify it in $SCRIPT_DIR/$(basename "$0"): WIRED_TOOLS if a CI workflow or script runs it, UNWIRED_TOOLS if nothing runs it and nothing depends on it, or MIXED_TOOLS if only SOME of its targets are live. The latter two also need a README.md labeling it '$LABEL_MARKER'."
 done
 [ "$n_disk" -gt 0 ] || fail "found no tools/*/Cargo.toml on disk — the filesystem half of this guard measured nothing; refusing to pass vacuously"
-[ "$n_disk" -eq $((n_wired + n_unwired)) ] || fail "the recorded lists name $((n_wired + n_unwired)) crate(s) but $n_disk exist on disk — a recorded crate was renamed or removed without updating $(basename "$0") (issue #1716)"
+[ "$n_disk" -eq $((n_wired + n_unwired + n_mixed)) ] || fail "the recorded lists name $((n_wired + n_unwired + n_mixed)) crate(s) but $n_disk exist on disk — a recorded crate was renamed or removed without updating $(basename "$0") (issue #1716)"
 ok "all $n_disk tools/ crate(s) on disk are classified by the recorded disposition"
 
 # --- 3. every recorded crate must actually EXIST. Without this, deleting a crate
@@ -112,22 +138,37 @@ while IFS= read -r crate; do
   [ -f "$ROOT/tools/$crate/Cargo.toml" ] \
     || fail "tools/$crate is recorded in $(basename "$0") but has no Cargo.toml on disk — remove it from the list if the crate is gone (issue #1716)"
 done <<< "$wired_sorted
-$unwired_sorted"
+$unwired_sorted
+$mixed_sorted"
 ok "every recorded crate exists on disk"
 
-# --- 4. the actual acceptance criterion of #1716: each unwired crate carries a
-# ---    README that SAYS it is not CI-wired. A present-but-silent README does
+# --- 4. the actual acceptance criterion of #1716: every crate carrying orphaned
+# ---    targets carries a README that SAYS so. A present-but-silent README does
 # ---    not label anything, so the marker is required, not just the file.
 while IFS= read -r crate; do
   [ -n "$crate" ] || continue
   readme="$ROOT/tools/$crate/README.md"
   [ -f "$readme" ] \
-    || fail "tools/$crate is recorded as unwired but has no README.md — issue #1716 requires each unwired tool be LABELED (what it is, that it is not CI-wired, how to build/run it)"
+    || fail "tools/$crate carries orphaned targets but has no README.md — issue #1716 requires it be LABELED (what it is, that its unwired parts are not CI-wired, how to build/run it)"
   [ -r "$readme" ] \
     || fail "tools/$crate/README.md is not readable — cannot verify its label; unmeasurable is not a pass"
   grep -qF "$LABEL_MARKER" "$readme" \
-    || fail "tools/$crate/README.md exists but does not contain the label '$LABEL_MARKER' — the README must STATE that no CI workflow or script invokes this crate, not merely exist (issue #1716)"
-done <<< "$unwired_sorted"
-ok "all $n_unwired unwired crate(s) carry a README.md stating '$LABEL_MARKER'"
+    || fail "tools/$crate/README.md exists but does not contain '$LABEL_MARKER' — the README must STATE that no CI workflow or script invokes it (or its orphaned targets), not merely exist (issue #1716)"
+done <<< "$labelled_sorted"
+ok "all $n_labelled crate(s) with orphaned targets carry a README.md stating '$LABEL_MARKER'"
+
+# --- 5. a MIXED crate's README must ALSO name its LIVE half. Without this, a
+# ---    mixed crate's label is indistinguishable from a wholly-unwired one — the
+# ---    false census roborev job 75 caught — and a future reader could delete or
+# ---    workspace-`exclude` a dependency the gate needs.
+if [ "$n_mixed" -gt 0 ]; then
+  while IFS= read -r crate; do
+    [ -n "$crate" ] || continue
+    readme="$ROOT/tools/$crate/README.md"
+    grep -qF "$MIXED_WIRED_MARKER" "$readme" \
+      || fail "tools/$crate is recorded MIXED (some targets live, some orphaned) but its README.md never says '$MIXED_WIRED_MARKER' — a mixed crate labeled only '$LABEL_MARKER' reads as wholly dead, which invites deleting or workspace-excluding the half the gate depends on (issue #1716)"
+  done <<< "$mixed_sorted"
+  ok "all $n_mixed mixed crate(s) name their live half ('$MIXED_WIRED_MARKER') in the README"
+fi
 
 echo "PASS: tools/ crate disposition census (#1716)"

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -192,13 +192,32 @@ workspace_dependents() {
 wired_sorted=$(printf '%s\n' "$WIRED_TOOLS" | grep . | sort -u)
 unwired_sorted=$(printf '%s\n' "$UNWIRED_TOOLS" | grep . | sort -u)
 mixed_sorted=$(printf '%s\n' "$MIXED_TOOLS" | grep . | sort -u)
-n_wired=$(printf '%s\n' "$wired_sorted" | grep -c .)
-n_unwired=$(printf '%s\n' "$unwired_sorted" | grep -c .)
-n_mixed=$(printf '%s\n' "$mixed_sorted" | grep -c .)
+# `grep -c` exits 1 for a count of ZERO while still PRINTING "0", so its status is
+# deliberately not used as a signal here — the printed count is the datum, and the
+# floors below are what reject zero. count_lines guards the one thing that would
+# otherwise slip through: a value that is not a number at all (a grep that died
+# printing nothing), which would reach `[ "$n" -gt 0 ]` as a bash syntax error
+# rather than as a named cause.
+# RETURNS non-zero rather than calling fail(): fail() ends with `exit`, and an
+# `exit` inside a command substitution leaves only the SUBSHELL — the parent would
+# carry on with an empty value and hit `[ "" -gt 0 ]` as a bash syntax error
+# instead of a named cause. So the status is propagated and checked at each call
+# site with `|| fail`.
+count_lines() {
+  local n
+  n=$(printf '%s\n' "$1" | grep -c .)
+  case "$n" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s\n' "$n"
+}
+n_wired=$(count_lines "$wired_sorted")     || fail "cannot count WIRED_TOOLS (grep -c returned no usable number) — unmeasurable is not a pass"
+n_unwired=$(count_lines "$unwired_sorted") || fail "cannot count UNWIRED_TOOLS (grep -c returned no usable number) — unmeasurable is not a pass"
+n_mixed=$(count_lines "$mixed_sorted")     || fail "cannot count MIXED_TOOLS (grep -c returned no usable number) — unmeasurable is not a pass"
 # Crates that carry orphaned targets: UNWIRED (wholly) + MIXED (partly). Both owe
 # a label; only MIXED additionally owes a statement of its live half.
 labelled_sorted=$(printf '%s\n%s\n' "$unwired_sorted" "$mixed_sorted" | grep . | sort -u)
-n_labelled=$(printf '%s\n' "$labelled_sorted" | grep -c .)
+n_labelled=$(count_lines "$labelled_sorted") || fail "cannot count the label-bearing crate set (grep -c returned no usable number) — unmeasurable is not a pass"
 
 # --- affirmative-measurement floor: the label-bearing set must be non-empty, or
 # --- the label loop below would enforce nothing while still reporting PASS.
@@ -209,9 +228,17 @@ n_labelled=$(printf '%s\n' "$labelled_sorted" | grep -c .)
 # ---    satisfy the accounted-for loop below while making its label requirement
 # ---    ambiguous — which is the exact defect the third category exists to fix
 # ---    (roborev job 75), so it is asserted rather than assumed.
+#
+# `comm`'s exit status is CHECKED, not discarded. An unchecked `both=$(comm ...)`
+# yields an empty string when comm FAILS, and "empty intersection" is precisely
+# this check's PASS condition — so a comm failure would silently certify the lists
+# as disjoint. Same shape as roborev jobs 78/80: never let a permissive verdict
+# rest on the absence of output that a failure also produces.
 check_disjoint() {
-  local a="$1" b="$2" name_a="$3" name_b="$4" both
+  local a="$1" b="$2" name_a="$3" name_b="$4" both rc
   both=$(comm -12 <(printf '%s\n' "$a") <(printf '%s\n' "$b"))
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "cannot compare $name_a against $name_b (comm exited $rc) — an unmeasurable comparison is not a pass; a comm failure and an EMPTY intersection both produce no output, so this status must be checked"
   [ -z "$both" ] || fail "crate(s) recorded in BOTH $name_a and $name_b: $(printf '%s ' $both)- a crate has exactly ONE disposition"
 }
 check_disjoint "$wired_sorted"   "$unwired_sorted" WIRED_TOOLS   UNWIRED_TOOLS

--- a/scripts/tests/test_tools_crate_disposition.sh
+++ b/scripts/tests/test_tools_crate_disposition.sh
@@ -45,6 +45,17 @@ ws0-corpus-gen"
 
 # Invoked by NO workflow, NO script and NO live doc (census: issue #1716).
 # Each MUST carry a README.md carrying the label marker below.
+#
+# "Unwired" here is a statement about what anything RUNS, which is not the same as
+# what anything DEPENDS ON, and tools/format-validator is the case that separates
+# them: nothing invokes any of its four binaries, so it belongs on this list — yet
+# its LIBRARY is a path dependency of tests/format-compatibility (the gate's
+# `format-compat` component). So membership here means "no CI workflow or script
+# runs this crate", never "this crate is unused", and it is emphatically NOT a
+# licence to delete or to workspace-`exclude`: excluding format-validator breaks
+# that gate component, scripts/tests/test_agent_gate_summary.sh (which uses its
+# lib.rs as the owners-resolution fixture) and xtask/src/oom_audit/scope.rs. Each
+# README states its own crate's split.
 UNWIRED_TOOLS="cqlite-validator
 format-validator
 memory-safety-runner"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -246,6 +246,64 @@ expect_green "GREEN 4 (MIXED via an OPTIONAL-FEATURE dependent) PASSes" \
 expect_green "GREEN 5 (MIXED via a NON-HOST TARGET dependent) PASSes" \
   targetmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone:target'
 
+# --- roborev job 80: an UNMEASURABLE dependency graph must FAIL, never be read as
+# --- "zero dependents". Forced by substituting a `cargo` ARTIFACT in the scratch
+# --- tree's PATH that fails — not by any env seam in the guard, which has none.
+ws=$(make_ws unmeasurable 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
+mkdir -p "$ws/stubbin"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$ws/stubbin/cargo"
+chmod +x "$ws/stubbin/cargo"
+out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
+if [ $rc -eq 0 ]; then
+  fail_case "unmeasurable dependency graph: guard PASSED when cargo could not answer — an unmeasurable graph was read as 'zero dependents' (the fail-closed contract inverted)"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
+  fail_case "unmeasurable dependency graph: guard failed but not via the fail-closed measurement path:"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+else
+  pass_case "unmeasurable dependency graph: guard FAILs closed rather than inferring zero dependents"
+fi
+
+# ...and the SAME stub must not be able to fake a PASS the other way: a cargo that
+# prints nothing is equally unmeasurable (cargo always echoes the subject as the
+# tree root, so empty output means it answered nothing).
+ws=$(make_ws emptycargo 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
+mkdir -p "$ws/stubbin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$ws/stubbin/cargo"
+chmod +x "$ws/stubbin/cargo"
+out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
+if [ $rc -eq 0 ]; then
+  fail_case "silent cargo: guard PASSED on empty cargo output (measured nothing, reported no dependents)"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
+  fail_case "silent cargo: guard failed but not via the fail-closed measurement path:"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+else
+  pass_case "silent cargo (exit 0, no output): guard FAILs closed rather than reporting zero dependents"
+fi
+
+# --- and the FILTERING stage itself must fail closed (the specific ask of roborev
+# --- job 80). `awk` is used ONLY inside workspace_dependents, so substituting a
+# --- failing `awk` artifact isolates the parse stage exactly: cargo still answers
+# --- correctly, and only the filtering breaks. The construct this replaces —
+# --- `sed | grep -v || true | sort` followed by an unconditional `return 0` —
+# --- discarded the pipeline status entirely, so a broken filter yielded EMPTY
+# --- output that read as "zero dependents": a false PASS for an UNWIRED record.
+ws=$(make_ws filterfail 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
+mkdir -p "$ws/stubbin"
+printf '#!/usr/bin/env bash\nexit 2\n' > "$ws/stubbin/awk"
+chmod +x "$ws/stubbin/awk"
+out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
+if [ $rc -eq 0 ]; then
+  fail_case "filtering-stage failure: guard PASSED though the parse stage failed — a broken filter was read as 'zero dependents'"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
+  fail_case "filtering-stage failure: guard failed but not via the fail-closed measurement path:"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+else
+  pass_case "filtering-stage failure: guard FAILs closed rather than reading a broken filter as zero dependents"
+fi
+
 # --- fail-closed on an absent subject
 ws=$(make_ws notools 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
 rm -rf "$ws/tools"
@@ -264,4 +322,4 @@ if [ "$fails" -ne 0 ]; then
   echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
   exit 1
 fi
-echo "PASS: tools/ crate disposition self-test (#1716) — 5 green controls + 15 negative controls"
+echo "PASS: tools/ crate disposition self-test (#1716) — 5 green controls + 18 negative controls"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -9,7 +9,7 @@
 # copy of the tree), rewrites the three recorded lists for that tree, and asserts
 # the verdict.
 #
-# THREE GREEN CONTROLS, not one. Without a green control per shape, a guard
+# FIVE GREEN CONTROLS, not one. Without a green control per shape, a guard
 # hardwired to refuse everything — or one that rejects every MIXED crate, or every
 # crate with a real dependent — would satisfy all the red cases and look tested.
 set -uo pipefail
@@ -38,7 +38,12 @@ fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
 #                 (crates not named get no README at all)
 #   consumer-of : if non-empty, create a `consumer` workspace member (package
 #                 `scratch-consumer`) that path-depends on tools/<that crate>, so
-#                 `cargo tree --workspace --invert` reports a REAL dependent
+#                 `cargo tree --workspace --invert` reports a REAL dependent.
+#                 Accepts `<crate>` , `<crate>:optional` (dependency behind a
+#                 non-default feature) or `<crate>:target` (dependency inside a
+#                 `[target.'cfg(...)'.dependencies]` table). The latter two are the
+#                 shapes `cargo tree` hides unless queried with `--all-features`
+#                 and `--target all` (roborev job 79).
 #   a literal "-" for any list means "empty list"
 make_ws() {
   local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}" consumer_of="${7:-}"
@@ -67,10 +72,26 @@ make_ws() {
   } > "$ws/Cargo.toml"
   : > "$ws/src/lib.rs"
   if [ -n "$consumer_of" ]; then
+    local dep_crate="${consumer_of%%:*}" dep_kind="plain"
+    case "$consumer_of" in *:*) dep_kind="${consumer_of##*:}" ;; esac
     mkdir -p "$ws/consumer/src"
     {
       printf '[package]\nname = "scratch-consumer"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n\n'
-      printf '[dependencies.scratch-%s]\npath = "../tools/%s"\n' "$consumer_of" "$consumer_of"
+      case "$dep_kind" in
+        optional)
+          # Behind a NON-DEFAULT feature: invisible to a default-feature resolve.
+          printf '[features]\ndefault = []\nextra = ["scratch-%s"]\n\n' "$dep_crate"
+          printf '[dependencies.scratch-%s]\npath = "../tools/%s"\noptional = true\n' "$dep_crate" "$dep_crate"
+          ;;
+        target)
+          # Target-gated on a cfg that is NOT this host: invisible to a host-only
+          # resolve. windows is chosen because the fleet is linux.
+          printf '[target."cfg(windows)".dependencies.scratch-%s]\npath = "../tools/%s"\n' "$dep_crate" "$dep_crate"
+          ;;
+        *)
+          printf '[dependencies.scratch-%s]\npath = "../tools/%s"\n' "$dep_crate" "$dep_crate"
+          ;;
+      esac
     } > "$ws/consumer/Cargo.toml"
     : > "$ws/consumer/src/lib.rs"
   fi
@@ -205,6 +226,26 @@ expect_red "UNWIRED recorded but a workspace package DOES depend on it" \
   "that is a FALSE census" \
   unwireddep 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'orphanone'
 
+# --- roborev job 79: a dependency behind an OPTIONAL FEATURE or a NON-HOST TARGET
+# --- is invisible to a default `cargo tree` resolve, so an UNWIRED record would
+# --- look correct while something really depends on the crate. These two cases
+# --- fail unless the query carries BOTH --all-features and --target all.
+expect_red "UNWIRED but an OPTIONAL-FEATURE dependency exists (roborev job 79)" \
+  "that is a FALSE census" \
+  optdep 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'orphanone:optional'
+
+expect_red "UNWIRED but a NON-HOST TARGET dependency exists (roborev job 79)" \
+  "that is a FALSE census" \
+  targetdep 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'orphanone:target'
+
+# ...and the same two shapes must SATISFY a MIXED record, so the widened query is
+# shown to find real dependents rather than merely to reject more.
+expect_green "GREEN 4 (MIXED via an OPTIONAL-FEATURE dependent) PASSes" \
+  optmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone:optional'
+
+expect_green "GREEN 5 (MIXED via a NON-HOST TARGET dependent) PASSes" \
+  targetmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone:target'
+
 # --- fail-closed on an absent subject
 ws=$(make_ws notools 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
 rm -rf "$ws/tools"
@@ -223,4 +264,4 @@ if [ "$fails" -ne 0 ]; then
   echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
   exit 1
 fi
-echo "PASS: tools/ crate disposition self-test (#1716) — 3 green controls + 13 negative controls"
+echo "PASS: tools/ crate disposition self-test (#1716) — 5 green controls + 15 negative controls"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -2,14 +2,16 @@
 # Self-test for scripts/tests/test_tools_crate_disposition.sh (issue #1716).
 #
 # A guard is only worth its green if it is capable of red. Every case builds a
-# scratch tools/ tree, copies the guard into it at the same relative path (the
-# guard resolves its root from its OWN location, so there is deliberately no
-# path/env seam to point at a fixture — CLAUDE.md #3312: a case needing a
-# different subject SUBSTITUTES THE ARTIFACT in its own scratch copy of the
-# tree), rewrites the two recorded lists for that tree, and asserts the verdict.
+# minimal, dependency-free scratch cargo workspace, copies the guard into it at
+# the same relative path (the guard resolves its root from its OWN location, so
+# there is deliberately NO path/env seam to point at a fixture — CLAUDE.md #3312:
+# a case needing a different subject SUBSTITUTES THE ARTIFACT in its own scratch
+# copy of the tree), rewrites the three recorded lists for that tree, and asserts
+# the verdict.
 #
-# Includes a GREEN control: without it, a guard hardwired to refuse everything
-# would satisfy every red case below and look fully tested.
+# THREE GREEN CONTROLS, not one. Without a green control per shape, a guard
+# hardwired to refuse everything — or one that rejects every MIXED crate, or every
+# crate with a real dependent — would satisfy all the red cases and look tested.
 set -uo pipefail
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
@@ -17,6 +19,7 @@ GUARD="$SCRIPT_DIR/test_tools_crate_disposition.sh"
 GUARD_BASE=$(basename "$GUARD")
 [ -f "$GUARD" ] || { echo "FAIL: guard under test not found at $GUARD" >&2; exit 1; }
 
+export CARGO_NET_OFFLINE=1
 TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/toolsdisp.XXXXXX") || exit 1
 trap 'rm -rf "$TMPROOT"' EXIT
 
@@ -24,29 +27,61 @@ fails=0
 pass_case() { echo "ok: $*"; }
 fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
 
-# make_ws <case> <wired-list> <unwired-list> <mixed-list> <on-disk crates> <readme spec>
-#   on-disk crates: space-separated dir names to create under tools/
-#   readme spec   : space-separated `crate:kind`, kind =
-#                     labeled   -> says "NOT CI-wired" only (correct for UNWIRED)
-#                     mixed     -> says "NOT CI-wired" AND "WIRED" (correct for MIXED)
-#                     unlabeled -> says neither
-#                   (crates not named get no README at all)
+# make_ws <case> <wired> <unwired> <mixed> <disk crates> <readme spec> [consumer-of]
+#   disk crates : space-separated dir names to create under tools/
+#   readme spec : space-separated `crate:kind`, kind =
+#                   labeled      -> says "NOT CI-wired" only
+#                   namesdep     -> says "NOT CI-wired" AND names scratch-consumer
+#                   genericwired -> says "NOT CI-wired" AND the bare word WIRED,
+#                                   but NEVER names the dependent (roborev job 78)
+#                   unlabeled    -> says neither
+#                 (crates not named get no README at all)
+#   consumer-of : if non-empty, create a `consumer` workspace member (package
+#                 `scratch-consumer`) that path-depends on tools/<that crate>, so
+#                 `cargo tree --workspace --invert` reports a REAL dependent
 #   a literal "-" for any list means "empty list"
 make_ws() {
-  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}"
+  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}" consumer_of="${7:-}"
   local ws="$TMPROOT/$case_name" c spec crate kind
-  mkdir -p "$ws/scripts/tests"
+  mkdir -p "$ws/src" "$ws/scripts/tests"
   for c in $disk; do
     mkdir -p "$ws/tools/$c/src"
-    printf '[package]\nname = "scratch-%s"\nversion = "0.1.0"\nedition = "2021"\n' "$c" > "$ws/tools/$c/Cargo.toml"
+    printf '[package]\nname = "scratch-%s"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n' "$c" \
+      > "$ws/tools/$c/Cargo.toml"
+    : > "$ws/tools/$c/src/lib.rs"
   done
+  {
+    echo '[workspace]'
+    if [ -n "$consumer_of" ]; then
+      echo 'members = ["tools/*", "consumer"]'
+    else
+      echo 'members = ["tools/*"]'
+    fi
+    echo 'resolver = "2"'
+    echo
+    echo '[package]'
+    echo 'name = "scratch-root"'
+    echo 'version = "0.1.0"'
+    echo 'edition = "2021"'
+    echo 'publish = false'
+  } > "$ws/Cargo.toml"
+  : > "$ws/src/lib.rs"
+  if [ -n "$consumer_of" ]; then
+    mkdir -p "$ws/consumer/src"
+    {
+      printf '[package]\nname = "scratch-consumer"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n\n'
+      printf '[dependencies.scratch-%s]\npath = "../tools/%s"\n' "$consumer_of" "$consumer_of"
+    } > "$ws/consumer/Cargo.toml"
+    : > "$ws/consumer/src/lib.rs"
+  fi
   for spec in $readmes; do
     crate="${spec%%:*}"; kind="${spec##*:}"
     case "$kind" in
-      labeled) printf '# scratch %s\n\nThis crate is NOT CI-wired.\n' "$crate" > "$ws/tools/$crate/README.md" ;;
-      mixed)   printf '# scratch %s\n\nIts lib is WIRED; its binaries are NOT CI-wired.\n' "$crate" > "$ws/tools/$crate/README.md" ;;
-      *)       printf '# scratch %s\n\nSome prose that never says whether anything runs it.\n' "$crate" > "$ws/tools/$crate/README.md" ;;
-    esac
+      labeled)      printf '# scratch %s\n\nThis crate is NOT CI-wired.\n' "$crate" ;;
+      namesdep)     printf '# scratch %s\n\nIts binaries are NOT CI-wired; its library is used by scratch-consumer.\n' "$crate" ;;
+      genericwired) printf '# scratch %s\n\nPreviously WIRED, now entirely NOT CI-wired.\n' "$crate" ;;
+      *)            printf '# scratch %s\n\nProse that never says whether anything runs it.\n' "$crate" ;;
+    esac > "$ws/tools/$crate/README.md"
   done
   [ "$wired" = "-" ] && wired=""
   [ "$unwired" = "-" ] && unwired=""
@@ -55,10 +90,10 @@ make_ws() {
   #
   # `skip` must NOT be armed for a SELF-CONTAINED assignment. A single-line list
   # such as `MIXED_TOOLS="format-validator"` both opens and closes its string on
-  # one line, so arming skip made the rewriter swallow the NEXT `"`-terminated
-  # line — which is `LABEL_MARKER=...`, leaving every scratch guard with an unbound
-  # variable. That produced a green-control failure rather than a wrong verdict, so
-  # it surfaced immediately; the two-quote test below is what makes it correct.
+  # one line, so arming skip-until-quote made the rewriter swallow the NEXT
+  # `"`-terminated line — `LABEL_MARKER=` — leaving every scratch guard with an
+  # unbound variable. It broke the GREEN control rather than producing a wrong
+  # verdict, which is why the green controls exist.
   awk -v w="$wired" -v u="$unwired" -v m="$mixed" '
     function multiline(line) { return gsub(/"/, "\"", line) < 2 }
     /^WIRED_TOOLS="/   { print "WIRED_TOOLS=\"" w "\"";   skip=multiline($0); next }
@@ -74,16 +109,18 @@ make_ws() {
 
 run_guard() { bash "$1/scripts/tests/$GUARD_BASE" 2>&1; }
 
-# --- CASE 1 (GREEN CONTROL) ---------------------------------------------------
-ws=$(make_ws green 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
-out=$(run_guard "$ws"); rc=$?
-if [ $rc -eq 0 ] && grep -q '^PASS:' <<<"$out"; then
-  pass_case "GREEN control: a correctly-classified tools/ tree PASSes (guard is not hardwired to refuse)"
-else
-  fail_case "GREEN control did NOT pass (rc=$rc):"; printf '%s\n' "$out" | sed 's/^/    /' >&2
-fi
+expect_green() {
+  local label="$1"; shift
+  local w o r
+  w=$(make_ws "$@")
+  o=$(run_guard "$w"); r=$?
+  if [ $r -eq 0 ] && grep -q '^PASS:' <<<"$o"; then
+    pass_case "$label"
+  else
+    fail_case "$label — did NOT pass (rc=$r):"; printf '%s\n' "$o" | sed 's/^/    /' >&2
+  fi
+}
 
-# --- red cases ---------------------------------------------------------------
 expect_red() {
   local label="$1" needle="$2"; shift 2
   local w o r
@@ -100,77 +137,75 @@ expect_red() {
   fi
 }
 
-# 2. a NEW crate arrives via the tools/* glob with no recorded disposition.
+# ============================ GREEN CONTROLS ================================
+expect_green "GREEN 1: a correctly-classified WIRED+UNWIRED tree PASSes" \
+  green 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled'
+
+expect_green "GREEN 2 (MIXED): a real dependent + a README naming it PASSes" \
+  mixedgreen 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone'
+
+expect_green "GREEN 3: UNWIRED alongside a consumer of a DIFFERENT crate PASSes" \
+  unwiredgreen 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'wiredone'
+
+# ============================== RED CASES ===================================
+# --- classification completeness / consistency
 expect_red "new unclassified tools/ crate" \
   "is in NONE of the three recorded lists" \
   newcomer 'wiredone' 'orphanone' '-' 'wiredone orphanone newcomer' 'orphanone:labeled'
 
-# 3. an unwired crate with no README at all => not labeled.
-expect_red "unwired crate with no README" \
-  "has no README.md" \
-  noreadme 'wiredone' 'orphanone' '-' 'wiredone orphanone' ''
-
-# 4. an unwired crate whose README exists but never states the fact.
-expect_red "unwired crate README missing the label marker" \
-  "does not contain 'NOT CI-wired'" \
-  unlabeled 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:unlabeled'
-
-# 5. a recorded crate deleted from disk without updating the list.
 expect_red "recorded crate removed from disk" \
   "was renamed or removed without updating" \
   ghost 'wiredone
 ghostcrate' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled'
 
-# 6. a crate recorded as both wired and unwired.
 expect_red "crate recorded in BOTH WIRED and UNWIRED" \
   "recorded in BOTH WIRED_TOOLS and UNWIRED_TOOLS" \
-  both 'wiredone
+  bothwu 'wiredone
 orphanone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled'
 
-# 7. an EMPTY unwired list would make the label requirement enforce nothing.
-expect_red "empty UNWIRED_TOOLS and MIXED_TOOLS lists" \
-  "refusing to pass vacuously" \
-  emptyunwired 'wiredone' '-' '-' 'wiredone' ''
-
-# --- MIXED-category cases (roborev job 75: a two-way split let a partly-live
-# --- crate be recorded as wholly unwired, asserting something untrue about it).
-
-# 7b. GREEN control for MIXED: a correctly-labeled mixed crate must PASS. Without
-#     this, cases 7c-7e below could all be satisfied by a guard that simply
-#     rejects every MIXED crate.
-ws=$(make_ws mixedgreen 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:mixed')
-out=$(run_guard "$ws"); rc=$?
-if [ $rc -eq 0 ] && grep -q '^PASS:' <<<"$out"; then
-  pass_case "GREEN control (MIXED): a correctly-labeled mixed crate PASSes"
-else
-  fail_case "GREEN control (MIXED) did NOT pass (rc=$rc):"; printf '%s\n' "$out" | sed 's/^/    /' >&2
-fi
-
-# 7c. THE ROBOREV DEFECT ITSELF: a mixed crate whose README says only
-#     "NOT CI-wired" and never names its live half reads as wholly dead.
-expect_red "MIXED crate labeled as if wholly unwired (roborev job 75)" \
-  "reads as wholly dead" \
-  mixedhalf 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:labeled'
-
-# 7d. a mixed crate with no README at all still owes a label.
-expect_red "MIXED crate with no README" \
-  "has no README.md" \
-  mixednoreadme 'wiredone' '-' 'mixedone' 'wiredone mixedone' ''
-
-# 7e. disjointness must hold for the NEW pairs too, not just wired-vs-unwired.
-expect_red "crate recorded in BOTH UNWIRED and MIXED" \
-  "recorded in BOTH UNWIRED_TOOLS and MIXED_TOOLS" \
-  bothum 'wiredone' 'mixedone' 'mixedone' 'wiredone mixedone' 'mixedone:mixed'
 expect_red "crate recorded in BOTH WIRED and MIXED" \
   "recorded in BOTH WIRED_TOOLS and MIXED_TOOLS" \
   bothwm 'wiredone
-mixedone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:mixed'
+mixedone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone'
 
-# 7f. MIXED alone must satisfy the label-bearing floor (an empty UNWIRED is fine
-#     when MIXED is populated) — asserted via the GREEN case 7b above, and here
-#     that the floor is keyed on the UNION, not on UNWIRED alone.
+expect_red "crate recorded in BOTH UNWIRED and MIXED" \
+  "recorded in BOTH UNWIRED_TOOLS and MIXED_TOOLS" \
+  bothum 'wiredone' 'mixedone' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone'
 
-# 8. no tools/ directory at all => the guard's subject is absent.
+expect_red "empty UNWIRED_TOOLS and MIXED_TOOLS lists" \
+  "refusing to pass vacuously" \
+  emptyboth 'wiredone' '-' '-' 'wiredone' ''
+
+# --- the labeling half (#1716's actual acceptance criterion)
+expect_red "UNWIRED crate with no README" \
+  "has no README.md" \
+  noreadme 'wiredone' 'orphanone' '-' 'wiredone orphanone' ''
+
+expect_red "UNWIRED crate README missing the label marker" \
+  "does not contain 'NOT CI-wired'" \
+  unlabeled 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:unlabeled'
+
+expect_red "MIXED crate with no README" \
+  "has no README.md" \
+  mixednoreadme 'wiredone' '-' 'mixedone' 'wiredone mixedone' '' 'mixedone'
+
+# --- THE DERIVED CROSS-CHECK: the census must match the MANIFESTS, both ways.
+# roborev job 78: the MIXED label used to be verified by grepping for the generic
+# word "WIRED", which this README satisfies while saying the OPPOSITE. The
+# requirement is now to name the crate's ACTUAL, DERIVED dependent.
+expect_red "MIXED README carries the word WIRED but never names its dependent (roborev job 78)" \
+  "never mentions 'scratch-consumer'" \
+  job78 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:genericwired' 'mixedone'
+
+expect_red "MIXED recorded but NOTHING in the workspace depends on it" \
+  "the 'live half' claim is unsupported" \
+  mixednodep 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep'
+
+expect_red "UNWIRED recorded but a workspace package DOES depend on it" \
+  "that is a FALSE census" \
+  unwireddep 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'orphanone'
+
+# --- fail-closed on an absent subject
 ws=$(make_ws notools 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
 rm -rf "$ws/tools"
 out=$(run_guard "$ws"); rc=$?
@@ -188,4 +223,4 @@ if [ "$fails" -ne 0 ]; then
   echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
   exit 1
 fi
-echo "PASS: tools/ crate disposition self-test (#1716) — 2 green controls + 11 negative controls"
+echo "PASS: tools/ crate disposition self-test (#1716) — 3 green controls + 13 negative controls"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -24,13 +24,16 @@ fails=0
 pass_case() { echo "ok: $*"; }
 fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
 
-# make_ws <case> <wired-list> <unwired-list> <on-disk crates> <readme spec>
+# make_ws <case> <wired-list> <unwired-list> <mixed-list> <on-disk crates> <readme spec>
 #   on-disk crates: space-separated dir names to create under tools/
-#   readme spec   : space-separated `crate:kind`, kind = labeled | unlabeled
+#   readme spec   : space-separated `crate:kind`, kind =
+#                     labeled   -> says "NOT CI-wired" only (correct for UNWIRED)
+#                     mixed     -> says "NOT CI-wired" AND "WIRED" (correct for MIXED)
+#                     unlabeled -> says neither
 #                   (crates not named get no README at all)
-#   a literal "-" for the wired/unwired list means "empty list"
+#   a literal "-" for any list means "empty list"
 make_ws() {
-  local case_name="$1" wired="$2" unwired="$3" disk="$4" readmes="${5:-}"
+  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}"
   local ws="$TMPROOT/$case_name" c spec crate kind
   mkdir -p "$ws/scripts/tests"
   for c in $disk; do
@@ -39,17 +42,28 @@ make_ws() {
   done
   for spec in $readmes; do
     crate="${spec%%:*}"; kind="${spec##*:}"
-    if [ "$kind" = labeled ]; then
-      printf '# scratch %s\n\nThis crate is NOT CI-wired.\n' "$crate" > "$ws/tools/$crate/README.md"
-    else
-      printf '# scratch %s\n\nSome prose that never says whether anything runs it.\n' "$crate" > "$ws/tools/$crate/README.md"
-    fi
+    case "$kind" in
+      labeled) printf '# scratch %s\n\nThis crate is NOT CI-wired.\n' "$crate" > "$ws/tools/$crate/README.md" ;;
+      mixed)   printf '# scratch %s\n\nIts lib is WIRED; its binaries are NOT CI-wired.\n' "$crate" > "$ws/tools/$crate/README.md" ;;
+      *)       printf '# scratch %s\n\nSome prose that never says whether anything runs it.\n' "$crate" > "$ws/tools/$crate/README.md" ;;
+    esac
   done
   [ "$wired" = "-" ] && wired=""
   [ "$unwired" = "-" ] && unwired=""
-  awk -v w="$wired" -v u="$unwired" '
-    /^WIRED_TOOLS="/   { print "WIRED_TOOLS=\"" w "\"";   skip=1; next }
-    /^UNWIRED_TOOLS="/ { print "UNWIRED_TOOLS=\"" u "\""; skip=1; next }
+  [ "$mixed" = "-" ] && mixed=""
+  # Substitute the three recorded lists for this scratch tree's crates.
+  #
+  # `skip` must NOT be armed for a SELF-CONTAINED assignment. A single-line list
+  # such as `MIXED_TOOLS="format-validator"` both opens and closes its string on
+  # one line, so arming skip made the rewriter swallow the NEXT `"`-terminated
+  # line — which is `LABEL_MARKER=...`, leaving every scratch guard with an unbound
+  # variable. That produced a green-control failure rather than a wrong verdict, so
+  # it surfaced immediately; the two-quote test below is what makes it correct.
+  awk -v w="$wired" -v u="$unwired" -v m="$mixed" '
+    function multiline(line) { return gsub(/"/, "\"", line) < 2 }
+    /^WIRED_TOOLS="/   { print "WIRED_TOOLS=\"" w "\"";   skip=multiline($0); next }
+    /^UNWIRED_TOOLS="/ { print "UNWIRED_TOOLS=\"" u "\""; skip=multiline($0); next }
+    /^MIXED_TOOLS="/   { print "MIXED_TOOLS=\"" m "\"";   skip=multiline($0); next }
     skip && /"$/ { skip=0; next }
     skip { next }
     { print }
@@ -61,7 +75,7 @@ make_ws() {
 run_guard() { bash "$1/scripts/tests/$GUARD_BASE" 2>&1; }
 
 # --- CASE 1 (GREEN CONTROL) ---------------------------------------------------
-ws=$(make_ws green 'wiredone' 'orphanone' 'wiredone orphanone' 'orphanone:labeled')
+ws=$(make_ws green 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
 out=$(run_guard "$ws"); rc=$?
 if [ $rc -eq 0 ] && grep -q '^PASS:' <<<"$out"; then
   pass_case "GREEN control: a correctly-classified tools/ tree PASSes (guard is not hardwired to refuse)"
@@ -88,38 +102,76 @@ expect_red() {
 
 # 2. a NEW crate arrives via the tools/* glob with no recorded disposition.
 expect_red "new unclassified tools/ crate" \
-  "is in NEITHER recorded list" \
-  newcomer 'wiredone' 'orphanone' 'wiredone orphanone newcomer' 'orphanone:labeled'
+  "is in NONE of the three recorded lists" \
+  newcomer 'wiredone' 'orphanone' '-' 'wiredone orphanone newcomer' 'orphanone:labeled'
 
 # 3. an unwired crate with no README at all => not labeled.
 expect_red "unwired crate with no README" \
   "has no README.md" \
-  noreadme 'wiredone' 'orphanone' 'wiredone orphanone' ''
+  noreadme 'wiredone' 'orphanone' '-' 'wiredone orphanone' ''
 
 # 4. an unwired crate whose README exists but never states the fact.
 expect_red "unwired crate README missing the label marker" \
-  "does not contain the label" \
-  unlabeled 'wiredone' 'orphanone' 'wiredone orphanone' 'orphanone:unlabeled'
+  "does not contain 'NOT CI-wired'" \
+  unlabeled 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:unlabeled'
 
 # 5. a recorded crate deleted from disk without updating the list.
 expect_red "recorded crate removed from disk" \
   "was renamed or removed without updating" \
   ghost 'wiredone
-ghostcrate' 'orphanone' 'wiredone orphanone' 'orphanone:labeled'
+ghostcrate' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled'
 
 # 6. a crate recorded as both wired and unwired.
-expect_red "crate recorded in BOTH lists" \
-  "recorded as BOTH wired and unwired" \
+expect_red "crate recorded in BOTH WIRED and UNWIRED" \
+  "recorded in BOTH WIRED_TOOLS and UNWIRED_TOOLS" \
   both 'wiredone
-orphanone' 'orphanone' 'wiredone orphanone' 'orphanone:labeled'
+orphanone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled'
 
 # 7. an EMPTY unwired list would make the label requirement enforce nothing.
-expect_red "empty UNWIRED_TOOLS list" \
+expect_red "empty UNWIRED_TOOLS and MIXED_TOOLS lists" \
   "refusing to pass vacuously" \
-  emptyunwired 'wiredone' '-' 'wiredone' ''
+  emptyunwired 'wiredone' '-' '-' 'wiredone' ''
+
+# --- MIXED-category cases (roborev job 75: a two-way split let a partly-live
+# --- crate be recorded as wholly unwired, asserting something untrue about it).
+
+# 7b. GREEN control for MIXED: a correctly-labeled mixed crate must PASS. Without
+#     this, cases 7c-7e below could all be satisfied by a guard that simply
+#     rejects every MIXED crate.
+ws=$(make_ws mixedgreen 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:mixed')
+out=$(run_guard "$ws"); rc=$?
+if [ $rc -eq 0 ] && grep -q '^PASS:' <<<"$out"; then
+  pass_case "GREEN control (MIXED): a correctly-labeled mixed crate PASSes"
+else
+  fail_case "GREEN control (MIXED) did NOT pass (rc=$rc):"; printf '%s\n' "$out" | sed 's/^/    /' >&2
+fi
+
+# 7c. THE ROBOREV DEFECT ITSELF: a mixed crate whose README says only
+#     "NOT CI-wired" and never names its live half reads as wholly dead.
+expect_red "MIXED crate labeled as if wholly unwired (roborev job 75)" \
+  "reads as wholly dead" \
+  mixedhalf 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:labeled'
+
+# 7d. a mixed crate with no README at all still owes a label.
+expect_red "MIXED crate with no README" \
+  "has no README.md" \
+  mixednoreadme 'wiredone' '-' 'mixedone' 'wiredone mixedone' ''
+
+# 7e. disjointness must hold for the NEW pairs too, not just wired-vs-unwired.
+expect_red "crate recorded in BOTH UNWIRED and MIXED" \
+  "recorded in BOTH UNWIRED_TOOLS and MIXED_TOOLS" \
+  bothum 'wiredone' 'mixedone' 'mixedone' 'wiredone mixedone' 'mixedone:mixed'
+expect_red "crate recorded in BOTH WIRED and MIXED" \
+  "recorded in BOTH WIRED_TOOLS and MIXED_TOOLS" \
+  bothwm 'wiredone
+mixedone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:mixed'
+
+# 7f. MIXED alone must satisfy the label-bearing floor (an empty UNWIRED is fine
+#     when MIXED is populated) — asserted via the GREEN case 7b above, and here
+#     that the floor is keyed on the UNION, not on UNWIRED alone.
 
 # 8. no tools/ directory at all => the guard's subject is absent.
-ws=$(make_ws notools 'wiredone' 'orphanone' 'wiredone orphanone' 'orphanone:labeled')
+ws=$(make_ws notools 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
 rm -rf "$ws/tools"
 out=$(run_guard "$ws"); rc=$?
 if [ $rc -eq 0 ]; then
@@ -136,4 +188,4 @@ if [ "$fails" -ne 0 ]; then
   echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
   exit 1
 fi
-echo "PASS: tools/ crate disposition self-test (#1716) — 1 green control + 7 negative controls"
+echo "PASS: tools/ crate disposition self-test (#1716) — 2 green controls + 11 negative controls"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -9,7 +9,7 @@
 # copy of the tree), rewrites the three recorded lists for that tree, and asserts
 # the verdict.
 #
-# SEVEN GREEN CONTROLS, not one. Without a green control per shape, a guard
+# EIGHT GREEN CONTROLS, not one. Without a green control per shape, a guard
 # hardwired to refuse everything — or one that rejects every MIXED crate, or every
 # crate with a real dependent — would satisfy all the red cases and look tested.
 set -uo pipefail
@@ -44,20 +44,20 @@ fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
 #                 `[target.'cfg(...)'.dependencies]` table). The latter two are the
 #                 shapes `cargo tree` hides unless queried with `--all-features`
 #                 and `--target all` (roborev job 79).
-#   mixed-live  : 8th arg, the MIXED_LIVE body (`<crate>|dependency` or
-#                 `<crate>|invoked:<bin>,...`). Defaults to `<mixed>|dependency`.
+#   mixed-inv   : 8th arg, the MIXED_INVOKED body (`<crate>|none` or
+#                 `<crate>|<bin>[,<bin>...]`). Defaults to `<mixed>|none`.
 #   a literal "-" for any list means "empty list"
 make_ws() {
-  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}" consumer_of="${7:-}" mixed_live="${8:-}"
-  # "-" means "use the default"; "NONE" means a genuinely EMPTY MIXED_LIVE, which
+  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}" consumer_of="${7:-}" mixed_invoked="${8:-}"
+  # "-" means "use the default"; "NONE" means a genuinely EMPTY MIXED_INVOKED, which
   # is what an UNRECORDED MIXED crate looks like and cannot be expressed by "-"
   # (the default would fill it back in).
-  [ "$mixed_live" = "-" ] && mixed_live=""
+  [ "$mixed_invoked" = "-" ] && mixed_invoked=""
   # default: any MIXED crate is recorded as live-via-dependency
-  if [ "$mixed_live" = "NONE" ]; then
-    mixed_live=""
-  elif [ -z "$mixed_live" ] && [ -n "$mixed" ] && [ "$mixed" != "-" ]; then
-    mixed_live="$mixed|dependency"
+  if [ "$mixed_invoked" = "NONE" ]; then
+    mixed_invoked=""
+  elif [ -z "$mixed_invoked" ] && [ -n "$mixed" ] && [ "$mixed" != "-" ]; then
+    mixed_invoked="$mixed|none"
   fi
   local ws="$TMPROOT/$case_name" c spec crate kind
   mkdir -p "$ws/src" "$ws/scripts/tests"
@@ -122,6 +122,7 @@ make_ws() {
       namesdep)     printf '# scratch %s\n\nIts binaries are NOT CI-wired; its library is used by scratch-consumer.\n' "$crate" ;;
       genericwired) printf '# scratch %s\n\nPreviously WIRED, now entirely NOT CI-wired.\n' "$crate" ;;
       namesbins)    printf '# scratch %s\n\nCI runs live-bin; the other binaries are NOT CI-wired.\n' "$crate" ;;
+      namesboth)    printf '# scratch %s\n\nCI runs live-bin and scratch-consumer uses the lib; the rest is NOT CI-wired.\n' "$crate" ;;
       namesnobins)  printf '# scratch %s\n\nSome binaries are NOT CI-wired.\n' "$crate" ;;
       *)            printf '# scratch %s\n\nProse that never says whether anything runs it.\n' "$crate" ;;
     esac > "$ws/tools/$crate/README.md"
@@ -137,12 +138,12 @@ make_ws() {
   # `"`-terminated line — `LABEL_MARKER=` — leaving every scratch guard with an
   # unbound variable. It broke the GREEN control rather than producing a wrong
   # verdict, which is why the green controls exist.
-  awk -v w="$wired" -v u="$unwired" -v m="$mixed" -v ml="$mixed_live" '
+  awk -v w="$wired" -v u="$unwired" -v m="$mixed" -v ml="$mixed_invoked" '
     function multiline(line) { return gsub(/"/, "\"", line) < 2 }
     /^WIRED_TOOLS="/   { print "WIRED_TOOLS=\"" w "\"";   skip=multiline($0); next }
     /^UNWIRED_TOOLS="/ { print "UNWIRED_TOOLS=\"" u "\""; skip=multiline($0); next }
     /^MIXED_TOOLS="/   { print "MIXED_TOOLS=\"" m "\"";   skip=multiline($0); next }
-    /^MIXED_LIVE="/    { print "MIXED_LIVE=\"" ml "\"";    skip=multiline($0); next }
+    /^MIXED_INVOKED="/    { print "MIXED_INVOKED=\"" ml "\"";    skip=multiline($0); next }
     skip && /"$/ { skip=0; next }
     skip { next }
     { print }
@@ -249,8 +250,8 @@ expect_red "MIXED README carries the word WIRED but never names its dependent (r
   job78 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:genericwired' 'mixedone'
 
 expect_red "MIXED recorded but NOTHING in the workspace depends on it" \
-  "recorded MIXED via 'dependency' but NO workspace package depends on it" \
-  mixednodep 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep'
+  "has NO live half from either source" \
+  mixednodep 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' '' 'mixedone|none'
 
 expect_red "UNWIRED recorded but a workspace package DOES depend on it" \
   "that is a FALSE census" \
@@ -393,34 +394,42 @@ fi
 # --- workspace dependent for every MIXED crate REJECTED a correct classification
 # --- and told its author to record it UNWIRED — which is false.
 expect_green "GREEN 7 (MIXED via an INVOKED BINARY, no workspace dependent at all) PASSes" \
-  invokedmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|invoked:live-bin'
+  invokedmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|live-bin'
 
 # ...and the recorded form is still CROSS-CHECKED, so "invoked:" is not a way to
 # assert anything you like: the target must be a DECLARED [[bin]], and the README
 # must name it.
 expect_red "MIXED invoked target that is not a declared [[bin]]" \
   "declares no [[bin]] by that name" \
-  invokedghost 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|invoked:no-such-bin'
+  invokedghost 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|no-such-bin'
 
 expect_red "MIXED invoked target never named in the README" \
   "never mentions 'dead-bin'" \
-  invokedunnamed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesnobins' '' 'mixedone|invoked:dead-bin'
+  invokedunnamed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesnobins' '' 'mixedone|dead-bin'
 
-expect_red "MIXED crate with no MIXED_LIVE entry at all" \
-  "has no entry in MIXED_LIVE" \
+expect_red "MIXED crate with no MIXED_INVOKED entry at all" \
+  "has no entry in MIXED_INVOKED" \
   nolive 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'NONE'
 
-expect_red "MIXED_LIVE kind that is neither 'dependency' nor 'invoked:'" \
-  "unrecognised MIXED_LIVE kind" \
-  badkind 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|sortof'
+expect_red "MIXED_INVOKED with a blank target list (neither a bin nor 'none')" \
+  "write 'mixedone|none' to say so explicitly" \
+  blanklist 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|'
 
-expect_red "MIXED_LIVE with an empty invoked target list" \
-  "names no target" \
-  emptyinvoked 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|invoked:'
 
-expect_red "stale MIXED_LIVE entry for a crate that is not MIXED" \
+expect_red "stale MIXED_INVOKED entry for a crate that is not MIXED" \
   "which is not in MIXED_TOOLS" \
-  stalelive 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' '' 'ghostcrate|dependency'
+  stalelive 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' '' 'ghostcrate|none'
+
+# --- roborev job 85: the COMBINED shape. A crate can have BOTH a workspace
+# --- dependent AND a CI-invoked binary. Treating the two as mutually exclusive let
+# --- a recorded invoked list SKIP dependency discovery entirely, so the README
+# --- could omit a real dependent and still pass. Both must now be documented.
+expect_green "GREEN 8 (MIXED with BOTH a dependent and an invoked bin) PASSes when the README names both" \
+  bothsources 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesboth' 'mixedone' 'mixedone|live-bin'
+
+expect_red "MIXED with BOTH sources whose README names the invoked bin but OMITS the real dependent (roborev job 85)" \
+  "never mentions 'scratch-consumer'" \
+  bothomitdep 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' 'mixedone' 'mixedone|live-bin'
 
 # --- fail-closed on an absent subject
 ws=$(make_ws notools 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
@@ -440,4 +449,4 @@ if [ "$fails" -ne 0 ]; then
   echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
   exit 1
 fi
-echo "PASS: tools/ crate disposition self-test (#1716) — 7 green controls + 25 negative controls"
+echo "PASS: tools/ crate disposition self-test (#1716) — 8 green controls + 25 negative controls"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -9,7 +9,7 @@
 # copy of the tree), rewrites the three recorded lists for that tree, and asserts
 # the verdict.
 #
-# SIX GREEN CONTROLS, not one. Without a green control per shape, a guard
+# SEVEN GREEN CONTROLS, not one. Without a green control per shape, a guard
 # hardwired to refuse everything — or one that rejects every MIXED crate, or every
 # crate with a real dependent — would satisfy all the red cases and look tested.
 set -uo pipefail
@@ -44,16 +44,36 @@ fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
 #                 `[target.'cfg(...)'.dependencies]` table). The latter two are the
 #                 shapes `cargo tree` hides unless queried with `--all-features`
 #                 and `--target all` (roborev job 79).
+#   mixed-live  : 8th arg, the MIXED_LIVE body (`<crate>|dependency` or
+#                 `<crate>|invoked:<bin>,...`). Defaults to `<mixed>|dependency`.
 #   a literal "-" for any list means "empty list"
 make_ws() {
-  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}" consumer_of="${7:-}"
+  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}" consumer_of="${7:-}" mixed_live="${8:-}"
+  # "-" means "use the default"; "NONE" means a genuinely EMPTY MIXED_LIVE, which
+  # is what an UNRECORDED MIXED crate looks like and cannot be expressed by "-"
+  # (the default would fill it back in).
+  [ "$mixed_live" = "-" ] && mixed_live=""
+  # default: any MIXED crate is recorded as live-via-dependency
+  if [ "$mixed_live" = "NONE" ]; then
+    mixed_live=""
+  elif [ -z "$mixed_live" ] && [ -n "$mixed" ] && [ "$mixed" != "-" ]; then
+    mixed_live="$mixed|dependency"
+  fi
   local ws="$TMPROOT/$case_name" c spec crate kind
   mkdir -p "$ws/src" "$ws/scripts/tests"
   for c in $disk; do
     mkdir -p "$ws/tools/$c/src"
-    printf '[package]\nname = "scratch-%s"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n' "$c" \
-      > "$ws/tools/$c/Cargo.toml"
+    {
+      printf '[package]\nname = "scratch-%s"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n' "$c"
+      # Two [[bin]] targets, so a crate can legitimately be MIXED with one bin
+      # invoked by CI and the other orphaned — the shape that has NO reverse cargo
+      # dependency at all (roborev job 83).
+      printf '\n[[bin]]\nname = "live-bin"\npath = "src/live.rs"\n'
+      printf '\n[[bin]]\nname = "dead-bin"\npath = "src/dead.rs"\n'
+    } > "$ws/tools/$c/Cargo.toml"
     : > "$ws/tools/$c/src/lib.rs"
+    printf 'fn main() {}\n' > "$ws/tools/$c/src/live.rs"
+    printf 'fn main() {}\n' > "$ws/tools/$c/src/dead.rs"
   done
   {
     echo '[workspace]'
@@ -101,6 +121,8 @@ make_ws() {
       labeled)      printf '# scratch %s\n\nThis crate is NOT CI-wired.\n' "$crate" ;;
       namesdep)     printf '# scratch %s\n\nIts binaries are NOT CI-wired; its library is used by scratch-consumer.\n' "$crate" ;;
       genericwired) printf '# scratch %s\n\nPreviously WIRED, now entirely NOT CI-wired.\n' "$crate" ;;
+      namesbins)    printf '# scratch %s\n\nCI runs live-bin; the other binaries are NOT CI-wired.\n' "$crate" ;;
+      namesnobins)  printf '# scratch %s\n\nSome binaries are NOT CI-wired.\n' "$crate" ;;
       *)            printf '# scratch %s\n\nProse that never says whether anything runs it.\n' "$crate" ;;
     esac > "$ws/tools/$crate/README.md"
   done
@@ -115,11 +137,12 @@ make_ws() {
   # `"`-terminated line — `LABEL_MARKER=` — leaving every scratch guard with an
   # unbound variable. It broke the GREEN control rather than producing a wrong
   # verdict, which is why the green controls exist.
-  awk -v w="$wired" -v u="$unwired" -v m="$mixed" '
+  awk -v w="$wired" -v u="$unwired" -v m="$mixed" -v ml="$mixed_live" '
     function multiline(line) { return gsub(/"/, "\"", line) < 2 }
     /^WIRED_TOOLS="/   { print "WIRED_TOOLS=\"" w "\"";   skip=multiline($0); next }
     /^UNWIRED_TOOLS="/ { print "UNWIRED_TOOLS=\"" u "\""; skip=multiline($0); next }
     /^MIXED_TOOLS="/   { print "MIXED_TOOLS=\"" m "\"";   skip=multiline($0); next }
+    /^MIXED_LIVE="/    { print "MIXED_LIVE=\"" ml "\"";    skip=multiline($0); next }
     skip && /"$/ { skip=0; next }
     skip { next }
     { print }
@@ -226,7 +249,7 @@ expect_red "MIXED README carries the word WIRED but never names its dependent (r
   job78 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:genericwired' 'mixedone'
 
 expect_red "MIXED recorded but NOTHING in the workspace depends on it" \
-  "the 'live half' claim is unsupported" \
+  "recorded MIXED via 'dependency' but NO workspace package depends on it" \
   mixednodep 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep'
 
 expect_red "UNWIRED recorded but a workspace package DOES depend on it" \
@@ -364,6 +387,41 @@ else
   printf '%s\n' "$out" | sed 's/^/    /' >&2
 fi
 
+# --- roborev job 83: a MIXED crate whose live half is an INVOKED BINARY, not a
+# --- library dependency. A multi-binary tool with one bin wired into CI and
+# --- another orphaned has NO reverse cargo dependency at all, so requiring a
+# --- workspace dependent for every MIXED crate REJECTED a correct classification
+# --- and told its author to record it UNWIRED — which is false.
+expect_green "GREEN 7 (MIXED via an INVOKED BINARY, no workspace dependent at all) PASSes" \
+  invokedmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|invoked:live-bin'
+
+# ...and the recorded form is still CROSS-CHECKED, so "invoked:" is not a way to
+# assert anything you like: the target must be a DECLARED [[bin]], and the README
+# must name it.
+expect_red "MIXED invoked target that is not a declared [[bin]]" \
+  "declares no [[bin]] by that name" \
+  invokedghost 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|invoked:no-such-bin'
+
+expect_red "MIXED invoked target never named in the README" \
+  "never mentions 'dead-bin'" \
+  invokedunnamed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesnobins' '' 'mixedone|invoked:dead-bin'
+
+expect_red "MIXED crate with no MIXED_LIVE entry at all" \
+  "has no entry in MIXED_LIVE" \
+  nolive 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'NONE'
+
+expect_red "MIXED_LIVE kind that is neither 'dependency' nor 'invoked:'" \
+  "unrecognised MIXED_LIVE kind" \
+  badkind 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|sortof'
+
+expect_red "MIXED_LIVE with an empty invoked target list" \
+  "names no target" \
+  emptyinvoked 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|invoked:'
+
+expect_red "stale MIXED_LIVE entry for a crate that is not MIXED" \
+  "which is not in MIXED_TOOLS" \
+  stalelive 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' '' 'ghostcrate|dependency'
+
 # --- fail-closed on an absent subject
 ws=$(make_ws notools 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
 rm -rf "$ws/tools"
@@ -382,4 +440,4 @@ if [ "$fails" -ne 0 ]; then
   echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
   exit 1
 fi
-echo "PASS: tools/ crate disposition self-test (#1716) — 6 green controls + 19 negative controls"
+echo "PASS: tools/ crate disposition self-test (#1716) — 7 green controls + 25 negative controls"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Self-test for scripts/tests/test_tools_crate_disposition.sh (issue #1716).
+#
+# A guard is only worth its green if it is capable of red. Every case builds a
+# scratch tools/ tree, copies the guard into it at the same relative path (the
+# guard resolves its root from its OWN location, so there is deliberately no
+# path/env seam to point at a fixture — CLAUDE.md #3312: a case needing a
+# different subject SUBSTITUTES THE ARTIFACT in its own scratch copy of the
+# tree), rewrites the two recorded lists for that tree, and asserts the verdict.
+#
+# Includes a GREEN control: without it, a guard hardwired to refuse everything
+# would satisfy every red case below and look fully tested.
+set -uo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GUARD="$SCRIPT_DIR/test_tools_crate_disposition.sh"
+GUARD_BASE=$(basename "$GUARD")
+[ -f "$GUARD" ] || { echo "FAIL: guard under test not found at $GUARD" >&2; exit 1; }
+
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/toolsdisp.XXXXXX") || exit 1
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fails=0
+pass_case() { echo "ok: $*"; }
+fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
+
+# make_ws <case> <wired-list> <unwired-list> <on-disk crates> <readme spec>
+#   on-disk crates: space-separated dir names to create under tools/
+#   readme spec   : space-separated `crate:kind`, kind = labeled | unlabeled
+#                   (crates not named get no README at all)
+#   a literal "-" for the wired/unwired list means "empty list"
+make_ws() {
+  local case_name="$1" wired="$2" unwired="$3" disk="$4" readmes="${5:-}"
+  local ws="$TMPROOT/$case_name" c spec crate kind
+  mkdir -p "$ws/scripts/tests"
+  for c in $disk; do
+    mkdir -p "$ws/tools/$c/src"
+    printf '[package]\nname = "scratch-%s"\nversion = "0.1.0"\nedition = "2021"\n' "$c" > "$ws/tools/$c/Cargo.toml"
+  done
+  for spec in $readmes; do
+    crate="${spec%%:*}"; kind="${spec##*:}"
+    if [ "$kind" = labeled ]; then
+      printf '# scratch %s\n\nThis crate is NOT CI-wired.\n' "$crate" > "$ws/tools/$crate/README.md"
+    else
+      printf '# scratch %s\n\nSome prose that never says whether anything runs it.\n' "$crate" > "$ws/tools/$crate/README.md"
+    fi
+  done
+  [ "$wired" = "-" ] && wired=""
+  [ "$unwired" = "-" ] && unwired=""
+  awk -v w="$wired" -v u="$unwired" '
+    /^WIRED_TOOLS="/   { print "WIRED_TOOLS=\"" w "\"";   skip=1; next }
+    /^UNWIRED_TOOLS="/ { print "UNWIRED_TOOLS=\"" u "\""; skip=1; next }
+    skip && /"$/ { skip=0; next }
+    skip { next }
+    { print }
+  ' "$GUARD" > "$ws/scripts/tests/$GUARD_BASE"
+  chmod +x "$ws/scripts/tests/$GUARD_BASE"
+  echo "$ws"
+}
+
+run_guard() { bash "$1/scripts/tests/$GUARD_BASE" 2>&1; }
+
+# --- CASE 1 (GREEN CONTROL) ---------------------------------------------------
+ws=$(make_ws green 'wiredone' 'orphanone' 'wiredone orphanone' 'orphanone:labeled')
+out=$(run_guard "$ws"); rc=$?
+if [ $rc -eq 0 ] && grep -q '^PASS:' <<<"$out"; then
+  pass_case "GREEN control: a correctly-classified tools/ tree PASSes (guard is not hardwired to refuse)"
+else
+  fail_case "GREEN control did NOT pass (rc=$rc):"; printf '%s\n' "$out" | sed 's/^/    /' >&2
+fi
+
+# --- red cases ---------------------------------------------------------------
+expect_red() {
+  local label="$1" needle="$2"; shift 2
+  local w o r
+  w=$(make_ws "$@")
+  o=$(run_guard "$w"); r=$?
+  if [ $r -eq 0 ]; then
+    fail_case "$label: guard PASSED on a tree it must reject"
+    printf '%s\n' "$o" | sed 's/^/    /' >&2
+  elif ! grep -qF "$needle" <<<"$o"; then
+    fail_case "$label: guard failed (good) but not for the expected reason (wanted '$needle')"
+    printf '%s\n' "$o" | sed 's/^/    /' >&2
+  else
+    pass_case "$label: guard FAILs, naming the right cause"
+  fi
+}
+
+# 2. a NEW crate arrives via the tools/* glob with no recorded disposition.
+expect_red "new unclassified tools/ crate" \
+  "is in NEITHER recorded list" \
+  newcomer 'wiredone' 'orphanone' 'wiredone orphanone newcomer' 'orphanone:labeled'
+
+# 3. an unwired crate with no README at all => not labeled.
+expect_red "unwired crate with no README" \
+  "has no README.md" \
+  noreadme 'wiredone' 'orphanone' 'wiredone orphanone' ''
+
+# 4. an unwired crate whose README exists but never states the fact.
+expect_red "unwired crate README missing the label marker" \
+  "does not contain the label" \
+  unlabeled 'wiredone' 'orphanone' 'wiredone orphanone' 'orphanone:unlabeled'
+
+# 5. a recorded crate deleted from disk without updating the list.
+expect_red "recorded crate removed from disk" \
+  "was renamed or removed without updating" \
+  ghost 'wiredone
+ghostcrate' 'orphanone' 'wiredone orphanone' 'orphanone:labeled'
+
+# 6. a crate recorded as both wired and unwired.
+expect_red "crate recorded in BOTH lists" \
+  "recorded as BOTH wired and unwired" \
+  both 'wiredone
+orphanone' 'orphanone' 'wiredone orphanone' 'orphanone:labeled'
+
+# 7. an EMPTY unwired list would make the label requirement enforce nothing.
+expect_red "empty UNWIRED_TOOLS list" \
+  "refusing to pass vacuously" \
+  emptyunwired 'wiredone' '-' 'wiredone' ''
+
+# 8. no tools/ directory at all => the guard's subject is absent.
+ws=$(make_ws notools 'wiredone' 'orphanone' 'wiredone orphanone' 'orphanone:labeled')
+rm -rf "$ws/tools"
+out=$(run_guard "$ws"); rc=$?
+if [ $rc -eq 0 ]; then
+  fail_case "absent tools/ directory: guard PASSED with no subject at all (vacuous pass)"
+elif ! grep -qF "refusing to pass vacuously" <<<"$out"; then
+  fail_case "absent tools/ directory: guard failed but not via the fail-closed path:"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+else
+  pass_case "absent tools/ directory: guard FAILs closed rather than passing vacuously"
+fi
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
+  exit 1
+fi
+echo "PASS: tools/ crate disposition self-test (#1716) — 1 green control + 7 negative controls"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -2,16 +2,21 @@
 # Self-test for scripts/tests/test_tools_crate_disposition.sh (issue #1716).
 #
 # A guard is only worth its green if it is capable of red. Every case builds a
-# minimal, dependency-free scratch cargo workspace, copies the guard into it at
-# the same relative path (the guard resolves its root from its OWN location, so
-# there is deliberately NO path/env seam to point at a fixture — CLAUDE.md #3312:
-# a case needing a different subject SUBSTITUTES THE ARTIFACT in its own scratch
-# copy of the tree), rewrites the three recorded lists for that tree, and asserts
-# the verdict.
+# scratch tools/ tree, copies the guard into it at the same relative path (the guard
+# resolves its root from its OWN location, so there is deliberately NO path/env seam
+# to point at a fixture — CLAUDE.md #3312: a case needing a different subject
+# SUBSTITUTES THE ARTIFACT in its own scratch copy of the tree), rewrites the three
+# recorded lists for that tree, and asserts the verdict.
 #
-# EIGHT GREEN CONTROLS, not one. Without a green control per shape, a guard
-# hardwired to refuse everything — or one that rejects every MIXED crate, or every
-# crate with a real dependent — would satisfy all the red cases and look tested.
+# NO CARGO ANYWHERE. An earlier version built scratch cargo workspaces to exercise a
+# dependency-derivation half of the guard that has since been removed. Those
+# workspaces lived OUTSIDE the repository, so they did not inherit
+# rust-toolchain.toml, which made a MANDATORY gate component's behaviour depend on
+# the host's default toolchain (roborev job 86). The guard is now filesystem-and-list
+# only, so this self-test is too: deterministic, offline, toolchain-independent.
+#
+# TWO GREEN CONTROLS: without one per shape, a guard hardwired to refuse everything
+# would satisfy every red case below and look fully tested.
 set -uo pipefail
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
@@ -19,7 +24,6 @@ GUARD="$SCRIPT_DIR/test_tools_crate_disposition.sh"
 GUARD_BASE=$(basename "$GUARD")
 [ -f "$GUARD" ] || { echo "FAIL: guard under test not found at $GUARD" >&2; exit 1; }
 
-export CARGO_NET_OFFLINE=1
 TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/toolsdisp.XXXXXX") || exit 1
 trap 'rm -rf "$TMPROOT"' EXIT
 
@@ -27,104 +31,27 @@ fails=0
 pass_case() { echo "ok: $*"; }
 fail_case() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
 
-# make_ws <case> <wired> <unwired> <mixed> <disk crates> <readme spec> [consumer-of]
+# make_ws <case> <wired> <unwired> <mixed> <disk crates> [readme spec]
 #   disk crates : space-separated dir names to create under tools/
 #   readme spec : space-separated `crate:kind`, kind =
-#                   labeled      -> says "NOT CI-wired" only
-#                   namesdep     -> says "NOT CI-wired" AND names scratch-consumer
-#                   genericwired -> says "NOT CI-wired" AND the bare word WIRED,
-#                                   but NEVER names the dependent (roborev job 78)
-#                   unlabeled    -> says neither
+#                   labeled   -> contains "NOT CI-wired"
+#                   unlabeled -> a README that never states the fact
 #                 (crates not named get no README at all)
-#   consumer-of : if non-empty, create a `consumer` workspace member (package
-#                 `scratch-consumer`) that path-depends on tools/<that crate>, so
-#                 `cargo tree --workspace --invert` reports a REAL dependent.
-#                 Accepts `<crate>` , `<crate>:optional` (dependency behind a
-#                 non-default feature) or `<crate>:target` (dependency inside a
-#                 `[target.'cfg(...)'.dependencies]` table). The latter two are the
-#                 shapes `cargo tree` hides unless queried with `--all-features`
-#                 and `--target all` (roborev job 79).
-#   mixed-inv   : 8th arg, the MIXED_INVOKED body (`<crate>|none` or
-#                 `<crate>|<bin>[,<bin>...]`). Defaults to `<mixed>|none`.
 #   a literal "-" for any list means "empty list"
 make_ws() {
-  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}" consumer_of="${7:-}" mixed_invoked="${8:-}"
-  # "-" means "use the default"; "NONE" means a genuinely EMPTY MIXED_INVOKED, which
-  # is what an UNRECORDED MIXED crate looks like and cannot be expressed by "-"
-  # (the default would fill it back in).
-  [ "$mixed_invoked" = "-" ] && mixed_invoked=""
-  # default: any MIXED crate is recorded as live-via-dependency
-  if [ "$mixed_invoked" = "NONE" ]; then
-    mixed_invoked=""
-  elif [ -z "$mixed_invoked" ] && [ -n "$mixed" ] && [ "$mixed" != "-" ]; then
-    mixed_invoked="$mixed|none"
-  fi
+  local case_name="$1" wired="$2" unwired="$3" mixed="$4" disk="$5" readmes="${6:-}"
   local ws="$TMPROOT/$case_name" c spec crate kind
-  mkdir -p "$ws/src" "$ws/scripts/tests"
+  mkdir -p "$ws/scripts/tests"
   for c in $disk; do
-    mkdir -p "$ws/tools/$c/src"
-    {
-      printf '[package]\nname = "scratch-%s"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n' "$c"
-      # Two [[bin]] targets, so a crate can legitimately be MIXED with one bin
-      # invoked by CI and the other orphaned — the shape that has NO reverse cargo
-      # dependency at all (roborev job 83).
-      printf '\n[[bin]]\nname = "live-bin"\npath = "src/live.rs"\n'
-      printf '\n[[bin]]\nname = "dead-bin"\npath = "src/dead.rs"\n'
-    } > "$ws/tools/$c/Cargo.toml"
-    : > "$ws/tools/$c/src/lib.rs"
-    printf 'fn main() {}\n' > "$ws/tools/$c/src/live.rs"
-    printf 'fn main() {}\n' > "$ws/tools/$c/src/dead.rs"
+    mkdir -p "$ws/tools/$c"
+    printf '[package]\nname = "%s"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n' "$c" \
+      > "$ws/tools/$c/Cargo.toml"
   done
-  {
-    echo '[workspace]'
-    if [ -n "$consumer_of" ]; then
-      echo 'members = ["tools/*", "consumer"]'
-    else
-      echo 'members = ["tools/*"]'
-    fi
-    echo 'resolver = "2"'
-    echo
-    echo '[package]'
-    echo 'name = "scratch-root"'
-    echo 'version = "0.1.0"'
-    echo 'edition = "2021"'
-    echo 'publish = false'
-  } > "$ws/Cargo.toml"
-  : > "$ws/src/lib.rs"
-  if [ -n "$consumer_of" ]; then
-    local dep_crate="${consumer_of%%:*}" dep_kind="plain"
-    case "$consumer_of" in *:*) dep_kind="${consumer_of##*:}" ;; esac
-    mkdir -p "$ws/consumer/src"
-    {
-      printf '[package]\nname = "scratch-consumer"\nversion = "0.1.0"\nedition = "2021"\npublish = false\n\n'
-      case "$dep_kind" in
-        optional)
-          # Behind a NON-DEFAULT feature: invisible to a default-feature resolve.
-          printf '[features]\ndefault = []\nextra = ["scratch-%s"]\n\n' "$dep_crate"
-          printf '[dependencies.scratch-%s]\npath = "../tools/%s"\noptional = true\n' "$dep_crate" "$dep_crate"
-          ;;
-        target)
-          # Target-gated on a cfg that is NOT this host: invisible to a host-only
-          # resolve. windows is chosen because the fleet is linux.
-          printf '[target."cfg(windows)".dependencies.scratch-%s]\npath = "../tools/%s"\n' "$dep_crate" "$dep_crate"
-          ;;
-        *)
-          printf '[dependencies.scratch-%s]\npath = "../tools/%s"\n' "$dep_crate" "$dep_crate"
-          ;;
-      esac
-    } > "$ws/consumer/Cargo.toml"
-    : > "$ws/consumer/src/lib.rs"
-  fi
   for spec in $readmes; do
     crate="${spec%%:*}"; kind="${spec##*:}"
     case "$kind" in
-      labeled)      printf '# scratch %s\n\nThis crate is NOT CI-wired.\n' "$crate" ;;
-      namesdep)     printf '# scratch %s\n\nIts binaries are NOT CI-wired; its library is used by scratch-consumer.\n' "$crate" ;;
-      genericwired) printf '# scratch %s\n\nPreviously WIRED, now entirely NOT CI-wired.\n' "$crate" ;;
-      namesbins)    printf '# scratch %s\n\nCI runs live-bin; the other binaries are NOT CI-wired.\n' "$crate" ;;
-      namesboth)    printf '# scratch %s\n\nCI runs live-bin and scratch-consumer uses the lib; the rest is NOT CI-wired.\n' "$crate" ;;
-      namesnobins)  printf '# scratch %s\n\nSome binaries are NOT CI-wired.\n' "$crate" ;;
-      *)            printf '# scratch %s\n\nProse that never says whether anything runs it.\n' "$crate" ;;
+      labeled) printf '# scratch %s\n\nThis crate is NOT CI-wired.\n' "$crate" ;;
+      *)       printf '# scratch %s\n\nProse that never says whether anything runs it.\n' "$crate" ;;
     esac > "$ws/tools/$crate/README.md"
   done
   [ "$wired" = "-" ] && wired=""
@@ -133,29 +60,21 @@ make_ws() {
   # Substitute the three recorded lists for this scratch tree's crates.
   #
   # `skip` must NOT be armed for a SELF-CONTAINED assignment. A single-line list
-  # such as `MIXED_TOOLS="format-validator"` both opens and closes its string on
-  # one line, so arming skip-until-quote made the rewriter swallow the NEXT
+  # such as `MIXED_TOOLS="format-validator"` both opens and closes its string on one
+  # line, so arming skip-until-quote made the rewriter swallow the NEXT
   # `"`-terminated line — `LABEL_MARKER=` — leaving every scratch guard with an
   # unbound variable. It broke the GREEN control rather than producing a wrong
   # verdict, which is why the green controls exist.
-  awk -v w="$wired" -v u="$unwired" -v m="$mixed" -v ml="$mixed_invoked" '
+  awk -v w="$wired" -v u="$unwired" -v m="$mixed" '
     function multiline(line) { return gsub(/"/, "\"", line) < 2 }
     /^WIRED_TOOLS="/   { print "WIRED_TOOLS=\"" w "\"";   skip=multiline($0); next }
     /^UNWIRED_TOOLS="/ { print "UNWIRED_TOOLS=\"" u "\""; skip=multiline($0); next }
     /^MIXED_TOOLS="/   { print "MIXED_TOOLS=\"" m "\"";   skip=multiline($0); next }
-    /^MIXED_INVOKED="/    { print "MIXED_INVOKED=\"" ml "\"";    skip=multiline($0); next }
     skip && /"$/ { skip=0; next }
     skip { next }
     { print }
   ' "$GUARD" > "$ws/scripts/tests/$GUARD_BASE"
   chmod +x "$ws/scripts/tests/$GUARD_BASE"
-  # The guard queries cargo with `--locked`, which REFUSES to create or rewrite a
-  # lockfile — correct for the real repo (it is what stops the guard mutating the
-  # tree it inspects), but it means a scratch workspace needs its own Cargo.lock
-  # first. These crates have no external dependencies, so this resolves offline.
-  # Failure is ignored on purpose: the stub-cargo cases below never reach real
-  # cargo, and the cases that DO would fail loudly on their own assertion anyway.
-  (cd "$ws" && cargo generate-lockfile --offline --quiet >/dev/null 2>&1) || true
   echo "$ws"
 }
 
@@ -193,11 +112,8 @@ expect_red() {
 expect_green "GREEN 1: a correctly-classified WIRED+UNWIRED tree PASSes" \
   green 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled'
 
-expect_green "GREEN 2 (MIXED): a real dependent + a README naming it PASSes" \
-  mixedgreen 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone'
-
-expect_green "GREEN 3: UNWIRED alongside a consumer of a DIFFERENT crate PASSes" \
-  unwiredgreen 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'wiredone'
+expect_green "GREEN 2: a correctly-labeled MIXED crate PASSes" \
+  mixedgreen 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:labeled'
 
 # ============================== RED CASES ===================================
 # --- classification completeness / consistency
@@ -218,15 +134,19 @@ orphanone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled'
 expect_red "crate recorded in BOTH WIRED and MIXED" \
   "recorded in BOTH WIRED_TOOLS and MIXED_TOOLS" \
   bothwm 'wiredone
-mixedone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone'
+mixedone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:labeled'
 
 expect_red "crate recorded in BOTH UNWIRED and MIXED" \
   "recorded in BOTH UNWIRED_TOOLS and MIXED_TOOLS" \
-  bothum 'wiredone' 'mixedone' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone'
+  bothum 'wiredone' 'mixedone' 'mixedone' 'wiredone mixedone' 'mixedone:labeled'
 
 expect_red "empty UNWIRED_TOOLS and MIXED_TOOLS lists" \
   "refusing to pass vacuously" \
   emptyboth 'wiredone' '-' '-' 'wiredone' ''
+
+expect_red "empty WIRED_TOOLS list" \
+  "WIRED_TOOLS list is empty" \
+  emptywired '-' 'orphanone' '-' 'orphanone' 'orphanone:labeled'
 
 # --- the labeling half (#1716's actual acceptance criterion)
 expect_red "UNWIRED crate with no README" \
@@ -239,197 +159,11 @@ expect_red "UNWIRED crate README missing the label marker" \
 
 expect_red "MIXED crate with no README" \
   "has no README.md" \
-  mixednoreadme 'wiredone' '-' 'mixedone' 'wiredone mixedone' '' 'mixedone'
+  mixednoreadme 'wiredone' '-' 'mixedone' 'wiredone mixedone' ''
 
-# --- THE DERIVED CROSS-CHECK: the census must match the MANIFESTS, both ways.
-# roborev job 78: the MIXED label used to be verified by grepping for the generic
-# word "WIRED", which this README satisfies while saying the OPPOSITE. The
-# requirement is now to name the crate's ACTUAL, DERIVED dependent.
-expect_red "MIXED README carries the word WIRED but never names its dependent (roborev job 78)" \
-  "never mentions 'scratch-consumer'" \
-  job78 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:genericwired' 'mixedone'
-
-expect_red "MIXED recorded but NOTHING in the workspace depends on it" \
-  "has NO live half from either source" \
-  mixednodep 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' '' 'mixedone|none'
-
-expect_red "UNWIRED recorded but a workspace package DOES depend on it" \
-  "that is a FALSE census" \
-  unwireddep 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'orphanone'
-
-# --- roborev job 79: a dependency behind an OPTIONAL FEATURE or a NON-HOST TARGET
-# --- is invisible to a default `cargo tree` resolve, so an UNWIRED record would
-# --- look correct while something really depends on the crate. These two cases
-# --- fail unless the query carries BOTH --all-features and --target all.
-expect_red "UNWIRED but an OPTIONAL-FEATURE dependency exists (roborev job 79)" \
-  "that is a FALSE census" \
-  optdep 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'orphanone:optional'
-
-expect_red "UNWIRED but a NON-HOST TARGET dependency exists (roborev job 79)" \
-  "that is a FALSE census" \
-  targetdep 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' 'orphanone:target'
-
-# ...and the same two shapes must SATISFY a MIXED record, so the widened query is
-# shown to find real dependents rather than merely to reject more.
-expect_green "GREEN 4 (MIXED via an OPTIONAL-FEATURE dependent) PASSes" \
-  optmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone:optional'
-
-expect_green "GREEN 5 (MIXED via a NON-HOST TARGET dependent) PASSes" \
-  targetmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesdep' 'mixedone:target'
-
-# --- roborev job 80: an UNMEASURABLE dependency graph must FAIL, never be read as
-# --- "zero dependents". Forced by substituting a `cargo` ARTIFACT in the scratch
-# --- tree's PATH that fails — not by any env seam in the guard, which has none.
-ws=$(make_ws unmeasurable 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
-mkdir -p "$ws/stubbin"
-printf '#!/usr/bin/env bash\nexit 1\n' > "$ws/stubbin/cargo"
-chmod +x "$ws/stubbin/cargo"
-out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
-if [ $rc -eq 0 ]; then
-  fail_case "unmeasurable dependency graph: guard PASSED when cargo could not answer — an unmeasurable graph was read as 'zero dependents' (the fail-closed contract inverted)"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
-  fail_case "unmeasurable dependency graph: guard failed but not via the fail-closed measurement path:"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-else
-  pass_case "unmeasurable dependency graph: guard FAILs closed rather than inferring zero dependents"
-fi
-
-# ...and the SAME stub must not be able to fake a PASS the other way: a cargo that
-# prints nothing is equally unmeasurable (cargo always echoes the subject as the
-# tree root, so empty output means it answered nothing).
-ws=$(make_ws emptycargo 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
-mkdir -p "$ws/stubbin"
-printf '#!/usr/bin/env bash\nexit 0\n' > "$ws/stubbin/cargo"
-chmod +x "$ws/stubbin/cargo"
-out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
-if [ $rc -eq 0 ]; then
-  fail_case "silent cargo: guard PASSED on empty cargo output (measured nothing, reported no dependents)"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
-  fail_case "silent cargo: guard failed but not via the fail-closed measurement path:"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-else
-  pass_case "silent cargo (exit 0, no output): guard FAILs closed rather than reporting zero dependents"
-fi
-
-# --- and the FILTERING stage itself must fail closed (the specific ask of roborev
-# --- job 80). `awk` is used ONLY inside workspace_dependents, so substituting a
-# --- failing `awk` artifact isolates the parse stage exactly: cargo still answers
-# --- correctly, and only the filtering breaks. The construct this replaces —
-# --- `sed | grep -v || true | sort` followed by an unconditional `return 0` —
-# --- discarded the pipeline status entirely, so a broken filter yielded EMPTY
-# --- output that read as "zero dependents": a false PASS for an UNWIRED record.
-ws=$(make_ws filterfail 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
-mkdir -p "$ws/stubbin"
-printf '#!/usr/bin/env bash\nexit 2\n' > "$ws/stubbin/awk"
-chmod +x "$ws/stubbin/awk"
-out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
-if [ $rc -eq 0 ]; then
-  fail_case "filtering-stage failure: guard PASSED though the parse stage failed — a broken filter was read as 'zero dependents'"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
-  fail_case "filtering-stage failure: guard failed but not via the fail-closed measurement path:"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-else
-  pass_case "filtering-stage failure: guard FAILs closed rather than reading a broken filter as zero dependents"
-fi
-
-# --- roborev job 82: cargo output that is NON-EMPTY but UNPARSEABLE. A successful
-# --- awk run matching nothing used to be read as "zero dependents", so a change in
-# --- cargo's tree format would let an UNWIRED crate with REAL dependents pass. The
-# --- parser must now prove it recognised the SUBJECT (cargo always prints it as the
-# --- tree root) before an empty dependent set is allowed to mean anything.
-ws=$(make_ws unparseable 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
-mkdir -p "$ws/stubbin"
-# exits 0, prints plausible-looking output that contains NO "<name> v<digit>" record
-printf '#!/usr/bin/env bash\nprintf "some future cargo format\\nwith no version records\\n"\nexit 0\n' \
-  > "$ws/stubbin/cargo"
-chmod +x "$ws/stubbin/cargo"
-out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
-if [ $rc -eq 0 ]; then
-  fail_case "unparseable cargo output: guard PASSED — a successful parse matching NOTHING was read as 'zero dependents', so an UNWIRED crate with real dependents would pass"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
-  fail_case "unparseable cargo output: guard failed but not via the fail-closed measurement path:"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-else
-  pass_case "unparseable cargo output (exit 0, no version records): guard FAILs closed"
-fi
-
-# --- and the complement: output whose ONLY record is the subject must still be a
-# --- legitimate "zero dependents" PASS, so the new subject check cannot be
-# --- satisfied by simply rejecting every empty result.
-ws=$(make_ws subjectonly 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
-mkdir -p "$ws/stubbin"
-cat > "$ws/stubbin/cargo" <<'STUB'
-#!/usr/bin/env bash
-# Echo ONLY the subject, as real cargo does for a crate with no dependents.
-# The subject is the argument immediately after `--invert`. Scanning for "the
-# first non-flag argument" does NOT work: `--target all` contributes a bare
-# `all`, which is how the first version of this stub picked the wrong subject
-# and made this green control fail.
-subj=""
-prev=""
-for a in "$@"; do
-  if [ "$prev" = "--invert" ]; then subj="$a"; break; fi
-  prev="$a"
-done
-[ -n "$subj" ] || { echo "stub: no --invert argument found" >&2; exit 64; }
-printf "%s v0.1.0 (/scratch/%s)\n" "$subj" "$subj"
-exit 0
-STUB
-chmod +x "$ws/stubbin/cargo"
-out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
-if [ $rc -eq 0 ] && grep -q '^PASS:' <<<"$out"; then
-  pass_case "GREEN 6: cargo output containing ONLY the subject is a legitimate zero-dependents PASS"
-else
-  fail_case "GREEN 6 — subject-only cargo output did NOT pass (rc=$rc); the subject check must not reject every empty result:"
-  printf '%s\n' "$out" | sed 's/^/    /' >&2
-fi
-
-# --- roborev job 83: a MIXED crate whose live half is an INVOKED BINARY, not a
-# --- library dependency. A multi-binary tool with one bin wired into CI and
-# --- another orphaned has NO reverse cargo dependency at all, so requiring a
-# --- workspace dependent for every MIXED crate REJECTED a correct classification
-# --- and told its author to record it UNWIRED — which is false.
-expect_green "GREEN 7 (MIXED via an INVOKED BINARY, no workspace dependent at all) PASSes" \
-  invokedmixed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|live-bin'
-
-# ...and the recorded form is still CROSS-CHECKED, so "invoked:" is not a way to
-# assert anything you like: the target must be a DECLARED [[bin]], and the README
-# must name it.
-expect_red "MIXED invoked target that is not a declared [[bin]]" \
-  "declares no [[bin]] by that name" \
-  invokedghost 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|no-such-bin'
-
-expect_red "MIXED invoked target never named in the README" \
-  "never mentions 'dead-bin'" \
-  invokedunnamed 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesnobins' '' 'mixedone|dead-bin'
-
-expect_red "MIXED crate with no MIXED_INVOKED entry at all" \
-  "has no entry in MIXED_INVOKED" \
-  nolive 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'NONE'
-
-expect_red "MIXED_INVOKED with a blank target list (neither a bin nor 'none')" \
-  "write 'mixedone|none' to say so explicitly" \
-  blanklist 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' '' 'mixedone|'
-
-
-expect_red "stale MIXED_INVOKED entry for a crate that is not MIXED" \
-  "which is not in MIXED_TOOLS" \
-  stalelive 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled' '' 'ghostcrate|none'
-
-# --- roborev job 85: the COMBINED shape. A crate can have BOTH a workspace
-# --- dependent AND a CI-invoked binary. Treating the two as mutually exclusive let
-# --- a recorded invoked list SKIP dependency discovery entirely, so the README
-# --- could omit a real dependent and still pass. Both must now be documented.
-expect_green "GREEN 8 (MIXED with BOTH a dependent and an invoked bin) PASSes when the README names both" \
-  bothsources 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesboth' 'mixedone' 'mixedone|live-bin'
-
-expect_red "MIXED with BOTH sources whose README names the invoked bin but OMITS the real dependent (roborev job 85)" \
-  "never mentions 'scratch-consumer'" \
-  bothomitdep 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:namesbins' 'mixedone' 'mixedone|live-bin'
+expect_red "MIXED crate README missing the label marker" \
+  "does not contain 'NOT CI-wired'" \
+  mixedunlabeled 'wiredone' '-' 'mixedone' 'wiredone mixedone' 'mixedone:unlabeled'
 
 # --- fail-closed on an absent subject
 ws=$(make_ws notools 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
@@ -444,9 +178,26 @@ else
   pass_case "absent tools/ directory: guard FAILs closed rather than passing vacuously"
 fi
 
+# --- an UNREADABLE README is unmeasurable, not unlabeled
+ws=$(make_ws unreadable 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
+chmod 000 "$ws/tools/orphanone/README.md"
+out=$(run_guard "$ws"); rc=$?
+chmod 644 "$ws/tools/orphanone/README.md" 2>/dev/null || true
+if [ "$(id -u)" = 0 ]; then
+  pass_case "unreadable README: SKIPPED (running as root, which can read anything)"
+elif [ $rc -eq 0 ]; then
+  fail_case "unreadable README: guard PASSED though it could not verify the label"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
+  fail_case "unreadable README: guard failed but not via the fail-closed path:"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+else
+  pass_case "unreadable README: guard FAILs closed rather than treating it as unlabeled"
+fi
+
 echo
 if [ "$fails" -ne 0 ]; then
   echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
   exit 1
 fi
-echo "PASS: tools/ crate disposition self-test (#1716) — 8 green controls + 25 negative controls"
+echo "PASS: tools/ crate disposition self-test (#1716) — 2 green controls + 12 negative controls, no cargo"

--- a/scripts/tests/test_tools_crate_disposition_selftest.sh
+++ b/scripts/tests/test_tools_crate_disposition_selftest.sh
@@ -9,7 +9,7 @@
 # copy of the tree), rewrites the three recorded lists for that tree, and asserts
 # the verdict.
 #
-# FIVE GREEN CONTROLS, not one. Without a green control per shape, a guard
+# SIX GREEN CONTROLS, not one. Without a green control per shape, a guard
 # hardwired to refuse everything — or one that rejects every MIXED crate, or every
 # crate with a real dependent — would satisfy all the red cases and look tested.
 set -uo pipefail
@@ -125,6 +125,13 @@ make_ws() {
     { print }
   ' "$GUARD" > "$ws/scripts/tests/$GUARD_BASE"
   chmod +x "$ws/scripts/tests/$GUARD_BASE"
+  # The guard queries cargo with `--locked`, which REFUSES to create or rewrite a
+  # lockfile — correct for the real repo (it is what stops the guard mutating the
+  # tree it inspects), but it means a scratch workspace needs its own Cargo.lock
+  # first. These crates have no external dependencies, so this resolves offline.
+  # Failure is ignored on purpose: the stub-cargo cases below never reach real
+  # cargo, and the cases that DO would fail loudly on their own assertion anyway.
+  (cd "$ws" && cargo generate-lockfile --offline --quiet >/dev/null 2>&1) || true
   echo "$ws"
 }
 
@@ -304,6 +311,59 @@ else
   pass_case "filtering-stage failure: guard FAILs closed rather than reading a broken filter as zero dependents"
 fi
 
+# --- roborev job 82: cargo output that is NON-EMPTY but UNPARSEABLE. A successful
+# --- awk run matching nothing used to be read as "zero dependents", so a change in
+# --- cargo's tree format would let an UNWIRED crate with REAL dependents pass. The
+# --- parser must now prove it recognised the SUBJECT (cargo always prints it as the
+# --- tree root) before an empty dependent set is allowed to mean anything.
+ws=$(make_ws unparseable 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
+mkdir -p "$ws/stubbin"
+# exits 0, prints plausible-looking output that contains NO "<name> v<digit>" record
+printf '#!/usr/bin/env bash\nprintf "some future cargo format\\nwith no version records\\n"\nexit 0\n' \
+  > "$ws/stubbin/cargo"
+chmod +x "$ws/stubbin/cargo"
+out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
+if [ $rc -eq 0 ]; then
+  fail_case "unparseable cargo output: guard PASSED — a successful parse matching NOTHING was read as 'zero dependents', so an UNWIRED crate with real dependents would pass"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+elif ! grep -qF "unmeasurable is not a pass" <<<"$out"; then
+  fail_case "unparseable cargo output: guard failed but not via the fail-closed measurement path:"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+else
+  pass_case "unparseable cargo output (exit 0, no version records): guard FAILs closed"
+fi
+
+# --- and the complement: output whose ONLY record is the subject must still be a
+# --- legitimate "zero dependents" PASS, so the new subject check cannot be
+# --- satisfied by simply rejecting every empty result.
+ws=$(make_ws subjectonly 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
+mkdir -p "$ws/stubbin"
+cat > "$ws/stubbin/cargo" <<'STUB'
+#!/usr/bin/env bash
+# Echo ONLY the subject, as real cargo does for a crate with no dependents.
+# The subject is the argument immediately after `--invert`. Scanning for "the
+# first non-flag argument" does NOT work: `--target all` contributes a bare
+# `all`, which is how the first version of this stub picked the wrong subject
+# and made this green control fail.
+subj=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--invert" ]; then subj="$a"; break; fi
+  prev="$a"
+done
+[ -n "$subj" ] || { echo "stub: no --invert argument found" >&2; exit 64; }
+printf "%s v0.1.0 (/scratch/%s)\n" "$subj" "$subj"
+exit 0
+STUB
+chmod +x "$ws/stubbin/cargo"
+out=$(PATH="$ws/stubbin:$PATH" run_guard "$ws"); rc=$?
+if [ $rc -eq 0 ] && grep -q '^PASS:' <<<"$out"; then
+  pass_case "GREEN 6: cargo output containing ONLY the subject is a legitimate zero-dependents PASS"
+else
+  fail_case "GREEN 6 — subject-only cargo output did NOT pass (rc=$rc); the subject check must not reject every empty result:"
+  printf '%s\n' "$out" | sed 's/^/    /' >&2
+fi
+
 # --- fail-closed on an absent subject
 ws=$(make_ws notools 'wiredone' 'orphanone' '-' 'wiredone orphanone' 'orphanone:labeled')
 rm -rf "$ws/tools"
@@ -322,4 +382,4 @@ if [ "$fails" -ne 0 ]; then
   echo "FAIL: $fails tools/ disposition self-test case(s) failed" >&2
   exit 1
 fi
-echo "PASS: tools/ crate disposition self-test (#1716) — 5 green controls + 18 negative controls"
+echo "PASS: tools/ crate disposition self-test (#1716) — 6 green controls + 19 negative controls"

--- a/tools/cqlite-validator/README.md
+++ b/tools/cqlite-validator/README.md
@@ -1,0 +1,29 @@
+# `cqlite-validator` — manual dev tool (NOT CI-wired)
+
+**Status: manual developer tool.** No CI workflow, no script, and no live doc invokes this crate
+or its `cqlite-validator` binary — verified by census in issue #1716 (epic #1688, audit finding
+AK5). It is therefore **not** in the workspace `default-members`, so a bare `cargo build` at the
+repo root does not compile it.
+
+```bash
+cargo run -p cqlite-validator -- --help     # build + run on demand
+cargo build -p cqlite-validator             # build only
+cargo test  -p cqlite-validator             # this crate's own tests (it currently has none)
+```
+
+It is still a workspace **member**, so the agent gate's
+`cargo clippy --workspace --all-targets --all-features` lints it under `-D warnings` — dropping out
+of `default-members` costs build time, never lint coverage.
+
+## What it does
+
+A standalone SSTable validation CLI: `test` (self-check), `file <path>` (validate one component)
+and `dir <path>` (walk a Cassandra data directory). It predates the `cqlite` CLI's own validation
+surface. The archived quick-start that used to drive it is
+`docs/archive/user-guides-superseded/UAT_QUICK_START.md` — archived, not live.
+
+## Before you delete it
+
+Retained deliberately: issue #1716 permits deletion only for a tool that **duplicates a live gate
+check entirely**, and this one is not wired into any gate lane, so there is nothing to compare it
+against. Batch-deletion of dead tooling is epic #1688 decision #9 — take it there, not here.

--- a/tools/cqlite-validator/README.md
+++ b/tools/cqlite-validator/README.md
@@ -27,6 +27,15 @@ and `dir <path>` (walk a Cassandra data directory). It predates the `cqlite` CLI
 surface. The archived quick-start that used to drive it is
 `docs/archive/user-guides-superseded/UAT_QUICK_START.md` — archived, not live.
 
+## Its tests run only when you touch it
+
+No CI job or gate component runs workspace-wide tests, so this crate's own unit tests do not
+execute on an unrelated change — but the agent gate's `--lite` blast-radius maps a touched path to
+its package, so **editing anything in this directory (this README included) makes `--lite` run
+`cargo test -p cqlite-validator --lib`**. Expect latent failures the first time that happens: on #1716,
+touching `tools/format-validator/README.md` ran that crate's tests for the first time and one had
+never been correct. Run them yourself first with `cargo test -p cqlite-validator`.
+
 ## Before you delete it
 
 Retained deliberately: issue #1716 permits deletion only for a tool that **duplicates a live gate

--- a/tools/cqlite-validator/README.md
+++ b/tools/cqlite-validator/README.md
@@ -2,8 +2,7 @@
 
 **Status: manual developer tool.** No CI workflow, no script, and no live doc invokes this crate
 or its `cqlite-validator` binary — verified by census in issue #1716 (epic #1688, audit finding
-AK5). It is therefore **not** in the workspace `default-members`, so a bare `cargo build` at the
-repo root does not compile it.
+AK5).
 
 ```bash
 cargo run -p cqlite-validator -- --help     # build + run on demand
@@ -11,9 +10,15 @@ cargo build -p cqlite-validator             # build only
 cargo test  -p cqlite-validator             # this crate's own tests (it currently has none)
 ```
 
-It is still a workspace **member**, so the agent gate's
-`cargo clippy --workspace --all-targets --all-features` lints it under `-D warnings` — dropping out
-of `default-members` costs build time, never lint coverage.
+A bare `cargo build` at the repo root does not compile this crate — but **not because of
+anything #1716 changed**: this workspace has a root package (`cqlite`), so cargo's default member
+set is *that package alone*, and every `tools/` crate is compiled only by an explicit
+`--workspace` or `-p`. See the `default-members` note in the root `Cargo.toml` before "optimizing"
+that.
+
+It is a workspace **member**, and stays one, so the agent gate's
+`cargo clippy --workspace --all-targets --all-features` lints it under `-D warnings`. Being
+unwired costs it no lint coverage.
 
 ## What it does
 

--- a/tools/format-validator/README.md
+++ b/tools/format-validator/README.md
@@ -19,15 +19,17 @@ issue #1716 (epic #1688, audit finding AK5):
 3. **`xtask/src/oom_audit/scope.rs`** asserts on a `tools/format-validator/` path.
 
 **Therefore this crate must stay a workspace member and must NOT be added to the workspace
-`exclude` list** — doing so breaks all three. See the `default-members` comment in the root
-`Cargo.toml`.
+`exclude` list** — doing so breaks all three.
 
 ## The four binaries are not wired
 
-No CI workflow, no script and no live doc invokes any of them. So the crate is **not** in
-`default-members`: a bare `cargo build` at the repo root no longer compiles the four binaries,
-while the library still builds as `format-compatibility-tests`' dependency — which is exactly the
-coverage the `format-compat` gate component needs.
+No CI workflow, no script and no live doc invokes any of them. They are built only by an explicit
+`--workspace`/`--all-targets` (notably the gate's clippy) or by the `-p` commands below — a bare
+`cargo build` at the repo root compiles only the root `cqlite` package, so it never built them.
+Measured on 16 cores with dependencies warm, these four binaries cost **51.1 s** of a
+`cargo build --workspace --all-targets`, which is 82% of all three unwired crates' combined 62.6 s
+(issue #1716). Deleting or feature-gating them is proposed as a follow-up there; #1716's own rules
+do not authorize it (they permit deletion only for a tool that duplicates a live gate check).
 
 ```bash
 cargo run -p format-validator --bin hex-analyzer -- --help    # or format-checker,
@@ -35,9 +37,9 @@ cargo build -p format-validator --bins                        # deviation-detect
 cargo test  -p format-validator                               # benchmark-validator
 ```
 
-The crate is still a workspace **member**, so the gate's
+The crate is a workspace **member**, so the gate's
 `cargo clippy --workspace --all-targets --all-features` lints every target here under
-`-D warnings` — dropping out of `default-members` costs build time, never lint coverage. (Note the
+`-D warnings`. (Note the
 crate-level `#![allow(clippy::all)]` in `src/lib.rs`, an old "EMERGENCY M1 FIX", suppresses most of
 that within the lib; unrelated to #1716 and left alone.)
 

--- a/tools/format-validator/README.md
+++ b/tools/format-validator/README.md
@@ -1,0 +1,57 @@
+# `format-validator` — a WIRED library plus four manual dev BINARIES
+
+This crate is **split-status**, and the split is the whole point of this file. Verified by census in
+issue #1716 (epic #1688, audit finding AK5):
+
+| target | status |
+|---|---|
+| the **library** (`format_validator`) | **WIRED — do not remove** |
+| the four **binaries** (`hex-analyzer`, `format-checker`, `deviation-detector`, `benchmark-validator`) | **manual dev tools, NOT CI-wired** |
+
+## The library is wired — three live consumers
+
+1. **`tests/format-compatibility`** (package `format-compatibility-tests`) path-depends on this
+   crate, and `tests/format-compatibility/tests/oa_format_compliance.rs` uses
+   `format_validator::format_constants` and `format_validator::utils`. That package is its own
+   **full agent-gate component** (`format-compat`), so this library is on the gate's critical path.
+2. **`scripts/tests/test_agent_gate_summary.sh`** uses `tools/format-validator/src/lib.rs` as the
+   fixture for the gate's path → package **"owners"** resolution (which reads `cargo metadata`).
+3. **`xtask/src/oom_audit/scope.rs`** asserts on a `tools/format-validator/` path.
+
+**Therefore this crate must stay a workspace member and must NOT be added to the workspace
+`exclude` list** — doing so breaks all three. See the `default-members` comment in the root
+`Cargo.toml`.
+
+## The four binaries are not wired
+
+No CI workflow, no script and no live doc invokes any of them. So the crate is **not** in
+`default-members`: a bare `cargo build` at the repo root no longer compiles the four binaries,
+while the library still builds as `format-compatibility-tests`' dependency — which is exactly the
+coverage the `format-compat` gate component needs.
+
+```bash
+cargo run -p format-validator --bin hex-analyzer -- --help    # or format-checker,
+cargo build -p format-validator --bins                        # deviation-detector,
+cargo test  -p format-validator                               # benchmark-validator
+```
+
+The crate is still a workspace **member**, so the gate's
+`cargo clippy --workspace --all-targets --all-features` lints every target here under
+`-D warnings` — dropping out of `default-members` costs build time, never lint coverage. (Note the
+crate-level `#![allow(clippy::all)]` in `src/lib.rs`, an old "EMERGENCY M1 FIX", suppresses most of
+that within the lib; unrelated to #1716 and left alone.)
+
+## What the binaries do
+
+- **`hex-analyzer`** — format-aware hex dump of an SSTable component (magic numbers, structures,
+  data layout).
+- **`format-checker`** — format compliance check of an SSTable file.
+- **`deviation-detector`** — flags deviations/anomalies against the expected Cassandra 5+ layout.
+- **`benchmark-validator`** — benchmarks the validation operations themselves.
+
+## Before you delete anything
+
+The library is wired — deleting it breaks the gate. The binaries are retained deliberately: issue
+#1716 permits deletion only for a tool that **duplicates a live gate check entirely**, and these
+four are not wired into any gate lane. Batch-deletion of dead tooling is epic #1688 decision #9 —
+take it there, not here.

--- a/tools/format-validator/README.md
+++ b/tools/format-validator/README.md
@@ -51,6 +51,25 @@ that within the lib; unrelated to #1716 and left alone.)
 - **`deviation-detector`** — flags deviations/anomalies against the expected Cassandra 5+ layout.
 - **`benchmark-validator`** — benchmarks the validation operations themselves.
 
+## Its tests run only when you touch it — and one was wrong for years
+
+No CI job or gate component runs workspace-wide tests, so this crate's unit tests did not execute on
+unrelated changes. But the agent gate's `--lite` blast-radius maps a touched path to its package, so
+**editing anything in this directory (this README included) makes `--lite` run
+`cargo test -p format-validator --lib`**.
+
+On #1716 that happened for the first time and `utils::tests::test_hex_dump_formatting` **failed**:
+it asserted `dump.contains("48656c6c6f")`, an unseparated hex run that `format_hex_dump` can never
+emit for any input — it produces a conventional `hexdump -C` layout:
+
+```text
+00000000: 48 65 6c 6c 6f 2c 20 57  6f 72 6c 64 21 20 54 68  |Hello, World! Th|
+```
+
+The **test** was wrong, not the formatter, so the expectation was corrected (and tightened to also
+pin the address prefix and the post-gap half of the line). Run `cargo test -p format-validator`
+before touching anything here.
+
 ## Before you delete anything
 
 The library is wired — deleting it breaks the gate. The binaries are retained deliberately: issue

--- a/tools/format-validator/src/lib.rs
+++ b/tools/format-validator/src/lib.rs
@@ -308,7 +308,15 @@ mod tests {
     fn test_hex_dump_formatting() {
         let data = b"Hello, World! This is a test.";
         let dump = format_hex_dump(data, 0, data.len());
-        assert!(dump.contains("48656c6c6f")); // "Hello" in hex
-        assert!(dump.contains("Hello")); // ASCII representation
+        // `format_hex_dump` emits a conventional `hexdump -C` layout — an address
+        // prefix, SPACE-SEPARATED hex pairs with a gap after the 8th byte, then an
+        // ASCII gutter. Asserting the UNSEPARATED "48656c6c6f" (as this test did
+        // until #1716) can never hold for any input; it was simply never run,
+        // because nothing invoked this crate. Verified actual output for this input:
+        //   00000000: 48 65 6c 6c 6f 2c 20 57  6f 72 6c 64 21 20 54 68  |Hello, World! Th|
+        assert!(dump.contains("48 65 6c 6c 6f")); // "Hello", hex pairs
+        assert!(dump.contains("Hello")); // ASCII gutter
+        assert!(dump.starts_with("00000000: ")); // address prefix
+        assert!(dump.contains("6f 72 6c 64 21")); // the post-gap half of line 1
     }
 }

--- a/tools/memory-safety-runner/README.md
+++ b/tools/memory-safety-runner/README.md
@@ -1,8 +1,7 @@
 # `memory-safety-runner` — manual dev tool (NOT CI-wired, and currently NOT EXECUTABLE)
 
 **Status: manual developer tool.** No CI workflow, no script, and no live doc references this
-crate — verified by census in issue #1716 (epic #1688, audit finding AK5). It is therefore **not**
-in the workspace `default-members`, so a bare `cargo build` at the repo root does not compile it.
+crate — verified by census in issue #1716 (epic #1688, audit finding AK5).
 
 ## Read this first: there is no binary
 
@@ -19,9 +18,15 @@ cargo build -p memory-safety-runner    # type-check / lint the library
 To actually run the wrapped tools you would have to add a `[[bin]]` here (or call the library from
 a test). That is deliberately left undone — see "Before you delete it" below.
 
-It is still a workspace **member**, so the agent gate's
-`cargo clippy --workspace --all-targets --all-features` lints it under `-D warnings` — dropping out
-of `default-members` costs build time, never lint coverage.
+A bare `cargo build` at the repo root does not compile this crate — but **not because of
+anything #1716 changed**: this workspace has a root package (`cqlite`), so cargo's default member
+set is *that package alone*, and every `tools/` crate is compiled only by an explicit
+`--workspace` or `-p`. See the `default-members` note in the root `Cargo.toml` before "optimizing"
+that.
+
+It is a workspace **member**, and stays one, so the agent gate's
+`cargo clippy --workspace --all-targets --all-features` lints it under `-D warnings`. Being
+unwired costs it no lint coverage.
 
 ## What it does
 

--- a/tools/memory-safety-runner/README.md
+++ b/tools/memory-safety-runner/README.md
@@ -1,0 +1,41 @@
+# `memory-safety-runner` — manual dev tool (NOT CI-wired, and currently NOT EXECUTABLE)
+
+**Status: manual developer tool.** No CI workflow, no script, and no live doc references this
+crate — verified by census in issue #1716 (epic #1688, audit finding AK5). It is therefore **not**
+in the workspace `default-members`, so a bare `cargo build` at the repo root does not compile it.
+
+## Read this first: there is no binary
+
+This crate is **library-only**. It declares no `[[bin]]` target and no other crate depends on it,
+so — unlike the other manual tools in `tools/` — **`cargo run -p memory-safety-runner` does not
+work**, and nothing in the repository can currently execute `MemorySafetyRunner`. It is reachable
+only by its own unit tests, or by code you write against it:
+
+```bash
+cargo test  -p memory-safety-runner    # its 2 unit tests
+cargo build -p memory-safety-runner    # type-check / lint the library
+```
+
+To actually run the wrapped tools you would have to add a `[[bin]]` here (or call the library from
+a test). That is deliberately left undone — see "Before you delete it" below.
+
+It is still a workspace **member**, so the agent gate's
+`cargo clippy --workspace --all-targets --all-features` lints it under `-D warnings` — dropping out
+of `default-members` costs build time, never lint coverage.
+
+## What it does
+
+Wraps three external memory-safety checkers behind one `MemorySafetyRunner` type: **Miri**,
+**Valgrind** and **AddressSanitizer**, each probed for availability first
+(`run_miri_tests`, `run_valgrind_tests`, `run_asan_tests`, `run_stress_tests`,
+`run_all_available_tests`, `print_available_tools`). Std-only, no dependencies.
+
+## Before you delete it
+
+Retained deliberately, and **not** wired into the gate on purpose. Issue #1716 allows wiring a tool
+in only when it checks something no existing lane does — this one qualifies on subject matter
+(nothing in CQLite's stable gate runs Miri/Valgrind/ASan) but **Miri and ASan require a nightly
+toolchain**, which `docs/development/ci-toolchain-policy.md` keeps out of the stable gate (the same
+reason `fuzz/` is its own excluded workspace). Deletion is permitted by #1716 only for a tool that
+duplicates a live gate check entirely, which this does not. Both the "wire it up" and the "delete
+it" calls belong to epic #1688 (decision #9) — take them there, not here.

--- a/tools/memory-safety-runner/README.md
+++ b/tools/memory-safety-runner/README.md
@@ -35,6 +35,15 @@ Wraps three external memory-safety checkers behind one `MemorySafetyRunner` type
 (`run_miri_tests`, `run_valgrind_tests`, `run_asan_tests`, `run_stress_tests`,
 `run_all_available_tests`, `print_available_tools`). Std-only, no dependencies.
 
+## Its tests run only when you touch it
+
+No CI job or gate component runs workspace-wide tests, so this crate's own unit tests do not
+execute on an unrelated change — but the agent gate's `--lite` blast-radius maps a touched path to
+its package, so **editing anything in this directory (this README included) makes `--lite` run
+`cargo test -p memory-safety-runner --lib`**. Expect latent failures the first time that happens: on #1716,
+touching `tools/format-validator/README.md` ran that crate's tests for the first time and one had
+never been correct. Run them yourself first with `cargo test -p memory-safety-runner`.
+
 ## Before you delete it
 
 Retained deliberately, and **not** wired into the gate on purpose. Issue #1716 allows wiring a tool


### PR DESCRIPTION
## What this is

Epic #1688 finding **AK5**: three `tools/` crates are invoked by no CI workflow, no script and no
live doc, yet "read" as live tooling. This labels them, records a disposition for **all seven**
`tools/` crates, and pins that disposition with a new gate guard.

It also **corrects the issue's central premise**, with evidence. That correction is most of the
value here, so it leads.

---

## Correction 1 — a bare `cargo build` never compiled these crates

The issue says the three crates are *"compiled by every workspace build"* and prescribes removing
them from `default-members` as *"the build-cost win"*. **Both halves are wrong, and doing what the
issue asks would have made things worse.**

Cargo's default for `default-members`, when the workspace has a **root package**, is **that package
alone** — "all members" is the default only for a *virtual* workspace. This workspace has a root
package (`cqlite`). Verified empirically on **pre-change `origin/main`** in a detached worktree:

```console
$ git worktree add --detach /tmp/premain origin/main
$ grep -c default-members /tmp/premain/Cargo.toml
0
$ cd /tmp/premain && cargo tree --depth 0     # what a BARE `cargo build` targets
cqlite v0.16.1 (/tmp/premain)                 # ← the root package, and nothing else
```

So a bare `cargo build` at the root already compiled the **narrowest possible** set. I did add the
prescribed `default-members` list first (commit d96193b) — and it **expanded** the bare build from
**1 package to 14**, the exact opposite of the intent. It is reverted in 9210f7f; the final diff
adds no `default-members`, and both the root `Cargo.toml` and CLAUDE.md now carry a note explaining
why it must not be re-added.

### So what *does* pay for these crates?

Only an explicit `--workspace`/`--all-targets` (most notably the gate's
`cargo clippy --workspace --all-targets --all-features`) or `-p`. **Build-time delta, measured** —
16 cores, dependencies warm, per-package `cargo clean -p` then rebuild, `cargo build`:

| measured | wall |
|---|---|
| `cargo build --workspace`, whole workspace warm-start reference | 135.0 s |
| no-op rebuild (noise floor) | 7.5 s |
| **all three unwired crates, `--all-targets`** | **62.6 s** |
| └─ `format-validator`'s **4 binaries** alone | **51.1 s  ← 82%** |
| └─ `cqlite-validator` + `memory-safety-runner`, `--all-targets` | **4.9 s** |
| `format-validator`'s **lib** alone (still built either way — it is wired) | 0.8 s |

Raw log: `/tmp/cqlite-gates/1716/measure.txt` (method in `measure.sh`). Note these are `cargo build`
numbers, which include linking; `cargo clippy` skips final codegen/link for the linted crate, so the
gate's clippy pays **less** than 51.1 s for those bins. I measured `build` and am not extrapolating
a clippy number I did not take.

**The actionable consequence:** the orphan build cost is not spread across three crates, it is
**82% concentrated in `format-validator`'s four binaries** — and those are the one part I am *not*
authorized to remove (see Correction 2 and the follow-up proposal below). The two crates the issue
most clearly targets are worth **4.9 s**, which is why this PR does **not** exclude them from the
workspace: a second `Cargo.lock` per crate, loss of `-p` from the root, loss of
`clippy --workspace -D warnings` coverage, and inlining `version.workspace`/`edition.workspace` are
all a bad trade for 4.9 s.

## Correction 2 — `format-validator`'s library is WIRED; `exclude` would break three things

The issue offers *"or exclude from the workspace"*. For `format-validator` that would break:

1. **`tests/format-compatibility`** (package `format-compatibility-tests`) path-depends on it, and
   `tests/format-compatibility/tests/oa_format_compliance.rs` uses
   `format_validator::format_constants` and `::utils`. That package is its **own full-gate
   component** (`format-compat`) — so this library is on the gate's critical path.
2. **`scripts/tests/test_agent_gate_summary.sh`** uses `tools/format-validator/src/lib.rs` as the
   fixture for the gate's path→package **owners** resolution (which reads `cargo metadata`).
3. **`xtask/src/oom_audit/scope.rs:123`** asserts on a `tools/format-validator/` path.

Only its **four binaries** are orphaned. The crate stays a member; the README states the split.

## Correction 3 — `publish = false` was already landed

On **all seven** `tools/` crates, before this PR. Recording it rather than claiming it.

## Correction 4 — these crates' tests DO run, when your diff touches them (and one was wrong)

I initially wrote into CLAUDE.md that these crates' unit tests are "run by no automated lane and
never were". **That was false, and `--lite` proved it on my own branch.** No CI job or gate
component runs workspace-wide tests, but `--lite`'s blast-radius maps a touched path to its package
— so **editing only `tools/format-validator/README.md` made `--lite` run that crate's `--lib` tests
for the first time**, and `scoped-tests` FAILed:

```
thread 'tests::test_hex_dump_formatting' panicked at tools/format-validator/src/lib.rs:311:9:
assertion failed: dump.contains("48656c6c6f")
```

The **test** was wrong, not the code. `format_hex_dump` emits a conventional `hexdump -C` layout;
the assertion demanded an *unseparated* hex run that the function can never produce for any input.
Verified by probing the real function rather than reading it:

```text
00000000: 48 65 6c 6c 6f 2c 20 57  6f 72 6c 64 21 20 54 68  |Hello, World! Th|
00000010: 69 73 20 69 73 20 61 20  74 65 73 74 2e           |is is a test.|
contains unseparated "48656c6c6f" : false
contains spaced      "48 65 6c 6c 6f": true
```

So the expectation is corrected (and tightened — it now also pins the address prefix and the
post-gap half of the line). **The formatter is untouched.** 8/8 `format-validator` tests pass.

This is a pre-existing defect in never-executed code, but it is mine to fix because my diff is what
runs it — and note the prose waiver is **unavailable** here regardless: `bash
scripts/ci/classify-docs-only.sh` exits **1** on this diff (`Cargo.toml` → FULL PATH), so nothing
was waived and nothing was patched to force a green.

It also sharpens AK5's point: code nothing runs is not merely idle, it **rots undetected**. Both
CLAUDE.md and the READMEs now warn to expect latent failures the first time you touch a long-unwired
crate.

---

## AC step 1 — the census, run rather than assumed

Live paths only (`.github/`, `scripts/`, `xtask/`, `Makefile*`), archive excluded, by crate name
**and every declared binary name**:

| crate | live refs | disposition |
|---|---|---|
| `cqlite-validator` | **0** | unwired manual dev tool |
| `memory-safety-runner` | **0** | unwired manual dev tool |
| `format-validator` | 2 files, **neither an invocation** (path fixtures) | lib **wired**; 4 bins unwired |
| `cassandra-parity` | 11 | CI-wired |
| `flight-loadgen` | 32 | CI-wired |
| `ws0-corpus-gen` | 21 | CI-wired |
| `sstabledump-validator` | 2 (`scripts/ci/test-sstabledump-parity-gate.sh` builds **and runs** it) | CI-wired |

## What landed

- **Three READMEs** (`tools/{cqlite-validator,memory-safety-runner,format-validator}/README.md`) —
  each says what the tool is, that it is **NOT CI-wired**, how to build/run it, and why it was not
  deleted. `format-validator`'s documents the lib-wired / bins-unwired split and the `exclude` trap.
  `memory-safety-runner`'s records an honest wrinkle: it is **lib-only with no `[[bin]]` and no
  consumer**, so the issue's suggested `cargo run -p <name>` label is literally inapplicable —
  nothing in the repo can currently execute it.
- **Corrected doctrine** in the root `Cargo.toml` and CLAUDE.md's Workspace Structure section: the
  cargo `default-members` semantics, the recorded disposition, and when these crates' tests actually
  run (see Correction 4 — I got this wrong once myself and fixed it).
- **New gate guard** `scripts/tests/test_tools_crate_disposition.sh`, wired into the full gate's
  `tooling-tests` component. It needs **no cargo, python3, Docker or network** — filesystem and lists
  only, so it always runs and cannot be environment-dependent. It asserts every `tools/` crate is
  explicitly classified `WIRED`/`UNWIRED`/`MIXED`, that the lists are pairwise disjoint, that the
  on-disk set matches them exactly, that every recorded crate exists, and that every crate carrying
  orphaned targets carries a README that **states** it is not CI-wired. **Fails closed** on an absent
  or unmeasurable subject and refuses to pass vacuously.
  It deliberately does **not** grep-infer wiredness — a grep gets it wrong in both directions
  (`format-validator` is referenced twice purely as a path fixture; `ws0-corpus-gen` is wired via a
  binary name differing from its package name), and a guard whose FAIL agents learn to waive is worse
  than no guard. Wiredness is recorded by a human and reviewed in the diff.
  **Scope, stated in the guard itself:** it verifies a disposition was **recorded and labeled**, not
  that the record is **true**, and it is per-**crate** — an orphaned bin added to a `WIRED` crate
  passes unchanged. Both are accepted limitations (see "The guard was reduced" below).
- **Self-test** `test_tools_crate_disposition_selftest.sh`: **2 green controls + 12 negative
  controls**, no cargo. Each case substitutes the artifact in its own scratch tree; there is
  deliberately no path/env seam to redirect the guard. The green controls exist so a guard hardwired
  to refuse everything could not satisfy the red cases.

## The guard was reduced — 11 findings, all in one place

Review produced **11 Medium findings across 8 rounds (roborev jobs 75, 78, 79, 80, 82, 83, 85, 86).
Every one landed in a cargo-derived dependency cross-check I had added; zero landed in the
list-and-README part** that serves AK5's actual acceptance criteria. Each fix was correct, and the
family kept regenerating — the findings were, in order: a wrong data model (2 slots for a 3-state
fact), verification by grepping prose the author controls, a query narrowed to default features and
the host target, `|| true` masking real errors, a parser that proved it *ran* but not that it
*parsed*, over-derivation that rejected a legitimate shape, two independent live-half sources treated
as exclusive, and finally host-toolchain dependence.

**Round 8's second finding was decisive:** the cross-check's self-tests built scratch cargo workspaces
**outside** the repository, which do not inherit `rust-toolchain.toml` — so a **mandatory** full-gate
component's behaviour depended on the host's default toolchain. A flaky mandatory gate is a fleet-wide
liability, and that is a bad trade for a P3 labeling task. The deeper point: a *labeling* guard has no
business invoking cargo at all.

So the cross-check is **removed** (`dfc0129`). Gone with it: `workspace_dependents`,
`package_name_of`, `declared_bins`, `mixed_invoked_targets`, the `MIXED_INVOKED` list, and every cargo
invocation — and with them the whole failure class the last five rounds were about. **400 → 205
lines**, deterministic and offline.

**Kept, and never once the source of a finding:** classification, disjointness, on-disk matching,
existence, and the README label. Exactly what #1716 asked for.

**What is no longer claimed** — recorded in the guard, the gate header and CLAUDE.md rather than left
to be discovered: it verifies a disposition was *recorded and labeled*, not that the record is *true*;
and a `MIXED` crate's live-half claim is documented, not verified. **A guard that overpromises is worse
than a small one.** Verifying truth properly belongs to epic #1688 as its own issue.

This removed scope **I** added beyond the AC, which is mine to remove. **Option B — the derived
cross-check — is one revert away at `8ceabf4`**; it is genuinely stronger and was well covered by
then, and the trade is recorded here. I recommend the reduced form.

Two findings were also caught by **self-audit**, with no review round: `comm`'s exit status discarded
(an empty intersection is that check's PASS condition, so a comm failure would have silently certified
disjointness), and counts reaching `[ "$n" -gt 0 ]` unvalidated. Both survive in the reduced guard.
One trap from that fix is worth carrying forward: **`fail()` ends in `exit`, and an `exit` inside a
command substitution leaves only the subshell** — the parent carries on with an empty value.


## Known accepted gap — one fact written twice

The recorded disposition now lives in **two** places: `WIRED_TOOLS`/`UNWIRED_TOOLS` in the guard
(the enforcer) and the `tools/` block in CLAUDE.md (descriptive, so agents read it without opening
the guard). **Nothing asserts they agree** — the same shape CLAUDE.md warns about for the
`.roborev.toml` / census mirror, and it is called out here rather than left to be discovered.

I did not add a drift assert on purpose: it would have to parse CLAUDE.md prose, which is the
"second implementation whose correctness is only knowable by differential testing" trap. The guard
is the half that fails closed, and CLAUDE.md points at it by filename, so a reader who follows the
pointer lands on the authority. If the duplication proves to bite, the cheap fix is to delete the
enumeration from CLAUDE.md and keep only the pointer.

## Scope note

The guard + self-test go beyond the issue's literal text. Deliberate: this change's only mechanism
is *documentation*, which decays silently — `members` globs `tools/*`, so the next crate joins with
no statement of whether anything runs it, and a deleted README is invisible. Without the guard, AK5
regresses to exactly the state it was filed for. Flagging it rather than burying it.

## Follow-up proposed (owner decision, not taken here)

`format-validator`'s four unwired binaries are **82% (51.1 s)** of the orphan build cost, paid on
every `--workspace --all-targets` build. Removing that needs deletion or feature-gating, and:
- this issue authorizes deletion **only** for a tool that "duplicates a live gate check entirely",
  which these do not — so deletion is a **product decision** and not mine to take;
- `required-features` gating does **not** work here, because the gate's clippy passes
  `--all-features`, which re-enables any feature the bins are gated behind.

Raised as `coord:follow-up-proposed` on #1716 for epic #1688 decision #9.

## Verification

- `bash scripts/tests/test_tools_crate_disposition.sh` → **PASS** (4 wired, 2 unwired, 1 mixed;
  7/7 on-disk crates classified; 3/3 label-bearing READMEs verified)
- `bash scripts/tests/test_tools_crate_disposition_selftest.sh` → **PASS** (2 green + 12 negative
  controls, no cargo)
- `cargo test -p format-validator --lib` → **PASS** 8/8 (was 7/8 before the corrected assertion)
- `scripts/agent-gate.sh --lite` → **PASS** at `dfc0129` (`tree-integrity: PASS`); 12 lite rounds run
- `tooling-tests` component exercised end-to-end via `--only tooling-tests` → **PASS (1044s)**, with
  the guard and its self-test both executing inside the real component
- roborev: 8 rounds, 11 findings, all resolved or removed with the machinery they were in
- Full `scripts/agent-gate.sh` SUMMARY (the gate of record): _pasted below by the closer._

Closes #1716.
