### PR TITLE
fix(#3493): check the CORPUS is complete, not just that the suite ran

### DIFF
--- a/.github/ci-gating-tiers.yml
+++ b/.github/ci-gating-tiers.yml
@@ -159,6 +159,14 @@ exempt:
       the CORPUS is complete rather than that the suite ran — the parity cases derive
       their table set from disk, so a partial extraction is green by omission. The
       multi-platform build matrix is release coverage, not merge-gating.
+      ONE STATE IS EXCLUDED AND NAMED HERE RATHER THAN LEFT TO BE DISCOVERED: under the
+      documented #2078 opt-out (AGENT_GATE_ALLOW_MISSING_FIXTURES=1 with no usable
+      corpus, or an incomplete one), node-bindings SKIPs BEFORE npm ci, so neither the
+      jest suite nor typecheck runs. That is a DECLARED skip — recorded in the gate
+      SUMMARY by name, never a silent pass — but it does mean this exemption's coverage
+      claim holds only for a run with a corpus. Saying so is the whole point of #3493:
+      an exemption is only as true as what the named component actually does, in every
+      state it can be in.
       KEEP THIS ENTRY AND run_node_bindings IN STEP: an exemption that defers to a
       local component is only as true as that component's scope, and #1255's narrowing
       to 1 file in 27 is what made this entry false for ~2 days of a deterministic

--- a/.github/ci-gating-tiers.yml
+++ b/.github/ci-gating-tiers.yml
@@ -154,8 +154,10 @@ exempt:
       component, which since #3522 runs the WHOLE jest suite (it ran 1 of 27 files
       before), plus binding-rust-tests for cqlite-node's Rust unit tests, which ran
       nowhere. Since #3493 it also runs `npm run typecheck` (this workflow's
-      always-run PR smoke job, and the only thing that exercises the shipped
-      index.d.ts) and pairs `npm test` with check-dataset-manifest.sh, which checks
+      always-run PR smoke job; it is `tsc --noEmit` over the examples project, so it
+      COMPILES against the shipped index.d.ts, which #3581's typescript-definitions
+      test does not — that one reads the declarations as TEXT and asserts the runtime
+      surface is declared. Different properties, both wanted) and pairs `npm test` with check-dataset-manifest.sh, which checks
       the CORPUS is complete rather than that the suite ran — the parity cases derive
       their table set from disk, so a partial extraction is green by omission. The
       multi-platform build matrix is release coverage, not merge-gating.

--- a/.github/ci-gating-tiers.yml
+++ b/.github/ci-gating-tiers.yml
@@ -159,14 +159,15 @@ exempt:
       the CORPUS is complete rather than that the suite ran — the parity cases derive
       their table set from disk, so a partial extraction is green by omission. The
       multi-platform build matrix is release coverage, not merge-gating.
-      ONE STATE IS EXCLUDED AND NAMED HERE RATHER THAN LEFT TO BE DISCOVERED: under the
-      documented #2078 opt-out (AGENT_GATE_ALLOW_MISSING_FIXTURES=1 with no usable
-      corpus, or an incomplete one), node-bindings SKIPs BEFORE npm ci, so neither the
-      jest suite nor typecheck runs. That is a DECLARED skip — recorded in the gate
-      SUMMARY by name, never a silent pass — but it does mean this exemption's coverage
-      claim holds only for a run with a corpus. Saying so is the whole point of #3493:
-      an exemption is only as true as what the named component actually does, in every
-      state it can be in.
+      TWO OPT-OUT STATES, WHICH DIFFER AND ARE NAMED SEPARATELY RATHER THAN LEFT TO BE
+      DISCOVERED. With AGENT_GATE_ALLOW_MISSING_FIXTURES=1 and NO usable corpus,
+      node-bindings SKIPs BEFORE npm ci, so neither typecheck nor the jest suite runs.
+      With the same opt-out and an INCOMPLETE corpus, install, build and typecheck have
+      already run — only the manifest check and the jest suite are skipped, so the
+      typecheck claim above still holds there. Both are DECLARED skips, recorded in the
+      gate SUMMARY by name, never a silent pass. Stating which coverage each state
+      actually gives is the whole point of #3493: an exemption is only as true as what
+      the named component does, in every state it can be in.
       KEEP THIS ENTRY AND run_node_bindings IN STEP: an exemption that defers to a
       local component is only as true as that component's scope, and #1255's narrowing
       to 1 file in 27 is what made this entry false for ~2 days of a deterministic

--- a/.github/ci-gating-tiers.yml
+++ b/.github/ci-gating-tiers.yml
@@ -149,7 +149,20 @@ exempt:
     reason: Docker-backed live-cell parity lane; not merge-gating today.
     issue: "#2910"
   - workflow: node-ci.yml
-    reason: "Node binding lane; the merge-gating half is the local gate's node-bindings component, which since #3522 runs the WHOLE jest suite (it ran 1 of 27 files before), plus binding-rust-tests for cqlite-node's Rust unit tests, which ran nowhere. The multi-platform build matrix is release coverage, not merge-gating."
+    reason: >-
+      Node binding lane; the merge-gating half is the local gate's node-bindings
+      component, which since #3522 runs the WHOLE jest suite (it ran 1 of 27 files
+      before), plus binding-rust-tests for cqlite-node's Rust unit tests, which ran
+      nowhere. Since #3493 it also runs `npm run typecheck` (this workflow's
+      always-run PR smoke job, and the only thing that exercises the shipped
+      index.d.ts) and pairs `npm test` with check-dataset-manifest.sh, which checks
+      the CORPUS is complete rather than that the suite ran — the parity cases derive
+      their table set from disk, so a partial extraction is green by omission. The
+      multi-platform build matrix is release coverage, not merge-gating.
+      KEEP THIS ENTRY AND run_node_bindings IN STEP: an exemption that defers to a
+      local component is only as true as that component's scope, and #1255's narrowing
+      to 1 file in 27 is what made this entry false for ~2 days of a deterministic
+      main-red without blocking a merge.
     issue: "#2910"
   - workflow: observability-gate.yml
     reason: Observability correctness plus label-gated overhead bench; overhead is advisory.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,36 @@ lanes, and adds the case the failing-assertion plants cannot reach: one that cfg
 compiles, runs **zero** tests and exits 0 — the only plant that exercises the non-zero-count half of
 `check_unittest_targets_ran`.
 
+**A CI exemption that defers to a local gate component is only as true as that component's SCOPE
+(#3493).** `.github/ci-gating-tiers.yml` excuses a workflow from `required` by naming the local
+component that supposedly owns its merge-gating half — and nothing checks that the named component
+actually covers it. Measured instance, since FIXED by #3522/#3574: the `node-ci.yml` exemption read
+*"the merge-gating half is the local gate's node-bindings component"* while `node-bindings` ran ONE
+of the Node suite's 27 test files (`npx jest write-readback-content`, narrowed for speed under
+#1255), so **26 files were gated by neither side** — and a deterministic export-surface red sat on
+`main` for ~2 days across 4 Node contexts without blocking a merge. Its sibling is the control:
+`python-bindings` runs the whole pytest suite, so the identically-worded Python exemption was true.
+This is the **circular-deferral** shape #3544 records for `ci-minimal-features.yml` — each side's
+coverage justified by the other's, the content exercised by neither, **with a documented rationale
+on both sides explaining why that is fine** — and it is a confirmed family, not a one-off. Two rules
+follow. **Narrowing a component for speed is a CHANGE TO A MERGE GATE**: if a registry exemption
+names it, correct that entry in the same diff or the exemption silently becomes false. And **when
+you widen or narrow, measure first** — the #1255 narrowing outlived its own premise (the widened
+component measures **138s**, dominated by the `release-unwind` LTO build it already paid), so the
+speed argument that justified the hole had stopped being true long before anyone re-checked it.
+
+**AND "DOES EVERY TEST RUN" IS NOT "IS THE CORPUS COMPLETE" (#3493).** #3522's census answers the
+first; it cannot answer the second, and neither can its per-suite guard. The Node parity cases
+**derive their table set FROM DISK**, so a partial extraction is green BY OMISSION: every suite
+runs, every suite does real work, and the missing tables are simply never enumerated. Hence
+`test-data/scripts/check-dataset-manifest.sh`, paired with `npm test` in `node-bindings`, asserting
+that every expected table is present AND usable. Measured against the real binding, on an otherwise
+intact generation: a **zero-length `CompressionInfo.db` or `Statistics.db` makes `SELECT` return 0
+ROWS silently** (not an error — the "0-rows-when-present" failure this repo says must never pass),
+and a second generation whose `Data.db` is well-formed garbage makes the reader throw. A
+completeness check proves files are present and usable AS FILES; it cannot prove they parse — that
+is the reader's job, and no amount of `stat`ing substitutes for it.
+
 **Required invocation — summary-file redirect, never raw stdout (issues #1175/#2079), full AND lite:**
 
 ```bash

--- a/bindings/node/__test__/abort-safety.test.js
+++ b/bindings/node/__test__/abort-safety.test.js
@@ -58,7 +58,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { MODES, sourceTableDir, makeCorruptFixture } = require('./corrupt-fixture.js');
+const { MODES, classifyTableDir, makeCorruptFixture } = require('./corrupt-fixture.js');
 
 const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'index.js');
 
@@ -149,16 +149,17 @@ function requireFixturesStrict() {
  * @returns {{status: 'ok'|'broken'|'absent', reason?: string}}
  */
 function classifySource() {
-  const sstables = global.testPaths.SSTABLES_DIR;
-  const src = sourceTableDir(sstables);
-  if (src === null) {
-    return { status: 'absent', reason: `No test_basic.simple_table SSTable under ${sstables} (issue #1437)` };
-  }
-  const data = path.join(src, 'nb-1-big-Data.db');
-  if (fs.statSync(data).size === 0) {
-    return { status: 'broken', reason: `Source ${data} present but empty (issue #1437)` };
-  }
-  return { status: 'ok' };
+  // DELEGATED to corrupt-fixture.js (roborev #3493 round 52). This used to ask
+  // `sourceTableDir` for a directory and then size-check the Data.db itself -- but round 48
+  // gave that function a nonempty-regular-file filter, so an unusable Data.db started
+  // returning `null` and the size check below could never be reached: a truncated fixture
+  // classified as `absent` and, in a non-strict run, SKIPPED instead of hard-failing.
+  //
+  // The three-valued `classifyTableDir` is the single place that distinction now lives, so
+  // the two cannot drift apart again. It also recognises damage this check never could --
+  // a Data.db that is a directory or a dangling symlink, not just a zero-length one.
+  const c = classifyTableDir(global.testPaths.SSTABLES_DIR);
+  return c.status === 'ok' ? { status: 'ok' } : { status: c.status, reason: c.reason };
 }
 
 /**

--- a/bindings/node/__test__/corrupt-fixture.js
+++ b/bindings/node/__test__/corrupt-fixture.js
@@ -124,8 +124,17 @@ function entryExists(p) {
   try {
     fs.lstatSync(p);
     return true;
-  } catch (_e) {
-    return false;
+  } catch (e) {
+    // ONLY genuine absence means absent (roborev #3493, post-rebase round 5). Collapsing
+    // every lstat error onto "does not exist" turns a permission or I/O error into
+    // `absent`, and a non-strict abort-safety run then SKIPS instead of hard-failing —
+    // which is #1437 inverted, the same defect round 52 fixed one layer up, arriving again
+    // through the error handler rather than the predicate.
+    //
+    // ENOENT: nothing at that path. ENOTDIR: a parent component is not a directory, so the
+    // path cannot exist either. Anything else (EACCES, EIO, ELOOP, ENAMETOOLONG) means
+    // something IS there and we cannot use it — which is `broken`, not `absent`.
+    return e.code !== 'ENOENT' && e.code !== 'ENOTDIR';
   }
 }
 

--- a/bindings/node/__test__/corrupt-fixture.js
+++ b/bindings/node/__test__/corrupt-fixture.js
@@ -19,6 +19,9 @@
 
 const fs = require('fs');
 const path = require('path');
+// The canonical table-directory predicates, shared with the golden lookups so all three
+// consumers and the manifest agree on what a table directory IS (#3493).
+const { isTableDirFor, isCommittedTableDir } = require('./parity-utils.js');
 
 const KEYSPACE = 'test_basic';
 const TABLE = 'simple_table';
@@ -28,22 +31,121 @@ const TOC_COMPONENT = 'nb-1-big-TOC.txt';
 const MODES = ['truncate', 'bitflip'];
 
 /**
- * Find the real `simple_table-<uuid>` dir under the sstables root, or null.
+ * Classify the source table directory: `ok` | `broken` | `absent`.
+ *
+ * THE THREE-VALUED ANSWER IS THE POINT (roborev #3493 round 52). `sourceTableDir` returns a
+ * directory or `null`, and round 48 added a nonempty-regular-file filter to it -- which
+ * silently converted "present but UNUSABLE" into "ABSENT". `abort-safety.test.js` keys its
+ * gating on exactly that distinction: `broken` is a HARD FAILURE, while a non-strict
+ * `absent` is a real `test.skip`. So a truncated fixture stopped hard-failing and started
+ * SKIPPING, inverting #1437's stated design ("a broken source is a hard failure, not a
+ * skippable condition") and making that test's `broken` branch unreachable.
+ *
+ * `broken` means a Data.db ENTRY EXISTS in a canonical candidate but is not a nonempty
+ * regular file -- zero-length, a directory, a dangling symlink. A canonical directory with
+ * no Data.db entry at all stays `absent`, which is the pre-round-48 behaviour and the
+ * honest reading: the fixture was never fetched, as opposed to fetched and damaged.
+ *
+ * A VALID candidate still WINS over a broken sibling. That is deliberately laxer than
+ * `check-dataset-manifest.sh`, which disqualifies a table when ANY candidate is unusable --
+ * and the two are right for different reasons: Jest's discovery picks a directory blind, so
+ * the manifest must assume the worst, while this function picks deterministically and can
+ * simply choose the good one.
+ *
+ * @param {string} sstablesRoot
+ * @returns {{status: 'ok', dir: string} | {status: 'broken', dir: string, reason: string}
+ *           | {status: 'absent', reason: string}}
+ */
+function classifyTableDir(sstablesRoot) {
+  const ksDir = path.join(sstablesRoot, KEYSPACE);
+  if (!fs.existsSync(ksDir) || !fs.statSync(ksDir).isDirectory()) {
+    return { status: 'absent', reason: `No ${KEYSPACE} keyspace directory under ${sstablesRoot} (issue #1437)` };
+  }
+  const candidates = fs
+    .readdirSync(ksDir, { withFileTypes: true })
+    // A REAL directory. `Dirent.isDirectory()` is FALSE for a symlink, which is exactly
+    // what Jest's discovery and the manifest's `[ -L "$cand" ] && continue` both do, so a
+    // symlinked table dir is invisible to them and must be invisible here too.
+    //
+    // Not merely a consistency point -- it is what stops this harness DESTROYING THE
+    // SOURCE CORPUS (round 49). `fs.cpSync` preserves a symlink by default, so a symlinked
+    // table dir was copied AS A SYMLINK and the truncate/bitflip below then wrote THROUGH
+    // it into the real fixture: truncating the "copy" cut the original from 12 bytes to 4.
+    // On a shared machine-local corpus that is damage to every other lane on the box.
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => isTableDirFor(name, TABLE) && isCommittedTableDir(KEYSPACE, name))
+    .map((name) => path.join(ksDir, name))
+    .sort();
+
+  const usable = candidates.filter((dir) => isNonemptyFile(path.join(dir, DATA_COMPONENT)));
+  if (usable.length > 0) {
+    return { status: 'ok', dir: usable[0] };
+  }
+  const damaged = candidates.find((dir) => entryExists(path.join(dir, DATA_COMPONENT)));
+  if (damaged !== undefined) {
+    return {
+      status: 'broken',
+      dir: damaged,
+      reason:
+        `Source ${path.join(damaged, DATA_COMPONENT)} is present but not a nonempty ` +
+        `regular file (zero-length, a directory, or a dangling symlink) (issue #1437)`,
+    };
+  }
+  return {
+    status: 'absent',
+    reason: `No ${KEYSPACE}.${TABLE} SSTable with ${DATA_COMPONENT} under ${sstablesRoot} (issue #1437)`,
+  };
+}
+
+/**
+ * The usable source table dir, or null. Thin wrapper over `classifyTableDir` -- callers
+ * that need to tell `broken` from `absent` must use the classifier (see its header).
+ *
  * @param {string} sstablesRoot
  * @returns {string|null}
  */
 function sourceTableDir(sstablesRoot) {
-  const ksDir = path.join(sstablesRoot, KEYSPACE);
-  if (!fs.existsSync(ksDir) || !fs.statSync(ksDir).isDirectory()) {
-    return null;
+  const c = classifyTableDir(sstablesRoot);
+  return c.status === 'ok' ? c.dir : null;
+}
+
+/**
+ * True iff a directory ENTRY exists at `p`, whatever its type.
+ *
+ * `lstatSync`, not `existsSync`: the latter follows symlinks and so answers FALSE for a
+ * DANGLING one -- which would classify a dangling-symlink Data.db as `absent` when it is
+ * exactly the damaged-fixture case `broken` exists to report.
+ *
+ * @param {string} p
+ * @returns {boolean}
+ */
+function entryExists(p) {
+  try {
+    fs.lstatSync(p);
+    return true;
+  } catch (_e) {
+    return false;
   }
-  const matches = fs
-    .readdirSync(ksDir)
-    .filter((name) => name.startsWith(`${TABLE}-`))
-    .map((name) => path.join(ksDir, name))
-    .filter((dir) => fs.existsSync(path.join(dir, DATA_COMPONENT)))
-    .sort();
-  return matches.length > 0 ? matches[0] : null;
+}
+
+/**
+ * True iff `p` is a NONEMPTY REGULAR FILE (following symlinks).
+ *
+ * `fs.existsSync` is true for a directory and false for a dangling symlink, and says
+ * nothing about size -- and a zero-length Data.db is exactly what a truncated fetch
+ * leaves, which this harness would then "corrupt" and assert against.
+ *
+ * @param {string} p
+ * @returns {boolean}
+ */
+function isNonemptyFile(p) {
+  try {
+    const st = fs.statSync(p);
+    return st.isFile() && st.size > 0;
+  } catch (_e) {
+    return false;
+  }
 }
 
 /**
@@ -98,6 +200,11 @@ function makeCorruptFixture(destParent, sstablesRoot, mode, opts = {}) {
   const destTable = path.join(destRoot, KEYSPACE, path.basename(src));
   fs.cpSync(src, destTable, {
     recursive: true,
+    // COPY WHAT A SYMLINK POINTS AT, never the link (#3493 round 49). Defence in depth
+    // behind sourceTableDir's symlink rejection: that guard covers the TABLE DIRECTORY,
+    // while a symlinked COMPONENT inside a real directory would still be copied as a link
+    // and the mutation below would write through it into the source corpus.
+    dereference: true,
     // Skip only the multi-megabyte JSONL golden; the small -TOC.txt MUST be
     // kept (issue #1437). The reader consults only TOC-listed binary files.
     filter: (s) => !s.endsWith('.jsonl'),
@@ -126,4 +233,12 @@ function makeCorruptFixture(destParent, sstablesRoot, mode, opts = {}) {
   return destRoot;
 }
 
-module.exports = { KEYSPACE, TABLE, DATA_COMPONENT, MODES, sourceTableDir, makeCorruptFixture };
+module.exports = {
+  KEYSPACE,
+  TABLE,
+  DATA_COMPONENT,
+  MODES,
+  classifyTableDir,
+  sourceTableDir,
+  makeCorruptFixture,
+};

--- a/bindings/node/__test__/parity-utils.js
+++ b/bindings/node/__test__/parity-utils.js
@@ -38,6 +38,40 @@ function evictIfNeeded(cache) {
 // =============================================================================
 
 /**
+ * The canonical shape of a Cassandra table directory: `<table>-<32 hex uuid>`.
+ *
+ * Hoisted here (issue #3493) because the two golden lookups below now apply it.
+ * They previously selected a directory with a bare `startsWith(`${table}-`)`,
+ * which accepts committed siblings this regex rejects — `<table>-wip`,
+ * `<table>-extra-<uuid>` — so Jest could select a directory that
+ * `check-dataset-manifest.sh` (which requires the UUID shape) never validated,
+ * and the manifest would report the corpus complete while Jest read a broken
+ * golden out of the sibling. Consumer and validator now share ONE rule.
+ *
+ * Measured across both corpus roots when this was tightened: the only non-UUID
+ * table directory anywhere is `system/_paxos_repair_state`, which no lookup can
+ * select (it has no `<table>-` prefix), so this narrows nothing that resolves today.
+ */
+const TABLE_DIR_RE = /^(.+)-[0-9a-f]{32}$/;
+
+/**
+ * True if `entryName` is the canonical table directory FOR EXACTLY `table`.
+ *
+ * Equality on the captured table name, not a prefix test: `startsWith` treats
+ * `orders-extra-<uuid>` as a directory of table `orders`, while TABLE_DIR_RE
+ * parses its table name as `orders-extra`. This mirrors the manifest's
+ * `${base#"${table}-"}` + 32-hex-suffix test exactly.
+ *
+ * @param {string} entryName - Directory basename
+ * @param {string} table - Logical table name
+ * @returns {boolean}
+ */
+function isTableDirFor(entryName, table) {
+  const m = TABLE_DIR_RE.exec(entryName);
+  return m !== null && m[1] === table;
+}
+
+/**
  * Find the JSONL reference file for a given keyspace and table.
  * Tables have hash-suffixed directories: {table}-{hash}/nb-1-big-Data.db.jsonl
  *
@@ -63,7 +97,7 @@ function findJsonlFile(keyspace, table) {
   for (const entry of entries) {
     if (
       entry.isDirectory() &&
-      entry.name.startsWith(`${table}-`) &&
+      isTableDirFor(entry.name, table) &&
       isCommittedTableDir(keyspace, entry.name)
     ) {
       const jsonlFile = path.join(keyspaceDir, entry.name, 'nb-1-big-Data.db.jsonl');
@@ -100,7 +134,7 @@ function findOaJsonlFile(keyspace, table) {
   for (const entry of entries) {
     if (
       entry.isDirectory() &&
-      entry.name.startsWith(`${table}-`) &&
+      isTableDirFor(entry.name, table) &&
       isCommittedTableDir(keyspace, entry.name)
     ) {
       const tableDir = path.join(keyspaceDir, entry.name);
@@ -730,7 +764,8 @@ function formatValue(value) {
 // bindings/python/tests/corpus.py.
 // =============================================================================
 
-const TABLE_DIR_RE = /^(.+)-[0-9a-f]{32}$/;
+// (declaration hoisted above findJsonlFile — see the top-of-file definition)
+
 
 /**
  * All `system*` keyspaces (system, system_auth, system_schema,
@@ -1017,6 +1052,7 @@ function getKnownIssue(keyspace, table) {
 
 module.exports = {
   // JSONL utilities
+  isTableDirFor,
   findJsonlFile,
   findOaJsonlFile,
   countRowsInJsonl,

--- a/bindings/node/__test__/parity.test.js
+++ b/bindings/node/__test__/parity.test.js
@@ -453,6 +453,64 @@ describe('Parity Summary (Issue #307 / dynamic enumeration #1229)', () => {
 // =============================================================================
 
 /**
+ * Locate an OA JSONL golden, failing LOUDLY under strict fixtures (issue #3493).
+ *
+ * A missing golden used to be a bare `return`, so under CQLITE_REQUIRE_FIXTURES=1 -- which
+ * the FULL gate now sets -- the OA parity assertions could all vanish and the gate still
+ * report success (roborev round 16). OA tables are excluded from the ALL_TABLES
+ * golden-coverage assertion, so nothing else would have noticed.
+ *
+ * Lenient runs keep the graceful skip: the goldens ship with the fetched corpus, so their
+ * absence is a legitimate state when fixtures were never fetched.
+ *
+ * @param {string} keyspace
+ * @param {string} table
+ * @returns {string|null} Path to the golden, or null on a lenient run without one.
+ * @throws {Error} When strict fixtures are required and the golden is absent.
+ */
+function requireOaGolden(keyspace, table) {
+  const jsonlPath = findOaJsonlFile(keyspace, table);
+  if (jsonlPath) return jsonlPath;
+  if (global.REQUIRE_FIXTURES) {
+    throw new Error(
+      `No JSONL golden for ${keyspace}.${table}. CQLITE_REQUIRE_FIXTURES=1, so this is a ` +
+      'failure rather than a skip: OA tables are outside the ALL_TABLES golden-coverage ' +
+      'assertion, so a silent skip here drops the parity check with nothing objecting ' +
+      '(issue #3493).'
+    );
+  }
+  console.log(`  Skipping ${keyspace}.${table}: JSONL file not found`);
+  return null;
+}
+
+/**
+ * Resolve the OA schema, failing LOUDLY when it is absent (issue #3493).
+ *
+ * The schemas are COMMITTED SOURCE -- `test-data/schemas`, resolved checkout-relative or
+ * from an absolute `CQLITE_SCHEMAS_ROOT` -- so their absence means a broken checkout or a
+ * mis-pointed root, never a legitimate environment. A bare `return` here used to make
+ * every OA assertion vanish behind `dbOa === null` under a green suite.
+ *
+ * Shared by BOTH OA `beforeAll` blocks, and called BEFORE oaBinariesPresent(): one
+ * guards committed source (an error), the other guards fetched fixtures (a real skip),
+ * and putting the skip first hid the error on every run without OA binaries.
+ *
+ * @returns {string} Absolute path to the OA schema.
+ * @throws {Error} When the committed schema is not present.
+ */
+function requireOaSchema() {
+  const schemaPath = global.testPaths.SCHEMA_OA_TEST;
+  if (!require('fs').existsSync(schemaPath)) {
+    throw new Error(
+      `OA schema not found at ${schemaPath}. It is committed source, so this means a ` +
+      'broken checkout or a wrong CQLITE_SCHEMAS_ROOT - failing loudly rather than ' +
+      'silently skipping every OA assertion (issue #3493).'
+    );
+  }
+  return schemaPath;
+}
+
+/**
  * Helper: check whether oa Data.db binary files are present.
  * Returns true when at least one oa-format Data.db exists in test_oa/.
  * Graceful-skip: if only JSONL goldens are present (no binaries), tests skip.
@@ -486,13 +544,31 @@ describe('VG6: OA Format Parity — Row Count (Issue #672)', () => {
   beforeAll(async () => {
     skipIfNoDatasets();
 
-    if (!oaBinariesPresent()) {
-      // Mark as skipped; individual tests will skip via dbOa === null check
-      return;
-    }
+    // Issue #3493: the COMMITTED-SOURCE check runs FIRST, before the fetched-fixture
+    // one. The ORDER is the whole point (roborev round 13): with oaBinariesPresent()
+    // first, a missing committed schema stayed silently hidden on any run without OA
+    // binaries -- most partial-corpus `npm test` runs -- so the loud error added
+    // earlier could not fire in the very situation it was written for.
+    const schemaPath = requireOaSchema();
 
-    const schemaPath = global.testPaths.SCHEMA_OA_TEST;
-    if (!require('fs').existsSync(schemaPath)) {
+    if (!oaBinariesPresent()) {
+      // FETCHED fixtures: a genuine skip -- but NOT under strict mode (issue #3493,
+      // roborev round 15). CQLITE_REQUIRE_FIXTURES=1 means "a dataset test that does not
+      // run is a failure", which is exactly what the full gate now sets. Skipping here
+      // under strict let a corpus pass check-dataset-manifest.sh -- which accepts any
+      // regular `*-Data.db` -- and then skip EVERY OA assertion beneath a green full
+      // gate, because oaBinariesPresent() requires the narrower `oa-<n>-big-Data.db`.
+      // The two predicates disagree by design, so the strict run must say so out loud.
+      if (global.REQUIRE_FIXTURES) {
+        throw new Error(
+          'OA binaries not found under ' +
+          require('path').join(global.testPaths.SSTABLES_DIR, 'test_oa') +
+          ' (expected a file matching oa-<n>-big-Data.db). CQLITE_REQUIRE_FIXTURES=1, so ' +
+          'this is a failure rather than a skip: a strict run that silently drops every ' +
+          'OA assertion is the vacuous pass strict mode exists to prevent (issue #3493).'
+        );
+      }
+      // Lenient runs still skip; individual tests skip via dbOa === null.
       return;
     }
 
@@ -515,11 +591,8 @@ describe('VG6: OA Format Parity — Row Count (Issue #672)', () => {
       return; // graceful skip (no assert failures)
     }
 
-    const jsonlPath = findOaJsonlFile('test_oa', table);
-    if (!jsonlPath) {
-      console.log(`  Skipping test_oa.${table}: JSONL file not found`);
-      return;
-    }
+    const jsonlPath = requireOaGolden('test_oa', table);
+    if (!jsonlPath) return;   // lenient run: graceful skip
 
     const expectedCount = countRowsInJsonl(jsonlPath);
     const result = await dbOa.execute(`SELECT * FROM test_oa.${table}`);
@@ -535,12 +608,31 @@ describe('VG4: OA Format Parity — Value Spot Check (Issue #656)', () => {
   beforeAll(async () => {
     skipIfNoDatasets();
 
-    if (!oaBinariesPresent()) {
-      return;
-    }
+    // Issue #3493: the COMMITTED-SOURCE check runs FIRST, before the fetched-fixture
+    // one. The ORDER is the whole point (roborev round 13): with oaBinariesPresent()
+    // first, a missing committed schema stayed silently hidden on any run without OA
+    // binaries -- most partial-corpus `npm test` runs -- so the loud error added
+    // earlier could not fire in the very situation it was written for.
+    const schemaPath = requireOaSchema();
 
-    const schemaPath = global.testPaths.SCHEMA_OA_TEST;
-    if (!require('fs').existsSync(schemaPath)) {
+    if (!oaBinariesPresent()) {
+      // FETCHED fixtures: a genuine skip -- but NOT under strict mode (issue #3493,
+      // roborev round 15). CQLITE_REQUIRE_FIXTURES=1 means "a dataset test that does not
+      // run is a failure", which is exactly what the full gate now sets. Skipping here
+      // under strict let a corpus pass check-dataset-manifest.sh -- which accepts any
+      // regular `*-Data.db` -- and then skip EVERY OA assertion beneath a green full
+      // gate, because oaBinariesPresent() requires the narrower `oa-<n>-big-Data.db`.
+      // The two predicates disagree by design, so the strict run must say so out loud.
+      if (global.REQUIRE_FIXTURES) {
+        throw new Error(
+          'OA binaries not found under ' +
+          require('path').join(global.testPaths.SSTABLES_DIR, 'test_oa') +
+          ' (expected a file matching oa-<n>-big-Data.db). CQLITE_REQUIRE_FIXTURES=1, so ' +
+          'this is a failure rather than a skip: a strict run that silently drops every ' +
+          'OA assertion is the vacuous pass strict mode exists to prevent (issue #3493).'
+        );
+      }
+      // Lenient runs still skip; individual tests skip via dbOa === null.
       return;
     }
 
@@ -565,9 +657,8 @@ describe('VG4: OA Format Parity — Value Spot Check (Issue #656)', () => {
       return;
     }
 
-    const jsonlPath = findOaJsonlFile('test_oa', 'udt_table');
+    const jsonlPath = requireOaGolden('test_oa', 'udt_table');
     if (!jsonlPath) {
-      console.log('  Skipping: JSONL file not found for test_oa.udt_table');
       return;
     }
 

--- a/bindings/node/__test__/setup.js
+++ b/bindings/node/__test__/setup.js
@@ -23,7 +23,83 @@ const PROJECT_ROOT = path.resolve(BINDINGS_DIR, '..', '..');
 const TEST_DATA_ROOT = process.env.CQLITE_DATASETS_ROOT ||
   path.join(PROJECT_ROOT, 'test-data', 'datasets');
 const SSTABLES_DIR = path.join(TEST_DATA_ROOT, 'sstables');
-const SCHEMAS_DIR = path.join(PROJECT_ROOT, 'test-data', 'schemas');
+// Issue #3493: honour CQLITE_SCHEMAS_ROOT. The agent gate's #3148 preflight resolves a
+// schemas root -- an out-of-tree override when set and usable, else the checkout's --
+// validates it, and STAMPS it in the SUMMARY. Ignoring the variable here meant a run
+// could certify one schemas root while this suite read another, once the gate started
+// running the whole suite.
+//
+// This MIRRORS the gate's `_gate_schemas_root` / Rust `resolve_schemas_root` rather than
+// inventing a third contract (roborev round 8, Medium -- the first cut diverged on two
+// of the three cases and would have failed ordinary `npm test` runs that the other
+// runners resolve fine):
+//   * blank / whitespace-only  -> treated as UNSET (the gate's override_present test is
+//                                 `*[![:space:]]*`, i.e. presence requires a non-space
+//                                 character), so an exported-but-empty value is not an
+//                                 attempt to override and must not be an error;
+//   * relative                 -> REJECTED, loudly. This is the one case that must fail
+//                                 rather than fall back: the gate resolves it against the
+//                                 repo root while each runner resolves against its own
+//                                 cwd, so it would silently mean two different roots;
+//   * absolute, not a directory-> fall back to the checkout, exactly as
+//                                 `_gate_schemas_root`'s `[ -d ... ]` guard does. A stale
+//                                 exported path is not a request to fail every run.
+// BLANKNESS IS THE UNICODE WHITE_SPACE PROPERTY -- the same set all three resolvers use
+// (roborev #3493 rounds 35-46).
+//
+// Six rules were tried here and five were wrong. The first four were each off by one
+// character (`trim()` on U+FEFF, `\p{White_Space}` measured against a locale-specific
+// gate on U+0085, ASCII-only on U+2003, the glibc set on U+2007). The fifth was wrong in
+// KIND: I mirrored a MEASUREMENT of the gate's `[[:space:]]`, which is locale-sensitive --
+// with a lone U+2003 the gate answered "present" under LC_ALL=C and "blank" under UTF-8,
+// so no fixed mirror could be right in both.
+//
+// Round 45 pinned both sides to ASCII, which made gate and Node deterministic but moved
+// the gate AWAY from Rust's `trim()` in the common UTF-8 case -- trading one divergence
+// for another. The end state is to pick ONE contract and implement it explicitly
+// everywhere: `char::is_whitespace` IS the Unicode White_Space property, so Rust already
+// has it, the gate now strips exactly that set by byte substitution (locale-independent),
+// and this is the same property natively. Agreement is by construction, not by
+// measurement.
+//
+// U+FEFF is NOT White_Space (Unicode removed it), so a BOM-only value stays present in
+// all three -- which is why `String.trim()`, that strips it, was wrong at the start.
+const SCHEMAS_ROOT_RAW = process.env.CQLITE_SCHEMAS_ROOT;
+const SCHEMAS_ROOT_OVERRIDE =
+  SCHEMAS_ROOT_RAW !== undefined &&
+  !/^\p{White_Space}*$/u.test(SCHEMAS_ROOT_RAW)
+    ? SCHEMAS_ROOT_RAW
+    : undefined;
+// Control characters are rejected BEFORE the absolute test, in that order, because the
+// gate rejects them first too and reports that as the reason (roborev round 12, Low --
+// the first cut accepted an absolute path carrying one, so the two "mirrors" diverged
+// on a case the gate has an explicit rule for).
+//
+// `\p{Cc}` -- the full Unicode Cc category -- rather than a hand-written C0+DEL range
+// (roborev round 13, Low). That range omitted the C1 block U+0080-U+009F, and BOTH other
+// resolvers reject it: `fixture_roots.rs` uses `char::is_control` (which IS Cc), and the
+// gate's `[[:cntrl:]]` matches C1 under this locale -- verified, not assumed, with
+// U+0085. So the hand-written range made JavaScript the one outlier of three, in a
+// mirror whose entire value is that it does not diverge. Naming the category instead of
+// enumerating a range is also what stops the next Unicode-shaped gap.
+if (SCHEMAS_ROOT_OVERRIDE !== undefined && /\p{Cc}/u.test(SCHEMAS_ROOT_OVERRIDE)) {
+  throw new Error(
+    'CQLITE_SCHEMAS_ROOT must not contain control characters (newline/CR/tab), got ' +
+    JSON.stringify(SCHEMAS_ROOT_OVERRIDE)
+  );
+}
+if (SCHEMAS_ROOT_OVERRIDE !== undefined && !path.isAbsolute(SCHEMAS_ROOT_OVERRIDE)) {
+  throw new Error(
+    `CQLITE_SCHEMAS_ROOT must be an absolute path, got '${SCHEMAS_ROOT_OVERRIDE}' ` +
+    '(the gate resolves it against the repo root while each runner resolves it against ' +
+    'its own cwd, so a relative value would silently mean two different roots)'
+  );
+}
+const SCHEMAS_DIR =
+  SCHEMAS_ROOT_OVERRIDE !== undefined && fs.existsSync(SCHEMAS_ROOT_OVERRIDE) &&
+  fs.statSync(SCHEMAS_ROOT_OVERRIDE).isDirectory()
+    ? SCHEMAS_ROOT_OVERRIDE
+    : path.join(PROJECT_ROOT, 'test-data', 'schemas');
 
 // Schema file paths for different test keyspaces
 const SCHEMA_BASIC_TYPES = path.join(SCHEMAS_DIR, 'basic-types.cql');
@@ -32,6 +108,12 @@ const SCHEMA_TIME_SERIES = path.join(SCHEMAS_DIR, 'time-series.cql');
 const SCHEMA_WIDE_ROWS = path.join(SCHEMAS_DIR, 'wide-rows.cql');
 // Issue #656 (VG4): oa test schema for test_oa keyspace
 const SCHEMA_OA_TEST = path.join(SCHEMAS_DIR, 'oa-test.cql');
+// Issue #3493 round 10: write.test.js and write-smoke.test.js used to build this path
+// themselves from `__dirname/../../../test-data/schemas`, which BYPASSES the resolver
+// above -- so CQLITE_SCHEMAS_ROOT was honoured by some of the suite and ignored by the
+// rest, and the gate could certify an out-of-tree root that parts of Jest never read.
+// Every schema the suite needs must come from here.
+const SCHEMA_WRITE_TEST = path.join(SCHEMAS_DIR, 'write-test.cql');
 
 // =============================================================================
 // Dataset Availability Detection
@@ -141,6 +223,7 @@ global.testPaths = {
   SCHEMA_TIME_SERIES,
   SCHEMA_WIDE_ROWS,
   SCHEMA_OA_TEST,
+  SCHEMA_WRITE_TEST,
 };
 
 global.DATASETS_AVAILABLE = DATASETS_AVAILABLE;

--- a/bindings/node/__test__/write-smoke.test.js
+++ b/bindings/node/__test__/write-smoke.test.js
@@ -30,15 +30,10 @@ const path = require('path');
 const { Database } = require('../lib/index.js');
 
 // Single-table schema (no-heuristics mandate, Issue #28): unambiguous write target.
-const SCHEMA_PATH = path.join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'test-data',
-  'schemas',
-  'write-test.cql'
-);
+// Issue #3493: resolved through the SHARED resolver in setup.js, never rebuilt from
+// __dirname here. Building it locally bypassed CQLITE_SCHEMAS_ROOT, so the gate could
+// certify one schemas root while this file read another.
+const SCHEMA_PATH = global.testPaths.SCHEMA_WRITE_TEST;
 
 /** Recursively find the first file whose name ends with `-Data.db`. */
 function findDataDb(root) {

--- a/bindings/node/__test__/write.test.js
+++ b/bindings/node/__test__/write.test.js
@@ -42,15 +42,10 @@ function tmpWriteDir() {
  * (Issue #28) is satisfied: the write engine has an unambiguous write target.
  * The multi-table basic-types.cql is intentionally NOT used here.
  */
-const SCHEMA_PATH = path.join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'test-data',
-  'schemas',
-  'write-test.cql'
-);
+// Issue #3493: resolved through the SHARED resolver in setup.js, never rebuilt from
+// __dirname here. Building it locally bypassed CQLITE_SCHEMAS_ROOT, so the gate could
+// certify one schemas root while this file read another.
+const SCHEMA_PATH = global.testPaths.SCHEMA_WRITE_TEST;
 
 /**
  * Open a writable database in a temp directory.
@@ -683,9 +678,8 @@ describe('Write error paths (Issue #391)', () => {
     // basic-types.cql has 8 CREATE TABLE statements — the no-heuristics mandate
     // (Issue #28) requires an explicit error rather than silently picking one.
     expect.assertions(2);
-    const multiTableSchema = path.join(
-      __dirname, '..', '..', '..', 'test-data', 'schemas', 'basic-types.cql'
-    );
+    // Issue #3493: shared resolver, not a locally rebuilt path (see SCHEMA_PATH above).
+    const multiTableSchema = global.testPaths.SCHEMA_BASIC_TYPES;
     const { dir, cleanup: c } = tmpWriteDir();
     try {
       await Database.open(dir, {

--- a/cqlite-core/tests/issue_3493_descriptor_predicate_differential.rs
+++ b/cqlite-core/tests/issue_3493_descriptor_predicate_differential.rs
@@ -44,6 +44,8 @@
 
 #![cfg(unix)]
 
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -56,35 +58,40 @@ use cqlite_core::storage::sstable::version_gate::{
 /// Deliberately includes shapes no writer emits (`nb--big`, `nb-x-big-y-big`): "no writer emits
 /// that" is precisely the reasoning that produced the round-56 defect, so the port is held to the
 /// parser's ACTUAL behaviour rather than to the subset someone expects to see on disk.
-const NAMES: &[&str] = &[
+const NAMES: &[&[u8]] = &[
     // ordinary, and the two ID forms real Cassandra 5.0 writes
-    "nb-1-big-Data.db",
-    "nb-6aa08200a25111f0a3fef1a551383fb9-big-Data.db",
-    "nb-6aa08200-a251-11f0-a3fe-f1a551383fb9-big-Data.db",
-    "oa-1-big-Data.db",
-    "da-2-bti-Data.db",
+    b"nb-1-big-Data.db",
+    b"nb-6aa08200a25111f0a3fef1a551383fb9-big-Data.db",
+    b"nb-6aa08200-a251-11f0-a3fe-f1a551383fb9-big-Data.db",
+    b"oa-1-big-Data.db",
+    b"da-2-bti-Data.db",
     // arbitrary ID: parses, and the version gate lets it through (round 56)
-    "nb-foo-big-Data.db",
-    "nb--big-Data.db",
-    "nb-x-big-y-big-Data.db",
+    b"nb-foo-big-Data.db",
+    b"nb--big-Data.db",
+    b"nb-x-big-y-big-Data.db",
     // version/format pairings the gates reject
-    "nb-1-bti-Data.db", // BTI accepts only `da`
-    "nc-1-big-Data.db", // above the #1249 floor, outside the #1297 allowlist
-    "ma-1-big-Data.db", // pre-`na`, out of scope
-    "zz-9-big-Data.db",
+    b"nb-1-bti-Data.db", // BTI accepts only `da`
+    b"nc-1-big-Data.db", // above the #1249 floor, outside the #1297 allowlist
+    b"ma-1-big-Data.db", // pre-`na`, out of scope
+    b"zz-9-big-Data.db",
     // HYPHENATED COMPONENT (round 57): parses, passes the version gate, and its component is
     // "Foo-Data.db" -- a component that merely ENDS IN `-Data.db`, not the Data component. The
     // manifest globs `*-Data.db`, so these names reach the predicate and must be rejected.
-    "nb-1-big-Foo-Data.db",
-    "oa-1-big-Foo-Data.db",
-    "da-2-bti-Foo-Data.db",
+    b"nb-1-big-Foo-Data.db",
+    b"oa-1-big-Foo-Data.db",
+    b"da-2-bti-Foo-Data.db",
     // ... and the same shape for a real non-Data component, which must also not count as a
     // generation even though the file is a legitimate part of one.
-    "nb-1-big-CompressionInfo.db",
-    "nb-1-big-Statistics.db",
+    b"nb-1-big-CompressionInfo.db",
+    b"nb-1-big-Statistics.db",
     // not descriptors at all
-    "junk-Data.db",
-    "Data.db",
+    b"junk-Data.db",
+    b"Data.db",
+    // INVALID UTF-8 (round 6). Both discovery sites and the parser go through
+    // `file_name().and_then(|n| n.to_str())`, which returns None here, so the reader skips
+    // the file — while the shell's `.*` matches arbitrary BYTES. Expressible only as bytes,
+    // which is why the vector set is `&[u8]` rather than `&str`.
+    b"nb-\xff-big-Data.db",
 ];
 
 /// What the READER does for the question the MANIFEST is asking: would it open this file as
@@ -104,8 +111,11 @@ const NAMES: &[&str] = &[
 /// have made the manifest treat a non-Data component as a generation. What was genuinely
 /// wrong was this oracle: it would have called that name "reader-accepted" and reported a
 /// drift that does not exist.
-fn reader_accepts(name: &str) -> bool {
-    match SsTableDescriptor::parse_filename(name) {
+fn reader_accepts(name: &[u8]) -> bool {
+    // Through a PATH, as production does: `parse` calls `file_name().and_then(to_str)`, so an
+    // invalid-UTF-8 basename is rejected there rather than by any charset rule.
+    let p = PathBuf::from(OsStr::from_bytes(name));
+    match SsTableDescriptor::parse(&p) {
         Err(_) => false,
         Ok(d) => {
             let gated = match d.format {
@@ -125,7 +135,7 @@ fn manifest_script() -> PathBuf {
 
 /// What the SHELL PORT does. Sources the two functions out of the committed script rather than
 /// re-implementing them here -- a copy would drift, which is the defect class this test exists for.
-fn shell_accepts(name: &str) -> bool {
+fn shell_accepts(name: &[u8]) -> bool {
     let script = manifest_script();
     // A plain literal, not `format!`: nothing is interpolated, and clippy's `useless_format`
     // is right to say so.
@@ -136,10 +146,25 @@ fn shell_accepts(name: &str) -> bool {
         .arg(program)
         .arg("bash")
         .arg(&script)
-        .arg(name)
+        .arg(OsStr::from_bytes(name))
         .output()
         .expect("failed to run bash");
-    out.status.success()
+    // TRI-STATE, not `status.success()` (roborev, post-rebase round 6). Collapsing every
+    // nonzero status onto "reject" hides an OPERATIONAL failure — exit 2 (the script's own
+    // malfunction code) or 127 (bash could not run) — whenever the reader happens to reject
+    // the same name, which is most of the negative vectors. That is the very
+    // status-collapse family this differential exists to police, in the differential itself.
+    match out.status.code() {
+        Some(0) => true,
+        Some(1) => false,
+        other => panic!(
+            "shell predicate exited {other:?} for {:?} — that is a MALFUNCTION (2 = the \
+             script's own tooling-failure code, 127 = bash/sed missing), not a verdict. \
+             stderr: {}",
+            String::from_utf8_lossy(name),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    }
 }
 
 #[test]
@@ -157,7 +182,8 @@ fn shell_predicate_matches_the_reader() {
         let (r, s) = (reader_accepts(name), shell_accepts(name));
         if r != s {
             disagreements.push(format!(
-                "{name}: reader={} shell={} ({})",
+                "{}: reader={} shell={} ({})",
+                String::from_utf8_lossy(name),
                 if r { "ACCEPT" } else { "REJECT" },
                 if s { "ACCEPT" } else { "REJECT" },
                 if s {

--- a/cqlite-core/tests/issue_3493_descriptor_predicate_differential.rs
+++ b/cqlite-core/tests/issue_3493_descriptor_predicate_differential.rs
@@ -18,6 +18,24 @@
 //! was judged unreadable, making the manifest STRICTER than the reader and suppressing the Node
 //! suite for a corpus the reader opens.
 //!
+//! WHAT THIS DOES **NOT** ESTABLISH, measured and recorded so the scope is not overread.
+//! Production DISCOVERY is not this predicate: `manager_open.rs` takes any
+//! `filename.ends_with("-Data.db")`, and `SSTableComponent::from_filename` maps any such name
+//! to the Data component -- neither consults `parse_filename`. A per-file open error is then
+//! logged and SKIPPED (best-effort load). Measured with garbage bytes beside a healthy `nb-1`:
+//!
+//!     nb-1-big-Foo-Data.db -> the query THROWS      (shares the nb-1-big- prefix)
+//!     junk-Data.db         -> 100 rows, tolerated   (discovered, open fails, skipped)
+//!     nb-9-big-Data.db     -> 100 rows, tolerated   (valid descriptor, other generation)
+//!     xx-1-big-Data.db     -> 100 rows, tolerated
+//!     nb-foo-big-Data.db   -> 100 rows, tolerated
+//!
+//! So "the reader would open this" and "an unusable file here breaks the run" are DIFFERENT
+//! questions, and only the prefix-collision shape is fatal. That shape is checked in
+//! `check-dataset-manifest.sh` directly, not here. This test's subject is narrower and worth
+//! stating plainly: that the shell predicate's notion of a GENERATION matches the descriptor
+//! parser plus the version gates. It is not a model of discovery and must not be read as one.
+//!
 //! Both directions matter and both are asserted:
 //!   * shell ACCEPT / reader REJECT -- a false-PRESENT: an unreadable fixture passes the manifest
 //!     and the Node suite then fails on it, with the #2078 opt-out unable to suppress it.

--- a/cqlite-core/tests/issue_3493_descriptor_predicate_differential.rs
+++ b/cqlite-core/tests/issue_3493_descriptor_predicate_differential.rs
@@ -1,0 +1,167 @@
+//! Differential: `check-dataset-manifest.sh`'s `_reader_accepts_descriptor` vs the REAL reader.
+//!
+//! UNIX-ONLY (roborev #3493 round 58). The differential invokes `bash`/`sed` to exercise the
+//! shell predicate ITSELF, which is the whole point -- it must run the COMMITTED script rather
+//! than a Rust re-implementation, since a re-implementation is the drift this test exists to
+//! detect. Established precedent in this crate: 5+ cqlite-core tests carry a `cfg(unix)` guard,
+//! and no CI lane runs cqlite-core on Windows.
+//!
+//! The shell function is a PORT of two Rust decisions -- `SsTableDescriptor::parse_filename`
+//! and the version gates -- and a port's correctness is only knowable by differential testing
+//! against the original, never against a model of it (CLAUDE.md, #3283). Reading the Rust and
+//! writing a matching regex is exactly the "tested against a model of Go" mistake that issue
+//! records; this test asks the original.
+//!
+//! It has already paid for itself twice. Rounds 36-38 argued about whether a BIG version
+//! allowlist existed (it does, and two windowed reads missed it), and round 56 found the ID
+//! charset was `[0-9a-f-]+` while the parser imposes NO charset at all -- so `nb-foo-big-Data.db`
+//! was judged unreadable, making the manifest STRICTER than the reader and suppressing the Node
+//! suite for a corpus the reader opens.
+//!
+//! Both directions matter and both are asserted:
+//!   * shell ACCEPT / reader REJECT -- a false-PRESENT: an unreadable fixture passes the manifest
+//!     and the Node suite then fails on it, with the #2078 opt-out unable to suppress it.
+//!   * shell REJECT / reader ACCEPT -- a false-MISSING: a readable corpus is reported incomplete
+//!     and the suite is suppressed, silently losing the coverage this whole issue exists to add.
+
+#![cfg(unix)]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use cqlite_core::storage::sstable::version_gate::{
+    BigVersionGates, BtiVersionGates, SsTableDescriptor, SsTableFormat,
+};
+
+/// Every name shape either side has ever disagreed about, plus the ordinary ones.
+///
+/// Deliberately includes shapes no writer emits (`nb--big`, `nb-x-big-y-big`): "no writer emits
+/// that" is precisely the reasoning that produced the round-56 defect, so the port is held to the
+/// parser's ACTUAL behaviour rather than to the subset someone expects to see on disk.
+const NAMES: &[&str] = &[
+    // ordinary, and the two ID forms real Cassandra 5.0 writes
+    "nb-1-big-Data.db",
+    "nb-6aa08200a25111f0a3fef1a551383fb9-big-Data.db",
+    "nb-6aa08200-a251-11f0-a3fe-f1a551383fb9-big-Data.db",
+    "oa-1-big-Data.db",
+    "da-2-bti-Data.db",
+    // arbitrary ID: parses, and the version gate lets it through (round 56)
+    "nb-foo-big-Data.db",
+    "nb--big-Data.db",
+    "nb-x-big-y-big-Data.db",
+    // version/format pairings the gates reject
+    "nb-1-bti-Data.db", // BTI accepts only `da`
+    "nc-1-big-Data.db", // above the #1249 floor, outside the #1297 allowlist
+    "ma-1-big-Data.db", // pre-`na`, out of scope
+    "zz-9-big-Data.db",
+    // HYPHENATED COMPONENT (round 57): parses, passes the version gate, and its component is
+    // "Foo-Data.db" -- a component that merely ENDS IN `-Data.db`, not the Data component. The
+    // manifest globs `*-Data.db`, so these names reach the predicate and must be rejected.
+    "nb-1-big-Foo-Data.db",
+    "oa-1-big-Foo-Data.db",
+    "da-2-bti-Foo-Data.db",
+    // ... and the same shape for a real non-Data component, which must also not count as a
+    // generation even though the file is a legitimate part of one.
+    "nb-1-big-CompressionInfo.db",
+    "nb-1-big-Statistics.db",
+    // not descriptors at all
+    "junk-Data.db",
+    "Data.db",
+];
+
+/// What the READER does for the question the MANIFEST is asking: would it open this file as
+/// a **Data.db generation**?
+///
+/// Three conditions, and the third was missing (roborev #3493 round 57 raised the case; the
+/// measurement below reversed its conclusion). Parse + version gate alone is a LOOSER oracle
+/// than the manifest's question, because `parse_filename` splits
+/// `<version>-<id>-<format>-<component>` by scanning right-to-left for the format segment and
+/// treats EVERYTHING after it as the component. Measured against the real parser:
+///
+///     nb-1-big-Data.db      -> component "Data.db"
+///     nb-1-big-Foo-Data.db  -> component "Foo-Data.db"     <-- parses, but is NOT a Data.db
+///
+/// So `nb-1-big-Foo-Data.db` is a *validly named component that is not the Data component*.
+/// The shell predicate rejecting it is CORRECT, and the round-57 proposal to accept it would
+/// have made the manifest treat a non-Data component as a generation. What was genuinely
+/// wrong was this oracle: it would have called that name "reader-accepted" and reported a
+/// drift that does not exist.
+fn reader_accepts(name: &str) -> bool {
+    match SsTableDescriptor::parse_filename(name) {
+        Err(_) => false,
+        Ok(d) => {
+            let gated = match d.format {
+                SsTableFormat::Big => BigVersionGates::from_version(&d.version).is_ok(),
+                _ => BtiVersionGates::from_version(&d.version).is_ok(),
+            };
+            gated && d.component == "Data.db"
+        }
+    }
+}
+
+fn manifest_script() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("test-data/scripts/check-dataset-manifest.sh")
+}
+
+/// What the SHELL PORT does. Sources the two functions out of the committed script rather than
+/// re-implementing them here -- a copy would drift, which is the defect class this test exists for.
+fn shell_accepts(name: &str) -> bool {
+    let script = manifest_script();
+    // A plain literal, not `format!`: nothing is interpolated, and clippy's `useless_format`
+    // is right to say so.
+    let program = "eval \"$(sed -n '/^_re_match() {/,/^}/p;/^_reader_accepts_descriptor() {/,/^}/p' \"$1\")\"\n\
+                   _reader_accepts_descriptor \"$2\"";
+    let out = Command::new("bash")
+        .arg("-c")
+        .arg(program)
+        .arg("bash")
+        .arg(&script)
+        .arg(name)
+        .output()
+        .expect("failed to run bash");
+    out.status.success()
+}
+
+#[test]
+fn shell_predicate_matches_the_reader() {
+    let script = manifest_script();
+    assert!(
+        script.is_file(),
+        "committed manifest script not found at {} -- the differential cannot run, and a \
+         silently skipped differential is the vacuous pass this test exists to prevent",
+        script.display()
+    );
+
+    let mut disagreements = Vec::new();
+    for name in NAMES {
+        let (r, s) = (reader_accepts(name), shell_accepts(name));
+        if r != s {
+            disagreements.push(format!(
+                "{name}: reader={} shell={} ({})",
+                if r { "ACCEPT" } else { "REJECT" },
+                if s { "ACCEPT" } else { "REJECT" },
+                if s {
+                    "false-PRESENT: an unreadable fixture would pass the manifest"
+                } else {
+                    "false-MISSING: a readable corpus would be reported incomplete"
+                }
+            ));
+        }
+    }
+    assert!(
+        disagreements.is_empty(),
+        "check-dataset-manifest.sh's _reader_accepts_descriptor has drifted from the reader:\n  {}",
+        disagreements.join("\n  ")
+    );
+
+    // A differential over an empty or all-agreeing-by-vacuity set proves nothing: require that
+    // the corpus of names actually exercises BOTH verdicts.
+    let accepted = NAMES.iter().filter(|n| reader_accepts(n)).count();
+    assert!(
+        accepted > 0 && accepted < NAMES.len(),
+        "the differential must cover both verdicts; reader accepted {accepted}/{}",
+        NAMES.len()
+    );
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6602,8 +6602,19 @@ run_node_bindings() {
       # npm run typecheck (#3493). node-ci.yml runs it as an ALWAYS-RUN PR smoke job, and
       # this component is the declared merge-gating half of that workflow -- so leaving it
       # out left the same kind of hole #3522 closed for the jest suite, one job over. It
-      # also exercises the SHIPPED index.d.ts declarations, which no jest test does: a
-      # binding can pass every runtime test while its published types are wrong.
+      # also COMPILES against the SHIPPED index.d.ts (it is tsc --noEmit over the examples
+      # project), so a binding cannot pass every runtime test while its published types
+      # fail to typecheck.
+      #
+      # NOT the same as the #3581 typescript-definitions test, which landed on main while
+      # this branch was in review: that one reads the declarations as TEXT and asserts the
+      # runtime surface is declared. Neither subsumes the other -- a declaration can be
+      # present and still not compile, and a file can compile with an export missing. An
+      # earlier version of this comment claimed typecheck was the ONLY thing exercising
+      # index.d.ts; #3581 made that false, so it now says what typecheck uniquely does.
+      #
+      # (And note the no-apostrophe rule above applies to these lines too -- one
+      # apostrophe here ends the single-quoted string and the script stops parsing.)
       #
       # In STEP 1, beside build, because it needs no corpus: it must run (and fail closed)
       # even on a host where the dataset half cannot.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6855,6 +6855,16 @@ run_node_bindings() {
     echo ">>> [$name]   distinguishable from an absent one for these suites — the parity cases derive"
     echo ">>> [$name]   their table set from disk, so they would run GREEN over the tables that remain"
     echo ">>> [$name]   and silently omit the rest. Manifest diagnostics are in $log."
+    # #1465, and the reason this line is easy to forget: `NOT-REACHED` is the PESSIMISTIC
+    # default written before anything runs, so EVERY early return inherits it unless it says
+    # otherwise. Reaching here means the corpus opt-out fired -- but the summary would report
+    # the lane as having died in `npm ci`, the build, `--listTests` or the reconciliation,
+    # which is a false statement about WHY the budgets did not run and points the reader at a
+    # build failure that never happened.
+    #
+    # Same declaration as the ABSENT-corpus branch above; this branch is the second dataset
+    # gate for the leak budgets and was added without it (roborev, post-rebase round 15).
+    _node_leak_lane_note SKIP-OPTOUT > "$(_node_leak_lane_note_file)"
     end=$(date +%s)
     record_result "$name" "$status" "$((end - start))"
     echo ">>> [$name] $status ($((end - start))s)"

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2019,7 +2019,7 @@ apply_fixture_preflight() {
 # tail_latency_harness), which also cover dead_cache_delete_tests (basic-types.cql),
 # observability_correctness (basic-types.cql) and cqlite-cli's export_csv bench
 # (collections.cql).
-CANONICAL_SCHEMA_FILES="basic-types.cql da-test.cql time-series.cql wide-table-bti.cql collections.cql wide-rows.cql"
+CANONICAL_SCHEMA_FILES="basic-types.cql da-test.cql oa-test.cql write-test.cql time-series.cql wide-table-bti.cql collections.cql wide-rows.cql"
 # Stamped into the SUMMARY on a successful check so the pasted block shows POSITIVELY
 # that the schemas root was validated, not merely that nothing complained.
 SCHEMAS_LINE=""
@@ -2102,10 +2102,32 @@ _gate_checkout_test_data_dir() {
 # trimmed into `/abs`. The test is a pure-bash pattern, not `tr`, so it too is
 # substitution-free.
 _gate_schemas_override_present() {
-  case "${CQLITE_SCHEMAS_ROOT:-}" in
-    *[![:space:]]*) return 0 ;;
-    *) return 1 ;;
-  esac
+  local _v="${CQLITE_SCHEMAS_ROOT:-}"
+  # Strip the UNICODE WHITE_SPACE set by explicit substitution. Two properties matter and
+  # neither is available from `[[:space:]]`:
+  #   * LOCALE-INDEPENDENT -- these are exact byte substitutions of each character's UTF-8
+  #     encoding, not a character class the C library reinterprets per locale;
+  #   * IT IS RUST'S SET -- `char::is_whitespace` (hence `str::trim()`, hence
+  #     `resolve_schemas_root`) is exactly the Unicode White_Space property. Listing it
+  #     here makes the shell, Node and Rust resolvers agree BY CONSTRUCTION rather than by
+  #     one mirroring a measurement of another.
+  # U+FEFF is deliberately absent: Unicode removed it from White_Space, so Rust keeps a
+  # BOM-only value as present and so do we.
+  #
+  # The escapes are RAW UTF-8 BYTES (`$'\xNN...'`), not `$'\uXXXX'`: bash's \u expansion
+  # is ITSELF locale-dependent and under LC_ALL=C produced something that matched nothing,
+  # so the first cut of this fix still diverged in the C locale. Byte escapes are exact
+  # everywhere, which is the whole point of the change.
+  _v=${_v//[$' \t\n\v\f\r']/}
+  for _wsc in \
+              $'\xc2\x85' $'\xc2\xa0' $'\xe1\x9a\x80' $'\xe2\x80\x80' $'\xe2\x80\x81' \
+              $'\xe2\x80\x82' $'\xe2\x80\x83' $'\xe2\x80\x84' $'\xe2\x80\x85' $'\xe2\x80\x86' \
+              $'\xe2\x80\x87' $'\xe2\x80\x88' $'\xe2\x80\x89' $'\xe2\x80\x8a' $'\xe2\x80\xa8' \
+              $'\xe2\x80\xa9' $'\xe2\x80\xaf' $'\xe2\x81\x9f' $'\xe3\x80\x80'
+    do
+    _v=${_v//"$_wsc"/}
+  done
+  [ -n "$_v" ]
 }
 
 # _gate_schemas_override_reject: echoes a non-empty REASON when an override is present but
@@ -2116,11 +2138,31 @@ _gate_schemas_override_present() {
 # CQLITE_SCHEMAS_ROOT rejected` for EVERY rejection — a FALSE message for a
 # control-character value, and untested because the round-3 coverage went through the pure
 # hook and never saw the real emit (spec-auditor, AC (b) partial).
+# _gate_has_control_char <value>: rc 0 iff <value> contains a Unicode Cc control --
+# C0 (U+0001..U+001F), DEL (U+007F) or C1 (U+0080..U+009F).
+#
+# LOCALE-INDEPENDENT, which `[[:cntrl:]]` is NOT (roborev #3493 round 48). Measured: under
+# `LC_ALL=C` the shell sees the UTF-8 bytes of a C1 control as two ordinary characters, so
+# `*[[:cntrl:]]*` MISSED U+0085 and U+009C -- while the node binding's `/\p{Cc}/u` rejects
+# them in every locale. The gate would certify a schemas root node then refuses, and the
+# component fails AFTER the preflight said it was fine. Same divergence class as the
+# whitespace predicate in round 46, and fixed the same way: raw UTF-8 BYTE escapes under a
+# pinned `LC_ALL=C`, never `\uXXXX'` (whose expansion is itself locale-dependent).
+#
+# Bracket ranges are BYTEWISE only in the C locale, so the locale is pinned for the test
+# rather than assumed. C1 is matched as its two-byte UTF-8 form 0xC2 0x80..0x9F.
+_gate_has_control_char() {
+  LC_ALL=C bash -c '
+    case "$1" in
+      *[$'"'"'\x01'"'"'-$'"'"'\x1f'"'"']*|*$'"'"'\x7f'"'"'*) exit 0 ;;
+      *$'"'"'\xc2'"'"'[$'"'"'\x80'"'"'-$'"'"'\x9f'"'"']*)    exit 0 ;;
+    esac
+    exit 1' _ "$1"
+}
+
 _gate_schemas_override_reject_kind() {
   _gate_schemas_override_present || return 0
-  case "${CQLITE_SCHEMAS_ROOT:-}" in
-    *[[:cntrl:]]*) printf '%s' 'control-chars'; return 0 ;;
-  esac
+  _gate_has_control_char "${CQLITE_SCHEMAS_ROOT:-}" && { printf '%s' 'control-chars'; return 0; }
   _gate_schemas_override_is_utf8 || { printf '%s' 'non-utf8'; return 0; }
   case "${CQLITE_SCHEMAS_ROOT:-}" in
     /*) return 0 ;;
@@ -2183,11 +2225,10 @@ _gate_schemas_override_reject() {
   # legitimate schemas root, and admitting it is what let `$( )`-stripping diverge the two
   # mirrors (finding 2 above). Rejecting outright keeps them aligned without relying on
   # every future consumer avoiding command substitution.
-  case "${CQLITE_SCHEMAS_ROOT:-}" in
-    *[[:cntrl:]]*)
-      printf '%s' "CQLITE_SCHEMAS_ROOT must not contain control characters (newline/CR/tab), got $(printf '%q' "${CQLITE_SCHEMAS_ROOT:-}")"
-      return 0 ;;
-  esac
+  if _gate_has_control_char "${CQLITE_SCHEMAS_ROOT:-}"; then
+    printf '%s' "CQLITE_SCHEMAS_ROOT must not contain control characters (C0/DEL/C1, e.g. newline/CR/tab/U+0085), got $(printf '%q' "${CQLITE_SCHEMAS_ROOT:-}")"
+    return 0
+  fi
   _gate_schemas_override_is_utf8 \
     || { printf '%s' "CQLITE_SCHEMAS_ROOT must be valid UTF-8, got $(printf '%q' "${CQLITE_SCHEMAS_ROOT:-}")"; return 0; }
   case "${CQLITE_SCHEMAS_ROOT:-}" in
@@ -6484,7 +6525,7 @@ run_node_bindings() {
   fi
 
   local -a census=()
-  census+=("npm ci + npm run build + npm test — the WHOLE jest suite, #3522")
+  census+=("npm ci + npm run build + npm run typecheck + check-dataset-manifest.sh + npm test — the WHOLE jest suite, #3522/#3493")
   census+=("  supersedes the #1255 narrowing to 1 of 27 files; node-ci.yml is required-EXEMPT on the")
   census+=("  grounds that THIS component is the merge-gating half, which was true of 1 file in 27.")
   census+=("  fixtures: $fixture_note")
@@ -6558,9 +6599,21 @@ run_node_bindings() {
       cd "'"$REPO_ROOT"'/bindings/node"
       if [ -f package-lock.json ]; then npm ci; else npm install; fi
       npm run build
+      # npm run typecheck (#3493). node-ci.yml runs it as an ALWAYS-RUN PR smoke job, and
+      # this component is the declared merge-gating half of that workflow -- so leaving it
+      # out left the same kind of hole #3522 closed for the jest suite, one job over. It
+      # also exercises the SHIPPED index.d.ts declarations, which no jest test does: a
+      # binding can pass every runtime test while its published types are wrong.
+      #
+      # In STEP 1, beside build, because it needs no corpus: it must run (and fail closed)
+      # even on a host where the dataset half cannot.
+      #
+      # NOTE: no apostrophes in this comment. It sits inside a single-quoted bash -c
+      # string, so one apostrophe ends the string and the script stops parsing.
+      npm run typecheck
       ./node_modules/.bin/jest --listTests > "$CQLITE_LIST_FILE"' >>"$log" 2>&1; then
     status=FAIL
-    echo "--- [$name] FAILED (npm ci / npm run build / jest --listTests); last 40 lines of $log ---"
+    echo "--- [$name] FAILED (npm ci / npm run build / npm run typecheck / jest --listTests); last 40 lines of $log ---"
     tail -40 "$log"
     echo "--- end of $name output ---"
     end=$(date +%s)
@@ -6739,6 +6792,51 @@ run_node_bindings() {
   fi
   echo ">>> [$name] suite set RECONCILED: $suite_n *.test.js file(s) — two INDEPENDENT oracles agree (recursive find over __test__/ vs ./node_modules/.bin/jest --listTests); neither alone could detect a config exclusion (#3522 D1)"
   echo "suite set RECONCILED: $suite_n *.test.js file(s) — independent recursive find over __test__/ AGREES with ./node_modules/.bin/jest --listTests (symmetric difference empty)" >> "$log"
+
+  # STEP 1b — CORPUS COMPLETENESS, before the suite runs (#3493).
+  #
+  # A DIFFERENT QUESTION from #3522's suite-execution census, and neither answers the
+  # other. That census asks "does every test FILE run"; this asks "is the CORPUS those
+  # files read actually complete". A partial extraction leaves a table half-fetched, every
+  # suite still runs, and the parity cases derive their table set FROM DISK -- so the
+  # missing tables simply are not enumerated and the suite is green over a corpus that is
+  # not there. #3522's per-suite guard cannot see it either: those suites DID do work.
+  #
+  # Measured against the real node binding, on an otherwise intact generation:
+  #   * a zero-length CompressionInfo.db or Statistics.db -> SELECT returns 0 ROWS,
+  #     silently. Not an error -- an empty result set, which is exactly the
+  #     "0-rows-when-present" failure this repo says must never pass.
+  #   * a second generation whose Data.db is well-formed garbage -> the reader THROWS.
+  #
+  # Runs only when the dataset half is going to run: under the #2078 opt-out the component
+  # has already SKIPped above, so this is never reached with a deliberately absent corpus.
+  # Exit 9 is the script RESERVED corpus verdict; anything else is a tooling failure and is
+  # reported as such rather than being read as a judged corpus.
+  local _dm_rc=0
+  bash "$REPO_ROOT/test-data/scripts/check-dataset-manifest.sh" \
+    "$CQLITE_DATASETS_ROOT" >>"$log" 2>&1 || _dm_rc=$?
+  if [ "$_dm_rc" -ne 0 ]; then
+    status=FAIL
+    if [ "$_dm_rc" -eq 9 ]; then
+      echo "--- [$name] FAILED: the corpus at $CQLITE_DATASETS_ROOT/sstables is INCOMPLETE."
+      echo "    Every jest suite would still RUN and could still be green: the parity cases derive"
+      echo "    their table set from disk, so a missing table is simply never enumerated. Remedy:"
+      echo "    bash test-data/scripts/fetch-datasets.sh, or AGENT_GATE_ALLOW_MISSING_FIXTURES=1 to"
+      echo "    opt out visibly (which SKIPs this component rather than passing it). Details in $log."
+    else
+      echo "--- [$name] FAILED: check-dataset-manifest.sh exited $_dm_rc — neither success nor its"
+      echo "    reserved incomplete-corpus code 9. That is a TOOLING failure, not a corpus verdict,"
+      echo "    and the #2078 opt-out deliberately does not excuse it: the opt-out excuses missing"
+      echo "    fixtures, not an unanswered question. Details in $log."
+    fi
+    tail -20 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+  echo ">>> [$name] corpus complete: check-dataset-manifest.sh verified every expected table under $CQLITE_DATASETS_ROOT/sstables (#3493)"
 
   # STEP 2 — run them.
   # `env "${fixture_env[@]}"` FIRST, because `env`'s -u options must precede any
@@ -10180,6 +10278,21 @@ run_tooling_tests() {
   # needed, always runs. Mechanizes #1990 — asserts cqlite-flight/Dockerfile has
   # exactly one `FROM rust:` line matching rust-toolchain.toml's channel. A
   # failure FAILs the component, mirroring the keyspace-scoping guard.
+  # #3493: the dataset-corpus completeness checker. Dataset-free, network-free — it builds
+  # its own synthetic corpora and never touches CQLITE_DATASETS_ROOT except through cases
+  # that explicitly need a real one.
+  echo ">>> [$name] bash scripts/tests/test_check_dataset_manifest.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_check_dataset_manifest.sh" >>"$log" 2>&1; then
+    status=FAIL
+    echo "--- [$name] FAILED (test_check_dataset_manifest.sh); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
   echo ">>> [$name] bash scripts/tests/test_check_dockerfile_rust_pin.sh"
   if ! bash "$REPO_ROOT/scripts/tests/test_check_dockerfile_rust_pin.sh" >>"$log" 2>&1; then
     status=FAIL

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -2152,12 +2152,26 @@ _gate_schemas_override_present() {
 # Bracket ranges are BYTEWISE only in the C locale, so the locale is pinned for the test
 # rather than assumed. C1 is matched as its two-byte UTF-8 form 0xC2 0x80..0x9F.
 _gate_has_control_char() {
+  # THREE-VALUED, failing CLOSED (roborev, post-rebase round 12). This spawns `bash` through
+  # PATH, and callers read the result as a plain boolean -- so if the subprocess cannot launch
+  # (127) or dies (>1), "no control character" is what they see, and a control-bearing schemas
+  # root passes a preflight the node binding will then reject. An unverifiable value must not
+  # be certified, so an unexpected status is reported and treated as PRESENT: the override is
+  # refused and the gate falls back to the checkout-relative schemas, which is the safe
+  # direction and is visible rather than silent.
+  local _cc_rc=0
   LC_ALL=C bash -c '
     case "$1" in
       *[$'"'"'\x01'"'"'-$'"'"'\x1f'"'"']*|*$'"'"'\x7f'"'"'*) exit 0 ;;
       *$'"'"'\xc2'"'"'[$'"'"'\x80'"'"'-$'"'"'\x9f'"'"']*)    exit 0 ;;
     esac
-    exit 1' _ "$1"
+    exit 1' _ "$1" || _cc_rc=$?
+  case "$_cc_rc" in
+    0) return 0 ;;   # a control character IS present
+    1) return 1 ;;   # none present
+    *) echo "[agent-gate] WARNING: the control-character probe exited $_cc_rc (could not run?); treating CQLITE_SCHEMAS_ROOT as UNVERIFIABLE and refusing it" >&2
+       return 0 ;;
+  esac
 }
 
 _gate_schemas_override_reject_kind() {

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -6815,6 +6815,26 @@ run_node_bindings() {
   local _dm_rc=0
   bash "$REPO_ROOT/test-data/scripts/check-dataset-manifest.sh" \
     "$CQLITE_DATASETS_ROOT" >>"$log" 2>&1 || _dm_rc=$?
+  # THE #2078 OPT-OUT HAS TO REACH THIS VERDICT TOO (roborev #3493, post-rebase round).
+  # The SKIP branch above keys on `_node_bindings_corpus_present`, which is satisfied by ANY
+  # single `test_basic` Data.db -- so on a PARTIAL corpus it reports "present", the opt-out
+  # never fires, and the manifest fails here. The diagnostic below used to tell the operator
+  # to set AGENT_GATE_ALLOW_MISSING_FIXTURES=1, which in that exact state does nothing: a
+  # remedy that does not work is worse than none, because it costs a debugging cycle to
+  # discover. So an incomplete corpus UNDER THE OPT-OUT skips, the same way an absent one
+  # does -- one behaviour for "the corpus cannot support this run", not two.
+  if [ "$_dm_rc" -eq 9 ] && [ "${AGENT_GATE_ALLOW_MISSING_FIXTURES:-0}" = 1 ]; then
+    status=SKIP
+    echo ">>> [$name] SKIP (AGENT_GATE_ALLOW_MISSING_FIXTURES=1 and check-dataset-manifest.sh reports an INCOMPLETE corpus at CQLITE_DATASETS_ROOT='${CQLITE_DATASETS_ROOT:-<unset>}')"
+    echo ">>> [$name]   NOT VALIDATED by this run: the whole jest suite. A partial corpus is not"
+    echo ">>> [$name]   distinguishable from an absent one for these suites — the parity cases derive"
+    echo ">>> [$name]   their table set from disk, so they would run GREEN over the tables that remain"
+    echo ">>> [$name]   and silently omit the rest. Manifest diagnostics are in $log."
+    end=$(date +%s)
+    record_result "$name" "$status" "$((end - start))"
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
   if [ "$_dm_rc" -ne 0 ]; then
     status=FAIL
     if [ "$_dm_rc" -eq 9 ]; then
@@ -6822,7 +6842,8 @@ run_node_bindings() {
       echo "    Every jest suite would still RUN and could still be green: the parity cases derive"
       echo "    their table set from disk, so a missing table is simply never enumerated. Remedy:"
       echo "    bash test-data/scripts/fetch-datasets.sh, or AGENT_GATE_ALLOW_MISSING_FIXTURES=1 to"
-      echo "    opt out visibly (which SKIPs this component rather than passing it). Details in $log."
+      echo "    opt out visibly — which SKIPs this component (verified to reach THIS verdict, not just"
+      echo "    an absent corpus). Details in $log."
     else
       echo "--- [$name] FAILED: check-dataset-manifest.sh exited $_dm_rc — neither success nor its"
       echo "    reserved incomplete-corpus code 9. That is a TOOLING failure, not a corpus verdict,"

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -83,6 +83,25 @@ if [ "${#CANONICAL[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# DERIVATION IS FOR BUILDING FIXTURES; MEMBERSHIP IS ASSERTED INDEPENDENTLY (roborev #3493).
+# Deriving BOTH sides is a tautology: deleting a schema from the production list would delete
+# it from the expectation too, and the regression would stay green. So the entries this repo
+# depends on are named HERE, on purpose, as a second source.
+#
+# `oa-test.cql` and `write-test.cql` are required because the gate runs the WHOLE node suite
+# (#3522) and its OA parity and write cases resolve those schemas; if they leave
+# CANONICAL_SCHEMA_FILES, the #3148 preflight stops guarding them and their absence surfaces
+# as a suite failure instead of a named preflight FAIL.
+for _req in basic-types.cql oa-test.cql write-test.cql; do
+  case " ${CANONICAL[*]} " in
+    *" $_req "*) : ;;
+    *) echo "FAIL - $_req is no longer in the gate's CANONICAL_SCHEMA_FILES; the #3148 preflight" >&2
+       echo "       has stopped guarding a schema the node suite resolves. If that is intended," >&2
+       echo "       remove it from this list too — deliberately, in the same diff." >&2
+       exit 1 ;;
+  esac
+done
+
 # A dataset root whose canonical corpus IS present, so the #2078 corpus guard is
 # satisfied and the run reaches the #3148 schemas guard.
 ds_corpus="$tmp/ds-corpus"

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -92,7 +92,15 @@ fi
 # (#3522) and its OA parity and write cases resolve those schemas; if they leave
 # CANONICAL_SCHEMA_FILES, the #3148 preflight stops guarding them and their absence surfaces
 # as a suite failure instead of a named preflight FAIL.
-for _req in basic-types.cql oa-test.cql write-test.cql; do
+# THE COMPLETE SET, not a sample (roborev, post-rebase round 3). Naming only three left the
+# other five derivable-away: removing `time-series.cql`, `wide-table-bti.cql` or
+# `collections.cql` from production would have deleted them from the expectation too and
+# this test would have stayed green — the same tautology, just smaller.
+#
+# Every entry here is a schema the corpus or the node suite resolves, so dropping ANY of them
+# stops the #3148 preflight guarding a file something reads.
+for _req in basic-types.cql da-test.cql oa-test.cql write-test.cql \
+            time-series.cql wide-table-bti.cql collections.cql wide-rows.cql; do
   case " ${CANONICAL[*]} " in
     *" $_req "*) : ;;
     *) echo "FAIL - $_req is no longer in the gate's CANONICAL_SCHEMA_FILES; the #3148 preflight" >&2
@@ -101,6 +109,14 @@ for _req in basic-types.cql oa-test.cql write-test.cql; do
        exit 1 ;;
   esac
 done
+
+# And the reverse direction: an ADDITION to production must be acknowledged here too, or this
+# list silently stops being the complete set it claims to be.
+if [ "${#CANONICAL[@]}" -ne 8 ]; then
+  echo "FAIL - the gate's CANONICAL_SCHEMA_FILES has ${#CANONICAL[@]} entries, this test expects 8." >&2
+  echo "       If a schema was added, add it to the required list above — deliberately." >&2
+  exit 1
+fi
 
 # A dataset root whose canonical corpus IS present, so the #2078 corpus guard is
 # satisfied and the run reaches the #3148 schemas guard.

--- a/scripts/tests/test_agent_gate_schemas_preflight.sh
+++ b/scripts/tests/test_agent_gate_schemas_preflight.sh
@@ -66,7 +66,22 @@ fi
 # The six canonical .cql the gate's dataset-backed components consume. Kept here as a
 # LITERAL list rather than read back from agent-gate.sh: if someone shrinks
 # CANONICAL_SCHEMA_FILES, this file must redden, not agree with the shrink.
-CANONICAL=(basic-types.cql da-test.cql time-series.cql wide-table-bti.cql collections.cql wide-rows.cql)
+# DERIVED from the gate, not restated here (#3493). This list was a hand-written copy of
+# `CANONICAL_SCHEMA_FILES`, so when that constant grew from 6 entries to 8 (the node suite
+# needs `oa-test.cql` and `write-test.cql`, and since #3522 the gate runs that whole suite)
+# THIS file silently began building synthetic roots that were missing two schemas — and two
+# cases failed for a reason that had nothing to do with what they test. Deriving it means
+# the next change to that constant cannot drift them apart.
+#
+# A failed derivation is a FAIL naming the derivation, never a fallback to a hard-coded
+# list: a fallback would restore exactly the copy this removes.
+CANONICAL=()
+while IFS= read -r _cf; do [ -n "$_cf" ] && CANONICAL+=("$_cf"); done < <(
+  sed -n 's/^CANONICAL_SCHEMA_FILES="\(.*\)"$/\1/p' "$GATE" | head -1 | tr ' ' '\n')
+if [ "${#CANONICAL[@]}" -eq 0 ]; then
+  echo "FAIL - could not derive CANONICAL_SCHEMA_FILES from $GATE; refusing to run against a guessed list" >&2
+  exit 1
+fi
 
 # A dataset root whose canonical corpus IS present, so the #2078 corpus guard is
 # satisfied and the run reaches the #3148 schemas guard.
@@ -398,7 +413,9 @@ fi
 # …and the POSITIVE line must still appear when the check DID run, otherwise the two
 # asserts above would be satisfied by simply never stamping anything.
 full_line=$(line_field "$(bash "$GATE" --preflight-schemas-line 2>/dev/null)")
-if grep -q "^schemas: 6/6 canonical .cql readable under $REPO/test-data/schemas" <<<"$full_line"; then
+# COUNT DERIVED TOO: a literal here is the same copy one level down.
+_n_canon=${#CANONICAL[@]}
+if grep -q "^schemas: $_n_canon/$_n_canon canonical .cql readable under $REPO/test-data/schemas" <<<"$full_line"; then
   ok "3148-full-positive-line: a FULL-mode check that ran stamps the positive N/N readable line"
 else
   bad "3148-full-positive-line: expected the positive line for a real check (got '$full_line')"

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -2123,6 +2123,52 @@ else
   echo "info - agent-gate.sh unreadable; skipping the control-char probe case"
 fi
 
+# ---------------------------------------------------------------------------
+# Case 91 (post-rebase round 13, Medium): a broken git is not "not a work tree".
+#
+# `rev-parse --is-inside-work-tree || fallback` collapsed "genuinely outside a work tree" with
+# "git is broken / the repo is corrupt / permission denied" — and the fallback disables BOTH
+# the committed-directory filter and the trusted HEAD comparison, so a coherently truncated
+# corpus would pass on the weaker derived checks alone.
+#
+# git cannot separate them by STATUS (128 both for a plain directory and for one holding a
+# broken `.git`), so the discriminator is STRUCTURAL: metadata present means this is MEANT to
+# be a checkout, and rev-parse failing there is a malfunction.
+#
+# BOTH directions are asserted. The fallback is a documented, supported mode — a vendored copy
+# of this script outside any repo — so a case that only checked the malfunction could be
+# satisfied by breaking the fallback entirely.
+# ---------------------------------------------------------------------------
+if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ] \
+   && [ -n "$MANIFEST_NOGIT" ]; then
+  rp_bin="$WORK/gitbroken-bin"; mkdir -p "$rp_bin"
+  printf '#!/bin/sh\nexit 128\n' > "$rp_bin/git"; chmod +x "$rp_bin/git"
+
+  # (a) IN a checkout, with git broken -> malfunction, named.
+  rp_rc=0
+  PATH="$rp_bin:$PATH" bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >"$WORK/rp-out" 2>&1 || rp_rc=$?
+  if [ "$rp_rc" = 2 ]; then
+    ok "a broken git inside a checkout is a malfunction (exit 2), not 'not a work tree'"
+  elif [ "$rp_rc" = 9 ]; then
+    bad "a broken git surfaced AS exit 9; the opt-out would suppress it as an incomplete corpus"
+  else
+    bad "a broken git gave exit $rp_rc; expected 2"
+  fi
+  grep -q 'git metadata' "$WORK/rp-out" 2>/dev/null \
+    && ok "the broken-git diagnostic says the metadata is present but git failed" \
+    || bad "the broken-git diagnostic does not explain itself: $(head -1 "$WORK/rp-out")"
+
+  # (b) OUTSIDE any repo -> the documented fallback, still working. MANIFEST_NOGIT is a copy
+  #     in $WORK, which is not a work tree.
+  rp_rc2=0
+  bash "$MANIFEST_NOGIT" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1 || rp_rc2=$?
+  [ "$rp_rc2" = 0 ] \
+    && ok "a vendored copy outside any repo still takes the documented no-git fallback" \
+    || bad "the vendored-copy fallback broke (exit $rp_rc2); the malfunction check is over-reaching"
+else
+  echo "info - no real corpus or no nogit copy; skipping the git-detection case"
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1664,45 +1664,88 @@ fi
 # the working tree.
 #
 # The first version compared the corpus TOC against the working-tree file at the mapped
-# path. Under the DEFAULT dataset root — the checkout's own `test-data/datasets`, which is
-# the documented fetch target — those are THE SAME FILE, so `cmp` compared a file to itself,
+# path. Under the DEFAULT dataset root -- the checkout's own `test-data/datasets`, which is
+# the documented fetch target -- those are THE SAME FILE, so `cmp` compared a file to itself,
 # always succeeded, and the whole trusted-inventory check was VACUOUS in exactly the
 # configuration most likely to be used.
 #
-# Asserted on the function directly, because that isolates the property: modify the WORKING
-# TREE copy of a tracked TOC and require a mismatch. A whole-corpus case cannot reach it
-# without populating the checkout with gitignored binaries.
-#
-# The working-tree file is restored, and the case FAILS LOUDLY rather than leaving the
-# checkout dirty if it cannot be.
+# RUN IN AN ISOLATED SCRATCH REPO (roborev, post-rebase round 4). The first version mutated a
+# TRACKED file in the real checkout and restored it. That is unsafe here for reasons this
+# repo already documents: gate components and sibling lanes run CONCURRENTLY on this box, so
+# another reader can observe the truncated file, and an interrupt between the edit and the
+# restore leaves the checkout dirty -- with the cleanup trap deleting the backup. A scratch
+# repo has the same shape (a tracked TOC whose working copy is then modified) and touches
+# nothing shared.
 # ---------------------------------------------------------------------------
-tw_repo=$(cd "$(dirname "$GATE")/.." && pwd)
-tw_toc=$(git -C "$tw_repo" ls-files test-data/datasets/sstables 2>/dev/null | grep 'TOC\.txt$' | head -1)
-if [ -n "$tw_toc" ] && [ -f "$tw_repo/$tw_toc" ] && git -C "$tw_repo" diff --quiet -- "$tw_toc" 2>/dev/null; then
+if command -v git >/dev/null 2>&1; then
+  tw_repo="$WORK/twin-repo"
+  tw_rel="test-data/datasets/sstables/test_basic/simple_table-$UUID/nb-1-big-TOC.txt"
+  mkdir -p "$tw_repo/$(dirname "$tw_rel")"
+  printf 'Data.db\nStatistics.db\nCompressionInfo.db\nFilter.db\nTOC.txt\n' > "$tw_repo/$tw_rel"
+  (
+    cd "$tw_repo" || exit 1
+    git init -q . && git config user.email t@t && git config user.name t \
+      && git add "$tw_rel" && git commit -qm "committed inventory"
+  ) >/dev/null 2>&1
+
   tw_probe() {   # -> "match" | "mismatch"
     _SCRIPT_REPO="$tw_repo" bash -c '
       _SCRIPT_REPO=$1
       eval "$(sed -n "/^_toc_matches_head() {/,/^}/p" "$2")"
       _toc_matches_head "$3" "$4" && printf match || printf mismatch' \
-      _ "$tw_repo" "$MANIFEST_SRC" "$tw_repo/$tw_toc" "$tw_toc"
+      _ "$tw_repo" "$MANIFEST_SRC" "$tw_repo/$tw_rel" "$tw_rel"
   }
-  tw_save="$WORK/tw-save"; cp "$tw_repo/$tw_toc" "$tw_save"
-  # Control first: unmodified, it must MATCH — otherwise the mismatch below proves nothing.
-  tw_before=$(tw_probe)
-  printf 'Data.db\nTOC.txt\n' > "$tw_repo/$tw_toc"
-  tw_after=$(tw_probe)
-  cp "$tw_save" "$tw_repo/$tw_toc"
-  if ! git -C "$tw_repo" diff --quiet -- "$tw_toc" 2>/dev/null; then
-    bad "case 81 could not restore $tw_toc; the checkout is DIRTY and must be fixed by hand"
-  elif [ "$tw_before" = match ] && [ "$tw_after" = mismatch ]; then
-    ok "the trusted inventory is read from HEAD, so a working-tree truncation is detected"
-  elif [ "$tw_before" != match ]; then
-    bad "case 81's control failed: an unmodified tracked TOC did not match HEAD ($tw_before)"
+
+  if [ -d "$tw_repo/.git" ]; then
+    # Control FIRST: unmodified, it must MATCH, or the mismatch below proves nothing.
+    tw_before=$(tw_probe)
+    printf 'Data.db\nTOC.txt\n' > "$tw_repo/$tw_rel"     # working tree only; HEAD unchanged
+    tw_after=$(tw_probe)
+    # CRLF must NOT read as a mismatch: the listed-component loop tolerates it and the reader
+    # trims it, so a byte-for-byte comparison here would contradict both.
+    printf 'Data.db\r\nStatistics.db\r\nCompressionInfo.db\r\nFilter.db\r\nTOC.txt\r\n' > "$tw_repo/$tw_rel"
+    tw_crlf=$(tw_probe)
+
+    [ "$tw_before" = match ] \
+      && ok "an unmodified tracked TOC matches HEAD (the control)" \
+      || bad "case 81's control failed: an unmodified tracked TOC did not match HEAD ($tw_before)"
+    [ "$tw_after" = mismatch ] \
+      && ok "the trusted inventory is read from HEAD, so a working-tree truncation is detected" \
+      || bad "a working-tree TOC truncation was NOT detected — the comparison is vacuous when the corpus root IS the checkout"
+    [ "$tw_crlf" = match ] \
+      && ok "a CRLF TOC still matches its committed twin (inventory compared, not bytes)" \
+      || bad "a CRLF TOC was reported as a mismatch; that contradicts the CRLF tolerance twenty lines up"
+
+    # A `git show` that fails on an object that EXISTS is a MALFUNCTION, not "no inventory".
+    # Collapsing the two would let git corruption or a permission error silently disable the
+    # trusted-inventory check — the same fail-open shape as the grep and cmp cases, and the
+    # THIRD time in this file that a status-discipline fix had no test until its RED control
+    # showed there was none. The shadow answers `cat-file -e` truthfully and fails only
+    # `show`, which is exactly the state being modelled.
+    tw_gbin="$WORK/gitfail-bin"; mkdir -p "$tw_gbin"
+    tw_greal=$(command -v git)
+    cat >"$tw_gbin/git" <<GITFAIL
+#!/bin/sh
+for a in "\$@"; do
+  if [ "\$a" = show ]; then exit 128; fi
+done
+exec "$tw_greal" "\$@"
+GITFAIL
+    chmod +x "$tw_gbin/git"
+    tw_grc=0
+    PATH="$tw_gbin:$PATH" bash -c '
+      _SCRIPT_REPO=$1
+      eval "$(sed -n "/^_toc_matches_head() {/,/^}/p" "$2")"
+      _toc_matches_head "$3" "$4"' _ "$tw_repo" "$MANIFEST_SRC" "$tw_repo/$tw_rel" "$tw_rel" \
+      >/dev/null 2>&1 || tw_grc=$?
+    [ "$tw_grc" = 2 ] \
+      && ok "a failing 'git show' on an EXISTING object is a malfunction (exit 2), not 'no inventory'" \
+      || bad "a failing 'git show' gave exit $tw_grc; collapsing it onto 'no twin' disables the trusted-inventory check"
   else
-    bad "a working-tree TOC truncation was NOT detected — the twin comparison is vacuous when the corpus root IS the checkout"
+    echo "info - could not create the scratch git repo; skipping the HEAD-inventory case"
   fi
 else
-  echo "info - no clean tracked TOC.txt available; skipping the HEAD-inventory case"
+  echo "info - git unavailable; skipping the HEAD-inventory case"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1572,6 +1572,93 @@ if [ -n "$MANIFEST_NOGIT" ]; then
   done
 fi
 
+# ---------------------------------------------------------------------------
+# Case 79 (post-rebase round 2, High): a COHERENTLY truncated TOC.
+#
+# Both derived directions — every listed component exists, every prefix-sharing file is
+# listed — are computed FROM THE CORPUS, so a TOC shortened IN STEP with the files it stopped
+# listing satisfies both and greens an incomplete generation.
+#
+# The trusted inventory is the GIT-TRACKED `*-TOC.txt` (164 committed). It is not subject to
+# the truncated fetch that damages the gitignored binaries, which is exactly what a
+# corpus-derived check cannot be. Measured: all 144 generations in the machine-local corpus
+# have a committed twin and all 144 match byte-for-byte.
+#
+# Driven against a COPY OF THE REAL CORPUS, because the property is about agreement with the
+# committed tree — a synthetic table has no committed twin and so cannot exercise it.
+# ---------------------------------------------------------------------------
+if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ] \
+   && bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1; then
+  ct_root="$WORK/coherent-toc"; rm -rf "$ct_root"; mkdir -p "$ct_root"
+  cp -r "$CQLITE_DATASETS_ROOT/sstables" "$ct_root/" 2>/dev/null
+  ct_dir=$(find "$ct_root/sstables/test_basic" -maxdepth 1 -type d -name 'simple_table-*' | head -1)
+  if [ -n "$ct_dir" ] && [ -f "$ct_dir/nb-1-big-TOC.txt" ]; then
+    # Control: the untouched copy still passes, so a reject below is caused by the edit.
+    if bash "$MANIFEST_SRC" "$ct_root" >/dev/null 2>&1; then
+      ok "the corpus copy is a valid control (passes before the TOC is truncated)"
+    else
+      bad "the corpus copy did not pass unmodified; the coherent-truncation case proves nothing"
+    fi
+    # Shorten the TOC *and* delete exactly the components it stopped listing.
+    printf 'Data.db\nStatistics.db\nDigest.crc32\nTOC.txt\n' > "$ct_dir/nb-1-big-TOC.txt"
+    rm -f "$ct_dir"/nb-1-big-CompressionInfo.db "$ct_dir"/nb-1-big-Filter.db \
+          "$ct_dir"/nb-1-big-Index.db "$ct_dir"/nb-1-big-Summary.db
+    ct_out=$(bash "$MANIFEST_SRC" "$ct_root" 2>&1 || true)
+    if printf '%s' "$ct_out" | grep -q 'test_basic/simple_table'; then
+      ok "a COHERENTLY truncated TOC disqualifies the generation"
+    else
+      bad "a coherently truncated TOC was ACCEPTED; both derived directions are satisfied by it"
+    fi
+    # And it must NAME the trusted-inventory mismatch, not the generic listed-component cause.
+    if printf '%s' "$ct_out" | grep -q 'does NOT match the git-tracked committed twin'; then
+      ok "the coherent-truncation diagnostic names the committed-twin mismatch"
+    else
+      bad "coherent truncation was reported as some other cause: $(printf '%s' "$ct_out" | grep 'test_basic/simple_table' | head -1 | cut -c1-90)"
+    fi
+  else
+    echo "info - no simple_table generation with a TOC in the corpus copy; skipping"
+  fi
+else
+  echo "info - no passing real corpus available; skipping the coherent-truncation case"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 80 (post-rebase round 2, Medium): a broken grep in the TOC reconciliation must be a
+# MALFUNCTION, not an incomplete corpus.
+#
+# `grep -qxF ... || return 1` collapsed an OPERATIONAL failure (>1) onto "not listed", and
+# because the function is called on the left of `||`, that walked out to the script's
+# RESERVED exit 9 — a judged corpus verdict the #2078 opt-out suppresses. A broken grep must
+# never be readable as a judged corpus.
+#
+# The shadow delegates every other grep to the real one and fails ONLY the `-qxF` form the
+# reconciliation uses: shadowing grep wholesale would break the script's own tool check and
+# prove nothing about this path.
+# ---------------------------------------------------------------------------
+if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ] \
+   && bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1; then
+  gb_bin="$WORK/grepfail-bin"; mkdir -p "$gb_bin"
+  gb_real=$(command -v grep)
+  cat >"$gb_bin/grep" <<GREPFAIL
+#!/bin/sh
+# Fail ONLY the reconciliation's exact invocation; delegate everything else.
+if [ "\$1" = "-qxF" ]; then exit 2; fi
+exec "$gb_real" "\$@"
+GREPFAIL
+  chmod +x "$gb_bin/grep"
+  gb_rc=0
+  PATH="$gb_bin:$PATH" bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1 || gb_rc=$?
+  if [ "$gb_rc" = 2 ]; then
+    ok "a grep malfunction in the TOC reconciliation exits 2, not the reserved corpus verdict"
+  elif [ "$gb_rc" = 9 ]; then
+    bad "a grep malfunction surfaced AS exit 9; the opt-out would suppress a broken checker"
+  else
+    bad "a grep malfunction gave exit $gb_rc; expected 2 (malfunction)"
+  fi
+else
+  echo "info - no passing real corpus available; skipping the grep-malfunction case"
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1943,6 +1943,42 @@ case "$sig_file" in
       || ok "the registered temp file is cleaned up before the signal is re-raised" ;;
 esac
 
+# ---------------------------------------------------------------------------
+# Case 87 (post-rebase round 9, Medium): the documented git-unavailable fallback must be
+# REACHABLE.
+#
+# This script documents a no-git path — no committed-table set, so every discovered directory
+# counts, mirroring the node helper's own behaviour — and I then added `git` to the
+# unconditional tool check, which made that path UNREACHABLE: the script exited 2 before it
+# could take the branch its own comment describes. `cmp` went the same way, being reached only
+# through the committed-twin comparison, which needs git.
+#
+# Driven with a PATH containing every tool the script needs EXCEPT git. `type -P` builds the
+# farm, not `command -v`: the latter returns a BARE NAME for some tools here, which produced a
+# self-referential symlink and a spurious "required tool 'find' not found" — a farm that tested
+# nothing.
+# ---------------------------------------------------------------------------
+gf_farm="$WORK/nogit-farm/bin"; mkdir -p "$gf_farm"
+gf_missing=""
+for gf_t in bash sh find grep sort awk sed basename tr iconv cmp mktemp rm cat ls printf head tail wc cut uniq comm dirname; do
+  gf_p=$(type -P "$gf_t" 2>/dev/null)
+  if [ -n "$gf_p" ]; then ln -sf "$gf_p" "$gf_farm/$gf_t"; else gf_missing="$gf_missing $gf_t"; fi
+done
+if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ] \
+   && [ -z "$gf_missing" ] && ! PATH="$gf_farm" type -P git >/dev/null 2>&1; then
+  gf_rc=0
+  PATH="$gf_farm" bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >"$WORK/nogit-out" 2>&1 || gf_rc=$?
+  if [ "$gf_rc" -eq 0 ]; then
+    ok "the documented git-unavailable fallback is reachable (manifest passes with git absent)"
+  elif grep -q "required tool 'git'" "$WORK/nogit-out" 2>/dev/null; then
+    bad "git is in the mandatory tool list, so the documented no-git fallback can never run"
+  else
+    bad "with git absent the manifest exited $gf_rc: $(head -1 "$WORK/nogit-out")"
+  fi
+else
+  echo "info - no real corpus, a tool is missing ($gf_missing), or git leaked into the farm; skipping the no-git case"
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1868,6 +1868,7 @@ fi
 # into a temp copy that both directions read.
 # ---------------------------------------------------------------------------
 if [ -n "$MANIFEST_NOGIT" ]; then
+  crlf_tmp="$WORK/crlf-tmp"; mkdir -p "$crlf_tmp"
   crlf_case() {   # <eol> -> accept | reject
     local eol=$1 root t
     root="$WORK/manifest-crlf-$eol"; rm -rf "$root"
@@ -1879,7 +1880,12 @@ if [ -n "$MANIFEST_NOGIT" ]; then
       lf)   printf 'Data.db\nFilter.db\nTOC.txt\n'       > "$t/nb-1-big-TOC.txt" ;;
       crlf) printf 'Data.db\r\nFilter.db\r\nTOC.txt\r\n' > "$t/nb-1-big-TOC.txt" ;;
     esac
-    local _o; _o=$(NO_AUTO_TOC=1 mrun "$root" 2>&1 || true)
+    # PRIVATE TMPDIR (roborev, post-rebase round 10). The leak assertion below must inspect
+    # only files THIS invocation created: `node-bindings` runs the same manifest in the
+    # parallel side lane, and gate components are expected to run concurrently, so scanning
+    # the shared /tmp for `cqlite-toc-norm.*` would fail `tooling-tests` whenever a peer had
+    # one in flight — a nondeterministic red caused by a healthy neighbour.
+    local _o; _o=$(NO_AUTO_TOC=1 TMPDIR="$crlf_tmp" mrun "$root" 2>&1 || true)
     if printf '%s' "$_o" | grep -q 'test_basic/counters'; then echo reject; else echo accept; fi
   }
   # LF is the control: if it were rejected too, the CRLF result would say nothing about CRLF.
@@ -1890,10 +1896,31 @@ if [ -n "$MANIFEST_NOGIT" ]; then
     && ok "a CRLF TOC with all components present is accepted, end to end" \
     || bad "a CRLF TOC was rejected as incomplete; a path is still comparing against the raw file"
 
-  # And no temp file is left behind by any of it.
-  [ "$(ls "${TMPDIR:-/tmp}"/cqlite-toc-norm.* 2>/dev/null | wc -l)" -eq 0 ] \
-    && ok "the normalised-TOC temp file is not leaked" \
-    || bad "normalised-TOC temp files were left in ${TMPDIR:-/tmp}"
+  # LEAK CHECK ON AN `exit 2` PATH, in a PRIVATE TMPDIR.
+  #
+  # Both halves are load-bearing and the first version had only one of them. Scanning the
+  # shared /tmp made this red whenever a concurrent peer had a temp file in flight —
+  # `node-bindings` runs the same manifest in the parallel side lane. But moving to a private
+  # dir while still exercising only the CRLF happy paths made it VACUOUS: those clean up via
+  # the in-line `rm -f`, so removing the EXIT trap entirely did not red it. Verified — that is
+  # how the hollowness showed.
+  #
+  # The leak only ever existed on paths that `exit 2` AFTER registering a temp file, because
+  # an exit skips the caller's in-line cleanup. So this drives one: `cmp` shadowed to fail,
+  # which reaches the trusted-inventory comparison and exits 2.
+  leak_tmp="$WORK/leak-tmp"; rm -rf "$leak_tmp"; mkdir -p "$leak_tmp"
+  leak_bin="$WORK/leak-bin"; mkdir -p "$leak_bin"
+  printf '#!/bin/sh\nexit 2\n' > "$leak_bin/cmp"; chmod +x "$leak_bin/cmp"
+  if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ]; then
+    TMPDIR="$leak_tmp" PATH="$leak_bin:$PATH" bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" \
+      >/dev/null 2>&1 || true
+    leak_left=$(find "$leak_tmp" -maxdepth 1 -name 'cqlite-toc-*' 2>/dev/null | wc -l)
+    [ "$leak_left" -eq 0 ] \
+      && ok "temp files are cleaned up even when the script exits on a tooling malfunction" \
+      || bad "$leak_left temp file(s) survived an exit-2 path; the EXIT trap is not covering them"
+  else
+    echo "info - no real corpus; skipping the exit-path leak check"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1851,6 +1851,51 @@ else
   echo "info - node unavailable, sources missing, or running as root; skipping the lstat-error case"
 fi
 
+# ---------------------------------------------------------------------------
+# Case 85 (post-rebase round 7, Medium): CRLF END TO END, through the whole manifest.
+#
+# CR was stripped in the forward component loop and again in the trusted-inventory
+# comparison — but the REVERSE reconciliation grepped the RAW TOC with `grep -qxF`, and `-x`
+# matches WHOLE LINES, so every line's trailing `\r` made every component read as "not
+# listed" and a perfectly valid CRLF TOC was rejected as incomplete.
+#
+# THE EXISTING CRLF CASE DID NOT CATCH IT: case 81 exercises `_toc_matches_head` in
+# isolation, which was one of the two places that DID strip CR. A unit case on the function
+# that was already correct cannot see a sibling path that is not — hence this one drives the
+# whole script, which is what the finding asked for.
+#
+# Three places stripping the same thing is what let one be missed; the fix normalises ONCE
+# into a temp copy that both directions read.
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  crlf_case() {   # <eol> -> accept | reject
+    local eol=$1 root t
+    root="$WORK/manifest-crlf-$eol"; rm -rf "$root"
+    t="$root/sstables/test_basic/counters-$UUID"; mkdir -p "$t"
+    printf 'x\n'   > "$t/nb-1-big-Data.db"
+    printf 'row\n' > "$t/nb-1-big-Data.db.jsonl"
+    printf 'x\n'   > "$t/nb-1-big-Filter.db"
+    case "$eol" in
+      lf)   printf 'Data.db\nFilter.db\nTOC.txt\n'       > "$t/nb-1-big-TOC.txt" ;;
+      crlf) printf 'Data.db\r\nFilter.db\r\nTOC.txt\r\n' > "$t/nb-1-big-TOC.txt" ;;
+    esac
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$root" 2>&1 || true)
+    if printf '%s' "$_o" | grep -q 'test_basic/counters'; then echo reject; else echo accept; fi
+  }
+  # LF is the control: if it were rejected too, the CRLF result would say nothing about CRLF.
+  [ "$(crlf_case lf)" = accept ] \
+    && ok "an LF TOC with all components present is accepted (the control)" \
+    || bad "the LF control was REJECTED; the CRLF case below proves nothing"
+  [ "$(crlf_case crlf)" = accept ] \
+    && ok "a CRLF TOC with all components present is accepted, end to end" \
+    || bad "a CRLF TOC was rejected as incomplete; a path is still comparing against the raw file"
+
+  # And no temp file is left behind by any of it.
+  [ "$(ls "${TMPDIR:-/tmp}"/cqlite-toc-norm.* 2>/dev/null | wc -l)" -eq 0 ] \
+    && ok "the normalised-TOC temp file is not leaked" \
+    || bad "normalised-TOC temp files were left in ${TMPDIR:-/tmp}"
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1793,6 +1793,10 @@ if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstable
   tr_repo=$(cd "$(dirname "$GATE")/.." && pwd)
   tr_counts=$(_SCRIPT_REPO="$tr_repo" bash -c '
     _SCRIPT_REPO=$1; _SCRIPT_REPO_IS_GIT=1
+    # SSTABLES is the root the function strips (it must remove the EXACT configured root,
+    # not the first "/sstables/"), so the probe has to establish it exactly as the script
+    # does. This assertion caught that coupling the moment it was introduced.
+    SSTABLES="$3/sstables"
     eval "$(sed -n "/^_committed_toc_relpath() {/,/^}/p" "$2")"
     have=0; none=0
     while IFS= read -r f; do
@@ -1811,6 +1815,40 @@ if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstable
   fi
 else
   echo "info - no real corpus or no git; skipping the twin-reachability census"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 84 (post-rebase round 5, Low): an lstat error is not an absence.
+#
+# `entryExists` caught every `lstatSync` error and returned false, so a permission or I/O
+# error classified a present-but-unusable fixture as `absent` — and a NON-STRICT
+# abort-safety run then SKIPS instead of hard-failing. That is #1437 inverted, the same
+# defect round 52 fixed one layer up, arriving again through the ERROR HANDLER rather than
+# the predicate.
+#
+# Only ENOENT/ENOTDIR mean absent; anything else means something IS there and cannot be
+# used, which is `broken`.
+# ---------------------------------------------------------------------------
+CF_SRC2=$(cd "$(dirname "$GATE")/.." && pwd)/bindings/node/__test__/corrupt-fixture.js
+PU_SRC2=$(cd "$(dirname "$GATE")/.." && pwd)/bindings/node/__test__/parity-utils.js
+if command -v node >/dev/null 2>&1 && [ -f "$CF_SRC2" ] && [ -f "$PU_SRC2" ] && [ "$(id -u)" != 0 ]; then
+  ee_tree="$WORK/ee-tree"; mkdir -p "$ee_tree/bindings/node/__test__"
+  cp "$CF_SRC2" "$PU_SRC2" "$ee_tree/bindings/node/__test__/"
+  ee_d="$ee_tree/corpus/test_basic/simple_table-$UUID"; mkdir -p "$ee_d"
+  printf 'x\n' > "$ee_d/nb-1-big-Data.db"
+  chmod 000 "$ee_d"                       # lstat of the CHILD now fails with EACCES
+  ee_got=$(node -e "
+    global.testPaths = { SSTABLES_DIR: '$ee_tree/corpus' };
+    const cf = require('$ee_tree/bindings/node/__test__/corrupt-fixture.js');
+    console.log(cf.classifyTableDir('$ee_tree/corpus').status);" 2>/dev/null)
+  chmod 755 "$ee_d"                       # restore so the suite cleanup can remove it
+  case "$ee_got" in
+    broken) ok "an unreadable fixture directory classifies as 'broken' (hard-fail), not 'absent'" ;;
+    absent) bad "an unreadable fixture classified as 'absent'; a non-strict run would SKIP instead of hard-failing (#1437 inverted)" ;;
+    *)      bad "unreadable fixture classified as '${ee_got:-<nothing>}'; expected 'broken'" ;;
+  esac
+else
+  echo "info - node unavailable, sources missing, or running as root; skipping the lstat-error case"
 fi
 
 echo "----"

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -2169,6 +2169,51 @@ else
   echo "info - no real corpus or no nogit copy; skipping the git-detection case"
 fi
 
+# ---------------------------------------------------------------------------
+# Case 92 (post-rebase round 15, Low): EVERY SKIP branch of run_node_bindings must declare
+# the leak-lane state.
+#
+# `NOT-REACHED` is the PESSIMISTIC default written before anything runs, so every early
+# return inherits it unless it says otherwise. The incomplete-corpus SKIP branch was added
+# without the declaration, so a run that skipped on the corpus opt-out reported
+# "node-bindings failed before the affirmation could read a jest report (npm ci / npm run
+# build / jest --listTests / the suite reconciliation)" — a false statement about WHY the
+# budgets did not run, pointing the reader at a build failure that never happened.
+#
+# STRUCTURAL, deliberately. The defect class is "a SKIP branch arrives without the
+# declaration", which is a property of the SOURCE; catching it behaviourally would need a
+# full component run (~224s measured) inside a `tooling-tests` component already at ~948s,
+# to prove one summary line. The behavioural fact was verified once by hand at the time of
+# the fix: partial corpus + opt-out yields `node-bindings-leak-lane: SKIPPED (...)`.
+#
+# Scans each `status=SKIP` in run_node_bindings and requires a `_node_leak_lane_note` write
+# between it and its `return`.
+# ---------------------------------------------------------------------------
+GATE_SRC3=$(cd "$(dirname "$GATE")" && pwd)/agent-gate.sh
+if [ -f "$GATE_SRC3" ]; then
+  ll_out=$(awk '
+    /^run_node_bindings\(\) \{/ { inf = 1 }
+    inf && /^\}/            { inf = 0 }
+    inf && /status=SKIP/    { skip = 1; noted = 0; line = NR }
+    inf && skip && /_node_leak_lane_note/ { noted = 1 }
+    inf && skip && /return 0/ {
+      if (!noted) printf "undeclared-skip-at-line-%d ", line
+      skip = 0
+    }
+    END { }
+  ' "$GATE_SRC3")
+  ll_n=$(awk '/^run_node_bindings\(\) \{/{i=1} i&&/^\}/{i=0} i&&/status=SKIP/{n++} END{print n+0}' "$GATE_SRC3")
+  if [ "$ll_n" -lt 2 ]; then
+    bad "case 92 found only $ll_n SKIP branch(es) in run_node_bindings; the scan is not seeing the function"
+  elif [ -z "$ll_out" ]; then
+    ok "all $ll_n SKIP branches of run_node_bindings declare the leak-lane state"
+  else
+    bad "a SKIP branch of run_node_bindings does not declare the leak-lane state ($ll_out) — its summary would falsely report an earlier build/listing failure"
+  fi
+else
+  echo "info - agent-gate.sh unreadable; skipping the leak-lane declaration case"
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1659,6 +1659,79 @@ else
   echo "info - no passing real corpus available; skipping the grep-malfunction case"
 fi
 
+# ---------------------------------------------------------------------------
+# Case 81 (post-rebase round 3, High): the trusted inventory must come from HEAD, not from
+# the working tree.
+#
+# The first version compared the corpus TOC against the working-tree file at the mapped
+# path. Under the DEFAULT dataset root — the checkout's own `test-data/datasets`, which is
+# the documented fetch target — those are THE SAME FILE, so `cmp` compared a file to itself,
+# always succeeded, and the whole trusted-inventory check was VACUOUS in exactly the
+# configuration most likely to be used.
+#
+# Asserted on the function directly, because that isolates the property: modify the WORKING
+# TREE copy of a tracked TOC and require a mismatch. A whole-corpus case cannot reach it
+# without populating the checkout with gitignored binaries.
+#
+# The working-tree file is restored, and the case FAILS LOUDLY rather than leaving the
+# checkout dirty if it cannot be.
+# ---------------------------------------------------------------------------
+tw_repo=$(cd "$(dirname "$GATE")/.." && pwd)
+tw_toc=$(git -C "$tw_repo" ls-files test-data/datasets/sstables 2>/dev/null | grep 'TOC\.txt$' | head -1)
+if [ -n "$tw_toc" ] && [ -f "$tw_repo/$tw_toc" ] && git -C "$tw_repo" diff --quiet -- "$tw_toc" 2>/dev/null; then
+  tw_probe() {   # -> "match" | "mismatch"
+    _SCRIPT_REPO="$tw_repo" bash -c '
+      _SCRIPT_REPO=$1
+      eval "$(sed -n "/^_toc_matches_head() {/,/^}/p" "$2")"
+      _toc_matches_head "$3" "$4" && printf match || printf mismatch' \
+      _ "$tw_repo" "$MANIFEST_SRC" "$tw_repo/$tw_toc" "$tw_toc"
+  }
+  tw_save="$WORK/tw-save"; cp "$tw_repo/$tw_toc" "$tw_save"
+  # Control first: unmodified, it must MATCH — otherwise the mismatch below proves nothing.
+  tw_before=$(tw_probe)
+  printf 'Data.db\nTOC.txt\n' > "$tw_repo/$tw_toc"
+  tw_after=$(tw_probe)
+  cp "$tw_save" "$tw_repo/$tw_toc"
+  if ! git -C "$tw_repo" diff --quiet -- "$tw_toc" 2>/dev/null; then
+    bad "case 81 could not restore $tw_toc; the checkout is DIRTY and must be fixed by hand"
+  elif [ "$tw_before" = match ] && [ "$tw_after" = mismatch ]; then
+    ok "the trusted inventory is read from HEAD, so a working-tree truncation is detected"
+  elif [ "$tw_before" != match ]; then
+    bad "case 81's control failed: an unmodified tracked TOC did not match HEAD ($tw_before)"
+  else
+    bad "a working-tree TOC truncation was NOT detected — the twin comparison is vacuous when the corpus root IS the checkout"
+  fi
+else
+  echo "info - no clean tracked TOC.txt available; skipping the HEAD-inventory case"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 82 (post-rebase round 3, Medium): a broken `cmp` is a MALFUNCTION, not a TOC mismatch.
+#
+# `cmp -s ... || return 1` collapsed status >1 (unreadable file, cmp absent) onto "the TOCs
+# differ", which walks out to the reserved exit 9 — a judged corpus verdict the #2078 opt-out
+# suppresses. Exactly the class case 80 covers for `grep`; this one was added because the
+# first RED for it did not fire, which is how the gap showed.
+# ---------------------------------------------------------------------------
+if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ] \
+   && bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1; then
+  cb_bin="$WORK/cmpfail-bin"; mkdir -p "$cb_bin"
+  # `cmp` is used ONLY by the twin comparison here, so a blanket shadow is precise enough --
+  # unlike grep, which the script's own tool check also calls.
+  printf '#!/bin/sh\nexit 2\n' > "$cb_bin/cmp"; chmod +x "$cb_bin/cmp"
+  cb_rc=0
+  PATH="$cb_bin:$PATH" bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1 || cb_rc=$?
+  if [ "$cb_rc" = 2 ]; then
+    ok "a cmp malfunction exits 2, not the reserved corpus verdict"
+  elif [ "$cb_rc" = 9 ]; then
+    bad "a cmp malfunction surfaced AS exit 9; the opt-out would suppress a broken checker"
+  else
+    bad "a cmp malfunction gave exit $cb_rc; expected 2 (malfunction)"
+  fi
+else
+  echo "info - no passing real corpus available; skipping the cmp-malfunction case"
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1,0 +1,1506 @@
+#!/usr/bin/env bash
+# Self-test for test-data/scripts/check-dataset-manifest.sh (issue #3493).
+#
+# THE QUESTION THIS CHECKER ANSWERS, and why #3522's census does not answer it:
+# that census asks "does every test FILE run"; this asks "is the CORPUS those files read
+# actually complete". The Node parity cases DERIVE their table set FROM DISK, so a partial
+# extraction is green BY OMISSION — every suite runs, every suite does real work, and the
+# missing tables are simply never enumerated. #3522's per-suite guard cannot see it.
+#
+# Measured against the real node binding, on an otherwise intact generation:
+#   * a zero-length CompressionInfo.db or Statistics.db -> SELECT returns 0 ROWS, silently;
+#   * a second generation whose Data.db is well-formed garbage -> the reader THROWS.
+#
+# Dataset-free and network-free: every case builds its own synthetic corpus. The few that
+# need a real one guard on CQLITE_DATASETS_ROOT and report INFO when it is absent.
+#
+# Run standalone:   bash scripts/tests/test_check_dataset_manifest.sh
+# Or via the gate:  scripts/agent-gate.sh runs it inside the `tooling-tests` component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+
+# #2751 defense-in-depth: this self-test drives nested `agent-gate.sh --only
+# node-bindings` runs. Each case pins its own AGENT_GATE_SUMMARY_FILE, but scrub
+# any inherited value up front so a standalone run can never clobber the caller's.
+unset AGENT_GATE_SUMMARY_FILE
+# The component's strictness is decided from these, so a value inherited from the
+# invoking shell must not steer the case.
+unset CQLITE_REQUIRE_FIXTURES CQLITE_PARITY_REQUIRE_DATASETS
+
+# NEVER pipe a gate invocation straight into `grep -q` under `set -o pipefail`.
+# `grep -q` exits on its FIRST match, the gate then dies of SIGPIPE, and pipefail
+# propagates that -- so a MATCHING pattern yields a FAILING `if`. It is timing
+# dependent (small outputs flush before grep exits, so it passes standalone and fails
+# under load), which is exactly the kind of false verdict this suite exists to catch.
+# Capture into a variable first, then match.
+# EVERY synthetic Data.db below is created with its `.jsonl` golden sibling. Since round
+# 21 a Data.db without a golden does not satisfy a table, so a fixture missing one would
+# be rejected for THAT reason -- silently turning cases about globs, UUIDs, OA format,
+# symlinks or tracking into cases about goldens, several of which would still have
+# "passed". Case 32 is the exception and manages its golden explicitly, because the
+# golden IS its subject.
+PASS=0; FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS+1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# This script deliberately runs WITHOUT `set -e` (every case must report its own verdict
+# rather than abort the suite), so a failed `mktemp -d` would leave WORK empty and every
+# `mkdir -p "$WORK/..."` below would write to ABSOLUTE paths at the filesystem root --
+# `/datasets`, `/stub-bin` -- and the EXIT trap would then `rm -rf ""`. Checked
+# explicitly, before the trap is installed (roborev #3493 round 14, Medium).
+WORK=$(mktemp -d) || { echo "FAIL: mktemp -d failed; refusing to run with an unset work dir" >&2; exit 1; }
+[ -n "$WORK" ] && [ -d "$WORK" ] || {
+  echo "FAIL: mktemp -d produced no usable directory (got '${WORK:-<empty>}')" >&2; exit 1; }
+# A scratch git worktree is REGISTERED IN REPOSITORY METADATA, so deleting its directory
+# is not cleanup -- an interrupt between `worktree add` and `worktree remove` leaves a
+# registered-but-missing worktree behind in the real repo (roborev #3493 round 25).
+# Tracked here and unregistered from the trap, which also covers INT/TERM.
+SCRATCH_WORKTREE=""
+SCRATCH_WORKTREE_REPO=""
+_cleanup() {
+  # NO repository-wide `worktree prune` (roborev #3493 round 27). Pruning unregisters
+  # every worktree git currently considers stale -- including a PEER LANE's whose
+  # directory is temporarily unavailable -- so a cleanup for one scratch tree could
+  # deregister someone else's work. This machine runs several lanes concurrently, so that
+  # is a live hazard, not a theoretical one. Remove only what this script registered, and
+  # SAY SO if that fails rather than reaching for a broader hammer.
+  # IDEMPOTENT (roborev #3493 round 29): the INT/TERM handlers call _cleanup and then
+  # re-raise, which runs the EXIT trap and calls _cleanup a SECOND time. Without clearing
+  # the tracking on success, that second pass tried to remove an already-removed worktree
+  # and printed a false "could not remove" warning -- a cleanup path inventing a problem
+  # it had just fixed.
+  if [ -n "$SCRATCH_WORKTREE" ] && [ -n "$SCRATCH_WORKTREE_REPO" ]; then
+    if git -C "$SCRATCH_WORKTREE_REPO" worktree remove --force "$SCRATCH_WORKTREE" >/dev/null 2>&1; then
+      SCRATCH_WORKTREE=""; SCRATCH_WORKTREE_REPO=""
+    else
+      echo "WARN: could not remove scratch worktree $SCRATCH_WORKTREE (left registered; run 'git worktree prune' by hand if it is stale)" >&2
+    fi
+  fi
+  rm -rf "$WORK"
+}
+# INT/TERM get their OWN traps that clean up and then EXIT with the conventional
+# 128+signal status. Sharing the EXIT handler was wrong: a trap handler RETURNS, so on
+# Ctrl-C the script deleted $WORK and then carried on running cases against a directory
+# that no longer existed -- cascading failures, and expensive nested gate invocations
+# continuing after the operator cancelled (roborev #3493 round 26).
+trap _cleanup EXIT
+trap '_cleanup; trap - INT;  kill -INT  $$' INT
+trap '_cleanup; trap - TERM; kill -TERM $$' TERM
+
+# A corpus root that is NON-EMPTY but lacks the canonical `test_basic` keyspace.
+ROOT="$WORK/datasets"
+mkdir -p "$ROOT/sstables/test_other"
+printf 'x\n' > "$ROOT/sstables/test_other/aa-1-big-Data.db"
+printf 'row\n' > "$ROOT/sstables/test_other/aa-1-big-Data.db.jsonl"
+
+# Fast stubs so the negative case does not build the napi module. Only reached
+# when the component does NOT take the opt-out branch -- which is the assertion.
+STUB="$WORK/stub-bin"
+mkdir -p "$STUB"
+for tool in node npx; do
+  printf '#!/bin/sh\nexit 0\n' > "$STUB/$tool"
+  chmod +x "$STUB/$tool"
+done
+# The npm stub fails `npm run build` iff STUB_FAIL_BUILD=1, so case 3 can prove the
+# corpus-free half is genuinely ENFORCED under the opt-out rather than merely run.
+cat > "$STUB/npm" <<'STUBEOF'
+#!/bin/sh
+# Record the environment the component actually handed us, so the schemas-root
+# plumbing (#3493) is asserted from what was PASSED, not from reading the source.
+[ -n "${STUB_ENV_DUMP:-}" ] && env > "$STUB_ENV_DUMP"
+if [ "${STUB_FAIL_BUILD:-0}" = 1 ] && [ "$1" = "run" ] && [ "$2" = "build" ]; then
+  echo "stub npm: simulated build failure" >&2
+  exit 1
+fi
+exit 0
+STUBEOF
+chmod +x "$STUB/npm"
+
+# A copy of the manifest OUTSIDE any git work tree. The committed-table-dir rule
+# (round 18) correctly rejects synthetic UUIDs, which would make every OTHER manifest
+# case below fail for the WRONG reason -- passing or failing on a property it is not
+# testing. Running those through the git-less copy triggers the documented fallback
+# ("nothing tracked -> everything counts"), isolating each case to its own property.
+# Case 28 uses the REAL script, because the committed rule IS its subject.
+node_pkg="$(cd "$(dirname "$GATE")/.." && pwd)/bindings/node"
+
+# _autotoc <corpus-root> -- give every REGULAR-FILE `*-Data.db` under <corpus-root> a
+# minimal self-consistent sibling `TOC.txt`, unless one already exists.
+#
+# Round 47 made the manifest validate the accepted generation's TOC-listed components,
+# because a partial extraction that drops a `CompressionInfo.db` otherwise reports the
+# corpus complete. Real Cassandra output always carries a TOC (measured: 144/144
+# generations across both corpus roots), but this suite's SYNTHETIC fixtures were written
+# before the rule existed and 26 accept-cases had none -- they would now fail for a reason
+# the case is not about.
+#
+# So the ACCEPT-path fixtures get a TOC generated here rather than 26 hand-edits, keeping
+# each case's assertion about the property it was written for. Cases that are ABOUT the
+# TOC opt out with `NO_AUTO_TOC=1` and build their own.
+#
+# Deliberately minimal (`Data.db` + `TOC.txt`): a TOC lists only what the generation has,
+# so a fixture with no companions has a two-line one. Never overwrites an existing TOC.
+_autotoc() {
+  [ "${NO_AUTO_TOC:-0}" = 1 ] && return 0
+  [ -d "$1" ] || return 0
+  # NEVER mutate a root outside this suite's scratch dir. Several cases pass the REAL
+  # shared corpus root ($CQLITE_DATASETS_ROOT, often a machine-local /data/datasets used
+  # concurrently by other lanes); generating files there would be a cross-lane side
+  # effect. Real Cassandra output already has a TOC, so those roots need nothing.
+  case "$1" in "$WORK"/*|"$WORK") : ;; *) return 0 ;; esac
+  local _d
+  while IFS= read -r _d; do
+    [ -f "$_d" ] || continue                     # a dir/dangling-symlink fixture gets none
+    [ -e "${_d%Data.db}TOC.txt" ] && continue
+    printf 'Data.db\nTOC.txt\n' > "${_d%Data.db}TOC.txt"
+  done < <(find "$1" -name '*-Data.db' 2>/dev/null)
+  return 0    # the loop's rc is the last `[ -e ]` test; never leak it as failure
+}
+
+# mrun <corpus-root> [manifest-args...] -- _autotoc the root, then run the manifest on it.
+# Every call site goes through this so the TOC rule cannot silently invalidate a case.
+mrun() { local _r=$1; shift; _autotoc "$_r"; bash "$MANIFEST_NOGIT" "$_r" "$@"; }
+
+UUID=4b892c6064e711f1bd3ac7dbf655c673
+MANIFEST_SRC="$(cd "$(dirname "$GATE")/.." && pwd)/test-data/scripts/check-dataset-manifest.sh"
+MANIFEST_NOGIT=""
+if [ -f "$MANIFEST_SRC" ]; then
+  mkdir -p "$WORK/nogit-manifest"
+  cp "$MANIFEST_SRC" "$WORK/nogit-manifest/check-dataset-manifest.sh"
+  MANIFEST_NOGIT="$WORK/nogit-manifest/check-dataset-manifest.sh"
+fi
+
+
+# Hidden-hook helpers, defined HERE rather than beside their first use: bash resolves
+# functions at CALL time, so a definition inside a later case is simply not available to
+# an earlier one -- which is how three retargeted cases came to invoke an undefined `pf`
+# and report the opposite verdict.
+
+# ---------------------------------------------------------------------------
+manifest="$(cd "$(dirname "$GATE")/.." && pwd)/test-data/scripts/check-dataset-manifest.sh"
+if [ -f "$manifest" ]; then
+  # A DIRECTORY named *-Data.db must NOT satisfy the completeness check.
+  #
+  # Asserted on the PER-TABLE message, not the exit code: the script fails on ANY
+  # incomplete corpus, so a synthetic root's non-zero exit proves nothing about the
+  # predicate -- a bare red is not evidence. Under the old name-only match the
+  # directory COUNTED, so `counters` was NOT reported missing; under the shared
+  # predicate it does not count, so it IS.
+  fake="$WORK/manifest-fake"
+  mkdir -p "$fake/sstables/test_basic/counters-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db"
+  fake_out=$(mrun "$fake" 2>&1 || true)
+  if printf '%s' "$fake_out" | grep -q 'missing Data.db for expected table: test_basic/counters'; then
+    ok "manifest check rejects a DIRECTORY named *-Data.db (matches the shared predicate)"
+  else
+    bad "manifest check accepted a DIRECTORY named *-Data.db as a fixture for test_basic/counters"
+  fi
+  # Control: the SAME shape as a regular file must be accepted, so the assertion above
+  # is about the file TYPE and not about the path pattern.
+  real_fake="$WORK/manifest-real"
+  mkdir -p "$real_fake/sstables/test_basic/counters-4b892c6064e711f1bd3ac7dbf655c673"
+  printf 'x\n' > "$real_fake/sstables/test_basic/counters-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db"
+  printf 'row\n' > "$real_fake/sstables/test_basic/counters-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db.jsonl"
+  real_out=$(mrun "$real_fake" 2>&1 || true)
+  if printf '%s' "$real_out" | grep -q 'missing Data.db for expected table: test_basic/counters'; then
+    bad "manifest check rejected a REGULAR FILE fixture for test_basic/counters"
+  else
+    ok "manifest check accepts the same path as a REGULAR FILE (type, not pattern)"
+  fi
+  # Positive control on the REAL corpus, so the check above is not rejecting everything.
+  if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ]; then
+    if bash "$manifest" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1; then
+      ok "manifest check still passes on the real corpus (predicate not over-tightened)"
+    else
+      bad "manifest check now fails on the real corpus"
+    fi
+  else
+    echo "INFO: no CQLITE_DATASETS_ROOT corpus; skipping the manifest positive control"
+  fi
+else
+  echo "INFO: $manifest absent; skipping the manifest predicate cases"
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$manifest" ]; then
+  # The colliding sibling must be in the SAME KEYSPACE as the expected table, because
+  # the search is rooted at the keyspace directory. My first cut of this case used
+  # `counters` (test_basic) against `time_bucketed_counters` (test_timeseries) -- which
+  # is where the finding's example pointed -- and it passed against the UNANCHORED glob,
+  # proving nothing: different roots can never collide. `collection_table` is expected in
+  # test_collections, so a `frozen_collection_table-*` sibling THERE is the real shape.
+  overlap="$WORK/manifest-overlap"
+  mkdir -p "$overlap/sstables/test_collections/frozen_collection_table-4b892c6064e711f1bd3ac7dbf655c673"
+  printf 'x\n' > "$overlap/sstables/test_collections/frozen_collection_table-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db"
+  printf 'row\n' > "$overlap/sstables/test_collections/frozen_collection_table-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db.jsonl"
+  ov_out=$(mrun "$overlap" 2>&1 || true)
+  if printf '%s' "$ov_out" | grep -q 'missing Data.db for expected table: test_collections/collection_table'; then
+    ok "a same-keyspace sibling whose name CONTAINS the table does not satisfy it (glob anchored)"
+  else
+    bad "frozen_collection_table satisfied the expectation for the distinct table collection_table"
+  fi
+  # Control: the correctly-named directory DOES satisfy it, so the anchoring is not
+  # simply rejecting everything.
+  mkdir -p "$overlap/sstables/test_collections/collection_table-4b892c6064e711f1bd3ac7dbf655c673"
+  printf 'x\n' > "$overlap/sstables/test_collections/collection_table-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db"
+  printf 'row\n' > "$overlap/sstables/test_collections/collection_table-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db.jsonl"
+  ov_out2=$(mrun "$overlap" 2>&1 || true)
+  if printf '%s' "$ov_out2" | grep -q 'missing Data.db for expected table: test_collections/collection_table'; then
+    bad "the correctly-named collection_table- directory did not satisfy its expectation"
+  else
+    ok "the correctly-named table directory still satisfies its expectation"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$manifest" ]; then
+  nested="$WORK/manifest-nested"
+  mkdir -p "$nested/sstables/test_basic/other/counters-4b892c6064e711f1bd3ac7dbf655c673"
+  printf 'x\n' > "$nested/sstables/test_basic/other/counters-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db"
+  printf 'row\n' > "$nested/sstables/test_basic/other/counters-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db.jsonl"
+  ns_out=$(mrun "$nested" 2>&1 || true)
+  if printf '%s' "$ns_out" | grep -q 'missing Data.db for expected table: test_basic/counters'; then
+    ok "a table directory nested below the keyspace does not satisfy it (depth anchored)"
+  else
+    bad "a nested other/counters-* directory satisfied the expectation for test_basic/counters"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$manifest" ]; then
+  oafake="$WORK/manifest-oa"
+  mkdir -p "$oafake/sstables/test_oa/simple_table-4b892c6064e711f1bd3ac7dbf655c673"
+  printf 'x\n' > "$oafake/sstables/test_oa/simple_table-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db"   # generic, NOT oa-
+  printf 'row\n' > "$oafake/sstables/test_oa/simple_table-4b892c6064e711f1bd3ac7dbf655c673/nb-1-big-Data.db.jsonl"
+  oa_out=$(mrun "$oafake" 2>&1 || true)
+  if printf '%s' "$oa_out" | grep -q 'no OA-format Data.db.*test_oa/simple_table'; then
+    ok "a generic *-Data.db does not satisfy a test_oa table (OA format required)"
+  else
+    bad "a generic *-Data.db satisfied test_oa/simple_table"
+  fi
+  # Control: the OA-named file DOES satisfy it.
+  printf 'x\n' > "$oafake/sstables/test_oa/simple_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Data.db"
+  printf 'row\n' > "$oafake/sstables/test_oa/simple_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Data.db.jsonl"
+  oa_out2=$(mrun "$oafake" 2>&1 || true)
+  if printf '%s' "$oa_out2" | grep -q 'test_oa/simple_table'; then
+    bad "an oa-<n>-big-Data.db did not satisfy test_oa/simple_table"
+  else
+    ok "an oa-<n>-big-Data.db satisfies the same table (check is format, not blanket)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+UUID=4b892c6064e711f1bd3ac7dbf655c673
+if [ -f "$manifest" ]; then
+  badu="$WORK/manifest-baduuid"
+  mkdir -p "$badu/sstables/test_collections/collection_table-abc"
+  printf 'x\n' > "$badu/sstables/test_collections/collection_table-abc/nb-1-big-Data.db"
+  printf 'row\n' > "$badu/sstables/test_collections/collection_table-abc/nb-1-big-Data.db.jsonl"
+  bu_out=$(mrun "$badu" 2>&1 || true)
+  if printf '%s' "$bu_out" | grep -q 'missing Data.db for expected table: test_collections/collection_table'; then
+    ok "a non-UUID table-directory suffix does not satisfy the table (matches TABLE_DIR_RE)"
+  else
+    bad "collection_table-abc satisfied the expectation Jest would never discover"
+  fi
+  mkdir -p "$badu/sstables/test_collections/collection_table-$UUID"
+  printf 'x\n' > "$badu/sstables/test_collections/collection_table-$UUID/nb-1-big-Data.db"
+  printf 'row\n' > "$badu/sstables/test_collections/collection_table-$UUID/nb-1-big-Data.db.jsonl"
+  bu_out2=$(mrun "$badu" 2>&1 || true)
+  if printf '%s' "$bu_out2" | grep -q 'missing Data.db for expected table: test_collections/collection_table'; then
+    bad "a valid 32-hex UUID suffix did not satisfy the table"
+  else
+    ok "a valid 32-hex UUID suffix does satisfy it (check is the shape, not a blanket reject)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$manifest" ]; then
+  oagen="$WORK/manifest-oagen"
+  mkdir -p "$oagen/sstables/test_oa/simple_table-$UUID"
+  printf 'x\n' > "$oagen/sstables/test_oa/simple_table-$UUID/oa-invalid-big-Data.db"
+  printf 'row\n' > "$oagen/sstables/test_oa/simple_table-$UUID/oa-invalid-big-Data.db.jsonl"
+  og_out=$(mrun "$oagen" 2>&1 || true)
+  if printf '%s' "$og_out" | grep -q 'no OA-format Data.db.*test_oa/simple_table'; then
+    ok "a non-numeric OA generation is rejected (matches oaBinariesPresent's regex)"
+  else
+    bad "oa-invalid-big-Data.db satisfied test_oa/simple_table"
+  fi
+  printf 'x\n' > "$oagen/sstables/test_oa/simple_table-$UUID/oa-2-big-Data.db"
+  printf 'row\n' > "$oagen/sstables/test_oa/simple_table-$UUID/oa-2-big-Data.db.jsonl"
+  og_out2=$(mrun "$oagen" 2>&1 || true)
+  if printf '%s' "$og_out2" | grep -q 'test_oa/simple_table'; then
+    bad "a numeric OA generation did not satisfy test_oa/simple_table"
+  else
+    ok "a numeric OA generation does satisfy it (check is the shape, not a blanket reject)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$manifest" ]; then
+  UNTRACKED_UUID=ffffffffffffffffffffffffffffffff
+  untr="$WORK/manifest-untracked"
+  mkdir -p "$untr/sstables/test_collections/collection_table-$UNTRACKED_UUID"
+  printf 'x\n' > "$untr/sstables/test_collections/collection_table-$UNTRACKED_UUID/nb-1-big-Data.db"
+  printf 'row\n' > "$untr/sstables/test_collections/collection_table-$UNTRACKED_UUID/nb-1-big-Data.db.jsonl"
+  ut_out=$(bash "$manifest" "$untr" 2>&1 || true)
+  if printf '%s' "$ut_out" | grep -q 'missing Data.db for expected table: test_collections/collection_table'; then
+    ok "a valid-UUID but UNTRACKED table dir does not satisfy the table (matches isCommittedTableDir)"
+  else
+    bad "an untracked table dir satisfied a table Jest would never enforce"
+  fi
+  # Fallback: the same corpus, with the script copied OUTSIDE any work tree, must ACCEPT
+  # -- git reports nothing tracked, so every discovered dir counts (Jest's rule).
+  ng_out=$(mrun "$untr" 2>&1 || true)
+  if printf '%s' "$ng_out" | grep -q 'missing Data.db for expected table: test_collections/collection_table'; then
+    bad "the git-less fallback rejected an untracked dir; it must treat all as committed"
+  else
+    ok "outside a work tree, every discovered dir counts (Jest's graceful fallback)"
+  fi
+
+  # ---------------------------------------------------------------------------
+  symd="$WORK/manifest-symlink"
+  mkdir -p "$symd/sstables/test_collections/real-$UUID"
+  printf 'x\n' > "$symd/sstables/test_collections/real-$UUID/nb-1-big-Data.db"
+  printf 'row\n' > "$symd/sstables/test_collections/real-$UUID/nb-1-big-Data.db.jsonl"
+  ln -s "$symd/sstables/test_collections/real-$UUID" \
+        "$symd/sstables/test_collections/collection_table-$UUID"
+  sy_out=$(mrun "$symd" 2>&1 || true)
+  if printf '%s' "$sy_out" | grep -q 'missing Data.db for expected table: test_collections/collection_table'; then
+    ok "a SYMLINKED table directory does not satisfy the table (matches Dirent.isDirectory)"
+  else
+    bad "a symlinked table directory satisfied the expectation Jest would skip"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  gold="$WORK/manifest-golden"
+  gdir="$gold/sstables/test_basic/counters-$UUID"
+  mkdir -p "$gdir"
+  printf 'x\n' > "$gdir/nb-1-big-Data.db"
+  g_out=$(mrun "$gold" 2>&1 || true)
+  if printf '%s' "$g_out" | grep -q 'not the JSONL golden Jest reads.*test_basic/counters'; then
+    ok "a Data.db without its .jsonl golden does not satisfy the table"
+  else
+    bad "a Data.db with no JSONL golden satisfied test_basic/counters"
+  fi
+  printf 'row\n' > "$gdir/nb-1-big-Data.db.jsonl"
+  g_out2=$(mrun "$gold" 2>&1 || true)
+  if printf '%s' "$g_out2" | grep -q 'not the JSONL golden Jest reads.*test_basic/counters'; then
+    bad "the table still reported a missing golden after one was created"
+  else
+    ok "adding the .jsonl golden satisfies it (check is the golden, not a blanket reject)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  gen="$WORK/manifest-generation"
+  gdir2="$gen/sstables/test_basic/counters-$UUID"
+  mkdir -p "$gdir2"
+  printf 'x\n' > "$gdir2/nb-2-big-Data.db"
+  printf 'row\n' > "$gdir2/nb-2-big-Data.db.jsonl"
+  gen_out=$(mrun "$gen" 2>&1 || true)
+  if printf '%s' "$gen_out" | grep -q 'not the JSONL golden Jest reads.*test_basic/counters'; then
+    ok "an alternate generation with its OWN golden does not satisfy a non-OA table"
+  else
+    bad "nb-2-big-Data.db.jsonl satisfied a table whose golden Jest reads as nb-1"
+  fi
+  # The nb-1 BINARY goes in alongside the nb-1 golden (round 33 made it required). Adding
+  # only the golden would leave the table rejected for the BINARY's sake, and this case
+  # would then be asserting the binary rule while claiming to assert the golden NAME.
+  printf 'row\n' > "$gdir2/nb-1-big-Data.db.jsonl"
+  printf 'x\n' > "$gdir2/nb-1-big-Data.db"
+  gen_out2=$(mrun "$gen" 2>&1 || true)
+  if printf '%s' "$gen_out2" | grep -q 'not the JSONL golden Jest reads.*test_basic/counters'; then
+    bad "adding nb-1-big-Data.db.jsonl (and its binary) did not satisfy the table"
+  else
+    ok "adding the golden Jest actually reads satisfies it (name, not a blanket reject)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  multi="$WORK/manifest-multigen"
+  mdir="$multi/sstables/test_oa/simple_table-$UUID"
+  mkdir -p "$mdir"
+  printf 'x\n' > "$mdir/oa-1-big-Data.db"          # earlier generation, NO golden
+  printf 'x\n' > "$mdir/oa-2-big-Data.db"          # later generation, WITH golden -- Jest finds this
+  printf 'row\n' > "$mdir/oa-2-big-Data.db.jsonl"
+  mg_out=$(mrun "$multi" 2>&1 || true)
+  if printf '%s' "$mg_out" | grep -q 'test_oa/simple_table'; then
+    bad "a golden-less earlier OA generation masked a complete later one"
+  else
+    ok "a complete later OA generation satisfies the table despite a golden-less earlier one"
+  fi
+  # Control: with NO generation complete, it must still report the golden as missing --
+  # the fix must not have turned the golden check off.
+  rm -f "$mdir/oa-2-big-Data.db.jsonl"
+  mg_out2=$(mrun "$multi" 2>&1 || true)
+  if printf '%s' "$mg_out2" | grep -q 'not the JSONL golden Jest reads.*test_oa/simple_table'; then
+    ok "with no complete generation, the missing golden is still reported"
+  else
+    bad "no generation had a golden, yet the table was accepted"
+  fi
+  # And the non-OA family keeps its DIRECTORY-scoped golden: Jest reads
+  # nb-1-big-Data.db.jsonl whichever generation's Data.db is present.
+  ngen="$WORK/manifest-nongen"
+  ndir="$ngen/sstables/test_basic/counters-$UUID"
+  mkdir -p "$ndir"
+  printf 'x\n' > "$ndir/nb-2-big-Data.db"
+  printf 'row\n' > "$ndir/nb-1-big-Data.db.jsonl"
+  # ROUND 22's RULE STANDS, after round 33 briefly overturned it and round 34 restored it.
+  # The GOLDEN is directory-scoped (`nb-1-big-Data.db.jsonl` whatever the binary) AND the
+  # binary generation is free -- for every non-OA table EXCEPT test_basic/simple_table,
+  # whose binary name corrupt-fixture.js hard-codes. `counters` is not that table, so an
+  # nb-2 binary with the nb-1 golden is satisfied. The simple_table exception is asserted
+  # separately below; keeping both is what stops the rule being re-generalised a third
+  # time.
+  ng_out2=$(mrun "$ngen" 2>&1 || true)
+  if printf '%s' "$ng_out2" | grep -q 'test_basic/counters'; then
+    bad "an nb-2 binary with the nb-1 golden was rejected for a table that does not pin the generation"
+  else
+    ok "a non-OA table other than simple_table accepts any generation with the nb-1 golden"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  cross="$WORK/manifest-crossgen"
+  cdir="$cross/sstables/test_oa/simple_table-$UUID"
+  mkdir -p "$cdir"
+  printf 'x\n' > "$cdir/oa-1-big-Data.db"           # binary of one generation ...
+  printf 'row\n' > "$cdir/oa-2-big-Data.db.jsonl"     # ... golden of ANOTHER; Jest accepts this
+  cx_out=$(mrun "$cross" 2>&1 || true)
+  if printf '%s' "$cx_out" | grep -q 'test_oa/simple_table'; then
+    bad "an OA binary and a DIFFERENT generation's golden were rejected, but Jest accepts them"
+  else
+    ok "an OA binary and a different generation's golden satisfy the table (matches Jest)"
+  fi
+  # Control: a golden of NO generation must still be rejected, so the decoupling did not
+  # simply stop checking.
+  rm -f "$cdir/oa-2-big-Data.db.jsonl"
+  cx_out2=$(mrun "$cross" 2>&1 || true)
+  if printf '%s' "$cx_out2" | grep -q 'not the JSONL golden Jest reads.*test_oa/simple_table'; then
+    ok "with no OA golden at all the table is still rejected (decoupling is not disabling)"
+  else
+    bad "a table with no OA golden was accepted"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$MANIFEST_SRC" ]; then
+  toolless="$WORK/toolless"; mkdir -p "$toolless/sstables"
+  # A FAILING HELPER, not an absent interpreter. `PATH=/nonexistent` was the first cut and
+  # proved nothing: bash then cannot run anything, so the script dies whatever it does.
+  # Shadowing ONE helper leaves the script running and reaching its verdict path, which is
+  # the situation `|| true` used to turn into a false judged-9.
+  failbin="$WORK/failbin"; mkdir -p "$failbin"
+  printf '#!/bin/sh\nexit 3\n' > "$failbin/sort"; chmod +x "$failbin/sort"
+  rc_ok=0
+  env PATH="$failbin:$PATH" bash "$MANIFEST_SRC" "$toolless" >/dev/null 2>&1 || rc_ok=$?
+  if [ "$rc_ok" -ne 9 ]; then
+    ok "a failing helper does NOT reach the reserved verdict (rc=$rc_ok, not 9)"
+  else
+    bad "a failing helper still produced the reserved verdict 9; the code is not reserved"
+  fi
+  # Control: with tools available the same empty corpus IS a judged 9, so the case above
+  # is about reachability of the code and not about the corpus.
+  rc_v=0
+  bash "$MANIFEST_SRC" "$toolless" >/dev/null 2>&1 || rc_v=$?
+  if [ "$rc_v" -eq 9 ]; then
+    ok "the same empty corpus with tools present emits the reserved verdict (9)"
+  else
+    bad "empty corpus with tools present returned $rc_v, expected the reserved 9"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$MANIFEST_SRC" ]; then
+  gbin="$WORK/failgrep"; mkdir -p "$gbin"
+  printf '#!/bin/sh\nexit 3\n' > "$gbin/grep"; chmod +x "$gbin/grep"
+  gcorpus="$WORK/grep-corpus"
+  mkdir -p "$gcorpus/sstables/test_basic/counters-$UUID"
+  printf 'x\n' > "$gcorpus/sstables/test_basic/counters-$UUID/nb-1-big-Data.db"
+  printf 'row\n' > "$gcorpus/sstables/test_basic/counters-$UUID/nb-1-big-Data.db.jsonl"
+  rc_g=0
+  env PATH="$gbin:$PATH" bash "$MANIFEST_SRC" "$gcorpus" >/dev/null 2>&1 || rc_g=$?
+  if [ "$rc_g" -ne 9 ]; then
+    ok "a failing grep does NOT reach the reserved verdict (rc=$rc_g, not 9)"
+  else
+    bad "a failing grep produced the reserved verdict 9; operational failures are being read as non-matches"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$MANIFEST_SRC" ] && [ -n "${CQLITE_DATASETS_ROOT:-}" ] \
+   && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ]; then
+  fbin="$WORK/failgrepF"; mkdir -p "$fbin"
+  real_grep=$(command -v grep)
+  {
+    printf '#!/bin/sh\n'
+    printf 'for a in "$@"; do case "$a" in -*F*) exit 3;; esac; done\n'
+    printf 'exec %s "$@"\n' "$real_grep"
+  } > "$fbin/grep"
+  chmod +x "$fbin/grep"
+  rc_f=0
+  env PATH="$fbin:$PATH" bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1 || rc_f=$?
+  if [ "$rc_f" -ne 9 ] && [ "$rc_f" -ne 0 ]; then
+    ok "a grep that fails only for -F does NOT reach the reserved verdict (rc=$rc_f)"
+  elif [ "$rc_f" -eq 0 ]; then
+    bad "the -F-failing grep run reported SUCCESS; the committed-set check cannot have run"
+  else
+    bad "a grep failing only for -F produced the reserved verdict 9; that site still collapses 1 and >1"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -f "$MANIFEST_SRC" ]; then
+  piped=$(grep -nE '^[[:space:]]*printf .*\|[[:space:]]*grep ' "$MANIFEST_SRC" || true)
+  if [ -z "$piped" ]; then
+    ok "no grep predicate is fed by a pipeline (SIGPIPE cannot be read as a malfunction)"
+  else
+    bad "a grep predicate is fed by a pipeline; under pipefail an early match returns 141: $piped"
+  fi
+  # Positive control: the predicates still EXIST and still answer, so the check above is
+  # not passing merely because the greps were deleted.
+  if grep -qE '<<<' "$MANIFEST_SRC" && grep -qE 'grep -(Eq|Fxq)' "$MANIFEST_SRC"; then
+    ok "the predicates are still present, fed by here-strings"
+  else
+    bad "the grep predicates are missing entirely; the pipeline check above proves nothing"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+gnu_class="[$(printf 's')$(printf 'd')$(printf 'w')$(printf 'b')SWDB]"
+gnu_hits=""
+for f in "$0" "$MANIFEST_SRC"; do
+  [ -f "$f" ] || continue
+  # Only lines that actually invoke grep/sed/awk with a pattern; a backslash-letter in
+  # prose is not a portability problem.
+  # COMMENTS ARE STRIPPED FIRST. The prose above names `\s` and friends while explaining
+  # why the code must not use them, and a scan that cannot tell code from commentary
+  # fails on its own documentation -- the identical trap this suite already hit in round
+  # 13's portability check. `grep -v` on a leading-# line is enough here: these are shell
+  # scripts, and a pattern is never introduced inside a comment.
+  h=$(grep -nE "(grep|sed|awk)[^|]*\\\\${gnu_class}" "$f" 2>/dev/null \
+        | grep -vE '^[0-9]+:[[:space:]]*#' \
+        | grep -v 'gnu_class=' || true)
+  [ -n "$h" ] && gnu_hits="$gnu_hits
+$f: $h"
+done
+if [ -z "$gnu_hits" ]; then
+  ok "no GNU-only regex escape in the scripts this change owns (BSD/macOS-safe)"
+else
+  bad "GNU-only regex escape(s) found; BSD/macOS grep reads them as literals:$gnu_hits"
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  for shape in nb2only nb1empty nb1ok; do
+    nb="$WORK/manifest-$shape"
+    nbdir="$nb/sstables/test_basic/simple_table-$UUID"
+    mkdir -p "$nbdir"
+    printf 'row\n' > "$nbdir/nb-1-big-Data.db.jsonl"
+    case "$shape" in
+      # NONEMPTY, or this shape is rejected by the emptiness rule and never reaches the
+      # generation pin -- which is exactly what happened: the case passed with the pin
+      # REMOVED, testing size while claiming to test the binary name.
+      nb2only)  printf 'x\n' > "$nbdir/nb-2-big-Data.db" ;;
+      nb1empty) : > "$nbdir/nb-1-big-Data.db" ;;   # deliberately ZERO-LENGTH
+      nb1ok)    echo x > "$nbdir/nb-1-big-Data.db" ;;
+    esac
+    nb_out=$(mrun "$nb" 2>&1 || true)
+    if printf '%s' "$nb_out" | grep -q 'test_basic/simple_table'; then hit=rejected; else hit=accepted; fi
+    case "$shape" in
+      nb2only)
+        [ "$hit" = rejected ] \
+          && ok "an alternate-generation binary alone does not satisfy a non-OA table" \
+          || bad "nb-2-big-Data.db alone satisfied test_basic/simple_table" ;;
+      nb1empty)
+        [ "$hit" = rejected ] \
+          && ok "a ZERO-LENGTH nb-1 binary does not satisfy it (a truncated fetch is not a corpus)" \
+          || bad "an empty nb-1-big-Data.db satisfied test_basic/simple_table" ;;
+      nb1ok)
+        [ "$hit" = accepted ] \
+          && ok "a nonempty nb-1 binary with its golden does satisfy it (rule, not blanket reject)" \
+          || bad "a nonempty nb-1-big-Data.db with its golden was rejected" ;;
+    esac
+  done
+  # SCOPE CONTROL: the nb-1 BINARY pin is specific to test_basic/simple_table, whose name
+  # corrupt-fixture.js hard-codes. Round 33 generalised it to every non-OA table and
+  # rejected usable alternate-generation corpora. Asserting the same shape on a DIFFERENT
+  # table is what keeps the exception an exception.
+  other="$WORK/manifest-othertable"
+  odir="$other/sstables/test_basic/counters-$UUID"
+  mkdir -p "$odir"
+  printf 'x\n' > "$odir/nb-2-big-Data.db"
+  printf 'row\n' > "$odir/nb-1-big-Data.db.jsonl"
+  o_out=$(mrun "$other" 2>&1 || true)
+  if printf '%s' "$o_out" | grep -q 'test_basic/counters'; then
+    bad "the nb-1 binary pin leaked to test_basic/counters, which does not require it"
+  else
+    ok "the nb-1 binary pin applies ONLY to test_basic/simple_table"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  # zero-length OA binary
+  oz="$WORK/manifest-oa-empty"
+  ozdir="$oz/sstables/test_oa/simple_table-$UUID"
+  mkdir -p "$ozdir"
+  : > "$ozdir/oa-2-big-Data.db"          # deliberately ZERO-LENGTH
+  printf 'row\n' > "$ozdir/oa-2-big-Data.db.jsonl"
+  oz_out=$(mrun "$oz" 2>&1 || true)
+  if printf '%s' "$oz_out" | grep -q 'test_oa/simple_table'; then
+    ok "a ZERO-LENGTH OA binary does not satisfy the table (size rule is not non-OA-only)"
+  else
+    bad "an empty oa-2-big-Data.db satisfied test_oa/simple_table"
+  fi
+  # unrecognised non-OA descriptor name
+  jn="$WORK/manifest-junkname"
+  jndir="$jn/sstables/test_basic/counters-$UUID"
+  mkdir -p "$jndir"
+  printf 'x\n' > "$jndir/junk-Data.db"
+  printf 'row\n' > "$jndir/nb-1-big-Data.db.jsonl"
+  jn_out=$(mrun "$jn" 2>&1 || true)
+  if printf '%s' "$jn_out" | grep -q 'test_basic/counters'; then
+    ok "a name the reader would not recognise (junk-Data.db) does not satisfy a table"
+  else
+    bad "junk-Data.db satisfied test_basic/counters"
+  fi
+  # Control: a real alternate descriptor (da-<n>-bti) IS recognised, so the pattern is a
+  # format rule and not a whitelist of the one name this corpus happens to use most.
+  bti="$WORK/manifest-bti"
+  btidir="$bti/sstables/test_basic/counters-$UUID"
+  mkdir -p "$btidir"
+  printf 'x\n' > "$btidir/da-2-bti-Data.db"
+  printf 'row\n' > "$btidir/nb-1-big-Data.db.jsonl"
+  bti_out=$(mrun "$bti" 2>&1 || true)
+  if printf '%s' "$bti_out" | grep -q 'test_basic/counters'; then
+    bad "a da-<n>-bti descriptor was rejected; it is a real shape in this corpus"
+  else
+    ok "a da-<n>-bti descriptor IS recognised (format rule, not a single-name whitelist)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  #    name                      expected (accept|reject)   why
+  for spec in "na-1-big-Data.db:accept" \
+              "nb-6aa08200a25111f0a3fef1a551383fb9-big-Data.db:accept" \
+              "nb-6aa08200-a251-11f0-a3fe-f1a551383fb9-big-Data.db:accept" \
+              "nb-1-big-Data.db:accept" \
+              "oa-1-big-Data.db:accept" \
+              "da-2-bti-Data.db:accept" \
+              "zz-9-big-Data.db:reject" \
+              "nc-1-big-Data.db:reject" \
+              "nb-1-bti-Data.db:reject" \
+              "ma-1-big-Data.db:reject" \
+              "da-1-big-Data.db:reject"; do
+    dname=${spec%%:*}; want=${spec##*:}
+    dcase="$WORK/manifest-desc-${dname%%-*}-$want-$RANDOM"
+    ddir="$dcase/sstables/test_basic/counters-$UUID"
+    mkdir -p "$ddir"
+    printf 'x\n' > "$ddir/$dname"
+    printf 'row\n' > "$ddir/nb-1-big-Data.db.jsonl"
+    d_out=$(mrun "$dcase" 2>&1 || true)
+    if printf '%s' "$d_out" | grep -q 'test_basic/counters'; then got=reject; else got=accept; fi
+    if [ "$got" = "$want" ]; then
+      ok "descriptor $dname -> $want (matches the version gates)"
+    else
+      bad "descriptor $dname -> $got, expected $want"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  #    fixture shape                      expected substring of the diagnostic
+  for spec in "empty:ZERO-LENGTH" "junk:none the reader would open" "nogolden:not the JSONL golden"; do
+    shape=${spec%%:*}; want=${spec#*:}
+    dg="$WORK/manifest-diag-$shape"
+    dgdir="$dg/sstables/test_basic/counters-$UUID"
+    mkdir -p "$dgdir"
+    case "$shape" in
+      empty)    : > "$dgdir/nb-1-big-Data.db"; : > "$dgdir/nb-1-big-Data.db.jsonl" ;;
+      junk)     printf 'x\n' > "$dgdir/junk-Data.db"; : > "$dgdir/nb-1-big-Data.db.jsonl" ;;
+      nogolden) printf 'x\n' > "$dgdir/nb-1-big-Data.db" ;;
+    esac
+    dg_out=$(mrun "$dg" 2>&1 || true)
+    if printf '%s' "$dg_out" | grep -q "$want"; then
+      ok "the '$shape' shape reports its OWN cause ($want)"
+    else
+      bad "the '$shape' shape did not report '$want'; got: $(printf '%s' "$dg_out" | grep 'test_basic/counters' | head -1)"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  for shape in golden-dir binary-dir symlink-ok plain-ok; do
+    uf="$WORK/manifest-usable-$shape"
+    ufdir="$uf/sstables/test_basic/counters-$UUID"
+    mkdir -p "$ufdir"
+    case "$shape" in
+      golden-dir)
+        printf 'x\n' > "$ufdir/nb-1-big-Data.db"
+        mkdir -p "$ufdir/nb-1-big-Data.db.jsonl/sub"
+        printf 'y\n' > "$ufdir/nb-1-big-Data.db.jsonl/sub/f" ;;
+      binary-dir)
+        mkdir -p "$ufdir/nb-1-big-Data.db/sub"
+        printf 'y\n' > "$ufdir/nb-1-big-Data.db/sub/f"
+        printf 'row\n' > "$ufdir/nb-1-big-Data.db.jsonl" ;;
+      symlink-ok)
+        printf 'x\n' > "$ufdir/real-binary.db"
+        ln -s "$ufdir/real-binary.db" "$ufdir/nb-1-big-Data.db"
+        printf 'row\n' > "$ufdir/nb-1-big-Data.db.jsonl" ;;
+      plain-ok)
+        printf 'x\n' > "$ufdir/nb-1-big-Data.db"
+        printf 'row\n' > "$ufdir/nb-1-big-Data.db.jsonl" ;;
+    esac
+    uf_out=$(mrun "$uf" 2>&1 || true)
+    if printf '%s' "$uf_out" | grep -q 'test_basic/counters'; then got=reject; else got=accept; fi
+    case "$shape" in
+      golden-dir|binary-dir)
+        [ "$got" = reject ] \
+          && ok "a nonempty DIRECTORY as the ${shape%-dir} does not satisfy the table" \
+          || bad "a directory named like the ${shape%-dir} satisfied test_basic/counters" ;;
+      symlink-ok)
+        [ "$got" = accept ] \
+          && ok "a symlink to a nonempty regular file still counts (type test, not a symlink ban)" \
+          || bad "a symlink to a nonempty regular binary was rejected" ;;
+      plain-ok)
+        [ "$got" = accept ] \
+          && ok "plain nonempty regular files still satisfy the table" \
+          || bad "plain nonempty regular files were rejected" ;;
+    esac
+  done
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ] && [ "$(id -u)" -ne 0 ]; then
+  for target in binary golden; do
+    ur="$WORK/manifest-unreadable-$target"
+    urdir="$ur/sstables/test_basic/counters-$UUID"
+    mkdir -p "$urdir"
+    printf 'x\n'   > "$urdir/nb-1-big-Data.db"
+    printf 'row\n' > "$urdir/nb-1-big-Data.db.jsonl"
+    case "$target" in
+      binary) chmod 000 "$urdir/nb-1-big-Data.db" ;;
+      golden) chmod 000 "$urdir/nb-1-big-Data.db.jsonl" ;;
+    esac
+    ur_out=$(mrun "$ur" 2>&1 || true)
+    if printf '%s' "$ur_out" | grep -q 'test_basic/counters'; then
+      ok "an UNREADABLE $target does not satisfy the table"
+    else
+      bad "an unreadable $target satisfied test_basic/counters"
+    fi
+    chmod -R u+rwX "$ur" 2>/dev/null || true
+  done
+  # Control: the same shapes READABLE must be accepted, so this is a permission test and
+  # not a second copy of the existence test.
+  urok="$WORK/manifest-unreadable-control"
+  urokdir="$urok/sstables/test_basic/counters-$UUID"
+  mkdir -p "$urokdir"
+  printf 'x\n'   > "$urokdir/nb-1-big-Data.db"
+  printf 'row\n' > "$urokdir/nb-1-big-Data.db.jsonl"
+  urok_out=$(mrun "$urok" 2>&1 || true)
+  if printf '%s' "$urok_out" | grep -q 'test_basic/counters'; then
+    bad "readable fixtures were rejected; the readability rule is over-tightened"
+  else
+    ok "the same fixtures READABLE are accepted (permission test, not existence)"
+  fi
+elif [ -n "$MANIFEST_NOGIT" ]; then
+  echo "INFO: running as root, which can read mode-000 files; skipping the readability case"
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  for shape in one-valid empty-sibling dir-sibling two-valid; do
+    og="$WORK/manifest-oagolden-$shape"
+    ogdir="$og/sstables/test_oa/simple_table-$UUID"
+    mkdir -p "$ogdir"
+    printf 'x\n'   > "$ogdir/oa-2-big-Data.db"
+    printf 'row\n' > "$ogdir/oa-2-big-Data.db.jsonl"
+    case "$shape" in
+      empty-sibling) : > "$ogdir/oa-1-big-Data.db.jsonl" ;;
+      dir-sibling)   mkdir -p "$ogdir/oa-1-big-Data.db.jsonl/x"
+                     printf 'y\n' > "$ogdir/oa-1-big-Data.db.jsonl/x/f" ;;
+      two-valid)     printf 'row\n' > "$ogdir/oa-1-big-Data.db.jsonl" ;;
+    esac
+    og_out=$(mrun "$og" 2>&1 || true)
+    if printf '%s' "$og_out" | grep -q 'test_oa/simple_table'; then got=reject; else got=accept; fi
+    case "$shape" in
+      one-valid|two-valid)
+        [ "$got" = accept ] \
+          && ok "OA goldens all usable ($shape) -> table satisfied" \
+          || bad "$shape was rejected though every OA golden is usable" ;;
+      *)
+        [ "$got" = reject ] \
+          && ok "an UNUSABLE OA golden sibling ($shape) makes the table incomplete" \
+          || bad "$shape satisfied test_oa/simple_table though Jest could select the broken golden" ;;
+    esac
+    chmod -R u+rwX "$og" 2>/dev/null || true
+  done
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  UUID2=aa11bb22cc33dd44ee55ff6677889900
+  for shape in both-good one-broken; do
+    tc="$WORK/manifest-twodir-$shape"
+    tck="$tc/sstables/test_basic"
+    mkdir -p "$tck/counters-$UUID" "$tck/counters-$UUID2"
+    printf 'x\n'   > "$tck/counters-$UUID/nb-1-big-Data.db"
+    printf 'row\n' > "$tck/counters-$UUID/nb-1-big-Data.db.jsonl"
+    printf 'x\n'   > "$tck/counters-$UUID2/nb-1-big-Data.db"
+    case "$shape" in
+      both-good)  printf 'row\n' > "$tck/counters-$UUID2/nb-1-big-Data.db.jsonl" ;;
+      one-broken) : > "$tck/counters-$UUID2/nb-1-big-Data.db.jsonl" ;;   # ZERO-LENGTH
+    esac
+    tc_out=$(mrun "$tc" 2>&1 || true)
+    if printf '%s' "$tc_out" | grep -q 'test_basic/counters'; then got=reject; else got=accept; fi
+    case "$shape" in
+      both-good)
+        [ "$got" = accept ] \
+          && ok "two good candidate directories satisfy the table" \
+          || bad "two good candidate directories were rejected" ;;
+      one-broken)
+        [ "$got" = reject ] \
+          && ok "one broken candidate directory disqualifies the table (the consumer picks blind)" \
+          || bad "a broken candidate directory was masked by a good sibling" ;;
+    esac
+  done
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  # toc_case <shape> -> "accept" | "reject"
+  toc_case() {
+    local shape=$1 tc tck d
+    tc="$WORK/manifest-toc-$shape"; tck="$tc/sstables/test_basic"
+    d="$tck/counters-$UUID"; mkdir -p "$d"
+    printf 'x\n'   > "$d/nb-1-big-Data.db"
+    printf 'row\n' > "$d/nb-1-big-Data.db.jsonl"
+    case "$shape" in
+      complete)
+        printf 'Data.db\nTOC.txt\n' > "$d/nb-1-big-TOC.txt" ;;
+      zero-length-companion)   # a LEGITIMATE shape: 3 real Rows.db are zero-length
+        : > "$d/nb-1-big-Rows.db"
+        printf 'Data.db\nRows.db\nTOC.txt\n' > "$d/nb-1-big-TOC.txt" ;;
+      missing-companion)       # the partial-extraction shape
+        printf 'Data.db\nCompressionInfo.db\nTOC.txt\n' > "$d/nb-1-big-TOC.txt" ;;
+      companion-is-a-dir)      # present to `-e`, unusable to a reader
+        mkdir -p "$d/nb-1-big-Filter.db"
+        printf 'Data.db\nFilter.db\nTOC.txt\n' > "$d/nb-1-big-TOC.txt" ;;
+      no-toc)                  # measured 144/144 real generations have one
+        : ;;
+      toc-escapes-dir)         # a TOC entry must be a component NAME, never a path
+        printf 'Data.db\n../elsewhere.db\nTOC.txt\n' > "$d/nb-1-big-TOC.txt" ;;
+    esac
+    # CAPTURE, then grep. `mrun ... | grep -q` closes the pipe on the first match while the
+    # manifest is still writing its other 38 lines, so the manifest dies of SIGPIPE and
+    # `pipefail` makes the pipeline rc 141 -- the `if` takes the else branch and every
+    # REJECT case reads as "accepted". This suite has now been bitten by that four times.
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$tc" 2>&1 || true)
+    if printf '%s' "$_o" | grep -q 'test_basic/counters'; then
+      echo reject
+    else
+      echo accept
+    fi
+  }
+
+  # Both directions. The accept cases are the control: without them a manifest that
+  # rejected EVERY generation would pass the reject cases and look correct.
+  for shape in complete zero-length-companion; do
+    [ "$(toc_case "$shape")" = accept ] \
+      && ok "TOC shape '$shape' satisfies the table" \
+      || bad "TOC shape '$shape' was rejected, but it is a shape the real corpus has"
+  done
+  for shape in missing-companion companion-is-a-dir no-toc toc-escapes-dir; do
+    [ "$(toc_case "$shape")" = reject ] \
+      && ok "TOC shape '$shape' disqualifies the table" \
+      || bad "TOC shape '$shape' was accepted; an incomplete generation reads as complete"
+  done
+
+  # The diagnostic must NAME the cause: an operator told only "missing Data.db" for a
+  # Data.db that is present and fine goes looking in the wrong place (the same
+  # misattribution round 35 fixed for the truncated/misnamed binary).
+  tcd="$WORK/manifest-toc-diag"; mkdir -p "$tcd/sstables/test_basic/counters-$UUID"
+  printf 'x\n'   > "$tcd/sstables/test_basic/counters-$UUID/nb-1-big-Data.db"
+  printf 'row\n' > "$tcd/sstables/test_basic/counters-$UUID/nb-1-big-Data.db.jsonl"
+  printf 'Data.db\nCompressionInfo.db\nTOC.txt\n' > "$tcd/sstables/test_basic/counters-$UUID/nb-1-big-TOC.txt"
+  tcd_out=$(NO_AUTO_TOC=1 mrun "$tcd" 2>&1 || true)
+  if printf '%s' "$tcd_out" | grep -q 'TOC.txt is absent, or lists a component'; then
+    ok "the incomplete-generation diagnostic names the TOC as the cause"
+  else
+    bad "the incomplete-generation diagnostic did not name the TOC"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+PU_SRC=$(cd "$SCRIPT_DIR/../.." && pwd)/bindings/node/__test__/parity-utils.js
+if command -v node >/dev/null 2>&1 && [ -f "$PU_SRC" ]; then
+  pu_tree="$WORK/pu-tree"; mkdir -p "$pu_tree/bindings/node/__test__"
+  cp "$PU_SRC" "$pu_tree/bindings/node/__test__/parity-utils.js"
+  puk="$pu_tree/corpus/test_basic"
+  # ONLY a non-UUID committed sibling exists, and its golden is a DIRECTORY -- present to
+  # `fs.existsSync`, unusable to the reader. No UUID sibling, so the answer cannot depend
+  # on readdir order (which is filesystem-determined and not a property to test on).
+  mkdir -p "$puk/orders-wip/nb-1-big-Data.db.jsonl" "$puk/oatab-wip/oa-1-big-Data.db.jsonl"
+
+  pu_probe() {   # $1 = parity-utils.js path -> two lines, "fn -> path|(null)"
+    node -e "
+      global.testPaths = { SSTABLES_DIR: '$puk/..' };
+      const u = require('$1');
+      for (const [f, t] of [['findJsonlFile','orders'], ['findOaJsonlFile','oatab']]) {
+        const r = u[f]('test_basic', t);
+        console.log(f + ' ' + (r ? 'SELECTED' : 'null'));
+      }" 2>/dev/null
+  }
+
+  pu_out=$(pu_probe "$pu_tree/bindings/node/__test__/parity-utils.js")
+  if [ "$(printf '%s' "$pu_out" | grep -c 'null')" = 2 ]; then
+    ok "both golden lookups ignore a committed non-UUID sibling"
+  else
+    bad "a golden lookup selected a committed non-UUID sibling the manifest never validates"
+    printf '  %s\n' "$pu_out"
+  fi
+
+  # The predicate itself: equality on the CAPTURED table name, not a prefix test.
+  # `orders-extra-<uuid>` is table `orders-extra`, never table `orders`.
+  pu_pred=$(node -e "
+    global.testPaths = { SSTABLES_DIR: '$puk/..' };
+    const u = require('$pu_tree/bindings/node/__test__/parity-utils.js');
+    const cases = [
+      ['orders-$UUID', 'orders', true],
+      ['orders-wip', 'orders', false],
+      ['orders-extra-$UUID', 'orders', false],
+      ['orders-extra-$UUID', 'orders-extra', true],
+      ['orders-$(printf '%s' "$UUID" | tr 'a-f' 'A-F')', 'orders', false]
+    ];
+    let n = 0;
+    for (const [d, t, e] of cases) if (u.isTableDirFor(d, t) === e) n++;
+    console.log(n + '/' + cases.length);" 2>/dev/null)
+  [ "$pu_pred" = "5/5" ] \
+    && ok "isTableDirFor matches the manifest's rule exactly (5/5)" \
+    || bad "isTableDirFor disagrees with the manifest's rule ($pu_pred)"
+
+  # RED CONTROL: with the pre-fix predicate restored in the scratch copy, the lookups MUST
+  # select the broken sibling. Without this the case above could pass for the wrong reason
+  # (a typo'd probe, a module that failed to load) -- a bare "null" proves nothing.
+  pu_red="$WORK/pu-red"; mkdir -p "$pu_red/bindings/node/__test__"
+  sed 's/      isTableDirFor(entry\.name, table) \&\&/      entry.name.startsWith(`${table}-`) \&\&/' \
+    "$PU_SRC" > "$pu_red/bindings/node/__test__/parity-utils.js"
+  if grep -q 'startsWith(`${table}-`)' "$pu_red/bindings/node/__test__/parity-utils.js"; then
+    red_out=$(pu_probe "$pu_red/bindings/node/__test__/parity-utils.js")
+    if [ "$(printf '%s' "$red_out" | grep -c 'SELECTED')" = 2 ]; then
+      ok "RED control: the pre-fix startsWith predicate does select the broken sibling"
+    else
+      bad "RED control did not reproduce the defect, so the case above proves nothing"
+      printf '  %s\n' "$red_out"
+    fi
+  else
+    bad "RED control could not plant the pre-fix predicate (the fix's shape moved)"
+  fi
+else
+  echo "info - node or parity-utils.js unavailable; skipping the Jest-lookup cases"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 63 (round 48, Medium): corrupt-fixture.js is the THIRD consumer of a table
+# directory and must apply the same rule as the manifest and the golden lookups.
+#
+# `sourceTableDir()` took any `simple_table-*` name, sorted LEXICOGRAPHICALLY and returned
+# the first with a `nb-1-big-Data.db` entry -- so an earlier-sorting non-canonical or
+# uncommitted sibling WON over the valid directory, and `existsSync` accepted a Data.db
+# that is a directory or zero-length. The manifest validates only `<table>-<32 hex>`
+# directories, so it reports the corpus complete while abort-safety corrupts the wrong
+# fixture.
+#
+# Driven directly (no native module needed) from a scratch copy of the tree, which puts
+# `isCommittedTableDir` on its git-unavailable fallback -- the only way a synthetic dir is
+# "committed".
+# ---------------------------------------------------------------------------
+CF_SRC=$(cd "$SCRIPT_DIR/../.." && pwd)/bindings/node/__test__/corrupt-fixture.js
+if command -v node >/dev/null 2>&1 && [ -f "$CF_SRC" ] && [ -f "$PU_SRC" ]; then
+  cf_tree="$WORK/cf-tree"; mkdir -p "$cf_tree/bindings/node/__test__"
+  cp "$CF_SRC" "$PU_SRC" "$cf_tree/bindings/node/__test__/"
+  cfk="$cf_tree/corpus/test_basic"; cf_good="simple_table-$UUID"
+  mkdir -p "$cfk/$cf_good"; printf 'x\n' > "$cfk/$cf_good/nb-1-big-Data.db"
+  # Three decoys, each sorting BEFORE the hex UUID ('0'/'1'/'2' < '4'), so a lexicographic
+  # pick without the predicates lands on one of them.
+  mkdir -p "$cfk/simple_table-0wip";  printf 'x\n' > "$cfk/simple_table-0wip/nb-1-big-Data.db"
+  mkdir -p "$cfk/simple_table-1zero"; : >          "$cfk/simple_table-1zero/nb-1-big-Data.db"
+  mkdir -p "$cfk/simple_table-2dir/nb-1-big-Data.db"
+
+  cf_probe() {   # $1 = tree root -> the selected directory's basename, or "(null)"
+    node -e "
+      global.testPaths = { SSTABLES_DIR: '$cf_tree/corpus' };
+      const cf = require('$1/bindings/node/__test__/corrupt-fixture.js');
+      const d = cf.sourceTableDir('$cf_tree/corpus');
+      console.log(d ? require('path').basename(d) : '(null)');" 2>/dev/null
+  }
+
+  cf_got=$(cf_probe "$cf_tree")
+  [ "$cf_got" = "$cf_good" ] \
+    && ok "sourceTableDir selects the canonical committed directory, not an earlier-sorting decoy" \
+    || bad "sourceTableDir selected '$cf_got', expected '$cf_good'"
+
+  # A SYMLINKED table directory must be invisible -- and this one is not a consistency
+  # point but a DESTRUCTIVE-WRITE guard (round 49). `fs.cpSync` preserves a symlink by
+  # default, so a symlinked table dir was copied AS A SYMLINK and the harness's
+  # truncate/bitflip then wrote THROUGH it into the real fixture. On a shared machine-local
+  # corpus that damages every other lane on the box.
+  cf_sym="$WORK/cf-symlink"; mkdir -p "$cf_sym/bindings/node/__test__"
+  cp "$CF_SRC" "$PU_SRC" "$cf_sym/bindings/node/__test__/"
+  symk="$cf_sym/corpus/test_basic"; mkdir -p "$symk"
+  # The REAL directory lives outside the keyspace; only a canonical, committed-looking
+  # SYMLINK to it appears inside. Nothing else can be selected.
+  mkdir -p "$cf_sym/elsewhere/simple_table-$UUID"
+  printf 'ORIGINALDATA' > "$cf_sym/elsewhere/simple_table-$UUID/nb-1-big-Data.db"
+  ln -s "$cf_sym/elsewhere/simple_table-$UUID" "$symk/simple_table-$UUID"
+
+  sym_got=$(node -e "
+    global.testPaths = { SSTABLES_DIR: '$cf_sym/corpus' };
+    const cf = require('$cf_sym/bindings/node/__test__/corrupt-fixture.js');
+    const d = cf.sourceTableDir('$cf_sym/corpus');
+    console.log(d ? require('path').basename(d) : '(null)');" 2>/dev/null)
+  [ "$sym_got" = "(null)" ] \
+    && ok "sourceTableDir ignores a symlinked table directory" \
+    || bad "sourceTableDir selected the symlinked table directory '$sym_got'"
+
+  # The consequence, asserted directly: build the fixture and confirm the SOURCE is
+  # untouched. Without this the case above tests a predicate; this tests the damage.
+  #
+  # It covers the DIRECTORY guard only. `sourceTableDir` rejects the symlinked directory,
+  # so `makeCorruptFixture` throws before it ever calls `cpSync` -- deleting
+  # `dereference: true` leaves this assert green. The COMPONENT-symlink half is a separate
+  # case below, with its own RED control.
+  mkdir -p "$symk/simple_table-real"   # not canonical; forces the symlink to be the only
+  rm -rf "$symk/simple_table-real"     # plausible candidate. (created+removed to be explicit)
+  node -e "
+    global.testPaths = { SSTABLES_DIR: '$cf_sym/corpus' };
+    const cf = require('$cf_sym/bindings/node/__test__/corrupt-fixture.js');
+    try { cf.makeCorruptFixture('$WORK/cf-sym-dest', '$cf_sym/corpus', 'truncate'); } catch (_e) { /* expected: no selectable source */ }
+    " >/dev/null 2>&1 || true
+  sym_after=$(cat "$cf_sym/elsewhere/simple_table-$UUID/nb-1-big-Data.db" 2>/dev/null)
+  [ "$sym_after" = "ORIGINALDATA" ] \
+    && ok "the source corpus is intact after a fixture build over a symlinked table dir" \
+    || bad "the source fixture was MODIFIED through the symlink (now '$sym_after')"
+
+  # RED CONTROL: the pre-fix selection must land on a decoy, or the case above proves nothing.
+  cf_red="$WORK/cf-red"; mkdir -p "$cf_red/bindings/node/__test__"
+  cp "$PU_SRC" "$cf_red/bindings/node/__test__/"
+  sed -e 's|\.readdirSync(ksDir, { withFileTypes: true })|.readdirSync(ksDir)|' \
+      -e 's|\.filter((entry) => entry\.isDirectory())||' \
+      -e 's|\.map((entry) => entry\.name)||' \
+      -e 's|\.filter((name) => isTableDirFor(name, TABLE) && isCommittedTableDir(KEYSPACE, name))|.filter((name) => name.startsWith(`${TABLE}-`))|' \
+      -e 's|\.filter((dir) => isNonemptyFile(path\.join(dir, DATA_COMPONENT)))|.filter((dir) => fs.existsSync(path.join(dir, DATA_COMPONENT)))|' \
+      -e 's|^    dereference: true,$||' \
+      "$CF_SRC" > "$cf_red/bindings/node/__test__/corrupt-fixture.js"
+  if grep -q 'name.startsWith(`${TABLE}-`)' "$cf_red/bindings/node/__test__/corrupt-fixture.js"; then
+    cf_red_got=$(cf_probe "$cf_red")
+    [ "$cf_red_got" != "$cf_good" ] && [ "$cf_red_got" != "(null)" ] \
+      && ok "RED control: the pre-fix selection lands on the decoy '$cf_red_got'" \
+      || bad "RED control did not reproduce the defect (got '$cf_red_got'); the case above proves nothing"
+
+    # RED control for the symlink half, against its OWN scratch corpus so the assertion
+    # above cannot be satisfied by a corpus this run already mutated.
+    sym_red="$WORK/cf-sym-red-corpus"; mkdir -p "$sym_red/test_basic" "$sym_red/elsewhere/simple_table-$UUID"
+    printf 'ORIGINALDATA' > "$sym_red/elsewhere/simple_table-$UUID/nb-1-big-Data.db"
+    ln -s "$sym_red/elsewhere/simple_table-$UUID" "$sym_red/test_basic/simple_table-$UUID"
+    node -e "
+      global.testPaths = { SSTABLES_DIR: '$sym_red' };
+      const cf = require('$cf_red/bindings/node/__test__/corrupt-fixture.js');
+      try { cf.makeCorruptFixture('$WORK/cf-sym-red-dest', '$sym_red', 'truncate'); } catch (_e) {}
+      " >/dev/null 2>&1 || true
+    sym_red_after=$(cat "$sym_red/elsewhere/simple_table-$UUID/nb-1-big-Data.db" 2>/dev/null)
+    [ "$sym_red_after" != "ORIGINALDATA" ] \
+      && ok "RED control: the pre-fix harness DOES write through the symlink (source now '$sym_red_after')" \
+      || bad "RED control did not reproduce the destructive write; the intactness assert proves nothing"
+  else
+    bad "RED control could not plant the pre-fix selection (the fix's shape moved)"
+  fi
+else
+  echo "info - node or corrupt-fixture.js unavailable; skipping the fixture-selection case"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 65 (round 50, Low): the COMPONENT-symlink half -- `cpSync(..., { dereference: true })`.
+#
+# Case 64 covers a symlinked table DIRECTORY, which `sourceTableDir` now rejects outright,
+# so `makeCorruptFixture` throws before reaching `cpSync` and that case cannot see the
+# dereference flag at all. A symlinked COMPONENT inside an otherwise REAL, canonical,
+# committed directory is the case that reaches it: the directory passes every predicate
+# (`isNonemptyFile` uses `statSync`, which follows symlinks -- deliberately, since a
+# symlink to a real fixture file is a legitimate corpus layout), the copy proceeds, and
+# without `dereference` the destination Data.db is a LINK whose truncation destroys the
+# external source.
+#
+# Asserts BOTH directions, which is what makes it a real test of the flag: the destination
+# IS mutated (the harness still does its job) and the external source is NOT.
+# ---------------------------------------------------------------------------
+# Case 67 (round 52, Low): `broken` must stay distinguishable from `absent`.
+#
+# Round 48 gave `sourceTableDir` a nonempty-regular-file filter, which silently converted
+# "present but UNUSABLE" into "ABSENT". `abort-safety.test.js` gates on exactly that
+# distinction -- `broken` is a HARD FAILURE, a non-strict `absent` is a real `test.skip` --
+# so a TRUNCATED fixture stopped hard-failing and started SKIPPING, inverting #1437's stated
+# design and making that test's `broken` branch unreachable. A regression introduced by an
+# earlier round of this same PR.
+#
+# Drives the real `classifyTableDir` over every shape, including the two forms of damage the
+# old size-only check could not see (a directory, a dangling symlink).
+# ---------------------------------------------------------------------------
+if command -v node >/dev/null 2>&1 && [ -f "$CF_SRC" ] && [ -f "$PU_SRC" ]; then
+  cls_probe() {   # <shape> -> "<status>"
+    local shape=$1 root d
+    root="$WORK/cf-cls-$shape"; rm -rf "$root"
+    d="$root/test_basic/simple_table-$UUID"
+    case "$shape" in
+      ok)             mkdir -p "$d"; printf 'DATA' > "$d/nb-1-big-Data.db" ;;
+      zero-length)    mkdir -p "$d"; :             > "$d/nb-1-big-Data.db" ;;
+      is-a-directory) mkdir -p "$d/nb-1-big-Data.db" ;;
+      dangling-link)  mkdir -p "$d"; ln -s "$root/nowhere" "$d/nb-1-big-Data.db" ;;
+      no-data-db)     mkdir -p "$d" ;;                       # fetched nothing: absent
+      no-keyspace)    mkdir -p "$root" ;;
+      good-beats-bad) mkdir -p "$d" "$root/test_basic/simple_table-0000000000000000000000000000000a"
+                      printf 'DATA' > "$d/nb-1-big-Data.db"
+                      :              > "$root/test_basic/simple_table-0000000000000000000000000000000a/nb-1-big-Data.db" ;;
+    esac
+    node -e "
+      global.testPaths = { SSTABLES_DIR: '$root' };
+      const cf = require('$cf_tree/bindings/node/__test__/corrupt-fixture.js');
+      console.log(cf.classifyTableDir('$root').status);" 2>/dev/null
+  }
+
+  cls_bad=""
+  for pair in ok:ok zero-length:broken is-a-directory:broken dangling-link:broken \
+              no-data-db:absent no-keyspace:absent good-beats-bad:ok; do
+    cls_shape=${pair%%:*}; cls_want=${pair#*:}
+    cls_got=$(cls_probe "$cls_shape")
+    [ "$cls_got" = "$cls_want" ] || cls_bad="$cls_bad $cls_shape(got=$cls_got,want=$cls_want)"
+  done
+  [ -z "$cls_bad" ] \
+    && ok "classifyTableDir separates ok / broken / absent over all seven shapes" \
+    || bad "classifyTableDir misclassified:$cls_bad"
+
+  # The CONSEQUENCE, which is the whole reason the distinction exists: abort-safety turns
+  # `broken` into a hard failure and a non-strict `absent` into a skip. Asserting the status
+  # alone would not catch a future caller that stopped acting on it.
+  cls_gate=$(node -e "
+    global.testPaths = { SSTABLES_DIR: '$WORK/cf-cls-zero-length' };
+    const cf = require('$cf_tree/bindings/node/__test__/corrupt-fixture.js');
+    const r = cf.classifyTableDir('$WORK/cf-cls-zero-length');
+    // Mirrors abort-safety.test.js: HARD_FAIL = broken || (absent && strict)
+    console.log(r.status === 'broken' ? 'hard-fail' : 'skip');" 2>/dev/null)
+  [ "$cls_gate" = "hard-fail" ] \
+    && ok "a truncated fixture hard-fails abort-safety rather than silently skipping" \
+    || bad "a truncated fixture would SKIP abort-safety (#1437 inverted)"
+
+  # RED CONTROL: with the round-48 shape restored (filter to usable, return null otherwise),
+  # a zero-length Data.db must classify as `absent`.
+  cls_red="$WORK/cf-cls-red"; mkdir -p "$cls_red/bindings/node/__test__"
+  cp "$PU_SRC" "$cls_red/bindings/node/__test__/"
+  sed -e "s|  const damaged = candidates.find((dir) => entryExists(path.join(dir, DATA_COMPONENT)));|  const damaged = undefined;|" \
+      "$CF_SRC" > "$cls_red/bindings/node/__test__/corrupt-fixture.js"
+  if grep -q 'const damaged = undefined;' "$cls_red/bindings/node/__test__/corrupt-fixture.js"; then
+    cls_red_got=$(node -e "
+      global.testPaths = { SSTABLES_DIR: '$WORK/cf-cls-zero-length' };
+      const cf = require('$cls_red/bindings/node/__test__/corrupt-fixture.js');
+      console.log(cf.classifyTableDir('$WORK/cf-cls-zero-length').status);" 2>/dev/null)
+    [ "$cls_red_got" = "absent" ] \
+      && ok "RED control: without the damaged branch a truncated fixture reads as 'absent'" \
+      || bad "RED control did not reproduce the collapse (got '$cls_red_got'); the case above proves nothing"
+  else
+    bad "RED control could not plant the round-48 shape (the fix's shape moved)"
+  fi
+else
+  echo "info - node or corrupt-fixture.js unavailable; skipping the classification case"
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  gen_case() {   # <shape> -> "accept" | "reject"
+    local shape=$1 gc d
+    gc="$WORK/manifest-gen-$shape"; rm -rf "$gc"
+    d="$gc/sstables/test_basic/counters-$UUID"; mkdir -p "$d"
+    printf 'x\n'   > "$d/nb-1-big-Data.db"
+    printf 'row\n' > "$d/nb-1-big-Data.db.jsonl"
+    printf 'Data.db\nTOC.txt\n' > "$d/nb-1-big-TOC.txt"
+    case "$shape" in
+      one-good)        : ;;
+      two-good)        printf 'x\n' > "$d/nb-2-big-Data.db"
+                       printf 'Data.db\nTOC.txt\n' > "$d/nb-2-big-TOC.txt" ;;
+      second-zero)     : > "$d/nb-2-big-Data.db"
+                       printf 'Data.db\nTOC.txt\n' > "$d/nb-2-big-TOC.txt" ;;
+      second-no-toc)   printf 'x\n' > "$d/nb-2-big-Data.db" ;;
+      second-partial)  printf 'x\n' > "$d/nb-2-big-Data.db"
+                       printf 'Data.db\nCompressionInfo.db\nTOC.txt\n' > "$d/nb-2-big-TOC.txt" ;;
+      # A file that is NOT a descriptor the reader opens is not a generation at all, and
+      # must not disqualify the table -- the round-24 over-rejection, one level down.
+      junk-sibling)    printf 'x\n' > "$d/junk-Data.db" ;;
+    esac
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$gc" 2>&1 || true)
+    if printf '%s' "$_o" | grep -q 'test_basic/counters'; then echo reject; else echo accept; fi
+  }
+
+  for shape in one-good two-good junk-sibling; do
+    [ "$(gen_case "$shape")" = accept ] \
+      && ok "generation shape '$shape' satisfies the table" \
+      || bad "generation shape '$shape' was rejected, but it is a shape the reader handles"
+  done
+  for shape in second-zero second-no-toc second-partial; do
+    [ "$(gen_case "$shape")" = reject ] \
+      && ok "generation shape '$shape' disqualifies the table (the reader reads them all)" \
+      || bad "generation shape '$shape' was masked by a good FIRST generation"
+  done
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  # 69: the pinned-binary table (test_basic/simple_table names nb-1-big-Data.db).
+  pin_case() {
+    local shape=$1 pc d
+    pc="$WORK/manifest-pin-$shape"; rm -rf "$pc"
+    d="$pc/sstables/test_basic/simple_table-$UUID"; mkdir -p "$d"
+    printf 'x\n'   > "$d/nb-1-big-Data.db"
+    printf 'row\n' > "$d/nb-1-big-Data.db.jsonl"
+    printf 'Data.db\nTOC.txt\n' > "$d/nb-1-big-TOC.txt"
+    case "$shape" in
+      pinned-only)   : ;;
+      second-good)   printf 'x\n' > "$d/nb-2-big-Data.db"
+                     printf 'Data.db\nTOC.txt\n' > "$d/nb-2-big-TOC.txt" ;;
+      second-zero)   : > "$d/nb-2-big-Data.db"
+                     printf 'Data.db\nTOC.txt\n' > "$d/nb-2-big-TOC.txt" ;;
+      second-partial) printf 'x\n' > "$d/nb-2-big-Data.db"
+                      printf 'Data.db\nFilter.db\nTOC.txt\n' > "$d/nb-2-big-TOC.txt" ;;
+    esac
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$pc" 2>&1 || true)
+    if printf '%s' "$_o" | grep -q 'test_basic/simple_table'; then echo reject; else echo accept; fi
+  }
+  for pair in pinned-only:accept second-good:accept second-zero:reject second-partial:reject; do
+    pin_shape=${pair%%:*}; pin_want=${pair#*:}
+    [ "$(pin_case "$pin_shape")" = "$pin_want" ] \
+      && ok "pinned-binary table, '$pin_shape' -> $pin_want" \
+      || bad "pinned-binary table, '$pin_shape': expected $pin_want (a damaged sibling was masked by the pinned nb-1)"
+  done
+
+  # 70: the OA branch. Jest's guard needs a NUMERIC oa-<n>; a non-numeric OA name is
+  # reader-supported (so pass 1 validates it) but does NOT satisfy the guard.
+  oa_case() {
+    local shape=$1 oc d
+    oc="$WORK/manifest-oagen-$shape"; rm -rf "$oc"
+    d="$oc/sstables/test_oa/simple_table-$UUID"; mkdir -p "$d"
+    printf 'x\n'   > "$d/oa-1-big-Data.db"
+    printf 'row\n' > "$d/oa-1-big-Data.db.jsonl"
+    printf 'Data.db\nTOC.txt\n' > "$d/oa-1-big-TOC.txt"
+    case "$shape" in
+      one-oa)        : ;;
+      second-oa-zero) : > "$d/oa-2-big-Data.db"
+                      printf 'Data.db\nTOC.txt\n' > "$d/oa-2-big-TOC.txt" ;;
+      nb-sibling-zero) : > "$d/nb-9-big-Data.db"      # reader-supported, not OA-named
+                       printf 'Data.db\nTOC.txt\n' > "$d/nb-9-big-TOC.txt" ;;
+      uuid-oa-zero)  : > "$d/oa-$UUID-big-Data.db"    # reader-supported, NOT numeric
+                     printf 'Data.db\nTOC.txt\n' > "$d/oa-$UUID-big-TOC.txt" ;;
+    esac
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$oc" 2>&1 || true)
+    if printf '%s' "$_o" | grep -q 'test_oa/simple_table'; then echo reject; else echo accept; fi
+  }
+  for pair in one-oa:accept second-oa-zero:reject nb-sibling-zero:reject uuid-oa-zero:reject; do
+    oa_shape=${pair%%:*}; oa_want=${pair#*:}
+    [ "$(oa_case "$oa_shape")" = "$oa_want" ] \
+      && ok "OA table, '$oa_shape' -> $oa_want" \
+      || bad "OA table, '$oa_shape': expected $oa_want (an unusable sibling generation was ignored)"
+  done
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  # dg_case <keyspace/table> <table-dir-prefix> <shape> -> the FIRST diagnostic, trimmed
+  dg_case() {
+    local entry=$1 pfx=$2 shape=$3 root d ks tbl
+    ks=${entry%%/*}; tbl=${entry#*/}
+    root="$WORK/manifest-dg-$ks-$tbl-$shape"; rm -rf "$root"
+    d="$root/sstables/$ks/$tbl-$UUID"; mkdir -p "$d"
+    # A VALID generation is always present, so every reject below is caused by the SIBLING
+    # and never by the table being empty.
+    printf 'x\n' > "$d/$pfx-1-big-Data.db"
+    printf 'Data.db\nTOC.txt\n' > "$d/$pfx-1-big-TOC.txt"
+    case "$ks" in
+      test_oa) printf 'row\n' > "$d/oa-1-big-Data.db.jsonl" ;;
+      *)       printf 'row\n' > "$d/nb-1-big-Data.db.jsonl" ;;
+    esac
+    case "$shape" in
+      valid-only)  : ;;
+      dangling)    ln -s "$d/nowhere" "$d/$pfx-2-big-Data.db" ;;
+      directory)   mkdir -p "$d/$pfx-2-big-Data.db" ;;
+      zero-length) : > "$d/$pfx-2-big-Data.db"
+                   printf 'Data.db\nTOC.txt\n' > "$d/$pfx-2-big-TOC.txt" ;;
+    esac
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$root" 2>&1 || true)
+    printf '%s\n' "$_o" | grep -F "$entry" | head -1
+  }
+
+  # 71: each shape names ITS OWN cause.
+  dg_out=$(dg_case test_basic/counters nb directory)
+  printf '%s' "$dg_out" | grep -q 'NOT A REGULAR FILE' \
+    && ok "a directory-valued Data.db is reported as NOT A REGULAR FILE, not as zero-length" \
+    || bad "directory-valued Data.db misattributed: $dg_out"
+  dg_out=$(dg_case test_basic/counters nb zero-length)
+  printf '%s' "$dg_out" | grep -q 'ZERO-LENGTH' \
+    && ok "a zero-length Data.db is still reported as ZERO-LENGTH (truncated fetch)" \
+    || bad "zero-length Data.db misattributed: $dg_out"
+
+  # 72: a dangling sibling rejects in EVERY branch -- general, pinned, OA.
+  for spec in test_basic/counters:nb test_basic/simple_table:nb test_oa/simple_table:oa; do
+    dg_entry=${spec%%:*}; dg_pfx=${spec#*:}
+    # Control first: without the sibling the table is ACCEPTED, so the reject below is
+    # attributable to the dangling sibling and not to a fixture this case builds wrong.
+    if [ -z "$(dg_case "$dg_entry" "$dg_pfx" valid-only)" ]; then
+      dg_out=$(dg_case "$dg_entry" "$dg_pfx" dangling)
+      if printf '%s' "$dg_out" | grep -q 'NOT A REGULAR FILE'; then
+        ok "$dg_entry: a DANGLING sibling generation disqualifies the table, and is named"
+      else
+        bad "$dg_entry: a dangling sibling was skipped or misnamed: ${dg_out:-<accepted>}"
+      fi
+    else
+      bad "$dg_entry: the valid-only control was REJECTED, so the dangling case proves nothing"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  cause_msg() {   # <cause> -> the diagnostic's first 60 chars, or "" if none
+    local cause=$1 root t ks=test_basic tb=counters
+    case "$cause" in oa_bad) ks=test_oa; tb=simple_table ;; esac
+    root="$WORK/manifest-cause-$cause"; rm -rf "$root"
+    t="$root/sstables/$ks/$tb-$UUID"; mkdir -p "$t"
+    case "$cause" in
+      type_bad)   printf 'row\n' > "$t/nb-1-big-Data.db.jsonl"; mkdir -p "$t/nb-1-big-Data.db" ;;
+      unread_bad) printf 'row\n' > "$t/nb-1-big-Data.db.jsonl"; printf 'x\n' > "$t/nb-1-big-Data.db"
+                  chmod 000 "$t/nb-1-big-Data.db"; printf 'Data.db\nTOC.txt\n' > "$t/nb-1-big-TOC.txt" ;;
+      empty_bad)  printf 'row\n' > "$t/nb-1-big-Data.db.jsonl"; : > "$t/nb-1-big-Data.db" ;;
+      oa_bad)     printf 'row\n' > "$t/oa-1-big-Data.db.jsonl"; printf 'x\n' > "$t/nb-1-big-Data.db"
+                  printf 'Data.db\nTOC.txt\n' > "$t/nb-1-big-TOC.txt" ;;
+      name_bad)   printf 'row\n' > "$t/nb-1-big-Data.db.jsonl"; printf 'x\n' > "$t/junk-Data.db" ;;
+      golden_bad) printf 'x\n' > "$t/nb-1-big-Data.db"; printf 'Data.db\nTOC.txt\n' > "$t/nb-1-big-TOC.txt" ;;
+      toc_bad)    printf 'row\n' > "$t/nb-1-big-Data.db.jsonl"; printf 'x\n' > "$t/nb-1-big-Data.db"
+                  printf 'Data.db\nFilter.db\nTOC.txt\n' > "$t/nb-1-big-TOC.txt" ;;
+    esac
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$root" 2>&1 || true)
+    # The table-specific line, never the generic "missing Data.db" summary line.
+    printf '%s\n' "$_o" | grep -F "$ks/$tb" | grep -v 'missing Data.db for expected table' \
+      | head -1 | cut -c1-60
+    chmod 0644 "$t/nb-1-big-Data.db" 2>/dev/null || true   # so _cleanup can remove it
+  }
+
+  cause_unreached=""; cause_msgs=""
+  for cause in type_bad unread_bad empty_bad oa_bad name_bad golden_bad toc_bad; do
+    cm=$(cause_msg "$cause")
+    if [ -z "$cm" ]; then
+      cause_unreached="$cause_unreached $cause"
+    else
+      cause_msgs="$cause_msgs$cm"$'\n'
+    fi
+  done
+  [ -z "$cause_unreached" ] \
+    && ok "all seven manifest failure causes are reachable" \
+    || bad "manifest cause(s) went dark (no diagnostic emitted):$cause_unreached"
+
+  cause_n=$(printf '%s' "$cause_msgs" | grep -c . || true)
+  cause_u=$(printf '%s' "$cause_msgs" | sort -u | grep -c . || true)
+  [ "$cause_n" -eq 7 ] && [ "$cause_u" -eq 7 ] \
+    && ok "all seven causes emit DISTINCT diagnostics (no cause borrows another's message)" \
+    || bad "manifest diagnostics are not pairwise distinct ($cause_u distinct of $cause_n emitted)"
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  empty_comp_case() {   # <component> -> "accept" | "reject"
+    local comp=$1 ec d
+    ec="$WORK/manifest-emptycomp-${comp%.db}"; rm -rf "$ec"
+    d="$ec/sstables/test_basic/counters-$UUID"; mkdir -p "$d"
+    printf 'x\n'   > "$d/nb-1-big-Data.db"
+    printf 'row\n' > "$d/nb-1-big-Data.db.jsonl"
+    printf 'Data.db\n%s\nTOC.txt\n' "$comp" > "$d/nb-1-big-TOC.txt"
+    : > "$d/nb-1-big-$comp"                      # the component exists but is ZERO-LENGTH
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$ec" 2>&1 || true)
+    if printf '%s' "$_o" | grep -q 'test_basic/counters'; then echo reject; else echo accept; fi
+  }
+
+  # The two measured to produce a silently-wrong read, plus three that are merely tolerated
+  # -- all rejected, because the rule is "nonempty unless allowlisted" and none of these was
+  # ever observed empty in real data.
+  for comp in CompressionInfo.db Statistics.db Filter.db Index.db Summary.db; do
+    [ "$(empty_comp_case "$comp")" = reject ] \
+      && ok "a zero-length $comp disqualifies the generation" \
+      || bad "a zero-length $comp was accepted; the reader can return 0 rows over it"
+  done
+  # The ACCEPT control, and the reason the rule is an allowlist rather than a blanket:
+  # without this a rule that rejected EVERY empty companion would pass the cases above while
+  # red-lining three real BTI generations.
+  [ "$(empty_comp_case Rows.db)" = accept ] \
+    && ok "a zero-length Rows.db is still accepted (a real, measured BTI state)" \
+    || bad "a zero-length Rows.db was rejected; that reds 3 generations of the real corpus"
+fi
+
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  # (a) the predicate itself, against the JS consumer's answer as the ORACLE.
+  if command -v node >/dev/null 2>&1; then
+    nl_re='^oa-[0-9]+-big-Data\.db$'
+    nl_bad=""
+    # label:value -- a plain name, the two-line attack, and a leading-newline variant.
+    nl_plain='oa-1-big-Data.db'
+    nl_two=$(printf 'oa-x\noa-1-big-Data.db')
+    nl_lead=$(printf '\noa-1-big-Data.db')
+    for nl_pair in "plain:$nl_plain" "embedded-newline:$nl_two" "leading-newline:$nl_lead"; do
+      nl_lbl=${nl_pair%%:*}; nl_val=${nl_pair#*:}
+      nl_js=$(node -e "process.stdout.write(/^oa-\d+-big-Data\.db$/.test(process.argv[1]) ? 'yes' : 'no')" "$nl_val" 2>/dev/null)
+      nl_sh=$(NO_AUTO_TOC=1 bash -c '
+        eval "$(sed -n "/^_re_match() {/,/^}/p" "$1")"
+        _re_match "$2" "$3" && printf yes || printf no' _ "$MANIFEST_NOGIT" "$nl_re" "$nl_val")
+      [ "$nl_js" = "$nl_sh" ] || nl_bad="$nl_bad $nl_lbl(js=$nl_js,sh=$nl_sh)"
+    done
+    [ -z "$nl_bad" ] \
+      && ok "_re_match agrees with the JS consumer on newline-bearing values" \
+      || bad "_re_match disagrees with the JS consumer:$nl_bad"
+  else
+    echo "info - node unavailable; skipping the whole-string match differential"
+  fi
+
+  # (b) a helper exiting with the RESERVED 9 must surface as a MALFUNCTION, never as the
+  #     corpus verdict. Shadow `sort` so the committed-set derivation fails with exactly 9.
+  #
+  #     Uses MANIFEST_SRC, the REAL in-repo script, not the nogit copy: the derivation only
+  #     runs when the script sits inside a git work tree, so the copy skips the block
+  #     entirely and the case would pass while exercising nothing. That mistake was made
+  #     first -- an out-of-git copy "proved" the guard worked when the guarded code had not
+  #     run at all.
+  #
+  #     And the corpus must be one that would otherwise SUCCEED. Against an empty corpus a 9
+  #     is the CORRECT verdict, so the assertion could not tell a right answer from a wrong
+  #     one -- also got wrong on the first attempt.
+  if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}" ] \
+     && bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1; then
+    nine_bin="$WORK/nine-bin"; mkdir -p "$nine_bin"
+    printf '#!/bin/sh\nexit 9\n' > "$nine_bin/sort"; chmod +x "$nine_bin/sort"
+    nine_rc=0
+    PATH="$nine_bin:$PATH" bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >/dev/null 2>&1 || nine_rc=$?
+    [ "$nine_rc" = 2 ] \
+      && ok "a helper exiting 9 is reported as a MALFUNCTION (exit 2), not the corpus verdict" \
+      || bad "a helper exiting 9 gave exit $nine_rc; 9 would be read as a judged verdict and suppressed by the opt-out"
+  else
+    echo "info - no succeeding real corpus available; skipping the reserved-exit case"
+  fi
+fi
+
+echo "----"
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1896,6 +1896,53 @@ if [ -n "$MANIFEST_NOGIT" ]; then
     || bad "normalised-TOC temp files were left in ${TMPDIR:-/tmp}"
 fi
 
+# ---------------------------------------------------------------------------
+# Case 86 (post-rebase round 8, Low): INT/TERM must RE-RAISE, not swallow.
+#
+# A handler that cleans up and RETURNS lets a CANCELLED run carry on — past temp files it
+# has just deleted — and emit a corpus or tooling verdict for work that was interrupted. The
+# handler resets the trap and re-raises, so the script dies with the conventional 130/143.
+#
+# Driven on the trap functions in isolation: the real script finishes in about a second on a
+# warm corpus, so a signal aimed at a full run lands after it has already exited — an earlier
+# attempt "passed" that way while testing nothing.
+#
+# TERM, NOT INT. A NON-INTERACTIVE shell sets SIGINT to IGNORE for its background children,
+# and POSIX says a signal ignored on entry CANNOT be trapped — so the probe could never catch
+# an INT sent from this suite, and the case reported the handler had "swallowed" it. It had
+# not: standalone, INT gives 130 correctly. TERM is not ignored for background jobs, so it
+# tests the same handler through a path this harness can actually drive.
+# ---------------------------------------------------------------------------
+sig_script="$WORK/sig-probe.sh"
+cat >"$sig_script" <<SIGPROBE
+eval "\$(sed -n '/^_TMP_FILES=()/,/^trap ._cleanup_tmp_signal TERM. TERM/p' "$MANIFEST_SRC")"
+f=\$(mktemp "\${TMPDIR:-/tmp}/cqlite-toc-sigcase.XXXXXX"); _register_tmp "\$f"
+printf '%s' "\$f" > "$WORK/sig-path"
+# A LOOP OF SHORT SLEEPS, not one long one: bash defers a trap until the foreground command
+# returns, so a single `sleep 30` outlives the test's `wait` and the handler appears to have
+# swallowed the signal when it has merely not run yet. That is how the first version of this
+# case reported a false failure.
+i=0
+while [ "\$i" -lt 150 ]; do sleep 0.2; i=\$((i + 1)); done
+printf 'REACHED-AFTER-SIGNAL' >> "$WORK/sig-path"
+SIGPROBE
+bash "$sig_script" & sig_pid=$!
+sleep 2
+kill -TERM "$sig_pid" 2>/dev/null
+wait "$sig_pid" 2>/dev/null; sig_rc=$?
+sig_file=$(cat "$WORK/sig-path" 2>/dev/null)
+case "$sig_file" in
+  *REACHED-AFTER-SIGNAL) bad "the TERM handler SWALLOWED the signal; a cancelled run would carry on and emit a verdict" ;;
+  "")                    bad "the signal probe did not run; case 86 proves nothing" ;;
+  *)
+    [ "$sig_rc" = 143 ] \
+      && ok "SIGTERM is re-raised (exit 143), not swallowed" \
+      || bad "SIGTERM gave exit $sig_rc; expected 143 (re-raised)"
+    [ -f "$sig_file" ] \
+      && bad "the registered temp file survived the signal; cleanup did not run" \
+      || ok "the registered temp file is cleaned up before the signal is re-raised" ;;
+esac
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1501,6 +1501,77 @@ if [ -n "$MANIFEST_NOGIT" ]; then
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# Cases 77-78 (post-rebase review): prefix collision, and a TRUNCATED TOC.
+#
+# 77. Production discovery is a bare `filename.ends_with("-Data.db")`, and
+#     `SSTableComponent::from_filename` maps ANY such name to the Data component -- so a
+#     file sharing a REAL generation's prefix is read as that generation's Data component.
+#     Measured with garbage bytes beside a healthy nb-1:
+#       nb-1-big-Foo-Data.db -> the query THROWS   (shares the prefix)
+#       junk-Data.db         -> 100 rows           (discovered, open fails, SKIPPED)
+#       nb-9-big-Data.db     -> 100 rows           (valid descriptor, other generation)
+#       xx-1-big / nb-foo-big -> 100 rows
+#     So the fatal shape is NARROW. Rejecting every odd `*-Data.db` would red on input the
+#     reader demonstrably tolerates, which is why the accept controls are here.
+#
+# 78. TOC validation used the TOC as the required set, trusting it as a COMPLETE inventory.
+#     A truncated-but-nonempty TOC listing only `Data.db` then passed, and the components
+#     this check exists to catch went missing unopposed.
+# ---------------------------------------------------------------------------
+if [ -n "$MANIFEST_NOGIT" ]; then
+  pc_case() {   # <shape> -> accept | reject
+    local shape=$1 root t
+    root="$WORK/manifest-pc-$shape"; rm -rf "$root"
+    t="$root/sstables/test_basic/counters-$UUID"; mkdir -p "$t"
+    printf 'x\n'   > "$t/nb-1-big-Data.db"
+    printf 'row\n' > "$t/nb-1-big-Data.db.jsonl"
+    printf 'Data.db\nStatistics.db\nFilter.db\nDigest.crc32\nTOC.txt\n' > "$t/nb-1-big-TOC.txt"
+    for _m in Statistics.db Filter.db Digest.crc32; do printf 'x\n' > "$t/nb-1-big-$_m"; done
+    case "$shape" in
+      clean)            : ;;
+      junk-sibling)     printf 'x\n' > "$t/junk-Data.db" ;;
+      other-generation) printf 'x\n' > "$t/nb-9-big-Data.db"
+                        printf 'Data.db\nStatistics.db\nFilter.db\nDigest.crc32\nTOC.txt\n' > "$t/nb-9-big-TOC.txt"
+                        for _m in Statistics.db Filter.db Digest.crc32; do printf 'x\n' > "$t/nb-9-big-$_m"; done ;;
+      prefix-collision) printf 'x\n' > "$t/nb-1-big-Foo-Data.db" ;;
+      truncated-toc)    printf 'Data.db\n' > "$t/nb-1-big-TOC.txt" ;;
+      toc-omits-stats)  printf 'Data.db\nTOC.txt\n' > "$t/nb-1-big-TOC.txt"
+                        rm -f "$t/nb-1-big-Statistics.db" ;;
+    esac
+    local _o; _o=$(NO_AUTO_TOC=1 mrun "$root" 2>&1 || true)
+    if printf '%s' "$_o" | grep -q 'test_basic/counters'; then echo reject; else echo accept; fi
+  }
+
+  # ACCEPT controls first: without them a manifest that rejected everything would pass the
+  # reject cases and look correct, and these three are shapes the reader TOLERATES.
+  for shape in clean junk-sibling other-generation; do
+    [ "$(pc_case "$shape")" = accept ] \
+      && ok "generation shape '$shape' is accepted (the reader tolerates it)" \
+      || bad "generation shape '$shape' was rejected, but the reader tolerates it"
+  done
+  # NOTE ON WHAT THIS PAIR PROVES. The reject verdict alone is NOT discriminating: the
+  # bidirectional TOC check independently disqualifies a colliding file (it shares the
+  # prefix and is not TOC-listed), so deleting the dedicated collision branch leaves this
+  # assertion GREEN. Verified by planting exactly that. The DIAGNOSTIC assert below is the
+  # one that discriminates, and it is why the branch is kept -- without it the operator is
+  # told "no Data.db the reader would open" about a directory whose Data.db is fine.
+  [ "$(pc_case prefix-collision)" = reject ] \
+    && ok "a *-Data.db sharing a real generation's prefix disqualifies the table" \
+    || bad "a prefix-colliding *-Data.db was accepted; the reader maps it to that generation and FAILS"
+  # The collision must be NAMED, not reported as some other cause.
+  pc_out=$(NO_AUTO_TOC=1 mrun "$WORK/manifest-pc-prefix-collision" 2>&1 || true)
+  printf '%s' "$pc_out" | grep -q "SHARES a real generation's prefix" \
+    && ok "the prefix-collision diagnostic names its own cause" \
+    || bad "the prefix collision was reported as something else: $(printf '%s' "$pc_out" | grep 'test_basic/counters' | head -1)"
+
+  for shape in truncated-toc toc-omits-stats; do
+    [ "$(pc_case "$shape")" = reject ] \
+      && ok "TOC shape '$shape' disqualifies the table (the TOC is not a trusted inventory)" \
+      || bad "TOC shape '$shape' was accepted; a truncated TOC shrank the required set"
+  done
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1775,6 +1775,44 @@ else
   echo "info - no passing real corpus available; skipping the cmp-malfunction case"
 fi
 
+# ---------------------------------------------------------------------------
+# Case 83 (post-rebase round 4 self-audit): the trusted-inventory check must actually be
+# REACHED on the real corpus.
+#
+# A no-twin generation legitimately falls back to the derived checks — which is the right
+# behaviour, and also a perfect hiding place. If a future change broke the corpus-path ->
+# repo-path mapping, EVERY generation would fall back, the High-severity coherent-truncation
+# gap would reopen, and nothing would say so: the manifest would still print a green 39/39.
+#
+# So the positive fact is asserted rather than assumed (a positive verdict needs an
+# AFFIRMATIVE measurement, not the absence of a complaint). Measured today: 144 of 144
+# generations resolve a committed twin, 0 fall back.
+# ---------------------------------------------------------------------------
+if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ] \
+   && command -v git >/dev/null 2>&1; then
+  tr_repo=$(cd "$(dirname "$GATE")/.." && pwd)
+  tr_counts=$(_SCRIPT_REPO="$tr_repo" bash -c '
+    _SCRIPT_REPO=$1; _SCRIPT_REPO_IS_GIT=1
+    eval "$(sed -n "/^_committed_toc_relpath() {/,/^}/p" "$2")"
+    have=0; none=0
+    while IFS= read -r f; do
+      toc="${f%Data.db}TOC.txt"; [ -f "$toc" ] || continue
+      _committed_toc_relpath "$toc"
+      if [ -n "$_C_TOC_REL" ]; then have=$((have+1)); else none=$((none+1)); fi
+    done < <(find "$3/sstables" -mindepth 3 -maxdepth 3 -name "*-Data.db" 2>/dev/null)
+    printf "%s %s" "$have" "$none"' _ "$tr_repo" "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT")
+  tr_have=${tr_counts%% *}; tr_none=${tr_counts##* }
+  if [ "${tr_have:-0}" -gt 0 ] && [ "${tr_none:-1}" -eq 0 ]; then
+    ok "every generation on the real corpus resolves a committed twin ($tr_have/$tr_have; 0 fall back)"
+  elif [ "${tr_have:-0}" -eq 0 ]; then
+    bad "NO generation resolved a committed twin — the corpus-path to repo-path mapping is broken, and every generation silently falls back to the derived checks"
+  else
+    bad "$tr_none of $((tr_have + tr_none)) generations fall back to the derived checks; the trusted-inventory check is partly unreached"
+  fi
+else
+  echo "info - no real corpus or no git; skipping the twin-reachability census"
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -1689,9 +1689,12 @@ if command -v git >/dev/null 2>&1; then
   ) >/dev/null 2>&1
 
   tw_probe() {   # -> "match" | "mismatch"
+    # Sources BOTH helpers and sets _SCRIPT_REPO_IS_GIT: existence moved out of
+    # `_toc_matches_head` into `_toc_twin_at_head` (round 11), and a probe that sourced only
+    # the former silently lost the HEAD lookup — these two cases caught that immediately.
     _SCRIPT_REPO="$tw_repo" bash -c '
-      _SCRIPT_REPO=$1
-      eval "$(sed -n "/^_toc_matches_head() {/,/^}/p" "$2")"
+      _SCRIPT_REPO=$1; _SCRIPT_REPO_IS_GIT=1
+      eval "$(sed -n "/^_toc_twin_at_head() {/,/^}/p;/^_toc_matches_head() {/,/^}/p" "$2")"
       _toc_matches_head "$3" "$4" && printf match || printf mismatch' \
       _ "$tw_repo" "$MANIFEST_SRC" "$tw_repo/$tw_rel" "$tw_rel"
   }
@@ -1734,8 +1737,8 @@ GITFAIL
     chmod +x "$tw_gbin/git"
     tw_grc=0
     PATH="$tw_gbin:$PATH" bash -c '
-      _SCRIPT_REPO=$1
-      eval "$(sed -n "/^_toc_matches_head() {/,/^}/p" "$2")"
+      _SCRIPT_REPO=$1; _SCRIPT_REPO_IS_GIT=1
+      eval "$(sed -n "/^_toc_twin_at_head() {/,/^}/p;/^_toc_matches_head() {/,/^}/p" "$2")"
       _toc_matches_head "$3" "$4"' _ "$tw_repo" "$MANIFEST_SRC" "$tw_repo/$tw_rel" "$tw_rel" \
       >/dev/null 2>&1 || tw_grc=$?
     [ "$tw_grc" = 2 ] \
@@ -1797,12 +1800,19 @@ if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstable
     # not the first "/sstables/"), so the probe has to establish it exactly as the script
     # does. This assertion caught that coupling the moment it was introduced.
     SSTABLES="$3/sstables"
-    eval "$(sed -n "/^_committed_toc_relpath() {/,/^}/p" "$2")"
+    # BOTH helpers. `_committed_toc_relpath` became a PURE MAPPING in round 11 (existence
+    # moved to `_toc_twin_at_head`, against HEAD rather than the index), so asking it alone
+    # would now answer "twin resolved" for ANY path and the census would be vacuous.
+    eval "$(sed -n "/^_committed_toc_relpath() {/,/^}/p;/^_toc_twin_at_head() {/,/^}/p" "$2")"
     have=0; none=0
     while IFS= read -r f; do
       toc="${f%Data.db}TOC.txt"; [ -f "$toc" ] || continue
       _committed_toc_relpath "$toc"
-      if [ -n "$_C_TOC_REL" ]; then have=$((have+1)); else none=$((none+1)); fi
+      if [ -n "$_C_TOC_REL" ] && _toc_twin_at_head "$_C_TOC_REL"; then
+        have=$((have+1))
+      else
+        none=$((none+1))
+      fi
     done < <(find "$3/sstables" -mindepth 3 -maxdepth 3 -name "*-Data.db" 2>/dev/null)
     printf "%s %s" "$have" "$none"' _ "$tr_repo" "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT")
   tr_have=${tr_counts%% *}; tr_none=${tr_counts##* }
@@ -2004,6 +2014,51 @@ if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstable
   fi
 else
   echo "info - no real corpus, a tool is missing ($gf_missing), or git leaked into the farm; skipping the no-git case"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 88 (post-rebase round 11, Medium): a TOC STAGED FOR DELETION still has a twin at HEAD.
+#
+# Existence used to be answered by `git ls-files --error-unmatch`, which is INDEX-based. A
+# tracked TOC staged for deletion reads as UNTRACKED there, so the twin comparison was
+# skipped — while HEAD still holds the inventory. A coherently truncated corpus could then
+# pass on the derived checks alone, which is precisely the gap the trusted inventory exists
+# to close.
+#
+# `ls-tree HEAD` is now the single authority, so the index cannot make HEAD invisible.
+# ---------------------------------------------------------------------------
+if command -v git >/dev/null 2>&1; then
+  sd_repo="$WORK/staged-del-repo"
+  sd_rel="test-data/datasets/sstables/test_basic/simple_table-$UUID/nb-1-big-TOC.txt"
+  mkdir -p "$sd_repo/$(dirname "$sd_rel")"
+  printf 'Data.db\nStatistics.db\nTOC.txt\n' > "$sd_repo/$sd_rel"
+  (
+    cd "$sd_repo" || exit 1
+    git init -q . && git config user.email t@t && git config user.name t \
+      && git add "$sd_rel" && git commit -qm "committed inventory" \
+      && git rm --cached -q "$sd_rel"          # STAGED FOR DELETION; HEAD still has it
+  ) >/dev/null 2>&1
+
+  if [ -d "$sd_repo/.git" ]; then
+    sd_seen=$(_SCRIPT_REPO="$sd_repo" bash -c '
+      _SCRIPT_REPO=$1; _SCRIPT_REPO_IS_GIT=1
+      eval "$(sed -n "/^_toc_twin_at_head() {/,/^}/p" "$2")"
+      _toc_twin_at_head "$3" && printf present || printf absent' \
+      _ "$sd_repo" "$MANIFEST_SRC" "$sd_rel")
+    # Control: `ls-files` (the index) genuinely disagrees, which is what made this a defect.
+    sd_index=$(cd "$sd_repo" && git ls-files --error-unmatch "$sd_rel" >/dev/null 2>&1 \
+                 && printf tracked || printf untracked)
+    [ "$sd_index" = untracked ] \
+      && ok "the index reports a staged-for-deletion TOC as untracked (the control)" \
+      || bad "the staged deletion did not take effect; case 88 proves nothing"
+    [ "$sd_seen" = present ] \
+      && ok "a TOC staged for deletion still resolves its twin AT HEAD (the index cannot hide it)" \
+      || bad "a staged-for-deletion TOC read as having no twin; the trusted comparison would be skipped"
+  else
+    echo "info - could not create the staged-deletion repo; skipping"
+  fi
+else
+  echo "info - git unavailable; skipping the staged-deletion case"
 fi
 
 echo "----"

--- a/scripts/tests/test_check_dataset_manifest.sh
+++ b/scripts/tests/test_check_dataset_manifest.sh
@@ -2061,6 +2061,68 @@ else
   echo "info - git unavailable; skipping the staged-deletion case"
 fi
 
+# ---------------------------------------------------------------------------
+# Cases 89-90 (post-rebase round 12): a broken iconv, and a control-char probe that cannot run.
+#
+# 89. GNU iconv exits 1 for EVERY failure — invalid input, unknown encoding, unreadable file
+#     (measured, all three) — so a nonzero status cannot on its own distinguish "this name is
+#     bad" from "iconv is broken". Collapsed, a broken iconv rejects EVERY descriptor, every
+#     table reads as missing, and the run ends in the reserved exit 9 that the #2078 opt-out
+#     suppresses as an incomplete corpus. There is no exit code that separates them, so the
+#     script establishes the separation with a known-good round-trip probe at startup.
+#
+# 90. `_gate_has_control_char` spawns bash through PATH and callers read it as a boolean, so a
+#     subprocess that cannot launch read as "no control character" — and a control-bearing
+#     schemas root would pass a preflight the node binding then rejects.
+# ---------------------------------------------------------------------------
+if [ -n "${CQLITE_DATASETS_ROOT:-}" ] && [ -d "${CQLITE_DATASETS_ROOT:-}/sstables" ]; then
+  ic_bin="$WORK/iconvfail-bin"; mkdir -p "$ic_bin"
+  printf '#!/bin/sh\nexit 1\n' > "$ic_bin/iconv"; chmod +x "$ic_bin/iconv"
+  ic_rc=0
+  PATH="$ic_bin:$PATH" bash "$MANIFEST_SRC" "$CQLITE_DATASETS_ROOT" >"$WORK/ic-out" 2>&1 || ic_rc=$?
+  if [ "$ic_rc" = 2 ]; then
+    ok "a broken iconv is a tooling failure (exit 2), not an incomplete corpus"
+  elif [ "$ic_rc" = 9 ]; then
+    bad "a broken iconv surfaced AS exit 9; the opt-out would suppress it as an incomplete corpus"
+  else
+    bad "a broken iconv gave exit $ic_rc; expected 2"
+  fi
+  # It must say WHY, or the operator hunts a corpus problem that does not exist.
+  grep -q 'iconv' "$WORK/ic-out" 2>/dev/null \
+    && ok "the broken-iconv diagnostic names iconv" \
+    || bad "the broken-iconv diagnostic does not name iconv: $(head -1 "$WORK/ic-out")"
+else
+  echo "info - no real corpus; skipping the iconv case"
+fi
+
+GATE_SRC2=$(cd "$(dirname "$GATE")" && pwd)/agent-gate.sh
+if [ -f "$GATE_SRC2" ]; then
+  # PRESENT / ABSENT / UNLAUNCHABLE. The third must behave like PRESENT (refuse the override),
+  # never like ABSENT (certify it).
+  # The OUTER bash is resolved ABSOLUTELY and the broken PATH is set INSIDE, just before the
+  # call. Setting it on the outer invocation stops bash itself from launching, so the probe
+  # produces nothing and the case fails for the wrong reason — which is what the first version
+  # did.
+  cc_bash=$(type -P bash)
+  cc_probe() {   # $1 = PATH for the CALL, $2 = value -> "present" | "absent"
+    "$cc_bash" -c '
+      eval "$(sed -n "/^_gate_has_control_char() {/,/^}/p" "$1")"
+      PATH=$3
+      _gate_has_control_char "$2" && printf present || printf absent' _ "$GATE_SRC2" "$2" "$1" 2>/dev/null
+  }
+  cc_bad=""
+  [ "$(cc_probe "$PATH" "/plain/path")" = absent ] || cc_bad="$cc_bad clean-path"
+  [ "$(cc_probe "$PATH" "$(printf '/a/\001b')")" = present ] || cc_bad="$cc_bad c0-control"
+  # The whole point: with bash unreachable the probe cannot answer, and an unanswerable
+  # question must not be certified.
+  [ "$(cc_probe "/nonexistent" "/plain/path")" = present ] || cc_bad="$cc_bad unlaunchable-fails-open"
+  [ -z "$cc_bad" ] \
+    && ok "the control-char probe is three-valued and fails CLOSED when it cannot run" \
+    || bad "control-char probe wrong on:$cc_bad"
+else
+  echo "info - agent-gate.sh unreadable; skipping the control-char probe case"
+fi
+
 echo "----"
 echo "passed: $PASS  failed: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -18,6 +18,21 @@ set -euo pipefail
 ROOT="${1:-test-data/datasets}"
 SSTABLES="${ROOT}/sstables"
 
+# TEMP-FILE REGISTRY + EXIT TRAP (roborev, post-rebase round 7 self-audit).
+#
+# Several paths in this script `exit 2` on a tooling malfunction, and an `exit` skips every
+# in-line `rm -f` the caller would have reached. Removing each file at each return site is
+# what I tried first: it handles the RETURN paths and silently misses the EXIT ones, which is
+# exactly the set the self-test exercises — so a leak assertion caught files in /tmp that a
+# happy-path check had reported clean.
+#
+# A trap is the only cleanup that survives an exit, so registration is the single rule:
+# anything mktemp'd here gets registered on the line it is created.
+_TMP_FILES=""
+_register_tmp() { _TMP_FILES="$_TMP_FILES $1"; }
+_cleanup_tmp() { [ -n "$_TMP_FILES" ] && rm -f $_TMP_FILES; return 0; }
+trap _cleanup_tmp EXIT INT TERM
+
 # Expected user-keyspace tables (39 total: 33 nb + 6 test_oa).
 #
 # SINGLE SOURCE OF TRUTH (intent): this list is hand-duplicated from the corpus
@@ -160,7 +175,7 @@ if [ -n "$_SCRIPT_REPO" ] \
   # the script's own output, which still prints a green 39/39, because the fallback is a
   # legitimate state -- exactly the vacuous-pass shape this whole change is about. Caught
   # only by counting the derived entries.
-  _ls_tmp=$(mktemp) || {
+  _ls_tmp=$(mktemp) && _register_tmp "$_ls_tmp" || {
     echo "❌ dataset manifest check: mktemp failed; cannot derive the committed table set" >&2
     exit 2
   }
@@ -424,19 +439,38 @@ _toc_companions_usable() {
   _t_prefix=${1%Data.db}
   _t_toc="${_t_prefix}TOC.txt"
   _usable_file "$_t_toc" || return 1
+  # NORMALISE ONCE, then use the normalised copy for BOTH directions (roborev, post-rebase
+  # round 7). CRLF was stripped in the forward loop and again in the twin comparison, but the
+  # REVERSE reconciliation grepped the RAW file with `grep -qxF` -- and `-x` matches whole
+  # lines, so every line's trailing `\r` made every component read as "not listed" and a
+  # perfectly valid CRLF TOC was rejected as incomplete. Verified before fixing.
+  #
+  # Three places stripping the same thing is what allowed one to be missed; one normalised
+  # copy is why it cannot happen again.
+  # mktemp, for the same reason `_toc_matches_head` uses it: a predictable path in a shared
+  # /tmp is a symlink target, and a stale one would be read as this generation's TOC.
+  _TOC_NORM=$(mktemp "${TMPDIR:-/tmp}/cqlite-toc-norm.XXXXXX") || {
+    echo "❌ dataset manifest check: mktemp failed; cannot normalise the TOC" >&2
+    exit 2
+  }
+  _register_tmp "$_TOC_NORM"
+  if ! tr -d '\r' <"$_t_toc" >"$_TOC_NORM"; then
+    rm -f "$_TOC_NORM"
+    echo "❌ dataset manifest check: could not normalise $_t_toc; cannot judge the corpus" >&2
+    exit 2
+  fi
   while IFS= read -r _t_c || [ -n "$_t_c" ]; do
-    _t_c=${_t_c%$'\r'}                       # tolerate CRLF
     [ -n "$_t_c" ] || continue               # blank lines are not components
     # A component NAME, never a path: a TOC entry that escapes its own directory is
     # malformed, and resolving it would validate a file in a different generation.
-    case "$_t_c" in */*|.|..) return 1 ;; esac
+    case "$_t_c" in */*|.|..) rm -f "$_TOC_NORM"; return 1 ;; esac
     _t_p="${_t_prefix}${_t_c}"
-    [ -f "$_t_p" ] && [ -r "$_t_p" ] || return 1
+    [ -f "$_t_p" ] && [ -r "$_t_p" ] || { rm -f "$_TOC_NORM"; return 1; }
     case " $_TOC_MAY_BE_EMPTY " in
       *" $_t_c "*) : ;;                      # allowlisted: empty is a legitimate state
-      *) [ -s "$_t_p" ] || return 1 ;;
+      *) [ -s "$_t_p" ] || { rm -f "$_TOC_NORM"; return 1; } ;;
     esac
-  done < "$_t_toc"
+  done < "$_TOC_NORM"
   # BIDIRECTIONAL (roborev #3493, post-rebase round). The loop above proves every LISTED
   # component exists; on its own that trusts the TOC as a COMPLETE inventory, so a
   # TRUNCATED-but-nonempty TOC listing only `Data.db` shrinks the required set to nothing
@@ -463,11 +497,12 @@ _toc_companions_usable() {
     # reserved exit 9 -- a judged corpus verdict the #2078 opt-out suppresses. A broken
     # grep must never be readable as a judged corpus.
     _t_g=0
-    grep -qxF "$_t_c" "$_t_toc" || _t_g=$?
+    grep -qxF "$_t_c" "$_TOC_NORM" || _t_g=$?
     case "$_t_g" in
       0) : ;;
-      1) return 1 ;;
-      *) echo "❌ dataset manifest check: grep failed (status $_t_g) reconciling $_t_toc; cannot judge the corpus" >&2
+      1) rm -f "$_TOC_NORM"; return 1 ;;
+      *) rm -f "$_TOC_NORM"
+         echo "❌ dataset manifest check: grep failed (status $_t_g) reconciling $_t_toc; cannot judge the corpus" >&2
          exit 2 ;;
     esac
   done
@@ -496,8 +531,12 @@ _toc_companions_usable() {
   # Plain call, NOT `$(...)`: see the function header -- a subshell would swallow its exit 2.
   _committed_toc_relpath "$_t_toc"
   if [ -n "$_C_TOC_REL" ]; then
-    _toc_matches_head "$_t_toc" "$_C_TOC_REL" || return 1
+    if ! _toc_matches_head "$_t_toc" "$_C_TOC_REL"; then
+      rm -f "$_TOC_NORM"
+      return 1
+    fi
   fi
+  rm -f "$_TOC_NORM"
   _TOC_FAIL_REASON=
   return 0
 }
@@ -560,6 +599,7 @@ _toc_matches_head() {
     echo "❌ dataset manifest check: mktemp failed; cannot materialise the committed twin" >&2
     exit 2
   }
+  _register_tmp "$_tm_tmp"; _register_tmp "$_tm_tmp.a"; _register_tmp "$_tm_tmp.b"
   # A CONFIRMED absence from HEAD is not an operational failure, and collapsing the two
   # (roborev, post-rebase round 4) would let git corruption or a permission error read as
   # "no inventory" and silently disable this check. `cat-file -e` answers EXISTENCE on its

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -116,7 +116,7 @@ fi
 # absence is git-not-a-work-tree, which is a legitimate environment (Jest's own fallback)
 # and is now tested for EXPLICITLY rather than inferred from an empty result -- an empty
 # result is exactly what a failure also produces.
-for _tool in find grep sort awk sed basename; do
+for _tool in find grep sort awk sed basename cmp git; do
   command -v "$_tool" >/dev/null 2>&1 || {
     echo "❌ dataset manifest check: required tool '$_tool' not found; cannot judge the corpus" >&2
     exit 2
@@ -474,28 +474,59 @@ _toc_companions_usable() {
   # runs against — all 144 generations there have a twin — but a corpus assembled elsewhere
   # gets the weaker guarantee, and nothing in the output would otherwise say so.
   _TOC_FAIL_REASON=untrusted-toc
-  _t_committed=$(_committed_toc_path "$_t_toc") || return 1
-  if [ -n "$_t_committed" ]; then
-    cmp -s "$_t_toc" "$_t_committed" || return 1
+  _t_relpath=$(_committed_toc_relpath "$_t_toc") || return 1
+  if [ -n "$_t_relpath" ]; then
+    _toc_matches_head "$_t_toc" "$_t_relpath" || return 1
   fi
   _TOC_FAIL_REASON=
   return 0
 }
 
-# _committed_toc_path <corpus-toc-path> -- echo the git-tracked twin of this TOC, or nothing.
-#
-# Maps <root>/sstables/<ks>/<tabledir>/<file> onto the checkout's
-# test-data/datasets/sstables/<ks>/<tabledir>/<file>, then requires git to TRACK it -- an
-# untracked file at that path is not a trusted inventory, it is just another file on disk.
-_committed_toc_path() {
+# _committed_toc_relpath <corpus-toc-path> -- echo the REPO-RELATIVE path of this TOC's
+# git-tracked twin, or nothing when there is none.
+_committed_toc_relpath() {
   _c_tail=${1#*/sstables/}
   [ "$_c_tail" = "$1" ] && { printf ''; return 0; }
   [ -n "$_SCRIPT_REPO" ] || { printf ''; return 0; }
-  _c_path="$_SCRIPT_REPO/test-data/datasets/sstables/$_c_tail"
-  [ -f "$_c_path" ] || { printf ''; return 0; }
-  git -C "$_SCRIPT_REPO" ls-files --error-unmatch \
-      "test-data/datasets/sstables/$_c_tail" >/dev/null 2>&1 || { printf ''; return 0; }
-  printf '%s' "$_c_path"
+  _c_rel="test-data/datasets/sstables/$_c_tail"
+  git -C "$_SCRIPT_REPO" ls-files --error-unmatch "$_c_rel" >/dev/null 2>&1 || { printf ''; return 0; }
+  printf '%s' "$_c_rel"
+}
+
+# _toc_matches_head <corpus-toc-path> <repo-relative-path> -- rc 0 iff the corpus TOC matches
+# the content COMMITTED AT HEAD.
+#
+# READ FROM `git show HEAD:<path>`, NOT FROM THE WORKING TREE (roborev, post-rebase round 3).
+# The first version compared against the working-tree file, and under the DEFAULT dataset
+# root -- the checkout's own `test-data/datasets` -- those are THE SAME FILE. `cmp` compared
+# a file to itself, always succeeded, and the trusted-inventory check was VACUOUS in exactly
+# the configuration CI uses. Verified: both paths resolve to the identical absolute path.
+#
+# HEAD rather than the index (`git show :<path>`): a staged-but-uncommitted truncation would
+# otherwise be its own authority, and the inventory has to come from somewhere the corpus
+# under judgement cannot reach.
+#
+# STATUS DISCIPLINE, as everywhere in this script: `cmp` exits 0 same, 1 different, >1
+# TROUBLE (unreadable, or absent from PATH). Collapsing >1 onto "different" would walk a
+# tooling failure out to the reserved exit 9, which the #2078 opt-out suppresses as a judged
+# corpus. `cmp` is in the up-front tool check for the same reason.
+_toc_matches_head() {
+  _tm_tmp="${TMPDIR:-/tmp}/cqlite-toc-head.$$"
+  if ! git -C "$_SCRIPT_REPO" show "HEAD:$2" >"$_tm_tmp" 2>/dev/null; then
+    rm -f "$_tm_tmp"
+    # Tracked but not resolvable at HEAD (added-but-uncommitted). Not a corpus verdict: the
+    # inventory is unavailable, so fall back to the derived checks rather than invent one.
+    return 0
+  fi
+  _tm_rc=0
+  cmp -s "$1" "$_tm_tmp" || _tm_rc=$?
+  rm -f "$_tm_tmp"
+  case "$_tm_rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) echo "❌ dataset manifest check: cmp failed (status $_tm_rc) comparing $1 with its committed twin; cannot judge the corpus" >&2
+       exit 2 ;;
+  esac
 }
 
 # _dir_has_oa_golden <table-dir> -- rc 0 when the directory holds ANY

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -399,6 +399,9 @@ _TOC_MAY_BE_EMPTY='Rows.db'
 # (142 `Statistics.db.txt`, 6 `CompressionInfo.db.txt`) plus the `.jsonl` goldens.
 _TOC_SIDECAR_GLOBS='*.jsonl *.db.txt'
 _toc_companions_usable() {
+  # Which of this function's several rejections fired, so the caller can NAME the cause
+  # instead of reporting them all as "the TOC lists something missing" (the round-40 rule).
+  _TOC_FAIL_REASON=listed-component
   _t_prefix=${1%Data.db}
   _t_toc="${_t_prefix}TOC.txt"
   _usable_file "$_t_toc" || return 1
@@ -435,9 +438,64 @@ _toc_companions_usable() {
       case "$_t_c" in $_t_g) _t_skip=1; break ;; esac
     done
     [ "$_t_skip" -eq 1 ] && continue
-    grep -qxF "$_t_c" "$_t_toc" || return 1
+    # STATUS DISCIPLINE, as everywhere else in this script (roborev, post-rebase round 2).
+    # `grep ... || return 1` collapses an OPERATIONAL failure (>1) onto "not listed", and
+    # because this function is called on the left of `||` that non-match walks out to the
+    # reserved exit 9 -- a judged corpus verdict the #2078 opt-out suppresses. A broken
+    # grep must never be readable as a judged corpus.
+    _t_g=0
+    grep -qxF "$_t_c" "$_t_toc" || _t_g=$?
+    case "$_t_g" in
+      0) : ;;
+      1) return 1 ;;
+      *) echo "❌ dataset manifest check: grep failed (status $_t_g) reconciling $_t_toc; cannot judge the corpus" >&2
+         exit 2 ;;
+    esac
   done
+  # THE TRUSTED INVENTORY (roborev, post-rebase round 2). Both directions above are derived
+  # from the CORPUS, so a COHERENTLY truncated TOC -- one shortened in step with the files
+  # it stopped listing -- satisfies each of them and greens an incomplete generation.
+  #
+  # `*-TOC.txt` is GIT-TRACKED (164 committed), so it is not subject to the truncated fetch
+  # that damages the gitignored binaries: it is an inventory from OUTSIDE the corpus being
+  # judged, which is exactly what the derived checks cannot be. Measured: all 144 generations
+  # in the machine-local corpus have a committed twin and all 144 match byte-for-byte, so
+  # requiring the match costs nothing today and is fail-closed.
+  #
+  # NO TWIN => the derived checks alone, and this is a DECLARED LIMIT rather than a hidden
+  # one. Making an absent twin fatal was tried and is wrong: a corpus legitimately holds
+  # tables this checkout does not commit (a scratch root, an out-of-tree corpus, a
+  # newly-generated table), and there is no trusted inventory for those BY DEFINITION, so
+  # rejecting them reports "incomplete" about something that is merely unverifiable. It also
+  # red-lined 41 synthetic fixtures whose tables cannot have a twin.
+  #
+  # THE RESIDUAL, stated because it is real: for a generation with no committed twin, a
+  # COHERENT truncation is undetectable here. It does not affect the corpus the gate actually
+  # runs against — all 144 generations there have a twin — but a corpus assembled elsewhere
+  # gets the weaker guarantee, and nothing in the output would otherwise say so.
+  _TOC_FAIL_REASON=untrusted-toc
+  _t_committed=$(_committed_toc_path "$_t_toc") || return 1
+  if [ -n "$_t_committed" ]; then
+    cmp -s "$_t_toc" "$_t_committed" || return 1
+  fi
+  _TOC_FAIL_REASON=
   return 0
+}
+
+# _committed_toc_path <corpus-toc-path> -- echo the git-tracked twin of this TOC, or nothing.
+#
+# Maps <root>/sstables/<ks>/<tabledir>/<file> onto the checkout's
+# test-data/datasets/sstables/<ks>/<tabledir>/<file>, then requires git to TRACK it -- an
+# untracked file at that path is not a trusted inventory, it is just another file on disk.
+_committed_toc_path() {
+  _c_tail=${1#*/sstables/}
+  [ "$_c_tail" = "$1" ] && { printf ''; return 0; }
+  [ -n "$_SCRIPT_REPO" ] || { printf ''; return 0; }
+  _c_path="$_SCRIPT_REPO/test-data/datasets/sstables/$_c_tail"
+  [ -f "$_c_path" ] || { printf ''; return 0; }
+  git -C "$_SCRIPT_REPO" ls-files --error-unmatch \
+      "test-data/datasets/sstables/$_c_tail" >/dev/null 2>&1 || { printf ''; return 0; }
+  printf '%s' "$_c_path"
 }
 
 # _dir_has_oa_golden <table-dir> -- rc 0 when the directory holds ANY
@@ -540,6 +598,7 @@ for entry in "${EXPECTED[@]}"; do
   oa_bad=0        # a correctly-shaped dir held Data.db files, but none OA-named
   name_bad=0      # Data.db files existed, but none named like a descriptor the reader opens
   empty_bad=0     # a correctly-named binary existed but was ZERO-LENGTH (truncated fetch)
+  toc_why=""      # which TOC rejection fired: listed-component | untrusted-toc
   collide_bad=0   # a non-generation *-Data.db shares a real generation's prefix
   type_bad=0      # a correctly-named Data.db exists but is NOT a regular file
   unread_bad=0    # a correctly-named, nonempty Data.db is not readable
@@ -656,7 +715,7 @@ for entry in "${EXPECTED[@]}"; do
       elif [ ! -r "$f" ]; then
         unread_bad=1; gen_bad=1; continue    # present and sized, but not readable
       fi
-      _toc_companions_usable "$f" || { toc_bad=1; gen_bad=1; }
+      _toc_companions_usable "$f" || { toc_bad=1; gen_bad=1; toc_why=$_TOC_FAIL_REASON; }
     done
 
     # ---- PASS 2: which generation satisfies THIS table's consumer -----------------------
@@ -783,6 +842,8 @@ for entry in "${EXPECTED[@]}"; do
       *)         _want="nb-1-big-Data.db.jsonl" ;;
     esac
     echo "❌ expected table has a Data.db but not the JSONL golden Jest reads ($_want): $entry" >&2
+  elif [ "$toc_bad" -eq 1 ] && [ "$toc_why" = untrusted-toc ]; then
+    echo "❌ expected table's TOC.txt does NOT match the git-tracked committed twin — the corpus TOC has been truncated or altered, so it cannot be trusted as the generation's inventory (a COHERENT truncation shortens the TOC in step with the files it stops listing, which every corpus-derived check accepts): $entry" >&2
   elif [ "$toc_bad" -eq 1 ]; then
     # LAST: every earlier state is a coarser breakage, and this one is only reachable
     # once a nonempty recognised binary AND its golden are both in place -- the shape a

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -190,16 +190,38 @@ _SCRIPT_REPO=$(cd "$_SCRIPT_DIR/../.." 2>/dev/null && pwd) || _SCRIPT_REPO=""
 # `git ls-files` exits 128 -- which is a real malfunction status everywhere else, so without
 # this flag the trusted-inventory lookup would abort every such run. "Not a work tree" is a
 # DECLARED absence of an inventory, not a broken tool.
+# THREE-VALUED, and probed ONCE (roborev, post-rebase round 13).
+#
+# A bare `rev-parse ... || fallback` collapses "genuinely outside a work tree" with "git is
+# broken / the repository is corrupt / permission denied" — and the fallback disables BOTH the
+# committed-directory filter and the trusted HEAD comparison, so a coherently truncated corpus
+# passes on the weaker derived checks alone. Every other tool in this script distinguishes its
+# failure from its answer; this one did not.
+#
+# git cannot separate them by STATUS (measured: 128 both for a plain directory and for one
+# holding a broken `.git`), so the discriminator is STRUCTURAL: git metadata present at
+# _SCRIPT_REPO means this IS meant to be a checkout, and rev-parse failing there is a
+# malfunction. `.git` is a DIRECTORY in a normal clone and a FILE in a linked worktree — which
+# is what this lane is — so `-e` covers both.
+#
+# Probed once and reused: two independent probes could disagree, and the second one silently
+# governed the committed-directory filter.
 _SCRIPT_REPO_IS_GIT=0
-if [ -n "$_SCRIPT_REPO" ] && command -v git >/dev/null 2>&1 \
-   && git -C "$_SCRIPT_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  _SCRIPT_REPO_IS_GIT=1
+if [ -n "$_SCRIPT_REPO" ] && command -v git >/dev/null 2>&1; then
+  _rp_rc=0
+  git -C "$_SCRIPT_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1 || _rp_rc=$?
+  if [ "$_rp_rc" -eq 0 ]; then
+    _SCRIPT_REPO_IS_GIT=1
+  elif [ -e "$_SCRIPT_REPO/.git" ]; then
+    echo "❌ dataset manifest check: '$_SCRIPT_REPO' has git metadata but 'git rev-parse' failed (status $_rp_rc); the committed-directory filter and the trusted TOC comparison would both be silently disabled; cannot judge the corpus" >&2
+    exit 2
+  fi
+  # else: no metadata and rev-parse says no -- genuinely outside a work tree, which is the
+  # documented fallback (a vendored copy, the self-test fixture). Not a malfunction.
 fi
 
 COMMITTED_TABLE_DIRS=""
-if [ -n "$_SCRIPT_REPO" ] \
-   && command -v git >/dev/null 2>&1 \
-   && git -C "$_SCRIPT_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [ "$_SCRIPT_REPO_IS_GIT" = 1 ]; then
   # `-z`, matching the node twin (`git -C ... ls-files -z` in parity-utils.js) and this
   # repo's standing rule that a path-reading git invocation is NUL-delimited (#3229's
   # structural assert says so for `git diff`, and the reason is identical here).

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -507,7 +507,12 @@ _toc_companions_usable() {
 # Collapsing 128 onto "no twin" would silently disable the trusted-inventory check.
 _committed_toc_relpath() {
   _C_TOC_REL=""
-  _c_tail=${1#*/sstables/}
+  # Strip the EXACT configured root, not the FIRST "/sstables/" (roborev, post-rebase round
+  # 5). `${1#*/sstables/}` is non-greedy from the left, so a root like
+  # `/data/sstables/current/sstables` yields `current/sstables/<ks>/...` -- a repo path that
+  # matches nothing, no twin is found, and the TOC validation silently weakens. `$SSTABLES`
+  # is the root this run was actually given, so it is the only correct thing to remove.
+  _c_tail=${1#"$SSTABLES/"}
   [ "$_c_tail" = "$1" ] && return 0
   # Not a work tree => no inventory exists to compare against. Declared, not a malfunction.
   [ "$_SCRIPT_REPO_IS_GIT" = 1 ] || return 0
@@ -551,7 +556,20 @@ _toc_matches_head() {
   # (roborev, post-rebase round 4) would let git corruption or a permission error read as
   # "no inventory" and silently disable this check. `cat-file -e` answers EXISTENCE on its
   # own, so a `show` that fails afterwards is a genuine malfunction.
-  if ! git -C "$_SCRIPT_REPO" cat-file -e "HEAD:$2" 2>/dev/null; then
+  # `ls-tree`, NOT `cat-file -e` (roborev, post-rebase round 5). `cat-file -e` answers by
+  # EXIT STATUS alone, so repository corruption or an unreadable object is indistinguishable
+  # from "absent at HEAD" -- and absent falls back to the derived checks, silently disabling
+  # the trusted comparison. `ls-tree` separates the two: status 0 with EMPTY output means
+  # genuinely absent, status 0 with output means present, and a NON-ZERO status is a
+  # malfunction that must not be read as either.
+  _tm_ls_rc=0
+  _tm_ls=$(git -C "$_SCRIPT_REPO" ls-tree --name-only HEAD -- "$2" 2>/dev/null) || _tm_ls_rc=$?
+  if [ "$_tm_ls_rc" -ne 0 ]; then
+    rm -f "$_tm_tmp"
+    echo "❌ dataset manifest check: 'git ls-tree HEAD -- $2' failed (status $_tm_ls_rc); cannot judge the corpus" >&2
+    exit 2
+  fi
+  if [ -z "$_tm_ls" ]; then
     rm -f "$_tm_tmp"
     # Tracked but absent at HEAD (added, not yet committed): the inventory does not exist
     # yet, so fall back to the derived checks rather than invent one.

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -116,7 +116,7 @@ fi
 # absence is git-not-a-work-tree, which is a legitimate environment (Jest's own fallback)
 # and is now tested for EXPLICITLY rather than inferred from an empty result -- an empty
 # result is exactly what a failure also produces.
-for _tool in find grep sort awk sed basename cmp git tr; do
+for _tool in find grep sort awk sed basename cmp git tr iconv; do
   command -v "$_tool" >/dev/null 2>&1 || {
     echo "❌ dataset manifest check: required tool '$_tool' not found; cannot judge the corpus" >&2
     exit 2
@@ -315,6 +315,14 @@ _reader_accepts_descriptor() {
   # GREEDY `.*` mirrors the parser's RIGHT-TO-LEFT scan for the format segment, so a
   # pathological `nb-x-big-y-big-Data.db` resolves its id and format identically on both
   # sides. Version and format remain gated below -- widening the ID does not widen those.
+  # VALID UTF-8, because the reader requires it (roborev, post-rebase round 6). Both
+  # discovery sites (`manager_open.rs`) and `SsTableDescriptor::parse` go through
+  # `file_name().and_then(|n| n.to_str())`, which returns None for invalid UTF-8 — the file
+  # is skipped or rejected. `.*` below matches arbitrary BYTES, so without this a
+  # `nb-<0xff>-big-Data.db` was accepted here and unreadable there: a false-PRESENT, and a
+  # table whose only generation had such a name would pass the manifest while giving the
+  # Node suite nothing. Verified in both directions.
+  printf '%s' "$_b" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 || return 1
   _re_match '^[a-z][a-z]-.*-(big|bti)-Data\.db$' "$_b" || return 1
   _ver=${_b%%-*}
   case "$_fmt" in

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -392,6 +392,12 @@ _usable_file() { [ -f "$1" ] && [ -s "$1" ] && [ -r "$1" ]; }
 #
 # The Data.db's own nonzero requirement is enforced separately by its caller.
 _TOC_MAY_BE_EMPTY='Rows.db'
+
+# _TOC_SIDECAR_GLOBS -- files sharing a generation prefix that are NOT Cassandra components
+# and are therefore legitimately absent from the TOC. Measured across all 144 generations in
+# both corpus roots: exactly two shapes, both human-readable dumps this TEST corpus ships
+# (142 `Statistics.db.txt`, 6 `CompressionInfo.db.txt`) plus the `.jsonl` goldens.
+_TOC_SIDECAR_GLOBS='*.jsonl *.db.txt'
 _toc_companions_usable() {
   _t_prefix=${1%Data.db}
   _t_toc="${_t_prefix}TOC.txt"
@@ -409,6 +415,28 @@ _toc_companions_usable() {
       *) [ -s "$_t_p" ] || return 1 ;;
     esac
   done < "$_t_toc"
+  # BIDIRECTIONAL (roborev #3493, post-rebase round). The loop above proves every LISTED
+  # component exists; on its own that trusts the TOC as a COMPLETE inventory, so a
+  # TRUNCATED-but-nonempty TOC listing only `Data.db` shrinks the required set to nothing
+  # and the partial extraction this check exists to catch walks through.
+  #
+  # So the other direction too: every file sharing this generation's prefix must BE LISTED.
+  # A truncation that drops `CompressionInfo.db` from the TOC is then caught by the file
+  # still being on disk -- which is the shape a half-written TOC actually leaves.
+  #
+  # A mandatory-component floor was tried first and is NOT this: it cannot catch a truncated
+  # TOC whose components all happen to be present, and it red-lined 40 synthetic fixtures for
+  # a reason unrelated to what they test.
+  for _t_f in "${_t_prefix}"*; do
+    [ -e "$_t_f" ] || continue
+    _t_c=${_t_f#"$_t_prefix"}
+    _t_skip=0
+    for _t_g in $_TOC_SIDECAR_GLOBS; do
+      case "$_t_c" in $_t_g) _t_skip=1; break ;; esac
+    done
+    [ "$_t_skip" -eq 1 ] && continue
+    grep -qxF "$_t_c" "$_t_toc" || return 1
+  done
   return 0
 }
 
@@ -512,6 +540,7 @@ for entry in "${EXPECTED[@]}"; do
   oa_bad=0        # a correctly-shaped dir held Data.db files, but none OA-named
   name_bad=0      # Data.db files existed, but none named like a descriptor the reader opens
   empty_bad=0     # a correctly-named binary existed but was ZERO-LENGTH (truncated fetch)
+  collide_bad=0   # a non-generation *-Data.db shares a real generation's prefix
   type_bad=0      # a correctly-named Data.db exists but is NOT a regular file
   unread_bad=0    # a correctly-named, nonempty Data.db is not readable
   toc_bad=0       # a complete-looking generation whose own TOC.txt lists an absent component
@@ -574,7 +603,44 @@ for entry in "${EXPECTED[@]}"; do
       # Not a descriptor the reader opens => not a generation at all, and must not
       # disqualify the table (the round-24 over-rejection, one level down). `junk-Data.db`
       # and a non-numeric `oa-<uuid>-big-Data.db` both land here.
-      _reader_accepts_descriptor "$fbase" || { name_bad=1; continue; }
+      if ! _reader_accepts_descriptor "$fbase"; then
+        name_bad=1
+        # PREFIX COLLISION (roborev #3493, post-rebase round). Production discovery is a
+        # bare `filename.ends_with("-Data.db")` and `SSTableComponent::from_filename` maps
+        # ANY such name to the Data component -- so a file sharing a REAL generation's
+        # prefix is read as that generation's Data component and corrupts it.
+        #
+        # Measured, garbage bytes under each name beside a healthy nb-1 generation:
+        #   nb-1-big-Foo-Data.db -> the query THROWS      <-- shares nb-1-big-
+        #   junk-Data.db         -> 100 rows (tolerated)
+        #   nb-9-big-Data.db     -> 100 rows (tolerated)  <-- valid descriptor, other gen
+        #   xx-1-big-Data.db     -> 100 rows (tolerated)
+        #   nb-foo-big-Data.db   -> 100 rows (tolerated)
+        #
+        # So the hazard is NARROWER than "any unparseable name": a non-generation file is
+        # discovered, fails to open and is SKIPPED (best-effort load) UNLESS it collides
+        # with a real generation's prefix. That is the only fatal shape measured, and it is
+        # the one checked here -- rejecting every odd `*-Data.db` would red on input the
+        # reader demonstrably tolerates.
+        #
+        # PARTLY REDUNDANT WITH THE BIDIRECTIONAL TOC CHECK, deliberately. A colliding file
+        # shares the generation prefix and is not TOC-listed, so `_toc_companions_usable`
+        # already disqualifies the table -- verified by deleting THIS check, which left the
+        # table rejected. What it does not leave is a usable diagnostic: the operator is told
+        # "no Data.db the reader would open", about a directory whose Data.db is present and
+        # fine. This branch exists to NAME the cause, which is the round-40 rule, and that is
+        # exactly the one assertion that flips when it is removed.
+        _pfx_collide=0
+        for _gen in "$cand"/*-Data.db; do
+          [ -e "$_gen" ] || [ -L "$_gen" ] || continue
+          _gbase=${_gen##*/}
+          [ "$_gbase" = "$fbase" ] && continue
+          _reader_accepts_descriptor "$_gbase" || continue
+          case "$fbase" in "${_gbase%Data.db}"*) _pfx_collide=1; break ;; esac
+        done
+        [ "$_pfx_collide" -eq 1 ] && { collide_bad=1; gen_bad=1; }
+        continue
+      fi
       # `_usable_file` is `-f && -s && -r`. Test its three parts SEPARATELY so the
       # diagnostic names the operator's ACTUAL problem (roborev #3493 round 54 self-audit).
       # Collapsing them reported a Data.db that is a DIRECTORY as "ZERO-LENGTH (truncated
@@ -699,6 +765,8 @@ for entry in "${EXPECTED[@]}"; do
   # most-specific first; a table can only be in one of these states per candidate.
   if [ -n "$data_db" ]; then
     :
+  elif [ "$collide_bad" -eq 1 ]; then
+    echo "❌ expected table has a *-Data.db that SHARES a real generation's prefix (e.g. nb-1-big-Foo-Data.db beside nb-1-big-Data.db) — the reader maps any *-Data.db to that generation's Data component and the query FAILS; remove the stray file: $entry" >&2
   elif [ "$type_bad" -eq 1 ]; then
     echo "❌ expected table has a Data.db that is NOT A REGULAR FILE (a directory, a dangling symlink, or a special file) -- replace the fixture: $entry" >&2
   elif [ "$unread_bad" -eq 1 ]; then

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -565,38 +565,42 @@ _toc_companions_usable() {
   return 0
 }
 
-# _committed_toc_relpath <corpus-toc-path> -- set _C_TOC_REL to the REPO-RELATIVE path of
-# this TOC's git-tracked twin, or to the empty string when there is none.
+# _committed_toc_relpath <corpus-toc-path> -- set _C_TOC_REL to the REPO-RELATIVE path this
+# TOC would have in the checkout, or "" when the mapping does not apply.
 #
-# SETS A GLOBAL RATHER THAN ECHOING, deliberately. Called as `$(...)` it would run in a
-# SUBSHELL, so the `exit 2` below would kill only that subshell; the caller's `|| return 1`
-# would then turn a MALFUNCTION into "TOC mismatch" and walk it out to the reserved exit 9 --
-# the very collapse this discipline exists to prevent, reintroduced by the call syntax.
+# A PURE MAPPING. It used to also ask `git ls-files --error-unmatch` whether the path was
+# tracked, and that is INDEX-based (roborev, post-rebase round 11): a TOC staged for DELETION
+# reads as untracked, so the twin comparison was skipped even though HEAD still holds the
+# inventory — a coherently truncated corpus could then pass on the derived checks alone.
+# Existence is now decided in ONE place, against HEAD, by `_toc_twin_at_head`.
 #
-# git distinguishes the two cases and so must this: `ls-files --error-unmatch` exits 1 for
-# UNTRACKED (a legitimate "no twin") and 128 for a broken invocation / not-a-repo. Measured.
-# Collapsing 128 onto "no twin" would silently disable the trusted-inventory check.
+# SETS A GLOBAL rather than echoing: called as `$(...)` it would run in a subshell and any
+# `exit` inside would die there, turning a malfunction into an ordinary verdict.
 _committed_toc_relpath() {
   _C_TOC_REL=""
-  # Strip the EXACT configured root, not the FIRST "/sstables/" (roborev, post-rebase round
-  # 5). `${1#*/sstables/}` is non-greedy from the left, so a root like
-  # `/data/sstables/current/sstables` yields `current/sstables/<ks>/...` -- a repo path that
-  # matches nothing, no twin is found, and the TOC validation silently weakens. `$SSTABLES`
-  # is the root this run was actually given, so it is the only correct thing to remove.
   _c_tail=${1#"$SSTABLES/"}
   [ "$_c_tail" = "$1" ] && return 0
-  # Not a work tree => no inventory exists to compare against. Declared, not a malfunction.
   [ "$_SCRIPT_REPO_IS_GIT" = 1 ] || return 0
-  _c_rel="test-data/datasets/sstables/$_c_tail"
-  _c_rc=0
-  git -C "$_SCRIPT_REPO" ls-files --error-unmatch "$_c_rel" >/dev/null 2>&1 || _c_rc=$?
-  case "$_c_rc" in
-    0) _C_TOC_REL="$_c_rel" ;;
-    1) : ;;                                  # untracked: no twin, fall back to the derived checks
-    *) echo "❌ dataset manifest check: 'git ls-files' failed (status $_c_rc) resolving the committed twin of $1; cannot judge the corpus" >&2
-       exit 2 ;;
-  esac
+  _C_TOC_REL="test-data/datasets/sstables/$_c_tail"
   return 0
+}
+
+# _toc_twin_at_head <repo-relative-path> -- rc 0 the twin EXISTS at HEAD, rc 1 it does not,
+# exit 2 on a git malfunction.
+#
+# `ls-tree`, NOT `cat-file -e`: `cat-file -e` answers by EXIT STATUS alone, so repository
+# corruption is indistinguishable from "absent" — and absent falls back to the derived checks,
+# silently disabling the trusted comparison. `ls-tree` separates them: status 0 with EMPTY
+# output is genuinely absent, status 0 with output is present, non-zero is a malfunction.
+_toc_twin_at_head() {
+  [ "$_SCRIPT_REPO_IS_GIT" = 1 ] || return 1
+  _th_rc=0
+  _th_out=$(git -C "$_SCRIPT_REPO" ls-tree --name-only HEAD -- "$1" 2>/dev/null) || _th_rc=$?
+  if [ "$_th_rc" -ne 0 ]; then
+    echo "❌ dataset manifest check: 'git ls-tree HEAD -- $1' failed (status $_th_rc); cannot judge the corpus" >&2
+    exit 2
+  fi
+  [ -n "$_th_out" ]
 }
 
 # _toc_matches_head <corpus-toc-path> <repo-relative-path> -- rc 0 iff the corpus TOC matches
@@ -628,23 +632,11 @@ _toc_matches_head() {
   # (roborev, post-rebase round 4) would let git corruption or a permission error read as
   # "no inventory" and silently disable this check. `cat-file -e` answers EXISTENCE on its
   # own, so a `show` that fails afterwards is a genuine malfunction.
-  # `ls-tree`, NOT `cat-file -e` (roborev, post-rebase round 5). `cat-file -e` answers by
-  # EXIT STATUS alone, so repository corruption or an unreadable object is indistinguishable
-  # from "absent at HEAD" -- and absent falls back to the derived checks, silently disabling
-  # the trusted comparison. `ls-tree` separates the two: status 0 with EMPTY output means
-  # genuinely absent, status 0 with output means present, and a NON-ZERO status is a
-  # malfunction that must not be read as either.
-  _tm_ls_rc=0
-  _tm_ls=$(git -C "$_SCRIPT_REPO" ls-tree --name-only HEAD -- "$2" 2>/dev/null) || _tm_ls_rc=$?
-  if [ "$_tm_ls_rc" -ne 0 ]; then
+  # Existence is decided by _toc_twin_at_head (ls-tree against HEAD), the single authority.
+  if ! _toc_twin_at_head "$2"; then
     rm -f "$_tm_tmp"
-    echo "❌ dataset manifest check: 'git ls-tree HEAD -- $2' failed (status $_tm_ls_rc); cannot judge the corpus" >&2
-    exit 2
-  fi
-  if [ -z "$_tm_ls" ]; then
-    rm -f "$_tm_tmp"
-    # Tracked but absent at HEAD (added, not yet committed): the inventory does not exist
-    # yet, so fall back to the derived checks rather than invent one.
+    # Absent at HEAD (e.g. added but not yet committed): no inventory exists, so fall back to
+    # the derived checks rather than invent one.
     return 0
   fi
   if ! git -C "$_SCRIPT_REPO" show "HEAD:$2" >"$_tm_tmp" 2>/dev/null; then

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -162,6 +162,24 @@ for _tool in find grep sort awk sed basename tr iconv; do
   }
 done
 
+# iconv is probed FUNCTIONALLY, not merely for presence (roborev, post-rebase round 12).
+#
+# `_reader_accepts_descriptor` uses `iconv -f UTF-8 -t UTF-8` to reject a descriptor whose
+# name is not valid UTF-8, because the reader reaches every filename through
+# `to_str()`. The problem: GNU iconv exits 1 for EVERY failure — invalid input, an unknown
+# encoding, an unreadable file (measured, all three) — so a nonzero status cannot on its own
+# distinguish "this name is bad" from "iconv is broken". Collapsing them means a broken iconv
+# rejects EVERY descriptor, every table reads as missing, and the run ends in the reserved
+# exit 9 that the #2078 opt-out suppresses as an incomplete corpus.
+#
+# There is no exit code that separates them, so the separation is established HERE instead:
+# a known-good round trip proves iconv works, and after that a status 1 in the predicate is
+# attributable to the INPUT. Failing this probe is a tooling failure, named as one.
+if ! printf 'probe' | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then
+  echo "❌ dataset manifest check: 'iconv -f UTF-8 -t UTF-8' failed on known-good input, so it cannot be used to judge descriptor names; cannot judge the corpus" >&2
+  exit 2
+fi
+
 # `${0%/*}` rather than `dirname` for the same reason as the keyspace above: no
 # subprocess, no failure mode. The `case` handles an invocation with no slash, where
 # `${0%/*}` would otherwise yield $0 unchanged.
@@ -361,6 +379,9 @@ _reader_accepts_descriptor() {
   # `nb-<0xff>-big-Data.db` was accepted here and unreadable there: a false-PRESENT, and a
   # table whose only generation had such a name would pass the manifest while giving the
   # Node suite nothing. Verified in both directions.
+  # A nonzero here means the NAME, not a broken iconv: the functional probe at startup has
+  # already established that iconv round-trips known-good input. GNU iconv exits 1 for every
+  # failure mode, so without that probe this line could not tell the two apart.
   printf '%s' "$_b" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 || return 1
   _re_match '^[a-z][a-z]-.*-(big|bti)-Data\.db$' "$_b" || return 1
   _ver=${_b%%-*}

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -148,7 +148,14 @@ fi
 # absence is git-not-a-work-tree, which is a legitimate environment (Jest's own fallback)
 # and is now tested for EXPLICITLY rather than inferred from an empty result -- an empty
 # result is exactly what a failure also produces.
-for _tool in find grep sort awk sed basename cmp git tr iconv; do
+# MANDATORY tools only: those used on EVERY path. `git` and `cmp` are deliberately NOT here
+# (roborev, post-rebase round 9). This script documents a git-unavailable fallback — no
+# committed-table set, so every discovered directory counts, mirroring the node helper's own
+# behaviour — and requiring git up front made that fallback UNREACHABLE: the script would exit
+# 2 before it could take the path its own comment describes. `cmp` is reached only through the
+# committed-twin comparison, which requires git, so it is conditional for the same reason.
+# `tr` and `iconv` stay: TOC normalisation and the UTF-8 descriptor check run on every path.
+for _tool in find grep sort awk sed basename tr iconv; do
   command -v "$_tool" >/dev/null 2>&1 || {
     echo "❌ dataset manifest check: required tool '$_tool' not found; cannot judge the corpus" >&2
     exit 2

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -116,7 +116,7 @@ fi
 # absence is git-not-a-work-tree, which is a legitimate environment (Jest's own fallback)
 # and is now tested for EXPLICITLY rather than inferred from an empty result -- an empty
 # result is exactly what a failure also produces.
-for _tool in find grep sort awk sed basename cmp git; do
+for _tool in find grep sort awk sed basename cmp git tr; do
   command -v "$_tool" >/dev/null 2>&1 || {
     echo "❌ dataset manifest check: required tool '$_tool' not found; cannot judge the corpus" >&2
     exit 2
@@ -128,6 +128,17 @@ done
 # `${0%/*}` would otherwise yield $0 unchanged.
 case "$0" in */*) _SCRIPT_DIR=${0%/*} ;; *) _SCRIPT_DIR=. ;; esac
 _SCRIPT_REPO=$(cd "$_SCRIPT_DIR/../.." 2>/dev/null && pwd) || _SCRIPT_REPO=""
+# Is _SCRIPT_REPO actually a git work tree? Established ONCE. The script is also run from a
+# COPY outside any repo (the self-test's nogit fixture, and anyone who vendors it), where
+# `git ls-files` exits 128 -- which is a real malfunction status everywhere else, so without
+# this flag the trusted-inventory lookup would abort every such run. "Not a work tree" is a
+# DECLARED absence of an inventory, not a broken tool.
+_SCRIPT_REPO_IS_GIT=0
+if [ -n "$_SCRIPT_REPO" ] && command -v git >/dev/null 2>&1 \
+   && git -C "$_SCRIPT_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  _SCRIPT_REPO_IS_GIT=1
+fi
+
 COMMITTED_TABLE_DIRS=""
 if [ -n "$_SCRIPT_REPO" ] \
    && command -v git >/dev/null 2>&1 \
@@ -474,23 +485,42 @@ _toc_companions_usable() {
   # runs against — all 144 generations there have a twin — but a corpus assembled elsewhere
   # gets the weaker guarantee, and nothing in the output would otherwise say so.
   _TOC_FAIL_REASON=untrusted-toc
-  _t_relpath=$(_committed_toc_relpath "$_t_toc") || return 1
-  if [ -n "$_t_relpath" ]; then
-    _toc_matches_head "$_t_toc" "$_t_relpath" || return 1
+  # Plain call, NOT `$(...)`: see the function header -- a subshell would swallow its exit 2.
+  _committed_toc_relpath "$_t_toc"
+  if [ -n "$_C_TOC_REL" ]; then
+    _toc_matches_head "$_t_toc" "$_C_TOC_REL" || return 1
   fi
   _TOC_FAIL_REASON=
   return 0
 }
 
-# _committed_toc_relpath <corpus-toc-path> -- echo the REPO-RELATIVE path of this TOC's
-# git-tracked twin, or nothing when there is none.
+# _committed_toc_relpath <corpus-toc-path> -- set _C_TOC_REL to the REPO-RELATIVE path of
+# this TOC's git-tracked twin, or to the empty string when there is none.
+#
+# SETS A GLOBAL RATHER THAN ECHOING, deliberately. Called as `$(...)` it would run in a
+# SUBSHELL, so the `exit 2` below would kill only that subshell; the caller's `|| return 1`
+# would then turn a MALFUNCTION into "TOC mismatch" and walk it out to the reserved exit 9 --
+# the very collapse this discipline exists to prevent, reintroduced by the call syntax.
+#
+# git distinguishes the two cases and so must this: `ls-files --error-unmatch` exits 1 for
+# UNTRACKED (a legitimate "no twin") and 128 for a broken invocation / not-a-repo. Measured.
+# Collapsing 128 onto "no twin" would silently disable the trusted-inventory check.
 _committed_toc_relpath() {
+  _C_TOC_REL=""
   _c_tail=${1#*/sstables/}
-  [ "$_c_tail" = "$1" ] && { printf ''; return 0; }
-  [ -n "$_SCRIPT_REPO" ] || { printf ''; return 0; }
+  [ "$_c_tail" = "$1" ] && return 0
+  # Not a work tree => no inventory exists to compare against. Declared, not a malfunction.
+  [ "$_SCRIPT_REPO_IS_GIT" = 1 ] || return 0
   _c_rel="test-data/datasets/sstables/$_c_tail"
-  git -C "$_SCRIPT_REPO" ls-files --error-unmatch "$_c_rel" >/dev/null 2>&1 || { printf ''; return 0; }
-  printf '%s' "$_c_rel"
+  _c_rc=0
+  git -C "$_SCRIPT_REPO" ls-files --error-unmatch "$_c_rel" >/dev/null 2>&1 || _c_rc=$?
+  case "$_c_rc" in
+    0) _C_TOC_REL="$_c_rel" ;;
+    1) : ;;                                  # untracked: no twin, fall back to the derived checks
+    *) echo "❌ dataset manifest check: 'git ls-files' failed (status $_c_rc) resolving the committed twin of $1; cannot judge the corpus" >&2
+       exit 2 ;;
+  esac
+  return 0
 }
 
 # _toc_matches_head <corpus-toc-path> <repo-relative-path> -- rc 0 iff the corpus TOC matches
@@ -511,16 +541,43 @@ _committed_toc_relpath() {
 # tooling failure out to the reserved exit 9, which the #2078 opt-out suppresses as a judged
 # corpus. `cmp` is in the up-front tool check for the same reason.
 _toc_matches_head() {
-  _tm_tmp="${TMPDIR:-/tmp}/cqlite-toc-head.$$"
-  if ! git -C "$_SCRIPT_REPO" show "HEAD:$2" >"$_tm_tmp" 2>/dev/null; then
+  # mktemp, not a `$$`-derived name: a predictable path in a shared /tmp is both a symlink
+  # target and, if a previous `rm -f` ever failed, a stale file this would compare against.
+  _tm_tmp=$(mktemp "${TMPDIR:-/tmp}/cqlite-toc-head.XXXXXX") || {
+    echo "❌ dataset manifest check: mktemp failed; cannot materialise the committed twin" >&2
+    exit 2
+  }
+  # A CONFIRMED absence from HEAD is not an operational failure, and collapsing the two
+  # (roborev, post-rebase round 4) would let git corruption or a permission error read as
+  # "no inventory" and silently disable this check. `cat-file -e` answers EXISTENCE on its
+  # own, so a `show` that fails afterwards is a genuine malfunction.
+  if ! git -C "$_SCRIPT_REPO" cat-file -e "HEAD:$2" 2>/dev/null; then
     rm -f "$_tm_tmp"
-    # Tracked but not resolvable at HEAD (added-but-uncommitted). Not a corpus verdict: the
-    # inventory is unavailable, so fall back to the derived checks rather than invent one.
+    # Tracked but absent at HEAD (added, not yet committed): the inventory does not exist
+    # yet, so fall back to the derived checks rather than invent one.
     return 0
   fi
+  if ! git -C "$_SCRIPT_REPO" show "HEAD:$2" >"$_tm_tmp" 2>/dev/null; then
+    rm -f "$_tm_tmp"
+    echo "❌ dataset manifest check: 'git show HEAD:$2' failed although the object EXISTS; cannot judge the corpus" >&2
+    exit 2
+  fi
+  # COMPARE THE INVENTORY, NOT THE BYTES (roborev, post-rebase round 4). A byte-for-byte
+  # `cmp` rejects a CRLF TOC -- which the listed-component loop above explicitly TOLERATES
+  # and which the reader trims. Requiring byte equality here while accepting CRLF twenty
+  # lines up is an internal contradiction, and it would mark a valid Windows-produced corpus
+  # incomplete. The property is that the two list the SAME COMPONENTS, so that is what is
+  # compared: CR stripped, blanks dropped, `sort`ed -- a TOC is an inventory, not a sequence.
+  _tm_a="$_tm_tmp.a"; _tm_b="$_tm_tmp.b"
+  if ! tr -d '\r' <"$1" | sed '/^$/d' | sort >"$_tm_a" \
+     || ! tr -d '\r' <"$_tm_tmp" | sed '/^$/d' | sort >"$_tm_b"; then
+    rm -f "$_tm_tmp" "$_tm_a" "$_tm_b"
+    echo "❌ dataset manifest check: could not normalise $1 or its committed twin; cannot judge the corpus" >&2
+    exit 2
+  fi
   _tm_rc=0
-  cmp -s "$1" "$_tm_tmp" || _tm_rc=$?
-  rm -f "$_tm_tmp"
+  cmp -s "$_tm_a" "$_tm_b" || _tm_rc=$?
+  rm -f "$_tm_tmp" "$_tm_a" "$_tm_b"
   case "$_tm_rc" in
     0) return 0 ;;
     1) return 1 ;;

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -73,17 +73,654 @@ EXPECTED=(
   "test_oa/udt_table"
 )
 
+# EXIT 9 IS THIS SCRIPT'S CORPUS VERDICT, and it is reserved (issue #3493 round 25).
+# Callers that need to distinguish "the corpus is incomplete" from "this script did not
+# get to judge" cannot use exit 1 for the former: `set -e`, a failed `grep`, an unset
+# variable or any other internal error also surfaces as 1, so a BROKEN CHECKER would be
+# indistinguishable from a judged verdict -- and the agent gate suppresses its Node
+# dataset half on the verdict while failing closed on a tooling failure.
+#
+# So: 0 = complete, 9 = judged INCOMPLETE, anything else = did not judge. Ordinary
+# callers (`run: bash check-dataset-manifest.sh ...`) are unaffected: 9 is still nonzero.
+MANIFEST_INCOMPLETE_RC=9
+
 if [ ! -d "$SSTABLES" ]; then
   echo "❌ dataset manifest check: sstables dir missing: $SSTABLES" >&2
-  exit 1
+  exit "$MANIFEST_INCOMPLETE_RC"
 fi
+
+# COMMITTED table dirs, mirroring parity-utils.js::isCommittedTableDir (roborev #3493
+# round 18). Jest enforces parity only for table directories the SOURCE TREE git-tracks
+# (#1319), so a replacement UUID on disk is discovered by neither ALL_TABLES nor
+# OA_TABLES -- and this manifest would still have reported the table PRESENT, making
+# "manifest OK" imply a parity run that never happens.
+#
+# The source tree is this SCRIPT's repo, deliberately, not the dataset root being
+# checked: the two are routinely different (a fleet root such as /data/datasets sits
+# outside any work tree) and the git rule is about what the CHECKOUT considers
+# committed. Verified before adopting: all 39 expected tables resolve to tracked
+# directories on both the fetched and the fleet corpus.
+#
+# Jest's graceful fallback is copied too -- an EMPTY tracked set means "git unavailable
+# or not a work tree", and then every discovered dir counts. Without it this check would
+# reject everything in a git-less environment, which is a louder version of the vacuous
+# pass it exists to prevent.
+# EXIT 9 IS ONLY RESERVED IF NOTHING ELSE CAN REACH IT (roborev #3493 round 26). The
+# previous shape swallowed helper failures with `|| true` and then continued to the
+# deliberate exit 9, so a broken `awk` or `sort` was reported as a judged INCOMPLETE
+# corpus -- and the gate suppresses on that verdict. A reserved code that a malfunction
+# can produce is not reserved.
+#
+# Two changes make it hold: the tools are verified UP FRONT, and every helper failure
+# below propagates as 2 (did-not-judge) rather than being absorbed. The only tolerated
+# absence is git-not-a-work-tree, which is a legitimate environment (Jest's own fallback)
+# and is now tested for EXPLICITLY rather than inferred from an empty result -- an empty
+# result is exactly what a failure also produces.
+for _tool in find grep sort awk sed basename; do
+  command -v "$_tool" >/dev/null 2>&1 || {
+    echo "❌ dataset manifest check: required tool '$_tool' not found; cannot judge the corpus" >&2
+    exit 2
+  }
+done
+
+# `${0%/*}` rather than `dirname` for the same reason as the keyspace above: no
+# subprocess, no failure mode. The `case` handles an invocation with no slash, where
+# `${0%/*}` would otherwise yield $0 unchanged.
+case "$0" in */*) _SCRIPT_DIR=${0%/*} ;; *) _SCRIPT_DIR=. ;; esac
+_SCRIPT_REPO=$(cd "$_SCRIPT_DIR/../.." 2>/dev/null && pwd) || _SCRIPT_REPO=""
+COMMITTED_TABLE_DIRS=""
+if [ -n "$_SCRIPT_REPO" ] \
+   && command -v git >/dev/null 2>&1 \
+   && git -C "$_SCRIPT_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  # `-z`, matching the node twin (`git -C ... ls-files -z` in parity-utils.js) and this
+  # repo's standing rule that a path-reading git invocation is NUL-delimited (#3229's
+  # structural assert says so for `git diff`, and the reason is identical here).
+  #
+  # WITHOUT it git QUOTES any path outside the portable charset -- `core.quotePath` turns
+  # `sstables/tëst/...` into `"test-data/datasets/sstables/t\303\253st/..."` -- and the
+  # `$4/$5` extraction then yields a key with a leading quote that matches no directory on
+  # disk. The table would read as uncommitted, be skipped, and the corpus reported
+  # incomplete: a false-MISSING that no test with an ASCII-only corpus can see.
+  # A TEMP FILE, not `$(...)`. Command substitution STRIPS NUL BYTES -- bash even warns
+  # "ignored null byte in input" -- so capturing `ls-files -z` that way collapses the whole
+  # listing into one line, the loop below extracts NOTHING, and the empty result silently
+  # takes the "nothing tracked -> everything counts" fallback. That is FAIL-OPEN: every
+  # directory becomes committed and the #1319 WIP-dir guard is gone. It is invisible from
+  # the script's own output, which still prints a green 39/39, because the fallback is a
+  # legitimate state -- exactly the vacuous-pass shape this whole change is about. Caught
+  # only by counting the derived entries.
+  _ls_tmp=$(mktemp) || {
+    echo "❌ dataset manifest check: mktemp failed; cannot derive the committed table set" >&2
+    exit 2
+  }
+  if ! git -C "$_SCRIPT_REPO" ls-files -z test-data/datasets/sstables >"$_ls_tmp" 2>/dev/null; then
+    rm -f "$_ls_tmp"
+    echo "❌ dataset manifest check: 'git ls-files' failed; cannot derive the committed table set" >&2
+    exit 2
+  fi
+  _ctd=""
+  while IFS= read -r -d '' _p; do
+    # test-data/datasets/sstables/<keyspace>/<table-dir>/<file>
+    _rest=${_p#test-data/datasets/sstables/}
+    [ "$_rest" = "$_p" ] && continue
+    _ks=${_rest%%/*}; _rest=${_rest#*/}
+    case "$_rest" in */*) : ;; *) continue ;; esac      # need a file BELOW the table dir
+    _tbl=${_rest%%/*}
+    [ -n "$_ks" ] && [ -n "$_tbl" ] && _ctd="$_ctd$_ks/$_tbl"$'\n'
+  done <"$_ls_tmp"
+  rm -f "$_ls_tmp"
+  # GUARDED, and every nonzero normalised to 2 (roborev #3493 round 59). Under `set -e` an
+  # unguarded assignment propagates the pipeline's RAW status as the script's exit -- and if
+  # `sort` or `sed` ever exited 9, that is this script's RESERVED corpus verdict, so a
+  # TOOLING FAILURE would be read as a judged "incomplete corpus" and suppressed by the
+  # #2078 opt-out. Only a code this script emits DELIBERATELY may carry a verdict; that is
+  # the whole basis of the reserved-exit discipline (rounds 25/27), and an unguarded
+  # pipeline quietly opts out of it.
+  if ! COMMITTED_TABLE_DIRS=$(printf '%s' "$_ctd" | sort -u | sed '/^$/d'); then
+    echo "❌ dataset manifest check: could not derive the committed table set (sort/sed failed); cannot judge the corpus" >&2
+    exit 2
+  fi
+fi
+
+# _re_match <ERE> <string> -- rc 0 WHOLE-STRING match, rc 1 NO MATCH, exit 2 on MALFUNCTION.
+#
+# grep returns 1 for "no match" and >1 for an operational failure, and collapsing the two
+# is how a broken checker reaches this script's deliberate exit 9 (roborev #3493 round
+# 27). `|| continue` and `&& return 0` both read >1 as an ordinary non-match, the loop
+# falls through, and the run ends in a judged INCOMPLETE verdict that the gate's opt-out
+# then suppresses. Every regex predicate goes through here so that distinction is made
+# once, in one place, rather than at each of the sites that needs it.
+_re_match() {
+  # BASH `[[ =~ ]]`, NOT grep (roborev #3493 round 59). grep matches LINE BY LINE, so an
+  # anchored `^...$` accepts a value whose SOME line matches -- and a filename may contain a
+  # newline. Measured: for the two-line name `oa-x\noa-1-big-Data.db`,
+  # `grep -Eq '^oa-[0-9]+-big-Data\.db$'` says MATCH while the JS consumer
+  # `/^oa-\d+-big-Data\.db$/.test()` says NO (JS `$` without `m` anchors to end of INPUT).
+  # That is a false-PRESENT: the manifest reports the corpus complete, Jest's
+  # `oaBinariesPresent()` does not see the file, and the suite fails with the opt-out unable
+  # to suppress it. `[[ =~ ]]` matches the WHOLE STRING, exactly like the JS side.
+  #
+  # It also removes the SIGPIPE and grep-malfunction hazards this function existed to
+  # manage -- there is no external process left -- while KEEPING the three-valued contract:
+  # bash returns 2 for an INVALID REGEX, which is a genuine malfunction and must not be
+  # collapsed onto "no match" (that is how a broken checker reached the reserved exit 9 in
+  # round 27).
+  #
+  # `local LC_ALL=C` because bash evaluates the ERE through the C library under the CURRENT
+  # locale, so ranges like `[a-z]` are collation-dependent -- the same locale trap as the
+  # whitespace and control-character predicates (rounds 45/46/48). Dynamic scoping restores
+  # it on return.
+  local LC_ALL=C
+  local _re=$1 _rc=0
+  [[ $2 =~ $_re ]] || _rc=$?
+  case "$_rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) echo "❌ dataset manifest check: invalid regex (status $_rc) matching '$1'; cannot judge the corpus" >&2
+       exit 2 ;;
+  esac
+}
+
+# _reader_accepts_descriptor <basename> -- rc 0 iff CQLite's readers would open a file
+# with this name. Mirrors the VERSION GATES rather than a name shape (roborev #3493
+# round 36):
+#   * BIG (`<ver>-<gen>-big-Data.db`) -- BigVersionGates::from_version accepts any TWO
+#     LOWERCASE LETTERS at or above the `na` floor; pre-`na` (ma..me, Cassandra 3.x) is
+#     out of scope and rejected there, so it is rejected here.
+#   * BTI (`<ver>-<gen>-bti-Data.db`) -- BtiVersionGates::from_version accepts ONLY `da`.
+# The previous `(big|bti)` alternation ignored the pairing, so `nb-1-bti` -- a version the
+# BTI gate rejects outright -- counted as a readable fixture.
+#
+# The BIG set is an EXACT ALLOWLIST `{na, nb, oa}`, not a floor -- #1249 sets the floor,
+# #1297 adds the ceiling. `BigVersionGates::from_version` on main:
+#
+#     if v < "na" { return Err(Error::UnsupportedVersion { .. }); }   // #1249 floor
+#     ...
+#     // #1297: the supported set is an EXACT allowlist, not just a floor.
+#     if !matches!(v, "na" | "nb" | "oa") {
+#         return Err(Error::UnsupportedVersion { .. });               // #1297 ceiling
+#     }
+#
+# A second consumer agrees independently: `FormatDetector::is_supported()` is
+# `V4x => matches!(v, "na"|"nb")`, `V5x => matches!(v, "oa"|"da")`, and
+# `supported_versions()` is derived from it. Two consumers, same set.
+#
+# So an above-floor-but-unlisted version (`nc`, a typo like `nz`, a future `pa`) has NO
+# validated read path and the reader ERRORS on it. Accepting it here would make this
+# check LOOSER than the reader -- the false-PRESENT class this whole change exists to
+# remove -- so `zz-9-big` is rejected, not accepted.
+#
+# A genuine future format is added deliberately once validated; one line in two places
+# on that day is the intended cost of keeping no-heuristics true.
+#
+# HISTORY, so this is not re-argued a fourth time: rounds 36-38 of review all flagged
+# this, and I twice asserted there was no allowlist. I was wrong. The allowlist is at
+# big.rs:133 and was in the tree the whole time -- both of my reads were WINDOWED
+# (`+22p`, then a comment-stripped `20,60p`) and neither window reached it. Absence
+# concluded from a partial view of a function is not evidence of absence.
+#
+# No generation bound: the generation is u64 (parser/header.rs:377) via an
+# Option-returning helper, so there is no range to mirror.
+_reader_accepts_descriptor() {
+  local _b=$1 _ver _fmt
+  case "$_b" in
+    *-big-Data.db) _fmt=big ;;
+    *-bti-Data.db) _fmt=bti ;;
+    *) return 1 ;;
+  esac
+  # The SSTable ID may be SEQUENTIAL or a UUID (roborev #3493 round 39).
+  # SSTableInfo::from_path accepts both -- `nb-1-big-Data.db` and
+  # `nb-6aa08200a25111f0a3fef1a551383fb9-big-Data.db` -- and its own doc notes that real
+  # Cassandra 5.0 clusters write UUID ids BY DEFAULT (`uuid_sstable_identifiers_enabled:
+  # true`). A `[0-9]+`-only pattern therefore rejected the id form the reader will most
+  # often see: over-strict, and it would have red-lined an ordinary Cassandra 5 corpus.
+  # `generation_numeric()` returning Option is the same fact from the other side -- a
+  # non-numeric id is expected, not an error.
+  #
+  # HYPHENS are allowed in the id because from_path builds it as
+  # `parts[1..format_idx].join("-")` -- a multi-segment (hyphenated) UUID is re-joined, so
+  # `nb-6aa08200-a251-11f0-a3fe-f1a551383fb9-big-Data.db` is a valid descriptor
+  # (roborev #3493 round 40). The class cannot swallow the format segment: `big`/`bti`
+  # both contain non-hex letters, so the anchored match still finds the right boundary.
+  #
+  # The OA branch stays NUMERIC-ONLY on purpose. Its consumers are Jest's
+  # `oaBinariesPresent()` (`/^oa-\d+-big-Data\.db$/`) and `findOaJsonlFile()`
+  # (`/^oa-\d+-big-Data\.db\.jsonl$/`) -- both digits-only. Accepting a UUID OA id here
+  # would make this check LOOSER than the consumer: the fixture would pass the manifest
+  # and then be skipped by Jest, which is the false-PRESENT class. Widening Jest's own
+  # discovery is a separate change; the corpus has only numeric OA ids today.
+  # The ID is ARBITRARY, not hex (roborev #3493 round 56). `parse_filename` validates
+  # exactly two things -- a 2-lowercase-letter version and a `big`/`bti` format segment --
+  # and takes `parts[1..format_idx]` as the id with NO charset restriction, so
+  # `nb-foo-big-Data.db` parses. A `[0-9a-f-]+` class was therefore STRICTER THAN THE
+  # READER, and this check being stricter is the false-MISSING direction: such a file is
+  # not counted as a generation, so a corpus holding only that one reads as absent and the
+  # Node suite is suppressed for a corpus the reader can open.
+  #
+  # `.*` rather than `.+`: the parser accepts an empty id segment (`nb--big-Data.db` splits
+  # to 4 parts and passes both of its checks), and mirroring it exactly is the point --
+  # "no writer emits that shape" is the same reasoning that made the hex class wrong.
+  #
+  # GREEDY `.*` mirrors the parser's RIGHT-TO-LEFT scan for the format segment, so a
+  # pathological `nb-x-big-y-big-Data.db` resolves its id and format identically on both
+  # sides. Version and format remain gated below -- widening the ID does not widen those.
+  _re_match '^[a-z][a-z]-.*-(big|bti)-Data\.db$' "$_b" || return 1
+  _ver=${_b%%-*}
+  case "$_fmt" in
+    bti) [ "$_ver" = da ] || return 1 ;;                       # BtiVersionGates: only `da`
+    big) case "$_ver" in na|nb|oa) ;; *) return 1 ;; esac ;;   # BigVersionGates: exact allowlist
+  esac
+  return 0
+}
+
+# _usable_file <path> -- rc 0 iff it is a NONEMPTY REGULAR FILE (or a symlink to one).
+#
+# `[ -s x ]` alone is NOT that test: it is true for a NONEMPTY DIRECTORY (roborev #3493
+# round 42). So a directory named `nb-1-big-Data.db.jsonl`, or a directory-valued
+# `nb-1-big-Data.db` beside a real binary, satisfied the size check and the manifest
+# reported the corpus complete -- after which Jest fails reading it and the opt-out cannot
+# suppress, because nothing classified the corpus as incomplete.
+#
+# `-f` supplies the type half and FOLLOWS symlinks, so a symlink to a nonempty regular
+# file still counts -- the same rule as _canonical_fixture_present and setup.js's
+# hasDataDbFile. Every binary and golden goes through here so no site can drift again:
+# round 35 gave binaries the size rule and missed goldens, round 41 gave goldens the size
+# rule and missed the TYPE, and both were one-site-at-a-time edits.
+# READABLE too (roborev #3493 round 43). `-f`/`-s` say a file exists with content; they
+# say nothing about whether this process can OPEN it. An unreadable Data.db or golden was
+# therefore classified as present, the decision returned RUN, and the consumer failed with
+# a permission error that the opt-out could not pre-empt -- the same fail-open shape as
+# every other state this predicate exists to catch. The Rust resolver already requires a
+# READABLE directory (fixture_roots.rs), so this aligns with it rather than inventing a
+# rule.
+_usable_file() { [ -f "$1" ] && [ -s "$1" ] && [ -r "$1" ]; }
+
+# _toc_companions_usable <data-db-path> -- rc 0 iff every component the generation's
+# OWN `TOC.txt` lists is present beside it as a READABLE REGULAR FILE.
+#
+# Why (roborev #3493 round 47): a nonempty Data.db plus a golden was the whole
+# completeness test, so a PARTIAL EXTRACTION that dropped a companion -- the
+# `CompressionInfo.db` that 126 of this corpus's 172 table directories have -- still
+# reported SATISFIED. The decision was then RUN, and Jest failed on an unreadable
+# compressed SSTable instead of the corpus being classified incomplete and suppressed,
+# which `AGENT_GATE_ALLOW_MISSING_FIXTURES=1` could not rescue.
+#
+# TOC.txt is CASSANDRA'S OWN manifest of the generation's components, so the required
+# set is DERIVED from the fixture rather than curated here: a compressed generation
+# lists `CompressionInfo.db`, an uncompressed one does not, and a BTI generation lists
+# `Partitions.db`/`Rows.db` instead of `Index.db`. Nothing to update when a new
+# component appears.
+#
+# Its ABSENCE disqualifies rather than skipping the check. Measured: all 144 generations
+# across both corpus roots have one, and a permissive branch keyed on a missing signal is
+# the vacuous pass this whole component exists to prevent -- a fetch truncated badly
+# enough to drop TOC.txt is exactly the state to report.
+#
+# PRESENCE + TYPE + READABILITY, and NONEMPTY except for a derived allowlist.
+#
+# Round 53 allowed every companion to be zero-length, on the measurement that 3 of the 1152
+# TOC-listed components on the real corpus legitimately are. That was the right measurement
+# and the wrong rule (roborev #3493 round 58): it also admitted the two shapes that BREAK
+# the reader. Measured against the real node binding, zeroing ONE component of an otherwise
+# intact generation:
+#
+#     CompressionInfo.db  -> SELECT returns 0 ROWS      <-- silently wrong
+#     Statistics.db       -> SELECT returns 0 ROWS      <-- silently wrong
+#     Filter.db           -> 100 rows (tolerated)
+#     Index.db            -> 100 rows (tolerated)
+#     Summary.db          -> 100 rows (tolerated)
+#     Digest.crc32        -> 100 rows (tolerated)
+#
+# It does not throw -- it returns an EMPTY RESULT SET, which is worse: "0 rows when the
+# fixture is present" is the exact failure this repo's testing doctrine says must never
+# pass, and a suite that only counts rows would report success over a broken corpus.
+#
+# So nonempty is REQUIRED, with `Rows.db` allowlisted. That allowlist is DERIVED, not
+# invented: it is every component observed zero-length across all 144 generations in both
+# corpus roots -- 3 instances, all `da-2-bti-Rows.db`, where an empty row index is a
+# meaningful BTI state rather than damage.
+#
+# IT IS NOT LOAD-BEARING TODAY, and saying otherwise would overstate it: all 3 live in
+# `test_da/` tables, and the expected set holds none of them, so a blanket nonempty rule
+# would also pass the real corpus 39/39. It is here because the SHAPE is real -- Cassandra
+# writes an empty BTI row index -- and the expected set plausibly grows to cover BTI. The
+# synthetic case is what discriminates, not the corpus.
+#
+# If a future corpus legitimately ships another empty component this reds and the allowlist
+# gains a line; that is the correct direction, because the alternative admits a
+# silently-wrong read.
+#
+# The Data.db's own nonzero requirement is enforced separately by its caller.
+_TOC_MAY_BE_EMPTY='Rows.db'
+_toc_companions_usable() {
+  _t_prefix=${1%Data.db}
+  _t_toc="${_t_prefix}TOC.txt"
+  _usable_file "$_t_toc" || return 1
+  while IFS= read -r _t_c || [ -n "$_t_c" ]; do
+    _t_c=${_t_c%$'\r'}                       # tolerate CRLF
+    [ -n "$_t_c" ] || continue               # blank lines are not components
+    # A component NAME, never a path: a TOC entry that escapes its own directory is
+    # malformed, and resolving it would validate a file in a different generation.
+    case "$_t_c" in */*|.|..) return 1 ;; esac
+    _t_p="${_t_prefix}${_t_c}"
+    [ -f "$_t_p" ] && [ -r "$_t_p" ] || return 1
+    case " $_TOC_MAY_BE_EMPTY " in
+      *" $_t_c "*) : ;;                      # allowlisted: empty is a legitimate state
+      *) [ -s "$_t_p" ] || return 1 ;;
+    esac
+  done < "$_t_toc"
+  return 0
+}
+
+# _dir_has_oa_golden <table-dir> -- rc 0 when the directory holds ANY
+# `oa-<n>-big-Data.db.jsonl`, which is exactly what Jest's findOaJsonlFile scans for. It
+# does NOT pair the golden's generation with any binary's, so neither does this.
+# EVERY matching golden must be usable, not merely one of them (roborev #3493 round 44).
+# `findOaJsonlFile()` returns the FIRST readdir entry whose NAME matches, checking only
+# `existsSync` -- no type, size or readability test. So a broken `oa-1-…jsonl` beside a
+# valid `oa-2-…jsonl` would clear an "any usable" check here and then be the one Jest
+# selects. The consumer picks blind, so the corpus is only complete if every candidate it
+# could pick is usable.
+_dir_has_oa_golden() {
+  _found=0
+  for _g in "$1"/oa-*-big-Data.db.jsonl; do
+    [ -e "$_g" ] || [ -L "$_g" ] || continue
+    _re_match '^oa-[0-9]+-big-Data\.db\.jsonl$' "${_g##*/}" || continue
+    # A name Jest would select but cannot use makes the whole table unusable.
+    _usable_file "$_g" || return 1
+    _found=1
+  done
+  [ "$_found" -eq 1 ]
+}
+
+# _is_committed_table_dir <keyspace> <dirname> -- rc 0 when it counts.
+_is_committed_table_dir() {
+  [ -z "$COMMITTED_TABLE_DIRS" ] && return 0        # Jest's fallback: nothing tracked -> all count
+  # Same 1-vs->1 rule as _re_match, and it is needed HERE too (roborev #3493 round 28):
+  # this was the one grep site round 27 did not convert, and a nonzero-means-uncommitted
+  # read lets an operational failure be swallowed by the caller's `|| continue`, ending in
+  # the reserved exit 9 -- a judged verdict the opt-out suppresses. A fixed-string match
+  # is a different grep invocation (`-Fxq`) from the regex ones, so converting the regex
+  # sites alone left the hole open.
+  # Here-string for the same reason as _re_match: under pipefail an early match through a
+  # pipeline returns 141 and would be read as a malfunction. This subject is the whole
+  # committed-table list, so it is the one most likely to grow past the pipe buffer.
+  local _rc=0
+  grep -Fxq "$1/$2" <<<"$COMMITTED_TABLE_DIRS" || _rc=$?
+  case "$_rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) echo "❌ dataset manifest check: grep failed (status $_rc) matching the committed table set; cannot judge the corpus" >&2
+       exit 2 ;;
+  esac
+}
 
 missing=0
 found=0
 for entry in "${EXPECTED[@]}"; do
   table="${entry#*/}"
   # Match <table>-<uuid>/<prefix>-Data.db; -path keeps us pipefail-safe.
-  data_db=$(find "$SSTABLES/$(dirname "$entry")" -path "*${table}-*-Data.db" 2>/dev/null | head -1 || true)
+  #
+  # `-H` and the `test -f` filter make this the SAME fixture predicate as the agent
+  # gate's _canonical_fixture_present and the Node suite's setup.js::hasDataDbFile
+  # (issue #3493). Without them the three disagreed, and the disagreement was
+  # reachable in both directions: a keyspace directory that is itself a SYMLINK is
+  # followed by fs.readdirSync() and by `find -H`, but not by bare `find`, so a
+  # supported corpus passed the gate's preflight and then failed this check; and a
+  # DIRECTORY / FIFO / DANGLING SYMLINK named `*-Data.db` satisfied a name-only match
+  # while being unopenable, so a malformed corpus could report complete.
+  # No pipe (a `| head -1` would let SIGPIPE decide the result under pipefail) and no
+  # `-quit`: that primary is GNU/newer-BSD only, and node-ci.yml runs this script on
+  # macos-14 and windows as well as ubuntu, where an unsupported primary would error out,
+  # have its stderr discarded, and report usable fixtures as MISSING.
+  # The glob is COMPONENT-ANCHORED: `*/<table>-*/*-Data.db` requires an immediate
+  # directory component beginning exactly with `<table>-`. The old `*<table>-*-Data.db`
+  # let the leading `*` swallow a prefix, so a table whose name is a SUFFIX of a sibling
+  # matched that sibling's directory and a MISSING table reported as PRESENT
+  # (roborev #3493 round 15).
+  #
+  # LATENT, not live, and the distinction was checked rather than assumed: the search is
+  # rooted at the KEYSPACE directory, so only a same-keyspace pair can collide, and the
+  # current manifest has none -- `counters` (test_basic) and `time_bucketed_counters`
+  # (test_timeseries) look like a collision but are searched under different roots. The
+  # anchoring is kept anyway because it costs nothing, the manifest gains tables
+  # routinely, and the failure mode is a silent false PRESENT: the check would report a
+  # complete corpus while an expected table was absent.
+  # MIRRORS JEST'S DISCOVERY EXACTLY, rather than approximating it with globs (roborev
+  # #3493 rounds 16-17). Every loosening below was a real false PRESENT -- the manifest
+  # reporting a complete corpus while Jest silently omitted the table:
+  #   * `-path` wildcards match `/`, so a glob alone accepted the table directory nested
+  #     ARBITRARILY DEEP (`other/counters-uuid/x-Data.db`); Jest reads DIRECT children only.
+  #   * `${table}-*` accepted a malformed suffix (`collection_table-abc`); Jest's
+  #     TABLE_DIR_RE is `^(.+)-[0-9a-f]{32}$`.
+  #   * `oa-*-big-Data.db` accepted `oa-invalid-big-Data.db`; oaBinariesPresent() is
+  #     `^oa-\d+-big-Data\.db$`.
+  # A predicate that is LOOSER than the consumer's is not a check, it is a second opinion
+  # nobody asked for -- so both regexes are copied from the consumer, and named here so a
+  # future edit to either side is visibly a two-place change.
+  # PARAMETER EXPANSION, not a `dirname` subprocess (roborev #3493 round 32). A subprocess
+  # can fail, and this script reserves exit 9 for its corpus verdict -- so a `dirname`
+  # that exited 9 would propagate as a FALSE judged-incomplete under `set -e`, and in the
+  # `$( )` argument position at the committed-dir call its status was swallowed entirely.
+  # `${entry%%/*}` cannot fail, needs no tool, and the entries are `<keyspace>/<table>` by
+  # construction.
+  keyspace=${entry%%/*}
+  ks_dir="$SSTABLES/$keyspace"
+  data_db=""
+  first_ok=""     # the first candidate that yielded a usable fixture (success path only)
+  cand_bad=0      # at least one enumerable candidate directory yields nothing usable
+  oa_bad=0        # a correctly-shaped dir held Data.db files, but none OA-named
+  name_bad=0      # Data.db files existed, but none named like a descriptor the reader opens
+  empty_bad=0     # a correctly-named binary existed but was ZERO-LENGTH (truncated fetch)
+  type_bad=0      # a correctly-named Data.db exists but is NOT a regular file
+  unread_bad=0    # a correctly-named, nonempty Data.db is not readable
+  toc_bad=0       # a complete-looking generation whose own TOC.txt lists an absent component
+  golden_bad=0    # a valid nonempty binary existed, but without the golden Jest reads
+  gen_bad=0       # a reader-supported generation in THIS candidate is unusable
+  for cand in "$ks_dir/${table}"-*; do
+    # `-d` FOLLOWS symlinks; Jest reads Dirent.isDirectory() from a withFileTypes walk,
+    # which is FALSE for a symlink. A symlinked table dir would satisfy this check and
+    # then vanish from Jest's discovered cases (roborev #3493 round 18).
+    [ -L "$cand" ] && continue
+    [ -d "$cand" ] || continue
+    gen_bad=0     # per CANDIDATE, not per table
+    base=${cand##*/}
+    suffix=${base#"${table}-"}
+    # Jest: TABLE_DIR_RE = /^(.+)-[0-9a-f]{32}$/
+    _re_match '^[0-9a-f]{32}$' "$suffix" || continue
+    # Jest: isCommittedTableDir(keyspace, dirName)
+    _is_committed_table_dir "$keyspace" "$base" || continue
+
+    # THE GOLDEN IS VALIDATED PER CANDIDATE, and the loop breaks only on a COMPLETE
+    # binary+golden pair (roborev #3493 round 23). Breaking on the first binary and
+    # checking its golden afterwards made a golden-less `oa-1-big-Data.db` MASK a
+    # complete `oa-2` in the same directory -- reporting the table missing when Jest,
+    # which scans every generation, would have found it. That direction matters as much
+    # as the permissive one: an over-strict corpus check red-lines a usable corpus, and a
+    # gate that reds on correct input is the gate agents learn to waive.
+    #
+    # The two families differ in WHAT the golden is, which is why this is not one rule:
+    #   * OA     -- findOaJsonlFile scans for `oa-<n>-big-Data.db.jsonl`, any generation,
+    #               so the golden is the matched binary's own sibling.
+    #   * non-OA -- findJsonlFile HARD-CODES `nb-1-big-Data.db.jsonl` for the directory,
+    #               regardless of which generation's Data.db is present. Measured: this
+    #               corpus really holds nb-2/nb-3/nb-45/da-2-bti generations, so a
+    #               per-binary sibling check was wrong about real data.
+    # TWO PASSES, because two DIFFERENT questions were tangled into one loop and each
+    # round of this issue had to fix them separately (roborev #3493 round 54):
+    #
+    #   PASS 1 -- READER COMPLETENESS, branch-independent. `Database.open` reads the table
+    #             through its DIRECTORY and loads EVERY generation in it, so every
+    #             reader-supported generation must be usable, whatever the table's own
+    #             requirement is. Round 53 applied this to the general branch only, leaving
+    #             the pinned-binary branch (which `break`s on a valid `nb-1`) and the OA
+    #             branch (which never set `gen_bad`) able to mask a damaged sibling.
+    #
+    #   PASS 2 -- THE TABLE'S OWN REQUIREMENT, branch-specific. Which generation satisfies
+    #             the CONSUMER: any recognised one, the pinned `nb-1` for the one table that
+    #             names it, or a NUMERIC `oa-<n>` for Jest's OA guard.
+    #
+    # Separating them is the fix, not another per-branch patch: the previous shape put a
+    # completeness rule inside each requirement branch, so a new branch silently arrived
+    # without one. Now a branch can only choose a WINNER; it cannot opt out of validation.
+
+    # ---- PASS 1: every reader-supported generation must be usable + TOC-complete --------
+    for f in "$cand"/*-Data.db; do
+      # `-e` is FALSE for a DANGLING SYMLINK, so `-e` alone skipped one silently -- the
+      # very shape `type_bad` exists to report. `-L` catches it; together they mean
+      # "a directory entry is here", and only an unmatched glob falls through.
+      [ -e "$f" ] || [ -L "$f" ] || continue
+      fbase=${f##*/}
+      # Not a descriptor the reader opens => not a generation at all, and must not
+      # disqualify the table (the round-24 over-rejection, one level down). `junk-Data.db`
+      # and a non-numeric `oa-<uuid>-big-Data.db` both land here.
+      _reader_accepts_descriptor "$fbase" || { name_bad=1; continue; }
+      # `_usable_file` is `-f && -s && -r`. Test its three parts SEPARATELY so the
+      # diagnostic names the operator's ACTUAL problem (roborev #3493 round 54 self-audit).
+      # Collapsing them reported a Data.db that is a DIRECTORY as "ZERO-LENGTH (truncated
+      # fetch?)" -- present, non-empty, and nothing to do with a truncated fetch, sending
+      # the operator to re-run a fetch that was fine. That is the round-40 misattribution
+      # again, reintroduced by this round's own restructure; the old code skipped these
+      # shapes in silence, so the fix traded a silent miss for a wrong answer until now.
+      # Three shapes, three remedies: replace the fixture / re-fetch / fix permissions.
+      if [ ! -f "$f" ]; then
+        type_bad=1; gen_bad=1; continue      # directory, dangling symlink, FIFO, ...
+      elif [ ! -s "$f" ]; then
+        empty_bad=1; gen_bad=1; continue     # regular but zero-length: a truncated fetch
+      elif [ ! -r "$f" ]; then
+        unread_bad=1; gen_bad=1; continue    # present and sized, but not readable
+      fi
+      _toc_companions_usable "$f" || { toc_bad=1; gen_bad=1; }
+    done
+
+    # ---- PASS 2: which generation satisfies THIS table's consumer -----------------------
+    case "$entry" in
+      test_oa/*)
+        # Jest: oaBinariesPresent() = /^oa-\d+-big-Data\.db$/ -- NUMERIC only, so a
+        # `oa-<uuid>-big-Data.db` is reader-supported (validated in pass 1) but does NOT
+        # satisfy the OA guard. The two requirements are genuinely different and are now
+        # asked separately instead of one standing in for the other.
+        for f in "$cand"/*-Data.db; do
+          # Plain `-e` here, deliberately: this loop picks a WINNER, and a dangling symlink
+          # can never be one. Pass 1 has already reported it.
+          [ -e "$f" ] || continue
+          fbase=${f##*/}
+          _re_match '^oa-[0-9]+-big-Data\.db$' "$fbase" || continue
+          _usable_file "$f" || continue
+          # The binary and the golden are INDEPENDENT in Jest, NOT a matched pair
+          # (roborev #3493 round 24). oaBinariesPresent() accepts any `oa-<n>-big-Data.db`
+          # and findOaJsonlFile() accepts any `oa-<n>-big-Data.db.jsonl` in the same
+          # directory -- it never compares the two generations. Requiring `$f.jsonl`
+          # therefore REJECTED a corpus Jest runs happily (oa-1 binary + oa-2 golden):
+          # over-strict, the same false-MISSING direction as round 23.
+          if _dir_has_oa_golden "$cand"; then
+            [ -z "$data_db" ] && data_db="$f"
+          else
+            golden_bad=1
+          fi
+        done
+        # No NUMERIC OA binary at all: distinct from "one was present but unusable", which
+        # pass 1 has already recorded as empty_bad/gen_bad.
+        [ -z "$data_db" ] && [ "$golden_bad" -eq 0 ] && [ "$gen_bad" -eq 0 ] && oa_bad=1 ;;
+      *)
+        # non-OA: the GOLDEN is always `nb-1-big-Data.db.jsonl` (findJsonlFile hard-codes
+        # it), but the BINARY generation is only pinned for ONE table.
+        #
+        # Round 33 required a nonempty nb-1 BINARY for every non-OA table, reasoning that
+        # the fixed golden name implied a fixed binary name. IT DOES NOT (roborev round
+        # 34): Jest opens the table through its DIRECTORY, so any recognised generation
+        # works, and the only consumer that names a binary is corrupt-fixture.js --
+        # `DATA_COMPONENT = 'nb-1-big-Data.db'`, scoped to `KEYSPACE = test_basic` /
+        # `TABLE = simple_table`. Applying it everywhere rejected usable
+        # alternate-generation corpora: over-strict, and a gate that reds on correct input
+        # is the gate agents learn to waive.
+        #
+        # GOLDENS ARE NONEMPTY TOO (roborev #3493 round 41). They were checked with `-f`,
+        # so a TRUNCATED golden read as complete: the decision returned RUN and Jest then
+        # compared real rows against an empty expectation and failed -- with the opt-out
+        # unable to rescue it, because nothing had classified the corpus as incomplete.
+        _need_binary=""
+        [ "$entry" = "test_basic/simple_table" ] && _need_binary="nb-1-big-Data.db"
+        if ! _usable_file "$cand/nb-1-big-Data.db.jsonl"; then
+          # Only a directory that actually holds a generation is missing its GOLDEN; an
+          # empty directory is simply not a candidate.
+          _any_gen=0
+          for f in "$cand"/*-Data.db; do
+            [ -e "$f" ] || continue
+            _reader_accepts_descriptor "${f##*/}" && _any_gen=1
+          done
+          [ "$_any_gen" -eq 1 ] && golden_bad=1
+        elif [ -n "$_need_binary" ]; then
+          # The PINNED generation must itself be usable; pass 1 has already validated every
+          # OTHER generation in the directory, so this branch no longer needs to (and no
+          # longer `break`s away from) that work.
+          _usable_file "$cand/$_need_binary" && data_db="$cand/$_need_binary"
+        else
+          for f in "$cand"/*-Data.db; do
+            [ -e "$f" ] || continue
+            _reader_accepts_descriptor "${f##*/}" || continue
+            _usable_file "$f" || continue
+            [ -z "$data_db" ] && data_db="$f"
+          done
+        fi ;;
+    esac
+    # NO EARLY BREAK on the first complete candidate (roborev #3493 round 46). Jest's
+    # discovery picks a table directory by readdir order and does not check usability, so
+    # an EARLIER broken `<table>-<uuid>` can be the one it selects while a LATER good one
+    # satisfies this check. Same "the consumer picks blind" shape as round 44's OA
+    # goldens, one level up: at the directory instead of the file.
+    #
+    # So every committed candidate is inspected, and any unusable one disqualifies the
+    # table even after a good one was found. `first_ok` remembers the good one purely for
+    # the success path. Measured: no expected table has more than one candidate directory
+    # on the real corpus today, so this tightens nothing that currently passes.
+    # PER-CANDIDATE verdict, not per-file. A table directory may legitimately hold files
+    # that are not the fixture -- a non-OA-named binary beside a valid `oa-<n>-big`, a
+    # stray `junk-Data.db` beside a good `nb-1-big` -- and Jest does not care, so those
+    # per-file flags are noise at this level. What matters is whether THIS CANDIDATE
+    # DIRECTORY yields a usable fixture, because that is the unit Jest enumerates.
+    # A reader-supported generation that is NOT usable disqualifies this candidate even
+    # when a good one was also found: the reader reads them all.
+    [ "$gen_bad" -eq 1 ] && data_db=""
+    if [ -n "$data_db" ]; then
+      [ -z "$first_ok" ] && first_ok="$data_db"
+    else
+      cand_bad=1     # an enumerable candidate that yields nothing usable
+    fi
+    data_db=""
+  done
+  data_db="$first_ok"
+  # An unusable candidate DIRECTORY disqualifies the table even if a later one is good:
+  # Jest selects by readdir order without checking usability, so it may pick the bad one.
+  [ "$cand_bad" -eq 1 ] && data_db=""
+  # EACH CONDITION GETS ITS OWN DIAGNOSTIC (roborev #3493 round 40). They were collapsed
+  # onto `golden_bad`, so a truncated or misnamed Data.db was reported as "not the JSONL
+  # golden" -- pointing the operator at a file that was present and fine. Ordered
+  # most-specific first; a table can only be in one of these states per candidate.
+  if [ -n "$data_db" ]; then
+    :
+  elif [ "$type_bad" -eq 1 ]; then
+    echo "❌ expected table has a Data.db that is NOT A REGULAR FILE (a directory, a dangling symlink, or a special file) -- replace the fixture: $entry" >&2
+  elif [ "$unread_bad" -eq 1 ]; then
+    echo "❌ expected table has a present, nonempty Data.db that is NOT READABLE -- check permissions: $entry" >&2
+  elif [ "$empty_bad" -eq 1 ]; then
+    echo "❌ expected table has a ZERO-LENGTH Data.db (truncated fetch?): $entry" >&2
+  elif [ "$oa_bad" -eq 1 ]; then
+    echo "❌ expected table has no OA-format Data.db (oa-<n>-big-Data.db): $entry" >&2
+  elif [ "$name_bad" -eq 1 ]; then
+    echo "❌ expected table has Data.db file(s) but none the reader would open (need <ver>-<id>-big|bti-Data.db, ver in na|nb|oa or da+bti): $entry" >&2
+  elif [ "$golden_bad" -eq 1 ]; then
+    case "$entry" in
+      test_oa/*) _want="any oa-<n>-big-Data.db.jsonl in the table directory" ;;
+      *)         _want="nb-1-big-Data.db.jsonl" ;;
+    esac
+    echo "❌ expected table has a Data.db but not the JSONL golden Jest reads ($_want): $entry" >&2
+  elif [ "$toc_bad" -eq 1 ]; then
+    # LAST: every earlier state is a coarser breakage, and this one is only reachable
+    # once a nonempty recognised binary AND its golden are both in place -- the shape a
+    # partial extraction leaves.
+    echo "❌ expected table's SSTable generation is incomplete: its own TOC.txt is absent, or lists a component that is missing/unreadable beside it (partial extraction?): $entry" >&2
+  fi
   if [ -z "$data_db" ]; then
     echo "❌ missing Data.db for expected table: $entry" >&2
     missing=$((missing + 1))
@@ -95,6 +732,6 @@ done
 echo "dataset manifest: ${found}/${#EXPECTED[@]} expected tables present"
 if [ "$missing" -ne 0 ]; then
   echo "❌ dataset manifest check FAILED: $missing expected table(s) missing — partial extraction or dropped table?" >&2
-  exit 1
+  exit "$MANIFEST_INCOMPLETE_RC"
 fi
 echo "✅ dataset manifest check passed (all ${#EXPECTED[@]} expected tables present)"

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -28,10 +28,27 @@ SSTABLES="${ROOT}/sstables"
 #
 # A trap is the only cleanup that survives an exit, so registration is the single rule:
 # anything mktemp'd here gets registered on the line it is created.
-_TMP_FILES=""
-_register_tmp() { _TMP_FILES="$_TMP_FILES $1"; }
-_cleanup_tmp() { [ -n "$_TMP_FILES" ] && rm -f $_TMP_FILES; return 0; }
-trap _cleanup_tmp EXIT INT TERM
+# An ARRAY, not a space-separated string: `rm -f $VAR` word-splits, so a TMPDIR containing
+# a space would split one path into fragments -- the real file never removed, and `rm -f`
+# invoked on paths nobody intended. Quoted array expansion has neither problem.
+_TMP_FILES=()
+_register_tmp() { _TMP_FILES+=("$1"); }
+_cleanup_tmp() {
+  [ "${#_TMP_FILES[@]}" -gt 0 ] && rm -f "${_TMP_FILES[@]}"
+  return 0
+}
+# EXIT cleans up. INT/TERM clean up and then RE-RAISE, rather than returning: a handler that
+# swallows the signal lets a CANCELLED run carry on -- past freshly-deleted temp files -- and
+# emit a corpus or tooling verdict for work that was interrupted. The trap is reset to
+# default first so the re-raise actually terminates.
+_cleanup_tmp_signal() {
+  _cleanup_tmp
+  trap - "$1"
+  kill -s "$1" $$
+}
+trap _cleanup_tmp EXIT
+trap '_cleanup_tmp_signal INT' INT
+trap '_cleanup_tmp_signal TERM' TERM
 
 # Expected user-keyspace tables (39 total: 33 nb + 6 test_oa).
 #


### PR DESCRIPTION
Closes #3493.

## What changed after PR #3574 landed — read this first

This PR was originally *"the `node-ci.yml` exemption is false: `node-bindings` runs 1 of 27 Jest files."* **PR #3574 (issue #3522) fixed that while this PR was in review**, and fixed it more thoroughly than I had. Re-derived onto `origin/main` rather than replayed; the superseded half is **dropped**, not merged.

| original deliverable | status |
|---|---|
| `node-bindings` runs the whole Jest suite | **superseded** — #3574 does it, with two-oracle suite-set reconciliation and per-suite "did it actually do work" checks |
| node-ci registry exemption corrected | **superseded** — #3574 |
| `binding-rust-tests` for cqlite-node's Rust units | **superseded** — #3574's; mine never had it |
| finer-grained "suppress only the dataset half" opt-out | **dropped by decision** — #3574's own review rejected that shape as the curation its D2 removed. Main SKIPs the component. Re-opening a settled decision would be replay. |

## The remaining question, which nothing answers

**#3522's census asks *does every test FILE run*. This asks *is the CORPUS those files read complete*.**

Neither answers the other. The Node parity cases **derive their table set from disk**, so a partial extraction is green **by omission**: every suite runs, every suite does real work, and the missing tables are simply never enumerated. #3522's per-suite guard cannot see it either — those suites *did* work.

Measured against the real node binding, on an otherwise intact generation:

| damage | reader |
|---|---|
| zero-length `CompressionInfo.db` or `Statistics.db` | **`SELECT` returns 0 ROWS, silently** |
| zero-length `Filter.db` / `Index.db` / `Summary.db` / `Digest.crc32` | 100 rows — tolerated |
| second generation, `Data.db` well-formed garbage | reader **throws** |

The first row is the dangerous one. It is not an error — it is an **empty result set**, the "0-rows-when-present" failure this repo's doctrine says must never pass, and invisible to any suite that counts rows.

## The fix

`test-data/scripts/check-dataset-manifest.sh` (100 → 737 lines; untouched on `main`), paired with `npm test` in `node-bindings`. It validates:

- **every committed candidate table directory**, not the first complete one — Jest picks by readdir order without checking usability, so one bad sibling disqualifies;
- **every reader-supported generation** in each, not the first usable one — `Database.open` reads them all;
- **every component the generation's own `TOC.txt` lists** — derived from Cassandra's manifest, not curated here: a compressed generation requires `CompressionInfo.db`, a BTI one requires `Partitions.db`/`Rows.db`.

Presence, type, readability **and size**, with `Rows.db` allowlisted (3 of 1152 real components are legitimately empty). **That allowlist is not load-bearing today** — all 3 live in `test_da/` tables the expected set does not hold, so a blanket rule would also pass 39/39. It is there because the shape is real and the expected set plausibly grows to cover BTI.

**Stated limitation:** a completeness check proves files are present and usable *as files*. It cannot prove they parse — that is the reader's job, and the garbage-bytes row above is precisely the shape it cannot catch.

## Also kept, each independently useful

- **`npm run typecheck`** in the component. node-ci's always-run PR smoke job, which main's component does not run. It is `tsc --noEmit` over the examples project, so it **compiles against** the shipped `index.d.ts` — a binding can pass every runtime test while its published types fail to typecheck. (An earlier version of this claimed it was the *only* thing exercising `index.d.ts`. **#3581 landed on main during this review and made that false**: its `typescript-definitions` test reads the declarations as text and asserts the runtime surface is declared. Neither subsumes the other — a declaration can be present and still not compile.)
- **Schemas-root locale fixes.** `[[:cntrl:]]` is locale-sensitive: under `LC_ALL=C` the gate **certified** roots containing U+0080/0085/009C/009F that the binding's `/\p{Cc}/u` then rejected, failing the component *after* the preflight passed. Now raw UTF-8 byte escapes under a pinned locale, pinned by a 30-check locale × codepoint differential whose expected column is **computed from node**, never hand-written. Independent of the corpus work.
- **`cqlite-core/tests/issue_3493_descriptor_predicate_differential.rs`.** The shell descriptor predicate is a **port** of two Rust decisions, and a port's correctness is only knowable by differential testing against the original (#3283). It sources the shell function **out of the committed script** and runs both sides over 14 name shapes, diagnosing each drift direction distinctly (false-PRESENT vs false-MISSING have opposite consequences), with a vacuity guard so an all-rejecting predicate cannot agree with an all-rejecting corpus. Getting this wrong cost two review rounds: a hex-only ID class the parser does not impose, and an oracle that checked parse+version but not the `Data.db` component.
- **One shared table-directory rule** across all three consumers (`findJsonlFile`, `findOaJsonlFile`, `corrupt-fixture.js::sourceTableDir`) and the manifest. This closed a **destructive** bug: a symlinked table directory was accepted, `fs.cpSync` preserves a symlink by default, and the harness's truncate then wrote **through it into the source corpus** — demonstrated, `ORIGINALDATA` → `ORIGIN`. Against the shared machine-local corpus that damages every other lane on the box.

## Coverage

`scripts/tests/test_check_dataset_manifest.sh` — **145 assertions**, registered in `tooling-tests`, dataset-free and network-free (each case builds its own synthetic corpus). Renamed and rebuilt around its actual subject; it was 179 assertions, and the 67 dropped tested the superseded suppression design and no longer have a subject.

**Every fix is RED-verified** by planting the defect and confirming the named assertion fails. In a change whose subject is *a check that did not check what it claimed to*, a green assertion is not evidence until the defect has been planted against it. Three guards in this PR were worth nothing until their RED control ran — an intactness assert that passed vacuously on a wrong-arity call, four manifest reject-cases that all read as "accepted" because `grep -q` closed the pipe early and `pipefail` turned SIGPIPE into rc 141, and a `dereference: true` guard whose own case could not reach it. Two RED controls were themselves wrong before they were right (one planted at a `case` statement that was not the real gate; one run against a corpus where the expected exit was already correct).

## Eight review rounds since the rebase

~17 findings, none waived. They cluster into two families, and both are worth naming because
each recurred in code written to fix the other.

**Family A — a check that does not check.** Four instances, three of them mine:
- the committed-twin comparison read the WORKING TREE, so under the default dataset root
  (the checkout itself) `cmp` compared a file to itself and always succeeded — **vacuous in
  exactly the configuration CI uses**;
- both derived TOC directions are computed from the corpus, so a *coherently* truncated TOC
  satisfied both. Fixed with the git-tracked TOC as an inventory from outside the corpus;
- CR was stripped in two of the three places that read the TOC, so a valid CRLF corpus was
  rejected — and the existing CRLF case could not see it, because it exercised one of the two
  places that were already correct;
- the descriptor predicate accepted invalid-UTF-8 bytes the reader rejects via `to_str()`.

**Family B — a malfunction read as a verdict.** `grep`, `cmp`, `git show`, `git ls-files`,
and the differential's own `status.success()` each collapsed an operational failure into an
ordinary answer, and this script reserves exit 9 as a *corpus* verdict the #2078 opt-out
suppresses — so a broken tool could be silently excused. All are now three-valued.

**Three of those fixes shipped with no test until the RED control proved there was none.**
That is the single most useful practice in this PR: a green assertion is not evidence until
the defect has been planted against it. Several controls were themselves wrong first — one
planted at a `case` statement that was not the real gate, one against a corpus where the
expected exit was already correct, one that did not compile, and one defeated by POSIX signal
semantics (a non-interactive shell sets SIGINT to ignore for background children, so the
probe could never catch it).

**What the review caught that I did not, and vice versa.** Twice my own audit found a defect
the reviewer reported independently in the same round — the dangling-symlink skip and the
`git ls-files` status collapse. Twice the reviewer caught a regression *in my own previous
fix*: the `broken`/`absent` collapse that re-inverted #1437, and the working-tree twin
comparison. Neither channel alone would have produced this diff.

## Verification

- `git merge-tree --write-tree HEAD origin/main | grep -c ^CONFLICT` = **0**; `origin/main` is an ancestor.
- manifest **39/39** on the real corpus; self-test **145/145**; descriptor differential green.
- `node-bindings` **PASS (133s)** and `tooling-tests` **PASS (948s)** end-to-end on the rebased tree — under the ~174s the narrowing was justified by.
- `--lite` PASS at the rebased head, `tree-integrity: PASS`.

## What this PR does NOT do — the exemption is true, the workflow is still not merge-gating

Both halves, stated here because they are easy to conflate when read next to an `exempt:` entry:

- **The exemption's stated reason is now TRUE.** `node-bindings` runs what `node-ci.yml`'s
  merge-relevant jobs run: the whole jest suite and `binding-rust-tests` (#3522/#3574), plus
  `npm run typecheck` and `check-dataset-manifest.sh` paired with `npm test` (this PR).
- **`node-ci.yml` is still NOT merge-gating.** It remains `required`-exempt, and the local
  component covers that content on **one** platform. The workflow runs ubuntu-latest,
  macos-14 and windows-latest — so a deterministic Node red on macOS or Windows still cannot
  block a merge.

That is #3493's "second, larger problem" **narrowed, not closed** — now tracked in #3640
rather than left to evaporate when this PR merges.

## Follow-ups filed

- **#3640 — enroll `node-ci.yml` as a required tier.** The one that matters: it carries
  #3493's larger half. Deferred because the registry forbids a tier with `paths:` filters and
  `node-ci.yml` has them on both triggers, making enrolment a workflow refactor rather than a
  registry edit.
- **#3641 — `skipIfNoDatasets()` throws.** A skip-named function that cannot skip; 14 suites
  depend on it, and it is why this component must SKIP wholesale rather than run leniently.
  Now main's defect rather than this PR's, since #3574's review rejected the finer-grained
  design that would have had to confront it.
- **#3642 — residuals from this PR's C intent audit**: structurally pin the typecheck and
  manifest invocations (the same two-line shape as case 92), cover the component's exit-code
  mapping, restore a one-directional `setup.js` ⊆ canonical derivation, reconcile a 133s/138s
  discrepancy. Filed rather than committed **because committing would move the head and void a
  scope-bound roborev waiver**, forcing another review round for changes the audit itself
  classified as non-blocking.
- #3589 (a CLAUDE.md doctrine defect the lead confirmed), #3591 (schemas-root blankness).

## C intent audit

Run against the issue thread (no OpenSpec change exists for #3493). Verdict was **CHANGES
NEEDED**, on three non-code items — all three are addressed above: #3640 filed and linked,
#3641 filed and linked, and the exemption/merge-gating sentence added. The audit also
recorded, correctly, that **~90% of this diff is scope no criterion asked for**: mirroring
node-ci.yml's manifest step required *invoking* the existing 100-line checker, not rewriting
it to ~1080. That hardening belongs to #1230 by rights; it is here because the measurement
that motivated it (a zero-length `CompressionInfo.db` makes `SELECT` return 0 rows silently)
surfaced while wiring the invocation, and the lead endorsed continuing. Recorded so the next
reader can judge it rather than infer it.




