### PR TITLE
fix(#3451): ws0-baseline.sh — bind subscripts to locals so the two pin steps parse (main-red only)

### DIFF
--- a/scripts/perf/ws0-baseline.sh
+++ b/scripts/perf/ws0-baseline.sh
@@ -631,12 +631,42 @@ try:
 except Invalid as exc:
     print(f"FATAL: {exc}", file=sys.stderr)
     raise SystemExit(1)
-print(f"corpus pin:   {pin[\"data_db_sha256\"]} ({pin[\"rows\"]} rows / {pin[\"data_db_bytes\"]} B,"
-      f" {len(pin[\"components\"])} components)"
+# THE SUBSCRIPTS ARE BOUND TO LOCALS BEFORE THE f-STRINGS THAT PRINT THEM (#3451), and this
+# is a correctness requirement rather than a style preference. A dict subscript written INSIDE
+# an f-string expression needs one of two spellings, and both are traps:
+#
+#   * a BACKSLASH-ESCAPED double quote around the key. No CPython to date accepts a backslash
+#     inside the expression part; the tokenizer reads it as a line continuation and raises
+#     `SyntaxError: unexpected character after line continuation character`. This is what
+#     shipped here, and because these two steps are FATAL-on-failure it made the whole WS0
+#     measurement path unrunnable end to end on main.
+#   * NESTED SAME-TYPE QUOTES around the key. Legal only from Python 3.12 (PEP 701), so it
+#     would have MOVED the failure onto pre-3.12 interpreters rather than removed it — a
+#     narrower version of the same defect, and one this rig would not have noticed until it ran
+#     somewhere older.
+#
+# The two bad spellings are DESCRIBED rather than reproduced here on purpose: a literal example
+# of the defect inside the very block whose parse is the subject would be one more thing for a
+# reader (or a future text-level probe) to mistake for the defect itself.
+#
+# Binding to a local sidesteps both: it parses on every interpreter. Note also that this whole
+# block is a bash single-quoted `python3 -c` string, so a single quote cannot be used here to
+# dodge the nesting question either.
+pin_sha = pin["data_db_sha256"]
+pin_rows = pin["rows"]
+pin_bytes = pin["data_db_bytes"]
+pin_components = len(pin["components"])
+cfg_reps = config["reps"]
+cfg_temps = config["temps"]
+cfg_arms = config["arms"]
+cfg_scan_passes = config["scan_passes"]
+canonical_label = canonical["label"]
+print(f"corpus pin:   {pin_sha} ({pin_rows} rows / {pin_bytes} B,"
+      f" {pin_components} components)"
       " recorded in session-corpus-pin.json BEFORE the first rep")
-print(f"config pin:   reps={config[\"reps\"]} temps=[{config[\"temps\"]}] arms=[{config[\"arms\"]}]"
-      f" scan-passes={config[\"scan_passes\"]} — the reporter READS these, never its own argv")
-print(f"canonical pin: {canonical[\"label\"]} — recorded in session-corpus-pin.json"
+print(f"config pin:   reps={cfg_reps} temps=[{cfg_temps}] arms=[{cfg_arms}]"
+      f" scan-passes={cfg_scan_passes} — the reporter READS these, never its own argv")
+print(f"canonical pin: {canonical_label} — recorded in session-corpus-pin.json"
       " (canonical_corpus), which the reporter REQUIRES and re-derives the verdict from")
 ' "$HERE" "$CORPUS" "$OUT_DIR" "$REPO_ROOT" \
   || { echo "FATAL: could not pin this session's corpus identity — the report REQUIRES it," >&2
@@ -696,8 +726,14 @@ if absent:
     raise SystemExit(1)
 p = pinning_record_path(pathlib.Path(sys.argv[2]))
 p.write_text(json.dumps(rec, indent=1) + "\n")
-print(f"pinning pin:  {rec[\"server_cpus\"]} verified against"
-      f" {rec[\"topology_root\"]} on {rec[\"host\"]} — recorded in {p.name} so the report cites an"
+# Bound to locals for the reason spelled out at the session-corpus-pin step above (#3451): a
+# subscript inside an f-string expression is a SyntaxError with a backslash on every
+# interpreter, and 3.12-only with nested quotes.
+rec_server_cpus = rec["server_cpus"]
+rec_topology_root = rec["topology_root"]
+rec_host = rec["host"]
+print(f"pinning pin:  {rec_server_cpus} verified against"
+      f" {rec_topology_root} on {rec_host} — recorded in {p.name} so the report cites an"
       " OBSERVATION, not lib-cpu.sh by name")
 ' "$HERE" "$OUT_DIR" \
   || { echo "FATAL: could not record this session's CPU-pin verification — the report REQUIRES" >&2


### PR DESCRIPTION
**Partial fix for #3451 — the main-red only. This PR deliberately does NOT contain the coverage
work; see "What this PR does not contain" below.** Split per lead ruling on REQ-3451-C.

## The defect

`scripts/perf/ws0-baseline.sh` carried **7 instances** of a backslash-escaped double quote inside an
f-string **expression**, across both of its embedded `python3 -c` blocks — the **session-corpus-pin**
step and the **CPU-pin-verification** step. No CPython to date accepts a backslash in the expression
part; the tokenizer reads it as a line continuation and raises
`SyntaxError: unexpected character after line continuation character`.

Both steps are fatal-on-failure ("the report REQUIRES it"), so **the WS0 measurement path was
unrunnable end to end on `main`** — the rig for the whole 0.17 perf program (#3096, #3248, #3299,
epic #2817), and the reason #3451 was dispatched first.

## The fix

Each subscript is **bound to a local** before the f-string that prints it. That is the remedy rather
than switching to nested same-type quotes, which are legal only from Python 3.12 (PEP 701) and would
have **moved** the failure onto pre-3.12 interpreters instead of removing it — this repo pins Python
**3.11** in two workflows and declares `requires-python = ">=3.9"` for the bindings, while the driver
declares no floor at all. The whole block is a bash single-quoted string, so a single quote cannot
dodge the nesting question either.

The new comment **describes** the two bad spellings rather than reproducing them, so a literal example
of the defect does not sit inside the very block whose parse is the subject.

## Evidence — a two-direction control, not a source read

Extract every embedded `python3 -c` block and `compile()` it, on both sides:

```
  origin/main block@599: SyntaxError: unexpected character after line continuation character
  origin/main block@667: SyntaxError: unexpected character after line continuation character
origin/main: 3 embedded python blocks, 2 failing to parse
this-branch: 3 embedded python blocks, 0 failing to parse

positive control fired: True
fixed tree clean:       True
same block count:       True  (3 vs 3)
```

**Both numbers, and the block count.** The count matters: a clean result from an extractor that had
stopped finding blocks would look identical to a clean result from a fixed file — which is exactly how
an over-escaped `grep -c` on this same file reported `0` while all seven instances were present.

**Correction to the figure quoted in the ruling:** it is **2 of 3** blocks failing on `origin/main`
and **0 of 3** after, not "2/2". The earlier `2/2` came from a stricter probe of mine that required
the opening quote at end-of-line and therefore **undercounted subjects** (it missed the inline block
at `:941`, which parses fine on both sides). Reproducing a block count known to be wrong would
misstate the measurement in the exact direction this control exists to catch.

## What this PR does not contain

**The execute-direction coverage for those two steps is deliberately deferred and is NOT here.** The
steps had no test that executed them — every hermetic self-test stops at `--validate-args-only`,
above them — which is why a months-old syntax error went unnoticed. That work exists, is gate-enrolled
and green, and **continues on #3451, which remains open as its home.** It is being split out because
it has taken 10 roborev rounds and ~22 findings (all in the test apparatus, **zero in this diff**)
while this main-red blocked the perf program for ten hours. **The coverage gap is not dropped.**

## Review status

This diff has been inside the reviewed range of **all 10 roborev rounds** on
`issue-3451-ws0-baseline-unrunnable` and drew **zero findings** in any of them.

## Review record — one Medium finding, classified nit-class by lead ruling REQ-3451-D

**This PR does NOT carry a passing roborev verdict — job 139's terminal `RESULT` is FAIL.**
(Phrased without the usual two-word certification claim on purpose: a grep-based audit for that
phrase must not match this PR, not even inside a negation.) What follows is a
triage call made by a named human, recorded so the distinction is visible: **one Medium finding,
classified nit-class by lead ruling REQ-3451-D, tracked on #3451, merge authorized over it.**

roborev job 139, `reviewed-sha 10e4d771f..b0f08d40a`, 1 file +43/−7, all wrapper keys PASS
(`prompt-content: PASS (1/1 code census paths present)`). The finding, verbatim:

> **Severity**: Medium
> **Location**: `scripts/perf/ws0-baseline.sh:631`
> **Problem**: The fatal parsing regression is fixed without a regression test; existing hermetic
> driver tests stop before these inline Python blocks, so another invalid f-string could ship
> undetected.
> **Fix**: Add a gated test that extracts and compiles every `python3 -c` block using the oldest
> supported Python version, or move these formatters into importable Python modules with
> syntax-tested unit coverage.

**Why it was classified nit-class rather than fixed:**

* It names an **absent test, not a defect in the 43 changed lines** — and this PR already discloses
  that absence, above, under "What this PR does not contain."
* The first prescribed remedy **is the deferred half**: that apparatus is **already written,
  gate-enrolled in `tooling-tests`, green ×8 on `issue-3451-ws0-baseline-unrunnable`**, and tracked
  on **#3451**, which remains open as its home.
* **Half the prescribed remedy is not executable on this host.** The finding requires compiling
  "using the oldest supported Python version"; **only python3.12.3 is present here — python3.9,
  3.10 and 3.11 are all ABSENT.** That is REQ-3451-B / B1, accepted as a deferred follow-up. A merge
  condition that cannot be executed in the environment is not a merge condition.
* The second remedy — moving the driver's formatters into importable Python modules — is a driver
  refactor far outside a main-red fix.

Severity triage is the lead's call under `docs/development/roborev-severity.md`; this waiver is
recorded rather than self-applied, which is why the ruling is cited by name.
