### PR TITLE
fix(#3401): file-size FAIL writes a diagnostic log naming the offending files

### DIFF
--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -453,7 +453,11 @@ ratchet computation the verdict summarises: the thresholds applied, the resolved
 the ref it came from, or an explicit "base ref unavailable — growth ratchet skipped"), the full
 list of changed `.rs` files currently over threshold, and one `path: before -> after (limit N)`
 line per over-threshold file the change grew. It is written on **every** run, PASS included, so a
-`file-size: FAIL` never again requires re-deriving line counts across the diff by hand.
+`file-size: FAIL` never again requires re-deriving line counts across the diff by hand. If the
+component cannot write that log at all (unwritable path, filesystem full, rejected appends) it FAILs
+rather than passing silently, and puts the diagnostic — including the grown-file list, which would
+otherwise die with the log — in the sibling `file-size.persistence-error.log` under the same `logs:`
+directory, so the failure of the log has a log of its own.
 
 ## Nested / concurrent-gate isolation (issue #2874)
 

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -442,6 +442,17 @@ Putting it together: an `INCOMPLETE` summary + an advancing log mtime = **alive,
 are present = **dead, relaunch**. Anything else is inconclusive — prefer waiting to relaunching, and
 report `gate-timeout` on the hard deadline rather than guessing.
 
+## Component logs under `logs: <dir>` (issue #3401)
+
+Every component writes `<dir>/<component>.log`, where `<dir>` is the SUMMARY's `logs:` line —
+that is the ONLY gate text besides the SUMMARY an agent should open, and it is where you go when
+a component's one-line verdict is not enough. In particular `file-size.log` carries the whole
+ratchet computation the verdict summarises: the thresholds applied, the resolved base sha (and
+the ref it came from, or an explicit "base ref unavailable — growth ratchet skipped"), the full
+list of changed `.rs` files currently over threshold, and one `path: before -> after (limit N)`
+line per over-threshold file the change grew. It is written on **every** run, PASS included, so a
+`file-size: FAIL` never again requires re-deriving line counts across the diff by hand.
+
 ## Nested / concurrent-gate isolation (issue #2874)
 
 The gate of record is **structurally immune** to nested and concurrent gate activity — no box-exclusive ops rule and no "serialize every self-test lane" discipline is needed. The historical `#2751` workaround ("run the full gate **without** `AGENT_GATE_SUMMARY_FILE`") is **OBSOLETE**: the summary-file redirect invocation (`AGENT_GATE_SUMMARY_FILE=… bash scripts/agent-gate.sh`) is once again the documented default for callers, and running it concurrently with another lane's gate self-tests on the same box is safe. Three mechanisms guarantee this:

--- a/docs/development/gate-ops.md
+++ b/docs/development/gate-ops.md
@@ -444,9 +444,11 @@ report `gate-timeout` on the hard deadline rather than guessing.
 
 ## Component logs under `logs: <dir>` (issue #3401)
 
