### PR TITLE
docs(#1699): correct the census wording and two false claims in _ansi_stripped_log's header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ reach a child module through a cfg the derivation does not evaluate (`#[cfg(all(
 support;` on a shared helper — 3 such targets in `cqlite-core` today), and the closure used to follow that child
 while DISCARDING the attribute gating it, so a gated test inside counted as executable while an ungated sibling
 kept the target non-zero and the co-required census reported **no gap**. Such a subtree is now reported as a
-`DECLARED GAP` with a `cfg-gated-subtree gaps: N` census line (affirmative at `0`). Deliberately **declared, not
+`DECLARED GAP` with a `cfg-gated-subtree gaps: N RECOGNISED` census line that states its own non-exhaustiveness and is affirmative at `0` — **`0 RECOGNISED`, never a bare `0`**, because a bare zero in a gate log reads as a verified all-clear from a scan that is documented as incomplete. Deliberately **declared, not
 fatal**: failing the lane on it was tried and reverted, because those helpers are correct code and **a lane that
 reds on correct input is the lane agents learn to waive**. The `UNRESOLVED` half stays fail-closed — an
 incomplete source set is permissive everywhere, an unevaluated one is merely unattributable. And

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -4907,8 +4907,9 @@ run_roborev_lints_cmd() {
 # _ansi_stripped_log <logfile> — echo a path to <logfile> with ANSI escapes removed.
 #
 # roborev round-15 finding (HIGH), and the premise checked out: `.github/workflows/gate.yml`
-# (the nightly FULL gate) sets `CARGO_TERM_COLOR: always`, as do seven other workflows and
-# scripts/local/pre-merge.sh. Cargo then emits
+# (the nightly FULL gate) sets `CARGO_TERM_COLOR: always`, as do 17 other workflows under
+# .github/workflows/ (18 in total, measured — an earlier version of this comment said 8, which was
+# never measured) and scripts/local/pre-merge.sh. Cargo then emits
 #     ESC[1mESC[92m     RunningESC[0m unittests src/lib.rs (...)
 # with the reset sequence sitting BETWEEN `Running` and the path — so every parser keyed on
 # the literal text sees nothing. MEASURED on both guards, and the two directions differ:
@@ -4916,8 +4917,9 @@ run_roborev_lints_cmd() {
 #     nightly run, reporting "no Running unittests line" about a perfectly healthy log.
 #   * check_no_unexpected_zero_tests -> VACUOUS PASS: a target running ZERO tests is never
 #     associated with its result, so the #2039 guard silently reports OK. That one is
-#     PRE-EXISTING and affects its other callers (core-tests, cli-tests) on nightly CI too;
-#     filed separately.
+#     PRE-EXISTING and affects its OTHER CALLER on nightly CI too — which is `cli-tests`, both
+#     of whose passes call it. An earlier version of this comment also named `core-tests`;
+#     core-tests does NOT call this guard, and that claim was never measured. Filed as #3400.
 #
 # Stripping is done ONCE into a sibling file, not per line and not through a pipe. A pipe
 # would put the reading loop in a SUBSHELL and its accumulated verdict variables would be

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -243,8 +243,13 @@ datasets_root;`, the shape shared test helpers actually use (3 such targets in `
 closure followed such a child while **discarding the attribute gating it**, so a legacy-gated test inside the
 subtree counted as *executable* at this lane's feature set, an ungated sibling kept the target non-zero, and
 the co-required census reported **no gap** — the one thing that census exists to find. Such a subtree is now
-emitted as a `DECLARED GAP` naming the target, the module and the cfg text, with a `cfg-gated-subtree gaps: N`
-census line that is affirmative at `0` (so a pasted census shows the scan ran).
+emitted as a `DECLARED GAP` naming the target, the module and the cfg text, with a
+`cfg-gated-subtree gaps: N RECOGNISED` census line that is affirmative at `0` (so a pasted census shows the
+scan ran) **and that states its own non-exhaustiveness in the emitted text**. The `RECOGNISED` qualifier is
+load-bearing rather than decorative: a bare `0` reads as a verified all-clear, and this scan is documented as
+incomplete, so the census must say that a clean result means *nothing was recognised* — never that nothing is
+there. The same applies to the co-required census, whose populated branch also carries the qualifier: the
+disclaimer belongs on the surface a reader acts on, not only in the source comments.
 
 It is **declared, not fatal**, and the distinction is load-bearing: failing the lane on it was implemented,
 measured against the real tree, and reverted — those helpers are correct code, and **a lane that reds on


### PR DESCRIPTION
Committed follow-through on #3403's ruled disposition: the head never moved before merge, so these land off the **new** `main`, where the text they correct now exists. **Before the merge this patch could not apply at all** — all four target phrases had zero occurrences on `main`, since the text is what #3403 introduced. A separate PR then would have had no subject.

### Three corrections

1. **Census wording** (`CLAUDE.md`, `gate-contract.md`) — described the lane as emitting `cfg-gated-subtree gaps: N` "(affirmative at `0`)". It emits **`0 RECOGNISED`** plus an explicit non-exhaustiveness clause. Not false, but incomplete in the way the job-108 fix addressed: *a bare zero in a gate log reads as a verified all-clear*. The job-108 commit fixed the census strings and the seam comments and missed these two — **the source-vs-emitted split, in the documentation of a fix for that split.**
2. **`_ansi_stripped_log` header: workflow count** — said "seven other workflows" set `CARGO_TERM_COLOR: always`. Measured: **18**. I have no record of where 8 came from; it was not measured.
3. **`_ansi_stripped_log` header: caller set** — said the pre-existing exposure "affects its other callers (**core-tests**, cli-tests)". `check_no_unexpected_zero_tests` has exactly two callers, both `cli-tests` passes; **`core-tests` does not call it.**

Corrections 2 and 3 were reported by the worker driving **#3400** and verified here before accepting. A third claim they corrected — an unqualified reference to `check_unittest_targets_ran` — is **valid on this tree** (the function exists here, absent on their branch), so it is deliberately unchanged; that is the one line where "resolve toward the corrected text" would be wrong.

### Why this needs a full gate rather than a cheap lane

`agent-gate.sh` changes here are **comments only**, and proven rather than asserted: strip every `#` line from this file and from `main`'s and the results are **byte-identical at 5680 code lines**. But `scripts/ci/classify-docs-only.sh` reports the diff as **not** prose-only, because `agent-gate.sh` is a compiled input by that predicate — so no #3042 cite-and-waive and no `--delta`. I ran the oracle instead of judging by path shape; its answer is inconvenient and correct.

Self-test **390/0** against the corrected file.