### PR TITLE
fix(#1717): AK7 — read-sstable renders values via the canonical ValueFormatter

### DIFF
--- a/cqlite-cli/src/commands/read_sstable.rs
+++ b/cqlite-cli/src/commands/read_sstable.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::cli::OutputFormat;
+use crate::output::value_fmt::ValueFormatter;
 
 /// Execute the read-sstable command
 #[allow(clippy::too_many_arguments)]
@@ -208,7 +209,7 @@ fn display_table_format(
         ]);
 
         if !keys_only {
-            let value_str = format_value(value, raw);
+            let value_str = render_scan_row(value, raw);
             row.add_cell(Cell::new(&value_str));
         }
 
@@ -237,7 +238,7 @@ fn display_json_format(
                 "key": key_str,
             })
         } else {
-            let value_str = format_value(value, raw);
+            let value_str = render_scan_row(value, raw);
             serde_json::json!({
                 "table_id": table_id_str,
                 "key": key_str,
@@ -275,7 +276,7 @@ fn display_csv_format(
         if keys_only {
             wtr.write_record([&table_id_str, &key_str])?;
         } else {
-            let value_str = format_value(value, raw);
+            let value_str = render_scan_row(value, raw);
             wtr.write_record([&table_id_str, &key_str, &value_str])?;
         }
     }
@@ -291,28 +292,45 @@ fn format_row_key(key: &RowKey, _raw: bool) -> String {
     format!("{:?}", key)
 }
 
-/// Format a scanned row's value for display.
+/// Render a scanned row for display.
 ///
 /// Issue #1334: the scan carries the row as a [`ScanRow`]. A live row is rendered
-/// as a `{name: value, …}` object (using each cell value's `Display`); a marker
-/// (row tombstone / null row) renders its inner value.
-fn format_value(value: &ScanRow, raw: bool) -> String {
+/// as a `{name: value, …}` object; a marker (row tombstone / null row) renders its
+/// inner value.
+///
+/// Issue #1717 (AK7): every VALUE is rendered by the canonical
+/// [`ValueFormatter`] — the same cqlsh-compatible mapping the table/JSON/CSV
+/// output writers use. This function previously hand-rolled its own
+/// `format_value`, rendering each cell with `Value`'s `Display` impl (a
+/// debug-oriented, type-tagged form: `'text'`, `BLOB(n bytes)`,
+/// `TIMESTAMP(1759713126059)`, `counter:41`, `UUID(<unhyphenated hex>)`), so a
+/// formatting fix landing in `ValueFormatter` silently missed `read-sstable`.
+/// That fork is gone: the only logic left here is the row-shape wrapper, which
+/// contains no value formatting of its own.
+///
+/// `raw` is unchanged and deliberately NOT routed through the formatter: it is a
+/// verbatim structural dump of the scan carrier (`Debug`), not a value rendering.
+pub fn render_scan_row(row: &ScanRow, raw: bool) -> String {
     if raw {
         // Show raw representation
-        return format!("{:?}", value);
+        return format!("{:?}", row);
     }
-    match value {
-        ScanRow::Row(cells) => {
-            let inner: Vec<String> = cells
-                .iter()
-                .map(|(name, v)| format!("{}: {}", name, v))
-                .collect();
-            format!("{{{}}}", inner.join(", "))
-        }
+    match row {
+        ScanRow::Row(cells) => render_cells(cells.iter().map(|(name, v)| (name.as_ref(), v))),
         // A raw undecoded fallback row renders its bytes as a single "data" blob.
         ScanRow::RawRow(bytes) => {
-            format!("{{data: {}}}", cqlite_core::Value::blob(bytes.clone()))
+            let blob = Value::blob(bytes.clone());
+            render_cells(std::iter::once(("data", &blob)))
         }
-        ScanRow::Marker(v) => format!("{}", v),
+        ScanRow::Marker(v) => ValueFormatter::format_value(v),
     }
+}
+
+/// Render `name: value` cells as a `{…}` object, formatting every value with the
+/// canonical [`ValueFormatter`] (issue #1717).
+fn render_cells<'a>(cells: impl Iterator<Item = (&'a str, &'a Value)>) -> String {
+    let inner: Vec<String> = cells
+        .map(|(name, v)| format!("{}: {}", name, ValueFormatter::format_value(v)))
+        .collect();
+    format!("{{{}}}", inner.join(", "))
 }

--- a/cqlite-cli/tests/issue_1717_read_sstable_value_formatter_parity.rs
+++ b/cqlite-cli/tests/issue_1717_read_sstable_value_formatter_parity.rs
@@ -1,0 +1,483 @@
+//! Issue #1717 (AK7): `read-sstable` renders values with the canonical
+//! [`ValueFormatter`] — there is no second formatter.
+//!
+//! `cqlite-cli/src/commands/read_sstable.rs` used to hand-roll a local
+//! `format_value` that rendered each cell with `Value`'s `Display` impl (a
+//! debug-oriented, type-tagged form: `'text'`, `BLOB(n bytes)`,
+//! `TIMESTAMP(1759713126059)`, `counter:41`, `UUID(<unhyphenated hex>)`), while
+//! every other CLI writer used `ValueFormatter`. Two formatters =
+//! N-copies-of-truth: a formatting fix landed in one and `read-sstable`
+//! silently diverged.
+//!
+//! What is locked here, over REAL corpus fixtures (never synthesized values):
+//!
+//!   1. PARITY — for every cell of every row of every fixture table,
+//!      `render_scan_row` output equals the rendering composed independently
+//!      from `ValueFormatter::format_value`. This is the acceptance criterion
+//!      "read_sstable's rendering == ValueFormatter's rendering for every value
+//!      type present".
+//!   2. THE FORK IS GONE — wherever the deleted `Display`-based rendering
+//!      differs from the canonical one, the output must NOT be the legacy form.
+//!      Reverting `read_sstable.rs` to `format!("{}", v)` fails this.
+//!   3. TYPE COVERAGE — each fixture must actually surface the value variants it
+//!      is here for (per-CASE assertion, so a case cannot silently contribute
+//!      nothing behind a green suite; issue #3220).
+//!   4. WIRING — the shipped `cqlite read-sstable --format json` stdout carries
+//!      those canonical renderings and none of the legacy type tags, so the
+//!      parity above is the behavior a user actually gets.
+//!
+//! `--raw` is deliberately unchanged: it is a structural `Debug` dump of the
+//! scan carrier, not a value rendering (locked in AC 1's raw check).
+//!
+//! Gated on `state_machine` (as the sibling `read_sstable_stdout_tests.rs` is):
+//! the `read-sstable` subcommand only exists with it.
+
+#![cfg(feature = "state_machine")]
+
+use cqlite_cli::commands::read_sstable::render_scan_row;
+use cqlite_cli::output::value_fmt::ValueFormatter;
+use cqlite_core::types::{ScanRow, Value};
+use cqlite_core::{storage::sstable::reader::SSTableReader, Config as CoreConfig};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// A corpus table this test reads, with the value variants it must surface.
+struct Fixture {
+    keyspace: &'static str,
+    table: &'static str,
+    /// Top-level cell variants this table MUST yield (measured from the corpus).
+    /// Nested variants (a UDT inside a list, …) are covered transitively by the
+    /// recursive parity assertion, so they are not listed here.
+    required_variants: &'static [&'static str],
+    /// `true` for a table of the four documented dataset keyspaces (always in
+    /// the fetched corpus). A `false` table may be absent on an older dataset
+    /// pin — but if its keyspace is present, the table must be too.
+    must_run: bool,
+}
+
+/// Fixtures chosen so their union covers every value variant the corpus carries
+/// at the top level: 23 of the 27 `Value` variants (`Null`, `Varint`, `Json` and
+/// `Tuple` do not occur as top-level cells anywhere in the corpus).
+const FIXTURES: &[Fixture] = &[
+    Fixture {
+        keyspace: "test_basic",
+        table: "simple_table",
+        required_variants: &[
+            "BigInt",
+            "Blob",
+            "Boolean",
+            "Date",
+            "Decimal",
+            "Duration",
+            "Float",
+            "Float32",
+            "Inet",
+            "Integer",
+            "SmallInt",
+            "Text",
+            "Time",
+            "Timestamp",
+            "TinyInt",
+            "Uuid",
+        ],
+        must_run: true,
+    },
+    Fixture {
+        keyspace: "test_basic",
+        table: "counters",
+        required_variants: &["Counter"],
+        must_run: true,
+    },
+    Fixture {
+        keyspace: "test_collections",
+        table: "collection_table",
+        required_variants: &["List", "Map", "Set"],
+        must_run: true,
+    },
+    Fixture {
+        // Nested UDTs inside list/set/map values.
+        keyspace: "test_collections",
+        table: "collections_with_udts",
+        required_variants: &["List", "Map", "Set"],
+        must_run: true,
+    },
+    Fixture {
+        keyspace: "test_collections",
+        table: "frozen_collections_table",
+        required_variants: &["Frozen", "Set"],
+        must_run: true,
+    },
+    Fixture {
+        keyspace: "test_wide_rows",
+        table: "chat_messages",
+        required_variants: &["Text", "Timestamp", "Tombstone", "Uuid"],
+        must_run: true,
+    },
+    Fixture {
+        // Top-level multicell UDT; only in the wider dataset pin.
+        keyspace: "test_types",
+        table: "cx_multicell_udt_collection_paths",
+        required_variants: &["Udt"],
+        must_run: false,
+    },
+];
+
+/// The `Value` variant name, used for per-case type-coverage assertions.
+fn variant_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "Null",
+        Value::Boolean(_) => "Boolean",
+        Value::TinyInt(_) => "TinyInt",
+        Value::SmallInt(_) => "SmallInt",
+        Value::Integer(_) => "Integer",
+        Value::BigInt(_) => "BigInt",
+        Value::Counter(_) => "Counter",
+        Value::Float32(_) => "Float32",
+        Value::Float(_) => "Float",
+        Value::Text(_) => "Text",
+        Value::Blob(_) => "Blob",
+        Value::Timestamp(_) => "Timestamp",
+        Value::Date(_) => "Date",
+        Value::Time(_) => "Time",
+        Value::Uuid(_) => "Uuid",
+        Value::Varint(_) => "Varint",
+        Value::Decimal { .. } => "Decimal",
+        Value::Duration { .. } => "Duration",
+        Value::Json(_) => "Json",
+        Value::List(_) => "List",
+        Value::Set(_) => "Set",
+        Value::Map(_) => "Map",
+        Value::Tuple(_) => "Tuple",
+        Value::Udt(_) => "Udt",
+        Value::Frozen(_) => "Frozen",
+        Value::Tombstone(_) => "Tombstone",
+        Value::Inet(_) => "Inet",
+    }
+}
+
+/// Candidate dataset roots, in the order they are probed. EVERY root is walked
+/// for EVERY table (issue #3220): neither root is a superset of the other, so
+/// committing to one by keyspace can silently skip a table the other holds.
+fn candidate_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(env_root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        roots.push(PathBuf::from(env_root));
+    }
+    let checkout = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(|p| p.join("test-data/datasets"));
+    if let Some(checkout) = checkout {
+        if !roots.contains(&checkout) {
+            roots.push(checkout);
+        }
+    }
+    roots
+}
+
+/// Does any candidate root hold this keyspace directory?
+fn keyspace_present(keyspace: &str) -> bool {
+    candidate_roots()
+        .iter()
+        .any(|root| root.join("sstables").join(keyspace).is_dir() || root.join(keyspace).is_dir())
+}
+
+/// Resolve a `*-Data.db` for `<keyspace>/<table>` by walking every candidate
+/// root (with and without the optional `sstables/` layer) and every UUID-suffixed
+/// table directory. Returns the lexicographically first match so the choice is
+/// deterministic.
+fn find_table_data_db(keyspace: &str, table: &str) -> Option<PathBuf> {
+    let prefix = format!("{}-", table);
+    for root in candidate_roots() {
+        for keyspace_dir in [root.join("sstables").join(keyspace), root.join(keyspace)] {
+            let Ok(entries) = std::fs::read_dir(&keyspace_dir) else {
+                continue;
+            };
+            let mut table_dirs: Vec<PathBuf> = entries
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.is_dir()
+                        && p.file_name()
+                            .map(|n| n.to_string_lossy().starts_with(&prefix))
+                            .unwrap_or(false)
+                })
+                .collect();
+            table_dirs.sort();
+            for table_dir in table_dirs {
+                let Ok(files) = std::fs::read_dir(&table_dir) else {
+                    continue;
+                };
+                let mut data_files: Vec<PathBuf> = files
+                    .flatten()
+                    .map(|e| e.path())
+                    .filter(|p| p.to_string_lossy().ends_with("-Data.db"))
+                    .collect();
+                data_files.sort();
+                if let Some(first) = data_files.into_iter().next() {
+                    return Some(first);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Read every entry of an SSTable exactly as `read-sstable` does.
+async fn read_scan_rows(path: &Path) -> Vec<ScanRow> {
+    let config = CoreConfig::default();
+    let platform = Arc::new(
+        cqlite_core::platform::Platform::new(&config)
+            .await
+            .expect("platform init"),
+    );
+    let reader = SSTableReader::open(path, &config, platform)
+        .await
+        .unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    reader
+        .get_all_entries()
+        .await
+        .unwrap_or_else(|e| panic!("read entries of {}: {e}", path.display()))
+        .into_iter()
+        .map(|(_table_id, _key, row)| row)
+        .collect()
+}
+
+/// The canonical expectation, composed INDEPENDENTLY of `read_sstable.rs`:
+/// the `{name: value, …}` row shape with every value rendered by
+/// `ValueFormatter::format_value`.
+fn canonical_rendering(row: &ScanRow) -> String {
+    let cells: Vec<String> = match row {
+        ScanRow::Row(cells) => cells
+            .iter()
+            .map(|(name, v)| format!("{}: {}", name, ValueFormatter::format_value(v)))
+            .collect(),
+        ScanRow::RawRow(bytes) => vec![format!(
+            "data: {}",
+            ValueFormatter::format_value(&Value::blob(bytes.clone()))
+        )],
+        ScanRow::Marker(v) => return ValueFormatter::format_value(v),
+    };
+    format!("{{{}}}", cells.join(", "))
+}
+
+/// The DELETED fork, reproduced here ONLY as a negative oracle: `Value`'s
+/// `Display` impl per cell. Nothing in `cqlite-cli` may render values this way
+/// again — assertion 2 fails if `read_sstable.rs` returns to it.
+fn legacy_display_rendering(row: &ScanRow) -> String {
+    let cells: Vec<String> = match row {
+        ScanRow::Row(cells) => cells
+            .iter()
+            .map(|(name, v)| format!("{}: {}", name, v))
+            .collect(),
+        ScanRow::RawRow(bytes) => vec![format!("data: {}", Value::blob(bytes.clone()))],
+        ScanRow::Marker(v) => return format!("{}", v),
+    };
+    format!("{{{}}}", cells.join(", "))
+}
+
+/// Top-level cell values of a scan row (a marker's inner value included, since
+/// that is what `read-sstable` renders for it).
+fn top_level_values(row: &ScanRow) -> Vec<Value> {
+    match row {
+        ScanRow::Row(cells) => cells.iter().map(|(_n, v)| v.clone()).collect(),
+        ScanRow::RawRow(bytes) => vec![Value::blob(bytes.clone())],
+        ScanRow::Marker(v) => vec![v.clone()],
+    }
+}
+
+/// AC 1/2/3: parity, fork-is-gone and per-case type coverage over the corpus.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_sstable_value_rendering_is_value_formatter() {
+    let resolved: Vec<(&Fixture, Option<PathBuf>)> = FIXTURES
+        .iter()
+        .map(|f| (f, find_table_data_db(f.keyspace, f.table)))
+        .collect();
+
+    // Corpus entirely absent (a checkout without the fetched Data.db binaries):
+    // skip loudly. Any fixture found means the corpus IS present, and then every
+    // `must_run` fixture must be found too — a partial corpus fails, it never
+    // quietly narrows coverage.
+    if resolved.iter().all(|(_f, p)| p.is_none()) {
+        eprintln!(
+            "SKIP: no fixture Data.db found under any candidate dataset root \
+             (run test-data/scripts/fetch-datasets.sh and export the printed \
+             CQLITE_DATASETS_ROOT)"
+        );
+        return;
+    }
+
+    let mut diverging_variants: BTreeSet<&'static str> = BTreeSet::new();
+
+    for (fixture, path) in resolved {
+        let path = match path {
+            Some(path) => path,
+            None if fixture.must_run => panic!(
+                "fixture {}/{} not found under any candidate dataset root, but the \
+                 corpus is present — partial corpus, coverage would silently narrow",
+                fixture.keyspace, fixture.table
+            ),
+            None => {
+                // Optional fixture: absent keyspace is fine, absent table is not.
+                assert!(
+                    !keyspace_present(fixture.keyspace),
+                    "keyspace {} is present but table {} is missing from it",
+                    fixture.keyspace,
+                    fixture.table
+                );
+                eprintln!(
+                    "NOTE: optional fixture {}/{} absent from this dataset pin",
+                    fixture.keyspace, fixture.table
+                );
+                continue;
+            }
+        };
+
+        let rows = read_scan_rows(&path).await;
+        assert!(
+            !rows.is_empty(),
+            "fixture {}/{} ({}) yielded 0 rows — a dataset-dependent case must \
+             never pass on an empty read",
+            fixture.keyspace,
+            fixture.table,
+            path.display()
+        );
+
+        let mut observed_variants: BTreeSet<&'static str> = BTreeSet::new();
+        let mut cells_checked = 0usize;
+
+        for row in &rows {
+            let rendered = render_scan_row(row, false);
+            let canonical = canonical_rendering(row);
+            assert_eq!(
+                rendered, canonical,
+                "read-sstable rendering diverges from ValueFormatter for {}/{}",
+                fixture.keyspace, fixture.table
+            );
+
+            let legacy = legacy_display_rendering(row);
+            if legacy != canonical {
+                assert_ne!(
+                    rendered, legacy,
+                    "read-sstable fell back to the deleted Display-based fork for {}/{}",
+                    fixture.keyspace, fixture.table
+                );
+            }
+
+            // `--raw` is a structural dump of the carrier, unchanged by #1717.
+            assert_eq!(render_scan_row(row, true), format!("{:?}", row));
+
+            for value in top_level_values(row) {
+                let name = variant_name(&value);
+                observed_variants.insert(name);
+                if ValueFormatter::format_value(&value) != format!("{}", value) {
+                    diverging_variants.insert(name);
+                }
+                cells_checked += 1;
+            }
+        }
+
+        assert!(
+            cells_checked > 0,
+            "fixture {}/{} produced rows but no cells to compare",
+            fixture.keyspace,
+            fixture.table
+        );
+        for required in fixture.required_variants {
+            assert!(
+                observed_variants.contains(required),
+                "fixture {}/{} did not surface a {} value (observed: {:?}) — the \
+                 case is no longer covering the type it exists for",
+                fixture.keyspace,
+                fixture.table,
+                required,
+                observed_variants
+            );
+        }
+    }
+
+    // The two formatters really do differ, so assertion 2 above is not vacuous.
+    for expected in [
+        "Blob",
+        "Counter",
+        "Date",
+        "Decimal",
+        "Duration",
+        "Frozen",
+        "Text",
+        "Time",
+        "Timestamp",
+        "Tombstone",
+        "Uuid",
+    ] {
+        assert!(
+            diverging_variants.contains(expected),
+            "expected {} to diverge between Display and ValueFormatter \
+             (observed diverging: {:?})",
+            expected,
+            diverging_variants
+        );
+    }
+}
+
+/// AC 4 (wiring): the shipped binary's `--format json` stdout carries the
+/// canonical renderings and none of the legacy type tags.
+#[test]
+fn read_sstable_json_stdout_carries_canonical_renderings() {
+    let Some(path) = find_table_data_db("test_basic", "simple_table") else {
+        eprintln!("SKIP: test_basic/simple_table Data.db fixture not present");
+        return;
+    };
+
+    let rows = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime")
+        .block_on(read_scan_rows(&path));
+    assert!(!rows.is_empty(), "simple_table yielded 0 rows");
+    let expected: BTreeSet<String> = rows.iter().map(canonical_rendering).collect();
+
+    let output = assert_cmd::Command::cargo_bin("cqlite")
+        .expect("cqlite binary should be built for integration tests")
+        .args(["read-sstable"])
+        .arg(&path)
+        .args(["--format", "json", "--limit", "5"])
+        .output()
+        .expect("read-sstable should execute");
+    assert!(
+        output.status.success(),
+        "read-sstable exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("stdout is not JSON: {e}"));
+    assert!(!entries.is_empty(), "read-sstable emitted no JSON entries");
+
+    for entry in &entries {
+        let value = entry
+            .get("value")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("entry without a string `value`: {entry}"));
+        assert!(
+            expected.contains(value),
+            "read-sstable emitted a rendering that is not ValueFormatter's: {value}"
+        );
+    }
+
+    // Legacy `Display` type tags that the deleted fork emitted for this table.
+    for tag in [
+        "BLOB(",
+        "TIMESTAMP(",
+        "DATE(",
+        "DECIMAL(",
+        "DURATION(",
+        "UUID(",
+        "TIME(",
+    ] {
+        assert!(
+            !stdout.contains(tag),
+            "legacy Display type tag {tag:?} is back in read-sstable stdout"
+        );
+    }
+}

--- a/cqlite-cli/tests/issue_1717_read_sstable_value_formatter_parity.rs
+++ b/cqlite-cli/tests/issue_1717_read_sstable_value_formatter_parity.rs
@@ -175,11 +175,16 @@ fn candidate_roots() -> Vec<PathBuf> {
     roots
 }
 
-/// Does any candidate root hold this keyspace directory?
+/// Are this keyspace's SSTable BINARIES present under any candidate root?
+///
+/// Measured by EVIDENCE — the presence of a `*-Data.db` — never by directory
+/// shape (#3220). `is_dir()` would be wrong here: `test-data/datasets/sstables/`
+/// ships git-TRACKED metadata directories (e.g. `test_types/` carries 116 tracked
+/// `.jsonl`/TOC/digest/Statistics files and ZERO committed `*-Data.db`), so a
+/// directory test answers `true` on every checkout from metadata alone and would
+/// turn an optional fixture's legitimate absence into a false failure.
 fn keyspace_present(keyspace: &str) -> bool {
-    candidate_roots()
-        .iter()
-        .any(|root| root.join("sstables").join(keyspace).is_dir() || root.join(keyspace).is_dir())
+    first_data_db(keyspace, None).is_some()
 }
 
 /// Resolve a `*-Data.db` for `<keyspace>/<table>` by walking every candidate
@@ -187,7 +192,14 @@ fn keyspace_present(keyspace: &str) -> bool {
 /// table directory. Returns the lexicographically first match so the choice is
 /// deterministic.
 fn find_table_data_db(keyspace: &str, table: &str) -> Option<PathBuf> {
-    let prefix = format!("{}-", table);
+    first_data_db(keyspace, Some(&format!("{}-", table)))
+}
+
+/// The one directory walk both presence questions are answered from: the first
+/// `*-Data.db` under `<candidate root>[/sstables]/<keyspace>/<table-dir>`, where
+/// `table_prefix` (when given) restricts the UUID-suffixed table directories to
+/// one table. `None` accepts any table, i.e. "does this keyspace have binaries".
+fn first_data_db(keyspace: &str, table_prefix: Option<&str>) -> Option<PathBuf> {
     for root in candidate_roots() {
         for keyspace_dir in [root.join("sstables").join(keyspace), root.join(keyspace)] {
             let Ok(entries) = std::fs::read_dir(&keyspace_dir) else {
@@ -198,9 +210,11 @@ fn find_table_data_db(keyspace: &str, table: &str) -> Option<PathBuf> {
                 .map(|e| e.path())
                 .filter(|p| {
                     p.is_dir()
-                        && p.file_name()
-                            .map(|n| n.to_string_lossy().starts_with(&prefix))
-                            .unwrap_or(false)
+                        && table_prefix.is_none_or(|prefix| {
+                            p.file_name()
+                                .map(|n| n.to_string_lossy().starts_with(prefix))
+                                .unwrap_or(false)
+                        })
                 })
                 .collect();
             table_dirs.sort();


### PR DESCRIPTION
Closes #1717 (AK7 — `read_sstable`: replace local `format_value` with canonical `ValueFormatter`).
Part of epic #1688 (dead code + pub-surface). Audit finding AK7, audit block 6.

## What changed

`cqlite-cli/src/commands/read_sstable.rs` hand-rolled its own `format_value`, rendering each cell
with `Value`'s `Display` impl — a debug-oriented, type-tagged form — while
`cqlite-cli/src/output/value_fmt.rs`'s `ValueFormatter` is the canonical cqlsh-compatible formatter
every other CLI output writer uses. Two formatters is the N-copies-of-truth disease in miniature: a
formatting fix lands in one and `read-sstable` silently diverges.

- The fork is **deleted**. The wrapper is now `render_scan_row`, and it contains **no value
  formatting of its own** — every value goes through `ValueFormatter::format_value` via a
  `render_cells` helper. All three `ScanRow` arms (`Row`, `RawRow`, `Marker`) route through it.
- **`ValueFormatter` was NOT modified** — `read-sstable` needed nothing it lacked, so there is no
  new formatter option and no residual fork.
- `--raw` is deliberately unchanged and NOT routed through the formatter: it is a verbatim
  structural `Debug` dump of the scan carrier, not a value rendering. A test pins that, so it
  cannot silently start or stop formatting.
- No JSON/CSV **export** formatting was touched (that is AE5 #1499's scope).

## Before/after divergence samples (required by the issue)

Measured over the whole fetched corpus (`CQLITE_DATASETS_ROOT=/data/datasets`, 155 `*-Data.db`,
every non-`system*` keyspace) with a throwaway harness that rendered each **real** cell value twice
— **before** = the deleted local `format_value`, **after** = the canonical `ValueFormatter`. The
harness ran *before* the fork was deleted; samples are verbatim corpus values, not synthesized.
Full table (incl. whole-row samples for 6 tables): `docs/` not required — reproduced below.

**15 of 23 corpus-observed value types change output. 8 are byte-for-byte identical.**

| Value type | before (deleted local `format_value`) | after (canonical `ValueFormatter`) |
|---|---|---|
| Text | `'information'` | `information` |
| Blob | `BLOB(66 bytes)` | `0xb078182a1e8805530d6728259713e09d…` (full lowercase hex) |
| Uuid | `UUID(795db24aa25111f0a18dd6726a637a4c)` | `795db24a-a251-11f0-a18d-d6726a637a4c` |
| Counter | `counter:41` | `41` |
| Timestamp | `TIMESTAMP(1759713126059)` | `2025-10-06 01:12:06.059+0000` |
| Date | `DATE(20257)` | `2025-06-18` |
| Time | `TIME(01:12:05.394017000)` | `01:12:05.394017000` |
| Decimal | `DECIMAL(scale=2, unscaled=[48, 54, 15])` | `31595.67` |
| Duration | `DURATION(0M 0D 46702000000000ns)` | `46702000000000ns` |
| Tombstone | `TOMBSTONE(CELL@1782341457458955)` | `<deleted@1782341457458955>` |
| Frozen | `FROZEN({'k': 'v'})` | `{k: v}` |
| Udt | `person_type{'active': true, 'age': 41, 'first_name': 'Alan', …}` | `{first_name: Alan, last_name: Turing, age: 41, active: true}` |
| List | `[TIMESTAMP(1734484327048)]` | `[2024-12-18 01:12:07.048+0000]` |
| Set | `{'but', 'save'}` | `{but, save}` |
| Map | `{'want': 104237}` | `{want: 104237}` |

Identical under both (no output change): `Boolean`, `TinyInt`, `SmallInt`, `Integer`, `BigInt`,
`Float32`, `Float` (f64), `Inet`.

`List`/`Set`/`Map`/`Frozen`/`Udt` are containers — they diverge exactly when they hold a diverging
element type and are byte-identical when they hold only non-diverging scalars (e.g.
`[23, 99, 42, 11]`, `{55, 563, 733}`). `Udt` additionally moves from **alphabetical** field order to
CQL **declaration** order, which is the cqlsh-compatible order.

Whole-row samples:

```
test_basic/counters
  BEFORE {like_count: counter:41, share_count: counter:35, total_interactions: counter:205}
  AFTER  {like_count: 41, share_count: 35, total_interactions: 205}

test_basic/multi_partition_table
  BEFORE {clustering_key_0: 'A', clustering_key_1: UUID(795db24aa25111f0a18dd6726a637a4c), name: 'Mrs'}
  AFTER  {clustering_key_0: A, clustering_key_1: 795db24a-a251-11f0-a18d-d6726a637a4c, name: Mrs}

test_collections/collections_with_udts   (nested UDT: field order + quoting)
  BEFORE {addresses: [FROZEN(address_type{'city': 'Alyssafurt', 'state': 'IL', 'street': '07372 Mary Shoals Suite 758', …})]}
  AFTER  {addresses: [{street: 07372 Mary Shoals Suite 758, city: Alyssafurt, state: IL, …}]}
```

Every row above is the divergence the issue describes, and the AFTER column is the correct
behavior: `read-sstable` was the only writer still emitting the debug-oriented form.

**One ergonomics change worth calling out explicitly rather than leaving in the table:** `Blob` now
renders as full lowercase hex instead of `BLOB(n bytes)`, so a 457-byte blob becomes ~916 characters
in a human-facing inspection command. That is the correct canonical/cqlsh behavior and the issue
forbids adding formatter options speculatively, so it ships as-is — flagged for visibility, and
carried into the nit follow-up below.

## Tests

`cqlite-cli/tests/issue_1717_read_sstable_value_formatter_parity.rs` (2 tests, corpus-backed):

1. `read_sstable_value_rendering_is_value_formatter` — over 7 corpus fixtures, asserts
   `render_scan_row(row) == ` an independently-composed `ValueFormatter` expectation for every row,
   plus a **negative oracle** (the deleted fork is reproduced in the test and `assert_ne!` fires if
   `read_sstable` ever falls back to it), plus per-fixture `required_variants` type coverage, plus
   a `--raw`-is-unchanged assertion. It ends by asserting the two formatters **genuinely diverge**
   for 11 named variants, so the equality assertion cannot pass vacuously.
2. `read_sstable_json_stdout_carries_canonical_renderings` — **wiring evidence**: spawns the
   shipped `cqlite` binary, runs `read-sstable --format json`, and asserts every emitted `value` is
   a canonical rendering **and** that the legacy type tags are absent from stdout.

Fail-closed properties: per-case `must_run` (a partial corpus fails rather than silently narrowing
coverage), `!rows.is_empty()` and `cells_checked > 0` per fixture, so a dataset-dependent case can
never pass on an empty read.

## Acceptance criteria

- [x] Output-parity test: `read_sstable` rendering == `ValueFormatter` rendering for every value
      type present in the corpus fixtures.
- [x] Local `format_value` deleted; before/after divergence samples above.
- [ ] `scripts/agent-gate.sh` PASS — full gate of record runs in `flow-closer`; SUMMARY block
      pasted below when it lands.

## Verification record

- `--lite` re-cert: **PASS** at `c6ec22c` (`tree-integrity: PASS`, clean tree).
- **roborev round 1** (job 71, codex/gpt-5.6-sol): `RESULT: FAIL`, 1 Medium finding — genuine
  review (input 1046696 / cached 929280 tokens, vs the ~18.7k/0 vacuous baseline), all oracle keys
  PASS incl. `prompt-content: PASS (2/2)` and `sha-assert: PASS`.
- That finding, triaged **BLOCKER** (a false-red on a supported configuration) and fixed in
  `c6ec22c94`: `keyspace_present()` decided *binary* keyspace presence from `is_dir()`, but
  `test-data/datasets/sstables/test_types/` is a git-**tracked** metadata-only directory (116
  tracked files, **0** committed `*-Data.db`), so the "optional" fixture could never actually be
  skipped and **false-FAILED on any smaller/older dataset pin**. Presence is now measured from an
  actual `*-Data.db` via one shared walk (`first_data_db`) — evidence, not directory shape (#3220).
  **Verified RED→GREEN** against a reconstructed smaller pin (test_basic + test_collections +
  test_wide_rows, no `test_types`): pre-fix FAILS at `:322`, post-fix takes the optional-skip path.
- **roborev round 2** (job 77, codex/gpt-5.6-sol) on the fixed diff: **`RESULT: PASS`,
  `findings: NONE`** — genuine review (input 1560584 / cached 1414656 tokens), range
  `47a927d82..c6ec22c94` verified against the merge-base, all oracle keys PASS including
  `prompt-content: PASS (2/2)`, `vacuity-tier1/2: PASS`, `sha-assert: PASS`.

### Review provenance (stated plainly)

The Rust code review for this PR was **conducted by the driving lead, not by an independent
`rust-reviewer` agent**. `rust-reviewer` was spawned twice and produced **zero artifacts** both
times — no report, and the second spawn did not write even the output file it was contracted to
write. Rather than let "agent went idle" stand in for "review clean", the lead reviewed the diff
directly and recorded the result with its provenance: **0 blockers, 4 nits**, covering whether
every value path reaches `ValueFormatter`, whether the `first_data_db` refactor widened the table
prefix match (it did not — the pre-fix code already used `starts_with("<table>-")`), whether
`bytes.clone()` is a new copy (it is not — identical pre-fix), whether `pub fn render_scan_row` is
justified (it is — integration tests are a separate crate, so `pub(crate)` cannot work), and
whether the parity assertion is self-referential in the #3042 sense (it is not — the oracle *is*
`ValueFormatter` and the required property is identity to it, backstopped by a negative oracle, an
anti-vacuity guard, and a subprocess test on the shipped binary).

This is weaker than an independent review and is disclosed as such. **roborev is the independent
review of record here**, and it ran twice. The `rust-reviewer` failure is a fleet reliability
problem, not specific to this issue: any lane treating an idle notice as a clean verdict would ship
unreviewed code.

### Nits — batched to ONE follow-up issue at merge (never a re-verify round, per doctrine)

1. The parity test greens vacuously in a corpus-less checkout (all fixtures absent ⇒ blanket SKIP,
   still reports `ok`). Sanctioned for a fetch-only corpus with `missing-fixtures: FAIL-CLOSED
   (#2078)` as the gate-level backstop, but it could anchor on one of the 34 git-committed
   `*-Data.db` fixtures and be fail-closed independent of the gate.
2. The test's `canonical_rendering` duplicates the `{name: value, …}` row-shape join, so a
   *simultaneous* row-shape change in both it and `render_cells` would pass.
3. `pub fn render_scan_row` widens the CLI lib surface, and nothing in this repo detects
   public-API drift (#3366), so no other alarm would fire.
4. `read-sstable` Blob rendering is now full hex (~916 chars for a 457-byte blob) in a
   human-facing inspection command.