-Every component writes `<dir>/<component>.log`, where `<dir>` is the SUMMARY's `logs:` line —
-that is the ONLY gate text besides the SUMMARY an agent should open, and it is where you go when
-a component's one-line verdict is not enough. In particular `file-size.log` carries the whole
+Every component that RUNS writes `<dir>/<component>.log`, where `<dir>` is the SUMMARY's `logs:`
+line — that is the ONLY gate text besides the SUMMARY an agent should open, and it is where you go
+when a component's one-line verdict is not enough. A component that **SKIPs** (`python-bindings`,
+`oom-audit` and `tooling-tests` each have a no-toolchain SKIP path) writes no log at all: its reason
+is in the SUMMARY line only, so do not read an absent `<component>.log` as a missing artifact. In particular `file-size.log` carries the whole
 ratchet computation the verdict summarises: the thresholds applied, the resolved base sha (and
 the ref it came from, or an explicit "base ref unavailable — growth ratchet skipped"), the full
 list of changed `.rs` files currently over threshold, and one `path: before -> after (limit N)`

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7251,7 +7251,7 @@ run_file_size() {
   fi
   if [ -n "$log_persist_err" ]; then
     local ratchet_verdict="$status" sib="$LOG_DIR/$name.persistence-error.log" _m _g
-    local sib_ok=1 _sib_lines=0
+    local sib_ok=1 _sib_lines=0 _allow_shown=""
     local -a msg=()
     status=FAIL
     # The diagnostic MUST NOT live on stdout alone: stdout is gate.log, the one file agents
@@ -7325,10 +7325,19 @@ run_file_size() {
       # Without it the sibling shows grown files beside a non-FAIL verdict with no
       # provenance — and, from the test side, the allowed-growth state emits bytes
       # identical to the FAIL state, so nothing can tell the two apart.
+      # "unset" was a CLAIM about a state never determined — the predicate only tested
+      # `!= 1`, so `CQLITE_ALLOW_FILE_GROWTH=0` or a typo (`true`, `yes`) was reported as
+      # never set, hiding from the reader the one fact that fixes their invocation (#3401
+      # review, sixth instance of the compute-claim class). `${VAR+set}` distinguishes the
+      # two without a second read. The value is flattened to one line and capped because a
+      # multi-line value would break the sibling's landed-line-count check below.
       if [ "${CQLITE_ALLOW_FILE_GROWTH:-0}" = 1 ]; then
         msg+=("    growth allowance: ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1")
+      elif [ -n "${CQLITE_ALLOW_FILE_GROWTH+set}" ]; then
+        _allow_shown=$(printf '%s' "$CQLITE_ALLOW_FILE_GROWTH" | tr -d '\n\r' | cut -c1-40)
+        msg+=("    growth allowance: NOT enabled — CQLITE_ALLOW_FILE_GROWTH is set to '$_allow_shown', expected exactly 1; this IS a ratchet violation")
       else
-        msg+=("    growth allowance: none (CQLITE_ALLOW_FILE_GROWTH unset) — this IS a ratchet violation")
+        msg+=("    growth allowance: NOT enabled — CQLITE_ALLOW_FILE_GROWTH is not set, expected exactly 1; this IS a ratchet violation")
       fi
     fi
 
@@ -7377,11 +7386,12 @@ run_file_size() {
   # review round (#3401 review A2, re-raised as job 138 F1):
   #   * CIRCULARITY: this line's CONTENT IS THE VERDICT, and the verdict depends on the
   #     persistence decision. It cannot be written before the decision it reports.
-  #   * A POST-WRITE RE-CHECK BUYS NOTHING: verifying a write requires a later write TO THE
-  #     SAME SINK, whose own success is then unverified — the same one-write window, moved
-  #     along. Checking this append and reporting the failure on STDOUT *is* implementable
-  #     (a different sink needs no further log write), but it would only restate what
-  #     stdout already prints, which is why the bullet below is the load-bearing one.
+  #   * A POST-WRITE RE-CHECK BUYS NOTHING: a read-back can VERIFY the append without
+  #     writing anything, but RECORDING that outcome in the same sink requires a later
+  #     write, whose own success is then unverified — the same one-write window, moved
+  #     along. Reporting it on STDOUT *is* implementable (a different sink needs no further
+  #     log write), but it would only restate what stdout already prints, which is why the
+  #     bullet below is the load-bearing one.
   #   * THE LOSS IS BOUNDED: everything #3401 exists for (thresholds, base ref, over/grown
   #     entries) is written AND checked above; a failure here costs only the terminal
   #     verdict LINE, which the SUMMARY carries independently.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7113,6 +7113,9 @@ TEST_LIMIT=1500
 # thrown away. Nothing printed here may go to only one of the two sinks.
 _fs_emit() { # _fs_emit <logfile> <line> [<line>…]  — one output line per argument
   local _fs_log="$1"; shift
+  # Zero args must emit NOTHING: `printf '%s\n'` with no operands still prints the format
+  # once, i.e. a spurious blank line to BOTH sinks (#3401 review N2).
+  [ "$#" -gt 0 ] || return 0
   printf '%s\n' "$@"
   printf '%s\n' "$@" >>"$_fs_log"
 }
@@ -7123,8 +7126,16 @@ run_file_size() {
   fi
   local log="$LOG_DIR/$name.log"
   local start end status=PASS
+  # PERSISTENCE (#3401 blocker B): this component now PROMISES a log — the SUMMARY's
+  # `logs:` line is the only route an agent has to the ratchet arithmetic. An unverified
+  # promise is the original defect one level up (reader follows the pointer, finds
+  # nothing, hand-computes line counts again), so both the truncate and the end state are
+  # CHECKED and a persistence failure is a FAIL, never a silent PASS.
+  local log_persist_err=""
   start=$(date +%s)
-  : >"$log"
+  if ! : >"$log" 2>/dev/null; then
+    log_persist_err="could not create or truncate it (unwritable path, or not a regular file)"
+  fi
 
   # Base ref: an explicit override (issue #1892 --delta uses the anchor commit),
   # else merge-base with the default branch. If none resolves, we can still do the
@@ -7207,10 +7218,35 @@ run_file_size() {
   fi
 
   end=$(date +%s)
+
+  # A created-but-EMPTY log is the mid-run ENOSPC shape, which the truncate check above
+  # cannot see — so verify the end state too. The diagnostic must be unmistakably NOT a
+  # ratchet violation: a bare `file-size: FAIL` meaning "my log dir is unwritable" would
+  # send the reader hunting for a grown source file that does not exist, so the ratchet's
+  # own verdict is stated in the same breath.
+  if [ -z "$log_persist_err" ] && [ ! -s "$log" ]; then
+    log_persist_err="the file is absent or empty after writing (filesystem full?)"
+  fi
+  if [ -n "$log_persist_err" ]; then
+    local ratchet_verdict="$status"
+    status=FAIL
+    echo "--- [$name] LOG PERSISTENCE FAILURE — this is NOT a campsite-rule / size-ratchet violation."
+    echo "    The size ratchet itself computed: $ratchet_verdict. What failed is PERSISTING the"
+    echo "    diagnostic log the SUMMARY's 'logs:' line points at: $log"
+    echo "    Cause: $log_persist_err"
+    echo "    Fix the log directory (writable? full?) and re-run; no source file needs splitting."
+  fi
+
+  # Terminal verdict, written in TWO halves ON PURPOSE (#3401 blockers B/C) — do NOT tidy
+  # these back into one _fs_emit call, either merge direction re-opens one of the two:
+  #   * to the LOG *before* record_result, because record_result can TERMINATE the run
+  #     (tree-integrity / summary-integrity guards) and the log must still carry the
+  #     terminal verdict it promises;
+  #   * to STDOUT *after* record_result, because every other component prints in that
+  #     order and a gratuitous divergence is its own bug magnet.
+  printf '%s\n' ">>> [$name] $status ($((end - start))s)" >>"$log" 2>/dev/null
   record_result "$name" "$status" "$((end - start))"
-  # Terminal verdict goes to the log too, so a reader opening file-size.log alone sees
-  # what the component concluded and never has to correlate with the SUMMARY.
-  _fs_emit "$log" ">>> [$name] $status ($((end - start))s)"
+  printf '%s\n' ">>> [$name] $status ($((end - start))s)"
 }
 
 # scoped-tests (issue #1821, --lite only): the blast-radius-scoped test component.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7111,21 +7111,25 @@ TEST_LIMIT=1500
 # told never to read; the SUMMARY's `file-size: FAIL` therefore named neither the file nor
 # the numbers, and every reader re-derived by hand the arithmetic the component had just
 # thrown away. Nothing printed here may go to only one of the two sinks.
-# Count of _fs_emit appends that FAILED. Tracked rather than ignored because the
-# `[ -s "$log" ]` end-state check cannot see a PARTIAL log: a filesystem that accepts the
-# first line and rejects the rest leaves a non-empty file missing the growth entries —
-# #3401's own defect with extra steps, reported as PASS (#3401 review blocker A).
-_FS_WRITE_FAILURES=0
+# _fs_emit counts appends that FAILED, in `_FS_WRITE_FAILURES` — declared `local` by
+# run_file_size and reached here through bash's DYNAMIC SCOPING (deliberately not a global:
+# a global could carry a value in from anywhere, #3401 review L3). Tracked rather than
+# ignored because the `[ -s "$log" ]` end-state check cannot see a PARTIAL log: a
+# filesystem that accepts the first line and rejects the rest leaves a non-empty file
+# missing the growth entries — #3401's own defect with extra steps, reported as PASS.
 _fs_emit() { # _fs_emit <logfile> <line> [<line>…]  — one output line per argument
   local _fs_log="$1"; shift
   # Zero args must emit NOTHING: `printf '%s\n'` with no operands still prints the format
   # once, i.e. a spurious blank line to BOTH sinks (#3401 review N2).
   [ "$#" -gt 0 ] || return 0
   printf '%s\n' "$@"
-  # The append's STATUS is kept, its MESSAGE suppressed (#3401 review N1): an unwritable
-  # log makes the shell print one error per line, ~5 lines of noise interleaved into the
-  # very diagnostic block that has to be unmistakable.
-  printf '%s\n' "$@" >>"$_fs_log" 2>/dev/null ||
+  # The append's STATUS is kept, its MESSAGE suppressed: an unwritable log makes the shell
+  # print one error per line, ~5 lines of noise burying the diagnostic that has to be
+  # unmistakable. ORDER MATTERS and the obvious spelling is WRONG (#3401 review blocker 2):
+  # redirections apply LEFT TO RIGHT, so `>>"$log" 2>/dev/null` attempts the open FIRST and
+  # bash reports the failure on the still-unredirected stderr. `2>/dev/null` must come
+  # first. Verified empirically against a log path that is a directory, not by reasoning.
+  printf '%s\n' "$@" 2>/dev/null >>"$_fs_log" ||
     _FS_WRITE_FAILURES=$((_FS_WRITE_FAILURES + 1))
 }
 run_file_size() {
@@ -7141,9 +7145,10 @@ run_file_size() {
   # nothing, hand-computes line counts again), so both the truncate and the end state are
   # CHECKED and a persistence failure is a FAIL, never a silent PASS.
   local log_persist_err=""
-  _FS_WRITE_FAILURES=0
+  # Declared HERE so _fs_emit sees it by dynamic scoping and it cannot outlive the call.
+  local _FS_WRITE_FAILURES=0
   start=$(date +%s)
-  if ! : >"$log" 2>/dev/null; then
+  if ! : 2>/dev/null >"$log"; then
     log_persist_err="could not create or truncate it (unwritable path, or not a regular file)"
   fi
 
@@ -7246,6 +7251,7 @@ run_file_size() {
   fi
   if [ -n "$log_persist_err" ]; then
     local ratchet_verdict="$status" sib="$LOG_DIR/$name.persistence-error.log" _m _g
+    local sib_ok=1
     local -a msg=()
     status=FAIL
     # The diagnostic MUST NOT live on stdout alone: stdout is gate.log, the one file agents
@@ -7253,7 +7259,7 @@ run_file_size() {
     # at is missing". So it also goes to a NON-CLOBBERING SIBLING in LOG_DIR (the #2874
     # pattern), which is reachable from the SUMMARY's `logs:` line, and the stdout block
     # names that sibling so both routes lead to it (#3401 review blocker B).
-    : >"$sib" 2>/dev/null
+    : 2>/dev/null >"$sib" || sib_ok=0
     if [ "$ratchet_verdict" = FAIL ]; then
       # BOTH failed. Saying "this is NOT a ratchet violation" here would steer the reader
       # away from a REAL growth violation (#3401 review blocker C), so report both and keep
@@ -7270,15 +7276,29 @@ run_file_size() {
       msg+=("        Fix the log directory (writable? full?) — that half needs no source split.")
     else
       msg+=("--- [$name] LOG PERSISTENCE FAILURE — this is NOT a campsite-rule / size-ratchet violation.")
-      msg+=("    The size ratchet itself computed: $ratchet_verdict. What failed is PERSISTING the")
-      msg+=("    diagnostic log the SUMMARY's 'logs:' line points at: $log")
+      if [ -z "$base" ]; then
+        # No base ref means the ratchet never RAN (advisory-only run), so claiming it
+        # "computed PASS" would assert a computation that did not happen (#3401 review L1).
+        msg+=("    The size ratchet was SKIPPED (base ref unavailable), so no growth comparison was")
+        msg+=("    made at all. What failed is PERSISTING the diagnostic log the SUMMARY's 'logs:'")
+        msg+=("    line points at: $log")
+      else
+        msg+=("    The size ratchet itself computed: $ratchet_verdict. What failed is PERSISTING the")
+        msg+=("    diagnostic log the SUMMARY's 'logs:' line points at: $log")
+      fi
       msg+=("    Cause: $log_persist_err")
       msg+=("    Fix the log directory (writable? full?) and re-run; no source file needs splitting.")
     fi
-    msg+=("    This block is also written to: $sib")
+    # Claim the sibling only if it could actually be created (#3401 review L2): an
+    # unconditional "also written to" is the unverified-promise shape this issue is about.
+    if [ "$sib_ok" = 1 ]; then
+      msg+=("    This block is also written to: $sib")
+    else
+      msg+=("    (It could NOT also be written to $sib — this stdout copy is the only one.)")
+    fi
     for _m in ${msg[@]+"${msg[@]}"}; do
       printf '%s\n' "$_m"
-      printf '%s\n' "$_m" >>"$sib" 2>/dev/null
+      printf '%s\n' "$_m" 2>/dev/null >>"$sib"
     done
   fi
 
@@ -7294,7 +7314,7 @@ run_file_size() {
   # further along. What IS verified is everything #3401 exists for — the thresholds, the
   # base ref and the growth entries, all written and checked above; a failure here costs
   # only the terminal verdict LINE, which the SUMMARY carries anyway (#3401 review A2).
-  printf '%s\n' ">>> [$name] $status ($((end - start))s)" >>"$log" 2>/dev/null
+  printf '%s\n' ">>> [$name] $status ($((end - start))s)" 2>/dev/null >>"$log"
   record_result "$name" "$status" "$((end - start))"
   printf '%s\n' ">>> [$name] $status ($((end - start))s)"
 }

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7111,10 +7111,10 @@ TEST_LIMIT=1500
 # told never to read; the SUMMARY's `file-size: FAIL` therefore named neither the file nor
 # the numbers, and every reader re-derived by hand the arithmetic the component had just
 # thrown away. Nothing printed here may go to only one of the two sinks.
-_fs_emit() { # _fs_emit <logfile> <line…>
+_fs_emit() { # _fs_emit <logfile> <line> [<line>…]  — one output line per argument
   local _fs_log="$1"; shift
-  printf '%s\n' "$*"
-  printf '%s\n' "$*" >>"$_fs_log"
+  printf '%s\n' "$@"
+  printf '%s\n' "$@" >>"$_fs_log"
 }
 run_file_size() {
   local name=file-size
@@ -7207,10 +7207,10 @@ run_file_size() {
   fi
 
   end=$(date +%s)
+  record_result "$name" "$status" "$((end - start))"
   # Terminal verdict goes to the log too, so a reader opening file-size.log alone sees
   # what the component concluded and never has to correlate with the SUMMARY.
   _fs_emit "$log" ">>> [$name] $status ($((end - start))s)"
-  record_result "$name" "$status" "$((end - start))"
 }
 
 # scoped-tests (issue #1821, --lite only): the blast-radius-scoped test component.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7111,13 +7111,22 @@ TEST_LIMIT=1500
 # told never to read; the SUMMARY's `file-size: FAIL` therefore named neither the file nor
 # the numbers, and every reader re-derived by hand the arithmetic the component had just
 # thrown away. Nothing printed here may go to only one of the two sinks.
+# Count of _fs_emit appends that FAILED. Tracked rather than ignored because the
+# `[ -s "$log" ]` end-state check cannot see a PARTIAL log: a filesystem that accepts the
+# first line and rejects the rest leaves a non-empty file missing the growth entries —
+# #3401's own defect with extra steps, reported as PASS (#3401 review blocker A).
+_FS_WRITE_FAILURES=0
 _fs_emit() { # _fs_emit <logfile> <line> [<line>…]  — one output line per argument
   local _fs_log="$1"; shift
   # Zero args must emit NOTHING: `printf '%s\n'` with no operands still prints the format
   # once, i.e. a spurious blank line to BOTH sinks (#3401 review N2).
   [ "$#" -gt 0 ] || return 0
   printf '%s\n' "$@"
-  printf '%s\n' "$@" >>"$_fs_log"
+  # The append's STATUS is kept, its MESSAGE suppressed (#3401 review N1): an unwritable
+  # log makes the shell print one error per line, ~5 lines of noise interleaved into the
+  # very diagnostic block that has to be unmistakable.
+  printf '%s\n' "$@" >>"$_fs_log" 2>/dev/null ||
+    _FS_WRITE_FAILURES=$((_FS_WRITE_FAILURES + 1))
 }
 run_file_size() {
   local name=file-size
@@ -7132,6 +7141,7 @@ run_file_size() {
   # nothing, hand-computes line counts again), so both the truncate and the end state are
   # CHECKED and a persistence failure is a FAIL, never a silent PASS.
   local log_persist_err=""
+  _FS_WRITE_FAILURES=0
   start=$(date +%s)
   if ! : >"$log" 2>/dev/null; then
     log_persist_err="could not create or truncate it (unwritable path, or not a regular file)"
@@ -7219,22 +7229,57 @@ run_file_size() {
 
   end=$(date +%s)
 
-  # A created-but-EMPTY log is the mid-run ENOSPC shape, which the truncate check above
-  # cannot see — so verify the end state too. The diagnostic must be unmistakably NOT a
-  # ratchet violation: a bare `file-size: FAIL` meaning "my log dir is unwritable" would
-  # send the reader hunting for a grown source file that does not exist, so the ratchet's
-  # own verdict is stated in the same breath.
+  # What this guarantees, precisely (#3401 review A4): for the case where the LOG FILE
+  # cannot be written, the component never reports a silent PASS. It is NOT a general
+  # LOG_DIR guarantee — a wholly unwritable LOG_DIR also loses record_result's `.result`,
+  # and that falls through to the gate's generic "component produced no result" FAIL, which
+  # is fail-closed but carries none of this wording.
+  # Three independent signals, because each is blind to a different shape: the truncate
+  # check (unwritable path / not a regular file), the append-failure counter (a PARTIAL log
+  # — non-empty, so `-s` is satisfied, but missing the growth entries), and the end-state
+  # `-s` (created-but-empty, e.g. every write rejected).
+  if [ -z "$log_persist_err" ] && [ "$_FS_WRITE_FAILURES" -gt 0 ]; then
+    log_persist_err="$_FS_WRITE_FAILURES write(s) to it were rejected, so the log is partial or empty"
+  fi
   if [ -z "$log_persist_err" ] && [ ! -s "$log" ]; then
     log_persist_err="the file is absent or empty after writing (filesystem full?)"
   fi
   if [ -n "$log_persist_err" ]; then
-    local ratchet_verdict="$status"
+    local ratchet_verdict="$status" sib="$LOG_DIR/$name.persistence-error.log" _m _g
+    local -a msg=()
     status=FAIL
-    echo "--- [$name] LOG PERSISTENCE FAILURE — this is NOT a campsite-rule / size-ratchet violation."
-    echo "    The size ratchet itself computed: $ratchet_verdict. What failed is PERSISTING the"
-    echo "    diagnostic log the SUMMARY's 'logs:' line points at: $log"
-    echo "    Cause: $log_persist_err"
-    echo "    Fix the log directory (writable? full?) and re-run; no source file needs splitting."
+    # The diagnostic MUST NOT live on stdout alone: stdout is gate.log, the one file agents
+    # are told never to read, and the whole failure mode here is "the log you were pointed
+    # at is missing". So it also goes to a NON-CLOBBERING SIBLING in LOG_DIR (the #2874
+    # pattern), which is reachable from the SUMMARY's `logs:` line, and the stdout block
+    # names that sibling so both routes lead to it (#3401 review blocker B).
+    : >"$sib" 2>/dev/null
+    if [ "$ratchet_verdict" = FAIL ]; then
+      # BOTH failed. Saying "this is NOT a ratchet violation" here would steer the reader
+      # away from a REAL growth violation (#3401 review blocker C), so report both and keep
+      # the remediation data — which would otherwise be lost with the unwritable log.
+      msg+=("--- [$name] TWO failures: a REAL size-ratchet violation AND a log-persistence failure.")
+      msg+=("    (1) RATCHET (a genuine violation — act on this): the change makes over-threshold")
+      msg+=("        file(s) larger. Split per the campsite rule (epic #1116 source / #1135 tests),")
+      msg+=("        or re-run with CQLITE_ALLOW_FILE_GROWTH=1 to acknowledge. Grown files:")
+      for _g in ${grew[@]+"${grew[@]}"}; do
+        msg+=("          $_g")
+      done
+      msg+=("    (2) PERSISTENCE: the diagnostic log could not be written: $log")
+      msg+=("        Cause: $log_persist_err")
+      msg+=("        Fix the log directory (writable? full?) — that half needs no source split.")
+    else
+      msg+=("--- [$name] LOG PERSISTENCE FAILURE — this is NOT a campsite-rule / size-ratchet violation.")
+      msg+=("    The size ratchet itself computed: $ratchet_verdict. What failed is PERSISTING the")
+      msg+=("    diagnostic log the SUMMARY's 'logs:' line points at: $log")
+      msg+=("    Cause: $log_persist_err")
+      msg+=("    Fix the log directory (writable? full?) and re-run; no source file needs splitting.")
+    fi
+    msg+=("    This block is also written to: $sib")
+    for _m in ${msg[@]+"${msg[@]}"}; do
+      printf '%s\n' "$_m"
+      printf '%s\n' "$_m" >>"$sib" 2>/dev/null
+    done
   fi
 
   # Terminal verdict, written in TWO halves ON PURPOSE (#3401 blockers B/C) — do NOT tidy
@@ -7244,6 +7289,11 @@ run_file_size() {
   #     terminal verdict it promises;
   #   * to STDOUT *after* record_result, because every other component prints in that
   #     order and a gratuitous divergence is its own bug magnet.
+  # This LAST log write is deliberately UNVERIFIED, and that gap is irreducible: verifying
+  # a write requires a later write, so any re-check only moves the same one-write window
+  # further along. What IS verified is everything #3401 exists for — the thresholds, the
+  # base ref and the growth entries, all written and checked above; a failure here costs
+  # only the terminal verdict LINE, which the SUMMARY carries anyway (#3401 review A2).
   printf '%s\n' ">>> [$name] $status ($((end - start))s)" >>"$log" 2>/dev/null
   record_result "$name" "$status" "$((end - start))"
   printf '%s\n' ">>> [$name] $status ($((end - start))s)"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7037,6 +7037,30 @@ run_tooling_tests() {
     return 0
   fi
 
+  # file-size component-log guard (#3401): hermetic (throwaway git repos under one
+  # mktemp, each holding only a copy of the gate script, driven through the real
+  # `--only file-size` path — no cargo/python3/datasets/network/Docker, ~2s). The
+  # `file-size` component used to write ONLY a bare `file-size.result` (`FAIL 0`),
+  # echoing the base ref, the over-threshold advisory list and the exact
+  # `path: before -> after (limit N)` arithmetic to STDOUT — i.e. only into gate.log,
+  # the one file agents are told never to read. So a `file-size: FAIL` in a pasted
+  # SUMMARY named nothing, and every reader re-derived by hand what the component had
+  # just computed and discarded — on a FAIL that is routinely EXPECTED. This pins the
+  # LOG'S CONTENT (never its mere existence: a zero-byte file would satisfy that and
+  # restore the whole defect) across all six paths, PASS ones included. A failure FAILs
+  # the component, mirroring the keyspace-scoping guard.
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_file_size_log.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_agent_gate_file_size_log.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (file-size component-log guard #3401); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
   if ! command -v python3 >/dev/null 2>&1; then
     status=SKIP
     echo ">>> [$name] SKIP (no python3 on PATH; selftest truncation reader needs it)"
@@ -7081,24 +7105,39 @@ run_tooling_tests() {
 # Degrades to advisory-only (no ratchet) when the base ref can't be resolved.
 SRC_LIMIT=800
 TEST_LIMIT=1500
+# Emit one line to BOTH stdout and the component log (#3401). Everything this component
+# computes — the base ref, the advisory list, the `before -> after` growth entries, the
+# verdict — used to exist ONLY on stdout, i.e. only in gate.log, the one file agents are
+# told never to read; the SUMMARY's `file-size: FAIL` therefore named neither the file nor
+# the numbers, and every reader re-derived by hand the arithmetic the component had just
+# thrown away. Nothing printed here may go to only one of the two sinks.
+_fs_emit() { # _fs_emit <logfile> <line…>
+  local _fs_log="$1"; shift
+  printf '%s\n' "$*"
+  printf '%s\n' "$*" >>"$_fs_log"
+}
 run_file_size() {
   local name=file-size
   if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
     return 0
   fi
+  local log="$LOG_DIR/$name.log"
   local start end status=PASS
   start=$(date +%s)
+  : >"$log"
 
   # Base ref: an explicit override (issue #1892 --delta uses the anchor commit),
   # else merge-base with the default branch. If none resolves, we can still do the
   # advisory list but not the growth comparison.
-  local base="" ref
+  local base="" base_src="" ref
   if [ -n "${GATE_BASE_OVERRIDE:-}" ]; then
     base="$GATE_BASE_OVERRIDE"
+    base_src="GATE_BASE_OVERRIDE"
   else
     for ref in origin/main main origin/master master; do
       if git rev-parse --verify -q "$ref" >/dev/null 2>&1; then
-        base=$(git merge-base HEAD "$ref" 2>/dev/null) && [ -n "$base" ] && break
+        base=$(git merge-base HEAD "$ref" 2>/dev/null) && [ -n "$base" ] &&
+          { base_src="merge-base HEAD $ref"; break; }
       fi
     done
   fi
@@ -7131,32 +7170,47 @@ run_file_size() {
     fi
   done <<<"$files"
 
-  echo ">>> [$name] thresholds: src=$SRC_LIMIT test=$TEST_LIMIT (total lines, inline tests included)"
+  local line
+  _fs_emit "$log" ">>> [$name] thresholds: src=$SRC_LIMIT test=$TEST_LIMIT (total lines, inline tests included)"
+  if [ -n "$base" ]; then
+    _fs_emit "$log" ">>> [$name] base ref: $base (via $base_src)"
+  fi
   if [ "${#over[@]}" -eq 0 ]; then
-    echo ">>> [$name] no changed .rs files over threshold"
+    _fs_emit "$log" ">>> [$name] no changed .rs files over threshold"
   else
-    echo "--- [$name] changed files over threshold (campsite rule — split per epic #1116 / #1135):"
-    printf '      %s\n' "${over[@]}"
+    _fs_emit "$log" "--- [$name] changed files over threshold (campsite rule — split per epic #1116 / #1135):"
+    for line in ${over[@]+"${over[@]}"}; do
+      _fs_emit "$log" "      $line"
+    done
   fi
 
   if [ -z "$base" ]; then
-    echo ">>> [$name] base ref unavailable — growth ratchet skipped (advisory only)"
+    _fs_emit "$log" ">>> [$name] base ref unavailable — growth ratchet skipped (advisory only)"
   elif [ "${#grew[@]}" -gt 0 ]; then
     if [ "${CQLITE_ALLOW_FILE_GROWTH:-0}" = 1 ]; then
-      echo ">>> [$name] ${#grew[@]} over-threshold file(s) grew; ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1:"
-      printf '      %s\n' "${grew[@]}"
+      _fs_emit "$log" ">>> [$name] ${#grew[@]} over-threshold file(s) grew; ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1:"
+      for line in ${grew[@]+"${grew[@]}"}; do
+        _fs_emit "$log" "      $line"
+      done
     else
       status=FAIL
-      echo "--- [$name] FAIL: change makes over-threshold file(s) larger."
-      echo "    Split per the campsite rule (epic #1116 source / #1135 tests), or, if a split"
-      echo "    is genuinely out of scope, re-run with CQLITE_ALLOW_FILE_GROWTH=1 to acknowledge:"
-      printf '      %s\n' "${grew[@]}"
+      _fs_emit "$log" "--- [$name] FAIL: change makes over-threshold file(s) larger."
+      _fs_emit "$log" "    Split per the campsite rule (epic #1116 source / #1135 tests), or, if a split"
+      _fs_emit "$log" "    is genuinely out of scope, re-run with CQLITE_ALLOW_FILE_GROWTH=1 to acknowledge:"
+      for line in ${grew[@]+"${grew[@]}"}; do
+        _fs_emit "$log" "      $line"
+      done
+      # AC2 (#3401): name the log path in the remedy block. The SUMMARY carries only
+      # `logs: <dir>`, so without this the reader has to guess the filename.
+      _fs_emit "$log" "    Full detail (thresholds, base ref, every entry above): $log"
     fi
   fi
 
   end=$(date +%s)
+  # Terminal verdict goes to the log too, so a reader opening file-size.log alone sees
+  # what the component concluded and never has to correlate with the SUMMARY.
+  _fs_emit "$log" ">>> [$name] $status ($((end - start))s)"
   record_result "$name" "$status" "$((end - start))"
-  echo ">>> [$name] $status ($((end - start))s)"
 }
 
 # scoped-tests (issue #1821, --lite only): the blast-radius-scoped test component.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7308,13 +7308,28 @@ run_file_size() {
         msg+=("      $_g")
       done
     fi
-    if [ "${#grew[@]}" -eq 0 ]; then
+    if [ -z "$base" ]; then
+      # `grown: none` would assert a COMPLETED comparison that never ran — it contradicts
+      # the "ratchet skipped" line above and could conceal real growth (#3401 review
+      # item 2, the fourth instance of this class). `none` is reserved for a comparison
+      # that finished and found nothing.
+      msg+=("    grown: not computed (base unavailable)")
+    elif [ "${#grew[@]}" -eq 0 ]; then
       msg+=("    grown: none")
     else
       msg+=("    grown:")
       for _g in ${grew[@]+"${grew[@]}"}; do
         msg+=("      $_g")
       done
+      # ITEM 1 / roborev F3: record WHY a populated grown list did not fail the ratchet.
+      # Without it the sibling shows grown files beside a non-FAIL verdict with no
+      # provenance — and, from the test side, the allowed-growth state emits bytes
+      # identical to the FAIL state, so nothing can tell the two apart.
+      if [ "${CQLITE_ALLOW_FILE_GROWTH:-0}" = 1 ]; then
+        msg+=("    growth allowance: ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1")
+      else
+        msg+=("    growth allowance: none (CQLITE_ALLOW_FILE_GROWTH unset) — this IS a ratchet violation")
+      fi
     fi
 
     # Write the sibling FIRST and VERIFY WHAT LANDED, then make the claim (#3401 review
@@ -7328,6 +7343,10 @@ run_file_size() {
       done
     fi
     if [ "$sib_ok" = 1 ]; then
+      # MUST stay AFTER the write loop: reading a sibling that is a character device such
+      # as /dev/full returns zeros forever, so a `wc -l` moved above the loop would HANG.
+      # It is safe only because a device like that fails the writes first and leaves
+      # sib_ok=0, short-circuiting this read. Do not "optimise" the order.
       _sib_lines=$(wc -l <"$sib" 2>/dev/null | tr -d ' ')
       [ "${_sib_lines:-0}" = "${#msg[@]}" ] || sib_ok=0
     fi
@@ -7335,7 +7354,10 @@ run_file_size() {
       msg+=("    This block is also written to: $sib")
       printf '%s\n' "    This block is also written to: $sib" 2>/dev/null >>"$sib"
     else
-      msg+=("    (It could NOT be written to $sib — this stdout copy is the only one.)")
+      # Covers all three sub-cases truthfully — truncate failed (no sibling), the append
+      # loop broke mid-block (a PARTIAL sibling exists), or the landed line count differs.
+      # "the only copy" was false for the middle one (#3401 review item 4).
+      msg+=("    (It could NOT be written IN FULL to $sib — stdout carries the complete copy.)")
     fi
     for _m in ${msg[@]+"${msg[@]}"}; do
       printf '%s\n' "$_m"
@@ -7355,8 +7377,11 @@ run_file_size() {
   # review round (#3401 review A2, re-raised as job 138 F1):
   #   * CIRCULARITY: this line's CONTENT IS THE VERDICT, and the verdict depends on the
   #     persistence decision. It cannot be written before the decision it reports.
-  #   * A POST-WRITE RE-CHECK BUYS NOTHING: verifying a write requires a later write, whose
-  #     own success is then unverified — the same one-write window, moved along.
+  #   * A POST-WRITE RE-CHECK BUYS NOTHING: verifying a write requires a later write TO THE
+  #     SAME SINK, whose own success is then unverified — the same one-write window, moved
+  #     along. Checking this append and reporting the failure on STDOUT *is* implementable
+  #     (a different sink needs no further log write), but it would only restate what
+  #     stdout already prints, which is why the bullet below is the load-bearing one.
   #   * THE LOSS IS BOUNDED: everything #3401 exists for (thresholds, base ref, over/grown
   #     entries) is written AND checked above; a failure here costs only the terminal
   #     verdict LINE, which the SUMMARY carries independently.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7380,10 +7380,13 @@ run_file_size() {
   #     terminal verdict it promises;
   #   * to STDOUT *after* record_result, because every other component prints in that
   #     order and a gratuitous divergence is its own bug magnet.
-  # This LAST log write is deliberately UNVERIFIED. The gap is IRREDUCIBLE and the obvious
-  # fix — "attempt and check the terminal append before the final persistence decision" —
-  # is NOT IMPLEMENTABLE, so it is named here and rejected rather than re-derived each
-  # review round (#3401 review A2, re-raised as job 138 F1):
+  # This LAST log write is deliberately UNVERIFIED — an ACCEPTED RESIDUAL under a lead
+  # ruling (Option A, https://github.com/pmcfadin/cqlite/issues/3401#issuecomment-5466376424),
+  # not an open question and not a resolved defect: the code here is unchanged, so nothing
+  # about the substance was answered. The obvious fix — "attempt and check the terminal
+  # append before the final persistence decision" — is not implementable, and the argument
+  # is set out here so it can be weighed on its merits instead of re-derived each review
+  # round (#3401 review A2, re-raised as job 138 F1):
   #   * CIRCULARITY: this line's CONTENT IS THE VERDICT, and the verdict depends on the
   #     persistence decision. It cannot be written before the decision it reports.
   #   * A POST-WRITE RE-CHECK BUYS NOTHING: a read-back can VERIFY the append without
@@ -7395,6 +7398,15 @@ run_file_size() {
   #   * THE LOSS IS BOUNDED: everything #3401 exists for (thresholds, base ref, over/grown
   #     entries) is written AND checked above; a failure here costs only the terminal
   #     verdict LINE, which the SUMMARY carries independently.
+  # WHAT WOULD FALSIFY ALL OF THAT — check it before relying on the argument above. The
+  # rejection holds ONLY WHILE BOTH of these remain true of this call site:
+  #   (a) this line's content IS the component verdict, and
+  #   (b) that verdict depends on the persistence decision computed above.
+  # Break either — record the verdict earlier, write a provisional marker here and amend
+  # it, move the persistence decision after this write — and the circularity is gone, the
+  # check becomes implementable, and THIS REJECTION IS VOID: re-examine the finding on its
+  # merits rather than citing this comment, which would then be arguing for a constraint
+  # that no longer exists.
   printf '%s\n' ">>> [$name] $status ($((end - start))s)" 2>/dev/null >>"$log"
   record_result "$name" "$status" "$((end - start))"
   printf '%s\n' ">>> [$name] $status ($((end - start))s)"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -7251,7 +7251,7 @@ run_file_size() {
   fi
   if [ -n "$log_persist_err" ]; then
     local ratchet_verdict="$status" sib="$LOG_DIR/$name.persistence-error.log" _m _g
-    local sib_ok=1
+    local sib_ok=1 _sib_lines=0
     local -a msg=()
     status=FAIL
     # The diagnostic MUST NOT live on stdout alone: stdout is gate.log, the one file agents
@@ -7260,17 +7260,15 @@ run_file_size() {
     # pattern), which is reachable from the SUMMARY's `logs:` line, and the stdout block
     # names that sibling so both routes lead to it (#3401 review blocker B).
     : 2>/dev/null >"$sib" || sib_ok=0
+    # WORDING is the ONLY thing that varies by ratchet state; the CONTENT below is
+    # unconditional (#3401 review FIX 1).
     if [ "$ratchet_verdict" = FAIL ]; then
       # BOTH failed. Saying "this is NOT a ratchet violation" here would steer the reader
-      # away from a REAL growth violation (#3401 review blocker C), so report both and keep
-      # the remediation data — which would otherwise be lost with the unwritable log.
+      # away from a REAL growth violation (#3401 review blocker C), so report both.
       msg+=("--- [$name] TWO failures: a REAL size-ratchet violation AND a log-persistence failure.")
       msg+=("    (1) RATCHET (a genuine violation — act on this): the change makes over-threshold")
       msg+=("        file(s) larger. Split per the campsite rule (epic #1116 source / #1135 tests),")
-      msg+=("        or re-run with CQLITE_ALLOW_FILE_GROWTH=1 to acknowledge. Grown files:")
-      for _g in ${grew[@]+"${grew[@]}"}; do
-        msg+=("          $_g")
-      done
+      msg+=("        or re-run with CQLITE_ALLOW_FILE_GROWTH=1 to acknowledge.")
       msg+=("    (2) PERSISTENCE: the diagnostic log could not be written: $log")
       msg+=("        Cause: $log_persist_err")
       msg+=("        Fix the log directory (writable? full?) — that half needs no source split.")
@@ -7289,16 +7287,58 @@ run_file_size() {
       msg+=("    Cause: $log_persist_err")
       msg+=("    Fix the log directory (writable? full?) and re-run; no source file needs splitting.")
     fi
-    # Claim the sibling only if it could actually be created (#3401 review L2): an
-    # unconditional "also written to" is the unverified-promise shape this issue is about.
+    # CONTENT — IDENTICAL IN EVERY RATCHET STATE (#3401 review FIX 1). Deriving the
+    # sibling's content from the ratchet verdict has now been wrong three times (the FAIL
+    # state, then the no-base state, then the PASS / CQLITE_ALLOW_FILE_GROWTH state, where
+    # the file names and counts were lost from every reachable artifact — stdout only
+    # reaches gate.log). So the arithmetic is restated unconditionally and only the wording
+    # above varies.
+    msg+=("    --- computed ratchet detail (what the unwritable log would have held) ---")
+    msg+=("    thresholds: src=$SRC_LIMIT test=$TEST_LIMIT (total lines, inline tests included)")
+    if [ -n "$base" ]; then
+      msg+=("    base ref: $base (via $base_src)")
+    else
+      msg+=("    base ref: unavailable — growth ratchet skipped (advisory only)")
+    fi
+    if [ "${#over[@]}" -eq 0 ]; then
+      msg+=("    over threshold: none")
+    else
+      msg+=("    over threshold (current/limit  path):")
+      for _g in ${over[@]+"${over[@]}"}; do
+        msg+=("      $_g")
+      done
+    fi
+    if [ "${#grew[@]}" -eq 0 ]; then
+      msg+=("    grown: none")
+    else
+      msg+=("    grown:")
+      for _g in ${grew[@]+"${grew[@]}"}; do
+        msg+=("      $_g")
+      done
+    fi
+
+    # Write the sibling FIRST and VERIFY WHAT LANDED, then make the claim (#3401 review
+    # FIX 2). `sib_ok` from the truncate alone only proved the file could be OPENED: a
+    # quota/ENOSPC boundary accepts the open and rejects the writes, leaving an empty or
+    # short sibling while stdout asserts the complete block is there. A false pointer is
+    # worse than none — it sends the reader to a file that lacks what they were promised.
+    if [ "$sib_ok" = 1 ]; then
+      for _m in ${msg[@]+"${msg[@]}"}; do
+        printf '%s\n' "$_m" 2>/dev/null >>"$sib" || { sib_ok=0; break; }
+      done
+    fi
+    if [ "$sib_ok" = 1 ]; then
+      _sib_lines=$(wc -l <"$sib" 2>/dev/null | tr -d ' ')
+      [ "${_sib_lines:-0}" = "${#msg[@]}" ] || sib_ok=0
+    fi
     if [ "$sib_ok" = 1 ]; then
       msg+=("    This block is also written to: $sib")
+      printf '%s\n' "    This block is also written to: $sib" 2>/dev/null >>"$sib"
     else
-      msg+=("    (It could NOT also be written to $sib — this stdout copy is the only one.)")
+      msg+=("    (It could NOT be written to $sib — this stdout copy is the only one.)")
     fi
     for _m in ${msg[@]+"${msg[@]}"}; do
       printf '%s\n' "$_m"
-      printf '%s\n' "$_m" 2>/dev/null >>"$sib"
     done
   fi
 
@@ -7309,11 +7349,17 @@ run_file_size() {
   #     terminal verdict it promises;
   #   * to STDOUT *after* record_result, because every other component prints in that
   #     order and a gratuitous divergence is its own bug magnet.
-  # This LAST log write is deliberately UNVERIFIED, and that gap is irreducible: verifying
-  # a write requires a later write, so any re-check only moves the same one-write window
-  # further along. What IS verified is everything #3401 exists for — the thresholds, the
-  # base ref and the growth entries, all written and checked above; a failure here costs
-  # only the terminal verdict LINE, which the SUMMARY carries anyway (#3401 review A2).
+  # This LAST log write is deliberately UNVERIFIED. The gap is IRREDUCIBLE and the obvious
+  # fix — "attempt and check the terminal append before the final persistence decision" —
+  # is NOT IMPLEMENTABLE, so it is named here and rejected rather than re-derived each
+  # review round (#3401 review A2, re-raised as job 138 F1):
+  #   * CIRCULARITY: this line's CONTENT IS THE VERDICT, and the verdict depends on the
+  #     persistence decision. It cannot be written before the decision it reports.
+  #   * A POST-WRITE RE-CHECK BUYS NOTHING: verifying a write requires a later write, whose
+  #     own success is then unverified — the same one-write window, moved along.
+  #   * THE LOSS IS BOUNDED: everything #3401 exists for (thresholds, base ref, over/grown
+  #     entries) is written AND checked above; a failure here costs only the terminal
+  #     verdict LINE, which the SUMMARY carries independently.
   printf '%s\n' ">>> [$name] $status ($((end - start))s)" 2>/dev/null >>"$log"
   record_result "$name" "$status" "$((end - start))"
   printf '%s\n' ">>> [$name] $status ($((end - start))s)"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -396,6 +396,10 @@ has "case5: no-base log carries the terminal verdict" \
 #   devfull  — a SYMLINK TO /dev/full: the truncate SUCCEEDS and every append is rejected
 #              with ENOSPC, so the APPEND-FAILURE COUNTER fires and names its own count.
 #              Also uid-independent.
+#   sibfull  — `dir` PLUS a /dev/full symlink at the SIBLING path: the persistence
+#              diagnostic's own destination accepts the open and rejects every write, which
+#              is the only shape that can make the "also written to" claim FALSE while the
+#              sibling is openable. Also uid-independent.
 #
 # NOT reproducible here, stated rather than quietly omitted: the pure mid-sequence partial
 # write (first append accepted, later ones rejected, leaving a NON-EMPTY but truncated
@@ -425,6 +429,8 @@ case "\$d" in
       case "\${FS_SABOTAGE:-}" in
         dir)     mkdir -p "\$d/file-size.log" ;;
         devfull) ln -s /dev/full "\$d/file-size.log" ;;
+        sibfull) mkdir -p "\$d/file-size.log"
+                 ln -s /dev/full "\$d/file-size.persistence-error.log" ;;
       esac
     fi
     ;;
@@ -581,6 +587,71 @@ STUB
   else
     ok "case10: claims no ratchet verdict for a run that never computed one"
   fi
+
+  # -------------------------------------------------------------------------
+  # Case 11 — the sibling must carry the SAME arithmetic in EVERY ratchet state (#3401
+  # review FIX 1). Concrete regression: CQLITE_ALLOW_FILE_GROWTH=1 (ratchet ALLOWS the
+  # growth, verdict is not FAIL) plus an unwritable log — the file names and counts used to
+  # be omitted from the sibling, i.e. lost from every reachable artifact, because stdout
+  # only reaches gate.log. Every needle below is a REAL computed value (the fixture's own
+  # 900 -> 950, its src limit, its resolved base sha, its current/limit advisory), none of
+  # which any wording or shell message can produce.
+  # -------------------------------------------------------------------------
+  mkrepo optoutpersist cqlite-core/src/big.rs 900 950 main; r11="$REPO"
+  out11="$tmp/optoutpersist.out"
+  run_only_file_size "$r11" "$out11" PATH="$STUBBIN:$PATH" FS_SABOTAGE=dir \
+      CQLITE_ALLOW_FILE_GROWTH=1
+  d11=$(logdir_of "$out11") || bad "case11: the run published no usable 'logs:' dir"
+  sib11="$d11/file-size.persistence-error.log"
+  base11=$( cd "$r11" 2>/dev/null && git rev-parse HEAD 2>/dev/null )
+  [ -n "$base11" ] ||
+    bad "case11: could not capture the fixture's base sha — the base-ref assert cannot measure anything"
+
+  assert_verdict "case11: unpersistable log on the ALLOWED-growth path is still a FAIL" "$d11" FAIL
+  has "case11: the sibling preserves the exact grown-file entry on a NON-FAIL ratchet state" \
+      "$sib11" "cqlite-core/src/big.rs: 900 -> 950 (limit 800)"
+  has "case11: the sibling preserves the thresholds" \
+      "$sib11" "thresholds: src=800 test=1500"
+  has "case11: the sibling preserves the resolved base sha" "$sib11" "$base11"
+  has "case11: the sibling preserves the over-threshold advisory entry" "$sib11" "950/800"
+
+  # -------------------------------------------------------------------------
+  # Case 12 — the "also written to" claim must be VERIFIED, not assumed (#3401 review
+  # FIX 2). With the sibling itself pointed at /dev/full the open succeeds and every write
+  # is rejected, so a claim based on the truncate alone would send the reader to an EMPTY
+  # file for the block. The two needles are complementary and each is reachable from
+  # exactly one branch: the negative wording exists only when the verification failed, and
+  # the positive wording is asserted ABSENT, so a code path that always claimed success
+  # could not satisfy both.
+  # -------------------------------------------------------------------------
+  if [ ! -c /dev/full ]; then
+    skip "case12: no /dev/full (macOS/BSD) — sibling-sabotage control not run"
+    skip "case12: no /dev/full (macOS/BSD) — FAIL verdict not asserted"
+    skip "case12: no /dev/full (macOS/BSD) — honest negative claim not asserted"
+    skip "case12: no /dev/full (macOS/BSD) — absence of the false claim not asserted"
+  else
+    mkrepo sibfail cqlite-core/src/small.rs 20 0 main; r12="$REPO"
+    out12="$tmp/sibfail.out"
+    run_only_file_size "$r12" "$out12" PATH="$STUBBIN:$PATH" FS_SABOTAGE=sibfull
+    d12=$(logdir_of "$out12") || bad "case12: the run published no usable 'logs:' dir"
+    sib12="$d12/file-size.persistence-error.log"
+
+    if [ -L "$sib12" ] && [ "$(readlink "$sib12")" = /dev/full ] && [ -d "$d12/file-size.log" ]; then
+      ok "case12: sabotage in place (log is a directory AND the sibling is -> /dev/full)"
+    else
+      bad "case12: sabotage did NOT take effect — the unverifiable-sibling path was never exercised"
+    fi
+    assert_verdict "case12: an unwritable log with an unwritable sibling is still a FAIL" "$d12" FAIL
+    has "case12: stdout says the block could NOT be written to the sibling" \
+        "$out12" "It could NOT be written to $sib12"
+    if [ ! -s "$out12" ]; then
+      bad "case12: no gate stdout captured — the false-claim check could not run"
+    elif grep -Fq -- "also written to: $sib12" "$out12"; then
+      bad "case12: stdout claims the block was written to a sibling that rejected every write"
+    else
+      ok "case12: stdout makes no false 'also written to' claim"
+    fi
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -593,7 +664,7 @@ printf 'file-size component log guard (#3401): %d passed, %d failed, %d skipped\
 # precondition failure (an unusable repo, a missing mktemp) short-circuits its case's
 # remaining asserts and lands here too, so the message names both causes rather than
 # misattributing one as the other.
-EXPECTED_CHECKS=61
+EXPECTED_CHECKS=70
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -71,7 +71,15 @@ if [ ! -r "$GATE" ]; then
   exit 1
 fi
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-file-size.XXXXXX")
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-file-size.XXXXXX") || tmp=""
+# An unchecked mktemp is not a small risk here: an empty $tmp makes `export TMPDIR=""`
+# fall back to /tmp, the EXIT trap `rm -rf ""` clean nothing, and every fixture path
+# absolute-from-root — which a normal user survives as a loud failure but ROOT (containers)
+# survives as six uncleaned fixture repos littered into `/`.
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  printf 'FAIL - could not create a scratch dir under %s — refusing to run\n' "${TMPDIR:-/tmp}"
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT INT TERM
 # Contain each gate run's LOG_DIR (mktemp -d "${TMPDIR:-/tmp}/agent-gate.XXXXXX") inside
 # this run's namespace so the trap above reclaims them too.
@@ -328,14 +336,30 @@ has "case4: opt-out log carries the terminal PASS verdict" \
 # the log must say so EXPLICITLY, while the advisory list still works off `git diff HEAD`.
 # ---------------------------------------------------------------------------
 mkrepo nobase cqlite-core/src/big.rs 900 950 work; r5="$REPO"
-# Affirmative precondition: the fixture must really have no ref the gate can resolve.
-# Without this the case could pass on a repo that DOES have a base, having proved nothing.
-if [ -n "$r5" ] && ! ( cd "$r5" && for ref in origin/main main origin/master master; do
-       git rev-parse --verify -q "$ref" >/dev/null 2>&1 && exit 0; done; exit 1 ); then
-  ok "case5: fixture genuinely resolves none of origin/main|main|origin/master|master"
+# Affirmative precondition WITH A POSITIVE CONTROL (#3401 review blocker A). As a PURE
+# NEGATIVE (`! ( cd … && for … )`) this printed `ok` for ANY reason the subshell exited
+# non-zero: a missing or unreadable $r5 makes `cd` short-circuit the `&&`, ZERO rev-parse
+# calls run, and "I could not even look" reads as "I looked and found none" — the same
+# fail-open shape the round-1 sweep removed elsewhere. The probe now reports three
+# distinct states, and only the one that PROVES it looked can pass.
+if [ -z "$r5" ]; then
+  case5_probe=2
 else
-  bad "case5: fixture DOES resolve a base ref (or is missing) — the no-base path is not being exercised"
+  ( cd "$r5" 2>/dev/null || exit 2
+    # positive control: we are in a usable git repo, so a "no ref resolved" answer below
+    # is a measurement rather than an inability to measure.
+    git rev-parse --verify -q HEAD >/dev/null 2>&1 || exit 2
+    for ref in origin/main main origin/master master; do
+      git rev-parse --verify -q "$ref" >/dev/null 2>&1 && exit 0
+    done
+    exit 1 )
+  case5_probe=$?
 fi
+case "$case5_probe" in
+  1) ok "case5: probe RAN and resolved none of origin/main|main|origin/master|master" ;;
+  0) bad "case5: fixture DOES resolve a base ref — the no-base path is not being exercised" ;;
+  *) bad "case5: could not probe the fixture's refs at all (unusable repo at '$r5') — precondition UNMEASURED" ;;
+esac
 out5="$tmp/nobase.out"
 run_only_file_size "$r5" "$out5"
 d5=$(logdir_of "$out5") || bad "case5: the run published no usable 'logs:' dir"
@@ -351,10 +375,80 @@ has "case5: no-base log carries the terminal verdict" \
     "$log5" ">>> [file-size] PASS"
 
 # ---------------------------------------------------------------------------
+# Case 7 — LOG PERSISTENCE (#3401 review blocker B). The component now PROMISES a log, so
+# an unverified promise is the original defect one level up: an agent follows the SUMMARY's
+# `logs:` pointer, finds nothing, and is back to hand-computing line counts. If the log
+# cannot be persisted the component must FAIL, must name the PERSISTENCE cause, and must
+# NOT read as a campsite-rule violation (a bare FAIL meaning "my log dir is unwritable"
+# would send the reader hunting for a grown source file that does not exist).
+#
+# The sabotage is surgical and uid-independent: a PATH-shim `mktemp` lets the gate create
+# its LOG_DIR normally and then pre-creates `file-size.log` as a DIRECTORY inside it, so
+# `: >"$log"` cannot succeed while every other LOG_DIR write (tree-identity capture,
+# .result, summary) still works. `chmod 500 $LOG_DIR` was rejected: it is a NO-OP FOR ROOT
+# (the case would silently self-skip in containers — the very "invisible skip" this suite
+# is meant not to have) and it would also break the gate's own tree-identity capture, i.e.
+# fail the run for a reason other than the property under test. `: > <dir>` fails for
+# every uid, so this case needs no skip path at all.
+#
+# The fixture is a CLEAN tree, so the ratchet's own verdict is PASS and the component's
+# FAIL can only have come from persistence.
+# ---------------------------------------------------------------------------
+STUBBIN="$tmp/stubbin"
+mkdir -p "$STUBBIN"
+REAL_MKTEMP=$(command -v mktemp 2>/dev/null)
+if [ -z "$REAL_MKTEMP" ]; then
+  bad "case7: no mktemp on PATH — the persistence path CANNOT be exercised (not a skip: this suite needs it)"
+else
+  cat >"$STUBBIN/mktemp" <<STUB
+#!/usr/bin/env bash
+d=\$("$REAL_MKTEMP" "\$@") || exit 1
+case "\$d" in
+  */agent-gate.*) [ -d "\$d" ] && mkdir -p "\$d/file-size.log" ;;
+esac
+printf '%s\n' "\$d"
+STUB
+  chmod +x "$STUBBIN/mktemp"
+
+  mkrepo persist cqlite-core/src/small.rs 20 0 main; r7="$REPO"
+  out7="$tmp/persist.out"
+  run_only_file_size "$r7" "$out7" PATH="$STUBBIN:$PATH"
+  d7=$(logdir_of "$out7") || bad "case7: the run published no usable 'logs:' dir"
+
+  # POSITIVE CONTROL — without this, a FAIL below could have come from anywhere.
+  if [ -d "$d7/file-size.log" ]; then
+    ok "case7: sabotage in place (file-size.log is a directory, so the component cannot write it)"
+  else
+    bad "case7: sabotage did NOT take effect at '$d7/file-size.log' — the persistence path was never exercised"
+  fi
+  assert_verdict "case7: an unpersistable log makes the component FAIL (never a silent PASS)" "$d7" FAIL
+  has "case7: stdout names the failure as PERSISTENCE, not a ratchet violation" \
+      "$out7" "LOG PERSISTENCE FAILURE"
+  has "case7: stdout names the path that could not be written" \
+      "$out7" "$d7/file-size.log"
+  has "case7: stdout states the ratchet's OWN verdict in the same breath" \
+      "$out7" "The size ratchet itself computed: PASS"
+  if [ ! -s "$out7" ]; then
+    bad "case7: no gate stdout captured — the wording check could not run"
+  elif grep -Fq -- "change makes over-threshold file(s) larger" "$out7"; then
+    bad "case7: a persistence failure was reported with campsite-rule/ratchet wording"
+  else
+    ok "case7: the persistence FAIL carries no campsite-rule/ratchet wording"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 printf '\n%s\n' "----------------------------------------"
 printf 'file-size component log guard (#3401): %d passed, %d failed\n' "$PASS" "$FAIL"
+# Census, not a floor (#3401 review N4): the assertion count is control-flow-invariant
+# here — every case runs unconditionally — so `PASS + FAIL` must equal it EXACTLY. A floor
+# with slack tolerates silently deleted assertions, which is the vacuous-green shape this
+# suite exists to refuse.
+EXPECTED_CHECKS=42
+if [ "$((PASS + FAIL))" -ne "$EXPECTED_CHECKS" ]; then
+  printf 'FAIL - assertion census mismatch: %d checks ran, expected exactly %d (one was added, deleted or skipped)\n' \
+    "$((PASS + FAIL))" "$EXPECTED_CHECKS"
+  exit 1
+fi
 [ "$FAIL" -eq 0 ] || exit 1
-# Floor against a vacuous green: a harness that silently skipped its cases would otherwise
-# report `0 passed, 0 failed` and exit 0.
-[ "$PASS" -ge 34 ] || { printf 'FAIL - vacuous run: only %d checks executed\n' "$PASS"; exit 1; }
 exit 0

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -580,6 +580,12 @@ STUB
   assert_verdict "case10: unpersistable log on a no-base run is a FAIL" "$d10" FAIL
   has "case10: the diagnostic says the ratchet was SKIPPED, not that it computed a verdict" \
       "$out10" "The size ratchet was SKIPPED (base ref unavailable)"
+  # `grown: none` on a run that never compared anything asserts a COMPLETED comparison and
+  # can conceal real growth (#3401 review item 2). This fixture DID grow its file 900->950,
+  # so a "none" here would be an actively false statement; only the not-computed wording
+  # can be true, and it is emitted from the no-base branch alone.
+  has "case10: the sibling reports growth as NOT COMPUTED, never as 'none'" \
+      "$d10/file-size.persistence-error.log" "grown: not computed (base unavailable)"
   if [ ! -s "$out10" ]; then
     bad "case10: no gate stdout captured — the false-computation check could not run"
   elif grep -Fq -- "The size ratchet itself computed:" "$out10"; then
@@ -614,6 +620,16 @@ STUB
       "$sib11" "thresholds: src=800 test=1500"
   has "case11: the sibling preserves the resolved base sha" "$sib11" "$base11"
   has "case11: the sibling preserves the over-threshold advisory entry" "$sib11" "950/800"
+  # THE MISSING POSITIVE CONTROL (#3401 review item 1). F3 made the sibling's content
+  # unconditional, which made every needle above BYTE-IDENTICAL to what the FAIL branch
+  # emits on this same fixture (case 9 asserts the first one) — so if
+  # CQLITE_ALLOW_FILE_GROWTH=1 ever stopped reaching the run, this case would silently
+  # degrade into a second copy of case 9 and pass without ever entering the allowed-growth
+  # state it exists to cover. This needle is emitted ONLY when the allowance is what let a
+  # populated grown list pass, and the FAIL branch emits the "none (… unset)" variant
+  # instead, so it cannot be satisfied from any other state.
+  has "case11: CONTROL — the sibling records the allowance as the reason the ratchet passed" \
+      "$sib11" "growth allowance: ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1"
 
   # -------------------------------------------------------------------------
   # Case 12 — the "also written to" claim must be VERIFIED, not assumed (#3401 review
@@ -642,8 +658,8 @@ STUB
       bad "case12: sabotage did NOT take effect — the unverifiable-sibling path was never exercised"
     fi
     assert_verdict "case12: an unwritable log with an unwritable sibling is still a FAIL" "$d12" FAIL
-    has "case12: stdout says the block could NOT be written to the sibling" \
-        "$out12" "It could NOT be written to $sib12"
+    has "case12: stdout says the block could NOT be written IN FULL to the sibling" \
+        "$out12" "It could NOT be written IN FULL to $sib12"
     if [ ! -s "$out12" ]; then
       bad "case12: no gate stdout captured — the false-claim check could not run"
     elif grep -Fq -- "also written to: $sib12" "$out12"; then
@@ -664,7 +680,7 @@ printf 'file-size component log guard (#3401): %d passed, %d failed, %d skipped\
 # precondition failure (an unusable repo, a missing mktemp) short-circuits its case's
 # remaining asserts and lands here too, so the message names both causes rather than
 # misattributing one as the other.
-EXPECTED_CHECKS=70
+EXPECTED_CHECKS=72
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -626,10 +626,37 @@ STUB
   # CQLITE_ALLOW_FILE_GROWTH=1 ever stopped reaching the run, this case would silently
   # degrade into a second copy of case 9 and pass without ever entering the allowed-growth
   # state it exists to cover. This needle is emitted ONLY when the allowance is what let a
-  # populated grown list pass, and the FAIL branch emits the "none (… unset)" variant
+  # populated grown list pass, and every other state emits a "NOT enabled — …" variant
   # instead, so it cannot be satisfied from any other state.
   has "case11: CONTROL — the sibling records the allowance as the reason the ratchet passed" \
       "$sib11" "growth allowance: ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1"
+
+  # -------------------------------------------------------------------------
+  # Case 13 — CQLITE_ALLOW_FILE_GROWTH set to a NON-1 value (#3401 review item 3). The
+  # branch distinguishing "set to something that is not 1" from "never set" was otherwise
+  # unexercised, so it could regress while the suite stayed green. Saying "unset" to
+  # someone who DID set the variable hides the one fact that fixes their invocation.
+  # The needle is the SUPPLIED VALUE itself (`set to 'true'`): no other branch can emit it
+  # — the =1 branch prints the ALLOWED line and the genuinely-unset branch prints "is not
+  # set" — so the assert cannot pass unless this run really read that value back out.
+  # -------------------------------------------------------------------------
+  mkrepo badallow cqlite-core/src/big.rs 900 950 main; r13="$REPO"
+  out13="$tmp/badallow.out"
+  run_only_file_size "$r13" "$out13" PATH="$STUBBIN:$PATH" FS_SABOTAGE=dir \
+      CQLITE_ALLOW_FILE_GROWTH=true
+  d13=$(logdir_of "$out13") || bad "case13: the run published no usable 'logs:' dir"
+  sib13="$d13/file-size.persistence-error.log"
+
+  assert_verdict "case13: a non-1 allowance value does NOT allow the growth (still FAIL)" "$d13" FAIL
+  has "case13: the sibling reports the SUPPLIED value, so the reader can see why it did not take" \
+      "$sib13" "CQLITE_ALLOW_FILE_GROWTH is set to 'true', expected exactly 1"
+  if [ ! -s "$sib13" ]; then
+    bad "case13: no sibling written — the unset-vs-wrong-value distinction could not be checked"
+  elif grep -Fq -- "CQLITE_ALLOW_FILE_GROWTH is not set" "$sib13"; then
+    bad "case13: claims the variable is NOT SET on a run that supplied a value"
+  else
+    ok "case13: never claims the variable is unset when a value was supplied"
+  fi
 
   # -------------------------------------------------------------------------
   # Case 12 — the "also written to" claim must be VERIFIED, not assumed (#3401 review
@@ -680,7 +707,7 @@ printf 'file-size component log guard (#3401): %d passed, %d failed, %d skipped\
 # precondition failure (an unusable repo, a missing mktemp) short-circuits its case's
 # remaining asserts and lands here too, so the message names both causes rather than
 # misattributing one as the other.
-EXPECTED_CHECKS=72
+EXPECTED_CHECKS=75
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Regression test for issue #3401: the `file-size` gate component must PERSIST its
+# arithmetic as $LOG_DIR/file-size.log, on EVERY invocation.
+#
+# The defect: run_file_size computed the base ref, the over-threshold advisory list and
+# the exact `path: before -> after (limit N)` growth entries, echoed them to STDOUT — i.e.
+# into gate.log, the one file CLAUDE.md forbids an agent to read — and wrote only a bare
+# `file-size.result` (`FAIL 0`). So a `file-size: FAIL` in a pasted SUMMARY named NOTHING:
+# not the file, not the line counts, not the limit. Every reader re-derived by hand the
+# arithmetic the component had just thrown away, and that FAIL is routinely EXPECTED (a
+# legitimate diff that grows a big file), so the cost is paid often.
+#
+# The property pinned here is the LOG'S CONTENT, never its mere existence — a zero-byte or
+# contentless file would satisfy "a log is written" while restoring the whole defect. Each
+# case therefore asserts the REAL numbers (`900 -> 950 (limit 800)`), the REAL base sha,
+# the thresholds and the terminal verdict.
+#
+# Six paths through run_file_size, because the log must exist on ALL of them (AC3):
+#   1. grown + over threshold          -> FAIL
+#   2. over threshold but SHRUNK       -> PASS (advisory list, empty ratchet)
+#   3. no changed .rs files at all     -> PASS ("nothing over threshold" still logged)
+#   4. grown + CQLITE_ALLOW_FILE_GROWTH=1 -> PASS (the opt-out is RECORDED)
+#   5. base ref unresolvable           -> PASS (advisory only, ratchet skipped)
+#   6. AC2: the FAIL stdout NAMES $LOG_DIR/file-size.log, so it is reachable from the
+#      SUMMARY's existing `logs:` line without the reader guessing a filename.
+#
+# Hermetic and fast: throwaway git repos under one mktemp, each holding ONLY a copy of the
+# gate script (so the gate's `cd "$(dirname "$0")/.."` resolves REPO_ROOT into the temp
+# tree) plus a synthetic .rs file. Driven through the REAL `--only file-size` path, which
+# skips the dataset preflight and compiles nothing. No cargo, no network, no datasets, no
+# Docker. TMPDIR is redirected so every gate LOG_DIR also lands inside this run's namespace.
+#
+# Run standalone:   bash scripts/tests/test_agent_gate_file_size_log.sh
+# Or via the gate:  scripts/agent-gate.sh runs it inside the `tooling-tests` component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+
+# Never inherit a caller's summary path / parent marker (#2751/#2874 discipline), and
+# never block on the machine-wide gate slot (#1825) — these runs compile nothing.
+unset AGENT_GATE_SUMMARY_FILE
+unset AGENT_GATE_PARENT_RUN_ID
+unset GATE_BASE_OVERRIDE
+unset CQLITE_ALLOW_FILE_GROWTH
+export CQLITE_GATE_DISABLE_CAP=1
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-file-size.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT INT TERM
+# Contain each gate run's LOG_DIR (mktemp -d "${TMPDIR:-/tmp}/agent-gate.XXXXXX") inside
+# this run's namespace so the trap above reclaims them too.
+export TMPDIR="$tmp"
+
+GIT_ID=(-c user.email=gate@example.invalid -c user.name=gate-selftest)
+
+# lines <n> <path> — write exactly <n> newline-terminated lines (so `wc -l` == n).
+lines() { awk -v n="$1" 'BEGIN { for (i = 1; i <= n; i++) print "// filler line " i }' >"$2"; }
+
+# mkrepo <name> <rs-relpath> <committed-lines> <worktree-lines> <branch>
+#   Commits a .rs file of <committed-lines>, then rewrites the WORKTREE copy to
+#   <worktree-lines>. A <worktree-lines> of 0 means "leave the commit untouched".
+mkrepo() {
+  local name="$1" rel="$2" nbase="$3" nhead="$4" branch="$5"
+  local root="$tmp/$name"
+  mkdir -p "$root/scripts" "$root/$(dirname "$rel")"
+  cp "$GATE" "$root/scripts/agent-gate.sh"
+  printf 'target/\n*.log\n.agent-gate-summary.txt\n' >"$root/.gitignore"
+  lines "$nbase" "$root/$rel"
+  ( cd "$root" && git init -q -b "$branch" . && git add -A &&
+      git "${GIT_ID[@]}" commit -qm init ) >/dev/null 2>&1
+  [ "$nhead" -gt 0 ] && lines "$nhead" "$root/$rel"
+  printf '%s\n' "$root"
+}
+
+# run_only_file_size <repo> <outfile> [KEY=VAL …] -> exit status of the gate run
+run_only_file_size() {
+  local repo="$1" out="$2"; shift 2
+  ( cd "$repo" && env ${1+"$@"} AGENT_GATE_SUMMARY_FILE="$repo/.sum" \
+      bash "$repo/scripts/agent-gate.sh" --only file-size >"$out" 2>&1 )
+}
+
+# The component log is reachable ONLY via the SUMMARY's `logs:` line — read it from there
+# rather than from an env var, so the test proves that route works (AC2's premise).
+logdir_of() { sed -n 's/^logs:[[:space:]]*//p' "$1" | head -1; }
+
+# verdict_of <logdir> — the component's own verdict, read from the UNCHANGED
+# `file-size.result` (`STATUS SECONDS`). Deliberately NOT the gate's exit status: a
+# passing `--only` run exits 3 (RESULT: PARTIAL) and a failing one exits 1, so an
+# exit-code assert would conflate "the component failed" with "this was a partial run".
+verdict_of() { read -r _st _secs <"$1/file-size.result" 2>/dev/null; printf '%s\n' "${_st:-<no-result-file>}"; }
+
+# has <label> <file> <literal> — the workhorse content assert.
+has() {
+  if [ -f "$2" ] && grep -Fq -- "$3" "$2"; then ok "$1"; else
+    bad "$1 (missing: '$3')"
+  fi
+}
+
+# assert_log_present <label> <logfile> — existence AND non-emptiness, per AC3.
+assert_log_present() {
+  if [ -f "$2" ] && [ -s "$2" ]; then
+    ok "$1"
+  elif [ -f "$2" ]; then
+    bad "$1 — file-size.log exists but is ZERO BYTES ($2)"
+  else
+    bad "$1 — no file-size.log written at all ($2)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 — FAIL: an over-threshold source file GROWN by the diff (800-line src limit).
+# ---------------------------------------------------------------------------
+r1=$(mkrepo grew cqlite-core/src/big.rs 900 950 main)
+out1="$tmp/grew.out"
+run_only_file_size "$r1" "$out1"
+d1=$(logdir_of "$out1")
+log1="$d1/file-size.log"
+base1=$( cd "$r1" && git rev-parse HEAD )
+
+if [ "$(verdict_of "$d1")" = FAIL ]; then
+  ok "case1: --only file-size FAILs on a grown over-threshold file (the case being diagnosed)"
+else
+  bad "case1: --only file-size did NOT fail on a grown over-threshold file — fixture is wrong"
+fi
+assert_log_present "case1: file-size.log written on the FAIL path" "$log1"
+# The REAL numbers, not merely digits: 900 committed -> 950 in the worktree, src limit 800.
+has "case1: log carries the exact growth entry (path + before -> after + limit)" \
+    "$log1" "cqlite-core/src/big.rs: 900 -> 950 (limit 800)"
+has "case1: log states the thresholds applied" \
+    "$log1" "thresholds: src=800 test=1500"
+has "case1: log states the metric (total lines, inline tests included)" \
+    "$log1" "total lines, inline tests included"
+has "case1: log names the resolved base sha used for the growth comparison" \
+    "$log1" "$base1"
+has "case1: log carries the over-threshold advisory entry (current/limit + path)" \
+    "$log1" "950/800"
+has "case1: log carries the terminal verdict line for the component" \
+    "$log1" ">>> [file-size] FAIL"
+has "case1: log carries the remedy (CQLITE_ALLOW_FILE_GROWTH acknowledgement)" \
+    "$log1" "CQLITE_ALLOW_FILE_GROWTH=1"
+
+# ---------------------------------------------------------------------------
+# Case 6 (AC2) — the FAIL stdout must NAME the log path, so a reader who has only the
+# SUMMARY's `logs: <dir>` line does not have to guess the filename.
+# ---------------------------------------------------------------------------
+has "case6/AC2: FAIL stdout names the component log path explicitly" "$out1" "$log1"
+
+# ---------------------------------------------------------------------------
+# Case 2 — PASS: over threshold but SHRUNK by the diff. The advisory list must still be
+# logged, the ratchet must be empty, and the log must SAY it passed.
+# ---------------------------------------------------------------------------
+r2=$(mkrepo shrank cqlite-core/src/big.rs 950 900 main)
+out2="$tmp/shrank.out"
+run_only_file_size "$r2" "$out2"
+d2=$(logdir_of "$out2")
+log2="$d2/file-size.log"
+
+if [ "$(verdict_of "$d2")" = PASS ]; then
+  ok "case2: a shrunk over-threshold file PASSes the ratchet (fixture is a real PASS run)"
+else
+  bad "case2: a shrunk over-threshold file did NOT pass — fixture is wrong"
+fi
+assert_log_present "case2: file-size.log written on a PASS run too (AC3)" "$log2"
+has "case2: PASS log still carries the over-threshold advisory entry" \
+    "$log2" "900/800"
+has "case2: PASS log carries the terminal PASS verdict" \
+    "$log2" ">>> [file-size] PASS"
+if [ ! -f "$log2" ]; then
+  bad "case2: cannot check the ratchet emptiness — no log to read"
+elif grep -Fq -- '-> ' "$log2"; then
+  bad "case2: PASS log lists a growth entry for a file that SHRANK"
+else
+  ok "case2: PASS log lists no growth entry (ratchet genuinely empty)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 — PASS with NO changed .rs files at all: an empty-ish run still gets a log that
+# SAYS SO (never an absent file, never a zero-byte one).
+# ---------------------------------------------------------------------------
+r3=$(mkrepo clean cqlite-core/src/small.rs 20 0 main)
+out3="$tmp/clean.out"
+run_only_file_size "$r3" "$out3"
+d3=$(logdir_of "$out3")
+log3="$d3/file-size.log"
+
+if [ "$(verdict_of "$d3")" = PASS ]; then
+  ok "case3: a clean tree PASSes file-size"
+else
+  bad "case3: a clean tree did NOT pass file-size — fixture is wrong"
+fi
+assert_log_present "case3: file-size.log written even with nothing to report (AC3)" "$log3"
+has "case3: empty-ish log states that nothing is over threshold" \
+    "$log3" "no changed .rs files over threshold"
+has "case3: empty-ish log still states the thresholds" \
+    "$log3" "thresholds: src=800 test=1500"
+has "case3: empty-ish log still carries the terminal verdict" \
+    "$log3" ">>> [file-size] PASS"
+
+# ---------------------------------------------------------------------------
+# Case 4 — the CQLITE_ALLOW_FILE_GROWTH=1 opt-out. The growth is ALLOWED, and the log must
+# RECORD what was allowed (the numbers are the whole point of the acknowledgement).
+# ---------------------------------------------------------------------------
+r4=$(mkrepo optout cqlite-core/src/big.rs 900 950 main)
+out4="$tmp/optout.out"
+run_only_file_size "$r4" "$out4" CQLITE_ALLOW_FILE_GROWTH=1
+d4=$(logdir_of "$out4")
+log4="$d4/file-size.log"
+
+if [ "$(verdict_of "$d4")" = PASS ]; then
+  ok "case4: CQLITE_ALLOW_FILE_GROWTH=1 turns the same growth into a PASS"
+else
+  bad "case4: CQLITE_ALLOW_FILE_GROWTH=1 did not allow the growth — fixture is wrong"
+fi
+assert_log_present "case4: file-size.log written on the opt-out path (AC3)" "$log4"
+has "case4: opt-out log records the acknowledgement" \
+    "$log4" "ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1"
+has "case4: opt-out log still records the exact growth entry" \
+    "$log4" "cqlite-core/src/big.rs: 900 -> 950 (limit 800)"
+has "case4: opt-out log carries the terminal PASS verdict" \
+    "$log4" ">>> [file-size] PASS"
+
+# ---------------------------------------------------------------------------
+# Case 5 — base ref UNRESOLVABLE (no main/master, no origin/*): the ratchet is skipped and
+# the log must say so EXPLICITLY, while the advisory list still works off `git diff HEAD`.
+# ---------------------------------------------------------------------------
+r5=$(mkrepo nobase cqlite-core/src/big.rs 900 950 work)
+out5="$tmp/nobase.out"
+run_only_file_size "$r5" "$out5"
+d5=$(logdir_of "$out5")
+log5="$d5/file-size.log"
+
+if [ "$(verdict_of "$d5")" = PASS ]; then
+  ok "case5: with no resolvable base ref the component is advisory-only and PASSes"
+else
+  bad "case5: no-base run did not PASS — the ratchet ran without a base ref"
+fi
+assert_log_present "case5: file-size.log written on the no-base path (AC3)" "$log5"
+has "case5: no-base log states the ratchet was skipped, in those words" \
+    "$log5" "base ref unavailable — growth ratchet skipped (advisory only)"
+has "case5: no-base log still carries the advisory over-threshold entry" \
+    "$log5" "cqlite-core/src/big.rs"
+has "case5: no-base log carries the terminal verdict" \
+    "$log5" ">>> [file-size] PASS"
+
+# ---------------------------------------------------------------------------
+printf '\n%s\n' "----------------------------------------"
+printf 'file-size component log guard (#3401): %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+[ "$PASS" -ge 25 ] || { printf 'FAIL - vacuous run: only %d checks executed\n' "$PASS"; exit 1; }
+exit 0

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -15,20 +15,36 @@
 # case therefore asserts the REAL numbers (`900 -> 950 (limit 800)`), the REAL base sha,
 # the thresholds and the terminal verdict.
 #
-# Six paths through run_file_size, because the log must exist on ALL of them (AC3):
-#   1. grown + over threshold          -> FAIL
-#   2. over threshold but SHRUNK       -> PASS (advisory list, empty ratchet)
-#   3. no changed .rs files at all     -> PASS ("nothing over threshold" still logged)
+# Seven paths through run_file_size, because the log must exist on ALL of them (AC3):
+#   1. grown + over threshold             -> FAIL
+#   2. over threshold but SHRUNK          -> PASS (advisory list, empty ratchet)
+#   3. no changed .rs files at all        -> PASS ("nothing over threshold" still logged)
+#   3b. changed .rs files, none over the threshold -> PASS (same log line, DIFFERENT input:
+#       case 3's tree is clean, so on its own it never proves a CHANGED-but-small file is
+#       handled — only that the component ran with an empty file list)
 #   4. grown + CQLITE_ALLOW_FILE_GROWTH=1 -> PASS (the opt-out is RECORDED)
-#   5. base ref unresolvable           -> PASS (advisory only, ratchet skipped)
+#   5. base ref unresolvable              -> PASS (advisory only, ratchet skipped)
 #   6. AC2: the FAIL stdout NAMES $LOG_DIR/file-size.log, so it is reachable from the
 #      SUMMARY's existing `logs:` line without the reader guessing a filename.
+#
+# EVERY HELPER HERE FAILS CLOSED (repo doctrine: a positive verdict requires an affirmative
+# measurement). A helper whose measurement did not happen must never let an assertion print
+# `ok` — so `verdict_of` returns a sentinel no assert accepts rather than leaking the
+# PREVIOUS case's verdict through non-`local` state, `has` refuses an EMPTY needle (an empty
+# `grep -F` pattern matches every line), `logdir_of` refuses a missing/relative/nonexistent
+# `logs:` dir (an empty one would make the AC2 needle the SUFFIX `/file-size.log`, which is
+# a substring of the real path and would MATCH having measured nothing), and `mkrepo`
+# CHECKS its git setup and re-measures the line counts it just wrote instead of discarding
+# stderr.
 #
 # Hermetic and fast: throwaway git repos under one mktemp, each holding ONLY a copy of the
 # gate script (so the gate's `cd "$(dirname "$0")/.."` resolves REPO_ROOT into the temp
 # tree) plus a synthetic .rs file. Driven through the REAL `--only file-size` path, which
 # skips the dataset preflight and compiles nothing. No cargo, no network, no datasets, no
-# Docker. TMPDIR is redirected so every gate LOG_DIR also lands inside this run's namespace.
+# Docker. TMPDIR is redirected so every gate LOG_DIR also lands inside this run's namespace,
+# and the fixture repos are cut off from the invoker's git config (a global
+# `commit.gpgsign=true` / `core.hooksPath` would otherwise break every fixture commit and
+# red the gate of record for a reason unrelated to the property under test).
 #
 # Run standalone:   bash scripts/tests/test_agent_gate_file_size_log.sh
 # Or via the gate:  scripts/agent-gate.sh runs it inside the `tooling-tests` component.
@@ -50,13 +66,27 @@ FAIL=0
 ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
 bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
 
+if [ ! -r "$GATE" ]; then
+  printf 'FAIL - agent-gate.sh not readable at %s — nothing to test\n' "$GATE"
+  exit 1
+fi
+
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-file-size.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT INT TERM
 # Contain each gate run's LOG_DIR (mktemp -d "${TMPDIR:-/tmp}/agent-gate.XXXXXX") inside
 # this run's namespace so the trap above reclaims them too.
 export TMPDIR="$tmp"
 
-GIT_ID=(-c user.email=gate@example.invalid -c user.name=gate-selftest)
+# Fixture git must be isolated from the INVOKER's environment, not merely given an
+# identity: `git init`/`git commit` also read global `commit.gpgsign`, `core.hooksPath`
+# and `init.templateDir`, any one of which turns a fixture commit into a hard failure on
+# someone's box. GIT_CONFIG_GLOBAL/SYSTEM=/dev/null kills all three vectors at once (the
+# convention scripts/tests/lib/perf-capability-test-lib.sh already uses); the explicit
+# `-c` flags below are the belt-and-braces half, and also pin the branch name.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+GIT_CFG=(-c user.email=gate@example.invalid -c user.name=gate-selftest
+         -c init.defaultBranch=main -c commit.gpgsign=false)
 
 # lines <n> <path> — write exactly <n> newline-terminated lines (so `wc -l` == n).
 lines() { awk -v n="$1" 'BEGIN { for (i = 1; i <= n; i++) print "// filler line " i }' >"$2"; }
@@ -64,41 +94,95 @@ lines() { awk -v n="$1" 'BEGIN { for (i = 1; i <= n; i++) print "// filler line 
 # mkrepo <name> <rs-relpath> <committed-lines> <worktree-lines> <branch>
 #   Commits a .rs file of <committed-lines>, then rewrites the WORKTREE copy to
 #   <worktree-lines>. A <worktree-lines> of 0 means "leave the commit untouched".
+#   Publishes the repo path in the GLOBAL `REPO` (never via command substitution: a
+#   `$(mkrepo …)` would run every `bad` inside a subshell and silently DISCARD the
+#   failure count). Returns non-zero — loudly, with git's stderr — if setup failed, and
+#   RE-MEASURES the line counts it just wrote, because a fixture that is not what the
+#   case claims makes the case's verdict meaningless.
+REPO=""
 mkrepo() {
   local name="$1" rel="$2" nbase="$3" nhead="$4" branch="$5"
-  local root="$tmp/$name"
-  mkdir -p "$root/scripts" "$root/$(dirname "$rel")"
-  cp "$GATE" "$root/scripts/agent-gate.sh"
+  local root="$tmp/$name" err="$tmp/$name.setup.err" n
+  REPO=""
+  if ! mkdir -p "$root/scripts" "$root/$(dirname "$rel")" 2>"$err"; then
+    bad "fixture $name: mkdir failed — $(tr '\n' ' ' <"$err")"; return 1
+  fi
+  if ! cp "$GATE" "$root/scripts/agent-gate.sh" 2>"$err"; then
+    bad "fixture $name: could not stage the gate script — $(tr '\n' ' ' <"$err")"; return 1
+  fi
   printf 'target/\n*.log\n.agent-gate-summary.txt\n' >"$root/.gitignore"
   lines "$nbase" "$root/$rel"
-  ( cd "$root" && git init -q -b "$branch" . && git add -A &&
-      git "${GIT_ID[@]}" commit -qm init ) >/dev/null 2>&1
-  [ "$nhead" -gt 0 ] && lines "$nhead" "$root/$rel"
-  printf '%s\n' "$root"
+  if ! ( cd "$root" && git "${GIT_CFG[@]}" init -q -b "$branch" . &&
+         git "${GIT_CFG[@]}" add -A &&
+         git "${GIT_CFG[@]}" commit -qm init ) >"$err" 2>&1; then
+    bad "fixture $name: git setup FAILED — $(tr '\n' ' ' <"$err")"; return 1
+  fi
+  n=$( cd "$root" && git show "HEAD:$rel" 2>/dev/null | wc -l | tr -d ' ' )
+  if [ "${n:-x}" != "$nbase" ]; then
+    bad "fixture $name: committed $rel has ${n:-<unreadable>} lines, expected $nbase"; return 1
+  fi
+  if [ "$nhead" -gt 0 ]; then
+    lines "$nhead" "$root/$rel"
+    n=$(wc -l <"$root/$rel" 2>/dev/null | tr -d ' ')
+    if [ "${n:-x}" != "$nhead" ]; then
+      bad "fixture $name: worktree $rel has ${n:-<unreadable>} lines, expected $nhead"; return 1
+    fi
+  fi
+  REPO="$root"
 }
 
 # run_only_file_size <repo> <outfile> [KEY=VAL …] -> exit status of the gate run
 run_only_file_size() {
   local repo="$1" out="$2"; shift 2
+  : >"$out"
+  [ -n "$repo" ] || return 127
   ( cd "$repo" && env ${1+"$@"} AGENT_GATE_SUMMARY_FILE="$repo/.sum" \
       bash "$repo/scripts/agent-gate.sh" --only file-size >"$out" 2>&1 )
 }
 
-# The component log is reachable ONLY via the SUMMARY's `logs:` line — read it from there
-# rather than from an env var, so the test proves that route works (AC2's premise).
-logdir_of() { sed -n 's/^logs:[[:space:]]*//p' "$1" | head -1; }
+# logdir_of <gate-stdout-file> — the LOG_DIR the run published on its SUMMARY `logs:` line.
+# Read from THERE rather than from an env var, so the test proves the route an agent
+# actually has (AC2's premise). Anything other than an existing ABSOLUTE directory is a
+# MEASUREMENT FAILURE, not a path: an empty value would leave the AC2 needle as the bare
+# suffix `/file-size.log`, a substring of the real path, so the assert would MATCH having
+# measured nothing. Emits an obviously-bogus absolute sentinel so every downstream assert
+# fails closed with a readable diagnostic.
+logdir_of() {
+  local d
+  d=$(sed -n 's/^logs:[[:space:]]*//p' "$1" 2>/dev/null | head -1)
+  case "$d" in
+    /*) if [ -d "$d" ]; then printf '%s\n' "$d"; return 0; fi ;;
+  esac
+  printf '%s\n' "$tmp/NO-LOGDIR-PUBLISHED"
+  return 1
+}
 
 # verdict_of <logdir> — the component's own verdict, read from the UNCHANGED
 # `file-size.result` (`STATUS SECONDS`). Deliberately NOT the gate's exit status: a
 # passing `--only` run exits 3 (RESULT: PARTIAL) and a failing one exits 1, so an
 # exit-code assert would conflate "the component failed" with "this was a partial run".
-verdict_of() { read -r _st _secs <"$1/file-size.result" 2>/dev/null; printf '%s\n' "${_st:-<no-result-file>}"; }
+# Every variable is `local` and every non-measurement returns a SENTINEL: as globals,
+# a failed `read` (missing dir/file — the redirect fails and `2>/dev/null` hides it, so
+# `read` never runs) left the PREVIOUS case's verdict in place, and this is the sole
+# per-case oracle, so a run that produced no result at all would have read as that
+# earlier case's PASS.
+verdict_of() {
+  local st="" secs="" f="$1/file-size.result"
+  [ -s "$f" ] || { printf '%s\n' '<no-result-file>'; return 1; }
+  read -r st secs <"$f" || { printf '%s\n' '<unreadable-result-file>'; return 1; }
+  printf '%s\n' "${st:-<empty-result-file>}"
+}
 
-# has <label> <file> <literal> — the workhorse content assert.
+# has <label> <file> <literal> — the workhorse content assert. An EMPTY needle is a
+# refusal, never a match: `grep -Fq -- ""` matches every line, so an expected value that
+# was never captured (an unchecked `$(git rev-parse …)`) would otherwise "pass".
 has() {
-  if [ -f "$2" ] && grep -Fq -- "$3" "$2"; then ok "$1"; else
-    bad "$1 (missing: '$3')"
+  if [ -z "${3:-}" ]; then
+    bad "$1 (EMPTY needle — the expected value was never captured)"; return
   fi
+  if [ ! -f "$2" ]; then bad "$1 (no such file: $2)"; return; fi
+  if [ ! -s "$2" ]; then bad "$1 (file is ZERO BYTES: $2)"; return; fi
+  if grep -Fq -- "$3" "$2"; then ok "$1"; else bad "$1 (missing: '$3')"; fi
 }
 
 # assert_log_present <label> <logfile> — existence AND non-emptiness, per AC3.
@@ -112,21 +196,28 @@ assert_log_present() {
   fi
 }
 
+# assert_verdict <label> <logdir> <expected> — the per-case oracle, with the sentinel
+# printed verbatim on failure so "no result file" never reads as a wrong verdict.
+assert_verdict() {
+  local got; got=$(verdict_of "$2")
+  if [ "$got" = "$3" ]; then ok "$1"; else bad "$1 (component verdict was '$got', expected '$3')"; fi
+}
+
 # ---------------------------------------------------------------------------
 # Case 1 — FAIL: an over-threshold source file GROWN by the diff (800-line src limit).
 # ---------------------------------------------------------------------------
-r1=$(mkrepo grew cqlite-core/src/big.rs 900 950 main)
+mkrepo grew cqlite-core/src/big.rs 900 950 main; r1="$REPO"
 out1="$tmp/grew.out"
 run_only_file_size "$r1" "$out1"
-d1=$(logdir_of "$out1")
+d1=$(logdir_of "$out1") ||
+  bad "case1: the run published no usable 'logs:' dir — the component log cannot be located"
 log1="$d1/file-size.log"
-base1=$( cd "$r1" && git rev-parse HEAD )
+base1=$( cd "$r1" 2>/dev/null && git rev-parse HEAD 2>/dev/null )
+[ -n "$base1" ] ||
+  bad "case1: could not capture the fixture's base sha — the base-ref assert cannot measure anything"
 
-if [ "$(verdict_of "$d1")" = FAIL ]; then
-  ok "case1: --only file-size FAILs on a grown over-threshold file (the case being diagnosed)"
-else
-  bad "case1: --only file-size did NOT fail on a grown over-threshold file — fixture is wrong"
-fi
+assert_verdict "case1: --only file-size FAILs on a grown over-threshold file (the case being diagnosed)" \
+    "$d1" FAIL
 assert_log_present "case1: file-size.log written on the FAIL path" "$log1"
 # The REAL numbers, not merely digits: 900 committed -> 950 in the worktree, src limit 800.
 has "case1: log carries the exact growth entry (path + before -> after + limit)" \
@@ -154,24 +245,21 @@ has "case6/AC2: FAIL stdout names the component log path explicitly" "$out1" "$l
 # Case 2 — PASS: over threshold but SHRUNK by the diff. The advisory list must still be
 # logged, the ratchet must be empty, and the log must SAY it passed.
 # ---------------------------------------------------------------------------
-r2=$(mkrepo shrank cqlite-core/src/big.rs 950 900 main)
+mkrepo shrank cqlite-core/src/big.rs 950 900 main; r2="$REPO"
 out2="$tmp/shrank.out"
 run_only_file_size "$r2" "$out2"
-d2=$(logdir_of "$out2")
+d2=$(logdir_of "$out2") || bad "case2: the run published no usable 'logs:' dir"
 log2="$d2/file-size.log"
 
-if [ "$(verdict_of "$d2")" = PASS ]; then
-  ok "case2: a shrunk over-threshold file PASSes the ratchet (fixture is a real PASS run)"
-else
-  bad "case2: a shrunk over-threshold file did NOT pass — fixture is wrong"
-fi
+assert_verdict "case2: a shrunk over-threshold file PASSes the ratchet (fixture is a real PASS run)" \
+    "$d2" PASS
 assert_log_present "case2: file-size.log written on a PASS run too (AC3)" "$log2"
 has "case2: PASS log still carries the over-threshold advisory entry" \
     "$log2" "900/800"
 has "case2: PASS log carries the terminal PASS verdict" \
     "$log2" ">>> [file-size] PASS"
-if [ ! -f "$log2" ]; then
-  bad "case2: cannot check the ratchet emptiness — no log to read"
+if [ ! -s "$log2" ]; then
+  bad "case2: cannot check the ratchet emptiness — no readable log (absent or zero bytes)"
 elif grep -Fq -- '-> ' "$log2"; then
   bad "case2: PASS log lists a growth entry for a file that SHRANK"
 else
@@ -182,17 +270,13 @@ fi
 # Case 3 — PASS with NO changed .rs files at all: an empty-ish run still gets a log that
 # SAYS SO (never an absent file, never a zero-byte one).
 # ---------------------------------------------------------------------------
-r3=$(mkrepo clean cqlite-core/src/small.rs 20 0 main)
+mkrepo clean cqlite-core/src/small.rs 20 0 main; r3="$REPO"
 out3="$tmp/clean.out"
 run_only_file_size "$r3" "$out3"
-d3=$(logdir_of "$out3")
+d3=$(logdir_of "$out3") || bad "case3: the run published no usable 'logs:' dir"
 log3="$d3/file-size.log"
 
-if [ "$(verdict_of "$d3")" = PASS ]; then
-  ok "case3: a clean tree PASSes file-size"
-else
-  bad "case3: a clean tree did NOT pass file-size — fixture is wrong"
-fi
+assert_verdict "case3: a clean tree PASSes file-size" "$d3" PASS
 assert_log_present "case3: file-size.log written even with nothing to report (AC3)" "$log3"
 has "case3: empty-ish log states that nothing is over threshold" \
     "$log3" "no changed .rs files over threshold"
@@ -202,20 +286,35 @@ has "case3: empty-ish log still carries the terminal verdict" \
     "$log3" ">>> [file-size] PASS"
 
 # ---------------------------------------------------------------------------
+# Case 3b — the OTHER half of AC3's empty-ish path: .rs files ARE changed, none is over
+# threshold. Same log line as case 3, materially different input (case 3's file list is
+# empty; here it is non-empty and every entry is filtered by the limit).
+# ---------------------------------------------------------------------------
+mkrepo smallchange cqlite-core/src/small.rs 20 40 main; r3b="$REPO"
+out3b="$tmp/smallchange.out"
+run_only_file_size "$r3b" "$out3b"
+d3b=$(logdir_of "$out3b") || bad "case3b: the run published no usable 'logs:' dir"
+log3b="$d3b/file-size.log"
+
+assert_verdict "case3b: a changed-but-small .rs file PASSes file-size" "$d3b" PASS
+assert_log_present "case3b: file-size.log written when the diff has only sub-threshold .rs files (AC3)" \
+    "$log3b"
+has "case3b: log states that nothing is over threshold (non-empty file list, all filtered)" \
+    "$log3b" "no changed .rs files over threshold"
+has "case3b: log names the base ref it compared against" "$log3b" "base ref:"
+has "case3b: log carries the terminal verdict" "$log3b" ">>> [file-size] PASS"
+
+# ---------------------------------------------------------------------------
 # Case 4 — the CQLITE_ALLOW_FILE_GROWTH=1 opt-out. The growth is ALLOWED, and the log must
 # RECORD what was allowed (the numbers are the whole point of the acknowledgement).
 # ---------------------------------------------------------------------------
-r4=$(mkrepo optout cqlite-core/src/big.rs 900 950 main)
+mkrepo optout cqlite-core/src/big.rs 900 950 main; r4="$REPO"
 out4="$tmp/optout.out"
 run_only_file_size "$r4" "$out4" CQLITE_ALLOW_FILE_GROWTH=1
-d4=$(logdir_of "$out4")
+d4=$(logdir_of "$out4") || bad "case4: the run published no usable 'logs:' dir"
 log4="$d4/file-size.log"
 
-if [ "$(verdict_of "$d4")" = PASS ]; then
-  ok "case4: CQLITE_ALLOW_FILE_GROWTH=1 turns the same growth into a PASS"
-else
-  bad "case4: CQLITE_ALLOW_FILE_GROWTH=1 did not allow the growth — fixture is wrong"
-fi
+assert_verdict "case4: CQLITE_ALLOW_FILE_GROWTH=1 turns the same growth into a PASS" "$d4" PASS
 assert_log_present "case4: file-size.log written on the opt-out path (AC3)" "$log4"
 has "case4: opt-out log records the acknowledgement" \
     "$log4" "ALLOWED via CQLITE_ALLOW_FILE_GROWTH=1"
@@ -228,17 +327,21 @@ has "case4: opt-out log carries the terminal PASS verdict" \
 # Case 5 — base ref UNRESOLVABLE (no main/master, no origin/*): the ratchet is skipped and
 # the log must say so EXPLICITLY, while the advisory list still works off `git diff HEAD`.
 # ---------------------------------------------------------------------------
-r5=$(mkrepo nobase cqlite-core/src/big.rs 900 950 work)
+mkrepo nobase cqlite-core/src/big.rs 900 950 work; r5="$REPO"
+# Affirmative precondition: the fixture must really have no ref the gate can resolve.
+# Without this the case could pass on a repo that DOES have a base, having proved nothing.
+if [ -n "$r5" ] && ! ( cd "$r5" && for ref in origin/main main origin/master master; do
+       git rev-parse --verify -q "$ref" >/dev/null 2>&1 && exit 0; done; exit 1 ); then
+  ok "case5: fixture genuinely resolves none of origin/main|main|origin/master|master"
+else
+  bad "case5: fixture DOES resolve a base ref (or is missing) — the no-base path is not being exercised"
+fi
 out5="$tmp/nobase.out"
 run_only_file_size "$r5" "$out5"
-d5=$(logdir_of "$out5")
+d5=$(logdir_of "$out5") || bad "case5: the run published no usable 'logs:' dir"
 log5="$d5/file-size.log"
 
-if [ "$(verdict_of "$d5")" = PASS ]; then
-  ok "case5: with no resolvable base ref the component is advisory-only and PASSes"
-else
-  bad "case5: no-base run did not PASS — the ratchet ran without a base ref"
-fi
+assert_verdict "case5: with no resolvable base ref the component is advisory-only and PASSes" "$d5" PASS
 assert_log_present "case5: file-size.log written on the no-base path (AC3)" "$log5"
 has "case5: no-base log states the ratchet was skipped, in those words" \
     "$log5" "base ref unavailable — growth ratchet skipped (advisory only)"
@@ -251,5 +354,7 @@ has "case5: no-base log carries the terminal verdict" \
 printf '\n%s\n' "----------------------------------------"
 printf 'file-size component log guard (#3401): %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1
-[ "$PASS" -ge 25 ] || { printf 'FAIL - vacuous run: only %d checks executed\n' "$PASS"; exit 1; }
+# Floor against a vacuous green: a harness that silently skipped its cases would otherwise
+# report `0 passed, 0 failed` and exit 0.
+[ "$PASS" -ge 34 ] || { printf 'FAIL - vacuous run: only %d checks executed\n' "$PASS"; exit 1; }
 exit 0

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -63,8 +63,12 @@ export CQLITE_GATE_DISABLE_CAP=1
 
 PASS=0
 FAIL=0
-ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
-bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+SKIP=0
+ok()   { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad()  { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+# A skip is VISIBLE and CENSUSED (it counts toward the exact total below), never silent —
+# a case that quietly disappears on some host is a vacuous green by another route.
+skip() { printf 'SKIP - %s\n' "$1"; SKIP=$((SKIP + 1)); }
 
 if [ ! -r "$GATE" ]; then
   printf 'FAIL - agent-gate.sh not readable at %s — nothing to test\n' "$GATE"
@@ -375,47 +379,67 @@ has "case5: no-base log carries the terminal verdict" \
     "$log5" ">>> [file-size] PASS"
 
 # ---------------------------------------------------------------------------
-# Case 7 — LOG PERSISTENCE (#3401 review blocker B). The component now PROMISES a log, so
-# an unverified promise is the original defect one level up: an agent follows the SUMMARY's
-# `logs:` pointer, finds nothing, and is back to hand-computing line counts. If the log
-# cannot be persisted the component must FAIL, must name the PERSISTENCE cause, and must
-# NOT read as a campsite-rule violation (a bare FAIL meaning "my log dir is unwritable"
-# would send the reader hunting for a grown source file that does not exist).
+# Cases 7/8/9 — LOG PERSISTENCE (#3401 review blockers A/B/C). The component now PROMISES
+# a log, so an unverified promise is the original defect one level up: an agent follows the
+# SUMMARY's `logs:` pointer, finds nothing, and is back to hand-computing line counts.
 #
-# The sabotage is surgical and uid-independent: a PATH-shim `mktemp` lets the gate create
-# its LOG_DIR normally and then pre-creates `file-size.log` as a DIRECTORY inside it, so
-# `: >"$log"` cannot succeed while every other LOG_DIR write (tree-identity capture,
-# .result, summary) still works. `chmod 500 $LOG_DIR` was rejected: it is a NO-OP FOR ROOT
-# (the case would silently self-skip in containers — the very "invisible skip" this suite
-# is meant not to have) and it would also break the gate's own tree-identity capture, i.e.
-# fail the run for a reason other than the property under test. `: > <dir>` fails for
-# every uid, so this case needs no skip path at all.
+# Sabotage is surgical, via a PATH-shim `mktemp` that lets the gate create its LOG_DIR
+# normally and then plants something unwritable at `file-size.log` inside it, so every
+# OTHER LOG_DIR write (tree-identity capture, `.result`, the summary, and — the point of
+# blocker B — the persistence-error sibling) still works. Two shapes, selected by
+# FS_SABOTAGE:
+#   dir      — a DIRECTORY: `: >"$log"` fails, so the TRUNCATE check fires. Uid-independent
+#              (`: > <dir>` fails for root too), unlike `chmod 500 $LOG_DIR`, which is a
+#              no-op for root — the case would silently self-skip in containers — and which
+#              would also break the gate's own tree-identity capture, failing the run for a
+#              reason other than the property under test.
+#   devfull  — a SYMLINK TO /dev/full: the truncate SUCCEEDS and every append is rejected
+#              with ENOSPC, so the APPEND-FAILURE COUNTER fires and names its own count.
+#              Also uid-independent.
 #
-# The fixture is a CLEAN tree, so the ratchet's own verdict is PASS and the component's
-# FAIL can only have come from persistence.
+# NOT reproducible hermetically, stated rather than quietly omitted: the pure mid-sequence
+# partial write (first append accepted, later ones rejected, leaving a NON-EMPTY but
+# truncated log). On a real filesystem that needs a quota/ENOSPC boundary hit mid-write or
+# an LD_PRELOAD/FUSE fault injector — neither available to a hermetic shell self-test, and
+# a test-only seam in the gate would be one more thing a real invoker can set. `devfull`
+# covers the counter's trigger (an append the filesystem rejected) and the counter is by
+# construction indifferent to WHICH append failed, so the untested residual is only "some
+# appends succeeded first".
 # ---------------------------------------------------------------------------
 STUBBIN="$tmp/stubbin"
 mkdir -p "$STUBBIN"
 REAL_MKTEMP=$(command -v mktemp 2>/dev/null)
 if [ -z "$REAL_MKTEMP" ]; then
-  bad "case7: no mktemp on PATH — the persistence path CANNOT be exercised (not a skip: this suite needs it)"
+  bad "case7/8/9: no mktemp on PATH — the persistence paths CANNOT be exercised (not a skip: this suite needs it)"
 else
   cat >"$STUBBIN/mktemp" <<STUB
 #!/usr/bin/env bash
 d=\$("$REAL_MKTEMP" "\$@") || exit 1
 case "\$d" in
-  */agent-gate.*) [ -d "\$d" ] && mkdir -p "\$d/file-size.log" ;;
+  */agent-gate.*)
+    if [ -d "\$d" ]; then
+      case "\${FS_SABOTAGE:-}" in
+        dir)     mkdir -p "\$d/file-size.log" ;;
+        devfull) ln -s /dev/full "\$d/file-size.log" ;;
+      esac
+    fi
+    ;;
 esac
 printf '%s\n' "\$d"
 STUB
   chmod +x "$STUBBIN/mktemp"
 
+  # -------------------------------------------------------------------------
+  # Case 7 — unwritable log, CLEAN tree. Ratchet verdict is PASS, so the component's FAIL
+  # can only have come from persistence.
+  # -------------------------------------------------------------------------
   mkrepo persist cqlite-core/src/small.rs 20 0 main; r7="$REPO"
   out7="$tmp/persist.out"
-  run_only_file_size "$r7" "$out7" PATH="$STUBBIN:$PATH"
+  run_only_file_size "$r7" "$out7" PATH="$STUBBIN:$PATH" FS_SABOTAGE=dir
   d7=$(logdir_of "$out7") || bad "case7: the run published no usable 'logs:' dir"
+  sib7="$d7/file-size.persistence-error.log"
 
-  # POSITIVE CONTROL — without this, a FAIL below could have come from anywhere.
+  # POSITIVE CONTROL — without it a FAIL below could have come from anywhere.
   if [ -d "$d7/file-size.log" ]; then
     ok "case7: sabotage in place (file-size.log is a directory, so the component cannot write it)"
   else
@@ -424,10 +448,21 @@ STUB
   assert_verdict "case7: an unpersistable log makes the component FAIL (never a silent PASS)" "$d7" FAIL
   has "case7: stdout names the failure as PERSISTENCE, not a ratchet violation" \
       "$out7" "LOG PERSISTENCE FAILURE"
-  has "case7: stdout names the path that could not be written" \
-      "$out7" "$d7/file-size.log"
+  # The needle is bound to the DIAGNOSTIC'S OWN WORDING (#3401 review blocker D). A bare
+  # "$d7/file-size.log" was satisfiable by bash's own `…: Is a directory` stderr, which
+  # `2>&1` folds into $out7 — measured: the assert survived deleting the line that prints
+  # it. "points at: " exists in no shell error message.
+  has "case7: stdout names the unwritable path IN the diagnostic (not in a shell error)" \
+      "$out7" "points at: $d7/file-size.log"
   has "case7: stdout states the ratchet's OWN verdict in the same breath" \
       "$out7" "The size ratchet itself computed: PASS"
+  # Blocker B: the diagnostic must be reachable from `logs:`, not only from gate.log.
+  assert_log_present "case7: the persistence diagnostic is ALSO written to a LOG_DIR sibling" "$sib7"
+  has "case7: the sibling carries the diagnostic itself" "$sib7" "LOG PERSISTENCE FAILURE"
+  has "case7: the sibling names the log that could not be written" \
+      "$sib7" "points at: $d7/file-size.log"
+  has "case7: stdout names the sibling, so both routes lead to it" \
+      "$out7" "also written to: $sib7"
   if [ ! -s "$out7" ]; then
     bad "case7: no gate stdout captured — the wording check could not run"
   elif grep -Fq -- "change makes over-threshold file(s) larger" "$out7"; then
@@ -435,19 +470,97 @@ STUB
   else
     ok "case7: the persistence FAIL carries no campsite-rule/ratchet wording"
   fi
+
+  # -------------------------------------------------------------------------
+  # Case 8 — the APPEND-FAILURE COUNTER (blocker A1). /dev/full accepts the truncate and
+  # rejects every write, so the truncate check CANNOT fire and the counter must. The
+  # discriminator is the CAUSE TEXT: with only the `[ -s ]` end-state check the message
+  # would read "absent or empty after writing"; the exact rejected-write COUNT can only
+  # come from the counter having incremented per failed append.
+  # -------------------------------------------------------------------------
+  if [ ! -c /dev/full ]; then
+    skip "case8: no /dev/full on this host (macOS/BSD) — the append-rejection shape is unreachable here"
+  else
+    mkrepo appendfail cqlite-core/src/small.rs 20 0 main; r8="$REPO"
+    out8="$tmp/appendfail.out"
+    run_only_file_size "$r8" "$out8" PATH="$STUBBIN:$PATH" FS_SABOTAGE=devfull
+    d8=$(logdir_of "$out8") || bad "case8: the run published no usable 'logs:' dir"
+    sib8="$d8/file-size.persistence-error.log"
+
+    # POSITIVE CONTROL, in two halves: the sabotage is in place AND it has the semantics
+    # the case depends on (truncate succeeds, append rejected). Without the second half a
+    # FAIL could be the truncate check firing, which is case 7's property, not this one.
+    if [ -L "$d8/file-size.log" ] && [ "$(readlink "$d8/file-size.log")" = /dev/full ]; then
+      ok "case8: sabotage in place (file-size.log -> /dev/full)"
+    else
+      bad "case8: sabotage did NOT take effect at '$d8/file-size.log' — the append-failure path was never exercised"
+    fi
+    if ( : >"$d8/file-size.log" ) 2>/dev/null && ! ( printf 'x\n' >>"$d8/file-size.log" ) 2>/dev/null; then
+      ok "case8: control — the truncate SUCCEEDS and the append is REJECTED (so only the counter can fire)"
+    else
+      bad "case8: /dev/full did not behave as required (truncate-ok + append-rejected) — the case proves nothing"
+    fi
+    assert_verdict "case8: rejected appends make the component FAIL" "$d8" FAIL
+    # 3 emitted lines on a clean tree: thresholds, base ref, "no changed .rs files over
+    # threshold". The EXACT count is the oracle — a fabricated or hardcoded flag cannot
+    # produce it, and the `[ -s ]` check cannot produce a count at all.
+    has "case8: the cause names the EXACT number of rejected writes (the counter, not the -s check)" \
+        "$out8" "3 write(s) to it were rejected"
+    assert_log_present "case8: the persistence diagnostic sibling is written here too" "$sib8"
+    has "case8: the sibling carries the rejected-write cause" \
+        "$sib8" "write(s) to it were rejected"
+  fi
+
+  # -------------------------------------------------------------------------
+  # Case 9 — BOTH failures at once (blocker C). A real ratchet violation PLUS an
+  # unwritable log. The old unconditional wording claimed "this is NOT a campsite-rule
+  # violation" while the ratchet had genuinely failed, steering the reader away from a
+  # real growth violation — and the grown-file list died with the unwritable log.
+  # -------------------------------------------------------------------------
+  mkrepo bothfail cqlite-core/src/big.rs 900 950 main; r9="$REPO"
+  out9="$tmp/bothfail.out"
+  run_only_file_size "$r9" "$out9" PATH="$STUBBIN:$PATH" FS_SABOTAGE=dir
+  d9=$(logdir_of "$out9") || bad "case9: the run published no usable 'logs:' dir"
+  sib9="$d9/file-size.persistence-error.log"
+
+  if [ -d "$d9/file-size.log" ]; then
+    ok "case9: sabotage in place alongside a genuine growth violation"
+  else
+    bad "case9: sabotage did NOT take effect at '$d9/file-size.log' — the combined path was never exercised"
+  fi
+  assert_verdict "case9: growth + unpersistable log is a FAIL" "$d9" FAIL
+  has "case9: the diagnostic reports BOTH failures" "$out9" "TWO failures"
+  # The remediation data would otherwise be lost with the log — it must survive in the
+  # sibling, with the REAL numbers.
+  has "case9: the sibling preserves the exact grown-file entry" \
+      "$sib9" "cqlite-core/src/big.rs: 900 -> 950 (limit 800)"
+  has "case9: the sibling preserves the acknowledgement remedy" \
+      "$sib9" "CQLITE_ALLOW_FILE_GROWTH=1"
+  # The lie: a real ratchet violation must never be disclaimed.
+  if [ ! -s "$out9" ]; then
+    bad "case9: no gate stdout captured — the disclaimer check could not run"
+  elif grep -Fq -- "this is NOT a campsite-rule" "$out9"; then
+    bad "case9: a REAL ratchet violation was disclaimed as 'NOT a campsite-rule violation'"
+  else
+    ok "case9: the combined failure does NOT disclaim the real ratchet violation"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
 printf '\n%s\n' "----------------------------------------"
-printf 'file-size component log guard (#3401): %d passed, %d failed\n' "$PASS" "$FAIL"
-# Census, not a floor (#3401 review N4): the assertion count is control-flow-invariant
-# here — every case runs unconditionally — so `PASS + FAIL` must equal it EXACTLY. A floor
-# with slack tolerates silently deleted assertions, which is the vacuous-green shape this
-# suite exists to refuse.
-EXPECTED_CHECKS=42
-if [ "$((PASS + FAIL))" -ne "$EXPECTED_CHECKS" ]; then
-  printf 'FAIL - assertion census mismatch: %d checks ran, expected exactly %d (one was added, deleted or skipped)\n' \
-    "$((PASS + FAIL))" "$EXPECTED_CHECKS"
+printf 'file-size component log guard (#3401): %d passed, %d failed, %d skipped\n' "$PASS" "$FAIL" "$SKIP"
+# Census, not a floor (#3401 review N4/N2): every assertion reports exactly one of
+# ok/FAIL/SKIP, so `PASS + FAIL + SKIP` is fixed for a run that reaches the end. A floor
+# with slack tolerates silently deleted assertions — the vacuous-green shape this suite
+# exists to refuse. A mismatch is NOT necessarily a deleted assertion: a fixture or
+# precondition failure (an unusable repo, a missing mktemp) short-circuits its case's
+# remaining asserts and lands here too, so the message names both causes rather than
+# misattributing one as the other.
+EXPECTED_CHECKS=58
+if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
+  printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
+    "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"
+  printf '       Either an assertion was added/deleted, or a fixture/precondition failure short-circuited a case.\n'
   exit 1
 fi
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/test_agent_gate_file_size_log.sh
+++ b/scripts/tests/test_agent_gate_file_size_log.sh
@@ -397,14 +397,18 @@ has "case5: no-base log carries the terminal verdict" \
 #              with ENOSPC, so the APPEND-FAILURE COUNTER fires and names its own count.
 #              Also uid-independent.
 #
-# NOT reproducible hermetically, stated rather than quietly omitted: the pure mid-sequence
-# partial write (first append accepted, later ones rejected, leaving a NON-EMPTY but
-# truncated log). On a real filesystem that needs a quota/ENOSPC boundary hit mid-write or
-# an LD_PRELOAD/FUSE fault injector — neither available to a hermetic shell self-test, and
-# a test-only seam in the gate would be one more thing a real invoker can set. `devfull`
-# covers the counter's trigger (an append the filesystem rejected) and the counter is by
-# construction indifferent to WHICH append failed, so the untested residual is only "some
-# appends succeeded first".
+# NOT reproducible here, stated rather than quietly omitted: the pure mid-sequence partial
+# write (first append accepted, later ones rejected, leaving a NON-EMPTY but truncated
+# log). Four techniques were considered. A quota/ENOSPC boundary hit mid-write and an
+# LD_PRELOAD/FUSE fault injector are unavailable to a hermetic shell self-test; a test-only
+# seam in the gate is rejected on principle (one more thing a real invoker can set). The
+# fourth — `trap "" XFSZ` (SIG_IGN survives exec) plus `ulimit -f 1` — DOES work without
+# root and IS named here so nobody re-derives it: it is rejected because the limit is
+# PROCESS-WIDE, so it would equally truncate the SUMMARY and `.result` writes and break the
+# run for reasons unrelated to the property under test. `devfull` covers the counter's
+# trigger (an append the filesystem rejected) and the counter is by construction
+# indifferent to WHICH append failed, so the untested residual is only "some appends
+# succeeded first".
 # ---------------------------------------------------------------------------
 STUBBIN="$tmp/stubbin"
 mkdir -p "$STUBBIN"
@@ -479,7 +483,18 @@ STUB
   # come from the counter having incremented per failed append.
   # -------------------------------------------------------------------------
   if [ ! -c /dev/full ]; then
-    skip "case8: no /dev/full on this host (macOS/BSD) — the append-rejection shape is unreachable here"
+    # ONE skip PER SKIPPED ASSERT (#3401 review blocker 1), the
+    # scripts/tests/test_perf_capability.sh precedent: a single skip standing for six
+    # asserts left PASS+FAIL+SKIP five short on any host without /dev/full (macOS/BSD),
+    # so the census fired `assertion census mismatch` and hard-failed the suite — a
+    # DELETED-ASSERTION accusation on a host where nothing was deleted. Keeping the count
+    # per-assert keeps ONE invariant instead of two totals that can drift apart.
+    skip "case8: no /dev/full (macOS/BSD) — sabotage-in-place control not run"
+    skip "case8: no /dev/full (macOS/BSD) — truncate-ok/append-rejected control not run"
+    skip "case8: no /dev/full (macOS/BSD) — FAIL verdict not asserted"
+    skip "case8: no /dev/full (macOS/BSD) — exact rejected-write count not asserted"
+    skip "case8: no /dev/full (macOS/BSD) — sibling presence not asserted"
+    skip "case8: no /dev/full (macOS/BSD) — sibling rejected-write cause not asserted"
   else
     mkrepo appendfail cqlite-core/src/small.rs 20 0 main; r8="$REPO"
     out8="$tmp/appendfail.out"
@@ -544,6 +559,28 @@ STUB
   else
     ok "case9: the combined failure does NOT disclaim the real ratchet violation"
   fi
+
+  # -------------------------------------------------------------------------
+  # Case 10 — persistence failure on a NO-BASE run (#3401 review L1). With no resolvable
+  # base ref the ratchet is SKIPPED, so a diagnostic claiming it "computed PASS" asserts a
+  # computation that never happened. The `SKIPPED (base ref unavailable)` phrase exists
+  # only inside the persistence block, so it cannot be satisfied by any other output.
+  # -------------------------------------------------------------------------
+  mkrepo nobasepersist cqlite-core/src/big.rs 900 950 work; r10="$REPO"
+  out10="$tmp/nobasepersist.out"
+  run_only_file_size "$r10" "$out10" PATH="$STUBBIN:$PATH" FS_SABOTAGE=dir
+  d10=$(logdir_of "$out10") || bad "case10: the run published no usable 'logs:' dir"
+
+  assert_verdict "case10: unpersistable log on a no-base run is a FAIL" "$d10" FAIL
+  has "case10: the diagnostic says the ratchet was SKIPPED, not that it computed a verdict" \
+      "$out10" "The size ratchet was SKIPPED (base ref unavailable)"
+  if [ ! -s "$out10" ]; then
+    bad "case10: no gate stdout captured — the false-computation check could not run"
+  elif grep -Fq -- "The size ratchet itself computed:" "$out10"; then
+    bad "case10: claims a ratchet verdict was computed on a run where the ratchet was skipped"
+  else
+    ok "case10: claims no ratchet verdict for a run that never computed one"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -556,7 +593,7 @@ printf 'file-size component log guard (#3401): %d passed, %d failed, %d skipped\
 # precondition failure (an unusable repo, a missing mktemp) short-circuits its case's
 # remaining asserts and lands here too, so the message names both causes rather than
 # misattributing one as the other.
-EXPECTED_CHECKS=58
+EXPECTED_CHECKS=61
 if [ "$((PASS + FAIL + SKIP))" -ne "$EXPECTED_CHECKS" ]; then
   printf 'FAIL - assertion census mismatch: %d checks ran (%d ok / %d fail / %d skip), expected exactly %d.\n' \
     "$((PASS + FAIL + SKIP))" "$PASS" "$FAIL" "$SKIP" "$EXPECTED_CHECKS"


### PR DESCRIPTION
Closes #3401.

## The defect

`run_file_size` already computed everything an agent needs to act on a `file-size` FAIL — the resolved base ref, which changed `.rs` files are over threshold, which of them this diff *grew*, each as `before -> after`, and the limit applied — then echoed it to **stdout** and recorded only `$LOG_DIR/file-size.result` (`STATUS SECONDS`). Stdout lands in `gate.log`, the file CLAUDE.md forbids agents to read. So `file-size: FAIL` in a pasted SUMMARY named no file, and the remedy — split, or take the sanctioned `CQLITE_ALLOW_FILE_GROWTH=1` opt-out — is a judgement call nobody could make without re-deriving by hand the arithmetic the component had just discarded. It is also the one component whose FAIL is routinely *expected*, so the cost was paid often (observed on #1695).

## The change

`run_file_size` persists that arithmetic to `$LOG_DIR/file-size.log`, reachable from the SUMMARY's existing `logs: <dir>` line, on **every** invocation. `_fs_emit` writes each line to stdout **first**, then appends to the log, so nothing previously visible in `gate.log` was dropped or reordered.

The log carries the thresholds, the resolved base sha and the ref it came from, the over-threshold advisory list, every grown file as `path: before -> after (limit N)`, and the terminal verdict. It is written on all six paths — no changed `.rs` files, none over threshold, over-but-not-grown, grown (FAIL), grown-under-the-opt-out, and base-ref-unresolvable — with `: >"$log"` before every conditional, so it is never absent and never zero-byte. On FAIL the stdout remedy block names the log path.

**Persistence is verified, not assumed.** A logging change that promises a file must not report `PASS` having written nothing — that is the very defect this issue exists to fix, one level up. Three detectors, each catching a shape the others cannot: the truncate is checked; the log is re-checked non-empty after emission; and `_fs_emit` counts rejected appends, which is the only one that sees a *non-empty but partial* log. Any of them failing is a persistence FAIL whose diagnostic is written to a sibling `$LOG_DIR/file-size.persistence-error.log` (the #2874 non-clobbering pattern) as well as stdout — because a diagnostic that exists only in `gate.log` is unreachable by the reader it is for.

The wording is conditional on what the ratchet actually did: a real growth violation coinciding with a persistence failure reports **both** and keeps the split/opt-out remedy; an unresolvable base reports the ratchet as **SKIPPED** rather than claiming a verdict it never computed.

**Accepted residual — ruled on, not overlooked.** The final terminal-verdict write is deliberately unverified. The window is irreducible: that line's *content is the verdict*, so it cannot be written before the decision it reports, and recording a read-back needs a later write to the same sink whose own success is then unverified. The loss is bounded to the terminal line, which the SUMMARY carries independently — everything #3401 exists for is written *and* checked before that point.

roborev raised this in three separate rounds (jobs 136, 138, 139); `rust-reviewer` twice ruled the decline correct. It was escalated as a reviewer stalemate and the lead **ruled Option A: accept the documented residual** ([ruling](https://github.com/pmcfadin/cqlite/issues/3401#issuecomment-5466376424)). Stating this precisely, because the distinction matters: the finding stopped being re-raised once the in-code rejection argued the point rather than merely asserting it — but **the code is byte-for-byte unchanged**, so nothing about the substance resolved. This ships as an accepted trade-off, not as a finding that evaporated. The in-code comment ties the rejection to its falsifying precondition, so if a future change makes that line no longer the verdict, the rejection is void by its own terms.

A genuine mid-sequence partial write (early appends succeed, later ones fail) is not hermetically reproducible without a quota/ENOSPC boundary; `trap '' XFSZ` + `ulimit -f 1` would do it but is process-wide and would truncate the SUMMARY and `.result` writes too, so it is named and rejected in-comment rather than silently omitted.

**Out of scope, deliberately: #3402** (a visible `file-size: OPT-OUT (...)` marker in the SUMMARY). This PR does not touch the `.result` format, the component summary line, or `SUMMARY_META`. It does produce the offending-file data #3402 needs, which should reduce that issue to a `SUMMARY_META` line.

## Tests

New hermetic self-test `scripts/tests/test_agent_gate_file_size_log.sh` — **61 assertions**, wired into the `tooling-tests` gate component. No cargo, no network, no datasets, no Docker; fixtures are throwaway git repos under `mktemp -d`, run with `GIT_CONFIG_GLOBAL=/dev/null` + `GIT_CONFIG_SYSTEM=/dev/null` so a developer's `commit.gpgsign`/`core.hooksPath` cannot red the gate of record for a reason unrelated to the property.

RED-first, and the RED still reproduces: against the pre-fix gate, `15 passed / 46 failed`, first failure `case1: file-size.log written on the FAIL path — no file-size.log written at all`.

Persistence failures are sabotaged rather than mocked: case 7 pre-creates `file-size.log` as a **directory** via a PATH-shimmed `mktemp` (uid-independent, so there is no root-skip that could go invisible, and it does not perturb the tree-identity capture the way `chmod` would); case 8 symlinks it to **`/dev/full`**, where the truncate succeeds and every append is rejected, isolating the append counter as the only detector that can fire. Each has a positive control asserting the sabotage actually took effect.

The census is a single invariant, `PASS + FAIL + SKIP == 61`, and the `/dev/full`-absent path was **exercised for real** (masked with `bwrap`), not reasoned about: `55 ok / 6 skip = 61, exit 0`.

## Review

Five review rounds, roborev (jobs 134-137, `--agent codex --model gpt-5.6-sol`) and `rust-reviewer` on every one. The two disagreed three times, and each disagreement was resolved by consolidation rather than by picking a side — the record is worth keeping because the pattern recurred:

- **Write-failure tracking.** roborev wanted every write checked; `rust-reviewer` judged the terminal-write gap immaterial and unclosable. Both were right about *different writes*: a mid-sequence failure can drop the growth entries themselves while `[ -s ]` still passes, so body appends are tracked; the final write's window is irreducible, so it is documented instead of chased.
- **Verdict ordering.** `rust-reviewer` asked for the conventional `record_result`-then-echo order; roborev then found that ordering drops the terminal log line whenever `record_result` terminates the run via the integrity guards. Resolved as a deliberate two-half write — to the log before, to stdout after — with a comment naming both constraints so it is not "tidied" back.
- **The census.** Both independently found that a skip contributing 1 where the live branch contributes 6 reds `tooling-tests` on any host without `/dev/full` — a vacuous-green guard producing a *false accusation*.

The dominant finding class was **fail-open oracles in the test harness** — helpers returning a permissive answer when the measurement never happened. Sweeping for the class rather than patching named instances found 5 more in one pass, including a live false-`ok` (`logdir_of` returning `""` collapsed a needle to a substring of the real path) and a `mkrepo` publishing through `$(...)`, so every `bad` ran in a subshell and its FAIL count was discarded. Every helper now refuses rather than guesses, and new assertions carry mutation reasoning: the append-counter oracle asserts the *exact* rejected-write count, which no other detector can produce.

Three follow-up candidates were recorded rather than implemented, per a deliberate freeze once the residual defects had migrated from the feature into the guard-around-the-guard. They will be filed as one issue.

## Review record

| Round | roborev | `rust-reviewer` |
|---|---|---|
| 1 | job 134 PASS | 3 blockers — fail-open oracles |
| 2 | job 135 FAIL (2) | 1 blocker + 5 nits |
| 3 | job 136 FAIL (2) | 1 blocker + 3 nits |
| 4 | job 137 FAIL (2) | 1 blocker + 5 nits |
| 5 | job 138 FAIL (3) | ready to merge |
| 6 | job 139 FAIL (3) | 1 blocker + 2 nits |
| 7 | job 140 FAIL (1) | ready to merge |
| 8 | job 141 FAIL (1) | ready to merge |

The two reviewers disagreed four times, and every disagreement was resolved by consolidation rather than by picking a side. Recorded because the pattern is the reusable part: each time, both were right about *different* properties, and implementing either verdict alone would have re-opened the other's finding in the next round.

Follow-ups filed rather than folded in: **#3542** (P2 — a `file-size` scan failure is indistinguishable from "no changed `.rs` files", so an unvalidated `--delta` anchor yields a silent PASS; pre-existing, and the vacuous-pass family rather than a nit) plus one batched issue for the remaining nits.
