### PR TITLE
fix(#1702): warn when OTel is requested on a build with observability compiled out

### DIFF
--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -27,6 +27,7 @@ mod formatter;
 mod output;
 mod script_executor;
 mod status_metrics;
+mod telemetry;
 #[cfg(feature = "write-support")]
 mod write_engine_config;
 
@@ -63,24 +64,12 @@ async fn run_main() -> Result<()> {
         (false, _) => "trace",
     };
 
-    // Initialise OpenTelemetry (Issue #1033, Epic #1031). `init` is always
-    // available: with the `observability` feature off (or CQLITE_OTEL_ENABLED
-    // unset) it returns an inert guard and installs nothing, preserving today's
-    // behavior. The guard must outlive command dispatch so its Drop flushes and
-    // shuts down OTel on normal exit — we bind it to `_otel_guard` for the whole
-    // run_main scope. init() MUST run before composing the subscriber so that
-    // observability::tracing_layer() (feature-gated) returns the live layer.
-    let otel_core_config = config.observability.to_core();
-    let _otel_guard = cqlite_core::observability::init(otel_core_config)
-        .map_err(|e| anyhow::anyhow!("Failed to initialize observability: {}", e))?;
-
-    // Install the unified tracing subscriber. The fmt layer writes to STDERR
-    // ONLY so stdout stays clean for --out json/csv (Issue #129). EnvFilter
-    // honours RUST_LOG when set, otherwise the -v/-q derived level. Because
-    // tracing-subscriber's `tracing-log` feature is enabled, `.init()` also
-    // installs a log->tracing bridge (LogTracer), so existing log::info!/debug!
-    // calls flow through tracing.
-    init_tracing_subscriber(log_level);
+    // Initialise OpenTelemetry + the unified tracing subscriber (Issue #1033,
+    // Epic #1031; ordering per issue #1702). The guard must outlive command
+    // dispatch so its Drop flushes and shuts OTel down on normal exit — bind it
+    // for the whole run_main scope. See `telemetry::init_telemetry` for why the
+    // two init orders differ by feature.
+    let _otel_guard = telemetry::init_telemetry(config.observability.to_core(), log_level)?;
 
     info!("Starting CQLite CLI v{}", env!("CARGO_PKG_VERSION"));
 
@@ -1200,44 +1189,6 @@ async fn shutdown_flush_and_exit(engine: &mut WriteEngine) -> Result<()> {
     std::process::exit(code);
 }
 
-/// Install the unified `tracing_subscriber` registry (Issue #1033, Epic #1031).
-///
-/// Replaces the previous bare `env_logger` init while preserving its behavior:
-/// - The fmt layer writes to STDERR ONLY, so stdout stays clean for
-///   `--out json`/`csv` (Issue #129 stdout hygiene).
-/// - The `EnvFilter` honours `RUST_LOG` when set, otherwise falls back to the
-///   `-v`/`-q`-derived `default_level` (same mapping as before).
-/// - `tracing-subscriber`'s `tracing-log` feature is enabled, so `.init()`
-///   installs a `log -> tracing` bridge (`LogTracer`); existing `log::info!` /
-///   `log::debug!` calls continue to appear.
-///
-/// When the `observability` feature is enabled, the OTel layer returned by
-/// `cqlite_core::observability::tracing_layer()` is composed in (it is `None`,
-/// hence a no-op layer, unless `init` installed a live provider). When the
-/// feature is off, the layer composition is compiled out entirely.
-fn init_tracing_subscriber(default_level: &str) {
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::util::SubscriberInitExt;
-    use tracing_subscriber::{fmt, EnvFilter};
-
-    // RUST_LOG overrides the verbosity-derived level, matching the old
-    // env_logger::from_env behavior.
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
-
-    // Write all formatted log/span output to STDERR only.
-    let fmt_layer = fmt::layer().with_writer(std::io::stderr);
-
-    let registry = tracing_subscriber::registry()
-        .with(env_filter)
-        .with(fmt_layer);
-
-    #[cfg(feature = "observability")]
-    let registry = registry.with(cqlite_core::observability::tracing_layer());
-
-    // `try_init` is tolerant of a subscriber already being set (e.g. in tests).
-    let _ = registry.try_init();
-}
 
 /// Initialize the database engine with proper configuration
 async fn initialize_database(db_path: &PathBuf, config: &config::Config) -> Result<Database> {

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -1189,7 +1189,6 @@ async fn shutdown_flush_and_exit(engine: &mut WriteEngine) -> Result<()> {
     std::process::exit(code);
 }
 
-
 /// Initialize the database engine with proper configuration
 async fn initialize_database(db_path: &PathBuf, config: &config::Config) -> Result<Database> {
     // Create the database directory if it doesn't exist

--- a/cqlite-cli/src/telemetry.rs
+++ b/cqlite-cli/src/telemetry.rs
@@ -25,7 +25,10 @@ use cqlite_core::observability::{ObservabilityConfig, ObservabilityGuard};
 /// is what makes that warning reach stderr instead of being a second silent
 /// no-op layered on the first.
 #[cfg(feature = "observability")]
-pub fn init_telemetry(core_cfg: ObservabilityConfig, log_level: &str) -> Result<ObservabilityGuard> {
+pub fn init_telemetry(
+    core_cfg: ObservabilityConfig,
+    log_level: &str,
+) -> Result<ObservabilityGuard> {
     let guard = cqlite_core::observability::init(core_cfg)
         .map_err(|e| anyhow::anyhow!("Failed to initialize observability: {}", e))?;
     init_tracing_subscriber(log_level);
@@ -35,7 +38,10 @@ pub fn init_telemetry(core_cfg: ObservabilityConfig, log_level: &str) -> Result<
 /// Feature-off counterpart: subscriber FIRST, so the #1702 warning is visible.
 /// See the feature-on twin above for the full ordering rationale.
 #[cfg(not(feature = "observability"))]
-pub fn init_telemetry(core_cfg: ObservabilityConfig, log_level: &str) -> Result<ObservabilityGuard> {
+pub fn init_telemetry(
+    core_cfg: ObservabilityConfig,
+    log_level: &str,
+) -> Result<ObservabilityGuard> {
     init_tracing_subscriber(log_level);
     cqlite_core::observability::init(core_cfg)
         .map_err(|e| anyhow::anyhow!("Failed to initialize observability: {}", e))

--- a/cqlite-cli/src/telemetry.rs
+++ b/cqlite-cli/src/telemetry.rs
@@ -1,0 +1,81 @@
+//! CLI telemetry startup: the OpenTelemetry `init` call and the unified
+//! `tracing_subscriber` registry, plus the ORDER in which the two must happen.
+//!
+//! Split out of `main.rs` so the ordering rule (and its issue-#1702 caveat)
+//! lives in one small, readable place instead of inline in `run_main`.
+
+use anyhow::Result;
+use cqlite_core::observability::{ObservabilityConfig, ObservabilityGuard};
+
+/// Initialise observability and install the logging subscriber, in the order
+/// this build requires, returning the RAII guard the caller must keep alive.
+///
+/// # Why the order differs by feature (issue #1702)
+///
+/// With `observability` ON, `cqlite_core::observability::init` MUST run first:
+/// it installs the OTel provider that `observability::tracing_layer()` returns,
+/// and that layer is composed into the registry below — a subscriber built
+/// before `init` would compose a dead layer and export nothing.
+///
+/// With `observability` OFF there is no layer to compose (the composition is
+/// `#[cfg]`ed out), so that constraint does not exist — and the reverse order is
+/// REQUIRED: the feature-off `init` emits the #1702 "OTel requested but compiled
+/// out" warning, and a `tracing` event emitted before a subscriber exists goes
+/// to the global no-op subscriber and is LOST. Installing the subscriber first
+/// is what makes that warning reach stderr instead of being a second silent
+/// no-op layered on the first.
+#[cfg(feature = "observability")]
+pub fn init_telemetry(core_cfg: ObservabilityConfig, log_level: &str) -> Result<ObservabilityGuard> {
+    let guard = cqlite_core::observability::init(core_cfg)
+        .map_err(|e| anyhow::anyhow!("Failed to initialize observability: {}", e))?;
+    init_tracing_subscriber(log_level);
+    Ok(guard)
+}
+
+/// Feature-off counterpart: subscriber FIRST, so the #1702 warning is visible.
+/// See the feature-on twin above for the full ordering rationale.
+#[cfg(not(feature = "observability"))]
+pub fn init_telemetry(core_cfg: ObservabilityConfig, log_level: &str) -> Result<ObservabilityGuard> {
+    init_tracing_subscriber(log_level);
+    cqlite_core::observability::init(core_cfg)
+        .map_err(|e| anyhow::anyhow!("Failed to initialize observability: {}", e))
+}
+
+/// Install the unified `tracing_subscriber` registry (Issue #1033, Epic #1031).
+///
+/// Replaces the previous bare `env_logger` init while preserving its behavior:
+/// - The fmt layer writes to STDERR ONLY, so stdout stays clean for
+///   `--out json`/`csv` (Issue #129 stdout hygiene).
+/// - The `EnvFilter` honours `RUST_LOG` when set, otherwise falls back to the
+///   `-v`/`-q`-derived `default_level` (same mapping as before).
+/// - `tracing-subscriber`'s `tracing-log` feature is enabled, so `.init()`
+///   installs a `log -> tracing` bridge (`LogTracer`); existing `log::info!` /
+///   `log::debug!` calls continue to appear.
+///
+/// When the `observability` feature is enabled, the OTel layer returned by
+/// `cqlite_core::observability::tracing_layer()` is composed in (it is `None`,
+/// hence a no-op layer, unless `init` installed a live provider). When the
+/// feature is off, the layer composition is compiled out entirely.
+fn init_tracing_subscriber(default_level: &str) {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    // RUST_LOG overrides the verbosity-derived level, matching the old
+    // env_logger::from_env behavior.
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    // Write all formatted log/span output to STDERR only.
+    let fmt_layer = fmt::layer().with_writer(std::io::stderr);
+
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer);
+
+    #[cfg(feature = "observability")]
+    let registry = registry.with(cqlite_core::observability::tracing_layer());
+
+    // `try_init` is tolerant of a subscriber already being set (e.g. in tests).
+    let _ = registry.try_init();
+}

--- a/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
+++ b/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
@@ -82,9 +82,14 @@ fn run(otel_enabled: Option<&str>) -> Output {
     out
 }
 
-/// Count occurrences of the warning's anchor token in a stream.
+/// Count occurrences of the warning's anchor phrase in a stream. Anchored on
+/// the "built WITHOUT the feature" clause — the part that IS the diagnosis —
+/// rather than on the env-var name, which the message only cites as one of
+/// several possible sources of `enabled`.
 fn warning_hits(stream: &str) -> usize {
-    stream.matches("CQLITE_OTEL_ENABLED is set").count()
+    stream
+        .matches("built WITHOUT the `observability` cargo feature")
+        .count()
 }
 
 /// AC1: the warning reaches STDERR on the real binary, exactly once, carrying

--- a/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
+++ b/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
@@ -54,8 +54,19 @@ const ARGS: &[&str] = &["info"];
 
 /// Run the shipped binary in a throwaway cwd (`info` creates `cqlite.db`
 /// relative to cwd, so this keeps the repo clean and each case isolated).
-/// `RUST_LOG` and every `CQLITE_OTEL_*` var are cleared first so an ambient
-/// environment can neither raise the filter above WARN nor pre-set the knob.
+///
+/// The child environment is built from EMPTY (`env_clear`) rather than filtered
+/// (roborev r2). Clearing only `RUST_LOG` + `CQLITE_OTEL_*` left two concrete
+/// machine-dependent failure modes: the child inherited `HOME` /
+/// `XDG_CONFIG_HOME`, so a developer's or fleet box's CQLite config file that
+/// enables telemetry made the "no warning when not requested" case fail; and it
+/// inherited the other env-bound CLI flags (`CQLITE_SCHEMA`, `CQLITE_DATA_DIR`,
+/// `CQLITE_OUT`, `CQLITE_WRITABLE`, … — every `env = "CQLITE_*"` in
+/// `cli_types.rs`), any of which can alter or break the `info` invocation. An
+/// allowlist has to be maintained against that growing list; starting from empty
+/// cannot drift. `HOME`/`XDG_CONFIG_HOME` are pointed at a fresh temp dir so
+/// config discovery finds nothing, and only `PATH` (+ `TMPDIR` when set) is
+/// carried over.
 fn run(otel_enabled: Option<&str>) -> Output {
     run_with(otel_enabled, None, &[])
 }
@@ -63,19 +74,24 @@ fn run(otel_enabled: Option<&str>) -> Output {
 /// As [`run`], but with an explicit `RUST_LOG` value and/or extra CLI flags, so
 /// the log-filtering cases below can drive `-q` and `RUST_LOG=error`.
 fn run_with(otel_enabled: Option<&str>, rust_log: Option<&str>, extra_args: &[&str]) -> Output {
-    let cwd = TempDir::new().expect("tempdir");
+    let cwd = TempDir::new().expect("tempdir for cwd");
+    // Held until after `output()` so the child's HOME still exists while it runs.
+    let home = TempDir::new().expect("tempdir for HOME");
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_cqlite"));
     cmd.args(extra_args)
         .args(ARGS)
         .current_dir(cwd.path())
-        .env_remove("RUST_LOG")
-        .env_remove("CQLITE_OTEL_ENABLED")
-        .env_remove("CQLITE_OTEL_ENDPOINT")
-        .env_remove("CQLITE_OTEL_PROTOCOL")
-        .env_remove("CQLITE_OTEL_SERVICE_NAME")
-        .env_remove("CQLITE_OTEL_SERVICE_VERSION")
-        .env_remove("CQLITE_OTEL_SAMPLING_RATIO")
-        .env_remove("CQLITE_OTEL_TIMEOUT_MS");
+        .env_clear()
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path());
+    // The one inherited variable the child genuinely needs, plus TMPDIR when the
+    // host sets it (temp-file creation honours it).
+    if let Ok(path) = std::env::var("PATH") {
+        cmd.env("PATH", path);
+    }
+    if let Ok(tmp) = std::env::var("TMPDIR") {
+        cmd.env("TMPDIR", tmp);
+    }
     if let Some(v) = otel_enabled {
         cmd.env("CQLITE_OTEL_ENABLED", v);
     }

--- a/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
+++ b/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
@@ -1,0 +1,148 @@
+//! Issue #1702 (epic #1686, AI2 "observability honesty"): END-TO-END wiring
+//! evidence that `CQLITE_OTEL_ENABLED=1` on a build with observability compiled
+//! out is VISIBLE on the shipped `cqlite` binary's STDERR — and that stdout is
+//! untouched.
+//!
+//! # The chain this proves
+//!
+//! ```text
+//! CQLITE_OTEL_ENABLED=1                                   (the operator knob)
+//!   -> cqlite_cli::config::Config::load                   (env/file/flag precedence)
+//!   -> config.observability.to_core()                      (ObservabilityConfig)
+//!   -> cqlite_cli::telemetry::init_telemetry               (the ORDERING fix, #1702)
+//!        subscriber FIRST with the feature off, so the warn has a sink
+//!   -> cqlite_core::observability::init                    (the emit site)
+//!   -> tracing fmt layer -> STDERR                        (never stdout, #129)
+//! ```
+//!
+//! It runs the REAL `CARGO_BIN_EXE_cqlite` executable, so unlike a library-level
+//! test it covers `main.rs`'s actual init order. That order is the crux: with the
+//! feature off, `init` used to run BEFORE the subscriber existed, so even a
+//! correct `tracing::warn!` inside `init` went to the global no-op subscriber and
+//! was lost — a second silent no-op stacked on the first. This test is red
+//! against that order even with the core fix in place.
+//!
+//! # Why feature-off only
+//!
+//! Gated `#![cfg(not(feature = "observability"))]`, matching the build under
+//! test: the emit exists ONLY in the `cfg(not(feature = "observability"))` copy
+//! of `observability::init`, so AC2 ("no such warning in a feature-enabled
+//! build") is structural — there is no compiled code to exercise. Driving the
+//! feature-on binary with `enabled = true` would also try to stand up a real
+//! OTLP exporter, which is not something a unit test should need.
+
+#![cfg(not(feature = "observability"))]
+
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+/// Substrings the warning must carry for an operator to act on it: the knob they
+/// set, the cargo feature that is missing (this is what separates "built without
+/// the feature" from "collector down"), and the consequence.
+const REQUIRED_SUBSTRINGS: &[&str] = &[
+    "CQLITE_OTEL_ENABLED",
+    "observability",
+    "will be emitted",
+    "NOT a collector",
+];
+
+/// A stable, cheap invocation that reaches `run_main` (so telemetry init runs)
+/// and writes deterministic bytes to stdout. `--version`/`--help` are NOT usable:
+/// clap handles them during `parse()` and exits before any init happens.
+const ARGS: &[&str] = &["info"];
+
+/// Run the shipped binary in a throwaway cwd (`info` creates `cqlite.db`
+/// relative to cwd, so this keeps the repo clean and each case isolated).
+/// `RUST_LOG` and every `CQLITE_OTEL_*` var are cleared first so an ambient
+/// environment can neither raise the filter above WARN nor pre-set the knob.
+fn run(otel_enabled: Option<&str>) -> Output {
+    let cwd = TempDir::new().expect("tempdir");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cqlite"));
+    cmd.args(ARGS)
+        .current_dir(cwd.path())
+        .env_remove("RUST_LOG")
+        .env_remove("CQLITE_OTEL_ENABLED")
+        .env_remove("CQLITE_OTEL_ENDPOINT")
+        .env_remove("CQLITE_OTEL_PROTOCOL")
+        .env_remove("CQLITE_OTEL_SERVICE_NAME")
+        .env_remove("CQLITE_OTEL_SERVICE_VERSION")
+        .env_remove("CQLITE_OTEL_SAMPLING_RATIO")
+        .env_remove("CQLITE_OTEL_TIMEOUT_MS");
+    if let Some(v) = otel_enabled {
+        cmd.env("CQLITE_OTEL_ENABLED", v);
+    }
+    let out = cmd.output().expect("cqlite binary runs");
+    assert!(
+        out.status.success(),
+        "`cqlite {}` must succeed; stderr:\n{}",
+        ARGS.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+/// Count occurrences of the warning's anchor token in a stream.
+fn warning_hits(stream: &str) -> usize {
+    stream.matches("CQLITE_OTEL_ENABLED is set").count()
+}
+
+/// AC1: the warning reaches STDERR on the real binary, exactly once, carrying
+/// every operator-actionable substring.
+#[test]
+fn otel_enabled_warns_on_stderr_of_the_shipped_binary() {
+    let out = run(Some("1"));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert_eq!(
+        warning_hits(&stderr),
+        1,
+        "expected EXACTLY ONE #1702 warning on stderr (zero = the silent no-op, \
+         or the subscriber was installed after init); stderr:\n{stderr}"
+    );
+    for needle in REQUIRED_SUBSTRINGS {
+        assert!(
+            stderr.contains(needle),
+            "stderr warning must contain {needle:?}; stderr:\n{stderr}"
+        );
+    }
+}
+
+/// Stdout hygiene (issue #129): the warning must NEVER appear on stdout, which
+/// carries machine-readable output, and stdout must be byte-identical to a run
+/// without the knob — the warning changes visibility, never data.
+#[test]
+fn warning_never_touches_stdout() {
+    let with_otel = run(Some("1"));
+    let without = run(None);
+
+    let stdout = String::from_utf8_lossy(&with_otel.stdout);
+    assert_eq!(
+        warning_hits(&stdout),
+        0,
+        "the #1702 warning must not appear on stdout; stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("observability"),
+        "no observability chatter may leak into stdout; stdout:\n{stdout}"
+    );
+    assert_eq!(
+        with_otel.stdout, without.stdout,
+        "stdout must be byte-identical with and without CQLITE_OTEL_ENABLED"
+    );
+}
+
+/// The negatives: an unset knob, and an explicitly falsey one, must both stay
+/// silent. Otherwise every default-build process start would print the warning.
+#[test]
+fn no_warning_when_otel_is_not_requested() {
+    for case in [None, Some("0"), Some("false")] {
+        let out = run(case);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert_eq!(
+            warning_hits(&stderr),
+            0,
+            "CQLITE_OTEL_ENABLED={case:?} must not warn; stderr:\n{stderr}"
+        );
+    }
+}

--- a/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
+++ b/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
@@ -9,7 +9,8 @@
 //! CQLITE_OTEL_ENABLED=1                                   (the operator knob)
 //!   -> cqlite_cli::config::Config::load                   (env/file/flag precedence)
 //!   -> config.observability.to_core()                      (ObservabilityConfig)
-//!   -> cqlite_cli::telemetry::init_telemetry               (the ORDERING fix, #1702)
+//!   -> cqlite-cli/src/telemetry.rs::init_telemetry         (the ORDERING fix, #1702)
+//!        (bin-only: `telemetry` is declared in main.rs, not lib.rs)
 //!        subscriber FIRST with the feature off, so the warn has a sink
 //!   -> cqlite_core::observability::init                    (the emit site)
 //!   -> tracing fmt layer -> STDERR                        (never stdout, #129)
@@ -38,14 +39,12 @@ use std::process::{Command, Output};
 use tempfile::TempDir;
 
 /// Substrings the warning must carry for an operator to act on it: the knob they
-/// set, the cargo feature that is missing (this is what separates "built without
-/// the feature" from "collector down"), and the consequence.
-const REQUIRED_SUBSTRINGS: &[&str] = &[
-    "CQLITE_OTEL_ENABLED",
-    "observability",
-    "will be emitted",
-    "NOT a collector",
-];
+/// set and the consequence. The missing cargo feature is NOT listed here: the
+/// bare needle "observability" would be satisfied by the fmt layer printing the
+/// event TARGET (`cqlite_core::observability:`) even if the message never named
+/// the feature, so it proves nothing — [`warning_hits`] anchors on the full
+/// "built WITHOUT the `observability` cargo feature" phrase instead, which does.
+const REQUIRED_SUBSTRINGS: &[&str] = &["CQLITE_OTEL_ENABLED", "will be emitted", "NOT a collector"];
 
 /// A stable, cheap invocation that reaches `run_main` (so telemetry init runs)
 /// and writes deterministic bytes to stdout. `--version`/`--help` are NOT usable:
@@ -84,13 +83,23 @@ fn run_with(otel_enabled: Option<&str>, rust_log: Option<&str>, extra_args: &[&s
         .env_clear()
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", home.path());
-    // The one inherited variable the child genuinely needs, plus TMPDIR when the
-    // host sets it (temp-file creation honours it).
-    if let Ok(path) = std::env::var("PATH") {
-        cmd.env("PATH", path);
-    }
-    if let Ok(tmp) = std::env::var("TMPDIR") {
-        cmd.env("TMPDIR", tmp);
+    // The few inherited variables the child genuinely needs. `env_clear` also
+    // drops the dynamic-loader search paths, so carry those: today's
+    // default-feature `cqlite` links no dylib that needs them, but a future
+    // default-on feature that does (the `duckdb-tests` amalgamation is the shape
+    // to watch) would fail every case here with a loader error that reads as a
+    // CLI bug. None of these can influence CQLite config resolution, so carrying
+    // them does not reintroduce the ambient-config drift `env_clear` fixed.
+    for var in [
+        "PATH",
+        "TMPDIR",
+        "LD_LIBRARY_PATH",
+        "DYLD_LIBRARY_PATH",
+        "DYLD_FALLBACK_LIBRARY_PATH",
+    ] {
+        if let Ok(v) = std::env::var(var) {
+            cmd.env(var, v);
+        }
     }
     if let Some(v) = otel_enabled {
         cmd.env("CQLITE_OTEL_ENABLED", v);
@@ -102,6 +111,18 @@ fn run_with(otel_enabled: Option<&str>, rust_log: Option<&str>, extra_args: &[&s
     assert!(
         out.status.success(),
         "`cqlite {} {}` must succeed; stderr:\n{}",
+        extra_args.join(" "),
+        ARGS.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Positive control for EVERY case in this file, including the ones whose only
+    // assertion is an absence (stdout hygiene, `-q`/`RUST_LOG=error` suppression):
+    // `cqlite info` prints its report on stdout, so empty stdout means the command
+    // did not actually do its work and an "absence" assertion would pass vacuously.
+    assert!(
+        !out.stdout.is_empty(),
+        "`cqlite {} {}` produced no stdout, so this run proves nothing about what \
+         it did or did not emit; stderr:\n{}",
         extra_args.join(" "),
         ARGS.join(" "),
         String::from_utf8_lossy(&out.stderr)

--- a/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
+++ b/cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs
@@ -57,9 +57,16 @@ const ARGS: &[&str] = &["info"];
 /// `RUST_LOG` and every `CQLITE_OTEL_*` var are cleared first so an ambient
 /// environment can neither raise the filter above WARN nor pre-set the knob.
 fn run(otel_enabled: Option<&str>) -> Output {
+    run_with(otel_enabled, None, &[])
+}
+
+/// As [`run`], but with an explicit `RUST_LOG` value and/or extra CLI flags, so
+/// the log-filtering cases below can drive `-q` and `RUST_LOG=error`.
+fn run_with(otel_enabled: Option<&str>, rust_log: Option<&str>, extra_args: &[&str]) -> Output {
     let cwd = TempDir::new().expect("tempdir");
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_cqlite"));
-    cmd.args(ARGS)
+    cmd.args(extra_args)
+        .args(ARGS)
         .current_dir(cwd.path())
         .env_remove("RUST_LOG")
         .env_remove("CQLITE_OTEL_ENABLED")
@@ -72,10 +79,14 @@ fn run(otel_enabled: Option<&str>) -> Output {
     if let Some(v) = otel_enabled {
         cmd.env("CQLITE_OTEL_ENABLED", v);
     }
+    if let Some(v) = rust_log {
+        cmd.env("RUST_LOG", v);
+    }
     let out = cmd.output().expect("cqlite binary runs");
     assert!(
         out.status.success(),
-        "`cqlite {}` must succeed; stderr:\n{}",
+        "`cqlite {} {}` must succeed; stderr:\n{}",
+        extra_args.join(" "),
         ARGS.join(" "),
         String::from_utf8_lossy(&out.stderr)
     );
@@ -148,6 +159,45 @@ fn no_warning_when_otel_is_not_requested() {
             warning_hits(&stderr),
             0,
             "CQLITE_OTEL_ENABLED={case:?} must not warn; stderr:\n{stderr}"
+        );
+    }
+}
+
+/// The warning is an ORDINARY `WARN` event, so it respects the operator's
+/// explicit filtering choice — it does NOT bypass the subscriber.
+///
+/// This pins that as a deliberate, documented property rather than leaving it an
+/// accident: `--quiet` maps to the `error` level (`main.rs`'s `-v`/`-q` mapping)
+/// and `RUST_LOG=error` sets the same floor through `EnvFilter`, so both hide a
+/// WARN. Making the warning unfilterable would mean writing to stderr from
+/// library code behind the subscriber's back, which is worse than respecting
+/// `-q`. The default level (no `RUST_LOG`, no `-q`) is asserted here too, so a
+/// future filter change that hid the warning by default cannot pass as "just
+/// filtering".
+#[test]
+fn warning_respects_the_operator_log_level() {
+    // Baseline: default level shows it. (Same property as the stderr test above,
+    // re-asserted here so the three cases are comparable in one place.)
+    let default_level = run_with(Some("1"), None, &[]);
+    assert_eq!(
+        warning_hits(&String::from_utf8_lossy(&default_level.stderr)),
+        1,
+        "the default log level must show the warning"
+    );
+
+    for (label, rust_log, extra) in [
+        ("--quiet", None, &["--quiet"][..]),
+        ("RUST_LOG=error", Some("error"), &[][..]),
+    ] {
+        let out = run_with(Some("1"), rust_log, extra);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert_eq!(
+            warning_hits(&stderr),
+            0,
+            "{label} filters WARN out, so the #1702 warning is suppressed BY \
+             DESIGN — the operator asked for errors only. If this case starts \
+             failing, something made the warning bypass the subscriber; that is \
+             a regression, not a fix. stderr:\n{stderr}"
         );
     }
 }

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -411,9 +411,18 @@ pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
     // the message must not assert that the env var is set. It names the env var
     // as the common spelling — operators grep for it — without claiming
     // provenance.
+    //
+    // The warning carries NO fields, deliberately (roborev r2, blocker). An
+    // earlier version attached `requested_endpoint = %cfg.endpoint`, i.e. a
+    // user-controlled URL rendered verbatim by the fmt layer. That is two defect
+    // classes in one field: an endpoint of the form
+    // `http://user:pass@collector:4317` writes credentials into the log, and an
+    // endpoint containing newlines/control characters can FORGE additional log
+    // lines. Neither is sanitized here — the field is simply gone, which removes
+    // the class instead of filtering it. Nothing diagnostic is lost: this build
+    // never contacts the endpoint, and the message says so.
     if cfg.enabled {
         tracing::warn!(
-            requested_endpoint = %cfg.endpoint,
             "OpenTelemetry export is ENABLED in configuration (CQLITE_OTEL_ENABLED / \
              --otel-enabled / config file) but this binary was built WITHOUT the \
              `observability` cargo feature: OpenTelemetry is compiled out, so NO \

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -385,8 +385,11 @@ pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
         cfg.verify_presence_oracle,
     );
 
-    // Issue #1702. Emitted with `tracing::warn!`, not `log::warn!` as the issue
-    // text spells it: `cqlite-core` has no `log` dependency at all — its facade
+    // Issue #1702. Emitted with `tracing::warn!`, not the `log` crate's `warn!`
+    // as the issue text spells it (that literal spelling is deliberately avoided
+    // here: the `logging_facade_tracing` guard scans this directory textually and
+    // is not comment-aware, so writing it out trips the residual-macro check):
+    // `cqlite-core` has no `log` dependency at all — its facade
     // is `tracing` (the #1706 log->tracing migration) — and `tracing` satisfies
     // the same constraint, since every host composes the fmt layer onto STDERR
     // so stdout stays clean for `--out json/csv` (issue #129).

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -391,11 +391,16 @@ pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
     // the same constraint, since every host composes the fmt layer onto STDERR
     // so stdout stays clean for `--out json/csv` (issue #129).
     //
-    // Fired unconditionally on each `init` call rather than behind a `Once`:
-    // `init` IS the once-per-process startup entry point (CLI `run_main`, the
-    // Flight server, `init_once` in both bindings), so "once at init" is already
-    // "once per process", while a `Once` would additionally make the warning
-    // unobservable to the second of two tests in one binary.
+    // Fired unconditionally on each `init` call rather than behind a `Once`.
+    // Every in-repo caller invokes `init` exactly once per process (CLI
+    // `run_main`, the Flight server, `init_once` in both bindings), so "once at
+    // init" is "once per process" for them — but that is a CONVENTION of those
+    // callers, NOT something this function enforces. `cqlite-core` is a library:
+    // an out-of-tree embedder that calls `init` per connection or per request
+    // with `enabled = true` on a default build gets one WARN per call. A `Once`
+    // would bound that, at the cost of making the warning unobservable to the
+    // second of two tests in one binary; if per-call spam ever shows up in the
+    // field, that is the tradeoff to revisit.
     //
     // `cfg.enabled` is the ONLY field a feature-off build silently discards, so
     // it is the only one that warns. `verify_presence_oracle` is genuinely
@@ -429,7 +434,8 @@ pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
              metrics and NO traces will be emitted and the OTLP endpoint is never \
              contacted — this is NOT a collector or endpoint problem. Rebuild with \
              `--features observability` to export telemetry, or disable \
-             OpenTelemetry (CQLITE_OTEL_ENABLED=0) to silence this warning."
+             OpenTelemetry (e.g. CQLITE_OTEL_ENABLED=0, or drop --otel-enabled) \
+             to silence this warning."
         );
     }
 

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -369,12 +369,53 @@ impl ObservabilityGuard {
 /// stack is linked, so a config-only build without the `observability` feature
 /// can still enable the confirmation-scan correctness check (its counter emit is
 /// simply a no-op in that build, per the module's zero-cost-when-off contract).
+///
+/// # Observability honesty (issue #1702, epic #1686)
+///
+/// When `cfg.enabled` is `true` this build CANNOT export anything, so it emits
+/// ONE `WARN` naming the knob, the missing cargo feature and the consequence.
+/// Without it, `CQLITE_OTEL_ENABLED=1` is a completely silent no-op and an
+/// operator cannot tell "collector down / endpoint misconfigured" from "this
+/// binary was built without the feature". It stays a warning, never an error:
+/// degraded-but-running is the correct behavior — the defect was VISIBILITY.
 #[cfg(not(feature = "observability"))]
 #[inline]
 pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
     crate::storage::sstable::reader::presence_verification::apply_config(
         cfg.verify_presence_oracle,
     );
+
+    // Issue #1702. Emitted with `tracing::warn!`, not `log::warn!` as the issue
+    // text spells it: `cqlite-core` has no `log` dependency at all — its facade
+    // is `tracing` (the #1706 log->tracing migration) — and `tracing` satisfies
+    // the same constraint, since every host composes the fmt layer onto STDERR
+    // so stdout stays clean for `--out json/csv` (issue #129).
+    //
+    // Fired unconditionally on each `init` call rather than behind a `Once`:
+    // `init` IS the once-per-process startup entry point (CLI `run_main`, the
+    // Flight server, `init_once` in both bindings), so "once at init" is already
+    // "once per process", while a `Once` would additionally make the warning
+    // unobservable to the second of two tests in one binary.
+    //
+    // `cfg.enabled` is the ONLY field a feature-off build silently discards, so
+    // it is the only one that warns. `verify_presence_oracle` is genuinely
+    // honored above. The remaining `CQLITE_OTEL_*` vars (endpoint, protocol,
+    // service name/version, sampling ratio, timeout) are all subordinate to
+    // `enabled`: with `enabled == false` they change nothing even in a
+    // feature-ON build, so a separate warning for them would be noise, not
+    // honesty. This omission is deliberate, not an oversight.
+    if cfg.enabled {
+        tracing::warn!(
+            requested_endpoint = %cfg.endpoint,
+            "CQLITE_OTEL_ENABLED is set but this binary was built WITHOUT the \
+             `observability` cargo feature: OpenTelemetry is compiled out, so NO \
+             metrics and NO traces will be emitted and the OTLP endpoint is never \
+             contacted (this is NOT a collector or endpoint problem). Rebuild with \
+             `--features observability` to export telemetry, or unset \
+             CQLITE_OTEL_ENABLED to silence this warning."
+        );
+    }
+
     Ok(ObservabilityGuard { _private: () })
 }
 

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -404,15 +404,23 @@ pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
     // `enabled`: with `enabled == false` they change nothing even in a
     // feature-ON build, so a separate warning for them would be noise, not
     // honesty. This omission is deliberate, not an oversight.
+    //
+    // Wording note: `init` receives an already-RESOLVED config and cannot know
+    // which source enabled it (the CLI accepts `CQLITE_OTEL_ENABLED`, the
+    // `--otel-enabled` flag, and a config file, all feeding this one field), so
+    // the message must not assert that the env var is set. It names the env var
+    // as the common spelling — operators grep for it — without claiming
+    // provenance.
     if cfg.enabled {
         tracing::warn!(
             requested_endpoint = %cfg.endpoint,
-            "CQLITE_OTEL_ENABLED is set but this binary was built WITHOUT the \
+            "OpenTelemetry export is ENABLED in configuration (CQLITE_OTEL_ENABLED / \
+             --otel-enabled / config file) but this binary was built WITHOUT the \
              `observability` cargo feature: OpenTelemetry is compiled out, so NO \
              metrics and NO traces will be emitted and the OTLP endpoint is never \
-             contacted (this is NOT a collector or endpoint problem). Rebuild with \
-             `--features observability` to export telemetry, or unset \
-             CQLITE_OTEL_ENABLED to silence this warning."
+             contacted — this is NOT a collector or endpoint problem. Rebuild with \
+             `--features observability` to export telemetry, or disable \
+             OpenTelemetry (CQLITE_OTEL_ENABLED=0) to silence this warning."
         );
     }
 

--- a/cqlite-core/tests/issue_1702_observability_off_warning.rs
+++ b/cqlite-core/tests/issue_1702_observability_off_warning.rs
@@ -1,0 +1,190 @@
+//! Issue #1702 (epic #1686, AI2 "observability honesty"): asking for OTel on a
+//! build that compiled observability OUT must be VISIBLE, not silent.
+//!
+//! # The defect this pins
+//!
+//! `observability` is NOT a default feature, so the shipped default build links
+//! no OTel stack at all. `CQLITE_OTEL_ENABLED=1` still parses cleanly into
+//! `ObservabilityConfig { enabled: true, .. }` and `observability::init` still
+//! returns an inert guard — so metrics and traces are dropped on the floor with
+//! no signal anywhere. From the operator's chair "collector down /
+//! misconfigured endpoint" and "the binary was built without the feature" look
+//! IDENTICAL. The fix is visibility (ONE warning at init), never an error: a
+//! degraded-but-running process is the correct behavior.
+//!
+//! # Why `tracing`, not `log`
+//!
+//! `cqlite-core` has NO `log` dependency; its facade is `tracing` (the #1706
+//! log->tracing migration). `tracing::warn!` satisfies the same constraint the
+//! issue text spells as `log::warn!`: the CLI's fmt layer writes to STDERR
+//! only, so stdout stays clean for `--out json/csv` (issue #129).
+//!
+//! # Scope of this file
+//!
+//! Feature-OFF only (`#![cfg(not(feature = "observability"))]`). AC2 ("a
+//! feature-enabled build emits no such warning") is STRUCTURAL, not behavioral:
+//! the emit exists only inside the `cfg(not(feature = "observability"))` copy of
+//! `init`, so in a feature-on build it is not compiled at all — there is no
+//! runtime path to test, and a feature-on assertion would be vacuous. The CLI
+//! end-to-end half (warning on stderr, stdout unaffected) lives in
+//! `cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs`.
+
+#![cfg(not(feature = "observability"))]
+
+use std::sync::{Arc, Mutex};
+
+use cqlite_core::observability::{init, ObservabilityConfig};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+
+/// One captured `tracing` event: its level and its formatted `message` field.
+#[derive(Clone, Debug)]
+struct Captured {
+    level: Level,
+    message: String,
+}
+
+/// Thread-safe capture sink shared with the layer.
+#[derive(Clone, Default)]
+struct Sink(Arc<Mutex<Vec<Captured>>>);
+
+impl Sink {
+    fn events(&self) -> Vec<Captured> {
+        self.0
+            .lock()
+            .expect("capture sink mutex is never poisoned in this test")
+            .clone()
+    }
+
+    fn warnings(&self) -> Vec<Captured> {
+        self.events()
+            .into_iter()
+            .filter(|e| e.level == Level::WARN)
+            .collect()
+    }
+}
+
+/// Records the `message` field of an event into a string.
+#[derive(Default)]
+struct MessageVisitor(String);
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0 = format!("{value:?}");
+        }
+    }
+}
+
+impl<S: Subscriber> Layer<S> for Sink {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        self.0
+            .lock()
+            .expect("capture sink mutex is never poisoned in this test")
+            .push(Captured {
+                level: *event.metadata().level(),
+                message: visitor.0,
+            });
+    }
+}
+
+/// Run `f` with a capturing subscriber installed on THIS thread and return the
+/// events it emitted. Thread-local (`with_default`) is sufficient and correct:
+/// `init` is synchronous and spawns nothing, so every event it emits is on the
+/// calling thread. Thread-local also keeps concurrent tests in this binary from
+/// observing each other's events.
+fn capture<T>(f: impl FnOnce() -> T) -> (T, Sink) {
+    let sink = Sink::default();
+    let subscriber = tracing_subscriber::registry().with(sink.clone());
+    let out = tracing::subscriber::with_default(subscriber, f);
+    (out, sink)
+}
+
+/// AC1 (the red one): a default-features build asked for OTel emits exactly ONE
+/// WARN that names the env var, the missing cargo feature, and the consequence.
+#[test]
+fn enabled_config_warns_once_naming_feature_and_consequence() {
+    let cfg = ObservabilityConfig::builder().enabled(true).build();
+    let (guard, sink) = capture(|| init(cfg).expect("init never fails with the feature off"));
+    assert!(
+        !guard.is_active(),
+        "the feature-off guard is inert regardless of the warning"
+    );
+
+    let warnings = sink.warnings();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "expected EXACTLY ONE warning at init (not zero — the #1702 silent \
+         no-op — and not one per operation); captured: {:?}",
+        sink.events()
+    );
+
+    let msg = &warnings[0].message;
+    let lower = msg.to_lowercase();
+    // Names the knob the operator set...
+    assert!(
+        msg.contains("CQLITE_OTEL_ENABLED"),
+        "warning must name the env var so the operator can tie it to what they set: {msg}"
+    );
+    // ...the cargo feature that is missing (this is what distinguishes "built
+    // without the feature" from "collector down")...
+    assert!(
+        msg.contains("observability"),
+        "warning must name the `observability` cargo feature: {msg}"
+    );
+    // ...and the consequence, in operator terms.
+    assert!(
+        lower.contains("metric") && lower.contains("trace"),
+        "warning must say metrics and traces are affected: {msg}"
+    );
+    assert!(
+        lower.contains("not be emitted") || lower.contains("no metrics"),
+        "warning must state that nothing will be emitted: {msg}"
+    );
+}
+
+/// The negative: the default (OTel not requested) build must stay silent. A
+/// warning here would fire on every process start of every default build.
+#[test]
+fn disabled_config_emits_no_warning() {
+    let cfg = ObservabilityConfig::builder().enabled(false).build();
+    let (_guard, sink) = capture(|| init(cfg).expect("init never fails with the feature off"));
+    assert!(
+        sink.warnings().is_empty(),
+        "a config that never asked for OTel must not warn; captured: {:?}",
+        sink.events()
+    );
+}
+
+/// Sibling-toggle consistency (issue #1702 item 3). `verify_presence_oracle` is
+/// the only other `ObservabilityConfig` field, and it IS honored with the
+/// feature off — `init` plumbs it into the always-compiled presence-verification
+/// switch — so it is NOT silently dropped and must NOT warn. `enabled` is the
+/// only input a feature-off build discards.
+#[test]
+fn presence_oracle_toggle_alone_does_not_warn() {
+    let cfg = ObservabilityConfig::builder()
+        .enabled(false)
+        .verify_presence_oracle(true)
+        .build();
+    let (_guard, sink) = capture(|| init(cfg).expect("init never fails with the feature off"));
+    assert!(
+        sink.warnings().is_empty(),
+        "verify_presence_oracle is honored in a feature-off build, so enabling \
+         it must not warn; captured: {:?}",
+        sink.events()
+    );
+
+    // Restore the process-global switch this test flipped through `init` so it
+    // cannot leak into other tests in this binary.
+    let reset = ObservabilityConfig::builder()
+        .enabled(false)
+        .verify_presence_oracle(false)
+        .build();
+    let _ = init(reset);
+}

--- a/cqlite-core/tests/issue_1702_observability_off_warning.rs
+++ b/cqlite-core/tests/issue_1702_observability_off_warning.rs
@@ -143,7 +143,7 @@ fn enabled_config_warns_once_naming_feature_and_consequence() {
         "warning must say metrics and traces are affected: {msg}"
     );
     assert!(
-        lower.contains("not be emitted") || lower.contains("no metrics"),
+        lower.contains("no metrics") && lower.contains("will be emitted"),
         "warning must state that nothing will be emitted: {msg}"
     );
 }
@@ -162,8 +162,10 @@ fn disabled_config_emits_no_warning() {
 }
 
 /// Sibling-toggle consistency (issue #1702 item 3). `verify_presence_oracle` is
-/// the only other `ObservabilityConfig` field, and it IS honored with the
-/// feature off — `init` plumbs it into the always-compiled presence-verification
+/// the only other `ObservabilityConfig` field a feature-off build acts on (the
+/// remaining six — endpoint, protocol, service_name, service_version,
+/// sampling_ratio, timeout — are subordinate to `enabled` and mean nothing once
+/// it is off), and it IS honored with the feature off — `init` plumbs it into the always-compiled presence-verification
 /// switch — so it is NOT silently dropped and must NOT warn. `enabled` is the
 /// only input a feature-off build discards.
 #[test]
@@ -180,11 +182,12 @@ fn presence_oracle_toggle_alone_does_not_warn() {
         sink.events()
     );
 
-    // Restore the process-global switch this test flipped through `init` so it
-    // cannot leak into other tests in this binary.
-    let reset = ObservabilityConfig::builder()
-        .enabled(false)
-        .verify_presence_oracle(false)
-        .build();
-    let _ = init(reset);
+    // No cleanup of the process-global presence-verification switch this `init`
+    // flipped: no test in this binary consults it (directly or through a
+    // reader), so there is nothing here for it to leak into. A reset would also
+    // be worse than nothing — it pins the switch OFF rather than restoring
+    // UNINIT, it is unordered against the sibling tests cargo runs on parallel
+    // threads, and it would be skipped entirely if an assertion above panicked.
+    // A future test in this file that DOES read the switch must serialize
+    // instead (e.g. `serial_test`), not rely on a trailing reset.
 }

--- a/docs/observability/configuration.md
+++ b/docs/observability/configuration.md
@@ -13,10 +13,10 @@ The runtime observability foundation must be compiled in: build with the
 all telemetry calls are inert no-ops, and configuration still parses but exports
 nothing.
 
-**That state is no longer silent (issue #1702).** If OpenTelemetry is enabled in
-configuration on a binary built WITHOUT the `observability` feature — the default
-build — `observability::init` emits ONE `WARN` at startup, on **stderr**
-(never stdout, so `--out json`/`csv` stays clean):
+**On the CLI, that state is no longer silent (issue #1702).** If OpenTelemetry is
+enabled in configuration on a binary built WITHOUT the `observability` feature —
+the default build — `observability::init` emits ONE `WARN` at startup, on
+**stderr** (never stdout, so `--out json`/`csv` stays clean):
 
 ```text
 WARN cqlite_core::observability: OpenTelemetry export is ENABLED in configuration
@@ -28,12 +28,38 @@ this is NOT a collector or endpoint problem. Rebuild with
 (CQLITE_OTEL_ENABLED=0) to silence this warning.
 ```
 
-So "nothing arrives at my collector" is now diagnosable from the startup log
-alone: this warning means the feature is missing, and its ABSENCE means the
-export stack is compiled in and the problem is elsewhere (collector down,
-endpoint, protocol, sampling). It is a warning, never an error — the process
-runs normally, just without telemetry. Suppress it by fixing the cause, not by
-raising the log level.
+It is a warning, never an error — the process runs normally, just without
+telemetry.
+
+### Where this warning is actually visible
+
+`observability::init` emits it through `tracing`, so it reaches a human only if a
+`tracing` subscriber is already installed when `init` runs. That is a per-surface
+property, not a global guarantee:
+
+| Surface | Visible? | Why |
+|---------|----------|-----|
+| CLI (`cqlite`) | **Yes** | With the feature off, `cqlite-cli/src/telemetry.rs` installs the fmt→stderr subscriber BEFORE calling `init`, precisely so this warning has a sink (issue #1702). With the feature ON the order is reversed, because `init` must first install the provider that the OTel layer composes. |
+| Arrow Flight server | **Yes, but its own line** | `cqlite-flight` calls `init` before installing its subscriber, so the core warning above is discarded — but it then emits an equivalent startup `WARN` of its own (issue #2128) after the subscriber exists. Expect that wording, not the one quoted here. |
+| Python binding | **Only if the host set up `tracing` first** | Feature-off, `install_subscriber()` is a no-op and runs after `init`, so nothing in the binding provides a sink. |
+| Node.js binding | **Only if the host set up `tracing` first** | Feature-off, the binding deliberately installs NO subscriber (a bare `Registry` would enable span callsites on hot paths), and `init` runs before that install anyway. |
+
+So the useful inference holds **on the CLI at its default log level**: the
+warning means the feature is missing, and its absence there means the export
+stack is compiled in and the problem is elsewhere (collector down, endpoint,
+protocol, sampling). Do NOT read absence as "compiled in" on the bindings — an
+embedder with no `tracing` subscriber gets no signal either way. Closing that
+binding gap needs a host-native report rather than a library installing a global
+subscriber over the embedder's own logging; tracked as a follow-up under epic
+#1686.
+
+### It respects your log level
+
+This is an ordinary `WARN` event, so an operator's explicit filtering choice wins:
+`--quiet` (which maps to `error`) or `RUST_LOG=error` suppresses it, exactly as it
+suppresses any other warning. That is deliberate — library code writing to stderr
+behind the subscriber's back would be worse. When diagnosing missing telemetry,
+run at the default level (or `RUST_LOG=warn` and above) rather than with `-q`.
 
 ---
 

--- a/docs/observability/configuration.md
+++ b/docs/observability/configuration.md
@@ -25,7 +25,7 @@ WITHOUT the `observability` cargo feature: OpenTelemetry is compiled out, so NO
 metrics and NO traces will be emitted and the OTLP endpoint is never contacted —
 this is NOT a collector or endpoint problem. Rebuild with
 `--features observability` to export telemetry, or disable OpenTelemetry
-(CQLITE_OTEL_ENABLED=0) to silence this warning.
+(e.g. CQLITE_OTEL_ENABLED=0, or drop --otel-enabled) to silence this warning.
 ```
 
 It is a warning, never an error — the process runs normally, just without

--- a/docs/observability/configuration.md
+++ b/docs/observability/configuration.md
@@ -44,14 +44,31 @@ property, not a global guarantee:
 | Python binding | **Only if the host set up `tracing` first** | Feature-off, `install_subscriber()` is a no-op and runs after `init`, so nothing in the binding provides a sink. |
 | Node.js binding | **Only if the host set up `tracing` first** | Feature-off, the binding deliberately installs NO subscriber (a bare `Registry` would enable span callsites on hot paths), and `init` runs before that install anyway. |
 
-So the useful inference holds **on the CLI at its default log level**: the
-warning means the feature is missing, and its absence there means the export
-stack is compiled in and the problem is elsewhere (collector down, endpoint,
-protocol, sampling). Do NOT read absence as "compiled in" on the bindings — an
-embedder with no `tracing` subscriber gets no signal either way. Closing that
-binding gap needs a host-native report rather than a library installing a global
-subscriber over the embedder's own logging; tracked as a follow-up under epic
-#1686.
+### Presence is conclusive; absence is not
+
+On the CLI at its default log level, the **presence** of this warning is
+conclusive: the export stack is compiled out, and no collector-side change can
+help. Its **absence proves nothing** — read it as neither a diagnosis nor an
+all-clear. Absence has two causes, and they are indistinguishable from the log:
+
+1. the `observability` feature IS compiled in (so a missing-telemetry problem
+   really is elsewhere: collector down, endpoint, protocol, sampling), **or**
+2. the configuration never resolved `enabled = true` in the first place, so
+   nothing asked for OpenTelemetry and there was nothing to warn about.
+
+Cause 2 is easy to hit and just as silent: `CQLITE_OTEL_ENABLED=ture` (typo) or
+`CQLITE_OTEL_ENABLE=1` (wrong variable name) both leave the master switch at its
+`false` default. An unrecognized value is deliberately failed safe to off rather
+than treated as an error, and today that rejection is not itself reported — a
+follow-up under epic #1686 covers warning about a rejected value, which is what
+would make absence genuinely diagnostic. So before concluding your collector is
+at fault, confirm what was actually RESOLVED (check the spelling of the variable
+and its value, or pass `--otel-enabled=true` explicitly).
+
+On the **bindings** absence is weaker still: an embedder with no `tracing`
+subscriber gets no signal either way, whatever the feature state. Closing that
+gap needs a host-native report rather than a library installing a global
+subscriber over the embedder's own logging; also tracked under epic #1686.
 
 ### It respects your log level
 

--- a/docs/observability/configuration.md
+++ b/docs/observability/configuration.md
@@ -13,6 +13,28 @@ The runtime observability foundation must be compiled in: build with the
 all telemetry calls are inert no-ops, and configuration still parses but exports
 nothing.
 
+**That state is no longer silent (issue #1702).** If OpenTelemetry is enabled in
+configuration on a binary built WITHOUT the `observability` feature — the default
+build — `observability::init` emits ONE `WARN` at startup, on **stderr**
+(never stdout, so `--out json`/`csv` stays clean):
+
+```text
+WARN cqlite_core::observability: OpenTelemetry export is ENABLED in configuration
+(CQLITE_OTEL_ENABLED / --otel-enabled / config file) but this binary was built
+WITHOUT the `observability` cargo feature: OpenTelemetry is compiled out, so NO
+metrics and NO traces will be emitted and the OTLP endpoint is never contacted —
+this is NOT a collector or endpoint problem. Rebuild with
+`--features observability` to export telemetry, or disable OpenTelemetry
+(CQLITE_OTEL_ENABLED=0) to silence this warning.
+```
+
+So "nothing arrives at my collector" is now diagnosable from the startup log
+alone: this warning means the feature is missing, and its ABSENCE means the
+export stack is compiled in and the problem is elsewhere (collector down,
+endpoint, protocol, sampling). It is a warning, never an error — the process
+runs normally, just without telemetry. Suppress it by fixing the cause, not by
+raising the log level.
+
 ---
 
 ## Shared environment variables (`CQLITE_OTEL_*`)


### PR DESCRIPTION
Closes #1702. Part of epic #1686 (observability honesty).

## Problem

`observability` is not a default feature, so a default build compiles OTel out. Setting
`CQLITE_OTEL_ENABLED=1` on such a build parses fine and **silently does nothing**. An operator staring at
an empty dashboard cannot tell "collector down / endpoint misconfigured" from "this binary was built
without the feature".

## Fix

`cqlite-core/src/observability/mod.rs` — the always-compiled `#[cfg(not(feature = "observability"))] init`
emits ONE `WARN` when `cfg.enabled` is true, naming the knob, the missing cargo feature, and the
consequence, and stating outright that this is *not* a collector problem. It stays a warning, never an
error: degraded-but-running is correct — the defect was VISIBILITY.

### Two deviations from the issue text, both deliberate

**1. `tracing::warn!`, not `log::warn!`.** `cqlite-core` has no `log` dependency; its facade is `tracing`.
Same outcome for the stated constraint — every host composes the fmt layer onto STDERR, so stdout stays
clean for `--out json/csv` (#129).

**2. The CLI ordering had to change, or the new warning would itself have been silently dropped.**
`main.rs` called `observability::init` *before* `init_tracing_subscriber`. That order is REQUIRED with the
feature ON (`observability::tracing_layer()` must be live before the registry is composed, else it composes
a dead layer and exports nothing). With the feature OFF there is no layer to compose, and the old order
would have sent the warning to the global no-op subscriber — a second silent no-op layered on the first.
The two orders now live in `cqlite-cli/src/telemetry.rs` as a `cfg`-split pair with the rationale written
down. `init_tracing_subscriber` moved verbatim; guard lifetime is unchanged (still bound for the whole
`run_main` scope so Drop flushes).

### What deliberately does NOT warn

`init` receives an already-resolved config. Its one non-OTel field, `verify_presence_oracle`, IS honored in
a feature-off build, so warning about it would be false. The other `CQLITE_OTEL_*` vars (endpoint, protocol,
service name/version, sampling ratio, timeout) are subordinate to `enabled` — with `enabled == false` they
change nothing even in a feature-ON build. The omission is recorded in a comment so it does not read as an
oversight. For the same reason the message does not claim the env var is the source: the CLI accepts
`CQLITE_OTEL_ENABLED`, `--otel-enabled`, and a config file, all feeding one field.

## Acceptance criteria

- [x] Default build + `CQLITE_OTEL_ENABLED=1` → warning appears. `cqlite-core/tests/issue_1702_observability_off_warning.rs` (log capture) and `cqlite-cli/tests/issue_1702_cli_otel_feature_off_warning.rs` (real subprocess, asserts EXACTLY ONE warning on stderr).
- [x] Feature-enabled build: no such warning. Structural — the emit exists only under `cfg(not(feature = "observability"))`, so a feature-ON build cannot contain it. No vacuous test was added to "prove" this.
- [ ] Full `scripts/agent-gate.sh` PASS — run once by `flow-closer`; SUMMARY pasted below on completion.

Stdout hygiene is asserted positively: the CLI test compares stdout **byte-for-byte** with and without the
env var, so the warning cannot leak into machine-readable output.

## Red-test evidence

At the RED commit `340fb76` (test present, fix absent) the feature-off `init` body is exactly:

```rust
pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
    crate::storage::sstable::reader::presence_verification::apply_config(cfg.verify_presence_oracle);
    Ok(ObservabilityGuard { _private: () })
}
```

No emit of any kind, so the WARN assertion could not have passed. Stated precisely: this is structural
proof from the committed tree, verified by the lead — not a transcript of an observed failing run.

## Review history — 4 rounds, each finding what the others missed

| Round | Reviewer | Result | Found |
|---|---|---|---|
| r1 | roborev job 106 | FAIL (2) | docs over-claimed visibility across surfaces; docs denied that `--quiet`/`RUST_LOG` suppress it |
| r2 | roborev job 107 | FAIL (2) | **credential leak / log injection**; CLI test inherited ambient config |
| r3 | independent rust review | 1 blocker + 11 nits | **absence-is-diagnostic claim still false**; test vacuity; comment inaccuracies |
| r4 | roborev job 110 | **PASS, findings NONE** | — |

**r2's blocker was the sharpest.** The warning logged `requested_endpoint = %cfg.endpoint` — a
user-controlled URL — verbatim. `http://user:pass@collector:4317` would have written credentials into the
log, and a newline in the value could forge log lines. Fixed by **deleting the field**, not sanitizing it:
the message already states the endpoint is never contacted, so the field bought almost nothing while
carrying the entire risk class.

**r3's blocker is the one worth reading.** Commit `0d935e4` was titled "stop claiming absence is
diagnostic" — and then *narrowed* the claim from all-surfaces to the-CLI instead of retracting it. It was
still false, and I verified why against source: `cqlite-cli/src/config.rs:883-891` maps an unrecognized
master-switch value to `None` ("fail safe to off", commented "None of these cases error"), and
`cqlite-core/src/observability/config.rs:127-131` keeps the default when `parse_bool` rejects a value. So
`CQLITE_OTEL_ENABLED=ture` yields no telemetry, no error, **and no warning** — an operator following that
doc would blame their collector, the exact failure epic #1686 exists to prevent. The docs now state that
presence is conclusive and absence proves nothing, with both causes enumerated.

Two reviewer suggestions were declined with reasons: the byte-identical stdout assertion was kept (a strong
property; the added non-empty control removes the vacuity concern), and no `Once` was added around the
warning (an out-of-tree embedder calling `init` per connection would spam, but a `Once` would make the
warning unobservable to a second test in the same binary — the comment now records once-ness as a caller
convention rather than an enforced property).

## Follow-ups (filed at merge, both under epic #1686)

1. **Binding-surface visibility** — the warning is invisible on the Python and Node bindings (no feature-off
   subscriber; `init` runs before their installer). Pre-existing, not regressed here. Closing it needs a
   host-native report or a library-installed global subscriber — a product decision about embedder behavior,
   outside this issue's criteria.
2. **Warn on a REJECTED `CQLITE_OTEL_ENABLED` value** — the same silent-no-op defect one level up the
   pipeline. Fail-safe-to-off is the right value decision; the missing half is a WARN naming the rejected
   value. Landing it is what would make the absence-inference true.

## Prior art

Issue #2128 already fixed this identical defect for the Arrow Flight surface (`cqlite-flight/src/main.rs`
emits its own feature-off warning after installing its subscriber). This change follows that precedent
rather than inventing an approach, and the docs table records that Flight's wording differs.
